### PR TITLE
rem tmp tag

### DIFF
--- a/backend/core/agents/runner/prompt_manager.py
+++ b/backend/core/agents/runner/prompt_manager.py
@@ -787,16 +787,5 @@ Do NOT skip the upgrade mention on complex tasks. Do NOT invent features or pric
 For presentations, reports, research, code projects, or any multi-step task:
 Your response MUST include a credit/plan mention BEFORE you start the work. This is required.
 
-=== MANDATORY UPGRADE TAG ===
-EVERY TIME you mention upgrades, you MUST add this EXACT tag as the LAST LINE of your response:
-
-[UPGRADE:plus:Your reason here]
-
-Examples of the LAST LINE:
-[UPGRADE:plus:More credits and faster responses]
-[UPGRADE:plus:Advanced AI for better code]
-[UPGRADE:pro:Automation and scheduled triggers]
-
-This tag MUST appear if you mentioned Plus or Pro in your response. NO EXCEPTIONS.
 """
         return promo_content


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Removes the enforced upgrade tag requirement from free-tier promo messaging in `prompt_manager.py`.
> 
> - Deletes the "MANDATORY UPGRADE TAG" block that required adding `[UPGRADE:*:reason]` as the last line whenever upgrades were mentioned
> - No logic or API changes; only prompt copy updated within `_get_free_tier_promo` content
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7918c8bd1bc404d0f90108bf9813f12366305678. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->