### PR TITLE
refactor(api/github): GitHub backing is App-only — drop server PAT path

### DIFF
--- a/apps/api/src/__tests__/e2e-create-repo-starter.test.ts
+++ b/apps/api/src/__tests__/e2e-create-repo-starter.test.ts
@@ -161,7 +161,6 @@ mock.module('../projects/github', () => ({
   verifyGitHubAppInstallStatePayload: (state: string) => state === 'valid-install-state'
     ? { accountId: ACCOUNT_ID, nonce: 'valid-install-nonce', issuedAt: Math.floor(Date.now() / 1000) }
     : null,
-  getGitHubPatAuthContext: () => null,
   deleteFile: async () => undefined,
   commitFile: async (input: any) => {
     commitCalls.push(input);
@@ -218,7 +217,6 @@ mock.module('../projects/github', () => ({
       }]
     : [],
   isGithubAppConfigured: () => true,
-  isGithubPatConfigured: () => false,
 }));
 
 mock.module('../platform/services/session-sandbox', () => ({
@@ -474,7 +472,6 @@ describe('create-repo starter scaffold contract', () => {
       installed: true,
       configured: true,
       requires_installation: false,
-      pat_fallback_available: false,
       installation_id: '42',
       owner_login: 'kortix-org',
       owner_type: 'Organization',

--- a/apps/api/src/projects/github.ts
+++ b/apps/api/src/projects/github.ts
@@ -71,10 +71,6 @@ export interface CreateRepoInput {
   auth?: GitHubAuthContext;
 }
 
-function patToken() {
-  return process.env.KORTIX_GITHUB_TOKEN || process.env.GITHUB_TOKEN || null;
-}
-
 function githubAppId() {
   return process.env.KORTIX_GITHUB_APP_ID || process.env.GITHUB_APP_ID || null;
 }
@@ -87,20 +83,6 @@ export function githubAppSlug() {
   return process.env.KORTIX_GITHUB_APP_SLUG || process.env.GITHUB_APP_SLUG || null;
 }
 
-export function isGithubPatConfigured() {
-  return Boolean(patToken());
-}
-
-export function getGitHubPatAuthContext(): GitHubAuthContext | null {
-  const token = patToken();
-  if (!token) return null;
-  return {
-    token,
-    source: 'pat',
-    owner: process.env.KORTIX_GITHUB_OWNER?.trim() || undefined,
-  };
-}
-
 export function isGithubAppConfigured() {
   return Boolean(githubAppId() && githubAppPrivateKey());
 }
@@ -110,7 +92,6 @@ function githubAppStateSecret() {
     process.env.KORTIX_GITHUB_APP_STATE_SECRET ||
     process.env.SUPABASE_JWT_SECRET ||
     githubAppPrivateKey() ||
-    patToken() ||
     null
   );
 }
@@ -225,11 +206,7 @@ export function createGitHubAppJwt(nowMs = Date.now()) {
 
 function requestToken(auth?: Pick<GitHubAuthContext, 'token'>) {
   if (auth?.token) return auth.token;
-  const token = patToken();
-  if (!token) {
-    throw new Error('GitHub auth is not configured for this request');
-  }
-  return token;
+  throw new Error('GitHub auth is not configured for this request — a GitHub App installation token or a project credential is required');
 }
 
 function headers(auth?: Pick<GitHubAuthContext, 'token'>): Record<string, string> {
@@ -328,15 +305,8 @@ async function resolveDefaultOwner(auth?: GitHubAuthContext): Promise<{ owner: s
     return { owner: auth.owner, isOrg: auth.ownerType !== 'User' };
   }
 
-  const envOwner = process.env.KORTIX_GITHUB_OWNER?.trim();
-  if (envOwner) {
-    try {
-      await ghFetch<{ login: string; type?: string }>(`/orgs/${envOwner}`, undefined, auth);
-      return { owner: envOwner, isOrg: true };
-    } catch {
-      return { owner: envOwner, isOrg: false };
-    }
-  }
+  // App-only: the installation auth context carries the owner. Fall back to
+  // the token's authenticated account only if it somehow wasn't provided.
   const me = await ghFetch<{ login: string }>(`/user`, undefined, auth);
   return { owner: me.login, isOrg: false };
 }

--- a/apps/api/src/projects/index.ts
+++ b/apps/api/src/projects/index.ts
@@ -74,9 +74,7 @@ import {
   getFileSha,
   getRepo,
   getGitHubAppInstallation,
-  getGitHubPatAuthContext,
   isGithubAppConfigured,
-  isGithubPatConfigured,
   listInstallationRepositories,
   type GitHubAuthContext,
   type GitHubRepo,
@@ -602,21 +600,16 @@ function serializeGitHubInstallation(
   installUrl: string | null,
 ) {
   const installed = Boolean(row);
-  const kortixDefaultAvailable = isGithubPatConfigured();
   const metadata = normalizeJsonObject(row?.metadata);
-  // requires_installation is now only true when neither a per-account
-  // install nor a Kortix-owned default exists. The default Create flow
-  // always uses the Kortix org via PAT when one is configured, so users
-  // don't need to install anything to get started.
-  const requiresInstallation = isGithubAppConfigured() && !installed && !kortixDefaultAvailable;
+  // GitHub backing is App-only: a per-account App installation is required
+  // whenever the App is configured and this account hasn't installed it yet.
+  const requiresInstallation = isGithubAppConfigured() && !installed;
   return {
     account_id: accountId,
     installation_row_id: row?.installationRowId ?? null,
     installed,
     configured: isGithubAppConfigured(),
     requires_installation: requiresInstallation,
-    kortix_default_available: kortixDefaultAvailable,
-    pat_fallback_available: !isGithubAppConfigured() && kortixDefaultAvailable,
     install_url: installed ? null : installUrl,
     installation_id: row?.installationId ?? null,
     owner_login: row?.ownerLogin ?? null,
@@ -638,7 +631,7 @@ function serializeGitHubInstallations(
   return {
     ...base,
     installed: rows.length > 0,
-    requires_installation: isGithubAppConfigured() && rows.length === 0 && !isGithubPatConfigured(),
+    requires_installation: isGithubAppConfigured() && rows.length === 0,
     install_url: installUrl,
     installations: rows.map((row) => serializeGitHubInstallation(row, accountId, null)),
   };
@@ -804,7 +797,7 @@ class GitHubInstallationRequiredError extends Error {
 
 async function resolveGitHubRepoAuth(accountId: string, installationId?: string | null): Promise<{
   auth?: GitHubAuthContext;
-  authSource: 'app_installation' | 'pat';
+  authSource: 'app_installation';
   installation?: typeof accountGithubInstallations.$inferSelect;
 }> {
   const installation = await getAccountGitHubInstallation(accountId, installationId);
@@ -826,39 +819,14 @@ async function resolveGitHubRepoAuth(accountId: string, installationId?: string 
     throw new Error('Selected GitHub installation is not connected to this account');
   }
 
-  // No per-account installation. Default Create flow puts the repo under the
-  // Kortix-owned org via PAT — users don't have to install anything to get
-  // started. Per-account App install remains an opt-in for "use my own org".
-  if (isGithubPatConfigured()) {
-    return { authSource: 'pat' };
-  }
-
+  // GitHub backing is App-only: a per-account App installation is required.
+  // (Linking an existing repo with a user-supplied token is a separate flow
+  // that stores a project_credential — see resolveGitHubImportWithPat.)
   if (isGithubAppConfigured()) {
     throw new GitHubInstallationRequiredError(accountId);
   }
 
   throw new Error('GitHub is not configured on the server');
-}
-
-function projectCreatedWithServerPat(project: ProjectRow): boolean {
-  const metadata = normalizeJsonObject(project.metadata);
-  const github = normalizeJsonObject(metadata.github);
-  if (github.auth_source !== 'pat') return false;
-
-  const repo = parseGitHubRepoUrl(project.repoUrl);
-  if (!repo) return false;
-
-  const fullName = normalizeString(github.full_name);
-  if (fullName && fullName.toLowerCase() !== `${repo.owner}/${repo.repo}`.toLowerCase()) {
-    return false;
-  }
-
-  const configuredOwner = process.env.KORTIX_GITHUB_OWNER?.trim();
-  if (configuredOwner && repo.owner.toLowerCase() !== configuredOwner.toLowerCase()) {
-    return false;
-  }
-
-  return true;
 }
 
 interface ProjectGitRemote {
@@ -1063,7 +1031,7 @@ async function hasServerManagedGitAuth(project: ProjectRow): Promise<boolean> {
   if (remote.provider === 'github' && remote.authMethod === 'github_app') {
     return true;
   }
-  return projectCreatedWithServerPat(project);
+  return false;
 }
 
 async function resolveProjectGitAuth(project: ProjectRow): Promise<{
@@ -1127,21 +1095,6 @@ async function resolveProjectGitAuth(project: ProjectRow): Promise<{
         authSource: 'project_credential',
       };
     }
-  }
-
-  if (remote.provider === 'github' && remote.authMethod === 'pat' && projectCreatedWithServerPat(project)) {
-    const auth = getGitHubPatAuthContext();
-    if (auth) {
-      return {
-        auth,
-        authSource: 'pat',
-      };
-    }
-  }
-
-  if (projectCreatedWithServerPat(project)) {
-    const auth = getGitHubPatAuthContext();
-    if (auth) return { auth, authSource: 'pat' };
   }
 
   return { authSource: 'none' };
@@ -3303,7 +3256,7 @@ projectsApp.post('/create-repo', async (c) => {
       repoUrl: row.repoUrl,
       defaultBranch: row.defaultBranch,
       manifestPath: row.manifestPath,
-      gitAuthToken: githubAuth.auth?.token ?? (githubAuth.authSource === 'pat' ? getGitHubPatAuthContext()?.token ?? null : null),
+      gitAuthToken: githubAuth.auth?.token ?? null,
     },
     { accountId: scope.accountId, source: 'project-create' },
   );

--- a/apps/web/src/lib/projects-client.ts
+++ b/apps/web/src/lib/projects-client.ts
@@ -289,8 +289,6 @@ export interface GitHubInstallationStatus {
   installed: boolean;
   configured: boolean;
   requires_installation: boolean;
-  kortix_default_available: boolean;
-  pat_fallback_available: boolean;
   install_url: string | null;
   installation_id: string | null;
   owner_login: string | null;


### PR DESCRIPTION
## What

Makes GitHub repo backing **App-only** and removes the server-side PAT mechanism (`KORTIX_GITHUB_TOKEN` / `KORTIX_GITHUB_OWNER`) that auto-created repos under a single Kortix-owned org.

A per-account **GitHub App installation** is now required to create/back a GitHub repo — the create-repo route already surfaces this as `409` + `install_url` via `GitHubInstallationRequiredError`.

## What is NOT affected
The **user-supplied-token** flow stays exactly as-is: linking an existing repo with a caller-provided token (`body.github_token` → `resolveGitHubImportWithPat` → encrypted `project_credential`) never used the server PAT and keeps working. So does Freestyle-managed git.

## Changes

**`projects/github.ts`**
- Remove `patToken()`, `getGitHubPatAuthContext()`, `isGithubPatConfigured()`
- Drop the `patToken()` fallback from `githubAppStateSecret()` and `requestToken()` — every GitHub API call must now carry explicit auth (installation token or project credential)
- `resolveDefaultOwner()`: drop the `KORTIX_GITHUB_OWNER` env branch (the installation auth context carries the owner)

**`projects/index.ts`**
- `resolveGitHubRepoAuth`: remove the `'pat'` fallback branch — App installation or `GitHubInstallationRequiredError`
- Remove `projectCreatedWithServerPat()` and the two server-PAT branches in `resolveProjectGitAuth`; `hasServerManagedGitAuth` no longer treats server-PAT as managed
- Drop `kortix_default_available` / `pat_fallback_available` from the installation-status payload; `requires_installation` is now simply `app-configured && !installed`

**`apps/web` + tests**
- Drop the two removed fields from the `GitHubInstallationStatus` type
- Update `e2e-create-repo-starter` to the App-only status shape

## Verification
- `tsc --noEmit` passes (apps/api)
- No remaining references to the removed server-PAT symbols in non-test code

> Note: the full e2e suite couldn't be run locally due to a pre-existing, unrelated harness error (`hasDatabase` export missing from the db mock) — CI is the gate. The 5 other GitHub-mocking e2e tests use `resolveGitHubImport` / direct seeding (paths untouched here), not the changed `resolveGitHubRepoAuth`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)