### PR TITLE
Remove blur from triggers box

### DIFF
--- a/frontend/src/app/(dashboard)/agents/config/[agentId]/page.tsx
+++ b/frontend/src/app/(dashboard)/agents/config/[agentId]/page.tsx
@@ -320,7 +320,8 @@ export default function AgentConfigurationPageRefactored() {
                       onStyleChange={handleStyleChange}
                     />
                   </TabsContent>
-                  <TabsContent value="configuration" className="flex-1 h-0 m-0 overflow-y-auto">
+                                  <TabsContent value="configuration" className="flex-1 h-0 m-0 overflow-y-auto">
+                  <div className="h-full">
                     <ConfigurationTab
                       agentId={agentId}
                       displayData={displayData}
@@ -329,7 +330,8 @@ export default function AgentConfigurationPageRefactored() {
                       onFieldChange={handleFieldChange}
                       onMCPChange={handleMCPChange}
                     />
-                  </TabsContent>
+                  </div>
+                </TabsContent>
                 </Tabs>
               </div>
             </div>
@@ -427,14 +429,16 @@ export default function AgentConfigurationPageRefactored() {
                 </TabsContent>
 
                 <TabsContent value="configuration" className="flex-1 h-0 m-0 overflow-y-auto">
-                  <ConfigurationTab
-                    agentId={agentId}
-                    displayData={displayData}
-                    versionData={versionData}
-                    isViewingOldVersion={isViewingOldVersion}
-                    onFieldChange={handleFieldChange}
-                    onMCPChange={handleMCPChange}
-                  />
+                  <div className="h-full">
+                    <ConfigurationTab
+                      agentId={agentId}
+                      displayData={displayData}
+                      versionData={versionData}
+                      isViewingOldVersion={isViewingOldVersion}
+                      onFieldChange={handleFieldChange}
+                      onMCPChange={handleMCPChange}
+                    />
+                  </div>
                 </TabsContent>
               </Tabs>
             </div>

--- a/frontend/src/components/agents/agent-config-modal.tsx
+++ b/frontend/src/components/agents/agent-config-modal.tsx
@@ -259,8 +259,8 @@ export const AgentConfigModal: React.FC<AgentConfigModalProps> = ({
               </div>
             </TabsContent>
 
-            <TabsContent value="triggers" className="flex-1 m-0 mt-0 overflow-y-auto overflow-hidden">
-              <div className="h-full">
+            <TabsContent value="triggers" className="flex-1 m-0 mt-0 overflow-y-auto">
+              <div className="h-full p-4">
                 {selectedAgentId ? (
                   <AgentTriggersConfiguration agentId={selectedAgentId} />
                 ) : (
@@ -271,8 +271,8 @@ export const AgentConfigModal: React.FC<AgentConfigModalProps> = ({
               </div>
             </TabsContent>
 
-            <TabsContent value="workflows" className="flex-1 m-0 mt-0 overflow-y-auto overflow-hidden">
-              <div className="h-full">
+            <TabsContent value="workflows" className="flex-1 m-0 mt-0 overflow-y-auto">
+              <div className="h-full p-4">
                 {selectedAgentId ? (
                   <AgentWorkflowsConfiguration
                     agentId={selectedAgentId}

--- a/frontend/src/components/agents/config/configuration-tab.tsx
+++ b/frontend/src/components/agents/config/configuration-tab.tsx
@@ -42,7 +42,7 @@ export function ConfigurationTab({
   onMCPChange,
 }: ConfigurationTabProps) {
   return (
-    <div className="p-4">
+    <div className="p-4 pb-8">
       <Accordion type="single" collapsible defaultValue="system" className="space-y-2">
         <AccordionItem 
           value="system" 


### PR DESCRIPTION
Remove blur effect and improve visibility of the Triggers section in agent configuration.

The blur was caused by CSS `overflow-hidden` constraints, improper height management, and insufficient bottom padding, leading to content being visually cut off or distorted. This PR addresses these styling issues for the Triggers and other bottom sections.

---

[Slack Thread](https://kortixworkspace.slack.com/archives/C08QYH7MV6F/p1752668432171019?thread_ts=1752668432.171019&cid=C08QYH7MV6F)