### PR TITLE
chore(security): CI security scanning (Dependabot, CodeQL, gitleaks)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+# Dependabot — automated dependency updates + security PRs.
+# Supports SOC 2 CC7.1 (vulnerability management). Security updates for
+# vulnerable deps are opened regardless of the schedule below.
+version: 2
+updates:
+  # JS/TS dependencies (pnpm uses the npm ecosystem).
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    labels: ["dependencies"]
+    groups:
+      # Batch low-risk minor/patch bumps into one PR to cut review noise.
+      minor-and-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+
+  # Keep GitHub Actions pinned and current (supply-chain hygiene).
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels: ["dependencies", "github-actions"]

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,40 @@
+name: CodeQL
+
+# Static application security testing (SAST). Supports SOC 2 CC7.1 / CC8.1.
+# Findings appear under the repo's Security > Code scanning tab.
+
+on:
+  push:
+    branches: [newer-kortix, main]
+  pull_request:
+    branches: [newer-kortix, main]
+  schedule:
+    - cron: "27 3 * * 1" # weekly, Monday 03:27 UTC
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (javascript-typescript)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript
+          queries: security-and-quality
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:javascript-typescript"

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,38 @@
+name: secret-scan
+
+# Scans pull-request commits for committed secrets with gitleaks.
+# Supports SOC 2 CC6.1 (protect credentials). Complements GitHub's native
+# secret scanning + push protection (which cover known provider patterns).
+# We run the gitleaks binary directly: the gitleaks GitHub Action requires a
+# paid license for organizations, but the binary itself is free (MIT).
+
+on:
+  pull_request:
+    branches: [newer-kortix, main]
+
+permissions:
+  contents: read
+
+jobs:
+  gitleaks:
+    name: gitleaks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install gitleaks
+        env:
+          GITLEAKS_VERSION: "8.30.1"
+        run: |
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" -o gitleaks.tar.gz
+          tar -xzf gitleaks.tar.gz gitleaks
+          ./gitleaks version
+
+      - name: Scan PR commits for secrets
+        run: |
+          ./gitleaks git \
+            --log-opts="${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}" \
+            --redact --verbose --exit-code 1


### PR DESCRIPTION
Adds the **automated security scanning** controls for SOC 2 (Security / Common Criteria).

## Workflows & config
- **`.github/dependabot.yml`** — weekly dependency + GitHub Actions update PRs (grouped). Pairs with Dependabot **security updates**, now enabled at the repo level (addresses the open vulnerability alerts). [CC7.1]
- **`.github/workflows/codeql.yml`** — CodeQL **SAST** for JS/TS on PR, push, and weekly. Findings land in Security → Code scanning. [CC7.1]
- **`.github/workflows/secret-scan.yml`** — **gitleaks** scan of PR commits. Complements GitHub native secret scanning + **push protection** (also just enabled). [CC6.1]

## Repo settings flipped on (outside this diff)
- Secret scanning **push protection**: enabled
- Secret scanning **non-provider patterns**: enabled
- Dependabot **security updates**: enabled

> Note: the `Vercel` preview check fails on every PR (pre-existing integration), and is not a required check.