### PR TITLE
Backend frontend claims matching

### DIFF
--- a/backend/core/billing/shared/config.py
+++ b/backend/core/billing/shared/config.py
@@ -17,6 +17,12 @@ CREDITS_PER_DOLLAR = 100
 
 FREE_TIER_INITIAL_CREDITS = Decimal('0.00')
 
+# "Unlimited" plan limits
+# We keep these as large integers (instead of None/inf) to avoid touching downstream
+# DB queries, JSON serialization, and comparison logic across the codebase.
+UNLIMITED_THREAD_LIMIT = 100_000
+UNLIMITED_PROJECT_LIMIT = UNLIMITED_THREAD_LIMIT * 2
+
 @dataclass
 class Tier:
     name: str
@@ -91,12 +97,16 @@ TIERS: Dict[str, Tier] = {
         display_name='Plus',
         can_purchase_credits=False,
         models=['all'],
-        project_limit=200,  # 2x thread_limit
-        thread_limit=100,
+        # Frontend advertises "Unlimited Chats" on paid tiers.
+        # Threads are effectively "chats" and each thread creates a project, so both
+        # limits must be raised together to avoid mismatches and unexpected blocking.
+        project_limit=UNLIMITED_PROJECT_LIMIT,  # 2x thread_limit
+        thread_limit=UNLIMITED_THREAD_LIMIT,
         concurrent_runs=3,
         custom_workers_limit=5,
         scheduled_triggers_limit=5,
-        app_triggers_limit=10,
+        # Matches frontend pricing copy: "25 app triggers"
+        app_triggers_limit=25,
         memory_config={
             'enabled': True,
             'max_memories': 100,
@@ -120,12 +130,13 @@ TIERS: Dict[str, Tier] = {
         display_name='Pro',
         can_purchase_credits=False,
         models=['all'],
-        project_limit=1000,  # 2x thread_limit
-        thread_limit=500,
+        project_limit=UNLIMITED_PROJECT_LIMIT,  # 2x thread_limit
+        thread_limit=UNLIMITED_THREAD_LIMIT,
         concurrent_runs=5,
         custom_workers_limit=20,
         scheduled_triggers_limit=10,
-        app_triggers_limit=25,
+        # Matches frontend pricing copy: "50 app triggers"
+        app_triggers_limit=50,
         memory_config={
             'enabled': True,
             'max_memories': 500,
@@ -149,12 +160,13 @@ TIERS: Dict[str, Tier] = {
         display_name='Ultra',
         can_purchase_credits=True,
         models=['all'],
-        project_limit=5000,  # 2x thread_limit
-        thread_limit=2500,
+        project_limit=UNLIMITED_PROJECT_LIMIT,  # 2x thread_limit
+        thread_limit=UNLIMITED_THREAD_LIMIT,
         concurrent_runs=20,
         custom_workers_limit=100,
         scheduled_triggers_limit=50,
-        app_triggers_limit=100,
+        # Matches frontend pricing copy: "200 app triggers"
+        app_triggers_limit=200,
         memory_config={
             'enabled': True,
             'max_memories': 2000,

--- a/frontend/src/components/dashboard/usage-limits-popover.tsx
+++ b/frontend/src/components/dashboard/usage-limits-popover.tsx
@@ -18,6 +18,12 @@ export function UsageLimitsPopover() {
   const t = useTranslations('dashboard');
   const { data: accountState } = useAccountState();
   const limits = accountState?.limits;
+  const UNLIMITED_THRESHOLD = 100_000;
+
+  const formatMax = (max: number | undefined) => {
+    const value = max || 0;
+    return value >= UNLIMITED_THRESHOLD ? 'Unlimited' : value;
+  };
 
   return (
     <Popover>
@@ -36,7 +42,9 @@ export function UsageLimitsPopover() {
                   <TooltipTrigger asChild>
                     <div className="flex justify-between text-xs cursor-help">
                       <span className="text-muted-foreground">Chats</span>
-                      <span className="font-medium">{limits?.threads?.current || 0} / {limits?.threads?.max || 0}</span>
+                      <span className="font-medium">
+                        {limits?.threads?.current || 0} / {formatMax(limits?.threads?.max)}
+                      </span>
                     </div>
                   </TooltipTrigger>
                   <TooltipContent>
@@ -45,7 +53,11 @@ export function UsageLimitsPopover() {
                 </Tooltip>
                 <Progress 
                   className='h-1'
-                  value={((limits?.threads?.current || 0) / (limits?.threads?.max || 1)) * 100} 
+                  value={
+                    (limits?.threads?.max || 0) >= UNLIMITED_THRESHOLD
+                      ? 0
+                      : ((limits?.threads?.current || 0) / (limits?.threads?.max || 1)) * 100
+                  }
                 />
               </div>
               <div className='space-y-2'>


### PR DESCRIPTION
Align backend tier limits with frontend marketing claims and display "Unlimited" for high caps in the UI.

The frontend advertised "Unlimited Chats" for paid tiers while the backend enforced a 100-chat limit. Additionally, app trigger limits in the backend (`10/25/100`) did not match frontend claims (`25/50/200`). This PR updates backend limits to reflect marketing copy and ensures the UI displays "Unlimited" for effectively uncapped features, preventing user confusion and inconsistencies. It also fixes an edge case where accounts without agents were shown incorrect hard-coded trigger limits.

---
[Slack Thread](https://kortixworkspace.slack.com/archives/C08QYH7MV6F/p1766931369648039?thread_ts=1766931369.648039&cid=C08QYH7MV6F)

<a href="https://cursor.com/background-agent?bcId=bc-caa358b7-04f9-4efe-a534-67c7201939de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-caa358b7-04f9-4efe-a534-67c7201939de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates plan constraints to match pricing copy and improves limits display/accuracy.
> 
> - Sets paid tiers (`Plus/Pro/Ultra`) to effectively unlimited `thread_limit` and matching `project_limit`; adjusts `app_triggers_limit` to 25/50/200
> - Adds constants `UNLIMITED_THREAD_LIMIT` and `UNLIMITED_PROJECT_LIMIT` to avoid infinite/null handling across systems
> - In `limits_checker.check_trigger_limit`, when an account has no agents, return tier-derived `scheduled`/`app` limits instead of hardcoded values
> - In `usage-limits-popover.tsx`, show "Unlimited" for very high caps and avoid progress fill for unlimited threads
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b8cf1838b989a9b29314859171995f8b2e83632a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->