### PR TITLE
aggressive compression + batch update

### DIFF
--- a/backend/core/agentpress/context_manager.py
+++ b/backend/core/agentpress/context_manager.py
@@ -973,7 +973,8 @@ class ContextManager:
                         if _i > self.keep_recent_user_messages:  # If this is not one of the most recent N User messages
                             message_id = msg.get('message_id')  # Get the message_id
                             if message_id:
-                                msg["content"] = self.compress_message(msg["content"], message_id, token_threshold * 3)
+                                # Secondary compression - just placeholder
+                                msg["content"] = f"[Content compressed]\n\nmessage_id \"{message_id}\"\nUse expand-message tool to see contents"
                             else:
                                 logger.warning(f"UNEXPECTED: Message has no message_id {str(msg)[:100]}")
                         else:
@@ -1003,7 +1004,8 @@ class ContextManager:
                         if _i > self.keep_recent_assistant_messages:  # If this is not one of the most recent N Assistant messages
                             message_id = msg.get('message_id')  # Get the message_id
                             if message_id:
-                                msg["content"] = self.compress_message(msg["content"], message_id, token_threshold * 3)
+                                # Secondary compression - just placeholder
+                                msg["content"] = f"[Content compressed]\n\nmessage_id \"{message_id}\"\nUse expand-message tool to see contents"
                             else:
                                 logger.warning(f"UNEXPECTED: Message has no message_id {str(msg)[:100]}")
                         else:
@@ -1150,8 +1152,8 @@ class ContextManager:
 
         # Recurse if still too large
         if max_iterations <= 0:
-            logger.warning(f"Max iterations reached, omitting messages")
-            result = await self.compress_messages_by_omitting_messages(result, llm_model, max_tokens, system_prompt=system_prompt)
+            logger.warning(f"Max iterations reached, omitting messages to target ({target_tokens})")
+            result = await self.compress_messages_by_omitting_messages(result, llm_model, target_tokens, system_prompt=system_prompt)
             compressed_total = await self.count_tokens(llm_model, result, system_prompt, apply_caching=True)
             # Fall through to last_usage update
         elif compressed_total > max_tokens:
@@ -1318,6 +1320,25 @@ class ContextManager:
             if omitted_to_save:
                 try:
                     await self.save_compressed_messages(omitted_to_save)
+                    
+                    # Also mark any tool results belonging to omitted assistant messages
+                    # This handles the case where tool results were compressed separately
+                    omitted_tool_call_ids = []
+                    for msg in all_omitted_messages:
+                        if msg.get('tool_calls'):
+                            for tc in msg['tool_calls']:
+                                tc_id = tc.get('id')
+                                if tc_id:
+                                    omitted_tool_call_ids.append(tc_id)
+                    
+                    if omitted_tool_call_ids and self.thread_id:
+                        from core.threads import repo as threads_repo
+                        marked_count = await threads_repo.mark_tool_results_as_omitted(
+                            self.thread_id, 
+                            omitted_tool_call_ids
+                        )
+                        if marked_count > 0:
+                            logger.info(f"📝 Also marked {marked_count} orphaned tool results as omitted")
                 except Exception as e:
                     logger.warning(f"Failed to save omitted messages: {e}")
 
@@ -1415,6 +1436,25 @@ class ContextManager:
             if omitted_to_save:
                 try:
                     await self.save_compressed_messages(omitted_to_save)
+                    
+                    # Also mark any tool results belonging to omitted assistant messages
+                    omitted_tool_call_ids = []
+                    for group in removed_groups:
+                        for msg in group:
+                            if msg.get('tool_calls'):
+                                for tc in msg['tool_calls']:
+                                    tc_id = tc.get('id')
+                                    if tc_id:
+                                        omitted_tool_call_ids.append(tc_id)
+                    
+                    if omitted_tool_call_ids and self.thread_id:
+                        from core.threads import repo as threads_repo
+                        marked_count = await threads_repo.mark_tool_results_as_omitted(
+                            self.thread_id, 
+                            omitted_tool_call_ids
+                        )
+                        if marked_count > 0:
+                            logger.info(f"📝 Also marked {marked_count} orphaned tool results as omitted")
                 except Exception as e:
                     logger.warning(f"Failed to save middle-out omitted messages: {e}")
         

