### PR TITLE
fix(v2): per-user daemons join docker + abc groups, drop project-grou…

### DIFF
--- a/core/kortix-supervisor/src/daemons.ts
+++ b/core/kortix-supervisor/src/daemons.ts
@@ -3,7 +3,6 @@ import { dirname } from 'path'
 import { execFileSync, execSync } from 'child_process'
 import { sysbin } from './sysbin'
 import type { DaemonSpec, DaemonInfo } from './schema'
-import { projectGroupName } from './projects'
 
 const PORT_BASE = 4097
 const UID_MIN = 10_000
@@ -164,31 +163,26 @@ export class DaemonRegistry {
     } catch {}
 
     this.ensureWriterGroup()
-    if (!this.userInGroup(spec.username, DB_WRITER_GROUP)) {
+    // Default groups every per-user daemon needs:
+    //   - kortix_db: DB writer access
+    //   - docker:   so `supabase start`, `docker compose`, etc. work without
+    //               root (the docker socket is srw-rw---- root:docker)
+    //   - abc:      sandbox-global resources owned by `abc` (workspace,
+    //               .opencode, .kortix, .secrets, etc.) — gives the daemon
+    //               full read/traverse without per-project group dances
+    // Project-specific groups (proj_<id>) used to be added per-member; that
+    // whole "team perms" model is dead weight now. Project files are
+    // world-readable via umask 0022 + initial sandbox chmod, isolation lives
+    // in supervisor's grant/revoke logic (not kernel mode bits).
+    for (const group of [DB_WRITER_GROUP, 'docker', 'abc']) {
+      if (!this.groupExists(group)) continue
+      if (this.userInGroup(spec.username, group)) continue
       try {
-        execFileSync(sysbin('gpasswd'), ['-a', spec.username, DB_WRITER_GROUP], { stdio: 'ignore' })
+        execFileSync(sysbin('gpasswd'), ['-a', spec.username, group], { stdio: 'ignore' })
       } catch (err) {
         console.warn(
-          `[supervisor] gpasswd -a ${spec.username} ${DB_WRITER_GROUP} failed: ${err instanceof Error ? err.message : err}`,
+          `[supervisor] gpasswd -a ${spec.username} ${group} failed: ${err instanceof Error ? err.message : err}`,
         )
-      }
-    }
-
-    for (const projectId of spec.project_ids ?? []) {
-      const group = projectGroupName(projectId)
-      if (!this.groupExists(group)) {
-        try {
-          execFileSync(sysbin('groupadd'), [group], { stdio: 'ignore' })
-        } catch {}
-      }
-      if (this.groupExists(group) && !this.userInGroup(spec.username, group)) {
-        try {
-          execFileSync(sysbin('gpasswd'), ['-a', spec.username, group], { stdio: 'ignore' })
-        } catch (err) {
-          console.warn(
-            `[supervisor] gpasswd -a ${spec.username} ${group} failed: ${err instanceof Error ? err.message : err}`,
-          )
-        }
       }
     }
   }


### PR DESCRIPTION
…p dance

Two changes that let per-user opencode daemons actually do work:

1. Add docker + abc to the default group list every k_<hash> account joins at daemon-spawn time. docker unlocks `supabase start`, `docker compose` and anything else that talks to /var/run/docker.sock (srw-rw---- root:docker). abc gives the daemon read+traverse on every sandbox-global path owned by abc — workspace, .opencode, .kortix, .secrets — without needing per-resource group dances.

2. Stop iterating spec.project_ids and adding the user to each proj_<id> group. With umask 0022 + initial sandbox chmod giving everything o+rX, the per-project Linux group system added zero security and one whole class of EACCES regressions (a project's .opencode/.kortix dirs landing 2750, every member's daemon except the creator's failing /agent lookups, dispatch silently stalling). Project-level access control already lives in the supervisor's grant/revoke RPCs, not in kernel mode bits.

Schema field DaemonSpec.project_ids is left in place for backward compat with kortix-master/services/supervisor-client.ts; it just isn't read anymore.