### PR TITLE
fix: Prevent MCP tool name collision with built-in AgentPress tools

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -28,6 +28,7 @@ share/python-wheels/
 *.egg
 MANIFEST
 node_modules/
+debug_streams/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/backend/core/agentpress/tool_registry.py
+++ b/backend/core/agentpress/tool_registry.py
@@ -94,9 +94,11 @@ class ToolRegistry:
         # Get OpenAPI tool functions
         for tool_name, tool_info in self.tools.items():
             tool_instance = tool_info['instance']
-            function_name = tool_name
-            function = getattr(tool_instance, function_name)
-            available_functions[function_name] = function
+            # Use stored method_name if available (for renamed MCP tools with collisions)
+            # Otherwise fall back to the registration name
+            method_name = tool_info.get('method_name', tool_name)
+            function = getattr(tool_instance, method_name)
+            available_functions[tool_name] = function  # Key is registration name
             
         # logger.debug(f"Retrieved {len(available_functions)} available functions")
         return available_functions

--- a/backend/core/tools/utils/dynamic_tool_builder.py
+++ b/backend/core/tools/utils/dynamic_tool_builder.py
@@ -65,18 +65,25 @@ class DynamicToolBuilder:
         return tool_data
     
     def _parse_tool_name(self, tool_name: str) -> tuple[str, str, str]:
-        """Parse tool name and extract server info, but KEEP the full name to prevent collisions."""
-        # Extract server_name for description purposes only
+        """Parse tool name to extract stripped name and server info.
+        
+        Returns:
+            tuple: (method_name, clean_tool_name, server_name)
+        """
         if tool_name.startswith("custom_"):
             parts = tool_name.split("_")
-            server_name = parts[1] if len(parts) > 1 else "unknown"
+            if len(parts) >= 3:
+                clean_tool_name = "_".join(parts[2:])
+                server_name = parts[1] if len(parts) > 1 else "unknown"
+            else:
+                clean_tool_name = tool_name
+                server_name = "unknown"
         else:
             parts = tool_name.split("_", 2)
+            clean_tool_name = parts[2] if len(parts) > 2 else tool_name
             server_name = parts[1] if len(parts) > 1 else "unknown"
         
-        # KEEP the full tool name - don't strip prefix to prevent collision with built-in tools
-        method_name = tool_name.replace('-', '_')
-        clean_tool_name = tool_name
+        method_name = clean_tool_name.replace('-', '_')
         return method_name, clean_tool_name, server_name
     
     def _build_description(self, tool_info: Dict[str, Any], server_name: str) -> str:


### PR DESCRIPTION
# PR: fix: Prevent MCP tool name collision with built-in AgentPress tools

## Summary

Fixes silent overwriting of built-in AgentPress tools when MCP tools have colliding method names.

## Problem

MCP tools were silently overwriting built-in tools when their stripped names collided. For example:
- MCP tool `custom_github_web_search` stripped to `web_search`
- Built-in `web_search` (Tavily) was silently overwritten
- No warning raised, causing non-deterministic behavior across Dramatiq workers

## Root Cause

1. Method name stripping: `custom_github_web_search` → `web_search`
2. Direct dictionary assignment without collision check

## Solution

When a collision is detected, the MCP tool is registered with a `custom_mcp_` prefix:

```python
if method_name in self.thread_manager.tool_registry.tools:
    registration_name = f"custom_mcp_{method_name}"
```

## Result

| Scenario | Registered Name | Tool Instance |
|----------|-----------------|---------------|
| Built-in | `web_search` | SandboxWebSearchTool ✅ |
| MCP (collision) | `custom_mcp_web_search` | MCPToolWrapper ✅ |
| MCP (no collision) | `send_email` | MCPToolWrapper ✅ |

## Files Changed

- `backend/core/run.py` - Collision detection with `custom_mcp_` prefix
- `backend/core/agentpress/tool_registry.py` - Support for `method_name` lookup

## Testing

- Built-in tools are preserved and accessible
- MCP tools with colliding names are renamed with `custom_mcp_` prefix
- Both tool types work correctly
- No silent overwrites


### SYSTEM PROMPT (before) :
collides with default web_search tool
<img width="604" height="261" alt="image" src="https://github.com/user-attachments/assets/cdb89f20-c078-4ff1-87c4-b27e3a1b417f" />

### SYSTEM PROMPT (after) :
renames and adds
<img width="611" height="250" alt="image" src="https://github.com/user-attachments/assets/5c39ee44-ba4f-42c9-a13d-247f58f024f5" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Detect and avoid MCP tool name collisions by prefixing registration names and syncing schema function names, with registry lookup and prompt listing updated to use the correct method names.
> 
> - **MCP tool registration (collision handling)**:
>   - Check for name collisions against `ToolRegistry.tools`; on conflict, register as `custom_mcp_{method_name}` and log.
>   - Update OpenAPI `schema['function']['name']` to the new registration name.
>   - Store original `method_name` with each tool entry for accurate method resolution.
> - **Tool lookup and prompt listing**:
>   - `ToolRegistry.get_available_functions` now resolves functions via stored `method_name` while keeping the registration key.
>   - System prompt lists MCP tools using the schema's `function.name` (reflecting any renames).
> - **Dynamic MCP tools**:
>   - Clarify `_parse_tool_name` with a docstring and explicit return contract (no behavior change).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 819369cdbbef37f1356f816458a4e5e0e64fe32e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->