### PR TITLE
Update sandbox creation to use snapshots

### DIFF
--- a/backend/sandbox/README.md
+++ b/backend/sandbox/README.md
@@ -24,13 +24,14 @@ You can modify the sandbox environment for development or to add new capabilitie
    ```
 3. Test your changes locally using docker-compose
 
-## Using a Custom Image
+## Using a Custom Snapshot
 
-To use your custom sandbox image:
+To use your custom sandbox snapshot:
 
 1. Change the `image` parameter in `docker-compose.yml` (that defines the image name `kortix/suna:___`)
-2. Update the same image name in `backend/sandbox/sandbox.py` in the `create_sandbox` function
-3. If using Daytona for deployment, update the image reference there as well
+2. Build and create a snapshot in Daytona with the same name
+3. Update the snapshot name in `backend/sandbox/sandbox.py` in the `create_sandbox` function
+4. If using Daytona for deployment, update the snapshot reference there as well
 
 ## Publishing New Versions
 
@@ -39,7 +40,8 @@ When publishing a new version of the sandbox:
 1. Update the version number in `docker-compose.yml` (e.g., from `0.1.2` to `0.1.3`)
 2. Build the new image: `docker compose build`
 3. Push the new version: `docker push kortix/suna:0.1.3`
-4. Update all references to the image version in:
+4. Create a new snapshot in Daytona with the same name
+5. Update all references to the snapshot version in:
    - `backend/utils/config.py`
-   - Daytona images
-   - Any other services using this image
+   - Daytona snapshots
+   - Any other services using this snapshot

--- a/backend/sandbox/sandbox.py
+++ b/backend/sandbox/sandbox.py
@@ -1,4 +1,4 @@
-from daytona_sdk import AsyncDaytona, DaytonaConfig, CreateSandboxFromImageParams, AsyncSandbox, SessionExecuteRequest, Resources, SandboxState
+from daytona_sdk import AsyncDaytona, DaytonaConfig, CreateSandboxFromSnapshotParams, AsyncSandbox, SessionExecuteRequest, Resources, SandboxState
 from dotenv import load_dotenv
 from utils.logger import logger
 from utils.config import config
@@ -82,15 +82,15 @@ async def create_sandbox(password: str, project_id: str = None) -> AsyncSandbox:
     """Create a new sandbox with all required services configured and running."""
     
     logger.debug("Creating new Daytona sandbox environment")
-    logger.debug("Configuring sandbox with browser-use image and environment variables")
+    logger.debug("Configuring sandbox with snapshot and environment variables")
     
     labels = None
     if project_id:
         logger.debug(f"Using sandbox_id as label: {project_id}")
         labels = {'id': project_id}
         
-    params = CreateSandboxFromImageParams(
-        image=Configuration.SANDBOX_IMAGE_NAME,
+    params = CreateSandboxFromSnapshotParams(
+        snapshot=Configuration.SANDBOX_SNAPSHOT_NAME,
         public=True,
         labels=labels,
         env_vars={

--- a/backend/utils/config.py
+++ b/backend/utils/config.py
@@ -222,6 +222,7 @@ class Configuration:
     
     # Sandbox configuration
     SANDBOX_IMAGE_NAME = "kortix/suna:0.1.3"
+    SANDBOX_SNAPSHOT_NAME = "kortix/suna:0.1.3"
     SANDBOX_ENTRYPOINT = "/usr/bin/supervisord -n -c /etc/supervisor/conf.d/supervisord.conf"
 
     # LangFuse configuration

--- a/setup.py
+++ b/setup.py
@@ -649,7 +649,7 @@ class SetupWizard:
         )
         print_info("Create a snapshot with these exact settings:")
         print_info(f"   - Name:\t\t{Colors.GREEN}kortix/suna:0.1.3{Colors.ENDC}")
-        print_info(f"   - Image name:\t{Colors.GREEN}kortix/suna:0.1.3{Colors.ENDC}")
+        print_info(f"   - Snapshot name:\t{Colors.GREEN}kortix/suna:0.1.3{Colors.ENDC}")
         print_info(
             f"   - Entrypoint:\t{Colors.GREEN}/usr/bin/supervisord -n -c /etc/supervisor/conf.d/supervisord.conf{Colors.ENDC}"
         )


### PR DESCRIPTION
Migrate sandbox creation to use snapshots instead of images to comply with Daytona SDK v0.21.0 breaking changes.

---

**Open Background Agent:** 

[Web](https://www.cursor.com/agents?id=bc-780e8c07-c9a1-4099-ae9a-1cece0db8a63) · [Cursor](https://cursor.com/background-agent?bcId=bc-780e8c07-c9a1-4099-ae9a-1cece0db8a63)