### PR TITLE
memory leak

### DIFF
--- a/backend/core/agents/pipeline/stateless/config.py
+++ b/backend/core/agents/pipeline/stateless/config.py
@@ -9,25 +9,30 @@ class StatelessConfig:
     MAX_PENDING_WRITES: ClassVar[int] = 100
     MAX_STEPS: ClassVar[int] = 100
     MAX_DURATION_SECONDS: ClassVar[int] = 3600
-    
+
     FLUSH_INTERVAL_SECONDS: ClassVar[float] = 5.0
     HEARTBEAT_INTERVAL_SECONDS: ClassVar[int] = 15
     RECOVERY_SWEEP_INTERVAL_SECONDS: ClassVar[int] = 60
-    
+
     HEARTBEAT_TTL_SECONDS: ClassVar[int] = 45
     CLAIM_TTL_SECONDS: ClassVar[int] = 3600
     ORPHAN_THRESHOLD_SECONDS: ClassVar[int] = 90
-    STUCK_RUN_THRESHOLD_SECONDS: ClassVar[int] = 7200
+    STUCK_RUN_THRESHOLD_SECONDS: ClassVar[int] = 600
 
     MAX_THREAD_LOCKS: ClassVar[int] = 100
     MAX_FLUSH_TASKS: ClassVar[int] = 10
     MAX_CONTENT_LENGTH: ClassVar[int] = 100_000
-    
+
     TASK_CANCEL_TIMEOUT_SECONDS: ClassVar[float] = 2.0
     TOOL_CLEANUP_TIMEOUT_SECONDS: ClassVar[float] = 5.0
-    
+
     PENDING_WRITES_WARNING_THRESHOLD: ClassVar[int] = 80
     FLUSH_LATENCY_WARNING_THRESHOLD_SECONDS: ClassVar[float] = 10.0
     ACTIVE_RUNS_WARNING_THRESHOLD: ClassVar[int] = 1000
+
+    MAX_BUFFERED_RUNS: ClassVar[int] = 500
+    CLEANUP_INTERVAL_SECONDS: ClassVar[int] = 60
+    MEMORY_PRESSURE_THRESHOLD_RUNS: ClassVar[int] = 300
+    STALE_RUN_AGE_SECONDS: ClassVar[int] = 600
 
 config = StatelessConfig()

--- a/backend/core/agents/pipeline/stateless/coordinator/stateless.py
+++ b/backend/core/agents/pipeline/stateless/coordinator/stateless.py
@@ -248,6 +248,8 @@ class StatelessCoordinator(BaseCoordinator):
             except Exception as e:
                 cleanup_errors.append(f"ownership: {e}")
 
+            idempotency.remove(ctx.agent_run_id)
+
             if self._thread_manager:
                 try:
                     await self._thread_manager.cleanup()

--- a/backend/core/agents/pipeline/stateless/flusher.py
+++ b/backend/core/agents/pipeline/stateless/flusher.py
@@ -1,5 +1,6 @@
 import asyncio
 import heapq
+import time
 from typing import Dict, Any, Optional, List, Tuple, TYPE_CHECKING
 
 from core.utils.logger import logger
@@ -11,9 +12,11 @@ if TYPE_CHECKING:
 
 class WriteBuffer:
     FLUSH_INTERVAL = stateless_config.FLUSH_INTERVAL_SECONDS
-    STALE_RUN_THRESHOLD_SECONDS = 7200
-    CLEANUP_INTERVAL_SECONDS = 300
+    STALE_RUN_THRESHOLD_SECONDS = stateless_config.STALE_RUN_AGE_SECONDS
+    CLEANUP_INTERVAL_SECONDS = stateless_config.CLEANUP_INTERVAL_SECONDS
     MAX_CONCURRENT_FLUSHES = 50
+    MAX_BUFFERED_RUNS = stateless_config.MAX_BUFFERED_RUNS
+    MEMORY_PRESSURE_THRESHOLD = stateless_config.MEMORY_PRESSURE_THRESHOLD_RUNS
 
     def __init__(self):
         self._runs: Dict[str, 'RunState'] = {}
@@ -21,6 +24,8 @@ class WriteBuffer:
         self._running: bool = False
         self._last_cleanup: float = 0
         self._flush_semaphore: Optional[asyncio.Semaphore] = None
+        self._eviction_count: int = 0
+        self._eviction_tasks: set = set()
 
     @property
     def run_count(self) -> int:
@@ -31,10 +36,38 @@ class WriteBuffer:
         return self._running
 
     def register(self, state: 'RunState') -> None:
+        if len(self._runs) >= self.MAX_BUFFERED_RUNS:
+            task = asyncio.create_task(self._evict_oldest_run())
+            self._eviction_tasks.add(task)
+            task.add_done_callback(lambda t: self._eviction_tasks.discard(t))
         self._runs[state.run_id] = state
 
     def unregister(self, run_id: str) -> None:
         self._runs.pop(run_id, None)
