### PR TITLE
Fix : Allow Team Owners and Admins to Access All Agents (Public and Private)

### DIFF
--- a/backend/admin/api.py
+++ b/backend/admin/api.py
@@ -1,10 +1,11 @@
-from fastapi import APIRouter, HTTPException, Depends
-from typing import Optional, Dict
+from fastapi import APIRouter, HTTPException, Depends, Body
+from typing import Optional, Dict, List
 from utils.auth_utils import verify_admin_api_key
 from utils.suna_default_agent_service import SunaDefaultAgentService
 from utils.logger import logger
 from utils.config import config, EnvMode
 from dotenv import load_dotenv, set_key, find_dotenv, dotenv_values
+from services.supabase import DBConnection
 
 router = APIRouter(prefix="/admin", tags=["admin"])
 
@@ -30,6 +31,114 @@ async def admin_install_suna_for_user(
             status_code=500, 
             detail=f"Failed to install Suna agent for user {account_id}"
         )
+
+@router.get("/agents/user/{account_id}")
+async def admin_get_user_agents(
+    account_id: str,
+    _: bool = Depends(verify_admin_api_key)
+):
+    """Admin endpoint to get all agents for a specific user. Admin users can access all agents."""
+    logger.info(f"Admin fetching all agents for user: {account_id}")
+    
+    try:
+        db = DBConnection()
+        await db.initialize()
+        client = await db.client
+        
+        # Use service_role to bypass RLS and get all agents for the user
+        agents_result = await client.table('agents').select('*').eq('account_id', account_id).execute()
+        
+        return {
+            "account_id": account_id,
+            "agents": agents_result.data,
+            "count": len(agents_result.data) if agents_result.data else 0
+        }
+    except Exception as e:
+        logger.error(f"Error fetching agents for user {account_id}: {str(e)}")
+        raise HTTPException(status_code=500, detail=f"Failed to fetch agents: {str(e)}")
+
+@router.post("/users/{user_id}/make-admin")
+async def admin_make_user_admin(
+    user_id: str,
+    is_admin: bool = Body(..., embed=True),
+    _: bool = Depends(verify_admin_api_key)
+):
+    """Admin endpoint to make a user an admin or remove admin privileges."""
+    logger.info(f"Admin {'granting' if is_admin else 'revoking'} admin privileges for user: {user_id}")
+    
+    try:
+        db = DBConnection()
+        await db.initialize()
+        client = await db.client
+        
+        # Check if user exists
+        user_result = await client.schema('auth').table('users').select('*').eq('id', user_id).execute()
+        if not user_result.data:
+            raise HTTPException(status_code=404, detail="User not found")
+        
+        # Check if user already has a config entry
+        config_result = await client.schema('basejump').table('config').select('*').eq('user_id', user_id).execute()
+        
+        if config_result.data:
+            # Update existing config
+            await client.schema('basejump').table('config').update({
+                'is_admin': is_admin
+            }).eq('user_id', user_id).execute()
+        else:
+            # Create new config entry
+            await client.schema('basejump').table('config').insert({
+                'user_id': user_id,
+                'is_admin': is_admin,
+                'enable_team_accounts': True,
+                'enable_personal_account_billing': True,
+                'enable_team_account_billing': True,
+                'billing_provider': 'stripe'
+            }).execute()
+        
+        return {
+            "success": True,
+            "message": f"User {user_id} is {'now' if is_admin else 'no longer'} an admin"
+        }
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error {'granting' if is_admin else 'revoking'} admin privileges for user {user_id}: {str(e)}")
+        raise HTTPException(status_code=500, detail=f"Failed to update admin privileges: {str(e)}")
+
+@router.get("/users/{user_id}/is-admin")
+async def admin_check_user_admin(
+    user_id: str,
+    _: bool = Depends(verify_admin_api_key)
+):
+    """Admin endpoint to check if a user is an admin."""
+    logger.info(f"Admin checking admin privileges for user: {user_id}")
+    
+    try:
+        db = DBConnection()
+        await db.initialize()
+        client = await db.client
+        
+        # Check if user exists
+        user_result = await client.schema('auth').table('users').select('*').eq('id', user_id).execute()
+        if not user_result.data:
+            raise HTTPException(status_code=404, detail="User not found")
+        
+        # Check if user has admin privileges
+        config_result = await client.schema('basejump').table('config').select('is_admin').eq('user_id', user_id).execute()
+        
+        is_admin = False
+        if config_result.data:
+            is_admin = config_result.data[0].get('is_admin', False)
+        
+        return {
+            "user_id": user_id,
+            "is_admin": is_admin
+        }
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error checking admin privileges for user {user_id}: {str(e)}")
+        raise HTTPException(status_code=500, detail=f"Failed to check admin privileges: {str(e)}")
 
 @router.get("/env-vars")
 def get_env_vars() -> Dict[str, str]:
