### PR TITLE
add otp auth

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -49,6 +49,7 @@ from core.triggers import api as triggers_api
 from core.services import api_keys_api
 from core.notifications import api as notifications_api
 from core.services.orphan_cleanup import cleanup_orphaned_agent_runs
+from auth import api as auth_api
 
 
 if sys.platform == "win32":
@@ -363,6 +364,9 @@ api_router.include_router(staged_files_router, prefix="/files")
 
 from core.sandbox.canvas_ai_api import router as canvas_ai_router
 api_router.include_router(canvas_ai_router)
+
+# Auth OTP endpoint for expired magic links
+api_router.include_router(auth_api.router)
 
 @api_router.get("/health", summary="Health Check", operation_id="health_check", tags=["system"])
 async def health_check():

--- a/backend/auth/__init__.py
+++ b/backend/auth/__init__.py
@@ -1,0 +1,1 @@
+# Auth module

--- a/backend/auth/api.py
+++ b/backend/auth/api.py
@@ -1,0 +1,119 @@
+"""
+Auth API - OTP Email Endpoint
+
+Provides an endpoint to send OTP-only emails for users who experience
+magic link expiration due to email security scanners (e.g., Microsoft Defender).
+"""
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, EmailStr
+import httpx
+import os
+from core.utils.logger import logger
+from core.utils.config import config
+from core.services.email import email_service
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+
+
+class SendOtpRequest(BaseModel):
+    email: EmailStr
+
+
+class SendOtpResponse(BaseModel):
+    success: bool
+    message: str
+
+
+@router.post("/send-otp", response_model=SendOtpResponse)
+async def send_otp_email(request: SendOtpRequest):
+    """
+    Generate a new OTP and send it via custom email (no magic link).
+
+    This endpoint is used when a user's magic link has expired due to
+    email security scanners pre-fetching the link.
+
+    Flow:
+    1. Call Supabase Admin API to generate a magic link (creates new token)
+    2. Extract the OTP token from the response
+    3. Send custom email via Mailtrap with just the OTP code (no clickable link)
+    """
+    try:
+        email = request.email.lower().strip()
+
+        # Call Supabase Admin API to generate link
+        supabase_url = config.SUPABASE_URL
+        service_role_key = config.SUPABASE_SERVICE_ROLE_KEY
+
+        if not supabase_url or not service_role_key:
+            logger.error("Supabase configuration missing")
+            raise HTTPException(status_code=500, detail="Server configuration error")
+
+        # Generate magic link via Admin API
+        # This creates a new token and returns the OTP code
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                f"{supabase_url}/auth/v1/admin/generate_link",
+                headers={
+                    "Authorization": f"Bearer {service_role_key}",
+                    "apikey": service_role_key,
+                    "Content-Type": "application/json"
+                },
+                json={
+                    "type": "magiclink",
+                    "email": email
+                },
+                timeout=30.0
+            )
+
+            if response.status_code != 200:
+                error_detail = response.text
+                logger.error(f"Supabase generate_link failed: {response.status_code} - {error_detail}")
+
+                # Check for specific error - user might not exist
+                if "User not found" in error_detail:
+                    raise HTTPException(status_code=404, detail="No account found with this email")
+
+                raise HTTPException(status_code=500, detail="Failed to generate verification code")
+
+            data = response.json()
+
+        # Extract the OTP token from the response
+        # Supabase may return email_otp at top level or in properties
+        otp_token = data.get("email_otp")
+        if not otp_token:
+            properties = data.get("properties", {})
+            otp_token = properties.get("email_otp")
+
+        if not otp_token:
+            logger.warning(f"No email_otp in response. Keys: {list(data.keys())}")
+
+            # If we can't get the OTP, we can't proceed with custom email
+            # Fall back to telling the user to check their email (Supabase might have sent one)
+            raise HTTPException(
+                status_code=500,
+                detail="Unable to generate verification code. Please try the magic link in your email."
+            )
+
+        # Send custom email with OTP code via Mailtrap
+        success = email_service.send_otp_email(
+            user_email=email,
+            otp_code=otp_token
+        )
+
+        if not success:
+            logger.error(f"Failed to send OTP email to {email}")
+            raise HTTPException(status_code=500, detail="Failed to send verification email")
+
+        logger.info(f"OTP email sent successfully to {email}")
+
+        return SendOtpResponse(
+            success=True,
+            message="Verification code sent to your email"
+        )
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error in send_otp_email: {str(e)}")
+        raise HTTPException(status_code=500, detail="An error occurred")

