### PR TITLE
fix billing sync for legacy Stripe accounts

### DIFF
--- a/apps/api/src/__tests__/unit-resolve-account.test.ts
+++ b/apps/api/src/__tests__/unit-resolve-account.test.ts
@@ -1,0 +1,206 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+const accounts = { __table: 'accounts', accountId: 'accountId' };
+const accountMembers = { __table: 'accountMembers', accountId: 'accountId', userId: 'userId' };
+const accountUser = { __table: 'accountUser', accountId: 'accountId', userId: 'userId' };
+const billingCustomers = { __table: 'billingCustomers', accountId: 'accountId', id: 'id', email: 'email', active: 'active', provider: 'provider' };
+const creditAccounts = { __table: 'creditAccounts', accountId: 'accountId', tier: 'tier', stripeSubscriptionId: 'stripeSubscriptionId' };
+
+const state = {
+  membership: null as { accountId: string } | null,
+  legacyMembership: null as { accountId: string } | null,
+  creditAccount: null as { tier?: string | null; stripeSubscriptionId?: string | null } | null,
+  legacyCustomer: null as { id?: string | null; email?: string | null } | null,
+  customerSearchResults: [] as Array<{ id: string }>,
+  subscriptionResults: {} as Record<string, any[]>,
+};
+
+const insertCalls: Array<{ table: string; data: Record<string, unknown> }> = [];
+const upsertCustomerCalls: Array<Record<string, unknown>> = [];
+const upsertCreditAccountCalls: Array<{ accountId: string; data: Record<string, unknown> }> = [];
+const resetExpiringCreditsCalls: Array<any[]> = [];
+const stripeListCalls: string[] = [];
+
+function rowsForTable(table: { __table: string }) {
+  switch (table.__table) {
+    case 'accountMembers':
+      return state.membership ? [state.membership] : [];
+    case 'accountUser':
+      return state.legacyMembership ? [state.legacyMembership] : [];
+    case 'creditAccounts':
+      return state.creditAccount ? [state.creditAccount] : [];
+    default:
+      return [];
+  }
+}
+
+const fakeDb = {
+  select: () => ({
+    from: (table: { __table: string }) => ({
+      where: () => ({
+        limit: async (count: number) => rowsForTable(table).slice(0, count),
+      }),
+    }),
+  }),
+  insert: (table: { __table: string }) => ({
+    values: (data: Record<string, unknown>) => {
+      insertCalls.push({ table: table.__table, data });
+      return {
+        onConflictDoNothing: async () => undefined,
+      };
+    },
+  }),
+};
+
+mock.module('drizzle-orm', () => ({
+  eq: (column: string, value: unknown) => ({ column, value }),
+}));
+
+mock.module('@kortix/db', () => ({
+  accounts,
+  accountMembers,
+  accountUser,
+  billingCustomers,
+  creditAccounts,
+}));
+
+mock.module('../shared/db', () => ({ db: fakeDb }));
+
+mock.module('../billing/repositories/customers', () => ({
+  getCustomerByAccountId: async () => state.legacyCustomer,
+  upsertCustomer: async (data: Record<string, unknown>) => {
+    upsertCustomerCalls.push(data);
+  },
+}));
+
+mock.module('../billing/repositories/credit-accounts', () => ({
+  upsertCreditAccount: async (accountId: string, data: Record<string, unknown>) => {
+    upsertCreditAccountCalls.push({ accountId, data });
+  },
+}));
+
+mock.module('../billing/services/credits', () => ({
+  resetExpiringCredits: async (...args: any[]) => {
+    resetExpiringCreditsCalls.push(args);
+  },
+}));
+
+mock.module('../billing/services/tiers', () => ({
+  MACHINE_CREDIT_BONUS: 5,
+  getTier: (tierName: string) => ({
+    name: tierName,
+    monthlyCredits: tierName === 'tier_2_20' ? 20 : tierName === 'tier_6_50' ? 50 : 0,
+  }),
+  getTierByPriceId: (priceId: string) => {
+    if (priceId === 'price_paid_yearly') return { name: 'tier_2_20' };
+    if (priceId === 'price_paid_monthly') return { name: 'tier_6_50' };
+    if (priceId === 'price_free') return { name: 'free' };
+    return null;
+  },
+  getBillingPeriodByPriceId: (priceId: string) => {
+    if (priceId === 'price_paid_yearly') return 'yearly';
+    return 'monthly';
+  },
+}));
+
+mock.module('../shared/stripe', () => ({
+  getStripe: () => ({
+    customers: {
+      retrieve: async (id: string) => ({ id, deleted: false }),
+      search: async () => ({ data: state.customerSearchResults }),
+    },
+    subscriptions: {
+      update: async () => null,
+      list: async ({ customer }: { customer: string }) => {
+        stripeListCalls.push(customer);
+        return { data: state.subscriptionResults[customer] ?? [] };
+      },
+    },
+  }),
+}));
+
+const { resolveAccountId } = await import('../shared/resolve-account');
+
+beforeEach(() => {
+  state.membership = null;
+  state.legacyMembership = null;
+  state.creditAccount = null;
+  state.legacyCustomer = null;
+  state.customerSearchResults = [];
+  state.subscriptionResults = {};
+  insertCalls.length = 0;
+  upsertCustomerCalls.length = 0;
+  upsertCreditAccountCalls.length = 0;
+  resetExpiringCreditsCalls.length = 0;
+  stripeListCalls.length = 0;
+});
+
+describe('resolveAccountId legacy billing sync', () => {
+  test('syncs a paid legacy Stripe subscription for an already-migrated membership', async () => {
+    state.membership = { accountId: 'acct_paid_123' };
+    state.legacyCustomer = { id: 'cus_legacy_123', email: 'paid@example.com' };
+    state.subscriptionResults = {
+      cus_legacy_123: [
+        {
+          id: 'sub_paid_123',
+          status: 'active',
+          items: {
+            data: [
+              {
+                price: {
+                  id: 'price_paid_yearly',
+                  recurring: { interval: 'year' },
+                },
+              },
+            ],
+          },
+        },
+      ],
+    };
+
+    const accountId = await resolveAccountId('user_paid_123');
+
+    expect(accountId).toBe('acct_paid_123');
+    expect(stripeListCalls).toEqual(['cus_legacy_123']);
+    expect(upsertCreditAccountCalls).toHaveLength(1);
+    expect(upsertCreditAccountCalls[0]).toEqual({
+      accountId: 'acct_paid_123',
+      data: {
+        billingCycleAnchor: undefined,
+        commitmentEndDate: null,
+        commitmentType: null,
+        tier: 'tier_2_20',
+        provider: 'stripe',
+        stripeSubscriptionId: 'sub_paid_123',
+        stripeSubscriptionStatus: 'active',
+        planType: 'yearly',
+      },
+    });
+    expect(upsertCustomerCalls).toContainEqual({
+      accountId: 'acct_paid_123',
+      id: 'cus_legacy_123',
+      email: 'paid@example.com',
+      active: true,
+      provider: 'stripe',
+    });
+    expect(resetExpiringCreditsCalls).toContainEqual([
+      'acct_paid_123',
+      20,
+      'Recovered legacy Stripe subscription: 20 credits',
+      'legacy_sync:sub_paid_123',
+    ]);
+  });
+
+  test('skips Stripe sync when the account already has a Stripe subscription row', async () => {
+    state.membership = { accountId: 'acct_existing_123' };
+    state.creditAccount = { tier: 'tier_6_50', stripeSubscriptionId: 'sub_existing_123' };
+    state.legacyCustomer = { id: 'cus_existing_123', email: 'existing@example.com' };
+
+    const accountId = await resolveAccountId('user_existing_123');
+
+    expect(accountId).toBe('acct_existing_123');
+    expect(stripeListCalls).toHaveLength(0);
+    expect(upsertCreditAccountCalls).toHaveLength(0);
+    expect(insertCalls).toHaveLength(0);
+  });
+});

