### PR TITLE
feat(start): added container starter/stopper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,12 @@ cd suna
 python setup.py
 ```
 
+3. **Start or stop the containers**:
+
+```bash
+python start.py
+```
+
 ### Manual Setup
 
 See the [Self-Hosting Guide](./docs/SELF-HOSTING.md) for detailed manual setup instructions.

--- a/docs/SELF-HOSTING.md
+++ b/docs/SELF-HOSTING.md
@@ -199,7 +199,9 @@ Suna can be started in two ways:
 This method starts all required services in Docker containers:
 
 ```bash
-docker compose up -d
+docker compose up -d # Use `docker compose down` to stop it later
+# or
+python start.py # Use the same to stop it later
 ```
 
 ### 2. Manual Startup

--- a/start.py
+++ b/start.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+
+import subprocess
+import sys
+
+def check_docker_compose_up():
+    result = subprocess.run(
+        ["docker", "compose", "ps", "-q"],
+        capture_output=True,
+        text=True
+    )
+    return len(result.stdout.strip()) > 0
+
+def main():
+    force = False
+    if "--help" in sys.argv:
+        print("Usage: ./script.py [OPTION]")
+        print("Manage docker-compose services interactively")
+        print("\nOptions:")
+        print("  -f\tForce start containers without confirmation")
+        print("  --help\tShow this help message")
+        return
+    if "-f" in sys.argv:
+        force = True
+        print("Force awakened. Skipping confirmation.")
+
+    is_up = check_docker_compose_up()
+
+    if is_up:
+        action = "stop"
+        msg = "🛑 Stop containers? [y/N] "  # No default
+    else:
+        action = "start"
+        msg = "⚡ Start containers? [Y/n] "  # Yes default
+
+    if not force:
+        response = input(msg).strip().lower()
+        if action == "stop":
+            # Only proceed if user explicitly types 'y'
+            if response != "y":
+                print("Aborting.")
+                return
+        else:
+            # Proceed unless user types 'n'
+            if response == "n":
+                print("Aborting.")
+                return
+
+    if action == "stop":
+        subprocess.run(["docker", "compose", "down"])
+    else:
+        subprocess.run(["docker", "compose", "up", "-d"])
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This pull request introduces a new script, `start.py`, to interactively manage Docker Compose services. The script provides options to start or stop containers with user confirmation and includes a force mode to bypass prompts.

### Added functionality:

* **Interactive Docker Compose management**: The script determines whether Docker Compose services are running and prompts the user to start or stop them based on their current state.
* **Command-line options**: Added support for `--help` to display usage information and `-f` to enable force mode, skipping user confirmation.