### PR TITLE
fix: add missing @babel/plugin-transform-class-properties for expensi…

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -124,6 +124,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.26.0",
+    "@babel/plugin-transform-class-properties": "^7.26.0",
     "@babel/plugin-transform-react-jsx": "^7.26.0",
     "@types/react": "~19.1.10",
     "@types/react-syntax-highlighter": "^15.5.13",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1024,6 +1024,9 @@ importers:
       '@babel/core':
         specifier: ^7.26.0
         version: 7.28.5
+      '@babel/plugin-transform-class-properties':
+        specifier: ^7.26.0
+        version: 7.27.1(@babel/core@7.28.5)
       '@babel/plugin-transform-react-jsx':
         specifier: ^7.26.0
         version: 7.27.1(@babel/core@7.28.5)


### PR DESCRIPTION
…fy-common worklets

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds missing Babel configuration for class properties in the mobile app.
> 
> - Adds `@babel/plugin-transform-class-properties` to `devDependencies` in `apps/mobile/package.json`
> - Updates `pnpm-lock.yaml` to include the new plugin and resolved version
> 
> This enables compatibility with `expensify-common` worklets that rely on class properties.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb8698e2e269e1035cf0d19f5d4f4d86e498e29c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->