### PR TITLE
track plan

### DIFF
--- a/frontend/src/lib/analytics/gtm.ts
+++ b/frontend/src/lib/analytics/gtm.ts
@@ -464,3 +464,137 @@ export function clearCheckoutData() {
   sessionStorage.removeItem('gtm_checkout_data');
 }
 
+// =============================================================================
+// PLANS EVENTS - select_item, view_item, add_to_cart
+// =============================================================================
+
+export interface PlanItemData {
+  item_id: string;         // e.g., "pro_monthly", "plus_yearly", "ultra_monthly"
+  item_name: string;       // e.g., "Pro Monthly", "Plus Yearly", "Ultra"
+  coupon?: string;
+  discount?: number;
+  item_brand: string;      // "Kortix AI"
+  item_category: string;   // "Plans"
+  item_list_id: string;    // "plans_listing"
+  item_list_name: string;  // "Plans Listing"
+  price: number;
+  quantity: number;
+}
+
+/**
+ * Track select_item event when user clicks on Plus/Pro/Ultra plan tabs
+ * Priority 2 event
+ */
+export function trackSelectItem(item: PlanItemData) {
+  if (typeof window === 'undefined') return;
+  
+  initDataLayer();
+  
+  // Clear previous ecommerce object (GA4 best practice)
+  window.dataLayer?.push({ ecommerce: null });
+  
+  const selectItemEvent = {
+    event: 'select_item',
+    ecommerce: {
+      item_list_id: 'plans_listing',
+      item_list_name: 'Plans Listing',
+      items: [{
+        item_id: item.item_id,
+        item_name: item.item_name,
+        coupon: item.coupon ?? '',
+        discount: item.discount ?? 0,
+        item_brand: item.item_brand,
+        item_category: item.item_category,
+        item_list_id: item.item_list_id,
+        item_list_name: item.item_list_name,
+        price: item.price,
+        quantity: item.quantity,
+      }],
+    },
+  };
+  
+  window.dataLayer?.push(selectItemEvent);
+  
+  if (process.env.NODE_ENV === 'development') {
+    console.log('[GTM] select_item pushed:', selectItemEvent);
+  }
+}
+
+/**
+ * Track view_item event when modal opens or billing period changes
+ * Priority 2 event
+ */
+export function trackViewItem(item: PlanItemData, currency: string, value: number) {
+  if (typeof window === 'undefined') return;
+  
+  initDataLayer();
+  
+  // Clear previous ecommerce object (GA4 best practice)
+  window.dataLayer?.push({ ecommerce: null });
+  
+  const viewItemEvent = {
+    event: 'view_item',
+    ecommerce: {
+      currency: currency,
+      value: value,
+      items: [{
+        item_id: item.item_id,
+        item_name: item.item_name,
+        coupon: item.coupon ?? '',
+        discount: item.discount ?? 0,
+        item_brand: item.item_brand,
+        item_category: item.item_category,
+        item_list_id: item.item_list_id,
+        item_list_name: item.item_list_name,
+        price: item.price,
+        quantity: item.quantity,
+      }],
+    },
+  };
+  
+  window.dataLayer?.push(viewItemEvent);
+  
+  if (process.env.NODE_ENV === 'development') {
+    console.log('[GTM] view_item pushed:', viewItemEvent);
+  }
+}
+
+/**
+ * Track add_to_cart event when user clicks Upgrade button
+ * Priority 2 event
+ */
+export function trackAddToCart(item: PlanItemData, currency: string, value: number) {
+  if (typeof window === 'undefined') return;
+  
+  initDataLayer();
+  
+  // Clear previous ecommerce object (GA4 best practice)
+  window.dataLayer?.push({ ecommerce: null });
+  
+  const addToCartEvent = {
+    event: 'add_to_cart',
+    ecommerce: {
+      currency: currency,
+      value: value,
+      items: [{
+        item_id: item.item_id,
+        item_name: item.item_name,
+        coupon: item.coupon ?? '',
+        discount: item.discount ?? 0,
+        item_brand: item.item_brand,
+        item_category: item.item_category,
+        item_list_id: item.item_list_id,
+        item_list_name: item.item_list_name,
+        price: item.price,
+        quantity: item.quantity,
+      }],
+    },
+  };
+  
+  window.dataLayer?.push(addToCartEvent);
+  
+  if (process.env.NODE_ENV === 'development') {
+    console.log('[GTM] add_to_cart pushed:', addToCartEvent);
+  }
+}
+


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Implements GA4 ecommerce tracking for plan interactions and hooks it into the pricing UI.
> 
> - Adds `PlanItemData` and GTM helpers `trackSelectItem`, `trackViewItem`, `trackAddToCart` in `analytics/gtm.ts` (clears `ecommerce`, pushes GA4-compliant payloads to `dataLayer`).
> - In `pricing-section.tsx`: tracks `view_item` on mount and when billing period changes, `select_item` on plan tab clicks, and `add_to_cart` on upgrade/subscribe clicks; introduces `buildPlanItemData`, `handlePlanTabClick`, `handleBillingPeriodChange` and wires them to desktop/mobile plan switchers and billing toggles; updates `onBillingPeriodChange` prop usage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8cdc628e113d54ce9badee0bdfba8a19f8564b31. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->