### PR TITLE
refactor: enhance slide handling and previews in tool components

### DIFF
--- a/apps/frontend/src/components/thread/content/ThreadContent.tsx
+++ b/apps/frontend/src/components/thread/content/ThreadContent.tsx
@@ -448,6 +448,7 @@ const AssistantGroupRow = memo(function AssistantGroupRow({
             }
             onToolClick={handleToolClick}
             showExpanded={false}
+            project={project}
             startTime={Date.now()}
           />
         ) : null}
@@ -542,6 +543,7 @@ const AssistantGroupRow = memo(function AssistantGroupRow({
             onToolClick={handleToolClick}
             showExpanded={false}
             startTime={Date.now()}
+            project={project}
           />
         ) : null}
       </div>
@@ -673,6 +675,7 @@ const AssistantGroupRow = memo(function AssistantGroupRow({
                   onToolClick={handleToolClick}
                   showExpanded={false}
                   toolCall={tc}
+                  project={project}
                 />
               );
             })

--- a/apps/frontend/src/components/thread/content/ToolCard.tsx
+++ b/apps/frontend/src/components/thread/content/ToolCard.tsx
@@ -2,7 +2,10 @@ import React, { useState } from 'react';
 import { AppIcon } from '../tool-views/shared/AppIcon';
 import { cn } from '@/lib/utils';
 import { Dialog, DialogContent } from '@/components/ui/dialog';
-import { Download, X, Presentation } from 'lucide-react';
+import { Download, X } from 'lucide-react';
+import { PresentationSlidePreview } from '../tool-views/presentation-tools/PresentationSlidePreview';
+import { PresentationSlideSkeleton } from '../tool-views/presentation-tools/PresentationSlideSkeleton';
+import type { Project } from '@/lib/api/threads';
 
 export interface SlideInfo {
   presentationName: string;
@@ -24,6 +27,7 @@ export interface ToolCardProps {
   websiteUrls?: string[];
   imageUrls?: string[];
   slideInfo?: SlideInfo;
+  project?: Project;
 }
 
 const getFavicon = (url: string): string | null => {
@@ -69,6 +73,7 @@ export const ToolCard: React.FC<ToolCardProps> = ({
   websiteUrls,
   imageUrls,
   slideInfo,
+  project,
 }) => {
   const [selectedImage, setSelectedImage] = useState<string | null>(null);
   const favicons = websiteUrls?.slice(0, 4).map(getFavicon).filter(Boolean) as string[] || [];
@@ -201,22 +206,26 @@ export const ToolCard: React.FC<ToolCardProps> = ({
       )}
 
       {slideInfo && (
-        <button
-          onClick={onClick}
-          className="flex items-center gap-3 mt-1 p-3 border rounded-xl bg-muted/30 border border-border hover:bg-muted/80 transition-colors w-fit max-w-xs"
-        >
-          <div className="flex items-center justify-center w-10 h-10 rounded-md bg-gradient-to-br from-orange-500 to-amber-500 text-white">
-            <Presentation className="w-5 h-5" />
+        project?.sandbox?.sandbox_url ? (
+          <div className="mt-2 max-w-sm">
+            <PresentationSlidePreview
+              presentationName={slideInfo.presentationName}
+              project={project}
+              initialSlide={slideInfo.slideNumber}
+              onFullScreenClick={onClick ? () => onClick() : undefined}
+              className="w-full"
+            />
           </div>
-          <div className="flex flex-col items-start min-w-0">
-            <span className="text-sm font-medium text-foreground truncate max-w-[180px]">
-              {slideInfo.slideTitle}
-            </span>
-            <span className="text-xs text-muted-foreground">
-              Slide {slideInfo.slideNumber} of {slideInfo.totalSlides} · {slideInfo.presentationName}
-            </span>
+        ) : (
+          <div className="mt-2 max-w-sm">
+            <PresentationSlideSkeleton
+              slideNumber={slideInfo.slideNumber}
+              slideTitle={slideInfo.slideTitle}
+              isGenerating={true}
+              className="w-full"
+            />
           </div>
-        </button>
+        )
       )}
 
       <Dialog open={!!selectedImage} onOpenChange={(open) => !open && setSelectedImage(null)}>

--- a/apps/frontend/src/components/thread/kortix-computer/FileBrowserView.tsx
+++ b/apps/frontend/src/components/thread/kortix-computer/FileBrowserView.tsx
@@ -66,6 +66,7 @@ import { VersionBanner } from './VersionBanner';
 import { KortixComputerHeader } from './KortixComputerHeader';
 import { useFileData } from '@/hooks/use-file-data';
 import { PresentationSlidePreview } from '../tool-views/presentation-tools/PresentationSlidePreview';
+import { PresentationSlideSkeleton } from '../tool-views/presentation-tools/PresentationSlideSkeleton';
 import { PdfRenderer } from '@/components/file-renderers/pdf-renderer';
 import { UnifiedMarkdown } from '@/components/markdown/unified-markdown';
 
@@ -476,12 +477,23 @@ function ThumbnailPreview({
   const hasError = blobError || textError;
   
   // For presentation folders, show the slide preview
-  if (isPresentationFolder && project?.sandbox?.sandbox_url) {
+  if (isPresentationFolder) {
     const presentationName = file.name;
+    if (project?.sandbox?.sandbox_url) {
+      return (
+        <PresentationSlidePreview
+          presentationName={presentationName}
+          project={project}
+          className="w-full h-full"
+        />
+      );
+    }
+    // Show skeleton while waiting for sandbox
     return (
-      <PresentationSlidePreview
-        presentationName={presentationName}
-        project={project}
+      <PresentationSlideSkeleton
+        slideNumber={1}
+        slideTitle={presentationName}
+        isGenerating={true}
         className="w-full h-full"
       />
     );


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces end-to-end slide preview support across streaming tools, assistant render, and file browser.
> 
> - New `SlideStreamPreview` in `ShowToolStream.tsx` loads slide iframes from presentation metadata, with sandbox ensure-active, polling, retries, and shimmer; recognizes slide tools via `SLIDE_CREATION_TOOLS`
> - `ShowToolStream` renders a ToolCard + live slide preview for slide tools; accepts `project` and passes it through
> - `ThreadContent.tsx` now forwards `project` to all `ShowToolStream` usages
> - Assistant renderer: adds inline slide rendering (`SlideInlineThumbnail`) and `renderSlideToolCall` for `create-slide` calls; passes `project` into `ToolCard`
> - `ToolCard.tsx` shows `PresentationSlidePreview` or `PresentationSlideSkeleton` based on sandbox readiness
> - `FileBrowserView.tsx` displays slide previews (or skeletons) for presentation folders even before sandbox URL is ready
> 
> Overall: integrates presentation previews consistently, improves streaming UX, and adds graceful fallbacks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 69f42a167992534714ca94effb2e23b197e55741. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->