### PR TITLE
Docker fixes for mac

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -3,6 +3,14 @@ FROM ghcr.io/astral-sh/uv:python3.11-alpine
 ENV ENV_MODE production
 WORKDIR /app
 
+# Install build dependencies for Rust-based Python packages
+RUN apk add --no-cache \
+    gcc \
+    musl-dev \
+    libffi-dev \
+    rust \
+    cargo
+
 # Install Python dependencies
 COPY pyproject.toml uv.lock ./
 ENV UV_LINK_MODE=copy

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -30,7 +30,6 @@ services:
 
   backend:
     image: ghcr.io/suna-ai/suna-backend:latest
-    platform: linux/amd64
     build:
       context: ./backend
       dockerfile: Dockerfile
@@ -57,7 +56,6 @@ services:
 
   worker:
     image: ghcr.io/suna-ai/suna-backend:latest
-    platform: linux/amd64
     build:
       context: ./backend
       dockerfile: Dockerfile


### PR DESCRIPTION
1. Add packages to the dockerfile (tiktoken requires those packages)
2. Remove platform specification to run on mac

**Reporting Issues**

Steps to reproduce: 
1. First install with docker compose
2. Error, something about Rosetta
3. Remove platform: linux/amd64 => works fine, but then tiktoken error
4. Add packages => everything works just fine

Environment details (OS, Node/Docker versions, etc.)
MacOS 15.5 (24F74), Macbook Pro 16-inch, 2021, Apple M1 Max