### PR TITLE
fix minimax fallback

### DIFF
--- a/backend/core/services/llm.py
+++ b/backend/core/services/llm.py
@@ -191,15 +191,9 @@ async def make_llm_api_call(
     
     params = model_manager.get_litellm_params(resolved_model_name, **override_params)
     
-    # Add OpenRouter app parameter if using OpenRouter
-    # Check if the actual LiteLLM model ID is an OpenRouter model
-    actual_litellm_model_id = params.get("model", resolved_model_name)
-    if isinstance(actual_litellm_model_id, str) and actual_litellm_model_id.startswith("openrouter/"):
-        # OpenRouter requires the "app" parameter in extra_body
-        if "extra_body" not in params:
-            params["extra_body"] = {}
-        params["extra_body"]["app"] = "Kortix.com"
-        logger.debug(f"Added OpenRouter app parameter: Kortix.com for model {actual_litellm_model_id}")
+    # Note: OpenRouter app name is handled via OR_APP_NAME env var (set in setup_api_keys)
+    # We don't add extra_body here because it breaks fallback to non-OpenRouter models (e.g., Bedrock)
+    # LiteLLM automatically picks up OR_APP_NAME and OR_SITE_URL for OpenRouter calls
     
     # Add tools if provided
     if tools:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Relies on environment variables for OpenRouter metadata to avoid breaking non-OpenRouter fallbacks.
> 
> - Removes manual `extra_body.app` injection in `llm.py`; documents using `OR_APP_NAME`/`OR_SITE_URL` picked up by LiteLLM
> - Prevents parameter incompatibilities that blocked fallbacks to other providers (e.g., Bedrock/Minimax)
> - No external API changes; only request parameter construction adjusted
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 21459dec117d676641a43bb2dade1bc60fa78a98. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->