### PR TITLE
mobile maintenance screen

### DIFF
--- a/apps/mobile/app/home.tsx
+++ b/apps/mobile/app/home.tsx
@@ -8,15 +8,17 @@ import { Stack, useRouter, useLocalSearchParams } from 'expo-router';
 import { useColorScheme } from 'nativewind';
 import * as React from 'react';
 import { StatusBar as RNStatusBar, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Drawer } from 'react-native-drawer-layout';
 import { useQueryClient } from '@tanstack/react-query';
 import type { Agent } from '@/api/types';
 import type { Conversation } from '@/components/menu/types';
 import { FeedbackDrawer } from '@/components/chat/tool-views/complete-tool/FeedbackDrawer';
 import { useFeedbackDrawerStore } from '@/stores/feedback-drawer-store';
-import { MaintenanceBanner, TechnicalIssueBanner } from '@/components/status';
+import { MaintenanceBanner, TechnicalIssueBanner, MaintenancePage } from '@/components/status';
 
 export default function AppScreen() {
+  const insets = useSafeAreaInsets();
   const { colorScheme } = useColorScheme();
   const { isAuthenticated } = useAuthContext();
   const router = useRouter();
@@ -26,9 +28,30 @@ export default function AppScreen() {
   const pageNav = usePageNavigation();
   const { isOpen: isFeedbackDrawerOpen } = useFeedbackDrawerStore();
   const homePageRef = React.useRef<HomePageRef>(null);
-  const { data: systemStatus } = useSystemStatus();
+  const { data: systemStatus, refetch: refetchSystemStatus, isLoading: isSystemStatusLoading } = useSystemStatus();
   const { data: adminRole } = useAdminRole();
   const isAdmin = adminRole?.isAdmin ?? false;
+
+  const isMaintenanceActive = React.useMemo(() => {
+    const notice = systemStatus?.maintenanceNotice;
+    if (!notice?.enabled || !notice.startTime || !notice.endTime) {
+      return false;
+    }
+    const now = new Date();
+    const start = new Date(notice.startTime);
+    const end = new Date(notice.endTime);
+    return now >= start && now <= end;
+  }, [systemStatus?.maintenanceNotice]);
+
+  const isMaintenanceScheduled = React.useMemo(() => {
+    const notice = systemStatus?.maintenanceNotice;
+    if (!notice?.enabled || !notice.startTime || !notice.endTime) {
+      return false;
+    }
+    const now = new Date();
+    const start = new Date(notice.startTime);
+    return now < start;
+  }, [systemStatus?.maintenanceNotice]);
 
   // Worker config drawer state for MenuPage
   const [menuWorkerConfigWorkerId, setMenuWorkerConfigWorkerId] = React.useState<string | null>(
@@ -167,38 +190,55 @@ export default function AppScreen() {
           />
         )}>
         <View className="flex-1">
-          {!isAdmin && systemStatus?.maintenanceNotice?.enabled && systemStatus.maintenanceNotice.startTime && systemStatus.maintenanceNotice.endTime && (
-            <MaintenanceBanner
-              startTime={systemStatus.maintenanceNotice.startTime}
-              endTime={systemStatus.maintenanceNotice.endTime}
-            />
-          )}
-          {!isAdmin && systemStatus?.technicalIssue?.enabled && systemStatus.technicalIssue.message && (
-            <TechnicalIssueBanner
-              message={systemStatus.technicalIssue.message}
-              statusUrl={systemStatus.technicalIssue.statusUrl}
-              description={systemStatus.technicalIssue.description}
-              estimatedResolution={systemStatus.technicalIssue.estimatedResolution}
-              severity={systemStatus.technicalIssue.severity}
-              affectedServices={systemStatus.technicalIssue.affectedServices}
-            />
-          )}
-          {chat.hasActiveThread ? (
-            <ThreadPage
-              onMenuPress={pageNav.openDrawer}
-              chat={chat}
-              isAuthenticated={canSendMessages}
-              onOpenWorkerConfig={handleOpenWorkerConfigFromAgentDrawer}
+          {isMaintenanceActive ? (
+            <MaintenancePage 
+              onRefresh={() => refetchSystemStatus()}
+              isRefreshing={isSystemStatusLoading}
             />
           ) : (
-            <HomePage
-              ref={homePageRef}
-              onMenuPress={pageNav.openDrawer}
-              chat={chat}
-              isAuthenticated={canSendMessages}
-              onOpenWorkerConfig={handleOpenWorkerConfigFromAgentDrawer}
-              showThreadListView={false}
-            />
+            <>
+              {chat.hasActiveThread ? (
+                <ThreadPage
+                  onMenuPress={pageNav.openDrawer}
+                  chat={chat}
+                  isAuthenticated={canSendMessages}
+                  onOpenWorkerConfig={handleOpenWorkerConfigFromAgentDrawer}
+                />
+              ) : (
+                <View className="flex-1">
+                  <HomePage
+                    ref={homePageRef}
+                    onMenuPress={pageNav.openDrawer}
+                    chat={chat}
+                    isAuthenticated={canSendMessages}
+                    onOpenWorkerConfig={handleOpenWorkerConfigFromAgentDrawer}
+                    showThreadListView={false}
+                  />
+                  {(isMaintenanceScheduled || (systemStatus?.technicalIssue?.enabled && systemStatus.technicalIssue.message)) && (
+                    <View style={{ position: 'absolute', top: insets.top + 60, left: 0, right: 0 }}>
+                      {isMaintenanceScheduled && systemStatus?.maintenanceNotice?.startTime && systemStatus.maintenanceNotice.endTime && (
+                        <MaintenanceBanner
+                          startTime={systemStatus.maintenanceNotice.startTime}
+                          endTime={systemStatus.maintenanceNotice.endTime}
+                          updatedAt={systemStatus.updatedAt}
+                        />
+                      )}
+                      {systemStatus?.technicalIssue?.enabled && systemStatus.technicalIssue.message && (
+                        <TechnicalIssueBanner
+                          message={systemStatus.technicalIssue.message}
+                          statusUrl={systemStatus.technicalIssue.statusUrl}
+                          description={systemStatus.technicalIssue.description}
+                          estimatedResolution={systemStatus.technicalIssue.estimatedResolution}
+                          severity={systemStatus.technicalIssue.severity}
+                          affectedServices={systemStatus.technicalIssue.affectedServices}
+                          updatedAt={systemStatus.updatedAt}
+                        />
+                      )}
+                    </View>
+                  )}
+                </View>
+              )}
+            </>
           )}
         </View>
       </Drawer>

--- a/apps/mobile/components/status/AlertBanner.tsx
+++ b/apps/mobile/components/status/AlertBanner.tsx
@@ -1,0 +1,143 @@
+import React, { useState, useEffect } from 'react';
+import { View, Pressable, Linking } from 'react-native';
+import { Text } from '@/components/ui/text';
+import { Icon } from '@/components/ui/icon';
+import { X, ExternalLink, LucideIcon } from 'lucide-react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import Animated, { FadeIn, FadeOut } from 'react-native-reanimated';
+
+export type AlertBannerVariant = 'warning' | 'error' | 'info';
+
+interface AlertBannerProps {
+  title: string;
+  message?: string;
+  variant?: AlertBannerVariant;
+  icon: LucideIcon;
+  dismissKey: string;
+  statusUrl?: string;
+  countdown?: string;
+  onDismiss?: () => void;
+}
+
+const variantStyles: Record<AlertBannerVariant, {
+  bg: string;
+  border: string;
+  textColor: string;
+  iconColor: string;
+}> = {
+  warning: {
+    bg: 'bg-muted',
+    border: 'border-muted',
+    textColor: 'text-foreground',
+    iconColor: 'text-amber-500',
+  },
+  error: {
+    bg: 'bg-muted',
+    border: 'border-muted',
+    textColor: 'text-foreground',
+    iconColor: 'text-red-500',
+  },
+  info: {
+    bg: 'bg-muted',
+    border: 'border-muted',
+    textColor: 'text-foreground',
+    iconColor: 'text-blue-500',
+  },
+};
+
+export function AlertBanner({
+  title,
+  message,
+  variant = 'warning',
+  icon: IconComponent,
+  dismissKey,
+  statusUrl,
+  countdown,
+  onDismiss,
+}: AlertBannerProps) {
+  const [isDismissed, setIsDismissed] = useState(false);
+  const [isMounted, setIsMounted] = useState(false);
+
+  const storageKey = `alert-dismissed-${dismissKey}`;
+
+  useEffect(() => {
+    setIsMounted(true);
+    AsyncStorage.getItem(storageKey).then((value) => {
+      if (value === 'true') {
+        setIsDismissed(true);
+      }
+    }).catch(() => {});
+  }, [storageKey]);
+
+  const handleDismiss = async () => {
+    setIsDismissed(true);
+    try {
+      await AsyncStorage.setItem(storageKey, 'true');
+    } catch {}
+    onDismiss?.();
+  };
+
+  const handleStatusPress = () => {
+    if (statusUrl) {
+      const url = statusUrl.startsWith('http') ? statusUrl : `https://kortix.ai${statusUrl}`;
+      Linking.openURL(url).catch(() => {});
+    }
+  };
+
+  if (!isMounted || isDismissed) {
+    return null;
+  }
+
+  const styles = variantStyles[variant];
+
+  return (
+    <Animated.View
+      entering={FadeIn.duration(200)}
+      exiting={FadeOut.duration(150)}
+    >
+      <View className={`mx-4 rounded-xl border p-3 ${styles.bg} ${styles.border}`}>
+        <View className="flex-row items-center gap-2">
+          <Icon as={IconComponent} size={16} className={styles.iconColor} />
+          
+          <View className="flex-1 flex-row items-center gap-2 flex-wrap">
+            <Text className={`font-roobert-medium text-sm ${styles.textColor}`}>
+              {title}
+            </Text>
+            {countdown && (
+              <>
+                <Text className={`text-sm ${styles.textColor}`}>•</Text>
+                <Text className={`text-sm ${styles.textColor}`}>{countdown}</Text>
+              </>
+            )}
+          </View>
+          
+          <Pressable
+            onPress={handleDismiss}
+            hitSlop={8}
+            className="h-6 w-6 items-center justify-center rounded-full"
+          >
+            <Icon as={X} size={12} className={styles.textColor} />
+          </Pressable>
+        </View>
+
+        {message && (
+          <Text className={`mt-1.5 ml-6 text-xs ${styles.textColor} opacity-80`}>
+            {message}
+          </Text>
+        )}
+
+        {statusUrl && (
+          <Pressable
+            onPress={handleStatusPress}
+            className="mt-2 ml-6 flex-row items-center gap-1"
+          >
+            <Text className={`font-roobert-medium text-xs ${styles.textColor}`}>
+              View Status
+            </Text>
+            <Icon as={ExternalLink} size={10} className={styles.textColor} />
+          </Pressable>
+        )}
+      </View>
+    </Animated.View>
+  );
+}

--- a/apps/mobile/components/status/MaintenanceBanner.tsx
+++ b/apps/mobile/components/status/MaintenanceBanner.tsx
@@ -1,133 +1,86 @@
 import React, { useState, useEffect } from 'react';
-import { View, Pressable } from 'react-native';
-import { Text } from '@/components/ui/text';
-import { Icon } from '@/components/ui/icon';
-import { AlertCircle, X, Info } from 'lucide-react-native';
-import AsyncStorage from '@react-native-async-storage/async-storage';
+import { AlertCircle } from 'lucide-react-native';
+import { AlertBanner } from './AlertBanner';
 
 interface MaintenanceBannerProps {
   startTime: string;
   endTime: string;
+  updatedAt?: string;
 }
 
-export function MaintenanceBanner({ startTime, endTime }: MaintenanceBannerProps) {
-  const [timeDisplay, setTimeDisplay] = useState<string>('');
-  const [isMaintenanceActive, setIsMaintenanceActive] = useState(false);
-  const [isDismissed, setIsDismissed] = useState(false);
-  const [isMounted, setIsMounted] = useState(false);
-
-  const maintenanceKey = `maintenance-dismissed-${startTime}-${endTime}`;
-
-  useEffect(() => {
-    setIsMounted(true);
-    AsyncStorage.getItem(maintenanceKey).then((value) => {
-      if (value === 'true') {
-        setIsDismissed(true);
-      }
-    });
-  }, [maintenanceKey]);
+export function MaintenanceBanner({ startTime, endTime, updatedAt }: MaintenanceBannerProps) {
+  const [countdown, setCountdown] = useState<string>('');
+  const [isActive, setIsActive] = useState(false);
+  const [isOver, setIsOver] = useState(false);
 
   useEffect(() => {
     const updateCountdown = () => {
-      const now = new Date();
-      const start = new Date(startTime);
-      const end = new Date(endTime);
+      try {
+        const now = new Date();
+        const start = new Date(startTime);
+        const end = new Date(endTime);
 
-      if (now >= start && now <= end) {
-        setIsMaintenanceActive(true);
-        const diffToEnd = end.getTime() - now.getTime();
-
-        if (diffToEnd <= 0) {
-          setTimeDisplay('Maintenance completed');
+        if (isNaN(start.getTime()) || isNaN(end.getTime())) {
+          setIsOver(true);
           return;
         }
 
-        const hours = Math.floor(diffToEnd / (1000 * 60 * 60));
-        const minutes = Math.floor((diffToEnd % (1000 * 60 * 60)) / (1000 * 60));
-
-        if (hours > 0) {
-          setTimeDisplay(`${hours}h ${minutes}m remaining`);
-        } else {
-          setTimeDisplay(`${minutes}m remaining`);
-        }
-      } else if (now < start) {
-        setIsMaintenanceActive(false);
-        const diffToStart = start.getTime() - now.getTime();
-
-        if (diffToStart <= 0) {
-          setTimeDisplay('starting now');
+        if (now > end) {
+          setIsOver(true);
           return;
         }
 
-        const days = Math.floor(diffToStart / (1000 * 60 * 60 * 24));
-        const hours = Math.floor((diffToStart % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
-        const minutes = Math.floor((diffToStart % (1000 * 60 * 60)) / (1000 * 60));
+        if (now >= start && now <= end) {
+          setIsActive(true);
+          const diffToEnd = end.getTime() - now.getTime();
+          const hours = Math.floor(diffToEnd / (1000 * 60 * 60));
+          const minutes = Math.floor((diffToEnd % (1000 * 60 * 60)) / (1000 * 60));
 
-        if (days > 0) {
-          setTimeDisplay(`starting in ${days}d ${hours}h`);
-        } else if (hours > 0) {
-          setTimeDisplay(`starting in ${hours}h ${minutes}m`);
-        } else {
-          setTimeDisplay(`starting in ${minutes}m`);
+          if (hours > 0) {
+            setCountdown(`${hours}h ${minutes}m remaining`);
+          } else if (minutes > 0) {
+            setCountdown(`${minutes}m remaining`);
+          } else {
+            setCountdown('ending soon');
+          }
+        } else if (now < start) {
+          setIsActive(false);
+          const diffToStart = start.getTime() - now.getTime();
+          const days = Math.floor(diffToStart / (1000 * 60 * 60 * 24));
+          const hours = Math.floor((diffToStart % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
+          const minutes = Math.floor((diffToStart % (1000 * 60 * 60)) / (1000 * 60));
+
+          if (days > 0) {
+            setCountdown(`in ${days}d ${hours}h`);
+          } else if (hours > 0) {
+            setCountdown(`in ${hours}h ${minutes}m`);
+          } else if (minutes > 0) {
+            setCountdown(`in ${minutes}m`);
+          } else {
+            setCountdown('starting soon');
+          }
         }
-      } else {
-        setTimeDisplay('');
+      } catch {
+        setIsOver(true);
       }
     };
 
     updateCountdown();
-    const interval = setInterval(updateCountdown, 60000);
+    const interval = setInterval(updateCountdown, 30000);
     return () => clearInterval(interval);
   }, [startTime, endTime]);
 
-  const handleDismiss = async () => {
-    setIsDismissed(true);
-    await AsyncStorage.setItem(maintenanceKey, 'true');
-  };
-
-  const now = new Date();
-  const end = new Date(endTime);
-
-  if (!isMounted || now > end || isDismissed) {
+  if (isOver || isActive) {
     return null;
   }
 
-  const getBgColor = () => {
-    return isMaintenanceActive 
-      ? 'bg-orange-500/10 border-orange-500/30'
-      : 'bg-amber-500/10 border-amber-500/30';
-  };
-
-  const getTextColor = () => {
-    return isMaintenanceActive ? 'text-orange-400' : 'text-amber-400';
-  };
-
   return (
-    <View className={`mx-4 mb-4 rounded-xl border p-3 ${getBgColor()}`}>
-      <View className="flex-row items-center gap-2">
-        <Icon as={AlertCircle} size={16} className={getTextColor()} />
-        
-        <View className="flex-1 flex-row items-center gap-2">
-          <Text className={`font-roobert-medium text-sm ${getTextColor()}`}>
-            {isMaintenanceActive 
-              ? 'Scheduled maintenance in progress'
-              : 'Scheduled maintenance'}
-          </Text>
-          {timeDisplay && (
-            <>
-              <Text className={`text-sm ${getTextColor()}`}>•</Text>
-              <Text className={`text-sm ${getTextColor()}`}>{timeDisplay}</Text>
-            </>
-          )}
-        </View>
-        
-        <Pressable
-          onPress={handleDismiss}
-          className="h-6 w-6 items-center justify-center rounded-full"
-        >
-          <Icon as={X} size={12} className={getTextColor()} />
-        </Pressable>
-      </View>
-    </View>
+    <AlertBanner
+      title="Scheduled maintenance"
+      variant="warning"
+      icon={AlertCircle}
+      dismissKey={`maintenance-${startTime}-${updatedAt || endTime}`}
+      countdown={countdown}
+    />
   );
 }

--- a/apps/mobile/components/status/MaintenancePage.tsx
+++ b/apps/mobile/components/status/MaintenancePage.tsx
@@ -5,6 +5,7 @@ import { Icon } from '@/components/ui/icon';
 import { KortixLoader } from '@/components/ui/kortix-loader';
 import { KortixLogo } from '@/components/ui/KortixLogo';
 import { RefreshCw } from 'lucide-react-native';
+import { useColorScheme } from 'nativewind';
 
 interface MaintenancePageProps {
   onRefresh?: () => void;
@@ -12,10 +13,13 @@ interface MaintenancePageProps {
 }
 
 export function MaintenancePage({ onRefresh, isRefreshing = false }: MaintenancePageProps) {
+  const { colorScheme } = useColorScheme();
+  const isDark = colorScheme === 'dark';
+
   return (
     <View className="flex-1 items-center justify-center bg-background px-6">
       <View className="w-full max-w-sm items-center">
-        <KortixLogo size={32} />
+        <KortixLogo size={32} color={isDark ? 'dark' : 'light'} />
         
         <Text className="mt-8 text-center font-roobert-semibold text-3xl text-foreground">
           We'll Be Right Back

--- a/apps/mobile/components/status/TechnicalIssueBanner.tsx
+++ b/apps/mobile/components/status/TechnicalIssueBanner.tsx
@@ -1,13 +1,6 @@
-import React, { useState, useEffect } from 'react';
-import { View, Pressable, Linking } from 'react-native';
-import { Text } from '@/components/ui/text';
-import { Icon } from '@/components/ui/icon';
-import { AlertTriangle, X, ExternalLink } from 'lucide-react-native';
-import AsyncStorage from '@react-native-async-storage/async-storage';
-import Animated, { 
-  FadeInDown,
-  FadeOutDown,
-} from 'react-native-reanimated';
+import React from 'react';
+import { AlertTriangle } from 'lucide-react-native';
+import { AlertBanner } from './AlertBanner';
 
 interface TechnicalIssueBannerProps {
   message: string;
@@ -16,119 +9,26 @@ interface TechnicalIssueBannerProps {
   estimatedResolution?: string;
   severity?: 'degraded' | 'outage' | 'maintenance';
   affectedServices?: string[];
+  updatedAt?: string;
 }
 
 export function TechnicalIssueBanner({
   message,
   statusUrl,
-  description,
-  estimatedResolution,
-  severity = 'degraded',
-  affectedServices,
+  updatedAt,
 }: TechnicalIssueBannerProps) {
-  const [isDismissed, setIsDismissed] = useState(false);
-  const [isMounted, setIsMounted] = useState(false);
-
-  const dismissKey = `technical-issue-dismissed-${message}`;
-
-  useEffect(() => {
-    setIsMounted(true);
-    AsyncStorage.getItem(dismissKey).then((value) => {
-      if (value === 'true') {
-        setIsDismissed(true);
-      }
-    });
-  }, [dismissKey]);
-
-  const handleDismiss = async () => {
-    setIsDismissed(true);
-    await AsyncStorage.setItem(dismissKey, 'true');
-  };
-
-  const handleStatusPress = () => {
-    if (statusUrl) {
-      Linking.openURL(statusUrl).catch(console.warn);
-    }
-  };
-
-  if (!isMounted || isDismissed) {
-    return null;
-  }
-
-  const getSeverityColor = () => {
-    switch (severity) {
-      case 'outage':
-        return 'bg-destructive/10 border-destructive/30';
-      case 'maintenance':
-        return 'bg-amber-500/10 border-amber-500/30';
-      default:
-        return 'bg-orange-500/10 border-orange-500/30';
-    }
-  };
+  const dismissKey = updatedAt 
+    ? `technical-issue-${updatedAt}` 
+    : `technical-issue-${message.slice(0, 20)}`;
 
   return (
-    <Animated.View
-      entering={FadeInDown.duration(300)}
-      exiting={FadeOutDown.duration(200)}
-      className="mx-4 mb-4"
-    >
-      <View className={`rounded-2xl border p-4 ${getSeverityColor()}`}>
-        <Pressable
-          onPress={handleDismiss}
-          className="absolute right-2 top-2 z-10 h-6 w-6 items-center justify-center rounded-full bg-background/50"
-        >
-          <Icon as={X} size={12} className="text-foreground" />
-        </Pressable>
-
-        <View className="flex-row items-start gap-3 pr-6">
-          <View className="h-10 w-10 items-center justify-center rounded-xl bg-destructive/20 border border-destructive/30">
-            <Icon as={AlertTriangle} size={20} className="text-destructive" />
-          </View>
-          
-          <View className="flex-1">
-            <Text className="font-roobert-semibold text-sm text-foreground">
-              Technical Issue
-            </Text>
-            <Text className="mt-0.5 text-xs text-muted-foreground leading-relaxed">
-              {message}
-            </Text>
-            
-            {description && (
-              <Text className="mt-2 text-xs text-muted-foreground leading-relaxed">
-                {description}
-              </Text>
-            )}
-            
-            {affectedServices && affectedServices.length > 0 && (
-              <View className="mt-2 flex-row flex-wrap gap-1">
-                {affectedServices.map((service, index) => (
-                  <View key={index} className="rounded-md bg-muted px-2 py-0.5">
-                    <Text className="text-xs text-muted-foreground">{service}</Text>
-                  </View>
-                ))}
-              </View>
-            )}
-            
-            {estimatedResolution && (
-              <Text className="mt-2 text-xs text-muted-foreground">
-                Est. resolution: {estimatedResolution}
-              </Text>
-            )}
-            
-            {statusUrl && (
-              <Pressable
-                onPress={handleStatusPress}
-                className="mt-3 flex-row items-center gap-1"
-              >
-                <Text className="font-roobert-medium text-xs text-foreground">
-                  View Status
-                </Text>
-                <Icon as={ExternalLink} size={12} className="text-foreground" />
-              </Pressable>
-            )}
-          </View>
-        </View>
-      </View>
-    </Animated.View>
+    <AlertBanner
+      title="Technical Issue"
+      message={message}
+      variant="error"
+      icon={AlertTriangle}
+      dismissKey={dismissKey}
+      statusUrl={statusUrl}
+    />
   );
 }

--- a/apps/mobile/components/status/index.ts
+++ b/apps/mobile/components/status/index.ts
@@ -1,3 +1,5 @@
 export { MaintenancePage } from './MaintenancePage';
 export { MaintenanceBanner } from './MaintenanceBanner';
 export { TechnicalIssueBanner } from './TechnicalIssueBanner';
+export { AlertBanner } from './AlertBanner';
+export type { AlertBannerVariant } from './AlertBanner';

--- a/apps/mobile/hooks/useSystemStatus.ts
+++ b/apps/mobile/hooks/useSystemStatus.ts
@@ -20,6 +20,7 @@ export interface TechnicalIssue {
 export interface SystemStatus {
   maintenanceNotice: MaintenanceNotice;
   technicalIssue: TechnicalIssue;
+  updatedAt?: string;
 }
 
 async function fetchSystemStatus(): Promise<SystemStatus> {
@@ -44,9 +45,10 @@ export function useSystemStatus() {
   return useQuery<SystemStatus>({
     queryKey: ['system-status'],
     queryFn: fetchSystemStatus,
-    staleTime: 5 * 60 * 1000,
-    refetchInterval: 5 * 60 * 1000,
-    refetchOnWindowFocus: false,
+    staleTime: 30 * 1000,
+    refetchInterval: 60 * 1000,
+    refetchOnWindowFocus: true,
+    refetchOnMount: 'always',
     retry: 3,
     placeholderData: {
       maintenanceNotice: { enabled: false },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces a dedicated maintenance experience and consolidates status alerts.
> 
> - Adds `MaintenancePage` and shows it in `home.tsx` when maintenance is active; otherwise overlays scheduled maintenance and technical issue banners only on the Home view
> - Introduces reusable `AlertBanner` and refactors `MaintenanceBanner` and `TechnicalIssueBanner` to use it (with dismiss persistence and optional status link)
> - Updates `useSystemStatus` to include `updatedAt`, reduce `staleTime` to 30s, set `refetchInterval` to 60s, and enable focus/mount refetching
> - Adjusts `home.tsx` layout (safe-area insets, conditional banners, updated props) and updates `status/index.ts` exports
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 66b9eac7281b81763ecaade791cffe81cb7e5861. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->