### PR TITLE
Add 'buy more credits' button to dashboard pricing page only

### DIFF
--- a/apps/frontend/src/components/billing/pricing/plan-selection-modal.tsx
+++ b/apps/frontend/src/components/billing/pricing/plan-selection-modal.tsx
@@ -103,6 +103,7 @@ export function PlanSelectionModal({
                             alertTitle={storeAlertTitle}
                             alertSubtitle={storeAlertSubtitle}
                             onSubscriptionUpdate={handleSubscriptionUpdate}
+                            showBuyCredits={true}
                         />
                     </div>
                 </div>

--- a/apps/frontend/src/components/billing/pricing/pricing-section.tsx
+++ b/apps/frontend/src/components/billing/pricing/pricing-section.tsx
@@ -1010,6 +1010,7 @@ interface PricingSectionProps {
   isAlert?: boolean;
   alertTitle?: string;
   alertSubtitle?: string;
+  showBuyCredits?: boolean;
 }
 
 export function PricingSection({
@@ -1022,7 +1023,8 @@ export function PricingSection({
   customTitle,
   isAlert = false,
   alertTitle,
-  alertSubtitle
+  alertSubtitle,
+  showBuyCredits = false
 }: PricingSectionProps) {
   const t = useTranslations('billing');
   const { user } = useAuth();
@@ -1434,8 +1436,9 @@ export function PricingSection({
           )}
         </div>
 
-        {/* Get Additional Credits Button - Only visible if tier allows credit purchases */}
-        {isAuthenticated &&
+        {/* Get Additional Credits Button - Only visible on dashboard pricing page when tier allows credit purchases */}
+        {showBuyCredits &&
+          isAuthenticated &&
           currentSubscription?.subscription.can_purchase_credits && (
             <div className="w-full max-w-6xl mt-12 flex flex-col items-center gap-4">
               <Button


### PR DESCRIPTION
Added showBuyCredits prop to PricingSection to control visibility of the buy credits button. Only enabled in PlanSelectionModal for dashboard context.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a feature flag to conditionally show the buy-credits CTA on pricing.
> 
> - Adds `showBuyCredits` prop to `PricingSection` (default `false`)
> - Renders "Get Additional Credits" button only when `showBuyCredits` && authenticated && `currentSubscription.subscription.can_purchase_credits`; opens `CreditPurchaseModal` and includes a "Credits Explained" link
> - Passes `showBuyCredits={true}` from `plan-selection-modal.tsx` to enable the button on the dashboard pricing modal
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eea3c6da3516d82e402c87a901fcdaff4e51fd54. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->