### PR TITLE
resolve Redis Cluster CROSSSLOT errors in agent run ownership

### DIFF
--- a/backend/core/agents/pipeline/stateless/ownership.py
+++ b/backend/core/agents/pipeline/stateless/ownership.py
@@ -70,21 +70,25 @@ class RunOwnership:
     async def claim(self, run_id: str) -> bool:
         try:
             from core.services import redis
-
             client = await redis.get_client()
             
-            # Split into two operations to avoid CROSSSLOT errors in Redis Cluster
-            # Pipeline 1: All keys with same hash slot (run_id)
-            pipeline = client.pipeline()
-            pipeline.set(f"run:{run_id}:owner", self.worker_id, nx=True, ex=self.CLAIM_TTL)
-            pipeline.set(f"run:{run_id}:status", "running", ex=self.CLAIM_TTL)
-            pipeline.set(f"run:{run_id}:start", str(time.time()), ex=self.CLAIM_TTL)
-            pipeline.set(f"run:{run_id}:heartbeat", str(time.time()), ex=self.HEARTBEAT_TTL)
+            try:
+                pipeline = client.pipeline()
+                pipeline.set(f"run:{{{run_id}}}:owner", self.worker_id, nx=True, ex=self.CLAIM_TTL)
+                pipeline.set(f"run:{{{run_id}}}:status", "running", ex=self.CLAIM_TTL)
+                pipeline.set(f"run:{{{run_id}}}:start", str(time.time()), ex=self.CLAIM_TTL)
+                pipeline.set(f"run:{{{run_id}}}:heartbeat", str(time.time()), ex=self.HEARTBEAT_TTL)
+                
+                results = await pipeline.execute()
+                claimed = results[0]
+            except Exception as e:
+                logger.warning(f"[Ownership] Pipeline failed for {run_id}, using individual ops: {e}")
+                claimed = await client.set(f"run:{{{run_id}}}:owner", self.worker_id, nx=True, ex=self.CLAIM_TTL)
+                if claimed:
+                    await client.set(f"run:{{{run_id}}}:status", "running", ex=self.CLAIM_TTL)
+                    await client.set(f"run:{{{run_id}}}:start", str(time.time()), ex=self.CLAIM_TTL)
+                    await client.set(f"run:{{{run_id}}}:heartbeat", str(time.time()), ex=self.HEARTBEAT_TTL)
             
-            results = await pipeline.execute()
-            claimed = results[0]
-            
-            # Separate operation for runs:active (different hash slot)
             if claimed:
                 try:
                     await client.sadd("runs:active", run_id)
@@ -99,7 +103,7 @@ class RunOwnership:
                 logger.info(f"[Ownership] Claimed {run_id} (worker: {self.worker_id})")
                 return True
 
-            current = await redis.get(f"run:{run_id}:owner")
+            current = await redis.get(f"run:{{{run_id}}}:owner")
             if current:
                 current = current.decode() if isinstance(current, bytes) else current
                 if current == self.worker_id:
@@ -120,10 +124,16 @@ class RunOwnership:
             from core.services import redis
 
             client = await redis.get_client()
-            pipeline = client.pipeline()
-            pipeline.set(f"run:{run_id}:status", status, ex=self.CLAIM_TTL)
-            pipeline.delete(f"run:{run_id}:owner")
-            await pipeline.execute()
+            
+            try:
+                pipeline = client.pipeline()
+                pipeline.set(f"run:{{{run_id}}}:status", status, ex=self.CLAIM_TTL)
+                pipeline.delete(f"run:{{{run_id}}}:owner")
+                await pipeline.execute()
+            except Exception as e:
+                logger.warning(f"[Ownership] Pipeline failed for release {run_id}, using individual ops: {e}")
+                await client.set(f"run:{{{run_id}}}:status", status, ex=self.CLAIM_TTL)
+                await client.delete(f"run:{{{run_id}}}:owner")
             
             if status in ("completed", "failed", "cancelled"):
                 try:
@@ -143,12 +153,17 @@ class RunOwnership:
             from core.services import redis
 
             client = await redis.get_client()
-            pipeline = client.pipeline()
             
-            pipeline.set(f"run:{run_id}:status", "resumable", ex=self.CLAIM_TTL)
-            pipeline.delete(f"run:{run_id}:owner")
+            try:
+                pipeline = client.pipeline()
+                pipeline.set(f"run:{{{run_id}}}:status", "resumable", ex=self.CLAIM_TTL)
+                pipeline.delete(f"run:{{{run_id}}}:owner")
+                await pipeline.execute()
+            except Exception as e:
+                logger.warning(f"[Ownership] Pipeline failed for mark_resumable {run_id}, using individual ops: {e}")
+                await client.set(f"run:{{{run_id}}}:status", "resumable", ex=self.CLAIM_TTL)
+                await client.delete(f"run:{{{run_id}}}:owner")
             
