### PR TITLE
Integrate Grok 4 Fast AI model

### DIFF
--- a/backend/core/ai_models/registry.py
+++ b/backend/core/ai_models/registry.py
@@ -139,7 +139,7 @@ class ModelRegistry:
             id="xai/grok-4",
             name="Grok 4",
             provider=ModelProvider.XAI,
-            aliases=["grok-4", "x-ai/grok-4", "Grok 4"],
+            aliases=["grok-4", "x-ai/grok-4", "openrouter/x-ai/grok-4", "Grok 4"],
             context_window=128_000,
             capabilities=[
                 ModelCapability.CHAT,

--- a/backend/core/ai_models/registry.py
+++ b/backend/core/ai_models/registry.py
@@ -139,7 +139,7 @@ class ModelRegistry:
             id="xai/grok-4",
             name="Grok 4",
             provider=ModelProvider.XAI,
-            aliases=["grok-4", "x-ai/grok-4", "openrouter/x-ai/grok-4", "Grok 4"],
+            aliases=["grok-4", "x-ai/grok-4", "Grok 4"],
             context_window=128_000,
             capabilities=[
                 ModelCapability.CHAT,
@@ -154,16 +154,41 @@ class ModelRegistry:
             enabled=True
         ))
 
+        # xAI - Grok 4 Fast (Non-Reasoning)
+        self.register(Model(
+            id="xai/grok-4-fast-non-reasoning",
+            name="Grok 4 Fast (Non-Reasoning)",
+            provider=ModelProvider.XAI,
+            aliases=[
+                "grok-4-fast-non-reasoning",
+                "grok-4-fast-nonreasoning",
+                "x-ai/grok-4-fast-non-reasoning",
+                "Grok 4 Fast Non-Reasoning"
+            ],
+            context_window=2_000_000,
+            capabilities=[
+                ModelCapability.CHAT,
+                ModelCapability.FUNCTION_CALLING,
+                ModelCapability.STRUCTURED_OUTPUT,
+            ],
+            pricing=ModelPricing(
+                input_cost_per_million_tokens=0.20,
+                output_cost_per_million_tokens=0.50
+            ),
+            tier_availability=["paid"],
+            priority=94,
+            enabled=True
+        ))
+
         # xAI - Grok 4 Fast (Reasoning)
         self.register(Model(
             id="xai/grok-4-fast-reasoning",
-            name="Grok 4 Fast",
+            name="Grok 4 Fast (Reasoning)",
             provider=ModelProvider.XAI,
             aliases=[
                 "grok-4-fast-reasoning",
                 "grok-4-fast",
                 "x-ai/grok-4-fast-reasoning",
-                "openrouter/x-ai/grok-4-fast-reasoning",
                 "Grok 4 Fast"
             ],
             context_window=2_000_000,

--- a/backend/core/ai_models/registry.py
+++ b/backend/core/ai_models/registry.py
@@ -153,6 +153,34 @@ class ModelRegistry:
             priority=94,
             enabled=True
         ))
