### PR TITLE
fix routeChange

### DIFF
--- a/apps/frontend/src/components/billing/pricing/plan-selection-modal.tsx
+++ b/apps/frontend/src/components/billing/pricing/plan-selection-modal.tsx
@@ -13,6 +13,7 @@ import { PricingSection } from './pricing-section';
 import { KortixLogo } from '@/components/sidebar/kortix-logo';
 import { cn } from '@/lib/utils';
 import { usePricingModalStore } from '@/stores/pricing-modal-store';
+import { trackRouteChangeForModal } from '@/lib/analytics/gtm';
 
 interface PlanSelectionModalProps {
     open?: boolean;
@@ -37,6 +38,13 @@ export function PlanSelectionModal({
     const onOpenChange = controlledOnOpenChange || ((open: boolean) => !open && closePricingModal());
     const returnUrl = controlledReturnUrl || storeReturnUrl || defaultReturnUrl;
     const displayReason = controlledUpgradeReason || storeCustomTitle;
+
+    // Track routeChange when Plans modal opens
+    React.useEffect(() => {
+        if (isOpen) {
+            trackRouteChangeForModal('plans');
+        }
+    }, [isOpen]);
 
     // Note: Checkout success detection is handled by dashboard-content.tsx
     // The modal just needs to close after subscription updates


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improves GA4/GTM SPA pageview tracking and introduces modal-based route tracking.
> 
> - Adds `TRACKED_PAGE_TYPES`, `shouldTrackRouteChange`, and expands `getPageContext` (plans, checkout) to standardize which pages fire `routeChange`
> - Updates `trackRouteChange` to: include contextual fields (`master_group`, `content_group`, `page_type`), treat dashboard with `subscription=activated` as `order_confirm`, avoid queries in `page_path`, and skip internal pages
> - Introduces `trackRouteChangeForModal(pageType)` and invokes it from `plan-selection-modal` to track Plans modal opens without URL changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b2177e9275a589a1be56a74c17ef630a1191c9a5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->