### PR TITLE
fix: improve forgot password dialog opacity and remove duplicate close button

### DIFF
--- a/frontend/src/app/auth/page.tsx
+++ b/frontend/src/app/auth/page.tsx
@@ -509,7 +509,7 @@ function LoginContent() {
 
       {/* Forgot Password Dialog */}
       <Dialog open={forgotPasswordOpen} onOpenChange={setForgotPasswordOpen}>
-        <DialogContent className="sm:max-w-md rounded-xl bg-[#F3F4F6] dark:bg-[#F9FAFB]/[0.02] border border-border">
+        <DialogContent className="sm:max-w-md rounded-xl bg-[#F3F4F6] dark:bg-[#17171A] border border-border [&>button]:hidden">
           <DialogHeader>
             <div className="flex items-center justify-between">
               <DialogTitle className="text-xl font-medium">

--- a/frontend/src/components/GoogleSignIn.tsx
+++ b/frontend/src/components/GoogleSignIn.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useCallback, useRef, useState } from 'react';
 import Script from 'next/script';
 import { createClient } from '@/lib/supabase/client';
+import { useTheme } from 'next-themes';
 
 // Add type declarations for Google One Tap
 declare global {
@@ -68,6 +69,7 @@ interface GoogleSignInProps {
 export default function GoogleSignIn({ returnUrl }: GoogleSignInProps) {
   const googleClientId = process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID;
   const [isLoading, setIsLoading] = useState(false);
+  const { resolvedTheme } = useTheme();
 
   const handleGoogleSignIn = useCallback(
     async (response: GoogleSignInResponse) => {
@@ -184,7 +186,7 @@ export default function GoogleSignIn({ returnUrl }: GoogleSignInProps) {
             if (buttonContainer) {
               window.google.accounts.id.renderButton(buttonContainer, {
                 type: 'standard',
-                theme: 'outline',
+                theme: resolvedTheme === 'dark' ? 'filled_black' : 'outline',
                 size: 'large',
                 text: 'continue_with',
                 shape: 'pill',


### PR DESCRIPTION
**What This PR Does**

- Improves readability of the "Forgot Password" dialog in dark mode by increasing its background opacity to reduce visual conflict between background and foreground text.
- Removes the default dialog close button to prevent duplication, as a custom close button is already implemented and visible.

Fixes #383 

**Screenshot**
![image](https://github.com/user-attachments/assets/3c1f99a5-29d3-461e-b62a-60baa4a95ff7)


These changes enhance the user experience and accessibility, particularly in dark theme environments.