### PR TITLE
hotfix(setup): uncomment required steps

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -824,16 +824,16 @@ def main():
     
     current_step += 1
     
-    # # Collect all environment variables
-    # print_step(current_step, total_steps, "Collecting Supabase information")
-    # supabase_info = collect_supabase_info()
-    # # Set Supabase URL in environment for later use
-    # os.environ['SUPABASE_URL'] = supabase_info['SUPABASE_URL']
-    # current_step += 1
+    # Collect all environment variables
+    print_step(current_step, total_steps, "Collecting Supabase information")
+    supabase_info = collect_supabase_info()
+    # Set Supabase URL in environment for later use
+    os.environ['SUPABASE_URL'] = supabase_info['SUPABASE_URL']
+    current_step += 1
     
-    # print_step(current_step, total_steps, "Collecting Daytona information")
-    # daytona_info = collect_daytona_info()
-    # current_step += 1
+    print_step(current_step, total_steps, "Collecting Daytona information")
+    daytona_info = collect_daytona_info()
+    current_step += 1
     
     print_step(current_step, total_steps, "Collecting LLM API keys")
     llm_api_keys = collect_llm_api_keys()


### PR DESCRIPTION
This pull request re-enables previously commented-out sections of the `main()` function in `setup.py` to restore functionality for collecting Supabase and Daytona information during the setup process.

Restored functionality:

* Re-enabled the steps for collecting Supabase information, including setting the `SUPABASE_URL` environment variable. (`[setup.pyL827-R836](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L827-R836)`)
* Re-enabled the steps for collecting Daytona information. (`[setup.pyL827-R836](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L827-R836)`)