### PR TITLE
fix(Dockerfile): update Python dependency installation to use uv for improved performance

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -21,7 +21,8 @@ RUN useradd -m -u 1000 appuser && \
 
 # Install Python dependencies
 COPY --chown=appuser:appuser requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt gunicorn
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+RUN uv pip install --system --no-cache-dir -r requirements.txt gunicorn
 
 # Switch to non-root user
 USER appuser


### PR DESCRIPTION
This pull request updates the `backend/Dockerfile` to improve dependency installation and security practices by leveraging a new tool for Python package management.

Dependency installation improvement:

* [`backend/Dockerfile`](diffhunk://#diff-fed51f49a9f26cb93cc870efdc9419d425b9422354ae41bb651c3333c8bff486L24-R25): Replaced the standard `pip` command with `uv pip` (from the `ghcr.io/astral-sh/uv:latest` image) for installing Python dependencies. This change enhances system-level package management during the build process.