### PR TITLE
Fix : Render terminal output as human-readable text in tool panel (fixes #1086)

### DIFF
--- a/frontend/src/components/thread/tool-views/command-tool/CommandToolView.tsx
+++ b/frontend/src/components/thread/tool-views/command-tool/CommandToolView.tsx
@@ -174,21 +174,33 @@ export function CommandToolView({
                     )}
                   </div>
                   <div className="p-4 max-h-96 overflow-auto scrollbar-hide">
-                    <pre className="text-xs text-zinc-600 dark:text-zinc-300 font-mono whitespace-pre-wrap break-all overflow-visible">
-                      {/* Show command only */}
+                    {/* Command line */}
+                    <div className="py-0.5 bg-transparent font-mono text-xs">
                       {command && (
-                        <div className="py-0.5 bg-transparent">
+                        <>
                           <span className="text-green-500 dark:text-green-400 font-semibold">{displayPrefix} </span>
                           <span className="text-zinc-700 dark:text-zinc-300">{command}</span>
-                        </div>
+                        </>
                       )}
+                    </div>
 
-                      {!showFullOutput && hasMoreLines && (
-                        <div className="text-zinc-500 mt-2 border-t border-zinc-700/30 pt-2">
-                          + {formattedOutput.length - 10} more lines
-                        </div>
-                      )}
-                    </pre>
+                    {/* Terminal output (render as real terminal text, not JSON) */}
+                    {formattedOutput.length > 0 && (
+                      <pre className="mt-2 text-xs text-zinc-600 dark:text-zinc-300 font-mono whitespace-pre-wrap break-words">
+                        {linesToShow.map((line, idx) => (
+                          <span key={idx}>
+                            {line}
+                            {'\n'}
+                          </span>
+                        ))}
+                      </pre>
+                    )}
+
+                    {!showFullOutput && hasMoreLines && (
+                      <div className="text-zinc-500 mt-2 border-t border-zinc-700/30 pt-2 text-xs font-mono">
+                        + {formattedOutput.length - 10} more lines
+                      </div>
+                    )}
                   </div>
                 </div>
               </div>
@@ -242,4 +254,4 @@ export function CommandToolView({
       </div>
     </Card>
   );
-} 
+}


### PR DESCRIPTION

<img width="1897" height="859" alt="image" src="https://github.com/user-attachments/assets/cf798d85-4c65-4d37-95bf-85a00e4464b4" />


- Reworked the CommandToolView to display real terminal-like output instead of JSON envelopes, preserving newlines, tabs, and unicode.
- Added line-by-line rendering with monospace pre-wrap, command prefix ($/tmux:), and a compact preview with “+ N more lines” for long outputs.
- Localized change limited to the command tool view; resolves issue #1086 by replacing the JSON dump with readable terminal output.