### PR TITLE
more logs in execution pipeline

### DIFF
--- a/backend/core/agents/pipeline/stateless/coordinator/execution.py
+++ b/backend/core/agents/pipeline/stateless/coordinator/execution.py
@@ -126,7 +126,6 @@ class ExecutionEngine:
     async def execute_step(self) -> AsyncGenerator[Dict[str, Any], None]:
         messages = self._state.get_messages()
         
-        # Fast pre-check - only do full validation if needed
         context_manager = ToolCallValidator()
         if context_manager.needs_tool_ordering_repair(messages):
             logger.warning("[ExecutionEngine] Tool ordering issue detected, repairing...")
@@ -168,6 +167,8 @@ class ExecutionEngine:
         
         cost = self._state.estimate_cost(tokens, 1000)
         if not self._state.deduct_credits(cost):
+            logger.error(f"[ExecutionEngine] Insufficient credits for LLM call (required: {cost})")
+            self._state._terminate("error: insufficient_credits")
             yield {"type": "error", "error": "Insufficient credits", "error_code": "INSUFFICIENT_CREDITS"}
             return
 
@@ -179,7 +180,13 @@ class ExecutionEngine:
             tool_execution_strategy=config.AGENT_TOOL_EXECUTION_STRATEGY
         )
 
-        logger.debug(f"📤 [ExecutionEngine] Sending {len(prepared)} messages, {tokens} tokens")
+        logger.info(f"📤 [ExecutionEngine] Sending {len(prepared)} messages, {tokens} tokens to {self._state.model_name}")
+        
+        if len(prepared) < 2:
+            logger.error(f"[ExecutionEngine] No valid messages to send (only {len(prepared)} messages after processing)")
+            self._state._terminate("error: no_valid_messages")
+            yield {"type": "error", "error": "No valid messages to send", "error_code": "NO_MESSAGES"}
+            return
         
         validator = ToolCallValidator()
         is_valid, orphaned_ids, unanswered_ids = validator.validate_tool_call_pairing(prepared)
@@ -204,19 +211,29 @@ class ExecutionEngine:
             )
 
         executor = LLMExecutor()
-        response = await executor.execute(
-            prepared_messages=prepared,
-            llm_model=self._state.model_name,
-            llm_temperature=0,
-            llm_max_tokens=None,
-            openapi_tool_schemas=self._state.tool_schemas,
-            tool_choice="auto",
-            native_tool_calling=processor_config.native_tool_calling,
-            xml_tool_calling=processor_config.xml_tool_calling,
-            stream=True
-        )
+        try:
+            response = await executor.execute(
+                prepared_messages=prepared,
+                llm_model=self._state.model_name,
+                llm_temperature=0,
+                llm_max_tokens=None,
+                openapi_tool_schemas=self._state.tool_schemas,
+                tool_choice="auto",
+                native_tool_calling=processor_config.native_tool_calling,
+                xml_tool_calling=processor_config.xml_tool_calling,
+                stream=True
+            )
+        except Exception as e:
+            error_msg = str(e)[:200]
+            logger.error(f"[ExecutionEngine] LLM executor exception: {error_msg}", exc_info=True)
+            self._state._terminate(f"error: {error_msg[:100]}")
+            yield {"type": "error", "error": error_msg, "error_code": "LLM_EXECUTOR_ERROR"}
+            return
 
         if isinstance(response, dict) and response.get("status") == "error":
+            error_msg = response.get("message", "unknown LLM error")
+            logger.error(f"[ExecutionEngine] LLM returned error: {error_msg}")
+            self._state._terminate(f"error: {error_msg[:100]}")
             yield response
             return
 

--- a/backend/core/agents/runner/executor.py
+++ b/backend/core/agents/runner/executor.py
@@ -220,11 +220,13 @@ async def execute_agent_run_stateless(
                     final_status = status if status != 'error' else 'failed'
                     if status in ['failed', 'error']:
                         error_message = response.get('message') or response.get('error')
+                        logger.error(f"[STATELESS] Agent run error: {error_message}")
                     break
 
             if response.get('type') == 'error':
                 final_status = 'failed'
                 error_message = response.get('error')
+                logger.error(f"[STATELESS] Agent run error: {error_message}")
                 break
 
         if final_status == "failed" and not error_message:
@@ -423,11 +425,13 @@ async def execute_agent_run_fast(
                     final_status = status if status != 'error' else 'failed'
                     if status in ['failed', 'error']:
                         error_message = response.get('message') or response.get('error')
+                        logger.error(f"[FAST] Agent run error: {error_message}")
                     break
             
             if response.get('type') == 'error':
                 final_status = 'failed'
                 error_message = response.get('error')
+                logger.error(f"[FAST] Agent run error: {error_message}")
                 break
         
         if final_status == "failed" and not error_message:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Strengthens reliability and observability around LLM execution and agent runs.
> 
> - In `backend/core/agents/pipeline/stateless/coordinator/execution.py`:
>   - Log and terminate on insufficient credits (`error_code: INSUFFICIENT_CREDITS`) and on no valid messages (`error_code: NO_MESSAGES`).
>   - Promote send log to info with model context; validate `prepared` length before LLM call.
>   - Wrap `LLMExecutor.execute` with try/except; on exception, log with stack, terminate, and yield `LLM_EXECUTOR_ERROR`.
>   - When LLM returns an error response, log and terminate with truncated message.
> - In `backend/core/agents/runner/executor.py`:
>   - Log errors when agent run responses indicate `failed`/`error` in both stateless (`[STATELESS]`) and fast (`[FAST]`) pipelines.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8b82f7896e1f61169b84d29397756b6836e40575. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->