### PR TITLE
fix supavisor connection params

### DIFF
--- a/backend/core/services/db.py
+++ b/backend/core/services/db.py
@@ -174,11 +174,13 @@ async def init_db() -> None:
     
     dsn = _get_dsn()
     is_supavisor = "pooler.supabase.com" in dsn or ":6543" in dsn
+    
     connect_args = {
         "connect_timeout": CONNECT_TIMEOUT,
-        "options": f"-c statement_timeout={STATEMENT_TIMEOUT} -c lock_timeout=5000",
         "prepare_threshold": None,
     }
+    if not is_supavisor:
+        connect_args["options"] = f"-c statement_timeout={STATEMENT_TIMEOUT} -c lock_timeout=5000"
     
     use_nullpool = USE_NULLPOOL == "true" or (USE_NULLPOOL == "auto" and is_supavisor)
     execution_opts = {"prepared_statement_cache_size": 0}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adjusts DB connection args for Supabase Supavisor compatibility.
> 
> - In `backend/core/services/db.py` `init_db`, conditionally set `connect_args["options"]` (statement/lock timeouts) only when the DSN is not Supavisor (`pooler.supabase.com` or port `6543`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7a2fe684f78f1867c98f56d1dc33cd74a92c53e8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->