### PR TITLE
fix cookie pos

### DIFF
--- a/apps/frontend/src/app/globals.css
+++ b/apps/frontend/src/app/globals.css
@@ -950,3 +950,16 @@
 .animate-text-shimmer {
   animation: text-shimmer 1.2s ease-in-out infinite;
 }
+
+/* CookieYes consent button - right side on desktop, left side on mobile */
+.cky-btn-revisit-wrapper {
+  left: auto !important;
+  right: 20px !important;
+}
+
+@media (max-width: 768px) {
+  .cky-btn-revisit-wrapper {
+    left: 20px !important;
+    right: auto !important;
+  }
+}

--- a/apps/frontend/src/app/layout.tsx
+++ b/apps/frontend/src/app/layout.tsx
@@ -22,6 +22,7 @@ const PlanSelectionModal = lazy(() => import('@/components/billing/pricing/plan-
 const AnnouncementDialog = lazy(() => import('@/components/announcements/announcement-dialog').then(mod => ({ default: mod.AnnouncementDialog })));
 const RouteChangeTracker = lazy(() => import('@/components/analytics/route-change-tracker').then(mod => ({ default: mod.RouteChangeTracker })));
 const AuthEventTracker = lazy(() => import('@/components/analytics/auth-event-tracker').then(mod => ({ default: mod.AuthEventTracker })));
+const CookieVisibility = lazy(() => import('@/components/cookie-visibility').then(mod => ({ default: mod.CookieVisibility })));
 
 
 export const viewport: Viewport = {
@@ -280,6 +281,9 @@ export default function RootLayout({
           </Suspense>
           <Suspense fallback={null}>
             <AuthEventTracker />
+          </Suspense>
+          <Suspense fallback={null}>
+            <CookieVisibility />
           </Suspense>
         </ThemeProvider>
       </body>

--- a/apps/frontend/src/components/cookie-visibility.tsx
+++ b/apps/frontend/src/components/cookie-visibility.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+
+export function CookieVisibility() {
+  const pathname = usePathname();
+
+  // Only show cookie button on homepage and dashboard
+  const showOnPaths = ['/', '/dashboard'];
+  const shouldShow = showOnPaths.some(path => pathname === path);
+
+  if (shouldShow) return null;
+
+  return (
+    <style jsx global>{`
+      .cky-btn-revisit-wrapper {
+        display: none !important;
+      }
+    `}</style>
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adjusts CookieYes consent UI visibility and positioning.
> 
> - Adds `CookieVisibility` (lazy-loaded in `layout.tsx`) to hide `.cky-btn-revisit-wrapper` on all routes except `/` and `/dashboard`
> - Updates `globals.css` to position the CookieYes revisit button on the right for desktop and on the left for mobile
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 478ff86d293d914f9ab66fe12964a68ed68cf9f0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->