### PR TITLE
fix: update backend/pyproject.toml

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,9 +4,8 @@ version = "1.0"
 description = "open source generalist AI Worker"
 authors = [{ name = "marko-kraemer", email = "mail@markokraemer.com" }]
 readme = "README.md"
-license = { text = "Apache-2.0" }
+license = "Apache-2.0"
 classifiers = [
-  "License :: OSI Approved :: Apache-2.0 License",
   "Programming Language :: Python :: 3.11",
 ]
 requires-python = ">=3.11"
@@ -82,4 +81,23 @@ package = false
 [dependency-groups]
 dev = [
     "orjson>=3.11.1",
+]
+
+[tool.setuptools.packages.find]
+include = [
+  "admin*",
+  "agent*",
+  "flags*",
+  "models*",
+  "sandbox*",
+  "services*",
+  "supabase*",
+  "triggers*",
+  "pipedream*",
+  "templates*",
+  "agentpress*",
+  "mcp_module*",
+  "credentials*",
+  "knowledge_base*",
+  "composio_integration*",
 ]


### PR DESCRIPTION
Short description

Removed deprecated license classifier from `backend/pyproject.toml` and added explicit setuptools package discovery.

What & why

- Removed: "License :: OSI Approved :: Apache-2.0 License" from `classifiers` because license classifiers are superseded by license expressions (PEP 639) and setuptools rejects them.
- Added: `[tool.setuptools.packages.find]` include list to allow editable installs for the repo's flat package layout.

Quick checks for reviewers

- [ ] `pyproject.toml` parses (e.g. `python -c "import tomllib; tomllib.loads(open('backend/pyproject.toml','rb').read())"`).
- [ ] `python -m pip install -e .` in `backend` completes without the previous setuptools errors.
