### PR TITLE
filter category by tiers

### DIFF
--- a/backend/supabase/migrations/20260102223204_tier_distribution_analytics.sql
+++ b/backend/supabase/migrations/20260102223204_tier_distribution_analytics.sql
@@ -1,0 +1,114 @@
+-- Migration: Add tier distribution analytics functions
+-- Enables filtering threads by subscription tier in admin analytics
+
+-- 1. Function to get thread tier distribution for a date range
+-- Groups threads by the account's subscription tier
+CREATE OR REPLACE FUNCTION get_thread_tier_distribution(
+    start_date TIMESTAMPTZ,
+    end_date TIMESTAMPTZ
+)
+RETURNS TABLE(tier TEXT, count BIGINT) AS $$
+BEGIN
+    RETURN QUERY
+    SELECT 
+        COALESCE(ca.tier, 'none')::TEXT as tier,
+        COUNT(*)::BIGINT as count
+    FROM threads t
+    INNER JOIN credit_accounts ca ON t.account_id = ca.account_id
+    WHERE t.created_at >= start_date
+      AND t.created_at <= end_date
+    GROUP BY ca.tier
+    ORDER BY count DESC;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- 2. Function to get threads by tier with pagination
+CREATE OR REPLACE FUNCTION get_threads_by_tier(
+    p_tier TEXT,
+    p_date_from TIMESTAMPTZ DEFAULT NULL,
+    p_date_to TIMESTAMPTZ DEFAULT NULL,
+    p_min_messages INT DEFAULT NULL,
+    p_max_messages INT DEFAULT NULL,
+    p_sort_by TEXT DEFAULT 'created_at',
+    p_sort_order TEXT DEFAULT 'desc',
+    p_limit INT DEFAULT 15,
+    p_offset INT DEFAULT 0
+)
+RETURNS TABLE(
+    thread_id UUID,
+    project_id UUID,
+    account_id UUID,
+    is_public BOOLEAN,
+    created_at TIMESTAMPTZ,
+    updated_at TIMESTAMPTZ,
+    user_message_count INT,
+    total_message_count INT
+) AS $$
+BEGIN
+    RETURN QUERY
+    SELECT 
+        t.thread_id,
+        t.project_id,
+        t.account_id,
+        t.is_public,
+        t.created_at,
+        t.updated_at,
+        t.user_message_count,
+        t.total_message_count
+    FROM threads t
+    INNER JOIN credit_accounts ca ON t.account_id = ca.account_id
+    WHERE 
+        -- Handle tier filter (treat 'none' as NULL tier)
+        CASE 
+            WHEN p_tier = 'none' THEN (ca.tier IS NULL OR ca.tier = 'none')
+            ELSE ca.tier = p_tier
+        END
+        AND (p_date_from IS NULL OR t.created_at >= p_date_from)
+        AND (p_date_to IS NULL OR t.created_at <= p_date_to)
+        AND (p_min_messages IS NULL OR COALESCE(t.user_message_count, 0) >= p_min_messages)
+        AND (p_max_messages IS NULL OR COALESCE(t.user_message_count, 0) <= p_max_messages)
+    ORDER BY
+        CASE WHEN p_sort_by = 'created_at' AND p_sort_order = 'desc' THEN t.created_at END DESC,
+        CASE WHEN p_sort_by = 'created_at' AND p_sort_order = 'asc' THEN t.created_at END ASC,
+        CASE WHEN p_sort_by = 'updated_at' AND p_sort_order = 'desc' THEN t.updated_at END DESC,
+        CASE WHEN p_sort_by = 'updated_at' AND p_sort_order = 'asc' THEN t.updated_at END ASC
+    LIMIT p_limit
+    OFFSET p_offset;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- 3. Function to get count of threads by tier (for pagination)
+CREATE OR REPLACE FUNCTION get_threads_by_tier_count(
+    p_tier TEXT,
+    p_date_from TIMESTAMPTZ DEFAULT NULL,
+    p_date_to TIMESTAMPTZ DEFAULT NULL,
+    p_min_messages INT DEFAULT NULL,
+    p_max_messages INT DEFAULT NULL
+)
+RETURNS BIGINT AS $$
+DECLARE
+    total_count BIGINT;
+BEGIN
+    SELECT COUNT(*)
+    INTO total_count
+    FROM threads t
+    INNER JOIN credit_accounts ca ON t.account_id = ca.account_id
+    WHERE 
+        CASE 
+            WHEN p_tier = 'none' THEN (ca.tier IS NULL OR ca.tier = 'none')
+            ELSE ca.tier = p_tier
+        END
+        AND (p_date_from IS NULL OR t.created_at >= p_date_from)
+        AND (p_date_to IS NULL OR t.created_at <= p_date_to)
+        AND (p_min_messages IS NULL OR COALESCE(t.user_message_count, 0) >= p_min_messages)
+        AND (p_max_messages IS NULL OR COALESCE(t.user_message_count, 0) <= p_max_messages);
+    
+    RETURN total_count;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- Grant execute permissions
+GRANT EXECUTE ON FUNCTION get_thread_tier_distribution(TIMESTAMPTZ, TIMESTAMPTZ) TO service_role, authenticated;
+GRANT EXECUTE ON FUNCTION get_threads_by_tier(TEXT, TIMESTAMPTZ, TIMESTAMPTZ, INT, INT, TEXT, TEXT, INT, INT) TO service_role, authenticated;
+GRANT EXECUTE ON FUNCTION get_threads_by_tier_count(TEXT, TIMESTAMPTZ, TIMESTAMPTZ, INT, INT) TO service_role, authenticated;
+

