### PR TITLE
Landing page: remove showcase cards, adjust hero height, update foote…

### DIFF
--- a/apps/frontend/src/app/(home)/page.tsx
+++ b/apps/frontend/src/app/(home)/page.tsx
@@ -5,9 +5,6 @@ import { BackgroundAALChecker } from '@/components/auth/background-aal-checker';
 import { HeroSection as NewHeroSection } from '@/components/home/hero-section';
 
 // Lazy load below-the-fold components for faster FCP/LCP
-const ShowCaseSection = lazy(() => 
-  import('@/components/home/showcase-section').then(mod => ({ default: mod.ShowCaseSection }))
-);
 const WordmarkFooter = lazy(() => 
   import('@/components/home/wordmark-footer').then(mod => ({ default: mod.WordmarkFooter }))
 );
@@ -18,32 +15,10 @@ const MobileAppInterstitial = lazy(() =>
   import('@/components/announcements/mobile-app-interstitial').then(mod => ({ default: mod.MobileAppInterstitial }))
 );
 
-// Skeleton placeholder for ShowCaseSection while loading
-function ShowCaseSkeleton() {
-  return (
-    <section className="w-full px-6 py-16 md:py-24 lg:py-32">
-      <div className="max-w-7xl mx-auto">
-        <div className="text-center mb-12 md:mb-16">
-          <div className="h-12 w-96 max-w-full mx-auto bg-muted/30 rounded-lg animate-pulse" />
-          <div className="h-6 w-80 max-w-full mx-auto bg-muted/20 rounded-lg mt-4 animate-pulse" />
-        </div>
-        <div className="space-y-6">
-          {[1, 2].map((i) => (
-            <div key={i} className="h-[400px] bg-muted/10 rounded-[24px] animate-pulse" />
-          ))}
-        </div>
-      </div>
-    </section>
-  );
-}
-
 export default function Home() {
   return (
     <BackgroundAALChecker>
       <NewHeroSection />
-      <Suspense fallback={<ShowCaseSkeleton />}>
-        <ShowCaseSection />
-      </Suspense>
       <Suspense fallback={null}>
         <WordmarkFooter />
       </Suspense>

--- a/apps/frontend/src/components/home/hero-section.tsx
+++ b/apps/frontend/src/components/home/hero-section.tsx
@@ -53,7 +53,7 @@ export function HeroSection() {
   
   return (
     <section id="hero" className="w-full relative overflow-hidden">
-      <div className="relative flex flex-col items-center w-full px-4 sm:px-6 pb-8 sm:pb-10">
+      <div className="relative flex flex-col items-center w-full px-6 pb-8 sm:pb-10">
         <AnimatedBg
           variant="hero"
           sizeMultiplier={isMobile ? 0.7 : 1}
@@ -88,12 +88,12 @@ export function HeroSection() {
           } : undefined}
         />
 
-        <div className="relative z-10 pt-20 sm:pt-24 md:pt-32 mx-auto h-full w-full max-w-6xl flex flex-col items-center justify-center min-h-[60vh] sm:min-h-0">
-          <div className="flex flex-col items-center justify-center gap-4 sm:gap-5 pt-12 sm:pt-20 max-w-4xl mx-auto pb-4 sm:pb-5">
+        <div className="relative z-10 pt-20 sm:pt-24 md:pt-32 pb-24 sm:pb-32 mx-auto h-full w-full sm:max-w-6xl flex flex-col items-center justify-center min-h-[calc(100vh-120px)]">
+          <div className="flex flex-col items-center justify-center gap-4 sm:gap-5 pt-12 sm:pt-20 sm:max-w-4xl mx-auto pb-4 sm:pb-5">
             {/* Greeting is rendered inside AgentStartInput */}
           </div>
 
-          <div className="flex flex-col items-center w-full max-w-3xl mx-auto gap-2 flex-wrap justify-center px-4 sm:px-0 mt-1">
+          <div className="flex flex-col items-center w-full sm:max-w-3xl mx-auto gap-2 flex-wrap justify-center mt-1">
             <div className="w-full relative">
               <div className="relative z-10 w-full flex flex-col items-center space-y-4">
                 <AgentStartInput
@@ -102,13 +102,13 @@ export function HeroSection() {
                   onAuthRequired={handleAuthRequired}
                   redirectOnError="/"
                   showGreeting={true}
-                  greetingClassName="text-2xl sm:text-3xl md:text-3xl lg:text-4xl font-medium text-balance text-center px-4 sm:px-2"
+                  greetingClassName="text-2xl sm:text-3xl md:text-3xl lg:text-4xl font-medium text-balance text-center sm:px-2"
                   autoFocus={false}
                   showLoginStatus={true}
                   showAlertBanners={false}
                   showModesPanel={true}
                   isMobile={isMobile}
-                  modesPanelWrapperClassName="w-full max-w-3xl mx-auto mt-4 px-4 sm:px-0 animate-in fade-in-0 slide-in-from-bottom-4 duration-500 delay-200 fill-mode-both"
+                  modesPanelWrapperClassName="w-full sm:max-w-3xl mx-auto mt-4 animate-in fade-in-0 slide-in-from-bottom-4 duration-500 delay-200 fill-mode-both"
                 />
               </div>
             </div>

--- a/apps/frontend/src/components/home/simple-footer.tsx
+++ b/apps/frontend/src/components/home/simple-footer.tsx
@@ -19,7 +19,13 @@ export function SimpleFooter() {
           {/* Brand column */}
           <div className="col-span-2 md:col-span-1 space-y-4">
             <Link href="/" className="inline-flex items-center gap-2 group">
-              <KortixLogo size={24} />
+              {/* Wordmark on mobile, symbol on desktop */}
+              <span className="md:hidden">
+                <KortixLogo size={18} variant="logomark" />
+              </span>
+              <span className="hidden md:block">
+                <KortixLogo size={24} variant="symbol" />
+              </span>
             </Link>
             {/* Social links */}
             <div className="flex items-center gap-3 pt-2">
@@ -101,10 +107,13 @@ export function SimpleFooter() {
             </div>
 
             {/* Theme and language switchers */}
-            <div className="flex items-center gap-1 pt-2">
-              <ThemeToggle variant="compact" />
-              <span className="text-muted-foreground/30">|</span>
-              <LocaleSwitcher variant="compact" />
+            <div className="flex items-center gap-3 pt-2">
+              <div className="rounded-lg bg-muted/50">
+                <ThemeToggle variant="compact" />
+              </div>
+              <div className="rounded-lg bg-muted/50">
+                <LocaleSwitcher variant="compact" />
+              </div>
             </div>
           </div>
 


### PR DESCRIPTION
…r styling

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Streamlines the landing page and tweaks responsive layout/styling.
> 
> - Removes `ShowCaseSection` and its skeleton/loading from `app/(home)/page.tsx`, keeping only `HeroSection`, `WordmarkFooter`, `SimpleFooter`, and `MobileAppInterstitial`
> - Adjusts `HeroSection` layout (padding, max-widths, and `min-h-[calc(100vh-120px)]`) for a taller, more centered hero on mobile and desktop
> - Updates `SimpleFooter` brand to show `KortixLogo` logomark on mobile and symbol on desktop; restyles theme and locale switchers with rounded containers and spacing
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 40dac118b581e3e7e9ec0697e2718cf88df5d02f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->