### PR TITLE
fix: simplify thread init architecture and increase startup timeout

### DIFF
--- a/backend/core/temporal/activities.py
+++ b/backend/core/temporal/activities.py
@@ -1,15 +1,11 @@
 """
-Temporal activities for background processing.
-
-Activities are the actual work units in Temporal workflows. They can be retried
-and support heartbeating for long-running operations.
+Temporal activities - work units that can be retried and heartbeated.
 """
 import asyncio
 import json
 import time
 import traceback
-import uuid
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 from typing import Optional, Dict, Any, List
 
 from temporalio import activity
@@ -23,24 +19,19 @@ from core.services.langfuse import langfuse
 from core.run import run_agent
 from core.tool_output_streaming_context import set_tool_output_streaming_context, clear_tool_output_streaming_context
 
-# Import functions from run_agent_background that we'll reuse
 from run_agent_background import (
-    initialize,
-    acquire_run_lock,
-    load_agent_config,
-    create_redis_keys,
-    process_agent_responses,
-    handle_normal_completion,
-    send_completion_notification,
-    send_failure_notification,
-    update_agent_run_status,
-    cleanup_redis_keys_for_agent_run,
+    initialize, acquire_run_lock, load_agent_config, create_redis_keys,
+    process_agent_responses, handle_normal_completion, send_completion_notification,
+    send_failure_notification, update_agent_run_status, cleanup_redis_keys_for_agent_run,
 )
 
 db = DBConnection()
 
-# TTL for Redis stream keys
-REDIS_STREAM_TTL_SECONDS = 600  # 10 minutes
+
+def bind_context(**kwargs):
+    """Helper to set structured logging context."""
+    structlog.contextvars.clear_contextvars()
+    structlog.contextvars.bind_contextvars(**kwargs)
 
 
 @activity.defn(name="run_agent")
@@ -54,507 +45,131 @@ async def run_agent_activity(
     account_id: Optional[str] = None,
     request_id: Optional[str] = None,
 ) -> Dict[str, Any]:
-    """
-    Execute an agent run - main activity for agent execution.
-    
-    This activity wraps the core agent execution logic from run_agent_background.
-    It supports heartbeating for long-running operations and handles cancellation
-    via Temporal's cancellation mechanism.
-    """
+    """Execute an agent run with heartbeating and cancellation support."""
+    bind_context(agent_run_id=agent_run_id, thread_id=thread_id, request_id=request_id)
     worker_start = time.time()
-    timings = {}
+    # #region agent log
+    try:
+        import urllib.request as _ur; _ur.urlopen(_ur.Request('http://host.docker.internal:7242/ingest/8574b837-03d2-4ece-8422-988bb17343e8',data=__import__('json').dumps({"location":"activities.py:run_agent:start","message":"run_agent STARTED","data":{"agent_run_id":agent_run_id,"thread_id":thread_id,"instance_id":instance_id},"timestamp":time.time()*1000,"sessionId":"debug-session","hypothesisId":"A,C,E"}).encode(),headers={'Content-Type':'application/json'}),timeout=1)
+    except: pass
+    # #endregion
     
-    structlog.contextvars.clear_contextvars()
-    structlog.contextvars.bind_contextvars(
-        agent_run_id=agent_run_id,
-        thread_id=thread_id,
-        request_id=request_id,
-    )
-    
-    logger.info(f"⏱️ [TIMING] Activity received job at {worker_start}")
-    
-    # Initialize worker resources
-    t = time.time()
     try:
         await initialize()
     except Exception as e:
-        logger.critical(f"Failed to initialize worker resources (Redis/DB): {e}")
-        raise ActivityError(f"Worker setup failed: {str(e)}")
-    timings['initialize'] = (time.time() - t) * 1000
+        raise ActivityError(f"Worker init failed: {e}")
     
-    client = None
-    final_status = "failed"
-    
-    try:
-        client = await db.client
-        lock_acquired = await acquire_run_lock(agent_run_id, instance_id, client)
-        if not lock_acquired:
-            logger.info(f"Agent run {agent_run_id} already being processed by another instance")
-            return {"status": "skipped", "reason": "lock_not_acquired"}
-        
-        sentry.sentry.set_tag("thread_id", thread_id)
-        
-        timings['lock_acquisition'] = (time.time() - worker_start) * 1000 - timings['initialize']
-        logger.info(f"⏱️ [TIMING] Worker init: {timings['initialize']:.1f}ms | Lock: {timings['lock_acquisition']:.1f}ms")
-        logger.info(f"Starting agent run: {agent_run_id} for thread: {thread_id} (Instance: {instance_id})")
-        
-        from core.ai_models import model_manager
-        effective_model = model_manager.resolve_model_id(model_name)
-        logger.info(f"🚀 Using model: {effective_model}")
-        
-        start_time = datetime.now(timezone.utc)
-        cancellation_event = asyncio.Event()
-        
-        redis_keys = create_redis_keys(agent_run_id, instance_id)
-        
-        await redis.verify_stream_writable(redis_keys['response_stream'])
-        logger.info(f"✅ Verified Redis stream {redis_keys['response_stream']} is writable")
-        
-        trace = langfuse.trace(
-            name="agent_run",
-            id=agent_run_id,
-            session_id=thread_id,
-            metadata={"project_id": project_id, "instance_id": instance_id}
-        )
-        
-        # Set instance active key
-        try:
-            await asyncio.wait_for(
-                redis.set(redis_keys['instance_active'], "running", ex=redis.REDIS_KEY_TTL),
-                timeout=5.0
-            )
-        except (asyncio.TimeoutError, Exception) as e:
-            logger.warning(f"Redis error setting instance_active key: {e} - continuing")
-        
-        agent_config = await load_agent_config(agent_id, account_id)
-        
-        # Set tool output streaming context
-        set_tool_output_streaming_context(
-            agent_run_id=agent_run_id,
-            stream_key=redis_keys['response_stream']
-        )
-        
-        # Check for cancellation periodically and send heartbeats with progress data
-        stop_signal_checker_state = {
-            'stop_signal_received': False, 
-            'total_responses': 0, 
-            'stop_reason': None,
-            'last_response_type': None,
-            'started_at': datetime.now(timezone.utc).isoformat(),
-        }
-        
-        async def check_cancellation_and_heartbeat():
-            """
-            Check for Temporal cancellation and send heartbeats with progress data.
-            
-            Heartbeats include:
-            - Total responses processed
-            - Last response type
-            - Running duration
-            - Agent run ID for tracking
-            """
-            heartbeat_count = 0
-            while not stop_signal_checker_state.get('stop_signal_received'):
-                try:
-                    heartbeat_count += 1
-                    
-                    # Build progress data for heartbeat
-                    progress_data = {
-                        "agent_run_id": agent_run_id,
-                        "thread_id": thread_id,
-                        "responses_processed": stop_signal_checker_state.get('total_responses', 0),
-                        "last_response_type": stop_signal_checker_state.get('last_response_type'),
-                        "heartbeat_count": heartbeat_count,
-                        "running_seconds": (datetime.now(timezone.utc) - start_time).total_seconds(),
-                    }
-                    
-                    # Send heartbeat with progress data to Temporal
-                    # This allows monitoring and detecting stuck activities
-                    activity.heartbeat(progress_data)
-                    
-                    # Also check if Temporal requested cancellation
-                    if activity.is_cancelled():
-                        logger.warning(f"🛑 Temporal cancellation detected for agent run {agent_run_id}")
-                        stop_signal_checker_state['stop_signal_received'] = True
-                        stop_signal_checker_state['stop_reason'] = 'temporal_cancellation'
-                        cancellation_event.set()
-                        break
-                    
-                    # Refresh instance_active TTL every 25 heartbeats (~12.5 seconds)
-                    if heartbeat_count % 25 == 0:
-                        try:
-                            await asyncio.wait_for(
-                                redis.expire(redis_keys['instance_active'], redis.REDIS_KEY_TTL),
-                                timeout=3.0
-                            )
-                        except (asyncio.TimeoutError, Exception):
-                            pass
-                    
-                    await asyncio.sleep(0.5)  # Heartbeat every 500ms
-                    
-                except asyncio.CancelledError:
-                    logger.warning(f"🛑 Activity cancelled for agent run {agent_run_id}")
-                    stop_signal_checker_state['stop_signal_received'] = True
-                    stop_signal_checker_state['stop_reason'] = 'temporal_cancellation'
-                    cancellation_event.set()
-                    break
-                except Exception as e:
-                    logger.error(f"Error in heartbeat/cancellation checker: {e}", exc_info=True)
-                    await asyncio.sleep(1)
-        
-        cancellation_checker = asyncio.create_task(check_cancellation_and_heartbeat())
-        
-        try:
-            agent_gen = run_agent(
-                thread_id=thread_id,
-                project_id=project_id,
-                model_name=effective_model,
-                agent_config=agent_config,
-                trace=trace,
-                cancellation_event=cancellation_event,
-                account_id=account_id,
-            )
-            
-            total_to_ready = (time.time() - worker_start) * 1000
-            logger.info(f"⏱️ [TIMING] 🏁 Worker ready for first LLM call: {total_to_ready:.1f}ms from job start")
-            
-            final_status, error_message, complete_tool_called, total_responses = await process_agent_responses(
-                agent_gen, agent_run_id, redis_keys, trace, worker_start, stop_signal_checker_state
-            )
-            
-            if final_status == "running":
-                final_status = "completed"
-                await handle_normal_completion(agent_run_id, start_time, total_responses, redis_keys, trace)
-                await send_completion_notification(client, thread_id, agent_config, complete_tool_called)
-                if not complete_tool_called:
-                    logger.info(f"Agent run {agent_run_id} completed without explicit complete tool call")
-            
-            await update_agent_run_status(client, agent_run_id, final_status, error=error_message, account_id=account_id)
-            
-            if final_status == "failed" and error_message:
-                await send_failure_notification(client, thread_id, error_message)
-            
-            return {
-                "status": final_status,
-                "error": error_message,
-                "total_responses": total_responses,
-                "complete_tool_called": complete_tool_called,
-            }
-            
-        except Exception as e:
-            error_message = str(e)
-            traceback_str = traceback.format_exc()
-            duration = (datetime.now(timezone.utc) - start_time).total_seconds()
-            logger.error(f"Error in agent run {agent_run_id} after {duration:.2f}s: {error_message}\n{traceback_str}")
-            final_status = "failed"
-            trace.span(name="agent_run_failed").end(status_message=error_message, level="ERROR")
-            
-            await send_failure_notification(client, thread_id, error_message)
-            
-            error_response = {"type": "status", "status": "error", "message": error_message}
-            try:
-                error_json = json.dumps(error_response)
-                await asyncio.wait_for(
-                    redis.stream_add(
-                        redis_keys['response_stream'],
-                        {'data': error_json},
-                        maxlen=200,
-                        approximate=True
-                    ),
-                    timeout=5.0
-                )
-            except (asyncio.TimeoutError, Exception) as redis_err:
-                logger.error(f"Failed to write error response to stream: {redis_err}")
-            
-            await update_agent_run_status(client, agent_run_id, "failed", error=f"{error_message}\n{traceback_str}", account_id=account_id)
-            
-            raise ActivityError(f"Agent run failed: {error_message}")
-        
-        finally:
-            if cancellation_checker and not cancellation_checker.done():
-                cancellation_checker.cancel()
-                try:
-                    await cancellation_checker
-                except asyncio.CancelledError:
-                    pass
-            
-            clear_tool_output_streaming_context()
-            await cleanup_redis_keys_for_agent_run(agent_run_id, instance_id)
-            
-            # Memory cleanup
-            try:
-                import gc
-                collected = gc.collect()
-                if collected > 0:
-                    logger.debug(f"Garbage collected {collected} objects after agent run {agent_run_id}")
-            except Exception:
-                pass
-    
-    except Exception as e:
-        logger.error(f"Critical error during activity setup for {agent_run_id}: {e}", exc_info=True)
-        try:
-            if not client:
-                client = await db.client
-            await update_agent_run_status(client, agent_run_id, "failed", error=f"Activity setup failed: {str(e)}", account_id=account_id)
-        except Exception:
-            pass
-        try:
-            await cleanup_redis_keys_for_agent_run(agent_run_id, instance_id)
-        except Exception:
-            pass
-        raise ActivityError(f"Activity setup failed: {str(e)}")
-
-
-@activity.defn(name="extract_memories")
-async def extract_memories_activity(
-    thread_id: str,
-    account_id: str,
-    message_ids: List[str]
-) -> Optional[List[Dict[str, Any]]]:
-    """
-    Extract memories from conversation messages.
-    
-    Returns:
-        List of extracted memories (dict format) or None if extraction skipped
-    """
-    structlog.contextvars.clear_contextvars()
-    structlog.contextvars.bind_contextvars(
-        thread_id=thread_id,
-        account_id=account_id,
-        job_type="memory_extraction"
-    )
-    
-    logger.info(f"Starting memory extraction for thread {thread_id}")
-    
-    await db.initialize()
     client = await db.client
     
