### PR TITLE
fix: credits free tier

### DIFF
--- a/backend/core/billing/subscriptions/free_tier_service.py
+++ b/backend/core/billing/subscriptions/free_tier_service.py
@@ -97,6 +97,11 @@ class FreeTierService:
                     )
 
                 logger.info(f"[FREE TIER] ✅ LOCAL mode: Created mock subscription {mock_subscription_id} for {account_id}")
+
+                # Invalidate account_state cache to ensure fresh data is fetched
+                from ..shared.cache_utils import invalidate_account_state_cache
+                await invalidate_account_state_cache(account_id)
+
                 return {
                     'success': True,
                     'subscription_id': mock_subscription_id,
@@ -200,7 +205,12 @@ class FreeTierService:
                 logger.info(f"[FREE TIER] User {account_id} already has sufficient credits, skipping grant")
             
             logger.info(f"[FREE TIER] ✅ Successfully created free tier subscription {subscription.id} for {account_id}")
-            
+
+            # Invalidate account_state cache to ensure fresh data is fetched
+            from ..shared.cache_utils import invalidate_account_state_cache
+            await invalidate_account_state_cache(account_id)
+            logger.info(f"[FREE TIER] Invalidated account_state cache for {account_id}")
+
             return {
                 'success': True,
                 'subscription_id': subscription.id,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Ensures fresh account data after free-tier setup by clearing cached state.
> 
> - Calls `invalidate_account_state_cache(account_id)` in `free_tier_service.py` after creating mock (LOCAL) and real (Stripe) subscriptions and credit grants
> - Adds corresponding log message for cache invalidation
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 629326e0afd3c6737423822203a53bce127e3798. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->