### PR TITLE
Fix: Add gunicorn to backend requirements.txt

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -33,3 +33,4 @@ tavily-python>=0.5.4
 pytesseract==0.3.13
 stripe>=7.0.0
 dramatiq[rabbitmq]>=1.17.1
+gunicorn


### PR DESCRIPTION
Ensures that gunicorn is listed as a dependency in requirements.txt, consistent with its installation in the Dockerfile. This addresses a potential inconsistency in dependency management for the backend service.