### PR TITLE
toggle stuck

### DIFF
--- a/apps/frontend/src/app/(dashboard)/admin/analytics/page.tsx
+++ b/apps/frontend/src/app/(dashboard)/admin/analytics/page.tsx
@@ -64,6 +64,7 @@ export default function AdminAnalyticsPage() {
   const [analyticsSource, setAnalyticsSource] = useState<AnalyticsSource>('vercel');
   const [activeTab, setActiveTab] = useState<string>('overview');
   const [tierViewMode, setTierViewMode] = useState<'revenue' | 'cost' | 'profit'>('revenue');
+  const [includeStuckTasks, setIncludeStuckTasks] = useState(false);
 
   const handleCategoryFilter = (category: string | null) => {
     setCategoryFilter(category);
@@ -392,15 +393,33 @@ export default function AdminAnalyticsPage() {
                         </div>
 
                         {/* Avg Duration */}
-                        <div className="text-center p-4 rounded-lg bg-muted/30 flex flex-col justify-center">
+                        <div className="text-center p-4 rounded-lg bg-muted/30 flex flex-col justify-center relative">
                           <p className="text-2xl font-bold">
-                            {taskPerformance?.avg_duration_seconds
-                              ? taskPerformance.avg_duration_seconds < 60
-                                ? `${taskPerformance.avg_duration_seconds.toFixed(0)}s`
-                                : `${(taskPerformance.avg_duration_seconds / 60).toFixed(1)}m`
-                              : '—'}
+                            {(() => {
+                              const duration = includeStuckTasks
+                                ? taskPerformance?.avg_duration_with_stuck_seconds
+                                : taskPerformance?.avg_duration_seconds;
+                              if (!duration) return '—';
+                              return duration < 60
+                                ? `${duration.toFixed(0)}s`
+                                : `${(duration / 60).toFixed(1)}m`;
+                            })()}
                           </p>
                           <p className="text-xs text-muted-foreground mt-1">Avg Task Duration</p>
+                          {(taskPerformance?.stuck_task_count ?? 0) > 0 && (
+                            <button
+                              onClick={() => setIncludeStuckTasks(!includeStuckTasks)}
+                              className={cn(
+                                "text-[9px] mt-1 px-1.5 py-0.5 rounded cursor-pointer transition-colors",
+                                includeStuckTasks
+                                  ? "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400"
+                                  : "bg-muted text-muted-foreground hover:bg-muted/80"
+                              )}
+                              title={includeStuckTasks ? "Click to exclude stuck tasks" : "Click to include stuck tasks"}
+                            >
+                              {taskPerformance.stuck_task_count} stuck {includeStuckTasks ? '(included)' : '(excluded)'}
+                            </button>
+                          )}
                         </div>
                       </div>
                     </div>

--- a/apps/frontend/src/hooks/admin/use-admin-analytics.ts
+++ b/apps/frontend/src/hooks/admin/use-admin-analytics.ts
@@ -747,7 +747,9 @@ export interface TaskPerformance {
   running_runs: number;
   pending_runs: number;  // Not started yet
   success_rate: number;  // completed / (completed + failed + stopped)
-  avg_duration_seconds: number | null;
+  avg_duration_seconds: number | null;  // Excludes stuck tasks (> 1hr)
+  avg_duration_with_stuck_seconds: number | null;  // Includes all tasks
+  stuck_task_count: number;  // Tasks with duration > 1hr (likely stuck)
   runs_by_status: Record<string, number>;
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces stuck-task awareness in task performance metrics and UI.
> 
> - Frontend (`admin/analytics/page.tsx`): Adds `includeStuckTasks` toggle and button showing `stuck_task_count`; avg duration card now switches between `avg_duration_seconds` and `avg_duration_with_stuck_seconds`.
> - Types/hooks (`use-admin-analytics.ts`): Extends `TaskPerformance` with `avg_duration_with_stuck_seconds` and `stuck_task_count`.
> - Backend (`analytics_admin_api.py`): Updates `TaskPerformance` model and `/task-performance` endpoint to return `avg_duration_with_stuck_seconds` and `stuck_task_count` alongside existing metrics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 88821706fc75a2b473ce49c2b44529e6232a2713. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->