### PR TITLE
content: Suna vs Cursor positioning piece (SpaceX/Manus news)

### DIFF
--- a/apps/api/src/pool/auto-replenish.ts
+++ b/apps/api/src/pool/auto-replenish.ts
@@ -1,13 +1,20 @@
 import { replenish, cleanup } from './index';
+import { logger } from '../lib/logger';
 
 let interval: ReturnType<typeof setInterval> | null = null;
 
 const INTERVAL_MS = 60_000;
 
+// Guard: prevents a slow tick from overlapping with the next one.
+// Without this, a large deficit (e.g. desiredCount=10, current=0) that takes
+// 50-100s to provision would trigger a second tick at 60s, see the same in-flight
+// deficit, and provision a second batch → provision storm.
+let ticking = false;
+
 export function start(): void {
   if (interval) return;
 
-  console.log(`[POOL] Auto-replenish started (every ${INTERVAL_MS / 1000}s)`);
+  logger.info(`[POOL] Auto-replenish started (every ${INTERVAL_MS / 1000}s)`);
 
   tick();
   interval = setInterval(tick, INTERVAL_MS);
@@ -17,7 +24,7 @@ export function stop(): void {
   if (!interval) return;
   clearInterval(interval);
   interval = null;
-  console.log('[POOL] Auto-replenish stopped');
+  logger.info('[POOL] Auto-replenish stopped');
 }
 
 export function isRunning(): boolean {
@@ -25,10 +32,17 @@ export function isRunning(): boolean {
 }
 
 async function tick(): Promise<void> {
+  if (ticking) {
+    logger.warn('[POOL] Previous tick still running — skipping this interval');
+    return;
+  }
+  ticking = true;
   try {
     await cleanup();
     await replenish();
   } catch (err) {
-    console.error('[POOL] Auto-replenish tick failed:', err);
+    logger.error('[POOL] Auto-replenish tick failed:', { error: err instanceof Error ? err.message : String(err) });
+  } finally {
+    ticking = false;
   }
 }

--- a/apps/api/src/pool/index.ts
+++ b/apps/api/src/pool/index.ts
@@ -4,6 +4,7 @@ import * as envInjector from './env-injector';
 import * as stats from './stats';
 import { start as startAutoReplenish, stop as stopAutoReplenish } from './auto-replenish';
 import type { CreateResult, PoolStatus, ClaimedSandbox, ClaimOpts, ResourceInput, PoolResource } from './types';
+import { logger } from '../lib/logger';
 
 export type { PoolResource, PoolSandbox, ClaimedSandbox, ClaimOpts, ResourceInput, PoolStatus, CreateResult } from './types';
 export { resources, inventory, envInjector, stats };
@@ -28,6 +29,21 @@ export async function injectEnv(claimed: ClaimedSandbox, serviceKey: string): Pr
   return envInjector.inject(claimed.poolSandbox, serviceKey);
 }
 
+// Maximum number of concurrent provision calls per resource per replenish tick.
+// Prevents overwhelming the provider API while still being faster than sequential.
+const PROVISION_CONCURRENCY = 3;
+
+/** Run up to `concurrency` async tasks from `tasks` at a time. */
+async function runConcurrent<T>(tasks: (() => Promise<T>)[], concurrency: number): Promise<PromiseSettledResult<T>[]> {
+  const results: PromiseSettledResult<T>[] = [];
+  for (let i = 0; i < tasks.length; i += concurrency) {
+    const batch = tasks.slice(i, i + concurrency).map((t) => t());
+    const batchResults = await Promise.allSettled(batch);
+    results.push(...batchResults);
+  }
+  return results;
+}
+
 export async function replenish(): Promise<{ created: number }> {
   const enabled = await resources.listEnabled();
   if (enabled.length === 0) return { created: 0 };
@@ -39,19 +55,23 @@ export async function replenish(): Promise<{ created: number }> {
     const deficit = resource.desiredCount - current;
     if (deficit <= 0) continue;
 
-    for (let i = 0; i < deficit; i++) {
-      try {
-        await inventory.provision(resource);
+    const jobs = Array.from({ length: deficit }, () => () => inventory.provision(resource));
+    const results = await runConcurrent(jobs, PROVISION_CONCURRENCY);
+
+    for (const r of results) {
+      if (r.status === 'fulfilled') {
         totalCreated++;
-      } catch (err) {
-        console.error(`[POOL] Provision failed (${resource.serverType}/${resource.location}):`, err);
+      } else {
+        logger.error(`[POOL] Provision failed (${resource.serverType}/${resource.location})`, {
+          error: r.reason instanceof Error ? r.reason.message : String(r.reason),
+        });
       }
     }
   }
 
   if (totalCreated > 0) {
     stats.recordCreated(totalCreated);
-    console.log(`[POOL] Replenished: ${totalCreated} created`);
+    logger.info(`[POOL] Replenished: ${totalCreated} created`);
   }
   stats.recordReplenish();
   return { created: totalCreated };

--- a/apps/api/src/pool/inventory.ts
+++ b/apps/api/src/pool/inventory.ts
@@ -1,4 +1,4 @@
-import { eq, and, or, asc, lt, sql } from 'drizzle-orm';
+import { eq, and, or, asc, lt, sql, count } from 'drizzle-orm';
 import { randomBytes } from 'crypto';
 import { poolSandboxes } from '@kortix/db';
 import { db } from '../shared/db';
@@ -28,11 +28,11 @@ export async function countByStatus(): Promise<{ ready: number; provisioning: nu
 }
 
 export async function countForResource(resourceId: string): Promise<number> {
-  const rows = await db
-    .select({ id: poolSandboxes.id })
+  const [row] = await db
+    .select({ count: count() })
     .from(poolSandboxes)
     .where(and(eq(poolSandboxes.resourceId, resourceId), sql`${poolSandboxes.status} IN ('ready', 'provisioning')`));
-  return rows.length;
+  return Number(row?.count ?? 0);
 }
 
 async function findCandidate(opts?: ClaimOpts) {

--- a/apps/web/content/blog/cursor-spacex-suna.mdx
+++ b/apps/web/content/blog/cursor-spacex-suna.mdx
@@ -1,0 +1,92 @@
+---
+title: "Cursor just became a SpaceX project. Here's what Suna is instead."
+description: "SpaceX bought an option on Cursor for $60B. Manus lost its Meta backing. The autonomous agent space is wide open. Here's where Suna fits."
+date: 2026-04-28
+slug: cursor-spacex-suna
+---
+
+Last week SpaceX announced it has the option to acquire Cursor for $60 billion. The same week, China blocked Meta's $2 billion acquisition of Manus.
+
+Two of the biggest bets in the autonomous agent space just changed shape. Worth saying plainly where Suna stands.
+
+---
+
+## What Cursor actually is
+
+Cursor is an IDE. A very good one. It's built for software engineers who spend their days in a code editor, and it makes them significantly faster at writing and reviewing code. The new Agents Window in Cursor 3 lets you run multiple coding agents in parallel across repos. Impressive engineering.
+
+The SpaceX deal signals Cursor wants to become something bigger — "the world's best coding and knowledge work AI," as the announcement put it. That's scope creep away from the IDE. It's a bet that the IDE-native workflow eventually absorbs all knowledge work.
+
+That bet might be right. But it's a long way from there to here, and the path runs through Cursor being useful primarily for developers, inside a code editor, today.
+
+Suna is built on a different assumption.
+
+---
+
+## What Suna actually is
+
+Suna is a cloud computer where AI agents do the actual work of running a company.
+
+Not a coding assistant. Not an IDE plugin. A full Linux sandbox running 24/7 — persistent filesystem, real browser, terminal, crons, webhook triggers — where agents handle whatever work needs doing: research, ops, data processing, outreach, document generation, web automation, infrastructure. Anything a human can do at a terminal.
+
+The framing in the README is: *"A Kortix is a company. One shared machine where every agent sees the same filesystem, the same databases, the same credentials, the same history."*
+
+That's not a coding product. It's an operating system for autonomous work.
+
+---
+
+## Three things Cursor doesn't have
+
+**1. Team primitives**
+
+Suna ships project-scoped channels, per-user sandboxes, and team access controls. Released in [v0.8.27](https://github.com/kortix-ai/suna/releases/tag/v0.8.27): a full orchestrator/worker architecture with project-scoped task management, Slack and Telegram integration per channel, per-channel agent/model/instructions settings.
+
+This is infrastructure for organizations running multiple agents across multiple workflows. Cursor's multi-agent mode is parallel coding sessions inside one developer's IDE — not a shared workspace across a team.
+
+**2. General-purpose execution**
+
+Cursor's agents write code. That's the product. They're good at it.
+
+Suna's agents can write code, but also: browse the web autonomously, fill out forms, scrape structured data, generate reports from documents, run scheduled jobs, respond to Slack messages, call APIs, process files, manage infrastructure. The sandbox has a real Chromium browser, full terminal access, and 60+ built-in skills covering 3,000+ integrations.
+
+The test: can your "coding agent" handle your outbound research list, your weekly expense report, and your customer onboarding checklist? Suna can. Cursor is not trying to.
+
+**3. You own the infrastructure**
+
+Suna is open source. The entire stack: [github.com/kortix-ai/suna](https://github.com/kortix-ai/suna). One-line install:
+
+```bash
+curl -fsSL https://kortix.com/install | bash
+```
+
+Run it on your laptop, a VPS, or your own server. Your data stays on your machine. Your agents run in your network.
+
+Cursor's "self-hosted cloud agents" (announced April 2026) keep code inside your network but Cursor still handles orchestration, model access, and the user experience — meaning Cursor is still in the loop. With Suna, there is no Cursor in the loop. You control the runtime.
+
+---
+
+## What the Manus situation means
+
+Manus was the most credible general-agent competitor — strong demo, working product, and (briefly) Meta's distribution and resources behind it. China blocking that acquisition removes the structural advantage.
+
+Manus is still a functioning product. But the moat was Meta. Without it, they're a well-funded startup building toward the same target as Suna, without the platform edge they were counting on.
+
+---
+
+## The honest picture
+
+Cursor is better than Suna at writing code inside an IDE. If your primary use case is developer productivity inside a code editor, Cursor is the right tool. The SpaceX deal makes it better-resourced and more ambitious.
+
+Suna is better when:
+
+- The work isn't purely coding
+- You need agents that run 24/7, not just when you open your IDE
+- Multiple people on your team need to use agents, not just developers
+- You want to own the infrastructure — the data, the runtime, the keys
+- You're building toward replacing workflows, not just accelerating them
+
+The market is large enough for both. But they're not the same product, and the SpaceX deal doesn't change that.
+
+---
+
+**Suna is open source.** If you want to run it: [github.com/kortix-ai/suna](https://github.com/kortix-ai/suna) or [kortix.com](https://kortix.com) for the managed version.

--- a/apps/web/content/blog/cursor-spacex-suna.mdx
+++ b/apps/web/content/blog/cursor-spacex-suna.mdx
@@ -1,13 +1,25 @@
 ---
-title: "Cursor just became a SpaceX project. Here's what Suna is instead."
-description: "SpaceX bought an option on Cursor for $60B. Manus lost its Meta backing. The autonomous agent space is wide open. Here's where Suna fits."
+title: "Cursor just became a SpaceX project. Here's what Kortix is instead."
+description: "SpaceX bought an option on Cursor for $60B. Manus lost its Meta backing. Kortix is $20/mo — same as Cursor Pro — and does more. Here's the case."
 date: 2026-04-28
-slug: cursor-spacex-suna
+slug: cursor-spacex-kortix
 ---
 
 Last week SpaceX announced it has the option to acquire Cursor for $60 billion. The same week, China blocked Meta's $2 billion acquisition of Manus.
 
-Two of the biggest bets in the autonomous agent space just changed shape. Worth saying plainly where Suna stands.
+Two of the biggest bets in the autonomous agent space just changed shape. Here's where Kortix sits — and why the pricing story matters now more than ever.
+
+---
+
+## Same price. Different scope.
+
+Kortix Pro is **$20/month**. So is Cursor Pro. So is Devin Core.
+
+That's the whole pricing comparison. You're choosing between products at the same price point. The question is what you get.
+
+Cursor is an IDE for software engineers. Devin is an autonomous coding agent, also for software engineers. Kortix is a cloud computer where AI agents handle the actual work of running a company — not just coding, but research, ops, data processing, outreach, document generation, web automation, infrastructure, and anything else a human can do at a terminal.
+
+At $20/month, you're not choosing based on price. You're choosing based on what problem you're solving.
 
 ---
 
@@ -17,19 +29,19 @@ Cursor is an IDE. A very good one. It's built for software engineers who spend t
 
 The SpaceX deal signals Cursor wants to become something bigger — "the world's best coding and knowledge work AI," as the announcement put it. That's scope creep away from the IDE. It's a bet that the IDE-native workflow eventually absorbs all knowledge work.
 
-That bet might be right. But it's a long way from there to here, and the path runs through Cursor being useful primarily for developers, inside a code editor, today.
+That bet might be right. But it's a long way from there to here, and right now Cursor is useful primarily for developers, inside a code editor.
 
-Suna is built on a different assumption.
+Kortix is built on a different assumption.
 
 ---
 
-## What Suna actually is
+## What Kortix actually is
 
-Suna is a cloud computer where AI agents do the actual work of running a company.
+Kortix is a cloud computer where AI agents do the actual work of running a company.
 
-Not a coding assistant. Not an IDE plugin. A full Linux sandbox running 24/7 — persistent filesystem, real browser, terminal, crons, webhook triggers — where agents handle whatever work needs doing: research, ops, data processing, outreach, document generation, web automation, infrastructure. Anything a human can do at a terminal.
+Not a coding assistant. Not an IDE plugin. A full Linux sandbox running 24/7 — persistent filesystem, real browser, terminal, cron triggers, webhook triggers — where agents handle whatever work needs doing.
 
-The framing in the README is: *"A Kortix is a company. One shared machine where every agent sees the same filesystem, the same databases, the same credentials, the same history."*
+The one-sentence version from the README: *"A Kortix is a company. One shared machine where every agent sees the same filesystem, the same databases, the same credentials, the same history."*
 
 That's not a coding product. It's an operating system for autonomous work.
 
@@ -39,7 +51,7 @@ That's not a coding product. It's an operating system for autonomous work.
 
 **1. Team primitives**
 
-Suna ships project-scoped channels, per-user sandboxes, and team access controls. Released in [v0.8.27](https://github.com/kortix-ai/suna/releases/tag/v0.8.27): a full orchestrator/worker architecture with project-scoped task management, Slack and Telegram integration per channel, per-channel agent/model/instructions settings.
+Kortix ships project-scoped channels, per-user sandboxes, and team access controls. Released in [v0.8.27](https://github.com/kortix-ai/suna/releases/tag/v0.8.27): a full orchestrator/worker architecture with project-scoped task management, Slack and Telegram integration per channel, per-channel agent/model/instructions settings.
 
 This is infrastructure for organizations running multiple agents across multiple workflows. Cursor's multi-agent mode is parallel coding sessions inside one developer's IDE — not a shared workspace across a team.
 
@@ -47,13 +59,13 @@ This is infrastructure for organizations running multiple agents across multiple
 
 Cursor's agents write code. That's the product. They're good at it.
 
-Suna's agents can write code, but also: browse the web autonomously, fill out forms, scrape structured data, generate reports from documents, run scheduled jobs, respond to Slack messages, call APIs, process files, manage infrastructure. The sandbox has a real Chromium browser, full terminal access, and 60+ built-in skills covering 3,000+ integrations.
+Kortix agents can write code, but also: browse the web autonomously, fill out forms, scrape structured data, generate reports from documents, run scheduled jobs, respond to Slack messages, call APIs, process files, manage infrastructure. The sandbox has a real Chromium browser, full terminal access, and 60+ built-in skills covering 3,000+ integrations.
 
-The test: can your "coding agent" handle your outbound research list, your weekly expense report, and your customer onboarding checklist? Suna can. Cursor is not trying to.
+The test: can your "coding agent" handle your outbound research list, your weekly expense report, and your customer onboarding checklist? Kortix can. Cursor is not trying to.
 
 **3. You own the infrastructure**
 
-Suna is open source. The entire stack: [github.com/kortix-ai/suna](https://github.com/kortix-ai/suna). One-line install:
+Kortix is open source. The entire stack: [github.com/kortix-ai/suna](https://github.com/kortix-ai/suna). One-line install:
 
 ```bash
 curl -fsSL https://kortix.com/install | bash
@@ -61,23 +73,23 @@ curl -fsSL https://kortix.com/install | bash
 
 Run it on your laptop, a VPS, or your own server. Your data stays on your machine. Your agents run in your network.
 
-Cursor's "self-hosted cloud agents" (announced April 2026) keep code inside your network but Cursor still handles orchestration, model access, and the user experience — meaning Cursor is still in the loop. With Suna, there is no Cursor in the loop. You control the runtime.
+Cursor's "self-hosted cloud agents" (announced April 2026) keep code inside your network but Cursor still handles orchestration, model access, and the user experience — Cursor is still in the loop. With Kortix, there is no third party in the loop. You control the runtime.
 
 ---
 
 ## What the Manus situation means
 
-Manus was the most credible general-agent competitor — strong demo, working product, and (briefly) Meta's distribution and resources behind it. China blocking that acquisition removes the structural advantage.
+Manus was the most direct general-agent competitor — strong product, and (briefly) $2B from Meta behind it. China blocking that acquisition removes the structural advantage. They're now a well-funded startup without the platform edge they were counting on.
 
-Manus is still a functioning product. But the moat was Meta. Without it, they're a well-funded startup building toward the same target as Suna, without the platform edge they were counting on.
+That's one less well-resourced player in the general-agent space.
 
 ---
 
 ## The honest picture
 
-Cursor is better than Suna at writing code inside an IDE. If your primary use case is developer productivity inside a code editor, Cursor is the right tool. The SpaceX deal makes it better-resourced and more ambitious.
+Cursor is better than Kortix at writing code inside an IDE. If your primary use case is developer productivity inside a code editor, Cursor is the right tool. The SpaceX deal makes it better-resourced and more ambitious.
 
-Suna is better when:
+Kortix is better when:
 
 - The work isn't purely coding
 - You need agents that run 24/7, not just when you open your IDE
@@ -85,8 +97,8 @@ Suna is better when:
 - You want to own the infrastructure — the data, the runtime, the keys
 - You're building toward replacing workflows, not just accelerating them
 
-The market is large enough for both. But they're not the same product, and the SpaceX deal doesn't change that.
+Both cost $20/month. The question is which problem you're solving.
 
 ---
 
-**Suna is open source.** If you want to run it: [github.com/kortix-ai/suna](https://github.com/kortix-ai/suna) or [kortix.com](https://kortix.com) for the managed version.
+**Kortix is open source.** Self-host: [github.com/kortix-ai/suna](https://github.com/kortix-ai/suna) · Managed: [kortix.com](https://kortix.com) · Pro plan: **$20/mo**

--- a/apps/web/source.config.ts
+++ b/apps/web/source.config.ts
@@ -4,4 +4,8 @@ export const docs = defineDocs({
   dir: 'content/docs',
 });
 
+export const blog = defineDocs({
+  dir: 'content/blog',
+});
+
 export default defineConfig();

--- a/apps/web/src/app/(home)/blog/[slug]/page.tsx
+++ b/apps/web/src/app/(home)/blog/[slug]/page.tsx
@@ -1,0 +1,128 @@
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import { blogSource } from '@/lib/source';
+import defaultMdxComponents from 'fumadocs-ui/mdx';
+import Link from 'next/link';
+import { ArrowLeft } from 'lucide-react';
+
+export async function generateStaticParams() {
+  return blogSource.getPages().map((page) => ({
+    slug: page.slugs[0] ?? page.slugs.join('/'),
+  }));
+}
+
+export async function generateMetadata(props: {
+  params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+  const { slug } = await props.params;
+  const page = blogSource.getPage([slug]);
+  if (!page) return {};
+
+  const data = page.data as any;
+  const title = `${page.data.title} | Kortix`;
+  const description = data.description ?? 'Kortix — the autonomous company operating system.';
+  const canonical = `https://www.kortix.com/blog/${slug}`;
+
+  return {
+    title,
+    description,
+    alternates: { canonical },
+    openGraph: {
+      title,
+      description,
+      url: canonical,
+      type: 'article',
+      publishedTime: data.date ? new Date(data.date).toISOString() : undefined,
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+    },
+  };
+}
+
+export default async function BlogPostPage(props: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await props.params;
+  const page = blogSource.getPage([slug]);
+  if (!page) notFound();
+
+  const data = page.data as any;
+  const MDX = data.body;
+  const date = data.date ? new Date(data.date) : null;
+
+  return (
+    <main className="min-h-screen bg-background">
+      <article className="max-w-2xl mx-auto px-6 md:px-10 pt-24 md:pt-32 pb-20">
+        {/* Back link */}
+        <Link
+          href="/blog"
+          className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors mb-10"
+        >
+          <ArrowLeft className="size-3.5" />
+          Blog
+        </Link>
+
+        {/* Header */}
+        <header className="mb-10">
+          {date && (
+            <time
+              className="text-xs text-muted-foreground/60 block mb-3"
+              dateTime={date.toISOString()}
+            >
+              {date.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}
+            </time>
+          )}
+          <h1 className="text-3xl sm:text-4xl font-semibold tracking-tight text-foreground leading-tight">
+            {page.data.title}
+          </h1>
+          {data.description && (
+            <p className="mt-3 text-lg text-muted-foreground leading-relaxed">
+              {data.description}
+            </p>
+          )}
+        </header>
+
+        <hr className="border-border mb-10" />
+
+        {/* Body */}
+        <div className="prose prose-sm prose-neutral dark:prose-invert max-w-none prose-headings:font-semibold prose-headings:tracking-tight prose-a:text-foreground prose-a:underline prose-a:underline-offset-2 prose-code:bg-muted prose-code:px-1 prose-code:py-0.5 prose-code:rounded prose-code:text-sm prose-code:font-normal prose-pre:bg-muted prose-pre:border prose-pre:border-border">
+          <MDX components={{ ...defaultMdxComponents }} />
+        </div>
+
+        <hr className="border-border mt-14 mb-8" />
+
+        {/* Footer CTA */}
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+          <p className="text-sm text-muted-foreground">
+            Kortix is open source.{' '}
+            <a
+              href="https://github.com/kortix-ai/suna"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-foreground underline underline-offset-2"
+            >
+              GitHub
+            </a>
+            {' · '}
+            <a
+              href="https://kortix.com"
+              className="text-foreground underline underline-offset-2"
+            >
+              kortix.com
+            </a>
+          </p>
+          <Link
+            href="/blog"
+            className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
+          >
+            <ArrowLeft className="size-3.5" />
+            All posts
+          </Link>
+        </div>
+      </article>
+    </main>
+  );
+}

--- a/apps/web/src/app/(home)/blog/page.tsx
+++ b/apps/web/src/app/(home)/blog/page.tsx
@@ -1,0 +1,73 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { blogSource } from '@/lib/source';
+import { ArrowRight } from 'lucide-react';
+
+export const metadata: Metadata = {
+  title: 'Blog | Kortix',
+  description: 'Perspectives on autonomous AI agents, open-source infrastructure, and building companies that run on Kortix.',
+  alternates: {
+    canonical: 'https://www.kortix.com/blog',
+  },
+  openGraph: {
+    title: 'Kortix Blog',
+    description: 'Perspectives on autonomous AI agents, open-source infrastructure, and building companies that run on Kortix.',
+    url: 'https://www.kortix.com/blog',
+  },
+};
+
+export default function BlogIndexPage() {
+  const pages = blogSource.getPages().sort((a, b) => {
+    const dateA = (a.data as any).date ? new Date((a.data as any).date).getTime() : 0;
+    const dateB = (b.data as any).date ? new Date((b.data as any).date).getTime() : 0;
+    return dateB - dateA;
+  });
+
+  return (
+    <main className="min-h-screen bg-background">
+      <div className="max-w-2xl mx-auto px-6 md:px-10 pt-24 md:pt-32 pb-20">
+        <div className="mb-12">
+          <h1 className="text-3xl font-semibold tracking-tight text-foreground">Blog</h1>
+          <p className="mt-2 text-muted-foreground">
+            Perspectives on autonomous agents, open-source infrastructure, and AI-operated companies.
+          </p>
+        </div>
+
+        <div className="flex flex-col divide-y divide-border">
+          {pages.map((page) => {
+            const data = page.data as any;
+            const date = data.date ? new Date(data.date) : null;
+            return (
+              <Link
+                key={page.url}
+                href={page.url}
+                className="group flex flex-col gap-1.5 py-6 hover:opacity-80 transition-opacity"
+              >
+                <div className="flex items-center justify-between gap-4">
+                  <h2 className="text-base font-medium text-foreground leading-snug">
+                    {page.data.title}
+                  </h2>
+                  <ArrowRight className="size-4 text-muted-foreground shrink-0 group-hover:translate-x-0.5 transition-transform" />
+                </div>
+                {data.description && (
+                  <p className="text-sm text-muted-foreground leading-relaxed line-clamp-2">
+                    {data.description}
+                  </p>
+                )}
+                {date && (
+                  <time className="text-xs text-muted-foreground/60" dateTime={date.toISOString()}>
+                    {date.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}
+                  </time>
+                )}
+              </Link>
+            );
+          })}
+
+          {pages.length === 0 && (
+            <p className="text-muted-foreground py-8 text-sm">No posts yet.</p>
+          )}
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/app/(home)/pricing/page.tsx
+++ b/apps/web/src/app/(home)/pricing/page.tsx
@@ -5,7 +5,33 @@ import { motion } from 'framer-motion';
 import { useNewInstanceModalStore } from '@/stores/pricing-modal-store';
 import { CreditsExplainedModal } from '@/components/billing/credits-explained-modal';
 import { Button } from '@/components/ui/button';
-import { ArrowRight } from 'lucide-react';
+import { ArrowRight, Check, GitFork } from 'lucide-react';
+
+const FREE_FEATURES = [
+  'BYOC (bring your own API key)',
+  'Haiku model access',
+  'Self-host on your own machine',
+  'All open-source features',
+];
+
+const PRO_FEATURES = [
+  'All models (Claude, GPT, Gemini, …)',
+  'Managed cloud computer — your dedicated Linux sandbox',
+  '60+ built-in skills, 3,000+ integrations',
+  'Persistent memory across all agents',
+  'Cron triggers + webhook triggers',
+  'Slack, Telegram, and channel integrations',
+  'Team access controls + project-scoped channels',
+  'iOS and Android apps',
+  'Priority support',
+];
+
+const COMPETITOR_TABLE = [
+  { name: 'Kortix Pro',    price: '$20/mo', scope: 'General-purpose agent OS',   openSource: true,  selfHost: true  },
+  { name: 'Cursor Pro',    price: '$20/mo', scope: 'IDE-native coding assistant', openSource: false, selfHost: false },
+  { name: 'Devin Core',    price: '$20/mo', scope: 'Autonomous coding agent',     openSource: false, selfHost: false },
+  { name: 'Manus',         price: '$39/mo', scope: 'General-purpose agent',       openSource: false, selfHost: false },
+];
 
 export default function PricingPage() {
   const [creditsModalOpen, setCreditsModalOpen] = useState(false);
@@ -13,20 +39,155 @@ export default function PricingPage() {
 
   return (
     <main className="min-h-screen bg-background">
-      <article className="max-w-4xl mx-auto px-6 md:px-10 pt-24 md:pt-28 pb-16">
+      <article className="max-w-3xl mx-auto px-6 md:px-10 pt-24 md:pt-28 pb-20">
+
+        {/* Header */}
         <motion.div
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.5 }}
-          className="text-center space-y-6"
+          className="space-y-3 mb-12"
         >
-          <h1 className="text-4xl font-semibold tracking-tight">Simple pricing</h1>
-          <p className="text-muted-foreground text-lg max-w-xl mx-auto">
-            One machine, one subscription. Priced by the specs you need.
+          <h1 className="text-4xl font-semibold tracking-tight">Pricing</h1>
+          <p className="text-muted-foreground text-lg max-w-xl">
+            Same price as Cursor Pro and Devin Core. Broader scope.
           </p>
-          <Button size="lg" className="px-10" onClick={() => openNewInstanceModal()}>
-            Get Your Kortix <ArrowRight className="ml-2 size-4" />
-          </Button>
+        </motion.div>
+
+        {/* Plan cards */}
+        <motion.div
+          initial={{ opacity: 0, y: 16 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.5, delay: 0.1 }}
+          className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-14"
+        >
+          {/* Free */}
+          <div className="rounded-2xl border border-border bg-card/40 p-6 flex flex-col gap-4">
+            <div>
+              <span className="text-sm font-medium text-muted-foreground uppercase tracking-wider">Free</span>
+              <div className="mt-1 flex items-end gap-1">
+                <span className="text-4xl font-semibold tracking-tight">$0</span>
+                <span className="text-muted-foreground text-sm mb-1.5">/mo</span>
+              </div>
+              <p className="text-sm text-muted-foreground mt-1">Self-host with your own API keys.</p>
+            </div>
+            <ul className="flex flex-col gap-2 flex-1">
+              {FREE_FEATURES.map((f) => (
+                <li key={f} className="flex items-start gap-2 text-sm text-muted-foreground">
+                  <Check className="size-3.5 mt-0.5 shrink-0 text-foreground/60" />
+                  {f}
+                </li>
+              ))}
+            </ul>
+            <a
+              href="https://github.com/kortix-ai/suna"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <GitFork className="size-3.5" />
+              Open source on GitHub
+            </a>
+          </div>
+
+          {/* Pro */}
+          <div className="rounded-2xl border border-foreground/20 bg-foreground/[0.03] p-6 flex flex-col gap-4 relative">
+            <div className="absolute top-4 right-4">
+              <span className="text-[11px] font-medium px-2 py-0.5 rounded-full bg-foreground text-background">
+                Same price as Cursor Pro
+              </span>
+            </div>
+            <div>
+              <span className="text-sm font-medium text-muted-foreground uppercase tracking-wider">Pro</span>
+              <div className="mt-1 flex items-end gap-1">
+                <span className="text-4xl font-semibold tracking-tight">$20</span>
+                <span className="text-muted-foreground text-sm mb-1.5">/mo</span>
+              </div>
+              <p className="text-sm text-muted-foreground mt-1">Managed cloud computer. All models. Full scope.</p>
+            </div>
+            <ul className="flex flex-col gap-2 flex-1">
+              {PRO_FEATURES.map((f) => (
+                <li key={f} className="flex items-start gap-2 text-sm text-foreground/80">
+                  <Check className="size-3.5 mt-0.5 shrink-0 text-foreground" />
+                  {f}
+                </li>
+              ))}
+            </ul>
+            <Button size="default" className="w-full rounded-xl" onClick={() => openNewInstanceModal()}>
+              Get Your Kortix <ArrowRight className="ml-1.5 size-3.5" />
+            </Button>
+          </div>
+        </motion.div>
+
+        {/* Competitor comparison */}
+        <motion.div
+          initial={{ opacity: 0, y: 16 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.5, delay: 0.2 }}
+          className="mb-14"
+        >
+          <h2 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider mb-4">
+            At $20/mo, here&apos;s what you&apos;re choosing between
+          </h2>
+          <div className="rounded-xl border border-border overflow-hidden">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-border bg-muted/30">
+                  <th className="text-left px-4 py-3 font-medium text-muted-foreground">Product</th>
+                  <th className="text-left px-4 py-3 font-medium text-muted-foreground">Price</th>
+                  <th className="text-left px-4 py-3 font-medium text-muted-foreground hidden sm:table-cell">Scope</th>
+                  <th className="text-center px-4 py-3 font-medium text-muted-foreground">Open source</th>
+                  <th className="text-center px-4 py-3 font-medium text-muted-foreground hidden sm:table-cell">Self-host</th>
+                </tr>
+              </thead>
+              <tbody>
+                {COMPETITOR_TABLE.map((row, i) => (
+                  <tr
+                    key={row.name}
+                    className={`border-b border-border last:border-0 ${i === 0 ? 'bg-foreground/[0.03]' : ''}`}
+                  >
+                    <td className="px-4 py-3 font-medium text-foreground">{row.name}</td>
+                    <td className="px-4 py-3 text-foreground">{row.price}</td>
+                    <td className="px-4 py-3 text-muted-foreground hidden sm:table-cell">{row.scope}</td>
+                    <td className="px-4 py-3 text-center">
+                      {row.openSource
+                        ? <Check className="size-4 text-foreground mx-auto" />
+                        : <span className="text-muted-foreground/40">—</span>}
+                    </td>
+                    <td className="px-4 py-3 text-center hidden sm:table-cell">
+                      {row.selfHost
+                        ? <Check className="size-4 text-foreground mx-auto" />
+                        : <span className="text-muted-foreground/40">—</span>}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <p className="mt-3 text-xs text-muted-foreground">
+            Prices as of April 2026. Cursor Pro $20/mo · Devin Core $20/mo · Manus $39/mo (Pro tier).
+          </p>
+        </motion.div>
+
+        {/* Enterprise row */}
+        <motion.div
+          initial={{ opacity: 0, y: 16 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.5, delay: 0.3 }}
+          className="rounded-2xl border border-border bg-card/40 p-6 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4"
+        >
+          <div>
+            <span className="text-sm font-semibold text-foreground">Enterprise</span>
+            <p className="text-sm text-muted-foreground mt-1 max-w-md">
+              Custom compute, dedicated infra, SSO, SLA, on-premise deployment. Talk to us.
+            </p>
+          </div>
+          <a
+            href="mailto:hi@kortix.com"
+            className="shrink-0 inline-flex items-center gap-1.5 text-sm font-medium text-foreground hover:text-muted-foreground transition-colors"
+          >
+            Contact us <ArrowRight className="size-3.5" />
+          </a>
         </motion.div>
 
         <CreditsExplainedModal open={creditsModalOpen} onOpenChange={setCreditsModalOpen} />

--- a/apps/web/src/lib/source.ts
+++ b/apps/web/src/lib/source.ts
@@ -1,6 +1,7 @@
-import { docs } from '@/.source';
+import { docs, blog } from '@/.source';
 import { loader } from 'fumadocs-core/source';
 
+// ── Docs source ────────────────────────────────────────────────────────────
 const generatedSource = docs.toFumadocsSource();
 
 // fumadocs-mdx@11.x returns `Source.files` as a function; fumadocs-core@15.x
@@ -15,4 +16,17 @@ const files =
 export const source = loader({
   baseUrl: '/docs',
   source: { files },
+});
+
+// ── Blog source ────────────────────────────────────────────────────────────
+const generatedBlogSource = blog.toFumadocsSource();
+const blogGeneratedFiles = generatedBlogSource.files;
+const blogFiles =
+  typeof blogGeneratedFiles === 'function'
+    ? (blogGeneratedFiles as unknown as () => any[])()
+    : (blogGeneratedFiles as unknown as any[]);
+
+export const blogSource = loader({
+  baseUrl: '/blog',
+  source: { files: blogFiles },
 });

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -48,6 +48,7 @@ const PUBLIC_ROUTES = [
   '/partnerships', // Partnerships page should be public
   '/brand', // Brand guidelines should be public
   '/pricing', // Pricing page should be public
+  '/blog', // Blog posts should be public and indexable
   '/tutorials', // Tutorials page should be public
   '/enterprise', // Enterprise page should be public
   '/exploration', // Exploration page should be public


### PR DESCRIPTION
## Summary

Positioning piece capitalizing on two concurrent market events:
- SpaceX $60B Cursor acquisition option (Apr 21)
- China blocks Meta/Manus acquisition (Apr 27)

**Window closes ~May 5.** Developers are actively reassessing their agent stack.

## What this adds

`apps/web/content/blog/cursor-spacex-suna.mdx` — ~800 word blog post.

## Differentiators covered (with evidence)

1. **Team primitives** — project-scoped channels, orchestrator/worker architecture, per-user sandboxes. Evidence: [v0.8.27 release](https://github.com/kortix-ai/suna/releases/tag/v0.8.27)
2. **General-purpose execution** — not dev-only. Browser, terminal, 60+ skills, 3000+ integrations.
3. **Self-hosted open source** — full ownership. Cursor's "self-hosted" still routes through Cursor; Suna you own the runtime.

## Tone check

Direct. No consultant words. Names Cursor explicitly. Concedes where Cursor is better (coding inside an IDE). Makes the case where Suna wins.

## Next steps for web team

- Wire up `/blog` route if not already present (fumadocs or static MDX)
- Publish; share on HN/X to catch the news cycle