### PR TITLE
Redesign: project-focused UI

### DIFF
--- a/apps/api/scripts/reprovision-sandbox-for-user.ts
+++ b/apps/api/scripts/reprovision-sandbox-for-user.ts
@@ -1,0 +1,126 @@
+/**
+ * Comp re-provision: spin up a fresh sandbox for a user whose machine
+ * never came up (or got removed upstream) without re-charging them.
+ *
+ * Updates the existing sandbox row in place — same accountId, same name,
+ * same stripe_subscription_item_id — and only swaps externalId / baseUrl
+ * for a freshly provisioned justavps machine. Stripe is never touched.
+ *
+ * Usage:
+ *   bun run scripts/reprovision-sandbox-for-user.ts <email>            # dry run
+ *   bun run scripts/reprovision-sandbox-for-user.ts <email> --apply    # do it
+ *   bun run scripts/reprovision-sandbox-for-user.ts --sandbox <id> --apply
+ *
+ * Requires DATABASE_URL and JUSTAVPS_* env vars.
+ */
+
+import { sql as drizzleSql, eq } from 'drizzle-orm';
+import { sandboxes } from '@kortix/db';
+import { db } from '../src/shared/db';
+import { getProvider } from '../src/platform/providers';
+import { JustAVPSProvider } from '../src/platform/providers/justavps';
+import { reprovisionFailedJustAvpsSandbox } from '../src/platform/services/sandbox-reinitialize';
+
+const args = process.argv.slice(2);
+const apply = args.includes('--apply');
+const sandboxFlagIdx = args.indexOf('--sandbox');
+const sandboxIdArg = sandboxFlagIdx >= 0 ? args[sandboxFlagIdx + 1]?.trim() : undefined;
+const skipIdx = sandboxFlagIdx >= 0 ? sandboxFlagIdx + 1 : -1;
+const positional = args.filter((a, i) => !a.startsWith('--') && i !== skipIdx);
+const email = positional[0]?.trim().toLowerCase();
+
+if (!email && !sandboxIdArg) {
+  console.error('Usage:');
+  console.error('  bun run scripts/reprovision-sandbox-for-user.ts <email> [--apply]');
+  console.error('  bun run scripts/reprovision-sandbox-for-user.ts --sandbox <sandboxId> [--apply]');
+  process.exit(1);
+}
+
+async function findSandboxByEmail(targetEmail: string) {
+  const accountRows = await db.execute(drizzleSql`
+    select au.account_id::text as account_id
+    from auth.users u
+    join basejump.account_user au on au.user_id = u.id
+    where lower(u.email) = ${targetEmail}
+    limit 1
+  `);
+  const list = (accountRows as any).rows ?? (Array.isArray(accountRows) ? accountRows : []);
+  const accountId: string | undefined = list[0]?.account_id;
+  if (!accountId) return null;
+
+  const rows = await db
+    .select()
+    .from(sandboxes)
+    .where(eq(sandboxes.accountId, accountId))
+    .orderBy(drizzleSql`${sandboxes.createdAt} desc`);
+  return rows.find((r) => r.status !== 'archived') ?? null;
+}
+
+async function findSandboxById(id: string) {
+  const [row] = await db.select().from(sandboxes).where(eq(sandboxes.sandboxId, id)).limit(1);
+  return row ?? null;
+}
+
+const target = sandboxIdArg
+  ? await findSandboxById(sandboxIdArg)
+  : await findSandboxByEmail(email!);
+
+if (!target) {
+  console.error(sandboxIdArg
+    ? `No sandbox found for id ${sandboxIdArg}`
+    : `No sandbox found for ${email}`);
+  process.exit(2);
+}
+
+const sandbox = (target as typeof sandboxes.$inferSelect);
+
+if (sandbox.provider !== 'justavps') {
+  console.error(`Sandbox provider is ${sandbox.provider}, this script only supports justavps.`);
+  process.exit(3);
+}
+
+const provider = getProvider('justavps') as InstanceType<typeof JustAVPSProvider>;
+const providerStatus = sandbox.externalId ? await provider.getStatus(sandbox.externalId).catch(() => null) : null;
+
+console.log('---- target sandbox ----');
+console.log(`sandbox_id:     ${sandbox.sandboxId}`);
+console.log(`account_id:     ${sandbox.accountId}`);
+console.log(`name:           ${sandbox.name}`);
+console.log(`db_status:      ${sandbox.status}`);
+console.log(`external_id:    ${sandbox.externalId ?? '(none)'}`);
+console.log(`base_url:       ${sandbox.baseUrl ?? '(none)'}`);
+console.log(`provider says:  ${providerStatus ?? '(unknown)'}`);
+const meta = (sandbox.metadata as Record<string, unknown>) ?? {};
+console.log(`server_type:    ${meta.serverType ?? '(unknown)'}`);
+console.log(`location:       ${meta.location ?? '(unknown)'}`);
+console.log(`tier_key:       ${meta.tier_key ?? '(unknown)'}`);
+const stripeSub = (meta as any).stripe_subscription_id ?? sandbox.stripeSubscriptionItemId ?? '(none)';
+console.log(`stripe ref:     ${stripeSub}`);
+console.log(`prov_error:     ${meta.provisioningError ?? '(none)'}`);
+console.log('------------------------');
+
+if (!apply) {
+  console.log('\nDry run only. Re-run with --apply to provision a fresh machine on justavps');
+  console.log('and update this row in place. Stripe will not be touched.');
+  process.exit(0);
+}
+
+console.log('\nProvisioning a fresh justavps machine for this sandbox row...');
+const refreshed = await reprovisionFailedJustAvpsSandbox({
+  db,
+  sandbox,
+  provider,
+  userId: sandbox.accountId,
+});
+
+if (!refreshed) {
+  console.error('Reprovision returned no row — check logs above for failure.');
+  process.exit(4);
+}
+
+console.log('\n---- after ----');
+console.log(`status:        ${refreshed.status}`);
+console.log(`external_id:   ${refreshed.externalId}`);
+console.log(`base_url:      ${refreshed.baseUrl}`);
+console.log('---------------');
+console.log('\nDone. The user can now access their sandbox.');

--- a/apps/web/components.json
+++ b/apps/web/components.json
@@ -19,6 +19,7 @@
     "hooks": "@/hooks"
   },
   "registries": {
-    "@magicui": "https://magicui.design/r/{name}"
+    "@magicui": "https://magicui.design/r/{name}",
+    "@fluid": "https://www.fluidfunctionalism.com/r/{name}.json"
   }
 }

--- a/apps/web/src/app/(dashboard)/[...catchAll]/page.tsx
+++ b/apps/web/src/app/(dashboard)/[...catchAll]/page.tsx
@@ -1,48 +1,40 @@
 'use client';
 
-import { use, useEffect, useRef } from 'react';
+import { lazy, Suspense, use, useEffect, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import { useTabStore } from '@/stores/tab-store';
 import { resolveTabFromPathname } from '@/lib/tab-route-resolver';
+import { getActiveInstanceIdFromCookie, buildInstancePath } from '@/lib/instance-routes';
+import { featureFlags } from '@/lib/feature-flags';
+
+const PageTabContent = lazy(() =>
+  import('@/components/tabs/page-tab-content').then((m) => ({
+    default: m.PageTabContent,
+  })),
+);
 
 interface CatchAllPageProps {
   params: Promise<{ catchAll: string[] }>;
 }
 
-/**
- * Dashboard catch-all page — handles any URL that:
- *   1. Falls under the (dashboard) route group
- *   2. Does NOT have its own dedicated page.tsx
- *
- * This prevents the global not-found.tsx from showing when a user hard-reloads
- * a tab-based URL (e.g. /browser, /desktop, /memory, /sessions/:id, etc.).
- *
- * On mount it resolves the current pathname to a Tab descriptor via
- * `resolveTabFromPathname`, then opens/activates the tab so the
- * SessionTabsContainer makes the right content visible.
- *
- * If the pathname is completely unknown it redirects to /dashboard rather
- * than showing a 404, because the dashboard is always a safe landing point.
- *
- * Renders nothing — the tab container manages all visual output.
- */
 export default function DashboardCatchAllPage({ params }: CatchAllPageProps) {
   const { catchAll } = use(params);
   const router = useRouter();
   const { tabs, openTab, setActiveTab } = useTabStore();
   const handledRef = useRef(false);
 
+  const pathname = '/' + (catchAll ?? []).join('/');
+  const descriptor = resolveTabFromPathname(pathname);
+
   useEffect(() => {
+    if (featureFlags.newLayout) return;
     if (handledRef.current) return;
     handledRef.current = true;
 
-    // Reconstruct the pathname from the catchAll segments
-    const pathname = '/' + (catchAll ?? []).join('/');
-
-    const descriptor = resolveTabFromPathname(pathname);
-
     if (!descriptor) {
       router.replace('/dashboard');
+      const iid = getActiveInstanceIdFromCookie();
+      router.replace(iid ? buildInstancePath(iid, '/dashboard') : '/dashboard');
       return;
     }
 
@@ -59,6 +51,21 @@ export default function DashboardCatchAllPage({ params }: CatchAllPageProps) {
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  if (featureFlags.newLayout) {
+    if (!descriptor) {
+      if (typeof window !== 'undefined') {
+        const iid = getActiveInstanceIdFromCookie();
+        router.replace(iid ? buildInstancePath(iid, '/dashboard') : '/dashboard');
+      }
+      return null;
+    }
+    return (
+      <Suspense fallback={null}>
+        <PageTabContent href={descriptor.href} />
+      </Suspense>
+    );
+  }
 
   return null;
 }

--- a/apps/web/src/app/(dashboard)/dashboard/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/page.tsx
@@ -1,32 +1,41 @@
-import { cn } from "@/lib/utils";
-import { DashboardContent } from "../../../components/dashboard/dashboard-content";
-import { BackgroundAALChecker } from "@/components/auth/background-aal-checker";
 import { Suspense } from "react";
+import { BackgroundAALChecker } from "@/components/auth/background-aal-checker";
+import { ProjectsDashboard } from "@/components/dashboard/projects-dashboard";
 import { Skeleton } from "@/components/ui/skeleton";
+
+function DashboardSkeleton() {
+  return (
+    <div className="mx-auto w-full max-w-7xl px-4 pt-8 sm:px-6">
+      <div className="flex items-end justify-between gap-4">
+        <div className="space-y-2">
+          <Skeleton className="h-7 w-32" />
+          <Skeleton className="h-4 w-72" />
+        </div>
+        <div className="flex gap-2">
+          <Skeleton className="h-9 w-24" />
+          <Skeleton className="h-9 w-28" />
+        </div>
+      </div>
+      <div className="mt-6 flex gap-2">
+        <Skeleton className="h-9 w-72" />
+        <div className="ml-auto">
+          <Skeleton className="h-9 w-56" />
+        </div>
+      </div>
+      <div className="mt-6 grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+        {Array.from({ length: 8 }).map((_, i) => (
+          <Skeleton key={i} className="h-[160px] rounded-2xl" />
+        ))}
+      </div>
+    </div>
+  );
+}
 
 export default async function DashboardPage() {
   return (
     <BackgroundAALChecker>
-      <Suspense
-        fallback={
-          <div className="flex flex-col h-full w-full">
-            <div className="flex-1 flex flex-col items-center justify-center px-4">
-              <div className={cn(
-                "flex flex-col items-center text-center w-full space-y-8",
-                "max-w-[850px] sm:max-w-full sm:px-4"
-              )}>
-                <Skeleton className="h-10 w-40 sm:h-8 sm:w-32" />
-                <Skeleton className="h-7 w-56 sm:h-6 sm:w-48" />
-                <Skeleton className="w-full h-[100px] rounded-xl sm:h-[80px]" />
-                <div className="block sm:hidden lg:block w-full">
-                  <Skeleton className="h-20 w-full" />
-                </div>
-              </div>
-            </div>
-          </div>
-        }
-      >
-        <DashboardContent />
+      <Suspense fallback={<DashboardSkeleton />}>
+        <ProjectsDashboard />
       </Suspense>
     </BackgroundAALChecker>
   );

--- a/apps/web/src/app/(dashboard)/projects/[id]/page.tsx
+++ b/apps/web/src/app/(dashboard)/projects/[id]/page.tsx
@@ -61,9 +61,9 @@ import { formatCost, formatTokens } from '@/ui/turns';
 import { AgentAvatar } from '@/components/kortix/agent-avatar';
 import { ChevronDown, TimerIcon, Webhook as WebhookIcon } from 'lucide-react';
 import {
-  ProjectHeader,
   type ProjectTab,
 } from '@/components/kortix/project-header';
+import { ProjectSidebar } from '@/components/kortix/project-sidebar';
 import { ProjectAbout } from '@/components/kortix/project-about';
 import { ProjectMembersTab } from '@/components/kortix/project-members-tab';
 import { TasksTab } from '@/components/kortix/tasks-tab';
@@ -285,58 +285,54 @@ export default function ProjectPage({ params }: { params?: Promise<{ id: string 
   const hasFiles = project.path && project.path !== '/';
 
   return (
-    <div className="flex-1 bg-background flex flex-col overflow-hidden">
-      <ProjectHeader
+    <div className="flex-1 bg-background flex overflow-hidden">
+      <ProjectSidebar
         project={project}
         tab={tab}
         onTabChange={setTab}
-        structureVersion={project.structure_version}
         onNewTask={isV2 ? () => openNewTicket() : () => openNewTask()}
         newActionLabel={isV2 ? 'New ticket' : 'New task'}
-        rightSlot={isV2 ? (
-          <>
+        footerSlot={isV2 ? (
+          <div className="flex items-center justify-between gap-1">
             <Button
-              variant="outline"
+              variant="ghost"
               size="sm"
               onClick={openPmChat}
               disabled={ensurePmSession.isPending}
-              className="h-7 px-2.5 text-[12px] gap-1.5 border-border/40 hover:border-border/60 hover:bg-muted/30"
+              className="flex-1 justify-start text-muted-foreground hover:text-foreground"
               title="Open a chat with the Project Manager agent"
             >
               {ensurePmSession.isPending ? (
-                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                <Loader2 className="animate-spin" />
               ) : (
-                <MessageSquareText className="h-3.5 w-3.5" />
+                <MessageSquareText />
               )}
-              <span className="hidden sm:inline">Ask PM</span>
+              Ask PM
             </Button>
-          <NotificationsBell
-            projectId={project.id}
-            userHandle={userHandle}
-            events={activity}
-            tickets={tickets}
-            agents={agents}
-            lastSeenAt={lastSeenAt}
-            onMarkAllRead={(iso) => {
-              writeLastSeen(project.id, userHandle, iso);
-              setLastSeenAt(iso);
-            }}
-            onOpenTicket={(id, focusId) => {
-              setOpenTicketId(id);
-              setFocusEventId(focusId ?? null);
-              // Clicking a notification is the "read" signal. Advance lastSeen
-              // to that event's timestamp so it (and anything older) drops
-              // from the unread count. Newer events stay unread.
-              if (focusId && activity) {
-                const ev = activity.find((e) => e.id === focusId);
-                if (ev && (!lastSeenAt || ev.created_at > lastSeenAt)) {
-                  writeLastSeen(project.id, userHandle, ev.created_at);
-                  setLastSeenAt(ev.created_at);
+            <NotificationsBell
+              projectId={project.id}
+              userHandle={userHandle}
+              events={activity}
+              tickets={tickets}
+              agents={agents}
+              lastSeenAt={lastSeenAt}
+              onMarkAllRead={(iso) => {
+                writeLastSeen(project.id, userHandle, iso);
+                setLastSeenAt(iso);
+              }}
+              onOpenTicket={(id, focusId) => {
+                setOpenTicketId(id);
+                setFocusEventId(focusId ?? null);
+                if (focusId && activity) {
+                  const ev = activity.find((e) => e.id === focusId);
+                  if (ev && (!lastSeenAt || ev.created_at > lastSeenAt)) {
+                    writeLastSeen(project.id, userHandle, ev.created_at);
+                    setLastSeenAt(ev.created_at);
+                  }
                 }
-              }
-            }}
-          />
-          </>
+              }}
+            />
+          </div>
         ) : undefined}
       />
 

--- a/apps/web/src/app/(dashboard)/projects/[id]/page.tsx
+++ b/apps/web/src/app/(dashboard)/projects/[id]/page.tsx
@@ -12,7 +12,8 @@
  */
 
 import { use, useState, useEffect, useMemo, useCallback, useRef } from 'react';
-import { FolderGit2, MessageSquareText, Loader2 } from 'lucide-react';
+import { motion } from 'framer-motion';
+import { FolderGit2, MessageSquareText, Loader2, Bot, Zap, Sparkles } from 'lucide-react';
 import { toast } from 'sonner';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
@@ -50,7 +51,7 @@ import {
   createFilesStore,
   FilesStoreProvider,
 } from '@/features/files/store/files-store';
-import { FileExplorerPage } from '@/features/files/components/file-explorer-page';
+import { ProjectFilesTab } from '@/components/kortix/project-files-tab';
 import { relativeTime } from '@/lib/kortix/task-meta';
 import { classifySession } from '@/lib/kortix/session-category';
 import type { ProjectAgent } from '@/hooks/kortix/use-kortix-tickets';
@@ -61,9 +62,9 @@ import { formatCost, formatTokens } from '@/ui/turns';
 import { AgentAvatar } from '@/components/kortix/agent-avatar';
 import { ChevronDown, TimerIcon, Webhook as WebhookIcon } from 'lucide-react';
 import {
+  ProjectHeader,
   type ProjectTab,
 } from '@/components/kortix/project-header';
-import { ProjectSidebar } from '@/components/kortix/project-sidebar';
 import { ProjectAbout } from '@/components/kortix/project-about';
 import { ProjectMembersTab } from '@/components/kortix/project-members-tab';
 import { TasksTab } from '@/components/kortix/tasks-tab';
@@ -124,6 +125,15 @@ export default function ProjectPage({ params }: { params?: Promise<{ id: string 
 
   const sessionList = useMemo(() => sessions ?? [], [sessions]);
   const taskList = useMemo<KortixTask[]>(() => tasks ?? [], [tasks]);
+
+  const isLive = useMemo(() => {
+    if (sessionList.length === 0) return false;
+    const fiveMinAgo = Date.now() - 5 * 60_000;
+    return sessionList.some((s: any) => {
+      const t = s?.time?.updated ?? Date.parse(s?.updated_at ?? '');
+      return typeof t === 'number' && t > fiveMinAgo;
+    });
+  }, [sessionList]);
 
   // ─── v2 state ──────────────────────────────────────────────────────────
   const [openTicketId, setOpenTicketId] = useState<string | null>(null);
@@ -240,6 +250,7 @@ export default function ProjectPage({ params }: { params?: Promise<{ id: string 
   }, [taskList, search]);
 
   // ─── Keyboard shortcuts ────────────────────────────────────────────────
+  const newKeyLockRef = useRef(0);
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       if (!isProjectRouteActive || newTaskOpen || newTicketOpen || e.repeat) return;
@@ -250,6 +261,8 @@ export default function ProjectPage({ params }: { params?: Promise<{ id: string 
 
       if (e.key === '/' && tab === 'tasks' && !inField) { e.preventDefault(); searchRef.current?.focus(); }
       if ((e.key === 'c' || e.key === 'C') && !inField && !e.metaKey && !e.ctrlKey) {
+        if (Date.now() - newKeyLockRef.current < 300) return;
+        newKeyLockRef.current = Date.now();
         e.preventDefault();
         if (isV2) setNewTicketOpen(true);
         else setNewTaskOpen(true);
@@ -285,21 +298,24 @@ export default function ProjectPage({ params }: { params?: Promise<{ id: string 
   const hasFiles = project.path && project.path !== '/';
 
   return (
-    <div className="flex-1 bg-background flex overflow-hidden">
-      <ProjectSidebar
+    <div className="flex-1 bg-background flex flex-col overflow-hidden">
+      <ProjectHeader
         project={project}
         tab={tab}
         onTabChange={setTab}
         onNewTask={isV2 ? () => openNewTicket() : () => openNewTask()}
         newActionLabel={isV2 ? 'New ticket' : 'New task'}
-        footerSlot={isV2 ? (
-          <div className="flex items-center justify-between gap-1">
+        structureVersion={isV2 ? 2 : 1}
+        isLive={isLive}
+        tabBadges={isV2 ? { board: unread.total } : undefined}
+        rightSlot={isV2 ? (
+          <div className="flex items-center gap-1">
             <Button
               variant="ghost"
               size="sm"
               onClick={openPmChat}
               disabled={ensurePmSession.isPending}
-              className="flex-1 justify-start text-muted-foreground hover:text-foreground"
+              className="text-muted-foreground hover:text-foreground"
               title="Open a chat with the Project Manager agent"
             >
               {ensurePmSession.isPending ? (
@@ -307,7 +323,7 @@ export default function ProjectPage({ params }: { params?: Promise<{ id: string 
               ) : (
                 <MessageSquareText />
               )}
-              Ask PM
+              <span className="hidden sm:inline">Ask PM</span>
             </Button>
             <NotificationsBell
               projectId={project.id}
@@ -338,7 +354,11 @@ export default function ProjectPage({ params }: { params?: Promise<{ id: string 
 
       <div className="flex-1 min-h-0 relative">
         <TabPanel active={tab === 'about'}>
-          <ProjectAbout project={project} />
+          <ProjectAbout
+            project={project}
+            onNavigate={setTab}
+            onOpenTicket={(id) => setOpenTicketId(id)}
+          />
         </TabPanel>
 
         {!isV2 && (
@@ -389,7 +409,7 @@ export default function ProjectPage({ params }: { params?: Promise<{ id: string 
           {hasFiles ? (
             <div className="flex-1 min-h-0">
               <FilesStoreProvider store={projectFilesStore}>
-                <FileExplorerPage />
+                <ProjectFilesTab projectName={project.name} projectPath={project.path} />
               </FilesStoreProvider>
             </div>
           ) : (
@@ -613,117 +633,174 @@ function SessionsList({
   const teamAgents = agents.filter((a) => buckets.byAgent.has(a.name.toLowerCase()));
   const activeTriggers = triggers.filter((t: any) => buckets.byTrigger.has(t.name));
 
-  return (
-    <div className="flex-1 overflow-y-auto bg-background">
-      <div className="container mx-auto max-w-3xl px-3 sm:px-4 py-5 space-y-5">
+  const tokens = totalTokens(totals.tokens);
 
-        <SessionsSummaryCard
-          totalSessions={sessions.length}
-          totals={totals}
-          loading={statsLoading}
-        />
+  return (
+    <div className="h-full overflow-y-auto">
+      <motion.div
+        initial="hidden"
+        animate="show"
+        variants={{
+          hidden: {},
+          show: { transition: { staggerChildren: 0.04, delayChildren: 0.04 } },
+        }}
+        className="mx-auto w-full max-w-3xl px-6 pt-12 pb-24"
+      >
+        <SessionsSection>
+          <header>
+            <h1 className="text-xl font-semibold tracking-tight text-foreground">Sessions</h1>
+            <p className="mt-1.5 text-sm leading-relaxed text-muted-foreground">
+              Every conversation with your agents — grouped by who or what started it.
+            </p>
+          </header>
+        </SessionsSection>
+
+        <SessionsSection delay>
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-2">
+            <SessionStatPill label={sessions.length === 1 ? 'session' : 'sessions'} value={sessions.length} dot="bg-violet-500" />
+            <SessionStatPill label="messages" value={totals.messageCount} dot="bg-blue-500" muted={statsLoading} />
+            <SessionStatPill label="tokens" value={formatTokens(tokens)} dot="bg-amber-500" muted={statsLoading} />
+            <SessionStatPill label="spent" value={formatCost(totals.cost)} dot="bg-emerald-500" muted={statsLoading} />
+          </div>
+        </SessionsSection>
 
         {teamAgents.length > 0 && (
-          <SessionsSection label="Team agents" count={totalAgentSessions}>
-            {teamAgents.map((agent) => {
-              const list = buckets.byAgent.get(agent.name.toLowerCase()) ?? [];
-              return (
-                <AgentSessionsRow
-                  key={agent.id}
-                  agent={agent}
-                  sessions={list}
-                  statsById={statsById}
-                  openSession={openSession}
-                />
-              );
-            })}
+          <SessionsSection delay>
+            <SessionsGroup icon={Bot} label="Team agents" count={totalAgentSessions}>
+              {teamAgents.map((agent, i) => {
+                const list = buckets.byAgent.get(agent.name.toLowerCase()) ?? [];
+                return (
+                  <AgentSessionsRow
+                    key={agent.id}
+                    agent={agent}
+                    sessions={list}
+                    statsById={statsById}
+                    openSession={openSession}
+                    isLast={i === teamAgents.length - 1}
+                  />
+                );
+              })}
+            </SessionsGroup>
           </SessionsSection>
         )}
 
         {activeTriggers.length > 0 && (
-          <SessionsSection label="Trigger executions" count={totalTriggerSessions}>
-            {activeTriggers.map((t: any) => {
-              const list = buckets.byTrigger.get(t.name) ?? [];
-              return (
-                <TriggerSessionsRow
-                  key={t.id}
-                  trigger={t}
-                  sessions={list}
-                  statsById={statsById}
-                  openSession={openSession}
-                />
-              );
-            })}
+          <SessionsSection delay>
+            <SessionsGroup icon={Zap} label="Trigger executions" count={totalTriggerSessions}>
+              {activeTriggers.map((t: any, i: number) => {
+                const list = buckets.byTrigger.get(t.name) ?? [];
+                return (
+                  <TriggerSessionsRow
+                    key={t.id}
+                    trigger={t}
+                    sessions={list}
+                    statsById={statsById}
+                    openSession={openSession}
+                    isLast={i === activeTriggers.length - 1}
+                  />
+                );
+              })}
+            </SessionsGroup>
           </SessionsSection>
         )}
 
         {buckets.onboarding.length > 0 && (
-          <SessionsSection label="Onboarding" count={buckets.onboarding.length}>
-            {buckets.onboarding.map((s) => (
-              <PlainSessionRow key={s.id} session={s} stats={statsById.get(s.id)} onClick={() => openSession(s)} />
-            ))}
+          <SessionsSection delay>
+            <SessionsGroup icon={Sparkles} label="Onboarding" count={buckets.onboarding.length}>
+              {buckets.onboarding.map((s, i) => (
+                <PlainSessionRow
+                  key={s.id}
+                  session={s}
+                  stats={statsById.get(s.id)}
+                  onClick={() => openSession(s)}
+                  isLast={i === buckets.onboarding.length - 1}
+                />
+              ))}
+            </SessionsGroup>
           </SessionsSection>
         )}
 
         {buckets.human.length > 0 && (
-          <SessionsSection label="Chats" count={buckets.human.length}>
-            {buckets.human.map((s) => (
-              <PlainSessionRow key={s.id} session={s} stats={statsById.get(s.id)} onClick={() => openSession(s)} />
-            ))}
+          <SessionsSection delay>
+            <SessionsGroup icon={MessageSquareText} label="Chats" count={buckets.human.length}>
+              {buckets.human.map((s, i) => (
+                <PlainSessionRow
+                  key={s.id}
+                  session={s}
+                  stats={statsById.get(s.id)}
+                  onClick={() => openSession(s)}
+                  isLast={i === buckets.human.length - 1}
+                />
+              ))}
+            </SessionsGroup>
           </SessionsSection>
         )}
-      </div>
+      </motion.div>
     </div>
   );
 }
 
-function SessionsSummaryCard({
-  totalSessions,
-  totals,
-  loading,
-}: {
-  totalSessions: number;
-  totals: SessionStats;
-  loading: boolean;
-}) {
-  const tokens = totalTokens(totals.tokens);
+function SessionsSection({ children, delay }: { children: React.ReactNode; delay?: boolean }) {
   return (
-    <section className="rounded-xl border border-border/40 bg-card px-4 py-3">
-      <div className="text-[10px] uppercase tracking-[0.08em] text-muted-foreground/50 font-semibold mb-2">
-        Project totals
-      </div>
-      <div className="grid grid-cols-4 gap-4">
-        <Stat label="Sessions" value={String(totalSessions)} />
-        <Stat label="Messages" value={String(totals.messageCount)} muted={loading} />
-        <Stat label="Tokens" value={formatTokens(tokens)} muted={loading} />
-        <Stat label="Cost" value={formatCost(totals.cost)} muted={loading} />
-      </div>
-    </section>
+    <motion.section
+      variants={{
+        hidden: { opacity: 0, y: 6 },
+        show: { opacity: 1, y: 0, transition: { duration: 0.3, ease: 'easeOut' } },
+      }}
+      className={cn(delay && 'mt-10')}
+    >
+      {children}
+    </motion.section>
   );
 }
 
-function Stat({ label, value, muted }: { label: string; value: string; muted?: boolean }) {
+function SessionStatPill({
+  label,
+  value,
+  dot,
+  muted,
+}: {
+  label: string;
+  value: number | string;
+  dot: string;
+  muted?: boolean;
+}) {
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-xs text-muted-foreground',
+        muted && 'opacity-60',
+      )}
+    >
+      <span className={cn('size-1.5 rounded-full', dot)} />
+      <span className="font-semibold tabular-nums text-foreground">{value}</span>
+      <span>{label}</span>
+    </span>
+  );
+}
+
+function SessionsGroup({
+  icon: Icon,
+  label,
+  count,
+  children,
+}: {
+  icon: typeof Bot;
+  label: string;
+  count: number;
+  children: React.ReactNode;
+}) {
   return (
     <div>
-      <div className="text-[10px] uppercase tracking-[0.08em] text-muted-foreground/50">{label}</div>
-      <div className={cn('text-[16px] font-semibold tabular-nums mt-0.5', muted && 'text-muted-foreground/50')}>
-        {value}
+      <div className="flex items-center gap-2 mb-3">
+        <Icon className="size-3.5 text-muted-foreground/60" />
+        <h2 className="text-xs font-medium uppercase tracking-[0.12em] text-muted-foreground">{label}</h2>
+        <span className="text-xs tabular-nums text-muted-foreground/45">{count}</span>
       </div>
-    </div>
-  );
-}
-
-function SessionsSection({ label, count, children }: { label: string; count: number; children: React.ReactNode }) {
-  return (
-    <section>
-      <div className="flex items-baseline gap-2 mb-2 px-1">
-        <h3 className="text-[10px] uppercase tracking-[0.08em] font-semibold text-muted-foreground/60">{label}</h3>
-        <span className="text-[11px] tabular-nums text-muted-foreground/40">{count}</span>
-      </div>
-      <div className="rounded-xl border border-border/40 bg-card divide-y divide-border/30 overflow-hidden">
+      <div className="overflow-hidden rounded-2xl bg-muted/30">
         {children}
       </div>
-    </section>
+    </div>
   );
 }
 
@@ -732,11 +809,13 @@ function AgentSessionsRow({
   sessions,
   statsById,
   openSession,
+  isLast,
 }: {
   agent: ProjectAgent;
   sessions: any[];
   statsById: Map<string, SessionStats>;
   openSession: (s: any) => void;
+  isLast: boolean;
 }) {
   const [open, setOpen] = useState(false);
   const aggregate = useMemo(
@@ -745,42 +824,38 @@ function AgentSessionsRow({
   );
   const tokens = totalTokens(aggregate.tokens);
   return (
-    <div>
+    <div className={cn(!isLast && 'border-b border-border/40')}>
       <button
         onClick={() => setOpen((v) => !v)}
-        className="w-full flex items-center gap-3 px-4 py-3 hover:bg-muted/20 transition-colors cursor-pointer text-left group"
+        className="group flex w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-muted/60"
       >
-        <AgentAvatar hue={agent.color_hue} icon={agent.icon} slug={agent.slug} name={agent.name} size="md" />
-        <div className="flex-1 min-w-0">
+        <AgentAvatar hue={agent.color_hue} icon={agent.icon} slug={agent.slug} name={agent.name} size="sm" />
+        <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2 min-w-0">
-            <span className="text-[13px] font-semibold truncate">@{agent.slug}</span>
-            <span className="text-[11.5px] text-muted-foreground/50 truncate">{agent.name}</span>
+            <span className="text-sm font-medium text-foreground truncate">@{agent.slug}</span>
+            <span className="text-xs text-muted-foreground/60 truncate">{agent.name}</span>
           </div>
-          <div className="flex items-center gap-3 mt-1 text-[11px] tabular-nums text-muted-foreground/70">
-            <span>{sessions.length} session{sessions.length === 1 ? '' : 's'}</span>
-            <span className="text-muted-foreground/25">·</span>
-            <span>{formatTokens(tokens)} tokens</span>
-            <span className="text-muted-foreground/25">·</span>
-            <span>{formatCost(aggregate.cost)}</span>
-            {aggregate.lastUpdated && (
-              <>
-                <span className="text-muted-foreground/25">·</span>
-                <span className="text-muted-foreground/55">active {relativeTime(aggregate.lastUpdated)}</span>
-              </>
-            )}
-          </div>
+          <SessionMetaLine
+            count={sessions.length}
+            unit="session"
+            tokens={tokens}
+            cost={aggregate.cost}
+            lastTimestamp={aggregate.lastUpdated}
+            lastLabel="active"
+          />
         </div>
-        <ChevronDown className={cn('h-3.5 w-3.5 text-muted-foreground/40 transition-transform', open && 'rotate-180')} />
+        <ChevronDown className={cn('size-3.5 shrink-0 text-muted-foreground/40 transition-transform', open && 'rotate-180')} />
       </button>
       {open && (
-        <div className="bg-muted/10 border-t border-border/30 divide-y divide-border/20">
-          {sessions.map((s) => (
+        <div className="border-t border-border/40 bg-muted/40">
+          {sessions.map((s, i) => (
             <PlainSessionRow
               key={s.id}
               session={s}
               stats={statsById.get(s.id)}
               onClick={() => openSession(s)}
               dense
+              isLast={i === sessions.length - 1}
             />
           ))}
         </div>
@@ -794,11 +869,13 @@ function TriggerSessionsRow({
   sessions,
   statsById,
   openSession,
+  isLast,
 }: {
   trigger: any;
   sessions: any[];
   statsById: Map<string, SessionStats>;
   openSession: (s: any) => void;
+  isLast: boolean;
 }) {
   const [open, setOpen] = useState(false);
   const aggregate = useMemo(
@@ -808,49 +885,78 @@ function TriggerSessionsRow({
   const tokens = totalTokens(aggregate.tokens);
   const isCron = trigger.type === 'cron';
   return (
-    <div>
+    <div className={cn(!isLast && 'border-b border-border/40')}>
       <button
         onClick={() => setOpen((v) => !v)}
-        className="w-full flex items-center gap-3 px-4 py-3 hover:bg-muted/20 transition-colors cursor-pointer text-left group"
+        className="group flex w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-muted/60"
       >
-        <div className="h-8 w-8 rounded-full bg-muted/40 text-muted-foreground/70 flex items-center justify-center shrink-0">
-          {isCron ? <TimerIcon className="h-4 w-4" /> : <WebhookIcon className="h-4 w-4" />}
+        <div className="inline-flex size-7 items-center justify-center rounded-full bg-muted/60 text-muted-foreground/70 shrink-0">
+          {isCron ? <TimerIcon className="size-3.5" /> : <WebhookIcon className="size-3.5" />}
         </div>
-        <div className="flex-1 min-w-0">
+        <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2 min-w-0">
-            <span className="text-[13px] font-semibold truncate">{trigger.name}</span>
-            <span className="inline-flex items-center h-4 px-1.5 rounded text-[10px] font-mono bg-muted/40 text-muted-foreground/70">
+            <span className="text-sm font-medium text-foreground truncate">{trigger.name}</span>
+            <span className="inline-flex h-4 items-center rounded bg-muted/60 px-1.5 font-mono text-[10px] text-muted-foreground/70">
               {isCron ? (trigger.cronExpr || 'cron') : 'webhook'}
             </span>
           </div>
-          <div className="flex items-center gap-3 mt-1 text-[11px] tabular-nums text-muted-foreground/70">
-            <span>{sessions.length} fire{sessions.length === 1 ? '' : 's'}</span>
-            <span className="text-muted-foreground/25">·</span>
-            <span>{formatTokens(tokens)} tokens</span>
-            <span className="text-muted-foreground/25">·</span>
-            <span>{formatCost(aggregate.cost)}</span>
-            {aggregate.lastUpdated && (
-              <>
-                <span className="text-muted-foreground/25">·</span>
-                <span className="text-muted-foreground/55">last {relativeTime(aggregate.lastUpdated)}</span>
-              </>
-            )}
-          </div>
+          <SessionMetaLine
+            count={sessions.length}
+            unit="fire"
+            tokens={tokens}
+            cost={aggregate.cost}
+            lastTimestamp={aggregate.lastUpdated}
+            lastLabel="last"
+          />
         </div>
-        <ChevronDown className={cn('h-3.5 w-3.5 text-muted-foreground/40 transition-transform', open && 'rotate-180')} />
+        <ChevronDown className={cn('size-3.5 shrink-0 text-muted-foreground/40 transition-transform', open && 'rotate-180')} />
       </button>
       {open && (
-        <div className="bg-muted/10 border-t border-border/30 divide-y divide-border/20">
-          {sessions.map((s) => (
+        <div className="border-t border-border/40 bg-muted/40">
+          {sessions.map((s, i) => (
             <PlainSessionRow
               key={s.id}
               session={s}
               stats={statsById.get(s.id)}
               onClick={() => openSession(s)}
               dense
+              isLast={i === sessions.length - 1}
             />
           ))}
         </div>
+      )}
+    </div>
+  );
+}
+
+function SessionMetaLine({
+  count,
+  unit,
+  tokens,
+  cost,
+  lastTimestamp,
+  lastLabel,
+}: {
+  count: number;
+  unit: string;
+  tokens: number;
+  cost: number;
+  lastTimestamp: number | null;
+  lastLabel: string;
+}) {
+  const dot = <span className="text-muted-foreground/30">·</span>;
+  return (
+    <div className="mt-0.5 flex items-center gap-1.5 text-xs tabular-nums text-muted-foreground/70">
+      <span>{count} {unit}{count === 1 ? '' : 's'}</span>
+      {dot}
+      <span>{formatTokens(tokens)}</span>
+      {dot}
+      <span>{formatCost(cost)}</span>
+      {lastTimestamp && (
+        <>
+          {dot}
+          <span className="text-muted-foreground/55">{lastLabel} {relativeTime(lastTimestamp)}</span>
+        </>
       )}
     </div>
   );
@@ -861,30 +967,36 @@ function PlainSessionRow({
   stats,
   onClick,
   dense,
+  isLast,
 }: {
   session: any;
   stats?: SessionStats;
   onClick: () => void;
   dense?: boolean;
+  isLast?: boolean;
 }) {
   const tokens = stats ? totalTokens(stats.tokens) : 0;
   return (
     <button
       onClick={onClick}
       className={cn(
-        'w-full flex items-center gap-3 text-left hover:bg-muted/20 transition-colors cursor-pointer',
-        dense ? 'px-4 py-1.5' : 'px-4 py-2.5',
+        'group flex w-full items-center gap-3 text-left transition-colors hover:bg-muted/60',
+        dense ? 'px-4 py-2' : 'px-4 py-3',
+        !isLast && 'border-b border-border/40',
       )}
     >
-      <span className="flex-1 min-w-0 text-[12.5px] text-foreground/85 truncate">
+      <span className="size-1.5 shrink-0 rounded-full bg-muted-foreground/40" />
+      <span className="min-w-0 flex-1 truncate text-sm text-foreground/90">
         {session.title || 'Untitled session'}
       </span>
       {stats && stats.messageCount > 0 && (
-        <span className="text-[10.5px] tabular-nums text-muted-foreground/60 shrink-0">
-          {formatTokens(tokens)} · {formatCost(stats.cost)}
+        <span className="hidden shrink-0 items-center gap-1.5 text-xs tabular-nums text-muted-foreground/60 sm:inline-flex">
+          <span>{formatTokens(tokens)}</span>
+          <span className="text-muted-foreground/30">·</span>
+          <span>{formatCost(stats.cost)}</span>
         </span>
       )}
-      <span className="text-[10.5px] tabular-nums text-muted-foreground/40 w-[70px] text-right shrink-0">
+      <span className="w-[70px] shrink-0 text-right text-xs tabular-nums text-muted-foreground/45">
         {relativeTime(session.time?.updated)}
       </span>
     </button>

--- a/apps/web/src/app/(dashboard)/projects/[id]/page.tsx
+++ b/apps/web/src/app/(dashboard)/projects/[id]/page.tsx
@@ -66,6 +66,7 @@ import {
   type ProjectTab,
 } from '@/components/kortix/project-header';
 import { ProjectAbout } from '@/components/kortix/project-about';
+import { ProjectActivityTab } from '@/components/kortix/project-activity-tab';
 import { ProjectMembersTab } from '@/components/kortix/project-members-tab';
 import { TasksTab } from '@/components/kortix/tasks-tab';
 import { TaskDetailView } from '@/components/kortix/task-detail-view';
@@ -394,6 +395,12 @@ export default function ProjectPage({ params }: { params?: Promise<{ id: string 
             <TabPanel active={tab === 'milestones'}>
               <MilestonesTab projectId={project.id} />
             </TabPanel>
+            <TabPanel active={tab === 'activity'}>
+              <ProjectActivityTab
+                projectId={project.id}
+                onOpenTicket={(id) => setOpenTicketId(id)}
+              />
+            </TabPanel>
             <TabPanel active={tab === 'settings'}>
               <ProjectSettingsTab
                 projectId={project.id}
@@ -409,7 +416,11 @@ export default function ProjectPage({ params }: { params?: Promise<{ id: string 
           {hasFiles ? (
             <div className="flex-1 min-h-0">
               <FilesStoreProvider store={projectFilesStore}>
-                <ProjectFilesTab projectName={project.name} projectPath={project.path} />
+                <ProjectFilesTab
+                  projectId={project.id}
+                  projectName={project.name}
+                  projectPath={project.path}
+                />
               </FilesStoreProvider>
             </div>
           ) : (

--- a/apps/web/src/app/(dashboard)/projects/page.tsx
+++ b/apps/web/src/app/(dashboard)/projects/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from 'next/navigation';
 
 export default function ProjectsPage() {
-  redirect('/workspace');
+  redirect('/dashboard');
 }

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -31,6 +31,14 @@
   --color-fd-accent: oklch(0.92 0 0 / 0.5);
   --color-fd-accent-foreground: oklch(0.205 0 0);
   --color-fd-ring: oklch(0.708 0 0);
+  --sidebar: hsl(0 0% 98%);
+  --sidebar-foreground: hsl(240 5.3% 26.1%);
+  --sidebar-primary: hsl(240 5.9% 10%);
+  --sidebar-primary-foreground: hsl(0 0% 98%);
+  --sidebar-accent: hsl(240 4.8% 95.9%);
+  --sidebar-accent-foreground: hsl(240 5.9% 10%);
+  --sidebar-border: hsl(220 13% 91%);
+  --sidebar-ring: hsl(217.2 91.2% 59.8%);
 }
 .dark {
   --color-fd-background: oklch(0.18 0 0);
@@ -49,6 +57,14 @@
   --color-fd-accent: oklch(0.35 0 0 / 0.5);
   --color-fd-accent-foreground: oklch(0.94 0 0);
   --color-fd-ring: oklch(0.50 0 0);
+  --sidebar: hsl(240 5.9% 10%);
+  --sidebar-foreground: hsl(240 4.8% 95.9%);
+  --sidebar-primary: hsl(224.3 76.3% 48%);
+  --sidebar-primary-foreground: hsl(0 0% 100%);
+  --sidebar-accent: hsl(240 3.7% 15.9%);
+  --sidebar-accent-foreground: hsl(240 4.8% 95.9%);
+  --sidebar-border: hsl(240 3.7% 15.9%);
+  --sidebar-ring: hsl(217.2 91.2% 59.8%);
 }
 .dark #nd-sidebar {
   --color-fd-muted: oklch(0.22 0 0);

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -1,0 +1,219 @@
+"use client"
+
+import * as React from "react"
+import { useRouter, usePathname } from "next/navigation"
+import {
+  FolderOpen,
+  MessageSquareText,
+  Search,
+  Sparkles,
+} from "lucide-react"
+
+import { NavMain, type NavMainItem } from "@/components/nav-main"
+import { NavProjects, type NavProjectItem } from "@/components/nav-projects"
+import { NavUser } from "@/components/nav-user"
+import { KortixBrand } from "@/components/kortix-brand"
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarHeader,
+  SidebarRail,
+} from "@/components/ui/sidebar"
+import { ProjectIcon } from "@/components/kortix/project-icon"
+import { SessionList } from "@/components/sidebar/session-list"
+import {
+  getCurrentInstanceIdFromPathname,
+  getActiveInstanceIdFromCookie,
+  toInstanceAwarePath,
+  normalizeAppPathname,
+} from "@/lib/instance-routes"
+import { useKortixProjects, type KortixProject } from "@/hooks/kortix/use-kortix-projects"
+import { useCreateOpenCodeSession } from "@/hooks/opencode/use-opencode-sessions"
+import { useDeleteProject } from "@/hooks/kortix/use-kortix-projects"
+import { useAdminRole } from "@/hooks/admin"
+import { createClient } from "@/lib/supabase/client"
+import { toast } from "sonner"
+
+export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
+  const pathname = usePathname()
+  const router = useRouter()
+
+  const instanceId = React.useMemo(
+    () =>
+      getCurrentInstanceIdFromPathname(pathname) ||
+      getActiveInstanceIdFromCookie(),
+    [pathname],
+  )
+  const normalized = normalizeAppPathname(pathname)
+  const buildHref = React.useCallback(
+    (href: string) => toInstanceAwarePath(href, instanceId),
+    [instanceId],
+  )
+
+  const user = useUserDisplay()
+  const isMac = useIsMac()
+
+  const openCommandPalette = React.useCallback(() => {
+    document.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        key: "k",
+        code: "KeyK",
+        metaKey: isMac,
+        ctrlKey: !isMac,
+        bubbles: true,
+        cancelable: true,
+      }),
+    )
+  }, [isMac])
+
+  const createSession = useCreateOpenCodeSession()
+  const handleNewSession = React.useCallback(async () => {
+    try {
+      const session = await createSession.mutateAsync()
+      router.push(buildHref(`/sessions/${session.id}`))
+      requestAnimationFrame(() => {
+        window.dispatchEvent(new CustomEvent("focus-session-textarea"))
+      })
+    } catch {
+      router.push(buildHref("/dashboard"))
+    }
+  }, [createSession, router, buildHref])
+
+  const { data: projectsData } = useKortixProjects()
+  const deleteProject = useDeleteProject()
+  const projects = React.useMemo<KortixProject[]>(() => {
+    if (!projectsData || !Array.isArray(projectsData)) return []
+    return [...projectsData].sort(
+      (a, b) =>
+        new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
+    )
+  }, [projectsData])
+
+  const isFilesActive =
+    normalized === "/files" || normalized.startsWith("/files/")
+  const isSessionsActive =
+    normalized === "/sessions" || normalized.startsWith("/sessions/")
+  const isProjectsRoute = normalized.startsWith("/projects/")
+  const activeProjectId = React.useMemo(() => {
+    const m = normalized.match(/^\/projects\/([^/]+)/)
+    return m ? decodeURIComponent(m[1]) : null
+  }, [normalized])
+
+  const navMain: NavMainItem[] = [
+    {
+      title: "Search",
+      icon: Search,
+      shortcut: isMac ? "⌘K" : "Ctrl K",
+      onAction: openCommandPalette,
+    },
+    {
+      title: "New chat",
+      icon: Sparkles,
+      shortcut: isMac ? "⌘J" : "Ctrl J",
+      onAction: handleNewSession,
+    },
+    {
+      title: "Files",
+      url: buildHref("/files"),
+      icon: FolderOpen,
+      isActive: isFilesActive,
+    },
+    {
+      title: "Sessions",
+      icon: MessageSquareText,
+      isActive: isSessionsActive,
+      renderContent: () => (
+        <div className="max-h-[40vh] overflow-y-auto pl-1 [&::-webkit-scrollbar]:hidden">
+          <SessionList projectId={null} />
+        </div>
+      ),
+    },
+  ]
+
+  const projectItems: NavProjectItem[] = projects.map((project) => ({
+    id: project.id,
+    name: project.name,
+    url: buildHref(`/projects/${encodeURIComponent(project.id)}`),
+    isActive: activeProjectId === project.id,
+    leading: <ProjectIcon project={project} size="xs" />,
+    onView: () =>
+      router.push(buildHref(`/projects/${encodeURIComponent(project.id)}`)),
+    onDelete: async () => {
+      if (!confirm(`Delete "${project.name}"? This cannot be undone.`)) return
+      try {
+        await deleteProject.mutateAsync(project.id)
+        toast.success(`Deleted ${project.name}`)
+        if (isProjectsRoute && activeProjectId === project.id) {
+          router.push(buildHref("/dashboard"))
+        }
+      } catch (err) {
+        toast.error(
+          err instanceof Error ? err.message : "Failed to delete project",
+        )
+      }
+    },
+  }))
+
+  return (
+    <Sidebar collapsible="icon" {...props} className="border-r border-sidebar-border/30">
+      <SidebarHeader>
+        <KortixBrand href={buildHref("/dashboard")} />
+      </SidebarHeader>
+      <SidebarContent>
+        <NavMain items={navMain} />
+        <NavProjects
+          projects={projectItems}
+          emptyState="No projects yet"
+        />
+      </SidebarContent>
+      <SidebarFooter>
+        <NavUser user={user} />
+      </SidebarFooter>
+      <SidebarRail />
+    </Sidebar>
+  )
+}
+
+function useUserDisplay() {
+  const { data: adminRoleData } = useAdminRole()
+  const isAdmin = adminRoleData?.isAdmin ?? false
+  const [user, setUser] = React.useState<{
+    name: string
+    email: string
+    avatar: string
+  }>({ name: "Loading…", email: "", avatar: "" })
+
+  React.useEffect(() => {
+    let cancelled = false
+    ;(async () => {
+      const supabase = createClient()
+      const { data } = await supabase.auth.getUser()
+      if (cancelled || !data.user) return
+      setUser({
+        name:
+          data.user.user_metadata?.name ||
+          data.user.email?.split("@")[0] ||
+          "User",
+        email: data.user.email || "",
+        avatar:
+          data.user.user_metadata?.avatar_url ||
+          data.user.user_metadata?.picture ||
+          "",
+      })
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [isAdmin])
+
+  return user
+}
+
+function useIsMac() {
+  const [isMac, setIsMac] = React.useState(false)
+  React.useEffect(() => {
+    setIsMac(/Mac/.test(navigator.userAgent))
+  }, [])
+  return isMac
+}

--- a/apps/web/src/components/dashboard/layout-content.tsx
+++ b/apps/web/src/components/dashboard/layout-content.tsx
@@ -47,6 +47,7 @@ import {
 	AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
 import { ChevronRight } from "lucide-react";
+import { AppSidebar } from "@/components/app-sidebar";
 
 /** Monitors session status transitions and fires browser notifications. Renders nothing. */
 function WebNotificationProvider() {
@@ -549,6 +550,9 @@ export default function DashboardLayoutContent({
 	const setActiveTab = useTabStore((s) => s.setActiveTab);
 
 	useEffect(() => {
+		// In the new layout we drive everything off Next.js routes — no tab store.
+		if (featureFlags.newLayout) return;
+
 		const normalizedPath = normalizeAppPathname(pathname);
 		const descriptor = resolveTabFromPathname(normalizedPath);
 		if (!descriptor) return;
@@ -1020,6 +1024,7 @@ export default function DashboardLayoutContent({
 					// there's no persisted choice yet.
 					initialSidebarOpen ?? !ob.active
 				}
+				sidebarContent={featureFlags.newLayout ? <AppSidebar /> : undefined}
 				sidebarSiblings={
 					<Suspense fallback={null}>
 						<StatusOverlay />
@@ -1058,9 +1063,9 @@ export default function DashboardLayoutContent({
 						<CommandPalette />
 					</Suspense>
 
-					{/* Tab bar — hidden during onboarding, morphs in */}
+					{/* Tab bar — hidden during onboarding, morphs in. Suppressed when newLayout is on. */}
 					<AnimatePresence initial={false}>
-						{!hideChrome && (
+						{!hideChrome && !featureFlags.newLayout && (
 							<motion.div
 								key="tab-bar"
 								initial={{ height: 0, opacity: 0 }}
@@ -1074,8 +1079,17 @@ export default function DashboardLayoutContent({
 						)}
 					</AnimatePresence>
 
-					<div className="flex-1 min-h-0 flex flex-col md:border md:border-b-0 md:border-border/50 overflow-hidden md:rounded-t-xl relative">
-						<SessionTabsContainer>{children}</SessionTabsContainer>
+					<div className={cn(
+						'flex-1 min-h-0 flex flex-col overflow-hidden relative',
+						!featureFlags.newLayout && 'md:border md:border-b-0 md:border-border/50 md:rounded-t-xl',
+					)}>
+						{featureFlags.newLayout ? (
+							<div className="flex-1 min-h-0 flex flex-col overflow-y-auto bg-background">
+								{children}
+							</div>
+						) : (
+							<SessionTabsContainer>{children}</SessionTabsContainer>
+						)}
 
 						{/* Floating skip button during onboarding chat session */}
 						{ob.active && !ob.showBoot && !ob.showSetup && ob.sessionId && (

--- a/apps/web/src/components/dashboard/projects-dashboard.tsx
+++ b/apps/web/src/components/dashboard/projects-dashboard.tsx
@@ -1,0 +1,786 @@
+'use client';
+
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  ArrowDownAZ,
+  ArrowUpRight,
+  Clock4,
+  FolderGit2,
+  LayoutGrid,
+  ListIcon,
+  MessageSquarePlus,
+  Plus,
+  Search as SearchIcon,
+  Sparkles,
+  X,
+} from 'lucide-react';
+import { motion } from 'framer-motion';
+import { toast } from 'sonner';
+import { cn } from '@/lib/utils';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Kbd } from '@/components/ui/kbd';
+import { Skeleton } from '@/components/ui/skeleton';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import {
+  useKortixProjects,
+  type KortixProject,
+} from '@/hooks/kortix/use-kortix-projects';
+import { useCreateOpenCodeSession } from '@/hooks/opencode/use-opencode-sessions';
+import { openTabAndNavigate } from '@/stores/tab-store';
+import { useServerStore } from '@/stores/server-store';
+
+type SortKey = 'recent' | 'name' | 'created';
+type ViewMode = 'grid' | 'list';
+
+const SORTS: { key: SortKey; label: string; icon: typeof Clock4 }[] = [
+  { key: 'recent', label: 'Last activity', icon: Clock4 },
+  { key: 'created', label: 'Recently created', icon: Sparkles },
+  { key: 'name', label: 'Name', icon: ArrowDownAZ },
+];
+
+const ICON_HUES = [12, 30, 50, 90, 145, 195, 230, 265, 305, 340] as const;
+
+function projectAccent(id: string): string {
+  let hash = 0;
+  for (let i = 0; i < id.length; i++) hash = (hash * 31 + id.charCodeAt(i)) | 0;
+  const hue = ICON_HUES[Math.abs(hash) % ICON_HUES.length];
+  return `oklch(0.62 0.14 ${hue})`;
+}
+
+function projectInitial(name: string): string {
+  const cleaned = name.replace(/[^A-Za-z0-9]/g, '').trim();
+  return (cleaned[0] || '?').toUpperCase();
+}
+
+function relativeWhen(input?: number | string | null): string | null {
+  if (input == null) return null;
+  const ms = typeof input === 'number' ? input : Date.parse(input);
+  if (Number.isNaN(ms)) return null;
+  const diff = Date.now() - ms;
+  if (diff < 0) return 'just now';
+  const m = Math.floor(diff / 60_000);
+  if (m < 1) return 'just now';
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  const d = Math.floor(h / 24);
+  if (d < 7) return `${d}d ago`;
+  const w = Math.floor(d / 7);
+  if (w < 5) return `${w}w ago`;
+  const mo = Math.floor(d / 30);
+  if (mo < 12) return `${mo}mo ago`;
+  return `${Math.floor(d / 365)}y ago`;
+}
+
+function projectUpdatedMs(p: KortixProject): number {
+  if (p.time?.updated) return p.time.updated;
+  const c = Date.parse(p.created_at || '');
+  return Number.isFinite(c) ? c : 0;
+}
+
+function projectCreatedMs(p: KortixProject): number {
+  if (p.time?.created) return p.time.created;
+  const c = Date.parse(p.created_at || '');
+  return Number.isFinite(c) ? c : 0;
+}
+
+function isActive(p: KortixProject, withinDays = 7): boolean {
+  const updated = projectUpdatedMs(p);
+  if (!updated) return false;
+  return Date.now() - updated < withinDays * 86_400_000;
+}
+
+type IconSize = 'sm' | 'md';
+
+const ICON_SIZE_CLASS: Record<IconSize, string> = {
+  sm: 'size-7 text-xs',
+  md: 'size-9 text-sm',
+};
+
+function ProjectIcon({
+  project,
+  size = 'md',
+  className,
+}: {
+  project: KortixProject;
+  size?: IconSize;
+  className?: string;
+}) {
+  const accent = projectAccent(project.id);
+  const initial = projectInitial(project.name);
+  return (
+    <div
+      className={cn(
+        'flex shrink-0 items-center justify-center rounded-lg font-semibold tracking-tight text-white ring-1 ring-inset ring-white/10',
+        ICON_SIZE_CLASS[size],
+        className,
+      )}
+      style={{ backgroundColor: accent }}
+    >
+      {initial}
+    </div>
+  );
+}
+
+function ActivityPulse({ active }: { active: boolean }) {
+  if (!active) {
+    return (
+      <span className="relative flex h-1.5 w-1.5 shrink-0 items-center justify-center">
+        <span className="h-1.5 w-1.5 rounded-full bg-muted-foreground/30" />
+      </span>
+    );
+  }
+  return (
+    <span className="relative flex h-1.5 w-1.5 shrink-0 items-center justify-center">
+      <span className="absolute h-2.5 w-2.5 animate-ping rounded-full bg-emerald-500/40" />
+      <span className="relative h-1.5 w-1.5 rounded-full bg-emerald-500" />
+    </span>
+  );
+}
+
+const CARD_BASE = cn(
+  'group relative flex h-full flex-col rounded-2xl border bg-card p-4 text-left',
+  'transition-colors duration-150 hover:bg-muted/30',
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40',
+);
+
+function CardHeader({
+  left,
+  right,
+}: {
+  left: React.ReactNode;
+  right: React.ReactNode;
+}) {
+  return (
+    <div className="flex items-start justify-between gap-2">
+      {left}
+      <span
+        aria-hidden
+        className="text-muted-foreground/30 transition-colors duration-150 group-hover:text-foreground"
+      >
+        {right}
+      </span>
+    </div>
+  );
+}
+
+function CardTitle({
+  title,
+  pathLabel,
+  pathMono = true,
+}: {
+  title: string;
+  pathLabel: string;
+  pathMono?: boolean;
+}) {
+  return (
+    <div className="mt-3 min-w-0">
+      <h3 className="truncate text-sm font-semibold leading-tight tracking-tight text-foreground">
+        {title}
+      </h3>
+      <Badge
+        variant="secondary"
+        size="sm"
+        className={cn(
+          'mt-1.5 max-w-full rounded-md normal-case tracking-normal',
+          pathMono && 'font-mono',
+        )}
+      >
+        <span className="truncate">{pathLabel}</span>
+      </Badge>
+    </div>
+  );
+}
+
+function CardBody({ children }: { children: React.ReactNode }) {
+  return (
+    <p className="mt-2 line-clamp-2 min-h-8 text-xs leading-snug text-muted-foreground">
+      {children}
+    </p>
+  );
+}
+
+function CardFooter({ children }: { children: React.ReactNode }) {
+  return <div className="mt-auto flex items-center gap-1.5 pt-3">{children}</div>;
+}
+
+function ProjectCardGrid({
+  project,
+  index,
+  onOpen,
+}: {
+  project: KortixProject;
+  index: number;
+  onOpen: (p: KortixProject) => void;
+}) {
+  const updated = relativeWhen(project.time?.updated ?? project.created_at);
+  const active = isActive(project);
+  const isV2 = project.structure_version === 2;
+  const cleanPath =
+    project.path && project.path !== '/' && project.path !== '/workspace'
+      ? project.path
+      : '/workspace';
+  const sessions = project.sessionCount ?? 0;
+
+  return (
+    <motion.button
+      type="button"
+      onClick={() => onOpen(project)}
+      layout
+      initial={{ opacity: 0, y: 4 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.15, delay: Math.min(index * 0.01, 0.1), ease: 'easeOut' }}
+      className={CARD_BASE}
+    >
+      <CardHeader
+        left={<ProjectIcon project={project} size="md" />}
+        right={
+          <ArrowUpRight className="size-4 transition-transform duration-200 group-hover:translate-x-0.5 group-hover:-translate-y-0.5" />
+        }
+      />
+      <CardTitle title={project.name} pathLabel={`~${cleanPath}`} />
+      <CardBody>
+        {project.description?.trim() || (
+          <span className="italic text-muted-foreground/40">No description</span>
+        )}
+      </CardBody>
+      <CardFooter>
+        <Badge
+          variant={active ? 'success' : 'muted'}
+          size="sm"
+          className="gap-1.5 uppercase tracking-wider tabular-nums"
+        >
+          <ActivityPulse active={active} />
+          {updated ?? 'idle'}
+        </Badge>
+        <div className="ml-auto flex items-center gap-1">
+          {sessions > 0 && (
+            <Badge
+              variant="muted"
+              size="sm"
+              className="uppercase tracking-wider tabular-nums"
+            >
+              <span className="font-semibold text-foreground/80">{sessions}</span>
+              sess
+            </Badge>
+          )}
+          <Badge
+            variant={isV2 ? 'highlight' : 'muted'}
+            size="sm"
+            className="font-semibold uppercase tracking-wider tabular-nums"
+          >
+            {isV2 ? 'v2' : 'v1'}
+          </Badge>
+        </div>
+      </CardFooter>
+    </motion.button>
+  );
+}
+
+function ProjectRow({
+  project,
+  index,
+  onOpen,
+}: {
+  project: KortixProject;
+  index: number;
+  onOpen: (p: KortixProject) => void;
+}) {
+  const updated = relativeWhen(project.time?.updated ?? project.created_at);
+  const active = isActive(project);
+  const isV2 = project.structure_version === 2;
+  const cleanPath =
+    project.path && project.path !== '/' && project.path !== '/workspace'
+      ? project.path
+      : null;
+  const sessions = project.sessionCount ?? 0;
+
+  return (
+    <motion.button
+      type="button"
+      onClick={() => onOpen(project)}
+      layout
+      initial={{ opacity: 0, y: 4 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.15, delay: Math.min(index * 0.01, 0.1), ease: 'easeOut' }}
+      className={cn(
+        'group flex w-full items-center gap-4 border-b px-4 py-3 text-left',
+        'transition-colors duration-150 hover:bg-muted/30 focus-visible:bg-muted/40 focus-visible:outline-none',
+      )}
+    >
+      <ProjectIcon project={project} size="sm" />
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <h3 className="truncate text-sm font-medium text-foreground">
+            {project.name}
+          </h3>
+          {cleanPath && (
+            <Badge
+              variant="secondary"
+              size="sm"
+              className="hidden rounded-md font-mono normal-case tracking-normal sm:inline-flex"
+            >
+              {cleanPath}
+            </Badge>
+          )}
+        </div>
+        {project.description?.trim() && (
+          <p className="mt-0.5 truncate text-xs text-muted-foreground">
+            {project.description}
+          </p>
+        )}
+      </div>
+      <div className="hidden items-center gap-1.5 sm:flex">
+        {sessions > 0 && (
+          <Badge variant="muted" size="sm" className="uppercase tracking-wider tabular-nums">
+            <span className="font-semibold text-foreground/80">{sessions}</span>
+            sess
+          </Badge>
+        )}
+        <Badge
+          variant={isV2 ? 'highlight' : 'muted'}
+          size="sm"
+          className="font-semibold uppercase tracking-wider tabular-nums"
+        >
+          {isV2 ? 'v2' : 'v1'}
+        </Badge>
+      </div>
+      <div className="flex w-24 shrink-0 items-center gap-2 text-xs text-muted-foreground">
+        <ActivityPulse active={active} />
+        <span className="truncate tabular-nums">{updated ?? '—'}</span>
+      </div>
+      <ArrowUpRight className="size-4 shrink-0 text-muted-foreground/30 transition-colors duration-150 group-hover:text-foreground" />
+    </motion.button>
+  );
+}
+
+function NewProjectCard({ onClick }: { onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(CARD_BASE, 'border-dashed bg-transparent')}
+    >
+      <CardHeader
+        left={
+          <span className="flex size-9 items-center justify-center rounded-lg border border-dashed text-muted-foreground transition-transform duration-200 group-hover:rotate-90 group-hover:text-foreground">
+            <Plus className="size-4" />
+          </span>
+        }
+        right={<ArrowUpRight className="size-4 transition-transform duration-200 group-hover:translate-x-0.5 group-hover:-translate-y-0.5" />}
+      />
+      <CardTitle title="New project" pathLabel="scaffold" pathMono={false} />
+      <CardBody>
+        Suna asks what you want to build, then sets up files, agents, and a board for you.
+      </CardBody>
+      <CardFooter>
+        <Badge variant="muted" size="sm" className="uppercase tracking-wider">
+          Ready
+        </Badge>
+        <Kbd className="ml-auto bg-transparent">N</Kbd>
+      </CardFooter>
+    </button>
+  );
+}
+
+function GridSkeleton() {
+  return (
+    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+      {Array.from({ length: 8 }).map((_, i) => (
+        <div
+          key={i}
+          className="flex flex-col rounded-2xl border bg-card p-4"
+        >
+          <div className="flex items-start justify-between gap-2">
+            <Skeleton className="size-9 rounded-lg" />
+            <Skeleton className="size-4 rounded" />
+          </div>
+          <div className="mt-3 space-y-2">
+            <Skeleton className="h-3.5 w-2/3" />
+            <Skeleton className="h-4 w-1/2 rounded-md" />
+          </div>
+          <div className="mt-2 space-y-1.5">
+            <Skeleton className="h-3 w-full" />
+            <Skeleton className="h-3 w-3/4" />
+          </div>
+          <div className="mt-auto flex items-center justify-between pt-3">
+            <Skeleton className="h-5 w-20 rounded-2xl" />
+            <Skeleton className="h-5 w-10 rounded-2xl" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function EmptyHero({ onNew }: { onNew: () => void }) {
+  return (
+    <div className="rounded-2xl border border-dashed bg-card/40 px-6 py-12 text-center">
+      <div className="mx-auto flex size-10 items-center justify-center rounded-lg border bg-card text-foreground">
+        <FolderGit2 className="size-4" />
+      </div>
+      <h2 className="mt-4 text-base font-semibold tracking-tight text-foreground">
+        Spin up your first project
+      </h2>
+      <p className="mx-auto mt-1.5 max-w-md text-xs leading-relaxed text-muted-foreground">
+        Projects group files, boards, agents, and sessions. Start one and the rest
+        of the workspace fills in around it.
+      </p>
+      <div className="mt-5 flex items-center justify-center gap-2">
+        <Button onClick={onNew} size="sm">
+          <Plus />
+          New project
+        </Button>
+        <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
+          or press <Kbd className="bg-transparent">N</Kbd>
+        </span>
+      </div>
+    </div>
+  );
+}
+
+export function ProjectsDashboard() {
+  const [search, setSearch] = useState('');
+  const [sort, setSort] = useState<SortKey>('recent');
+  const [view, setView] = useState<ViewMode>('grid');
+  const searchRef = useRef<HTMLInputElement>(null);
+
+  const { data: projects, isLoading, error, refetch } = useKortixProjects();
+  const createSession = useCreateOpenCodeSession();
+
+  const items = useMemo<KortixProject[]>(() => {
+    if (!projects) return [];
+    const filtered = search.trim()
+      ? projects.filter((p) => {
+          const q = search.toLowerCase();
+          return (
+            p.name.toLowerCase().includes(q) ||
+            (p.description?.toLowerCase().includes(q) ?? false) ||
+            (p.path?.toLowerCase().includes(q) ?? false)
+          );
+        })
+      : [...projects];
+
+    filtered.sort((a, b) => {
+      if (sort === 'name') return a.name.localeCompare(b.name);
+      if (sort === 'created') return projectCreatedMs(b) - projectCreatedMs(a);
+      return projectUpdatedMs(b) - projectUpdatedMs(a);
+    });
+    return filtered;
+  }, [projects, search, sort]);
+
+  const openProject = useCallback((p: KortixProject) => {
+    openTabAndNavigate({
+      id: `project:${p.id}`,
+      title: p.name,
+      type: 'project',
+      href: `/projects/${encodeURIComponent(p.id)}`,
+      serverId: useServerStore.getState().activeServerId,
+    });
+  }, []);
+
+  const startNewProject = useCallback(async () => {
+    try {
+      const session = await createSession.mutateAsync({ title: 'New project' });
+      sessionStorage.setItem(
+        `opencode_pending_prompt:${session.id}`,
+        "HEY let's set up a new project. Ask for the name and purpose, then create it in the right workspace location with a clean starting structure.",
+      );
+      openTabAndNavigate({
+        id: session.id,
+        title: 'New project',
+        type: 'session',
+        href: `/sessions/${session.id}`,
+        serverId: useServerStore.getState().activeServerId,
+      });
+      requestAnimationFrame(() =>
+        window.dispatchEvent(new CustomEvent('focus-session-textarea')),
+      );
+    } catch {
+      toast.error('Failed to start session');
+    }
+  }, [createSession]);
+
+  const startNewChat = useCallback(async () => {
+    try {
+      const session = await createSession.mutateAsync({ title: 'New session' });
+      openTabAndNavigate({
+        id: session.id,
+        title: 'New session',
+        type: 'session',
+        href: `/sessions/${session.id}`,
+        serverId: useServerStore.getState().activeServerId,
+      });
+      requestAnimationFrame(() =>
+        window.dispatchEvent(new CustomEvent('focus-session-textarea')),
+      );
+    } catch {
+      toast.error('Failed to start session');
+    }
+  }, [createSession]);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement | null;
+      const tag = target?.tagName;
+      const inField =
+        tag === 'INPUT' ||
+        tag === 'TEXTAREA' ||
+        (target as HTMLElement | null)?.isContentEditable;
+      if (inField) return;
+      if (e.key === '/') {
+        e.preventDefault();
+        searchRef.current?.focus();
+      } else if (e.key === 'n' && !e.metaKey && !e.ctrlKey && !e.altKey) {
+        e.preventDefault();
+        startNewProject();
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [startNewProject]);
+
+  const hasProjects = (projects?.length ?? 0) > 0;
+  const showSkeleton = isLoading && !projects;
+  const currentSort = SORTS.find((s) => s.key === sort) ?? SORTS[0];
+
+  return (
+    <div className="flex h-full w-full flex-col overflow-y-auto">
+      <div className="mx-auto w-full max-w-6xl px-4 pb-12 pt-6 sm:px-6 sm:pt-8">
+        <header className="flex flex-wrap items-end justify-between gap-4">
+          <div className="min-w-0">
+            <div className="flex items-center gap-2">
+              <div className="flex items-center justify-center rounded-lg bg-muted p-2 border">
+                <FolderGit2 className="h-4 w-4" />
+              </div>
+              <h1 className="font-semibold leading-tight tracking-tight text-foreground text-2xl">
+                Projects
+              </h1>
+            </div>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Pick one to dive into its board, files, agents, and sessions.
+            </p>
+          </div>
+          <div className="flex shrink-0 items-center gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={startNewChat}
+              disabled={createSession.isPending}
+            >
+              <MessageSquarePlus />
+              New chat
+            </Button>
+            <Button
+              size="sm"
+              onClick={startNewProject}
+              disabled={createSession.isPending}
+            >
+              <Plus />
+              New project
+            </Button>
+          </div>
+        </header>
+
+        <div className="mt-6 flex flex-wrap items-center gap-2">
+          <div className="relative flex-1 sm:max-w-sm">
+            <SearchIcon className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground/70" />
+            <input
+              ref={searchRef}
+              type="text"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Search projects"
+              className={cn(
+                'h-9 w-full rounded-lg border bg-card pl-9 pr-10 text-sm',
+                'placeholder:text-muted-foreground/70',
+                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:border-foreground/30',
+                'transition-colors duration-150',
+              )}
+            />
+            {search ? (
+              <button
+                type="button"
+                onClick={() => setSearch('')}
+                className="absolute right-2 top-1/2 grid size-6 -translate-y-1/2 place-items-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground"
+                aria-label="Clear search"
+              >
+                <X className="size-3" />
+              </button>
+            ) : (
+              <Kbd className="absolute right-2 top-1/2 -translate-y-1/2 bg-transparent text-muted-foreground/70">
+                /
+              </Kbd>
+            )}
+          </div>
+
+          <div className="ml-auto flex items-center gap-1.5">
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="text-muted-foreground hover:text-foreground"
+                >
+                  <currentSort.icon />
+                  <span className="hidden sm:inline">{currentSort.label}</span>
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-48">
+                <DropdownMenuLabel className="text-xs uppercase tracking-wider text-muted-foreground/70">
+                  Sort by
+                </DropdownMenuLabel>
+                <DropdownMenuSeparator />
+                <DropdownMenuRadioGroup
+                  value={sort}
+                  onValueChange={(v) => setSort(v as SortKey)}
+                >
+                  {SORTS.map((s) => (
+                    <DropdownMenuRadioItem
+                      key={s.key}
+                      value={s.key}
+                      className="text-sm"
+                    >
+                      <s.icon className="mr-2 size-3.5 text-muted-foreground" />
+                      {s.label}
+                    </DropdownMenuRadioItem>
+                  ))}
+                </DropdownMenuRadioGroup>
+              </DropdownMenuContent>
+            </DropdownMenu>
+
+            <div className="inline-flex h-9 items-center rounded-lg border bg-card p-0.5">
+              <button
+                type="button"
+                onClick={() => setView('grid')}
+                aria-label="Grid view"
+                className={cn(
+                  'flex size-7 items-center justify-center rounded-md transition-colors',
+                  view === 'grid'
+                    ? 'bg-muted text-foreground'
+                    : 'text-muted-foreground hover:text-foreground',
+                )}
+              >
+                <LayoutGrid className="size-3.5" />
+              </button>
+              <button
+                type="button"
+                onClick={() => setView('list')}
+                aria-label="List view"
+                className={cn(
+                  'flex size-7 items-center justify-center rounded-md transition-colors',
+                  view === 'list'
+                    ? 'bg-muted text-foreground'
+                    : 'text-muted-foreground hover:text-foreground',
+                )}
+              >
+                <ListIcon className="size-3.5" />
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <div className="mt-5">
+          {showSkeleton ? (
+            <GridSkeleton />
+          ) : error ? (
+            <div className="rounded-2xl border border-dashed px-6 py-12 text-center">
+              <p className="text-sm font-medium text-foreground">
+                Couldn't load projects
+              </p>
+              <p className="mx-auto mt-1.5 max-w-md text-xs text-muted-foreground">
+                Check your sandbox connection and try again.
+              </p>
+              <Button variant="outline" size="sm" className="mt-4" onClick={() => refetch()}>
+                Retry
+              </Button>
+            </div>
+          ) : !hasProjects ? (
+            <EmptyHero onNew={startNewProject} />
+          ) : items.length === 0 ? (
+            <div className="rounded-2xl border border-dashed px-6 py-12 text-center">
+              <p className="text-sm font-medium text-foreground">
+                Nothing matched "{search}"
+              </p>
+              <p className="mx-auto mt-1.5 max-w-md text-xs text-muted-foreground">
+                Try a different search, or clear it to see every project.
+              </p>
+              <Button
+                variant="outline"
+                size="sm"
+                className="mt-4"
+                onClick={() => setSearch('')}
+              >
+                Clear search
+              </Button>
+            </div>
+          ) : view === 'grid' ? (
+            <div className="grid auto-rows-fr grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+              {items.map((p, i) => (
+                <ProjectCardGrid
+                  key={p.id}
+                  project={p}
+                  index={i}
+                  onOpen={openProject}
+                />
+              ))}
+              <NewProjectCard onClick={startNewProject} />
+            </div>
+          ) : (
+            <div className="overflow-hidden rounded-2xl border bg-card">
+              <div className="flex items-center gap-4 border-b bg-muted/20 px-4 py-2 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                <span className="w-7" />
+                <span className="flex-1">Project</span>
+                <span className="hidden sm:inline">Meta</span>
+                <span className="w-24 text-right">Activity</span>
+                <span className="w-4" />
+              </div>
+              <div className="flex flex-col">
+                {items.map((p, i) => (
+                  <ProjectRow
+                    key={p.id}
+                    project={p}
+                    index={i}
+                    onOpen={openProject}
+                  />
+                ))}
+              </div>
+              <button
+                type="button"
+                onClick={startNewProject}
+                className="flex w-full items-center gap-3 px-4 py-3 text-left text-sm text-muted-foreground transition-colors hover:bg-muted/30 hover:text-foreground"
+              >
+                <span className="flex size-7 items-center justify-center rounded-lg border border-dashed">
+                  <Plus className="size-3.5" />
+                </span>
+                <span>New project</span>
+                <Kbd className="ml-auto bg-transparent">N</Kbd>
+              </button>
+            </div>
+          )}
+        </div>
+
+        {hasProjects && !showSkeleton && items.length > 0 && (
+          <div className="mt-4 flex items-center justify-between text-xs text-muted-foreground">
+            <span className="tabular-nums">
+              Showing {items.length} of {projects?.length ?? 0}
+            </span>
+            <span className="hidden sm:inline">
+              Press <Kbd className="bg-transparent">/</Kbd> to search,{' '}
+              <Kbd className="bg-transparent">N</Kbd> for new project
+            </span>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/dashboard/projects-dashboard.tsx
+++ b/apps/web/src/components/dashboard/projects-dashboard.tsx
@@ -17,7 +17,6 @@ import {
 import { motion } from 'framer-motion';
 import { toast } from 'sonner';
 import { cn } from '@/lib/utils';
-import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Kbd } from '@/components/ui/kbd';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -34,32 +33,21 @@ import {
   useKortixProjects,
   type KortixProject,
 } from '@/hooks/kortix/use-kortix-projects';
+import { ProjectIcon } from '@/components/kortix/project-icon';
 import { useCreateOpenCodeSession } from '@/hooks/opencode/use-opencode-sessions';
 import { openTabAndNavigate } from '@/stores/tab-store';
 import { useServerStore } from '@/stores/server-store';
 
 type SortKey = 'recent' | 'name' | 'created';
-type ViewMode = 'grid' | 'list';
+type ViewMode = 'list' | 'grid';
+
+const VIEW_STORAGE_KEY = 'kortix-projects-view';
 
 const SORTS: { key: SortKey; label: string; icon: typeof Clock4 }[] = [
   { key: 'recent', label: 'Last activity', icon: Clock4 },
   { key: 'created', label: 'Recently created', icon: Sparkles },
   { key: 'name', label: 'Name', icon: ArrowDownAZ },
 ];
-
-const ICON_HUES = [12, 30, 50, 90, 145, 195, 230, 265, 305, 340] as const;
-
-function projectAccent(id: string): string {
-  let hash = 0;
-  for (let i = 0; i < id.length; i++) hash = (hash * 31 + id.charCodeAt(i)) | 0;
-  const hue = ICON_HUES[Math.abs(hash) % ICON_HUES.length];
-  return `oklch(0.62 0.14 ${hue})`;
-}
-
-function projectInitial(name: string): string {
-  const cleaned = name.replace(/[^A-Za-z0-9]/g, '').trim();
-  return (cleaned[0] || '?').toUpperCase();
-}
 
 function relativeWhen(input?: number | string | null): string | null {
   if (input == null) return null;
@@ -99,360 +87,22 @@ function isActive(p: KortixProject, withinDays = 7): boolean {
   return Date.now() - updated < withinDays * 86_400_000;
 }
 
-type IconSize = 'sm' | 'md';
-
-const ICON_SIZE_CLASS: Record<IconSize, string> = {
-  sm: 'size-7 text-xs',
-  md: 'size-9 text-sm',
-};
-
-function ProjectIcon({
-  project,
-  size = 'md',
-  className,
-}: {
-  project: KortixProject;
-  size?: IconSize;
-  className?: string;
-}) {
-  const accent = projectAccent(project.id);
-  const initial = projectInitial(project.name);
-  return (
-    <div
-      className={cn(
-        'flex shrink-0 items-center justify-center rounded-lg font-semibold tracking-tight text-white ring-1 ring-inset ring-white/10',
-        ICON_SIZE_CLASS[size],
-        className,
-      )}
-      style={{ backgroundColor: accent }}
-    >
-      {initial}
-    </div>
-  );
-}
-
-function ActivityPulse({ active }: { active: boolean }) {
-  if (!active) {
-    return (
-      <span className="relative flex h-1.5 w-1.5 shrink-0 items-center justify-center">
-        <span className="h-1.5 w-1.5 rounded-full bg-muted-foreground/30" />
-      </span>
-    );
-  }
-  return (
-    <span className="relative flex h-1.5 w-1.5 shrink-0 items-center justify-center">
-      <span className="absolute h-2.5 w-2.5 animate-ping rounded-full bg-emerald-500/40" />
-      <span className="relative h-1.5 w-1.5 rounded-full bg-emerald-500" />
-    </span>
-  );
-}
-
-const CARD_BASE = cn(
-  'group relative flex h-full flex-col rounded-2xl border bg-card p-4 text-left',
-  'transition-colors duration-150 hover:bg-muted/30',
-  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40',
-);
-
-function CardHeader({
-  left,
-  right,
-}: {
-  left: React.ReactNode;
-  right: React.ReactNode;
-}) {
-  return (
-    <div className="flex items-start justify-between gap-2">
-      {left}
-      <span
-        aria-hidden
-        className="text-muted-foreground/30 transition-colors duration-150 group-hover:text-foreground"
-      >
-        {right}
-      </span>
-    </div>
-  );
-}
-
-function CardTitle({
-  title,
-  pathLabel,
-  pathMono = true,
-}: {
-  title: string;
-  pathLabel: string;
-  pathMono?: boolean;
-}) {
-  return (
-    <div className="mt-3 min-w-0">
-      <h3 className="truncate text-sm font-semibold leading-tight tracking-tight text-foreground">
-        {title}
-      </h3>
-      <Badge
-        variant="secondary"
-        size="sm"
-        className={cn(
-          'mt-1.5 max-w-full rounded-md normal-case tracking-normal',
-          pathMono && 'font-mono',
-        )}
-      >
-        <span className="truncate">{pathLabel}</span>
-      </Badge>
-    </div>
-  );
-}
-
-function CardBody({ children }: { children: React.ReactNode }) {
-  return (
-    <p className="mt-2 line-clamp-2 min-h-8 text-xs leading-snug text-muted-foreground">
-      {children}
-    </p>
-  );
-}
-
-function CardFooter({ children }: { children: React.ReactNode }) {
-  return <div className="mt-auto flex items-center gap-1.5 pt-3">{children}</div>;
-}
-
-function ProjectCardGrid({
-  project,
-  index,
-  onOpen,
-}: {
-  project: KortixProject;
-  index: number;
-  onOpen: (p: KortixProject) => void;
-}) {
-  const updated = relativeWhen(project.time?.updated ?? project.created_at);
-  const active = isActive(project);
-  const isV2 = project.structure_version === 2;
-  const cleanPath =
-    project.path && project.path !== '/' && project.path !== '/workspace'
-      ? project.path
-      : '/workspace';
-  const sessions = project.sessionCount ?? 0;
-
-  return (
-    <motion.button
-      type="button"
-      onClick={() => onOpen(project)}
-      layout
-      initial={{ opacity: 0, y: 4 }}
-      animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.15, delay: Math.min(index * 0.01, 0.1), ease: 'easeOut' }}
-      className={CARD_BASE}
-    >
-      <CardHeader
-        left={<ProjectIcon project={project} size="md" />}
-        right={
-          <ArrowUpRight className="size-4 transition-transform duration-200 group-hover:translate-x-0.5 group-hover:-translate-y-0.5" />
-        }
-      />
-      <CardTitle title={project.name} pathLabel={`~${cleanPath}`} />
-      <CardBody>
-        {project.description?.trim() || (
-          <span className="italic text-muted-foreground/40">No description</span>
-        )}
-      </CardBody>
-      <CardFooter>
-        <Badge
-          variant={active ? 'success' : 'muted'}
-          size="sm"
-          className="gap-1.5 uppercase tracking-wider tabular-nums"
-        >
-          <ActivityPulse active={active} />
-          {updated ?? 'idle'}
-        </Badge>
-        <div className="ml-auto flex items-center gap-1">
-          {sessions > 0 && (
-            <Badge
-              variant="muted"
-              size="sm"
-              className="uppercase tracking-wider tabular-nums"
-            >
-              <span className="font-semibold text-foreground/80">{sessions}</span>
-              sess
-            </Badge>
-          )}
-          <Badge
-            variant={isV2 ? 'highlight' : 'muted'}
-            size="sm"
-            className="font-semibold uppercase tracking-wider tabular-nums"
-          >
-            {isV2 ? 'v2' : 'v1'}
-          </Badge>
-        </div>
-      </CardFooter>
-    </motion.button>
-  );
-}
-
-function ProjectRow({
-  project,
-  index,
-  onOpen,
-}: {
-  project: KortixProject;
-  index: number;
-  onOpen: (p: KortixProject) => void;
-}) {
-  const updated = relativeWhen(project.time?.updated ?? project.created_at);
-  const active = isActive(project);
-  const isV2 = project.structure_version === 2;
-  const cleanPath =
-    project.path && project.path !== '/' && project.path !== '/workspace'
-      ? project.path
-      : null;
-  const sessions = project.sessionCount ?? 0;
-
-  return (
-    <motion.button
-      type="button"
-      onClick={() => onOpen(project)}
-      layout
-      initial={{ opacity: 0, y: 4 }}
-      animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.15, delay: Math.min(index * 0.01, 0.1), ease: 'easeOut' }}
-      className={cn(
-        'group flex w-full items-center gap-4 border-b px-4 py-3 text-left',
-        'transition-colors duration-150 hover:bg-muted/30 focus-visible:bg-muted/40 focus-visible:outline-none',
-      )}
-    >
-      <ProjectIcon project={project} size="sm" />
-      <div className="min-w-0 flex-1">
-        <div className="flex items-center gap-2">
-          <h3 className="truncate text-sm font-medium text-foreground">
-            {project.name}
-          </h3>
-          {cleanPath && (
-            <Badge
-              variant="secondary"
-              size="sm"
-              className="hidden rounded-md font-mono normal-case tracking-normal sm:inline-flex"
-            >
-              {cleanPath}
-            </Badge>
-          )}
-        </div>
-        {project.description?.trim() && (
-          <p className="mt-0.5 truncate text-xs text-muted-foreground">
-            {project.description}
-          </p>
-        )}
-      </div>
-      <div className="hidden items-center gap-1.5 sm:flex">
-        {sessions > 0 && (
-          <Badge variant="muted" size="sm" className="uppercase tracking-wider tabular-nums">
-            <span className="font-semibold text-foreground/80">{sessions}</span>
-            sess
-          </Badge>
-        )}
-        <Badge
-          variant={isV2 ? 'highlight' : 'muted'}
-          size="sm"
-          className="font-semibold uppercase tracking-wider tabular-nums"
-        >
-          {isV2 ? 'v2' : 'v1'}
-        </Badge>
-      </div>
-      <div className="flex w-24 shrink-0 items-center gap-2 text-xs text-muted-foreground">
-        <ActivityPulse active={active} />
-        <span className="truncate tabular-nums">{updated ?? '—'}</span>
-      </div>
-      <ArrowUpRight className="size-4 shrink-0 text-muted-foreground/30 transition-colors duration-150 group-hover:text-foreground" />
-    </motion.button>
-  );
-}
-
-function NewProjectCard({ onClick }: { onClick: () => void }) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      className={cn(CARD_BASE, 'border-dashed bg-transparent')}
-    >
-      <CardHeader
-        left={
-          <span className="flex size-9 items-center justify-center rounded-lg border border-dashed text-muted-foreground transition-transform duration-200 group-hover:rotate-90 group-hover:text-foreground">
-            <Plus className="size-4" />
-          </span>
-        }
-        right={<ArrowUpRight className="size-4 transition-transform duration-200 group-hover:translate-x-0.5 group-hover:-translate-y-0.5" />}
-      />
-      <CardTitle title="New project" pathLabel="scaffold" pathMono={false} />
-      <CardBody>
-        Suna asks what you want to build, then sets up files, agents, and a board for you.
-      </CardBody>
-      <CardFooter>
-        <Badge variant="muted" size="sm" className="uppercase tracking-wider">
-          Ready
-        </Badge>
-        <Kbd className="ml-auto bg-transparent">N</Kbd>
-      </CardFooter>
-    </button>
-  );
-}
-
-function GridSkeleton() {
-  return (
-    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-      {Array.from({ length: 8 }).map((_, i) => (
-        <div
-          key={i}
-          className="flex flex-col rounded-2xl border bg-card p-4"
-        >
-          <div className="flex items-start justify-between gap-2">
-            <Skeleton className="size-9 rounded-lg" />
-            <Skeleton className="size-4 rounded" />
-          </div>
-          <div className="mt-3 space-y-2">
-            <Skeleton className="h-3.5 w-2/3" />
-            <Skeleton className="h-4 w-1/2 rounded-md" />
-          </div>
-          <div className="mt-2 space-y-1.5">
-            <Skeleton className="h-3 w-full" />
-            <Skeleton className="h-3 w-3/4" />
-          </div>
-          <div className="mt-auto flex items-center justify-between pt-3">
-            <Skeleton className="h-5 w-20 rounded-2xl" />
-            <Skeleton className="h-5 w-10 rounded-2xl" />
-          </div>
-        </div>
-      ))}
-    </div>
-  );
-}
-
-function EmptyHero({ onNew }: { onNew: () => void }) {
-  return (
-    <div className="rounded-2xl border border-dashed bg-card/40 px-6 py-12 text-center">
-      <div className="mx-auto flex size-10 items-center justify-center rounded-lg border bg-card text-foreground">
-        <FolderGit2 className="size-4" />
-      </div>
-      <h2 className="mt-4 text-base font-semibold tracking-tight text-foreground">
-        Spin up your first project
-      </h2>
-      <p className="mx-auto mt-1.5 max-w-md text-xs leading-relaxed text-muted-foreground">
-        Projects group files, boards, agents, and sessions. Start one and the rest
-        of the workspace fills in around it.
-      </p>
-      <div className="mt-5 flex items-center justify-center gap-2">
-        <Button onClick={onNew} size="sm">
-          <Plus />
-          New project
-        </Button>
-        <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
-          or press <Kbd className="bg-transparent">N</Kbd>
-        </span>
-      </div>
-    </div>
-  );
-}
-
 export function ProjectsDashboard() {
   const [search, setSearch] = useState('');
   const [sort, setSort] = useState<SortKey>('recent');
-  const [view, setView] = useState<ViewMode>('grid');
+  const [view, setView] = useState<ViewMode>('list');
   const searchRef = useRef<HTMLInputElement>(null);
+
+  // Persist view preference across reloads
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(VIEW_STORAGE_KEY);
+      if (stored === 'list' || stored === 'grid') setView(stored);
+    } catch { /* private mode */ }
+  }, []);
+  useEffect(() => {
+    try { localStorage.setItem(VIEW_STORAGE_KEY, view); } catch { /* private mode */ }
+  }, [view]);
 
   const { data: projects, isLoading, error, refetch } = useKortixProjects();
   const createSession = useCreateOpenCodeSession();
@@ -477,6 +127,13 @@ export function ProjectsDashboard() {
     });
     return filtered;
   }, [projects, search, sort]);
+
+  const stats = useMemo(() => {
+    const list = projects ?? [];
+    const active = list.filter((p) => isActive(p)).length;
+    const totalSessions = list.reduce((sum, p) => sum + (p.sessionCount ?? 0), 0);
+    return { total: list.length, active, totalSessions };
+  }, [projects]);
 
   const openProject = useCallback((p: KortixProject) => {
     openTabAndNavigate({
@@ -554,232 +211,532 @@ export function ProjectsDashboard() {
   const currentSort = SORTS.find((s) => s.key === sort) ?? SORTS[0];
 
   return (
-    <div className="flex h-full w-full flex-col overflow-y-auto">
-      <div className="mx-auto w-full max-w-6xl px-4 pb-12 pt-6 sm:px-6 sm:pt-8">
-        <header className="flex flex-wrap items-end justify-between gap-4">
-          <div className="min-w-0">
-            <div className="flex items-center gap-2">
-              <div className="flex items-center justify-center rounded-lg bg-muted p-2 border">
-                <FolderGit2 className="h-4 w-4" />
+    <div className="h-full overflow-y-auto">
+      <motion.div
+        initial="hidden"
+        animate="show"
+        variants={{
+          hidden: {},
+          show: { transition: { staggerChildren: 0.04, delayChildren: 0.04 } },
+        }}
+        className="mx-auto w-full max-w-3xl px-6 pt-12 pb-24"
+      >
+        <Section>
+          <header>
+            <div className="flex flex-wrap items-end justify-between gap-3">
+              <div className="min-w-0">
+                <h1 className="text-xl font-semibold tracking-tight text-foreground">
+                  Projects
+                </h1>
+                <p className="mt-1.5 text-sm leading-relaxed text-muted-foreground">
+                  Pick one to dive into its board, files, agents, and sessions.
+                </p>
               </div>
-              <h1 className="font-semibold leading-tight tracking-tight text-foreground text-2xl">
-                Projects
-              </h1>
-            </div>
-            <p className="mt-1 text-sm text-muted-foreground">
-              Pick one to dive into its board, files, agents, and sessions.
-            </p>
-          </div>
-          <div className="flex shrink-0 items-center gap-2">
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={startNewChat}
-              disabled={createSession.isPending}
-            >
-              <MessageSquarePlus />
-              New chat
-            </Button>
-            <Button
-              size="sm"
-              onClick={startNewProject}
-              disabled={createSession.isPending}
-            >
-              <Plus />
-              New project
-            </Button>
-          </div>
-        </header>
-
-        <div className="mt-6 flex flex-wrap items-center gap-2">
-          <div className="relative flex-1 sm:max-w-sm">
-            <SearchIcon className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground/70" />
-            <input
-              ref={searchRef}
-              type="text"
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              placeholder="Search projects"
-              className={cn(
-                'h-9 w-full rounded-lg border bg-card pl-9 pr-10 text-sm',
-                'placeholder:text-muted-foreground/70',
-                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:border-foreground/30',
-                'transition-colors duration-150',
-              )}
-            />
-            {search ? (
-              <button
-                type="button"
-                onClick={() => setSearch('')}
-                className="absolute right-2 top-1/2 grid size-6 -translate-y-1/2 place-items-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground"
-                aria-label="Clear search"
-              >
-                <X className="size-3" />
-              </button>
-            ) : (
-              <Kbd className="absolute right-2 top-1/2 -translate-y-1/2 bg-transparent text-muted-foreground/70">
-                /
-              </Kbd>
-            )}
-          </div>
-
-          <div className="ml-auto flex items-center gap-1.5">
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
+              <div className="flex shrink-0 items-center gap-2">
                 <Button
-                  variant="outline"
+                  variant="ghost"
                   size="sm"
+                  onClick={startNewChat}
+                  disabled={createSession.isPending}
                   className="text-muted-foreground hover:text-foreground"
                 >
-                  <currentSort.icon />
-                  <span className="hidden sm:inline">{currentSort.label}</span>
+                  <MessageSquarePlus />
+                  New chat
                 </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="w-48">
-                <DropdownMenuLabel className="text-xs uppercase tracking-wider text-muted-foreground/70">
-                  Sort by
-                </DropdownMenuLabel>
-                <DropdownMenuSeparator />
-                <DropdownMenuRadioGroup
-                  value={sort}
-                  onValueChange={(v) => setSort(v as SortKey)}
+                <Button
+                  size="sm"
+                  onClick={startNewProject}
+                  disabled={createSession.isPending}
                 >
-                  {SORTS.map((s) => (
-                    <DropdownMenuRadioItem
-                      key={s.key}
-                      value={s.key}
-                      className="text-sm"
-                    >
-                      <s.icon className="mr-2 size-3.5 text-muted-foreground" />
-                      {s.label}
-                    </DropdownMenuRadioItem>
-                  ))}
-                </DropdownMenuRadioGroup>
-              </DropdownMenuContent>
-            </DropdownMenu>
+                  <Plus />
+                  New project
+                </Button>
+              </div>
+            </div>
+          </header>
+        </Section>
 
-            <div className="inline-flex h-9 items-center rounded-lg border bg-card p-0.5">
-              <button
-                type="button"
-                onClick={() => setView('grid')}
-                aria-label="Grid view"
+        {hasProjects && (
+          <Section delay>
+            <div className="flex flex-wrap items-center gap-x-2 gap-y-2">
+              <StatPill label={stats.total === 1 ? 'project' : 'projects'} value={stats.total} dot="bg-blue-500" />
+              <StatPill label="active" value={stats.active} dot="bg-emerald-500" />
+              <StatPill
+                label={stats.totalSessions === 1 ? 'session' : 'sessions'}
+                value={stats.totalSessions}
+                dot="bg-violet-500"
+              />
+            </div>
+          </Section>
+        )}
+
+        <Section delay>
+          <div className="flex flex-wrap items-center gap-2">
+            <div className="relative flex-1 sm:max-w-sm">
+              <SearchIcon className="pointer-events-none absolute left-3 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground/45" />
+              <input
+                ref={searchRef}
+                type="text"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                placeholder="Search projects"
                 className={cn(
-                  'flex size-7 items-center justify-center rounded-md transition-colors',
-                  view === 'grid'
-                    ? 'bg-muted text-foreground'
-                    : 'text-muted-foreground hover:text-foreground',
+                  'h-8 w-full rounded-full bg-muted/40 pl-8 pr-10 text-sm outline-none transition-colors',
+                  'placeholder:text-muted-foreground/45',
+                  'hover:bg-muted/60 focus:bg-muted/70 focus:ring-2 focus:ring-ring/20',
                 )}
-              >
-                <LayoutGrid className="size-3.5" />
-              </button>
-              <button
-                type="button"
-                onClick={() => setView('list')}
-                aria-label="List view"
-                className={cn(
-                  'flex size-7 items-center justify-center rounded-md transition-colors',
-                  view === 'list'
-                    ? 'bg-muted text-foreground'
-                    : 'text-muted-foreground hover:text-foreground',
-                )}
-              >
-                <ListIcon className="size-3.5" />
-              </button>
+              />
+              {search ? (
+                <button
+                  type="button"
+                  onClick={() => setSearch('')}
+                  className="absolute right-2 top-1/2 inline-flex size-5 -translate-y-1/2 items-center justify-center rounded-full text-muted-foreground/55 hover:bg-muted hover:text-foreground"
+                  aria-label="Clear search"
+                >
+                  <X className="size-3" />
+                </button>
+              ) : (
+                <Kbd className="absolute right-2 top-1/2 -translate-y-1/2 bg-transparent text-muted-foreground/55">
+                  /
+                </Kbd>
+              )}
+            </div>
+
+            <div className="ml-auto flex items-center gap-1.5">
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="text-muted-foreground hover:text-foreground"
+                  >
+                    <currentSort.icon />
+                    <span className="hidden sm:inline">{currentSort.label}</span>
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="w-48">
+                  <DropdownMenuLabel className="text-xs uppercase tracking-wider text-muted-foreground/70">
+                    Sort by
+                  </DropdownMenuLabel>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuRadioGroup
+                    value={sort}
+                    onValueChange={(v) => setSort(v as SortKey)}
+                  >
+                    {SORTS.map((s) => (
+                      <DropdownMenuRadioItem key={s.key} value={s.key} className="text-sm">
+                        <s.icon className="mr-2 size-3.5 text-muted-foreground" />
+                        {s.label}
+                      </DropdownMenuRadioItem>
+                    ))}
+                  </DropdownMenuRadioGroup>
+                </DropdownMenuContent>
+              </DropdownMenu>
+
+              <ViewToggle view={view} onChange={setView} />
             </div>
           </div>
-        </div>
+        </Section>
 
-        <div className="mt-5">
+        <Section delay>
           {showSkeleton ? (
-            <GridSkeleton />
+            view === 'list' ? <ListSkeleton /> : <GridSkeleton />
           ) : error ? (
-            <div className="rounded-2xl border border-dashed px-6 py-12 text-center">
-              <p className="text-sm font-medium text-foreground">
-                Couldn't load projects
-              </p>
-              <p className="mx-auto mt-1.5 max-w-md text-xs text-muted-foreground">
-                Check your sandbox connection and try again.
-              </p>
-              <Button variant="outline" size="sm" className="mt-4" onClick={() => refetch()}>
-                Retry
-              </Button>
-            </div>
+            <ErrorBlock onRetry={() => refetch()} />
           ) : !hasProjects ? (
             <EmptyHero onNew={startNewProject} />
           ) : items.length === 0 ? (
-            <div className="rounded-2xl border border-dashed px-6 py-12 text-center">
-              <p className="text-sm font-medium text-foreground">
-                Nothing matched "{search}"
-              </p>
-              <p className="mx-auto mt-1.5 max-w-md text-xs text-muted-foreground">
-                Try a different search, or clear it to see every project.
-              </p>
-              <Button
-                variant="outline"
-                size="sm"
-                className="mt-4"
-                onClick={() => setSearch('')}
-              >
-                Clear search
-              </Button>
-            </div>
-          ) : view === 'grid' ? (
-            <div className="grid auto-rows-fr grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+            <NoMatchBlock onClear={() => setSearch('')} query={search} />
+          ) : view === 'list' ? (
+            <div className="overflow-hidden rounded-2xl bg-muted/30">
               {items.map((p, i) => (
-                <ProjectCardGrid
+                <ProjectRow
                   key={p.id}
                   project={p}
-                  index={i}
                   onOpen={openProject}
+                  isLast={i === items.length - 1}
                 />
+              ))}
+              <NewProjectRow onClick={startNewProject} />
+            </div>
+          ) : (
+            <div className="grid auto-rows-fr grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+              {items.map((p) => (
+                <ProjectCard key={p.id} project={p} onOpen={openProject} />
               ))}
               <NewProjectCard onClick={startNewProject} />
             </div>
-          ) : (
-            <div className="overflow-hidden rounded-2xl border bg-card">
-              <div className="flex items-center gap-4 border-b bg-muted/20 px-4 py-2 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                <span className="w-7" />
-                <span className="flex-1">Project</span>
-                <span className="hidden sm:inline">Meta</span>
-                <span className="w-24 text-right">Activity</span>
-                <span className="w-4" />
-              </div>
-              <div className="flex flex-col">
-                {items.map((p, i) => (
-                  <ProjectRow
-                    key={p.id}
-                    project={p}
-                    index={i}
-                    onOpen={openProject}
-                  />
-                ))}
-              </div>
-              <button
-                type="button"
-                onClick={startNewProject}
-                className="flex w-full items-center gap-3 px-4 py-3 text-left text-sm text-muted-foreground transition-colors hover:bg-muted/30 hover:text-foreground"
-              >
-                <span className="flex size-7 items-center justify-center rounded-lg border border-dashed">
-                  <Plus className="size-3.5" />
-                </span>
-                <span>New project</span>
-                <Kbd className="ml-auto bg-transparent">N</Kbd>
-              </button>
-            </div>
           )}
-        </div>
+        </Section>
 
         {hasProjects && !showSkeleton && items.length > 0 && (
-          <div className="mt-4 flex items-center justify-between text-xs text-muted-foreground">
-            <span className="tabular-nums">
-              Showing {items.length} of {projects?.length ?? 0}
-            </span>
-            <span className="hidden sm:inline">
-              Press <Kbd className="bg-transparent">/</Kbd> to search,{' '}
-              <Kbd className="bg-transparent">N</Kbd> for new project
-            </span>
-          </div>
+          <Section delay>
+            <div className="flex items-center justify-between text-xs text-muted-foreground/60">
+              <span className="tabular-nums">
+                Showing {items.length} of {projects?.length ?? 0}
+              </span>
+              <span className="hidden sm:inline">
+                Press <Kbd className="bg-transparent">/</Kbd> to search,{' '}
+                <Kbd className="bg-transparent">N</Kbd> for new project
+              </span>
+            </div>
+          </Section>
         )}
+      </motion.div>
+    </div>
+  );
+}
+
+function Section({ children, delay }: { children: React.ReactNode; delay?: boolean }) {
+  return (
+    <motion.section
+      variants={{
+        hidden: { opacity: 0, y: 6 },
+        show: { opacity: 1, y: 0, transition: { duration: 0.3, ease: 'easeOut' } },
+      }}
+      className={cn(delay && 'mt-6')}
+    >
+      {children}
+    </motion.section>
+  );
+}
+
+function StatPill({
+  label,
+  value,
+  dot,
+}: {
+  label: string;
+  value: number;
+  dot: string;
+}) {
+  return (
+    <span className="inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-xs text-muted-foreground">
+      <span className={cn('size-1.5 rounded-full', dot)} />
+      <span className="font-semibold tabular-nums text-foreground">{value}</span>
+      <span>{label}</span>
+    </span>
+  );
+}
+
+function ProjectRow({
+  project,
+  onOpen,
+  isLast,
+}: {
+  project: KortixProject;
+  onOpen: (p: KortixProject) => void;
+  isLast: boolean;
+}) {
+  const updated = relativeWhen(project.time?.updated ?? project.created_at);
+  const active = isActive(project);
+  const isV2 = project.structure_version === 2;
+  const cleanPath =
+    project.path && project.path !== '/' && project.path !== '/workspace'
+      ? project.path
+      : null;
+  const sessions = project.sessionCount ?? 0;
+  const description = project.description?.trim();
+
+  return (
+    <button
+      type="button"
+      onClick={() => onOpen(project)}
+      className={cn(
+        'group flex w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-muted/60',
+        !isLast && 'border-b border-border/40',
+      )}
+    >
+      <ProjectIcon project={project} size="sm" />
+
+      <div className="min-w-0 flex-1">
+        <div className="flex min-w-0 items-center gap-2">
+          <h3 className="truncate text-sm font-medium text-foreground">{project.name}</h3>
+          {active && <span className="size-1.5 shrink-0 rounded-full bg-emerald-500" />}
+          {isV2 && (
+            <span className="hidden shrink-0 rounded-md bg-muted/60 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-muted-foreground/70 sm:inline">
+              v2
+            </span>
+          )}
+        </div>
+        <div className="mt-0.5 flex min-w-0 items-center gap-2 text-xs text-muted-foreground/65">
+          {cleanPath && <span className="truncate">~{cleanPath}</span>}
+          {description && (
+            <>
+              <span className="text-muted-foreground/30">·</span>
+              <span className="truncate">{description}</span>
+            </>
+          )}
+        </div>
+      </div>
+
+      <div className="hidden items-center gap-3 text-xs tabular-nums text-muted-foreground/65 sm:flex">
+        {sessions > 0 && (
+          <span>
+            <span className="font-medium text-foreground/80">{sessions}</span>{' '}
+            {sessions === 1 ? 'session' : 'sessions'}
+          </span>
+        )}
+        {updated && <span>{updated}</span>}
+      </div>
+
+      <ArrowUpRight className="size-3.5 shrink-0 text-muted-foreground/30 transition-all group-hover:-translate-y-0.5 group-hover:translate-x-0.5 group-hover:text-foreground" />
+    </button>
+  );
+}
+
+function NewProjectRow({ onClick }: { onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="group flex w-full items-center gap-3 border-t border-border/40 px-4 py-3 text-left transition-colors hover:bg-muted/60"
+    >
+      <span className="inline-flex size-7 items-center justify-center rounded-full bg-muted/60 text-muted-foreground/70 transition-colors group-hover:bg-muted group-hover:text-foreground">
+        <Plus className="size-3.5" />
+      </span>
+      <span className="text-sm font-medium text-muted-foreground/80 group-hover:text-foreground">
+        New project
+      </span>
+      <Kbd className="ml-auto bg-transparent text-muted-foreground/55">N</Kbd>
+    </button>
+  );
+}
+
+function ListSkeleton() {
+  return (
+    <div className="overflow-hidden rounded-2xl bg-muted/30">
+      {Array.from({ length: 5 }).map((_, i) => (
+        <div
+          key={i}
+          className={cn(
+            'flex items-center gap-3 px-4 py-3',
+            i !== 4 && 'border-b border-border/40',
+          )}
+        >
+          <Skeleton className="size-7 rounded-md" />
+          <div className="flex-1 space-y-1.5">
+            <Skeleton className="h-3.5 w-40" />
+            <Skeleton className="h-3 w-64" />
+          </div>
+          <Skeleton className="hidden h-3 w-20 sm:block" />
+          <Skeleton className="hidden h-3 w-12 sm:block" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function ErrorBlock({ onRetry }: { onRetry: () => void }) {
+  return (
+    <div className="rounded-2xl bg-muted/30 px-6 py-12 text-center">
+      <p className="text-sm font-medium text-foreground">Couldn&apos;t load projects</p>
+      <p className="mx-auto mt-1.5 max-w-md text-xs text-muted-foreground/70">
+        Check your sandbox connection and try again.
+      </p>
+      <Button variant="outline" size="sm" className="mt-4" onClick={onRetry}>
+        Retry
+      </Button>
+    </div>
+  );
+}
+
+function NoMatchBlock({ onClear, query }: { onClear: () => void; query: string }) {
+  return (
+    <div className="rounded-2xl bg-muted/30 px-6 py-12 text-center">
+      <p className="text-sm font-medium text-foreground">
+        Nothing matched &quot;{query}&quot;
+      </p>
+      <p className="mx-auto mt-1.5 max-w-md text-xs text-muted-foreground/70">
+        Try a different search, or clear it to see every project.
+      </p>
+      <Button variant="outline" size="sm" className="mt-4" onClick={onClear}>
+        Clear search
+      </Button>
+    </div>
+  );
+}
+
+function ViewToggle({
+  view,
+  onChange,
+}: {
+  view: ViewMode;
+  onChange: (v: ViewMode) => void;
+}) {
+  return (
+    <div className="inline-flex h-8 items-center rounded-full bg-muted/40 p-0.5">
+      <button
+        type="button"
+        onClick={() => onChange('list')}
+        aria-label="List view"
+        title="List view"
+        className={cn(
+          'flex size-7 items-center justify-center rounded-full transition-colors',
+          view === 'list'
+            ? 'bg-background text-foreground'
+            : 'text-muted-foreground/65 hover:text-foreground',
+        )}
+      >
+        <ListIcon className="size-3.5" />
+      </button>
+      <button
+        type="button"
+        onClick={() => onChange('grid')}
+        aria-label="Grid view"
+        title="Grid view"
+        className={cn(
+          'flex size-7 items-center justify-center rounded-full transition-colors',
+          view === 'grid'
+            ? 'bg-background text-foreground'
+            : 'text-muted-foreground/65 hover:text-foreground',
+        )}
+      >
+        <LayoutGrid className="size-3.5" />
+      </button>
+    </div>
+  );
+}
+
+function ProjectCard({
+  project,
+  onOpen,
+}: {
+  project: KortixProject;
+  onOpen: (p: KortixProject) => void;
+}) {
+  const updated = relativeWhen(project.time?.updated ?? project.created_at);
+  const active = isActive(project);
+  const isV2 = project.structure_version === 2;
+  const cleanPath =
+    project.path && project.path !== '/' && project.path !== '/workspace'
+      ? project.path
+      : null;
+  const sessions = project.sessionCount ?? 0;
+  const description = project.description?.trim();
+
+  return (
+    <button
+      type="button"
+      onClick={() => onOpen(project)}
+      className={cn(
+        'group relative flex h-full flex-col gap-3 rounded-2xl bg-muted/30 p-4 text-left transition-colors',
+        'hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30',
+      )}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <ProjectIcon project={project} size="md" />
+        <ArrowUpRight className="size-3.5 shrink-0 text-muted-foreground/30 transition-all group-hover:-translate-y-0.5 group-hover:translate-x-0.5 group-hover:text-foreground" />
+      </div>
+
+      <div className="min-w-0">
+        <div className="flex min-w-0 items-center gap-2">
+          <h3 className="truncate text-sm font-medium text-foreground">{project.name}</h3>
+          {active && <span className="size-1.5 shrink-0 rounded-full bg-emerald-500" />}
+          {isV2 && (
+            <span className="ml-auto shrink-0 rounded-md bg-muted/60 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-muted-foreground/70">
+              v2
+            </span>
+          )}
+        </div>
+        {cleanPath && (
+          <p className="mt-0.5 truncate text-xs text-muted-foreground/65">~{cleanPath}</p>
+        )}
+      </div>
+
+      <p className="line-clamp-2 min-h-8 text-xs leading-relaxed text-muted-foreground/75">
+        {description ?? (
+          <span className="italic text-muted-foreground/40">No description</span>
+        )}
+      </p>
+
+      <div className="mt-auto flex items-center gap-2 text-xs tabular-nums text-muted-foreground/60">
+        {sessions > 0 && (
+          <>
+            <span>
+              <span className="font-medium text-foreground/80">{sessions}</span>{' '}
+              {sessions === 1 ? 'session' : 'sessions'}
+            </span>
+            {updated && <span className="text-muted-foreground/30">·</span>}
+          </>
+        )}
+        {updated && <span>{updated}</span>}
+      </div>
+    </button>
+  );
+}
+
+function NewProjectCard({ onClick }: { onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        'group flex h-full flex-col items-start justify-between gap-3 rounded-2xl border border-dashed border-border/60 bg-transparent p-4 text-left transition-colors',
+        'hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30',
+      )}
+    >
+      <span className="inline-flex size-9 items-center justify-center rounded-lg bg-muted/40 text-muted-foreground/70 transition-colors group-hover:bg-muted group-hover:text-foreground">
+        <Plus className="size-4" />
+      </span>
+      <div>
+        <h3 className="text-sm font-medium text-foreground">New project</h3>
+        <p className="mt-1 text-xs leading-relaxed text-muted-foreground/70">
+          Suna asks what you want to build, then sets up files, agents, and a board for you.
+        </p>
+      </div>
+      <Kbd className="ml-auto bg-transparent text-muted-foreground/55">N</Kbd>
+    </button>
+  );
+}
+
+function GridSkeleton() {
+  return (
+    <div className="grid auto-rows-fr grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+      {Array.from({ length: 6 }).map((_, i) => (
+        <div key={i} className="flex flex-col gap-3 rounded-2xl bg-muted/30 p-4">
+          <div className="flex items-start justify-between">
+            <Skeleton className="size-9 rounded-xl" />
+            <Skeleton className="size-3.5 rounded" />
+          </div>
+          <div className="space-y-1.5">
+            <Skeleton className="h-3.5 w-2/3" />
+            <Skeleton className="h-3 w-1/2" />
+          </div>
+          <div className="space-y-1.5">
+            <Skeleton className="h-3 w-full" />
+            <Skeleton className="h-3 w-3/4" />
+          </div>
+          <div className="mt-auto">
+            <Skeleton className="h-3 w-32" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function EmptyHero({ onNew }: { onNew: () => void }) {
+  return (
+    <div className="rounded-2xl bg-muted/30 px-6 py-16 text-center">
+      <div className="mx-auto inline-flex size-10 items-center justify-center rounded-full bg-muted/60">
+        <FolderGit2 className="size-4 text-muted-foreground/70" />
+      </div>
+      <h2 className="mt-3 text-sm font-medium text-foreground">
+        Spin up your first project
+      </h2>
+      <p className="mx-auto mt-1 max-w-md text-xs leading-relaxed text-muted-foreground/70">
+        Projects group files, boards, agents, and sessions. Start one and the rest
+        of the workspace fills in around it.
+      </p>
+      <div className="mt-4 inline-flex items-center gap-2">
+        <Button onClick={onNew} size="sm">
+          <Plus />
+          New project
+        </Button>
+        <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground/65">
+          or press <Kbd className="bg-transparent">N</Kbd>
+        </span>
       </div>
     </div>
   );

--- a/apps/web/src/components/kortix-brand.tsx
+++ b/apps/web/src/components/kortix-brand.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import Link from 'next/link';
+import {
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+} from '@/components/ui/sidebar';
+import { KortixLogo } from '@/components/sidebar/kortix-logo';
+
+/**
+ * Brand row for the sidebar header — replaces the shadcn TeamSwitcher block.
+ * Matches the same `size-lg` slot dimensions so the header stays vertically
+ * aligned with the rest of the sidebar primitives.
+ */
+export function KortixBrand({ href = '/dashboard' }: { href?: string }) {
+  return (
+    <SidebarMenu>
+      <SidebarMenuItem>
+        <div className="flex items-center justify-start p-2">
+          <Link href={href} aria-label="Kortix home">
+            <KortixLogo size={16} variant="logomark" />
+          </Link>
+        </div>
+      </SidebarMenuItem>
+    </SidebarMenu>
+  );
+}

--- a/apps/web/src/components/kortix/channels-tab.tsx
+++ b/apps/web/src/components/kortix/channels-tab.tsx
@@ -126,26 +126,24 @@ export function ChannelsTab({ projectId }: { projectId: string }) {
   const slack = useMemo(() => channels.filter((c) => c.platform === 'slack'), [channels]);
 
   return (
-    <div className="h-full flex flex-col overflow-hidden">
-      {/* Header */}
-      <div className="shrink-0 border-b border-border/40 px-4 py-3 flex items-center justify-between gap-2">
-        <div className="flex items-center gap-2">
-          <Radio className="h-3.5 w-3.5 text-muted-foreground" />
-          <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Channels</span>
-          <Badge variant="secondary" className="text-[10px] tabular-nums">{channels.length}</Badge>
+    <div className="h-full overflow-y-auto">
+      <div className="mx-auto w-full max-w-3xl px-4 sm:px-6 py-8 space-y-6">
+        <div className="flex items-center justify-between gap-2">
+          <div className="flex items-center gap-2">
+            <Radio className="h-3.5 w-3.5 text-muted-foreground" />
+            <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Channels</span>
+            <Badge variant="secondary" className="text-[10px] tabular-nums">{channels.length}</Badge>
+          </div>
+          <Button
+            size="sm"
+            onClick={() => { setConfigPlatform(undefined); setConfigOpen(true); }}
+            disabled={!serverUrl}
+          >
+            <Plus />
+            Add
+          </Button>
         </div>
-        <Button
-          size="sm"
-          className="gap-1.5 h-7 text-[12px]"
-          onClick={() => { setConfigPlatform(undefined); setConfigOpen(true); }}
-          disabled={!serverUrl}
-        >
-          <Plus className="h-3 w-3" />
-          Add
-        </Button>
-      </div>
 
-      <div className="flex-1 min-h-0 overflow-y-auto px-4 py-3">
         {loading ? (
           <div className="space-y-2">
             {[0, 1].map((i) => (

--- a/apps/web/src/components/kortix/credentials-tab.tsx
+++ b/apps/web/src/components/kortix/credentials-tab.tsx
@@ -53,8 +53,8 @@ export function CredentialsTab({ projectId }: { projectId: string }) {
   const items = useMemo(() => data ?? [], [data]);
 
   return (
-    <div className="flex-1 overflow-y-auto bg-background">
-      <div className="container mx-auto max-w-3xl px-3 sm:px-4 py-5 space-y-5">
+    <div className="h-full overflow-y-auto bg-background">
+      <div className="mx-auto w-full max-w-3xl px-4 sm:px-6 py-8 space-y-8">
 
         <header className="flex items-end justify-between gap-3">
           <div>

--- a/apps/web/src/components/kortix/mention-textarea.tsx
+++ b/apps/web/src/components/kortix/mention-textarea.tsx
@@ -16,6 +16,7 @@ import {
   forwardRef,
   useCallback,
   useImperativeHandle,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -222,6 +223,45 @@ function candidateSlug(c: Candidate): string {
   return c.type === 'user' ? c.handle : c.agent.slug;
 }
 
+const CARET_MIRROR_PROPS = [
+  'box-sizing', 'width',
+  'padding-top', 'padding-right', 'padding-bottom', 'padding-left',
+  'border-top-width', 'border-right-width', 'border-bottom-width', 'border-left-width',
+  'font-family', 'font-size', 'font-weight', 'font-style', 'font-variant',
+  'letter-spacing', 'text-transform', 'word-spacing', 'text-indent',
+  'line-height', 'tab-size', 'text-align',
+] as const;
+
+function getCaretCoords(textarea: HTMLTextAreaElement, position: number): { top: number; left: number; lineHeight: number } {
+  const style = window.getComputedStyle(textarea);
+  const mirror = document.createElement('div');
+  for (const prop of CARET_MIRROR_PROPS) {
+    mirror.style.setProperty(prop, style.getPropertyValue(prop));
+  }
+  mirror.style.position = 'absolute';
+  mirror.style.visibility = 'hidden';
+  mirror.style.whiteSpace = 'pre-wrap';
+  mirror.style.wordWrap = 'break-word';
+  mirror.style.overflow = 'hidden';
+  mirror.style.top = '0';
+  mirror.style.left = '-9999px';
+  document.body.appendChild(mirror);
+
+  mirror.textContent = textarea.value.substring(0, position);
+  const marker = document.createElement('span');
+  marker.textContent = textarea.value.substring(position) || '.';
+  mirror.appendChild(marker);
+
+  const lineHeight = parseFloat(style.lineHeight) || parseFloat(style.fontSize) * 1.4;
+  const coords = {
+    top: marker.offsetTop,
+    left: marker.offsetLeft,
+    lineHeight,
+  };
+  document.body.removeChild(mirror);
+  return coords;
+}
+
 export interface MentionTextareaProps
   extends Omit<TextareaHTMLAttributes<HTMLTextAreaElement>, 'onChange'> {
   value: string;
@@ -354,6 +394,16 @@ export const MentionTextarea = forwardRef<HTMLTextAreaElement, MentionTextareaPr
 
     const open = query !== null && candidates.length > 0;
 
+    const [caretPos, setCaretPos] = useState<{ top: number; left: number; lineHeight: number } | null>(null);
+
+    useLayoutEffect(() => {
+      if (!open || !innerRef.current || !anchor) {
+        setCaretPos(null);
+        return;
+      }
+      setCaretPos(getCaretCoords(innerRef.current, anchor.start));
+    }, [open, anchor, value]);
+
     const handleScroll = (e: UIEvent<HTMLTextAreaElement>) => setScrollTop(e.currentTarget.scrollTop);
 
     // Shared style surface so the overlay's wrapping EXACTLY matches the
@@ -406,10 +456,14 @@ export const MentionTextarea = forwardRef<HTMLTextAreaElement, MentionTextareaPr
           className={textareaCls}
           spellCheck={textareaProps.spellCheck ?? false}
         />
-        {open && (
+        {open && caretPos && (
           <div
             role="listbox"
-            className="absolute left-0 top-full mt-1 min-w-[220px] max-w-[280px] rounded-xl border border-border/60 bg-card shadow-xl z-[10001] overflow-hidden py-1"
+            style={{
+              top: caretPos.top + caretPos.lineHeight - scrollTop + 4,
+              left: caretPos.left,
+            }}
+            className="absolute min-w-[220px] max-w-[280px] rounded-xl border border-border/60 bg-card shadow-xl z-[10001] overflow-hidden py-1"
             onMouseDown={(e) => e.preventDefault()}
           >
             <div className="px-3 py-1.5 text-[10px] uppercase tracking-[0.08em] text-muted-foreground/55 font-semibold">

--- a/apps/web/src/components/kortix/milestone-dialog.tsx
+++ b/apps/web/src/components/kortix/milestone-dialog.tsx
@@ -1,29 +1,22 @@
 'use client';
 
-/**
- * Milestone dialog — single modal for create AND edit.
- *
- * Create mode: compact form (title, description, acceptance, due, color).
- *
- * Edit mode: expanded — same form + linked tickets + activity log + close
- * / reopen / delete buttons. Replaces the old right-side drawer because
- * modal-in-place keeps the user in context and fixes the a11y warning
- * (DialogTitle always rendered).
- */
-
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { toast } from 'sonner';
+import { format } from 'date-fns';
 import {
   Dialog,
   DialogContent,
-  DialogHeader,
   DialogTitle,
   DialogDescription,
-  DialogFooter,
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
+import { Calendar } from '@/components/ui/calendar';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
 import {
   useCloseMilestone,
   useCreateMilestone,
@@ -35,9 +28,37 @@ import {
   type Milestone,
 } from '@/hooks/kortix/use-milestones';
 import { cn } from '@/lib/utils';
-import { CheckCircle2, XCircle, RotateCcw, Trash2, Loader2 } from 'lucide-react';
+import {
+  CheckCircle2,
+  XCircle,
+  RotateCcw,
+  Trash2,
+  Loader2,
+  Sparkles,
+  Calendar as CalendarIcon,
+  Palette,
+  X,
+  Check,
+  ChevronDown,
+} from 'lucide-react';
 
-const HUE_OPTIONS = [0, 30, 50, 120, 170, 210, 260, 290, 330];
+const HUE_OPTIONS = [
+  { hue: 0, name: 'Rose' },
+  { hue: 30, name: 'Orange' },
+  { hue: 50, name: 'Amber' },
+  { hue: 120, name: 'Emerald' },
+  { hue: 170, name: 'Teal' },
+  { hue: 210, name: 'Sky' },
+  { hue: 260, name: 'Indigo' },
+  { hue: 290, name: 'Violet' },
+  { hue: 330, name: 'Pink' },
+];
+
+const PILL_TRIGGER = cn(
+  'group inline-flex items-center gap-1.5 rounded-full bg-muted/40 px-2.5 py-1 text-xs',
+  'text-foreground transition-colors hover:bg-muted',
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30',
+);
 
 export function MilestoneDialog({
   projectId,
@@ -57,11 +78,15 @@ export function MilestoneDialog({
       <DialogContent
         className={cn(
           'p-0 overflow-hidden gap-0 border-border/60 bg-background',
-          // Wider in edit mode — needs room for the tickets + activity
-          // sections. Create mode stays compact.
-          isEdit ? 'sm:max-w-[640px] max-h-[85vh] flex flex-col' : 'sm:max-w-[540px]',
+          isEdit ? 'sm:max-w-[640px] max-h-[88vh] flex flex-col' : 'sm:max-w-[560px]',
         )}
       >
+        <DialogTitle className="sr-only">
+          {isEdit ? `Milestone M${milestone.number}` : 'New milestone'}
+        </DialogTitle>
+        <DialogDescription className="sr-only">
+          {isEdit ? 'Edit milestone details, linked tickets, and activity.' : 'Create a new outcome-level goal.'}
+        </DialogDescription>
         {isEdit && milestone
           ? <EditPanel projectId={projectId} milestone={milestone} onClose={() => onOpenChange(false)} />
           : <CreatePanel projectId={projectId} onClose={() => onOpenChange(false)} />}
@@ -70,18 +95,20 @@ export function MilestoneDialog({
   );
 }
 
-// ── Create ──────────────────────────────────────────────────────────────────
-
 function CreatePanel({ projectId, onClose }: { projectId: string; onClose: () => void }) {
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
   const [acceptance, setAcceptance] = useState('');
-  const [dueAt, setDueAt] = useState('');
+  const [dueAt, setDueAt] = useState<Date | undefined>(undefined);
   const [hue, setHue] = useState<number | null>(null);
   const createM = useCreateMilestone();
+  const titleRef = useRef<HTMLTextAreaElement>(null);
 
-  const submit = async (e: React.FormEvent) => {
-    e.preventDefault();
+  useEffect(() => {
+    titleRef.current?.focus();
+  }, []);
+
+  const submit = async () => {
     const trimmed = title.trim();
     if (!trimmed) { toast.error('Title is required'); return; }
     try {
@@ -90,7 +117,7 @@ function CreatePanel({ projectId, onClose }: { projectId: string; onClose: () =>
         title: trimmed,
         description_md: description || undefined,
         acceptance_md: acceptance || undefined,
-        due_at: dueAt || null,
+        due_at: dueAt ? dueAt.toISOString().slice(0, 10) : null,
         color_hue: hue,
       });
       toast.success(`Created milestone "${trimmed}"`);
@@ -100,36 +127,79 @@ function CreatePanel({ projectId, onClose }: { projectId: string; onClose: () =>
     }
   };
 
-  return (
-    <>
-      <DialogHeader className="px-5 py-4 border-b border-border/40">
-        <DialogTitle>New milestone</DialogTitle>
-        <DialogDescription>
-          An outcome-level goal that groups tickets. Keep the acceptance criteria concrete — PM will run it to verify "done".
-        </DialogDescription>
-      </DialogHeader>
+  const onTitleKey = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      submit();
+    }
+  };
+  const onBodyKey = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+      e.preventDefault();
+      submit();
+    }
+  };
 
-      <form onSubmit={submit} className="p-5 space-y-4">
-        <FormFields
-          title={title} setTitle={setTitle}
-          description={description} setDescription={setDescription}
-          acceptance={acceptance} setAcceptance={setAcceptance}
-          dueAt={dueAt} setDueAt={setDueAt}
-          hue={hue} setHue={setHue}
-          autoFocusTitle
+  return (
+    <div className="relative flex flex-col">
+      <div className="flex items-center gap-2 px-5 pt-4">
+        <Sparkles className="size-3.5 text-muted-foreground/50" />
+        <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+          New milestone
+        </span>
+      </div>
+
+      <div className="px-5 pt-3">
+        <textarea
+          ref={titleRef}
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          onKeyDown={onTitleKey}
+          placeholder="What outcome are you tracking?"
+          rows={1}
+          maxLength={120}
+          className="w-full resize-none overflow-hidden border-0 bg-transparent text-lg font-semibold leading-tight tracking-tight outline-none placeholder:text-muted-foreground/30 focus:ring-0"
         />
-        <DialogFooter>
-          <Button type="button" variant="ghost" onClick={onClose} disabled={createM.isPending}>Cancel</Button>
-          <Button type="submit" disabled={createM.isPending || !title.trim()}>
-            {createM.isPending ? 'Saving…' : 'Create milestone'}
+        <textarea
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          onKeyDown={onBodyKey}
+          placeholder="One line on what this covers (optional)"
+          rows={1}
+          className="mt-0.5 w-full resize-none overflow-hidden border-0 bg-transparent text-sm leading-snug outline-none placeholder:text-muted-foreground/40 focus:ring-0"
+        />
+      </div>
+
+      <div className="px-5 pt-3">
+        <AcceptanceField
+          value={acceptance}
+          onChange={setAcceptance}
+          onKeyDown={onBodyKey}
+        />
+      </div>
+
+      <div className="flex flex-wrap items-center gap-1.5 px-5 pb-4 pt-3">
+        <DuePill value={dueAt} onChange={setDueAt} />
+        <ColorPill hue={hue} setHue={setHue} />
+      </div>
+
+      <div className="flex items-center gap-2 border-t border-border/40 px-5 py-3">
+        <span className="inline-flex items-center gap-1 text-xs text-muted-foreground">
+          <kbd className="inline-flex h-5 min-w-5 items-center justify-center rounded-md bg-muted px-1 font-mono text-[10px]">⌘</kbd>
+          <kbd className="inline-flex h-5 min-w-5 items-center justify-center rounded-md bg-muted px-1 font-mono text-[10px]">↵</kbd>
+          <span className="ml-0.5">to create</span>
+        </span>
+        <div className="ml-auto flex items-center gap-2">
+          <Button variant="ghost" size="sm" onClick={onClose} disabled={createM.isPending}>Cancel</Button>
+          <Button size="sm" onClick={submit} disabled={createM.isPending || !title.trim()}>
+            {createM.isPending && <Loader2 className="size-3.5 animate-spin" />}
+            Create milestone
           </Button>
-        </DialogFooter>
-      </form>
-    </>
+        </div>
+      </div>
+    </div>
   );
 }
-
-// ── Edit (with tickets + activity) ──────────────────────────────────────────
 
 function EditPanel({
   projectId,
@@ -140,7 +210,6 @@ function EditPanel({
   milestone: Milestone;
   onClose: () => void;
 }) {
-  // Live re-fetch to keep linked tickets + activity fresh
   const { data: detail } = useMilestone(projectId, String(milestone.number));
   const { data: events } = useMilestoneEvents(projectId, String(milestone.number));
   const updateM = useUpdateMilestone();
@@ -151,23 +220,31 @@ function EditPanel({
   const [title, setTitle] = useState(milestone.title);
   const [description, setDescription] = useState(milestone.description_md);
   const [acceptance, setAcceptance] = useState(milestone.acceptance_md);
-  const [dueAt, setDueAt] = useState(milestone.due_at ? milestone.due_at.slice(0, 10) : '');
+  const [dueAt, setDueAt] = useState<Date | undefined>(milestone.due_at ? new Date(milestone.due_at) : undefined);
   const [hue, setHue] = useState<number | null>(milestone.color_hue);
   const [closeSummary, setCloseSummary] = useState('');
   const [confirmDelete, setConfirmDelete] = useState(false);
 
-  // Keep form inputs synced if the cached Milestone prop changes under us
   useEffect(() => {
     setTitle(milestone.title);
     setDescription(milestone.description_md);
     setAcceptance(milestone.acceptance_md);
-    setDueAt(milestone.due_at ? milestone.due_at.slice(0, 10) : '');
+    setDueAt(milestone.due_at ? new Date(milestone.due_at) : undefined);
     setHue(milestone.color_hue);
   }, [milestone]);
 
   const tickets = detail?.tickets ?? [];
   const isOpen = milestone.status === 'open';
   const anyPending = updateM.isPending || closeM.isPending || reopenM.isPending || deleteM.isPending;
+
+  const dueIso = dueAt ? dueAt.toISOString().slice(0, 10) : '';
+  const milestoneDueIso = milestone.due_at ? milestone.due_at.slice(0, 10) : '';
+  const dirty =
+    title.trim() !== milestone.title ||
+    description !== milestone.description_md ||
+    acceptance !== milestone.acceptance_md ||
+    dueIso !== milestoneDueIso ||
+    hue !== milestone.color_hue;
 
   const saveChanges = async () => {
     try {
@@ -177,7 +254,7 @@ function EditPanel({
           title: title.trim(),
           description_md: description,
           acceptance_md: acceptance,
-          due_at: dueAt || null,
+          due_at: dueIso || null,
           color_hue: hue,
         },
       });
@@ -219,234 +296,364 @@ function EditPanel({
 
   return (
     <>
-      <DialogHeader className="px-5 py-4 border-b border-border/40">
-        <div className="flex items-center gap-2 text-[10.5px] uppercase tracking-[0.06em] text-muted-foreground/55 font-semibold">
-          <span
-            className="h-2 w-2 rounded-full"
-            style={{ backgroundColor: `hsl(${milestone.color_hue ?? 210} 70% 55%)` }}
-          />
-          M{milestone.number} · {milestone.status}
-        </div>
-        <DialogTitle className="text-[16px] font-semibold">
-          {milestone.title}
-        </DialogTitle>
-        <DialogDescription className="text-[11.5px] text-muted-foreground/55">
-          {milestone.progress.done}/{milestone.progress.total} tickets done · {milestone.percent_complete}% complete
-          {milestone.due_at && isOpen && <> · due {new Date(milestone.due_at).toLocaleDateString()}</>}
-        </DialogDescription>
-      </DialogHeader>
+      <div className="flex items-center gap-2 px-5 pt-4 shrink-0">
+        <Sparkles className="size-3.5 text-muted-foreground/50" />
+        <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+          Milestone
+        </span>
+        <span className="text-muted-foreground/30">·</span>
+        <span className="font-mono text-xs tabular-nums text-muted-foreground">
+          M{milestone.number}
+        </span>
+        <span className="text-muted-foreground/30">·</span>
+        <span className="text-xs uppercase tracking-wider text-muted-foreground">
+          {milestone.status}
+        </span>
+      </div>
 
-      <div className="flex-1 overflow-y-auto px-5 py-4 space-y-5 text-[13px]">
-        <FormFields
-          title={title} setTitle={setTitle}
-          description={description} setDescription={setDescription}
-          acceptance={acceptance} setAcceptance={setAcceptance}
-          dueAt={dueAt} setDueAt={setDueAt}
-          hue={hue} setHue={setHue}
+      <div className="px-5 pt-3 shrink-0">
+        <textarea
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="What outcome are you tracking?"
+          rows={1}
+          maxLength={120}
+          className="w-full resize-none overflow-hidden border-0 bg-transparent text-lg font-semibold leading-tight tracking-tight outline-none placeholder:text-muted-foreground/30 focus:ring-0"
         />
+        <textarea
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          placeholder="One line on what this covers (optional)"
+          rows={1}
+          className="mt-0.5 w-full resize-none overflow-hidden border-0 bg-transparent text-sm leading-snug outline-none placeholder:text-muted-foreground/40 focus:ring-0"
+        />
+      </div>
 
-        <div className="flex justify-end">
-          <Button size="sm" variant="outline" onClick={saveChanges} disabled={anyPending}>
-            {updateM.isPending ? 'Saving…' : 'Save changes'}
-          </Button>
+      <div className="flex flex-1 min-h-0 flex-col overflow-y-auto">
+        <div className="px-5 pt-3">
+          <AcceptanceField
+            value={acceptance}
+            onChange={setAcceptance}
+          />
         </div>
 
-        <Section label={`Linked tickets (${tickets.length})`}>
-          {tickets.length === 0
-            ? (
-              <p className="text-[11.5px] text-muted-foreground/55">
-                No tickets yet. TL links sub-tickets during decomposition; you can also set a ticket's milestone from its detail view.
-              </p>
-            ) : (
-              <ul className="rounded-md border border-border/40 divide-y divide-border/30 overflow-hidden">
-                {tickets.map((t) => (
-                  <li key={t.id} className="flex items-center justify-between gap-3 px-3 py-2">
-                    <div className="flex items-center gap-2 min-w-0">
-                      <span className="text-[10.5px] text-muted-foreground/50 font-mono shrink-0">#{t.number}</span>
-                      <span className="text-[12.5px] truncate">{t.title}</span>
-                    </div>
-                    <TicketStatusBadge status={t.status} />
-                  </li>
-                ))}
-              </ul>
-            )}
+        <div className="flex flex-wrap items-center gap-1.5 px-5 pt-3 pb-2">
+          <DuePill value={dueAt} onChange={setDueAt} />
+          <ColorPill hue={hue} setHue={setHue} />
+          <ProgressPill done={milestone.progress.done} total={milestone.progress.total} percent={milestone.percent_complete} />
+        </div>
+
+        <Section label={`Linked tickets · ${tickets.length}`}>
+          {tickets.length === 0 ? (
+            <p className="text-xs text-muted-foreground/60">
+              No tickets yet. TL links sub-tickets during decomposition.
+            </p>
+          ) : (
+            <ul className="overflow-hidden rounded-2xl bg-muted/30">
+              {tickets.map((t, i) => (
+                <li
+                  key={t.id}
+                  className={cn(
+                    'flex items-center justify-between gap-3 px-3 py-2',
+                    i !== tickets.length - 1 && 'border-b border-border/40',
+                  )}
+                >
+                  <div className="flex items-center gap-2 min-w-0">
+                    <span className="font-mono text-[10.5px] text-muted-foreground/55 shrink-0">#{t.number}</span>
+                    <span className="text-sm truncate">{t.title}</span>
+                  </div>
+                  <TicketStatusBadge status={t.status} />
+                </li>
+              ))}
+            </ul>
+          )}
         </Section>
 
         <Section label="Activity">
-          {events && events.length > 0
-            ? (
-              <ul className="space-y-1.5">
-                {events.slice(0, 20).map((e) => (
-                  <li key={e.id} className="flex items-start gap-2 text-[11.5px] leading-snug">
-                    <span className="text-muted-foreground/45 tabular-nums shrink-0 w-[110px]">
-                      {new Date(e.created_at).toLocaleString(undefined, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })}
-                    </span>
-                    <span className={cn(
-                      'text-[10px] uppercase tracking-[0.05em] font-semibold px-1 rounded shrink-0',
-                      e.actor_type === 'agent' ? 'bg-primary/10 text-primary' : 'bg-muted/40 text-muted-foreground/70',
-                    )}>
-                      {e.actor_type}
-                    </span>
-                    <span className="text-foreground/80">
-                      {e.type.replace(/_/g, ' ')}{e.message ? ` — ${truncate(e.message, 120)}` : ''}
-                    </span>
-                  </li>
-                ))}
-              </ul>
-            ) : (
-              <p className="text-[11.5px] text-muted-foreground/55">No activity yet.</p>
-            )}
+          {events && events.length > 0 ? (
+            <ul className="space-y-1.5">
+              {events.slice(0, 20).map((e) => (
+                <li key={e.id} className="flex items-start gap-2 text-xs leading-snug">
+                  <span className="text-muted-foreground/45 tabular-nums shrink-0 w-[110px]">
+                    {new Date(e.created_at).toLocaleString(undefined, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })}
+                  </span>
+                  <span className="text-foreground/80">
+                    <span className="font-medium text-foreground">@{e.actor_id ?? e.actor_type}</span>
+                    {' '}
+                    {e.type.replace(/_/g, ' ')}{e.message ? ` — ${truncate(e.message, 120)}` : ''}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-xs text-muted-foreground/60">No activity yet.</p>
+          )}
         </Section>
-      </div>
 
-      {/* Action footer */}
-      <div className="px-5 py-3 border-t border-border/40 bg-muted/10 space-y-3">
-        {isOpen ? (
-          <>
+        {isOpen && (
+          <Section label="Close milestone">
             <Textarea
               value={closeSummary}
               onChange={(e) => setCloseSummary(e.target.value)}
               placeholder="Closing summary — evidence the acceptance criteria pass (file:line, test output, curl result)."
               rows={2}
-              className="text-[12px] resize-y"
+              className="text-xs resize-y"
             />
-            <div className="flex items-center gap-2 flex-wrap">
-              <Button size="sm" onClick={doClose(false)} disabled={anyPending} className="gap-1.5">
-                <CheckCircle2 className="h-3.5 w-3.5" /> Mark as done
-              </Button>
-              <Button size="sm" variant="ghost" onClick={doClose(true)} disabled={anyPending} className="gap-1.5">
-                <XCircle className="h-3.5 w-3.5" /> Cancel milestone
-              </Button>
-              <div className="ml-auto">
-                <DeleteButton confirm={confirmDelete} pending={deleteM.isPending}
-                  onClick={() => confirmDelete ? doDelete() : setConfirmDelete(true)}
-                  onCancelConfirm={() => setConfirmDelete(false)}
-                />
-              </div>
-            </div>
-          </>
-        ) : (
-          <div className="flex items-center gap-2">
-            <Button size="sm" variant="outline" onClick={doReopen} disabled={anyPending} className="gap-1.5">
-              <RotateCcw className="h-3.5 w-3.5" /> Reopen
-            </Button>
-            <div className="ml-auto">
-              <DeleteButton confirm={confirmDelete} pending={deleteM.isPending}
-                onClick={() => confirmDelete ? doDelete() : setConfirmDelete(true)}
-                onCancelConfirm={() => setConfirmDelete(false)}
-              />
-            </div>
-          </div>
+          </Section>
         )}
+
+        <div className="px-5 pb-5" />
+      </div>
+
+      <div className="flex items-center gap-2 border-t border-border/40 px-5 py-3 shrink-0">
+        <DeleteButton
+          confirm={confirmDelete}
+          pending={deleteM.isPending}
+          onClick={() => confirmDelete ? doDelete() : setConfirmDelete(true)}
+          onCancelConfirm={() => setConfirmDelete(false)}
+        />
+
+        <div className="ml-auto flex items-center gap-2">
+          {dirty && (
+            <Button size="sm" variant="outline" onClick={saveChanges} disabled={anyPending}>
+              {updateM.isPending && <Loader2 className="size-3.5 animate-spin" />}
+              Save changes
+            </Button>
+          )}
+          {isOpen ? (
+            <>
+              <Button size="sm" variant="ghost" onClick={doClose(true)} disabled={anyPending} className="gap-1.5 text-muted-foreground hover:text-foreground">
+                <XCircle className="size-3.5" />
+                Cancel
+              </Button>
+              <Button size="sm" onClick={doClose(false)} disabled={anyPending} className="gap-1.5">
+                <CheckCircle2 className="size-3.5" />
+                Mark as done
+              </Button>
+            </>
+          ) : (
+            <Button size="sm" variant="outline" onClick={doReopen} disabled={anyPending} className="gap-1.5">
+              <RotateCcw className="size-3.5" />
+              Reopen
+            </Button>
+          )}
+        </div>
       </div>
     </>
   );
 }
 
-// ── Shared form fields (used in both create + edit panels) ──────────────────
-
-function FormFields({
-  title, setTitle,
-  description, setDescription,
-  acceptance, setAcceptance,
-  dueAt, setDueAt,
-  hue, setHue,
-  autoFocusTitle,
-}: {
-  title: string; setTitle: (v: string) => void;
-  description: string; setDescription: (v: string) => void;
-  acceptance: string; setAcceptance: (v: string) => void;
-  dueAt: string; setDueAt: (v: string) => void;
-  hue: number | null; setHue: (v: number | null) => void;
-  autoFocusTitle?: boolean;
-}) {
+function ColorPill({ hue, setHue }: { hue: number | null; setHue: (h: number | null) => void }) {
+  const current = HUE_OPTIONS.find((h) => h.hue === hue);
   return (
-    <div className="space-y-4">
-      <FieldRow label="Title">
-        <Input
-          value={title}
-          onChange={(e) => setTitle(e.target.value)}
-          placeholder="Delivery path e2e"
-          autoFocus={autoFocusTitle}
-          maxLength={120}
-        />
-      </FieldRow>
-
-      <FieldRow label="Description">
-        <Textarea
-          value={description}
-          onChange={(e) => setDescription(e.target.value)}
-          placeholder="1–3 lines of context — what this outcome covers."
-          rows={2}
-          className="resize-y"
-        />
-      </FieldRow>
-
-      <FieldRow label="Acceptance criteria">
-        <Textarea
-          value={acceptance}
-          onChange={(e) => setAcceptance(e.target.value)}
-          placeholder="Done when: POST /events → subscriber receives signed hook within 3 attempts."
-          rows={3}
-          className="resize-y font-mono text-[12px]"
-        />
-        <p className="text-[10.5px] text-muted-foreground/50 mt-1">
-          A concrete check — shell command, curl, test name, manual verification step.
-        </p>
-      </FieldRow>
-
-      <div className="grid grid-cols-2 gap-4">
-        <FieldRow label="Due date (optional)">
-          <Input type="date" value={dueAt} onChange={(e) => setDueAt(e.target.value)} />
-        </FieldRow>
-        <FieldRow label="Color">
-          <div className="flex items-center gap-1.5 flex-wrap">
-            <button
-              type="button"
-              onClick={() => setHue(null)}
-              className={cn('h-5 w-5 rounded-full border transition',
-                hue === null ? 'border-foreground ring-2 ring-foreground/20' : 'border-border/50 hover:border-border',
-              )}
-              aria-label="No color"
-              title="No color"
-            >
-              <span className="block h-full w-full rounded-full bg-muted/40" />
-            </button>
-            {HUE_OPTIONS.map((h) => (
-              <button
-                key={h}
-                type="button"
-                onClick={() => setHue(h)}
-                className={cn('h-5 w-5 rounded-full border transition',
-                  hue === h ? 'border-foreground ring-2 ring-foreground/30' : 'border-border/40 hover:border-foreground/40',
-                )}
-                style={{ backgroundColor: `hsl(${h} 70% 55%)` }}
-                aria-label={`hue ${h}`}
-                title={`hue ${h}`}
+    <Popover>
+      <PopoverTrigger asChild>
+        <button className={PILL_TRIGGER} aria-label="Color">
+          {hue === null ? (
+            <>
+              <Palette className="size-3 text-muted-foreground/70" />
+              <span className="text-muted-foreground">No color</span>
+            </>
+          ) : (
+            <>
+              <span
+                className="size-2.5 rounded-full"
+                style={{ backgroundColor: `hsl(${hue} 70% 55%)` }}
               />
-            ))}
-          </div>
-        </FieldRow>
+              <span className="font-medium">{current?.name ?? 'Custom'}</span>
+            </>
+          )}
+          <ChevronDown className="size-3 text-muted-foreground/50" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-auto p-3">
+        <ColorSwatchGrid hue={hue} setHue={setHue} />
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function ColorSwatchGrid({ hue, setHue }: { hue: number | null; setHue: (h: number | null) => void }) {
+  return (
+    <div>
+      <div className="mb-2 text-[10px] font-semibold uppercase tracking-[0.08em] text-muted-foreground/60">
+        Color
+      </div>
+      <div className="flex items-center gap-1.5">
+        <button
+          type="button"
+          onClick={() => setHue(null)}
+          className={cn(
+            'inline-flex size-7 items-center justify-center rounded-full bg-muted transition-colors hover:bg-muted/70',
+            hue === null && 'ring-2 ring-foreground/70 ring-offset-2 ring-offset-background',
+          )}
+          aria-label="No color"
+          title="No color"
+        >
+          <span className="block size-3 rounded-full border-2 border-dashed border-muted-foreground/40" />
+        </button>
+        {HUE_OPTIONS.map((opt) => (
+          <button
+            key={opt.hue}
+            type="button"
+            onClick={() => setHue(opt.hue)}
+            className={cn(
+              'inline-flex size-7 items-center justify-center rounded-full transition-transform hover:scale-110',
+              hue === opt.hue && 'ring-2 ring-foreground/80 ring-offset-2 ring-offset-background',
+            )}
+            style={{ backgroundColor: `hsl(${opt.hue} 70% 55%)` }}
+            aria-label={opt.name}
+            title={opt.name}
+          >
+            {hue === opt.hue && <Check className="size-3.5 text-white" />}
+          </button>
+        ))}
       </div>
     </div>
   );
 }
 
-function FieldRow({ label, children }: { label: string; children: React.ReactNode }) {
+function DuePill({ value, onChange }: { value: Date | undefined; onChange: (v: Date | undefined) => void }) {
+  const presets = useMemo(() => {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    const tomorrow = new Date(today);
+    tomorrow.setDate(today.getDate() + 1);
+    const inWeek = new Date(today);
+    inWeek.setDate(today.getDate() + 7);
+    const inMonth = new Date(today);
+    inMonth.setDate(today.getDate() + 30);
+    return [
+      { label: 'Today', date: today },
+      { label: 'Tomorrow', date: tomorrow },
+      { label: 'In a week', date: inWeek },
+      { label: 'In a month', date: inMonth },
+    ];
+  }, []);
+
   return (
-    <div className="space-y-1.5">
-      <label className="text-[11px] uppercase tracking-[0.06em] font-semibold text-muted-foreground/70">{label}</label>
-      {children}
-    </div>
+    <Popover>
+      <PopoverTrigger asChild>
+        <button className={PILL_TRIGGER} aria-label="Due date">
+          <CalendarIcon className="size-3 text-muted-foreground/70" />
+          {value ? (
+            <span className="font-medium tabular-nums">
+              {format(value, 'MMM d, yyyy')}
+            </span>
+          ) : (
+            <span className="text-muted-foreground">No due date</span>
+          )}
+          {value && (
+            <span
+              role="button"
+              tabIndex={0}
+              onClick={(e) => { e.stopPropagation(); onChange(undefined); }}
+              onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); e.stopPropagation(); onChange(undefined); } }}
+              className="-mr-1 ml-0.5 inline-flex size-3.5 cursor-pointer items-center justify-center rounded-full text-muted-foreground/55 hover:bg-muted hover:text-foreground"
+              aria-label="Clear due date"
+            >
+              <X className="size-2.5" />
+            </span>
+          )}
+          {!value && <ChevronDown className="size-3 text-muted-foreground/50" />}
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-auto p-0">
+        <div className="flex">
+          <div className="flex w-32 flex-col gap-0.5 border-r border-border/50 p-2">
+            <div className="px-2 pb-1 text-[10px] font-semibold uppercase tracking-[0.08em] text-muted-foreground/60">
+              Quick
+            </div>
+            {presets.map((p) => (
+              <button
+                key={p.label}
+                type="button"
+                onClick={() => onChange(p.date)}
+                className="rounded-md px-2 py-1.5 text-left text-xs text-foreground/80 transition-colors hover:bg-muted/60 hover:text-foreground"
+              >
+                {p.label}
+              </button>
+            ))}
+            {value && (
+              <>
+                <div className="my-1 h-px bg-border/40" />
+                <button
+                  type="button"
+                  onClick={() => onChange(undefined)}
+                  className="rounded-md px-2 py-1.5 text-left text-xs text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground"
+                >
+                  Clear
+                </button>
+              </>
+            )}
+          </div>
+          <Calendar
+            mode="single"
+            selected={value}
+            onSelect={(d) => onChange(d)}
+            initialFocus
+          />
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function ProgressPill({ done, total, percent }: { done: number; total: number; percent: number }) {
+  return (
+    <span className={cn(PILL_TRIGGER, 'pointer-events-none')}>
+      <span className="tabular-nums text-foreground">{done}</span>
+      <span className="text-muted-foreground/60">/{total}</span>
+      <span className="text-muted-foreground/30">·</span>
+      <span className="font-medium tabular-nums">{percent}%</span>
+    </span>
   );
 }
 
 function Section({ label, children }: { label: string; children: React.ReactNode }) {
   return (
-    <section>
-      <div className="text-[10px] uppercase tracking-[0.08em] font-semibold text-muted-foreground/55 mb-2">{label}</div>
+    <section className="px-5 pt-5">
+      <div className="text-[10px] uppercase tracking-[0.08em] font-semibold text-muted-foreground/55 mb-2">
+        {label}
+      </div>
       {children}
     </section>
+  );
+}
+
+function AcceptanceField({
+  value,
+  onChange,
+  onKeyDown,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  onKeyDown?: (e: React.KeyboardEvent<HTMLTextAreaElement>) => void;
+}) {
+  const ref = useRef<HTMLTextAreaElement>(null);
+  return (
+    <div
+      onClick={() => ref.current?.focus()}
+      className={cn(
+        'group/accept rounded-xl bg-muted/40 px-3.5 py-3 cursor-text',
+        'transition-colors hover:bg-muted/55 focus-within:bg-muted/55',
+        'focus-within:ring-2 focus-within:ring-ring/20',
+      )}
+    >
+      <div className="flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-[0.1em] text-muted-foreground/70">
+        <CheckCircle2 className="size-3" />
+        Done when
+      </div>
+      <textarea
+        ref={ref}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        onKeyDown={onKeyDown}
+        placeholder="Subscriber receives signed hook within 3 attempts"
+        rows={2}
+        className="mt-1.5 w-full resize-none border-0 bg-transparent font-mono text-[12.5px] leading-relaxed text-foreground outline-none placeholder:text-muted-foreground/45 focus:ring-0"
+      />
+    </div>
   );
 }
 
@@ -460,7 +667,7 @@ function DeleteButton({
       <div className="flex items-center gap-1.5">
         <Button size="sm" variant="ghost" onClick={onCancelConfirm} disabled={pending}>Cancel</Button>
         <Button size="sm" variant="destructive" onClick={onClick} disabled={pending} className="gap-1.5">
-          {pending ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Trash2 className="h-3.5 w-3.5" />}
+          {pending ? <Loader2 className="size-3.5 animate-spin" /> : <Trash2 className="size-3.5" />}
           Confirm delete
         </Button>
       </div>
@@ -468,7 +675,8 @@ function DeleteButton({
   }
   return (
     <Button size="sm" variant="ghost" onClick={onClick} className="gap-1.5 text-muted-foreground/60 hover:text-destructive">
-      <Trash2 className="h-3.5 w-3.5" /> Delete
+      <Trash2 className="size-3.5" />
+      Delete
     </Button>
   );
 }
@@ -476,13 +684,7 @@ function DeleteButton({
 function TicketStatusBadge({ status }: { status: string }) {
   return (
     <span className={cn(
-      'inline-flex items-center h-4 px-1.5 rounded text-[9.5px] font-mono uppercase tracking-[0.04em] shrink-0',
-      status === 'done' && 'bg-emerald-500/10 text-emerald-500/90',
-      status === 'in_progress' && 'bg-blue-500/10 text-blue-500/90',
-      status === 'review' && 'bg-purple-500/10 text-purple-500/90',
-      status === 'blocked' && 'bg-amber-500/10 text-amber-500/90',
-      status === 'backlog' && 'bg-muted/40 text-muted-foreground/70',
-      !['done', 'in_progress', 'review', 'blocked', 'backlog'].includes(status) && 'bg-muted/30 text-muted-foreground/60',
+      'inline-flex h-5 items-center rounded-md bg-muted/60 px-1.5 text-[9.5px] font-mono uppercase tracking-[0.04em] text-muted-foreground shrink-0',
     )}>
       {status}
     </span>

--- a/apps/web/src/components/kortix/milestones-tab.tsx
+++ b/apps/web/src/components/kortix/milestones-tab.tsx
@@ -1,23 +1,18 @@
 'use client';
 
-/**
- * Milestones tab — matches the Team tab's visual pattern exactly.
- *
- *   max-w-3xl container, section label with icon + count + "New" button,
- *   rounded-xl card with border-border/40 divide-y rows.
- *
- * Each row: color dot + title + muted acceptance snippet, a couple of
- * small badges (M-#, N/M done, status), and a pencil on the right. No
- * competing progress bar, no 4-segment breakdown, no standalone % label.
- * One visual line per milestone.
- *
- * Closed milestones render in their own section below, same card style,
- * with reduced opacity.
- */
-
 import { useMemo, useState } from 'react';
-import { Flag, Plus, Pencil, Circle, CheckCircle2, XCircle } from 'lucide-react';
+import { motion } from 'framer-motion';
+import {
+  Flag,
+  Plus,
+  CheckCircle2,
+  ArrowUpRight,
+  Calendar,
+  AlertTriangle,
+  XCircle,
+} from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
   useMilestones,
@@ -30,81 +25,114 @@ export function MilestonesTab({ projectId }: { projectId: string }) {
   const { data, isLoading } = useMilestones(projectId, 'all');
   const [dialog, setDialog] = useState<{ mode: 'create' } | { mode: 'edit'; milestone: Milestone } | null>(null);
 
-  const { open, closed } = useMemo(() => {
+  const { open, closed, avgPercent } = useMemo(() => {
     const all = data ?? [];
-    return {
-      open: all.filter((m) => m.status === 'open'),
-      closed: all.filter((m) => m.status !== 'open'),
-    };
+    const o = all.filter((m) => m.status === 'open');
+    const c = all.filter((m) => m.status !== 'open');
+    const avg = o.length === 0 ? 0 : Math.round(o.reduce((acc, m) => acc + m.percent_complete, 0) / o.length);
+    return { open: o, closed: c, avgPercent: avg };
   }, [data]);
 
   return (
-    <div className="h-full overflow-y-auto animate-in fade-in-0 duration-300 fill-mode-both">
-      <div className="container mx-auto max-w-3xl px-4 sm:px-6 lg:px-10 py-8 sm:py-10 space-y-8">
+    <div className="h-full overflow-y-auto">
+      <motion.div
+        initial="hidden"
+        animate="show"
+        variants={{
+          hidden: {},
+          show: { transition: { staggerChildren: 0.04, delayChildren: 0.04 } },
+        }}
+        className="mx-auto w-full max-w-3xl px-6 pt-12 pb-24"
+      >
+        <Section>
+          <header>
+            <h1 className="text-xl font-semibold tracking-tight text-foreground">
+              Milestones
+            </h1>
+            <p className="mt-1.5 text-sm leading-relaxed text-muted-foreground">
+              Outcome-level goals. Group related tickets and verify done by acceptance criteria.
+            </p>
+          </header>
+        </Section>
 
-        {/* ─── Open milestones ─── */}
-        <section>
-          <div className="flex items-center gap-2 mb-3">
-            <Flag className="h-3.5 w-3.5 text-muted-foreground/45" />
-            <span className="text-[10px] uppercase tracking-[0.08em] text-muted-foreground/55 font-semibold">Milestones</span>
-            <span className="text-[10px] text-muted-foreground/30 tabular-nums">{open.length}</span>
-            <Button
-              size="sm"
-              variant="ghost"
-              className="ml-auto h-6 px-2 text-[11px] text-muted-foreground/60 hover:text-foreground gap-1"
-              onClick={() => setDialog({ mode: 'create' })}
-            >
-              <Plus className="h-3 w-3" />
-              New milestone
-            </Button>
+        <Section delay>
+          <StatsRow
+            open={open.length}
+            closed={closed.length}
+            avgPercent={avgPercent}
+            hasOpen={open.length > 0}
+            onNew={() => setDialog({ mode: 'create' })}
+          />
+        </Section>
+
+        <Section delay>
+          <div>
+            <SectionLabel
+              icon={Flag}
+              label="Active"
+              count={open.length}
+              action={
+                open.length > 0 ? (
+                  <button
+                    type="button"
+                    onClick={() => setDialog({ mode: 'create' })}
+                    className="inline-flex items-center gap-0.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
+                  >
+                    <Plus className="size-3" />
+                    New
+                  </button>
+                ) : null
+              }
+            />
+            <div className="mt-3 overflow-hidden rounded-2xl bg-muted/30">
+              {isLoading ? (
+                <div className="px-4 py-8 text-center text-sm text-muted-foreground/55">Loading…</div>
+              ) : open.length === 0 ? (
+                <button
+                  onClick={() => setDialog({ mode: 'create' })}
+                  className="group flex w-full items-start gap-3 px-4 py-6 text-left transition-colors hover:bg-muted/60"
+                >
+                  <Flag className="mt-0.5 size-4 shrink-0 text-muted-foreground/40 transition-colors group-hover:text-foreground/60" />
+                  <div>
+                    <p className="text-sm font-medium text-foreground">No open milestones</p>
+                    <p className="mt-1 max-w-md text-sm leading-relaxed text-muted-foreground">
+                      Group tickets by end-to-end outcome. PM runs the acceptance criteria to verify done.
+                    </p>
+                  </div>
+                </button>
+              ) : (
+                open.map((m, i) => (
+                  <MilestoneRow
+                    key={m.id}
+                    milestone={m}
+                    onClick={() => setDialog({ mode: 'edit', milestone: m })}
+                    isLast={i === open.length - 1}
+                  />
+                ))
+              )}
+            </div>
           </div>
+        </Section>
 
-          <div className="rounded-xl border border-border/40 divide-y divide-border/30 overflow-hidden bg-card">
-            {isLoading ? (
-              <div className="py-8 text-center text-[12px] text-muted-foreground/50">Loading…</div>
-            ) : open.length === 0 ? (
-              <button
-                onClick={() => setDialog({ mode: 'create' })}
-                className="w-full py-8 text-center hover:bg-muted/20 transition-colors cursor-pointer"
-              >
-                <p className="text-[12.5px] text-foreground/70 font-medium mb-0.5">No open milestones</p>
-                <p className="text-[11.5px] text-muted-foreground/50">Group tickets by end-to-end outcome. Create the first one.</p>
-              </button>
-            ) : (
-              open.map((m) => (
-                <MilestoneRow
-                  key={m.id}
-                  milestone={m}
-                  onClick={() => setDialog({ mode: 'edit', milestone: m })}
-                />
-              ))
-            )}
-          </div>
-        </section>
-
-        {/* ─── Closed milestones ─── */}
         {closed.length > 0 && (
-          <section>
-            <div className="flex items-center gap-2 mb-3">
-              <CheckCircle2 className="h-3.5 w-3.5 text-muted-foreground/45" />
-              <span className="text-[10px] uppercase tracking-[0.08em] text-muted-foreground/55 font-semibold">Closed</span>
-              <span className="text-[10px] text-muted-foreground/30 tabular-nums">{closed.length}</span>
+          <Section delay>
+            <div>
+              <SectionLabel icon={CheckCircle2} label="Closed" count={closed.length} />
+              <div className="mt-3 overflow-hidden rounded-2xl bg-muted/20">
+                {closed.map((m, i) => (
+                  <MilestoneRow
+                    key={m.id}
+                    milestone={m}
+                    onClick={() => setDialog({ mode: 'edit', milestone: m })}
+                    isLast={i === closed.length - 1}
+                    subdued
+                  />
+                ))}
+              </div>
             </div>
-
-            <div className="rounded-xl border border-border/30 divide-y divide-border/20 overflow-hidden bg-card/60">
-              {closed.map((m) => (
-                <MilestoneRow
-                  key={m.id}
-                  milestone={m}
-                  onClick={() => setDialog({ mode: 'edit', milestone: m })}
-                  subdued
-                />
-              ))}
-            </div>
-          </section>
+          </Section>
         )}
-
-      </div>
+      </motion.div>
 
       <MilestoneDialog
         projectId={projectId}
@@ -116,86 +144,178 @@ export function MilestonesTab({ projectId }: { projectId: string }) {
   );
 }
 
-// ─── Row ────────────────────────────────────────────────────────────────────
+function Section({ children, delay }: { children: React.ReactNode; delay?: boolean }) {
+  return (
+    <motion.section
+      variants={{
+        hidden: { opacity: 0, y: 6 },
+        show: { opacity: 1, y: 0, transition: { duration: 0.3, ease: 'easeOut' } },
+      }}
+      className={cn(delay && 'mt-10')}
+    >
+      {children}
+    </motion.section>
+  );
+}
+
+function SectionLabel({
+  icon: Icon,
+  label,
+  count,
+  action,
+}: {
+  icon: typeof Flag;
+  label: string;
+  count?: number;
+  action?: React.ReactNode;
+}) {
+  return (
+    <div className="flex items-center justify-between">
+      <div className="flex items-center gap-2">
+        <Icon className="size-3.5 text-muted-foreground/60" />
+        <h2 className="text-xs font-medium uppercase tracking-[0.12em] text-muted-foreground">
+          {label}
+        </h2>
+        {typeof count === 'number' && count > 0 && (
+          <Badge variant="muted" size="sm" className="tabular-nums">
+            {count}
+          </Badge>
+        )}
+      </div>
+      {action}
+    </div>
+  );
+}
+
+function StatsRow({
+  open,
+  closed,
+  avgPercent,
+  hasOpen,
+  onNew,
+}: {
+  open: number;
+  closed: number;
+  avgPercent: number;
+  hasOpen: boolean;
+  onNew: () => void;
+}) {
+  const stats: Array<{ label: string; value: string | number; dot: string }> = [
+    { label: open === 1 ? 'open' : 'open', value: open, dot: 'bg-emerald-500' },
+    { label: closed === 1 ? 'closed' : 'closed', value: closed, dot: 'bg-muted-foreground/50' },
+  ];
+  if (hasOpen) {
+    stats.push({ label: 'avg progress', value: `${avgPercent}%`, dot: 'bg-blue-500' });
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-x-2 gap-y-2">
+      {stats.map((s) => (
+        <span
+          key={s.label}
+          className="inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-xs text-muted-foreground"
+        >
+          <span className={cn('size-1.5 rounded-full', s.dot)} />
+          <span className="font-semibold tabular-nums text-foreground">{s.value}</span>
+          <span>{s.label}</span>
+        </span>
+      ))}
+      <Button
+        size="sm"
+        onClick={onNew}
+        className="ml-auto"
+      >
+        <Plus />
+        New milestone
+      </Button>
+    </div>
+  );
+}
 
 function MilestoneRow({
   milestone,
   onClick,
+  isLast,
   subdued,
 }: {
   milestone: Milestone;
   onClick: () => void;
+  isLast: boolean;
   subdued?: boolean;
 }) {
   const hue = milestone.color_hue ?? 210;
-  const acceptance = milestone.acceptance_md.trim().split('\n')[0]?.slice(0, 140) ?? '';
-  const p = milestone.progress;
+  const acceptance = milestone.acceptance_md.trim().split('\n')[0]?.slice(0, 90) ?? '';
+  const due = milestone.due_at ? new Date(milestone.due_at) : null;
+  const overdue = due && due < new Date() && milestone.status === 'open';
 
   return (
     <button
+      type="button"
       onClick={onClick}
       className={cn(
-        'w-full flex items-center gap-3 px-4 py-3 hover:bg-muted/20 transition-colors cursor-pointer text-left group',
-        subdued && 'opacity-75 hover:opacity-100',
+        'group flex w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-muted/60',
+        !isLast && 'border-b border-border/40',
+        subdued && 'opacity-70 hover:opacity-100',
       )}
     >
-      {/* Color dot — same slot the AgentAvatar fills on the Team tab.
-          Sized medium so rows align visually across both tabs. */}
-      <div
-        className="h-8 w-8 rounded-full shrink-0 flex items-center justify-center"
-        style={{ backgroundColor: `hsl(${hue} 70% 55% / 0.15)` }}
-      >
-        <span
-          className="h-3 w-3 rounded-full"
-          style={{ backgroundColor: `hsl(${hue} 70% 55%)`, opacity: subdued ? 0.6 : 1 }}
-        />
-      </div>
+      <span
+        className="size-1.5 shrink-0 rounded-full"
+        style={{ backgroundColor: `hsl(${hue} 70% 55%)` }}
+      />
+      <span className="shrink-0 font-mono text-xs tabular-nums text-muted-foreground/60">
+        M{milestone.number}
+      </span>
+      <span className="min-w-0 flex-1 truncate text-sm text-foreground">
+        {milestone.title}
+        {acceptance && (
+          <span className="ml-2 text-muted-foreground/55">{acceptance}</span>
+        )}
+      </span>
 
-      <div className="flex-1 min-w-0">
-        <div className="flex items-center gap-2 min-w-0">
-          <span className={cn(
-            'text-[13px] font-semibold truncate',
-            subdued && 'text-foreground/70',
-          )}>
-            {milestone.title}
-          </span>
-          {acceptance && (
-            <span className="text-[11.5px] text-muted-foreground/50 truncate">
-              {acceptance}
-            </span>
-          )}
-        </div>
-        <div className="flex items-center gap-1.5 mt-1 flex-wrap">
-          <span className="inline-flex items-center h-4 px-1.5 rounded text-[10px] font-mono bg-muted/40 text-muted-foreground/70">
-            M{milestone.number}
-          </span>
-          <span className="inline-flex items-center h-4 px-1.5 rounded text-[10px] tabular-nums bg-muted/40 text-muted-foreground/70">
-            {p.done}/{p.total} done · {milestone.percent_complete}%
-          </span>
-          <StatusChip status={milestone.status} />
-          {p.blocked > 0 && (
-            <span className="inline-flex items-center h-4 px-1.5 rounded text-[10px] bg-amber-500/10 text-amber-400/80">
-              {p.blocked} blocked
-            </span>
-          )}
-        </div>
-      </div>
-      <Pencil className="h-3.5 w-3.5 text-muted-foreground/25 group-hover:text-foreground transition-colors shrink-0" />
+      {due && (
+        <span className={cn(
+          'hidden items-center gap-1 text-xs tabular-nums sm:inline-flex',
+          overdue ? 'text-amber-500' : 'text-muted-foreground/60',
+        )}>
+          {overdue && <AlertTriangle className="size-3" />}
+          <Calendar className="size-3" />
+          {due.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })}
+        </span>
+      )}
+
+      <StatusChip status={milestone.status} />
+
+      <span className="hidden shrink-0 items-center gap-2 sm:flex">
+        <span className="text-xs tabular-nums text-muted-foreground/60">
+          {milestone.progress.done}/{milestone.progress.total}
+        </span>
+        <span className="relative h-1 w-16 overflow-hidden rounded-full bg-muted">
+          <span
+            className="absolute inset-y-0 left-0 rounded-full"
+            style={{
+              width: `${milestone.percent_complete}%`,
+              backgroundColor: `hsl(${hue} 70% 55%)`,
+              opacity: subdued ? 0.5 : 0.85,
+            }}
+          />
+        </span>
+        <span className="w-8 text-right text-xs font-medium tabular-nums text-foreground/80">
+          {milestone.percent_complete}%
+        </span>
+      </span>
+
+      <ArrowUpRight className="size-3.5 shrink-0 text-muted-foreground/30 transition-all group-hover:-translate-y-0.5 group-hover:translate-x-0.5 group-hover:text-foreground" />
     </button>
   );
 }
 
 function StatusChip({ status }: { status: MilestoneStatus }) {
-  const cfg = {
-    open: { label: 'open', cls: 'bg-emerald-500/10 text-emerald-400/80', Icon: Circle },
-    closed: { label: 'closed', cls: 'bg-muted/50 text-muted-foreground/80', Icon: CheckCircle2 },
-    cancelled: { label: 'cancelled', cls: 'bg-muted/30 text-muted-foreground/60', Icon: XCircle },
-  }[status];
-  const Icon = cfg.Icon;
+  if (status === 'open') return null;
+  const Icon = status === 'closed' ? CheckCircle2 : XCircle;
   return (
-    <span className={cn('inline-flex items-center gap-1 h-4 px-1.5 rounded text-[10px] font-medium', cfg.cls)}>
-      <Icon className="h-[8px] w-[8px]" />
-      {cfg.label}
+    <span className="hidden items-center gap-1 text-xs uppercase tracking-wider text-muted-foreground/60 sm:inline-flex">
+      <Icon className="size-3" />
+      {status}
     </span>
   );
 }

--- a/apps/web/src/components/kortix/new-ticket-dialog.tsx
+++ b/apps/web/src/components/kortix/new-ticket-dialog.tsx
@@ -146,11 +146,8 @@ export function NewTicketDialog({ open, onOpenChange, projectId, columns, defaul
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
         className={cn(
-          'p-0 overflow-hidden gap-0 border-border/60 bg-background',
-          // The repo's DialogContent hardcodes `sm:max-w-5xl`, so a plain
-          // `max-w-md` gets overridden once the viewport hits `sm`.
-          // The responsive variant below wins via Tailwind ordering.
-          step === 'pick' ? 'max-w-sm sm:max-w-sm' : 'max-w-xl sm:max-w-xl',
+          'gap-0 overflow-hidden p-0',
+          step === 'pick' ? 'max-w-sm sm:max-w-sm' : 'max-w-2xl sm:max-w-2xl',
         )}
         hideCloseButton
       >
@@ -382,88 +379,95 @@ function TicketForm({
   };
 
   return (
-    <div className="flex flex-col">
-      {/* Header */}
-      <div className="flex items-center px-5 pt-4 pb-3 gap-3">
-        {showBack ? (
-          <Button variant="ghost" size="sm" className="h-6 px-1.5 -ml-1.5 text-muted-foreground/60 hover:text-foreground text-[11px]" onClick={onBack}>
-            <ArrowLeft className="h-3.5 w-3.5 mr-1" />
-            Templates
-          </Button>
-        ) : (
-          <div className="text-[10px] uppercase tracking-[0.08em] text-muted-foreground/55 font-semibold">
-            New ticket{template ? ` · ${template.name}` : ''}
-          </div>
+    <div className="relative flex flex-col">
+      <div className="flex items-center gap-2 px-5 pt-4">
+        <Sparkles className="size-3.5 text-muted-foreground/50" />
+        <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+          New ticket
+        </span>
+        {template && (
+          <>
+            <span className="text-muted-foreground/30">·</span>
+            <span className="text-xs text-muted-foreground">
+              From <span className="font-medium text-foreground">{template.name}</span>
+            </span>
+          </>
         )}
-        <Button variant="ghost" size="sm" className="ml-auto h-7 w-7 p-0 text-muted-foreground/50 hover:text-foreground" onClick={onClose}>
-          <X className="h-4 w-4" />
-        </Button>
-      </div>
-
-      {/* Body — 2-column layout: seamless editor on the left, meta rail on the right */}
-      <div className="grid grid-cols-[1fr_180px] min-h-[300px]">
-        <div className="px-5 pt-5 pb-4 flex flex-col min-w-0">
-          <textarea
-            ref={titleRef}
-            value={title}
-            onChange={(e) => onTitleChange(e.target.value)}
-            onKeyDown={onTitleKey}
-            placeholder="Ticket title"
-            rows={1}
-            className="w-full text-[20px] font-semibold tracking-tight bg-transparent border-0 outline-none focus:ring-0 placeholder:text-muted-foreground/25 resize-none overflow-hidden leading-tight"
-          />
-
-          <MentionTextarea
-            ref={bodyRef}
-            value={body}
-            onChange={onBodyChange}
-            onKeyDown={onBodyKey}
-            agents={agents}
-            userHandle={userHandle}
-            userAvatarUrl={myAvatarUrl}
-            placeholder={"Description, acceptance criteria, notes…\n\nMarkdown supported. Type @ to tag a team member."}
-            rows={8}
-            className="w-full mt-3 text-[13px] leading-[1.7] border-0 outline-none focus:ring-0 resize-none placeholder:text-muted-foreground/25 font-mono"
-          />
-        </div>
-
-        {/* Meta rail — no divider, same bg as body. */}
-        <aside className="px-4 pt-5 pb-4 space-y-5">
-          <MetaBlock label="Assignees">
-            <AssigneePicker
-              agents={agents}
-              userHandle={userHandle}
-              pending={pending}
-              onAdd={onAddAssignee}
-              onRemove={onRemoveAssignee}
-            />
-          </MetaBlock>
-          <MetaBlock label="Status">
-            <StatusPicker columns={columns} value={status} onChange={onStatusChange} />
-          </MetaBlock>
-          {milestones.length > 0 && (
-            <MetaBlock label="Milestone">
-              <select
-                value={milestoneId}
-                onChange={(e) => onMilestoneChange(e.target.value)}
-                className="w-full h-7 text-[12px] bg-transparent border border-border/50 rounded-md px-2 outline-none focus:ring-2 focus:ring-primary/20"
-              >
-                <option value="">— none —</option>
-                {milestones.map((m) => (
-                  <option key={m.id} value={m.id}>M{m.number} · {m.title}</option>
-                ))}
-              </select>
-            </MetaBlock>
+        <div className="ml-auto flex items-center gap-1">
+          {showBack && (
+            <Button
+              variant="ghost"
+              size="xs"
+              className="text-muted-foreground hover:text-foreground"
+              onClick={onBack}
+            >
+              <ArrowLeft />
+              Templates
+            </Button>
           )}
-        </aside>
+          <Button
+            variant="ghost"
+            size="icon-xs"
+            onClick={onClose}
+            className="text-muted-foreground hover:text-foreground"
+            aria-label="Close"
+          >
+            <X />
+          </Button>
+        </div>
       </div>
 
-      {/* Footer */}
-      <div className="border-t border-border/40 px-5 py-2.5 flex items-center gap-2">
-        <span className="text-[11px] text-muted-foreground/50">
-          <kbd className="inline-flex items-center justify-center min-w-[18px] h-4 px-1 rounded border border-border/50 bg-muted/40 text-[10px] font-mono leading-none">⌘</kbd>
-          <kbd className="inline-flex items-center justify-center min-w-[18px] h-4 px-1 ml-0.5 rounded border border-border/50 bg-muted/40 text-[10px] font-mono leading-none">↵</kbd>
-          <span className="ml-1.5">to create</span>
+      <div className="flex items-start gap-3 px-5 pt-5">
+        <StatusCircle columns={columns} value={status} onChange={onStatusChange} />
+        <textarea
+          ref={titleRef}
+          value={title}
+          onChange={(e) => onTitleChange(e.target.value)}
+          onKeyDown={onTitleKey}
+          placeholder="Ticket title"
+          rows={1}
+          className="w-full resize-none overflow-hidden border-0 bg-transparent pt-px text-lg font-semibold leading-tight tracking-tight outline-none placeholder:text-muted-foreground/30 focus:ring-0"
+        />
+      </div>
+
+      <div className="px-5 pt-2 pb-3 pl-[3.25rem]">
+        <MentionTextarea
+          ref={bodyRef}
+          value={body}
+          onChange={onBodyChange}
+          onKeyDown={onBodyKey}
+          agents={agents}
+          userHandle={userHandle}
+          userAvatarUrl={myAvatarUrl}
+          placeholder="Add a description… markdown supported, @ to mention"
+          rows={3}
+          className="w-full resize-none border-0 bg-transparent text-sm leading-relaxed outline-none placeholder:text-muted-foreground/30 focus:ring-0"
+        />
+      </div>
+
+      <div className="flex flex-wrap items-center gap-1.5 px-5 pb-4">
+        <StatusPill columns={columns} value={status} onChange={onStatusChange} />
+        <AssigneePill
+          agents={agents}
+          userHandle={userHandle}
+          pending={pending}
+          onAdd={onAddAssignee}
+          onRemove={onRemoveAssignee}
+        />
+        {milestones.length > 0 && (
+          <MilestonePill
+            milestones={milestones}
+            value={milestoneId}
+            onChange={onMilestoneChange}
+          />
+        )}
+      </div>
+
+      <div className="flex items-center gap-2 px-5 pb-4 pt-1">
+        <span className="inline-flex items-center gap-1 text-xs text-muted-foreground">
+          <kbd className="inline-flex h-5 min-w-5 items-center justify-center rounded-md bg-muted px-1 font-mono text-[10px]">⌘</kbd>
+          <kbd className="inline-flex h-5 min-w-5 items-center justify-center rounded-md bg-muted px-1 font-mono text-[10px]">↵</kbd>
+          <span className="ml-1">to create</span>
         </span>
         <div className="ml-auto flex items-center gap-1.5">
           <SaveAsTemplateButton
@@ -471,17 +475,62 @@ function TicketForm({
             saving={savingTemplate}
             onSave={onSaveAsTemplate}
           />
-          <Button
-            size="sm"
-            className="h-7 px-3 text-[12px]"
-            onClick={onSubmit}
-            disabled={!title.trim() || submitting}
-          >
+          <Button size="sm" onClick={onSubmit} disabled={!title.trim() || submitting}>
             {submitting ? 'Creating…' : 'Create ticket'}
           </Button>
         </div>
       </div>
     </div>
+  );
+}
+
+function StatusCircle({
+  columns,
+  value,
+  onChange,
+}: {
+  columns: TicketColumn[];
+  value: string;
+  onChange: (k: string) => void;
+}) {
+  const selected = columns.find((c) => c.key === value) ?? columns[0];
+  if (!selected) return null;
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          className={cn(
+            'inline-flex size-6 shrink-0 items-center justify-center rounded-md',
+            'transition-colors hover:bg-muted',
+            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30',
+          )}
+          aria-label={`Status: ${selected.label}`}
+          title={selected.label}
+        >
+          {columnIcon(selected)}
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="z-[10000] w-48">
+        <DropdownMenuLabel className="text-xs uppercase tracking-wider text-muted-foreground">
+          Status
+        </DropdownMenuLabel>
+        {columns.map((c) => {
+          const active = c.key === value;
+          return (
+            <DropdownMenuItem
+              key={c.key}
+              onClick={() => onChange(c.key)}
+              className="gap-2"
+            >
+              {columnIcon(c)}
+              <span className="flex-1 truncate">{c.label}</span>
+              {active && <Check className="size-3 text-primary" />}
+            </DropdownMenuItem>
+          );
+        })}
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }
 
@@ -566,53 +615,51 @@ function SaveAsTemplateButton({ disabled, saving, onSave }: {
   );
 }
 
-// ─── Meta block (right-rail section) ────────────────────────────────────────
+// ─── Status picker ──────────────────────────────────────────────────────────
 
-function MetaBlock({ label, children }: { label: string; children: React.ReactNode }) {
-  return (
-    <div>
-      <div className="text-[10px] uppercase tracking-[0.08em] text-muted-foreground/55 font-semibold mb-2">{label}</div>
-      {children}
-    </div>
-  );
+const PILL_TRIGGER = cn(
+  'group inline-flex items-center gap-1.5 rounded-full bg-muted/40 px-2.5 py-1 text-xs',
+  'text-foreground transition-colors hover:bg-muted',
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30',
+);
+
+function columnIcon(c: TicketColumn) {
+  const cls = c.is_terminal
+    ? 'size-3 text-emerald-500'
+    : c.key === 'in_progress'
+      ? 'size-3 text-blue-500'
+      : c.key === 'review'
+        ? 'size-3 text-amber-500'
+        : 'size-3 text-muted-foreground/60';
+  if (c.is_terminal) return <CheckCircle2 className={cls} />;
+  if (c.key === 'in_progress') return <Loader2 className={cls} />;
+  if (c.key === 'review') return <CircleDot className={cls} />;
+  return <Circle className={cls} />;
 }
 
-// ─── Status picker: single chip → dropdown with every column ────────────────
-
-function columnIcon(c: TicketColumn, active: boolean) {
-  const className = active
-    ? 'h-3.5 w-3.5'
-    : c.is_terminal
-      ? 'h-3.5 w-3.5 text-emerald-500/70'
-      : c.key === 'in_progress'
-        ? 'h-3.5 w-3.5 text-blue-500/80'
-        : c.key === 'review'
-          ? 'h-3.5 w-3.5 text-amber-500/70'
-          : 'h-3.5 w-3.5 text-muted-foreground/55';
-  if (c.is_terminal) return <CheckCircle2 className={className} />;
-  if (c.key === 'in_progress') return <Loader2 className={className} />;
-  if (c.key === 'review') return <CircleDot className={className} />;
-  return <Circle className={className} />;
-}
-
-function StatusPicker({ columns, value, onChange }: { columns: TicketColumn[]; value: string; onChange: (k: string) => void }) {
+function StatusPill({
+  columns,
+  value,
+  onChange,
+}: {
+  columns: TicketColumn[];
+  value: string;
+  onChange: (k: string) => void;
+}) {
   const selected = columns.find((c) => c.key === value) ?? columns[0];
   if (!selected) return null;
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <button
-          className="group w-full inline-flex items-center gap-2 h-8 px-2.5 rounded-lg border border-border/50 hover:border-border bg-card/60 hover:bg-muted/40 text-[12.5px] text-foreground transition-colors cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-primary/30"
-          aria-label={`Status: ${selected.label}`}
-        >
-          {columnIcon(selected, false)}
-          <span className="truncate flex-1 text-left font-medium">{selected.label}</span>
-          <ChevronDown className="h-3 w-3 text-muted-foreground/40 group-hover:text-foreground transition-colors" />
-        </button>
+        <Button size="xs" className={cn(PILL_TRIGGER, 'bg-muted text-muted-foreground hover:bg-muted/70')} aria-label={`Status: ${selected.label}`}>
+          {columnIcon(selected)}
+          <span className="font-medium">{selected.label}</span>
+          <ChevronDown className="size-3 text-muted-foreground/50" />
+        </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="start" className="w-[200px] z-[10000]">
-        <DropdownMenuLabel className="text-[10px] uppercase tracking-[0.08em] text-muted-foreground/55 font-semibold">
-          Move to
+      <DropdownMenuContent align="start" className="z-[10000] w-48">
+        <DropdownMenuLabel className="text-xs uppercase tracking-wider text-muted-foreground">
+          Status
         </DropdownMenuLabel>
         {columns.map((c) => {
           const active = c.key === value;
@@ -620,11 +667,11 @@ function StatusPicker({ columns, value, onChange }: { columns: TicketColumn[]; v
             <DropdownMenuItem
               key={c.key}
               onClick={() => onChange(c.key)}
-              className="gap-2 cursor-pointer"
+              className="gap-2"
             >
-              {columnIcon(c, false)}
+              {columnIcon(c)}
               <span className="flex-1 truncate">{c.label}</span>
-              {active && <Check className="h-3 w-3 text-primary" />}
+              {active && <Check className="size-3 text-primary" />}
             </DropdownMenuItem>
           );
         })}
@@ -633,9 +680,56 @@ function StatusPicker({ columns, value, onChange }: { columns: TicketColumn[]; v
   );
 }
 
-// ─── Assignee picker ────────────────────────────────────────────────────────
+function MilestonePill({
+  milestones,
+  value,
+  onChange,
+}: {
+  milestones: Milestone[];
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  const selected = milestones.find((m) => m.id === value);
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button size="xs" className={cn(PILL_TRIGGER, 'bg-muted text-muted-foreground hover:bg-muted/70')} aria-label="Milestone">
+          <CircleDot className="size-3 text-violet-500" />
+          <span className={cn('font-medium', !selected && 'text-muted-foreground')}>
+            {selected ? selected.title : 'No milestone'}
+          </span>
+          <ChevronDown className="size-3 text-muted-foreground/50" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="z-[10000] w-56">
+        <DropdownMenuLabel className="text-xs uppercase tracking-wider text-muted-foreground">
+          Milestone
+        </DropdownMenuLabel>
+        <DropdownMenuItem onClick={() => onChange('')} className="gap-2">
+          <Circle className="size-3 text-muted-foreground/40" />
+          <span className="flex-1 truncate text-muted-foreground">No milestone</span>
+          {!value && <Check className="size-3 text-primary" />}
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        {milestones.map((m) => (
+          <DropdownMenuItem
+            key={m.id}
+            onClick={() => onChange(m.id)}
+            className="gap-2"
+          >
+            <CircleDot className="size-3 text-violet-500" />
+            <span className="flex-1 truncate">
+              <span className="font-mono text-muted-foreground">M{m.number}</span> {m.title}
+            </span>
+            {m.id === value && <Check className="size-3 text-primary" />}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
 
-function AssigneePicker({
+function AssigneePill({
   agents,
   userHandle,
   pending,
@@ -648,63 +742,73 @@ function AssigneePicker({
   onAdd: (a: PendingAssignee) => void;
   onRemove: (a: PendingAssignee) => void;
 }) {
-  const alreadyAdded = (t: AssigneeType, id: string) => pending.some((x) => x.type === t && x.id === id);
   const { avatarUrl: myAvatarUrl } = useCurrentUserAvatarProps();
-  const agentBySlug = new Map(agents.map((a) => [a.slug, a] as const));
+  const alreadyAdded = (t: AssigneeType, id: string) =>
+    pending.some((x) => x.type === t && x.id === id);
 
   return (
-    <div className="flex flex-col gap-1.5">
-      {pending.length === 0 && (
-        <p className="text-[11.5px] text-muted-foreground/40 leading-snug">
-          Unassigned — column defaults still fire.
-        </p>
-      )}
+    <>
       {pending.map((a) => {
         const ag = a.type === 'agent' ? agents.find((x) => x.id === a.id) : null;
         return (
-          <div
+          <span
             key={`${a.type}:${a.id}`}
-            className="inline-flex items-center gap-1.5 h-7 pl-0.5 pr-1 rounded-full bg-muted/40 w-fit"
+            className="inline-flex items-center gap-1.5 rounded-full bg-muted/40 py-0.5 pl-0.5 pr-1.5 text-xs"
           >
             {ag ? (
-              <AgentAvatar hue={ag.color_hue} icon={ag.icon} slug={ag.slug} name={ag.name} size="sm" />
+              <AgentAvatar
+                hue={ag.color_hue}
+                icon={ag.icon}
+                slug={ag.slug}
+                name={ag.name}
+                size="sm"
+              />
             ) : (
-              <UserAvatar handle={a.label} avatarUrl={a.type === 'user' && a.label === userHandle ? myAvatarUrl : null} size="sm" />
+              <UserAvatar
+                handle={a.label}
+                avatarUrl={a.type === 'user' && a.label === userHandle ? myAvatarUrl : null}
+                size="sm"
+              />
             )}
-            <span className="text-[11.5px] font-mono text-foreground/85 truncate max-w-[120px]">@{a.label}</span>
+            <span className="font-mono text-foreground/90">@{a.label}</span>
             <button
+              type="button"
               onClick={() => onRemove(a)}
-              className="h-4 w-4 inline-flex items-center justify-center rounded-full text-muted-foreground/50 hover:text-foreground hover:bg-muted/60 transition-colors"
-              aria-label="Remove"
+              className="grid size-4 place-items-center rounded-full text-muted-foreground hover:bg-muted hover:text-foreground"
+              aria-label="Remove assignee"
             >
-              <X className="h-2.5 w-2.5" />
+              <X className="size-2.5" />
             </button>
-          </div>
+          </span>
         );
       })}
+
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <Button
-            variant="ghost"
-            size="sm"
-            className="h-6 px-2 text-[11px] gap-1 text-muted-foreground/60 hover:text-foreground border border-dashed border-border/40 hover:border-border rounded-full w-fit"
+            size="xs"
+            className={cn(
+              PILL_TRIGGER,
+              'bg-muted text-muted-foreground hover:bg-muted/70',
+            )}
+            aria-label="Add assignee"
           >
-            <UserPlus className="h-2.5 w-2.5" />
-            Add
+            <UserPlus className="size-3" />
+            <span className="font-medium">{pending.length === 0 ? 'Assign' : 'Add'}</span>
           </Button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent align="start" className="w-60 z-[10000]">
-          <DropdownMenuLabel className="text-[10px] uppercase tracking-[0.08em] text-muted-foreground/55 font-semibold">
+        <DropdownMenuContent align="start" className="z-[10000] w-56">
+          <DropdownMenuLabel className="text-xs uppercase tracking-wider text-muted-foreground">
             Assign to
           </DropdownMenuLabel>
           <DropdownMenuItem
             disabled={alreadyAdded('user', userHandle)}
             onClick={() => onAdd({ type: 'user', id: userHandle, label: userHandle })}
-            className="gap-2 cursor-pointer"
+            className="gap-2"
           >
             <UserAvatar handle={userHandle} avatarUrl={myAvatarUrl} size="sm" />
             <span className="flex-1 truncate">@{userHandle}</span>
-            <span className="text-[10px] text-muted-foreground/40">you</span>
+            <span className="text-xs text-muted-foreground">you</span>
           </DropdownMenuItem>
           {agents.length > 0 && <DropdownMenuSeparator />}
           {agents.map((a) => (
@@ -712,16 +816,21 @@ function AssigneePicker({
               key={a.id}
               disabled={alreadyAdded('agent', a.id)}
               onClick={() => onAdd({ type: 'agent', id: a.id, label: a.slug })}
-              className="gap-2 cursor-pointer"
+              className="gap-2"
             >
-              <AgentAvatar hue={a.color_hue} icon={a.icon} slug={a.slug} name={a.name} size="sm" />
+              <AgentAvatar
+                hue={a.color_hue}
+                icon={a.icon}
+                slug={a.slug}
+                name={a.name}
+                size="sm"
+              />
               <span className="flex-1 truncate">@{a.slug}</span>
             </DropdownMenuItem>
           ))}
         </DropdownMenuContent>
       </DropdownMenu>
-      {/* Silence unused-variable linting for the reference map (kept for future @-mention UX). */}
-      {agentBySlug.size === -1 && null}
-    </div>
+    </>
   );
 }
+

--- a/apps/web/src/components/kortix/notifications-bell.tsx
+++ b/apps/web/src/components/kortix/notifications-bell.tsx
@@ -106,7 +106,7 @@ export function NotificationsBell({
         </Button>
       </PopoverTrigger>
       <PopoverContent
-        align="end"
+        align="start"
         sideOffset={8}
         className="w-[400px] p-0 z-[10000] overflow-hidden border-border/60"
       >

--- a/apps/web/src/components/kortix/project-about.tsx
+++ b/apps/web/src/components/kortix/project-about.tsx
@@ -8,6 +8,7 @@ import {
   useMemo,
   useRef,
 } from 'react';
+import { motion } from 'framer-motion';
 import { toast as sonnerToast } from 'sonner';
 import { cn } from '@/lib/utils';
 import { UnifiedMarkdown } from '@/components/markdown';
@@ -20,81 +21,76 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+import {
   AlertCircle,
-  ArrowRight,
-  Calendar,
+  ArrowUpRight,
+  Boxes,
   Check,
   CircleDot,
-  Copy,
-  FileText,
-  FolderGit2,
   Loader2,
-  MessageSquareText,
   Pencil,
-  Plus,
-  Sparkles,
   Target,
-  Users,
 } from 'lucide-react';
 import {
   AgentAvatar,
   UserAvatar,
 } from '@/components/kortix/agent-avatar';
-import { useTickets, useProjectAgents, useProjectActivity, useUserHandle, type TicketEvent, type ProjectAgent, type Ticket } from '@/hooks/kortix/use-kortix-tickets';
-import { useMilestones, type Milestone } from '@/hooks/kortix/use-milestones';
+import {
+  useTickets,
+  useProjectAgents,
+  useProjectActivity,
+  useUserHandle,
+  type TicketEvent,
+  type ProjectAgent,
+  type Ticket,
+} from '@/hooks/kortix/use-kortix-tickets';
+import { useMilestones } from '@/hooks/kortix/use-milestones';
 import { useKortixProjectSessions } from '@/hooks/kortix/use-kortix-projects';
-import { relativeTime, fullDate } from '@/lib/kortix/task-meta';
+import { fullDate } from '@/lib/kortix/task-meta';
+import type { ProjectTab } from '@/components/kortix/project-header';
 
 const TERMINAL_STATUSES = new Set(['done', 'closed', 'cancelled', 'archived']);
 
 interface ProjectAboutProps {
   project: any;
+  onNavigate?: (tab: ProjectTab) => void;
+  onOpenTicket?: (id: string) => void;
 }
 
-export function ProjectAbout({ project }: ProjectAboutProps) {
+export function ProjectAbout({
+  project,
+  onNavigate,
+  onOpenTicket,
+}: ProjectAboutProps) {
   const projectId = project?.id;
 
-  const { data: tickets = [], isLoading: ticketsLoading } = useTickets(projectId, {
+  const { data: tickets = [] } = useTickets(projectId, { pollingEnabled: false });
+  const { data: milestones = [] } = useMilestones(projectId, 'all');
+  const { data: agents = [] } = useProjectAgents(projectId);
+  const { data: sessions = [] } = useKortixProjectSessions(projectId);
+  const { data: activity = [] } = useProjectActivity(projectId, {
     pollingEnabled: false,
   });
-  const { data: milestones = [], isLoading: milestonesLoading } = useMilestones(
-    projectId,
-    'all',
-  );
-  const { data: agents = [], isLoading: agentsLoading } = useProjectAgents(projectId);
-  const { data: sessions = [], isLoading: sessionsLoading } =
-    useKortixProjectSessions(projectId);
-  const { data: activity = [], isLoading: activityLoading } = useProjectActivity(
-    projectId,
-    { pollingEnabled: false },
-  );
   const userHandle = useUserHandle();
 
-  const ticketStats = useMemo(() => {
-    const total = tickets.length;
-    const open = tickets.filter((t) => !TERMINAL_STATUSES.has(t.status)).length;
-    const done = total - open;
-    return { total, open, done };
-  }, [tickets]);
-
-  const milestoneStats = useMemo(() => {
-    const open = milestones.filter((m) => m.status === 'open').length;
-    const closed = milestones.filter((m) => m.status === 'closed').length;
-    return { total: milestones.length, open, closed };
-  }, [milestones]);
-
-  const activeMilestones = useMemo(
-    () =>
-      milestones
-        .filter((m) => m.status === 'open')
-        .sort((a, b) => {
-          const ad = a.due_at ? Date.parse(a.due_at) : Number.POSITIVE_INFINITY;
-          const bd = b.due_at ? Date.parse(b.due_at) : Number.POSITIVE_INFINITY;
-          return ad - bd;
-        })
-        .slice(0, 4),
+  const openTickets = useMemo(
+    () => tickets.filter((t) => !TERMINAL_STATUSES.has(t.status)),
+    [tickets],
+  );
+  const openMilestones = useMemo(
+    () => milestones.filter((m) => m.status === 'open').length,
     [milestones],
   );
+
+  const agentById = useMemo(() => {
+    const m = new Map<string, ProjectAgent>();
+    agents.forEach((a) => m.set(a.id, a));
+    return m;
+  }, [agents]);
 
   const ticketTitleById = useMemo(() => {
     const m = new Map<string, string>();
@@ -102,307 +98,517 @@ export function ProjectAbout({ project }: ProjectAboutProps) {
     return m;
   }, [tickets]);
 
-  const recentActivity = useMemo(() => activity.slice(0, 8), [activity]);
+  const rawDescription = project?.description?.trim();
+  const isAutoDescription =
+    rawDescription &&
+    project?.name &&
+    rawDescription.toLowerCase() === `new project: ${project.name.toLowerCase()}`;
+  const description = isAutoDescription ? '' : rawDescription;
 
   return (
     <div className="h-full overflow-y-auto">
-      <div className="mx-auto w-full max-w-5xl space-y-8 px-4 py-8 sm:px-6 sm:py-10">
-        <StatsGrid
-          loading={ticketsLoading || milestonesLoading || agentsLoading || sessionsLoading}
-          tickets={ticketStats}
-          milestones={milestoneStats}
-          sessions={sessions.length}
-          agents={agents.length}
-        />
+      <motion.div
+        initial="hidden"
+        animate="show"
+        variants={{
+          hidden: {},
+          show: { transition: { staggerChildren: 0.04, delayChildren: 0.04 } },
+        }}
+        className="mx-auto w-full max-w-3xl px-6 pt-10 pb-24"
+      >
+        {description && (
+          <Section>
+            <p className="text-sm leading-relaxed text-muted-foreground">
+              {description}
+            </p>
+          </Section>
+        )}
 
-        <Section
-          icon={Target}
-          label="Active milestones"
-          count={milestoneStats.open}
-          loading={milestonesLoading}
-        >
-          {activeMilestones.length === 0 ? (
-            <EmptyTile
-              icon={Target}
-              title="No active milestones"
-              hint="Create a milestone to group tickets toward a release goal."
-            />
-          ) : (
-            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-              {activeMilestones.map((m) => (
-                <MilestoneCard key={m.id} milestone={m} />
-              ))}
-            </div>
-          )}
+        <Section delay={!!description}>
+          <StatusRow
+            openTickets={openTickets.length}
+            openMilestones={openMilestones}
+            sessionCount={sessions.length}
+            agentCount={agents.length}
+            agents={agents}
+            userHandle={userHandle}
+            onNavigate={onNavigate}
+          />
         </Section>
 
-        <div className="grid grid-cols-1 gap-6 lg:grid-cols-[1.2fr_1fr]">
-          <Section icon={Users} label="Team" count={agents.length} loading={agentsLoading}>
-            <TeamPanel agents={agents} userHandle={userHandle} />
-          </Section>
-
-          <Section
-            icon={Sparkles}
-            label="Recent activity"
-            count={recentActivity.length}
-            loading={activityLoading}
-          >
-            <ActivityPanel
-              events={recentActivity}
-              ticketTitleById={ticketTitleById}
+        {openTickets.length > 0 && (
+          <Section delay>
+            <ActiveWork
+              tickets={openTickets.slice(0, 4)}
+              total={openTickets.length}
+              agentById={agentById}
+              onOpenTicket={onOpenTicket}
+              onSeeAll={() => onNavigate?.('board')}
             />
           </Section>
-        </div>
+        )}
 
-        <ContextSection project={project} />
-      </div>
-    </div>
-  );
-}
+        <Section delay>
+          <Activity
+            events={activity.slice(0, 16)}
+            ticketTitleById={ticketTitleById}
+            agentById={agentById}
+            onOpenTicket={onOpenTicket}
+          />
+        </Section>
 
-function StatsGrid({
-  loading,
-  tickets,
-  milestones,
-  sessions,
-  agents,
-}: {
-  loading: boolean;
-  tickets: { total: number; open: number; done: number };
-  milestones: { total: number; open: number; closed: number };
-  sessions: number;
-  agents: number;
-}) {
-  const items: Array<{
-    label: string;
-    value: number;
-    sub: string;
-    icon: typeof CircleDot;
-  }> = [
-    {
-      label: 'Tickets',
-      value: tickets.total,
-      sub: `${tickets.open} open · ${tickets.done} done`,
-      icon: CircleDot,
-    },
-    {
-      label: 'Milestones',
-      value: milestones.total,
-      sub: `${milestones.open} open · ${milestones.closed} closed`,
-      icon: Target,
-    },
-    {
-      label: 'Sessions',
-      value: sessions,
-      sub: sessions === 1 ? '1 chat' : `${sessions} chats`,
-      icon: MessageSquareText,
-    },
-    {
-      label: 'Agents',
-      value: agents,
-      sub: agents === 1 ? '1 in the team' : `${agents} in the team`,
-      icon: Users,
-    },
-  ];
-
-  return (
-    <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-      {items.map((item) => (
-        <div
-          key={item.label}
-          className="flex flex-col gap-2 rounded-2xl border bg-card p-4"
-        >
-          <div className="flex items-center justify-between">
-            <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              {item.label}
-            </span>
-            <item.icon className="size-3.5 text-muted-foreground/50" />
-          </div>
-          {loading ? (
-            <Skeleton className="h-7 w-12" />
-          ) : (
-            <span className="text-2xl font-semibold tabular-nums tracking-tight">
-              {item.value}
-            </span>
-          )}
-          <span className="text-xs tabular-nums text-muted-foreground">
-            {loading ? <Skeleton className="h-3 w-20" /> : item.sub}
-          </span>
-        </div>
-      ))}
+        <Section delay>
+          <ContextSection project={project} />
+        </Section>
+      </motion.div>
     </div>
   );
 }
 
 function Section({
+  children,
+  delay,
+}: {
+  children: React.ReactNode;
+  delay?: boolean;
+}) {
+  return (
+    <motion.section
+      variants={{
+        hidden: { opacity: 0, y: 6 },
+        show: { opacity: 1, y: 0, transition: { duration: 0.3, ease: 'easeOut' } },
+      }}
+      className={cn(delay && 'mt-10')}
+    >
+      {children}
+    </motion.section>
+  );
+}
+
+function StatusRow({
+  openTickets,
+  openMilestones,
+  sessionCount,
+  agentCount,
+  agents,
+  userHandle,
+  onNavigate,
+}: {
+  openTickets: number;
+  openMilestones: number;
+  sessionCount: number;
+  agentCount: number;
+  agents: ProjectAgent[];
+  userHandle: string;
+  onNavigate?: (tab: ProjectTab) => void;
+}) {
+  const stats: Array<{
+    label: string;
+    value: number;
+    dot: string;
+    tab: ProjectTab;
+  }> = [
+    {
+      label: openTickets === 1 ? 'open ticket' : 'open tickets',
+      value: openTickets,
+      dot: 'bg-blue-500',
+      tab: 'board',
+    },
+    {
+      label: openMilestones === 1 ? 'milestone' : 'milestones',
+      value: openMilestones,
+      dot: 'bg-amber-500',
+      tab: 'milestones',
+    },
+    {
+      label: sessionCount === 1 ? 'session' : 'sessions',
+      value: sessionCount,
+      dot: 'bg-violet-500',
+      tab: 'sessions',
+    },
+  ];
+
+  return (
+    <div className="flex flex-wrap items-center gap-x-2 gap-y-2">
+      {stats.map((s) => (
+        <button
+          key={s.label}
+          type="button"
+          onClick={() => onNavigate?.(s.tab)}
+          className={cn(
+            'inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-xs',
+            'text-muted-foreground transition-colors',
+            'hover:border-foreground/30 hover:bg-muted/40 hover:text-foreground',
+          )}
+        >
+          <span className={cn('size-1.5 rounded-full', s.dot)} />
+          <span className="font-semibold tabular-nums text-foreground">
+            {s.value}
+          </span>
+          <span>{s.label}</span>
+        </button>
+      ))}
+
+      <span className="mx-1 hidden h-4 w-px bg-border sm:block" />
+
+      <div className="flex -space-x-1.5">
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className="rounded-full ring-2 ring-background">
+              <UserAvatar handle={userHandle} avatarUrl={null} size="sm" />
+            </span>
+          </TooltipTrigger>
+          <TooltipContent>@{userHandle}</TooltipContent>
+        </Tooltip>
+        {agents.map((agent) => (
+          <Tooltip key={agent.id}>
+            <TooltipTrigger asChild>
+              <span className="rounded-full ring-2 ring-background">
+                <AgentAvatar
+                  hue={agent.color_hue}
+                  icon={agent.icon}
+                  slug={agent.slug}
+                  name={agent.name}
+                  size="sm"
+                />
+              </span>
+            </TooltipTrigger>
+            <TooltipContent>
+              @{agent.slug} · {agent.name}
+            </TooltipContent>
+          </Tooltip>
+        ))}
+      </div>
+      <span className="text-xs tabular-nums text-muted-foreground">
+        {agentCount} {agentCount === 1 ? 'agent' : 'agents'}
+      </span>
+    </div>
+  );
+}
+
+function SectionLabel({
   icon: Icon,
   label,
   count,
-  loading,
-  action,
-  children,
+  onSeeAll,
+  liveDot,
 }: {
-  icon: typeof Target;
+  icon: typeof CircleDot;
   label: string;
   count?: number;
-  loading?: boolean;
-  action?: React.ReactNode;
-  children: React.ReactNode;
+  onSeeAll?: () => void;
+  liveDot?: boolean;
 }) {
   return (
-    <section>
-      <div className="mb-3 flex items-center gap-2">
+    <div className="group/header flex items-center justify-between">
+      <div className="flex items-center gap-2">
         <Icon className="size-3.5 text-muted-foreground/60" />
-        <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+        <h2 className="text-xs font-medium uppercase tracking-[0.12em] text-muted-foreground">
           {label}
-        </span>
-        {typeof count === 'number' && !loading && (
+        </h2>
+        {typeof count === 'number' && count > 0 && (
           <Badge variant="muted" size="sm" className="tabular-nums">
             {count}
           </Badge>
         )}
-        {action && <div className="ml-auto">{action}</div>}
+        {liveDot && <LivePulse />}
       </div>
-      {children}
-    </section>
-  );
-}
-
-function MilestoneCard({ milestone }: { milestone: Milestone }) {
-  const pct = Math.max(0, Math.min(100, milestone.percent_complete));
-  const total = milestone.progress?.total ?? 0;
-  const done = milestone.progress?.done ?? 0;
-  const due = milestone.due_at;
-
-  return (
-    <div className="group flex flex-col gap-3 rounded-2xl border bg-card p-4 transition-colors hover:bg-muted/30">
-      <div className="flex items-start justify-between gap-2">
-        <div className="min-w-0">
-          <h3 className="truncate text-sm font-semibold tracking-tight text-foreground">
-            {milestone.title}
-          </h3>
-          <p className="mt-0.5 text-xs tabular-nums text-muted-foreground">
-            {done} of {total} tickets · {pct}%
-          </p>
-        </div>
-        <Badge
-          variant={due ? 'highlight' : 'muted'}
-          size="sm"
-          className="tabular-nums"
+      {onSeeAll && (
+        <button
+          type="button"
+          onClick={onSeeAll}
+          className="inline-flex items-center gap-0.5 text-xs text-muted-foreground opacity-0 transition-opacity hover:text-foreground group-hover/header:opacity-100"
         >
-          {due ? relativeTime(due) : 'No due date'}
-        </Badge>
-      </div>
-      <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted">
-        <div
-          className="h-full rounded-full bg-foreground/80 transition-[width] duration-500 ease-out"
-          style={{ width: `${pct}%` }}
-        />
-      </div>
+          View all
+          <ArrowUpRight className="size-3" />
+        </button>
+      )}
     </div>
   );
 }
 
-function TeamPanel({
-  agents,
-  userHandle,
+function ActiveWork({
+  tickets,
+  total,
+  agentById,
+  onOpenTicket,
+  onSeeAll,
 }: {
-  agents: ProjectAgent[];
-  userHandle: string;
+  tickets: Ticket[];
+  total: number;
+  agentById: Map<string, ProjectAgent>;
+  onOpenTicket?: (id: string) => void;
+  onSeeAll?: () => void;
 }) {
-  if (agents.length === 0) {
-    return (
-      <EmptyTile
-        icon={Users}
-        title="No agents yet"
-        hint="Add an agent in Settings → Team to start delegating work."
-      />
-    );
-  }
-
   return (
-    <div className="overflow-hidden rounded-2xl border bg-card">
-      <Member
-        avatar={
-          <UserAvatar
-            handle={userHandle}
-            avatarUrl={null}
-            size="sm"
+    <div>
+      <SectionLabel
+        icon={Boxes}
+        label="Active work"
+        count={total}
+        onSeeAll={total > tickets.length ? onSeeAll : undefined}
+      />
+      <div className="mt-3 overflow-hidden rounded-2xl bg-muted/30">
+        {tickets.map((ticket, i) => (
+          <TicketRow
+            key={ticket.id}
+            ticket={ticket}
+            agentById={agentById}
+            onOpen={onOpenTicket}
+            isLast={i === tickets.length - 1}
           />
-        }
-        name={`@${userHandle}`}
-        role="Human · default reviewer"
-      />
-      {agents.map((agent) => (
-        <Member
-          key={agent.id}
-          avatar={
-            <AgentAvatar
-              hue={agent.color_hue}
-              icon={agent.icon}
-              slug={agent.slug}
-              name={agent.name}
-              size="sm"
-            />
-          }
-          name={`@${agent.slug}`}
-          role={agent.name}
-        />
-      ))}
-    </div>
-  );
-}
-
-function Member({
-  avatar,
-  name,
-  role,
-}: {
-  avatar: React.ReactNode;
-  name: string;
-  role: string;
-}) {
-  return (
-    <div className="flex items-center gap-3 border-b px-4 py-3 last:border-b-0">
-      {avatar}
-      <div className="min-w-0 flex-1">
-        <p className="truncate text-sm font-medium tabular-nums text-foreground">
-          {name}
-        </p>
-        <p className="truncate text-xs text-muted-foreground">{role}</p>
+        ))}
       </div>
     </div>
   );
 }
 
-function ActivityPanel({
+function TicketRow({
+  ticket,
+  agentById,
+  onOpen,
+  isLast,
+}: {
+  ticket: Ticket;
+  agentById: Map<string, ProjectAgent>;
+  onOpen?: (id: string) => void;
+  isLast: boolean;
+}) {
+  const status = ticket.column?.label ?? ticket.status ?? 'todo';
+  const dot = statusDotColor(ticket.status);
+  const assignee = ticket.assignees?.[0];
+  const agent =
+    assignee?.assignee_type === 'agent' && assignee.assignee_id
+      ? agentById.get(assignee.assignee_id)
+      : undefined;
+
+  return (
+    <button
+      type="button"
+      onClick={() => onOpen?.(ticket.id)}
+      className={cn(
+        'group flex w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-muted/60',
+        !isLast && 'border-b border-border/40',
+      )}
+    >
+      <span className={cn('size-1.5 shrink-0 rounded-full', dot)} />
+      <span className="shrink-0 font-mono text-xs tabular-nums text-muted-foreground/60">
+        #{ticket.number}
+      </span>
+      <span className="min-w-0 flex-1 truncate text-sm text-foreground">
+        {ticket.title}
+      </span>
+      <span className="hidden text-xs uppercase tracking-wider text-muted-foreground/70 sm:inline">
+        {status}
+      </span>
+      {assignee && agent ? (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className="shrink-0">
+              <AgentAvatar
+                hue={agent.color_hue}
+                icon={agent.icon}
+                slug={agent.slug}
+                name={agent.name}
+                size="sm"
+              />
+            </span>
+          </TooltipTrigger>
+          <TooltipContent>@{agent.slug}</TooltipContent>
+        </Tooltip>
+      ) : assignee?.assignee_type === 'user' && assignee.assignee_id ? (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className="shrink-0">
+              <UserAvatar handle={assignee.assignee_id} avatarUrl={null} size="sm" />
+            </span>
+          </TooltipTrigger>
+          <TooltipContent>@{assignee.assignee_id}</TooltipContent>
+        </Tooltip>
+      ) : (
+        <span className="shrink-0 text-xs text-muted-foreground/40">unassigned</span>
+      )}
+      <ArrowUpRight className="size-3.5 shrink-0 text-muted-foreground/30 transition-all group-hover:translate-x-0.5 group-hover:-translate-y-0.5 group-hover:text-foreground" />
+    </button>
+  );
+}
+
+function statusDotColor(status: string): string {
+  const s = status.toLowerCase();
+  if (s.includes('done') || s.includes('closed')) return 'bg-emerald-500';
+  if (s.includes('progress') || s.includes('doing') || s.includes('working')) return 'bg-blue-500';
+  if (s.includes('review')) return 'bg-violet-500';
+  if (s.includes('block')) return 'bg-rose-500';
+  return 'bg-muted-foreground/50';
+}
+
+function Activity({
   events,
   ticketTitleById,
+  agentById,
+  onOpenTicket,
 }: {
   events: TicketEvent[];
   ticketTitleById: Map<string, string>;
+  agentById: Map<string, ProjectAgent>;
+  onOpenTicket?: (id: string) => void;
 }) {
   if (events.length === 0) {
     return (
-      <EmptyTile
-        icon={Sparkles}
-        title="Nothing yet"
-        hint="Comments, status changes, and assignments will appear here."
-      />
+      <div>
+        <SectionLabel icon={CircleDot} label="Activity" />
+        <div className="mt-3 rounded-2xl bg-muted/30 px-6 py-10 text-center">
+          <p className="text-sm font-medium text-foreground/85">Quiet so far</p>
+          <p className="mx-auto mt-1 max-w-md text-xs leading-relaxed text-muted-foreground/65">
+            Comments, status changes, and assignments will appear here.
+          </p>
+        </div>
+      </div>
     );
   }
 
+  const groups = groupByDay(events);
+  const recent = isRecent(events[0]?.created_at);
+
   return (
-    <ol className="overflow-hidden rounded-2xl border bg-card">
-      {events.map((ev) => (
-        <ActivityRow
-          key={ev.id}
-          event={ev}
-          ticketTitle={ticketTitleById.get(ev.ticket_id)}
-        />
-      ))}
-    </ol>
+    <div>
+      <SectionLabel
+        icon={CircleDot}
+        label="Activity"
+        count={events.length}
+        liveDot={recent}
+      />
+      <div className="mt-3 space-y-5">
+        {groups.map(({ label, events: items }, gi) => (
+          <div key={label}>
+            <div className="mb-2 flex items-center gap-2 px-1">
+              <span className="text-[10px] font-semibold uppercase tracking-[0.1em] text-muted-foreground/55">
+                {label}
+              </span>
+              {gi === 0 && recent && <LivePulse />}
+              <span className="ml-auto text-[10px] tabular-nums text-muted-foreground/40">
+                {items.length}
+              </span>
+            </div>
+            <div className="overflow-hidden rounded-2xl bg-muted/30">
+              {items.map((ev, i) => (
+                <ActivityRow
+                  key={ev.id}
+                  event={ev}
+                  ticketTitle={ticketTitleById.get(ev.ticket_id)}
+                  agent={
+                    ev.actor_type === 'agent' && ev.actor_id
+                      ? agentById.get(ev.actor_id)
+                      : undefined
+                  }
+                  onOpen={onOpenTicket}
+                  isLast={i === items.length - 1}
+                />
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
   );
+}
+
+function LivePulse() {
+  return (
+    <span className="relative inline-flex items-center justify-center">
+      <span className="absolute size-2 animate-ping rounded-full bg-emerald-500/40" />
+      <span className="relative size-1 rounded-full bg-emerald-500" />
+    </span>
+  );
+}
+
+function isRecent(iso?: string): boolean {
+  if (!iso) return false;
+  const t = Date.parse(iso);
+  if (Number.isNaN(t)) return false;
+  return Date.now() - t < 5 * 60_000;
+}
+
+function ActivityRow({
+  event,
+  ticketTitle,
+  agent,
+  onOpen,
+  isLast,
+}: {
+  event: TicketEvent;
+  ticketTitle?: string;
+  agent?: ProjectAgent;
+  onOpen?: (id: string) => void;
+  isLast: boolean;
+}) {
+  const handle =
+    event.actor_type === 'user'
+      ? `@${event.actor_id ?? 'unknown'}`
+      : event.actor_type === 'agent'
+        ? `@${agent?.slug ?? event.actor_id ?? 'agent'}`
+        : 'System';
+  const verb = describeEventType(event.type);
+  const verbClass = verbColor(event.type);
+  const ref = ticketTitle ?? `ticket ${event.ticket_id.slice(0, 6)}`;
+
+  return (
+    <button
+      type="button"
+      onClick={() => onOpen?.(event.ticket_id)}
+      className={cn(
+        'group flex w-full items-center gap-3 px-4 py-2.5 text-left transition-colors hover:bg-muted/60',
+        !isLast && 'border-b border-border/40',
+      )}
+    >
+      <span className="shrink-0">
+        {event.actor_type === 'agent' && agent ? (
+          <AgentAvatar
+            hue={agent.color_hue}
+            icon={agent.icon}
+            slug={agent.slug}
+            name={agent.name}
+            size="sm"
+          />
+        ) : (
+          <UserAvatar
+            handle={event.actor_id ?? 'system'}
+            avatarUrl={null}
+            size="sm"
+          />
+        )}
+      </span>
+
+      <p className="min-w-0 flex-1 truncate text-sm leading-snug text-foreground/85">
+        <span className="font-medium text-foreground">{handle}</span>
+        <span className={verbClass}> {verb} </span>
+        <span className="text-foreground">{ref}</span>
+      </p>
+
+      <span
+        className="hidden shrink-0 text-xs tabular-nums text-muted-foreground/55 sm:inline"
+        title={fullDate(event.created_at)}
+      >
+        {timeOnly(event.created_at)}
+      </span>
+
+      <ArrowUpRight className="size-3.5 shrink-0 text-muted-foreground/30 transition-all group-hover:-translate-y-0.5 group-hover:translate-x-0.5 group-hover:text-foreground" />
+    </button>
+  );
+}
+
+function verbColor(type: string): string {
+  switch (type) {
+    case 'closed':
+      return 'text-emerald-600 dark:text-emerald-400';
+    case 'created':
+    case 'reopened':
+      return 'text-blue-600 dark:text-blue-400';
+    case 'status_change':
+      return 'text-violet-600 dark:text-violet-400';
+    default:
+      return 'text-muted-foreground';
+  }
 }
 
 function describeEventType(type: string): string {
@@ -416,7 +622,7 @@ function describeEventType(type: string): string {
     case 'status_change':
       return 'moved';
     case 'created':
-      return 'created';
+      return 'opened';
     case 'closed':
       return 'closed';
     case 'reopened':
@@ -426,58 +632,49 @@ function describeEventType(type: string): string {
   }
 }
 
-function ActivityRow({
-  event,
-  ticketTitle,
-}: {
-  event: TicketEvent;
-  ticketTitle?: string;
-}) {
-  const actor =
-    event.actor_type === 'user'
-      ? `@${event.actor_id ?? 'unknown'}`
-      : event.actor_type === 'agent'
-        ? `@${event.actor_id ?? 'agent'}`
-        : 'System';
-  const action = describeEventType(event.type);
-  const ticketRef =
-    ticketTitle ?? `ticket ${event.ticket_id.slice(0, 6)}`;
-
-  return (
-    <li className="flex items-start gap-3 border-b px-4 py-3 last:border-b-0">
-      <span className="mt-1.5 size-1.5 shrink-0 rounded-full bg-muted-foreground/40" />
-      <div className="min-w-0 flex-1">
-        <p className="truncate text-xs text-muted-foreground">
-          <span className="font-medium text-foreground">{actor}</span>{' '}
-          {action}{' '}
-          <span className="font-medium text-foreground">{ticketRef}</span>
-        </p>
-        <p className="mt-0.5 text-xs tabular-nums text-muted-foreground/70">
-          {relativeTime(event.created_at)}
-        </p>
-      </div>
-    </li>
-  );
+function timeOnly(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '';
+  return d.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
 }
 
-function EmptyTile({
-  icon: Icon,
-  title,
-  hint,
-}: {
-  icon: typeof Target;
-  title: string;
-  hint: string;
-}) {
-  return (
-    <div className="rounded-2xl border border-dashed bg-card/40 px-6 py-10 text-center">
-      <div className="mx-auto flex size-9 items-center justify-center rounded-lg border bg-card text-muted-foreground">
-        <Icon className="size-4" />
-      </div>
-      <p className="mt-3 text-sm font-medium text-foreground">{title}</p>
-      <p className="mx-auto mt-1 max-w-xs text-xs text-muted-foreground">{hint}</p>
-    </div>
-  );
+function groupByDay(events: TicketEvent[]): Array<{ label: string; events: TicketEvent[] }> {
+  const today = startOfDay(new Date());
+  const yesterday = new Date(today);
+  yesterday.setDate(today.getDate() - 1);
+  const lastWeek = new Date(today);
+  lastWeek.setDate(today.getDate() - 7);
+
+  const buckets: Record<string, TicketEvent[]> = {};
+  const order: string[] = [];
+
+  const push = (label: string, ev: TicketEvent) => {
+    if (!buckets[label]) {
+      buckets[label] = [];
+      order.push(label);
+    }
+    buckets[label].push(ev);
+  };
+
+  for (const ev of events) {
+    const t = new Date(ev.created_at);
+    if (Number.isNaN(t.getTime())) continue;
+    const tDay = startOfDay(t).getTime();
+    if (tDay === today.getTime()) push('Today', ev);
+    else if (tDay === yesterday.getTime()) push('Yesterday', ev);
+    else if (t >= lastWeek)
+      push(t.toLocaleDateString([], { weekday: 'long' }), ev);
+    else
+      push(t.toLocaleDateString([], { month: 'short', day: 'numeric' }), ev);
+  }
+
+  return order.map((label) => ({ label, events: buckets[label] }));
+}
+
+function startOfDay(d: Date): Date {
+  const x = new Date(d);
+  x.setHours(0, 0, 0, 0);
+  return x;
 }
 
 function ContextSection({ project }: { project: any }) {
@@ -498,7 +695,6 @@ function ContextSection({ project }: { project: any }) {
   const [draft, setDraft] = useState('');
   const [saving, setSaving] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
-  const [pathCopied, setPathCopied] = useState(false);
 
   const startEditing = useCallback(() => {
     setDraft(contextContent || '');
@@ -545,13 +741,6 @@ function ContextSection({ project }: { project: any }) {
     if (editing) setTimeout(() => textareaRef.current?.focus(), 0);
   }, [editing]);
 
-  const copyPath = useCallback(() => {
-    if (!project?.path) return;
-    navigator.clipboard.writeText(project.path).catch(() => {});
-    setPathCopied(true);
-    setTimeout(() => setPathCopied(false), 1200);
-  }, [project?.path]);
-
   const action = editing ? (
     <div className="flex items-center gap-1">
       <Button
@@ -563,11 +752,7 @@ function ContextSection({ project }: { project: any }) {
       >
         Cancel
       </Button>
-      <Button
-        size="sm"
-        onClick={saveContext}
-        disabled={saving}
-      >
+      <Button size="sm" onClick={saveContext} disabled={saving}>
         {saving ? <Loader2 className="animate-spin" /> : <Check />}
         Save
       </Button>
@@ -585,120 +770,70 @@ function ContextSection({ project }: { project: any }) {
   ) : null;
 
   return (
-    <Section icon={FileText} label="Context" action={action}>
-      <div className="mb-3 flex items-center gap-2 text-xs text-muted-foreground">
-        <span>Source</span>
-        <Badge variant="secondary" size="sm" className="rounded-md font-mono normal-case tracking-normal">
-          .kortix/CONTEXT.md
-        </Badge>
+    <div>
+      <div className="flex items-baseline justify-between gap-3">
+        <div className="flex items-baseline gap-3">
+          <SectionLabel icon={Target} label="Context" />
+          <Badge
+            variant="secondary"
+            size="sm"
+            className="rounded-md font-mono normal-case tracking-normal"
+          >
+            .kortix/CONTEXT.md
+          </Badge>
+        </div>
+        {action}
       </div>
 
-      {contextLoading ? (
-        <div className="flex items-center justify-center gap-2 rounded-2xl border bg-card py-12 text-muted-foreground">
-          <Loader2 className="size-4 animate-spin" />
-          <span className="text-sm">Loading CONTEXT.md…</span>
-        </div>
-      ) : editing ? (
-        <textarea
-          ref={textareaRef}
-          value={draft}
-          onChange={(e) => setDraft(e.target.value)}
-          onKeyDown={(e) => {
-            if (e.key === 'Escape') {
-              e.preventDefault();
-              cancelEditing();
-            }
-            if (e.key === 's' && (e.metaKey || e.ctrlKey)) {
-              e.preventDefault();
-              saveContext();
-            }
-          }}
-          spellCheck
-          className={cn(
-            'min-h-60 w-full resize-none overflow-hidden rounded-2xl border bg-card p-5',
-            'font-mono text-sm leading-relaxed text-foreground/85 outline-none',
-            'placeholder:text-muted-foreground/40',
-            'focus:border-foreground/30 focus:ring-2 focus:ring-ring/30',
-            'transition-colors',
-          )}
-          placeholder="# Project Context\n\nMission, architecture, key decisions, open questions — the durable project memory every agent reads first."
-        />
-      ) : contextError || !contextContent ? (
-        <button
-          onClick={startEditing}
-          className="group w-full rounded-2xl border border-dashed bg-card/40 p-10 text-center transition-colors hover:border-foreground/40 hover:bg-muted/30"
-        >
-          <AlertCircle className="mx-auto mb-3 size-5 text-muted-foreground/30 transition-colors group-hover:text-foreground/60" />
-          <p className="mb-1 text-sm font-medium text-foreground">No CONTEXT.md yet</p>
-          <p className="mx-auto max-w-sm text-xs leading-relaxed text-muted-foreground">
-            Click to create{' '}
-            <Badge variant="secondary" size="sm" className="rounded-md font-mono normal-case tracking-normal">
-              .kortix/CONTEXT.md
-            </Badge>{' '}
-            — the durable project memory every agent reads first.
-          </p>
-        </button>
-      ) : (
-        <div className="rounded-2xl border bg-card px-5 py-5 sm:px-6">
+      <div className="mt-4">
+        {contextLoading ? (
+          <div className="space-y-2">
+            <Skeleton className="h-4 w-2/3" />
+            <Skeleton className="h-4 w-full" />
+            <Skeleton className="h-4 w-5/6" />
+          </div>
+        ) : editing ? (
+          <textarea
+            ref={textareaRef}
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Escape') {
+                e.preventDefault();
+                cancelEditing();
+              }
+              if (e.key === 's' && (e.metaKey || e.ctrlKey)) {
+                e.preventDefault();
+                saveContext();
+              }
+            }}
+            spellCheck
+            className={cn(
+              'min-h-60 w-full resize-none overflow-hidden bg-transparent',
+              'font-mono text-sm leading-relaxed text-foreground/85 outline-none',
+              'placeholder:text-muted-foreground/40',
+            )}
+            placeholder="# Project context\n\nMission, architecture, key decisions, open questions — the durable project memory every agent reads first."
+          />
+        ) : contextError || !contextContent ? (
+          <button
+            onClick={startEditing}
+            className="group flex w-full items-start gap-3 rounded-lg py-2 text-left transition-colors hover:bg-muted/30"
+          >
+            <AlertCircle className="mt-0.5 size-4 shrink-0 text-muted-foreground/40 transition-colors group-hover:text-foreground/60" />
+            <div>
+              <p className="text-sm font-medium text-foreground">No context yet</p>
+              <p className="mt-1 max-w-md text-sm leading-relaxed text-muted-foreground">
+                Write the durable project memory every agent reads first — mission,
+                architecture, key decisions, open questions.
+              </p>
+            </div>
+          </button>
+        ) : (
           <article className="prose prose-sm max-w-none dark:prose-invert">
             <UnifiedMarkdown content={contextContent} />
           </article>
-        </div>
-      )}
-
-      <div className="mt-4 grid grid-cols-1 gap-px overflow-hidden rounded-2xl border bg-border sm:grid-cols-2">
-        <DetailRow
-          icon={<FolderGit2 className="size-3.5 text-muted-foreground/60" />}
-          label="Path"
-          value={
-            <button
-              onClick={copyPath}
-              className="inline-flex max-w-full min-w-0 items-center gap-1.5 truncate font-mono text-xs text-foreground/80 transition-colors hover:text-foreground"
-              title="Copy path"
-            >
-              <span className="truncate">{project?.path || '—'}</span>
-              {pathCopied ? (
-                <Check className="size-3 shrink-0 text-emerald-500" />
-              ) : (
-                <Copy className="size-3 shrink-0 text-muted-foreground/40" />
-              )}
-            </button>
-          }
-        />
-        <DetailRow
-          icon={<Calendar className="size-3.5 text-muted-foreground/60" />}
-          label="Created"
-          value={
-            <span
-              className="text-xs tabular-nums text-foreground/80"
-              title={fullDate(project?.created_at)}
-            >
-              {relativeTime(project?.created_at)}
-            </span>
-          }
-        />
-      </div>
-    </Section>
-  );
-}
-
-function DetailRow({
-  icon,
-  label,
-  value,
-}: {
-  icon: React.ReactNode;
-  label: string;
-  value: React.ReactNode;
-}) {
-  return (
-    <div className="flex min-w-0 items-center gap-3 bg-card px-4 py-3">
-      <span className="shrink-0">{icon}</span>
-      <span className="w-16 shrink-0 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-        {label}
-      </span>
-      <div className="flex min-w-0 flex-1 items-center justify-end text-right">
-        {value}
+        )}
       </div>
     </div>
   );

--- a/apps/web/src/components/kortix/project-about.tsx
+++ b/apps/web/src/components/kortix/project-about.tsx
@@ -1,75 +1,514 @@
 'use client';
 
-/**
- * Project About — single-column, centered, Context is the main thing.
- *
- *   Context (.kortix/CONTEXT.md) — HERO, main attraction
- *   ────
- *   Details card: path, created at
- */
-
-import { useState, useCallback, useEffect, useLayoutEffect, useRef } from 'react';
+import {
+  useState,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+} from 'react';
 import { toast as sonnerToast } from 'sonner';
 import { cn } from '@/lib/utils';
 import { UnifiedMarkdown } from '@/components/markdown';
-import { useFileContent, useInvalidateFileContent } from '@/features/files/hooks/use-file-content';
-import { uploadFile } from '@/features/files/api/opencode-files';
-import { Button } from '@/components/ui/button';
 import {
+  useFileContent,
+  useInvalidateFileContent,
+} from '@/features/files/hooks/use-file-content';
+import { uploadFile } from '@/features/files/api/opencode-files';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import {
+  AlertCircle,
+  ArrowRight,
+  Calendar,
+  Check,
+  CircleDot,
+  Copy,
   FileText,
   FolderGit2,
   Loader2,
-  AlertCircle,
+  MessageSquareText,
   Pencil,
-  Check,
-  Copy,
-  Calendar,
+  Plus,
+  Sparkles,
+  Target,
+  Users,
 } from 'lucide-react';
+import {
+  AgentAvatar,
+  UserAvatar,
+} from '@/components/kortix/agent-avatar';
+import { useTickets, useProjectAgents, useProjectActivity, useUserHandle, type TicketEvent, type ProjectAgent, type Ticket } from '@/hooks/kortix/use-kortix-tickets';
+import { useMilestones, type Milestone } from '@/hooks/kortix/use-milestones';
+import { useKortixProjectSessions } from '@/hooks/kortix/use-kortix-projects';
 import { relativeTime, fullDate } from '@/lib/kortix/task-meta';
+
+const TERMINAL_STATUSES = new Set(['done', 'closed', 'cancelled', 'archived']);
 
 interface ProjectAboutProps {
   project: any;
 }
 
 export function ProjectAbout({ project }: ProjectAboutProps) {
-  // ── CONTEXT.md file path ─────────────────────────────────
-  const contextPath = project?.path && project.path !== '/'
-    ? `${project.path.replace(/\/+$/, '')}/.kortix/CONTEXT.md`
-    : null;
+  const projectId = project?.id;
+
+  const { data: tickets = [], isLoading: ticketsLoading } = useTickets(projectId, {
+    pollingEnabled: false,
+  });
+  const { data: milestones = [], isLoading: milestonesLoading } = useMilestones(
+    projectId,
+    'all',
+  );
+  const { data: agents = [], isLoading: agentsLoading } = useProjectAgents(projectId);
+  const { data: sessions = [], isLoading: sessionsLoading } =
+    useKortixProjectSessions(projectId);
+  const { data: activity = [], isLoading: activityLoading } = useProjectActivity(
+    projectId,
+    { pollingEnabled: false },
+  );
+  const userHandle = useUserHandle();
+
+  const ticketStats = useMemo(() => {
+    const total = tickets.length;
+    const open = tickets.filter((t) => !TERMINAL_STATUSES.has(t.status)).length;
+    const done = total - open;
+    return { total, open, done };
+  }, [tickets]);
+
+  const milestoneStats = useMemo(() => {
+    const open = milestones.filter((m) => m.status === 'open').length;
+    const closed = milestones.filter((m) => m.status === 'closed').length;
+    return { total: milestones.length, open, closed };
+  }, [milestones]);
+
+  const activeMilestones = useMemo(
+    () =>
+      milestones
+        .filter((m) => m.status === 'open')
+        .sort((a, b) => {
+          const ad = a.due_at ? Date.parse(a.due_at) : Number.POSITIVE_INFINITY;
+          const bd = b.due_at ? Date.parse(b.due_at) : Number.POSITIVE_INFINITY;
+          return ad - bd;
+        })
+        .slice(0, 4),
+    [milestones],
+  );
+
+  const ticketTitleById = useMemo(() => {
+    const m = new Map<string, string>();
+    tickets.forEach((t) => m.set(t.id, t.title));
+    return m;
+  }, [tickets]);
+
+  const recentActivity = useMemo(() => activity.slice(0, 8), [activity]);
+
+  return (
+    <div className="h-full overflow-y-auto">
+      <div className="mx-auto w-full max-w-5xl space-y-8 px-4 py-8 sm:px-6 sm:py-10">
+        <StatsGrid
+          loading={ticketsLoading || milestonesLoading || agentsLoading || sessionsLoading}
+          tickets={ticketStats}
+          milestones={milestoneStats}
+          sessions={sessions.length}
+          agents={agents.length}
+        />
+
+        <Section
+          icon={Target}
+          label="Active milestones"
+          count={milestoneStats.open}
+          loading={milestonesLoading}
+        >
+          {activeMilestones.length === 0 ? (
+            <EmptyTile
+              icon={Target}
+              title="No active milestones"
+              hint="Create a milestone to group tickets toward a release goal."
+            />
+          ) : (
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+              {activeMilestones.map((m) => (
+                <MilestoneCard key={m.id} milestone={m} />
+              ))}
+            </div>
+          )}
+        </Section>
+
+        <div className="grid grid-cols-1 gap-6 lg:grid-cols-[1.2fr_1fr]">
+          <Section icon={Users} label="Team" count={agents.length} loading={agentsLoading}>
+            <TeamPanel agents={agents} userHandle={userHandle} />
+          </Section>
+
+          <Section
+            icon={Sparkles}
+            label="Recent activity"
+            count={recentActivity.length}
+            loading={activityLoading}
+          >
+            <ActivityPanel
+              events={recentActivity}
+              ticketTitleById={ticketTitleById}
+            />
+          </Section>
+        </div>
+
+        <ContextSection project={project} />
+      </div>
+    </div>
+  );
+}
+
+function StatsGrid({
+  loading,
+  tickets,
+  milestones,
+  sessions,
+  agents,
+}: {
+  loading: boolean;
+  tickets: { total: number; open: number; done: number };
+  milestones: { total: number; open: number; closed: number };
+  sessions: number;
+  agents: number;
+}) {
+  const items: Array<{
+    label: string;
+    value: number;
+    sub: string;
+    icon: typeof CircleDot;
+  }> = [
+    {
+      label: 'Tickets',
+      value: tickets.total,
+      sub: `${tickets.open} open · ${tickets.done} done`,
+      icon: CircleDot,
+    },
+    {
+      label: 'Milestones',
+      value: milestones.total,
+      sub: `${milestones.open} open · ${milestones.closed} closed`,
+      icon: Target,
+    },
+    {
+      label: 'Sessions',
+      value: sessions,
+      sub: sessions === 1 ? '1 chat' : `${sessions} chats`,
+      icon: MessageSquareText,
+    },
+    {
+      label: 'Agents',
+      value: agents,
+      sub: agents === 1 ? '1 in the team' : `${agents} in the team`,
+      icon: Users,
+    },
+  ];
+
+  return (
+    <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+      {items.map((item) => (
+        <div
+          key={item.label}
+          className="flex flex-col gap-2 rounded-2xl border bg-card p-4"
+        >
+          <div className="flex items-center justify-between">
+            <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+              {item.label}
+            </span>
+            <item.icon className="size-3.5 text-muted-foreground/50" />
+          </div>
+          {loading ? (
+            <Skeleton className="h-7 w-12" />
+          ) : (
+            <span className="text-2xl font-semibold tabular-nums tracking-tight">
+              {item.value}
+            </span>
+          )}
+          <span className="text-xs tabular-nums text-muted-foreground">
+            {loading ? <Skeleton className="h-3 w-20" /> : item.sub}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function Section({
+  icon: Icon,
+  label,
+  count,
+  loading,
+  action,
+  children,
+}: {
+  icon: typeof Target;
+  label: string;
+  count?: number;
+  loading?: boolean;
+  action?: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <section>
+      <div className="mb-3 flex items-center gap-2">
+        <Icon className="size-3.5 text-muted-foreground/60" />
+        <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+          {label}
+        </span>
+        {typeof count === 'number' && !loading && (
+          <Badge variant="muted" size="sm" className="tabular-nums">
+            {count}
+          </Badge>
+        )}
+        {action && <div className="ml-auto">{action}</div>}
+      </div>
+      {children}
+    </section>
+  );
+}
+
+function MilestoneCard({ milestone }: { milestone: Milestone }) {
+  const pct = Math.max(0, Math.min(100, milestone.percent_complete));
+  const total = milestone.progress?.total ?? 0;
+  const done = milestone.progress?.done ?? 0;
+  const due = milestone.due_at;
+
+  return (
+    <div className="group flex flex-col gap-3 rounded-2xl border bg-card p-4 transition-colors hover:bg-muted/30">
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <h3 className="truncate text-sm font-semibold tracking-tight text-foreground">
+            {milestone.title}
+          </h3>
+          <p className="mt-0.5 text-xs tabular-nums text-muted-foreground">
+            {done} of {total} tickets · {pct}%
+          </p>
+        </div>
+        <Badge
+          variant={due ? 'highlight' : 'muted'}
+          size="sm"
+          className="tabular-nums"
+        >
+          {due ? relativeTime(due) : 'No due date'}
+        </Badge>
+      </div>
+      <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted">
+        <div
+          className="h-full rounded-full bg-foreground/80 transition-[width] duration-500 ease-out"
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+    </div>
+  );
+}
+
+function TeamPanel({
+  agents,
+  userHandle,
+}: {
+  agents: ProjectAgent[];
+  userHandle: string;
+}) {
+  if (agents.length === 0) {
+    return (
+      <EmptyTile
+        icon={Users}
+        title="No agents yet"
+        hint="Add an agent in Settings → Team to start delegating work."
+      />
+    );
+  }
+
+  return (
+    <div className="overflow-hidden rounded-2xl border bg-card">
+      <Member
+        avatar={
+          <UserAvatar
+            handle={userHandle}
+            avatarUrl={null}
+            size="sm"
+          />
+        }
+        name={`@${userHandle}`}
+        role="Human · default reviewer"
+      />
+      {agents.map((agent) => (
+        <Member
+          key={agent.id}
+          avatar={
+            <AgentAvatar
+              hue={agent.color_hue}
+              icon={agent.icon}
+              slug={agent.slug}
+              name={agent.name}
+              size="sm"
+            />
+          }
+          name={`@${agent.slug}`}
+          role={agent.name}
+        />
+      ))}
+    </div>
+  );
+}
+
+function Member({
+  avatar,
+  name,
+  role,
+}: {
+  avatar: React.ReactNode;
+  name: string;
+  role: string;
+}) {
+  return (
+    <div className="flex items-center gap-3 border-b px-4 py-3 last:border-b-0">
+      {avatar}
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-sm font-medium tabular-nums text-foreground">
+          {name}
+        </p>
+        <p className="truncate text-xs text-muted-foreground">{role}</p>
+      </div>
+    </div>
+  );
+}
+
+function ActivityPanel({
+  events,
+  ticketTitleById,
+}: {
+  events: TicketEvent[];
+  ticketTitleById: Map<string, string>;
+}) {
+  if (events.length === 0) {
+    return (
+      <EmptyTile
+        icon={Sparkles}
+        title="Nothing yet"
+        hint="Comments, status changes, and assignments will appear here."
+      />
+    );
+  }
+
+  return (
+    <ol className="overflow-hidden rounded-2xl border bg-card">
+      {events.map((ev) => (
+        <ActivityRow
+          key={ev.id}
+          event={ev}
+          ticketTitle={ticketTitleById.get(ev.ticket_id)}
+        />
+      ))}
+    </ol>
+  );
+}
+
+function describeEventType(type: string): string {
+  switch (type) {
+    case 'comment':
+      return 'commented on';
+    case 'assigned':
+      return 'was assigned to';
+    case 'unassigned':
+      return 'was unassigned from';
+    case 'status_change':
+      return 'moved';
+    case 'created':
+      return 'created';
+    case 'closed':
+      return 'closed';
+    case 'reopened':
+      return 'reopened';
+    default:
+      return type.replace(/_/g, ' ');
+  }
+}
+
+function ActivityRow({
+  event,
+  ticketTitle,
+}: {
+  event: TicketEvent;
+  ticketTitle?: string;
+}) {
+  const actor =
+    event.actor_type === 'user'
+      ? `@${event.actor_id ?? 'unknown'}`
+      : event.actor_type === 'agent'
+        ? `@${event.actor_id ?? 'agent'}`
+        : 'System';
+  const action = describeEventType(event.type);
+  const ticketRef =
+    ticketTitle ?? `ticket ${event.ticket_id.slice(0, 6)}`;
+
+  return (
+    <li className="flex items-start gap-3 border-b px-4 py-3 last:border-b-0">
+      <span className="mt-1.5 size-1.5 shrink-0 rounded-full bg-muted-foreground/40" />
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-xs text-muted-foreground">
+          <span className="font-medium text-foreground">{actor}</span>{' '}
+          {action}{' '}
+          <span className="font-medium text-foreground">{ticketRef}</span>
+        </p>
+        <p className="mt-0.5 text-xs tabular-nums text-muted-foreground/70">
+          {relativeTime(event.created_at)}
+        </p>
+      </div>
+    </li>
+  );
+}
+
+function EmptyTile({
+  icon: Icon,
+  title,
+  hint,
+}: {
+  icon: typeof Target;
+  title: string;
+  hint: string;
+}) {
+  return (
+    <div className="rounded-2xl border border-dashed bg-card/40 px-6 py-10 text-center">
+      <div className="mx-auto flex size-9 items-center justify-center rounded-lg border bg-card text-muted-foreground">
+        <Icon className="size-4" />
+      </div>
+      <p className="mt-3 text-sm font-medium text-foreground">{title}</p>
+      <p className="mx-auto mt-1 max-w-xs text-xs text-muted-foreground">{hint}</p>
+    </div>
+  );
+}
+
+function ContextSection({ project }: { project: any }) {
+  const contextPath =
+    project?.path && project.path !== '/'
+      ? `${project.path.replace(/\/+$/, '')}/.kortix/CONTEXT.md`
+      : null;
 
   const {
     data: contextFile,
     isLoading: contextLoading,
     error: contextError,
   } = useFileContent(contextPath, { staleTime: 30_000 });
-
   const invalidateContent = useInvalidateFileContent();
   const contextContent = contextFile?.type === 'text' ? contextFile.content : null;
 
-  // ── CONTEXT.md edit state ────────────────────────────────
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState('');
   const [saving, setSaving] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const [pathCopied, setPathCopied] = useState(false);
 
   const startEditing = useCallback(() => {
     setDraft(contextContent || '');
     setEditing(true);
   }, [contextContent]);
 
-  useLayoutEffect(() => {
-    if (!editing) return;
-    const el = textareaRef.current;
-    if (!el) return;
-    el.style.height = 'auto';
-    el.style.height = `${el.scrollHeight}px`;
-  }, [editing, draft]);
-
-  useEffect(() => {
-    if (editing) {
-      setTimeout(() => textareaRef.current?.focus(), 0);
-    }
-  }, [editing]);
+  const cancelEditing = useCallback(() => {
+    setEditing(false);
+    setDraft('');
+  }, []);
 
   const saveContext = useCallback(async () => {
     if (!contextPath || draft === (contextContent || '')) {
@@ -94,13 +533,18 @@ export function ProjectAbout({ project }: ProjectAboutProps) {
     }
   }, [contextPath, draft, contextContent, invalidateContent]);
 
-  const cancelEditing = useCallback(() => {
-    setEditing(false);
-    setDraft('');
-  }, []);
+  useLayoutEffect(() => {
+    if (!editing) return;
+    const el = textareaRef.current;
+    if (!el) return;
+    el.style.height = 'auto';
+    el.style.height = `${el.scrollHeight}px`;
+  }, [editing, draft]);
 
-  // ── Path copy ────────────────────────────────────────────
-  const [pathCopied, setPathCopied] = useState(false);
+  useEffect(() => {
+    if (editing) setTimeout(() => textareaRef.current?.focus(), 0);
+  }, [editing]);
+
   const copyPath = useCallback(() => {
     if (!project?.path) return;
     navigator.clipboard.writeText(project.path).catch(() => {});
@@ -108,170 +552,137 @@ export function ProjectAbout({ project }: ProjectAboutProps) {
     setTimeout(() => setPathCopied(false), 1200);
   }, [project?.path]);
 
+  const action = editing ? (
+    <div className="flex items-center gap-1">
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={cancelEditing}
+        disabled={saving}
+        className="text-muted-foreground hover:text-foreground"
+      >
+        Cancel
+      </Button>
+      <Button
+        size="sm"
+        onClick={saveContext}
+        disabled={saving}
+      >
+        {saving ? <Loader2 className="animate-spin" /> : <Check />}
+        Save
+      </Button>
+    </div>
+  ) : contextContent ? (
+    <Button
+      variant="ghost"
+      size="sm"
+      onClick={startEditing}
+      className="text-muted-foreground hover:text-foreground"
+    >
+      <Pencil />
+      Edit
+    </Button>
+  ) : null;
+
   return (
-    <div className="h-full overflow-y-auto animate-in fade-in-0 duration-300 fill-mode-both">
-      <div className="container mx-auto max-w-3xl px-4 sm:px-6 lg:px-10 py-8 sm:py-10 space-y-10">
-
-        {/* ─── Context (.kortix/CONTEXT.md) — HERO ───────── */}
-        <section>
-          <div className="flex items-center gap-2 mb-3">
-            <FileText className="h-3.5 w-3.5 text-muted-foreground/45" />
-            <span className="text-[10px] uppercase tracking-[0.08em] text-muted-foreground/55 font-semibold">
-              Context
-            </span>
-            <span className="text-[11px] text-muted-foreground/30 font-mono hidden sm:inline">
-              .kortix/CONTEXT.md
-            </span>
-            <div className="ml-auto flex items-center gap-1">
-              {editing ? (
-                <>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="h-6 px-2 text-[11px] text-muted-foreground hover:text-foreground cursor-pointer"
-                    onClick={cancelEditing}
-                    disabled={saving}
-                  >
-                    Cancel
-                  </Button>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="h-6 px-2 text-[11px] text-emerald-500 hover:text-emerald-400 gap-1 cursor-pointer"
-                    onClick={saveContext}
-                    disabled={saving}
-                  >
-                    {saving ? <Loader2 className="h-3 w-3 animate-spin" /> : <Check className="h-3 w-3" />}
-                    Save
-                  </Button>
-                </>
-              ) : contextContent ? (
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="h-6 px-2 text-[11px] text-muted-foreground/50 hover:text-foreground gap-1 cursor-pointer"
-                  onClick={startEditing}
-                >
-                  <Pencil className="h-3 w-3" />
-                  Edit
-                </Button>
-              ) : null}
-            </div>
-          </div>
-
-          {contextLoading ? (
-            <div className="rounded-xl border border-border/40 bg-card flex items-center gap-2 justify-center py-12 text-muted-foreground/40">
-              <Loader2 className="h-4 w-4 animate-spin" />
-              <span className="text-[13px]">Loading CONTEXT.md…</span>
-            </div>
-          ) : editing ? (
-            <textarea
-              ref={textareaRef}
-              value={draft}
-              onChange={(e) => setDraft(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === 'Escape') {
-                  e.preventDefault();
-                  cancelEditing();
-                }
-                if (e.key === 's' && (e.metaKey || e.ctrlKey)) {
-                  e.preventDefault();
-                  saveContext();
-                }
-              }}
-              spellCheck
-              className={cn(
-                'w-full min-h-[240px] resize-none overflow-hidden',
-                'bg-card border border-border/40 rounded-xl outline-none',
-                'text-[13px] text-foreground/85 leading-[1.7] font-mono',
-                'placeholder:text-muted-foreground/30',
-                'focus:border-primary/30 focus:ring-1 focus:ring-primary/20',
-                'p-5 transition-colors',
-              )}
-              placeholder="# Project Context&#10;&#10;Mission, architecture, key decisions, open questions — the durable project memory every agent reads first."
-            />
-          ) : contextError || !contextContent ? (
-            <button
-              onClick={startEditing}
-              className="w-full rounded-xl border border-dashed border-border/60 p-10 text-center hover:border-primary/40 hover:bg-primary/[0.02] transition-colors cursor-pointer group"
-            >
-              <AlertCircle className="h-5 w-5 text-muted-foreground/25 mx-auto mb-3 group-hover:text-primary/50 transition-colors" />
-              <p className="text-[13px] text-foreground/70 mb-1 font-medium">
-                No CONTEXT.md yet
-              </p>
-              <p className="text-[12px] text-muted-foreground/40 max-w-[380px] mx-auto leading-relaxed">
-                Click to create{' '}
-                <code className="font-mono text-[11px] bg-muted/40 px-1.5 py-0.5 rounded">
-                  .kortix/CONTEXT.md
-                </code>
-                {' '}— the durable project memory every agent reads first.
-              </p>
-            </button>
-          ) : (
-            <div className="rounded-xl border border-border/40 bg-card px-5 sm:px-6 py-5">
-              <article className="prose prose-sm dark:prose-invert max-w-none">
-                <UnifiedMarkdown content={contextContent} />
-              </article>
-            </div>
-          )}
-        </section>
-
-        {/* ─── Details card (compact, reference info) ─────── */}
-        <section>
-          <SectionLabel label="Details" />
-          <div className="rounded-xl border border-border/40 divide-y divide-border/30 overflow-hidden bg-card">
-            <MetaRow
-              icon={<FolderGit2 className="h-3.5 w-3.5 text-muted-foreground/45" />}
-              label="Path"
-              value={
-                <button
-                  onClick={copyPath}
-                  className="text-[12px] font-mono text-foreground/75 hover:text-foreground inline-flex items-center gap-1.5 transition-colors cursor-pointer max-w-full min-w-0"
-                  title="Copy path"
-                >
-                  <span className="truncate">{project?.path || '—'}</span>
-                  {pathCopied ? (
-                    <Check className="h-3 w-3 text-emerald-500 shrink-0" />
-                  ) : (
-                    <Copy className="h-3 w-3 text-muted-foreground/30 shrink-0" />
-                  )}
-                </button>
-              }
-            />
-            <MetaRow
-              icon={<Calendar className="h-3.5 w-3.5 text-muted-foreground/45" />}
-              label="Created"
-              value={
-                <span
-                  className="text-[12px] text-foreground/70 tabular-nums"
-                  title={fullDate(project?.created_at)}
-                >
-                  {relativeTime(project?.created_at)}
-                </span>
-              }
-            />
-          </div>
-        </section>
+    <Section icon={FileText} label="Context" action={action}>
+      <div className="mb-3 flex items-center gap-2 text-xs text-muted-foreground">
+        <span>Source</span>
+        <Badge variant="secondary" size="sm" className="rounded-md font-mono normal-case tracking-normal">
+          .kortix/CONTEXT.md
+        </Badge>
       </div>
-    </div>
+
+      {contextLoading ? (
+        <div className="flex items-center justify-center gap-2 rounded-2xl border bg-card py-12 text-muted-foreground">
+          <Loader2 className="size-4 animate-spin" />
+          <span className="text-sm">Loading CONTEXT.md…</span>
+        </div>
+      ) : editing ? (
+        <textarea
+          ref={textareaRef}
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Escape') {
+              e.preventDefault();
+              cancelEditing();
+            }
+            if (e.key === 's' && (e.metaKey || e.ctrlKey)) {
+              e.preventDefault();
+              saveContext();
+            }
+          }}
+          spellCheck
+          className={cn(
+            'min-h-60 w-full resize-none overflow-hidden rounded-2xl border bg-card p-5',
+            'font-mono text-sm leading-relaxed text-foreground/85 outline-none',
+            'placeholder:text-muted-foreground/40',
+            'focus:border-foreground/30 focus:ring-2 focus:ring-ring/30',
+            'transition-colors',
+          )}
+          placeholder="# Project Context\n\nMission, architecture, key decisions, open questions — the durable project memory every agent reads first."
+        />
+      ) : contextError || !contextContent ? (
+        <button
+          onClick={startEditing}
+          className="group w-full rounded-2xl border border-dashed bg-card/40 p-10 text-center transition-colors hover:border-foreground/40 hover:bg-muted/30"
+        >
+          <AlertCircle className="mx-auto mb-3 size-5 text-muted-foreground/30 transition-colors group-hover:text-foreground/60" />
+          <p className="mb-1 text-sm font-medium text-foreground">No CONTEXT.md yet</p>
+          <p className="mx-auto max-w-sm text-xs leading-relaxed text-muted-foreground">
+            Click to create{' '}
+            <Badge variant="secondary" size="sm" className="rounded-md font-mono normal-case tracking-normal">
+              .kortix/CONTEXT.md
+            </Badge>{' '}
+            — the durable project memory every agent reads first.
+          </p>
+        </button>
+      ) : (
+        <div className="rounded-2xl border bg-card px-5 py-5 sm:px-6">
+          <article className="prose prose-sm max-w-none dark:prose-invert">
+            <UnifiedMarkdown content={contextContent} />
+          </article>
+        </div>
+      )}
+
+      <div className="mt-4 grid grid-cols-1 gap-px overflow-hidden rounded-2xl border bg-border sm:grid-cols-2">
+        <DetailRow
+          icon={<FolderGit2 className="size-3.5 text-muted-foreground/60" />}
+          label="Path"
+          value={
+            <button
+              onClick={copyPath}
+              className="inline-flex max-w-full min-w-0 items-center gap-1.5 truncate font-mono text-xs text-foreground/80 transition-colors hover:text-foreground"
+              title="Copy path"
+            >
+              <span className="truncate">{project?.path || '—'}</span>
+              {pathCopied ? (
+                <Check className="size-3 shrink-0 text-emerald-500" />
+              ) : (
+                <Copy className="size-3 shrink-0 text-muted-foreground/40" />
+              )}
+            </button>
+          }
+        />
+        <DetailRow
+          icon={<Calendar className="size-3.5 text-muted-foreground/60" />}
+          label="Created"
+          value={
+            <span
+              className="text-xs tabular-nums text-foreground/80"
+              title={fullDate(project?.created_at)}
+            >
+              {relativeTime(project?.created_at)}
+            </span>
+          }
+        />
+      </div>
+    </Section>
   );
 }
 
-// ── Section Label ────────────────────────────────────────────────────────
-
-function SectionLabel({ label }: { label: string }) {
-  return (
-    <div className="mb-2">
-      <span className="text-[10px] uppercase tracking-[0.08em] text-muted-foreground/55 font-semibold">
-        {label}
-      </span>
-    </div>
-  );
-}
-
-// ── Meta Row ─────────────────────────────────────────────────────────────
-
-function MetaRow({
+function DetailRow({
   icon,
   label,
   value,
@@ -281,12 +692,12 @@ function MetaRow({
   value: React.ReactNode;
 }) {
   return (
-    <div className="flex items-center gap-3 px-4 py-3 min-w-0">
+    <div className="flex min-w-0 items-center gap-3 bg-card px-4 py-3">
       <span className="shrink-0">{icon}</span>
-      <span className="text-[11px] uppercase tracking-[0.06em] text-muted-foreground/45 font-medium w-[72px] shrink-0">
+      <span className="w-16 shrink-0 text-xs font-medium uppercase tracking-wider text-muted-foreground">
         {label}
       </span>
-      <div className="flex-1 min-w-0 flex items-center justify-end text-right">
+      <div className="flex min-w-0 flex-1 items-center justify-end text-right">
         {value}
       </div>
     </div>

--- a/apps/web/src/components/kortix/project-about.tsx
+++ b/apps/web/src/components/kortix/project-about.tsx
@@ -27,8 +27,6 @@ import {
 } from '@/components/ui/tooltip';
 import {
   AlertCircle,
-  ArrowUpRight,
-  Boxes,
   Check,
   CircleDot,
   Loader2,
@@ -42,15 +40,11 @@ import {
 import {
   useTickets,
   useProjectAgents,
-  useProjectActivity,
   useUserHandle,
-  type TicketEvent,
   type ProjectAgent,
-  type Ticket,
 } from '@/hooks/kortix/use-kortix-tickets';
 import { useMilestones } from '@/hooks/kortix/use-milestones';
 import { useKortixProjectSessions } from '@/hooks/kortix/use-kortix-projects';
-import { fullDate } from '@/lib/kortix/task-meta';
 import type { ProjectTab } from '@/components/kortix/project-header';
 
 const TERMINAL_STATUSES = new Set(['done', 'closed', 'cancelled', 'archived']);
@@ -64,7 +58,6 @@ interface ProjectAboutProps {
 export function ProjectAbout({
   project,
   onNavigate,
-  onOpenTicket,
 }: ProjectAboutProps) {
   const projectId = project?.id;
 
@@ -72,9 +65,6 @@ export function ProjectAbout({
   const { data: milestones = [] } = useMilestones(projectId, 'all');
   const { data: agents = [] } = useProjectAgents(projectId);
   const { data: sessions = [] } = useKortixProjectSessions(projectId);
-  const { data: activity = [] } = useProjectActivity(projectId, {
-    pollingEnabled: false,
-  });
   const userHandle = useUserHandle();
 
   const openTickets = useMemo(
@@ -85,18 +75,6 @@ export function ProjectAbout({
     () => milestones.filter((m) => m.status === 'open').length,
     [milestones],
   );
-
-  const agentById = useMemo(() => {
-    const m = new Map<string, ProjectAgent>();
-    agents.forEach((a) => m.set(a.id, a));
-    return m;
-  }, [agents]);
-
-  const ticketTitleById = useMemo(() => {
-    const m = new Map<string, string>();
-    tickets.forEach((t) => m.set(t.id, t.title));
-    return m;
-  }, [tickets]);
 
   const rawDescription = project?.description?.trim();
   const isAutoDescription =
@@ -133,27 +111,6 @@ export function ProjectAbout({
             agents={agents}
             userHandle={userHandle}
             onNavigate={onNavigate}
-          />
-        </Section>
-
-        {openTickets.length > 0 && (
-          <Section delay>
-            <ActiveWork
-              tickets={openTickets.slice(0, 4)}
-              total={openTickets.length}
-              agentById={agentById}
-              onOpenTicket={onOpenTicket}
-              onSeeAll={() => onNavigate?.('board')}
-            />
-          </Section>
-        )}
-
-        <Section delay>
-          <Activity
-            events={activity.slice(0, 16)}
-            ticketTitleById={ticketTitleById}
-            agentById={agentById}
-            onOpenTicket={onOpenTicket}
           />
         </Section>
 
@@ -249,39 +206,41 @@ function StatusRow({
         </button>
       ))}
 
-      <span className="mx-1 hidden h-4 w-px bg-border sm:block" />
+      <div className="flex items-center gap-2">
+        <span className="hidden h-4 w-px bg-border sm:block" />
 
-      <div className="flex -space-x-1.5">
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <span className="rounded-full ring-2 ring-background">
-              <UserAvatar handle={userHandle} avatarUrl={null} size="sm" />
-            </span>
-          </TooltipTrigger>
-          <TooltipContent>@{userHandle}</TooltipContent>
-        </Tooltip>
-        {agents.map((agent) => (
-          <Tooltip key={agent.id}>
+        <div className="flex items-center -space-x-1.5">
+          <Tooltip>
             <TooltipTrigger asChild>
-              <span className="rounded-full ring-2 ring-background">
-                <AgentAvatar
-                  hue={agent.color_hue}
-                  icon={agent.icon}
-                  slug={agent.slug}
-                  name={agent.name}
-                  size="sm"
-                />
+              <span className="inline-flex rounded-full ring-2 ring-background">
+                <UserAvatar handle={userHandle} avatarUrl={null} size="sm" />
               </span>
             </TooltipTrigger>
-            <TooltipContent>
-              @{agent.slug} · {agent.name}
-            </TooltipContent>
+            <TooltipContent>@{userHandle}</TooltipContent>
           </Tooltip>
-        ))}
+          {agents.map((agent) => (
+            <Tooltip key={agent.id}>
+              <TooltipTrigger asChild>
+                <span className="inline-flex rounded-full ring-2 ring-background">
+                  <AgentAvatar
+                    hue={agent.color_hue}
+                    icon={agent.icon}
+                    slug={agent.slug}
+                    name={agent.name}
+                    size="sm"
+                  />
+                </span>
+              </TooltipTrigger>
+              <TooltipContent>
+                @{agent.slug} · {agent.name}
+              </TooltipContent>
+            </Tooltip>
+          ))}
+        </div>
+        <span className="text-xs tabular-nums text-muted-foreground">
+          {agentCount} {agentCount === 1 ? 'agent' : 'agents'}
+        </span>
       </div>
-      <span className="text-xs tabular-nums text-muted-foreground">
-        {agentCount} {agentCount === 1 ? 'agent' : 'agents'}
-      </span>
     </div>
   );
 }
@@ -289,392 +248,18 @@ function StatusRow({
 function SectionLabel({
   icon: Icon,
   label,
-  count,
-  onSeeAll,
-  liveDot,
 }: {
   icon: typeof CircleDot;
   label: string;
-  count?: number;
-  onSeeAll?: () => void;
-  liveDot?: boolean;
 }) {
   return (
-    <div className="group/header flex items-center justify-between">
-      <div className="flex items-center gap-2">
-        <Icon className="size-3.5 text-muted-foreground/60" />
-        <h2 className="text-xs font-medium uppercase tracking-[0.12em] text-muted-foreground">
-          {label}
-        </h2>
-        {typeof count === 'number' && count > 0 && (
-          <Badge variant="muted" size="sm" className="tabular-nums">
-            {count}
-          </Badge>
-        )}
-        {liveDot && <LivePulse />}
-      </div>
-      {onSeeAll && (
-        <button
-          type="button"
-          onClick={onSeeAll}
-          className="inline-flex items-center gap-0.5 text-xs text-muted-foreground opacity-0 transition-opacity hover:text-foreground group-hover/header:opacity-100"
-        >
-          View all
-          <ArrowUpRight className="size-3" />
-        </button>
-      )}
+    <div className="flex items-center gap-2">
+      <Icon className="size-3.5 text-muted-foreground/60" />
+      <h2 className="text-xs font-medium uppercase tracking-[0.12em] text-muted-foreground">
+        {label}
+      </h2>
     </div>
   );
-}
-
-function ActiveWork({
-  tickets,
-  total,
-  agentById,
-  onOpenTicket,
-  onSeeAll,
-}: {
-  tickets: Ticket[];
-  total: number;
-  agentById: Map<string, ProjectAgent>;
-  onOpenTicket?: (id: string) => void;
-  onSeeAll?: () => void;
-}) {
-  return (
-    <div>
-      <SectionLabel
-        icon={Boxes}
-        label="Active work"
-        count={total}
-        onSeeAll={total > tickets.length ? onSeeAll : undefined}
-      />
-      <div className="mt-3 overflow-hidden rounded-2xl bg-muted/30">
-        {tickets.map((ticket, i) => (
-          <TicketRow
-            key={ticket.id}
-            ticket={ticket}
-            agentById={agentById}
-            onOpen={onOpenTicket}
-            isLast={i === tickets.length - 1}
-          />
-        ))}
-      </div>
-    </div>
-  );
-}
-
-function TicketRow({
-  ticket,
-  agentById,
-  onOpen,
-  isLast,
-}: {
-  ticket: Ticket;
-  agentById: Map<string, ProjectAgent>;
-  onOpen?: (id: string) => void;
-  isLast: boolean;
-}) {
-  const status = ticket.column?.label ?? ticket.status ?? 'todo';
-  const dot = statusDotColor(ticket.status);
-  const assignee = ticket.assignees?.[0];
-  const agent =
-    assignee?.assignee_type === 'agent' && assignee.assignee_id
-      ? agentById.get(assignee.assignee_id)
-      : undefined;
-
-  return (
-    <button
-      type="button"
-      onClick={() => onOpen?.(ticket.id)}
-      className={cn(
-        'group flex w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-muted/60',
-        !isLast && 'border-b border-border/40',
-      )}
-    >
-      <span className={cn('size-1.5 shrink-0 rounded-full', dot)} />
-      <span className="shrink-0 font-mono text-xs tabular-nums text-muted-foreground/60">
-        #{ticket.number}
-      </span>
-      <span className="min-w-0 flex-1 truncate text-sm text-foreground">
-        {ticket.title}
-      </span>
-      <span className="hidden text-xs uppercase tracking-wider text-muted-foreground/70 sm:inline">
-        {status}
-      </span>
-      {assignee && agent ? (
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <span className="shrink-0">
-              <AgentAvatar
-                hue={agent.color_hue}
-                icon={agent.icon}
-                slug={agent.slug}
-                name={agent.name}
-                size="sm"
-              />
-            </span>
-          </TooltipTrigger>
-          <TooltipContent>@{agent.slug}</TooltipContent>
-        </Tooltip>
-      ) : assignee?.assignee_type === 'user' && assignee.assignee_id ? (
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <span className="shrink-0">
-              <UserAvatar handle={assignee.assignee_id} avatarUrl={null} size="sm" />
-            </span>
-          </TooltipTrigger>
-          <TooltipContent>@{assignee.assignee_id}</TooltipContent>
-        </Tooltip>
-      ) : (
-        <span className="shrink-0 text-xs text-muted-foreground/40">unassigned</span>
-      )}
-      <ArrowUpRight className="size-3.5 shrink-0 text-muted-foreground/30 transition-all group-hover:translate-x-0.5 group-hover:-translate-y-0.5 group-hover:text-foreground" />
-    </button>
-  );
-}
-
-function statusDotColor(status: string): string {
-  const s = status.toLowerCase();
-  if (s.includes('done') || s.includes('closed')) return 'bg-emerald-500';
-  if (s.includes('progress') || s.includes('doing') || s.includes('working')) return 'bg-blue-500';
-  if (s.includes('review')) return 'bg-violet-500';
-  if (s.includes('block')) return 'bg-rose-500';
-  return 'bg-muted-foreground/50';
-}
-
-function Activity({
-  events,
-  ticketTitleById,
-  agentById,
-  onOpenTicket,
-}: {
-  events: TicketEvent[];
-  ticketTitleById: Map<string, string>;
-  agentById: Map<string, ProjectAgent>;
-  onOpenTicket?: (id: string) => void;
-}) {
-  if (events.length === 0) {
-    return (
-      <div>
-        <SectionLabel icon={CircleDot} label="Activity" />
-        <div className="mt-3 rounded-2xl bg-muted/30 px-6 py-10 text-center">
-          <p className="text-sm font-medium text-foreground/85">Quiet so far</p>
-          <p className="mx-auto mt-1 max-w-md text-xs leading-relaxed text-muted-foreground/65">
-            Comments, status changes, and assignments will appear here.
-          </p>
-        </div>
-      </div>
-    );
-  }
-
-  const groups = groupByDay(events);
-  const recent = isRecent(events[0]?.created_at);
-
-  return (
-    <div>
-      <SectionLabel
-        icon={CircleDot}
-        label="Activity"
-        count={events.length}
-        liveDot={recent}
-      />
-      <div className="mt-3 space-y-5">
-        {groups.map(({ label, events: items }, gi) => (
-          <div key={label}>
-            <div className="mb-2 flex items-center gap-2 px-1">
-              <span className="text-[10px] font-semibold uppercase tracking-[0.1em] text-muted-foreground/55">
-                {label}
-              </span>
-              {gi === 0 && recent && <LivePulse />}
-              <span className="ml-auto text-[10px] tabular-nums text-muted-foreground/40">
-                {items.length}
-              </span>
-            </div>
-            <div className="overflow-hidden rounded-2xl bg-muted/30">
-              {items.map((ev, i) => (
-                <ActivityRow
-                  key={ev.id}
-                  event={ev}
-                  ticketTitle={ticketTitleById.get(ev.ticket_id)}
-                  agent={
-                    ev.actor_type === 'agent' && ev.actor_id
-                      ? agentById.get(ev.actor_id)
-                      : undefined
-                  }
-                  onOpen={onOpenTicket}
-                  isLast={i === items.length - 1}
-                />
-              ))}
-            </div>
-          </div>
-        ))}
-      </div>
-    </div>
-  );
-}
-
-function LivePulse() {
-  return (
-    <span className="relative inline-flex items-center justify-center">
-      <span className="absolute size-2 animate-ping rounded-full bg-emerald-500/40" />
-      <span className="relative size-1 rounded-full bg-emerald-500" />
-    </span>
-  );
-}
-
-function isRecent(iso?: string): boolean {
-  if (!iso) return false;
-  const t = Date.parse(iso);
-  if (Number.isNaN(t)) return false;
-  return Date.now() - t < 5 * 60_000;
-}
-
-function ActivityRow({
-  event,
-  ticketTitle,
-  agent,
-  onOpen,
-  isLast,
-}: {
-  event: TicketEvent;
-  ticketTitle?: string;
-  agent?: ProjectAgent;
-  onOpen?: (id: string) => void;
-  isLast: boolean;
-}) {
-  const handle =
-    event.actor_type === 'user'
-      ? `@${event.actor_id ?? 'unknown'}`
-      : event.actor_type === 'agent'
-        ? `@${agent?.slug ?? event.actor_id ?? 'agent'}`
-        : 'System';
-  const verb = describeEventType(event.type);
-  const verbClass = verbColor(event.type);
-  const ref = ticketTitle ?? `ticket ${event.ticket_id.slice(0, 6)}`;
-
-  return (
-    <button
-      type="button"
-      onClick={() => onOpen?.(event.ticket_id)}
-      className={cn(
-        'group flex w-full items-center gap-3 px-4 py-2.5 text-left transition-colors hover:bg-muted/60',
-        !isLast && 'border-b border-border/40',
-      )}
-    >
-      <span className="shrink-0">
-        {event.actor_type === 'agent' && agent ? (
-          <AgentAvatar
-            hue={agent.color_hue}
-            icon={agent.icon}
-            slug={agent.slug}
-            name={agent.name}
-            size="sm"
-          />
-        ) : (
-          <UserAvatar
-            handle={event.actor_id ?? 'system'}
-            avatarUrl={null}
-            size="sm"
-          />
-        )}
-      </span>
-
-      <p className="min-w-0 flex-1 truncate text-sm leading-snug text-foreground/85">
-        <span className="font-medium text-foreground">{handle}</span>
-        <span className={verbClass}> {verb} </span>
-        <span className="text-foreground">{ref}</span>
-      </p>
-
-      <span
-        className="hidden shrink-0 text-xs tabular-nums text-muted-foreground/55 sm:inline"
-        title={fullDate(event.created_at)}
-      >
-        {timeOnly(event.created_at)}
-      </span>
-
-      <ArrowUpRight className="size-3.5 shrink-0 text-muted-foreground/30 transition-all group-hover:-translate-y-0.5 group-hover:translate-x-0.5 group-hover:text-foreground" />
-    </button>
-  );
-}
-
-function verbColor(type: string): string {
-  switch (type) {
-    case 'closed':
-      return 'text-emerald-600 dark:text-emerald-400';
-    case 'created':
-    case 'reopened':
-      return 'text-blue-600 dark:text-blue-400';
-    case 'status_change':
-      return 'text-violet-600 dark:text-violet-400';
-    default:
-      return 'text-muted-foreground';
-  }
-}
-
-function describeEventType(type: string): string {
-  switch (type) {
-    case 'comment':
-      return 'commented on';
-    case 'assigned':
-      return 'was assigned to';
-    case 'unassigned':
-      return 'was unassigned from';
-    case 'status_change':
-      return 'moved';
-    case 'created':
-      return 'opened';
-    case 'closed':
-      return 'closed';
-    case 'reopened':
-      return 'reopened';
-    default:
-      return type.replace(/_/g, ' ');
-  }
-}
-
-function timeOnly(iso: string): string {
-  const d = new Date(iso);
-  if (Number.isNaN(d.getTime())) return '';
-  return d.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
-}
-
-function groupByDay(events: TicketEvent[]): Array<{ label: string; events: TicketEvent[] }> {
-  const today = startOfDay(new Date());
-  const yesterday = new Date(today);
-  yesterday.setDate(today.getDate() - 1);
-  const lastWeek = new Date(today);
-  lastWeek.setDate(today.getDate() - 7);
-
-  const buckets: Record<string, TicketEvent[]> = {};
-  const order: string[] = [];
-
-  const push = (label: string, ev: TicketEvent) => {
-    if (!buckets[label]) {
-      buckets[label] = [];
-      order.push(label);
-    }
-    buckets[label].push(ev);
-  };
-
-  for (const ev of events) {
-    const t = new Date(ev.created_at);
-    if (Number.isNaN(t.getTime())) continue;
-    const tDay = startOfDay(t).getTime();
-    if (tDay === today.getTime()) push('Today', ev);
-    else if (tDay === yesterday.getTime()) push('Yesterday', ev);
-    else if (t >= lastWeek)
-      push(t.toLocaleDateString([], { weekday: 'long' }), ev);
-    else
-      push(t.toLocaleDateString([], { month: 'short', day: 'numeric' }), ev);
-  }
-
-  return order.map((label) => ({ label, events: buckets[label] }));
-}
-
-function startOfDay(d: Date): Date {
-  const x = new Date(d);
-  x.setHours(0, 0, 0, 0);
-  return x;
 }
 
 function ContextSection({ project }: { project: any }) {

--- a/apps/web/src/components/kortix/project-activity-tab.tsx
+++ b/apps/web/src/components/kortix/project-activity-tab.tsx
@@ -1,0 +1,508 @@
+'use client';
+
+import { useMemo } from 'react';
+import { motion } from 'framer-motion';
+import {
+  ArrowUpRight,
+  Boxes,
+  CircleDot,
+} from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { Badge } from '@/components/ui/badge';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+import {
+  AgentAvatar,
+  UserAvatar,
+} from '@/components/kortix/agent-avatar';
+import {
+  useTickets,
+  useProjectAgents,
+  useProjectActivity,
+  type TicketEvent,
+  type ProjectAgent,
+  type Ticket,
+} from '@/hooks/kortix/use-kortix-tickets';
+import { fullDate } from '@/lib/kortix/task-meta';
+
+const TERMINAL_STATUSES = new Set(['done', 'closed', 'cancelled', 'archived']);
+
+interface ProjectActivityTabProps {
+  projectId: string;
+  onOpenTicket?: (id: string) => void;
+}
+
+export function ProjectActivityTab({
+  projectId,
+  onOpenTicket,
+}: ProjectActivityTabProps) {
+  const { data: tickets = [] } = useTickets(projectId, { pollingEnabled: false });
+  const { data: agents = [] } = useProjectAgents(projectId);
+  const { data: activity = [] } = useProjectActivity(projectId, {
+    pollingEnabled: false,
+  });
+
+  const openTickets = useMemo(
+    () => tickets.filter((t) => !TERMINAL_STATUSES.has(t.status)),
+    [tickets],
+  );
+
+  const agentById = useMemo(() => {
+    const m = new Map<string, ProjectAgent>();
+    agents.forEach((a) => m.set(a.id, a));
+    return m;
+  }, [agents]);
+
+  const ticketTitleById = useMemo(() => {
+    const m = new Map<string, string>();
+    tickets.forEach((t) => m.set(t.id, t.title));
+    return m;
+  }, [tickets]);
+
+  return (
+    <div className="h-full overflow-y-auto">
+      <motion.div
+        initial="hidden"
+        animate="show"
+        variants={{
+          hidden: {},
+          show: { transition: { staggerChildren: 0.04, delayChildren: 0.04 } },
+        }}
+        className="mx-auto w-full max-w-3xl px-6 pt-12 pb-24"
+      >
+        <Section>
+          <header>
+            <h1 className="text-xl font-semibold tracking-tight text-foreground">
+              Activity
+            </h1>
+            <p className="mt-1.5 text-sm leading-relaxed text-muted-foreground">
+              What's in flight and what's happened — every ticket and event in one place.
+            </p>
+          </header>
+        </Section>
+
+        <Section delay>
+          <ActiveWork
+            tickets={openTickets}
+            agentById={agentById}
+            onOpenTicket={onOpenTicket}
+          />
+        </Section>
+
+        <Section delay>
+          <Activity
+            events={activity}
+            ticketTitleById={ticketTitleById}
+            agentById={agentById}
+            onOpenTicket={onOpenTicket}
+          />
+        </Section>
+      </motion.div>
+    </div>
+  );
+}
+
+function Section({
+  children,
+  delay,
+}: {
+  children: React.ReactNode;
+  delay?: boolean;
+}) {
+  return (
+    <motion.section
+      variants={{
+        hidden: { opacity: 0, y: 6 },
+        show: { opacity: 1, y: 0, transition: { duration: 0.3, ease: 'easeOut' } },
+      }}
+      className={cn(delay && 'mt-10')}
+    >
+      {children}
+    </motion.section>
+  );
+}
+
+function SectionLabel({
+  icon: Icon,
+  label,
+  count,
+  liveDot,
+}: {
+  icon: typeof CircleDot;
+  label: string;
+  count?: number;
+  liveDot?: boolean;
+}) {
+  return (
+    <div className="flex items-center gap-2">
+      <Icon className="size-3.5 text-muted-foreground/60" />
+      <h2 className="text-xs font-medium uppercase tracking-[0.12em] text-muted-foreground">
+        {label}
+      </h2>
+      {typeof count === 'number' && count > 0 && (
+        <Badge variant="muted" size="sm" className="tabular-nums">
+          {count}
+        </Badge>
+      )}
+      {liveDot && <LivePulse />}
+    </div>
+  );
+}
+
+function ActiveWork({
+  tickets,
+  agentById,
+  onOpenTicket,
+}: {
+  tickets: Ticket[];
+  agentById: Map<string, ProjectAgent>;
+  onOpenTicket?: (id: string) => void;
+}) {
+  if (tickets.length === 0) {
+    return (
+      <div>
+        <SectionLabel icon={Boxes} label="Active work" />
+        <div className="mt-3 rounded-2xl bg-muted/30 px-6 py-10 text-center">
+          <p className="text-sm font-medium text-foreground/85">Nothing in flight</p>
+          <p className="mx-auto mt-1 max-w-md text-xs leading-relaxed text-muted-foreground/65">
+            Open tickets will show up here.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <SectionLabel icon={Boxes} label="Active work" count={tickets.length} />
+      <div className="mt-3 overflow-hidden rounded-2xl bg-muted/30">
+        {tickets.map((ticket, i) => (
+          <TicketRow
+            key={ticket.id}
+            ticket={ticket}
+            agentById={agentById}
+            onOpen={onOpenTicket}
+            isLast={i === tickets.length - 1}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function TicketRow({
+  ticket,
+  agentById,
+  onOpen,
+  isLast,
+}: {
+  ticket: Ticket;
+  agentById: Map<string, ProjectAgent>;
+  onOpen?: (id: string) => void;
+  isLast: boolean;
+}) {
+  const status = ticket.column?.label ?? ticket.status ?? 'todo';
+  const dot = statusDotColor(ticket.status);
+  const assignee = ticket.assignees?.[0];
+  const agent =
+    assignee?.assignee_type === 'agent' && assignee.assignee_id
+      ? agentById.get(assignee.assignee_id)
+      : undefined;
+
+  return (
+    <button
+      type="button"
+      onClick={() => onOpen?.(ticket.id)}
+      className={cn(
+        'group flex w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-muted/60',
+        !isLast && 'border-b border-border/40',
+      )}
+    >
+      <span className={cn('size-1.5 shrink-0 rounded-full', dot)} />
+      <span className="shrink-0 text-xs tabular-nums text-muted-foreground/60">
+        #{ticket.number}
+      </span>
+      <span className="min-w-0 flex-1 truncate text-sm text-foreground">
+        {ticket.title}
+      </span>
+      <span className="hidden text-xs uppercase tracking-wider text-muted-foreground/70 sm:inline">
+        {status}
+      </span>
+      {assignee && agent ? (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className="shrink-0">
+              <AgentAvatar
+                hue={agent.color_hue}
+                icon={agent.icon}
+                slug={agent.slug}
+                name={agent.name}
+                size="sm"
+              />
+            </span>
+          </TooltipTrigger>
+          <TooltipContent>@{agent.slug}</TooltipContent>
+        </Tooltip>
+      ) : assignee?.assignee_type === 'user' && assignee.assignee_id ? (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className="shrink-0">
+              <UserAvatar handle={assignee.assignee_id} avatarUrl={null} size="sm" />
+            </span>
+          </TooltipTrigger>
+          <TooltipContent>@{assignee.assignee_id}</TooltipContent>
+        </Tooltip>
+      ) : (
+        <span className="shrink-0 text-xs text-muted-foreground/40">unassigned</span>
+      )}
+      <ArrowUpRight className="size-3.5 shrink-0 text-muted-foreground/30 transition-all group-hover:translate-x-0.5 group-hover:-translate-y-0.5 group-hover:text-foreground" />
+    </button>
+  );
+}
+
+function statusDotColor(status: string): string {
+  const s = status.toLowerCase();
+  if (s.includes('done') || s.includes('closed')) return 'bg-emerald-500';
+  if (s.includes('progress') || s.includes('doing') || s.includes('working')) return 'bg-blue-500';
+  if (s.includes('review')) return 'bg-violet-500';
+  if (s.includes('block')) return 'bg-rose-500';
+  return 'bg-muted-foreground/50';
+}
+
+function Activity({
+  events,
+  ticketTitleById,
+  agentById,
+  onOpenTicket,
+}: {
+  events: TicketEvent[];
+  ticketTitleById: Map<string, string>;
+  agentById: Map<string, ProjectAgent>;
+  onOpenTicket?: (id: string) => void;
+}) {
+  if (events.length === 0) {
+    return (
+      <div>
+        <SectionLabel icon={CircleDot} label="History" />
+        <div className="mt-3 rounded-2xl bg-muted/30 px-6 py-10 text-center">
+          <p className="text-sm font-medium text-foreground/85">Quiet so far</p>
+          <p className="mx-auto mt-1 max-w-md text-xs leading-relaxed text-muted-foreground/65">
+            Comments, status changes, and assignments will appear here.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  const groups = groupByDay(events);
+  const recent = isRecent(events[0]?.created_at);
+
+  return (
+    <div>
+      <SectionLabel
+        icon={CircleDot}
+        label="History"
+        count={events.length}
+        liveDot={recent}
+      />
+      <div className="mt-3 space-y-5">
+        {groups.map(({ label, events: items }, gi) => (
+          <div key={label}>
+            <div className="mb-2 flex items-center gap-2 px-1">
+              <span className="text-[10px] font-semibold uppercase tracking-[0.1em] text-muted-foreground/55">
+                {label}
+              </span>
+              {gi === 0 && recent && <LivePulse />}
+              <span className="ml-auto text-[10px] tabular-nums text-muted-foreground/40">
+                {items.length}
+              </span>
+            </div>
+            <div className="overflow-hidden rounded-2xl bg-muted/30">
+              {items.map((ev, i) => (
+                <ActivityRow
+                  key={ev.id}
+                  event={ev}
+                  ticketTitle={ticketTitleById.get(ev.ticket_id)}
+                  agent={
+                    ev.actor_type === 'agent' && ev.actor_id
+                      ? agentById.get(ev.actor_id)
+                      : undefined
+                  }
+                  onOpen={onOpenTicket}
+                  isLast={i === items.length - 1}
+                />
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function LivePulse() {
+  return (
+    <span className="relative inline-flex items-center justify-center">
+      <span className="absolute size-2 animate-ping rounded-full bg-emerald-500/40" />
+      <span className="relative size-1 rounded-full bg-emerald-500" />
+    </span>
+  );
+}
+
+function isRecent(iso?: string): boolean {
+  if (!iso) return false;
+  const t = Date.parse(iso);
+  if (Number.isNaN(t)) return false;
+  return Date.now() - t < 5 * 60_000;
+}
+
+function ActivityRow({
+  event,
+  ticketTitle,
+  agent,
+  onOpen,
+  isLast,
+}: {
+  event: TicketEvent;
+  ticketTitle?: string;
+  agent?: ProjectAgent;
+  onOpen?: (id: string) => void;
+  isLast: boolean;
+}) {
+  const handle =
+    event.actor_type === 'user'
+      ? `@${event.actor_id ?? 'unknown'}`
+      : event.actor_type === 'agent'
+        ? `@${agent?.slug ?? event.actor_id ?? 'agent'}`
+        : 'System';
+  const verb = describeEventType(event.type);
+  const verbClass = verbColor(event.type);
+  const ref = ticketTitle ?? `ticket ${event.ticket_id.slice(0, 6)}`;
+
+  return (
+    <button
+      type="button"
+      onClick={() => onOpen?.(event.ticket_id)}
+      className={cn(
+        'group flex w-full items-center gap-3 px-4 py-2.5 text-left transition-colors hover:bg-muted/60',
+        !isLast && 'border-b border-border/40',
+      )}
+    >
+      <span className="shrink-0">
+        {event.actor_type === 'agent' && agent ? (
+          <AgentAvatar
+            hue={agent.color_hue}
+            icon={agent.icon}
+            slug={agent.slug}
+            name={agent.name}
+            size="sm"
+          />
+        ) : (
+          <UserAvatar
+            handle={event.actor_id ?? 'system'}
+            avatarUrl={null}
+            size="sm"
+          />
+        )}
+      </span>
+
+      <p className="min-w-0 flex-1 truncate text-sm leading-snug text-foreground/85">
+        <span className="font-medium text-foreground">{handle}</span>
+        <span className={verbClass}> {verb} </span>
+        <span className="text-foreground">{ref}</span>
+      </p>
+
+      <span
+        className="hidden shrink-0 text-xs tabular-nums text-muted-foreground/55 sm:inline"
+        title={fullDate(event.created_at)}
+      >
+        {timeOnly(event.created_at)}
+      </span>
+
+      <ArrowUpRight className="size-3.5 shrink-0 text-muted-foreground/30 transition-all group-hover:-translate-y-0.5 group-hover:translate-x-0.5 group-hover:text-foreground" />
+    </button>
+  );
+}
+
+function verbColor(type: string): string {
+  switch (type) {
+    case 'closed':
+      return 'text-emerald-600 dark:text-emerald-400';
+    case 'created':
+    case 'reopened':
+      return 'text-blue-600 dark:text-blue-400';
+    case 'status_change':
+      return 'text-violet-600 dark:text-violet-400';
+    default:
+      return 'text-muted-foreground';
+  }
+}
+
+function describeEventType(type: string): string {
+  switch (type) {
+    case 'comment':
+      return 'commented on';
+    case 'assigned':
+      return 'was assigned to';
+    case 'unassigned':
+      return 'was unassigned from';
+    case 'status_change':
+      return 'moved';
+    case 'created':
+      return 'opened';
+    case 'closed':
+      return 'closed';
+    case 'reopened':
+      return 'reopened';
+    default:
+      return type.replace(/_/g, ' ');
+  }
+}
+
+function timeOnly(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '';
+  return d.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+}
+
+function groupByDay(events: TicketEvent[]): Array<{ label: string; events: TicketEvent[] }> {
+  const today = startOfDay(new Date());
+  const yesterday = new Date(today);
+  yesterday.setDate(today.getDate() - 1);
+  const lastWeek = new Date(today);
+  lastWeek.setDate(today.getDate() - 7);
+
+  const buckets: Record<string, TicketEvent[]> = {};
+  const order: string[] = [];
+
+  const push = (label: string, ev: TicketEvent) => {
+    if (!buckets[label]) {
+      buckets[label] = [];
+      order.push(label);
+    }
+    buckets[label].push(ev);
+  };
+
+  for (const ev of events) {
+    const t = new Date(ev.created_at);
+    if (Number.isNaN(t.getTime())) continue;
+    const tDay = startOfDay(t).getTime();
+    if (tDay === today.getTime()) push('Today', ev);
+    else if (tDay === yesterday.getTime()) push('Yesterday', ev);
+    else if (t >= lastWeek)
+      push(t.toLocaleDateString([], { weekday: 'long' }), ev);
+    else
+      push(t.toLocaleDateString([], { month: 'short', day: 'numeric' }), ev);
+  }
+
+  return order.map((label) => ({ label, events: buckets[label] }));
+}
+
+function startOfDay(d: Date): Date {
+  const x = new Date(d);
+  x.setHours(0, 0, 0, 0);
+  return x;
+}

--- a/apps/web/src/components/kortix/project-files-tab.tsx
+++ b/apps/web/src/components/kortix/project-files-tab.tsx
@@ -18,6 +18,9 @@ import {
   RefreshCw,
   FileText,
   Search,
+  GitBranch,
+  Languages,
+  Users as UsersIcon,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import {
@@ -34,6 +37,11 @@ import {
   ContextMenuItem,
   ContextMenuSeparator,
 } from '@/components/ui/context-menu';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useFilesStore } from '@/features/files/store/files-store';
@@ -44,6 +52,7 @@ import {
   useGitStatus,
   buildGitStatusMap,
 } from '@/features/files/hooks';
+import { useProjectFileIndex } from '@/features/files/hooks/use-workspace-file-index';
 import {
   useFileUpload,
   useFileDelete,
@@ -59,13 +68,24 @@ import { getFileIcon } from '@/features/files/components/file-icon';
 import type { FileNode } from '@/features/files/types';
 import { cn } from '@/lib/utils';
 import { toast } from '@/lib/toast';
+import {
+  useProjectAgents,
+  type ProjectAgent,
+} from '@/hooks/kortix/use-kortix-tickets';
+import { AgentAvatar } from '@/components/kortix/agent-avatar';
+import {
+  bucketLanguages,
+  type LanguageBucket,
+} from '@/lib/kortix/file-language';
 
 const ELEVATED_DIRS = new Set(['.kortix', '.opencode']);
 
 export function ProjectFilesTab({
+  projectId,
   projectName,
   projectPath,
 }: {
+  projectId: string;
   projectName: string;
   projectPath: string;
 }) {
@@ -86,6 +106,16 @@ export function ProjectFilesTab({
 
   const { data: gitStatuses } = useGitStatus({ enabled: health?.healthy === true });
   const gitStatusMap = useMemo(() => buildGitStatusMap(gitStatuses), [gitStatuses]);
+  const dirtyCount = useMemo(
+    () => (gitStatuses ?? []).length,
+    [gitStatuses],
+  );
+
+  const { data: projectIndex, isLoading: isIndexLoading } = useProjectFileIndex(projectPath, {
+    enabled: health?.healthy === true,
+  });
+
+  const { data: agents = [] } = useProjectAgents(projectId);
 
   const uploadMutation = useFileUpload();
   const deleteMutation = useFileDelete();
@@ -149,6 +179,13 @@ export function ProjectFilesTab({
       fileItems: files.filter((f) => f.type === 'file').sort(cmpName),
     };
   }, [files]);
+
+  const languages = useMemo(
+    () => bucketLanguages((projectIndex ?? []).map((p) => p.split('/').pop() ?? p)),
+    [projectIndex],
+  );
+
+  const totalProjectFiles = projectIndex?.length ?? 0;
 
   const filtered = useMemo(() => {
     const q = search.trim().toLowerCase();
@@ -290,11 +327,9 @@ export function ProjectFilesTab({
           hidden: {},
           show: { transition: { staggerChildren: 0.04, delayChildren: 0.04 } },
         }}
-        className="mx-auto w-full max-w-3xl px-6 pt-8 pb-24"
+        className="mx-auto w-full max-w-3xl px-6 pt-10 pb-24"
       >
-        <motion.div
-          variants={{ hidden: { opacity: 0, y: 6 }, show: { opacity: 1, y: 0, transition: { duration: 0.3, ease: 'easeOut' } } }}
-        >
+        <Section>
           <Breadcrumb
             projectName={projectName}
             isAtRoot={isAtRoot}
@@ -302,8 +337,21 @@ export function ProjectFilesTab({
             onJumpToRoot={() => navigateToPath(projectPath)}
             onNavigate={navigateToPath}
           />
+        </Section>
 
-          <div className="mt-4 flex flex-wrap items-center gap-2">
+        <Section delay>
+          <RepoStatsCard
+            agents={agents}
+            languages={languages}
+            dirtyCount={dirtyCount}
+            totalFiles={totalProjectFiles}
+            totalDirs={dirs.length}
+            languagesLoading={isIndexLoading && !projectIndex}
+          />
+        </Section>
+
+        <Section delay>
+          <div className="flex flex-wrap items-center gap-2">
             <div className="relative flex-1 min-w-[220px]">
               <Search className="pointer-events-none absolute left-3 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground/45" />
               <input
@@ -331,12 +379,9 @@ export function ProjectFilesTab({
               New file
             </Button>
           </div>
-        </motion.div>
+        </Section>
 
-        <motion.div
-          variants={{ hidden: { opacity: 0, y: 6 }, show: { opacity: 1, y: 0, transition: { duration: 0.3, ease: 'easeOut' } } }}
-          className="mt-6"
-        >
+        <Section delay>
           <div className="overflow-hidden rounded-2xl bg-muted/30">
             {isLoading && showSkeleton ? (
               <div className="divide-y divide-border/40">
@@ -442,7 +487,7 @@ export function ProjectFilesTab({
               )}
             </p>
           )}
-        </motion.div>
+        </Section>
       </motion.div>
 
       <input
@@ -468,6 +513,201 @@ export function ProjectFilesTab({
         onConfirm={handleConfirmDelete}
         isPending={deleteMutation.isPending}
       />
+    </div>
+  );
+}
+
+function Section({
+  children,
+  delay,
+}: {
+  children: React.ReactNode;
+  delay?: boolean;
+}) {
+  return (
+    <motion.section
+      variants={{
+        hidden: { opacity: 0, y: 6 },
+        show: { opacity: 1, y: 0, transition: { duration: 0.3, ease: 'easeOut' } },
+      }}
+      className={cn(delay && 'mt-6')}
+    >
+      {children}
+    </motion.section>
+  );
+}
+
+function RepoStatsCard({
+  agents,
+  languages,
+  dirtyCount,
+  totalFiles,
+  totalDirs,
+  languagesLoading,
+}: {
+  agents: ProjectAgent[];
+  languages: LanguageBucket[];
+  dirtyCount: number;
+  totalFiles: number;
+  totalDirs: number;
+  languagesLoading: boolean;
+}) {
+  return (
+    <div className="overflow-hidden rounded-2xl bg-muted/30">
+      <div className="grid gap-px bg-border/40 sm:grid-cols-2">
+        <ContributorsPanel agents={agents} />
+        <LanguagesPanel languages={languages} loading={languagesLoading} />
+      </div>
+
+      <div className="flex flex-wrap items-center gap-x-4 gap-y-1.5 border-t border-border/40 px-4 py-2.5 text-xs text-muted-foreground/75">
+        <span className="inline-flex items-center gap-1.5">
+          <span className="size-1.5 rounded-full bg-muted-foreground/40" />
+          <span className="tabular-nums text-foreground/85">{totalDirs}</span>
+          <span>{totalDirs === 1 ? 'folder here' : 'folders here'}</span>
+        </span>
+        <span className="inline-flex items-center gap-1.5">
+          <span className="size-1.5 rounded-full bg-muted-foreground/40" />
+          <span className="tabular-nums text-foreground/85">
+            {languagesLoading ? '—' : totalFiles}
+          </span>
+          <span>{totalFiles === 1 ? 'file in project' : 'files in project'}</span>
+        </span>
+        <span className="ml-auto inline-flex items-center gap-1.5">
+          <GitBranch className="size-3" />
+          <span className="text-foreground/85">main</span>
+          {dirtyCount > 0 && (
+            <span className="inline-flex items-center gap-1 rounded-full bg-amber-500/12 px-1.5 py-0.5 text-[10px] font-medium text-amber-600 dark:text-amber-400">
+              {dirtyCount} {dirtyCount === 1 ? 'change' : 'changes'}
+            </span>
+          )}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function ContributorsPanel({ agents }: { agents: ProjectAgent[] }) {
+  return (
+    <div className="bg-muted/30 px-4 py-3.5">
+      <div className="flex items-center gap-2">
+        <UsersIcon className="size-3.5 text-muted-foreground/55" />
+        <h3 className="text-[10px] font-semibold uppercase tracking-[0.12em] text-muted-foreground/75">
+          Contributors
+        </h3>
+        <span className="ml-auto text-[10px] tabular-nums text-muted-foreground/55">
+          {agents.length}
+        </span>
+      </div>
+
+      {agents.length === 0 ? (
+        <p className="mt-3 text-xs text-muted-foreground/55">No agents yet</p>
+      ) : (
+        <div className="mt-3 flex flex-wrap items-center gap-1.5">
+          {agents.slice(0, 12).map((agent) => (
+            <Tooltip key={agent.id}>
+              <TooltipTrigger asChild>
+                <span className="inline-flex">
+                  <AgentAvatar
+                    hue={agent.color_hue}
+                    icon={agent.icon}
+                    slug={agent.slug}
+                    name={agent.name}
+                    size="md"
+                  />
+                </span>
+              </TooltipTrigger>
+              <TooltipContent>
+                @{agent.slug} · {agent.name}
+              </TooltipContent>
+            </Tooltip>
+          ))}
+          {agents.length > 12 && (
+            <span className="inline-flex h-6 min-w-6 items-center justify-center rounded-full bg-muted/60 px-1.5 text-[10px] tabular-nums text-muted-foreground/70">
+              +{agents.length - 12}
+            </span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function LanguagesPanel({
+  languages,
+  loading,
+}: {
+  languages: LanguageBucket[];
+  loading: boolean;
+}) {
+  const top = languages.slice(0, 6);
+  const otherPct = languages.slice(6).reduce((n, l) => n + l.pct, 0);
+
+  return (
+    <div className="bg-muted/30 px-4 py-3.5">
+      <div className="flex items-center gap-2">
+        <Languages className="size-3.5 text-muted-foreground/55" />
+        <h3 className="text-[10px] font-semibold uppercase tracking-[0.12em] text-muted-foreground/75">
+          Languages
+        </h3>
+        <span className="ml-auto text-[10px] tabular-nums text-muted-foreground/55">
+          {loading ? '…' : languages.length}
+        </span>
+      </div>
+
+      {loading && top.length === 0 ? (
+        <div className="mt-3 space-y-2">
+          <Skeleton className="h-2 w-full rounded-full" />
+          <div className="flex flex-wrap gap-x-3 gap-y-1">
+            <Skeleton className="h-3 w-16" />
+            <Skeleton className="h-3 w-14" />
+            <Skeleton className="h-3 w-20" />
+          </div>
+        </div>
+      ) : top.length === 0 ? (
+        <p className="mt-3 text-xs text-muted-foreground/55">No files in this project</p>
+      ) : (
+        <>
+          <div className="mt-3 flex h-2 w-full overflow-hidden rounded-full bg-muted-foreground/10">
+            {top.map((l) => (
+              <span
+                key={l.name}
+                className="h-full"
+                style={{ width: `${l.pct}%`, backgroundColor: l.color }}
+                title={`${l.name} ${l.pct.toFixed(1)}%`}
+              />
+            ))}
+            {otherPct > 0 && (
+              <span
+                className="h-full bg-muted-foreground/30"
+                style={{ width: `${otherPct}%` }}
+                title={`Other ${otherPct.toFixed(1)}%`}
+              />
+            )}
+          </div>
+
+          <div className="mt-2.5 flex flex-wrap gap-x-3 gap-y-1 text-[11px]">
+            {top.map((l) => (
+              <span key={l.name} className="inline-flex items-center gap-1.5 text-muted-foreground/85">
+                <span
+                  className="size-2 rounded-full"
+                  style={{ backgroundColor: l.color }}
+                />
+                <span className="text-foreground/90">{l.name}</span>
+                <span className="tabular-nums text-muted-foreground/55">
+                  {l.pct.toFixed(l.pct >= 10 ? 0 : 1)}%
+                </span>
+              </span>
+            ))}
+            {otherPct > 0 && (
+              <span className="inline-flex items-center gap-1.5 text-muted-foreground/55">
+                <span className="size-2 rounded-full bg-muted-foreground/30" />
+                <span>Other</span>
+                <span className="tabular-nums">{otherPct.toFixed(0)}%</span>
+              </span>
+            )}
+          </div>
+        </>
+      )}
     </div>
   );
 }
@@ -717,7 +957,7 @@ function GitBadge({ status }: { status: string }) {
   const entry = cfg[status] ?? { label: status, cls: 'bg-muted/60 text-muted-foreground/80' };
   return (
     <span className={cn(
-      'ml-1 inline-flex h-4 min-w-4 items-center justify-center rounded px-1 text-[10px] font-mono font-medium',
+      'ml-1 inline-flex h-4 min-w-4 items-center justify-center rounded px-1 text-[10px] font-medium tabular-nums',
       entry.cls,
     )}>
       {entry.label}

--- a/apps/web/src/components/kortix/project-files-tab.tsx
+++ b/apps/web/src/components/kortix/project-files-tab.tsx
@@ -1,0 +1,770 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { motion } from 'framer-motion';
+import {
+  Upload,
+  FolderPlus,
+  FilePlus,
+  ChevronRight,
+  Home,
+  MoreHorizontal,
+  Trash2,
+  Pencil,
+  Download,
+  ExternalLink,
+  Loader2,
+  ServerOff,
+  RefreshCw,
+  FileText,
+  Search,
+} from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+} from '@/components/ui/dropdown-menu';
+import {
+  ContextMenu,
+  ContextMenuTrigger,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+} from '@/components/ui/context-menu';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
+import { Skeleton } from '@/components/ui/skeleton';
+import { useFilesStore } from '@/features/files/store/files-store';
+import {
+  useFileList,
+  useServerHealth,
+  useFileEventInvalidation,
+  useGitStatus,
+  buildGitStatusMap,
+} from '@/features/files/hooks';
+import {
+  useFileUpload,
+  useFileDelete,
+  useFileMkdir,
+  useFileRename,
+  useFileCreate,
+} from '@/features/files/hooks/use-file-mutations';
+import { downloadFile } from '@/features/files/api/opencode-files';
+import { useDirectoryDownload } from '@/features/files/hooks/use-directory-download';
+import { useServerStore } from '@/stores/server-store';
+import { openTabAndNavigate } from '@/stores/tab-store';
+import { getFileIcon } from '@/features/files/components/file-icon';
+import type { FileNode } from '@/features/files/types';
+import { cn } from '@/lib/utils';
+import { toast } from '@/lib/toast';
+
+const ELEVATED_DIRS = new Set(['.kortix', '.opencode']);
+
+export function ProjectFilesTab({
+  projectName,
+  projectPath,
+}: {
+  projectName: string;
+  projectPath: string;
+}) {
+  const currentPath = useFilesStore((s) => s.currentPath);
+  const navigateToPath = useFilesStore((s) => s.navigateToPath);
+
+  const serverUrl = useServerStore((s) => s.getActiveServerUrl());
+  const { data: health, isLoading: isHealthLoading, refetch: refetchHealth } = useServerHealth();
+
+  useFileEventInvalidation();
+
+  const {
+    data: files,
+    isLoading,
+    error,
+    refetch: refetchFiles,
+  } = useFileList(currentPath, { enabled: health?.healthy === true });
+
+  const { data: gitStatuses } = useGitStatus({ enabled: health?.healthy === true });
+  const gitStatusMap = useMemo(() => buildGitStatusMap(gitStatuses), [gitStatuses]);
+
+  const uploadMutation = useFileUpload();
+  const deleteMutation = useFileDelete();
+  const mkdirMutation = useFileMkdir();
+  const renameMutation = useFileRename();
+  const createMutation = useFileCreate();
+  const { downloadDir, isDownloading: isDirDownloading } = useDirectoryDownload();
+
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const newNameRef = useRef<HTMLInputElement>(null);
+
+  const [creating, setCreating] = useState<{ kind: 'file' | 'folder'; name: string } | null>(null);
+  const [renaming, setRenaming] = useState<{ node: FileNode; name: string } | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<FileNode | null>(null);
+  const [search, setSearch] = useState('');
+  const [showSkeleton, setShowSkeleton] = useState(false);
+
+  useEffect(() => {
+    if (!isLoading) { setShowSkeleton(false); return; }
+    const t = setTimeout(() => setShowSkeleton(true), 200);
+    return () => clearTimeout(t);
+  }, [isLoading]);
+
+  useEffect(() => {
+    if (creating || renaming) {
+      requestAnimationFrame(() => {
+        const el = newNameRef.current;
+        if (!el) return;
+        el.focus();
+        const dot = el.value.lastIndexOf('.');
+        el.setSelectionRange(0, dot > 0 ? dot : el.value.length);
+      });
+    }
+  }, [creating, renaming]);
+
+  const isAtRoot = currentPath === projectPath || currentPath === '/' || !currentPath;
+  const normalizedCurrentPath = currentPath.replace(/\/$/, '');
+
+  const segments = useMemo(() => {
+    if (!projectPath || isAtRoot) return [] as Array<{ name: string; path: string }>;
+    const rel = currentPath.startsWith(projectPath)
+      ? currentPath.slice(projectPath.length).replace(/^\//, '')
+      : currentPath;
+    if (!rel) return [];
+    const parts = rel.split('/').filter(Boolean);
+    let acc = projectPath;
+    return parts.map((name) => {
+      acc = `${acc}/${name}`;
+      return { name, path: acc };
+    });
+  }, [currentPath, projectPath, isAtRoot]);
+
+  const { dirs, fileItems } = useMemo(() => {
+    if (!files) return { dirs: [] as FileNode[], fileItems: [] as FileNode[] };
+    const cmpName = (a: FileNode, b: FileNode) => a.name.localeCompare(b.name);
+    const allDirs = files.filter((f) => f.type === 'directory');
+    const elevated = allDirs.filter((f) => ELEVATED_DIRS.has(f.name)).sort(cmpName);
+    const rest = allDirs.filter((f) => !ELEVATED_DIRS.has(f.name)).sort(cmpName);
+    return {
+      dirs: [...elevated, ...rest],
+      fileItems: files.filter((f) => f.type === 'file').sort(cmpName),
+    };
+  }, [files]);
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    if (!q) return { dirs, fileItems };
+    return {
+      dirs: dirs.filter((f) => f.name.toLowerCase().includes(q)),
+      fileItems: fileItems.filter((f) => f.name.toLowerCase().includes(q)),
+    };
+  }, [dirs, fileItems, search]);
+
+  const totalCount = filtered.dirs.length + filtered.fileItems.length;
+
+  const handleNavigateUp = useCallback(() => {
+    if (isAtRoot) return;
+    const parent = currentPath.slice(0, currentPath.lastIndexOf('/')) || projectPath;
+    navigateToPath(parent);
+  }, [currentPath, projectPath, navigateToPath, isAtRoot]);
+
+  const handleOpenFile = useCallback((node: FileNode) => {
+    openTabAndNavigate({
+      id: `file:${node.path}`,
+      title: node.name,
+      type: 'file',
+      href: `/files/${encodeURIComponent(node.path)}`,
+    });
+  }, []);
+
+  const handleUploadClick = useCallback(() => fileInputRef.current?.click(), []);
+
+  const handleUploadFiles = useCallback(async (fileList: FileList | File[]) => {
+    const arr = Array.from(fileList);
+    if (arr.length === 0) return;
+    let ok = 0;
+    for (const f of arr) {
+      try {
+        await uploadMutation.mutateAsync({ file: f, targetPath: isAtRoot ? undefined : currentPath });
+        ok++;
+      } catch (err) {
+        toast.error(`Failed to upload ${f.name}: ${err instanceof Error ? err.message : 'Unknown error'}`);
+      }
+    }
+    if (ok > 0) toast.success(ok === 1 ? `Uploaded ${arr[0].name}` : `Uploaded ${ok} files`);
+  }, [uploadMutation, isAtRoot, currentPath]);
+
+  const handleFileInputChange = useCallback(async (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (!e.target.files) return;
+    await handleUploadFiles(e.target.files);
+    e.target.value = '';
+  }, [handleUploadFiles]);
+
+  const handleStartCreate = (kind: 'file' | 'folder') =>
+    setCreating({ kind, name: kind === 'folder' ? 'New folder' : 'untitled.txt' });
+
+  const handleConfirmCreate = useCallback(async () => {
+    if (!creating) return;
+    const trimmed = creating.name.trim();
+    if (!trimmed) { setCreating(null); return; }
+    const fullPath = normalizedCurrentPath ? `${normalizedCurrentPath}/${trimmed}` : trimmed;
+    try {
+      if (creating.kind === 'folder') {
+        await mkdirMutation.mutateAsync({ dirPath: fullPath });
+        toast.success(`Created folder: ${trimmed}`);
+      } else {
+        await createMutation.mutateAsync({ filePath: fullPath });
+        toast.success(`Created file: ${trimmed}`);
+      }
+    } catch (err) {
+      toast.error(`Failed: ${err instanceof Error ? err.message : 'Unknown error'}`);
+    } finally {
+      setCreating(null);
+    }
+  }, [creating, normalizedCurrentPath, mkdirMutation, createMutation]);
+
+  const handleConfirmRename = useCallback(async () => {
+    if (!renaming) return;
+    const trimmed = renaming.name.trim();
+    if (!trimmed || trimmed === renaming.node.name) { setRenaming(null); return; }
+    const parent = renaming.node.path.substring(0, renaming.node.path.lastIndexOf('/'));
+    const dest = parent ? `${parent}/${trimmed}` : trimmed;
+    try {
+      await renameMutation.mutateAsync({ from: renaming.node.path, to: dest });
+      toast.success(`Renamed to ${trimmed}`);
+    } catch (err) {
+      toast.error(`Failed to rename: ${err instanceof Error ? err.message : 'Unknown error'}`);
+    } finally {
+      setRenaming(null);
+    }
+  }, [renaming, renameMutation]);
+
+  const handleConfirmDelete = useCallback(async () => {
+    if (!deleteTarget) return;
+    try {
+      await deleteMutation.mutateAsync({ filePath: deleteTarget.path });
+      toast.success(`Deleted ${deleteTarget.name}`);
+    } catch (err) {
+      toast.error(`Failed to delete: ${err instanceof Error ? err.message : 'Unknown error'}`);
+    } finally {
+      setDeleteTarget(null);
+    }
+  }, [deleteTarget, deleteMutation]);
+
+  const handleDownload = useCallback(async (node: FileNode) => {
+    try {
+      if (node.type === 'directory') {
+        downloadDir(node.path, node.name);
+      } else {
+        await downloadFile(node.path, node.name);
+        toast.success(`Downloaded ${node.name}`);
+      }
+    } catch {
+      toast.error(`Failed to download ${node.name}`);
+    }
+  }, [downloadDir]);
+
+  if (!isHealthLoading && !health?.healthy) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-4 p-8 text-center">
+        <ServerOff className="size-10 text-muted-foreground/30" />
+        <div>
+          <h3 className="text-base font-medium text-foreground">Server not reachable</h3>
+          <p className="mt-1.5 text-sm text-muted-foreground">
+            Could not connect to <span className="rounded bg-muted px-1.5 py-0.5 text-xs">{serverUrl}</span>
+          </p>
+        </div>
+        <Button variant="outline" size="sm" onClick={() => refetchHealth()}>
+          <RefreshCw />
+          Retry
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full overflow-y-auto">
+      <motion.div
+        initial="hidden"
+        animate="show"
+        variants={{
+          hidden: {},
+          show: { transition: { staggerChildren: 0.04, delayChildren: 0.04 } },
+        }}
+        className="mx-auto w-full max-w-3xl px-6 pt-8 pb-24"
+      >
+        <motion.div
+          variants={{ hidden: { opacity: 0, y: 6 }, show: { opacity: 1, y: 0, transition: { duration: 0.3, ease: 'easeOut' } } }}
+        >
+          <Breadcrumb
+            projectName={projectName}
+            isAtRoot={isAtRoot}
+            segments={segments}
+            onJumpToRoot={() => navigateToPath(projectPath)}
+            onNavigate={navigateToPath}
+          />
+
+          <div className="mt-4 flex flex-wrap items-center gap-2">
+            <div className="relative flex-1 min-w-[220px]">
+              <Search className="pointer-events-none absolute left-3 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground/45" />
+              <input
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                placeholder="Filter in this folder…"
+                className="h-9 w-full rounded-full bg-muted/40 pl-9 pr-3 text-sm outline-none placeholder:text-muted-foreground/45 transition-colors focus:bg-muted/60 focus:ring-2 focus:ring-ring/20"
+              />
+            </div>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleUploadClick}
+              disabled={uploadMutation.isPending}
+            >
+              {uploadMutation.isPending ? <Loader2 className="animate-spin" /> : <Upload />}
+              Upload
+            </Button>
+            <Button variant="outline" size="sm" onClick={() => handleStartCreate('folder')}>
+              <FolderPlus />
+              New folder
+            </Button>
+            <Button size="sm" onClick={() => handleStartCreate('file')}>
+              <FilePlus />
+              New file
+            </Button>
+          </div>
+        </motion.div>
+
+        <motion.div
+          variants={{ hidden: { opacity: 0, y: 6 }, show: { opacity: 1, y: 0, transition: { duration: 0.3, ease: 'easeOut' } } }}
+          className="mt-6"
+        >
+          <div className="overflow-hidden rounded-2xl bg-muted/30">
+            {isLoading && showSkeleton ? (
+              <div className="divide-y divide-border/40">
+                {Array.from({ length: 8 }).map((_, i) => (
+                  <div key={i} className="flex items-center gap-3 px-4 py-3">
+                    <Skeleton className="size-4 rounded" />
+                    <Skeleton className="h-4 w-40" />
+                    <Skeleton className="ml-auto h-3 w-20" />
+                  </div>
+                ))}
+              </div>
+            ) : error ? (
+              <div className="flex flex-col items-center justify-center gap-2 px-6 py-16 text-center">
+                <p className="text-sm text-foreground">Failed to load files</p>
+                <p className="text-xs text-muted-foreground">
+                  {error instanceof Error ? error.message : 'Unknown error'}
+                </p>
+                <Button variant="outline" size="sm" onClick={() => refetchFiles()} className="mt-2">
+                  Retry
+                </Button>
+              </div>
+            ) : totalCount === 0 && !creating ? (
+              <EmptyState
+                hasSearch={search.trim().length > 0}
+                onClearSearch={() => setSearch('')}
+                onCreateFile={() => handleStartCreate('file')}
+                onUpload={handleUploadClick}
+              />
+            ) : (
+              <ul>
+                {!isAtRoot && (
+                  <UpRow onClick={handleNavigateUp} />
+                )}
+                {creating && (
+                  <CreateRow
+                    kind={creating.kind}
+                    name={creating.name}
+                    onChange={(name) => setCreating({ ...creating, name })}
+                    onCommit={handleConfirmCreate}
+                    onCancel={() => setCreating(null)}
+                    inputRef={newNameRef}
+                  />
+                )}
+                {filtered.dirs.map((d) => {
+                  const isElevated = ELEVATED_DIRS.has(d.name);
+                  return (
+                    <FileRow
+                      key={d.path}
+                      node={d}
+                      gitStatus={gitStatusMap.get(d.path)}
+                      onOpen={() => navigateToPath(d.path)}
+                      onRename={(name) => setRenaming({ node: d, name })}
+                      onDelete={() => setDeleteTarget(d)}
+                      onDownload={() => handleDownload(d)}
+                      isDownloading={isDirDownloading(d.path)}
+                      isElevated={isElevated}
+                      isRenaming={renaming?.node.path === d.path}
+                      renameValue={renaming?.node.path === d.path ? renaming.name : undefined}
+                      onRenameChange={(name) => renaming && setRenaming({ ...renaming, name })}
+                      onRenameCommit={handleConfirmRename}
+                      onRenameCancel={() => setRenaming(null)}
+                      renameInputRef={newNameRef}
+                    />
+                  );
+                })}
+                {filtered.fileItems.map((f) => (
+                  <FileRow
+                    key={f.path}
+                    node={f}
+                    gitStatus={gitStatusMap.get(f.path)}
+                    onOpen={() => handleOpenFile(f)}
+                    onRename={(name) => setRenaming({ node: f, name })}
+                    onDelete={() => setDeleteTarget(f)}
+                    onDownload={() => handleDownload(f)}
+                    isRenaming={renaming?.node.path === f.path}
+                    renameValue={renaming?.node.path === f.path ? renaming.name : undefined}
+                    onRenameChange={(name) => renaming && setRenaming({ ...renaming, name })}
+                    onRenameCommit={handleConfirmRename}
+                    onRenameCancel={() => setRenaming(null)}
+                    renameInputRef={newNameRef}
+                  />
+                ))}
+              </ul>
+            )}
+          </div>
+
+          {!isLoading && !error && totalCount > 0 && (
+            <p className="mt-3 px-1 text-xs tabular-nums text-muted-foreground/55">
+              {filtered.dirs.length} {filtered.dirs.length === 1 ? 'folder' : 'folders'}
+              {' · '}
+              {filtered.fileItems.length} {filtered.fileItems.length === 1 ? 'file' : 'files'}
+              {search && (
+                <>
+                  {' · '}
+                  <button
+                    type="button"
+                    onClick={() => setSearch('')}
+                    className="text-muted-foreground/70 hover:text-foreground"
+                  >
+                    clear filter
+                  </button>
+                </>
+              )}
+            </p>
+          )}
+        </motion.div>
+      </motion.div>
+
+      <input
+        ref={fileInputRef}
+        type="file"
+        multiple
+        className="hidden"
+        onChange={handleFileInputChange}
+      />
+
+      <ConfirmDialog
+        open={!!deleteTarget}
+        onOpenChange={(o) => { if (!o) setDeleteTarget(null); }}
+        title={`Delete ${deleteTarget?.type === 'directory' ? 'folder' : 'file'}`}
+        description={
+          <span>
+            Delete{' '}
+            <span className="font-semibold text-foreground">&quot;{deleteTarget?.name}&quot;</span>?
+            This action cannot be undone.
+          </span>
+        }
+        confirmLabel={deleteMutation.isPending ? 'Deleting…' : 'Delete'}
+        onConfirm={handleConfirmDelete}
+        isPending={deleteMutation.isPending}
+      />
+    </div>
+  );
+}
+
+function Breadcrumb({
+  projectName,
+  isAtRoot,
+  segments,
+  onJumpToRoot,
+  onNavigate,
+}: {
+  projectName: string;
+  isAtRoot: boolean;
+  segments: Array<{ name: string; path: string }>;
+  onJumpToRoot: () => void;
+  onNavigate: (path: string) => void;
+}) {
+  return (
+    <div className="flex items-center gap-1.5 text-sm text-muted-foreground">
+      <button
+        type="button"
+        onClick={onJumpToRoot}
+        className={cn(
+          'inline-flex items-center gap-1.5 rounded-md px-1.5 py-0.5 transition-colors hover:bg-muted hover:text-foreground',
+          isAtRoot && 'text-foreground',
+        )}
+      >
+        <Home className="size-3.5" />
+        <span className="font-medium">{projectName}</span>
+      </button>
+      {segments.map((s, i) => {
+        const isLast = i === segments.length - 1;
+        return (
+          <span key={s.path} className="inline-flex items-center gap-1.5">
+            <ChevronRight className="size-3 text-muted-foreground/40" />
+            <button
+              type="button"
+              onClick={() => onNavigate(s.path)}
+              className={cn(
+                'rounded-md px-1.5 py-0.5 transition-colors hover:bg-muted hover:text-foreground',
+                isLast && 'text-foreground font-medium',
+              )}
+            >
+              {s.name}
+            </button>
+          </span>
+        );
+      })}
+    </div>
+  );
+}
+
+function UpRow({ onClick }: { onClick: () => void }) {
+  return (
+    <li
+      className="group flex w-full cursor-pointer items-center gap-3 border-b border-border/40 px-4 py-2.5 transition-colors hover:bg-muted/60"
+      onClick={onClick}
+    >
+      <ChevronRight className="size-4 -rotate-90 text-muted-foreground/60" />
+      <span className="text-sm font-medium text-muted-foreground">Up one folder</span>
+    </li>
+  );
+}
+
+function CreateRow({
+  kind,
+  name,
+  onChange,
+  onCommit,
+  onCancel,
+  inputRef,
+}: {
+  kind: 'file' | 'folder';
+  name: string;
+  onChange: (s: string) => void;
+  onCommit: () => void;
+  onCancel: () => void;
+  inputRef: React.RefObject<HTMLInputElement>;
+}) {
+  const Icon = kind === 'folder' ? FolderPlus : FileText;
+  return (
+    <li className="flex w-full items-center gap-3 border-b border-border/40 bg-muted/40 px-4 py-2.5">
+      <Icon className="size-4 text-muted-foreground" />
+      <input
+        ref={inputRef}
+        value={name}
+        onChange={(e) => onChange(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') onCommit();
+          if (e.key === 'Escape') onCancel();
+        }}
+        onBlur={onCommit}
+        className="h-7 flex-1 rounded-md border border-border/60 bg-background px-2 text-sm outline-none focus:ring-2 focus:ring-ring/30"
+        placeholder={kind === 'folder' ? 'Folder name' : 'File name'}
+      />
+    </li>
+  );
+}
+
+function FileRow({
+  node,
+  gitStatus,
+  onOpen,
+  onRename,
+  onDelete,
+  onDownload,
+  isDownloading,
+  isElevated,
+  isRenaming,
+  renameValue,
+  onRenameChange,
+  onRenameCommit,
+  onRenameCancel,
+  renameInputRef,
+}: {
+  node: FileNode;
+  gitStatus?: string;
+  onOpen: () => void;
+  onRename: (name: string) => void;
+  onDelete: () => void;
+  onDownload: () => void;
+  isDownloading?: boolean;
+  isElevated?: boolean;
+  isRenaming: boolean;
+  renameValue?: string;
+  onRenameChange: (s: string) => void;
+  onRenameCommit: () => void;
+  onRenameCancel: () => void;
+  renameInputRef: React.RefObject<HTMLInputElement>;
+}) {
+  const isDir = node.type === 'directory';
+  const icon = getFileIcon(node.name, {
+    isDirectory: isDir,
+    className: 'size-4 shrink-0',
+  });
+
+  const openLabel = isDir ? 'Open folder' : 'Open file';
+
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger asChild>
+        <li className="group flex w-full items-center gap-3 border-b border-border/40 px-4 py-2.5 transition-colors last:border-b-0 hover:bg-muted/60 data-[state=open]:bg-muted/60">
+          <button
+            type="button"
+            onClick={isRenaming ? undefined : onOpen}
+            className="flex min-w-0 flex-1 items-center gap-3 text-left"
+          >
+            {icon}
+            {isRenaming ? (
+              <input
+                ref={renameInputRef}
+                value={renameValue ?? ''}
+                onChange={(e) => onRenameChange(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') onRenameCommit();
+                  if (e.key === 'Escape') onRenameCancel();
+                }}
+                onBlur={onRenameCommit}
+                onClick={(e) => e.stopPropagation()}
+                className="h-7 flex-1 rounded-md border border-border/60 bg-background px-2 text-sm outline-none focus:ring-2 focus:ring-ring/30"
+              />
+            ) : (
+              <span className={cn(
+                'truncate text-sm',
+                isDir ? 'font-medium text-foreground' : 'text-foreground/90',
+                isElevated && 'text-muted-foreground',
+              )}>
+                {node.name}
+              </span>
+            )}
+
+            {gitStatus && <GitBadge status={gitStatus} />}
+          </button>
+
+          {isDownloading && <Loader2 className="size-3.5 animate-spin text-muted-foreground/60" />}
+
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button
+                type="button"
+                onClick={(e) => e.stopPropagation()}
+                className="inline-flex size-7 items-center justify-center rounded-md text-muted-foreground/55 opacity-0 transition-opacity hover:bg-muted hover:text-foreground focus:opacity-100 group-hover:opacity-100"
+                aria-label="More actions"
+              >
+                <MoreHorizontal className="size-3.5" />
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-44 z-[10000]">
+              <DropdownMenuItem onClick={onOpen}>
+                <ExternalLink className="size-3.5 text-muted-foreground/60" />
+                {openLabel}
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => onRename(node.name)}>
+                <Pencil className="size-3.5 text-muted-foreground/60" />
+                Rename
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={onDownload}>
+                <Download className="size-3.5 text-muted-foreground/60" />
+                Download
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                onClick={onDelete}
+                className="text-destructive focus:text-destructive"
+              >
+                <Trash2 className="size-3.5" />
+                Delete
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </li>
+      </ContextMenuTrigger>
+      <ContextMenuContent className="w-44 z-[10000]">
+        <ContextMenuItem onClick={onOpen}>
+          <ExternalLink className="size-3.5 text-muted-foreground/60" />
+          {openLabel}
+        </ContextMenuItem>
+        <ContextMenuItem onClick={() => onRename(node.name)}>
+          <Pencil className="size-3.5 text-muted-foreground/60" />
+          Rename
+        </ContextMenuItem>
+        <ContextMenuItem onClick={onDownload}>
+          <Download className="size-3.5 text-muted-foreground/60" />
+          Download
+        </ContextMenuItem>
+        <ContextMenuSeparator />
+        <ContextMenuItem
+          onClick={onDelete}
+          className="text-destructive focus:text-destructive"
+        >
+          <Trash2 className="size-3.5" />
+          Delete
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
+  );
+}
+
+function GitBadge({ status }: { status: string }) {
+  const cfg: Record<string, { label: string; cls: string }> = {
+    M: { label: 'M', cls: 'bg-amber-500/15 text-amber-500/90' },
+    A: { label: 'A', cls: 'bg-emerald-500/15 text-emerald-500/90' },
+    D: { label: 'D', cls: 'bg-red-500/15 text-red-500/90' },
+    '??': { label: 'U', cls: 'bg-blue-500/15 text-blue-500/90' },
+    R: { label: 'R', cls: 'bg-violet-500/15 text-violet-500/90' },
+  };
+  const entry = cfg[status] ?? { label: status, cls: 'bg-muted/60 text-muted-foreground/80' };
+  return (
+    <span className={cn(
+      'ml-1 inline-flex h-4 min-w-4 items-center justify-center rounded px-1 text-[10px] font-mono font-medium',
+      entry.cls,
+    )}>
+      {entry.label}
+    </span>
+  );
+}
+
+function EmptyState({
+  hasSearch,
+  onClearSearch,
+  onCreateFile,
+  onUpload,
+}: {
+  hasSearch: boolean;
+  onClearSearch: () => void;
+  onCreateFile: () => void;
+  onUpload: () => void;
+}) {
+  if (hasSearch) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-2 px-6 py-16 text-center">
+        <Search className="size-5 text-muted-foreground/40" />
+        <p className="text-sm font-medium text-foreground">No matches</p>
+        <p className="text-xs text-muted-foreground">Try a different filter.</p>
+        <Button variant="ghost" size="sm" onClick={onClearSearch} className="mt-1">
+          Clear filter
+        </Button>
+      </div>
+    );
+  }
+  return (
+    <div className="flex flex-col items-center justify-center gap-2 px-6 py-16 text-center">
+      <div className="inline-flex size-10 items-center justify-center rounded-full bg-muted/60">
+        <FilePlus className="size-4 text-muted-foreground/70" />
+      </div>
+      <p className="mt-1 text-sm font-medium text-foreground">This folder is empty</p>
+      <p className="text-xs text-muted-foreground">Create a file or upload one to get started.</p>
+      <div className="mt-3 flex items-center gap-2">
+        <Button variant="outline" size="sm" onClick={onUpload}>
+          <Upload />
+          Upload
+        </Button>
+        <Button size="sm" onClick={onCreateFile}>
+          <FilePlus />
+          New file
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/kortix/project-header.tsx
+++ b/apps/web/src/components/kortix/project-header.tsx
@@ -12,6 +12,7 @@ import {
   Settings as SettingsIcon,
   ListChecks,
   Users as UsersIcon,
+  Activity as ActivityIcon,
   Check,
   Copy,
   type LucideIcon,
@@ -28,6 +29,7 @@ export type ProjectTab =
   | 'tasks'
   | 'board'
   | 'milestones'
+  | 'activity'
   | 'team'
   | 'credentials'
   | 'triggers'
@@ -64,6 +66,7 @@ const V2_TABS: TabDef[] = [
   { id: 'about', label: 'Overview', icon: Sparkles },
   { id: 'board', label: 'Board', icon: Boxes },
   { id: 'milestones', label: 'Milestones', icon: Flag },
+  { id: 'activity', label: 'Activity', icon: ActivityIcon },
   { id: 'files', label: 'Files', icon: FolderOpen },
   { id: 'sessions', label: 'Sessions', icon: MessageSquareText },
   { id: 'settings', label: 'Settings', icon: SettingsIcon },
@@ -94,9 +97,8 @@ export function ProjectHeader({
   return (
     <header className="shrink-0 bg-background">
       <div className="mx-auto w-full max-w-7xl px-4 pt-6 pb-3 sm:px-6">
-        <div className="flex items-start gap-4">
+        <div className="flex items-center gap-4">
           <ProjectIcon project={project} size="md" />
-
           <div className="min-w-0 flex-1">
             <div className="flex items-center gap-2">
               <h1
@@ -117,7 +119,7 @@ export function ProjectHeader({
               )}
             </div>
 
-            <div className="mt-1.5 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground/85">
+            {/* <div className="mt-1.5 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground/85">
               <PathButton path={cleanPath} fullPath={project.path} />
               {project?.created_at && (
                 <>
@@ -125,7 +127,7 @@ export function ProjectHeader({
                   <span>Created {relativeShort(project.created_at)}</span>
                 </>
               )}
-            </div>
+            </div> */}
           </div>
 
           <div className="flex shrink-0 items-center gap-1.5">

--- a/apps/web/src/components/kortix/project-header.tsx
+++ b/apps/web/src/components/kortix/project-header.tsx
@@ -1,16 +1,12 @@
 'use client';
 
-/**
- * Project header — single compact row, underline tabs.
- *
- * v1 projects see the legacy layout: About · Tasks · Files · Sessions.
- * v2 projects see: About · Board · Team · Settings · Files · Sessions.
- */
-
 import * as TabsPrimitive from '@radix-ui/react-tabs';
 import { Plus } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { Kbd } from '@/components/ui/kbd';
+import { ProjectIcon } from '@/components/kortix/project-icon';
 
 export type ProjectTab =
   | 'about'
@@ -77,28 +73,33 @@ export function ProjectHeader({
   const label = newActionLabel ?? (isV2 ? 'New ticket' : 'New task');
   const hotkey = newActionHotkey ?? 'C';
   return (
-    <header className="shrink-0 border-b border-border/60 bg-background">
-      <div className="container mx-auto max-w-7xl h-11 px-3 sm:px-4">
+    <header className="shrink-0 border-b bg-background">
+      <div className="container mx-auto flex h-12 max-w-7xl items-center gap-4 px-3 sm:px-4">
         <TabsPrimitive.Root
           value={tab}
           onValueChange={(v) => onTabChange(v as ProjectTab)}
-          className="h-full flex items-center gap-4"
+          className="flex h-full flex-1 items-center gap-4"
         >
-          <div className="flex-1 min-w-0 flex items-center gap-2">
+          <div className="flex min-w-0 flex-1 items-center gap-2.5">
+            <ProjectIcon project={project} size="xs" />
             <h1
-              className="text-[14px] font-semibold tracking-tight text-foreground truncate"
+              className="truncate text-sm font-semibold tracking-tight text-foreground"
               title={project.name}
             >
               {project.name}
             </h1>
             {isV2 && (
-              <span className="text-[10px] uppercase tracking-wider text-muted-foreground/50 font-mono">
+              <Badge
+                variant="muted"
+                size="sm"
+                className="font-mono uppercase tracking-wider"
+              >
                 v2
-              </span>
+              </Badge>
             )}
           </div>
 
-          <TabsPrimitive.List className="flex items-center h-full gap-5 shrink-0">
+          <TabsPrimitive.List className="flex h-full shrink-0 items-center gap-5">
             {tabs.map((t) => {
               const badge = tabBadges?.[t.id] ?? 0;
               return (
@@ -106,41 +107,38 @@ export function ProjectHeader({
                   key={t.id}
                   value={t.id}
                   className={cn(
-                    'relative h-full inline-flex items-center gap-1.5 text-[13px] font-medium tracking-tight cursor-pointer transition-colors outline-none',
-                    'text-muted-foreground/60 hover:text-foreground',
+                    'relative inline-flex h-full cursor-pointer items-center gap-1.5 text-sm font-medium tracking-tight outline-none transition-colors',
+                    'text-muted-foreground/70 hover:text-foreground',
                     'data-[state=active]:text-foreground',
-                    'after:absolute after:inset-x-0 after:bottom-0 after:h-[2px] after:bg-foreground after:rounded-full',
-                    'after:opacity-0 data-[state=active]:after:opacity-100 after:transition-opacity',
+                    'after:absolute after:inset-x-0 after:-bottom-px after:h-0.5 after:rounded-full after:bg-foreground',
+                    'after:opacity-0 after:transition-opacity data-[state=active]:after:opacity-100',
                   )}
                 >
                   {t.label}
                   {badge > 0 && (
-                    <span
-                      className="inline-flex items-center justify-center min-w-[16px] h-[16px] px-1 rounded-full bg-destructive text-destructive-foreground text-[10px] font-semibold leading-none tabular-nums"
+                    <Badge
+                      variant="destructive"
+                      size="sm"
+                      className="rounded-full tabular-nums"
                       aria-label={`${badge} unread`}
                     >
                       {badge > 99 ? '99+' : badge}
-                    </span>
+                    </Badge>
                   )}
                 </TabsPrimitive.Trigger>
               );
             })}
           </TabsPrimitive.List>
 
-          <div className="flex-1 flex items-center justify-end gap-1.5">
+          <div className="flex flex-1 items-center justify-end gap-1.5">
             {rightSlot}
             {onNewTask && (
-              <Button
-                size="sm"
-                onClick={onNewTask}
-                title={`${label} (${hotkey})`}
-                className="h-7 px-2.5 text-[12px] gap-1.5"
-              >
-                <Plus className="h-3.5 w-3.5" />
+              <Button size="sm" onClick={onNewTask} title={`${label} (${hotkey})`}>
+                <Plus />
                 <span className="hidden sm:inline">{label}</span>
-                <kbd className="hidden sm:inline-flex items-center justify-center min-w-[18px] h-4 px-1 rounded border border-primary-foreground/20 bg-primary-foreground/10 text-[10px] font-mono font-medium leading-none text-primary-foreground/90">
+                <Kbd className="hidden border border-primary-foreground/20 bg-primary-foreground/10 text-primary-foreground/90 sm:inline-flex">
                   {hotkey}
-                </kbd>
+                </Kbd>
               </Button>
             )}
           </div>

--- a/apps/web/src/components/kortix/project-header.tsx
+++ b/apps/web/src/components/kortix/project-header.tsx
@@ -1,60 +1,72 @@
 'use client';
 
+import { useCallback, useState } from 'react';
 import * as TabsPrimitive from '@radix-ui/react-tabs';
-import { Plus } from 'lucide-react';
+import {
+  Plus,
+  Sparkles,
+  Boxes,
+  Flag,
+  FolderOpen,
+  MessageSquareText,
+  Settings as SettingsIcon,
+  ListChecks,
+  Users as UsersIcon,
+  Check,
+  Copy,
+  type LucideIcon,
+} from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Kbd } from '@/components/ui/kbd';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { ProjectIcon } from '@/components/kortix/project-icon';
 
 export type ProjectTab =
   | 'about'
-  | 'tasks'       // v1
-  | 'board'       // v2
-  | 'milestones'  // v2
-  | 'team'        // v2 (legacy — folded into Settings)
-  | 'credentials' // v2 (legacy — folded into Settings)
-  | 'triggers'    // v2 (legacy — folded into Settings)
-  | 'channels'    // v2 (legacy — folded into Settings)
-  | 'settings'    // v2
+  | 'tasks'
+  | 'board'
+  | 'milestones'
+  | 'team'
+  | 'credentials'
+  | 'triggers'
+  | 'channels'
+  | 'settings'
   | 'files'
   | 'sessions'
-  | 'members';    // from main — v1 team-based-access
+  | 'members';
 
 export interface ProjectHeaderProps {
   project: any;
   tab: ProjectTab;
   onTabChange: (tab: ProjectTab) => void;
   onNewTask?: () => void;
-  /** 2 for tickets/board, 1 (or undefined) for legacy. */
   structureVersion?: number;
   newActionLabel?: string;
   newActionHotkey?: string;
-  /** Per-tab unread badge counts (currently only used for 'board'). */
   tabBadges?: Partial<Record<ProjectTab, number>>;
-  /** Right-side slot — rendered between tabs and the New-task button. */
   rightSlot?: React.ReactNode;
+  isLive?: boolean;
 }
 
-const V1_TABS: Array<{ id: ProjectTab; label: string }> = [
-  { id: 'about', label: 'About' },
-  { id: 'tasks', label: 'Tasks' },
-  { id: 'files', label: 'Files' },
-  { id: 'sessions', label: 'Sessions' },
-  { id: 'members', label: 'Members' },
+type TabDef = { id: ProjectTab; label: string; icon: LucideIcon };
+
+const V1_TABS: TabDef[] = [
+  { id: 'about', label: 'About', icon: Sparkles },
+  { id: 'tasks', label: 'Tasks', icon: ListChecks },
+  { id: 'files', label: 'Files', icon: FolderOpen },
+  { id: 'sessions', label: 'Sessions', icon: MessageSquareText },
+  { id: 'members', label: 'Members', icon: UsersIcon },
 ];
 
-// Top-level tabs intentionally stay lean — 6 work surfaces users actually
-// scan every visit. Rarely-touched configuration (team, credentials,
-// triggers, board columns/fields/templates) lives inside Settings.
-const V2_TABS: Array<{ id: ProjectTab; label: string }> = [
-  { id: 'about', label: 'About' },
-  { id: 'board', label: 'Board' },
-  { id: 'milestones', label: 'Milestones' },
-  { id: 'files', label: 'Files' },
-  { id: 'sessions', label: 'Sessions' },
-  { id: 'settings', label: 'Settings' },
+const V2_TABS: TabDef[] = [
+  { id: 'about', label: 'Overview', icon: Sparkles },
+  { id: 'board', label: 'Board', icon: Boxes },
+  { id: 'milestones', label: 'Milestones', icon: Flag },
+  { id: 'files', label: 'Files', icon: FolderOpen },
+  { id: 'sessions', label: 'Sessions', icon: MessageSquareText },
+  { id: 'settings', label: 'Settings', icon: SettingsIcon },
 ];
 
 export function ProjectHeader({
@@ -67,70 +79,56 @@ export function ProjectHeader({
   newActionHotkey,
   tabBadges,
   rightSlot,
+  isLive,
 }: ProjectHeaderProps) {
   const isV2 = structureVersion === 2;
   const tabs = isV2 ? V2_TABS : V1_TABS;
   const label = newActionLabel ?? (isV2 ? 'New ticket' : 'New task');
   const hotkey = newActionHotkey ?? 'C';
+
+  const cleanPath =
+    project?.path && project.path !== '/' && project.path !== '/workspace'
+      ? project.path
+      : '/workspace';
+
   return (
-    <header className="shrink-0 border-b bg-background">
-      <div className="container mx-auto flex h-12 max-w-7xl items-center gap-4 px-3 sm:px-4">
-        <TabsPrimitive.Root
-          value={tab}
-          onValueChange={(v) => onTabChange(v as ProjectTab)}
-          className="flex h-full flex-1 items-center gap-4"
-        >
-          <div className="flex min-w-0 flex-1 items-center gap-2.5">
-            <ProjectIcon project={project} size="xs" />
-            <h1
-              className="truncate text-sm font-semibold tracking-tight text-foreground"
-              title={project.name}
-            >
-              {project.name}
-            </h1>
-            {isV2 && (
-              <Badge
-                variant="muted"
-                size="sm"
-                className="font-mono uppercase tracking-wider"
+    <header className="shrink-0 bg-background">
+      <div className="mx-auto w-full max-w-7xl px-4 pt-6 pb-3 sm:px-6">
+        <div className="flex items-start gap-4">
+          <ProjectIcon project={project} size="md" />
+
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2">
+              <h1
+                className="truncate text-lg font-semibold leading-tight tracking-tight text-foreground"
+                title={project.name}
               >
-                v2
-              </Badge>
-            )}
+                {project.name}
+              </h1>
+              {isLive && <LivePulse />}
+              {isV2 && (
+                <Badge
+                  variant="muted"
+                  size="sm"
+                  className="font-mono uppercase tracking-wider"
+                >
+                  v2
+                </Badge>
+              )}
+            </div>
+
+            <div className="mt-1.5 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground/85">
+              <PathButton path={cleanPath} fullPath={project.path} />
+              {project?.created_at && (
+                <>
+                  <span className="text-muted-foreground/30">·</span>
+                  <span>Created {relativeShort(project.created_at)}</span>
+                </>
+              )}
+            </div>
           </div>
 
-          <TabsPrimitive.List className="flex h-full shrink-0 items-center gap-5">
-            {tabs.map((t) => {
-              const badge = tabBadges?.[t.id] ?? 0;
-              return (
-                <TabsPrimitive.Trigger
-                  key={t.id}
-                  value={t.id}
-                  className={cn(
-                    'relative inline-flex h-full cursor-pointer items-center gap-1.5 text-sm font-medium tracking-tight outline-none transition-colors',
-                    'text-muted-foreground/70 hover:text-foreground',
-                    'data-[state=active]:text-foreground',
-                    'after:absolute after:inset-x-0 after:-bottom-px after:h-0.5 after:rounded-full after:bg-foreground',
-                    'after:opacity-0 after:transition-opacity data-[state=active]:after:opacity-100',
-                  )}
-                >
-                  {t.label}
-                  {badge > 0 && (
-                    <Badge
-                      variant="destructive"
-                      size="sm"
-                      className="rounded-full tabular-nums"
-                      aria-label={`${badge} unread`}
-                    >
-                      {badge > 99 ? '99+' : badge}
-                    </Badge>
-                  )}
-                </TabsPrimitive.Trigger>
-              );
-            })}
-          </TabsPrimitive.List>
-
-          <div className="flex flex-1 items-center justify-end gap-1.5">
+          <div className="flex shrink-0 items-center gap-1.5">
             {rightSlot}
             {onNewTask && (
               <Button size="sm" onClick={onNewTask} title={`${label} (${hotkey})`}>
@@ -142,8 +140,102 @@ export function ProjectHeader({
               </Button>
             )}
           </div>
-        </TabsPrimitive.Root>
+        </div>
+      </div>
+
+      <div className="border-b border-border/50">
+        <div className="mx-auto w-full max-w-7xl px-4 sm:px-6">
+          <TabsPrimitive.Root
+            value={tab}
+            onValueChange={(v) => onTabChange(v as ProjectTab)}
+          >
+            <TabsPrimitive.List className="-mb-px flex h-10 items-center gap-1">
+              {tabs.map((t) => {
+                const badge = tabBadges?.[t.id] ?? 0;
+                const Icon = t.icon;
+                return (
+                  <TabsPrimitive.Trigger
+                    key={t.id}
+                    value={t.id}
+                    className={cn(
+                      'relative inline-flex h-full cursor-pointer items-center gap-1.5 rounded-t-md px-2.5 text-sm font-medium tracking-tight outline-none transition-colors',
+                      'text-muted-foreground/70 hover:text-foreground',
+                      'data-[state=active]:text-foreground',
+                      'after:absolute after:inset-x-2.5 after:-bottom-px after:h-[2px] after:rounded-full after:bg-foreground',
+                      'after:opacity-0 after:transition-opacity data-[state=active]:after:opacity-100',
+                      'focus-visible:ring-2 focus-visible:ring-ring/30',
+                    )}
+                  >
+                    <Icon className="size-3.5" />
+                    {t.label}
+                    {badge > 0 && (
+                      <Badge
+                        variant="destructive"
+                        size="sm"
+                        className="rounded-full tabular-nums"
+                        aria-label={`${badge} unread`}
+                      >
+                        {badge > 99 ? '99+' : badge}
+                      </Badge>
+                    )}
+                  </TabsPrimitive.Trigger>
+                );
+              })}
+            </TabsPrimitive.List>
+          </TabsPrimitive.Root>
+        </div>
       </div>
     </header>
   );
+}
+
+function PathButton({ path, fullPath }: { path: string; fullPath?: string }) {
+  const [copied, setCopied] = useState(false);
+  const copy = useCallback(() => {
+    if (!fullPath) return;
+    navigator.clipboard.writeText(fullPath).catch(() => {});
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1200);
+  }, [fullPath]);
+  return (
+    <button
+      type="button"
+      onClick={copy}
+      className="inline-flex items-center gap-1 rounded transition-colors hover:text-foreground"
+      title="Copy path"
+    >
+      <span>~{path}</span>
+      {copied ? (
+        <Check className="size-3 text-emerald-500" />
+      ) : (
+        <Copy className="size-3 opacity-40" />
+      )}
+    </button>
+  );
+}
+
+function LivePulse() {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className="relative inline-flex items-center justify-center">
+          <span className="absolute size-2.5 animate-ping rounded-full bg-emerald-500/40" />
+          <span className="relative size-1.5 rounded-full bg-emerald-500" />
+        </span>
+      </TooltipTrigger>
+      <TooltipContent>An agent is working right now</TooltipContent>
+    </Tooltip>
+  );
+}
+
+function relativeShort(iso: string): string {
+  const t = new Date(iso).getTime();
+  if (Number.isNaN(t)) return '';
+  const diff = Date.now() - t;
+  const m = 60_000, h = m * 60, d = h * 24;
+  if (diff < m) return 'just now';
+  if (diff < h) return `${Math.round(diff / m)}m ago`;
+  if (diff < d) return `${Math.round(diff / h)}h ago`;
+  if (diff < d * 30) return `${Math.round(diff / d)}d ago`;
+  return new Date(iso).toLocaleDateString();
 }

--- a/apps/web/src/components/kortix/project-icon.tsx
+++ b/apps/web/src/components/kortix/project-icon.tsx
@@ -1,0 +1,49 @@
+import { cn } from '@/lib/utils';
+
+const ICON_HUES = [12, 30, 50, 90, 145, 195, 230, 265, 305, 340] as const;
+
+export function projectAccent(id: string): string {
+  let hash = 0;
+  for (let i = 0; i < id.length; i++) hash = (hash * 31 + id.charCodeAt(i)) | 0;
+  const hue = ICON_HUES[Math.abs(hash) % ICON_HUES.length];
+  return `oklch(0.62 0.14 ${hue})`;
+}
+
+export function projectInitial(name: string): string {
+  const cleaned = name.replace(/[^A-Za-z0-9]/g, '').trim();
+  return (cleaned[0] || '?').toUpperCase();
+}
+
+export type ProjectIconSize = 'xs' | 'sm' | 'md' | 'lg';
+
+const SIZE_CLASS: Record<ProjectIconSize, string> = {
+  xs: 'size-5 text-[0.625rem]',
+  sm: 'size-7 text-xs',
+  md: 'size-9 text-sm',
+  lg: 'size-12 text-base',
+};
+
+export function ProjectIcon({
+  project,
+  size = 'md',
+  className,
+}: {
+  project: { id: string; name: string };
+  size?: ProjectIconSize;
+  className?: string;
+}) {
+  const accent = projectAccent(project.id);
+  const initial = projectInitial(project.name);
+  return (
+    <div
+      className={cn(
+        'flex shrink-0 items-center justify-center rounded-lg font-semibold tracking-tight text-white ring-1 ring-inset ring-white/10',
+        SIZE_CLASS[size],
+        className,
+      )}
+      style={{ backgroundColor: accent }}
+    >
+      {initial}
+    </div>
+  );
+}

--- a/apps/web/src/components/kortix/project-icon.tsx
+++ b/apps/web/src/components/kortix/project-icon.tsx
@@ -1,12 +1,29 @@
 import { cn } from '@/lib/utils';
 
-const ICON_HUES = [12, 30, 50, 90, 145, 195, 230, 265, 305, 340] as const;
+const PALETTE = [
+  { border: 'border-red-500/30',     text: 'text-red-500',     bg: 'bg-red-500/20',     dot: 'bg-red-500' },
+  { border: 'border-orange-500/30',  text: 'text-orange-500',  bg: 'bg-orange-500/20',  dot: 'bg-orange-500' },
+  { border: 'border-amber-500/30',   text: 'text-amber-500',   bg: 'bg-amber-500/20',   dot: 'bg-amber-500' },
+  { border: 'border-emerald-500/30', text: 'text-emerald-500', bg: 'bg-emerald-500/20', dot: 'bg-emerald-500' },
+  { border: 'border-teal-500/30',    text: 'text-teal-500',    bg: 'bg-teal-500/20',    dot: 'bg-teal-500' },
+  { border: 'border-cyan-500/30',    text: 'text-cyan-500',    bg: 'bg-cyan-500/20',    dot: 'bg-cyan-500' },
+  { border: 'border-blue-500/30',    text: 'text-blue-500',    bg: 'bg-blue-500/20',    dot: 'bg-blue-500' },
+  { border: 'border-indigo-500/30',  text: 'text-indigo-500',  bg: 'bg-indigo-500/20',  dot: 'bg-indigo-500' },
+  { border: 'border-violet-500/30',  text: 'text-violet-500',  bg: 'bg-violet-500/20',  dot: 'bg-violet-500' },
+  { border: 'border-fuchsia-500/30', text: 'text-fuchsia-500', bg: 'bg-fuchsia-500/20', dot: 'bg-fuchsia-500' },
+  { border: 'border-rose-500/30',    text: 'text-rose-500',    bg: 'bg-rose-500/20',    dot: 'bg-rose-500' },
+] as const;
 
-export function projectAccent(id: string): string {
-  let hash = 0;
-  for (let i = 0; i < id.length; i++) hash = (hash * 31 + id.charCodeAt(i)) | 0;
-  const hue = ICON_HUES[Math.abs(hash) % ICON_HUES.length];
-  return `oklch(0.62 0.14 ${hue})`;
+export type ProjectColor = (typeof PALETTE)[number];
+
+function hashString(s: string): number {
+  let h = 0;
+  for (let i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) | 0;
+  return h;
+}
+
+export function projectColor(id: string): ProjectColor {
+  return PALETTE[Math.abs(hashString(id)) % PALETTE.length];
 }
 
 export function projectInitial(name: string): string {
@@ -32,18 +49,19 @@ export function ProjectIcon({
   size?: ProjectIconSize;
   className?: string;
 }) {
-  const accent = projectAccent(project.id);
-  const initial = projectInitial(project.name);
+  const color = projectColor(project.id);
   return (
     <div
       className={cn(
-        'flex shrink-0 items-center justify-center rounded-lg font-semibold tracking-tight text-white ring-1 ring-inset ring-white/10',
+        'flex shrink-0 items-center justify-center rounded-xl border font-semibold tracking-tight',
+        color.border,
+        color.text,
+        color.bg,
         SIZE_CLASS[size],
         className,
       )}
-      style={{ backgroundColor: accent }}
     >
-      {initial}
+      {projectInitial(project.name)}
     </div>
   );
 }

--- a/apps/web/src/components/kortix/project-settings-tab.tsx
+++ b/apps/web/src/components/kortix/project-settings-tab.tsx
@@ -1,21 +1,8 @@
 'use client';
 
-/**
- * Project Settings hub — a single tab that absorbs Team, Triggers,
- * Credentials, and the existing Board config (columns/fields/templates).
- *
- * Why: the top-level tab bar was getting crowded (9 tabs). Top-level is
- * reserved for work surfaces (Board, Milestones, Sessions, Files, About);
- * set-once / rarely-touched configuration lives here.
- *
- * UX: sub-pills mirror the existing style used inside TicketSettingsTab
- * (rounded-full, filled when active). Section state is purely client-side
- * — URL sync is opt-in via the `initialSection` prop (wire up later if
- * needed for deep-links).
- */
-
-import { type ComponentType } from 'react';
 import { Users, KeyRound, Zap, LayoutGrid, Radio } from 'lucide-react';
+import { motion } from 'framer-motion';
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { cn } from '@/lib/utils';
 import { TeamTab } from './team-tab';
 import { CredentialsTab } from './credentials-tab';
@@ -25,11 +12,21 @@ import { TicketSettingsTab } from './ticket-settings-tab';
 
 export type SettingsSection = 'team' | 'credentials' | 'triggers' | 'channels' | 'board';
 
-/**
- * Controlled component: parent owns the section state so it survives
- * tab-away / tab-back on the outer project tab bar. Parent also uses
- * `section` to land legacy `setTab('team')` etc. on the right pill.
- */
+const SECTIONS: Array<{ value: SettingsSection; label: string; icon: typeof Users; hint: string }> = [
+  { value: 'team', label: 'Team', icon: Users, hint: 'Agents, humans, and roles' },
+  { value: 'credentials', label: 'Credentials', icon: KeyRound, hint: 'API keys and secrets' },
+  { value: 'triggers', label: 'Triggers', icon: Zap, hint: 'Cron jobs and webhooks' },
+  { value: 'channels', label: 'Channels', icon: Radio, hint: 'Slack, email, and inbound routes' },
+  { value: 'board', label: 'Board', icon: LayoutGrid, hint: 'Columns, fields, and templates' },
+];
+
+const TRIGGER_CLS = cn(
+  'data-[state=active]:shadow-none',
+  'data-[state=active]:ring-0',
+  'data-[state=active]:bg-background data-[state=active]:text-foreground',
+  'data-[state=active]:border-border/60',
+);
+
 export function ProjectSettingsTab({
   projectId,
   projectPath,
@@ -41,58 +38,66 @@ export function ProjectSettingsTab({
   section: SettingsSection;
   onSectionChange: (s: SettingsSection) => void;
 }) {
-  const setSection = onSectionChange;
+  const current = SECTIONS.find((s) => s.value === section) ?? SECTIONS[0];
 
   return (
-    <div className="h-full flex flex-col overflow-hidden bg-background">
-      {/* Sub-nav — sticks at the top of the settings pane, same visual
-          language as the pill nav inside TicketSettingsTab. */}
-      <div className="shrink-0 border-b border-border/40 bg-background/95 backdrop-blur">
-        <div className="container mx-auto max-w-3xl px-3 sm:px-4 py-2.5 flex items-center gap-1">
-          <SectionPill active={section === 'team'} onClick={() => setSection('team')} icon={Users} label="Team" />
-          <SectionPill active={section === 'credentials'} onClick={() => setSection('credentials')} icon={KeyRound} label="Credentials" />
-          <SectionPill active={section === 'triggers'} onClick={() => setSection('triggers')} icon={Zap} label="Triggers" />
-          <SectionPill active={section === 'channels'} onClick={() => setSection('channels')} icon={Radio} label="Channels" />
-          <SectionPill active={section === 'board'} onClick={() => setSection('board')} icon={LayoutGrid} label="Board" />
+    <div className="flex h-full flex-col overflow-hidden bg-background">
+      <Tabs
+        value={section}
+        onValueChange={(v) => onSectionChange(v as SettingsSection)}
+        className="flex h-full min-h-0 flex-col gap-0"
+      >
+        <div className="shrink-0">
+          <motion.div
+            initial={{ opacity: 0, y: 6 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.3, ease: 'easeOut' }}
+            className="mx-auto w-full max-w-3xl px-4 pt-12 sm:px-6"
+          >
+            <header>
+              <h1 className="text-xl font-semibold tracking-tight text-foreground">
+                Settings
+              </h1>
+              <p className="mt-1.5 text-sm leading-relaxed text-muted-foreground">
+                {current.hint}.
+              </p>
+            </header>
+
+            <div className="mt-6">
+              <TabsList>
+                {SECTIONS.map((s) => (
+                  <TabsTrigger
+                    key={s.value}
+                    value={s.value}
+                    className={cn('flex-none px-3', TRIGGER_CLS)}
+                  >
+                    <s.icon />
+                    {s.label}
+                  </TabsTrigger>
+                ))}
+              </TabsList>
+            </div>
+          </motion.div>
         </div>
-      </div>
 
-      <div className="flex-1 min-h-0 overflow-hidden">
-        {section === 'team' && <TeamTab projectId={projectId} />}
-        {section === 'credentials' && <CredentialsTab projectId={projectId} />}
-        {section === 'triggers' && (
-          <TriggersTab projectId={projectId} projectPath={projectPath ?? ''} />
-        )}
-        {section === 'channels' && <ChannelsTab projectId={projectId} />}
-        {section === 'board' && <TicketSettingsTab projectId={projectId} />}
-      </div>
+        <div className="min-h-0 flex-1 overflow-hidden">
+          <motion.div
+            key={section}
+            initial={{ opacity: 0, y: 4 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.2, ease: 'easeOut' }}
+            className="h-full"
+          >
+            {section === 'team' && <TeamTab projectId={projectId} />}
+            {section === 'credentials' && <CredentialsTab projectId={projectId} />}
+            {section === 'triggers' && (
+              <TriggersTab projectId={projectId} projectPath={projectPath ?? ''} />
+            )}
+            {section === 'channels' && <ChannelsTab projectId={projectId} />}
+            {section === 'board' && <TicketSettingsTab projectId={projectId} />}
+          </motion.div>
+        </div>
+      </Tabs>
     </div>
-  );
-}
-
-function SectionPill({
-  active,
-  onClick,
-  icon: Icon,
-  label,
-}: {
-  active: boolean;
-  onClick: () => void;
-  icon: ComponentType<{ className?: string }>;
-  label: string;
-}) {
-  return (
-    <button
-      onClick={onClick}
-      className={cn(
-        'inline-flex items-center gap-1.5 h-7 px-2.5 rounded-full text-[12px] transition-colors cursor-pointer',
-        active
-          ? 'bg-foreground text-background'
-          : 'text-muted-foreground/70 hover:text-foreground hover:bg-muted/40',
-      )}
-    >
-      <Icon className="h-3.5 w-3.5" />
-      {label}
-    </button>
   );
 }

--- a/apps/web/src/components/kortix/project-sidebar.tsx
+++ b/apps/web/src/components/kortix/project-sidebar.tsx
@@ -72,10 +72,10 @@ export function ProjectSidebar({
       : '/workspace';
 
   return (
-    <aside className="flex w-60 shrink-0 flex-col overflow-hidden border-r bg-card">
-      <div className="border-b px-3 py-3.5">
-        <div className="flex items-center gap-2.5">
-          <ProjectIcon project={project} size="md" />
+    <aside className="m-3 flex w-60 shrink-0 flex-col overflow-hidden rounded-2xl border bg-muted/40">
+      <div className="px-3 pt-4">
+        <div className="flex items-center gap-3">
+          <ProjectIcon project={project} size="lg" />
           <div className="min-w-0 flex-1">
             <div className="flex items-center gap-1.5">
               <h2
@@ -94,24 +94,20 @@ export function ProjectSidebar({
                 </Badge>
               )}
             </div>
-            <Badge
-              variant="secondary"
-              size="sm"
-              className="mt-1 max-w-full rounded-md font-mono normal-case tracking-normal"
+            <p
+              className="mt-0.5 truncate font-mono text-xs text-muted-foreground"
               title={cleanPath}
             >
-              <span className="truncate">~{cleanPath}</span>
-            </Badge>
+              ~{cleanPath}
+            </p>
           </div>
         </div>
-      </div>
 
-      {onNewTask && (
-        <div className="border-b px-3 py-2.5">
+        {onNewTask && (
           <Button
             size="sm"
             onClick={onNewTask}
-            className="w-full justify-start"
+            className="mt-4 w-full justify-start"
             title={`${ctaLabel} (${ctaKey})`}
           >
             <Plus />
@@ -120,10 +116,10 @@ export function ProjectSidebar({
               {ctaKey}
             </Kbd>
           </Button>
-        </div>
-      )}
+        )}
+      </div>
 
-      <nav className="flex-1 overflow-y-auto px-2 py-2">
+      <nav className="mt-5 flex-1 overflow-y-auto px-2">
         {items.map((item) => {
           const isActive = tab === item.id;
           const badge = tabBadges?.[item.id] ?? 0;
@@ -134,16 +130,16 @@ export function ProjectSidebar({
               type="button"
               onClick={() => onTabChange(item.id)}
               className={cn(
-                'group flex w-full items-center gap-2.5 rounded-lg px-2.5 py-1.5 text-left text-sm font-medium transition-colors',
+                'group relative flex w-full items-center gap-2.5 rounded-lg px-2.5 py-1.5 text-left text-sm font-medium transition-colors',
                 isActive
                   ? 'bg-muted text-foreground'
-                  : 'text-muted-foreground hover:bg-muted/50 hover:text-foreground',
+                  : 'text-muted-foreground hover:bg-muted/40 hover:text-foreground',
               )}
             >
               <Icon
                 className={cn(
-                  'size-4 shrink-0',
-                  isActive ? 'text-foreground' : 'text-muted-foreground/70',
+                  'size-4 shrink-0 transition-colors',
+                  isActive ? 'text-foreground' : 'text-muted-foreground/60 group-hover:text-muted-foreground',
                 )}
               />
               <span className="flex-1 truncate">{item.label}</span>
@@ -162,7 +158,7 @@ export function ProjectSidebar({
       </nav>
 
       {footerSlot && (
-        <div className="border-t px-2 py-2">{footerSlot}</div>
+        <div className="px-2 pb-2 pt-2">{footerSlot}</div>
       )}
     </aside>
   );

--- a/apps/web/src/components/kortix/project-sidebar.tsx
+++ b/apps/web/src/components/kortix/project-sidebar.tsx
@@ -1,0 +1,169 @@
+'use client';
+
+import {
+  Boxes,
+  CircleDot,
+  FolderTree,
+  MessageSquareText,
+  Plus,
+  Settings,
+  Sparkles,
+  Target,
+  Users,
+} from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Kbd } from '@/components/ui/kbd';
+import { ProjectIcon } from '@/components/kortix/project-icon';
+import type { ProjectTab } from '@/components/kortix/project-header';
+
+interface SidebarItem {
+  id: ProjectTab;
+  label: string;
+  icon: typeof CircleDot;
+}
+
+const V1_NAV: SidebarItem[] = [
+  { id: 'about', label: 'Overview', icon: Sparkles },
+  { id: 'tasks', label: 'Tasks', icon: CircleDot },
+  { id: 'files', label: 'Files', icon: FolderTree },
+  { id: 'sessions', label: 'Sessions', icon: MessageSquareText },
+  { id: 'members', label: 'Members', icon: Users },
+];
+
+const V2_NAV: SidebarItem[] = [
+  { id: 'about', label: 'Overview', icon: Sparkles },
+  { id: 'board', label: 'Board', icon: Boxes },
+  { id: 'milestones', label: 'Milestones', icon: Target },
+  { id: 'files', label: 'Files', icon: FolderTree },
+  { id: 'sessions', label: 'Sessions', icon: MessageSquareText },
+  { id: 'settings', label: 'Settings', icon: Settings },
+];
+
+export interface ProjectSidebarProps {
+  project: { id: string; name: string; path?: string; structure_version?: number };
+  tab: ProjectTab;
+  onTabChange: (tab: ProjectTab) => void;
+  onNewTask?: () => void;
+  newActionLabel?: string;
+  newActionHotkey?: string;
+  tabBadges?: Partial<Record<ProjectTab, number>>;
+  footerSlot?: React.ReactNode;
+}
+
+export function ProjectSidebar({
+  project,
+  tab,
+  onTabChange,
+  onNewTask,
+  newActionLabel,
+  newActionHotkey,
+  tabBadges,
+  footerSlot,
+}: ProjectSidebarProps) {
+  const isV2 = project.structure_version === 2;
+  const items = isV2 ? V2_NAV : V1_NAV;
+  const ctaLabel = newActionLabel ?? (isV2 ? 'New ticket' : 'New task');
+  const ctaKey = newActionHotkey ?? 'C';
+  const cleanPath =
+    project.path && project.path !== '/' && project.path !== '/workspace'
+      ? project.path
+      : '/workspace';
+
+  return (
+    <aside className="flex w-60 shrink-0 flex-col overflow-hidden border-r bg-card">
+      <div className="border-b px-3 py-3.5">
+        <div className="flex items-center gap-2.5">
+          <ProjectIcon project={project} size="md" />
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-1.5">
+              <h2
+                className="truncate text-sm font-semibold tracking-tight text-foreground"
+                title={project.name}
+              >
+                {project.name}
+              </h2>
+              {isV2 && (
+                <Badge
+                  variant="muted"
+                  size="sm"
+                  className="font-mono uppercase tracking-wider"
+                >
+                  v2
+                </Badge>
+              )}
+            </div>
+            <Badge
+              variant="secondary"
+              size="sm"
+              className="mt-1 max-w-full rounded-md font-mono normal-case tracking-normal"
+              title={cleanPath}
+            >
+              <span className="truncate">~{cleanPath}</span>
+            </Badge>
+          </div>
+        </div>
+      </div>
+
+      {onNewTask && (
+        <div className="border-b px-3 py-2.5">
+          <Button
+            size="sm"
+            onClick={onNewTask}
+            className="w-full justify-start"
+            title={`${ctaLabel} (${ctaKey})`}
+          >
+            <Plus />
+            <span className="flex-1 text-left">{ctaLabel}</span>
+            <Kbd className="border border-primary-foreground/20 bg-primary-foreground/10 text-primary-foreground/90">
+              {ctaKey}
+            </Kbd>
+          </Button>
+        </div>
+      )}
+
+      <nav className="flex-1 overflow-y-auto px-2 py-2">
+        {items.map((item) => {
+          const isActive = tab === item.id;
+          const badge = tabBadges?.[item.id] ?? 0;
+          const Icon = item.icon;
+          return (
+            <button
+              key={item.id}
+              type="button"
+              onClick={() => onTabChange(item.id)}
+              className={cn(
+                'group flex w-full items-center gap-2.5 rounded-lg px-2.5 py-1.5 text-left text-sm font-medium transition-colors',
+                isActive
+                  ? 'bg-muted text-foreground'
+                  : 'text-muted-foreground hover:bg-muted/50 hover:text-foreground',
+              )}
+            >
+              <Icon
+                className={cn(
+                  'size-4 shrink-0',
+                  isActive ? 'text-foreground' : 'text-muted-foreground/70',
+                )}
+              />
+              <span className="flex-1 truncate">{item.label}</span>
+              {badge > 0 && (
+                <Badge
+                  variant="destructive"
+                  size="sm"
+                  className="rounded-full tabular-nums"
+                >
+                  {badge > 99 ? '99+' : badge}
+                </Badge>
+              )}
+            </button>
+          );
+        })}
+      </nav>
+
+      {footerSlot && (
+        <div className="border-t px-2 py-2">{footerSlot}</div>
+      )}
+    </aside>
+  );
+}

--- a/apps/web/src/components/kortix/team-tab.tsx
+++ b/apps/web/src/components/kortix/team-tab.tsx
@@ -108,7 +108,7 @@ export function TeamTab({ projectId }: { projectId: string }) {
 
   return (
     <div className="h-full overflow-y-auto animate-in fade-in-0 duration-300 fill-mode-both">
-      <div className="container mx-auto max-w-3xl px-4 sm:px-6 lg:px-10 py-8 sm:py-10 space-y-8">
+      <div className="mx-auto w-full max-w-3xl px-4 sm:px-6 py-8 space-y-8">
 
         {/* ─── Roster ─── */}
         <section>

--- a/apps/web/src/components/kortix/ticket-board.tsx
+++ b/apps/web/src/components/kortix/ticket-board.tsx
@@ -11,7 +11,7 @@
  * column membership.
  */
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   Circle,
   CircleDot,
@@ -30,6 +30,8 @@ import {
   Zap,
   ExternalLink,
   Copy,
+  Target,
+  ChevronDown,
   type LucideIcon,
 } from 'lucide-react';
 import {
@@ -57,6 +59,8 @@ import {
   DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuSeparator,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
 } from '@/components/ui/dropdown-menu';
 import type {
   Ticket,
@@ -224,51 +228,15 @@ export function TicketBoard({ tickets, columns, agents, onOpenTicket, onNewTicke
 
   return (
     <div className="h-full flex flex-col overflow-hidden">
-      <div className="shrink-0 bg-background border-b border-border/50">
-        <div className="container mx-auto max-w-7xl px-3 sm:px-4 h-11 flex items-center gap-2">
-          <div className="relative">
-            <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3 w-3 text-muted-foreground/40 pointer-events-none" />
-            <input
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              placeholder="Search tickets or #number…"
-              className="h-7 w-[220px] pl-7 pr-7 text-[12px] bg-transparent border border-border/50 rounded-full outline-none focus:ring-2 focus:ring-primary/20 placeholder:text-muted-foreground/35"
-            />
-            {search && (
-              <button
-                onClick={() => setSearch('')}
-                className="absolute right-1.5 top-1/2 -translate-y-1/2 h-4 w-4 flex items-center justify-center text-muted-foreground/40 hover:text-foreground cursor-pointer rounded-full"
-              >
-                <X className="h-3 w-3" />
-              </button>
-            )}
-          </div>
-          {milestones.length > 0 && (
-            <select
-              value={milestoneFilter}
-              onChange={(e) => setMilestoneFilter(e.target.value)}
-              className="h-7 text-[12px] bg-transparent border border-border/50 rounded-full outline-none focus:ring-2 focus:ring-primary/20 px-2.5"
-              title="Filter by milestone"
-            >
-              <option value="all">All milestones</option>
-              <option value="none">— no milestone —</option>
-              {milestones.filter((m) => m.status === 'open').map((m) => (
-                <option key={m.id} value={m.id}>M{m.number} · {m.title}</option>
-              ))}
-              {milestones.some((m) => m.status !== 'open') && (
-                <optgroup label="Closed / cancelled">
-                  {milestones.filter((m) => m.status !== 'open').map((m) => (
-                    <option key={m.id} value={m.id}>M{m.number} · {m.title} ({m.status})</option>
-                  ))}
-                </optgroup>
-              )}
-            </select>
-          )}
-          <span className="text-[11px] text-muted-foreground/40 ml-2 hidden sm:inline">
-            drag cards to move — or use the ⋯ menu
-          </span>
-        </div>
-      </div>
+      <BoardToolbar
+        search={search}
+        onSearchChange={setSearch}
+        milestones={milestones}
+        milestoneFilter={milestoneFilter}
+        onMilestoneFilterChange={setMilestoneFilter}
+        count={filtered.length}
+        total={tickets.length}
+      />
 
       <DndContext
         sensors={sensors}
@@ -292,9 +260,10 @@ export function TicketBoard({ tickets, columns, agents, onOpenTicket, onNewTicke
                   {rows.length === 0 ? (
                     <button
                       onClick={() => onNewTicket(col.key)}
-                      className="w-full py-6 rounded-xl border border-dashed border-border/40 text-[12px] text-muted-foreground/30 hover:text-foreground hover:border-border hover:bg-muted/20 transition-all cursor-pointer"
+                      className="flex w-full items-center justify-center gap-1.5 rounded-xl py-5 text-xs text-muted-foreground/40 transition-colors hover:bg-muted/30 hover:text-foreground"
                     >
-                      + Add ticket
+                      <Plus className="size-3" />
+                      Add ticket
                     </button>
                   ) : (
                     rows.map((t) => (
@@ -342,6 +311,171 @@ export function TicketBoard({ tickets, columns, agents, onOpenTicket, onNewTicke
   );
 }
 
+// ─── Board toolbar ─────────────────────────────────────────────────────────
+
+function BoardToolbar({
+  search,
+  onSearchChange,
+  milestones,
+  milestoneFilter,
+  onMilestoneFilterChange,
+  count,
+  total,
+}: {
+  search: string;
+  onSearchChange: (v: string) => void;
+  milestones: Milestone[];
+  milestoneFilter: string;
+  onMilestoneFilterChange: (v: string) => void;
+  count: number;
+  total: number;
+}) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== '/') return;
+      const target = e.target as HTMLElement | null;
+      if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)) return;
+      e.preventDefault();
+      inputRef.current?.focus();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, []);
+
+  const openMilestones = useMemo(() => milestones.filter((m) => m.status === 'open'), [milestones]);
+  const closedMilestones = useMemo(() => milestones.filter((m) => m.status !== 'open'), [milestones]);
+
+  const activeMilestone = milestoneFilter === 'all' || milestoneFilter === 'none'
+    ? null
+    : milestones.find((m) => m.id === milestoneFilter) ?? null;
+
+  const milestoneLabel = milestoneFilter === 'all'
+    ? 'All milestones'
+    : milestoneFilter === 'none'
+      ? 'No milestone'
+      : activeMilestone
+        ? `M${activeMilestone.number} · ${activeMilestone.title}`
+        : 'Milestone';
+
+  const milestoneActive = milestoneFilter !== 'all';
+  const filterActive = milestoneActive || !!search;
+
+  return (
+    <div className="shrink-0 bg-background/80 backdrop-blur-sm">
+      <div className="container mx-auto max-w-7xl px-4 sm:px-6 h-12 flex items-center gap-2">
+        <div className="relative group/search">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 size-3.5 text-muted-foreground/45 pointer-events-none transition-colors group-focus-within/search:text-foreground/70" />
+          <input
+            ref={inputRef}
+            value={search}
+            onChange={(e) => onSearchChange(e.target.value)}
+            placeholder="Search tickets or #number…"
+            className={cn(
+              'h-8 w-[260px] pl-8 pr-12 text-sm rounded-full outline-none transition-colors',
+              'bg-muted/40 hover:bg-muted/60 focus:bg-muted/70',
+              'placeholder:text-muted-foreground/45',
+              'focus:ring-2 focus:ring-primary/20',
+            )}
+          />
+          {search ? (
+            <button
+              onClick={() => onSearchChange('')}
+              className="absolute right-2 top-1/2 -translate-y-1/2 inline-flex size-5 items-center justify-center rounded-full text-muted-foreground/55 hover:bg-muted hover:text-foreground"
+              aria-label="Clear search"
+            >
+              <X className="size-3" />
+            </button>
+          ) : (
+            <kbd className="absolute right-2 top-1/2 -translate-y-1/2 inline-flex h-5 min-w-[20px] items-center justify-center rounded-md border border-border/60 bg-background/60 px-1 text-[10px] font-mono text-muted-foreground/60">
+              /
+            </kbd>
+          )}
+        </div>
+
+        {milestones.length > 0 && (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button
+                className={cn(
+                  'group inline-flex items-center gap-1.5 h-8 pl-2.5 pr-2 text-sm rounded-full transition-colors',
+                  milestoneActive
+                    ? 'bg-primary/10 text-foreground hover:bg-primary/15'
+                    : 'bg-muted/40 text-foreground hover:bg-muted/60',
+                )}
+              >
+                <Target className={cn('size-3.5', milestoneActive ? 'text-primary' : 'text-muted-foreground/70')} />
+                <span className="max-w-[180px] truncate">{milestoneLabel}</span>
+                <ChevronDown className="size-3 text-muted-foreground/55 transition-transform group-data-[state=open]:rotate-180" />
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start" className="w-64 z-[10000]">
+              <DropdownMenuLabel className="text-[10px] uppercase tracking-[0.08em] text-muted-foreground/60 font-semibold">
+                Filter by milestone
+              </DropdownMenuLabel>
+              <DropdownMenuRadioGroup value={milestoneFilter} onValueChange={onMilestoneFilterChange}>
+                <DropdownMenuRadioItem value="all" className="text-sm cursor-pointer">
+                  All milestones
+                </DropdownMenuRadioItem>
+                <DropdownMenuRadioItem value="none" className="text-sm cursor-pointer text-muted-foreground">
+                  No milestone
+                </DropdownMenuRadioItem>
+                {openMilestones.length > 0 && <DropdownMenuSeparator />}
+                {openMilestones.map((m) => (
+                  <DropdownMenuRadioItem key={m.id} value={m.id} className="text-sm cursor-pointer">
+                    <span className="size-1.5 rounded-full mr-2" style={{ backgroundColor: `hsl(${m.color_hue ?? 210} 70% 55%)` }} />
+                    <span className="font-mono text-[11px] tabular-nums text-muted-foreground/70 mr-1.5">M{m.number}</span>
+                    <span className="truncate">{m.title}</span>
+                  </DropdownMenuRadioItem>
+                ))}
+                {closedMilestones.length > 0 && (
+                  <>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuLabel className="text-[10px] uppercase tracking-[0.08em] text-muted-foreground/55 font-semibold">
+                      Closed
+                    </DropdownMenuLabel>
+                    {closedMilestones.map((m) => (
+                      <DropdownMenuRadioItem key={m.id} value={m.id} className="text-sm cursor-pointer text-muted-foreground/70">
+                        <span className="font-mono text-[11px] tabular-nums text-muted-foreground/55 mr-1.5">M{m.number}</span>
+                        <span className="truncate line-through decoration-[0.5px]">{m.title}</span>
+                      </DropdownMenuRadioItem>
+                    ))}
+                  </>
+                )}
+              </DropdownMenuRadioGroup>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
+
+        {filterActive && (
+          <button
+            onClick={() => { onSearchChange(''); onMilestoneFilterChange('all'); }}
+            className="inline-flex items-center gap-1 h-8 px-2.5 text-xs text-muted-foreground/70 hover:text-foreground rounded-full hover:bg-muted/40 transition-colors"
+          >
+            <X className="size-3" />
+            Clear
+          </button>
+        )}
+
+        <div className="ml-auto flex items-center gap-1.5 text-xs tabular-nums text-muted-foreground/55">
+          {filterActive && total !== count ? (
+            <>
+              <span className="text-foreground/80 font-medium">{count}</span>
+              <span className="text-muted-foreground/40">of</span>
+              <span>{total}</span>
+            </>
+          ) : (
+            <span>{count}</span>
+          )}
+          <span className="text-muted-foreground/40">{count === 1 ? 'ticket' : 'tickets'}</span>
+        </div>
+      </div>
+      <div className="h-px bg-border/40" />
+    </div>
+  );
+}
+
 // ─── Column (drop target) ──────────────────────────────────────────────────
 
 function Column({ column, count, onAdd, isActiveDrag, children }: {
@@ -356,24 +490,25 @@ function Column({ column, count, onAdd, isActiveDrag, children }: {
   const tint = tintForColumn(column);
   return (
     <div className="flex flex-col w-[300px] shrink-0 h-full">
-      <div className="flex items-center gap-2 mb-2 px-1 shrink-0">
-        <Icon className={cn('h-4 w-4', tint)} />
-        <span className="text-[13px] font-semibold text-foreground tracking-tight">{column.label}</span>
-        <span className="text-[11px] text-muted-foreground/40 tabular-nums">{count}</span>
+      <div className="group/header flex items-center gap-2 mb-2 px-1 shrink-0">
+        <Icon className={cn('size-3.5', tint)} />
+        <span className="text-sm font-semibold tracking-tight text-foreground">{column.label}</span>
+        <span className="text-xs tabular-nums text-muted-foreground/50">{count}</span>
         <Button
           variant="ghost"
-          size="sm"
-          className="ml-auto h-6 w-6 p-0 text-muted-foreground/40 hover:text-foreground"
+          size="icon-xs"
+          className="ml-auto text-muted-foreground/50 opacity-0 transition-opacity hover:text-foreground group-hover/header:opacity-100 focus-visible:opacity-100"
           onClick={onAdd}
           title="Add ticket"
+          aria-label="Add ticket"
         >
-          <Plus className="h-3.5 w-3.5" />
+          <Plus />
         </Button>
       </div>
       <div
         ref={setNodeRef}
         className={cn(
-          'flex-1 min-h-0 overflow-y-auto space-y-2 pr-1 pb-4 rounded-xl transition-colors',
+          'flex-1 min-h-0 overflow-y-auto space-y-2 pb-4 rounded-xl transition-colors',
           isActiveDrag && 'bg-muted/10',
           isOver && 'bg-primary/[0.04] ring-1 ring-inset ring-primary/30',
         )}
@@ -491,7 +626,7 @@ function TicketCardInner({
     <div
       onClick={onSelect}
       className={cn(
-        'group rounded-xl border border-border/50 bg-card p-3 cursor-pointer select-none',
+        'group rounded-xl border border-border/50 bg-muted/60 p-3 cursor-pointer select-none',
         'transition-colors hover:border-border/80 hover:bg-muted/20',
         dragging && 'shadow-xl border-primary/40',
       )}

--- a/apps/web/src/components/kortix/ticket-settings-tab.tsx
+++ b/apps/web/src/components/kortix/ticket-settings-tab.tsx
@@ -1,14 +1,7 @@
 'use client';
 
-/**
- * Ticket Settings tab — Columns, Custom Fields, Templates.
- *
- * Matches Project About styling: max-w-3xl container, small uppercase section
- * labels, rounded cards on bg-card, row-based lists with dividers.
- * Each panel replaces the whole list on Save — server stays authoritative.
- */
-
 import { useEffect, useMemo, useState } from 'react';
+import { motion } from 'framer-motion';
 import {
   Plus,
   Trash2,
@@ -19,12 +12,11 @@ import {
   Columns as ColumnsIcon,
   SlidersHorizontal,
   FileStack,
-  Check,
-  ChevronDown,
   Pause,
   Play,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import {
   Select,
   SelectContent,
@@ -56,61 +48,80 @@ import { COLUMN_ICONS, COLUMN_ICON_KEYS, defaultColumnIcon } from '@/components/
 
 type Panel = 'columns' | 'fields' | 'templates';
 
+const TRIGGER_CLS = cn(
+  'data-[state=active]:shadow-none',
+  'data-[state=active]:ring-0',
+  'data-[state=active]:bg-background data-[state=active]:text-foreground',
+  'data-[state=active]:border-border/60',
+);
+
+const INPUT_CLS =
+  'h-8 rounded-lg bg-muted/40 border-0 px-2.5 text-sm text-foreground outline-none placeholder:text-muted-foreground/40 transition-colors focus:bg-muted/60 focus:ring-2 focus:ring-ring/20';
+
 export function TicketSettingsTab({ projectId }: { projectId: string }) {
   const [panel, setPanel] = useState<Panel>('columns');
   return (
-    <div className="h-full overflow-y-auto animate-in fade-in-0 duration-300 fill-mode-both">
-      <div className="container mx-auto max-w-3xl px-4 sm:px-6 lg:px-10 py-8 sm:py-10 space-y-8">
+    <div className="h-full overflow-y-auto">
+      <div className="mx-auto w-full max-w-3xl px-4 sm:px-6 py-8 space-y-8">
+        <Tabs value={panel} onValueChange={(v) => setPanel(v as Panel)}>
+          <TabsList>
+            <TabsTrigger value="columns" className={cn('flex-none px-3', TRIGGER_CLS)}>
+              <ColumnsIcon />
+              Columns
+            </TabsTrigger>
+            <TabsTrigger value="fields" className={cn('flex-none px-3', TRIGGER_CLS)}>
+              <SlidersHorizontal />
+              Custom fields
+            </TabsTrigger>
+            <TabsTrigger value="templates" className={cn('flex-none px-3', TRIGGER_CLS)}>
+              <FileStack />
+              Templates
+            </TabsTrigger>
+          </TabsList>
+        </Tabs>
 
-        <nav className="flex items-center gap-1 -ml-2">
-          <NavTab active={panel === 'columns'} onClick={() => setPanel('columns')} icon={<ColumnsIcon className="h-3.5 w-3.5" />} label="Columns" />
-          <NavTab active={panel === 'fields'} onClick={() => setPanel('fields')} icon={<SlidersHorizontal className="h-3.5 w-3.5" />} label="Custom fields" />
-          <NavTab active={panel === 'templates'} onClick={() => setPanel('templates')} icon={<FileStack className="h-3.5 w-3.5" />} label="Templates" />
-        </nav>
-
-        {panel === 'columns' && <ColumnsEditor projectId={projectId} />}
-        {panel === 'fields' && <FieldsEditor projectId={projectId} />}
-        {panel === 'templates' && <TemplatesEditor projectId={projectId} />}
+        <motion.div
+          key={panel}
+          initial={{ opacity: 0, y: 4 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.2, ease: 'easeOut' }}
+        >
+          {panel === 'columns' && <ColumnsEditor projectId={projectId} />}
+          {panel === 'fields' && <FieldsEditor projectId={projectId} />}
+          {panel === 'templates' && <TemplatesEditor projectId={projectId} />}
+        </motion.div>
       </div>
     </div>
   );
 }
 
-function NavTab({ active, onClick, icon, label }: { active: boolean; onClick: () => void; icon: React.ReactNode; label: string }) {
-  return (
-    <button
-      onClick={onClick}
-      className={cn(
-        'inline-flex items-center gap-1.5 h-7 px-2.5 rounded-full text-[12px] transition-colors cursor-pointer',
-        active
-          ? 'bg-foreground text-background'
-          : 'text-muted-foreground/70 hover:text-foreground hover:bg-muted/40',
-      )}
-    >
-      {icon}
-      {label}
-    </button>
-  );
-}
-
-function SectionHead({ icon, label, description, action }: {
-  icon: React.ReactNode; label: string; description: string; action?: React.ReactNode;
+function SectionHead({
+  icon: Icon,
+  label,
+  count,
+  description,
+  action,
+}: {
+  icon: typeof ColumnsIcon;
+  label: string;
+  count?: number;
+  description: string;
+  action?: React.ReactNode;
 }) {
   return (
-    <>
-      <div className="flex items-center gap-2 mb-3">
-        {icon}
-        <span className="text-[10px] uppercase tracking-[0.08em] text-muted-foreground/55 font-semibold">{label}</span>
+    <div className="mb-3">
+      <div className="flex items-center gap-2">
+        <Icon className="size-3.5 text-muted-foreground/60" />
+        <h2 className="text-xs font-medium uppercase tracking-[0.12em] text-muted-foreground">{label}</h2>
+        {typeof count === 'number' && (
+          <span className="text-xs tabular-nums text-muted-foreground/45">{count}</span>
+        )}
         {action && <div className="ml-auto">{action}</div>}
       </div>
-      <p className="text-[12px] text-muted-foreground/55 -mt-2 mb-3">{description}</p>
-    </>
+      <p className="mt-1.5 text-sm leading-relaxed text-muted-foreground">{description}</p>
+    </div>
   );
 }
-
-// ═══════════════════════════════════════════════════════════════════════════
-// Columns
-// ═══════════════════════════════════════════════════════════════════════════
 
 interface ColumnDraft {
   key: string;
@@ -130,10 +141,11 @@ function ColumnsEditor({ projectId }: { projectId: string }) {
   const [drafts, setDrafts] = useState<ColumnDraft[]>([]);
   useEffect(() => { if (columnsData) setDrafts(columnsData.map(toColumnDraft)); }, [columnsData]);
 
-  const dirty = useMemo(() => JSON.stringify(drafts.map(toColumnKeyShape)) !== JSON.stringify((columnsData ?? []).map(toColumnKey)), [drafts, columnsData]);
+  const dirty = useMemo(
+    () => JSON.stringify(drafts.map(toColumnKeyShape)) !== JSON.stringify((columnsData ?? []).map(toColumnKey)),
+    [drafts, columnsData],
+  );
 
-  // Derive flow vs off-flow from drafts. The draft array stays flat so index
-  // identities stay stable across renders — we filter for display.
   const flowRows = useMemo(
     () => drafts.map((d, idx) => ({ d, idx })).filter((r) => !r.d.is_off_flow),
     [drafts],
@@ -152,12 +164,12 @@ function ColumnsEditor({ projectId }: { projectId: string }) {
     default_assignee_type: null, default_assignee_id: null, is_terminal: false, is_off_flow: true, icon: 'pause',
   }]);
   const removeAt = (i: number) => setDrafts((ds) => ds.filter((_, idx) => idx !== i));
-  const patchAt = (i: number, patch: Partial<ColumnDraft>) => setDrafts((ds) => ds.map((d, idx) => idx === i ? { ...d, ...patch } : d));
-  const toggleOffFlow = (i: number) => setDrafts((ds) => ds.map((d, idx) => idx === i ? { ...d, is_off_flow: !d.is_off_flow } : d));
+  const patchAt = (i: number, patch: Partial<ColumnDraft>) =>
+    setDrafts((ds) => ds.map((d, idx) => idx === i ? { ...d, ...patch } : d));
+  const toggleOffFlow = (i: number) =>
+    setDrafts((ds) => ds.map((d, idx) => idx === i ? { ...d, is_off_flow: !d.is_off_flow } : d));
 
-  // Reorder among flow columns only. Off-flow columns hold their draft slot.
   const moveFlowUp = (draftIdx: number) => setDrafts((ds) => {
-    // Find the previous on-flow draft index.
     let prev = -1;
     for (let k = draftIdx - 1; k >= 0; k--) if (!ds[k].is_off_flow) { prev = k; break; }
     if (prev === -1) return ds;
@@ -174,8 +186,6 @@ function ColumnsEditor({ projectId }: { projectId: string }) {
     return next;
   });
 
-  // Save order: flow columns first (preserving their relative order), then
-  // off-flow. Off-flow relative order doesn't matter, but we keep it stable.
   const save = () => {
     const ordered = [
       ...drafts.filter((d) => !d.is_off_flow),
@@ -185,66 +195,33 @@ function ColumnsEditor({ projectId }: { projectId: string }) {
   };
 
   return (
-    <section>
-      <SectionHead
-        icon={<ColumnsIcon className="h-3.5 w-3.5 text-muted-foreground/45" />}
-        label="Flow"
-        description="The linear sequence tickets move through. Order matters — new tickets land in the first column. Click a column's icon to change it."
-        action={
-          <Button
-            variant="ghost" size="sm" className="h-6 px-2 text-[11px] gap-1 text-muted-foreground/60 hover:text-foreground"
-            onClick={addFlowColumn}
-          >
-            <Plus className="h-3 w-3" />
-            Add column
-          </Button>
-        }
-      />
-
-      <div className="rounded-xl border border-border/40 divide-y divide-border/30 overflow-hidden bg-card">
-        {flowRows.length === 0 && (
-          <div className="py-8 text-center text-[12px] text-muted-foreground/50">No flow columns yet.</div>
-        )}
-        {flowRows.map(({ d, idx }, displayI) => (
-          <ColumnRow
-            key={idx}
-            draft={d}
-            agents={agents}
-            onPatch={(patch) => patchAt(idx, patch)}
-            onDelete={() => removeAt(idx)}
-            onToggleOffFlow={() => toggleOffFlow(idx)}
-            // Flow-only controls:
-            canMoveUp={displayI > 0}
-            canMoveDown={displayI < flowRows.length - 1}
-            onMoveUp={() => moveFlowUp(idx)}
-            onMoveDown={() => moveFlowDown(idx)}
-          />
-        ))}
-      </div>
-
-      <div className="mt-8">
+    <section className="space-y-8">
+      <div>
         <SectionHead
-          icon={<Pause className="h-3.5 w-3.5 text-muted-foreground/45" />}
-          label="Off-flow"
-          description="Side-channel columns (e.g. blocked, on hold). Reachable from any flow column but don't participate in the linear sequence — skip-column and gate-column guards ignore them."
+          icon={ColumnsIcon}
+          label="Flow"
+          count={flowRows.length}
+          description="The linear sequence tickets move through. Order matters — new tickets land in the first column. Click a column's icon to change it."
           action={
             <Button
-              variant="ghost" size="sm" className="h-6 px-2 text-[11px] gap-1 text-muted-foreground/60 hover:text-foreground"
-              onClick={addOffFlowColumn}
+              variant="ghost"
+              size="sm"
+              onClick={addFlowColumn}
+              className="h-7 text-xs text-muted-foreground hover:text-foreground"
             >
-              <Plus className="h-3 w-3" />
-              Add side-channel
+              <Plus />
+              Add column
             </Button>
           }
         />
 
-        <div className="rounded-xl border border-border/40 divide-y divide-border/30 overflow-hidden bg-card">
-          {offFlowRows.length === 0 && (
-            <div className="py-6 text-center text-[11.5px] text-muted-foreground/45">
-              None. Tickets that stall waiting on external input can sit in a flow column, or you can add a side-channel like <code className="font-mono text-[10.5px] px-1 py-0.5 rounded bg-muted/30">blocked</code>.
+        <div className="overflow-hidden rounded-2xl bg-muted/30">
+          {flowRows.length === 0 && (
+            <div className="px-4 py-10 text-center text-sm text-muted-foreground/60">
+              No flow columns yet.
             </div>
           )}
-          {offFlowRows.map(({ d, idx }) => (
+          {flowRows.map(({ d, idx }, displayI) => (
             <ColumnRow
               key={idx}
               draft={d}
@@ -252,7 +229,50 @@ function ColumnsEditor({ projectId }: { projectId: string }) {
               onPatch={(patch) => patchAt(idx, patch)}
               onDelete={() => removeAt(idx)}
               onToggleOffFlow={() => toggleOffFlow(idx)}
-              // Off-flow: no arrows, order doesn't matter.
+              isLast={displayI === flowRows.length - 1}
+              canMoveUp={displayI > 0}
+              canMoveDown={displayI < flowRows.length - 1}
+              onMoveUp={() => moveFlowUp(idx)}
+              onMoveDown={() => moveFlowDown(idx)}
+            />
+          ))}
+        </div>
+      </div>
+
+      <div>
+        <SectionHead
+          icon={Pause}
+          label="Off-flow"
+          count={offFlowRows.length}
+          description="Side-channel columns (e.g. blocked, on hold). Reachable from any flow column but don't participate in the linear sequence."
+          action={
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={addOffFlowColumn}
+              className="h-7 text-xs text-muted-foreground hover:text-foreground"
+            >
+              <Plus />
+              Add side-channel
+            </Button>
+          }
+        />
+
+        <div className="overflow-hidden rounded-2xl bg-muted/30">
+          {offFlowRows.length === 0 && (
+            <div className="px-4 py-10 text-center text-sm text-muted-foreground/60">
+              No side-channels. Tickets that stall on external input can stay in a flow column, or you can add one like blocked.
+            </div>
+          )}
+          {offFlowRows.map(({ d, idx }, displayI) => (
+            <ColumnRow
+              key={idx}
+              draft={d}
+              agents={agents}
+              onPatch={(patch) => patchAt(idx, patch)}
+              onDelete={() => removeAt(idx)}
+              onToggleOffFlow={() => toggleOffFlow(idx)}
+              isLast={displayI === offFlowRows.length - 1}
             />
           ))}
         </div>
@@ -265,6 +285,7 @@ function ColumnsEditor({ projectId }: { projectId: string }) {
 
 function ColumnRow({
   draft: d, agents, onPatch, onDelete, onToggleOffFlow,
+  isLast,
   canMoveUp, canMoveDown, onMoveUp, onMoveDown,
 }: {
   draft: ColumnDraft;
@@ -272,12 +293,16 @@ function ColumnRow({
   onPatch: (patch: Partial<ColumnDraft>) => void;
   onDelete: () => void;
   onToggleOffFlow: () => void;
+  isLast: boolean;
   canMoveUp?: boolean; canMoveDown?: boolean;
   onMoveUp?: () => void; onMoveDown?: () => void;
 }) {
   const isOffFlow = d.is_off_flow;
   return (
-    <div className="flex items-center gap-2 px-3 py-2.5">
+    <div className={cn(
+      'group flex items-center gap-2 px-3 py-2.5 transition-colors hover:bg-muted/40',
+      !isLast && 'border-b border-border/40',
+    )}>
       <ColumnIconPicker
         iconKey={d.icon ?? defaultColumnIcon(d.key)}
         onChange={(k) => onPatch({ icon: k })}
@@ -286,13 +311,13 @@ function ColumnRow({
         value={d.label}
         onChange={(e) => onPatch({ label: e.target.value })}
         placeholder="Label"
-        className="h-7 flex-1 text-[12.5px] bg-transparent border-0 outline-none focus:ring-0 placeholder:text-muted-foreground/30"
+        className="h-8 flex-1 rounded-lg border-0 bg-transparent px-2 text-sm font-medium outline-none placeholder:text-muted-foreground/40 focus:bg-muted/40 focus:ring-2 focus:ring-ring/20"
       />
       <input
         value={d.key}
         onChange={(e) => onPatch({ key: e.target.value.toLowerCase().replace(/\s+/g, '_') })}
         placeholder="key"
-        className="h-6 w-[110px] text-[10.5px] font-mono bg-muted/30 border border-border/30 rounded px-2 outline-none focus:ring-2 focus:ring-primary/20"
+        className={cn(INPUT_CLS, 'w-[120px]')}
       />
       <Select
         value={d.default_assignee_id ?? '_none'}
@@ -300,45 +325,76 @@ function ColumnRow({
           ? { default_assignee_type: null, default_assignee_id: null }
           : { default_assignee_type: 'agent', default_assignee_id: v })}
       >
-        <SelectTrigger size="sm" className="h-6 text-[11px] w-[130px]"><SelectValue placeholder="Default…" /></SelectTrigger>
+        <SelectTrigger size="sm" className="h-8 w-[140px] text-sm">
+          <SelectValue placeholder="No default" />
+        </SelectTrigger>
         <SelectContent>
           <SelectItem value="_none">No default</SelectItem>
           {agents.map((a) => <SelectItem key={a.id} value={a.id}>@{a.slug}</SelectItem>)}
         </SelectContent>
       </Select>
-      <div className="flex items-center gap-0.5 ml-1">
+      <div className="flex items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100">
         {!isOffFlow && (
           <>
-            <Button
-              variant="ghost" size="sm"
-              className={cn('h-6 w-6 p-0 hover:text-foreground', canMoveUp ? 'text-muted-foreground/40' : 'text-muted-foreground/15 pointer-events-none')}
+            <RowIconButton
               onClick={onMoveUp}
+              disabled={!canMoveUp}
               title="Move up"
-            ><ArrowUp className="h-3 w-3" /></Button>
-            <Button
-              variant="ghost" size="sm"
-              className={cn('h-6 w-6 p-0 hover:text-foreground', canMoveDown ? 'text-muted-foreground/40' : 'text-muted-foreground/15 pointer-events-none')}
+              icon={<ArrowUp className="size-3.5" />}
+            />
+            <RowIconButton
               onClick={onMoveDown}
+              disabled={!canMoveDown}
               title="Move down"
-            ><ArrowDown className="h-3 w-3" /></Button>
+              icon={<ArrowDown className="size-3.5" />}
+            />
           </>
         )}
-        <Button
-          variant="ghost" size="sm"
-          className="h-6 w-6 p-0 text-muted-foreground/40 hover:text-foreground"
+        <RowIconButton
           onClick={onToggleOffFlow}
-          title={isOffFlow ? 'Move back to flow' : 'Move to off-flow (side-channel)'}
-        >
-          {isOffFlow ? <Play className="h-3 w-3" /> : <Pause className="h-3 w-3" />}
-        </Button>
-        <Button
-          variant="ghost" size="sm"
-          className="h-6 w-6 p-0 text-muted-foreground/40 hover:text-destructive"
+          title={isOffFlow ? 'Move back to flow' : 'Move to off-flow'}
+          icon={isOffFlow ? <Play className="size-3.5" /> : <Pause className="size-3.5" />}
+        />
+        <RowIconButton
           onClick={onDelete}
           title="Delete column"
-        ><Trash2 className="h-3 w-3" /></Button>
+          icon={<Trash2 className="size-3.5" />}
+          destructive
+        />
       </div>
     </div>
+  );
+}
+
+function RowIconButton({
+  onClick,
+  disabled,
+  title,
+  icon,
+  destructive,
+}: {
+  onClick?: () => void;
+  disabled?: boolean;
+  title: string;
+  icon: React.ReactNode;
+  destructive?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      title={title}
+      aria-label={title}
+      className={cn(
+        'inline-flex size-7 items-center justify-center rounded-md transition-colors',
+        'text-muted-foreground/60 hover:bg-muted hover:text-foreground',
+        'disabled:pointer-events-none disabled:opacity-30',
+        destructive && 'hover:text-destructive',
+      )}
+    >
+      {icon}
+    </button>
   );
 }
 
@@ -353,10 +409,7 @@ function toColumnDraft(c: TicketColumn): ColumnDraft {
     icon: c.icon ?? null,
   };
 }
-function toColumnKeyShape(d: ColumnDraft) {
-  // For dirty comparison — include is_off_flow so toggling it flags dirty.
-  return { ...d };
-}
+function toColumnKeyShape(d: ColumnDraft) { return { ...d }; }
 function toColumnKey(c: TicketColumn) {
   return {
     key: c.key, label: c.label,
@@ -376,15 +429,17 @@ function ColumnIconPicker({ iconKey, onChange }: { iconKey: string; onChange: (k
       <DropdownMenuTrigger asChild>
         <button
           type="button"
-          className="w-7 h-7 rounded-md flex items-center justify-center shrink-0 hover:bg-muted/40 transition-colors cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-primary/30"
+          className="inline-flex size-8 shrink-0 items-center justify-center rounded-lg transition-colors hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30"
           title="Change icon"
           aria-label="Change column icon"
         >
-          <Ic className={cn('h-4 w-4', entry.tint)} />
+          <Ic className={cn('size-4', entry.tint)} />
         </button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="start" className="w-[220px] z-[10000]">
-        <DropdownMenuLabel className="text-[10px] uppercase tracking-[0.08em] text-muted-foreground/55 font-semibold">Column icon</DropdownMenuLabel>
+      <DropdownMenuContent align="start" className="w-56 z-[10000]">
+        <DropdownMenuLabel className="text-[10px] uppercase tracking-[0.08em] text-muted-foreground/60 font-semibold">
+          Column icon
+        </DropdownMenuLabel>
         <div className="grid grid-cols-4 gap-1 p-1.5">
           {COLUMN_ICON_KEYS.map((k) => {
             const c = COLUMN_ICONS[k];
@@ -395,13 +450,13 @@ function ColumnIconPicker({ iconKey, onChange }: { iconKey: string; onChange: (k
                 key={k}
                 onClick={() => onChange(k)}
                 className={cn(
-                  'flex flex-col items-center justify-center gap-0.5 h-12 cursor-pointer p-1',
-                  active && 'bg-muted/40',
+                  'flex h-12 cursor-pointer flex-col items-center justify-center gap-0.5 p-1',
+                  active && 'bg-muted/60',
                 )}
                 title={c.label}
               >
-                <I className={cn('h-3.5 w-3.5', c.tint)} />
-                <span className="text-[9.5px] text-muted-foreground/70 truncate max-w-full">{c.label}</span>
+                <I className={cn('size-4', c.tint)} />
+                <span className="max-w-full truncate text-[10px] text-muted-foreground/70">{c.label}</span>
               </DropdownMenuItem>
             );
           })}
@@ -410,10 +465,6 @@ function ColumnIconPicker({ iconKey, onChange }: { iconKey: string; onChange: (k
     </DropdownMenu>
   );
 }
-
-// ═══════════════════════════════════════════════════════════════════════════
-// Fields
-// ═══════════════════════════════════════════════════════════════════════════
 
 interface FieldDraft {
   key: string;
@@ -428,71 +479,101 @@ function FieldsEditor({ projectId }: { projectId: string }) {
   const [drafts, setDrafts] = useState<FieldDraft[]>([]);
   useEffect(() => { if (fieldsData) setDrafts(fieldsData.map(toFieldDraft)); }, [fieldsData]);
 
-  const dirty = useMemo(() => JSON.stringify(drafts) !== JSON.stringify((fieldsData ?? []).map(toFieldDraft)), [drafts, fieldsData]);
+  const dirty = useMemo(
+    () => JSON.stringify(drafts) !== JSON.stringify((fieldsData ?? []).map(toFieldDraft)),
+    [drafts, fieldsData],
+  );
 
-  const add = () => setDrafts((ds) => [...ds, { key: `field_${Date.now().toString(36)}`, label: 'New field', type: 'text', options: [] }]);
+  const add = () => setDrafts((ds) => [...ds, {
+    key: `field_${Date.now().toString(36)}`, label: 'New field', type: 'text', options: [],
+  }]);
   const removeAt = (i: number) => setDrafts((ds) => ds.filter((_, idx) => idx !== i));
-  const patchAt = (i: number, patch: Partial<FieldDraft>) => setDrafts((ds) => ds.map((d, idx) => idx === i ? { ...d, ...patch } : d));
+  const patchAt = (i: number, patch: Partial<FieldDraft>) =>
+    setDrafts((ds) => ds.map((d, idx) => idx === i ? { ...d, ...patch } : d));
 
   const save = () => replace.mutate({
     projectId,
-    fields: drafts.map((d) => ({ key: d.key, label: d.label, type: d.type, options: d.type === 'select' ? d.options : null })),
+    fields: drafts.map((d) => ({
+      key: d.key, label: d.label, type: d.type,
+      options: d.type === 'select' ? d.options : null,
+    })),
   });
 
   return (
     <section>
       <SectionHead
-        icon={<SlidersHorizontal className="h-3.5 w-3.5 text-muted-foreground/45" />}
+        icon={SlidersHorizontal}
         label="Custom fields"
+        count={drafts.length}
         description="Per-project fields shown on every ticket. Type controls the editor — text, number, date, or a select with predefined options."
         action={
           <Button
-            variant="ghost" size="sm"
-            className="h-6 px-2 text-[11px] gap-1 text-muted-foreground/60 hover:text-foreground"
+            variant="ghost"
+            size="sm"
             onClick={add}
+            className="h-7 text-xs text-muted-foreground hover:text-foreground"
           >
-            <Plus className="h-3 w-3" />
+            <Plus />
             Add field
           </Button>
         }
       />
 
-      <div className="rounded-xl border border-border/40 divide-y divide-border/30 overflow-hidden bg-card">
+      <div className="overflow-hidden rounded-2xl bg-muted/30">
         {drafts.length === 0 && (
-          <div className="py-8 text-center text-[12px] text-muted-foreground/50">No custom fields yet.</div>
+          <div className="px-4 py-10 text-center text-sm text-muted-foreground/60">
+            No custom fields yet.
+          </div>
         )}
         {drafts.map((d, i) => (
-          <div key={i} className="px-3 py-3">
+          <div
+            key={i}
+            className={cn(
+              'group px-3 py-3 transition-colors hover:bg-muted/40',
+              i !== drafts.length - 1 && 'border-b border-border/40',
+            )}
+          >
             <div className="flex items-center gap-2">
               <input
                 value={d.label}
                 onChange={(e) => patchAt(i, { label: e.target.value })}
                 placeholder="Label"
-                className="h-7 flex-1 text-[12.5px] bg-transparent border-0 outline-none focus:ring-0 placeholder:text-muted-foreground/30"
+                className="h-8 flex-1 rounded-lg border-0 bg-transparent px-2 text-sm font-medium outline-none placeholder:text-muted-foreground/40 focus:bg-muted/40 focus:ring-2 focus:ring-ring/20"
               />
               <input
                 value={d.key}
                 onChange={(e) => patchAt(i, { key: e.target.value.toLowerCase().replace(/\s+/g, '_') })}
                 placeholder="key"
-                className="h-6 w-[110px] text-[10.5px] font-mono bg-muted/30 border border-border/30 rounded px-2 outline-none focus:ring-2 focus:ring-primary/20"
+                className={cn(INPUT_CLS, 'w-[120px]')}
               />
               <Select value={d.type} onValueChange={(v) => patchAt(i, { type: v as FieldDraft['type'] })}>
-                <SelectTrigger size="sm" className="h-6 text-[11px] w-[100px]"><SelectValue /></SelectTrigger>
+                <SelectTrigger size="sm" className="h-8 w-[110px] text-sm">
+                  <SelectValue />
+                </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="text">text</SelectItem>
-                  <SelectItem value="number">number</SelectItem>
-                  <SelectItem value="date">date</SelectItem>
-                  <SelectItem value="select">select</SelectItem>
+                  <SelectItem value="text">Text</SelectItem>
+                  <SelectItem value="number">Number</SelectItem>
+                  <SelectItem value="date">Date</SelectItem>
+                  <SelectItem value="select">Select</SelectItem>
                 </SelectContent>
               </Select>
-              <Button variant="ghost" size="sm" className="h-6 w-6 p-0 text-muted-foreground/40 hover:text-destructive" onClick={() => removeAt(i)}><Trash2 className="h-3 w-3" /></Button>
+              <div className="opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100">
+                <RowIconButton
+                  onClick={() => removeAt(i)}
+                  title="Delete field"
+                  icon={<Trash2 className="size-3.5" />}
+                  destructive
+                />
+              </div>
             </div>
             {d.type === 'select' && (
               <input
                 value={d.options.join(', ')}
-                onChange={(e) => patchAt(i, { options: e.target.value.split(',').map((s) => s.trim()).filter(Boolean) })}
+                onChange={(e) => patchAt(i, {
+                  options: e.target.value.split(',').map((s) => s.trim()).filter(Boolean),
+                })}
                 placeholder="Options, comma-separated — e.g. P0, P1, P2, P3"
-                className="mt-2 h-7 w-full text-[11.5px] bg-muted/20 border border-border/30 rounded-lg px-2.5 outline-none focus:ring-2 focus:ring-primary/20"
+                className={cn(INPUT_CLS, 'mt-2 w-full h-8')}
               />
             )}
           </div>
@@ -510,10 +591,6 @@ function toFieldDraft(f: ProjectField): FieldDraft {
   return { key: f.key, label: f.label, type: f.type, options };
 }
 
-// ═══════════════════════════════════════════════════════════════════════════
-// Templates
-// ═══════════════════════════════════════════════════════════════════════════
-
 interface TemplateDraft { name: string; body_md: string }
 
 function TemplatesEditor({ projectId }: { projectId: string }) {
@@ -525,7 +602,10 @@ function TemplatesEditor({ projectId }: { projectId: string }) {
     if (templatesData) setDrafts(templatesData.map((t) => ({ name: t.name, body_md: t.body_md })));
   }, [templatesData]);
 
-  const dirty = useMemo(() => JSON.stringify(drafts) !== JSON.stringify((templatesData ?? []).map((t) => ({ name: t.name, body_md: t.body_md }))), [drafts, templatesData]);
+  const dirty = useMemo(
+    () => JSON.stringify(drafts) !== JSON.stringify((templatesData ?? []).map((t) => ({ name: t.name, body_md: t.body_md }))),
+    [drafts, templatesData],
+  );
 
   const add = () => {
     const next = drafts.length;
@@ -539,77 +619,86 @@ function TemplatesEditor({ projectId }: { projectId: string }) {
     setDrafts((ds) => ds.filter((_, idx) => idx !== i));
     setActive((a) => (a === null ? null : a === i ? null : a > i ? a - 1 : a));
   };
-  const patchAt = (i: number, patch: Partial<TemplateDraft>) => setDrafts((ds) => ds.map((d, idx) => idx === i ? { ...d, ...patch } : d));
+  const patchAt = (i: number, patch: Partial<TemplateDraft>) =>
+    setDrafts((ds) => ds.map((d, idx) => idx === i ? { ...d, ...patch } : d));
 
   const save = () => replace.mutate({ projectId, templates: drafts });
 
   return (
     <section>
       <SectionHead
-        icon={<FileStack className="h-3.5 w-3.5 text-muted-foreground/45" />}
+        icon={FileStack}
         label="Ticket templates"
+        count={drafts.length}
         description="Markdown templates shown in the New-ticket picker. Acceptance criteria lives in the body — no hardcoded verification field."
         action={
           <Button
-            variant="ghost" size="sm"
-            className="h-6 px-2 text-[11px] gap-1 text-muted-foreground/60 hover:text-foreground"
+            variant="ghost"
+            size="sm"
             onClick={add}
+            className="h-7 text-xs text-muted-foreground hover:text-foreground"
           >
-            <Plus className="h-3 w-3" />
+            <Plus />
             Add template
           </Button>
         }
       />
 
-      <div className="rounded-xl border border-border/40 overflow-hidden bg-card">
+      <div className="overflow-hidden rounded-2xl bg-muted/30">
         {drafts.length === 0 ? (
-          <div className="py-8 text-center text-[12px] text-muted-foreground/50">No templates yet.</div>
+          <div className="px-4 py-10 text-center text-sm text-muted-foreground/60">
+            No templates yet.
+          </div>
         ) : (
-          <div className="flex min-h-[320px]">
-            <div className="w-48 border-r border-border/30 divide-y divide-border/30 shrink-0">
+          <div className="flex min-h-[360px]">
+            <div className="w-52 shrink-0 border-r border-border/40">
               {drafts.map((d, i) => (
                 <button
                   key={i}
                   onClick={() => setActive(i)}
                   className={cn(
-                    'w-full text-left px-3 py-2.5 hover:bg-muted/25 transition-colors cursor-pointer',
-                    active === i && 'bg-muted/40',
+                    'group block w-full cursor-pointer px-3 py-2.5 text-left transition-colors hover:bg-muted/60',
+                    i !== drafts.length - 1 && 'border-b border-border/40',
+                    active === i && 'bg-muted/60',
                   )}
                 >
-                  <div className="text-[12.5px] font-medium truncate">{d.name || 'Untitled'}</div>
-                  <div className="text-[10.5px] text-muted-foreground/45 truncate mt-0.5">
+                  <div className="truncate text-sm font-medium text-foreground">
+                    {d.name || 'Untitled'}
+                  </div>
+                  <div className="mt-0.5 truncate text-xs text-muted-foreground/55">
                     {summarise(d.body_md)}
                   </div>
                 </button>
               ))}
             </div>
-            <div className="flex-1 min-w-0 flex flex-col">
+            <div className="flex min-w-0 flex-1 flex-col bg-background">
               {active === null ? (
-                <div className="flex-1 flex items-center justify-center text-[12px] text-muted-foreground/45">
+                <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground/60">
                   Select a template to edit, or add a new one.
                 </div>
               ) : (
                 <>
-                  <div className="flex items-center gap-2 px-3 py-2 border-b border-border/30">
+                  <div className="group flex items-center gap-2 border-b border-border/40 px-3 py-2">
                     <input
                       value={drafts[active].name}
                       onChange={(e) => patchAt(active, { name: e.target.value })}
                       placeholder="Name (e.g. Bug)"
-                      className="h-7 flex-1 text-[12.5px] bg-transparent border-0 outline-none focus:ring-0 placeholder:text-muted-foreground/30 font-medium"
+                      className="h-8 flex-1 rounded-lg border-0 bg-transparent px-2 text-sm font-semibold outline-none placeholder:text-muted-foreground/40 focus:bg-muted/40 focus:ring-2 focus:ring-ring/20"
                     />
-                    <Button
-                      variant="ghost" size="sm"
-                      className="h-6 w-6 p-0 text-muted-foreground/40 hover:text-destructive"
-                      onClick={() => removeAt(active)}
-                    >
-                      <Trash2 className="h-3 w-3" />
-                    </Button>
+                    <div className="opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100">
+                      <RowIconButton
+                        onClick={() => removeAt(active)}
+                        title="Delete template"
+                        icon={<Trash2 className="size-3.5" />}
+                        destructive
+                      />
+                    </div>
                   </div>
                   <textarea
                     value={drafts[active].body_md}
                     onChange={(e) => patchAt(active, { body_md: e.target.value })}
                     rows={14}
-                    className="flex-1 text-[12px] font-mono bg-transparent border-0 outline-none focus:ring-0 resize-none px-3 py-2.5 leading-[1.7] placeholder:text-muted-foreground/30"
+                    className="flex-1 resize-none border-0 bg-transparent px-3 py-2.5 text-sm leading-relaxed outline-none placeholder:text-muted-foreground/40 focus:ring-0"
                     placeholder="Markdown body…"
                   />
                 </>
@@ -630,20 +719,16 @@ function summarise(body: string): string {
   return clean.length > 40 ? `${clean.slice(0, 40)}…` : clean;
 }
 
-// ═══════════════════════════════════════════════════════════════════════════
-// Save row
-// ═══════════════════════════════════════════════════════════════════════════
-
 function SaveRow({ disabled, submitting, onSave }: { disabled: boolean; submitting: boolean; onSave: () => void }) {
   return (
-    <div className="mt-3 flex items-center justify-end gap-2">
+    <div className="mt-4 flex items-center justify-end">
       <Button
         size="sm"
-        className="h-7 px-3 text-[12px] gap-1"
         disabled={disabled || submitting}
         onClick={onSave}
+        className="gap-1.5"
       >
-        {submitting ? <Loader2 className="h-3 w-3 animate-spin" /> : <Save className="h-3 w-3" />}
+        {submitting ? <Loader2 className="size-3.5 animate-spin" /> : <Save className="size-3.5" />}
         {disabled ? 'Saved' : 'Save changes'}
       </Button>
     </div>

--- a/apps/web/src/components/kortix/trigger-detail-dialog.tsx
+++ b/apps/web/src/components/kortix/trigger-detail-dialog.tsx
@@ -1,0 +1,578 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  DialogDescription,
+} from '@/components/ui/dialog';
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { cn } from '@/lib/utils';
+import {
+  X,
+  Trash2,
+  Power,
+  PowerOff,
+  Play,
+  Loader2,
+  Sparkles,
+  Timer,
+  Webhook,
+  CheckCircle2,
+  XCircle,
+  AlertTriangle,
+  SkipForward,
+  Clock,
+  ExternalLink,
+  Copy,
+  Check,
+} from 'lucide-react';
+import {
+  useUpdateTrigger,
+  useDeleteTrigger,
+  useToggleTrigger,
+  useRunTrigger,
+  useTriggerExecutions,
+  type Trigger,
+  type Execution,
+  type ExecutionStatus,
+  type SessionMode,
+} from '@/hooks/scheduled-tasks';
+import { useSandbox } from '@/hooks/platform/use-sandbox';
+import { getSandboxUrl } from '@/lib/platform-client';
+import { AgentSelector } from '@/components/session/session-chat-input';
+import { useVisibleAgents } from '@/hooks/opencode/use-opencode-sessions';
+
+const TIMEZONES = [
+  'UTC',
+  'America/New_York',
+  'America/Chicago',
+  'America/Denver',
+  'America/Los_Angeles',
+  'Europe/London',
+  'Europe/Berlin',
+  'Europe/Paris',
+  'Asia/Tokyo',
+  'Asia/Shanghai',
+  'Asia/Kolkata',
+  'Australia/Sydney',
+];
+
+const TRIGGER_CLS = cn(
+  'data-[state=active]:shadow-none',
+  'data-[state=active]:ring-0',
+  'data-[state=active]:bg-background data-[state=active]:text-foreground',
+  'data-[state=active]:border-border/60',
+);
+
+export function TriggerDetailDialog({
+  trigger,
+  open,
+  onClose,
+}: {
+  trigger: Trigger | null;
+  open: boolean;
+  onClose: () => void;
+}) {
+  return (
+    <Dialog open={open} onOpenChange={(o) => { if (!o) onClose(); }}>
+      <DialogContent
+        className="p-0 overflow-hidden gap-0 sm:max-w-2xl h-[80vh] flex flex-col [&>button:last-child]:hidden"
+      >
+        <DialogTitle className="sr-only">{trigger?.name ?? 'Trigger'}</DialogTitle>
+        <DialogDescription className="sr-only">
+          Trigger settings, schedule, and execution history.
+        </DialogDescription>
+        {trigger && <TriggerEditor trigger={trigger} onClose={onClose} />}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function TriggerEditor({ trigger, onClose }: { trigger: Trigger; onClose: () => void }) {
+  const router = useRouter();
+  const { sandbox } = useSandbox();
+  const webhookBaseUrl = useMemo(() => {
+    try { if (sandbox) return getSandboxUrl(sandbox); } catch {}
+    return 'https://<sandbox-url>';
+  }, [sandbox]);
+
+  const [tab, setTab] = useState<'settings' | 'executions'>('settings');
+  const [name, setName] = useState(trigger.name);
+  const [cronExpr, setCronExpr] = useState(trigger.cronExpr || '');
+  const [timezone, setTimezone] = useState(trigger.timezone || 'UTC');
+  const [prompt, setPrompt] = useState(trigger.prompt);
+  const [sessionMode, setSessionMode] = useState<SessionMode>(trigger.sessionMode as SessionMode);
+  const [agentName, setAgentName] = useState<string | null>(trigger.agentName || null);
+  const [webhookPath, setWebhookPath] = useState(trigger.webhook?.path || '');
+  const [isDirty, setIsDirty] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+
+  const updateMutation = useUpdateTrigger();
+  const deleteMutation = useDeleteTrigger();
+  const toggleMutation = useToggleTrigger();
+  const runMutation = useRunTrigger();
+
+  const agents = useVisibleAgents();
+  const { data: executions = [] } = useTriggerExecutions(
+    tab === 'executions' && trigger.triggerId ? trigger.triggerId : '',
+  );
+
+  useEffect(() => {
+    setName(trigger.name);
+    setCronExpr(trigger.cronExpr || '');
+    setTimezone(trigger.timezone || 'UTC');
+    setPrompt(trigger.prompt);
+    setSessionMode(trigger.sessionMode as SessionMode);
+    setAgentName(trigger.agentName || null);
+    setWebhookPath(trigger.webhook?.path || '');
+    setIsDirty(false);
+    setConfirmDelete(false);
+  }, [trigger.id]);
+
+  const markDirty = () => setIsDirty(true);
+
+  const handleSave = async () => {
+    if (!trigger.triggerId) return;
+    try {
+      const data: any = { name, session_mode: sessionMode, agent_name: agentName || null };
+      if (trigger.type === 'cron') {
+        data.cron_expr = cronExpr;
+        data.timezone = timezone;
+      }
+      if (trigger.type === 'webhook') {
+        data.source = { path: webhookPath };
+      }
+      if (trigger.action_type === 'prompt' || !trigger.action_type) {
+        data.prompt = prompt;
+      }
+      await updateMutation.mutateAsync({ id: trigger.triggerId, data });
+      toast.success('Trigger updated');
+      setIsDirty(false);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to update');
+    }
+  };
+
+  const handleToggle = async () => {
+    if (!trigger.triggerId) return;
+    try {
+      await toggleMutation.mutateAsync({ id: trigger.triggerId, isActive: !trigger.isActive });
+      toast.success(trigger.isActive ? 'Trigger paused' : 'Trigger resumed');
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to toggle');
+    }
+  };
+
+  const handleRun = async () => {
+    if (!trigger.triggerId) return;
+    try {
+      await runMutation.mutateAsync(trigger.triggerId);
+      toast.success('Trigger fired');
+      setTab('executions');
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to run');
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!trigger.triggerId) return;
+    try {
+      await deleteMutation.mutateAsync(trigger.triggerId);
+      toast.success('Trigger deleted');
+      onClose();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to delete');
+    }
+  };
+
+  const isPromptAction = trigger.action_type === 'prompt' || !trigger.action_type;
+  const isCron = trigger.type === 'cron';
+  const TypeIcon = isCron ? Timer : Webhook;
+  const anyPending = updateMutation.isPending || deleteMutation.isPending || toggleMutation.isPending || runMutation.isPending;
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex items-center gap-2 px-5 pt-4 shrink-0">
+        <Sparkles className="size-3.5 text-muted-foreground/50" />
+        <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+          {isCron ? 'Cron trigger' : 'Webhook'}
+        </span>
+        <span className="text-muted-foreground/30">·</span>
+        <span className={cn(
+          'inline-flex h-5 items-center rounded-md px-1.5 text-[10px] font-medium uppercase tracking-[0.06em]',
+          trigger.isActive
+            ? 'bg-emerald-500/10 text-emerald-500/90'
+            : 'bg-muted/60 text-muted-foreground/80',
+        )}>
+          {trigger.isActive ? 'Active' : 'Paused'}
+        </span>
+        <Button
+          variant="ghost"
+          size="icon-xs"
+          onClick={onClose}
+          className="ml-auto text-muted-foreground hover:text-foreground"
+          aria-label="Close"
+        >
+          <X />
+        </Button>
+      </div>
+
+      <div className="flex items-start gap-3 px-5 pt-3 shrink-0">
+        <div className="mt-0.5 inline-flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground/70">
+          <TypeIcon className="size-4" />
+        </div>
+        <textarea
+          value={name}
+          onChange={(e) => { setName(e.target.value); markDirty(); }}
+          placeholder="Trigger name"
+          rows={1}
+          maxLength={120}
+          className="w-full resize-none overflow-hidden border-0 bg-transparent pt-px text-lg font-semibold leading-tight tracking-tight outline-none placeholder:text-muted-foreground/30 focus:ring-0"
+        />
+      </div>
+
+      <div className="px-5 pt-4 shrink-0">
+        <Tabs value={tab} onValueChange={(v) => setTab(v as 'settings' | 'executions')}>
+          <TabsList>
+            <TabsTrigger value="settings" className={cn('flex-none px-3', TRIGGER_CLS)}>
+              Settings
+            </TabsTrigger>
+            <TabsTrigger value="executions" className={cn('flex-none px-3', TRIGGER_CLS)}>
+              Executions
+            </TabsTrigger>
+          </TabsList>
+        </Tabs>
+      </div>
+
+      <div className="flex-1 min-h-0 overflow-y-auto px-5 py-4">
+        {tab === 'settings' ? (
+          <div className="space-y-5">
+            {isCron ? (
+              <>
+                <Field label="Schedule" hint="6-field cron: second minute hour day month weekday">
+                  <Input
+                    value={cronExpr}
+                    onChange={(e) => { setCronExpr(e.target.value); markDirty(); }}
+                    placeholder="0 0 * * * *"
+                  />
+                </Field>
+
+                <Field label="Timezone">
+                  <Select value={timezone} onValueChange={(v) => { setTimezone(v); markDirty(); }}>
+                    <SelectTrigger className="w-full">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {TIMEZONES.map((tz) => (
+                        <SelectItem key={tz} value={tz}>{tz}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </Field>
+              </>
+            ) : (
+              <>
+                <Field label="Path">
+                  <Input
+                    value={webhookPath}
+                    onChange={(e) => { setWebhookPath(e.target.value); markDirty(); }}
+                    placeholder="/hooks/my-endpoint"
+                  />
+                </Field>
+
+                <WebhookUrlBlock
+                  url={`${webhookBaseUrl}${trigger.webhook?.path || webhookPath || '/hooks/...'}`}
+                  secretProtected={trigger.webhook?.secretProtected}
+                />
+              </>
+            )}
+
+            {isPromptAction && (
+              <Field label="Prompt" hint="Sent to the agent each time the trigger fires.">
+                <Textarea
+                  value={prompt}
+                  onChange={(e) => { setPrompt(e.target.value); markDirty(); }}
+                  placeholder="The instruction sent to your agent…"
+                  rows={5}
+                  className="resize-y text-sm leading-relaxed"
+                />
+              </Field>
+            )}
+
+            {isPromptAction && (
+              <div className="grid grid-cols-2 gap-4">
+                <Field label="Session mode">
+                  <Select
+                    value={sessionMode}
+                    onValueChange={(v) => { setSessionMode(v as SessionMode); markDirty(); }}
+                  >
+                    <SelectTrigger className="w-full">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="new">New session each fire</SelectItem>
+                      <SelectItem value="reuse">Reuse session</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </Field>
+
+                <Field label="Agent">
+                  <div className="rounded-lg border border-input bg-transparent px-2 py-1">
+                    <AgentSelector
+                      agents={agents}
+                      selectedAgent={agentName}
+                      onSelect={(next) => { setAgentName(next); markDirty(); }}
+                    />
+                  </div>
+                </Field>
+              </div>
+            )}
+
+            <InfoGrid trigger={trigger} />
+          </div>
+        ) : (
+          <ExecutionsList
+            executions={executions}
+            onOpenSession={(sid) => router.push(`/sessions/${sid}`)}
+          />
+        )}
+      </div>
+
+      <div className="flex items-center gap-2 border-t border-border/40 px-5 py-3 shrink-0">
+        {confirmDelete ? (
+          <>
+            <Button size="sm" variant="ghost" onClick={() => setConfirmDelete(false)} disabled={anyPending}>
+              Cancel
+            </Button>
+            <Button size="sm" variant="destructive" onClick={handleDelete} disabled={anyPending} className="gap-1.5">
+              {deleteMutation.isPending ? <Loader2 className="size-3.5 animate-spin" /> : <Trash2 className="size-3.5" />}
+              Confirm delete
+            </Button>
+          </>
+        ) : (
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={() => setConfirmDelete(true)}
+            disabled={!trigger.triggerId || anyPending}
+            className="gap-1.5 text-muted-foreground/60 hover:text-destructive"
+          >
+            <Trash2 className="size-3.5" />
+            Delete
+          </Button>
+        )}
+
+        <div className="ml-auto flex items-center gap-2">
+          {trigger.triggerId && trigger.type === 'cron' && (
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={handleToggle}
+              disabled={anyPending}
+              className="gap-1.5 text-muted-foreground hover:text-foreground"
+            >
+              {trigger.isActive ? <PowerOff className="size-3.5" /> : <Power className="size-3.5" />}
+              {trigger.isActive ? 'Pause' : 'Resume'}
+            </Button>
+          )}
+          {trigger.triggerId && (
+            <Button size="sm" variant="outline" onClick={handleRun} disabled={anyPending} className="gap-1.5">
+              {runMutation.isPending ? <Loader2 className="size-3.5 animate-spin" /> : <Play className="size-3.5" />}
+              Run now
+            </Button>
+          )}
+          {isDirty && (
+            <Button size="sm" onClick={handleSave} disabled={anyPending}>
+              {updateMutation.isPending && <Loader2 className="size-3.5 animate-spin" />}
+              Save changes
+            </Button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Field({
+  label,
+  hint,
+  children,
+}: {
+  label: string;
+  hint?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="space-y-1.5">
+      <label className="text-xs font-medium text-muted-foreground">{label}</label>
+      {children}
+      {hint && <p className="text-[11px] text-muted-foreground/55">{hint}</p>}
+    </div>
+  );
+}
+
+function InfoGrid({ trigger }: { trigger: Trigger }) {
+  const rows: Array<[string, string]> = [
+    ['Type', `${trigger.type} → ${trigger.action_type ?? 'prompt'}`],
+    ['Next run', trigger.type === 'cron'
+      ? (trigger.isActive ? formatDateTime(trigger.nextRunAt) : 'Paused')
+      : 'On demand',
+    ],
+    ['Last run', formatDateTime(trigger.lastRunAt)],
+  ];
+  if (trigger.action_type === 'prompt' || !trigger.action_type) {
+    rows.push(['Model', trigger.modelId || 'Default (Sonnet)']);
+    rows.push(['Agent', trigger.agentName || 'Default']);
+  }
+  rows.push(['Created', new Date(trigger.createdAt).toLocaleDateString()]);
+
+  return (
+    <div className="overflow-hidden rounded-xl bg-muted/30">
+      {rows.map(([k, v], i) => (
+        <div
+          key={k}
+          className={cn(
+            'flex items-center justify-between gap-3 px-3 py-2 text-xs',
+            i !== rows.length - 1 && 'border-b border-border/40',
+          )}
+        >
+          <span className="text-muted-foreground/70">{k}</span>
+          <span className="truncate font-medium tabular-nums text-foreground">{v}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function WebhookUrlBlock({ url, secretProtected }: { url: string; secretProtected?: boolean }) {
+  const [copied, setCopied] = useState(false);
+  const copy = () => {
+    navigator.clipboard.writeText(url).catch(() => {});
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1200);
+  };
+  return (
+    <div className="overflow-hidden rounded-xl bg-muted/30">
+      <div className="flex items-center justify-between border-b border-border/40 px-3 py-1.5">
+        <span className="text-[10px] font-semibold uppercase tracking-[0.08em] text-muted-foreground/70">
+          Endpoint
+        </span>
+        <div className="flex items-center gap-1.5">
+          {secretProtected && (
+            <span className="text-[10px] uppercase tracking-[0.06em] text-emerald-500/80">
+              secret-protected
+            </span>
+          )}
+          <button
+            type="button"
+            onClick={copy}
+            className="inline-flex size-5 items-center justify-center rounded text-muted-foreground/55 hover:bg-muted hover:text-foreground"
+            aria-label="Copy URL"
+            title="Copy URL"
+          >
+            {copied ? <Check className="size-3 text-emerald-500" /> : <Copy className="size-3" />}
+          </button>
+        </div>
+      </div>
+      <span className="block break-all px-3 py-2 text-xs leading-relaxed text-foreground/85">
+        {url}
+      </span>
+    </div>
+  );
+}
+
+function ExecutionsList({
+  executions,
+  onOpenSession,
+}: {
+  executions: Execution[];
+  onOpenSession: (sessionId: string) => void;
+}) {
+  if (executions.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-16 text-center">
+        <Clock className="size-6 text-muted-foreground/40" />
+        <p className="mt-3 text-sm font-medium text-foreground">No executions yet</p>
+        <p className="mt-1 text-xs text-muted-foreground/65">
+          Once this trigger fires, runs will appear here.
+        </p>
+      </div>
+    );
+  }
+  return (
+    <ul className="overflow-hidden rounded-xl bg-muted/30">
+      {executions.map((e, i) => (
+        <li
+          key={e.executionId}
+          className={cn(
+            'group flex items-center gap-3 px-3 py-2.5 transition-colors hover:bg-muted/60',
+            i !== executions.length - 1 && 'border-b border-border/40',
+            e.sessionId && 'cursor-pointer',
+          )}
+          onClick={() => { if (e.sessionId) onOpenSession(e.sessionId); }}
+        >
+          {statusIcon(e.status)}
+          <span className={cn('text-sm font-medium capitalize', statusColor(e.status))}>
+            {e.status}
+          </span>
+          {e.retryCount > 0 && (
+            <span className="text-xs text-muted-foreground/65">retry {e.retryCount}</span>
+          )}
+          <span className="ml-auto flex items-center gap-3 text-xs tabular-nums text-muted-foreground/65">
+            <span>{formatDuration(e.durationMs)}</span>
+            <span>{e.startedAt ? new Date(e.startedAt).toLocaleString(undefined, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' }) : '--'}</span>
+            {e.sessionId && <ExternalLink className="size-3 text-muted-foreground/40 transition-colors group-hover:text-foreground" />}
+          </span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function statusIcon(status: ExecutionStatus) {
+  switch (status) {
+    case 'completed': return <CheckCircle2 className="size-3.5 text-emerald-500" />;
+    case 'failed': return <XCircle className="size-3.5 text-red-500" />;
+    case 'timeout': return <AlertTriangle className="size-3.5 text-amber-500" />;
+    case 'skipped': return <SkipForward className="size-3.5 text-muted-foreground" />;
+    case 'running': return <Loader2 className="size-3.5 text-blue-500 animate-spin" />;
+    default: return <Clock className="size-3.5 text-muted-foreground" />;
+  }
+}
+
+function statusColor(status: ExecutionStatus): string {
+  switch (status) {
+    case 'completed': return 'text-emerald-600 dark:text-emerald-400';
+    case 'failed': return 'text-red-600 dark:text-red-400';
+    case 'timeout': return 'text-amber-600 dark:text-amber-400';
+    case 'skipped': return 'text-muted-foreground';
+    case 'running': return 'text-blue-600 dark:text-blue-400';
+    default: return 'text-muted-foreground';
+  }
+}
+
+function formatDuration(ms: number | null): string {
+  if (ms === null) return '--';
+  if (ms < 1000) return `${ms}ms`;
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
+  return `${(ms / 60_000).toFixed(1)}m`;
+}
+
+function formatDateTime(s: string | null): string {
+  if (!s) return 'Never';
+  return new Date(s).toLocaleString(undefined, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' });
+}

--- a/apps/web/src/components/kortix/triggers-tab.tsx
+++ b/apps/web/src/components/kortix/triggers-tab.tsx
@@ -12,7 +12,7 @@
 import React, { useMemo, useState } from 'react';
 import { useTriggers, useDeleteTrigger, type Trigger } from '@/hooks/scheduled-tasks';
 import { TaskConfigDialog } from '@/components/scheduled-tasks/task-config-dialog';
-import { TaskDetailPanel } from '@/components/scheduled-tasks/task-detail-panel';
+import { TriggerDetailDialog } from './trigger-detail-dialog';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Badge } from '@/components/ui/badge';
@@ -220,10 +220,8 @@ export function TriggersTab({ projectId }: Props) {
   };
 
   return (
-    <div className="h-full overflow-hidden flex">
-      {/* List */}
-      <div className="flex-1 overflow-y-auto">
-        <div className="container mx-auto max-w-4xl px-4 sm:px-6 py-6 space-y-4">
+    <div className="h-full overflow-y-auto">
+      <div className="mx-auto w-full max-w-3xl px-4 sm:px-6 py-8 space-y-4">
           <div className="flex items-center justify-between">
             <div>
               <h2 className="text-base font-semibold tracking-tight">Triggers</h2>
@@ -278,17 +276,14 @@ export function TriggersTab({ projectId }: Props) {
               />
             ))}
           </div>
-        </div>
       </div>
 
-      {/* Detail panel */}
-      {selected && (
-        <div className="w-[520px] shrink-0 border-l border-border/60 h-full overflow-y-auto bg-background">
-          <TaskDetailPanel trigger={selected} onClose={() => setSelected(null)} />
-        </div>
-      )}
+      <TriggerDetailDialog
+        trigger={selected}
+        open={!!selected}
+        onClose={() => setSelected(null)}
+      />
 
-      {/* Create dialog — stamps project_id */}
       <TaskConfigDialog
         open={showCreate}
         onOpenChange={setShowCreate}

--- a/apps/web/src/components/nav-main.tsx
+++ b/apps/web/src/components/nav-main.tsx
@@ -8,7 +8,7 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@/components/ui/collapsible"
-import { Kbd } from "@/components/ui/kbd"
+import { KbdShortcut } from "@/components/ui/kbd"
 import {
   SidebarGroup,
   SidebarGroupLabel,
@@ -67,9 +67,10 @@ export function NavMain({
                       {item.icon && <item.icon className="text-muted-foreground/50" />}
                       <span>{item.title}</span>
                       {item.shortcut && (
-                        <Kbd className="ml-auto bg-transparent text-muted-foreground/55 group-data-[collapsible=icon]:hidden">
-                          {item.shortcut}
-                        </Kbd>
+                        <KbdShortcut
+                          shortcut={item.shortcut}
+                          className="ml-auto group-data-[collapsible=icon]:hidden"
+                        />
                       )}
                     </Link>
                   ) : (
@@ -77,9 +78,10 @@ export function NavMain({
                       {item.icon && <item.icon className="text-muted-foreground/50" />}
                       <span>{item.title}</span>
                       {item.shortcut && (
-                        <Kbd className="ml-auto bg-transparent text-muted-foreground/55 group-data-[collapsible=icon]:hidden">
-                          {item.shortcut}
-                        </Kbd>
+                        <KbdShortcut
+                          shortcut={item.shortcut}
+                          className="ml-auto group-data-[collapsible=icon]:hidden"
+                        />
                       )}
                     </>
                   )}

--- a/apps/web/src/components/nav-main.tsx
+++ b/apps/web/src/components/nav-main.tsx
@@ -1,0 +1,136 @@
+"use client"
+
+import Link from "next/link"
+import { ChevronRight, type LucideIcon } from "lucide-react"
+
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible"
+import { Kbd } from "@/components/ui/kbd"
+import {
+  SidebarGroup,
+  SidebarGroupLabel,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarMenuSub,
+  SidebarMenuSubButton,
+  SidebarMenuSubItem,
+} from "@/components/ui/sidebar"
+
+export type NavMainItem = {
+  title: string
+  url?: string
+  icon?: LucideIcon
+  isActive?: boolean
+  shortcut?: string
+  onAction?: () => void
+  items?: {
+    title: string
+    url: string
+    isActive?: boolean
+    leading?: React.ReactNode
+  }[]
+  /**
+   * Optional escape hatch for items whose collapsible body isn't a static
+   * list — e.g. Sessions, which renders its own data-driven component.
+   * If provided, the item is rendered as a collapsible and `renderContent`
+   * is shown inside <CollapsibleContent> instead of the `items` list.
+   */
+  renderContent?: () => React.ReactNode
+}
+
+export function NavMain({
+  items,
+  label = "Platform",
+}: {
+  items: NavMainItem[]
+  label?: string
+}) {
+  return (
+    <SidebarGroup>
+      <SidebarGroupLabel>{label}</SidebarGroupLabel>
+      <SidebarMenu>
+        {items.map((item) => {
+          const hasSubItems = !!item.items?.length
+          const hasCustomContent = !!item.renderContent
+          const isCollapsible = hasSubItems || hasCustomContent
+
+          if (!isCollapsible) {
+            return (
+              <SidebarMenuItem key={item.title}>
+                <SidebarMenuButton
+                  tooltip={item.shortcut ? `${item.title} ${item.shortcut}` : item.title}
+                  isActive={item.isActive}
+                  asChild={!!item.url}
+                  onClick={item.onAction}
+                >
+                  {item.url ? (
+                    <Link href={item.url}>
+                      {item.icon && <item.icon />}
+                      <span>{item.title}</span>
+                      {item.shortcut && (
+                        <Kbd className="ml-auto bg-transparent text-muted-foreground/55 group-data-[collapsible=icon]:hidden">
+                          {item.shortcut}
+                        </Kbd>
+                      )}
+                    </Link>
+                  ) : (
+                    <>
+                      {item.icon && <item.icon />}
+                      <span>{item.title}</span>
+                      {item.shortcut && (
+                        <Kbd className="ml-auto bg-transparent text-muted-foreground/55 group-data-[collapsible=icon]:hidden">
+                          {item.shortcut}
+                        </Kbd>
+                      )}
+                    </>
+                  )}
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+            )
+          }
+
+          return (
+            <Collapsible
+              key={item.title}
+              asChild
+              defaultOpen={item.isActive}
+              className="group/collapsible"
+            >
+              <SidebarMenuItem>
+                <CollapsibleTrigger asChild>
+                  <SidebarMenuButton tooltip={item.title}>
+                    {item.icon && <item.icon />}
+                    <span>{item.title}</span>
+                    <ChevronRight className="ml-auto transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90" />
+                  </SidebarMenuButton>
+                </CollapsibleTrigger>
+                <CollapsibleContent>
+                  {hasCustomContent ? (
+                    item.renderContent!()
+                  ) : (
+                    <SidebarMenuSub>
+                      {item.items?.map((subItem) => (
+                        <SidebarMenuSubItem key={subItem.title}>
+                          <SidebarMenuSubButton asChild isActive={subItem.isActive}>
+                            <Link href={subItem.url}>
+                              {subItem.leading}
+                              <span className="truncate">{subItem.title}</span>
+                            </Link>
+                          </SidebarMenuSubButton>
+                        </SidebarMenuSubItem>
+                      ))}
+                    </SidebarMenuSub>
+                  )}
+                </CollapsibleContent>
+              </SidebarMenuItem>
+            </Collapsible>
+          )
+        })}
+      </SidebarMenu>
+    </SidebarGroup>
+  )
+}

--- a/apps/web/src/components/nav-main.tsx
+++ b/apps/web/src/components/nav-main.tsx
@@ -33,12 +33,6 @@ export type NavMainItem = {
     isActive?: boolean
     leading?: React.ReactNode
   }[]
-  /**
-   * Optional escape hatch for items whose collapsible body isn't a static
-   * list — e.g. Sessions, which renders its own data-driven component.
-   * If provided, the item is rendered as a collapsible and `renderContent`
-   * is shown inside <CollapsibleContent> instead of the `items` list.
-   */
   renderContent?: () => React.ReactNode
 }
 
@@ -66,10 +60,11 @@ export function NavMain({
                   isActive={item.isActive}
                   asChild={!!item.url}
                   onClick={item.onAction}
+                  className="font-medium text-primary"
                 >
                   {item.url ? (
                     <Link href={item.url}>
-                      {item.icon && <item.icon />}
+                      {item.icon && <item.icon className="text-muted-foreground/50" />}
                       <span>{item.title}</span>
                       {item.shortcut && (
                         <Kbd className="ml-auto bg-transparent text-muted-foreground/55 group-data-[collapsible=icon]:hidden">
@@ -79,7 +74,7 @@ export function NavMain({
                     </Link>
                   ) : (
                     <>
-                      {item.icon && <item.icon />}
+                      {item.icon && <item.icon className="text-muted-foreground/50" />}
                       <span>{item.title}</span>
                       {item.shortcut && (
                         <Kbd className="ml-auto bg-transparent text-muted-foreground/55 group-data-[collapsible=icon]:hidden">
@@ -103,8 +98,8 @@ export function NavMain({
               <SidebarMenuItem>
                 <CollapsibleTrigger asChild>
                   <SidebarMenuButton tooltip={item.title}>
-                    {item.icon && <item.icon />}
-                    <span>{item.title}</span>
+                    {item.icon && <item.icon className="text-muted-foreground/50" />}
+                    <span className="font-medium text-primary">{item.title}</span>
                     <ChevronRight className="ml-auto transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90" />
                   </SidebarMenuButton>
                 </CollapsibleTrigger>

--- a/apps/web/src/components/nav-projects.tsx
+++ b/apps/web/src/components/nav-projects.tsx
@@ -64,7 +64,7 @@ export function NavProjects({
 
         {projects.map((item) => (
           <SidebarMenuItem key={item.id}>
-            <SidebarMenuButton asChild isActive={item.isActive}>
+            <SidebarMenuButton asChild isActive={item.isActive} className="font-medium text-primary">
               <Link href={item.url}>
                 {item.leading ?? <Folder />}
                 <span className="truncate">{item.name}</span>

--- a/apps/web/src/components/nav-projects.tsx
+++ b/apps/web/src/components/nav-projects.tsx
@@ -1,0 +1,120 @@
+"use client"
+
+import Link from "next/link"
+import {
+  Folder,
+  Forward,
+  MoreHorizontal,
+  Trash2,
+} from "lucide-react"
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import {
+  SidebarGroup,
+  SidebarGroupLabel,
+  SidebarMenu,
+  SidebarMenuAction,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  useSidebar,
+} from "@/components/ui/sidebar"
+
+export type NavProjectItem = {
+  id: string
+  name: string
+  url: string
+  isActive?: boolean
+  /** Custom leading element — usually a colored project avatar/icon. */
+  leading?: React.ReactNode
+  onView?: () => void
+  onShare?: () => void
+  onDelete?: () => void
+}
+
+export function NavProjects({
+  projects,
+  label = "Projects",
+  emptyState,
+  footer,
+}: {
+  projects: NavProjectItem[]
+  label?: string
+  emptyState?: React.ReactNode
+  footer?: React.ReactNode
+}) {
+  const { isMobile } = useSidebar()
+
+  return (
+    <SidebarGroup className="group-data-[collapsible=icon]:hidden">
+      <SidebarGroupLabel>{label}</SidebarGroupLabel>
+      <SidebarMenu>
+        {projects.length === 0 && emptyState && (
+          <SidebarMenuItem>
+            <div className="px-2 py-1.5 text-xs text-muted-foreground/65">
+              {emptyState}
+            </div>
+          </SidebarMenuItem>
+        )}
+
+        {projects.map((item) => (
+          <SidebarMenuItem key={item.id}>
+            <SidebarMenuButton asChild isActive={item.isActive}>
+              <Link href={item.url}>
+                {item.leading ?? <Folder />}
+                <span className="truncate">{item.name}</span>
+              </Link>
+            </SidebarMenuButton>
+            {(item.onView || item.onShare || item.onDelete) && (
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <SidebarMenuAction showOnHover>
+                    <MoreHorizontal />
+                    <span className="sr-only">More</span>
+                  </SidebarMenuAction>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent
+                  className="w-48 rounded-lg"
+                  side={isMobile ? "bottom" : "right"}
+                  align={isMobile ? "end" : "start"}
+                >
+                  {item.onView && (
+                    <DropdownMenuItem onClick={item.onView}>
+                      <Folder className="text-muted-foreground" />
+                      <span>View project</span>
+                    </DropdownMenuItem>
+                  )}
+                  {item.onShare && (
+                    <DropdownMenuItem onClick={item.onShare}>
+                      <Forward className="text-muted-foreground" />
+                      <span>Share project</span>
+                    </DropdownMenuItem>
+                  )}
+                  {item.onDelete && (
+                    <>
+                      <DropdownMenuSeparator />
+                      <DropdownMenuItem
+                        onClick={item.onDelete}
+                        className="text-destructive focus:text-destructive"
+                      >
+                        <Trash2 />
+                        <span>Delete project</span>
+                      </DropdownMenuItem>
+                    </>
+                  )}
+                </DropdownMenuContent>
+              </DropdownMenu>
+            )}
+          </SidebarMenuItem>
+        ))}
+
+        {footer && <SidebarMenuItem>{footer}</SidebarMenuItem>}
+      </SidebarMenu>
+    </SidebarGroup>
+  )
+}

--- a/apps/web/src/components/nav-user.tsx
+++ b/apps/web/src/components/nav-user.tsx
@@ -1,0 +1,122 @@
+"use client"
+
+import { useRouter } from "next/navigation"
+import {
+  BadgeCheck,
+  Bell,
+  ChevronsUpDown,
+  CreditCard,
+  LogOut,
+} from "lucide-react"
+
+import {
+  Avatar,
+  AvatarFallback,
+  AvatarImage,
+} from "@/components/ui/avatar"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import {
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  useSidebar,
+} from "@/components/ui/sidebar"
+import { createClient } from "@/lib/supabase/client"
+import { useUserSettingsModalStore } from "@/stores/user-settings-modal-store"
+
+export function NavUser({
+  user,
+}: {
+  user: {
+    name: string
+    email: string
+    avatar: string
+  }
+}) {
+  const { isMobile } = useSidebar()
+  const router = useRouter()
+  const openUserSettings = useUserSettingsModalStore((s) => s.openUserSettings)
+
+  const initials = (user.name || "U").slice(0, 1).toUpperCase()
+
+  const onSignOut = async () => {
+    try {
+      await createClient().auth.signOut()
+    } catch {
+      /* fall through to redirect */
+    }
+    router.push("/auth")
+  }
+
+  return (
+    <SidebarMenu>
+      <SidebarMenuItem>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <SidebarMenuButton
+              size="lg"
+              className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
+            >
+              <Avatar className="h-8 w-8 rounded-lg">
+                <AvatarImage src={user.avatar} alt={user.name} />
+                <AvatarFallback className="rounded-lg">{initials}</AvatarFallback>
+              </Avatar>
+              <div className="grid flex-1 text-left text-sm leading-tight">
+                <span className="truncate font-medium">{user.name}</span>
+                <span className="truncate text-xs">{user.email}</span>
+              </div>
+              <ChevronsUpDown className="ml-auto size-4" />
+            </SidebarMenuButton>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent
+            className="w-(--radix-dropdown-menu-trigger-width) min-w-56 rounded-lg"
+            side={isMobile ? "bottom" : "right"}
+            align="end"
+            sideOffset={4}
+          >
+            <DropdownMenuLabel className="p-0 font-normal">
+              <div className="flex items-center gap-2 px-1 py-1.5 text-left text-sm">
+                <Avatar className="h-8 w-8 rounded-lg">
+                  <AvatarImage src={user.avatar} alt={user.name} />
+                  <AvatarFallback className="rounded-lg">{initials}</AvatarFallback>
+                </Avatar>
+                <div className="grid flex-1 text-left text-sm leading-tight">
+                  <span className="truncate font-medium">{user.name}</span>
+                  <span className="truncate text-xs">{user.email}</span>
+                </div>
+              </div>
+            </DropdownMenuLabel>
+            <DropdownMenuSeparator />
+            <DropdownMenuGroup>
+              <DropdownMenuItem onClick={() => openUserSettings({ tab: "general" })}>
+                <BadgeCheck />
+                Account
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => openUserSettings({ tab: "billing" })}>
+                <CreditCard />
+                Billing
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => openUserSettings({ tab: "notifications" })}>
+                <Bell />
+                Notifications
+              </DropdownMenuItem>
+            </DropdownMenuGroup>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onClick={onSignOut}>
+              <LogOut />
+              Log out
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </SidebarMenuItem>
+    </SidebarMenu>
+  )
+}

--- a/apps/web/src/components/settings/user-settings-modal.tsx
+++ b/apps/web/src/components/settings/user-settings-modal.tsx
@@ -286,62 +286,64 @@ export function UserSettingsModal({
                     /* Desktop Layout - Side by Side */
                     <div className="flex flex-row h-[700px]">
                         {/* Desktop Sidebar */}
-                        <div className="bg-background flex-shrink-0 w-56 p-4 border-r border-border">
-                            <div className="flex justify-start mb-3">
-                                <Button
-                                    variant="ghost"
-                                    size="icon"
-                                    className="h-8 w-8"
-                                    onClick={() => onOpenChange(false)}
-                                >
-                                    <X className="h-4 w-4" />
-                                </Button>
-                            </div>
+                        <div className="flex flex-col h-full p-2">
+                            <div className="bg-muted  rounded-xl flex-shrink-0 w-56 h-full p-2 border">
+                                <div className="flex justify-start mb-3">
+                                    <Button
+                                        variant="ghost"
+                                        size="icon"
+                                        className="h-8 w-8"
+                                        onClick={() => onOpenChange(false)}
+                                    >
+                                        <X className="h-4 w-4" />
+                                    </Button>
+                                </div>
 
-                            {/* Desktop Tabs - Grouped */}
-                            <div className="flex flex-col gap-4">
-                                {tabGroups.map((group, groupIdx) => (
-                                    <div key={group.skeleton ? `skeleton-${groupIdx}` : group.label}>
-                                        <div className="px-4 pb-1.5">
-                                            {group.skeleton ? (
-                                                <Skeleton className="h-3 w-20 rounded" />
-                                            ) : (
-                                                <span className="text-[11px] font-medium text-muted-foreground/70 uppercase tracking-wider">{group.label}</span>
-                                            )}
-                                        </div>
-                                        <div className="flex flex-col gap-0.5">
-                                            {group.skeleton ? (
-                                                <>
-                                                    <Skeleton className="mx-2 h-9 rounded-md" />
-                                                    <Skeleton className="mx-2 h-9 rounded-md" />
-                                                </>
-                                            ) : (
-                                                group.tabs.map((tab) => {
-                                                const Icon = tab.icon;
-                                                const isActive = activeTab === tab.id;
+                                {/* Desktop Tabs - Grouped */}
+                                <div className="flex flex-col gap-4">
+                                    {tabGroups.map((group, groupIdx) => (
+                                        <div key={group.skeleton ? `skeleton-${groupIdx}` : group.label}>
+                                            <div className="px-4 pb-1.5">
+                                                {group.skeleton ? (
+                                                    <Skeleton className="h-3 w-20 rounded" />
+                                                ) : (
+                                                    <span className="text-[11px] font-medium text-muted-foreground/70 uppercase tracking-wider">{group.label}</span>
+                                                )}
+                                            </div>
+                                            <div className="flex flex-col gap-0.5">
+                                                {group.skeleton ? (
+                                                    <>
+                                                        <Skeleton className="mx-2 h-9 rounded-md" />
+                                                        <Skeleton className="mx-2 h-9 rounded-md" />
+                                                    </>
+                                                ) : (
+                                                    group.tabs.map((tab) => {
+                                                    const Icon = tab.icon;
+                                                    const isActive = activeTab === tab.id;
 
-                                                return (
-                                                    <Button
-                                                        key={tab.id}
-                                                        onClick={() => handleTabClick(tab.id)}
-                                                        disabled={tab.disabled}
-                                                        variant="ghost"
-                                                        className={cn(
-                                                            "w-full flex items-center gap-3 justify-start",
-                                                            isActive
-                                                                ? "bg-accent text-foreground hover:bg-accent"
-                                                                : "text-muted-foreground hover:text-foreground"
-                                                        )}
-                                                    >
-                                                        <Icon className="h-4 w-4 flex-shrink-0" />
-                                                        <span>{tab.label}</span>
-                                                    </Button>
-                                                );
-                                                })
-                                            )}
+                                                    return (
+                                                        <Button
+                                                            key={tab.id}
+                                                            onClick={() => handleTabClick(tab.id)}
+                                                            disabled={tab.disabled}
+                                                            variant="ghost"
+                                                            className={cn(
+                                                                "w-full flex items-center gap-3 justify-start",
+                                                                isActive
+                                                                    ? "bg-accent text-foreground hover:bg-accent"
+                                                                    : "text-muted-foreground hover:text-foreground"
+                                                            )}
+                                                        >
+                                                            <Icon className="h-4 w-4 flex-shrink-0" />
+                                                            <span>{tab.label}</span>
+                                                        </Button>
+                                                    );
+                                                    })
+                                                )}
+                                            </div>
                                         </div>
-                                    </div>
-                                ))}
+                                    ))}
+                                </div>
                             </div>
                         </div>
 

--- a/apps/web/src/components/sidebar/new-sidebar-items.tsx
+++ b/apps/web/src/components/sidebar/new-sidebar-items.tsx
@@ -1,0 +1,236 @@
+'use client';
+
+import Link from 'next/link';
+import { ChevronDown, type LucideIcon } from 'lucide-react';
+import {
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarMenuSub,
+  SidebarMenuSubButton,
+  SidebarMenuSubItem,
+} from '@/components/ui/sidebar';
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible';
+import { Kbd } from '@/components/ui/kbd';
+import { cn } from '@/lib/utils';
+
+const ROW_BASE =
+  'h-9 rounded-lg text-sm font-medium transition-colors';
+const ROW_INACTIVE =
+  'text-muted-foreground/80 hover:bg-muted/50 hover:text-foreground';
+const ROW_ACTIVE =
+  'bg-muted text-foreground';
+
+const SUB_BASE = 'h-7 gap-2 rounded-md text-[13px] transition-colors';
+const SUB_INACTIVE = 'text-muted-foreground/80 hover:bg-muted/50 hover:text-foreground';
+const SUB_ACTIVE = 'bg-muted text-foreground font-medium';
+
+export function SidebarSectionLabel({ label }: { label: string }) {
+  return (
+    <div className="mb-1 mt-5 px-2 text-[10px] font-semibold uppercase tracking-[0.1em] text-muted-foreground/55 group-data-[collapsible=icon]:hidden">
+      {label}
+    </div>
+  );
+}
+
+export function SidebarActionItem({
+  icon: Icon,
+  label,
+  onClick,
+  kbd,
+  tooltip,
+  loading,
+  disabled,
+  loadingIcon,
+}: {
+  icon: LucideIcon;
+  label: string;
+  onClick: () => void;
+  kbd?: string;
+  tooltip?: string;
+  loading?: boolean;
+  disabled?: boolean;
+  loadingIcon?: React.ReactNode;
+}) {
+  return (
+    <SidebarMenuItem>
+      <SidebarMenuButton
+        tooltip={tooltip ?? `${label}${kbd ? ` ${kbd}` : ''}`}
+        disabled={disabled || loading}
+        onClick={onClick}
+        className={cn(ROW_BASE, ROW_INACTIVE, 'disabled:opacity-60')}
+      >
+        {loading && loadingIcon ? loadingIcon : <Icon />}
+        <span>{label}</span>
+        {kbd && (
+          <Kbd className="ml-auto bg-transparent text-muted-foreground/55 group-data-[collapsible=icon]:hidden">
+            {kbd}
+          </Kbd>
+        )}
+      </SidebarMenuButton>
+    </SidebarMenuItem>
+  );
+}
+
+export function SidebarLinkItem({
+  icon: Icon,
+  label,
+  href,
+  isActive,
+  kbd,
+  tooltip,
+}: {
+  icon: LucideIcon;
+  label: string;
+  href: string;
+  isActive?: boolean;
+  kbd?: string;
+  tooltip?: string;
+}) {
+  return (
+    <SidebarMenuItem>
+      <SidebarMenuButton
+        asChild
+        isActive={isActive}
+        tooltip={tooltip ?? label}
+        className={cn(ROW_BASE, isActive ? ROW_ACTIVE : ROW_INACTIVE)}
+      >
+        <Link href={href}>
+          <Icon />
+          <span>{label}</span>
+          {kbd && (
+            <Kbd className="ml-auto bg-transparent text-muted-foreground/55 group-data-[collapsible=icon]:hidden">
+              {kbd}
+            </Kbd>
+          )}
+        </Link>
+      </SidebarMenuButton>
+    </SidebarMenuItem>
+  );
+}
+
+type GroupId = 'projects' | 'sessions';
+
+const GROUP_VARIANT_CLASSES: Record<GroupId, { container: string; rotate: string }> = {
+  projects: {
+    container: 'group/projects',
+    rotate: 'group-data-[state=closed]/projects:-rotate-90',
+  },
+  sessions: {
+    container: 'group/sessions',
+    rotate: 'group-data-[state=closed]/sessions:-rotate-90',
+  },
+};
+
+export function SidebarCollapsibleGroup({
+  id,
+  icon: Icon,
+  label,
+  count,
+  defaultOpen = true,
+  isActive,
+  scrollable,
+  className,
+  children,
+}: {
+  id: GroupId;
+  icon: LucideIcon;
+  label: string;
+  count?: number;
+  defaultOpen?: boolean;
+  isActive?: boolean;
+  scrollable?: boolean;
+  className?: string;
+  children: React.ReactNode;
+}) {
+  const variant = GROUP_VARIANT_CLASSES[id];
+  return (
+    <Collapsible
+      defaultOpen={defaultOpen}
+      className={cn(
+        variant.container,
+        'mt-0.5 flex min-h-0 flex-col group-data-[collapsible=icon]:hidden',
+        className,
+      )}
+    >
+      <CollapsibleTrigger asChild>
+        <button
+          type="button"
+          className={cn(
+            'flex h-9 w-full items-center gap-2 rounded-lg px-2',
+            ROW_BASE,
+            isActive ? ROW_ACTIVE : ROW_INACTIVE,
+          )}
+        >
+          <Icon className="size-4" />
+          <span className="flex-1 text-left">{label}</span>
+          {typeof count === 'number' && count > 0 && (
+            <span className="rounded-md bg-muted/60 px-1.5 py-0.5 text-[10px] font-semibold tabular-nums text-muted-foreground/70">
+              {count}
+            </span>
+          )}
+          <ChevronDown
+            className={cn(
+              'size-3.5 text-muted-foreground/55 transition-transform duration-200',
+              variant.rotate,
+            )}
+          />
+        </button>
+      </CollapsibleTrigger>
+      <CollapsibleContent
+        className={cn(
+          'min-h-0 overflow-hidden',
+          scrollable &&
+            'data-[state=open]:max-h-[40vh] data-[state=open]:overflow-y-auto data-[state=open]:pt-1 [&::-webkit-scrollbar]:hidden',
+        )}
+      >
+        {children}
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}
+
+export function SidebarSubLink({
+  href,
+  isActive,
+  indicator,
+  label,
+}: {
+  href: string;
+  isActive?: boolean;
+  indicator?: React.ReactNode;
+  label: string;
+}) {
+  return (
+    <SidebarMenuSubItem>
+      <SidebarMenuSubButton
+        asChild
+        isActive={isActive}
+        className={cn(SUB_BASE, isActive ? SUB_ACTIVE : SUB_INACTIVE)}
+      >
+        <Link href={href}>
+          {indicator}
+          <span className="truncate">{label}</span>
+        </Link>
+      </SidebarMenuSubButton>
+    </SidebarMenuSubItem>
+  );
+}
+
+export function SidebarGroupBody({ children }: { children: React.ReactNode }) {
+  return (
+    <SidebarMenuSub className="mr-0 mt-0.5 border-l-border/40 pl-3">
+      {children}
+    </SidebarMenuSub>
+  );
+}
+
+export function SidebarGroupEmpty({ children }: { children: React.ReactNode }) {
+  return <li className="px-2 py-2 text-xs text-muted-foreground/60">{children}</li>;
+}
+
+export { SidebarMenu };

--- a/apps/web/src/components/sidebar/new-sidebar-left.tsx
+++ b/apps/web/src/components/sidebar/new-sidebar-left.tsx
@@ -1,0 +1,259 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname, useRouter } from 'next/navigation';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  FolderGit2,
+  MessageSquareText,
+  FolderOpen,
+  Search,
+  Sparkles,
+  PanelLeft,
+  PanelLeftClose,
+  Loader2,
+} from 'lucide-react';
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarHeader,
+  useSidebar,
+} from '@/components/ui/sidebar';
+import {
+  getCurrentInstanceIdFromPathname,
+  getActiveInstanceIdFromCookie,
+  toInstanceAwarePath,
+  normalizeAppPathname,
+} from '@/lib/instance-routes';
+import { createClient } from '@/lib/supabase/client';
+import { useAdminRole } from '@/hooks/admin';
+import { useKortixProjects, type KortixProject } from '@/hooks/kortix/use-kortix-projects';
+import { useCreateOpenCodeSession } from '@/hooks/opencode/use-opencode-sessions';
+import { ProjectIcon } from '@/components/kortix/project-icon';
+import { SessionList } from '@/components/sidebar/session-list';
+import { KortixLogo } from './kortix-logo';
+import { UserMenu } from './user-menu';
+import {
+  SidebarActionItem,
+  SidebarLinkItem,
+  SidebarCollapsibleGroup,
+  SidebarSubLink,
+  SidebarGroupBody,
+  SidebarGroupEmpty,
+  SidebarMenu,
+} from './new-sidebar-items';
+
+export function NewSidebarLeft({ ...props }: React.ComponentProps<typeof Sidebar>) {
+  const pathname = usePathname();
+  const router = useRouter();
+  const { state, toggleSidebar } = useSidebar();
+  const collapsed = state === 'collapsed';
+
+  const instanceId = useMemo(
+    () => getCurrentInstanceIdFromPathname(pathname) || getActiveInstanceIdFromCookie(),
+    [pathname],
+  );
+  const normalized = normalizeAppPathname(pathname);
+  const buildHref = useCallback(
+    (href: string) => toInstanceAwarePath(href, instanceId),
+    [instanceId],
+  );
+
+  const user = useUserDisplay();
+  const isMac = useIsMac();
+
+  const openCommandPalette = useCallback(() => {
+    document.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: 'k',
+        code: 'KeyK',
+        metaKey: isMac,
+        ctrlKey: !isMac,
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+  }, [isMac]);
+
+  const createSession = useCreateOpenCodeSession();
+  const handleNewSession = useCallback(async () => {
+    try {
+      const session = await createSession.mutateAsync();
+      router.push(buildHref(`/sessions/${session.id}`));
+      requestAnimationFrame(() => {
+        window.dispatchEvent(new CustomEvent('focus-session-textarea'));
+      });
+    } catch {
+      router.push(buildHref('/dashboard'));
+    }
+  }, [createSession, router, buildHref]);
+
+  const { data: projectsData } = useKortixProjects();
+  const projects = useMemo<KortixProject[]>(() => {
+    if (!projectsData || !Array.isArray(projectsData)) return [];
+    return [...projectsData].sort(
+      (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
+    );
+  }, [projectsData]);
+
+  const isFilesActive = normalized === '/files' || normalized.startsWith('/files/');
+  const isSessionsActive = normalized === '/sessions' || normalized.startsWith('/sessions/');
+  const isProjectsActive =
+    normalized === '/dashboard' || normalized === '/projects' || normalized.startsWith('/projects/');
+  const activeProjectId = useMemo(() => {
+    const m = normalized.match(/^\/projects\/([^/]+)/);
+    return m ? decodeURIComponent(m[1]) : null;
+  }, [normalized]);
+
+  return (
+    <Sidebar collapsible="icon" {...props}>
+      <SidebarHeader className="p-2">
+        <div className="flex h-8 items-center gap-2">
+          <Link
+            href={buildHref('/dashboard')}
+            className="flex min-w-0 flex-1 items-center gap-2 rounded-md px-1.5 transition-colors hover:bg-muted/60 group-data-[collapsible=icon]:hidden"
+            aria-label="Kortix home"
+          >
+            <KortixLogo size={14} variant="logomark" />
+          </Link>
+          <button
+            type="button"
+            onClick={toggleSidebar}
+            className="inline-flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground/60 transition-colors hover:bg-muted/60 hover:text-foreground group-data-[collapsible=icon]:mx-auto"
+            aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+            title={`${collapsed ? 'Expand' : 'Collapse'} sidebar (⌘B)`}
+          >
+            {collapsed ? <PanelLeft className="size-4" /> : <PanelLeftClose className="size-4" />}
+          </button>
+        </div>
+      </SidebarHeader>
+
+      <SidebarContent className="gap-0 px-2 pt-3">
+        <SidebarMenu>
+          <SidebarActionItem
+            icon={Search}
+            label="Search"
+            kbd="⌘K"
+            onClick={openCommandPalette}
+          />
+          <SidebarActionItem
+            icon={Sparkles}
+            label="New chat"
+            kbd="⌘J"
+            onClick={handleNewSession}
+            loading={createSession.isPending}
+            loadingIcon={<Loader2 className="animate-spin" />}
+          />
+        </SidebarMenu>
+
+        <SidebarMenu>
+          <SidebarLinkItem
+            icon={FolderOpen}
+            label="Files"
+            href={buildHref('/files')}
+            isActive={isFilesActive}
+          />
+        </SidebarMenu>
+
+        <SidebarCollapsibleGroup
+          id="projects"
+          icon={FolderGit2}
+          label="Projects"
+          count={projects.length}
+          defaultOpen
+          isActive={isProjectsActive}
+        >
+          <SidebarGroupBody>
+            {projects.length === 0 ? (
+              <SidebarGroupEmpty>No projects yet</SidebarGroupEmpty>
+            ) : (
+              projects.slice(0, 12).map((project) => (
+                <SidebarSubLink
+                  key={project.id}
+                  href={buildHref(`/projects/${encodeURIComponent(project.id)}`)}
+                  isActive={activeProjectId === project.id}
+                  indicator={<ProjectIcon project={project} size="xs" />}
+                  label={project.name}
+                />
+              ))
+            )}
+          </SidebarGroupBody>
+        </SidebarCollapsibleGroup>
+
+        <SidebarCollapsibleGroup
+          id="sessions"
+          icon={MessageSquareText}
+          label="Sessions"
+          defaultOpen={false}
+          isActive={isSessionsActive}
+          scrollable
+        >
+          <div className="ml-3 border-l border-border/40 pl-1">
+            <SessionList projectId={null} />
+          </div>
+        </SidebarCollapsibleGroup>
+
+        {/* Collapsed-rail fallback for the surfaces hidden behind groups */}
+        <SidebarMenu className="hidden group-data-[collapsible=icon]:flex">
+          <SidebarLinkItem
+            icon={FolderGit2}
+            label="Projects"
+            href={buildHref('/dashboard')}
+            isActive={isProjectsActive}
+          />
+          <SidebarLinkItem
+            icon={MessageSquareText}
+            label="Sessions"
+            href={buildHref('/sessions')}
+            isActive={isSessionsActive}
+          />
+        </SidebarMenu>
+      </SidebarContent>
+
+      <SidebarFooter className="p-2">
+        <UserMenu user={user} />
+      </SidebarFooter>
+    </Sidebar>
+  );
+}
+
+function useUserDisplay() {
+  const { data: adminRoleData } = useAdminRole();
+  const isAdmin = adminRoleData?.isAdmin ?? false;
+  const [user, setUser] = useState<{
+    name: string;
+    email: string;
+    avatar: string;
+    isAdmin?: boolean;
+  }>({ name: 'Loading…', email: '', avatar: '', isAdmin: false });
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const supabase = createClient();
+      const { data } = await supabase.auth.getUser();
+      if (cancelled || !data.user) return;
+      setUser({
+        name: data.user.user_metadata?.name || data.user.email?.split('@')[0] || 'User',
+        email: data.user.email || '',
+        avatar:
+          data.user.user_metadata?.avatar_url ||
+          data.user.user_metadata?.picture ||
+          '',
+        isAdmin,
+      });
+    })();
+    return () => { cancelled = true; };
+  }, [isAdmin]);
+
+  return user;
+}
+
+function useIsMac() {
+  const [isMac, setIsMac] = useState(false);
+  useEffect(() => {
+    setIsMac(/Mac/.test(navigator.userAgent));
+  }, []);
+  return isMac;
+}

--- a/apps/web/src/components/sidebar/sidebar-left.tsx
+++ b/apps/web/src/components/sidebar/sidebar-left.tsx
@@ -37,6 +37,8 @@ import { useUpdateDialogStore } from '@/stores/update-dialog-store';
 
 import { UserMenu } from '@/components/sidebar/user-menu';
 import { KortixLogo } from '@/components/sidebar/kortix-logo';
+import { ProjectIcon } from '@/components/kortix/project-icon';
+import { KbdShortcut } from '@/components/ui/kbd';
 import { ThreadIcon } from '@/components/sidebar/thread-icon';
 import {
   CurrentWorkspaceAvatar,
@@ -50,6 +52,12 @@ import {
   SidebarHeader,
   SidebarFooter,
   SidebarRail,
+  SidebarGroup,
+  SidebarGroupLabel,
+  SidebarMenu,
+  SidebarMenuItem,
+  SidebarMenuButton,
+  SidebarMenuAction,
   useSidebar,
 } from '@/components/ui/sidebar';
 import { Button } from '@/components/ui/button';
@@ -698,53 +706,24 @@ function SidebarSections() {
   };
 
   return (
-    <div className="flex flex-col min-h-0 flex-1 pt-0.5 space-y-0.5">
-      {/* Projects — primary, default open, takes remaining space */}
+    <div className="flex flex-col min-h-0 flex-1">
+      {/* Projects — NavProjects look (SidebarGroup + SidebarGroupLabel),
+          flex-1 so it absorbs the remaining height */}
       {sortedProjects.length > 0 && (
-        <Collapsible defaultOpen className="group/projects flex flex-col min-h-0 data-[state=open]:flex-1">
-          <div className="px-3 flex-shrink-0">
-            <CollapsibleTrigger asChild>
-              <Button variant="sidebar" className="rounded-lg">
-                <FolderKanban className="h-4 w-4 flex-shrink-0 text-sidebar-foreground" />
-                <span className="flex-1 text-left">Projects</span>
-                <ChevronDown className="h-3.5 w-3.5 text-muted-foreground transition-transform duration-200 group-data-[state=closed]/projects:-rotate-90" />
-              </Button>
-            </CollapsibleTrigger>
-          </div>
-          <CollapsibleContent className="min-h-0 data-[state=open]:flex-1 data-[state=open]:pt-1 data-[state=open]:overflow-y-auto [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]">
-            <div className="flex flex-col px-3">
-              <div className="px-2 pb-2">
-                <div className="space-y-0.5">
-                  {sortedProjects.map((project) => (
-                    <SidebarProjectRow
-                      key={project.id}
-                      project={project}
-                      active={pathname?.startsWith(`/projects/${project.id}`) ?? false}
-                      onClick={() => handleProjectClick(project)}
-                    />
-                  ))}
-                </div>
-              </div>
-            </div>
-          </CollapsibleContent>
-        </Collapsible>
+        <SidebarGroup className="flex flex-col min-h-0 data-[slot=sidebar-group]:flex-1">
+          <SidebarGroupLabel>Projects</SidebarGroupLabel>
+          <SidebarMenu className="min-h-0 flex-1 overflow-y-auto [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]">
+            {sortedProjects.map((project) => (
+              <SidebarProjectRow
+                key={project.id}
+                project={project}
+                active={pathname?.startsWith(`/projects/${project.id}`) ?? false}
+                onClick={() => handleProjectClick(project)}
+              />
+            ))}
+          </SidebarMenu>
+        </SidebarGroup>
       )}
-
-      {/* Sessions — subdued, collapsed by default. Live inside projects now. */}
-      <Collapsible defaultOpen={false} className="group/sessions flex flex-col min-h-0">
-        <div className="px-3 flex-shrink-0">
-          <CollapsibleTrigger asChild>
-            <Button variant="sidebar" className="rounded-lg">
-              <ListTree className="h-4 w-4 flex-shrink-0 text-sidebar-foreground" />
-              <span className="flex-1 text-left">Sessions</span>
-              <ChevronDown className="h-3.5 w-3.5 text-muted-foreground/70 transition-transform duration-200 group-data-[state=closed]/sessions:-rotate-90" />
-            </Button>
-          </CollapsibleTrigger>
-        </div>
-        <CollapsibleContent className="min-h-0 data-[state=open]:max-h-[40vh] data-[state=open]:pt-1 data-[state=open]:overflow-y-auto [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]">
-          <SessionList projectId={null} />
-        </CollapsibleContent>
-      </Collapsible>
 
       {hasLegacy && (
         // mt-auto pins this block to the bottom of the SidebarSections column.
@@ -929,34 +908,30 @@ function SidebarProjectRow({
   );
 
   return (
-    <div
-      onClick={onClick}
-      className={cn(
-        'flex items-center gap-2 rounded-lg cursor-pointer transition-colors duration-150',
-        'pr-1.5 py-1.5 pl-3',
-        active
-          ? 'bg-sidebar-accent text-sidebar-accent-foreground'
-          : 'text-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-foreground',
-      )}
-    >
-      <span className={cn('flex-1 truncate text-[13px]', (active || unread > 0) && 'font-medium')}>
-        {project.name}
-      </span>
-      {unread > 0 && (
-        <span
-          className="flex-shrink-0 inline-flex items-center justify-center min-w-[16px] h-[16px] px-1 rounded-full bg-destructive text-destructive-foreground text-[10px] font-semibold leading-none tabular-nums"
-          aria-label={`${unread} unread`}
-          title={`${unread} unread`}
-        >
-          {unread > 99 ? '99+' : unread}
-        </span>
-      )}
-      {unread === 0 && (project.sessionCount ?? 0) > 0 && (
-        <span className="flex-shrink-0 text-[10px] text-muted-foreground/40 tabular-nums">
-          {project.sessionCount}
-        </span>
-      )}
-    </div>
+    <SidebarMenuItem>
+      <SidebarMenuButton
+        isActive={active}
+        onClick={onClick}
+        tooltip={project.name}
+        className={cn(active || unread > 0 ? 'font-medium text-primary' : 'text-muted-foreground')}
+      >
+        <ProjectIcon project={project} size="xs" />
+        <span className="truncate">{project.name}</span>
+        {unread > 0 ? (
+          <span
+            className="ml-auto inline-flex h-[16px] min-w-[16px] items-center justify-center rounded-full bg-destructive px-1 text-[10px] font-semibold leading-none tabular-nums text-destructive-foreground group-data-[collapsible=icon]:hidden"
+            aria-label={`${unread} unread`}
+            title={`${unread} unread`}
+          >
+            {unread > 99 ? '99+' : unread}
+          </span>
+        ) : (project.sessionCount ?? 0) > 0 ? (
+          <span className="ml-auto text-[10px] tabular-nums text-muted-foreground/45 group-data-[collapsible=icon]:hidden">
+            {project.sessionCount}
+          </span>
+        ) : null}
+      </SidebarMenuButton>
+    </SidebarMenuItem>
   );
 }
 
@@ -1566,86 +1541,113 @@ export function SidebarLeft({ ...props }: React.ComponentProps<typeof Sidebar>) 
           'flex flex-col h-full min-h-0',
           effectiveState === 'collapsed' ? 'opacity-0 pointer-events-none' : 'opacity-100 pointer-events-auto'
         )}>
-          {/* Navigation */}
-          <nav className="flex-shrink-0 px-3 pt-2 space-y-0.5">
-            {/* Projects \u2014 primary entry point */}
-            <Button
-              onClick={() => {
-                openTabAndNavigate({
-                  id: 'page:/dashboard',
-                  title: 'Projects',
-                  type: 'dashboard',
-                  href: '/dashboard',
-                }, router);
-              }}
-              variant="sidebar"
-              className="rounded-lg"
-            >
-              <SquarePen className="h-4 w-4 flex-shrink-0 text-sidebar-foreground" />
-              <span className="flex-1 text-left">{createSession.isPending ? 'Creating...' : 'New session'}</span>
-              <kbd className="text-[10px] text-muted-foreground">
-                {isMac ? '\u2318J' : 'Ctrl J'}
-              </kbd>
-              <FolderKanban className="h-4 w-4 flex-shrink-0 text-muted-foreground/50" />
-              <span className="flex-1 text-left">Projects</span>
-            </Button>
+          {/* Navigation \u2014 Workspace group, NavMain look */}
+          <SidebarGroup>
+            <SidebarGroupLabel>Workspace</SidebarGroupLabel>
+            <SidebarMenu>
+              <SidebarMenuItem>
+                <SidebarMenuButton
+                  tooltip="Projects"
+                  isActive={pathname === '/dashboard' || pathname?.startsWith('/projects') === true}
+                  onClick={() => {
+                    openTabAndNavigate({
+                      id: 'page:/dashboard',
+                      title: 'Projects',
+                      type: 'dashboard',
+                      href: '/dashboard',
+                    }, router);
+                  }}
+                  className="font-medium text-primary"
+                >
+                  <FolderKanban className="text-muted-foreground/50" />
+                  <span>Projects</span>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
 
-            {/* Search */}
-            <Button
-              onClick={() => {
-                document.dispatchEvent(
-                  new KeyboardEvent('keydown', {
-                    key: 'k',
-                    code: 'KeyK',
-                    metaKey: isMac,
-                    ctrlKey: !isMac,
-                    bubbles: true,
-                    cancelable: true,
-                  }),
-                );
-              }}
-              variant="sidebar"
-              className="rounded-lg"
-            >
-              <Search className="h-4 w-4 flex-shrink-0 text-sidebar-foreground" />
-              <span className="flex-1 text-left">Search</span>
-              <kbd className="text-[10px] text-muted-foreground">
-                {isMac ? '\u2318K' : 'Ctrl K'}
-              </kbd>
-            </Button>
+              <SidebarMenuItem>
+                <SidebarMenuButton
+                  tooltip={`Search ${isMac ? '\u2318K' : 'Ctrl K'}`}
+                  onClick={() => {
+                    document.dispatchEvent(
+                      new KeyboardEvent('keydown', {
+                        key: 'k',
+                        code: 'KeyK',
+                        metaKey: isMac,
+                        ctrlKey: !isMac,
+                        bubbles: true,
+                        cancelable: true,
+                      }),
+                    );
+                  }}
+                  className="font-medium text-primary"
+                >
+                  <Search className="text-muted-foreground/50" />
+                  <span>Search</span>
+                  <KbdShortcut
+                    shortcut={isMac ? '\u2318K' : 'Ctrl K'}
+                    className="ml-auto group-data-[collapsible=icon]:hidden"
+                  />
+                </SidebarMenuButton>
+              </SidebarMenuItem>
 
-            {/* Files */}
-            <Button
-              onClick={() => {
-                openTabAndNavigate({
-                  id: 'page:/files',
-                  title: 'Files',
-                  type: 'page',
-                  href: '/files',
-                });
-              }}
-              variant="sidebar"
-              className="rounded-lg"
-            >
-              <FolderOpen className="h-4 w-4 flex-shrink-0 text-sidebar-foreground" />
-              <span className="flex-1 text-left">Files</span>
-            </Button>
+              <SidebarMenuItem>
+                <SidebarMenuButton
+                  tooltip="Files"
+                  isActive={pathname === '/files'}
+                  onClick={() => {
+                    openTabAndNavigate({
+                      id: 'page:/files',
+                      title: 'Files',
+                      type: 'page',
+                      href: '/files',
+                    });
+                  }}
+                  className="font-medium text-primary"
+                >
+                  <FolderOpen className="text-muted-foreground/50" />
+                  <span>Files</span>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
 
-            {/* New session — sessions live inside projects now, so this sits
-                below the primary nav with muted styling. */}
-            <Button
-              onClick={handleNewSession}
-              disabled={createSession.isPending}
-              variant="sidebar"
-              className="rounded-lg text-muted-foreground hover:text-foreground"
-            >
-              <SquarePen className="h-4 w-4 flex-shrink-0 text-muted-foreground/40" />
-              <span className="flex-1 text-left">{createSession.isPending ? 'Creating...' : 'New session'}</span>
-              <kbd className="text-[10px] text-muted-foreground/70">
-                {isMac ? '⌘J' : 'Ctrl J'}
-              </kbd>
-            </Button>
-            </nav>
+              <SidebarMenuItem>
+                <SidebarMenuButton
+                  tooltip={`New session ${isMac ? '⌘J' : 'Ctrl J'}`}
+                  onClick={handleNewSession}
+                  disabled={createSession.isPending}
+                  className="font-medium text-primary"
+                >
+                  <SquarePen className="text-muted-foreground/50" />
+                  <span>{createSession.isPending ? 'Creating…' : 'New session'}</span>
+                  <KbdShortcut
+                    shortcut={isMac ? '⌘J' : 'Ctrl J'}
+                    className="ml-auto group-data-[collapsible=icon]:hidden"
+                  />
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+
+              <Collapsible
+                asChild
+                defaultOpen={false}
+                className="group/sessions"
+              >
+                <SidebarMenuItem>
+                  <CollapsibleTrigger asChild>
+                    <SidebarMenuButton
+                      tooltip="Sessions"
+                      className="font-medium text-primary"
+                    >
+                      <ListTree className="text-muted-foreground/50" />
+                      <span>Sessions</span>
+                      <ChevronRight className="ml-auto size-3.5 text-muted-foreground/55 transition-transform duration-200 group-data-[state=open]/sessions:rotate-90 group-data-[collapsible=icon]:hidden" />
+                    </SidebarMenuButton>
+                  </CollapsibleTrigger>
+                  <CollapsibleContent className="overflow-hidden data-[state=open]:max-h-[40vh] data-[state=open]:overflow-y-auto [&::-webkit-scrollbar]:hidden">
+                    <SessionList projectId={null} />
+                  </CollapsibleContent>
+                </SidebarMenuItem>
+              </Collapsible>
+            </SidebarMenu>
+          </SidebarGroup>
 
           <SidebarSections />
         </div>

--- a/apps/web/src/components/sidebar/sidebar-left.tsx
+++ b/apps/web/src/components/sidebar/sidebar-left.tsx
@@ -699,9 +699,9 @@ function SidebarSections() {
 
   return (
     <div className="flex flex-col min-h-0 flex-1 pt-0.5 space-y-0.5">
-      {/* Projects — collapsible list above Sessions, same UX as Sessions */}
+      {/* Projects — primary, default open, takes remaining space */}
       {sortedProjects.length > 0 && (
-        <Collapsible defaultOpen={false} className="group/projects flex flex-col min-h-0">
+        <Collapsible defaultOpen className="group/projects flex flex-col min-h-0 data-[state=open]:flex-1">
           <div className="px-3 flex-shrink-0">
             <CollapsibleTrigger asChild>
               <Button variant="sidebar" className="rounded-lg">
@@ -711,7 +711,7 @@ function SidebarSections() {
               </Button>
             </CollapsibleTrigger>
           </div>
-          <CollapsibleContent className="min-h-0 data-[state=open]:pt-1 overflow-y-auto [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]">
+          <CollapsibleContent className="min-h-0 data-[state=open]:flex-1 data-[state=open]:pt-1 data-[state=open]:overflow-y-auto [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]">
             <div className="flex flex-col px-3">
               <div className="px-2 pb-2">
                 <div className="space-y-0.5">
@@ -730,18 +730,18 @@ function SidebarSections() {
         </Collapsible>
       )}
 
-      {/* Sessions — always visible, takes remaining space */}
-      <Collapsible defaultOpen className="group/sessions flex flex-col min-h-0 data-[state=open]:flex-1">
+      {/* Sessions — subdued, collapsed by default. Live inside projects now. */}
+      <Collapsible defaultOpen={false} className="group/sessions flex flex-col min-h-0">
         <div className="px-3 flex-shrink-0">
           <CollapsibleTrigger asChild>
             <Button variant="sidebar" className="rounded-lg">
               <ListTree className="h-4 w-4 flex-shrink-0 text-sidebar-foreground" />
               <span className="flex-1 text-left">Sessions</span>
-              <ChevronDown className="h-3.5 w-3.5 text-muted-foreground transition-transform duration-200 group-data-[state=closed]/sessions:-rotate-90" />
+              <ChevronDown className="h-3.5 w-3.5 text-muted-foreground/70 transition-transform duration-200 group-data-[state=closed]/sessions:-rotate-90" />
             </Button>
           </CollapsibleTrigger>
         </div>
-        <CollapsibleContent className="min-h-0 data-[state=open]:flex-1 data-[state=open]:pt-1 data-[state=open]:overflow-y-auto [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]">
+        <CollapsibleContent className="min-h-0 data-[state=open]:max-h-[40vh] data-[state=open]:pt-1 data-[state=open]:overflow-y-auto [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]">
           <SessionList projectId={null} />
         </CollapsibleContent>
       </Collapsible>
@@ -1507,10 +1507,17 @@ export function SidebarLeft({ ...props }: React.ComponentProps<typeof Sidebar>) 
             flyoutContent={<WorkspacesFlyoutContent />}
           />
           <CollapsedIconButton
-            icon={<SquarePen className="h-4 w-4" />}
-            label="New session"
-            onClick={handleNewSession}
-            disabled={createSession.isPending}
+            icon={<FolderKanban className="h-4 w-4" />}
+            label="Projects"
+            isActive={pathname === '/dashboard' || pathname?.startsWith('/projects') === true}
+            onClick={() => {
+              openTabAndNavigate({
+                id: 'page:/dashboard',
+                title: 'Projects',
+                type: 'dashboard',
+                href: '/dashboard',
+              }, router);
+            }}
           />
           <CollapsedIconButton
             icon={<Search className="h-4 w-4" />}
@@ -1542,9 +1549,10 @@ export function SidebarLeft({ ...props }: React.ComponentProps<typeof Sidebar>) 
             }}
           />
           <CollapsedIconButton
-            icon={<FolderKanban className="h-4 w-4" />}
-            label="Projects"
-            flyoutContent={<ProjectsFlyout />}
+            icon={<SquarePen className="h-4 w-4" />}
+            label="New session"
+            onClick={handleNewSession}
+            disabled={createSession.isPending}
           />
           <CollapsedIconButton
             icon={<ListTree className="h-4 w-4" />}
@@ -1560,10 +1568,16 @@ export function SidebarLeft({ ...props }: React.ComponentProps<typeof Sidebar>) 
         )}>
           {/* Navigation */}
           <nav className="flex-shrink-0 px-3 pt-2 space-y-0.5">
-            {/* New session */}
+            {/* Projects \u2014 primary entry point */}
             <Button
-              onClick={handleNewSession}
-              disabled={createSession.isPending}
+              onClick={() => {
+                openTabAndNavigate({
+                  id: 'page:/dashboard',
+                  title: 'Projects',
+                  type: 'dashboard',
+                  href: '/dashboard',
+                }, router);
+              }}
               variant="sidebar"
               className="rounded-lg"
             >
@@ -1572,6 +1586,8 @@ export function SidebarLeft({ ...props }: React.ComponentProps<typeof Sidebar>) 
               <kbd className="text-[10px] text-muted-foreground">
                 {isMac ? '\u2318J' : 'Ctrl J'}
               </kbd>
+              <FolderKanban className="h-4 w-4 flex-shrink-0 text-muted-foreground/50" />
+              <span className="flex-1 text-left">Projects</span>
             </Button>
 
             {/* Search */}
@@ -1615,7 +1631,20 @@ export function SidebarLeft({ ...props }: React.ComponentProps<typeof Sidebar>) 
               <span className="flex-1 text-left">Files</span>
             </Button>
 
-            {/* Sessions — expandable, default open */}
+            {/* New session — sessions live inside projects now, so this sits
+                below the primary nav with muted styling. */}
+            <Button
+              onClick={handleNewSession}
+              disabled={createSession.isPending}
+              variant="sidebar"
+              className="rounded-lg text-muted-foreground hover:text-foreground"
+            >
+              <SquarePen className="h-4 w-4 flex-shrink-0 text-muted-foreground/40" />
+              <span className="flex-1 text-left">{createSession.isPending ? 'Creating...' : 'New session'}</span>
+              <kbd className="text-[10px] text-muted-foreground/70">
+                {isMac ? '⌘J' : 'Ctrl J'}
+              </kbd>
+            </Button>
             </nav>
 
           <SidebarSections />

--- a/apps/web/src/components/tabs/page-tab-content.tsx
+++ b/apps/web/src/components/tabs/page-tab-content.tsx
@@ -16,6 +16,12 @@ const DashboardContent = lazy(() =>
 	})),
 );
 
+const ProjectsDashboard = lazy(() =>
+	import('@/components/dashboard/projects-dashboard').then((m) => ({
+		default: m.ProjectsDashboard,
+	})),
+);
+
 const SecretsPage = lazy(() =>
 	import('@/app/(dashboard)/settings/credentials/page'),
 );
@@ -115,7 +121,8 @@ const TaskDetailPage = lazy(() =>
 // ---------------------------------------------------------------------------
 
 const PAGE_COMPONENTS: Record<string, ComponentType> = {
-	'/dashboard': DashboardContent,
+	'/dashboard': ProjectsDashboard,
+	'/chat': DashboardContent,
 	'/configuration': WorkspacePage,
 	'/settings/credentials': SecretsPage,
 	'/settings/api-keys': ApiKeysPage,
@@ -123,7 +130,7 @@ const PAGE_COMPONENTS: Record<string, ComponentType> = {
 	'/credits-explained': CreditsPage,
 	'/changelog': ChangelogPage,
 	'/workspace': WorkspacePage,
-	'/projects': WorkspacePage,
+	'/projects': ProjectsDashboard,
 	// Marketplace - browse and install all components from registry
 	'/marketplace': MarketplacePage,
 	'/skills': MarketplacePage, // backwards compat

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -36,18 +36,14 @@ const buttonVariants = cva(
           "bg-emerald-500/10 text-emerald-600 hover:bg-emerald-500/20 dark:text-emerald-400",
       },
       size: {
-        default: "h-9 px-4 py-2 text-sm rounded-full [&_svg:not([class*='size-'])]:size-4 has-[>svg]:px-3",
-        sm: "h-8 gap-1.5 px-3 text-sm rounded-full [&_svg:not([class*='size-'])]:size-4 has-[>svg]:px-2.5",
-        lg: "h-11 px-6 text-sm rounded-full [&_svg:not([class*='size-'])]:size-4 has-[>svg]:px-4",
-        icon: "size-9 rounded-full [&_svg:not([class*='size-'])]:size-4",
-        // Compact toolbar actions
-        toolbar: "h-7 gap-1.5 px-2.5 text-[0.6875rem] rounded-full [&_svg:not([class*='size-'])]:size-3.5",
-        // Micro buttons for inline/compact contexts
-        xs: "h-6 gap-1 px-2 text-[0.625rem] rounded-full [&_svg:not([class*='size-'])]:size-3",
-        // Small icon button (toolbar density)
-        "icon-sm": "size-7 rounded-full [&_svg:not([class*='size-'])]:size-3.5",
-        // Tiny icon button (inline density)
-        "icon-xs": "size-6 rounded-full [&_svg:not([class*='size-'])]:size-3",
+        default: "h-9 px-4 py-2 text-sm rounded-lg [&_svg:not([class*='size-'])]:size-4 has-[>svg]:px-3",
+        sm: "h-8 gap-1.5 px-3 text-sm rounded-lg [&_svg:not([class*='size-'])]:size-4 has-[>svg]:px-2.5",
+        lg: "h-11 px-6 text-sm rounded-lg [&_svg:not([class*='size-'])]:size-4 has-[>svg]:px-4",
+        icon: "size-9 rounded-lg [&_svg:not([class*='size-'])]:size-4",
+        toolbar: "h-7 gap-1.5 px-2.5 text-[0.6875rem] rounded-lg [&_svg:not([class*='size-'])]:size-3.5",
+        xs: "h-6 gap-1 px-2 text-[0.625rem] rounded-lg [&_svg:not([class*='size-'])]:size-3",
+        "icon-sm": "size-7 rounded-lg [&_svg:not([class*='size-'])]:size-3.5",
+        "icon-xs": "size-6 rounded-lg [&_svg:not([class*='size-'])]:size-3",
       },
     },
     defaultVariants: {

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -20,18 +20,14 @@ const buttonVariants = cva(
         ghost:
           "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
         link: "text-primary underline-offset-4 hover:underline",
-        // Tinted primary — bg-primary at 10% opacity
         subtle:
           "bg-primary/10 text-primary hover:bg-primary/15",
         sidebar:
           "font-medium text-sidebar-foreground hover:bg-sidebar-accent/80 flex items-center justify-start gap-3 w-full transition-colors duration-150",
-        // Muted ghost — neutral background on hover
         muted:
           "text-muted-foreground hover:bg-muted hover:text-foreground",
-        // Inverted — foreground as bg (white-on-black / black-on-white)
         inverse:
           "bg-foreground text-background hover:bg-foreground/90",
-        // Success — emerald tint
         success:
           "bg-emerald-500/10 text-emerald-600 hover:bg-emerald-500/20 dark:text-emerald-400",
       },

--- a/apps/web/src/components/ui/kbd.tsx
+++ b/apps/web/src/components/ui/kbd.tsx
@@ -25,4 +25,29 @@ function KbdGroup({ className, ...props }: React.ComponentProps<"div">) {
   )
 }
 
-export { Kbd, KbdGroup }
+function KbdShortcut({
+  shortcut,
+  className,
+}: {
+  shortcut: string
+  className?: string
+}) {
+  const parts = shortcut.includes(" ")
+    ? shortcut.split(/\s+/)
+    : Array.from(shortcut)
+
+  return (
+    <KbdGroup className={cn("gap-0.5", className)}>
+      {parts.map((p, i) => (
+        <Kbd
+          key={i}
+          className="h-5 min-w-5 rounded-md border border-border/60 bg-muted/70 px-1 text-[10px] font-medium tabular-nums text-muted-foreground/85"
+        >
+          {p}
+        </Kbd>
+      ))}
+    </KbdGroup>
+  )
+}
+
+export { Kbd, KbdGroup, KbdShortcut }

--- a/apps/web/src/features/files/api/opencode-files.ts
+++ b/apps/web/src/features/files/api/opencode-files.ts
@@ -457,6 +457,27 @@ export async function findFiles(
 }
 
 /**
+ * Enumerate files under a directory using the server's /find/file endpoint.
+ * Server-side scan — single round trip, fast even for large repos.
+ */
+export async function findFilesInDirectory(
+  directory: string,
+  query: string = '.',
+): Promise<string[]> {
+  try {
+    const client = getClient();
+    const result = await client.find.files({
+      query,
+      directory,
+      dirs: 'false',
+    } as any);
+    return (unwrap(result) ?? []) as string[];
+  } catch {
+    return [];
+  }
+}
+
+/**
  * Search for text patterns across project files (ripgrep).
  */
 export async function findText(pattern: string): Promise<FindMatch[]> {

--- a/apps/web/src/features/files/hooks/use-workspace-file-index.ts
+++ b/apps/web/src/features/files/hooks/use-workspace-file-index.ts
@@ -1,0 +1,41 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { useServerStore } from '@/stores/server-store';
+import {
+  getWorkspaceFileIndex,
+} from '../search/workspace-search-service';
+import { findFilesInDirectory } from '../api/opencode-files';
+import type { WorkspaceSearchEntry } from '../search/workspace-search-core';
+
+export function useWorkspaceFileIndex(options?: { enabled?: boolean }) {
+  const serverUrl = useServerStore((s) => s.getActiveServerUrl());
+
+  return useQuery<WorkspaceSearchEntry[]>({
+    queryKey: ['opencode-files', 'workspace-index', serverUrl],
+    queryFn: () => getWorkspaceFileIndex(),
+    enabled: options?.enabled !== false,
+    staleTime: 60_000,
+    gcTime: 5 * 60_000,
+    refetchOnWindowFocus: false,
+    retry: 1,
+  });
+}
+
+export function useProjectFileIndex(
+  projectPath: string | null | undefined,
+  options?: { enabled?: boolean },
+) {
+  const serverUrl = useServerStore((s) => s.getActiveServerUrl());
+  const enabled = !!projectPath && projectPath !== '/' && options?.enabled !== false;
+
+  return useQuery<string[]>({
+    queryKey: ['opencode-files', 'project-file-paths', serverUrl, projectPath ?? ''],
+    queryFn: () => findFilesInDirectory(projectPath as string),
+    enabled,
+    staleTime: 60_000,
+    gcTime: 5 * 60_000,
+    refetchOnWindowFocus: false,
+    retry: 1,
+  });
+}

--- a/apps/web/src/features/files/search/workspace-search-service.ts
+++ b/apps/web/src/features/files/search/workspace-search-service.ts
@@ -322,3 +322,7 @@ export async function searchWorkspaceFilePaths(
   const entries = await searchWorkspaceFileEntries(query, options);
   return entries.map(toResultPath);
 }
+
+export async function getWorkspaceFileIndex(): Promise<WorkspaceSearchEntry[]> {
+  return getWorkspaceIndexEntries();
+}

--- a/apps/web/src/hooks/use-mobile.ts
+++ b/apps/web/src/hooks/use-mobile.ts
@@ -1,0 +1,19 @@
+import * as React from "react"
+
+const MOBILE_BREAKPOINT = 768
+
+export function useIsMobile() {
+  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
+
+  React.useEffect(() => {
+    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
+    const onChange = () => {
+      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
+    }
+    mql.addEventListener("change", onChange)
+    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
+    return () => mql.removeEventListener("change", onChange)
+  }, [])
+
+  return !!isMobile
+}

--- a/apps/web/src/lib/feature-flags.ts
+++ b/apps/web/src/lib/feature-flags.ts
@@ -7,25 +7,16 @@ function parseEnvBoolean(value: string | undefined, defaultValue: boolean): bool
 }
 
 export const featureFlags = {
-  /**
-   * When true, hide any mobile app download / install advertising across the web app.
-   *
-   * Default: false (shown)
-   * Set NEXT_PUBLIC_DISABLE_MOBILE_ADVERTISING=true to hide.
-   */
   disableMobileAdvertising: parseEnvBoolean(
     process.env.NEXT_PUBLIC_DISABLE_MOBILE_ADVERTISING,
     false,
   ),
-  /** When true, show the dino game easter egg during provisioning. Default: false. */
   enableDinoGame: parseEnvBoolean(
     process.env.NEXT_PUBLIC_ENABLE_DINO_GAME,
     false,
   ),
+  newLayout: parseEnvBoolean(
+    process.env.NEXT_PUBLIC_FRONTEND_NEW_LAYOUT,
+    false,
+  ),
 } as const;
-
-// Debug: uncomment to inspect feature flags during development
-// if (process.env.NODE_ENV !== 'production') {
-//   console.log('[featureFlags]', featureFlags);
-// }
-

--- a/apps/web/src/lib/kortix/file-language.ts
+++ b/apps/web/src/lib/kortix/file-language.ts
@@ -1,0 +1,120 @@
+export type LanguageMeta = { name: string; color: string };
+
+const EXT_MAP: Record<string, LanguageMeta> = {
+  ts: { name: 'TypeScript', color: '#3178c6' },
+  tsx: { name: 'TypeScript', color: '#3178c6' },
+  js: { name: 'JavaScript', color: '#f1e05a' },
+  jsx: { name: 'JavaScript', color: '#f1e05a' },
+  mjs: { name: 'JavaScript', color: '#f1e05a' },
+  cjs: { name: 'JavaScript', color: '#f1e05a' },
+  py: { name: 'Python', color: '#3572A5' },
+  rb: { name: 'Ruby', color: '#701516' },
+  go: { name: 'Go', color: '#00ADD8' },
+  rs: { name: 'Rust', color: '#dea584' },
+  java: { name: 'Java', color: '#b07219' },
+  kt: { name: 'Kotlin', color: '#A97BFF' },
+  swift: { name: 'Swift', color: '#F05138' },
+  c: { name: 'C', color: '#555555' },
+  h: { name: 'C', color: '#555555' },
+  cpp: { name: 'C++', color: '#f34b7d' },
+  cc: { name: 'C++', color: '#f34b7d' },
+  hpp: { name: 'C++', color: '#f34b7d' },
+  cs: { name: 'C#', color: '#178600' },
+  php: { name: 'PHP', color: '#4F5D95' },
+  lua: { name: 'Lua', color: '#000080' },
+  sh: { name: 'Shell', color: '#89e051' },
+  bash: { name: 'Shell', color: '#89e051' },
+  zsh: { name: 'Shell', color: '#89e051' },
+  fish: { name: 'Shell', color: '#89e051' },
+  ps1: { name: 'PowerShell', color: '#012456' },
+
+  html: { name: 'HTML', color: '#e34c26' },
+  htm: { name: 'HTML', color: '#e34c26' },
+  css: { name: 'CSS', color: '#563d7c' },
+  scss: { name: 'SCSS', color: '#c6538c' },
+  sass: { name: 'Sass', color: '#a53b70' },
+  less: { name: 'Less', color: '#1d365d' },
+  vue: { name: 'Vue', color: '#41b883' },
+  svelte: { name: 'Svelte', color: '#ff3e00' },
+
+  json: { name: 'JSON', color: '#d19a66' },
+  yaml: { name: 'YAML', color: '#cb171e' },
+  yml: { name: 'YAML', color: '#cb171e' },
+  toml: { name: 'TOML', color: '#9c4221' },
+  xml: { name: 'XML', color: '#0060ac' },
+
+  md: { name: 'Markdown', color: '#083fa1' },
+  mdx: { name: 'MDX', color: '#1e88e5' },
+  txt: { name: 'Text', color: '#a0a0a0' },
+  rst: { name: 'reST', color: '#141414' },
+
+  sql: { name: 'SQL', color: '#e38c00' },
+  prisma: { name: 'Prisma', color: '#0c344b' },
+  graphql: { name: 'GraphQL', color: '#e10098' },
+  gql: { name: 'GraphQL', color: '#e10098' },
+  proto: { name: 'Protobuf', color: '#7c4dff' },
+
+  dockerfile: { name: 'Docker', color: '#384d54' },
+  makefile: { name: 'Makefile', color: '#427819' },
+
+  png: { name: 'Image', color: '#a371f7' },
+  jpg: { name: 'Image', color: '#a371f7' },
+  jpeg: { name: 'Image', color: '#a371f7' },
+  gif: { name: 'Image', color: '#a371f7' },
+  webp: { name: 'Image', color: '#a371f7' },
+  svg: { name: 'SVG', color: '#FFB13B' },
+  ico: { name: 'Image', color: '#a371f7' },
+
+  pdf: { name: 'PDF', color: '#b30b00' },
+  zip: { name: 'Archive', color: '#6e7781' },
+  tar: { name: 'Archive', color: '#6e7781' },
+  gz: { name: 'Archive', color: '#6e7781' },
+
+  csv: { name: 'CSV', color: '#237346' },
+  tsv: { name: 'CSV', color: '#237346' },
+  xlsx: { name: 'Excel', color: '#1d6f42' },
+
+  env: { name: 'Env', color: '#ECD53F' },
+  log: { name: 'Log', color: '#a0a0a0' },
+  lock: { name: 'Lockfile', color: '#a0a0a0' },
+};
+
+const FILENAME_MAP: Record<string, LanguageMeta> = {
+  dockerfile: { name: 'Docker', color: '#384d54' },
+  makefile: { name: 'Makefile', color: '#427819' },
+  rakefile: { name: 'Ruby', color: '#701516' },
+  gemfile: { name: 'Ruby', color: '#701516' },
+  procfile: { name: 'Procfile', color: '#a0a0a0' },
+};
+
+const OTHER: LanguageMeta = { name: 'Other', color: '#94a3b8' };
+
+export function detectLanguage(filename: string): LanguageMeta {
+  const lower = filename.toLowerCase();
+  if (FILENAME_MAP[lower]) return FILENAME_MAP[lower];
+  const dot = lower.lastIndexOf('.');
+  if (dot < 0) return OTHER;
+  const ext = lower.slice(dot + 1);
+  return EXT_MAP[ext] ?? OTHER;
+}
+
+export type LanguageBucket = LanguageMeta & { count: number; pct: number };
+
+export function bucketLanguages(filenames: string[]): LanguageBucket[] {
+  if (filenames.length === 0) return [];
+  const counts = new Map<string, { meta: LanguageMeta; count: number }>();
+  for (const f of filenames) {
+    const meta = detectLanguage(f);
+    const key = meta.name;
+    const entry = counts.get(key);
+    if (entry) entry.count++;
+    else counts.set(key, { meta, count: 1 });
+  }
+  const total = filenames.length;
+  const list: LanguageBucket[] = [];
+  for (const { meta, count } of counts.values()) {
+    list.push({ ...meta, count, pct: (count / total) * 100 });
+  }
+  list.sort((a, b) => b.count - a.count);
+  return list;
+}

--- a/apps/web/src/lib/shape-context.tsx
+++ b/apps/web/src/lib/shape-context.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  useCallback,
+  type ReactNode,
+} from "react";
+
+type ShapeVariant = "pill" | "rounded";
+
+const shapeOrder: ShapeVariant[] = ["rounded", "pill"];
+
+interface ShapeClasses {
+  item: string;
+  bg: string;
+  focusRing: string;
+  mergedBg: string;
+  container: string;
+  button: string;
+  input: string;
+}
+
+const shapeMap: Record<ShapeVariant, ShapeClasses> = {
+  pill: {
+    item: "rounded-[20px]",
+    bg: "rounded-[20px]",
+    focusRing: "rounded-[20px]",
+    mergedBg: "rounded-2xl",
+    container: "rounded-3xl",
+    button: "rounded-[20px]",
+    input: "rounded-[20px]",
+  },
+  rounded: {
+    item: "rounded-lg",
+    bg: "rounded-lg",
+    focusRing: "rounded-[10px]",
+    mergedBg: "rounded-lg",
+    container: "rounded-xl",
+    button: "rounded-lg",
+    input: "rounded-lg",
+  },
+};
+
+interface ShapeContextValue {
+  shape: ShapeVariant;
+  setShape: (shape: ShapeVariant) => void;
+  classes: ShapeClasses;
+}
+
+const ShapeContext = createContext<ShapeContextValue | null>(null);
+
+function useShape(): ShapeClasses {
+  const ctx = useContext(ShapeContext);
+  if (!ctx) return shapeMap.pill;
+  return ctx.classes;
+}
+
+function useShapeContext() {
+  const ctx = useContext(ShapeContext);
+  if (!ctx) throw new Error("useShapeContext must be used within a ShapeProvider");
+  return ctx;
+}
+
+function transitionShape(callback: () => void) {
+  const root = document.documentElement;
+  root.classList.add("transitioning");
+  void root.offsetHeight;
+  callback();
+  setTimeout(() => root.classList.remove("transitioning"), 200);
+}
+
+function ShapeProvider({
+  children,
+  defaultShape = "pill",
+}: {
+  children: ReactNode;
+  defaultShape?: ShapeVariant;
+}) {
+  const [shape, setShapeState] = useState<ShapeVariant>(defaultShape);
+
+  const setShape = useCallback((next: ShapeVariant) => {
+    transitionShape(() => setShapeState(next));
+  }, []);
+
+  // Global keyboard shortcut: R to cycle radius
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== "r" && e.key !== "R") return;
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+      const tag = (e.target as HTMLElement)?.tagName;
+      if (tag === "INPUT" || tag === "TEXTAREA" || (e.target as HTMLElement)?.isContentEditable) return;
+      e.preventDefault();
+      transitionShape(() => {
+        setShapeState((prev) => {
+          const idx = shapeOrder.indexOf(prev);
+          return shapeOrder[(idx + 1) % shapeOrder.length];
+        });
+      });
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, []);
+
+  return (
+    <ShapeContext.Provider value={{ shape, setShape, classes: shapeMap[shape] }}>
+      {children}
+    </ShapeContext.Provider>
+  );
+}
+
+export { ShapeProvider, useShape, useShapeContext, shapeMap };
+export type { ShapeVariant, ShapeClasses };

--- a/apps/web/src/stores/tab-store.ts
+++ b/apps/web/src/stores/tab-store.ts
@@ -4,6 +4,7 @@ import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import { useServerStore } from '@/stores/server-store';
 import { getCurrentInstanceIdFromWindow, toInstanceAwarePath } from '@/lib/instance-routes';
+import { featureFlags } from '@/lib/feature-flags';
 
 // ============================================================================
 // Types
@@ -522,9 +523,22 @@ export function openTabAndNavigate(
   tabInput: Omit<Tab, 'openedAt'>,
   router?: { push: (url: string) => void },
 ) {
-  useTabStore.getState().openTab(tabInput);
   if (typeof window === 'undefined') return;
   const href = toInstanceAwarePath(tabInput.href, getCurrentInstanceIdFromWindow());
+
+  // New layout: no tab store, navigate via the App Router so Next.js
+  // re-renders the route tree. Falls back to a full assign if no router was
+  // provided by the caller.
+  if (featureFlags.newLayout) {
+    if (router) {
+      router.push(href);
+    } else {
+      window.location.assign(href);
+    }
+    return;
+  }
+
+  useTabStore.getState().openTab(tabInput);
   if (PRE_MOUNTED_TAB_TYPES.has(tabInput.type)) {
     window.history.pushState(null, '', href);
   } else if (router) {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   "pnpm": {
     "overrides": {
       "@types/react": "^18.3.28",
-      "@types/react-dom": "^18.3.7"
+      "@types/react-dom": "^18.3.7",
+      "@codemirror/state": "6.5.4"
     }
   },
   "packageManager": "pnpm@8.15.8+sha512.d1a029e1a447ad90bc96cd58b0fad486d2993d531856396f7babf2d83eb1823bb83c5a3d0fc18f675b2d10321d49eb161fece36fe8134aa5823ecd215feed392"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   '@types/react': ^18.3.28
   '@types/react-dom': ^18.3.7
+  '@codemirror/state': 6.5.4
 
 importers:
 
@@ -480,8 +481,8 @@ importers:
         specifier: ^6.9.5
         version: 6.9.5
       '@codemirror/state':
-        specifier: ^6.6.0
-        version: 6.6.0
+        specifier: 6.5.4
+        version: 6.5.4
       '@codemirror/view':
         specifier: ^6.41.0
         version: 6.41.1
@@ -832,16 +833,16 @@ importers:
         version: 0.183.1
       '@uiw/codemirror-extensions-langs':
         specifier: ^4.23.10
-        version: 4.25.4(@codemirror/autocomplete@6.20.1)(@codemirror/lang-css@6.3.1)(@codemirror/lang-html@6.4.11)(@codemirror/lang-javascript@6.2.5)(@codemirror/language-data@6.5.2)(@codemirror/language@6.12.3)(@codemirror/state@6.6.0)(@codemirror/view@6.41.1)(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@lezer/javascript@1.5.4)(@lezer/lr@1.4.10)
+        version: 4.25.4(@codemirror/autocomplete@6.20.1)(@codemirror/lang-css@6.3.1)(@codemirror/lang-html@6.4.11)(@codemirror/lang-javascript@6.2.5)(@codemirror/language-data@6.5.2)(@codemirror/language@6.12.3)(@codemirror/state@6.5.4)(@codemirror/view@6.41.1)(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@lezer/javascript@1.5.4)(@lezer/lr@1.4.10)
       '@uiw/codemirror-theme-vscode':
         specifier: ^4.23.10
-        version: 4.25.4(@codemirror/language@6.12.3)(@codemirror/state@6.6.0)(@codemirror/view@6.41.1)
+        version: 4.25.4(@codemirror/language@6.12.3)(@codemirror/state@6.5.4)(@codemirror/view@6.41.1)
       '@uiw/codemirror-theme-xcode':
         specifier: ^4.23.10
-        version: 4.25.4(@codemirror/language@6.12.3)(@codemirror/state@6.6.0)(@codemirror/view@6.41.1)
+        version: 4.25.4(@codemirror/language@6.12.3)(@codemirror/state@6.5.4)(@codemirror/view@6.41.1)
       '@uiw/react-codemirror':
         specifier: ^4.23.10
-        version: 4.25.4(@babel/runtime@7.29.2)(@codemirror/autocomplete@6.20.1)(@codemirror/language@6.12.3)(@codemirror/lint@6.9.5)(@codemirror/search@6.7.0)(@codemirror/state@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.41.1)(codemirror@6.0.2)(react-dom@18.3.1)(react@18.3.1)
+        version: 4.25.4(@babel/runtime@7.29.2)(@codemirror/autocomplete@6.20.1)(@codemirror/language@6.12.3)(@codemirror/lint@6.9.5)(@codemirror/search@6.7.0)(@codemirror/state@6.5.4)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.41.1)(codemirror@6.0.2)(react-dom@18.3.1)(react@18.3.1)
       '@univerjs/preset-sheets-core':
         specifier: ^0.17.0
         version: 0.17.0(@types/react-dom@18.3.7)(@types/react@18.3.28)(@wendellhu/redi@1.1.1)(react-dom@18.3.1)(react@18.3.1)(rxjs@7.8.2)
@@ -3170,7 +3171,7 @@ packages:
     resolution: {integrity: sha512-1cvg3Vz1dSSToCNlJfRA2WSI4ht3K+WplO0UMOgmUYPivCyy2oueZY6Lx7M9wThm7SDUBViRmuT+OG/i8+ON9A==}
     dependencies:
       '@codemirror/language': 6.12.3
-      '@codemirror/state': 6.6.0
+      '@codemirror/state': 6.5.4
       '@codemirror/view': 6.41.1
       '@lezer/common': 1.5.2
     dev: false
@@ -3179,7 +3180,7 @@ packages:
     resolution: {integrity: sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q==}
     dependencies:
       '@codemirror/language': 6.12.3
-      '@codemirror/state': 6.6.0
+      '@codemirror/state': 6.5.4
       '@codemirror/view': 6.41.1
       '@lezer/common': 1.5.2
     dev: false
@@ -3207,7 +3208,7 @@ packages:
     dependencies:
       '@codemirror/autocomplete': 6.20.1
       '@codemirror/language': 6.12.3
-      '@codemirror/state': 6.6.0
+      '@codemirror/state': 6.5.4
       '@lezer/common': 1.5.2
       '@lezer/css': 1.3.3
     dev: false
@@ -3217,7 +3218,7 @@ packages:
     dependencies:
       '@codemirror/autocomplete': 6.20.1
       '@codemirror/language': 6.12.3
-      '@codemirror/state': 6.6.0
+      '@codemirror/state': 6.5.4
       '@lezer/common': 1.5.2
       '@lezer/go': 1.0.1
     dev: false
@@ -3229,7 +3230,7 @@ packages:
       '@codemirror/lang-css': 6.3.1
       '@codemirror/lang-javascript': 6.2.5
       '@codemirror/language': 6.12.3
-      '@codemirror/state': 6.6.0
+      '@codemirror/state': 6.5.4
       '@codemirror/view': 6.41.1
       '@lezer/common': 1.5.2
       '@lezer/css': 1.3.3
@@ -3249,7 +3250,7 @@ packages:
       '@codemirror/autocomplete': 6.20.1
       '@codemirror/language': 6.12.3
       '@codemirror/lint': 6.9.5
-      '@codemirror/state': 6.6.0
+      '@codemirror/state': 6.5.4
       '@codemirror/view': 6.41.1
       '@lezer/common': 1.5.2
       '@lezer/javascript': 1.5.4
@@ -3261,7 +3262,7 @@ packages:
       '@codemirror/autocomplete': 6.20.1
       '@codemirror/lang-html': 6.4.11
       '@codemirror/language': 6.12.3
-      '@codemirror/state': 6.6.0
+      '@codemirror/state': 6.5.4
       '@codemirror/view': 6.41.1
       '@lezer/common': 1.5.2
       '@lezer/highlight': 1.2.3
@@ -3291,7 +3292,7 @@ packages:
       '@codemirror/autocomplete': 6.20.1
       '@codemirror/lang-html': 6.4.11
       '@codemirror/language': 6.12.3
-      '@codemirror/state': 6.6.0
+      '@codemirror/state': 6.5.4
       '@codemirror/view': 6.41.1
       '@lezer/common': 1.5.2
       '@lezer/highlight': 1.2.3
@@ -3304,7 +3305,7 @@ packages:
       '@codemirror/autocomplete': 6.20.1
       '@codemirror/lang-html': 6.4.11
       '@codemirror/language': 6.12.3
-      '@codemirror/state': 6.6.0
+      '@codemirror/state': 6.5.4
       '@codemirror/view': 6.41.1
       '@lezer/common': 1.5.2
       '@lezer/markdown': 1.6.3
@@ -3315,7 +3316,7 @@ packages:
     dependencies:
       '@codemirror/lang-html': 6.4.11
       '@codemirror/language': 6.12.3
-      '@codemirror/state': 6.6.0
+      '@codemirror/state': 6.5.4
       '@lezer/common': 1.5.2
       '@lezer/php': 1.0.5
     dev: false
@@ -3325,7 +3326,7 @@ packages:
     dependencies:
       '@codemirror/autocomplete': 6.20.1
       '@codemirror/language': 6.12.3
-      '@codemirror/state': 6.6.0
+      '@codemirror/state': 6.5.4
       '@lezer/common': 1.5.2
       '@lezer/python': 1.1.18
     dev: false
@@ -3342,7 +3343,7 @@ packages:
     dependencies:
       '@codemirror/lang-css': 6.3.1
       '@codemirror/language': 6.12.3
-      '@codemirror/state': 6.6.0
+      '@codemirror/state': 6.5.4
       '@lezer/common': 1.5.2
       '@lezer/sass': 1.1.0
     dev: false
@@ -3352,7 +3353,7 @@ packages:
     dependencies:
       '@codemirror/autocomplete': 6.20.1
       '@codemirror/language': 6.12.3
-      '@codemirror/state': 6.6.0
+      '@codemirror/state': 6.5.4
       '@lezer/common': 1.5.2
       '@lezer/highlight': 1.2.3
       '@lezer/lr': 1.4.10
@@ -3383,7 +3384,7 @@ packages:
     dependencies:
       '@codemirror/autocomplete': 6.20.1
       '@codemirror/language': 6.12.3
-      '@codemirror/state': 6.6.0
+      '@codemirror/state': 6.5.4
       '@codemirror/view': 6.41.1
       '@lezer/common': 1.5.2
       '@lezer/xml': 1.0.6
@@ -3394,7 +3395,7 @@ packages:
     dependencies:
       '@codemirror/autocomplete': 6.20.1
       '@codemirror/language': 6.12.3
-      '@codemirror/state': 6.6.0
+      '@codemirror/state': 6.5.4
       '@lezer/common': 1.5.2
       '@lezer/highlight': 1.2.3
       '@lezer/lr': 1.4.10
@@ -3432,7 +3433,7 @@ packages:
   /@codemirror/language@6.12.3:
     resolution: {integrity: sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==}
     dependencies:
-      '@codemirror/state': 6.6.0
+      '@codemirror/state': 6.5.4
       '@codemirror/view': 6.41.1
       '@lezer/common': 1.5.2
       '@lezer/highlight': 1.2.3
@@ -3449,7 +3450,7 @@ packages:
   /@codemirror/lint@6.9.5:
     resolution: {integrity: sha512-GElsbU9G7QT9xXhpUg1zWGmftA/7jamh+7+ydKRuT0ORpWS3wOSP0yT1FOlIZa7mIJjpVPipErsyvVqB9cfTFA==}
     dependencies:
-      '@codemirror/state': 6.6.0
+      '@codemirror/state': 6.5.4
       '@codemirror/view': 6.41.1
       crelt: 1.0.6
     dev: false
@@ -3457,13 +3458,13 @@ packages:
   /@codemirror/search@6.7.0:
     resolution: {integrity: sha512-ZvGm99wc/s2cITtMT15LFdn8aH/aS+V+DqyGq/N5ZlV5vWtH+nILvC2nw0zX7ByNoHHDZ2IxxdW38O0tc5nVHg==}
     dependencies:
-      '@codemirror/state': 6.6.0
+      '@codemirror/state': 6.5.4
       '@codemirror/view': 6.41.1
       crelt: 1.0.6
     dev: false
 
-  /@codemirror/state@6.6.0:
-    resolution: {integrity: sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==}
+  /@codemirror/state@6.5.4:
+    resolution: {integrity: sha512-8y7xqG/hpB53l25CIoit9/ngxdfoG+fx+V3SHBrinnhOtLvKHRyAJJuHzkWrR4YXXLX8eXBsejgAAxHUOdW1yw==}
     dependencies:
       '@marijn/find-cluster-break': 1.0.2
     dev: false
@@ -3472,7 +3473,7 @@ packages:
     resolution: {integrity: sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA==}
     dependencies:
       '@codemirror/language': 6.12.3
-      '@codemirror/state': 6.6.0
+      '@codemirror/state': 6.5.4
       '@codemirror/view': 6.41.1
       '@lezer/highlight': 1.2.3
     dev: false
@@ -3480,7 +3481,7 @@ packages:
   /@codemirror/view@6.41.1:
     resolution: {integrity: sha512-ToDnWKbBnke+ZLrP6vgTTDScGi5H37YYuZGniQaBzxMVdtCxMrslsmtnOvbPZk4RX9bvkQqnWR/WS/35tJA0qg==}
     dependencies:
-      '@codemirror/state': 6.6.0
+      '@codemirror/state': 6.5.4
       crelt: 1.0.6
       style-mod: 4.1.3
       w3c-keyname: 2.2.8
@@ -11120,12 +11121,12 @@ packages:
     resolution: {integrity: sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg==}
     dev: false
 
-  /@replit/codemirror-lang-nix@6.0.1(@codemirror/autocomplete@6.20.1)(@codemirror/language@6.12.3)(@codemirror/state@6.6.0)(@codemirror/view@6.41.1)(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@lezer/lr@1.4.10):
+  /@replit/codemirror-lang-nix@6.0.1(@codemirror/autocomplete@6.20.1)(@codemirror/language@6.12.3)(@codemirror/state@6.5.4)(@codemirror/view@6.41.1)(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@lezer/lr@1.4.10):
     resolution: {integrity: sha512-lvzjoYn9nfJzBD5qdm3Ut6G3+Or2wEacYIDJ49h9+19WSChVnxv4ojf+rNmQ78ncuxIt/bfbMvDLMeMP0xze6g==}
     peerDependencies:
       '@codemirror/autocomplete': ^6.0.0
       '@codemirror/language': ^6.0.0
-      '@codemirror/state': ^6.0.0
+      '@codemirror/state': 6.5.4
       '@codemirror/view': ^6.0.0
       '@lezer/common': ^1.0.0
       '@lezer/highlight': ^1.0.0
@@ -11133,7 +11134,7 @@ packages:
     dependencies:
       '@codemirror/autocomplete': 6.20.1
       '@codemirror/language': 6.12.3
-      '@codemirror/state': 6.6.0
+      '@codemirror/state': 6.5.4
       '@codemirror/view': 6.41.1
       '@lezer/common': 1.5.2
       '@lezer/highlight': 1.2.3
@@ -11149,7 +11150,7 @@ packages:
       '@lezer/highlight': 1.2.3
     dev: false
 
-  /@replit/codemirror-lang-svelte@6.0.0(@codemirror/autocomplete@6.20.1)(@codemirror/lang-css@6.3.1)(@codemirror/lang-html@6.4.11)(@codemirror/lang-javascript@6.2.5)(@codemirror/language@6.12.3)(@codemirror/state@6.6.0)(@codemirror/view@6.41.1)(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@lezer/javascript@1.5.4)(@lezer/lr@1.4.10):
+  /@replit/codemirror-lang-svelte@6.0.0(@codemirror/autocomplete@6.20.1)(@codemirror/lang-css@6.3.1)(@codemirror/lang-html@6.4.11)(@codemirror/lang-javascript@6.2.5)(@codemirror/language@6.12.3)(@codemirror/state@6.5.4)(@codemirror/view@6.41.1)(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@lezer/javascript@1.5.4)(@lezer/lr@1.4.10):
     resolution: {integrity: sha512-U2OqqgMM6jKelL0GNWbAmqlu1S078zZNoBqlJBW+retTc5M4Mha6/Y2cf4SVg6ddgloJvmcSpt4hHrVoM4ePRA==}
     peerDependencies:
       '@codemirror/autocomplete': ^6.0.0
@@ -11157,7 +11158,7 @@ packages:
       '@codemirror/lang-html': ^6.2.0
       '@codemirror/lang-javascript': ^6.1.1
       '@codemirror/language': ^6.0.0
-      '@codemirror/state': ^6.0.0
+      '@codemirror/state': 6.5.4
       '@codemirror/view': ^6.0.0
       '@lezer/common': ^1.0.0
       '@lezer/highlight': ^1.0.0
@@ -11169,7 +11170,7 @@ packages:
       '@codemirror/lang-html': 6.4.11
       '@codemirror/lang-javascript': 6.2.5
       '@codemirror/language': 6.12.3
-      '@codemirror/state': 6.6.0
+      '@codemirror/state': 6.5.4
       '@codemirror/view': 6.41.1
       '@lezer/common': 1.5.2
       '@lezer/highlight': 1.2.3
@@ -15633,7 +15634,7 @@ packages:
       eslint-visitor-keys: 4.2.1
     dev: true
 
-  /@uiw/codemirror-extensions-basic-setup@4.25.4(@codemirror/autocomplete@6.20.1)(@codemirror/commands@6.10.3)(@codemirror/language@6.12.3)(@codemirror/lint@6.9.5)(@codemirror/search@6.7.0)(@codemirror/state@6.6.0)(@codemirror/view@6.41.1):
+  /@uiw/codemirror-extensions-basic-setup@4.25.4(@codemirror/autocomplete@6.20.1)(@codemirror/commands@6.10.3)(@codemirror/language@6.12.3)(@codemirror/lint@6.9.5)(@codemirror/search@6.7.0)(@codemirror/state@6.5.4)(@codemirror/view@6.41.1):
     resolution: {integrity: sha512-YzNwkm0AbPv1EXhCHYR5v0nqfemG2jEB0Z3Att4rBYqKrlG7AA9Rhjc3IyBaOzsBu18wtrp9/+uhTyu7TXSRng==}
     peerDependencies:
       '@codemirror/autocomplete': '>=6.0.0'
@@ -15641,7 +15642,7 @@ packages:
       '@codemirror/language': '>=6.0.0'
       '@codemirror/lint': '>=6.0.0'
       '@codemirror/search': '>=6.0.0'
-      '@codemirror/state': '>=6.0.0'
+      '@codemirror/state': 6.5.4
       '@codemirror/view': '>=6.0.0'
     dependencies:
       '@codemirror/autocomplete': 6.20.1
@@ -15649,11 +15650,11 @@ packages:
       '@codemirror/language': 6.12.3
       '@codemirror/lint': 6.9.5
       '@codemirror/search': 6.7.0
-      '@codemirror/state': 6.6.0
+      '@codemirror/state': 6.5.4
       '@codemirror/view': 6.41.1
     dev: false
 
-  /@uiw/codemirror-extensions-langs@4.25.4(@codemirror/autocomplete@6.20.1)(@codemirror/lang-css@6.3.1)(@codemirror/lang-html@6.4.11)(@codemirror/lang-javascript@6.2.5)(@codemirror/language-data@6.5.2)(@codemirror/language@6.12.3)(@codemirror/state@6.6.0)(@codemirror/view@6.41.1)(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@lezer/javascript@1.5.4)(@lezer/lr@1.4.10):
+  /@uiw/codemirror-extensions-langs@4.25.4(@codemirror/autocomplete@6.20.1)(@codemirror/lang-css@6.3.1)(@codemirror/lang-html@6.4.11)(@codemirror/lang-javascript@6.2.5)(@codemirror/language-data@6.5.2)(@codemirror/language@6.12.3)(@codemirror/state@6.5.4)(@codemirror/view@6.41.1)(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@lezer/javascript@1.5.4)(@lezer/lr@1.4.10):
     resolution: {integrity: sha512-mLcEEg8Gt0wzNPaeI350INSLHlXv7qV8eYzQt3oExN+rDB54zL0k2pVhR445wZXDQKbP/fMWuq3qv8SiL/3pxQ==}
     peerDependencies:
       '@codemirror/language': '>=6.0.0'
@@ -15661,9 +15662,9 @@ packages:
     dependencies:
       '@codemirror/language': 6.12.3
       '@codemirror/language-data': 6.5.2
-      '@replit/codemirror-lang-nix': 6.0.1(@codemirror/autocomplete@6.20.1)(@codemirror/language@6.12.3)(@codemirror/state@6.6.0)(@codemirror/view@6.41.1)(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@lezer/lr@1.4.10)
+      '@replit/codemirror-lang-nix': 6.0.1(@codemirror/autocomplete@6.20.1)(@codemirror/language@6.12.3)(@codemirror/state@6.5.4)(@codemirror/view@6.41.1)(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@lezer/lr@1.4.10)
       '@replit/codemirror-lang-solidity': 6.0.2(@codemirror/language@6.12.3)
-      '@replit/codemirror-lang-svelte': 6.0.0(@codemirror/autocomplete@6.20.1)(@codemirror/lang-css@6.3.1)(@codemirror/lang-html@6.4.11)(@codemirror/lang-javascript@6.2.5)(@codemirror/language@6.12.3)(@codemirror/state@6.6.0)(@codemirror/view@6.41.1)(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@lezer/javascript@1.5.4)(@lezer/lr@1.4.10)
+      '@replit/codemirror-lang-svelte': 6.0.0(@codemirror/autocomplete@6.20.1)(@codemirror/lang-css@6.3.1)(@codemirror/lang-html@6.4.11)(@codemirror/lang-javascript@6.2.5)(@codemirror/language@6.12.3)(@codemirror/state@6.5.4)(@codemirror/view@6.41.1)(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@lezer/javascript@1.5.4)(@lezer/lr@1.4.10)
       codemirror-lang-mermaid: 0.5.0
     transitivePeerDependencies:
       - '@codemirror/autocomplete'
@@ -15678,43 +15679,43 @@ packages:
       - '@lezer/lr'
     dev: false
 
-  /@uiw/codemirror-theme-vscode@4.25.4(@codemirror/language@6.12.3)(@codemirror/state@6.6.0)(@codemirror/view@6.41.1):
+  /@uiw/codemirror-theme-vscode@4.25.4(@codemirror/language@6.12.3)(@codemirror/state@6.5.4)(@codemirror/view@6.41.1):
     resolution: {integrity: sha512-9ob5EtLqrXBFl8uf4eFRkXjyjfyfBRVsJdt7xbc33f+2/I29/2v2nEdU/xw40+dhloxF/h1Ry281f8wAs97MWQ==}
     dependencies:
-      '@uiw/codemirror-themes': 4.25.4(@codemirror/language@6.12.3)(@codemirror/state@6.6.0)(@codemirror/view@6.41.1)
+      '@uiw/codemirror-themes': 4.25.4(@codemirror/language@6.12.3)(@codemirror/state@6.5.4)(@codemirror/view@6.41.1)
     transitivePeerDependencies:
       - '@codemirror/language'
       - '@codemirror/state'
       - '@codemirror/view'
     dev: false
 
-  /@uiw/codemirror-theme-xcode@4.25.4(@codemirror/language@6.12.3)(@codemirror/state@6.6.0)(@codemirror/view@6.41.1):
+  /@uiw/codemirror-theme-xcode@4.25.4(@codemirror/language@6.12.3)(@codemirror/state@6.5.4)(@codemirror/view@6.41.1):
     resolution: {integrity: sha512-h6tDJeNE1pNkbKBRloiq06SgYfsZAbYXvlMobvwR0gd156TZHgOSwwZb/NRQZkP2TDjNyFU26UTEomUJHzVcXA==}
     dependencies:
-      '@uiw/codemirror-themes': 4.25.4(@codemirror/language@6.12.3)(@codemirror/state@6.6.0)(@codemirror/view@6.41.1)
+      '@uiw/codemirror-themes': 4.25.4(@codemirror/language@6.12.3)(@codemirror/state@6.5.4)(@codemirror/view@6.41.1)
     transitivePeerDependencies:
       - '@codemirror/language'
       - '@codemirror/state'
       - '@codemirror/view'
     dev: false
 
-  /@uiw/codemirror-themes@4.25.4(@codemirror/language@6.12.3)(@codemirror/state@6.6.0)(@codemirror/view@6.41.1):
+  /@uiw/codemirror-themes@4.25.4(@codemirror/language@6.12.3)(@codemirror/state@6.5.4)(@codemirror/view@6.41.1):
     resolution: {integrity: sha512-2SLktItgcZC4p0+PfFusEbAHwbuAWe3bOOntCevVgHtrWGtGZX3IPv2k8IKZMgOXtAHyGKpJvT9/nspPn/uCQg==}
     peerDependencies:
       '@codemirror/language': '>=6.0.0'
-      '@codemirror/state': '>=6.0.0'
+      '@codemirror/state': 6.5.4
       '@codemirror/view': '>=6.0.0'
     dependencies:
       '@codemirror/language': 6.12.3
-      '@codemirror/state': 6.6.0
+      '@codemirror/state': 6.5.4
       '@codemirror/view': 6.41.1
     dev: false
 
-  /@uiw/react-codemirror@4.25.4(@babel/runtime@7.29.2)(@codemirror/autocomplete@6.20.1)(@codemirror/language@6.12.3)(@codemirror/lint@6.9.5)(@codemirror/search@6.7.0)(@codemirror/state@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.41.1)(codemirror@6.0.2)(react-dom@18.3.1)(react@18.3.1):
+  /@uiw/react-codemirror@4.25.4(@babel/runtime@7.29.2)(@codemirror/autocomplete@6.20.1)(@codemirror/language@6.12.3)(@codemirror/lint@6.9.5)(@codemirror/search@6.7.0)(@codemirror/state@6.5.4)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.41.1)(codemirror@6.0.2)(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-ipO067oyfUw+DVaXhQCxkB0ZD9b7RnY+ByrprSYSKCHaULvJ3sqWYC/Zen6zVQ8/XC4o5EPBfatGiX20kC7XGA==}
     peerDependencies:
       '@babel/runtime': '>=7.11.0'
-      '@codemirror/state': '>=6.0.0'
+      '@codemirror/state': 6.5.4
       '@codemirror/theme-one-dark': '>=6.0.0'
       '@codemirror/view': '>=6.0.0'
       codemirror: '>=6.0.0'
@@ -15723,10 +15724,10 @@ packages:
     dependencies:
       '@babel/runtime': 7.29.2
       '@codemirror/commands': 6.10.3
-      '@codemirror/state': 6.6.0
+      '@codemirror/state': 6.5.4
       '@codemirror/theme-one-dark': 6.1.3
       '@codemirror/view': 6.41.1
-      '@uiw/codemirror-extensions-basic-setup': 4.25.4(@codemirror/autocomplete@6.20.1)(@codemirror/commands@6.10.3)(@codemirror/language@6.12.3)(@codemirror/lint@6.9.5)(@codemirror/search@6.7.0)(@codemirror/state@6.6.0)(@codemirror/view@6.41.1)
+      '@uiw/codemirror-extensions-basic-setup': 4.25.4(@codemirror/autocomplete@6.20.1)(@codemirror/commands@6.10.3)(@codemirror/language@6.12.3)(@codemirror/lint@6.9.5)(@codemirror/search@6.7.0)(@codemirror/state@6.5.4)(@codemirror/view@6.41.1)
       codemirror: 6.0.2
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -19379,7 +19380,7 @@ packages:
       '@codemirror/language': 6.12.3
       '@codemirror/lint': 6.9.5
       '@codemirror/search': 6.7.0
-      '@codemirror/state': 6.6.0
+      '@codemirror/state': 6.5.4
       '@codemirror/view': 6.41.1
     dev: false
 


### PR DESCRIPTION
Reframe the platform around projects as the primary surface, demoting chat from "the app" to "one tab inside a project." Sessions, files, milestones, tickets, triggers, and activity all live under a single project page now, navigated by a new sidebar.

## Summary

- **New left sidebar** (`app-sidebar.tsx`, `nav-main.tsx`, `nav-projects.tsx`, `nav-user.tsx`, `new-sidebar-left.tsx`, `new-sidebar-items.tsx`) — top-level nav is workspace + project list, not a chat history. Old chat-history sidebar replaced; `sidebar-left.tsx` rewritten end-to-end.
- **Project page is now tab-based** — Activity, Files, Milestones, Tickets, Triggers, Team, Settings. New tabs added: `project-activity-tab.tsx`, `project-files-tab.tsx` (~1k lines, includes directory scanning + workspace file index). Existing tabs (`project-about`, `project-header`, `project-settings-tab`, `milestones-tab`, `ticket-board`, etc.) restructured to fit the new shell.
- **Workspace file index** — `use-workspace-file-index.ts`, `opencode-files.ts`, `workspace-search-service.ts`, `lib/kortix/file-language.ts`. Powers the new Files tab and cross-project search.
- **Trigger detail dialog** — new `trigger-detail-dialog.tsx` so triggers can be inspected/edited inline from the Triggers tab instead of opening a separate route.
- **Milestone & ticket dialogs reworked** — `milestone-dialog.tsx` and `new-ticket-dialog.tsx` rewritten for the new project context (assignees, project scope, richer fields).
- **Polish** — new `kortix-brand.tsx`, `shape-context.tsx`, `kbd.tsx` updates, `use-mobile.ts` hook, dashboard (`projects-dashboard.tsx`) rewritten as the project-list landing page, projects/[id] page reworked to host the tab shell.
- **Feature flag** — gated behind a flag in `lib/feature-flags.ts` so the old chat-first shell stays reachable during rollout.