### PR TITLE
default batch to 20

### DIFF
--- a/apps/frontend/src/app/(dashboard)/admin/stress-test/page.tsx
+++ b/apps/frontend/src/app/(dashboard)/admin/stress-test/page.tsx
@@ -30,7 +30,7 @@ import { cn } from '@/lib/utils';
 
 export default function AdminStressTestPage() {
   const [numRequests, setNumRequests] = useState(5);
-  const [batchSize, setBatchSize] = useState(1);
+  const [batchSize, setBatchSize] = useState(20);
   const [measureTtft, setMeasureTtft] = useState(true);
   
   const { state, runStressTest, cancelTest, resetTest } = useStressTest();


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Admin Stress Test updates**
> 
> - Frontend: default `batchSize` increased from `1` to `20` in `page.tsx`.
> - Backend: enhanced logging in `wait_for_timing_messages` to log stream wait start, terminal status detection, Redis `xread` errors, and timeout warnings for TTFT collection.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 36721e0faa2e90b8b374d38694f8cec1b6f1b2b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->