### PR TITLE
fix: update Redis SSL environment variable handling

### DIFF
--- a/backend/services/redis.py
+++ b/backend/services/redis.py
@@ -25,7 +25,9 @@ def initialize():
     redis_host = os.getenv('REDIS_HOST', 'redis')
     redis_port = int(os.getenv('REDIS_PORT', 6379))
     redis_password = os.getenv('REDIS_PASSWORD', '')
-    redis_ssl = os.getenv('REDIS_SSL', False)
+    # Convert string 'True'/'False' to boolean
+    redis_ssl_str = os.getenv('REDIS_SSL', 'False')
+    redis_ssl = redis_ssl_str.lower() == 'true'
 
     logger.info(f"Initializing Redis connection to {redis_host}:{redis_port}")
 
@@ -146,4 +148,4 @@ async def expire(key: str, time: int):
 async def keys(pattern: str) -> List[str]:
     """Get keys matching a pattern."""
     redis_client = await get_client()
-    return await redis_client.keys(pattern) 
+    return await redis_client.keys(pattern)


### PR DESCRIPTION
This pull request includes a small update to the `initialize` method in `backend/services/redis.py`. The change ensures that the `REDIS_SSL` environment variable is properly converted from a string ('True'/'False') to a boolean value.

* [`backend/services/redis.py`](diffhunk://#diff-290e53607a21739ecd0374ebb30506d829b28559f6bdc9bf8a3abc46e82217bbL28-R30): Added logic to convert the `REDIS_SSL` environment variable from a string to a boolean for proper handling.