### PR TITLE
Hero section banner placement

### DIFF
--- a/frontend/src/components/home/hero-section.tsx
+++ b/frontend/src/components/home/hero-section.tsx
@@ -398,8 +398,8 @@ export function HeroSection() {
                 <div className="relative z-10 pt-20 sm:pt-24 md:pt-32 mx-auto h-full w-full max-w-6xl flex flex-col items-center justify-center min-h-[60vh] sm:min-h-0">
 
                     <div className="flex flex-col items-center justify-center gap-4 sm:gap-5 pt-12 sm:pt-20 max-w-4xl mx-auto pb-4 sm:pb-5">
-                        <DynamicGreeting className="text-2xl sm:text-3xl md:text-3xl lg:text-4xl font-medium text-balance text-center px-4 sm:px-2" />
                         <PromoBanner />
+                        <DynamicGreeting className="text-2xl sm:text-3xl md:text-3xl lg:text-4xl font-medium text-balance text-center px-4 sm:px-2" />
                     </div>
 
                     <div className="flex flex-col items-center w-full max-w-3xl mx-auto gap-2 flex-wrap justify-center px-4 sm:px-0 mt-1 animate-in fade-in-0 slide-in-from-bottom-4 duration-500 delay-100 fill-mode-both">

--- a/frontend/src/components/home/promo-banner.tsx
+++ b/frontend/src/components/home/promo-banner.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useEffect } from 'react';
 import { Gift, Clock } from 'lucide-react';
 import { usePromo } from '@/hooks/utils/use-promo';
 
@@ -10,13 +11,21 @@ interface PromoBannerProps {
 export function PromoBanner({ className }: PromoBannerProps) {
   const promo = usePromo();
 
+  useEffect(() => {
+    if (promo && process.env.NODE_ENV !== 'production') {
+      // Helpful during development/debugging; logs only when the active promo changes.
+      // eslint-disable-next-line no-console
+      console.log('[PromoBanner] promo', promo);
+    }
+  }, [promo?.promoId]);
+
   // Don't render if no active promo
   if (!promo || !promo.isActive) {
     return null;
   }
 
   return (
-    <div className={`animate-in fade-in-0 slide-in-from-bottom-2 duration-300 delay-150 fill-mode-both ${className || ''}`}>
+    <div className={`animate-in fade-in-0 slide-in-from-top-2 duration-300 delay-150 fill-mode-both ${className || ''}`}>
       <div className="inline-flex items-center gap-3 px-4 py-2.5 rounded-full bg-primary/5 border border-primary/10 backdrop-blur-sm">
         <div className="flex items-center gap-2">
           <Gift className="w-4 h-4 text-primary" />


### PR DESCRIPTION
Move the promotion banner to display above the hero title and update its entrance animation.

---
[Slack Thread](https://kortixworkspace.slack.com/archives/C08QYH7MV6F/p1767125070404379?thread_ts=1767125070.404379&cid=C08QYH7MV6F)

<a href="https://cursor.com/background-agent?bcId=bc-99b62c64-38f1-41bc-aa5a-3fbab02328f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-99b62c64-38f1-41bc-aa5a-3fbab02328f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Moves the promo banner above the hero title and updates its entrance animation, with a small dev-only debug addition.
> 
> - Repositions `PromoBanner` before `DynamicGreeting` in `hero-section.tsx`
> - Changes banner animation to `slide-in-from-top-2` (was from bottom)
> - Adds dev-only `useEffect` log when active promo changes in `promo-banner.tsx`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 95bfb0f9f145dba0590e879f3c43ff930a68f749. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->