### PR TITLE
fix: refactor playback controls and consolidate XML tag constants

### DIFF
--- a/frontend/src/app/share/[threadId]/page.tsx
+++ b/frontend/src/app/share/[threadId]/page.tsx
@@ -288,33 +288,6 @@ export default function ThreadPage({
     [],
   );
 
-  // useEffect(() => {
-  //   if (!isPlaying || messages.length === 0) return;
-
-  //   let playbackTimeout: NodeJS.Timeout;
-
-  //   const playbackNextMessage = async () => {
-  //     if (currentMessageIndex >= messages.length) {
-  //       setIsPlaying(false);
-  //       return;
-  //     }
-
-  //     const currentMessage = messages[currentMessageIndex];
-  //     console.log(
-  //       `Playing message ${currentMessageIndex}:`,
-  //       currentMessage.type,
-  //       currentMessage.message_id,
-  //     );
-
-  //     setCurrentMessageIndex((prevIndex) => prevIndex + 1);
-  //   };
-  //   playbackTimeout = setTimeout(playbackNextMessage, 500);
-
-  //   return () => {
-  //     clearTimeout(playbackTimeout);
-  //   };
-  // }, [isPlaying, currentMessageIndex, messages]);
-
   const {
     status: streamHookStatus,
     toolCall: streamingToolCall,

--- a/frontend/src/components/thread/content/PlaybackControls.tsx
+++ b/frontend/src/components/thread/content/PlaybackControls.tsx
@@ -275,6 +275,7 @@ export const PlaybackControls = ({
         if (currentChunk.isTool && currentIndex === 0) {
           // For tool calls, check if they should be hidden during streaming
           if (isToolInitialized) {
+            // TODO: better to change tool index by uniq tool id
             setCurrentToolIndex((prev) => prev + 1);
           } else {
             setIsToolInitialized(true);

--- a/frontend/src/components/thread/content/ThreadContent.tsx
+++ b/frontend/src/components/thread/content/ThreadContent.tsx
@@ -16,40 +16,8 @@ import { AgentLoader } from './loader';
 import { parseXmlToolCalls, isNewXmlFormat } from '@/components/thread/tool-views/xml-parser';
 import { ShowToolStream } from './ShowToolStream';
 import { ComposioUrlDetector } from './composio-url-detector';
+import { HIDE_STREAMING_XML_TAGS } from '@/components/thread/utils';
 
-const HIDE_STREAMING_XML_TAGS = new Set([
-    'execute-command',
-    'create-file',
-    'delete-file',
-    'full-file-rewrite',
-    'edit-file',
-    'str-replace',
-    'browser-click-element',
-    'browser-close-tab',
-    'browser-drag-drop',
-    'browser-get-dropdown-options',
-    'browser-go-back',
-    'browser-input-text',
-    'browser-navigate-to',
-    'browser-scroll-down',
-    'browser-scroll-to-text',
-    'browser-scroll-up',
-    'browser-select-dropdown-option',
-    'browser-send-keys',
-    'browser-switch-tab',
-    'browser-wait',
-    'deploy',
-    'ask',
-    'complete',
-    'crawl-webpage',
-    'web-search',
-    'see-image',
-    'execute_data_provider_call',
-    'execute_data_provider_endpoint',
-
-    'execute-data-provider-call',
-    'execute-data-provider-endpoint',
-]);
 
 // Helper function to render attachments (keeping original implementation for now)
 export function renderAttachments(attachments: string[], fileViewerHandler?: (filePath?: string, filePathList?: string[]) => void, sandboxId?: string, project?: Project) {

--- a/frontend/src/components/thread/tool-call-side-panel.tsx
+++ b/frontend/src/components/thread/tool-call-side-panel.tsx
@@ -151,10 +151,9 @@ export function ToolCallSidePanel({
   }, [toolCalls, navigationMode, toolCallSnapshots.length, isInitialized]);
 
   React.useEffect(() => {
-    if (isOpen && !isInitialized && toolCallSnapshots.length > 0) {
-      setInternalIndex(Math.min(currentIndex, toolCallSnapshots.length - 1));
-    }
-  }, [isOpen, currentIndex, isInitialized, toolCallSnapshots.length]);
+    // This is used to sync the internal index to the current index
+    setInternalIndex(Math.min(currentIndex, toolCallSnapshots.length - 1));
+  }, [currentIndex, toolCallSnapshots.length]);
 
   const safeInternalIndex = Math.min(internalIndex, Math.max(0, toolCallSnapshots.length - 1));
   const currentSnapshot = toolCallSnapshots[safeInternalIndex];

--- a/frontend/src/components/thread/utils.ts
+++ b/frontend/src/components/thread/utils.ts
@@ -494,3 +494,38 @@ export function getUserFriendlyToolName(toolName: string): string {
   }
   return TOOL_DISPLAY_NAMES.get(toolName) || toolName;
 }
+
+export const HIDE_STREAMING_XML_TAGS = new Set([
+  'create-tasks',
+  'execute-command',
+  'create-file',
+  'delete-file',
+  'full-file-rewrite',
+  'edit-file',
+  'str-replace',
+  'browser-click-element',
+  'browser-close-tab',
+  'browser-drag-drop',
+  'browser-get-dropdown-options',
+  'browser-go-back',
+  'browser-input-text',
+  'browser-navigate-to',
+  'browser-scroll-down',
+  'browser-scroll-to-text',
+  'browser-scroll-up',
+  'browser-select-dropdown-option',
+  'browser-send-keys',
+  'browser-switch-tab',
+  'browser-wait',
+  'deploy',
+  'ask',
+  'complete',
+  'crawl-webpage',
+  'web-search',
+  'see-image',
+  'execute_data_provider_call',
+  'execute_data_provider_endpoint',
+
+  'execute-data-provider-call',
+  'execute-data-provider-endpoint',
+]);

--- a/frontend/src/components/ui/slider.tsx
+++ b/frontend/src/components/ui/slider.tsx
@@ -45,7 +45,7 @@ function Slider({
         <SliderPrimitive.Range
           data-slot="slider-range"
           className={cn(
-            'bg-primary absolute data-[orientation=horizontal]:h-full data-[orientation=vertical]:w-full',
+            'cursor-pointer bg-primary absolute data-[orientation=horizontal]:h-full data-[orientation=vertical]:w-full',
           )}
         />
       </SliderPrimitive.Track>
@@ -53,7 +53,7 @@ function Slider({
         <SliderPrimitive.Thumb
           data-slot="slider-thumb"
           key={index}
-          className="border-primary bg-background ring-ring/50 block size-4 shrink-0 rounded-full border shadow-sm transition-[color,box-shadow] hover:ring-4 focus-visible:ring-4 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50"
+          className="cursor-pointer border-primary bg-background ring-ring/50 block size-4 shrink-0 rounded-full border shadow-sm transition-[color,box-shadow] hover:ring-4 focus-visible:ring-4 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50"
         />
       ))}
     </SliderPrimitive.Root>


### PR DESCRIPTION
This PR is mainly for fixing the index of tools in playback mode. Right now, the streaming text is synchronized with the tool index.

https://github.com/user-attachments/assets/7da6f18b-d380-4c4a-b514-188bd95efdce

- Remove unused toolName tracking in chunk processing (Right now, all tool names are `function–call`, which are useless for parsing tool names)
- Simplify tool call handling in PlaybackControls by removing toolPlaybackIndex state
- Fix tool navigation initialization and synchronization issues
- Consolidate HIDE_STREAMING_XML_TAGS constant from multiple files into utils.ts
- Add 'create-tasks' to hidden streaming XML tags list
- Improve tool call side panel index synchronization
- Add cursor pointer styling to slider components for better UX
- Fix tool index initialization to start at 0 instead of -1