### PR TITLE
Tool call display refactor

### DIFF
--- a/apps/frontend/src/components/thread/content/ThreadContent.tsx
+++ b/apps/frontend/src/components/thread/content/ThreadContent.tsx
@@ -549,7 +549,7 @@ const AssistantGroupRow = memo(function AssistantGroupRow({
     // Filter out hidden tools (internal/initialization tools)
     const visibleToolCalls = toolCalls.filter((tc: any) => {
       const toolName = tc.function_name?.replace(/_/g, "-") || "";
-      return !isHiddenTool(toolName);
+      return !isHiddenTool(toolName, tc.arguments);
     });
 
     // If all tools were hidden, don't render anything

--- a/apps/frontend/src/components/thread/kortix-computer/KortixComputer.tsx
+++ b/apps/frontend/src/components/thread/kortix-computer/KortixComputer.tsx
@@ -249,7 +249,7 @@ export const KortixComputer = memo(function KortixComputer({
   const visibleToolCalls = useMemo(() => {
     return toolCalls.filter(tc => {
       const toolName = tc.toolCall?.function_name?.replace(/_/g, '-').toLowerCase() || '';
-      return !isHiddenTool(toolName);
+      return !isHiddenTool(toolName, tc.toolCall?.arguments);
     });
   }, [toolCalls]);
 

--- a/apps/frontend/src/components/thread/tool-views/types.ts
+++ b/apps/frontend/src/components/thread/tool-views/types.ts
@@ -9,6 +9,8 @@ export interface ToolCallData {
   arguments: Record<string, any>;
   /** Raw string arguments for streaming partial JSON parsing */
   rawArguments?: string;
+  /** Optional UI display hint injected by backend (e.g., "Presentation Mode activated") */
+  _display_hint?: string;
   source: 'native' | 'xml';
 }
 

--- a/apps/frontend/src/hooks/messages/utils/assistant-message-renderer.tsx
+++ b/apps/frontend/src/hooks/messages/utils/assistant-message-renderer.tsx
@@ -240,7 +240,7 @@ export function renderAssistantMessage(props: AssistantMessageRendererProps): Re
     const toolName = toolCall.function_name.replace(/_/g, '-');
     
     // Skip hidden tools (internal/initialization tools that don't provide meaningful user feedback)
-    if (isHiddenTool(toolName)) {
+    if (isHiddenTool(toolName, (toolCall as any).arguments)) {
       return;
     }
     

--- a/apps/mobile/components/chat/ThreadContent.tsx
+++ b/apps/mobile/components/chat/ThreadContent.tsx
@@ -1369,7 +1369,7 @@ export const ThreadContent: React.FC<ThreadContentProps> = React.memo(
                       // Filter out hidden tools (internal/initialization tools)
                       const visibleToolCalls = toolCalls.filter((tc: any) => {
                         const toolName = tc.function_name?.replace(/_/g, '-') || '';
-                        return !isHiddenTool(toolName);
+                        return !isHiddenTool(toolName, tc.arguments);
                       });
 
                       // If all tools were hidden, don't render anything

--- a/apps/mobile/components/chat/assistant-message-renderer.tsx
+++ b/apps/mobile/components/chat/assistant-message-renderer.tsx
@@ -292,7 +292,7 @@ export function renderAssistantMessage(props: AssistantMessageRendererProps): Re
     const toolName = toolCall.function_name?.replace(/_/g, '-') || '';
 
     // Skip hidden tools (internal/initialization tools that don't provide meaningful user feedback)
-    if (isHiddenTool(toolName)) {
+    if (isHiddenTool(toolName, (toolCall as any).arguments)) {
       return;
     }
 


### PR DESCRIPTION
Make `initialize_tools` visible and display "Presentation Mode activated" when it activates the presentation tool.

Previously, `initialize_tools` was always hidden in the UI. This change makes it visible specifically when it's used to activate the `sb_presentation_tool`, providing clearer feedback to the user that "Presentation Mode" has been enabled. The backend now injects a `_display_hint` for this specific case, which the frontend then uses to display the custom label.

---
[Slack Thread](https://kortixworkspace.slack.com/archives/C08QYH7MV6F/p1767598256305589?thread_ts=1767598256.305589&cid=C08QYH7MV6F)

<a href="https://cursor.com/background-agent?bcId=bc-9c8a971f-dbdc-45d3-a0de-51fd01f1218c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9c8a971f-dbdc-45d3-a0de-51fd01f1218c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

