### PR TITLE
fix: support chained method calls in Langfuse mock objects

### DIFF
--- a/backend/core/services/langfuse.py
+++ b/backend/core/services/langfuse.py
@@ -111,6 +111,10 @@ if enabled:
                 def __init__(self): 
                     self.id = "mock-trace-id"
                 
+                # Ensure chained calls like trace.span(...).end(...) are safe no-ops
+                def span(self, **kwargs):
+                    return MockSpan()
+                
                 def __getattr__(self, name):
                     # Return a no-op function for any method call
                     def no_op(*args, **kwargs):
@@ -154,6 +158,10 @@ else:
     class MockTrace:
         def __init__(self): 
             self.id = "mock-trace-id"
+        
+        # Ensure chained calls like trace.span(...).end(...) are safe no-ops
+        def span(self, **kwargs):
+            return MockSpan()
         
         def __getattr__(self, name):
             # Return a no-op function for any method call


### PR DESCRIPTION
When Langfuse is disabled (missing credentials), the application crashes on chained method calls:
```python
trace.span(name="agent_run_stopped").end(status_message="...", level="WARNING")
```

- Add span() method to MockTrace to support trace.span().end() chaining
- Prevents crashes when Langfuse is disabled or not configured

Testing
- Verified application starts without Langfuse credentials
- Confirmed chained method calls execute without errors
- No impact when Langfuse is properly configured

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements MockTrace.span() returning MockSpan so chained trace.span(...).end(...) works in disabled/fallback Langfuse modes.
> 
> - **Backend**:
>   - **Langfuse mock behavior**: In `backend/core/services/langfuse.py`, add `MockTrace.span()` returning `MockSpan` to support chained calls like `trace.span(...).end(...)`.
>     - Applied in both fallback mock (initialization failure) and disabled mock (missing credentials) code paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a60b6fcdd3473399070cc4769a2b31f1e2122d93. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->