### PR TITLE
fix: Add thread-safety to ToolRegistry to prevent race conditions

### DIFF
--- a/backend/core/agentpress/tool_registry.py
+++ b/backend/core/agentpress/tool_registry.py
@@ -129,7 +129,7 @@ class ToolRegistry:
                         native_exposed += 1
                     else:
                         mcp_hidden += 1
-                    logger.debug(f"🔒 [HIDE] {tool_name} (MCP)")
+                        logger.debug(f"🔒 [HIDE] {tool_name} (MCP)")
             
             # Update cache while holding the lock
             self._cached_openapi_schemas = schemas


### PR DESCRIPTION
## 🐛 Bug Fix: Thread-Safety for ToolRegistry

### Problem
ToolRegistry had multiple thread-safety issues causing failures in concurrent scenarios:

**Critical Issues:**
1. **Race Condition in Cache** - Multiple threads simultaneously computing cache due to check-then-act pattern
2. **Dictionary Concurrent Modification** - `RuntimeError: dictionary changed size during iteration` when registering tools during parallel execution
3. **Cache Invalidation Race** - JIT-loaded tools not discovered due to stale cache reads
4. **Unsafe Iterations** - Unprotected dictionary iterations in `get_available_functions()` and `get_openapi_schemas()`

**Affected Scenarios:**
- Parallel tool execution (`tool_execution_strategy="parallel"`)
- Streaming execution with `execute_on_stream=True`
- JIT tool dynamic loading
- High-concurrency test scenarios

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens concurrency safety and caching in `backend/core/agentpress/tool_registry.py`.
> 
> - Introduces `threading.RLock` and wraps reads/writes with locks in `register_tool`, `get_tool`, `get_all_schemas`, and cache invalidation methods
> - Implements double-checked locking for `get_available_functions` and `get_openapi_schemas` to avoid redundant cache recomputation
> - Moves cache invalidation (`_cached_functions`, `_cached_openapi_schemas`) inside locked sections during registration and explicit invalidation
> - Maintains OpenAPI/MCP separation while computing schemas and updates the cache atomically
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 23ba4cab6595aa2581914b5e340822ddcf9ecc15. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->