### PR TITLE
ci(dev): deploy API to ECS via OIDC (retire SSH-to-box) + carry live ECS fixes

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -235,32 +235,37 @@ jobs:
 
           echo "image=kortix/kortix-frontend:dev-${SHA8}" >> "$GITHUB_OUTPUT"
 
-  # ── Deploy API to dev VPS ──────────────────────────────────────────────────
+  # ── Deploy API to dev (ECS Fargate, via GitHub OIDC) ───────────────────────
+  # The dev API runs on ECS Fargate (cluster/service "kortix-dev"). The task
+  # definition pins kortix/kortix-api:dev-latest, which merge-api just pushed,
+  # so a force-new-deployment re-pulls that tag and rolls the service. Auth is
+  # via OIDC (role kortix-gha-ecs-deploy) — no long-lived AWS keys.
   deploy-api:
-    name: Deploy API to dev
+    name: Deploy API to dev (ECS)
     needs: merge-api
     runs-on: ubuntu-latest
     environment: dev
+    permissions:
+      id-token: write # assume the AWS role via GitHub OIDC
+      contents: read
     steps:
-      - name: Zero-downtime deploy via SSH
-        uses: appleboy/ssh-action@v1
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          host: ${{ secrets.VPS_HOST }}
-          username: ${{ secrets.VPS_USERNAME }}
-          key: ${{ secrets.AWS_DEV_KEY }}
-          port: 22
-          timeout: 300s
-          script: |
-            set -e
-            cd ~/suna
-            git -c fetch.recurseSubmodules=false fetch origin main
-            git reset --hard origin/main
-            git submodule sync --recursive
-            git submodule update --init --recursive --remote
-            PREBUILT_IMAGE="${{ needs.merge-api.outputs.image }}" bash scripts/deploy-zero-downtime.sh
+          role-to-assume: arn:aws:iam::935064898258:role/kortix-gha-ecs-deploy
+          aws-region: us-west-2
+      - name: Roll the ECS service onto the freshly-built image
+        run: |
+          set -euo pipefail
+          echo "Rolling ECS service kortix-dev (image ${{ needs.merge-api.outputs.image }} via :dev-latest)…"
+          aws ecs update-service --cluster kortix-dev --service kortix-dev --force-new-deployment >/dev/null
+          aws ecs wait services-stable --cluster kortix-dev --services kortix-dev
+          aws ecs describe-services --cluster kortix-dev --services kortix-dev \
+            --query 'services[0].{running:runningCount,desired:desiredCount,rollout:deployments[0].rolloutState}' \
+            --output table
 
       - name: Summary
         if: always()
         run: |
-          echo "### Deployed API → **dev**" >> "$GITHUB_STEP_SUMMARY"
-          echo "Image: \`${{ needs.merge-api.outputs.image }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "### Deployed API → **dev** (ECS Fargate)" >> "$GITHUB_STEP_SUMMARY"
+          echo "Image: \`${{ needs.merge-api.outputs.image }}\` rolled onto ECS service \`kortix-dev\`" >> "$GITHUB_STEP_SUMMARY"