@@ -67,4 +176,4 @@ def save_env_vars(request: Dict[str, str]) -> Dict[str, str]:
         return {"message": "Env variables saved successfully"}
     except Exception as e:
         logger.error(f"Failed to save env variables: {e}")
-        raise HTTPException(status_code=500, detail=f"Failed to save env variables: {e}") 
+        raise HTTPException(status_code=500, detail=f"Failed to save env variables: {e}")

--- a/backend/agent/api.py
+++ b/backend/agent/api.py
@@ -14,7 +14,7 @@ import os
 from agentpress.thread_manager import ThreadManager
 from services.supabase import DBConnection
 from services import redis
-from utils.auth_utils import get_current_user_id_from_jwt, get_user_id_from_stream_auth, verify_thread_access, verify_admin_api_key
+from utils.auth_utils import get_current_user_id_from_jwt, get_user_id_from_stream_auth, verify_thread_access, verify_admin_api_key, verify_agent_access
 from utils.logger import logger, structlog
 from services.billing import check_billing_status, can_use_model
 from utils.config import config
@@ -1266,7 +1266,13 @@ async def get_agents(
     has_agentpress_tools: Optional[bool] = Query(None, description="Filter by agents with AgentPress tools"),
     tools: Optional[str] = Query(None, description="Comma-separated list of tools to filter by")
 ):
