### PR TITLE
chore(governance): change-management controls for SOC 2 (CC8.1)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,28 @@
+# CODEOWNERS — required reviewers for pull requests
+#
+# Purpose: enforce peer review of changes (SOC 2 CC8.1, change management).
+# When a PR touches a path below, the listed owner is automatically requested
+# for review. Combined with branch protection on `newer-kortix`, this ensures
+# no code reaches the protected branch without review.
+#
+# Syntax: <path pattern>  <@owner ...>  (last matching rule wins)
+# Add teammates' GitHub handles as the team grows so PRs need a *peer* review
+# (an author can never approve their own PR).
+
+# Default owner for everything in the repo.
+*                       @markokraemer
+
+# --- Security-sensitive areas (explicit ownership for auditability) ---
+# Auth, IAM, crypto, secrets
+/apps/api/src/iam/                  @markokraemer
+/apps/api/src/middleware/auth.ts    @markokraemer
+/apps/api/src/shared/crypto.ts      @markokraemer
+/apps/api/src/projects/secrets.ts   @markokraemer
+
+# Database schema & migrations (data-layer changes)
+/packages/db/                       @markokraemer
+/supabase/migrations/               @markokraemer
+
+# CI/CD, release, and repo governance
+/.github/                           @markokraemer
+/docs/compliance/                   @markokraemer

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,43 @@
+<!--
+  Every change to a protected branch goes through this PR + review (SOC 2 CC8.1).
+  Fill out each section. PRs cannot be merged without a passing CI check and an
+  approving review from someone other than the author.
+-->
+
+## Summary
+
+<!-- What does this change do, and why? Link the issue/ticket if there is one. -->
+
+Closes #
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactor / chore
+- [ ] Infrastructure / CI
+- [ ] Security fix
+- [ ] Breaking change
+
+## How was this tested?
+
+<!-- Commands run, manual steps, screenshots. State what you verified. -->
+
+## Security & data review
+
+- [ ] No secrets, keys, or credentials are committed (verified by secret scan / review)
+- [ ] Authorization checks are in place for any new/changed endpoints (IAM / access control)
+- [ ] User input is validated (e.g. Zod) and output is safe
+- [ ] No sensitive data (tokens, PII, secrets) is written to logs
+- [ ] DB schema / migration changes are reviewed and reversible
+- [ ] Touches auth / IAM / crypto / billing / migrations → requested the relevant code owner
+
+## Rollout / rollback
+
+<!-- Migrations, feature flags, env vars, and how to revert if this misbehaves. -->
+
+## Reviewer checklist
+
+- [ ] Change is scoped and understandable
+- [ ] Tests/CI pass and cover the change
+- [ ] Security & data review above is satisfied

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,17 +23,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10
-
       - name: Install Node
-        # Node 24 + pnpm >=10 satisfy the repo's engine-strict requirements.
+        # Node 24 satisfies the repo's engine-strict requirements.
         uses: actions/setup-node@v4
         with:
           node-version: 24
-          cache: pnpm
+
+      - name: Install pnpm
+        # Install pnpm directly (not via corepack/action-setup) to avoid the
+        # stale packageManager pin (pnpm@8.11.0), which conflicts with deps
+        # that require pnpm >=10. Mirrors how the repo is built locally.
+        run: npm install -g pnpm@10
 
       - name: Install dependencies (kortix-api + workspace deps)
         run: pnpm install --frozen-lockfile --filter "kortix-api..."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,12 +26,13 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 8.11.0
+          version: 10
 
       - name: Install Node
+        # Node 24 + pnpm >=10 satisfy the repo's engine-strict requirements.
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
 
       - name: Install dependencies (kortix-api + workspace deps)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,6 @@ jobs:
   api-typecheck:
     name: API typecheck
     runs-on: ubuntu-latest
-    env:
-      # Stop pnpm from auto-switching to the pinned packageManager (8.11.0),
-      # which is older than some deps require. Use the pnpm we install instead.
-      npm_config_manage_package_manager_versions: "false"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -34,13 +30,14 @@ jobs:
           node-version: 24
 
       - name: Install pnpm
