### PR TITLE
Fix downgrade confirmation modal scrollability

### DIFF
--- a/apps/frontend/src/components/billing/downgrade-confirmation-dialog.tsx
+++ b/apps/frontend/src/components/billing/downgrade-confirmation-dialog.tsx
@@ -104,9 +104,9 @@ export function DowngradeConfirmationDialog({
       if (!open) resetAndClose();
       else onOpenChange(open);
     }}>
-      <DialogContent className="sm:max-w-lg p-0 gap-0 overflow-hidden max-h-[90vh] sm:max-h-[85vh]">
+      <DialogContent className="sm:max-w-lg p-0 gap-0 overflow-hidden max-h-[90vh] sm:max-h-[85vh] flex flex-col">
         {step === 1 ? (
-          <div className="p-4 sm:p-8">
+          <div className="p-4 sm:p-8 overflow-y-auto">
             {/* Logo & Header - compact on mobile */}
             <div className="flex flex-col items-center text-center mb-4 sm:mb-6">
               <div className="mb-2 sm:mb-4 p-2 sm:p-3 rounded-xl sm:rounded-2xl bg-muted/50">
@@ -139,7 +139,7 @@ export function DowngradeConfirmationDialog({
             </div>
           </div>
         ) : (
-          <div className="p-4 sm:p-8 overflow-y-auto max-h-[85vh] sm:max-h-none">
+          <div className="p-4 sm:p-8 overflow-y-auto">
             {/* Logo & Header - compact on mobile */}
             <div className="flex flex-col items-center text-center mb-3 sm:mb-6">
               <div className="mb-2 sm:mb-4 p-2 sm:p-3 rounded-xl sm:rounded-2xl bg-muted/50">


### PR DESCRIPTION
Make the modal scrollable when content overflows by adding flex-col to DialogContent and overflow-y-auto to content divs. Removed sm:max-h-none which was preventing scroll on larger screens.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves scroll behavior in the downgrade confirmation dialog to handle content overflow across screen sizes.
> 
> - Adds `flex flex-col` to `DialogContent` for proper flex sizing and scrolling
> - Applies `overflow-y-auto` to both step containers; removes restrictive `max-h` settings on step 2
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f4a816dd5498e096ec2f2550df412e79d12a1883. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->