### PR TITLE
feat(channels): project-scoped channels — pick a project, route to it…

### DIFF
--- a/apps/web/src/app/(dashboard)/projects/[id]/page.tsx
+++ b/apps/web/src/app/(dashboard)/projects/[id]/page.tsx
@@ -105,7 +105,7 @@ export default function ProjectPage({ params }: { params?: Promise<{ id: string 
   const [tab, setTabState] = useState<ProjectTab>('about');
   // Team/Credentials/Triggers live inside Settings now. If any caller passes
   // those legacy values, route to Settings and pre-select the matching section.
-  const [settingsSection, setSettingsSection] = useState<'team' | 'credentials' | 'triggers' | 'board'>('team');
+  const [settingsSection, setSettingsSection] = useState<'team' | 'credentials' | 'triggers' | 'channels' | 'board'>('team');
   const isProjectRouteActive = useIsRouteActive(`/projects/${encodeURIComponent(pid)}`);
 
   // ─── v1 state ──────────────────────────────────────────────────────────
@@ -204,7 +204,7 @@ export default function ProjectPage({ params }: { params?: Promise<{ id: string 
     // Legacy values from before the tab collapse — route them into Settings
     // with the matching section pre-selected so old bookmarks / links still
     // land on the right config pane.
-    if (next === 'team' || next === 'credentials' || next === 'triggers') {
+    if (next === 'team' || next === 'credentials' || next === 'triggers' || next === 'channels') {
       setSettingsSection(next);
       setTabState('settings');
       return;

--- a/apps/web/src/components/channels/channel-config-dialog.tsx
+++ b/apps/web/src/components/channels/channel-config-dialog.tsx
@@ -22,9 +22,11 @@ interface ChannelConfigDialogProps {
   onCreated: () => void;
   /** Pre-select a platform when opening (bypasses the picker) */
   initialPlatform?: 'telegram' | 'slack';
+  /** Pre-select a project for the new channel (e.g. from project-filtered view) */
+  initialProjectId?: string | null;
 }
 
-export function ChannelConfigDialog({ open, onOpenChange, onCreated, initialPlatform }: ChannelConfigDialogProps) {
+export function ChannelConfigDialog({ open, onOpenChange, onCreated, initialPlatform, initialProjectId = null }: ChannelConfigDialogProps) {
   const [platform, setPlatform] = useState<Platform>(initialPlatform ?? null);
 
   // Sync platform when dialog opens with a new initialPlatform
@@ -87,12 +89,20 @@ export function ChannelConfigDialog({ open, onOpenChange, onCreated, initialPlat
         ) : platform === 'telegram' ? (
           <>
             <VisuallyHidden><DialogTitle>Telegram Setup</DialogTitle></VisuallyHidden>
-            <TelegramSetupWizard onCreated={handleCreated} onBack={handleBack} />
+            <TelegramSetupWizard
+              onCreated={handleCreated}
+              onBack={handleBack}
+              initialProjectId={initialProjectId}
+            />
           </>
         ) : (
           <>
             <VisuallyHidden><DialogTitle>Slack Setup</DialogTitle></VisuallyHidden>
-            <SlackSetupWizard onCreated={handleCreated} onBack={handleBack} />
+            <SlackSetupWizard
+              onCreated={handleCreated}
+              onBack={handleBack}
+              initialProjectId={initialProjectId}
+            />
           </>
         )}
       </DialogContent>

--- a/apps/web/src/components/channels/channel-project-picker.tsx
+++ b/apps/web/src/components/channels/channel-project-picker.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import React from 'react';
+import { Loader2 } from 'lucide-react';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { useKortixProjects } from '@/hooks/kortix/use-kortix-projects';
+
+const WORKSPACE_OPTION = '__workspace__';
+
+interface ChannelProjectPickerProps {
+  /** Current project id, or null for workspace-scoped. */
+  value: string | null;
+  /** Called with the new project id (null = workspace). */
+  onChange: (projectId: string | null) => void;
+  className?: string;
+}
+
+/**
+ * Project selector for channels. The "Workspace" option means the channel
+ * is global (no project_id) and dispatches against opencode's workspace
+ * agent set (kortix, general, …). Picking a project scopes the dispatch
+ * to that project's working directory so per-project agents (engineer,
+ * qa, tech-lead, …) become discoverable.
+ */
+export function ChannelProjectPicker({ value, onChange, className }: ChannelProjectPickerProps) {
+  const { data: projects = [], isLoading } = useKortixProjects();
+
+  const visibleProjects = projects.filter((p) => p.id !== 'proj-workspace');
+
+  const handleChange = (next: string) => {
+    onChange(next === WORKSPACE_OPTION ? null : next);
+  };
+
+  return (
+    <Select value={value ?? WORKSPACE_OPTION} onValueChange={handleChange}>
+      <SelectTrigger className={className}>
+        <SelectValue>
+          {isLoading ? (
+            <span className="flex items-center gap-2 text-sm text-muted-foreground">
+              <Loader2 className="h-3 w-3 animate-spin" /> Loading projects…
+            </span>
+          ) : value ? (
+            visibleProjects.find((p) => p.id === value)?.name ?? value
+          ) : (
+            'Workspace (no project)'
+          )}
+        </SelectValue>
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value={WORKSPACE_OPTION}>
+          <div className="flex flex-col">
+            <span className="text-sm font-medium">Workspace</span>
+            <span className="text-[11px] text-muted-foreground">Global agents (kortix, general, …)</span>
+          </div>
+        </SelectItem>
+        {visibleProjects.map((p) => (
+          <SelectItem key={p.id} value={p.id}>
+            <div className="flex flex-col">
+              <span className="text-sm font-medium">{p.name}</span>
+              <span className="text-[11px] text-muted-foreground">{p.path}</span>
+            </div>
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/apps/web/src/components/channels/channels-page.tsx
+++ b/apps/web/src/components/channels/channels-page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useState, useCallback } from 'react';
+import React, { useEffect, useState, useCallback, useMemo } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -14,6 +14,7 @@ import {
   Settings,
   MessageSquare,
   ExternalLink,
+  FolderKanban,
 } from 'lucide-react';
 import { SpotlightCard } from '@/components/ui/spotlight-card';
 import { PageHeader } from '@/components/ui/page-header';
@@ -33,6 +34,7 @@ import {
 import { toast } from '@/lib/toast';
 import { useServerStore, getActiveOpenCodeUrl } from '@/stores/server-store';
 import { authenticatedFetch } from '@/lib/auth-token';
+import { useKortixProjects } from '@/hooks/kortix/use-kortix-projects';
 import { ChannelConfigDialog } from './channel-config-dialog';
 import { ChannelSettingsDialog } from './channel-settings-dialog';
 
@@ -47,6 +49,7 @@ interface Channel {
   default_agent: string;
   default_model: string;
   instructions?: string;
+  project_id?: string | null;
   webhook_path: string;
   webhook_url?: string | null;
   created_by: string | null;
@@ -100,12 +103,15 @@ async function detectChannelsFromEnv(): Promise<Channel[]> {
 function ChannelCard({
   channel,
   index,
+  projectName,
   onToggle,
   onRemove,
   onSettings,
 }: {
   channel: Channel;
   index: number;
+  /** Display name for channel.project_id, or null when workspace-scoped */
+  projectName: string | null;
   onToggle: (id: string, enabled: boolean) => void;
   onRemove: (id: string) => void;
   onSettings: (channel: Channel) => void;
@@ -130,7 +136,7 @@ function ChannelCard({
 
           {/* Info */}
           <div className="flex-1 min-w-0">
-            <div className="flex items-center gap-2 mb-0.5">
+            <div className="flex items-center gap-2 mb-0.5 flex-wrap">
               <h3 className="text-sm font-semibold text-foreground truncate">{channel.name}</h3>
               <Badge
                 variant={channel.enabled ? "highlight" : "secondary"}
@@ -138,6 +144,12 @@ function ChannelCard({
               >
                 {channel.enabled ? "Live" : "Off"}
               </Badge>
+              {channel.project_id && (
+                <Badge variant="secondary" className="text-[10px] shrink-0 inline-flex items-center gap-1">
+                  <FolderKanban className="h-2.5 w-2.5" />
+                  {projectName ?? channel.project_id}
+                </Badge>
+              )}
             </div>
             <p className="text-xs text-muted-foreground truncate">
               @{channel.bot_username || '?'}
@@ -171,6 +183,52 @@ function ChannelCard({
 
 // ─── Main ───────────────────────────────────────────────────────────────────
 
+/** Sentinel value used when "All projects" is selected. */
+const FILTER_ALL = '__all__';
+const FILTER_WORKSPACE = '__workspace__';
+
+/**
+ * Compact dropdown that drives both the channel list filter and the
+ * default project for new channels created from this view.
+ *
+ * Three states the user can pick:
+ *   • All        → show every channel (FILTER_ALL)
+ *   • Workspace  → only channels with no project (null)
+ *   • <project>  → only channels scoped to that project id
+ */
+function ChannelsProjectFilter({
+  value,
+  onChange,
+}: {
+  value: string | null | typeof FILTER_ALL;
+  onChange: (next: string | null | typeof FILTER_ALL) => void;
+}) {
+  const { data: projects = [] } = useKortixProjects();
+  const visibleProjects = projects.filter((p) => p.id !== 'proj-workspace');
+
+  const current = value === FILTER_ALL ? FILTER_ALL : value === null ? FILTER_WORKSPACE : value;
+
+  return (
+    <select
+      value={current}
+      onChange={(e) => {
+        const next = e.target.value;
+        if (next === FILTER_ALL) onChange(FILTER_ALL);
+        else if (next === FILTER_WORKSPACE) onChange(null);
+        else onChange(next);
+      }}
+      className="h-7 rounded-md border border-border/50 bg-card px-2 text-xs text-foreground hover:bg-muted/50 cursor-pointer focus:outline-none focus:ring-1 focus:ring-primary/30"
+      aria-label="Filter channels by project"
+    >
+      <option value={FILTER_ALL}>All projects</option>
+      <option value={FILTER_WORKSPACE}>Workspace (no project)</option>
+      {visibleProjects.map((p) => (
+        <option key={p.id} value={p.id}>{p.name}</option>
+      ))}
+    </select>
+  );
+}
+
 export function ChannelsPage() {
   const [channels, setChannels] = useState<Channel[]>([]);
   const [loading, setLoading] = useState(true);
@@ -181,8 +239,21 @@ export function ChannelsPage() {
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [removeTarget, setRemoveTarget] = useState<Channel | null>(null);
   const [removing, setRemoving] = useState(false);
+  // Project filter:
+  //   FILTER_ALL  → show every channel
+  //   null        → workspace-scoped channels only (channel.project_id IS NULL)
+  //   "<id>"      → channels scoped to this project
+  // Same value seeds `initialProjectId` on the setup wizard so a new channel
+  // inherits the current view.
+  const [projectFilter, setProjectFilter] = useState<string | null | typeof FILTER_ALL>(FILTER_ALL);
 
   const serverUrl = useServerStore((s) => s.getActiveServerUrl());
+  const { data: projects = [] } = useKortixProjects();
+  const projectNameById = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const p of projects) map.set(p.id, p.name);
+    return map;
+  }, [projects]);
 
   const load = useCallback(async () => {
     const data = await channelFetch('');
@@ -302,8 +373,20 @@ export function ChannelsPage() {
     setConfigDialogOpen(true);
   };
 
-  const telegramChannels = channels.filter(c => c.platform === 'telegram');
-  const slackChannels = channels.filter(c => c.platform === 'slack');
+  // Apply the project filter before splitting by platform.
+  const visibleChannels = useMemo(() => {
+    if (projectFilter === FILTER_ALL) return channels;
+    if (projectFilter === null) return channels.filter((c) => !c.project_id);
+    return channels.filter((c) => c.project_id === projectFilter);
+  }, [channels, projectFilter]);
+
+  const telegramChannels = visibleChannels.filter(c => c.platform === 'telegram');
+  const slackChannels = visibleChannels.filter(c => c.platform === 'slack');
+
+  // Seed value for the setup-wizard `initialProjectId`. When the user has
+  // narrowed to a specific project, new channels default to that project.
+  // FILTER_ALL = no preference → workspace-global by default.
+  const wizardInitialProjectId = projectFilter === FILTER_ALL ? null : projectFilter;
 
   return (
     <div className="min-h-[100dvh]">
@@ -322,9 +405,21 @@ export function ChannelsPage() {
         {/* Action bar */}
         {channels.length > 0 && (
           <div className="flex items-center justify-between gap-4 pb-4 animate-in fade-in-0 slide-in-from-bottom-4 duration-500 fill-mode-both delay-75">
-            <div className="flex items-center gap-2">
-              <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Your Channels</span>
-              <Badge variant="secondary" className="text-xs tabular-nums">{channels.length}</Badge>
+            <div className="flex items-center gap-3 flex-wrap">
+              <div className="flex items-center gap-2">
+                <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Your Channels</span>
+                <Badge variant="secondary" className="text-xs tabular-nums">{visibleChannels.length}</Badge>
+              </div>
+              {/*
+                Project filter — narrows the visible list and seeds the
+                "new channel" wizard with the same project so a workflow
+                like "open this project's view → add a Slack channel"
+                lands the channel scoped correctly without an extra step.
+              */}
+              <ChannelsProjectFilter
+                value={projectFilter}
+                onChange={setProjectFilter}
+              />
             </div>
             <div className="flex gap-2">
               <Button variant="ghost" size="sm" className="h-8 w-8 p-0" onClick={load}>
@@ -402,7 +497,15 @@ export function ChannelsPage() {
                 <div className="space-y-2">
                   <AnimatePresence mode="popLayout">
                     {telegramChannels.map((ch, i) => (
-                      <ChannelCard key={ch.id} channel={ch} index={i} onToggle={handleToggle} onRemove={handleRemove} onSettings={(ch) => { setSettingsChannel(ch); setSettingsOpen(true); }} />
+                      <ChannelCard
+                        key={ch.id}
+                        channel={ch}
+                        index={i}
+                        projectName={ch.project_id ? projectNameById.get(ch.project_id) ?? null : null}
+                        onToggle={handleToggle}
+                        onRemove={handleRemove}
+                        onSettings={(ch) => { setSettingsChannel(ch); setSettingsOpen(true); }}
+                      />
                     ))}
                   </AnimatePresence>
                 </div>
@@ -419,7 +522,15 @@ export function ChannelsPage() {
                 <div className="space-y-2">
                   <AnimatePresence mode="popLayout">
                     {slackChannels.map((ch, i) => (
-                      <ChannelCard key={ch.id} channel={ch} index={i} onToggle={handleToggle} onRemove={handleRemove} onSettings={(ch) => { setSettingsChannel(ch); setSettingsOpen(true); }} />
+                      <ChannelCard
+                        key={ch.id}
+                        channel={ch}
+                        index={i}
+                        projectName={ch.project_id ? projectNameById.get(ch.project_id) ?? null : null}
+                        onToggle={handleToggle}
+                        onRemove={handleRemove}
+                        onSettings={(ch) => { setSettingsChannel(ch); setSettingsOpen(true); }}
+                      />
                     ))}
                   </AnimatePresence>
                 </div>
@@ -434,6 +545,7 @@ export function ChannelsPage() {
         onOpenChange={setConfigDialogOpen}
         onCreated={() => load()}
         initialPlatform={configDialogPlatform}
+        initialProjectId={wizardInitialProjectId}
       />
 
       <ChannelSettingsDialog

--- a/apps/web/src/components/channels/slack-setup-wizard.tsx
+++ b/apps/web/src/components/channels/slack-setup-wizard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useId, useMemo, useState } from 'react';
+import React, { useId, useMemo, useState, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -22,10 +22,14 @@ import { authenticatedFetch } from '@/lib/auth-token';
 import { AgentSelector, flattenModels } from '@/components/session/session-chat-input';
 import { ModelSelector } from '@/components/session/model-selector';
 import { useVisibleAgents, useOpenCodeProviders } from '@/hooks/opencode/use-opencode-sessions';
+import { useKortixProjects } from '@/hooks/kortix/use-kortix-projects';
+import { ChannelProjectPicker } from './channel-project-picker';
 
 interface SlackSetupWizardProps {
   onCreated: () => void;
   onBack: () => void;
+  /** Pre-select a project (e.g. when launched from a project-filtered view) */
+  initialProjectId?: string | null;
 }
 
 const STEP_ANIMATION = {
@@ -47,10 +51,11 @@ function defaultBotName(seed: string): string {
   return `Kortix ${BOT_NAMES[hash % BOT_NAMES.length]}`;
 }
 
-export function SlackSetupWizard({ onCreated, onBack }: SlackSetupWizardProps) {
+export function SlackSetupWizard({ onCreated, onBack, initialProjectId = null }: SlackSetupWizardProps) {
   const botNameSeed = useId();
   const [step, setStep] = useState(1);
   const [botName, setBotName] = useState(() => defaultBotName(botNameSeed));
+  const [projectId, setProjectId] = useState<string | null>(initialProjectId);
   const [agentName, setAgentName] = useState<string | null>('kortix');
   const [selectedModel, setSelectedModel] = useState<{ providerID: string; modelID: string } | null>(null);
   const [manifest, setManifest] = useState<Record<string, unknown> | null>(null);
@@ -62,9 +67,22 @@ export function SlackSetupWizard({ onCreated, onBack }: SlackSetupWizardProps) {
   const [isGenerating, setIsGenerating] = useState(false);
 
   const slackConnect = useSlackConnect();
-  const agents = useVisibleAgents();
+  const { data: projects = [] } = useKortixProjects();
+  const projectDirectory = useMemo(
+    () => projects.find((p) => p.id === projectId)?.path,
+    [projects, projectId],
+  );
+  const agents = useVisibleAgents(projectDirectory ? { directory: projectDirectory } : undefined);
   const { data: providers, isLoading: modelsLoading } = useOpenCodeProviders();
   const models = useMemo(() => flattenModels(providers), [providers]);
+
+  // Reset agent if it isn't valid in the new project's scope.
+  useEffect(() => {
+    if (!agentName) return;
+    if (agents.length === 0) return;
+    const stillValid = agents.some((a) => a.name === agentName);
+    if (!stillValid) setAgentName('kortix');
+  }, [agents, agentName]);
 
   const handleGenerateManifest = async () => {
     setIsGenerating(true);
@@ -79,7 +97,7 @@ export function SlackSetupWizard({ onCreated, onBack }: SlackSetupWizardProps) {
       const res = await authenticatedFetch(`${baseUrl}/kortix/channels/slack-manifest`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ publicUrl: '', botName: botName.trim() || undefined }),
+        body: JSON.stringify({ publicUrl: '', botName: botName.trim() || undefined, projectId }),
       });
       const text = await res.text();
       let data: any;
@@ -143,6 +161,7 @@ export function SlackSetupWizard({ onCreated, onBack }: SlackSetupWizardProps) {
         channelId: manifestChannelId || undefined,
         defaultAgent: agentName || undefined,
         defaultModel: modelStr,
+        projectId,
       });
       const webhookUrl = result.channel?.webhookUrl;
       if (webhookUrl) {
@@ -217,6 +236,17 @@ export function SlackSetupWizard({ onCreated, onBack }: SlackSetupWizardProps) {
                 onChange={(e) => setBotName(e.target.value)}
               />
               <p className="text-[11px] text-muted-foreground">Display name in Slack.</p>
+            </div>
+
+            {/* Project */}
+            <div className="space-y-1.5">
+              <Label className="text-xs">Project</Label>
+              <ChannelProjectPicker value={projectId} onChange={setProjectId} className="bg-card" />
+              <p className="text-[11px] text-muted-foreground px-0.5">
+                {projectId
+                  ? 'Bot runs inside this project — agent pick is scoped to it.'
+                  : 'Workspace channel — uses the global agent set.'}
+              </p>
             </div>
 
             {/* Agent */}

--- a/apps/web/src/components/channels/telegram-setup-wizard.tsx
+++ b/apps/web/src/components/channels/telegram-setup-wizard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -17,24 +17,47 @@ import { useTelegramVerifyToken, useTelegramConnect } from '@/hooks/channels/use
 import { AgentSelector, flattenModels } from '@/components/session/session-chat-input';
 import { ModelSelector } from '@/components/session/model-selector';
 import { useVisibleAgents, useOpenCodeProviders } from '@/hooks/opencode/use-opencode-sessions';
+import { useKortixProjects } from '@/hooks/kortix/use-kortix-projects';
+import { ChannelProjectPicker } from './channel-project-picker';
 
 interface TelegramSetupWizardProps {
   onCreated: () => void;
   onBack: () => void;
+  /** Pre-select a project (e.g. when launched from a project-filtered view) */
+  initialProjectId?: string | null;
 }
 
-export function TelegramSetupWizard({ onCreated, onBack }: TelegramSetupWizardProps) {
+export function TelegramSetupWizard({ onCreated, onBack, initialProjectId = null }: TelegramSetupWizardProps) {
   const [botToken, setBotToken] = useState('');
   const [botInfo, setBotInfo] = useState<{ id: number; username: string; firstName: string } | null>(null);
+  const [projectId, setProjectId] = useState<string | null>(initialProjectId);
   const [agentName, setAgentName] = useState<string | null>('kortix');
   const [selectedModel, setSelectedModel] = useState<{ providerID: string; modelID: string } | null>(null);
 
   const verifyToken = useTelegramVerifyToken();
   const connect = useTelegramConnect();
 
-  const agents = useVisibleAgents();
+  // Project list — used to resolve the project's working directory so the
+  // agent picker shows that project's per-role agents (engineer, qa, …).
+  const { data: projects = [] } = useKortixProjects();
+  const projectDirectory = useMemo(
+    () => projects.find((p) => p.id === projectId)?.path,
+    [projects, projectId],
+  );
+
+  const agents = useVisibleAgents(projectDirectory ? { directory: projectDirectory } : undefined);
   const { data: providers, isLoading: modelsLoading } = useOpenCodeProviders();
   const models = useMemo(() => flattenModels(providers), [providers]);
+
+  // When the project changes, the available agent set changes — reset the
+  // picked agent if it isn't valid for the new scope so we never persist
+  // a stale slug. `kortix` is always present, so it's a safe default.
+  useEffect(() => {
+    if (!agentName) return;
+    if (agents.length === 0) return;
+    const stillValid = agents.some((a) => a.name === agentName);
+    if (!stillValid) setAgentName('kortix');
+  }, [agents, agentName]);
 
   const handleVerify = async () => {
     const trimmed = botToken.trim();
@@ -71,6 +94,7 @@ export function TelegramSetupWizard({ onCreated, onBack }: TelegramSetupWizardPr
         publicUrl: '',
         defaultAgent: agentName || undefined,
         defaultModel: modelStr,
+        projectId,
       });
       const webhookUrl = result.channel?.webhookUrl;
       if (webhookUrl) {
@@ -148,9 +172,19 @@ export function TelegramSetupWizard({ onCreated, onBack }: TelegramSetupWizardPr
           </div>
         )}
 
-        {/* Agent & Model — shown after token is verified */}
+        {/* Project & Agent & Model — shown after token is verified */}
         {botInfo && (
           <div className="space-y-3">
+            <div className="space-y-1.5">
+              <Label className="text-xs">Project</Label>
+              <ChannelProjectPicker value={projectId} onChange={setProjectId} className="bg-card" />
+              <p className="text-[11px] text-muted-foreground px-0.5">
+                {projectId
+                  ? 'Bot runs inside this project — agents pick is scoped to it.'
+                  : 'Workspace channel — uses the global agent set.'}
+              </p>
+            </div>
+
             <div className="space-y-1.5">
               <Label className="text-xs">Agent</Label>
               <div className="rounded-xl border bg-card px-2 py-1">

--- a/apps/web/src/components/kortix/channels-tab.tsx
+++ b/apps/web/src/components/kortix/channels-tab.tsx
@@ -1,0 +1,366 @@
+'use client';
+
+/**
+ * Project Channels tab — filtered view of /kortix/channels scoped to
+ * `project_id = <projectId>`. Mirrors TriggersTab in shape: same section
+ * lives on the workspace-global Channels page; this tab is just the
+ * narrowed slice plus an "Add" button that pre-stamps project_id so the
+ * new channel surfaces here on next load.
+ */
+
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/skeleton';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { TelegramIcon } from '@/components/ui/icons/telegram';
+import { SlackIcon } from '@/components/ui/icons/slack';
+import { Plus, Power, PowerOff, Settings, Trash2, Radio, MessageSquare } from 'lucide-react';
+import { toast } from '@/lib/toast';
+import { useServerStore } from '@/stores/server-store';
+import { authenticatedFetch } from '@/lib/auth-token';
+import { ChannelConfigDialog } from '@/components/channels/channel-config-dialog';
+import { ChannelSettingsDialog } from '@/components/channels/channel-settings-dialog';
+
+interface Channel {
+  id: string;
+  platform: 'telegram' | 'slack';
+  name: string;
+  enabled: boolean;
+  bot_username: string | null;
+  default_agent: string;
+  default_model: string;
+  instructions?: string;
+  project_id?: string | null;
+  webhook_path: string;
+  webhook_url?: string | null;
+  created_by: string | null;
+  created_at: string;
+}
+
+async function projectChannelsFetch(serverUrl: string, path: string, opts?: RequestInit): Promise<any> {
+  try {
+    const res = await authenticatedFetch(`${serverUrl}/kortix/channels${path}`, opts);
+    const text = await res.text();
+    let data: any = null;
+    try { data = JSON.parse(text); } catch { data = null; }
+    if (res.ok) return data;
+    return data || { ok: false, error: text || `Request failed (${res.status})` };
+  } catch (error: any) {
+    return { ok: false, error: error?.message || 'Request failed' };
+  }
+}
+
+export function ChannelsTab({ projectId }: { projectId: string }) {
+  const serverUrl = useServerStore((s) => s.getActiveServerUrl());
+  const [channels, setChannels] = useState<Channel[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [configOpen, setConfigOpen] = useState(false);
+  const [configPlatform, setConfigPlatform] = useState<'telegram' | 'slack' | undefined>(undefined);
+  const [settingsChannel, setSettingsChannel] = useState<Channel | null>(null);
+  const [settingsOpen, setSettingsOpen] = useState(false);
+  const [removeTarget, setRemoveTarget] = useState<Channel | null>(null);
+  const [removing, setRemoving] = useState(false);
+
+  const load = useCallback(async () => {
+    if (!serverUrl) return;
+    setLoading(true);
+    const data = await projectChannelsFetch(
+      serverUrl,
+      `?project_id=${encodeURIComponent(projectId)}`,
+    );
+    if (data?.ok && Array.isArray(data.channels)) {
+      setChannels(data.channels);
+    } else {
+      setChannels([]);
+    }
+    setLoading(false);
+  }, [serverUrl, projectId]);
+
+  useEffect(() => { void load(); }, [load]);
+
+  const handleToggle = async (id: string, enabled: boolean) => {
+    if (!serverUrl) return;
+    setChannels((prev) => prev.map((ch) => ch.id === id ? { ...ch, enabled } : ch));
+    const data = await projectChannelsFetch(serverUrl, `/${id}/${enabled ? 'enable' : 'disable'}`, { method: 'POST' });
+    if (!data?.ok) {
+      setChannels((prev) => prev.map((ch) => ch.id === id ? { ...ch, enabled: !enabled } : ch));
+      toast.error('Failed to update channel', { description: data?.error });
+    } else {
+      toast.success(enabled ? 'Channel enabled' : 'Channel disabled');
+    }
+  };
+
+  const handleRemoveConfirm = async () => {
+    if (!removeTarget || !serverUrl) return;
+    setRemoving(true);
+    const ch = removeTarget;
+    setChannels((prev) => prev.filter((c) => c.id !== ch.id));
+    const data = await projectChannelsFetch(serverUrl, `/${ch.id}`, { method: 'DELETE' });
+    setRemoving(false);
+    setRemoveTarget(null);
+    if (!data?.ok) {
+      toast.error('Failed to remove channel', { description: data?.error });
+      await load();
+      return;
+    }
+    toast.success('Channel removed');
+    if (settingsChannel?.id === ch.id) {
+      setSettingsOpen(false);
+      setSettingsChannel(null);
+    }
+    await load();
+  };
+
+  const telegram = useMemo(() => channels.filter((c) => c.platform === 'telegram'), [channels]);
+  const slack = useMemo(() => channels.filter((c) => c.platform === 'slack'), [channels]);
+
+  return (
+    <div className="h-full flex flex-col overflow-hidden">
+      {/* Header */}
+      <div className="shrink-0 border-b border-border/40 px-4 py-3 flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <Radio className="h-3.5 w-3.5 text-muted-foreground" />
+          <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Channels</span>
+          <Badge variant="secondary" className="text-[10px] tabular-nums">{channels.length}</Badge>
+        </div>
+        <Button
+          size="sm"
+          className="gap-1.5 h-7 text-[12px]"
+          onClick={() => { setConfigPlatform(undefined); setConfigOpen(true); }}
+          disabled={!serverUrl}
+        >
+          <Plus className="h-3 w-3" />
+          Add
+        </Button>
+      </div>
+
+      <div className="flex-1 min-h-0 overflow-y-auto px-4 py-3">
+        {loading ? (
+          <div className="space-y-2">
+            {[0, 1].map((i) => (
+              <div key={i} className="rounded-xl border bg-card p-3 flex items-center gap-3">
+                <Skeleton className="h-9 w-9 rounded-lg" />
+                <div className="flex-1 space-y-2">
+                  <Skeleton className="h-3 w-32" />
+                  <Skeleton className="h-2.5 w-48" />
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : channels.length === 0 ? (
+          <EmptyState
+            onAdd={(p) => { setConfigPlatform(p); setConfigOpen(true); }}
+          />
+        ) : (
+          <div className="space-y-4">
+            {telegram.length > 0 && (
+              <ChannelGroup
+                title="Telegram"
+                Icon={TelegramIcon}
+                channels={telegram}
+                onToggle={handleToggle}
+                onRemove={(c) => setRemoveTarget(c)}
+                onSettings={(c) => { setSettingsChannel(c); setSettingsOpen(true); }}
+              />
+            )}
+            {slack.length > 0 && (
+              <ChannelGroup
+                title="Slack"
+                Icon={SlackIcon}
+                channels={slack}
+                onToggle={handleToggle}
+                onRemove={(c) => setRemoveTarget(c)}
+                onSettings={(c) => { setSettingsChannel(c); setSettingsOpen(true); }}
+              />
+            )}
+          </div>
+        )}
+      </div>
+
+      <ChannelConfigDialog
+        open={configOpen}
+        onOpenChange={setConfigOpen}
+        onCreated={() => { void load(); }}
+        initialPlatform={configPlatform}
+        initialProjectId={projectId}
+      />
+
+      <ChannelSettingsDialog
+        channel={settingsChannel}
+        open={settingsOpen}
+        onOpenChange={setSettingsOpen}
+        onUpdated={load}
+      />
+
+      <AlertDialog open={Boolean(removeTarget)} onOpenChange={(open) => { if (!open && !removing) setRemoveTarget(null); }}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Remove channel?</AlertDialogTitle>
+            <AlertDialogDescription>
+              {removeTarget
+                ? `This disconnects ${removeTarget.name} from this project.`
+                : 'This disconnects the selected channel.'}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={removing}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              disabled={removing}
+              onClick={(e) => { e.preventDefault(); void handleRemoveConfirm(); }}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {removing ? 'Removing…' : 'Remove channel'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}
+
+// ─── Sub-components ─────────────────────────────────────────────────────────
+
+function ChannelGroup({
+  title,
+  Icon,
+  channels,
+  onToggle,
+  onRemove,
+  onSettings,
+}: {
+  title: string;
+  Icon: React.ComponentType<{ className?: string }>;
+  channels: Channel[];
+  onToggle: (id: string, enabled: boolean) => void;
+  onRemove: (ch: Channel) => void;
+  onSettings: (ch: Channel) => void;
+}) {
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-center gap-2 px-1">
+        <Icon className="h-3 w-3 text-muted-foreground" />
+        <span className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">{title}</span>
+        <Badge variant="secondary" className="text-[10px] tabular-nums">{channels.length}</Badge>
+      </div>
+      <div className="space-y-2">
+        <AnimatePresence mode="popLayout">
+          {channels.map((ch) => (
+            <motion.div
+              key={ch.id}
+              layout
+              initial={{ opacity: 0, y: 6 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, scale: 0.96 }}
+              transition={{ duration: 0.15 }}
+            >
+              <ChannelRow ch={ch} Icon={Icon} onToggle={onToggle} onRemove={onRemove} onSettings={onSettings} />
+            </motion.div>
+          ))}
+        </AnimatePresence>
+      </div>
+    </div>
+  );
+}
+
+function ChannelRow({
+  ch,
+  Icon,
+  onToggle,
+  onRemove,
+  onSettings,
+}: {
+  ch: Channel;
+  Icon: React.ComponentType<{ className?: string }>;
+  onToggle: (id: string, enabled: boolean) => void;
+  onRemove: (ch: Channel) => void;
+  onSettings: (ch: Channel) => void;
+}) {
+  const modelShort = ch.default_model ? ch.default_model.split('/').pop() : null;
+  return (
+    <div
+      className="rounded-xl border border-border/50 bg-card p-3 flex items-start gap-3 cursor-pointer hover:bg-muted/30 transition-colors group"
+      onClick={() => onSettings(ch)}
+    >
+      <div className="flex items-center justify-center w-9 h-9 rounded-lg bg-muted border border-border/50 shrink-0">
+        <Icon className="h-4 w-4 text-foreground" />
+      </div>
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2 mb-0.5 flex-wrap">
+          <h4 className="text-sm font-semibold text-foreground truncate">{ch.name}</h4>
+          <Badge variant={ch.enabled ? 'highlight' : 'secondary'} className="text-[10px] shrink-0">
+            {ch.enabled ? 'Live' : 'Off'}
+          </Badge>
+        </div>
+        <p className="text-[11px] text-muted-foreground truncate">
+          @{ch.bot_username || '?'}
+          {modelShort ? ` · ${modelShort}` : ''}
+          {ch.default_agent && ch.default_agent !== 'kortix' ? ` · ${ch.default_agent}` : ''}
+        </p>
+      </div>
+      <div className="flex items-center gap-0.5 shrink-0" onClick={(e) => e.stopPropagation()}>
+        <Button variant="ghost" size="sm" className="h-7 w-7 p-0 opacity-0 group-hover:opacity-100 transition-opacity" onClick={() => onSettings(ch)}>
+          <Settings className="h-3 w-3" />
+        </Button>
+        <Button variant="ghost" size="sm" className="h-7 w-7 p-0" onClick={() => onToggle(ch.id, !ch.enabled)}>
+          {ch.enabled ? <PowerOff className="h-3 w-3" /> : <Power className="h-3 w-3" />}
+        </Button>
+        <Button variant="ghost" size="sm" className="h-7 w-7 p-0 text-muted-foreground hover:text-destructive" onClick={() => onRemove(ch)}>
+          <Trash2 className="h-3 w-3" />
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function EmptyState({ onAdd }: { onAdd: (platform: 'telegram' | 'slack') => void }) {
+  return (
+    <div className="space-y-3 py-4">
+      <div className="text-center py-4">
+        <div className="w-10 h-10 rounded-xl bg-muted border flex items-center justify-center mx-auto mb-2">
+          <MessageSquare className="h-5 w-5 text-muted-foreground" />
+        </div>
+        <h4 className="text-sm font-semibold mb-0.5">No channels in this project</h4>
+        <p className="text-[12px] text-muted-foreground max-w-sm mx-auto">
+          Connect Telegram or Slack — messages will dispatch to this project's agents.
+        </p>
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 max-w-md mx-auto">
+        <button
+          onClick={() => onAdd('telegram')}
+          className="flex items-center gap-3 p-3 rounded-xl border border-border/50 bg-card hover:bg-muted/50 transition-colors cursor-pointer text-left group"
+        >
+          <div className="w-8 h-8 rounded-lg bg-muted border border-border/50 flex items-center justify-center shrink-0 group-hover:border-primary/30 transition-colors">
+            <TelegramIcon className="h-4 w-4 text-foreground" />
+          </div>
+          <div>
+            <p className="text-[13px] font-medium">Telegram</p>
+            <p className="text-[11px] text-muted-foreground">Connect a Telegram bot</p>
+          </div>
+        </button>
+        <button
+          onClick={() => onAdd('slack')}
+          className="flex items-center gap-3 p-3 rounded-xl border border-border/50 bg-card hover:bg-muted/50 transition-colors cursor-pointer text-left group"
+        >
+          <div className="w-8 h-8 rounded-lg bg-muted border border-border/50 flex items-center justify-center shrink-0 group-hover:border-primary/30 transition-colors">
+            <SlackIcon className="h-4 w-4 text-foreground" />
+          </div>
+          <div>
+            <p className="text-[13px] font-medium">Slack</p>
+            <p className="text-[11px] text-muted-foreground">Connect a Slack app</p>
+          </div>
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/kortix/project-header.tsx
+++ b/apps/web/src/components/kortix/project-header.tsx
@@ -20,6 +20,7 @@ export type ProjectTab =
   | 'team'        // v2 (legacy — folded into Settings)
   | 'credentials' // v2 (legacy — folded into Settings)
   | 'triggers'    // v2 (legacy — folded into Settings)
+  | 'channels'    // v2 (legacy — folded into Settings)
   | 'settings'    // v2
   | 'files'
   | 'sessions'

--- a/apps/web/src/components/kortix/project-settings-tab.tsx
+++ b/apps/web/src/components/kortix/project-settings-tab.tsx
@@ -15,14 +15,15 @@
  */
 
 import { type ComponentType } from 'react';
-import { Users, KeyRound, Zap, LayoutGrid } from 'lucide-react';
+import { Users, KeyRound, Zap, LayoutGrid, Radio } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { TeamTab } from './team-tab';
 import { CredentialsTab } from './credentials-tab';
 import { TriggersTab } from './triggers-tab';
+import { ChannelsTab } from './channels-tab';
 import { TicketSettingsTab } from './ticket-settings-tab';
 
-export type SettingsSection = 'team' | 'credentials' | 'triggers' | 'board';
+export type SettingsSection = 'team' | 'credentials' | 'triggers' | 'channels' | 'board';
 
 /**
  * Controlled component: parent owns the section state so it survives
@@ -51,6 +52,7 @@ export function ProjectSettingsTab({
           <SectionPill active={section === 'team'} onClick={() => setSection('team')} icon={Users} label="Team" />
           <SectionPill active={section === 'credentials'} onClick={() => setSection('credentials')} icon={KeyRound} label="Credentials" />
           <SectionPill active={section === 'triggers'} onClick={() => setSection('triggers')} icon={Zap} label="Triggers" />
+          <SectionPill active={section === 'channels'} onClick={() => setSection('channels')} icon={Radio} label="Channels" />
           <SectionPill active={section === 'board'} onClick={() => setSection('board')} icon={LayoutGrid} label="Board" />
         </div>
       </div>
@@ -61,6 +63,7 @@ export function ProjectSettingsTab({
         {section === 'triggers' && (
           <TriggersTab projectId={projectId} projectPath={projectPath ?? ''} />
         )}
+        {section === 'channels' && <ChannelsTab projectId={projectId} />}
         {section === 'board' && <TicketSettingsTab projectId={projectId} />}
       </div>
     </div>

--- a/apps/web/src/hooks/channels/use-slack-wizard.ts
+++ b/apps/web/src/hooks/channels/use-slack-wizard.ts
@@ -4,7 +4,7 @@ import { getActiveOpenCodeUrl } from '@/stores/server-store';
 
 export function useSlackConnect() {
   return useMutation({
-    mutationFn: async ({ botToken, signingSecret, publicUrl, name, createdBy, channelId, defaultAgent, defaultModel }: {
+    mutationFn: async ({ botToken, signingSecret, publicUrl, name, createdBy, channelId, defaultAgent, defaultModel, projectId }: {
       botToken: string;
       signingSecret?: string;
       publicUrl?: string;
@@ -13,13 +13,14 @@ export function useSlackConnect() {
       channelId?: string;
       defaultAgent?: string;
       defaultModel?: string;
+      projectId?: string | null;
     }) => {
       const baseUrl = getActiveOpenCodeUrl();
       if (!baseUrl) throw new Error('No active instance');
       const res = await authenticatedFetch(`${baseUrl}/kortix/channels/setup/slack`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ botToken, signingSecret, publicUrl, name, createdBy, channelId, defaultAgent, defaultModel }),
+        body: JSON.stringify({ botToken, signingSecret, publicUrl, name, createdBy, channelId, defaultAgent, defaultModel, projectId }),
       });
       const text = await res.text();
       let data: any;

--- a/apps/web/src/hooks/channels/use-telegram-wizard.ts
+++ b/apps/web/src/hooks/channels/use-telegram-wizard.ts
@@ -45,12 +45,13 @@ export function useTelegramVerifyToken() {
 export function useTelegramConnect() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async ({ botToken, publicUrl, createdBy, defaultAgent, defaultModel }: {
+    mutationFn: async ({ botToken, publicUrl, createdBy, defaultAgent, defaultModel, projectId }: {
       botToken: string;
       publicUrl: string;
       createdBy?: string;
       defaultAgent?: string;
       defaultModel?: string;
+      projectId?: string | null;
     }) => {
       const baseUrl = getActiveOpenCodeUrl();
       if (!baseUrl) throw new Error('No active instance');
@@ -59,7 +60,7 @@ export function useTelegramConnect() {
       const res = await authenticatedFetch(`${baseUrl}/kortix/channels/setup/telegram`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ botToken, publicUrl, createdBy, defaultAgent, defaultModel }),
+        body: JSON.stringify({ botToken, publicUrl, createdBy, defaultAgent, defaultModel, projectId }),
       });
       const text = await res.text();
       let data: any;

--- a/apps/web/src/hooks/opencode/use-visible-agents.ts
+++ b/apps/web/src/hooks/opencode/use-visible-agents.ts
@@ -7,9 +7,13 @@ import { useOpenCodeAgents } from './use-opencode-sessions';
 /**
  * Returns only visible agents (non-hidden, non-subagent).
  * Use this for agent selectors in UI where users pick which agent to use.
+ *
+ * Pass `directory` to scope to a project — opencode then includes
+ * `<directory>/.opencode/agent/*.md` (e.g. project-manager, engineer,
+ * qa) on top of the global set.
  */
-export function useVisibleAgents(): Agent[] {
-  const { data: agents = [] } = useOpenCodeAgents();
+export function useVisibleAgents(options?: { directory?: string }): Agent[] {
+  const { data: agents = [] } = useOpenCodeAgents(options);
   return useMemo(
     () => agents.filter((a) => !a.hidden && a.mode !== 'subagent'),
     [agents]
@@ -20,8 +24,8 @@ export function useVisibleAgents(): Agent[] {
  * Returns all visible agents including subagents.
  * Use this when you need to show subagents too (e.g., advanced mode).
  */
-export function useAllVisibleAgents(): Agent[] {
-  const { data: agents = [] } = useOpenCodeAgents();
+export function useAllVisibleAgents(options?: { directory?: string }): Agent[] {
+  const { data: agents = [] } = useOpenCodeAgents(options);
   return useMemo(
     () => agents.filter((a) => !a.hidden),
     [agents]

--- a/core/kortix-master/channels/channel-db.ts
+++ b/core/kortix-master/channels/channel-db.ts
@@ -59,6 +59,7 @@ export function getDb(): Database {
       default_model TEXT DEFAULT '',
       bridge_instructions TEXT,
       instructions TEXT,
+      project_id TEXT,
       created_by TEXT,
       created_at TEXT NOT NULL,
       updated_at TEXT NOT NULL
@@ -110,6 +111,9 @@ export function getDb(): Database {
     if (!columns.some((column) => column.name === 'bridge_instructions')) {
       _db.exec(`ALTER TABLE channels ADD COLUMN bridge_instructions TEXT`)
     }
+    if (!columns.some((column) => column.name === 'project_id')) {
+      _db.exec(`ALTER TABLE channels ADD COLUMN project_id TEXT`)
+    }
   } catch {}
 
   return _db
@@ -132,6 +136,13 @@ export interface ChannelConfig {
   default_model: string
   bridge_instructions: string | null
   instructions: string | null
+  /**
+   * Optional project the channel is scoped to. When set, dispatch loads
+   * the project's `.opencode/agent/` tree (so per-project agent slugs like
+   * `engineer`, `qa`, `tech-lead` resolve), and the conversation runs
+   * inside that project's working directory. NULL = workspace-global.
+   */
+  project_id: string | null
   created_by: string | null
   created_at: string
   updated_at: string
@@ -174,6 +185,7 @@ export function createChannel(opts: {
   default_model?: string
   bridge_instructions?: string
   instructions?: string
+  project_id?: string | null
   created_by?: string
   enabled?: boolean
 }): ChannelConfig {
@@ -190,14 +202,14 @@ export function createChannel(opts: {
 
   db.prepare(`
     INSERT INTO channels (id, platform, name, enabled, bot_token, signing_secret, webhook_secret, webhook_path,
-      bot_id, bot_username, default_agent, default_model, bridge_instructions, instructions, created_by, created_at, updated_at)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      bot_id, bot_username, default_agent, default_model, bridge_instructions, instructions, project_id, created_by, created_at, updated_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `).run(
     id, opts.platform, name, enabled, opts.bot_token, opts.signing_secret || null,
     webhookSecret, webhookPath,
     opts.bot_id || null, opts.bot_username || null,
     opts.default_agent || "kortix", opts.default_model || "", opts.bridge_instructions || null,
-    opts.instructions || null, opts.created_by || null, now, now,
+    opts.instructions || null, opts.project_id || null, opts.created_by || null, now, now,
   )
 
   return getChannel(id)!
@@ -239,6 +251,7 @@ export function upsertChannelByBot(opts: {
   default_agent?: string
   default_model?: string
   instructions?: string
+  project_id?: string | null
   created_by?: string
 }): { channel: ChannelConfig; created: boolean; deduped: number } {
   const botId = opts.bot_id || ""
@@ -259,6 +272,7 @@ export function upsertChannelByBot(opts: {
     instructions: opts.instructions ?? keeper.instructions ?? undefined,
     bot_id: opts.bot_id ?? keeper.bot_id ?? undefined,
     bot_username: opts.bot_username ?? keeper.bot_username ?? undefined,
+    project_id: opts.project_id !== undefined ? opts.project_id : keeper.project_id,
   })!
 
   let deduped = 0
@@ -269,19 +283,31 @@ export function upsertChannelByBot(opts: {
   return { channel: updated, created: false, deduped }
 }
 
-export function listChannels(platform?: string): ChannelConfig[] {
+export function listChannels(filter?: { platform?: string; project_id?: string | null }): ChannelConfig[] {
   const db = getDb()
-  let rows: any[]
-  if (platform) {
-    rows = db.query("SELECT * FROM channels WHERE platform = ? ORDER BY created_at DESC").all(platform) as any[]
-  } else {
-    rows = db.query("SELECT * FROM channels ORDER BY created_at DESC").all() as any[]
+  const where: string[] = []
+  const params: any[] = []
+  if (filter?.platform) {
+    where.push("platform = ?")
+    params.push(filter.platform)
   }
+  if (filter?.project_id !== undefined) {
+    if (filter.project_id === null) {
+      where.push("project_id IS NULL")
+    } else {
+      where.push("project_id = ?")
+      params.push(filter.project_id)
+    }
+  }
+  const sql = where.length === 0
+    ? "SELECT * FROM channels ORDER BY created_at DESC"
+    : `SELECT * FROM channels WHERE ${where.join(" AND ")} ORDER BY created_at DESC`
+  const rows = db.query(sql).all(...params) as any[]
   return rows.map(r => ({ ...r, enabled: !!r.enabled }))
 }
 
 export function updateChannel(id: string, updates: Partial<Pick<ChannelConfig,
-  "name" | "enabled" | "bot_token" | "signing_secret" | "default_agent" | "default_model" | "bridge_instructions" | "instructions" | "bot_id" | "bot_username"
+  "name" | "enabled" | "bot_token" | "signing_secret" | "default_agent" | "default_model" | "bridge_instructions" | "instructions" | "bot_id" | "bot_username" | "project_id"
 >>): ChannelConfig | null {
   const db = getDb()
   const existing = getChannel(id)

--- a/core/kortix-master/channels/kchannel.ts
+++ b/core/kortix-master/channels/kchannel.ts
@@ -60,7 +60,7 @@ async function main(): Promise<void> {
 
   switch (command) {
     case "list": case "ls": {
-      const channels = listChannels(flags.platform)
+      const channels = listChannels(flags.platform ? { platform: flags.platform } : undefined)
       if (!channels.length) { out({ ok: true, channels: [], message: "No channels configured" }); break }
       out({ ok: true, channels: channels.map(formatChannel) })
       break

--- a/core/kortix-master/src/routes/channel-webhooks.ts
+++ b/core/kortix-master/src/routes/channel-webhooks.ts
@@ -246,6 +246,34 @@ async function handleChannelCommand(
 
 // ── Dispatch to OpenCode ────────────────────────────────────────────────────
 
+/**
+ * If the channel is scoped to a project, resolve the project's working
+ * directory so opencode loads its `.opencode/agent/` tree. Without this,
+ * a `default_agent` like `engineer` / `qa` (which only exist as project
+ * agents) silently falls back to the global agent set and the wrong
+ * persona answers.
+ *
+ * Workspace-global channels (no project_id) return undefined → opencode
+ * uses the global agent registry, same as before.
+ */
+async function resolveChannelDirectory(channel: ChannelConfig): Promise<string | undefined> {
+  if (!channel.project_id) return undefined
+  try {
+    const { Database } = await import('bun:sqlite')
+    const path = await import('path')
+    const dbPath = path.join(process.env.KORTIX_WORKSPACE || '/workspace', '.kortix', 'kortix.db')
+    const db = new Database(dbPath, { readonly: true })
+    try {
+      const row = db.prepare('SELECT path FROM projects WHERE id = ?').get(channel.project_id) as { path?: string } | undefined
+      return row?.path || undefined
+    } finally {
+      try { db.close() } catch {}
+    }
+  } catch {
+    return undefined
+  }
+}
+
 async function dispatchToOpenCode(
   channel: ChannelConfig,
   event: NormalizedChannelEvent,
@@ -262,10 +290,16 @@ async function dispatchToOpenCode(
       })()
     : undefined
 
+  // Project scope — directory passed as a query param so opencode loads
+  // <directory>/.opencode/agent/* and the channel's default_agent slug
+  // resolves against it.
+  const directory = await resolveChannelDirectory(channel)
+  const dirQuery = directory ? `?directory=${encodeURIComponent(directory)}` : ''
+
   // Reuse existing session — always send to the same session for continuity
   if (existingSessionId) {
     try {
-      const res = await fetch(`${OPENCODE_URL}/session/${existingSessionId}/prompt_async`, {
+      const res = await fetch(`${OPENCODE_URL}/session/${existingSessionId}/prompt_async${dirQuery}`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -286,8 +320,9 @@ async function dispatchToOpenCode(
     }
   }
 
-  // Create new session
-  const createRes = await fetch(`${OPENCODE_URL}/session`, {
+  // Create new session — pass directory as a query so the new session is
+  // bound to the project's opencode project record (not the workspace root).
+  const createRes = await fetch(`${OPENCODE_URL}/session${dirQuery}`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
@@ -302,7 +337,7 @@ async function dispatchToOpenCode(
   const session = await createRes.json() as { id: string }
 
   // Send the prompt
-  const promptRes = await fetch(`${OPENCODE_URL}/session/${session.id}/prompt_async`, {
+  const promptRes = await fetch(`${OPENCODE_URL}/session/${session.id}/prompt_async${dirQuery}`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({

--- a/core/kortix-master/src/routes/channels.ts
+++ b/core/kortix-master/src/routes/channels.ts
@@ -51,7 +51,14 @@ channelsRouter.get('/', async (c) => {
   try {
     const { listChannels } = await loadDb()
     const platform = c.req.query('platform')
-    const channels = listChannels(platform || undefined)
+    // ?project_id=<id> filters to that project. ?project_id=__none__ returns
+    // workspace-global channels only. Omit to return everything.
+    const projectIdQ = c.req.query('project_id')
+    const filter: { platform?: string; project_id?: string | null } = {}
+    if (platform) filter.platform = platform
+    if (projectIdQ === '__none__') filter.project_id = null
+    else if (projectIdQ) filter.project_id = projectIdQ
+    const channels = listChannels(Object.keys(filter).length ? filter : undefined)
     const publicBase = getChannelPublicBaseUrl()
     return c.json({
       ok: true,
@@ -65,6 +72,7 @@ channelsRouter.get('/', async (c) => {
         default_model: ch.default_model,
         bridge_instructions: ch.bridge_instructions || '',
         instructions: ch.instructions || '',
+        project_id: ch.project_id,
         webhook_path: ch.webhook_path,
         webhook_url: publicBase ? joinPublicBaseUrl(publicBase, ch.webhook_path) : null,
         created_by: ch.created_by,
@@ -99,7 +107,7 @@ channelsRouter.post('/verify-telegram', async (c) => {
 
 channelsRouter.post('/setup/telegram', async (c) => {
   try {
-    const { botToken, publicUrl, createdBy, defaultAgent, defaultModel } = await c.req.json()
+    const { botToken, publicUrl, createdBy, defaultAgent, defaultModel, projectId } = await c.req.json()
     if (!botToken) return c.json({ ok: false, error: 'botToken required' }, 400)
 
     // 1. Verify token via Telegram getMe
@@ -122,6 +130,7 @@ channelsRouter.post('/setup/telegram', async (c) => {
       created_by: createdBy,
       default_agent: defaultAgent || undefined,
       default_model: defaultModel || undefined,
+      project_id: typeof projectId === 'string' && projectId ? projectId : (projectId === null ? null : undefined),
     })
 
     // 3. Register default Telegram bot commands so the slash menu works immediately
@@ -250,7 +259,7 @@ function buildSlackManifest(displayName: string, webhookUrl: string) {
 
 channelsRouter.post('/slack-manifest', async (c) => {
   try {
-    const { publicUrl, botName } = await c.req.json()
+    const { publicUrl, botName, projectId } = await c.req.json()
     const resolvedUrl = publicUrl || getChannelPublicBaseUrl() || ''
     if (!resolvedUrl) return c.json({ ok: false, error: 'Could not resolve public URL. Set PUBLIC_BASE_URL or provide publicUrl.' }, 400)
 
@@ -262,6 +271,7 @@ channelsRouter.post('/slack-manifest', async (c) => {
       platform: 'slack',
       name: displayName,
       bot_token: '',
+      project_id: typeof projectId === 'string' && projectId ? projectId : null,
       enabled: false, // disabled until /setup/slack provides real credentials
     })
 
@@ -276,7 +286,7 @@ channelsRouter.post('/slack-manifest', async (c) => {
 
 channelsRouter.post('/setup/slack', async (c) => {
   try {
-    const { botToken, signingSecret, publicUrl, name, createdBy, channelId, defaultAgent, defaultModel } = await c.req.json()
+    const { botToken, signingSecret, publicUrl, name, createdBy, channelId, defaultAgent, defaultModel, projectId } = await c.req.json()
     if (!botToken) return c.json({ ok: false, error: 'botToken required' }, 400)
 
     // 1. Verify token
@@ -305,6 +315,9 @@ channelsRouter.post('/setup/slack', async (c) => {
           name: name || existing.name,
           default_agent: defaultAgent || existing.default_agent,
           default_model: defaultModel || existing.default_model,
+          project_id: typeof projectId === 'string' && projectId
+            ? projectId
+            : (projectId === null ? null : existing.project_id),
           enabled: true,
         })!
       }
@@ -317,6 +330,7 @@ channelsRouter.post('/setup/slack', async (c) => {
         signing_secret: signingSecret,
         bot_id: authData.user_id,
         bot_username: authData.user,
+        project_id: typeof projectId === 'string' && projectId ? projectId : null,
         created_by: createdBy,
       })
     }
@@ -361,6 +375,7 @@ channelsRouter.get('/:id', async (c) => {
         default_model: ch.default_model,
         bridge_instructions: ch.bridge_instructions || '',
         instructions: ch.instructions,
+        project_id: ch.project_id,
         webhook_path: ch.webhook_path,
         webhook_url: publicBase ? joinPublicBaseUrl(publicBase, ch.webhook_path) : null,
         created_by: ch.created_by,
@@ -475,15 +490,26 @@ channelsRouter.patch('/:id', async (c) => {
     if (body.instructions !== undefined) updates.instructions = body.instructions
     if (body.name !== undefined) updates.name = body.name
     if (body.enabled !== undefined) updates.enabled = body.enabled
+    // project_id may be set to a string (scope to that project), null
+    // (workspace-global), or omitted (no change). Empty-string normalises
+    // to null so the UI can clear the assignment.
+    if (body.project_id !== undefined) {
+      updates.project_id = typeof body.project_id === 'string' && body.project_id
+        ? body.project_id
+        : null
+    }
 
     const ch = updateChannel(c.req.param('id'), updates)
     if (!ch) return c.json({ ok: false, error: 'Not found' }, 404)
 
+    // Changing project_id reroutes dispatch to a different working directory
+    // (and therefore a different agent set), so old session keys must drop.
     const resetsChannelSession = (
       body.default_agent !== undefined ||
       body.default_model !== undefined ||
       body.bridge_instructions !== undefined ||
-      body.instructions !== undefined
+      body.instructions !== undefined ||
+      body.project_id !== undefined
     )
     const resetCount = resetsChannelSession ? clearChannelSessions(ch.platform, ch.id) : 0
 


### PR DESCRIPTION
…s agents

Channels were workspace-global: a Slack/Telegram bot dispatched to whatever slug it found in the global agent registry. With per-project agent files (`<project>/.opencode/agent/engineer.md`, `qa.md`, `tech-lead.md`) those slugs aren't visible until opencode bootstraps the project — so a channel named for a project's agent silently fell back to global agents and the wrong persona answered.

Backend (kortix-master)

- channels.project_id (TEXT, NULL = workspace-global) added to schema with idempotent ALTER for existing DBs.
- channel-db.ts: project_id threaded through createChannel / updateChannel / upsertChannelByBot, listChannels accepts { platform?, project_id? } filter (project_id: null means "workspace-only", undefined means "all").
- routes/channels.ts: GET / supports ?project_id= filter; setup + manifest endpoints accept projectId; PATCH accepts project_id (and busts the channel-session cache when it changes — different working directory means different agent set, so reusing the old session id would bind the convo to the wrong project tree).
- channel-webhooks.ts: when channel.project_id is set, resolve the project's path from the workspace DB and pass directory= as a query param on session.create + prompt_async. Mirrors the same fix the prompt-action ticket dispatch already uses; without it opencode can't see the per-project agent files and the slug silently no-ops.

Frontend (apps/web)

- ChannelProjectPicker (new): reusable Workspace / project dropdown, used inside both setup wizards.
- useVisibleAgents now takes optional { directory } so the agent picker scopes to the selected project's `.opencode/agent/*.md`.
- Telegram + Slack setup wizards: project picker step + agent picker scoped to that project's directory; "kortix" reset if the previously picked agent isn't valid in the new scope.
- ChannelsPage: project-filter dropdown (All / Workspace / per-project) that doubles as the seed for the "new channel" wizard; channel cards show a project badge.
- ChannelsTab (new): project-scoped channels view, mirrors TriggersTab in shape and lives next to it under Project → Settings → Channels. Pre-stamps project_id when adding from this tab.
- ProjectTab + SettingsSection unions extended with 'channels'.

Migration is automatic on next master boot — old channels stay workspace-global (NULL project_id), behaviour unchanged.