### PR TITLE
rem redis from stress

### DIFF
--- a/backend/core/admin/stress_test_admin_api.py
+++ b/backend/core/admin/stress_test_admin_api.py
@@ -4,10 +4,9 @@ Runs stress tests by making actual HTTP calls to /agent/start endpoint.
 This distributes load across workers like real production traffic.
 Uses mock-ai model to avoid token costs.
 
-TIMING DEFINITIONS:
-- request_time: Total time for the HTTP request to complete (thread creation + agent start)
-- time_to_first_response: Time from agent start until first LLM response chunk
-- total_ttft: request_time + time_to_first_response
+TIMING:
+- request_time: Total time for the HTTP request to complete
+- timing_breakdown: Detailed timing returned directly in HTTP response (no Redis needed)
 """
 
 from fastapi import APIRouter, HTTPException, Depends, Request
@@ -22,7 +21,6 @@ import os
 import httpx
 from core.auth import require_super_admin
 from core.utils.logger import logger
-from core.services.redis import redis
 
 router = APIRouter(prefix="/admin/stress-test", tags=["admin-stress-test"])
 
@@ -44,10 +42,8 @@ STRESS_TEST_HOST_HEADER = os.getenv("STRESS_TEST_HOST_HEADER", "api.kortix.com")
 
 class StressTestConfig(BaseModel):
     num_requests: int = 20
-    batch_size: int = 20
+    batch_size: Optional[int] = None  # Defaults to num_requests (all at once)
     prompts: Optional[List[str]] = None
-    measure_ttft: bool = True  # Whether to wait for first response
-    ttft_timeout: float = 120.0  # Max seconds to wait for first response
 
 class StressTestResult(BaseModel):
     request_id: int
@@ -56,11 +52,8 @@ class StressTestResult(BaseModel):
     project_id: Optional[str] = None
     agent_run_id: Optional[str] = None
     request_time: float = 0.0  # Time for HTTP request to complete
-    time_to_first_response: Optional[float] = None
-    total_ttft: Optional[float] = None
-    llm_ttft: Optional[float] = None
     error: Optional[str] = None
-    # Detailed timing breakdown (when emit_timing is enabled)
+    # Detailed timing breakdown returned directly from HTTP response (no Redis needed)
     timing_breakdown: Optional[Dict[str, float]] = None
 
 # Default prompts for stress testing
@@ -73,58 +66,6 @@ DEFAULT_PROMPTS = [
 ]
 
 
-class TimingResult:
-    """Container for timing values from Redis stream."""
-    def __init__(self):
-        self.first_response_ms: Optional[float] = None
-        self.llm_ttft_seconds: Optional[float] = None
-
-
-async def wait_for_timing_messages(agent_run_id: str, timeout: float = 120.0) -> TimingResult:
-    """
-    Subscribe to Redis stream and wait for timing messages.
-    """
-    stream_key = f"agent_run:{agent_run_id}:stream"
-    start_time = time.time()
-    last_id = "0"
-    
-    result = TimingResult()
-    
-    while time.time() - start_time < timeout:
-        if result.first_response_ms is not None and result.llm_ttft_seconds is not None:
-            break
-            
-        try:
-            entries = await redis.xread({stream_key: last_id}, count=10, block=200)
-            
-            if entries:
-                for stream_name, stream_entries in entries:
-                    for entry_id, fields in stream_entries:
-                        last_id = entry_id
-                        try:
-                            data_field = fields.get(b'data') or fields.get('data')
-                            if isinstance(data_field, bytes):
-                                data_field = data_field.decode()
-                            
-                            data = json.loads(data_field or '{}')
-                            msg_type = data.get('type')
-                            
-                            if msg_type == 'timing' and 'first_response_ms' in data:
-                                result.first_response_ms = data['first_response_ms']
-                            
-                            if msg_type == 'llm_ttft' and 'ttft_seconds' in data:
-                                result.llm_ttft_seconds = data['ttft_seconds']
-                            
-                            if msg_type == 'status' and data.get('status') in ['completed', 'failed', 'stopped', 'error']:
-                                return result
-                        except Exception as e:
-                            logger.debug(f"Error parsing stream message: {e}")
-        except Exception as e:
-            await asyncio.sleep(0.2)
-    
-    return result
-
-
 async def run_single_request_via_http(
     request_id: int,
     base_url: str,
@@ -132,12 +73,11 @@ async def run_single_request_via_http(
     prompt: str,
     host_header: Optional[str] = None,
     skip_ssl_verify: bool = False,
-    measure_ttft: bool = True,
-    ttft_timeout: float = 120.0,
 ) -> Dict[str, Any]:
     """
     Run a single agent request by making an actual HTTP call.
     This gets distributed across workers like real traffic.
