### PR TITLE
ci(dependabot): target newer-kortix (CI-gated security PRs)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,10 +6,14 @@ updates:
   # JS/TS dependencies (pnpm uses the npm ecosystem).
   - package-ecosystem: "npm"
     directory: "/"
+    # Active development happens on newer-kortix, not the default branch (main).
+    # PRs must target it so they land on the trunk AND get CI-gated (the
+    # typecheck/gitleaks/codeql workflows live on newer-kortix).
+    target-branch: "newer-kortix"
     schedule:
       interval: "weekly"
       day: "monday"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 20
     labels: ["dependencies"]
     groups:
       # Batch low-risk minor/patch bumps into one PR to cut review noise.
@@ -20,6 +24,7 @@ updates:
   # Keep GitHub Actions pinned and current (supply-chain hygiene).
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "newer-kortix"
     schedule:
       interval: "weekly"
       day: "monday"


### PR DESCRIPTION
Dependabot was opening PRs against `main` (100+ commits behind, and the typecheck/gitleaks/codeql workflows aren't there yet → no gating). Point it at the active trunk so its **range-scoped, per-package security PRs** land on `newer-kortix` and run CI.

This is the safe path to clear the 169 open alerts: each Dependabot PR is correctly version-scoped and CI-gated, vs. a hand-rolled blanket override that would force-break consumers needing modern majors.