### PR TITLE
fix: update Docker image version in setup instructions

### DIFF
--- a/docs/SELF-HOSTING.md
+++ b/docs/SELF-HOSTING.md
@@ -115,7 +115,7 @@ As part of the setup, you'll need to:
 1. Create a Daytona account
 2. Generate an API key
 3. Create a Docker image:
-   - Image name: `kortix/suna:0.1.2`
+   - Image name: `kortix/suna:0.1.2.8`
    - Entrypoint: `/usr/bin/supervisord -n -c /etc/supervisor/conf.d/supervisord.conf`
 
 ## Manual Configuration

--- a/setup.py
+++ b/setup.py
@@ -193,7 +193,7 @@ def collect_daytona_info():
     print_info("Then, generate an API key from 'Keys' menu")
     print_info("After that, go to Images (https://app.daytona.io/dashboard/images)")
     print_info("Click '+ Create Image'")
-    print_info(f"Enter 'kortix/suna:0.1.2' as the image name")
+    print_info(f"Enter 'kortix/suna:0.1.2.8' as the image name")
     print_info(f"Set '/usr/bin/supervisord -n -c /etc/supervisor/conf.d/supervisord.conf' as the Entrypoint")
 
     input("Press Enter to continue once you've completed these steps...")


### PR DESCRIPTION
This pull request updates the version of the Docker image used in the setup instructions and related script output to ensure consistency and accuracy.

### Updates to Docker image version:

* [`docs/SELF-HOSTING.md`](diffhunk://#diff-dcc9d304e935ffdccb5e599aa3f2cf5779616c2d96578db1cdf84ce72d391e53L118-R118): Updated the Docker image name from `kortix/suna:0.1.2` to `kortix/suna:0.1.2.8` in the setup instructions.
* [`setup.py`](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L196-R196): Updated the printed instructions in the `collect_daytona_info()` function to reflect the new Docker image version `kortix/suna:0.1.2.8`.