### PR TITLE
remove checkmark beside tool card

### DIFF
--- a/apps/mobile/components/chat/CompactToolCard.tsx
+++ b/apps/mobile/components/chat/CompactToolCard.tsx
@@ -174,12 +174,6 @@ export const CompactToolCard = React.memo(function CompactToolCard({
       <Text className="text-sm font-roobert-medium text-muted-foreground" numberOfLines={1}>
         {displayName}
       </Text>
-
-      <Icon
-        as={isError ? AlertCircle : CheckCircle2}
-        size={12}
-        className={isError ? 'text-destructive ml-2' : 'text-emerald-500 ml-2'}
-      />
     </AnimatedPressable>
   );
 });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Removes the extra completion checkmark from the compact tool card UI so only the tool icon (or `AlertCircle` on error) and name are shown.
> 
> - In `CompactToolCard.tsx`, deleted the trailing status `Icon` (previously `CheckCircle2` or `AlertCircle`) following `displayName`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6a259bf6d261e1807027e5aa324b122ae0f8dcd5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->