### PR TITLE
fix: supabase ERROR: function uuid_generate_v4() does not exist (SQLSTATE 42883)

### DIFF
--- a/backend/supabase/migrations/20251126075301_notifications.sql
+++ b/backend/supabase/migrations/20251126075301_notifications.sql
@@ -8,7 +8,7 @@ CREATE TABLE IF NOT EXISTS notification_settings (
 );
 
 CREATE TABLE IF NOT EXISTS device_tokens (
-    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    id UUID PRIMARY KEY DEFAULT extensions.uuid_generate_v4(),
     user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
     device_token TEXT NOT NULL,
     device_type TEXT NOT NULL,


### PR DESCRIPTION
Fixes issue #2188 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch `device_tokens.id` default to `extensions.uuid_generate_v4()` to resolve missing function error.
> 
> - **Database (Supabase migration `backend/supabase/migrations/20251126075301_notifications.sql`)**:
>   - Update `device_tokens.id` default from `uuid_generate_v4()` to `extensions.uuid_generate_v4()` to use the extension-qualified function.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ce756c1031d9800d406aff171c3f52e6f8415cbe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->