### PR TITLE
shwo date range in transaction period picker

### DIFF
--- a/frontend/src/components/billing/thread-usage.tsx
+++ b/frontend/src/components/billing/thread-usage.tsx
@@ -2,6 +2,8 @@
 
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { format } from 'date-fns';
+import type { DateRange } from 'react-day-picker';
 import {
   Card,
   CardContent,
@@ -20,13 +22,7 @@ import {
 import { Skeleton } from '@/components/ui/skeleton';
 import { Button } from '@/components/ui/button';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+import { DateRangePicker } from '@/components/ui/date-range-picker';
 import {
   AlertCircle,
   TrendingDown,
@@ -37,10 +33,18 @@ import { useThreadUsage } from '@/hooks/react-query/billing/use-thread-usage';
 export default function ThreadUsage() {
   const router = useRouter();
   const [offset, setOffset] = useState(0);
-  const [days, setDays] = useState(30);
+  const [dateRange, setDateRange] = useState<DateRange>({
+    from: new Date(new Date().setDate(new Date().getDate() - 29)),
+    to: new Date(),
+  });
   const limit = 50;
 
-  const { data, isLoading, error } = useThreadUsage(limit, offset, days);
+  const { data, isLoading, error } = useThreadUsage({
+    limit,
+    offset,
+    startDate: dateRange?.from,
+    endDate: dateRange?.to,
+  });
 
   const formatDate = (dateString: string) => {
     return new Date(dateString).toLocaleString('en-US', {
@@ -66,8 +70,8 @@ export default function ThreadUsage() {
     }
   };
 
-  const handleDaysChange = (value: string) => {
-    setDays(parseInt(value));
+  const handleDateRangeUpdate = (values: { range: DateRange }) => {
+    setDateRange(values.range);
     setOffset(0);
   };
 
@@ -123,11 +127,15 @@ export default function ThreadUsage() {
     <div className="space-y-6">
       {summary && (
           <Card className='w-full'>
-            <CardHeader>
-              <CardTitle>Total Usage</CardTitle>
-              <CardDescription>Credits consumed across all threads</CardDescription>
-            </CardHeader>
-            <CardContent>
+            <CardHeader className='flex items-center justify-between'>
+              <div>
+                <CardTitle>Total Usage</CardTitle>
+                <CardDescription className='mt-2'>
+                  {dateRange.from && dateRange.to
+                    ? `${format(dateRange.from, "MMM dd, yyyy")} - ${format(dateRange.to, "MMM dd, yyyy")}`
+                    : 'Selected period'}
+                </CardDescription>
+              </div>
               <div className="flex items-center gap-2">
                 <TrendingDown className="h-5 w-5 text-red-500" />
                 <div>
@@ -135,14 +143,13 @@ export default function ThreadUsage() {
                     {formatCredits(summary.total_credits_used)}
                   </div>
                   <p className="text-sm text-muted-foreground">
-                    Last {summary.period_days} days
+                    Credits consumed
                   </p>
                 </div>
               </div>
-            </CardContent>
+            </CardHeader>
           </Card>
       )}
-
       <Card className='p-0 px-0 bg-transparent shadow-none border-none'>
         <CardHeader className='px-0'>
           <div className="flex items-center justify-between">
@@ -152,26 +159,21 @@ export default function ThreadUsage() {
                 Credit consumption per conversation
               </CardDescription>
             </div>
-            <Select value={days.toString()} onValueChange={handleDaysChange}>
-              <SelectTrigger className="w-[180px]">
-                <SelectValue placeholder="Select period" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="7">Last 7 days</SelectItem>
-                <SelectItem value="30">Last 30 days</SelectItem>
-                <SelectItem value="60">Last 60 days</SelectItem>
-                <SelectItem value="90">Last 90 days</SelectItem>
-                <SelectItem value="180">Last 180 days</SelectItem>
-                <SelectItem value="365">Last year</SelectItem>
-              </SelectContent>
-            </Select>
+            <DateRangePicker
+              initialDateFrom={dateRange.from}
+              initialDateTo={dateRange.to}
+              onUpdate={handleDateRangeUpdate}
+              align="end"
+            />
           </div>
         </CardHeader>
         <CardContent className='px-0'>
           {threadRecords.length === 0 ? (
             <div className="text-center py-8">
               <p className="text-muted-foreground">
-                No thread usage found in the last {days} days.
+                {dateRange.from && dateRange.to
+                  ? `No thread usage found between ${format(dateRange.from, "MMM dd, yyyy")} and ${format(dateRange.to, "MMM dd, yyyy")}.`
+                  : 'No thread usage found.'}
               </p>
             </div>
           ) : (

--- a/frontend/src/components/settings/user-settings-modal.tsx
+++ b/frontend/src/components/settings/user-settings-modal.tsx
@@ -857,7 +857,6 @@ function CreditsHelpAlert() {
 function UsageTab() {
   return (
       <div className="p-6 space-y-6">
-        <CreditsHelpAlert />
         <ThreadUsage />
       </div>
   );

--- a/frontend/src/components/ui/calendar.tsx
+++ b/frontend/src/components/ui/calendar.tsx
@@ -55,7 +55,7 @@ function Calendar({
           'day-outside text-muted-foreground aria-selected:text-muted-foreground',
         day_disabled: 'text-muted-foreground opacity-50',
         day_range_middle:
-          'aria-selected:bg-accent aria-selected:text-accent-foreground',
+          'aria-selected:bg-transparent aria-selected:text-accent-foreground',
         day_hidden: 'invisible',
         ...classNames,
       }}

--- a/frontend/src/components/ui/date-range-picker.tsx
+++ b/frontend/src/components/ui/date-range-picker.tsx
@@ -1,0 +1,316 @@
+'use client'
+
+import React, { type FC, useState, useEffect } from 'react'
+import { Button } from './button'
+import { Popover, PopoverContent, PopoverTrigger } from './popover'
+import { Calendar } from './calendar'
+import { ChevronUpIcon, ChevronDownIcon, CheckIcon } from '@radix-ui/react-icons'
+import { cn } from '@/lib/utils'
+import type { DateRange } from 'react-day-picker'
+
+export interface DateRangePickerProps {
+  onUpdate?: (values: { range: DateRange }) => void
+  initialDateFrom?: Date | string
+  initialDateTo?: Date | string
+  align?: 'start' | 'center' | 'end'
+  locale?: string
+}
+
+const formatDate = (date: Date, locale: string = 'en-us'): string => {
+  return date.toLocaleDateString(locale, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric'
+  })
+}
+
+const getDateAdjustedForTimezone = (dateInput: Date | string): Date => {
+  if (typeof dateInput === 'string') {
+    const parts = dateInput.split('-').map((part) => parseInt(part, 10))
+    const date = new Date(parts[0], parts[1] - 1, parts[2])
+    return date
+  } else {
+    return dateInput
+  }
+}
+
+interface Preset {
+  name: string
+  label: string
+}
+
+const PRESETS: Preset[] = [
+  { name: 'today', label: 'Today' },
+  { name: 'yesterday', label: 'Yesterday' },
+  { name: 'last7', label: 'Last 7 days' },
+  { name: 'last14', label: 'Last 14 days' },
+  { name: 'last30', label: 'Last 30 days' },
+  { name: 'thisWeek', label: 'This Week' },
+  { name: 'lastWeek', label: 'Last Week' },
+  { name: 'thisMonth', label: 'This Month' },
+  { name: 'lastMonth', label: 'Last Month' }
+]
+
+export const DateRangePicker: FC<DateRangePickerProps> = ({
+  initialDateFrom = new Date(new Date().setHours(0, 0, 0, 0)),
+  initialDateTo,
+  onUpdate,
+  align = 'end',
+  locale = 'en-US',
+}): JSX.Element => {
+  const [isOpen, setIsOpen] = useState(false)
+
+  const [range, setRange] = useState<DateRange>({
+    from: getDateAdjustedForTimezone(initialDateFrom),
+    to: initialDateTo
+      ? getDateAdjustedForTimezone(initialDateTo)
+      : getDateAdjustedForTimezone(initialDateFrom)
+  })
+
+  const [selectedPreset, setSelectedPreset] = useState<string | undefined>(undefined)
+
+  const [isSmallScreen, setIsSmallScreen] = useState(
+    typeof window !== 'undefined' ? window.innerWidth < 960 : false
+  )
+
+  useEffect(() => {
+    const handleResize = (): void => {
+      setIsSmallScreen(window.innerWidth < 960)
+    }
+
+    window.addEventListener('resize', handleResize)
+
+    return () => {
+      window.removeEventListener('resize', handleResize)
+    }
+  }, [])
+
+  const getPresetRange = (presetName: string): DateRange => {
+    const preset = PRESETS.find(({ name }) => name === presetName)
+    if (!preset) throw new Error(`Unknown date range preset: ${presetName}`)
+    const from = new Date()
+    const to = new Date()
+    const first = from.getDate() - from.getDay()
+
+    switch (preset.name) {
+      case 'today':
+        from.setHours(0, 0, 0, 0)
+        to.setHours(23, 59, 59, 999)
+        break
+      case 'yesterday':
+        from.setDate(from.getDate() - 1)
+        from.setHours(0, 0, 0, 0)
+        to.setDate(to.getDate() - 1)
+        to.setHours(23, 59, 59, 999)
+        break
+      case 'last7':
+        from.setDate(from.getDate() - 6)
+        from.setHours(0, 0, 0, 0)
+        to.setHours(23, 59, 59, 999)
+        break
+      case 'last14':
+        from.setDate(from.getDate() - 13)
+        from.setHours(0, 0, 0, 0)
+        to.setHours(23, 59, 59, 999)
+        break
+      case 'last30':
+        from.setDate(from.getDate() - 29)
+        from.setHours(0, 0, 0, 0)
+        to.setHours(23, 59, 59, 999)
+        break
+      case 'thisWeek':
+        from.setDate(first)
+        from.setHours(0, 0, 0, 0)
+        to.setHours(23, 59, 59, 999)
+        break
+      case 'lastWeek':
+        from.setDate(from.getDate() - 7 - from.getDay())
+        to.setDate(to.getDate() - to.getDay() - 1)
+        from.setHours(0, 0, 0, 0)
+        to.setHours(23, 59, 59, 999)
+        break
+      case 'thisMonth':
+        from.setDate(1)
+        from.setHours(0, 0, 0, 0)
+        to.setHours(23, 59, 59, 999)
+        break
+      case 'lastMonth':
+        from.setMonth(from.getMonth() - 1)
+        from.setDate(1)
+        from.setHours(0, 0, 0, 0)
+        to.setDate(0)
+        to.setHours(23, 59, 59, 999)
+        break
+    }
+
+    return { from, to }
+  }
+
+  const setPreset = (preset: string): void => {
+    const range = getPresetRange(preset)
+    setRange(range)
+    setSelectedPreset(preset)
+  }
+
+  const checkPreset = (): void => {
+    for (const preset of PRESETS) {
+      const presetRange = getPresetRange(preset.name)
+
+      const normalizedRangeFrom = new Date(range.from);
+      normalizedRangeFrom.setHours(0, 0, 0, 0);
+      const normalizedPresetFrom = new Date(
+        presetRange.from.setHours(0, 0, 0, 0)
+      )
+
+      const normalizedRangeTo = new Date(range.to ?? 0);
+      normalizedRangeTo.setHours(0, 0, 0, 0);
+      const normalizedPresetTo = new Date(
+        presetRange.to?.setHours(0, 0, 0, 0) ?? 0
+      )
+
+      if (
+        normalizedRangeFrom.getTime() === normalizedPresetFrom.getTime() &&
+        normalizedRangeTo.getTime() === normalizedPresetTo.getTime()
+      ) {
+        setSelectedPreset(preset.name)
+        return
+      }
+    }
+
+    setSelectedPreset(undefined)
+  }
+
+  useEffect(() => {
+    checkPreset()
+  }, [range])
+
+  const PresetButton = ({
+    preset,
+    label,
+    isSelected
+  }: {
+    preset: string
+    label: string
+    isSelected: boolean
+  }): JSX.Element => (
+    <Button
+      className={cn(isSelected && 'pointer-events-none')}
+      variant="ghost"
+      onClick={() => {
+        setPreset(preset)
+      }}
+    >
+      <>
+        <span className={cn('pr-2 opacity-0', isSelected && 'opacity-70')}>
+          <CheckIcon width={18} height={18} />
+        </span>
+        {label}
+      </>
+    </Button>
+  )
+
+  return (
+    <Popover
+      modal={true}
+      open={isOpen}
+      onOpenChange={setIsOpen}
+    >
+      <PopoverTrigger asChild>
+        <Button size={'default'} variant="outline">
+          <div className="text-right">
+            <div className="py-1">
+              <div className="text-sm">{`${formatDate(range.from, locale)}${
+                range.to != null ? ' - ' + formatDate(range.to, locale) : ''
+              }`}</div>
+            </div>
+          </div>
+          <div className="pl-1 opacity-60 -mr-2 scale-125">
+            {isOpen ? (<ChevronUpIcon width={24} />) : (<ChevronDownIcon width={24} />)}
+          </div>
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align={align} className="w-auto max-w-[calc(100vw-2rem)]">
+        <div className="flex flex-col lg:flex-row py-2">
+          {isSmallScreen && (
+            <div className="flex flex-col gap-1 px-2 pb-4 border-b mb-4">
+              {PRESETS.map((preset) => (
+                <Button
+                  key={preset.name}
+                  className={cn(
+                    "justify-start",
+                    selectedPreset === preset.name && 'bg-muted'
+                  )}
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => {
+                    setPreset(preset.name)
+                  }}
+                >
+                  {preset.label}
+                </Button>
+              ))}
+            </div>
+          )}
+          <div className="flex">
+            <div className="flex flex-col">
+              <div>
+                <Calendar
+                  mode="range"
+                  onSelect={(value: DateRange | undefined) => {
+                    if (value?.from != null) {
+                      setRange({ from: value.from, to: value?.to })
+                    }
+                  }}
+                  selected={range}
+                  numberOfMonths={isSmallScreen ? 1 : 2}
+                  defaultMonth={
+                    new Date(
+                      new Date().setMonth(
+                        new Date().getMonth() - (isSmallScreen ? 0 : 1)
+                      )
+                    )
+                  }
+                />
+              </div>
+            </div>
+          </div>
+          {!isSmallScreen && (
+            <div className="flex flex-col items-end gap-1 pr-2 pl-6 pb-6">
+              <div className="flex w-full flex-col items-end gap-1">
+                {PRESETS.map((preset) => (
+                  <PresetButton
+                    key={preset.name}
+                    preset={preset.name}
+                    label={preset.label}
+                    isSelected={selectedPreset === preset.name}
+                  />
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+        <div className="flex justify-end gap-2 py-2 pr-4">
+          <Button
+            onClick={() => {
+              setIsOpen(false)
+            }}
+            variant="ghost"
+          >
+            Cancel
+          </Button>
+          <Button
+            onClick={() => {
+              setIsOpen(false)
+              onUpdate?.({ range })
+            }}
+          >
+            Update
+          </Button>
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}
+
+DateRangePicker.displayName = 'DateRangePicker'
+


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a date range picker to thread usage UI and extends backend API to accept start/end dates, returning matching summary fields.
> 
> - **Backend (`backend/core/billing/api.py`)**
>   - `GET /billing/credit-usage-by-thread`:
>     - Accepts optional `start_date`/`end_date` (with fallback to `days` or 30d default).
>     - Applies `created_at <= end_date` filter and returns `summary.start_date`/`summary.end_date` with `period_days` possibly `null`.
> - **Frontend**
>   - **Thread usage (`frontend/src/components/billing/thread-usage.tsx`)**:
>     - Replaces days dropdown with `DateRangePicker`; passes `start_date`/`end_date` to query; updates headers/empty-state text.
>   - **Hook (`frontend/src/hooks/react-query/billing/use-thread-usage.ts`)**:
>     - API params now object-based; supports `startDate`/`endDate`; updates `summary` types (`period_days` can be `null`, adds `start_date`/`end_date`).
>   - **UI**:
>     - Adds `DateRangePicker` component (`frontend/src/components/ui/date-range-picker.tsx`).
>     - Tweaks calendar range styling in `frontend/src/components/ui/calendar.tsx`.
>   - **Settings**:
>     - Removes `CreditsHelpAlert` from Usage tab content.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5e479ab13330e1af63a444e4f3b08ee9bd604f9e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->