### PR TITLE
Frontend annual default selection

### DIFF
--- a/frontend/src/components/billing/pricing/pricing-section.tsx
+++ b/frontend/src/components/billing/pricing/pricing-section.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { PricingTier } from '@/lib/pricing-config';
-import { siteConfig } from '@/lib/site-config';
+import React, { useState, useEffect, useCallback } from 'react';
 import { cn } from '@/lib/utils';
 import { motion } from 'framer-motion';
 import React, { useState, useCallback } from 'react';


### PR DESCRIPTION
Set the default billing period to annual for unauthenticated users and sync with existing subscriptions.

The change ensures that new visitors initially see the annual billing option, while authenticated users' displayed billing period correctly updates to reflect their current subscription after their account data loads.

---
[Slack Thread](https://kortixworkspace.slack.com/archives/C09HH3K3B39/p1766419113207509?thread_ts=1766419113.207509&cid=C09HH3K3B39)

<a href="https://cursor.com/background-agent?bcId=bc-2596decd-37e3-484f-b151-5c6562ad83da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2596decd-37e3-484f-b151-5c6562ad83da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

