### PR TITLE
fix(api): correct reload flag logic that always evaluated to False

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -631,5 +631,5 @@ if __name__ == "__main__":
         port=8000,
         workers=workers,
         loop="asyncio",
-        reload=False if is_dev_env else False
+        reload=reload
     )


### PR DESCRIPTION
## Summary
Fixes a logic error in `backend/api.py` where the reload flag for uvicorn was always `False` regardless of environment.

## Problem
Line 634 had:
```python
reload=False if is_dev_env else False
```
This ternary expression **always evaluates to `False`** since both branches return `False`.

## Solution
Use the `reload` variable that was already correctly computed on line 625:
```python
reload = is_dev_env  # line 625
```

Changed to:
```python
reload=reload
```

## Impact
- **Local/Staging environments**: Hot-reloading now works as originally intended
- **Production**: No change (reload remains `False` as expected)

## Testing
- Verified the logic: `is_dev_env` is `True` for LOCAL/STAGING → `reload` should be `True`
- No breaking changes for production deployments

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes uvicorn reload behavior to match environment.
> 
> - In `backend/api.py`, replaces `reload=False if is_dev_env else False` with `reload=reload`, so uvicorn hot-reload is enabled in LOCAL/STAGING and remains disabled in production
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ce016499e39a1ca866b83f61e9ca2b55338abd32. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->