### PR TITLE
Fix the bug in has_builder_tools

### DIFF
--- a/backend/core/run/prompt_manager.py
+++ b/backend/core/run/prompt_manager.py
@@ -127,10 +127,18 @@ If relevant context seems missing, ask a clarifying question.
             return system_content
         
         agentpress_tools = agent_config.get('agentpress_tools', {})
-        has_builder_tools = any(
-            agentpress_tools.get(tool, False) 
-            for tool in ['agent_config_tool', 'mcp_search_tool', 'credential_profile_tool', 'trigger_tool']
-        )
+        
+        def is_tool_enabled(tool_name: str) -> bool:
+            tool_config = agentpress_tools.get(tool_name)
+            if isinstance(tool_config, bool):
+                return tool_config
+            elif isinstance(tool_config, dict):
+                return tool_config.get('enabled', False)
+            else:
+                return False
+        
+        builder_tool_names = ['agent_creation_tool', 'agent_config_tool', 'mcp_search_tool', 'credential_profile_tool', 'trigger_tool']
+        has_builder_tools = any(is_tool_enabled(tool) for tool in builder_tool_names)
         
         if has_builder_tools:
             builder_prompt = get_agent_builder_prompt()


### PR DESCRIPTION
The agentpress_tools.get(tool, False) returns a dict instead of a bool.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes builder tools detection to handle dict configs with `enabled` and includes `agent_creation_tool`, ensuring the builder prompt is appended when appropriate.
> 
> - **Core (prompt manager)**
>   - Refines builder tools detection in `backend/core/run/prompt_manager.py`:
>     - Introduces `is_tool_enabled()` to support bool or dict (`{"enabled": true}`) configs in `agentpress_tools`.
>     - Expands builder tool list to include `agent_creation_tool`.
>     - Ensures builder prompt (`get_agent_builder_prompt()`) is appended when any builder tool is enabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d18388093ffa2e7ec28c46481e8e9dc2da626449. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->