### PR TITLE
feat(starter): ship project-brain memory system

### DIFF
--- a/packages/starter/templates/base/.kortix/memory/MEMORY.md
+++ b/packages/starter/templates/base/.kortix/memory/MEMORY.md
@@ -1,0 +1,14 @@
+# Project Memory
+
+The **project brain** for `{{projectName}}`. Auto-injected into every
+agent's system prompt as a `<kortix-memory>` block. Sub-files below are
+NOT auto-loaded — open them with `read` when relevant.
+
+- [overview.md](overview.md) — what this project is, its purpose and shape
+- [integrations.md](integrations.md) — third parties, MCP servers, channels, executor connectors
+- [conventions.md](conventions.md) — patterns, naming, style, do / don't
+- [decisions.md](decisions.md) — architectural and business choices worth not re-debating
+
+Curated by the **memory-reflector** agent
+(`.kortix/opencode/agents/memory-reflector.md`). To add or update
+memory, load the **kortix-memory** skill.

--- a/packages/starter/templates/base/.kortix/memory/conventions.md
+++ b/packages/starter/templates/base/.kortix/memory/conventions.md
@@ -1,0 +1,20 @@
+# Conventions
+
+How this project is built — patterns, naming, style, do / don't. The
+*de facto* rules across the codebase that aren't otherwise written
+down.
+
+> _Empty stub. The memory-reflector agent will fill this in as
+> patterns emerge and decisions are made._
+
+Good entries cover:
+
+- **Naming** — file, folder, identifier, branch, commit conventions.
+- **Code style** — patterns specific to this project (not "use
+  Prettier"; that's tooling).
+- **Branching and review** — how work flows from session branch to
+  `main`, who reviews what.
+- **Testing** — what gets tested, where, with what framework.
+- **Do / don't** — anti-patterns we've explicitly rejected and why.
+
+Cite file paths so the convention is checkable against real code.

--- a/packages/starter/templates/base/.kortix/memory/decisions.md
+++ b/packages/starter/templates/base/.kortix/memory/decisions.md
@@ -1,0 +1,22 @@
+# Decisions
+
+Architectural and business choices worth not re-debating. A short log
+of "we chose X over Y because Z" so future sessions don't relitigate.
+
+> _Empty stub. The memory-reflector agent will fill this in as
+> decisions are made._
+
+Format each entry as:
+
+```
+## YYYY-MM-DD — <one-line decision>
+
+**Context:** What problem we were solving.
+**Choice:** What we picked.
+**Alternatives:** What we rejected and why.
+**Consequences:** What this means going forward.
+```
+
+Keep the log append-only as much as possible. If a decision is later
+reversed, leave the original and add a new dated entry pointing back —
+the history is the point.

--- a/packages/starter/templates/base/.kortix/memory/integrations.md
+++ b/packages/starter/templates/base/.kortix/memory/integrations.md
@@ -1,0 +1,20 @@
+# Integrations
+
+Third parties, MCP servers, channels, executor connectors — anything
+this project talks to that lives outside its own repo.
+
+> _Empty stub. The memory-reflector agent will fill this in as
+> integrations are wired up._
+
+For each integration, note:
+
+- **What it is and why we use it** (one line).
+- **Where it's configured** — `kortix.toml` connector slug, MCP server
+  entry, channel platform, env var names. Cite file paths.
+- **Scope** — which environments it runs in, which agents need it,
+  what it has access to.
+- **Gotchas** — auth quirks, rate limits, regional issues, anything
+  that bit us once.
+
+Do **not** store credentials here. Tokens and keys live in the Kortix
+Secrets Manager.

--- a/packages/starter/templates/base/.kortix/memory/overview.md
+++ b/packages/starter/templates/base/.kortix/memory/overview.md
@@ -1,0 +1,15 @@
+# Overview
+
+What this project is, at a glance.
+
+> _Empty stub. The memory-reflector agent will fill this in as it
+> learns about the project, or any agent can update it directly via a
+> change request._
+
+When this file is filled in, it should answer:
+
+- **What does this project do?** One paragraph, plain language.
+- **Who is it for?** End users, internal teams, both?
+- **What's the high-level shape?** The 3–5 surfaces (web app, API,
+  worker, CLI, …) and how they talk to each other.
+- **What's the current state?** Production, beta, prototype, dormant.

