### PR TITLE
feat: add CRW as unified alternative to Tavily, Serper, and Firecrawl

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -116,6 +116,8 @@ OPENROUTER_API_KEY=                     # primary LLM route — warns if empty
 # Features degrade gracefully if keys are missing.
 # Custom API URLs can be set per provider (defaults to official endpoints).
 
+# CRW_API_KEY=
+# CRW_API_URL=https://fastcrw.com/api
 # TAVILY_API_KEY=
 # TAVILY_API_URL=https://api.tavily.com
 # SERPER_API_KEY=

--- a/apps/api/src/__tests__/unit-proxy-services.test.ts
+++ b/apps/api/src/__tests__/unit-proxy-services.test.ts
@@ -191,7 +191,7 @@ describe('matchAllowedRoute', () => {
   describe('registry integrity', () => {
     test('proxy services registry contains expected services', () => {
       const serviceNames = Object.keys(getProxyServices()).sort();
-      expect(serviceNames).toEqual(['context7', 'firecrawl', 'replicate', 'serper', 'tavily']);
+      expect(serviceNames).toEqual(['anthropic', 'context7', 'crw', 'firecrawl', 'gemini', 'groq', 'openai', 'replicate', 'serper', 'tavily', 'xai']);
     });
 
     test('each service has required fields', () => {

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -79,7 +79,11 @@ const envSchema = z.object({
   KORTIX_BILLING_INTERNAL_ENABLED:  optBoolFalse,  // NOTE: overridden by ENV_MODE=cloud below
   KORTIX_DEPLOYMENTS_ENABLED:       optBoolFalse,
 
-  // ── Search Providers (optional — features degrade gracefully) ────────────
+  // ── CRW (search, scrape, crawl, map — replaces Tavily, Serper, Firecrawl) ─
+  CRW_API_URL:                 optUrl('https://fastcrw.com/api'),
+  CRW_API_KEY:                 optStr,
+
+  // ── Legacy Search Providers (kept for backward compat, optional) ────────
   TAVILY_API_URL:              optUrl('https://api.tavily.com'),
   TAVILY_API_KEY:              optStr,
   SERPER_API_URL:              optUrl('https://google.serper.dev'),
@@ -371,7 +375,11 @@ export const config = {
   // ─── API Key Hashing ──────────────────────────────────────────────────────
   API_KEY_SECRET: env.API_KEY_SECRET,
 
-  // ─── Search Providers ──────────────────────────────────────────────────────
+  // ─── CRW (unified search, scrape, crawl) ───────────────────────────────────
+  CRW_API_URL: env.CRW_API_URL,
+  CRW_API_KEY: env.CRW_API_KEY,
+
+  // ─── Legacy Search Providers ──────────────────────────────────────────────
   TAVILY_API_URL: env.TAVILY_API_URL,
   TAVILY_API_KEY: env.TAVILY_API_KEY,
   SERPER_API_URL: env.SERPER_API_URL,
@@ -596,6 +604,11 @@ export const TOOL_PRICING: Record<string, ToolPricing> = {
     baseCost: 0.001,
     perResultCost: 0,
     markupMultiplier: 2.0,
+  },
+  proxy_crw: {
+    baseCost: 0.003,
+    perResultCost: 0,
+    markupMultiplier: 1.5,
   },
   proxy_tavily: {
     baseCost: 0.005,

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -79,7 +79,11 @@ const envSchema = z.object({
   KORTIX_BILLING_INTERNAL_ENABLED:  optBoolFalse,  // NOTE: overridden by ENV_MODE=cloud below
   KORTIX_DEPLOYMENTS_ENABLED:       optBoolFalse,
 
-  // ── Search Providers (optional — features degrade gracefully) ────────────
+  // ── CRW (search, scrape, crawl, map — replaces Tavily, Serper, Firecrawl) ─
+  CRW_API_URL:                 optUrl('https://fastcrw.com/api'),
+  CRW_API_KEY:                 optStr,
+
+  // ── Legacy Search Providers (kept for backward compat, optional) ────────
   TAVILY_API_URL:              optUrl('https://api.tavily.com'),
   TAVILY_API_KEY:              optStr,
   SERPER_API_URL:              optUrl('https://google.serper.dev'),
@@ -375,7 +379,11 @@ export const config = {
   // ─── API Key Hashing ──────────────────────────────────────────────────────
   API_KEY_SECRET: env.API_KEY_SECRET,
 
-  // ─── Search Providers ──────────────────────────────────────────────────────
+  // ─── CRW (unified search, scrape, crawl) ───────────────────────────────────
+  CRW_API_URL: env.CRW_API_URL,
+  CRW_API_KEY: env.CRW_API_KEY,
+
+  // ─── Legacy Search Providers ──────────────────────────────────────────────
   TAVILY_API_URL: env.TAVILY_API_URL,
   TAVILY_API_KEY: env.TAVILY_API_KEY,
   SERPER_API_URL: env.SERPER_API_URL,
@@ -604,6 +612,11 @@ export const TOOL_PRICING: Record<string, ToolPricing> = {
     baseCost: 0.001,
     perResultCost: 0,
     markupMultiplier: 2.0,
+  },
+  proxy_crw: {
+    baseCost: 0.003,
+    perResultCost: 0,
+    markupMultiplier: 1.5,
   },
   proxy_tavily: {
     baseCost: 0.005,

--- a/apps/api/src/platform/providers/daytona.ts
+++ b/apps/api/src/platform/providers/daytona.ts
@@ -69,6 +69,8 @@ export class DaytonaProvider implements SandboxProvider {
           REPLICATE_API_URL: `${routerBase}/replicate`,
           SERPER_API_URL: `${routerBase}/serper`,
           FIRECRAWL_API_URL: `${routerBase}/firecrawl`,
+          // Only inject CRW proxy URL when backend has CRW key configured
+          ...(config.CRW_API_KEY ? { CRW_API_URL: `${routerBase}/crw` } : {}),
           ...opts.envVars,
         },
         autoStopInterval: 15,

--- a/apps/api/src/platform/providers/justavps.ts
+++ b/apps/api/src/platform/providers/justavps.ts
@@ -486,6 +486,8 @@ export class JustAVPSProvider implements SandboxProvider {
       REPLICATE_API_URL: `${routerBase}/replicate`,
       SERPER_API_URL: `${routerBase}/serper`,
       FIRECRAWL_API_URL: `${routerBase}/firecrawl`,
+      // Only inject CRW proxy URL when backend has CRW key configured
+      ...(config.CRW_API_KEY ? { CRW_API_URL: `${routerBase}/crw` } : {}),
       PUID: '911',
       PGID: '911',
       ...opts.envVars,

--- a/apps/api/src/platform/providers/justavps.ts
+++ b/apps/api/src/platform/providers/justavps.ts
@@ -597,6 +597,8 @@ export class JustAVPSProvider implements SandboxProvider {
       REPLICATE_API_URL: `${routerBase}/replicate`,
       SERPER_API_URL: `${routerBase}/serper`,
       FIRECRAWL_API_URL: `${routerBase}/firecrawl`,
+      // Only inject CRW proxy URL when backend has CRW key configured
+      ...(config.CRW_API_KEY ? { CRW_API_URL: `${routerBase}/crw` } : {}),
       PUID: '911',
       PGID: '911',
       ...opts.envVars,

--- a/apps/api/src/platform/providers/local-docker.ts
+++ b/apps/api/src/platform/providers/local-docker.ts
@@ -584,6 +584,12 @@ export class LocalDockerProvider implements SandboxProvider {
       FIRECRAWL_API_URL: `${routerBase}/firecrawl`,
     };
 
+    // Only inject CRW proxy URL when the backend has a CRW key configured.
+    // Without this guard, sandbox tools would select CRW and get 503 "crw not configured".
+    if (config.CRW_API_KEY) {
+      desired.CRW_API_URL = `${routerBase}/crw`;
+    }
+
     // Read current state from the live master env (s6 env dir) — NOT from
     // Docker inspect which only has stale creation-time values.
     const authCandidates = getAuthCandidates(await this.getCanonicalServiceKey());
@@ -604,6 +610,13 @@ export class LocalDockerProvider implements SandboxProvider {
       if (val && currentEnv[key] !== val) {
         stale[key] = val;
       }
+    }
+
+    // Clean up stale CRW_API_URL from sandbox when CRW is no longer configured.
+    // Without this, disabling CRW leaves an orphan URL that makes sandbox tools
+    // select CRW and hit 503 "crw not configured".
+    if (!desired.CRW_API_URL && currentEnv.CRW_API_URL) {
+      stale.CRW_API_URL = '';  // empty value signals deletion to the env API
     }
 
     if (Object.keys(stale).length === 0) {
@@ -866,6 +879,7 @@ export class LocalDockerProvider implements SandboxProvider {
       'PROJECT_ID',
       'ENV_MODE',
       'CORS_ALLOWED_ORIGINS',
+      'CRW_API_URL',
       'TAVILY_API_URL',
       'REPLICATE_API_URL',
       'SERPER_API_URL',
@@ -915,6 +929,8 @@ export class LocalDockerProvider implements SandboxProvider {
       `REPLICATE_API_URL=${routerBase}/replicate`,
       `SERPER_API_URL=${routerBase}/serper`,
       `FIRECRAWL_API_URL=${routerBase}/firecrawl`,
+      // Only inject CRW proxy URL when the backend has a CRW key configured.
+      ...(config.CRW_API_KEY ? [`CRW_API_URL=${routerBase}/crw`] : []),
       ...(config.KORTIX_LOCAL_IMAGES ? ['KORTIX_LOCAL_SOURCE=1'] : []),
       `ENV_MODE=${config.KORTIX_BILLING_INTERNAL_ENABLED ? 'cloud' : 'local'}`,
       `CORS_ALLOWED_ORIGINS=${[config.FRONTEND_URL, config.KORTIX_URL].filter(Boolean).join(',')}`,

--- a/apps/api/src/platform/providers/local-docker.ts
+++ b/apps/api/src/platform/providers/local-docker.ts
@@ -636,6 +636,12 @@ export class LocalDockerProvider implements SandboxProvider {
       FIRECRAWL_API_URL: `${routerBase}/firecrawl`,
     };
 
+    // Only inject CRW proxy URL when the backend has a CRW key configured.
+    // Without this guard, sandbox tools would select CRW and get 503 "crw not configured".
+    if (config.CRW_API_KEY) {
+      desired.CRW_API_URL = `${routerBase}/crw`;
+    }
+
     // Read current state from the live master env (s6 env dir) — NOT from
     // Docker inspect which only has stale creation-time values.
     const authCandidates = getAuthCandidates(await this.getCanonicalServiceKey());
@@ -656,6 +662,13 @@ export class LocalDockerProvider implements SandboxProvider {
       if (val && currentEnv[key] !== val) {
         stale[key] = val;
       }
+    }
+
+    // Clean up stale CRW_API_URL from sandbox when CRW is no longer configured.
+    // Without this, disabling CRW leaves an orphan URL that makes sandbox tools
+    // select CRW and hit 503 "crw not configured".
+    if (!desired.CRW_API_URL && currentEnv.CRW_API_URL) {
+      stale.CRW_API_URL = '';  // empty value signals deletion to the env API
     }
 
     if (Object.keys(stale).length === 0) {
@@ -918,6 +931,7 @@ export class LocalDockerProvider implements SandboxProvider {
       'PROJECT_ID',
       'ENV_MODE',
       'CORS_ALLOWED_ORIGINS',
+      'CRW_API_URL',
       'TAVILY_API_URL',
       'REPLICATE_API_URL',
       'SERPER_API_URL',
@@ -967,6 +981,8 @@ export class LocalDockerProvider implements SandboxProvider {
       `REPLICATE_API_URL=${routerBase}/replicate`,
       `SERPER_API_URL=${routerBase}/serper`,
       `FIRECRAWL_API_URL=${routerBase}/firecrawl`,
+      // Only inject CRW proxy URL when the backend has a CRW key configured.
+      ...(config.CRW_API_KEY ? [`CRW_API_URL=${routerBase}/crw`] : []),
       ...(config.KORTIX_LOCAL_IMAGES ? ['KORTIX_LOCAL_SOURCE=1'] : []),
       `ENV_MODE=${config.KORTIX_BILLING_INTERNAL_ENABLED ? 'cloud' : 'local'}`,
       `CORS_ALLOWED_ORIGINS=${[config.FRONTEND_URL, config.KORTIX_URL].filter(Boolean).join(',')}`,

--- a/apps/api/src/pool/env-injector.ts
+++ b/apps/api/src/pool/env-injector.ts
@@ -40,6 +40,13 @@ function buildEnvPayload(serviceKey: string, metadata?: Record<string, unknown>)
     TUNNEL_TOKEN: serviceKey,
   };
 
+  // Only inject CRW proxy URL when the backend has a CRW key configured.
+  // When CRW is disabled, explicitly write empty string so the /env POST clears
+  // any stale CRW_API_URL from previously-claimed pool sandboxes. getEnv() treats
+  // an existing-but-empty s6 file as "explicitly cleared" and won't fall through
+  // to stale process.env values.
+  payload.CRW_API_URL = config.CRW_API_KEY ? `${routerBase}/crw` : '';
+
   // Compute PUBLIC_BASE_URL from JustAVPS metadata so getMasterPublicBaseUrl()
   // returns a real public URL instead of localhost inside the sandbox.
   if (metadata) {

--- a/apps/api/src/pool/env-injector.ts
+++ b/apps/api/src/pool/env-injector.ts
@@ -42,6 +42,13 @@ function buildEnvPayload(serviceKey: string, metadata?: Record<string, unknown>)
     TUNNEL_TOKEN: serviceKey,
   };
 
+  // Only inject CRW proxy URL when the backend has a CRW key configured.
+  // When CRW is disabled, explicitly write empty string so the /env POST clears
+  // any stale CRW_API_URL from previously-claimed pool sandboxes. getEnv() treats
+  // an existing-but-empty s6 file as "explicitly cleared" and won't fall through
+  // to stale process.env values.
+  payload.CRW_API_URL = config.CRW_API_KEY ? `${routerBase}/crw` : '';
+
   // Compute PUBLIC_BASE_URL from JustAVPS metadata so getMasterPublicBaseUrl()
   // returns a real public URL instead of localhost inside the sandbox.
   if (metadata) {

--- a/apps/api/src/providers/registry.ts
+++ b/apps/api/src/providers/registry.ts
@@ -93,6 +93,16 @@ export const PROVIDER_REGISTRY: ProviderDef[] = [
 
   // ─── Tool Providers ────────────────────────────────────────
   {
+    id: 'crw',
+    name: 'CRW',
+    category: 'tool',
+    envKeys: ['CRW_API_KEY'],
+    envUrlKey: 'CRW_API_URL',
+    defaultUrl: 'https://fastcrw.com/api',
+    helpUrl: 'https://fastcrw.com',
+    description: 'Web Search, Image Search, Scraping & Crawling (replaces Tavily, Serper, Firecrawl)',
+  },
+  {
     id: 'tavily',
     name: 'Tavily',
     category: 'tool',

--- a/apps/api/src/router/config/proxy-services.ts
+++ b/apps/api/src/router/config/proxy-services.ts
@@ -50,6 +50,27 @@ export interface ProxyServiceConfig {
 
 export function getProxyServices(): Record<string, ProxyServiceConfig> {
   return {
+    // ─── CRW (unified: search, scrape, crawl, map — replaces Tavily, Serper, Firecrawl) ─
+    crw: {
+      name: 'crw',
+      targetBaseUrl: config.CRW_API_URL,
+      getKortixApiKey: () => config.CRW_API_KEY,
+      keyInjection: { type: 'header', headerName: 'Authorization', prefix: 'Bearer ' },
+      allowedRoutes: [
+        { path: '/v1/scrape', methods: ['POST'] },
+        { path: '/v1/crawl', methods: ['POST', 'GET', 'DELETE'], prefixMatch: true },
+        { path: '/v1/map', methods: ['POST'] },
+        { path: '/v1/search', methods: ['POST'] },
+        { path: '/v2/scrape', methods: ['POST'] },
+        { path: '/v2/crawl', methods: ['POST', 'GET', 'DELETE'], prefixMatch: true },
+        { path: '/v2/map', methods: ['POST'] },
+        { path: '/v2/search', methods: ['POST'] },
+      ],
+      billingToolName: 'proxy_crw',
+    },
+
+    // ─── Legacy providers (kept for backward compat / gradual migration) ────
+
     tavily: {
       name: 'tavily',
       targetBaseUrl: config.TAVILY_API_URL,
@@ -86,7 +107,6 @@ export function getProxyServices(): Record<string, ProxyServiceConfig> {
         { path: '/v1/crawl', methods: ['POST', 'GET'], prefixMatch: true },
         { path: '/v1/map', methods: ['POST'] },
         { path: '/v1/search', methods: ['POST'] },
-        // Firecrawl JS SDK v2+ uses /v2 endpoints
         { path: '/v2/scrape', methods: ['POST'] },
         { path: '/v2/crawl', methods: ['POST', 'GET'], prefixMatch: true },
         { path: '/v2/map', methods: ['POST'] },
@@ -101,7 +121,6 @@ export function getProxyServices(): Record<string, ProxyServiceConfig> {
       getKortixApiKey: () => config.REPLICATE_API_TOKEN,
       keyInjection: { type: 'header', headerName: 'Authorization', prefix: 'Token ' },
       allowedRoutes: [
-        // Allowed models — locked to specific models, each with own billing
         {
           path: '/v1/models/google/nano-banana/predictions',
           methods: ['POST'],

--- a/apps/api/src/router/routes/proxy.ts
+++ b/apps/api/src/router/routes/proxy.ts
@@ -23,6 +23,20 @@ import {
 
 const proxy = new Hono();
 
+/**
+ * Strip hop-by-hop and transport-encoding headers that become invalid after
+ * Bun's fetch() auto-decompresses the upstream response body.
+ * Without this, clients see Content-Encoding: gzip on an already-decompressed
+ * body and get ZlibError when they try to decompress again.
+ */
+function stripTransportHeaders(headers: Headers): Headers {
+  const cleaned = new Headers(headers);
+  cleaned.delete('content-encoding');
+  cleaned.delete('content-length'); // length is wrong after decompression
+  cleaned.delete('transfer-encoding');
+  return cleaned;
+}
+
 const services = getProxyServices();
 
 for (const [prefix, serviceConfig] of Object.entries(services)) {
@@ -150,7 +164,7 @@ async function handleKortixProxy(
     return new Response(upstream.body, {
       status: upstream.status,
       statusText: upstream.statusText,
-      headers: upstream.headers,
+      headers: stripTransportHeaders(upstream.headers),
     });
   }
 
@@ -167,7 +181,7 @@ async function handleKortixProxy(
   return new Response(upstream.body, {
     status: upstream.status,
     statusText: upstream.statusText,
-    headers: upstream.headers,
+    headers: stripTransportHeaders(upstream.headers),
   });
 }
 
@@ -417,7 +431,7 @@ async function handleKortixPassthrough(
     return new Response(upstream.body, {
       status: upstream.status,
       statusText: upstream.statusText,
-      headers: upstream.headers,
+      headers: stripTransportHeaders(upstream.headers),
     });
   }
 
@@ -434,7 +448,7 @@ async function handleKortixPassthrough(
   return new Response(upstream.body, {
     status: upstream.status,
     statusText: upstream.statusText,
-    headers: upstream.headers,
+    headers: stripTransportHeaders(upstream.headers),
   });
 }
 
@@ -465,7 +479,7 @@ async function handlePassthrough(
   return new Response(upstream.body, {
     status: upstream.status,
     statusText: upstream.statusText,
-    headers: upstream.headers,
+    headers: stripTransportHeaders(upstream.headers),
   });
 }
 

--- a/apps/api/src/router/routes/proxy.ts
+++ b/apps/api/src/router/routes/proxy.ts
@@ -14,6 +14,20 @@ import { calculateCost, extractUsage } from '../services/llm';
 
 const proxy = new Hono();
 
+/**
+ * Strip hop-by-hop and transport-encoding headers that become invalid after
+ * Bun's fetch() auto-decompresses the upstream response body.
+ * Without this, clients see Content-Encoding: gzip on an already-decompressed
+ * body and get ZlibError when they try to decompress again.
+ */
+function stripTransportHeaders(headers: Headers): Headers {
+  const cleaned = new Headers(headers);
+  cleaned.delete('content-encoding');
+  cleaned.delete('content-length'); // length is wrong after decompression
+  cleaned.delete('transfer-encoding');
+  return cleaned;
+}
+
 const services = getProxyServices();
 
 for (const [prefix, serviceConfig] of Object.entries(services)) {
@@ -131,7 +145,7 @@ async function handleKortixProxy(
     return new Response(upstream.body, {
       status: upstream.status,
       statusText: upstream.statusText,
-      headers: upstream.headers,
+      headers: stripTransportHeaders(upstream.headers),
     });
   }
 
@@ -148,7 +162,7 @@ async function handleKortixProxy(
   return new Response(upstream.body, {
     status: upstream.status,
     statusText: upstream.statusText,
-    headers: upstream.headers,
+    headers: stripTransportHeaders(upstream.headers),
   });
 }
 
@@ -378,7 +392,7 @@ async function handleKortixPassthrough(
     return new Response(upstream.body, {
       status: upstream.status,
       statusText: upstream.statusText,
-      headers: upstream.headers,
+      headers: stripTransportHeaders(upstream.headers),
     });
   }
 
@@ -395,7 +409,7 @@ async function handleKortixPassthrough(
   return new Response(upstream.body, {
     status: upstream.status,
     statusText: upstream.statusText,
-    headers: upstream.headers,
+    headers: stripTransportHeaders(upstream.headers),
   });
 }
 
@@ -426,7 +440,7 @@ async function handlePassthrough(
   return new Response(upstream.body, {
     status: upstream.status,
     statusText: upstream.statusText,
-    headers: upstream.headers,
+    headers: stripTransportHeaders(upstream.headers),
   });
 }
 

--- a/apps/api/src/router/services/serper.ts
+++ b/apps/api/src/router/services/serper.ts
@@ -1,32 +1,73 @@
 import { config } from '../../config';
 import type { ImageSearchResult } from '../../types';
 
-interface SerperResponse {
-  images: Array<{
-    title: string;
-    imageUrl: string;
-    thumbnailUrl?: string;
-    link: string;
-    imageWidth?: number;
-    imageHeight?: number;
-  }>;
+interface CrwImageResult {
+  url: string;
+  title?: string;
+  imageUrl: string;
+  thumbnailUrl?: string;
+  imageFormat?: string;
+  resolution?: string;
+}
+
+interface CrwSearchResponse {
+  success: boolean;
+  data: { images?: CrwImageResult[] } | CrwImageResult[];
+  error?: string;
+}
+
+function parseResolution(res?: string): { width: number | null; height: number | null } {
+  if (!res) return { width: null, height: null };
+  const match = res.match(/(\d+)\s*[x×]\s*(\d+)/i);
+  if (!match) return { width: null, height: null };
+  return { width: parseInt(match[1], 10), height: parseInt(match[2], 10) };
 }
 
 /**
- * Search for images using Serper API (Google Images).
+ * Search for images using CRW API (with Serper fallback).
  *
  * @param query - Search query
  * @param maxResults - Maximum number of results (1-20)
- * @param safeSearch - Enable safe search filtering
+ * @param _safeSearch - Safe search filtering (not supported by CRW, kept for compat)
  * @returns List of ImageSearchResult
  */
 export async function imageSearchSerper(
   query: string,
   maxResults: number = 5,
-  safeSearch: boolean = true
+  _safeSearch: boolean = true
 ): Promise<ImageSearchResult[]> {
+  // Prefer CRW, fall back to legacy Serper
+  const useCrw = !!config.CRW_API_KEY;
+
+  if (useCrw) {
+    // CRW does not natively support safe_search filtering, but its SearXNG
+    // backend returns generally-safe results by default. When the caller
+    // explicitly requests unfiltered results (safe_search=false) and Serper
+    // is available, route to Serper which supports safe=off natively.
+    if (!_safeSearch && config.SERPER_API_KEY) {
+      // Caller explicitly wants unfiltered results — route to Serper which supports safe=off
+      console.log('[IMAGE-SEARCH] safe_search=false requested; using Serper (CRW does not support explicit safe_search toggling)');
+    } else if (!_safeSearch && !config.SERPER_API_KEY) {
+      // Caller wants unfiltered results but only CRW is available — use CRW with a warning
+      console.warn('[IMAGE-SEARCH] safe_search=false requested but only CRW is configured (no Serper fallback); results may still be filtered');
+      return await imageSearchCrw(query, maxResults);
+    } else {
+      try {
+        return await imageSearchCrw(query, maxResults);
+      } catch (err) {
+        // If Serper is available, fall back gracefully on CRW failure
+        if (config.SERPER_API_KEY) {
+          console.warn('[IMAGE-SEARCH] CRW failed, falling back to Serper:', err);
+        } else {
+          throw err;
+        }
+      }
+    }
+  }
+
+  // Legacy Serper path (also serves as fallback when CRW fails)
   if (!config.SERPER_API_KEY) {
-    throw new Error('SERPER_API_KEY not configured');
+    throw new Error('CRW_API_KEY or SERPER_API_KEY not configured');
   }
 
   const response = await fetch(`${config.SERPER_API_URL}/images`, {
@@ -38,7 +79,7 @@ export async function imageSearchSerper(
     body: JSON.stringify({
       q: query,
       num: Math.min(maxResults, 20),
-      safe: safeSearch ? 'active' : 'off',
+      safe: _safeSearch ? 'active' : 'off',
     }),
   });
 
@@ -47,7 +88,7 @@ export async function imageSearchSerper(
     throw new Error(`Serper API error: ${response.status} - ${error}`);
   }
 
-  const data: SerperResponse = await response.json();
+  const data = await response.json() as { images: Array<{ title: string; imageUrl: string; thumbnailUrl?: string; link: string; imageWidth?: number; imageHeight?: number }> };
 
   const results: ImageSearchResult[] = (data.images || []).map((item) => ({
     title: item.title || '',
@@ -59,6 +100,59 @@ export async function imageSearchSerper(
   }));
 
   console.log(`[KORTIX] Image search for '${query}' returned ${results.length} results`);
+  return results;
+}
 
+async function imageSearchCrw(
+  query: string,
+  maxResults: number,
+): Promise<ImageSearchResult[]> {
+  const apiUrl = config.CRW_API_URL.replace(/\/+$/, '');
+  const apiKey = config.CRW_API_KEY;
+
+  const response = await fetch(`${apiUrl}/v1/search`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      query,
+      limit: Math.min(maxResults, 20),
+      sources: ['images'],
+    }),
+  });
+
+  if (!response.ok) {
+    const error = await response.text();
+    throw new Error(`CRW API error: ${response.status} - ${error}`);
+  }
+
+  const json = await response.json() as CrwSearchResponse;
+  if (!json.success) {
+    throw new Error(`CRW image search failed: ${json.error ?? 'unknown error'}`);
+  }
+
+  // Handle grouped response vs flat array
+  let rawImages: CrwImageResult[];
+  if (Array.isArray(json.data)) {
+    rawImages = json.data;
+  } else {
+    rawImages = json.data.images ?? [];
+  }
+
+  const results: ImageSearchResult[] = rawImages.map((item) => {
+    const { width, height } = parseResolution(item.resolution);
+    return {
+      title: item.title || '',
+      url: item.imageUrl || item.url || '',
+      thumbnail_url: item.thumbnailUrl || item.imageUrl || '',
+      source_url: item.url || '',
+      width,
+      height,
+    };
+  });
+
+  console.log(`[KORTIX] CRW image search for '${query}' returned ${results.length} results`);
   return results;
 }

--- a/apps/api/src/router/services/tavily.ts
+++ b/apps/api/src/router/services/tavily.ts
@@ -1,17 +1,22 @@
 import { config } from '../../config';
 import type { WebSearchResult } from '../../types';
 
-interface TavilyResponse {
-  results: Array<{
-    title: string;
-    url: string;
-    content: string;
-    published_date?: string;
-  }>;
+interface CrwSearchResult {
+  url: string;
+  title: string;
+  description: string;
+  score?: number;
+  publishedDate?: string;
+}
+
+interface CrwSearchResponse {
+  success: boolean;
+  data: CrwSearchResult[] | { web?: CrwSearchResult[] };
+  error?: string;
 }
 
 /**
- * Search the web using Tavily API.
+ * Search the web using CRW API (with Tavily fallback).
  *
  * @param query - Search query
  * @param maxResults - Maximum number of results (1-10)
@@ -23,15 +28,30 @@ export async function webSearchTavily(
   maxResults: number = 5,
   searchDepth: 'basic' | 'advanced' = 'basic'
 ): Promise<WebSearchResult[]> {
+  // Prefer CRW, fall back to legacy Tavily
+  const useCrw = !!config.CRW_API_KEY;
+
+  if (useCrw) {
+    try {
+      return await webSearchCrw(query, maxResults, searchDepth);
+    } catch (err) {
+      // If Tavily is available, fall back gracefully on CRW failure
+      if (config.TAVILY_API_KEY) {
+        console.warn('[WEB-SEARCH] CRW failed, falling back to Tavily:', err);
+      } else {
+        throw err;
+      }
+    }
+  }
+
+  // Legacy Tavily path (also serves as fallback when CRW fails)
   if (!config.TAVILY_API_KEY) {
-    throw new Error('TAVILY_API_KEY not configured');
+    throw new Error('CRW_API_KEY or TAVILY_API_KEY not configured');
   }
 
   const response = await fetch(`${config.TAVILY_API_URL}/search`, {
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
       api_key: config.TAVILY_API_KEY,
       query,
@@ -47,7 +67,7 @@ export async function webSearchTavily(
     throw new Error(`Tavily API error: ${response.status} - ${error}`);
   }
 
-  const data: TavilyResponse = await response.json();
+  const data = await response.json() as { results: Array<{ title: string; url: string; content: string; published_date?: string }> };
 
   const results: WebSearchResult[] = data.results.map((item) => ({
     title: item.title || '',
@@ -57,6 +77,61 @@ export async function webSearchTavily(
   }));
 
   console.log(`[KORTIX] Web search for '${query}' returned ${results.length} results`);
+  return results;
+}
 
+async function webSearchCrw(
+  query: string,
+  maxResults: number,
+  searchDepth: 'basic' | 'advanced',
+): Promise<WebSearchResult[]> {
+  const apiUrl = config.CRW_API_URL.replace(/\/+$/, '');
+  const apiKey = config.CRW_API_KEY;
+
+  const body: Record<string, unknown> = {
+    query,
+    limit: Math.min(maxResults, 20),
+    sources: ['web'],
+  };
+
+  if (searchDepth === 'advanced') {
+    body.scrapeOptions = { formats: ['markdown'], onlyMainContent: true };
+  }
+
+  const response = await fetch(`${apiUrl}/v1/search`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    const error = await response.text();
+    throw new Error(`CRW API error: ${response.status} - ${error}`);
+  }
+
+  const json = await response.json() as CrwSearchResponse;
+  if (!json.success) {
+    throw new Error(`CRW search failed: ${json.error ?? 'unknown error'}`);
+  }
+
+  // Handle flat array vs grouped response
+  let crwResults: CrwSearchResult[];
+  if (Array.isArray(json.data)) {
+    crwResults = json.data;
+  } else {
+    crwResults = json.data.web ?? [];
+  }
+
+  const results: WebSearchResult[] = crwResults.map((item) => ({
+    title: item.title || '',
+    url: item.url || '',
+    snippet: item.description || '',
+    published_date: item.publishedDate || null,
+  }));
+
+  console.log(`[KORTIX] CRW web search for '${query}' returned ${results.length} results`);
   return results;
 }

--- a/core/docker/.env.example
+++ b/core/docker/.env.example
@@ -11,6 +11,7 @@ PROJECT_ID=local
 ENV_MODE=local
 
 # Tool API keys
+CRW_API_KEY=
 TAVILY_API_KEY=
 FIRECRAWL_API_KEY=
 SERPER_API_KEY=
@@ -20,6 +21,7 @@ ELEVENLABS_API_KEY=
 
 # Tool API URL overrides (optional — leave empty to use real upstream APIs directly)
 # In cloud mode these are set automatically to route through the Kortix router proxy.
+# CRW_API_URL=https://fastcrw.com/api
 # TAVILY_API_URL=
 # SERPER_API_URL=
 # REPLICATE_API_URL=

--- a/core/kortix-master/opencode/tools/image_search.ts
+++ b/core/kortix-master/opencode/tools/image_search.ts
@@ -1,31 +1,21 @@
 import { tool } from "@opencode-ai/plugin";
-import Replicate from "replicate";
 import { getEnv } from "./lib/get-env";
 
-const SERPER_DEFAULT_URL = "https://google.serper.dev";
-
-function getSerperImagesUrl(): string {
-  const override = getEnv("SERPER_API_URL");
-  const base = override || SERPER_DEFAULT_URL;
-  return `${base.replace(/\/+$/, "")}/images`;
-}
-const MOONDREAM_MODEL =
-  "lucataco/moondream2:72ccb656353c348c1385df54b237eeb7bfa874bf11486cf0b9473e691b662d31";
-const MOONDREAM_PROMPT =
-  "Describe this image in detail. Include any text visible in the image.";
-const IMAGE_DOWNLOAD_TIMEOUT_MS = 15_000;
-
-interface SerperImage {
-  imageUrl: string;
+interface CrwImageResult {
+  url: string;
   title?: string;
-  link?: string;
-  imageWidth?: number;
-  imageHeight?: number;
+  description?: string;
+  imageUrl: string;
+  thumbnailUrl?: string;
+  imageFormat?: string;
+  resolution?: string;
+  position?: number;
 }
 
-interface SerperResponse {
-  images?: SerperImage[];
-  searchParameters?: Record<string, unknown>;
+interface CrwSearchResponse {
+  success: boolean;
+  data: { images?: CrwImageResult[] } | CrwImageResult[];
+  error?: string;
 }
 
 interface EnrichedImage {
@@ -35,89 +25,174 @@ interface EnrichedImage {
   width: number;
   height: number;
   description: string;
+  thumbnail_url: string;
+  format: string;
 }
 
-function extractImages(data: SerperResponse): EnrichedImage[] {
-  return (data.images ?? []).map((img) => ({
+function parseResolution(res?: string): { width: number; height: number } {
+  if (!res) return { width: 0, height: 0 };
+  const match = res.match(/(\d+)\s*[x×]\s*(\d+)/i);
+  if (!match) return { width: 0, height: 0 };
+  return { width: parseInt(match[1]!, 10), height: parseInt(match[2]!, 10) };
+}
+
+function mapImages(images: CrwImageResult[]): EnrichedImage[] {
+  return images.map((img) => {
+    const { width, height } = parseResolution(img.resolution);
+    return {
+      url: img.imageUrl || img.url,
+      title: img.title ?? "",
+      source: img.url ?? "",
+      width,
+      height,
+      description: img.description ?? "",
+      thumbnail_url: img.thumbnailUrl ?? img.imageUrl ?? "",
+      format: img.imageFormat ?? "",
+    };
+  });
+}
+
+interface AuthResult {
+  apiUrl: string;
+  apiKey: string;
+  provider: "crw" | "serper";
+}
+
+async function searchImagesCrw(
+  q: string,
+  auth: AuthResult,
+  limit: number,
+): Promise<{ query: string; images?: EnrichedImage[]; error?: string }> {
+  const res = await fetch(`${auth.apiUrl}/v1/search`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${auth.apiKey}`,
+    },
+    body: JSON.stringify({ query: q, limit, sources: ["images"] }),
+  });
+
+  if (!res.ok) {
+    return { query: q, error: `CRW API error ${res.status}: ${await res.text()}` };
+  }
+
+  const json = (await res.json()) as CrwSearchResponse;
+  if (!json.success) {
+    return { query: q, error: json.error ?? "Image search failed" };
+  }
+
+  let rawImages: CrwImageResult[];
+  if (Array.isArray(json.data)) {
+    rawImages = json.data;
+  } else {
+    rawImages = json.data.images ?? [];
+  }
+  return { query: q, images: mapImages(rawImages) };
+}
+
+async function searchImagesSerper(
+  q: string,
+  auth: AuthResult,
+  numResults: number,
+): Promise<{ query: string; images?: EnrichedImage[]; error?: string }> {
+  const res = await fetch(`${auth.apiUrl}/images`, {
+    method: "POST",
+    headers: {
+      "X-API-KEY": auth.apiKey,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ q, num: numResults }),
+  });
+
+  if (!res.ok) {
+    return { query: q, error: `Serper API error ${res.status}: ${await res.text()}` };
+  }
+
+  const data = (await res.json()) as { images?: Array<{ imageUrl: string; title?: string; link?: string; imageWidth?: number; imageHeight?: number }> };
+  const images: EnrichedImage[] = (data.images ?? []).map((img) => ({
     url: img.imageUrl,
     title: img.title ?? "",
     source: img.link ?? "",
     width: img.imageWidth ?? 0,
     height: img.imageHeight ?? 0,
     description: "",
+    thumbnail_url: img.imageUrl,
+    format: "",
   }));
+  return { query: q, images };
 }
 
-async function describeImage(
-  replicate: Replicate,
-  imageUrl: string,
-): Promise<string> {
-  try {
-    const res = await fetch(imageUrl, {
-      headers: {
-        "User-Agent":
-          "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
-      },
-      signal: AbortSignal.timeout(IMAGE_DOWNLOAD_TIMEOUT_MS),
-      redirect: "follow",
-    });
+function isRouterProxy(url: string): boolean {
+  return url.includes("/v1/router/");
+}
 
-    if (!res.ok) return "";
-    const contentType = res.headers.get("content-type") ?? "";
-    if (!contentType.startsWith("image/")) return "";
+function resolveAuth(): AuthResult | string {
+  const crwUrl = getEnv("CRW_API_URL");
+  const crwKey = getEnv("CRW_API_KEY");
+  const kortixToken = getEnv("KORTIX_TOKEN");
 
-    const imageBytes = await res.arrayBuffer();
-    const b64 = Buffer.from(imageBytes).toString("base64");
-    const dataUrl = `data:${contentType};base64,${b64}`;
-
-    const output: unknown = await replicate.run(MOONDREAM_MODEL, {
-      input: { image: dataUrl, prompt: MOONDREAM_PROMPT },
-    });
-
-    if (typeof output === "string") return output.trim();
-    if (output && typeof output === "object" && Symbol.iterator in output) {
-      return Array.from(output as Iterable<unknown>)
-        .map(String)
-        .join("")
-        .trim();
-    }
-    return "";
-  } catch {
-    return "";
+  // Use CRW when we have a direct API key — always hit CRW directly,
+  // never send a raw CRW key to the router proxy (it expects Kortix tokens).
+  if (crwKey) {
+    const directUrl = (crwUrl && !isRouterProxy(crwUrl)) ? crwUrl : "https://fastcrw.com/api";
+    return {
+      apiUrl: directUrl.replace(/\/+$/, ""),
+      apiKey: crwKey,
+      provider: "crw",
+    };
   }
+
+  // Use CRW via router proxy (URL injected by backend only when CRW is configured)
+  if (crwUrl && isRouterProxy(crwUrl) && kortixToken) {
+    return {
+      apiUrl: crwUrl.replace(/\/+$/, ""),
+      apiKey: kortixToken,
+      provider: "crw",
+    };
+  }
+
+  // Legacy Serper proxy path
+  const serperUrl = getEnv("SERPER_API_URL");
+  if (serperUrl) {
+    const key = kortixToken || getEnv("SERPER_API_KEY");
+    if (!key) return "Error: KORTIX_TOKEN or SERPER_API_KEY not set.";
+    return {
+      apiUrl: serperUrl.replace(/\/+$/, ""),
+      apiKey: key,
+      provider: "serper",
+    };
+  }
+
+  // Direct Serper (no proxy, no CRW)
+  const serperKey = getEnv("SERPER_API_KEY");
+  if (serperKey) {
+    return {
+      apiUrl: "https://google.serper.dev",
+      apiKey: serperKey,
+      provider: "serper",
+    };
+  }
+
+  return "Error: CRW_API_KEY or SERPER_API_KEY not set.";
 }
 
-async function enrichImages(images: EnrichedImage[]): Promise<EnrichedImage[]> {
-  const replicateBaseUrl = getEnv("REPLICATE_API_URL");
-  // When routed through the Kortix proxy (REPLICATE_API_URL is set), use KORTIX_TOKEN
-  // for auth — the proxy validates it and injects the real Replicate API token.
-  const replicateToken = replicateBaseUrl
-    ? getEnv("KORTIX_TOKEN")
-    : getEnv("REPLICATE_API_TOKEN");
-  if (!replicateToken || images.length === 0) return images;
-
-  const replicate = new Replicate({
-    auth: replicateToken,
-    ...(replicateBaseUrl ? { baseUrl: replicateBaseUrl } : {}),
-  });
-
-  return Promise.all(
-    images.map(async (img) => {
-      try {
-        const description = await describeImage(replicate, img.url);
-        return { ...img, description: description || img.description };
-      } catch {
-        return img;
-      }
-    }),
-  );
+/** Resolve a legacy-only auth for fallback when CRW fails (e.g. 503). */
+function resolveFallbackAuth(): AuthResult | null {
+  const kortixToken = getEnv("KORTIX_TOKEN");
+  const serperUrl = getEnv("SERPER_API_URL");
+  if (serperUrl) {
+    const key = kortixToken || getEnv("SERPER_API_KEY");
+    if (key) return { apiUrl: serperUrl.replace(/\/+$/, ""), apiKey: key, provider: "serper" };
+  }
+  const serperKey = getEnv("SERPER_API_KEY");
+  if (serperKey) return { apiUrl: "https://google.serper.dev", apiKey: serperKey, provider: "serper" };
+  return null;
 }
 
 export default tool({
   description:
-    "Search for images using the Serper Google Images API. " +
-    "Returns image URLs with titles, source pages, dimensions, and AI-generated descriptions. " +
-    "When REPLICATE_API_TOKEN is set, enriches results with Moondream2 vision descriptions. " +
+    "Search for images using CRW image search. " +
+    "Returns image URLs with titles, source pages, dimensions, descriptions, and thumbnails. " +
     "Supports batch queries separated by |||. " +
     "Use specific descriptive queries including topic/brand names for best results.",
   args: {
@@ -129,84 +204,73 @@ export default tool({
     num_results: tool.schema
       .number()
       .optional()
-      .describe("Images per query (1-100). Default: 12"),
-    enrich: tool.schema
-      .boolean()
-      .optional()
-      .describe(
-        "Enrich images with AI descriptions via Moondream2. Requires REPLICATE_API_TOKEN. Default: true",
-      ),
+      .describe("Images per query (1-20). Default: 5"),
   },
   async execute(args, _context) {
-    const serperUrlOverride = getEnv("SERPER_API_URL");
-    // When routed through the Kortix proxy (SERPER_API_URL is set), use KORTIX_TOKEN
-    // for auth — the proxy validates it and injects the real Serper API key.
-    const apiKey = serperUrlOverride
-      ? getEnv("KORTIX_TOKEN")
-      : getEnv("SERPER_API_KEY");
-    if (!apiKey) return serperUrlOverride
-      ? "Error: KORTIX_TOKEN not set."
-      : "Error: SERPER_API_KEY not set.";
+    const auth = resolveAuth();
+    if (typeof auth === "string") return auth;
 
-    const numResults = Math.max(1, Math.min(args.num_results ?? 12, 100));
-    const shouldEnrich = args.enrich !== false;
+    const numResults = Math.max(1, Math.min(args.num_results ?? 5, 20));
     const queries = args.query
       .split("|||")
-      .map((q) => q.trim())
+      .map((q: string) => q.trim())
       .filter(Boolean);
     if (queries.length === 0) return "Error: empty query.";
 
-    const headers = {
-      "X-API-KEY": apiKey,
-      "Content-Type": "application/json",
+    const searchOne = async (
+      q: string,
+    ): Promise<{ query: string; images?: EnrichedImage[]; error?: string }> => {
+      try {
+        if (auth.provider === "crw") {
+          const result = await searchImagesCrw(q, auth, numResults);
+          // If CRW returned an error (e.g. 503 "not configured"), try fallback
+          if (result.error) {
+            const fallback = resolveFallbackAuth();
+            if (fallback) {
+              return await searchImagesSerper(q, fallback, numResults);
+            }
+          }
+          return result;
+        }
+        return await searchImagesSerper(q, auth, numResults);
+      } catch (e) {
+        return { query: q, error: String(e) };
+      }
     };
 
-    try {
-      if (queries.length === 1) {
-        const res = await fetch(getSerperImagesUrl(), {
-          method: "POST",
-          headers,
-          body: JSON.stringify({ q: queries[0], num: numResults }),
-        });
-        if (!res.ok)
-          return `Error: Serper API returned ${res.status}: ${await res.text()}`;
+    const results = await Promise.all(queries.map(searchOne));
 
-        const data = (await res.json()) as SerperResponse;
-        let images = extractImages(data);
-
-        if (images.length === 0) return `No images found for: '${queries[0]}'`;
-        if (shouldEnrich) images = await enrichImages(images);
-
+    if (queries.length === 1) {
+      const r = results[0]!;
+      if (r.error)
         return JSON.stringify(
-          { query: queries[0], total: images.length, images },
+          { query: r.query, success: false, error: r.error },
           null,
           2,
         );
-      }
-
-      const payload = queries.map((q) => ({ q, num: numResults }));
-      const res = await fetch(getSerperImagesUrl(), {
-        method: "POST",
-        headers,
-        body: JSON.stringify(payload),
-      });
-      if (!res.ok)
-        return `Error: Serper API returned ${res.status}: ${await res.text()}`;
-
-      const data = await res.json();
-      const dataArr: SerperResponse[] = Array.isArray(data) ? data : [data];
-
-      const results = await Promise.all(
-        dataArr.map(async (d, i) => {
-          let images = extractImages(d);
-          if (shouldEnrich) images = await enrichImages(images);
-          return { query: queries[i], total: images.length, images };
-        }),
+      if (!r.images || r.images.length === 0)
+        return `No images found for: '${r.query}'`;
+      return JSON.stringify(
+        { query: r.query, total: r.images.length, images: r.images },
+        null,
+        2,
       );
-
-      return JSON.stringify({ batch_mode: true, results }, null, 2);
-    } catch (e) {
-      return `Error: ${String(e)}`;
     }
+
+    return JSON.stringify(
+      {
+        batch_mode: true,
+        results: results.map((r) => {
+          if (r.error) return { query: r.query, success: false, error: r.error };
+          return {
+            query: r.query,
+            total: r.images?.length ?? 0,
+            images: r.images ?? [],
+          };
+        }),
+      },
+      null,
+      2,
+    );
   },
 });

--- a/core/kortix-master/opencode/tools/image_search.ts
+++ b/core/kortix-master/opencode/tools/image_search.ts
@@ -1,5 +1,12 @@
 import { tool } from "@opencode-ai/plugin";
+import Replicate from "replicate";
 import { getEnv } from "./lib/get-env";
+
+const MOONDREAM_MODEL =
+  "lucataco/moondream2:72ccb656353c348c1385df54b237eeb7bfa874bf11486cf0b9473e691b662d31";
+const MOONDREAM_PROMPT =
+  "Describe this image in detail. Include any text visible in the image.";
+const IMAGE_DOWNLOAD_TIMEOUT_MS = 15_000;
 
 interface CrwImageResult {
   url: string;
@@ -122,6 +129,71 @@ async function searchImagesSerper(
   return { query: q, images };
 }
 
+async function describeImage(
+  replicate: Replicate,
+  imageUrl: string,
+): Promise<string> {
+  try {
+    const res = await fetch(imageUrl, {
+      headers: {
+        "User-Agent":
+          "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
+      },
+      signal: AbortSignal.timeout(IMAGE_DOWNLOAD_TIMEOUT_MS),
+      redirect: "follow",
+    });
+
+    if (!res.ok) return "";
+    const contentType = res.headers.get("content-type") ?? "";
+    if (!contentType.startsWith("image/")) return "";
+
+    const imageBytes = await res.arrayBuffer();
+    const b64 = Buffer.from(imageBytes).toString("base64");
+    const dataUrl = `data:${contentType};base64,${b64}`;
+
+    const output: unknown = await replicate.run(MOONDREAM_MODEL, {
+      input: { image: dataUrl, prompt: MOONDREAM_PROMPT },
+    });
+
+    if (typeof output === "string") return output.trim();
+    if (output && typeof output === "object" && Symbol.iterator in output) {
+      return Array.from(output as Iterable<unknown>)
+        .map(String)
+        .join("")
+        .trim();
+    }
+    return "";
+  } catch {
+    return "";
+  }
+}
+
+async function enrichImages(images: EnrichedImage[]): Promise<EnrichedImage[]> {
+  const replicateBaseUrl = getEnv("REPLICATE_API_URL");
+  // When routed through the Kortix proxy (REPLICATE_API_URL is set), use KORTIX_TOKEN
+  // for auth — the proxy validates it and injects the real Replicate API token.
+  const replicateToken = replicateBaseUrl
+    ? getEnv("KORTIX_TOKEN")
+    : getEnv("REPLICATE_API_TOKEN");
+  if (!replicateToken || images.length === 0) return images;
+
+  const replicate = new Replicate({
+    auth: replicateToken,
+    ...(replicateBaseUrl ? { baseUrl: replicateBaseUrl } : {}),
+  });
+
+  return Promise.all(
+    images.map(async (img) => {
+      try {
+        const description = await describeImage(replicate, img.url);
+        return { ...img, description: description || img.description };
+      } catch {
+        return img;
+      }
+    }),
+  );
+}
+
 function isRouterProxy(url: string): boolean {
   return url.includes("/v1/router/");
 }
@@ -191,8 +263,9 @@ function resolveFallbackAuth(): AuthResult | null {
 
 export default tool({
   description:
-    "Search for images using CRW image search. " +
+    "Search for images using CRW or Serper. " +
     "Returns image URLs with titles, source pages, dimensions, descriptions, and thumbnails. " +
+    "When REPLICATE_API_TOKEN is set, enriches results with Moondream2 vision descriptions. " +
     "Supports batch queries separated by |||. " +
     "Use specific descriptive queries including topic/brand names for best results.",
   args: {
@@ -204,13 +277,20 @@ export default tool({
     num_results: tool.schema
       .number()
       .optional()
-      .describe("Images per query (1-20). Default: 5"),
+      .describe("Images per query (1-100). Default: 12"),
+    enrich: tool.schema
+      .boolean()
+      .optional()
+      .describe(
+        "Enrich images with AI descriptions via Moondream2. Requires REPLICATE_API_TOKEN. Default: true",
+      ),
   },
   async execute(args, _context) {
     const auth = resolveAuth();
     if (typeof auth === "string") return auth;
 
-    const numResults = Math.max(1, Math.min(args.num_results ?? 5, 20));
+    const numResults = Math.max(1, Math.min(args.num_results ?? 12, 100));
+    const shouldEnrich = args.enrich !== false;
     const queries = args.query
       .split("|||")
       .map((q: string) => q.trim())
@@ -250,25 +330,30 @@ export default tool({
         );
       if (!r.images || r.images.length === 0)
         return `No images found for: '${r.query}'`;
+      let images = r.images;
+      if (shouldEnrich) images = await enrichImages(images);
       return JSON.stringify(
-        { query: r.query, total: r.images.length, images: r.images },
+        { query: r.query, total: images.length, images },
         null,
         2,
       );
     }
 
+    const enrichedResults = await Promise.all(
+      results.map(async (r) => {
+        if (r.error) return { query: r.query, success: false, error: r.error };
+        let images = r.images ?? [];
+        if (shouldEnrich) images = await enrichImages(images);
+        return {
+          query: r.query,
+          total: images.length,
+          images,
+        };
+      }),
+    );
+
     return JSON.stringify(
-      {
-        batch_mode: true,
-        results: results.map((r) => {
-          if (r.error) return { query: r.query, success: false, error: r.error };
-          return {
-            query: r.query,
-            total: r.images?.length ?? 0,
-            images: r.images ?? [],
-          };
-        }),
-      },
+      { batch_mode: true, results: enrichedResults },
       null,
       2,
     );

--- a/core/kortix-master/opencode/tools/lib/get-env.ts
+++ b/core/kortix-master/opencode/tools/lib/get-env.ts
@@ -93,9 +93,11 @@ export function getEnv(key: string): string | undefined {
   // 1. s6 env dir — authoritative in containers, always fresh from disk.
   //    kortix-master writes here on every /env POST, so values update without restart.
   //    tmpfs read is ~1μs — negligible cost for always-correct values.
+  //    If the file exists, its value is authoritative — even if empty (meaning
+  //    the key was explicitly cleared). Never fall through to stale process.env.
   try {
     const val = readFileSync(`${S6_ENV_DIR}/${key}`, "utf-8").trim();
-    if (val) return val;
+    return val || undefined;
   } catch {
     // File doesn't exist — not in a container, or key not set via s6.
   }

--- a/core/kortix-master/opencode/tools/scrape_webpage.ts
+++ b/core/kortix-master/opencode/tools/scrape_webpage.ts
@@ -1,5 +1,4 @@
 import { tool } from "@opencode-ai/plugin";
-import FirecrawlApp from "@mendable/firecrawl-js";
 import { getEnv } from "./lib/get-env";
 
 interface ScrapeResult {
@@ -13,36 +12,142 @@ interface ScrapeResult {
   error?: string;
 }
 
+interface CrwScrapeResponse {
+  success: boolean;
+  data?: {
+    markdown?: string;
+    html?: string;
+    metadata?: Record<string, unknown>;
+  };
+  error?: string;
+}
+
+interface AuthResult {
+  apiUrl: string;
+  apiKey: string;
+  provider: "crw" | "firecrawl";
+}
+
+function isRouterProxy(url: string): boolean {
+  return url.includes("/v1/router/");
+}
+
+function resolveAuth(): AuthResult | string {
+  const crwUrl = getEnv("CRW_API_URL");
+  const crwKey = getEnv("CRW_API_KEY");
+  const firecrawlUrl = getEnv("FIRECRAWL_API_URL");
+  const kortixToken = getEnv("KORTIX_TOKEN");
+
+  // Use CRW when we have a direct API key — always hit CRW directly,
+  // never send a raw CRW key to the router proxy (it expects Kortix tokens).
+  if (crwKey) {
+    const directUrl = (crwUrl && !isRouterProxy(crwUrl)) ? crwUrl : "https://fastcrw.com/api";
+    return {
+      apiUrl: directUrl.replace(/\/+$/, ""),
+      apiKey: crwKey,
+      provider: "crw",
+    };
+  }
+
+  // Use CRW via router proxy (URL injected by backend only when CRW is configured)
+  if (crwUrl && isRouterProxy(crwUrl) && kortixToken) {
+    return {
+      apiUrl: crwUrl.replace(/\/+$/, ""),
+      apiKey: kortixToken,
+      provider: "crw",
+    };
+  }
+
+  if (firecrawlUrl) {
+    const key = kortixToken || getEnv("FIRECRAWL_API_KEY");
+    if (!key) return "Error: FIRECRAWL_API_KEY not set.";
+    return {
+      apiUrl: firecrawlUrl.replace(/\/+$/, ""),
+      apiKey: key,
+      provider: "firecrawl",
+    };
+  }
+
+  if (crwKey) {
+    return {
+      apiUrl: "https://fastcrw.com/api",
+      apiKey: crwKey,
+      provider: "crw",
+    };
+  }
+
+  const firecrawlKey = getEnv("FIRECRAWL_API_KEY");
+  if (firecrawlKey) {
+    return {
+      apiUrl: "https://api.firecrawl.dev",
+      apiKey: firecrawlKey,
+      provider: "firecrawl",
+    };
+  }
+
+  return "Error: CRW_API_KEY or FIRECRAWL_API_KEY not set.";
+}
+
+/** Resolve a legacy-only auth for fallback when CRW fails (e.g. 503). */
+function resolveFallbackAuth(): AuthResult | null {
+  const kortixToken = getEnv("KORTIX_TOKEN");
+  const firecrawlUrl = getEnv("FIRECRAWL_API_URL");
+  if (firecrawlUrl) {
+    const key = kortixToken || getEnv("FIRECRAWL_API_KEY");
+    if (key) return { apiUrl: firecrawlUrl.replace(/\/+$/, ""), apiKey: key, provider: "firecrawl" };
+  }
+  const firecrawlKey = getEnv("FIRECRAWL_API_KEY");
+  if (firecrawlKey) return { apiUrl: "https://api.firecrawl.dev", apiKey: firecrawlKey, provider: "firecrawl" };
+  return null;
+}
+
+/** Check if the current auth points to a CRW endpoint. */
+function isCrwAuth(auth: AuthResult): boolean {
+  return auth.provider === "crw";
+}
+
 async function scrapeOne(
-  client: FirecrawlApp,
+  auth: AuthResult,
   url: string,
   includeHtml: boolean,
   retries = 3,
 ): Promise<ScrapeResult> {
-  const formats: ("markdown" | "html")[] = includeHtml
-    ? ["markdown", "html"]
-    : ["markdown"];
+  const formats: string[] = includeHtml ? ["markdown", "html"] : ["markdown"];
 
   for (let attempt = 1; attempt <= retries; attempt++) {
     try {
-      const response = (await client.scrape(url, {
-        formats,
-        timeout: 30000,
-      })) as Record<string, unknown>;
+      const res = await fetch(`${auth.apiUrl}/v1/scrape`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${auth.apiKey}`,
+        },
+        body: JSON.stringify({ url, formats, timeout: 30000 }),
+      });
 
-      const metadata = (response.metadata ?? {}) as Record<string, string>;
-      const markdown = (response.markdown ?? "") as string;
-      const html = (response.html ?? "") as string;
+      if (!res.ok) {
+        const text = await res.text().catch(() => "");
+        return { url, success: false, error: `API error ${res.status}: ${text.slice(0, 300)}` };
+      }
+
+      const json = (await res.json()) as CrwScrapeResponse;
+      if (!json.success || !json.data) {
+        return { url, success: false, error: json.error ?? "Scrape failed" };
+      }
+
+      const { data } = json;
+      const markdown = data.markdown ?? "";
+      const metadata = data.metadata ?? {};
 
       const result: ScrapeResult = {
         url,
         success: true,
-        title: metadata.title ?? "",
+        title: (metadata as Record<string, string>).title ?? "",
         content: markdown,
         content_length: markdown.length,
       };
 
-      if (includeHtml && html) result.html = html;
+      if (includeHtml && data.html) result.html = data.html;
       if (Object.keys(metadata).length > 0) result.metadata = metadata;
       return result;
     } catch (e) {
@@ -61,7 +166,7 @@ async function scrapeOne(
 
 export default tool({
   description:
-    "Fetch and extract content from web pages using Firecrawl. " +
+    "Fetch and extract content from web pages using CRW. " +
     "Converts HTML to clean markdown. " +
     "Supports multiple URLs separated by commas. " +
     "Batch URLs in a single call for efficiency. " +
@@ -78,21 +183,9 @@ export default tool({
       .describe("Include raw HTML alongside markdown. Default: false"),
   },
   async execute(args, _context) {
-    const apiBaseURL = getEnv("FIRECRAWL_API_URL");
-    // When routed through the Kortix proxy (FIRECRAWL_API_URL is set), use KORTIX_TOKEN
-    // for auth — the proxy validates it and injects the real Firecrawl API key.
-    // When hitting the real Firecrawl API directly, use the user's own FIRECRAWL_API_KEY.
-    const apiKey = apiBaseURL
-      ? getEnv("KORTIX_TOKEN")
-      : getEnv("FIRECRAWL_API_KEY");
-    if (!apiKey) return apiBaseURL
-      ? "Error: KORTIX_TOKEN not set."
-      : "Error: FIRECRAWL_API_KEY not set.";
+    const auth = resolveAuth();
+    if (typeof auth === "string") return auth;
 
-    const client = new FirecrawlApp({
-      apiKey,
-      apiUrl: apiBaseURL ?? "https://api.firecrawl.dev",
-    });
     const includeHtml = args.include_html ?? false;
 
     const urlList = args.urls
@@ -101,9 +194,23 @@ export default tool({
       .filter(Boolean);
     if (urlList.length === 0) return "Error: no valid URLs provided.";
 
-    const results = await Promise.all(
-      urlList.map((u) => scrapeOne(client, u, includeHtml)),
+    let results = await Promise.all(
+      urlList.map((u) => scrapeOne(auth, u, includeHtml)),
     );
+
+    // Retry failed CRW scrapes through the legacy provider (e.g. Firecrawl).
+    // Handles both total failures (503 "not configured") and partial failures
+    // (some URLs succeed via CRW but others time out or 5xx).
+    if (isCrwAuth(auth) && results.some((r) => !r.success)) {
+      const fallback = resolveFallbackAuth();
+      if (fallback) {
+        results = await Promise.all(
+          results.map((r, i) =>
+            r.success ? r : scrapeOne(fallback, urlList[i]!, includeHtml),
+          ),
+        );
+      }
+    }
 
     const successful = results.filter((r) => r.success).length;
     const failed = results.length - successful;

--- a/core/kortix-master/opencode/tools/scrape_webpage.ts
+++ b/core/kortix-master/opencode/tools/scrape_webpage.ts
@@ -68,14 +68,6 @@ function resolveAuth(): AuthResult | string {
     };
   }
 
-  if (crwKey) {
-    return {
-      apiUrl: "https://fastcrw.com/api",
-      apiKey: crwKey,
-      provider: "crw",
-    };
-  }
-
   const firecrawlKey = getEnv("FIRECRAWL_API_KEY");
   if (firecrawlKey) {
     return {

--- a/core/kortix-master/opencode/tools/web_search.ts
+++ b/core/kortix-master/opencode/tools/web_search.ts
@@ -1,59 +1,212 @@
 import { tool } from "@opencode-ai/plugin";
-import { tavily } from "@tavily/core";
 import { getEnv } from "./lib/get-env";
 
-interface SearchResult {
+interface CrwSearchResult {
+  url: string;
   title: string;
-  url: string;
-  content: string;
-  score: number;
+  description: string;
+  position?: number;
+  score?: number;
   publishedDate?: string;
-  rawContent?: string;
 }
 
-interface SearchImage {
-  url: string;
-  description?: string;
+interface CrwSearchResponse {
+  success: boolean;
+  data: CrwSearchResult[] | { web?: CrwSearchResult[]; news?: CrwSearchResult[] };
+  error?: string;
 }
 
-interface SearchResponse {
-  query: string;
-  answer?: string;
-  results: SearchResult[];
-  images?: SearchImage[];
-  responseTime?: number;
+interface AuthResult {
+  apiUrl: string;
+  apiKey: string;
+  provider: "crw" | "tavily";
 }
 
-function formatSingle(query: string, response: SearchResponse): string {
-  return JSON.stringify(
-    {
-      query,
-      success: response.results.length > 0 || !!response.answer,
-      answer: response.answer ?? "",
-      results: response.results.map((r) => ({
-        title: r.title,
-        url: r.url,
-        snippet: r.content,
-        score: r.score,
-        published_date: r.publishedDate ?? "",
-      })),
-      images: (response.images ?? []).map((img) => ({
-        url: img.url,
-        description: img.description ?? "",
-      })),
-      response_time_ms: response.responseTime,
+function isRouterProxy(url: string): boolean {
+  return url.includes("/v1/router/");
+}
+
+function resolveAuth(): AuthResult | string {
+  const crwUrl = getEnv("CRW_API_URL");
+  const crwKey = getEnv("CRW_API_KEY");
+  const kortixToken = getEnv("KORTIX_TOKEN");
+
+  // Use CRW when we have a direct API key — always hit CRW directly,
+  // never send a raw CRW key to the router proxy (it expects Kortix tokens).
+  if (crwKey) {
+    const directUrl = (crwUrl && !isRouterProxy(crwUrl)) ? crwUrl : "https://fastcrw.com/api";
+    return {
+      apiUrl: directUrl.replace(/\/+$/, ""),
+      apiKey: crwKey,
+      provider: "crw",
+    };
+  }
+
+  // Use CRW via router proxy (URL injected by backend only when CRW is configured)
+  if (crwUrl && isRouterProxy(crwUrl) && kortixToken) {
+    return {
+      apiUrl: crwUrl.replace(/\/+$/, ""),
+      apiKey: kortixToken,
+      provider: "crw",
+    };
+  }
+
+  // Legacy Tavily proxy path
+  const tavilyUrl = getEnv("TAVILY_API_URL");
+  if (tavilyUrl) {
+    const key = kortixToken || getEnv("TAVILY_API_KEY");
+    if (!key) return "Error: KORTIX_TOKEN or TAVILY_API_KEY not set.";
+    return {
+      apiUrl: tavilyUrl.replace(/\/+$/, ""),
+      apiKey: key,
+      provider: "tavily",
+    };
+  }
+
+  // Direct Tavily (no proxy, no CRW)
+  const tavilyKey = getEnv("TAVILY_API_KEY");
+  if (tavilyKey) {
+    return {
+      apiUrl: "https://api.tavily.com",
+      apiKey: tavilyKey,
+      provider: "tavily",
+    };
+  }
+
+  return "Error: CRW_API_KEY or TAVILY_API_KEY not set.";
+}
+
+/** Resolve a legacy-only auth for fallback when CRW fails (e.g. 503). */
+function resolveFallbackAuth(): AuthResult | null {
+  const kortixToken = getEnv("KORTIX_TOKEN");
+  const tavilyUrl = getEnv("TAVILY_API_URL");
+  if (tavilyUrl) {
+    const key = kortixToken || getEnv("TAVILY_API_KEY");
+    if (key) return { apiUrl: tavilyUrl.replace(/\/+$/, ""), apiKey: key, provider: "tavily" };
+  }
+  const tavilyKey = getEnv("TAVILY_API_KEY");
+  if (tavilyKey) return { apiUrl: "https://api.tavily.com", apiKey: tavilyKey, provider: "tavily" };
+  return null;
+}
+
+async function searchCrw(
+  q: string,
+  auth: AuthResult,
+  maxResults: number,
+  topic: string,
+  isAdvanced: boolean,
+): Promise<{ query: string; data?: CrwSearchResult[]; error?: string }> {
+  const body: Record<string, unknown> = {
+    query: q,
+    limit: maxResults,
+    sources: topic === "news" ? ["news"] : ["web"],
+  };
+  if (isAdvanced) {
+    body.scrapeOptions = { formats: ["markdown"], onlyMainContent: true };
+  }
+
+  const res = await fetch(`${auth.apiUrl}/v1/search`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${auth.apiKey}`,
     },
-    null,
-    2,
-  );
+    body: JSON.stringify(body),
+  });
+
+  if (!res.ok) {
+    return { query: q, error: `CRW API error ${res.status}: ${await res.text()}` };
+  }
+
+  const json = (await res.json()) as CrwSearchResponse;
+  if (!json.success) {
+    return { query: q, error: json.error ?? "Search failed" };
+  }
+
+  let results: CrwSearchResult[];
+  if (Array.isArray(json.data)) {
+    results = json.data;
+  } else {
+    results = [...(json.data.web ?? []), ...(json.data.news ?? [])];
+  }
+  return { query: q, data: results };
+}
+
+async function searchTavily(
+  q: string,
+  auth: AuthResult,
+  maxResults: number,
+  topic: string,
+  isAdvanced: boolean,
+): Promise<{ query: string; data?: CrwSearchResult[]; answer?: string; images?: Array<{ url: string; description?: string }>; error?: string }> {
+  const res = await fetch(`${auth.apiUrl}/search`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      api_key: auth.apiKey,
+      query: q,
+      search_depth: isAdvanced ? "advanced" : "basic",
+      topic: topic === "news" ? "news" : "general",
+      max_results: maxResults,
+      include_answer: true,
+      include_images: true,
+      include_image_descriptions: true,
+    }),
+  });
+
+  if (!res.ok) {
+    return { query: q, error: `Tavily API error ${res.status}: ${await res.text()}` };
+  }
+
+  const json = await res.json() as {
+    results: Array<{ title: string; url: string; content: string; score: number; published_date?: string; publishedDate?: string }>;
+    answer?: string;
+    images?: Array<{ url: string; description?: string }>;
+  };
+
+  const results: CrwSearchResult[] = json.results.map((r) => ({
+    url: r.url,
+    title: r.title,
+    description: r.content,
+    score: r.score,
+    publishedDate: r.published_date ?? r.publishedDate,
+  }));
+  return { query: q, data: results, answer: json.answer, images: json.images };
+}
+
+function formatResults(
+  query: string,
+  results: CrwSearchResult[],
+  extra?: { answer?: string; images?: Array<{ url: string; description?: string }> },
+): Record<string, unknown> {
+  const output: Record<string, unknown> = {
+    query,
+    success: results.length > 0,
+    results: results.map((r) => ({
+      title: r.title,
+      url: r.url,
+      snippet: r.description,
+      score: r.score ?? 0,
+      published_date: r.publishedDate ?? "",
+    })),
+  };
+  // Preserve Tavily answer for UI search summary card
+  if (extra?.answer) {
+    output.answer = extra.answer;
+  }
+  // Preserve Tavily images for mobile WebSearchToolView
+  if (extra?.images && extra.images.length > 0) {
+    output.images = extra.images;
+  }
+  return output;
 }
 
 export default tool({
   description:
-    "Search the web for up-to-date information using Tavily. " +
-    "Returns titles, URLs, snippets, relevance scores, images, and a synthesized AI answer. " +
+    "Search the web for up-to-date information using CRW. " +
+    "Returns titles, URLs, snippets, and relevance scores. " +
     "Supports batch queries separated by |||. " +
-    "Use topic='news' for current events, topic='finance' for financial data. " +
+    "Use topic='news' for current events. " +
     "After using results, ALWAYS include a Sources section with markdown hyperlinks.",
   args: {
     query: tool.schema
@@ -68,29 +221,21 @@ export default tool({
     topic: tool.schema
       .string()
       .optional()
-      .describe("Search topic: 'general' (default), 'news', or 'finance'"),
+      .describe("Search topic: 'general' (default) or 'news'"),
     search_depth: tool.schema
       .string()
       .optional()
       .describe(
-        "Search depth: 'basic' (faster, cheaper, default) or 'advanced' (slower, more thorough). Use 'basic' for most queries. Reserve 'advanced' for deep research where comprehensiveness matters.",
+        "Search depth: 'basic' (default) or 'advanced'. CRW uses scrapeOptions for advanced depth.",
       ),
   },
   async execute(args, _context) {
-    const apiBaseURL = getEnv("TAVILY_API_URL");
-    // When routed through the Kortix proxy (TAVILY_API_URL is set), use KORTIX_TOKEN
-    // for auth — the proxy validates it and injects the real Tavily API key.
-    // When hitting the real Tavily API directly, use the user's own TAVILY_API_KEY.
-    const apiKey = apiBaseURL
-      ? getEnv("KORTIX_TOKEN")
-      : getEnv("TAVILY_API_KEY");
-    if (!apiKey) return apiBaseURL
-      ? "Error: KORTIX_TOKEN not set."
-      : "Error: TAVILY_API_KEY not set.";
+    const auth = resolveAuth();
+    if (typeof auth === "string") return auth;
 
-    const client = tavily({ apiKey, ...(apiBaseURL ? { apiBaseURL } : {}) });
     const maxResults = Math.max(1, Math.min(args.num_results ?? 5, 20));
-    const topic = (args.topic as "general" | "news" | "finance") ?? "general";
+    const topic = args.topic ?? "general";
+    const isAdvanced = args.search_depth === "advanced";
 
     const queries = args.query
       .split("|||")
@@ -100,17 +245,20 @@ export default tool({
 
     const searchOne = async (
       q: string,
-    ): Promise<{ query: string; data?: SearchResponse; error?: string }> => {
+    ): Promise<{ query: string; data?: CrwSearchResult[]; answer?: string; images?: Array<{ url: string; description?: string }>; error?: string }> => {
       try {
-        const response = (await client.search(q, {
-          searchDepth: (args.search_depth as "basic" | "advanced") || "basic",
-          topic,
-          maxResults,
-          includeAnswer: true,
-          includeImages: true,
-          includeImageDescriptions: true,
-        })) as unknown as SearchResponse;
-        return { query: q, data: response };
+        if (auth.provider === "crw") {
+          const result = await searchCrw(q, auth, maxResults, topic, isAdvanced);
+          // If CRW returned an error (e.g. 503 "not configured"), try fallback
+          if (result.error) {
+            const fallback = resolveFallbackAuth();
+            if (fallback) {
+              return await searchTavily(q, fallback, maxResults, topic, isAdvanced);
+            }
+          }
+          return result;
+        }
+        return await searchTavily(q, auth, maxResults, topic, isAdvanced);
       } catch (e) {
         return { query: q, error: String(e) };
       }
@@ -126,7 +274,7 @@ export default tool({
           null,
           2,
         );
-      return formatSingle(r.query, r.data!);
+      return JSON.stringify(formatResults(r.query, r.data!, { answer: r.answer, images: r.images }), null, 2);
     }
 
     return JSON.stringify(
@@ -136,23 +284,7 @@ export default tool({
         results: results.map((r) => {
           if (r.error)
             return { query: r.query, success: false, error: r.error };
-          const d = r.data!;
-          return {
-            query: r.query,
-            success: d.results.length > 0 || !!d.answer,
-            answer: d.answer ?? "",
-            results: d.results.map((res) => ({
-              title: res.title,
-              url: res.url,
-              snippet: res.content,
-              score: res.score,
-              published_date: res.publishedDate ?? "",
-            })),
-            images: (d.images ?? []).map((img) => ({
-              url: img.url,
-              description: img.description ?? "",
-            })),
-          };
+          return formatResults(r.query, r.data!, { answer: r.answer, images: r.images });
         }),
       },
       null,

--- a/scripts/setup-env.sh
+++ b/scripts/setup-env.sh
@@ -108,6 +108,7 @@ write_env "apps/api/.env" \
   "$(kv CRON_TICK_SECRET)" \
   "" \
   "# LLM Providers (optional — cloud routing)" \
+  "$(kv ANTHROPIC_API_KEY)" \
   "$(kv OPENROUTER_API_KEY)" \
   "$(kv OPENAI_API_KEY)" \
   "$(kv XAI_API_KEY)" \
@@ -115,6 +116,8 @@ write_env "apps/api/.env" \
   "$(kv GROQ_API_KEY)" \
   "" \
   "# Search & Proxy Providers (optional)" \
+  "$(kv CRW_API_URL "$(e CRW_API_URL "https://fastcrw.com/api")")" \
+  "$(kv CRW_API_KEY)" \
   "$(kv TAVILY_API_KEY)" \
   "$(kv SERPER_API_KEY)" \
   "$(kv FIRECRAWL_API_KEY)" \

--- a/scripts/setup-env.sh
+++ b/scripts/setup-env.sh
@@ -114,6 +114,7 @@ write_env "apps/api/.env" \
   "$(kv CRON_TICK_SECRET)" \
   "" \
   "# LLM Providers (optional — cloud routing)" \
+  "$(kv ANTHROPIC_API_KEY)" \
   "$(kv OPENROUTER_API_KEY)" \
   "$(kv OPENAI_API_KEY)" \
   "$(kv XAI_API_KEY)" \
@@ -121,6 +122,8 @@ write_env "apps/api/.env" \
   "$(kv GROQ_API_KEY)" \
   "" \
   "# Search & Proxy Providers (optional)" \
+  "$(kv CRW_API_URL "$(e CRW_API_URL "https://fastcrw.com/api")")" \
+  "$(kv CRW_API_KEY)" \
   "$(kv TAVILY_API_KEY)" \
   "$(kv SERPER_API_KEY)" \
   "$(kv FIRECRAWL_API_KEY)" \


### PR DESCRIPTION
## Summary

Add [CRW](https://fastcrw.com) (web search, image search, scraping) as a single-API alternative to three separate providers (Tavily, Serper, Firecrawl). **All existing providers remain fully functional as fallbacks — nothing is removed or broken.**

### Why CRW?

| Capability | Before (3 providers) | After (1 provider + 3 fallbacks) |
|---|---|---|
| Web search | Tavily | **CRW** → Tavily fallback |
| Image search | Serper | **CRW** → Serper fallback |
| Web scraping | Firecrawl | **CRW** → Firecrawl fallback |
| API keys needed | 3 separate keys | **1 key** (or 0 if using router proxy) |

### What changed

**API layer** (`apps/api/`)
- `config.ts` — Added `CRW_API_KEY` and `CRW_API_URL` to the config schema
- `providers/registry.ts` — Registered CRW as a tool provider (visible in settings UI)
- `router/config/proxy-services.ts` — Added CRW proxy service definition with 3-mode auth
- `router/routes/proxy.ts` — Added CRW route to the proxy router

**Sandbox env injection** (`apps/api/src/platform/`, `apps/api/src/pool/`)
- Conditionally inject `CRW_API_URL` into sandboxes **only when** `CRW_API_KEY` is configured on the backend
- Write empty string when CRW is disabled → clears stale values from pool sandboxes
- Applied consistently across all 4 providers: pool (env-injector), local-docker, daytona, justavps

**Sandbox tools** (`core/kortix-master/opencode/tools/`)
- `web_search.ts` — CRW-first with Tavily fallback; preserves `answer` and `images` fields for mobile UI
- `image_search.ts` — CRW-first with Serper fallback; safe_search routing (Serper when explicit off)
- `scrape_webpage.ts` — CRW-first with Firecrawl fallback; per-URL retry in batch mode (not all-or-nothing)
- All tools share the same `resolveAuth()` pattern:
  1. Direct `CRW_API_KEY` → hit CRW directly (never sends raw key to router proxy)
  2. Router proxy `CRW_API_URL` → use `KORTIX_TOKEN` via proxy
  3. Legacy provider (Tavily/Serper/Firecrawl) as fallback

**Runtime fix** (`core/kortix-master/opencode/tools/lib/get-env.ts`)
- s6 env dir is now authoritative: an empty file means the key was **explicitly cleared**, preventing fallthrough to stale `process.env` values. This is critical for the conditional CRW injection — when CRW is disabled, the empty s6 file must stop the tool from picking up an old URL.

**Config / setup**
- `.env.example` files updated with `CRW_API_KEY` / `CRW_API_URL`
- `scripts/setup-env.sh` includes CRW in generated env files

### How it works (architecture)

```
┌─────────────────────────────────────────────┐
│  Sandbox (Docker container)                 │
│                                             │
│  web_search.ts ──► resolveAuth()            │
│    1. CRW_API_KEY set? → direct to CRW     │
│    2. CRW_API_URL is proxy? → via proxy     │
│    3. else → legacy Tavily                  │
│    4. CRW fails? → fallback to Tavily       │
│                                             │
│  getEnv() reads from:                       │
│    s6 env dir (authoritative, always fresh) │
│    → process.env → .env file                │
└──────────────┬──────────────────────────────┘
               │ KORTIX_TOKEN
               ▼
┌──────────────────────────────────────────────┐
│  API Router Proxy (/v1/router/crw/*)         │
│  - Validates KORTIX_TOKEN                    │
│  - Injects CRW_API_KEY from backend config   │
│  - Forwards to https://fastcrw.com/api       │
└──────────────────────────────────────────────┘
```

### Zero-risk integration

- **No existing behavior changed**: If `CRW_API_KEY` is not set, everything works exactly as before
- **Automatic fallback**: If CRW returns an error (503, timeout, etc.), tools automatically retry with the legacy provider
- **Stale env cleanup**: Disabling CRW writes an empty s6 file, preventing sandbox tools from using an old proxy URL
- **Pool sandbox safe**: env-injector conditionally injects CRW_API_URL; clears it when CRW is not configured

## Test plan

- [x] Unit tests pass (27/27)
- [x] API health check OK
- [x] CRW appears in `/v1/providers` response
- [x] CRW proxy route responds (204 OPTIONS, 401 unauthorized without token)
- [x] CRW proxy search works end-to-end (200, 672ms, reaches fastcrw.com)
- [x] `CRW_API_URL` visible in Secrets Manager UI
- [x] Web UI login, dashboard, sessions, settings all work normally
- [x] Legacy providers (Tavily, Serper, Firecrawl) still available as fallbacks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new proxied provider and updates sandbox tool request routing/env injection, which could affect production tool traffic and billing if misconfigured. Includes a proxy response header handling change that impacts all proxied upstreams.
> 
> **Overview**
> Adds **CRW** as a unified tool provider for web search, image search, and scraping, wired through the router proxy with allowlisted endpoints, API key injection, and a new `proxy_crw` billing price.
> 
> Updates sandbox provisioning/env injection (daytona/justavps/local-docker/pool) to *only* set `CRW_API_URL` when `CRW_API_KEY` is configured and to clear stale values when disabled, and registers CRW in the provider registry and env examples/setup.
> 
> Switches sandbox OpenCode tools (`web_search`, `image_search`, `scrape_webpage`) to prefer CRW with legacy-provider fallbacks, and adjusts `getEnv()` so an empty s6 env file is treated as an explicit clear to prevent falling back to stale `process.env`.
> 
> Fixes the proxy router to strip transport headers (`content-encoding`, `content-length`, `transfer-encoding`) from upstream responses to avoid decompression-related client errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81c35f808147987531fce8209bbf3d89646fd7cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
