### PR TITLE
Enhance ViewToggle: add showBrowserTab prop and update view options l…

### DIFF
--- a/apps/mobile/components/kortix-computer/KortixComputer.tsx
+++ b/apps/mobile/components/kortix-computer/KortixComputer.tsx
@@ -160,6 +160,13 @@ export function KortixComputer({
     }
   }, [showFilesTab, activeView, setActiveView]);
 
+  // If browser tab is hidden and we're on browser view, switch to tools
+  React.useEffect(() => {
+    if (activeView === 'browser') {
+      setActiveView('tools');
+    }
+  }, [activeView, setActiveView]);
+
   if (!isOpen) {
     return null;
   }

--- a/apps/mobile/components/kortix-computer/ViewToggle.tsx
+++ b/apps/mobile/components/kortix-computer/ViewToggle.tsx
@@ -14,21 +14,29 @@ interface ViewToggleProps {
   currentView: ViewType;
   onViewChange: (view: ViewType) => void;
   showFilesTab?: boolean;
+  showBrowserTab?: boolean;
 }
 
 const AnimatedView = Animated.createAnimatedComponent(View);
 
-export function ViewToggle({ currentView, onViewChange, showFilesTab = true }: ViewToggleProps) {
-  const viewOptions = showFilesTab
-    ? ['tools', 'files', 'browser'] as const
-    : ['tools', 'browser'] as const;
+export function ViewToggle({ currentView, onViewChange, showFilesTab = true, showBrowserTab = false }: ViewToggleProps) {
+  const viewOptions = React.useMemo(() => {
+    const options: ViewType[] = ['tools'];
+    if (showFilesTab) options.push('files');
+    if (showBrowserTab) options.push('browser');
+    return options;
+  }, [showFilesTab, showBrowserTab]);
 
   const getViewIndex = (view: ViewType) => {
     // If files tab is hidden and current view is files, default to tools
     if (!showFilesTab && view === 'files') {
       return 0; // tools
     }
-    const index = viewOptions.indexOf(view as any);
+    // If browser tab is hidden and current view is browser, default to tools
+    if (!showBrowserTab && view === 'browser') {
+      return 0; // tools
+    }
+    const index = viewOptions.indexOf(view);
     return index >= 0 ? index : 0;
   };
 
@@ -42,7 +50,7 @@ export function ViewToggle({ currentView, onViewChange, showFilesTab = true }: V
       damping: 30,
       stiffness: 300,
     });
-  }, [currentView, indicatorPosition, showFilesTab]);
+  }, [currentView, indicatorPosition, showFilesTab, showBrowserTab]);
 
   const indicatorStyle = useAnimatedStyle(() => ({
     transform: [{ translateX: indicatorPosition.value }],
@@ -86,17 +94,19 @@ export function ViewToggle({ currentView, onViewChange, showFilesTab = true }: V
         </Pressable>
       )}
 
-      <Pressable
-        onPress={() => handlePress('browser')}
-        className="relative z-10 h-7 w-7 items-center justify-center rounded-xl"
-      >
-        <Icon
-          as={Globe}
-          size={14}
-          className={currentView === 'browser' ? 'text-primary-foreground' : 'text-primary'}
-          strokeWidth={2}
-        />
-      </Pressable>
+      {showBrowserTab && (
+        <Pressable
+          onPress={() => handlePress('browser')}
+          className="relative z-10 h-7 w-7 items-center justify-center rounded-xl"
+        >
+          <Icon
+            as={Globe}
+            size={14}
+            className={currentView === 'browser' ? 'text-primary-foreground' : 'text-primary'}
+            strokeWidth={2}
+          />
+        </Pressable>
+      )}
     </View>
   );
 }


### PR DESCRIPTION
…ogic

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes navigation/state behavior for the `KortixComputer` panel; a new effect currently forces `'browser'` back to `'tools'`, which may unintentionally disable the browser view and affect user navigation.
> 
> **Overview**
> **Adds configurability for the browser tab in `ViewToggle`.** `ViewToggle` now accepts `showBrowserTab` (default `false`), builds its tab list dynamically, and updates indicator/index logic to fall back to `tools` when a tab is hidden.
> 
> **Alters `KortixComputer` view switching behavior.** A new effect switches from `browser` to `tools` when `activeView` is `browser`, effectively preventing staying on the browser view (and the browser tab is not enabled from `KortixComputer` in this diff).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0b94ab97ba3a8f998104c517fcc031897adccce9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->