### PR TITLE
ci(deploy-dev): always build+deploy both frontend & backend on merge to main

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,7 +1,8 @@
 name: Deploy Dev
 
 # Builds multi-arch Docker images using native runners (amd64 + arm64 in parallel),
-# deploys API + frontend to dev VPS. Path-filtered — only builds what changed.
+# deploys API + frontend to dev VPS. Always builds BOTH on every push to main
+# (when AUTO_DEPLOY_DEV=true) or on manual dispatch.
 #
 # Auto-deploy on push is controlled by the repo variable AUTO_DEPLOY_DEV.
 # Set to 'true' to enable, anything else to disable. Manual dispatch always works.
@@ -9,14 +10,6 @@ name: Deploy Dev
 on:
   push:
     branches: [main]
-    paths:
-      - 'apps/api/**'
-      - 'apps/kortix-sandbox-agent-server/**'
-      - 'apps/sandbox/**'
-      - 'apps/web/**'
-      - 'packages/**'
-      - 'pnpm-lock.yaml'
-      - 'pnpm-workspace.yaml'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Enables true auto-deploy to dev. Once `AUTO_DEPLOY_DEV=true`, **every merge to main** rebuilds and redeploys **both** the API and the frontend.

- Removed the `on.push` `paths:` filter → any push to main triggers the workflow (the `gate` job still enforces `AUTO_DEPLOY_DEV==true` or manual dispatch, so nothing deploys while the flag is off).
- Replaced each build job's path-conditional with `needs.detect-changes.result == 'success'` so API (amd64+arm64) **and** frontend (amd64+arm64) always build, then deploy via the existing zero-downtime SSH steps.

`detect-changes` stays as the dependency anchor (outputs now unused, harmless). Manual `workflow_dispatch` unchanged.

Separately I'm setting the `AUTO_DEPLOY_DEV` variable to `true` after this merges.