### PR TITLE
fix e2e cicd

### DIFF
--- a/.github/workflows/e2e-api-tests.yml
+++ b/.github/workflows/e2e-api-tests.yml
@@ -81,13 +81,18 @@ jobs:
       - name: Trigger E2E tests via API
         env:
           API_URL: ${{ steps.env.outputs.api_url }}
-          ADMIN_API_KEY: ${{ secrets.KORTIX_ADMIN_API_KEY }}
+          ADMIN_API_KEY: ${{ steps.env.outputs.environment == 'production' && secrets.PRODUCTION_KORTIX_ADMIN_API_KEY || secrets.STAGING_KORTIX_ADMIN_API_KEY }}
+          ENVIRONMENT: ${{ steps.env.outputs.environment }}
         run: |
           set -e
           
           # Validate admin API key is configured
           if [ -z "$ADMIN_API_KEY" ]; then
-            echo "❌ Error: KORTIX_ADMIN_API_KEY is not set"
+            if [ "$ENVIRONMENT" = "production" ]; then
+              echo "❌ Error: PRODUCTION_KORTIX_ADMIN_API_KEY is not set"
+            else
+              echo "❌ Error: STAGING_KORTIX_ADMIN_API_KEY is not set"
+            fi
             echo "Please add it at: https://github.com/${{ github.repository }}/settings/secrets/actions"
             exit 1
           fi
@@ -145,7 +150,7 @@ jobs:
             echo ""
             echo "🔍 Troubleshooting:"
             echo "  1. Verify API URL is correct: $API_URL"
-            echo "  2. Check that KORTIX_ADMIN_API_KEY is valid"
+            echo "  2. Check that STAGING_KORTIX_ADMIN_API_KEY or PRODUCTION_KORTIX_ADMIN_API_KEY is valid"
             echo "  3. Ensure the API server is running and accessible"
             echo "  4. Check API server logs for more details"
             exit 1

--- a/.github/workflows/e2e-benchmark-emergency-stop.yml
+++ b/.github/workflows/e2e-benchmark-emergency-stop.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Emergency Stop All Tests
         env:
           API_URL: ${{ inputs.environment == 'production' && 'https://api.kortix.com' || 'https://staging-api.suna.so' }}
-          ADMIN_API_KEY: ${{ secrets.KORTIX_ADMIN_API_KEY }}
+          ADMIN_API_KEY: ${{ inputs.environment == 'production' && secrets.PRODUCTION_KORTIX_ADMIN_API_KEY || secrets.STAGING_KORTIX_ADMIN_API_KEY }}
         run: |
           set -e
           

--- a/.github/workflows/e2e-benchmark.yml
+++ b/.github/workflows/e2e-benchmark.yml
@@ -40,13 +40,18 @@ jobs:
       - name: Run E2E Benchmark
         env:
           API_URL: ${{ inputs.environment == 'production' && 'https://api.kortix.com' || 'https://staging-api.suna.so' }}
-          ADMIN_API_KEY: ${{ secrets.KORTIX_ADMIN_API_KEY }}
+          ADMIN_API_KEY: ${{ inputs.environment == 'production' && secrets.PRODUCTION_KORTIX_ADMIN_API_KEY || secrets.STAGING_KORTIX_ADMIN_API_KEY }}
+          ENVIRONMENT: ${{ inputs.environment }}
         run: |
           set -e
           
           # Validate admin API key is configured
           if [ -z "$ADMIN_API_KEY" ]; then
-            echo "❌ Error: KORTIX_ADMIN_API_KEY is not set"
+            if [ "$ENVIRONMENT" = "production" ]; then
+              echo "❌ Error: PRODUCTION_KORTIX_ADMIN_API_KEY is not set"
+            else
+              echo "❌ Error: STAGING_KORTIX_ADMIN_API_KEY is not set"
+            fi
             echo "Please add it at: https://github.com/${{ github.repository }}/settings/secrets/actions"
             exit 1
           fi
@@ -128,7 +133,7 @@ jobs:
             echo ""
             echo "🔍 Troubleshooting:"
             echo "  1. Verify API URL is correct: $API_URL"
-            echo "  2. Check that KORTIX_ADMIN_API_KEY is valid"
+            echo "  2. Check that STAGING_KORTIX_ADMIN_API_KEY or PRODUCTION_KORTIX_ADMIN_API_KEY is valid"
             echo "  3. Ensure the API server is running and accessible"
             echo "  4. Check API server logs for more details"
             exit 1


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Aligns E2E workflows with environment-specific secrets and clearer validation.
> 
> - In `e2e-api-tests.yml`, `e2e-benchmark.yml`, and `e2e-benchmark-emergency-stop.yml`, select `PRODUCTION_KORTIX_ADMIN_API_KEY` or `STAGING_KORTIX_ADMIN_API_KEY` dynamically based on environment, replacing the single `KORTIX_ADMIN_API_KEY` usage
> - Add `ENVIRONMENT` for validation in `e2e-api-tests.yml` and `e2e-benchmark.yml`; update error and troubleshooting messages to reference the correct secret names
> - No behavioral changes to test execution logic beyond key selection and improved diagnostics
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5cedc64be8cd4fcde45f3ca6684ffd004b05e84b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->