### PR TITLE
rpc

### DIFF
--- a/apps/frontend/src/app/(dashboard)/admin/analytics/page.tsx
+++ b/apps/frontend/src/app/(dashboard)/admin/analytics/page.tsx
@@ -704,7 +704,7 @@ export default function AdminAnalyticsPage() {
                         <p className="text-xs text-muted-foreground">{userFunnel.clicked_checkout_rate}% of signups</p>
                         {userFunnel.other_clicked_checkout > 0 && (
                           <p className="text-xs text-muted-foreground mt-1">
-                            +{userFunnel.other_clicked_checkout} signed up earlier
+                            +{userFunnel.other_clicked_checkout} signed up earlier, clicked today
                           </p>
                         )}
                       </div>

--- a/backend/supabase/migrations/20260203175703_get_other_checkout_clicks_rpc.sql
+++ b/backend/supabase/migrations/20260203175703_get_other_checkout_clicks_rpc.sql
@@ -1,0 +1,25 @@
+-- RPC to count "other" checkout clicks (free tier users who signed up before range but clicked during)
+
+CREATE OR REPLACE FUNCTION get_other_checkout_clicks_count(
+    date_from TIMESTAMPTZ,
+    date_to TIMESTAMPTZ
+)
+RETURNS INTEGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+    result INTEGER;
+BEGIN
+    SELECT COUNT(DISTINCT cc.user_id) INTO result
+    FROM checkout_clicks cc
+    JOIN basejump.accounts a ON a.primary_owner_user_id = cc.user_id AND a.personal_account = true
+    LEFT JOIN credit_accounts ca ON ca.account_id = a.id
+    WHERE cc.clicked_at >= date_from
+      AND cc.clicked_at <= date_to
+      AND a.created_at < date_from  -- signed up BEFORE the range
+      AND COALESCE(ca.tier, 'free') IN ('free', 'none');  -- still on free tier
+
+    RETURN COALESCE(result, 0);
+END;
+$$;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a `SECURITY DEFINER` Postgres RPC and switches the admin analytics endpoint to depend on it, which could impact data correctness or permissions if the function is mis-scoped. Changes are limited to analytics counting and a small UI copy tweak.
> 
> **Overview**
> **Admin user-funnel analytics now computes “other” checkout clicks via a database RPC instead of client-side multi-query filtering.** The API replaces the previous in-app logic with a single `get_other_checkout_clicks_count(date_from, date_to)` call that counts distinct free-tier personal-account users created before the range who clicked checkout during the range.
> 
> Also updates the admin analytics UI copy to clarify that these “other” users *signed up earlier and clicked today*.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b055327b6f1b27dfae2627f0f3a3aa1f23bcd81d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->