### PR TITLE
fix: Configure Vercel build for monorepo

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+  "installCommand": "cd frontend && npm install",
+  "buildCommand": "cd frontend && npm run build"
+}


### PR DESCRIPTION
The Vercel deployment was failing because it could not find the Next.js project in the root directory.

This change adds a `vercel.json` file to the root of the repository to configure the build settings for Vercel. The `installCommand` and `buildCommand` are updated to change into the `frontend` directory before running the respective npm commands.

This will allow Vercel to correctly build and deploy the Next.js application located in the `frontend` subdirectory.