### PR TITLE
Fix auth callback redirect issues in self-hosted deployments

### DIFF
--- a/frontend/src/app/auth/callback/route.ts
+++ b/frontend/src/app/auth/callback/route.ts
@@ -3,15 +3,18 @@ import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 
 export async function GET(request: NextRequest) {
-  const { searchParams, origin } = new URL(request.url)
+  const { searchParams } = new URL(request.url)
   const code = searchParams.get('code')
-  const next = searchParams.get('next') ?? '/dashboard'
+  const next = searchParams.get('returnUrl') ?? '/dashboard'
+  
+  // Use configured URL instead of parsed origin to avoid 0.0.0.0 issues in self-hosted environments
+  const baseUrl = process.env.NEXT_PUBLIC_URL || 'http://localhost:3000'
   const error = searchParams.get('error')
   const errorDescription = searchParams.get('error_description')
 
   if (error) {
     console.error('❌ Auth callback error:', error, errorDescription)
-    return NextResponse.redirect(`${origin}/auth?error=${encodeURIComponent(error)}`)
+    return NextResponse.redirect(`${baseUrl}/auth?error=${encodeURIComponent(error)}`)
   }
 
   if (code) {
@@ -22,15 +25,15 @@ export async function GET(request: NextRequest) {
       
       if (error) {
         console.error('❌ Error exchanging code for session:', error)
-        return NextResponse.redirect(`${origin}/auth?error=${encodeURIComponent(error.message)}`)
+        return NextResponse.redirect(`${baseUrl}/auth?error=${encodeURIComponent(error.message)}`)
       }
 
       // URL to redirect to after sign in process completes
-      return NextResponse.redirect(`${origin}${next}`)
+      return NextResponse.redirect(`${baseUrl}${next}`)
     } catch (error) {
       console.error('❌ Unexpected error in auth callback:', error)
-      return NextResponse.redirect(`${origin}/auth?error=unexpected_error`)
+      return NextResponse.redirect(`${baseUrl}/auth?error=unexpected_error`)
     }
   }
-  return NextResponse.redirect(`${origin}/auth`)
+  return NextResponse.redirect(`${baseUrl}/auth`)
 }


### PR DESCRIPTION
## Summary
- Fixes auth callback redirect issues in self-hosted Supabase deployments
- Restores returnUrl functionality that was broken due to parameter mismatch
- Prevents 0.0.0.0 redirect errors in self-hosted environments

## Changes
1. **Restored emailRedirectTo in signup**: Preserves returnUrl functionality for email verification flow
2. **Fixed callback origin handling**: Uses `NEXT_PUBLIC_URL` environment variable instead of parsed origin to avoid 0.0.0.0 issues
3. **Corrected parameter name**: Changed from 'next' back to 'returnUrl' to match actual usage in signup and OAuth flows

## Problem
In self-hosted deployments, the auth callback was failing because:
- The parsed origin from request.url resolves to 0.0.0.0:3000 instead of the actual domain
- The callback was reading 'next' parameter but signup/OAuth flows pass 'returnUrl'
- This caused users to be redirected to inaccessible 0.0.0.0 addresses after email verification

🤖 Generated with [Claude Code](https://claude.ai/code)