### PR TITLE
track login signup and upgradde

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -25,6 +25,7 @@ const PlanSelectionModal = lazy(() => import('@/components/billing/pricing/plan-
 const AnnouncementDialog = lazy(() => import('@/components/announcements/announcement-dialog').then(mod => ({ default: mod.AnnouncementDialog })));
 const CookieConsent = lazy(() => import('@/components/cookie-consent').then(mod => ({ default: mod.CookieConsent })));
 const RouteChangeTracker = lazy(() => import('@/components/analytics/route-change-tracker').then(mod => ({ default: mod.RouteChangeTracker })));
+const AuthEventTracker = lazy(() => import('@/components/analytics/auth-event-tracker').then(mod => ({ default: mod.AuthEventTracker })));
 
 
 export const viewport: Viewport = {
@@ -143,29 +144,29 @@ export default function RootLayout({
         {/* Facebook Pixel - Will be blocked by cookie consent service until marketing consent is given */}
         {process.env.NEXT_PUBLIC_FACEBOOK_PIXEL_ID && (
           <>
-            <Script id="facebook-pixel" strategy="lazyOnload" data-cookieconsent="marketing">
-              {`
-                !function(f,b,e,v,n,t,s)
-                {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
-                n.callMethod.apply(n,arguments):n.queue.push(arguments)};
-                if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
-                n.queue=[];t=b.createElement(e);t.async=!0;
-                t.src=v;s=b.getElementsByTagName(e)[0];
-                s.parentNode.insertBefore(t,s)}(window, document,'script',
-                'https://connect.facebook.net/en_US/fbevents.js');
+        <Script id="facebook-pixel" strategy="lazyOnload" data-cookieconsent="marketing">
+          {`
+            !function(f,b,e,v,n,t,s)
+            {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+            n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+            if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+            n.queue=[];t=b.createElement(e);t.async=!0;
+            t.src=v;s=b.getElementsByTagName(e)[0];
+            s.parentNode.insertBefore(t,s)}(window, document,'script',
+            'https://connect.facebook.net/en_US/fbevents.js');
 
                 fbq('init', '${process.env.NEXT_PUBLIC_FACEBOOK_PIXEL_ID}');
-                fbq('track', 'PageView');
-              `}
-            </Script>
-            <noscript>
-              <img
-                height="1"
-                width="1"
-                style={{ display: "none" }}
+            fbq('track', 'PageView');
+          `}
+        </Script>
+        <noscript>
+          <img
+            height="1"
+            width="1"
+            style={{ display: "none" }}
                 src={`https://www.facebook.com/tr?id=${process.env.NEXT_PUBLIC_FACEBOOK_PIXEL_ID}&ev=PageView&noscript=1`}
-              />
-            </noscript>
+          />
+        </noscript>
           </>
         )}
 
@@ -252,14 +253,14 @@ export default function RootLayout({
             </Suspense>
           )}
           {process.env.NEXT_PUBLIC_GA_ID_2 && (
-            <Suspense fallback={null}>
+          <Suspense fallback={null}>
               <GoogleAnalytics gaId={process.env.NEXT_PUBLIC_GA_ID_2} />
-            </Suspense>
+          </Suspense>
           )}
           {process.env.NEXT_PUBLIC_GTM_ID && (
-            <Suspense fallback={null}>
+          <Suspense fallback={null}>
               <GoogleTagManager gtmId={process.env.NEXT_PUBLIC_GTM_ID} />
-            </Suspense>
+          </Suspense>
           )}
           <Suspense fallback={null}>
             <SpeedInsights />
@@ -272,6 +273,9 @@ export default function RootLayout({
           </Suspense>
           <Suspense fallback={null}>
             <RouteChangeTracker />
+          </Suspense>
+          <Suspense fallback={null}>
+            <AuthEventTracker />
           </Suspense>
         </ThemeProvider>
       </body>

--- a/frontend/src/components/AuthProvider.tsx
+++ b/frontend/src/components/AuthProvider.tsx
@@ -11,6 +11,7 @@ import { createClient } from '@/lib/supabase/client';
 import { User, Session } from '@supabase/supabase-js';
 import { SupabaseClient } from '@supabase/supabase-js';
 import { clearUserLocalStorage } from '@/lib/utils/clear-local-storage';
+// Auth tracking moved to AuthEventTracker component (handles OAuth redirects)
 
 type AuthContextType = {
   supabase: SupabaseClient;
@@ -52,6 +53,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
         if (isLoading) setIsLoading(false);
         switch (event) {
           case 'SIGNED_IN':
+            // Auth tracking handled by AuthEventTracker component via URL params
             break;
           case 'SIGNED_OUT':
             clearUserLocalStorage();

--- a/frontend/src/components/analytics/auth-event-tracker.tsx
+++ b/frontend/src/components/analytics/auth-event-tracker.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useSearchParams, useRouter, usePathname } from 'next/navigation';
+import { trackSignUp, trackLogin, AuthMethod } from '@/lib/analytics/gtm';
+
+/**
+ * Tracks auth events (sign_up, login) from URL parameters
+ * after OAuth/magic link redirects
+ */
+export function AuthEventTracker() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+
+  useEffect(() => {
+    const authEvent = searchParams?.get('auth_event');
+    const authMethod = searchParams?.get('auth_method');
+
+    if (authEvent && authMethod) {
+      // Map provider to AuthMethod format
+      const method: AuthMethod = 
+        authMethod === 'google' ? 'Google' :
+        authMethod === 'apple' ? 'Apple' :
+        authMethod === 'github' ? 'GitHub' : 'Email';
+
+      if (authEvent === 'signup') {
+        trackSignUp(method);
+      } else if (authEvent === 'login') {
+        trackLogin(method);
+      }
+
+      // Clean up URL params after tracking
+      const params = new URLSearchParams(searchParams?.toString() || '');
+      params.delete('auth_event');
+      params.delete('auth_method');
+      
+      const newUrl = params.toString() 
+        ? `${pathname}?${params.toString()}`
+        : pathname;
+      
+      // Replace URL without triggering navigation
+      window.history.replaceState({}, '', newUrl);
+    }
+  }, [searchParams, pathname, router]);
+
+  return null;
+}
+

--- a/frontend/src/components/billing/credits-display.tsx
+++ b/frontend/src/components/billing/credits-display.tsx
@@ -10,6 +10,7 @@ import { TierBadge } from '@/components/billing/tier-badge';
 import { PlanSelectionModal } from '@/components/billing/pricing';
 import { cn } from '@/lib/utils';
 import { useQueryClient } from '@tanstack/react-query';
+import { trackCtaUpgrade } from '@/lib/analytics/gtm';
 import { formatCredits } from '@/lib/utils/credit-formatter';
 
 export function CreditsDisplay() {
@@ -35,6 +36,7 @@ export function CreditsDisplay() {
   const formattedCredits = formatCredits(credits);
 
   const handleClick = () => {
+    trackCtaUpgrade();
     setShowPlanModal(true);
   };
 

--- a/frontend/src/components/home/hero-section.tsx
+++ b/frontend/src/components/home/hero-section.tsx
@@ -48,6 +48,7 @@ import { useAccountState } from '@/hooks/billing';
 import { DynamicGreeting } from '@/components/ui/dynamic-greeting';
 import { useOptimisticFilesStore } from '@/stores/optimistic-files-store';
 import { PromoBanner } from '@/components/home/promo-banner';
+import { trackCtaSignup } from '@/lib/analytics/gtm';
 
 const GoogleSignIn = lazy(() => import('@/components/GoogleSignIn'));
 const AgentRunLimitBanner = lazy(() => 
@@ -211,6 +212,7 @@ export function HeroSection() {
         }
         if (!user && !isLoading) {
             localStorage.setItem(PENDING_PROMPT_KEY, message.trim());
+            trackCtaSignup();
             setAuthDialogOpen(true);
             return;
         }
@@ -503,7 +505,10 @@ export function HeroSection() {
                         <Link
                             href={`/auth?returnUrl=${encodeURIComponent('/dashboard')}`}
                             className="flex h-12 items-center justify-center w-full text-center rounded-full bg-primary text-primary-foreground hover:bg-primary/90 transition-all shadow-sm font-medium"
-                            onClick={() => setAuthDialogOpen(false)}
+                            onClick={() => {
+                                trackCtaSignup();
+                                setAuthDialogOpen(false);
+                            }}
                         >
                             {tAuth('signInWithEmail')}
                         </Link>
@@ -511,7 +516,10 @@ export function HeroSection() {
                         <Link
                             href={`/auth?mode=signup&returnUrl=${encodeURIComponent('/dashboard')}`}
                             className="flex h-12 items-center justify-center w-full text-center rounded-full border border-border bg-background hover:bg-accent/50 transition-all font-medium"
-                            onClick={() => setAuthDialogOpen(false)}
+                            onClick={() => {
+                                trackCtaSignup();
+                                setAuthDialogOpen(false);
+                            }}
                         >
                             {tAuth('createNewAccount')}
                         </Link>

--- a/frontend/src/components/home/navbar.tsx
+++ b/frontend/src/components/home/navbar.tsx
@@ -14,6 +14,7 @@ import { useRouter, usePathname } from 'next/navigation';
 import { KortixLogo } from '@/components/sidebar/kortix-logo';
 import { useTranslations } from 'next-intl';
 import { Button } from '@/components/ui/button';
+import { trackCtaSignup } from '@/lib/analytics/gtm';
 
 // Scroll threshold with hysteresis to prevent flickering
 const SCROLL_THRESHOLD_DOWN = 50;
@@ -166,7 +167,7 @@ export function Navbar() {
                   size="sm"
                   className="w-fit flex items-center justify-center gap-2 bg-primary text-primary-foreground shadow-[inset_0_1px_2px_rgba(255,255,255,0.25),0_3px_3px_-1.5px_rgba(16,24,40,0.06),0_1px_1px_rgba(16,24,40,0.08)] border border-white/[0.12]"
                 >
-                  <Link href="/auth">
+                  <Link href="/auth" onClick={() => trackCtaSignup()}>
                     {t('tryFree')}
                   </Link>
                 </Button>
@@ -279,7 +280,7 @@ export function Navbar() {
                       size="sm"
                       className="w-full flex items-center justify-center gap-2 bg-primary text-primary-foreground shadow-[inset_0_1px_2px_rgba(255,255,255,0.25),0_3px_3px_-1.5px_rgba(16,24,40,0.06),0_1px_1px_rgba(16,24,40,0.08)] border border-white/[0.12]"
                     >
-                      <Link href="/auth">
+                      <Link href="/auth" onClick={() => trackCtaSignup()}>
                         {t('tryFree')}
                       </Link>
                     </Button>

--- a/frontend/src/components/home/showcase-section.tsx
+++ b/frontend/src/components/home/showcase-section.tsx
@@ -14,6 +14,7 @@ import { Button } from '@/components/ui/button';
 import { DynamicIcon } from 'lucide-react/dynamic';
 import { Computer } from 'lucide-react';
 import { KortixLogo } from '@/components/sidebar/kortix-logo';
+import { trackCtaSignup } from '@/lib/analytics/gtm';
 
 interface WorkerType {
     id: string;
@@ -159,7 +160,7 @@ export function ShowCaseSection() {
                                     </div>
 
                                     {/* CTA Button - Always at bottom */}
-                                    <Link href="/auth">
+                                    <Link href="/auth" onClick={() => trackCtaSignup()}>
                                         <Button
                                             variant="default"
                                             size="default"

--- a/frontend/src/components/sidebar/nav-user-with-teams.tsx
+++ b/frontend/src/components/sidebar/nav-user-with-teams.tsx
@@ -77,6 +77,7 @@ import { useReferralDialog } from '@/stores/referral-dialog';
 import { ReferralDialog } from '@/components/referrals/referral-dialog';
 import { Badge } from '@/components/ui/badge';
 import { SpotlightCard } from '@/components/ui/spotlight-card';
+import { trackCtaUpgrade } from '@/lib/analytics/gtm';
 
 export function NavUserWithTeams({
   user,
@@ -228,7 +229,10 @@ export function NavUserWithTeams({
             {/* Upgrade Button - Closest to user card */}
             {isFreeTier && (
               <Button
-                onClick={() => setShowPlanModal(true)}
+                onClick={() => {
+                  trackCtaUpgrade();
+                  setShowPlanModal(true);
+                }}
                 variant="default"
                 size="lg"
                 className="w-full"
@@ -355,6 +359,7 @@ export function NavUserWithTeams({
               <DropdownMenuGroup>
                 <DropdownMenuItem
                   onClick={() => {
+                    trackCtaUpgrade();
                     setShowPlanModal(true);
                   }}
                   className="gap-2 p-2"

--- a/frontend/src/components/thread/chat-input/chat-input.tsx
+++ b/frontend/src/components/thread/chat-input/chat-input.tsx
@@ -46,6 +46,7 @@ import { SpotlightCard } from '@/components/ui/spotlight-card';
 import { MemoryToggle } from './memory-toggle';
 
 import posthog from 'posthog-js';
+import { trackCtaUpgrade } from '@/lib/analytics/gtm';
 
 // ============================================================================
 // ISOLATED TEXTAREA - Manages its own state to prevent parent re-renders
@@ -1460,7 +1461,10 @@ export const ChatInput = memo(forwardRef<ChatInputHandles, ChatInputProps>(
             agentName={agentName}
             showToolPreview={showToolPreview}
             subscriptionData={subscriptionData}
-            onOpenUpgrade={() => setPlanSelectionModalOpen(true)}
+            onOpenUpgrade={() => {
+              trackCtaUpgrade();
+              setPlanSelectionModalOpen(true);
+            }}
             isVisible={isSnackVisible}
           />
 

--- a/frontend/src/lib/analytics/gtm.ts
+++ b/frontend/src/lib/analytics/gtm.ts
@@ -128,6 +128,93 @@ export function clearGTMSession() {
 }
 
 // =============================================================================
+// AUTH EVENTS - Sign Up & Login Tracking
+// =============================================================================
+
+export type AuthMethod = 'Email' | 'Google' | 'Apple' | 'GitHub';
+
+/**
+ * Track sign_up event when a user completes registration
+ * Priority 1 event
+ */
+export function trackSignUp(method: AuthMethod) {
+  if (typeof window === 'undefined') return;
+  
+  initDataLayer();
+  
+  const signUpEvent = {
+    event: 'sign_up',
+    method: method,
+  };
+  
+  window.dataLayer?.push(signUpEvent);
+  
+  if (process.env.NODE_ENV === 'development') {
+    console.log('[GTM] sign_up pushed:', signUpEvent);
+  }
+}
+
+/**
+ * Track login event when a user logs in
+ * Priority 3 event
+ */
+export function trackLogin(method: AuthMethod) {
+  if (typeof window === 'undefined') return;
+  
+  initDataLayer();
+  
+  const loginEvent = {
+    event: 'login',
+    method: method,
+  };
+  
+  window.dataLayer?.push(loginEvent);
+  
+  if (process.env.NODE_ENV === 'development') {
+    console.log('[GTM] login pushed:', loginEvent);
+  }
+}
+
+/**
+ * Track cta_upgrade event when user clicks upgrade CTA
+ * Priority 3 event
+ */
+export function trackCtaUpgrade() {
+  if (typeof window === 'undefined') return;
+  
+  initDataLayer();
+  
+  const ctaEvent = {
+    event: 'cta_upgrade',
+  };
+  
+  window.dataLayer?.push(ctaEvent);
+  
+  if (process.env.NODE_ENV === 'development') {
+    console.log('[GTM] cta_upgrade pushed:', ctaEvent);
+  }
+}
+
+/**
+ * Track cta_signup event when user clicks signup CTA on homepage
+ */
+export function trackCtaSignup() {
+  if (typeof window === 'undefined') return;
+  
+  initDataLayer();
+  
+  const ctaEvent = {
+    event: 'cta_signup',
+  };
+  
+  window.dataLayer?.push(ctaEvent);
+  
+  if (process.env.NODE_ENV === 'development') {
+    console.log('[GTM] cta_signup pushed:', ctaEvent);
+  }
+}
+
+// =============================================================================
 // ECOMMERCE EVENTS - Purchase Tracking
 // =============================================================================
 

--- a/frontend/src/stores/pricing-modal-store.ts
+++ b/frontend/src/stores/pricing-modal-store.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { trackCtaUpgrade } from '@/lib/analytics/gtm';
 
 interface PricingModalState {
   isOpen: boolean;
@@ -17,7 +18,10 @@ export const usePricingModalStore = create<PricingModalState>((set) => ({
   customTitle: undefined,
   alertSubtitle: undefined,
   returnUrl: undefined,
-  openPricingModal: (options) =>
+  openPricingModal: (options) => {
+    // Track cta_upgrade event for GTM/GA4
+    trackCtaUpgrade();
+    
     set({
       isOpen: true,
       customTitle: options?.title,
@@ -25,7 +29,8 @@ export const usePricingModalStore = create<PricingModalState>((set) => ({
       alertTitle: options?.alertTitle,
       alertSubtitle: options?.alertSubtitle,
       returnUrl: options?.returnUrl,
-    }),
+    });
+  },
   closePricingModal: () =>
     set({
       isOpen: false,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds end-to-end auth and CTA analytics with GTM and URL-based signals.
> 
> - New client `AuthEventTracker` reads `auth_event`/`auth_method` URL params and triggers `sign_up`/`login` via GTM
> - Auth flows updated to include tracking params: `signInWithPassword` and `/auth/callback` now append `auth_event` (signup vs login) and provider-derived `auth_method`
> - Introduces GTM helpers in `lib/analytics/gtm.ts`: `trackSignUp`, `trackLogin`, `trackCtaUpgrade`, `trackCtaSignup`
> - Wires CTA tracking across UI: hero auth links, navbar “Try Free”, showcase “Try it out”, credits/upgrade buttons, sidebar plan actions, chat snack upgrade, pricing modal store
> - Loads `AuthEventTracker` in `layout` and removes in-AuthProvider tracking responsibility; minor formatting tweaks to Facebook Pixel script
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b34cea84b17497404a2f7b2b5abee3074b111344. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->