### PR TITLE
Chat input debounce logic

### DIFF
--- a/frontend/src/app/(home)/berlin/page.tsx
+++ b/frontend/src/app/(home)/berlin/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useRef, useEffect, Suspense, lazy } from 'react';
 import { MapPin } from 'lucide-react';
 import { AnimatedBg } from '@/components/ui/animated-bg';
-import { useIsMobile } from '@/hooks/utils';
+import { useIsMobile, useLeadingDebouncedCallback } from '@/hooks/utils';
 import { ChatInput, ChatInputHandles } from '@/components/thread/chat-input/chat-input';
 import { useAuth } from '@/components/AuthProvider';
 import { useRouter } from 'next/navigation';
@@ -73,7 +73,7 @@ export default function BerlinPage() {
   const isSunaAgent = !user || selectedAgent?.metadata?.is_suna_default || false;
   const addOptimisticFiles = useOptimisticFilesStore((state) => state.addFiles);
 
-  const handleChatInputSubmit = async (
+  const handleChatInputSubmit = useLeadingDebouncedCallback(async (
     message: string,
     options?: { model_name?: string; enable_thinking?: boolean }
   ) => {
@@ -84,6 +84,7 @@ export default function BerlinPage() {
     }
 
     setIsSubmitting(true);
+    let didNavigate = false;
     try {
       const files = chatInputRef.current?.getPendingFiles() || [];
       const normalizedFiles = files.map((file) => {
@@ -109,8 +110,21 @@ export default function BerlinPage() {
       
       sessionStorage.setItem('optimistic_prompt', promptWithFiles);
       sessionStorage.setItem('optimistic_thread', threadId);
+
+      if (process.env.NODE_ENV !== 'production') {
+        console.log('[Berlin] Starting new thread:', {
+          projectId,
+          threadId,
+          agent_id: selectedAgentId || undefined,
+          model_name: options?.model_name,
+          promptLength: promptWithFiles.length,
+          promptPreview: promptWithFiles.slice(0, 140),
+          files: normalizedFiles.map((f) => ({ name: f.name, size: f.size, type: f.type })),
+        });
+      }
       
       router.push(`/projects/${projectId}/thread/${threadId}?new=true`);
+      didNavigate = true;
       
       optimisticAgentStart({
         thread_id: threadId,
@@ -135,10 +149,11 @@ export default function BerlinPage() {
       });
     } catch (error: any) {
       toast.error(error.message || 'Failed to create Worker. Please try again.');
-    } finally {
-      setIsSubmitting(false);
+      if (!didNavigate) {
+        setIsSubmitting(false);
+      }
     }
-  };
+  }, 1200);
 
   return (
     <main className="w-full">

--- a/frontend/src/hooks/utils/index.ts
+++ b/frontend/src/hooks/utils/index.ts
@@ -5,6 +5,7 @@ export { useMediaQuery } from './use-media-query';
 export { useIsMobile } from './use-mobile';
 export { useGitHubStars } from './use-github-stars';
 export { useSunaModePersistence } from './use-suna-modes-persistence';
+export { useLeadingDebouncedCallback } from './use-leading-debounced-callback';
 
 // Re-export error handling utilities directly from error-handler
 export { handleApiError, type ErrorContext } from '@/lib/error-handler';

--- a/frontend/src/hooks/utils/use-leading-debounced-callback.ts
+++ b/frontend/src/hooks/utils/use-leading-debounced-callback.ts
@@ -1,0 +1,63 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+type AnyFn = (...args: any[]) => any;
+
+/**
+ * Leading-edge debounced callback.
+ *
+ * - Calls immediately on first invocation
+ * - Ignores subsequent calls until `waitMs` has elapsed
+ * - Also prevents re-entrancy while the wrapped function is executing
+ *
+ * Useful for "create resource" actions that must be single-flight even if users
+ * tap/click multiple times quickly.
+ */
+export function useLeadingDebouncedCallback<TFn extends AnyFn>(fn: TFn, waitMs: number) {
+  const fnRef = useRef(fn);
+  const lastCallAtRef = useRef<number>(0);
+  const inFlightRef = useRef(false);
+  const releaseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    fnRef.current = fn;
+  }, [fn]);
+
+  useEffect(() => {
+    return () => {
+      if (releaseTimerRef.current) {
+        clearTimeout(releaseTimerRef.current);
+      }
+    };
+  }, []);
+
+  return useCallback(
+    async (...args: Parameters<TFn>): Promise<Awaited<ReturnType<TFn>> | undefined> => {
+      const now = Date.now();
+
+      if (inFlightRef.current) return undefined;
+      if (now - lastCallAtRef.current < waitMs) return undefined;
+
+      lastCallAtRef.current = now;
+      inFlightRef.current = true;
+
+      try {
+        return await fnRef.current(...args);
+      } finally {
+        // Keep blocked for at least `waitMs`, even if `fn` resolves quickly
+        const elapsed = Date.now() - now;
+        const remaining = Math.max(0, waitMs - elapsed);
+
+        if (releaseTimerRef.current) {
+          clearTimeout(releaseTimerRef.current);
+        }
+
+        releaseTimerRef.current = setTimeout(() => {
+          inFlightRef.current = false;
+          releaseTimerRef.current = null;
+        }, remaining);
+      }
+    },
+    [waitMs],
+  );
+}
+


### PR DESCRIPTION
Add a leading-edge debounce to new thread creation to prevent multiple threads from being created on rapid clicks.

Previously, the `isSubmitting` state was reset immediately after an optimistic thread start, allowing rapid clicks to re-enter the submit handler and generate multiple `threadId`s. This change introduces a `useLeadingDebouncedCallback` hook that ensures only one submission fires per window and keeps the button disabled until navigation or a timeout.

---
[Slack Thread](https://kortixworkspace.slack.com/archives/C08QYH7MV6F/p1767145649161419?thread_ts=1767145649.161419&cid=C08QYH7MV6F)

<a href="https://cursor.com/background-agent?bcId=bc-40595cc1-396c-42b9-8466-c3a19378fa25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-40595cc1-396c-42b9-8466-c3a19378fa25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a leading-edge debounce to new thread creation to avoid duplicate threads from rapid clicks and keeps inputs disabled until navigation or timeout.
> 
> - New `useLeadingDebouncedCallback(waitMs)` hook in `hooks/utils/use-leading-debounced-callback.ts`; exported via `hooks/utils/index.ts`
> - Wraps submit handlers in `home/hero-section.tsx`, `components/dashboard/dashboard-content.tsx`, and `(home)/berlin|milano/page.tsx` with `useLeadingDebouncedCallback(..., 1200)`
> - Sets `didNavigate` guards so `isSubmitting` only resets if navigation didn’t occur
> - Adds dev-only console logs summarizing new-thread params (prompt preview, file info) to aid debugging
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7a91f8e47da628f3e54ea0f5806b6db66e7bbc81. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->