### PR TITLE
Cursor issue fix

### DIFF
--- a/frontend/src/components/dashboard/dashboard-content.tsx
+++ b/frontend/src/components/dashboard/dashboard-content.tsx
@@ -33,7 +33,7 @@ import { normalizeFilenameToNFC } from '@/lib/utils/unicode';
 import { toast } from 'sonner';
 import { useSunaModePersistence } from '@/stores/suna-modes-store';
 import { Button } from '../ui/button';
-import { X, ChevronRight, HelpCircle } from 'lucide-react';
+import { X, ChevronRight } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { NotificationDropdown } from '../notifications/notification-dropdown';
 import { UsageLimitsPopover } from './usage-limits-popover';
@@ -533,13 +533,6 @@ export function DashboardContent() {
             <CreditsDisplay />
           </Suspense>
           <UsageLimitsPopover />
-          <a
-            href="mailto:support@kortix.com"
-            className="flex items-center justify-center h-[41px] w-[41px] border-[1.5px] border-border/60 dark:border-border rounded-full bg-background dark:bg-background hover:bg-accent/30 dark:hover:bg-accent/20 hover:border-border dark:hover:border-border/80 transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-            title="Contact Support"
-          >
-            <HelpCircle className="h-5 w-5 text-muted-foreground dark:text-muted-foreground/60" />
-          </a>
         </div>
 
         <div className="flex-1 overflow-y-auto">

--- a/frontend/src/components/sidebar/nav-user-with-teams.tsx
+++ b/frontend/src/components/sidebar/nav-user-with-teams.tsx
@@ -29,6 +29,7 @@ import {
   FileText,
   TrendingDown,
   Heart,
+  LifeBuoy,
 } from 'lucide-react';
 import { useAccounts } from '@/hooks/account';
 import { useAccountState } from '@/hooks/billing';
@@ -364,6 +365,12 @@ export function NavUserWithTeams({
                   <Link href="/knowledge" className="gap-2 p-2">
                     <FileText className="h-4 w-4" />
                     <span>Knowledge Base</span>
+                  </Link>
+                </DropdownMenuItem>
+                <DropdownMenuItem asChild>
+                  <Link href="/support" className="gap-2 p-2">
+                    <LifeBuoy className="h-4 w-4" />
+                    <span>Support</span>
                   </Link>
                 </DropdownMenuItem>
                 <DropdownMenuItem


### PR DESCRIPTION
Remove the confusing `mailto:` button from the dashboard header and add a "Support" link to the user dropdown menu.

The previous support button was poorly placed, lacked context, had an inconsistent icon size, and used a `mailto:` link which is not ideal. This change moves the support action to the user menu, linking to the `/support` page for a more consistent and user-friendly experience.

---
[Slack Thread](https://kortixworkspace.slack.com/archives/C09HH3K3B39/p1765827247145859?thread_ts=1765827247.145859&cid=C09HH3K3B39)

<a href="https://cursor.com/background-agent?bcId=bc-042ac447-bdf1-4156-ac00-85f2a2dafc9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-042ac447-bdf1-4156-ac00-85f2a2dafc9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

