### PR TITLE
Fix mcps not registered

### DIFF
--- a/backend/core/billing/webhook_service.py
+++ b/backend/core/billing/webhook_service.py
@@ -730,8 +730,62 @@ class WebhookService:
                 current_price_id = subscription['items']['data'][0]['price']['id'] if subscription.get('items') else None
                 prev_price_id = previous_attributes.get('items', {}).get('data', [{}])[0].get('price', {}).get('id') if previous_attributes.get('items') else None
                 
+                prev_status = previous_attributes.get('status')
+                current_status = subscription.get('status')
+                
                 if current_price_id and prev_price_id and current_price_id == prev_price_id:
-                    return
+                    if not (prev_status == 'incomplete' and current_status == 'active'):
+                        return
+                    else:
+                        logger.info(f"[WEBHOOK] Subscription {subscription['id']} changed from incomplete→active with same price_id, need to grant initial credits")
+                        
+                        account_id = subscription.get('metadata', {}).get('account_id')
+                        if not account_id:
+                            customer_id = subscription.get('customer')
+                            customer_result = await client.schema('basejump').from_('billing_customers')\
+                                .select('account_id')\
+                                .eq('id', customer_id)\
+                                .execute()
+                            if customer_result.data:
+                                account_id = customer_result.data[0].get('account_id')
+                        
+                        if account_id:
+                            trial_check = await client.from_('credit_accounts').select(
+                                'trial_status, tier'
+                            ).eq('account_id', account_id).execute()
+                            
+                            if trial_check.data:
+                                current_tier = trial_check.data[0].get('tier')
+                                
+                                if current_tier in ['free', 'none']:
+                                    tier_info = get_tier_by_price_id(current_price_id)
+                                    if not tier_info:
+                                        logger.error(f"[WEBHOOK] Cannot process incomplete→active transition - price_id {current_price_id} not recognized")
+                                        raise ValueError(f"Unrecognized price_id: {current_price_id}")
+                                    
+                                    billing_anchor = datetime.fromtimestamp(subscription['current_period_start'], tz=timezone.utc)
+                                    next_grant_date = datetime.fromtimestamp(subscription['current_period_end'], tz=timezone.utc)
+                                    
+                                    logger.info(f"[WEBHOOK] User {account_id} upgrading from {current_tier} via incomplete→active transition to {tier_info.name}")
+                                    await client.from_('credit_accounts').update({
+                                        'tier': tier_info.name,
+                                        'stripe_subscription_id': subscription['id'],
+                                        'billing_cycle_anchor': billing_anchor.isoformat(),
+                                        'next_credit_grant': next_grant_date.isoformat(),
+                                        'last_grant_date': billing_anchor.isoformat()
+                                    }).eq('account_id', account_id).execute()
+                                    
+                                    from decimal import Decimal
+                                    await credit_manager.add_credits(
+                                        account_id=account_id,
+                                        amount=Decimal(str(tier_info.monthly_credits)),
+                                        is_expiring=True,
+                                        description=f"Initial {tier_info.display_name} subscription credits (incomplete→active)",
+                                        expires_at=next_grant_date
+                                    )
+                                    
+                                    logger.info(f"[WEBHOOK] Granted {tier_info.monthly_credits} credits to {account_id} for incomplete→active upgrade")
+                                    return
 
                 current_tier_info = get_tier_by_price_id(current_price_id) if current_price_id else None
                 prev_tier_info = get_tier_by_price_id(prev_price_id) if prev_price_id else None
@@ -767,7 +821,9 @@ class WebhookService:
                         now = datetime.now(timezone.utc).timestamp()
                         time_since_period = now - current_period_start
                         
-                        if 0 <= time_since_period < 1800:
+                        is_incomplete_to_active = prev_status == 'incomplete' and current_status == 'active'
+                        
+                        if 0 <= time_since_period < 1800 and not is_incomplete_to_active:
                             return
 
                     if 'current_period_start' in previous_attributes:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Handle Stripe incomplete→active subscription transitions to grant initial credits and ensure account metadata is updated when skipping duplicate initial grants.
> 
> - **Billing/Webhooks**:
>   - **Subscription updates (`customer.subscription.updated`)**:
>     - Detect `incomplete → active` status change with unchanged `price_id` and grant initial credits; update `credit_accounts` (`tier`, `stripe_subscription_id`, `billing_cycle_anchor`, `next_credit_grant`, `last_grant_date`).
>     - Bypass the 30‑minute early‑return window for this transition.
>   - **Invoice handling (`handle_subscription_renewal`)**:
>     - When skipping duplicate initial grants, still update account metadata: `last_processed_invoice_id`, `tier`, `stripe_subscription_id`, `billing_cycle_anchor`, `next_credit_grant`, and optionally `trial_status`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6f645051071c91bf987e90a917943eaaebd727dc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->