### PR TITLE
fix(v2): per-user opencode daemons need umask 0022 not 0027

### DIFF
--- a/core/kortix-supervisor/src/daemons.ts
+++ b/core/kortix-supervisor/src/daemons.ts
@@ -399,7 +399,14 @@ export class DaemonRegistry {
       [
         '/bin/sh',
         '-c',
-        `umask 0027; exec s6-setuidgid ${spec.username} ${OPENCODE_BIN} serve --port ${port} --hostname 127.0.0.1`,
+        // umask 0022 (not 0027) so files/dirs the daemon creates are
+        // world-readable. Per-user daemons run as separate Linux uids
+        // (k_<hash>); a project's owner-uid daemon writing with 0027
+        // produces 2750 dirs that other members' daemons can't lstat,
+        // every /agent lookup returns EACCES, dispatch silently halts.
+        // Project-level isolation is enforced by the supervisor's
+        // project_grant/revoke + group membership, not by file mode.
+        `umask 0022; exec s6-setuidgid ${spec.username} ${OPENCODE_BIN} serve --port ${port} --hostname 127.0.0.1`,
       ],
       {
         env,


### PR DESCRIPTION
When the supervisor spawns a per-user opencode daemon as k_<hash>:proj_proj-workspace with umask 0027, every dir/file the daemon creates lands as 2750 (group-rx, other-none). Each project member runs as a *different* uid, so member B's daemon can't lstat project files member A's daemon wrote — every GET /agent returns EACCES, dispatch hangs in a 250ms retry loop, assignments silently never fire.

0022 makes new artefacts world-readable on disk. Project-level isolation is enforced by the supervisor's project_grant/revoke + group membership, not by file mode bits, so this doesn't loosen the actual access model.