### PR TITLE
Fix mcps not registered

### DIFF
--- a/backend/core/billing/subscription_service.py
+++ b/backend/core/billing/subscription_service.py
@@ -663,9 +663,24 @@ class SubscriptionService:
             seconds_since_period_start = (now - billing_anchor).total_seconds()
             
             if 0 <= seconds_since_period_start < 1800:
-                is_renewal = True
-                logger.warning(f"[RENEWAL DETECTION] We're only {seconds_since_period_start:.0f}s after period start")
-                logger.warning(f"[RENEWAL DETECTION] This is almost certainly a renewal - BLOCKING subscription.updated credits")
+                current_tier_name = current_account.data[0].get('tier') if current_account.data else 'none'
+                old_subscription_id = current_account.data[0].get('stripe_subscription_id') if current_account.data else None
+                new_tier_info = get_tier_by_price_id(price_id)
+                
+                is_new_subscription = (old_subscription_id is None or 
+                                      old_subscription_id == '' or 
+                                      old_subscription_id != subscription.get('id'))
+                
+                is_free_to_paid_upgrade = (current_tier_name in ['free', 'none'] and 
+                                          new_tier_info and 
+                                          new_tier_info.name not in ['free', 'none'])
+                
+                if is_new_subscription or is_free_to_paid_upgrade:
+                    logger.info(f"[RENEWAL DETECTION] Within 30min BUT new subscription (old_sub={old_subscription_id}, new_sub={subscription.get('id')}) or free-to-paid upgrade ({current_tier_name} → {new_tier_info.name if new_tier_info else 'unknown'}) - NOT blocking")
+                else:
+                    is_renewal = True
+                    logger.warning(f"[RENEWAL DETECTION] We're only {seconds_since_period_start:.0f}s after period start")
+                    logger.warning(f"[RENEWAL DETECTION] This is almost certainly a renewal - BLOCKING subscription.updated credits")
         
         if not is_renewal and not is_upgrade and previous_attributes and 'current_period_start' in previous_attributes:
             prev_period_start = previous_attributes.get('current_period_start')


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Treats within-30min events as non-renewals when the subscription is new or a free-to-paid upgrade, and improves related logging.
> 
> - **Backend**
>   - **Billing (`backend/core/billing/subscription_service.py`)**
>     - *Renewal detection near period start*:
>       - Extracts `old_subscription_id` from `credit_accounts` and computes `is_new_subscription`.
>       - Broadens condition to skip blocking when `is_new_subscription` or free-to-paid upgrade.
>       - Updates log messages to reflect new logic and include subscription IDs/tier transition context.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0fba450311f790ac40082a503e43dffa19fe0206. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->