### PR TITLE
Fix frontend install path (app/frontend)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1788,7 +1788,7 @@ class SetupWizard:
         try:
             print_info("Installing frontend dependencies with pnpm...")
             subprocess.run(
-                ["pnpm", "install"], cwd="frontend", check=True, shell=IS_WINDOWS
+                ["pnpm", "install"], cwd="apps/frontend", check=True, shell=IS_WINDOWS
             )
             print_success("Frontend dependencies installed.")
 
@@ -1952,7 +1952,7 @@ class SetupWizard:
 
             print(
                 f"\n{Colors.BOLD}{step_num}. Start Frontend (in a new terminal):{Colors.ENDC}")
-            print(f"{Colors.CYAN}   cd frontend && pnpm run dev{Colors.ENDC}")
+            print(f"{Colors.CYAN}   cd apps/frontend && pnpm run dev{Colors.ENDC}")
             step_num += 1
 
             print(


### PR DESCRIPTION
### Why
- `frontend` directory does not exist at root
- Actual path is `app/frontend`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Corrects frontend path references in `setup.py` to match monorepo structure.
> 
> - Runs `pnpm install` in `apps/frontend` instead of `frontend`
> - Updates manual start instructions to `cd apps/frontend && pnpm run dev`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 863fdbd9519ba85ab40b9135e52a45a3641a1062. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->