### PR TITLE
feat: add build information display to BetaScreen and adjust layout i…

### DIFF
--- a/apps/mobile/app/(settings)/beta.tsx
+++ b/apps/mobile/app/(settings)/beta.tsx
@@ -1,14 +1,16 @@
 import * as React from 'react';
-import { Pressable, View, Switch, ScrollView, Linking } from 'react-native';
+import { Pressable, View, Switch, ScrollView, Linking, Platform } from 'react-native';
 import { useColorScheme } from 'nativewind';
 import { useLanguage } from '@/contexts';
 import { useAdvancedFeatures } from '@/hooks';
 import { Text } from '@/components/ui/text';
 import { Icon } from '@/components/ui/icon';
-import { Layers, Globe, ExternalLink, AlertCircle, Rocket, Sparkles } from 'lucide-react-native';
+import { Layers, Globe, ExternalLink, AlertCircle, Info } from 'lucide-react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import * as Haptics from 'expo-haptics';
 import Constants from 'expo-constants';
+import * as Device from 'expo-device';
+import * as Updates from 'expo-updates';
 import { log } from '@/lib/logger';
 
 export default function BetaScreen() {
@@ -143,7 +145,7 @@ export default function BetaScreen() {
         </View>
 
         {/* Warning - Subtle */}
-        <View className="bg-muted/30 border border-border/30 rounded-2xl p-4">
+        <View className="bg-muted/30 border border-border/30 rounded-2xl p-4 mb-5">
           <View className="flex-row items-start gap-3">
             <Icon as={AlertCircle} size={16} className="text-muted-foreground mt-0.5" strokeWidth={2} />
             <Text className="text-xs font-roobert text-muted-foreground leading-5 flex-1">
@@ -151,7 +153,45 @@ export default function BetaScreen() {
             </Text>
           </View>
         </View>
+
+        {/* Build Info */}
+        <View className="bg-card border border-border/50 rounded-2xl p-4">
+          <View className="flex-row items-center gap-3 mb-3">
+            <Icon as={Info} size={16} className="text-muted-foreground" strokeWidth={2} />
+            <Text className="text-sm font-roobert-semibold text-foreground">
+              Build Information
+            </Text>
+          </View>
+          <View className="gap-2">
+            <BuildInfoRow label="Version" value={Constants.expoConfig?.version || 'N/A'} />
+            <BuildInfoRow
+              label="Build"
+              value={
+                Platform.OS === 'ios'
+                  ? Constants.expoConfig?.ios?.buildNumber || 'N/A'
+                  : Constants.expoConfig?.android?.versionCode?.toString() || 'N/A'
+              }
+            />
+            <BuildInfoRow label="Runtime" value={Updates.runtimeVersion || 'N/A'} />
+            <BuildInfoRow label="Update ID" value={Updates.updateId?.slice(0, 12) || 'Embedded'} />
+            <BuildInfoRow label="Channel" value={Updates.channel || 'N/A'} />
+            <BuildInfoRow label="Device" value={Device.modelName || 'N/A'} />
+            <BuildInfoRow
+              label="OS"
+              value={`${Platform.OS === 'ios' ? 'iOS' : 'Android'} ${Device.osVersion || ''}`}
+            />
+          </View>
+        </View>
       </View>
     </ScrollView>
+  );
+}
+
+function BuildInfoRow({ label, value }: { label: string; value: string }) {
+  return (
+    <View className="flex-row items-center justify-between">
+      <Text className="text-xs font-roobert text-muted-foreground">{label}</Text>
+      <Text className="text-xs font-roobert-medium text-foreground">{value}</Text>
+    </View>
   );
 }

--- a/apps/mobile/components/chat/ChatInput.tsx
+++ b/apps/mobile/components/chat/ChatInput.tsx
@@ -526,8 +526,8 @@ const RecordingMode = React.memo(({
   onStopPressOut,
   onSendAudio,
 }: RecordingModeProps) => (
-  <View style={{ minHeight: 100 }}>
-    <View className="items-center justify-center mb-3">
+  <View style={{ minHeight: 120 }}>
+    <View className="items-center justify-center mb-4" style={{ minHeight: 56 }}>
       <AudioWaveform isRecording={true} audioLevels={audioLevels} />
     </View>
     <View className="flex-row items-center justify-between">


### PR DESCRIPTION
…n RecordingMode

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only changes: adds a read-only build/debug info card and slightly adjusts recording-mode layout spacing; no changes to data flow or auth.
> 
> **Overview**
> Adds a new **Build Information** card to `BetaScreen`, displaying app/version/build numbers plus `expo-updates` runtime metadata (runtime version, update ID, channel) and basic device/OS details.
> 
> Tweaks `ChatInput` recording mode layout by increasing the minimum height and adding extra spacing/height for the waveform container to improve visual balance.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 917c67466cb19483daeae0cafd4310e9c99cbc19. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->