### PR TITLE
fix(frontend): replace "apt-get" with "apt" in Dockerfile

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -6,18 +6,18 @@ WORKDIR /app
 COPY package*.json ./
 
 # Install build dependencies for node-gyp
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    python3 \
-    make \
-    g++ \
-    build-essential \
-    pkg-config \
-    libcairo2-dev \
-    libpango1.0-dev \
-    libjpeg-dev \
-    libgif-dev \
-    librsvg2-dev \
-    && rm -rf /var/lib/apt/lists/*
+RUN apt update && apt install -y --no-install-recommends \
+  python3 \
+  make \
+  g++ \
+  build-essential \
+  pkg-config \
+  libcairo2-dev \
+  libpango1.0-dev \
+  libjpeg-dev \
+  libgif-dev \
+  librsvg2-dev \
+  && rm -rf /var/lib/apt/lists/*
 
 RUN npm install
 


### PR DESCRIPTION
- "apt" is a replacement for "apt-get" and work same as it , but with better performance. This in turn will increase performance of docker builds.
- Here is a screenshot of benchmarking of apt and apt-get: 
![Screenshot_20250523_110619](https://github.com/user-attachments/assets/9f21460f-b9da-4dc9-a8f9-295b630ea1d5)
