### PR TITLE
track route change

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -8,3 +8,10 @@ NEXT_PUBLIC_GOOGLE_CLIENT_ID=""
 NEXT_PUBLIC_POSTHOG_KEY=""
 KORTIX_ADMIN_API_KEY=""
 EDGE_CONFIG="https://edge-config.vercel.com/REDACTED?token=REDACTED"
+
+# Analytics & Tracking (Optional - only for production/your deployment)
+# Leave these empty if you're self-hosting and don't want analytics
+NEXT_PUBLIC_GTM_ID="" # Google Tag Manager ID (e.g., GTM-XXXXXXX)
+NEXT_PUBLIC_GA_ID_1="" # Google Analytics ID 1 (e.g., G-XXXXXXXXXX)
+NEXT_PUBLIC_GA_ID_2="" # Google Analytics ID 2 (optional, e.g., G-XXXXXXXXXX)
+NEXT_PUBLIC_FACEBOOK_PIXEL_ID="" # Facebook Pixel ID (e.g., 1234567890)

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -24,6 +24,7 @@ const PostHogIdentify = lazy(() => import('@/components/posthog-identify').then(
 const PlanSelectionModal = lazy(() => import('@/components/billing/pricing/plan-selection-modal').then(mod => ({ default: mod.PlanSelectionModal })));
 const AnnouncementDialog = lazy(() => import('@/components/announcements/announcement-dialog').then(mod => ({ default: mod.AnnouncementDialog })));
 const CookieConsent = lazy(() => import('@/components/cookie-consent').then(mod => ({ default: mod.CookieConsent })));
+const RouteChangeTracker = lazy(() => import('@/components/analytics/route-change-tracker').then(mod => ({ default: mod.RouteChangeTracker })));
 
 
 export const viewport: Viewport = {
@@ -140,29 +141,33 @@ export default function RootLayout({
         ) : null}
 
         {/* Facebook Pixel - Will be blocked by cookie consent service until marketing consent is given */}
-        <Script id="facebook-pixel" strategy="lazyOnload" data-cookieconsent="marketing">
-          {`
-            !function(f,b,e,v,n,t,s)
-            {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
-            n.callMethod.apply(n,arguments):n.queue.push(arguments)};
-            if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
-            n.queue=[];t=b.createElement(e);t.async=!0;
-            t.src=v;s=b.getElementsByTagName(e)[0];
-            s.parentNode.insertBefore(t,s)}(window, document,'script',
-            'https://connect.facebook.net/en_US/fbevents.js');
+        {process.env.NEXT_PUBLIC_FACEBOOK_PIXEL_ID && (
+          <>
+            <Script id="facebook-pixel" strategy="lazyOnload" data-cookieconsent="marketing">
+              {`
+                !function(f,b,e,v,n,t,s)
+                {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+                n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+                if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+                n.queue=[];t=b.createElement(e);t.async=!0;
+                t.src=v;s=b.getElementsByTagName(e)[0];
+                s.parentNode.insertBefore(t,s)}(window, document,'script',
+                'https://connect.facebook.net/en_US/fbevents.js');
 
-            fbq('init', '1385936776361131');
-            fbq('track', 'PageView');
-          `}
-        </Script>
-        <noscript>
-          <img
-            height="1"
-            width="1"
-            style={{ display: "none" }}
-            src="https://www.facebook.com/tr?id=1385936776361131&ev=PageView&noscript=1"
-          />
-        </noscript>
+                fbq('init', '${process.env.NEXT_PUBLIC_FACEBOOK_PIXEL_ID}');
+                fbq('track', 'PageView');
+              `}
+            </Script>
+            <noscript>
+              <img
+                height="1"
+                width="1"
+                style={{ display: "none" }}
+                src={`https://www.facebook.com/tr?id=${process.env.NEXT_PUBLIC_FACEBOOK_PIXEL_ID}&ev=PageView&noscript=1`}
+              />
+            </noscript>
+          </>
+        )}
 
 
         <script
@@ -241,13 +246,21 @@ export default function RootLayout({
           <Suspense fallback={null}>
             <Analytics />
           </Suspense>
-          <Suspense fallback={null}>
-            <GoogleAnalytics gaId="G-QSCBD7F1SD" />
-            <GoogleAnalytics gaId="G-6ETJFB3PT3" />
-          </Suspense>
-          <Suspense fallback={null}>
-            <GoogleTagManager gtmId="GTM-PKFG3JCX" />
-          </Suspense>
+          {process.env.NEXT_PUBLIC_GA_ID_1 && (
+            <Suspense fallback={null}>
+              <GoogleAnalytics gaId={process.env.NEXT_PUBLIC_GA_ID_1} />
+            </Suspense>
+          )}
+          {process.env.NEXT_PUBLIC_GA_ID_2 && (
+            <Suspense fallback={null}>
+              <GoogleAnalytics gaId={process.env.NEXT_PUBLIC_GA_ID_2} />
+            </Suspense>
+          )}
+          {process.env.NEXT_PUBLIC_GTM_ID && (
+            <Suspense fallback={null}>
+              <GoogleTagManager gtmId={process.env.NEXT_PUBLIC_GTM_ID} />
+            </Suspense>
+          )}
           <Suspense fallback={null}>
             <SpeedInsights />
           </Suspense>
@@ -256,6 +269,9 @@ export default function RootLayout({
           </Suspense>
           <Suspense fallback={null}>
             <CookieConsent />
+          </Suspense>
+          <Suspense fallback={null}>
+            <RouteChangeTracker />
           </Suspense>
         </ThemeProvider>
       </body>

--- a/frontend/src/components/analytics/route-change-tracker.tsx
+++ b/frontend/src/components/analytics/route-change-tracker.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { usePathname, useSearchParams } from 'next/navigation';
+import { trackRouteChange } from '@/lib/analytics/gtm';
+
+/**
+ * RouteChangeTracker Component
+ * 
+ * Tracks route changes in the Next.js app router and pushes
+ * routeChange events to Google Tag Manager's dataLayer.
+ * 
+ * This solves the SPA tracking problem where page views aren't
+ * automatically tracked on client-side navigation.
+ */
+export function RouteChangeTracker() {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const isInitialMount = useRef(true);
+  
+  useEffect(() => {
+    // On initial mount, track the current page
+    if (isInitialMount.current) {
+      isInitialMount.current = false;
+      
+      // Small delay to ensure document.title is set
+      const timeoutId = setTimeout(() => {
+        trackRouteChange(pathname, searchParams?.toString());
+      }, 100);
+      
+      return () => clearTimeout(timeoutId);
+    }
+    
+    // Track subsequent route changes
+    trackRouteChange(pathname, searchParams?.toString());
+  }, [pathname, searchParams]);
+  
+  // This component doesn't render anything
+  return null;
+}
+

--- a/frontend/src/lib/analytics/gtm.ts
+++ b/frontend/src/lib/analytics/gtm.ts
@@ -1,0 +1,129 @@
+/**
+ * Google Tag Manager Analytics Utilities
+ * Handles dataLayer pushes for GA4 tracking
+ */
+
+// Extend the Window interface to include dataLayer
+interface GTMWindow extends Window {
+  dataLayer?: object[];
+}
+
+declare const window: GTMWindow;
+
+/**
+ * Initialize the dataLayer if it doesn't exist
+ * GTM automatically creates window.dataLayer, so we just ensure it exists
+ */
+export function initDataLayer() {
+  if (typeof window !== 'undefined' && !window.dataLayer) {
+    window.dataLayer = [];
+  }
+}
+
+/**
+ * Get the current page referrer from sessionStorage or document.referrer
+ */
+function getPageReferrer(): string {
+  if (typeof window === 'undefined') return '';
+  
+  // Check if we have a stored previous page in sessionStorage
+  const previousPage = sessionStorage.getItem('gtm_previous_page');
+  
+  // If no previous page, use document.referrer (initial load)
+  return previousPage || document.referrer || '';
+}
+
+/**
+ * Store the current page as the previous page for next navigation
+ */
+function storePreviousPage() {
+  if (typeof window === 'undefined') return;
+  sessionStorage.setItem('gtm_previous_page', window.location.href);
+}
+
+/**
+ * Determine if this is the initial page load
+ */
+function isInitialLoad(): boolean {
+  if (typeof window === 'undefined') return false;
+  
+  // Check if we've tracked a page before
+  const hasTrackedBefore = sessionStorage.getItem('gtm_has_tracked');
+  return !hasTrackedBefore;
+}
+
+/**
+ * Mark that we've tracked at least one page
+ */
+function markAsTracked() {
+  if (typeof window === 'undefined') return;
+  sessionStorage.setItem('gtm_has_tracked', 'true');
+}
+
+export interface RouteChangeData {
+  event: 'routeChange';
+  page_location: string;
+  page_path: string;
+  page_title: string;
+  page_referrer: string;
+  is_initial_load: boolean;
+}
+
+/**
+ * Push a routeChange event to the dataLayer
+ * This tracks SPA navigation for accurate GA4 page views
+ */
+export function trackRouteChange(pathname: string, searchParams?: string) {
+  if (typeof window === 'undefined') return;
+  
+  // Initialize dataLayer if needed
+  initDataLayer();
+  
+  // Construct the full path with search params
+  const fullPath = searchParams ? `${pathname}?${searchParams}` : pathname;
+  const pageLocation = `${window.location.origin}${fullPath}`;
+  
+  // Get page title (or use pathname as fallback)
+  const pageTitle = document.title || pathname;
+  
+  // Get referrer
+  const pageReferrer = getPageReferrer();
+  
+  // Check if initial load
+  const initialLoad = isInitialLoad();
+  
+  // Construct the data object according to data dictionary
+  const routeChangeData: RouteChangeData = {
+    event: 'routeChange',
+    page_location: pageLocation,
+    page_path: fullPath,
+    page_title: pageTitle,
+    page_referrer: pageReferrer,
+    is_initial_load: initialLoad,
+  };
+  
+  // Push to dataLayer
+  window.dataLayer?.push(routeChangeData);
+  
+  // Console log for debugging (remove in production if needed)
+  if (process.env.NODE_ENV === 'development') {
+    console.log('[GTM] routeChange pushed:', routeChangeData);
+  }
+  
+  // Store current page as previous for next navigation
+  storePreviousPage();
+  
+  // Mark that we've tracked at least one page
+  markAsTracked();
+}
+
+/**
+ * Clear GTM tracking session data
+ * Useful for logout or session reset
+ */
+export function clearGTMSession() {
+  if (typeof window === 'undefined') return;
+  sessionStorage.removeItem('gtm_previous_page');
+  sessionStorage.removeItem('gtm_has_tracked');
+}
+


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces SPA route-change tracking and makes third-party analytics configurable.
> 
> - New `RouteChangeTracker` component pushes `routeChange` events to GTM `dataLayer` using `trackRouteChange`
> - Adds `lib/analytics/gtm.ts` utilities (`initDataLayer`, `trackRouteChange`, `clearGTMSession`) with referrer and initial-load handling
> - `layout.tsx`: conditionally loads `GoogleAnalytics`, `GoogleTagManager`, and Facebook Pixel based on `NEXT_PUBLIC_GA_ID_1/2`, `NEXT_PUBLIC_GTM_ID`, `NEXT_PUBLIC_FACEBOOK_PIXEL_ID`; removes hardcoded IDs; lazy-loads `RouteChangeTracker`
> - `.env.example`: adds optional analytics keys (`NEXT_PUBLIC_GTM_ID`, `NEXT_PUBLIC_GA_ID_1/2`, `NEXT_PUBLIC_FACEBOOK_PIXEL_ID`) with guidance
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b08c1ed20eca2a00380339ff72c969d7510b9b41. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->