### PR TITLE
Add dedupe helper (PR-bot demo)

### DIFF
--- a/scripts/examples/dedupe.ts
+++ b/scripts/examples/dedupe.ts
@@ -1,0 +1,20 @@
+// Small example utility used to demo the Kortix PR-bot review pipeline.
+// Returns the input list with duplicate string values removed, preserving
+// first-seen order.
+
+export function dedupe(items: string[]): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < items.length; i++) {
+    let seen = false;
+    for (let j = 0; j < out.length; j++) {
+      if (out[j] === items[i]) {
+        seen = true;
+        break;
+      }
+    }
+    if (!seen) {
+      out.push(items[i]);
+    }
+  }
+  return out;
+}


### PR DESCRIPTION
Small example utility to demo the Kortix PR-bot. Removes duplicate strings preserving first-seen order. Safe to close after the bot reviews it.