### PR TITLE
fix: remove param new

### DIFF
--- a/apps/frontend/src/hooks/threads/use-optimistic-agent-start.ts
+++ b/apps/frontend/src/hooks/threads/use-optimistic-agent-start.ts
@@ -172,8 +172,8 @@ export function useOptimisticAgentStart(
       }
 
       // Navigate immediately for optimistic UX
-      const modeStarterParam = modeStarter ? `&modeStarter=${modeStarter}` : '';
-      router.push(`/projects/${projectId}/thread/${threadId}?new=true${modeStarterParam}`);
+      const modeStarterParam = modeStarter ? `?modeStarter=${modeStarter}` : '';
+      router.push(`/projects/${projectId}/thread/${threadId}${modeStarterParam}`);
 
       // Start agent in background - only pass file_ids, backend handles everything
       optimisticAgentStart({


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Removes unused `new=true` query param from optimistic navigation and fixes query string composition.
> 
> - Updates `use-optimistic-agent-start.ts` to drop `?new=true` and build `modeStarter` as `?modeStarter=...` directly when present
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fdb4aa2fd408c6d982517db2f73d26d10029e1a2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->