### PR TITLE
Implement graceful shutdown with health endpoint for K8s terminationGracePeriodSeconds

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -63,9 +63,13 @@ _queue_metrics_task = None
 _worker_metrics_task = None
 _memory_watchdog_task = None
 
+# Graceful shutdown flag for health checks
+# When True, health check will return unhealthy to stop receiving traffic
+_is_shutting_down = False
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    global _queue_metrics_task, _worker_metrics_task, _memory_watchdog_task
+    global _queue_metrics_task, _worker_metrics_task, _memory_watchdog_task, _is_shutting_down
     env_mode = config.ENV_MODE.value if config.ENV_MODE else "unknown"
     logger.debug(f"Starting up FastAPI application with instance ID: {instance_id} in {env_mode} mode")
     try:
@@ -117,6 +121,14 @@ async def lifespan(app: FastAPI):
         _memory_watchdog_task = asyncio.create_task(_memory_watchdog())
         
         yield
+
+        # Shutdown sequence: Set flag first so health checks fail
+        _is_shutting_down = True
+        logger.info(f"Starting graceful shutdown for instance {instance_id}")
+        
+        # Give K8s readiness probe time to detect unhealthy state
+        # This ensures no new traffic is routed to this pod
+        await asyncio.sleep(2)
         
         logger.debug("Cleaning up agent resources")
         await core_api.cleanup()
@@ -318,6 +330,20 @@ api_router.include_router(memory_router)
 @api_router.get("/health", summary="Health Check", operation_id="health_check", tags=["system"])
 async def health_check():
     logger.debug("Health check endpoint called")
+
+    # During shutdown, return unhealthy status
+    # This causes K8s readinessProbe to fail and removes pod from service endpoints
+    if _is_shutting_down:
+        logger.debug(f"Health check returning unhealthy (shutting down) for instance {instance_id}")
+        raise HTTPException(
+            status_code=503,
+            detail={
+                "status": "shutting_down",
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "instance_id": instance_id
+            }
+        )
+    
     return {
         "status": "ok", 
         "timestamp": datetime.now(timezone.utc).isoformat(),


### PR DESCRIPTION
Implement graceful shutdown with health endpoint for K8s terminationGracePeriodSeconds
- Health endpoint returns 503 when shutting down to fail readiness probes
- You can set terminationGracePeriodSeconds to 60s-300s for proper cleanup in K8S deployment
- Ensures zero-downtime deployments during rolling updates

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce shutdown flag that makes `/v1/health` return 503 during teardown, with a brief delay to drain traffic before cleanup.
> 
> - **Backend/API**:
>   - **Graceful shutdown**:
>     - Add `_is_shutting_down` flag; set during `lifespan` shutdown.
>     - Wait ~2s before cleanup to let readiness probes fail and drain traffic.
>   - **Health endpoint** (`/v1/health`):
>     - Returns `503` with status `shutting_down`, timestamp, and `instance_id` when `_is_shutting_down` is true.
>     - Logs details for observability.
>   - **Cleanup sequence**:
>     - Proceeds after drain window; cancels background metric/watchdog tasks and closes Redis/DB connections.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 70f87abacc877530854f402947c2cd275a633fb1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->