### PR TITLE
fix browser tool

### DIFF
--- a/backend/core/tools/browser_tool.py
+++ b/backend/core/tools/browser_tool.py
@@ -347,7 +347,9 @@ class BrowserTool(SandboxToolsBase):
                         clean_result["screenshot_issue"] = f"Screenshot processing issue: {result['image_validation_error']}"
                     if result.get("image_upload_error"):
                         clean_result["screenshot_issue"] = f"Screenshot upload issue: {result['image_upload_error']}"
-                    clean_result["message_id"] = added_message.get("message_id")
+                    # Convert message_id to string to ensure JSON serialization works
+                    message_id = added_message.get("message_id")
+                    clean_result["message_id"] = str(message_id) if message_id else None
 
                     if clean_result.get("success"):
                         return self.success_response(clean_result)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Ensures BrowserTool responses are JSON-serializable when logging browser state.
> 
> - In `browser_tool.py`, converts `added_message.message_id` to a string before adding to `clean_result` (`message_id`), preventing serialization failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e4aba4e686336cd1fa0e85d46f94c2e21d5fa94. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->