--- a/backend/core/agentpress/thread_manager.py
+++ b/backend/core/agentpress/thread_manager.py
@@ -671,11 +671,8 @@ class ThreadManager:
                         # Use fast path if we have usage data
                         if usage:
                             last_total_tokens = int(usage.get('total_tokens', 0))
-                            
-                            cache_creation = int(usage.get("cache_creation_input_tokens", 0) or 0)
-                            if cache_creation > 0:
-                                last_total_tokens += cache_creation
-                                logger.debug(f"Added {cache_creation} cache creation tokens to fast check total")
+                            # Note: cache_creation_input_tokens is NOT added here - it's a billing metric,
+                            # not actual context window usage. The context window is just prompt_tokens.
                             
                             new_msg_tokens = 0
                             

--- a/backend/core/threads/repo.py
+++ b/backend/core/threads/repo.py
@@ -663,17 +663,11 @@ async def get_llm_messages(
         sql = """
         SELECT message_id, type, content, metadata
         FROM messages
-        WHERE thread_id = :thread_id AND is_llm_message = true
+        WHERE thread_id = :thread_id 
+          AND is_llm_message = true
+          AND (metadata->>'omitted' IS NULL OR metadata->>'omitted' != 'true')
         ORDER BY created_at ASC
         """
-        if limit:
-            sql = sql.replace("ORDER BY", f"ORDER BY created_at ASC LIMIT {limit} ORDER BY")
-            sql = f"""
-            SELECT message_id, type, content, metadata
-            FROM messages
-            WHERE thread_id = :thread_id AND is_llm_message = true
-            ORDER BY created_at ASC
-            """
         rows = await execute(sql, {"thread_id": thread_id})
     
     return [dict(row) for row in rows] if rows else []
@@ -687,7 +681,9 @@ async def get_llm_messages_paginated(
     sql = """
     SELECT message_id, type, content, metadata
     FROM messages
-    WHERE thread_id = :thread_id AND is_llm_message = true
+    WHERE thread_id = :thread_id 
+      AND is_llm_message = true
+      AND (metadata->>'omitted' IS NULL OR metadata->>'omitted' != 'true')
     ORDER BY created_at ASC
     LIMIT :limit OFFSET :offset
     """
@@ -931,25 +927,128 @@ async def save_compressed_message(
 
 
 async def save_compressed_messages_batch(
-    compressed_messages: List[Dict[str, Any]]
+    compressed_messages: List[Dict[str, Any]],
+    batch_size: int = 500
 ) -> int:
+    """Save compressed message content to database metadata in batch.
+    
+    Uses a single SQL UPDATE with VALUES clause for efficiency.
+    For 400 messages, this is 1 DB call instead of 800 (2 per message).
+    
+    Args:
+        compressed_messages: List of dicts with 'message_id', 'compressed_content', and optional 'is_omission'
+        batch_size: Max messages per SQL statement (default 500 to avoid very long queries)
+        
+    Returns:
+        Number of messages successfully saved
+    """
+    from core.services.db import execute_mutate
+    
     if not compressed_messages:
         return 0
     
-    saved_count = 0
-    for msg_data in compressed_messages:
-        message_id = msg_data.get("message_id")
-        compressed_content = msg_data.get("compressed_content")
-        is_omission = msg_data.get("is_omission", False)
-        
-        if message_id and compressed_content:
-            try:
-                await save_compressed_message(message_id, compressed_content, is_omission)
-                saved_count += 1
-            except Exception as e:
-                logger.warning(f"Failed to save compressed message {message_id}: {e}")
+    # Filter valid entries
+    valid = [
+        (m['message_id'], m['compressed_content'], m.get('is_omission', False)) 
+        for m in compressed_messages 
+        if m.get('message_id') and m.get('compressed_content')
+    ]
     
-    return saved_count
+    if not valid:
+        return 0
+    
+    total_saved = 0
+    
+    # Process in batches to avoid very long SQL statements
+    for batch_start in range(0, len(valid), batch_size):
+        batch = valid[batch_start:batch_start + batch_size]
+        
+        # Build VALUES clause dynamically
+        # Note: Can't use ::uuid cast in VALUES because SQLAlchemy confuses :: with param syntax
+        # Instead, cast in the WHERE clause comparison
+        values_parts = []
+        params = {}
+        for i, (msg_id, content, is_omit) in enumerate(batch):
+            values_parts.append(f"(:id_{i}, :content_{i}, :omit_{i})")
+            params[f'id_{i}'] = msg_id
+            params[f'content_{i}'] = content
+            params[f'omit_{i}'] = is_omit
+        
+        # Single UPDATE with all values - merges into existing metadata
+        # Cast data.id to uuid in WHERE clause to avoid SQLAlchemy param parsing issues
+        sql = f"""
+        UPDATE messages m
+        SET 
+            metadata = COALESCE(m.metadata, '{{}}'::jsonb) 
+                || jsonb_build_object(
+                    'compressed', true,
+                    'compressed_content', data.compressed_content,
+                    'omitted', data.is_omission
+                ),
+            updated_at = NOW()
+        FROM (VALUES {', '.join(values_parts)}) AS data(id, compressed_content, is_omission)
+        WHERE m.message_id = data.id::uuid  -- Cast string to uuid for comparison
+        """
+        
+        try:
+            await execute_mutate(sql, params)
+            total_saved += len(batch)
+        except Exception as e:
+            logger.warning(f"Failed to save compressed messages batch: {e}")
+            # Fallback to individual saves for this batch
+            for msg_id, content, is_omit in batch:
+                try:
+                    await save_compressed_message(msg_id, content, is_omit)
+                    total_saved += 1
+                except Exception as e2:
+                    logger.warning(f"Failed to save compressed message {msg_id}: {e2}")
+    
+    return total_saved
+
+
+async def mark_tool_results_as_omitted(thread_id: str, tool_call_ids: List[str]) -> int:
+    """Mark tool result messages as omitted when their parent assistant message is omitted.
+    
+    This handles the case where tool results were compressed separately from their
+    parent assistant message, and the assistant was later omitted.
+    
+    Args:
+        thread_id: The thread ID
+        tool_call_ids: List of tool_call_ids whose tool results should be marked as omitted
+        
+    Returns:
+        Number of messages marked as omitted
+    """
+    from core.services.db import execute_mutate
+    
+    if not tool_call_ids:
+        return 0
+    
+    # Build the SQL to find and update tool results with matching tool_call_ids
+    # Tool results have content->'tool_call_id' matching one of the IDs
+    placeholders = ', '.join([f':id_{i}' for i in range(len(tool_call_ids))])
+    params = {'thread_id': thread_id}
+    for i, tc_id in enumerate(tool_call_ids):
+        params[f'id_{i}'] = tc_id
+    
+    sql = f"""
+    UPDATE messages
+    SET 
+        metadata = COALESCE(metadata, '{{}}'::jsonb) || '{{"omitted": true}}'::jsonb,
+        updated_at = NOW()
+    WHERE thread_id = :thread_id
+      AND is_llm_message = true
+      AND content->>'tool_call_id' IN ({placeholders})
+      AND (metadata->>'omitted' IS NULL OR metadata->>'omitted' != 'true')
+    RETURNING message_id
+    """
+    
+    try:
+        result = await execute_mutate(sql, params)
+        return len(result) if result else 0
+    except Exception as e:
+        logger.warning(f"Failed to mark tool results as omitted: {e}")
+        return 0
 
 
 async def get_kb_entry_count(agent_id: str) -> int:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces more aggressive, deterministic context management and DB efficiencies.
> 
> - Compression: Older `user`/`assistant` messages now replaced with a short placeholder (keeps IDs); maintains tiered compression and adds correct target-based omission (`compress_messages_by_omitting_messages` uses `target_tokens`).
> - Omission propagation: When omitting assistant messages with `tool_calls`, also mark corresponding tool result messages as `omitted` via new `threads.repo.mark_tool_results_as_omitted`.
> - Message fetch: `threads.repo.get_llm_messages*` now exclude messages where `metadata.omitted == true` (non-lightweight and paginated paths).
> - Batch persistence: New `threads.repo.save_compressed_messages_batch` updates many messages in one SQL using `VALUES` + `jsonb` merge, with per-item fallback.
> - Token calc fix: Fast-path in `thread_manager` no longer adds `cache_creation_input_tokens` to context-window usage (billing-only metric).
> - Minor: Improved logs and placeholders in `context_manager` for compressed/omitted content and recursion end cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bc61148852744083848ffcfdc9d202bb9cb15627. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->