### PR TITLE
Fix NameError: compose_cmd_str not defined in final_instructions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1878,6 +1878,10 @@ class SetupWizard:
             f"Delete the {Colors.RED}.setup_progress{Colors.ENDC} file to reset the setup."
         )
 
+        # Get compose command for display
+        compose_cmd = self.get_compose_command()
+        compose_cmd_str = format_compose_cmd(compose_cmd)
+
         if self.env_vars["setup_method"] == "docker":
             print_info("Your Kortix Super Worker instance is ready to use!")
             


### PR DESCRIPTION
The compose_cmd_str variable was used but not defined in the final_instructions method, causing a crash when showing manual setup instructions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents a runtime error when showing final setup instructions by ensuring Docker Compose command strings are initialized.
> 
> - In `setup.py` `final_instructions()`, retrieves compose command via `get_compose_command()` and formats it with `format_compose_cmd()` to set `compose_cmd_str` before use
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4fc01e4153350303d55da4b94b13ad0e1f20e9ff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->