-    """Get agents for the current user with pagination, search, sort, and filter support."""
+    """Get agents for the current user with pagination, search, sort, and filter support.
+    Access control:
+    - Regular users see their own agents
+    - Team owners see all agents from team members
+    - Admin users see all agents
+    - Public agents are visible to everyone
+    """
     if not await is_enabled("custom_agents"):
         raise HTTPException(
             status_code=403, 
@@ -1279,8 +1285,8 @@ async def get_agents(
         # Calculate offset
         offset = (page - 1) * limit
         
-        # Start building the query
-        query = client.table('agents').select('*', count='exact').eq("account_id", user_id)
+        # Start building the query - get agents with access control handled by database RLS policies
+        query = client.table('agents').select('*', count='exact')
         
         # Apply search filter
         if search:
@@ -1500,7 +1506,13 @@ async def get_agents(
 
 @router.get("/agents/{agent_id}", response_model=AgentResponse)
 async def get_agent(agent_id: str, user_id: str = Depends(get_current_user_id_from_jwt)):
-    """Get a specific agent by ID with current version information. Only the owner can access non-public agents."""
+    """Get a specific agent by ID with current version information. 
+    Access control:
+    - Agent owners can access their own agents
+    - Team owners can access all agents from team members
+    - Admin users can access all agents
+    - Anyone can access public agents
+    """
     if not await is_enabled("custom_agents"):
         raise HTTPException(
             status_code=403, 
@@ -1511,17 +1523,8 @@ async def get_agent(agent_id: str, user_id: str = Depends(get_current_user_id_fr
     client = await db.client
     
     try:
-        # Get agent
-        agent = await client.table('agents').select('*').eq("agent_id", agent_id).execute()
-        
-        if not agent.data:
-            raise HTTPException(status_code=404, detail="Agent not found")
-        
-        agent_data = agent.data[0]
-        
-        # Check ownership - only owner can access non-public agents
-        if agent_data['account_id'] != user_id and not agent_data.get('is_public', False):
-            raise HTTPException(status_code=403, detail="Access denied")
+        # Verify agent access using the new access control function
+        agent_data = await verify_agent_access(client, agent_id, user_id)
         
         # Use versioning system to get current version data
         current_version = None
@@ -1612,34 +1615,36 @@ async def get_agent(agent_id: str, user_id: str = Depends(get_current_user_id_fr
 
 @router.get("/agents/{agent_id}/export", response_model=AgentExportData)
 async def export_agent(agent_id: str, user_id: str = Depends(get_current_user_id_from_jwt)):
-    """Export an agent configuration as JSON"""
+    """Export an agent configuration as JSON.
+    Access control:
+    - Agent owners can export their own agents
+    - Team owners can export all agents from team members
+    - Admin users can export all agents
+    - Anyone can export public agents
+    """
     logger.info(f"Exporting agent {agent_id} for user: {user_id}")
     
     try:
         client = await db.client
         
-        # Get agent data
-        agent_result = await client.table('agents').select('*').eq('agent_id', agent_id).eq('account_id', user_id).execute()
-        if not agent_result.data:
-            raise HTTPException(status_code=404, detail="Agent not found")
-        
-        agent = agent_result.data[0]
+        # Verify agent access using the new access control function
+        agent_data = await verify_agent_access(client, agent_id, user_id)
         
         # Get current version data if available
         current_version = None
-        if agent.get('current_version_id'):
-            version_result = await client.table('agent_versions').select('*').eq('version_id', agent['current_version_id']).execute()
+        if agent_data.get('current_version_id'):
+            version_result = await client.table('agent_versions').select('*').eq('version_id', agent_data['current_version_id']).execute()
             if version_result.data:
                 current_version = version_result.data[0]
         
         # Extract configuration using existing helper
         from agent.config_helper import extract_agent_config
-        config = extract_agent_config(agent, current_version)
+        config = extract_agent_config(agent_data, current_version)
         
         # Clean metadata for export (remove instance-specific data)
         export_metadata = {}
-        if agent.get('metadata'):
-            export_metadata = {k: v for k, v in agent['metadata'].items() 
+        if agent_data.get('metadata'):
+            export_metadata = {k: v for k, v in agent_data['metadata'].items() 
                              if k not in ['is_suna_default', 'centrally_managed', 'installation_date', 'last_central_update']}
         
         # Create export data
@@ -1652,7 +1657,7 @@ async def export_agent(agent_id: str, user_id: str = Depends(get_current_user_id
             custom_mcps=config.get('custom_mcps', []),
             avatar=config.get('avatar'),
             avatar_color=config.get('avatar_color'),
-            tags=agent.get('tags', []),
+            tags=agent_data.get('tags', []),
             metadata=export_metadata,
             exported_at=datetime.utcnow().isoformat(),
             exported_by=user_id
@@ -1871,6 +1876,12 @@ async def update_agent(
     agent_data: AgentUpdateRequest,
     user_id: str = Depends(get_current_user_id_from_jwt)
 ):
+    """Update an agent.
+    Access control:
+    - Agent owners can update their own agents
+    - Team owners can update all agents from team members
+    - Admin users can update all agents
+    """
     if not await is_enabled("custom_agents"):
         raise HTTPException(
             status_code=403, 
@@ -1880,12 +1891,8 @@ async def update_agent(
     client = await db.client
     
     try:
-        existing_agent = await client.table('agents').select('*').eq("agent_id", agent_id).eq("account_id", user_id).maybe_single().execute()
-        
-        if not existing_agent.data:
-            raise HTTPException(status_code=404, detail="Agent not found")
-        
-        existing_data = existing_agent.data
+        # Verify agent access using the new access control function
+        existing_data = await verify_agent_access(client, agent_id, user_id)
 
         agent_metadata = existing_data.get('metadata', {})
         is_suna_agent = agent_metadata.get('is_suna_default', False)
@@ -2207,6 +2214,12 @@ async def update_agent(
 
 @router.delete("/agents/{agent_id}")
 async def delete_agent(agent_id: str, user_id: str = Depends(get_current_user_id_from_jwt)):
+    """Delete an agent.
+    Access control:
+    - Agent owners can delete their own agents
+    - Team owners can delete all agents from team members
+    - Admin users can delete all agents
+    """
     if not await is_enabled("custom_agents"):
         raise HTTPException(
             status_code=403, 
@@ -2216,15 +2229,10 @@ async def delete_agent(agent_id: str, user_id: str = Depends(get_current_user_id
     client = await db.client
     
     try:
-        agent_result = await client.table('agents').select('*').eq('agent_id', agent_id).execute()
-        if not agent_result.data:
-            raise HTTPException(status_code=404, detail="Agent not found")
+        # Verify agent access using the new access control function
+        agent_data = await verify_agent_access(client, agent_id, user_id)
         
-        agent = agent_result.data[0]
-        if agent['account_id'] != user_id:
-            raise HTTPException(status_code=403, detail="Access denied")
-        
-        if agent['is_default']:
+        if agent_data['is_default']:
             raise HTTPException(status_code=400, detail="Cannot delete default agent")
         
         await client.table('agents').delete().eq('agent_id', agent_id).execute()
@@ -2243,7 +2251,13 @@ async def get_agent_builder_chat_history(
     agent_id: str,
     user_id: str = Depends(get_current_user_id_from_jwt)
 ):
-    """Get chat history for agent builder sessions for a specific agent."""
+    """Get chat history for agent builder sessions for a specific agent.
+    Access control:
+    - Agent owners can access their own agents
+    - Team owners can access all agents from team members
+    - Admin users can access all agents
+    - Anyone can access public agents
+    """
     if not await is_enabled("custom_agents"):
         raise HTTPException(
             status_code=403, 
@@ -2254,10 +2268,8 @@ async def get_agent_builder_chat_history(
     client = await db.client
     
     try:
-        # First verify the agent exists and belongs to the user
-        agent_result = await client.table('agents').select('*').eq('agent_id', agent_id).eq('account_id', user_id).execute()
-        if not agent_result.data:
-            raise HTTPException(status_code=404, detail="Agent not found or access denied")
+        # Verify agent access using the new access control function
+        agent_data = await verify_agent_access(client, agent_id, user_id)
         
         # Get all threads for this user with metadata field included
         threads_result = await client.table('threads').select('thread_id, created_at, metadata').eq('account_id', user_id).order('created_at', desc=True).execute()
@@ -2686,29 +2698,31 @@ async def get_agent_tools(
     agent_id: str,
     user_id: str = Depends(get_current_user_id_from_jwt)
 ):
+    """Get tools for a specific agent.
+    Access control:
+    - Agent owners can access their own agents
+    - Team owners can access all agents from team members
+    - Admin users can access all agents
+    - Anyone can access public agents
+    """
     if not await is_enabled("custom_agents"):
         raise HTTPException(status_code=403, detail="Custom agents currently disabled")
         
     logger.info(f"Fetching enabled tools for agent: {agent_id} by user: {user_id}")
     client = await db.client
 
-    agent_result = await client.table('agents').select('*').eq('agent_id', agent_id).execute()
-    if not agent_result.data:
-        raise HTTPException(status_code=404, detail="Agent not found")
-    agent = agent_result.data[0]
-    if agent['account_id'] != user_id and not agent.get('is_public', False):
-        raise HTTPException(status_code=403, detail="Access denied")
-
+    # Verify agent access using the new access control function
+    agent_data = await verify_agent_access(client, agent_id, user_id)
 
     # Extract configuration using the unified config approach
     version_data = None
-    if agent.get('current_version_id'):
+    if agent_data.get('current_version_id'):
         try:
             version_service = await _get_version_service()
 
             version_obj = await version_service.get_version(
                 agent_id=agent_id,
-                version_id=agent['current_version_id'],
+                version_id=agent_data['current_version_id'],
                 user_id=user_id
             )
             version_data = version_obj.to_dict()
@@ -2716,7 +2730,7 @@ async def get_agent_tools(
             logger.warning(f"Failed to fetch version data for tools endpoint: {e}")
     
     from agent.config_helper import extract_agent_config
-    agent_config = extract_agent_config(agent, version_data)
+    agent_config = extract_agent_config(agent_data, version_data)
     
     agentpress_tools_config = agent_config['agentpress_tools']
     configured_mcps = agent_config['configured_mcps'] 

--- a/backend/supabase/migrations/20250804110000_add_admin_user_config.sql
+++ b/backend/supabase/migrations/20250804110000_add_admin_user_config.sql
@@ -1,0 +1,60 @@
+-- Migration: Add admin user configuration
+-- This migration adds support for marking users as admins in the basejump.config table
+
+BEGIN;
+
+-- Add is_admin column to basejump.config table
+ALTER TABLE basejump.config ADD COLUMN IF NOT EXISTS is_admin BOOLEAN DEFAULT false;
+ALTER TABLE basejump.config ADD COLUMN IF NOT EXISTS user_id uuid REFERENCES auth.users(id);
+
+-- Create index for better performance
+CREATE INDEX IF NOT EXISTS idx_basejump_config_is_admin ON basejump.config(is_admin);
+CREATE INDEX IF NOT EXISTS idx_basejump_config_user_id ON basejump.config(user_id);
+
+-- Add comment
+COMMENT ON COLUMN basejump.config.is_admin IS 'Indicates if this user is an admin';
+COMMENT ON COLUMN basejump.config.user_id IS 'The user ID this config belongs to';
+
+-- Update the get_config function to handle user-specific configs
+CREATE OR REPLACE FUNCTION basejump.get_config()
+    RETURNS json AS
+$$
+DECLARE
+    result RECORD;
+BEGIN
+    SELECT * from basejump.config 
+    WHERE user_id = auth.uid() OR user_id IS NULL
+    ORDER BY user_id NULLS LAST
+    LIMIT 1
+    into result;
+    
+    -- If no user-specific config found, get the default config
+    IF result IS NULL THEN
+        SELECT * from basejump.config WHERE user_id IS NULL limit 1 into result;
+    END IF;
+    
+    return row_to_json(result);
+END;
+$$ LANGUAGE plpgsql;
+
+-- Update the is_set function to handle user-specific configs
+CREATE OR REPLACE FUNCTION basejump.is_set(field_name text)
+    RETURNS boolean AS
+$$
+DECLARE
+    result BOOLEAN;
+BEGIN
+    EXECUTE format('SELECT %I FROM basejump.config WHERE user_id = $1 OR user_id IS NULL ORDER BY user_id NULLS LAST LIMIT 1', field_name)
+    USING auth.uid()
+    INTO result;
+    
+    -- If no user-specific config found, get the default config
+    IF result IS NULL THEN
+        EXECUTE format('SELECT %I FROM basejump.config WHERE user_id IS NULL LIMIT 1', field_name) INTO result;
+    END IF;
+    
+    return result;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMIT;

--- a/backend/supabase/migrations/20250804110001_fix_team_owner_agent_access.sql
+++ b/backend/supabase/migrations/20250804110001_fix_team_owner_agent_access.sql
@@ -1,0 +1,126 @@
+-- Migration: Fix team owner agent access
+-- This migration updates the RLS policies for the agents table to allow:
+-- 1. Team owners to access all agents from team members
+-- 2. Admin users to access all agents
+-- 3. Regular users to access their own agents and public agents
+
+BEGIN;
+
+-- First, drop existing policies
+DROP POLICY IF EXISTS "Users can view their own agents" ON public.agents;
+DROP POLICY IF EXISTS "Users can view public agents" ON public.agents;
+DROP POLICY IF EXISTS "Users can insert their own agents" ON public.agents;
+DROP POLICY IF EXISTS "Users can update their own agents" ON public.agents;
+DROP POLICY IF EXISTS "Users can delete their own agents" ON public.agents;
+
+-- Create new policies with team owner access
+
+-- Select policy: Allow access to own agents, public agents, team member agents (for team owners), and all agents (for admins)
+CREATE POLICY "Users can view agents they have access to" 
+ON public.agents FOR SELECT 
+TO authenticated
+USING (
+  -- Agent owners can see their own agents
+  account_id = auth.uid()
+  OR
+  -- Anyone can see public agents
+  is_public = true
+  OR
+  -- Admin users can see all agents
+  EXISTS (
+    SELECT 1 FROM basejump.config 
+    WHERE config.is_admin = true 
+    AND config.user_id = auth.uid()
+  )
+  OR
+  -- Team owners can see all agents from their team members
+  EXISTS (
+    SELECT 1 
+    FROM basejump.account_user au1
+    JOIN basejump.account_user au2 ON au1.account_id = au2.account_id
+    WHERE au1.user_id = auth.uid() 
+    AND au1.account_role = 'owner'
+    AND au2.user_id = agents.account_id
+  )
+);
+
+-- Insert policy: Allow users to create their own agents
+CREATE POLICY "Users can insert their own agents" 
+ON public.agents FOR INSERT 
+TO authenticated
+WITH CHECK (account_id = auth.uid());
+
+-- Update policy: Allow access to own agents and team member agents (for team owners)
+CREATE POLICY "Users can update agents they have access to" 
+ON public.agents FOR UPDATE 
+TO authenticated
+USING (
+  -- Agent owners can update their own agents
+  account_id = auth.uid()
+  OR
+  -- Admin users can update all agents
+  EXISTS (
+    SELECT 1 FROM basejump.config 
+    WHERE config.is_admin = true 
+    AND config.user_id = auth.uid()
+  )
+  OR
+  -- Team owners can update all agents from their team members
+  EXISTS (
+    SELECT 1 
+    FROM basejump.account_user au1
+    JOIN basejump.account_user au2 ON au1.account_id = au2.account_id
+    WHERE au1.user_id = auth.uid() 
+    AND au1.account_role = 'owner'
+    AND au2.user_id = agents.account_id
+  )
+)
+WITH CHECK (
+  -- Agent owners can update their own agents
+  account_id = auth.uid()
+  OR
+  -- Admin users can update all agents
+  EXISTS (
+    SELECT 1 FROM basejump.config 
+    WHERE config.is_admin = true 
+    AND config.user_id = auth.uid()
+  )
+  OR
+  -- Team owners can update all agents from their team members
+  EXISTS (
+    SELECT 1 
+    FROM basejump.account_user au1
+    JOIN basejump.account_user au2 ON au1.account_id = au2.account_id
+    WHERE au1.user_id = auth.uid() 
+    AND au1.account_role = 'owner'
+    AND au2.user_id = agents.account_id
+  )
+);
+
+-- Delete policy: Allow access to own agents and team member agents (for team owners)
+CREATE POLICY "Users can delete agents they have access to" 
+ON public.agents FOR DELETE 
+TO authenticated
+USING (
+  -- Agent owners can delete their own agents
+  account_id = auth.uid()
+  OR
+  -- Admin users can delete all agents
+  EXISTS (
+    SELECT 1 FROM basejump.config 
+    WHERE config.is_admin = true 
+    AND config.user_id = auth.uid()
+  )
+  OR
+  -- Team owners can delete all agents from their team members
+  EXISTS (
+    SELECT 1 
+    FROM basejump.account_user au1
+    JOIN basejump.account_user au2 ON au1.account_id = au2.account_id
+    WHERE au1.user_id = auth.uid() 
+    AND au1.account_role = 'owner'
+    AND au2.user_id = agents.account_id
+  )
+);
+
+COMMIT;

--- a/backend/utils/auth_utils.py
+++ b/backend/utils/auth_utils.py
@@ -404,7 +404,13 @@ async def verify_admin_api_key(x_admin_api_key: Optional[str] = Header(None)):
 
 async def verify_agent_access(client, agent_id: str, user_id: str) -> dict:
     """
-    Verify that a user has access to a specific agent based on ownership.
+    Verify that a user has access to a specific agent based on ownership, team ownership, or admin status.
+    
+    Access control rules:
+    - Agent owners can access their own agents
+    - Team owners can access all agents from team members
+    - Admin users can access all agents
+    - Anyone can access public agents
     
     Args:
         client: The Supabase client
@@ -418,15 +424,64 @@ async def verify_agent_access(client, agent_id: str, user_id: str) -> dict:
         HTTPException: If the user doesn't have access to the agent or agent doesn't exist
     """
     try:
-        agent_result = await client.table('agents').select('*').eq('agent_id', agent_id).eq('account_id', user_id).execute()
+        # Get the agent data
+        agent_result = await client.table('agents').select('*').eq('agent_id', agent_id).execute()
         
         if not agent_result.data:
-            raise HTTPException(status_code=404, detail="Agent not found or access denied")
+            raise HTTPException(status_code=404, detail="Agent not found")
         
-        return agent_result.data[0]
+        agent_data = agent_result.data[0]
+        
+        # Check if agent is public - anyone can access public agents
+        if agent_data.get('is_public', False):
+            return agent_data
+            
+        # Check if user is the owner of the agent
+        if agent_data['account_id'] == user_id:
+            return agent_data
+            
+        # Check if user is an admin
+        admin_check = await client.schema('basejump').table('config').select('*').eq('user_id', user_id).eq('is_admin', True).execute()
+        if admin_check.data:
+            # User is an admin, can access all agents
+            return agent_data
+            
+        # Check if user is a team owner for the agent's account
+        # A user is a team owner if:
+        # 1. They are an owner of an account
+        # 2. The agent's owner is a member of that same account
+        team_owner_check = await client.schema('basejump').table('account_user').select('*').eq('user_id', user_id).eq('account_role', 'owner').execute()
+        if team_owner_check.data:
+            # User is an owner of at least one account
+            # Check if the agent's owner is a member of any account where the user is an owner
+            for owner_record in team_owner_check.data:
+                account_id = owner_record['account_id']
+                # Check if the agent's owner is a member of this account
+                member_check = await client.schema('basejump').table('account_user').select('*').eq('account_id', account_id).eq('user_id', agent_data['account_id']).execute()
+                if member_check.data:
+                    # The agent's owner is a member of an account where the current user is an owner
+                    return agent_data
+        
+        raise HTTPException(status_code=403, detail="Access denied")
         
     except HTTPException:
         raise
     except Exception as e:
         structlog.error(f"Error verifying agent access for agent {agent_id}, user {user_id}: {str(e)}")
         raise HTTPException(status_code=500, detail="Failed to verify agent access")
+
+async def is_user_admin(user_id: str) -> bool:
+    """
+    Check if a user is an admin based on the KORTIX_ADMIN_API_KEY configuration.
+    
+    Args:
+        user_id: The user ID to check
+        
+    Returns:
+        bool: True if the user is an admin, False otherwise
+    """
+    # In this implementation, we're using the admin API key as the indicator
+    # In a more robust implementation, you might have a dedicated admins table
+    # For now, we'll check if the user has provided a valid admin API key
+    # This is a simplified check - in practice, you'd want a more sophisticated admin user system
+    return config.KORTIX_ADMIN_API_KEY is not None and len(config.KORTIX_ADMIN_API_KEY) > 0


### PR DESCRIPTION


https://github.com/user-attachments/assets/68d0ec8a-97a7-40a0-80a3-6fb80bb75832


- Implements RLS policies enabling team owners to view/update/delete agents created by any member of their team, and allows admins to access all agents regardless of visibility.
- Adds admin flag support via basejump.config.is_admin with ordered migrations to avoid dependency issues; updates backend to use verify_agent_access across agent endpoints and fixes missing import.
- Ensures Admin can access every Suna Agent URL (public or not) and Team Owners can see members’ private agents, fixing issue #1009.