### PR TITLE
migrate credit manager

### DIFF
--- a/backend/core/billing/credits/manager.py
+++ b/backend/core/billing/credits/manager.py
@@ -1,15 +1,14 @@
 from typing import Dict, Optional, Tuple
 from decimal import Decimal
 from datetime import datetime, timezone, timedelta
-from core.services.supabase import DBConnection
 from core.utils.logger import logger
 from core.utils.cache import Cache
+from core.billing import repo as billing_repo
 import uuid
 
 
 class CreditManager:
     def __init__(self):
-        self.db = DBConnection()
         self.use_atomic_functions = True
     
     async def add_credits(
@@ -22,26 +21,24 @@ class CreditManager:
         type: Optional[str] = None,
         stripe_event_id: Optional[str] = None
     ) -> Dict:
-        client = await self.db.client
         amount = Decimal(str(amount))
         
         if self.use_atomic_functions:
             try:
                 idempotency_key = f"{account_id}_{description}_{amount}_{datetime.now(timezone.utc).strftime('%Y%m%d%H%M')}"
                 
-                result = await client.rpc('atomic_add_credits', {
-                    'p_account_id': account_id,
-                    'p_amount': float(amount),
-                    'p_is_expiring': is_expiring,
-                    'p_description': description,
-                    'p_expires_at': expires_at.isoformat() if expires_at else None,
-                    'p_type': type,
-                    'p_stripe_event_id': stripe_event_id,
-                    'p_idempotency_key': idempotency_key
-                }).execute()
+                result = await billing_repo.atomic_add_credits(
+                    account_id=account_id,
+                    amount=float(amount),
+                    is_expiring=is_expiring,
+                    description=description,
+                    expires_at=expires_at.isoformat() if expires_at else None,
+                    credit_type=type,
+                    stripe_event_id=stripe_event_id,
+                    idempotency_key=idempotency_key
+                )
                 
-                if result.data:
-                    data = result.data
+                if result:
                     logger.info(f"[ATOMIC] Added ${amount} credits to {account_id} atomically")
                     
                     await Cache.invalidate(f"credit_balance:{account_id}")
@@ -49,9 +46,8 @@ class CreditManager:
                     
                     return {
                         'success': True,
-                        'credit_id': data.get('credit_id'),
-                        'ledger_id': data.get('ledger_id'),
-                        'new_balance': Decimal(str(data.get('new_balance', 0))),
+                        'ledger_id': result.get('ledger_id'),
+                        'new_balance': Decimal(str(result.get('new_balance', 0))),
                         'amount_added': amount
                     }
                 else:
@@ -83,20 +79,17 @@ class CreditManager:
         description: str = "Monthly credit renewal",
         stripe_event_id: Optional[str] = None
     ) -> Dict:
-        client = await self.db.client
         if self.use_atomic_functions:
             try:
-                result = await client.rpc('atomic_reset_expiring_credits', {
-                    'p_account_id': account_id,
-                    'p_new_credits': float(new_credits),
-                    'p_description': description,
-                    'p_stripe_event_id': stripe_event_id
-                }).execute()
+                result = await billing_repo.atomic_reset_expiring_credits(
+                    account_id=account_id,
+                    new_credits=float(new_credits),
+                    description=description,
+                    stripe_event_id=stripe_event_id
+                )
                 
-                if result.data:
-                    data = result.data
-                    
-                    if data.get('success'):
+                if result:
+                    if result.get('success'):
                         logger.info(f"[ATOMIC] Reset expiring credits to ${new_credits} for {account_id} atomically")
                         
                         await Cache.invalidate(f"credit_balance:{account_id}")
@@ -104,26 +97,23 @@ class CreditManager:
                         
                         return {
                             'success': True,
-                            'new_expiring': data.get('new_expiring', 0),
-                            'non_expiring': data.get('non_expiring', 0),
-                            'total_balance': data.get('total_balance', 0)
+                            'new_expiring': result.get('new_expiring', 0),
+                            'non_expiring': result.get('non_expiring', 0),
+                            'total_balance': result.get('total_balance', 0)
                         }
                     else:
