### PR TITLE
upgrade in caht

### DIFF
--- a/apps/frontend/src/components/thread/chat-input/upgrade-preview.tsx
+++ b/apps/frontend/src/components/thread/chat-input/upgrade-preview.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { X } from 'lucide-react';
+import { X, Sparkles } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { isLocalMode } from '@/lib/config';
 import { Button } from '@/components/ui/button';
@@ -98,6 +98,20 @@ export const UpgradePreview: React.FC<UpgradePreviewProps> = ({
                     ))}
                 </button>
             )}
+
+            {/* Upgrade Button */}
+            <Button
+                variant="default"
+                size="sm"
+                className="h-8 px-3 flex-shrink-0 gap-1.5"
+                onClick={(e) => {
+                    e.stopPropagation();
+                    onOpenUpgrade?.();
+                }}
+            >
+                <Sparkles className="h-3.5 w-3.5" />
+                <span>Upgrade</span>
+            </Button>
 
             <Button variant="ghost" size="icon" className="h-8 w-8 flex-shrink-0 hover:bg-muted/50" onClick={(e) => { e.stopPropagation(); onClose?.(); }}>
                 <X className="h-4 w-4 text-muted-foreground hover:text-foreground transition-colors" />

--- a/apps/frontend/src/components/thread/content/StreamingText.tsx
+++ b/apps/frontend/src/components/thread/content/StreamingText.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { ComposioUrlDetector } from './composio-url-detector';
+import { UpgradeCTA, extractUpgradeCTA } from './UpgradeCTA';
 
 export interface StreamingTextProps {
   content: string;
@@ -10,5 +11,13 @@ export const StreamingText: React.FC<StreamingTextProps> = ({
   content,
   isStreaming = false,
 }) => {
-  return <ComposioUrlDetector content={content} isStreaming={isStreaming} />;
+  // Extract upgrade CTA if present
+  const { cleanContent, hasCTA } = extractUpgradeCTA(content);
+
+  return (
+    <>
+      <ComposioUrlDetector content={cleanContent} isStreaming={isStreaming} />
+      {hasCTA && !isStreaming && <UpgradeCTA />}
+    </>
+  );
 };

--- a/apps/frontend/src/components/thread/content/UpgradeCTA.tsx
+++ b/apps/frontend/src/components/thread/content/UpgradeCTA.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import React from 'react';
+import { Sparkles } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { usePricingModalStore } from '@/stores/pricing-modal-store';
+import { isLocalMode } from '@/lib/config';
+
+export function UpgradeCTA() {
+  const openPricingModal = usePricingModalStore((s) => s.openPricingModal);
+
+  if (isLocalMode()) return null;
+
+  return (
+    <Button
+      variant="default"
+      size="sm"
+      className="h-9 px-4 gap-2 my-3"
+      onClick={() => openPricingModal()}
+    >
+      <Sparkles className="h-4 w-4" />
+      <span>Upgrade</span>
+    </Button>
+  );
+}
+
+// Regex to match <upgrade_cta .../> tags
+const UPGRADE_CTA_REGEX = /<upgrade_cta\s*(?:recommended_plan=["']?(?:plus|pro)["']?)?\s*\/?>/gi;
+
+/**
+ * Extracts upgrade CTA tags from content and returns clean content + whether CTA was found
+ */
+export function extractUpgradeCTA(content: string): {
+  cleanContent: string;
+  hasCTA: boolean;
+} {
+  let hasCTA = false;
+
+  const cleanContent = content.replace(UPGRADE_CTA_REGEX, () => {
+    hasCTA = true;
+    return '';
+  });
+
+  return {
+    cleanContent: cleanContent.trim(),
+    hasCTA,
+  };
+}

--- a/apps/frontend/src/hooks/messages/utils/assistant-message-renderer.tsx
+++ b/apps/frontend/src/hooks/messages/utils/assistant-message-renderer.tsx
@@ -14,6 +14,7 @@ import { ToolCard } from '@/components/thread/content/ToolCard';
 import { ApifyApprovalInline } from '@/components/thread/content/ApifyApprovalInline';
 import { MediaGenerationInline } from '@/components/thread/content/MediaGenerationInline';
 import { constructHtmlPreviewUrl } from '@/lib/utils/url';
+import { UpgradeCTA, extractUpgradeCTA } from '@/components/thread/content/UpgradeCTA';
 
 export interface AssistantMessageRendererProps {
   message: UnifiedMessage;
@@ -49,12 +50,16 @@ function renderAskToolCall(
   const attachments = normalizeAttachments(toolCall.arguments?.attachments);
   const followUpAnswers = normalizeArrayValue(toolCall.arguments?.follow_up_answers);
 
+  // Extract upgrade CTA if present
+  const { cleanContent, hasCTA } = extractUpgradeCTA(askText);
+
   return (
     <div key={`ask-${index}`} className="space-y-3 my-1.5">
-      <ComposioUrlDetector 
-        content={askText} 
-        className="text-sm prose prose-sm dark:prose-invert chat-markdown max-w-none break-words [&>:first-child]:mt-0 prose-headings:mt-3" 
+      <ComposioUrlDetector
+        content={cleanContent}
+        className="text-sm prose prose-sm dark:prose-invert chat-markdown max-w-none break-words [&>:first-child]:mt-0 prose-headings:mt-3"
       />
+      {hasCTA && <UpgradeCTA />}
       {attachments.length > 0 && (
         <div className="mt-3">
           <FileAttachmentGrid
@@ -102,14 +107,18 @@ function renderCompleteToolCall(
   const attachments = normalizeAttachments(toolCall.arguments?.attachments);
   const followUpPrompts = normalizeArrayValue(toolCall.arguments?.follow_up_prompts);
 
+  // Extract upgrade CTA if present
+  const { cleanContent, hasCTA } = extractUpgradeCTA(completeText);
+
   return (
     <div key={`complete-${index}`} className="space-y-3 my-1.5">
       {/* Main content */}
-      <ComposioUrlDetector 
-        content={completeText} 
-        className="text-sm prose prose-sm dark:prose-invert chat-markdown max-w-none break-words [&>:first-child]:mt-0 prose-headings:mt-3" 
+      <ComposioUrlDetector
+        content={cleanContent}
+        className="text-sm prose prose-sm dark:prose-invert chat-markdown max-w-none break-words [&>:first-child]:mt-0 prose-headings:mt-3"
       />
-      
+      {hasCTA && <UpgradeCTA />}
+
       {/* Attachments underneath the text */}
       {attachments.length > 0 && (
         <div className="mt-4 space-y-3">
@@ -128,7 +137,7 @@ function renderCompleteToolCall(
           />
         </div>
       )}
-      
+
       {/* Task completed feedback */}
       <TaskCompletedFeedback
         taskSummary={completeText}
@@ -557,12 +566,16 @@ export function renderAssistantMessage(props: AssistantMessageRendererProps): Re
   const shouldRenderTextContent = textContent.trim() && textContent.trim() !== askCompleteText.trim();
 
   if (shouldRenderTextContent) {
+    // Extract upgrade CTA if present
+    const { cleanContent, hasCTA } = extractUpgradeCTA(textContent);
+
     contentParts.push(
       <div key="text-content" className="my-1.5">
         <ComposioUrlDetector
-          content={textContent}
+          content={cleanContent}
           className="text-sm prose prose-sm dark:prose-invert chat-markdown max-w-none break-words"
         />
+        {hasCTA && <UpgradeCTA />}
       </div>
     );
   }

--- a/backend/core/agents/runner/prompt_manager.py
+++ b/backend/core/agents/runner/prompt_manager.py
@@ -714,82 +714,83 @@ Multiple parallel tool calls:
 
         promo_content = """
 
-IMPORTANT: This user is on the FREE (Basic) tier. You MUST mention upgrades for any non-trivial task. Use ONLY the facts below - never make up pricing or features.
+<free_tier_user>
+This user is on the FREE (Basic) tier with limited features. When appropriate, mention upgrades and include an upgrade button.
 
-=== PLAN DETAILS (USE ONLY THESE) ===
+=== UPGRADE BUTTON ===
+When you mention upgrading, ALWAYS include this tag to show an upgrade button:
+<upgrade_cta/>
+
+=== KORTIX PLANS ===
 
 FREE (Basic) - $0/month:
-- 300 credits/week (refreshes weekly)
-- 1 concurrent run (no parallel tasks)
+- 300 credits/week
+- 1 concurrent run
 - 1 chat only
-- Basic AI model (slower, less capable)
+- Basic AI model (slower)
 - No custom AI workers
 - No automation/triggers
 - 2 projects max
 
-PLUS - $20/month ($17/month yearly):
+PLUS - $20/month:
 - 4,000 credits/month
 - 3 concurrent runs
 - Unlimited chats
-- Advanced AI models (faster responses, better quality, smarter reasoning)
+- Advanced AI models (faster, smarter)
 - 5 custom AI workers
 - 5 scheduled triggers
 - 25 app triggers
 
-PRO - $50/month ($42.50/month yearly):
+PRO - $50/month:
 - 10,000 credits/month
 - 5 concurrent runs
 - Unlimited chats
-- Advanced AI models (fastest, highest quality)
+- Best AI models
 - 20 custom AI workers
 - 10 scheduled triggers
 - 50 app triggers
 
-=== WHEN TO PUSH UPGRADES ===
+=== WHEN TO SHOW UPGRADE BUTTON ===
 
-ALWAYS mention upgrades for these tasks (weave it into your response naturally):
+1. FEATURE NOT AVAILABLE: When user asks for something their tier doesn't support
+   Example: "Automation requires Plus or higher. Your current plan doesn't include this feature."
+   <upgrade_cta/>
 
-COMPLEX TASKS (presentations, research, reports, web scraping, data analysis):
-"Heads up - this uses credits and you're on Basic (300/week). Plus ($20/month) gives you 4,000 credits/month plus faster, higher-quality responses."
+2. COMPLEX TASKS: Presentations, research, reports, code projects, data analysis
+   Example: "I'll help with that! Quick note - you're on Basic (300 credits/week). For tasks like this, Plus gives you 4,000 credits/month."
+   <upgrade_cta/>
 
-CODE & TECHNICAL WORK (building apps, debugging, complex scripts):
-"I'm on the basic AI which is slower and less capable. Plus ($20/month) unlocks advanced AI models - faster responses and much better at complex code."
+3. RUNNING LOW: When task will use significant credits
+   Example: "This will use several credits. You're on Basic with limited weekly credits."
+   <upgrade_cta/>
 
-AUTOMATION & WORKFLOWS (scheduling, triggers, recurring tasks):
-"Automation requires Plus ($20/month) or higher. Basic is manual-only."
+4. ASKING ABOUT CAPABILITIES: When user asks what Kortix can do
+   Example: "I can do a lot more on Plus! You'd get faster AI, unlimited chats, and 4,000 credits/month."
+   <upgrade_cta/>
 
-WHEN THEY ASK WHAT YOU CAN DO:
-"I can do a lot! On Basic you get 300 credits/week and the basic AI. Plus ($20/month) gives you faster responses, smarter AI, unlimited chats, and 4,000 credits/month."
+=== WHEN NOT TO SHOW ===
+- Simple greetings (hi, hello)
+- Quick one-line answers
+- Already showed upgrade in this conversation recently
 
-MULTI-STEP OR LONG TASKS:
-"This will take several steps. You're on Basic (300 credits/week, slower AI). Plus ($20/month) gives you 4,000 credits/month and faster, better responses."
+=== EXAMPLES ===
 
-STUDY/EDUCATION (flashcards, notes, quizzes, homework, explanations):
-"I can help with that! Note: study tasks use credits. Basic gets 300/week. Plus ($20/month) gives you 4,000/month and faster, better explanations."
+User: "Create a presentation about AI"
+You: "I'd love to help! Just so you know, you're on the Basic plan with 300 credits/week. Presentations use several credits - Plus ($20/month) gives you 4,000/month and faster responses.
+<upgrade_cta/>
 
-IMAGES/VISION (when user uploads an image, screenshot, photo, or asks about visual content):
-"I can see and analyze your image! Note: You're on Basic which uses our standard vision model. Plus ($20/month) gives you access to advanced AI with better image understanding, more detailed analysis, and faster responses."
+Let me start on your presentation..."
 
-ANY OTHER NON-TRIVIAL TASK (design, planning, translation, image work, writing, analysis, etc.):
-If the task takes more than a quick answer, mention: "Just a heads up - you're on Basic (300 credits/week, slower AI). Plus ($20/month) gives you more credits and faster, better results."
+User: "Set up a daily automation"
+You: "Automation features require Plus or Pro. Your Basic plan is manual-only.
+<upgrade_cta/>
 
-=== WHEN NOT TO MENTION ===
-Skip upgrade mentions for trivial tasks:
-- Greetings (hi, hello, hey)
-- Simple questions (what time is it, tell me a joke)
-- Quick fixes (fix this typo)
-- Single-line answers
+If you'd like, I can help you do this task manually instead?"
 
-=== TONE ===
-Mention the upgrade BEFORE diving into the task. Start with something like:
-"I'll create that for you! Quick note - this kind of task uses credits and you're on Basic (300/week). Plus ($20/month) gives 4,000/month if you plan to do this often. Now let me..."
+User: "What can you do?"
+You: "I'm Kortix - I can help with research, coding, documents, and much more! You're on Basic which has some limits. Upgrade to Plus for unlimited chats, faster AI, and way more credits.
+<upgrade_cta/>"
 
-Do NOT skip the upgrade mention on complex tasks. Do NOT invent features or pricing.
-
-=== CRITICAL ===
-For presentations, reports, research, code projects, image analysis, or any multi-step task:
-Your response MUST include a credit/plan mention BEFORE you start the work. This is required.
-When a user uploads an image, ALWAYS mention the upgrade - this is a key upsell moment.
-
+</free_tier_user>
 """
         return promo_content


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces a tag-driven upsell flow and updates promo guidance for free-tier users.
> 
> - Add `UpgradeCTA` component and `extractUpgradeCTA` parser to detect `<upgrade_cta/>` tags and render an Upgrade button; suppressed in streaming and local modes
> - Integrate CTA rendering into `StreamingText` and assistant message renderer (ask/complete/text_content) using cleaned content to avoid showing raw tags
> - Add an explicit Upgrade button to `upgrade-preview.tsx` (with Sparkles icon)
> - Revamp backend `prompt_manager` free-tier promo: wrap in `<free_tier_user>` block, include plan details, clear rules/examples, and require emitting `<upgrade_cta/>` for relevant scenarios
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c9e3a54197b44fa3f2f424f9407144ca42eae9c5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->