### PR TITLE
fix: add openpyxl to sandbox image

### DIFF
--- a/backend/sandbox/docker/requirements.txt
+++ b/backend/sandbox/docker/requirements.txt
@@ -9,3 +9,4 @@ playwright>=1.40.0
 PyPDF2>=3.0.0
 bs4==0.0.2
 python-pptx>=0.6.23
+openpyxl>=3.1.0


### PR DESCRIPTION
Adds pandas dependency to sandbox environment.
Fixes #1497 
<img width="1919" height="900" alt="image" src="https://github.com/user-attachments/assets/433cdfea-ddb6-45bf-b7e3-0ee33722062f" />
