### PR TITLE
Fix agents table schema compatibility after cleanup migrations

### DIFF
--- a/backend/agent/config_helper.py
+++ b/backend/agent/config_helper.py
@@ -69,8 +69,8 @@ def _extract_suna_agent_config(agent_data: Dict[str, Any], version_data: Optiona
             config['workflows'] = []
             config['triggers'] = []
     else:
-        config['configured_mcps'] = agent_data.get('configured_mcps', [])
-        config['custom_mcps'] = agent_data.get('custom_mcps', [])
+        config['configured_mcps'] = []
+        config['custom_mcps'] = []
         config['workflows'] = []
         config['triggers'] = []
     
@@ -259,5 +259,4 @@ def _extract_agentpress_tools_for_run(agentpress_config: Dict[str, Any]) -> Dict
             }
     
     return run_tools
-
 

--- a/backend/agent/handlers/agent_crud.py
+++ b/backend/agent/handlers/agent_crud.py
@@ -130,10 +130,10 @@ async def update_agent(
                     "agent_id": agent_id,
                     "version_number": 1,
                     "version_name": "v1",
-                    "system_prompt": existing_data.get('system_prompt', ''),
-                    "configured_mcps": existing_data.get('configured_mcps', []),
-                    "custom_mcps": existing_data.get('custom_mcps', []),
-                    "agentpress_tools": existing_data.get('agentpress_tools', {}),
+                    "system_prompt": '',
+                    "configured_mcps": [],
+                    "custom_mcps": [],
+                    "agentpress_tools": {},
                     "is_active": True,
                     "created_by": user_id
                 }
@@ -163,18 +163,18 @@ async def update_agent(
                     logger.debug(f"Created initial version for agent {agent_id}")
                 else:
                     current_version_data = {
-                        'system_prompt': existing_data.get('system_prompt', ''),
-                        'configured_mcps': existing_data.get('configured_mcps', []),
-                        'custom_mcps': existing_data.get('custom_mcps', []),
-                        'agentpress_tools': existing_data.get('agentpress_tools', {})
+                        'system_prompt': '',
+                        'configured_mcps': [],
+                        'custom_mcps': [],
+                        'agentpress_tools': {}
                     }
             except Exception as e:
                 logger.warning(f"Failed to create initial version for agent {agent_id}: {e}")
                 current_version_data = {
-                    'system_prompt': existing_data.get('system_prompt', ''),
-                    'configured_mcps': existing_data.get('configured_mcps', []),
-                    'custom_mcps': existing_data.get('custom_mcps', []),
-                    'agentpress_tools': existing_data.get('agentpress_tools', {})
+                    'system_prompt': '',
+                    'configured_mcps': [],
+                    'custom_mcps': [],
+                    'agentpress_tools': {}
                 }
         
         needs_new_version = False


### PR DESCRIPTION
## Summary
Fixes compatibility issues with agents table schema changes from migrations 20250723175911 and 20250729094718 which removed key configuration fields.

## Root Cause
Two conflicting cleanup migrations removed:
- First migration (20250723175911): Removed `system_prompt`, `configured_mcps`, `custom_mcps`, `agentpress_tools` fields after migrating to `config`
- Second migration (20250729094718): Removed the `config` field itself
- Result: Code attempted to access non-existent fields causing "JSON could not be generated" errors

## Changes
- **config_helper.py**: Use hardcoded empty defaults instead of accessing removed `agent_data` fields
- **agent_crud.py**: Initialize agent versions with safe defaults rather than querying removed table fields

🤖 Generated with [Claude Code](https://claude.ai/code)