--- a/packages/starter/templates/base/.kortix/opencode/agents/memory-reflector.md
+++ b/packages/starter/templates/base/.kortix/opencode/agents/memory-reflector.md
@@ -1,0 +1,75 @@
+---
+description: Reflects on recent project activity and curates `.kortix/memory/` — the project brain. Runs on a cron (configured by the `memory-reflector` trigger in `kortix.toml`) and ends every run by opening a single change request titled `memory: …`. Edit the **rubric** section of the `kortix-memory` skill to change what gets remembered.
+mode: primary
+permission:
+  edit: allow
+  write: allow
+  bash:
+    "git *": allow
+    "kortix cr *": allow
+    "kortix sessions *": allow
+    "*": ask
+---
+
+You are the **memory-reflector** for this Kortix project. Your job is
+to keep `.kortix/memory/` — the project brain — accurate and useful
+for every other agent.
+
+## How to run
+
+1. **Load the `kortix-memory` skill.** It defines the file layout, the
+   rubric for what to remember, and the change-request flow. Treat it
+   as your source of truth.
+2. **Survey recent activity.** Look at what's changed since your last
+   reflection:
+   - `git log --since="<since>" --pretty=format:"%h %s" origin/main` —
+     recent commits.
+   - `kortix cr ls --state merged --limit 20` — recently merged CRs.
+   - `git log -- .kortix/memory/ -10` — what *you* changed last; don't
+     repeat yourself.
+   - If you were invoked from a specific session, also re-read that
+     session's transcript or the prompt you were given.
+3. **Decide.** Apply the rubric in the `kortix-memory` skill. Keep
+   durable, team-relevant facts. Drop personal preferences, transient
+   state, and anything already obvious from the repo.
+4. **CRUD.** Edit existing files first; create new sub-files only when
+   a topic deserves its own page. Always update `MEMORY.md` to match
+   the folder.
+5. **Land via a change request.** Memory edits must go through CR —
+   same as code:
+
+   ```sh
+   git add .kortix/memory
+   git commit -m "memory: <one-line summary>"
+   git push origin HEAD
+   kortix cr open \
+     --title "memory: <one-line summary>" \
+     --description "What changed and why. Cite git refs / CR numbers."
+   ```
+
+6. **Exit silently if nothing is worth changing.** Do not open empty
+   CRs. Do not open a CR just to bump dates. A clean no-op run is the
+   right outcome most days.
+
+## What you do NOT do
+
+- You do not merge your own CRs. A human reviewer does.
+- You do not edit code outside `.kortix/memory/` in the same CR. Memory
+  CRs are scoped — one concern per change request.
+- You do not store secrets, tokens, or PII. Those belong in the Kortix
+  Secrets Manager, not in memory files.
+- You do not respond to the user in prose at the end of a run. Your
+  output is the CR (or no CR). The CR title and description are how
+  you communicate.
+
+## When configuration changes
+
+- To change **what** gets remembered: edit the **rubric** in
+  `.kortix/opencode/skills/kortix-memory/SKILL.md` and open a CR. You
+  read the skill fresh on every run, so the next reflection picks up
+  the new rubric automatically.
+- To change **how often** you run: edit the `memory-reflector` block
+  under `[[triggers]]` in `kortix.toml`. The cron sweep picks up new
+  schedules within a few seconds of the CR merging.
+- To **disable** yourself temporarily: flip `enabled = false` on the
+  trigger and open a CR. To re-enable, flip it back.

