### PR TITLE
fix staging

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -93,7 +93,6 @@ jobs:
             cd /home/ubuntu/suna/backend
             git fetch origin main
             git reset --hard origin/main
-            set -a && source .env && set +a
             
             echo "=== Pre-deployment disk usage ==="
             df -h / | tail -1
@@ -102,15 +101,14 @@ jobs:
             echo "=== Cleaning up old images ==="
             docker image prune -af --filter "until=24h" || true
             
-            # Build and deploy
-            echo "=== Building and deploying services ==="
-            docker compose build
+            # Pull pre-built image from registry and deploy
+            echo "=== Pulling and deploying services ==="
+            docker compose pull
             docker compose up -d --remove-orphans
             
             # Post cleanup
             echo "=== Post-deployment cleanup ==="
             docker image prune -af --filter "until=1h" || true
-            docker builder prune -af --keep-storage=2GB || true
             
             echo "=== Deployment complete ==="
             docker compose ps
@@ -155,7 +153,6 @@ jobs:
             cd /home/ubuntu/suna/backend
             git fetch origin PRODUCTION
             git reset --hard origin/PRODUCTION
-            set -a && source .env && set +a
             
             echo "=== Pre-deployment disk usage ==="
             df -h / | tail -1
@@ -164,15 +161,14 @@ jobs:
             echo "=== Cleaning up old images ==="
             docker image prune -af --filter "until=24h" || true
             
-            # Build and deploy
-            echo "=== Building and deploying services ==="
-            docker compose build
+            # Pull pre-built image from registry and deploy
+            echo "=== Pulling and deploying services ==="
+            docker compose pull
             docker compose up -d --remove-orphans
             
             # Post cleanup
             echo "=== Post-deployment cleanup ==="
             docker image prune -af --filter "until=1h" || true
-            docker builder prune -af --keep-storage=2GB || true
             
             echo "=== Deployment complete ==="
             docker compose ps

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   api:
-    image: ghcr.io/suna-ai/suna-backend:latest
+    image: ghcr.io/kortix-ai/suna/suna-backend:latest
     platform: linux/amd64
     build:
       context: .
@@ -38,7 +38,7 @@ services:
   # Worker service removed - agent runs now execute directly in API process
   # Memory/categorization tasks also run directly as async background tasks
   # worker:
-  #   image: ghcr.io/suna-ai/suna-backend:latest
+  #   image: ghcr.io/kortix-ai/suna/suna-backend:latest
   #   platform: linux/amd64
   #   build:
   #     context: .


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Deployment workflow changes**
> 
> - Staging and production SSH deploy steps now pull pre-built images (`docker compose pull`) instead of building on the server; removed `.env` sourcing and builder cache prune.
> - Retains image cleanup before/after deployment; still brings up services with `docker compose up -d --remove-orphans`.
> 
> **Docker Compose updates**
> 
> - Updates `api` image to `ghcr.io/kortix-ai/suna/suna-backend:latest` (and mirrored in commented `worker` section).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 76d2c997160fef51727e6650df0580097c7758e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->