### PR TITLE
inc retries

### DIFF
--- a/backend/core/services/llm.py
+++ b/backend/core/services/llm.py
@@ -24,9 +24,9 @@ from datetime import datetime, timezone
 litellm.modify_params = True
 litellm.drop_params = True
 
-# CRITICAL: Disable all LiteLLM internal retries to prevent infinite loops on 400 errors
-# We handle retries at our own layer (auto-continue) with proper error checking
-litellm.num_retries = 0
+# Configure LiteLLM retries for transient errors (rate limits, server errors)
+# Note: 400 Bad Request errors are handled separately and should not retry
+litellm.num_retries = 3
 
 # Enable additional debug logging
 # import logging
@@ -162,7 +162,7 @@ def setup_provider_router(openai_compatible_api_key: str = None, openai_compatib
     # EXCEPTION: ContextWindowExceededError is a special case where fallback to larger context models is appropriate
     provider_router = Router(
         model_list=model_list,
-        num_retries=0,  # CRITICAL: Disable all router-level retries to prevent infinite loops
+        num_retries=3,  # Retry transient errors (rate limits, server errors)
         fallbacks=fallbacks,
         context_window_fallbacks=context_window_fallbacks,  # Handle context window exceeded errors
         # Only use fallbacks for rate limits (429) and server errors (5xx), NOT client errors (4xx)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Increase LiteLLM and Router retry counts from 0 to 3 to handle transient 429/5xx errors while excluding 400s.
> 
> - **Backend**:
>   - **LLM service (`backend/core/services/llm.py`)**:
>     - Set `litellm.num_retries = 3` for transient error retries.
>     - Configure `Router(..., num_retries=3, ...)` to retry rate limits/server errors; preserve existing fallbacks and context-window handling; 400 errors remain non-retryable.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a5f5a7f9854faf3c20d49337569022974b19646d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->