### PR TITLE
docs: add links to other language versions of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,16 @@ Suna's powerful toolkit includes seamless browser automation to navigate the web
 [![GitHub Repo stars](https://img.shields.io/github/stars/kortix-ai/suna)](https://github.com/kortix-ai/suna)
 [![Issues](https://img.shields.io/github/issues/kortix-ai/suna)](https://github.com/kortix-ai/suna/labels/bug)
 
+<!-- Keep these links. Translations will automatically update with the README. -->
+[Deutsch](https://www.readme-i18n.com/kortix-ai/suna?lang=de) | 
+[Español](https://www.readme-i18n.com/kortix-ai/suna?lang=es) | 
+[français](https://www.readme-i18n.com/kortix-ai/suna?lang=fr) | 
+[日本語](https://www.readme-i18n.com/kortix-ai/suna?lang=ja) | 
+[한국어](https://www.readme-i18n.com/kortix-ai/suna?lang=ko) | 
+[Português](https://www.readme-i18n.com/kortix-ai/suna?lang=pt) | 
+[Русский](https://www.readme-i18n.com/kortix-ai/suna?lang=ru) | 
+[中文](https://www.readme-i18n.com/kortix-ai/suna?lang=zh)
+
 </div>
 
 ## Table of Contents


### PR DESCRIPTION
Added language selection links to the README for easier access to translated versions: German, Spanish, French, Japanese, Korean, Portuguese, Russian, and Chinese.

The updated can be previewed in my forked repository: https://github.com/dowithless/suna/tree/patch-1
