### PR TITLE
chore(config): refactor sandbox image constants into common config

### DIFF
--- a/backend/sandbox/sandbox.py
+++ b/backend/sandbox/sandbox.py
@@ -3,6 +3,7 @@ from daytona_api_client.models.workspace_state import WorkspaceState
 from dotenv import load_dotenv
 from utils.logger import logger
 from utils.config import config
+from utils.config import Configuration
 
 load_dotenv()
 
@@ -91,7 +92,7 @@ def create_sandbox(password: str, project_id: str = None):
         labels = {'id': project_id}
         
     params = CreateSandboxParams(
-        image="kortix/suna:0.1.2",
+        image=Configuration.SANDBOX_IMAGE_NAME,
         public=True,
         labels=labels,
         env_vars={

--- a/backend/utils/config.py
+++ b/backend/utils/config.py
@@ -158,6 +158,10 @@ class Configuration:
     STRIPE_PRODUCT_ID_PROD: str = 'prod_SCl7AQ2C8kK1CD'  # Production product ID
     STRIPE_PRODUCT_ID_STAGING: str = 'prod_SCgIj3G7yPOAWY'  # Staging product ID
     
+    # Sandbox configuration
+    SANDBOX_IMAGE_NAME = "kortix/suna:0.1.2"
+    SANDBOX_ENTRYPOINT = "/usr/bin/supervisord -n -c /etc/supervisor/conf.d/supervisord.conf"
+
     @property
     def STRIPE_PRODUCT_ID(self) -> str:
         if self.ENV_MODE == EnvMode.STAGING:

--- a/setup.py
+++ b/setup.py
@@ -1,19 +1,12 @@
 #!/usr/bin/env python3
 import os
 import sys
-import json
 import time
-import shutil
 import platform
 import subprocess
-from pathlib import Path
-import urllib.request
-import configparser
 from getpass import getpass
 import re
-import socket
-import random
-import string
+from backend.utils.config import Configuration
 
 # ANSI colors for pretty output
 class Colors:
@@ -201,9 +194,9 @@ def collect_daytona_info():
     print_info("Then, generate an API key from 'Keys' menu")
     print_info("After that, go to Images (https://app.daytona.io/dashboard/images)")
     print_info("Click '+ Create Image'")
-    print_info("Enter 'kortix/suna:0.1.2' as the image name")
-    print_info("Set '/usr/bin/supervisord -n -c /etc/supervisor/conf.d/supervisord.conf' as the Entrypoint")
-    
+    print_info(f"Enter '{Configuration.SANDBOX_IMAGE_NAME}' as the image name")
+    print_info(f"Set '{Configuration.SANDBOX_ENTRYPOINT}' as the Entrypoint")
+
     input("Press Enter to continue once you've completed these steps...")
     
     while True:


### PR DESCRIPTION
This pull request introduces a centralized configuration class (`Config`) for managing sandbox-related constants, replacing hardcoded values with references to the new class across the codebase. This change improves maintainability and reduces duplication.

### Centralized configuration:

* [`backend/config.py`](diffhunk://#diff-651976572b51d1a16ede6a1c4c1be9a1482605ce57ca58fbfca25e4a55c43210R1-R3): Added a new `Config` class with constants `SANDBOX_IMAGE_NAME` and `SANDBOX_ENTRYPOINT` to centralize sandbox configuration.

### Refactoring to use the `Config` class:

* `backend/sandbox/sandbox.py`:
  - Imported the `Config` class for use in sandbox-related operations.
  - Updated the `create_sandbox` function to use `Config.SANDBOX_IMAGE_NAME` instead of a hardcoded image name.
* `setup.py`:
  - Replaced hardcoded sandbox image name and entrypoint in `collect_daytona_info` with references to `Config.SANDBOX_IMAGE_NAME` and `Config.SANDBOX_ENTRYPOINT`.
  - Cleaned up unnecessary imports and added an import for the `Config` class.