### PR TITLE
Update start.py

### DIFF
--- a/start.py
+++ b/start.py
@@ -63,11 +63,11 @@ def print_manual_instructions():
     print(f"{Colors.CYAN}   cd frontend && npm run dev{Colors.ENDC}\n")
 
     print(f"{Colors.BOLD}3. Start Backend (in a new terminal):{Colors.ENDC}")
-    print(f"{Colors.CYAN}   cd backend && python run api.py{Colors.ENDC}\n")
+    print(f"{Colors.CYAN}   cd backend && uv run api.py{Colors.ENDC}\n")
 
     print(f"{Colors.BOLD}4. Start Background Worker (in a new terminal):{Colors.ENDC}")
     print(
-        f"{Colors.CYAN}   cd backend && python run -m dramatiq run_agent_background{Colors.ENDC}\n"
+        f"{Colors.CYAN}   cd backend && uv run -m dramatiq run_agent_background{Colors.ENDC}\n"
     )
 
     print("Once all services are running, access Suna at: http://localhost:3000\n")


### PR DESCRIPTION
fix: correct manual startup commands in start.py to use uv

Replace incorrect `python run` commands with proper `uv run` syntax