### PR TITLE
reduce concurrent

### DIFF
--- a/backend/core/analytics/conversation_analytics_worker.py
+++ b/backend/core/analytics/conversation_analytics_worker.py
@@ -15,7 +15,7 @@ from core.analytics.conversation_analyzer import analyze_conversation, store_ana
 # Worker configuration
 PROCESSING_INTERVAL_SECONDS = 15  # Check queue every 15 seconds
 BATCH_SIZE = 15  # Process up to 15 items per batch
-MAX_CONCURRENT = 5  # Max concurrent LLM calls (avoid rate limits)
+MAX_CONCURRENT = 2  # Max concurrent LLM calls (avoid rate limits)
 MAX_ATTEMPTS = 3  # Max retries for failed analysis
 INITIAL_DELAY_SECONDS = 15  # Wait before starting (let API settle)
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk configuration change that only reduces parallel LLM analysis calls; primary impact is slower queue throughput but less chance of hitting rate limits.
> 
> **Overview**
> Reduces the conversation analytics background worker’s maximum concurrent LLM analyses by changing `MAX_CONCURRENT` from `5` to `2` in `conversation_analytics_worker.py`, lowering parallelism to better avoid rate limiting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8a9179a324aafe8b528efffd226f598a4587ea66. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->