### PR TITLE
fix: selecting and ui improvements

### DIFF
--- a/apps/mobile/components/chat/ChatInput.tsx
+++ b/apps/mobile/components/chat/ChatInput.tsx
@@ -269,12 +269,12 @@ export const ChatInput = React.memo(React.forwardRef<ChatInputRef, ChatInputProp
       onCancelRecording?.();
       return;
     }
-    
+
     if (!onSendAudio) {
       console.error('❌ onSendAudio handler is not provided');
       return;
     }
-    
+
     try {
       console.log('📤 ChatInput: Calling onSendAudio handler');
       await onSendAudio();
@@ -334,7 +334,7 @@ export const ChatInput = React.memo(React.forwardRef<ChatInputRef, ChatInputProp
 
   // Determine button icon
   const ButtonIcon = React.useMemo(() => {
-    if (isAgentRunning) return Square;
+    if (isAgentRunning) return StopIcon;
     if (hasContent) return CornerDownLeft;
     return AudioLines;
   }, [isAgentRunning, hasContent]);
@@ -489,7 +489,7 @@ interface NormalModeProps {
   isSendingMessage: boolean;
   isTranscribing: boolean;
   isAgentRunning: boolean;
-  ButtonIcon: typeof Square | typeof CornerDownLeft | typeof AudioLines;
+  ButtonIcon: React.ComponentType<any>;
   buttonIconSize: number;
   buttonIconClass: string;
   isAuthenticated: boolean;
@@ -585,9 +585,9 @@ const NormalMode = React.memo(({
       </View>
 
       <View className="flex-row items-center gap-2">
-        <AgentSelector 
-          onPress={onAgentPress} 
-          compact={false} 
+        <AgentSelector
+          onPress={onAgentPress}
+          compact={false}
         />
 
         <AnimatedPressable
@@ -603,7 +603,11 @@ const NormalMode = React.memo(({
               <Icon as={Loader2} size={16} className="text-primary-foreground" strokeWidth={2} />
             </AnimatedView>
           ) : (
-            <Icon as={ButtonIcon} size={buttonIconSize} className={buttonIconClass} strokeWidth={2} />
+            ButtonIcon === StopIcon ? (
+              <StopIcon size={buttonIconSize} className={buttonIconClass} />
+            ) : (
+              <Icon as={ButtonIcon as any} size={buttonIconSize} className={buttonIconClass} strokeWidth={2} />
+            )
           )}
         </AnimatedPressable>
       </View>

--- a/apps/mobile/components/chat/FileAttachmentRenderer.tsx
+++ b/apps/mobile/components/chat/FileAttachmentRenderer.tsx
@@ -222,7 +222,7 @@ function ImageAttachment({
         }}
         onPress={handlePress}
         style={[animatedStyle, showPreview ? { width: '100%' } : undefined]}
-        className="rounded-2xl overflow-hidden border border-border bg-card"
+        className="rounded-3xl overflow-hidden border border-border bg-card"
       >
         <View style={{ width: showPreview ? '100%' : containerWidth, height: containerHeight }}>
           {!hasError && !shouldWaitForBlob ? (
@@ -472,9 +472,9 @@ function DocumentAttachment({
       }}
       onPress={handlePress}
       style={animatedStyle}
-      className="flex-row items-center bg-muted/30 rounded-2xl px-3 py-3 border border-border/30 mb-2 active:bg-muted/50"
+      className="flex-row items-center gap-2 px-4 py-2 rounded-3xl bg-card border border-border mb-2 active:bg-muted/50"
     >
-      <View className="bg-primary/10 rounded-2xl p-2 mr-3">
+      <View className="h-8 w-8 rounded-xl items-center justify-center border border-border mr-3 bg-background">
         <Icon
           as={FileText}
           size={compact ? 18 : 20}
@@ -497,12 +497,14 @@ function DocumentAttachment({
         )}
       </View>
 
-      <Icon
-        as={ExternalLink}
-        size={16}
-        className="text-muted-foreground ml-2"
-        strokeWidth={2}
-      />
+      <View className="h-8 w-8 rounded-xl items-center justify-center bg-background ml-3">
+        <Icon
+          as={ExternalLink}
+          size={16}
+          className="text-muted-foreground"
+          strokeWidth={2}
+        />
+      </View>
     </AnimatedPressable>
   );
 }
@@ -541,9 +543,9 @@ function GenericAttachment({
       }}
       onPress={handlePress}
       style={animatedStyle}
-      className="flex-row items-center bg-muted/30 rounded-2xl px-3 py-3 border border-border/30 mb-2 active:bg-muted/50"
+      className="flex-row items-center gap-2 px-4 py-2 rounded-3xl bg-card border border-border mb-2 active:bg-muted/50"
     >
-      <View className="bg-muted rounded-2xl p-2 mr-3">
+      <View className="h-8 w-8 rounded-xl items-center justify-center border border-border mr-3 bg-background">
         <Icon
           as={File}
           size={compact ? 18 : 20}
@@ -566,12 +568,14 @@ function GenericAttachment({
         )}
       </View>
 
-      <Icon
-        as={Download}
-        size={16}
-        className="text-muted-foreground ml-2"
-        strokeWidth={2}
-      />
+      <View className="h-8 w-8 rounded-xl items-center justify-center bg-background ml-3">
+        <Icon
+          as={Download}
+          size={16}
+          className="text-muted-foreground"
+          strokeWidth={2}
+        />
+      </View>
     </AnimatedPressable>
   );
 }

--- a/apps/mobile/components/chat/ThreadContent.tsx
+++ b/apps/mobile/components/chat/ThreadContent.tsx
@@ -869,7 +869,7 @@ export const ThreadContent: React.FC<ThreadContentProps> = React.memo(({
                       )}
 
                       {linkedTools && linkedTools.length > 0 && (
-                        <View className="gap-2 mt-3">
+                        <View className="gap-1 mt-2">
                           {linkedTools.map((toolMsg: UnifiedMessage, toolIdx: number) => {
                             const handlePress = () => {
                               const clickedIndex = allToolMessages.findIndex(
@@ -894,7 +894,7 @@ export const ThreadContent: React.FC<ThreadContentProps> = React.memo(({
 
                 {/* Render streaming text content (XML tool calls or regular text) */}
                 {groupIndex === groupedMessages.length - 1 && (streamHookStatus === 'streaming' || streamHookStatus === 'connecting') && streamingTextContent && (
-                  <View className="mt-3">
+                  <View className="mt-2">
                     {(() => {
                       const rawContent = streamingTextContent || '';
 
@@ -976,7 +976,7 @@ export const ThreadContent: React.FC<ThreadContentProps> = React.memo(({
                       const textToShow = askCompleteText || (toolName === 'ask' ? 'Asking...' : 'Completing...');
 
                       return (
-                        <View className="mt-3">
+                        <View className="mt-2">
                           <Markdown
                             style={colorScheme === 'dark' ? markdownStylesDark : markdownStyles}
                             rules={selectableRenderRules}
@@ -1041,7 +1041,7 @@ export const ThreadContent: React.FC<ThreadContentProps> = React.memo(({
                   !streamingTextContent &&
                   !streamingToolCall &&
                   (streamHookStatus === 'streaming' || streamHookStatus === 'connecting') && (
-                    <View className="mt-3">
+                    <View className="mt-2">
                       <AgentLoader />
                     </View>
                   )}

--- a/apps/mobile/components/ui/StopIcon.tsx
+++ b/apps/mobile/components/ui/StopIcon.tsx
@@ -10,8 +10,8 @@ interface StopIconProps extends SvgProps {
 const StopIconBase = ({ size = 24, ...props }: StopIconProps) => {
     return (
         <Svg
-            width={size}
-            height={size}
+            width={24}
+            height={24}
             viewBox="0 0 24 24"
             fill="none"
             {...props}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improves markdown text selection and link overlays, switches the chat action to a dedicated stop icon when agent is running, and updates attachment cards’ styling with refined spacing and visuals.
> 
> - **Chat Input**:
>   - Use `StopIcon` instead of `Square` when `isAgentRunning`; adjust icon typing/rendering to support custom component.
> - **Markdown Rendering/Selection** (`markdown-styles.tsx`):
>   - Rework `SelectableText` to better match text wrapping (bold/heading detection, measured overlay height) and maintain clickable links via precise overlays.
>   - Tweak list/link styles for alignment (top-aligned bullets, adjusted margins) and consistent typography.
> - **Attachments UI** (`FileAttachmentRenderer.tsx`):
>   - Update card visuals (rounded-3xl, borders/backgrounds, icon containers) for image, document, and generic files; move action icons into compact rounded buttons.
> - **Thread View Spacing** (`ThreadContent.tsx`):
>   - Reduce gaps/margins around linked tool cards, streaming text, and loaders for tighter layout.
> - **Icons** (`StopIcon.tsx`):
>   - Define `StopIcon` SVG with fixed 24x24 size; enable className color via `cssInterop`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 42f1a49b4dbecc9d522b715e89a544d1694f0229. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->