### PR TITLE
Add support for OpenAI-compatible base URL

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -17,6 +17,8 @@ REDIS_SSL=false
 # LLM Providers:
 ANTHROPIC_API_KEY=
 OPENAI_API_KEY=
+# For custom OpenAI-compatible endpoints (e.g., http://localhost:3000/v1)
+OPENAI_API_BASE=
 MODEL_TO_USE=
 
 AWS_ACCESS_KEY_ID=
@@ -29,7 +31,7 @@ OPENROUTER_API_KEY=
 # DATA APIS
 RAPID_API_KEY=
 
-# WEB SEARCH 
+# WEB SEARCH
 TAVILY_API_KEY=
 
 # WEB SCRAPE

--- a/backend/services/llm.py
+++ b/backend/services/llm.py
@@ -46,17 +46,22 @@ def setup_api_keys() -> None:
             logger.debug(f"API key set for provider: {provider}")
         else:
             logger.warning(f"No API key found for provider: {provider}")
-    
+
+    # Set up OpenAI API base if configured
+    if config.OPENAI_API_KEY and config.OPENAI_API_BASE:
+        os.environ['OPENAI_API_BASE'] = config.OPENAI_API_BASE
+        logger.debug(f"Set OPENAI_API_BASE to {config.OPENAI_API_BASE}")
+
     # Set up OpenRouter API base if not already set
     if config.OPENROUTER_API_KEY and config.OPENROUTER_API_BASE:
         os.environ['OPENROUTER_API_BASE'] = config.OPENROUTER_API_BASE
         logger.debug(f"Set OPENROUTER_API_BASE to {config.OPENROUTER_API_BASE}")
-    
+
     # Set up AWS Bedrock credentials
     aws_access_key = config.AWS_ACCESS_KEY_ID
     aws_secret_key = config.AWS_SECRET_ACCESS_KEY
     aws_region = config.AWS_REGION_NAME
-    
+
     if aws_access_key and aws_secret_key and aws_region:
         logger.debug(f"AWS credentials set for Bedrock in region: {aws_region}")
         # Configure LiteLLM to use AWS credentials
@@ -132,11 +137,11 @@ def prepare_params(
             "anthropic-beta": "output-128k-2025-02-19"
         }
         logger.debug("Added Claude-specific headers")
-    
+
     # Add OpenRouter-specific parameters
     if model_name.startswith("openrouter/"):
         logger.debug(f"Preparing OpenRouter parameters for model: {model_name}")
-        
+
         # Add optional site URL and app name from config
         site_url = config.OR_SITE_URL
         app_name = config.OR_APP_NAME
