### PR TITLE
fix avg duration

### DIFF
--- a/backend/core/admin/analytics_admin_api.py
+++ b/backend/core/admin/analytics_admin_api.py
@@ -2533,8 +2533,8 @@ async def get_task_performance(
             status = run.get('status', 'unknown')
             runs_by_status[status] = runs_by_status.get(status, 0) + 1
             
-            # Calculate duration for completed runs
-            if status == 'completed' and run.get('started_at') and run.get('completed_at'):
+            # Calculate duration for finished runs (completed, failed, stopped)
+            if status in ['completed', 'failed', 'stopped'] and run.get('started_at') and run.get('completed_at'):
                 try:
                     started = datetime.fromisoformat(run['started_at'].replace('Z', '+00:00'))
                     completed = datetime.fromisoformat(run['completed_at'].replace('Z', '+00:00'))


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adjusts task performance averaging to better reflect real run times.
> 
> - In `analytics_admin_api.py` `get_task_performance`, duration is now calculated for all finished runs (`completed`, `failed`, `stopped`) instead of only `completed`, updating `avg_duration_seconds` accordingly
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 70c017d5288dc47750e68d1f6993e3969c7cdbc5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->