--- a/backend/core/services/email.py
+++ b/backend/core/services/email.py
@@ -304,4 +304,87 @@ Claim your invite: {referral_url}
 ---
 © Kortix AI Corp. All rights reserved."""
 
+    def send_otp_email(self, user_email: str, otp_code: str) -> bool:
+        """Send an OTP-only email (no magic link button) for users with expired links."""
+        if not self.client:
+            logger.error("Cannot send email: MAILTRAP_API_TOKEN not configured")
+            return False
+
+        subject = "Your Kortix verification code"
+        html_content = self._get_otp_email_template(otp_code)
+        text_content = self._get_otp_email_text(otp_code)
+
+        try:
+            mail = mt.Mail(
+                sender=mt.Address(email=self.sender_email, name=self.sender_name),
+                to=[mt.Address(email=user_email, name=user_email.split('@')[0].title())],
+                subject=subject,
+                text=text_content,
+                html=html_content,
+                category="otp"
+            )
+
+            response = self.client.send(mail)
+            logger.info(f"OTP email sent to {user_email}. Response: {response}")
+            return True
+
+        except Exception as e:
+            logger.error(f"Error sending OTP email to {user_email}: {str(e)}")
+            return False
+
+    def _get_otp_email_template(self, otp_code: str) -> str:
+        return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Your verification code</title>
+</head>
+<body style="margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; background-color: #fafafa; color: #1a1a1a;">
+  <table border="0" cellpadding="0" cellspacing="0" width="100%" style="max-width: 520px; margin: 0 auto; padding: 40px 20px;">
+    <tr>
+      <td>
+        <div style="text-align: center; margin-bottom: 40px;">
+          <img src="https://kortix.com/Logomark.svg" alt="Kortix" style="height: 24px; width: auto; display: inline-block;" />
+        </div>
+        <div style="background-color: #ffffff; border-radius: 16px; padding: 40px 32px; text-align: center;">
+          <h1 style="font-size: 24px; font-weight: 500; color: #000; margin: 0 0 16px 0; letter-spacing: -0.02em;">
+            Your verification code
+          </h1>
+          <p style="font-size: 15px; line-height: 22px; color: #666; margin: 0 0 32px 0;">
+            Enter this code to sign in to your account:
+          </p>
+          <div style="background-color: #f5f5f5; border-radius: 12px; padding: 24px; margin-bottom: 32px;">
+            <p style="font-size: 36px; font-weight: 600; letter-spacing: 8px; color: #000; margin: 0; font-family: 'Courier New', monospace;">
+              {otp_code}
+            </p>
+          </div>
+          <p style="font-size: 13px; line-height: 18px; color: #999; margin: 0;">
+            This code expires in 1 hour. If you didn't request this, you can safely ignore this email.
+          </p>
+        </div>
+        <div style="text-align: center; margin-top: 32px;">
+          <p style="font-size: 12px; color: #999; margin: 0;">
+            &copy; Kortix AI Corp. All rights reserved.
+          </p>
+        </div>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>"""
+
+    def _get_otp_email_text(self, otp_code: str) -> str:
+        return f"""Your Kortix verification code
+
+Enter this code to sign in to your account:
+
+{otp_code}
+
+This code expires in 1 hour. If you didn't request this, you can safely ignore this email.
+
+---
+© Kortix AI Corp. All rights reserved."""
+
+
 email_service = EmailService() 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces an OTP fallback flow and improves magic-link reliability across web/desktop.
> 
> - Frontend: normalizes emails, appends `email` to magic-link redirects, and adds `verifyOtp` server action. Expired-link UX revamped to resend magic link or send a 6‑digit code, with inline OTP entry/verification and provider quick-open buttons.
> - Auth callback: reads `email` from query, routes expired/invalid links to `/auth?expired=true&email=...`, preserves `returnUrl`, and improves error handling.
> - Backend: new `POST /auth/send-otp` endpoint (FastAPI) generates a Supabase OTP via admin API and sends a Mailtrap email without a link. Email service gains OTP templates and sender.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2177098426c97b0de243f7bba32afd36abf6eed6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->