### PR TITLE
feat(profile-picture): User should be able to add profile picture

### DIFF
--- a/backend/core/api.py
+++ b/backend/core/api.py
@@ -11,6 +11,7 @@ from .tools_api import router as tools_api_router
 from .vapi_api import router as vapi_router
 from .account_deletion import router as account_deletion_router
 from .limits_api import router as limits_api_router
+from .user_profile import router as user_profile_router
 router = APIRouter()
 
 # Include all sub-routers
@@ -25,6 +26,7 @@ router.include_router(tools_api_router)
 router.include_router(vapi_router)
 router.include_router(account_deletion_router)
 router.include_router(limits_api_router)
+router.include_router(user_profile_router)
 
 # Re-export the initialize and cleanup functions
 __all__ = ['router', 'initialize', 'cleanup']

--- a/backend/core/user_profile.py
+++ b/backend/core/user_profile.py
@@ -1,0 +1,111 @@
+from fastapi import APIRouter, Depends, UploadFile, File, HTTPException
+from pydantic import BaseModel
+from typing import Optional, Tuple, Any
+
+from core.services.supabase import DBConnection
+from core.utils.auth_utils import verify_and_get_user_id_from_jwt
+from core.utils.logger import logger
+from core.utils.s3_upload_utils import upload_user_profile_picture
+
+
+router = APIRouter(tags=["user-profile"])
+
+MAX_FILE_SIZE_BYTES = 5 * 1024 * 1024  # 5MB
+ALLOWED_CONTENT_TYPES = {"image/png", "image/jpeg", "image/jpg", "image/webp"}
+PROFILE_PICTURE_BUCKET = "user-profile-pictures"
+
+
+class ProfilePictureResponse(BaseModel):
+    success: bool
+    profile_picture_url: Optional[str] = None
+
+
+async def _get_user_metadata(client, user_id: str) -> Tuple[dict, Any]:
+    user_response = await client.auth.admin.get_user_by_id(user_id)
+    if not user_response or not user_response.user:
+        raise HTTPException(status_code=404, detail="User not found")
+    metadata = dict(user_response.user.user_metadata or {})
+    return metadata, user_response
+
+
+@router.get("/users/profile-picture", response_model=ProfilePictureResponse)
+async def get_profile_picture(
+    user_id: str = Depends(verify_and_get_user_id_from_jwt),
+):
+    db = DBConnection()
+    client = await db.client
+
+    metadata, _ = await _get_user_metadata(client, user_id)
+    return ProfilePictureResponse(success=True, profile_picture_url=metadata.get("avatar_url"))
+
+
+@router.post("/users/profile-picture", response_model=ProfilePictureResponse)
+async def upload_profile_picture(
+    file: UploadFile = File(...),
+    user_id: str = Depends(verify_and_get_user_id_from_jwt),
+):
+    if not file:
+        raise HTTPException(status_code=400, detail="No file provided")
+
+    content_type = (file.content_type or "").lower()
+    if content_type not in ALLOWED_CONTENT_TYPES:
+        raise HTTPException(
+            status_code=400,
+            detail="Invalid file type. Please upload a PNG, JPG, or WEBP image.",
+        )
+
+    file_bytes = await file.read()
+    if not file_bytes:
+        raise HTTPException(status_code=400, detail="Uploaded file is empty")
+
+    if len(file_bytes) > MAX_FILE_SIZE_BYTES:
+        raise HTTPException(status_code=413, detail="File is too large (max 5MB)")
+
+    db = DBConnection()
+    client = await db.client
+
+    metadata, _ = await _get_user_metadata(client, user_id)
+    previous_path = metadata.get("profile_picture_path")
+
+    if previous_path:
+        try:
+            await client.storage.from_(PROFILE_PICTURE_BUCKET).remove([previous_path])
+        except Exception as e:
+            logger.warning(f"Failed to remove previous profile picture for user {user_id}: {e}")
+
+    public_url, storage_path = await upload_user_profile_picture(
+        user_id=user_id,
+        image_bytes=file_bytes,
+        content_type=content_type,
+        bucket_name=PROFILE_PICTURE_BUCKET,
+    )
+
+    metadata["avatar_url"] = public_url
+    metadata["profile_picture_path"] = storage_path
+
+    await client.auth.admin.update_user_by_id(user_id, {"user_metadata": metadata})
+
+    return ProfilePictureResponse(success=True, profile_picture_url=public_url)
+
+
+@router.delete("/users/profile-picture", response_model=ProfilePictureResponse)
+async def delete_profile_picture(
+    user_id: str = Depends(verify_and_get_user_id_from_jwt),
+):
+    db = DBConnection()
+    client = await db.client
+
+    metadata, _ = await _get_user_metadata(client, user_id)
+    previous_path = metadata.pop("profile_picture_path", None)
+    metadata.pop("avatar_url", None)
+
+    if previous_path:
+        try:
+            await client.storage.from_(PROFILE_PICTURE_BUCKET).remove([previous_path])
+        except Exception as e:
+            logger.warning(f"Failed to remove profile picture for user {user_id}: {e}")
+
+    await client.auth.admin.update_user_by_id(user_id, {"user_metadata": metadata})
+
+    return ProfilePictureResponse(success=True, profile_picture_url=None)
+

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -15,6 +15,7 @@ import { roobert } from './fonts/roobert';
 import { roobertMono } from './fonts/roobert-mono';
 import { PlanSelectionModal } from '@/components/billing/pricing/plan-selection-modal';
 import { Suspense } from 'react';
