### PR TITLE
fix(v2): unblock autonomous e2e — wake races, supervisor liveness, co…

### DIFF
--- a/apps/api/src/platform/providers/local-docker.ts
+++ b/apps/api/src/platform/providers/local-docker.ts
@@ -1063,9 +1063,18 @@ export class LocalDockerProvider implements SandboxProvider {
         // Single-line shell: `&&` between statements, `;` inside if-then-fi.
         // Detach with setsid + nohup + </dev/null so the bun process survives
         // after the `docker exec` command returns.
+        //
+        // Why we don't just trust `[ -S sock ]`: the socket file persists on
+        // disk after the supervisor process dies (e.g. previous container
+        // boot crashed, or kortix-supervisor restarted manually). A stale
+        // socket file makes the gate skip startup, then `/file` routes 500
+        // with "Was there a typo in the url or port?" because nothing is
+        // listening. Probe-then-start: if no process named `kortix-supervisor`
+        // is running, remove any stale socket and (re)start fresh.
         const cmd =
           'mkdir -p /run/kortix && ' +
-          'if [ ! -S /run/kortix/supervisor.sock ]; then ' +
+          'if ! pgrep -f "/ephemeral/kortix-supervisor/src/index.ts" >/dev/null 2>&1; then ' +
+          'rm -f /run/kortix/supervisor.sock; ' +
           'cd /ephemeral/kortix-supervisor && ' +
           'setsid nohup env KORTIX_SUPERVISOR_SOCKET=/run/kortix/supervisor.sock ' +
           'OPENCODE_BIN_PATH=/usr/local/bin/opencode-kortix ' +

--- a/apps/api/src/router/services/billing.ts
+++ b/apps/api/src/router/services/billing.ts
@@ -67,6 +67,14 @@ export async function deductToolCredits(
     throw new Error('DATABASE_URL is required for credit deductions');
   }
 
+  // Skip deduction in local mode regardless of DB. ENV_MODE=local users
+  // are running their own dev stack (no Stripe, no real subscriptions),
+  // and billing on a $0 balance just stalls everything with
+  // InsufficientCreditsError. Cloud mode (ENV_MODE=cloud) still bills.
+  if (!config.KORTIX_BILLING_INTERNAL_ENABLED) {
+    return { success: true, cost: 0, newBalance: 0 };
+  }
+
   console.info(`[BILLING] Deducting $${cost.toFixed(4)} for ${toolName} (direct DB)`);
 
   const result = await deductCreditsDb(accountId, cost, deductDescription);
@@ -110,6 +118,11 @@ export async function deductLLMCredits(
       return { success: true, cost: 0, newBalance: 0 };
     }
     throw new Error('DATABASE_URL is required for credit deductions');
+  }
+
+  // Skip deduction in local mode (see deductToolCredits for full rationale).
+  if (!config.KORTIX_BILLING_INTERNAL_ENABLED) {
+    return { success: true, cost: 0, newBalance: 0 };
   }
 
   console.info(`[BILLING] Deducting $${calculatedCost.toFixed(6)} for ${model} (direct DB)`);

--- a/apps/api/src/sandbox-proxy/routes/local-preview.ts
+++ b/apps/api/src/sandbox-proxy/routes/local-preview.ts
@@ -16,6 +16,7 @@
 import { config } from '../../config';
 import { execSync } from 'child_process';
 import { buildCanonicalSandboxAuthCommand } from '../../platform/services/sandbox-auth';
+import { invalidateProviderCache } from '..';
 
 const KORTIX_MASTER_PORT = 8000;
 const FETCH_TIMEOUT_MS = 30_000;
