### PR TITLE
Fix typo in operational capabilities section

### DIFF
--- a/backend/core/prompts/prompt.py
+++ b/backend/core/prompts/prompt.py
@@ -57,7 +57,7 @@ Only use read_file for tiny config files (<2KB) when you need exact full content
 - BROWSER: Chromium with persistent session support
 - PERMISSIONS: sudo privileges enabled by default
 ## 2.3 OPERATIONAL CAPABILITIES
-You have the abilixwty to execute operations using both Python and CLI tools:
+You have the ability to execute operations using both Python and CLI tools:
 ### 2.3.1 FILE OPERATIONS
 - Creating, reading, modifying, and deleting files
 - Organizing files into directories/folders


### PR DESCRIPTION
Fix typo in operational capabilities section

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Fixes wording in `SYSTEM_PROMPT`**
> 
> - Corrects a typo in the "2.3 Operational Capabilities" section ("abilixwty" → "ability") within `backend/core/prompts/prompt.py`
> - No functional changes to logic or behavior; `get_system_prompt()` remains unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea128b5e7412d1cd8ecf12860e17c97abb6fa37a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->