### PR TITLE
improve supabase timeouts

### DIFF
--- a/backend/core/services/supabase.py
+++ b/backend/core/services/supabase.py
@@ -45,12 +45,16 @@ class DBConnection:
                 logger.error("Missing required environment variables for Supabase connection")
                 raise RuntimeError("SUPABASE_URL and a key (SERVICE_ROLE_KEY or ANON_KEY) environment variables must be set.")
 
-            # logger.debug("Initializing Supabase connection")
+            from supabase.lib.client_options import AsyncClientOptions
             
-            # Create Supabase client with timeout configuration
+            options = AsyncClientOptions(
+                postgrest_client_timeout=30,
+            )
+            
             self._client = await create_async_client(
                 supabase_url, 
                 supabase_key,
+                options=options
             )
             
             self._initialized = True

--- a/backend/core/versioning/version_service.py
+++ b/backend/core/versioning/version_service.py
@@ -1,4 +1,5 @@
 import json
+import asyncio
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Dict, List, Any, Optional
@@ -7,6 +8,8 @@ from enum import Enum
 
 from core.services.supabase import DBConnection
 from core.utils.logger import logger
+
+MCP_CONFIG_QUERY_TIMEOUT = 10.0
 
 
 class VersionStatus(Enum):
@@ -137,6 +140,10 @@ class VersionService:
         
         if not result.data:
             raise Exception("Failed to update agent current version")
+        
+        from core.runtime_cache import invalidate_mcp_version_config
+        await invalidate_mcp_version_config(agent_id)
+        logger.debug(f"Invalidated MCP config cache for agent {agent_id} after version update")
     
     def _version_from_db_row(self, row: Dict[str, Any]) -> AgentVersion:
         config = row.get('config', {})
@@ -483,66 +490,89 @@ class VersionService:
     async def get_current_mcp_config(self, agent_id: str, user_id: str = "system") -> Optional[Dict[str, Any]]:
         logger.info(f"🔍 [VERSION-MCP-DEBUG] Loading current MCP config for agent {agent_id}")
         
+        from core.runtime_cache import (
+            get_cached_mcp_version_config,
+            set_cached_mcp_version_config
+        )
+        
+        cached = await get_cached_mcp_version_config(agent_id)
+        if cached:
+            logger.info(f"🔍 [VERSION-MCP-DEBUG] ⚡ Cache hit for agent {agent_id}")
+            cached['account_id'] = user_id
+            return cached
+        
         try:
-            client = await self._get_client()
+            async with asyncio.timeout(MCP_CONFIG_QUERY_TIMEOUT):
+                client = await self._get_client()
+                
+                agent_result = await client.table('agents').select('current_version_id').eq('agent_id', agent_id).execute()
+                logger.info(f"🔍 [VERSION-MCP-DEBUG] Agent query result: {agent_result.data}")
+                
+                if not agent_result.data or not agent_result.data[0].get('current_version_id'):
+                    logger.error(f"🔍 [VERSION-MCP-DEBUG] ❌ No current_version_id found for agent {agent_id}")
+                    empty_config = {'custom_mcp': [], 'configured_mcps': [], 'account_id': user_id}
+                    await set_cached_mcp_version_config(agent_id, {'custom_mcp': [], 'configured_mcps': []})
+                    return empty_config
+                
+                current_version_id = agent_result.data[0]['current_version_id']
+                logger.info(f"🔍 [VERSION-MCP-DEBUG] Agent {agent_id} current_version_id: {current_version_id}")
+                
+                version_result = await client.table('agent_versions').select('config').eq(
+                    'version_id', current_version_id
+                ).eq('agent_id', agent_id).execute()
+                
+                logger.info(f"🔍 [VERSION-MCP-DEBUG] Version query result: found {len(version_result.data) if version_result.data else 0} records")
+                
+                if not version_result.data:
+                    logger.error(f"🔍 [VERSION-MCP-DEBUG] ❌ Version {current_version_id} not found for agent {agent_id}")
+                    empty_config = {'custom_mcp': [], 'configured_mcps': [], 'account_id': user_id}
+                    await set_cached_mcp_version_config(agent_id, {'custom_mcp': [], 'configured_mcps': []})
+                    return empty_config
+                
+                config = version_result.data[0].get('config', {})
+                tools = config.get('tools', {})
+                
+                configured_mcps = tools.get('mcp', [])
+                custom_mcps = tools.get('custom_mcp', [])
+                
+                logger.info(f"🔍 [VERSION-MCP-DEBUG] Found raw MCP config:")
+                logger.info(f"🔍 [VERSION-MCP-DEBUG]   configured_mcps: {len(configured_mcps)}")
+                logger.info(f"🔍 [VERSION-MCP-DEBUG]   custom_mcps: {len(custom_mcps)}")
+                
+                for i, mcp in enumerate(configured_mcps):
+                    logger.info(f"🔍 [VERSION-MCP-DEBUG]   configured_mcp[{i}]: name={mcp.get('name')}, toolkit_slug={mcp.get('toolkit_slug')}")
+                
+                for i, mcp in enumerate(custom_mcps):
+                    toolkit_slug = mcp.get('toolkit_slug')
+                    mcp_type = mcp.get('type') or mcp.get('customType')
+                    enabled_tools = mcp.get('enabledTools', [])
+                    logger.info(f"🔍 [VERSION-MCP-DEBUG]   custom_mcp[{i}]: name={mcp.get('name')}, type={mcp_type}, toolkit_slug={toolkit_slug}, tools={len(enabled_tools)}")
+                
+                cache_data = {
+                    'custom_mcp': custom_mcps,
+                    'configured_mcps': configured_mcps,
+                }
+                await set_cached_mcp_version_config(agent_id, cache_data)
+                
+                final_config = {
+                    'custom_mcp': custom_mcps,
+                    'configured_mcps': configured_mcps,
+                    'account_id': user_id
+                }
+                
+                logger.info(f"🔍 [VERSION-MCP-DEBUG] ✅ Returning standardized config:")
+                logger.info(f"🔍 [VERSION-MCP-DEBUG]   final custom_mcp: {len(final_config['custom_mcp'])}")
+                logger.info(f"🔍 [VERSION-MCP-DEBUG]   final configured_mcps: {len(final_config['configured_mcps'])}")
+                
+                return final_config
             
