### PR TITLE
Header model selector cleanup

### DIFF
--- a/apps/frontend/src/components/thread/mode-indicator.tsx
+++ b/apps/frontend/src/components/thread/mode-indicator.tsx
@@ -12,7 +12,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from '@/components/ui/tooltip';
-import { ChevronDown, Check, Lock } from 'lucide-react';
+import { Check, Lock } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useModelSelection } from '@/hooks/agents';
 import { KortixLogo } from '@/components/sidebar/kortix-logo';
@@ -69,14 +69,14 @@ export const ModeIndicator = memo(function ModeIndicator() {
           <DropdownMenuTrigger asChild>
             <Button
               variant="outline"
-              className="h-10 px-3 bg-transparent border-[1.5px] border-border rounded-2xl cursor-pointer gap-1.5 text-muted-foreground hover:text-foreground hover:bg-accent/50"
-            >
-              {isPowerSelected && <KortixLogo size={12} variant="symbol" />}
-              <span className="text-sm font-medium">{currentModeLabel}</span>
-              {!canAccessPower && !isPowerSelected && (
-                <Lock className="h-3.5 w-3.5 text-muted-foreground" strokeWidth={2} />
+              size="icon"
+              aria-label={`Switch mode (currently ${currentModeLabel})`}
+              className={cn(
+                "h-10 w-10 p-0 bg-transparent border-[1.5px] border-border rounded-2xl cursor-pointer text-muted-foreground hover:text-foreground hover:bg-accent/50 flex items-center justify-center",
+                isPowerSelected && "border-primary/30 bg-primary/5"
               )}
-              <ChevronDown className="h-3.5 w-3.5 opacity-60" strokeWidth={2} />
+            >
+              <KortixLogo size={18} variant="symbol" />
             </Button>
           </DropdownMenuTrigger>
         </TooltipTrigger>

--- a/apps/frontend/src/components/thread/thread-site-header.tsx
+++ b/apps/frontend/src/components/thread/thread-site-header.tsx
@@ -20,7 +20,6 @@ import { SharePopover } from "@/components/sidebar/share-modal"
 import { useQueryClient } from "@tanstack/react-query";
 import { projectKeys } from "@/hooks/threads/keys";
 import { threadKeys } from "@/hooks/threads/keys";
-import { ModeIndicator } from "@/components/thread/mode-indicator";
 
 interface ThreadSiteHeaderProps {
   threadId?: string;
@@ -174,9 +173,6 @@ export function SiteHeader({
 
       <div className="flex items-center gap-1 pr-4">
         <TooltipProvider>
-          {/* Mode Indicator - only show for non-shared variant */}
-          {variant !== 'shared' && <ModeIndicator />}
-
           {variant === 'shared' ? (
             <Tooltip>
               <TooltipTrigger asChild>


### PR DESCRIPTION
Remove duplicate model selector from header and make the remaining selector icon-only.

The model selector (`ModeIndicator`) was appearing in both the header and the input area, so the header instance was removed. The remaining selector's trigger UI was updated to display only the Kortix logo mark, as requested.

---
[Slack Thread](https://kortixworkspace.slack.com/archives/C09NMGTBL8K/p1767913974285119?thread_ts=1767913974.285119&cid=C09NMGTBL8K)

<a href="https://cursor.com/background-agent?bcId=bc-a51eb889-ee5d-4866-8333-62fb8a98a2be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a51eb889-ee5d-4866-8333-62fb8a98a2be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

