### PR TITLE
fix slot manager

### DIFF
--- a/backend/core/agents/pipeline/slot_manager.py
+++ b/backend/core/agents/pipeline/slot_manager.py
@@ -56,12 +56,18 @@ def _get_tier_from_config(tier_name: str) -> Dict[str, Any]:
             'thread_limit': 10,
             'project_limit': 20,
             'concurrent_runs': 1,
+            'custom_workers_limit': 0,
+            'scheduled_triggers_limit': 0,
+            'app_triggers_limit': 0,
         }
     return {
         'name': tier_obj.name,
         'thread_limit': tier_obj.thread_limit,
         'project_limit': tier_obj.project_limit,
         'concurrent_runs': tier_obj.concurrent_runs,
+        'custom_workers_limit': tier_obj.custom_workers_limit,
+        'scheduled_triggers_limit': tier_obj.scheduled_triggers_limit,
+        'app_triggers_limit': tier_obj.app_triggers_limit,
     }
 
 

--- a/backend/core/utils/limits_checker.py
+++ b/backend/core/utils/limits_checker.py
@@ -47,9 +47,9 @@ async def _get_tier_info_if_needed(account_id: str, tier_info: Optional[Dict] = 
             'concurrent_runs': limits.get('concurrent_runs', defaults['concurrent_runs']),
             'thread_limit': limits.get('thread_limit', defaults['thread_limit']),
             'project_limit': limits.get('project_limit', defaults['project_limit']),
-            'custom_workers_limit': defaults['custom_workers_limit'],
-            'scheduled_triggers_limit': defaults['scheduled_triggers_limit'],
-            'app_triggers_limit': defaults['app_triggers_limit'],
+            'custom_workers_limit': limits.get('custom_workers_limit', defaults['custom_workers_limit']),
+            'scheduled_triggers_limit': limits.get('scheduled_triggers_limit', defaults['scheduled_triggers_limit']),
+            'app_triggers_limit': limits.get('app_triggers_limit', defaults['app_triggers_limit']),
         }
     except Exception as e:
         logger.warning(f"Could not get tier for {account_id}: {e}, using defaults")


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Expands tier limit handling to include worker/trigger caps and ensures they flow through limit checks.
> 
> - In `slot_manager.py`, extends `_get_tier_from_config` to return `custom_workers_limit`, `scheduled_triggers_limit`, and `app_triggers_limit` (with sensible defaults) alongside existing limits
> - In `limits_checker.py`, `_get_tier_info_if_needed` now sources those same limits from `get_tier_limits`, instead of defaulting, so downstream checks use subscription-provided values
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d9b1a19478541a68a1fb8fb671e0ccb4ebffbb11. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->