### PR TITLE
refactor useChat to avoid appending template context for existing thr…

### DIFF
--- a/apps/mobile/hooks/useChat.ts
+++ b/apps/mobile/hooks/useChat.ts
@@ -1463,21 +1463,10 @@ export function useChat(): UseChatReturn {
         setAttachments([]);
         
         setIsNewThreadOptimistic(true);
-        
-        let messageContent = content;
-        
-        // Append hidden context for slides template
-        if (selectedQuickAction === 'slides' && selectedQuickActionOption) {
-          messageContent += `\n\n----\n\n**Presentation Template:** ${selectedQuickActionOption}`;
-          log.log('[useChat] Appended slides template context:', selectedQuickActionOption);
-        }
-        
-        // Append hidden context for image style
-        if (selectedQuickAction === 'image' && selectedQuickActionOption) {
-          messageContent += `\n\n----\n\n**Image Style:** ${selectedQuickActionOption}`;
-          log.log('[useChat] Appended image style context:', selectedQuickActionOption);
-        }
-        
+
+        // For existing threads, DON'T append template context - it was already sent with the first message
+        const messageContent = content;
+
         // Convert attachments to files format for upload
         const filesToUpload = pendingAttachments.length > 0
           ? pendingAttachments.map(a => ({


### PR DESCRIPTION
…eads

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk behavioral tweak that changes the prompt text sent when messaging existing threads; may slightly affect AI outputs for slide/image modes but doesn’t touch auth, persistence, or backend APIs.
> 
> **Overview**
> Prevents `useChat` from appending hidden quick-action context (e.g. **Presentation Template** / **Image Style**) when sending messages to *existing* threads, since that context is intended to be provided only on the first message.
> 
> New-thread creation still appends the selected quick-action context, but follow-up messages now send the user’s raw `content` unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f103506ef2333cf4d189731e454612d2fe75d908. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->