### PR TITLE
autocontinue stop reason length

### DIFF
--- a/backend/core/services/llm.py
+++ b/backend/core/services/llm.py
@@ -206,7 +206,9 @@ async def make_llm_api_call(
         override_params["extra_headers"] = extra_headers
     if frequency_penalty is not None:
         override_params["frequency_penalty"] = frequency_penalty
-    
+    if max_tokens is not None:
+        override_params["max_tokens"] = max_tokens
+
     params = model_manager.get_litellm_params(resolved_model_name, **override_params)
     
     if tools:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces explicit handling for max-token cutoffs and ensures downstream consumers can auto-continue reliably.
> 
> - Adds `finish_reason == "length"` path in `response_processor` that finalizes/saves accumulated content, flushes state, and emits `assistant_complete` plus a `finish` status with reason `length`
> - Implements `_handle_length_finish` helper; integrates into `_handle_finish_reason` dispatch
> - LLM service now forwards `max_tokens` in override params to provider calls
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0d521181eef0928a0f1a7c15c3b3dfd294612603. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->