### PR TITLE
fix(backend): handle None value in prompt_tokens_details

### DIFF
--- a/backend/core/agentpress/thread_manager.py
+++ b/backend/core/agentpress/thread_manager.py
@@ -131,7 +131,8 @@ class ThreadManager:
             
             cache_read_tokens = int(usage.get("cache_read_input_tokens", 0) or 0)
             if cache_read_tokens == 0:
-                cache_read_tokens = int(usage.get("prompt_tokens_details", {}).get("cached_tokens", 0) or 0)
+                prompt_tokens_details = usage.get("prompt_tokens_details") or {}
+                cache_read_tokens = int(prompt_tokens_details.get("cached_tokens", 0) or 0)
             
             cache_creation_tokens = int(usage.get("cache_creation_input_tokens", 0) or 0)
             model = content.get("model")


### PR DESCRIPTION
When processing usage statistics, prompt_tokens_details may be None, which causes AttributeError when calling .get() on it. Use `or {}` to ensure we always have a dict object to work with.

🤖 Generated with [Claude Code](https://claude.com/claude-code)