### PR TITLE
fix race condition

### DIFF
--- a/backend/core/services/supabase.py
+++ b/backend/core/services/supabase.py
@@ -12,20 +12,10 @@ import time
 import asyncio
 
 # =============================================================================
-# Connection Pool Configuration
+# Connection Pool Configuration for High Traffic
 # =============================================================================
-# Tuned for Supabase 2XL tier:
-#   - Max client connections: 1500
-#   - Pool size: 250 (per user+db combination)
-#
-# With 12 workers x 48 concurrency = 576 max concurrent operations
-# We allocate ~120 connections per worker (12 * 120 = 1440, within 1500 limit)
-#
-# Key considerations:
-# - Each worker has its own connection pool (singleton per process)
-# - HTTP/2 multiplexes many requests over fewer TCP connections
-# - Pool timeout should be generous to avoid failures during traffic spikes
-# - Keepalive prevents connection churn under sustained load
+# Tuned for Supabase with high concurrency workloads.
+# Each service (PostgREST, Storage) gets its own client to avoid base_url conflicts.
 # =============================================================================
 
 # Connection limits (per worker process)
@@ -43,7 +33,7 @@ SUPABASE_POOL_TIMEOUT = 15.0      # Wait for pool slot - increased for high conc
 
 # HTTP transport settings
 SUPABASE_HTTP2_ENABLED = True
-SUPABASE_RETRIES = 3  # Increased retries for transient failures
+SUPABASE_RETRIES = 3  # Retries for transient connection failures
 
 
 class DBConnection:
@@ -58,7 +48,6 @@ class DBConnection:
                     cls._instance = super().__new__(cls)
                     cls._instance._initialized = False
                     cls._instance._client = None
-                    cls._instance._http_client = None
                     cls._instance._last_reset_time = 0
                     cls._instance._consecutive_errors = 0
         return cls._instance
@@ -104,42 +93,49 @@ class DBConnection:
         await self.initialize()
         logger.info("✅ Supabase connection re-established")
 
-    def _create_http_client(self) -> httpx.AsyncClient:
-        """
-        Create an HTTP client with optimized settings for high-concurrency workloads.
-        
-        Features:
-        - Connection pooling with keepalive
-        - Transport-level retries for transient failures
-        - HTTP/2 multiplexing (configurable)
-        - Generous timeouts for stability under load
-        """
+    def _create_optimized_transport(self) -> httpx.AsyncHTTPTransport:
+        """Create an optimized HTTP transport for high-traffic workloads."""
         limits = httpx.Limits(
             max_connections=SUPABASE_MAX_CONNECTIONS,
             max_keepalive_connections=SUPABASE_MAX_KEEPALIVE,
             keepalive_expiry=SUPABASE_KEEPALIVE_EXPIRY,
         )
+        return httpx.AsyncHTTPTransport(
+            http2=SUPABASE_HTTP2_ENABLED,
+            limits=limits,
+            retries=SUPABASE_RETRIES,
+        )
+
+    def _configure_service_clients(self):
+        """
+        Configure each service's httpx client with optimized connection pool settings.
         
-        timeout = httpx.Timeout(
+        This is called AFTER the SDK creates separate clients for each service,
+        so we can optimize without causing the shared client base_url bug.
+        """
+        optimized_timeout = httpx.Timeout(
             connect=SUPABASE_CONNECT_TIMEOUT,
             read=SUPABASE_READ_TIMEOUT,
             write=SUPABASE_WRITE_TIMEOUT,
             pool=SUPABASE_POOL_TIMEOUT,
         )
         
