### PR TITLE
fix tier info

### DIFF
--- a/apps/frontend/src/lib/pricing-config.ts
+++ b/apps/frontend/src/lib/pricing-config.ts
@@ -43,8 +43,8 @@ export const pricingTiers: PricingTier[] = [
     hours: '0 hours',
     features: [
       '300 weekly credits - Refreshes every 7 days',
-      '1 concurrent run',
-      '1 Chat',
+      '2 concurrent runs',
+      '10 Chats',
       'Basic Mode - Core Kortix experience with basic autonomy',
     ],
     disabledFeatures: [

--- a/apps/mobile/lib/billing/pricing.ts
+++ b/apps/mobile/lib/billing/pricing.ts
@@ -51,8 +51,8 @@ export const PRICING_TIERS: PricingTier[] = [
     description: 'Perfect for getting started',
     features: [
       '300 weekly credits - Refreshes every 7 days',
-      '1 concurrent run',
-      '1 Chat',
+      '2 concurrent runs',
+      '10 Chats',
       'Basic Mode - Core Kortix experience with basic autonomy',
     ],
     disabledFeatures: [

--- a/backend/core/agents/runner/prompt_manager.py
+++ b/backend/core/agents/runner/prompt_manager.py
@@ -602,7 +602,7 @@ Multiple parallel tool calls:
                     'custom_workers_limit': limits.get('custom_workers_limit', 0),
                     'scheduled_triggers_limit': limits.get('scheduled_triggers_limit', 0),
                     'app_triggers_limit': limits.get('app_triggers_limit', 0),
-                    'concurrent_runs': limits.get('concurrent_runs', 1),
+                    'concurrent_runs': limits.get('concurrent_runs', 2),
                     'can_purchase_credits': limits.get('can_purchase_credits', False),
                 }
             except Exception as e:
@@ -640,7 +640,7 @@ Multiple parallel tool calls:
                 tier_info += "Custom workers: 0 (upgrade to Plus or higher)\n"
                 tier_info += "Scheduled triggers: 0 (upgrade to Plus or higher)\n"
                 tier_info += "App triggers: 0 (upgrade to Plus or higher)\n"
-                tier_info += "Concurrent runs: 1\n"
+                tier_info += "Concurrent runs: 2\n"
                 tier_info += "Credit purchases: Not available (upgrade to Ultra)\n"
             else:
                 tier_info += "Tier type: Paid\n"
@@ -814,8 +814,8 @@ Multiple parallel tool calls:
 | Feature | Free | Plus | Pro | Ultra |
 |---------|------|------|-----|-------|
 | **Response quality** | Basic | Faster & better | Faster & better | Faster & better |
-| **Chats** | 1 | Unlimited | Unlimited | Unlimited |
-| **Parallel tasks** | 1 | 3 | 5 | 20 |
+| **Chats** | 10 | Unlimited | Unlimited | Unlimited |
+| **Parallel tasks** | 2 | 3 | 5 | 20 |
 | **Custom agents** | 0 | 5 | 20 | 100 |
 | **Scheduled automations** | 0 | 5 | 10 | 50 |
 | **App triggers** | 0 | 25 | 50 | 200 |


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Updates free-tier limit defaults and user-facing tier messaging; moderate risk because it can change enforced concurrent-run behavior if tier limits are missing/misconfigured.
> 
> **Overview**
> Updates the **Basic/Free** tier copy in both web (`pricing-config.ts`) and mobile (`billing/pricing.ts`) to advertise **2 concurrent runs** and **10 chats**.
> 
> Adjusts backend prompt subscription context generation (`prompt_manager.py`) so free-tier users (and any missing limit config) default to **2 concurrent runs**, and updates the injected free-tier promo comparison table to match the new **Chats=10** and **Parallel tasks=2** values.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 849807380b612706ae97221c799e963b1d2a67df. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->