-                        logger.error(f"[ATOMIC] Failed to reset credits: {data.get('error')}")
+                        logger.error(f"[ATOMIC] Failed to reset credits: {result.get('error')}")
                         
             except Exception as e:
                 logger.error(f"[ATOMIC] Failed to use atomic function for reset: {e}")
                 self.use_atomic_functions = False
 
-        result = await client.from_('credit_accounts').select(
-            'balance, expiring_credits, non_expiring_credits'
-        ).eq('account_id', account_id).execute()
+        # Fallback: manual reset
+        account_data = await billing_repo.get_credit_account_balances(account_id)
         
-        if result.data:
-            current = result.data[0]
-            current_balance = Decimal(str(current.get('balance', 0)))
-            current_expiring = Decimal(str(current.get('expiring_credits', 0)))
-            current_non_expiring = Decimal(str(current.get('non_expiring_credits', 0)))
+        if account_data:
+            current_balance = Decimal(str(account_data.get('balance', 0)))
+            current_non_expiring = Decimal(str(account_data.get('non_expiring_credits', 0)))
             
             if current_balance <= current_non_expiring:
                 actual_non_expiring = current_balance
@@ -135,35 +125,31 @@ class CreditManager:
         
         new_total = new_credits + actual_non_expiring
         
-        await client.from_('credit_accounts').update({
-            'expiring_credits': float(new_credits),
-            'non_expiring_credits': float(actual_non_expiring),
-            'balance': float(new_total),
-            'updated_at': datetime.now(timezone.utc).isoformat()
-        }).eq('account_id', account_id).execute()
+        await billing_repo.update_credit_account_balances(
+            account_id=account_id,
+            expiring_credits=float(new_credits),
+            non_expiring_credits=float(actual_non_expiring),
+            balance=float(new_total)
+        )
         
         expires_at = datetime.now(timezone.utc).replace(day=1) + timedelta(days=32)
         expires_at = expires_at.replace(day=1)
         
-        ledger_entry = {
-            'account_id': account_id,
-            'amount': float(new_credits),
-            'balance_after': float(new_total),
-            'type': 'tier_grant',
-            'description': description,
-            'is_expiring': True,
-            'expires_at': expires_at.isoformat(),
-            'metadata': {
+        await billing_repo.insert_credit_ledger(
+            account_id=account_id,
+            amount=float(new_credits),
+            balance_after=float(new_total),
+            ledger_type='tier_grant',
+            description=description,
+            is_expiring=True,
+            expires_at=expires_at.isoformat(),
+            metadata={
                 'renewal': True,
                 'non_expiring_preserved': float(actual_non_expiring),
                 'previous_balance': float(current_balance)
-            }
-        }
-        
-        if stripe_event_id:
-            ledger_entry['stripe_event_id'] = stripe_event_id
-        
-        await client.from_('credit_ledger').insert(ledger_entry).execute()
+            },
+            stripe_event_id=stripe_event_id
+        )
         
         await Cache.invalidate(f"credit_balance:{account_id}")
         await Cache.invalidate(f"credit_summary:{account_id}")
@@ -185,60 +171,33 @@ class CreditManager:
         type: Optional[str],
         stripe_event_id: Optional[str]
     ) -> Dict:
-        client = await self.db.client
         amount = Decimal(str(amount))
         
         if amount <= 0:
             raise ValueError("Amount must be positive")
         
-        credit_id = str(uuid.uuid4())
-        ledger_id = str(uuid.uuid4())
-        
-        credits_data = {
-            'id': credit_id,
-            'account_id': account_id,
-            'amount': float(amount),
-            'is_expiring': is_expiring,
-            'expires_at': expires_at.isoformat() if expires_at else None,
-        }
-        
-        if stripe_event_id:
-            credits_data['stripe_event_id'] = stripe_event_id
-        
-        ledger_data = {
-            'id': ledger_id,
-            'account_id': account_id,
-            'amount': float(amount),
-            'type': type or 'credit',
-            'description': description,
-            'credit_id': credit_id,
-        }
-        
-        if stripe_event_id:
-            ledger_data['stripe_event_id'] = stripe_event_id
-        
         logger.info(f"[MANUAL] Adding ${amount} credits to {account_id}")
         
