### PR TITLE
Frontend kortix computer issue

### DIFF
--- a/apps/frontend/src/hooks/threads/page/use-thread-data.ts
+++ b/apps/frontend/src/hooks/threads/page/use-thread-data.ts
@@ -255,9 +255,10 @@ export function useThreadData(
           }
         }
 
-        const requiredDataLoaded = isShared 
-          ? (threadQuery.data && messagesQuery.data)
-          : (threadQuery.data && messagesQuery.data && agentRunsQuery.data);
+        // "Initial load" should mean we can render the thread UI (messages + thread metadata).
+        // Agent runs are *nice to have* (they can be slow/404 transiently when infra changes),
+        // but they should never block the UI from becoming interactive (e.g. opening Kortix Computer).
+        const requiredDataLoaded = Boolean(threadQuery.data && messagesQuery.data);
           
         if (requiredDataLoaded) {
           initialLoadCompleted.current = true;

--- a/apps/frontend/src/hooks/threads/page/use-thread-keyboard-shortcuts.ts
+++ b/apps/frontend/src/hooks/threads/page/use-thread-keyboard-shortcuts.ts
@@ -10,16 +10,15 @@ interface UseKeyboardShortcutsProps {
 
 /**
  * Checks if user is currently focused on an editable element.
- * Returns true for editors, inputs, textareas, and contenteditable elements.
+ * Returns true for rich editors (TipTap/ProseMirror/CodeMirror, contenteditable).
+ *
+ * Note: We intentionally do NOT treat plain inputs/textareas as "editable" here.
+ * On the thread page, users almost always have focus in the chat textarea, and we
+ * still want Cmd+I / Cmd+B to reliably toggle the Kortix Computer / left sidebar.
  */
 function isEditableElementFocused(): boolean {
   const el = document.activeElement;
   if (!el) return false;
-
-  const tagName = el.tagName.toLowerCase();
-
-  // Input fields and textareas
-  if (tagName === 'input' || tagName === 'textarea') return true;
 
   // Contenteditable elements (TipTap/ProseMirror)
   if (el.getAttribute('contenteditable') === 'true') return true;


### PR DESCRIPTION
Fixes Kortix Computer panel not opening and CMD+I shortcut unreliability.

The Kortix Computer panel was previously gated by the `agentRunsQuery` completing successfully; if this query failed, the UI would never fully load, preventing the panel from being opened. Additionally, the CMD+I shortcut was blocked when typing in the chat input because plain text inputs were incorrectly treated as "editable elements" that should disable shortcuts. This PR adjusts the loading logic to decouple the panel from agent run data and refines the shortcut logic to only disable shortcuts for rich text editors.

---
[Slack Thread](https://kortixworkspace.slack.com/archives/C08QYH7MV6F/p1767874358267369?thread_ts=1767874358.267369&cid=C08QYH7MV6F)

<a href="https://cursor.com/background-agent?bcId=bc-d68f5e5e-029c-4de9-a6d5-7b1a13a46fcc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d68f5e5e-029c-4de9-a6d5-7b1a13a46fcc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves thread page responsiveness and keyboard shortcuts.
> 
> - Decouples initial thread UI load from `agentRunsQuery` in `use-thread-data.ts` so UI becomes interactive once `threadQuery` and `messagesQuery` resolve (agent runs no longer block rendering)
> - Refines `isEditableElementFocused` in `use-thread-keyboard-shortcuts.ts` to only treat rich editors (`contenteditable`, CodeMirror, ProseMirror) as editable, allowing `Cmd+I` / `Cmd+B` to toggle panels when focused in plain text inputs/textarea
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cc76210c1587479416bc6629e699a318bcd15b7a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->