@@ -101,6 +102,51 @@ function trySyncServiceKey(serviceKey: string): boolean {
   } catch (err: any) {
     console.error(`[LOCAL-PREVIEW] Failed to sync sandbox auth bundle (attempt ${_syncAttemptsForCurrentKey}/${MAX_SYNC_ATTEMPTS_PER_KEY}):`, err.message || err);
     return false;
+  }
+}
+
+/**
+ * Read the kortix-master process's currently-loaded KORTIX_TOKEN by
+ * cat-ing `/workspace/.secrets/.bootstrap-env.json` from inside the
+ * container. This is the source of truth for what the running process
+ * actually accepts (bootstrap-env.ts overrides process.env at startup
+ * with whatever's in this file).
+ */
+function readContainerBootstrapKey(): string | null {
+  try {
+    const env: Record<string, string> = { ...process.env as Record<string, string> };
+    if (config.DOCKER_HOST && !config.DOCKER_HOST.includes('://')) {
+      env.DOCKER_HOST = `unix://${config.DOCKER_HOST}`;
+    }
+    const out = execSync(
+      `docker exec ${shellQuote(config.SANDBOX_CONTAINER_NAME)} cat /workspace/.secrets/.bootstrap-env.json`,
+      { timeout: 5_000, stdio: ['pipe', 'pipe', 'pipe'], env },
+    ).toString('utf8');
+    const json = JSON.parse(out);
+    return typeof json.KORTIX_TOKEN === 'string' && json.KORTIX_TOKEN.length > 0 ? json.KORTIX_TOKEN : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Push a corrected serviceKey back into the sandboxes table so the
+ * provider cache can refresh and future requests use the right value
+ * without another 401 → docker exec round-trip.
+ */
+async function updateSandboxServiceKeyInDb(newKey: string): Promise<void> {
+  try {
+    const { db } = await import('../../shared/db');
+    const { sandboxes } = await import('@kortix/db');
+    const { eq, sql } = await import('drizzle-orm');
+    await db
+      .update(sandboxes)
+      .set({ config: sql`jsonb_set(config, '{serviceKey}', ${JSON.stringify(newKey)}::jsonb)` as any })
+      .where(eq(sandboxes.externalId, config.SANDBOX_CONTAINER_NAME));
+    invalidateProviderCache(config.SANDBOX_CONTAINER_NAME);
+    console.log('[LOCAL-PREVIEW] Refreshed sandbox serviceKey in DB + invalidated cache');
+  } catch (err) {
+    console.warn('[LOCAL-PREVIEW] Could not update sandbox serviceKey in DB:', (err as Error).message);
   }
 }
 
@@ -227,15 +273,58 @@ export async function proxyToSandbox(
     return out;
   }
 
-  // On 401 from sandbox: service key mismatch (rotation drift). Sync our
-  // key into the container and retry once. Only attempt local docker exec
-  // sync for local_docker provider (no baseUrlOverride). Unlike before, we
-  // re-attempt sync even if we've synced a DIFFERENT key before — rotations
-  // are common under `bun --hot`.
+  // On 401 from sandbox: service-key mismatch. Two failure modes:
+  //   (a) Container env files have key X but our cached serviceKey is Y.
+  //       Pushing Y into the s6 env via trySyncServiceKey only helps the
+  //       NEXT process spawn, not the currently-running kortix-master that
+  //       loaded X at start. So syncing+retrying with the same Y still 401s.
+  //   (b) The DB / our cache is fine but bootstrap-env.ts inside the
+  //       container loaded an older KORTIX_TOKEN from a stale persistent
+  //       /workspace/.secrets/.bootstrap-env.json.
+  //
+  // The container's bootstrap file is the source of truth for what the
+  // running kortix-master process actually accepts. On 401, read that
+  // file via `docker exec` and retry with whatever it says. If the retry
+  // succeeds we also publish the corrected key into our DB row so
+  // subsequent cache reads pick it up cleanly.
   if (response.status === 401 && !baseUrlOverride) {
+    const containerKey = readContainerBootstrapKey();
+    if (containerKey && containerKey !== serviceKey) {
+      console.log('[LOCAL-PREVIEW] 401 — retrying with container bootstrap key');
+      const retryHeaders = new Headers(headers);
+      retryHeaders.set('Authorization', `Bearer ${containerKey}`);
+      const retryController = new AbortController();
+      const retryTimer = setTimeout(() => retryController.abort(), FETCH_TIMEOUT_MS);
+      const retryResponse = await fetch(targetUrl, {
+        method,
+        headers: retryHeaders,
+        body: incomingBody,
+        signal: retryController.signal,
+        // @ts-ignore
+        decompress: false,
+        redirect: 'manual',
+      });
+      clearTimeout(retryTimer);
+      if (retryResponse.status !== 401) {
+        // Retry succeeded — push the working key back into the DB +
+        // invalidate the provider cache so subsequent requests use it.
+        void updateSandboxServiceKeyInDb(containerKey).catch(() => {});
+      }
+      const out = sanitizeResponseHeaders(retryResponse.headers);
+      if (origin) {
+        out.set('Access-Control-Allow-Origin', origin);
+        out.set('Access-Control-Allow-Credentials', 'true');
+      }
+      return new Response(retryResponse.body, {
+        status: retryResponse.status,
+        statusText: retryResponse.statusText,
+        headers: out,
+      });
+    }
+    // Fall back to the original docker-exec sync path if we couldn't read
+    // the container's bootstrap file (e.g. file missing on cloud sandboxes).
     const synced = trySyncServiceKey(serviceKey);
     if (synced) {
-      // Retry the request with the same key (now the sandbox should accept it)
       const retryController = new AbortController();
       const retryTimer = setTimeout(() => retryController.abort(), FETCH_TIMEOUT_MS);
       const retryResponse = await fetch(targetUrl, {

--- a/core/kortix-master/opencode/plugin/kortix-system/ticket-tools.ts
+++ b/core/kortix-master/opencode/plugin/kortix-system/ticket-tools.ts
@@ -841,13 +841,25 @@ export function ticketTools(db: Database, mgr: ProjectManager, client: any) {
         // Resolve agent slugs → real agent ids so column-default triggers
         // actually fire. A column that stores `agent:<slug>` never matches a
         // real agent row, so auto-assign and wake-up silently break.
+        //
+        // Also auto-set default_assignee_type='agent' when an unprefixed
+        // slug-form id resolves to an agent. PM agents historically pass
+        // {default_assignee_id: "qa"} without specifying default_assignee_type
+        // — leaving type=null silently skips the column-default trigger
+        // path in updateStatus (the `col.default_assignee_type && col.default_assignee_id`
+        // gate fails on null type), so QA never wakes when tickets hit review.
         for (const col of cols) {
-          if (col && col.default_assignee_type === 'agent' && typeof col.default_assignee_id === 'string') {
-            const raw = col.default_assignee_id
-            if (!raw.startsWith('ag-')) {
-              const ag = getAgentBySlug(db, pid, raw) || getAgentById(db, raw)
-              if (ag) col.default_assignee_id = ag.id
-            }
+          if (!col || typeof col.default_assignee_id !== 'string') continue
+          const raw = col.default_assignee_id
+          if (raw.startsWith('ag-')) {
+            // Already a real agent id — make sure type is set.
+            if (!col.default_assignee_type) col.default_assignee_type = 'agent'
+            continue
+          }
+          const ag = getAgentBySlug(db, pid, raw) || getAgentById(db, raw)
+          if (ag) {
+            col.default_assignee_id = ag.id
+            col.default_assignee_type = 'agent'
           }
         }
         replaceColumns(db, pid, cols)

--- a/core/kortix-master/src/index.ts
+++ b/core/kortix-master/src/index.ts
@@ -25,7 +25,7 @@ import webProxyRouter from './routes/web-proxy'
 import { updateRoutes as updateRouter } from './routes/update'
 import deployRouter from './routes/deploy'
 import servicesRouter from './routes/services'
-import pipedreamRouter, { pushPipedreamCredsToApi } from './routes/pipedream'
+import pipedreamRouter, { pushPipedreamCredsToApi, syncExistingConnectorsFromApi } from './routes/pipedream'
 import connectorsRouter from './routes/connectors'
 import suggestionsRouter from './routes/suggestions'
 import coreRouter from './routes/core'
@@ -714,6 +714,9 @@ console.log(`[Kortix Master] Starting on port ${config.PORT}`)
 
 // Push Pipedream creds to API after boot (async, non-blocking)
 setTimeout(() => pushPipedreamCredsToApi(), 5_000)
+// Reconcile Pipedream connectors from API into local kortix.db (self-heals
+// sandboxes that missed the fire-and-forget connector-sync call).
+setTimeout(() => syncExistingConnectorsFromApi(), 8_000)
 console.log(`[Kortix Master] Proxying to OpenCode at ${config.OPENCODE_HOST}:${config.OPENCODE_PORT}`)
 console.log(`[Kortix Master] API docs available at http://localhost:${config.PORT}/docs`)
 

--- a/core/kortix-master/src/routes/pipedream.ts
+++ b/core/kortix-master/src/routes/pipedream.ts
@@ -563,36 +563,39 @@ export async function pushPipedreamCredsToApi(): Promise<void> {
 // Called by the API when a new Pipedream OAuth connection is saved.
 // Inserts into the connectors SQLite table.
 
+async function upsertPipedreamConnector(app: string, appName?: string): Promise<string> {
+  const name = (appName || app).toLowerCase().replace(/[^a-z0-9-]/g, '-').replace(/^-|-$/g, '')
+  const { Database } = await import('bun:sqlite')
+  const { mkdirSync } = await import('node:fs')
+  const { randomUUID } = await import('node:crypto')
+
+  const root = process.env.KORTIX_WORKSPACE || '/workspace'
+  mkdirSync(`${root}/.kortix`, { recursive: true })
+  const db = new Database(`${root}/.kortix/kortix.db`)
+  db.exec("PRAGMA journal_mode=DELETE; PRAGMA busy_timeout=5000")
+  db.exec(`CREATE TABLE IF NOT EXISTS connectors (
+    id TEXT PRIMARY KEY, name TEXT NOT NULL UNIQUE, description TEXT, source TEXT,
+    pipedream_slug TEXT, env_keys TEXT, notes TEXT, auto_generated INTEGER DEFAULT 0,
+    created_at TEXT NOT NULL, updated_at TEXT NOT NULL
+  )`)
+
+  const now = new Date().toISOString()
+  db.prepare(`
+    INSERT INTO connectors (id, name, description, source, pipedream_slug, notes, auto_generated, created_at, updated_at)
+    VALUES (?, ?, ?, 'pipedream', ?, ?, 1, ?, ?)
+    ON CONFLICT(name) DO UPDATE SET
+      source = 'pipedream', pipedream_slug = excluded.pipedream_slug,
+      auto_generated = 1, updated_at = excluded.updated_at
+  `).run(randomUUID(), name, appName || app, app, `Connected via Pipedream OAuth`, now, now)
+  db.close()
+  return name
+}
+
 pipedreamRouter.post('/connector-sync', async (c) => {
   try {
     const { app, app_name } = await c.req.json() as { app: string; app_name?: string }
     if (!app) return c.json({ error: 'app is required' }, 400)
-
-    const name = (app_name || app).toLowerCase().replace(/[^a-z0-9-]/g, '-').replace(/^-|-$/g, '')
-    const { Database } = await import('bun:sqlite')
-    const { mkdirSync } = await import('node:fs')
-    const { randomUUID } = await import('node:crypto')
-
-    const root = process.env.KORTIX_WORKSPACE || '/workspace'
-    mkdirSync(`${root}/.kortix`, { recursive: true })
-    const db = new Database(`${root}/.kortix/kortix.db`)
-    db.exec("PRAGMA journal_mode=DELETE; PRAGMA busy_timeout=5000")
-    db.exec(`CREATE TABLE IF NOT EXISTS connectors (
-      id TEXT PRIMARY KEY, name TEXT NOT NULL UNIQUE, description TEXT, source TEXT,
-      pipedream_slug TEXT, env_keys TEXT, notes TEXT, auto_generated INTEGER DEFAULT 0,
-      created_at TEXT NOT NULL, updated_at TEXT NOT NULL
-    )`)
-
-    const now = new Date().toISOString()
-    db.prepare(`
-      INSERT INTO connectors (id, name, description, source, pipedream_slug, notes, auto_generated, created_at, updated_at)
-      VALUES (?, ?, ?, 'pipedream', ?, ?, 1, ?, ?)
-      ON CONFLICT(name) DO UPDATE SET
-        source = 'pipedream', pipedream_slug = excluded.pipedream_slug,
-        auto_generated = 1, updated_at = excluded.updated_at
-    `).run(randomUUID(), name, app_name || app, app, `Connected via Pipedream OAuth`, now, now)
-    db.close()
-
+    const name = await upsertPipedreamConnector(app, app_name)
     console.log(`[Pipedream] Auto-created connector: ${name}`)
     return c.json({ success: true, name })
   } catch (err) {
@@ -600,5 +603,51 @@ pipedreamRouter.post('/connector-sync', async (c) => {
     return c.json({ error: 'Failed to create connector' }, 500)
   }
 })
+
+// ─── Boot-time connector reconciliation ──────────────────────────────────────
+// Self-heals sandboxes that missed the fire-and-forget connector-sync call from
+// the API — e.g. sandbox was booting, network blipped, or this sandbox was
+// created after the user OAuth'd the connector. Fetches the account's current
+// Pipedream integrations from kortix-api and upserts each into kortix.db.
+
+export async function syncExistingConnectorsFromApi(): Promise<void> {
+  if (!config.KORTIX_TOKEN || !config.KORTIX_API_URL) {
+    console.log('[Pipedream] Connector boot-sync: no KORTIX_TOKEN/API_URL — skipping')
+    return
+  }
+  try {
+    const apiUrl = getApiV1()
+    const res = await fetch(`${apiUrl}/pipedream/connections`, {
+      headers: {
+        Authorization: `Bearer ${config.KORTIX_TOKEN}`,
+        ...getPipedreamHeaders(),
+      },
+      signal: AbortSignal.timeout(15_000),
+    })
+    if (!res.ok) {
+      console.warn(`[Pipedream] Connector boot-sync: GET /connections returned ${res.status}`)
+      return
+    }
+    const data = await res.json() as { connections?: Array<{ app: string; appName?: string; app_name?: string }> }
+    const rows = data.connections || []
+    if (rows.length === 0) {
+      console.log('[Pipedream] Connector boot-sync: no connections to reconcile')
+      return
+    }
+    let synced = 0
+    for (const row of rows) {
+      try {
+        const name = await upsertPipedreamConnector(row.app, row.appName || row.app_name)
+        synced++
+        console.log(`[Pipedream] Connector boot-sync upserted: ${name}`)
+      } catch (err) {
+        console.warn(`[Pipedream] Connector boot-sync failed for ${row.app}:`, err)
+      }
+    }
+    console.log(`[Pipedream] Connector boot-sync complete: ${synced}/${rows.length} reconciled`)
+  } catch (err) {
+    console.warn('[Pipedream] Connector boot-sync error:', err)
+  }
+}
 
 export default pipedreamRouter

--- a/core/kortix-master/src/services/ticket-triggers.ts
+++ b/core/kortix-master/src/services/ticket-triggers.ts
@@ -141,6 +141,16 @@ export async function fireAgentTrigger(opts: FireTriggerOptions): Promise<string
     }
   }
 
+  // Agent-cache freshness guard MUST run BEFORE session.create. Reason:
+  // ensureAgentCacheFresh may POST /instance/dispose to flush the
+  // directory's stale cache — and dispose nukes EVERY session in that
+  // directory, including one we just minted. Symptom is bad: session.create
+  // returns id X, dispose runs, promptAsync to X gets 204'd silently
+  // (opencode no longer has X), and the agent never wakes (msgs=0,
+  // ready_at=null forever). Always make the cache fresh first, then mint
+  // the session into a stable instance.
+  await ensureAgentCacheFresh(project.path, agent.slug)
+
   if (!sessionId) {
     try {
       const res = await client.session.create({
@@ -183,18 +193,6 @@ export async function fireAgentTrigger(opts: FireTriggerOptions): Promise<string
     reason,
     contextBody,
   })
-
-  // Agent-cache freshness guard: opencode caches `.opencode/agent/*.md` per
-  // directory. If the agent was just created by team_create_agent in the
-  // same PM turn, cache may not have picked it up yet — promptAsync then
-  // returns 2xx but no LLM loop starts (opencode internally logs
-  // `undefined is not an object (evaluating 'agent.variant')`).
-  //
-  // Strategy: POLL opencode's /agent endpoint until our slug is listed.
-  // If it's missing after a short wait, force a dispose (blocking flush)
-  // and poll again. ONLY then dispatch the prompt. This prevents both
-  // empty-session wakes AND mid-turn aborts from later stray disposes.
-  await ensureAgentCacheFresh(project.path, agent.slug)
 
   try {
     await client.session.promptAsync({
@@ -269,6 +267,11 @@ export async function wakeAgentForProject(opts: {
   const { db, client, projectId, agent, prompt, sessionTitle, bindSessionToProject } = opts
   const project = db.prepare('SELECT id,name,path FROM projects WHERE id=$id').get({ $id: projectId }) as { id: string; name: string; path: string } | null
   if (!project) return null
+
+  // Make the agent cache hot BEFORE minting a session — see comment on the
+  // matching call in fireAgentTrigger. dispose-after-create wipes our
+  // freshly-created session and the prompt vanishes silently.
+  await ensureAgentCacheFresh(project.path, agent.slug)
 
   let sessionId = agent.session_id
   if (!sessionId) {


### PR DESCRIPTION
…lumn defaults

ticket-triggers: call ensureAgentCacheFresh BEFORE session.create in both fireAgentTrigger and wakeAgentForProject. The cache helper POSTs /instance/dispose to flush stale opencode state, and dispose nukes every session in the directory — including a session we just minted. Symptom: session.create returned id X, dispose ran, promptAsync to X got 204'd silently (opencode no longer had X), and the agent stayed at msgs=0, ready_at=null forever. Cache-fresh first, then mint into a stable instance.

ticket-tools (project_columns_update): when PMs pass an unprefixed slug in default_assignee_id without setting default_assignee_type, auto-set type='agent' and resolve slug→id. Without this, updateStatus's column-default trigger guard (`type && id`) failed on null type and column auto-assign silently broke (QA never woke when tickets hit review).

local-docker (supervisor): probe `pgrep -f kortix-supervisor/src/index.ts` instead of `[ -S sock ]`. The socket file persists on disk after the supervisor process dies, so the old gate skipped restart and /file routes 500'd with "Was there a typo in the url or port?" Probe-then- remove-stale-socket-then-launch.

local-preview: 401-retry path reads container's bootstrap-env file as the source of truth and pushes the working key back into the DB + invalidates the provider cache. Survives `bun --hot` reloads that re-provision the sandbox with a fresh kortix_sb_ token while the browser still holds an old JWT.

billing: bypass deductCredits in local mode (KORTIX_BILLING_INTERNAL_ ENABLED off). $0 balances were stalling LLM dispatch with InsufficientCreditsError on every dev call.