### PR TITLE
feat: Add language selector to homepage navbar

### DIFF
--- a/apps/frontend/src/components/home/locale-switcher.tsx
+++ b/apps/frontend/src/components/home/locale-switcher.tsx
@@ -48,10 +48,10 @@ export function LocaleSwitcher({ variant = 'compact' }: LocaleSwitcherProps) {
       >
         <SelectTrigger 
           size="sm"
-          className="h-7 px-2.5 w-fit min-w-[60px] border-0 bg-transparent hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50 text-muted-foreground/60 transition-all duration-200 shadow-none"
+          className="h-8 px-2.5 w-fit min-w-[60px] border-0 bg-transparent hover:bg-accent/50 hover:text-foreground text-muted-foreground transition-all duration-300 ease-out shadow-none"
         >
           <div className="flex items-center gap-1.5">
-            <Globe className="size-3.5" />
+            <Globe className="size-3.5 opacity-70" />
             <SelectValue>
               {languageCodes[locale as Locale] || locale.toUpperCase()}
             </SelectValue>

--- a/apps/frontend/src/components/home/navbar.tsx
+++ b/apps/frontend/src/components/home/navbar.tsx
@@ -12,6 +12,7 @@ import { useRouter, usePathname } from 'next/navigation';
 import { KortixLogo } from '@/components/sidebar/kortix-logo';
 import { useTranslations } from 'next-intl';
 import { trackCtaSignup } from '@/lib/analytics/gtm';
+import { LocaleSwitcher } from '@/components/home/locale-switcher';
 
 // Scroll threshold with hysteresis to prevent flickering
 const SCROLL_THRESHOLD_DOWN = 50;
@@ -146,6 +147,7 @@ export function Navbar() {
 
             {/* Right Section - Actions */}
             <div className="flex items-center justify-end gap-2 sm:gap-3 ml-auto">
+              <LocaleSwitcher variant="compact" />
               {user ? (
                 <Link
                   href="/dashboard"
@@ -273,8 +275,9 @@ export function Navbar() {
                     </Link>
                   )}
                   
-                  {/* Theme Toggle */}
-                  <div className="flex justify-end">
+                  {/* Language Switcher and Theme Toggle */}
+                  <div className="flex items-center justify-between gap-3">
+                    <LocaleSwitcher variant="compact" />
                     <ThemeToggle />
                   </div>
                 </div>


### PR DESCRIPTION
- Add language selector component to top right of navbar
- Add language selector to mobile drawer menu
- Refine styling for smoother transitions and better visual integration
- Landing page components already support translations via next-intl

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a language selector to the homepage navigation and refines its compact styling for better visual integration.
> 
> - Integrates `LocaleSwitcher` into `navbar.tsx` (desktop right actions) and the mobile drawer alongside `ThemeToggle`
> - Tweaks `locale-switcher.tsx` compact variant styles (`SelectTrigger` height, hover colors, transition timing/ease, and `Globe` icon opacity)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6c319065d338333d4ff0bebaecf4bd0adf4a17b2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->