+
+        # xAI - Grok 4 Fast (Reasoning)
+        self.register(Model(
+            id="xai/grok-4-fast-reasoning",
+            name="Grok 4 Fast",
+            provider=ModelProvider.XAI,
+            aliases=[
+                "grok-4-fast-reasoning",
+                "grok-4-fast",
+                "x-ai/grok-4-fast-reasoning",
+                "openrouter/x-ai/grok-4-fast-reasoning",
+                "Grok 4 Fast"
+            ],
+            context_window=2_000_000,
+            capabilities=[
+                ModelCapability.CHAT,
+                ModelCapability.FUNCTION_CALLING,
+                ModelCapability.STRUCTURED_OUTPUT,
+                ModelCapability.THINKING,
+            ],
+            pricing=ModelPricing(
+                input_cost_per_million_tokens=0.20,
+                output_cost_per_million_tokens=0.50
+            ),
+            tier_availability=["paid"],
+            priority=95,
+            enabled=True
+        ))
         
         self.register(Model(
             id="openrouter/moonshotai/kimi-k2",

--- a/backend/core/services/llm.py
+++ b/backend/core/services/llm.py
@@ -103,8 +103,6 @@ def get_openrouter_fallback(model_name: str) -> Optional[str]:
     fallback_mapping = {
         "anthropic/claude-3-7-sonnet-latest": "openrouter/anthropic/claude-3.7-sonnet",
         "anthropic/claude-sonnet-4-20250514": "openrouter/anthropic/claude-sonnet-4",
-        "xai/grok-4": "openrouter/x-ai/grok-4",
-        "xai/grok-4-fast-reasoning": "openrouter/x-ai/grok-4-fast-reasoning",
         "gemini/gemini-2.5-pro": "openrouter/google/gemini-2.5-pro",
     }
     
@@ -121,8 +119,8 @@ def get_openrouter_fallback(model_name: str) -> Optional[str]:
     if "claude" in model_name.lower() or "anthropic" in model_name.lower():
         return "openrouter/anthropic/claude-sonnet-4"
     elif "xai" in model_name.lower() or "grok" in model_name.lower():
-        # Prefer Grok 4 Fast when available
-        return "openrouter/x-ai/grok-4-fast-reasoning"
+        # No OpenRouter fallback for xAI Grok 4 Fast; must use official xAI API
+        return None
     
     return None
 

--- a/backend/core/services/llm.py
+++ b/backend/core/services/llm.py
@@ -104,6 +104,7 @@ def get_openrouter_fallback(model_name: str) -> Optional[str]:
         "anthropic/claude-3-7-sonnet-latest": "openrouter/anthropic/claude-3.7-sonnet",
         "anthropic/claude-sonnet-4-20250514": "openrouter/anthropic/claude-sonnet-4",
         "xai/grok-4": "openrouter/x-ai/grok-4",
+        "xai/grok-4-fast-reasoning": "openrouter/x-ai/grok-4-fast-reasoning",
         "gemini/gemini-2.5-pro": "openrouter/google/gemini-2.5-pro",
     }
     
@@ -120,7 +121,8 @@ def get_openrouter_fallback(model_name: str) -> Optional[str]:
     if "claude" in model_name.lower() or "anthropic" in model_name.lower():
         return "openrouter/anthropic/claude-sonnet-4"
     elif "xai" in model_name.lower() or "grok" in model_name.lower():
-        return "openrouter/x-ai/grok-4"
+        # Prefer Grok 4 Fast when available
+        return "openrouter/x-ai/grok-4-fast-reasoning"
     
     return None
 
@@ -220,7 +222,14 @@ def _configure_thinking(params: Dict[str, Any], model_name: str, enable_thinking
 
     effort_level = reasoning_effort or 'low'
     is_anthropic = "anthropic" in model_name.lower() or "claude" in model_name.lower()
-    is_xai = "xai" in model_name.lower() or model_name.startswith("xai/")
+    # Detect xAI models, including OpenRouter's x-ai namespace
+    lower_name = model_name.lower()
+    is_xai = (
+        "xai" in lower_name or
+        lower_name.startswith("xai/") or
+        "/x-ai/" in lower_name or
+        lower_name.startswith("openrouter/x-ai/")
+    )
     
     if is_anthropic:
         params["reasoning_effort"] = effort_level

--- a/frontend/src/components/thread/chat-input/_use-model-selection.ts
+++ b/frontend/src/components/thread/chat-input/_use-model-selection.ts
@@ -61,9 +61,15 @@ export const MODELS = {
     recommended: false,
     lowQuality: false
   },
-  'grok-4-fast-reasoning': { 
-    tier: 'premium', 
+  'grok-4-fast-reasoning': {
+    tier: 'premium',
     priority: 95,
+    recommended: false,
+    lowQuality: false
+  },
+  'grok-4-fast-non-reasoning': {
+    tier: 'premium',
+    priority: 94,
     recommended: false,
     lowQuality: false
   },

--- a/frontend/src/components/thread/chat-input/_use-model-selection.ts
+++ b/frontend/src/components/thread/chat-input/_use-model-selection.ts
@@ -61,9 +61,9 @@ export const MODELS = {
     recommended: false,
     lowQuality: false
   },
-  'grok-4': { 
+  'grok-4-fast-reasoning': { 
     tier: 'premium', 
-    priority: 94,
+    priority: 95,
     recommended: false,
     lowQuality: false
   },

--- a/frontend/src/components/thread/chat-input/_use-model-selection.ts
+++ b/frontend/src/components/thread/chat-input/_use-model-selection.ts
@@ -61,6 +61,12 @@ export const MODELS = {
     recommended: false,
     lowQuality: false
   },
+  'grok-4': { 
+    tier: 'premium', 
+    priority: 94,
+    recommended: false,
+    lowQuality: false
+  },
   'grok-4-fast-reasoning': {
     tier: 'premium',
     priority: 95,


### PR DESCRIPTION
This pull request adds support for two new xAI Grok 4 Fast models—one for reasoning and one for non-reasoning—and updates related logic to ensure correct fallback and configuration handling. It also improves detection of xAI models in the codebase and updates the frontend model selection options.

**Model Registry and Fallback Logic Updates:**

* Added two new models to the registry: `xai/grok-4-fast-reasoning` and `xai/grok-4-fast-non-reasoning`, each with their own capabilities, pricing, and priority.
* Removed the OpenRouter fallback for xAI Grok 4 models, ensuring that requests for these models use the official xAI API instead. [[1]](diffhunk://#diff-82fe69c62c31e17980e26486bb6f0ab161b9d6ff4c000b1eeac43734bba258ddL106) [[2]](diffhunk://#diff-82fe69c62c31e17980e26486bb6f0ab161b9d6ff4c000b1eeac43734bba258ddL123-R123)

**Model Detection and Configuration:**

* Improved xAI model detection logic to include both direct xAI models and those under the OpenRouter `x-ai` namespace, ensuring correct configuration for reasoning features.

**Frontend Model Selection:**

* Added the new Grok 4 Fast models (`grok-4-fast-reasoning` and `grok-4-fast-non-reasoning`) to the frontend model selection list with appropriate tier and priority settings.