### PR TITLE
Fix ChatInput props type error

### DIFF
--- a/apps/frontend/src/app/(home)/berlin/page.tsx
+++ b/apps/frontend/src/app/(home)/berlin/page.tsx
@@ -155,9 +155,6 @@ export default function BerlinPage() {
                       enableAdvancedConfig={false}
                       selectedMode={selectedMode}
                       onModeDeselect={() => setSelectedMode(null)}
-                      selectedCharts={selectedCharts}
-                      selectedOutputFormat={selectedOutputFormat}
-                      selectedTemplate={selectedTemplate}
                     />
                   </div>
                 </div>

--- a/apps/frontend/src/app/(home)/milano/page.tsx
+++ b/apps/frontend/src/app/(home)/milano/page.tsx
@@ -154,9 +154,6 @@ export default function MilanoPage() {
                       enableAdvancedConfig={false}
                       selectedMode={selectedMode}
                       onModeDeselect={() => setSelectedMode(null)}
-                      selectedCharts={selectedCharts}
-                      selectedOutputFormat={selectedOutputFormat}
-                      selectedTemplate={selectedTemplate}
                     />
                   </div>
                 </div>


### PR DESCRIPTION
Remove selectedCharts, selectedOutputFormat, and selectedTemplate props from ChatInput component as they don't exist in ChatInputProps interface

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes unsupported props from `ChatInput` usage to align with `ChatInputProps` and fix type errors.
> 
> - In `apps/frontend/src/app/(home)/berlin/page.tsx` and `.../milano/page.tsx`, drop `selectedCharts`, `selectedOutputFormat`, and `selectedTemplate` from `ChatInput` props
> - No changes to `SunaModesPanel` usage; the selections remain managed there
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 48fdde372129fcbf654c2f522769ee8da0c7a882. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->