### PR TITLE
fix(v2): close the 4th structure_version DEFAULT 1 path

### DIFF
--- a/core/kortix-master/src/services/ticket-service.ts
+++ b/core/kortix-master/src/services/ticket-service.ts
@@ -340,7 +340,15 @@ export function ensureTicketTables(db: Database): void {
     CREATE INDEX IF NOT EXISTS idx_project_credential_events_project ON project_credential_events(project_id);
     CREATE INDEX IF NOT EXISTS idx_project_credential_events_name ON project_credential_events(project_id, credential_name);
   `)
-  try { db.exec(`ALTER TABLE projects ADD COLUMN structure_version INTEGER NOT NULL DEFAULT 1`) } catch {}
+  // v2 is the new default. This ALTER is a fallback — it only runs if no
+  // earlier path (routes/projects.ts CREATE/ALTER) has added the column yet.
+  // ensureTicketTables fires from many routes (credentials, milestones,
+  // tickets) and routes/projects.ts isn't guaranteed to have run first; if
+  // this ALTER landed first with DEFAULT 1, every subsequent ALTER (with
+  // DEFAULT 2) silently no-ops and the schema-level default stays wrong.
+  // See commit 84a222059 ("bulletproof v2-default") which fixed three other
+  // paths but missed this one.
+  try { db.exec(`ALTER TABLE projects ADD COLUMN structure_version INTEGER NOT NULL DEFAULT 2`) } catch {}
   try { db.exec(`ALTER TABLE project_agents ADD COLUMN default_model TEXT`) } catch {}
   try { db.exec(`ALTER TABLE project_agents ADD COLUMN color_hue INTEGER`) } catch {}
   try { db.exec(`ALTER TABLE project_agents ADD COLUMN icon TEXT`) } catch {}


### PR DESCRIPTION
Commit 84a222059 ("bulletproof v2-default") fixed three schema/insert paths but missed services/ticket-service.ts:343 — ensureTicketTables() was still ALTERing in `structure_version INTEGER NOT NULL DEFAULT 1`.

ensureTicketTables fires from credentials/milestones/tickets routes, which use services/db.ts::getDb — a separate singleton from routes/projects.ts::getDb, both opening the same kortix.db file. If any of those routes run first on a fresh DB, this ALTER lands ahead of routes/projects.ts:81 (DEFAULT 2), locking the column default to 1 since the later ALTER silently no-ops via try/catch.