### PR TITLE
Cookie consent removal

### DIFF
--- a/apps/frontend/src/app/layout.tsx
+++ b/apps/frontend/src/app/layout.tsx
@@ -12,16 +12,15 @@ import { roobertMono } from './fonts/roobert-mono';
 import { Suspense, lazy } from 'react';
 import { I18nProvider } from '@/components/i18n-provider';
 import { featureFlags } from '@/lib/feature-flags';
+import { CookieConsent } from '@/components/cookie-consent';
 
 // Lazy load non-critical analytics and global components
-// Note: Analytics scripts will be automatically blocked by cookie consent service until consent is given
 const Analytics = lazy(() => import('@vercel/analytics/react').then(mod => ({ default: mod.Analytics })));
 const SpeedInsights = lazy(() => import('@vercel/speed-insights/next').then(mod => ({ default: mod.SpeedInsights })));
 const GoogleTagManager = lazy(() => import('@next/third-parties/google').then(mod => ({ default: mod.GoogleTagManager })));
 const PostHogIdentify = lazy(() => import('@/components/posthog-identify').then(mod => ({ default: mod.PostHogIdentify })));
 const PlanSelectionModal = lazy(() => import('@/components/billing/pricing/plan-selection-modal').then(mod => ({ default: mod.PlanSelectionModal })));
 const AnnouncementDialog = lazy(() => import('@/components/announcements/announcement-dialog').then(mod => ({ default: mod.AnnouncementDialog })));
-const CookieConsent = lazy(() => import('@/components/cookie-consent').then(mod => ({ default: mod.CookieConsent })));
 const RouteChangeTracker = lazy(() => import('@/components/analytics/route-change-tracker').then(mod => ({ default: mod.RouteChangeTracker })));
 const AuthEventTracker = lazy(() => import('@/components/analytics/auth-event-tracker').then(mod => ({ default: mod.AuthEventTracker })));
 