-        credits_result = await client.from_('credits').insert(credits_data).execute()
-        if not credits_result.data:
-            raise Exception("Failed to insert credit record")
-        
-        ledger_result = await client.from_('credit_ledger').insert(ledger_data).execute()
-        if not ledger_result.data:
-            raise Exception("Failed to insert ledger record")
+        result = await billing_repo.add_credits_and_update_account(
+            account_id=account_id,
+            amount=float(amount),
+            ledger_type=type or 'credit',
+            description=description,
+            is_expiring=is_expiring,
+            expires_at=expires_at.isoformat() if expires_at else None,
+            stripe_event_id=stripe_event_id
+        )
         
         await Cache.invalidate(f"credit_balance:{account_id}")
         await Cache.invalidate(f"credit_summary:{account_id}")
         
-        balance_info = await self.get_balance(account_id)
-        new_balance = Decimal(str(balance_info.get('total', 0)))
+        new_balance = Decimal(str(result.get('new_balance', 0)))
         
         logger.info(f"[MANUAL] Successfully added ${amount} credits to {account_id}. New balance: ${new_balance}")
         
         return {
             'success': True,
-            'credit_id': credit_id,
-            'ledger_id': ledger_id,
+            'ledger_id': result.get('ledger_id'),
             'new_balance': new_balance,
             'amount_added': amount
         }
@@ -252,53 +211,40 @@ class CreditManager:
         stripe_event_id: Optional[str]
     ) -> Dict:
         """Manually replace all existing expiring credits with new amount"""
-        client = await self.db.client
         new_credits = Decimal(str(new_credits))
         
         logger.info(f"[MANUAL RESET] Replacing expiring credits with ${new_credits} for {account_id}")
         
         # First, expire all existing expiring credits
-        current_time = datetime.now(timezone.utc)
-        await client.from_('credits').update({
-            'expires_at': current_time.isoformat(),
-            'is_expired': True
-        }).eq('account_id', account_id).eq('is_expiring', True).is_('is_expired', 'null').execute()
+        await billing_repo.expire_existing_credits(account_id)
         
         # Add the new credits
         credit_id = str(uuid.uuid4())
         ledger_id = str(uuid.uuid4())
         
-        credits_data = {
-            'id': credit_id,
-            'account_id': account_id,
-            'amount': float(new_credits),
-            'is_expiring': True,
-            'expires_at': expires_at.isoformat() if expires_at else None,
-        }
-        
-        if stripe_event_id:
-            credits_data['stripe_event_id'] = stripe_event_id
-        
-        ledger_data = {
-            'id': ledger_id,
-            'account_id': account_id,
-            'amount': float(new_credits),
-            'type': 'tier_upgrade',
-            'description': description,
-            'credit_id': credit_id,
-        }
-        
-        if stripe_event_id:
-            ledger_data['stripe_event_id'] = stripe_event_id
-        
         # Insert new credit record
-        credits_result = await client.from_('credits').insert(credits_data).execute()
-        if not credits_result.data:
+        credits_result = await billing_repo.insert_credit_record(
+            credit_id=credit_id,
+            account_id=account_id,
+            amount=float(new_credits),
+            is_expiring=True,
+            expires_at=expires_at.isoformat() if expires_at else None,
+            stripe_event_id=stripe_event_id
+        )
+        if not credits_result:
             raise Exception("Failed to insert new credit record")
         
         # Insert ledger record
-        ledger_result = await client.from_('credit_ledger').insert(ledger_data).execute()
-        if not ledger_result.data:
+        ledger_result = await billing_repo.insert_credit_ledger_simple(
+            ledger_id=ledger_id,
+            account_id=account_id,
+            amount=float(new_credits),
+            ledger_type='tier_upgrade',
+            description=description,
+            credit_id=credit_id,
+            stripe_event_id=stripe_event_id
+        )
+        if not ledger_result:
             raise Exception("Failed to insert new ledger record")
         
         await Cache.invalidate(f"credit_balance:{account_id}")