-            agent_result = await client.table('agents').select('current_version_id').eq('agent_id', agent_id).execute()
-            logger.info(f"🔍 [VERSION-MCP-DEBUG] Agent query result: {agent_result.data}")
-            
-            if not agent_result.data or not agent_result.data[0].get('current_version_id'):
-                logger.error(f"🔍 [VERSION-MCP-DEBUG] ❌ No current_version_id found for agent {agent_id}")
-                logger.error(f"🔍 [VERSION-MCP-DEBUG] Agent data: {agent_result.data}")
-                return None
-            
-            current_version_id = agent_result.data[0]['current_version_id']
-            logger.info(f"🔍 [VERSION-MCP-DEBUG] Agent {agent_id} current_version_id: {current_version_id}")
-            
-            version_result = await client.table('agent_versions').select('config').eq(
-                'version_id', current_version_id
-            ).eq('agent_id', agent_id).execute()
-            
-            logger.info(f"🔍 [VERSION-MCP-DEBUG] Version query result: found {len(version_result.data) if version_result.data else 0} records")
-            
-            if not version_result.data:
-                logger.error(f"🔍 [VERSION-MCP-DEBUG] ❌ Version {current_version_id} not found for agent {agent_id}")
-                return None
-            
-            config = version_result.data[0].get('config', {})
-            tools = config.get('tools', {})
-            
-            configured_mcps = tools.get('mcp', [])
-            custom_mcps = tools.get('custom_mcp', [])
-            
-            logger.info(f"🔍 [VERSION-MCP-DEBUG] Found raw MCP config:")
-            logger.info(f"🔍 [VERSION-MCP-DEBUG]   configured_mcps: {len(configured_mcps)}")
-            logger.info(f"🔍 [VERSION-MCP-DEBUG]   custom_mcps: {len(custom_mcps)}")
-            
-            for i, mcp in enumerate(configured_mcps):
-                logger.info(f"🔍 [VERSION-MCP-DEBUG]   configured_mcp[{i}]: name={mcp.get('name')}, toolkit_slug={mcp.get('toolkit_slug')}")
-            
-            for i, mcp in enumerate(custom_mcps):
-                toolkit_slug = mcp.get('toolkit_slug')
-                mcp_type = mcp.get('type') or mcp.get('customType')
-                enabled_tools = mcp.get('enabledTools', [])
-                logger.info(f"🔍 [VERSION-MCP-DEBUG]   custom_mcp[{i}]: name={mcp.get('name')}, type={mcp_type}, toolkit_slug={toolkit_slug}, tools={len(enabled_tools)}")
-            
-            # Return in the EXACT format expected by all components
-            # CRITICAL: Use custom_mcp (singular) as that's what the loader expects
-            final_config = {
-                'custom_mcp': custom_mcps,        # Loader expects custom_mcp (singular)
-                'configured_mcps': configured_mcps,
-                'account_id': user_id
-            }
-            
-            logger.info(f"🔍 [VERSION-MCP-DEBUG] ✅ Returning standardized config:")
-            logger.info(f"🔍 [VERSION-MCP-DEBUG]   final custom_mcp: {len(final_config['custom_mcp'])}")
-            logger.info(f"🔍 [VERSION-MCP-DEBUG]   final configured_mcps: {len(final_config['configured_mcps'])}")
-            
-            return final_config
+        except asyncio.TimeoutError:
+            logger.error(f"🔍 [VERSION-MCP-DEBUG] ❌ TIMEOUT ({MCP_CONFIG_QUERY_TIMEOUT}s) loading MCP config for agent {agent_id}")
+            return {'custom_mcp': [], 'configured_mcps': [], 'account_id': user_id}
             
         except Exception as e:
             logger.error(f"🔍 [VERSION-MCP-DEBUG] ❌ Error loading current MCP config for agent {agent_id}: {e}", exc_info=True)
-            return None
+            return {'custom_mcp': [], 'configured_mcps': [], 'account_id': user_id}
 
     async def update_version_details(
         self,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces caching and tighter timeouts to reduce latency and improve resiliency around MCP config loading.
> 
> - Adds Redis cache for `mcp_version_config` in `runtime_cache.py` with TTL, plus `get/set/invalidate` helpers
> - Invalidates MCP version config cache when updating an agent’s current version in `version_service`
> - Wraps `get_current_mcp_config` DB calls with an `asyncio` timeout, caches/returns empty defaults on miss/timeout/errors, and uses the new cache for fast reads
> - Configures Supabase `AsyncClientOptions` with `postgrest_client_timeout=30` during client creation
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ee1e6f615606a3414847a653562a451c3a803b25. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->