### PR TITLE
fix for small vertical display

### DIFF
--- a/frontend/src/components/billing/pricing/plan-selection-modal.tsx
+++ b/frontend/src/components/billing/pricing/plan-selection-modal.tsx
@@ -64,7 +64,7 @@ export function PlanSelectionModal({
                 <DialogDescription className="sr-only">
                     {displayReason || (creditsExhausted ? 'Choose a plan to continue using Kortix' : 'Choose the plan that best fits your needs')}
                 </DialogDescription>
-                <div className="absolute top-0 left-0 right-0 z-50 flex items-center justify-between px-6 py-5 pointer-events-none bg-background/80 backdrop-blur-md lg:bg-transparent lg:backdrop-blur-none">
+                <div className="absolute top-0 left-0 right-0 z-50 flex items-center justify-between px-6 py-5 lg:py-3 pointer-events-none bg-background/80 backdrop-blur-md">
                     <div className="flex-1" />
                     
                     <div className="absolute -translate-y-1/2 top-1/2 left-1/2 -translate-x-1/2 pointer-events-none">
@@ -83,8 +83,8 @@ export function PlanSelectionModal({
                         </Button>
                     </div>
                 </div>
-                <div className="w-full h-full overflow-y-auto overflow-x-hidden bg-background pt-[67px] lg:flex lg:items-center lg:justify-center">
-                    <div className="lg:scale-90 xl:scale-100 w-full max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-8 lg:pt-0 pb-8 lg:pb-0 min-h-full lg:min-h-0 flex items-center justify-center">
+                <div className="w-full h-full overflow-y-auto overflow-x-hidden bg-background pt-[67px] lg:flex lg:justify-center">
+                    <div className="lg:scale-90 xl:scale-100 lg:origin-top w-full max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-8 lg:pt-0 pb-8 lg:pb-0 min-h-full lg:min-h-0 lg:my-auto flex items-center justify-center">
                         <PricingSection
                             returnUrl={returnUrl || defaultReturnUrl}
                             showTitleAndTabs={true}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refines the `PlanSelectionModal` layout for constrained vertical space.
> 
> - Header bar: simplifies responsive styles to always use `bg-background/80` and `backdrop-blur-md`, adds `lg:py-3` for tighter spacing
> - Content containers: remove `lg:items-center`, add `lg:origin-top` and `lg:my-auto` to improve vertical positioning/scroll behavior; keep center alignment within inner flex
> - No logic changes; only Tailwind class updates in `plan-selection-modal.tsx`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ce236a75eed3d538e3da7885293bb04e09e15295. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->