### PR TITLE
fix(api): suppress Bun fetch ConnectionRefused noise from Sentry

### DIFF
--- a/apps/api/src/__tests__/unit-local-preview-econnrefused.test.ts
+++ b/apps/api/src/__tests__/unit-local-preview-econnrefused.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Unit test for local-preview proxy connection error handling.
+ *
+ * Verifies that when Bun's fetch() throws "Unable to connect" (ECONNREFUSED),
+ * the proxy returns a proper 503 instead of propagating as an unhandled 500.
+ *
+ * Related: Betterstack incident #956953141
+ */
+import { describe, test, expect, beforeEach, afterEach, mock } from 'bun:test';
+
+// ─── Mock config ─────────────────────────────────────────────────────────────
+
+mock.module('../config', () => ({
+  config: {
+    isDaytonaEnabled: () => false,
+    isLocalDockerEnabled: () => true,
+    isJustAVPSEnabled: () => false,
+    SANDBOX_CONTAINER_NAME: 'kortix-sandbox',
+    SANDBOX_PORT_BASE: 3001,
+    SANDBOX_NETWORK: '',
+    INTERNAL_SERVICE_KEY: 'test-service-key',
+    DOCKER_HOST: '',
+    KORTIX_URL: '',
+    PORT: 8008,
+  },
+}));
+
+mock.module('../shared/db', () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: () => Promise.resolve([{
+            provider: 'local_docker',
+            baseUrl: 'http://localhost:3001',
+            config: { serviceKey: 'test-service-key' },
+            metadata: {},
+          }]),
+        }),
+      }),
+    }),
+    update: () => ({
+      set: () => ({
+        where: () => Promise.resolve(),
+      }),
+    }),
+  },
+}));
+
+mock.module('@kortix/db', () => ({
+  sandboxes: {
+    sandboxId: 'sandboxId',
+    externalId: 'externalId',
+    provider: 'provider',
+    baseUrl: 'baseUrl',
+    config: 'config',
+    metadata: 'metadata',
+    status: 'status',
+    accountId: 'accountId',
+  },
+}));
+
+mock.module('../middleware/auth', () => ({
+  combinedAuth: async (_c: any, next: any) => { await next(); },
+  supabaseAuth: async (_c: any, next: any) => { await next(); },
+  apiKeyAuth: async (_c: any, next: any) => { await next(); },
+}));
+
+mock.module('../shared/resolve-account', () => ({
+  resolveAccountId: async () => 'account-001',
+}));
+
+mock.module('../platform/providers/justavps', () => ({
+  isProxyTokenStale: () => false,
+  refreshSandboxProxyToken: async () => null,
+}));
+
+mock.module('../shared/preview-ownership', () => ({
+  canAccessPreviewSandbox: async () => true,
+  resolvePreviewUserContext: async () => null,
+}));
+
+mock.module('../shared/kortix-user-context', () => ({
+  encodeKortixUserContext: () => 'signed-token',
+  KORTIX_USER_CONTEXT_HEADER: 'X-Kortix-User-Context',
+}));
+
+mock.module('../platform/services/sandbox-auth', () => ({
+  buildCanonicalSandboxAuthCommand: () => 'echo auth',
+}));
+
+// ─── Import AFTER mocks ──────────────────────────────────────────────────────
+
+const { proxyToSandbox } = await import('../sandbox-proxy/routes/local-preview');
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe('proxyToSandbox: connection error handling', () => {
+  test('returns 503 when Bun throws "Unable to connect" (ECONNREFUSED)', async () => {
+    // Simulate Bun's ECONNREFUSED error message
+    globalThis.fetch = (() =>
+      Promise.reject(new Error('Unable to connect. Is the computer able to access the url?'))
+    ) as any;
+
+    const headers = new Headers({ host: 'localhost:8008' });
+    const response = await proxyToSandbox(
+      'kortix-sandbox',
+      8000,
+      'GET',
+      '/kortix/health',
+      '',
+      headers,
+      undefined,  // body
+      false,      // acceptsSSE
+      'http://localhost:3000',
+    );
+
+    expect(response.status).toBe(503);
+    const body = await response.json() as any;
+    expect(body.error).toBe(true);
+    expect(body.message).toContain('starting up');
+    expect(body.status).toBe(503);
+    // CORS should be set from origin
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe('http://localhost:3000');
+  });
+
+  test('returns 503 when fetch throws ECONNREFUSED (Node-style)', async () => {
+    globalThis.fetch = (() =>
+      Promise.reject(new Error('fetch failed: ECONNREFUSED 127.0.0.1:3001'))
+    ) as any;
+
+    const headers = new Headers({ host: 'localhost:8008' });
+    const response = await proxyToSandbox(
+      'kortix-sandbox',
+      8000,
+      'GET',
+      '/kortix/health',
+      '',
+      headers,
+      undefined,
+      false,
+      'http://localhost:3000',
+    );
+
+    expect(response.status).toBe(503);
+  });
+
+  test('returns 503 when fetch throws ECONNRESET', async () => {
+    globalThis.fetch = (() =>
+      Promise.reject(new Error('fetch failed: ECONNRESET'))
+    ) as any;
+
+    const headers = new Headers({ host: 'localhost:8008' });
+    const response = await proxyToSandbox(
+      'kortix-sandbox',
+      8000,
+      'GET',
+      '/kortix/health',
+      '',
+      headers,
+      undefined,
+      false,
+      '',
+    );
+
+    expect(response.status).toBe(503);
+  });
+
+  test('re-throws non-connection errors (e.g. AbortError)', async () => {
+    globalThis.fetch = (() =>
+      Promise.reject(new DOMException('The operation was aborted', 'AbortError'))
+    ) as any;
+
+    const headers = new Headers({ host: 'localhost:8008' });
+    await expect(
+      proxyToSandbox(
+        'kortix-sandbox',
+        8000,
+        'GET',
+        '/kortix/health',
+        '',
+        headers,
+        undefined,
+        false,
+        '',
+      )
+    ).rejects.toThrow();
+  });
+
+  test('returns upstream response normally when fetch succeeds', async () => {
+    globalThis.fetch = (() =>
+      Promise.resolve(new Response('{"status":"ok"}', {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }))
+    ) as any;
+
+    const headers = new Headers({ host: 'localhost:8008' });
+    const response = await proxyToSandbox(
+      'kortix-sandbox',
+      8000,
+      'GET',
+      '/kortix/health',
+      '',
+      headers,
+      undefined,
+      false,
+      '',
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.text();
+    expect(body).toBe('{"status":"ok"}');
+  });
+});

--- a/apps/api/src/lib/sentry.ts
+++ b/apps/api/src/lib/sentry.ts
@@ -38,6 +38,10 @@ if (SENTRY_DSN) {
       'ECONNRESET',
       'ETIMEDOUT',
       'UND_ERR_CONNECT_TIMEOUT',
+      // Bun-specific phrasing of ECONNREFUSED — surfaces when a sandbox port proxy
+      // hits a dead port (nothing listening on localhost:N). Expected, not actionable.
+      'Unable to connect',
+      'Is the computer able to access the url',
       // Client-side abort
       'AbortError',
       'The operation was aborted',

--- a/apps/api/src/sandbox-proxy/routes/local-preview.ts
+++ b/apps/api/src/sandbox-proxy/routes/local-preview.ts
@@ -253,15 +253,44 @@ export async function proxyToSandbox(
   const controller = new AbortController();
   const connectTimer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
 
-  const response = await fetch(targetUrl, {
-    method,
-    headers,
-    body: incomingBody,
-    signal: controller.signal,
-    // @ts-ignore — Bun extension: no decompression, raw byte passthrough
-    decompress: false,
-    redirect: 'manual',
-  });
+  let response: Response;
+  try {
+    response = await fetch(targetUrl, {
+      method,
+      headers,
+      body: incomingBody,
+      signal: controller.signal,
+      // @ts-ignore — Bun extension: no decompression, raw byte passthrough
+      decompress: false,
+      redirect: 'manual',
+    });
+  } catch (err: any) {
+    clearTimeout(connectTimer);
+    // Bun throws "Unable to connect. Is the computer able to access the url?"
+    // when the target port isn't listening (ECONNREFUSED). This is expected
+    // during sandbox startup — return a proper 503 instead of letting it
+    // propagate as an unhandled 500 + Sentry spike.
+    const msg = err?.message || String(err);
+    const isConnectionError =
+      msg.includes('Unable to connect') ||
+      msg.includes('ECONNREFUSED') ||
+      msg.includes('ECONNRESET') ||
+      msg.includes('Is the computer able to access the url');
+    if (isConnectionError) {
+      console.warn(`[PREVIEW] Sandbox ${sandboxId}:${port} not reachable on ${method} ${path}: ${msg}`);
+      const errHeaders = new Headers();
+      if (origin) {
+        errHeaders.set('Access-Control-Allow-Origin', origin);
+        errHeaders.set('Access-Control-Allow-Credentials', 'true');
+      }
+      return new Response(
+        JSON.stringify({ error: true, message: 'Sandbox is starting up. Please retry in a few seconds.', status: 503 }),
+        { status: 503, headers: errHeaders },
+      );
+    }
+    // Non-connection errors (abort, DNS, etc.) — re-throw to Hono error handler
+    throw err;
+  }
 
   // Headers received — clear the connection timeout.
   // The response body (potentially an SSE stream) continues flowing untouched.


### PR DESCRIPTION
## Summary

Fixes the root cause of Betterstack incident [#956953141](https://errors.betterstack.com/team/t502678/errors/6cd6a86c7b1b4653b94baa0edf023ffe47663570e2464261f746f98e60f71e68?s=2346961) — **Spike detected in Error from Kortix API (prod)**.

**Root cause:** `proxyToSandbox()` in `apps/api/src/sandbox-proxy/routes/local-preview.ts` did not catch connection errors from `fetch()`. When the sandbox port isn't listening yet, Bun throws `"Unable to connect. Is the computer able to access the url?"` (its ECONNREFUSED phrasing). This propagated to Hono's `app.onError` handler as a generic 500 + Sentry capture, causing the error spike of >70 exceptions.

**Previous fix** (commit `f787ac3`) only suppressed the error in Sentry's `ignoreErrors` filter — users still received 500 Internal Server Error responses.

## Changes

### Commit 1: `f787ac3` — Sentry ignoreErrors (belt-and-suspenders)
- Added Bun-specific ECONNREFUSED phrases to Sentry `ignoreErrors` filter

### Commit 2: `27f01e8` — Proper fix (root cause)
- **`apps/api/src/sandbox-proxy/routes/local-preview.ts`** — Wrap the primary `fetch()` in try/catch. Connection errors (`ECONNREFUSED`, `ECONNRESET`, Bun's "Unable to connect") now return a proper **503** with a descriptive message and CORS headers, instead of an unhandled 500. Non-connection errors (abort, DNS) are re-thrown to Hono's error handler.
- **`apps/api/src/__tests__/unit-local-preview-econnrefused.test.ts`** — New unit tests (5 cases) verifying 503 for all connection error variants, re-throw for non-connection errors, and normal passthrough.

## Verification

- Unit test: `bun test src/__tests__/unit-local-preview-econnrefused.test.ts` (5 test cases)
- Manual: proxy to sandbox with no listener on target port returns 503 (not 500)
- Sentry: `ignoreErrors` filter suppresses any residual connection errors from alerting

## Incident details

| Field | Value |
|-------|-------|
| **Incident** | #956953141 |
| **Application** | Kortix API (prod) |
| **Release** | kortix-api@0.8.44 |
| **Cause** | Unable to connect. Is the computer able to access the url? |
| **Started** | 2026-04-27T06:32:13.351Z |
| **Exceptions** | >70 |
| **Users affected** | >1 |
