### PR TITLE
fix llm context issue

### DIFF
--- a/backend/core/threads/repo.py
+++ b/backend/core/threads/repo.py
@@ -1325,14 +1325,21 @@ async def insert_message(
     metadata: Optional[Dict[str, Any]] = None,
     agent_id: Optional[str] = None,
     agent_version_id: Optional[str] = None,
-    message_id: Optional[str] = None
+    message_id: Optional[str] = None,
+    created_at: Optional[Any] = None
 ) -> Optional[Dict[str, Any]]:
     from datetime import datetime, timezone
     import uuid
     
     if message_id is None:
         message_id = str(uuid.uuid4())
-    now = datetime.now(timezone.utc)
+    
+    if created_at is None:
+        now = datetime.now(timezone.utc)
+    elif isinstance(created_at, (int, float)):
+        now = datetime.fromtimestamp(created_at, tz=timezone.utc)
+    else:
+        now = created_at
     
     sql = """
     INSERT INTO messages (

--- a/backend/core/tools/web_search_tool.py
+++ b/backend/core/tools/web_search_tool.py
@@ -454,15 +454,26 @@ class SandboxWebSearchTool(SandboxToolsBase):
         """
         Get image description using Moondream2 vision model.
         Runs in ~2 seconds on Replicate GPU, includes text extraction.
+        Skipped if REPLICATE_API_TOKEN is not configured.
         
         Args:
             image_bytes: Raw image bytes
             content_type: MIME type of the image
             
         Returns:
-            Image description, or empty string if processing fails
+            Image description, or empty string if processing fails or token not configured
         """
         try:
+            # Skip if Replicate token not configured
+            from core.utils.config import get_config
+            replicate_token = get_config().REPLICATE_API_TOKEN
+            if not replicate_token:
+                logging.debug("[WebSearch] Skipping Moondream2: REPLICATE_API_TOKEN not configured")
+                return ""
+            
+            import os
+            os.environ["REPLICATE_API_TOKEN"] = replicate_token
+            
             logging.debug(f"[WebSearch] Running Moondream2 on image ({len(image_bytes)} bytes)")
             
             # Convert to base64 data URL


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improves message persistence and runtime context while hardening web image enrichment.
> 
> - Caches successful LLM messages to runtime after `BatchWriter._flush_messages` to maintain conversational context; adds handling for unexpected task results and clearer error logs in `backend/core/agents/pipeline/stateless/persistence/batch.py`
> - Passes WAL entry `created_at` through to DB via `threads.repo.insert_message`, which now accepts optional `created_at` (unix timestamp or datetime) and uses it for `messages.created_at`
> - In `backend/core/tools/web_search_tool.py`, `_describe_image` now checks `REPLICATE_API_TOKEN` via config, skips Moondream2 if unset, and sets env var when present
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7a11c7a633356ed286103ad8e692122b23273d43. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->