-        # Disable corepack first: its `pnpm` shim honors the stale
-        # packageManager pin (pnpm@8.11.0) and shadows a direct install. We
-        # install pnpm 10 directly so it satisfies deps that require >=10,
-        # mirroring how the repo is built locally.
+        # The repo pins packageManager: pnpm@8.11.0, but the lockfile is pnpm 11
+        # and some deps require pnpm >=10 / Node >=24. We install pnpm 11 and drop
+        # the stale pin from the checked-out copy so pnpm doesn't self-switch to
+        # 8.11.0. corepack is disabled so its shim can't shadow our pnpm.
         run: |
           corepack disable || true
           npm install -g pnpm@11
+          npm pkg delete packageManager
           echo "pnpm: $(pnpm -v)  node: $(node -v)"
 
       - name: Install dependencies (kortix-api + workspace deps)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,14 @@ jobs:
           node-version: 24
 
       - name: Install pnpm
-        # Install pnpm directly (not via corepack/action-setup) to avoid the
-        # stale packageManager pin (pnpm@8.11.0), which conflicts with deps
-        # that require pnpm >=10. Mirrors how the repo is built locally.
-        run: npm install -g pnpm@10
+        # Disable corepack first: its `pnpm` shim honors the stale
+        # packageManager pin (pnpm@8.11.0) and shadows a direct install. We
+        # install pnpm 10 directly so it satisfies deps that require >=10,
+        # mirroring how the repo is built locally.
+        run: |
+          corepack disable || true
+          npm install -g pnpm@10
+          echo "pnpm: $(pnpm -v)  node: $(node -v)"
 
       - name: Install dependencies (kortix-api + workspace deps)
         run: pnpm install --frozen-lockfile --filter "kortix-api..."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+# Pull-request gate. Required to pass before merging into protected branches
+# (SOC 2 CC8.1 — automated checks run on every change before review/merge).
+
+on:
+  pull_request:
+    branches: [newer-kortix, main]
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  api-typecheck:
+    name: API typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 8.11.0
+
+      - name: Install Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies (kortix-api + workspace deps)
+        run: pnpm install --frozen-lockfile --filter "kortix-api..."
+
+      - name: Typecheck
+        run: pnpm --filter kortix-api typecheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,10 @@ jobs:
   api-typecheck:
     name: API typecheck
     runs-on: ubuntu-latest
+    env:
+      # Stop pnpm from auto-switching to the pinned packageManager (8.11.0),
+      # which is older than some deps require. Use the pnpm we install instead.
+      npm_config_manage_package_manager_versions: "false"
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,24 +24,25 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Node
-        # Node 24 satisfies the repo's engine-strict requirements.
         uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: 22
 
       - name: Install pnpm
-        # The repo pins packageManager: pnpm@8.11.0, but the lockfile is pnpm 11
-        # and some deps require pnpm >=10 / Node >=24. We install pnpm 11 and drop
-        # the stale pin from the checked-out copy so pnpm doesn't self-switch to
-        # 8.11.0. corepack is disabled so its shim can't shadow our pnpm.
+        # The lockfile is pnpm 8 format (lockfileVersion 6.0), matching the
+        # packageManager pin. corepack provides exactly that version.
         run: |
-          corepack disable || true
-          npm install -g pnpm@11
-          npm pkg delete packageManager
+          corepack enable pnpm
           echo "pnpm: $(pnpm -v)  node: $(node -v)"
 
       - name: Install dependencies (kortix-api + workspace deps)
+        # engine-strict is relaxed for CI only: an out-of-scope web dep declares
+        # engines pnpm>=10/node>=24, which conflicts with the repo's pnpm 8
+        # lockfile. This relaxes the version check only — supply-chain controls
+        # (minimum-release-age, ignore-scripts) stay enforced.
         run: pnpm install --frozen-lockfile --filter "kortix-api..."
+        env:
+          npm_config_engine_strict: "false"
 
       - name: Typecheck
         run: pnpm --filter kortix-api typecheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         # mirroring how the repo is built locally.
         run: |
           corepack disable || true
-          npm install -g pnpm@10
+          npm install -g pnpm@11
           echo "pnpm: $(pnpm -v)  node: $(node -v)"
 
       - name: Install dependencies (kortix-api + workspace deps)

