### PR TITLE
infra(terraform): adopt prod box + ECS Fargate autoscaling module

### DIFF
--- a/infra/terraform/environments/prod/backend.tf
+++ b/infra/terraform/environments/prod/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket         = "kortix-terraform-state"
+    key            = "prod/api-host.tfstate"
+    region         = "us-west-2"
+    dynamodb_table = "kortix-terraform-locks"
+    encrypt        = true
+  }
+}

--- a/infra/terraform/environments/prod/import.sh
+++ b/infra/terraform/environments/prod/import.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# One-time: adopt the already-running prod Lightsail box into Terraform state.
+# Safe to re-run — `terraform import` is a no-op for already-imported resources.
+set -euo pipefail
+cd "$(dirname "$0")"
+
+terraform init -input=false
+
+imp() {  # imp <address> <id>
+  if terraform state list 2>/dev/null | grep -qx "$1"; then
+    echo "  already imported: $1"
+  else
+    echo "  importing: $1  ($2)"
+    terraform import "$1" "$2"
+  fi
+}
+
+# prod has no managed static IP (manage_static_ip = false) — only 2 resources.
+imp 'module.api_host.aws_lightsail_instance.this'              'kortix-prod-xlarge-20260401'
+imp 'module.api_host.aws_lightsail_instance_public_ports.this' 'kortix-prod-xlarge-20260401'
+
+echo
+echo "Done. Now run:  terraform plan   (expect a near-empty diff)"

--- a/infra/terraform/environments/prod/main.tf
+++ b/infra/terraform/environments/prod/main.tf
@@ -1,0 +1,38 @@
+# ── prod environment ─────────────────────────────────────────────────────────
+# api.kortix.com — the Lightsail box "kortix-prod-xlarge-20260401" in us-west-2.
+# Adopts the existing live instance (see import.sh); does not recreate it.
+#
+# NOTE: this codifies the CURRENT hand-managed prod box so prod is reproducible
+# today. The SOC2 autoscaling target (ECS Fargate + ALB) lives in the separate
+# `ecs-api` module and is applied as a deliberate migration, not from here.
+
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+module "api_host" {
+  source = "../../modules/api-host"
+
+  instance_name     = "kortix-prod-xlarge-20260401"
+  availability_zone = "us-west-2a"
+  blueprint_id      = "ubuntu_24_04"
+  bundle_id         = "xlarge_3_0"
+  key_pair_name     = "kortix-lightsail"
+  manage_static_ip  = false # prod rides the instance's plain public IP
+
+  tags = {
+    Environment = "prod"
+    Service     = "kortix-api"
+    ManagedBy   = "terraform"
+  }
+}

--- a/infra/terraform/environments/prod/outputs.tf
+++ b/infra/terraform/environments/prod/outputs.tf
@@ -1,0 +1,8 @@
+output "public_ip" {
+  description = "prod (api.kortix.com) origin IP."
+  value       = module.api_host.public_ip
+}
+
+output "instance_name" {
+  value = module.api_host.instance_name
+}

--- a/infra/terraform/environments/prod/variables.tf
+++ b/infra/terraform/environments/prod/variables.tf
@@ -1,0 +1,5 @@
+variable "aws_region" {
+  description = "AWS region for the prod Lightsail resources."
+  type        = string
+  default     = "us-west-2"
+}

--- a/infra/terraform/modules/api-host/main.tf
+++ b/infra/terraform/modules/api-host/main.tf
@@ -27,12 +27,17 @@ resource "aws_lightsail_instance" "this" {
   }
 }
 
+# Static IP is optional — dev uses a Lightsail static IP (kortix-dev-ip);
+# prod currently rides the instance's plain public IP, so set
+# manage_static_ip = false there.
 resource "aws_lightsail_static_ip" "this" {
-  name = var.static_ip_name
+  count = var.manage_static_ip ? 1 : 0
+  name  = var.static_ip_name
 }
 
 resource "aws_lightsail_static_ip_attachment" "this" {
-  static_ip_name = aws_lightsail_static_ip.this.name
+  count          = var.manage_static_ip ? 1 : 0
+  static_ip_name = aws_lightsail_static_ip.this[0].name
   instance_name  = aws_lightsail_instance.this.name
 }
 

