### PR TITLE
chore(security): gitignore token-bearing npmrc + key files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,15 @@ build/
 .env.docker
 *.env.docker
 
+# Secrets & keys (defense-in-depth with secret-scanning push protection + gitleaks)
+# The committed root .npmrc is config-only (no secrets); ignore token-bearing variants
+# like .npmrc.release. *.key does not match Android's debug.keystore.
+.npmrc.*
+*.pem
+*.key
+*.p12
+*.pfx
+
 # Logs
 *.log
 npm-debug.log*


### PR DESCRIPTION
Small hardening follow-up to the secret-scanning work (CC6.1).

Adds to root `.gitignore`:
- `.npmrc.*` — blocks token-bearing npmrc variants (e.g. `.npmrc.release`, the source of a past npm-token leak) while keeping the committed config-only `.npmrc`.
- `*.pem`, `*.key`, `*.p12`, `*.pfx` — private keys / certs.

Verified safe: the only tracked match for key/cert patterns is `apps/mobile/android/app/debug.keystore` (standard Android debug keystore), and `*.key` does **not** match `.keystore`.

Defense-in-depth alongside the secret-scanning push protection + gitleaks gate already in place.