### PR TITLE
web/app separtaion subs + remove vercel

### DIFF
--- a/apps/frontend/src/app/(dashboard)/admin/analytics/page.tsx
+++ b/apps/frontend/src/app/(dashboard)/admin/analytics/page.tsx
@@ -36,7 +36,6 @@ import {
   useEngagementSummary,
   useTaskPerformance,
   useProfitability,
-  type AnalyticsSource,
 } from '@/hooks/admin/use-admin-analytics';
 import { AdminUserTable } from '@/components/admin/admin-user-table';
 import { AdminUserDetailsDialog } from '@/components/admin/admin-user-details-dialog';
@@ -61,7 +60,6 @@ export default function AdminAnalyticsPage() {
   const [calendarOpen, setCalendarOpen] = useState(false);
   const [categoryFilter, setCategoryFilter] = useState<string | null>(null);
   const [tierFilter, setTierFilter] = useState<string | null>(null);
-  const [analyticsSource, setAnalyticsSource] = useState<AnalyticsSource>('vercel');
   const [activeTab, setActiveTab] = useState<string>('overview');
   const [tierViewMode, setTierViewMode] = useState<'revenue' | 'cost' | 'profit'>('revenue');
   const [includeStuckTasks, setIncludeStuckTasks] = useState(false);
@@ -126,7 +124,7 @@ export default function AdminAnalyticsPage() {
   const { data: distribution, isFetching: distributionFetching } = useMessageDistribution(dateFromString, dateToString, isThreadsTab);
   const { data: categoryDistribution, isFetching: categoryFetching } = useCategoryDistribution(dateFromString, dateToString, tierFilter, isOverviewOrThreads);
   const { data: tierDistribution } = useTierDistribution(dateFromString, dateToString, isThreadsTab);
-  const { data: conversionFunnel, isLoading: funnelLoading } = useConversionFunnel(dateFromString, dateToString, analyticsSource);
+  const { data: conversionFunnel, isLoading: funnelLoading } = useConversionFunnel(dateFromString, dateToString, 'vercel');
   const { data: engagementSummary, isLoading: engagementLoading, isFetching: engagementFetching } = useEngagementSummary(dateFromString, dateToString);
   const { data: taskPerformance, isLoading: taskLoading, isFetching: taskFetching } = useTaskPerformance(dateFromString, dateToString);
   const { data: profitability, isLoading: profitabilityLoading, isFetching: profitabilityFetching } = useProfitability(dateFromString, dateToString);
@@ -475,15 +473,6 @@ export default function AdminAnalyticsPage() {
                     <TrendingUp className="h-4 w-4 text-muted-foreground" />
                     Conversion Funnel
                   </h2>
-                  <Select value={analyticsSource} onValueChange={(v) => setAnalyticsSource(v as AnalyticsSource)}>
-                    <SelectTrigger className="w-32 h-8 text-xs">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="vercel">Vercel</SelectItem>
-                      <SelectItem value="ga">Google Analytics</SelectItem>
-                    </SelectContent>
-                  </Select>
                 </div>
 
                 <div className="p-5">
@@ -525,36 +514,64 @@ export default function AdminAnalyticsPage() {
                         </div>
                       </div>
 
-                      {/* Paid */}
-                      <Popover>
-                        <PopoverTrigger asChild>
-                          <div className="flex-1 text-center p-4 rounded-r-lg bg-emerald-500/10 cursor-pointer hover:bg-emerald-500/20 transition-colors">
-                            <p className="text-3xl font-bold tracking-tight text-emerald-600">
-                              {conversionFunnel.subscriptions.toLocaleString()}
-                            </p>
-                            <p className="text-sm font-medium mt-1">Paid</p>
-                            <p className="text-xs text-muted-foreground">
-                              {conversionFunnel.visitors > 0
-                                ? ((conversionFunnel.subscriptions / conversionFunnel.visitors) * 100).toFixed(2)
-                                : 0}% of visitors
-                            </p>
-                          </div>
-                        </PopoverTrigger>
-                        <PopoverContent className="w-72 max-h-60 overflow-y-auto">
-                          <h4 className="font-medium text-sm mb-2">New Subscribers</h4>
-                          {conversionFunnel.subscriber_emails?.length > 0 ? (
-                            <ul className="space-y-1">
-                              {conversionFunnel.subscriber_emails.map((email, idx) => (
-                                <li key={idx} className="text-sm">
-                                  <UserEmailLink email={email} onUserClick={handleUserEmailClick} />
-                                </li>
-                              ))}
-                            </ul>
-                          ) : (
-                            <p className="text-sm text-muted-foreground">No new subscribers</p>
-                          )}
-                        </PopoverContent>
-                      </Popover>
+                      {/* Paid - with web/app breakdown */}
+                      <div className="flex-1 text-center p-4 rounded-r-lg bg-emerald-500/10">
+                        <p className="text-3xl font-bold tracking-tight text-emerald-600">
+                          {conversionFunnel.subscriptions.toLocaleString()}
+                        </p>
+                        <p className="text-sm font-medium mt-1">Paid</p>
+                        <p className="text-xs text-muted-foreground">
+                          {conversionFunnel.visitors > 0
+                            ? ((conversionFunnel.subscriptions / conversionFunnel.visitors) * 100).toFixed(2)
+                            : 0}% of visitors
+                        </p>
+                        {/* Web/App breakdown */}
+                        <div className="flex justify-center gap-3 mt-2 text-xs">
+                          <Popover>
+                            <PopoverTrigger asChild>
+                              <button className="text-blue-600 hover:underline cursor-pointer">
+                                Web: {conversionFunnel.web_subscriber_emails?.length || 0}
+                              </button>
+                            </PopoverTrigger>
+                            <PopoverContent className="w-72 max-h-60 overflow-y-auto">
+                              <h4 className="font-medium text-sm mb-2">Web Subscribers</h4>
+                              {conversionFunnel.web_subscriber_emails?.length > 0 ? (
+                                <ul className="space-y-1">
+                                  {conversionFunnel.web_subscriber_emails.map((email, idx) => (
+                                    <li key={idx} className="text-sm">
+                                      <UserEmailLink email={email} onUserClick={handleUserEmailClick} />
+                                    </li>
+                                  ))}
+                                </ul>
+                              ) : (
+                                <p className="text-sm text-muted-foreground">No web subscribers</p>
+                              )}
+                            </PopoverContent>
+                          </Popover>
+                          <span className="text-muted-foreground">|</span>
+                          <Popover>
+                            <PopoverTrigger asChild>
+                              <button className="text-purple-600 hover:underline cursor-pointer">
+                                App: {conversionFunnel.app_subscriber_emails?.length || 0}
+                              </button>
+                            </PopoverTrigger>
+                            <PopoverContent className="w-72 max-h-60 overflow-y-auto">
+                              <h4 className="font-medium text-sm mb-2">App Subscribers</h4>
+                              {conversionFunnel.app_subscriber_emails?.length > 0 ? (
+                                <ul className="space-y-1">
+                                  {conversionFunnel.app_subscriber_emails.map((email, idx) => (
+                                    <li key={idx} className="text-sm">
+                                      <UserEmailLink email={email} onUserClick={handleUserEmailClick} />
+                                    </li>
+                                  ))}
+                                </ul>
+                              ) : (
+                                <p className="text-sm text-muted-foreground">No app subscribers</p>
+                              )}
+                            </PopoverContent>
+                          </Popover>
+                        </div>
+                      </div>
                     </div>
                   ) : (
                     <p className="text-sm text-muted-foreground text-center py-4">
@@ -919,7 +936,7 @@ export default function AdminAnalyticsPage() {
 
           {/* ARR Simulator Tab */}
           <TabsContent value="simulator" className="mt-0">
-            <ARRSimulator analyticsSource={analyticsSource} />
+            <ARRSimulator analyticsSource="vercel" />
           </TabsContent>
         </Tabs>
 

--- a/apps/frontend/src/hooks/admin/use-admin-analytics.ts
+++ b/apps/frontend/src/hooks/admin/use-admin-analytics.ts
@@ -77,7 +77,9 @@ export interface ConversionFunnel {
   visitors: number;
   signups: number;
   subscriptions: number;
-  subscriber_emails: string[];  // Emails of new paid subscribers for this date
+  // Breakdown by platform (clickable to see emails)
+  web_subscriber_emails: string[];
+  app_subscriber_emails: string[];
   visitor_to_signup_rate: number;
   signup_to_subscription_rate: number;
   overall_conversion_rate: number;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces platform-specific paid subscriber details and simplifies analytics source handling.
> 
> - UI: Conversion Funnel "Paid" now shows web/app counts with popovers listing `web_subscriber_emails` and `app_subscriber_emails`; removes source selector and associated state; `ARRSimulator` and `useConversionFunnel` now use `vercel` explicitly
> - Types/API: Replaces `subscriber_emails` with `web_subscriber_emails` and `app_subscriber_emails` in `ConversionFunnel` (frontend `use-admin-analytics.ts` and backend `analytics_admin_api.py`)
> - Backend logic: Separately aggregates emails from Stripe (web) and RevenueCat (app), returns deduped lists per platform
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7a958833eed11f8b44beb6038370cdd6af504a86. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->