### PR TITLE
Switch Dockerfile from Alpine to Debian for temporalio wheel compatib…

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,23 +1,27 @@
-FROM ghcr.io/astral-sh/uv:python3.11-alpine
+# Use Debian-based image instead of Alpine for pre-built temporalio wheels
+FROM ghcr.io/astral-sh/uv:python3.11-bookworm-slim
 
-ENV ENV_MODE production
+ENV ENV_MODE=production
 WORKDIR /app
 
-RUN apk add --no-cache curl git \
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    git \
     # Dependencies for Python package compilation
-    freetype-dev \
+    libfreetype6-dev \
     gcc \
-    linux-headers \
-    musl-dev \
+    libc6-dev \
     python3-dev \
     # Dependencies for WeasyPrint (PDF generation)
-    pango \
-    cairo \
-    gdk-pixbuf \
-    libffi \
+    libpango-1.0-0 \
+    libpangocairo-1.0-0 \
+    libcairo2 \
+    libgdk-pixbuf2.0-0 \
+    libffi-dev \
     fontconfig \
-    ttf-dejavu \
-    ttf-liberation
+    fonts-dejavu \
+    fonts-liberation \
+    && rm -rf /var/lib/apt/lists/*
 
 # Install Python dependencies
 COPY pyproject.toml uv.lock ./


### PR DESCRIPTION
…ility

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Transitions backend container to Debian for compatibility with pre-built `temporalio` wheels and required system libs.
> 
> - Change base image to `ghcr.io/astral-sh/uv:python3.11-bookworm-slim` and migrate from `apk` to `apt-get`
> - Replace Alpine packages with Debian equivalents, including build tools and WeasyPrint runtime libs (`libpango-1.0-0`, `libcairo2`, `libgdk-pixbuf2.0-0`, `libffi-dev`, `libfreetype6-dev`, etc.)
> - Add apt cache cleanup and set `ENV ENV_MODE=production`; keep Gunicorn command and app startup behavior unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 769941956c827de69e1e9b4722a58fdf7a327ad7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->