### PR TITLE
hotfix(setup): backend url fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -523,15 +523,16 @@ def configure_frontend_env(env_vars, use_docker=True):
     env_path = os.path.join('frontend', '.env.local')
     
     # Use the appropriate backend URL based on start method
-    backend_url = "http://backend:8000/api" if use_docker else "http://localhost:8000/api"
-    
+    backend_url = "http://localhost:8000/api"
+
     config = {
         'NEXT_PUBLIC_SUPABASE_URL': env_vars['supabase']['SUPABASE_URL'],
         'NEXT_PUBLIC_SUPABASE_ANON_KEY': env_vars['supabase']['SUPABASE_ANON_KEY'],
         'NEXT_PUBLIC_BACKEND_URL': backend_url,
         'NEXT_PUBLIC_URL': 'http://localhost:3000',
+        'NEXT_PUBLIC_ENV_MODE': 'LOCAL',
     }
-    
+
     # Write to file
     with open(env_path, 'w') as f:
         for key, value in config.items():


### PR DESCRIPTION
This pull request includes a change to the `configure_frontend_env` function in `setup.py` to simplify the backend URL configuration and add a new environment variable for the frontend.

### Changes to environment configuration:

* [`setup.py`](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L526-R533): Removed the conditional logic for determining the backend URL, defaulting it to `http://localhost:8000/api` regardless of whether Docker is used. Added a new environment variable, `NEXT_PUBLIC_ENV_MODE`, set to `'LOCAL'`.