--- a/docs/compliance/change-management.md
+++ b/docs/compliance/change-management.md
@@ -1,0 +1,85 @@
+# Change Management Policy
+
+> Maps to SOC 2 Common Criteria **CC8.1** — "The entity authorizes, designs,
+> develops, configures, documents, tests, approves, and implements changes to
+> infrastructure, data, software, and procedures to meet its objectives."
+
+This document describes how code changes are reviewed, approved, and deployed
+for the Kortix (`suna`) repository. It is the source of truth a SOC 2 auditor
+will check against the actual GitHub configuration.
+
+## Scope
+
+All changes to application code, infrastructure-as-code, CI/CD workflows, and
+database schema in `kortix-ai/suna`.
+
+Protected branches (no direct pushes; changes land only via reviewed PR):
+
+- `newer-kortix` — active development trunk
+- `main` — release / production-target branch (protection to be enabled when
+  releases cut from `main`)
+
+## Roles
+
+- **Author** — the engineer who opens the change as a pull request.
+- **Reviewer** — an engineer, other than the author, who approves the PR. An
+  author can never approve their own PR (segregation of duties).
+- **Code owner** — reviewer required for sensitive paths, defined in
+  [`.github/CODEOWNERS`](../../.github/CODEOWNERS).
+
+## Standard change workflow
+
+1. **Branch** off the protected branch for the change.
+2. **Open a pull request** using the
+   [PR template](../../.github/pull_request_template.md). Fill in the summary,
+   testing notes, and the security & data review checklist.
+3. **Automated checks** (`.github/workflows/ci.yml`) run on the PR and must pass.
+4. **Peer review** — at least **one approving review** from a non-author. Stale
+   approvals are dismissed when new commits are pushed. All review conversations
+   must be resolved.
+5. **Merge** — only when checks pass and the review requirement is met. Direct
+   pushes and force-pushes to protected branches are blocked, including for
+   admins (`enforce_admins`).
+
+## Enforced controls (GitHub branch protection)
+
+The following are configured on each protected branch and constitute the
+technical enforcement of this policy:
+
+| Control | Setting |
+| --- | --- |
+| Require pull request before merge | ✅ |
+| Required approving reviews | 1 (non-author) |
+| Dismiss stale approvals on new commits | ✅ |
+| Require review from Code Owners | enabled once ≥2 code owners exist |
+| Require conversation resolution | ✅ |
+| Require status checks to pass | ✅ (`API typecheck`) |
+| Require branches up to date before merge | ✅ |
+| Block force pushes | ✅ |
+| Block branch deletion | ✅ |
+| Enforce on administrators (no bypass) | ✅ |
+
+> **Operational note:** with a single code owner, required reviews still require
+> a *second* person to approve (you cannot approve your own PR). Until a second
+> reviewer is added, admins may be temporarily exempted by disabling
+> `enforce_admins`; this exemption is itself a deviation that should be recorded.
+
+## Emergency / hotfix changes
+
+For urgent production fixes where a reviewer is unavailable:
+
+1. The change still goes through a PR.
+2. It may be merged with admin override **only if** the emergency is documented
+   in the PR description (what broke, why it could not wait).
+3. A retroactive review is requested within 1 business day and linked to the PR.
+
+## Evidence & auditability
+
+- Every merge has a PR with description, CI result, approver, and timestamp —
+  retained in GitHub.
+- Security-relevant runtime actions are recorded in the application audit log
+  (`kortix.audit_events`).
+- This policy is reviewed at least annually and whenever the branching model
+  changes.
+
+_Last reviewed: 2026-05-22._


### PR DESCRIPTION
Introduces the **code review / change-management process** required for SOC 2 (Common Criteria CC8.1).

## What's in here
- **`.github/CODEOWNERS`** — required reviewers; explicit ownership for auth, IAM, crypto, secrets, DB schema, migrations, and CI.
- **`.github/pull_request_template.md`** — PR template with a security & data review checklist.
- **`.github/workflows/ci.yml`** — `API typecheck` gate that runs on every PR (first required status check; more checks to follow).
- **`docs/compliance/change-management.md`** — the written policy auditors check against the live GitHub config.

## After merge
Branch protection on `newer-kortix` will require: PR + 1 approving review (non-author), passing CI, conversation resolution, no force-push/deletion, enforced on admins.

> Note: this bootstrap PR establishes the control; subsequent PRs are gated by it.