### PR TITLE
pool supabase connections

### DIFF
--- a/backend/core/services/supabase.py
+++ b/backend/core/services/supabase.py
@@ -1,44 +1,66 @@
-"""
-Centralized database connection management for AgentPress using Supabase.
-"""
-
 from typing import Optional
 from supabase import create_async_client, AsyncClient
 from core.utils.logger import logger
 from core.utils.config import config
 import base64
 import uuid
+import os
 from datetime import datetime
 import threading
+import httpx
+
+SUPABASE_MAX_CONNECTIONS = 500
+SUPABASE_MAX_KEEPALIVE = 100
+
+SUPABASE_CONNECT_TIMEOUT = 5.0
+SUPABASE_READ_TIMEOUT = 30.0
+SUPABASE_POOL_TIMEOUT = 10.0
+SUPABASE_WRITE_TIMEOUT = 30.0
+
 
 class DBConnection:
-    """Thread-safe singleton database connection manager using Supabase."""
-    
     _instance: Optional['DBConnection'] = None
     _lock = threading.Lock()
 
     def __new__(cls):
         if cls._instance is None:
             with cls._lock:
-                # Double-check locking pattern
                 if cls._instance is None:
                     cls._instance = super().__new__(cls)
                     cls._instance._initialized = False
                     cls._instance._client = None
+                    cls._instance._http_client = None
         return cls._instance
 
     def __init__(self):
-        """No initialization needed in __init__ as it's handled in __new__"""
         pass
 
+    def _create_http_client(self) -> httpx.AsyncClient:
+        limits = httpx.Limits(
+            max_connections=SUPABASE_MAX_CONNECTIONS,
+            max_keepalive_connections=SUPABASE_MAX_KEEPALIVE,
+            keepalive_expiry=30.0,
+        )
+        
+        timeout = httpx.Timeout(
+            connect=SUPABASE_CONNECT_TIMEOUT,
+            read=SUPABASE_READ_TIMEOUT,
+            write=SUPABASE_WRITE_TIMEOUT,
+            pool=SUPABASE_POOL_TIMEOUT,
+        )
+        
+        return httpx.AsyncClient(
+            limits=limits,
+            timeout=timeout,
+            http2=True,
+        )
+
     async def initialize(self):
-        """Initialize the database connection."""
         if self._initialized:
             return
                 
         try:
             supabase_url = config.SUPABASE_URL
-            # Use service role key preferentially for backend operations
             supabase_key = config.SUPABASE_SERVICE_ROLE_KEY or config.SUPABASE_ANON_KEY
             
             if not supabase_url or not supabase_key:
@@ -47,8 +69,10 @@ class DBConnection:
 
             from supabase.lib.client_options import AsyncClientOptions
             
+            self._http_client = self._create_http_client()
+            
             options = AsyncClientOptions(
-                postgrest_client_timeout=30,
+                postgrest_client_timeout=SUPABASE_READ_TIMEOUT,
             )
             
             self._client = await create_async_client(
@@ -57,9 +81,15 @@ class DBConnection:
                 options=options
             )
             
+            if hasattr(self._client, 'postgrest') and hasattr(self._client.postgrest, '_session'):
+                self._client.postgrest._session = self._http_client
+            
             self._initialized = True
             key_type = "SERVICE_ROLE_KEY" if config.SUPABASE_SERVICE_ROLE_KEY else "ANON_KEY"
-            logger.info(f"Database connection initialized with Supabase using {key_type}")
+            logger.info(
+                f"Database connection initialized with Supabase using {key_type} "
+                f"(max_conn={SUPABASE_MAX_CONNECTIONS}, connect_timeout={SUPABASE_CONNECT_TIMEOUT}s)"
+            )
             
         except Exception as e:
             logger.error(f"Database initialization error: {e}")
@@ -67,38 +97,37 @@ class DBConnection:
 
     @classmethod
     async def disconnect(cls):
-        """Disconnect from the database."""
-        if cls._instance and cls._instance._client:
-            # logger.debug("Disconnecting from Supabase database")
+        if cls._instance:
             try:
-                # Close Supabase client
-                if hasattr(cls._instance._client, 'close'):
+                if cls._instance._http_client:
+                    await cls._instance._http_client.aclose()
+                if cls._instance._client and hasattr(cls._instance._client, 'close'):
                     await cls._instance._client.close()
-                    
             except Exception as e:
                 logger.warning(f"Error during disconnect: {e}")
             finally:
                 cls._instance._initialized = False
                 cls._instance._client = None
+                cls._instance._http_client = None
                 logger.info("Database disconnected successfully")
 
     async def reset_connection(self):
-        """Reset the connection state, forcing reinitialization on next use."""
-        if self._client:
-            try:
-                if hasattr(self._client, 'close'):
-                    await self._client.close()
-            except Exception as e:
-                logger.warning(f"Error closing client during reset: {e}")
+        try:
+            if self._http_client:
+                await self._http_client.aclose()
+            if self._client and hasattr(self._client, 'close'):
+                await self._client.close()
+        except Exception as e:
+            logger.warning(f"Error closing client during reset: {e}")
+        
         self._initialized = False
         self._client = None
+        self._http_client = None
         logger.debug("Database connection reset")
 
     @property
     async def client(self) -> AsyncClient:
-        """Get the Supabase client instance."""
         if not self._initialized:
-            # logger.debug("Supabase client not initialized, initializing now")
             await self.initialize()
         if not self._client:
             logger.error("Database client is None after initialization")


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Supabase connection pooling and timeouts**
> - Create pooled `httpx.AsyncClient` with limits/timeouts and inject into Supabase PostgREST session; log config on init
> - Ensure proper cleanup on `disconnect`/`reset_connection` by closing both Supabase and HTTP clients
> 
> **Resilient DB retry utilities**
> - Add configurable defaults, jittered exponential backoff, and targeted resets on `PoolTimeout`/connection errors in `retry_db_operation`
> - Simplify callers by using new defaults; improve warnings/errors with clearer context
> 
> **Thread initialization flow**
> - Replace explicit retry params with `retry_db_operation` defaults; keep connection resets where needed
> - Increase retries for error-status update to 3
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d59768bb0b0c8787292d0bc30c0213fbfaf057c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->