### PR TITLE
get rid of OTA banners

### DIFF
--- a/apps/mobile/app/(settings)/beta.tsx
+++ b/apps/mobile/app/(settings)/beta.tsx
@@ -35,8 +35,7 @@ export default function BetaScreen() {
       contentContainerStyle={{ paddingBottom: insets.bottom + 20 }}
     >
       <View className="px-6 pt-4 pb-8">
-        {/* OTA Update Test Banner */}
-        <View className="mb-6 bg-gradient-to-br from-purple-500/20 to-pink-500/20 border-2 border-purple-500/40 rounded-3xl p-5 overflow-hidden">
+        {/* <View className="mb-6 bg-gradient-to-br from-purple-500/20 to-pink-500/20 border-2 border-purple-500/40 rounded-3xl p-5 overflow-hidden">
           <View className="flex-row items-center gap-3 mb-2">
             <View className="h-10 w-10 rounded-full bg-purple-500/30 items-center justify-center">
               <Icon
@@ -69,7 +68,7 @@ export default function BetaScreen() {
               {Constants.expoConfig?.extra?.eas?.projectId?.slice(0, 8) || 'Local'}
             </Text>
           </View>
-        </View>
+        </View> */}
 
         {/* Web Support - Prominent */}
         <View className="mb-6">

--- a/apps/mobile/components/settings/BetaPage.tsx
+++ b/apps/mobile/components/settings/BetaPage.tsx
@@ -60,7 +60,7 @@ export function BetaPage({ visible, onClose }: BetaPageProps) {
 
           <View className="px-6 pb-8 pt-2">
             {/* OTA Update Test Banner */}
-            <View className="mb-6 bg-gradient-to-br from-purple-500/20 to-pink-500/20 border-2 border-purple-500/40 rounded-3xl p-5 overflow-hidden">
+            {/* <View className="mb-6 bg-gradient-to-br from-purple-500/20 to-pink-500/20 border-2 border-purple-500/40 rounded-3xl p-5 overflow-hidden">
               <View className="flex-row items-center gap-3 mb-2">
                 <View className="h-10 w-10 rounded-full bg-purple-500/30 items-center justify-center">
                   <Icon as={Rocket} size={20} className="text-purple-600 dark:text-purple-400" strokeWidth={2.5} />
@@ -83,7 +83,7 @@ export function BetaPage({ visible, onClose }: BetaPageProps) {
                   Update ID: {Constants.expoConfig?.extra?.eas?.projectId?.slice(0, 8) || 'Local'}
                 </Text>
               </View>
-            </View>
+            </View> */}
 
             {/* Web Support - Prominent */}
             <View className="mb-6">


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk UI-only change that removes a non-functional test banner; no business logic or data flow is modified.
> 
> **Overview**
> Removes the OTA update test banner from the mobile beta settings UI by commenting it out in both `apps/mobile/app/(settings)/beta.tsx` and `apps/mobile/components/settings/BetaPage.tsx`, leaving the rest of the beta settings page unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2227eb63e44506fb0ce6cf3da2ee5c56478bb968. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->