### PR TITLE
- fix for frontend move

### DIFF
--- a/.cursor/worktrees.json
+++ b/.cursor/worktrees.json
@@ -1,6 +1,6 @@
 {
   "setup-worktree": [
-    "cd frontend && npm install",
+    "cd apps/frontend && npm install",
     "cd apps/mobile && npm install",
     "cd backend && uv venv && uv sync"
   ]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,4 +27,4 @@ This will guide you through configuring all required services and dependencies.
 For detailed setup instructions, please refer to:
 
 - [Backend Development Setup](backend/README.md) - Backend-specific development
-- [Frontend Development Setup](frontend/README.md) - Frontend-specific development
+- [Frontend Development Setup](apps/frontend/README.md) - Frontend-specific development

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Build, manage, and train sophisticated AI agents for any use case. Create powerf
 [Русский](https://www.readme-i18n.com/kortix-ai/suna?lang=ru) | 
 [中文](https://www.readme-i18n.com/kortix-ai/suna?lang=zh)
 
-![Kortix Screenshot](frontend/public/banner.png)
+![Kortix Screenshot](apps/frontend/public/banner.png)
 </div>
 
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -42,7 +42,7 @@ uv run api.py
 **2. Launching the frontend**
 
 ```bash
-cd frontend
+cd apps/frontend
 pnpm install
 pnpm run dev
 ```

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -81,7 +81,7 @@ services:
   frontend:
     init: true
     build:
-      context: ./frontend
+      context: ./apps/frontend
       dockerfile: Dockerfile
       args:
         NEXT_PUBLIC_BACKEND_URL: ${NEXT_PUBLIC_BACKEND_URL:-http://localhost:8000/v1}

--- a/setup.py
+++ b/setup.py
@@ -137,7 +137,7 @@ def parse_env_file(filepath):
 def load_existing_env_vars():
     """Loads existing environment variables from .env files."""
     backend_env = parse_env_file(os.path.join("backend", ".env"))
-    frontend_env = parse_env_file(os.path.join("frontend", ".env.local"))
+    frontend_env = parse_env_file(os.path.join("apps", "frontend", ".env.local"))
 
     # Organize the variables by category
     existing_vars = {
@@ -499,10 +499,10 @@ class SetupWizard:
                     return False
             
             # Check frontend .env.local
-            if not os.path.exists("frontend/.env.local"):
+            if not os.path.exists("apps/frontend/.env.local"):
                 return False
             
-            with open("frontend/.env.local", "r") as f:
+            with open("apps/frontend/.env.local", "r") as f:
                 frontend_content = f.read()
                 if "NEXT_PUBLIC_SUPABASE_URL" not in frontend_content:
                     return False
@@ -735,7 +735,7 @@ class SetupWizard:
     def check_suna_directory(self):
         """Checks if the script is run from the correct project root directory."""
         print_info("Verifying project structure...")
-        required_dirs = ["backend", "frontend"]
+        required_dirs = ["backend", "apps/frontend"]
         required_files = ["README.md", "docker-compose.yaml"]
 
         for directory in required_dirs:
@@ -1604,9 +1604,9 @@ class SetupWizard:
         for key, value in frontend_env.items():
             frontend_env_content += f"{key}={value or ''}\n"
 
-        with open(os.path.join("frontend", ".env.local"), "w") as f:
+        with open(os.path.join("apps", "frontend", ".env.local"), "w") as f:
             f.write(frontend_env_content)
-        print_success("Created frontend/.env.local file.")
+        print_success("Created apps/frontend/.env.local file.")
 
         # --- Mobile App .env ---
         # Mobile will access from the device, so it should use localhost (not Docker host)

--- a/start.py
+++ b/start.py
@@ -105,7 +105,7 @@ def print_manual_instructions(compose_cmd_str):
     step_num += 1
 
     print(f"{Colors.BOLD}{step_num}. Start Frontend (in a new terminal):{Colors.ENDC}")
-    print(f"{Colors.CYAN}   cd frontend && pnpm run dev{Colors.ENDC}\n")
+    print(f"{Colors.CYAN}   cd apps/frontend && pnpm run dev{Colors.ENDC}\n")
     step_num += 1
 
     print(f"{Colors.BOLD}{step_num}. Start Backend (in a new terminal):{Colors.ENDC}")


### PR DESCRIPTION
fix for frontend moved to apps/frontend

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Standardizes the frontend location to `apps/frontend` across the project.
> 
> - Updates Docker Compose build context for `frontend` service to `./apps/frontend`
> - Adjusts `setup.py` to read/write `apps/frontend/.env.local`, validate `apps/frontend` in project checks, and print updated status messages
> - Updates `start.py` and `backend/README.md` manual run instructions to `cd apps/frontend`
> - Fixes links and assets in docs: README banner path and CONTRIBUTING frontend setup link
> - Updates `.cursor/worktrees.json` to install dependencies in `apps/frontend`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6fef3e4e7d5920a30e80cb44e43c54688cbc9598. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->