### PR TITLE
fix: enable vertical scroll on plan modal for all screen sizes

### DIFF
--- a/frontend/src/components/billing/pricing/plan-selection-modal.tsx
+++ b/frontend/src/components/billing/pricing/plan-selection-modal.tsx
@@ -83,7 +83,7 @@ export function PlanSelectionModal({
                         </Button>
                     </div>
                 </div>
-                <div className="w-full h-full overflow-y-auto lg:overflow-hidden overflow-x-hidden bg-background pt-[67px] lg:flex lg:items-center lg:justify-center">
+                <div className="w-full h-full overflow-y-auto overflow-x-hidden bg-background pt-[67px] lg:flex lg:items-center lg:justify-center">
                     <div className="lg:scale-90 xl:scale-100 w-full max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-8 lg:pt-0 pb-8 lg:pb-0 min-h-full lg:min-h-0 flex items-center justify-center">
                         <PricingSection
                             returnUrl={returnUrl || defaultReturnUrl}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Ensures the plan selection modal remains vertically scrollable on large screens.
> 
> - Removes `lg:overflow-hidden` from the modal container, allowing `overflow-y-auto` to apply at all breakpoints
> - No functional or API changes beyond scrolling behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 61158b7d9ef8edc819314cf94fd9a87a51cfaac5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->