### PR TITLE
fix: correct JSON formatting in streamAgent for message type checks

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1091,17 +1091,8 @@ export const streamAgent = (
               `[STREAM] Detected thread run end message for ${agentRunId}`,
             );
 
-            // Add to non-running set
-            nonRunningAgentRuns.add(agentRunId);
-
             // Notify about the message
             callbacks.onMessage(rawData);
-
-            // Clean up
-            eventSource.close();
-            activeStreams.delete(agentRunId);
-            callbacks.onClose();
-
             return;
           }
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1001,7 +1001,7 @@ export const streamAgent = (
       eventSource.onmessage = (event) => {
         try {
           const rawData = event.data;
-          if (rawData.includes('"type":"ping"')) return;
+          if (rawData.includes('"type": "ping"')) return;
 
           // Log raw data for debugging (truncated for readability)
           console.log(
@@ -1055,18 +1055,15 @@ export const streamAgent = (
 
           // Check for completion messages
           if (
-            rawData.includes('"type":"status"') &&
-            rawData.includes('"status":"completed"')
+            rawData.includes('"type": "status"') &&
+            rawData.includes('"status": "completed"')
           ) {
             console.log(
               `[STREAM] Detected completion status message for ${agentRunId}`,
             );
 
             // Check for specific completion messages that indicate we should stop checking
-            if (
-              rawData.includes('Run data not available for streaming') ||
-              rawData.includes('Stream ended with status: completed')
-            ) {
+            if (rawData.includes('Agent run completed successfully')) {
               console.log(
                 `[STREAM] Detected final completion message for ${agentRunId}, adding to non-running set`,
               );
@@ -1087,8 +1084,8 @@ export const streamAgent = (
 
           // Check for thread run end message
           if (
-            rawData.includes('"type":"status"') &&
-            rawData.includes('"status_type":"thread_run_end"')
+            rawData.includes('"type": "status"') &&
+            rawData.includes('thread_run_end')
           ) {
             console.log(
               `[STREAM] Detected thread run end message for ${agentRunId}`,


### PR DESCRIPTION
There are some stringify issues when streaming the data on the frontend. The streaming data from the server side actually contains a space between the field and the value.
E.g. 
* `"type": "ping"` instead of `"type":"ping"`
* `"type": "status"` instead of `"type":"status"`

<img width="891" height="153" alt="image" src="https://github.com/user-attachments/assets/dc777619-b51f-4821-ae98-4548caf4120c" />

Besides, `thread_run_end` is inside the content object, which will be stringified twice on the server side. 
<img width="849" height="690" alt="image" src="https://github.com/user-attachments/assets/e2dabff9-add7-4816-b53b-42dfd313f3cb" />
