### PR TITLE
kimi for free

### DIFF
--- a/backend/core/agents/api.py
+++ b/backend/core/agents/api.py
@@ -756,8 +756,8 @@ async def unified_agent_start(
         from core.cache.runtime_cache import get_cached_tier_info
         tier_info = await get_cached_tier_info(account_id) or await subscription_service.get_user_subscription_tier(account_id)
         if tier_info.get('name') in ('free', 'none'):
-            logger.info(f"⚡ [MODEL_OVERRIDE] Free tier user {account_id} - using mimo-v2-flash instead of basic")
-            model_name = "kortix/mimo-v2-flash"
+            logger.info(f"⚡ [MODEL_OVERRIDE] Free tier user {account_id} - using kimi-k2 instead of basic")
+            model_name = "kortix/kimi-k2"
 
     memory_enabled_bool = memory_enabled.lower() == 'true' if memory_enabled else None
     
@@ -787,7 +787,7 @@ async def unified_agent_start(
             from core.files.upload_handler import fast_parse_files
             final_prompt, files_data = await fast_parse_files(files, final_prompt)
             logger.info(f"[AGENT_START] Received {len(files)} files, parsed {len(files_data)} for upload")
-        if files_data and model_name == "kortix/mimo-v2-flash":
+        if files_data and model_name == "kortix/kimi-k2":
             has_images = any(mime.startswith("image/") for _, _, mime, _ in files_data)
             if has_images:
                 logger.info(f"⚡ [IMAGE_UPGRADE] Free tier user uploaded image - injecting upgrade prompt")

--- a/backend/core/agents/runner/prompt_manager.py
+++ b/backend/core/agents/runner/prompt_manager.py
@@ -715,82 +715,41 @@ Multiple parallel tool calls:
         promo_content = """
 
 <free_tier_user>
-This user is on the FREE (Basic) tier with limited features. When appropriate, mention upgrades and include an upgrade button.
+**THIS USER IS ON THE FREE TIER.** For any non-trivial task, you must:
+1. Mention they're on the free/Basic plan with limits
+2. Mention the benefits of upgrading
+3. Include the upgrade button tag: <upgrade_cta/>
 
-=== UPGRADE BUTTON ===
-When you mention upgrading, ALWAYS include this tag to show an upgrade button:
+The <upgrade_cta/> tag renders as a clickable "Upgrade" button. Always include it when discussing plans/upgrades.
+
+PLANS:
+- FREE: 300 credits/week, 1 chat, basic AI, no automation
+- PLUS $20/mo: 4,000 credits/month, unlimited chats, fast AI, automation
+- PRO $50/mo: 10,000 credits/month, best AI, more automation
+
+ALWAYS SHOW <upgrade_cta/> FOR:
+- Presentations, reports, research, code projects
+- Automation requests (not available on free)
+- "What can you do?" questions
+- Any task using multiple credits
+
+DO NOT SHOW FOR: Simple greetings, one-line answers
+
+EXAMPLE RESPONSES:
+
+User: "Make a presentation"
+Response: "I'll create that! Note: you're on Basic (300 credits/week). Plus gives you 4,000/month and faster AI.
 <upgrade_cta/>
+Now let me build your presentation..."
 
-=== KORTIX PLANS ===
-
-FREE (Basic) - $0/month:
-- 300 credits/week
-- 1 concurrent run
-- 1 chat only
-- Basic AI model (slower)
-- No custom AI workers
-- No automation/triggers
-- 2 projects max
-
-PLUS - $20/month:
-- 4,000 credits/month
-- 3 concurrent runs
-- Unlimited chats
-- Advanced AI models (faster, smarter)
-- 5 custom AI workers
-- 5 scheduled triggers
-- 25 app triggers
-
-PRO - $50/month:
-- 10,000 credits/month
-- 5 concurrent runs
-- Unlimited chats
-- Best AI models
-- 20 custom AI workers
-- 10 scheduled triggers
-- 50 app triggers
-
-=== WHEN TO SHOW UPGRADE BUTTON ===
-
-1. FEATURE NOT AVAILABLE: When user asks for something their tier doesn't support
-   Example: "Automation requires Plus or higher. Your current plan doesn't include this feature."
-   <upgrade_cta/>
-
-2. COMPLEX TASKS: Presentations, research, reports, code projects, data analysis
-   Example: "I'll help with that! Quick note - you're on Basic (300 credits/week). For tasks like this, Plus gives you 4,000 credits/month."
-   <upgrade_cta/>
-
-3. RUNNING LOW: When task will use significant credits
-   Example: "This will use several credits. You're on Basic with limited weekly credits."
-   <upgrade_cta/>
-
-4. ASKING ABOUT CAPABILITIES: When user asks what Kortix can do
-   Example: "I can do a lot more on Plus! You'd get faster AI, unlimited chats, and 4,000 credits/month."
-   <upgrade_cta/>
-
-=== WHEN NOT TO SHOW ===
-- Simple greetings (hi, hello)
-- Quick one-line answers
-- Already showed upgrade in this conversation recently
-
-=== EXAMPLES ===
-
-User: "Create a presentation about AI"
-You: "I'd love to help! Just so you know, you're on the Basic plan with 300 credits/week. Presentations use several credits - Plus ($20/month) gives you 4,000/month and faster responses.
+User: "Set up automation"
+Response: "Automation requires Plus or Pro - not available on Basic.
 <upgrade_cta/>
-
-Let me start on your presentation..."
-
-User: "Set up a daily automation"
-You: "Automation features require Plus or Pro. Your Basic plan is manual-only.
-<upgrade_cta/>
-
-If you'd like, I can help you do this task manually instead?"
+I can help manually instead if you'd like."
 
 User: "What can you do?"
-You: "I'm Kortix - I can help with research, coding, documents, and much more! You're on Basic which has some limits. Upgrade to Plus for unlimited chats, faster AI, and way more credits.
+Response: "I can help with docs, code, research and more! You're on Basic with some limits. Plus unlocks faster AI and unlimited chats.
 <upgrade_cta/>"
-
 </free_tier_user>
 """
         return promo_content


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> - **Model override update**: Free/none tier users requesting `kortix/basic` now run on `kortix/kimi-k2` (non-local env). Image-upload upgrade prompt injection now triggers when model is `kortix/kimi-k2`.
> - **Free-tier promo refresh**: Replaces verbose promo with concise rules, plan bullets, clear guidance on when to include `<upgrade_cta/>`, and short example responses in `prompt_manager.py`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d94a799ccd23dea30b405b1f26e8517fc44cc8bd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->