### PR TITLE
fix pres name

### DIFF
--- a/backend/core/tools/sb_presentation_tool.py
+++ b/backend/core/tools/sb_presentation_tool.py
@@ -391,7 +391,7 @@ class SandboxPresentationTool(SandboxToolsBase):
             if presentation_path:
                 safe_name = self._sanitize_filename(presentation_name)
                 response_data["presentation_path"] = f"{self.presentations_dir}/{safe_name}"
-                response_data["presentation_name"] = presentation_name
+                response_data["presentation_name"] = presentation_name.lower()
                 response_data["copied_to_workspace"] = True
                 response_data["note"] = f"Template copied to /workspace/{self.presentations_dir}/{safe_name}/. **CRITICAL**: Use full_file_rewrite to edit slides. ONLY change text content - preserve ALL CSS, styling, colors, fonts, and HTML structure 100% exactly. The template's visual design must remain identical. This template provides ALL slides and extracted design patterns in one response."
                 response_data["usage_instructions"] = {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Lowercases `presentation_name` in `load_template_design` response when a template is copied to the workspace.
> 
> - **Behavior change**: `load_template_design` now returns lowercase `presentation_name` in the response when `presentation_name` is provided and the template is copied to workspace.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d7a13bd0e68663e6401789cfc1fe922af7c73c02. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->