### PR TITLE
infra(api-host): nginx must use direct proxy_pass (not upstream{}) for blue/green swap

### DIFF
--- a/infra/terraform/modules/api-host/files/nginx-kortix-api.conf
+++ b/infra/terraform/modules/api-host/files/nginx-kortix-api.conf
@@ -6,18 +6,13 @@ map $http_origin $cors_origin {
     "https://www.kortix.com" $http_origin;
 }
 
-# Per-request Connection header for upstream: only "upgrade" for real WebSocket
-# requests, otherwise empty so nginx manages keepalive itself. Hardcoding
-# "upgrade" on every request half-upgrades plain HTTP connections, which Bun
-# then resets — the source of the intermittent 502s.
+# Per-request Connection header: "upgrade" only for real WebSocket requests,
+# empty otherwise. Hardcoding "upgrade" on every request half-upgrades plain
+# HTTP connections, which Bun resets — the actual cause of the intermittent
+# 502s. THIS map is the 502 fix.
 map $http_upgrade $connection_upgrade {
     default upgrade;
     ''      "";
-}
-
-upstream kortix_api {
-    server 127.0.0.1:8008;
-    keepalive 32;
 }
 
 server {
@@ -28,7 +23,13 @@ server {
     ssl_certificate_key /etc/nginx/ssl/cf-origin-key.pem;
 
     location / {
-        proxy_pass http://kortix_api;
+        # Direct proxy_pass with an explicit 127.0.0.1:PORT — REQUIRED so the
+        # blue/green swap in scripts/deploy-zero-downtime.sh can flip the port
+        # via `sed s|proxy_pass http://127.0.0.1:[0-9]*;|...|`. Do NOT convert
+        # this to an `upstream {}` block + `proxy_pass http://name;` — the swap
+        # sed then silently no-ops and nginx keeps serving the dead old
+        # container after every deploy (→ 502). Current active = green:8009.
+        proxy_pass http://127.0.0.1:8009;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -38,13 +39,12 @@ server {
         proxy_set_header Connection $connection_upgrade;
         proxy_read_timeout 86400;
 
-        # Hide app CORS headers - nginx will set them uniformly
+        # Hide app CORS headers — nginx sets them uniformly below.
         proxy_hide_header Access-Control-Allow-Origin;
         proxy_hide_header Access-Control-Allow-Credentials;
         proxy_hide_header Access-Control-Allow-Methods;
         proxy_hide_header Access-Control-Allow-Headers;
 
-        # Set CORS once from nginx on ALL responses
         add_header Access-Control-Allow-Origin $cors_origin always;
         add_header Access-Control-Allow-Credentials true always;
         add_header Access-Control-Allow-Methods "GET, POST, PUT, DELETE, PATCH, OPTIONS" always;


### PR DESCRIPTION
The captured nginx config had drifted to an `upstream{}` block. `deploy-zero-downtime.sh` swaps the active port via `sed s|proxy_pass http://127.0.0.1:[0-9]*;|...|`, which does **not** match the upstream form — so every deploy left nginx on the dead old container → **502 after each deploy** (the bug behind the recent dev outages). Restored the swap-compatible direct `proxy_pass http://127.0.0.1:<port>;` form (keeping the `$connection_upgrade` keepalive map). A box rebuild now restores a config the deploy script can actually swap. Live box already corrected.