### PR TITLE
fix(migration): locate opencode store on newer JustAVPS images

### DIFF
--- a/apps/api/src/projects/legacy-vm-access.ts
+++ b/apps/api/src/projects/legacy-vm-access.ts
@@ -40,10 +40,14 @@ export const RESOLVE_WS_OC_SH = [
   '[ -d "$WS" ] || WS="${KORTIX_WORKSPACE:-/workspace}"',
   'if [ -n "${OPENCODE_STORAGE_BASE:-}" ] && [ -d "$OPENCODE_STORAGE_BASE" ]; then OC="$OPENCODE_STORAGE_BASE";',
   'elif [ -d "$WS/.local/share/opencode" ]; then OC="$WS/.local/share/opencode";',
+  // Newer image: canonical store is /persistent/opencode, which is the volume's
+  // .persistent-system/opencode on the host (the container's ~/.local/share and
+  // /persistent are symlinks that dangle when viewed from the host).
+  'elif [ -d "$WS/.persistent-system/opencode" ]; then OC="$WS/.persistent-system/opencode";',
   'elif [ -n "${KORTIX_PERSISTENT_ROOT:-}" ] && [ -d "$KORTIX_PERSISTENT_ROOT/opencode" ]; then OC="$KORTIX_PERSISTENT_ROOT/opencode";',
   'elif [ -d /persistent/opencode ]; then OC=/persistent/opencode;',
-  'elif [ -d "$HOME/.local/share/opencode" ]; then OC="$HOME/.local/share/opencode";',
-  'else OC="$(ls -d /var/lib/docker/volumes/*/_data/.local/share/opencode /home/*/.local/share/opencode 2>/dev/null | head -1)"; fi',
+  'elif [ -n "${HOME:-}" ] && [ -d "$HOME/.local/share/opencode" ]; then OC="$HOME/.local/share/opencode";',
+  'else OC="$(ls -d /var/lib/docker/volumes/*/_data/.persistent-system/opencode /var/lib/docker/volumes/*/_data/.local/share/opencode /home/*/.local/share/opencode 2>/dev/null | head -1)"; fi',
 ].join('\n');
 
 export interface LegacyExecResult {


### PR DESCRIPTION
extract failed on machines using the /persistent store scheme with "bash: line 9: HOME: unbound variable". Two causes in RESOLVE_WS_OC_SH:
- the backup script runs `set -euo pipefail` (strict -u) but the resolver had a bare $HOME; when HOME is unset and earlier path branches miss, it aborted → guard with ${HOME:-}.
- the real opencode.db lives at $WS/.persistent-system/opencode (host view of the container's /persistent/opencode); the resolver never checked there → add it (and to the glob fallback).

Verified against a failing machine: store now resolves, 4.7M db found, 10 sessions enumerated.

<!--
  Every change to a protected branch goes through this PR + review (SOC 2 CC8.1).
  Fill out each section. PRs cannot be merged without a passing CI check and an
  approving review from someone other than the author.
-->

## Summary

<!-- What does this change do, and why? Link the issue/ticket if there is one. -->

Closes #

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / chore
- [ ] Infrastructure / CI
- [ ] Security fix
- [ ] Breaking change

## How was this tested?

<!-- Commands run, manual steps, screenshots. State what you verified. -->

## Security & data review

- [ ] No secrets, keys, or credentials are committed (verified by secret scan / review)
- [ ] Authorization checks are in place for any new/changed endpoints (IAM / access control)
- [ ] User input is validated (e.g. Zod) and output is safe
- [ ] No sensitive data (tokens, PII, secrets) is written to logs
- [ ] DB schema / migration changes are reviewed and reversible
- [ ] Touches auth / IAM / crypto / billing / migrations → requested the relevant code owner

## Rollout / rollback

<!-- Migrations, feature flags, env vars, and how to revert if this misbehaves. -->

## Reviewer checklist

- [ ] Change is scoped and understandable
- [ ] Tests/CI pass and cover the change
- [ ] Security & data review above is satisfied
