### PR TITLE
fix: add hash tag to stop key in orphan cleanup for Redis Cluster

### DIFF
--- a/backend/core/services/orphan_cleanup.py
+++ b/backend/core/services/orphan_cleanup.py
@@ -135,7 +135,7 @@ async def cleanup_orphaned_agent_runs(db_client) -> int:
                 # Clean up Redis keys for THIS run only
                 try:
                     redis_client = await redis.get_client()
-                    await redis_client.delete(f"stop:{agent_run_id}")
+                    await redis_client.delete(f"stop:{{{agent_run_id}}}")
                     await redis_client.delete(stream_key)
                     logger.debug(f"🧹 Deleted Redis keys for orphaned run {agent_run_id}")
                 except Exception as e:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk, single-key change limited to orphaned-run Redis cleanup; main risk is failing to delete the intended key if other producers/consumers use a different key format.
> 
> **Overview**
> Fixes orphaned-run Redis cleanup to delete the `stop` key using a Redis Cluster hash tag: `stop:{agent_run_id}` instead of `stop:agent_run_id`.
> 
> This ensures the `stop` key is colocated/consistent for clustered Redis deployments when cleaning up an orphaned agent run.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit de5038532716c5a75d40bc5bef8d37beaea88944. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->