### PR TITLE
fix: handle None estimated_total_tokens in token diff calculation

### DIFF
--- a/backend/core/agentpress/thread_manager.py
+++ b/backend/core/agentpress/thread_manager.py
@@ -674,11 +674,8 @@ class ThreadManager:
                 logger.warning(f"⚠️ PRE-SEND VALIDATION: Found pairing issues - attempting repair")
                 logger.warning(f"⚠️ Orphaned tool_results: {orphaned_ids}")
                 logger.warning(f"⚠️ Unanswered tool_calls: {unanswered_ids}")
-                
-                # Attempt to repair by fixing both directions
+
                 prepared_messages = context_manager.repair_tool_call_pairing(prepared_messages)
-                
-                # Re-validate after repair
                 is_valid_after, orphans_after, unanswered_after = context_manager.validate_tool_call_pairing(prepared_messages)
                 if not is_valid_after:
                     logger.error(f"🚨 CRITICAL: Could not repair message structure. Orphaned: {len(orphans_after)}, Unanswered: {len(unanswered_after)}")
@@ -688,22 +685,22 @@ class ThreadManager:
                 logger.debug(f"✅ Pre-send validation passed: all tool calls properly paired")
             logger.debug(f"⏱️ [TIMING] Pre-send validation: {(time.time() - validation_start) * 1000:.1f}ms")
             
-            # Count actual tokens before sending (helps verify fast check accuracy)
             actual_tokens = token_counter(model=llm_model, messages=prepared_messages)
-            token_diff = actual_tokens - estimated_total_tokens
-            diff_pct = (token_diff / estimated_total_tokens * 100) if estimated_total_tokens > 0 else 0
-            logger.info(f"📤 PRE-SEND: {len(prepared_messages)} messages, {actual_tokens} tokens (fast check: {estimated_total_tokens}, diff: {token_diff:+d} / {diff_pct:+.1f}%)")
+            if estimated_total_tokens is not None:
+                token_diff = actual_tokens - estimated_total_tokens
+                diff_pct = (token_diff / estimated_total_tokens * 100) if estimated_total_tokens > 0 else 0
+                logger.info(f"📤 PRE-SEND: {len(prepared_messages)} messages, {actual_tokens} tokens (fast check: {estimated_total_tokens}, diff: {token_diff:+d} / {diff_pct:+.1f}%)")
+            else:
+                estimated_total_tokens = actual_tokens
+                logger.info(f"📤 PRE-SEND: {len(prepared_messages)} messages, {actual_tokens} tokens (no fast check available)")
             
-            # SAFETY CHECK: If actual tokens exceed threshold but fast check didn't trigger compression,
-            # we should have compressed. Log warning and ensure next iteration compresses.
             from core.ai_models.registry import registry as model_registry
             model_info = model_registry.get(llm_model) or model_registry.get(model_registry.resolve_model_id(llm_model))
             context_window = model_info.context_window if model_info else 200_000
             safety_threshold = int(context_window * 0.84)
             
-            if actual_tokens >= safety_threshold and estimated_total_tokens < safety_threshold:
+            if actual_tokens >= safety_threshold and (estimated_total_tokens is None or estimated_total_tokens < safety_threshold):
                 logger.warning(f"⚠️ FAST CHECK UNDERESTIMATED: actual={actual_tokens} >= threshold={safety_threshold}, but fast check={estimated_total_tokens} was under. Should have compressed!")
-                # Use actual tokens for response processor so it knows the real count
                 estimated_total_tokens = actual_tokens
             
             llm_call_start = time.time()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **fix(core): robust pre-send token accounting**
> 
> - Pre-send token logging now guards `estimated_total_tokens` being `None`; falls back to `actual_tokens` and logs "no fast check available"
> - Safety check updated to treat missing fast-check estimate as under-threshold when comparing against `context_window` (prevents false negatives)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3a05d4c3130d7b3cd7a49eb0a097f0bfb35666b5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->