### PR TITLE
fix: share patch bug

### DIFF
--- a/backend/core/threads.py
+++ b/backend/core/threads.py
@@ -451,6 +451,7 @@ async def delete_message(
 @router.patch("/threads/{thread_id}", summary="Update Thread", operation_id="update_thread")
 async def update_thread(
     thread_id: str,
+    request: Request,
     title: Optional[str] = Body(None, embed=True),
     is_public: Optional[bool] = Body(None, embed=True),
     auth: AuthorizedThreadAccess = Depends(require_thread_access)
@@ -512,7 +513,7 @@ async def update_thread(
         logger.debug(f"Successfully updated thread: {thread_id}")
         
         # Return the updated thread with project data
-        return await get_thread(thread_id, auth)
+        return await get_thread(thread_id, request)
         
     except HTTPException:
         raise


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> update_thread now accepts Request and returns the updated thread via request-aware get_thread to handle public/auth access correctly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e24dc736ac833017fe95c5477b39fcc7423cb642. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->