### PR TITLE
weekly 300 credits

### DIFF
--- a/apps/frontend/src/app/(dashboard)/credits-explained/page.tsx
+++ b/apps/frontend/src/app/(dashboard)/credits-explained/page.tsx
@@ -110,20 +110,20 @@ export default function CreditsPage() {
           </div>
 
           <p className="text-muted-foreground leading-relaxed">
-            Credits fall into two categories: expiring and non-expiring. When you run a task, credits are deducted in this priority order: expiring credits first (daily, then monthly), followed by non-expiring credits.
+            Credits fall into two categories: expiring and non-expiring. When you run a task, credits are deducted in this priority order: expiring credits first (daily/weekly, then monthly), followed by non-expiring credits.
           </p>
 
           {/* Credit Types Visual Grid */}
           <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-            {/* Daily Credits */}
+            {/* Daily / Weekly Credits */}
             <Card className="border-blue-500/20 bg-gradient-to-br from-blue-500/5 to-transparent">
               <CardContent className="pt-5">
                 <div className="flex items-center gap-2 mb-3">
                   <RotateCcw className="h-5 w-5 text-blue-500" />
-                  <h3 className="font-semibold text-foreground">Daily</h3>
+                  <h3 className="font-semibold text-foreground">Daily / Weekly</h3>
                 </div>
                 <p className="text-sm text-muted-foreground">
-                  Refresh every 24 hours. Use it or lose it—these credits reset daily and don't roll over.
+                  Free tier: 300 credits weekly. Paid tiers: 200 credits daily. Use it or lose it—these credits reset and don't roll over.
                 </p>
               </CardContent>
             </Card>
@@ -157,12 +157,12 @@ export default function CreditsPage() {
 
           <div className="space-y-4">
             <div>
-              <h3 className="font-semibold text-foreground mb-3">Expiring credits (Daily + Monthly)</h3>
+              <h3 className="font-semibold text-foreground mb-3">Expiring credits (Daily/Weekly + Monthly)</h3>
               <div className="space-y-3 text-muted-foreground">
                 <div className="flex items-start gap-3">
                   <div className="w-1.5 h-1.5 rounded-full bg-blue-500 mt-2 flex-shrink-0" />
                   <div>
-                    <span className="font-medium text-foreground">Daily credits:</span> Refresh every 24 hours based on your plan. Check your billing page to see when your next refresh happens. Unused daily credits don't roll over.
+                    <span className="font-medium text-foreground">Daily/Weekly credits:</span> Free tier gets 300 credits weekly. Paid tiers get 200 credits daily. Check your billing page to see when your next refresh happens. Unused credits don't roll over.
                   </div>
                 </div>
                 <div className="flex items-start gap-3">
@@ -209,7 +209,7 @@ export default function CreditsPage() {
           <Alert className="border-blue-500/20 bg-blue-500/5">
             <Info className="h-4 w-4" />
             <AlertDescription>
-              <strong>Credit usage priority:</strong> When running tasks, we always use your expiring credits first (daily → monthly) before touching your extra credits. This ensures you get the most value from all your credits.
+              <strong>Credit usage priority:</strong> When running tasks, we always use your expiring credits first (daily/weekly → monthly) before touching your extra credits. This ensures you get the most value from all your credits.
             </AlertDescription>
           </Alert>
         </div>

--- a/apps/frontend/src/lib/pricing-config.ts
+++ b/apps/frontend/src/lib/pricing-config.ts
@@ -42,7 +42,7 @@ export const pricingTiers: PricingTier[] = [
     isPopular: false,
     hours: '0 hours',
     features: [
-      '100 daily credits - Refreshes every 24 hours (applies to all tiers)',
+      '300 weekly credits - Refreshes every 7 days',
       '1 concurrent run',
       '10 Total Chats',
       'Basic Mode - Core Kortix experience with basic autonomy',

--- a/backend/core/billing/shared/config.py
+++ b/backend/core/billing/shared/config.py
@@ -81,8 +81,8 @@ TIERS: Dict[str, Tier] = {
         },
         daily_credit_config={
             'enabled': True,
-            'amount': Decimal('1.00'),
-            'refresh_interval_hours': 24
+            'amount': Decimal('3.00'),
+            'refresh_interval_hours': 168
         },
         monthly_refill_enabled=False
     ),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adjusts free-tier credit cadence and aligns frontend messaging, plus improves observability of the refresh path.
> 
> - Backend: Update `free` tier `daily_credit_config` to `amount=3.00` (300 credits) and `refresh_interval_hours=168` (weekly) in `config.py`
> - Frontend: Update `pricing-config.ts` to show `300 weekly credits`; revise `credits-explained/page.tsx` copy to “Daily/Weekly” with free=weekly(300) and paid=daily(200), including priority text `(daily/weekly → monthly)`
> - Services: Add detailed logging throughout `check_and_refresh_daily_credits` to trace refresh decisions and locking
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 82f3c34b414ea468a178c3cf2632722e6789102a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->