### PR TITLE
infra(terraform): codify dev API host (Lightsail), adopt live box

### DIFF
--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -1,0 +1,61 @@
+# Kortix Infrastructure (Terraform)
+
+Infrastructure-as-code for the Kortix API hosting. Each environment is a
+separate root module under `environments/` with its own state.
+
+```
+infra/terraform/
+  modules/
+    api-host/          # reusable: a Lightsail box that serves the kortix-api
+  environments/
+    dev/               # dev-api.kortix.com  (Lightsail kortix-dev, us-west-2)
+    prod/              # prod (api.kortix.com) — added after dev is proven
+```
+
+## Why Lightsail (today) → ECS (later)
+
+The dev + prod APIs currently run as Docker containers on AWS **Lightsail**
+instances behind nginx (blue/green on ports 8008/8009), deployed over SSH by
+`.github/workflows/deploy-dev.yml` / `release.yml`. This Terraform **adopts the
+existing live boxes** (via `terraform import`) so the infra is reproducible and
+the nginx/keepalive config can't be lost on a rebuild — it does NOT recreate
+them. The longer-term SOC2 target (autoscaling, no OS to patch) is ECS Fargate
++ ALB; that migration is a separate environment module added once dev is stable.
+
+## State
+
+State lives in S3 (`kortix-terraform-state`) with a DynamoDB lock table
+(`kortix-terraform-locks`), both in us-west-2 — see `environments/*/backend.tf`.
+Bootstrap once with `bash scripts/bootstrap-state.sh` (creates the bucket +
+table if absent), then `terraform init`.
+
+## Usage
+
+```bash
+cd infra/terraform/environments/dev
+terraform init
+terraform plan      # should show NO changes against the live box
+terraform apply     # only after a clean plan
+```
+
+## Importing the existing dev box (one-time)
+
+Already-running resources are adopted, never recreated:
+
+```bash
+cd infra/terraform/environments/dev
+bash import.sh      # imports the Lightsail instance, static IP, attachment, ports
+terraform plan      # confirm parity (empty/near-empty diff)
+```
+
+## What is NOT in Terraform (yet)
+
+- **Cloudflare DNS** (`dev-api.kortix.com` → box IP, orange-cloud) — needs a
+  `CLOUDFLARE_API_TOKEN`; wired as an optional module, disabled until the token
+  is provided as `TF_VAR_cloudflare_api_token`.
+- **The Vercel frontend** (dev.kortix.com) — managed by Vercel's own GitHub
+  integration, not Terraform.
+- **In-box provisioning** (nginx config, Docker, deploy scripts) — currently
+  applied via `cloud-init`/user-data is NOT retroactively settable on a running
+  Lightsail box; the canonical nginx config is committed at
+  `modules/api-host/files/nginx-kortix-api.conf` so a rebuild restores it.

--- a/infra/terraform/environments/dev/backend.tf
+++ b/infra/terraform/environments/dev/backend.tf
@@ -1,0 +1,15 @@
+# Remote state in S3 with DynamoDB locking. Run scripts/bootstrap-state.sh once
+# to create the bucket + lock table, then `terraform init -migrate-state`.
+#
+# Until bootstrapped, this block can be left commented to use local state for
+# the initial import/validation, then uncommented + migrated.
+
+terraform {
+  backend "s3" {
+    bucket         = "kortix-terraform-state"
+    key            = "dev/api-host.tfstate"
+    region         = "us-west-2"
+    dynamodb_table = "kortix-terraform-locks"
+    encrypt        = true
+  }
+}

