### PR TITLE
fix : Clicking Live Updates skips to the latest. Sometimes it bugs out (fixes #1333)

### DIFF
--- a/apps/mobile/components/RightPanel.tsx
+++ b/apps/mobile/components/RightPanel.tsx
@@ -239,39 +239,56 @@ export const RightPanel: React.FC<RightPanelProps> = ({ isVisible, onClose, mess
     const renderStatusBadge = () => {
         const isOnLatest = currentSnapshotIndex === totalSnapshots - 1;
 
-        if (isGenerating) {
-            return (
-                <View style={[styles.statusBadge, {
-                    backgroundColor: theme.primary + '10',
-                    borderColor: theme.primary + '30'
-                }]}>
-                    <View style={[styles.statusDot, { backgroundColor: theme.primary }]} />
-                    <Caption style={[styles.statusText, { color: theme.primary }]}>Live</Caption>
-                </View>
-            );
-        } else if (isOnLatest) {
-            return (
-                <View style={[styles.statusBadge, {
-                    backgroundColor: theme.accent + '10',
-                    borderColor: theme.accent + '30'
-                }]}>
-                    <View style={[styles.statusDot, { backgroundColor: theme.accent }]} />
-                    <Caption style={[styles.statusText, { color: theme.accent }]}>Latest</Caption>
-                </View>
-            );
+        if (isLiveMode) {
+            if (isGenerating) {
+                return (
+                    <View style={[styles.statusBadge, {
+                        backgroundColor: theme.primary + '10',
+                        borderColor: theme.primary + '30'
+                    }]}>
+                        <View style={[styles.statusDot, { backgroundColor: theme.primary }]} />
+                        <Caption style={[styles.statusText, { color: theme.primary }]}>Live Updates</Caption>
+                    </View>
+                );
+            } else {
+                return (
+                    <View style={[styles.statusBadge, {
+                        backgroundColor: theme.accent + '10',
+                        borderColor: theme.accent + '30'
+                    }]}>
+                        <View style={[styles.statusDot, { backgroundColor: theme.accent }]} />
+                        <Caption style={[styles.statusText, { color: theme.accent }]}>Latest Tool</Caption>
+                    </View>
+                );
+            }
         } else {
-            return (
-                <TouchableOpacity
-                    style={[styles.statusBadge, {
-                        backgroundColor: theme.muted + '20',
-                        borderColor: theme.border
-                    }]}
-                    onPress={handleJumpToLatest}
-                >
-                    <View style={[styles.statusDot, { backgroundColor: theme.mutedForeground }]} />
-                    <Caption style={[styles.statusText, { color: theme.mutedForeground }]}>Jump to latest</Caption>
-                </TouchableOpacity>
-            );
+            if (isGenerating) {
+                return (
+                    <TouchableOpacity
+                        style={[styles.statusBadge, {
+                            backgroundColor: theme.primary + '10',
+                            borderColor: theme.primary + '30'
+                        }]}
+                        onPress={handleJumpToLatest}
+                    >
+                        <View style={[styles.statusDot, { backgroundColor: theme.primary }]} />
+                        <Caption style={[styles.statusText, { color: theme.primary }]}>Jump to Live</Caption>
+                    </TouchableOpacity>
+                );
+            } else {
+                return (
+                    <TouchableOpacity
+                        style={[styles.statusBadge, {
+                            backgroundColor: theme.muted + '20',
+                            borderColor: theme.border
+                        }]}
+                        onPress={handleJumpToLatest}
+                    >
+                        <View style={[styles.statusDot, { backgroundColor: theme.mutedForeground }]} />
+                        <Caption style={[styles.statusText, { color: theme.mutedForeground }]}>Jump to latest</Caption>
+                    </TouchableOpacity>
+                );
+            }
         }
     };
 

--- a/apps/mobile/stores/ui-store.ts
+++ b/apps/mobile/stores/ui-store.ts
@@ -400,6 +400,19 @@ export const useUIStore = create<UIState>()(
       };
     }),
     
+    jumpToLive: () => set((state) => {
+      const snapshots = state.toolViewState.toolCallSnapshots;
+      if (snapshots.length === 0) return state;
+      
+      return {
+        toolViewState: {
+          ...state.toolViewState,
+          currentSnapshotIndex: snapshots.length - 1,
+          navigationMode: 'live',
+        }
+      };
+    }),
+    
     // Legacy time playback functions
     startTimePlayback: (messages) => set((state) => ({
       toolViewState: {


### PR DESCRIPTION

https://github.com/user-attachments/assets/ea8bd543-b46d-43d9-8302-02466160af30

This PR fixes the issue where the live updates button in tool side panel bugs out when clicked. This issue was reproducable when the user uses the slider to a certain step and then clicks on jump to latest. It will go to the latest step but then will stuck there and will not move along with the further steps. 

Fixes #1333.