--- a/backend/supabase/migrations/20260103052203_category_distribution_tier_filter.sql
+++ b/backend/supabase/migrations/20260103052203_category_distribution_tier_filter.sql
@@ -1,0 +1,39 @@
+-- Migration: Add tier filter to category distribution
+-- Allows filtering category distribution by subscription tier
+
+-- Update category distribution function to accept optional tier filter
+CREATE OR REPLACE FUNCTION get_project_category_distribution(
+    start_date TIMESTAMPTZ,
+    end_date TIMESTAMPTZ,
+    p_tier TEXT DEFAULT NULL
+)
+RETURNS TABLE(category TEXT, count BIGINT) AS $$
+BEGIN
+    RETURN QUERY
+    SELECT 
+        COALESCE(cat, 'Uncategorized')::TEXT as category,
+        COUNT(*)::BIGINT as count
+    FROM projects p
+    LEFT JOIN LATERAL unnest(CASE WHEN p.categories = '{}' OR p.categories IS NULL THEN ARRAY[NULL::TEXT] ELSE p.categories END) AS cat ON true
+    -- Join with credit_accounts if tier filter is provided
+    LEFT JOIN credit_accounts ca ON p.account_id = ca.account_id
+    WHERE p.created_at >= start_date
+      AND p.created_at <= end_date
+      -- Apply tier filter if provided
+      AND (
+          p_tier IS NULL 
+          OR (
+              CASE 
+                  WHEN p_tier = 'none' THEN (ca.tier IS NULL OR ca.tier = 'none')
+                  ELSE ca.tier = p_tier
+              END
+          )
+      )
+    GROUP BY cat
+    ORDER BY count DESC;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- Grant execute permissions (same signature, updated function)
+GRANT EXECUTE ON FUNCTION get_project_category_distribution(TIMESTAMPTZ, TIMESTAMPTZ, TEXT) TO service_role, authenticated;
+

