### PR TITLE
chore(billing): treat feature flag as the source of truth for billing gates

### DIFF
--- a/apps/api/src/billing/services/billing-gate.ts
+++ b/apps/api/src/billing/services/billing-gate.ts
@@ -1,4 +1,5 @@
 import { HTTPException } from 'hono/http-exception';
+import { config } from '../../config';
 import { getCreditAccount } from '../repositories/credit-accounts';
 import { isPerSeatAccount, MINIMUM_CREDIT_FOR_RUN } from './tiers';
 
@@ -19,6 +20,13 @@ export interface BillingGateBlocked {
 }
 
 export async function checkBillingActive(accountId: string): Promise<BillingGateOk | BillingGateBlocked> {
+  // Self-hosted / billing-disabled deploys treat every account as billing-active.
+  // No subscription, no credit balance, no 402 — the entire wallet pipeline is
+  // dormant on this deploy.
+  if (!config.KORTIX_BILLING_INTERNAL_ENABLED) {
+    return { ok: true };
+  }
+
   const account = await getCreditAccount(accountId);
   if (!account) {
     return {

--- a/apps/web/src/components/layout/app-providers.tsx
+++ b/apps/web/src/components/layout/app-providers.tsx
@@ -14,6 +14,7 @@ import { AccountSettingsModal } from '@/components/settings/account-settings-mod
 import { useUserSettingsModalStore } from '@/stores/user-settings-modal-store';
 import { useAccountSettingsModalStore } from '@/stores/account-settings-modal-store';
 import { GlobalUpgradeDialog } from '@/components/billing/upgrade-dialog';
+import { isBillingEnabled } from '@/lib/config';
 import { SidebarLeft } from '@/components/sidebar/sidebar-left';
 import { SidebarRight } from '@/components/sidebar/sidebar-right';
 
@@ -103,6 +104,7 @@ function GlobalUserSettingsModal() {
  *  402 error handler, session error banner) can open it from anywhere. */
 function GlobalAccountSettingsModal() {
   const { isOpen, defaultTab, closeAccountSettings } = useAccountSettingsModalStore();
+  if (!isBillingEnabled()) return null;
   return (
     <AccountSettingsModal
       open={isOpen}
@@ -152,7 +154,7 @@ export function AppProviders({
             <GlobalAccountSettingsModal />
           </>
         )}
-        <GlobalUpgradeDialog />
+        {isBillingEnabled() && <GlobalUpgradeDialog />}
       </SubscriptionStoreSync>
     </DeleteOperationEffectsWrapper>
   );

--- a/apps/web/src/components/settings/user-settings-modal.tsx
+++ b/apps/web/src/components/settings/user-settings-modal.tsx
@@ -1564,8 +1564,8 @@ export function BillingTab({ returnUrl, isActive }: { returnUrl: string; isActiv
                 </div>
             </div>
 
-            {/* ── Team plan (Billing v2) ── */}
-            <TeamPlanSection accountState={accountState} />
+            {/* ── Team plan (Billing v2) — only when billing is enabled on this deploy ── */}
+            {isBillingEnabled() && <TeamPlanSection accountState={accountState} />}
 
             {/* ── Kortix YOLO (shown between Credits and Top-up actions) ── */}
             {yoloUsage && (

--- a/apps/web/src/lib/error-handler.ts
+++ b/apps/web/src/lib/error-handler.ts
@@ -3,6 +3,7 @@ import { BillingError, isBillingError, formatBillingErrorForUI } from './api/err
 import { usePricingModalStore } from '@/stores/pricing-modal-store';
 import { useAccountSettingsModalStore } from '@/stores/account-settings-modal-store';
 import { useUpgradeDialogStore } from '@/stores/upgrade-dialog-store';
+import { isBillingEnabled } from '@/lib/config';
 import * as Sentry from '@sentry/nextjs';
 
 export interface ApiError extends Error {
@@ -199,6 +200,7 @@ export const handleApiError = (error: any, context?: ErrorContext): void => {
     typeof v2Detail?.balance === 'number' ? v2Detail.balance : 0;
 
   if (
+    isBillingEnabled() &&
     v2Status === 402 &&
     (v2Code === 'subscription_required' ||
       v2Code === 'insufficient_credits' ||


### PR DESCRIPTION
…gatesSelf-hosted deploys were still seeing the upgrade dialog, the Account Settings billing tab, and the "Subscribe to Team plan" CTA. The API could also emit 402s even when billing was nominally off. This PR closes all four gaps.

## Changes

| File | Behavior when flag is `false` |
|---|---|
| `billing-gate.ts` | `checkBillingActive` short-circuits to `ok: true` — no 402 ever fires |
| `app-providers.tsx` | `<GlobalUpgradeDialog />` not mounted; `<GlobalAccountSettingsModal />` returns null |
| `error-handler.ts` | 402 detection no longer dispatches to `openUpgradeDialog` |
| `user-settings-modal.tsx` | `<TeamPlanSection />` (Subscribe CTA + `SeatManagementCard`) doesn't render |

Defense-in-depth: any single layer failing still suppresses the UI.

## Test plan

- [ ] `KORTIX_BILLING_INTERNAL_ENABLED=false` → no billing UI anywhere, no 402s
- [ ] Flip back to `true` → Account Settings, Team plan CTA, and Upgrade dialog all work as before
