### PR TITLE
Add Tutorials link to navbar

### DIFF
--- a/apps/frontend/src/lib/site-config.ts
+++ b/apps/frontend/src/lib/site-config.ts
@@ -10,6 +10,7 @@ export const siteConfig = {
       { id: 1, name: 'Home', href: '/' },
       { id: 2, name: 'About', href: '/about' },
       { id: 3, name: 'Pricing', href: '/pricing' },
+      { id: 4, name: 'Tutorials', href: '/tutorials' },
     ],
   },
   hero: {
@@ -30,17 +31,18 @@ export const siteConfig = {
     {
       title: 'Resources',
       links: [
-        { id: 5, title: 'Documentation', url: 'https://github.com/kortix-ai/suna' },
-        { id: 6, title: 'Discord', url: 'https://discord.com/invite/RvFhXUdZ9H' },
-        { id: 7, title: 'GitHub', url: 'https://github.com/kortix-ai/suna' },
+        { id: 5, title: 'Tutorials', url: '/tutorials' },
+        { id: 6, title: 'Documentation', url: 'https://github.com/kortix-ai/suna' },
+        { id: 7, title: 'Discord', url: 'https://discord.com/invite/RvFhXUdZ9H' },
+        { id: 8, title: 'GitHub', url: 'https://github.com/kortix-ai/suna' },
       ],
     },
     {
       title: 'Legal',
       links: [
-        { id: 8, title: 'Privacy Policy', url: '/legal?tab=privacy' },
-        { id: 9, title: 'Terms of Service', url: '/legal?tab=terms' },
-        { id: 10, title: 'License', url: 'https://github.com/kortix-ai/suna/blob/main/LICENSE' },
+        { id: 9, title: 'Privacy Policy', url: '/legal?tab=privacy' },
+        { id: 10, title: 'Terms of Service', url: '/legal?tab=terms' },
+        { id: 11, title: 'License', url: 'https://github.com/kortix-ai/suna/blob/main/LICENSE' },
       ],
     },
   ],


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds Tutorials as a first-class site link.
> 
> - Adds `Tutorials` to top nav and `Resources` footer section (`/tutorials`)
> - Reorders `Resources` footer links and updates link IDs accordingly
> - Adjusts `Legal` footer link IDs (no URL changes)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d1fc6ea2d917ad92fb6771507d487906d78129d0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->