--- a/packages/starter/templates/base/.kortix/opencode/plugins/kortix-simple-memory.ts
+++ b/packages/starter/templates/base/.kortix/opencode/plugins/kortix-simple-memory.ts
@@ -1,0 +1,88 @@
+/**
+ * kortix-simple-memory — opencode plugin
+ *
+ * Injects `.kortix/memory/MEMORY.md` (the project-brain index) into the
+ * front of the system prompt as a `<kortix-memory>` block on every LLM
+ * call. Sub-files in `.kortix/memory/` are NOT auto-loaded — the agent
+ * reads them on demand with the built-in `read` tool.
+ *
+ * Why front of `output.system[]`: it sits in the cached prefix of the
+ * prompt, so as long as MEMORY.md doesn't change mid-session the
+ * provider's prefix cache keeps hitting.
+ *
+ * For the rubric on what belongs in project memory and how to update
+ * it, load the `kortix-memory` skill.
+ */
+
+import type { Plugin } from "@opencode-ai/plugin";
+import { readFile, readdir, stat } from "node:fs/promises";
+import { join } from "node:path";
+
+type Options = {
+  /** Path relative to project root. Default: ".kortix/memory" */
+  dir?: string;
+  /** Index filename inside `dir`. Default: "MEMORY.md" */
+  index?: string;
+  /** Soft cap on the injected block to keep the prompt cache tight. */
+  maxChars?: number;
+};
+
+export const KortixSimpleMemory: Plugin = async (ctx, opts: Options = {}) => {
+  const memDir   = opts.dir   ?? ".kortix/memory";
+  const indexRel = opts.index ?? "MEMORY.md";
+  const maxChars = opts.maxChars ?? 8192;
+
+  async function readBlock(): Promise<string | null> {
+    const root = ctx.directory;
+    const indexPath = join(root, memDir, indexRel);
+
+    let body: string;
+    try {
+      body = await readFile(indexPath, "utf8");
+    } catch {
+      return null; // memory not initialized — no-op
+    }
+
+    // List sibling files so the agent knows what's available to `read`.
+    let listing: string[] = [];
+    try {
+      const entries = await readdir(join(root, memDir));
+      for (const name of entries) {
+        if (name === indexRel || name.startsWith(".")) continue;
+        const full = join(root, memDir, name);
+        const s = await stat(full);
+        if (s.isFile()) listing.push(name);
+      }
+      listing.sort();
+    } catch { /* empty dir is fine */ }
+
+    const filesLine = listing.length
+      ? `Files in ${memDir}/ available via \`read\` / \`bash\`: ${listing.join(", ")}`
+      : "";
+
+    let block =
+      `<kortix-memory source="${memDir}/${indexRel}">\n` +
+      `[Project brain — durable, team-shared knowledge about this project.\n` +
+      ` The index below names sub-files in ${memDir}/. Open them with \`read\`\n` +
+      ` only when the index points at one that's relevant to the current task.\n` +
+      ` Load the \`kortix-memory\` skill when adding or updating memory.]\n\n` +
+      body.trim() +
+      (filesLine ? `\n\n${filesLine}` : "") +
+      `\n</kortix-memory>`;
+
+    if (block.length > maxChars) {
+      block = block.slice(0, maxChars - 32) + "\n[...truncated]\n</kortix-memory>";
+    }
+    return block;
+  }
+
+  return {
+    "experimental.chat.system.transform": async (_input, output) => {
+      const block = await readBlock();
+      if (!block) return;
+      output.system.unshift(block);
+    },
+  };
+};
+
+export default KortixSimpleMemory;

