### PR TITLE
Github context fix request

### DIFF
--- a/frontend/src/components/ui/sidebar.tsx
+++ b/frontend/src/components/ui/sidebar.tsx
@@ -228,7 +228,7 @@ function Sidebar({
 
   return (
     <div
-      className="group peer text-sidebar-foreground hidden md:block"
+      className="group peer text-sidebar-foreground"
       data-state={state}
       data-collapsible={state === 'collapsed' ? collapsible : ''}
       data-variant={variant}
@@ -250,7 +250,7 @@ function Sidebar({
       <div
         data-slot="sidebar-container"
         className={cn(
-          'fixed inset-y-0 z-10 hidden h-svh w-[var(--sidebar-width)] transition-[left,right,width] duration-200 ease-linear md:flex',
+          'fixed inset-y-0 z-10 h-svh w-[var(--sidebar-width)] transition-[left,right,width] duration-200 ease-linear flex',
           side === 'left'
             ? 'left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]'
             : 'right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]',


### PR DESCRIPTION
Remove `md:` media query classes from the sidebar to fix a visibility issue and allow JavaScript to control its display.

---
<a href="https://cursor.com/background-agent?bcId=bc-97a34ae6-c94e-4c71-be48-c51dd0bb0142"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-97a34ae6-c94e-4c71-be48-c51dd0bb0142"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes `md:` visibility constraints so the desktop sidebar is always rendered and controlled via component state, not media queries.
> 
> - **Frontend — `frontend/src/components/ui/sidebar.tsx`**:
>   - Remove `hidden md:block` from the sidebar wrapper (`data-slot="sidebar"`).
>   - Replace `hidden md:flex` with `flex` on `data-slot="sidebar-container"`.
>   - Effect: sidebar is rendered consistently across breakpoints; visibility is driven by `state/collapsible` logic instead of media queries.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 49de4de369fe56a2660e04d64ce21c33c174c520. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->