### PR TITLE
track magic link sent

### DIFF
--- a/frontend/src/app/auth/page.tsx
+++ b/frontend/src/app/auth/page.tsx
@@ -18,6 +18,7 @@ import { KortixLogo } from '@/components/sidebar/kortix-logo';
 import { ReferralCodeDialog } from '@/components/referrals/referral-code-dialog';
 import { isElectron, getAuthOrigin } from '@/lib/utils/is-electron';
 import { ExampleShowcase } from '@/components/auth/example-showcase';
+import { trackSendAuthLink } from '@/lib/analytics/gtm';
 
 // Lazy load heavy components
 const GoogleSignIn = lazy(() => import('@/components/GoogleSignIn'));
@@ -89,6 +90,7 @@ function LoginContent() {
   }, [isExpired, expiredEmail]);
 
   const handleAuth = async (prevState: any, formData: FormData) => {
+    trackSendAuthLink();
     markEmailAsUsed();
 
     const email = formData.get('email') as string;
@@ -181,6 +183,7 @@ function LoginContent() {
   };
 
   const handleResendMagicLink = async (prevState: any, formData: FormData) => {
+    trackSendAuthLink();
     markEmailAsUsed();
 
     const email = expiredEmailState || formData.get('email') as string;

--- a/frontend/src/lib/analytics/gtm.ts
+++ b/frontend/src/lib/analytics/gtm.ts
@@ -214,6 +214,26 @@ export function trackCtaSignup() {
   }
 }
 
+/**
+ * Track send_auth_link event when user clicks magic link button
+ * Priority 3 event
+ */
+export function trackSendAuthLink() {
+  if (typeof window === 'undefined') return;
+  
+  initDataLayer();
+  
+  const authLinkEvent = {
+    event: 'send_auth_link',
+  };
+  
+  window.dataLayer?.push(authLinkEvent);
+  
+  if (process.env.NODE_ENV === 'development') {
+    console.log('[GTM] send_auth_link pushed:', authLinkEvent);
+  }
+}
+
 // =============================================================================
 // ECOMMERCE EVENTS - Purchase Tracking
 // =============================================================================


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds analytics for magic link interactions.
> 
> - New `trackSendAuthLink` in `lib/analytics/gtm.ts` pushes `send_auth_link` to `dataLayer`
> - Wire tracking into `auth/page.tsx` by calling `trackSendAuthLink()` on magic link send and resend actions
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3bb923b700f10ede83036bfd2d711ead3770fea6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->