### PR TITLE
thread page performance

### DIFF
--- a/frontend/src/components/file-editors/index.tsx
+++ b/frontend/src/components/file-editors/index.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React from 'react';
+import dynamic from 'next/dynamic';
 import { cn } from '@/lib/utils';
 import { MarkdownEditor, type MarkdownEditorControls } from './markdown-editor';
 import { UnifiedMarkdown } from '@/components/markdown';
@@ -9,12 +10,17 @@ import { PdfRenderer } from '@/components/file-renderers/pdf-renderer';
 import { ImageRenderer } from '@/components/file-renderers/image-renderer';
 import { VideoRenderer } from '@/components/file-renderers/video-renderer';
 import { BinaryRenderer } from '@/components/file-renderers/binary-renderer';
-import { SpreadsheetViewer } from '../thread/tool-views/spreadsheet/SpreadsheetViewer';
 import { PptxRenderer } from '@/components/file-renderers/pptx-renderer';
 import { HtmlRenderer } from '@/components/file-renderers/html-renderer';
 import { CanvasRenderer } from '@/components/file-renderers/canvas-renderer';
 import { constructHtmlPreviewUrl } from '@/lib/utils/url';
 import { processUnicodeContent, getFileTypeFromExtension, getLanguageFromExtension } from './utils';
+
+// Lazy load SpreadsheetViewer as it imports Syncfusion (~1-2 MB)
+const SpreadsheetViewer = dynamic(
+  () => import('@/components/thread/tool-views/spreadsheet/SpreadsheetViewer').then((mod) => mod.SpreadsheetViewer),
+  { ssr: false, loading: () => <div className="flex items-center justify-center h-full text-muted-foreground">Loading spreadsheet...</div> }
+);
 
 export type EditableFileType =
   | 'markdown'

--- a/frontend/src/components/file-renderers/index.tsx
+++ b/frontend/src/components/file-renderers/index.tsx
@@ -7,7 +7,8 @@ export { VideoRenderer, InlineVideoPlayer } from './video-renderer';
 export { BinaryRenderer } from './binary-renderer';
 export { CsvRenderer } from './csv-renderer';
 export { XlsxRenderer } from './xlsx-renderer';
-export { SpreadsheetViewer } from '../thread/tool-views/spreadsheet/SpreadsheetViewer';
+// SpreadsheetViewer removed from barrel - imports Syncfusion (~1-2 MB)
+// Import directly: import { SpreadsheetViewer } from '@/components/thread/tool-views/spreadsheet/SpreadsheetViewer'
 export { PptxRenderer } from './pptx-renderer';
 export { HtmlRenderer } from './html-renderer';
 export { JsonRenderer } from './JsonRenderer';

--- a/frontend/src/components/thread/file-attachment.tsx
+++ b/frontend/src/components/thread/file-attachment.tsx
@@ -16,8 +16,15 @@ import {
     isPdfExtension,
 } from '@/lib/utils/file-types';
 import { AttachmentGroup } from './attachment-group';
-import { HtmlRenderer, SpreadsheetViewer, PdfRenderer, JsonRenderer } from '@/components/file-renderers';
+import { HtmlRenderer, PdfRenderer, JsonRenderer } from '@/components/file-renderers';
 import { UnifiedMarkdown } from '@/components/markdown';
