### PR TITLE
import fix

### DIFF
--- a/apps/frontend/src/components/home/navbar.tsx
+++ b/apps/frontend/src/components/home/navbar.tsx
@@ -13,6 +13,7 @@ import { KortixLogo } from '@/components/sidebar/kortix-logo';
 import { useTranslations } from 'next-intl';
 import { trackCtaSignup } from '@/lib/analytics/gtm';
 import { AppDownloadQR } from '@/components/common/app-download-qr';
+import { isMobileDevice } from '@/lib/utils/is-mobile-device';
 
 // Apple logo SVG
 function AppleLogo({ className }: { className?: string }) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Implements device-aware CTA routing in the homepage navbar.
> 
> - Import and use `isMobileDevice` to set `isMobile` on mount and derive `ctaLink` (`/app` on mobile, `/auth` otherwise)
> - Apply `ctaLink` to both desktop and mobile drawer "Try Free" buttons, preserving analytics tracking
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f6629a60387615ac7326d7afaa8d0b6fd5e17dd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->