### PR TITLE
Kortix computer esc key

### DIFF
--- a/frontend/src/components/thread/kortix-computer/KortixComputer.tsx
+++ b/frontend/src/components/thread/kortix-computer/KortixComputer.tsx
@@ -744,9 +744,28 @@ export const KortixComputer = memo(function KortixComputer({
   };
 
   if (isMobile) {
+    const handleDrawerKeyDown = (e: React.KeyboardEvent) => {
+      // Vaul drawers are dismissible by Escape by default.
+      // Prevent Escape / Esc from closing the Kortix Computer.
+      if (e.key === 'Escape' || e.key === 'Esc') {
+        e.preventDefault();
+        e.stopPropagation();
+      }
+    };
+
     return (
-      <Drawer open={isOpen} onOpenChange={(open) => !open && handleClose()}>
-        <DrawerContent className="h-[85vh] max-h-[85vh] overflow-hidden" style={{ contain: 'strict' }}>
+      <Drawer
+        open={isOpen}
+        onOpenChange={(open) => !open && handleClose()}
+        // Never allow Esc/Escape to dismiss the Kortix Computer.
+        // (Users commonly hit Escape in editors / sandbox UIs.)
+        dismissible={false}
+      >
+        <DrawerContent
+          className="h-[85vh] max-h-[85vh] overflow-hidden"
+          style={{ contain: 'strict' }}
+          onKeyDown={handleDrawerKeyDown}
+        >
           <PanelHeader
             agentName={agentName}
             onClose={handleClose}

--- a/frontend/src/components/thread/kortix-computer/components/LoadingState.tsx
+++ b/frontend/src/components/thread/kortix-computer/components/LoadingState.tsx
@@ -21,7 +21,16 @@ export const LoadingState = memo(function LoadingState({
   
   if (isMobile) {
     return (
-      <DrawerContent className="h-[85vh]">
+      <DrawerContent
+        className="h-[85vh]"
+        onKeyDown={(e) => {
+          // Prevent Escape / Esc from dismissing the Drawer (Kortix Computer).
+          if (e.key === 'Escape' || e.key === 'Esc') {
+            e.preventDefault();
+            e.stopPropagation();
+          }
+        }}
+      >
         <PanelHeader
           agentName={agentName}
           onClose={onClose}

--- a/frontend/src/hooks/threads/page/use-thread-keyboard-shortcuts.ts
+++ b/frontend/src/hooks/threads/page/use-thread-keyboard-shortcuts.ts
@@ -81,12 +81,8 @@ export function useThreadKeyboardShortcuts({
         }
         return;
       }
-
-      // Escape closes side panel
-      if (event.key === 'Escape' && isSidePanelOpen) {
-        setIsSidePanelOpen(false);
-        userClosedPanelRef.current = true;
-      }
+      // Intentionally do NOT close the Kortix Computer on Escape.
+      // Escape is commonly used inside editors / in-panel UIs and should not dismiss the panel.
     };
 
     window.addEventListener('keydown', handleKeyDown);


### PR DESCRIPTION
Prevent `Escape` from closing the Kortix Computer on both desktop and mobile.

`Escape` is commonly used within editors and sandboxes inside the Kortix Computer, and should not dismiss the panel.

---
[Slack Thread](https://kortixworkspace.slack.com/archives/C08QYH7MV6F/p1767145795151039?thread_ts=1767145795.151039&cid=C08QYH7MV6F)

<a href="https://cursor.com/background-agent?bcId=bc-9c90c048-bb27-4a24-9214-8c8bb1499f0c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9c90c048-bb27-4a24-9214-8c8bb1499f0c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures `Escape` no longer dismisses the Kortix Computer, avoiding accidental closes from in-panel editors/sandboxes.
> 
> - Mobile: `Drawer` set `dismissible={false}` and `onKeyDown` blocks `Escape` in `KortixComputer.tsx`; same `onKeyDown` added to `LoadingState`'s `DrawerContent`.
> - Desktop/Global: Removed `Escape` handler that previously closed the side panel in `use-thread-keyboard-shortcuts.ts`; `cmd+i`/`cmd+b` behaviors unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 21b203028391f3d06839b1a5399bdf2aebb85d94. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->