### PR TITLE
fix(web): normalize container border-radius to design-system rounded-2xl

### DIFF
--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -9,9 +9,71 @@ const compat = new FlatCompat({
   baseDirectory: __dirname,
 });
 
+/**
+ * Kortix design-system guard: chrome has exactly two radii. Every container /
+ * box / panel is `rounded-2xl`; pills (buttons, badges) are `rounded-full`.
+ * A bordered, padded box with `rounded-sm|md|lg|xl` is a hand-rolled container
+ * that drifted off-brand — it should be `rounded-2xl` (or, better, composed
+ * from `Card` / `SectionCard` / `InfoBanner`, which are `rounded-2xl` already).
+ *
+ * Heuristic: flag a className string only when it has BOTH a non-2xl container
+ * radius AND a `border*` AND padding (`p-/px-/py-`). Requiring all three keeps
+ * the sanctioned sub-element radii quiet: menu/list highlight rows
+ * (`rounded-lg` without a border), avatars/thing-tiles, and raw micro-bits
+ * (kbd keys, swatches, tiny icon squares) don't carry a border + padding box.
+ * Genuine edge cases can opt out with an inline eslint-disable comment.
+ */
+const BAD_RADIUS = /\brounded-(?:sm|md|lg|xl)\b/;
+const HAS_BORDER = /\bborder(?:-|\b)/;
+const HAS_PADDING = /\b(?:p|px|py)-[\w./[\]-]+/;
+
+const noHardcodedContainerRadius = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow non-2xl border-radius on bordered, padded containers (Kortix design system: containers are rounded-2xl).',
+    },
+    messages: {
+      badRadius:
+        'Container radius off-brand: this bordered, padded box uses {{radius}}. Kortix containers must be `rounded-2xl` (or compose Card/SectionCard/InfoBanner). Pills use `rounded-full`.',
+    },
+    schema: [],
+  },
+  create(context) {
+    function check(node, raw) {
+      if (typeof raw !== 'string') return;
+      const match = raw.match(BAD_RADIUS);
+      if (!match) return;
+      if (!HAS_BORDER.test(raw)) return;
+      if (!HAS_PADDING.test(raw)) return;
+      context.report({
+        node,
+        messageId: 'badRadius',
+        data: { radius: match[0] },
+      });
+    }
+    return {
+      Literal(node) {
+        check(node, node.value);
+      },
+      TemplateElement(node) {
+        check(node, node.value.raw);
+      },
+    };
+  },
+};
+
 const eslintConfig = [
   ...compat.extends('next/core-web-vitals', 'next/typescript'),
   {
+    plugins: {
+      'kortix-ds': {
+        rules: {
+          'no-hardcoded-container-radius': noHardcodedContainerRadius,
+        },
+      },
+    },
     rules: {
       '@typescript-eslint/no-unused-vars': 'off',
       '@typescript-eslint/no-explicit-any': 'off',
@@ -20,6 +82,7 @@ const eslintConfig = [
       '@next/next/no-img-element': 'warn',
       '@typescript-eslint/no-empty-object-type': 'off',
       'prefer-const': 'warn',
+      'kortix-ds/no-hardcoded-container-radius': 'error',
     },
   },
 ];

--- a/apps/web/src/app/(home)/design-system/page.tsx
+++ b/apps/web/src/app/(home)/design-system/page.tsx
@@ -472,7 +472,7 @@ function DemoContainer({
   return (
     <div
       className={cn(
-        'rounded-xl ring-1 ring-border/50 bg-card/30 p-6',
+        'rounded-2xl ring-1 ring-border/50 bg-card/30 p-6',
         className
       )}
     >
@@ -1572,10 +1572,10 @@ export default function BrandPage() {
                           </Button>
                         </CollapsibleTrigger>
                       </div>
-                      <div className="rounded-md border border-border/50 px-4 py-2 mt-2 text-sm">{tHardcodedUi.raw('appHomeDesignSystemPage.line1751JsxTextKortixDesignSystem')}</div>
+                      <div className="rounded-2xl border border-border/50 px-4 py-2 mt-2 text-sm">{tHardcodedUi.raw('appHomeDesignSystemPage.line1751JsxTextKortixDesignSystem')}</div>
                       <CollapsibleContent className="mt-2 space-y-2">
-                        <div className="rounded-md border border-border/50 px-4 py-2 text-sm">{tHardcodedUi.raw('appHomeDesignSystemPage.line1755JsxTextKortixComponents')}</div>
-                        <div className="rounded-md border border-border/50 px-4 py-2 text-sm">{tHardcodedUi.raw('appHomeDesignSystemPage.line1758JsxTextKortixTokens')}</div>
+                        <div className="rounded-2xl border border-border/50 px-4 py-2 text-sm">{tHardcodedUi.raw('appHomeDesignSystemPage.line1755JsxTextKortixComponents')}</div>
+                        <div className="rounded-2xl border border-border/50 px-4 py-2 text-sm">{tHardcodedUi.raw('appHomeDesignSystemPage.line1758JsxTextKortixTokens')}</div>
                       </CollapsibleContent>
                     </Collapsible>
                   </DemoContainer>
@@ -1828,7 +1828,7 @@ export default function BrandPage() {
                   <ComponentLabel>{tHardcodedUi.raw('appHomeDesignSystemPage.line2040JsxTextScrollArea')}</ComponentLabel>
                   <ComponentDesc>{tHardcodedUi.raw('appHomeDesignSystemPage.line2042JsxTextCustomScrollableContainerWithStyledScrollbar')}</ComponentDesc>
                   <DemoContainer>
-                    <ScrollArea className="h-48 w-full rounded-md border border-border/50 p-4">
+                    <ScrollArea className="h-48 w-full rounded-2xl border border-border/50 p-4">
                       <div className="space-y-2">
                         {Array.from({ length: 20 }, (_, i) => (
                           <div
@@ -1973,7 +1973,7 @@ export default function BrandPage() {
                   <code className="text-xs font-mono">full</code>.
                 </ComponentDesc>
                 <DemoContainer>
-                  <div className="rounded-lg border border-dashed border-border/60 py-10 text-center text-xs text-muted-foreground">
+                  <div className="rounded-2xl border border-dashed border-border/60 py-10 text-center text-xs text-muted-foreground">
                     <code>{tHardcodedUi.raw('appHomeDesignSystemPage.line2223JsxTextLtPageshellWidthQuotDefaultQuotGtLt')}</code>
                     <div className="mt-1 opacity-60">{tHardcodedUi.raw('appHomeDesignSystemPage.line2224JsxTextMaxW1000pxPx6LgPx10')}</div>
                   </div>

--- a/apps/web/src/app/(home)/home-wip/page.tsx
+++ b/apps/web/src/app/(home)/home-wip/page.tsx
@@ -113,7 +113,7 @@ function IntegrationPill({
   name: string;
 }) {
   return (
-    <div className="flex items-center gap-2 px-3 py-1.5 rounded-lg border border-border bg-card/60 hover:bg-muted/50 transition-colors">
+    <div className="flex items-center gap-2 px-3 py-1.5 rounded-2xl border border-border bg-card/60 hover:bg-muted/50 transition-colors">
       {domain ? (
         // eslint-disable-next-line @next/next/no-img-element
         <img

--- a/apps/web/src/app/(home)/status/page.tsx
+++ b/apps/web/src/app/(home)/status/page.tsx
@@ -188,7 +188,7 @@ function StatusPageContent() {
                       className="flex items-center justify-between p-3 rounded-2xl border bg-card/30 hover:bg-card/50 transition-colors"
                     >
                       <div className="flex items-center gap-3">
-                        <div className="p-2 rounded-xl border bg-primary/10">
+                        <div className="p-2 rounded-2xl border bg-primary/10">
                           <item.icon className="h-4 w-4 text-primary" />
                         </div>
                         <div>

--- a/apps/web/src/app/(home)/use-cases/page.tsx
+++ b/apps/web/src/app/(home)/use-cases/page.tsx
@@ -506,7 +506,7 @@ export default function UseCasesPage() {
                 <h4 className="text-sm font-semibold text-foreground mb-3">{tHardcodedUi.raw('appHomeUseCasesPage.line506JsxTextConnectsTo')}</h4>
                 <div className="flex flex-wrap items-center gap-2">
                   {breakdown.integrations.map((d) => (
-                    <span key={d} className="flex items-center gap-2 px-3 py-1.5 rounded-lg border border-border bg-card/60">
+                    <span key={d} className="flex items-center gap-2 px-3 py-1.5 rounded-2xl border border-border bg-card/60">
                       {/* eslint-disable-next-line @next/next/no-img-element */}
                       <img src={favicon(d)} alt={d} width={16} height={16} className="size-4 rounded-sm" />
                       <span className="text-sm text-foreground">{d.replace(/\.(com|so|google\.com|app)$/, '').replace('drive.', 'Drive')}</span>

--- a/apps/web/src/app/(home)/variant-2/page.tsx
+++ b/apps/web/src/app/(home)/variant-2/page.tsx
@@ -123,7 +123,7 @@ export default function Variant2Home() {
                 <span className="text-xs uppercase tracking-[0.2em] text-muted-foreground font-medium">{tHardcodedUi.raw('appHomeVariant2Page.line124JsxTextOrSelfHost')}</span>
                 <button
                   onClick={handleCopy}
-                  className="group flex items-center justify-between w-full max-w-sm h-10 px-4 rounded-lg bg-foreground/[0.03] border border-foreground/[0.08] hover:bg-foreground/[0.06] hover:border-foreground/[0.12] transition-colors cursor-pointer backdrop-blur-md"
+                  className="group flex items-center justify-between w-full max-w-sm h-10 px-4 rounded-2xl bg-foreground/[0.03] border border-foreground/[0.08] hover:bg-foreground/[0.06] hover:border-foreground/[0.12] transition-colors cursor-pointer backdrop-blur-md"
                 >
                   <div className="flex items-center gap-3 overflow-hidden">
                     <span className="font-mono text-xs text-muted-foreground select-none">$</span>
@@ -433,7 +433,7 @@ export default function Variant2Home() {
               </div>
               <button
                 onClick={handleCopy}
-                className="group inline-flex items-center gap-2.5 h-9 px-4 rounded-lg bg-foreground/[0.03] border border-foreground/[0.08] hover:bg-foreground/[0.06] hover:border-foreground/[0.12] transition-colors cursor-pointer"
+                className="group inline-flex items-center gap-2.5 h-9 px-4 rounded-2xl bg-foreground/[0.03] border border-foreground/[0.08] hover:bg-foreground/[0.06] hover:border-foreground/[0.12] transition-colors cursor-pointer"
               >
                 <span className="font-mono text-xs text-muted-foreground select-none">$</span>
                 <code className="text-xs font-mono text-foreground tracking-tight">{INSTALL_CMD}</code>

--- a/apps/web/src/app/accounts/[id]/groups/[groupId]/page.tsx
+++ b/apps/web/src/app/accounts/[id]/groups/[groupId]/page.tsx
@@ -353,13 +353,13 @@ function GroupMembersCard({
                   badges={
                     overrides && badgeLabel ? (
                       <span
-                        className="rounded-md border border-amber-500/40 bg-amber-500/10 px-1.5 py-0.5 text-[10px] font-normal capitalize text-amber-700 dark:text-amber-300"
+                        className="rounded-2xl border border-amber-500/40 bg-amber-500/10 px-1.5 py-0.5 text-[10px] font-normal capitalize text-amber-700 dark:text-amber-300"
                         title="Account owners and admins always have Manager access on every project, regardless of group role."
                       >
                         {badgeLabel}
                       </span>
                     ) : meta?.accountRole === 'member' ? (
-                      <span className="rounded-md border border-border/60 px-1.5 py-0.5 text-[10px] font-normal capitalize text-muted-foreground">
+                      <span className="rounded-2xl border border-border/60 px-1.5 py-0.5 text-[10px] font-normal capitalize text-muted-foreground">
                         member
                       </span>
                     ) : null
@@ -518,7 +518,7 @@ function AddGroupMembersDialog({
                     />
                     <span className="truncate text-sm">{label}</span>
                     {isMe && (
-                      <span className="ml-auto rounded-md border border-border/60 px-1.5 py-0.5 text-[10px] font-normal text-muted-foreground">
+                      <span className="ml-auto rounded-2xl border border-border/60 px-1.5 py-0.5 text-[10px] font-normal text-muted-foreground">
                         you
                       </span>
                     )}
@@ -820,7 +820,7 @@ function GroupProjectGrantsCard({
                 }
                 title={g.project_name}
                 badges={
-                  <span className="rounded-md border border-border/60 px-1.5 py-0.5 text-[10px] font-normal capitalize text-muted-foreground">
+                  <span className="rounded-2xl border border-border/60 px-1.5 py-0.5 text-[10px] font-normal capitalize text-muted-foreground">
                     {g.role}
                   </span>
                 }
@@ -1006,7 +1006,7 @@ function AttachToProjectDialog({
             {projectsQuery.isLoading ? (
               <Skeleton className="h-9 w-full" />
             ) : candidates.length === 0 ? (
-              <p className="rounded-md border border-border/60 bg-muted/20 px-3 py-2.5 text-xs text-muted-foreground">
+              <p className="rounded-2xl border border-border/60 bg-muted/20 px-3 py-2.5 text-xs text-muted-foreground">
                 {(projectsQuery.data ?? []).length === 0
                   ? 'No projects in this account yet.'
                   : attachedProjectIds.size > 0 &&

--- a/apps/web/src/app/accounts/[id]/page.tsx
+++ b/apps/web/src/app/accounts/[id]/page.tsx
@@ -1319,7 +1319,7 @@ function MembersCard({
                       {member.is_super_admin && (
                         <Badge
                           variant="outline"
-                          className="h-5 rounded-md border-amber-500/40 bg-amber-500/10 px-1.5 text-[10px] font-normal text-amber-700 dark:text-amber-300"
+                          className="h-5 rounded-2xl border-amber-500/40 bg-amber-500/10 px-1.5 text-[10px] font-normal text-amber-700 dark:text-amber-300"
                           title={tHardcodedUi.raw('appAccountsIdPage.line924JsxAttrTitleSuperAdminBypassesEveryIAMCheck')}
                         >
                           super
@@ -1347,7 +1347,7 @@ function MembersCard({
                       {member.has_verified_mfa && (
                         <Badge
                           variant="outline"
-                          className="h-5 rounded-md border-emerald-500/40 bg-emerald-500/10 px-1.5 text-[10px] font-normal text-emerald-700 dark:text-emerald-300"
+                          className="h-5 rounded-2xl border-emerald-500/40 bg-emerald-500/10 px-1.5 text-[10px] font-normal text-emerald-700 dark:text-emerald-300"
                           title={tHardcodedUi.raw('appAccountsIdPage.line952JsxAttrTitleMFAEnrolled')}
                         >
                           2FA
@@ -1969,7 +1969,7 @@ function BulkAddToGroupDialog({
           {groupsQuery.isLoading ? (
             <Skeleton className="h-9 w-full" />
           ) : groups.length === 0 ? (
-            <p className="rounded-md border border-border/60 bg-muted/20 px-3 py-2.5 text-xs text-muted-foreground">
+            <p className="rounded-2xl border border-border/60 bg-muted/20 px-3 py-2.5 text-xs text-muted-foreground">
               No groups exist on this account yet. Create one from the Groups
               tab first.
             </p>

--- a/apps/web/src/components/billing/account-overview.tsx
+++ b/apps/web/src/components/billing/account-overview.tsx
@@ -56,7 +56,7 @@ export function AccountOverviewTab({ accountId }: AccountOverviewTabProps = {}) 
   return (
     <div className="space-y-4">
       {/* Plan + wallet + status — compact three-up */}
-      <section className="rounded-lg border bg-card p-5">
+      <section className="rounded-2xl border bg-card p-5">
         <div className="grid gap-3 sm:grid-cols-3">
           <Field label="Plan">
             <div className="flex items-center gap-2">
@@ -87,7 +87,7 @@ export function AccountOverviewTab({ accountId }: AccountOverviewTabProps = {}) 
 
       {/* Spend this period */}
       {usage && (
-        <section className="rounded-lg border bg-card p-5">
+        <section className="rounded-2xl border bg-card p-5">
           <div className="mb-4 flex items-baseline justify-between">
             <h4 className="text-sm font-semibold">Spend this period</h4>
             <span className="text-xs text-muted-foreground tabular-nums">
@@ -113,7 +113,7 @@ export function AccountOverviewTab({ accountId }: AccountOverviewTabProps = {}) 
 
       {/* Limits */}
       {limits.length > 0 && (
-        <section className="rounded-lg border bg-card p-5">
+        <section className="rounded-2xl border bg-card p-5">
           <h4 className="mb-4 text-sm font-semibold">Limits</h4>
           <div className="space-y-3">
             {limits.map((row) => {
@@ -218,7 +218,7 @@ function StatCard({
   sublabel?: string;
 }) {
   return (
-    <div className="rounded-md border bg-background p-3">
+    <div className="rounded-2xl border bg-background p-3">
       <div className="flex items-center gap-2 text-xs text-muted-foreground">
         {icon}
         <span>{label}</span>

--- a/apps/web/src/components/billing/seat-management-card.tsx
+++ b/apps/web/src/components/billing/seat-management-card.tsx
@@ -21,7 +21,7 @@ export function SeatManagementCard({ accountState }: SeatManagementCardProps) {
   const usage = accountState.usage_this_period;
 
   return (
-    <div className="rounded-lg border bg-card p-6 space-y-5">
+    <div className="rounded-2xl border bg-card p-6 space-y-5">
       <header className="flex items-start justify-between gap-4">
         <div className="flex items-center gap-3">
           <div className="rounded-md bg-muted p-2 text-muted-foreground">
@@ -84,7 +84,7 @@ function UsageStat({
   valueUsd: number;
 }) {
   return (
-    <div className="rounded-md border bg-background p-3">
+    <div className="rounded-2xl border bg-background p-3">
       <div className="flex items-center gap-2 text-xs text-muted-foreground">
         {icon}
         <span>{label}</span>

--- a/apps/web/src/components/file-editors/markdown-editor.tsx
+++ b/apps/web/src/components/file-editors/markdown-editor.tsx
@@ -288,7 +288,7 @@ export function MarkdownEditor({
       }),
       CodeBlock.configure({
         HTMLAttributes: {
-          class: 'my-5 p-4 rounded-xl overflow-x-auto bg-zinc-100 dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 text-sm font-mono leading-relaxed text-zinc-800 dark:text-zinc-200',
+          class: 'my-5 p-4 rounded-2xl overflow-x-auto bg-zinc-100 dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 text-sm font-mono leading-relaxed text-zinc-800 dark:text-zinc-200',
         },
       }),
       HardBreak,

--- a/apps/web/src/components/file-editors/markdown-toolbar.tsx
+++ b/apps/web/src/components/file-editors/markdown-toolbar.tsx
@@ -875,7 +875,7 @@ export function MarkdownToolbar({
               />
             </div>
             {imageUrl && (
-              <div className="border rounded-lg p-2">
+              <div className="border rounded-2xl p-2">
                 {/* eslint-disable-next-line @next/next/no-img-element */}
                 <img
                   src={imageUrl}

--- a/apps/web/src/components/file-renderers/binary-renderer.tsx
+++ b/apps/web/src/components/file-renderers/binary-renderer.tsx
@@ -61,7 +61,7 @@ export function BinaryRenderer({
       <div className="flex flex-col items-center text-center max-w-md">
         <div className="relative mb-6">
           <File className="h-24 w-24 text-muted-foreground/50" />
-          <div className="absolute bottom-1 right-1 bg-background rounded-sm px-1.5 py-0.5 text-xs font-medium text-muted-foreground border">
+          <div className="absolute bottom-1 right-1 bg-background rounded-2xl px-1.5 py-0.5 text-xs font-medium text-muted-foreground border">
             {fileExtension.toUpperCase()}
           </div>
         </div>

--- a/apps/web/src/components/file-renderers/sqlite-renderer.tsx
+++ b/apps/web/src/components/file-renderers/sqlite-renderer.tsx
@@ -754,7 +754,7 @@ export function SqliteRenderer({ filePath, fileName, className, readOnly = false
           </div>
           <button
             onClick={() => window.location.reload()}
-            className="h-8 px-3 text-xs rounded-md border cursor-pointer inline-flex items-center gap-1.5 hover:bg-muted transition-colors"
+            className="h-8 px-3 text-xs rounded-2xl border cursor-pointer inline-flex items-center gap-1.5 hover:bg-muted transition-colors"
           >
             <RefreshCw className="w-3 h-3" />
             Retry
@@ -1066,7 +1066,7 @@ export function SqliteRenderer({ filePath, fileName, className, readOnly = false
                     {copied ? 'Copied' : 'Copy'}
                   </Button>
                 </div>
-                <pre className="bg-muted/50 rounded-lg p-4 text-xs font-mono text-foreground/80 overflow-x-auto whitespace-pre-wrap border select-text">
+                <pre className="bg-muted/50 rounded-2xl p-4 text-xs font-mono text-foreground/80 overflow-x-auto whitespace-pre-wrap border select-text">
                   {selectedTableInfo.sql || '-- No SQL available (system table or virtual table)'}
                 </pre>
               </div>
@@ -1191,7 +1191,7 @@ export function SqliteRenderer({ filePath, fileName, className, readOnly = false
                   onKeyDown={handleQueryKeyDown}
                   placeholder={`SELECT * FROM "${selectedTable || 'table_name'}" LIMIT 100`}
                   className={cn(
-                    'w-full h-24 px-3 py-2 rounded-md border bg-muted/30 font-mono text-xs cursor-text',
+                    'w-full h-24 px-3 py-2 rounded-2xl border bg-muted/30 font-mono text-xs cursor-text',
                     'resize-none focus:outline-none focus:ring-1 focus:ring-ring',
                     'placeholder:text-muted-foreground/30',
                   )}

--- a/apps/web/src/components/home/navbar.tsx
+++ b/apps/web/src/components/home/navbar.tsx
@@ -73,7 +73,7 @@ function PowerButton({ href, onClick, label = 'Launch Kortix' }: { href?: string
       <AnimatePresence>
         {hovered && (
           <motion.span
-            className="absolute -bottom-8 left-1/2 -translate-x-1/2 whitespace-nowrap text-xs text-foreground bg-background border border-border rounded-md px-2 py-0.5 pointer-events-none z-50 shadow-sm"
+            className="absolute -bottom-8 left-1/2 -translate-x-1/2 whitespace-nowrap text-xs text-foreground bg-background border border-border rounded-2xl px-2 py-0.5 pointer-events-none z-50 shadow-sm"
             initial={{ opacity: 0, y: -4 }}
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: -4 }}

--- a/apps/web/src/components/iam/audit-webhooks-card.tsx
+++ b/apps/web/src/components/iam/audit-webhooks-card.tsx
@@ -120,7 +120,7 @@ export function AuditWebhooksCard({ accountId, canManage }: AuditWebhooksCardPro
         )}
 
         {!hooksQuery.isLoading && hooks.length === 0 && (
-          <p className="rounded-md border border-dashed border-border/60 px-3 py-6 text-center text-xs text-muted-foreground">
+          <p className="rounded-2xl border border-dashed border-border/60 px-3 py-6 text-center text-xs text-muted-foreground">
             {tHardcodedUi.raw('componentsIamAuditWebhooksCard.line125JsxTextNoWebhooksConfigured')}</p>
         )}
 
@@ -129,7 +129,7 @@ export function AuditWebhooksCard({ accountId, canManage }: AuditWebhooksCardPro
             {hooks.map((h) => (
               <li
                 key={h.webhook_id}
-                className="rounded-md border border-border/60 px-3 py-2.5"
+                className="rounded-2xl border border-border/60 px-3 py-2.5"
               >
                 <div className="flex items-start gap-3">
                   <div className="min-w-0 flex-1">
@@ -384,7 +384,7 @@ function CreateAuditWebhookDialog({
                     key={preset.label}
                     type="button"
                     onClick={() => setActionPrefix(preset.prefix)}
-                    className={`rounded-md border px-2 py-0.5 text-[11px] transition-colors ${
+                    className={`rounded-2xl border px-2 py-0.5 text-[11px] transition-colors ${
                       actionPrefix === preset.prefix
                         ? 'border-primary bg-primary/10 text-foreground'
                         : 'border-border/60 text-muted-foreground hover:bg-muted/40'

--- a/apps/web/src/components/iam/mfa-required-card.tsx
+++ b/apps/web/src/components/iam/mfa-required-card.tsx
@@ -161,14 +161,14 @@ export function MfaRequiredCard({ accountId, canManage }: MfaRequiredCardProps) 
 
           <div className="space-y-3">
             {previewQuery.isLoading && (
-              <div className="rounded-md border border-border/60 px-3 py-3">
+              <div className="rounded-2xl border border-border/60 px-3 py-3">
                 <Skeleton className="h-4 w-3/4" />
                 <Skeleton className="mt-2 h-3 w-1/2" />
               </div>
             )}
 
             {previewQuery.data && previewQuery.data.will_lock_out_account && (
-              <div className="flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2.5 text-xs text-destructive">
+              <div className="flex items-start gap-2 rounded-2xl border border-destructive/30 bg-destructive/5 px-3 py-2.5 text-xs text-destructive">
                 <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
                 <p>
                   {tHardcodedUi.raw('componentsIamMfaRequiredCard.line185JsxTextNobodyWouldRetainAccessPromoteASuperAdmin')}</p>
@@ -176,7 +176,7 @@ export function MfaRequiredCard({ accountId, canManage }: MfaRequiredCardProps) 
             )}
 
             {previewQuery.data && !previewQuery.data.will_lock_out_account && (
-              <div className="rounded-md border border-border/60 bg-muted/20 px-3 py-2.5 text-xs text-muted-foreground">
+              <div className="rounded-2xl border border-border/60 bg-muted/20 px-3 py-2.5 text-xs text-muted-foreground">
                 <span className="font-medium text-foreground">
                   {previewQuery.data.members_with_mfa}
                 </span>{' '}
@@ -188,7 +188,7 @@ export function MfaRequiredCard({ accountId, canManage }: MfaRequiredCardProps) 
             )}
 
             {partitionedLosers.lockouts.length > 0 && (
-              <div className="rounded-md border border-amber-500/30 bg-amber-500/5 px-3 py-3 text-xs">
+              <div className="rounded-2xl border border-amber-500/30 bg-amber-500/5 px-3 py-3 text-xs">
                 <p className="mb-2 font-medium text-amber-700 dark:text-amber-400">
                   {partitionedLosers.lockouts.length}{' '}
                   {partitionedLosers.lockouts.length === 1 ? 'member' : 'members'} {tHardcodedUi.raw('componentsIamMfaRequiredCard.line208JsxTextWillBeLockedOutUntilTheyEnrolMFA')}</p>
@@ -209,7 +209,7 @@ export function MfaRequiredCard({ accountId, canManage }: MfaRequiredCardProps) 
             )}
 
             {partitionedLosers.exemptAdmins.length > 0 && (
-              <div className="rounded-md border border-border/60 bg-muted/20 px-3 py-3 text-xs">
+              <div className="rounded-2xl border border-border/60 bg-muted/20 px-3 py-3 text-xs">
                 <p className="mb-2 flex items-center gap-1.5 text-muted-foreground">
                   <Badge variant="outline" size="sm" className="text-[9px]">
                     exempt

--- a/apps/web/src/components/iam/permissions-help-popover.tsx
+++ b/apps/web/src/components/iam/permissions-help-popover.tsx
@@ -92,7 +92,7 @@ export function PermissionsHelpPopover({
           </p>
         </section>
 
-        <section className="space-y-1 rounded-md border border-amber-500/30 bg-amber-500/5 p-2.5">
+        <section className="space-y-1 rounded-2xl border border-amber-500/30 bg-amber-500/5 p-2.5">
           <h3 className="text-xs font-semibold text-amber-700 dark:text-amber-300">
             Override rule
           </h3>

--- a/apps/web/src/components/iam/scim-card.tsx
+++ b/apps/web/src/components/iam/scim-card.tsx
@@ -145,7 +145,7 @@ export function ScimCard({ accountId, canManage }: ScimCardProps) {
         )}
 
         {!tokensQuery.isLoading && tokens.length === 0 && (
-          <p className="rounded-md border border-dashed border-border/60 px-3 py-6 text-center text-xs text-muted-foreground">
+          <p className="rounded-2xl border border-dashed border-border/60 px-3 py-6 text-center text-xs text-muted-foreground">
             {tHardcodedUi.raw('componentsIamScimCard.line153JsxTextNoSCIMTokensYetCreateOneToConnect')}</p>
         )}
 
@@ -154,7 +154,7 @@ export function ScimCard({ accountId, canManage }: ScimCardProps) {
             {tokens.map((t) => (
               <li
                 key={t.token_id}
-                className="flex items-center gap-3 rounded-md border border-border/60 px-3 py-2.5"
+                className="flex items-center gap-3 rounded-2xl border border-border/60 px-3 py-2.5"
               >
                 <div className="min-w-0 flex-1">
                   <div className="flex items-center gap-2">

--- a/apps/web/src/components/iam/service-accounts-card.tsx
+++ b/apps/web/src/components/iam/service-accounts-card.tsx
@@ -356,7 +356,7 @@ function ShowBearerDialog({
             {tHardcodedUi.raw('componentsIamServiceAccountsCard.line362JsxTextThisIsTheOnlyTimeWeLlShow')}<strong>{bearer.name}</strong>{tHardcodedUi.raw('componentsIamServiceAccountsCard.line362JsxTextSSecretStoreItInYourSecretsManager')}</DialogDescription>
         </DialogHeader>
         <div className="space-y-3">
-          <div className="rounded-md border border-border/60 bg-muted/30 px-3 py-2 font-mono text-xs break-all">
+          <div className="rounded-2xl border border-border/60 bg-muted/30 px-3 py-2 font-mono text-xs break-all">
             {bearer.secret}
           </div>
           <div className="flex items-center justify-between gap-2">

--- a/apps/web/src/components/iam/session-controls-card.tsx
+++ b/apps/web/src/components/iam/session-controls-card.tsx
@@ -219,7 +219,7 @@ export function SessionControlsCard({ accountId, canManage }: SessionControlsCar
               muted={false}
             />
             {partitioned.revoked.length > 0 && (
-              <details className="rounded-md border border-border/60 px-3 py-2 text-xs">
+              <details className="rounded-2xl border border-border/60 px-3 py-2 text-xs">
                 <summary className="cursor-pointer text-muted-foreground">
                   {tHardcodedUi.raw('componentsIamSessionControlsCard.line233JsxTextRevokedExpired')}{partitioned.revoked.length})
                 </summary>

--- a/apps/web/src/components/kortix/new-ticket-dialog.tsx
+++ b/apps/web/src/components/kortix/new-ticket-dialog.tsx
@@ -448,7 +448,7 @@ function TicketForm({
               <select
                 value={milestoneId}
                 onChange={(e) => onMilestoneChange(e.target.value)}
-                className="w-full h-7 text-[12px] bg-transparent border border-border/50 rounded-md px-2 outline-none focus:ring-2 focus:ring-primary/20"
+                className="w-full h-7 text-[12px] bg-transparent border border-border/50 rounded-2xl px-2 outline-none focus:ring-2 focus:ring-primary/20"
               >
                 <option value="">{tHardcodedUi.raw('componentsKortixNewTicketDialog.line451JsxTextNone')}</option>
                 {milestones.map((m) => (
@@ -600,7 +600,7 @@ function StatusPicker({ columns, value, onChange }: { columns: TicketColumn[]; v
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
         <button
-          className="group w-full inline-flex items-center gap-2 h-8 px-2.5 rounded-lg border border-border/50 hover:border-border bg-card/60 hover:bg-muted/40 text-[12.5px] text-foreground transition-colors cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-primary/30"
+          className="group w-full inline-flex items-center gap-2 h-8 px-2.5 rounded-2xl border border-border/50 hover:border-border bg-card/60 hover:bg-muted/40 text-[12.5px] text-foreground transition-colors cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-primary/30"
           aria-label={`Status: ${selected.label}`}
         >
           {columnIcon(selected, false)}

--- a/apps/web/src/components/kortix/team-tab.tsx
+++ b/apps/web/src/components/kortix/team-tab.tsx
@@ -675,7 +675,7 @@ function ExecutionPicker({ value, onChange }: { value: ExecutionChoice; onChange
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <button className="group w-full inline-flex items-center gap-2 h-8 px-2.5 rounded-lg border border-border/50 hover:border-border bg-card/60 hover:bg-muted/40 text-[12.5px] text-foreground transition-colors cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-primary/30">
+        <button className="group w-full inline-flex items-center gap-2 h-8 px-2.5 rounded-2xl border border-border/50 hover:border-border bg-card/60 hover:bg-muted/40 text-[12.5px] text-foreground transition-colors cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-primary/30">
           <Zap className="h-3.5 w-3.5 text-muted-foreground/55" />
           <span className="flex-1 text-left truncate font-medium">{EXECUTION_LABELS[value]}</span>
           <ChevronDown className="h-3 w-3 text-muted-foreground/40 group-hover:text-foreground transition-colors" />
@@ -710,7 +710,7 @@ function RolePicker({ value, onChange }: { value: 'contributor' | 'orchestrator'
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <button className="group w-full inline-flex items-center gap-2 h-8 px-2.5 rounded-lg border border-border/50 hover:border-border bg-card/60 hover:bg-muted/40 text-[12.5px] text-foreground transition-colors cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-primary/30">
+        <button className="group w-full inline-flex items-center gap-2 h-8 px-2.5 rounded-2xl border border-border/50 hover:border-border bg-card/60 hover:bg-muted/40 text-[12.5px] text-foreground transition-colors cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-primary/30">
           <ShieldCheck className={cn('h-3.5 w-3.5', value === 'orchestrator' ? 'text-primary' : 'text-muted-foreground/55')} />
           <span className="flex-1 text-left truncate font-medium capitalize">{value}</span>
           <ChevronDown className="h-3 w-3 text-muted-foreground/40 group-hover:text-foreground transition-colors" />
@@ -760,7 +760,7 @@ function ModelPicker({ value, onChange }: { value: string; onChange: (v: string)
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <button className="group w-full inline-flex items-center gap-2 h-8 px-2.5 rounded-lg border border-border/50 hover:border-border bg-card/60 hover:bg-muted/40 text-[12.5px] text-foreground transition-colors cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-primary/30">
+        <button className="group w-full inline-flex items-center gap-2 h-8 px-2.5 rounded-2xl border border-border/50 hover:border-border bg-card/60 hover:bg-muted/40 text-[12.5px] text-foreground transition-colors cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-primary/30">
           <Cpu className={cn('h-3.5 w-3.5 shrink-0', value ? 'text-primary' : 'text-muted-foreground/55')} />
           <span className={cn('flex-1 text-left truncate', value ? 'font-medium' : 'text-muted-foreground/60')}>{label}</span>
           <ChevronDown className="h-3 w-3 text-muted-foreground/40 group-hover:text-foreground transition-colors" />
@@ -811,7 +811,7 @@ function ColumnPicker({ columns, value, onChange }: { columns: Array<{ key: stri
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <button className="group w-full inline-flex items-center gap-2 h-8 px-2.5 rounded-lg border border-border/50 hover:border-border bg-card/60 hover:bg-muted/40 text-[12.5px] text-foreground transition-colors cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-primary/30">
+        <button className="group w-full inline-flex items-center gap-2 h-8 px-2.5 rounded-2xl border border-border/50 hover:border-border bg-card/60 hover:bg-muted/40 text-[12.5px] text-foreground transition-colors cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-primary/30">
           <Cpu className="h-3.5 w-3.5 text-muted-foreground/55" />
           <span className="flex-1 text-left truncate font-medium">{label}</span>
           <ChevronDown className="h-3 w-3 text-muted-foreground/40 group-hover:text-foreground transition-colors" />

--- a/apps/web/src/components/kortix/ticket-detail-drawer.tsx
+++ b/apps/web/src/components/kortix/ticket-detail-drawer.tsx
@@ -382,7 +382,7 @@ function StatusPills({ columns, value, onChange }: { columns: TicketColumn[]; va
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
         <button
-          className="group w-full inline-flex items-center gap-2 h-8 px-2.5 rounded-lg border border-border/50 hover:border-border bg-card hover:bg-muted/40 text-[12.5px] text-foreground transition-colors cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-primary/30"
+          className="group w-full inline-flex items-center gap-2 h-8 px-2.5 rounded-2xl border border-border/50 hover:border-border bg-card hover:bg-muted/40 text-[12.5px] text-foreground transition-colors cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-primary/30"
         >
           {columnIcon(selected)}
           <span className="flex-1 text-left truncate font-medium">{selected.label}</span>
@@ -647,7 +647,7 @@ function MilestonePicker({
           setTicketMilestone.mutate({ projectId, ticketId, milestoneId: e.target.value || null })
         }
         disabled={setTicketMilestone.isPending}
-        className="w-full h-7 text-[12px] bg-transparent border border-border/50 rounded-md px-2 outline-none focus:ring-2 focus:ring-primary/20"
+        className="w-full h-7 text-[12px] bg-transparent border border-border/50 rounded-2xl px-2 outline-none focus:ring-2 focus:ring-primary/20"
       >
         <option value="">{tHardcodedUi.raw('componentsKortixTicketDetailDrawer.line647JsxTextNone')}</option>
         {milestones.filter((m) => m.status === 'open').map((m) => (

--- a/apps/web/src/components/kortix/ticket-settings-tab.tsx
+++ b/apps/web/src/components/kortix/ticket-settings-tab.tsx
@@ -492,7 +492,7 @@ function FieldsEditor({ projectId }: { projectId: string }) {
                 value={d.options.join(', ')}
                 onChange={(e) => patchAt(i, { options: e.target.value.split(',').map((s) => s.trim()).filter(Boolean) })}
                 placeholder={tHardcodedUi.raw('componentsKortixTicketSettingsTab.line494JsxAttrPlaceholderOptionsCommaSeparatedEGP0P1P2')}
-                className="mt-2 h-7 w-full text-[11.5px] bg-muted/20 border border-border/30 rounded-lg px-2.5 outline-none focus:ring-2 focus:ring-primary/20"
+                className="mt-2 h-7 w-full text-[11.5px] bg-muted/20 border border-border/30 rounded-2xl px-2.5 outline-none focus:ring-2 focus:ring-primary/20"
               />
             )}
           </div>

--- a/apps/web/src/components/layout/account-switcher.tsx
+++ b/apps/web/src/components/layout/account-switcher.tsx
@@ -142,7 +142,7 @@ export function AccountSwitcher({
       <SidebarMenuButton
         size="lg"
         className={cn(
-          'group/trigger relative h-auto gap-2 rounded-lg border border-transparent bg-transparent px-1.5 py-1',
+          'group/trigger relative h-auto gap-2 rounded-2xl border border-transparent bg-transparent px-1.5 py-1',
           'hover:bg-sidebar-accent/60 data-[state=open]:bg-sidebar-accent',
           'group-data-[collapsible=icon]:!gap-0 group-data-[collapsible=icon]:!justify-center group-data-[collapsible=icon]:!px-0',
         )}

--- a/apps/web/src/components/layout/project-switcher.tsx
+++ b/apps/web/src/components/layout/project-switcher.tsx
@@ -169,7 +169,7 @@ export function ProjectSwitcher({
       <SidebarMenuButton
         size="lg"
         className={cn(
-          'group/trigger relative h-auto gap-2 rounded-lg border border-transparent bg-transparent px-1.5 py-1',
+          'group/trigger relative h-auto gap-2 rounded-2xl border border-transparent bg-transparent px-1.5 py-1',
           'hover:bg-sidebar-accent/60 data-[state=open]:bg-sidebar-accent',
           'group-data-[collapsible=icon]:!gap-0 group-data-[collapsible=icon]:!justify-center group-data-[collapsible=icon]:!px-0',
         )}

--- a/apps/web/src/components/layout/user-menu.tsx
+++ b/apps/web/src/components/layout/user-menu.tsx
@@ -162,7 +162,7 @@ export function UserMenu({
       <SidebarMenuButton
         size="lg"
         className={cn(
-          'group/user relative h-auto gap-2 rounded-lg border border-transparent bg-transparent px-1.5 py-1',
+          'group/user relative h-auto gap-2 rounded-2xl border border-transparent bg-transparent px-1.5 py-1',
           'hover:bg-sidebar-accent/60 data-[state=open]:bg-sidebar-accent',
           'group-data-[collapsible=icon]:!gap-0 group-data-[collapsible=icon]:!justify-center group-data-[collapsible=icon]:!px-0',
         )}

--- a/apps/web/src/components/pages/admin/analytics/page.tsx
+++ b/apps/web/src/components/pages/admin/analytics/page.tsx
@@ -383,7 +383,7 @@ export default function AdminAnalyticsPage() {
                                 const total = Object.values(categoryDistribution.distribution).reduce((a, b) => a + b, 0);
                                 const percent = total > 0 ? ((count / total) * 100).toFixed(0) : 0;
                                 return (
-                                  <div key={cat} className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-background border">
+                                  <div key={cat} className="flex items-center gap-2 px-3 py-1.5 rounded-2xl bg-background border">
                                     <span className="text-sm font-medium">{cat}</span>
                                     <span className="text-xs text-muted-foreground">{count}</span>
                                     <span className="text-xs text-muted-foreground/70">({percent}%)</span>

--- a/apps/web/src/components/pages/workspace/page.tsx
+++ b/apps/web/src/components/pages/workspace/page.tsx
@@ -585,7 +585,7 @@ export default function WorkspacePage() {
               <select
                 value={kindFilter}
                 onChange={(e) => { setKindFilter(e.target.value as KindFilter); setScopeFilter('all'); }}
-                className="lg:hidden h-9 rounded-lg border border-input bg-card px-3 text-sm cursor-pointer"
+                className="lg:hidden h-9 rounded-2xl border border-input bg-card px-3 text-sm cursor-pointer"
               >
                 {kindTabs.map((tab) => (
                   <option key={tab.value} value={tab.value}>{tab.label} ({kindCounts[tab.value]})</option>

--- a/apps/web/src/components/projects/apps/app-form.tsx
+++ b/apps/web/src/components/projects/apps/app-form.tsx
@@ -177,7 +177,7 @@ export function AppForm({ projectId, existing, onDone }: AppFormProps) {
                   : 'Lowercase letters, digits, dashes. Auto-filled from the name.'}
               </p>
             </div>
-            <div className="flex items-center justify-between gap-3 rounded-lg border border-border/60 bg-muted/20 px-3 py-2.5">
+            <div className="flex items-center justify-between gap-3 rounded-2xl border border-border/60 bg-muted/20 px-3 py-2.5">
               <div className="flex flex-col">
                 <Label htmlFor="app-enabled" className="cursor-pointer">Enabled</Label>
                 <p className="text-xs text-muted-foreground">

--- a/apps/web/src/components/projects/apps/apps-list.tsx
+++ b/apps/web/src/components/projects/apps/apps-list.tsx
@@ -109,7 +109,7 @@ export function AppsList({ projectId, data, isLoading, onAdd, onEdit, onLogs }: 
       <div className="flex-1 overflow-y-auto px-5 py-4">
         <div className="mx-auto flex max-w-3xl flex-col gap-3">
           {errors.length > 0 && (
-            <div className="flex flex-col gap-2 rounded-lg border border-amber-500/40 bg-amber-500/5 px-4 py-3 text-xs text-amber-700 dark:text-amber-400">
+            <div className="flex flex-col gap-2 rounded-2xl border border-amber-500/40 bg-amber-500/5 px-4 py-3 text-xs text-amber-700 dark:text-amber-400">
               <p className="font-medium">Some entries in kortix.toml couldn&apos;t be parsed:</p>
               <ul className="list-disc pl-4">
                 {errors.map((err) => (
@@ -224,7 +224,7 @@ function AppCard({ app, busySlug, onDeploy, onStop, onLogs, onEdit, onDelete }: 
   const dep = app.latest_deployment;
 
   return (
-    <div className="flex flex-col gap-3 rounded-xl border border-border/60 bg-background px-4 py-3.5">
+    <div className="flex flex-col gap-3 rounded-2xl border border-border/60 bg-background px-4 py-3.5">
       <div className="flex items-start justify-between gap-3">
         <div className="flex min-w-0 flex-col gap-1">
           <div className="flex items-center gap-2">

--- a/apps/web/src/components/projects/customize/sections/changes-view.tsx
+++ b/apps/web/src/components/projects/customize/sections/changes-view.tsx
@@ -217,7 +217,7 @@ function ChangeRequestsTab({ onOpenDetail }: { onOpenDetail: (crId: string) => v
             return (
               <li
                 key={cr.cr_id}
-                className="group flex items-center gap-3 rounded-xl border border-border/60 bg-card px-3.5 py-3 transition-colors hover:border-foreground/20"
+                className="group flex items-center gap-3 rounded-2xl border border-border/60 bg-card px-3.5 py-3 transition-colors hover:border-foreground/20"
               >
                 <CrStatusIcon status={cr.status} />
                 <button
@@ -334,7 +334,7 @@ function VersionsTab({ projectId }: { projectId: string }) {
       {branches.map((b) => (
         <li
           key={b.name}
-          className="flex items-center gap-3 rounded-xl border border-border/60 bg-card px-3.5 py-3"
+          className="flex items-center gap-3 rounded-2xl border border-border/60 bg-card px-3.5 py-3"
         >
           <GitBranch className="h-4 w-4 shrink-0 text-muted-foreground" />
           <div className="min-w-0 flex-1">

--- a/apps/web/src/components/projects/customize/sections/secrets-view.tsx
+++ b/apps/web/src/components/projects/customize/sections/secrets-view.tsx
@@ -525,7 +525,7 @@ function SourceChooser({
   // Picking "Shared" is only meaningful if a shared value can reach the member.
   const sharedAvailable = row.sharedConfigured && row.usableByMe;
   return (
-    <div className="flex items-center rounded-lg border border-border/60 p-0.5">
+    <div className="flex items-center rounded-2xl border border-border/60 p-0.5">
       <button
         type="button"
         disabled={busy || !sharedAvailable}

--- a/apps/web/src/components/projects/project-create-modal.tsx
+++ b/apps/web/src/components/projects/project-create-modal.tsx
@@ -323,7 +323,7 @@ export function ProjectCreateModal({
                 />
               </div>
 
-              <div className="flex items-start justify-between gap-4 rounded-md border border-border/60 px-3 py-3">
+              <div className="flex items-start justify-between gap-4 rounded-2xl border border-border/60 px-3 py-3">
                 <div className="min-w-0 space-y-1">
                   <Label htmlFor="gkw-skills">
                     {tHardcodedUi.raw(

--- a/apps/web/src/components/projects/project-onboarding-wizard.tsx
+++ b/apps/web/src/components/projects/project-onboarding-wizard.tsx
@@ -567,7 +567,7 @@ function StepCard({
                 type="button"
                 onClick={() => onPickStarterPrompt(p)}
                 className={cn(
-                  'group relative flex cursor-pointer items-start gap-3 rounded-xl border bg-card/60 p-3 text-left',
+                  'group relative flex cursor-pointer items-start gap-3 rounded-2xl border bg-card/60 p-3 text-left',
                   'transition-all duration-150',
                   'hover:border-foreground/25 hover:bg-card hover:shadow-[0_1px_2px_rgba(0,0,0,0.04),0_8px_24px_-12px_rgba(0,0,0,0.18)]',
                   'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
@@ -653,7 +653,7 @@ function BusinessAppLogos({ onPick }: { onPick: () => void }) {
           title={app.name}
           aria-label={`Connect ${app.name}`}
           className={cn(
-            'group flex cursor-pointer flex-col items-center justify-center gap-1.5 rounded-xl border border-border/60 bg-card/60 px-2 py-3',
+            'group flex cursor-pointer flex-col items-center justify-center gap-1.5 rounded-2xl border border-border/60 bg-card/60 px-2 py-3',
             'transition-all duration-150',
             'hover:border-foreground/25 hover:bg-card hover:shadow-[0_1px_2px_rgba(0,0,0,0.04),0_8px_24px_-12px_rgba(0,0,0,0.18)]',
             'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',

--- a/apps/web/src/components/projects/project-provider-modal.tsx
+++ b/apps/web/src/components/projects/project-provider-modal.tsx
@@ -1000,7 +1000,7 @@ function ChatGptSubscriptionConnect({
         </div>
       </div>
       {(authInstructions || authUrl) && (
-        <div className="mt-3 rounded-xl border border-border/50 bg-background/70 p-3">
+        <div className="mt-3 rounded-2xl border border-border/50 bg-background/70 p-3">
           <div className="text-xs font-medium text-foreground">Complete authorization</div>
           {authUrl && (
             <Button
@@ -1017,12 +1017,12 @@ function ChatGptSubscriptionConnect({
           {deviceCode ? (
             <div className="mt-3">
               <div className="text-xs text-muted-foreground">Enter this code on the auth page:</div>
-              <div className="mt-1 w-fit rounded-lg border border-border/60 bg-muted px-3 py-2 font-mono text-lg font-semibold tracking-normal text-foreground">
+              <div className="mt-1 w-fit rounded-2xl border border-border/60 bg-muted px-3 py-2 font-mono text-lg font-semibold tracking-normal text-foreground">
                 {deviceCode}
               </div>
             </div>
           ) : authInstructions ? (
-            <pre className="mt-3 whitespace-pre-wrap rounded-lg border border-border/60 bg-muted p-3 text-xs text-muted-foreground">
+            <pre className="mt-3 whitespace-pre-wrap rounded-2xl border border-border/60 bg-muted p-3 text-xs text-muted-foreground">
               {authInstructions}
             </pre>
           ) : null}

--- a/apps/web/src/components/projects/sandbox-snapshot-card.tsx
+++ b/apps/web/src/components/projects/sandbox-snapshot-card.tsx
@@ -345,7 +345,7 @@ export function SandboxSnapshotCard({ projectId, canManage }: SandboxSnapshotCar
         )}
 
         {latestFailure && (
-          <div className="rounded-xl border border-destructive/30 bg-destructive/5 p-4">
+          <div className="rounded-2xl border border-destructive/30 bg-destructive/5 p-4">
             <div className="mb-1.5 flex flex-wrap items-center gap-2">
               <XCircle className="h-4 w-4 text-destructive" />
               <span className="text-sm font-semibold text-destructive">Latest build failed</span>

--- a/apps/web/src/components/projects/sandbox-template-form.tsx
+++ b/apps/web/src/components/projects/sandbox-template-form.tsx
@@ -227,7 +227,7 @@ export function SandboxTemplateForm({
                 type="button"
                 onClick={() => setMode('image')}
                 className={cn(
-                  'flex flex-col items-start gap-1 rounded-xl border border-border/60 p-3 text-left text-sm transition-colors',
+                  'flex flex-col items-start gap-1 rounded-2xl border border-border/60 p-3 text-left text-sm transition-colors',
                   mode === 'image' && 'border-foreground/30 bg-muted/40',
                 )}
               >
@@ -243,7 +243,7 @@ export function SandboxTemplateForm({
                 type="button"
                 onClick={() => setMode('dockerfile')}
                 className={cn(
-                  'flex flex-col items-start gap-1 rounded-xl border border-border/60 p-3 text-left text-sm transition-colors',
+                  'flex flex-col items-start gap-1 rounded-2xl border border-border/60 p-3 text-left text-sm transition-colors',
                   mode === 'dockerfile' && 'border-foreground/30 bg-muted/40',
                 )}
               >

--- a/apps/web/src/components/session/question-prompt.tsx
+++ b/apps/web/src/components/session/question-prompt.tsx
@@ -301,7 +301,7 @@ export const QuestionPrompt = React.forwardRef<QuestionPromptHandle, QuestionPro
 											setTab(i);
 										}}
 										className={cn(
-											"flex items-center gap-1 px-2 py-0.5 text-sm font-medium rounded-md border transition-colors duration-150 cursor-pointer whitespace-nowrap",
+											"flex items-center gap-1 px-2 py-0.5 text-sm font-medium rounded-2xl border transition-colors duration-150 cursor-pointer whitespace-nowrap",
 											tab === i
 												? "bg-background/80 text-foreground border-border/70"
 												: "text-muted-foreground border-transparent hover:text-foreground hover:bg-muted/70",
@@ -335,7 +335,7 @@ export const QuestionPrompt = React.forwardRef<QuestionPromptHandle, QuestionPro
 									setTab(questions.length);
 								}}
 							className={cn(
-								"px-2 py-0.5 text-sm font-medium rounded-md border transition-colors duration-150 cursor-pointer",
+								"px-2 py-0.5 text-sm font-medium rounded-2xl border transition-colors duration-150 cursor-pointer",
 								isConfirm
 									? "bg-background/80 text-foreground border-border/70"
 									: "text-muted-foreground border-transparent hover:text-foreground hover:bg-muted/70",

--- a/apps/web/src/components/session/session-chat-input.tsx
+++ b/apps/web/src/components/session/session-chat-input.tsx
@@ -955,7 +955,7 @@ function SlashCommandPopover({
               onSelect(cmd);
             }}
             className={cn(
-              'w-full flex flex-col gap-0.5 px-3 py-2 text-left transition-colors cursor-pointer border border-transparent rounded-md -mx-1',
+              'w-full flex flex-col gap-0.5 px-3 py-2 text-left transition-colors cursor-pointer border border-transparent rounded-2xl -mx-1',
               i === selectedIndex ? 'bg-muted border-border/50' : 'hover:bg-muted/50',
             )}
           >
@@ -2101,7 +2101,7 @@ export function SessionChatInput({
           {/* Staged command badge */}
           {stagedCommand && (
             <div className="flex items-center gap-2 px-4 pt-3 pb-0 min-w-0">
-              <div className="flex items-center gap-1.5 px-2.5 py-1 rounded-lg bg-muted/60 border border-border/50 shrink-0 max-w-full">
+              <div className="flex items-center gap-1.5 px-2.5 py-1 rounded-2xl bg-muted/60 border border-border/50 shrink-0 max-w-full">
                 <Terminal className="size-3 text-muted-foreground" />
                 <span className="font-mono text-xs font-medium text-foreground whitespace-nowrap max-w-[220px] sm:max-w-[320px] truncate">/{stagedCommand.name}</span>
                 <button

--- a/apps/web/src/components/session/session-chat.tsx
+++ b/apps/web/src/components/session/session-chat.tsx
@@ -3621,7 +3621,7 @@ function SessionTurn({
                   return (
                     <div key={part.id} className="flex items-center gap-2 py-2.5">
                       <div className="flex-1 h-px bg-border" />
-                      <div className="flex items-center gap-1.5 px-2.5 py-1 rounded-md bg-muted/80 border border-border/60">
+                      <div className="flex items-center gap-1.5 px-2.5 py-1 rounded-2xl bg-muted/80 border border-border/60">
                         <Layers className="size-3 text-muted-foreground" />
                         <span className="text-xs font-semibold text-muted-foreground tracking-wide">
                           Compaction
@@ -6080,7 +6080,7 @@ export function SessionChat({
                   <div className="space-y-3 mt-12">
                     <div className="flex items-center gap-3 py-4 my-3">
                       <div className="flex-1 h-px bg-border" />
-                      <div className="flex items-center gap-2 px-3 py-1.5 rounded-md bg-muted/80 border border-border/60">
+                      <div className="flex items-center gap-2 px-3 py-1.5 rounded-2xl bg-muted/80 border border-border/60">
                         <Layers className="size-3.5 text-muted-foreground" />
                         <span className="text-xs font-semibold text-muted-foreground tracking-wide">
                           Compaction
@@ -6130,7 +6130,7 @@ export function SessionChat({
                       {hasCompaction && (
                         <div className="flex items-center gap-3 py-4 my-3">
                           <div className="flex-1 h-px bg-border" />
-                          <div className="flex items-center gap-2 px-3 py-1.5 rounded-md bg-muted/80 border border-border/60">
+                          <div className="flex items-center gap-2 px-3 py-1.5 rounded-2xl bg-muted/80 border border-border/60">
                             <Layers className="size-3.5 text-muted-foreground" />
                             <span className="text-xs font-semibold text-muted-foreground tracking-wide">
                               Compaction

--- a/apps/web/src/components/session/session-files-version-banner.tsx
+++ b/apps/web/src/components/session/session-files-version-banner.tsx
@@ -187,7 +187,7 @@ export function SessionFilesVersionBanner({
           </p>
 
           {hasChanges && (
-            <div className="max-h-48 space-y-0.5 overflow-auto rounded-lg border border-border/40 bg-background/50 p-1">
+            <div className="max-h-48 space-y-0.5 overflow-auto rounded-2xl border border-border/40 bg-background/50 p-1">
               {changedFiles.map((file) => {
                 const badge = STATUS_BADGE[file.status] ?? STATUS_BADGE.modified;
                 const name = file.path.split('/').pop() || file.path;

--- a/apps/web/src/components/session/tool-renderers.tsx
+++ b/apps/web/src/components/session/tool-renderers.tsx
@@ -1795,7 +1795,7 @@ function GetMemTool({ part, defaultOpen, forceOpen, locked }: ToolProps) {
                           {report.filesRead.map((file) => (
                             <span
                               key={file}
-                              className="inline-flex items-center h-6 px-2 rounded-md text-xs font-mono bg-background border border-border/70 text-foreground/75 break-all"
+                              className="inline-flex items-center h-6 px-2 rounded-2xl text-xs font-mono bg-background border border-border/70 text-foreground/75 break-all"
                             >
                               {file}
                             </span>
@@ -8103,7 +8103,7 @@ function QuestionTool({
                         <div
                           key={j}
                           className={cn(
-                            'flex items-start gap-2 rounded-lg border px-2 py-1.5 text-xs transition-colors',
+                            'flex items-start gap-2 rounded-2xl border px-2 py-1.5 text-xs transition-colors',
                             picked
                               ? 'border-primary/30 bg-primary/5'
                               : 'border-transparent opacity-50',
@@ -8144,7 +8144,7 @@ function QuestionTool({
                     {customAnswers.map((a, k) => (
                       <div
                         key={`custom-${k}`}
-                        className="flex items-start gap-2 rounded-lg border border-primary/30 bg-primary/5 px-2 py-1.5 text-xs"
+                        className="flex items-start gap-2 rounded-2xl border border-primary/30 bg-primary/5 px-2 py-1.5 text-xs"
                       >
                         <span className={cn('mt-px flex-shrink-0', STATUS_TEXT.success)}>
                           <Check className="size-3.5" />
@@ -8156,7 +8156,7 @@ function QuestionTool({
                     ))}
                   </div>
                 ) : (
-                  <div className="rounded-lg border border-primary/30 bg-primary/5 px-2 py-1.5 text-sm font-medium text-foreground">
+                  <div className="rounded-2xl border border-primary/30 bg-primary/5 px-2 py-1.5 text-sm font-medium text-foreground">
                     {ans.length > 0 ? ans.join(', ') : '—'}
                   </div>
                 )}

--- a/apps/web/src/components/settings/user-settings-modal.tsx
+++ b/apps/web/src/components/settings/user-settings-modal.tsx
@@ -1614,7 +1614,7 @@ function TeamPlanSection({ accountState }: { accountState: AccountState | undefi
                 <p className="text-xs uppercase tracking-widest text-muted-foreground">Team plan</p>
                 <p className="text-xs text-muted-foreground/60">$20 / teammate / month</p>
             </div>
-            <div className="rounded-lg border bg-card p-4 space-y-3">
+            <div className="rounded-2xl border bg-card p-4 space-y-3">
                 <div>
                     <h3 className="text-sm font-semibold">Activate your seat</h3>
                     <p className="text-sm text-muted-foreground mt-1">

--- a/apps/web/src/components/sidebar/ssh-key-dialog.tsx
+++ b/apps/web/src/components/sidebar/ssh-key-dialog.tsx
@@ -106,7 +106,7 @@ function VisibleCodeBlock({ text, label, variant = 'default' }: {
   return (
     <div className="relative group cursor-pointer min-w-0 w-full" onClick={copy}>
       <pre className={cn(
-        'px-3 py-2.5 rounded-md text-xs font-mono border overflow-x-auto transition-colors leading-relaxed max-w-full whitespace-pre-wrap break-all',
+        'px-3 py-2.5 rounded-2xl text-xs font-mono border overflow-x-auto transition-colors leading-relaxed max-w-full whitespace-pre-wrap break-all',
         'bg-muted/40 border-border/50 hover:border-border',
         variant === 'green' ? 'text-emerald-400' : 'text-foreground/80',
       )}>
@@ -228,11 +228,11 @@ export function SSHResultView({ sshResult, copiedField, onCopy, onRegenerate, is
             <VisibleCodeBlock text={sshConfigCmd} label={tHardcodedUi.raw('componentsSidebarSshKeyDialog.line228JsxAttrLabelSshConfig')} variant="green" />
             <p className="text-xs text-muted-foreground leading-relaxed">
               Then{' '}
-              <kbd className="px-1 py-0.5 rounded-sm bg-muted border border-border/50 text-xs font-mono text-foreground/70">{tHardcodedUi.raw('componentsSidebarSshKeyDialog.line231JsxTextCmdShiftP')}</kbd>
+              <kbd className="px-1 py-0.5 rounded-2xl bg-muted border border-border/50 text-xs font-mono text-foreground/70">{tHardcodedUi.raw('componentsSidebarSshKeyDialog.line231JsxTextCmdShiftP')}</kbd>
               {' → '}
               <span className="text-foreground/70">{tHardcodedUi.raw('componentsSidebarSshKeyDialog.line233JsxTextRemoteSshConnectToHost')}</span>
               {' → '}
-              <code className="px-1 py-0.5 rounded-sm bg-muted border border-border/50 font-mono text-xs text-foreground/80">{sshResult.host_alias}</code>
+              <code className="px-1 py-0.5 rounded-2xl bg-muted border border-border/50 font-mono text-xs text-foreground/80">{sshResult.host_alias}</code>
             </p>
           </div>
 
@@ -392,7 +392,7 @@ export function SSHKeyDialog({ open, onOpenChange }: SSHKeyDialogProps) {
               <div className="rounded-2xl border border-border/50 p-3 space-y-2">
                 <p className="text-xs font-medium text-foreground/80">{tHardcodedUi.raw('componentsSidebarSshKeyDialog.line400JsxTextReconnectCommand')}</p>
                 <div className="flex items-center gap-2">
-                  <code className="flex-1 min-w-0 text-xs font-mono bg-muted/40 border border-border/50 rounded-md px-2.5 py-1.5 text-foreground/70 truncate select-all">
+                  <code className="flex-1 min-w-0 text-xs font-mono bg-muted/40 border border-border/50 rounded-2xl px-2.5 py-1.5 text-foreground/70 truncate select-all">
                     {sshMeta.ssh_command}
                   </code>
                   <InlineCopyButton text={sshMeta.ssh_command} label="Reconnect" />

--- a/apps/web/src/components/thread/content/sandbox-url-detector.tsx
+++ b/apps/web/src/components/thread/content/sandbox-url-detector.tsx
@@ -466,7 +466,7 @@ function SandboxUrlChip({
   const displayPath = detected.path !== '/' ? detected.path : '';
 
   return (
-    <div className="group/chip flex items-center gap-2 px-3 py-1.5 rounded-lg border border-border/40 bg-muted/15 hover:border-border/60 hover:bg-muted/25 transition-colors">
+    <div className="group/chip flex items-center gap-2 px-3 py-1.5 rounded-2xl border border-border/40 bg-muted/15 hover:border-border/60 hover:bg-muted/25 transition-colors">
       {/* Globe icon */}
       <Globe className="h-3.5 w-3.5 text-muted-foreground/50 shrink-0" />
 

--- a/apps/web/src/components/thread/tool-views/canvas-tool/CanvasToolView.tsx
+++ b/apps/web/src/components/thread/tool-views/canvas-tool/CanvasToolView.tsx
@@ -232,7 +232,7 @@ export function CanvasToolView({
         <div className="flex flex-row items-center justify-between">
           <div className="flex items-center gap-2">
             <div className={cn(
-              "relative p-2 rounded-lg border flex-shrink-0",
+              "relative p-2 rounded-2xl border flex-shrink-0",
               actionInfo.bgColor,
               actionInfo.borderColor
             )}>

--- a/apps/web/src/components/thread/tool-views/presentation-tools/FullScreenPresentationViewer.tsx
+++ b/apps/web/src/components/thread/tool-views/presentation-tools/FullScreenPresentationViewer.tsx
@@ -450,7 +450,7 @@ export function FullScreenPresentationViewer({
       <div className="flex-shrink-0 bg-white dark:bg-zinc-950 border-b border-zinc-200 dark:border-zinc-800">
         <div className="flex items-center justify-between p-4">
           <div className="flex items-center gap-3">
-            <div className="relative p-2 rounded-lg border flex-shrink-0 bg-zinc-200/60 dark:bg-zinc-900 border-zinc-300 dark:border-zinc-700">
+            <div className="relative p-2 rounded-2xl border flex-shrink-0 bg-zinc-200/60 dark:bg-zinc-900 border-zinc-300 dark:border-zinc-700">
               <Presentation className="w-5 h-5 text-zinc-500 dark:text-zinc-400" />
             </div>
             

--- a/apps/web/src/components/thread/tool-views/presentation-tools/PresentationViewer.tsx
+++ b/apps/web/src/components/thread/tool-views/presentation-tools/PresentationViewer.tsx
@@ -715,7 +715,7 @@ export function PresentationViewer({
       {showHeader && <CardHeader className="h-14 bg-zinc-50/80 dark:bg-zinc-900/80 backdrop-blur-sm border-b p-2 px-4 space-y-2">
         <div className="flex flex-row items-center justify-between">
           <div className="flex items-center gap-2">
-            <div className="relative p-2 rounded-lg border flex-shrink-0 bg-zinc-200/60 dark:bg-zinc-900 border-zinc-300 dark:border-zinc-700">
+            <div className="relative p-2 rounded-2xl border flex-shrink-0 bg-zinc-200/60 dark:bg-zinc-900 border-zinc-300 dark:border-zinc-700">
               <Presentation className="w-5 h-5 text-zinc-500 dark:text-zinc-400" />
             </div>
             <div className="flex items-center gap-2">

--- a/apps/web/src/components/thread/tool-views/spreadsheet/SpreadsheetToolview.tsx
+++ b/apps/web/src/components/thread/tool-views/spreadsheet/SpreadsheetToolview.tsx
@@ -92,7 +92,7 @@ export function SpreadsheetToolView({
       <CardHeader className="h-14 bg-zinc-50/80 dark:bg-zinc-900/80 backdrop-blur-sm border-b p-2 px-4 space-y-2">
         <div className="flex flex-row items-center justify-between">
           <div className="flex items-center gap-2">
-            <div className="relative p-2 rounded-lg border flex-shrink-0 bg-zinc-100 dark:bg-zinc-800 border-zinc-200 dark:border-zinc-700">
+            <div className="relative p-2 rounded-2xl border flex-shrink-0 bg-zinc-100 dark:bg-zinc-800 border-zinc-200 dark:border-zinc-700">
               {isStreaming || isLoading ? (
                 <KortixLoader customSize={20} />
               ) : (

--- a/apps/web/src/components/tunnel/scope-editors/filesystem-scope-editor.tsx
+++ b/apps/web/src/components/tunnel/scope-editors/filesystem-scope-editor.tsx
@@ -109,7 +109,7 @@ export function FilesystemScopeEditor({ scope, onChange }: FilesystemScopeEditor
             onChange={(e) => setPathInput(e.target.value)}
             onKeyDown={(e) => e.key === 'Enter' && (e.preventDefault(), addPath())}
             placeholder="/home/user/projects"
-            className="flex-1 rounded-lg border bg-background px-2.5 py-1.5 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/20"
+            className="flex-1 rounded-2xl border bg-background px-2.5 py-1.5 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/20"
           />
           <Button variant="outline" size="sm" onClick={addPath} disabled={!pathInput.trim()}>
             <Plus className="h-3.5 w-3.5" />
@@ -145,7 +145,7 @@ export function FilesystemScopeEditor({ scope, onChange }: FilesystemScopeEditor
                 onChange={(e) => setExcludeInput(e.target.value)}
                 onKeyDown={(e) => e.key === 'Enter' && (e.preventDefault(), addExclude())}
                 placeholder={tHardcodedUi.raw('componentsTunnelScopeEditorsFilesystemScopeEditor.line146JsxAttrPlaceholderNodeModules')}
-                className="flex-1 rounded-lg border bg-background px-2.5 py-1.5 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/20"
+                className="flex-1 rounded-2xl border bg-background px-2.5 py-1.5 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/20"
               />
               <Button variant="outline" size="sm" onClick={addExclude} disabled={!excludeInput.trim()}>
                 <Plus className="h-3.5 w-3.5" />

--- a/apps/web/src/components/tunnel/scope-editors/network-scope-editor.tsx
+++ b/apps/web/src/components/tunnel/scope-editors/network-scope-editor.tsx
@@ -94,7 +94,7 @@ export function NetworkScopeEditor({ scope, onChange }: NetworkScopeEditorProps)
             onChange={(e) => setPortInput(e.target.value)}
             onKeyDown={(e) => e.key === 'Enter' && (e.preventDefault(), addPort())}
             placeholder={tHardcodedUi.raw('componentsTunnelScopeEditorsNetworkScopeEditor.line93JsxAttrPlaceholderEG30008080')}
-            className="w-[140px] rounded-lg border bg-background px-2.5 py-1.5 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/20"
+            className="w-[140px] rounded-2xl border bg-background px-2.5 py-1.5 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/20"
           />
           <Button variant="outline" size="sm" onClick={addPort} disabled={!portInput.trim()}>
             <Plus className="h-3.5 w-3.5" />
@@ -124,7 +124,7 @@ export function NetworkScopeEditor({ scope, onChange }: NetworkScopeEditorProps)
             onChange={(e) => setHostInput(e.target.value)}
             onKeyDown={(e) => e.key === 'Enter' && (e.preventDefault(), addHost())}
             placeholder={tHardcodedUi.raw('componentsTunnelScopeEditorsNetworkScopeEditor.line123JsxAttrPlaceholderEGLocalhost127001')}
-            className="flex-1 rounded-lg border bg-background px-2.5 py-1.5 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/20"
+            className="flex-1 rounded-2xl border bg-background px-2.5 py-1.5 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/20"
           />
           <Button variant="outline" size="sm" onClick={addHost} disabled={!hostInput.trim()}>
             <Plus className="h-3.5 w-3.5" />

--- a/apps/web/src/components/tunnel/scope-editors/shell-scope-editor.tsx
+++ b/apps/web/src/components/tunnel/scope-editors/shell-scope-editor.tsx
@@ -66,7 +66,7 @@ export function ShellScopeEditor({ scope, onChange }: ShellScopeEditorProps) {
             onChange={(e) => setCommandInput(e.target.value)}
             onKeyDown={(e) => e.key === 'Enter' && (e.preventDefault(), addCommand())}
             placeholder={tHardcodedUi.raw('componentsTunnelScopeEditorsShellScopeEditor.line65JsxAttrPlaceholderEGGitNodePython')}
-            className="flex-1 rounded-lg border bg-background px-2.5 py-1.5 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/20"
+            className="flex-1 rounded-2xl border bg-background px-2.5 py-1.5 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/20"
           />
           <Button variant="outline" size="sm" onClick={() => addCommand()} disabled={!commandInput.trim()}>
             <Plus className="h-3.5 w-3.5" />
@@ -97,7 +97,7 @@ export function ShellScopeEditor({ scope, onChange }: ShellScopeEditorProps) {
           value={scope.workingDir || ''}
           onChange={(e) => onChange({ ...scope, workingDir: e.target.value || undefined })}
           placeholder={tHardcodedUi.raw('componentsTunnelScopeEditorsShellScopeEditor.line96JsxAttrPlaceholderHomeUserProjectOptional')}
-          className="w-full rounded-lg border bg-background px-2.5 py-1.5 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/20"
+          className="w-full rounded-2xl border bg-background px-2.5 py-1.5 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/20"
         />
       </div>
 

--- a/apps/web/src/components/ui/chart.tsx
+++ b/apps/web/src/components/ui/chart.tsx
@@ -189,7 +189,7 @@ function ChartTooltipContent({
   return (
     <div
       className={cn(
-        "border-border/50 bg-background grid min-w-[8rem] items-start gap-1.5 rounded-lg border px-2.5 py-1.5 text-xs shadow-xl",
+        "border-border/50 bg-background grid min-w-[8rem] items-start gap-1.5 rounded-2xl border px-2.5 py-1.5 text-xs shadow-xl",
         className
       )}
     >

--- a/apps/web/src/features/files/components/file-explorer-page.tsx
+++ b/apps/web/src/features/files/components/file-explorer-page.tsx
@@ -585,7 +585,7 @@ export function FileExplorerPage() {
                   if (e.key === 'Escape') { setIsCreatingFolder(false); setNewFolderName(''); }
                 }}
                 onBlur={handleCreateFolder}
-                className="flex-1 text-sm bg-transparent border border-border rounded-lg px-3 py-1.5 outline-none focus:ring-1 focus:ring-primary"
+                className="flex-1 text-sm bg-transparent border border-border rounded-2xl px-3 py-1.5 outline-none focus:ring-1 focus:ring-primary"
                 placeholder={tHardcodedUi.raw('featuresFilesComponentsFileExplorerPage.line603JsxAttrPlaceholderFolderName')}
               />
             </div>
@@ -603,7 +603,7 @@ export function FileExplorerPage() {
                   if (e.key === 'Escape') { setIsCreatingFile(false); setNewFileName(''); }
                 }}
                 onBlur={handleCreateFile}
-                className="flex-1 text-sm bg-transparent border border-border rounded-lg px-3 py-1.5 outline-none focus:ring-1 focus:ring-primary"
+                className="flex-1 text-sm bg-transparent border border-border rounded-2xl px-3 py-1.5 outline-none focus:ring-1 focus:ring-primary"
                 placeholder={tHardcodedUi.raw('featuresFilesComponentsFileExplorerPage.line621JsxAttrPlaceholderFileName')}
               />
             </div>

--- a/apps/web/src/features/project-files/components/file-explorer-page.tsx
+++ b/apps/web/src/features/project-files/components/file-explorer-page.tsx
@@ -591,7 +591,7 @@ export function FileExplorerPage() {
                   if (e.key === 'Escape') { setIsCreatingFolder(false); setNewFolderName(''); }
                 }}
                 onBlur={handleCreateFolder}
-                className="flex-1 text-sm bg-transparent border border-border rounded-lg px-3 py-1.5 outline-none focus:ring-1 focus:ring-primary"
+                className="flex-1 text-sm bg-transparent border border-border rounded-2xl px-3 py-1.5 outline-none focus:ring-1 focus:ring-primary"
                 placeholder={tHardcodedUi.raw('featuresProjectFilesComponentsFileExplorerPage.line594JsxAttrPlaceholderFolderName')}
               />
             </div>
@@ -609,7 +609,7 @@ export function FileExplorerPage() {
                   if (e.key === 'Escape') { setIsCreatingFile(false); setNewFileName(''); }
                 }}
                 onBlur={handleCreateFile}
-                className="flex-1 text-sm bg-transparent border border-border rounded-lg px-3 py-1.5 outline-none focus:ring-1 focus:ring-primary"
+                className="flex-1 text-sm bg-transparent border border-border rounded-2xl px-3 py-1.5 outline-none focus:ring-1 focus:ring-primary"
                 placeholder={tHardcodedUi.raw('featuresProjectFilesComponentsFileExplorerPage.line612JsxAttrPlaceholderFileName')}
               />
             </div>


### PR DESCRIPTION
## What & why

The Kortix design system allows exactly **two** radii on chrome: containers are `rounded-2xl`, pills are `rounded-full`. A bunch of hand-rolled boxes had drifted to `rounded-sm/md/lg/xl` because they bypassed the `Card`/`SectionCard`/`InfoBanner` primitives (which already default to `rounded-2xl`) and used the shadcn default radius instead. Nothing caught it in review, so it accumulated.

Spotted while reviewing the **New project** modal (the "starter skills" box was `rounded-md`); turned out to be a codebase-wide pattern.

## Changes

**1. Stop the bleeding — ESLint guard**
New self-contained flat-config rule `kortix-ds/no-hardcoded-container-radius` (severity `error`). It flags a className string only when it has all three of: a non-2xl radius + a `border` + padding. The triple condition keeps sanctioned sub-element radii quiet (menu/list highlight rows, avatars, kbd keys, swatches — none carry border+padding), and genuine edge cases can opt out with an inline `eslint-disable`.

**2. Fix all existing violations**
107 container radii across 56 files normalized to `rounded-2xl` (projects flow, iam, billing, accounts, kortix, session, sidebar, tunnel, file-renderers, layout switchers, the `/design-system` styleguide page itself, and the `ui/chart.tsx` tooltip primitive). Every edit is a one-token swap — no structural or behavioral change.

## Verification

- Rule reports **0 remaining** violations across `src`
- **0** ESLint parse errors introduced
- All diffs are pure `className` string changes

## Follow-ups (intentionally not in this PR)

- Several fixed boxes are also hand-rolled **colored note boxes** (e.g. the amber warning div in `mfa-required-card.tsx`) that should become `InfoBanner` — a separate colored-chrome violation, riskier to auto-change.
- A few full-width row-buttons sit at `rounded-2xl` where `rounded-full` could be reviewed.