### PR TITLE
fix kb, images, worker creation

### DIFF
--- a/apps/frontend/src/components/thread/tool-views/KbToolView.tsx
+++ b/apps/frontend/src/components/thread/tool-views/KbToolView.tsx
@@ -155,12 +155,18 @@ const KbResultDisplay: React.FC<{ operation: KbOperation; toolOutput: any }> = (
                     <div key={folder} className="text-sm bg-zinc-50 dark:bg-zinc-900 rounded p-2">
                       <span className="font-medium text-zinc-900 dark:text-zinc-100">{folder}</span>
                       <div className="text-xs text-zinc-600 dark:text-zinc-400 mt-1 space-y-1">
-                        {Array.isArray(files) ? files.map((file, idx) => (
-                          <div key={idx} className="flex items-center gap-1">
-                            <span>•</span>
-                            <span>{file}</span>
-                          </div>
-                        )) : `${files.length || 0} files`}
+                        {Array.isArray(files) ? files.map((file, idx) => {
+                          // Handle both string and object formats
+                          const fileName = typeof file === 'string'
+                            ? file
+                            : (file?.synced_as || file?.filename || file?.original || file?.path?.split('/').pop() || JSON.stringify(file));
+                          return (
+                            <div key={idx} className="flex items-center gap-1">
+                              <span>•</span>
+                              <span>{fileName}</span>
+                            </div>
+                          );
+                        }) : `${files?.length || 0} files`}
                       </div>
                     </div>
                   ))}

--- a/backend/core/agents/runner/prompt_manager.py
+++ b/backend/core/agents/runner/prompt_manager.py
@@ -195,7 +195,6 @@ class PromptManager:
         fetch_start = time.time()
         
         try:
-            # Check cache first
             from core.cache.runtime_cache import get_cached_kb_context, set_cached_kb_context
             cached = await get_cached_kb_context(agent_id)
             if cached is not None:  # None = miss, empty string = no entries (cached)
@@ -204,22 +203,25 @@ class PromptManager:
                 if cached:
                     kb_section = f"""
 
-                === AGENT KNOWLEDGE BASE ===
-                NOTICE: The following is your specialized knowledge base containing SUMMARIES of your knowledge files.
-                These summaries should be considered authoritative and take precedence over general knowledge when relevant.
+=== YOUR KNOWLEDGE BASE ===
+You have a knowledge base with files assigned to you. Below are SUMMARIES of those files:
 
-                {cached}
+{cached}
 
-                === END AGENT KNOWLEDGE BASE ===
+=== END KNOWLEDGE BASE ===
 
-                IMPORTANT KNOWLEDGE BASE ACCESS:
-                - The content above shows SUMMARIES only, not the full file contents
-                - To access the FULL content of knowledge base files:
-                  1. First call `global_kb_sync` to download files to sandbox
-                  2. Files will be available at `/workspace/downloads/global-knowledge/[FolderName]/[filename]`
-                  3. Then use `read_file` or `semantic_search` to access content
-                - Use these summaries directly for most queries without needing full file access
-                - Only sync and read full files when the summary is insufficient"""
+HOW TO ACCESS FULL FILE CONTENT:
+You have the `sb_kb_tool` with these functions to access your knowledge base:
+
+1. `global_kb_list_contents` - List all your KB files and folders with IDs
+2. `global_kb_sync` - Download KB files to `/workspace/downloads/global-knowledge/`
+3. After sync, read files at `/workspace/downloads/global-knowledge/[FolderName]/[filename]`
+4. `semantic_search` - Search across all files with natural language queries
+
+WHEN USER ASKS ABOUT KB FILES:
+1. Call `global_kb_sync` tool FIRST to download files to sandbox
+2. Then use file read tools or `semantic_search` to get content
+3. The summaries above are just previews - sync to read full content"""
                     return kb_section
                 return None
             
@@ -250,22 +252,25 @@ class PromptManager:
                 
                 kb_section = f"""
 
