### PR TITLE
fix(agent_runs): ensure default agent exists before loading

### DIFF
--- a/backend/core/agent_runs.py
+++ b/backend/core/agent_runs.py
@@ -16,6 +16,7 @@ from core.utils.config import config, EnvMode
 from core.services import redis
 from core.sandbox.sandbox import create_sandbox, delete_sandbox
 from core.utils.sandbox_utils import generate_unique_filename, get_uploads_directory
+from core.utils.ensure_suna import ensure_suna_installed
 from run_agent_background import run_agent_background
 from core.ai_models import model_manager
 
@@ -647,6 +648,7 @@ async def initiate_agent_with_files(
     else:
         # Load default agent
         logger.debug(f"[AGENT INITIATE] Loading default agent")
+        await ensure_suna_installed(account_id)
         default_agent = await client.table('agents').select('agent_id').eq('account_id', account_id).eq('is_default', True).maybe_single().execute()
         
         if default_agent.data:


### PR DESCRIPTION
## Description:
- Add ensure_suna_installed() call before default agent query
- Prevents AttributeError when no default agent exists
- Ensures every account has a default agent on first conversation
- Fixes issue where agent initiation fails for new accounts

## Problem
Agent initiation was failing with `AttributeError: 'NoneType' object has no attribute 'data'` for new accounts that don't have a default agent created yet.

## Root Cause
The `initiate_agent_with_files` function was trying to load a default agent without ensuring one exists first. The `ensure_suna_installed()` function exists to create default agents but was only called in billing endpoints, not in the agent initiation flow.

## Solution
Added `ensure_suna_installed(account_id)` call before querying for the default agent. This ensures a Suna default agent is created for the account if it doesn't exist.

## Changes
- Added 2 lines in `backend/core/agent_runs.py`
- Uses existing infrastructure (no new code needed)
- Minimal, efficient fix

## Testing
- ✅ New accounts now get default agents automatically
- ✅ Existing accounts continue to work normally
- ✅ No breaking changes to existing functionality