### PR TITLE
fix(web): brand-correct container radius in ErrorDetails (unblock dev.kortix.com)

### DIFF
--- a/apps/web/src/components/common/error-details.tsx
+++ b/apps/web/src/components/common/error-details.tsx
@@ -11,7 +11,7 @@ export function ErrorDetails({ error }: { error: Error & { digest?: string } }) 
   const stack = (error.stack || '').split('\n').slice(0, 6).join('\n').trim();
 
   return (
-    <div className="w-full max-w-md rounded-xl border border-border bg-muted/30 p-3 text-left">
+    <div className="w-full max-w-md rounded-2xl border border-border bg-muted/30 p-3 text-left">
       <div className="mb-1 flex items-baseline justify-between gap-2">
         <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/70">
           Error
@@ -27,7 +27,7 @@ export function ErrorDetails({ error }: { error: Error & { digest?: string } }) 
           <summary className="cursor-pointer select-none text-[10px] uppercase tracking-wide text-muted-foreground/60 outline-none">
             Stack
           </summary>
-          <pre className="mt-1.5 max-h-36 overflow-auto whitespace-pre-wrap break-words rounded-md border border-border/60 bg-background/60 p-2 font-mono text-[10px] leading-relaxed text-muted-foreground">
+          <pre className="mt-1.5 max-h-36 overflow-auto whitespace-pre-wrap break-words rounded-2xl border border-border/60 bg-background/60 p-2 font-mono text-[10px] leading-relaxed text-muted-foreground">
             {stack}
           </pre>
         </details>


### PR DESCRIPTION
next build runs ESLint; kortix-ds/no-hardcoded-container-radius failed the Vercel build for dev.kortix.com on src/components/common/error-details.tsx (outer card rounded-xl, stack pre rounded-md). Both → rounded-2xl (brand container radius). This was the last error after the Node 22 fix — `next lint` now passes on the file; the other 38 lint findings are warnings (non-blocking).