### PR TITLE
enable reasoning

### DIFF
--- a/backend/core/services/llm.py
+++ b/backend/core/services/llm.py
@@ -321,7 +321,7 @@ async def make_llm_api_call(
     # Handle MiniMax models (both direct API and OpenRouter)
     is_minimax = "minimax" in actual_model_id.lower()
     if is_minimax:
-        params["reasoning"] = {"enabled": False}
+        params["reasoning"] = {"enabled": True}
         params["reasoning_split"] = True
         
         # Add fallback to glm-4.6v if minimax doesn't support image input


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Enable reasoning for MiniMax models**
> 
> - For `minimax` models in `make_llm_api_call`, sets `reasoning: { enabled: true }` and keeps `reasoning_split: true` to return separated reasoning output
> - Maintains existing fallback to `openrouter/z-ai/glm-4.6v` when image input is detected
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c3cd2396beaa1228c18c891040e00b1eca678374. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->