### PR TITLE
Fix search_mcp_servers function to handle paginated response structure

### DIFF
--- a/backend/agent/tools/agent_builder_tools/mcp_search_tool.py
+++ b/backend/agent/tools/agent_builder_tools/mcp_search_tool.py
@@ -53,9 +53,11 @@ class MCPSearchTool(AgentBuilderBaseTool):
             integration_service = get_integration_service()
             
             if query:
-                toolkits = await integration_service.search_toolkits(query, category=category)
+                toolkits_response = await integration_service.search_toolkits(query, category=category)
+                toolkits = toolkits_response.get("items", [])
             else:
-                toolkits = await toolkit_service.list_toolkits(limit=limit, category=category)
+                toolkits_response = await toolkit_service.list_toolkits(limit=limit, category=category)
+                toolkits = toolkits_response.get("items", [])
             
             if len(toolkits) > limit:
                 toolkits = toolkits[:limit]


### PR DESCRIPTION
- Extract toolkit objects from response "items" key instead of iterating over response dict
- Resolves AttributeError: 'str' object has no attribute 'name'
- Both search_toolkits and list_toolkits return paginated response format

