### PR TITLE
fix: correct textarea auto-resize behavior and scroll appearance

### DIFF
--- a/frontend/src/components/thread/chat-input/message-input.tsx
+++ b/frontend/src/components/thread/chat-input/message-input.tsx
@@ -102,17 +102,16 @@ export const MessageInput = forwardRef<HTMLTextAreaElement, MessageInputProps>(
       if (!textarea.current) return;
 
       const adjustHeight = () => {
-        textarea.current!.style.height = 'auto';
-        const newHeight = Math.min(
-          Math.max(textarea.current!.scrollHeight, 24),
-          200,
-        );
-        textarea.current!.style.height = `${newHeight}px`;
+        const el = textarea.current;
+        if (!el) return;
+        el.style.height = 'auto';
+        el.style.maxHeight = '200px';
+        el.style.overflowY = el.scrollHeight > 200 ? 'auto' : 'hidden';
+
+        const newHeight = Math.min(el.scrollHeight, 200);
+        el.style.height = `${newHeight}px`;
       };
 
-      adjustHeight();
-
-      // Call it twice to ensure proper height calculation
       adjustHeight();
 
       window.addEventListener('resize', adjustHeight);


### PR DESCRIPTION
avoid scrollbars on initial load

<img width="1698" height="942" alt="CleanShot 2025-07-30 at 17 27 40@2x" src="https://github.com/user-attachments/assets/7e66c2ed-1238-482b-9b6c-046a5f011d40" />

<img width="1844" height="748" alt="CleanShot 2025-07-30 at 17 27 16@2x" src="https://github.com/user-attachments/assets/9ddb16d2-f70c-4fff-90ef-99ab5f741d4c" />