--- a/packages/starter/templates/base/.kortix/opencode/skills/kortix-memory/SKILL.md
+++ b/packages/starter/templates/base/.kortix/opencode/skills/kortix-memory/SKILL.md
@@ -1,0 +1,200 @@
+---
+name: kortix-memory
+description: How to read, write, and curate project memory in `.kortix/memory/` — the project brain. Load this skill whenever you (or the memory-reflector agent) need to add, update, or reorganize what this project knows about itself. Defines the rubric for what belongs in memory, the file structure, and the change-request flow for landing memory edits on `main`.
+---
+
+<skill name="kortix-memory">
+
+<overview>
+Every Kortix project has a **project brain** at `.kortix/memory/` — a
+folder of curated markdown files describing what this project is,
+which integrations it talks to, the conventions the team works by, and
+the decisions worth not re-litigating.
+
+`MEMORY.md` is the **index**. The `kortix-simple-memory` plugin
+(`.kortix/opencode/plugins/kortix-simple-memory.ts`) injects it into
+every LLM call as a `<kortix-memory>` block at the front of the system
+prompt — so every agent in every session sees it without doing
+anything. Sub-files (`overview.md`, `integrations.md`, etc.) are NOT
+auto-loaded; agents `read` them on demand when the index points at
+something relevant.
+
+Memory is **continuously CRUD'd**:
+
+- Regular sessions add or update memory whenever they discover
+  something durable worth keeping.
+- The `memory-reflector` agent (`.kortix/opencode/agents/memory-reflector.md`)
+  runs on a cron, surveys recent activity, and curates the folder.
+- Both consult this skill for the rubric.
+
+Memory is **team-shared**: it lives in the repo, every session sees the
+same content. Edits land on `main` only via a Kortix change request —
+never by pushing directly.
+</overview>
+
+<when-to-load>
+Load this skill when you:
+
+- Discover a project convention, integration detail, decision, or
+  workaround that should outlast this session
+- Notice the project brain is out of date or contradicts current code
+- Are the `memory-reflector` agent doing your scheduled reflection run
+- Want to know if something is worth writing down (use the rubric below)
+- Need to add, rename, split, or delete a memory file
+- Want to know how memory edits reach `main`
+
+Skip this skill for one-off questions about *operating* code. Project
+memory is about durable knowledge, not session state.
+</when-to-load>
+
+<file-layout>
+```
+.kortix/memory/
+├── MEMORY.md           Index. Auto-injected. One line per sub-file.
+├── overview.md         What this project IS — purpose, shape, stakeholders.
+├── integrations.md     Third parties, MCP servers, channels, executor connectors.
+├── conventions.md      Coding patterns, naming, do / don't, style decisions.
+└── decisions.md        Architectural and business decisions worth not re-debating.
+```
+
+Add new files freely when a topic deserves its own page (one topic per
+file, kebab-case filename). **Always** keep `MEMORY.md` in sync — one
+line per sub-file, format:
+
+```
+- [filename.md](filename.md) — one-line hook of what's inside
+```
+
+Don't move content out of `MEMORY.md` if it's a single line that
+already lives in the index — keep that one line. Sub-files exist when
+there's enough depth to warrant a click.
+</file-layout>
+
+<rubric>
+
+### What to remember (KEEP)
+
+- **The project's purpose** — what we're building, for whom, and the
+  one-sentence pitch.
+- **Architecture-level decisions** — why we use X over Y, which
+  service owns what, the data flow.
+- **Integration details** — which third parties / MCP servers /
+  channels are wired, what credentials they need, how they're scoped.
+- **Conventions** — naming, code style, branching, review norms — the
+  stuff that's *de facto* across the codebase but not stated.
+- **Workarounds and quirks** — known env issues, ordering constraints,
+  flaky dependencies, gotchas that bit us once.
+- **Ops runbooks** — how to deploy, how to roll back, how to debug the
+  thing that breaks every quarter.
+- **Glossary** — domain terms specific to this project that an
+  outsider wouldn't know.
+- **People & ownership** *(optional)* — who owns which surface, how to
+  reach them, what they care about.
+
+### What NOT to remember (DROP)
+
+- One user's personal preferences — those are not project memory.
+- Facts derivable from the repo layout, file names, or `git log`.
+- One-off task state that won't matter next week.
+- Anything that's already in `kortix.toml`, `AGENTS.md`, or a SKILL.md.
+- Secrets, tokens, API keys, PII — those live in the Kortix Secrets
+  Manager, never in memory files.
+- Speculation about future plans. Memory describes what *is*, not
+  what might be.
+
+### Style for entries
+
+- **Plain prose** with short sentences.
+- **State facts, not narratives** — "The web app talks to Supabase
+  Postgres for auth" beats "We decided to use Supabase…".
+- **Cite file paths** when the fact maps to code: `path/file.ts:120`.
+- **Date hard-to-verify facts** in `YYYY-MM-DD` so readers can judge
+  staleness.
+- **Prefer editing existing entries** over piling new ones on. A
+  bloated file is worse than a tight one.
+
+</rubric>
+
+<writing>
+
+### Adding or updating memory
+
+Memory uses the same `write` / `edit` tools you use for code. There is
+**no special memory tool**.
+
+1. Identify the right file. Most additions fit `overview.md`,
+   `integrations.md`, `conventions.md`, or `decisions.md`. Create a
+   new file when a topic deserves its own page.
+2. Edit the file. Keep entries short, factual, and consistent with the
+   surrounding prose.
+3. If you added, renamed, or deleted a file, update `MEMORY.md` so the
+   index matches the folder. The index is the user's table of
+   contents — and the only thing every session sees on every turn.
+4. If something turned out to be wrong, delete it. Don't leave stale
+   facts to confuse future agents.
+
+### Landing memory on `main`
+
+Session branches die when sessions end. Memory edits reach `main`
+only via a Kortix change request — same path as any code change:
+
+```sh
+git add .kortix/memory
+git commit -m "memory: <one-line summary of what changed>"
+git push origin HEAD
+kortix cr open \
+  --title "memory: <one-line summary>" \
+  --description "What changed and why."
+```
+
+The user reviews and merges. Don't merge your own CR.
+
+</writing>
+
+<reflector>
+
+The `memory-reflector` agent
+(`.kortix/opencode/agents/memory-reflector.md`) is a thin wrapper
+around this skill — its job is to:
+
+1. Load this skill.
+2. Survey recent project activity (git log since last run, recent
+   merged CRs, the active session transcript if invoked from one).
+3. Decide what's worth keeping per the **rubric** above.
+4. CRUD `.kortix/memory/` accordingly.
+5. Open a single CR titled `memory: …`.
+6. Exit silently if nothing is worth changing.
+
+To change *what the reflector remembers*, edit the **rubric** section
+of this skill. The reflector reads it fresh every run, so a merged CR
+to this file takes effect on the next reflection.
+
+To change *when the reflector runs*, edit the `[[triggers]]` block
+named `memory-reflector` in `kortix.toml`. The cron sweep picks up
+changes within a few seconds of the CR merging.
+
+</reflector>
+
+<gotchas>
+
+- **The index is everywhere; sub-files are on demand.** Don't dump
+  every fact into `MEMORY.md` — it gets injected into every turn.
+  Push depth into sub-files; keep the index a clean table of contents.
+- **`<kortix-memory>` content is part of the cached prefix.** If you
+  change `MEMORY.md` mid-session you'll pay one cache write on the
+  next turn (expected, fine). Don't churn it for no reason.
+- **Memory files are markdown, not databases.** Avoid heavy
+  formatting, tables of 50 rows, or auto-generated content. If you
+  catch yourself writing a script to generate a memory file, that
+  content probably belongs in code, not memory.
+- **Memory edits must go through CR.** Direct pushes to `main` bypass
+  the user-review contract — the same rule as code. The reflector
+  agent enforces this by always ending with `kortix cr open`.
+- **Don't put secrets in memory.** Memory is auto-injected into every
+  LLM call. Secrets, tokens, API keys, and PII belong in the Kortix
+  Secrets Manager, surfaced as env vars at runtime — not in
+  `.kortix/memory/`.
+
+</gotchas>
+
+</skill>

