### PR TITLE
Fix: Implement RFC5987-compliant Content-Disposition headers for Unicode filenames

### DIFF
--- a/backend/core/sandbox/docker/html_to_docx_router.py
+++ b/backend/core/sandbox/docker/html_to_docx_router.py
@@ -9,6 +9,7 @@ from io import BytesIO
 
 from fastapi import APIRouter, HTTPException
 from fastapi.responses import Response
+from urllib.parse import quote
 from pydantic import BaseModel, Field
 
 try:
@@ -265,10 +266,11 @@ async def convert_document_to_docx(request: ConvertRequest):
         if request.download:
             docx_content, doc_name = await converter.convert_to_docx(store_locally=False)
             
+            encoded_filename = quote(f"{doc_name}.docx", safe="")
             return Response(
                 content=docx_content,
                 media_type="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-                headers={"Content-Disposition": f"attachment; filename=\"{doc_name}.docx\""}
+                headers={"Content-Disposition": f"attachment; filename*=UTF-8''{encoded_filename}"}
             )
         
         # Otherwise, store locally and return JSON with download URL

--- a/backend/core/sandbox/docker/html_to_pdf_router.py
+++ b/backend/core/sandbox/docker/html_to_pdf_router.py
@@ -13,6 +13,7 @@ import tempfile
 
 from fastapi import APIRouter, HTTPException
 from fastapi.responses import Response
+from urllib.parse import quote
 from pydantic import BaseModel, Field
 
 try:
@@ -288,10 +289,11 @@ async def convert_presentation_to_pdf(request: ConvertRequest):
             
             print(f"✨ Direct download conversion completed for: {presentation_name}")
             
+            encoded_filename = quote(f"{presentation_name}.pdf", safe="")
             return Response(
                 content=pdf_content,
                 media_type="application/pdf",
-                headers={"Content-Disposition": f"attachment; filename=\"{presentation_name}.pdf\""}
+                headers={"Content-Disposition": f"attachment; filename*=UTF-8''{encoded_filename}"}
             )
         
         # Otherwise, store locally and return JSON with download URL

--- a/backend/core/sandbox/docker/html_to_pptx_router.py
+++ b/backend/core/sandbox/docker/html_to_pptx_router.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass
 
 from fastapi import APIRouter, HTTPException
 from fastapi.responses import Response
+from urllib.parse import quote
 from pydantic import BaseModel, Field
 
 try:
@@ -1524,10 +1525,11 @@ async def convert_presentation_to_pptx(request: ConvertRequest):
         if request.download:
             pptx_content, total_slides, presentation_name = await converter.convert_to_pptx(store_locally=False)
             
+            encoded_filename = quote(f"{presentation_name}.pptx", safe="")
             return Response(
                 content=pptx_content,
                 media_type="application/vnd.openxmlformats-officedocument.presentationml.presentation",
-                headers={"Content-Disposition": f"attachment; filename=\"{presentation_name}.pptx\""}
+                headers={"Content-Disposition": f"attachment; filename*=UTF-8''{encoded_filename}"}
             )
         
         # Otherwise, store locally and return JSON with download URL

--- a/backend/core/templates/presentations_api.py
+++ b/backend/core/templates/presentations_api.py
@@ -4,6 +4,7 @@ API endpoints for serving presentation template static files (images, PDFs).
 import os
 from fastapi import APIRouter, HTTPException
 from fastapi.responses import FileResponse
+from urllib.parse import quote
 
 from core.utils.logger import logger
 
@@ -64,10 +65,11 @@ async def get_presentation_template_pdf(template_name: str):
         
         pdf_path = os.path.join(pdf_folder, pdf_files[0])
         
+        encoded_filename = quote(f"{template_name}.pdf", safe="")
         return FileResponse(
             pdf_path,
             media_type="application/pdf",
-            headers={"Content-Disposition": f"inline; filename={template_name}.pdf"}
+            headers={"Content-Disposition": f"inline; filename*=UTF-8''{encoded_filename}"}
         )
     except HTTPException:
         raise

--- a/backend/core/tools/sb_presentation_tool.py
+++ b/backend/core/tools/sb_presentation_tool.py
@@ -9,6 +9,7 @@ from datetime import datetime
 import re
 import asyncio
 import httpx
+from urllib.parse import unquote
 
 @tool_metadata(
     display_name="Presentations",
@@ -1109,7 +1110,12 @@ print(json.dumps(result))
                     
                     # Extract filename from Content-Disposition if available
                     content_disposition = convert_response.headers.get("Content-Disposition", "")
-                    if "filename=" in content_disposition:
+                    if "filename*=UTF-8''" in content_disposition:
+                        # RFC5987 format: filename*=UTF-8''encoded_name
+                        encoded_name = content_disposition.split("filename*=UTF-8''")[1].split(';')[0]
+                        filename = unquote(encoded_name)
+                    elif 'filename="' in content_disposition:
+                        # Legacy format: filename="name"
                         filename = content_disposition.split('filename="')[1].split('"')[0]
                     
                     return self.success_response({
@@ -1210,7 +1216,12 @@ print(json.dumps(result))
                     
                     # Extract filename from Content-Disposition if available
                     content_disposition = convert_response.headers.get("Content-Disposition", "")
-                    if "filename=" in content_disposition:
+                    if "filename*=UTF-8''" in content_disposition:
+                        # RFC5987 format: filename*=UTF-8''encoded_name
+                        encoded_name = content_disposition.split("filename*=UTF-8''")[1].split(';')[0]
+                        filename = unquote(encoded_name)
+                    elif 'filename="' in content_disposition:
+                        # Legacy format: filename="name"
                         filename = content_disposition.split('filename="')[1].split('"')[0]
                     
                     return self.success_response({


### PR DESCRIPTION
Resolves file download errors that occurred when filenames contained Unicode characters (e.g., Chinese, Japanese) in sandbox document conversion endpoints (DOCX, PPTX, PDF).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Standardizes download headers to RFC5987 and updates clients to parse UTF-8 filenames across DOCX/PPTX/PDF conversions and template PDFs.
> 
> - **Sandbox Converters**:
>   - `sandbox/docker/html_to_docx_router.py`, `html_to_pdf_router.py`, `html_to_pptx_router.py`: set `Content-Disposition` using RFC5987 (`filename*=UTF-8''...`) with URL-encoded filenames.
> - **Templates**:
>   - `templates/presentations_api.py`: serve template PDFs with `Content-Disposition: inline; filename*=UTF-8''...`.
> - **Google Integrations**:
>   - `google/google_docs_api.py`, `google/google_slides_api.py`: extract filenames from `Content-Disposition` supporting RFC5987 (`filename*`) with fallback to legacy `filename`.
> - **Tools**:
>   - `tools/sb_presentation_tool.py`: parse `Content-Disposition` for RFC5987 `filename*` (fallback to legacy) when handling direct PPTX/PDF responses.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b00b431c4d9c6d978b0d6e2730cf048cb95b74bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->