### PR TITLE
fix: create basejump.billing_customers + grants for external Supabase installs

### DIFF
--- a/supabase/migrations/00000000000032_basejump_billing_customers_empty.sql
+++ b/supabase/migrations/00000000000032_basejump_billing_customers_empty.sql
@@ -1,0 +1,18 @@
+-- Create empty basejump.billing_customers table.
+-- Suna's reconcile-legacy-stripe-billing script and resolve-account
+-- both query basejump.billing_customers, but no migration ever
+-- creates it in basejump (only in kortix.). With billing disabled
+-- this table just needs to exist and return 0 rows.
+
+create schema if not exists basejump;
+
+create table if not exists basejump.billing_customers (
+  account_id uuid not null,
+  id text primary key,
+  email text,
+  active boolean,
+  provider text
+);
+
+create index if not exists idx_basejump_billing_customers_account_id
+  on basejump.billing_customers(account_id);

--- a/supabase/migrations/00000000000033_basejump_billing_grants.sql
+++ b/supabase/migrations/00000000000033_basejump_billing_grants.sql
@@ -1,0 +1,15 @@
+-- Grant access to basejump schema and basejump.billing_customers
+-- (created in migration 32). Without these, the API's resolve-account
+-- code (which connects as `authenticated`) gets:
+--   permission denied for schema basejump
+-- and logs "Stripe sync error" on every request.
+
+GRANT USAGE ON SCHEMA basejump TO authenticated, service_role, anon;
+
+ALTER DEFAULT PRIVILEGES IN SCHEMA basejump GRANT ALL ON TABLES TO service_role;
+ALTER DEFAULT PRIVILEGES IN SCHEMA basejump GRANT SELECT, INSERT, UPDATE ON TABLES TO authenticated;
+ALTER DEFAULT PRIVILEGES IN SCHEMA basejump GRANT SELECT ON TABLES TO anon;
+
+GRANT ALL ON ALL TABLES IN SCHEMA basejump TO service_role;
+GRANT SELECT, INSERT, UPDATE ON ALL TABLES IN SCHEMA basejump TO authenticated;
+GRANT SELECT ON ALL TABLES IN SCHEMA basejump TO anon;


### PR DESCRIPTION
## Problem

When self-hosting Suna against an **external cloud Supabase project** (`DB_MODE=external`), the API spams `[resolve-account] Stripe sync error` on every authenticated request, even with billing disabled:

\`\`\`
[resolve-account] Stripe sync error for <uuid>: Failed query: select "account_id", "id", "email", "active", "provider" from "basejump"."billing_customers" where "basejump"."billing_customers"."account_id" = \$1
\`\`\`

## Root cause

1. \`apps/api/src/scripts/reconcile-legacy-stripe-billing.ts\` queries \`basejump.billing_customers\` (legacy location), and the request-time \`resolve-account\` path does the same.
2. \`packages/db/src/schema/public.ts\` declares \`billingCustomersInBasejump\` in the \`basejump\` schema. But the comment above it says *"schemaFilter includes 'public'"* — basejump tables are never pushed by drizzle-kit.
3. With **Docker Supabase** the basejump schema gets bootstrapped with \`billing_customers\` by the bundled Supabase extensions, so the issue is hidden.
4. With **external/cloud Supabase**, the table never gets created. The query fails on every request.

There's also a permissions wrinkle: even after creating the table, the API connects as \`authenticated\` (via the Supavisor pooler with a JWT) and hits \`permission denied for schema basejump\` because the basejump schema is owned by \`supabase_admin\` with no usage grant for the standard Supabase roles.

## Fix

Two SQL migrations:

- **00000000000032** — \`create table if not exists basejump.billing_customers\` matching the shape declared in \`schema/public.ts\` (and matching \`kortix.billing_customers\`).
- **00000000000033** — \`grant usage on schema basejump\` + table grants for \`authenticated\`, \`service_role\`, \`anon\` (mirrors the pattern in \`00000000000001_table_grants.sql\` for the kortix schema).

## Validation

Tested against a fresh cloud Supabase project (\`eu-central-1\`) with Kortix v0.8.44:

- Before: \`[resolve-account] Stripe sync error\` on every request (one per second-ish during normal sandbox health checks).
- After: zero Stripe sync errors. Signup completes, sandbox bootstraps, dashboard loads cleanly.

## Notes for reviewers

- Migrations are gated with \`if not exists\` so they're safe for Docker Supabase installs where the table/schema may already exist.
- Migration 33 grants \`SELECT, INSERT, UPDATE\` to \`authenticated\` and \`SELECT\` to \`anon\` — same shape as existing kortix grants. If you want \`DELETE\` semantics for basejump too, happy to widen.
- Did not touch the \`apps/api/src/scripts/reconcile-legacy-stripe-billing.ts\` script or the \`resolve-account\` code path — the legacy-billing query stays valid, it just returns 0 rows when there's no Stripe data.