### PR TITLE
fix(channels): only respond to @-mentions in Slack channel messages

### DIFF
--- a/core/kortix-master/triggers/src/channel-webhooks.ts
+++ b/core/kortix-master/triggers/src/channel-webhooks.ts
@@ -445,9 +445,26 @@ export function parseSlackEvent(payload: any, configId: string, botUserId: strin
     // ── Regular message (DM or channel) ──
     const userId = event.user ?? ""
     const channel = event.channel ?? ""
-    const text = event.text ?? ""
+    const rawText = event.text ?? ""
     const isDm = event.channel_type === "im"
     const threadTs = event.thread_ts || event.event_ts || event.ts
+
+    // Channel-message subscriptions (`message.channels` / `message.groups`)
+    // fire on EVERY message, not just bot mentions — this is how Slack
+    // delivers thread replies that @-mention the bot, since `app_mention`
+    // only fires for top-level mentions. Without an @-mention filter here
+    // the bot would respond to every message in the channel. So: in
+    // non-DM channels, dispatch ONLY if the bot's user ID is @-mentioned
+    // in the text. DMs always dispatch (the user IS talking to the bot).
+    if (!isDm) {
+      if (!botUserId) return { is_challenge: false }
+      if (!rawText.includes(`<@${botUserId}>`)) return { is_challenge: false }
+    }
+
+    // Strip the @-mention so the agent gets the clean message body.
+    const text = botUserId
+      ? rawText.replace(new RegExp(`<@${botUserId}>\\s*`, "g"), "").trim()
+      : rawText
 
     const sessionKey = isDm
       ? `slack:${configId}:dm:${userId}`


### PR DESCRIPTION
Slack's `app_mention` event only fires for top-level mentions. Thread replies that @-mention the bot are delivered via `message.channels` (or `message.groups`/`message.mpim`). But parseSlackEvent's regular message branch dispatched EVERY channel message regardless of whether the bot was @-tagged — so users had to choose between:
  - subscribe to `message.channels` → bot responds to every message
  - drop `message.channels` → bot misses thread @-mentions entirely

Now the channel-message branch returns silently unless the bot's user ID appears as `<@BOTID>` in the message text. DMs still always dispatch (the user IS talking to the bot in a DM).

Reproduces: subscribe `app_mention` + `message.channels`, tag the bot in any thread reply, the bot responds without spamming the channel.