### PR TITLE
Refactor markdown styles to allow font inheritance for text elements

### DIFF
--- a/apps/mobile/components/ui/selectable-markdown.tsx
+++ b/apps/mobile/components/ui/selectable-markdown.tsx
@@ -349,11 +349,11 @@ const createAndroidMarkdownStyles = (isDark: boolean) => StyleSheet.create({
   },
   text: {
     color: isDark ? '#fafafa' : '#18181b',
-    fontFamily: 'Roobert-Regular',
+    // Don't set fontFamily here - let it inherit from parent (strong, em, etc.)
   },
   textgroup: {
     color: isDark ? '#fafafa' : '#18181b',
-    fontFamily: 'Roobert-Regular',
+    // Don't set fontFamily here - let children inherit from their specific styles (strong, em, etc.)
   },
   paragraph: {
     marginVertical: 0,
@@ -362,6 +362,7 @@ const createAndroidMarkdownStyles = (isDark: boolean) => StyleSheet.create({
   },
   strong: {
     fontFamily: 'Roobert-SemiBold',
+    fontWeight: '600',
   },
   em: {
     fontStyle: 'italic',


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refines Android markdown styling in `selectable-markdown.tsx` to improve typography consistency.
> 
> - Remove explicit `fontFamily` from `text` and `textgroup` so they inherit from parent styles (e.g., `strong`, `em`)
> - Add `fontWeight: '600'` to `strong` to ensure proper bold rendering on Android
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0ae5a620fd0872c40bd24abeac74ff1c12223e6b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->