--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -29,7 +29,11 @@ provider "aws" {
 }
 
 provider "cloudflare" {
-  api_token = var.cloudflare_api_token
+  # Auth precedence: scoped API token → global API key (email+key) → format-valid
+  # dummy token (so HTTP-only applies with no creds don't reject an empty token).
+  api_token = var.cloudflare_api_token != "" ? var.cloudflare_api_token : (var.cloudflare_api_key != "" ? null : "0000000000000000000000000000000000000000")
+  email     = var.cloudflare_api_key != "" ? var.cloudflare_email : null
+  api_key   = var.cloudflare_api_key != "" ? var.cloudflare_api_key : null
 }
 
 locals {
@@ -55,6 +59,7 @@ module "network" {
 # ── TLS cert (ACM, validated via Cloudflare DNS) ──────────────────────────────
 module "acm" {
   source      = "../../modules/acm-cloudflare"
+  count       = var.enable_https ? 1 : 0
   domain_name = local.domain
   zone_id     = var.cloudflare_zone_id
   tags        = local.tags
@@ -76,7 +81,8 @@ module "api" {
 
   image           = var.api_image
   container_port  = var.container_port
-  certificate_arn = module.acm.certificate_arn
+  enable_https    = var.enable_https
+  certificate_arn = var.enable_https ? one(module.acm[*].certificate_arn) : ""
   environment     = var.api_environment
   secrets         = var.api_secrets
 
@@ -93,6 +99,7 @@ module "api" {
 # ── DNS: dev-api.kortix.com → the ALB (Cloudflare-proxied) ─────────────────────
 module "dns" {
   source  = "../../modules/cloudflare-dns"
+  count   = var.manage_dns ? 1 : 0
   zone_id = var.cloudflare_zone_id
 
   records = {

--- a/infra/terraform/environments/dev/outputs.tf
+++ b/infra/terraform/environments/dev/outputs.tf
@@ -16,5 +16,5 @@ output "log_group" {
 }
 
 output "dns_records" {
-  value = module.dns.record_hostnames
+  value = try(one(module.dns[*].record_hostnames), null)
 }

--- a/infra/terraform/environments/dev/variables.tf
+++ b/infra/terraform/environments/dev/variables.tf
@@ -11,7 +11,20 @@ variable "cloudflare_zone_id" {
 }
 
 variable "cloudflare_api_token" {
-  description = "Cloudflare API token (= CLOUDFLARE_API_TOKEN secret). Supply via TF_VAR_cloudflare_api_token."
+  description = "Cloudflare scoped API token (= CLOUDFLARE_API_TOKEN secret). Supply via TF_VAR_cloudflare_api_token."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "cloudflare_email" {
+  description = "Cloudflare account email (for global-API-key auth, when no scoped token is used)."
+  type        = string
+  default     = ""
+}
+
+variable "cloudflare_api_key" {
+  description = "Cloudflare global API key (alternative to a scoped token). Supply via TF_VAR_cloudflare_api_key."
   type        = string
   default     = ""
   sensitive   = true
@@ -39,4 +52,16 @@ variable "api_secrets" {
   description = "Secret env vars: name -> Secrets Manager/SSM ARN. Populate via tfvars; never inline secret values."
   type        = map(string)
   default     = {}
+}
+
+variable "enable_https" {
+  description = "Create the ACM cert + HTTPS listener (needs the Cloudflare token for DNS validation). false = HTTP-only ALB, e.g. for parallel validation."
+  type        = bool
+  default     = true
+}
+
+variable "manage_dns" {
+  description = "Manage the dev-api Cloudflare record (CNAME -> ALB). false = leave DNS untouched (no cutover)."
+  type        = bool
+  default     = true
 }

--- a/infra/terraform/environments/prod/main.tf
+++ b/infra/terraform/environments/prod/main.tf
@@ -28,7 +28,8 @@ provider "aws" {
 }
 
 provider "cloudflare" {
-  api_token = var.cloudflare_api_token
+  # CF token is only used when managing DNS/ACM. Format-valid dummy when absent.
+  api_token = var.cloudflare_api_token != "" ? var.cloudflare_api_token : "0000000000000000000000000000000000000000"
 }
 
 locals {
@@ -72,6 +73,7 @@ module "api" {
 
   image           = var.api_image
   container_port  = var.container_port
+  enable_https    = true
   certificate_arn = module.acm.certificate_arn
   environment     = var.api_environment
   secrets         = var.api_secrets

--- a/infra/terraform/modules/ecs-api/main.tf
+++ b/infra/terraform/modules/ecs-api/main.tf
@@ -20,7 +20,9 @@ locals {
   name = var.name
   # PORT is always injected so the app binds the port the target group checks.
   environment = merge(var.environment, { PORT = tostring(var.container_port) })
-  https       = var.certificate_arn != ""
+  # Gate the HTTPS listener on a STATIC flag (count can't depend on the ACM
+  # cert ARN, which is unknown until apply).
+  https = var.enable_https
 }
 
 # ── Logs ──────────────────────────────────────────────────────────────────────
@@ -60,9 +62,10 @@ resource "aws_iam_role_policy" "secrets" {
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [{
-      Effect   = "Allow"
-      Action   = ["secretsmanager:GetSecretValue", "ssm:GetParameters"]
-      Resource = values(var.secrets)
+      Effect = "Allow"
+      Action = ["secretsmanager:GetSecretValue", "ssm:GetParameters"]
+      # Grant on the base secret/parameter ARN (strip any :json-key::version suffix from valueFrom).
+      Resource = distinct([for v in values(var.secrets) : join(":", slice(split(":", v), 0, 7))])
     }]
   })
 }
@@ -242,13 +245,9 @@ resource "aws_ecs_task_definition" "this" {
         "awslogs-stream-prefix" = "api"
       }
     }
-    healthCheck = {
-      command     = ["CMD-SHELL", "curl -f http://localhost:${var.container_port}${var.health_check_path} || exit 1"]
-      interval    = 30
-      timeout     = 5
-      retries     = 3
-      startPeriod = 60
-    }
+    # No container-level healthCheck: the Bun image has no curl/wget, and the
+    # ALB target group health check (HTTP GET health_check_path) is the
+    # authoritative gate for routing + the deployment circuit breaker.
   }])
 
   tags = var.tags

--- a/infra/terraform/modules/ecs-api/variables.tf
+++ b/infra/terraform/modules/ecs-api/variables.tf
@@ -105,9 +105,15 @@ variable "memory_target" {
 
 # ── Options ───────────────────────────────────────────────────────────────────
 variable "certificate_arn" {
-  description = "ACM cert ARN for the HTTPS listener. Empty = HTTP-only listener (e.g. behind a TLS-terminating proxy)."
+  description = "ACM cert ARN for the HTTPS listener (used when enable_https = true)."
   type        = string
   default     = ""
+}
+
+variable "enable_https" {
+  description = "Create the HTTPS :443 listener (certificate_arn) and make :80 redirect to it. false = HTTP-only :80 forward. Must be a static value (gates count)."
+  type        = bool
+  default     = false
 }
 
 variable "use_fargate_spot" {


### PR DESCRIPTION
**Finishes the dev → ECS migration's deploy path.**

- `deploy-dev.yml` deploy-api job no longer SSHes to the retired Lightsail box. It assumes an AWS role via **GitHub OIDC** (`kortix-gha-ecs-deploy`, no long-lived keys) and rolls the dev ECS service: `aws ecs update-service --force-new-deployment` + `wait services-stable`. Task def pins `kortix/kortix-api:dev-latest` (pushed by merge-api), so the roll re-pulls the new image.
- Carries the live-bring-up infra fixes so source matches the deployed dev ECS stack (static `enable_https` gate, container healthcheck removed, IAM base-secret-ARN grant, `aws_region` var, Cloudflare global-key support).

OIDC provider already existed; the IAM role + trust (repo:kortix-ai/suna:*) are created. terraform validate clean.