### PR TITLE
Update thread_manager.py for handle billing error

### DIFF
--- a/backend/core/agentpress/thread_manager.py
+++ b/backend/core/agentpress/thread_manager.py
@@ -131,7 +131,8 @@ class ThreadManager:
             
             cache_read_tokens = int(usage.get("cache_read_input_tokens", 0) or 0)
             if cache_read_tokens == 0:
-                cache_read_tokens = int(usage.get("prompt_tokens_details", {}).get("cached_tokens", 0) or 0)
+                # safely handle prompt_tokens_details that might be None
+                cache_read_tokens = int((usage.get("prompt_tokens_details") or {}).get("cached_tokens", 0) or 0)
             
             cache_creation_tokens = int(usage.get("cache_creation_input_tokens", 0) or 0)
             model = content.get("model")


### PR DESCRIPTION
Enhance the safety of _handle_billing when reading prompt_tokens_details. For the grok-4-fast and gpt-5 models, the prompt_tokens_details field is None, which can cause _handle_billing to throw a “System error: can only concatenate str (not ‘list’) to str”, thereby interrupting the task flow.