### PR TITLE
fetch recent mssage by chceking last mesg

### DIFF
--- a/backend/supabase/migrations/20251227222453_fix_categorization_use_message_created_at.sql
+++ b/backend/supabase/migrations/20251227222453_fix_categorization_use_message_created_at.sql
@@ -1,0 +1,33 @@
+-- Fix: Use messages.created_at instead of threads.updated_at
+-- threads.updated_at can be bumped by migrations, causing false positives
+-- messages.created_at only changes when user actually sends a message
+
+CREATE OR REPLACE FUNCTION get_stale_projects_for_categorization(
+    stale_threshold TIMESTAMP WITH TIME ZONE,
+    max_count INT DEFAULT 50
+)
+RETURNS TABLE (project_id UUID) 
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+AS $$
+    SELECT p.project_id
+    FROM projects p
+    INNER JOIN threads t ON t.project_id = p.project_id
+    INNER JOIN (
+        SELECT m.thread_id, MAX(m.created_at) as last_message_at
+        FROM messages m
+        WHERE m.type = 'user'
+        GROUP BY m.thread_id
+    ) msg_activity ON msg_activity.thread_id = t.thread_id
+    WHERE msg_activity.last_message_at < stale_threshold
+      AND (p.last_categorized_at IS NULL OR p.last_categorized_at < msg_activity.last_message_at)
+    ORDER BY msg_activity.last_message_at DESC
+    LIMIT max_count;
+$$;
+
+-- Add index on messages for faster lookups
+CREATE INDEX IF NOT EXISTS idx_messages_thread_type_created 
+ON messages (thread_id, type, created_at DESC);
+
+


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Corrects project categorization staleness logic to rely on actual user activity and improves query performance.
> 
> - Updates `get_stale_projects_for_categorization` to use `MAX(messages.created_at)` (user messages only) per thread instead of `threads.updated_at`
> - Returns projects where `last_message_at < stale_threshold` and `last_categorized_at` is null or older than `last_message_at`
> - Adds index `idx_messages_thread_type_created` on `messages(thread_id, type, created_at DESC)` to speed lookups
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3931c2abc931fc5bb217cae3345a2dbb5bbb53ce. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->