### PR TITLE
fix fallback

### DIFF
--- a/backend/core/services/llm.py
+++ b/backend/core/services/llm.py
@@ -216,15 +216,9 @@ async def make_llm_api_call(
     
     params = model_manager.get_litellm_params(resolved_model_name, **override_params)
     
-    # Add OpenRouter app parameter if using OpenRouter
-    # Check if the actual LiteLLM model ID is an OpenRouter model
-    actual_litellm_model_id = params.get("model", resolved_model_name)
-    if isinstance(actual_litellm_model_id, str) and actual_litellm_model_id.startswith("openrouter/"):
-        # OpenRouter requires the "app" parameter in extra_body
-        if "extra_body" not in params:
-            params["extra_body"] = {}
-        params["extra_body"]["app"] = "Kortix.com"
-        logger.debug(f"Added OpenRouter app parameter: Kortix.com for model {actual_litellm_model_id}")
+    # NOTE: OpenRouter app params (OR_APP_NAME, OR_SITE_URL) are set via environment
+    # variables in setup_api_keys(). Do NOT use extra_body here as it breaks
+    # fallback to other providers (e.g. Bedrock rejects extra_body params).
     
     # Add tools if provided
     if tools:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Change overview**
> 
> - Removes injection of OpenRouter `extra_body.app` and documents that `OR_APP_NAME`/`OR_SITE_URL` are set via environment in `setup_api_keys()`.
> - Prevents passing `extra_body` so Router fallbacks work across providers that reject unknown params (e.g., Bedrock).
> 
> **Scope**
> 
> - Single file update: `backend/core/services/llm.py`; no API surface changes, only parameter handling for provider compatibility.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a8f74ad3699c13056dc4dfe04beb1a7d19d89f73. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->