### PR TITLE
feat(channels): slack v2 — multi-project routing, live streaming, native hitl, slash commands

### DIFF
--- a/apps/api/scripts/probe-slack-stream.ts
+++ b/apps/api/scripts/probe-slack-stream.ts
@@ -1,0 +1,214 @@
+// Manual probe for Slack's plan-mode streaming API.
+//
+// Loads the bot token from the project's encrypted secret store, then walks
+// through the chat.startStream → chat.appendStream → chat.stopStream lifecycle
+// against a real channel so we can see Slack's exact responses.
+//
+// Run: bun apps/api/scripts/probe-slack-stream.ts <channel> [project_id]
+
+import { createDecipheriv, hkdfSync } from 'node:crypto';
+import postgres from 'postgres';
+
+const DATABASE_URL = process.env.DATABASE_URL || 'postgresql://postgres:postgres@127.0.0.1:54322/postgres';
+const API_KEY_SECRET = process.env.API_KEY_SECRET || '69696';
+const SLACK_API = 'https://slack.com/api';
+
+function fromB64url(s: string): Buffer { return Buffer.from(s, 'base64url'); }
+
+function projectSecretKey(projectId: string): Buffer {
+  const key = hkdfSync('sha256',
+    Buffer.from(API_KEY_SECRET, 'utf8'),
+    Buffer.from(projectId, 'utf8'),
+    Buffer.from('kortix-project-secret-v1', 'utf8'),
+    32);
+  return Buffer.from(key);
+}
+
+function decrypt(projectId: string, env: string): string {
+  const [v, ivB64, tagB64, ctB64] = env.split(':');
+  if (v !== 'v1') throw new Error(`bad envelope: ${v}`);
+  const d = createDecipheriv('aes-256-gcm', projectSecretKey(projectId), fromB64url(ivB64));
+  d.setAuthTag(fromB64url(tagB64));
+  return Buffer.concat([d.update(fromB64url(ctB64)), d.final()]).toString('utf8');
+}
+
+async function slack(token: string, method: string, body: Record<string, unknown>): Promise<any> {
+  const res = await fetch(`${SLACK_API}/${method}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json; charset=utf-8', Authorization: `Bearer ${token}` },
+    body: JSON.stringify(body),
+  });
+  return res.json();
+}
+
+const channel = process.argv[2];
+const projectIdArg = process.argv[3];
+if (!channel) {
+  console.error('Usage: bun probe-slack-stream.ts <channel-id-or-name> [project_id]');
+  process.exit(1);
+}
+
+const sql = postgres(DATABASE_URL);
+
+const installs = projectIdArg
+  ? await sql<{ project_id: string; workspace_id: string }[]>`
+      SELECT project_id, workspace_id FROM kortix.chat_installs
+      WHERE platform='slack' AND project_id=${projectIdArg} LIMIT 1`
+  : await sql<{ project_id: string; workspace_id: string }[]>`
+      SELECT project_id, workspace_id FROM kortix.chat_installs
+      WHERE platform='slack' ORDER BY connected_at DESC LIMIT 1`;
+
+if (installs.length === 0) {
+  console.error('no chat_installs row found');
+  process.exit(1);
+}
+const { project_id: projectId, workspace_id: workspaceId } = installs[0];
+
+const [secretRow] = await sql<{ value_enc: string }[]>`
+  SELECT value_enc FROM kortix.project_secrets
+  WHERE project_id=${projectId} AND name='SLACK_BOT_TOKEN' LIMIT 1`;
+if (!secretRow) { console.error('no SLACK_BOT_TOKEN secret for project'); process.exit(1); }
+const token = decrypt(projectId, secretRow.value_enc);
+
+const auth = await slack(token, 'auth.test', {});
+console.log('--- auth.test ---'); console.log(auth);
+
+const meUserId = auth.user_id;
+const teamId = auth.team_id || workspaceId;
+
+// Resolve channel: U-prefix → open DM; C-prefix → use as-is; otherwise look
+// up by name via conversations.list.
+let channelId: string | null;
+if (channel.startsWith('U')) {
+  const open = await slack(token, 'conversations.open', { users: channel });
+  console.log('--- conversations.open ---'); console.log(open);
+  if (!open.ok) process.exit(1);
+  channelId = open.channel.id;
+  // The DM is "between Saumya and our bot" — recipient_user_id should be the
+  // human, not the bot.
+} else if (channel.startsWith('C') || channel.startsWith('D') || channel.startsWith('G')) {
+  channelId = channel;
+} else {
+  const list = await slack(token, 'conversations.list', {
+    limit: 1000,
+    types: 'public_channel,private_channel',
+    exclude_archived: true,
+  });
+  const channels = list.channels ?? [];
+  const found = channels.find((c: any) => c.name === channel);
+  channelId = found?.id ?? null;
+  console.log('--- conversations.list lookup ---');
+  console.log({ name: channel, id: channelId });
+}
+if (!channelId) { console.error('channel not found'); process.exit(1); }
+
+// In a DM, plan-mode streams should be addressed to the human user, not the bot.
+const recipientUserId = channel.startsWith('U') ? channel : meUserId;
+
+const triggerMsg = await slack(token, 'chat.postMessage', {
+  channel: channelId,
+  text: `🧪 stream probe ${new Date().toISOString()}`,
+});
+console.log('--- trigger postMessage ---'); console.log({ ok: triggerMsg.ok, ts: triggerMsg.ts, error: triggerMsg.error, channel: channelId });
+if (!triggerMsg.ok) process.exit(1);
+const threadTs: string = triggerMsg.ts;
+
+console.log('\n=== VARIANT A: startStream in thread of trigger msg (our current shape) ===');
+const startA = await slack(token, 'chat.startStream', {
+  channel: channelId,
+  thread_ts: threadTs,
+  recipient_user_id: recipientUserId,
+  recipient_team_id: teamId,
+  task_display_mode: 'plan',
+  chunks: [{ type: 'task_update', id: 'step-0', title: 'Probing…', status: 'in_progress' }],
+});
+console.log(startA);
+
+if (!startA.ok) {
+  console.log('\n=== VARIANT B: startStream without thread_ts (top-level in channel) ===');
+  const startB = await slack(token, 'chat.startStream', {
+    channel: channelId,
+    recipient_user_id: recipientUserId,
+    recipient_team_id: teamId,
+    task_display_mode: 'plan',
+    chunks: [{ type: 'task_update', id: 'step-0', title: 'Probing…', status: 'in_progress' }],
+  });
+  console.log(startB);
+
+  console.log('\n=== VARIANT C: post bot parent, startStream in its own thread ===');
+  const parent = await slack(token, 'chat.postMessage', { channel: channelId, text: 'Working on it…' });
+  console.log({ parent_ts: parent.ts, parent_ok: parent.ok });
+  if (parent.ok) {
+    const startC = await slack(token, 'chat.startStream', {
+      channel: channelId,
+      thread_ts: parent.ts,
+      recipient_user_id: recipientUserId,
+      recipient_team_id: teamId,
+      task_display_mode: 'plan',
+      chunks: [{ type: 'task_update', id: 'step-0', title: 'Probing…', status: 'in_progress' }],
+    });
+    console.log(startC);
+  }
+
+  console.log('\n=== VARIANT D: no task_display_mode (default) ===');
+  const startD = await slack(token, 'chat.startStream', {
+    channel: channelId,
+    thread_ts: threadTs,
+    recipient_user_id: recipientUserId,
+    recipient_team_id: teamId,
+    chunks: [{ type: 'markdown_text', text: 'streaming a plain reply' }],
+  });
+  console.log(startD);
+
+  console.log('\n=== VARIANT E: omit recipient_user_id/team_id ===');
+  const startE = await slack(token, 'chat.startStream', {
+    channel: channelId,
+    thread_ts: threadTs,
+    task_display_mode: 'plan',
+    chunks: [{ type: 'task_update', id: 'step-0', title: 'Probing…', status: 'in_progress' }],
+  });
+  console.log(startE);
+}
+
+if (startA.ok && startA.ts) {
+  const streamTs = startA.ts;
+
+  console.log('\n=== APPEND 1: complete step-0, add step-1 ===');
+  const a1 = await slack(token, 'chat.appendStream', {
+    channel: channelId,
+    ts: streamTs,
+    chunks: [
+      { type: 'task_update', id: 'step-0', title: 'Probing…', status: 'complete' },
+      { type: 'task_update', id: 'step-1', title: 'Searching the docs', status: 'in_progress' },
+    ],
+  });
+  console.log(a1);
+
+  await new Promise((r) => setTimeout(r, 800));
+
+  console.log('\n=== APPEND 2: complete step-1, add step-2 ===');
+  const a2 = await slack(token, 'chat.appendStream', {
+    channel: channelId,
+    ts: streamTs,
+    chunks: [
+      { type: 'task_update', id: 'step-1', title: 'Searching the docs', status: 'complete' },
+      { type: 'task_update', id: 'step-2', title: 'Writing the answer', status: 'in_progress' },
+    ],
+  });
+  console.log(a2);
+
+  await new Promise((r) => setTimeout(r, 800));
+
+  console.log('\n=== STOP: complete step-2 + markdown_text answer ===');
+  const stop = await slack(token, 'chat.stopStream', {
+    channel: channelId,
+    ts: streamTs,
+    chunks: [
+      { type: 'task_update', id: 'step-2', title: 'Writing the answer', status: 'complete' },
+      { type: 'markdown_text', text: '**done.** all three checkpoints showed up.' },
+    ],
+  });
+  console.log(stop);
+}
+
+await sql.end();

--- a/apps/api/src/channels/index.ts
+++ b/apps/api/src/channels/index.ts
@@ -20,7 +20,7 @@ export {
   type SlackManifest,
   type GenerateManifestInput,
 } from './slack-manifest';
-export { slackWebhookApp } from './slack-webhook';
+export { slackWebhookApp, relayTurnStep, relayTurnAnswer } from './slack-webhook';
 export { telegramWebhookApp } from './telegram-webhook';
 export { slackOauthApp, buildSlackInstallUrl } from './slack-oauth';
 export { slackOauthMode } from './slack-oauth-mode';

--- a/apps/api/src/channels/install-store.ts
+++ b/apps/api/src/channels/install-store.ts
@@ -1,5 +1,5 @@
 import { and, eq } from 'drizzle-orm';
-import { projectSecrets } from '@kortix/db';
+import { chatInstalls, projectSecrets } from '@kortix/db';
 import { db } from '../shared/db';
 import {
   decryptProjectSecret,
@@ -65,6 +65,58 @@ export async function deleteSlackInstall(projectId: string): Promise<void> {
       .delete(projectSecrets)
       .where(and(eq(projectSecrets.projectId, projectId), eq(projectSecrets.name, name)));
   }
+  await db
+    .delete(chatInstalls)
+    .where(and(eq(chatInstalls.platform, 'slack'), eq(chatInstalls.projectId, projectId)));
+}
+
+export interface SlackOauthInstallInput {
+  projectId: string;
+  workspaceId: string;
+  botToken: string;
+  botUserId: string;
+  teamName: string | null;
+}
+
+// Universal Kortix Slack App install. Records this project's membership of the
+// workspace, then fans the bot token + workspace metadata out to every project
+// on the workspace — Slack issues one token per (app, workspace) and a re-auth
+// rotates it, so all sharing projects must be kept current. The signing secret
+// is the master Kortix one and stays server-side; it is never persisted here.
+export async function saveSlackOauthInstall(
+  input: SlackOauthInstallInput,
+): Promise<SlackInstallSummary> {
+  await db
+    .insert(chatInstalls)
+    .values({ platform: 'slack', workspaceId: input.workspaceId, projectId: input.projectId })
+    .onConflictDoNothing();
+
+  const projectIds = await listProjectsForWorkspace('slack', input.workspaceId);
+  if (!projectIds.includes(input.projectId)) projectIds.push(input.projectId);
+  for (const projectId of projectIds) {
+    await upsertSecret(projectId, SLACK_BOT_TOKEN, input.botToken);
+    await upsertSecret(projectId, SLACK_TEAM_ID, input.workspaceId);
+    await upsertSecret(projectId, SLACK_BOT_USER_ID, input.botUserId);
+    await upsertSecret(projectId, SLACK_TEAM_NAME, input.teamName ?? '');
+  }
+
+  return {
+    workspaceId: input.workspaceId,
+    workspaceName: input.teamName,
+    botUserId: input.botUserId,
+    installedAt: new Date().toISOString(),
+  };
+}
+
+export async function listProjectsForWorkspace(
+  platform: string,
+  workspaceId: string,
+): Promise<string[]> {
+  const rows = await db
+    .select({ projectId: chatInstalls.projectId })
+    .from(chatInstalls)
+    .where(and(eq(chatInstalls.platform, platform), eq(chatInstalls.workspaceId, workspaceId)));
+  return rows.map((r) => r.projectId);
 }
 
 export async function loadSlackInstall(

--- a/apps/api/src/channels/slack-api.ts
+++ b/apps/api/src/channels/slack-api.ts
@@ -88,6 +88,21 @@ export async function updateMessage(
   }
 }
 
+export async function updateBlocks(
+  token: string,
+  channel: string,
+  ts: string,
+  text: string,
+  blocks: unknown[],
+): Promise<void> {
+  try {
+    const r = await slackApiCall(token, 'chat.update', { channel, ts, text, blocks });
+    if (!r.ok) console.warn('[slack-api] chat.update (blocks) failed', { error: r.error });
+  } catch (err) {
+    console.warn('[slack-api] chat.update (blocks) error', err);
+  }
+}
+
 export async function deleteMessage(token: string, channel: string, ts: string): Promise<void> {
   try {
     const r = await slackApiCall(token, 'chat.delete', { channel, ts });
@@ -96,6 +111,27 @@ export async function deleteMessage(token: string, channel: string, ts: string):
     }
   } catch (err) {
     console.warn('[slack-api] chat.delete error', err);
+  }
+}
+
+// chat.startStream requires the bot to be a member of the channel — posting
+// via chat:write.public is not enough. Join is idempotent (already-a-member
+// is `ok: true`). Returns false for private channels / DMs where join isn't
+// applicable; callers should treat that as non-fatal.
+export async function joinChannel(token: string, channel: string): Promise<boolean> {
+  try {
+    const r = await slackApiCall(token, 'conversations.join', { channel });
+    if (r.ok) return true;
+    // method_not_supported_for_channel_type → DM or private; nothing to join.
+    // already_in_channel → still a member, treat as success.
+    if (r.error === 'already_in_channel') return true;
+    if (r.error !== 'method_not_supported_for_channel_type') {
+      console.warn('[slack-api] conversations.join failed', { error: r.error, channel });
+    }
+    return false;
+  } catch (err) {
+    console.warn('[slack-api] conversations.join error', err);
+    return false;
   }
 }
 
@@ -141,6 +177,18 @@ export interface StreamTaskChunk {
   id: string;
   title: string;
   status: StreamTaskStatus;
+  // Optional inline rich text. Slack accepts these as plain strings on the
+  // streaming chunk and auto-wraps them into rich_text blocks server-side.
+  // `details` renders as the subtitle line under the task title (visible while
+  // in_progress); `output` renders as the bullet line shown after completion.
+  // Note: re-sending these for the same task_id APPENDS rather than replaces
+  // — only set them once per task_id.
+  details?: string;
+  output?: string;
+  // Citation footer rendered under the task card. Plain-string `details`
+  // and `output` accept `<url|text>` mrkdwn for inline links; `sources` is
+  // the dedicated, structured citation list.
+  sources?: Array<{ type: 'url'; url: string; text: string }>;
 }
 
 export interface StreamTextChunk {
@@ -148,10 +196,18 @@ export interface StreamTextChunk {
   text: string;
 }
 
-// A stream chunk — a plan checkpoint or a piece of answer text. The answer
-// must ride as a `markdown_text` chunk: chat.stopStream rejects a top-level
-// `markdown_text` param alongside `chunks`.
-export type StreamChunk = StreamTaskChunk | StreamTextChunk;
+// Full Block Kit closing chunk — use for rich answers (headers, sections,
+// images, context actions). Slack validates these against the standard
+// Block Kit schema. Only valid as a closing chunk on chat.stopStream.
+export interface StreamBlocksChunk {
+  type: 'blocks';
+  blocks: unknown[];
+}
+
+// A stream chunk — a plan checkpoint, a piece of answer text, or a full
+// Block Kit blocks payload. The answer must ride as `markdown_text` OR
+// `blocks` — chat.stopStream rejects top-level text alongside `chunks`.
+export type StreamChunk = StreamTaskChunk | StreamTextChunk | StreamBlocksChunk;
 
 export async function startStream(
   token: string,
@@ -211,6 +267,26 @@ export async function stopStream(
     }
   } catch (err) {
     console.warn('[slack-api] chat.stopStream error', err);
+  }
+}
+
+// Publish a Block Kit view to a user's App Home tab. View shape:
+//   { type: 'home', blocks: [...Block Kit blocks] }
+export async function publishHomeView(
+  token: string,
+  userId: string,
+  view: Record<string, unknown>,
+): Promise<boolean> {
+  try {
+    const r = await slackApiCall(token, 'views.publish', { user_id: userId, view });
+    if (!r.ok) {
+      console.warn('[slack-api] views.publish failed', { error: r.error, user_id: userId });
+      return false;
+    }
+    return true;
+  } catch (err) {
+    console.warn('[slack-api] views.publish error', err);
+    return false;
   }
 }
 

--- a/apps/api/src/channels/slack-api.ts
+++ b/apps/api/src/channels/slack-api.ts
@@ -1,0 +1,226 @@
+const SLACK_API_BASE = 'https://slack.com/api';
+
+interface SlackApiResult {
+  ok: boolean;
+  error?: string;
+  ts?: string;
+  [key: string]: unknown;
+}
+
+async function slackApiCall(
+  token: string,
+  method: string,
+  body: Record<string, unknown>,
+): Promise<SlackApiResult> {
+  const res = await fetch(`${SLACK_API_BASE}/${method}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(body),
+    signal: AbortSignal.timeout(10_000),
+  });
+  return (await res.json()) as SlackApiResult;
+}
+
+// Posts a plain message. Returns the message ts (needed to delete it later).
+export async function postMessage(
+  token: string,
+  channel: string,
+  text: string,
+  threadTs?: string,
+): Promise<string | null> {
+  try {
+    const r = await slackApiCall(token, 'chat.postMessage', {
+      channel,
+      text,
+      ...(threadTs ? { thread_ts: threadTs } : {}),
+    });
+    if (!r.ok) {
+      console.warn('[slack-api] chat.postMessage failed', { error: r.error });
+      return null;
+    }
+    return typeof r.ts === 'string' ? r.ts : null;
+  } catch (err) {
+    console.warn('[slack-api] chat.postMessage error', err);
+    return null;
+  }
+}
+
+// Posts a Block Kit message and returns its ts (needed to edit it later).
+export async function postBlocks(
+  token: string,
+  channel: string,
+  text: string,
+  blocks: unknown[],
+  threadTs?: string,
+): Promise<string | null> {
+  try {
+    const r = await slackApiCall(token, 'chat.postMessage', {
+      channel,
+      text,
+      blocks,
+      ...(threadTs ? { thread_ts: threadTs } : {}),
+    });
+    if (!r.ok) {
+      console.warn('[slack-api] postBlocks failed', { error: r.error });
+      return null;
+    }
+    return typeof r.ts === 'string' ? r.ts : null;
+  } catch (err) {
+    console.warn('[slack-api] postBlocks error', err);
+    return null;
+  }
+}
+
+export async function updateMessage(
+  token: string,
+  channel: string,
+  ts: string,
+  text: string,
+): Promise<void> {
+  try {
+    const r = await slackApiCall(token, 'chat.update', { channel, ts, text, blocks: [] });
+    if (!r.ok) console.warn('[slack-api] chat.update failed', { error: r.error });
+  } catch (err) {
+    console.warn('[slack-api] chat.update error', err);
+  }
+}
+
+export async function deleteMessage(token: string, channel: string, ts: string): Promise<void> {
+  try {
+    const r = await slackApiCall(token, 'chat.delete', { channel, ts });
+    if (!r.ok && r.error !== 'message_not_found') {
+      console.warn('[slack-api] chat.delete failed', { error: r.error });
+    }
+  } catch (err) {
+    console.warn('[slack-api] chat.delete error', err);
+  }
+}
+
+export async function addReaction(
+  token: string,
+  channel: string,
+  timestamp: string,
+  name: string,
+): Promise<void> {
+  try {
+    const r = await slackApiCall(token, 'reactions.add', { channel, timestamp, name });
+    if (!r.ok && r.error !== 'already_reacted') {
+      console.warn('[slack-api] reactions.add failed', { error: r.error });
+    }
+  } catch (err) {
+    console.warn('[slack-api] reactions.add error', err);
+  }
+}
+
+export async function removeReaction(
+  token: string,
+  channel: string,
+  timestamp: string,
+  name: string,
+): Promise<void> {
+  try {
+    const r = await slackApiCall(token, 'reactions.remove', { channel, timestamp, name });
+    if (!r.ok && r.error !== 'no_reaction') {
+      console.warn('[slack-api] reactions.remove failed', { error: r.error });
+    }
+  } catch (err) {
+    console.warn('[slack-api] reactions.remove error', err);
+  }
+}
+
+// ─── Streaming (chat.startStream / appendStream / stopStream) ────────────────
+// Renders a live plan block in a channel thread. task_update chunks are the
+// plan checkpoints; markdown_text is the final answer body.
+export type StreamTaskStatus = 'pending' | 'in_progress' | 'complete' | 'error';
+
+export interface StreamTaskChunk {
+  type: 'task_update';
+  id: string;
+  title: string;
+  status: StreamTaskStatus;
+}
+
+export interface StreamTextChunk {
+  type: 'markdown_text';
+  text: string;
+}
+
+// A stream chunk — a plan checkpoint or a piece of answer text. The answer
+// must ride as a `markdown_text` chunk: chat.stopStream rejects a top-level
+// `markdown_text` param alongside `chunks`.
+export type StreamChunk = StreamTaskChunk | StreamTextChunk;
+
+export async function startStream(
+  token: string,
+  channel: string,
+  threadTs: string,
+  recipientUserId: string,
+  recipientTeamId: string,
+  chunks: StreamChunk[],
+): Promise<string | null> {
+  try {
+    const r = await slackApiCall(token, 'chat.startStream', {
+      channel,
+      thread_ts: threadTs,
+      recipient_user_id: recipientUserId,
+      recipient_team_id: recipientTeamId,
+      task_display_mode: 'plan',
+      chunks,
+    });
+    if (!r.ok) {
+      console.warn('[slack-api] chat.startStream failed', { error: r.error });
+      return null;
+    }
+    return typeof r.ts === 'string' ? r.ts : null;
+  } catch (err) {
+    console.warn('[slack-api] chat.startStream error', err);
+    return null;
+  }
+}
+
+export async function appendStream(
+  token: string,
+  channel: string,
+  ts: string,
+  chunks: StreamChunk[],
+): Promise<void> {
+  try {
+    const r = await slackApiCall(token, 'chat.appendStream', { channel, ts, chunks });
+    if (!r.ok) console.warn('[slack-api] chat.appendStream failed', { error: r.error });
+  } catch (err) {
+    console.warn('[slack-api] chat.appendStream error', err);
+  }
+}
+
+// Finalize a stream. The closing chunks carry the last checkpoint state and the
+// answer as a `markdown_text` chunk.
+export async function stopStream(
+  token: string,
+  channel: string,
+  ts: string,
+  chunks: StreamChunk[],
+): Promise<void> {
+  try {
+    const r = await slackApiCall(token, 'chat.stopStream', { channel, ts, chunks });
+    // A watchdog stop can race the agent's own stop — ignore "already stopped".
+    if (!r.ok && r.error !== 'message_not_streaming' && r.error !== 'cant_update_message') {
+      console.warn('[slack-api] chat.stopStream failed', { error: r.error });
+    }
+  } catch (err) {
+    console.warn('[slack-api] chat.stopStream error', err);
+  }
+}
+
+export async function getChannelName(token: string, channel: string): Promise<string | null> {
+  try {
+    const r = await slackApiCall(token, 'conversations.info', { channel });
+    if (!r.ok) return null;
+    const info = r.channel as { name?: string } | undefined;
+    return info?.name ?? null;
+  } catch {
+    return null;
+  }
+}

--- a/apps/api/src/channels/slack-app-manifest.json
+++ b/apps/api/src/channels/slack-app-manifest.json
@@ -1,15 +1,29 @@
 {
-  "_comment": "Static manifest for the universal Kortix Slack App (OAuth mode). Paste at https://api.slack.com/apps → 'Create New App' → 'From a manifest'. Swap every occurrence of https://frugal-ranunculaceous-patrica.ngrok-free.dev for your production public URL (e.g. https://api.kortix.com) before going live.",
   "display_information": {
-    "name": "Kortix",
-    "description": "Run Kortix project sessions from Slack — @-mention the bot in any invited channel and the agent replies in-thread.",
+    "name": "KortixDevTest",
+    "description": "A coding teammate that lives in your Slack",
+    "long_description": "Kortix is a coding teammate for your Slack workspace.\n\nInvite the bot to a channel, @-mention it with a task, and it'll get on it: reading your codebase, running the work in an isolated sandbox, and replying in the thread as it goes. Follow-ups stay in the same conversation — Kortix remembers the context.\n\n*What it can do*\n• Read your repo, search docs, summarize threads\n• Open PRs, edit files, run scripts and tests in a real sandbox\n• Pull data, generate reports, share CSVs and files back into the thread\n• Pick up where it left off — every thread keeps its full context\n\n*A few things teammates ask it*\n• `@Kortix scan this codebase and write me a one-pager`\n• `@Kortix open a PR that switches our logger to pino`\n• `@Kortix what changed on main this week?`\n• `@Kortix pull yesterday's sign-ups, group them by source, drop the CSV here`\n\nConnect a Kortix project once, then talk to Kortix like you'd talk to anyone else on the team. No slash commands. No copy-paste. Just @-mention and reply.\n\n*AI Disclaimer*\nKortix uses AI to generate responses and perform tasks. While we strive for accuracy, AI-generated content may occasionally contain errors. Review important outputs before acting on them.\n\nManaged by Kortix · https://kortix.com",
     "background_color": "#0a0a0a"
   },
   "features": {
+    "app_home": {
+      "home_tab_enabled": true,
+      "messages_tab_enabled": true,
+      "messages_tab_read_only_enabled": false
+    },
     "bot_user": {
-      "display_name": "Kortix",
+      "display_name": "KortixDevTest",
       "always_online": true
-    }
+    },
+    "slash_commands": [
+      {
+        "command": "/kortix",
+        "url": "https://frugal-ranunculaceous-patrica.ngrok-free.dev/v1/webhooks/slack/commands",
+        "description": "Manage your Kortix project from Slack",
+        "usage_hint": "[projects | switch | unbind | sessions | whoami | help]",
+        "should_escape": false
+      }
+    ]
   },
   "oauth_config": {
     "redirect_urls": [
@@ -34,7 +48,11 @@
         "mpim:read",
         "reactions:read",
         "reactions:write",
-        "users:read"
+        "users:read",
+        "team:read",
+        "links:read",
+        "links:write",
+        "commands"
       ]
     }
   },
@@ -47,6 +65,7 @@
       "request_url": "https://frugal-ranunculaceous-patrica.ngrok-free.dev/v1/webhooks/slack",
       "bot_events": [
         "app_mention",
+        "app_home_opened",
         "message.im",
         "message.channels",
         "message.groups",
@@ -54,7 +73,8 @@
         "reaction_added",
         "reaction_removed",
         "member_joined_channel",
-        "file_shared"
+        "file_shared",
+        "link_shared"
       ]
     },
     "org_deploy_enabled": false,

