### PR TITLE
use envs if avlble

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - app-network
     environment:
       - LOG_LEVEL=INFO
-      - WORKERS=16
+      - WORKERS=${WORKERS:-16}
       - SUPABASE_MAX_CONNECTIONS=50
     logging:
       driver: "json-file"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Allows overriding the API worker count via environment variable while defaulting to 16.
> 
> - In `backend/docker-compose.yml`, `WORKERS` is now set to `${WORKERS:-16}` instead of a fixed `16`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f114b10cc39b876cdcc295f722306c4f1265ec08. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->