--- a/packages/starter/templates/base/kortix.toml
+++ b/packages/starter/templates/base/kortix.toml
@@ -39,7 +39,30 @@ config_dir = ".kortix/opencode"
 # Each `[[triggers]]` entry spawns a fresh session that runs `prompt` as
 # its initial message. Add from the Kortix UI or uncomment one below.
 # Slugs must be lowercase URL-safe and unique per project.
+
+# Memory reflector — surveys recent project activity and curates
+# `.kortix/memory/` (the project brain). Reads its rubric from the
+# `kortix-memory` skill. Opens a `memory: …` change request at the end
+# of each run; exits silently when nothing is worth changing.
 #
+# Disabled by default. Flip `enabled = true` once your project has
+# enough activity for reflection to find signal — usually after the
+# first week or two.
+[[triggers]]
+slug = "memory-reflector"
+name = "Memory reflector"
+type = "cron"
+agent = "memory-reflector"
+enabled = false
+cron = "0 0 3 * * *"             # 03:00 daily
+timezone = "UTC"
+prompt = """
+Load the `kortix-memory` skill, then reflect on the last 24h of
+project activity (git log, merged CRs). Update `.kortix/memory/` per
+the rubric and open a single CR titled `memory: …`. Exit silently if
+nothing is worth changing.
+"""
+
 # Cron trigger — fires on a 6-field croner expression
 # (second minute hour day month weekday).
 #


