### PR TITLE
Enhance media extraction regex to support filenames with spaces and a…

### DIFF
--- a/apps/frontend/src/components/thread/content/MediaGenerationInline.tsx
+++ b/apps/frontend/src/components/thread/content/MediaGenerationInline.tsx
@@ -30,14 +30,18 @@ function extractGeneratedMedia(output: string | undefined): { path: string; type
   if (!output) return null;
   
   // Check for video first - handle /workspace/ prefix
-  const videoMatch = output.match(/Video saved as:\s*(?:\/workspace\/)?([^\s\n]+\.(?:mp4|webm|mov))/i);
+  // Supports filenames with spaces (e.g., "Mock Video abc123.mp4")
+  const videoMatch = output.match(/Video saved as:\s*(?:\/workspace\/)?(.+\.(?:mp4|webm|mov))/i);
   if (videoMatch?.[1]) return { path: videoMatch[1].trim(), type: 'video' };
+  // Legacy format with underscores
   const directVideoMatch = output.match(/(?:\/workspace\/)?(generated_video_[a-z0-9]+\.(?:mp4|webm|mov))/i);
   if (directVideoMatch?.[1]) return { path: directVideoMatch[1].trim(), type: 'video' };
   
   // Check for image - handle /workspace/ prefix
-  const imageMatch = output.match(/Image saved as:\s*(?:\/workspace\/)?([^\s\n]+\.(?:png|jpg|jpeg|webp|gif))/i);
+  // Supports filenames with spaces (e.g., "Geometric Glass Facade.png")
+  const imageMatch = output.match(/Image saved as:\s*(?:\/workspace\/)?(.+\.(?:png|jpg|jpeg|webp|gif))/i);
   if (imageMatch?.[1]) return { path: imageMatch[1].trim(), type: 'image' };
+  // Legacy format with underscores
   const directImageMatch = output.match(/(?:\/workspace\/)?(generated_image_[a-z0-9]+\.(?:png|jpg|jpeg|webp|gif))/i);
   if (directImageMatch?.[1]) return { path: directImageMatch[1].trim(), type: 'image' };
   

--- a/apps/frontend/src/components/thread/tool-views/image-edit-generate-tool/_utils.ts
+++ b/apps/frontend/src/components/thread/tool-views/image-edit-generate-tool/_utils.ts
@@ -68,20 +68,21 @@ function extractGeneratedImages(output: unknown): string[] {
   
   if (typeof output === 'string') {
     // Pattern 1: "Image saved as: /workspace/filename.png" or "Image saved as: filename.png"
-    const singleMatch = output.match(/Image saved as:\s*(?:\/workspace\/)?([^\s\n]+\.(?:png|jpg|jpeg|webp|gif))/i);
+    // Supports filenames with spaces (e.g., "Geometric Glass Facade.png")
+    const singleMatch = output.match(/Image saved as:\s*(?:\/workspace\/)?(.+\.(?:png|jpg|jpeg|webp|gif))/i);
     if (singleMatch?.[1]) {
       images.push(singleMatch[1].trim());
     }
     
-    // Pattern 2: "- filename.png" (batch mode list)
-    const batchMatches = output.matchAll(/^- (?:\/workspace\/)?([^\n]+\.(?:png|jpg|jpeg|webp|gif))/gim);
+    // Pattern 2: "- filename.png" (batch mode list) - supports spaces in filenames
+    const batchMatches = output.matchAll(/^- (?:\/workspace\/)?(.+\.(?:png|jpg|jpeg|webp|gif))\s*$/gim);
     for (const match of batchMatches) {
       if (match[1] && !images.includes(match[1].trim())) {
         images.push(match[1].trim());
       }
     }
     
-    // Pattern 3: Direct generated_image_xxx.png pattern (with or without /workspace/)
+    // Pattern 3: Direct generated_image_xxx.png pattern (legacy format with underscores)
     if (images.length === 0) {
       const directMatches = output.matchAll(/(?:\/workspace\/)?(generated_image_[a-z0-9]+\.(?:png|jpg|jpeg|webp|gif))/gi);
       for (const match of directMatches) {
@@ -127,12 +128,13 @@ function extractGeneratedVideos(output: unknown): string[] {
   
   if (typeof output === 'string') {
     // Pattern 1: "Video saved as: /workspace/filename.mp4" or "Video saved as: filename.mp4"
-    const singleMatch = output.match(/Video saved as:\s*(?:\/workspace\/)?([^\s\n]+\.(?:mp4|webm|mov))/i);
+    // Supports filenames with spaces (e.g., "Mock Video abc123.mp4")
+    const singleMatch = output.match(/Video saved as:\s*(?:\/workspace\/)?(.+\.(?:mp4|webm|mov))/i);
     if (singleMatch?.[1]) {
       videos.push(singleMatch[1].trim());
     }
     
-    // Pattern 2: Direct generated_video_xxx.mp4 pattern (with or without /workspace/)
+    // Pattern 2: Direct generated_video_xxx.mp4 pattern (legacy format with underscores)
     if (videos.length === 0) {
       const directMatches = output.matchAll(/(?:\/workspace\/)?(generated_video_[a-z0-9]+\.(?:mp4|webm|mov))/gi);
       for (const match of directMatches) {

--- a/apps/mobile/components/chat/tool-views/image-edit-tool/_utils.ts
+++ b/apps/mobile/components/chat/tool-views/image-edit-tool/_utils.ts
@@ -55,13 +55,14 @@ export function extractImageEditData({ toolCall, toolResult }: { toolCall: ToolC
         generatedImagePath = `/workspace/${generatedImagePath}`;
       }
     } else if (typeof output === 'string') {
-      // Match patterns like "Image saved as: generated_image_966956f9.png"
-      const imagePathMatch = output.match(/Image saved as:\s*([^\s.]+\.(png|jpg|jpeg|webp|gif))/i) ||
-                            output.match(/saved as:\s*([^\s.]+\.(png|jpg|jpeg|webp|gif))/i) ||
-                            output.match(/(\/workspace\/[^\s]+\.(png|jpg|jpeg|webp))/i) ||
+      // Match patterns like "Image saved as: Geometric Glass Facade.png" (with spaces)
+      // or legacy format like "Image saved as: generated_image_966956f9.png"
+      const imagePathMatch = output.match(/Image saved as:\s*(?:\/workspace\/)?(.+\.(png|jpg|jpeg|webp|gif))/i) ||
+                            output.match(/saved as:\s*(?:\/workspace\/)?(.+\.(png|jpg|jpeg|webp|gif))/i) ||
+                            output.match(/(\/workspace\/.+\.(png|jpg|jpeg|webp))/i) ||
                             output.match(/(generated_image_[\w]+\.(png|jpg|jpeg|webp))/i);
       if (imagePathMatch) {
-        const path = imagePathMatch[1] || imagePathMatch[0];
+        const path = (imagePathMatch[1] || imagePathMatch[0]).trim();
         generatedImagePath = path.startsWith('/') ? path : `/workspace/${path}`;
       }
       


### PR DESCRIPTION
…dd legacy format handling for generated media files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves media filename extraction to handle spaces and preserve legacy patterns across web and mobile.
> 
> - Updates `MediaGenerationInline.tsx` to parse `Image/Video saved as:` lines with filenames containing spaces; retains legacy `generated_image_*`/`generated_video_*` matches
> - Enhances `image-edit-generate-tool/_utils.ts` (web) to broaden single and batch image matches (supports spaces), and video matches; keeps legacy underscore patterns
> - Extends mobile `image-edit-tool/_utils.ts` string parsing to support spaced filenames, trims paths, and maintains `/workspace/` prefix logic and legacy pattern support
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a0881a8e9a5446125548169b6088089537eba71c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->