+
+    async def _evict_oldest_run(self) -> None:
+        if not self._runs:
+            return
+
+        oldest_run_id = None
+        oldest_time = float('inf')
+
+        for run_id, state in self._runs.items():
+            if state._start_time < oldest_time:
+                oldest_time = state._start_time
+                oldest_run_id = run_id
+
+        if oldest_run_id:
+            state = self._runs.get(oldest_run_id)
+            if state:
+                logger.warning(f"[WriteBuffer] Evicting oldest run due to memory pressure: {oldest_run_id}")
+                try:
+                    await state.flush()
+                    await state.cleanup()
+                except Exception as e:
+                    logger.error(f"[WriteBuffer] Eviction flush failed for {oldest_run_id}: {e}")
+                self._runs.pop(oldest_run_id, None)
+                self._eviction_count += 1
 
     def get(self, run_id: str) -> Optional['RunState']:
         return self._runs.get(run_id)
@@ -56,15 +89,37 @@ class WriteBuffer:
             except asyncio.CancelledError:
                 pass
             self._task = None
+
+        for task in list(self._eviction_tasks):
+            if not task.done():
+                task.cancel()
+        self._eviction_tasks.clear()
+
         await self.flush_all()
         logger.info("[WriteBuffer] Stopped")
 
     async def _loop(self) -> None:
+        from core.agents.pipeline.stateless.metrics import metrics
+
+        cleanup_counter = 0
         while self._running:
             try:
                 await asyncio.sleep(self.FLUSH_INTERVAL)
                 await self.flush_all()
-                await self._cleanup_stale_runs()
+
+                metrics.update_buffered_runs(len(self._runs), self.MAX_BUFFERED_RUNS)
+
+                cleanup_counter += 1
+                if cleanup_counter >= (self.CLEANUP_INTERVAL_SECONDS / self.FLUSH_INTERVAL):
+                    cleanup_counter = 0
+                    cleaned = await self._cleanup_stale_runs()
+                    if cleaned > 0:
+                        metrics.record_stale_cleanup(cleaned)
+
+                if len(self._runs) > self.MEMORY_PRESSURE_THRESHOLD:
+                    evicted = await self._handle_memory_pressure()
+                    for _ in range(evicted):
+                        metrics.record_eviction()
             except asyncio.CancelledError:
                 break
             except Exception as e:
@@ -121,29 +176,89 @@ class WriteBuffer:
         return await state.flush() if state else 0
 
     async def _cleanup_stale_runs(self) -> int:
-        import time
         now = time.time()
-
-        if now - self._last_cleanup < self.CLEANUP_INTERVAL_SECONDS:
-            return 0
-        
         self._last_cleanup = now
         cleaned = 0
-        
+
         for run_id, state in list(self._runs.items()):
-            if now - state._start_time > self.STALE_RUN_THRESHOLD_SECONDS:
-                logger.warning(f"[WriteBuffer] Cleaning stale run: {run_id} (age: {now - state._start_time:.0f}s)")
+            age = now - state._start_time
+            inactive_time = now - state._last_activity
+
+            is_terminated = not state.is_active
+            is_old_and_inactive = age > self.STALE_RUN_THRESHOLD_SECONDS and inactive_time > 120
+            is_very_old = age > 1800
+            is_long_inactive = inactive_time > 300 and is_terminated
+
+            should_clean = (is_old_and_inactive and is_terminated) or is_very_old or is_long_inactive
+
+            if should_clean:
+                reason = "very_old" if is_very_old else ("terminated" if is_terminated else "stale_inactive")
+                logger.warning(f"[WriteBuffer] Cleaning {reason} run: {run_id} (age: {age:.0f}s, inactive: {inactive_time:.0f}s, active: {state.is_active})")
                 try:
                     await state.flush()
+                    await state.cleanup()
                 except Exception as e:
-                    logger.error(f"[WriteBuffer] Failed to flush stale run {run_id}: {e}")
+                    logger.error(f"[WriteBuffer] Failed to cleanup run {run_id}: {e}")
                 self._runs.pop(run_id, None)
                 cleaned += 1
-        
+
         if cleaned > 0:
-            logger.info(f"[WriteBuffer] Cleaned {cleaned} stale runs")
-        
+            logger.info(f"[WriteBuffer] Cleaned {cleaned} runs, remaining: {len(self._runs)}")
+
         return cleaned
