### PR TITLE
fix(web): build dev.kortix.com on Node 22 (Vercel)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -277,5 +277,8 @@
     "tw-animate-css": "^1.2.4",
     "typescript": "^5",
     "vscode-jsonrpc": "8.2.0"
+  },
+  "engines": {
+    "node": "22.x"
   }
 }


### PR DESCRIPTION
Sets `engines.node=22.x` in `apps/web/package.json` so Vercel builds dev.kortix.com on Node 22.

After the react-simple-icons pin (#3231), the Vercel build hit the next engine wall: `camera-controls@3.1.2` requires `node>=22` but Vercel defaulted to Node 20, and our root `.npmrc` has `engine-strict=true`. Vercel reads `engines.node` from the project package.json to choose the build's Node version. 22.x is Vercel-supported and satisfies every `>=22` dep in the tree (only camera-controls today). CI and the API Docker build already run Node 22.

**Verifying via this PR's Vercel preview check** — if it builds green, dev.kortix.com is unblocked.