### PR TITLE
dhont show img in iframe in ask

### DIFF
--- a/apps/frontend/src/components/thread/file-attachment/index.tsx
+++ b/apps/frontend/src/components/thread/file-attachment/index.tsx
@@ -374,6 +374,18 @@ function isUrl(str: string): boolean {
     return str.startsWith('http://') || str.startsWith('https://');
 }
 
+// Helper function to check if a URL points to an image
+function isImageUrl(url: string): boolean {
+    try {
+        const urlObj = new URL(url);
+        const pathname = urlObj.pathname.toLowerCase();
+        const imageExtensions = ['.jpg', '.jpeg', '.png', '.gif', '.webp', '.svg', '.bmp', '.ico', '.heic', '.heif'];
+        return imageExtensions.some(ext => pathname.endsWith(ext));
+    } catch {
+        return false;
+    }
+}
+
 export function FileAttachmentGrid({
     attachments,
     onFileClick,
@@ -425,6 +437,45 @@ export function FileAttachmentGrid({
             {urls.length > 0 && (
                 <div className="space-y-3">
                     {urls.map((url, index) => {
+                        // Check if this URL is an image
+                        if (isImageUrl(url)) {
+                            // Extract filename from URL for caption
+                            let imageName = '';
+                            try {
+                                const urlObj = new URL(url);
+                                const pathname = urlObj.pathname;
+                                imageName = pathname.split('/').pop() || '';
+                                // Decode URI and clean up the name
+                                imageName = decodeURIComponent(imageName).replace(/[_-]/g, ' ');
+                            } catch {
+                                // Keep empty if parsing fails
+                            }
+
+                            return (
+                                <span
+                                    key={`url-${index}`}
+                                    className="block my-5"
+                                >
+                                    <img
+                                        src={url}
+                                        alt={imageName}
+                                        className={cn(
+                                            "max-w-full h-auto rounded-xl",
+                                            "border border-border/40",
+                                            "shadow-sm"
+                                        )}
+                                        loading="lazy"
+                                    />
+                                    {imageName && (
+                                        <span className="block mt-2 text-center text-sm text-muted-foreground">
+                                            {imageName}
+                                        </span>
+                                    )}
+                                </span>
+                            );
+                        }
+
+                        // Non-image URLs: render with iframe preview
                         let domain = url;
                         try {
                             const urlObj = new URL(url);
@@ -432,7 +483,7 @@ export function FileAttachmentGrid({
                         } catch {
                             // Keep original URL if parsing fails
                         }
-                        
+
                         return (
                             <div
                                 key={`url-${index}`}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improves URL handling in `FileAttachmentGrid` to better preview external links.
> 
> - Adds `isImageUrl` to detect image URLs and render them as images with optional decoded filename captions
> - Keeps iframe-based previews for non-image URLs with domain header and open-in-new-tab action
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a70905fd27f14d2aa4dd6d424cd4236ff3b886df. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->