--- a/backend/supabase/migrations/20260103061226_threads_combined_tier_category_filter.sql
+++ b/backend/supabase/migrations/20260103061226_threads_combined_tier_category_filter.sql
@@ -1,0 +1,117 @@
+-- Migration: Add combined tier + category filter support for threads
+-- Allows filtering threads by both tier AND category simultaneously
+
+-- Function to get threads filtered by both tier and category
+CREATE OR REPLACE FUNCTION get_threads_by_tier_and_category(
+    p_tier TEXT DEFAULT NULL,
+    p_category TEXT DEFAULT NULL,
+    p_date_from TIMESTAMPTZ DEFAULT NULL,
+    p_date_to TIMESTAMPTZ DEFAULT NULL,
+    p_min_messages INT DEFAULT NULL,
+    p_max_messages INT DEFAULT NULL,
+    p_sort_by TEXT DEFAULT 'created_at',
+    p_sort_order TEXT DEFAULT 'desc',
+    p_limit INT DEFAULT 15,
+    p_offset INT DEFAULT 0
+)
+RETURNS TABLE(
+    thread_id UUID,
+    project_id UUID,
+    account_id UUID,
+    is_public BOOLEAN,
+    created_at TIMESTAMPTZ,
+    updated_at TIMESTAMPTZ,
+    user_message_count INT,
+    total_message_count INT
+) AS $$
+BEGIN
+    RETURN QUERY
+    SELECT 
+        t.thread_id,
+        t.project_id,
+        t.account_id,
+        t.is_public,
+        t.created_at,
+        t.updated_at,
+        t.user_message_count,
+        t.total_message_count
+    FROM threads t
+    -- Join with credit_accounts for tier filter
+    LEFT JOIN credit_accounts ca ON t.account_id = ca.account_id
+    -- Join with projects for category filter
+    LEFT JOIN projects p ON t.project_id = p.project_id
+    WHERE 
+        -- Tier filter (if provided)
+        (p_tier IS NULL OR (
+            CASE 
+                WHEN p_tier = 'none' THEN (ca.tier IS NULL OR ca.tier = 'none')
+                ELSE ca.tier = p_tier
+            END
+        ))
+        -- Category filter (if provided)
+        AND (p_category IS NULL OR (
+            CASE 
+                WHEN p_category = 'Uncategorized' THEN (p.categories IS NULL OR p.categories = '{}')
+                ELSE p_category = ANY(p.categories)
+            END
+        ))
+        -- Date filters
+        AND (p_date_from IS NULL OR t.created_at >= p_date_from)
+        AND (p_date_to IS NULL OR t.created_at <= p_date_to)
+        -- Message count filters
+        AND (p_min_messages IS NULL OR COALESCE(t.user_message_count, 0) >= p_min_messages)
+        AND (p_max_messages IS NULL OR COALESCE(t.user_message_count, 0) <= p_max_messages)
+    ORDER BY
+        CASE WHEN p_sort_by = 'created_at' AND p_sort_order = 'desc' THEN t.created_at END DESC,
+        CASE WHEN p_sort_by = 'created_at' AND p_sort_order = 'asc' THEN t.created_at END ASC,
+        CASE WHEN p_sort_by = 'updated_at' AND p_sort_order = 'desc' THEN t.updated_at END DESC,
+        CASE WHEN p_sort_by = 'updated_at' AND p_sort_order = 'asc' THEN t.updated_at END ASC
+    LIMIT p_limit
+    OFFSET p_offset;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- Function to get count for combined tier + category filter (for pagination)
+CREATE OR REPLACE FUNCTION get_threads_by_tier_and_category_count(
+    p_tier TEXT DEFAULT NULL,
+    p_category TEXT DEFAULT NULL,
+    p_date_from TIMESTAMPTZ DEFAULT NULL,
+    p_date_to TIMESTAMPTZ DEFAULT NULL,
+    p_min_messages INT DEFAULT NULL,
+    p_max_messages INT DEFAULT NULL
+)
+RETURNS BIGINT AS $$
+DECLARE
+    total_count BIGINT;
+BEGIN
+    SELECT COUNT(*)
+    INTO total_count
+    FROM threads t
+    LEFT JOIN credit_accounts ca ON t.account_id = ca.account_id
+    LEFT JOIN projects p ON t.project_id = p.project_id
+    WHERE 
+        (p_tier IS NULL OR (
+            CASE 
+                WHEN p_tier = 'none' THEN (ca.tier IS NULL OR ca.tier = 'none')
+                ELSE ca.tier = p_tier
+            END
+        ))
+        AND (p_category IS NULL OR (
+            CASE 
+                WHEN p_category = 'Uncategorized' THEN (p.categories IS NULL OR p.categories = '{}')
+                ELSE p_category = ANY(p.categories)
+            END
+        ))
+        AND (p_date_from IS NULL OR t.created_at >= p_date_from)
+        AND (p_date_to IS NULL OR t.created_at <= p_date_to)
+        AND (p_min_messages IS NULL OR COALESCE(t.user_message_count, 0) >= p_min_messages)
+        AND (p_max_messages IS NULL OR COALESCE(t.user_message_count, 0) <= p_max_messages);
+    
+    RETURN total_count;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- Grant execute permissions
+GRANT EXECUTE ON FUNCTION get_threads_by_tier_and_category(TEXT, TEXT, TIMESTAMPTZ, TIMESTAMPTZ, INT, INT, TEXT, TEXT, INT, INT) TO service_role, authenticated;
+GRANT EXECUTE ON FUNCTION get_threads_by_tier_and_category_count(TEXT, TEXT, TIMESTAMPTZ, TIMESTAMPTZ, INT, INT) TO service_role, authenticated;
+


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces subscription tier awareness across admin analytics.
> 
> - Adds `tier` filter to `threads/browse` with default 7‑day range when any of `messages/category/tier` is set; new filtered path calls `get_threads_by_tier_and_category(_count)` RPCs
> - New endpoint `GET /threads/tier-distribution` and updated `GET /projects/category-distribution` to accept `tier` (with backend handling and totals logic)
> - Supabase: new analytics functions `get_thread_tier_distribution`, `get_threads_by_tier(_count)`, and combined `get_threads_by_tier_and_category(_count)`; updates `get_project_category_distribution` to support `p_tier`
> - Frontend: thread browser supports `tierFilter`; category distribution card gains tier dropdown fed by `useTierDistribution`; `useCategoryDistribution` accepts tier; queries plumb `tier` to API
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8236d750ca1c24bd4f50a11c27412ccdd2481277. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->