+import dynamic from 'next/dynamic';
+
+// Lazy load SpreadsheetViewer as it imports Syncfusion (~1-2 MB)
+const SpreadsheetViewer = dynamic(
+  () => import('@/components/thread/tool-views/spreadsheet/SpreadsheetViewer').then((mod) => mod.SpreadsheetViewer),
+  { ssr: false, loading: () => <div className="p-4 text-muted-foreground">Loading spreadsheet...</div> }
+);
 import {
     DropdownMenu,
     DropdownMenuContent,

--- a/frontend/src/components/thread/kortix-computer/components/Desktop.tsx
+++ b/frontend/src/components/thread/kortix-computer/components/Desktop.tsx
@@ -26,8 +26,14 @@ import { EnhancedFileBrowser } from './EnhancedFileBrowser';
 import { getFileIconByName } from './Icons';
 import { SystemInfoContent } from './SystemInfoContent';
 import { FileInfoContent, FileInfo } from './FileInfoContent';
-import { SpreadsheetApp } from './SpreadsheetApp';
+import dynamic from 'next/dynamic';
 import { toast } from 'sonner';
+
+// Lazy load SpreadsheetApp as it imports Syncfusion (~1-2 MB)
+const SpreadsheetApp = dynamic(
+  () => import('./SpreadsheetApp').then((mod) => mod.SpreadsheetApp),
+  { ssr: false, loading: () => <div className="flex items-center justify-center h-full text-muted-foreground">Loading spreadsheet...</div> }
+);
 import { useQueryClient } from '@tanstack/react-query';
 import { useAuth } from '@/components/AuthProvider';
 

--- a/frontend/src/components/thread/tool-views/file-operation/FileOperationToolView.tsx
+++ b/frontend/src/components/thread/tool-views/file-operation/FileOperationToolView.tsx
@@ -25,8 +25,15 @@ import {
   getFileTypeFromExtension,
 } from '@/components/file-editors';
 import { UnifiedMarkdown } from '@/components/markdown';
-import { SpreadsheetViewer, HtmlRenderer, JsonRenderer } from '@/components/file-renderers';
+import { HtmlRenderer, JsonRenderer } from '@/components/file-renderers';
+import dynamic from 'next/dynamic';
 import { cn } from '@/lib/utils';
+
+// Lazy load SpreadsheetViewer as it imports Syncfusion (~1-2 MB)
+const SpreadsheetViewer = dynamic(
+  () => import('../spreadsheet/SpreadsheetViewer').then((mod) => mod.SpreadsheetViewer),
+  { ssr: false, loading: () => <div className="p-4 text-muted-foreground">Loading spreadsheet...</div> }
+);
 import { useTheme } from 'next-themes';
 import { constructHtmlPreviewUrl } from '@/lib/utils/url';
 import {

--- a/frontend/src/components/thread/tool-views/sheets-tools/sheets-tool-view.tsx
+++ b/frontend/src/components/thread/tool-views/sheets-tools/sheets-tool-view.tsx
@@ -8,8 +8,14 @@ import { CheckCircle, AlertTriangle, Download, FileSpreadsheet, Table, Grid, Tab
 import { cn } from '@/lib/utils';
 import { parseToolResult } from '../tool-result-parser';
 import { FileAttachment } from '../../file-attachment';
-import { SpreadsheetViewer } from '@/components/file-renderers';
+import dynamic from 'next/dynamic';
 import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem } from '@/components/ui/dropdown-menu';
+
+// Lazy load SpreadsheetViewer as it imports Syncfusion (~1-2 MB)
+const SpreadsheetViewer = dynamic(
+  () => import('../spreadsheet/SpreadsheetViewer').then((mod) => mod.SpreadsheetViewer),
+  { ssr: false, loading: () => <div className="p-4 text-muted-foreground">Loading spreadsheet...</div> }
+);
 import { useAuth } from '@/components/AuthProvider';
 import { fetchFileContent } from '@/hooks/files/use-file-queries';
 import { useDownloadRestriction } from '@/hooks/billing';

--- a/frontend/src/components/thread/tool-views/wrapper/ToolViewRegistry.tsx
+++ b/frontend/src/components/thread/tool-views/wrapper/ToolViewRegistry.tsx
@@ -26,24 +26,41 @@ import { GetCredentialProfilesToolView } from '../get-credential-profiles/get-cr
 import { GetCurrentAgentConfigToolView } from '../get-current-agent-config/get-current-agent-config';
 import { TaskListToolView } from '../task-list/TaskListToolView';
 import { ListPresentationTemplatesToolView } from '../presentation-tools/ListPresentationTemplatesToolView';
-import { PresentationViewer } from '../presentation-tools/PresentationViewer';
 import { ListPresentationsToolView } from '../presentation-tools/ListPresentationsToolView';
 import { DeleteSlideToolView } from '../presentation-tools/DeleteSlideToolView';
 import { DeletePresentationToolView } from '../presentation-tools/DeletePresentationToolView';
 // import { PresentationStylesToolView } from '../presentation-tools/PresentationStylesToolView';
 import { ExportToolView } from '../presentation-tools/ExportToolView';
-import { SheetsToolView } from '../sheets-tools/sheets-tool-view';
 import { GetProjectStructureView } from '../web-dev/GetProjectStructureView';
 import { ImageEditGenerateToolView } from '../image-edit-generate-tool/ImageEditGenerateToolView';
 import { DesignerToolView } from '../designer-tool/DesignerToolView';
 import dynamic from 'next/dynamic';
 import { UploadFileToolView } from '../UploadFileToolView';
 
-// Dynamically import CanvasToolView to avoid SSR issues with react-konva
+// Dynamically import heavy tool views to reduce initial bundle size
 const CanvasToolView = dynamic(
   () => import('../canvas-tool/CanvasToolView').then((mod) => mod.CanvasToolView),
   { ssr: false }
 );
+
+// Syncfusion Spreadsheet is ~1-2 MB - must be lazy loaded
+const SpreadsheetToolView = dynamic(
+  () => import('../spreadsheet/SpreadsheetToolview').then((mod) => mod.SpreadsheetToolView),
+  { ssr: false, loading: () => <div className="p-4 text-muted-foreground">Loading spreadsheet...</div> }
+);
+
+// SheetsToolView also uses heavy charting/table libraries
+const SheetsToolView = dynamic(
+  () => import('../sheets-tools/sheets-tool-view').then((mod) => mod.SheetsToolView),
+  { ssr: false, loading: () => <div className="p-4 text-muted-foreground">Loading sheets...</div> }
+);
+
+// Presentation tools have heavy dependencies
+const PresentationViewer = dynamic(
+  () => import('../presentation-tools/PresentationViewer').then((mod) => mod.PresentationViewer),
+  { ssr: false, loading: () => <div className="p-4 text-muted-foreground">Loading presentation...</div> }
+);
+
 import { CreateNewAgentToolView } from '../create-new-agent/create-new-agent';
 import { UpdateAgentToolView } from '../update-agent/update-agent';
 import { SearchMcpServersForAgentToolView } from '../search-mcp-servers-for-agent/search-mcp-servers-for-agent';
@@ -67,7 +84,6 @@ import { ExpandMessageToolView } from '../expand-message-tool/ExpandMessageToolV
 import { RealityDefenderToolView } from '../reality-defender-tool/RealityDefenderToolView';
 import { ApifyToolView } from '../apify-tool/ToolView';
 import { FileReaderToolView } from '../file-reader-tool/FileReaderToolView';
-import { SpreadsheetToolView } from '../spreadsheet/SpreadsheetToolview';
 
 
 export type ToolViewComponent = React.ComponentType<ToolViewProps>;

--- a/frontend/src/components/ui/skeleton.tsx
+++ b/frontend/src/components/ui/skeleton.tsx
@@ -59,12 +59,12 @@ function Skeleton({
           animation: shimmerAnimation 1s infinite;
           position: absolute;
           top: 0;
-          left: -150%;
+          transform: translateX(-300%);
         }
 
         @keyframes shimmerAnimation {
           to {
-            left: 150%;
+            transform: translateX(300%);
           }
         }
       `}</style>

--- a/frontend/src/stores/spreadsheet-store.ts
+++ b/frontend/src/stores/spreadsheet-store.ts
@@ -1,6 +1,8 @@
 import { create } from 'zustand';
 import { devtools } from 'zustand/middleware';
-import { SpreadsheetComponent } from '@syncfusion/ej2-react-spreadsheet';
+
+// Type-only import to avoid bundling the 1-2 MB Syncfusion library
+type SpreadsheetComponent = import('@syncfusion/ej2-react-spreadsheet').SpreadsheetComponent;
 
 export interface SpreadsheetCell {
   value?: string;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Optimizes initial load by deferring heavy libraries and views until needed.
> 
> - Lazy-load `SpreadsheetViewer`, `SpreadsheetApp`, `SpreadsheetToolView`, `SheetsToolView`, and `PresentationViewer` with `ssr: false` and lightweight loading states
> - Remove `SpreadsheetViewer` from `file-renderers` barrel; import it directly where used
> - Update file editors and attachments to use dynamic `SpreadsheetViewer` for `csv/xlsx` previews and editors
> - Tool registry now dynamically imports spreadsheet/sheets/presentation views; keeps Canvas as dynamic
> - Switch `spreadsheet-store` to a type-only import of Syncfusion component to avoid bundling it by default
> - Tweak `Skeleton` shimmer to use CSS transforms instead of left positioning (reduces layout thrash)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3cf7434194a00980f84c1027794e3d6d6f672310. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->