### PR TITLE
Mobile chat input conflict

### DIFF
--- a/frontend/src/components/thread/chat-input/chat-input.tsx
+++ b/frontend/src/components/thread/chat-input/chat-input.tsx
@@ -1312,11 +1312,13 @@ export const ChatInput = memo(forwardRef<ChatInputHandles, ChatInputProps>(
         />
 
         {onModeDeselect && (
-          <ModeButton
-            selectedMode={selectedMode}
-            isModeDismissing={isModeDismissing}
-            onDeselect={handleModeDeselect}
-          />
+          <div className="hidden sm:block">
+            <ModeButton
+              selectedMode={selectedMode}
+              isModeDismissing={isModeDismissing}
+              onDeselect={handleModeDeselect}
+            />
+          </div>
         )}
       </div>
     ), [hideAttachments, loading, disabled, isAgentRunning, isUploading, sandboxId, projectId, messages, isLoggedIn, isFreeTier, quickIntegrations, integrationIcons, handleOpenRegistry, handleOpenPlanModal, threadId, memoryEnabled, onMemoryToggle, isSunaAgent, sunaAgentModes, onModeDeselect, selectedMode, isModeDismissing, handleModeDeselect]);


### PR DESCRIPTION
Hide the `ModeButton` (action chip) on mobile breakpoints to prevent conflicts with other chat input elements.

---
<a href="https://cursor.com/background-agent?bcId=bc-5c018f30-eca2-4698-99f5-fd49ae667b25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5c018f30-eca2-4698-99f5-fd49ae667b25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Hide `ModeButton` on mobile by wrapping it with `hidden sm:block` in the chat input controls.
> 
> - **Frontend**
>   - **Chat input** (`frontend/src/components/thread/chat-input/chat-input.tsx`):
>     - Wrap `ModeButton` in a `div` with `hidden sm:block` to hide on mobile and show on `sm`+.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 64e47c9f0d17bebd7b64ef01ff3ecc07b97ee342. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->