### PR TITLE
Remove OAuth authorization requirement from apps

### DIFF
--- a/frontend/src/components/agents/composio/composio-connector.tsx
+++ b/frontend/src/components/agents/composio/composio-connector.tsx
@@ -1,15 +1,52 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import { Button } from '@/components/ui/button';
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Alert, AlertDescription } from '@/components/ui/alert';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { ArrowLeft, Check, AlertCircle, Plus, ExternalLink, ChevronRight, Search, Save, Loader2, User, Settings, Info, Eye, Zap, Wrench, X, Shield } from 'lucide-react';
-import { useCreateComposioProfile, useComposioTools, useCheckProfileNameAvailability } from '@/hooks/composio/use-composio';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  ArrowLeft,
+  Check,
+  AlertCircle,
+  Plus,
+  ExternalLink,
+  ChevronRight,
+  Search,
+  Save,
+  Loader2,
+  User,
+  Settings,
+  Info,
+  Eye,
+  Zap,
+  Wrench,
+  X,
+  Shield,
+} from 'lucide-react';
+import {
+  useCreateComposioProfile,
+  useComposioTools,
+  useCheckProfileNameAvailability,
+} from '@/hooks/composio/use-composio';
 import { useComposioProfiles } from '@/hooks/composio/use-composio-profiles';
 import { useComposioToolkitDetails } from '@/hooks/composio/use-composio';
-import type { ComposioToolkit, ComposioProfile, AuthConfigField } from '@/hooks/composio/utils';
+import type {
+  ComposioToolkit,
+  ComposioProfile,
+  AuthConfigField,
+} from '@/hooks/composio/utils';
 import { toast } from 'sonner';
 import { formatDistanceToNow } from 'date-fns';
 import { cn } from '@/lib/utils';
@@ -37,7 +74,7 @@ enum Step {
   ProfileCreate = 'profile-create',
   Connecting = 'connecting',
   ToolsSelection = 'tools-selection',
-  Success = 'success'
+  Success = 'success',
 }
 
 interface StepConfig {
@@ -60,40 +97,52 @@ const stepConfigs: StepConfig[] = [
     id: Step.ProfileCreate,
     title: 'Create Profile',
     icon: <Plus className="h-4 w-4" />,
-    showInProgress: true
+    showInProgress: true,
   },
   {
     id: Step.Connecting,
     title: 'Authenticate',
     icon: <ExternalLink className="h-4 w-4" />,
-    showInProgress: true
+    showInProgress: true,
   },
   {
     id: Step.ToolsSelection,
     title: 'Select Tools',
     icon: <Settings className="h-4 w-4" />,
-    showInProgress: true
+    showInProgress: true,
   },
   {
     id: Step.Success,
     title: 'Complete',
     description: 'Successfully connected',
     icon: <Check className="h-4 w-4" />,
-    showInProgress: false
-  }
+    showInProgress: false,
+  },
 ];
 
 const getStepIndex = (step: Step): number => {
-  return stepConfigs.findIndex(config => config.id === step);
+  return stepConfigs.findIndex((config) => config.id === step);
 };
 
