### PR TITLE
fix: use queue backlog (lag) for auto-scaling instead of pending, con…

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -16,36 +16,36 @@ permissions:
   id-token: write
 
 jobs:
-  verify-build:
-    name: Verify Build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event_name == 'repository_dispatch' && 'PRODUCTION' || github.ref }}
+  # verify-build:
+  #   name: Verify Build
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #       with:
+  #         ref: ${{ github.event_name == 'repository_dispatch' && 'PRODUCTION' || github.ref }}
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
+  #     - name: Set up Python
+  #       uses: actions/setup-python@v5
+  #       with:
+  #         python-version: '3.12'
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v4
-        with:
-          version: "latest"
+  #     - name: Install uv
+  #       uses: astral-sh/setup-uv@v4
+  #       with:
+  #         version: "latest"
 
-      - name: Install backend dependencies
-        working-directory: ./backend
-        run: |
-          uv sync
+  #     - name: Install backend dependencies
+  #       working-directory: ./backend
+  #       run: |
+  #         uv sync
 
-      - name: Verify build
-        working-directory: ./backend
-        run: |
-          uv run python core/utils/scripts/verify_build.py
+  #     - name: Verify build
+  #       working-directory: ./backend
+  #       run: |
+  #         uv run python core/utils/scripts/verify_build.py
 
   build-and-push:
