### PR TITLE
fix: add pandas to sandbox requirements to resolve ModuleNotFoundError (#1043)

### DIFF
--- a/backend/sandbox/docker/requirements.txt
+++ b/backend/sandbox/docker/requirements.txt
@@ -4,3 +4,4 @@ pyautogui==0.9.54
 pillow==10.2.0
 pydantic==2.6.1
 pytesseract==0.3.13
+pandas==2.3.0


### PR DESCRIPTION
<img width="1913" height="868" alt="image" src="https://github.com/user-attachments/assets/f81b3f93-912b-487d-88b7-2984a1c9564b" />
Adds pandas dependency to sandbox environment to fix ModuleNotFoundError when agents process Excel files. Fixes #1043 