### PR TITLE
hotfix: syncfusion backup key

### DIFF
--- a/apps/frontend/src/components/thread/kortix-computer/components/SpreadsheetApp.tsx
+++ b/apps/frontend/src/components/thread/kortix-computer/components/SpreadsheetApp.tsx
@@ -42,7 +42,7 @@ import '../../../../../node_modules/@syncfusion/ej2-grids/styles/material.css';
 import '../../../../../node_modules/@syncfusion/ej2-react-spreadsheet/styles/material.css';
 import '../../tool-views/spreadsheet/kortix-spreadsheet-styles.css';
 
-const SYNCFUSION_LICENSE = "Ngo9BigBOggjHTQxAR8/V1JGaF5cXGpCf0x0QHxbf1x2ZFFMYFtbRHZPMyBoS35Rc0RhW3ledHRSRmVeVUx+VEFf";
+const SYNCFUSION_LICENSE = "Ngo9BigBOggjHTQxAR8/V1JGaF5cXGpCfEx0QXxbf1x2ZFRMZVxbQXNPIiBoS35RcEViW3pfc3FXQmJYUkZ3VEFf";
 const SYNCFUSION_BASE_URL = 'https://ej2services.syncfusion.com/production/web-services/api/spreadsheet';
 
 registerLicense(SYNCFUSION_LICENSE);

--- a/apps/frontend/src/components/thread/tool-views/spreadsheet/SpreadsheetViewer.tsx
+++ b/apps/frontend/src/components/thread/tool-views/spreadsheet/SpreadsheetViewer.tsx
@@ -26,7 +26,7 @@ import '../../../../../node_modules/@syncfusion/ej2-react-spreadsheet/styles/mat
 import './kortix-spreadsheet-styles.css';
 
 
-const SYNCFUSION_LICENSE = "Ngo9BigBOggjHTQxAR8/V1JGaF5cXGpCf0x0QHxbf1x2ZFFMYFtbRHZPMyBoS35Rc0RhW3ledHRSRmVeVUx+VEFf";
+const SYNCFUSION_LICENSE = "Ngo9BigBOggjHTQxAR8/V1JGaF5cXGpCfEx0QXxbf1x2ZFRMZVxbQXNPIiBoS35RcEViW3pfc3FXQmJYUkZ3VEFf";
 const SYNCFUSION_BASE_URL = 'https://ej2services.syncfusion.com/production/web-services/api/spreadsheet';
 
 registerLicense(SYNCFUSION_LICENSE);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates Syncfusion licensing for the spreadsheet UI.
> 
> - Replaces `SYNCFUSION_LICENSE` value in `SpreadsheetApp.tsx` and `SpreadsheetViewer.tsx`
> - Continues to call `registerLicense` and use the same Syncfusion web service endpoints
> 
> No functional code changes beyond the license key swap.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9291623a6fbe29f352dcabc9744bc87e193b315f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->