### PR TITLE
Enhance GitHub Button Interactivity for Better Open-Source Engagement (#159)

### DIFF
--- a/frontend/src/components/home/sections/open-source-section.tsx
+++ b/frontend/src/components/home/sections/open-source-section.tsx
@@ -15,7 +15,8 @@ export function OpenSourceSection() {
             100% Open Source
           </h2>
           <p className="text-muted-foreground text-center text-balance font-medium">
-            Suna is fully open source. Join our community and help shape the future of AI.
+            Suna is fully open source. Join our community and help shape the
+            future of AI.
           </p>
         </SectionHeader>
 
@@ -31,7 +32,8 @@ export function OpenSourceSection() {
                   The Generalist AI Agent
                 </h3>
                 <p className="text-muted-foreground mt-2">
-                  Explore, contribute, or fork our repository. Suna is built with transparency and collaboration at its core.
+                  Explore, contribute, or fork our repository. Suna is built
+                  with transparency and collaboration at its core.
                 </p>
               </div>
               <div className="flex flex-wrap gap-2">
@@ -45,65 +47,159 @@ export function OpenSourceSection() {
                   Apache 2.0 License
                 </span>
               </div>
-              <Link 
-                href="https://github.com/Kortix-ai/Suna" 
-                target="_blank" 
+              <a
+                href="https://github.com/Kortix-ai/Suna"
+                target="_blank"
                 rel="noopener noreferrer"
-                className="group inline-flex h-10 items-center justify-center gap-2 text-sm font-medium tracking-wide rounded-full text-primary-foreground dark:text-black px-6 shadow-[inset_0_1px_2px_rgba(255,255,255,0.25),0_3px_3px_-1.5px_rgba(16,24,40,0.06),0_1px_1px_rgba(16,24,40,0.08)] bg-primary dark:bg-white hover:bg-primary/90 dark:hover:bg-white/90 transition-all duration-200 w-fit"
+                className="group inline-flex h-8 items-center justify-center gap-2 text-xl  font-medium tracking-wide rounded-full text-primary-foreground dark:text-black px-6 shadow-[inset_0_1px_2px_rgba(255,255,255,0.25),0_3px_3px_-1.5px_rgba(16,24,40,0.06),0_1px_1px_rgba(16,24,40,0.08)] bg-primary dark:bg-white hover:bg-primary/90 dark:hover:bg-white/90 transition-all duration-200 w-fit "
               >
-                <span>View on GitHub</span>
-                <span className="inline-flex items-center justify-center size-5 rounded-full bg-white/20 dark:bg-black/10 group-hover:bg-white/30 dark:group-hover:bg-black/20 transition-colors duration-200">
-                  <svg width="12" height="12" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" className="text-primary-foreground dark:text-black">
-                    <path d="M7 17L17 7M17 7H8M17 7V16" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
-                  </svg>
+                <span className="grid grid-cols-[2.5rem_1fr_0rem] group-hover:grid-cols-[0rem_1fr_2.5rem] items-center transition-all duration-300">
+                  {/*Left Icon */}
+                  <span className="flex justify-center">
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      width={21}
+                      height={21}
+                      fill="currentColor"
+                      viewBox="0 0 16 16"
+                    >
+                      <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8" />
+                    </svg>
+                  </span>
+                  {/*Text Github */}
+                  <span className="flex justify-center">View on Github</span>
+                  {/*Right Icon*/}
+                  <span className="flex justify-center">
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      className="opacity-0 translate-x-6 transition-all duration-300 group-hover:translate-x-0 group-hover:opacity-100"
+                      width={25}
+                      height={25}
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      strokeWidth={1.5}
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        d="M4.5 19.5l15-15m0 0H8.25m11.25 0v11.25"
+                      />
+                    </svg>
+                  </span>
                 </span>
-              </Link>
+              </a>
             </div>
           </div>
-          
+
           <div className="rounded-xl bg-[#F3F4F6] dark:bg-[#F9FAFB]/[0.02] border border-border p-6">
             <div className="flex flex-col gap-6">
               <h3 className="text-xl md:text-2xl font-medium tracking-tight">
                 Transparency & Trust
               </h3>
               <p className="text-muted-foreground">
-                We believe AI should be open and accessible to everyone. Our open source approach ensures accountability, innovation, and community collaboration.
+                We believe AI should be open and accessible to everyone. Our
+                open source approach ensures accountability, innovation, and
+                community collaboration.
               </p>
               <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
                 <div className="flex items-start gap-3">
                   <div className="rounded-full bg-secondary/10 p-2 mt-0.5">
-                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" className="text-secondary">
-                      <path d="M9.75 12.75L11.25 14.25L14.25 9.75" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"></path>
-                      <path d="M4.75 12C4.75 7.99594 7.99594 4.75 12 4.75C16.0041 4.75 19.25 7.99594 19.25 12C19.25 16.0041 16.0041 19.25 12 19.25C7.99594 19.25 4.75 16.0041 4.75 12Z" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"></path>
+                    <svg
+                      width="16"
+                      height="16"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      xmlns="http://www.w3.org/2000/svg"
+                      className="text-secondary"
+                    >
+                      <path
+                        d="M9.75 12.75L11.25 14.25L14.25 9.75"
+                        stroke="currentColor"
+                        strokeWidth="1.5"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      ></path>
+                      <path
+                        d="M4.75 12C4.75 7.99594 7.99594 4.75 12 4.75C16.0041 4.75 19.25 7.99594 19.25 12C19.25 16.0041 16.0041 19.25 12 19.25C7.99594 19.25 4.75 16.0041 4.75 12Z"
+                        stroke="currentColor"
+                        strokeWidth="1.5"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      ></path>
                     </svg>
                   </div>
                   <div>
                     <h4 className="font-medium">Transparency</h4>
-                    <p className="text-muted-foreground text-sm">Fully auditable codebase</p>
+                    <p className="text-muted-foreground text-sm">
+                      Fully auditable codebase
+                    </p>
                   </div>
                 </div>
                 <div className="flex items-start gap-3">
                   <div className="rounded-full bg-secondary/10 p-2 mt-0.5">
-                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" className="text-secondary">
-                      <path d="M9.75 12.75L11.25 14.25L14.25 9.75" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"></path>
-                      <path d="M4.75 12C4.75 7.99594 7.99594 4.75 12 4.75C16.0041 4.75 19.25 7.99594 19.25 12C19.25 16.0041 16.0041 19.25 12 19.25C7.99594 19.25 4.75 16.0041 4.75 12Z" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"></path>
+                    <svg
+                      width="16"
+                      height="16"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      xmlns="http://www.w3.org/2000/svg"
+                      className="text-secondary"
+                    >
+                      <path
+                        d="M9.75 12.75L11.25 14.25L14.25 9.75"
+                        stroke="currentColor"
+                        strokeWidth="1.5"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      ></path>
+                      <path
+                        d="M4.75 12C4.75 7.99594 7.99594 4.75 12 4.75C16.0041 4.75 19.25 7.99594 19.25 12C19.25 16.0041 16.0041 19.25 12 19.25C7.99594 19.25 4.75 16.0041 4.75 12Z"
+                        stroke="currentColor"
+                        strokeWidth="1.5"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      ></path>
                     </svg>
                   </div>
                   <div>
                     <h4 className="font-medium">Community</h4>
-                    <p className="text-muted-foreground text-sm">Join our developers</p>
+                    <p className="text-muted-foreground text-sm">
+                      Join our developers
+                    </p>
                   </div>
                 </div>
                 <div className="flex items-start gap-3">
                   <div className="rounded-full bg-secondary/10 p-2 mt-0.5">
-                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" className="text-secondary">
-                      <path d="M9.75 12.75L11.25 14.25L14.25 9.75" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"></path>
-                      <path d="M4.75 12C4.75 7.99594 7.99594 4.75 12 4.75C16.0041 4.75 19.25 7.99594 19.25 12C19.25 16.0041 16.0041 19.25 12 19.25C7.99594 19.25 4.75 16.0041 4.75 12Z" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"></path>
+                    <svg
+                      width="16"
+                      height="16"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      xmlns="http://www.w3.org/2000/svg"
+                      className="text-secondary"
+                    >
+                      <path
+                        d="M9.75 12.75L11.25 14.25L14.25 9.75"
+                        stroke="currentColor"
+                        strokeWidth="1.5"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      ></path>
+                      <path
+                        d="M4.75 12C4.75 7.99594 7.99594 4.75 12 4.75C16.0041 4.75 19.25 7.99594 19.25 12C19.25 16.0041 16.0041 19.25 12 19.25C7.99594 19.25 4.75 16.0041 4.75 12Z"
+                        stroke="currentColor"
+                        strokeWidth="1.5"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      ></path>
                     </svg>
                   </div>
                   <div>
                     <h4 className="font-medium">Apache 2.0</h4>
-                    <p className="text-muted-foreground text-sm">Free to use and modify</p>
+                    <p className="text-muted-foreground text-sm">
+                      Free to use and modify
+                    </p>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
> Changes Implemented

Redesigned the GitHub button with a more dynamic and engaging layout.
Added smooth hover animations:
       GitHub icon transitions out on hover.
       Arrow icon fades and slides in to indicate action.
       Subtle background and color transitions to improve visual feedback.
Ensured responsiveness and compatibility across light and dark themes.

>Before

https://github.com/user-attachments/assets/253f8273-34a4-492a-a495-4de7e54edea3

>After


https://github.com/user-attachments/assets/f478cc03-3084-4c6a-a5f9-7c0fb84a357c
>Result
The GitHub button now feels much more interactive and polished, aligning with open-source best practices and providing a better first impression for contributors and users.


