### PR TITLE
fix: phantom dependency

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@calcom/embed-react": "^1.5.2",
+    "@codemirror/view": "^6.38.1",
     "@hookform/resolvers": "^5.0.1",
     "@next/third-parties": "^15.3.1",
     "@number-flow/react": "^0.5.7",


### PR DESCRIPTION
There's a phantom package in the `frontend/src/components/file-renderers/code-renderer.tsx` that is not included in package.json, which may cause potential dependency issues.

```tsx
import { EditorView } from '@codemirror/view';
```