### PR TITLE
hide library button

### DIFF
--- a/apps/frontend/src/components/sidebar/sidebar-left.tsx
+++ b/apps/frontend/src/components/sidebar/sidebar-left.tsx
@@ -377,7 +377,7 @@ export function SidebarLeft({
           <div className="w-full flex flex-col items-center space-y-3">
             {[
               { view: 'chats' as const, icon: MessageCircle },
-              { view: 'library' as const, icon: Library },
+              // { view: 'library' as const, icon: Library },
               { view: 'workers' as const, icon: Users },
               { view: 'starred' as const, icon: Zap },
             ].map(({ view, icon: Icon }) => (
@@ -443,7 +443,7 @@ export function SidebarLeft({
             <div className="flex justify-between items-center gap-2">
               {[
                 { view: 'chats' as const, icon: MessageCircle, label: t('chats') },
-                { view: 'library' as const, icon: Library, label: t('library') },
+                // { view: 'library' as const, icon: Library, label: t('library') },
                 { view: 'workers' as const, icon: Users, label: 'Workers' },
                 { view: 'starred' as const, icon: Zap, label: t('triggers') }
               ].map(({ view, icon: Icon, label }) => (


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Removes the Library navigation entry from `sidebar-left.tsx` so it no longer appears in the sidebar buttons.
> 
> - Comments out the `library` item in the state button lists for both collapsed and expanded views, leaving Chats, Workers, and Triggers visible.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ca5e9d5caaa557d954519dd4b70dc8df29f167e9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->