### PR TITLE
minimax+friendly upgrade

### DIFF
--- a/apps/frontend/src/components/thread/content/UpgradeCTA.tsx
+++ b/apps/frontend/src/components/thread/content/UpgradeCTA.tsx
@@ -1,26 +1,118 @@
 'use client';
 
-import React from 'react';
-import { Sparkles } from 'lucide-react';
-import { Button } from '@/components/ui/button';
+import React, { useState, useEffect } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { Ticket, ArrowRight, Sparkles } from 'lucide-react';
+import { cn } from '@/lib/utils';
 import { usePricingModalStore } from '@/stores/pricing-modal-store';
 import { isLocalMode } from '@/lib/config';
+import { TierBadge } from '@/components/billing/tier-badge';
+
+const PLANS = ['Plus', 'Pro', 'Ultra'] as const;
 
 export function UpgradeCTA() {
   const openPricingModal = usePricingModalStore((s) => s.openPricingModal);
+  const [currentPlan, setCurrentPlan] = useState(0);
+  const [isHovered, setIsHovered] = useState(false);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setCurrentPlan((prev) => (prev + 1) % PLANS.length);
+    }, 1800);
+    return () => clearInterval(interval);
+  }, []);
 
   if (isLocalMode()) return null;
 
   return (
-    <Button
-      variant="default"
-      size="sm"
-      className="h-9 px-4 gap-2 my-3"
+    <motion.button
       onClick={() => openPricingModal()}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+      initial={{ opacity: 0, y: 6 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.3, ease: 'easeOut' }}
+      className={cn(
+        'group relative flex items-center gap-3 w-full mt-4 p-3',
+        'rounded-2xl border border-border',
+        'bg-gradient-to-r from-muted/80 via-muted/40 to-muted/80',
+        'hover:border-primary/30 hover:from-muted via-muted/60 hover:to-muted',
+        'transition-all duration-300 cursor-pointer text-left',
+        'overflow-hidden'
+      )}
     >
-      <Sparkles className="h-4 w-4" />
-      <span>Upgrade</span>
-    </Button>
+      {/* Subtle animated shimmer on hover */}
+      <motion.div
+        className="absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity duration-500"
+        style={{
+          background: 'linear-gradient(90deg, transparent 0%, rgba(var(--primary-rgb, 0 0 0) / 0.03) 50%, transparent 100%)',
+          backgroundSize: '200% 100%',
+        }}
+        animate={isHovered ? { backgroundPosition: ['200% 0%', '-200% 0%'] } : {}}
+        transition={{ duration: 1.5, ease: 'easeInOut', repeat: Infinity }}
+      />
+
+      {/* Left: Cycling tier badge */}
+      <div className="relative flex-shrink-0 w-10 h-10 flex items-center justify-center">
+        <AnimatePresence mode="wait">
+          <motion.div
+            key={PLANS[currentPlan]}
+            initial={{ opacity: 0, scale: 0.8, y: 6 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            exit={{ opacity: 0, scale: 0.8, y: -6 }}
+            transition={{ duration: 0.25, ease: 'easeOut' }}
+            className="absolute"
+          >
+            <TierBadge planName={PLANS[currentPlan]} size="xs" />
+          </motion.div>
+        </AnimatePresence>
+      </div>
+
+      {/* Center: Content */}
+      <div className="flex-1 min-w-0 flex flex-col gap-0.5">
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-semibold text-foreground">
+            Upgrade & Save
+          </span>
+          <Sparkles className="w-3.5 h-3.5 text-amber-500" />
+        </div>
+
+        {/* Coupon ticket */}
+        <div className="flex items-center gap-1.5">
+          <span className="text-xs text-muted-foreground">
+            Use code
+          </span>
+          <span className={cn(
+            'inline-flex items-center gap-1 px-1.5 py-0.5',
+            'rounded-md bg-primary/10 border border-primary/20',
+            'text-xs font-mono font-semibold text-primary',
+            'tracking-wide'
+          )}>
+            KORTIX2026
+          </span>
+          <span className="text-xs text-muted-foreground">
+            for
+          </span>
+          <span className="text-xs font-semibold text-foreground">
+            30% off + 2X credits
+          </span>
+        </div>
+      </div>
+
+      {/* Right: Arrow CTA */}
+      <motion.div
+        className={cn(
+          'flex-shrink-0 flex items-center justify-center',
+          'w-8 h-8 rounded-xl',
+          'bg-primary text-primary-foreground',
+          'shadow-sm'
+        )}
+        animate={{ x: isHovered ? 2 : 0 }}
+        transition={{ duration: 0.2 }}
+      >
+        <ArrowRight className="w-4 h-4" />
+      </motion.div>
+    </motion.button>
   );
 }
 

--- a/backend/core/agents/api.py
+++ b/backend/core/agents/api.py
@@ -756,8 +756,8 @@ async def unified_agent_start(
         from core.cache.runtime_cache import get_cached_tier_info
         tier_info = await get_cached_tier_info(account_id) or await subscription_service.get_user_subscription_tier(account_id)
         if tier_info.get('name') in ('free', 'none'):
-            logger.info(f"⚡ [MODEL_OVERRIDE] Free tier user {account_id} - using kimi-k2 instead of basic")
-            model_name = "kortix/kimi-k2"
+            logger.info(f"⚡ [MODEL_OVERRIDE] Free tier user {account_id} - using minimax instead of basic")
+            model_name = "kortix/minimax"
 
     memory_enabled_bool = memory_enabled.lower() == 'true' if memory_enabled else None
     
@@ -787,7 +787,7 @@ async def unified_agent_start(
             from core.files.upload_handler import fast_parse_files
             final_prompt, files_data = await fast_parse_files(files, final_prompt)
             logger.info(f"[AGENT_START] Received {len(files)} files, parsed {len(files_data)} for upload")
-        if files_data and model_name == "kortix/kimi-k2":
+        if files_data and model_name == "kortix/minimax":
             has_images = any(mime.startswith("image/") for _, _, mime, _ in files_data)
             if has_images:
                 logger.info(f"⚡ [IMAGE_UPGRADE] Free tier user uploaded image - injecting upgrade prompt")

--- a/backend/core/agents/runner/prompt_manager.py
+++ b/backend/core/agents/runner/prompt_manager.py
@@ -688,91 +688,77 @@ Multiple parallel tool calls:
         if not user_id:
             return None
 
-        try:
-            from core.billing.subscriptions.handlers.tier import TierHandler
-            from core.utils.config import config, EnvMode
+        logger.info(f"✅ [PROMO] Injecting upgrade promo for user {user_id}")
 
-            # Skip tier check in local mode (for testing)
-            if config.ENV_MODE == EnvMode.LOCAL:
-                logger.debug(f"[PROMO] Local mode - showing promo for testing")
-            else:
-                tier_info = await TierHandler.get_user_subscription_tier(user_id)
-                tier_name = tier_info.get('name', 'free')
+        # try:
+        #     from core.billing.subscriptions.handlers.tier import TierHandler
+        #     from core.utils.config import config, EnvMode
 
-                if tier_name not in ('free', 'none'):
-                    logger.debug(f"[PROMO] User {user_id} is on {tier_name} tier - skipping promo")
-                    return None
+        #     # Skip tier check in local mode (for testing)
+        #     if config.ENV_MODE == EnvMode.LOCAL:
+        #         logger.debug(f"[PROMO] Local mode - showing promo for testing")
+        #     else:
+        #         tier_info = await TierHandler.get_user_subscription_tier(user_id)
+        #         tier_name = tier_info.get('name', 'free')
 
-        except Exception as e:
-            logger.warning(f"[PROMO] Failed to check tier for {user_id}: {e} - skipping promo (fail safe)")
-            return None
-        logger.info(f"✅ [PROMO] User {user_id} is on free tier - injecting upgrade promo")
+        #         if tier_name not in ('free', 'none'):
+        #             logger.debug(f"[PROMO] User {user_id} is on {tier_name} tier - skipping promo")
+        #             return None
+
+        # except Exception as e:
+        #     logger.warning(f"[PROMO] Failed to check tier for {user_id}: {e} - skipping promo (fail safe)")
+        #     return None
+        # logger.info(f"✅ [PROMO] User {user_id} is on free tier - injecting upgrade promo")
 
         promo_content = """
 
-<free_tier_user>
-**FREE TIER USER** - Mention plan limits for complex tasks.
+<SYSTEM_INSTRUCTION>
+## FREE TIER USER - CONTEXTUAL UPGRADE PROMPT
 
-PLAN DETAILS (use this to answer questions about plans):
+After completing tasks, add a CONTEXTUAL upgrade message with the <upgrade_cta/> tag.
+The message must relate to what the user asked for - don't use a generic message.
 
-BASIC (FREE):
-- 300 credits/week (refreshes weekly)
-- 1 chat only
-- 1 concurrent run
-- Basic mode
-- NO: custom workers, scheduled triggers, app triggers, integrations
+### CONTEXTUAL MESSAGES (match to task type):
 
-PLUS ($20/mo):
-- 4,000 credits/month
-- Unlimited chats
-- 3 concurrent runs
-- 5 custom AI Workers
-- 5 scheduled triggers, 25 app triggers
-- 100+ integrations (Google Drive, Slack, Notion, Gmail, GitHub...)
-- Advanced mode (faster, better responses)
+PRESENTATIONS → "Want higher quality slides and faster generation? Use code **KORTIX2026** for 30% off + 2X credits! <upgrade_cta/>"
 
-PRO ($50/mo):
-- 10,000 credits/month
-- Unlimited chats
-- 5 concurrent runs
-- 20 custom AI Workers
-- 10 scheduled triggers, 50 app triggers
-- 100+ integrations
-- Advanced mode (best quality)
+CODE/PROGRAMMING → "Need advanced debugging and faster code generation? Use code **KORTIX2026** for 30% off + 2X credits! <upgrade_cta/>"
 
-ULTRA ($200/mo):
-- 40,000 credits/month
-- 20 concurrent runs
-- 100 custom AI Workers
-- 50 scheduled triggers, 200 app triggers
+WRITING/ESSAYS → "Want better writing quality and unlimited revisions? Use code **KORTIX2026** for 30% off + 2X credits! <upgrade_cta/>"
 
-FORMAT - mention limits THEN immediately show <upgrade_cta/> THEN do the task:
-"[Acknowledge task]. You're on free (300 credits/week). Plus gives you faster, better responses and more credits. <upgrade_cta/>
+RESEARCH/ANALYSIS → "Need deeper analysis and faster research? Use code **KORTIX2026** for 30% off + 2X credits! <upgrade_cta/>"
 
-[Now do the task]"
+CAPABILITY QUESTIONS → "Want faster responses and advanced features? Use code **KORTIX2026** for 30% off + 2X credits! <upgrade_cta/>"
 
-EXAMPLES:
+AUTOMATION/WORKFLOWS → "Need integrations and scheduled triggers? Use code **KORTIX2026** for 30% off + 2X credits! <upgrade_cta/>"
 
-User: "Make a presentation on AI"
-You: "I'll create that! You're on the free plan (300 credits/week, 1 chat). Plus gives you 4,000/month, unlimited chats, and faster, higher-quality responses. <upgrade_cta/>
+### EXAMPLES:
 
-Now building your AI presentation..."
+User: "make a ppt on AI"
+You: "[...presentation content...]
 
-User: "What can you do?"
-You: "I can help with presentations, research, code, reports and more! You're on free with 300 credits/week. Plus gives you 4,000/month, unlimited chats, and faster, higher-quality responses. <upgrade_cta/>"
+Want higher quality slides and faster generation? Use code **KORTIX2026** for 30% off + 2X credits! <upgrade_cta/>"
 
-IMPORTANT: <upgrade_cta/> must come RIGHT AFTER mentioning upgrade benefits, not at the end of your response.
+User: "write python code for scraping"
+You: "[...code...]
 
-DO NOT mention upgrades for:
-- Simple greetings (hi, hello, hey)
-- Quick questions with short answers
-- Casual chat
+Need advanced debugging and faster code generation? Use code **KORTIX2026** for 30% off + 2X credits! <upgrade_cta/>"
 
-ALWAYS mention upgrades for:
-- Presentations, reports, research, code projects
-- Automation requests
-- "What can you do?" / capability questions
-- Any task using multiple credits
-</free_tier_user>
+User: "what can you do?"
+You: "[...capabilities list...]
+
+Want faster responses and advanced features? Use code **KORTIX2026** for 30% off + 2X credits! <upgrade_cta/>"
+
+### SKIP ENTIRELY FOR:
+- Simple greetings: hi, hello, hey
+- Thanks, ok, bye, sure
+
+### RULES:
+1. MUST include the <upgrade_cta/> tag (triggers UI button)
+2. Message MUST be contextual to user's task
+3. Keep it helpful, not pushy
+4. Place at END of response
+
+</SYSTEM_INSTRUCTION>
 """
         return promo_content

--- a/backend/core/ai_models/registry.py
+++ b/backend/core/ai_models/registry.py
@@ -83,7 +83,7 @@ class PricingPresets:
     )
 
 
-FREE_MODEL_ID = "kortix/kimi-k2"
+FREE_MODEL_ID = "kortix/minimax"
 PREMIUM_MODEL_ID = "kortix/power"
 IMAGE_MODEL_ID = "kortix/haiku"
 
@@ -597,15 +597,14 @@ class ModelFactory:
     def create_kimi_k2() -> Model:
         return Model(
             id="kortix/kimi-k2",
-            name="Kimi K2 Thinking",
-            litellm_model_id="openrouter/moonshotai/kimi-k2-thinking",
+            name="Kimi K2",
+            litellm_model_id="openrouter/moonshotai/kimi-k2",
             provider=ModelProvider.OPENROUTER,
-            aliases=["kimi-k2", "kimi", "moonshotai/kimi-k2-thinking"],
+            aliases=["kimi-k2", "kimi", "moonshotai/kimi-k2"],
             context_window=262_144,
             capabilities=[
                 ModelCapability.CHAT,
                 ModelCapability.FUNCTION_CALLING,
-                ModelCapability.THINKING,
                 ModelCapability.PROMPT_CACHING,
             ],
             pricing=PricingPresets.KIMI_K2,
@@ -660,7 +659,7 @@ class ModelRegistry:
         self._litellm_id_to_pricing["openrouter/x-ai/grok-4.1-fast"] = PricingPresets.GROK_4_1_FAST
         self._litellm_id_to_pricing["openrouter/openai/gpt-4o-mini"] = PricingPresets.GPT_4O_MINI
         self._litellm_id_to_pricing["openrouter/xiaomi/mimo-v2-flash"] = PricingPresets.MIMO_V2_FLASH
-        self._litellm_id_to_pricing["openrouter/moonshotai/kimi-k2-thinking"] = PricingPresets.KIMI_K2
+        self._litellm_id_to_pricing["openrouter/moonshotai/kimi-k2"] = PricingPresets.KIMI_K2
         self._litellm_id_to_pricing["bedrock/anthropic.claude-3-5-haiku-20241022-v1:0"] = PricingPresets.HAIKU_3_5
         self._litellm_id_to_pricing["openrouter/deepseek/deepseek-chat-v3-0324"] = PricingPresets.DEEPSEEK_V3
     


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> - **Model routing:** Set `FREE_MODEL_ID` to `kortix/minimax`; override `kortix/basic` to `kortix/minimax` for free users; update Kimi mapping (`openrouter/moonshotai/kimi-k2`) and pricing alias map.
> - **Promo logic:** Replace prior free-tier limits blurb with contextual upgrade prompts appended at the end of responses, each including `<upgrade_cta/>` and coupon `KORTIX2026` (presentations/code/writing/research/capabilities/automation variants). Image uploads on free tier inject an upgrade-only response.
> - **Frontend CTA:** Redesign `UpgradeCTA` with animations (Framer Motion), cycling `TierBadge` (Plus/Pro/Ultra), shimmer hover, and coupon display “30% off + 2X credits”; maintains `<upgrade_cta/>` parsing via `extractUpgradeCTA`.
> - **Registry/metadata:** Keep `kortix/kimi-k2` model but adjust name/id and remove thinking capability; ensure pricing mappings align.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5487fb75219060023250266cf0a190cc2a63b40c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->