### PR TITLE
increase stream timeout to 300s

### DIFF
--- a/backend/core/services/llm.py
+++ b/backend/core/services/llm.py
@@ -43,7 +43,8 @@ litellm.num_retries = int(os.environ.get("LITELLM_NUM_RETRIES", 1))
 litellm.request_timeout = 1800  # 30 min for long streams
 
 # Stream timeout: max time to wait between stream chunks (prevents indefinite hangs)
-litellm.stream_timeout = int(os.environ.get("LITELLM_STREAM_TIMEOUT", 120))
+# Increased to 300s (5 min) to allow MiniMax reasoning mode to work on complex outputs
+litellm.stream_timeout = int(os.environ.get("LITELLM_STREAM_TIMEOUT", 300))
 
 # Custom callback to track LiteLLM retries and timing
 from litellm.integrations.custom_logger import CustomLogger

--- a/backend/core/tools/agent_builder_tools/credential_profile_tool.py
+++ b/backend/core/tools/agent_builder_tools/credential_profile_tool.py
@@ -236,6 +236,9 @@ After connecting, you'll be able to use {result.toolkit.name} tools in your agen
             new_mcp_config = {
                 'name': profile.toolkit_name,
                 'type': 'composio',
+                'customType': 'composio',
+                'toolkit_slug': profile.toolkit_slug,
+                'mcp_qualified_name': profile.mcp_qualified_name,
                 'config': {
                     'profile_id': profile_id,
                     'toolkit_slug': profile.toolkit_slug,
@@ -388,4 +391,4 @@ After connecting, you'll be able to use {result.toolkit.name} tools in your agen
             })
             
         except Exception as e:
-            return self.fail_response("Error deleting credential profile") 
+            return self.fail_response("Error deleting credential profile")


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Increases LLM streaming tolerance and enriches MCP config for composio integrations.
> 
> - Raises LiteLLM `stream_timeout` default from `120` to `300` seconds to support longer reasoning streams in `backend/core/services/llm.py`
> - Extends credential profile MCP config in `credential_profile_tool.py` with top-level `customType`, `toolkit_slug`, and `mcp_qualified_name` for more explicit composio metadata
> - Minor cleanup in error handling message formatting
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 80ab724eb4925205a6cf09870b659e090001fa99. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->