### PR TITLE
use anthropic temp

### DIFF
--- a/backend/core/ai_models/registry.py
+++ b/backend/core/ai_models/registry.py
@@ -59,9 +59,9 @@ class ModelRegistry:
         self._litellm_id_to_pricing["minimax/minimax-m2.1"] = minimax_m2_pricing
         self._litellm_id_to_pricing["openrouter/minimax/minimax-m2.1"] = minimax_m2_pricing
         
-        # Kortix Basic - using MiniMax M2.1
-        # basic_litellm_id = build_bedrock_profile_arn(HAIKU_4_5_PROFILE_ID) if SHOULD_USE_BEDROCK else "anthropic/claude-haiku-4-5-20251001"
-        basic_litellm_id = "openrouter/minimax/minimax-m2.1"  # 204,800 context $0.30/M input tokens $1.20/M output tokens
+        # Kortix Basic - using Anthropic Claude Haiku 4.5
+        # MiniMax M2.1: basic_litellm_id = "openrouter/minimax/minimax-m2.1"  # 204,800 context $0.30/M input tokens $1.20/M output tokens
+        basic_litellm_id = build_bedrock_profile_arn(HAIKU_4_5_PROFILE_ID) if SHOULD_USE_BEDROCK else "anthropic/claude-haiku-4-5-20251001"
         
         self.register(Model(
             id="kortix/basic",
@@ -71,7 +71,8 @@ class ModelRegistry:
             vision_litellm_model_id=HAIKU_BEDROCK_ARN,
             vision_context_window=200_000,
             vision_pricing=HAIKU_PRICING,
-            provider=ModelProvider.OPENROUTER,
+            # MiniMax: provider=ModelProvider.OPENROUTER,
+            provider=ModelProvider.ANTHROPIC,
             aliases=["kortix-basic", "Kortix Basic"],
             context_window=200_000,
             capabilities=[
@@ -80,33 +81,35 @@ class ModelRegistry:
                 ModelCapability.VISION,
                 ModelCapability.PROMPT_CACHING,
             ],
+            # MiniMax pricing:
+            # pricing=ModelPricing(
+            #     input_cost_per_million_tokens=0.30,
+            #     output_cost_per_million_tokens=1.20,
+            #     cached_read_cost_per_million_tokens=0.03,
+            #     cache_write_5m_cost_per_million_tokens=0.375,
+            # ),
             pricing=ModelPricing(
-                input_cost_per_million_tokens=0.30,
-                output_cost_per_million_tokens=1.20,
-                cached_read_cost_per_million_tokens=0.03,
-                cache_write_5m_cost_per_million_tokens=0.375,
-                # OLD Haiku 4.5 pricing:
-                # input_cost_per_million_tokens=1.00,
-                # output_cost_per_million_tokens=5.00,
-                # cached_read_cost_per_million_tokens=0.10,
-                # cache_write_5m_cost_per_million_tokens=1.25,
-                # cache_write_1h_cost_per_million_tokens=2.00
+                input_cost_per_million_tokens=1.00,
+                output_cost_per_million_tokens=5.00,
+                cached_read_cost_per_million_tokens=0.10,
+                cache_write_5m_cost_per_million_tokens=1.25,
+                cache_write_1h_cost_per_million_tokens=2.00
             ),
             tier_availability=["free", "paid"],
             priority=102,
             recommended=True,
             enabled=True,
+            # MiniMax: config=ModelConfig()
             config=ModelConfig(
-                # OLD Anthropic config:
-                # extra_headers={
-                #     "anthropic-beta": "fine-grained-tool-streaming-2025-05-14,token-efficient-tools-2025-02-19" 
-                # },
+                extra_headers={
+                    "anthropic-beta": "fine-grained-tool-streaming-2025-05-14,token-efficient-tools-2025-02-19" 
+                },
             )
         ))
         
