### PR TITLE
fix conditional hook error

### DIFF
--- a/apps/frontend/src/hooks/files/use-cached-file.ts
+++ b/apps/frontend/src/hooks/files/use-cached-file.ts
@@ -278,15 +278,17 @@ export function useCachedFile<T = string>(
       setIsLoading(false);
       setError(null);
     }
-    
-    // Clean up the local blob URL when component unmounts
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sandboxId, filePath, options.contentType]);
+
+  // Separate cleanup effect for blob URL
+  useEffect(() => {
     return () => {
       if (localBlobUrl) {
         URL.revokeObjectURL(localBlobUrl);
-        setLocalBlobUrl(null);
       }
     };
-  }, [sandboxId, filePath, options.contentType]);
+  }, [localBlobUrl]);
 
   // Expose the cache manipulation functions
   return {

--- a/apps/frontend/src/lib/streaming/animations.ts
+++ b/apps/frontend/src/lib/streaming/animations.ts
@@ -164,10 +164,6 @@ export function useSmoothStream(
   enabled: boolean = true,
   _speed?: number
 ): string {
-  if (!SMOOTH_STREAMING_ENABLED) {
-    return text;
-  }
-
   const storeRef = useRef<SmoothStreamStore | null>(null);
   
   if (!storeRef.current) {
@@ -179,7 +175,7 @@ export function useSmoothStream(
   
   useLayoutEffect(() => {
     store.update(text, enabled);
-  }, [text, enabled]);
+  }, [store, text, enabled]);
   
   useSyncExternalStore(
     store.subscribe,
@@ -192,6 +188,10 @@ export function useSmoothStream(
       storeRef.current?.destroy();
     };
   }, []);
+
+  if (!SMOOTH_STREAMING_ENABLED) {
+    return text;
+  }
 
   return store.getText();
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Addresses React hook rule violations and cleanup behavior.
> 
> - `useSmoothStream`: Moves `SMOOTH_STREAMING_ENABLED` guard after hooks and adds `store` to `useLayoutEffect` deps to prevent conditional hooks and stale refs
> - `useCachedFile`: Splits blob URL cleanup into its own effect keyed by `localBlobUrl`, adjusts main effect deps, and avoids state updates during unmount
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c8aa191cc46906794fa210fd9d61f31ed89236ee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->