### PR TITLE
User language adaptation prompt

### DIFF
--- a/backend/core/utils/user_locale.py
+++ b/backend/core/utils/user_locale.py
@@ -92,21 +92,37 @@ def get_locale_context_prompt(locale: str) -> str:
     """
     locale_instructions = {
         'en': """## LANGUAGE PREFERENCE
-The user has set their preferred language to English. You should respond in English using an informal, semi-personal, and neutral tone. Use casual but professional language throughout your responses.""",
+The user has set their preferred UI language to English. Default to responding in English using an informal, semi-personal, and neutral tone. Use casual but professional language throughout your responses.
+
+IMPORTANT: If the user is typing in a different language in the chat, respond in the language the user is currently using (infer from the most recent user message). Treat the locale as a UI/tone preference and use it only as a fallback when the user's message language is unclear.""",
         'de': """## SPRACHPREFERENZ
-Der Benutzer hat Deutsch als bevorzugte Sprache eingestellt. Du solltest auf Deutsch antworten und dabei eine informelle, halbpersönliche und neutrale Tonart verwenden. Verwende "du" statt "Sie" und eine lockere aber professionelle Sprache in allen deinen Antworten, Erklärungen und Interaktionen.""",
+Der Benutzer hat Deutsch als bevorzugte UI-Sprache eingestellt. Standardmäßig sollst du auf Deutsch antworten und dabei eine informelle, halbpersönliche und neutrale Tonart verwenden. Verwende "du" statt "Sie" und eine lockere aber professionelle Sprache in allen deinen Antworten, Erklärungen und Interaktionen.
+
+WICHTIG: Wenn der Benutzer im Chat in einer anderen Sprache schreibt, antworte in der Sprache, die der Benutzer aktuell verwendet (ableiten aus der letzten Benutzernachricht). Betrachte die Locale nur als UI-/Ton-Voreinstellung und nutze sie nur als Fallback, wenn die Sprache der Benutzernachricht unklar ist.""",
         'it': """## PREFERENZA LINGUISTICA
-L'utente ha impostato l'italiano come lingua preferita. Dovresti rispondere in italiano usando un tono informale, semi-personale e neutro. Usa "tu" invece di "Lei" e un linguaggio casuale ma professionale in tutte le tue risposte, spiegazioni e interazioni.""",
+L'utente ha impostato l'italiano come lingua preferita dell'interfaccia. Di default rispondi in italiano usando un tono informale, semi-personale e neutro. Usa "tu" invece di "Lei" e un linguaggio casuale ma professionale in tutte le tue risposte, spiegazioni e interazioni.
+
+IMPORTANTE: Se l'utente sta scrivendo in un'altra lingua nella chat, rispondi nella lingua che l'utente sta usando in quel momento (inferiscila dall'ultimo messaggio dell'utente). Considera la locale come una preferenza di UI/tono e usala solo come fallback quando la lingua del messaggio non è chiara.""",
         'zh': """## 语言偏好
-用户已将首选语言设置为中文。你应该用中文回复，使用非正式、半个人化且中性的语气。在所有回复、解释和交互中使用随意但专业的语言。""",
+用户已将界面首选语言设置为中文。默认用中文回复，使用非正式、半个人化且中性的语气。在所有回复、解释和交互中使用随意但专业的语言。
+
+重要：如果用户在聊天中使用另一种语言输入，请用用户当前使用的语言回复（根据用户的最新一条消息判断）。将 locale 视为界面/语气偏好；只有在用户消息语言不明确时才作为后备。""",
         'ja': """## 言語設定
