### PR TITLE
refactor: remove specific feature context from pricing modal trigger …

### DIFF
--- a/frontend/src/components/dashboard/dashboard-content.tsx
+++ b/frontend/src/components/dashboard/dashboard-content.tsx
@@ -711,7 +711,7 @@ export function DashboardContent() {
                             selectedTemplate={selectedTemplate}
                             onTemplateChange={setSelectedTemplate}
                             isFreeTier={isFreeTier || false}
-                            onUpgradeClick={() => pricingModalStore.openPricingModal({ featureContext: 'Video generation requires a paid plan' })}
+                            onUpgradeClick={() => pricingModalStore.openPricingModal()}
                           />
                         </Suspense>
                       </div>

--- a/frontend/src/components/home/hero-section.tsx
+++ b/frontend/src/components/home/hero-section.tsx
@@ -444,7 +444,7 @@ export function HeroSection() {
                                     selectedTemplate={selectedTemplate}
                                     onTemplateChange={setSelectedTemplate}
                                     isFreeTier={isFreeTier || false}
-                                    onUpgradeClick={() => pricingModalStore.openPricingModal({ featureContext: 'Video generation requires a paid plan' })}
+                                    onUpgradeClick={() => pricingModalStore.openPricingModal()}
                                 />
                             </Suspense>
                         </div>


### PR DESCRIPTION
…in dashboard and hero section

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies and standardizes how the pricing modal is opened.
> 
> - In `dashboard-content.tsx` and `hero-section.tsx`, `onUpgradeClick` now calls `pricingModalStore.openPricingModal()` without a `featureContext` argument
> - Affects `SunaModesPanel` usages, removing the hardcoded "Video generation requires a paid plan" context
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit af02a6757f70ae65a94c4ffeb780cfa87569e45d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->