-                === AGENT KNOWLEDGE BASE ===
-                NOTICE: The following is your specialized knowledge base containing SUMMARIES of your knowledge files.
-                These summaries should be considered authoritative and take precedence over general knowledge when relevant.
+=== YOUR KNOWLEDGE BASE ===
+You have a knowledge base with files assigned to you. Below are SUMMARIES of those files:
 
-                {kb_data}
+{kb_data}
 
-                === END AGENT KNOWLEDGE BASE ===
+=== END KNOWLEDGE BASE ===
 
-                IMPORTANT KNOWLEDGE BASE ACCESS:
-                - The content above shows SUMMARIES only, not the full file contents
-                - To access the FULL content of knowledge base files:
-                  1. First call `global_kb_sync` to download files to sandbox
-                  2. Files will be available at `/workspace/downloads/global-knowledge/[FolderName]/[filename]`
-                  3. Then use `read_file` or `semantic_search` to access content
-                - Use these summaries directly for most queries without needing full file access
-                - Only sync and read full files when the summary is insufficient"""
+HOW TO ACCESS FULL FILE CONTENT:
+You have the `sb_kb_tool` with these functions to access your knowledge base:
+
+1. `global_kb_list_contents` - List all your KB files and folders with IDs
+2. `global_kb_sync` - Download KB files to `/workspace/downloads/global-knowledge/`
+3. After sync, read files at `/workspace/downloads/global-knowledge/[FolderName]/[filename]`
+4. `semantic_search` - Search across all files with natural language queries
+
+WHEN USER ASKS ABOUT KB FILES:
+1. Call `global_kb_sync` tool FIRST to download files to sandbox
+2. Then use file read tools or `semantic_search` to get content
+3. The summaries above are just previews - sync to read full content"""
 
                 return kb_section
             else:

--- a/backend/core/agents/runner/tool_manager.py
+++ b/backend/core/agents/runner/tool_manager.py
@@ -26,6 +26,7 @@ DEFAULT_CORE_TOOLS = [
     'sb_image_edit_tool',   # Image generation
     'sb_upload_file_tool',  # File uploads
     'sb_expose_tool',       # Port exposure
+    'sb_kb_tool',           # Knowledge base operations
     'agent_config_tool',
     'agent_creation_tool',
     'mcp_search_tool',
@@ -133,14 +134,15 @@ class ToolManager:
         
         # Core sandbox tools - only register if enabled
         core_sandbox_tools = [
-            'sb_shell_tool', 
-            'sb_git_sync', 
+            'sb_shell_tool',
+            'sb_git_sync',
             'sb_files_tool',
             'sb_file_reader_tool',
             'sb_vision_tool',
             'sb_image_edit_tool',
             'sb_upload_file_tool',
-            'sb_expose_tool'
+            'sb_expose_tool',
+            'sb_kb_tool',  # Knowledge base operations
         ]
         tools_needing_thread_id = {'sb_vision_tool', 'sb_image_edit_tool', 'sb_design_tool'}
         
@@ -185,7 +187,8 @@ class ToolManager:
         ]
         
         agent_id = self.agent_config.get('agent_id') if self.agent_config else None
-        account_id = self.agent_config.get('account_id') if self.agent_config else None
+        # Get account_id from thread_manager (it's not in agent_config)
+        account_id = getattr(self.thread_manager, 'account_id', None)
         db_connection = getattr(self.thread_manager, 'db', None)
         
         logger.info(f"🔧 Registering agent builder tools (agent_id={agent_id}, account_id={account_id}, has_db={db_connection is not None})")

--- a/backend/core/files/upload_handler.py
+++ b/backend/core/files/upload_handler.py
@@ -9,6 +9,7 @@ from core.services import redis
 from core.services.supabase import DBConnection
 from core.utils.logger import logger
 from core.utils.sandbox_utils import generate_unique_filename, get_uploads_directory
+from core.utils.files_utils import normalize_filename
 from core.sandbox.resolver import resolve_sandbox
 
 db = DBConnection()
