### PR TITLE
fix(v2): bulletproof v2-default — fix 3 schema/insert paths that stil…

### DIFF
--- a/core/kortix-master/opencode/plugin/kortix-system/projects.ts
+++ b/core/kortix-master/opencode/plugin/kortix-system/projects.ts
@@ -265,7 +265,12 @@ export class ProjectManager {
 			const ocProject = ocResult.data as any
 			if (ocProject?.id && ocProject.id !== "global") opencodeId = ocProject.id
 		} catch {}
-		this.db.prepare("INSERT INTO projects (id,name,path,description,created_at,opencode_id) VALUES ($id,$n,$p,$d,$c,$oid)")
+		// Explicit structure_version=2 — don't rely on the column's default.
+		// Two other code paths (routes/projects.ts CREATE TABLE + ALTER) have
+		// historically shipped with default=1; even though those are now also
+		// fixed to default 2, being explicit here prevents a v1 row ever
+		// being created regardless of which migrator ran first.
+		this.db.prepare("INSERT INTO projects (id,name,path,description,created_at,opencode_id,structure_version) VALUES ($id,$n,$p,$d,$c,$oid,2)")
 			.run({ $id: id, $n: name, $p: pp, $d: desc || "", $c: now, $oid: opencodeId })
 		return { id, name, path: pp, description: desc || "", created_at: now, opencode_id: opencodeId }
 	}

--- a/core/kortix-master/src/routes/projects.ts
+++ b/core/kortix-master/src/routes/projects.ts
@@ -67,12 +67,23 @@ function getDb(): Database {
       id TEXT PRIMARY KEY, name TEXT NOT NULL, path TEXT NOT NULL UNIQUE,
       description TEXT NOT NULL DEFAULT '', created_at TEXT NOT NULL,
       opencode_id TEXT, maintainer_session_id TEXT,
-      structure_version INTEGER NOT NULL DEFAULT 1,
+      structure_version INTEGER NOT NULL DEFAULT 2,
       user_handle TEXT
     );
   `)
-  try { _db.exec(`ALTER TABLE projects ADD COLUMN structure_version INTEGER NOT NULL DEFAULT 1`) } catch {}
+  // v2 is the new default — any legacy row that was inserted with the old
+  // default=1 gets upgraded automatically on the next boot. (The only
+  // project that SHOULD stay v1 is the virtual `proj-workspace` catch-all,
+  // which represents /workspace itself and has no PM/board/tickets.)
+  try { _db.exec(`ALTER TABLE projects ADD COLUMN structure_version INTEGER NOT NULL DEFAULT 2`) } catch {}
   try { _db.exec(`ALTER TABLE projects ADD COLUMN user_handle TEXT`) } catch {}
+  // One-shot migration: upgrade every non-workspace v1 row to v2. Any
+  // project the user spawned against older plugin/route code that defaulted
+  // to 1 gets corrected on the next boot without manual intervention.
+  try {
+    const up = _db.prepare(`UPDATE projects SET structure_version=2 WHERE structure_version<2 AND id<>'proj-workspace'`).run()
+    if (up.changes > 0) console.log(`[projects] migrated ${up.changes} legacy project(s) from v1 → v2`)
+  } catch {}
   ensureTicketTables(_db)
 
   return _db


### PR DESCRIPTION
…l set 1

Root cause of 'new project came out v1 on dev.kortix.com': There are THREE places that write a structure_version default, and TWO of them were still set to 1:

  1. opencode/plugin/kortix-system/projects.ts:152  → default '2' ✅ (already fixed)
  2. src/routes/projects.ts:70  CREATE TABLE       → default 1 ❌
  3. src/routes/projects.ts:74  ALTER ADD COLUMN   → default 1 ❌

If the first boot ran routes/projects.ts getDb() before the opencode plugin's initProjectsDb(), the projects table was created/altered with default=1. All subsequent inserts via the plugin's ProjectManager. createProject() (which didn't set structure_version explicitly, so it took the schema default) got v1. The 'UPDATE projects SET structure_version=2' in the project_create tool masked this for the chat flow most of the time, but any race / failure path leaked v1 rows.

Fixes:

1. routes/projects.ts CREATE TABLE: default 2
2. routes/projects.ts ALTER ADD COLUMN: default 2
3. plugin ProjectManager.createProject(): INSERT now writes structure_version=2 explicitly — no reliance on any schema default.
4. routes/projects.ts init: one-shot migration 'UPDATE projects SET structure_version=2 WHERE structure_version<2 AND id<>proj-workspace' runs on every boot. Any existing v1 row from prior builds gets upgraded automatically on next deploy. The virtual proj-workspace stays v1 (it has no PM/board — it's the /workspace catch-all).

After this deploys to cloud (dev.kortix.com), fresh projects land as v2 AND existing legacy v1 rows get migrated on container boot. No manual SQL or user intervention required.