--- a/infra/terraform/environments/dev/import.sh
+++ b/infra/terraform/environments/dev/import.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# One-time: adopt the already-running dev Lightsail box into Terraform state.
+# Safe to re-run — `terraform import` is a no-op for already-imported resources.
+set -euo pipefail
+cd "$(dirname "$0")"
+
+terraform init -input=false
+
+imp() {  # imp <address> <id>
+  if terraform state list 2>/dev/null | grep -qx "$1"; then
+    echo "  already imported: $1"
+  else
+    echo "  importing: $1  ($2)"
+    terraform import "$1" "$2"
+  fi
+}
+
+# Lightsail resource IDs are just their names.
+imp 'module.api_host.aws_lightsail_instance.this'             'kortix-dev'
+imp 'module.api_host.aws_lightsail_static_ip.this'            'kortix-dev-ip'
+imp 'module.api_host.aws_lightsail_static_ip_attachment.this' 'kortix-dev-ip'
+imp 'module.api_host.aws_lightsail_instance_public_ports.this' 'kortix-dev'
+
+echo
+echo "Done. Now run:  terraform plan   (expect a near-empty diff)"

--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -1,0 +1,34 @@
+# ── dev environment ──────────────────────────────────────────────────────────
+# dev-api.kortix.com — the Lightsail box "kortix-dev" in us-west-2.
+# Adopts the existing live instance (see import.sh); does not recreate it.
+
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+module "api_host" {
+  source = "../../modules/api-host"
+
+  instance_name     = "kortix-dev"
+  availability_zone = "us-west-2a"
+  blueprint_id      = "ubuntu_24_04"
+  bundle_id         = "small_3_0"
+  key_pair_name     = "kortix-lightsail"
+  static_ip_name    = "kortix-dev-ip"
+
+  tags = {
+    Environment = "dev"
+    Service     = "kortix-api"
+    ManagedBy   = "terraform"
+  }
+}

--- a/infra/terraform/environments/dev/outputs.tf
+++ b/infra/terraform/environments/dev/outputs.tf
@@ -1,0 +1,8 @@
+output "public_ip" {
+  description = "dev-api.kortix.com origin IP."
+  value       = module.api_host.public_ip
+}
+
+output "instance_name" {
+  value = module.api_host.instance_name
+}

--- a/infra/terraform/environments/dev/variables.tf
+++ b/infra/terraform/environments/dev/variables.tf
@@ -1,0 +1,5 @@
+variable "aws_region" {
+  description = "AWS region for the dev Lightsail resources."
+  type        = string
+  default     = "us-west-2"
+}

--- a/infra/terraform/modules/api-host/files/nginx-kortix-api.conf
+++ b/infra/terraform/modules/api-host/files/nginx-kortix-api.conf
@@ -1,0 +1,53 @@
+map $http_origin $cors_origin {
+    default "";
+    "https://dev.kortix.com" $http_origin;
+    "https://dev-new.kortix.com" $http_origin;
+    "https://kortix.com" $http_origin;
+    "https://www.kortix.com" $http_origin;
+}
+
+# Per-request Connection header for upstream: only "upgrade" for real WebSocket
+# requests, otherwise empty so nginx manages keepalive itself. Hardcoding
+# "upgrade" on every request half-upgrades plain HTTP connections, which Bun
+# then resets — the source of the intermittent 502s.
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      "";
+}
+
+upstream kortix_api {
+    server 127.0.0.1:8008;
+    keepalive 32;
+}
+
+server {
+    listen 443 ssl;
+    server_name _;
+
+    ssl_certificate /etc/nginx/ssl/cf-origin-cert.pem;
+    ssl_certificate_key /etc/nginx/ssl/cf-origin-key.pem;
+
+    location / {
+        proxy_pass http://kortix_api;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+        proxy_read_timeout 86400;
+
+        # Hide app CORS headers - nginx will set them uniformly
+        proxy_hide_header Access-Control-Allow-Origin;
+        proxy_hide_header Access-Control-Allow-Credentials;
+        proxy_hide_header Access-Control-Allow-Methods;
+        proxy_hide_header Access-Control-Allow-Headers;
+
+        # Set CORS once from nginx on ALL responses
+        add_header Access-Control-Allow-Origin $cors_origin always;
+        add_header Access-Control-Allow-Credentials true always;
+        add_header Access-Control-Allow-Methods "GET, POST, PUT, DELETE, PATCH, OPTIONS" always;
+        add_header Access-Control-Allow-Headers "Authorization, Content-Type, X-Requested-With, Accept, Origin, Cookie, X-Preview-Token" always;
+    }
+}

