### PR TITLE
fix conflict

### DIFF
--- a/backend/core/agentpress/context_manager.py
+++ b/backend/core/agentpress/context_manager.py
@@ -15,7 +15,7 @@ from anthropic import Anthropic
 from core.services.supabase import DBConnection
 from core.utils.logger import logger
 from core.ai_models import model_manager
-from core.agentpress.prompt_caching import apply_anthropic_caching_strategy
+from core.agentpress.prompt_caching import apply_anthropic_caching_strategy, supports_prompt_caching
 
 DEFAULT_TOKEN_THRESHOLD = 120000
 
@@ -128,7 +128,7 @@ class ContextManager:
         messages_to_count = messages
         system_to_count = system_prompt
         
-        if apply_caching and ('claude' in model.lower() or 'anthropic' in model.lower() or 'bedrock' in model.lower()):
+        if apply_caching and supports_prompt_caching(model):
             try:
                 # Temporarily apply caching transformation
                 prepared = await apply_anthropic_caching_strategy(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Aligns token counting with centralized prompt-caching capability detection.
> 
> - Import `supports_prompt_caching` and use it to decide when to apply caching transformation in `count_tokens`
> - Removes brittle string-based model checks (`'claude'/'anthropic'/'bedrock'`) in favor of the helper
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 970453e54a8881ddd2fe0338c1ae62c127c14a74. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->