### PR TITLE
#772-fix: raise error if SUPABASE_URL is missing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -615,6 +615,10 @@ def setup_supabase():
                         supabase_url = line.strip().split('=', 1)[1]
                         break
 
+    # Add this check
+    if not supabase_url:
+        raise RuntimeError("SUPABASE_URL not found in environment or backend/.env file.")
+
     project_ref = None
     if supabase_url:
         # Extract project reference from URL (format: https://[project_ref].supabase.co)

--- a/setup.py
+++ b/setup.py
@@ -336,7 +336,7 @@ def collect_llm_api_keys():
                     for i, model in enumerate(model_aliases['ANTHROPIC'], 1):
                         print(f"{Colors.CYAN}[{i}] {Colors.GREEN}{model}{Colors.ENDC}")
                     
-                    model_choice = input("Select default model (1-3) or press Enter for claude-3-7-sonnet: ").strip()
+                    model_choice = input("Select default model (1-3) or press Enter for claude-3-7-sonnet ").strip()
                     if not model_choice or model_choice == '1':
                         model_info['default_model'] = 'anthropic/claude-3-7-sonnet-latest'
                     elif model_choice.isdigit() and 1 <= int(model_choice) <= len(model_aliases['ANTHROPIC']):


### PR DESCRIPTION
This PR fixes an issue where `SUPABASE_URL` could be None if missing from the environment or `.env` file.

Added a check after reading the env and `.env` to raise a clear error message if the value is not found.

Closes #772