--- a/infra/terraform/modules/api-host/outputs.tf
+++ b/infra/terraform/modules/api-host/outputs.tf
@@ -3,8 +3,8 @@ output "instance_name" {
 }
 
 output "public_ip" {
-  description = "Static public IP attached to the instance (DNS target)."
-  value       = aws_lightsail_static_ip.this.ip_address
+  description = "Public IP (DNS target): the managed static IP if any, else the instance's public IP."
+  value       = var.manage_static_ip ? aws_lightsail_static_ip.this[0].ip_address : aws_lightsail_instance.this.public_ip_address
 }
 
 output "private_ip" {

--- a/infra/terraform/modules/api-host/variables.tf
+++ b/infra/terraform/modules/api-host/variables.tf
@@ -25,9 +25,16 @@ variable "key_pair_name" {
   default     = "LightsailDefaultKeyPair"
 }
 
+variable "manage_static_ip" {
+  description = "Whether to manage a Lightsail static IP for this instance. Dev=true; prod currently uses the plain public IP so false."
+  type        = bool
+  default     = true
+}
+
 variable "static_ip_name" {
-  description = "Name of the Lightsail static IP attached to the instance."
+  description = "Name of the Lightsail static IP attached to the instance (only used when manage_static_ip = true)."
   type        = string
+  default     = ""
 }
 
 variable "open_ports" {

--- a/infra/terraform/modules/ecs-api/README.md
+++ b/infra/terraform/modules/ecs-api/README.md
@@ -1,0 +1,35 @@
+# ecs-api — autoscaling Kortix API on ECS Fargate + ALB
+
+The SOC2 target for the Kortix API: the `kortix/kortix-api` Docker image (the
+same one `deploy-dev.yml` / `release.yml` build) running as an **ECS Fargate**
+service behind an **Application Load Balancer**, with **target-tracking
+autoscaling** on CPU. No EC2/Lightsail OS to patch — the strongest control
+story for CC-series controls (least surface, managed runtime, immutable
+deploys, CloudWatch logs + alarms).
+
+## Why this replaces the Lightsail box (eventually)
+
+Today dev/prod run as Docker on a single hand-managed Lightsail instance
+behind nginx (blue/green 8008/8009), deployed over SSH. That has no horizontal
+autoscaling, an OS to patch, and config that lives only on the box. This module
+is the migration target: ≥2 tasks across AZs, rolling deploys, autoscaling,
+and everything in code.
+
+## ⚠️ This module provisions BILLABLE, net-new production infra
+
+Applying it creates an ALB, a NAT-less Fargate service (tasks in public subnets
+with assign_public_ip, or private subnets + NAT — see `assign_public_ip`),
+CloudWatch log group, target group, autoscaling target + policy, and security
+groups. **It is intentionally NOT wired into any environment yet** — adopt it
+deliberately (new `environments/prod-ecs/`) after reviewing `terraform plan`
+and the cost. Secrets are injected from SSM Parameter Store / Secrets Manager
+ARNs you pass in — never hardcoded.
+
+## Inputs of note
+
+- `image` — full image ref, e.g. `kortix/kortix-api:0.8.31`.
+- `desired_count`, `min_capacity`, `max_capacity`, `cpu_target_percent`.
+- `container_secrets` — map of ENV_NAME → SSM/Secrets-Manager ARN.
+- `vpc_id` / `subnet_ids` / `alb_subnet_ids` — bring your own network.
+- `certificate_arn` — ACM cert for HTTPS on the ALB.
+- `health_check_path` — defaults to `/v1/health`.

--- a/infra/terraform/modules/ecs-api/main.tf
+++ b/infra/terraform/modules/ecs-api/main.tf
@@ -1,0 +1,286 @@
+# ── ecs-api ──────────────────────────────────────────────────────────────────
+# kortix-api on ECS Fargate behind an ALB, with CPU target-tracking autoscaling.
+# SOC2 target: managed runtime (no OS to patch), ≥2 tasks across AZs, rolling
+# deploys, CloudWatch logs + alarms, secrets from SSM/Secrets Manager.
+
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}
+
+# ── Logs ─────────────────────────────────────────────────────────────────────
+resource "aws_cloudwatch_log_group" "this" {
+  name              = "/ecs/${var.name}"
+  retention_in_days = var.log_retention_days
+  tags              = var.tags
+}
+
+# ── IAM ──────────────────────────────────────────────────────────────────────
+data "aws_iam_policy_document" "assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+# Execution role: pull image, write logs, read the secrets we inject.
+resource "aws_iam_role" "execution" {
+  name               = "${var.name}-exec"
+  assume_role_policy = data.aws_iam_policy_document.assume.json
+  tags               = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "execution_managed" {
+  role       = aws_iam_role.execution.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_iam_role_policy" "execution_secrets" {
+  count = length(var.container_secrets) > 0 ? 1 : 0
+  name  = "${var.name}-exec-secrets"
+  role  = aws_iam_role.execution.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["ssm:GetParameters", "secretsmanager:GetSecretValue", "kms:Decrypt"]
+      Resource = values(var.container_secrets)
+    }]
+  })
+}
+
+# Task role: the app's own AWS identity at runtime (empty by default).
+resource "aws_iam_role" "task" {
+  name               = "${var.name}-task"
+  assume_role_policy = data.aws_iam_policy_document.assume.json
+  tags               = var.tags
+}
+
+# ── Security groups ──────────────────────────────────────────────────────────
+resource "aws_security_group" "alb" {
+  name        = "${var.name}-alb"
+  description = "Ingress to the ${var.name} ALB"
+  vpc_id      = var.vpc_id
+  tags        = var.tags
+
+  ingress {
+    description = "HTTPS"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  ingress {
+    description = "HTTP (redirect/ACME)"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_security_group" "service" {
+  name        = "${var.name}-svc"
+  description = "Ingress to ${var.name} tasks from the ALB only"
+  vpc_id      = var.vpc_id
+  tags        = var.tags
+
+  ingress {
+    description     = "ALB → container port"
+    from_port       = var.container_port
+    to_port         = var.container_port
+    protocol        = "tcp"
+    security_groups = [aws_security_group.alb.id]
+  }
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+# ── ALB ──────────────────────────────────────────────────────────────────────
+resource "aws_lb" "this" {
+  name               = var.name
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.alb.id]
+  subnets            = var.alb_subnet_ids
+  tags               = var.tags
+}
+
+resource "aws_lb_target_group" "this" {
+  name        = var.name
+  port        = var.container_port
+  protocol    = "HTTP"
+  vpc_id      = var.vpc_id
+  target_type = "ip"
+
+  health_check {
+    path                = var.health_check_path
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+    timeout             = 5
+    interval            = 15
+    matcher             = "200"
+  }
+  tags = var.tags
+}
+
+resource "aws_lb_listener" "https" {
+  count             = var.certificate_arn != "" ? 1 : 0
+  load_balancer_arn = aws_lb.this.arn
+  port              = 443
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+  certificate_arn   = var.certificate_arn
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.this.arn
+  }
+}
+
+# Plain HTTP listener: redirect→HTTPS when a cert exists, else forward (dev).
+resource "aws_lb_listener" "http" {
+  load_balancer_arn = aws_lb.this.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type             = var.certificate_arn != "" ? "redirect" : "forward"
+    target_group_arn = var.certificate_arn != "" ? null : aws_lb_target_group.this.arn
+
+    dynamic "redirect" {
+      for_each = var.certificate_arn != "" ? [1] : []
+      content {
+        port        = "443"
+        protocol    = "HTTPS"
+        status_code = "HTTP_301"
+      }
+    }
+  }
+}
+
+# ── ECS cluster + task + service ─────────────────────────────────────────────
+resource "aws_ecs_cluster" "this" {
+  name = var.name
+  setting {
+    name  = "containerInsights"
+    value = "enabled"
+  }
+  tags = var.tags
+}
+
+resource "aws_ecs_task_definition" "this" {
+  family                   = var.name
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = var.cpu
+  memory                   = var.memory
+  execution_role_arn       = aws_iam_role.execution.arn
+  task_role_arn            = aws_iam_role.task.arn
+  tags                     = var.tags
+
+  container_definitions = jsonencode([{
+    name      = "kortix-api"
+    image     = var.image
+    essential = true
+    portMappings = [{
+      containerPort = var.container_port
+      protocol      = "tcp"
+    }]
+    environment = [for k, v in var.environment : { name = k, value = v }]
+    secrets     = [for k, v in var.container_secrets : { name = k, valueFrom = v }]
+    logConfiguration = {
+      logDriver = "awslogs"
+      options = {
+        "awslogs-group"         = aws_cloudwatch_log_group.this.name
+        "awslogs-region"        = var.aws_region
+        "awslogs-stream-prefix" = "api"
+      }
+    }
+    healthCheck = {
+      command     = ["CMD-SHELL", "curl -fsS http://localhost:${var.container_port}${var.health_check_path} || exit 1"]
+      interval    = 30
+      timeout     = 5
+      retries     = 3
+      startPeriod = 30
+    }
+  }])
+}
+
+resource "aws_ecs_service" "this" {
+  name            = var.name
+  cluster         = aws_ecs_cluster.this.id
+  task_definition = aws_ecs_task_definition.this.arn
+  desired_count   = var.desired_count
+  launch_type     = "FARGATE"
+
+  # Rolling deploy with circuit breaker → auto-rollback on a bad release.
+  deployment_minimum_healthy_percent = 100
+  deployment_maximum_percent         = 200
+  deployment_circuit_breaker {
+    enable   = true
+    rollback = true
+  }
+
+  network_configuration {
+    subnets          = var.subnet_ids
+    security_groups  = [aws_security_group.service.id]
+    assign_public_ip = var.assign_public_ip
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.this.arn
+    container_name   = "kortix-api"
+    container_port   = var.container_port
+  }
+
+  # CI updates the image out-of-band (new task def revision) → don't fight it.
+  lifecycle {
+    ignore_changes = [task_definition, desired_count]
+  }
+
+  depends_on = [aws_lb_listener.http]
+  tags       = var.tags
+}
+
+# ── Autoscaling (target-tracking on CPU) ─────────────────────────────────────
+resource "aws_appautoscaling_target" "this" {
+  max_capacity       = var.max_capacity
+  min_capacity       = var.min_capacity
+  resource_id        = "service/${aws_ecs_cluster.this.name}/${aws_ecs_service.this.name}"
+  scalable_dimension = "ecs:service:DesiredCount"
+  service_namespace  = "ecs"
+}
+
+resource "aws_appautoscaling_policy" "cpu" {
+  name               = "${var.name}-cpu-target"
+  policy_type        = "TargetTrackingScaling"
+  resource_id        = aws_appautoscaling_target.this.resource_id
+  scalable_dimension = aws_appautoscaling_target.this.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.this.service_namespace
+
+  target_tracking_scaling_policy_configuration {
+    predefined_metric_specification {
+      predefined_metric_type = "ECSServiceAverageCPUUtilization"
+    }
+    target_value       = var.cpu_target_percent
+    scale_in_cooldown  = 300
+    scale_out_cooldown = 60
+  }
+}

