### PR TITLE
power users;

### DIFF
--- a/backend/core/ai_models/registry.py
+++ b/backend/core/ai_models/registry.py
@@ -102,6 +102,10 @@ class ModelRegistry:
             id="kortix/power",
             name="Kortix Advanced Mode",
             litellm_model_id=power_litellm_id,
+            # Vision model: Use Haiku Bedrock when thread has images
+            vision_litellm_model_id=HAIKU_BEDROCK_ARN,
+            vision_context_window=200_000,
+            vision_pricing=HAIKU_PRICING,
             provider=ModelProvider.OPENROUTER,
             aliases=["kortix-power", "Kortix POWER Mode", "Kortix Power", "Kortix Advanced Mode"],
             context_window=200_000,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds vision support to the premium model for image-containing threads.
> 
> - For `kortix/power` in `backend/core/ai_models/registry.py`, sets `vision_litellm_model_id` to `HAIKU_BEDROCK_ARN` with `vision_context_window=200_000` and `vision_pricing=HAIKU_PRICING`
> - Aligns `kortix/power` behavior with `kortix/basic` by using Haiku Bedrock for vision while keeping primary `litellm_model_id` on MiniMax M2.1
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 033119c7724ad605b0e07008d64741636bb45bca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->