### PR TITLE
fix: restore build dependencies

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -9,6 +9,20 @@ WORKDIR /app
 
 # Install dependencies based on the preferred package manager
 COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml* .npmrc* ./
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3 \
+    make \
+    g++ \
+    build-essential \
+    pkg-config \
+    libcairo2-dev \
+    libpango1.0-dev \
+    libjpeg-dev \
+    libgif-dev \
+    librsvg2-dev \
+    && rm -rf /var/lib/apt/lists/*
+
 RUN \
   if [ -f yarn.lock ]; then yarn --frozen-lockfile; \
   elif [ -f package-lock.json ]; then npm ci; \


### PR DESCRIPTION
fixes #939 

Some build dependencies were removed in #934 due to which frontend build was failing in docker


<img width="1440" height="900" alt="Screenshot 2025-07-13 at 3 02 49 PM" src="https://github.com/user-attachments/assets/c9c59930-4482-45ea-be5e-0cfde6cac557" />
