### PR TITLE
enhance has_image

### DIFF
--- a/backend/core/agentpress/response_processor.py
+++ b/backend/core/agentpress/response_processor.py
@@ -3320,6 +3320,10 @@ class ResponseProcessor:
                 logger.warning("_image_context_data missing message_content, skipping")
                 return
             
+            # Set has_images flag on thread metadata
+            from core.agentpress.thread_manager import set_thread_has_images
+            await set_thread_has_images(thread_id)
+            
             # Save the image_context message AFTER the tool result
             await self.add_message(
                 thread_id=thread_id,

--- a/backend/core/agents/runs.py
+++ b/backend/core/agents/runs.py
@@ -825,6 +825,10 @@ async def start_agent_run(
     # Insert image context messages in background (don't block)
     if image_contexts_to_inject:
         async def insert_image_contexts():
+            # Set has_images flag on thread metadata (once, before inserting messages)
+            from core.agentpress.thread_manager import set_thread_has_images
+            await set_thread_has_images(thread_id, client)
+            
             for img_info in image_contexts_to_inject:
                 try:
                     await client.table('messages').insert({


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a fast, cached indicator for image presence in threads and updates all image handling to maintain it.
> 
> - New `set_thread_has_images(thread_id)` writes `metadata.has_images=True` to `threads` and caches `thread_has_images:{thread_id}` in Redis (2h TTL)
> - `ThreadManager.thread_has_images` now checks Redis first, then `threads.metadata.has_images` (single-row query), replacing the prior `messages` scan
> - `response_processor._save_deferred_image_context` calls `set_thread_has_images` before saving `image_context`
> - `agents/runs.py` sets the flag once before bulk inserting `image_context` messages
> - Improved logging and timeouts around cache/DB paths
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb2e71226e5911914d07fd6402a6a9e24f0b485e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->