### PR TITLE
Website footer discord link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Build, manage, and train sophisticated AI agents for any use case. Create powerful agents that act autonomously on your behalf.
 
-[![Discord Follow](https://dcbadge.limes.pink/api/server/Py6pCBUUPw?style=flat)](https://discord.gg/RvFhXUdZ9H)
+[![Discord Follow](https://dcbadge.limes.pink/api/server/RvFhXUdZ9H?style=flat)](https://discord.com/invite/RvFhXUdZ9H)
 [![Twitter Follow](https://img.shields.io/twitter/follow/kortix)](https://x.com/korti)
 [![GitHub Repo stars](https://img.shields.io/github/stars/kortix-ai/suna)](https://github.com/kortix-ai/suna)
 [![Issues](https://img.shields.io/github/issues/kortix-ai/suna)](https://github.com/kortix-ai/suna/labels/bug)
@@ -177,6 +177,6 @@ Just use "setup.py". Ty mate.
 
 **Ready to build your first AI agent?** 
 
-[Get Started](./docs/SELF-HOSTING.md) • [Join Discord](https://discord.gg/RvFhXUdZ9H) • [Follow on Twitter](https://x.com/kortix)
+[Get Started](./docs/SELF-HOSTING.md) • [Join Discord](https://discord.com/invite/RvFhXUdZ9H) • [Follow on Twitter](https://x.com/kortix)
 
 </div>

--- a/apps/frontend/src/app/help/credits/page.tsx
+++ b/apps/frontend/src/app/help/credits/page.tsx
@@ -323,7 +323,7 @@ export default function CreditsPage() {
             <Button
               variant="outline"
               className="gap-2"
-              onClick={() => window.open('https://discord.gg/kortix', '_blank')}
+              onClick={() => window.open('https://discord.com/invite/RvFhXUdZ9H', '_blank')}
             >
               <MessageCircle className="h-4 w-4" />
               Join Discord

--- a/apps/frontend/src/components/help/help-sidebar.tsx
+++ b/apps/frontend/src/components/help/help-sidebar.tsx
@@ -46,7 +46,7 @@ const helpData = {
         },
         {
           title: "Discord Community",
-          url: "https://discord.gg/Py6pCBUUPw",
+          url: "https://discord.com/invite/RvFhXUdZ9H",
           external: true,
         },
       ],

--- a/apps/frontend/src/components/home/simple-footer.tsx
+++ b/apps/frontend/src/components/home/simple-footer.tsx
@@ -44,7 +44,7 @@ export function SimpleFooter() {
                 </span>
               </a>
               <a
-                href="https://discord.gg/Py6pCBUUPw"
+                href="https://discord.com/invite/RvFhXUdZ9H"
                 target="_blank"
                 rel="noopener noreferrer"
                 aria-label="Discord"

--- a/apps/frontend/src/lib/site-config.ts
+++ b/apps/frontend/src/lib/site-config.ts
@@ -31,7 +31,7 @@ export const siteConfig = {
       title: 'Resources',
       links: [
         { id: 5, title: 'Documentation', url: 'https://github.com/kortix-ai/suna' },
-        { id: 6, title: 'Discord', url: 'https://discord.gg/Py6pCBUUPw' },
+        { id: 6, title: 'Discord', url: 'https://discord.com/invite/RvFhXUdZ9H' },
         { id: 7, title: 'GitHub', url: 'https://github.com/kortix-ai/suna' },
       ],
     },


### PR DESCRIPTION
Update Discord invite links to use the canonical URL across the site.

---
[Slack Thread](https://kortixworkspace.slack.com/archives/C0A5L512J13/p1767692546763849?thread_ts=1767692546.763849&cid=C0A5L512J13)

<a href="https://cursor.com/background-agent?bcId=bc-9090e7d3-572d-404f-972b-2edcb21e17de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9090e7d3-572d-404f-972b-2edcb21e17de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Standardizes Discord links to the canonical `https://discord.com/invite/RvFhXUdZ9H`.
> 
> - Updates README badge and footer "Join Discord" link
> - Replaces Discord URL in `help/credits/page.tsx` button action
> - Updates "Discord Community" quick link in `components/help/help-sidebar.tsx`
> - Changes footer social Discord link in `components/home/simple-footer.tsx`
> - Updates `site-config.ts` footer "Discord" resource link
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e797dc4e8680b48ade14099435510f35c7bd429e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->