### PR TITLE
Windows: docker-compose fallback + NEXT_PUBLIC_* build args

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -83,6 +83,10 @@ services:
     build:
       context: ./frontend
       dockerfile: Dockerfile
+      args:
+        NEXT_PUBLIC_BACKEND_URL: ${NEXT_PUBLIC_BACKEND_URL:-http://localhost:8000/v1}
+        NEXT_PUBLIC_URL: ${NEXT_PUBLIC_URL:-http://localhost:3000}
+        NEXT_PUBLIC_ENV_MODE: ${NEXT_PUBLIC_ENV_MODE:-LOCAL}
     ports:
       - "3000:3000"
     depends_on:

--- a/docs/DOCKER_COMPOSE_WINDOWS.md
+++ b/docs/DOCKER_COMPOSE_WINDOWS.md
@@ -1,0 +1,20 @@
+# Docker Compose no Windows
+
+Algumas instalações do Docker Desktop para Windows não disponibilizam o subcomando `docker compose`, apenas o executável `docker-compose`. Os scripts do Suna detectam automaticamente qual comando está disponível e usam `docker-compose` como fallback quando necessário.
+
+## Como o repositório detecta
+- Primeiro tenta `docker compose version`.
+- Se falhar, tenta `docker-compose version`.
+- Se nenhum funcionar, o script avisa para instalar o Docker Desktop ou o Docker Compose.
+
+## Onde isso é aplicado
+- `start.py` e `setup.py` usam o comando detectado para subir/derrubar serviços e gerar instruções.
+- Mensagens de ajuda e dicas passam a exibir o comando certo para o seu ambiente.
+
+## Verificação manual
+```powershell
+docker compose version  # deve funcionar em instalações mais novas
+docker-compose version  # fallback disponível no Docker Desktop
+```
+
+Se apenas `docker-compose` funcionar, basta rodar os scripts normalmente — eles já farão o fallback.

--- a/docs/ESTHER_IN_SUNA.md
+++ b/docs/ESTHER_IN_SUNA.md
@@ -1,0 +1,26 @@
+# Demo da Esther no sandbox do Suna (Daytona)
+
+Passo a passo para rodar o agente Esther diretamente no sandbox do Suna (via chat).
+
+## 1) No chat do Suna
+Peça para o agente executar comandos em sandbox e cole o bloco abaixo:
+
+```bash
+cat > task.json <<'EOF'
+{"project":"Esther Orbiter","goal":"Demo run via Suna sandbox","params":{"mode":"status_report","lang":"pt-PT"}}
+EOF
+git clone https://github.com/19721102/esther-orbiter.git
+cd esther-orbiter
+bash scripts/kortix_agent_bootstrap.sh ../task.json
+cat out_kortix/result.json
+ls -la out_kortix
+```
+
+> Antes de rebuildar o frontend local, copie `frontend/.env.example` para `frontend/.env.local` e rode `docker-compose up -d --build`.
+
+## 2) Artefatos esperados
+- `out_kortix/result.json`
+- `out_kortix/report.txt`
+- `out_kortix/run.log`
+
+Esses arquivos são gerados pelo bootstrap e contêm o resultado, relatório e log do run.

--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,34 @@ def print_error(message):
     print(f"{Colors.RED}❌  {message}{Colors.ENDC}")
 
 
+
+def detect_docker_compose_command():
+    """Detects whether 'docker compose' or 'docker-compose' is available."""
+    candidates = [
+        ["docker", "compose"],
+        ["docker-compose"],
+    ]
+    for cmd in candidates:
+        try:
+            subprocess.run(
+                cmd + ["version"],
+                capture_output=True,
+                text=True,
+                check=True,
+                shell=IS_WINDOWS,
+            )
+            return cmd
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            continue
+
+    print_error("Docker Compose command not found. Install Docker Desktop or docker-compose.")
+    return None
+
+
+def format_compose_cmd(compose_cmd):
+    """Formats the compose command list for display."""
+    return " ".join(compose_cmd) if compose_cmd else "docker compose"
+
 # --- Environment File Parsing ---
 def parse_env_file(filepath):
     """Parses a .env file and returns a dictionary of key-value pairs."""
@@ -323,6 +351,15 @@ class SetupWizard:
                 self.env_vars[key] = value
 
         self.total_steps = 17
+        self.compose_cmd = None
+
+    def get_compose_command(self):
+        """Returns the docker compose command list, caching the detection result."""
+        if self.compose_cmd:
+            return self.compose_cmd
+        self.compose_cmd = detect_docker_compose_command()
+        return self.compose_cmd
+
 
     def show_current_config(self):
         """Shows the current configuration status."""
@@ -623,6 +660,9 @@ class SetupWizard:
     def check_requirements(self):
         """Checks if all required tools for the chosen setup method are installed."""
         print_step(2, self.total_steps, "Checking Requirements")
+
+        compose_cmd = self.get_compose_command()
+        compose_cmd_str = format_compose_cmd(compose_cmd) if compose_cmd else "docker compose"
 
         if self.env_vars["setup_method"] == "docker":
             requirements = {
@@ -1779,9 +1819,14 @@ class SetupWizard:
         print_step(17, self.total_steps, "Starting Kortix Super Worker")
         if self.env_vars["setup_method"] == "docker":
             print_info("Starting Kortix Super Worker with Docker Compose...")
+            compose_cmd = self.get_compose_command()
+            if not compose_cmd:
+                print_warning("Docker Compose command not detected. Install Docker Desktop or docker-compose and rerun.")
+                return
+            compose_cmd_str = format_compose_cmd(compose_cmd)
             try:
                 subprocess.run(
-                    ["docker", "compose", "up", "-d", "--build"],
+                    compose_cmd + ["up", "-d", "--build"],
                     check=True,
                     shell=IS_WINDOWS,
                 )
@@ -1789,7 +1834,7 @@ class SetupWizard:
                 time.sleep(15)
                 # A simple check to see if containers are running
                 result = subprocess.run(
-                    ["docker", "compose", "ps"],
+                    compose_cmd + ["ps"],
                     capture_output=True,
                     text=True,
                     shell=IS_WINDOWS,
@@ -1798,7 +1843,7 @@ class SetupWizard:
                     print_success("Kortix Super Worker services are starting up!")
                 else:
                     print_warning(
-                        "Some services might not be running. Check 'docker compose ps' for details."
+                        "Some services might not be running. Check '{compose_cmd_str} ps' for details."
                     )
             except subprocess.SubprocessError as e:
                 print_error(f"Failed to start Kortix Super Worker with Docker Compose: {e}")
@@ -1808,13 +1853,13 @@ class SetupWizard:
                 print_info(
                     "WORKAROUND: Try starting without rebuilding:"
                 )
-                print_info(f"  {Colors.CYAN}docker compose up -d{Colors.ENDC} (without --build)")
+                print_info(f"  {Colors.CYAN}{compose_cmd_str} up -d{Colors.ENDC} (without --build)")
                 print_info(
                     "\nIf that doesn't work, you may need to:"
                 )
                 print_info(f"  1. {Colors.CYAN}cd frontend{Colors.ENDC}")
                 print_info(f"  2. {Colors.CYAN}npm run build{Colors.ENDC}")
-                print_info(f"  3. {Colors.CYAN}cd .. && docker compose up -d{Colors.ENDC}")
+                print_info(f"  3. {Colors.CYAN}cd .. && {compose_cmd_str} up -d{Colors.ENDC}")
                 # Don't exit, let the final instructions show
                 return
         else:
@@ -1859,13 +1904,13 @@ class SetupWizard:
             
             print("\nUseful Docker commands:")
             print(
-                f"  {Colors.CYAN}docker compose ps{Colors.ENDC}         - Check service status"
+                f"  {Colors.CYAN}{compose_cmd_str} ps{Colors.ENDC}         - Check service status"
             )
             print(
-                f"  {Colors.CYAN}docker compose logs -f{Colors.ENDC}    - Follow logs"
+                f"  {Colors.CYAN}{compose_cmd_str} logs -f{Colors.ENDC}    - Follow logs"
             )
             print(
-                f"  {Colors.CYAN}docker compose down{Colors.ENDC}       - Stop Kortix Super Worker services"
+                f"  {Colors.CYAN}{compose_cmd_str} down{Colors.ENDC}       - Stop Kortix Super Worker services"
             )
             print(
                 f"  {Colors.CYAN}python start.py{Colors.ENDC}           - To start or stop Kortix Super Worker services"
@@ -1893,7 +1938,7 @@ class SetupWizard:
             print(
                 f"\n{Colors.BOLD}{step_num}. Start Infrastructure (in project root):{Colors.ENDC}"
             )
-            print(f"{Colors.CYAN}   docker compose up redis -d{Colors.ENDC}")
+            print(f"{Colors.CYAN}   {compose_cmd_str} up redis -d{Colors.ENDC}")
             step_num += 1
 
             print(


### PR DESCRIPTION
﻿## What / Why
This PR fixes Windows environments where `docker compose` is unavailable (but `docker-compose` exists), by adding automatic detection/fallback in `start.py`/`setup.py`.

It also documents and standardizes local Next.js public env configuration by passing `NEXT_PUBLIC_*` as Docker build args (defaults point to `/v1`) so the dashboard connects correctly.

## Changes
- `start.py`, `setup.py`: detect Compose command (try `docker compose`, fallback to `docker-compose`)
- `docker-compose.yaml`: pass `NEXT_PUBLIC_*` build args with defaults
- `docs/DOCKER_COMPOSE_WINDOWS.md`: Windows guidance
- `docs/ESTHER_IN_SUNA.md`: sandbox run notes

## How to test (Windows)
1) Run setup/start and ensure containers expose 3000/8000.
2) Verify API: http://localhost:8000/v1/health returns 200.
3) Open dashboard: http://localhost:3000/dashboard and hard refresh (Ctrl+F5).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Docker Compose command detection (Windows compatibility)**
> 
> - `start.py`/`setup.py`: detect and cache the available Compose command (`docker compose` → fallback to `docker-compose`), use it for all `up/ps/down` calls, and reflect it in help/instructions.
> 
> **Frontend build configuration**
> 
> - `docker-compose.yaml`: pass `NEXT_PUBLIC_BACKEND_URL`, `NEXT_PUBLIC_URL`, `NEXT_PUBLIC_ENV_MODE` as build args with localhost defaults so the Next.js app points to `/v1` locally.
> 
> **Docs**
> 
> - `docs/DOCKER_COMPOSE_WINDOWS.md`: explains Compose detection and fallback.
> - `docs/ESTHER_IN_SUNA.md`: adds sandbox run steps and expected artifacts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bbd6b095738c08ebbe5aa2c14b3ff4ac2289d020. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->