### PR TITLE
Update input field corner radius to 24px and fix tool button styling

### DIFF
--- a/frontend/src/components/thread/chat-input/chat-input.tsx
+++ b/frontend/src/components/thread/chat-input/chat-input.tsx
@@ -159,7 +159,7 @@ const IsolatedTextarea = memo(forwardRef<HTMLTextAreaElement, IsolatedTextareaPr
         onPaste={onPaste}
         placeholder={placeholder}
         className={cn(
-          'w-full bg-transparent dark:bg-transparent border-none shadow-none focus-visible:ring-0 px-0.5 pb-6 pt-4 !text-[15px] min-h-[100px] sm:min-h-[72px] max-h-[200px] overflow-y-auto resize-none',
+          'w-full bg-transparent dark:bg-transparent border-none shadow-none focus-visible:ring-0 px-0.5 pb-6 pt-4 !text-[15px] min-h-[100px] sm:min-h-[72px] max-h-[200px] overflow-y-auto resize-none rounded-[24px]',
           isDraggingOver ? 'opacity-40' : '',
         )}
         disabled={disabled && !isAgentRunning}
@@ -1281,7 +1281,7 @@ export const ChatInput = memo(forwardRef<ChatInputHandles, ChatInputProps>(
             }}
           >
             <div className="w-full text-sm flex flex-col justify-between items-start rounded-lg">
-              <CardContent className={`w-full p-1.5 pb-2 ${bgColor} border rounded-2xl`}>
+              <CardContent className={`w-full p-1.5 pb-2 ${bgColor} border rounded-[24px]`}>
                 {(uploadedFiles.length > 0 || isUploading) && (
                   <div className="relative">
                     <AttachmentGroup

--- a/frontend/src/components/thread/content/ShowToolStream.tsx
+++ b/frontend/src/components/thread/content/ShowToolStream.tsx
@@ -359,9 +359,9 @@ export const ShowToolStream: React.FC<ShowToolStreamProps> = ({
         <div className="my-1">
             <button
                 onClick={() => onToolClick?.(messageId, toolName)}
-                className="animate-shimmer inline-flex items-center gap-1.5 py-1 px-1 pr-1.5 text-xs text-muted-foreground bg-muted hover:bg-muted/80 rounded-2xl transition-colors cursor-pointer border border-neutral-200 dark:border-neutral-700/50"
+                className="animate-shimmer inline-flex items-center gap-1.5 py-1 px-1 pr-1.5 text-xs text-muted-foreground bg-card hover:bg-card/80 rounded-2xl transition-colors cursor-pointer border border-neutral-200 dark:border-neutral-700/50 whitespace-nowrap"
             >
-                <div className='border-2 bg-gradient-to-br from-neutral-200 to-neutral-300 dark:from-neutral-700 dark:to-neutral-800 flex items-center justify-center p-0.5 rounded-sm border-neutral-400/20 dark:border-neutral-600'>
+                <div className='flex items-center justify-center'>
                     <CircleDashed className="h-3.5 w-3.5 text-muted-foreground flex-shrink-0 animate-spin animation-duration-2000" />
                 </div>
                 <span className="font-mono text-xs text-foreground">{displayName}</span>

--- a/frontend/src/components/thread/kortix-computer/KortixComputer.tsx
+++ b/frontend/src/components/thread/kortix-computer/KortixComputer.tsx
@@ -1056,7 +1056,7 @@ export const KortixComputer = memo(function KortixComputer({
     }
 
     return (
-      <div className="h-full w-full max-w-full max-h-full overflow-hidden min-w-0 min-h-0" style={{ contain: 'strict' }}>
+      <div className="h-full w-full max-w-full max-h-full overflow-auto min-w-0 min-h-0" style={{ contain: 'layout style' }}>
         <ToolView
           toolCall={displayToolCall.toolCall}
           toolResult={displayToolCall.toolResult}

--- a/frontend/src/components/thread/tool-views/wrapper/ToolViewRegistry.tsx
+++ b/frontend/src/components/thread/tool-views/wrapper/ToolViewRegistry.tsx
@@ -296,9 +296,9 @@ export function ToolView({ toolCall, toolResult, ...props }: ToolViewProps) {
     };
   }
 
-  // Wrap all tool views in a container with strict CSS containment to prevent overflow
+  // Wrap all tool views in a container with CSS containment to prevent overflow
   return (
-    <div className="h-full w-full max-h-full max-w-full overflow-hidden min-w-0 min-h-0" style={{ contain: 'strict' }}>
+    <div className="h-full w-full max-h-full max-w-full overflow-auto min-w-0 min-h-0" style={{ contain: 'layout style' }}>
       <ToolViewComponent toolCall={toolCall} toolResult={modifiedToolResult} {...props} />
     </div>
   );

--- a/frontend/src/hooks/messages/utils/assistant-message-renderer.tsx
+++ b/frontend/src/hooks/messages/utils/assistant-message-renderer.tsx
@@ -163,9 +163,9 @@ function renderRegularToolCall(
     <div key={`tool-${index}`} className="my-1">
       <button
         onClick={() => onToolClick(message.message_id, toolName)}
-        className="inline-flex items-center gap-1.5 py-1 px-1 pr-1.5 text-xs text-muted-foreground bg-muted hover:bg-muted/80 rounded-2xl transition-colors cursor-pointer border border-neutral-200 dark:border-neutral-700/50"
+        className="inline-flex items-center gap-1.5 py-1 px-1 pr-1.5 text-xs text-muted-foreground bg-card hover:bg-card/80 rounded-2xl transition-colors cursor-pointer border border-neutral-200 dark:border-neutral-700/50 whitespace-nowrap"
       >
-        <div className='border-2 bg-gradient-to-br from-neutral-200 to-neutral-300 dark:from-neutral-700 dark:to-neutral-800 flex items-center justify-center p-0.5 rounded-sm border-neutral-400/20 dark:border-neutral-600'>
+        <div className='flex items-center justify-center'>
           <IconComponent className="h-3.5 w-3.5 text-muted-foreground flex-shrink-0" />
         </div>
         <span className="font-mono text-xs text-foreground">{getUserFriendlyToolName(toolName)}</span>


### PR DESCRIPTION
- Changed ChatInput CardContent and Textarea corner radius from rounded-2xl to rounded-[24px]
- Updated tool buttons to use bg-card instead of bg-muted to match Kortix Computer
- Added whitespace-nowrap to prevent text breaking in tool buttons
- Removed background and border from tool button icons
- Fixed ToolView clipping by changing overflow-hidden to overflow-auto and contain:strict to contain:layout style