### PR TITLE
use mock ai for stress test

### DIFF
--- a/backend/core/api_models/threads.py
+++ b/backend/core/api_models/threads.py
@@ -1,7 +1,7 @@
 """Thread-related API models."""
 
 from pydantic import BaseModel
-from typing import Optional
+from typing import Optional, Dict
 
 
 class UnifiedAgentStartResponse(BaseModel):
@@ -10,6 +10,8 @@ class UnifiedAgentStartResponse(BaseModel):
     agent_run_id: Optional[str] = None  # None in optimistic mode
     project_id: Optional[str] = None    # Returned in optimistic mode
     status: str = "running"  # "running" for regular, "pending" for optimistic
+    # Optional timing breakdown for stress testing (only present when X-Emit-Timing header is set)
+    timing_breakdown: Optional[Dict[str, float]] = None
 
 
 class CreateThreadResponse(BaseModel):

--- a/backend/core/test_harness/mock_llm.py
+++ b/backend/core/test_harness/mock_llm.py
@@ -115,6 +115,11 @@ class MockLLMProvider:
                 if tool_calls:
                     self.tool_calls = tool_calls
         
+        # Yield TTFT metadata first (simulates time to first token)
+        # The delay_ms represents the mock "thinking" time
+        ttft_seconds = self.delay_ms / 1000.0
+        yield {"__llm_ttft_seconds__": ttft_seconds, "model": model}
+        
         # Stream tool calls first
         for i, tool_call in enumerate(tool_calls):
             await asyncio.sleep(self.delay_ms / 1000)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Reworks admin stress testing to mirror production traffic and provide clearer latency metrics.
> 
> - Backend: `admin/stress-test` now issues real `POST /v1/agent/start` HTTP requests (distributed across workers), always using `mock-ai`; adds `X-Skip-Limits` (super admin-gated) and `X-Emit-Timing` to collect timing; streams NDJSON results with `request_time`, `time_to_first_response`, `total_ttft`, `llm_ttft`; aggregates breakdown stats (`load_config_ms`, `get_model_ms`, `create_*_ms`, `total_setup_ms`); constrains batch size via `REDIS_MAX_CONNECTIONS`.
> - Agents API: instruments setup phases and returns optional `timing_breakdown` when timing emission is enabled; response model updated to include `timing_breakdown`.
> - Frontend: admin page and hook migrated from `thread_creation_time` to `request_time`; removed batch size and TTFT toggle; updated tables, progress text, and formulas; added error tooltips and a timing breakdown table; normalized request count input.
> - Mock LLM: emits TTFT metadata first to support accurate `llm_ttft` capture.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a95cdf6eb8959059554ed5f577c024e98b3d6fb7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->