### PR TITLE
fix: circular imports in mcp adding

### DIFF
--- a/backend/core/agents/agent_tools.py
+++ b/backend/core/agents/agent_tools.py
@@ -200,7 +200,7 @@ async def update_custom_mcp_tools_for_agent(
         tools['custom_mcp'] = custom_mcps
         agent_config['tools'] = tools
         
-        from .versioning.version_service import get_version_service
+        from core.versioning.version_service import get_version_service
         try:
             version_service = await get_version_service() 
             new_version = await version_service.create_version(
@@ -322,7 +322,7 @@ async def update_agent_custom_mcps(
         tools['custom_mcp'] = existing_custom_mcps
         agent_config['tools'] = tools
         
-        from .versioning.version_service import get_version_service
+        from core.versioning.version_service import get_version_service
         import datetime
         
         try:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Resolves circular import issues in MCP tool update/versioning paths by standardizing imports.
> 
> - In `agent_tools.py`, replace relative `versioning.version_service` imports with absolute `core.versioning.version_service` for both custom MCP tools POST and PUT handlers
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7d7e92e06bd189fed0c1911d811b59c57a56cc56. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->