### PR TITLE
track coupon

### DIFF
--- a/apps/frontend/src/components/dashboard/dashboard-content.tsx
+++ b/apps/frontend/src/components/dashboard/dashboard-content.tsx
@@ -29,6 +29,7 @@ import { useWelcomeBannerStore } from '@/stores/welcome-banner-store';
 import { cn } from '@/lib/utils';
 import { DynamicGreeting } from '@/components/ui/dynamic-greeting';
 import { trackPurchase, getStoredCheckoutData, clearCheckoutData } from '@/lib/analytics/gtm';
+import { getCheckoutSession } from '@/lib/api/billing';
 
 // Lazy load heavy components that aren't immediately visible
 // Note: PlanSelectionModal is rendered globally in layout.tsx
@@ -218,21 +219,82 @@ export function DashboardContent() {
       celebrationTriggeredRef.current = true;
       
       // Track purchase event for GTM/GA4
-      // item_id, item_name match add_to_cart format
-      // value = actual transaction value (after discounts), price = product price
-      const checkoutData = getStoredCheckoutData();
-      if (checkoutData) {
+      // Fetch actual transaction amounts from Stripe for accurate tracking
+      const trackPurchaseEvent = async () => {
+        const checkoutData = getStoredCheckoutData();
+        if (!checkoutData) return;
+        
+        // Default values from stored checkout data
+        let transactionValue = checkoutData.value;
+        let discountAmount = checkoutData.discount || 0;
+        let taxAmount = 0;
+        let couponId = checkoutData.coupon || '';
+        let currency = checkoutData.currency;
+        
+        // If we have a session_id, fetch actual amounts from Stripe
+        // This also validates that the payment was actually successful
+        if (sessionId) {
+          try {
+            const stripeSession = await getCheckoutSession(sessionId);
+            if (stripeSession) {
+              // IMPORTANT: Only track purchase if payment was actually successful
+              // This prevents false positives from failed payments or manual URL navigation
+              if (stripeSession.payment_status !== 'paid' && stripeSession.status !== 'complete') {
+                console.warn('[GTM] Purchase NOT tracked - payment not confirmed:', {
+                  payment_status: stripeSession.payment_status,
+                  status: stripeSession.status
+                });
+                return; // Don't track purchase for failed/incomplete payments
+              }
+              
+              // Use actual amounts from Stripe (convert from cents to dollars)
+              transactionValue = stripeSession.amount_total / 100;
+              discountAmount = stripeSession.amount_discount / 100;
+              taxAmount = stripeSession.amount_tax / 100;
+              // Prefer promotion_code (customer-facing like "HEHE2020") over coupon_id
+              couponId = stripeSession.promotion_code || stripeSession.coupon_name || stripeSession.coupon_id || '';
+              currency = stripeSession.currency.toUpperCase();
+              console.log('[GTM] Using Stripe session data:', {
+                amount_total: stripeSession.amount_total,
+                amount_discount: stripeSession.amount_discount,
+                amount_tax: stripeSession.amount_tax,
+                promotion_code: stripeSession.promotion_code,
+                coupon_name: stripeSession.coupon_name,
+                coupon_id: stripeSession.coupon_id,
+                payment_status: stripeSession.payment_status
+              });
+            } else {
+              console.warn('[GTM] Stripe session returned null - purchase NOT tracked to avoid false positives');
+              return; // Don't track without verified session
+            }
+          } catch (error) {
+            console.warn('[GTM] Could not fetch Stripe session - purchase NOT tracked:', error);
+            return; // Don't track without verified session
+          }
+        } else {
+          console.warn('[GTM] No session_id available - purchase NOT tracked to avoid false positives');
+          return; // Don't track without session_id
+        }
+        
+        // Determine customer_type based on previous tier
+        // 'new' = first time subscriber (was free/none)
+        // 'returning' = upgrading/changing from a paid plan
+        const previousTier = checkoutData.previous_tier || 'none';
+        const isReturningCustomer = previousTier !== 'none' && previousTier !== 'free';
+        const customerType = isReturningCustomer ? 'returning' : 'new';
+        
         trackPurchase({
           transaction_id: sessionId || `txn_${Date.now()}`,
-          value: checkoutData.value, // Actual transaction value after discounts
-          currency: checkoutData.currency,
-          coupon: checkoutData.coupon,
-          customer_type: 'new', // Could be enhanced to detect returning customers
+          value: transactionValue, // Actual transaction value after discounts (from Stripe)
+          tax: taxAmount, // Tax amount from Stripe
+          currency: currency,
+          coupon: couponId,
+          customer_type: customerType,
           items: [{
             item_id: checkoutData.item_id,       // e.g., "pro_yearly" - matches add_to_cart
             item_name: checkoutData.item_name,   // e.g., "Pro Yearly" - matches add_to_cart
-            coupon: checkoutData.coupon,
-            discount: checkoutData.discount,
+            coupon: couponId,
+            discount: discountAmount,
             item_brand: 'Kortix AI',
             item_category: 'Plans',
             item_list_id: 'plans_listing',
@@ -246,7 +308,10 @@ export function DashboardContent() {
           },
         });
         clearCheckoutData();
-      }
+      };
+      
+      // Execute purchase tracking
+      trackPurchaseEvent();
       
       // Invalidate and force refetch billing queries to refresh data immediately
       // This ensures fresh data after checkout, bypassing staleTime
@@ -269,7 +334,7 @@ export function DashboardContent() {
         router.replace(url.pathname + url.search, { scroll: false });
       }, 100);
     }
-  }, [searchParams, queryClient, router, setSidebarOpen]);
+  }, [searchParams, queryClient, router, setSidebarOpen, user]);
 
   // Handle expired link notification for logged-in users
   React.useEffect(() => {

--- a/apps/frontend/src/lib/analytics/gtm.ts
+++ b/apps/frontend/src/lib/analytics/gtm.ts
@@ -537,6 +537,7 @@ export function trackPurchase(data: PurchaseData) {
  * 
  * price = full product price (before discounts)
  * value = actual transaction value (after discounts/coupons)
+ * previous_tier = user's tier before checkout (to determine customer_type)
  */
 export function storeCheckoutData(data: {
   item_id: string;       // e.g., "pro_yearly" - matches add_to_cart format
@@ -547,6 +548,7 @@ export function storeCheckoutData(data: {
   billing_period: string;
   coupon?: string;
   discount?: number;
+  previous_tier?: string; // User's tier before checkout (e.g., "free", "tier_2_20")
 }) {
   if (typeof window === 'undefined') return;
   sessionStorage.setItem('gtm_checkout_data', JSON.stringify({
@@ -567,6 +569,7 @@ export function getStoredCheckoutData(): {
   billing_period: string;
   coupon?: string;
   discount?: number;
+  previous_tier?: string;
   timestamp: number;
 } | null {
   if (typeof window === 'undefined') return null;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improves post-checkout analytics accuracy and reliability by verifying payment and using actual Stripe amounts.
> 
> - Adds `GET /billing/checkout-session/{session_id}` to return `amount_total/subtotal`, `amount_discount`, `amount_tax`, `currency`, `coupon_id/name`, `promotion_code`, `status`, and `payment_status`
> - Frontend retrieves session via `getCheckoutSession(session_id)` on dashboard load, only tracks purchase if `payment_status==='paid'` or `status==='complete'`, and uses Stripe-derived totals/tax/discount/coupon
> - Updates checkout `success_url` to include `session_id={CHECKOUT_SESSION_ID}` so it can be read after redirect
> - Extends GTM helpers to store/read `previous_tier` and classifies `customer_type` (new vs returning) based on it
> - Exposes `getCheckoutSession` in billing API and updates analytics to include coupon/discount/tax in purchase events
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 68a0d3895b9c4de533c981eb7b56f3a0b8b0a2be. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->