### PR TITLE
fix

### DIFF
--- a/frontend/src/hooks/threads/page/use-thread-data.ts
+++ b/frontend/src/hooks/threads/page/use-thread-data.ts
@@ -54,8 +54,10 @@ export function useThreadData(
     refetchInterval: enablePolling ? 1000 : false,
   });
   
-  const effectiveProjectId = projectId || threadQuery.data?.project_id || '';
+  const effectiveProjectId = threadQuery.data?.project_id || projectId || '';
+  const hasThreadData = !!threadQuery.data;
   const projectQuery = useProjectQuery(effectiveProjectId, {
+    enabled: hasThreadData && !!effectiveProjectId,
     refetchOnWindowFocus: true,
     refetchInterval: 10000,
   });


### PR DESCRIPTION
This PR:


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use the thread's `project_id` before the passed `projectId` and only run the project query once thread data is present.
> 
> - **Frontend/hooks**:
>   - `frontend/src/hooks/threads/page/use-thread-data.ts`:
>     - Adjust `effectiveProjectId` precedence to prefer `threadQuery.data.project_id` over `projectId`.
>     - Add `enabled` guard to `useProjectQuery` (`hasThreadData && !!effectiveProjectId`) to avoid premature fetches.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5be88227ba714c8e306b325030b6515fc0f22c23. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->