### PR TITLE
send system metrics to cloudwatch

### DIFF
--- a/backend/core/services/system_metrics.py
+++ b/backend/core/services/system_metrics.py
@@ -1,0 +1,57 @@
+import os
+from typing import Any, Dict
+
+try:
+    import psutil
+except ImportError:
+    psutil = None
+
+
+def get_system_metrics() -> Dict[str, Any]:
+    out: Dict[str, Any] = {}
+    if psutil is None:
+        return {"error": "psutil not installed"}
+
+    try:
+        process = psutil.Process()
+        mem = process.memory_info()
+        out["memory_rss_mb"] = round(mem.rss / 1024 / 1024, 1)
+        out["memory_vms_mb"] = round(mem.vms / 1024 / 1024, 1)
+    except Exception as e:
+        out["memory_error"] = str(e)
+
+    try:
+        vm = psutil.virtual_memory()
+        out["memory_system_total_mb"] = round(vm.total / 1024 / 1024, 1)
+        out["memory_system_available_mb"] = round(vm.available / 1024 / 1024, 1)
+        out["memory_system_percent"] = round(vm.percent, 1)
+    except Exception as e:
+        out["memory_system_error"] = str(e)
+
+    try:
+        out["cpu_process_percent"] = round(process.cpu_percent(interval=0.1), 1)
+    except Exception as e:
+        out["cpu_process_error"] = str(e)
+
+    try:
+        out["cpu_system_percent"] = round(psutil.cpu_percent(interval=0.1), 1)
+    except Exception as e:
+        out["cpu_system_error"] = str(e)
+
+    try:
+        n = process.num_fds()
+        out["open_fds"] = n
+    except (AttributeError, OSError):
+        try:
+            out["open_fds"] = len(process.open_files())
+        except Exception:
+            out["open_fds"] = None
+
+    try:
+        du = psutil.disk_usage("/")
+        out["disk_percent"] = round(du.percent, 1)
+        out["disk_free_gb"] = round(du.free / 1024 / 1024 / 1024, 2)
+    except Exception as e:
+        out["disk_error"] = str(e)
+
+    return out


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new background logging loop and expands the `/health-docker` response, which could increase log volume and slightly impact startup/shutdown and health-check latency if metrics collection misbehaves.
> 
> **Overview**
> Adds periodic system metrics reporting via a new `_metrics_logger_loop` background task started in `lifespan`, configurable by `METRICS_LOG_INTERVAL_SECONDS`, and cleanly cancelled on shutdown.
> 
> Introduces `core.services.system_metrics.get_system_metrics()` (psutil-based) and reuses it in a new `_get_health_metrics()` helper to embed CPU/memory/disk/FD and active-run counts into the `/health-docker` response (and into the structured log payload sent to CloudWatch via existing logging).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fcfb8918c7da8c2442d290399f1202d687bf5d90. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->