@@ -275,9 +274,7 @@ export default function RootLayout({
           <Suspense fallback={null}>
             <PostHogIdentify />
           </Suspense>
-          <Suspense fallback={null}>
-            <CookieConsent />
-          </Suspense>
+          <CookieConsent />
           <Suspense fallback={null}>
             <RouteChangeTracker />
           </Suspense>

--- a/apps/frontend/src/components/cookie-consent.tsx
+++ b/apps/frontend/src/components/cookie-consent.tsx
@@ -1,10 +1,192 @@
 'use client';
 
+import { useEffect } from 'react';
+
 /**
  * Cookie consent component
- * CookieYes script has been removed
+ *
+ * The CMP script/widget is not owned by the app code in some environments
+ * (e.g. injected via GTM, hosting provider, or legacy snippets). To ensure it
+ * cannot break core UI interactions (capturing clicks / stuck overlays), we
+ * aggressively remove known cookie-consent artifacts from the DOM.
  */
 export function CookieConsent() {
+  useEffect(() => {
+    const SELECTORS: string[] = [
+      // CookieYes (CKY)
+      '.cky-consent-container',
+      '.cky-consent-bar',
+      '.cky-overlay',
+      '.cky-modal',
+      '.cky-btn-revisit-wrapper',
+      '.cky-btn-revisit',
+      '#cky-consent-container',
+      '#cky-consent-bar',
+      '#cky-overlay',
+      '#cky-btn-revisit-wrapper',
+
+      // OneTrust
+      '#onetrust-consent-sdk',
+      '#onetrust-banner-sdk',
+      '#ot-sdk-btn',
+      '.ot-sdk-container',
+      '.ot-sdk-row',
+
+      // Cookiebot
+      '#CybotCookiebotDialog',
+      '#CybotCookiebotDialogBodyUnderlay',
+      '#CookiebotWidget',
+      '#CookiebotBanner',
+
+      // Osano
+      '.osano-cm-widget',
+      '.osano-cm-dialog',
+      '.osano-cm-window',
+      '.osano-cm-overlay',
+
+      // Iubenda
+      '.iubenda-cs-container',
+      '.iubenda-cs-overlay',
+
+      // Quantcast
+      '#qc-cmp2-ui',
+      '.qc-cmp2-container',
+    ];
+
+    const SRC_MATCHERS = [
+      // CookieYes / CookieLawInfo
+      'cdn-cookieyes.com',
+      'cookieyes.com',
+      'cookie-law-info',
+      // OneTrust (common CDN host)
+      'cookielaw.org',
+      // OneTrust
+      'onetrust',
+      'optanon',
+      // Cookiebot
+      'cookiebot',
+      'cybot',
+      // Osano
+      'osano',
+      // Iubenda
+      'iubenda',
+      // Quantcast
+      'quantcast',
+      'qc-cmp',
+    ];
+
+    const matchesKnownCmpSrc = (src: string) => {
+      const s = src.toLowerCase();
+      return SRC_MATCHERS.some(m => s.includes(m));
+    };
+
+    const removeArtifacts = () => {
+      const removedSelectors: Array<{ selector: string; count: number }> = [];
+
+      for (const selector of SELECTORS) {
+        const nodes = Array.from(document.querySelectorAll(selector));
+        if (nodes.length > 0) {
+          for (const node of nodes) node.remove();
+          removedSelectors.push({ selector, count: nodes.length });
+        }
+      }
+
+      const removedScripts = Array.from(document.querySelectorAll('script[src]'))
+        .filter(script => matchesKnownCmpSrc(script.getAttribute('src') ?? ''))
+        .map(script => {
+          const src = script.getAttribute('src') ?? '';
+          script.remove();
+          return src;
+        });
+
+      const removedIframes = Array.from(document.querySelectorAll('iframe[src]'))
+        .filter(iframe => matchesKnownCmpSrc(iframe.getAttribute('src') ?? ''))
+        .map(iframe => {
+          const src = iframe.getAttribute('src') ?? '';
+          iframe.remove();
+          return src;
+        });
+
+      // Some CMPs inject inline <style> tags; only remove those that mention known CMP keywords.
+      const removedStyles = Array.from(document.querySelectorAll('style'))
+        .filter(styleEl => matchesKnownCmpSrc(styleEl.textContent ?? ''))
+        .map(styleEl => {
+          const preview = (styleEl.textContent ?? '').slice(0, 120);
+          styleEl.remove();
+          return preview;
+        });
+
+      if (process.env.NODE_ENV !== 'production') {
+        // Keep the payload compact but useful for debugging.
+        // eslint-disable-next-line no-console
+        console.info('[cookie-consent] scrubbed', {
+          removedSelectors,
+          removedScripts,
+          removedIframes,
+          removedStylesCount: removedStyles.length,
+        });
+      }
+    };
+
+    // Run once immediately (covers CMPs injected before hydration)...
+    removeArtifacts();
+
+    // ...and keep watching briefly for late injections (e.g. GTM).
+    let scheduled = false;
+    const hasCmpMarker = (node: Node) => {
+      if (node.nodeType !== Node.ELEMENT_NODE) return false;
+      const el = node as Element;
+
+      // Fast checks on the element itself.
+      const id = (el.getAttribute('id') ?? '').toLowerCase();
+      const className = (el.getAttribute('class') ?? '').toLowerCase();
+      const tag = el.tagName.toLowerCase();
+      const src = (el.getAttribute('src') ?? '').toLowerCase();
+
+      if (id.includes('onetrust') || id.includes('optanon') || id.includes('cookiebot') || id.includes('cybot')) return true;
+      if (id.includes('qc-cmp') || id.includes('quantcast') || id.includes('iubenda') || id.includes('osano')) return true;
+      if (id.startsWith('cky') || className.includes('cky-') || className.includes('osano-cm')) return true;
+      if ((tag === 'script' || tag === 'iframe') && matchesKnownCmpSrc(src)) return true;
+
+      // If a wrapper node is inserted, check a small set of known markers within it.
+      return (
+        el.querySelector(
+          [
+            '#ot-sdk-btn',
+            '#onetrust-consent-sdk',
+            '#CybotCookiebotDialog',
+            '#qc-cmp2-ui',
+            '.cky-btn-revisit-wrapper',
+            '.cky-consent-container',
+            '.osano-cm-widget',
+            '.iubenda-cs-container',
+          ].join(', ')
+        ) !== null
+      );
+    };
+
+    const observer = new MutationObserver(records => {
+      if (scheduled) return;
+      const shouldScrub = records.some(r => Array.from(r.addedNodes).some(hasCmpMarker));
+      if (!shouldScrub) return;
+      scheduled = true;
+      window.requestAnimationFrame(() => {
+        scheduled = false;
+        removeArtifacts();
+      });
+    });
+
+    observer.observe(document.documentElement, { childList: true, subtree: true });
+
+    const stopAfterMs = 30_000;
+    const timeout = window.setTimeout(() => observer.disconnect(), stopAfterMs);
+
+    return () => {
+      window.clearTimeout(timeout);
+      observer.disconnect();
+    };
+  }, []);
+
   return null;
 }
 


### PR DESCRIPTION
Remove the cookie consent widget and any click-blocking overlay by actively scrubbing known CMP artifacts from the DOM.

The existing `CookieConsent` component was a no-op, and the visible widget was being injected externally (e.g., via GTM). This PR hardens the `CookieConsent` component to act as a client-side "CMP scrubber" that removes known cookie-consent DOM nodes and scripts, and loads it immediately to ensure early execution.

---
[Slack Thread](https://kortixworkspace.slack.com/archives/C08QYH7MV6F/p1767854202392059?thread_ts=1767854202.392059&cid=C08QYH7MV6F)

<a href="https://cursor.com/background-agent?bcId=bc-51fe4e04-984d-4269-abb0-333881f41e5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-51fe4e04-984d-4269-abb0-333881f41e5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces the no-op cookie consent with an aggressive client-side CMP scrubber and ensures it executes immediately to prevent click-blocking overlays.
> 
> - New `CookieConsent` removes known CMP DOM nodes, scripts, iframes, and related inline styles; runs once on mount and via a `MutationObserver` (~30s), with compact dev-only logging
> - In `layout.tsx`, import/render `CookieConsent` directly (no `lazy`/`Suspense`) for early execution; other analytics remain lazy-loaded
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c8fee580dec6ddb93aa9d78148c05ce5ff960ccd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->