### PR TITLE
Fix error in `setup.py` when adding API keys for search

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -878,8 +878,9 @@ class SetupWizard:
         )
         self.env_vars["search"]["EXA_API_KEY"] = self._get_input(
             "Enter your Exa API key (optional): ",
-            lambda x: x == "" or validate_api_key(x),
+            validate_api_key,
             "Invalid API key.",
+            allow_empty=True,
             default_value=self.env_vars["search"]["EXA_API_KEY"],
         )
 


### PR DESCRIPTION
<img width="1200" height="762" alt="image" src="https://github.com/user-attachments/assets/a58071b3-10dc-4a24-918e-1e85eb95f51d" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes the EXA API key prompt in `setup.py` to use `validate_api_key` with `allow_empty=True`, properly allowing optional input.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 61615da47c39a599911c9383bbc8996b29f8a852. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->