### PR TITLE
Fix WebSearch tool favicons & add type badge

### DIFF
--- a/apps/mobile/hooks/useToolsMetadata.ts
+++ b/apps/mobile/hooks/useToolsMetadata.ts
@@ -83,3 +83,4 @@ export function useToolsMetadata() {
 
 
 
+


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk UI-only changes; main behavior shift is always generating a favicon URL and displaying a derived type badge, which could affect rendering but not data or security flows.
> 
> **Overview**
> **WebSearch results now render more reliably and with clearer context.** Favicons are displayed via a new `Favicon` component that falls back to a globe icon when image loading fails.
> 
> Each result also shows a small *type badge* (e.g., Website/Article/Wiki/Blog) derived by the new `getResultType` helper. The favicon helper `getFavicon` was updated to always return a URL (with a default when parsing fails), removing prior null-handling branches.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 943efb9b99df4f1ba9e6ad6caff05ea5e1cca218. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->