### PR TITLE
Refactor image handling in SandboxCanvasTool and SandboxImageEditTool…

### DIFF
--- a/backend/core/tools/sb_image_edit_tool.py
+++ b/backend/core/tools/sb_image_edit_tool.py
@@ -773,18 +773,12 @@ class SandboxImageEditTool(SandboxToolsBase):
                         elem_width = actual_width
                         elem_height = actual_height
                     
-                    # Convert to base64 for embedding
-                    ext = image_file.lower().split('.')[-1] if '.' in image_file else 'png'
-                    mime_map = {'png': 'image/png', 'jpg': 'image/jpeg', 'jpeg': 'image/jpeg', 'gif': 'image/gif', 'webp': 'image/webp'}
-                    mime_type = mime_map.get(ext, 'image/png')
-                    image_base64 = base64.b64encode(image_bytes).decode('utf-8')
-                    image_data_url = f"data:{mime_type};base64,{image_base64}"
-                    
-                    # Create element
+                    # Create element with PATH reference (NOT base64 - avoids LLM context bloat)
+                    # Frontend canvas-renderer.tsx fetches images via sandbox API
                     element = {
                         "id": str(uuid.uuid4()),
                         "type": "image",
-                        "src": image_data_url,
+                        "src": image_file,  # Store path, not base64
                         "x": current_x,
                         "y": current_y,
                         "width": elem_width,


### PR DESCRIPTION
… to use file path references instead of base64 data URLs. This change reduces context bloat for LLMs and improves performance by allowing the frontend to fetch images via the sandbox API. Updated comments for clarity on the new approach.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Refactor: path-based image handling (no base64 in canvases)**
> 
> - `sb_canvas_tool.py`: `add_image_to_canvas` now saves `src` as the image path (not base64); computes dimensions via PIL only for sizing; removes base64 logic/import; updates comments to note frontend fetch via sandbox API.
> - `list_canvas_elements`: returns `src` as path or `(embedded image)` indicator, never base64; adds safe defaults for `rotation`, `opacity`, `locked`.
> - `sb_image_edit_tool.py`: `_add_images_to_canvas` creates image elements with path-based `src` instead of base64.
> 
> *Net effect:* reduces LLM context bloat and lets frontend fetch images directly via sandbox API.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 740d1bc2d82db1a4a10e6ffe5c154e0ff14784df. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->