@@ -34,9 +35,10 @@ async def fast_parse_files(files: List[UploadFile], prompt: str = "") -> Tuple[s
     for file in files:
         if not file.filename:
             continue
-        
+
         try:
-            original_filename = file.filename.replace('/', '_').replace('\\', '_')
+            # Normalize filename for Unicode compatibility (macOS screenshots, etc.)
+            original_filename = normalize_filename(file.filename.replace('/', '_').replace('\\', '_'))
             content_bytes = await file.read()
             mime_type = file.content_type or "application/octet-stream"
             

--- a/backend/core/jit/loader.py
+++ b/backend/core/jit/loader.py
@@ -21,9 +21,9 @@ class JITLoader:
     @staticmethod
     def get_core_tools() -> List[str]:
         return [
-            'expand_msg_tool', 
-            'message_tool', 
-            'task_list_tool', 
+            'expand_msg_tool',
+            'message_tool',
+            'task_list_tool',
             'sb_shell_tool',
             'sb_files_tool',
             'sb_file_reader_tool',
@@ -35,7 +35,8 @@ class JITLoader:
             'browser_tool',
             'sb_git_sync',
             'sb_upload_file_tool',
-            'sb_expose_tool'
+            'sb_expose_tool',
+            'sb_kb_tool',  # Knowledge base operations
         ]
     
     @staticmethod

--- a/backend/core/tools/agent_creation_tool.py
+++ b/backend/core/tools/agent_creation_tool.py
@@ -544,7 +544,9 @@ class AgentCreationTool(Tool):
                     "message": success_message,
                     "agent_id": agent_id,
                     "agent_name": name,
-                    "is_default": is_default
+                    "name": name,  # Also include 'name' for frontend compatibility
+                    "is_default": is_default,
+                    "success": True  # Explicit success flag for frontend parsing
                 })
                 
             except Exception as e:

