### PR TITLE
fix tyepe

### DIFF
--- a/apps/frontend/src/hooks/admin/use-admin-analytics.ts
+++ b/apps/frontend/src/hooks/admin/use-admin-analytics.ts
@@ -855,6 +855,7 @@ export interface TierProfitability {
   provider: 'stripe' | 'revenuecat';
   payment_count: number;
   unique_users: number;
+  usage_users: number;  // Users with LLM usage (from credit_ledger)
   total_revenue: number;
   total_cost: number;
   total_actual_cost: number;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Expands profitability analytics typing to include LLM usage counts.
> 
> - Adds `usage_users: number` to `TierProfitability` in `use-admin-analytics.ts` (users with LLM usage from `credit_ledger`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0d6c3c0c9e85b30a72a686189a719399a7c5f993. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->