@@ -326,7 +272,6 @@ class CreditManager:
         message_id: Optional[str] = None,
         thread_id: Optional[str] = None
     ) -> Dict:
-        client = await self.db.client
         amount = Decimal(str(amount))
         
         if amount <= 0:
@@ -341,25 +286,18 @@ class CreditManager:
         
         if self.use_atomic_functions:
             try:
-                metadata = {}
-                if message_id:
-                    metadata['message_id'] = message_id
-                if thread_id:
-                    metadata['thread_id'] = thread_id
+                result = await billing_repo.atomic_use_credits(
+                    account_id=account_id,
+                    amount=float(amount),
+                    description=description,
+                    thread_id=thread_id,
+                    message_id=message_id
+                )
                 
-                result = await client.rpc('atomic_use_credits', {
-                    'p_account_id': account_id,
-                    'p_amount': float(amount),
-                    'p_description': description,
-                    'p_thread_id': thread_id,
-                    'p_message_id': message_id
-                }).execute()
-                
-                if result.data:
-                    data = result.data[0] if isinstance(result.data, list) else result.data
-                    new_balance = Decimal(str(data.get('new_total', 0)))
+                if result:
+                    new_balance = Decimal(str(result.get('new_total', 0)))
                     amount_deducted = amount
-                    success = data.get('success', True)
+                    success = result.get('success', True)
                     
                     await Cache.invalidate(f"credit_balance:{account_id}")
                     await Cache.invalidate(f"credit_summary:{account_id}")
@@ -371,9 +309,9 @@ class CreditManager:
                         'amount_deducted': amount_deducted,
                         'new_balance': new_balance,
                         'new_total': float(new_balance),
-                        'from_expiring': float(data.get('from_expiring', 0)),
-                        'from_non_expiring': float(data.get('from_non_expiring', 0)),
-                        'transaction_id': data.get('transaction_id')
+                        'from_expiring': float(result.get('from_expiring', 0)),
+                        'from_non_expiring': float(result.get('from_non_expiring', 0)),
+                        'transaction_id': result.get('transaction_id')
                     }
                 else:
                     raise Exception("No data returned from atomic_deduct_credits")
@@ -395,43 +333,23 @@ class CreditManager:
         message_id: Optional[str],
         thread_id: Optional[str]
     ) -> Dict:
-        client = await self.db.client
         amount = Decimal(str(amount))
         
         logger.info(f"[MANUAL] Deducting ${amount} from {account_id}")
         
-        balance_info = await self.get_balance(account_id)
-        current_balance = Decimal(str(balance_info.get('total', 0)))
-        
-        if current_balance <= 0:
-            logger.warning(f"[MANUAL] Account {account_id} has non-positive balance ${current_balance}")
-        
-        ledger_id = str(uuid.uuid4())
-        ledger_data = {
-            'id': ledger_id,
-            'account_id': account_id,
-            'amount': -float(amount),
-            'type': type,
-            'description': description,
-        }
-        
-        metadata = {}
-        if message_id:
-            metadata['message_id'] = message_id
-        if thread_id:
-            metadata['thread_id'] = thread_id
-        if metadata:
-            ledger_data['metadata'] = metadata
-        
-        ledger_result = await client.from_('credit_ledger').insert(ledger_data).execute()
-        if not ledger_result.data:
-            raise Exception("Failed to insert deduction ledger record")
+        result = await billing_repo.deduct_credits_and_update_account(
+            account_id=account_id,
+            amount=float(amount),
+            description=description,
+            ledger_type=type,
+            thread_id=thread_id,
+            message_id=message_id
+        )
         
         await Cache.invalidate(f"credit_balance:{account_id}")
         await Cache.invalidate(f"credit_summary:{account_id}")
         
