### PR TITLE
bugfix(frontend/Dockerfile): Intro dockerfile fix to fix canvas build step in docker

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,6 +2,18 @@
 # ---- Base Stage ----
 FROM node:22-slim AS base
 
+# Install Python and build tools needed for native modules like canvas
+RUN apt-get update && apt-get install -y \
+    python3 \
+    python3-pip \
+    build-essential \
+    libcairo2-dev \
+    libpango1.0-dev \
+    libjpeg-dev \
+    libgif-dev \
+    librsvg2-dev \
+    && rm -rf /var/lib/apt/lists/*
+
 # Install dependencies only when needed
 FROM base AS deps
 


### PR DESCRIPTION
# Bug Description

Running docker compose and building the FE container resulted in gyp error, the included changes achieve the a successful container build.

> Stdout Below:
```sh
> [frontend deps 3/3] RUN   if [ -f yarn.lock ]; then yarn --frozen-lockfile;   elif [ -f package-lock.json ]; then npm ci;   elif [ -f pnpm-lock.yaml ]; then corepack enable pnpm && pnpm i --frozen-lockfile;   else echo "Lockfile not found." && exit 1;   fi:
11.01 npm error code 1
11.01 npm error path /app/node_modules/canvas
11.01 npm error command failed
11.01 npm error command sh -c prebuild-install -r napi || node-gyp rebuild
11.01 npm error prebuild-install warn install No prebuilt binaries found (target=7 runtime=napi arch=arm64 libc= platform=linux)
11.01 npm error gyp info it worked if it ends with ok
11.01 npm error gyp info using node-gyp@11.0.0
11.01 npm error gyp info using node@22.17.0 | linux | arm64
11.01 npm error gyp ERR! find Python
11.01 npm error gyp ERR! find Python Python is not set from command line or npm configuration
11.01 npm error gyp ERR! find Python Python is not set from environment variable PYTHON
11.01 npm error gyp ERR! find Python checking if "python3" can be used
11.01 npm error gyp ERR! find Python - executable path is ""
11.01 npm error gyp ERR! find Python - "" could not be run
11.01 npm error gyp ERR! find Python checking if "python" can be used
11.01 npm error gyp ERR! find Python - executable path is ""
11.01 npm error gyp ERR! find Python - "" could not be run
11.01 npm error gyp ERR! find Python
11.01 npm error gyp ERR! find Python **********************************************************
11.01 npm error gyp ERR! find Python You need to install the latest version of Python.
11.01 npm error gyp ERR! find Python Node-gyp should be able to find and use Python. If not,
11.01 npm error gyp ERR! find Python you can try one of the following options:
11.01 npm error gyp ERR! find Python - Use the switch --python="/path/to/pythonexecutable"
11.01 npm error gyp ERR! find Python (accepted by both node-gyp and npm)
11.01 npm error gyp ERR! find Python - Set the environment variable PYTHON
11.01 npm error gyp ERR! find Python - Set the npm configuration variable python:
11.01 npm error gyp ERR! find Python npm config set python "/path/to/pythonexecutable"
11.01 npm error gyp ERR! find Python For more information consult the documentation at:
11.01 npm error gyp ERR! find Python https://github.com/nodejs/node-gyp#installation
11.01 npm error gyp ERR! find Python **********************************************************
11.01 npm error gyp ERR! find Python
11.01 npm error gyp ERR! configure error
11.01 npm error gyp ERR! stack Error: Could not find any Python installation to use
11.01 npm error gyp ERR! stack at PythonFinder.fail (/usr/local/lib/node_modules/npm/node_modules/node-gyp/lib/find-python.js:306:11)
11.01 npm error gyp ERR! stack at PythonFinder.findPython (/usr/local/lib/node_modules/npm/node_modules/node-gyp/lib/find-python.js:164:17)
11.01 npm error gyp ERR! stack at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
11.01 npm error gyp ERR! stack at async configure (/usr/local/lib/node_modules/npm/node_modules/node-gyp/lib/configure.js:27:18)
11.01 npm error gyp ERR! stack at async run (/usr/local/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js:81:18)
11.01 npm error gyp ERR! System Linux 6.10.14-linuxkit
11.01 npm error gyp ERR! command "/usr/local/bin/node" "/usr/local/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
11.01 npm error gyp ERR! cwd /app/node_modules/canvas
11.01 npm error gyp ERR! node -v v22.17.0
11.01 npm error gyp ERR! node-gyp -v v11.0.0
11.01 npm error gyp ERR! not ok
11.01 npm notice
11.01 npm notice New major version of npm available! 10.9.2 -> 11.4.2
11.01 npm notice Changelog: https://github.com/npm/cli/releases/tag/v11.4.2
11.01 npm notice To update run: npm install -g npm@11.4.2
11.01 npm notice
11.01 npm error A complete log of this run can be found in: /root/.npm/_logs/2025-07-12T20_24_39_578Z-debug-0.log
```