+
+    async def _handle_memory_pressure(self) -> int:
+        now = time.time()
+
+        terminated_runs = []
+        active_runs = []
+
+        for run_id, state in self._runs.items():
+            age = now - state._start_time
+            inactive_time = now - state._last_activity
+            if not state.is_active:
+                terminated_runs.append((run_id, state, age, inactive_time))
+            else:
+                active_runs.append((run_id, state, age, inactive_time))
+
+        terminated_runs.sort(key=lambda x: x[2], reverse=True)
+        active_runs.sort(key=lambda x: x[3], reverse=True)
+
+        to_evict = len(self._runs) - self.MEMORY_PRESSURE_THRESHOLD + 50
+        evicted = 0
+
+        for run_id, state, age, inactive_time in terminated_runs:
+            if evicted >= to_evict:
+                break
+            logger.warning(f"[WriteBuffer] Memory pressure eviction (terminated): {run_id} (age: {age:.0f}s)")
+            try:
+                await state.flush()
+                await state.cleanup()
+            except Exception as e:
+                logger.error(f"[WriteBuffer] Eviction cleanup failed for {run_id}: {e}")
+            self._runs.pop(run_id, None)
+            evicted += 1
+            self._eviction_count += 1
+
+        if evicted < to_evict:
+            for run_id, state, age, inactive_time in active_runs:
+                if evicted >= to_evict:
+                    break
+                if inactive_time > 300 or age > 1800:
+                    logger.warning(f"[WriteBuffer] Memory pressure eviction (inactive active): {run_id} (age: {age:.0f}s, inactive: {inactive_time:.0f}s)")
+                    try:
+                        await state.flush()
+                        await state.cleanup()
+                    except Exception as e:
+                        logger.error(f"[WriteBuffer] Eviction cleanup failed for {run_id}: {e}")
+                    self._runs.pop(run_id, None)
+                    evicted += 1
+                    self._eviction_count += 1
+
+        if evicted > 0:
+            logger.warning(f"[WriteBuffer] Memory pressure: evicted {evicted} runs, remaining: {len(self._runs)}")
+
+        return evicted
 
     async def finalize(self, state: 'RunState') -> Dict[str, Any]:
         from core.agents import repo as agents_repo
@@ -172,6 +287,9 @@ class WriteBuffer:
             "runs": len(self._runs),
             "pending": total_pending,
             "running": self._running,
+            "evictions": self._eviction_count,
+            "max_runs": self.MAX_BUFFERED_RUNS,
+            "pressure_threshold": self.MEMORY_PRESSURE_THRESHOLD,
         }
 
 

--- a/backend/core/agents/pipeline/stateless/persistence/dlq.py
+++ b/backend/core/agents/pipeline/stateless/persistence/dlq.py
@@ -54,7 +54,11 @@ class DeadLetterQueue:
         self._lock = asyncio.Lock()
 
     def on_entry(self, handler: Callable[[DLQEntry], Awaitable[None]]) -> None:
-        self._handlers.append(handler)
+        if handler not in self._handlers:
+            self._handlers.append(handler)
+
+    def off_entry(self, handler: Callable[[DLQEntry], Awaitable[None]]) -> None:
+        self._handlers = [h for h in self._handlers if h != handler]
 
     async def send(
         self,

--- a/backend/core/agents/pipeline/stateless/recovery.py
+++ b/backend/core/agents/pipeline/stateless/recovery.py
@@ -49,7 +49,11 @@ class RunRecovery:
         return self._shard_id is not None and self._total_shards is not None
 
     def on_recovery(self, callback: Callable[[str], Awaitable[None]]) -> None:
-        self._callbacks.append(callback)
+        if callback not in self._callbacks:
+            self._callbacks.append(callback)
+
+    def off_recovery(self, callback: Callable[[str], Awaitable[None]]) -> None:
+        self._callbacks = [cb for cb in self._callbacks if cb != callback]
 
     async def start(self) -> None:
         if self._running:

--- a/backend/core/agents/pipeline/stateless/state.py
+++ b/backend/core/agents/pipeline/stateless/state.py
@@ -570,6 +570,12 @@ class RunState:
         self._pending_writes.clear()
         self._deferred_tool_results.clear()
 
+        self._accumulated_content = ""
+        self._accumulated_reasoning = ""
+        self.system_prompt = None
+        self.tool_schemas = None
+        self.agent_config = None
+
     def to_dict(self) -> Dict[str, Any]:
         return {
             "run_id": self.run_id,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the stateless pipeline’s buffering/cleanup behavior (stale-run cleanup, eviction under memory pressure, and shorter stuck-run thresholds), which could impact in-flight runs or lose buffered state if flush/cleanup fails. Risk is mitigated by best-effort flush+cleanup and added observability metrics/alerts.
> 
> **Overview**
> **Prevents unbounded memory growth in the stateless pipeline** by introducing explicit limits and cleanup/eviction for buffered `RunState`s.
> 
> The `WriteBuffer` now caps buffered runs, periodically cleans up stale/terminated runs (with `RunState.cleanup()`), and evicts runs under memory pressure (including on over-cap registration), while tracking eviction/cleanup counts and exposing new metrics/health warnings.
> 
> Separately, cleanup paths were tightened: `StatelessCoordinator` removes `IdempotencyTracker` entries on run teardown, `IdempotencyTracker` now expires local cache entries by TTL, and `RunState.cleanup()` clears additional accumulated prompt/tool state. `DeadLetterQueue` and `RunRecovery` now dedupe callbacks and support unregistering handlers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit beedd5b0a9f8ad8cf5608c7b6e1f5cd41de63e53. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->