### PR TITLE
ci(deploy-dev): actually always-build both api+frontend (finish #3245)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -63,7 +63,7 @@ jobs:
   build-api-amd64:
     name: API (amd64)
     needs: detect-changes
-    if: needs.detect-changes.outputs.api_changed == 'true' || github.event_name == 'workflow_dispatch'
+    if: needs.detect-changes.result == 'success'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -85,7 +85,7 @@ jobs:
   build-api-arm64:
     name: API (arm64)
     needs: detect-changes
-    if: needs.detect-changes.outputs.api_changed == 'true' || github.event_name == 'workflow_dispatch'
+    if: needs.detect-changes.result == 'success'
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
@@ -135,7 +135,7 @@ jobs:
   build-frontend-amd64:
     name: Frontend (amd64)
     needs: detect-changes
-    if: needs.detect-changes.outputs.frontend_changed == 'true' || github.event_name == 'workflow_dispatch'
+    if: needs.detect-changes.result == 'success'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -172,7 +172,7 @@ jobs:
   build-frontend-arm64:
     name: Frontend (arm64)
     needs: detect-changes
-    if: needs.detect-changes.outputs.frontend_changed == 'true' || github.event_name == 'workflow_dispatch'
+    if: needs.detect-changes.result == 'success'
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
#3245 removed the on.push paths filter but a sed escaping error meant the four build-job `if:` conditions were never changed — they still required `api_changed`/`frontend_changed`, so a plain merge to main built+deployed **nothing** (only manual `workflow_dispatch` worked). This replaces all four with `needs.detect-changes.result == 'success'` so every push to main (gated by AUTO_DEPLOY_DEV=true) builds API (amd64+arm64) **and** frontend (amd64+arm64), then deploys both via the zero-downtime SSH steps.