### PR TITLE
fix: remove msg add, send msg with /start

### DIFF
--- a/apps/frontend/src/hooks/threads/use-agent-run.ts
+++ b/apps/frontend/src/hooks/threads/use-agent-run.ts
@@ -27,13 +27,15 @@ export const useAgentRunsQuery = (threadId: string, options?) => {
 
 export const useStartAgentMutation = () => {
   const queryClient = useQueryClient();
-  
+
   return useMutation({
     mutationFn: ({
       threadId,
+      prompt,
       options,
     }: {
       threadId: string;
+      prompt?: string;
       options?: {
         model_name?: string;
         agent_id?: string;
@@ -41,6 +43,7 @@ export const useStartAgentMutation = () => {
       };
     }) => unifiedAgentStart({
       threadId,
+      prompt,
       model_name: options?.model_name && options.model_name.trim() ? options.model_name.trim() : undefined,
       agent_id: options?.agent_id,
       file_ids: options?.file_ids,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Consolidates message send + agent start into a single call and updates hooks/UI accordingly.
> 
> - In `ThreadComponent`, remove `useAddUserMessageMutation`; submit now passes `prompt` to `useStartAgentMutation` (`/agent/start`) to atomically create the user message and start the agent
> - Set `agentRunId` and agent status from mutation result to begin streaming immediately; keep optimistic user message when status becomes `connecting`
> - Stream/error handling refined: handle `BillingError`/`ProjectLimitError` via billing modal, `AgentRunLimitError` via banner; fallback toast on other failures
> - In `useStartAgentMutation`, accept optional `prompt` and forward to `unifiedAgentStart`; continue invalidating `active-agent-runs` on success and only swallow `BillingError` on error
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a77a5b11ade09a271757666f74437bf0333a469d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->