### PR TITLE
disable sandboc xreation

### DIFF
--- a/backend/core/sandbox/pool_background.py
+++ b/backend/core/sandbox/pool_background.py
@@ -153,6 +153,12 @@ async def start_pool_service() -> None:
         logger.info("[SANDBOX_POOL] Pool service is disabled via configuration")
         return
     
+    # EMERGENCY: Disable sandbox pool creation entirely due to Daytona rate limiting
+    # The DB has fewer pooled sandboxes tracked than Daytona actually has, causing
+    # the pool to spam creation requests and get rate limited
+    logger.warning("[SANDBOX_POOL] Pool service DISABLED - sandbox creation paused due to Daytona rate limiting")
+    return
+    
     service = get_pool_service()
     
     logger.info(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Temporarily pause sandbox pool service**
> 
> - Short-circuits `start_pool_service` with an early return, preventing pool warmup and background loops (`_pool_replenishment_loop`, `_cleanup_loop`, `_keepalive_loop`, `_initial_pool_warmup`)
> - Adds warning log indicating sandbox creation is paused due to Daytona rate limiting
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b4239348fd47d826044a6da9da4025c5cc241e75. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->