--- a/apps/api/src/channels/slack-app-manifest.json
+++ b/apps/api/src/channels/slack-app-manifest.json
@@ -39,6 +39,10 @@
     }
   },
   "settings": {
+    "interactivity": {
+      "is_enabled": true,
+      "request_url": "https://frugal-ranunculaceous-patrica.ngrok-free.dev/v1/webhooks/slack/interactivity"
+    },
     "event_subscriptions": {
       "request_url": "https://frugal-ranunculaceous-patrica.ngrok-free.dev/v1/webhooks/slack",
       "bot_events": [

--- a/apps/api/src/channels/slack-oauth.ts
+++ b/apps/api/src/channels/slack-oauth.ts
@@ -1,12 +1,12 @@
 import { Hono } from 'hono';
 import type { Context } from 'hono';
 import { createHmac, timingSafeEqual, randomBytes } from 'node:crypto';
-import { eq, sql } from 'drizzle-orm';
-import { chatChannelBindings, projects } from '@kortix/db';
+import { eq } from 'drizzle-orm';
+import { projects } from '@kortix/db';
 import { db } from '../shared/db';
 import { config } from '../config';
 import { slackOauthMode } from './slack-oauth-mode';
-import { saveSlackInstall } from './install-store';
+import { saveSlackOauthInstall } from './install-store';
 
 const STATE_TTL_MS = 10 * 60 * 1000;
 
@@ -101,26 +101,13 @@ slackOauthApp.get('/callback', async (c) => {
     .limit(1);
   if (!project) return redirectToDashboard(c, { error: 'project_not_found' });
 
-  await saveSlackInstall({
+  await saveSlackOauthInstall({
     projectId: payload.projectId,
+    workspaceId: tokenJson.team.id,
     botToken: tokenJson.access_token,
-    signingSecret: mode.signingSecret ?? '',
-    teamId: tokenJson.team.id,
-    teamName: tokenJson.team.name ?? null,
     botUserId: tokenJson.bot_user_id ?? '',
+    teamName: tokenJson.team.name ?? null,
   });
-
-  await db
-    .insert(chatChannelBindings)
-    .values({
-      projectId: payload.projectId,
-      platform: 'slack',
-      workspaceId: tokenJson.team.id,
-    })
-    .onConflictDoUpdate({
-      target: [chatChannelBindings.platform, chatChannelBindings.workspaceId],
-      set: { projectId: payload.projectId, installedAt: sql`now()` },
-    });
 
   return redirectToDashboard(c, { projectId: payload.projectId, success: '1' });
 });

--- a/apps/api/src/channels/slack-webhook.ts
+++ b/apps/api/src/channels/slack-webhook.ts
@@ -1,26 +1,214 @@
 import { Hono } from 'hono';
-import { createHmac, timingSafeEqual } from 'node:crypto';
-import { and, eq, sql } from 'drizzle-orm';
-import { chatChannelBindings, chatThreads, projects, sessionSandboxes } from '@kortix/db';
+import { createHmac, randomUUID, timingSafeEqual } from 'node:crypto';
+import { and, eq, inArray, sql } from 'drizzle-orm';
+import {
+  chatChannelBindings,
+  chatInstalls,
+  chatThreads,
+  projects,
+  sessionSandboxes,
+} from '@kortix/db';
 import { db } from '../shared/db';
 import { getDaytona } from '../shared/daytona';
-import {
-  createProjectSession,
-  resolveGitTriggerActor,
-} from '../projects';
+import { createProjectSession, resolveGitTriggerActor } from '../projects';
 import {
   loadSlackBotUserIdForProject,
   loadSlackSigningSecretForProject,
+  loadSlackTokenForProject,
 } from './install-store';
 import { slackOauthMode } from './slack-oauth-mode';
+import {
+  addReaction,
+  appendStream,
+  getChannelName,
+  postBlocks,
+  postMessage,
+  removeReaction,
+  startStream,
+  stopStream,
+  updateMessage,
+  type StreamChunk,
+  type StreamTaskChunk,
+} from './slack-api';
 
 export const slackWebhookApp = new Hono();
 
 const FIVE_MINUTES = 5 * 60;
 
+// Slack-triggered agent turns run on this model (provider/model form). It is
+// passed through to opencode's prompt API for the session's sandbox only.
+const SLACK_AGENT_MODEL = 'anthropic/claude-sonnet-4-6';
+
+// ─── Event de-duplication ────────────────────────────────────────────────────
+// Slack re-delivers an event if it doesn't get a 200 within 3s. Without this, a
+// retry spawns a second sandbox for one message. `event_id` is stable across
+// re-deliveries, so a short-TTL seen-set collapses them.
+const EVENT_DEDUPE_TTL_MS = 5 * 60 * 1000;
+const seenEventIds = new Map<string, number>();
+
+function alreadyHandled(eventId: string | undefined): boolean {
+  if (!eventId) return false;
+  const now = Date.now();
+  for (const [id, expiry] of seenEventIds) {
+    if (expiry < now) seenEventIds.delete(id);
+  }
+  if (seenEventIds.has(eventId)) return true;
+  seenEventIds.set(eventId, now + EVENT_DEDUPE_TTL_MS);
+  return false;
+}
+
+// ─── Turn stream ─────────────────────────────────────────────────────────────
+// Each triggering turn opens a Slack stream (chat.startStream) — a live plan
+// block. apps/api owns the stream object: it starts it, posts the boot
+// checkpoint, finalizes on failure, and exposes relay helpers the agent calls
+// (via the agent-cli) to narrate checkpoints and deliver the final answer.
+const WORKING_EMOJI = 'hourglass_flowing_sand';
+const STREAM_TTL_MS = 15 * 60 * 1000;
+
+interface TurnStream {
+  channel: string;
+  ts: string;
+  token: string;
+  triggerTs: string;
+  steps: StreamTaskChunk[];
+  streaming: boolean; // false = chat.startStream unavailable, plain-message fallback
+  expiry: number;
+  finalized: boolean;
+}
+
+// Keyed by Kortix session id — the agent-cli relays by session id.
+const activeStreams = new Map<string, TurnStream>();
+
+// Watchdog — a turn whose stream never finalized (agent crash, opencode
+// restart) gets a visible close instead of a forever-"Working…".
+setInterval(() => {
+  const now = Date.now();
+  for (const [sessionId, handle] of activeStreams) {
+    if (!handle.finalized && handle.expiry < now) {
+      activeStreams.delete(sessionId);
+      void finalizeStream(handle, { error: '_The run stopped unexpectedly — try again._' });
+    }
+  }
+}, 60_000).unref();
+
+// Open a stream for a turn. Returns an unbound handle — the caller binds it to
+// the session id once known.
+async function startTurnStream(
+  projectId: string,
+  teamId: string,
+  event: SlackEvent,
+  firstStepTitle: string,
+): Promise<TurnStream | null> {
+  if (!event.channel || !event.ts || !event.user) return null;
+  const token = await loadSlackTokenForProject(projectId);
+  if (!token) return null;
+  const bootStep: StreamTaskChunk = {
+    type: 'task_update',
+    id: 'step-0',
+    title: firstStepTitle,
+    status: 'in_progress',
+  };
+  const threadTs = event.thread_ts ?? event.ts;
+  await addReaction(token, event.channel, event.ts, WORKING_EMOJI);
+
+  const base = {
+    channel: event.channel,
+    token,
+    triggerTs: event.ts,
+    expiry: Date.now() + STREAM_TTL_MS,
+    finalized: false,
+  };
+  const streamTs = await startStream(
+    token,
+    event.channel,
+    threadTs,
+    event.user,
+    teamId,
+    [bootStep],
+  );
+  if (streamTs) {
+    return { ...base, ts: streamTs, steps: [bootStep], streaming: true };
+  }
+  // chat.startStream unavailable — fall back to a plain placeholder message
+  // that the final answer edits into place.
+  const placeholderTs = await postMessage(
+    token,
+    event.channel,
+    '⏳ _Kortix is working on it…_',
+    threadTs,
+  );
+  if (!placeholderTs) return null;
+  return { ...base, ts: placeholderTs, steps: [], streaming: false };
+}
+
+// Complete the current checkpoint and append a new one. Returns false when
+// there is no live stream for the session (e.g. a non-Slack session).
+export async function relayTurnStep(sessionId: string, title: string): Promise<boolean> {
+  const handle = activeStreams.get(sessionId);
+  if (!handle || handle.finalized) return false;
+  // Plain-message fallback has no plan block — accept the step but no-op it so
+  // the agent doesn't treat it as a failure.
+  if (!handle.streaming) {
+    handle.expiry = Date.now() + STREAM_TTL_MS;
+    return true;
+  }
+  const chunks: StreamTaskChunk[] = [];
+  const last = handle.steps[handle.steps.length - 1];
+  if (last && last.status === 'in_progress') {
+    last.status = 'complete';
+    chunks.push({ ...last });
+  }
+  const next: StreamTaskChunk = {
+    type: 'task_update',
+    id: `step-${handle.steps.length}`,
+    title: title.slice(0, 200),
+    status: 'in_progress',
+  };
+  handle.steps.push(next);
+  chunks.push(next);
+  handle.expiry = Date.now() + STREAM_TTL_MS;
+  await appendStream(handle.token, handle.channel, handle.ts, chunks);
+  return true;
+}
+
+// Finalize the stream with the agent's answer.
+export async function relayTurnAnswer(sessionId: string, text: string): Promise<boolean> {
+  const handle = activeStreams.get(sessionId);
+  if (!handle || handle.finalized) return false;
+  activeStreams.delete(sessionId);
+  await finalizeStream(handle, { answer: text });
+  return true;
+}
+
+async function finalizeStream(
+  handle: TurnStream,
+  opts: { answer?: string; error?: string },
+): Promise<void> {
+  if (handle.finalized) return;
+  handle.finalized = true;
+  const body = (opts.answer ?? opts.error ?? '_Done._').slice(0, 11000);
+  if (handle.streaming) {
+    // Closing chunks: the last checkpoint's final state + the answer as a
+    // markdown_text chunk (chat.stopStream rejects a top-level markdown_text).
+    const chunks: StreamChunk[] = [];
+    const last = handle.steps[handle.steps.length - 1];
+    if (last && last.status === 'in_progress') {
+      last.status = opts.error ? 'error' : 'complete';
+      chunks.push({ ...last });
+    }
+    chunks.push({ type: 'markdown_text', text: body });
+    await stopStream(handle.token, handle.channel, handle.ts, chunks);
+  } else {
+    await updateMessage(handle.token, handle.channel, handle.ts, body);
+  }
+  await removeReaction(handle.token, handle.channel, handle.triggerTs, WORKING_EMOJI);
+}
+
+// ─── Project picker ──────────────────────────────────────────────────────────
+const PICKER_TTL_MS = 60 * 60 * 1000;
+const pendingPickers = new Map<string, { envelope: SlackEnvelope; expiry: number }>();
+
 // OAuth mode — single endpoint, shared signing secret, route by team_id.
-// Reached when the Kortix Slack App posts events here. Returns 503 if the
-// server isn't configured for OAuth (BYO mode users hit /:projectId instead).
 slackWebhookApp.post('/', async (c) => {
   const mode = slackOauthMode();
   if (!mode.available || !mode.signingSecret) {
@@ -38,29 +226,256 @@ slackWebhookApp.post('/', async (c) => {
   if (!envelope) return c.json({ error: 'Invalid JSON' }, 400);
   if (envelope.type === 'url_verification') return c.json({ challenge: envelope.challenge });
   if (envelope.type !== 'event_callback' || !envelope.event) return c.json({ ok: true });
+  if (alreadyHandled(envelope.event_id)) return c.json({ ok: true });
 
-  const teamId = envelope.team_id ?? envelope.event.team ?? '';
-  if (!teamId) return c.json({ ok: true });
+  void (async () => {
+    const teamId = envelope.team_id ?? envelope.event?.team ?? '';
+    if (!teamId) return;
+    const resolution = await resolveOauthProject(teamId, envelope.event?.channel);
+    if (resolution.kind === 'project') {
+      await dispatchSlackEvent(resolution.projectId, envelope);
+    } else if (resolution.kind === 'ambiguous') {
+      await maybePostPicker(teamId, resolution.projectIds, envelope);
+    }
+  })().catch((err) => console.error('[slack-webhook] oauth handler failed', err));
 
-  const [binding] = await db
-    .select({ projectId: chatChannelBindings.projectId })
-    .from(chatChannelBindings)
+  return c.json({ ok: true });
+});
+
+// Slack interactivity (Block Kit button clicks). Registered before /:projectId
+// so the literal path wins over the BYO param route.
+slackWebhookApp.post('/interactivity', async (c) => {
+  const mode = slackOauthMode();
+  if (!mode.available || !mode.signingSecret) {
+    return c.json({ error: 'OAuth mode not configured' }, 503);
+  }
+  const rawBody = await c.req.text();
+  const timestamp = c.req.header('x-slack-request-timestamp') ?? '';
+  const signature = c.req.header('x-slack-signature') ?? '';
+  if (!verifySlackSignature(rawBody, timestamp, signature, mode.signingSecret)) {
+    return c.json({ error: 'Invalid signature' }, 401);
+  }
+  const payloadRaw = new URLSearchParams(rawBody).get('payload');
+  if (!payloadRaw) return c.json({ ok: true });
+  let payload: SlackInteractionPayload;
+  try {
+    payload = JSON.parse(payloadRaw) as SlackInteractionPayload;
+  } catch {
+    return c.json({ ok: true });
+  }
+  if (payload.type === 'block_actions') {
+    void handleBlockAction(payload).catch((err) =>
+      console.error('[slack-webhook] block action failed', err),
+    );
+  }
+  return c.json({ ok: true });
+});
+
+type ProjectResolution =
+  | { kind: 'project'; projectId: string }
+  | { kind: 'ambiguous'; projectIds: string[] }
+  | { kind: 'pending' }
+  | { kind: 'none' };
+
+// Resolve which Kortix project an OAuth-mode Slack event belongs to.
+//   1. A per-channel binding wins; a NULL-project binding = picker pending.
+//   2. Else, if the workspace has exactly one project, use it and bind lazily.
+//   3. Else (2+ projects, unbound channel) it is ambiguous — post a picker.
+async function resolveOauthProject(
+  teamId: string,
+  channelId: string | undefined,
+): Promise<ProjectResolution> {
+  if (channelId) {
+    const [binding] = await db
+      .select({ projectId: chatChannelBindings.projectId })
+      .from(chatChannelBindings)
+      .where(
+        and(
+          eq(chatChannelBindings.platform, 'slack'),
+          eq(chatChannelBindings.workspaceId, teamId),
+          eq(chatChannelBindings.channelId, channelId),
+        ),
+      )
+      .limit(1);
+    if (binding) {
+      return binding.projectId
+        ? { kind: 'project', projectId: binding.projectId }
+        : { kind: 'pending' };
+    }
+  }
+
+  const installs = await db
+    .select({ projectId: chatInstalls.projectId })
+    .from(chatInstalls)
+    .where(and(eq(chatInstalls.platform, 'slack'), eq(chatInstalls.workspaceId, teamId)));
+  if (installs.length === 0) return { kind: 'none' };
+  if (installs.length === 1) {
+    const onlyProjectId = installs[0].projectId;
+    if (channelId) {
+      await db
+        .insert(chatChannelBindings)
+        .values({ platform: 'slack', workspaceId: teamId, channelId, projectId: onlyProjectId })
+        .onConflictDoNothing();
+    }
+    return { kind: 'project', projectId: onlyProjectId };
+  }
+  return { kind: 'ambiguous', projectIds: installs.map((i) => i.projectId) };
+}
+
+// Post a Block Kit project picker for an ambiguous channel and park the
+// triggering event until a button is clicked.
+async function maybePostPicker(
+  teamId: string,
+  projectIds: string[],
+  envelope: SlackEnvelope,
+): Promise<void> {
+  const event = envelope.event;
+  if (!event || !event.channel || event.bot_id) return;
+  const isMention = event.type === 'app_mention';
+  const isDm = event.type === 'message' && event.channel_type === 'im' && !event.subtype;
+  if (!isMention && !isDm) return;
+
+  const channelId = event.channel;
+  const claimed = await db
+    .insert(chatChannelBindings)
+    .values({ platform: 'slack', workspaceId: teamId, channelId, projectId: null })
+    .onConflictDoNothing()
+    .returning({ id: chatChannelBindings.bindingId });
+  if (claimed.length === 0) return;
+
+  const token = await loadSlackTokenForProject(projectIds[0]);
+  if (!token) return;
+
+  const projectRows = await db
+    .select({ projectId: projects.projectId, name: projects.name })
+    .from(projects)
+    .where(inArray(projects.projectId, projectIds));
+
+  const pickerId = randomUUID();
+  const channelName = isDm ? null : await getChannelName(token, channelId);
+  const channelLabel = isDm ? 'this DM' : channelName ? `#${channelName}` : `<#${channelId}>`;
+
+  const blocks = [
+    {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: `*Which project should ${channelLabel} use?*\nAsked once — I'll remember it for this channel.`,
+      },
+    },
+    {
+      type: 'actions',
+      elements: projectRows.map((row, idx) => ({
+        type: 'button',
+        text: { type: 'plain_text', text: row.name.slice(0, 75) },
+        value: JSON.stringify({ k: pickerId, p: row.projectId }),
+        action_id: `pick_project_${idx}`,
+      })),
+    },
+  ];
+
+  const now = Date.now();
+  for (const [k, v] of pendingPickers) {
+    if (v.expiry < now) pendingPickers.delete(k);
+  }
+  pendingPickers.set(pickerId, { envelope, expiry: now + PICKER_TTL_MS });
+
+  const pickerTs = await postBlocks(
+    token,
+    channelId,
+    `Which project should ${channelLabel} use?`,
+    blocks,
+    event.thread_ts ?? event.ts,
+  );
+  if (pickerTs) {
+    await db
+      .update(chatChannelBindings)
+      .set({ pickerTs, channelName: channelName ?? null })
+      .where(
+        and(
+          eq(chatChannelBindings.platform, 'slack'),
+          eq(chatChannelBindings.workspaceId, teamId),
+          eq(chatChannelBindings.channelId, channelId),
+        ),
+      );
+  }
+}
+
+// Handle a project-picker button click.
+async function handleBlockAction(payload: SlackInteractionPayload): Promise<void> {
+  const action = payload.actions?.[0];
+  if (!action?.action_id?.startsWith('pick_project')) return;
+  let value: { k?: string; p?: string };
+  try {
+    value = JSON.parse(action.value ?? '{}') as { k?: string; p?: string };
+  } catch {
+    return;
+  }
+  const pickerId = value.k;
+  const projectId = value.p;
+  const teamId = payload.team?.id ?? '';
+  const channelId = payload.channel?.id ?? '';
+  const pickerTs = payload.message?.ts ?? '';
+  if (!pickerId || !projectId || !teamId || !channelId) return;
+
+  const token = await loadSlackTokenForProject(projectId);
+
+  const stillInstalled = await db
+    .select({ id: chatInstalls.installId })
+    .from(chatInstalls)
+    .where(
+      and(
+        eq(chatInstalls.platform, 'slack'),
+        eq(chatInstalls.workspaceId, teamId),
+        eq(chatInstalls.projectId, projectId),
+      ),
+    )
+    .limit(1);
+  if (stillInstalled.length === 0) {
+    if (token && pickerTs) {
+      await updateMessage(
+        token,
+        channelId,
+        pickerTs,
+        'That project is no longer connected here — @mention me again to pick another.',
+      );
+    }
+    return;
+  }
+
+  await db
+    .update(chatChannelBindings)
+    .set({ projectId, pickerTs: null })
     .where(
       and(
         eq(chatChannelBindings.platform, 'slack'),
         eq(chatChannelBindings.workspaceId, teamId),
+        eq(chatChannelBindings.channelId, channelId),
       ),
-    )
+    );
+
+  const [proj] = await db
+    .select({ name: projects.name })
+    .from(projects)
+    .where(eq(projects.projectId, projectId))
     .limit(1);
-  if (!binding) return c.json({ ok: true });
+  if (token && pickerTs) {
+    await updateMessage(
+      token,
+      channelId,
+      pickerTs,
+      `✓ Linked <#${channelId}> to *${proj?.name ?? 'project'}*.`,
+    );
+  }
 
-  await dispatchSlackEvent(binding.projectId, envelope);
-  return c.json({ ok: true });
-});
+  const pending = pendingPickers.get(pickerId);
+  if (pending) {
+    pendingPickers.delete(pickerId);
+    await dispatchSlackEvent(projectId, pending.envelope);
+  }
+}
 
-// BYO mode — per-project URL, per-project signing secret. The "bring your own
-// Slack app" path for users who can't / won't install the shared Kortix Slack
-// App. No bindings table lookup needed; project is in the URL.
+// BYO mode — per-project URL, per-project signing secret.
 slackWebhookApp.post('/:projectId', async (c) => {
   const projectId = c.req.param('projectId');
   const rawBody = await c.req.text();
@@ -78,28 +493,81 @@ slackWebhookApp.post('/:projectId', async (c) => {
   if (!envelope) return c.json({ error: 'Invalid JSON' }, 400);
   if (envelope.type === 'url_verification') return c.json({ challenge: envelope.challenge });
   if (envelope.type !== 'event_callback' || !envelope.event) return c.json({ ok: true });
+  if (alreadyHandled(envelope.event_id)) return c.json({ ok: true });
 
-  await dispatchSlackEvent(projectId, envelope);
+  void dispatchSlackEvent(projectId, envelope).catch((err) =>
+    console.error('[slack-webhook] byo handler failed', err),
+  );
   return c.json({ ok: true });
 });
+
+type EventClass = 'mention' | 'dm' | 'follow_up' | 'ignore';
+
+// Decide whether a Slack event should trigger an agent turn.
+async function classifyEvent(
+  teamId: string,
+  event: SlackEvent,
+  botUserId: string | null,
+): Promise<EventClass> {
+  if (event.type === 'app_mention') return 'mention';
+  if (event.type !== 'message') return 'ignore';
+  if (event.subtype) return 'ignore';
+  // Slack delivers both `app_mention` and `message.*` for a message that
+  // mentions the bot. `app_mention` owns those; drop the message twin.
+  if (botUserId && (event.text ?? '').includes(`<@${botUserId}>`)) return 'ignore';
+  if (event.channel_type === 'im') return 'dm';
+  if (event.thread_ts && (await threadIsOwned(teamId, event.thread_ts))) return 'follow_up';
+  return 'ignore';
+}
+
+async function threadIsOwned(teamId: string, threadTs: string): Promise<boolean> {
+  const [row] = await db
+    .select({ id: chatThreads.threadRowId })
+    .from(chatThreads)
+    .where(
+      and(
+        eq(chatThreads.platform, 'slack'),
+        eq(chatThreads.workspaceId, teamId),
+        eq(chatThreads.threadId, threadTs),
+      ),
+    )
+    .limit(1);
+  return !!row;
+}
+
+function stripMentions(text: string): string {
+  return text.replace(/<@[A-Z0-9]+>/g, '').trim();
+}
 
 async function dispatchSlackEvent(projectId: string, envelope: SlackEnvelope): Promise<void> {
   const event = envelope.event;
   if (!event) return;
 
+  const teamId = envelope.team_id ?? event.team ?? '';
   const botUserId = await loadSlackBotUserIdForProject(projectId);
-  if (botUserId && event.user === botUserId) return;
-  if (event.bot_id) return;
 
-  const shouldTrigger =
-    event.type === 'app_mention' ||
-    (event.type === 'message' && event.channel_type === 'im') ||
-    (event.type === 'message' && event.thread_ts && !event.subtype);
-  if (!shouldTrigger) return;
+  // Echo guard — never process the bot's own messages (including its streamed
+  // message and the stream's edits).
+  if ((botUserId && event.user === botUserId) || event.bot_id) return;
 
-  spawnAgentTurn(projectId, envelope, event).catch((err) =>
-    console.error('[slack-webhook] spawn failed', err),
-  );
+  const eventClass = await classifyEvent(teamId, event, botUserId);
+  if (eventClass === 'ignore') return;
+
+  // Bare "@Kortix" with no task — answer with a nudge, don't burn a sandbox.
+  if (eventClass === 'mention' && !stripMentions(event.text ?? '')) {
+    const token = await loadSlackTokenForProject(projectId);
+    if (token && event.channel) {
+      await postMessage(
+        token,
+        event.channel,
+        "Hi! @mention me with a task and I'll get on it.",
+        event.thread_ts ?? event.ts,
+      );
+    }
+    return;
+  }
+
+  await spawnAgentTurn(projectId, envelope, event);
 }
 
 function parseEnvelope(rawBody: string): SlackEnvelope | null {
@@ -135,19 +603,9 @@ async function spawnAgentTurn(
 ): Promise<void> {
   const teamId = envelope.team_id ?? event.team ?? '';
   const threadId = event.thread_ts ?? event.ts ?? '';
-  console.log('[slack-webhook] dispatch', {
-    projectId,
-    teamId,
-    threadId,
-    eventType: event.type,
-    eventTs: event.ts,
-    eventThreadTs: event.thread_ts,
-    user: event.user,
-  });
 
-  // Thread continuity: if a session already owns this thread, deliver the
-  // new message as a follow-up to that running sandbox instead of spawning
-  // a fresh session with no conversation history.
+  // Thread continuity: deliver to an existing live session before spawning.
+  let revived = false;
   if (teamId && threadId) {
     const [existing] = await db
       .select({ sessionId: chatThreads.sessionId })
@@ -160,15 +618,11 @@ async function spawnAgentTurn(
         ),
       )
       .limit(1);
-    console.log('[slack-webhook] thread lookup', {
-      threadId,
-      found: !!existing,
-      existingSessionId: existing?.sessionId ?? null,
-    });
     if (existing) {
       const outcome = await deliverFollowUpToSandbox(existing.sessionId, envelope, event);
-      console.log('[slack-webhook] follow-up outcome', { sessionId: existing.sessionId, outcome });
       if (outcome === 'delivered') {
+        const handle = await startTurnStream(projectId, teamId, event, 'On it');
+        if (handle) activeStreams.set(existing.sessionId, handle);
         await db
           .update(chatThreads)
           .set({ lastMessageAt: new Date() })
@@ -181,17 +635,10 @@ async function spawnAgentTurn(
           );
         return;
       }
-      if (outcome === 'transient') {
-        // The sandbox is alive but the relay failed for a transient reason —
-        // /kortix/prompt 409 (opencode still pinning), network blip, opencode
-        // mid-restart. Don't spawn a duplicate session. The user can retry
-        // by sending another message and we'll attempt delivery again.
-        console.warn('[slack-webhook] follow-up delivery transient failure — skipping');
-        return;
-      }
-      // outcome === 'stale': the original sandbox is gone (stopped, archived,
-      // evicted). Drop the row and fall through to spawning a fresh session.
-      console.info('[slack-webhook] thread session is stale, replacing');
+      // Transient: alive but the relay failed retryably — don't duplicate.
+      if (outcome === 'transient') return;
+      // Stale: sandbox gone — spawn fresh and tell the agent context is lost.
+      revived = true;
       await db
         .delete(chatThreads)
         .where(
@@ -217,7 +664,9 @@ async function spawnAgentTurn(
     return;
   }
 
-  const initialPrompt = renderAgentPrompt(envelope, event);
+  // Open the stream now — the user sees a live plan immediately, well before
+  // the sandbox is ready.
+  const handle = await startTurnStream(projectId, teamId, event, 'Spinning up a sandbox');
 
   const result = await createProjectSession({
     project,
@@ -225,7 +674,8 @@ async function spawnAgentTurn(
     body: {
       base_ref: project.defaultBranch,
       agent_name: 'default',
-      initial_prompt: initialPrompt,
+      initial_prompt: renderAgentPrompt(envelope, event, revived),
+      opencode_model: SLACK_AGENT_MODEL,
     },
     enforceAccountCap: false,
     metadata: {
@@ -242,16 +692,16 @@ async function spawnAgentTurn(
 
   if (result.error) {
     console.error('[slack-webhook] createProjectSession failed', result.error.body);
+    if (handle) {
+      await finalizeStream(handle, { error: "I couldn't start up just now — try again in a moment." });
+    }
     return;
   }
 
-  // Remember the session ↔ thread mapping for follow-ups.
-  console.log('[slack-webhook] post-spawn chat_threads insert check', {
-    hasRow: !!result.row,
-    sessionId: result.row?.sessionId ?? null,
-    teamId,
-    threadId,
-  });
+  if (result.row && handle) {
+    activeStreams.set(result.row.sessionId, handle);
+  }
+
   if (result.row && teamId && threadId) {
     try {
       await db
@@ -267,41 +717,15 @@ async function spawnAgentTurn(
           target: [chatThreads.platform, chatThreads.workspaceId, chatThreads.threadId],
           set: { sessionId: result.row.sessionId, lastMessageAt: sql`now()` },
         });
-      console.log('[slack-webhook] chat_threads row written', {
-        sessionId: result.row.sessionId,
-        threadId,
-      });
     } catch (err) {
       console.warn('[slack-webhook] failed to record chat_threads row', err);
     }
-  } else {
-    console.warn('[slack-webhook] SKIPPED chat_threads insert', {
-      reason: !result.row ? 'no result.row' : !teamId ? 'no teamId' : !threadId ? 'no threadId' : 'unknown',
-    });
   }
 }
 
-/**
- * Deliver a follow-up Slack message to the kortix-agent's /kortix/prompt
- * endpoint, which forwards it to the pinned opencode session. Returns true
- * on delivery, false if the sandbox is gone or unreachable (caller can fall
- * back to spawning a fresh session).
- */
 type DeliveryOutcome = 'delivered' | 'transient' | 'stale';
 
-/**
- * Try to deliver a follow-up Slack message to the kortix-agent's
- * /kortix/prompt endpoint inside the running sandbox.
- *
- * Returns:
- *   'delivered' — opencode accepted the prompt
- *   'transient' — sandbox is alive but the relay failed for a reason that
- *                 will probably succeed on retry (boot race, network blip).
- *                 Caller should NOT spawn a new session — that creates a
- *                 duplicate for the same Slack thread.
- *   'stale'     — sandbox is genuinely gone (stopped, archived, evicted).
- *                 Caller should drop the chat_threads row and spawn fresh.
- */
+// Deliver a follow-up Slack message to the running sandbox's /kortix/prompt.
 async function deliverFollowUpToSandbox(
   kortixSessionId: string,
   envelope: SlackEnvelope,
@@ -317,12 +741,10 @@ async function deliverFollowUpToSandbox(
     .where(eq(sessionSandboxes.sessionId, kortixSessionId))
     .limit(1);
 
-  // No row, or sandbox is stopped/archived/error → genuinely stale.
   if (!sandbox) return 'stale';
   if (sandbox.status === 'stopped' || sandbox.status === 'archived' || sandbox.status === 'error') {
     return 'stale';
   }
-  // Still provisioning — alive, just not ready yet.
   if (sandbox.status !== 'active') return 'transient';
 
   const daytonaSandboxId = (sandbox.metadata as Record<string, unknown> | null)?.[
@@ -330,10 +752,6 @@ async function deliverFollowUpToSandbox(
   ];
   if (typeof daytonaSandboxId !== 'string' || !daytonaSandboxId) return 'stale';
 
-  // Daytona's public proxy URL needs an X-Daytona-Preview-Token header to
-  // route the request to the sandbox's port 8000. Without it the proxy
-  // returns 404 "Not found." (which is what bit us before — the same path
-  // worked fine when curl'd from inside the sandbox but failed end-to-end).
   let previewUrl: string;
   let previewToken: string | null;
   try {
@@ -348,7 +766,6 @@ async function deliverFollowUpToSandbox(
     return 'transient';
   }
 
-  const followUpText = renderFollowUpPrompt(envelope, event);
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
     'X-Daytona-Skip-Preview-Warning': 'true',
@@ -360,7 +777,7 @@ async function deliverFollowUpToSandbox(
     const res = await fetch(`${previewUrl.replace(/\/$/, '')}/kortix/prompt`, {
       method: 'POST',
       headers,
-      body: JSON.stringify({ text: followUpText }),
+      body: JSON.stringify({ text: renderFollowUpPrompt(envelope, event) }),
       signal: AbortSignal.timeout(15_000),
     });
     if (res.ok) return 'delivered';
@@ -369,9 +786,6 @@ async function deliverFollowUpToSandbox(
       status: res.status,
       body: bodyText,
     });
-    // 404 = the sandbox image lacks the /kortix/prompt route (predates this
-    // feature) → effectively unusable for follow-ups, treat as stale.
-    // 5xx + 409 ("no opencode session pinned yet") = transient, retry.
     if (res.status === 404) return 'stale';
     return 'transient';
   } catch (err) {
@@ -380,12 +794,20 @@ async function deliverFollowUpToSandbox(
   }
 }
 
-/** Short prompt for thread continuations — opencode already has the full
- *  conversation context from the original message, no need to re-explain
- *  the CLIs or workspace. Just the new message + reply hint. */
+// How the agent narrates its turn and delivers its answer. Shared by the cold
+// and follow-up prompts.
+const TURN_INSTRUCTIONS = [
+  'How to work:',
+  '- As you go, post a short progress checkpoint before each major step:',
+  '    slack step "Reading the incident logs"',
+  '  Keep them human and brief — a few per task, not one per command.',
+  '- When you are done, deliver your answer with:',
+  '    slack send "<your reply>"',
+  '  Write it like a teammate: concise, Slack-formatted, no preamble. This',
+  '  finalizes the live update in the thread.',
+].join('\n');
+
 function renderFollowUpPrompt(envelope: SlackEnvelope, event: SlackEvent): string {
-  const channel = event.channel ?? '?';
-  const threadTs = event.thread_ts ?? event.ts ?? '';
   const user = event.user ?? 'unknown';
   const text = event.text ?? '';
   return [
@@ -393,44 +815,46 @@ function renderFollowUpPrompt(envelope: SlackEnvelope, event: SlackEvent): strin
     '',
     text,
     '',
-    `Reply via: slack send --channel ${channel} --thread ${threadTs} --text "..."`,
+    TURN_INSTRUCTIONS,
   ].join('\n');
 }
 
-function renderAgentPrompt(envelope: SlackEnvelope, event: SlackEvent): string {
+function renderAgentPrompt(
+  envelope: SlackEnvelope,
+  event: SlackEvent,
+  revived: boolean,
+): string {
   const channel = event.channel ?? '?';
   const threadTs = event.thread_ts ?? event.ts ?? '';
   const user = event.user ?? 'unknown';
   const text = event.text ?? '';
 
-  return [
-    'You received a message on Slack.',
+  const lines: string[] = [];
+  if (revived) {
+    lines.push(
+      'NOTE: This Slack thread had an earlier conversation, but that session',
+      'has ended — you do NOT have its history. Open your reply by briefly',
+      'saying you are picking the thread back up without the earlier context.',
+      '',
+    );
+  }
+  lines.push(
+    "You're answering a message on Slack as a teammate.",
     '',
     `Workspace:  ${envelope.team_id ?? 'unknown'}`,
     `Channel:    ${channel}`,
     `User:       ${user}`,
-    threadTs ? `Thread ts:  ${threadTs}` : '',
-    '',
-    'Message:',
-    text,
-    '',
-    'To reply in the same thread, run:',
-    `  slack send --channel ${channel} --thread ${threadTs} --text "..."`,
-    '',
-    'Agent CLIs are installed in /usr/local/bin. Discover them:',
-    '  ls /usr/local/bin/            # see every CLI',
-    '  <cli> help                    # surface for any specific one',
-    '',
-    'Common starting points: `slack help`, `telegram help`, `kchannel help`.',
-  ]
-    .filter((line) => line !== '')
-    .join('\n');
+  );
+  if (threadTs) lines.push(`Thread ts:  ${threadTs}`);
+  lines.push('', 'Message:', text, '', TURN_INSTRUCTIONS);
+  return lines.join('\n');
 }
 
 interface SlackEnvelope {
   type: string;
   team_id?: string;
   challenge?: string;
+  event_id?: string;
   event?: SlackEvent;
 }
 
@@ -445,4 +869,13 @@ interface SlackEvent {
   thread_ts?: string;
   subtype?: string;
   team?: string;
+}
+
+interface SlackInteractionPayload {
+  type: string;
+  team?: { id: string };
+  user?: { id: string };
+  channel?: { id: string };
+  message?: { ts: string };
+  actions?: Array<{ action_id?: string; value?: string }>;
 }

--- a/apps/api/src/channels/slack-webhook.ts
+++ b/apps/api/src/channels/slack-webhook.ts
@@ -1,11 +1,12 @@
 import { Hono } from 'hono';
 import { createHmac, randomUUID, timingSafeEqual } from 'node:crypto';
-import { and, eq, inArray, sql } from 'drizzle-orm';
+import { and, desc, eq, inArray, sql } from 'drizzle-orm';
 import {
   chatChannelBindings,
   chatInstalls,
   chatThreads,
   projects,
+  projectSessions,
   sessionSandboxes,
 } from '@kortix/db';
 import { db } from '../shared/db';
@@ -19,30 +20,28 @@ import {
 import { slackOauthMode } from './slack-oauth-mode';
 import {
   addReaction,
+  joinChannel,
   appendStream,
+  deleteMessage,
   getChannelName,
   postBlocks,
   postMessage,
+  publishHomeView,
   removeReaction,
   startStream,
   stopStream,
+  updateBlocks,
   updateMessage,
   type StreamChunk,
   type StreamTaskChunk,
 } from './slack-api';
+import { config } from '../config';
 
 export const slackWebhookApp = new Hono();
 
 const FIVE_MINUTES = 5 * 60;
-
-// Slack-triggered agent turns run on this model (provider/model form). It is
-// passed through to opencode's prompt API for the session's sandbox only.
 const SLACK_AGENT_MODEL = 'anthropic/claude-sonnet-4-6';
 
-// ─── Event de-duplication ────────────────────────────────────────────────────
-// Slack re-delivers an event if it doesn't get a 200 within 3s. Without this, a
-// retry spawns a second sandbox for one message. `event_id` is stable across
-// re-deliveries, so a short-TTL seen-set collapses them.
 const EVENT_DEDUPE_TTL_MS = 5 * 60 * 1000;
 const seenEventIds = new Map<string, number>();
 
@@ -57,11 +56,6 @@ function alreadyHandled(eventId: string | undefined): boolean {
   return false;
 }
 
-// ─── Turn stream ─────────────────────────────────────────────────────────────
-// Each triggering turn opens a Slack stream (chat.startStream) — a live plan
-// block. apps/api owns the stream object: it starts it, posts the boot
-// checkpoint, finalizes on failure, and exposes relay helpers the agent calls
-// (via the agent-cli) to narrate checkpoints and deliver the final answer.
 const WORKING_EMOJI = 'hourglass_flowing_sand';
 const STREAM_TTL_MS = 15 * 60 * 1000;
 
@@ -71,16 +65,22 @@ interface TurnStream {
   token: string;
   triggerTs: string;
   steps: StreamTaskChunk[];
-  streaming: boolean; // false = chat.startStream unavailable, plain-message fallback
+  streaming: boolean;
   expiry: number;
   finalized: boolean;
+  projectId: string;
+  sessionId: string;
+  controlsTs: string | null;
+  stopped: boolean;
+  // Persisted so we can re-open a fresh stream *below* the question form
+  // when the user submits — otherwise the agent's post-question answer
+  // lands in this old stream's message slot (above the form).
+  teamId: string;
+  originatingEvent: SlackEvent;
 }
 
-// Keyed by Kortix session id — the agent-cli relays by session id.
 const activeStreams = new Map<string, TurnStream>();
 
-// Watchdog — a turn whose stream never finalized (agent crash, opencode
-// restart) gets a visible close instead of a forever-"Working…".
 setInterval(() => {
   const now = Date.now();
   for (const [sessionId, handle] of activeStreams) {
@@ -91,8 +91,6 @@ setInterval(() => {
   }
 }, 60_000).unref();
 
-// Open a stream for a turn. Returns an unbound handle — the caller binds it to
-// the session id once known.
 async function startTurnStream(
   projectId: string,
   teamId: string,
@@ -109,6 +107,7 @@ async function startTurnStream(
     status: 'in_progress',
   };
   const threadTs = event.thread_ts ?? event.ts;
+  await joinChannel(token, event.channel);
   await addReaction(token, event.channel, event.ts, WORKING_EMOJI);
 
   const base = {
@@ -117,6 +116,12 @@ async function startTurnStream(
     triggerTs: event.ts,
     expiry: Date.now() + STREAM_TTL_MS,
     finalized: false,
+    projectId,
+    sessionId: '',
+    controlsTs: null as string | null,
+    stopped: false,
+    teamId,
+    originatingEvent: event,
   };
   const streamTs = await startStream(
     token,
@@ -129,8 +134,6 @@ async function startTurnStream(
   if (streamTs) {
     return { ...base, ts: streamTs, steps: [bootStep], streaming: true };
   }
-  // chat.startStream unavailable — fall back to a plain placeholder message
-  // that the final answer edits into place.
   const placeholderTs = await postMessage(
     token,
     event.channel,
@@ -141,13 +144,218 @@ async function startTurnStream(
   return { ...base, ts: placeholderTs, steps: [], streaming: false };
 }
 
-// Complete the current checkpoint and append a new one. Returns false when
-// there is no live stream for the session (e.g. a non-Slack session).
-export async function relayTurnStep(sessionId: string, title: string): Promise<boolean> {
+function buildSlackTurnEnv(teamId: string, event: SlackEvent): Record<string, string> {
+  const env: Record<string, string> = {};
+  if (teamId) env.SLACK_TEAM_ID = teamId;
+  if (event.channel) env.SLACK_CHANNEL_ID = event.channel;
+  if (event.thread_ts ?? event.ts) env.SLACK_THREAD_TS = (event.thread_ts ?? event.ts)!;
+  if (event.ts) env.SLACK_TRIGGER_TS = event.ts;
+  if (event.user) env.SLACK_USER_ID = event.user;
+  return env;
+}
+
+// ─── opencode question.asked → Slack Block Kit form ─────────────────────────
+// The agent uses opencode's built-in `question` tool. The sandbox subscribes
+// to opencode's SSE stream and relays each question.asked here as a
+// QuestionInfo[]. We render a Block Kit form, block on Submit, return the
+// answers (string[][] — one array per question), and the sandbox POSTs them
+// back to opencode's /question/{requestID}/reply so the tool resumes.
+// Mirrors opencode's QuestionOption schema — { label, description }. The
+// dashboard sends the picked label back as the answer string (there is no
+// separate `value` field), so we use the label for both Slack's option
+// `value` and the visible text, and surface `description` as the helper
+// line under each option.
+export interface QuestionInfo {
+  question: string;
+  header?: string;
+  options: Array<{ label: string; description?: string }>;
+  multiple?: boolean;
+  custom?: boolean;
+}
+
+interface PendingAsk {
+  askId: string;
+  questions: QuestionInfo[];
+  resolve: (answers: string[][]) => void;
+  expiry: number;
+  channel: string;
+  messageTs: string | null;
+  token: string;
+  // Persisted for the post-submit stream rotation so the agent's continuation
+  // lands BELOW the form instead of in the old (now-parked) stream message.
+  sessionId: string;
+  projectId: string;
+  teamId: string;
+  originatingEvent: SlackEvent;
+}
+
+const ASK_TTL_MS = 15 * 60 * 1000;
+const pendingAsks = new Map<string, PendingAsk>();
+
+setInterval(() => {
+  const now = Date.now();
+  for (const [askId, ask] of pendingAsks) {
+    if (ask.expiry < now) {
+      pendingAsks.delete(askId);
+      // Empty answers signal timeout to the sandbox, which sends question.reject.
+      ask.resolve(ask.questions.map(() => []));
+    }
+  }
+}, 60_000).unref();
+
+export async function postQuestionAndWait(
+  sessionId: string,
+  questions: QuestionInfo[],
+): Promise<{ ok: boolean; ask_id?: string; answers?: string[][]; error?: string }> {
   const handle = activeStreams.get(sessionId);
-  if (!handle || handle.finalized) return false;
-  // Plain-message fallback has no plan block — accept the step but no-op it so
-  // the agent doesn't treat it as a failure.
+  if (!handle) {
+    return { ok: false, error: 'No active Slack turn for this session.' };
+  }
+
+  // Capture the data needed to spin up a fresh stream BELOW the form once
+  // the user submits. We do this before finalizing because finalizeStream
+  // mutates `handle` and may delete the Stop controls.
+  const teamId = handle.teamId;
+  const originatingEvent = handle.originatingEvent;
+
+  // Park the current stream so it doesn't keep spinning while the user is
+  // filling in the form. Drop it from activeStreams so any stray relay
+  // calls fail loud instead of mutating a paused stream.
+  await finalizeStream(handle, { answer: '_Waiting on your answer below…_' });
+  activeStreams.delete(sessionId);
+
+  const askId = randomUUID();
+  const blocks = buildQuestionBlocks(askId, questions);
+  const messageTs = await postBlocks(
+    handle.token,
+    handle.channel,
+    questions[0]?.question?.slice(0, 200) ?? 'A question for you',
+    blocks,
+    handle.triggerTs,
+  );
+  if (!messageTs) {
+    return { ok: false, error: 'Failed to post the form to Slack.' };
+  }
+  const answers = await new Promise<string[][]>((resolve) => {
+    pendingAsks.set(askId, {
+      askId,
+      questions,
+      resolve,
+      expiry: Date.now() + ASK_TTL_MS,
+      channel: handle.channel,
+      messageTs,
+      token: handle.token,
+      sessionId,
+      projectId: handle.projectId,
+      teamId,
+      originatingEvent,
+    });
+  });
+  return { ok: true, ask_id: askId, answers };
+}
+
+function buildQuestionBlocks(askId: string, questions: QuestionInfo[]): Array<Record<string, unknown>> {
+  const blocks: Array<Record<string, unknown>> = [];
+  questions.forEach((q, i) => {
+    blocks.push({
+      type: 'section',
+      text: { type: 'mrkdwn', text: `*${escapeMrkdwn(q.question)}*` },
+    });
+    if (q.options.length > 0) {
+      const options = q.options.map((o) => {
+        const opt: Record<string, unknown> = {
+          text: { type: 'plain_text', text: o.label.slice(0, 75), emoji: true },
+          value: o.label.slice(0, 75),
+        };
+        if (o.description) {
+          opt.description = {
+            type: 'plain_text',
+            text: o.description.slice(0, 75),
+            emoji: true,
+          };
+        }
+        return opt;
+      });
+      blocks.push({
+        type: 'input',
+        block_id: `q_${i}_choice`,
+        label: { type: 'plain_text', text: 'Choose', emoji: true },
+        element: q.multiple
+          ? { type: 'checkboxes', action_id: 'value', options }
+          : { type: 'radio_buttons', action_id: 'value', options },
+        optional: q.custom !== false,
+      });
+    }
+    if (q.custom !== false) {
+      blocks.push({
+        type: 'input',
+        block_id: `q_${i}_custom`,
+        label: { type: 'plain_text', text: q.options.length > 0 ? 'Or type your own answer' : 'Your answer', emoji: true },
+        element: { type: 'plain_text_input', action_id: 'value', multiline: false },
+        optional: q.options.length > 0,
+      });
+    }
+  });
+  blocks.push({
+    type: 'actions',
+    elements: [
+      {
+        type: 'button',
+        text: { type: 'plain_text', text: 'Submit', emoji: true },
+        style: 'primary',
+        action_id: 'ask_submit',
+        value: askId,
+      },
+    ],
+  });
+  return blocks;
+}
+
+async function attachStopControls(handle: TurnStream, sessionId: string): Promise<void> {
+  handle.sessionId = sessionId;
+  const threadTs = handle.streaming ? undefined : undefined;
+  const threadRoot = handle.triggerTs;
+  const ts = await postBlocks(
+    handle.token,
+    handle.channel,
+    'Working on it — click Stop to interrupt.',
+    [
+      {
+        type: 'actions',
+        elements: [
+          {
+            type: 'button',
+            text: { type: 'plain_text', text: 'Stop' },
+            style: 'danger',
+            action_id: 'stop_turn',
+            value: JSON.stringify({ s: sessionId, p: handle.projectId }),
+          },
+        ],
+      },
+    ],
+    threadRoot,
+  );
+  if (ts) handle.controlsTs = ts;
+}
+
+export async function relayTurnStep(
+  sessionId: string,
+  title: string,
+  opts: {
+    detail?: string;
+    outputForPrev?: string;
+    sourcesForPrev?: Array<{ url: string; text: string }>;
+  } = {},
+): Promise<boolean> {
+  const handle = activeStreams.get(sessionId);
+  if (!handle || handle.finalized) {
+    console.warn('[slack-webhook] turn-stream step relay dropped — no active stream', {
+      sessionId,
+      title: title.slice(0, 80),
+      finalized: handle?.finalized ?? null,
+    });
+    return false;
+  }
   if (!handle.streaming) {
     handle.expiry = Date.now() + STREAM_TTL_MS;
     return true;
@@ -156,7 +364,21 @@ export async function relayTurnStep(sessionId: string, title: string): Promise<b
   const last = handle.steps[handle.steps.length - 1];
   if (last && last.status === 'in_progress') {
     last.status = 'complete';
-    chunks.push({ ...last });
+    const closing: StreamTaskChunk = {
+      type: 'task_update',
+      id: last.id,
+      title: last.title,
+      status: 'complete',
+    };
+    if (opts.outputForPrev) closing.output = opts.outputForPrev.slice(0, 500);
+    if (opts.sourcesForPrev && opts.sourcesForPrev.length > 0) {
+      closing.sources = opts.sourcesForPrev.slice(0, 8).map((s) => ({
+        type: 'url',
+        url: s.url,
+        text: s.text.slice(0, 80),
+      }));
+    }
+    chunks.push(closing);
   }
   const next: StreamTaskChunk = {
     type: 'task_update',
@@ -164,6 +386,7 @@ export async function relayTurnStep(sessionId: string, title: string): Promise<b
     title: title.slice(0, 200),
     status: 'in_progress',
   };
+  if (opts.detail) next.details = opts.detail.slice(0, 500);
   handle.steps.push(next);
   chunks.push(next);
   handle.expiry = Date.now() + STREAM_TTL_MS;
@@ -171,44 +394,57 @@ export async function relayTurnStep(sessionId: string, title: string): Promise<b
   return true;
 }
 
-// Finalize the stream with the agent's answer.
-export async function relayTurnAnswer(sessionId: string, text: string): Promise<boolean> {
+export async function relayTurnAnswer(
+  sessionId: string,
+  text: string,
+  blocks?: unknown[],
+): Promise<boolean> {
   const handle = activeStreams.get(sessionId);
   if (!handle || handle.finalized) return false;
   activeStreams.delete(sessionId);
-  await finalizeStream(handle, { answer: text });
+  await finalizeStream(handle, { answer: text, blocks });
   return true;
 }
 
 async function finalizeStream(
   handle: TurnStream,
-  opts: { answer?: string; error?: string },
+  opts: { answer?: string; error?: string; blocks?: unknown[] },
 ): Promise<void> {
   if (handle.finalized) return;
   handle.finalized = true;
   const body = (opts.answer ?? opts.error ?? '_Done._').slice(0, 11000);
   if (handle.streaming) {
-    // Closing chunks: the last checkpoint's final state + the answer as a
-    // markdown_text chunk (chat.stopStream rejects a top-level markdown_text).
     const chunks: StreamChunk[] = [];
     const last = handle.steps[handle.steps.length - 1];
     if (last && last.status === 'in_progress') {
       last.status = opts.error ? 'error' : 'complete';
-      chunks.push({ ...last });
+      // Strip details on the closing chunk — re-sending it appends server-side.
+      chunks.push({
+        type: 'task_update',
+        id: last.id,
+        title: last.title,
+        status: last.status,
+      });
     }
-    chunks.push({ type: 'markdown_text', text: body });
+    if (opts.blocks && opts.blocks.length > 0) {
+      chunks.push({ type: 'blocks', blocks: opts.blocks });
+    } else {
+      chunks.push({ type: 'markdown_text', text: body });
+    }
     await stopStream(handle.token, handle.channel, handle.ts, chunks);
   } else {
     await updateMessage(handle.token, handle.channel, handle.ts, body);
   }
   await removeReaction(handle.token, handle.channel, handle.triggerTs, WORKING_EMOJI);
+  if (handle.controlsTs && !handle.stopped) {
+    await deleteMessage(handle.token, handle.channel, handle.controlsTs);
+    handle.controlsTs = null;
+  }
 }
 
-// ─── Project picker ──────────────────────────────────────────────────────────
 const PICKER_TTL_MS = 60 * 60 * 1000;
 const pendingPickers = new Map<string, { envelope: SlackEnvelope; expiry: number }>();
 
-// OAuth mode — single endpoint, shared signing secret, route by team_id.
 slackWebhookApp.post('/', async (c) => {
   const mode = slackOauthMode();
   if (!mode.available || !mode.signingSecret) {
@@ -231,6 +467,18 @@ slackWebhookApp.post('/', async (c) => {
   void (async () => {
     const teamId = envelope.team_id ?? envelope.event?.team ?? '';
     if (!teamId) return;
+    if (envelope.event?.type === 'member_joined_channel') {
+      await maybePostChannelIntro(teamId, envelope.event);
+      return;
+    }
+    if (
+      envelope.event?.type === 'app_home_opened' &&
+      envelope.event.tab === 'home' &&
+      envelope.event.user
+    ) {
+      await publishHomeForUser(teamId, envelope.event.user);
+      return;
+    }
     const resolution = await resolveOauthProject(teamId, envelope.event?.channel);
     if (resolution.kind === 'project') {
       await dispatchSlackEvent(resolution.projectId, envelope);
@@ -242,8 +490,6 @@ slackWebhookApp.post('/', async (c) => {
   return c.json({ ok: true });
 });
 
-// Slack interactivity (Block Kit button clicks). Registered before /:projectId
-// so the literal path wins over the BYO param route.
 slackWebhookApp.post('/interactivity', async (c) => {
   const mode = slackOauthMode();
   if (!mode.available || !mode.signingSecret) {
@@ -271,16 +517,47 @@ slackWebhookApp.post('/interactivity', async (c) => {
   return c.json({ ok: true });
 });
 
+// Slash commands — Slack POSTs application/x-www-form-urlencoded here when
+// a user runs `/kortix …` in any channel/DM. Must respond within 3s.
+slackWebhookApp.post('/commands', async (c) => {
+  const mode = slackOauthMode();
+  if (!mode.available || !mode.signingSecret) {
+    return c.json({ response_type: 'ephemeral', text: 'OAuth mode not configured on this server.' }, 503);
+  }
+  const rawBody = await c.req.text();
+  const timestamp = c.req.header('x-slack-request-timestamp') ?? '';
+  const signature = c.req.header('x-slack-signature') ?? '';
+  if (!verifySlackSignature(rawBody, timestamp, signature, mode.signingSecret)) {
+    return c.json({ error: 'Invalid signature' }, 401);
+  }
+
+  const params = new URLSearchParams(rawBody);
+  const text = (params.get('text') ?? '').trim();
+  const teamId = params.get('team_id') ?? '';
+  const channelId = params.get('channel_id') ?? '';
+
+  const [sub, ...rest] = text.split(/\s+/);
+  const arg = rest.join(' ').trim();
+  const subLower = (sub || 'help').toLowerCase();
+
+  try {
+    const response = await handleSlashCommand(subLower, arg, { teamId, channelId });
+    return c.json(response);
+  } catch (err) {
+    console.error('[slack-webhook] slash command failed', err);
+    return c.json({
+      response_type: 'ephemeral',
+      text: 'Something went wrong handling that command. Try again in a moment.',
+    });
+  }
+});
+
 type ProjectResolution =
   | { kind: 'project'; projectId: string }
   | { kind: 'ambiguous'; projectIds: string[] }
   | { kind: 'pending' }
   | { kind: 'none' };
 
-// Resolve which Kortix project an OAuth-mode Slack event belongs to.
-//   1. A per-channel binding wins; a NULL-project binding = picker pending.
-//   2. Else, if the workspace has exactly one project, use it and bind lazily.
-//   3. Else (2+ projects, unbound channel) it is ambiguous — post a picker.
 async function resolveOauthProject(
   teamId: string,
   channelId: string | undefined,
@@ -322,8 +599,6 @@ async function resolveOauthProject(
   return { kind: 'ambiguous', projectIds: installs.map((i) => i.projectId) };
 }
 
-// Post a Block Kit project picker for an ambiguous channel and park the
-// triggering event until a button is clicked.
 async function maybePostPicker(
   teamId: string,
   projectIds: string[],
@@ -401,10 +676,694 @@ async function maybePostPicker(
   }
 }
 
-// Handle a project-picker button click.
+type SlashResponse = { response_type: 'ephemeral' | 'in_channel'; text?: string; blocks?: unknown[] };
+
+async function handleSlashCommand(
+  sub: string,
+  arg: string,
+  ctx: { teamId: string; channelId: string },
+): Promise<SlashResponse> {
+  switch (sub) {
+    case 'projects':
+    case 'list':
+      return slashProjects(ctx);
+    case 'switch':
+    case 'use':
+    case 'rebind':
+      return slashSwitch(ctx);
+    case 'unbind':
+      return slashUnbind(ctx);
+    case 'sessions':
+      return slashSessions(ctx);
+    case 'whoami':
+    case 'who':
+      return slashWhoami(ctx);
+    case 'help':
+    case '':
+      return slashHelp();
+    default:
+      return {
+        response_type: 'ephemeral',
+        text: `Unknown subcommand \`${sub}\`. Try \`/kortix help\`.`,
+      };
+  }
+  void arg;
+}
+
+function slashHelp(): SlashResponse {
+  const dashboardBase = (config.KORTIX_URL || 'https://kortix.com').replace(/\/$/, '');
+  return {
+    response_type: 'ephemeral',
+    blocks: [
+      {
+        type: 'header',
+        text: { type: 'plain_text', text: '⚡  Kortix slash commands', emoji: true },
+      },
+      {
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: 'Drive Kortix from any Slack channel. All responses are private to you.',
+        },
+      },
+      { type: 'divider' },
+      ...[
+        { cmd: '/kortix projects', desc: 'List every Kortix project connected to this workspace.' },
+        { cmd: '/kortix switch',   desc: 'Bind this channel to a different project (opens a picker).' },
+        { cmd: '/kortix unbind',   desc: 'Clear this channel\'s project binding.' },
+        { cmd: '/kortix sessions', desc: 'Show the last 5 sessions started in this workspace.' },
+        { cmd: '/kortix whoami',   desc: 'What project is currently bound to this channel.' },
+        { cmd: '/kortix help',     desc: 'This message.' },
+      ].map((r) => ({
+        type: 'section',
+        text: { type: 'mrkdwn', text: `\`${r.cmd}\`\n${r.desc}` },
+      })),
+      { type: 'divider' },
+      {
+        type: 'actions',
+        elements: [
+          {
+            type: 'button',
+            text: { type: 'plain_text', text: 'Open dashboard', emoji: true },
+            style: 'primary',
+            url: dashboardBase,
+            action_id: 'help_open_dashboard',
+          },
+        ],
+      },
+    ],
+  };
+}
+
+async function slashProjects(ctx: { teamId: string; channelId: string }): Promise<SlashResponse> {
+  const rows = await listWorkspaceProjects(ctx.teamId);
+  if (rows.length === 0) {
+    return {
+      response_type: 'ephemeral',
+      blocks: [
+        {
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: '*No Kortix projects connected yet.*\nHead to your Kortix dashboard to link one to this workspace.',
+          },
+          accessory: {
+            type: 'button',
+            text: { type: 'plain_text', text: 'Open dashboard', emoji: true },
+            style: 'primary',
+            url: (config.KORTIX_URL || 'https://kortix.com').replace(/\/$/, ''),
+            action_id: 'projects_empty_dashboard',
+          },
+        },
+      ],
+    };
+  }
+  const current = await currentChannelProjectId(ctx);
+  const dashboardBase = (config.KORTIX_URL || 'https://kortix.com').replace(/\/$/, '');
+  const blocks: Array<Record<string, unknown>> = [
+    {
+      type: 'header',
+      text: { type: 'plain_text', text: `Connected projects · ${rows.length}`, emoji: true },
+    },
+  ];
+  if (rows.length >= 2) {
+    blocks.push({
+      type: 'carousel',
+      elements: rows.map((p) => {
+        const isBound = p.projectId === current;
+        const og = repoOgImage(p.repoUrl);
+        const card: Record<string, unknown> = {
+          type: 'card',
+          block_id: `proj_${p.projectId}`,
+          title: { type: 'mrkdwn', text: `${isBound ? '✓ ' : ''}*${escapeMrkdwn(p.name)}*` },
+          subtitle: { type: 'mrkdwn', text: `_${escapeMrkdwn(repoLabel(p.repoUrl))}_` },
+          body: {
+            type: 'mrkdwn',
+            text: isBound ? '🟢  Bound to this channel — `@`-mentions here go to this project.' : '🟢  Connected to this workspace.',
+          },
+          actions: [
+            {
+              type: 'button',
+              text: { type: 'plain_text', text: 'Open', emoji: true },
+              style: 'primary',
+              url: `${dashboardBase}/projects/${p.projectId}`,
+              action_id: `projects_open_${p.projectId}`,
+            },
+            ...(!isBound ? [{
+              type: 'button',
+              text: { type: 'plain_text', text: 'Switch to this', emoji: true },
+              action_id: `switch_project_${p.projectId}`,
+              value: JSON.stringify({ p: p.projectId, c: ctx.channelId }),
+            }] : []),
+          ],
+        };
+        if (og) {
+          card.hero_image = { type: 'image', image_url: og, alt_text: `${p.name} repo` };
+        }
+        return card;
+      }),
+    });
+  } else {
+    const p = rows[0];
+    const isBound = p.projectId === current;
+    const og = repoOgImage(p.repoUrl);
+    blocks.push({
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: `${isBound ? '✓ ' : '🟢 '}*${escapeMrkdwn(p.name)}*\n_<${p.repoUrl}|${escapeMrkdwn(repoLabel(p.repoUrl))}>_\n${isBound ? '🟢  Bound to this channel.' : ''}`,
+      },
+      ...(og ? { accessory: { type: 'image', image_url: og, alt_text: `${p.name} repo` } } : {}),
+    });
+    blocks.push({
+      type: 'actions',
+      elements: [
+        {
+          type: 'button',
+          text: { type: 'plain_text', text: 'Open project', emoji: true },
+          style: 'primary',
+          url: `${dashboardBase}/projects/${p.projectId}`,
+          action_id: `projects_open_${p.projectId}`,
+        },
+      ],
+    });
+  }
+  return { response_type: 'ephemeral', blocks };
+}
+
+async function slashSwitch(ctx: { teamId: string; channelId: string }): Promise<SlashResponse> {
+  const rows = await listWorkspaceProjects(ctx.teamId);
+  if (rows.length === 0) {
+    return {
+      response_type: 'ephemeral',
+      blocks: [
+        {
+          type: 'section',
+          text: { type: 'mrkdwn', text: '*No projects to switch to.*\nLink a project to this workspace from your Kortix dashboard first.' },
+          accessory: {
+            type: 'button',
+            text: { type: 'plain_text', text: 'Open dashboard', emoji: true },
+            style: 'primary',
+            url: (config.KORTIX_URL || 'https://kortix.com').replace(/\/$/, ''),
+            action_id: 'switch_empty_dashboard',
+          },
+        },
+      ],
+    };
+  }
+  const current = await currentChannelProjectId(ctx);
+  const blocks: Array<Record<string, unknown>> = [
+    {
+      type: 'header',
+      text: { type: 'plain_text', text: 'Switch this channel to…', emoji: true },
+    },
+  ];
+  if (rows.length >= 2) {
+    blocks.push({
+      type: 'carousel',
+      elements: rows.map((p) => {
+        const isBound = p.projectId === current;
+        const og = repoOgImage(p.repoUrl);
+        const card: Record<string, unknown> = {
+          type: 'card',
+          block_id: `switch_${p.projectId}`,
+          title: { type: 'mrkdwn', text: `${isBound ? '✓ ' : ''}*${escapeMrkdwn(p.name)}*` },
+          subtitle: { type: 'mrkdwn', text: `_${escapeMrkdwn(repoLabel(p.repoUrl))}_` },
+          body: {
+            type: 'mrkdwn',
+            text: isBound ? 'Currently bound to this channel.' : 'Pick this to route `@`-mentions here to this project.',
+          },
+          actions: [
+            {
+              type: 'button',
+              text: { type: 'plain_text', text: isBound ? '✓ Current' : 'Pick this', emoji: true },
+              style: isBound ? undefined : 'primary',
+              action_id: `switch_project_${p.projectId}`,
+              value: JSON.stringify({ p: p.projectId, c: ctx.channelId }),
+            },
+          ],
+        };
+        if (og) card.hero_image = { type: 'image', image_url: og, alt_text: `${p.name} repo` };
+        return card;
+      }),
+    });
+  } else {
+    // Single-project workspace — there's nothing to switch to, but still show
+    // the project as confirmation.
+    const p = rows[0];
+    blocks.push({
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: `Only one project connected: *${escapeMrkdwn(p.name)}*\n_<${p.repoUrl}|${escapeMrkdwn(repoLabel(p.repoUrl))}>_`,
+      },
+    });
+  }
+  return { response_type: 'ephemeral', blocks };
+}
+
+async function slashUnbind(ctx: { teamId: string; channelId: string }): Promise<SlashResponse> {
+  if (!ctx.channelId) {
+    return { response_type: 'ephemeral', text: 'No channel context — run this from inside a channel.' };
+  }
+  await db
+    .delete(chatChannelBindings)
+    .where(and(
+      eq(chatChannelBindings.platform, 'slack'),
+      eq(chatChannelBindings.workspaceId, ctx.teamId),
+      eq(chatChannelBindings.channelId, ctx.channelId),
+    ));
+  return {
+    response_type: 'ephemeral',
+    blocks: [
+      {
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: '*Unbound.*\nThe next `@`-mention will show the project picker again.',
+        },
+      },
+    ],
+  };
+}
+
+async function slashSessions(ctx: { teamId: string; channelId: string }): Promise<SlashResponse> {
+  const rows = await db
+    .select({
+      projectId: chatThreads.projectId,
+      sessionId: chatThreads.sessionId,
+      lastMessageAt: chatThreads.lastMessageAt,
+    })
+    .from(chatThreads)
+    .where(and(eq(chatThreads.platform, 'slack'), eq(chatThreads.workspaceId, ctx.teamId)))
+    .orderBy(desc(chatThreads.lastMessageAt))
+    .limit(5);
+  if (rows.length === 0) {
+    return {
+      response_type: 'ephemeral',
+      blocks: [
+        { type: 'section', text: { type: 'mrkdwn', text: '*No recent Kortix sessions in this workspace.*\n`@`-mention me in any channel to start one.' } },
+      ],
+    };
+  }
+  const projectIds = Array.from(new Set(rows.map((r) => r.projectId)));
+  const projectRows = await db
+    .select({ projectId: projects.projectId, name: projects.name, repoUrl: projects.repoUrl })
+    .from(projects)
+    .where(inArray(projects.projectId, projectIds));
+  const projectById = new Map(projectRows.map((p) => [p.projectId, p]));
+  const dashboardBase = (config.KORTIX_URL || 'https://kortix.com').replace(/\/$/, '');
+  return {
+    response_type: 'ephemeral',
+    blocks: [
+      {
+        type: 'header',
+        text: { type: 'plain_text', text: 'Recent sessions', emoji: true },
+      },
+      ...rows.flatMap((r) => {
+        const p = projectById.get(r.projectId);
+        const projectName = p?.name ?? 'project';
+        const og = p ? repoOgImage(p.repoUrl) : null;
+        const section: Record<string, unknown> = {
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: `*${escapeMrkdwn(projectName)}*  ·  ${formatRelativeTime(r.lastMessageAt)}\n_<${dashboardBase}/projects/${r.projectId}/sessions/${r.sessionId}|Open session>_`,
+          },
+          ...(og ? { accessory: { type: 'image', image_url: og, alt_text: `${projectName} repo` } } : {}),
+        };
+        return [section];
+      }),
+    ],
+  };
+}
+
+async function slashWhoami(ctx: { teamId: string; channelId: string }): Promise<SlashResponse> {
+  const currentId = await currentChannelProjectId(ctx);
+  const dashboardBase = (config.KORTIX_URL || 'https://kortix.com').replace(/\/$/, '');
+  if (!currentId) {
+    return {
+      response_type: 'ephemeral',
+      blocks: [
+        {
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: '*No project bound to this channel.*\nRun `/kortix switch` to pick one.',
+          },
+        },
+      ],
+    };
+  }
+  const [p] = await db
+    .select({ projectId: projects.projectId, name: projects.name, repoUrl: projects.repoUrl })
+    .from(projects)
+    .where(eq(projects.projectId, currentId))
+    .limit(1);
+  if (!p) {
+    return {
+      response_type: 'ephemeral',
+      blocks: [
+        {
+          type: 'section',
+          text: { type: 'mrkdwn', text: '*This channel\'s bound project no longer exists.*\nRun `/kortix switch` to rebind.' },
+        },
+      ],
+    };
+  }
+  const og = repoOgImage(p.repoUrl);
+  const section: Record<string, unknown> = {
+    type: 'section',
+    text: {
+      type: 'mrkdwn',
+      text: `🟢  *${escapeMrkdwn(p.name)}*  ·  ✓ bound to this channel\n_<${p.repoUrl}|${escapeMrkdwn(repoLabel(p.repoUrl))}>_`,
+    },
+  };
+  if (og) section.accessory = { type: 'image', image_url: og, alt_text: `${p.name} repo` };
+  return {
+    response_type: 'ephemeral',
+    blocks: [
+      section,
+      {
+        type: 'actions',
+        elements: [
+          {
+            type: 'button',
+            text: { type: 'plain_text', text: 'Open project', emoji: true },
+            style: 'primary',
+            url: `${dashboardBase}/projects/${p.projectId}`,
+            action_id: `whoami_open_${p.projectId}`,
+          },
+          {
+            type: 'button',
+            text: { type: 'plain_text', text: 'View on GitHub', emoji: true },
+            url: p.repoUrl,
+            action_id: `whoami_repo_${p.projectId}`,
+          },
+        ],
+      },
+    ],
+  };
+}
+
+async function listWorkspaceProjects(teamId: string): Promise<Array<{ projectId: string; name: string; repoUrl: string }>> {
+  const installs = await db
+    .select({ projectId: chatInstalls.projectId })
+    .from(chatInstalls)
+    .where(and(eq(chatInstalls.platform, 'slack'), eq(chatInstalls.workspaceId, teamId)));
+  if (installs.length === 0) return [];
+  const ids = installs.map((i) => i.projectId);
+  return db
+    .select({ projectId: projects.projectId, name: projects.name, repoUrl: projects.repoUrl })
+    .from(projects)
+    .where(inArray(projects.projectId, ids));
+}
+
+async function currentChannelProjectId(ctx: { teamId: string; channelId: string }): Promise<string | null> {
+  if (!ctx.channelId) return null;
+  const [binding] = await db
+    .select({ projectId: chatChannelBindings.projectId })
+    .from(chatChannelBindings)
+    .where(and(
+      eq(chatChannelBindings.platform, 'slack'),
+      eq(chatChannelBindings.workspaceId, ctx.teamId),
+      eq(chatChannelBindings.channelId, ctx.channelId),
+    ))
+    .limit(1);
+  return binding?.projectId ?? null;
+}
+
+async function handleAskSubmit(payload: SlackInteractionPayload, askId: string): Promise<void> {
+  const pending = pendingAsks.get(askId);
+  if (!pending) {
+    await respondViaUrl(payload.response_url, {
+      response_type: 'ephemeral',
+      text: 'This form has already been submitted or expired.',
+    });
+    return;
+  }
+  pendingAsks.delete(askId);
+
+  const values = payload.state?.values ?? {};
+  const answers: string[][] = pending.questions.map((q, i) => {
+    const out: string[] = [];
+    const choice = values[`q_${i}_choice`]?.value;
+    if (choice) {
+      if (q.multiple) {
+        for (const opt of choice.selected_options ?? []) {
+          if (opt?.value) out.push(opt.value);
+        }
+      } else if (choice.selected_option?.value) {
+        out.push(choice.selected_option.value);
+      }
+    }
+    const custom = values[`q_${i}_custom`]?.value?.value?.trim();
+    if (custom) out.push(custom);
+    return out;
+  });
+
+  // Spin up a fresh stream BELOW the form so the agent's continuation
+  // (more `slack step`s + the final `slack send`) lands in chronological
+  // order under the user's submitted answers. Without this, the old
+  // (parked) stream message above the form gets edited in-place.
+  try {
+    const newHandle = await startTurnStream(
+      pending.projectId,
+      pending.teamId,
+      pending.originatingEvent,
+      'Continuing…',
+    );
+    if (newHandle) {
+      activeStreams.set(pending.sessionId, newHandle);
+      await attachStopControls(newHandle, pending.sessionId);
+    }
+  } catch (err) {
+    console.warn('[slack-webhook] post-question stream re-open failed', err);
+  }
+
+  pending.resolve(answers);
+
+  if (pending.messageTs) {
+    const recap: Array<Record<string, unknown>> = [];
+    pending.questions.forEach((q, i) => {
+      recap.push({
+        type: 'section',
+        text: { type: 'mrkdwn', text: `*${escapeMrkdwn(q.question)}*` },
+      });
+      const picked = answers[i] ?? [];
+      if (picked.length > 0) {
+        recap.push({
+          type: 'context',
+          elements: [{ type: 'mrkdwn', text: `→ ${picked.map(escapeMrkdwn).join(', ')}` }],
+        });
+      }
+    });
+    recap.push({
+      type: 'context',
+      elements: [{ type: 'mrkdwn', text: '✅  Submitted' }],
+    });
+    await updateBlocks(pending.token, pending.channel, pending.messageTs, 'Submitted.', recap);
+  }
+}
+
+// Agent-emitted button click (carousel cards, actions blocks). Routes the
+// click back into the thread as a synthesized follow-up so the agent's next
+// turn picks up from the user's choice.
+async function handleAgentClick(
+  payload: SlackInteractionPayload,
+  action: NonNullable<SlackInteractionPayload['actions']>[number],
+): Promise<void> {
+  const teamId = payload.team?.id ?? '';
+  const channelId = payload.channel?.id ?? '';
+  const userId = payload.user?.id ?? '';
+  const messageTs = payload.message?.ts ?? '';
+  const threadTs = payload.message?.thread_ts ?? messageTs;
+  if (!teamId || !channelId || !userId || !threadTs) return;
+
+  const label = (action.text?.text ?? action.action_id ?? '').trim();
+  const value = (action.value ?? '').trim();
+
+  await respondViaUrl(payload.response_url, {
+    response_type: 'ephemeral',
+    text: `On it — picked *${label || action.action_id}*.`,
+  });
+
+  const [thread] = await db
+    .select({ projectId: chatThreads.projectId })
+    .from(chatThreads)
+    .where(and(
+      eq(chatThreads.platform, 'slack'),
+      eq(chatThreads.workspaceId, teamId),
+      eq(chatThreads.threadId, threadTs),
+    ))
+    .limit(1);
+  if (!thread) return;
+
+  const lines = [`[Button click] The user clicked *${label || action.action_id}*.`];
+  if (action.action_id) lines.push(`action_id: \`${action.action_id}\``);
+  if (value) lines.push(`value: \`${value}\``);
+  lines.push('', 'Continue the turn based on this choice.');
+
+  const event: SlackEvent = {
+    type: 'message',
+    user: userId,
+    channel: channelId,
+    text: lines.join('\n'),
+    ts: messageTs,
+    thread_ts: threadTs,
+    team: teamId,
+  };
+  const envelope: SlackEnvelope = {
+    type: 'event_callback',
+    team_id: teamId,
+    event,
+  };
+  await spawnAgentTurn(thread.projectId, envelope, event);
+}
+
+async function handleSwitchProject(payload: SlackInteractionPayload, rawValue: string): Promise<void> {
+  let value: { p?: string; c?: string };
+  try {
+    value = JSON.parse(rawValue || '{}') as { p?: string; c?: string };
+  } catch {
+    return;
+  }
+  const projectId = value.p;
+  const channelId = value.c ?? payload.channel?.id;
+  const teamId = payload.team?.id ?? '';
+  if (!projectId || !channelId || !teamId) return;
+
+  const [install] = await db
+    .select({ id: chatInstalls.installId })
+    .from(chatInstalls)
+    .where(and(
+      eq(chatInstalls.platform, 'slack'),
+      eq(chatInstalls.workspaceId, teamId),
+      eq(chatInstalls.projectId, projectId),
+    ))
+    .limit(1);
+  if (!install) {
+    await respondViaUrl(payload.response_url, {
+      response_type: 'ephemeral',
+      replace_original: true,
+      text: 'That project is no longer connected to this workspace.',
+    });
+    return;
+  }
+
+  await db
+    .insert(chatChannelBindings)
+    .values({ platform: 'slack', workspaceId: teamId, channelId, projectId, pickerTs: null })
+    .onConflictDoUpdate({
+      target: [chatChannelBindings.platform, chatChannelBindings.workspaceId, chatChannelBindings.channelId],
+      set: { projectId, pickerTs: null },
+    });
+
+  const [p] = await db
+    .select({ name: projects.name })
+    .from(projects)
+    .where(eq(projects.projectId, projectId))
+    .limit(1);
+
+  await respondViaUrl(payload.response_url, {
+    response_type: 'ephemeral',
+    replace_original: true,
+    text: `Switched this channel to *${p?.name ?? 'project'}*.`,
+  });
+}
+
+async function respondViaUrl(url: string | undefined, body: unknown): Promise<void> {
+  if (!url) return;
+  try {
+    await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+  } catch (err) {
+    console.warn('[slack-webhook] response_url POST failed', err);
+  }
+}
+
+async function handleStopTurn(payload: SlackInteractionPayload, rawValue: string): Promise<void> {
+  let value: { s?: string; p?: string };
+  try {
+    value = JSON.parse(rawValue || '{}') as { s?: string; p?: string };
+  } catch {
+    return;
+  }
+  const sessionId = value.s;
+  const projectId = value.p;
+  if (!sessionId || !projectId) return;
+
+  const handle = activeStreams.get(sessionId);
+  if (handle) handle.stopped = true;
+  const token = handle?.token ?? (await loadSlackTokenForProject(projectId));
+  const channelId = payload.channel?.id ?? handle?.channel ?? '';
+  const controlsTs = payload.message?.ts ?? handle?.controlsTs ?? '';
+
+  const aborted = await abortSandboxTurn(sessionId);
+
+  if (token && channelId && controlsTs) {
+    await updateBlocks(
+      token,
+      channelId,
+      controlsTs,
+      aborted ? 'Stopped.' : "Couldn't stop in time.",
+      [
+        {
+          type: 'context',
+          elements: [
+            {
+              type: 'mrkdwn',
+              text: aborted ? '🛑  *Stopped by you*' : '⚠️  *Stop request failed — the turn may have already completed.*',
+            },
+          ],
+        },
+      ],
+    );
+  }
+
+  if (aborted && handle && !handle.finalized) {
+    await finalizeStream(handle, { error: '_Stopped._' });
+    activeStreams.delete(sessionId);
+  }
+}
+
 async function handleBlockAction(payload: SlackInteractionPayload): Promise<void> {
   const action = payload.actions?.[0];
-  if (!action?.action_id?.startsWith('pick_project')) return;
+  if (!action?.action_id) return;
+
+  if (action.action_id === 'stop_turn') {
+    await handleStopTurn(payload, action.value ?? '');
+    return;
+  }
+
+  if (action.action_id.startsWith('switch_project_')) {
+    await handleSwitchProject(payload, action.value ?? '');
+    return;
+  }
+
+  if (action.action_id === 'ask_submit') {
+    await handleAskSubmit(payload, action.value ?? '');
+    return;
+  }
+
+  if (action.action_id === 'value') {
+    // No-op: live input/select element clicks before Submit. Slack still POSTs
+    // here so we can preview/validate; we just don't act until ask_submit fires.
+    return;
+  }
+
+  // Anything else is an agent-emitted button (typically inside a carousel card
+  // or actions block from `slack send --blocks-file ...`). Route the click back
+  // into the thread as a synthesized follow-up so the agent can continue.
+  if (!action.action_id.startsWith('pick_project') && !action.action_id.startsWith('switch_project_')) {
+    await handleAgentClick(payload, action);
+    return;
+  }
+
+  if (!action.action_id.startsWith('pick_project')) return;
   let value: { k?: string; p?: string };
   try {
     value = JSON.parse(action.value ?? '{}') as { k?: string; p?: string };
@@ -475,7 +1434,6 @@ async function handleBlockAction(payload: SlackInteractionPayload): Promise<void
   }
 }
 
-// BYO mode — per-project URL, per-project signing secret.
 slackWebhookApp.post('/:projectId', async (c) => {
   const projectId = c.req.param('projectId');
   const rawBody = await c.req.text();
@@ -503,7 +1461,6 @@ slackWebhookApp.post('/:projectId', async (c) => {
 
 type EventClass = 'mention' | 'dm' | 'follow_up' | 'ignore';
 
-// Decide whether a Slack event should trigger an agent turn.
 async function classifyEvent(
   teamId: string,
   event: SlackEvent,
@@ -512,8 +1469,6 @@ async function classifyEvent(
   if (event.type === 'app_mention') return 'mention';
   if (event.type !== 'message') return 'ignore';
   if (event.subtype) return 'ignore';
-  // Slack delivers both `app_mention` and `message.*` for a message that
-  // mentions the bot. `app_mention` owns those; drop the message twin.
   if (botUserId && (event.text ?? '').includes(`<@${botUserId}>`)) return 'ignore';
   if (event.channel_type === 'im') return 'dm';
   if (event.thread_ts && (await threadIsOwned(teamId, event.thread_ts))) return 'follow_up';
@@ -539,6 +1494,326 @@ function stripMentions(text: string): string {
   return text.replace(/<@[A-Z0-9]+>/g, '').trim();
 }
 
+const CHANNEL_INTRO_FALLBACK = "👋 Hey! I'm Kortix — your coding teammate. `@`-mention me with a task and I'll get on it.";
+
+async function postChannelIntro(projectId: string, channelId: string): Promise<void> {
+  const token = await loadSlackTokenForProject(projectId);
+  if (!token) return;
+  const dashboardBase = (config.KORTIX_URL || 'https://kortix.com').replace(/\/$/, '');
+  const heroUrl = config.SLACK_HOME_HERO_URL || DEFAULT_HOME_HERO_URL;
+  const blocks: Array<Record<string, unknown>> = [
+    { type: 'image', image_url: heroUrl, alt_text: 'Kortix — your coding teammate in Slack' },
+    {
+      type: 'header',
+      text: { type: 'plain_text', text: "👋  Hey! I'm Kortix", emoji: true },
+    },
+    {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: [
+          "*Your coding teammate, right here in Slack.*",
+          '',
+          "`@`-mention me with a task and I'll get on it — read the repo, run the work in an isolated sandbox, and reply in this thread. Follow-ups stay in context.",
+        ].join('\n'),
+      },
+    },
+    {
+      type: 'context',
+      elements: [
+        { type: 'mrkdwn', text: '⚡  *Live plan streaming*' },
+        { type: 'mrkdwn', text: '🧵  *Thread memory*' },
+        { type: 'mrkdwn', text: '📁  *File I/O*' },
+        { type: 'mrkdwn', text: '🔒  *Isolated sandbox*' },
+      ],
+    },
+    { type: 'divider' },
+    {
+      type: 'section',
+      text: { type: 'mrkdwn', text: '*Try a task*' },
+    },
+    { type: 'section', text: { type: 'mrkdwn', text: '🔍  `@Kortix scan this codebase and write me a one-pager`' } },
+    { type: 'section', text: { type: 'mrkdwn', text: '🔧  `@Kortix open a PR that updates the README with our setup steps`' } },
+    { type: 'section', text: { type: 'mrkdwn', text: '📊  `@Kortix what changed on main this week?`' } },
+    { type: 'divider' },
+    {
+      type: 'actions',
+      elements: [
+        {
+          type: 'button',
+          text: { type: 'plain_text', text: 'Open dashboard', emoji: true },
+          style: 'primary',
+          url: dashboardBase,
+          action_id: 'intro_open_dashboard',
+        },
+        {
+          type: 'button',
+          text: { type: 'plain_text', text: '/kortix help', emoji: true },
+          url: dashboardBase,
+          action_id: 'intro_help',
+        },
+      ],
+    },
+    {
+      type: 'context',
+      elements: [
+        { type: 'mrkdwn', text: `🪐  Managed by Kortix  ·  <${dashboardBase}|kortix.com>` },
+      ],
+    },
+  ];
+  await postBlocks(token, channelId, CHANNEL_INTRO_FALLBACK, blocks);
+}
+
+async function publishHomeForUser(teamId: string, userId: string): Promise<void> {
+  const installs = await db
+    .select({ projectId: chatInstalls.projectId })
+    .from(chatInstalls)
+    .where(and(eq(chatInstalls.platform, 'slack'), eq(chatInstalls.workspaceId, teamId)));
+  if (installs.length === 0) return;
+
+  const token = await loadSlackTokenForProject(installs[0].projectId);
+  if (!token) return;
+
+  const projectIds = installs.map((i) => i.projectId);
+  const projectRows = await db
+    .select({ projectId: projects.projectId, name: projects.name, repoUrl: projects.repoUrl })
+    .from(projects)
+    .where(inArray(projects.projectId, projectIds));
+
+  const recent = await db
+    .select({
+      projectId: chatThreads.projectId,
+      lastMessageAt: chatThreads.lastMessageAt,
+      threadId: chatThreads.threadId,
+    })
+    .from(chatThreads)
+    .where(and(eq(chatThreads.platform, 'slack'), eq(chatThreads.workspaceId, teamId)))
+    .orderBy(desc(chatThreads.lastMessageAt))
+    .limit(5);
+
+  const view = buildHomeView({ projects: projectRows, recent });
+  await publishHomeView(token, userId, view);
+}
+
+const HOME_EXAMPLES: Array<{ emoji: string; prompt: string }> = [
+  { emoji: '🔍', prompt: '@Kortix scan this codebase and write me a one-pager' },
+  { emoji: '🔧', prompt: '@Kortix open a PR that switches our logger to pino' },
+  { emoji: '📊', prompt: '@Kortix what changed on main this week?' },
+  { emoji: '📦', prompt: '@Kortix pull yesterday\'s sign-ups, group them by source, drop the CSV here' },
+];
+
+const PROJECT_COVERS = [
+  '1517694712202-14dd9538aa97',
+  '1555066931-4365d14bab8c',
+  '1542831371-29b0f74f9713',
+  '1532619675605-1ede6c2ed2b0',
+  '1551033406-611cf9a28f67',
+  '1573164713988-8665fc963095',
+  '1551288049-bebda4e38f71',
+];
+
+function projectCoverUrl(projectId: string): string {
+  let h = 0;
+  for (let i = 0; i < projectId.length; i++) h = (h * 31 + projectId.charCodeAt(i)) | 0;
+  const idx = Math.abs(h) % PROJECT_COVERS.length;
+  return `https://images.unsplash.com/photo-${PROJECT_COVERS[idx]}?w=1600&h=400&fit=crop&q=80&auto=format`;
+}
+
+const DEFAULT_HOME_HERO_URL =
+  'https://images.unsplash.com/photo-1518770660439-4636190af475?w=1600&h=480&fit=crop&q=80&auto=format';
+
+interface HomeProjectRow { projectId: string; name: string; repoUrl: string }
+interface HomeRecentRow { projectId: string; lastMessageAt: Date; threadId: string }
+
+function repoOgImage(repoUrl: string): string | null {
+  const m = repoUrl.match(/github\.com[\/:]([\w.-]+)\/([\w.-]+?)(\.git)?$/i);
+  if (!m) return null;
+  return `https://opengraph.githubassets.com/1/${m[1]}/${m[2]}`;
+}
+
+function repoLabel(repoUrl: string): string {
+  return repoUrl
+    .replace(/^https?:\/\/(www\.)?github\.com\//, '')
+    .replace(/^git@github\.com:/, '')
+    .replace(/\.git$/, '');
+}
+
+function buildHomeView(input: { projects: HomeProjectRow[]; recent: HomeRecentRow[] }): Record<string, unknown> {
+  const dashboardBase = (config.KORTIX_URL || 'https://kortix.com').replace(/\/$/, '');
+  const heroUrl = config.SLACK_HOME_HERO_URL || DEFAULT_HOME_HERO_URL;
+  const blocks: Array<Record<string, unknown>> = [];
+
+  blocks.push({
+    type: 'image',
+    image_url: heroUrl,
+    alt_text: 'Kortix — your coding teammate in Slack',
+  });
+  blocks.push({
+    type: 'header',
+    text: { type: 'plain_text', text: '👋  Welcome to Kortix', emoji: true },
+  });
+  blocks.push({
+    type: 'section',
+    text: {
+      type: 'mrkdwn',
+      text: [
+        '*Your coding teammate, right here in Slack.*',
+        '',
+        "`@`-mention me in any channel with a task and I'll read the repo, run the work in an isolated sandbox, and reply in the thread. Follow-ups stay in context.",
+      ].join('\n'),
+    },
+  });
+  blocks.push({
+    type: 'context',
+    elements: [
+      { type: 'mrkdwn', text: '⚡  *Live plan streaming*' },
+      { type: 'mrkdwn', text: '🧵  *Thread memory*' },
+      { type: 'mrkdwn', text: '📁  *File I/O*' },
+      { type: 'mrkdwn', text: '🔒  *Isolated sandbox*' },
+    ],
+  });
+
+  blocks.push({ type: 'divider' });
+
+  if (input.projects.length === 0) {
+    blocks.push({
+      type: 'section',
+      text: { type: 'mrkdwn', text: '*No projects connected yet.*\nHead to your Kortix dashboard to link a project to this workspace.' },
+      accessory: {
+        type: 'button',
+        text: { type: 'plain_text', text: 'Open dashboard' },
+        style: 'primary',
+        url: dashboardBase,
+        action_id: 'home_open_dashboard',
+      },
+    });
+  } else {
+    blocks.push({
+      type: 'header',
+      text: { type: 'plain_text', text: `Connected projects · ${input.projects.length}`, emoji: true },
+    });
+    for (const p of input.projects) {
+      const label = repoLabel(p.repoUrl);
+      // Cover image — full-width card hero.
+      blocks.push({
+        type: 'image',
+        image_url: projectCoverUrl(p.projectId),
+        alt_text: `${p.name} cover`,
+      });
+      blocks.push({
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: [
+            `*${escapeMrkdwn(p.name)}*`,
+            `<${p.repoUrl}|${escapeMrkdwn(label)}>`,
+          ].join('\n'),
+        },
+      });
+      blocks.push({
+        type: 'context',
+        elements: [
+          { type: 'mrkdwn', text: '🟢  *Connected*' },
+          { type: 'mrkdwn', text: `🪐  <${dashboardBase}/projects/${p.projectId}|Dashboard>` },
+        ],
+      });
+      blocks.push({
+        type: 'actions',
+        elements: [
+          {
+            type: 'button',
+            text: { type: 'plain_text', text: 'Open project' },
+            style: 'primary',
+            url: `${dashboardBase}/projects/${p.projectId}`,
+            action_id: `home_open_${p.projectId}`,
+          },
+          {
+            type: 'button',
+            text: { type: 'plain_text', text: 'View on GitHub' },
+            url: p.repoUrl,
+            action_id: `home_repo_${p.projectId}`,
+          },
+        ],
+      });
+    }
+  }
+
+  blocks.push({ type: 'divider' });
+  blocks.push({
+    type: 'header',
+    text: { type: 'plain_text', text: 'Try a task', emoji: true },
+  });
+  blocks.push({
+    type: 'section',
+    text: { type: 'mrkdwn', text: '_Paste any of these into a channel I\'m in:_' },
+  });
+  for (const ex of HOME_EXAMPLES) {
+    blocks.push({
+      type: 'section',
+      text: { type: 'mrkdwn', text: `${ex.emoji}  \`${ex.prompt}\`` },
+    });
+  }
+
+  if (input.recent.length > 0) {
+    const projectById = new Map(input.projects.map((p) => [p.projectId, p]));
+    blocks.push({ type: 'divider' });
+    blocks.push({
+      type: 'header',
+      text: { type: 'plain_text', text: 'Recent activity', emoji: true },
+    });
+    for (const r of input.recent) {
+      const proj = projectById.get(r.projectId);
+      const projectName = proj?.name ?? 'project';
+      const when = formatRelativeTime(r.lastMessageAt);
+      const elements: Array<Record<string, unknown>> = [];
+      const og = proj ? repoOgImage(proj.repoUrl) : null;
+      if (og) elements.push({ type: 'image', image_url: og, alt_text: `${projectName} repo` });
+      elements.push({ type: 'mrkdwn', text: `*${escapeMrkdwn(projectName)}*  ·  ${when}` });
+      blocks.push({ type: 'context', elements });
+    }
+  }
+
+  blocks.push({ type: 'divider' });
+  blocks.push({
+    type: 'context',
+    elements: [
+      { type: 'mrkdwn', text: `🪐  Managed by Kortix  ·  <${dashboardBase}|kortix.com>  ·  <${dashboardBase}/docs|Docs>  ·  <${dashboardBase}/settings|Settings>` },
+    ],
+  });
+
+  return { type: 'home', blocks };
+}
+
+function formatRelativeTime(d: Date): string {
+  const ms = Date.now() - d.getTime();
+  const sec = Math.floor(ms / 1000);
+  if (sec < 60) return 'just now';
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const day = Math.floor(hr / 24);
+  if (day < 7) return `${day}d ago`;
+  return d.toISOString().slice(0, 10);
+}
+
+function escapeMrkdwn(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+async function maybePostChannelIntro(teamId: string, event: SlackEvent): Promise<void> {
+  if (!event.channel) return;
+  const [install] = await db
+    .select({ projectId: chatInstalls.projectId })
+    .from(chatInstalls)
+    .where(and(eq(chatInstalls.platform, 'slack'), eq(chatInstalls.workspaceId, teamId)))
+    .limit(1);
+  if (!install) return;
+  const botUserId = await loadSlackBotUserIdForProject(install.projectId);
+  if (!botUserId || event.user !== botUserId) return;
+  await postChannelIntro(install.projectId, event.channel);
+}
+
 async function dispatchSlackEvent(projectId: string, envelope: SlackEnvelope): Promise<void> {
   const event = envelope.event;
   if (!event) return;
@@ -546,14 +1821,21 @@ async function dispatchSlackEvent(projectId: string, envelope: SlackEnvelope): P
   const teamId = envelope.team_id ?? event.team ?? '';
   const botUserId = await loadSlackBotUserIdForProject(projectId);
 
-  // Echo guard — never process the bot's own messages (including its streamed
-  // message and the stream's edits).
+  if (
+    event.type === 'member_joined_channel' &&
+    botUserId &&
+    event.user === botUserId &&
+    event.channel
+  ) {
+    await postChannelIntro(projectId, event.channel);
+    return;
+  }
+
   if ((botUserId && event.user === botUserId) || event.bot_id) return;
 
   const eventClass = await classifyEvent(teamId, event, botUserId);
   if (eventClass === 'ignore') return;
 
-  // Bare "@Kortix" with no task — answer with a nudge, don't burn a sandbox.
   if (eventClass === 'mention' && !stripMentions(event.text ?? '')) {
     const token = await loadSlackTokenForProject(projectId);
     if (token && event.channel) {
@@ -604,7 +1886,6 @@ async function spawnAgentTurn(
   const teamId = envelope.team_id ?? event.team ?? '';
   const threadId = event.thread_ts ?? event.ts ?? '';
 
-  // Thread continuity: deliver to an existing live session before spawning.
   let revived = false;
   if (teamId && threadId) {
     const [existing] = await db
@@ -619,10 +1900,13 @@ async function spawnAgentTurn(
       )
       .limit(1);
     if (existing) {
+      const handle = await startTurnStream(projectId, teamId, event, 'On it');
+      if (handle) {
+        activeStreams.set(existing.sessionId, handle);
+        await attachStopControls(handle, existing.sessionId);
+      }
       const outcome = await deliverFollowUpToSandbox(existing.sessionId, envelope, event);
       if (outcome === 'delivered') {
-        const handle = await startTurnStream(projectId, teamId, event, 'On it');
-        if (handle) activeStreams.set(existing.sessionId, handle);
         await db
           .update(chatThreads)
           .set({ lastMessageAt: new Date() })
@@ -635,9 +1919,11 @@ async function spawnAgentTurn(
           );
         return;
       }
-      // Transient: alive but the relay failed retryably — don't duplicate.
+      if (handle) {
+        activeStreams.delete(existing.sessionId);
+        await finalizeStream(handle, { error: "I couldn't reach the sandbox — try again." });
+      }
       if (outcome === 'transient') return;
-      // Stale: sandbox gone — spawn fresh and tell the agent context is lost.
       revived = true;
       await db
         .delete(chatThreads)
@@ -664,8 +1950,6 @@ async function spawnAgentTurn(
     return;
   }
 
-  // Open the stream now — the user sees a live plan immediately, well before
-  // the sandbox is ready.
   const handle = await startTurnStream(projectId, teamId, event, 'Spinning up a sandbox');
 
   const result = await createProjectSession({
@@ -688,6 +1972,9 @@ async function spawnAgentTurn(
         event_type: event.type,
       },
     },
+    // Sandbox-side env the slack skill references. The agent uses these to
+    // talk back to the same thread without parsing IDs out of the prompt.
+    extraEnvVars: buildSlackTurnEnv(teamId, event),
   });
 
   if (result.error) {
@@ -700,6 +1987,7 @@ async function spawnAgentTurn(
 
   if (result.row && handle) {
     activeStreams.set(result.row.sessionId, handle);
+    await attachStopControls(handle, result.row.sessionId);
   }
 
   if (result.row && teamId && threadId) {
@@ -725,7 +2013,65 @@ async function spawnAgentTurn(
 
 type DeliveryOutcome = 'delivered' | 'transient' | 'stale';
 
-// Deliver a follow-up Slack message to the running sandbox's /kortix/prompt.
+async function resolveSandboxPreview(
+  kortixSessionId: string,
+): Promise<{ url: string; headers: Record<string, string> } | { error: 'stale' | 'transient' }> {
+  const [sandbox] = await db
+    .select({
+      sandboxId: sessionSandboxes.sandboxId,
+      metadata: sessionSandboxes.metadata,
+      status: sessionSandboxes.status,
+    })
+    .from(sessionSandboxes)
+    .where(eq(sessionSandboxes.sessionId, kortixSessionId))
+    .limit(1);
+  if (!sandbox) return { error: 'stale' };
+  if (sandbox.status === 'stopped' || sandbox.status === 'archived' || sandbox.status === 'error') {
+    return { error: 'stale' };
+  }
+  if (sandbox.status !== 'active') return { error: 'transient' };
+  const daytonaSandboxId = (sandbox.metadata as Record<string, unknown> | null)?.['daytonaSandboxId'];
+  if (typeof daytonaSandboxId !== 'string' || !daytonaSandboxId) return { error: 'stale' };
+  try {
+    const daytona = getDaytona();
+    const sb = await daytona.get(daytonaSandboxId);
+    const link = await (sb as { getPreviewLink: (port: number) => Promise<{ url?: string; token?: string }> })
+      .getPreviewLink(8000);
+    const url = (link.url ?? `https://8000-${daytonaSandboxId}.daytonaproxy01.net`).replace(/\/$/, '');
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      'X-Daytona-Skip-Preview-Warning': 'true',
+      'X-Daytona-Disable-CORS': 'true',
+    };
+    if (link.token) headers['X-Daytona-Preview-Token'] = link.token;
+    return { url, headers };
+  } catch (err) {
+    console.warn('[slack-webhook] getPreviewLink failed', err);
+    return { error: 'transient' };
+  }
+}
+
+async function abortSandboxTurn(kortixSessionId: string): Promise<boolean> {
+  const preview = await resolveSandboxPreview(kortixSessionId);
+  if ('error' in preview) return false;
+  try {
+    const res = await fetch(`${preview.url}/kortix/abort`, {
+      method: 'POST',
+      headers: preview.headers,
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!res.ok) {
+      const body = (await res.text()).slice(0, 300);
+      console.warn('[slack-webhook] kortix/abort returned non-ok', { status: res.status, body });
+      return false;
+    }
+    return true;
+  } catch (err) {
+    console.warn('[slack-webhook] kortix/abort fetch failed', err);
+    return false;
+  }
+}
+
 async function deliverFollowUpToSandbox(
   kortixSessionId: string,
   envelope: SlackEnvelope,
@@ -794,17 +2140,38 @@ async function deliverFollowUpToSandbox(
   }
 }
 
-// How the agent narrates its turn and delivers its answer. Shared by the cold
-// and follow-up prompts.
 const TURN_INSTRUCTIONS = [
   'How to work:',
+  '- **First, load the `slack` skill** via the `skill` tool. It is the canonical',
+  '  reference for posting in Slack — covers step/send semantics, link syntax,',
+  '  Block Kit answers, sources, tone, and gotchas. Do not skip it.',
   '- As you go, post a short progress checkpoint before each major step:',
   '    slack step "Reading the incident logs"',
   '  Keep them human and brief — a few per task, not one per command.',
-  '- When you are done, deliver your answer with:',
-  '    slack send "<your reply>"',
-  '  Write it like a teammate: concise, Slack-formatted, no preamble. This',
-  '  finalizes the live update in the thread.',
+  '- Attach inline context with mrkdwn links:',
+  '    slack step "Reading the logs" --detail "Pulling from <https://datadog.example.com|Datadog>"',
+  '  `--detail` is the subtitle under the new step. `<url|label>` becomes a real link.',
+  '- When the PREVIOUS step finished with a result, surface it:',
+  '    slack step "Drafting summary" --output "Found 3 incidents, 1 P0"',
+  '  Add `--source URL|TITLE` (repeatable) to cite the URLs you used.',
+  '- **Any time you would ask the user a question, use the built-in `question` tool — NEVER `slack send`.**',
+  '  If your reply would contain a `?` or any "please tell me / choose / which one / what',
+  '  would you like" phrasing, that is a question and it MUST go through `question`.',
+  '  `slack send` is for the FINAL ANSWER only, never for prompts.',
+  '  The `question` tool takes an `Array<QuestionInfo>` per opencode\'s schema — each',
+  '  with { question, header, options[], multiple, custom }. On Slack turns the sandbox',
+  '  automatically renders a Block Kit form (radio/checkboxes/text) in the same thread',
+  '  and resumes the tool with the user\'s answers (`string[][]` — one array per question).',
+  '  WRONG:  `slack send --blocks-file questions.json` (non-interactive — they can\'t reply!)',
+  '  RIGHT:  call the `question` tool with one or more QuestionInfo entries.',
+  '  Load the `slack` skill (`<asking-the-user>`) for the QuestionInfo schema + examples.',
+  '- Deliver the answer as a rich Block Kit message whenever the response',
+  '  benefits from structure (headers, sections, lists, links, bullets):',
+  '    slack send --text "fallback summary" --blocks-file /tmp/answer.json',
+  '  The `blocks` JSON follows the Block Kit schema (header, section with mrkdwn,',
+  '  divider, context, image, actions). Plain text via `slack send "..."` is fine',
+  '  for one-liners, but prefer blocks when there\'s real structure to convey.',
+  '- One `slack send` per turn. It finalizes the live stream and can\'t be undone.',
 ].join('\n');
 
 function renderFollowUpPrompt(envelope: SlackEnvelope, event: SlackEvent): string {
@@ -869,6 +2236,7 @@ interface SlackEvent {
   thread_ts?: string;
   subtype?: string;
   team?: string;
+  tab?: 'home' | 'messages';
 }
 
 interface SlackInteractionPayload {
@@ -876,6 +2244,25 @@ interface SlackInteractionPayload {
   team?: { id: string };
   user?: { id: string };
   channel?: { id: string };
-  message?: { ts: string };
-  actions?: Array<{ action_id?: string; value?: string }>;
+  message?: { ts: string; thread_ts?: string };
+  actions?: Array<{
+    action_id?: string;
+    value?: string;
+    text?: { type?: string; text?: string };
+  }>;
+  response_url?: string;
+  state?: {
+    values?: Record<
+      string,
+      Record<
+        string,
+        {
+          type?: string;
+          value?: string;
+          selected_option?: { value?: string } | null;
+          selected_options?: Array<{ value?: string }>;
+        }
+      >
+    >;
+  };
 }

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -121,6 +121,9 @@ const envSchema = z.object({
   // means the OAuth flow grants fewer scopes than the manifest advertises
   // and tools like `slack channels`/`slack users` fail with missing_scope.
   SLACK_OAUTH_SCOPES:          optStrDefault('app_mentions:read,channels:history,channels:read,channels:join,chat:write,chat:write.public,files:read,files:write,groups:history,groups:read,im:history,im:read,im:write,mpim:history,mpim:read,reactions:read,reactions:write,users:read'),
+  // Optional banner image rendered at the top of the App Home tab. Must be a
+  // public HTTPS URL Slack can fetch (no auth). Recommended 1600×400 PNG.
+  SLACK_HOME_HERO_URL:         optStr,
   KORTIX_API_KEY_ENC_KEY:      optStr,
   KORTIX_DASHBOARD_URL:        optStr,
 
@@ -403,6 +406,7 @@ export const config = {
   SLACK_CLIENT_SECRET: env.SLACK_CLIENT_SECRET,
   SLACK_REDIRECT_URI: env.SLACK_REDIRECT_URI,
   SLACK_OAUTH_SCOPES: env.SLACK_OAUTH_SCOPES,
+  SLACK_HOME_HERO_URL: env.SLACK_HOME_HERO_URL,
   KORTIX_DASHBOARD_URL: env.KORTIX_DASHBOARD_URL,
 
   // ─── LLM Providers ────────────────────────────────────────────────────────

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -156,7 +156,6 @@ export async function supabaseAuth(c: Context, next: Next) {
       auditLoginFail({ c, reason: result.error ?? 'invalid_pat', authType: 'pat' });
       throw new HTTPException(401, { message: result.error || 'Invalid PAT' });
     }
-    // Project-scoped tokens: enforce the URL's :projectId matches.
     if (result.projectId) {
       enforceTokenProjectScope(c, result.projectId);
     }
@@ -165,9 +164,6 @@ export async function supabaseAuth(c: Context, next: Next) {
     c.set('authType', 'pat');
     if (result.accountId) c.set('accountId', result.accountId);
     if (result.projectId) c.set('tokenProjectId', result.projectId);
-    // Token identity for the IAM engine. When the PAT has narrowing
-    // policies attached, authorize() evaluates only the token's policies
-    // instead of inheriting the minter's permissions.
     if (result.tokenId) c.set('iamTokenId', result.tokenId);
     setSentryUser({ id: result.userId, accountId: result.accountId });
     setContextField('userId', result.userId);
@@ -183,13 +179,18 @@ export async function supabaseAuth(c: Context, next: Next) {
     return;
   }
 
-  if (isKortixToken(token) && c.req.path.endsWith('/git/clone-credential')) {
+  const path = c.req.path;
+  const sandboxTokenPathAllowed =
+    path.endsWith('/git/clone-credential') ||
+    path.endsWith('/turn-stream') ||
+    path.endsWith('/turn-question');
+  if (isKortixToken(token) && sandboxTokenPathAllowed) {
     const result = await validateSecretKey(token);
     if (!result.isValid) {
       throw new HTTPException(401, { message: result.error || 'Invalid Kortix token' });
     }
     if (result.type !== 'sandbox' || !result.sandboxId) {
-      throw new HTTPException(403, { message: 'Clone credentials require a sandbox token' });
+      throw new HTTPException(403, { message: 'This route requires a sandbox token' });
     }
     c.set('userId', result.accountId || '');
     c.set('userEmail', '');

--- a/apps/api/src/projects/index.ts
+++ b/apps/api/src/projects/index.ts
@@ -147,6 +147,7 @@ import {
   loadSlackInstall,
   saveSlackInstall,
 } from '../channels/install-store';
+import { relayTurnStep, relayTurnAnswer } from '../channels/slack-webhook';
 import {
   buildDeploymentRequest,
   deployAppSpec,
@@ -1410,11 +1411,15 @@ async function buildSessionSandboxEnvVars(input: {
   baseRef: string;
   agentName: string;
   initialPrompt?: string | null;
+  opencodeModel?: string | null;
 }): Promise<Record<string, string>> {
   // Only user runtime secrets belong here. The sandbox-scoped KORTIX_TOKEN is
   // minted by provisionSessionSandbox() and injected at the provider boundary,
   // then reused by the daemon for both API calls and proxy HMAC validation.
   const runtimeSecrets = await listProjectSecrets(input.projectId);
+  // The Slack signing secret only verifies inbound webhooks (an apps/api job).
+  // The in-sandbox agent never needs it — keep it out of the sandbox env.
+  delete runtimeSecrets.SLACK_SIGNING_SECRET;
   return {
     ...runtimeSecrets,
     KORTIX_PROJECT_AUTO_CLONE: '1',
@@ -1428,6 +1433,9 @@ async function buildSessionSandboxEnvVars(input: {
     KORTIX_AGENT_NAME: input.agentName,
     KORTIX_API_URL: deriveKortixApiBase(),
     ...(input.initialPrompt ? { KORTIX_INITIAL_PROMPT: input.initialPrompt } : {}),
+    // Per-session model override (e.g. Slack turns pin a specific model).
+    // The sandbox agent reads this and sets it on every opencode prompt call.
+    ...(input.opencodeModel ? { KORTIX_OPENCODE_MODEL: input.opencodeModel } : {}),
   };
 }
 
@@ -1492,12 +1500,14 @@ export async function createProjectSession(input: {
   }
 
   const initialPrompt = normalizeString(body.initial_prompt ?? body.initialPrompt);
+  const opencodeModel = normalizeString(body.opencode_model ?? body.opencodeModel);
   const sessionName = normalizeString(body.name);
   const requestMetadata = normalizeJsonObject(body.metadata);
   const metadata = {
     ...requestMetadata,
     ...(sessionName ? { name: sessionName } : {}),
     ...(initialPrompt ? { initial_prompt: initialPrompt } : {}),
+    ...(opencodeModel ? { opencode_model: opencodeModel } : {}),
     ...(input.metadata ?? {}),
   };
 
@@ -1540,6 +1550,7 @@ export async function createProjectSession(input: {
         baseRef,
         agentName,
         initialPrompt,
+        opencodeModel,
       });
       await provisionSessionSandbox({
         sandboxId: sessionId,
@@ -3802,6 +3813,33 @@ projectsApp.delete('/:projectId/channels/slack/installation', async (c) => {
   return c.json({ status: 'disconnected' });
 });
 
+// POST /v1/projects/:projectId/turn-stream
+// Agent-cli relay for the live Slack plan: kind=step appends a checkpoint,
+// kind=answer finalizes the turn's streamed message with the agent's reply.
+projectsApp.post('/:projectId/turn-stream', async (c) => {
+  const projectId = c.req.param('projectId');
+  const loaded = await loadProjectForUser(c, projectId, 'read');
+  if (!loaded) return c.json({ error: 'Not found' }, 404);
+
+  let body: { session_id?: string; kind?: string; text?: string };
+  try {
+    body = (await c.req.json()) as typeof body;
+  } catch {
+    return c.json({ error: 'Invalid JSON body' }, 400);
+  }
+  const sessionId = body.session_id?.trim();
+  const text = (body.text ?? '').trim();
+  if (!sessionId || !text) {
+    return c.json({ error: 'session_id and text are required' }, 400);
+  }
+
+  const ok =
+    body.kind === 'answer'
+      ? await relayTurnAnswer(sessionId, text)
+      : await relayTurnStep(sessionId, text);
+  return c.json({ ok });
+});
+
 // POST /v1/projects/:projectId/triggers/:slug/fire
 //
 // Manual fire for git-backed triggers. Reads the file, renders the prompt
@@ -5089,6 +5127,9 @@ projectsApp.post('/:projectId/sessions/:sessionId/restart', async (c) => {
   const initialPrompt = typeof session.metadata?.initial_prompt === 'string'
     ? session.metadata.initial_prompt as string
     : null;
+  const opencodeModel = typeof session.metadata?.opencode_model === 'string'
+    ? session.metadata.opencode_model as string
+    : null;
 
   // Best-effort tear down: remove the old external container and revoke its
   // sandbox keys. Failures are logged but don't block restart — a stuck row
@@ -5153,6 +5194,7 @@ projectsApp.post('/:projectId/sessions/:sessionId/restart', async (c) => {
         baseRef: session.baseRef ?? loaded.row.defaultBranch,
         agentName: session.agentName ?? 'default',
         initialPrompt,
+        opencodeModel,
       });
       await provisionSessionSandbox({
         sandboxId: sessionId,

--- a/apps/api/src/projects/index.ts
+++ b/apps/api/src/projects/index.ts
@@ -147,7 +147,9 @@ import {
   loadSlackInstall,
   saveSlackInstall,
 } from '../channels/install-store';
-import { relayTurnStep, relayTurnAnswer } from '../channels/slack-webhook';
+import { relayTurnStep, relayTurnAnswer, postQuestionAndWait, type QuestionInfo } from '../channels/slack-webhook';
+import { buildSlackInstallUrl } from '../channels/slack-oauth';
+import { slackOauthMode } from '../channels/slack-oauth-mode';
 import {
   buildDeploymentRequest,
   deployAppSpec,
@@ -1450,6 +1452,7 @@ export async function createProjectSession(input: {
   body: Record<string, unknown>;
   enforceAccountCap?: boolean;
   metadata?: Record<string, unknown>;
+  extraEnvVars?: Record<string, string>;
   request?: RequestAuditContext;
 }): Promise<{ row?: ProjectSessionRow; error?: SessionCreateError; headers?: Record<string, string> }> {
   const { project, userId, body } = input;
@@ -1541,17 +1544,20 @@ export async function createProjectSession(input: {
   // status endpoint and shows the ConnectingScreen during the long tail.
   void (async () => {
     try {
-      const extraEnvVars = await buildSessionSandboxEnvVars({
-        accountId,
-        projectId,
-        sessionId,
-        userId,
-        repoUrl: project.repoUrl,
-        baseRef,
-        agentName,
-        initialPrompt,
-        opencodeModel,
-      });
+      const extraEnvVars = {
+        ...(await buildSessionSandboxEnvVars({
+          accountId,
+          projectId,
+          sessionId,
+          userId,
+          repoUrl: project.repoUrl,
+          baseRef,
+          agentName,
+          initialPrompt,
+          opencodeModel,
+        })),
+        ...(input.extraEnvVars ?? {}),
+      };
       await provisionSessionSandbox({
         sandboxId: sessionId,
         accountId,
@@ -3755,6 +3761,26 @@ projectsApp.get('/:projectId/channels/slack/installation', async (c) => {
   return c.json(install ?? null);
 });
 
+// GET /v1/projects/:projectId/channels/slack/mode
+// Tells the dashboard whether one-click "Add to Slack" is available (server
+// has SLACK_CLIENT_ID + SECRET + SIGNING_SECRET set) and the pre-signed
+// install URL to redirect the user to.
+projectsApp.get('/:projectId/channels/slack/mode', async (c) => {
+  const projectId = c.req.param('projectId');
+  const loaded = await loadProjectForUser(c, projectId, 'read');
+  if (!loaded) return c.json({ error: 'Not found' }, 404);
+  const mode = slackOauthMode();
+  if (!mode.available) {
+    return c.json({ oauth_available: false, install_url: null });
+  }
+  try {
+    const installUrl = buildSlackInstallUrl(projectId, loaded.userId);
+    return c.json({ oauth_available: true, install_url: installUrl });
+  } catch {
+    return c.json({ oauth_available: false, install_url: null });
+  }
+});
+
 // POST /v1/projects/:projectId/channels/slack/connect
 projectsApp.post('/:projectId/channels/slack/connect', async (c) => {
   const projectId = c.req.param('projectId');
@@ -3818,10 +3844,44 @@ projectsApp.delete('/:projectId/channels/slack/installation', async (c) => {
 // kind=answer finalizes the turn's streamed message with the agent's reply.
 projectsApp.post('/:projectId/turn-stream', async (c) => {
   const projectId = c.req.param('projectId');
-  const loaded = await loadProjectForUser(c, projectId, 'read');
-  if (!loaded) return c.json({ error: 'Not found' }, 404);
 
-  let body: { session_id?: string; kind?: string; text?: string };
+  // Two valid callers: a project-scoped PAT (dashboard or operator) and the
+  // session sandbox's own KORTIX_TOKEN (so the in-sandbox agent CLI can relay
+  // its plan steps without a second token). Each is scoped to one projectId.
+  const authType = (c as any).get('authType') as string | undefined;
+  if (authType === 'apiKey' && (c as any).get('apiKeyType') === 'sandbox') {
+    const accountId = (c as any).get('accountId') as string | undefined;
+    const sandboxId = (c as any).get('sandboxId') as string | undefined;
+    if (!accountId || !sandboxId) {
+      return c.json({ error: 'turn-stream requires a sandbox token' }, 403);
+    }
+    const [sandbox] = await db
+      .select({ sandboxId: sessionSandboxes.sandboxId })
+      .from(sessionSandboxes)
+      .where(and(
+        eq(sessionSandboxes.sandboxId, sandboxId),
+        eq(sessionSandboxes.projectId, projectId),
+        eq(sessionSandboxes.accountId, accountId),
+        inArray(sessionSandboxes.status, ['provisioning', 'active']),
+      ))
+      .limit(1);
+    if (!sandbox) {
+      return c.json({ error: 'sandbox token is not scoped to this project' }, 403);
+    }
+  } else {
+    const loaded = await loadProjectForUser(c, projectId, 'read');
+    if (!loaded) return c.json({ error: 'Not found' }, 404);
+  }
+
+  let body: {
+    session_id?: string;
+    kind?: string;
+    text?: string;
+    detail?: string;
+    output?: string;
+    sources?: Array<{ url?: string; text?: string }>;
+    blocks?: unknown[];
+  };
   try {
     body = (await c.req.json()) as typeof body;
   } catch {
@@ -3833,11 +3893,105 @@ projectsApp.post('/:projectId/turn-stream', async (c) => {
     return c.json({ error: 'session_id and text are required' }, 400);
   }
 
+  const detail = body.detail?.trim() || undefined;
+  const outputForPrev = body.output?.trim() || undefined;
+  const sourcesForPrev = Array.isArray(body.sources)
+    ? body.sources
+        .filter((s): s is { url: string; text: string } => !!s?.url && !!s?.text)
+        .map((s) => ({ url: s.url, text: s.text }))
+    : undefined;
+  const blocks = Array.isArray(body.blocks) && body.blocks.length > 0 ? body.blocks : undefined;
+
   const ok =
     body.kind === 'answer'
-      ? await relayTurnAnswer(sessionId, text)
-      : await relayTurnStep(sessionId, text);
+      ? await relayTurnAnswer(sessionId, text, blocks)
+      : await relayTurnStep(sessionId, text, { detail, outputForPrev, sourcesForPrev });
   return c.json({ ok });
+});
+
+// POST /v1/projects/:projectId/turn-question
+// Sandbox-to-apps/api relay for opencode's `question.asked` event. The
+// sandbox subscribes to opencode's SSE stream; when the agent calls the
+// built-in `question` tool, the sandbox relays the QuestionInfo[] here.
+// We post a Block Kit form, block on Submit, return `answers: string[][]`,
+// and the sandbox POSTs the same payload to opencode's
+// /question/{requestID}/reply so the tool resumes.
+projectsApp.post('/:projectId/turn-question', async (c) => {
+  const projectId = c.req.param('projectId');
+
+  const authType = (c as any).get('authType') as string | undefined;
+  if (authType === 'apiKey' && (c as any).get('apiKeyType') === 'sandbox') {
+    const accountId = (c as any).get('accountId') as string | undefined;
+    const sandboxId = (c as any).get('sandboxId') as string | undefined;
+    if (!accountId || !sandboxId) {
+      return c.json({ error: 'turn-question requires a sandbox token' }, 403);
+    }
+    const [sandbox] = await db
+      .select({ sandboxId: sessionSandboxes.sandboxId })
+      .from(sessionSandboxes)
+      .where(and(
+        eq(sessionSandboxes.sandboxId, sandboxId),
+        eq(sessionSandboxes.projectId, projectId),
+        eq(sessionSandboxes.accountId, accountId),
+        inArray(sessionSandboxes.status, ['provisioning', 'active']),
+      ))
+      .limit(1);
+    if (!sandbox) {
+      return c.json({ error: 'sandbox token is not scoped to this project' }, 403);
+    }
+  } else {
+    const loaded = await loadProjectForUser(c, projectId, 'read');
+    if (!loaded) return c.json({ error: 'Not found' }, 404);
+  }
+
+  let body: {
+    session_id?: string;
+    request_id?: string;
+    questions?: unknown[];
+  };
+  try {
+    body = (await c.req.json()) as typeof body;
+  } catch {
+    return c.json({ error: 'Invalid JSON body' }, 400);
+  }
+  const sessionId = body.session_id?.trim();
+  if (!sessionId) {
+    return c.json({ error: 'session_id is required' }, 400);
+  }
+  if (!Array.isArray(body.questions) || body.questions.length === 0) {
+    return c.json({ error: 'at least one question is required' }, 400);
+  }
+
+  // Validate + coerce to QuestionInfo[]. Tolerate the v2 SDK schema variants.
+  const questions: QuestionInfo[] = [];
+  for (const q of body.questions) {
+    if (!q || typeof q !== 'object') continue;
+    const obj = q as Record<string, unknown>;
+    const question = String(obj.question ?? '').trim();
+    if (!question) continue;
+    const optionsRaw = Array.isArray(obj.options) ? obj.options : [];
+    const options = optionsRaw
+      .map((o) => (o && typeof o === 'object' ? (o as Record<string, unknown>) : null))
+      .filter((o): o is Record<string, unknown> => !!o && typeof o.label === 'string')
+      .map((o) => ({
+        label: String(o.label),
+        description: typeof o.description === 'string' ? String(o.description) : undefined,
+      }));
+    questions.push({
+      question,
+      header: obj.header ? String(obj.header) : undefined,
+      options,
+      multiple: !!obj.multiple,
+      custom: obj.custom === false ? false : true,
+    });
+  }
+  if (questions.length === 0) {
+    return c.json({ error: 'no valid questions provided' }, 400);
+  }
+
+  const result = await postQuestionAndWait(sessionId, questions);
+  if (!result.ok) return c.json({ ok: false, error: result.error }, 409);
+  return c.json({ ok: true, ask_id: result.ask_id, answers: result.answers });
 });
 
 // POST /v1/projects/:projectId/triggers/:slug/fire

--- a/apps/kortix-sandbox-agent-server/src/main.ts
+++ b/apps/kortix-sandbox-agent-server/src/main.ts
@@ -98,6 +98,7 @@ async function maybeDeliverInitialPrompt(opencodePort: number): Promise<void> {
   const session = (await sessionRes.json()) as { id?: string }
   if (!session.id) throw new Error('opencode session create returned no id')
 
+  const model = resolveOpencodeModel()
   const promptRes = await fetch(
     `${baseUrl}/session/${session.id}/prompt_async?directory=${encodeURIComponent(workspace)}`,
     {
@@ -105,6 +106,7 @@ async function maybeDeliverInitialPrompt(opencodePort: number): Promise<void> {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         parts: [{ type: 'text', text: prompt }],
+        ...(model ? { model } : {}),
       }),
       signal: AbortSignal.timeout(15_000),
     },
@@ -119,6 +121,17 @@ async function maybeDeliverInitialPrompt(opencodePort: number): Promise<void> {
     logger.warn('[boot] failed to pin opencode session id', err)
   }
   logger.info('[boot] initial prompt delivered', { sessionId: session.id })
+}
+
+/** Per-session model override from KORTIX_OPENCODE_MODEL (provider/model form,
+ *  e.g. `anthropic/claude-sonnet-4-6`). Returned in opencode's
+ *  `{ providerID, modelID }` shape, or undefined when unset/malformed so
+ *  opencode falls back to its configured default. */
+export function resolveOpencodeModel(): { providerID: string; modelID: string } | undefined {
+  const raw = (process.env.KORTIX_OPENCODE_MODEL ?? '').trim()
+  const slash = raw.indexOf('/')
+  if (slash <= 0 || slash === raw.length - 1) return undefined
+  return { providerID: raw.slice(0, slash), modelID: raw.slice(slash + 1) }
 }
 
 /** Read the pinned opencode session id (set at boot when KORTIX_INITIAL_PROMPT

--- a/apps/kortix-sandbox-agent-server/src/main.ts
+++ b/apps/kortix-sandbox-agent-server/src/main.ts
@@ -1,9 +1,10 @@
 import { writeFileSync, readFileSync, existsSync, mkdirSync } from 'node:fs'
 import { dirname } from 'node:path'
-import { loadConfig, resolveOpencodeConfigDir } from './config'
+import { loadConfig, resolveOpencodeConfigDir, type Config } from './config'
 import { materializeRepo } from './git'
 import { logger } from './logger'
 import { createOpencodeSupervisor, waitForOpencodeReady } from './opencode'
+import { startOpencodeEventLoop, type QuestionRequest } from './opencode-events'
 import { startProxy } from './proxy'
 import type { SandboxBootState } from './routes/health'
 import { installShutdownHandlers } from './shutdown'
@@ -63,6 +64,13 @@ async function main() {
     const ready = await waitForOpencodeReady(opencode)
     if (ready) {
       logger.info('[boot] opencode ready', { opencodePid: opencode.getPid() })
+      startOpencodeEventLoop(opencode, cfg, {
+        onQuestionAsked: (req) => {
+          void relayQuestionToApi(req, cfg).catch((err) =>
+            logger.warn('[opencode-events] question relay failed', { err: (err as Error).message }),
+          )
+        },
+      })
       await maybeDeliverInitialPrompt(cfg.opencodeInternalPort).catch((err) => {
         logger.warn('[boot] initial prompt delivery failed', err)
       })
@@ -121,6 +129,76 @@ async function maybeDeliverInitialPrompt(opencodePort: number): Promise<void> {
     logger.warn('[boot] failed to pin opencode session id', err)
   }
   logger.info('[boot] initial prompt delivered', { sessionId: session.id })
+}
+
+// Relay an opencode question.asked event to apps/api. apps/api blocks until
+// the user submits the Slack form, returns the captured `answers: string[][]`.
+// We then POST those answers to opencode's /question/{id}/reply so the agent
+// resumes naturally — same flow the dashboard uses, just over Slack.
+async function relayQuestionToApi(req: QuestionRequest, cfg: Config): Promise<void> {
+  const projectId = process.env.KORTIX_PROJECT_ID?.trim()
+  const sessionId = process.env.KORTIX_SESSION_ID?.trim()
+  const token = (process.env.KORTIX_CLI_TOKEN || process.env.KORTIX_TOKEN || '').trim()
+  const apiUrl = process.env.KORTIX_API_URL?.replace(/\/$/, '')
+  if (!projectId || !sessionId || !token || !apiUrl) {
+    logger.warn('[opencode-events] missing env to relay question', {
+      hasProject: !!projectId, hasSession: !!sessionId, hasToken: !!token, hasApi: !!apiUrl,
+    })
+    return
+  }
+  const apiRoot = apiUrl.endsWith('/v1') ? apiUrl : `${apiUrl}/v1`
+  const url = `${apiRoot}/projects/${encodeURIComponent(projectId)}/turn-question`
+  logger.info('[opencode-events] relaying question.asked', {
+    requestId: req.id, questions: req.questions.length,
+  })
+  let answers: string[][] | null = null
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+      body: JSON.stringify({
+        session_id: sessionId,
+        request_id: req.id,
+        opencode_session_id: req.sessionID,
+        questions: req.questions,
+      }),
+      signal: AbortSignal.timeout(15 * 60_000),
+    })
+    if (!res.ok) {
+      const body = (await res.text()).slice(0, 300)
+      logger.warn('[opencode-events] turn-question relay non-ok', { status: res.status, body })
+      return
+    }
+    const data = (await res.json()) as { ok?: boolean; answers?: string[][] }
+    if (!data.ok || !Array.isArray(data.answers)) {
+      logger.warn('[opencode-events] turn-question malformed response', data)
+      return
+    }
+    answers = data.answers
+  } catch (err) {
+    logger.warn('[opencode-events] turn-question fetch failed', { err: (err as Error).message })
+    return
+  }
+
+  // Post the answers back into opencode so the question tool resumes.
+  const replyUrl = `http://127.0.0.1:${cfg.opencodeInternalPort}/question/${encodeURIComponent(req.id)}/reply?directory=${encodeURIComponent(cfg.workspace)}`
+  try {
+    const r = await fetch(replyUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ answers }),
+      signal: AbortSignal.timeout(15_000),
+    })
+    if (!r.ok) {
+      logger.warn('[opencode-events] opencode question.reply non-ok', {
+        status: r.status, body: (await r.text()).slice(0, 300),
+      })
+      return
+    }
+    logger.info('[opencode-events] question replied to opencode', { requestId: req.id })
+  } catch (err) {
+    logger.warn('[opencode-events] opencode question.reply failed', { err: (err as Error).message })
+  }
 }
 
 /** Per-session model override from KORTIX_OPENCODE_MODEL (provider/model form,

--- a/apps/kortix-sandbox-agent-server/src/opencode-events.ts
+++ b/apps/kortix-sandbox-agent-server/src/opencode-events.ts
@@ -1,0 +1,113 @@
+import { logger } from './logger'
+import type { Config } from './config'
+import type { Opencode } from './opencode'
+
+// opencode's QuestionInfo schema, mirrored from the v2 SDK. Anything richer
+// (like permission.asked) is layered on top of the same SSE stream.
+export interface QuestionInfo {
+  question: string
+  header: string
+  options: Array<{ value: string; label?: string }>
+  multiple?: boolean
+  custom?: boolean
+}
+
+export interface QuestionRequest {
+  id: string
+  sessionID: string
+  questions: QuestionInfo[]
+}
+
+export type OpencodeEventHandlers = {
+  onQuestionAsked?: (req: QuestionRequest) => void
+}
+
+// Subscribe to opencode's SSE event stream and dispatch known event types.
+// Auto-reconnects on close — when the underlying opencode supervisor restarts,
+// we'll loop reconnecting until /event is reachable again.
+export function startOpencodeEventLoop(
+  opencode: Opencode,
+  cfg: Config,
+  handlers: OpencodeEventHandlers,
+): { stop(): void } {
+  let stopping = false
+  let abortController: AbortController | null = null
+
+  async function connectOnce(): Promise<void> {
+    const url = `${opencode.getInternalUrl()}/event?directory=${encodeURIComponent(cfg.workspace)}`
+    abortController = new AbortController()
+    const res = await fetch(url, {
+      headers: { Accept: 'text/event-stream' },
+      signal: abortController.signal,
+    })
+    if (!res.ok || !res.body) {
+      throw new Error(`/event subscribe non-ok: ${res.status}`)
+    }
+    logger.info('[opencode-events] subscribed')
+
+    const reader = res.body.getReader()
+    const decoder = new TextDecoder()
+    let buf = ''
+    while (true) {
+      const { value, done } = await reader.read()
+      if (done) return
+      buf += decoder.decode(value, { stream: true })
+      // SSE frames are separated by a blank line.
+      let idx = buf.indexOf('\n\n')
+      while (idx !== -1) {
+        const frame = buf.slice(0, idx)
+        buf = buf.slice(idx + 2)
+        idx = buf.indexOf('\n\n')
+        const dataLines = frame
+          .split('\n')
+          .filter((l) => l.startsWith('data:'))
+          .map((l) => l.slice(5).trim())
+          .filter(Boolean)
+        if (dataLines.length === 0) continue
+        try {
+          const event = JSON.parse(dataLines.join('\n')) as {
+            type?: string
+            properties?: unknown
+          }
+          dispatch(event, handlers)
+        } catch (err) {
+          logger.warn('[opencode-events] parse failed', { err: (err as Error).message })
+        }
+      }
+    }
+  }
+
+  ;(async () => {
+    let backoffMs = 1_000
+    while (!stopping) {
+      try {
+        await connectOnce()
+        backoffMs = 1_000
+      } catch (err) {
+        if (stopping) return
+        logger.warn('[opencode-events] disconnected — reconnecting', {
+          err: (err as Error).message,
+          backoffMs,
+        })
+        await new Promise((r) => setTimeout(r, backoffMs))
+        backoffMs = Math.min(backoffMs * 2, 15_000)
+      }
+    }
+  })().catch((err) => logger.error('[opencode-events] loop crashed', err))
+
+  return {
+    stop() {
+      stopping = true
+      abortController?.abort()
+    },
+  }
+}
+
+function dispatch(event: { type?: string; properties?: unknown }, handlers: OpencodeEventHandlers): void {
+  if (event.type === 'question.asked' && handlers.onQuestionAsked) {
+    const req = event.properties as QuestionRequest
+    if (req?.id && req?.sessionID && Array.isArray(req.questions)) {
+      handlers.onQuestionAsked(req)
+    }
+  }
+}

--- a/apps/kortix-sandbox-agent-server/src/proxy.ts
+++ b/apps/kortix-sandbox-agent-server/src/proxy.ts
@@ -7,6 +7,7 @@ import { isRepoMaterialized } from './git'
 import { createHealthRouter, type SandboxBootState } from './routes/health'
 import { createRefreshRouter } from './routes/refresh'
 import { createPromptRouter } from './routes/prompt'
+import { createAbortRouter } from './routes/abort'
 import { createPortProxyRouter } from './routes/port-proxy'
 import webProxyRouter from './routes/web-proxy'
 import {
@@ -40,12 +41,15 @@ export function buildOpencodeApp(
   const healthRouter = createHealthRouter(cfg, opencode, bootTime, bootState)
   const refreshRouter = createRefreshRouter(cfg, opencode)
   const promptRouter = createPromptRouter(cfg)
+  const abortRouter = createAbortRouter(cfg)
   kortixRouter.route('/health', healthRouter)
   kortixRouter.route('/health/', healthRouter)
   kortixRouter.route('/refresh', refreshRouter)
   kortixRouter.route('/refresh/', refreshRouter)
   kortixRouter.route('/prompt', promptRouter)
   kortixRouter.route('/prompt/', promptRouter)
+  kortixRouter.route('/abort', abortRouter)
+  kortixRouter.route('/abort/', abortRouter)
 
   app.route('/kortix', kortixRouter)
 

--- a/apps/kortix-sandbox-agent-server/src/routes/abort.ts
+++ b/apps/kortix-sandbox-agent-server/src/routes/abort.ts
@@ -1,0 +1,41 @@
+import { Hono } from 'hono'
+import { logger } from '../logger'
+import { readPinnedOpencodeSessionId } from '../main'
+import type { Config } from '../config'
+
+// POST /kortix/abort — interrupt the in-flight opencode turn for the pinned
+// session. apps/api calls this when the user clicks "Stop" on the Slack
+// stream. opencode's /session/{id}/abort cancels the running model call and
+// any in-flight tools; the next prompt to the same session resumes cleanly.
+export function createAbortRouter(cfg: Config): Hono {
+  const app = new Hono()
+
+  app.post('/', async (c) => {
+    const sessionId = readPinnedOpencodeSessionId()
+    if (!sessionId) {
+      return c.json({ ok: false, error: 'No opencode session pinned.' }, 409)
+    }
+
+    const workspace = process.env.KORTIX_WORKSPACE || '/workspace'
+    const url = `http://127.0.0.1:${cfg.opencodeInternalPort}/session/${sessionId}/abort?directory=${encodeURIComponent(workspace)}`
+    try {
+      const res = await fetch(url, {
+        method: 'POST',
+        signal: AbortSignal.timeout(10_000),
+      })
+      if (!res.ok) {
+        const body = (await res.text()).slice(0, 300)
+        logger.warn('[abort] opencode abort failed', { sessionId, status: res.status, body })
+        return c.json({ ok: false, error: `opencode abort failed: ${res.status}`, detail: body }, 502)
+      }
+      logger.info('[abort] opencode turn aborted', { sessionId })
+      return c.json({ ok: true, opencode_session_id: sessionId })
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      logger.warn('[abort] opencode abort threw', { sessionId, error: message })
+      return c.json({ ok: false, error: message }, 502)
+    }
+  })
+
+  return app
+}

--- a/apps/kortix-sandbox-agent-server/src/routes/prompt.ts
+++ b/apps/kortix-sandbox-agent-server/src/routes/prompt.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono'
 import { logger } from '../logger'
-import { readPinnedOpencodeSessionId } from '../main'
+import { readPinnedOpencodeSessionId, resolveOpencodeModel } from '../main'
 import type { Config } from '../config'
 
 /**
@@ -42,10 +42,14 @@ export function createPromptRouter(cfg: Config): Hono {
       workspace,
     )}`
 
+    const model = resolveOpencodeModel()
     const res = await fetch(url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ parts: [{ type: 'text', text }] }),
+      body: JSON.stringify({
+        parts: [{ type: 'text', text }],
+        ...(model ? { model } : {}),
+      }),
       signal: AbortSignal.timeout(15_000),
     })
     if (!res.ok) {

--- a/apps/sandbox/agent-cli/channels/slack.ts
+++ b/apps/sandbox/agent-cli/channels/slack.ts
@@ -15,7 +15,18 @@ import {
 
 // Relay a checkpoint or the final answer into this turn's live Slack stream.
 // apps/api owns the streamed message; here we just hand it the content.
-async function relayTurnStream(kind: 'step' | 'answer', text: string): Promise<boolean> {
+//   detail → subtitle line under the new task's title (in_progress state).
+//   output → result line on the *previous* task as it transitions to complete.
+async function relayTurnStream(
+  kind: 'step' | 'answer',
+  text: string,
+  extras: {
+    detail?: string;
+    output?: string;
+    sources?: Array<{ url: string; text: string }>;
+    blocks?: unknown[];
+  } = {},
+): Promise<boolean> {
   const projectId = kortixProjectId();
   const sessionId = kortixSessionId();
   if (!projectId || !sessionId) return false;
@@ -24,11 +35,32 @@ async function relayTurnStream(kind: 'step' | 'answer', text: string): Promise<b
       session_id: sessionId,
       kind,
       text,
+      ...(extras.detail ? { detail: extras.detail } : {}),
+      ...(extras.output ? { output: extras.output } : {}),
+      ...(extras.sources && extras.sources.length > 0 ? { sources: extras.sources } : {}),
+      ...(extras.blocks && extras.blocks.length > 0 ? { blocks: extras.blocks } : {}),
     });
     return r?.ok === true;
   } catch {
     return false;
   }
+}
+
+// Parse a repeatable `--source` flag value like `https://example.com|Title`
+// into the structured shape the relay expects. Returns [] when missing.
+function readSourcesFlag(flags: Record<string, string>): Array<{ url: string; text: string }> {
+  const raw = flags.source ?? flags.sources;
+  if (!raw) return [];
+  return raw
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const i = line.indexOf('|');
+      if (i <= 0) return { url: line, text: line };
+      return { url: line.slice(0, i).trim(), text: line.slice(i + 1).trim() };
+    })
+    .filter((s) => /^https?:\/\//.test(s.url));
 }
 
 function slackApiBase(): string {
@@ -311,22 +343,36 @@ async function main(): Promise<void> {
     case 'step': {
       const text = (readTextFlag(flags) ?? args[0] ?? '').trim();
       if (!text) throw new CliError('checkpoint text required, e.g. slack step "Reading the logs"');
-      const relayed = await relayTurnStream('step', text);
+      // --detail: subtitle line shown under the NEW task while in_progress.
+      //          Supports inline `<https://… |label>` mrkdwn links.
+      // --output: result line attached to the PREVIOUS task as it completes.
+      //          Also supports `<url|label>` mrkdwn.
+      // --source URL|TITLE (repeatable, newline-separated): citations
+      //          rendered under the closing task's card.
+      const detail = flags.detail?.trim() || undefined;
+      const output = flags.output?.trim() || undefined;
+      const sources = readSourcesFlag(flags);
+      const relayed = await relayTurnStream('step', text, { detail, output, sources });
       out({ ok: true, relayed });
       break;
     }
     case 'send': {
       const text = readTextFlag(flags) ?? args[0];
       const blocks = readBlocksFlag(flags);
-      // No --channel + plain text → this is the turn answer: finalize the live
-      // streamed message rather than posting a separate one.
-      if (!flags.channel && !flags.file && !blocks) {
-        if (!text) {
+      // No --channel + no --file → this is the turn answer. Finalizes the
+      // live streamed message rather than posting a separate one. --blocks
+      // is allowed here: Slack accepts a closing `blocks` chunk on stopStream
+      // so the answer can be full Block Kit (header/section/actions/etc.).
+      if (!flags.channel && !flags.file) {
+        if (!text && (!blocks || blocks.length === 0)) {
           throw new CliError('message text required, e.g. slack send "Done — here is the summary"');
         }
-        const relayed = await relayTurnStream('answer', text);
+        const fallbackText = (text ?? 'Done.').slice(0, 11000);
+        const relayed = await relayTurnStream('answer', fallbackText, {
+          blocks: blocks && blocks.length > 0 ? blocks : undefined,
+        });
         if (relayed) {
-          out({ ok: true, delivered: 'stream' });
+          out({ ok: true, delivered: 'stream', mode: blocks ? 'blocks' : 'text' });
           break;
         }
         throw new CliError('No active Slack turn to answer. To post to a channel, pass --channel.');
@@ -408,6 +454,16 @@ async function main(): Promise<void> {
     case 'manifest':
       out(manifest({ url: flags.url, projectId: flags['project-id'], name: flags.name }));
       break;
+    case 'ask':
+      // `slack ask` was replaced by opencode's native `question` tool. Calling
+      // opencode's `question` from any agent turn triggered from Slack
+      // surfaces the form in the same thread automatically via the
+      // sandbox-side event subscriber. The CLI keeps this case so older
+      // workflows fail loud instead of pretending to work.
+      throw new CliError(
+        '`slack ask` was removed — use opencode\'s built-in `question` tool. ' +
+        'The Slack form is rendered automatically by the sandbox\'s opencode-events subscriber.',
+      );
     case 'help':
     default:
       console.log(`

--- a/apps/sandbox/agent-cli/channels/slack.ts
+++ b/apps/sandbox/agent-cli/channels/slack.ts
@@ -9,7 +9,27 @@ import {
   validateRequired,
   getEnv,
   kortixProjectId,
+  kortixSessionId,
+  kortixPost,
 } from '../lib';
+
+// Relay a checkpoint or the final answer into this turn's live Slack stream.
+// apps/api owns the streamed message; here we just hand it the content.
+async function relayTurnStream(kind: 'step' | 'answer', text: string): Promise<boolean> {
+  const projectId = kortixProjectId();
+  const sessionId = kortixSessionId();
+  if (!projectId || !sessionId) return false;
+  try {
+    const r = await kortixPost<{ ok?: boolean }>(`/projects/${projectId}/turn-stream`, {
+      session_id: sessionId,
+      kind,
+      text,
+    });
+    return r?.ok === true;
+  } catch {
+    return false;
+  }
+}
 
 function slackApiBase(): string {
   return (getEnv('SLACK_API_URL') ?? 'https://slack.com/api').replace(/\/$/, '');
@@ -286,12 +306,32 @@ function readBlocksFlag(flags: Record<string, string>): unknown[] | undefined {
 }
 
 async function main(): Promise<void> {
-  const { command, flags } = parseArgs(process.argv);
+  const { command, args, flags } = parseArgs(process.argv);
   switch (command) {
+    case 'step': {
+      const text = (readTextFlag(flags) ?? args[0] ?? '').trim();
+      if (!text) throw new CliError('checkpoint text required, e.g. slack step "Reading the logs"');
+      const relayed = await relayTurnStream('step', text);
+      out({ ok: true, relayed });
+      break;
+    }
     case 'send': {
-      validateRequired(flags, 'channel');
-      const text = readTextFlag(flags);
+      const text = readTextFlag(flags) ?? args[0];
       const blocks = readBlocksFlag(flags);
+      // No --channel + plain text → this is the turn answer: finalize the live
+      // streamed message rather than posting a separate one.
+      if (!flags.channel && !flags.file && !blocks) {
+        if (!text) {
+          throw new CliError('message text required, e.g. slack send "Done — here is the summary"');
+        }
+        const relayed = await relayTurnStream('answer', text);
+        if (relayed) {
+          out({ ok: true, delivered: 'stream' });
+          break;
+        }
+        throw new CliError('No active Slack turn to answer. To post to a channel, pass --channel.');
+      }
+      validateRequired(flags, 'channel');
       if (!text && !flags.file && !blocks) {
         throw new CliError('--text, --text-file, --blocks, --blocks-file, and/or --file required');
       }
@@ -374,6 +414,10 @@ async function main(): Promise<void> {
 slack — Slack Web API adapter
 
 Auth: SLACK_BOT_TOKEN env (injected from project_secrets at sandbox spawn).
+
+Turn commands (use these when answering a Slack message):
+  step         "<checkpoint>"            # narrate a live plan step as you work
+  send         "<answer>"                # deliver your reply — finalizes the live update
 
 Commands:
   send         (--channel, [--text|--text-file], [--blocks|--blocks-file], [--thread], [--file])

--- a/docs/specs/channels.md
+++ b/docs/specs/channels.md
@@ -1,0 +1,571 @@
+# Channels — Slack/Telegram integration design
+
+Status: **draft for review**
+Scope: how inbound chat events route to Kortix sessions, how conversation
+history is preserved, how multiple projects share a workspace, and how the
+in-sandbox CLIs are constrained per project.
+
+---
+
+## 1. Goals / non-goals
+
+**Goals**
+- A chat message (Slack `@mention`, thread reply, DM) reliably reaches the
+  *correct* Kortix session so conversation history is continuous.
+- One Slack workspace can serve multiple Kortix projects.
+- Per-project control over what the agent's in-sandbox CLI may do.
+- The model generalizes to Telegram and to future in-sandbox CLIs.
+
+**Non-goals (this round)**
+- Slack interactivity (buttons / modals firing `block_actions`) beyond the
+  one disambiguation prompt described in §6.
+- Slash-command routing.
+- Cross-Kortix-account workspace sharing (one workspace = one Kortix account).
+
+---
+
+## 2. Entities
+
+| Entity | Key | Notes |
+|---|---|---|
+| Slack workspace | `team_id` | One bot install per workspace (OAuth) |
+| Slack channel | `channel_id` | public / private / im / mpim |
+| Slack thread | `thread_ts` | Parent message ts; replies carry it |
+| Slack message | `ts` | Unique within channel |
+| Kortix project | `project_id` | Owns sessions; has its own sandbox image |
+| Kortix session | `session_id` | Runs in one sandbox; holds opencode convo |
+
+Current tables (post-merge):
+- `chat_channel_bindings` — `(platform, workspace_id)` UNIQUE → `project_id`
+- `chat_threads` — `(platform, workspace_id, thread_id)` UNIQUE → `session_id`
+
+The `chat_channel_bindings` unique key is the multi-project blocker (§6).
+
+---
+
+## 3. Slack event taxonomy
+
+Events the manifest subscribes to, and how we treat each:
+
+| Event | Fires when | Trigger an agent turn? |
+|---|---|---|
+| `app_mention` | Bot is @mentioned | **Yes** |
+| `message.im` | DM to the bot | **Yes** |
+| `message.channels/groups/mpim` | Any message in a channel the bot is in | **Only** if `thread_ts` belongs to a bot-owned thread |
+| `message` subtype `message_changed` | A message was edited | No (ignore) |
+| `message` subtype `message_deleted` | A message was deleted | No |
+| `message` subtype `bot_message` / has `bot_id` | A bot posted (incl. us) | No — **echo guard** |
+| `reaction_added` / `reaction_removed` | Emoji on a message | No (v1) — see §11.5 |
+| `member_joined_channel` | Someone joined | No |
+| `file_shared` | A file was shared | No (file arrives attached to a `message`) |
+| `url_verification` | Slack endpoint handshake | Reply `challenge` synchronously |
+| `app_uninstalled` / `tokens_revoked` | App removed from workspace | Clean up — see §7.L |
+
+**Rule:** an agent turn is triggered only by `app_mention`, a DM, or a
+non-subtype message inside a thread we already own. Everything else is
+recorded or ignored. This keeps the bot from reacting to every line of
+channel chatter.
+
+---
+
+## 4. The routing problem
+
+Inbound event = `(team_id, channel_id, thread_ts?, ts, user, type, text)`.
+We must resolve **(project_id, session_id)** before doing anything.
+
+Two sub-problems, independent:
+1. **project resolution** — which Kortix project owns this conversation
+2. **session resolution** — new session, or deliver to an existing one
+
+---
+
+## 5. Resolution algorithm
+
+```
+resolve(event):
+  threadKey = event.thread_ts ?? event.ts          # parent ts of the thread
+  ackReaction(event)                               # 👀 within ~1s — §8.2
+
+  # ── session resolution: thread already owns a session ───────────────
+  row = chat_threads[(platform, team_id, threadKey)]
+  if row:
+      if sessionAlive(row.session_id):
+          deliver_followup(row.session_id, event)   # continuity
+          return
+      else:
+          # sandbox stopped/archived/evicted — resume policy, §7.K
+          mark row stale; fall through to spawn
+
+  # ── project resolution ──────────────────────────────────────────────
+  project = resolveProject(event)                   # §6
+  if project == AMBIGUOUS:
+      postProjectPicker(event)                       # §6, one-time
+      return
+  if project == NONE:
+      return                                         # workspace not connected
+
+  # ── spawn ───────────────────────────────────────────────────────────
+  session = createProjectSession(project, initialPrompt(event))
+  chat_threads.insert((platform, team_id, threadKey) → session.id)
+  return
+```
+
+Key invariant: **`chat_threads` is keyed by the thread's parent ts**, so the
+first message and every later reply in that thread compute the same
+`threadKey` and resolve to the same session. This is the "associate in our
+db" requirement.
+
+---
+
+## 6. Multi-project per workspace
+
+### The problem
+`chat_channel_bindings` today is `(platform, workspace_id)` UNIQUE — one
+workspace → one project. A second project's OAuth install **overwrites** the
+row and silently orphans the first.
+
+### The model
+- **OAuth install is workspace-wide** and happens once. It does not by
+  itself bind any project to any conversation.
+- **`chat_installs`** (new) records `(workspace_id, project_id)` — every
+  project that connected this workspace. Answers "how many projects could
+  this event belong to."
+- **`chat_channel_bindings`** is re-keyed to `(platform, workspace_id,
+  channel_id)` → `project_id` and is populated **lazily** — by first use,
+  not by an upfront picker.
+
+### `resolveProject(event)`
+```
+binding = chat_channel_bindings[(platform, team_id, channel_id)]
+if binding and binding.project_id:  return binding.project_id
+if binding and not binding.project_id: return PENDING   # picker already up
+
+installs = chat_installs[workspace_id]
+if installs.length == 0: return NONE          # workspace not connected
+if installs.length == 1:
+    # unambiguous — bind the channel lazily, no user friction
+    chat_channel_bindings.insert((..., channel_id) → installs[0])
+    return installs[0]
+# 2+ projects, fresh channel → genuinely ambiguous
+return AMBIGUOUS
+```
+
+### The AMBIGUOUS case — **decided: Block Kit picker**
+The bot posts a Block Kit message in-thread: *"Which project should
+#channel-name use?"* with one button per installed project. The button
+click (`block_actions`) writes the `chat_channel_bindings` row and then
+re-dispatches the original event. Asked **once per channel**, ever.
+
+This is the one place we use Slack interactivity. It requires an
+`interactivity request_url` in the manifest (`/v1/webhooks/slack/interactivity`)
++ a `block_actions` handler in apps/api. Each button `value` carries the
+chosen `project_id` plus a `picker_id`; the triggering event itself is
+parked server-side (in memory) under that `picker_id`, so on click the
+handler binds the channel and resumes the parked event on the chosen
+project. The picker message is edited to a confirmation once a choice is
+made.
+
+**Picker-pending state.** When the picker is posted, a `chat_channel_bindings`
+row is written immediately with `project_id = NULL` + the picker message
+`ts`. `resolveProject` returns `PENDING` for that channel, so concurrent
+@mentions are absorbed silently — no duplicate pickers (edge V). The
+`block_actions` handler fills in `project_id`, flipping `PENDING` → bound.
+
+### Token storage — **decided: project_secrets + fan-out**
+The bot token stays in `project_secrets` (where it already lives) — sandbox
+env injection already works, no new code. Slack issues one token per (app,
+workspace) and a re-auth rotates it, so on every OAuth install the callback
+**fans the fresh token out** to every project on that workspace, keeping all
+copies current. `chat_installs` is the membership index that makes the
+fan-out target list computable.
+
+The Slack **signing secret** is a separate matter: the master one (OAuth
+mode) stays in `apps/api` config and is never persisted per-project; a BYO
+per-project signing secret may sit in `project_secrets` but is **stripped
+from the sandbox env** at injection — the agent never needs it, only the
+webhook verifier does.
+
+(Rejected: a dedicated workspace-scoped `chat_workspaces` token table — one
+fewer copy, but a 2nd new table + a new encryption scope + explicit
+injection code, for a token that essentially never rotates.)
+
+---
+
+## 7. Edge cases
+
+| # | Case | Resolution |
+|---|---|---|
+| A | Single project on workspace | `resolveProject` auto-binds; zero friction |
+| B | 2+ projects, fresh channel | AMBIGUOUS → one-time Block Kit picker (§6) |
+| C | Thread reply, session alive | `chat_threads` hit → deliver follow-up to same sandbox |
+| D | DM to the bot | No channel→project mapping possible. Resolve by: 1 install → use it; N installs → picker in the DM. Bind `(workspace, dm_channel_id)` like any channel. |
+| E | Non-mention message in a bot channel | Ignored unless `thread_ts` matches a `chat_threads` row we own |
+| F | Bot's own message echoes back | `event.bot_id` set OR `event.user == our bot_user_id` → drop immediately |
+| G | Slack retry (no 200 within 3s) | Webhook returns 200 **immediately**, processes async. Dedup on `event_id` (Slack sends a stable `event_id`) — keep a short-TTL seen-set. |
+| H | Two events, same new thread, ~same ms | Race on session create. `chat_threads` UNIQUE`(platform,workspace,thread)` — loser of the insert race re-reads the row and delivers a follow-up instead. |
+| I | Event ordering not guaranteed | Reply may arrive before parent's session is `running`. `deliver_followup` treats "sandbox provisioning" as **transient** — retry/skip, never spawn a duplicate (already implemented). |
+| J | Session sandbox stopped/archived | `chat_threads` row points at a dead session. **Decided: spawn clean** — mark the old row stale, create a fresh session with an empty opencode convo, update the `chat_threads` row to the new session. The agent restarts cold for that thread (the inbound message text is its only context). No transcript replay. |
+| K | Workspace uninstalled (`app_uninstalled`) | Delete `chat_installs` + `chat_channel_bindings` + workspace token. Leave `chat_threads` (FK-cascades when sessions are cleaned). |
+| L | Bot removed from a channel | `member_left_channel` for our bot → mark that channel's binding inactive; next mention re-binds. |
+| M | Slack rate limits (429) | `slack` CLI honors `Retry-After`; webhook side is read-only so unaffected. |
+| N | Agent runs a disabled CLI command | CLI checks the allow-list env var, returns `{ok:false, error}` exit 1 (§9). |
+| O | Prompt injection via a Slack message | Out of full scope; mitigations: system-prompt guardrail, never echo env, channel = trust boundary. Tracked separately. |
+| P | Same parent ts across two workspaces | `chat_threads` is keyed by `(platform, workspace_id, thread_id)` — workspace-scoped, no collision. |
+| Q | OAuth re-install of an already-connected workspace | Upsert `chat_installs`; refresh token. Existing channel bindings untouched. |
+| R | Project deleted while a thread is bound | FK `ON DELETE CASCADE` from `chat_threads`/`chat_channel_bindings` → rows vanish; next mention in that channel re-resolves. |
+| S | `message_changed` / `message_deleted` | Ignored — we act on original posts only. |
+| T | Thread reply in a channel whose binding points at a now-uninstalled project | Treat as stale; re-run `resolveProject`. |
+| U | Empty / whitespace-only mention (just "@Kortix") | No session spawned. Bot replies with a canned greeting (§8.10). Saves a sandbox + cost. |
+| V | Picker already pending for a channel | `chat_channel_bindings` row exists with `project_id = NULL` → `resolveProject` returns `PENDING` → drop the event, do not post a second picker (§6). |
+| W | Mention carries file attachments | `event.files[]` is surfaced in the initial prompt; the agent may `file-info` / `download` if those commands are allowed. |
+| X | Bot @mentioned in a channel it isn't a member of | We cannot post or react. Slack's own UI nudges the user to invite the bot; no retry on our side. |
+| Y | Picker button clicked after the workspace changed (project uninstalled between post and click) | `block_actions` handler re-validates the project is still in `chat_installs`; if gone, edit the picker to "that project was removed" and re-post a fresh picker. |
+
+---
+
+## 8. User experience
+
+§3–§7 are the mechanics. This section walks every scenario as the *person
+in Slack* actually experiences it — what they see, do, and wait on. UX is a
+first-class goal, not an afterthought.
+
+### 8.1 UX principles
+
+1. **Acknowledge in under a second.** The webhook posts a "working"
+   placeholder *before* any slow work (sandbox spawn). The user always knows
+   they were heard.
+2. **One answer per turn.** The agent posts its result as a single threaded
+   reply — not a stream of partial messages. Only genuinely long tasks add
+   explicit progress lines (8.12). No channel noise.
+3. **Stay in the thread.** Every bot reply is threaded under the message
+   that triggered it. The channel's top level stays clean; each task is its
+   own thread = its own session.
+4. **No upfront configuration.** No "pick your channels" wizard. Invite the
+   bot, @mention it, it works. Binding happens lazily and invisibly whenever
+   it can.
+5. **Be honest about limits.** If context was lost (a revived dead thread)
+   or an action is disabled, the bot says so plainly instead of acting
+   confused.
+
+### 8.2 Acknowledgement & feedback model
+
+The acknowledgement is a **working indicator** — two signals, owned by
+`apps/api` (it holds the workspace token). Slack has no real typing
+indicator for channel bots and message text can't animate, so this is the
+closest honest equivalent:
+
+| Moment | Signal | Owner |
+|---|---|---|
+| Event received, will trigger a turn | ⏳ `hourglass_flowing_sand` reaction on the user's message **+** a threaded *"⏳ Kortix is working on it…"* placeholder | webhook, instant |
+| Agent posts its reply in-thread | reaction removed **+** placeholder deleted | webhook |
+| Disambiguation needed | the picker message instead (8.6) | webhook |
+
+The placeholder is the contract: it lands within ~1 s of the @mention, long
+before the sandbox is ready, and reads as a live "bot is working" cue. It is
+**deleted** when the agent posts its reply — needing no `kortix-agent` ping:
+the webhook already *receives* the bot's own reply as a `message` event, so a
+bot message in a thread with a pending placeholder is the completion signal.
+The webhook remembers the placeholder ts (keyed by thread) so the reply
+event — which only carries `thread_ts` — finds and removes it. The
+placeholder's own post echoes back as a bot message; that is skipped by ts
+match so it doesn't delete itself. Net result: one transient message, gone
+once the answer lands — no clutter.
+
+DMs use the same model. If we later register the bot as a Slack Assistant,
+DMs gain a native "is typing…" status; until then the placeholder applies
+there too.
+
+> Throughout the §8 walkthroughs, "👀" is shorthand for this working
+> placeholder — the mechanism is the placeholder message described here.
+
+### 8.3 Connecting Slack — first project on a workspace
+
+1. In the Kortix dashboard, the user opens a project → **Channels** →
+   **Connect Slack**.
+2. Redirect to Slack's OAuth consent screen ("Kortix is requesting
+   permission to…"). The user picks the workspace and approves.
+3. Redirect back to the dashboard. The Channels dialog shows **Slack ·
+   connected** plus one line: *"Invite @Kortix to any channel and @mention
+   it, or DM it directly."*
+4. Behind the scenes: a `chat_installs(workspace, project)` row; the
+   encrypted workspace bot token stored on it. **No channel is bound yet.**
+
+No channel picker. The user does not choose channels up front.
+
+### 8.4 Connecting a second project to the same workspace
+
+1. From a *different* project's Channels dialog, the user clicks **Connect
+   Slack** and approves the same workspace again.
+2. Dashboard shows **Slack · connected**, with an added note: *"This
+   workspace already serves <project-alpha>. New channels will ask which
+   project to use the first time you @mention the bot there."*
+3. Behind the scenes: a second `chat_installs` row. The workspace now serves
+   2 projects. Existing channel bindings are untouched.
+
+### 8.5 First @mention — single project (the common path)
+
+1. User invites @Kortix to `#support`, then posts *"@Kortix summarise
+   today's incidents."*
+2. Within ~1 s the message gets a 👀 reaction — the user knows it landed.
+3. `resolveProject` finds exactly one project on the workspace → binds
+   `#support → project-alpha` **silently**, no prompt.
+4. A session spins up; the agent works.
+5. The agent posts its answer as a threaded reply under the user's message;
+   the 👀 is removed.
+6. Every later message in that thread continues the same session (8.7).
+
+Zero configuration, zero prompts — the experience signed off on: *"invite
+them into any channel & it just works when you tag him."*
+
+### 8.6 First @mention — multiple projects (the picker)
+
+1. User @mentions the bot in a fresh `#general`; the workspace serves
+   project-alpha **and** project-beta.
+2. 👀 reaction appears instantly.
+3. `resolveProject` returns AMBIGUOUS. The bot posts a **threaded** Block
+   Kit message (channel top level stays clean):
+
+   > **Which project should #general use?**
+   > Asked once — I'll remember it for this channel.
+   > `[ project-alpha ]`  `[ project-beta ]`
+
+4. Anyone in the channel can click. On click:
+   - the binding `#general → chosen project` is written,
+   - the picker message is edited to *"✓ #general is linked to
+     **project-beta**."*,
+   - the **original** @mention is replayed → session spawns → answer posted
+     in that same thread.
+5. The user experiences one extra click, once per channel, ever.
+   Subsequent @mentions go straight to 8.5 step 4.
+
+While a picker is pending, further @mentions in that channel are absorbed
+silently — no duplicate pickers (edge V).
+
+### 8.7 Thread reply — continuity
+
+1. The user (or a teammate) replies inside a thread the bot already answered
+   in.
+2. 👀 on the reply.
+3. `chat_threads[(slack, workspace, thread_ts)]` hits → the message is
+   relayed to the *same running session* via `/kortix/prompt`. No new
+   sandbox.
+4. The agent answers in the same thread with full memory of the
+   conversation.
+
+The thread — not the person — is the unit of conversation: a teammate
+jumping into the thread talks to the same session.
+
+### 8.8 DM to the bot
+
+1. User opens a DM with @Kortix and sends a task.
+2. 👀 on the message.
+3. A DM has no channel→project mapping. Resolution:
+   - workspace serves 1 project → use it,
+   - workspace serves N → the bot posts the same Block Kit picker, in the
+     DM.
+4. The DM is then bound like any channel (`(workspace, dm_channel_id)`); the
+   whole DM behaves as one long-lived thread/session.
+
+### 8.9 Reviving a thread whose session is gone
+
+Sandboxes are ephemeral — a thread the user revisits hours later may have a
+dead session.
+
+1. User replies in an old thread.
+2. 👀 on the reply.
+3. The `chat_threads` row is found but the session is dead → **spawn clean**
+   (§7.J): a fresh session, no transcript.
+4. Because context was lost, the agent's first reply opens with a short,
+   honest note:
+   > *Picking this thread back up — heads up, I don't have the earlier
+   > context from before. Quick recap of what you need?*
+
+   This is injected via the initial prompt, so the agent never pretends to
+   remember.
+5. From there the revived thread behaves normally.
+
+### 8.10 Error & empty paths
+
+| What happened | What the user sees |
+|---|---|
+| Sandbox spawn fails | The 👀 stays (no reply came) and the error is logged server-side. A user-facing error reply is a planned improvement — not yet built. |
+| Agent crashes mid-turn | Same — 👀 stays, error logged. Planned: a short threaded error reply. |
+| Bot @mentioned in a channel it isn't in | Slack itself prompts the user to invite the bot; we can't post until invited (edge X) |
+| Workspace has no linked project (stale install) | Silent drop — a workspace with 0 linked projects has no bot token, so there is nothing to reply with. |
+| Empty mention (just "@Kortix", no task) | Bot replies *"Hi! @mention me with a task and I'll get on it."* — **no session spawned** (edge U) |
+| Agent attempts a disabled CLI command | Internal: the CLI returns an error to the agent; the agent tells the user plainly (*"I'm not allowed to join channels on my own here."*) |
+
+### 8.11 Re-binding a channel to a different project
+
+A channel can end up bound to the wrong project (wrong picker button).
+
+- **v1:** the dashboard's Channels view lists every bound channel (`#general
+  → project-beta`) with a dropdown to reassign. When a binding is created we
+  store the channel name (one `conversations.info` call) so the dashboard
+  shows human names, not IDs.
+- In-Slack re-bind (e.g. `@Kortix switch project`) is **deferred** — it
+  needs reliable intent detection or a slash command, both out of v1 scope.
+
+### 8.12 Latency & expectation-setting
+
+| Phase | Typical | What covers the wait |
+|---|---|---|
+| @mention → 👀 | < 1 s | the reaction itself |
+| 👀 → reply, warm path (reply into a live thread) | a few seconds | 👀 |
+| 👀 → reply, cold path (new session, sandbox boot) | seconds | 👀; if the real answer isn't quick the agent posts one interim line — *"On it — give me a moment."* |
+| Long task (minutes) | — | the agent posts explicit progress updates in-thread |
+
+We deliberately do **not** post a "spinning up" message for every mention —
+the 👀 carries short waits, and placeholder + answer would be two messages.
+Only genuinely slow turns get an interim line, posted by the agent.
+
+### 8.13 Concurrency, as the user feels it
+
+- Two threads in the same channel, both with the bot → two independent
+  sessions, two sandboxes. Each thread is its own conversation; they never
+  cross.
+- Two people @mention the bot in different channels at once → fully
+  independent, no contention.
+- A user fires three messages into one thread rapidly → all three relay to
+  the one session; the agent reads them in order and answers once it has
+  worked through them. No duplicate sandboxes — guaranteed by the
+  `chat_threads` unique key and transient-retry handling (§7.H, §7.I).
+
+### 8.14 Telegram
+
+Telegram maps onto the same model with platform-specific surfaces: no emoji
+reactions, so the ack is a quick *"✓ on it"* message (later edited to the
+answer) instead of a 👀; Telegram's `reply_to_message_id` plays the role of
+`thread_ts`; group chats are channels, private chats are DMs. Routing,
+multi-project resolution, and CLI constraints are identical.
+
+### 8.15 Agent model
+
+Slack-triggered turns pin a specific model — `anthropic/claude-sonnet-4-6`.
+The webhook passes `opencode_model` into `createProjectSession`; it rides as
+the `KORTIX_OPENCODE_MODEL` env var on that session's sandbox, and the
+sandbox agent sets it on every opencode prompt call (initial @mention via
+`maybeDeliverInitialPrompt`, thread replies via `/kortix/prompt`). Scoped to
+the sandbox env, so only Slack sessions are affected — other sessions keep
+opencode's configured default. The session also records `opencode_model` in
+its metadata so a sandbox restart re-applies it.
+
+---
+
+## 9. In-sandbox CLI action constraints
+
+### Motivation
+The agent gets a `slack` CLI on PATH. A project may want to forbid certain
+actions — e.g. `join` so the bot can't self-join channels.
+
+### Config — `[[channels]]` in `kortix.toml` (config only; secrets stay in `project_secrets`)
+```toml
+[[channels]]
+platform = "slack"
+# Allow-list. Omit the key entirely = every command enabled (default-open).
+# Listed = ONLY these commands may run.
+commands = [
+  "send", "edit", "delete", "react", "typing", "history",
+  "thread", "channel-info", "users", "user", "me", "search",
+  "file-info", "download",
+]
+# "join", "channels", "manifest" omitted → blocked
+```
+
+Full command enum (slack): `send, edit, delete, react, typing, history,
+thread, channels, channel-info, join, users, user, me, search, file-info,
+download, manifest`. This list is expected to grow; new commands are
+**enabled by default** (default-open) unless a project ships an allow-list.
+
+### Enforcement path
+1. Session spawn → apps/api reads `[[channels]]` from the project's
+   `kortix.toml` → for each platform computes the allowed set.
+2. Injects `KORTIX_SLACK_COMMANDS=send,edit,react,…` into the sandbox env
+   (omitted entirely when no allow-list → default-open).
+3. The `slack` CLI, in its dispatch switch, calls a shared
+   `guardCommand("slack", command)` from `agent-cli/lib`. It reads
+   `KORTIX_SLACK_COMMANDS`; if set and `command` ∉ set →
+   `{ok:false, error:"command 'join' disabled by project config"}`, exit 1.
+
+### Generalization
+`guardCommand(cliName, command)` reads `KORTIX_<CLINAME>_COMMANDS`. Every
+future in-sandbox CLI (e.g. `executor`) imports it and gets per-project
+gating for free. `[[channels]]` constrains comms CLIs; a parallel
+`[[tools]]` (or similar) section can constrain non-channel CLIs later — the
+enforcement primitive is identical.
+
+### Deferred — inbound event constraints
+Gating **inbound** event types per project (e.g. "this project never spawns
+a session from a DM") via a separate `events` allow-list on `[[channels]]`
+is **deferred** (§11). v1: every event type in §3 always applies; only the
+outbound `commands` allow-list is configurable.
+
+---
+
+## 10. Data-model changes
+
+```
+NEW   chat_installs            (platform, workspace_id, project_id) UNIQUE
+                               + connected_at  — membership only, no secrets
+ALTER chat_channel_bindings    unique key → (platform, workspace_id, channel_id)
+                               project_id   → now NULLABLE (NULL = picker pending)
+                               + channel_name   varchar  (for the dashboard)
+                               + channel_type   varchar  (channel|group|im|mpim)
+                               + picker_ts      varchar  (ts of the pending picker msg)
+KEEP  chat_threads             unchanged — already (platform, workspace_id, thread_id)
+KEEP  project_secrets          still holds the bot token, fanned out to every
+                               project on the workspace; SLACK_SIGNING_SECRET
+                               is stripped from the sandbox env at injection
+```
+
+`chat_installs` is the workspace↔project membership index; `chat_channel_bindings`
+is the per-channel routing row (a NULL `project_id` means a picker is up and
+awaiting a click); `chat_threads` stays the per-thread session map.
+
+---
+
+## 11. Decisions
+
+**Resolved (2026-05-22):**
+1. **Picker** — Block Kit picker with a `block_actions` handler. No text
+   fallback. Manifest gains an `interactivity request_url`. (§6)
+2. **Dead-session policy** — spawn **clean**, no transcript replay. (§7.J)
+3. **Token storage** — bot token stays in `project_secrets`, fanned out to
+   every project on the workspace on each install; `chat_installs` is the
+   membership index. Signing secret never reaches a sandbox. (§6)
+4. **Acknowledgement model** — `apps/api` reacts 👀 to the triggering
+   message within ~1 s and removes it when the agent's reply lands. The
+   webhook detects the reply by observing the bot's own `message` event in
+   that thread — no `kortix-agent` ping needed. No per-mention "spinning up"
+   message. (§8.2)
+
+**Deferred to a later round:**
+4. **Inbound event allow-list** — per-project `events` allow-list on
+   `[[channels]]`. v1: all §3 event types always apply.
+5. **Reaction triggers** — `reaction_added` stays inert in v1; it never
+   triggers an agent turn.
+
+---
+
+## 12. Implementation order
+
+1. ✅ `chat_installs` table + migration; re-key `chat_channel_bindings` to
+   `(platform, workspace_id, channel_id)`, make `project_id` nullable, add
+   `channel_name` / `channel_type` / `picker_ts`.
+2. ✅ OAuth callback writes a `chat_installs` membership row (not an
+   overwrite) and fans the bot token + workspace metadata out to every
+   project on the workspace.
+3. ✅ Strip `SLACK_SIGNING_SECRET` from the sandbox env at injection.
+4. Webhook: full resolution algorithm (§5) + project resolution (§6) +
+   dead-session spawn-clean (§7.J) + instant 👀 ack (§8.2).
+4. ✅ Webhook: resolution algorithm (§5) + project resolution (§6) +
+   dead-session spawn-clean (§7.J) + instant 👀 ack, lifted on reply (§8.2).
+5. ✅ All event types handled per §3 + echo guard + `event_id` dedupe +
+   empty-mention canned reply (§8.10). (Not-connected reply is a no-op — a
+   workspace with 0 linked projects has no bot token to reply with.)
+6. ✅ Block Kit project picker + `block_actions` handler + picker-pending row +
+   `channel_name` capture; manifest gains `interactivity request_url`.
+7. `[[channels]]` parser (config-only) + `KORTIX_SLACK_COMMANDS` injection.
+8. `guardCommand` in `agent-cli/lib`; wire into `slack` CLI dispatch.
+9. Dashboard Channels view: list bound channels + reassign dropdown (§8.11).
+10. Strip leftover diagnostic `console.log` lines (done in Phase 2 rewrite).

--- a/docs/specs/slack-streaming.md
+++ b/docs/specs/slack-streaming.md
@@ -1,0 +1,186 @@
+# Slack streaming — live plan checkpoints
+
+Status: **draft for review**
+Scope: replace the static "⏳ working" placeholder with a **live plan block** —
+the agent narrates a handful of human checkpoints (*"Reading the incident
+logs… → Drafting the summary…"*) while it works, then the answer lands in the
+same message. Channel @mention surface only; builds on the routing in
+[`channels.md`](./channels.md).
+
+---
+
+## 1. Goal
+
+Today a turn is a black box: @mention → ⏳ → silence → a wall of markdown. The
+fix is a **plan block** that fills in as the agent works — not a raw tool log
+(noise), not a bare spinner (no information), but a few meaningful,
+agent-narrated checkpoints. The answer arrives at the end, in the same message.
+
+**Explicitly out of scope:** token-by-token streaming of the answer text. The
+checkpoints + a clean final answer already deliver the "colleague keeping you
+posted" feel; live-token response streaming is a later enhancement.
+
+---
+
+## 2. Slack primitives
+
+`chat.startStream` / `chat.appendStream` / `chat.stopStream` — they work in
+**channel threads** (`recipient_user_id` + `recipient_team_id` are *required
+when streaming to channels*).
+
+- **`chat.startStream`** — `{ channel, thread_ts, recipient_user_id,
+  recipient_team_id, task_display_mode: 'plan', chunks? }` → returns a message
+  `ts`.
+- **`chat.appendStream`** — `{ channel, ts, chunks }`.
+- **`chat.stopStream`** — `{ channel, ts, chunks?, markdown_text?, blocks? }` —
+  finalizes the message.
+
+Chunks we use:
+- `task_update` — `{ type:'task_update', id, title, status }` — one checkpoint.
+  `status ∈ pending|in_progress|complete|error`.
+- `markdown_text` — the final answer body, sent on `stopStream`.
+
+`task_display_mode: 'plan'` renders the `task_update`s as the collapsible plan
+block. Net result: **one streamed message** — a live plan that fills in, then
+the answer as the body.
+
+---
+
+## 3. Architecture — split ownership
+
+A turn has two phases: **pre-sandbox** (@mention → session → sandbox → opencode
+ready) and **agent** (opencode runs). Ownership:
+
+| Concern | Owner |
+|---|---|
+| Stream object — `startStream`, the `ts` | **apps/api** |
+| Pre-sandbox checkpoint(s) — *"Spinning up a sandbox"* | **apps/api** |
+| Agent-phase checkpoints — what the agent narrates | **agent**, via the agent-cli |
+| The final answer | **agent**, via the agent-cli — *the agent decides what to send* |
+| `stopStream` (finalize) | agent-cli on a normal finish; **apps/api** watchdog otherwise |
+
+**apps/api** receives the @mention, `startStream`s, posts the pre-sandbox
+checkpoint, and hands the stream handle (`ts` + channel + recipient) to the
+sandbox. **The agent**, through the agent-cli, appends its own checkpoints and
+the final answer to that same stream.
+
+No token-streaming, no SSE subscription — checkpoints are discrete
+`task_update` calls the agent makes deliberately. This needs an agent-cli
+change (a `step` command + a stream-aware `send`) → **one sandbox rebuild**.
+
+---
+
+## 4. The turn, end to end
+
+### 4.1 Cold turn (new @mention)
+
+```
+@mention
+  → chat.startStream(channel, thread_ts, recipient=mentioner, mode='plan',
+        chunks=[ task_update id=boot "Spinning up a sandbox" in_progress ])
+  → keep the stream ts; inject it (+ channel) into the sandbox env
+  → createProjectSession(...) as today
+  → opencode ready → apps/api appends task_update id=boot status=complete
+  → the agent works; each milestone it runs:
+        slack step "Reading the incident logs"
+          → completes the previous checkpoint, appends this one in_progress
+  → the agent finishes:
+        slack send "<final answer>"
+          → chat.stopStream: last checkpoint → complete,
+             markdown_text = the answer
+```
+
+### 4.2 Warm turn (thread reply, sandbox already up)
+
+`apps/api` `startStream`s, relays the message + the new stream handle via
+`/kortix/prompt`; no pre-sandbox checkpoint. The agent narrates + answers the
+same way.
+
+### 4.3 What the user sees
+
+```
+@user: @Kortix summarise today's incidents
+  └ Kortix  ▸ Working…                       ← streamed message, instant
+      ✓ Spinning up a sandbox
+      ✓ Reading the incident logs
+      ⟳ Drafting the summary
+  └ (finalized: plan collapses, the summary is the message body)
+```
+
+One message. The plan is collapsible; the answer is the body.
+
+---
+
+## 5. The agent-cli surface
+
+The agent drives its half of the stream with two commands. Both no-op
+gracefully when there is no active stream (e.g. a non-Slack session):
+
+- **`slack step "<text>"`** — completes the current checkpoint and appends a
+  new one as `in_progress`. The agent calls this a handful of times per turn.
+- **`slack send "<text>"`** — becomes stream-aware: with an active turn stream
+  it `stopStream`s (last checkpoint → `complete`, text → the answer body)
+  rather than posting a new message. Without one, it posts as it does today.
+
+**Relay, not direct.** The agent-cli does not call Slack itself for the
+stream — it relays to apps/api: `POST /v1/projects/:projectId/turn-stream`
+`{ session_id, kind:'step'|'answer', text }`, authed by the session CLI token
+(already in the sandbox env). apps/api keys its `activeStreams` map by
+`session_id`, so the agent-cli only needs `KORTIX_SESSION_ID` — no stream
+handle, no env injection, no handle file, and warm follow-ups just work (apps/api
+updates the map per turn). apps/api stays the sole owner of the Slack stream.
+
+If `chat.startStream` is unavailable, apps/api falls back to a plain
+placeholder message; `slack step` no-ops and `slack send` edits the
+placeholder into the answer — so a streaming-API problem never breaks replies.
+
+The agent is **prompted** to narrate: a few checkpoints, human phrasing, then
+one `slack send` with the answer. Over/under-narration is a prompt-tuning
+concern, not a correctness one.
+
+---
+
+## 6. What changes
+
+- **The placeholder is replaced.** `startWorkingIndicator` /
+  `clearWorkingIndicator` (the ⏳ message) → the streamed message. The ⏳
+  **reaction** on the user's message stays — apps/api adds it on `startStream`,
+  removes it on finalize.
+- **`renderAgentPrompt` changes.** It instructs the agent to narrate progress
+  with `slack step` and deliver the final answer with `slack send` — and that
+  `send` now finalizes the streamed message.
+- **agent-cli change** → one sandbox rebuild (+ snapshot bust). The only
+  rebuild this feature needs.
+
+---
+
+## 7. Edge cases
+
+| # | Case | Handling |
+|---|---|---|
+| A | Sandbox spawn fails | apps/api `stopStream`s — boot checkpoint → `error`, body *"I couldn't start up — try again in a moment."* |
+| B | Agent finishes without calling `slack send` | apps/api watchdog: opencode turn ended + stream still open → `stopStream` with whatever checkpoints exist + a short note |
+| C | opencode crashes mid-turn | Same watchdog → `stopStream` *"the run stopped unexpectedly."* **Fixes the stuck-"Working…" bug** |
+| D | Slack stream rate limit (Tier 2) | a turn fires only a few `step` relays — naturally paced, well under the limit; no coalescing needed |
+| E | Agent over-narrates (20 checkpoints) | tolerable — the plan block collapses; tighten via the prompt |
+| F | Agent never narrates a single step | plan shows just the boot checkpoint, then the answer — still fine, no worse than today |
+| G | Long answer (>12 000 chars) | split into multiple `markdown_text` chunks on `stopStream` |
+| H | Concurrent turns | one stream per turn, keyed by Kortix session id in `activeStreams` |
+| I | `slack send` called twice | first finalizes the stream; a second relay finds no active stream → the agent-cli errors or posts normally if `--channel` given |
+
+---
+
+## 8. Implementation order — **done**
+
+1. ✅ `chat.startStream` / `appendStream` / `stopStream` helpers in `slack-api.ts`.
+2. ✅ apps/api: `startTurnStream` on a triggering event — `startStream` with the
+   boot checkpoint + ⏳ reaction; `activeStreams` keyed by session id; replaced
+   `startWorkingIndicator`.
+3. ✅ Watchdog finalize for the failure cases (§7 A/B/C); plain-message fallback
+   when `chat.startStream` is unavailable.
+4. ✅ Relay endpoint `POST /v1/projects/:projectId/turn-stream`; agent-cli
+   `slack step` + stream-aware `slack send` relay through it by session id.
+5. ✅ `renderAgentPrompt` / `renderFollowUpPrompt` — narrate-with-`step`,
+   answer-with-`send`.
+6. ✅ Warm-turn path: `startTurnStream` bound to the existing session id.
+7. Rebuild the agent-cli into the snapshot; bust the cache.

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -40,6 +40,7 @@ export {
   projectTriggerEvents,
   projectTriggerRuntime,
   chatChannelBindings,
+  chatInstalls,
   chatThreads,
   projectSessions,
   projectRuntimeSnapshots,

--- a/packages/db/src/schema/kortix.ts
+++ b/packages/db/src/schema/kortix.ts
@@ -508,23 +508,55 @@ export const projectTriggerEvents = kortixSchema.table(
   ],
 );
 
-// Tiny lookup table — only used in OAuth (multi-tenant Kortix Slack app) mode
-// so the shared /v1/webhooks/slack endpoint can translate Slack's team_id into
-// the Kortix project that owns the workspace. BYO mode routes by URL
-// (/v1/webhooks/slack/:projectId) and skips this table entirely.
+// Workspace ↔ project membership: every project that connected a given Slack
+// workspace. Drives project resolution — a channel with no binding auto-binds
+// when the workspace has exactly one project, else a picker is shown.
+export const chatInstalls = kortixSchema.table(
+  'chat_installs',
+  {
+    installId: uuid('install_id').defaultRandom().primaryKey(),
+    platform: varchar('platform', { length: 32 }).notNull(),
+    workspaceId: varchar('workspace_id', { length: 128 }).notNull(),
+    projectId: uuid('project_id')
+      .notNull()
+      .references(() => projects.projectId, { onDelete: 'cascade' }),
+    connectedAt: timestamp('connected_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => [
+    uniqueIndex('idx_chat_installs_workspace_project').on(
+      table.platform,
+      table.workspaceId,
+      table.projectId,
+    ),
+    index('idx_chat_installs_workspace').on(table.platform, table.workspaceId),
+    index('idx_chat_installs_project').on(table.projectId),
+  ],
+);
+
+// Per-channel routing: which project owns a specific channel. Bound lazily on
+// first use. A NULL projectId means a project picker is posted in that channel
+// and awaiting a click.
 export const chatChannelBindings = kortixSchema.table(
   'chat_channel_bindings',
   {
     bindingId: uuid('binding_id').defaultRandom().primaryKey(),
-    projectId: uuid('project_id')
-      .notNull()
-      .references(() => projects.projectId, { onDelete: 'cascade' }),
+    projectId: uuid('project_id').references(() => projects.projectId, {
+      onDelete: 'cascade',
+    }),
     platform: varchar('platform', { length: 32 }).notNull(),
     workspaceId: varchar('workspace_id', { length: 128 }).notNull(),
+    channelId: varchar('channel_id', { length: 128 }).notNull(),
+    channelName: varchar('channel_name', { length: 256 }),
+    channelType: varchar('channel_type', { length: 32 }),
+    pickerTs: varchar('picker_ts', { length: 64 }),
     installedAt: timestamp('installed_at', { withTimezone: true }).defaultNow().notNull(),
   },
   (table) => [
-    uniqueIndex('idx_chat_channel_bindings_workspace').on(table.platform, table.workspaceId),
+    uniqueIndex('idx_chat_channel_bindings_channel').on(
+      table.platform,
+      table.workspaceId,
+      table.channelId,
+    ),
     index('idx_chat_channel_bindings_project').on(table.projectId),
   ],
 );

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -1,4 +1,4 @@
-import { sandboxes, deployments, kortixApiKeys, serverEntries, accounts, accountMembers, accountInvitations, accountGithubInstallations, auditEvents, usageEvents, projects, projectGitConnections, projectGitCredentials, projectMembers, projectSecrets, projectTriggers, projectTriggerEvents, projectSessions, projectRuntimeSnapshots, sessionSandboxes, legacySandboxMigrations, creditAccounts, tunnelConnections, tunnelPermissions, tunnelPermissionRequests, tunnelAuditLogs, chatChannelBindings, chatThreads } from './schema/kortix';
+import { sandboxes, deployments, kortixApiKeys, serverEntries, accounts, accountMembers, accountInvitations, accountGithubInstallations, auditEvents, usageEvents, projects, projectGitConnections, projectGitCredentials, projectMembers, projectSecrets, projectTriggers, projectTriggerEvents, projectSessions, projectRuntimeSnapshots, sessionSandboxes, legacySandboxMigrations, creditAccounts, tunnelConnections, tunnelPermissions, tunnelPermissionRequests, tunnelAuditLogs, chatChannelBindings, chatInstalls, chatThreads } from './schema/kortix';
 import { apiKeys, accountUser } from './schema/public';
 
 // Select types (what you get back from queries)
@@ -53,6 +53,8 @@ export type ServerEntry = typeof serverEntries.$inferSelect;
 export type NewServerEntry = typeof serverEntries.$inferInsert;
 export type ChatChannelBinding = typeof chatChannelBindings.$inferSelect;
 export type NewChatChannelBinding = typeof chatChannelBindings.$inferInsert;
+export type ChatInstall = typeof chatInstalls.$inferSelect;
+export type NewChatInstall = typeof chatInstalls.$inferInsert;
 export type ChatThread = typeof chatThreads.$inferSelect;
 export type NewChatThread = typeof chatThreads.$inferInsert;
 

--- a/packages/starter/templates/base/.kortix/opencode/skills/slack/SKILL.md
+++ b/packages/starter/templates/base/.kortix/opencode/skills/slack/SKILL.md
@@ -1,0 +1,414 @@
+---
+name: slack
+description: How to answer in Slack as a teammate. Covers the live plan-block stream (`slack step` with --detail/--output, `slack send` to finalize the answer), file uploads, posting to other channels/threads, reactions, search, message editing/deletion, and the tone the bot should use. Load this when the turn is triggered from Slack (the prompt mentions a Slack workspace/channel/thread, or when `$SLACK_BOT_TOKEN` is set in the env), or when the user asks how to do anything in Slack.
+---
+
+<skill name="slack">
+
+<overview>
+Your sandbox is wired into Slack. When a teammate `@`-mentions the bot or replies in a thread the bot owns, the platform spins up this session and hands you the message; your turn IS the Slack reply.
+
+The `slack` CLI is on `$PATH` and authenticated with `$SLACK_BOT_TOKEN`. Two patterns matter most:
+
+- **`slack step "..."`** — narrate progress. Updates the live plan block in the Slack thread *as you go*.
+- **`slack send "..."`** — finalize the turn with your answer. This closes the plan block and posts the reply.
+
+Everything else (`slack history`, `slack react`, `slack send --file`, `slack search`, …) is for when the task explicitly asks for it.
+</overview>
+
+<live-stream>
+The Slack message you're replying to has a live "plan block" attached. Each `slack step` you emit appears as a new checkpoint in that block in real time. Users can see what you're doing without waiting for the final answer.
+
+### `slack step "<title>"` — emit a checkpoint
+
+Call this **before each major step** of your work. Keep titles short, human, and present-tense. A few per task — not one per shell command.
+
+```sh
+slack step "Reading the incident logs"
+slack step "Cross-referencing with the deploy timeline"
+slack step "Drafting the post-mortem"
+```
+
+### `--detail "<subtitle>"` — short context line under the title
+
+Use `--detail` to add a one-line subtitle that explains *what specifically* you're doing in this step. Shown while the step is in_progress.
+
+```sh
+slack step "Reading the incident logs" --detail "Last 24h, severity >= warn"
+```
+
+### `--output "<result>"` — concrete result attached to the PREVIOUS step
+
+When you start a new step and the previous one produced a concrete result, surface it with `--output`. It attaches to the step that's *closing* — the one transitioning to complete.
+
+```sh
+slack step "Cross-referencing with the deploy timeline" \
+  --output "Found 47 ERROR lines clustered around 14:32 UTC"
+
+slack step "Drafting the post-mortem" \
+  --output "3 candidate deploys in the window; api@a3f1 looks suspicious"
+```
+
+### Inline links inside `--detail` / `--output`
+
+Use Slack mrkdwn link syntax `<https://… |label>` (NOT Markdown `[label](url)`). Slack server-parses these into proper rich-text link elements rendered inside the task card:
+
+```sh
+slack step "Reading the incident logs" \
+  --detail "Pulling from <https://datadog.example.com/dash/api-errors|Datadog API errors>"
+
+slack step "Cross-referencing the timeline" \
+  --output "Tied to <https://github.com/acme/api/commit/a3f1|api@a3f1> — auth middleware"
+```
+
+### `--source URL|TITLE` — citation footer (repeatable)
+
+Attach structured citations to the *closing* task. Slack renders them as a sources strip under that task's card. Pass multiple `--source` lines separated by newlines (use shell heredoc or repeat the flag in a wrapper).
+
+```sh
+slack step "Drafting the post-mortem" \
+  --output "3 candidate deploys" \
+  --source $'https://github.com/acme/api/commit/a3f1|api@a3f1
+https://datadog.example.com/dash/api-errors|Datadog dashboard'
+```
+
+Up to 8 sources per task, titles auto-trim at 80 chars.
+
+So the natural pattern, end-to-end, looks like:
+
+```sh
+slack step "Reading the incident logs" --detail "Last 24h, severity >= warn"
+# ... do the work ...
+slack step "Cross-referencing the deploy timeline" \
+  --output "47 ERROR lines around 14:32 UTC" \
+  --detail "Walking back from the first error"
+# ... do the work ...
+slack step "Drafting the post-mortem" \
+  --output "Pinned to api@a3f1 — auth middleware change" \
+  --detail "Writing root cause + remediation"
+# ... do the work ...
+slack send "It was api@a3f1 — the new auth middleware drops the trace header on retries. Reverting now."
+```
+
+### Rules
+
+- **Use `slack step` to mark phase transitions, not every shell call.** ~3–6 per turn is right for most tasks; one per `bash` is noise.
+- **Set `--detail` and `--output` once per step.** Re-sending them for the same step appends rather than replaces — surprising and ugly.
+- **Keep them short.** `--detail` and `--output` get truncated at 500 chars upstream; aim for one tight sentence.
+- **Don't `slack step` after you've called `slack send`.** The plan is closed. Further steps drop silently.
+</live-stream>
+
+<final-answer>
+### `slack send "<text>"` — plain-text answer
+
+For a one-liner, post directly:
+
+```sh
+slack send "Reverted api@a3f1. Errors are back to baseline — auth header is now preserved on retry."
+```
+
+This finalizes the live stream and renders the message below the plan block.
+
+### `slack send --blocks-file <path>` — Block Kit answer (preferred for structure)
+
+When the response has real structure — sections, headers, lists, links, citations — ship it as Block Kit. Slack accepts a closing `blocks` chunk on `chat.stopStream`, so the rich layout renders inline below the plan block. Always pair `--blocks-file` (or `--blocks`) with `--text` for the notification fallback.
+
+Write the JSON to a temp file, then send:
+
+```sh
+cat > /tmp/answer.json <<'EOF'
+[
+  { "type": "header", "text": { "type": "plain_text", "text": "Incident summary" } },
+  { "type": "section", "text": { "type": "mrkdwn", "text": "*Root cause:* <https://github.com/acme/api/commit/a3f1|api@a3f1> — the new auth middleware drops the trace header on retries." } },
+  { "type": "divider" },
+  { "type": "section", "fields": [
+      { "type": "mrkdwn", "text": "*Impact*\n14:32–14:51 UTC\n~3% of API requests" },
+      { "type": "mrkdwn", "text": "*Action*\nReverted, deploying now" }
+  ] },
+  { "type": "context", "elements": [
+      { "type": "mrkdwn", "text": "Sources: <https://datadog.example.com/dash/api-errors|Datadog>  ·  <https://github.com/acme/api/pull/8421|Revert PR>" }
+  ] }
+]
+EOF
+
+slack send --text "Reverted api@a3f1 — root cause was the auth middleware" --blocks-file /tmp/answer.json
+```
+
+Use Block Kit when ANY of these apply:
+- The answer has 2+ distinct sections (root cause + impact + action, or summary + details + sources).
+- You're presenting comparisons, tables, or lists of items.
+- The answer should cite multiple sources prominently.
+- The response benefits from a clear title (use a `header` block).
+
+Use plain `slack send "..."` when the answer is short prose with no structure.
+
+### Block Kit cheat sheet
+
+Common block types the agent uses most:
+
+| Block | Use for |
+| --- | --- |
+| `header` (plain_text) | Title of the answer |
+| `section` (mrkdwn) | Most prose, including `<url|label>` links |
+| `section` with `fields` | 2-column key/value layout (max 10 fields) |
+| `divider` | Visual break between sections |
+| `context` (mrkdwn) | Small footer text, sources, timestamps |
+| `image` (image_url + alt_text) | Charts, screenshots — needs a public URL |
+| `actions` (buttons / select menu) | Inline interactivity for follow-ups |
+| `carousel` (of `card` elements) | Side-scrollable gallery — see below |
+
+### Carousel of cards — for presenting a list of choices/items
+
+When the answer is a *list of things the user might pick between or browse* (deploy candidates, repo search hits, scheduled meetings, design variants), a carousel of cards reads way better than a markdown list. Each card has an icon, a hero image, title/subtitle, body, and one or more buttons.
+
+**Important constraints (Slack rules, not ours):**
+- Cards live ONLY inside a `carousel` block.
+- Cards support `body` (mrkdwn) and `actions` (buttons / select menus) — they do **NOT** support `input` / `radio_buttons` / `checkboxes`. If you need form inputs, use the `question` tool instead.
+- Each card's button click fires a `block_actions` interaction; the platform routes it back as a follow-up Slack message (`Picked: <button label>`) into the same thread, the agent's next turn starts from that.
+- 2–10 cards per carousel.
+
+Example — presenting 3 deploy candidates:
+
+```jsonc
+[
+  { "type": "section", "text": { "type": "mrkdwn", "text": "*Three deploy candidates* — pick one to ship:" } },
+  {
+    "type": "carousel",
+    "elements": [
+      {
+        "type": "card",
+        "block_id": "deploy_a3f1",
+        "icon": { "type": "image", "image_url": "https://github.com/acme.png?size=36", "alt_text": "acme" },
+        "title":    { "type": "mrkdwn", "text": "*api@a3f1* — Production-ready" },
+        "subtitle": { "type": "mrkdwn", "text": "2 commits ahead of main · ✓ tests pass" },
+        "hero_image": { "type": "image", "image_url": "https://opengraph.githubassets.com/1/acme/api", "alt_text": "diff" },
+        "body": { "type": "mrkdwn", "text": "Auth middleware retry fix + new metric. Safe to ship — small surface area, full coverage." },
+        "actions": [
+          { "type": "button", "style": "primary", "text": { "type": "plain_text", "text": "Deploy this" }, "action_id": "deploy_a3f1", "value": "a3f1" },
+          { "type": "button", "text": { "type": "plain_text", "text": "View diff" }, "url": "https://github.com/acme/api/compare/main...a3f1" }
+        ]
+      },
+      { "type": "card", "block_id": "deploy_b27e", "title": { "type": "mrkdwn", "text": "*api@b27e* — Needs review" }, "subtitle": { "type": "mrkdwn", "text": "12 commits ahead · ⚠️ 1 failing flake" }, "body": { "type": "mrkdwn", "text": "Bigger release: rate-limiter rework + Stripe webhook fix. Flake is in webhook tests." }, "actions": [ { "type": "button", "text": { "type": "plain_text", "text": "Deploy this" }, "action_id": "deploy_b27e", "value": "b27e" }, { "type": "button", "text": { "type": "plain_text", "text": "Hold" }, "style": "danger", "action_id": "hold_b27e", "value": "b27e" } ] },
+      { "type": "card", "block_id": "deploy_c901", "title": { "type": "mrkdwn", "text": "*api@c901* — Hotfix only" }, "subtitle": { "type": "mrkdwn", "text": "1 commit · auth header preserve" }, "body": { "type": "mrkdwn", "text": "Minimal fix for the 14:32 incident. Lowest risk." }, "actions": [ { "type": "button", "style": "primary", "text": { "type": "plain_text", "text": "Deploy this" }, "action_id": "deploy_c901", "value": "c901" } ] }
+    ]
+  }
+]
+```
+
+Ship it the same way as any Block Kit answer:
+
+```sh
+slack send --text "Pick a deploy candidate" --blocks-file /tmp/candidates.json
+```
+
+**When to reach for carousel:**
+- 2–6 items the user is choosing between, each with non-trivial context (subtitle, body, hero image).
+- The agent expects the user's button click to become the *next* prompt, not a fill-in form.
+
+**When NOT to:**
+- For mid-turn structured input (use `question` instead — carousel can't host inputs).
+- For 1 item (just a section) or 7+ items (split, paginate, or summarize).
+- For a quick yes/no (use `question` with single-select).
+
+Full Block Kit reference: <https://docs.slack.dev/reference/block-kit/blocks/>
+
+### Tone (applies to either mode)
+
+Reply like a colleague messaging on Slack:
+
+- **No preamble.** Don't open with "Sure!" / "I've taken a look and…". Get to the answer.
+- **Slack mrkdwn.** `*bold*` (single asterisks), `_italic_`, `` `code` ``, ` ```code blocks``` `. Markdown-style `**bold**` renders as literal asterisks — don't use it.
+- **Short.** A few sentences > a wall of text. Use bullet lists for ≥3 items.
+- **Link with `<url|text>`.** Slack's syntax, not Markdown `[label](url)`.
+- **No XML / no "Here's a summary:" headers.** This is a chat message, not a report.
+
+### One `slack send` per turn
+
+Each turn finalizes exactly one stream. Don't call `slack send` twice — the second call drops silently because the stream is already closed. If you need to deliver multiple things, fold them into one Block Kit message or use `slack send --channel ...` for sibling posts.
+</final-answer>
+
+<asking-the-user>
+### Use opencode's built-in `question` tool — Slack renders the form
+
+**Rule: if your reply contains a question, call the `question` tool. Never put questions inside `slack send`.**
+
+`slack send` finalizes the turn and closes the live stream — once it fires, the user can only reply with a free-text message. If you posted multi-choice questions via `slack send`, the answers come back as unstructured prose and you have to re-parse them. Don't.
+
+opencode ships a native `question` tool. Call it the same way you would in any other host (dashboard, TUI). When the turn is Slack-triggered, the sandbox automatically catches the `question.asked` event and renders a Block Kit form (radio buttons / checkboxes / a free-text box) in the same thread. The user submits → opencode resumes your tool call with their answers. Zero Slack-specific glue from your side.
+
+| When you want to… | Use |
+| --- | --- |
+| Ask a question or set of questions | `question` tool |
+| Deliver the final answer / summary | `slack send` |
+| Show progress along the way | `slack step` |
+| Post a separate message to another channel | `slack send --channel ...` |
+
+### Calling the `question` tool
+
+Per opencode's schema (`Array<QuestionInfo>`):
+
+```jsonc
+{
+  "questions": [
+    {
+      "question": "Which environment should I deploy to?",
+      "header": "Environment",          // short label (max 30 chars)
+      "options": [
+        { "value": "prod",    "label": "Production" },
+        { "value": "staging", "label": "Staging" },
+        { "value": "dev",     "label": "Dev (sandbox)" }
+      ],
+      "multiple": false,                 // false = radio, true = checkboxes
+      "custom":   true                   // true = also show a free-text box
+    }
+  ]
+}
+```
+
+Multiple questions in one call:
+
+```jsonc
+{
+  "questions": [
+    {
+      "question": "Priority for next sprint",
+      "header":   "Priority",
+      "options": [
+        { "value": "auth",    "label": "Finish the auth migration" },
+        { "value": "billing", "label": "Ship metered billing v2" },
+        { "value": "ingest",  "label": "Rebuild the ingest pipeline" }
+      ],
+      "multiple": false
+    },
+    {
+      "question": "What risks should I flag?",
+      "header":   "Risks",
+      "options": [
+        { "value": "rollback", "label": "Rollback complexity" },
+        { "value": "perf",     "label": "Performance regressions" },
+        { "value": "data",     "label": "Data migrations" }
+      ],
+      "multiple": true
+    },
+    {
+      "question": "Any constraints I should know about?",
+      "header":   "Constraints",
+      "options":  [],
+      "custom":   true
+    }
+  ]
+}
+```
+
+### Reading the answer
+
+The `question` tool's return value is `answers: string[][]` — one array per question, in the same order you sent them. Each inner array contains every value the user picked, plus any free-text they typed into the custom field (concatenated at the end).
+
+```jsonc
+// for the 3-question example above
+[
+  ["auth"],                              // single-select
+  ["rollback", "data"],                  // multi-select
+  ["Vendor X freeze ends Tuesday."]      // custom text only
+]
+```
+
+### Rules
+
+- **Use the `question` tool, not chat prose.** A free-text reply loses structure.
+- **Keep it focused.** 1–3 questions per call. If you need more, split into multiple `question` calls across the turn (each is its own pause).
+- **Form expires after 15 minutes.** If the user doesn't click Submit, the form resolves with empty arrays — opencode treats that as a reject; the tool returns and you can adapt.
+- **The Stop button still works.** A user who clicks 🛑 Stop aborts the turn; the form is closed and the tool returns empty.
+- **Skip trivial yes/no when context implies the answer.** Use judgment — the form is for *real* decisions, not "are you sure?" rituals.
+</asking-the-user>
+
+<files-and-artifacts>
+### Uploading files: `slack send --file <path> --channel <id>`
+
+When the work produces an artifact (a CSV, a report, a diff, a screenshot), upload it instead of pasting the contents. `--file` requires a `--channel` and (typically) a `--thread` so it lands under the answer:
+
+```sh
+slack send \
+  --channel "$SLACK_CHANNEL_ID" \
+  --thread  "$SLACK_THREAD_TS" \
+  --file    /workspace/output/report.md \
+  --text    "Full report ↓"
+```
+
+`$SLACK_CHANNEL_ID` and `$SLACK_THREAD_TS` are pre-set on Slack-triggered turns. Use them.
+
+**Note:** `slack send --file ...` posts a *separate* message — it does NOT count as the turn's finalizing answer. Combine it with a regular `slack send "..."` to also close the stream:
+
+```sh
+slack send --channel "$SLACK_CHANNEL_ID" --thread "$SLACK_THREAD_TS" \
+  --file /workspace/output/report.md --text "Full report attached."
+slack send "Pulled 12,847 sign-ups, grouped by source. CSV above."
+```
+</files-and-artifacts>
+
+<other-surfaces>
+Reach for these only when the task explicitly asks for them.
+
+### Read prior thread context
+
+```sh
+slack history --channel "$SLACK_CHANNEL_ID" --thread "$SLACK_THREAD_TS"
+slack thread   --channel "$SLACK_CHANNEL_ID" --ts     "$SLACK_THREAD_TS"
+```
+
+### React to a message
+
+```sh
+slack react --channel "$SLACK_CHANNEL_ID" --ts "$SLACK_TRIGGER_TS" --emoji "white_check_mark"
+```
+
+### Post to a different channel (announcements, cross-posts)
+
+```sh
+slack send --channel "C0123ABCD" --text "Heads up: rolled api@a3f1 forward."
+```
+
+### Edit / delete a message you posted earlier
+
+```sh
+slack edit   --channel "$SLACK_CHANNEL_ID" --ts "<msg_ts>" --text "Updated answer."
+slack delete --channel "$SLACK_CHANNEL_ID" --ts "<msg_ts>"
+```
+
+### Search the workspace
+
+```sh
+slack search --query "deploy api@"
+```
+
+### Look up users / channels
+
+```sh
+slack users
+slack user        --user "U0123ABCD"
+slack channels
+slack channel-info --channel "C0123ABCD"
+slack me
+```
+
+### Download a file shared in the thread
+
+```sh
+slack file-info --file "F0123ABCD"
+slack download  --url "<file.url_private>" --out /workspace/incoming/x.png
+```
+
+Full help: `slack help`.
+</other-surfaces>
+
+<gotchas>
+- **`*bold*` not `**bold**`.** Slack uses single asterisks. Double-asterisk markdown renders as literal asterisks.
+- **`--detail` and `--output` are append-not-replace per step.** Set each only once on the step that owns it. If you need to revise, advance to a new step.
+- **`slack step` after `slack send` drops silently.** Plan block is closed once the answer ships. Always send the answer last.
+- **`slack send --file` does NOT finalize the stream.** It posts a separate file message. Follow it with a regular `slack send "..."` to close the turn.
+- **`$SLACK_CHANNEL_ID`, `$SLACK_THREAD_TS`, `$SLACK_TRIGGER_TS` are pre-injected on Slack turns.** Use them — don't hard-code IDs.
+- **Stay in the thread.** Unless the task explicitly says "post in #channel-X", everything goes in the originating thread. Cross-posting to other channels needs a real reason (incident broadcast, scheduled digest).
+- **The user can hit Stop.** A red Stop button sits under the plan block; the user can click it any time. If you see the turn end abruptly, that's why — don't retry automatically.
+</gotchas>
+
+</skill>

--- a/supabase/migrations/00000000000059_chat_installs.sql
+++ b/supabase/migrations/00000000000059_chat_installs.sql
@@ -1,0 +1,66 @@
+-- ╔══════════════════════════════════════════════════════════════════════════╗
+-- ║  chat_installs  +  chat_channel_bindings restructure                       ║
+-- ║                                                                            ║
+-- ║  Multi-project per workspace. One Slack workspace can serve N Kortix       ║
+-- ║  projects, so routing splits into two questions:                           ║
+-- ║                                                                            ║
+-- ║    chat_installs          which projects connected this workspace          ║
+-- ║                           (workspace ↔ project membership)                ║
+-- ║    chat_channel_bindings  which project owns a specific channel            ║
+-- ║                           (per-channel routing, bound lazily on first use) ║
+-- ║                                                                            ║
+-- ║  The bot token still lives in kortix.project_secrets (fanned out to every  ║
+-- ║  project on the workspace by the OAuth callback). This table holds no      ║
+-- ║  secrets.                                                                  ║
+-- ╚══════════════════════════════════════════════════════════════════════════╝
+
+-- ── chat_installs ────────────────────────────────────────────────────────────
+-- One row per (workspace, project) the workspace was connected to. Answers
+-- "how many projects could an event in this workspace belong to" — the input
+-- to the auto-bind-if-single / show-a-picker-if-many decision.
+CREATE TABLE IF NOT EXISTS kortix.chat_installs (
+  install_id    uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  platform      varchar(32) NOT NULL,
+  workspace_id  varchar(128) NOT NULL,
+  project_id    uuid NOT NULL REFERENCES kortix.projects(project_id) ON DELETE CASCADE,
+  connected_at  timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_chat_installs_workspace_project
+  ON kortix.chat_installs (platform, workspace_id, project_id);
+
+CREATE INDEX IF NOT EXISTS idx_chat_installs_workspace
+  ON kortix.chat_installs (platform, workspace_id);
+
+CREATE INDEX IF NOT EXISTS idx_chat_installs_project
+  ON kortix.chat_installs (project_id);
+
+-- Existing chat_channel_bindings rows were keyed (platform, workspace_id) by the
+-- old single-project OAuth callback — they are workspace↔project memberships,
+-- not channel bindings. Migrate them into chat_installs.
+INSERT INTO kortix.chat_installs (platform, workspace_id, project_id, connected_at)
+  SELECT platform, workspace_id, project_id, installed_at
+  FROM kortix.chat_channel_bindings
+ON CONFLICT DO NOTHING;
+
+-- ── chat_channel_bindings → per-channel routing ──────────────────────────────
+-- Now keyed by (platform, workspace_id, channel_id). project_id becomes
+-- nullable: a NULL row means a project picker has been posted in that channel
+-- and is awaiting a click.
+DROP INDEX IF EXISTS kortix.idx_chat_channel_bindings_workspace;
+
+-- Old rows are migrated into chat_installs above; clear them so the table can
+-- be repurposed cleanly (it now means per-channel, not per-workspace).
+DELETE FROM kortix.chat_channel_bindings;
+
+ALTER TABLE kortix.chat_channel_bindings
+  ADD COLUMN IF NOT EXISTS channel_id   varchar(128),
+  ADD COLUMN IF NOT EXISTS channel_name varchar(256),
+  ADD COLUMN IF NOT EXISTS channel_type varchar(32),
+  ADD COLUMN IF NOT EXISTS picker_ts    varchar(64);
+
+ALTER TABLE kortix.chat_channel_bindings ALTER COLUMN project_id DROP NOT NULL;
+ALTER TABLE kortix.chat_channel_bindings ALTER COLUMN channel_id SET NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_chat_channel_bindings_channel
+  ON kortix.chat_channel_bindings (platform, workspace_id, channel_id);


### PR DESCRIPTION
Multi-project routing
- chat_installs binds workspace ↔ project; chat_channel_bindings pins a channel to a project; chat_threads keeps a Slack thread sticky to one session.
- New workspaces with ≥2 projects get a Block Kit picker on first mention in an unbound channel; single-project workspaces lazy-bind.

One-click "Add to Slack"
- GET /v1/projects/:id/channels/slack/mode returns a signed OAuth install URL.
- Dashboard renders the primary button when SLACK_CLIENT_ID/SECRET/SIGNING_SECRET are set; falls back to BYO otherwise.

Live plan-block streaming
- chat.startStream / appendStream / stopStream wired via /v1/projects/:id/turn-stream.
- Agent narrates with `slack step "..."` and `slack send "..."`; checkpoints render as a real Slack plan block in the thread.
- Auto-joins the channel first (chat.startStream rejects non-member bots with channel_type_not_supported).
- Race-fix: stream opens BEFORE delivering the prompt so early `slack step` calls find the active handle.

Stop button
- Every streamed turn posts a sibling "🛑 Stop" Block Kit button.
- Click → POST /kortix/abort on the sandbox → opencode /session/{id}/abort.
- Stream finalizes with "_Stopped._"; controls update to "Stopped by you" so the recap is visible.

/kortix slash commands
- help, projects, switch, unbind, sessions, whoami.
- Multi-project responses render as a Block Kit carousel of cards with GitHub OG thumbnails; single-project as a section with image accessory + actions row.
- switch_project block actions rebind atomically and confirm in-place via response_url.

App Home tab
- Published on app_home_opened: hero banner, feature pills, per-project cards with covers and Open/View-on-GitHub buttons, example prompts, recent activity with thumbnails, dashboard / docs / settings footer.

Channel-join welcome card
- On member_joined_channel for the bot itself: posts a hero-image Block Kit card with the welcome blurb, feature pills, example prompts, and primary Open-dashboard button. Intercepted at the OAuth root webhook so the multi-project picker can't drop it.

Native opencode HITL (replaces the earlier `slack ask` CLI)
- kortix-agent (sandbox) subscribes to opencode's SSE /event stream.
- question.asked → POST /v1/projects/:id/turn-question → apps/api posts a Block Kit form (radio / checkboxes with descriptions + optional plain-text + Submit) → user submits → answers POST'd back to opencode /question/{id}/reply.
- Stream rotates around the form: the in-progress stream parks, then a fresh stream opens below after Submit so the agent's continuation lands chronologically after the user's pick.

Block Kit answers + carousel display
- `slack send --blocks-file` finalizes the stream with a Block Kit body (header / section / divider / carousel of cards / context / images / actions).
- Agent-emitted button clicks (action_ids outside the reserved set) route back as synthesized follow-up prompts via handleAgentClick so click-to-act flows close the loop without extra glue.

Rich plan-block features
- task_update chunks carry `details` (subtitle), `output` (post-completion result line), and `sources` (citation footer).
- Plain strings auto-wrap into rich_text server-side; `<url|label>` mrkdwn renders as real links inside task cards.
- Fix: append-not-replace bug where re-sending `details` on the closing chunk doubled the text.

Default Slack skill
- packages/starter/templates/base/.kortix/opencode/skills/slack/SKILL.md ships in every `kortix init` scaffold.
- Documents step/send/question patterns, mrkdwn link syntax, Block Kit cheat sheet, carousel example, tone rules, file-upload pattern.

Auth middleware
- Sandbox tokens accepted on /git/clone-credential, /turn-stream, /turn-question (whitelist enforced; per-route handlers verify the sandbox's accountId+sandboxId actually scope to the URL's projectId).

DB
- New migration 00000000000059_chat_installs.sql adds chat_installs, restructures chat_channel_bindings, adds chat_threads.

Env
- SLACK_CLIENT_ID / SLACK_CLIENT_SECRET / SLACK_SIGNING_SECRET / SLACK_REDIRECT_URI / SLACK_OAUTH_SCOPES (now includes `commands`) / SLACK_HOME_HERO_URL (optional banner).

Sandbox-agent
- New routes: /kortix/abort, /kortix/prompt (follow-up delivery).
- New module: src/opencode-events.ts (SSE subscriber + relayQuestionToApi).
- Slack-turn env vars injected into the sandbox (SLACK_TEAM_ID, SLACK_CHANNEL_ID, SLACK_THREAD_TS, SLACK_TRIGGER_TS, SLACK_USER_ID) so the agent CLI can talk back to the originating thread without parsing the prompt.


# ─── PR description (markdown — no forced wrapping; GitHub reflows) ─────────

## Summary

Ships the full Slack integration v2 — multi-project routing, live plan-block streaming, Stop-button interrupt, `/kortix` slash commands, App Home tab, channel-join welcome card, and native HITL via opencode's `question` tool surfaced as a Block Kit form in the same Slack thread.

## What's new

### Routing & install

- One-click "Add to Slack" OAuth (`GET /v1/projects/:id/channels/slack/mode` returns a signed install URL).
- Multi-project picker via Block Kit; sticky channel ↔ project binding; threads sticky to sessions.
- `/kortix switch` and `/kortix unbind` rebind a channel mid-life without re-installing the app.

### Agent surface in Slack

- Live plan-block stream per turn (`chat.startStream` + `appendStream` + `stopStream`); checkpoints carry rich `details`, `output`, and `sources` with inline `<url|label>` links.
- Block Kit answers via `slack send --blocks-file` (header / section / divider / carousel / actions). Agent-emitted button clicks loop back as synthesized follow-up prompts.
- File I/O via `slack send --file --channel "$SLACK_CHANNEL_ID" --thread "$SLACK_THREAD_TS"`.

### HITL

- Native opencode `question` tool routed to Slack as a Block Kit form (radio / checkboxes with descriptions + optional free-text + Submit).
- Stream rotates around the form so the agent's continuation lands below the user's pick instead of editing the message above.

### Visible controls

- 🛑 Stop button per turn → aborts opencode mid-stream and closes the plan block cleanly.
- `/kortix` slash commands (help / projects / switch / unbind / sessions / whoami) with polished Block Kit responses.
- App Home tab with project covers, example prompts, and recent activity.
- Channel-join welcome card with hero, feature pills, and dashboard CTAs.

### Default skill

`packages/starter/templates/base/.kortix/opencode/skills/slack/SKILL.md` ships with every new project, teaching the agent the full step/send/question patterns, Slack tone, link syntax, and Block Kit usage.

## Files of note

- `apps/api/src/channels/slack-webhook.ts` — webhook router, stream/ask handlers, slash-command dispatch, agent-click handler, App Home view, welcome card.
- `apps/api/src/channels/slack-api.ts` — chat.* wrappers (postMessage, postBlocks, startStream, appendStream, stopStream, joinChannel, publishHomeView, etc.).
- `apps/api/src/channels/slack-oauth.ts` / `slack-oauth-mode.ts` — one-click OAuth flow with signed state.
- `apps/api/src/channels/install-store.ts` — encrypted per-project secrets store for bot tokens and signing secrets.
- `apps/api/src/channels/slack-app-manifest.json` — updated manifest with `app_home`, slash commands, `link_shared` event, `commands` scope.
- `apps/api/src/projects/index.ts` — `/turn-stream`, `/turn-question`, `/channels/slack/mode`, `/channels/slack/connect`, `/channels/slack/installation` routes; `extraEnvVars` plumbed through `createProjectSession`.
- `apps/api/src/middleware/auth.ts` — sandbox-token path whitelist for `/turn-stream` and `/turn-question`.
- `apps/kortix-sandbox-agent-server/src/opencode-events.ts` *(new)* — SSE subscriber + question relay.
- `apps/kortix-sandbox-agent-server/src/routes/abort.ts` *(new)* — `POST /kortix/abort`.
- `apps/kortix-sandbox-agent-server/src/main.ts` — wires the events loop and relays `question.asked` → apps/api → opencode `/question/{id}/reply`.
- `apps/sandbox/agent-cli/channels/slack.ts` — `slack step` (with `--detail`, `--output`, `--source`), `slack send` (with `--blocks-file`), file uploads, history/react/edit/delete/etc.
- `packages/starter/templates/base/.kortix/opencode/skills/slack/SKILL.md` *(new)* — agent-facing skill.
- `supabase/migrations/00000000000059_chat_installs.sql` *(new)* — DB schema.
- `docs/specs/channels.md`, `docs/specs/slack-streaming.md` *(new)* — design notes.

## Env vars

Required for OAuth mode (one-click install):

```
SLACK_CLIENT_ID=...
SLACK_CLIENT_SECRET=...
SLACK_SIGNING_SECRET=...
SLACK_REDIRECT_URI=https://api.kortix.com/v1/webhooks/slack/oauth/callback
SLACK_OAUTH_SCOPES=app_mentions:read,channels:history,channels:read,channels:join,chat:write,chat:write.public,files:read,files:write,groups:history,groups:read,im:history,im:read,im:write,mpim:history,mpim:read,reactions:read,reactions:write,users:read,team:read,links:read,links:write,commands
```

Optional:

```
SLACK_HOME_HERO_URL=https://...   # banner at the top of the App Home tab
```

## Test plan

- [ ] Fresh OAuth install from the dashboard's Channels → "Add to Slack" button; verify `chat_installs` row created.
- [ ] Multi-project workspace: `@`-mention bot in an unbound channel → picker renders; pick a project → channel rebinds; next mention skips picker.
- [ ] `@`-mention triggers a turn; the plan block streams checkpoints live; final `slack send "..."` finalizes the stream cleanly.
- [ ] `slack step "..." --detail "with <https://example.com|a link>"` → detail with link renders under the task title.
- [ ] `slack step "next" --output "result" --source "URL|TITLE"` → output line + sources strip on the closing task.
- [ ] 🛑 Stop button during a long turn → opencode aborts; plan block closes with `_Stopped._`; controls update to "Stopped by you".
- [ ] Agent calls opencode's `question` tool with options-with-descriptions and optional free-text → Slack form renders; submit; agent's next reply lands BELOW the form.
- [ ] `slack send --blocks-file /tmp/cards.json` with a carousel; click a card button → agent receives synthesized follow-up.
- [ ] `/kortix help` / `projects` / `switch` / `unbind` / `sessions` / `whoami` all return polished Block Kit responses.
- [ ] Bot self-join (`member_joined_channel` for the bot) → welcome card.
- [ ] App Home tab opens with hero + projects + recent activity.

## Migration / rollout notes

- Apply DB migration `00000000000059_chat_installs.sql` before deploying apps/api (otherwise OAuth callbacks 500 on inserts).
- Update the Slack app manifest at api.slack.com → your app → "App Manifest" → paste the new JSON (adds `/kortix` slash command, `app_home`, `link_shared` event, and the `commands` scope). Reinstalling the app to each workspace is required for the new scope to take effect.
- Sandbox snapshot rebuilds automatically via the artifact-byte fingerprint (`apps/api/src/snapshots/hash.ts currentRuntimeArtifactFingerprint`) — no manual `SANDBOX_VERSION` bump needed.
- Slack streams require the bot to be a real channel member (`chat.startStream` returns `channel_type_not_supported` otherwise); the welcome handler auto-joins via `channels:join` on first invite, but pre-existing channels need to `/invite @Kortix` once if they don't already have the bot.