--- a/infra/terraform/modules/api-host/main.tf
+++ b/infra/terraform/modules/api-host/main.tf
@@ -1,0 +1,50 @@
+# ── api-host ─────────────────────────────────────────────────────────────────
+# A single Lightsail instance that runs the kortix-api Docker container(s)
+# behind nginx (blue/green on 8008/8009). Mirrors the hand-built dev box so
+# Terraform can adopt it via import without recreating it.
+
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}
+
+resource "aws_lightsail_instance" "this" {
+  name              = var.instance_name
+  availability_zone = var.availability_zone
+  blueprint_id      = var.blueprint_id
+  bundle_id         = var.bundle_id
+  key_pair_name     = var.key_pair_name
+  tags              = var.tags
+
+  # The instance is provisioned/updated out-of-band (SSH deploy workflow).
+  # Don't let Terraform fight day-to-day changes to the boot script.
+  lifecycle {
+    ignore_changes = [user_data]
+  }
+}
+
+resource "aws_lightsail_static_ip" "this" {
+  name = var.static_ip_name
+}
+
+resource "aws_lightsail_static_ip_attachment" "this" {
+  static_ip_name = aws_lightsail_static_ip.this.name
+  instance_name  = aws_lightsail_instance.this.name
+}
+
+resource "aws_lightsail_instance_public_ports" "this" {
+  instance_name = aws_lightsail_instance.this.name
+
+  dynamic "port_info" {
+    for_each = var.open_ports
+    content {
+      from_port = port_info.value.from_port
+      to_port   = port_info.value.to_port
+      protocol  = port_info.value.protocol
+    }
+  }
+}

--- a/infra/terraform/modules/api-host/outputs.tf
+++ b/infra/terraform/modules/api-host/outputs.tf
@@ -1,0 +1,16 @@
+output "instance_name" {
+  value = aws_lightsail_instance.this.name
+}
+
+output "public_ip" {
+  description = "Static public IP attached to the instance (DNS target)."
+  value       = aws_lightsail_static_ip.this.ip_address
+}
+
+output "private_ip" {
+  value = aws_lightsail_instance.this.private_ip_address
+}
+
+output "availability_zone" {
+  value = aws_lightsail_instance.this.availability_zone
+}

--- a/infra/terraform/modules/api-host/variables.tf
+++ b/infra/terraform/modules/api-host/variables.tf
@@ -1,0 +1,52 @@
+variable "instance_name" {
+  description = "Lightsail instance name (also used to name related resources)."
+  type        = string
+}
+
+variable "availability_zone" {
+  description = "Lightsail AZ, e.g. us-west-2a."
+  type        = string
+}
+
+variable "blueprint_id" {
+  description = "Lightsail OS blueprint."
+  type        = string
+  default     = "ubuntu_24_04"
+}
+
+variable "bundle_id" {
+  description = "Lightsail bundle (instance size), e.g. small_3_0, large_3_0, xlarge_3_0."
+  type        = string
+}
+
+variable "key_pair_name" {
+  description = "Lightsail SSH key pair name attached to the instance."
+  type        = string
+  default     = "LightsailDefaultKeyPair"
+}
+
+variable "static_ip_name" {
+  description = "Name of the Lightsail static IP attached to the instance."
+  type        = string
+}
+
+variable "open_ports" {
+  description = "Firewall ports to open on the instance."
+  type = list(object({
+    from_port = number
+    to_port   = number
+    protocol  = string
+  }))
+  default = [
+    { from_port = 22, to_port = 22, protocol = "tcp" },     # ssh (deploy)
+    { from_port = 80, to_port = 80, protocol = "tcp" },     # http (acme/redirect)
+    { from_port = 443, to_port = 443, protocol = "tcp" },   # https (nginx → cf origin)
+    { from_port = 8008, to_port = 8009, protocol = "tcp" }, # blue/green api upstreams
+  ]
+}
+
+variable "tags" {
+  description = "Tags applied to taggable resources."
+  type        = map(string)
+  default     = {}
+}

