### PR TITLE
fix: fixed duplicate import in threadcontext.tsx

### DIFF
--- a/frontend/src/components/thread/content/ThreadContent.tsx
+++ b/frontend/src/components/thread/content/ThreadContent.tsx
@@ -4,7 +4,6 @@ import { ArrowDown, CircleDashed } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Markdown } from '@/components/ui/markdown';
 import { UnifiedMessage, ParsedContent, ParsedMetadata } from '@/components/thread/types';
-import { safeJsonParse } from '@/components/thread/utils';
 import { FileAttachmentGrid } from '@/components/thread/file-attachment';
 import { FileCache } from '@/hooks/use-cached-file';
 import { useAuth } from '@/components/AuthProvider';


### PR DESCRIPTION
### Problem Description
There was a duplicate import in ThreadContext.txt which was causing the frontend build to fail as can be seen from the image attached below.

<img width="1388" alt="Screenshot 2025-05-13 at 10 19 42 PM" src="https://github.com/user-attachments/assets/726e6808-c1b9-4c75-b9db-8afd2785ea43" />

### Enhancements
Removed the duplicate import.
This PR fixes https://github.com/kortix-ai/suna/issues/303