-        # Kortix Power - using MiniMax M2.1
-        # power_litellm_id = build_bedrock_profile_arn(HAIKU_4_5_PROFILE_ID) if SHOULD_USE_BEDROCK else "anthropic/claude-haiku-4-5-20251001"
-        power_litellm_id = "openrouter/minimax/minimax-m2.1"  # 204,800 context $0.30/M input tokens $1.20/M output tokens
+        # Kortix Power - using Anthropic Claude Haiku 4.5
+        # MiniMax M2.1: power_litellm_id = "openrouter/minimax/minimax-m2.1"  # 204,800 context $0.30/M input tokens $1.20/M output tokens
+        power_litellm_id = build_bedrock_profile_arn(HAIKU_4_5_PROFILE_ID) if SHOULD_USE_BEDROCK else "anthropic/claude-haiku-4-5-20251001"
         
         self.register(Model(
             id="kortix/power",
@@ -116,9 +119,18 @@ class ModelRegistry:
             vision_litellm_model_id=HAIKU_BEDROCK_ARN,
             vision_context_window=200_000,
             vision_pricing=HAIKU_PRICING,
-            provider=ModelProvider.OPENROUTER,
+            # MiniMax: provider=ModelProvider.OPENROUTER,
+            provider=ModelProvider.ANTHROPIC,
             aliases=["kortix-power", "Kortix POWER Mode", "Kortix Power", "Kortix Advanced Mode"],
             context_window=200_000,
+            # MiniMax capabilities (includes THINKING):
+            # capabilities=[
+            #     ModelCapability.CHAT,
+            #     ModelCapability.FUNCTION_CALLING,
+            #     ModelCapability.VISION,
+            #     ModelCapability.THINKING,
+            #     ModelCapability.PROMPT_CACHING,
+            # ],
             capabilities=[
                 ModelCapability.CHAT,
                 ModelCapability.FUNCTION_CALLING,
@@ -126,27 +138,29 @@ class ModelRegistry:
                 ModelCapability.THINKING,
                 ModelCapability.PROMPT_CACHING,
             ],
+            # MiniMax pricing:
+            # pricing=ModelPricing(
+            #     input_cost_per_million_tokens=0.30,
+            #     output_cost_per_million_tokens=1.20,
+            #     cached_read_cost_per_million_tokens=0.03,
+            #     cache_write_5m_cost_per_million_tokens=0.375,
+            # ),
             pricing=ModelPricing(
-                input_cost_per_million_tokens=0.30,
-                output_cost_per_million_tokens=1.20,
-                cached_read_cost_per_million_tokens=0.03,
-                cache_write_5m_cost_per_million_tokens=0.375,
-                # OLD Haiku 4.5 pricing:
-                # input_cost_per_million_tokens=1.00,
-                # output_cost_per_million_tokens=5.00,
-                # cached_read_cost_per_million_tokens=0.10,
-                # cache_write_5m_cost_per_million_tokens=1.25,
-                # cache_write_1h_cost_per_million_tokens=2.00
+                input_cost_per_million_tokens=1.00,
+                output_cost_per_million_tokens=5.00,
+                cached_read_cost_per_million_tokens=0.10,
+                cache_write_5m_cost_per_million_tokens=1.25,
+                cache_write_1h_cost_per_million_tokens=2.00
             ),
             tier_availability=["paid"],
             priority=101,
             recommended=True,
             enabled=True,
+            # MiniMax: config=ModelConfig()
             config=ModelConfig(
-                # OLD Anthropic config:
-                # extra_headers={
-                #     "anthropic-beta": "context-1m-2025-08-07,fine-grained-tool-streaming-2025-05-14,token-efficient-tools-2025-02-19" 
-                # },
+                extra_headers={
+                    "anthropic-beta": "context-1m-2025-08-07,fine-grained-tool-streaming-2025-05-14,token-efficient-tools-2025-02-19" 
+                },
             )
         ))
         


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Migrates primary Kortix models to Anthropic Haiku 4.5 with correct billing and config.
> 
> - `kortix/basic` and `kortix/power` now use `anthropic/claude-haiku-4-5-20251001` (or Bedrock profile via `build_bedrock_profile_arn`), provider set to `ANTHROPIC`
> - Pricing updated to Haiku 4.5 rates; vision remains on Haiku Bedrock ARN with `HAIKU_PRICING`
> - Adds `ModelConfig.extra_headers` with `anthropic-beta` flags for both models
> - Keeps MiniMax M2.1 pricing map for billing resolution but no longer used for basic/power
> - Non-prod `kortix/test` model switched to `openai/gpt-5-mini-2025-08-07`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 37d9e52590b61ee6111e9831e4fcaecdaa8b7348. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->