### PR TITLE
Default pro plan (50$) selected, instead of the 20$ 

### DIFF
--- a/frontend/src/components/billing/pricing/pricing-section.tsx
+++ b/frontend/src/components/billing/pricing/pricing-section.tsx
@@ -1067,10 +1067,10 @@ export function PricingSection({
 
   // Find the index of the user's current tier to pre-select it
   const getCurrentTierIndex = () => {
-    if (!isAuthenticated || !currentSubscription) return 0;
+    if (!isAuthenticated || !currentSubscription) return 1; // Default to Pro plan (index 1)
     const currentTierKey = currentSubscription.subscription.tier_key || currentSubscription.tier?.name;
     const index = paidTiers.findIndex(tier => tier.tierKey === currentTierKey);
-    return index >= 0 ? index : 0;
+    return index >= 0 ? index : 1; // Default to Pro plan (index 1) if tier not found
   };
 
   const [selectedPaidTierIndex, setSelectedPaidTierIndex] = useState(getCurrentTierIndex);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switches the default selected paid tier in the pricing plan switcher to `Pro`.
> 
> - Updates `getCurrentTierIndex` to return index `1` (Pro) instead of `0` when unauthenticated/no subscription and when the current tier isn’t found
> - Affects initial UI selection only; no API or pricing logic changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 48ac967262172c09f727b5109b44d5f2a52ecbbe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->