### PR TITLE
Adjust agents menu spacing

### DIFF
--- a/frontend/src/components/sidebar/sidebar-left.tsx
+++ b/frontend/src/components/sidebar/sidebar-left.tsx
@@ -173,57 +173,53 @@ export function SidebarLeft({
             </SidebarMenuButton>
           </Link>
           {!flagsLoading && customAgentsEnabled && (
-            <SidebarMenu>
-              <Collapsible
-                defaultOpen={pathname?.includes('/agents')}
-                className="group/collapsible"
-              >
-                <SidebarMenuItem>
-                  <CollapsibleTrigger asChild>
-                    <SidebarMenuButton
-                      tooltip="Agents"
+            <Collapsible
+              defaultOpen={pathname?.includes('/agents')}
+              className="group/collapsible"
+            >
+              <CollapsibleTrigger asChild>
+                <SidebarMenuButton
+                  tooltip="Agents"
+                >
+                  <Bot className="h-4 w-4" />
+                  <span>Agents</span>
+                  <ChevronRight className="ml-auto transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90" />
+                </SidebarMenuButton>
+              </CollapsibleTrigger>
+              <CollapsibleContent>
+                <SidebarMenuSub>
+                  <SidebarMenuSubItem>
+                    <SidebarMenuSubButton className={cn({
+                      'bg-accent text-accent-foreground font-medium': pathname === '/agents' && (searchParams.get('tab') === 'my-agents' || searchParams.get('tab') === null),
+                    })} asChild>
+                      <Link href="/agents?tab=my-agents">
+                        <Bot className="h-4 w-4" />
+                        <span>My Agents</span>
+                      </Link>
+                    </SidebarMenuSubButton>
+                  </SidebarMenuSubItem>
+                  <SidebarMenuSubItem>
+                    <SidebarMenuSubButton className={cn({
+                      'bg-accent text-accent-foreground font-medium': pathname === '/agents' && searchParams.get('tab') === 'marketplace',
+                    })} asChild>
+                      <Link href="/agents?tab=marketplace">
+                        <Store className="h-4 w-4" />
+                        <span>Marketplace</span>
+                      </Link>
+                    </SidebarMenuSubButton>
+                  </SidebarMenuSubItem>
+                  <SidebarMenuSubItem>
+                    <SidebarMenuSubButton 
+                      onClick={() => setShowNewAgentDialog(true)}
+                      className="cursor-pointer"
                     >
-                      <Bot className="h-4 w-4" />
-                      <span>Agents</span>
-                      <ChevronRight className="ml-auto transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90" />
-                    </SidebarMenuButton>
-                  </CollapsibleTrigger>
-                  <CollapsibleContent>
-                    <SidebarMenuSub>
-                      <SidebarMenuSubItem>
-                        <SidebarMenuSubButton className={cn({
-                          'bg-accent text-accent-foreground font-medium': pathname === '/agents' && (searchParams.get('tab') === 'my-agents' || searchParams.get('tab') === null),
-                        })} asChild>
-                          <Link href="/agents?tab=my-agents">
-                            <Bot className="h-4 w-4" />
-                            <span>My Agents</span>
-                          </Link>
-                        </SidebarMenuSubButton>
-                      </SidebarMenuSubItem>
-                      <SidebarMenuSubItem>
-                        <SidebarMenuSubButton className={cn({
-                          'bg-accent text-accent-foreground font-medium': pathname === '/agents' && searchParams.get('tab') === 'marketplace',
-                        })} asChild>
-                          <Link href="/agents?tab=marketplace">
-                            <Store className="h-4 w-4" />
-                            <span>Marketplace</span>
-                          </Link>
-                        </SidebarMenuSubButton>
-                      </SidebarMenuSubItem>
-                      <SidebarMenuSubItem>
-                        <SidebarMenuSubButton 
-                          onClick={() => setShowNewAgentDialog(true)}
-                          className="cursor-pointer"
-                        >
-                          <Plus className="h-4 w-4" />
-                          <span>New Agent</span>
-                        </SidebarMenuSubButton>
-                      </SidebarMenuSubItem>
-                    </SidebarMenuSub>
-                  </CollapsibleContent>
-                </SidebarMenuItem>
-              </Collapsible>
-            </SidebarMenu>
+                      <Plus className="h-4 w-4" />
+                      <span>New Agent</span>
+                    </SidebarMenuSubButton>
+                  </SidebarMenuSubItem>
+                </SidebarMenuSub>
+              </CollapsibleContent>
+            </Collapsible>
           )}
           {!flagsLoading && customAgentsEnabled && (
             <Link href="/settings/credentials">


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Standardize left spacing for 'Agents' menu item.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The 'Agents' menu item was previously wrapped in `SidebarMenu` and `SidebarMenuItem` components, which introduced additional left padding. Removing these wrappers ensures its structure is consistent with 'New Task' and 'Integrations', resolving the spacing discrepancy.

---

[Slack Thread](https://kortixworkspace.slack.com/archives/C08QYH7MV6F/p1752749101325459?thread_ts=1752749101.325459&cid=C08QYH7MV6F)