-        # Create transport with retries for connection-level failures
-        # This handles TCP connect failures, TLS handshake failures, etc.
-        # IMPORTANT: limits must be passed to transport, not client (when using custom transport)
-        transport = httpx.AsyncHTTPTransport(
-            retries=SUPABASE_RETRIES,
-            http2=SUPABASE_HTTP2_ENABLED,
-            limits=limits,  # Connection pool limits go on transport, not client!
-        )
-        
-        return httpx.AsyncClient(
-            timeout=timeout,
-            transport=transport,
-        )
+        # Configure PostgREST client
+        if self._client:
+            pg = self._client.postgrest
+            pg.session.timeout = optimized_timeout
+            # Replace transport with optimized one (old transport has 0 connections at this point)
+            old_pg_transport = pg.session._transport
+            pg.session._transport = self._create_optimized_transport()
+            # Close old transport to prevent any potential resource leak
+            asyncio.create_task(old_pg_transport.aclose())
+            
+            # Configure Storage client  
+            storage = self._client.storage
+            storage._client.timeout = optimized_timeout
+            old_storage_transport = storage._client._transport
+            storage._client._transport = self._create_optimized_transport()
+            asyncio.create_task(old_storage_transport.aclose())
 
     async def initialize(self):
         if self._initialized:
@@ -155,13 +151,16 @@ class DBConnection:
 
             from supabase.lib.client_options import AsyncClientOptions
             
-            # Create our custom HTTP client with optimized settings
-            self._http_client = self._create_http_client()
-            
-            # Pass the custom httpx client directly to the Supabase SDK
-            # This ensures ALL Supabase operations use our pooled/optimized client
+            # NOTE: We intentionally do NOT pass a shared httpx_client here.
+            # The Supabase SDK has a bug where postgrest and storage3 both mutate
+            # the shared client's base_url, causing a race condition:
+            # - PostgREST sets base_url to /rest/v1
+            # - Storage sets base_url to /storage/v1
+            # - Whichever runs last "wins", corrupting requests for the other service
+            # This caused production errors like "Route POST:/projects not found" 
+            # when REST requests were incorrectly routed to the Storage service.
+            # Let each service create its own httpx client with correct base_url.
             options = AsyncClientOptions(
-                httpx_client=self._http_client,  # <-- KEY FIX: Use our custom client
                 postgrest_client_timeout=SUPABASE_READ_TIMEOUT,
                 storage_client_timeout=SUPABASE_READ_TIMEOUT,
                 function_client_timeout=SUPABASE_READ_TIMEOUT,
@@ -172,6 +171,11 @@ class DBConnection:
                 supabase_key,
                 options=options
             )
+            
+            # Configure each service's httpx client with optimized connection pool settings.
+            # We do this AFTER creation to avoid the shared client bug while still getting
+            # optimal connection pooling for high traffic.
+            self._configure_service_clients()
             
             self._initialized = True
             key_type = "SERVICE_ROLE_KEY" if config.SUPABASE_SERVICE_ROLE_KEY else "ANON_KEY"
@@ -190,8 +194,6 @@ class DBConnection:
     async def disconnect(cls):
         if cls._instance:
             try:
-                if cls._instance._http_client:
-                    await cls._instance._http_client.aclose()
                 if cls._instance._client and hasattr(cls._instance._client, 'close'):
                     await cls._instance._client.close()
             except Exception as e:
@@ -199,13 +201,10 @@ class DBConnection:
             finally:
                 cls._instance._initialized = False
                 cls._instance._client = None
-                cls._instance._http_client = None
                 logger.info("Database disconnected successfully")
 
     async def reset_connection(self):
         try:
-            if self._http_client:
-                await self._http_client.aclose()
             if self._client and hasattr(self._client, 'close'):
                 await self._client.close()
         except Exception as e:
@@ -213,7 +212,6 @@ class DBConnection:
         
         self._initialized = False
         self._client = None
-        self._http_client = None
         logger.debug("Database connection reset")
 
     @property


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Addresses high-traffic stability and a client routing race in `backend/core/services/supabase.py`.
> 
> - Avoids passing a shared `httpx_client` to the SDK to prevent base_url mutation between PostgREST and Storage; lets SDK create per-service clients, then applies optimized timeouts and a new `_create_optimized_transport()` via `_configure_service_clients()`
> - Cleans up lifecycle by removing `_http_client`, updating `disconnect`/`reset_connection`, and closing old transports after swap
> - Adds resilience with `get_client_with_retry()` and `execute_with_reconnect()` to auto-reconnect on recoverable route-not-found/client-closed errors
> - Keeps tuned pool/timeouts/retries and improves initialization logs for visibility
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 68f54f513891396cba744bf8ea333b703432ea99. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->