--- a/apps/api/src/__tests__/unit-stripe-webhook-canonicalization.test.ts
+++ b/apps/api/src/__tests__/unit-stripe-webhook-canonicalization.test.ts
@@ -1,0 +1,157 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+const state = {
+  getCreditAccountResult: null as any,
+  getCustomerByStripeIdResult: null as any,
+  upsertCreditAccountCalls: [] as Array<{ accountId: string; data: Record<string, unknown> }>,
+  updateCreditAccountCalls: [] as Array<{ accountId: string; data: Record<string, unknown> }>,
+  resetExpiringCreditsCalls: [] as Array<any[]>,
+  stripeUpdateCalls: [] as Array<{ id: string; params: Record<string, unknown> }>,
+};
+
+const mockStripeClient = {
+  webhooks: {
+    constructEvent: (_body: string, _sig: string, _secret: string) => ({ id: 'evt_test', type: 'customer.subscription.updated', data: { object: {} } }),
+  },
+  subscriptions: {
+    retrieve: async () => ({}),
+    update: async (id: string, params: Record<string, unknown>) => {
+      state.stripeUpdateCalls.push({ id, params });
+      return { id, ...params };
+    },
+  },
+};
+
+mock.module('../shared/stripe', () => ({
+  getStripe: () => mockStripeClient,
+}));
+
+mock.module('../config', () => ({
+  config: {
+    STRIPE_WEBHOOK_SECRET: 'whsec_test',
+    REVENUECAT_WEBHOOK_SECRET: 'rc_test',
+    INTERNAL_KORTIX_ENV: 'prod',
+  },
+}));
+
+mock.module('@kortix/shared', () => ({
+  AUTO_TOPUP_DEFAULT_AMOUNT: 20,
+  AUTO_TOPUP_DEFAULT_THRESHOLD: 5,
+}));
+
+mock.module('../billing/repositories/credit-accounts', () => ({
+  getCreditAccount: async () => state.getCreditAccountResult,
+  upsertCreditAccount: async (accountId: string, data: Record<string, unknown>) => {
+    state.upsertCreditAccountCalls.push({ accountId, data });
+  },
+  updateCreditAccount: async (accountId: string, data: Record<string, unknown>) => {
+    state.updateCreditAccountCalls.push({ accountId, data });
+  },
+}));
+
+mock.module('../billing/repositories/customers', () => ({
+  getCustomerByStripeId: async () => state.getCustomerByStripeIdResult,
+  upsertCustomer: async () => null,
+}));
+
+mock.module('../billing/repositories/transactions', () => ({
+  updatePurchaseStatus: async () => null,
+  getPurchaseByPaymentIntent: async () => null,
+}));
+
+mock.module('../billing/services/credits', () => ({
+  grantCredits: async () => null,
+  resetExpiringCredits: async (...args: any[]) => {
+    state.resetExpiringCreditsCalls.push(args);
+  },
+}));
+
+mock.module('../billing/services/machine-bonus', () => ({
+  grantMachineBonusOnce: async () => null,
+  getStripeMachineBonusKey: (subscriptionId: string) => `machine_bonus:${subscriptionId}`,
+}));
+
+mock.module('../billing/services/subscriptions', () => ({
+  cancelFreeSubscriptionForUpgrade: async () => null,
+}));
+
+mock.module('../shared/resolve-account', () => ({
+  resolveAccountId: async (id: string) => id,
+}));
+
+const { processStripeWebhook } = await import('../billing/services/webhooks');
+
+beforeEach(() => {
+  state.getCreditAccountResult = null;
+  state.getCustomerByStripeIdResult = null;
+  state.upsertCreditAccountCalls = [];
+  state.updateCreditAccountCalls = [];
+  state.resetExpiringCreditsCalls = [];
+  state.stripeUpdateCalls = [];
+});
+
+describe('Stripe webhook canonicalization', () => {
+  test('repairs legacy account_id metadata and restores canonical billing state', async () => {
+    const subscription = {
+      id: 'sub_legacy_123',
+      customer: 'cus_legacy_123',
+      status: 'active',
+      cancel_at_period_end: false,
+      billing_cycle_anchor: 1771849066,
+      current_period_end: 1803385066,
+      items: {
+        data: [
+          {
+            id: 'si_legacy_123',
+            price: {
+              id: 'price_1ReHB5G6l1KZGqIrD70I1xqM',
+              unit_amount: 20400,
+              currency: 'usd',
+            },
+          },
+        ],
+      },
+      metadata: {
+        account_id: 'legacy_user_123',
+        commitment_type: 'yearly',
+      },
+    };
+
+    mockStripeClient.webhooks.constructEvent = () => ({
+      id: 'evt_test_canonical',
+      type: 'customer.subscription.updated',
+      data: { object: subscription },
+    });
+
+    state.getCustomerByStripeIdResult = {
+      id: 'cus_legacy_123',
+      accountId: 'acc_canonical_123',
+      email: 'legacy@example.com',
+      provider: 'stripe',
+      active: true,
+    };
+
+    await processStripeWebhook(JSON.stringify({}), 'sig');
+
+    expect(state.upsertCreditAccountCalls).toHaveLength(1);
+    expect(state.upsertCreditAccountCalls[0].accountId).toBe('acc_canonical_123');
+    expect(state.upsertCreditAccountCalls[0].data.tier).toBe('tier_2_20');
+    expect(state.resetExpiringCreditsCalls).toContainEqual([
+      'acc_canonical_123',
+      20,
+      'Recovered Stripe subscription: 20 credits',
+      'legacy_sync:sub_legacy_123',
+    ]);
+    expect(state.stripeUpdateCalls).toHaveLength(1);
+    expect(state.stripeUpdateCalls[0]).toEqual({
+      id: 'sub_legacy_123',
+      params: {
+        metadata: {
+          account_id: 'acc_canonical_123',
+          commitment_type: 'yearly',
+          legacy_account_id: 'legacy_user_123',
+        },
+      },
+    });
+  });
+});

