### PR TITLE
fix: add react-native-worklets/plugin to babel config for expensify-c…

### DIFF
--- a/apps/mobile/babel.config.js
+++ b/apps/mobile/babel.config.js
@@ -3,6 +3,7 @@ module.exports = function (api) {
   return {
     presets: ['babel-preset-expo', 'nativewind/babel'],
     plugins: [
+      'react-native-worklets/plugin',
       'react-native-reanimated/plugin',
     ],
   };


### PR DESCRIPTION
…ommon worklets support

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables worklet transformation in the mobile app build.
> 
> - Adds `react-native-worklets/plugin` to `plugins` in `apps/mobile/babel.config.js` (before `react-native-reanimated/plugin`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4eee0dfd62c0e976a7329d8cff2bd1fcf5a2d2b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->