### PR TITLE
fix billing issue

### DIFF
--- a/backend/core/agents/pipeline/stateless/coordinator/execution.py
+++ b/backend/core/agents/pipeline/stateless/coordinator/execution.py
@@ -165,13 +165,6 @@ class ExecutionEngine:
                 self._state._messages.append(msg)
             logger.debug(f"✅ [ExecutionEngine] State updated after compression: {len(self._state._messages)} messages")
         
-        cost = self._state.estimate_cost(tokens, 1000)
-        if not self._state.deduct_credits(cost):
-            logger.error(f"[ExecutionEngine] Insufficient credits for LLM call (required: {cost})")
-            self._state._terminate("error: insufficient_credits")
-            yield {"type": "error", "error": "Insufficient credits", "error_code": "INSUFFICIENT_CREDITS"}
-            return
-
         processor_config = ProcessorConfig(
             xml_tool_calling=config.AGENT_XML_TOOL_CALLING,
             native_tool_calling=config.AGENT_NATIVE_TOOL_CALLING,

--- a/backend/core/agents/pipeline/stateless/coordinator/response_processor.py
+++ b/backend/core/agents/pipeline/stateless/coordinator/response_processor.py
@@ -18,6 +18,8 @@ class ResponseProcessor:
         llm_response_id = str(uuid.uuid4())
         auto_continue_count = self._state.step - 1
         thread_run_id = self._message_builder._get_thread_run_id()
+        final_llm_response = None
+        finish_processed = False 
 
         if auto_continue_count == 0:
             self._state.add_status_message(
@@ -56,6 +58,10 @@ class ResponseProcessor:
                     yield chunk
                 continue
 
+            if hasattr(chunk, 'usage') and chunk.usage and final_llm_response is None:
+                final_llm_response = chunk
+                logger.debug(f"📊 [ResponseProcessor] Captured usage: prompt={getattr(chunk.usage, 'prompt_tokens', 0)}, completion={getattr(chunk.usage, 'completion_tokens', 0)}")
+            
             if not hasattr(chunk, 'choices') or not chunk.choices:
                 continue
 
@@ -76,9 +82,10 @@ class ResponseProcessor:
                 if tc_chunk:
                     yield tc_chunk
 
-            if finish_reason:
+            if finish_reason and not finish_processed:
+                finish_processed = True
                 async for msg in self._handle_finish_reason(
-                    finish_reason, tool_calls, tool_call_buffer, stream_start, llm_response_id
+                    finish_reason, tool_calls, tool_call_buffer, stream_start, llm_response_id, None
                 ):
                     yield msg
                 
@@ -86,6 +93,11 @@ class ResponseProcessor:
                 tool_call_buffer = {}
                 tool_call_sent_lengths = {}
 
+        if finish_processed:
+            response_data = self._extract_usage_data(final_llm_response, llm_response_id)
+            self._state.add_llm_response_end(llm_response_id, thread_run_id, response_data)
+            yield self._message_builder.build_llm_response_end()
+        
         if self._state._accumulated_content and not self._state._terminated:
             accumulated_content = self._state._accumulated_content
             assistant_message_id = self._state.finalize_assistant_message(
@@ -100,6 +112,36 @@ class ResponseProcessor:
         if isinstance(content, list):
             return ''.join(str(item) for item in content)
         return content
+    
+    def _extract_usage_data(self, final_llm_response, llm_response_id: str) -> Dict[str, Any]:
+        response_data = {"llm_response_id": llm_response_id}
+        
+        if final_llm_response and hasattr(final_llm_response, 'usage') and final_llm_response.usage:
+            usage = final_llm_response.usage
+            response_data["usage"] = {
+                "prompt_tokens": getattr(usage, 'prompt_tokens', 0),
+                "completion_tokens": getattr(usage, 'completion_tokens', 0),
+                "total_tokens": getattr(usage, 'total_tokens', 0),
+            }
+            
+            if hasattr(usage, 'cache_read_input_tokens'):
+                response_data["usage"]["cache_read_input_tokens"] = getattr(usage, 'cache_read_input_tokens', 0)
+            if hasattr(usage, 'cache_creation_input_tokens'):
+                response_data["usage"]["cache_creation_input_tokens"] = getattr(usage, 'cache_creation_input_tokens', 0)
+            if hasattr(usage, 'prompt_tokens_details'):
+                details = usage.prompt_tokens_details
+                response_data["usage"]["prompt_tokens_details"] = {
+                    "cached_tokens": getattr(details, 'cached_tokens', 0),
+                }
+            
+            if hasattr(final_llm_response, 'model'):
+                response_data["model"] = final_llm_response.model
+            
+            logger.info(f"💰 [ResponseProcessor] Usage data for billing: {response_data['usage']}")
+        else:
+            logger.warning(f"⚠️ [ResponseProcessor] No usage data available from LLM response")
+        
+        return response_data
 
     def _process_tool_call_deltas(self, tool_calls, tool_call_buffer):
         for tc_delta in tool_calls:
@@ -130,13 +172,14 @@ class ResponseProcessor:
         tool_calls: list, 
         tool_call_buffer: Dict, 
         stream_start: str,
-        llm_response_id: str
+        llm_response_id: str,
+        final_llm_response = None
     ) -> AsyncGenerator[Dict[str, Any], None]:
         if finish_reason == "tool_calls":
-            async for msg in self._handle_tool_calls_finish(tool_calls, tool_call_buffer, stream_start, llm_response_id):
+            async for msg in self._handle_tool_calls_finish(tool_calls, tool_call_buffer, stream_start, llm_response_id, final_llm_response):
                 yield msg
         elif finish_reason in ("stop", "end_turn"):
-            async for msg in self._handle_stop_finish(tool_calls, stream_start, llm_response_id):
+            async for msg in self._handle_stop_finish(tool_calls, stream_start, llm_response_id, final_llm_response):
                 yield msg
 
     async def _handle_tool_calls_finish(
@@ -144,7 +187,8 @@ class ResponseProcessor:
         tool_calls: list, 
         tool_call_buffer: Dict, 
         stream_start: str,
-        llm_response_id: str
+        llm_response_id: str,
+        final_llm_response = None
     ) -> AsyncGenerator[Dict[str, Any], None]:
         thread_run_id = self._message_builder._get_thread_run_id()
         
@@ -178,14 +222,12 @@ class ResponseProcessor:
         )
         yield self._message_builder.build_finish_message("tool_calls", tools_executed=True)
         
-        self._state.add_llm_response_end(llm_response_id, thread_run_id)
-        yield self._message_builder.build_llm_response_end()
-
     async def _handle_stop_finish(
         self, 
         tool_calls: list, 
         stream_start: str,
-        llm_response_id: str
+        llm_response_id: str,
+        final_llm_response = None
     ) -> AsyncGenerator[Dict[str, Any], None]:
         thread_run_id = self._message_builder._get_thread_run_id()
         
@@ -209,5 +251,3 @@ class ResponseProcessor:
         )
         yield self._message_builder.build_finish_message("stop")
         
-        self._state.add_llm_response_end(llm_response_id, thread_run_id)
-        yield self._message_builder.build_llm_response_end()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Moves billing to usage-based flow and captures usage from streamed LLM responses for accurate post-run charging.
> 
> - Capture final token usage and `model` from streamed responses in `ResponseProcessor`, emit `llm_response_end` with usage payload; ensure finish is processed once
> - Persist `llm_response_start/end` and, in `BatchWriter`, detect `llm_response_end` messages and call `billing_integration.deduct_usage` (supports cache read/creation tokens)
> - Remove shadow credit tracking and per-call deductions from `RunState` and `ExecutionEngine`; add startup `check_and_reserve_credits` with user-facing error on insufficient funds
> - Drop WAL credit flush path; batching now only persists messages and triggers billing off `llm_response_end`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9289f78b038e2e5e10bbd04fe98eea903582b943. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->