### PR TITLE
Improve End of Year Offer banner: move below greeting, style as compact card

### DIFF
--- a/frontend/src/components/home/hero-section.tsx
+++ b/frontend/src/components/home/hero-section.tsx
@@ -394,13 +394,12 @@ export function HeroSection() {
 
                 <div className="relative z-10 pt-20 sm:pt-24 md:pt-32 mx-auto h-full w-full max-w-6xl flex flex-col items-center justify-center min-h-[60vh] sm:min-h-0">
 
-                    <PromoBanner />
-
-                    <div className="flex flex-col items-center justify-center gap-3 sm:gap-4 pt-12 sm:pt-20 max-w-4xl mx-auto pb-6 sm:pb-7">
+                    <div className="flex flex-col items-center justify-center gap-4 sm:gap-5 pt-12 sm:pt-20 max-w-4xl mx-auto pb-4 sm:pb-5">
                         <DynamicGreeting className="text-2xl sm:text-3xl md:text-3xl lg:text-4xl font-medium text-balance text-center px-4 sm:px-2" />
+                        <PromoBanner />
                     </div>
 
-                    <div className="flex flex-col items-center w-full max-w-3xl mx-auto gap-2 flex-wrap justify-center px-4 sm:px-0 animate-in fade-in-0 slide-in-from-bottom-4 duration-500 delay-100 fill-mode-both">
+                    <div className="flex flex-col items-center w-full max-w-3xl mx-auto gap-2 flex-wrap justify-center px-4 sm:px-0 mt-1 animate-in fade-in-0 slide-in-from-bottom-4 duration-500 delay-100 fill-mode-both">
                         <div className="w-full relative">
                             <div className="relative z-10">
                                 <ChatInput

--- a/frontend/src/components/home/promo-banner.tsx
+++ b/frontend/src/components/home/promo-banner.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Badge } from '@/components/ui/badge';
+import { Gift, Clock } from 'lucide-react';
 import { usePromo } from '@/hooks/utils/use-promo';
 
 interface PromoBannerProps {
@@ -15,19 +15,21 @@ export function PromoBanner({ className }: PromoBannerProps) {
     return null;
   }
 
-  // Simple, minimal hero section banner - different from dashboard banner
   return (
-    <div className={`w-full max-w-2xl mx-auto px-4 sm:px-0 mb-6 animate-in fade-in-0 slide-in-from-bottom-4 duration-500 fill-mode-both ${className || ''}`}>
-      <div className="flex flex-col items-center justify-center gap-2 text-center">
-        <Badge className="rounded-full px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.2em]">
-          {promo.badgeLabel}
-        </Badge>
-        <p className="text-sm font-medium text-foreground tracking-tight">
-          Use code <span className="font-semibold text-primary">{promo.promoCode}</span> to get <span className="font-semibold">30% off</span> for the first three months + <span className="font-semibold">2X credits</span> as welcome bonus
-        </p>
-        <p className="text-xs text-muted-foreground">
-          Ends in {promo.timeLabel}
-        </p>
+    <div className={`animate-in fade-in-0 slide-in-from-bottom-2 duration-300 delay-150 fill-mode-both ${className || ''}`}>
+      <div className="inline-flex items-center gap-3 px-4 py-2.5 rounded-full bg-primary/5 border border-primary/10 backdrop-blur-sm">
+        <div className="flex items-center gap-2">
+          <Gift className="w-4 h-4 text-primary" />
+          <span className="text-sm font-medium text-foreground">
+            <span className="font-semibold">End of Year Offer</span>
+            <span className="text-muted-foreground mx-1.5">·</span>
+            <span className="text-primary font-semibold">{promo.promoCode}</span> for 30% off + 2X credits
+          </span>
+        </div>
+        <div className="flex items-center gap-1 text-xs text-muted-foreground">
+          <Clock className="w-3 h-3" />
+          <span>{promo.timeLabel}</span>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refines the hero layout and updates the promotional UI.
> 
> - Repositions `PromoBanner` to sit below `DynamicGreeting`; adjusts container gaps/padding and adds a small top margin before the input
> - Redesigns `PromoBanner` as a compact rounded pill with `Gift` and `Clock` icons, showing `promoCode` and `timeLabel`; removes previous badge-based layout and verbose copy
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c70a6390261539d8e0cfff28adf7107ab0c4367b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->