--- a/backend/core/utils/fast_parse/image_analyzer.py
+++ b/backend/core/utils/fast_parse/image_analyzer.py
@@ -67,9 +67,21 @@ Be concise but comprehensive."""
                 model_name=self._model,
                 max_tokens=self._max_tokens,
                 temperature=0.1,
+                stream=False,
             )
             
-            description = response.choices[0].message.content.strip()
+            description = ""
+            if isinstance(response, dict):
+                description = (
+                    (response.get("choices") or [{}])[0]
+                    .get("message", {})
+                    .get("content", "")
+                    .strip()
+                )
+            elif hasattr(response, "choices") and response.choices:
+                description = (response.choices[0].message.content or "").strip()
+            else:
+                description = str(response).strip()
             
             labels = self._extract_labels(description)
             text_content = self._extract_text_content(description)

--- a/backend/core/utils/files_utils.py
+++ b/backend/core/utils/files_utils.py
@@ -1,5 +1,42 @@
 
 import os
+import unicodedata
+from urllib.parse import unquote
+
+# Unicode space characters that should be normalized to ASCII space
+UNICODE_SPACES = [
+    '\u00A0',  # Non-breaking space
+    '\u2000',  # En quad
+    '\u2001',  # Em quad
+    '\u2002',  # En space
+    '\u2003',  # Em space
+    '\u2004',  # Three-per-em space
+    '\u2005',  # Four-per-em space
+    '\u2006',  # Six-per-em space
+    '\u2007',  # Figure space
+    '\u2008',  # Punctuation space
+    '\u2009',  # Thin space
+    '\u200A',  # Hair space
+    '\u202F',  # Narrow no-break space (common in macOS screenshots)
+    '\u205F',  # Medium mathematical space
+    '\u3000',  # Ideographic space
+]
+
+# Characters that cause issues in Unix filesystems and shell commands
+# These are replaced with safe alternatives
+UNSAFE_CHAR_REPLACEMENTS = {
+    ':': '-',   # Colons not allowed in many filesystems
+    '*': '-',   # Wildcard character
+    '?': '-',   # Wildcard character
+    '"': "'",   # Double quotes can break shell commands
+    '<': '-',   # Redirect operator
+    '>': '-',   # Redirect operator
+    '|': '-',   # Pipe operator
+    '\0': '',   # Null character
+    '\n': '_',  # Newline
+    '\r': '_',  # Carriage return
+    '\t': '_',  # Tab
+}
 
 # Files to exclude from operations
 EXCLUDED_FILES = {
@@ -64,43 +101,170 @@ def should_exclude_file(rel_path: str) -> bool:
 
     return False 
 
+def normalize_filename(filename: str) -> str:
+    """Normalize a single filename (not a path) for Unix compatibility.
+
+    Handles:
+    - URL decoding (handles %20, %E2%80%AF, etc.)
+    - Unicode normalization to NFC form
+    - Unicode space characters → ASCII space
+    - Unsafe shell/filesystem characters → safe alternatives
+    - Trimming of leading/trailing spaces and dots
+
+    This is critical for files uploaded from macOS which may use
+    narrow no-break spaces (\\u202F) in screenshot filenames, and
+    for any file with special characters that could break shell commands.
+
+    Args:
+        filename: The filename to normalize (should not contain path separators)
+
+    Returns:
+        Normalized filename safe for Unix filesystems and shell commands
+    """
+    if not filename:
+        return filename
+
+    try:
+        # URL-decode if needed (handles %20, %E2%80%AF, etc.)
+        try:
+            filename = unquote(filename)
+        except Exception:
+            pass
+
+        # Normalize to NFC (Normalized Form Composed)
+        filename = unicodedata.normalize('NFC', filename)
+
+        # Replace Unicode spaces with ASCII space
+        for unicode_space in UNICODE_SPACES:
+            filename = filename.replace(unicode_space, ' ')
+
+        # Replace unsafe characters with safe alternatives
+        for unsafe_char, safe_char in UNSAFE_CHAR_REPLACEMENTS.items():
+            filename = filename.replace(unsafe_char, safe_char)
+
+        # Trim leading/trailing spaces and dots (can cause issues)
+        # But preserve the extension's dot
+        name, ext = os.path.splitext(filename)
+        name = name.strip().strip('.')
+
+        # If name is empty after stripping, use a default
+        if not name:
+            name = 'file'
+
+        filename = name + ext
+
+        return filename
+    except Exception:
+        # Fallback: keep only safe ASCII characters
+        import re
+        return re.sub(r'[^a-zA-Z0-9._\- ]', '_', filename)
+
+
+def normalize_path(path: str) -> str:
+    """Normalize a file path for Unix compatibility.
+
+    Normalizes each component of the path (directories and filename) while
+    preserving the path structure. Handles Unicode characters, special
+    characters, and macOS-specific encoding issues.
+
+    Args:
+        path: The file path to normalize
+
+    Returns:
+        Normalized path safe for Unix filesystems and shell commands
+    """
+    if not path:
+        return path
+
+    try:
+        # URL-decode the entire path first
+        try:
+            path = unquote(path)
+        except Exception:
+            pass
+
+        # Normalize Unicode to NFC form
+        path = unicodedata.normalize('NFC', path)
+
+        # Replace Unicode spaces with ASCII space throughout the path
+        for unicode_space in UNICODE_SPACES:
+            path = path.replace(unicode_space, ' ')
+
+        # Split path into components and normalize each part
+        # Preserve leading slash if present
+        leading_slash = path.startswith('/')
+        parts = path.split('/')
+
+        normalized_parts = []
+        for i, part in enumerate(parts):
+            if not part:  # Empty part (from leading/trailing/double slashes)
+                if i == 0 and leading_slash:
+                    continue  # Skip empty part from leading slash
+                continue
+
+            # Replace unsafe characters in each path component
+            for unsafe_char, safe_char in UNSAFE_CHAR_REPLACEMENTS.items():
+                part = part.replace(unsafe_char, safe_char)
+
+            # Trim spaces from each component (but keep internal spaces)
+            part = part.strip()
+
+            if part:  # Only add non-empty parts
+                normalized_parts.append(part)
+
+        # Reconstruct the path
+        result = '/'.join(normalized_parts)
+        if leading_slash:
+            result = '/' + result
+
+        return result
+    except Exception:
+        return path
+
+
 def clean_path(path: str, workspace_path: str = "/workspace") -> str:
     """Clean and normalize a path to be relative to the workspace.
