### PR TITLE
add hard timeouts to kb and user context fetch

### DIFF
--- a/backend/core/agents/agent_json.py
+++ b/backend/core/agents/agent_json.py
@@ -308,7 +308,7 @@ class JsonImportService:
         try:
             logger.debug(f"Creating initial version for JSON imported agent {agent_id} with system_prompt: {system_prompt[:100]}...")
             
-            from .versioning.version_service import VersionService
+            from core.versioning.version_service import VersionService
             version_service = VersionService()
             
             version = await version_service.create_version(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improves prompt building resilience and fixes an import path.
> 
> - **Prompt timeouts:** Adds `_with_timeout` and wraps `KB` and `user context` fetches in `build_system_prompt` with 2s hard timeouts, logging on timeout/failure and returning `None` to avoid blocking
> - **Import fix:** Changes `VersionService` import in `agent_json.py` to `core.versioning.version_service`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8fd36e92dc72ae88fb36e24f0006f6ae649bbf24. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->