### PR TITLE
prewarm configs

### DIFF
--- a/apps/frontend/src/components/dashboard/layout-content.tsx
+++ b/apps/frontend/src/components/dashboard/layout-content.tsx
@@ -16,6 +16,7 @@ import { usePrefetchComposioIcons } from '@/hooks/composio/use-composio';
 import { useProjects } from '@/hooks/sidebar/use-sidebar';
 import { useIsMobile } from '@/hooks/utils';
 import { AppProviders } from '@/components/layout/app-providers';
+import { backendApi } from '@/lib/api-client';
 import { AnnouncementDialog } from '../announcements/announcement-dialog';
 import { NovuInboxProvider } from '../notifications/novu-inbox-provider';
 
@@ -121,6 +122,12 @@ export default function DashboardLayoutContent({
   
   // Prefetch popular Composio icons for faster UI
   const { prefetchPopularIcons } = usePrefetchComposioIcons();
+
+  useEffect(() => {
+    if (user) {
+      backendApi.post('/prewarm', undefined, { showErrors: false });
+    }
+  }, [user])
   
   useEffect(() => {
     if (user) {

--- a/backend/core/agents/agent_crud.py
+++ b/backend/core/agents/agent_crud.py
@@ -437,6 +437,13 @@ async def delete_agent(agent_id: str, user_id: str = Depends(verify_and_get_user
             raise HTTPException(status_code=403, detail="Unable to delete agent - permission denied or agent not found")
         
         try:
+            from core.cache.runtime_cache import invalidate_agent_config_cache
+            await invalidate_agent_config_cache(agent_id)
+            logger.debug(f"🗑️ Invalidated cache for deleted agent {agent_id}")
+        except Exception as cache_error:
+            logger.warning(f"Agent config cache invalidation failed for {agent_id}: {str(cache_error)}")
+        
+        try:
             from core.utils.cache import Cache
             await Cache.invalidate(f"agent_count_limit:{user_id}")
         except Exception as cache_error:

--- a/backend/core/agents/repo.py
+++ b/backend/core/agents/repo.py
@@ -163,6 +163,24 @@ async def get_agent_by_id(agent_id: str, account_id: Optional[str] = None) -> Op
     return serialize_row(dict(result)) if result else None
 
 
+async def get_agent_metadata(agent_id: str) -> Optional[Dict[str, Any]]:
+    sql = "SELECT metadata FROM agents WHERE agent_id = :agent_id"
+    result = await execute_one(sql, {"agent_id": agent_id})
+    if result:
+        metadata = result.get("metadata")
+        return metadata if isinstance(metadata, dict) else {}
+    return None
+
+
+async def get_user_agent_ids(user_id: str) -> List[str]:
+    sql = """
+    SELECT agent_id FROM agents 
+    WHERE account_id = :user_id AND current_version_id IS NOT NULL
+    """
+    rows = await execute(sql, {"user_id": user_id})
+    return [row["agent_id"] for row in rows] if rows else []
+
+
 async def get_agent_count(account_id: str) -> int:
     sql = "SELECT COUNT(*) as count FROM agents WHERE account_id = :account_id"
     result = await execute_one(sql, {"account_id": account_id})

--- a/backend/core/triggers/api.py
+++ b/backend/core/triggers/api.py
@@ -139,6 +139,13 @@ async def sync_triggers_to_version_config(agent_id: str):
         
         logger.debug(f"Synced {len(triggers)} triggers to version config for agent {agent_id}")
         
+        try:
+            from core.cache.runtime_cache import invalidate_agent_config_cache
+            await invalidate_agent_config_cache(agent_id)
+            logger.debug(f"🗑️ Invalidated cache for agent {agent_id} after trigger sync")
+        except Exception as cache_error:
+            logger.warning(f"Cache invalidation failed for agent {agent_id}: {cache_error}")
+        
     except Exception as e:
         logger.error(f"Failed to sync triggers to version config: {e}")
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> - **New endpoint & frontend hook**: Adds authenticated `POST /v1/prewarm` and calls it from `layout-content.tsx` on user presence to prewarm caches in the background.
> - **Faster config path**: `load_agent_config_fast` now uses cached agent type (`suna` vs `custom`) to choose fast paths (static Suna + MCPs or full config cache) before DB fallback.
> - **Runtime cache enhancements**: Caches agent type in Redis, adds `prewarm_user_agents` batch loader, and includes `agent_type:*` in invalidation.
> - **Repo helpers**: Adds `get_user_agent_ids` and `get_agent_metadata` for prewarm/load flows.
> - **Broader invalidation**: Invalidate agent caches on agent deletion and after trigger syncs to version config.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1a2841a123d06512c7dfac7a8e03badd56631afe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->