### PR TITLE
fix: unblock dev deploys — manifest-schema in API image + icon-pack Vercel pin

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -60,6 +60,7 @@ COPY packages/shared ./packages/shared
 COPY packages/db ./packages/db
 COPY packages/agent-tunnel ./packages/agent-tunnel
 COPY packages/starter ./packages/starter
+COPY packages/manifest-schema ./packages/manifest-schema
 
 # Install pnpm and deps for this app + workspace packages it depends on.
 # --shamefully-hoist flattens node_modules (no symlinks) so COPY works on all Docker versions.
@@ -104,6 +105,9 @@ COPY --from=deps /app/packages/agent-tunnel/package.json ./packages/agent-tunnel
 COPY --from=deps /app/packages/starter/src ./packages/starter/src
 COPY --from=deps /app/packages/starter/package.json ./packages/starter/package.json
 COPY --from=deps /app/packages/starter/tsconfig.json ./packages/starter/tsconfig.json
+COPY --from=deps /app/packages/manifest-schema/src ./packages/manifest-schema/src
+COPY --from=deps /app/packages/manifest-schema/package.json ./packages/manifest-schema/package.json
+COPY --from=deps /app/packages/manifest-schema/tsconfig.json ./packages/manifest-schema/tsconfig.json
 
 # Copy SQL migrations used by ensureSchema() at runtime.
 COPY supabase/migrations ./supabase/migrations

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "packageManager": "pnpm@8.11.0",
   "pnpm": {
     "overrides": {
+      "@icons-pack/react-simple-icons@>=13.11.2 <14": "13.11.1",
       "next@>=15.0.0 <15.5.18": "15.5.18",
       "axios@>=1.0.0 <1.15.2": "1.15.2",
       "protobufjs@>=7.0.0 <7.5.6": "7.5.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  '@icons-pack/react-simple-icons@>=13.11.2 <14': 13.11.1
   next@>=15.0.0 <15.5.18: 15.5.18
   axios@>=1.0.0 <1.15.2: 1.15.2
   protobufjs@>=7.0.0 <7.5.6: 7.5.6
@@ -587,8 +588,8 @@ importers:
         specifier: ^1.1.4
         version: 1.1.5(react@18.3.1)
       '@icons-pack/react-simple-icons':
-        specifier: ^13.7.0
-        version: 13.11.2(react@18.3.1)
+        specifier: 13.11.1
+        version: 13.11.1(react@18.3.1)
       '@kortix/shared':
         specifier: workspace:*
         version: link:../../packages/shared
@@ -5111,9 +5112,8 @@ packages:
       mlly: 1.8.0
     dev: false
 
-  /@icons-pack/react-simple-icons@13.11.2(react@18.3.1):
-    resolution: {integrity: sha512-IiYWH7Dlp4HvTxsL9Mh/1tjKKhLikKzL+578H1ngQkoREhfXaS9yNl1SXkjNGEAYqNH2w5/tBQc0uXLWAkcSFA==}
-    engines: {node: '>=24', pnpm: '>=10'}
+  /@icons-pack/react-simple-icons@13.11.1(react@18.3.1):
+    resolution: {integrity: sha512-WbwN/o7dUHEjDCJh2p3RvDZ4kZ8nhfUSkUSm0bWuPTXIsoKgDJpwD5UkMCG22R/5kZH6lHAZXwuHWsKNtX7fYA==}
     peerDependencies:
       react: ^16.13 || ^17 || ^18 || ^19
     dependencies:


### PR DESCRIPTION
Two fixes that unblock dev.kortix.com (Vercel) and dev-api.kortix.com (AWS VPS Docker), both verified locally.

### 1. `fix(api)`: copy @kortix/manifest-schema into the API Docker build
`apps/api` depends on `@kortix/manifest-schema` (`workspace:*`) but `apps/api/Dockerfile` never copied `packages/manifest-schema` into the deps stage → `pnpm install` fails with `ERR_PNPM_WORKSPACE_PKG_NOT_FOUND` and the dev API image never builds. Latent since the package was added — dev deploys were gated off (`AUTO_DEPLOY_DEV=false`) so it was never exercised; the cutover's manual deploy surfaced it. Mirrors the shared/db/starter copy pattern. **Verified: full `apps/api` image builds and `@kortix/manifest-schema` resolves at runtime in the container.**

### 2. `fix(deps)`: pin @icons-pack/react-simple-icons to 13.11.1
13.11.2+ declares `engines: {node:>=24, pnpm:>=10}`. Vercel builds dev.kortix.com with Node 20 / pnpm 8 and our root `.npmrc` sets `engine-strict=true`, so `pnpm install` fails on Vercel (CI dodges it via `engine-strict=false`). 13.11.1 is the last release without the constraint; one usage, identical API. Pinned via `pnpm.overrides`.

### Verified locally (matches CI)
- `pnpm@8.11.0 install --frozen-lockfile` ✅ (api + web)
- Full `docker build apps/api` ✅