### PR TITLE
Migrate to modern datetime library API

### DIFF
--- a/backend/utils/logger.py
+++ b/backend/utils/logger.py
@@ -12,7 +12,7 @@ import logging
 import json
 import sys
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 from contextvars import ContextVar
 from functools import wraps
 import traceback
@@ -29,7 +29,7 @@ class JSONFormatter(logging.Formatter):
     def format(self, record: logging.LogRecord) -> str:
         """Format log record as JSON with contextual information."""
         log_data = {
-            'timestamp': datetime.utcnow().isoformat(),
+            'timestamp': datetime.now(timezone.utc).replace(tzinfo=None).isoformat(),
             'level': record.levelname,
             'message': record.getMessage(),
             'module': record.module,


### PR DESCRIPTION
# PR Summary
This small PR resolves the `datetime` library warnings:
```python
DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC). or datetime.datetime.utcnow()
```
Note that `.replace(tzinfo=None)` allows to keep the original behavior where the time appears as a naive UTC timestamp (i.e., without any timezone offset).