### PR TITLE
feat: update sandbox docker version for RFC5987-compliant Content-Dis…

### DIFF
--- a/backend/core/sandbox/README.md
+++ b/backend/core/sandbox/README.md
@@ -20,7 +20,7 @@ You can modify the sandbox environment for development or to add new capabilitie
    ```
    cd backend/sandbox/docker
    docker compose build
-   docker push kortix/suna:0.1.3.25
+   docker push kortix/suna:0.1.3.26
    ```
 3. Test your changes locally using docker-compose
 

--- a/backend/core/sandbox/docker/docker-compose.yml
+++ b/backend/core/sandbox/docker/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       dockerfile: ${DOCKERFILE:-Dockerfile}
       args:
         TARGETPLATFORM: ${TARGETPLATFORM:-linux/amd64}
-    image: kortix/suna:0.1.3.25
+    image: kortix/suna:0.1.3.26
     ports:
       - "6080:6080"  # noVNC web interface
       - "5901:5901"  # VNC port

--- a/backend/core/utils/config.py
+++ b/backend/core/utils/config.py
@@ -379,8 +379,8 @@ class Configuration:
     STRIPE_PRODUCT_ID_STAGING: Optional[str] = 'prod_SCgIj3G7yPOAWY'
     
     # Sandbox configuration
-    SANDBOX_IMAGE_NAME = "kortix/suna:0.1.3.25"
-    SANDBOX_SNAPSHOT_NAME = "kortix/suna:0.1.3.25"
+    SANDBOX_IMAGE_NAME = "kortix/suna:0.1.3.26"
+    SANDBOX_SNAPSHOT_NAME = "kortix/suna:0.1.3.26"
     SANDBOX_ENTRYPOINT = "/usr/bin/supervisord -n -c /etc/supervisor/conf.d/supervisord.conf"
     
     # Debug configuration

--- a/setup.py
+++ b/setup.py
@@ -1046,9 +1046,9 @@ class SetupWizard:
         )
         print_info("Create a snapshot with these exact settings:")
         print_info(
-            f"   - Name:\t\t{Colors.GREEN}kortix/suna:0.1.3.25{Colors.ENDC}")
+            f"   - Name:\t\t{Colors.GREEN}kortix/suna:0.1.3.26{Colors.ENDC}")
         print_info(
-            f"   - Snapshot name:\t{Colors.GREEN}kortix/suna:0.1.3.25{Colors.ENDC}")
+            f"   - Snapshot name:\t{Colors.GREEN}kortix/suna:0.1.3.26{Colors.ENDC}")
         print_info(
             f"   - Entrypoint:\t{Colors.GREEN}/usr/bin/supervisord -n -c /etc/supervisor/conf.d/supervisord.conf{Colors.ENDC}"
         )


### PR DESCRIPTION
update sandbox docker version for RFC5987-compliant Content-Disposition headers to properly handle Unicode characters

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates sandbox Docker image and Daytona snapshot references from 0.1.3.25 to 0.1.3.26 across config, compose, docs, and setup instructions.
> 
> - **Sandbox version bump to `0.1.3.26`**
>   - `backend/core/sandbox/docker/docker-compose.yml`: set `image` to `kortix/suna:0.1.3.26`.
>   - `backend/core/utils/config.py`: update `SANDBOX_IMAGE_NAME` and `SANDBOX_SNAPSHOT_NAME` to `kortix/suna:0.1.3.26`.
>   - `setup.py`: adjust Daytona snapshot name instructions to `kortix/suna:0.1.3.26`.
>   - `backend/core/sandbox/README.md`: update `docker push` tag to `0.1.3.26`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f1e93c7c49aff853f094fb8a55007ca33d436a42. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->