### PR TITLE
fix(api): bundle starter templates in API image (fixes dev Create-project 502)

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -105,6 +105,11 @@ COPY --from=deps /app/packages/agent-tunnel/package.json ./packages/agent-tunnel
 COPY --from=deps /app/packages/starter/src ./packages/starter/src
 COPY --from=deps /app/packages/starter/package.json ./packages/starter/package.json
 COPY --from=deps /app/packages/starter/tsconfig.json ./packages/starter/tsconfig.json
+# Project-scaffold templates read at runtime: packages/starter/src/index.ts
+# resolves BASE_TEMPLATE_DIR = join(import.meta.dir,'..','templates','base').
+# Without this the "Create project" seed path throws
+# ENOENT scandir packages/starter/templates/base → 502.
+COPY --from=deps /app/packages/starter/templates ./packages/starter/templates
 COPY --from=deps /app/packages/manifest-schema/src ./packages/manifest-schema/src
 COPY --from=deps /app/packages/manifest-schema/package.json ./packages/manifest-schema/package.json
 COPY --from=deps /app/packages/manifest-schema/tsconfig.json ./packages/manifest-schema/tsconfig.json


### PR DESCRIPTION
## Root cause
The web **Create project** button (`POST /v1/projects/provision` with `seed_starter:true`) calls `buildStarterFiles()`, which reads scaffold templates at runtime: `packages/starter/src/index.ts` resolves `BASE_TEMPLATE_DIR = join(import.meta.dir,'..','templates','base')`. The API Dockerfile **runner** stage copied `packages/starter/{src,package.json,tsconfig.json}` but **not `templates/`** → seeding threw `ENOENT: scandir '/app/packages/starter/templates/base'` → 502.

Invisible the whole time because **Cloudflare replaces 5xx bodies with HTML** — the JSON error only shows when hitting the origin directly (`curl --resolve dev-api.kortix.com:443:<box-ip> -k ...`). The browser reported it as a **CORS error**, which it was not.

## Fix
One line: `COPY --from=deps /app/packages/starter/templates ./packages/starter/templates` in the runner stage.

## Verified
Hot-patched templates into the live dev container → provision + seed_starter returns **201 `seeded:true`** via both origin-direct and the public Cloudflare+Origin path. This PR bakes it so the next image build is correct without the hot-patch.