### PR TITLE
hotfix(setup): setup fails without a .env file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,6 @@ import platform
 import subprocess
 from getpass import getpass
 import re
-from backend.utils.config import Configuration
 
 # ANSI colors for pretty output
 class Colors:
@@ -194,8 +193,8 @@ def collect_daytona_info():
     print_info("Then, generate an API key from 'Keys' menu")
     print_info("After that, go to Images (https://app.daytona.io/dashboard/images)")
     print_info("Click '+ Create Image'")
-    print_info(f"Enter '{Configuration.SANDBOX_IMAGE_NAME}' as the image name")
-    print_info(f"Set '{Configuration.SANDBOX_ENTRYPOINT}' as the Entrypoint")
+    print_info(f"Enter 'kortix/suna:0.1.2' as the image name")
+    print_info(f"Set '/usr/bin/supervisord -n -c /etc/supervisor/conf.d/supervisord.conf' as the Entrypoint")
 
     input("Press Enter to continue once you've completed these steps...")
     


### PR DESCRIPTION
Fixes #365 and #364 

This pull request updates the `setup.py` file by removing a dependency on the `Configuration` class and replacing it with hardcoded values for better clarity and independence. Below are the key changes:

### Removal of `Configuration` dependency:
* Removed the import statement for `Configuration` from `backend.utils.config`, as it is no longer used in the script.

### Updates to `collect_daytona_info()` function:
* Replaced `Configuration.SANDBOX_IMAGE_NAME` with the hardcoded value `'kortix/suna:0.1.2'` for the image name.
* Replaced `Configuration.SANDBOX_ENTRYPOINT` with the hardcoded value `'/usr/bin/supervisord -n -c /etc/supervisor/conf.d/supervisord.conf'` for the Entrypoint.