### PR TITLE
feat: dismiss keyboard when recording starts and improve layout in Re…

### DIFF
--- a/apps/mobile/components/chat/ChatInput.tsx
+++ b/apps/mobile/components/chat/ChatInput.tsx
@@ -218,6 +218,13 @@ export const ChatInput = React.memo(React.forwardRef<ChatInputRef, ChatInputProp
     },
   }), []);
 
+  // Dismiss keyboard when recording starts
+  React.useEffect(() => {
+    if (isRecording) {
+      Keyboard.dismiss();
+    }
+  }, [isRecording]);
+
   // Animation effects
   React.useEffect(() => {
     if (isAgentRunning) {
@@ -519,16 +526,11 @@ const RecordingMode = React.memo(({
   onStopPressOut,
   onSendAudio,
 }: RecordingModeProps) => (
-  <>
-    <View className="flex-1 items-center bottom-5 justify-center">
+  <View style={{ minHeight: 100 }}>
+    <View className="items-center justify-center mb-3">
       <AudioWaveform isRecording={true} audioLevels={audioLevels} />
     </View>
-    <View className="absolute bottom-6 right-16 items-center">
-      <Text className="text-xs font-roobert-medium text-foreground/50">
-        {recordingStatusText}
-      </Text>
-    </View>
-    <View className="absolute bottom-4 left-4 right-4 flex-row items-center justify-between">
+    <View className="flex-row items-center justify-between">
       <AnimatedPressable
         onPressIn={onCancelPressIn}
         onPressOut={onCancelPressOut}
@@ -539,6 +541,9 @@ const RecordingMode = React.memo(({
       >
         <Icon as={X} size={16} className="text-foreground" strokeWidth={2} />
       </AnimatedPressable>
+      <Text className="text-xs font-roobert-medium text-foreground/50">
+        {recordingStatusText}
+      </Text>
       <AnimatedPressable
         onPressIn={onStopPressIn}
         onPressOut={onStopPressOut}
@@ -550,7 +555,7 @@ const RecordingMode = React.memo(({
         <Icon as={CornerDownLeft} size={16} className="text-primary-foreground" strokeWidth={2} />
       </AnimatedPressable>
     </View>
-  </>
+  </View>
 ));
 
 RecordingMode.displayName = 'RecordingMode';


### PR DESCRIPTION
…cordingMode

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/UX changes limited to `ChatInput` recording mode behavior and layout; main risk is minor regressions in spacing/alignment across devices.
> 
> **Overview**
> When `isRecording` becomes true, `ChatInput` now dismisses the on-screen keyboard to avoid overlap while recording.
> 
> The `RecordingMode` UI layout is simplified: it uses a fixed `minHeight`, removes absolute positioning, and places the status text inline between cancel and send/stop controls for more consistent alignment.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 26075d86c040429c0cdf9cd6beb4a69536b830ef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->