+    # Acquire lock
+    if not await acquire_run_lock(agent_run_id, instance_id, client):
+        return {"status": "skipped", "reason": "lock_not_acquired"}
+    
+    sentry.sentry.set_tag("thread_id", thread_id)
+    logger.info(f"Starting agent run: {agent_run_id} (thread: {thread_id})")
+    
+    from core.ai_models import model_manager
+    effective_model = model_manager.resolve_model_id(model_name)
+    
+    start_time = datetime.now(timezone.utc)
+    cancellation_event = asyncio.Event()
+    redis_keys = create_redis_keys(agent_run_id, instance_id)
+    
+    # #region agent log
     try:
-        from core.billing import subscription_service
-        from core.billing.shared.config import get_memory_config, is_memory_enabled
-        from core.memory.extraction_service import MemoryExtractionService
-        from core.memory.models import ExtractionQueueStatus
-        
-        tier_info = await subscription_service.get_user_subscription_tier(account_id)
-        tier_name = tier_info['name']
-        
-        if not is_memory_enabled(tier_name):
-            logger.debug(f"Memory disabled for tier {tier_name}, skipping extraction")
-            return None
-        
-        user_memory_result = await client.rpc('get_user_memory_enabled', {'p_account_id': account_id}).execute()
-        user_memory_enabled = user_memory_result.data if user_memory_result.data is not None else True
-        if not user_memory_enabled:
-            logger.debug(f"Memory disabled by user {account_id}, skipping extraction")
-            return None
-        
-        recent_extraction = await client.table('memory_extraction_queue').select('created_at').eq('thread_id', thread_id).eq('status', 'completed').order('created_at', desc=True).limit(1).execute()
-        
-        if recent_extraction.data:
-            from datetime import timedelta
-            last_extraction = datetime.fromisoformat(recent_extraction.data[0]['created_at'].replace('Z', '+00:00'))
-            if datetime.now(timezone.utc) - last_extraction < timedelta(hours=1):
-                logger.debug(f"Recent extraction found for thread {thread_id}, skipping")
-                return None
-        
-        messages_result = await client.table('messages').select('*').in_('message_id', message_ids).execute()
-        messages = messages_result.data or []
-        
-        extraction_service = MemoryExtractionService()
-        if not await extraction_service.should_extract(messages):
-            logger.debug(f"Not enough content for extraction in thread {thread_id}")
-            return None
-        
-        queue_entry = await client.table('memory_extraction_queue').insert({
-            'thread_id': thread_id,
-            'account_id': account_id,
-            'message_ids': message_ids,
-            'status': ExtractionQueueStatus.PROCESSING.value
-        }).execute()
-        
-        queue_id = queue_entry.data[0]['queue_id']
-        
-        extracted_memories = await extraction_service.extract_memories(
-            messages=messages,
-            account_id=account_id,
-            thread_id=thread_id
-        )
-        
-        if not extracted_memories:
-            logger.info(f"No memories extracted from thread {thread_id}")
-            await client.table('memory_extraction_queue').update({
-                'status': ExtractionQueueStatus.COMPLETED.value,
-                'processed_at': datetime.now(timezone.utc).isoformat()
-            }).eq('queue_id', queue_id).execute()
-            return None
-        
-        await client.table('memory_extraction_queue').update({
-            'status': ExtractionQueueStatus.COMPLETED.value,
-            'processed_at': datetime.now(timezone.utc).isoformat()
-        }).eq('queue_id', queue_id).execute()
-        
-        logger.info(f"Successfully extracted {len(extracted_memories)} memories from thread {thread_id}")
-        
-        # Return memories in dict format for next activity
-        return [
-            {
-                'content': mem.content,
-                'memory_type': mem.memory_type.value,
-                'confidence_score': mem.confidence_score,
-                'metadata': mem.metadata
-            }
-            for mem in extracted_memories
-        ]
+        import urllib.request as _ur; _ur.urlopen(_ur.Request('http://host.docker.internal:7242/ingest/8574b837-03d2-4ece-8422-988bb17343e8',data=__import__('json').dumps({"location":"activities.py:run_agent:redis_keys","message":"Redis keys created","data":{"agent_run_id":agent_run_id,"stream_key":redis_keys['response_stream']},"timestamp":time.time()*1000,"sessionId":"debug-session","hypothesisId":"B"}).encode(),headers={'Content-Type':'application/json'}),timeout=1)
+    except: pass
+    # #endregion
     