### PR DESCRIPTION
Adds a default **project-brain memory layer** to every new Kortix project. Modeled on how Hermes Agent does memory, but radically simpler: just markdown files + one opencode plugin that injects an index into the system prompt. No DB, no UI, no API changes, no new tools — it all lives in the starter template.

## What ships

Inside `packages/starter/templates/base/`:

| File | What it does |
|---|---|
| `.kortix/opencode/plugins/kortix-simple-memory.ts` | Opencode plugin (~80 LOC, no deps beyond node built-ins). On every LLM call it reads `.kortix/memory/MEMORY.md` and prepends it to `output.system[0]` as a `<kortix-memory>` block. Front of the array = cached prefix, so prompt cache stays warm. |
| `.kortix/opencode/skills/kortix-memory/SKILL.md` | The **rubric** for what belongs in project memory, the file layout, the writing flow, and the CR mandate. Source of truth that both regular agents and the memory-reflector consult — editing this file (via CR) is how the team changes what gets remembered. |
| `.kortix/opencode/agents/memory-reflector.md` | Thin reflector agent. Loads the `kortix-memory` skill, surveys recent activity, CRUDs the memory folder, opens a single `memory: …` CR. Exits silently on no-op runs. |
| `.kortix/memory/` seed | `MEMORY.md` index + `overview` / `integrations` / `conventions` / `decisions` stubs. New projects get a discoverable shape from day one. |
| `kortix.toml` | New `[[triggers]] memory-reflector` block, **`enabled = false`** (opt-in; flip to `true` once the project has activity). |

## Design

The whole system in one diagram:

```
every LLM call
   │
   └── opencode fires experimental.chat.system.transform
        │
        └── plugin reads .kortix/memory/MEMORY.md
             │
             └── prepends <kortix-memory>…</kortix-memory> to output.system[0]
                  │
                  └── agent sees the index, uses built-in `read` to open
                      sub-files when an index entry looks relevant
```

Writes happen two ways:

- **Ad-hoc** during a regular session: any agent that learns something durable can edit `.kortix/memory/*` directly with `write` / `edit`, update the index, and open a `memory: …` CR. No special tool.
- **Scheduled** by the `memory-reflector` agent (default daily 03:00 UTC, disabled by default in the starter): same flow, but autonomous and rubric-driven.

The rubric — "what's worth remembering" — lives in the skill, not in the agent. Updating it = editing one file = CR.

## Verified e2e locally

Tested against `opencode 1.15.10` with `openai/gpt-5.4-mini-fast` from a clean copy of the starter template:

- ✓ `<kortix-memory>` block reaches the model on every turn
- ✓ Bytewise-identical across calls (md5 stable → cache-safe)
- ✓ Model autonomously uses `read` to open sub-files when relevant
- ✓ Graceful no-op when `.kortix/memory/MEMORY.md` is absent
- ✓ Plugin discovered via `OPENCODE_CONFIG_DIR=.kortix/opencode` with `scope: local`

## What this does NOT do

- No platform code changes — entirely starter-template.
- No new tool surface — agents use existing `read` / `write` / `edit`.
- No database, no API, no UI.
- No external memory providers (Mem0 / Honcho / Mem0 / etc.) — explicitly out of scope. The whole system is "markdown files + injection."
- Per-user memory — out of scope for v1. Everything is project-scoped, team-shared.

## Follow-ups (separate CRs)

- Decide on direct-commit vs CR for personal-account projects (currently CR-only via the agent's instructions).
- Threat-scanner port for `.kortix/memory/**` writes (defense in depth — the file lands in every system prompt).
- A short paragraph in the starter's `README.md` explaining the folder to humans editing the repo.