### PR TITLE
feat: add reasoning grace period to prevent text appearing before rea…

### DIFF
--- a/apps/frontend/src/lib/streaming/types.ts
+++ b/apps/frontend/src/lib/streaming/types.ts
@@ -21,7 +21,7 @@ export type AgentStatus =
   | 'error';
 
 export interface StreamMessage {
-  type: 'assistant' | 'tool' | 'status' | 'user' | 'system' | 'ping' | 'tool_output_stream' | 'llm_response_start' | 'llm_response_end' | 'browser_state' | 'image_context' | 'ack' | 'estimate' | 'prep_stage' | 'degradation' | 'thinking' | 'error';
+  type: 'assistant' | 'tool' | 'status' | 'user' | 'system' | 'ping' | 'tool_output_stream' | 'llm_response_start' | 'llm_response_end' | 'browser_state' | 'image_context' | 'ack' | 'estimate' | 'prep_stage' | 'degradation' | 'thinking' | 'reasoning' | 'error';
   message_id?: string;
   thread_id?: string;
   content?: string;

--- a/backend/core/agents/pipeline/stateless/coordinator/message_builder.py
+++ b/backend/core/agents/pipeline/stateless/coordinator/message_builder.py
@@ -91,12 +91,30 @@ class MessageBuilder:
             "updated_at": stream_start
         }
 
+    def build_reasoning_chunk(self, reasoning_content: str, stream_start: str) -> Dict[str, Any]:
+        seq = self._increment_sequence()
+        return {
+            "sequence": seq,
+            "message_id": None,
+            "thread_id": self._get_thread_id(),
+            "type": "reasoning",
+            "is_llm_message": True,
+            "content": json.dumps({"reasoning_content": reasoning_content}),
+            "metadata": json.dumps({
+                "stream_status": "reasoning_chunk",
+                "thread_run_id": self._get_thread_run_id()
+            }),
+            "created_at": stream_start,
+            "updated_at": stream_start
+        }
+
     def build_assistant_complete(
-        self, 
-        message_id: str, 
-        content: str, 
-        tool_calls: Optional[List[Dict[str, Any]]], 
-        stream_start: str
+        self,
+        message_id: str,
+        content: str,
+        tool_calls: Optional[List[Dict[str, Any]]],
+        stream_start: str,
+        reasoning_content: Optional[str] = None
     ) -> Dict[str, Any]:
         unified_tool_calls = []
         transformed_tool_calls = []
@@ -135,6 +153,8 @@ class MessageBuilder:
         }
         if unified_tool_calls:
             metadata["tool_calls"] = unified_tool_calls
+        if reasoning_content:
+            metadata["reasoning_content"] = reasoning_content
         
         inner_content = {"role": "assistant", "content": content or ""}
         if transformed_tool_calls:

--- a/packages/shared/src/streaming/use-agent-stream-core.ts
+++ b/packages/shared/src/streaming/use-agent-stream-core.ts
@@ -568,12 +568,24 @@ export function useAgentStreamCore(
       case 'llm_response_start':
         // Ignore metadata-only messages
         break;
-        
+
+      case 'reasoning':
+        // Handle dedicated reasoning stream events from backend
+        // This is sent as type: "reasoning" with content: {"reasoning_content": "..."}
+        const reasoningFromContent = parsedContent.reasoning_content;
+        if (reasoningFromContent) {
+          const reasoningText = typeof reasoningFromContent === 'string'
+            ? reasoningFromContent
+            : String(reasoningFromContent);
+          setReasoningContent((prev) => prev + reasoningText);
+        }
+        break;
+
       case 'user':
       case 'system':
         if (message.message_id) callbacksRef.current.onMessage(message);
         break;
-        
+
       default:
         console.warn('[useAgentStreamCore] Unhandled message type:', message.type);
     }

--- a/packages/shared/src/types/messages.ts
+++ b/packages/shared/src/types/messages.ts
@@ -19,6 +19,7 @@ export interface UnifiedMessage {
     | 'tool'
     | 'system'
     | 'status'
+    | 'reasoning'
     | 'browser_state'
     | 'image_context'
     | 'llm_response_end'
@@ -74,6 +75,8 @@ export interface ParsedContent {
   is_error?: boolean;
   /** Error/status message text */
   message?: string;
+  /** Reasoning/thinking content from models with reasoning capabilities */
+  reasoning_content?: string;
   /** Usage stats for llm_response_end messages */
   usage?: {
     prompt_tokens?: number;
@@ -122,6 +125,8 @@ export interface ParsedMetadata {
   }>;
   /** Text content */
   text_content?: string;
+  /** Reasoning/thinking content from models with reasoning capabilities */
+  reasoning_content?: string;
   /** Function name - stored directly in metadata, not in result */
   function_name?: string;
   /** Tool result */


### PR DESCRIPTION
…soning

- Add 200ms grace period when agent starts to allow reasoning to arrive first
- Hide text/tool content during grace period, keep showing loader
- End grace period immediately when reasoning content arrives
- Apply fix to both frontend (ThreadContent.tsx) and mobile (ThreadContent.tsx)
- Add backend support for streaming reasoning chunks in stateless pipeline

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enhances streaming UX to show reasoning first and wires reasoning chunks across stack.
> 
> - **UI (web & mobile)**: Add 200ms reasoning grace period when agent starts; hide streaming text/tool calls during grace; show loader; end grace immediately on reasoning arrival or agent stop; cleanup timeouts. Applies in `ThreadContent.tsx` (web/mobile) to text, tool calls, loaders, and visibility checks.
> - **Streaming client**: Add `reasoning` message type handling in `use-agent-stream-core` and message processor; accumulate and display `reasoning_chunk` events; update shared types.
> - **Backend (stateless pipeline)**: Stream reasoning via new `reasoning` messages (`build_reasoning_chunk`); capture reasoning from provider deltas (incl. block formats) and append to state; include `reasoning_content` in assistant complete metadata; reset accumulated reasoning on finalize.
> 
> - *Minor*: Dependency arrays and cleanup for timers; visibility logic updates to avoid duplication/flash.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8b1319a19cf2b0f5de419dfbf35b46c1fd57e000. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->