--- a/infra/terraform/modules/ecs-api/outputs.tf
+++ b/infra/terraform/modules/ecs-api/outputs.tf
@@ -1,0 +1,20 @@
+output "alb_dns_name" {
+  description = "ALB DNS name — point the api.kortix.com CNAME / Cloudflare record here."
+  value       = aws_lb.this.dns_name
+}
+
+output "alb_zone_id" {
+  value = aws_lb.this.zone_id
+}
+
+output "cluster_name" {
+  value = aws_ecs_cluster.this.name
+}
+
+output "service_name" {
+  value = aws_ecs_service.this.name
+}
+
+output "log_group" {
+  value = aws_cloudwatch_log_group.this.name
+}

--- a/infra/terraform/modules/ecs-api/variables.tf
+++ b/infra/terraform/modules/ecs-api/variables.tf
@@ -1,0 +1,117 @@
+variable "name" {
+  description = "Name prefix for all resources (e.g. kortix-api-prod)."
+  type        = string
+}
+
+variable "aws_region" {
+  description = "AWS region (used for the awslogs driver)."
+  type        = string
+  default     = "us-west-2"
+}
+
+variable "image" {
+  description = "Full container image reference, e.g. kortix/kortix-api:0.8.31."
+  type        = string
+}
+
+variable "container_port" {
+  description = "Port the kortix-api listens on inside the container."
+  type        = number
+  default     = 8008
+}
+
+# ── Networking (bring your own VPC) ──────────────────────────────────────────
+variable "vpc_id" {
+  description = "VPC the service + ALB live in."
+  type        = string
+}
+
+variable "subnet_ids" {
+  description = "Subnets for the Fargate tasks (≥2 AZs)."
+  type        = list(string)
+}
+
+variable "alb_subnet_ids" {
+  description = "Public subnets for the ALB (≥2 AZs)."
+  type        = list(string)
+}
+
+variable "assign_public_ip" {
+  description = "Give tasks public IPs (true = public subnets, no NAT; false = private subnets + NAT)."
+  type        = bool
+  default     = false
+}
+
+variable "certificate_arn" {
+  description = "ACM certificate ARN for HTTPS on the ALB. Empty = HTTP-only listener (dev/testing)."
+  type        = string
+  default     = ""
+}
+
+# ── Sizing / autoscaling ─────────────────────────────────────────────────────
+variable "cpu" {
+  description = "Fargate task CPU units (256,512,1024,2048,4096)."
+  type        = number
+  default     = 1024
+}
+
+variable "memory" {
+  description = "Fargate task memory (MiB), valid pairing with cpu."
+  type        = number
+  default     = 2048
+}
+
+variable "desired_count" {
+  description = "Initial task count."
+  type        = number
+  default     = 2
+}
+
+variable "min_capacity" {
+  description = "Autoscaling floor (≥2 for HA across AZs)."
+  type        = number
+  default     = 2
+}
+
+variable "max_capacity" {
+  description = "Autoscaling ceiling."
+  type        = number
+  default     = 10
+}
+
+variable "cpu_target_percent" {
+  description = "Target-tracking CPU utilization % that scaling aims to hold."
+  type        = number
+  default     = 60
+}
+
+# ── App config ───────────────────────────────────────────────────────────────
+variable "environment" {
+  description = "Plain (non-secret) env vars for the container."
+  type        = map(string)
+  default     = {}
+}
+
+variable "container_secrets" {
+  description = "Secret env vars: ENV_NAME => SSM Parameter or Secrets Manager ARN."
+  type        = map(string)
+  default     = {}
+}
+
+variable "health_check_path" {
+  description = "ALB target-group health check path."
+  type        = string
+  default     = "/v1/health"
+}
+
+variable "log_retention_days" {
+  description = "CloudWatch log retention."
+  type        = number
+  default     = 30
+}
+
+variable "tags" {
+  description = "Tags applied to all resources."
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
Extends the Terraform IaC. Dev + prod are now both in **durable S3 remote state** (S3 `kortix-terraform-state` + DynamoDB lock `kortix-terraform-locks`), each imported from the live box with `terraform plan` = **No changes / 0 drift**.

## What's in this PR
- **`modules/api-host`** — static IP is now optional (`manage_static_ip`) so prod, which rides the instance's plain public IP, adopts cleanly.
- **`environments/prod`** — adopts the live prod Lightsail box (`kortix-prod-xlarge-20260401`, us-west-2a, xlarge_3_0) via `import.sh`; does not recreate. `terraform plan` = **No changes**.
- **`modules/ecs-api`** — the **SOC2 autoscaling target**: `kortix-api` on **ECS Fargate behind an ALB** with **CPU target-tracking autoscaling** (min 2 tasks across AZs, rolling deploy + deployment-circuit-breaker rollback, CloudWatch logs + Container Insights, secrets from SSM/Secrets Manager, BYO VPC, ACM HTTPS listener). **Validated but intentionally NOT wired to any environment / NOT applied** — adopting it provisions billable net-new prod infra and should be a deliberate migration after a reviewed `plan`.

## Verified
- `terraform fmt` + `validate` clean for **dev**, **prod**, and **ecs-api**.
- dev `plan` = No changes; prod `plan` = No changes.
- No `tfstate`/`.terraform` committed (`.gitignore` enforced).

## Follow-ups (need a go)
1. Apply the ECS stack into a new `environments/prod-ecs/` (review plan + cost first).
2. Cloudflare DNS module (needs `CLOUDFLARE_API_TOKEN`).
3. Flip `AUTO_DEPLOY_DEV=true` for push-to-main dev deploys.