### PR TITLE
active users separation

### DIFF
--- a/apps/frontend/src/app/(dashboard)/admin/analytics/page.tsx
+++ b/apps/frontend/src/app/(dashboard)/admin/analytics/page.tsx
@@ -622,8 +622,11 @@ export default function AdminAnalyticsPage() {
                       {/* Row 1: Key financial metrics */}
                       <div className="grid grid-cols-6 gap-4">
                         <div className="text-center p-3 rounded-lg bg-muted/30">
-                          <p className="text-xl font-bold">—</p>
+                          <p className="text-xl font-bold">{profitability.total_active_subscriptions?.toLocaleString() ?? '—'}</p>
                           <p className="text-xs text-muted-foreground">Total Active Subs</p>
+                          <p className="text-[10px] text-muted-foreground mt-1">
+                            Web: {profitability.stripe_active_subscriptions?.toLocaleString() ?? '—'} | App: {profitability.revenuecat_active_subscriptions?.toLocaleString() ?? '—'}
+                          </p>
                         </div>
                         <div className="text-center p-3 rounded-lg bg-muted/30">
                           <p className="text-xl font-bold">—</p>

--- a/apps/frontend/src/hooks/admin/use-admin-analytics.ts
+++ b/apps/frontend/src/hooks/admin/use-admin-analytics.ts
@@ -896,6 +896,11 @@ export interface ProfitabilitySummary {
   unique_active_users: number;   // Users who had usage (including free)
   paying_user_emails: string[];  // Emails of paying users (clickable)
 
+  // Active subscription counts (from credit_accounts, paid tiers only)
+  total_active_subscriptions: number;  // Total paid subs (Stripe + RevenueCat)
+  stripe_active_subscriptions: number;  // Stripe paid subscriptions
+  revenuecat_active_subscriptions: number;  // RevenueCat paid subscriptions
+
   // Meta
   period_start: string;
   period_end: string;

--- a/backend/supabase/migrations/20260120085241_active_subscription_counts_rpc.sql
+++ b/backend/supabase/migrations/20260120085241_active_subscription_counts_rpc.sql
@@ -1,0 +1,18 @@
+-- RPC function to get active subscription counts (paid tiers only)
+CREATE OR REPLACE FUNCTION get_active_subscription_counts()
+RETURNS TABLE (
+    stripe_paid BIGINT,
+    revenuecat_paid BIGINT
+)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    SELECT
+        COUNT(*) FILTER (WHERE stripe_subscription_id IS NOT NULL AND tier NOT IN ('free', 'none')) as stripe_paid,
+        COUNT(*) FILTER (WHERE revenuecat_subscription_id IS NOT NULL AND tier NOT IN ('free', 'none')) as revenuecat_paid
+    FROM credit_accounts;
+$$;
+
+-- Grant execute permission to service_role only (admin backend)
+GRANT EXECUTE ON FUNCTION get_active_subscription_counts() TO service_role;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces visibility into current paid subscribers across platforms.
> 
> - Backend: Extend `ProfitabilitySummary` with `total_active_subscriptions`, `stripe_active_subscriptions`, `revenuecat_active_subscriptions`; fetch via new RPC `get_active_subscription_counts` and return in `/profitability`.
> - Database: Add SQL migration creating `get_active_subscription_counts()` to count paid subs by provider from `credit_accounts`.
> - Frontend: Show `Total Active Subs` in `admin/analytics/page.tsx` with Web/App breakdown; update `use-admin-analytics` types to include the new fields.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f10678f9720a484c61e175ebd691d369680035a5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->