--- a/infra/terraform/scripts/bootstrap-state.sh
+++ b/infra/terraform/scripts/bootstrap-state.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Create the S3 bucket + DynamoDB lock table that hold Terraform remote state.
+# Idempotent — skips anything that already exists. Run once per AWS account.
+set -euo pipefail
+
+REGION="${AWS_REGION:-us-west-2}"
+BUCKET="${TF_STATE_BUCKET:-kortix-terraform-state}"
+TABLE="${TF_LOCK_TABLE:-kortix-terraform-locks}"
+
+echo "Region: $REGION  Bucket: $BUCKET  Lock table: $TABLE"
+
+# ── S3 bucket ────────────────────────────────────────────────────────────────
+if aws s3api head-bucket --bucket "$BUCKET" 2>/dev/null; then
+  echo "  bucket exists: $BUCKET"
+else
+  echo "  creating bucket: $BUCKET"
+  aws s3api create-bucket --bucket "$BUCKET" --region "$REGION" \
+    --create-bucket-configuration LocationConstraint="$REGION"
+fi
+echo "  enabling versioning + encryption + public-access-block"
+aws s3api put-bucket-versioning --bucket "$BUCKET" \
+  --versioning-configuration Status=Enabled
+aws s3api put-bucket-encryption --bucket "$BUCKET" \
+  --server-side-encryption-configuration '{"Rules":[{"ApplyServerSideEncryptionByDefault":{"SSEAlgorithm":"AES256"}}]}'
+aws s3api put-public-access-block --bucket "$BUCKET" \
+  --public-access-block-configuration BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=true
+
+# ── DynamoDB lock table ──────────────────────────────────────────────────────
+if aws dynamodb describe-table --table-name "$TABLE" --region "$REGION" >/dev/null 2>&1; then
+  echo "  lock table exists: $TABLE"
+else
+  echo "  creating lock table: $TABLE"
+  aws dynamodb create-table --table-name "$TABLE" --region "$REGION" \
+    --attribute-definitions AttributeName=LockID,AttributeType=S \
+    --key-schema AttributeName=LockID,KeyType=HASH \
+    --billing-mode PAY_PER_REQUEST
+fi
+
+echo "Done. cd into an environment and run: terraform init"


### PR DESCRIPTION
First Terraform for the Kortix API infra. Describes the running **dev** box (Lightsail `kortix-dev`, us-west-2a: ubuntu_24_04 / small_3_0 / key kortix-lightsail / static IP `kortix-dev-ip` / firewall 22,80,443,8008-8009) as a reusable `api-host` module + a `dev` environment that **adopts** the live instance via `terraform import` — it does **not** recreate it.

## Verified
- `terraform validate` ✓ (Terraform 1.5.7)
- On scratch local state: imported all 4 resources, `plan` = 0 destroy / 0 change.

## Contents
- `modules/api-host` — `aws_lightsail_instance` + `static_ip` + `static_ip_attachment` + `instance_public_ports`; `ignore_changes = [user_data]` (box is SSH-deployed by deploy-dev.yml).
- `modules/api-host/files/nginx-kortix-api.conf` — canonical nginx config **including the keepalive Connection-upgrade 502 fix**, so a rebuild restores it.
- `environments/dev` — root module + S3/DynamoDB remote-state backend + `import.sh`.
- `scripts/bootstrap-state.sh` — one-time S3 bucket + DynamoDB lock table.
- `.gitignore` — never commit tfstate/.terraform/tfvars.

## Next (follow-ups)
1. `bootstrap-state.sh` → `terraform init -migrate-state` + re-import (durable remote state).
2. Cloudflare DNS module for `dev-api.kortix.com` (needs `CLOUDFLARE_API_TOKEN`).
3. `environments/prod`, then the **ECS Fargate + ALB autoscaling** target for SOC2.