### PR TITLE
fix: add all messages if cant be cahched

### DIFF
--- a/backend/core/agentpress/prompt_caching.py
+++ b/backend/core/agentpress/prompt_caching.py
@@ -457,13 +457,11 @@ async def apply_anthropic_caching_strategy(
         blocks_used += chunks_created
         logger.debug(f"✅ Created {chunks_created} conversation cache blocks")
     else:
-        # Conversation too large - need summarization or truncation
-        logger.warning(f"Conversation ({total_conversation_tokens} tokens) exceeds cache limit ({max_cacheable_tokens})")
-        # For now, add recent messages only (could implement summarization here)
-        recent_token_limit = min(cache_threshold_tokens * 2, max_cacheable_tokens)
-        recent_messages = get_recent_messages_within_token_limit(conversation_messages, recent_token_limit, model_name)
-        prepared_messages.extend(recent_messages)
-        logger.debug(f"Added {len(recent_messages)} recent messages ({get_messages_token_count(recent_messages, model_name)} tokens)")
+        # Conversation too large for caching - add ALL messages without cache_control
+        # The compression system handles truncation, caching should not drop messages
+        logger.warning(f"Conversation ({total_conversation_tokens} tokens) exceeds cache limit ({max_cacheable_tokens}) - adding all messages without caching")
+        prepared_messages.extend(conversation_messages)
+        logger.debug(f"Added all {len(conversation_messages)} messages uncached (compression will handle if needed)")
     
     logger.debug(f"🎯 Total cache blocks used: {blocks_used}/4")
     


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates overflow handling in `apply_anthropic_caching_strategy`:
> 
> - When `total_conversation_tokens` exceeds `max_cacheable_tokens`, add all conversation messages without `cache_control` rather than selecting only recent messages
> - Adjusts logs to reflect the new behavior and reliance on downstream compression for truncation
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5106dc61bb6a0562e70994c1ca427b88ad526570. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->