### PR TITLE
fix: remove duplicate react-native-worklets plugin from babel config

### DIFF
--- a/apps/mobile/babel.config.js
+++ b/apps/mobile/babel.config.js
@@ -3,7 +3,6 @@ module.exports = function (api) {
   return {
     presets: ['babel-preset-expo', 'nativewind/babel'],
     plugins: [
-      'react-native-worklets/plugin',
       'react-native-reanimated/plugin',
     ],
   };


### PR DESCRIPTION
- Remove react-native-worklets/plugin from babel.config.js
- react-native-reanimated/plugin already includes worklets internally
- Fixes EAS update build failure with duplicate plugin error
- Verified locally: iOS and Android exports both succeed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes a redundant Babel plugin entry to fix build issues.
> 
> - Delete `react-native-worklets/plugin` from `apps/mobile/babel.config.js`
> - Keep only `react-native-reanimated/plugin`, which already handles worklets
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f03bbe1558492c2a765b2fe7a0f1e3e2b00b61c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->