+    Timing is returned directly in the HTTP response (no Redis needed).
     
     Args:
         host_header: If set, adds Host header (for ALB routing)
@@ -150,9 +90,6 @@ async def run_single_request_via_http(
         "project_id": None,
         "agent_run_id": None,
         "request_time": 0.0,
-        "time_to_first_response": None,
-        "total_ttft": None,
-        "llm_ttft": None,
         "error": None,
     }
     
@@ -165,7 +102,7 @@ async def run_single_request_via_http(
                 "Authorization": f"Bearer {auth_token}",
                 "Content-Type": "application/x-www-form-urlencoded",
                 "X-Skip-Limits": "true",  # Bypass limits for stress testing (verified server-side)
-                "X-Emit-Timing": "true",  # Emit detailed timing breakdown to Redis
+                "X-Emit-Timing": "true",  # Return detailed timing breakdown in HTTP response
             }
             if host_header:
                 headers["Host"] = host_header
@@ -198,19 +135,6 @@ async def run_single_request_via_http(
             if data.get("timing_breakdown"):
                 logger.info(f"📊 Request {request_id} got timing_breakdown: {data['timing_breakdown']}")
                 result["timing_breakdown"] = data["timing_breakdown"]
-            else:
-                logger.warning(f"📊 Request {request_id} NO timing_breakdown in response")
-            
-            # Wait for timing messages (first_response, llm_ttft) from Redis stream
-            if measure_ttft and result["agent_run_id"]:
-                timing_result = await wait_for_timing_messages(result["agent_run_id"], timeout=ttft_timeout)
-                
-                if timing_result.first_response_ms is not None:
-                    result["time_to_first_response"] = round(timing_result.first_response_ms / 1000, 3)
-                    result["total_ttft"] = round(request_time + (timing_result.first_response_ms / 1000), 3)
-                
-                if timing_result.llm_ttft_seconds is not None:
-                    result["llm_ttft"] = round(timing_result.llm_ttft_seconds, 3)
     
     except httpx.TimeoutException:
         result["request_time"] = round(time.time() - start_time, 3)
@@ -264,17 +188,10 @@ async def run_stress_test(
     
     prompts = config.prompts or DEFAULT_PROMPTS
     num_requests = min(config.num_requests, 200)
+    # Default batch_size to num_requests (all at once) if not specified
+    batch_size = min(config.batch_size or num_requests, 300)
     
-    # Limit batch size based on Redis pool to prevent connection exhaustion
-    # Each agent run uses multiple Redis connections, so limit concurrency
-    redis_max = int(os.getenv("REDIS_MAX_CONNECTIONS", "50"))
-    max_safe_batch = max(1, redis_max // 10)  # ~10 Redis ops per agent run
-    batch_size = min(config.batch_size, 50, max_safe_batch)
-    
-    measure_ttft = config.measure_ttft
-    ttft_timeout = config.ttft_timeout
-    
-    logger.info(f"Admin stress test: {num_requests} requests, batch size {batch_size} (redis_max={redis_max}), base_url={base_url}")
+    logger.info(f"Admin stress test: {num_requests} requests, batch size {batch_size}, base_url={base_url}")
     
     async def generate():
         """Generator for streaming results."""
@@ -288,7 +205,6 @@ async def run_stress_test(
             "num_requests": num_requests,
             "batch_size": batch_size,
             "num_batches": num_batches,
-            "measure_ttft": measure_ttft,
             "base_url": base_url,
         }) + "\n"
         
@@ -320,8 +236,6 @@ async def run_stress_test(
                     prompt=random.choice(prompts),
                     host_header=host_header,
                     skip_ssl_verify=skip_ssl_verify,
-                    measure_ttft=measure_ttft,
-                    ttft_timeout=ttft_timeout,
                 )
                 for req_id in batch_ids
             ]
@@ -344,16 +258,13 @@ async def run_stress_test(
         failed = [r for r in all_results if r["status"] == "error"]
         
         request_times = [r["request_time"] for r in all_results if r["request_time"] > 0]
-        first_response_times = [r["time_to_first_response"] for r in all_results if r.get("time_to_first_response") is not None]
-        total_ttft_times = [r["total_ttft"] for r in all_results if r.get("total_ttft") is not None]
-        llm_ttft_times = [r["llm_ttft"] for r in all_results if r.get("llm_ttft") is not None]
         
         error_breakdown = {}
         for r in failed:
             key = (r.get("error") or "Unknown")[:50]
             error_breakdown[key] = error_breakdown.get(key, 0) + 1
         
-        # Aggregate timing breakdown stats
+        # Aggregate timing breakdown stats (from HTTP response, no Redis needed)
         breakdown_keys = ["load_config_ms", "get_model_ms", "create_project_ms", 
                          "create_thread_ms", "create_message_and_run_ms", "total_setup_ms"]
         breakdown_stats = {}
@@ -379,22 +290,8 @@ async def run_stress_test(
             "min_request_time": round(min(request_times), 3) if request_times else 0,
             "avg_request_time": round(sum(request_times) / len(request_times), 3) if request_times else 0,
             "max_request_time": round(max(request_times), 3) if request_times else 0,
-            # Time to first response
-            "first_response_measured": len(first_response_times),
-            "min_time_to_first_response": round(min(first_response_times), 3) if first_response_times else None,
-            "avg_time_to_first_response": round(sum(first_response_times) / len(first_response_times), 3) if first_response_times else None,
-            "max_time_to_first_response": round(max(first_response_times), 3) if first_response_times else None,
-            # Total TTFT
-            "min_total_ttft": round(min(total_ttft_times), 3) if total_ttft_times else None,
-            "avg_total_ttft": round(sum(total_ttft_times) / len(total_ttft_times), 3) if total_ttft_times else None,
-            "max_total_ttft": round(max(total_ttft_times), 3) if total_ttft_times else None,
-            # LLM TTFT
-            "llm_ttft_measured": len(llm_ttft_times),
-            "min_llm_ttft": round(min(llm_ttft_times), 3) if llm_ttft_times else None,
-            "avg_llm_ttft": round(sum(llm_ttft_times) / len(llm_ttft_times), 3) if llm_ttft_times else None,
-            "max_llm_ttft": round(max(llm_ttft_times), 3) if llm_ttft_times else None,
             "error_breakdown": error_breakdown,
-            # Detailed timing breakdown
+            # Detailed timing breakdown (from HTTP response, no Redis needed)
             "timing_breakdown": breakdown_stats if breakdown_stats else None,
         }
         


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Shift to HTTP-based timing (no Redis)**
> - Removes Redis stream usage and TTFT tracking (`wait_for_timing_messages`, related fields) from `stress_test_admin_api.py`
> - Timing now returned in `timing_breakdown` directly from `/v1/agent/start` via `X-Emit-Timing`, aggregated in response summary
> 
> **Config and output simplifications**
> - `StressTestConfig.batch_size` is optional and defaults to `num_requests`; removes Redis-based concurrency limiting; caps batch size at 300
> - Drops `measure_ttft`, `ttft_timeout`, and TTFT/LLM metrics from per-request and summary stats; keeps `request_time` and timing breakdown aggregation
> - Updates streaming output to reflect new fields (no TTFT metrics) and logs accordingly
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6f74804c73e44baeee99868f0b93e2096fdf4579. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->