### PR TITLE
feat(analytics): add project categorization and optimize API latency

### DIFF
--- a/backend/core/thread_init_service.py
+++ b/backend/core/thread_init_service.py
@@ -8,6 +8,7 @@ import dramatiq
 
 from core.utils.logger import logger, structlog
 from core.services.supabase import DBConnection
+from core.utils.project_helpers import generate_and_update_project_name
 
 db = DBConnection()
 
@@ -115,6 +116,9 @@ async def create_thread_optimistically(
         }).execute()
         
         logger.debug(f"Created project {project_id} optimistically")
+        
+        # Start background task to generate proper name, icon, and category
+        asyncio.create_task(generate_and_update_project_name(project_id=project_id, prompt=prompt))
         
     except Exception as e:
         logger.error(f"Failed to create project optimistically: {str(e)}")

--- a/backend/supabase/migrations/20251208171320_add_project_category.sql
+++ b/backend/supabase/migrations/20251208171320_add_project_category.sql
@@ -1,0 +1,7 @@
+-- Migration: Add category column to projects table for analytics classification
+
+-- 1. Add the category column (default 'Uncategorized' for existing projects)
+ALTER TABLE projects ADD COLUMN IF NOT EXISTS category TEXT DEFAULT 'Uncategorized';
+
+-- 2. Add index for faster analytics queries
+CREATE INDEX IF NOT EXISTS idx_projects_category ON projects(category);

--- a/frontend/src/hooks/admin/use-admin-analytics.ts
+++ b/frontend/src/hooks/admin/use-admin-analytics.ts
@@ -34,6 +34,7 @@ export interface ThreadAnalytics {
   thread_id: string;
   project_id?: string | null;
   project_name?: string | null;
+  project_category?: string | null;
   account_id: string;
   user_email?: string | null;
   message_count: number;
@@ -63,6 +64,12 @@ export interface MessageDistribution {
     '5_plus_messages': number;
   };
   total_threads: number;
+}
+
+export interface CategoryDistribution {
+  distribution: Record<string, number>;
+  total_projects: number;
+  date: string;
 }
 
 export interface TranslationResponse {
@@ -95,6 +102,7 @@ export interface ThreadBrowseParams {
   min_messages?: number;
   max_messages?: number;
   search_email?: string;
+  category?: string;
   date_from?: string;
   date_to?: string;
   sort_by?: string;
@@ -151,6 +159,7 @@ export function useThreadBrowser(params: ThreadBrowseParams = {}) {
       if (params.min_messages !== undefined) searchParams.append('min_messages', params.min_messages.toString());
       if (params.max_messages !== undefined) searchParams.append('max_messages', params.max_messages.toString());
       if (params.search_email) searchParams.append('search_email', params.search_email);
+      if (params.category) searchParams.append('category', params.category);
       if (params.date_from) searchParams.append('date_from', params.date_from);
       if (params.date_to) searchParams.append('date_to', params.date_to);
       if (params.sort_by) searchParams.append('sort_by', params.sort_by);
@@ -181,6 +190,24 @@ export function useMessageDistribution(date?: string) {
     },
     staleTime: 300000, // 5 minutes
     placeholderData: (previousData) => previousData, // Keep previous data while loading
+  });
+}
+
+export function useCategoryDistribution(date?: string) {
+  return useQuery({
+    queryKey: ['admin', 'analytics', 'category-distribution', date],
+    queryFn: async (): Promise<CategoryDistribution> => {
+      const url = date
+        ? `/admin/analytics/projects/category-distribution?date=${date}`
+        : '/admin/analytics/projects/category-distribution';
+      const response = await backendApi.get(url);
+      if (response.error) {
+        throw new Error(response.error.message);
+      }
+      return response.data;
+    },
+    staleTime: 300000, // 5 minutes
+    placeholderData: (previousData) => previousData,
   });
 }
 


### PR DESCRIPTION
- Add AI-based project categorization when generating thread names
- Add category column to projects table with migration
- Add category filter to thread browser (click category to filter)
- Compact category distribution UI with clickable pills
- Show total threads per day in distribution card
- Parallelize DB queries in analytics endpoints (~3-9x faster):
  - get_analytics_summary: 9 queries run in parallel
  - _enrich_threads: 3 queries run in parallel
- Fix: call generate_and_update_project_name in optimistic thread creation