### PR TITLE
fixed redundancy in mcp loading

### DIFF
--- a/backend/core/versioning/version_service.py
+++ b/backend/core/versioning/version_service.py
@@ -9,7 +9,7 @@ from enum import Enum
 from core.services.supabase import DBConnection
 from core.utils.logger import logger
 
-MCP_CONFIG_QUERY_TIMEOUT = 10.0
+MCP_CONFIG_QUERY_TIMEOUT = 2.0
 
 
 class VersionStatus(Enum):


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refactors MCP prompt construction to avoid redundant config loads and tighten timeouts.
> 
> - Add `_fetch_mcp_config` and fetch once in `build_system_prompt` (wrapped with `_with_timeout`), then pass `fresh_mcp_config` to `_append_mcp_tools_info` and `_append_jit_mcp_info`
> - Update `_append_mcp_tools_info` and `_append_jit_mcp_info` to consume provided `fresh_mcp_config` (no internal version-service calls) and map `configured_mcps`/`custom_mcp` for prompt output
> - Reduce `MCP_CONFIG_QUERY_TIMEOUT` in `version_service.py` from `10.0` to `2.0`
> - Add/adjust timing logs around MCP stages for visibility
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8645ce602082cc91fa8b3f5bd5fa3f912dc5b260. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->