-            await pipeline.execute()
             self._owned.pop(run_id, None)
             self._heartbeat_states.pop(run_id, None)
             return True
@@ -159,7 +174,7 @@ class RunOwnership:
     async def _heartbeat(self, run_id: str) -> bool:
         try:
             from core.services import redis
-            await redis.set(f"run:{run_id}:heartbeat", str(time.time()), ex=self.HEARTBEAT_TTL)
+            await redis.set(f"run:{{{run_id}}}:heartbeat", str(time.time()), ex=self.HEARTBEAT_TTL)
             
             if run_id in self._heartbeat_states:
                 self._heartbeat_states[run_id].record_success()
@@ -207,13 +222,16 @@ class RunOwnership:
             from core.services import redis
 
             client = await redis.get_client()
-            pipeline = client.pipeline()
-
             now_str = str(time.time())
-            for run_id in run_ids:
-                pipeline.set(f"run:{run_id}:heartbeat", now_str, ex=self.HEARTBEAT_TTL)
-
-            results = await pipeline.execute()
+            
+            async def set_heartbeat(run_id: str) -> bool:
+                try:
+                    await client.set(f"run:{{{run_id}}}:heartbeat", now_str, ex=self.HEARTBEAT_TTL)
+                    return True
+                except Exception:
+                    return False
+            
+            results = await asyncio.gather(*[set_heartbeat(run_id) for run_id in run_ids], return_exceptions=False)
             success_count = sum(1 for r in results if r)
             
             if success_count == len(run_ids):
@@ -387,30 +405,30 @@ class RunOwnership:
             run_ids = [r.decode() if isinstance(r, bytes) else r for r in active]
             
             client = await redis.get_client()
-            pipeline = client.pipeline()
-            
-            for run_id in run_ids:
-                pipeline.get(f"run:{run_id}:status")
-                pipeline.get(f"run:{run_id}:heartbeat")
-            
-            results = await pipeline.execute()
             now = time.time()
             
-            for i, run_id in enumerate(run_ids):
-                status = results[i * 2]
-                hb = results[i * 2 + 1]
-                
-                if status:
-                    status = status.decode() if isinstance(status, bytes) else status
-                    if status not in ("running", "resumable"):
-                        continue
-                
-                if not hb:
-                    orphans.append(run_id)
-                else:
+            async def check_orphan(run_id: str) -> Optional[str]:
+                try:
+                    status = await client.get(f"run:{{{run_id}}}:status")
+                    if status:
+                        status = status.decode() if isinstance(status, bytes) else status
+                        if status not in ("running", "resumable"):
+                            return None
+                    
+                    hb = await client.get(f"run:{{{run_id}}}:heartbeat")
+                    if not hb:
+                        return run_id
+                    
                     hb = hb.decode() if isinstance(hb, bytes) else hb
                     if now - float(hb) > self.ORPHAN_THRESHOLD:
-                        orphans.append(run_id)
+                        return run_id
+                    
+                    return None
+                except Exception:
+                    return None
+            
+            results = await asyncio.gather(*[check_orphan(run_id) for run_id in run_ids], return_exceptions=False)
+            orphans = [r for r in results if r is not None]
 
             return orphans
         except Exception as e:
@@ -436,31 +454,30 @@ class RunOwnership:
                 return []
             
             client = await redis.get_client()
-            pipeline = client.pipeline()
-            
-            for run_id in run_ids:
-                pipeline.get(f"run:{run_id}:status")
-                pipeline.get(f"run:{run_id}:heartbeat")
-            
-            results = await pipeline.execute()
             now = time.time()
-            orphans = []
             
-            for i, run_id in enumerate(run_ids):
-                status = results[i * 2]
-                hb = results[i * 2 + 1]
-                
-                if status:
-                    status = status.decode() if isinstance(status, bytes) else status
-                    if status not in ("running", "resumable"):
-                        continue
-                
-                if not hb:
-                    orphans.append(run_id)
-                else:
+            async def check_orphan(run_id: str) -> Optional[str]:
+                try:
+                    status = await client.get(f"run:{{{run_id}}}:status")
+                    if status:
+                        status = status.decode() if isinstance(status, bytes) else status
+                        if status not in ("running", "resumable"):
+                            return None
+                    
+                    hb = await client.get(f"run:{{{run_id}}}:heartbeat")
+                    if not hb:
+                        return run_id
+                    
                     hb = hb.decode() if isinstance(hb, bytes) else hb
                     if now - float(hb) > self.ORPHAN_THRESHOLD:
-                        orphans.append(run_id)
+                        return run_id
+                    
+                    return None
+                except Exception:
+                    return None
+            
+            results = await asyncio.gather(*[check_orphan(run_id) for run_id in run_ids], return_exceptions=False)
+            orphans = [r for r in results if r is not None]
 
             return orphans
         except Exception as e:
