### PR TITLE
fix sandbox pooling

### DIFF
--- a/backend/core/sandbox/pool_service.py
+++ b/backend/core/sandbox/pool_service.py
@@ -109,6 +109,11 @@ class SandboxPoolService:
             return 0
     
     async def create_pooled_sandbox(self) -> Optional[str]:
+        current_size = await self.get_pool_size()
+        if current_size >= self.config.max_size:
+            logger.warning(f"[SANDBOX_POOL] Pool at max capacity ({current_size}/{self.config.max_size}), skipping creation")
+            return None
+        
         try:
             sandbox_pass = str(uuid.uuid4())
             


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Prevents over-provisioning by enforcing configured pool size limits during sandbox creation.
> 
> - Adds a capacity check in `create_pooled_sandbox` to compare current size against `config.max_size`; logs a warning and returns `None` when full
> - Uses `get_pool_size()` before provisioning to keep pool within limits
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9dbb39f04f98f662f2ace7a3b8750a4febf1bde2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->