### PR TITLE
chore: disable memory

### DIFF
--- a/backend/core/services/supabase.py
+++ b/backend/core/services/supabase.py
@@ -29,20 +29,21 @@ import asyncio
 # =============================================================================
 
 # Connection limits (per worker process)
-# With 12 workers: 12 * 30 = 360 max connections (reduced to avoid overwhelming PostgREST)
-SUPABASE_MAX_CONNECTIONS = 30
-SUPABASE_MAX_KEEPALIVE = 20
-SUPABASE_KEEPALIVE_EXPIRY = 30.0  # 30s keepalive
+# With 12 workers x 60 = 720 max connections (well within 1500 limit for 2XL tier)
+# Worker concurrency is 48, so we need at least 48+ connections per worker
+SUPABASE_MAX_CONNECTIONS = 60
+SUPABASE_MAX_KEEPALIVE = 40
+SUPABASE_KEEPALIVE_EXPIRY = 60.0  # 60s keepalive
 
-# Timeout settings (in seconds) - aggressive to fail fast
-SUPABASE_CONNECT_TIMEOUT = 5.0   # TCP connect
-SUPABASE_READ_TIMEOUT = 10.0        # Response read
-SUPABASE_WRITE_TIMEOUT = 10.0      # Request write
-SUPABASE_POOL_TIMEOUT = 5.0         # Wait for pool slot
+# Timeout settings (in seconds) - increased for stability under load
+SUPABASE_CONNECT_TIMEOUT = 10.0   # TCP connect
+SUPABASE_READ_TIMEOUT = 60.0      # Response read - increased for complex queries
+SUPABASE_WRITE_TIMEOUT = 60.0     # Request write - increased for large payloads
+SUPABASE_POOL_TIMEOUT = 15.0      # Wait for pool slot - increased for high concurrency
 
 # HTTP transport settings
 SUPABASE_HTTP2_ENABLED = True
-SUPABASE_RETRIES = 1  # Single retry only
+SUPABASE_RETRIES = 3  # Increased retries for transient failures
 
 
 class DBConnection:

--- a/backend/core/utils/config.py
+++ b/backend/core/utils/config.py
@@ -280,6 +280,7 @@ class Configuration:
     ANTHROPIC_API_KEY: Optional[str] = None
     OPENAI_API_KEY: Optional[str] = None
     
+    ENABLE_MEMORY: bool = False
     MEMORY_EMBEDDING_PROVIDER: Optional[str] = "openai"
     MEMORY_EMBEDDING_MODEL: Optional[str] = "text-embedding-3-small"
     MEMORY_EXTRACTION_MODEL: Optional[str] = "kortix/basic"

--- a/backend/core/utils/retry.py
+++ b/backend/core/utils/retry.py
@@ -9,9 +9,9 @@ from core.services.supabase import DBConnection
 
 T = TypeVar("T")
 
-DB_DEFAULT_MAX_RETRIES = 4
+DB_DEFAULT_MAX_RETRIES = 6
 DB_RETRY_INITIAL_DELAY = 0.5
-DB_RETRY_MAX_DELAY = 3.0
+DB_RETRY_MAX_DELAY = 10.0
 DB_RETRY_JITTER_FACTOR = 0.3
 
 DB_RETRYABLE_EXCEPTIONS: Tuple[Type[Exception], ...] = (


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Strengthens database client resilience and throughput under load.
> 
> - In `core/services/supabase.py`, increases connection pool (`SUPABASE_MAX_CONNECTIONS=60`, keepalive=40, expiry=60s), lengthens timeouts, and raises HTTP transport retries to 3
> - Adds reconnection-aware logic: `is_*_error` helpers, `force_reconnect`, `reset_connection`, `get_client_with_retry`, and `execute_with_reconnect`
> - Introduces `core/utils/retry.py` with exponential backoff/jitter, higher defaults (`DB_DEFAULT_MAX_RETRIES=6`, `DB_RETRY_MAX_DELAY=10s`), and `retry_db_operation` that resets connections on transient errors
> - In `core/utils/config.py`, adds `ENABLE_MEMORY` flag (default `False`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d7b302445279f70c80d15bb3bf158fc89a2864a7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->