### PR TITLE
use bedrock for images

### DIFF
--- a/backend/core/ai_models/models.py
+++ b/backend/core/ai_models/models.py
@@ -90,6 +90,12 @@ class Model:
     # If None, defaults to id
     litellm_model_id: Optional[str] = None
     
+    # Vision-specific LiteLLM model ID - used when thread has images
+    # If None, uses litellm_model_id for both text and vision
+    vision_litellm_model_id: Optional[str] = None
+    vision_context_window: Optional[int] = None  # Defaults to context_window if None
+    vision_pricing: Optional[ModelPricing] = None  # Defaults to pricing if None
+    
     aliases: List[str] = field(default_factory=list)
     context_window: int = 128_000
     capabilities: List[ModelCapability] = field(default_factory=list)
@@ -110,6 +116,31 @@ class Model:
         # Ensure CHAT capability is always present
         if ModelCapability.CHAT not in self.capabilities:
             self.capabilities.insert(0, ModelCapability.CHAT)
+    
+    def get_litellm_model_id_for_context(self, has_images: bool = False) -> str:
+        """Get the appropriate LiteLLM model ID based on context.
+        
+        Args:
+            has_images: Whether the thread/context has images
+            
+        Returns:
+            vision_litellm_model_id if has_images and it's set, otherwise litellm_model_id
+        """
+        if has_images and self.vision_litellm_model_id:
+            return self.vision_litellm_model_id
+        return self.litellm_model_id
+    
+    def get_context_window_for_context(self, has_images: bool = False) -> int:
+        """Get the appropriate context window based on context."""
+        if has_images and self.vision_context_window:
+            return self.vision_context_window
+        return self.context_window
+    
+    def get_pricing_for_context(self, has_images: bool = False) -> Optional[ModelPricing]:
+        """Get the appropriate pricing based on context."""
+        if has_images and self.vision_pricing:
+            return self.vision_pricing
+        return self.pricing
     
     @property
     def supports_thinking(self) -> bool:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Enhances multimodal handling and model selection to ensure correct ordering and capabilities when images are used.
> 
> - Add vision-aware fields/methods to model registry (`vision_litellm_model_id`, context window/pricing; getters consider `has_images`)
> - ThreadManager: detect `image_context` in a thread and switch to the model’s vision variant; compute context window via registry with `has_images`
> - ResponseProcessor: introduce `_save_deferred_image_context` and call it after saving tool results (streaming and non-streaming paths) to maintain `tool_call → tool_result → image_context` order
> - sb_vision_tool: stop writing `image_context` directly; return `_image_context_data` for deferred save
> - Logging/telemetry updates around image handling and model switching
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aaf65475559643e64ce7b8aa215445d2cb1caf62. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->