### PR TITLE
html to pdf

### DIFF
--- a/apps/frontend/src/components/thread/kortix-computer/FileViewerView.tsx
+++ b/apps/frontend/src/components/thread/kortix-computer/FileViewerView.tsx
@@ -1074,6 +1074,7 @@ export function FileViewerView({
                   content={typeof rawContent === 'string' ? rawContent : ''}
                   fileName={fileName}
                   getHtmlContent={mdEditorControls?.getHtml ? () => mdEditorControls.getHtml() : undefined}
+                  sandboxUrl={project?.sandbox?.sandbox_url}
                 />
               </>
             </TooltipProvider>

--- a/apps/frontend/src/components/thread/tool-views/file-operation/FileOperationToolView.tsx
+++ b/apps/frontend/src/components/thread/tool-views/file-operation/FileOperationToolView.tsx
@@ -1082,6 +1082,7 @@ export function FileOperationToolView({
                           content={fileContent || ''}
                           fileName={fileName}
                           disabled={isStreaming || !fileContent}
+                          sandboxUrl={project?.sandbox?.sandbox_url}
                         />
                       </span>
                     </TooltipTrigger>

--- a/apps/frontend/src/components/thread/tool-views/file-operation/PdfExportToolView.tsx
+++ b/apps/frontend/src/components/thread/tool-views/file-operation/PdfExportToolView.tsx
@@ -1,0 +1,208 @@
+'use client';
+
+import React, { useState, useMemo } from 'react';
+import { FileText, Download, CheckCircle2, AlertCircle } from 'lucide-react';
+import { KortixLoader } from '@/components/ui/kortix-loader';
+import { ToolViewProps } from '../types';
+import { formatTimestamp } from '../utils';
+import { toast } from '@/lib/toast';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { ToolViewIconTitle } from '../shared/ToolViewIconTitle';
+import { LoadingState } from '../shared/LoadingState';
+import { useAuth } from '@/components/AuthProvider';
+import { useDownloadRestriction } from '@/hooks/billing';
+
+export function PdfExportToolView({
+  toolCall,
+  toolResult,
+  assistantTimestamp,
+  toolTimestamp,
+  isStreaming = false,
+  project,
+}: ToolViewProps) {
+  const { session } = useAuth();
+  const { isRestricted: isDownloadRestricted, openUpgradeModal } = useDownloadRestriction({
+    featureName: 'exports',
+  });
+
+  const [isDownloading, setIsDownloading] = useState(false);
+
+  // Parse the tool result
+  const { outputFile, fileName, message, isSuccess } = useMemo(() => {
+    if (toolResult?.output) {
+      try {
+        const output = toolResult.output;
+        const parsed = typeof output === 'string' ? JSON.parse(output) : output;
+
+        const outputFilePath = parsed.output_file || '';
+        const extractedFileName = outputFilePath.split('/').pop() || 'document.pdf';
+
+        return {
+          outputFile: outputFilePath,
+          fileName: extractedFileName,
+          message: parsed.message || '',
+          isSuccess: toolResult.success !== false && !!parsed.output_file,
+        };
+      } catch (e) {
+        console.error('[PdfExportToolView] Parse error:', e);
+        return { outputFile: '', fileName: '', message: '', isSuccess: false };
+      }
+    }
+    return { outputFile: '', fileName: '', message: '', isSuccess: false };
+  }, [toolResult]);
+
+  const filePath = toolCall?.arguments?.file_path || '';
+  const sourceFileName = filePath.split('/').pop() || 'document';
+
+  if (!toolCall) return null;
+
+  const handleDownload = async () => {
+    if (isDownloadRestricted) {
+      openUpgradeModal();
+      return;
+    }
+
+    if (!outputFile || !project?.sandbox?.id) {
+      toast.error('Unable to download - missing file or sandbox info');
+      return;
+    }
+
+    setIsDownloading(true);
+    try {
+      const headers: Record<string, string> = {};
+      if (session?.access_token) {
+        headers['Authorization'] = `Bearer ${session.access_token}`;
+      }
+
+      const downloadPath = outputFile.startsWith('/workspace/')
+        ? outputFile
+        : `/workspace/${outputFile}`;
+
+      const response = await fetch(
+        `${process.env.NEXT_PUBLIC_BACKEND_URL}/sandboxes/${project.sandbox.id}/files/content?path=${encodeURIComponent(downloadPath)}`,
+        { headers }
+      );
+
+      if (!response.ok) throw new Error(`Download failed: ${response.status}`);
+
+      const blob = await response.blob();
+      const url = window.URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = fileName;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      window.URL.revokeObjectURL(url);
+
+      toast.success(`Downloaded ${fileName}`);
+    } catch (error) {
+      console.error('Download error:', error);
+      toast.error(`Failed to download: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    } finally {
+      setIsDownloading(false);
+    }
+  };
+
+  // Loading state while streaming
+  if (isStreaming) {
+    return (
+      <Card className="gap-0 flex border-0 shadow-none p-0 rounded-none flex-col h-full overflow-hidden bg-card">
+        <CardHeader className="h-14 bg-zinc-50/80 dark:bg-zinc-900/80 border-b p-2 px-4 flex-shrink-0">
+          <div className="flex flex-row items-center justify-between">
+            <ToolViewIconTitle icon={FileText} title="Export to PDF" />
+          </div>
+        </CardHeader>
+        <CardContent className="p-0 flex-1">
+          <LoadingState
+            icon={FileText}
+            iconColor="text-zinc-500"
+            bgColor="bg-zinc-50 dark:bg-zinc-900"
+            title="Exporting to PDF"
+            filePath={sourceFileName}
+            progressText="Converting HTML to PDF..."
+          />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="gap-0 flex border-0 shadow-none p-0 rounded-none flex-col h-full overflow-hidden bg-card">
+      {/* Header */}
+      <CardHeader className="h-14 bg-zinc-50/80 dark:bg-zinc-900/80 border-b p-2 px-4 flex-shrink-0">
+        <div className="flex flex-row items-center justify-between">
+          <ToolViewIconTitle
+            icon={FileText}
+            title={`Export: ${sourceFileName}`}
+          />
+          {isSuccess && (
+            <div className="flex items-center gap-1.5 text-xs text-emerald-600 dark:text-emerald-400">
+              <CheckCircle2 className="h-3.5 w-3.5" />
+              <span>Ready</span>
+            </div>
+          )}
+        </div>
+      </CardHeader>
+
+      {/* Content */}
+      <CardContent className="p-4">
+        {isSuccess ? (
+          <div className="space-y-3">
+            {/* File info */}
+            <div className="bg-zinc-50 dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-lg p-3">
+              <div className="flex items-center gap-3">
+                <div className="p-2 bg-red-50 dark:bg-red-950/50 rounded-lg">
+                  <FileText className="h-5 w-5 text-red-600 dark:text-red-400" />
+                </div>
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-medium text-zinc-900 dark:text-zinc-100 truncate">
+                    {fileName}
+                  </p>
+                  <p className="text-xs text-zinc-500 dark:text-zinc-400">
+                    PDF Document
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            {/* Download button */}
+            <Button
+              onClick={handleDownload}
+              disabled={isDownloading}
+              className="w-full h-11 bg-black hover:bg-zinc-800 text-white dark:bg-white dark:hover:bg-zinc-200 dark:text-black font-medium transition-colors"
+            >
+              {isDownloading ? (
+                <>
+                  <KortixLoader customSize={16} variant="white" className="mr-2 dark:hidden" />
+                  <KortixLoader customSize={16} variant="black" className="mr-2 hidden dark:flex" />
+                  <span>Downloading...</span>
+                </>
+              ) : (
+                <>
+                  <Download className="h-4 w-4 mr-2" />
+                  <span>Download PDF</span>
+                </>
+              )}
+            </Button>
+          </div>
+        ) : (
+          <div className="flex items-center gap-3 p-3 bg-red-50 dark:bg-red-950/30 border border-red-200 dark:border-red-900 rounded-lg">
+            <AlertCircle className="h-5 w-5 text-red-500 flex-shrink-0" />
+            <p className="text-sm text-red-600 dark:text-red-400">
+              {message || 'Export failed'}
+            </p>
+          </div>
+        )}
+      </CardContent>
+
+      {/* Footer */}
+      <div className="px-4 py-2 h-10 bg-zinc-50/80 dark:bg-zinc-900/80 border-t flex justify-end items-center flex-shrink-0 mt-auto">
+        <span className="text-xs text-muted-foreground">
+          {toolTimestamp ? formatTimestamp(toolTimestamp) : assistantTimestamp ? formatTimestamp(assistantTimestamp) : ''}
+        </span>
+      </div>
+    </Card>
+  );
+}

--- a/apps/frontend/src/components/thread/tool-views/wrapper/ToolViewRegistry.tsx
+++ b/apps/frontend/src/components/thread/tool-views/wrapper/ToolViewRegistry.tsx
@@ -31,6 +31,7 @@ import { DeleteSlideToolView } from '../presentation-tools/DeleteSlideToolView';
 import { DeletePresentationToolView } from '../presentation-tools/DeletePresentationToolView';
 // import { PresentationStylesToolView } from '../presentation-tools/PresentationStylesToolView';
 import { ExportToolView } from '../presentation-tools/ExportToolView';
+import { PdfExportToolView } from '../file-operation/PdfExportToolView';
 import { GetProjectStructureView } from '../web-dev/GetProjectStructureView';
 import { ImageEditGenerateToolView } from '../image-edit-generate-tool/ImageEditGenerateToolView';
 import { DesignerToolView } from '../designer-tool/DesignerToolView';
@@ -216,9 +217,9 @@ const defaultRegistry: ToolViewRegistryType = {
   'export_presentation': ExportToolView,
   // Legacy support for old tool names (backward compatibility)
   'export-to-pptx': ExportToolView,
-  'export-to-pdf': ExportToolView,
+  'export-to-pdf': PdfExportToolView,
   'export_to_pptx': ExportToolView,
-  'export_to_pdf': ExportToolView,
+  'export_to_pdf': PdfExportToolView,
 
   'create-sheet': SheetsToolView,
   'update-sheet': SheetsToolView,

--- a/apps/mobile/components/chat/tool-views/file-operation/FileOperationToolView.tsx
+++ b/apps/mobile/components/chat/tool-views/file-operation/FileOperationToolView.tsx
@@ -836,6 +836,7 @@ export function FileOperationToolView({
                 content={fileContent}
                 fileName={fileName || 'file.txt'}
                 disabled={isStreaming}
+                sandboxUrl={project?.sandbox?.sandbox_url}
               />
             )}
             {fileContent && !isPresentationSlide && (

--- a/backend/core/sandbox/README.md
+++ b/backend/core/sandbox/README.md
@@ -20,7 +20,7 @@ You can modify the sandbox environment for development or to add new capabilitie
    ```
    cd backend/sandbox/docker
    docker compose build
-   docker push kortix/suna:0.1.3.28
+   docker push kortix/suna:0.1.3.30
    ```
 3. Test your changes locally using docker-compose
 

--- a/backend/core/sandbox/docker/docker-compose.yml
+++ b/backend/core/sandbox/docker/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       dockerfile: ${DOCKERFILE:-Dockerfile}
       args:
         TARGETPLATFORM: ${TARGETPLATFORM:-linux/amd64}
-    image: kortix/suna:0.1.3.29
+    image: kortix/suna:0.1.3.30
     ports:
       - "6080:6080"  # noVNC web interface
       - "5901:5901"  # VNC port

--- a/backend/core/utils/config.py
+++ b/backend/core/utils/config.py
@@ -375,8 +375,8 @@ class Configuration:
     STRIPE_PRODUCT_ID_STAGING: Optional[str] = 'prod_SCgIj3G7yPOAWY'
     
     # Sandbox configuration
-    SANDBOX_IMAGE_NAME = "kortix/suna:0.1.3.29"
-    SANDBOX_SNAPSHOT_NAME = "kortix/suna:0.1.3.29"
+    SANDBOX_IMAGE_NAME = "kortix/suna:0.1.3.30"
+    SANDBOX_SNAPSHOT_NAME = "kortix/suna:0.1.3.30"
     SANDBOX_ENTRYPOINT = "/usr/bin/supervisord -n -c /etc/supervisor/conf.d/supervisord.conf"
     
     # Debug configuration

--- a/setup/steps/daytona.py
+++ b/setup/steps/daytona.py
@@ -78,8 +78,8 @@ class DaytonaStep(BaseStep):
         )
         self.info("Visit https://app.daytona.io/dashboard/snapshots to create a snapshot.")
         self.info("Create a snapshot with these exact settings:")
-        self.info("   - Name:          kortix/suna:0.1.3.28")
-        self.info("   - Snapshot name: kortix/suna:0.1.3.28")
+        self.info("   - Name:          kortix/suna:0.1.3.30")
+        self.info("   - Snapshot name: kortix/suna:0.1.3.30")
         self.info("   - Entrypoint:    /usr/bin/supervisord -n -c /etc/supervisor/conf.d/supervisord.conf")
 
         self.prompts.press_enter_to_continue(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces sandbox-powered HTML→PDF export for higher fidelity and consistent downloads across platforms.
> 
> - **Frontend (web/mobile)**: `FileDownloadButton` accepts `sandboxUrl`, adds HTML export flow and PDF via sandbox endpoint; new `PdfExportToolView` for `export-to-pdf`/`export_to_pdf`; registry updated to use it; buttons wired in file views/tool views.
> - **Backend**: Adds `/presentation/html-to-pdf` endpoint (Playwright/Chromium) and `sb_files_tool.export_to_pdf` to convert workspace HTML to PDF and save under `downloads/`; improves export preprocessing (`preprocess_html`) and DOCX export parsing; bumps sandbox image/snapshot to `kortix/suna:0.1.3.30`.
> - **Docs/Config**: Updates sandbox README, docker-compose, and setup snapshot references.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8a45c00dff5f21452c6e9b7bc0ecbd9bd2e09847. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->