### PR TITLE
fetch app users frim api

### DIFF
--- a/apps/frontend/src/hooks/admin/use-admin-analytics.ts
+++ b/apps/frontend/src/hooks/admin/use-admin-analytics.ts
@@ -896,10 +896,9 @@ export interface ProfitabilitySummary {
   unique_active_users: number;   // Users who had usage (including free)
   paying_user_emails: string[];  // Emails of paying users (clickable)
 
-  // Active subscription counts (from credit_accounts, paid tiers only)
-  total_active_subscriptions: number;  // Total paid subs (Stripe + RevenueCat)
-  stripe_active_subscriptions: number;  // Stripe paid subscriptions
-  revenuecat_active_subscriptions: number;  // RevenueCat paid subscriptions
+  total_active_subscriptions: number;
+  stripe_active_subscriptions: number;
+  revenuecat_active_subscriptions: number;
 
   // Meta
   period_start: string;

--- a/backend/core/utils/config.py
+++ b/backend/core/utils/config.py
@@ -361,6 +361,7 @@ class Configuration:
     # RevenueCat configuration
     REVENUECAT_WEBHOOK_SECRET: Optional[str] = None
     REVENUECAT_API_KEY: Optional[str] = None
+    REVENUECAT_PROJECT_ID: Optional[str] = None
     
     # Stripe Product IDs
     STRIPE_PRODUCT_ID_PROD: Optional[str] = 'prod_SCl7AQ2C8kK1CD'


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces RevenueCat active subscription integration into profitability metrics.
> 
> - Adds `_fetch_revenuecat_active_subscriptions` to call RevenueCat v2 metrics API and return `active_subscriptions`
> - Updates `get_profitability` to fetch Stripe RPC counts and RevenueCat counts in parallel, computing `total_active_subscriptions`, `stripe_active_subscriptions`, and `revenuecat_active_subscriptions`
> - Extends config with `REVENUECAT_PROJECT_ID` for API calls
> - Aligns TS/Pydantic `ProfitabilitySummary` to include subscription count fields (functional behavior unchanged on shape)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bc02390b9feb1b4b4384b7eb989331a3eff10e58. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->