### PR TITLE
fix: add requests to sandbox requirements (#1750)

### DIFF
--- a/backend/core/sandbox/docker/requirements.txt
+++ b/backend/core/sandbox/docker/requirements.txt
@@ -11,3 +11,4 @@ bs4==0.0.2
 python-pptx>=0.6.23
 openpyxl>=3.1.0
 python-docx>=1.1.0
+requests==2.31.0


### PR DESCRIPTION
Adds requests dependency to sandbox environment. Fixes #1750 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add `requests==2.31.0` to `backend/core/sandbox/docker/requirements.txt` for the sandbox environment.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d8c482d5d4804db24f9a3af550f39bbfb3d34dbc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->