### PR TITLE
fix: prevent right panel content overflow in ScrollArea component

### DIFF
--- a/frontend/src/components/ui/scroll-area.tsx
+++ b/frontend/src/components/ui/scroll-area.tsx
@@ -18,7 +18,7 @@ function ScrollArea({
     >
       <ScrollAreaPrimitive.Viewport
         data-slot="scroll-area-viewport"
-        className="focus-visible:ring-ring/50 size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:outline-1"
+        className="focus-visible:ring-ring/50 size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:outline-1 [&>div]:!block"
       >
         {children}
       </ScrollAreaPrimitive.Viewport>


### PR DESCRIPTION
Resolves content overflow issues in the right panel caused by the ScrollArea component's internal div with 'min-width:100%;display:table' styling. This addresses the known shadcn-ui ScrollArea limitation where the component takes up the entire width and causes overflow.

The fix ensures proper width constraints while maintaining scroll functionality.

References: https://github.com/shadcn-ui/ui/issues/3833