### PR TITLE
undo tier check

### DIFF
--- a/backend/core/agents/runner/prompt_manager.py
+++ b/backend/core/agents/runner/prompt_manager.py
@@ -688,25 +688,25 @@ Multiple parallel tool calls:
         if not user_id:
             return None
 
-        # try:
-        #     from core.billing.subscriptions.handlers.tier import TierHandler
-        #     from core.utils.config import config, EnvMode
+        try:
+            from core.billing.subscriptions.handlers.tier import TierHandler
+            from core.utils.config import config, EnvMode
 
-        #     # Skip tier check in local mode (for testing)
-        #     if config.ENV_MODE == EnvMode.LOCAL:
-        #         logger.debug(f"[PROMO] Local mode - showing promo for testing")
-        #     else:
-        #         tier_info = await TierHandler.get_user_subscription_tier(user_id)
-        #         tier_name = tier_info.get('name', 'free')
+            # Skip tier check in local mode (for testing)
+            if config.ENV_MODE == EnvMode.LOCAL:
+                logger.debug(f"[PROMO] Local mode - showing promo for testing")
+            else:
+                tier_info = await TierHandler.get_user_subscription_tier(user_id)
+                tier_name = tier_info.get('name', 'free')
 
-        #         if tier_name not in ('free', 'none'):
-        #             logger.debug(f"[PROMO] User {user_id} is on {tier_name} tier - skipping promo")
-        #             return None
+                if tier_name not in ('free', 'none'):
+                    logger.debug(f"[PROMO] User {user_id} is on {tier_name} tier - skipping promo")
+                    return None
 
-        # except Exception as e:
-        #     logger.warning(f"[PROMO] Failed to check tier for {user_id}: {e} - skipping promo (fail safe)")
-        #     return None
-        # logger.info(f"✅ [PROMO] User {user_id} is on free tier - injecting upgrade promo")
+        except Exception as e:
+            logger.warning(f"[PROMO] Failed to check tier for {user_id}: {e} - skipping promo (fail safe)")
+            return None
+        logger.info(f"✅ [PROMO] User {user_id} is on free tier - injecting upgrade promo")
 
         promo_content = """
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Restores tier-based gating for promotional messaging in `PromptManager._get_free_tier_promo`.
> 
> - Activates async check via `TierHandler.get_user_subscription_tier` and skips promo for non-free tiers
> - Skips tier check in local mode; adds info/debug logging and fail-safe early return on errors
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d577b453e48bc94c3876ecaa99a5d655eaaa0f7b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->