@@ -148,11 +153,11 @@ def prepare_params(
                 extra_headers["X-Title"] = app_name
             params["extra_headers"] = extra_headers
             logger.debug(f"Added OpenRouter site URL and app name to headers")
-    
+
     # Add Bedrock-specific parameters
     if model_name.startswith("bedrock/"):
         logger.debug(f"Preparing AWS Bedrock parameters for model: {model_name}")
-        
+
         if not model_id and "anthropic.claude-3-7-sonnet" in model_name:
             params["model_id"] = "arn:aws:bedrock:us-west-2:935064898258:inference-profile/us.anthropic.claude-3-7-sonnet-20250219-v1:0"
             logger.debug(f"Auto-set model_id for Claude 3.7 Sonnet: {params['model_id']}")
@@ -256,7 +261,7 @@ async def make_llm_api_call(
 ) -> Union[Dict[str, Any], AsyncGenerator]:
     """
     Make an API call to a language model using LiteLLM.
-    
+
     Args:
         messages: List of message dictionaries for the conversation
         model_name: Name of the model to use (e.g., "gpt-4", "claude-3", "openrouter/openai/gpt-4", "bedrock/anthropic.claude-3-sonnet-20240229-v1:0")
@@ -272,15 +277,15 @@ async def make_llm_api_call(
         model_id: Optional ARN for Bedrock inference profiles
         enable_thinking: Whether to enable thinking
         reasoning_effort: Level of reasoning effort
-        
+
     Returns:
         Union[Dict[str, Any], AsyncGenerator]: API response or stream
-        
+
     Raises:
         LLMRetryError: If API call fails after retries
         LLMError: For other API-related errors
     """
-    # debug <timestamp>.json messages 
+    # debug <timestamp>.json messages
     logger.debug(f"Making LLM API call to model: {model_name} (Thinking: {enable_thinking}, Effort: {reasoning_effort})")
     params = prepare_params(
         messages=messages,
@@ -303,20 +308,20 @@ async def make_llm_api_call(
         try:
             logger.debug(f"Attempt {attempt + 1}/{MAX_RETRIES}")
             # logger.debug(f"API request parameters: {json.dumps(params, indent=2)}")
-            
+
             response = await litellm.acompletion(**params)
             logger.debug(f"Successfully received API response from {model_name}")
             logger.debug(f"Response: {response}")
             return response
-            
+
         except (litellm.exceptions.RateLimitError, OpenAIError, json.JSONDecodeError) as e:
             last_error = e
             await handle_error(e, attempt, MAX_RETRIES)
-            
+
         except Exception as e:
             logger.error(f"Unexpected error during API call: {str(e)}", exc_info=True)
             raise LLMError(f"API call failed: {str(e)}")
-    
+
     error_msg = f"Failed to make API call after {MAX_RETRIES} attempts"
     if last_error:
         error_msg += f". Last error: {str(last_error)}"
@@ -332,7 +337,7 @@ async def test_openrouter():
     test_messages = [
         {"role": "user", "content": "Hello, can you give me a quick test response?"}
     ]
-    
+
     try:
         # Test with standard OpenRouter model
         print("\n--- Testing standard OpenRouter model ---")
@@ -343,7 +348,7 @@ async def test_openrouter():
             max_tokens=100
         )
         print(f"Response: {response.choices[0].message.content}")
-        
+
         # Test with deepseek model
         print("\n--- Testing deepseek model ---")
         response = await make_llm_api_call(
@@ -354,7 +359,7 @@ async def test_openrouter():
         )
         print(f"Response: {response.choices[0].message.content}")
         print(f"Model used: {response.model}")
-        
+
         # Test with Mistral model
         print("\n--- Testing Mistral model ---")
         response = await make_llm_api_call(
@@ -365,7 +370,7 @@ async def test_openrouter():
         )
         print(f"Response: {response.choices[0].message.content}")
         print(f"Model used: {response.model}")
-        
+
         return True
     except Exception as e:
         print(f"Error testing OpenRouter: {str(e)}")
@@ -376,8 +381,8 @@ async def test_bedrock():
     test_messages = [
         {"role": "user", "content": "Hello, can you give me a quick test response?"}
     ]
-    
-    try:    
+
+    try:
         response = await make_llm_api_call(
             model_name="bedrock/anthropic.claude-3-7-sonnet-20250219-v1:0",
             model_id="arn:aws:bedrock:us-west-2:935064898258:inference-profile/us.anthropic.claude-3-7-sonnet-20250219-v1:0",
@@ -388,7 +393,7 @@ async def test_bedrock():
         )
         print(f"Response: {response.choices[0].message.content}")
         print(f"Model used: {response.model}")
-        
+
         return True
     except Exception as e:
         print(f"Error testing Bedrock: {str(e)}")
@@ -396,9 +401,9 @@ async def test_bedrock():
 
 if __name__ == "__main__":
     import asyncio
-        
+
     test_success = asyncio.run(test_bedrock())
-    
+
     if test_success:
         print("\n✅ integration test completed successfully!")
     else:

--- a/backend/utils/config.py
+++ b/backend/utils/config.py
@@ -8,7 +8,7 @@ values.
 
 Usage:
     from utils.config import config
-    
+
     # Access configuration values
     api_key = config.OPENAI_API_KEY
     env_mode = config.ENV_MODE
@@ -31,14 +31,14 @@ class EnvMode(Enum):
 class Configuration:
     """
     Centralized configuration for AgentPress backend.
-    
+
     This class loads environment variables and provides type checking and validation.
     Default values can be specified for optional configuration items.
     """
-    
+
     # Environment mode
     ENV_MODE: EnvMode = EnvMode.LOCAL
-    
+
     # Subscription tier IDs - Production
     STRIPE_FREE_TIER_ID_PROD: str = 'price_1RILb4G6l1KZGqIrK4QLrx9i'
     STRIPE_TIER_2_20_ID_PROD: str = 'price_1RILb4G6l1KZGqIrhomjgDnO'
@@ -48,7 +48,7 @@ class Configuration:
     STRIPE_TIER_50_400_ID_PROD: str = 'price_1RILb4G6l1KZGqIruNBUMTF1'
     STRIPE_TIER_125_800_ID_PROD: str = 'price_1RILb3G6l1KZGqIrbJA766tN'
     STRIPE_TIER_200_1000_ID_PROD: str = 'price_1RILb3G6l1KZGqIrmauYPOiN'
-    
+
     # Subscription tier IDs - Staging
     STRIPE_FREE_TIER_ID_STAGING: str = 'price_1RIGvuG6l1KZGqIrw14abxeL'
     STRIPE_TIER_2_20_ID_STAGING: str = 'price_1RIGvuG6l1KZGqIrCRu0E4Gi'
@@ -58,116 +58,117 @@ class Configuration:
     STRIPE_TIER_50_400_ID_STAGING: str = 'price_1RIKNgG6l1KZGqIrvsat5PW7'
     STRIPE_TIER_125_800_ID_STAGING: str = 'price_1RIKNrG6l1KZGqIrjKT0yGvI'
     STRIPE_TIER_200_1000_ID_STAGING: str = 'price_1RIKQ2G6l1KZGqIrum9n8SI7'
-    
+
     # Computed subscription tier IDs based on environment
     @property
     def STRIPE_FREE_TIER_ID(self) -> str:
         if self.ENV_MODE == EnvMode.STAGING:
             return self.STRIPE_FREE_TIER_ID_STAGING
         return self.STRIPE_FREE_TIER_ID_PROD
-    
+
     @property
     def STRIPE_TIER_2_20_ID(self) -> str:
         if self.ENV_MODE == EnvMode.STAGING:
             return self.STRIPE_TIER_2_20_ID_STAGING
         return self.STRIPE_TIER_2_20_ID_PROD
-    
+
     @property
     def STRIPE_TIER_6_50_ID(self) -> str:
         if self.ENV_MODE == EnvMode.STAGING:
             return self.STRIPE_TIER_6_50_ID_STAGING
         return self.STRIPE_TIER_6_50_ID_PROD
-    
+
     @property
     def STRIPE_TIER_12_100_ID(self) -> str:
         if self.ENV_MODE == EnvMode.STAGING:
             return self.STRIPE_TIER_12_100_ID_STAGING
         return self.STRIPE_TIER_12_100_ID_PROD
-    
+
     @property
     def STRIPE_TIER_25_200_ID(self) -> str:
         if self.ENV_MODE == EnvMode.STAGING:
             return self.STRIPE_TIER_25_200_ID_STAGING
         return self.STRIPE_TIER_25_200_ID_PROD
-    
+
     @property
     def STRIPE_TIER_50_400_ID(self) -> str:
         if self.ENV_MODE == EnvMode.STAGING:
             return self.STRIPE_TIER_50_400_ID_STAGING
         return self.STRIPE_TIER_50_400_ID_PROD
-    
+
     @property
     def STRIPE_TIER_125_800_ID(self) -> str:
         if self.ENV_MODE == EnvMode.STAGING:
             return self.STRIPE_TIER_125_800_ID_STAGING
         return self.STRIPE_TIER_125_800_ID_PROD
-    
+
     @property
     def STRIPE_TIER_200_1000_ID(self) -> str:
         if self.ENV_MODE == EnvMode.STAGING:
             return self.STRIPE_TIER_200_1000_ID_STAGING
         return self.STRIPE_TIER_200_1000_ID_PROD
-    
+
     # LLM API keys
     ANTHROPIC_API_KEY: str = None
     OPENAI_API_KEY: Optional[str] = None
+    OPENAI_API_BASE: Optional[str] = None
     GROQ_API_KEY: Optional[str] = None
     OPENROUTER_API_KEY: Optional[str] = None
     OPENROUTER_API_BASE: Optional[str] = "https://openrouter.ai/api/v1"
     OR_SITE_URL: Optional[str] = None
-    OR_APP_NAME: Optional[str] = "Suna.so"    
-    
+    OR_APP_NAME: Optional[str] = "Suna.so"
+
     # AWS Bedrock credentials
     AWS_ACCESS_KEY_ID: Optional[str] = None
     AWS_SECRET_ACCESS_KEY: Optional[str] = None
     AWS_REGION_NAME: Optional[str] = None
-    
+
     # Model configuration
     MODEL_TO_USE: Optional[str] = "anthropic/claude-3-7-sonnet-latest"
-    
+
     # Supabase configuration
     SUPABASE_URL: str
     SUPABASE_ANON_KEY: str
     SUPABASE_SERVICE_ROLE_KEY: str
-    
+
     # Redis configuration
     REDIS_HOST: str
     REDIS_PORT: int = 6379
     REDIS_PASSWORD: str
     REDIS_SSL: bool = True
-    
+
     # Daytona sandbox configuration
     DAYTONA_API_KEY: str
     DAYTONA_SERVER_URL: str
     DAYTONA_TARGET: str
-    
+
     # Search and other API keys
     TAVILY_API_KEY: str
     RAPID_API_KEY: str
     CLOUDFLARE_API_TOKEN: Optional[str] = None
     FIRECRAWL_API_KEY: str
-    
+
     # Stripe configuration
     STRIPE_SECRET_KEY: Optional[str] = None
     STRIPE_WEBHOOK_SECRET: Optional[str] = None
     STRIPE_DEFAULT_PLAN_ID: Optional[str] = None
     STRIPE_DEFAULT_TRIAL_DAYS: int = 14
-    
+
     # Stripe Product IDs
     STRIPE_PRODUCT_ID_PROD: str = 'prod_SCl7AQ2C8kK1CD'  # Production product ID
     STRIPE_PRODUCT_ID_STAGING: str = 'prod_SCgIj3G7yPOAWY'  # Staging product ID
-    
+
     @property
     def STRIPE_PRODUCT_ID(self) -> str:
         if self.ENV_MODE == EnvMode.STAGING:
             return self.STRIPE_PRODUCT_ID_STAGING
         return self.STRIPE_PRODUCT_ID_PROD
-    
+
     def __init__(self):
         """Initialize configuration by loading from environment variables."""
         # Load environment variables from .env file if it exists
         load_dotenv()
-        
+
         # Set environment mode first
         env_mode_str = os.getenv("ENV_MODE", EnvMode.LOCAL.value)
         try:
@@ -175,20 +176,20 @@ class Configuration:
         except ValueError:
             logger.warning(f"Invalid ENV_MODE: {env_mode_str}, defaulting to LOCAL")
             self.ENV_MODE = EnvMode.LOCAL
-            
+
         logger.info(f"Environment mode: {self.ENV_MODE.value}")
-        
+
         # Load configuration from environment variables
         self._load_from_env()
-        
+
         # Perform validation
         self._validate()
-        
+
     def _load_from_env(self):
         """Load configuration values from environment variables."""
         for key, expected_type in get_type_hints(self.__class__).items():
             env_val = os.getenv(key)
-            
+
             if env_val is not None:
                 # Convert environment variable to the expected type
                 if expected_type == bool:
@@ -206,38 +207,38 @@ class Configuration:
                 else:
                     # String or other type
                     setattr(self, key, env_val)
-    
+
     def _validate(self):
         """Validate configuration based on type hints."""
         # Get all configuration fields and their type hints
         type_hints = get_type_hints(self.__class__)
-        
+
         # Find missing required fields
         missing_fields = []
         for field, field_type in type_hints.items():
             # Check if the field is Optional
             is_optional = hasattr(field_type, "__origin__") and field_type.__origin__ is Union and type(None) in field_type.__args__
-            
+
             # If not optional and value is None, add to missing fields
             if not is_optional and getattr(self, field) is None:
                 missing_fields.append(field)
-        
+
         if missing_fields:
             error_msg = f"Missing required configuration fields: {', '.join(missing_fields)}"
             logger.error(error_msg)
             raise ValueError(error_msg)
-    
+
     def get(self, key: str, default: Any = None) -> Any:
         """Get a configuration value with an optional default."""
         return getattr(self, key, default)
-    
+
     def as_dict(self) -> Dict[str, Any]:
         """Return configuration as a dictionary."""
         return {
-            key: getattr(self, key) 
+            key: getattr(self, key)
             for key in get_type_hints(self.__class__).keys()
             if not key.startswith('_')
         }
 
 # Create a singleton instance
-config = Configuration() 
+config = Configuration()


### PR DESCRIPTION
# Add Support for OpenAI Compatible API Base URL

## Feature Description

This PR adds support for a custom OpenAI compatible API base URL, allowing users to connect to locally running LLM APIs or other OpenAI compatible services.

## Implementation Details

1. Added `OPENAI_API_BASE` variable to the `Configuration` class to store the custom base URL for OpenAI compatible APIs.
2. Updated the `setup_api_keys` function to set the corresponding environment variables when `OPENAI_API_KEY` and `OPENAI_API_BASE` are configured.
3. Updated the `.env.example` file to include the new `OPENAI_API_BASE` variable and its description.

## How to Use

Users can set the following variables in their `.env` file:
OPENAI_API_KEY=your-api-key
OPENAI_API_BASE=http://localhost:3000/v1

This way, when using OpenAI compatible models, LiteLLM will automatically use the configured custom base URL.