### PR TITLE
chore: replace csv and xl viewer with spreadsheet viewer

### DIFF
--- a/frontend/src/components/file-editors/index.tsx
+++ b/frontend/src/components/file-editors/index.tsx
@@ -9,8 +9,7 @@ import { PdfRenderer } from '@/components/file-renderers/pdf-renderer';
 import { ImageRenderer } from '@/components/file-renderers/image-renderer';
 import { VideoRenderer } from '@/components/file-renderers/video-renderer';
 import { BinaryRenderer } from '@/components/file-renderers/binary-renderer';
-import { CsvRenderer } from '@/components/file-renderers/csv-renderer';
-import { XlsxRenderer } from '@/components/file-renderers/xlsx-renderer';
+import { SpreadsheetViewer } from '../thread/tool-views/spreadsheet/SpreadsheetViewer';
 import { PptxRenderer } from '@/components/file-renderers/pptx-renderer';
 import { HtmlRenderer } from '@/components/file-renderers/html-renderer';
 import { CanvasRenderer } from '@/components/file-renderers/canvas-renderer';
@@ -203,16 +202,13 @@ export function EditableFileRenderer({
         <VideoRenderer url={binaryUrl} />
       ) : fileType === 'pdf' && binaryUrl ? (
         <PdfRenderer url={binaryUrl} />
-      ) : fileType === 'csv' ? (
-        <CsvRenderer content={content || ''} />
-      ) : fileType === 'xlsx' ? (
-        <XlsxRenderer
-          content={content}
+      ) : fileType === 'csv' || fileType === 'xlsx' ? (
+        <SpreadsheetViewer
           filePath={filePath}
           fileName={fileName}
+          sandboxId={project?.sandbox?.id}
           project={project}
-          onDownload={onDownload}
-          isDownloading={isDownloading}
+          allowEditing={!readOnly}
         />
       ) : fileType === 'pptx' ? (
         <PptxRenderer

--- a/frontend/src/components/file-renderers/index.tsx
+++ b/frontend/src/components/file-renderers/index.tsx
@@ -7,6 +7,7 @@ export { VideoRenderer, InlineVideoPlayer } from './video-renderer';
 export { BinaryRenderer } from './binary-renderer';
 export { CsvRenderer } from './csv-renderer';
 export { XlsxRenderer } from './xlsx-renderer';
+export { SpreadsheetViewer } from '../thread/tool-views/spreadsheet/SpreadsheetViewer';
 export { PptxRenderer } from './pptx-renderer';
 export { HtmlRenderer } from './html-renderer';
 export { JsonRenderer } from './JsonRenderer';

--- a/frontend/src/components/thread/file-attachment.tsx
+++ b/frontend/src/components/thread/file-attachment.tsx
@@ -16,7 +16,7 @@ import {
     isPdfExtension,
 } from '@/lib/utils/file-types';
 import { AttachmentGroup } from './attachment-group';
-import { HtmlRenderer, CsvRenderer, XlsxRenderer, PdfRenderer, JsonRenderer } from '@/components/file-renderers';
+import { HtmlRenderer, SpreadsheetViewer, PdfRenderer, JsonRenderer } from '@/components/file-renderers';
 import { UnifiedMarkdown } from '@/components/markdown';
 import {
     DropdownMenu,
@@ -718,30 +718,18 @@ export function FileAttachment({
                                 ) : null;
                             })()}
                             
-                            {/* XLSX Preview */}
-                            {isXlsx && (() => {
-                                const xlsxUrlForRender = localPreviewUrl || (sandboxId ? (xlsxBlobUrl ?? null) : fileUrl);
-                                return xlsxUrlForRender ? (
-                                    <XlsxRenderer
-                                        filePath={xlsxUrlForRender}
-                                        fileName={filename}
-                                        className="h-full w-full"
-                                        project={project}
-                                    />
-                                ) : null;
-                            })()}
-                            
-                            {/* CSV Preview - compact mode */}
-                            {isCsv && fileContent && (
-                                <CsvRenderer
-                                    content={fileContent}
+                            {(isCsv || isXlsx) && (
+                                <SpreadsheetViewer
+                                    filePath={filepath}
+                                    fileName={filename}
+                                    sandboxId={sandboxId}
+                                    project={project}
                                     className="h-full w-full"
                                     compact={true}
-                                    containerHeight={300}
+                                    showToolbar={false}
+                                    allowEditing={false}
                                 />
                             )}
-                            
-                            {/* Markdown Preview */}
                             {(extension === 'md' || extension === 'markdown') && fileContent && (
                                 <div className="h-full w-full overflow-auto p-4">
                                     <UnifiedMarkdown content={fileContent} />

--- a/frontend/src/components/thread/layout/thread-layout.tsx
+++ b/frontend/src/components/thread/layout/thread-layout.tsx
@@ -142,13 +142,19 @@ export const ThreadLayout = memo(function ThreadLayout({
   // Get selected file path from store
   const selectedFilePath = useKortixComputerStore((state) => state.selectedFilePath);
   
-  // Suite Mode - ONLY activates when VIEWING files in file browser
-  // NOT for tool views in chat - those stay normal size
+  const SUITE_MODE_FILE_EXTENSIONS = [
+    'kanvax', 
+    'pptx', 
+    'ppt', 
+    'xlsx', 
+    'xls', 
+    'csv'
+  ];
+
   const isSuiteMode = useMemo(() => {
-    // ONLY check file being viewed in file browser
     if (selectedFilePath) {
       const ext = selectedFilePath.split('.').pop()?.toLowerCase();
-      if (['kanvax', 'pptx', 'ppt'].includes(ext || '')) {
+      if (SUITE_MODE_FILE_EXTENSIONS.includes(ext || '')) {
         return true;
       }
     }

--- a/frontend/src/components/thread/tool-views/file-operation/FileOperationToolView.tsx
+++ b/frontend/src/components/thread/tool-views/file-operation/FileOperationToolView.tsx
@@ -25,7 +25,7 @@ import {
   getFileTypeFromExtension,
 } from '@/components/file-editors';
 import { UnifiedMarkdown } from '@/components/markdown';
-import { CsvRenderer, XlsxRenderer, HtmlRenderer, JsonRenderer } from '@/components/file-renderers';
+import { SpreadsheetViewer, HtmlRenderer, JsonRenderer } from '@/components/file-renderers';
 import { cn } from '@/lib/utils';
 import { useTheme } from 'next-themes';
 import { constructHtmlPreviewUrl } from '@/lib/utils/url';
@@ -714,26 +714,15 @@ export function FileOperationToolView({
       );
     }
 
-    // For CSV files
-    if (isCsv) {
+    // For CSV and XLSX files
+    if (isCsv || isXlsx) {
       return (
         <div className="p-6 flex flex-col">
           <div className="flex-1 min-h-[400px] w-full bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-lg overflow-hidden">
-            <CsvRenderer content={processUnicodeContent(fileContent)} />
-          </div>
-        </div>
-      );
-    }
-
-    // For XLSX files
-    if (isXlsx) {
-      return (
-        <div className="p-6 flex flex-col">
-          <div className="flex-1 min-h-[400px] w-full bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-lg overflow-hidden">
-            <XlsxRenderer
-              content={fileContent}
-              filePath={processedFilePath}
+            <SpreadsheetViewer
+              filePath={filePath}
               fileName={fileName}
+              sandboxId={project?.sandbox?.id}
               project={project}
             />
           </div>

--- a/frontend/src/components/thread/tool-views/sheets-tools/sheets-tool-view.tsx
+++ b/frontend/src/components/thread/tool-views/sheets-tools/sheets-tool-view.tsx
@@ -8,7 +8,7 @@ import { CheckCircle, AlertTriangle, Download, FileSpreadsheet, Table, Grid, Tab
 import { cn } from '@/lib/utils';
 import { parseToolResult } from '../tool-result-parser';
 import { FileAttachment } from '../../file-attachment';
-import { XlsxRenderer } from '@/components/file-renderers';
+import { SpreadsheetViewer } from '@/components/file-renderers';
 import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem } from '@/components/ui/dropdown-menu';
 import { useAuth } from '@/components/AuthProvider';
 import { fetchFileContent } from '@/hooks/files/use-file-queries';
@@ -229,7 +229,7 @@ export function SheetsToolView({
               <div className="p-4 flex flex-col space-y-4">
                 {primaryXlsx ? (
                   <div className="space-y-3">
-                    <XlsxRenderer
+                    <SpreadsheetViewer
                       filePath={primaryXlsx}
                       fileName={(primaryXlsx.split('/').pop() || 'sheet.xlsx')}
                       project={project}

--- a/frontend/src/components/thread/tool-views/spreadsheet/SpreadsheetViewer.tsx
+++ b/frontend/src/components/thread/tool-views/spreadsheet/SpreadsheetViewer.tsx
@@ -1,0 +1,380 @@
+'use client';
+
+import { useRef, useState, useEffect, useCallback } from 'react';
+import { SpreadsheetComponent } from '@syncfusion/ej2-react-spreadsheet';
+import { registerLicense } from '@syncfusion/ej2-base';
+import { Loader2, FileSpreadsheet, Download, RefreshCw } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { useSpreadsheetSync } from './useSpreadsheetSync';
+import { SyncStatusIndicator } from './SyncStatusIndicator';
+import { Button } from '@/components/ui/button';
+import { useAuth } from '@/components/AuthProvider';
+import { toast } from 'sonner';
+import { useDownloadRestriction } from '@/hooks/billing';
+
+import '../../../../../node_modules/@syncfusion/ej2-base/styles/material.css';
+import '../../../../../node_modules/@syncfusion/ej2-inputs/styles/material.css';
+import '../../../../../node_modules/@syncfusion/ej2-buttons/styles/material.css';
+import '../../../../../node_modules/@syncfusion/ej2-splitbuttons/styles/material.css';
+import '../../../../../node_modules/@syncfusion/ej2-lists/styles/material.css';
+import '../../../../../node_modules/@syncfusion/ej2-navigations/styles/material.css';
+import '../../../../../node_modules/@syncfusion/ej2-popups/styles/material.css';
+import '../../../../../node_modules/@syncfusion/ej2-dropdowns/styles/material.css';
+import '../../../../../node_modules/@syncfusion/ej2-grids/styles/material.css';
+import '../../../../../node_modules/@syncfusion/ej2-react-spreadsheet/styles/material.css';
+import { SpreadsheetLoader } from './SpreadsheetLoader';
+
+const SYNCFUSION_LICENSE = "Ngo9BigBOggjHTQxAR8/V1JGaF5cXGpCf0x0QHxbf1x2ZFFMYFtbRHZPMyBoS35Rc0RhW3ledHRSRmVeVUx+VEFf";
+const SYNCFUSION_BASE_URL = 'https://ej2services.syncfusion.com/production/web-services/api/spreadsheet';
+
+registerLicense(SYNCFUSION_LICENSE);
+
+export type SyncStatus = 'idle' | 'syncing' | 'synced' | 'error' | 'offline' | 'conflict';
+
+export interface SyncState {
+  status: SyncStatus;
+  lastSyncedAt: number | null;
+  pendingChanges: boolean;
+  errorMessage?: string;
+  retryCount: number;
+}
+
+interface SpreadsheetViewerProps {
+  filePath?: string;
+  fileName: string;
+  className?: string;
+  sandboxId?: string;
+  project?: {
+    sandbox?: {
+      id?: string;
+    };
+  };
+  compact?: boolean;
+  showToolbar?: boolean;
+  showDownloadButton?: boolean;
+  allowEditing?: boolean;
+  onSyncStateChange?: (state: SyncState) => void;
+  onActionsReady?: (actions: { forceRefresh: () => Promise<boolean>; forceSave: () => void; resolveConflict: (keepLocal: boolean) => Promise<void> }) => void;
+  onLoadingChange?: (isLoading: boolean) => void;
+  onDownloadReady?: (download: () => void) => void;
+  onDownloadingChange?: (isDownloading: boolean) => void;
+}
+
+export function SpreadsheetViewer({
+  filePath,
+  fileName,
+  className,
+  sandboxId,
+  project,
+  compact = false,
+  showToolbar = true,
+  showDownloadButton = true,
+  allowEditing = true,
+  onSyncStateChange,
+  onActionsReady,
+  onLoadingChange,
+  onDownloadReady,
+  onDownloadingChange,
+}: SpreadsheetViewerProps) {
+  const ssRef = useRef<SpreadsheetComponent>(null);
+  const { session } = useAuth();
+  const [isDownloading, setIsDownloading] = useState(false);
+  const { isRestricted: isDownloadRestricted, openUpgradeModal } = useDownloadRestriction({
+    featureName: 'files',
+  });
+  
+  useEffect(() => {
+    const style = document.createElement('style');
+    style.innerHTML = `
+      .e-popup,
+      .e-popup-open,
+      .e-dropdown-popup,
+      .e-colorpicker-popup,
+      .e-dialog,
+      .e-menu-wrapper,
+      .e-contextmenu-wrapper,
+      .e-ul,
+      .e-menu-popup {
+        z-index: 999999 !important;
+      }
+    `;
+    document.head.appendChild(style);
+    return () => {
+      document.head.removeChild(style);
+    };
+  }, []);
+  
+  const resolvedSandboxId = sandboxId || project?.sandbox?.id;
+  
+  const resolvedFilePath = (() => {
+    if (!filePath) {
+      console.warn('[SpreadsheetViewer] No filePath provided, only fileName:', fileName);
+      return null;
+    }
+    
+    let path = filePath;
+    
+    if (path.startsWith('blob:')) {
+      console.log('[SpreadsheetViewer] Using blob URL:', path);
+      return path;
+    }
+    
+    if (!path.startsWith('/')) {
+      if (path.startsWith('workspace')) {
+        path = '/' + path;
+      } else if (!path.includes('workspace')) {
+        path = `/workspace/${path}`;
+      }
+    }
+    
+    console.log('[SpreadsheetViewer] Resolved path:', {
+      original: filePath,
+      resolved: path,
+      fileName,
+      sandboxId: resolvedSandboxId
+    });
+    
+    return path;
+  })();
+
+  const {
+    syncState,
+    isLoading,
+    handlers,
+    actions,
+  } = useSpreadsheetSync({
+    sandboxId: resolvedSandboxId,
+    filePath: resolvedFilePath,
+    spreadsheetRef: ssRef,
+    enabled: !!resolvedSandboxId && !!resolvedFilePath,
+    debounceMs: 1500,
+    maxRetries: 3,
+    pollIntervalMs: 5000,
+  });
+
+  useEffect(() => {
+    if (onSyncStateChange) {
+      onSyncStateChange(syncState);
+    }
+  }, [syncState, onSyncStateChange]);
+
+  useEffect(() => {
+    if (onLoadingChange) {
+      onLoadingChange(isLoading);
+    }
+  }, [isLoading, onLoadingChange]);
+
+  useEffect(() => {
+    if (onActionsReady) {
+      onActionsReady(actions);
+    }
+  }, [actions, onActionsReady]);
+
+  const handleDownload = useCallback(async () => {
+    if (isDownloadRestricted) {
+      openUpgradeModal();
+      return;
+    }
+    
+    if (!resolvedSandboxId || !resolvedFilePath || !session?.access_token) {
+      console.error('[SpreadsheetViewer] Download failed - missing:', {
+        resolvedSandboxId,
+        resolvedFilePath,
+        hasSession: !!session?.access_token
+      });
+      toast.error('Unable to download file');
+      return;
+    }
+
+    console.log('[SpreadsheetViewer] Downloading:', {
+      sandboxId: resolvedSandboxId,
+      filePath: resolvedFilePath,
+      fileName
+    });
+
+    setIsDownloading(true);
+    try {
+      const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/sandboxes/${resolvedSandboxId}/files/content?path=${encodeURIComponent(resolvedFilePath)}`, {
+        headers: {
+          'Authorization': `Bearer ${session.access_token}`
+        }
+      });
+
+      if (!response.ok) {
+        throw new Error(`Download failed: ${response.status}`);
+      }
+
+      const blob = await response.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = fileName;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+      
+      toast.success('File downloaded successfully');
+    } catch (error) {
+      console.error('[SpreadsheetViewer] Download error:', error);
+      toast.error('Failed to download file');
+    } finally {
+      setIsDownloading(false);
+    }
+  }, [resolvedSandboxId, resolvedFilePath, fileName, session, isDownloadRestricted, openUpgradeModal]);
+
+  useEffect(() => {
+    if (onDownloadReady) {
+      onDownloadReady(handleDownload);
+    }
+  }, [handleDownload, onDownloadReady]);
+
+  useEffect(() => {
+    if (onDownloadingChange) {
+      onDownloadingChange(isDownloading);
+    }
+  }, [isDownloading, onDownloadingChange]);
+
+  if (!resolvedFilePath) {
+    return (
+      <div className={cn('w-full h-full flex items-center justify-center', className)}>
+        <div className="text-center space-y-3">
+          <div className="w-16 h-16 mx-auto rounded-full bg-muted flex items-center justify-center">
+            <FileSpreadsheet className="h-8 w-8 text-muted-foreground" />
+          </div>
+          <div>
+            <h3 className="text-lg font-medium text-foreground">No file path provided</h3>
+            <p className="text-xs text-muted-foreground">FilePath is required to load the spreadsheet</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (syncState.status === 'error' && !isLoading) {
+    return (
+      <div className={cn('w-full h-full flex items-center justify-center', className)}>
+        <div className="text-center space-y-3">
+          <div className="w-16 h-16 mx-auto rounded-full bg-muted flex items-center justify-center">
+            <FileSpreadsheet className="h-8 w-8 text-muted-foreground" />
+          </div>
+          <div>
+            <h3 className="text-lg font-medium text-foreground">Failed to load spreadsheet</h3>
+            <p className="text-xs text-muted-foreground">{syncState.errorMessage || 'Unknown error'}</p>
+            {resolvedFilePath && (
+              <p className="text-xs text-muted-foreground mt-1">Path: {resolvedFilePath}</p>
+            )}
+            <Button
+              onClick={actions.forceRefresh}
+              variant="outline"
+              size="sm"
+              className="mt-3"
+            >
+              <RefreshCw className="w-3 h-3 mr-2" />
+              Retry
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn('w-full h-full relative flex flex-col', className)}>
+      {showToolbar && !compact && (
+        <div className="flex items-center justify-between px-4 py-2 border-b border-zinc-200 dark:border-zinc-700 bg-zinc-50/80 dark:bg-zinc-900/80 backdrop-blur-sm">
+          <div className="flex items-center gap-2">
+            <FileSpreadsheet className="w-4 h-4 text-emerald-500" />
+            <span className="text-sm font-medium text-zinc-900 dark:text-white truncate max-w-[200px]">
+              {fileName}
+            </span>
+            {syncState.pendingChanges && (
+              <span className="w-2 h-2 rounded-full bg-orange-500 shrink-0" title="Unsaved changes" />
+            )}
+          </div>
+          <div className="flex items-center gap-2">
+            <SyncStatusIndicator
+              status={syncState.status}
+              lastSyncedAt={syncState.lastSyncedAt}
+              pendingChanges={syncState.pendingChanges}
+              errorMessage={syncState.errorMessage}
+              onRefresh={actions.forceRefresh}
+              onResolveConflict={actions.resolveConflict}
+            />
+            {showDownloadButton && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={handleDownload}
+                disabled={isDownloading}
+                className="h-7 px-2"
+                title="Download file"
+              >
+                {isDownloading ? (
+                  <Loader2 className="w-3 h-3 animate-spin" />
+                ) : (
+                  <Download className="w-3 h-3" />
+                )}
+              </Button>
+            )}
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={actions.forceRefresh}
+              disabled={isLoading || syncState.status === 'syncing'}
+              className="h-7 px-2"
+            >
+              <RefreshCw className={cn("w-3 h-3", isLoading && "animate-spin")} />
+            </Button>
+          </div>
+        </div>
+      )}
+      
+      <div className="flex-1 relative">
+        <SpreadsheetComponent
+          ref={ssRef}
+          openUrl={`${SYNCFUSION_BASE_URL}/open`}
+          saveUrl={`${SYNCFUSION_BASE_URL}/save`}
+          showRibbon={!compact && allowEditing}
+          showFormulaBar={!compact && allowEditing}
+          showSheetTabs={true}
+          allowEditing={allowEditing}
+          allowOpen={true}
+          allowSave={allowEditing}
+          allowScrolling={true}
+          allowResizing={allowEditing}
+          allowCellFormatting={allowEditing}
+          allowNumberFormatting={allowEditing}
+          allowConditionalFormat={allowEditing}
+          allowDataValidation={allowEditing}
+          allowHyperlink={allowEditing}
+          allowInsert={allowEditing}
+          allowDelete={allowEditing}
+          allowMerge={allowEditing}
+          allowSorting={true}
+          allowFiltering={true}
+          allowWrap={allowEditing}
+          allowFreezePane={allowEditing}
+          allowUndoRedo={allowEditing}
+          allowChart={allowEditing}
+          allowImage={allowEditing}
+          enableClipboard={true}
+          cellEdit={handlers.handleCellEdit}
+          cellSave={handlers.handleCellSave}
+          actionComplete={handlers.handleActionComplete}
+          beforeSave={handlers.handleBeforeSave}
+          saveComplete={handlers.handleSaveComplete}
+          created={handlers.handleCreated}
+          openComplete={handlers.handleOpenComplete}
+          openFailure={handlers.handleOpenFailure}
+        />
+        
+        {isLoading && (
+          <div className="absolute inset-0 z-50 bg-background/95 backdrop-blur-sm">
+            <SpreadsheetLoader mode="max" />
+            </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/thread/tool-views/spreadsheet/useSpreadsheetSync.ts
+++ b/frontend/src/components/thread/tool-views/spreadsheet/useSpreadsheetSync.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { SpreadsheetComponent } from '@syncfusion/ej2-react-spreadsheet';
 import { backendApi } from '@/lib/api-client';
 import { getSandboxFileContent } from '@/lib/api/sandbox';
@@ -597,24 +597,28 @@ export function useSpreadsheetSync({
     }
   }, [forceSave, forceRefresh]);
 
+  const memoizedHandlers = useMemo(() => ({
+    handleCellEdit,
+    handleCellSave,
+    handleActionComplete,
+    handleBeforeSave,
+    handleSaveComplete,
+    handleOpenComplete,
+    handleOpenFailure,
+    handleCreated,
+  }), [handleCellEdit, handleCellSave, handleActionComplete, handleBeforeSave, handleSaveComplete, handleOpenComplete, handleOpenFailure, handleCreated]);
+
+  const memoizedActions = useMemo(() => ({
+    forceRefresh,
+    forceSave,
+    resolveConflict,
+  }), [forceRefresh, forceSave, resolveConflict]);
+
   return {
     syncState,
     isLoading,
     isComponentReady,
-    handlers: {
-      handleCellEdit,
-      handleCellSave,
-      handleActionComplete,
-      handleBeforeSave,
-      handleSaveComplete,
-      handleOpenComplete,
-      handleOpenFailure,
-      handleCreated,
-    },
-    actions: {
-      forceRefresh,
-      forceSave,
-      resolveConflict,
-    },
+    handlers: memoizedHandlers,
+    actions: memoizedActions,
   };
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Unifies spreadsheet handling and improves UX for CSV/XLSX files using a single viewer with sync + download support.
> 
> - Replace `CsvRenderer`/`XlsxRenderer` with `SpreadsheetViewer` in file editor, file attachments, `FileOperationToolView`, Sheets tool view, and Spreadsheet tool view
> - New `SpreadsheetViewer` component centralizes Syncfusion sheet rendering, editing toggles, loading/loader UI, sync status (`SyncStatusIndicator` via `useSpreadsheetSync`), and download (with auth + billing restriction checks)
> - Wire up callbacks: `onSyncStateChange`, `onActionsReady`, `onLoadingChange`, `onDownloadReady`, `onDownloadingChange`; expose download buttons in Spreadsheet tool view and `SpreadsheetApp`
> - Add suite mode detection to include `csv`/`xlsx` so side panel auto-expands for spreadsheets; re-export `SpreadsheetViewer` from `file-renderers/index.tsx`
> - Minor stability/perf: memoize handlers/actions in `useSpreadsheetSync`, normalize sandbox file paths, consistent toolbar visibility and read-only options
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d1e279de330922ff3cd620bfe217eff1f51956c9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->