+import { ProfilePictureProvider } from '@/hooks/profile/use-profile-picture';
 
 
 export const viewport: Viewport = {
@@ -204,11 +205,13 @@ export default function RootLayout({
         >
           <AuthProvider>
             <ReactQueryProvider>
-              {children}
-              <Toaster />
-              <Suspense fallback={null}>
-                <PlanSelectionModal />
-              </Suspense>
+              <ProfilePictureProvider>
+                {children}
+                <Toaster />
+                <Suspense fallback={null}>
+                  <PlanSelectionModal />
+                </Suspense>
+              </ProfilePictureProvider>
             </ReactQueryProvider>
           </AuthProvider>
           <Analytics />

--- a/frontend/src/hooks/profile/use-profile-picture.tsx
+++ b/frontend/src/hooks/profile/use-profile-picture.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import { createContext, useContext, ReactNode } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { backendApi } from '@/lib/api-client';
+import { createClient } from '@/lib/supabase/client';
+import { toast } from 'sonner';
+
+interface ProfilePictureApiResponse {
+  success: boolean;
+  profile_picture_url: string | null;
+}
+
+type ProfilePictureContextValue = {
+  profilePictureUrl: string | null;
+  isLoading: boolean;
+  uploadProfilePicture: (file: File) => Promise<ProfilePictureApiResponse>;
+  deleteProfilePicture: () => Promise<ProfilePictureApiResponse | undefined>;
+  isUploading: boolean;
+  isDeleting: boolean;
+  refetch: () => Promise<any>;
+};
+
+const ProfilePictureContext = createContext<ProfilePictureContextValue | undefined>(undefined);
+
+export function ProfilePictureProvider({ children }: { children: ReactNode }) {
+  const queryClient = useQueryClient();
+  const supabase = createClient();
+
+  const profilePictureQuery = useQuery({
+    queryKey: ['profile', 'picture'],
+    queryFn: async (): Promise<string | null> => {
+      const response = await backendApi.get<ProfilePictureApiResponse>('/users/profile-picture', {
+        showErrors: false,
+      });
+
+      if (response.error) {
+        throw new Error(response.error.message || 'Failed to load profile picture');
+      }
+
+      return response.data?.profile_picture_url ?? null;
+    },
+  });
+
+  const refreshSession = async () => {
+    try {
+      await supabase.auth.refreshSession();
+    } catch (error) {
+      console.error('Failed to refresh session after profile update', error);
+    }
+  };
+
+  const uploadMutation = useMutation({
+    mutationFn: async (file: File) => {
+      const formData = new FormData();
+      formData.append('file', file);
+
+      const response = await backendApi.upload<ProfilePictureApiResponse>(
+        '/users/profile-picture',
+        formData,
+        { showErrors: true }
+      );
+
+      if (response.error || !response.data) {
+        throw new Error(response.error?.message || 'Failed to upload profile picture');
+      }
+
+      return response.data;
+    },
+    onSuccess: async (data) => {
+      await refreshSession();
+      queryClient.setQueryData(['profile', 'picture'], data?.profile_picture_url ?? null);
+      toast.success('Profile picture updated');
+    },
+    onError: (error: any) => {
+      toast.error(error?.message || 'Failed to upload profile picture');
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: async () => {
+      const response = await backendApi.delete<ProfilePictureApiResponse>(
+        '/users/profile-picture',
+        { showErrors: true }
+      );
+
+      if (response.error) {
+        throw new Error(response.error.message || 'Failed to delete profile picture');
+      }
+
+      return response.data;
+    },
+    onSuccess: async (data) => {
+      await refreshSession();
+      queryClient.setQueryData(['profile', 'picture'], data?.profile_picture_url ?? null);
+      toast.success('Profile picture removed');
+    },
+    onError: (error: any) => {
+      toast.error(error?.message || 'Failed to delete profile picture');
+    },
+  });
+
+  const value: ProfilePictureContextValue = {
+    profilePictureUrl: profilePictureQuery.data ?? null,
+    isLoading: profilePictureQuery.isLoading,
+    uploadProfilePicture: uploadMutation.mutateAsync,
+    deleteProfilePicture: deleteMutation.mutateAsync,
+    isUploading: uploadMutation.isPending,
+    isDeleting: deleteMutation.isPending,
+    refetch: profilePictureQuery.refetch,
+  };
+
+  return (
+    <ProfilePictureContext.Provider value={value}>
+      {children}
+    </ProfilePictureContext.Provider>
+  );
+}
+
+export function useProfilePicture() {
+  const context = useContext(ProfilePictureContext);
+  if (!context) {
+    throw new Error('useProfilePicture must be used within a ProfilePictureProvider');
+  }
+  return context;
+}
+


### PR DESCRIPTION
## Summary
- add backend endpoints + Supabase storage helpers for profile pictures
- build React hook/context + settings modal UI with deferred save logic
- update sidebar + app layout to consume shared profile picture state

Add the below bucket in the supabase to make this work.
<img width="1021" height="1488" alt="image" src="https://github.com/user-attachments/assets/3052d052-2561-40b8-ad12-59dfea5d53e8" />


https://github.com/user-attachments/assets/121194d6-3e53-4e13-b815-880846366aa5

This PR fixes #1928 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds profile picture upload/delete API with Supabase storage and integrates a React provider to manage and display user avatars in settings and the sidebar.
> 
> - **Backend**:
>   - **API**: Add `GET/POST/DELETE /users/profile-picture` in `core/user_profile.py` (JWT-protected) with size/type validation and metadata updates (`avatar_url`, `profile_picture_path`).
>   - **Storage**: Add `upload_user_profile_picture(...)` in `core/utils/s3_upload_utils.py` to upload to `user-profile-pictures/USER_ID/...`, return public URL + storage path, and remove prior image.
>   - **Routing**: Include `user_profile_router` in `core/api.py`.
> - **Frontend**:
>   - **State/Hook**: Introduce `ProfilePictureProvider` and `useProfilePicture` (`frontend/src/hooks/profile/use-profile-picture.tsx`) using React Query to load/upload/delete via backend and refresh Supabase session.
>   - **App Integration**: Wrap app with `ProfilePictureProvider` in `src/app/layout.tsx`.
>   - **Settings UI**: Update `UserSettingsModal` (General tab) to preview, upload, and defer-remove profile pictures with validation and loading states.
>   - **Sidebar**: Use shared `profilePictureUrl` to render user avatar in `sidebar-left.tsx`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6efc0fd6f6a9d2fe6b2b8c49ac2217cc0cf6b5af. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->