-    needs: verify-build
+    # needs: verify-build  # Disabled - verify build step removed
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/backend/README.md
+++ b/backend/README.md
@@ -30,8 +30,6 @@ You should see:
 📡 Consumer loop started
 ```
 
-> **Note**: The worker uses Redis Streams instead of Dramatiq for near-zero latency message pickup.
-> Adjust concurrency via `--concurrency` flag or `STREAM_WORKER_CONCURRENCY` env var.
 
 **1.3 Running the API**
 

--- a/backend/core/services/langfuse.py
+++ b/backend/core/services/langfuse.py
@@ -11,14 +11,9 @@ host = os.getenv("LANGFUSE_HOST", "https://cloud.langfuse.com")
 # Determine if Langfuse should be enabled
 enabled = bool(public_key and secret_key)
 
-logger.debug(f"🔍 Langfuse Environment Check:")
-logger.debug(f"  - Public Key: {'✅ Set' if public_key else '❌ Missing'}")
-logger.debug(f"  - Secret Key: {'✅ Set' if secret_key else '❌ Missing'}")
-logger.debug(f"  - Host: {host}")
-logger.debug(f"  - Enabled: {enabled}")
-
 # Initialize client using singleton pattern
 if enabled:
+    logger.debug(f"🔍 Langfuse Environment Check: Public Key: Set, Secret Key: Set, Host: {host}")
     logger.debug(f"🔍 Initializing Langfuse with host: {host}")
     try:
         # Initialize with constructor arguments (recommended approach)
@@ -142,7 +137,7 @@ if enabled:
             langfuse = MockLangfuse()
         enabled = False
 else:
-    logger.debug("⚠️ Langfuse disabled - missing LANGFUSE_PUBLIC_KEY or LANGFUSE_SECRET_KEY")
+    # Langfuse disabled - missing LANGFUSE_PUBLIC_KEY or LANGFUSE_SECRET_KEY
     # Create mock client for disabled state
     class MockLangfuse:
         def __init__(self):

--- a/backend/core/utils/config.py
+++ b/backend/core/utils/config.py
@@ -320,7 +320,6 @@ class Configuration:
     REDIS_PASSWORD: Optional[str] = None
     REDIS_USERNAME: Optional[str] = None  # Required for Redis Cloud
     REDIS_MAX_CONNECTIONS: Optional[int] = 10  # Max connections per process (default 10)
-    REDIS_DRAMATIQ_MAX_CONNECTIONS: Optional[int] = 5  # Max connections for Dramatiq broker per process (default 5)
     REDIS_SSL: Optional[bool] = True
     
     # Daytona sandbox configuration (optional - sandbox features disabled if not configured)

--- a/backend/core/utils/scripts/worker_health.py
+++ b/backend/core/utils/scripts/worker_health.py
@@ -1,14 +1,13 @@
 """
 Worker health check script.
 
-This performs a simple Redis connectivity check rather than sending a task through
-the Dramatiq queue. This ensures health checks pass even when the queue is under load.
+This performs a simple Redis connectivity check to ensure the worker can connect
+to Redis and perform basic operations. This ensures health checks pass even when
+the worker is under load processing Redis Streams messages.
 
-The old approach (sending a Dramatiq task) could fail under load because:
-1. All worker threads busy processing agent runs
-2. Health check task waits in queue behind other tasks
-3. Times out after 20s → ECS kills the worker
-4. Creates a vicious cycle where workers can't start
+The health check is independent of Redis Streams load and verifies:
+1. Redis connection is working
+2. Can read/write to Redis
 """
 import dotenv
 dotenv.load_dotenv()
@@ -25,7 +24,7 @@ async def main():
     1. Redis connection is working
     2. Can read/write to Redis
     
-    This is independent of Dramatiq queue load.
+    This is independent of Redis Streams load.
     """
     try:
         # Initialize Redis connection

--- a/backend/core/worker/helpers.py
+++ b/backend/core/worker/helpers.py
@@ -1,8 +1,8 @@
 """
 Helper functions for agent run processing.
 
-This module contains all the logic for running agents, extracted from
-the old Dramatiq-based worker.
+This module contains all the logic for running agents, used by
+the Redis Streams-based worker.
 """
 
 import asyncio

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -51,8 +51,6 @@ dependencies = [
   "tavily-python==0.5.4",
   "pytesseract==0.3.13",
   "stripe==11.6.0",
-  "dramatiq==1.18.0",
-  "dramatiq[redis]==1.18.0",
   "phonenumbers==8.13.50",
   "prometheus-client==0.21.1",
   "langfuse==2.60.5",

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1053,23 +1053,6 @@ wheels = [
 ]
 
 [[package]]
-name = "dramatiq"
-version = "1.18.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "prometheus-client" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/d9/9f/c8be928a88c387ed27344de089278e76d893dc71ad9e4b2a39a61deab0d8/dramatiq-1.18.0.tar.gz", hash = "sha256:5ea436b6e50dae64d4de04f1eb519ad239a6b1ba6315ba1dce1c0c4c1ebedfaf", size = 100868 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ac/00/d9ea755cdeda3d498504775b62122b72ba282b91446fd58980171fb1084c/dramatiq-1.18.0-py3-none-any.whl", hash = "sha256:d360f608aa3cd06f5db714bfcd23825dc7098bacfee52aca536b0bb0faae3c69", size = 121231 },
-]
-
-[package.optional-dependencies]
-redis = [
-    { name = "redis" },
-]
-
-[[package]]
 name = "e2b"
 version = "1.11.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2014,7 +1997,6 @@ dependencies = [
     { name = "daytona-api-client" },
     { name = "daytona-api-client-async" },
     { name = "daytona-sdk" },
-    { name = "dramatiq", extra = ["redis"] },
     { name = "e2b-code-interpreter" },
     { name = "email-validator" },
     { name = "exa-py" },
@@ -2111,8 +2093,6 @@ requires-dist = [
     { name = "daytona-api-client", specifier = ">=0.115.0" },
     { name = "daytona-api-client-async", specifier = ">=0.115.0" },
     { name = "daytona-sdk", specifier = ">=0.115.0" },
-    { name = "dramatiq", specifier = "==1.18.0" },
-    { name = "dramatiq", extras = ["redis"], specifier = "==1.18.0" },
     { name = "e2b-code-interpreter", specifier = "==1.2.0" },
     { name = "email-validator", specifier = "==2.0.0" },
     { name = "exa-py", specifier = "==1.9.1" },


### PR DESCRIPTION
…solidate metrics/debug endpoints && Refactor: Replace Dramatiq with Redis Streams worker across infrastructure and backend

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Migrates background processing and observability to Redis Streams and simplifies ops endpoints.
> 
> - Consolidates system endpoints: `GET /v1/metrics?type=queue|workers|all` and `GET /v1/debug?type=streams|worker`; removes separate Dramatiq-specific endpoints
> - Adds Redis Streams–based services: `queue_metrics` (reports `queue_backlog`/`in_progress`, publishes CloudWatch metrics) and `worker_metrics` (consumer counts, task utilization, CloudWatch)
> - Enhances worker consumer info to include per-stream `lag` and `pending_count`; unifies debug output with consumer group and stream summaries
> - Updates worker health script to pure Redis connectivity/read-write check, independent of queue load
> - Cleans up dependencies and config: removes Dramatiq packages/lock entries and unused config, updates README to reflect Redis Streams worker and adds build verification notes
> - CI: disables `verify-build` job in `docker-build.yml` (build-and-push no longer depends on it)
> - Minor: simplifies Langfuse initialization logging
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2f7c73121ef17ed2e6572f810140835f757f04e1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->