@@ -475,10 +492,10 @@ class RunOwnership:
             def decode(v):
                 return v.decode() if isinstance(v, bytes) else v
 
-            owner = decode(await redis.get(f"run:{run_id}:owner"))
-            status = decode(await redis.get(f"run:{run_id}:status"))
-            hb = decode(await redis.get(f"run:{run_id}:heartbeat"))
-            start = decode(await redis.get(f"run:{run_id}:start"))
+            owner = decode(await redis.get(f"run:{{{run_id}}}:owner"))
+            status = decode(await redis.get(f"run:{{{run_id}}}:status"))
+            hb = decode(await redis.get(f"run:{{{run_id}}}:heartbeat"))
+            start = decode(await redis.get(f"run:{{{run_id}}}:start"))
 
             thread_id = None
             try:
@@ -511,15 +528,6 @@ class RunOwnership:
             from core.agents import repo as agents_repo
 
             client = await redis.get_client()
-            pipeline = client.pipeline()
-
-            for run_id in run_ids:
-                pipeline.get(f"run:{run_id}:owner")
-                pipeline.get(f"run:{run_id}:status")
-                pipeline.get(f"run:{run_id}:heartbeat")
-                pipeline.get(f"run:{run_id}:start")
-
-            results = await pipeline.execute()
 
             thread_ids_map = {}
             try:
@@ -527,18 +535,24 @@ class RunOwnership:
             except Exception as e:
                 logger.warning(f"[Ownership] Failed to batch get thread_ids: {e}")
 
-            infos = {}
-            for i, run_id in enumerate(run_ids):
-                base_idx = i * 4
-
+            # In Redis Cluster, use individual operations instead of pipeline
+            async def get_run_info(run_id: str) -> tuple:
                 def decode(v):
                     return v.decode() if isinstance(v, bytes) else v
+                
+                try:
+                    owner = decode(await client.get(f"run:{{{run_id}}}:owner"))
+                    status = decode(await client.get(f"run:{{{run_id}}}:status"))
+                    hb = decode(await client.get(f"run:{{{run_id}}}:heartbeat"))
+                    start = decode(await client.get(f"run:{{{run_id}}}:start"))
+                    return (run_id, owner, status, hb, start)
+                except Exception:
+                    return (run_id, None, None, None, None)
+            
+            results = await asyncio.gather(*[get_run_info(run_id) for run_id in run_ids], return_exceptions=False)
 
-                owner = decode(results[base_idx])
-                status = decode(results[base_idx + 1])
-                hb = decode(results[base_idx + 2])
-                start = decode(results[base_idx + 3])
-
+            infos = {}
+            for run_id, owner, status, hb, start in results:
                 infos[run_id] = {
                     "run_id": run_id,
                     "thread_id": thread_ids_map.get(run_id),
@@ -642,7 +656,7 @@ class IdempotencyTracker:
     async def check(self, run_id: str, step: int, operation: str) -> bool:
         try:
             from core.services import redis
-            key = f"run:{run_id}:idem:{step}:{operation}"
+            key = f"run:{{{run_id}}}:idem:{step}:{operation}"
             return bool(await redis.set(key, "1", nx=True, ex=self.ttl))
         except Exception:
             return True
@@ -657,7 +671,7 @@ class IdempotencyTracker:
         
         try:
             from core.services import redis
-            await redis.set(f"run:{run_id}:last_step", str(step), ex=self.ttl)
+            await redis.set(f"run:{{{run_id}}}:last_step", str(step), ex=self.ttl)
         except Exception:
             pass
 
@@ -668,7 +682,7 @@ class IdempotencyTracker:
         
         try:
             from core.services import redis
-            last_step = await redis.get(f"run:{run_id}:last_step")
+            last_step = await redis.get(f"run:{{{run_id}}}:last_step")
             if last_step:
                 last_step = last_step.decode() if isinstance(last_step, bytes) else last_step
                 step = int(last_step)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches run ownership/heartbeat and recovery paths; incorrect keying or concurrent per-run ops could impact run claiming, orphan detection, or cleanup behavior under load.
> 
> **Overview**
> Fixes Redis Cluster `CROSSSLOT` issues in stateless agent run ownership by switching run-scoped keys to use hash tags (`run:{<run_id>}:...`) and adding fallbacks when pipelining fails.
> 
> Reworks batch operations (heartbeats, orphan detection, and `get_info_batch`) to avoid multi-key pipelines by issuing per-run commands concurrently via `asyncio.gather`. Updates recovery flows to use the new key format for `start`/`status`/`error`/`owner` reads and writes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ca6b18a34363c551f3ab25f595db3c1a024f2082. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->