### PR TITLE
use mimo for free tier

### DIFF
--- a/backend/core/agents/api.py
+++ b/backend/core/agents/api.py
@@ -750,7 +750,15 @@ async def unified_agent_start(
         model_name = await model_manager.get_default_model_for_user(client, account_id)
     elif model_name != "mock-ai":
         model_name = model_manager.resolve_model_id(model_name)
-    
+
+    if model_name in ("kortix/basic", "kortix-basic") and config.ENV_MODE != EnvMode.LOCAL:
+        from core.billing.subscriptions import subscription_service
+        from core.cache.runtime_cache import get_cached_tier_info
+        tier_info = await get_cached_tier_info(account_id) or await subscription_service.get_user_subscription_tier(account_id)
+        if tier_info.get('name') in ('free', 'none'):
+            logger.info(f"⚡ [MODEL_OVERRIDE] Free tier user {account_id} - using mimo-v2-flash instead of basic")
+            model_name = "kortix/mimo-v2-flash"
+
     memory_enabled_bool = memory_enabled.lower() == 'true' if memory_enabled else None
     
     skip_limits = False
@@ -779,7 +787,19 @@ async def unified_agent_start(
             from core.files.upload_handler import fast_parse_files
             final_prompt, files_data = await fast_parse_files(files, final_prompt)
             logger.info(f"[AGENT_START] Received {len(files)} files, parsed {len(files_data)} for upload")
-        
+        if files_data and model_name == "kortix/mimo-v2-flash":
+            has_images = any(mime.startswith("image/") for _, _, mime, _ in files_data)
+            if has_images:
+                logger.info(f"⚡ [IMAGE_UPGRADE] Free tier user uploaded image - injecting upgrade prompt")
+                final_prompt = f"""[SYSTEM INSTRUCTION: The user uploaded an image but they are on the FREE tier which does not support image analysis. You MUST respond by:
+1. Acknowledge you see they uploaded an image
+2. Explain that image analysis requires an upgrade
+3. Promote Plus ($20/month) which includes: image analysis, unlimited threads, 4,000 credits/month, advanced AI models, and faster responses
+4. Be friendly and encouraging about upgrading
+DO NOT attempt to analyze or describe the image. Just deliver the upgrade message naturally.]
+
+{final_prompt}"""
+
         result = await start_agent_run(
             account_id=account_id,
             prompt=final_prompt,

--- a/backend/core/agents/runner/prompt_manager.py
+++ b/backend/core/agents/runner/prompt_manager.py
@@ -767,6 +767,9 @@ MULTI-STEP OR LONG TASKS:
 STUDY/EDUCATION (flashcards, notes, quizzes, homework, explanations):
 "I can help with that! Note: study tasks use credits. Basic gets 300/week. Plus ($20/month) gives you 4,000/month and faster, better explanations."
 
+IMAGES/VISION (when user uploads an image, screenshot, photo, or asks about visual content):
+"I can see and analyze your image! Note: You're on Basic which uses our standard vision model. Plus ($20/month) gives you access to advanced AI with better image understanding, more detailed analysis, and faster responses."
+
 ANY OTHER NON-TRIVIAL TASK (design, planning, translation, image work, writing, analysis, etc.):
 If the task takes more than a quick answer, mention: "Just a heads up - you're on Basic (300 credits/week, slower AI). Plus ($20/month) gives you more credits and faster, better results."
 
@@ -784,8 +787,9 @@ Mention the upgrade BEFORE diving into the task. Start with something like:
 Do NOT skip the upgrade mention on complex tasks. Do NOT invent features or pricing.
 
 === CRITICAL ===
-For presentations, reports, research, code projects, or any multi-step task:
+For presentations, reports, research, code projects, image analysis, or any multi-step task:
 Your response MUST include a credit/plan mention BEFORE you start the work. This is required.
+When a user uploads an image, ALWAYS mention the upgrade - this is a key upsell moment.
 
 """
         return promo_content


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Model routing change (free tier)**
> - Auto-override `kortix/basic`/`kortix-basic` to `kortix/mimo-v2-flash` for free/none tiers (non-local env).
> 
> **Image upload handling (free tier)**
> - If using `kortix/mimo-v2-flash` and files include images, prepend a system instruction that acknowledges the image, disallows analysis, and promotes Plus with specific benefits/pricing.
> 
> **Prompt promo updates**
> - Add free-tier promo copy for images/vision and mark image analysis as a “critical” upsell moment in `PromptManager`.
> 
> Risk: Medium — Alters model selection and runtime prompt injection for free users, impacting request handling and user messaging.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit acbfd57eb26e4ccaac4b6cdd762ca3d56019d866. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->