-    
+
     ALWAYS returns a relative path without the /workspace prefix.
     Tools should prepend workspace_path to get the full absolute path.
-    
+
+    Also normalizes Unicode characters and special characters to handle macOS
+    screenshot filenames with narrow no-break spaces and other problematic chars.
+
     Args:
         path: The path to clean
         workspace_path: The base workspace path to remove (default: "/workspace")
-        
+
     Returns:
         A cleaned relative path (never starts with /workspace or /)
-    
+
     Examples:
         "/workspace/uploads/image.png" -> "uploads/image.png"
-        "workspace/uploads/image.png" -> "uploads/image.png"  
+        "workspace/uploads/image.png" -> "uploads/image.png"
         "uploads/image.png" -> "uploads/image.png"
         "/uploads/image.png" -> "uploads/image.png"
     """
+    # Normalize Unicode and special characters in the path
+    path = normalize_path(path)
+
     # Strip the absolute /workspace prefix if present
     if path.startswith('/workspace/'):
         path = path[len('/workspace/'):]
     elif path.startswith('/workspace'):
         path = path[len('/workspace'):]
-    
+
     # Remove any leading slash
     path = path.lstrip('/')
-    
+
     # Remove workspace prefix if present (for paths like "workspace/foo")
     if path.startswith(workspace_path.lstrip('/')):
         path = path[len(workspace_path.lstrip('/')):]
-    
+
     # Remove workspace/ prefix if present (handles "workspace/uploads/...")
     if path.startswith('workspace/'):
         path = path[len('workspace/'):]
-    
+
     # Remove any remaining leading slash
     path = path.lstrip('/')
-    
+
     return path 

--- a/backend/core/utils/sandbox_utils.py
+++ b/backend/core/utils/sandbox_utils.py
@@ -5,20 +5,27 @@ from pathlib import Path
 from typing import Optional
 from daytona_sdk import AsyncSandbox
 from core.utils.logger import logger
+from core.utils.files_utils import normalize_filename
 
 
 async def generate_unique_filename(sandbox: AsyncSandbox, base_path: str, original_filename: str) -> str:
     """
     Generate a unique filename by appending a timestamp if the file already exists.
-    
+
+    Also normalizes the filename to handle Unicode characters (e.g., macOS screenshot
+    filenames with narrow no-break spaces).
+
     Args:
         sandbox: The sandbox instance
         base_path: The base directory path (e.g., /workspace/uploads)
         original_filename: The original filename
-        
+
     Returns:
         A unique filename that doesn't conflict with existing files
     """
+    # Normalize filename to handle Unicode characters (macOS screenshots, etc.)
+    original_filename = normalize_filename(original_filename)
+
     # Parse filename and extension
     file_path = Path(original_filename)
     name_without_ext = file_path.stem


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk: touches knowledge-base file sync/download paths, adds an API endpoint that reads stored file contents, and changes tool registration/prompt instructions, which could affect access control and runtime behavior if misconfigured.
> 
> **Overview**
> Improves Knowledge Base usability and reliability by preloading/registering `sb_kb_tool`, updating the system prompt KB section with clearer sync/read instructions, and enhancing `global_kb_sync` with filesystem-safe naming, retry/verification, richer response metadata, and better empty-assignment diagnostics (plus a new `global_kb_enable_all` helper and enabled-status in listings).
> 
> Adds a new `GET /knowledge-base/entries/{entry_id}/content` endpoint to fetch and (when possible) extract text from stored KB files (text/PDF/DOCX), and updates the frontend `KbToolView` to render the new `folder_structure` object format.
> 
> Hardens file handling and parsing by normalizing uploaded filenames (Unicode/macOS-safe) and making LLM call sites (`file_processor`, image analyzer) robust to dict vs SDK response shapes; also tweaks agent creation responses for frontend compatibility and fixes tool registration to source `account_id` from `thread_manager`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit defe9cd728a7b208157220007207008d06621bdc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->