### PR TITLE
fix

### DIFF
--- a/backend/core/analytics/conversation_analytics_worker.py
+++ b/backend/core/analytics/conversation_analytics_worker.py
@@ -34,11 +34,12 @@ async def claim_pending_queue_items(limit: int = BATCH_SIZE) -> List[Dict[str, A
     multiple workers grab the same items.
     """
     try:
-        from core.services.db import execute, serialize_rows
+        from core.services.db import execute_mutate, serialize_rows
 
         # Atomic claim: SELECT + UPDATE in one transaction
         # FOR UPDATE SKIP LOCKED ensures no two workers grab same row
-        result = await execute("""
+        # NOTE: Must use execute_mutate (not execute) to COMMIT the status change!
+        result = await execute_mutate("""
             UPDATE conversation_analytics_queue
             SET status = 'processing'
             WHERE id IN (


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the analytics worker’s queue-claiming query to use `execute_mutate`, which now commits the `status='processing'` update; any issues would directly affect whether items are reliably claimed and could impact duplicate or stuck processing.
> 
> **Overview**
> Fixes a bug in `conversation_analytics_worker.py` where claiming pending analytics queue items updated rows without committing.
> 
> `claim_pending_queue_items` now uses `execute_mutate` (with an explicit note about needing a commit) so the `status='processing'` transition is persisted when atomically claiming work via `FOR UPDATE SKIP LOCKED`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1dbe341696e761722619b0efe0f78db7548f0679. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->