### PR TITLE
fix

### DIFF
--- a/backend/supabase/migrations/20260203212144_funnel_counts_rpc.sql
+++ b/backend/supabase/migrations/20260203212144_funnel_counts_rpc.sql
@@ -1,0 +1,59 @@
+-- Fix: Return aggregated counts instead of rows to bypass PostgREST 1000 row limit
+
+CREATE OR REPLACE FUNCTION get_free_signups_funnel_counts(
+    date_from TIMESTAMPTZ,
+    date_to TIMESTAMPTZ
+)
+RETURNS TABLE (
+    total_signups BIGINT,
+    tried_task BIGINT,
+    viewed_pricing BIGINT,
+    tried_and_viewed BIGINT,
+    clicked_checkout BIGINT,
+    converted BIGINT
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+    RETURN QUERY
+    WITH signups AS (
+        SELECT
+            a.primary_owner_user_id as uid,
+            a.id as account_id
+        FROM basejump.accounts a
+        WHERE a.created_at >= date_from
+          AND a.created_at <= date_to
+          AND a.personal_account = true
+    ),
+    activity AS (
+        SELECT DISTINCT s.uid
+        FROM signups s
+        JOIN threads t ON t.account_id = s.account_id
+        JOIN agent_runs ar ON ar.thread_id = t.thread_id
+    ),
+    pricing AS (
+        SELECT DISTINCT s.uid
+        FROM signups s
+        JOIN pricing_views pv ON pv.user_id = s.uid
+    ),
+    checkout AS (
+        SELECT DISTINCT s.uid
+        FROM signups s
+        JOIN checkout_clicks cc ON cc.user_id = s.uid
+    ),
+    conversions AS (
+        SELECT DISTINCT s.uid
+        FROM signups s
+        JOIN credit_accounts ca ON ca.account_id = s.account_id
+        WHERE ca.tier NOT IN ('free', 'none')
+    )
+    SELECT
+        (SELECT COUNT(*) FROM signups)::BIGINT as total_signups,
+        (SELECT COUNT(*) FROM activity)::BIGINT as tried_task,
+        (SELECT COUNT(*) FROM pricing)::BIGINT as viewed_pricing,
+        (SELECT COUNT(*) FROM signups s WHERE EXISTS (SELECT 1 FROM activity a WHERE a.uid = s.uid) AND EXISTS (SELECT 1 FROM pricing p WHERE p.uid = s.uid))::BIGINT as tried_and_viewed,
+        (SELECT COUNT(*) FROM checkout)::BIGINT as clicked_checkout,
+        (SELECT COUNT(*) FROM conversions)::BIGINT as converted;
+END;
+$$;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces a new `SECURITY DEFINER` Supabase function and changes the admin funnel endpoint to rely on its aggregated results, which could affect reported metrics and has some DB/perf/permissions risk despite being admin-only.
> 
> **Overview**
> Updates the admin `GET /admin/analytics/user-funnel` logic to stop fetching per-user funnel rows and instead consume aggregated counts returned from a new Supabase RPC, avoiding PostgREST’s 1000-row response limit.
> 
> Adds a migration defining `get_free_signups_funnel_counts(date_from, date_to)` that computes funnel step counts (signups, activity, pricing view, checkout click, conversion) entirely in SQL and returns a single row of totals.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3cc0851a1851694b4ccab9b082ab92b79e618f69. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->