### PR TITLE
pass single istance of db down the thread manager

### DIFF
--- a/backend/core/agentpress/context_manager.py
+++ b/backend/core/agentpress/context_manager.py
@@ -51,13 +51,14 @@ def _get_bedrock_client_singleton():
 class ContextManager:
     """Manages thread context including token counting and summarization."""
     
-    def __init__(self, token_threshold: int = DEFAULT_TOKEN_THRESHOLD):
+    def __init__(self, token_threshold: int = DEFAULT_TOKEN_THRESHOLD, db=None):
         """Initialize the ContextManager.
         
         Args:
             token_threshold: Token count threshold to trigger summarization
+            db: Optional DBConnection instance to reuse (avoids creating new ones)
         """
-        self.db = DBConnection()
+        self.db = db if db is not None else DBConnection()
         self.token_threshold = token_threshold
         # Tool output management
         self.keep_recent_tool_outputs = 5  # Number of recent tool outputs to preserve

--- a/backend/core/agentpress/response_processor.py
+++ b/backend/core/agentpress/response_processor.py
@@ -1314,9 +1314,7 @@ class ResponseProcessor:
                     # Store placeholder message_id for cleanup if update fails
                     placeholder_message_id = last_assistant_message_object['message_id']
                     # Update the existing placeholder message with final content and metadata
-                    from core.services.supabase import DBConnection
-                    db = DBConnection()
-                    client = await db.client
+                    client = await self.thread_manager.db.client
                     try:
                         await client.table('messages').update({
                             'content': message_data,
@@ -1874,7 +1872,7 @@ class ResponseProcessor:
                     else:
                         logger.warning("💰 No LLM response with usage - ESTIMATING token usage for billing")
                         from core.agentpress.context_manager import ContextManager
-                        context_mgr = ContextManager()
+                        context_mgr = ContextManager(db=self.thread_manager.db if self.thread_manager else None)
                         estimated_usage = await context_mgr.estimate_token_usage(prompt_messages, accumulated_content, llm_model)
                         llm_end_content = {
                             "model": llm_model,
@@ -1958,9 +1956,7 @@ class ResponseProcessor:
                             # Update in database (protected by lock to prevent race conditions)
                             thread_lock = await self._get_thread_lock(thread_id)
                             async with thread_lock:
-                                from core.services.supabase import DBConnection
-                                db = DBConnection()
-                                client = await db.client
+                                client = await self.thread_manager.db.client
                                 await client.table('messages').update({
                                     'content': updated_content
                                 }).eq('message_id', last_assistant_message_object['message_id']).execute()

--- a/backend/core/run/tool_manager.py
+++ b/backend/core/run/tool_manager.py
@@ -198,9 +198,6 @@ class ToolManager:
             
     def _register_agent_builder_tools(self, agent_id: str, disabled_tools: List[str]):
         from core.tools.tool_registry import AGENT_BUILDER_TOOLS, get_tool_class
-        from core.services.supabase import DBConnection
-        
-        db = DBConnection()
 
         for tool_name, module_path, class_name in AGENT_BUILDER_TOOLS:
             if tool_name == 'agent_creation_tool':
@@ -219,7 +216,7 @@ class ToolManager:
                         tool_class, 
                         function_names=enabled_methods, 
                         thread_manager=self.thread_manager, 
-                        db_connection=db, 
+                        db_connection=self.thread_manager.db, 
                         agent_id=agent_id
                     )
                 except Exception as e:
@@ -228,9 +225,6 @@ class ToolManager:
     def _register_suna_specific_tools(self, disabled_tools: List[str]):
         if 'agent_creation_tool' not in disabled_tools and self.account_id:
             from core.tools.tool_registry import get_tool_info, get_tool_class
-            from core.services.supabase import DBConnection
-            
-            db = DBConnection()
             
             try:
                 tool_info = get_tool_info('agent_creation_tool')
@@ -245,7 +239,7 @@ class ToolManager:
                     AgentCreationTool, 
                     function_names=enabled_methods, 
                     thread_manager=self.thread_manager, 
-                    db_connection=db, 
+                    db_connection=self.thread_manager.db, 
                     account_id=self.account_id
                 )
             except (ImportError, AttributeError) as e:
@@ -333,15 +327,13 @@ class ToolManager:
         """Register Suna-specific tools like agent_creation_tool."""
         if 'agent_creation_tool' not in disabled_tools:
             from core.tools.agent_creation_tool import AgentCreationTool
-            from core.services.supabase import DBConnection
-            
-            db = DBConnection()
             
             if account_id:
                 enabled_methods = self._get_enabled_methods_for_tool('agent_creation_tool')
                 if enabled_methods is not None:
-                    self.thread_manager.add_tool(AgentCreationTool, function_names=enabled_methods, thread_manager=self.thread_manager, db_connection=db, account_id=account_id)
+                    self.thread_manager.add_tool(AgentCreationTool, function_names=enabled_methods, thread_manager=self.thread_manager, db_connection=self.thread_manager.db, account_id=account_id)
                 else:
-                    self.thread_manager.add_tool(AgentCreationTool, thread_manager=self.thread_manager, db_connection=db, account_id=account_id)
+                    self.thread_manager.add_tool(AgentCreationTool, thread_manager=self.thread_manager, db_connection=self.thread_manager.db, account_id=account_id)
             else:
                 logger.warning("Could not register agent_creation_tool: account_id not available")
+                

--- a/backend/core/tools/apify_tool.py
+++ b/backend/core/tools/apify_tool.py
@@ -195,7 +195,7 @@ class ApifyTool(SandboxToolsBase):
     def __init__(self, project_id: str, thread_manager: Optional[ThreadManager] = None):
         super().__init__(project_id, thread_manager)
         self.credit_manager = CreditManager()
-        self.db = DBConnection()
+        self.db = thread_manager.db if thread_manager else DBConnection()
         
         if config.APIFY_API_TOKEN:
             # Initialize Apify client with token

--- a/backend/core/tools/company_search_tool.py
+++ b/backend/core/tools/company_search_tool.py
@@ -61,7 +61,7 @@ class CompanySearchTool(Tool):
         super().__init__()
         self.thread_manager = thread_manager
         self.api_key = config.EXA_API_KEY
-        self.db = DBConnection()
+        self.db = thread_manager.db if thread_manager else DBConnection()
         self.credit_manager = CreditManager()
         self.exa_client = None
         

--- a/backend/core/tools/people_search_tool.py
+++ b/backend/core/tools/people_search_tool.py
@@ -59,10 +59,9 @@ from core.services.supabase import DBConnection
 )
 class PeopleSearchTool(Tool):
     def __init__(self, thread_manager: ThreadManager):