--- a/apps/api/src/billing/services/legacy-stripe-sync.ts
+++ b/apps/api/src/billing/services/legacy-stripe-sync.ts
@@ -1,0 +1,222 @@
+import { eq } from 'drizzle-orm';
+import { creditAccounts } from '@kortix/db';
+import { db } from '../../shared/db';
+
+export type LegacyStripeSyncResult = {
+  status:
+    | 'already_synced'
+    | 'no_customer'
+    | 'no_active_paid_subscription'
+    | 'would_sync'
+    | 'synced'
+    | 'error';
+  accountId: string;
+  customerId?: string | null;
+  customerEmail?: string | null;
+  subscriptionId?: string | null;
+  tier?: string | null;
+  planType?: string | null;
+  commitmentType?: string | null;
+  metadataUpdated?: boolean;
+  message?: string;
+  error?: string;
+};
+
+export async function syncLegacyStripeSubscription(
+  accountId: string,
+  options: { dryRun?: boolean } = {},
+): Promise<LegacyStripeSyncResult> {
+  const dryRun = options.dryRun === true;
+
+  try {
+    const [existing] = await db
+      .select({
+        tier: creditAccounts.tier,
+        provider: creditAccounts.provider,
+        stripeSubscriptionId: creditAccounts.stripeSubscriptionId,
+      })
+      .from(creditAccounts)
+      .where(eq(creditAccounts.accountId, accountId))
+      .limit(1);
+
+    if (existing?.provider && existing.provider !== 'stripe') {
+      return {
+        status: 'already_synced',
+        accountId,
+        subscriptionId: existing?.stripeSubscriptionId ?? null,
+        tier: existing?.tier ?? null,
+        message: `Account is owned by ${existing.provider} billing`,
+      };
+    }
+
+    if (existing?.stripeSubscriptionId) {
+      return {
+        status: 'already_synced',
+        accountId,
+        subscriptionId: existing?.stripeSubscriptionId ?? null,
+        tier: existing?.tier ?? null,
+        message: 'Account already has canonical billing state',
+      };
+    }
+
+    const { getCustomerByAccountId, upsertCustomer } = await import('../repositories/customers');
+    const customer = await getCustomerByAccountId(accountId);
+    const customerId = customer?.id ?? null;
+    const customerEmail = customer?.email ?? null;
+
+    if (!customerId && !customerEmail) {
+      return {
+        status: 'no_customer',
+        accountId,
+        message: 'No Stripe customer mapping found for account',
+      };
+    }
+
+    const { getStripe } = await import('../../shared/stripe');
+    const stripe = getStripe();
+    const { getBillingPeriodByPriceId, getTier, getTierByPriceId } = await import('./tiers');
+    const { upsertCreditAccount } = await import('../repositories/credit-accounts');
+    const { resetExpiringCredits } = await import('./credits');
+
+    const candidateCustomerIds = new Set<string>();
+    if (customerId) candidateCustomerIds.add(customerId);
+
+    if (customerEmail) {
+      const customers = await stripe.customers.search({
+        query: `email:'${customerEmail.replace(/'/g, "\\'")}'`,
+        limit: 10,
+      });
+
+      for (const match of customers.data) {
+        candidateCustomerIds.add(match.id);
+      }
+    }
+
+    for (const candidateCustomerId of candidateCustomerIds) {
+      try {
+        const stripeCustomer = await stripe.customers.retrieve(candidateCustomerId);
+        if ('deleted' in stripeCustomer && stripeCustomer.deleted) {
+          continue;
+        }
+      } catch {
+        continue;
+      }
+
+      const subscriptions = await stripe.subscriptions.list({
+        customer: candidateCustomerId,
+        status: 'active',
+        limit: 10,
+      });
+
+      for (const subscription of subscriptions.data) {
+        const priceId = subscription.items.data[0]?.price?.id;
+        if (!priceId) continue;
+
+        const tierConfig = getTierByPriceId(priceId);
+        if (!tierConfig || tierConfig.name === 'free' || tierConfig.name === 'none') continue;
+
+        const billingPeriod = getBillingPeriodByPriceId(priceId) ?? 'monthly';
+        const planType = billingPeriod === 'yearly_commitment' ? 'yearly' : billingPeriod;
+        const commitmentType = billingPeriod === 'yearly_commitment' ? 'yearly_commitment' : null;
+        const shouldUpdateMetadata =
+          subscription.metadata?.account_id !== accountId ||
+          subscription.metadata?.tier_key !== tierConfig.name ||
+          subscription.metadata?.billing_period !== billingPeriod ||
+          (commitmentType
+            ? subscription.metadata?.commitment_type !== commitmentType
+            : !!subscription.metadata?.commitment_type);
+
+        if (!dryRun && shouldUpdateMetadata) {
+          const metadata: Record<string, string> = {
+            ...subscription.metadata,
+            account_id: accountId,
+            tier_key: tierConfig.name,
+            billing_period: billingPeriod,
+          };
+
+          if (subscription.metadata?.account_id && subscription.metadata.account_id !== accountId) {
+            metadata.legacy_account_id = subscription.metadata.account_id;
+          }
+
+          if (commitmentType) {
+            metadata.commitment_type = commitmentType;
+          } else {
+            delete metadata.commitment_type;
+          }
+
+          await stripe.subscriptions.update(subscription.id, { metadata });
+        }
+
+        const result: LegacyStripeSyncResult = {
+          status: dryRun ? 'would_sync' : 'synced',
+          accountId,
+          customerId: candidateCustomerId,
+          customerEmail,
+          subscriptionId: subscription.id,
+          tier: tierConfig.name,
+          planType,
+          commitmentType,
+          metadataUpdated: shouldUpdateMetadata,
+        };
+
+        if (!dryRun) {
+          const tier = getTier(tierConfig.name);
+
+          await upsertCreditAccount(accountId, {
+            tier: tierConfig.name,
+            provider: 'stripe',
+            stripeSubscriptionId: subscription.id,
+            stripeSubscriptionStatus: subscription.status,
+            billingCycleAnchor: subscription.billing_cycle_anchor
+              ? new Date(subscription.billing_cycle_anchor * 1000).toISOString()
+              : undefined,
+            planType,
+            commitmentType,
+            commitmentEndDate: commitmentType && subscription.current_period_end
+              ? new Date(subscription.current_period_end * 1000).toISOString()
+              : null,
+          });
+
+          if (tier.monthlyCredits > 0) {
+            await resetExpiringCredits(
+              accountId,
+              tier.monthlyCredits,
+              `Recovered legacy Stripe subscription: ${tier.monthlyCredits} credits`,
+              `legacy_sync:${subscription.id}`,
+            );
+          }
+
+          await upsertCustomer({
+            accountId,
+            id: candidateCustomerId,
+            email: customerEmail,
+            active: true,
+            provider: 'stripe',
+          });
+
+          console.log(
+            `[legacy-stripe-sync] Synced Stripe sub ${subscription.id} → tier=${tierConfig.name} for ${accountId} (customer=${candidateCustomerId})`,
+          );
+        }
+
+        return result;
+      }
+    }
+
+    return {
+      status: 'no_active_paid_subscription',
+      accountId,
+      customerId,
+      customerEmail,
+      message: 'No active paid Stripe subscription found for mapped customer(s)',
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      status: 'error',
+      accountId,
+      error: message,
+      message: 'Legacy Stripe sync failed',
+    };
+  }
+}