-ユーザーは日本語を優先言語に設定しています。日本語で応答し、カジュアルで半個人的かつ中立的なトーンを使用してください。すべての応答、説明、インタラクションでカジュアルだがプロフェッショナルな言語を使用してください。""",
+ユーザーは日本語を優先言語（UI）に設定しています。デフォルトでは日本語で応答し、カジュアルで半個人的かつ中立的なトーンを使用してください。すべての応答、説明、インタラクションでカジュアルだがプロフェッショナルな言語を使用してください。
+
+重要：ユーザーがチャットで別の言語で入力している場合は、ユーザーが現在使っている言語で返答してください（直近のユーザーメッセージから推定）。locale はUI/トーンの設定として扱い、ユーザーメッセージの言語が不明確な場合のみフォールバックとして使用してください。""",
         'pt': """## PREFERÊNCIA DE IDIOMA
-O usuário definiu o português como idioma preferido. Você deve responder em português usando um tom informal, semi-pessoal e neutro. Use linguagem casual mas profissional em todas as suas respostas, explicações e interações.""",
+O usuário definiu o português como idioma preferido da interface. Por padrão, responda em português usando um tom informal, semi-pessoal e neutro. Use linguagem casual mas profissional em todas as suas respostas, explicações e interações.
+
+IMPORTANTE: Se o usuário estiver digitando em outro idioma no chat, responda no idioma que o usuário está usando no momento (inferido da mensagem mais recente do usuário). Trate a locale apenas como preferência de UI/tom e use-a apenas como fallback quando o idioma da mensagem do usuário não estiver claro.""",
         'fr': """## PRÉFÉRENCE DE LANGUE
-L'utilisateur a défini le français comme langue préférée. Tu dois répondre en français en utilisant un ton informel, semi-personnel et neutre. Utilise "tu" au lieu de "vous" et un langage décontracté mais professionnel dans toutes tes réponses, explications et interactions.""",
+L'utilisateur a défini le français comme langue préférée de l'interface. Par défaut, réponds en français en utilisant un ton informel, semi-personnel et neutre. Utilise "tu" au lieu de "vous" et un langage décontracté mais professionnel dans toutes tes réponses, explications et interactions.
+
+IMPORTANT : si l'utilisateur écrit dans une autre langue dans le chat, réponds dans la langue qu'il utilise actuellement (déduite du dernier message utilisateur). Considère la locale comme une préférence d'UI/de ton et ne l'utilise qu'en recours si la langue du message n'est pas claire.""",
         'es': """## PREFERENCIA DE IDIOMA
-El usuario ha establecido el español como idioma preferido. Debes responder en español usando un tono informal, semi-personal y neutro. Usa "tú" en lugar de "usted" y un lenguaje casual pero profesional en todas tus respuestas, explicaciones e interacciones."""
+El usuario ha establecido el español como idioma preferido de la interfaz. Por defecto, responde en español usando un tono informal, semi-personal y neutro. Usa "tú" en lugar de "usted" y un lenguaje casual pero profesional en todas tus respuestas, explicaciones e interacciones.
+
+IMPORTANTE: Si el usuario está escribiendo en otro idioma en el chat, responde en el idioma que el usuario esté usando en ese momento (inferido del mensaje más reciente del usuario). Considera la locale solo como una preferencia de UI/tono y úsala únicamente como fallback cuando el idioma del mensaje no esté claro."""
     }
     
     return locale_instructions.get(locale, locale_instructions['en'])


### PR DESCRIPTION
Update locale context prompt to prioritize user's message language over configured locale.

The previous prompt instructed the model to always respond in the user's configured locale, preventing the agent from adapting when the user typed in a different language. This change ensures the agent responds in the language the user is actively using in chat, with the locale serving as a fallback for UI and tone.

---
[Slack Thread](https://kortixworkspace.slack.com/archives/C08QYH7MV6F/p1767271518488309?thread_ts=1767271518.488309&cid=C08QYH7MV6F)

<a href="https://cursor.com/background-agent?bcId=bc-07bce0a2-99ff-4338-95a5-11394712d04b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-07bce0a2-99ff-4338-95a5-11394712d04b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns locale behavior with user message language across all supported locales.
> 
> - Updates `get_locale_context_prompt` strings for `en`, `de`, `it`, `zh`, `ja`, `pt`, `fr`, `es` to clarify UI/tone preference and default language
> - Adds explicit instruction to infer and respond in the language of the most recent user message, using locale only as a fallback
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 139c8d3801e093ab3550730b317abb64d2b7bdb7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->