### PR TITLE
fix(triggers): add timeout to /health probe in EADDRINUSE recovery

### DIFF
--- a/core/kortix-master/triggers/src/trigger-manager.ts
+++ b/core/kortix-master/triggers/src/trigger-manager.ts
@@ -97,7 +97,9 @@ export class TriggerManager {
       if (isAddrInUse) {
         const port = this.options.webhookPort ?? 8099
         try {
-          const res = await fetch(`http://127.0.0.1:${port}/health`)
+          const res = await fetch(`http://127.0.0.1:${port}/health`, {
+            signal: AbortSignal.timeout(2_000),
+          })
           if (res.ok) {
             this.log("info", `[triggers] Reusing existing webhook server on port ${port}`)
           } else {


### PR DESCRIPTION
## Summary

In `core/kortix-master/triggers/src/trigger-manager.ts`, when the webhook server fails to bind because the port is already in use (`EADDRINUSE`), the manager attempts to reach the existing server's `/health` endpoint to decide whether to reuse it.

This `fetch()` call had no timeout/`AbortSignal`. If the existing server is alive but stuck (deadlocked event loop, blocked on a slow handler, hung on a downstream call, etc.) the manager startup blocks **indefinitely** instead of falling through to the failure path.

Other `fetch()` calls in this codebase consistently use `AbortSignal.timeout()` — this one was the only outlier.

## Fix

Added a 2-second timeout via `AbortSignal.timeout(2_000)` to match the intent of a recovery-time probe — we want a quick "is it healthy right now?" answer, not an unbounded wait.

## Reproduction (conceptual)

1. Start a Kortix master that opens the webhook port.
2. Cause the webhook server's event loop to hang (e.g., a synchronous infinite loop in a handler, a blocking native call).
3. Restart the master without closing the first instance.
4. Before fix: `rebuildRuntime()` blocks forever in the `/health` fetch.
5. After fix: the fetch aborts after 2s, the catch path runs, and the user sees the original `EADDRINUSE` error rather than a silent hang.

## Test plan

- [x] Confirmed all other `fetch()` calls in `core/kortix-master/triggers/`, `core/kortix-supervisor/`, and the dispatch helpers use `AbortSignal.timeout()` or a `controller.signal` driven by `setTimeout`.
- [x] 2-second window matches the existing `isPortHealthy` probe (`AbortSignal.timeout(1_000)`) in `core/kortix-supervisor/src/daemons.ts:452` and `waitForPort` (`500ms`) — chosen slightly higher because this runs once during startup, not in a hot loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)