-        super().__init__()
         self.thread_manager = thread_manager
         self.api_key = config.EXA_API_KEY
-        self.db = DBConnection()
+        self.db = thread_manager.db if thread_manager else DBConnection()
         self.credit_manager = CreditManager()
         self.exa_client = None
         

--- a/backend/core/tools/sb_kb_tool.py
+++ b/backend/core/tools/sb_kb_tool.py
@@ -323,11 +323,8 @@ class SandboxKbTool(SandboxToolsBase):
             if not agent_id:
                 return self.fail_response("No agent ID found for knowledge base sync")
             
-            from core.services.supabase import DBConnection
-            db = DBConnection()
-            
             # Get agent's knowledge base entries
-            client = await db.client
+            client = await self.thread_manager.db.client
             
             result = await client.from_("agent_knowledge_entry_assignments").select("""
                 entry_id,
@@ -466,10 +463,8 @@ Agent ID: {agent_id}
             if not agent_id:
                 return self.fail_response("No agent ID found for knowledge base operations")
             
-            from core.services.supabase import DBConnection
             from core.knowledge_base.validation import validate_folder_name_unique
-            db = DBConnection()
-            client = await db.client
+            client = await self.thread_manager.db.client
             
             # Get agent's account ID
             agent_result = await client.table('agents').select('account_id').eq('agent_id', agent_id).execute()
@@ -559,8 +554,7 @@ Agent ID: {agent_id}
             import os
             import mimetypes
             
-            db = DBConnection()
-            client = await db.client
+            client = await self.thread_manager.db.client
             
             # Get agent's account ID
             agent_result = await client.table('agents').select('account_id').eq('agent_id', agent_id).execute()
@@ -680,9 +674,7 @@ Agent ID: {agent_id}
             if not agent_id:
                 return self.fail_response("No agent ID found for knowledge base operations")
             
-            from core.services.supabase import DBConnection
-            db = DBConnection()
-            client = await db.client
+            client = await self.thread_manager.db.client
             
             # Get agent's account ID
             agent_result = await client.table('agents').select('account_id').eq('agent_id', agent_id).execute()
@@ -769,9 +761,7 @@ Agent ID: {agent_id}
             if item_type != "file":
                 return self.fail_response("Only 'file' type is supported for enable/disable operations")
             
-            from core.services.supabase import DBConnection
-            db = DBConnection()
-            client = await db.client
+            client = await self.thread_manager.db.client
             
             # Get agent's account ID
             agent_result = await client.table('agents').select('account_id').eq('agent_id', agent_id).execute()
@@ -842,9 +832,7 @@ Agent ID: {agent_id}
             if not agent_id:
                 return self.fail_response("No agent ID found for knowledge base operations")
             
-            from core.services.supabase import DBConnection
-            db = DBConnection()
-            client = await db.client
+            client = await self.thread_manager.db.client
             
             # Get agent's account ID
             agent_result = await client.table('agents').select('account_id').eq('agent_id', agent_id).execute()

--- a/backend/core/tools/sb_vision_tool.py
+++ b/backend/core/tools/sb_vision_tool.py
@@ -92,7 +92,7 @@ class SandboxVisionTool(SandboxToolsBase):
         self.thread_id = thread_id
         # Make thread_manager accessible within the tool instance
         self.thread_manager = thread_manager
-        self.db = DBConnection()
+        self.db = thread_manager.db if thread_manager else DBConnection()
 
     async def convert_svg_with_sandbox_browser(self, svg_full_path: str) -> Tuple[bytes, str]:
         """Convert SVG to PNG using sandbox browser API for better rendering support.

--- a/backend/core/tools/vapi_voice_tool.py
+++ b/backend/core/tools/vapi_voice_tool.py
@@ -345,9 +345,7 @@ class VapiVoiceTool(Tool):
 
             if not user_id and thread_id:
                 try:
-                    from core.services.supabase import DBConnection
-                    db = DBConnection()
-                    client = await db.client
+                    client = await self.thread_manager.db.client
                     thread = await client.from_('threads').select('account_id').eq('thread_id', thread_id).single().execute()
                     if thread.data:
                         user_id = thread.data.get('account_id')
@@ -450,9 +448,7 @@ class VapiVoiceTool(Tool):
                 response.raise_for_status()
                 call_data = response.json()
             
-            from core.services.supabase import DBConnection
-            db = DBConnection()
-            client = await db.client
+            client = await self.thread_manager.db.client
             
             call_id = call_data.get("id")
             
@@ -573,9 +569,7 @@ class VapiVoiceTool(Tool):
                 
                 response.raise_for_status()
             
-            from core.services.supabase import DBConnection
-            db = DBConnection()
-            client = await db.client
+            client = await self.thread_manager.db.client
             
             await client.table("vapi_calls").update({
                 "status": "ended",
@@ -681,9 +675,7 @@ class VapiVoiceTool(Tool):
             return self.fail_response("VAPI_PRIVATE_KEY not configured")
         
         try:
-            from core.services.supabase import DBConnection
-            db = DBConnection()
-            client = await db.client
+            client = await self.thread_manager.db.client
             
             thread_id, user_id, agent_id = await self._get_current_thread_and_user()
             
@@ -820,9 +812,7 @@ The voice call has ended. You can continue with any follow-up actions."""
         try:
             thread_id, user_id, agent_id = await self._get_current_thread_and_user()
             
-            from core.services.supabase import DBConnection
-            db = DBConnection()
-            client = await db.client
+            client = await self.thread_manager.db.client
             
             query = client.table("vapi_calls").select("*").order("created_at", desc=True).limit(limit)
             

--- a/backend/supabase/migrations/20260106000000_optimize_slow_queries.sql
+++ b/backend/supabase/migrations/20260106000000_optimize_slow_queries.sql
@@ -1,0 +1,30 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_agent_runs_status_started_at 
+ON agent_runs(status, started_at DESC) 
+WHERE status = 'running';
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_agent_runs_thread_status 
+ON agent_runs(thread_id, status, started_at DESC);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_threads_account_id 
+ON threads(account_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_accounts_primary_owner_personal 
+ON basejump.accounts(primary_owner_user_id, personal_account) 
+WHERE personal_account = true;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_messages_thread_type_created 
+ON messages(thread_id, type, created_at DESC);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_messages_thread_is_llm_created 
+ON messages(thread_id, is_llm_message, created_at ASC);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_messages_thread_created 
+ON messages(thread_id, created_at ASC);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_threads_project_updated_created 
+ON threads(project_id, updated_at DESC, created_at DESC);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_projects_categorized_at 
+ON projects(last_categorized_at) 
+WHERE last_categorized_at IS NOT NULL;
+


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improves DB efficiency and prompt-caching performance by reusing a single DB client and tightening query paths.
> 
> - **DB reuse:** `ContextManager` now accepts `db` and is injected from `ThreadManager`; `response_processor` and many tools (`ApifyTool`, `CompanySearchTool`, `PeopleSearchTool`, `SandboxVisionTool`, `sb_kb_tool`, `vapi_voice_tool`, MCP executor) switch to `thread_manager.db` instead of creating new `DBConnection`s
> - **Prompt caching:** `get_stored_threshold`/`store_threshold` accept optional `client`; `apply_anthropic_caching_strategy` receives/persists via shared client
> - **ThreadManager performance:** adds timeouts (`asyncio.wait_for`) and slow-query logging for acquiring client and common queries; passes shared client into caching; uses shared `ContextManager` for compression/validation
> - **DB migrations:** adds targeted indexes to speed frequent reads on `agent_runs`, `threads`, `messages`, `projects`, and `basejump.accounts`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ba0ce4bf498ec8fdfff46ef4616439aae73e2351. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->