### PR TITLE
enable sandbox pooling

### DIFF
--- a/backend/core/sandbox/pool_background.py
+++ b/backend/core/sandbox/pool_background.py
@@ -133,7 +133,8 @@ async def _initial_pool_warmup(service: SandboxPoolService) -> None:
             logger.info(f"[SANDBOX_POOL] Warmup progress: {created_total}/{to_create} sandboxes created")
             
             if created_total < to_create:
-                await asyncio.sleep(1)
+                logger.info(f"[SANDBOX_POOL] Waiting {config.batch_delay}s before next batch to avoid rate limits...")
+                await asyncio.sleep(config.batch_delay)
         
         logger.info(f"[SANDBOX_POOL] Initial warmup complete: created {created_total} sandboxes")
         
@@ -153,11 +154,9 @@ async def start_pool_service() -> None:
         logger.info("[SANDBOX_POOL] Pool service is disabled via configuration")
         return
     
-    # EMERGENCY: Disable sandbox pool creation entirely due to Daytona rate limiting
-    # The DB has fewer pooled sandboxes tracked than Daytona actually has, causing
-    # the pool to spam creation requests and get rate limited
-    logger.warning("[SANDBOX_POOL] Pool service DISABLED - sandbox creation paused due to Daytona rate limiting")
-    return
+
+    # logger.warning("[SANDBOX_POOL] Pool service DISABLED - sandbox creation paused due to Daytona rate limiting")
+    # return
     
     service = get_pool_service()
     

--- a/backend/core/sandbox/pool_config.py
+++ b/backend/core/sandbox/pool_config.py
@@ -11,20 +11,23 @@ _DEFAULTS = {
         "check_interval": 30,
         "parallel_create_limit": 3,
         "replenish_threshold": 0.3,
+        "batch_delay": 5,
     },
     EnvMode.STAGING: {
         "min_size": 50,
-        "max_size": 200,
+        "max_size": 100,
         "check_interval": 20,
         "parallel_create_limit": 5,
         "replenish_threshold": 0.5,
+        "batch_delay": 5,
     },
     EnvMode.PRODUCTION: {
         "min_size": 100, 
-        "max_size": 1000,
+        "max_size": 300,
         "check_interval": 15,
         "parallel_create_limit": 10,
         "replenish_threshold": 0.7,
+        "batch_delay": 10,
     },
 }
 
@@ -43,6 +46,7 @@ class SandboxPoolConfig:
     max_age: int = 3600
     enabled: bool = True
     parallel_create_limit: int = 3
+    batch_delay: int = 10  # seconds to wait between batches to avoid rate limits
     
     @classmethod
     def from_env(cls) -> "SandboxPoolConfig":
@@ -54,6 +58,7 @@ class SandboxPoolConfig:
             max_age=int(os.getenv("SANDBOX_POOL_MAX_AGE", "3600")),
             enabled=os.getenv("SANDBOX_POOL_ENABLED", "true").lower() in ("true", "1", "yes"),
             parallel_create_limit=int(os.getenv("SANDBOX_POOL_PARALLEL_CREATE", str(_get_default("parallel_create_limit")))),
+            batch_delay=int(os.getenv("SANDBOX_POOL_BATCH_DELAY", str(_get_default("batch_delay")))),
         )
     
     @property

--- a/backend/scripts/create_sandbox_pool.py
+++ b/backend/scripts/create_sandbox_pool.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""
+Script to manually create sandboxes for the pool.
+Usage: python scripts/create_sandbox_pool.py <count> [--batch-size=5] [--delay=10]
+
+Example:
+    python scripts/create_sandbox_pool.py 20 --batch-size=3 --delay=15
+"""
+import asyncio
+import argparse
+import sys
+import os
+
+# Add backend to path
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from core.utils.logger import logger
+from core.sandbox.pool_service import SandboxPoolService
+from core.services.db import init_db, close_db
+
+
+async def create_sandboxes(count: int, batch_size: int, delay_seconds: int):
+    """Create sandboxes in batches with delays to avoid rate limits."""
+    
+    logger.info(f"Starting sandbox pool creation: {count} sandboxes, batch_size={batch_size}, delay={delay_seconds}s")
+    
+    # Initialize database
+    await init_db()
+    
+    service = SandboxPoolService()
+    created_total = 0
+    failed_total = 0
+    
+    try:
+        batches = (count + batch_size - 1) // batch_size  # ceiling division
+        
+        for batch_num in range(batches):
+            batch_start = batch_num * batch_size
+            batch_end = min(batch_start + batch_size, count)
+            current_batch_size = batch_end - batch_start
+            
+            logger.info(f"[Batch {batch_num + 1}/{batches}] Creating {current_batch_size} sandboxes...")
+            
+            # Create sandboxes in parallel within batch
+            tasks = [service.create_pooled_sandbox() for _ in range(current_batch_size)]
+            results = await asyncio.gather(*tasks, return_exceptions=True)
+            
+            batch_created = 0
+            batch_failed = 0
+            for result in results:
+                if isinstance(result, Exception):
+                    logger.error(f"Failed to create sandbox: {result}")
+                    batch_failed += 1
+                elif result is None:
+                    batch_failed += 1
+                else:
+                    batch_created += 1
+            
+            created_total += batch_created
+            failed_total += batch_failed
+            
+            logger.info(f"[Batch {batch_num + 1}/{batches}] Created {batch_created}/{current_batch_size} sandboxes (total: {created_total}/{count})")
+            
+            # Delay between batches (except after last batch)
+            if batch_num < batches - 1:
+                logger.info(f"Waiting {delay_seconds}s before next batch...")
+                await asyncio.sleep(delay_seconds)
+        
+        logger.info(f"✅ Sandbox pool creation complete: {created_total} created, {failed_total} failed")
+        
+    finally:
+        await close_db()
+    
+    return created_total, failed_total
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Create sandboxes for the pool")
+    parser.add_argument("count", type=int, help="Number of sandboxes to create")
+    parser.add_argument("--batch-size", type=int, default=5, help="Sandboxes per batch (default: 5)")
+    parser.add_argument("--delay", type=int, default=10, help="Seconds between batches (default: 10)")
+    
+    args = parser.parse_args()
+    
+    if args.count <= 0:
+        print("Error: count must be positive")
+        sys.exit(1)
+    
+    if args.batch_size <= 0:
+        print("Error: batch-size must be positive")
+        sys.exit(1)
+    
+    created, failed = asyncio.run(create_sandboxes(args.count, args.batch_size, args.delay))
+    
+    sys.exit(0 if failed == 0 else 1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces batching and delays to sandbox pool warmup and tunes pool sizing to reduce rate limits, plus a helper script for manual pool creation.
> 
> - Adds `batch_delay` to `SandboxPoolConfig` (env: `SANDBOX_POOL_BATCH_DELAY`) with per-env defaults; warmup now waits between batches and logs delay
> - Lowers `max_size` defaults (staging: 100, production: 300) to reduce over-provisioning
> - Removes hardcoded disable in `start_pool_service` to re-enable sandbox pool creation
> - New `scripts/create_sandbox_pool.py` to create sandboxes in configurable batches with delays
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4721507464ae52d9002f77bd132792b9081e3b9c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->