### PR TITLE
fix: hide panel when resetting the state of playback

### DIFF
--- a/frontend/src/components/thread/content/PlaybackControls.tsx
+++ b/frontend/src/components/thread/content/PlaybackControls.tsx
@@ -110,7 +110,7 @@ export const PlaybackControls = ({
     if (!isPlaying && !isSidePanelOpen) {
       onToggleSidePanel();
     }
-  }, [isPlaying, isSidePanelOpen, onToggleSidePanel]);
+  }, [isPlaying, isSidePanelOpen, onToggleSidePanel, updatePlaybackState]);
 
   const resetPlayback = useCallback(() => {
     updatePlaybackState({
@@ -122,7 +122,10 @@ export const PlaybackControls = ({
       currentToolCall: null,
       toolPlaybackIndex: -1,
     });
-  }, [updatePlaybackState]);
+    if (isSidePanelOpen) {
+      onToggleSidePanel();
+    }
+  }, [updatePlaybackState, isSidePanelOpen, onToggleSidePanel]);
 
   const skipToEnd = useCallback(() => {
     updatePlaybackState({


### PR DESCRIPTION
When clicking the reset button, the right panel doesn't hide.
<img width="1951" height="991" alt="image" src="https://github.com/user-attachments/assets/e3e21b57-b996-4ad8-9adf-9c92172150c0" />
