### PR TITLE
type check

### DIFF
--- a/apps/frontend/src/components/billing/pricing/pricing-section.tsx
+++ b/apps/frontend/src/components/billing/pricing/pricing-section.tsx
@@ -1112,7 +1112,7 @@ export function PricingSection({
 
   // Find the index of the user's current tier to pre-select it
   const getCurrentTierIndex = () => {
-    if (!isAuthenticated || !currentSubscription) return 1; // Default to Pro plan (index 1)
+    if (!isAuthenticated || !currentSubscription?.subscription) return 1; // Default to Pro plan (index 1)
     const currentTierKey = currentSubscription.subscription.tier_key || currentSubscription.tier?.name;
     const index = paidTiers.findIndex(tier => tier.tierKey === currentTierKey);
     return index >= 0 ? index : 1; // Default to Pro plan (index 1) if tier not found
@@ -1123,7 +1123,7 @@ export function PricingSection({
 
   // Update selected tier when subscription data loads
   React.useEffect(() => {
-    if (isAuthenticated && currentSubscription) {
+    if (isAuthenticated && currentSubscription?.subscription) {
       const currentTierKey = currentSubscription.subscription.tier_key || currentSubscription.tier?.name;
       const index = paidTiers.findIndex(tier => tier.tierKey === currentTierKey);
       if (index >= 0) {
@@ -1131,7 +1131,7 @@ export function PricingSection({
       }
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isAuthenticated, currentSubscription?.subscription.tier_key, currentSubscription?.tier?.name]);
+  }, [isAuthenticated, currentSubscription?.subscription?.tier_key, currentSubscription?.tier?.name]);
 
   const handlePlanSelect = (planId: string) => {
     setPlanLoadingStates((prev) => ({ ...prev, [planId]: true }));
@@ -1306,7 +1306,7 @@ export function PricingSection({
 
         {(() => {
           // Only show holiday promo for FREE tier users (not authenticated or on free tier)
-          const isFreeTier = !isAuthenticated || !accountState || 
+          const isFreeTier = !isAuthenticated || !accountState?.subscription || 
             accountState.subscription.tier_key === 'free' || 
             accountState.subscription.tier_key === 'none' ||
             (accountState.tier?.monthly_credits ?? 0) === 0;

--- a/apps/frontend/src/components/settings/user-settings-modal.tsx
+++ b/apps/frontend/src/components/settings/user-settings-modal.tsx
@@ -1018,11 +1018,12 @@ function BillingTab({ returnUrl, onOpenPlanModal, isActive }: { returnUrl: strin
         );
     }
 
-    const subStatus = accountState?.subscription.status;
+    const subscription = accountState?.subscription;
+    const subStatus = subscription?.status;
     const isSubscribed = subStatus === 'active' || subStatus === 'trialing';
-    const isFreeTier = accountState?.subscription.tier_key === 'free' || accountState?.subscription.tier_key === 'none';
-    const isCancelled = accountState?.subscription.is_cancelled || accountState?.subscription.cancel_at_period_end;
-    const canPurchaseCredits = accountState?.subscription.can_purchase_credits || false;
+    const isFreeTier = subscription?.tier_key === 'free' || subscription?.tier_key === 'none';
+    const isCancelled = subscription?.is_cancelled || subscription?.cancel_at_period_end;
+    const canPurchaseCredits = subscription?.can_purchase_credits || false;
 
     return (
         <div className="p-4 sm:p-6 space-y-6 sm:space-y-8 min-w-0 max-w-full overflow-x-hidden">

--- a/apps/frontend/src/hooks/billing/use-account-state.ts
+++ b/apps/frontend/src/hooks/billing/use-account-state.ts
@@ -397,21 +397,21 @@ export function useCancelTrial() {
 
 export const accountStateSelectors = {
   /** Check if user can run agents (has credits) */
-  canRun: (state: AccountState | undefined) => state?.credits.can_run ?? false,
+  canRun: (state: AccountState | undefined) => state?.credits?.can_run ?? false,
   
   /** Get total credits */
-  totalCredits: (state: AccountState | undefined) => state?.credits.total ?? 0,
+  totalCredits: (state: AccountState | undefined) => state?.credits?.total ?? 0,
   
   /** Get tier key */
-  tierKey: (state: AccountState | undefined) => state?.subscription.tier_key ?? 'none',
+  tierKey: (state: AccountState | undefined) => state?.subscription?.tier_key ?? 'none',
   
   /** Get tier display name */
   tierDisplayName: (state: AccountState | undefined) => 
-    state?.subscription.tier_display_name ?? 'No Plan',
+    state?.subscription?.tier_display_name ?? 'No Plan',
   
   /** Get plan name for TierBadge (e.g., 'Plus', 'Pro', 'Ultra', 'Basic') */
   planName: (state: AccountState | undefined) => {
-    if (!state) return 'Basic';
+    if (!state?.subscription) return 'Basic';
     const tierKey = state.subscription.tier_key || state.tier?.name;
     if (!tierKey || tierKey === 'none' || tierKey === 'free') return 'Basic';
     
@@ -421,34 +421,34 @@ export const accountStateSelectors = {
   },
   
   /** Check if on trial */
-  isTrial: (state: AccountState | undefined) => state?.subscription.is_trial ?? false,
+  isTrial: (state: AccountState | undefined) => state?.subscription?.is_trial ?? false,
   
   /** Check if subscription is cancelled */
-  isCancelled: (state: AccountState | undefined) => state?.subscription.is_cancelled ?? false,
+  isCancelled: (state: AccountState | undefined) => state?.subscription?.is_cancelled ?? false,
   
   /** Get allowed models */
   allowedModels: (state: AccountState | undefined) => 
-    state?.models.filter(m => m.allowed) ?? [],
+    state?.models?.filter(m => m.allowed) ?? [],
   
   /** Check if a specific model is allowed */
   isModelAllowed: (state: AccountState | undefined, modelId: string) =>
-    state?.models.find(m => m.id === modelId)?.allowed ?? false,
+    state?.models?.find(m => m.id === modelId)?.allowed ?? false,
   
   /** Get scheduled change info */
-  scheduledChange: (state: AccountState | undefined) => state?.subscription.scheduled_change,
+  scheduledChange: (state: AccountState | undefined) => state?.subscription?.scheduled_change,
   
   /** Check if has scheduled change */
   hasScheduledChange: (state: AccountState | undefined) => 
-    state?.subscription.has_scheduled_change ?? false,
+    state?.subscription?.has_scheduled_change ?? false,
   
   /** Get commitment info */
-  commitment: (state: AccountState | undefined) => state?.subscription.commitment,
+  commitment: (state: AccountState | undefined) => state?.subscription?.commitment,
   
   /** Check if can purchase credits */
   canPurchaseCredits: (state: AccountState | undefined) => 
-    state?.subscription.can_purchase_credits ?? false,
+    state?.subscription?.can_purchase_credits ?? false,
     
   /** Get daily credits info */
-  dailyCreditsInfo: (state: AccountState | undefined) => state?.credits.daily_refresh,
+  dailyCreditsInfo: (state: AccountState | undefined) => state?.credits?.daily_refresh,
 };
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Strengthens null/undefined handling in billing-related components to avoid crashes when `subscription` or `credits` are missing.
> 
> - `pricing-section.tsx`: Guard `currentSubscription?.subscription` in tier preselection and effect deps; adjust FREE-tier promo check to require `accountState?.subscription`; minor dependency fix for `tier_key` optional chaining
> - `user-settings-modal.tsx` (Billing tab): Centralize `subscription` const and compute flags (`isFreeTier`, `isCancelled`, `canPurchaseCredits`) via optional chaining
> - `use-account-state.ts` selectors: Add optional chaining for `credits` and `subscription` accessors (e.g., `credits?.total`, `subscription?.tier_key`, `models?[]`) to improve safety
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ec1053ac6c2de3c2dbfb6ffc197da35ec6e37d2b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->