### PR TITLE
fix(web/docs): bridge fumadocs-mdx / fumadocs-core Source.files mismatch

### DIFF
--- a/apps/web/src/lib/source.ts
+++ b/apps/web/src/lib/source.ts
@@ -3,9 +3,16 @@ import { loader } from 'fumadocs-core/source';
 
 const generatedSource = docs.toFumadocsSource();
 
+// fumadocs-mdx@11.x returns `Source.files` as a function; fumadocs-core@15.x
+// expects an array. Invoke it here to bridge the version mismatch (build
+// otherwise crashes during page-data collection with `a.map is not a function`).
+const generatedFiles = generatedSource.files;
+const files =
+  typeof generatedFiles === 'function'
+    ? (generatedFiles as unknown as () => any[])()
+    : (generatedFiles as unknown as any[]);
+
 export const source = loader({
   baseUrl: '/docs',
-  source: {
-    files: generatedSource.files,
-  },
+  source: { files },
 });


### PR DESCRIPTION
`next build` for `apps/web` was failing on the docs route with `TypeError: a.map is not a function`. The bug is a `Source.files` API mismatch between `fumadocs-core@15.8.5` (expects an array) and `fumadocs-mdx@11.10.1` (returns a function). One-line bridge in `src/lib/source.ts` — invoke the function before passing to `loader()`.

## What changed

- `apps/web/src/lib/source.ts` — invoke `generatedSource.files` if it's a function, otherwise pass through. Guard with `typeof === 'function'` so we stay compatible if a future fumadocs-mdx version returns an array directly.

## Why this happened

```ts
// fumadocs-core@15.8.5 — interface contract
interface Source<Config> {
  files: VirtualFile<Config>[];           // array
}

// fumadocs-mdx@11.10.1 — what it actually returns
function createMDXSource(docs, meta = []) {
  return {
    files: () => resolveFiles({ docs, meta }),   // function
  };
}
```

`loader()` then runs `source.files.map(...)` and explodes on the function reference.

## Why not bump fumadocs-mdx instead

The dep bump is the "real" fix, but it's a separate concern with its own risk surface (other API drift between minor releases, MDX option shape, etc.). This patch is contained to one file and has no behavioral impact beyond making the build green. A dep upgrade can land in its own PR.

🤖 Generated with [Kortix Agent](https://www.kortix.com/)