--- a/apps/api/src/billing/services/subscriptions.ts
+++ b/apps/api/src/billing/services/subscriptions.ts
@@ -625,9 +625,23 @@ export async function releaseSubscriptionSchedule(subscriptionId: string): Promi
 }
 
 export async function syncSubscription(accountId: string) {
-  const account = await getCreditAccount(accountId);
+  let account = await getCreditAccount(accountId);
   if (!account?.stripeSubscriptionId) {
-    return { success: true, message: 'No subscription to sync' };
+    const { syncLegacyStripeSubscription } = await import('./legacy-stripe-sync');
+    const reconciliation = await syncLegacyStripeSubscription(accountId);
+    if (reconciliation.status === 'error') {
+      throw new BillingError(reconciliation.error ?? 'Legacy subscription sync failed');
+    }
+
+    account = await getCreditAccount(accountId);
+    if (!account?.stripeSubscriptionId) {
+      return {
+        success: true,
+        message: reconciliation.status === 'no_active_paid_subscription'
+          ? 'No active paid subscription found to sync'
+          : 'No subscription to sync',
+      };
+    }
   }
 
   const stripe = getStripe();

--- a/apps/api/src/billing/services/tiers.ts
+++ b/apps/api/src/billing/services/tiers.ts
@@ -217,6 +217,18 @@ export function getTierByPriceId(priceId: string): TierConfig | null {
   return name ? TIERS[name] ?? null : null;
 }
 
+export function getBillingPeriodByPriceId(priceId: string): 'monthly' | 'yearly' | 'yearly_commitment' | null {
+  for (const priceConfig of [STRIPE_PRICES_PROD, STRIPE_PRICES_STAGING]) {
+    for (const tierPrices of Object.values(priceConfig.subscriptions)) {
+      if (tierPrices.monthly === priceId) return 'monthly';
+      if (tierPrices.yearly === priceId) return 'yearly';
+      if (tierPrices.yearlyCommitment === priceId) return 'yearly_commitment';
+    }
+  }
+
+  return null;
+}
+
 export function getAllTiers(): TierConfig[] {
   return Object.values(TIERS);
 }

--- a/apps/api/src/billing/services/webhooks.ts
+++ b/apps/api/src/billing/services/webhooks.ts
@@ -10,6 +10,7 @@ import {
 import { getCustomerByStripeId, upsertCustomer } from '../repositories/customers';
 import { updatePurchaseStatus, getPurchaseByPaymentIntent } from '../repositories/transactions';
 import {
+  getBillingPeriodByPriceId,
   getTier,
   getTierByPriceId,
   getMonthlyCredits,
@@ -226,26 +227,13 @@ async function handleSubscriptionCheckout(session: Stripe.Checkout.Session, acco
 }
 
 async function handleSubscriptionChange(subscription: Stripe.Subscription) {
-  const accountId = subscription.metadata?.account_id;
+  const accountId = await resolveCanonicalStripeAccountId(subscription.metadata?.account_id, subscription.customer);
   if (!accountId) {
-    const customerId = typeof subscription.customer === 'string'
-      ? subscription.customer
-      : subscription.customer?.id;
-    if (!customerId) {
-      console.warn('[Webhook] subscription change: no account_id or customer_id');
-      return;
-    }
-
-    const customer = await getCustomerByStripeId(customerId);
-    if (!customer) {
-      console.warn(`[Webhook] subscription change: no billing customer for stripe_id=${customerId}`);
-      return;
-    }
-
-    await syncSubscriptionState(customer.accountId, subscription);
+    console.warn('[Webhook] subscription change: no canonical account_id');
     return;
   }
 
+  await repairStripeSubscriptionAccountMetadata(subscription, accountId);
   await syncSubscriptionState(accountId, subscription);
 }
 
@@ -276,6 +264,10 @@ async function syncSubscriptionState(accountId: string, subscription: Stripe.Sub
   const tierKey = subscription.metadata?.tier_key;
   const priceId = subscription.items.data[0]?.price?.id;
   const resolvedTier = tierKey ?? getTierByPriceId(priceId ?? '')?.name ?? null;
+  const billingPeriod = getBillingPeriodByPriceId(priceId ?? '') ?? (subscription.metadata?.commitment_type as any) ?? 'monthly';
+  const shouldGrantRecoveryCredits =
+    !!resolvedTier &&
+    (!account || (!account.stripeSubscriptionId && (!account.tier || account.tier === 'free' || account.tier === 'none')));
 
   console.log(`[Webhook] syncSubscriptionState: account=${accountId} tier_meta=${tierKey} price=${priceId} resolved=${resolvedTier} status=${subscription.status}`);
 
@@ -283,6 +275,12 @@ async function syncSubscriptionState(accountId: string, subscription: Stripe.Sub
     stripeSubscriptionId: subscription.id,
     stripeSubscriptionStatus: subscription.status,
     billingCycleAnchor: new Date(subscription.billing_cycle_anchor * 1000).toISOString(),
+    provider: 'stripe',
+    planType: billingPeriod === 'yearly_commitment' ? 'yearly' : billingPeriod,
+    commitmentType: billingPeriod === 'yearly_commitment' ? 'yearly_commitment' : null,
+    commitmentEndDate: billingPeriod === 'yearly_commitment'
+      ? new Date(subscription.current_period_end * 1000).toISOString()
+      : null,
   };
 
   if (resolvedTier) {
@@ -295,22 +293,28 @@ async function syncSubscriptionState(accountId: string, subscription: Stripe.Sub
     updates.paymentStatus = 'active';
   }
 
-  await updateCreditAccount(accountId, updates);
+  if (!account) {
+    await upsertCreditAccount(accountId, updates);
+  } else {
+    await updateCreditAccount(accountId, updates);
+  }
+
+  if (shouldGrantRecoveryCredits && resolvedTier) {
+    const credits = getMonthlyCredits(resolvedTier);
+    if (credits > 0) {
+      await resetExpiringCredits(
+        accountId,
+        credits,
+        `Recovered Stripe subscription: ${credits} credits`,
+        `legacy_sync:${subscription.id}`,
+      );
+    }
+  }
 }
 
 async function handleSubscriptionDeleted(subscription: Stripe.Subscription) {
-  let accountId = subscription.metadata?.account_id;
-  if (!accountId) {
-    const customerId = typeof subscription.customer === 'string'
-      ? subscription.customer
-      : subscription.customer?.id;
-    if (!customerId) return;
-
-    const customer = await getCustomerByStripeId(customerId);
-    if (!customer) return;
-
-    accountId = customer.accountId;
-  }
+  const accountId = await resolveCanonicalStripeAccountId(subscription.metadata?.account_id, subscription.customer);
+  if (!accountId) return;
 
   await revertToFree(accountId, subscription.id);
 }
@@ -373,8 +377,10 @@ async function handleInvoicePaid(invoice: Stripe.Invoice) {
 
   const stripe = getStripe();
   const subscription = await stripe.subscriptions.retrieve(subscriptionId);
-  const accountId = subscription.metadata?.account_id;
+  const accountId = await resolveCanonicalStripeAccountId(subscription.metadata?.account_id, subscription.customer);
   if (!accountId) return;
+
+  await repairStripeSubscriptionAccountMetadata(subscription, accountId);
 
   const account = await getCreditAccount(accountId);
   if (!account) return;
@@ -492,8 +498,10 @@ async function handleInvoiceFailed(invoice: Stripe.Invoice) {
 
   const stripe = getStripe();
   const subscription = await stripe.subscriptions.retrieve(subscriptionId);
-  const accountId = subscription.metadata?.account_id;
+  const accountId = await resolveCanonicalStripeAccountId(subscription.metadata?.account_id, subscription.customer);
   if (!accountId) return;
+
+  await repairStripeSubscriptionAccountMetadata(subscription, accountId);
 
   await updateCreditAccount(accountId, {
     paymentStatus: 'past_due',
@@ -501,6 +509,43 @@ async function handleInvoiceFailed(invoice: Stripe.Invoice) {
   });
 
   console.log(`[Webhook] Payment failed for ${accountId}`);
+}
+
+async function resolveCanonicalStripeAccountId(
+  rawAccountId: string | undefined,
+  customer: string | Stripe.Customer | Stripe.DeletedCustomer | null | undefined,
+): Promise<string | null> {
+  const customerId = typeof customer === 'string'
+    ? customer
+    : ('id' in (customer ?? {}) ? (customer as Stripe.Customer | Stripe.DeletedCustomer).id : null);
+
+  if (customerId) {
+    const mappedCustomer = await getCustomerByStripeId(customerId);
+    if (mappedCustomer?.accountId) {
+      return mappedCustomer.accountId;
+    }
+  }
+
+  return rawAccountId ?? null;
+}
+
+async function repairStripeSubscriptionAccountMetadata(subscription: Stripe.Subscription, canonicalAccountId: string) {
+  const rawAccountId = subscription.metadata?.account_id;
+  if (!rawAccountId || rawAccountId === canonicalAccountId) return;
+
+  try {
+    const stripe = getStripe();
+    await stripe.subscriptions.update(subscription.id, {
+      metadata: {
+        ...subscription.metadata,
+        account_id: canonicalAccountId,
+        legacy_account_id: rawAccountId,
+      },
+    });
+    console.log(`[Webhook] Repaired subscription ${subscription.id} account_id ${rawAccountId} -> ${canonicalAccountId}`);
+  } catch (err) {
+    console.error(`[Webhook] Failed to repair subscription ${subscription.id} account metadata:`, err);
+  }
 }
 
 export async function processRevenueCatWebhook(body: any) {

--- a/apps/api/src/scripts/reconcile-legacy-stripe-billing.ts
+++ b/apps/api/src/scripts/reconcile-legacy-stripe-billing.ts
@@ -1,0 +1,109 @@
+import { sql } from 'drizzle-orm';
+import { syncLegacyStripeSubscription } from '../billing/services/legacy-stripe-sync';
+import { db } from '../shared/db';
+
+type CandidateRow = {
+  accountId: string;
+  email: string | null;
+  existingTier: string | null;
+  existingProvider: string | null;
+  existingStripeSubscriptionId: string | null;
+};
+
+function getArg(flag: string): string | null {
+  const exact = Bun.argv.find((arg) => arg === flag);
+  if (exact) {
+    const index = Bun.argv.indexOf(exact);
+    return Bun.argv[index + 1] ?? null;
+  }
+
+  const prefixed = Bun.argv.find((arg) => arg.startsWith(`${flag}=`));
+  return prefixed ? prefixed.slice(flag.length + 1) : null;
+}
+
+const apply = Bun.argv.includes('--apply');
+const accountId = getArg('--account-id');
+const email = getArg('--email');
+const limit = Number(getArg('--limit') ?? '500');
+
+const accountFilter = accountId ? sql`AND candidates.account_id = ${accountId}` : sql``;
+const emailFilter = email ? sql`AND lower(candidates.email) = lower(${email})` : sql``;
+
+const result = await db.execute(sql`
+  WITH customer_accounts AS (
+    SELECT account_id, email, COALESCE(provider, 'stripe') AS provider, COALESCE(active, true) AS active
+    FROM kortix.billing_customers
+    UNION ALL
+    SELECT account_id, email, COALESCE(provider, 'stripe') AS provider, COALESCE(active, true) AS active
+    FROM basejump.billing_customers
+  ),
+  candidates AS (
+    SELECT
+      customer_accounts.account_id,
+      max(customer_accounts.email) AS email
+    FROM customer_accounts
+    WHERE customer_accounts.provider = 'stripe'
+      AND customer_accounts.active = true
+    GROUP BY customer_accounts.account_id
+  )
+  SELECT
+    candidates.account_id AS "accountId",
+    candidates.email AS "email",
+    credit.tier AS "existingTier",
+    credit.provider AS "existingProvider",
+    credit.stripe_subscription_id AS "existingStripeSubscriptionId"
+  FROM candidates
+  LEFT JOIN kortix.credit_accounts credit
+    ON credit.account_id = candidates.account_id
+  WHERE (
+    credit.account_id IS NULL
+    OR credit.provider IS NULL
+    OR credit.provider = 'stripe'
+  )
+  AND (
+    credit.account_id IS NULL
+    OR credit.stripe_subscription_id IS NULL
+    OR credit.tier IS NULL
+    OR credit.tier IN ('none', 'free')
+  )
+  ${accountFilter}
+  ${emailFilter}
+  ORDER BY candidates.account_id
+  LIMIT ${Number.isFinite(limit) && limit > 0 ? limit : 500}
+`);
+
+const rows = (Array.isArray(result) ? result : (result as any).rows ?? []) as CandidateRow[];
+
+const summary = {
+  scanned: rows.length,
+  wouldSync: 0,
+  synced: 0,
+  alreadySynced: 0,
+  noCustomer: 0,
+  noActivePaidSubscription: 0,
+  errors: 0,
+};
+
+console.log(`[legacy-stripe-sync] mode=${apply ? 'apply' : 'dry-run'} candidates=${rows.length}`);
+
+for (const row of rows) {
+  const syncResult = await syncLegacyStripeSubscription(row.accountId, { dryRun: !apply });
+
+  if (syncResult.status === 'would_sync') summary.wouldSync += 1;
+  else if (syncResult.status === 'synced') summary.synced += 1;
+  else if (syncResult.status === 'already_synced') summary.alreadySynced += 1;
+  else if (syncResult.status === 'no_customer') summary.noCustomer += 1;
+  else if (syncResult.status === 'no_active_paid_subscription') summary.noActivePaidSubscription += 1;
+  else if (syncResult.status === 'error') summary.errors += 1;
+
+  console.log(JSON.stringify({
+    accountId: row.accountId,
+    email: row.email,
+    existingTier: row.existingTier,
+    existingProvider: row.existingProvider,
+    existingStripeSubscriptionId: row.existingStripeSubscriptionId,
+    result: syncResult,
+  }));
+}
+
+console.log(JSON.stringify({ summary }, null, 2));

--- a/apps/api/src/shared/resolve-account.ts
+++ b/apps/api/src/shared/resolve-account.ts
@@ -1,74 +1,12 @@
 import { eq } from 'drizzle-orm';
-import { accounts, accountMembers, accountUser, billingCustomers, creditAccounts } from '@kortix/db';
+import { accounts, accountMembers, accountUser } from '@kortix/db';
 import { db } from './db';
 
 async function syncLegacySubscription(accountId: string): Promise<void> {
-  const [existing] = await db
-    .select({ tier: creditAccounts.tier })
-    .from(creditAccounts)
-    .where(eq(creditAccounts.accountId, accountId))
-    .limit(1);
-
-  if (existing?.tier && existing.tier !== 'free' && existing.tier !== 'none') return;
-
-  let customerEmail: string | null = null;
-  try {
-    const [customer] = await db
-      .select({ email: billingCustomers.email })
-      .from(billingCustomers)
-      .where(eq(billingCustomers.accountId, accountId))
-      .limit(1);
-    customerEmail = customer?.email ?? null;
-  } catch { }
-
-  if (!customerEmail) return;
-
-  try {
-    const { getStripe } = await import('./stripe');
-    const stripe = getStripe();
-    const { getTierByPriceId } = await import('../billing/services/tiers');
-
-    const customers = await stripe.customers.search({
-      query: `email:'${customerEmail}'`,
-      limit: 10,
-    });
-
-    for (const customer of customers.data) {
-      const subs = await stripe.subscriptions.list({
-        customer: customer.id,
-        status: 'active',
-        limit: 5,
-      });
-
-      for (const sub of subs.data) {
-        const priceId = sub.items.data[0]?.price?.id;
-        if (!priceId) continue;
-
-        const tierConfig = getTierByPriceId(priceId);
-        if (!tierConfig || tierConfig.name === 'free' || tierConfig.name === 'none') continue;
-        const tier = tierConfig.name;
-
-        const { upsertCreditAccount } = await import('../billing/repositories/credit-accounts');
-        await upsertCreditAccount(accountId, {
-          tier,
-          stripeSubscriptionId: sub.id,
-          stripeSubscriptionStatus: sub.status,
-        });
-
-        await db.insert(billingCustomers).values({
-          accountId,
-          id: customer.id,
-          email: customerEmail,
-          active: true,
-          provider: 'stripe',
-        }).onConflictDoNothing();
-
-        console.log(`[resolve-account] Synced Stripe sub ${sub.id} → tier=${tier} for ${accountId} (customer=${customer.id})`);
-        return;
-      }
-    }
-  } catch (err) {
-    console.warn(`[resolve-account] Stripe sync error for ${accountId}:`, err);
+  const { syncLegacyStripeSubscription } = await import('../billing/services/legacy-stripe-sync');
+  const result = await syncLegacyStripeSubscription(accountId);
+  if (result.status === 'error') {
+    console.warn(`[resolve-account] Stripe sync error for ${accountId}: ${result.error}`);
   }
 }
 
@@ -80,7 +18,10 @@ export async function resolveAccountId(userId: string): Promise<string> {
       .where(eq(accountMembers.userId, userId))
       .limit(1);
 
-    if (membership) return membership.accountId;
+    if (membership) {
+      await syncLegacySubscription(membership.accountId);
+      return membership.accountId;
+    }
   } catch { }
 
   try {
@@ -109,9 +50,7 @@ export async function resolveAccountId(userId: string): Promise<string> {
         console.warn(`[resolve-account] Lazy migration failed for ${legacy.accountId}:`, migErr);
       }
 
-      syncLegacySubscription(legacy.accountId).catch((err) => {
-        console.warn(`[resolve-account] Stripe sync failed for ${legacy.accountId}:`, err);
-      });
+      await syncLegacySubscription(legacy.accountId);
 
       return legacy.accountId;
     }


### PR DESCRIPTION
## Summary
- restore canonical billing state for legacy Stripe accounts during account resolution and subscription sync
- canonicalize Stripe webhook account mapping and repair stale subscription metadata while restoring missing credits
- add a reconciliation script and focused regression tests for the legacy Stripe repair path