-        new_balance_info = await self.get_balance(account_id)
-        new_balance = Decimal(str(new_balance_info.get('total', 0)))
+        new_balance = Decimal(str(result.get('new_balance', 0)))
         
         logger.info(f"[MANUAL] Successfully deducted ${amount} from {account_id}. New balance: ${new_balance}")
         
@@ -439,7 +357,9 @@ class CreditManager:
             'success': True,
             'amount_deducted': amount,
             'new_balance': new_balance,
-            'ledger_id': ledger_id
+            'ledger_id': result.get('ledger_id'),
+            'from_expiring': result.get('from_expiring', 0),
+            'from_non_expiring': result.get('from_non_expiring', 0)
         }
     
     async def get_balance(self, account_id: str, use_cache: bool = True) -> Dict:
@@ -450,13 +370,11 @@ class CreditManager:
             if cached_balance is not None:
                 return cached_balance
         
-        client = await self.db.client
-        balance_result = await client.from_('credit_accounts').select('balance').eq('account_id', account_id).execute()
+        result = await billing_repo.get_credit_account_balance(account_id)
         
-        if balance_result.data and len(balance_result.data) > 0:
-            balance = balance_result.data[0]['balance']
+        if result:
             balance_data = {
-                'total': balance,
+                'total': result.get('balance', 0),
                 'account_id': account_id
             }
         else:
@@ -474,14 +392,9 @@ class CreditManager:
         if cached_summary is not None:
             return cached_summary
         
-        client = await self.db.client
+        account_data = await billing_repo.get_credit_account_balances(account_id)
         
-        account_result = await client.from_('credit_accounts').select(
-            'balance, expiring_credits, non_expiring_credits'
-        ).eq('account_id', account_id).execute()
-        
-        if account_result.data and len(account_result.data) > 0:
-            account_data = account_result.data[0]
+        if account_data:
             summary_data = {
                 'total_balance': account_data.get('balance', 0),
                 'expiring_balance': account_data.get('expiring_credits', 0),
@@ -489,7 +402,6 @@ class CreditManager:
                 'monthly_usage': 0,
                 'account_id': account_id
             }
-            
         else:
             summary_data = {
                 'total_balance': 0,
@@ -501,5 +413,6 @@ class CreditManager:
         
         await Cache.set(cache_key, summary_data, ttl=300)
         return summary_data
+
 
 credit_manager = CreditManager()

--- a/backend/core/services/db.py
+++ b/backend/core/services/db.py
@@ -89,10 +89,18 @@ TRANSIENT_ERRORS = (
 
 
 def serialize_row(row: Dict[str, Any]) -> Dict[str, Any]:
-    return {
-        k: str(v) if isinstance(v, uuid.UUID) else v.isoformat() if isinstance(v, datetime) else v
-        for k, v in row.items()
-    }
+    from decimal import Decimal
+    result = {}
+    for k, v in row.items():
+        if isinstance(v, uuid.UUID):
+            result[k] = str(v)
+        elif isinstance(v, datetime):
+            result[k] = v.isoformat()
+        elif isinstance(v, Decimal):
+            result[k] = float(v)
+        else:
+            result[k] = v
+    return result
 
 
 def serialize_rows(rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refactors credit management to use a new repository layer and SQL DB utilities instead of direct Supabase RPC/client usage.
> 
> - Rewrites `CreditManager` to call `core.billing.repo` for atomic ops and manual fallbacks; removes direct `DBConnection` usage and consolidates balance/ledger updates and cache invalidations
> - Adds repo functions: `atomic_add_credits`, `atomic_reset_expiring_credits`, `atomic_use_credits`, balance getters/updaters, ledger insert helpers, transactional `add_credits_and_update_account` and `deduct_credits_and_update_account`, and `expire_existing_credits`
> - Adjusts return payloads (e.g., `ledger_id`, `new_balance`) and error/duplicate handling; keeps cache keys consistent
> - Enhances `core.services.db.serialize_row` to convert `Decimal` to float for JSON-safe responses
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eeb9722606c586ea3d173fa0d554f43b9cbdfc1d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->