### PR TITLE
Fix UsageLogEntry interface and update truncateString function

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1675,14 +1675,19 @@ export interface UserSubscriptionResponse {
 
 // Usage log entry interface
 export interface UsageLogEntry {
-  id: string;
-  user_id: string;
-  model: string;
-  input_tokens: number;
-  output_tokens: number;
-  cost_usd: number;
-  timestamp: string;
-  session_type?: string;
+  message_id: string;
+  thread_id: string;
+  created_at: string;
+  content: {
+    usage: {
+      prompt_tokens: number;
+      completion_tokens: number;
+    };
+    model: string;
+  };
+  total_tokens: number;
+  estimated_cost: number;
+  project_id: string;
 }
 
 // Usage logs response interface

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -69,7 +69,8 @@ export const hasErrorInput = [
   'ring-red-200 dark:ring-red-700/30',
 ];
 
-export function truncateString(str: string, maxLength = 50) {
+export function truncateString(str?: string, maxLength = 50) {
+  if (!str) return '';
   if (str.length <= maxLength) return str;
   return str.slice(0, maxLength) + '...';
 }


### PR DESCRIPTION
- Updated the UsageLogEntry interface to include new fields: message_id, thread_id, created_at, content, total_tokens, estimated_cost, and project_id.
- Modified the truncateString function to handle optional string input, returning an empty string if no input is provided.