### PR TITLE
refactor: remove video lock logic from SunaModesPanel for cleaner mod…

### DIFF
--- a/frontend/src/components/dashboard/suna-modes-panel.tsx
+++ b/frontend/src/components/dashboard/suna-modes-panel.tsx
@@ -1289,7 +1289,6 @@ export function SunaModesPanel({
         <div className="grid grid-cols-3 gap-2 sm:inline-flex sm:gap-2">
           {modes.map((mode) => {
             const isActive = selectedMode === mode.id;
-            const isVideoLocked = mode.id === 'video' && isFreeTier;
             return (
               <Button
                 key={mode.id}
@@ -1300,15 +1299,11 @@ export function SunaModesPanel({
                   "h-10 flex items-center justify-center sm:justify-start gap-2 shrink-0 transition-all duration-200 rounded-xl cursor-pointer relative",
                   isActive
                     ? "bg-primary/10 text-primary border-primary hover:bg-primary/15 hover:text-primary shadow-sm"
-                    : "bg-background hover:bg-accent text-muted-foreground hover:text-foreground border-border",
-                  isVideoLocked && !isActive && "opacity-75"
+                    : "bg-background hover:bg-accent text-muted-foreground hover:text-foreground border-border"
                 )}
               >
                 {mode.icon}
                 <span>{mode.label}</span>
-                {isVideoLocked && (
-                  <Lock className="w-3 h-3 text-muted-foreground" />
-                )}
               </Button>
             );
           })}


### PR DESCRIPTION
…e rendering

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies mode tab rendering by removing special-case video lock handling.
> 
> - Deletes `isVideoLocked` checks, lock icon, and opacity styling from mode tab buttons in `suna-modes-panel.tsx`
> - Free-tier restrictions for `video` mode are still enforced via the existing upgrade banner and disabled content section, not the tabs
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4661f80a7d22f1a723041c9defac07a454f92074. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->