### PR TITLE
fix: add agent_id option to ChatInput onSubmit method

### DIFF
--- a/frontend/src/components/thread/chat-input/chat-input.tsx
+++ b/frontend/src/components/thread/chat-input/chat-input.tsx
@@ -38,7 +38,11 @@ export interface ChatInputHandles {
 export interface ChatInputProps {
   onSubmit: (
     message: string,
-    options?: { model_name?: string; enable_thinking?: boolean },
+    options?: {
+      model_name?: string;
+      enable_thinking?: boolean;
+      agent_id?: string;
+    },
   ) => void;
   placeholder?: string;
   loading?: boolean;
@@ -286,6 +290,7 @@ export const ChatInput = forwardRef<ChatInputHandles, ChatInputProps>(
       posthog.capture("task_prompt_submitted", { message });
 
       onSubmit(message, {
+        agent_id: selectedAgentId,
         model_name: baseModelName,
         enable_thinking: thinkingEnabled,
       });


### PR DESCRIPTION
In the Agent builder page, the agent ID is not passed to the server side in subsequent requests.