### PR TITLE
Minor fixes

### DIFF
--- a/backend/agent/run.py
+++ b/backend/agent/run.py
@@ -19,7 +19,7 @@ from agent.tools.sb_files_tool import SandboxFilesTool
 from agent.tools.sb_browser_tool import SandboxBrowserTool
 from agent.tools.data_providers_tool import DataProvidersTool
 from agent.prompt import get_system_prompt
-from utils import logger
+from utils.logger import logger
 from utils.auth_utils import get_account_id_from_thread
 from services.billing import check_billing_status
 from agent.tools.sb_vision_tool import SandboxVisionTool

--- a/backend/agent/tools/web_search_tool.py
+++ b/backend/agent/tools/web_search_tool.py
@@ -62,7 +62,7 @@ class WebSearchTool(Tool):
         mappings=[
             {"param_name": "query", "node_type": "attribute", "path": "."},
             # {"param_name": "summary", "node_type": "attribute", "path": "."},
-            {"param_name": "num_results", "node_type": "attribute", "path": "."}
+            {"param_name": "num_results", "node_type": "attribute", "path": ".", "required": False}
         ],
         example='''
         <!-- 


### PR DESCRIPTION
Fix crashes when agent logs.
Fix crashes when the web search doesn't have `num_results`.

TODO: Provide feedback to the agent if the tool call parsing failed (currently it silently stops execution)