-    except Exception as e:
-        logger.error(f"Memory extraction failed for thread {thread_id}: {str(e)}")
-        try:
-            from core.memory.models import ExtractionQueueStatus
-            await client.table('memory_extraction_queue').update({
-                'status': ExtractionQueueStatus.FAILED.value,
-                'error_message': str(e),
-                'processed_at': datetime.now(timezone.utc).isoformat()
-            }).eq('thread_id', thread_id).eq('status', ExtractionQueueStatus.PROCESSING.value).execute()
-        except Exception:
-            pass
-        raise ActivityError(f"Memory extraction failed: {str(e)}")
-
-
-@activity.defn(name="embed_and_store_memories")
-async def embed_and_store_memories_activity(
-    account_id: str,
-    thread_id: str,
-    extracted_memories: List[Dict[str, Any]]
-) -> Dict[str, Any]:
-    """
-    Embed and store extracted memories.
+    await redis.verify_stream_writable(redis_keys['response_stream'])
     
-    Returns:
-        Dict with count of stored memories
-    """
-    structlog.contextvars.clear_contextvars()
-    structlog.contextvars.bind_contextvars(
-        thread_id=thread_id,
-        account_id=account_id,
-        job_type="memory_embedding"
+    trace = langfuse.trace(
+        name="agent_run", id=agent_run_id, session_id=thread_id,
+        metadata={"project_id": project_id, "instance_id": instance_id}
     )
     
-    logger.info(f"Starting embedding and storage for {len(extracted_memories)} memories")
+    await redis.set(redis_keys['instance_active'], "running", ex=redis.REDIS_KEY_TTL)
+    agent_config = await load_agent_config(agent_id, account_id)
+    set_tool_output_streaming_context(agent_run_id=agent_run_id, stream_key=redis_keys['response_stream'])
     
-    await db.initialize()
-    client = await db.client
+    # State for heartbeat checker
+    state = {'stop': False, 'total_responses': 0, 'last_type': None}
     
-    try:
-        from core.billing import subscription_service
-        from core.billing.shared.config import get_memory_config
-        from core.memory.embedding_service import EmbeddingService
-        
-        tier_info = await subscription_service.get_user_subscription_tier(account_id)
-        tier_name = tier_info['name']
-        memory_config = get_memory_config(tier_name)
-        max_memories = memory_config.get('max_memories', 0)
-        
-        current_count_result = await client.table('user_memories').select('memory_id', count='exact').eq('account_id', account_id).execute()
-        current_count = current_count_result.count or 0
-        
-        embedding_service = EmbeddingService()
-        texts_to_embed = [mem['content'] for mem in extracted_memories]
-        embeddings = await embedding_service.embed_texts(texts_to_embed)
-        
-        memories_to_insert = []
-        for i, mem in enumerate(extracted_memories):
-            memories_to_insert.append({
-                'account_id': account_id,
-                'content': mem['content'],
-                'memory_type': mem['memory_type'],
-                'embedding': embeddings[i],
-                'source_thread_id': thread_id,
-                'confidence_score': mem.get('confidence_score', 0.8),
-                'metadata': mem.get('metadata', {})
+    async def heartbeat_loop():
+        """Send heartbeats and check for cancellation."""
+        count = 0
+        while not state['stop']:
+            count += 1
+            activity.heartbeat({
+                "agent_run_id": agent_run_id,
+                "responses": state['total_responses'],
+                "running_seconds": (datetime.now(timezone.utc) - start_time).total_seconds(),
             })
-        
-        if current_count + len(memories_to_insert) > max_memories:
-            overflow = (current_count + len(memories_to_insert)) - max_memories
             
-            old_memories = await client.table('user_memories').select('memory_id').eq('account_id', account_id).order('confidence_score', desc=False).order('created_at', desc=False).limit(overflow).execute()
+            if activity.is_cancelled():
+                logger.warning(f"🛑 Cancellation detected: {agent_run_id}")
+                state['stop'] = True
+                cancellation_event.set()
+                break
             
-            if old_memories.data:
-                memory_ids_to_delete = [m['memory_id'] for m in old_memories.data]
-                await client.table('user_memories').delete().in_('memory_id', memory_ids_to_delete).execute()
-                logger.info(f"Deleted {len(memory_ids_to_delete)} old memories to stay within limit")
-        
-        result = await client.table('user_memories').insert(memories_to_insert).execute()
-        
-        logger.info(f"Successfully stored {len(result.data)} memories for account {account_id}")
-        
-        return {"stored_count": len(result.data)}
+            if count % 25 == 0:
+                await redis.expire(redis_keys['instance_active'], redis.REDIS_KEY_TTL)
+            
+            await asyncio.sleep(0.5)
     
-    except Exception as e:
-        logger.error(f"Memory embedding and storage failed: {str(e)}")
-        raise ActivityError(f"Memory embedding failed: {str(e)}")
-
-
-@activity.defn(name="consolidate_memories")
-async def consolidate_memories_activity(account_id: str) -> Dict[str, Any]:
-    """
-    Consolidate duplicate memories for an account.
-    
-    Returns:
-        Dict with count of consolidated memories
-    """
-    structlog.contextvars.clear_contextvars()
-    structlog.contextvars.bind_contextvars(
-        account_id=account_id,
-        job_type="memory_consolidation"
-    )
-    
-    logger.info(f"Starting memory consolidation for account {account_id}")
-    
-    await db.initialize()
-    client = await db.client
+    heartbeat_task = asyncio.create_task(heartbeat_loop())
+    final_status = "failed"
+    error_message = None
     
     try:
-        memories_result = await client.table('user_memories').select('*').eq('account_id', account_id).order('created_at', desc=True).limit(500).execute()
+        agent_gen = run_agent(
+            thread_id=thread_id, project_id=project_id, model_name=effective_model,
+            agent_config=agent_config, trace=trace, cancellation_event=cancellation_event,
+            account_id=account_id,
+        )
         
-        memories = memories_result.data or []
+        logger.info(f"⏱️ Ready for LLM: {(time.time() - worker_start) * 1000:.0f}ms")
         
-        if len(memories) < 10:
-            logger.debug(f"Not enough memories to consolidate for {account_id}")
-            return {"consolidated_count": 0}
+        final_status, error_message, complete_tool_called, total_responses = await process_agent_responses(
+            agent_gen, agent_run_id, redis_keys, trace, worker_start, state
+        )
         
-        import numpy as np
-        similarity_threshold = 0.95
-        consolidated_count = 0
+        if final_status == "running":
+            final_status = "completed"
+            await handle_normal_completion(agent_run_id, start_time, total_responses, redis_keys, trace)
+            await send_completion_notification(client, thread_id, agent_config, complete_tool_called)
         
-        for i, mem1 in enumerate(memories):
-            if not mem1.get('embedding'):
-                continue
-            
-            for mem2 in memories[i+1:]:
-                if not mem2.get('embedding'):
-                    continue
-                
-                embedding1 = np.array(mem1['embedding'])
-                embedding2 = np.array(mem2['embedding'])
-                
-                similarity = np.dot(embedding1, embedding2) / (np.linalg.norm(embedding1) * np.linalg.norm(embedding2))
-                
-                if similarity >= similarity_threshold:
-                    if mem1.get('confidence_score', 0) >= mem2.get('confidence_score', 0):
-                        await client.table('user_memories').delete().eq('memory_id', mem2['memory_id']).execute()
-                    else:
-                        await client.table('user_memories').delete().eq('memory_id', mem1['memory_id']).execute()
-                        break
-                    
-                    consolidated_count += 1
+        await update_agent_run_status(client, agent_run_id, final_status, error=error_message, account_id=account_id)
         
-        logger.info(f"Consolidated {consolidated_count} duplicate memories for account {account_id}")
+        if final_status == "failed" and error_message:
+            await send_failure_notification(client, thread_id, error_message)
         
-        return {"consolidated_count": consolidated_count}
-    
+        return {"status": final_status, "error": error_message, "total_responses": total_responses}
+        
     except Exception as e:
-        logger.error(f"Memory consolidation failed for {account_id}: {str(e)}")
-        raise ActivityError(f"Memory consolidation failed: {str(e)}")
+        error_message = str(e)
+        logger.error(f"Agent run {agent_run_id} failed: {error_message}")
+        trace.span(name="agent_run_failed").end(status_message=error_message, level="ERROR")
+        await send_failure_notification(client, thread_id, error_message)
+        
+        try:
+            await redis.stream_add(redis_keys['response_stream'], {'data': json.dumps({"type": "status", "status": "error", "message": error_message})}, maxlen=200)
+        except Exception:
+            pass
+        
+        await update_agent_run_status(client, agent_run_id, "failed", error=f"{error_message}\n{traceback.format_exc()}", account_id=account_id)
+        raise ActivityError(f"Agent run failed: {error_message}")
+        
+    finally:
+        state['stop'] = True
+        heartbeat_task.cancel()
+        try:
+            await heartbeat_task
+        except asyncio.CancelledError:
+            pass
+        
+        clear_tool_output_streaming_context()
+        await cleanup_redis_keys_for_agent_run(agent_run_id, instance_id)
 
 
 @activity.defn(name="initialize_thread")
@@ -566,208 +181,243 @@ async def initialize_thread_activity(
     agent_id: Optional[str] = None,
     model_name: Optional[str] = None,
 ) -> Dict[str, Any]:
-    """
-    Initialize a thread and create agent run record.
-    
-    This activity performs all the thread initialization work.
-    
-    Returns:
-        Dict with agent_run_id, effective_model, and agent_config
-    """
-    structlog.contextvars.clear_contextvars()
-    structlog.contextvars.bind_contextvars(
-        thread_id=thread_id,
-        project_id=project_id,
-        account_id=account_id,
-    )
-    
-    logger.info(f"Starting thread initialization for thread {thread_id}")
+    """Initialize thread and create agent run record."""
+    bind_context(thread_id=thread_id, project_id=project_id, account_id=account_id)
+    logger.info(f"Initializing thread {thread_id}")
+    # #region agent log
+    try:
+        import urllib.request as _ur; _ur.urlopen(_ur.Request('http://host.docker.internal:7242/ingest/8574b837-03d2-4ece-8422-988bb17343e8',data=__import__('json').dumps({"location":"activities.py:initialize_thread:start","message":"initialize_thread STARTED","data":{"thread_id":thread_id},"timestamp":time.time()*1000,"sessionId":"debug-session","hypothesisId":"A,D"}).encode(),headers={'Content-Type':'application/json'}),timeout=1)
+    except: pass
+    # #endregion
     
     await db.initialize()
     client = await db.client
     
     try:
-        from datetime import datetime, timezone
         from core.utils.retry import retry_db_operation
         from core.ai_models import model_manager
-        from core.agent_runs import (
-            _load_agent_config,
-            _get_effective_model,
-            _create_agent_run_record,
-        )
+        from core.agent_runs import _load_agent_config, _get_effective_model, _create_agent_run_record
         
-        # Update thread status to initializing
-        async def update_thread_initializing():
-            client = await db.client
-            return await client.table('threads').update({
-                "status": "initializing",
-                "initialization_started_at": datetime.now(timezone.utc).isoformat()
-            }).eq('thread_id', thread_id).execute()
+        # Mark thread initializing
+        await client.table('threads').update({
+            "status": "initializing",
+            "initialization_started_at": datetime.now(timezone.utc).isoformat()
+        }).eq('thread_id', thread_id).execute()
         
-        await retry_db_operation(
-            update_thread_initializing,
-            f"Update thread {thread_id} to initializing",
-            max_retries=3,
-            initial_delay=1.0,
-            reset_connection_on_error=True,
-        )
-        
-        logger.debug(f"Thread {thread_id} marked as initializing")
-        
-        await asyncio.sleep(0.1)
-        
-        # Get default model if not provided
+        # Get model
         if model_name is None:
-            async def get_default_model():
-                client = await db.client
-                return await model_manager.get_default_model_for_user(client, account_id)
-            
-            model_name = await retry_db_operation(
-                get_default_model,
-                f"Get default model for user {account_id}",
-                max_retries=3,
-                initial_delay=1.0,
-            )
+            model_name = await model_manager.get_default_model_for_user(client, account_id)
         else:
             model_name = model_manager.resolve_model_id(model_name)
         
-        # Load agent config
-        async def load_agent_config():
-            client = await db.client
-            return await _load_agent_config(client, agent_id, account_id, account_id, is_new_thread=False)
+        # Load config and create run
+        agent_config = await _load_agent_config(client, agent_id, account_id, account_id, is_new_thread=False)
+        effective_model = await _get_effective_model(model_name, agent_config, client, account_id)
+        agent_run_id = await _create_agent_run_record(client, thread_id, agent_config, effective_model, account_id)
         
-        agent_config = await retry_db_operation(
-            load_agent_config,
-            f"Load agent config for thread {thread_id}",
-            max_retries=3,
-            initial_delay=1.0,
-        )
+        # Mark ready
+        await client.table('threads').update({
+            "status": "ready",
+            "initialization_completed_at": datetime.now(timezone.utc).isoformat()
+        }).eq('thread_id', thread_id).execute()
         
-        # Get effective model
-        async def get_effective_model(agent_config):
-            client = await db.client
-            return await _get_effective_model(model_name, agent_config, client, account_id)
+        # Pre-create the stream so frontend can subscribe immediately
+        stream_key = f"agent_run:{agent_run_id}:stream"
+        await redis.verify_stream_writable(stream_key)
         
-        effective_model = await retry_db_operation(
-            lambda: get_effective_model(agent_config),
-            f"Get effective model for thread {thread_id}",
-            max_retries=3,
-            initial_delay=1.0,
-        )
+        # #region agent log
+        try:
+            import urllib.request as _ur; _ur.urlopen(_ur.Request('http://host.docker.internal:7242/ingest/8574b837-03d2-4ece-8422-988bb17343e8',data=__import__('json').dumps({"location":"activities.py:initialize_thread:stream_created","message":"Stream pre-created","data":{"thread_id":thread_id,"agent_run_id":agent_run_id,"stream_key":stream_key},"timestamp":time.time()*1000,"sessionId":"debug-session","hypothesisId":"B,D"}).encode(),headers={'Content-Type':'application/json'}),timeout=1)
+        except: pass
+        # #endregion
         
-        # Create agent run record
-        async def create_agent_run_record(agent_config, effective_model):
-            client = await db.client
-            return await _create_agent_run_record(client, thread_id, agent_config, effective_model, account_id)
-        
-        agent_run_id = await retry_db_operation(
-            lambda: create_agent_run_record(agent_config, effective_model),
-            f"Create agent run record for thread {thread_id}",
-            max_retries=3,
-            initial_delay=1.0,
-        )
-        
-        # Update thread status to ready
-        async def update_thread_ready():
-            client = await db.client
-            return await client.table('threads').update({
-                "status": "ready",
-                "initialization_completed_at": datetime.now(timezone.utc).isoformat()
-            }).eq('thread_id', thread_id).execute()
-        
-        await retry_db_operation(
-            update_thread_ready,
-            f"Update thread {thread_id} to ready",
-            max_retries=3,
-            initial_delay=1.0,
-            reset_connection_on_error=True,
-        )
-        
-        logger.info(f"Thread {thread_id} initialized successfully, agent_run_id: {agent_run_id}")
-        
-        return {
-            "agent_run_id": agent_run_id,
-            "effective_model": effective_model,
-            "agent_config": agent_config,
-        }
+        logger.info(f"Thread {thread_id} ready, agent_run_id: {agent_run_id}")
+        return {"agent_run_id": agent_run_id, "effective_model": effective_model, "agent_config": agent_config}
         
     except Exception as e:
-        error_msg = str(e)
-        logger.error(f"Thread initialization failed for thread {thread_id}: {error_msg}")
-        
-        # Try to update thread status to error
+        logger.error(f"Thread init failed: {e}")
         try:
-            from datetime import datetime, timezone
-            from core.utils.retry import retry_db_operation
-            
-            async def update_thread_error():
-                client = await db.client
-                return await client.table('threads').update({
-                    "status": "error",
-                    "initialization_error": error_msg[:1000],
-                    "initialization_completed_at": datetime.now(timezone.utc).isoformat()
-                }).eq('thread_id', thread_id).execute()
-            
-            await retry_db_operation(
-                update_thread_error,
-                f"Update thread {thread_id} to error status",
-                max_retries=2,
-                initial_delay=0.5,
-            )
-        except Exception as update_error:
-            logger.error(f"Failed to update thread status to error: {update_error}")
+            await client.table('threads').update({
+                "status": "error",
+                "initialization_error": str(e)[:1000],
+            }).eq('thread_id', thread_id).execute()
+        except Exception:
+            pass
+        raise ActivityError(f"Thread init failed: {e}")
+
+
+@activity.defn(name="extract_memories")
+async def extract_memories_activity(thread_id: str, account_id: str, message_ids: List[str]) -> Optional[List[Dict[str, Any]]]:
+    """Extract memories from conversation messages."""
+    bind_context(thread_id=thread_id, account_id=account_id, job_type="memory_extraction")
+    logger.info(f"Extracting memories from {thread_id}")
+    
+    await db.initialize()
+    client = await db.client
+    
+    try:
+        from core.billing import subscription_service
+        from core.billing.shared.config import is_memory_enabled
+        from core.memory.extraction_service import MemoryExtractionService
+        from core.memory.models import ExtractionQueueStatus
         
-        raise ActivityError(f"Thread initialization failed: {error_msg}")
+        # Check if memory enabled
+        tier = (await subscription_service.get_user_subscription_tier(account_id))['name']
+        if not is_memory_enabled(tier):
+            return None
+        
+        user_enabled = (await client.rpc('get_user_memory_enabled', {'p_account_id': account_id}).execute()).data
+        if user_enabled is False:
+            return None
+        
+        # Check recent extraction
+        recent = await client.table('memory_extraction_queue').select('created_at').eq('thread_id', thread_id).eq('status', 'completed').order('created_at', desc=True).limit(1).execute()
+        if recent.data:
+            last = datetime.fromisoformat(recent.data[0]['created_at'].replace('Z', '+00:00'))
+            if datetime.now(timezone.utc) - last < timedelta(hours=1):
+                return None
+        
+        # Get messages and check if enough content
+        messages = (await client.table('messages').select('*').in_('message_id', message_ids).execute()).data or []
+        service = MemoryExtractionService()
+        if not await service.should_extract(messages):
+            return None
+        
+        # Create queue entry
+        queue = await client.table('memory_extraction_queue').insert({
+            'thread_id': thread_id, 'account_id': account_id, 'message_ids': message_ids,
+            'status': ExtractionQueueStatus.PROCESSING.value
+        }).execute()
+        queue_id = queue.data[0]['queue_id']
+        
+        # Extract
+        memories = await service.extract_memories(messages=messages, account_id=account_id, thread_id=thread_id)
+        
+        await client.table('memory_extraction_queue').update({
+            'status': ExtractionQueueStatus.COMPLETED.value,
+            'processed_at': datetime.now(timezone.utc).isoformat()
+        }).eq('queue_id', queue_id).execute()
+        
+        if not memories:
+            return None
+        
+        logger.info(f"Extracted {len(memories)} memories from {thread_id}")
+        return [{'content': m.content, 'memory_type': m.memory_type.value, 'confidence_score': m.confidence_score, 'metadata': m.metadata} for m in memories]
+        
+    except Exception as e:
+        logger.error(f"Memory extraction failed: {e}")
+        raise ActivityError(f"Memory extraction failed: {e}")
+
+
+@activity.defn(name="embed_and_store_memories")
+async def embed_and_store_memories_activity(account_id: str, thread_id: str, extracted_memories: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Embed and store extracted memories."""
+    bind_context(thread_id=thread_id, account_id=account_id, job_type="memory_embedding")
+    logger.info(f"Storing {len(extracted_memories)} memories")
+    
+    await db.initialize()
+    client = await db.client
+    
+    try:
+        from core.billing import subscription_service
+        from core.billing.shared.config import get_memory_config
+        from core.memory.embedding_service import EmbeddingService
+        
+        tier = (await subscription_service.get_user_subscription_tier(account_id))['name']
+        max_memories = get_memory_config(tier).get('max_memories', 0)
+        current_count = (await client.table('user_memories').select('memory_id', count='exact').eq('account_id', account_id).execute()).count or 0
+        
+        # Embed
+        embeddings = await EmbeddingService().embed_texts([m['content'] for m in extracted_memories])
+        
+        # Prepare inserts
+        to_insert = [{
+            'account_id': account_id, 'content': m['content'], 'memory_type': m['memory_type'],
+            'embedding': embeddings[i], 'source_thread_id': thread_id,
+            'confidence_score': m.get('confidence_score', 0.8), 'metadata': m.get('metadata', {})
+        } for i, m in enumerate(extracted_memories)]
+        
+        # Delete old if over limit
+        if current_count + len(to_insert) > max_memories:
+            overflow = (current_count + len(to_insert)) - max_memories
+            old = await client.table('user_memories').select('memory_id').eq('account_id', account_id).order('confidence_score').order('created_at').limit(overflow).execute()
+            if old.data:
+                await client.table('user_memories').delete().in_('memory_id', [m['memory_id'] for m in old.data]).execute()
+        
+        result = await client.table('user_memories').insert(to_insert).execute()
+        logger.info(f"Stored {len(result.data)} memories")
+        return {"stored_count": len(result.data)}
+        
+    except Exception as e:
+        raise ActivityError(f"Memory storage failed: {e}")
+
+
+@activity.defn(name="consolidate_memories")
+async def consolidate_memories_activity(account_id: str) -> Dict[str, Any]:
+    """Consolidate duplicate memories."""
+    bind_context(account_id=account_id, job_type="memory_consolidation")
+    
+    await db.initialize()
+    client = await db.client
+    
+    try:
+        import numpy as np
+        
+        memories = (await client.table('user_memories').select('*').eq('account_id', account_id).order('created_at', desc=True).limit(500).execute()).data or []
+        if len(memories) < 10:
+            return {"consolidated_count": 0}
+        
+        consolidated = 0
+        threshold = 0.95
+        
+        for i, m1 in enumerate(memories):
+            if not m1.get('embedding'):
+                continue
+            for m2 in memories[i+1:]:
+                if not m2.get('embedding'):
+                    continue
+                
+                e1, e2 = np.array(m1['embedding']), np.array(m2['embedding'])
+                sim = np.dot(e1, e2) / (np.linalg.norm(e1) * np.linalg.norm(e2))
+                
+                if sim >= threshold:
+                    to_delete = m2 if m1.get('confidence_score', 0) >= m2.get('confidence_score', 0) else m1
+                    await client.table('user_memories').delete().eq('memory_id', to_delete['memory_id']).execute()
+                    consolidated += 1
+                    if to_delete == m1:
+                        break
+        
+        logger.info(f"Consolidated {consolidated} memories")
+        return {"consolidated_count": consolidated}
+        
+    except Exception as e:
+        raise ActivityError(f"Consolidation failed: {e}")
 
 
 @activity.defn(name="find_stale_projects")
 async def find_stale_projects_activity() -> List[Dict[str, str]]:
-    """
-    Find stale projects that need categorization.
-    
-    Returns:
-        List of project dicts with project_id
-    """
+    """Find stale projects needing categorization."""
     await db.initialize()
     client = await db.client
     
     try:
-        from datetime import datetime, timezone, timedelta
-        
-        STALE_THRESHOLD_MINUTES = 30
-        MAX_PROJECTS_PER_RUN = 50
-        
-        stale_threshold = datetime.now(timezone.utc) - timedelta(minutes=STALE_THRESHOLD_MINUTES)
-        
-        # Find projects: inactive 30+ mins AND (never categorized OR has new activity)
-        result = await client.rpc(
-            'get_stale_projects_for_categorization',
-            {
-                'stale_threshold': stale_threshold.isoformat(),
-                'max_count': MAX_PROJECTS_PER_RUN
-            }
-        ).execute()
+        threshold = datetime.now(timezone.utc) - timedelta(minutes=30)
+        result = await client.rpc('get_stale_projects_for_categorization', {
+            'stale_threshold': threshold.isoformat(), 'max_count': 50
+        }).execute()
         
         projects = result.data or []
-        
-        logger.info(f"Found {len(projects)} stale projects for categorization")
-        
+        logger.info(f"Found {len(projects)} stale projects")
         return [{"project_id": p["project_id"]} for p in projects]
-    
+        
     except Exception as e:
-        logger.error(f"Failed to find stale projects: {str(e)}")
-        raise ActivityError(f"Failed to find stale projects: {str(e)}")
+        raise ActivityError(f"Find stale projects failed: {e}")
 
 
 @activity.defn(name="categorize_project")
 async def categorize_project_activity(project_id: str) -> Dict[str, Any]:
-    """
-    Categorize a project based on its thread messages.
-    
-    Returns:
-        Dict with categories assigned
-    """
-    logger.info(f"Categorizing project {project_id}")
+    """Categorize a project based on messages."""
+    logger.info(f"Categorizing {project_id}")
     
     await db.initialize()
     client = await db.client
@@ -775,55 +425,27 @@ async def categorize_project_activity(project_id: str) -> Dict[str, Any]:
     try:
         from core.categorization.service import categorize_from_messages
         
-        MIN_USER_MESSAGES = 1
-        
-        # Get the thread for this project
-        thread_result = await client.table('threads').select(
-            'thread_id'
-        ).eq('project_id', project_id).limit(1).execute()
-        
-        if not thread_result.data:
-            logger.debug(f"No thread for project {project_id}")
-            # Mark as categorized to avoid re-processing
-            await client.table('projects').update({
-                'last_categorized_at': datetime.now(timezone.utc).isoformat()
-            }).eq('project_id', project_id).execute()
+        # Get thread
+        thread = await client.table('threads').select('thread_id').eq('project_id', project_id).limit(1).execute()
+        if not thread.data:
+            await client.table('projects').update({'last_categorized_at': datetime.now(timezone.utc).isoformat()}).eq('project_id', project_id).execute()
             return {"categories": [], "skipped": True}
         
-        thread_id = thread_result.data[0]['thread_id']
+        # Get messages
+        messages = (await client.table('messages').select('type', 'content').eq('thread_id', thread.data[0]['thread_id']).order('created_at').execute()).data or []
         
-        # Get messages (type = role, content is JSONB)
-        messages_result = await client.table('messages').select(
-            'type', 'content'
-        ).eq('thread_id', thread_id).order('created_at').execute()
-        
-        messages = messages_result.data or []
-        
-        # Check minimum user messages
-        user_count = sum(1 for m in messages if m.get('type') == 'user')
-        if user_count < MIN_USER_MESSAGES:
-            logger.debug(f"Project {project_id} has only {user_count} user messages")
-            await client.table('projects').update({
-                'last_categorized_at': datetime.now(timezone.utc).isoformat()
-            }).eq('project_id', project_id).execute()
+        if sum(1 for m in messages if m.get('type') == 'user') < 1:
+            await client.table('projects').update({'last_categorized_at': datetime.now(timezone.utc).isoformat()}).eq('project_id', project_id).execute()
             return {"categories": [], "skipped": True}
         
-        # Categorize
-        categories = await categorize_from_messages(messages)
-        if not categories:
-            categories = ["Other"]
+        categories = await categorize_from_messages(messages) or ["Other"]
         
-        # Update project
         await client.table('projects').update({
-            'categories': categories,
-            'last_categorized_at': datetime.now(timezone.utc).isoformat()
+            'categories': categories, 'last_categorized_at': datetime.now(timezone.utc).isoformat()
         }).eq('project_id', project_id).execute()
         
-        logger.info(f"Categorized project {project_id}: {categories}")
-        
+        logger.info(f"Categorized {project_id}: {categories}")
         return {"categories": categories}
-    
+        
     except Exception as e:
-        logger.error(f"Categorization failed for project {project_id}: {e}")
-        raise ActivityError(f"Categorization failed: {str(e)}")
-
+        raise ActivityError(f"Categorization failed: {e}")

--- a/backend/core/temporal/worker.py
+++ b/backend/core/temporal/worker.py
@@ -1,16 +1,9 @@
 """
-Temporal worker entry point.
+Temporal worker - runs workflows and activities.
 
-Runs Temporal workflows and activities for background processing.
-
-ARCHITECTURE:
-- Two task queues for priority-based processing:
-  - "agent-runs": High-priority, long-running agent executions (limited concurrency)
-  - "background": Lower-priority tasks like memory extraction, categorization (higher concurrency)
-
-- Graceful shutdown handling for SIGTERM/SIGINT
-- Auto-tuned concurrency based on available system resources
-- Async activities run directly on event loop (no ThreadPoolExecutor needed)
+Two task queues:
+- "agent-runs": Long-running agent executions (limited concurrency)
+- "background": Memory/categorization tasks (higher concurrency)
 """
 import asyncio
 import os
@@ -25,7 +18,6 @@ from temporalio.worker import Worker
 from core.temporal.client import get_temporal_client
 from core.temporal.workflows import (
     AgentRunWorkflow,
-    ThreadInitWorkflow,
     MemoryExtractionWorkflow,
     CategorizationWorkflow,
     CategorizeProjectWorkflow,
@@ -44,230 +36,122 @@ from core.temporal.activities import (
 from core.utils.logger import logger
 from core.utils.tool_discovery import warm_up_tools_cache
 
+# Default concurrency settings
+DEFAULT_CONCURRENCY = {
+    "agent_runs": {"max_concurrent_activities": 8, "max_concurrent_workflow_tasks": 10},
+    "background": {"max_concurrent_activities": 50, "max_concurrent_workflow_tasks": 20},
+}
+
 
 def get_optimal_concurrency() -> dict:
-    """
-    Auto-tune worker concurrency based on available system resources.
-    
-    Returns:
-        Dict with optimal concurrency settings for each queue type
-    """
+    """Auto-tune worker concurrency based on system resources."""
     try:
         import psutil
         
-        # Get available memory in GB
-        available_memory_gb = psutil.virtual_memory().available / (1024 ** 3)
-        total_memory_gb = psutil.virtual_memory().total / (1024 ** 3)
-        cpu_count = os.cpu_count() or 4
+        available_gb = psutil.virtual_memory().available / (1024 ** 3)
+        total_gb = psutil.virtual_memory().total / (1024 ** 3)
+        cpus = os.cpu_count() or 4
+        usable_gb = available_gb * 0.7
         
-        # Estimate memory per agent run (LLM context, tool execution, etc.)
-        MEMORY_PER_AGENT_RUN_GB = 1.5  # Conservative estimate
-        MEMORY_PER_BACKGROUND_TASK_GB = 0.2  # Much lighter
+        # Calculate based on memory (agent runs ~1.5GB, background ~0.2GB each)
+        max_agent_runs = min(max(2, int(usable_gb / 1.5)), cpus * 4)
+        max_background = min(max(10, int(usable_gb / 0.2)), cpus * 10)
         
-        # Calculate max concurrent agent runs based on memory
-        # Use 70% of available memory to leave room for system
-        usable_memory_gb = available_memory_gb * 0.7
-        max_agent_runs = max(2, int(usable_memory_gb / MEMORY_PER_AGENT_RUN_GB))
-        
-        # Background tasks are lighter - can run more
-        max_background_tasks = max(10, int(usable_memory_gb / MEMORY_PER_BACKGROUND_TASK_GB))
-        
-        # Also consider CPU - don't exceed 4x CPU count for agent runs
-        max_agent_runs = min(max_agent_runs, cpu_count * 4)
-        max_background_tasks = min(max_background_tasks, cpu_count * 10)
-        
-        # Environment variable overrides
+        # Allow env overrides
         max_agent_runs = int(os.getenv("MAX_CONCURRENT_AGENT_RUNS", max_agent_runs))
-        max_background_tasks = int(os.getenv("MAX_CONCURRENT_BACKGROUND_TASKS", max_background_tasks))
+        max_background = int(os.getenv("MAX_CONCURRENT_BACKGROUND_TASKS", max_background))
         
-        logger.info(
-            f"🔧 Auto-tuned concurrency: "
-            f"memory={available_memory_gb:.1f}GB/{total_memory_gb:.1f}GB, "
-            f"cpus={cpu_count}, "
-            f"max_agent_runs={max_agent_runs}, "
-            f"max_background={max_background_tasks}"
-        )
+        logger.info(f"🔧 Concurrency: mem={available_gb:.1f}/{total_gb:.1f}GB, agent_runs={max_agent_runs}, background={max_background}")
         
         return {
-            "agent_runs": {
-                "max_concurrent_activities": max_agent_runs,
-                "max_concurrent_workflow_tasks": min(10, max_agent_runs),
-            },
-            "background": {
-                "max_concurrent_activities": max_background_tasks,
-                "max_concurrent_workflow_tasks": 20,
-            }
-        }
-        
-    except ImportError:
-        logger.warning("psutil not available, using default concurrency settings")
-        return {
-            "agent_runs": {
-                "max_concurrent_activities": 8,
-                "max_concurrent_workflow_tasks": 10,
-            },
-            "background": {
-                "max_concurrent_activities": 50,
-                "max_concurrent_workflow_tasks": 20,
-            }
+            "agent_runs": {"max_concurrent_activities": max_agent_runs, "max_concurrent_workflow_tasks": min(10, max_agent_runs)},
+            "background": {"max_concurrent_activities": max_background, "max_concurrent_workflow_tasks": 20},
         }
     except Exception as e:
-        logger.warning(f"Error calculating optimal concurrency: {e}, using defaults")
-        return {
-            "agent_runs": {
-                "max_concurrent_activities": 8,
-                "max_concurrent_workflow_tasks": 10,
-            },
-            "background": {
-                "max_concurrent_activities": 50,
-                "max_concurrent_workflow_tasks": 20,
-            }
-        }
+        logger.warning(f"Using default concurrency: {e}")
+        return DEFAULT_CONCURRENCY
 
 
 async def run_worker():
-    """
-    Run the Temporal worker with multi-queue support.
-    
-    This worker processes workflows and activities from Temporal Cloud
-    across two task queues with different priority/concurrency settings.
-    """
+    """Run the Temporal worker with multi-queue support."""
     logger.info("🚀 Starting Temporal worker...")
     
-    # Warm up tool cache before starting
+    # Warm caches
     warm_up_tools_cache()
-    logger.info("✅ Tool cache warmed")
-    
-    # Pre-cache Suna configs
     try:
         from core.runtime_cache import warm_up_suna_config_cache
         await warm_up_suna_config_cache()
-        logger.info("✅ Suna config cache warmed")
-    except Exception as e:
-        logger.warning(f"Failed to pre-cache Suna configs (non-fatal): {e}")
+    except Exception:
+        pass
     
-    # Get Temporal client
-    try:
-        client = await get_temporal_client()
-    except Exception as e:
-        logger.critical(f"❌ Failed to connect to Temporal Cloud: {e}")
-        raise
-    
-    # Get optimal concurrency settings
+    client = await get_temporal_client()
     concurrency = get_optimal_concurrency()
     
-    # Setup graceful shutdown
+    # Graceful shutdown
     shutdown_event = asyncio.Event()
     
-    def handle_shutdown(signum, frame):
-        sig_name = signal.Signals(signum).name if hasattr(signal, 'Signals') else str(signum)
-        logger.info(f"📴 Received {sig_name}, initiating graceful shutdown...")
+    def handle_shutdown(signum, _):
+        logger.info(f"📴 Shutdown signal received, draining tasks...")
         shutdown_event.set()
     
-    # Register signal handlers
     signal.signal(signal.SIGTERM, handle_shutdown)
     signal.signal(signal.SIGINT, handle_shutdown)
     
-    # All activities (used by both queues)
-    all_activities = [
-        run_agent_activity,
-        initialize_thread_activity,
-        extract_memories_activity,
-        embed_and_store_memories_activity,
-        consolidate_memories_activity,
-        find_stale_projects_activity,
+    # Shared activities and workflows for both queues
+    activities = [
+        run_agent_activity, initialize_thread_activity,
+        extract_memories_activity, embed_and_store_memories_activity,
+        consolidate_memories_activity, find_stale_projects_activity,
         categorize_project_activity,
     ]
-    
-    # All workflows
-    all_workflows = [
-        AgentRunWorkflow,
-        ThreadInitWorkflow,
-        MemoryExtractionWorkflow,
-        CategorizationWorkflow,
-        CategorizeProjectWorkflow,
+    workflows = [
+        AgentRunWorkflow, MemoryExtractionWorkflow,
+        CategorizationWorkflow, CategorizeProjectWorkflow,
     ]
     
-    # Create workers for each queue
-    # NOTE: All activities are async, so no activity_executor needed
-    # ThreadPoolExecutor is only required for synchronous (non-async) activities
+    # Create workers
+    workers = [
+        Worker(
+            client, task_queue=TASK_QUEUE_AGENT_RUNS,
+            workflows=workflows, activities=activities,
+            max_concurrent_activities=concurrency["agent_runs"]["max_concurrent_activities"],
+            max_concurrent_workflow_tasks=concurrency["agent_runs"]["max_concurrent_workflow_tasks"],
+        ),
+        Worker(
+            client, task_queue=TASK_QUEUE_BACKGROUND,
+            workflows=workflows, activities=activities,
+            max_concurrent_activities=concurrency["background"]["max_concurrent_activities"],
+            max_concurrent_workflow_tasks=concurrency["background"]["max_concurrent_workflow_tasks"],
+        ),
+    ]
     
-    agent_runs_worker = Worker(
-        client,
-        task_queue=TASK_QUEUE_AGENT_RUNS,
-        workflows=all_workflows,
-        activities=all_activities,
-        max_concurrent_activities=concurrency["agent_runs"]["max_concurrent_activities"],
-        max_concurrent_workflow_tasks=concurrency["agent_runs"]["max_concurrent_workflow_tasks"],
-        # No activity_executor - async activities run on event loop directly
-    )
+    logger.info(f"✅ Workers ready: {TASK_QUEUE_AGENT_RUNS}={concurrency['agent_runs']['max_concurrent_activities']}, {TASK_QUEUE_BACKGROUND}={concurrency['background']['max_concurrent_activities']}")
     
-    background_worker = Worker(
-        client,
-        task_queue=TASK_QUEUE_BACKGROUND,
-        workflows=all_workflows,
-        activities=all_activities,
-        max_concurrent_activities=concurrency["background"]["max_concurrent_activities"],
-        max_concurrent_workflow_tasks=concurrency["background"]["max_concurrent_workflow_tasks"],
-        # No activity_executor - async activities run on event loop directly
-    )
-    
-    logger.info(
-        f"✅ Temporal workers initialized:\n"
-        f"   - {TASK_QUEUE_AGENT_RUNS}: max_activities={concurrency['agent_runs']['max_concurrent_activities']}, "
-        f"max_workflows={concurrency['agent_runs']['max_concurrent_workflow_tasks']}\n"
-        f"   - {TASK_QUEUE_BACKGROUND}: max_activities={concurrency['background']['max_concurrent_activities']}, "
-        f"max_workflows={concurrency['background']['max_concurrent_workflow_tasks']}"
-    )
-    
-    async def run_with_shutdown(worker: Worker, queue_name: str):
-        """Run a worker until shutdown signal is received."""
-        try:
-            # Create a task for the worker
-            worker_task = asyncio.create_task(worker.run())
-            shutdown_task = asyncio.create_task(shutdown_event.wait())
-            
-            # Wait for either worker completion or shutdown
-            done, pending = await asyncio.wait(
-                [worker_task, shutdown_task],
-                return_when=asyncio.FIRST_COMPLETED
-            )
-            
-            if shutdown_task in done:
-                logger.info(f"🛑 Shutting down {queue_name} worker...")
-                # Cancel the worker task - this triggers graceful shutdown
-                worker_task.cancel()
-                try:
-                    await worker_task
-                except asyncio.CancelledError:
-                    pass
-            
-        except asyncio.CancelledError:
-            logger.info(f"🛑 {queue_name} worker cancelled")
-        except Exception as e:
-            logger.error(f"❌ {queue_name} worker error: {e}", exc_info=True)
-            raise
-    
-    # Run both workers concurrently
-    logger.info("🎯 Starting to poll for tasks on both queues...")
+    async def run_until_shutdown(worker: Worker):
+        """Run worker until shutdown signal."""
+        worker_task = asyncio.create_task(worker.run())
+        shutdown_task = asyncio.create_task(shutdown_event.wait())
+        
+        done, _ = await asyncio.wait([worker_task, shutdown_task], return_when=asyncio.FIRST_COMPLETED)
+        
+        if shutdown_task in done:
+            worker_task.cancel()
+            try:
+                await worker_task
+            except asyncio.CancelledError:
+                pass
     
     try:
-        await asyncio.gather(
-            run_with_shutdown(agent_runs_worker, TASK_QUEUE_AGENT_RUNS),
-            run_with_shutdown(background_worker, TASK_QUEUE_BACKGROUND),
-        )
-    except Exception as e:
-        logger.error(f"❌ Worker error: {e}", exc_info=True)
-        raise
+        await asyncio.gather(*[run_until_shutdown(w) for w in workers])
     finally:
-        logger.info("👋 Temporal worker shutdown complete")
+        logger.info("👋 Worker shutdown complete")
 
 
 if __name__ == "__main__":
     try:
         asyncio.run(run_worker())
     except KeyboardInterrupt:
-        logger.info("Worker shutdown requested via keyboard")
+        pass
     except Exception as e:
-        logger.critical(f"❌ Worker crashed: {e}", exc_info=True)
+        logger.critical(f"❌ Worker crashed: {e}")
         sys.exit(1)

--- a/backend/core/temporal/workflows.py
+++ b/backend/core/temporal/workflows.py
@@ -1,16 +1,11 @@
 """
-Temporal workflows - orchestrate activities and handle signals/queries.
+Temporal workflows - orchestrate activities.
 
-Workflows define the business logic and orchestration of activities. They support
-signals for external control (e.g., stop), queries for status, and child workflows
-for composition.
+Task queues:
+- "agent-runs": High-priority, long-running agent executions
+- "background": Memory extraction, categorization, etc.
 
-NOTE: Workflows run in a sandboxed environment. Use workflow.logger instead of
-importing logger modules directly.
-
-TASK QUEUE ARCHITECTURE:
-- "agent-runs": High-priority queue for long-running agent executions
-- "background": Lower-priority queue for memory extraction, categorization, etc.
+NOTE: Use workflow.logger, not imported logger (sandbox restriction).
 """
 import asyncio
 from datetime import timedelta
@@ -20,18 +15,26 @@ from temporalio import workflow
 from temporalio.common import RetryPolicy
 from temporalio.exceptions import ApplicationError
 
-# Do NOT import logger here - workflows run in sandbox
-# Use workflow.logger instead (provided by Temporal)
-
 # Task queue constants
 TASK_QUEUE_AGENT_RUNS = "agent-runs"
 TASK_QUEUE_BACKGROUND = "background"
 
-# Import activities - must use unsafe imports for workflow code
+# Shared retry policies
+RETRY_STANDARD = RetryPolicy(
+    initial_interval=timedelta(seconds=1),
+    maximum_interval=timedelta(seconds=30),
+    maximum_attempts=3,
+    backoff_coefficient=2.0,
+)
+RETRY_LIGHT = RetryPolicy(
+    initial_interval=timedelta(seconds=1),
+    maximum_interval=timedelta(seconds=10),
+    maximum_attempts=2,
+)
+
 with workflow.unsafe.imports_passed_through():
     from core.temporal.activities import (
         run_agent_activity,
-        initialize_thread_activity,
         extract_memories_activity,
         embed_and_store_memories_activity,
         consolidate_memories_activity,
@@ -42,16 +45,7 @@ with workflow.unsafe.imports_passed_through():
 
 @workflow.defn(name="AgentRunWorkflow")
 class AgentRunWorkflow:
-    """
-    Main workflow for executing an agent run.
-    
-    Supports:
-    - Stop signal for cancellation
-    - Status query for monitoring
-    - Long-running agent execution with heartbeating
-    
-    Runs on: agent-runs queue (high priority)
-    """
+    """Execute an agent run with stop signal support."""
     
     def __init__(self) -> None:
         self._status = "running"
@@ -71,295 +65,97 @@ class AgentRunWorkflow:
         account_id: Optional[str] = None,
         request_id: Optional[str] = None,
     ) -> Dict[str, Any]:
-        """
-        Execute the agent run workflow.
-        
-        Args:
-            agent_run_id: Unique ID for this agent run
-            thread_id: Thread ID for the conversation
-            instance_id: Worker instance ID
-            project_id: Project ID
-            model_name: Model to use
-            agent_id: Optional agent ID
-            account_id: Account ID
-            request_id: Optional request ID for tracing
-            
-        Returns:
-            Dict with status and results
-        """
-        workflow.logger.info(f"Starting AgentRunWorkflow for {agent_run_id}")
-        self._status = "running"
+        workflow.logger.info(f"AgentRunWorkflow starting: {agent_run_id}")
         
         try:
-            # Execute the agent run activity with long timeout and heartbeat
-            # Activities handle their own heartbeating, but we set generous timeouts
             result = await workflow.execute_activity(
                 run_agent_activity,
                 args=[agent_run_id, thread_id, instance_id, project_id, model_name, agent_id, account_id, request_id],
-                start_to_close_timeout=timedelta(hours=2),  # Long timeout for agent runs
-                heartbeat_timeout=timedelta(minutes=5),  # Heartbeat timeout
-                retry_policy=RetryPolicy(
-                    initial_interval=timedelta(seconds=1),
-                    maximum_interval=timedelta(seconds=30),
-                    maximum_attempts=3,
-                    backoff_coefficient=2.0,
-                ),
+                start_to_close_timeout=timedelta(hours=2),
+                heartbeat_timeout=timedelta(minutes=5),
+                retry_policy=RETRY_STANDARD,
             )
-            
             self._result = result
             self._status = result.get("status", "completed")
-            workflow.logger.info(f"AgentRunWorkflow completed for {agent_run_id} with status {self._status}")
             return result
             
         except asyncio.CancelledError:
-            workflow.logger.warning(f"AgentRunWorkflow cancelled for {agent_run_id}")
             self._status = "cancelled"
             raise
         except Exception as e:
-            error_msg = str(e)
-            workflow.logger.error(f"AgentRunWorkflow failed for {agent_run_id}: {error_msg}")
             self._status = "failed"
-            self._error = error_msg
-            raise ApplicationError(f"Agent run failed: {error_msg}", non_retryable=True)
+            self._error = str(e)
+            raise ApplicationError(f"Agent run failed: {e}", non_retryable=True)
     
     @workflow.signal
     async def stop(self, reason: Optional[str] = None) -> None:
-        """
-        Signal to stop the agent run.
-        
-        Args:
-            reason: Optional reason for stopping
-        """
-        workflow.logger.warning(f"Stop signal received for workflow (reason: {reason})")
+        workflow.logger.warning(f"Stop signal: {reason}")
         self._stop_requested = True
-        # The activity will check for cancellation via Temporal's cancellation mechanism
-        # We can't directly cancel the activity from here, but Temporal will propagate cancellation
     
     @workflow.query
     def get_status(self) -> Dict[str, Any]:
-        """
-        Query the current status of the workflow.
-        
-        Returns:
-            Dict with status, error, and result if available
-        """
-        return {
-            "status": self._status,
-            "error": self._error,
-            "result": self._result,
-            "stop_requested": self._stop_requested,
-        }
+        return {"status": self._status, "error": self._error, "stop_requested": self._stop_requested}
 
 
-@workflow.defn(name="ThreadInitWorkflow")
-class ThreadInitWorkflow:
-    """
-    Workflow for initializing a thread and then starting the agent run.
-    
-    OPTIMIZATION: Uses fire-and-forget pattern for child workflow.
-    Parent workflow completes immediately after starting child,
-    reducing resource usage for long-running agent runs.
-    
-    Runs on: agent-runs queue (high priority)
-    """
-    
-    @workflow.run
-    async def run(
-        self,
-        thread_id: str,
-        project_id: str,
-        account_id: str,
-        prompt: str,
-        agent_id: Optional[str] = None,
-        model_name: Optional[str] = None,
-    ) -> Dict[str, Any]:
-        """
-        Initialize thread and start agent run (fire-and-forget).
-        
-        Args:
-            thread_id: Thread ID
-            project_id: Project ID
-            account_id: Account ID
-            prompt: Initial prompt
-            agent_id: Optional agent ID
-            model_name: Optional model name
-            
-        Returns:
-            Dict with agent_run_id and status (returns immediately, doesn't wait for agent run)
-        """
-        workflow.logger.info(f"Starting ThreadInitWorkflow for thread {thread_id}")
-        
-        try:
-            # Execute thread initialization activity
-            init_result = await workflow.execute_activity(
-                initialize_thread_activity,
-                args=[thread_id, project_id, account_id, prompt, agent_id, model_name],
-                start_to_close_timeout=timedelta(minutes=5),
-                retry_policy=RetryPolicy(
-                    initial_interval=timedelta(seconds=1),
-                    maximum_interval=timedelta(seconds=30),
-                    maximum_attempts=3,
-                    backoff_coefficient=2.0,
-                ),
-            )
-            
-            agent_run_id = init_result["agent_run_id"]
-            effective_model = init_result["effective_model"]
-            
-            workflow.logger.info(f"Thread {thread_id} initialized, starting agent run: {agent_run_id}")
-            
-            # Start agent run as child workflow with FIRE-AND-FORGET pattern
-            # Use workflow.uuid4() for deterministic UUID generation in workflows
-            worker_instance_id = str(workflow.uuid4())[:8]
-            
-            # Start child workflow but DON'T await it
-            # Parent close policy ABANDON means child continues even if parent completes
-            await workflow.start_child_workflow(
-                AgentRunWorkflow.run,
-                args=[agent_run_id, thread_id, worker_instance_id, project_id, effective_model, agent_id, account_id, None],
-                id=f"agent-run-{agent_run_id}",
-                task_queue=TASK_QUEUE_AGENT_RUNS,
-                parent_close_policy=workflow.ParentClosePolicy.ABANDON,  # Child continues if parent closes
-            )
-            
-            workflow.logger.info(f"ThreadInitWorkflow completed for thread {thread_id}, agent_run_id: {agent_run_id} (fire-and-forget)")
-            
-            # Return immediately - don't wait for agent run to complete
-            return {
-                "thread_id": thread_id,
-                "agent_run_id": agent_run_id,
-                "status": "started",  # Changed from "completed" to "started"
-            }
-            
-        except Exception as e:
-            error_msg = str(e)
-            workflow.logger.error(f"ThreadInitWorkflow failed for thread {thread_id}: {error_msg}")
-            raise ApplicationError(f"Thread initialization failed: {error_msg}", non_retryable=True)
+# ThreadInitWorkflow removed - thread initialization is now done directly in the API
+# before starting AgentRunWorkflow. This simplifies the architecture significantly.
 
 
 @workflow.defn(name="MemoryExtractionWorkflow")
 class MemoryExtractionWorkflow:
-    """
-    Workflow for extracting and storing memories from a conversation.
-    
-    Orchestrates: extract → embed_and_store
-    
-    Runs on: background queue (lower priority)
-    """
+    """Extract and store memories from conversation."""
     
     @workflow.run
-    async def run(
-        self,
-        thread_id: str,
-        account_id: str,
-        message_ids: List[str],
-    ) -> Dict[str, Any]:
-        """
-        Extract and store memories from conversation.
-        
-        Args:
-            thread_id: Thread ID
-            account_id: Account ID
-            message_ids: List of message IDs to extract from
-            
-        Returns:
-            Dict with extraction and storage results
-        """
-        workflow.logger.info(f"Starting MemoryExtractionWorkflow for thread {thread_id}")
+    async def run(self, thread_id: str, account_id: str, message_ids: List[str]) -> Dict[str, Any]:
+        workflow.logger.info(f"MemoryExtractionWorkflow: {thread_id}")
         
         try:
-            # Step 1: Extract memories
-            extracted_memories = await workflow.execute_activity(
+            memories = await workflow.execute_activity(
                 extract_memories_activity,
                 args=[thread_id, account_id, message_ids],
                 start_to_close_timeout=timedelta(minutes=10),
-                retry_policy=RetryPolicy(
-                    initial_interval=timedelta(seconds=1),
-                    maximum_interval=timedelta(seconds=30),
-                    maximum_attempts=3,
-                ),
+                retry_policy=RETRY_STANDARD,
             )
             
-            if not extracted_memories:
-                workflow.logger.info(f"No memories extracted from thread {thread_id}")
+            if not memories:
                 return {"extracted_count": 0, "stored_count": 0}
             
-            # Step 2: Embed and store memories
-            storage_result = await workflow.execute_activity(
+            result = await workflow.execute_activity(
                 embed_and_store_memories_activity,
-                args=[account_id, thread_id, extracted_memories],
+                args=[account_id, thread_id, memories],
                 start_to_close_timeout=timedelta(minutes=10),
-                retry_policy=RetryPolicy(
-                    initial_interval=timedelta(seconds=1),
-                    maximum_interval=timedelta(seconds=30),
-                    maximum_attempts=3,
-                ),
+                retry_policy=RETRY_STANDARD,
             )
             
-            workflow.logger.info(
-                f"MemoryExtractionWorkflow completed for thread {thread_id}: "
-                f"extracted {len(extracted_memories)}, stored {storage_result.get('stored_count', 0)}"
-            )
-            
-            return {
-                "extracted_count": len(extracted_memories),
-                "stored_count": storage_result.get("stored_count", 0),
-            }
+            return {"extracted_count": len(memories), "stored_count": result.get("stored_count", 0)}
             
         except Exception as e:
-            error_msg = str(e)
-            workflow.logger.error(f"MemoryExtractionWorkflow failed for thread {thread_id}: {error_msg}")
-            raise ApplicationError(f"Memory extraction failed: {error_msg}", non_retryable=True)
+            raise ApplicationError(f"Memory extraction failed: {e}", non_retryable=True)
 
 
 @workflow.defn(name="CategorizationWorkflow")
 class CategorizationWorkflow:
-    """
-    Workflow for batch categorization of stale projects.
-    
-    Finds stale projects and categorizes them in parallel.
-    
-    Runs on: background queue (lower priority)
-    """
+    """Batch categorize stale projects."""
     
     @workflow.run
     async def run(self) -> Dict[str, Any]:
-        """
-        Find and categorize stale projects.
-        
-        Returns:
-            Dict with count of projects processed
-        """
-        workflow.logger.info("Starting CategorizationWorkflow")
+        workflow.logger.info("CategorizationWorkflow starting")
         
         try:
-            # Find stale projects via activity
             projects = await workflow.execute_activity(
                 find_stale_projects_activity,
                 start_to_close_timeout=timedelta(minutes=2),
-                retry_policy=RetryPolicy(
-                    initial_interval=timedelta(seconds=1),
-                    maximum_interval=timedelta(seconds=10),
-                    maximum_attempts=2,
-                ),
+                retry_policy=RETRY_LIGHT,
             )
             
             if not projects:
-                workflow.logger.debug("No stale projects to categorize")
                 return {"processed_count": 0}
             
-            workflow.logger.info(f"Found {len(projects)} stale projects")
-            
-            # Start child workflows for each project (with staggered delays)
-            DELAY_BETWEEN_PROJECTS_SECONDS = 2
-            child_handles = []
-            
+            # Start child workflows with stagger
+            handles = []
             for i, project in enumerate(projects):
-                # Stagger workflow starts to avoid rate limits
-                delay_seconds = i * DELAY_BETWEEN_PROJECTS_SECONDS
-                
-                if delay_seconds > 0:
-                    await asyncio.sleep(delay_seconds)
+                if i > 0:
+                    await asyncio.sleep(2)
                 
                 handle = await workflow.start_child_workflow(
                     CategorizeProjectWorkflow.run,
@@ -367,66 +163,35 @@ class CategorizationWorkflow:
                     id=f"categorize-{project['project_id']}",
                     task_queue=TASK_QUEUE_BACKGROUND,
                 )
-                child_handles.append(handle)
+                handles.append(handle)
             
-            # Wait for all children to complete
+            # Wait for all
             results = []
-            for handle in child_handles:
+            for handle in handles:
                 try:
-                    result = await handle
-                    results.append(result)
+                    results.append(await handle)
                 except Exception as e:
-                    workflow.logger.error(f"Child categorization workflow failed: {e}")
                     results.append({"error": str(e)})
             
-            processed_count = len([r for r in results if not r.get("error")])
-            
-            workflow.logger.info(f"CategorizationWorkflow completed: processed {processed_count}/{len(projects)} projects")
-            
-            return {"processed_count": processed_count, "total_count": len(projects)}
+            processed = len([r for r in results if not r.get("error")])
+            return {"processed_count": processed, "total_count": len(projects)}
             
         except Exception as e:
-            error_msg = str(e)
-            workflow.logger.error(f"CategorizationWorkflow failed: {error_msg}")
-            raise ApplicationError(f"Categorization failed: {error_msg}", non_retryable=True)
+            raise ApplicationError(f"Categorization failed: {e}", non_retryable=True)
 
 
 @workflow.defn(name="CategorizeProjectWorkflow")
 class CategorizeProjectWorkflow:
-    """
-    Workflow for categorizing a single project.
-    
-    Runs on: background queue (lower priority)
-    """
+    """Categorize a single project."""
     
     @workflow.run
     async def run(self, project_id: str) -> Dict[str, Any]:
-        """
-        Categorize a single project.
-        
-        Args:
-            project_id: Project ID to categorize
-            
-        Returns:
-            Dict with categories assigned
-        """
-        workflow.logger.info(f"Categorizing project {project_id}")
-        
         try:
-            result = await workflow.execute_activity(
+            return await workflow.execute_activity(
                 categorize_project_activity,
                 project_id,
                 start_to_close_timeout=timedelta(minutes=5),
-                retry_policy=RetryPolicy(
-                    initial_interval=timedelta(seconds=1),
-                    maximum_interval=timedelta(seconds=10),
-                    maximum_attempts=2,
-                ),
+                retry_policy=RETRY_LIGHT,
             )
-            
-            return result
-            
         except Exception as e:
-            error_msg = str(e)
-            workflow.logger.error(f"CategorizeProjectWorkflow failed for {project_id}: {error_msg}")
-            raise ApplicationError(f"Project categorization failed: {error_msg}", non_retryable=True)
+            raise ApplicationError(f"Project categorization failed: {e}", non_retryable=True)

--- a/backend/core/utils/run_management.py
+++ b/backend/core/utils/run_management.py
@@ -72,7 +72,7 @@ async def stop_agent_run_with_helpers(agent_run_id: str, error_message: Optional
         except Exception as redis_err:
             logger.error(f"Failed to set Redis stop signal fallback: {redis_err}")
 
-    # Comprehensive cleanup of all Redis keys for this agent run
+        # Comprehensive cleanup of all Redis keys for this agent run
     try:
         await cleanup_redis_keys_for_agent_run(agent_run_id)
     except Exception as e:

--- a/backend/sentry.py
+++ b/backend/sentry.py
@@ -3,14 +3,14 @@ import os
 
 sentry_dsn = os.getenv("SENTRY_DSN", None)
 if sentry_dsn:
-    sentry_sdk.init(
-        dsn=sentry_dsn,
+  sentry_sdk.init(
+      dsn=sentry_dsn,
         integrations=[],
-        traces_sample_rate=0.1,
-        send_default_pii=True,
-        _experiments={
-            "enable_logs": True,
-        },
-    )
+      traces_sample_rate=0.1,
+      send_default_pii=True,
+      _experiments={
+          "enable_logs": True,
+      },
+  )
 
 sentry = sentry_sdk


### PR DESCRIPTION
- Remove ThreadInitWorkflow, do direct DB init before starting AgentRunWorkflow
- Increase startup timeout from 20s to 60s for Temporal Cloud latency
- Unify new thread and existing thread code paths

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Streamlines Temporal and streaming flow and hardens startup behavior.
> 
> - **Remove `ThreadInitWorkflow`; direct init + run:** Thread initialization moved to API/service (`thread_init_service`) which creates DB records and pre-creates Redis stream, then starts `AgentRunWorkflow` directly; `workflows.py` and `worker.py` updated accordingly (shared retry policies, simplified worker setup/concurrency).
> - **SSE streaming robustness:** Backend immediately yields `{"type":"connected"}` and increases startup timeout to 60s; preserves catch-up logic and trims safely; richer logging and error propagation.
> - **Frontend stream simplification:** `streamAgent` now connects directly (no pre-status check), handles `connected`/`ping`/terminal `status` messages, and cleans up/marks non-running on completion or error.
> - **Activities cleanup:** `run_agent` heartbeat/cancellation loop simplified; memory extraction/embedding/consolidation made leaner; categorization flows use shared retry policies.
> - **Misc:** Worker concurrency auto-tune simplified; minor Sentry init formatting; small comment/cleanup tweaks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 193624a958523e08ca933a09f424aafc18f5f51d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->