### PR TITLE
add logging to ecs

### DIFF
--- a/backend/core/agents/api.py
+++ b/backend/core/agents/api.py
@@ -515,6 +515,7 @@ async def start_agent_run(
     setup_time_ms = round((time.time() - total_start) * 1000, 1)
     logger.info(f"⚡ [FAST RESPONSE] Returning in {setup_time_ms}ms (thread={thread_id}, run={agent_run_id})")
     
+    logger.info(f"[START_AGENT] Creating background task for agent_run_id={agent_run_id}, thread_id={thread_id}")
     asyncio.create_task(_background_setup_and_execute(
         account_id=account_id,
         prompt=prompt,
@@ -575,6 +576,8 @@ async def _background_setup_and_execute(
         project_id=project_id,
         account_id=account_id
     )
+    
+    logger.info(f"[BG_TASK_START] Background task starting for agent_run_id={agent_run_id}")
     
     try:
         final_message_content = prompt

--- a/backend/core/agents/pipeline/stateless/coordinator/stateless.py
+++ b/backend/core/agents/pipeline/stateless/coordinator/stateless.py
@@ -37,6 +37,7 @@ class StatelessCoordinator(BaseCoordinator):
             await stream_prep_stage(ctx.stream_key, "initializing", "Setting up", 10)
 
             if not await ownership.claim(ctx.agent_run_id):
+                logger.error(f"[CLAIM_FAILED] Run {ctx.agent_run_id} already claimed by another worker! Worker ID: {ownership.worker_id}")
                 yield {"type": "error", "error": "Run already claimed", "error_code": "ALREADY_CLAIMED"}
                 return
 

--- a/backend/core/agents/pipeline/stateless/ownership.py
+++ b/backend/core/agents/pipeline/stateless/ownership.py
@@ -88,7 +88,7 @@ class RunOwnership:
                 self._owned[run_id] = now
                 heapq.heappush(self._owned_heap, (now, run_id))
                 self._heartbeat_states[run_id] = HeartbeatState()
-                logger.info(f"[Ownership] Claimed {run_id}")
+                logger.info(f"[Ownership] Claimed {run_id} (worker: {self.worker_id})")
                 return True
 
             current = await redis.get(f"run:{run_id}:owner")
@@ -97,7 +97,10 @@ class RunOwnership:
                 if current == self.worker_id:
                     if run_id not in self._heartbeat_states:
                         self._heartbeat_states[run_id] = HeartbeatState()
+                    logger.warning(f"[Ownership] Run {run_id} already owned by THIS worker {self.worker_id}")
                     return True
+                else:
+                    logger.error(f"[Ownership] Run {run_id} already claimed by DIFFERENT worker: {current} (this worker: {self.worker_id})")
 
             return False
         except Exception as e:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: changes are logging-only, but they touch high-throughput async/Redis ownership paths and could increase log volume/noise in production.
> 
> **Overview**
> Adds more structured diagnostics around agent-run execution and stateless worker ownership.
> 
> `start_agent_run` now logs when the background task is created and when the background setup task begins. The stateless coordinator and ownership layer add clearer logs when a run claim fails, including worker IDs and whether the run is already owned by the same worker vs a different one.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2aad3db0958ec01b824d4046d21d13efa8f795e9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->