### PR TITLE
invalidate redis cache on inserting msg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 .DS_Store
 
+CLAUDE.md
+WARP.md
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Ensures message consumers see up-to-date history after LLM message changes.
> 
> - Adds `_invalidate_message_cache` helper (uses `invalidate_message_history_cache`) with safe logging
> - Triggers invalidation after successful ops in `create_message`, `create_message_full`, `insert_message`, `delete_message`, and `delete_message_by_id` (where applicable)
> - Tiny housekeeping: updates `.gitignore`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5fd33713235a823b62d0bd9c7154dd66cbd0b8d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->