### PR TITLE
feat: add check for temporary/disposable emails in signup flow

### DIFF
--- a/backend/core/services/email.py
+++ b/backend/core/services/email.py
@@ -223,8 +223,8 @@ You received this email because you signed up for a Suna account."""
             response = httpx.get(url, timeout=5.0)
             response.raise_for_status()
             domains = set(response.json())
-            
-            await redis.set(cache_key, json.dumps(list(domains)), ex=3600)
+
+            await redis.set(cache_key, json.dumps(list(domains)), ex=86400) # Cache for 24 hours
             logger.debug(f"Cached {len(domains)} disposable domains")
             return domains
         except Exception as e:

--- a/backend/core/services/email.py
+++ b/backend/core/services/email.py
@@ -219,7 +219,7 @@ You received this email because you signed up for a Suna account."""
             logger.warning(f"Failed to get cached disposable domains: {e}")
         
         try:
-            url = "https://disposable.github.io/disposable-email-domains/domains.json"
+            url = "https://raw.githubusercontent.com/disposable/disposable-email-domains/master/domains.json"
             response = httpx.get(url, timeout=5.0)
             response.raise_for_status()
             domains = set(response.json())

--- a/backend/core/services/email_api.py
+++ b/backend/core/services/email_api.py
@@ -44,3 +44,22 @@ async def send_welcome_email(
             status_code=500,
             detail="Internal server error while sending welcome email"
         ) 
+
+class TempEmailResponse(BaseModel):
+    is_temp_email: bool
+
+@router.get("/is-temp-email/{email}", response_model=TempEmailResponse)
+async def is_temp_email(
+    email: EmailStr,
+    _: bool = Depends(verify_admin_api_key)
+):
+    try:
+        result = await email_service.is_temp_email(email)
+        return TempEmailResponse(is_temp_email=result)
+    except Exception as e:
+        logger.error(f"Error checking if {email} is a temp email: {str(e)}")
+        raise HTTPException(
+            status_code=500,
+            detail="Internal server error while checking email"
+        )
+    

--- a/frontend/src/app/auth/actions.ts
+++ b/frontend/src/app/auth/actions.ts
@@ -82,6 +82,28 @@ export async function signUp(prevState: any, formData: FormData) {
     return { message: 'Passwords do not match' };
   }
 
+  const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
+  const adminApiKey = process.env.KORTIX_ADMIN_API_KEY;
+  
+  if (adminApiKey) {
+    const response = await fetch(`${backendUrl}/is-temp-email/${email}`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Admin-Api-Key': adminApiKey,
+      },
+    });
+
+    if (response.ok) {
+      const data = await response.json();
+      if (data.is_temp_email) {
+        return { message: 'Please use a non-temporary email address' };
+      }
+    }
+  } else {
+    console.error('KORTIX_ADMIN_API_KEY not configured');
+  }
+
   const supabase = await createClient();
 
   const { error } = await supabase.auth.signUp({


### PR DESCRIPTION
## Summary  
- Add comprehensive **temporary email detection** to prevent signup with disposable email addresses  
- Implement **domain validation** using MX record checks and external disposable domain lists  
- Add new **API endpoint** for admin email validation with Redis cache support  

## Changes Made  
- **Backend (`email.py`)**:  
  - Added `is_temp_email()` method with:  
    - Disposable domain checking (via GitHub repo, refreshed every 24h)  
    - MX record validation fallback  
    - Redis cache integration for faster lookups  
- **Backend (`email_api.py`)**:  
  - Introduced new `/is-temp-email/{email}` endpoint for admin API access  
- **Frontend (`actions.ts`)**:  
  - Integrated temp email validation in the signup flow with proper error handling and user feedback  

## Technical Details  
- Uses **open-source disposable domain list** from [disposable/disposable-email-domains](https://github.com/disposable/disposable-email-domains), automatically updated every 24 hours  
- Implements **Redis cache** with 24h TTL to minimize external list fetches and improve performance  
- Adds **DNS MX record validation** as a secondary check for domains not in the disposable list  
- Utilizes **LRU cache** for repeated MX record lookups to reduce DNS query overhead