### PR TITLE
keep variance in total

### DIFF
--- a/frontend/src/app/(dashboard)/admin/analytics/page.tsx
+++ b/frontend/src/app/(dashboard)/admin/analytics/page.tsx
@@ -2985,9 +2985,7 @@ function ARRSimulator({ analyticsSource }: ARRSimulatorProps) {
                             )}
                           </div>
                         </td>
-                        <td className={`text-right p-1 text-[10px] ${subsVar.color}`}>
-                          {effectiveSubs > 0 ? `${subsVar.value >= 0 ? '+' : ''}${subsVar.value.toFixed(1)}%` : '—'}
-                        </td>
+                        <td className="text-right p-1 text-[10px] text-muted-foreground">—</td>
                         {/* MRR */}
                         <td className="text-right p-1"></td>
                         <td className="text-right p-1">
@@ -3020,9 +3018,7 @@ function ARRSimulator({ analyticsSource }: ARRSimulatorProps) {
                             )}
                           </div>
                         </td>
-                        <td className={`text-right p-1 text-[10px] ${mrrVar.color}`}>
-                          {actual?.mrr ? `${mrrVar.value >= 0 ? '+' : ''}${mrrVar.value.toFixed(1)}%` : '—'}
-                        </td>
+                        <td className="text-right p-1 text-[10px] text-muted-foreground">—</td>
                         {/* ARR */}
                         <td className="text-right p-1"></td>
                         <td className="text-right p-1">
@@ -3055,9 +3051,7 @@ function ARRSimulator({ analyticsSource }: ARRSimulatorProps) {
                             )}
                           </div>
                         </td>
-                        <td className={`text-right p-1 text-[10px] ${arrVar.color}`}>
-                          {actual?.arr ? `${arrVar.value >= 0 ? '+' : ''}${arrVar.value.toFixed(1)}%` : '—'}
-                        </td>
+                        <td className="text-right p-1 text-[10px] text-muted-foreground">—</td>
                         <td className="p-1">
                           {(actual?.newPaid || actual?.mrr || actual?.arr) && (
                             <button


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Simplifies the weekly tracking table in `frontend/src/app/(dashboard)/admin/analytics/page.tsx` by removing per-platform variance percentages.
> 
> - Replaces per-platform variance cells for `Subscribers`, `MRR`, and `ARR` with a muted em dash (`—`)
> - Keeps variance calculations and display intact in the weekly "total" row only
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b2365c70ec960855fdbd4922f1e0ac8bd05242b7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->