### PR TITLE
minor fix

### DIFF
--- a/backend/core/agentpress/context_manager.py
+++ b/backend/core/agentpress/context_manager.py
@@ -128,7 +128,7 @@ class ContextManager:
         messages_to_count = messages
         system_to_count = system_prompt
         
-        if apply_caching and ('claude' in model.lower() or 'anthropic' in model.lower()):
+        if apply_caching and ('claude' in model.lower() or 'anthropic' in model.lower() or 'bedrock' in model.lower()):
             try:
                 # Temporarily apply caching transformation
                 prepared = await apply_anthropic_caching_strategy(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Ensures token counting matches actual API payloads for Bedrock models.
> 
> - Broadens `apply_caching` condition in `ContextManager.count_tokens` to include models containing `bedrock` (previously only `claude`/`anthropic`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b3de3ef532345f52432cda1c822d14619251fde5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->