-const StepIndicator = ({ currentStep, mode }: { currentStep: Step; mode: 'full' | 'profile-only' }) => {
+const StepIndicator = ({
+  currentStep,
+  mode,
+}: {
+  currentStep: Step;
+  mode: 'full' | 'profile-only';
+}) => {
   const currentIndex = getStepIndex(currentStep);
-  const visibleSteps = mode === 'profile-only'
-    ? stepConfigs.filter(step => step.id !== Step.ToolsSelection && step.id !== Step.ProfileSelect)
-    : stepConfigs;
+  const visibleSteps =
+    mode === 'profile-only'
+      ? stepConfigs.filter(
+          (step) =>
+            step.id !== Step.ToolsSelection && step.id !== Step.ProfileSelect,
+        )
+      : stepConfigs;
 
-  const visibleCurrentIndex = visibleSteps.findIndex(step => step.id === currentStep);
+  const visibleCurrentIndex = visibleSteps.findIndex(
+    (step) => step.id === currentStep,
+  );
 
   return (
     <div className="px-6 py-3">
@@ -103,9 +152,9 @@ const StepIndicator = ({ currentStep, mode }: { currentStep: Step; mode: 'full' 
           className="absolute left-0 top-[10px] h-[1px] bg-primary -z-10"
           initial={{ width: 0 }}
           animate={{
-            width: `${(visibleCurrentIndex / (visibleSteps.length - 1)) * 100}%`
+            width: `${(visibleCurrentIndex / (visibleSteps.length - 1)) * 100}%`,
           }}
-          transition={{ duration: 0.5, ease: "easeInOut" }}
+          transition={{ duration: 0.5, ease: 'easeInOut' }}
         />
 
         {visibleSteps.map((step, index) => {
@@ -125,11 +174,13 @@ const StepIndicator = ({ currentStep, mode }: { currentStep: Step; mode: 'full' 
               <div className="bg-background p-0.5 rounded-full">
                 <div
                   className={cn(
-                    "w-5 h-5 rounded-full flex items-center justify-center transition-all duration-300 relative",
-                    isCompleted && "bg-primary text-primary-foreground",
-                    isCurrent && "bg-primary text-primary-foreground shadow-lg shadow-primary/25",
-                    isUpcoming && "bg-muted-foreground/20 text-muted-foreground",
-                    isCurrent && "ring-2 ring-primary/20"
+                    'w-5 h-5 rounded-full flex items-center justify-center transition-all duration-300 relative',
+                    isCompleted && 'bg-primary text-primary-foreground',
+                    isCurrent &&
+                      'bg-primary text-primary-foreground shadow-lg shadow-primary/25',
+                    isUpcoming &&
+                      'bg-muted-foreground/20 text-muted-foreground',
+                    isCurrent && 'ring-2 ring-primary/20',
                   )}
                 >
                   {isCompleted ? (
@@ -157,9 +208,12 @@ const StepIndicator = ({ currentStep, mode }: { currentStep: Step; mode: 'full' 
   );
 };
 
-
-
-const InitiationFieldInput = ({ field, value, onChange, error }: {
+const InitiationFieldInput = ({
+  field,
+  value,
+  onChange,
+  error,
+}: {
   field: AuthConfigField;
   value: string;
   onChange: (value: string) => void;
@@ -185,7 +239,9 @@ const InitiationFieldInput = ({ field, value, onChange, error }: {
 
   const inputType = getInputType(field.type);
   const isBooleanField = field.type.toLowerCase() === 'boolean';
-  const isNumberField = field.type.toLowerCase() === 'number' || field.type.toLowerCase() === 'double';
+  const isNumberField =
+    field.type.toLowerCase() === 'number' ||
+    field.type.toLowerCase() === 'double';
 
   return (
     <div className="space-y-2">
@@ -215,9 +271,11 @@ const InitiationFieldInput = ({ field, value, onChange, error }: {
           type={inputType}
           value={value}
           onChange={(e) => onChange(e.target.value)}
-          placeholder={field.default || `Enter ${field.displayName.toLowerCase()}`}
-          className={cn(error && "border-destructive focus:border-destructive")}
-          step={isNumberField ? "any" : undefined}
+          placeholder={
+            field.default || `Enter ${field.displayName.toLowerCase()}`
+          }
+          className={cn(error && 'border-destructive focus:border-destructive')}
+          step={isNumberField ? 'any' : undefined}
         />
       )}
 
@@ -239,11 +297,12 @@ const InitiationFieldInput = ({ field, value, onChange, error }: {
 
 import type { ComposioTool } from '@/hooks/composio/utils';
 
-const CUSTOM_OAUTH_REQUIRED_APPS = [
-  'zendesk',
-];
+const CUSTOM_OAUTH_REQUIRED_APPS = ['zendesk'];
 
-const ToolPreviewCard = ({ tool, searchTerm }: {
+const ToolPreviewCard = ({
+  tool,
+  searchTerm,
+}: {
   tool: ComposioTool;
   searchTerm: string;
 }) => {
@@ -252,31 +311,56 @@ const ToolPreviewCard = ({ tool, searchTerm }: {
     const regex = new RegExp(`(${term})`, 'gi');
     const parts = text.split(regex);
     return parts.map((part, index) =>
-      regex.test(part) ?
-        <mark key={index} className="bg-yellow-200 dark:bg-yellow-900 px-0.5">{part}</mark> :
+      regex.test(part) ? (
+        <mark key={index} className="bg-yellow-200 dark:bg-yellow-900 px-0.5">
+          {part}
+        </mark>
+      ) : (
         part
+      ),
     );
   };
 
   // Generate icon based on tool name/category
   const getToolIcon = (toolName: string) => {
     const name = toolName.toLowerCase();
-    if (name.includes('create') || name.includes('add') || name.includes('new')) {
+    if (
+      name.includes('create') ||
+      name.includes('add') ||
+      name.includes('new')
+    ) {
       return <Plus className="w-3 h-3" />;
     }
-    if (name.includes('get') || name.includes('fetch') || name.includes('read') || name.includes('view')) {
+    if (
+      name.includes('get') ||
+      name.includes('fetch') ||
+      name.includes('read') ||
+      name.includes('view')
+    ) {
       return <Eye className="w-3 h-3" />;
     }
-    if (name.includes('update') || name.includes('edit') || name.includes('modify')) {
+    if (
+      name.includes('update') ||
+      name.includes('edit') ||
+      name.includes('modify')
+    ) {
       return <Settings className="w-3 h-3" />;
     }
-    if (name.includes('send') || name.includes('post') || name.includes('message')) {
+    if (
+      name.includes('send') ||
+      name.includes('post') ||
+      name.includes('message')
+    ) {
       return <ChevronRight className="w-3 h-3" />;
     }
     if (name.includes('search') || name.includes('find')) {
       return <Search className="w-3 h-3" />;
     }
-    if (name.includes('user') || name.includes('profile') || name.includes('account')) {
+    if (
+      name.includes('user') ||
+      name.includes('profile') ||
+      name.includes('account')
+    ) {
       return <User className="w-3 h-3" />;
     }
     // Default to first letter of tool name
@@ -293,11 +377,11 @@ const ToolPreviewCard = ({ tool, searchTerm }: {
       title={tool.description} // Show full description on hover
     >
       <div className="flex items-center gap-2">
-        <div className="flex-shrink-0">
-          {getToolIcon(tool.name)}
-        </div>
+        <div className="flex-shrink-0">{getToolIcon(tool.name)}</div>
         <div className="min-w-0 flex-1">
-          <div className="text-xs font-medium truncate">{highlightText(tool.name, searchTerm)}</div>
+          <div className="text-xs font-medium truncate">
+            {highlightText(tool.name, searchTerm)}
+          </div>
           {tool.tags && tool.tags.length > 0 && (
             <div className="text-[10px] text-muted-foreground truncate">
               {tool.tags[0]}
@@ -315,66 +399,75 @@ export const ComposioConnector: React.FC<ComposioConnectorProps> = ({
   onOpenChange,
   onComplete,
   mode = 'full',
-  agentId
+  agentId,
 }) => {
   const [currentStep, setCurrentStep] = useState<Step>(Step.ProfileSelect);
   const [profileName, setProfileName] = useState(`${app.name} Profile`);
   const [selectedProfileId, setSelectedProfileId] = useState<string>('');
   const [createdProfileId, setCreatedProfileId] = useState<string | null>(null);
-  const [selectedProfile, setSelectedProfile] = useState<ComposioProfile | null>(null);
+  const [selectedProfile, setSelectedProfile] =
+    useState<ComposioProfile | null>(null);
   const [redirectUrl, setRedirectUrl] = useState<string | null>(null);
   const [showToolsManager, setShowToolsManager] = useState(false);
-  const [selectedConnectionType, setSelectedConnectionType] = useState<'existing' | 'new' | null>(null);
+  const [selectedConnectionType, setSelectedConnectionType] = useState<
+    'existing' | 'new' | null
+  >(null);
 
-  const [initiationFields, setInitiationFields] = useState<Record<string, string>>({});
-  const [initiationFieldsErrors, setInitiationFieldsErrors] = useState<Record<string, string>>({});
+  const [initiationFields, setInitiationFields] = useState<
+    Record<string, string>
+  >({});
+  const [initiationFieldsErrors, setInitiationFieldsErrors] = useState<
+    Record<string, string>
+  >({});
 
   // Custom OAuth configuration state
   const [useCustomAuth, setUseCustomAuth] = useState(false);
-  const [customAuthConfig, setCustomAuthConfig] = useState<Record<string, string>>({});
-  const [customAuthConfigErrors, setCustomAuthConfigErrors] = useState<Record<string, string>>({});
+  const [customAuthConfig, setCustomAuthConfig] = useState<
+    Record<string, string>
+  >({});
+  const [customAuthConfigErrors, setCustomAuthConfigErrors] = useState<
+    Record<string, string>
+  >({});
 
   const [selectedTools, setSelectedTools] = useState<string[]>([]);
 
-  const { mutate: createProfile, isPending: isCreating } = useCreateComposioProfile();
-  const { data: profiles, isLoading: isLoadingProfiles } = useComposioProfiles();
+  const { mutate: createProfile, isPending: isCreating } =
+    useCreateComposioProfile();
+  const { data: profiles, isLoading: isLoadingProfiles } =
+    useComposioProfiles();
 
-  const { data: toolkitDetails, isLoading: isLoadingToolkitDetails } = useComposioToolkitDetails(
-    app.slug,
-    { enabled: open && currentStep === Step.ProfileCreate }
-  );
+  const { data: toolkitDetails, isLoading: isLoadingToolkitDetails } =
+    useComposioToolkitDetails(app.slug, {
+      enabled: open && currentStep === Step.ProfileCreate,
+    });
 
   // Profile name availability checking
-  const { data: nameAvailability, isLoading: isCheckingName } = useCheckProfileNameAvailability(
-    app.slug,
-    profileName,
-    {
-      enabled: open && currentStep === Step.ProfileCreate && profileName.length > 0,
-      debounceMs: 500
-    }
-  );
+  const { data: nameAvailability, isLoading: isCheckingName } =
+    useCheckProfileNameAvailability(app.slug, profileName, {
+      enabled:
+        open && currentStep === Step.ProfileCreate && profileName.length > 0,
+      debounceMs: 500,
+    });
 
-  const existingProfiles = profiles?.filter(p =>
-    p.toolkit_slug === app.slug && p.is_connected
-  ) || [];
-
-
+  const existingProfiles =
+    profiles?.filter((p) => p.toolkit_slug === app.slug && p.is_connected) ||
+    [];
 
   const [toolsPreviewSearchTerm, setToolsPreviewSearchTerm] = useState('');
-  const { data: toolsResponse, isLoading: isLoadingToolsPreview } = useComposioTools(
-    app.slug,
-    {
+  const { data: toolsResponse, isLoading: isLoadingToolsPreview } =
+    useComposioTools(app.slug, {
       enabled: open && currentStep === Step.ProfileSelect,
-      limit: 50
-    }
-  );
+      limit: 50,
+    });
 
   const availableToolsPreview = toolsResponse?.tools || [];
 
   useEffect(() => {
     if (open) {
       const requiresCustomAuth = CUSTOM_OAUTH_REQUIRED_APPS.includes(app.slug);
-      setCurrentStep(mode === 'profile-only' ? Step.ProfileCreate : Step.ProfileSelect);
+      setCurrentStep(
+        mode === 'profile-only' ? Step.ProfileCreate : Step.ProfileSelect,
+      );
       setProfileName(`${app.name} Profile`);
       setSelectedProfileId('');
       setSelectedProfile(null);
@@ -391,18 +484,17 @@ export const ComposioConnector: React.FC<ComposioConnectorProps> = ({
     }
   }, [open, app.name, app.slug, mode]);
 
-
-
   const handleInitiationFieldChange = (fieldName: string, value: string) => {
-    setInitiationFields(prev => ({ ...prev, [fieldName]: value }));
+    setInitiationFields((prev) => ({ ...prev, [fieldName]: value }));
     if (initiationFieldsErrors[fieldName]) {
-      setInitiationFieldsErrors(prev => ({ ...prev, [fieldName]: '' }));
+      setInitiationFieldsErrors((prev) => ({ ...prev, [fieldName]: '' }));
     }
   };
 
   const validateInitiationFields = (): boolean => {
     const newErrors: Record<string, string> = {};
-    const initiationRequirements = toolkitDetails?.toolkit.connected_account_initiation_fields;
+    const initiationRequirements =
+      toolkitDetails?.toolkit.connected_account_initiation_fields;
 
     if (initiationRequirements?.required) {
       for (const field of initiationRequirements.required) {
@@ -414,9 +506,14 @@ export const ComposioConnector: React.FC<ComposioConnectorProps> = ({
             continue;
           }
 
-          if ((field.type.toLowerCase() === 'number' || field.type.toLowerCase() === 'double') && value) {
+          if (
+            (field.type.toLowerCase() === 'number' ||
+              field.type.toLowerCase() === 'double') &&
+            value
+          ) {
             if (isNaN(Number(value))) {
-              newErrors[field.name] = `${field.displayName} must be a valid number`;
+              newErrors[field.name] =
+                `${field.displayName} must be a valid number`;
               continue;
             }
           }
@@ -433,9 +530,9 @@ export const ComposioConnector: React.FC<ComposioConnectorProps> = ({
   };
 
   const handleCustomAuthFieldChange = (fieldName: string, value: string) => {
-    setCustomAuthConfig(prev => ({ ...prev, [fieldName]: value }));
+    setCustomAuthConfig((prev) => ({ ...prev, [fieldName]: value }));
     if (customAuthConfigErrors[fieldName]) {
-      setCustomAuthConfigErrors(prev => ({ ...prev, [fieldName]: '' }));
+      setCustomAuthConfigErrors((prev) => ({ ...prev, [fieldName]: '' }));
     }
   };
 
@@ -466,15 +563,24 @@ export const ComposioConnector: React.FC<ComposioConnectorProps> = ({
   const handleSaveTools = async () => {
     if (!selectedProfile || !agentId) return;
 
-    const mcpConfigResponse = await composioApi.getMcpConfigForProfile(selectedProfile.profile_id);
-    const response = await backendApi.put(`/agents/${agentId}/custom-mcp-tools`, {
-      custom_mcps: [{
-        ...mcpConfigResponse.mcp_config,
-        enabledTools: selectedTools
-      }]
-    });
+    const mcpConfigResponse = await composioApi.getMcpConfigForProfile(
+      selectedProfile.profile_id,
+    );
+    const response = await backendApi.put(
+      `/agents/${agentId}/custom-mcp-tools`,
+      {
+        custom_mcps: [
+          {
+            ...mcpConfigResponse.mcp_config,
+            enabledTools: selectedTools,
+          },
+        ],
+      },
+    );
     if (response.data.success) {
-      toast.success(`Added ${selectedTools.length} ${selectedProfile.toolkit_name} tools to your agent!`);
+      toast.success(
+        `Added ${selectedTools.length} ${selectedProfile.toolkit_name} tools to your agent!`,
+      );
       onComplete(selectedProfile.profile_id, app.name, app.slug);
       onOpenChange(false);
     }
@@ -497,7 +603,9 @@ export const ComposioConnector: React.FC<ComposioConnectorProps> = ({
     if (selectedProfileId === 'new') {
       navigateToStep(Step.ProfileCreate);
     } else if (selectedProfileId) {
-      const profile = existingProfiles.find(p => p.profile_id === selectedProfileId);
+      const profile = existingProfiles.find(
+        (p) => p.profile_id === selectedProfileId,
+      );
       if (profile) {
         setSelectedProfile(profile);
         setCreatedProfileId(profile.profile_id);
@@ -518,7 +626,9 @@ export const ComposioConnector: React.FC<ComposioConnectorProps> = ({
     }
 
     if (nameAvailability && !nameAvailability.available) {
-      toast.error('This profile name is already in use. Please choose a different name.');
+      toast.error(
+        'This profile name is already in use. Please choose a different name.',
+      );
       return;
     }
 
@@ -532,52 +642,67 @@ export const ComposioConnector: React.FC<ComposioConnectorProps> = ({
       return;
     }
 
-    createProfile({
-      toolkit_slug: app.slug,
-      profile_name: profileName,
-      initiation_fields: Object.keys(initiationFields).length > 0 ? initiationFields : undefined,
-      custom_auth_config: useCustomAuth && Object.keys(customAuthConfig).length > 0 ? customAuthConfig : undefined,
-      use_custom_auth: useCustomAuth,
-    }, {
-      onSuccess: (response) => {
-        setCreatedProfileId(response.profile_id);
-        if (response.redirect_url) {
-          setRedirectUrl(response.redirect_url);
-          navigateToStep(Step.Connecting);
-          window.open(response.redirect_url, '_blank', 'width=600,height=700');
-        } else {
-          if (mode === 'full' && agentId) {
-            const newProfile = {
-              profile_id: response.profile_id,
-              profile_name: profileName,
-              toolkit_name: app.name,
-              toolkit_slug: app.slug,
-              is_connected: true,
-              created_at: new Date().toISOString(),
-              mcp_url: response.mcp_url || '',
-              display_name: profileName,
-              is_default: false
-            };
-            setSelectedProfile(newProfile);
-            navigateToStep(Step.ToolsSelection);
-          } else {
-            navigateToStep(Step.Success);
-            setTimeout(() => {
-              onComplete(response.profile_id, app.name, app.slug);
-              onOpenChange(false);
-            }, 1500);
-          }
-        }
+    createProfile(
+      {
+        toolkit_slug: app.slug,
+        profile_name: profileName,
+        initiation_fields:
+          Object.keys(initiationFields).length > 0
+            ? initiationFields
+            : undefined,
+        custom_auth_config:
+          useCustomAuth && Object.keys(customAuthConfig).length > 0
+            ? customAuthConfig
+            : undefined,
+        use_custom_auth: useCustomAuth,
       },
-      onError: (error: any) => {
-        toast.error(error.message || 'Failed to create profile');
-      }
-    });
+      {
+        onSuccess: (response) => {
+          setCreatedProfileId(response.profile_id);
+          if (response.redirect_url) {
+            setRedirectUrl(response.redirect_url);
+            navigateToStep(Step.Connecting);
+            window.open(
+              response.redirect_url,
+              '_blank',
+              'width=600,height=700',
+            );
+          } else {
+            if (mode === 'full' && agentId) {
+              const newProfile = {
+                profile_id: response.profile_id,
+                profile_name: profileName,
+                toolkit_name: app.name,
+                toolkit_slug: app.slug,
+                is_connected: true,
+                created_at: new Date().toISOString(),
+                mcp_url: response.mcp_url || '',
+                display_name: profileName,
+                is_default: false,
+              };
+              setSelectedProfile(newProfile);
+              navigateToStep(Step.ToolsSelection);
+            } else {
+              navigateToStep(Step.Success);
+              setTimeout(() => {
+                onComplete(response.profile_id, app.name, app.slug);
+                onOpenChange(false);
+              }, 1500);
+            }
+          }
+        },
+        onError: (error: any) => {
+          toast.error(error.message || 'Failed to create profile');
+        },
+      },
+    );
   };
 
   const handleAuthComplete = () => {
     if (createdProfileId && mode === 'full' && agentId) {
-      const profile = existingProfiles.find(p => p.profile_id === createdProfileId) || {
+      const profile = existingProfiles.find(
+        (p) => p.profile_id === createdProfileId,
+      ) || {
         profile_id: createdProfileId,
         profile_name: profileName,
         toolkit_name: app.name,
@@ -586,7 +711,7 @@ export const ComposioConnector: React.FC<ComposioConnectorProps> = ({
         created_at: new Date().toISOString(),
         mcp_url: '',
         display_name: profileName,
-        is_default: false
+        is_default: false,
       };
       setSelectedProfile(profile);
       navigateToStep(Step.ToolsSelection);
@@ -612,7 +737,9 @@ export const ComposioConnector: React.FC<ComposioConnectorProps> = ({
         if (mode === 'profile-only') {
           onOpenChange(false);
         } else {
-          const requiresCustomAuth = CUSTOM_OAUTH_REQUIRED_APPS.includes(app.slug);
+          const requiresCustomAuth = CUSTOM_OAUTH_REQUIRED_APPS.includes(
+            app.slug,
+          );
           setInitiationFields({});
           setInitiationFieldsErrors({});
           setCustomAuthConfig({});
@@ -633,11 +760,16 @@ export const ComposioConnector: React.FC<ComposioConnectorProps> = ({
     }
   };
 
-  const filteredToolsPreview = availableToolsPreview.filter(tool =>
-    !toolsPreviewSearchTerm ||
-    tool.name.toLowerCase().includes(toolsPreviewSearchTerm.toLowerCase()) ||
-    tool.description.toLowerCase().includes(toolsPreviewSearchTerm.toLowerCase()) ||
-    tool.tags?.some(tag => tag.toLowerCase().includes(toolsPreviewSearchTerm.toLowerCase()))
+  const filteredToolsPreview = availableToolsPreview.filter(
+    (tool) =>
+      !toolsPreviewSearchTerm ||
+      tool.name.toLowerCase().includes(toolsPreviewSearchTerm.toLowerCase()) ||
+      tool.description
+        .toLowerCase()
+        .includes(toolsPreviewSearchTerm.toLowerCase()) ||
+      tool.tags?.some((tag) =>
+        tag.toLowerCase().includes(toolsPreviewSearchTerm.toLowerCase()),
+      ),
   );
 
   return (
@@ -645,9 +777,12 @@ export const ComposioConnector: React.FC<ComposioConnectorProps> = ({
       <DialogContent
         hideCloseButton
         className={cn(
-          "overflow-hidden gap-0",
-          currentStep === Step.ToolsSelection ? "max-w-2xl h-[85vh] p-0 flex flex-col" :
-            currentStep === Step.ProfileSelect ? "max-w-2xl p-0" : "max-w-lg p-0"
+          'overflow-hidden gap-0',
+          currentStep === Step.ToolsSelection
+            ? 'max-w-2xl h-[85vh] p-0 flex flex-col'
+            : currentStep === Step.ProfileSelect
+              ? 'max-w-2xl p-0'
+              : 'max-w-lg p-0',
         )}
       >
         <StepIndicator currentStep={currentStep} mode={mode} />
@@ -657,7 +792,11 @@ export const ComposioConnector: React.FC<ComposioConnectorProps> = ({
             <DialogHeader className="px-6 pb-3">
               <div className="flex items-center gap-3">
                 {app.logo ? (
-                  <img src={app.logo} alt={app.name} className="w-10 h-10 rounded-lg object-contain bg-muted p-1.5 border" />
+                  <img
+                    src={app.logo}
+                    alt={app.name}
+                    className="w-10 h-10 rounded-lg object-contain bg-muted p-1.5 border"
+                  />
                 ) : (
                   <div className="w-10 h-10 rounded-lg bg-gradient-to-br from-primary/20 to-primary/10 flex items-center justify-center text-primary font-semibold text-sm">
                     {app.name.charAt(0)}
@@ -665,18 +804,28 @@ export const ComposioConnector: React.FC<ComposioConnectorProps> = ({
                 )}
                 <div className="flex-1">
                   <DialogTitle className="text-base font-semibold">
-                    {stepConfigs.find(config => config.id === currentStep)?.title}
+                    {
+                      stepConfigs.find((config) => config.id === currentStep)
+                        ?.title
+                    }
                   </DialogTitle>
                   <p className="text-xs text-muted-foreground">
-                    {stepConfigs.find(config => config.id === currentStep)?.description}
+                    {
+                      stepConfigs.find((config) => config.id === currentStep)
+                        ?.description
+                    }
                   </p>
                 </div>
               </div>
             </DialogHeader>
-            <div className={cn(
-              "flex-1 overflow-hidden",
-              currentStep === Step.ProfileSelect ? "px-0 pb-0 pt-0" : "px-8 pb-8 pt-6"
-            )}>
+            <div
+              className={cn(
+                'flex-1 overflow-hidden',
+                currentStep === Step.ProfileSelect
+                  ? 'px-0 pb-0 pt-0'
+                  : 'px-8 pb-8 pt-6',
+              )}
+            >
               {currentStep === Step.ProfileSelect && (
                 <div className="flex flex-col h-full max-h-[500px]">
                   <div className="flex-1 overflow-y-auto scrollbar-thin scrollbar-thumb-primary/20 scrollbar-track-transparent">
@@ -684,17 +833,32 @@ export const ComposioConnector: React.FC<ComposioConnectorProps> = ({
                       <div className="space-y-4">
                         <div className="flex items-center gap-3 mb-4">
                           {app.logo ? (
-                            <img src={app.logo} alt={app.name} className="w-8 h-8 rounded-lg object-contain bg-muted p-1 border flex-shrink-0" />
+                            <img
+                              src={app.logo}
+                              alt={app.name}
+                              className="w-8 h-8 rounded-lg object-contain bg-muted p-1 border flex-shrink-0"
+                            />
                           ) : (
                             <div className="w-8 h-8 rounded-lg bg-gradient-to-br from-primary/20 to-primary/10 flex items-center justify-center text-primary font-semibold text-sm flex-shrink-0">
                               {app.name.charAt(0)}
                             </div>
                           )}
                           <div className="flex-1">
-                            <h4 className="font-medium text-foreground">Connect to {app.name}</h4>
-                            <p className="text-xs text-muted-foreground">Choose an existing profile or create a new connection</p>
+                            <h4 className="font-medium text-foreground">
+                              Connect to {app.name}
+                            </h4>
+                            <p className="text-xs text-muted-foreground">
+                              Choose an existing profile or create a new
+                              connection
+                            </p>
                           </div>
-                          <Button variant="outline" size="sm" onClick={() => setShowToolsManager(!showToolsManager)}>
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() =>
+                              setShowToolsManager(!showToolsManager)
+                            }
+                          >
                             {showToolsManager ? 'Hide' : 'View'} Tools
                           </Button>
                         </div>
@@ -703,8 +867,10 @@ export const ComposioConnector: React.FC<ComposioConnectorProps> = ({
                           {existingProfiles.length > 0 && (
                             <Card
                               className={cn(
-                                "cursor-pointer p-0 transition-all",
-                                selectedConnectionType === 'existing' ? "border-primary bg-primary/5" : "border-border hover:border-border/80"
+                                'cursor-pointer p-0 transition-all',
+                                selectedConnectionType === 'existing'
+                                  ? 'border-primary bg-primary/5'
+                                  : 'border-border hover:border-border/80',
                               )}
                               onClick={() => {
                                 if (selectedConnectionType === 'existing') {
@@ -712,50 +878,81 @@ export const ComposioConnector: React.FC<ComposioConnectorProps> = ({
                                   setSelectedProfileId('');
                                 } else {
                                   setSelectedConnectionType('existing');
-                                  setSelectedProfileId(existingProfiles[0]?.profile_id || '');
+                                  setSelectedProfileId(
+                                    existingProfiles[0]?.profile_id || '',
+                                  );
                                 }
                               }}
                             >
-                              <CardContent className='p-2'>
+                              <CardContent className="p-2">
                                 <div className="flex items-center justify-between">
                                   <div className="flex items-center gap-3">
                                     <div className="w-10 h-10 rounded-xl bg-green-200 dark:bg-green-900/20 flex items-center justify-center">
                                       <Check className="w-5 h-5 text-green-600 dark:text-green-400" />
                                     </div>
                                     <div>
-                                      <h5 className="font-medium text-sm">Use Existing Connection</h5>
-                                      <p className="text-xs text-muted-foreground">{existingProfiles.length} profile{existingProfiles.length > 1 ? 's' : ''} already connected</p>
+                                      <h5 className="font-medium text-sm">
+                                        Use Existing Connection
+                                      </h5>
+                                      <p className="text-xs text-muted-foreground">
+                                        {existingProfiles.length} profile
+                                        {existingProfiles.length > 1
+                                          ? 's'
+                                          : ''}{' '}
+                                        already connected
+                                      </p>
                                     </div>
                                   </div>
-                                  <ChevronRight className={cn("w-4 h-4 text-muted-foreground transition-transform", selectedConnectionType === 'existing' && "rotate-90")} />
+                                  <ChevronRight
+                                    className={cn(
+                                      'w-4 h-4 text-muted-foreground transition-transform',
+                                      selectedConnectionType === 'existing' &&
+                                        'rotate-90',
+                                    )}
+                                  />
                                 </div>
                                 <AnimatePresence>
                                   {selectedConnectionType === 'existing' && (
                                     <motion.div
                                       initial={{ height: 0, opacity: 0 }}
-                                      animate={{ height: "auto", opacity: 1 }}
+                                      animate={{ height: 'auto', opacity: 1 }}
                                       exit={{ height: 0, opacity: 0 }}
-                                      transition={{ duration: 0.2, ease: "easeInOut" }}
+                                      transition={{
+                                        duration: 0.2,
+                                        ease: 'easeInOut',
+                                      }}
                                       className="overflow-hidden"
                                     >
                                       <div className="mt-3 pt-3 border-t border-border/50">
-                                        <Select value={selectedProfileId} onValueChange={setSelectedProfileId}>
+                                        <Select
+                                          value={selectedProfileId}
+                                          onValueChange={setSelectedProfileId}
+                                        >
                                           <SelectTrigger className="w-full h-10">
                                             <SelectValue placeholder="Select a profile..." />
                                           </SelectTrigger>
                                           <SelectContent>
                                             {existingProfiles.map((profile) => (
-                                              <SelectItem key={profile.profile_id} value={profile.profile_id}>
+                                              <SelectItem
+                                                key={profile.profile_id}
+                                                value={profile.profile_id}
+                                              >
                                                 <div className="flex items-center gap-3">
                                                   {app.logo ? (
-                                                    <img src={app.logo} alt={app.name} className="w-5 h-5 rounded-lg object-contain bg-muted p-0.5 border flex-shrink-0" />
+                                                    <img
+                                                      src={app.logo}
+                                                      alt={app.name}
+                                                      className="w-5 h-5 rounded-lg object-contain bg-muted p-0.5 border flex-shrink-0"
+                                                    />
                                                   ) : (
                                                     <div className="w-5 h-5 rounded-lg bg-gradient-to-br from-primary/20 to-primary/10 flex items-center justify-center text-primary text-xs font-semibold flex-shrink-0">
                                                       {app.name.charAt(0)}
                                                     </div>
                                                   )}
                                                   <div>
-                                                    <div className="text-sm font-medium">{profile.profile_name}</div>
+                                                    <div className="text-sm font-medium">
+                                                      {profile.profile_name}
+                                                    </div>
                                                   </div>
                                                 </div>
                                               </SelectItem>
@@ -770,35 +967,45 @@ export const ComposioConnector: React.FC<ComposioConnectorProps> = ({
                             </Card>
                           )}
 
-                          <Card className={cn(
-                            "cursor-pointer p-0 transition-all",
-                            selectedConnectionType === 'new' ? "border-primary bg-primary/5" : "border-border hover:border-border/80"
-                          )} onClick={() => {
-                            if (selectedConnectionType === 'new') {
-                              setSelectedConnectionType(null);
-                              setSelectedProfileId('');
-                            } else {
-                              setSelectedConnectionType('new');
-                              setSelectedProfileId('new');
-                              // Clear all fields when selecting new connection to prevent stale data
-                              const requiresCustomAuth = CUSTOM_OAUTH_REQUIRED_APPS.includes(app.slug);
-                              setInitiationFields({});
-                              setInitiationFieldsErrors({});
-                              setCustomAuthConfig({});
-                              setCustomAuthConfigErrors({});
-                              setUseCustomAuth(requiresCustomAuth);
-                              setProfileName(`${app.name} Profile`);
-                            }
-                          }}>
-                            <CardContent className='p-2'>
+                          <Card
+                            className={cn(
+                              'cursor-pointer p-0 transition-all',
+                              selectedConnectionType === 'new'
+                                ? 'border-primary bg-primary/5'
+                                : 'border-border hover:border-border/80',
+                            )}
+                            onClick={() => {
+                              if (selectedConnectionType === 'new') {
+                                setSelectedConnectionType(null);
+                                setSelectedProfileId('');
+                              } else {
+                                setSelectedConnectionType('new');
+                                setSelectedProfileId('new');
+                                // Clear all fields when selecting new connection to prevent stale data
+                                const requiresCustomAuth =
+                                  CUSTOM_OAUTH_REQUIRED_APPS.includes(app.slug);
+                                setInitiationFields({});
+                                setInitiationFieldsErrors({});
+                                setCustomAuthConfig({});
+                                setCustomAuthConfigErrors({});
+                                setUseCustomAuth(requiresCustomAuth);
+                                setProfileName(`${app.name} Profile`);
+                              }
+                            }}
+                          >
+                            <CardContent className="p-2">
                               <div className="flex items-center justify-between">
                                 <div className="flex items-center gap-3">
                                   <div className="w-10 h-10 rounded-xl bg-primary/10 flex items-center justify-center">
                                     <Plus className="w-5 h-5 text-primary" />
                                   </div>
                                   <div>
-                                    <h5 className="font-medium text-sm">Create New Connection</h5>
-                                    <p className="text-xs text-muted-foreground">Connect a new {app.name} account</p>
+                                    <h5 className="font-medium text-sm">
+                                      Create New Connection
+                                    </h5>
+                                    <p className="text-xs text-muted-foreground">
+                                      Connect a new {app.name} account
+                                    </p>
                                   </div>
                                 </div>
                                 <ChevronRight className="w-4 h-4 text-muted-foreground" />
@@ -811,9 +1018,9 @@ export const ComposioConnector: React.FC<ComposioConnectorProps> = ({
                         {showToolsManager && (
                           <motion.div
                             initial={{ height: 0, opacity: 0 }}
-                            animate={{ height: "auto", opacity: 1 }}
+                            animate={{ height: 'auto', opacity: 1 }}
                             exit={{ height: 0, opacity: 0 }}
-                            transition={{ duration: 0.3, ease: "easeInOut" }}
+                            transition={{ duration: 0.3, ease: 'easeInOut' }}
                             className="overflow-hidden"
                           >
                             <div className="space-y-3">
@@ -822,7 +1029,10 @@ export const ComposioConnector: React.FC<ComposioConnectorProps> = ({
                                   {isLoadingToolsPreview ? (
                                     <div className="grid grid-cols-2 gap-1">
                                       {[...Array(8)].map((_, i) => (
-                                        <div key={i} className="border rounded-md p-2 animate-pulse bg-background/50">
+                                        <div
+                                          key={i}
+                                          className="border rounded-md p-2 animate-pulse bg-background/50"
+                                        >
                                           <div className="h-2 bg-muted rounded w-3/4 mb-1"></div>
                                           <div className="h-2 bg-muted rounded w-1/2"></div>
                                         </div>
@@ -842,7 +1052,9 @@ export const ComposioConnector: React.FC<ComposioConnectorProps> = ({
                                     <div className="text-center py-6 text-muted-foreground">
                                       <Search className="h-4 w-4 mx-auto mb-2" />
                                       <p className="text-xs">
-                                        {toolsPreviewSearchTerm ? 'No matches' : 'No tools available'}
+                                        {toolsPreviewSearchTerm
+                                          ? 'No matches'
+                                          : 'No tools available'}
                                       </p>
                                     </div>
                                   )}
@@ -857,10 +1069,14 @@ export const ComposioConnector: React.FC<ComposioConnectorProps> = ({
                   <div className="px-6 py-4 border-t border-border/50 bg-muted/20 flex-shrink-0">
                     <div className="flex items-center justify-between">
                       <div className="text-sm text-muted-foreground">
-                        {selectedConnectionType === 'new' ? 'Ready to create new connection' :
-                          selectedConnectionType === 'existing' && selectedProfileId ? 'Profile selected' :
-                            selectedConnectionType === 'existing' ? 'Select a profile to continue' :
-                              'Choose how you want to connect'}
+                        {selectedConnectionType === 'new'
+                          ? 'Ready to create new connection'
+                          : selectedConnectionType === 'existing' &&
+                              selectedProfileId
+                            ? 'Profile selected'
+                            : selectedConnectionType === 'existing'
+                              ? 'Select a profile to continue'
+                              : 'Choose how you want to connect'}
                       </div>
                       <div className="flex gap-3">
                         <Button
@@ -878,7 +1094,11 @@ export const ComposioConnector: React.FC<ComposioConnectorProps> = ({
                               handleProfileSelect();
                             }
                           }}
-                          disabled={!selectedConnectionType || (selectedConnectionType === 'existing' && !selectedProfileId)}
+                          disabled={
+                            !selectedConnectionType ||
+                            (selectedConnectionType === 'existing' &&
+                              !selectedProfileId)
+                          }
                           className="px-8 min-w-[120px]"
                         >
                           {selectedConnectionType === 'new' ? (
@@ -886,9 +1106,12 @@ export const ComposioConnector: React.FC<ComposioConnectorProps> = ({
                               Create Connection
                               <ChevronRight className="h-4 w-4 ml-1" />
                             </>
-                          ) : selectedConnectionType === 'existing' && selectedProfileId ? (
+                          ) : selectedConnectionType === 'existing' &&
+                            selectedProfileId ? (
                             <>
-                              {mode === 'full' && agentId ? 'Configure Tools' : 'Use Profile'}
+                              {mode === 'full' && agentId
+                                ? 'Configure Tools'
+                                : 'Use Profile'}
                               <ChevronRight className="h-4 w-4 ml-1" />
                             </>
                           ) : (
@@ -905,7 +1128,10 @@ export const ComposioConnector: React.FC<ComposioConnectorProps> = ({
                   <div className="flex-1 overflow-y-auto">
                     <div className="space-y-3">
                       <div className="space-y-1.5">
-                        <Label htmlFor="profileName" className="text-sm font-medium">
+                        <Label
+                          htmlFor="profileName"
+                          className="text-sm font-medium"
+                        >
                           Profile Name
                         </Label>
                         <div className="relative">
@@ -915,24 +1141,31 @@ export const ComposioConnector: React.FC<ComposioConnectorProps> = ({
                             onChange={(e) => setProfileName(e.target.value)}
                             placeholder={`e.g., ${app.name} Production`}
                             className={cn(
-                              "pr-10 h-9",
-                              nameAvailability && !nameAvailability.available && "border-destructive",
-                              nameAvailability && nameAvailability.available && profileName.length > 0 && "border-green-500"
+                              'pr-10 h-9',
+                              nameAvailability &&
+                                !nameAvailability.available &&
+                                'border-destructive',
+                              nameAvailability &&
+                                nameAvailability.available &&
+                                profileName.length > 0 &&
+                                'border-green-500',
                             )}
                           />
                           <div className="absolute right-2 top-1/2 -translate-y-1/2">
                             {isCheckingName && profileName.length > 0 && (
                               <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />
                             )}
-                            {!isCheckingName && nameAvailability && profileName.length > 0 && (
-                              <>
-                                {nameAvailability.available ? (
-                                  <Check className="h-3.5 w-3.5 text-green-500" />
-                                ) : (
-                                  <X className="h-3.5 w-3.5 text-destructive" />
-                                )}
-                              </>
-                            )}
+                            {!isCheckingName &&
+                              nameAvailability &&
+                              profileName.length > 0 && (
+                                <>
+                                  {nameAvailability.available ? (
+                                    <Check className="h-3.5 w-3.5 text-green-500" />
+                                  ) : (
+                                    <X className="h-3.5 w-3.5 text-destructive" />
+                                  )}
+                                </>
+                              )}
                           </div>
                         </div>
 
@@ -943,91 +1176,144 @@ export const ComposioConnector: React.FC<ComposioConnectorProps> = ({
                             </p>
                             {nameAvailability.suggestions.length > 0 && (
                               <div className="flex flex-wrap gap-1">
-                                {nameAvailability.suggestions.map((suggestion) => (
-                                  <button
-                                    key={suggestion}
-                                    type="button"
-                                    onClick={() => setProfileName(suggestion)}
-                                    className="text-xs px-2 py-0.5 rounded bg-muted hover:bg-muted/80 transition-colors"
-                                  >
-                                    {suggestion}
-                                  </button>
-                                ))}
+                                {nameAvailability.suggestions.map(
+                                  (suggestion) => (
+                                    <button
+                                      key={suggestion}
+                                      type="button"
+                                      onClick={() => setProfileName(suggestion)}
+                                      className="text-xs px-2 py-0.5 rounded bg-muted hover:bg-muted/80 transition-colors"
+                                    >
+                                      {suggestion}
+                                    </button>
+                                  ),
+                                )}
                               </div>
                             )}
                           </div>
                         )}
-                        {nameAvailability && nameAvailability.available && profileName.length > 0 && (
-                          <p className="text-xs text-green-600 dark:text-green-400">
-                            Name available
-                          </p>
-                        )}
+                        {nameAvailability &&
+                          nameAvailability.available &&
+                          profileName.length > 0 && (
+                            <p className="text-xs text-green-600 dark:text-green-400">
+                              Name available
+                            </p>
+                          )}
                       </div>
 
                       {!isLoadingToolkitDetails &&
-                        toolkitDetails?.toolkit.connected_account_initiation_fields?.required?.length > 0 && (
+                        toolkitDetails?.toolkit
+                          .connected_account_initiation_fields?.required
+                          ?.length > 0 && (
                           <div className="space-y-2">
                             <div className="flex items-center gap-1.5">
                               <Settings className="h-3.5 w-3.5 text-muted-foreground" />
-                              <Label className="text-sm font-medium">Connection Details</Label>
+                              <Label className="text-sm font-medium">
+                                Connection Details
+                              </Label>
                             </div>
-                            {toolkitDetails.toolkit.connected_account_initiation_fields.required.map((field) => {
-                              const fieldType = field.type?.toLowerCase() || 'string';
-                              const isBoolean = fieldType === 'boolean';
-                              const isNumber = fieldType === 'number' || fieldType === 'double';
+                            {toolkitDetails.toolkit.connected_account_initiation_fields.required.map(
+                              (field) => {
+                                const fieldType =
+                                  field.type?.toLowerCase() || 'string';
+                                const isBoolean = fieldType === 'boolean';
+                                const isNumber =
+                                  fieldType === 'number' ||
+                                  fieldType === 'double';
 
-                              return (
-                                <div key={field.name} className="space-y-1">
-                                  <Label htmlFor={field.name} className="text-xs">
-                                    {field.displayName}
-                                    {field.required && <span className="text-destructive ml-1">*</span>}
-                                  </Label>
-
-                                  {isBoolean ? (
-                                    <div className="flex items-center space-x-2">
-                                      <Switch
-                                        id={field.name}
-                                        checked={initiationFields[field.name] === 'true'}
-                                        onCheckedChange={(checked) =>
-                                          handleInitiationFieldChange(field.name, checked ? 'true' : 'false')
-                                        }
-                                      />
-                                      <Label htmlFor={field.name} className="text-xs font-normal">
-                                        {field.description || 'Enable'}
-                                      </Label>
-                                    </div>
-                                  ) : (
-                                    <>
-                                      <Input
-                                        id={field.name}
-                                        type={fieldType === 'password' ? 'password' :
-                                          fieldType === 'email' ? 'email' :
-                                            fieldType === 'url' ? 'url' :
-                                              isNumber ? 'number' : 'text'}
-                                        value={initiationFields[field.name] || ''}
-                                        onChange={(e) => handleInitiationFieldChange(field.name, e.target.value)}
-                                        placeholder={field.default || field.description || `Enter ${field.displayName.toLowerCase()}`}
-                                        className={cn(
-                                          "h-8",
-                                          initiationFieldsErrors[field.name] && "border-destructive"
-                                        )}
-                                        step={isNumber ? "any" : undefined}
-                                      />
-                                      {field.description && !isBoolean && (
-                                        <p className="text-[10px] text-muted-foreground">{field.description}</p>
+                                return (
+                                  <div key={field.name} className="space-y-1">
+                                    <Label
+                                      htmlFor={field.name}
+                                      className="text-xs"
+                                    >
+                                      {field.displayName}
+                                      {field.required && (
+                                        <span className="text-destructive ml-1">
+                                          *
+                                        </span>
                                       )}
-                                    </>
-                                  )}
+                                    </Label>
 
-                                  {initiationFieldsErrors[field.name] && (
-                                    <p className="text-[10px] text-destructive">{initiationFieldsErrors[field.name]}</p>
-                                  )}
-                                </div>
-                              );
-                            })}
+                                    {isBoolean ? (
+                                      <div className="flex items-center space-x-2">
+                                        <Switch
+                                          id={field.name}
+                                          checked={
+                                            initiationFields[field.name] ===
+                                            'true'
+                                          }
+                                          onCheckedChange={(checked) =>
+                                            handleInitiationFieldChange(
+                                              field.name,
+                                              checked ? 'true' : 'false',
+                                            )
+                                          }
+                                        />
+                                        <Label
+                                          htmlFor={field.name}
+                                          className="text-xs font-normal"
+                                        >
+                                          {field.description || 'Enable'}
+                                        </Label>
+                                      </div>
+                                    ) : (
+                                      <>
+                                        <Input
+                                          id={field.name}
+                                          type={
+                                            fieldType === 'password'
+                                              ? 'password'
+                                              : fieldType === 'email'
+                                                ? 'email'
+                                                : fieldType === 'url'
+                                                  ? 'url'
+                                                  : isNumber
+                                                    ? 'number'
+                                                    : 'text'
+                                          }
+                                          value={
+                                            initiationFields[field.name] || ''
+                                          }
+                                          onChange={(e) =>
+                                            handleInitiationFieldChange(
+                                              field.name,
+                                              e.target.value,
+                                            )
+                                          }
+                                          placeholder={
+                                            field.default ||
+                                            field.description ||
+                                            `Enter ${field.displayName.toLowerCase()}`
+                                          }
+                                          className={cn(
+                                            'h-8',
+                                            initiationFieldsErrors[
+                                              field.name
+                                            ] && 'border-destructive',
+                                          )}
+                                          step={isNumber ? 'any' : undefined}
+                                        />
+                                        {field.description && !isBoolean && (
+                                          <p className="text-[10px] text-muted-foreground">
+                                            {field.description}
+                                          </p>
+                                        )}
+                                      </>
+                                    )}
+
+                                    {initiationFieldsErrors[field.name] && (
+                                      <p className="text-[10px] text-destructive">
+                                        {initiationFieldsErrors[field.name]}
+                                      </p>
+                                    )}
+                                  </div>
+                                );
+                              },
+                            )}
                           </div>
                         )}
-                      {toolkitDetails?.toolkit.auth_config_details?.[0]?.fields?.auth_config_creation && (
+                      {/* {toolkitDetails?.toolkit.auth_config_details?.[0]?.fields?.auth_config_creation && (
                         <div className="space-y-3 border rounded-lg p-3">
                           <div className="flex items-center justify-between">
                             <div className="flex items-center gap-2">
@@ -1158,19 +1444,19 @@ export const ComposioConnector: React.FC<ComposioConnectorProps> = ({
                             )}
                           </AnimatePresence>
                         </div>
-                      )}
+                      )} */}
 
                       {/* Loading State */}
                       {isLoadingToolkitDetails && (
                         <div className="space-y-3">
                           <Skeleton className="h-4 w-32" />
-                          <Skeleton className="h-10 w-full" />
-                          <Skeleton className="h-10 w-full" />
+                          {/* <Skeleton className="h-10 w-full" />
+                          <Skeleton className="h-10 w-full" /> */}
                         </div>
                       )}
                     </div>
                   </div>
-                  <div className='mt-4'>
+                  <div className="mt-4">
                     <div className="flex gap-2">
                       <Button
                         variant="outline"
@@ -1217,10 +1503,13 @@ export const ComposioConnector: React.FC<ComposioConnectorProps> = ({
                       <ExternalLink className="h-10 w-10 text-primary animate-pulse" />
                     </div>
                     <div className="space-y-1">
-                      <h3 className="font-semibold text-lg">Complete Authentication</h3>
+                      <h3 className="font-semibold text-lg">
+                        Complete Authentication
+                      </h3>
                       <p className="text-sm text-muted-foreground max-w-sm mx-auto">
-                        A new window has opened for you to authorize your {app.name} connection.
-                        Complete the process there and return here.
+                        A new window has opened for you to authorize your{' '}
+                        {app.name} connection. Complete the process there and
+                        return here.
                       </p>
                     </div>
                   </div>
@@ -1238,10 +1527,7 @@ export const ComposioConnector: React.FC<ComposioConnectorProps> = ({
                       </AlertDescription>
                     </Alert>
                   )}
-                  <Button
-                    onClick={handleAuthComplete}
-                    className="w-full"
-                  >
+                  <Button onClick={handleAuthComplete} className="w-full">
                     I've Completed Authentication
                     <ChevronRight className="h-4 w-4" />
                   </Button>
@@ -1254,7 +1540,9 @@ export const ComposioConnector: React.FC<ComposioConnectorProps> = ({
                       <Check className="h-10 w-10 text-white" />
                     </div>
                     <div className="space-y-1">
-                      <h3 className="font-semibold text-lg">Successfully Connected!</h3>
+                      <h3 className="font-semibold text-lg">
+                        Successfully Connected!
+                      </h3>
                       <p className="text-sm text-muted-foreground">
                         Your {app.name} integration is ready.
                       </p>
@@ -1307,17 +1595,12 @@ export const ComposioConnector: React.FC<ComposioConnectorProps> = ({
                 <div className="px-6 py-4 border-t bg-muted/20 flex-shrink-0">
                   <div className="flex items-center justify-between">
                     <div className="text-sm text-muted-foreground">
-                      {selectedTools.length > 0 ? (
-                        `${selectedTools.length} tool${selectedTools.length === 1 ? '' : 's'} will be added to your agent`
-                      ) : (
-                        'No tools selected'
-                      )}
+                      {selectedTools.length > 0
+                        ? `${selectedTools.length} tool${selectedTools.length === 1 ? '' : 's'} will be added to your agent`
+                        : 'No tools selected'}
                     </div>
                     <div className="flex gap-3">
-                      <Button
-                        variant="outline"
-                        onClick={handleBack}
-                      >
+                      <Button variant="outline" onClick={handleBack}>
                         <ArrowLeft className="h-4 w-4" />
                         Back
                       </Button>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Revamps the Composio connection flow with existing/new connection cards, in-dialog tool preview/selection and saving to the agent, and removes the custom OAuth configuration UI (kept gated for required apps).
> 
> - **Composio Connector UI/Flow** (`frontend/src/components/agents/composio/composio-connector.tsx`):
>   - Add card-based choice between `existing` and `new` connections with animated expand/collapse and profile selector.
>   - Integrate in-dialog tools preview (search/filter, skeletons) using `useComposioTools`; add `ToolPreviewCard` with highlighting and contextual icons.
>   - Enhance step indicator and dialogs; refine transitions and headers/footers.
>   - Improve profile name availability checks with inline indicators and suggestions.
> - **Tools Configuration**:
>   - Add tools selection footer with counts and actions; persist selection by fetching MCP config (`composioApi.getMcpConfigForProfile`) and `PUT /agents/{agentId}/custom-mcp-tools` with `enabledTools`.
> - **Auth/OAuth Changes**:
>   - Keep connection initiation fields validation; boolean handling tweaks.
>   - Remove/comment out the Custom OAuth configuration UI; default behavior remains, with `CUSTOM_OAUTH_REQUIRED_APPS` (e.g., `zendesk`) retained.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 584c969443eb0d66f43c3bfd518811f46a0ab0b1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->