### PR TITLE
ci: split desktop out of dev pipeline; decouple CLI publish

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,7 +1,8 @@
 name: Deploy Dev
 
-# DEV pipeline. `main` is the dev branch: every push auto-deploys everything as
-# a DEV build versioned `$(cat VERSION)-dev.<sha8>`.
+# DEV pipeline. `main` is the dev branch: every push auto-deploys the things that
+# change on most commits — API, frontend, CLI — as a DEV build versioned
+# `$(cat VERSION)-dev.<sha8>`.
 #
 #   - API image   → kortix/kortix-api:dev-<sha8> + :dev-latest, then rolled onto
 #                   the ECS Fargate dev service (kortix-dev) via GitHub OIDC.
@@ -10,10 +11,14 @@ name: Deploy Dev
 #                   from `main` via Vercel's own Git integration — no deploy step.
 #   - CLI         → 4 cross-compiled binaries published to the mutable
 #                   `dev-latest` GitHub prerelease (default API base dev-api).
-#   - Desktop     → signed installers published into the same `dev-latest`
-#                   prerelease (default URL dev.kortix.com).
 #
-# Promotion to production is a separate, manual workflow (promote.yml).
+# Desktop is intentionally NOT here — it's a Tauri webview shell that changes
+# rarely and needs slow signed macOS/Windows runners, so it lives in its own
+# workflow (desktop.yml: only on apps/desktop/** changes or manual dispatch) and
+# never blocks the CLI/API/frontend dev deploy.
+#
+# Promotion to production is a separate, manual workflow (promote.yml), which cuts
+# the single unified vX.Y.Z release bundling API + frontend + CLI + desktop.
 
 on:
   push:
@@ -33,7 +38,6 @@ jobs:
       api: ${{ steps.filter.outputs.api }}
       frontend: ${{ steps.filter.outputs.frontend }}
       cli: ${{ steps.filter.outputs.cli }}
-      desktop: ${{ steps.filter.outputs.desktop }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -64,12 +68,6 @@ jobs:
               - 'pnpm-workspace.yaml'
               - 'package.json'
               - 'VERSION'
-            desktop:
-              - 'apps/desktop/**'
-              - 'pnpm-lock.yaml'
-              - 'pnpm-workspace.yaml'
-              - 'package.json'
-              - 'VERSION'
       - name: Summary
         run: |
           {
@@ -77,7 +75,6 @@ jobs:
             echo "- API: ${{ steps.filter.outputs.api }}"
             echo "- Frontend: ${{ steps.filter.outputs.frontend }}"
             echo "- CLI: ${{ steps.filter.outputs.cli }}"
-            echo "- Desktop: ${{ steps.filter.outputs.desktop }}"
           } >> "$GITHUB_STEP_SUMMARY"
 
   # ── Build + push the multi-arch API image ───────────────────────────────────
@@ -289,201 +286,13 @@ jobs:
             artifacts/SHA256SUMS
           if-no-files-found: error
 
-  # ── Build dev desktop installers (per-OS signed matrix) ─────────────────────
-  build-desktop:
-    name: Build dev desktop ${{ matrix.target_pretty }}
-    needs: detect-changes
-    if: needs.detect-changes.outputs.desktop == 'true'
-    runs-on: ${{ matrix.runner }}
-    env:
-      DESKTOP_PRODUCT_NAME: Kortix Dev
-      DESKTOP_IDENTIFIER: com.kortix.desktop.dev
-      DESKTOP_URL: https://dev.kortix.com/dashboard
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - target_pretty: macos-arm64
-            runner: macos-14
-            bundles: dmg
-            artifact: desktop-macos-arm64
-            files: apps/desktop/src-tauri/target/release/bundle/dmg/*.dmg
-          - target_pretty: macos-x64
-            runner: macos-13
-            bundles: dmg
-            artifact: desktop-macos-x64
-            files: apps/desktop/src-tauri/target/release/bundle/dmg/*.dmg
-          - target_pretty: windows-x64
-            runner: windows-2022
-            bundles: msi
-            artifact: desktop-windows-x64
-            files: apps/desktop/src-tauri/target/release/bundle/msi/*.msi
-          - target_pretty: linux-x64
-            runner: ubuntu-22.04
-            bundles: appimage
-            artifact: desktop-linux-x64
-            files: apps/desktop/src-tauri/target/release/bundle/appimage/*.AppImage
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install Linux Tauri dependencies
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            build-essential \
-            curl \
-            file \
-            libgtk-3-dev \
-            libssl-dev \
-            libwebkit2gtk-4.1-dev \
-            libappindicator3-dev \
-            librsvg2-dev \
-            patchelf \
-            wget
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-
-      - uses: dtolnay/rust-toolchain@stable
-
-      - name: Install pnpm
-        run: corepack enable pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile --filter @kortix/desktop
-        env:
-          npm_config_engine_strict: "false"
-
-      - name: Compute dev version
-        id: ver
-        shell: bash
-        run: echo "version=$(cat VERSION)-dev.${GITHUB_SHA::8}" >> "$GITHUB_OUTPUT"
-
-      - name: Validate signing secrets
-        shell: bash
-        env:
-          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
-          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
-          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
-          APPLE_API_KEY_P8: ${{ secrets.APPLE_API_KEY_P8 }}
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD || secrets.APPLE_APP_SPECIFIC_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          WINDOWS_CERTIFICATE: ${{ secrets.WINDOWS_CERTIFICATE }}
-          WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}
-          WINDOWS_CERTIFICATE_THUMBPRINT: ${{ secrets.WINDOWS_CERTIFICATE_THUMBPRINT }}
-        run: |
-          case "${{ runner.os }}" in
-            macOS)
-              test -n "$APPLE_CERTIFICATE" || { echo "Missing APPLE_CERTIFICATE"; exit 1; }
-              test -n "$APPLE_CERTIFICATE_PASSWORD" || { echo "Missing APPLE_CERTIFICATE_PASSWORD"; exit 1; }
-              if [ -n "$APPLE_API_ISSUER" ] || [ -n "$APPLE_API_KEY" ] || [ -n "$APPLE_API_KEY_P8" ]; then
-                test -n "$APPLE_API_ISSUER" || { echo "Missing APPLE_API_ISSUER"; exit 1; }
-                test -n "$APPLE_API_KEY" || { echo "Missing APPLE_API_KEY"; exit 1; }
-                test -n "$APPLE_API_KEY_P8" || { echo "Missing APPLE_API_KEY_P8"; exit 1; }
-              else
-                test -n "$APPLE_ID" || { echo "Missing APPLE_ID"; exit 1; }
-                test -n "$APPLE_PASSWORD" || { echo "Missing APPLE_PASSWORD"; exit 1; }
-                test -n "$APPLE_TEAM_ID" || { echo "Missing APPLE_TEAM_ID"; exit 1; }
-              fi
-              ;;
-            Windows)
-              test -n "$WINDOWS_CERTIFICATE" || { echo "Missing WINDOWS_CERTIFICATE"; exit 1; }
-              test -n "$WINDOWS_CERTIFICATE_PASSWORD" || { echo "Missing WINDOWS_CERTIFICATE_PASSWORD"; exit 1; }
-              test -n "$WINDOWS_CERTIFICATE_THUMBPRINT" || { echo "Missing WINDOWS_CERTIFICATE_THUMBPRINT"; exit 1; }
-              ;;
-          esac
-
-      - name: Prepare macOS notarization key
-        if: runner.os == 'macOS'
-        shell: bash
-        env:
-          APPLE_API_KEY_P8: ${{ secrets.APPLE_API_KEY_P8 }}
-        run: |
-          if [ -n "$APPLE_API_KEY_P8" ]; then
-            KEY_PATH="$RUNNER_TEMP/AuthKey.p8"
-            printf '%s' "$APPLE_API_KEY_P8" > "$KEY_PATH"
-            echo "APPLE_API_KEY_PATH=$KEY_PATH" >> "$GITHUB_ENV"
-          fi
-
-      - name: Import Windows signing certificate
-        if: runner.os == 'Windows'
-        shell: pwsh
-        env:
-          WINDOWS_CERTIFICATE: ${{ secrets.WINDOWS_CERTIFICATE }}
-          WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}
-        run: |
-          New-Item -ItemType Directory -Force -Path certificate | Out-Null
-          Set-Content -Path certificate/tempCert.txt -Value $env:WINDOWS_CERTIFICATE
-          certutil -decode certificate/tempCert.txt certificate/certificate.pfx
-          Remove-Item certificate/tempCert.txt
-          Import-PfxCertificate `
-            -FilePath certificate/certificate.pfx `
-            -CertStoreLocation Cert:\CurrentUser\My `
-            -Password (ConvertTo-SecureString -String $env:WINDOWS_CERTIFICATE_PASSWORD -Force -AsPlainText)
-
-      - name: Configure dev desktop build
-        shell: bash
-        env:
-          DESKTOP_VERSION: ${{ steps.ver.outputs.version }}
-          WINDOWS_CERTIFICATE_THUMBPRINT: ${{ secrets.WINDOWS_CERTIFICATE_THUMBPRINT }}
-          WINDOWS_TIMESTAMP_URL: ${{ secrets.WINDOWS_TIMESTAMP_URL }}
-        run: |
-          node <<'NODE'
-          const fs = require('node:fs');
-          const path = 'apps/desktop/src-tauri/tauri.conf.json';
-          const config = JSON.parse(fs.readFileSync(path, 'utf8'));
-          // Tauri requires a strict semver version; dev builds use the clean
-          // X.Y.Z so the bundler accepts it (the -dev.<sha> suffix is not valid
-          // for Windows MSI/macOS bundle versions).
-          config.version = (process.env.DESKTOP_VERSION || '0.0.0').split('-')[0];
-          config.productName = process.env.DESKTOP_PRODUCT_NAME;
-          config.identifier = process.env.DESKTOP_IDENTIFIER;
-          if (process.env.WINDOWS_CERTIFICATE_THUMBPRINT) {
-            config.bundle ||= {};
-            config.bundle.windows ||= {};
-            config.bundle.windows.certificateThumbprint = process.env.WINDOWS_CERTIFICATE_THUMBPRINT;
-            config.bundle.windows.digestAlgorithm = 'sha256';
-            config.bundle.windows.timestampUrl = process.env.WINDOWS_TIMESTAMP_URL || 'http://timestamp.digicert.com';
-          }
-          fs.writeFileSync(path, JSON.stringify(config, null, 2) + '\n');
-          NODE
-
-      - name: Prepare desktop shell assets
-        run: pnpm --filter @kortix/desktop run prepare-assets
-
-      - name: Build desktop installer
-        run: pnpm --filter @kortix/desktop tauri build --bundles ${{ matrix.bundles }}
-        env:
-          KORTIX_DESKTOP_DEFAULT_URL: ${{ env.DESKTOP_URL }}
-          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
-          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
-          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
-          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD || secrets.APPLE_APP_SPECIFIC_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-
-      - name: Upload installer artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ matrix.artifact }}
-          path: ${{ matrix.files }}
-          if-no-files-found: error
-
-  # ── Publish/refresh the single mutable `dev-latest` prerelease ──────────────
+  # ── Publish/refresh the mutable `dev-latest` prerelease (CLI binaries) ──────
+  # CLI-only and depends solely on build-cli, so a slow/scarce desktop runner can
+  # never block the dev CLI channel (`kortix update` --dev).
   publish-dev-release:
     name: Publish dev-latest prerelease
-    needs: [detect-changes, build-cli, build-desktop]
-    # Run whenever the CLI and/or desktop built (and didn't fail). `always()`
-    # lets us proceed even if one of the two was skipped by change-detection.
-    if: |
-      always() &&
-      (needs.build-cli.result == 'success' || needs.build-desktop.result == 'success')
+    needs: [detect-changes, build-cli]
+    if: needs.detect-changes.outputs.cli == 'true' && needs.build-cli.result == 'success'
     runs-on: ubuntu-22.04
     permissions:
       contents: write
@@ -493,34 +302,13 @@ jobs:
           fetch-depth: 0
 
       - name: Download CLI artifacts
-        if: needs.build-cli.result == 'success'
         uses: actions/download-artifact@v4
         with:
           name: cli-binaries
-          path: artifacts/
+          path: release/
 
-      - name: Download desktop artifacts
-        if: needs.build-desktop.result == 'success'
-        uses: actions/download-artifact@v4
-        with:
-          path: desktop-artifacts/
-          pattern: desktop-*
-          merge-multiple: true
-
-      - name: Assemble release assets
-        run: |
-          set -euo pipefail
-          mkdir -p release
-          # CLI binaries + checksums (if present)
-          if [ -d artifacts ]; then
-            cp -v artifacts/* release/ 2>/dev/null || true
-          fi
-          # Desktop installers (if present)
-          if [ -d desktop-artifacts ]; then
-            find desktop-artifacts -maxdepth 1 -type f -exec cp -v {} release/ \;
-          fi
-          cd release
-          ls -lh
+      - name: List assets
+        run: ls -lh release/
 
       - name: Move dev-latest tag to this commit
         run: |
@@ -536,9 +324,9 @@ jobs:
           make_latest: false
           generate_release_notes: false
           body: |
-            Mutable DEV build for `${{ github.sha }}` (`$(cat VERSION)-dev.${{ github.sha }}`).
+            Mutable DEV CLI build for `${{ github.sha }}`.
 
-            - CLI defaults to `https://dev-api.kortix.com`.
-            - Desktop defaults to `https://dev.kortix.com/dashboard`.
+            Install: `curl -fsSL https://kortix.com/install | KORTIX_CHANNEL=dev bash`
+            Defaults to `https://dev-api.kortix.com`.
           files: |
             release/*

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -321,9 +321,14 @@ jobs:
           if-no-files-found: error
 
   # ── Cut a single GitHub Release vX.Y.Z (CLI + desktop) ──────────────────────
+  # CLI is required (it gates the release); desktop is best-effort — if signing
+  # fails on some/all desktop targets the release still ships with whatever
+  # installers built (or none), so a desktop cert problem never blocks the
+  # API/frontend/CLI release. Re-run desktop + re-dispatch later to attach them.
   github-release:
     name: GitHub Release v${{ needs.version.outputs.version }}
     needs: [version, retag-images, build-cli, build-desktop]
+    if: always() && needs.build-cli.result == 'success' && needs.retag-images.result == 'success'
     runs-on: ubuntu-22.04
     permissions:
       contents: write
@@ -338,8 +343,9 @@ jobs:
           name: cli-binaries
           path: artifacts/
 
-      - name: Download desktop artifacts
+      - name: Download desktop artifacts (best-effort)
         uses: actions/download-artifact@v4
+        continue-on-error: true
         with:
           path: desktop-artifacts/
           pattern: desktop-*
@@ -350,7 +356,11 @@ jobs:
           set -euo pipefail
           mkdir -p release
           cp -v artifacts/kortix-* release/
-          find desktop-artifacts -maxdepth 1 -type f -exec cp -v {} release/ \;
+          if [ -d desktop-artifacts ]; then
+            find desktop-artifacts -maxdepth 1 -type f -exec cp -v {} release/ \;
+          else
+            echo "::warning::No desktop installers attached (build-desktop did not succeed) — release ships CLI + images only."
+          fi
           cd release
           sha256sum * > SHA256SUMS
           ls -lh

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -1,0 +1,263 @@
+name: Desktop
+
+# Desktop (Tauri) build — kept OUT of Deploy Dev on purpose. The desktop app is a
+# thin webview shell that changes rarely and needs slow, signed macOS/Windows
+# runners, so building it on every main push would be wasteful and would gate the
+# fast API/frontend/CLI path on scarce runners.
+#
+# It builds only when desktop code actually changes (push to main touching
+# apps/desktop/**) or when manually dispatched. Signed installers are published
+# to the mutable `desktop-dev-latest` prerelease.
+#
+# Production desktop installers are built separately by deploy-prod.yml and
+# bundled into the unified vX.Y.Z release.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/desktop/**'
+      - '.github/workflows/desktop.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: desktop-dev
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build dev desktop ${{ matrix.target_pretty }}
+    runs-on: ${{ matrix.runner }}
+    env:
+      DESKTOP_PRODUCT_NAME: Kortix Dev
+      DESKTOP_IDENTIFIER: com.kortix.desktop.dev
+      DESKTOP_URL: https://dev.kortix.com/dashboard
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target_pretty: macos-arm64
+            runner: macos-14
+            bundles: dmg
+            artifact: desktop-macos-arm64
+            files: apps/desktop/src-tauri/target/release/bundle/dmg/*.dmg
+          - target_pretty: macos-x64
+            runner: macos-13
+            bundles: dmg
+            artifact: desktop-macos-x64
+            files: apps/desktop/src-tauri/target/release/bundle/dmg/*.dmg
+          - target_pretty: windows-x64
+            runner: windows-2022
+            bundles: msi
+            artifact: desktop-windows-x64
+            files: apps/desktop/src-tauri/target/release/bundle/msi/*.msi
+          - target_pretty: linux-x64
+            runner: ubuntu-22.04
+            bundles: appimage
+            artifact: desktop-linux-x64
+            files: apps/desktop/src-tauri/target/release/bundle/appimage/*.AppImage
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Linux Tauri dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential \
+            curl \
+            file \
+            libgtk-3-dev \
+            libssl-dev \
+            libwebkit2gtk-4.1-dev \
+            libappindicator3-dev \
+            librsvg2-dev \
+            patchelf \
+            wget
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Install pnpm
+        run: corepack enable pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --filter @kortix/desktop
+        env:
+          npm_config_engine_strict: "false"
+
+      - name: Compute dev version
+        id: ver
+        shell: bash
+        run: echo "version=$(cat VERSION)-dev.${GITHUB_SHA::8}" >> "$GITHUB_OUTPUT"
+
+      - name: Validate signing secrets
+        shell: bash
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_KEY_P8: ${{ secrets.APPLE_API_KEY_P8 }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD || secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          WINDOWS_CERTIFICATE: ${{ secrets.WINDOWS_CERTIFICATE }}
+          WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}
+          WINDOWS_CERTIFICATE_THUMBPRINT: ${{ secrets.WINDOWS_CERTIFICATE_THUMBPRINT }}
+        run: |
+          case "${{ runner.os }}" in
+            macOS)
+              test -n "$APPLE_CERTIFICATE" || { echo "Missing APPLE_CERTIFICATE"; exit 1; }
+              test -n "$APPLE_CERTIFICATE_PASSWORD" || { echo "Missing APPLE_CERTIFICATE_PASSWORD"; exit 1; }
+              if [ -n "$APPLE_API_ISSUER" ] || [ -n "$APPLE_API_KEY" ] || [ -n "$APPLE_API_KEY_P8" ]; then
+                test -n "$APPLE_API_ISSUER" || { echo "Missing APPLE_API_ISSUER"; exit 1; }
+                test -n "$APPLE_API_KEY" || { echo "Missing APPLE_API_KEY"; exit 1; }
+                test -n "$APPLE_API_KEY_P8" || { echo "Missing APPLE_API_KEY_P8"; exit 1; }
+              else
+                test -n "$APPLE_ID" || { echo "Missing APPLE_ID"; exit 1; }
+                test -n "$APPLE_PASSWORD" || { echo "Missing APPLE_PASSWORD"; exit 1; }
+                test -n "$APPLE_TEAM_ID" || { echo "Missing APPLE_TEAM_ID"; exit 1; }
+              fi
+              ;;
+            Windows)
+              test -n "$WINDOWS_CERTIFICATE" || { echo "Missing WINDOWS_CERTIFICATE"; exit 1; }
+              test -n "$WINDOWS_CERTIFICATE_PASSWORD" || { echo "Missing WINDOWS_CERTIFICATE_PASSWORD"; exit 1; }
+              test -n "$WINDOWS_CERTIFICATE_THUMBPRINT" || { echo "Missing WINDOWS_CERTIFICATE_THUMBPRINT"; exit 1; }
+              ;;
+          esac
+
+      - name: Prepare macOS notarization key
+        if: runner.os == 'macOS'
+        shell: bash
+        env:
+          APPLE_API_KEY_P8: ${{ secrets.APPLE_API_KEY_P8 }}
+        run: |
+          if [ -n "$APPLE_API_KEY_P8" ]; then
+            KEY_PATH="$RUNNER_TEMP/AuthKey.p8"
+            printf '%s' "$APPLE_API_KEY_P8" > "$KEY_PATH"
+            echo "APPLE_API_KEY_PATH=$KEY_PATH" >> "$GITHUB_ENV"
+          fi
+
+      - name: Import Windows signing certificate
+        if: runner.os == 'Windows'
+        shell: pwsh
+        env:
+          WINDOWS_CERTIFICATE: ${{ secrets.WINDOWS_CERTIFICATE }}
+          WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}
+        run: |
+          New-Item -ItemType Directory -Force -Path certificate | Out-Null
+          Set-Content -Path certificate/tempCert.txt -Value $env:WINDOWS_CERTIFICATE
+          certutil -decode certificate/tempCert.txt certificate/certificate.pfx
+          Remove-Item certificate/tempCert.txt
+          Import-PfxCertificate `
+            -FilePath certificate/certificate.pfx `
+            -CertStoreLocation Cert:\CurrentUser\My `
+            -Password (ConvertTo-SecureString -String $env:WINDOWS_CERTIFICATE_PASSWORD -Force -AsPlainText)
+
+      - name: Configure dev desktop build
+        shell: bash
+        env:
+          DESKTOP_VERSION: ${{ steps.ver.outputs.version }}
+          WINDOWS_CERTIFICATE_THUMBPRINT: ${{ secrets.WINDOWS_CERTIFICATE_THUMBPRINT }}
+          WINDOWS_TIMESTAMP_URL: ${{ secrets.WINDOWS_TIMESTAMP_URL }}
+        run: |
+          node <<'NODE'
+          const fs = require('node:fs');
+          const path = 'apps/desktop/src-tauri/tauri.conf.json';
+          const config = JSON.parse(fs.readFileSync(path, 'utf8'));
+          // Tauri requires a strict semver version; dev builds use the clean
+          // X.Y.Z so the bundler accepts it (the -dev.<sha> suffix is not valid
+          // for Windows MSI/macOS bundle versions).
+          config.version = (process.env.DESKTOP_VERSION || '0.0.0').split('-')[0];
+          config.productName = process.env.DESKTOP_PRODUCT_NAME;
+          config.identifier = process.env.DESKTOP_IDENTIFIER;
+          if (process.env.WINDOWS_CERTIFICATE_THUMBPRINT) {
+            config.bundle ||= {};
+            config.bundle.windows ||= {};
+            config.bundle.windows.certificateThumbprint = process.env.WINDOWS_CERTIFICATE_THUMBPRINT;
+            config.bundle.windows.digestAlgorithm = 'sha256';
+            config.bundle.windows.timestampUrl = process.env.WINDOWS_TIMESTAMP_URL || 'http://timestamp.digicert.com';
+          }
+          fs.writeFileSync(path, JSON.stringify(config, null, 2) + '\n');
+          NODE
+
+      - name: Prepare desktop shell assets
+        run: pnpm --filter @kortix/desktop run prepare-assets
+
+      - name: Build desktop installer
+        run: pnpm --filter @kortix/desktop tauri build --bundles ${{ matrix.bundles }}
+        env:
+          KORTIX_DESKTOP_DEFAULT_URL: ${{ env.DESKTOP_URL }}
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD || secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+
+      - name: Upload installer artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: ${{ matrix.files }}
+          if-no-files-found: error
+
+  # ── Publish/refresh the mutable `desktop-dev-latest` prerelease ─────────────
+  publish:
+    name: Publish desktop-dev-latest
+    needs: build
+    # Publish whatever installers built — a single OS's signing failure shouldn't
+    # discard the others.
+    if: always() && needs.build.result != 'cancelled'
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Download desktop artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: desktop-artifacts/
+          pattern: desktop-*
+          merge-multiple: true
+
+      - name: Assemble assets + checksums
+        run: |
+          set -euo pipefail
+          mkdir -p release
+          find desktop-artifacts -maxdepth 1 -type f -exec cp -v {} release/ \;
+          cd release
+          if [ -z "$(ls -A)" ]; then
+            echo "No desktop installers were produced (all targets failed)." >&2
+            exit 1
+          fi
+          sha256sum * > SHA256SUMS
+          ls -lh
+
+      - name: Move desktop-dev-latest tag to this commit
+        run: |
+          git tag -f desktop-dev-latest "$GITHUB_SHA"
+          git push -f origin desktop-dev-latest
+
+      - name: Publish GitHub prerelease (desktop-dev-latest)
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: desktop-dev-latest
+          name: desktop-dev-latest
+          prerelease: true
+          make_latest: false
+          generate_release_notes: false
+          body: |
+            Mutable DEV desktop build for `${{ github.sha }}`.
+            Defaults to `https://dev.kortix.com/dashboard`.
+          files: |
+            release/*

--- a/infra/CICD.md
+++ b/infra/CICD.md
@@ -15,11 +15,14 @@ A branch-based dev→prod model with one unified version.
 ## Version flow
 
 The root [`VERSION`](../VERSION) file is the single source of truth for the API,
-web, CLI, and desktop.
+web, CLI, **and** desktop — they share **one** version, never separate ones. A
+promotion cuts a single `vX.Y.Z` GitHub Release that bundles the latest
+API + frontend + CLI + desktop together.
 
-- **Dev** (on `main`): artifacts are stamped `$(cat VERSION)-dev.<sha8>`.
+- **Dev** (on `main`): artifacts are stamped `$(cat VERSION)-dev.<sha8>` and land
+  on rolling channels (`dev-latest`, `desktop-dev-latest`) — no version ceremony.
 - **Promoted** (on `production`): artifacts are the clean `$(cat VERSION)` =
-  `X.Y.Z`.
+  `X.Y.Z`, the one number shared by every component.
 
 [`scripts/version.sh`](../scripts/version.sh) computes these:
 
@@ -41,16 +44,31 @@ DEV=1 scripts/version.sh    # X.Y.Z-dev.<sha8>
    retags the dev images to `:X.Y.Z` + `:latest` and cuts the GitHub Release
    `vX.Y.Z`. The prod ECS roll stays gated (see below).
 
-## The 6 workflows
+## The 7 workflows
 
 | Workflow            | Trigger                          | Purpose                                                                                  |
 | ------------------- | -------------------------------- | ---------------------------------------------------------------------------------------- |
-| `ci.yml`            | PR → `main`                      | Typecheck/build gates (API, frontend, sandbox agent, CLI, desktop).                      |
+| `ci.yml`            | PR → `main`,`production`          | Typecheck/build gates (API, frontend, sandbox agent, CLI, desktop).                      |
 | `codeql.yml`        | push/PR → `main`,`production` + weekly | CodeQL SAST (SOC 2 CC7.1/CC8.1).                                                     |
 | `secret-scan.yml`   | PR → `main`,`production`          | gitleaks secret scan.                                                                     |
-| `deploy-dev.yml`    | push → `main` + dispatch         | Build+push dev images, roll dev ECS, publish dev CLI + desktop to the `dev-latest` prerelease. |
+| `deploy-dev.yml`    | push → `main` + dispatch         | Build+push dev API+frontend images, roll dev ECS, publish dev **CLI** to `dev-latest`. Desktop is NOT here. |
+| `desktop.yml`       | push → `main` (`apps/desktop/**` only) + dispatch | Build signed desktop installers → `desktop-dev-latest` prerelease. Only runs when desktop code changes. |
 | `promote.yml`       | dispatch                         | Bump VERSION, tag `vX.Y.Z`, fast-forward `production`.                                    |
-| `deploy-prod.yml`   | push → `production` + dispatch   | Retag images → `vX.Y.Z`+`latest`, cut GitHub Release `vX.Y.Z`, [gated] roll prod ECS.    |
+| `deploy-prod.yml`   | push → `production` + dispatch   | Retag images → `vX.Y.Z`+`latest`, build prod CLI + desktop, cut GitHub Release `vX.Y.Z`, [gated] roll prod ECS. |
+
+### Why desktop is separate
+
+The desktop app is a Tauri webview shell that changes rarely and needs slow,
+scarce, **signed** macOS/Windows runners. Building it on every `main` push would
+waste runner time and — worse — gate the fast API/frontend/CLI path on a mac
+runner being free. So:
+
+- On `main`, desktop builds **only** when `apps/desktop/**` changes (or via manual
+  dispatch). The CLI dev channel (`dev-latest`) is published by `deploy-dev.yml`
+  independently and is never blocked by desktop.
+- On `production`, desktop is built into the unified `vX.Y.Z` release but is
+  **best-effort**: a desktop signing failure does not abort the
+  API/frontend/CLI release (re-run desktop and re-attach later).
 
 ### Artifacts
 
@@ -62,8 +80,9 @@ DEV=1 scripts/version.sh    # X.Y.Z-dev.<sha8>
   - Dev → `dev-latest` prerelease (defaults to `dev-api.kortix.com`).
   - Prod → `vX.Y.Z` release (defaults to `api.kortix.com`).
   - Installed via `scripts/install.sh` (served at `kortix.com/install`).
-- **Desktop:** signed installers (.dmg/.msi/.AppImage) attached to the same
-  releases as the CLI.
+- **Desktop:** signed installers (.dmg/.msi/.AppImage).
+  - Dev → `desktop-dev-latest` prerelease (built only when desktop code changes).
+  - Prod → bundled into the `vX.Y.Z` release alongside the CLI.
 - **Frontend (hosted):** `dev.kortix.com` and `kortix.com` are deployed by
   Vercel from `main` and `production` respectively — not by these workflows.
 


### PR DESCRIPTION
Splits the desktop (Tauri) build out of the dev pipeline and decouples the CLI publish, per discussion.

## Problem
Desktop is a webview shell that changes rarely and needs slow, scarce, **signed** macOS/Windows runners. The previous `deploy-dev.yml`:
1. Rebuilt desktop on every `main` push (its path filter included `VERSION`/`package.json`/lockfile → fired on basically everything, including every promote).
2. Combined CLI + desktop into one `publish-dev-release` job that waited on the **whole desktop matrix** — so one queued macOS runner blocked the dev **CLI** binaries from ever publishing. (Observed live: `macos-x64` stuck ~50 min, CLI never published.)

## Fix
- **`deploy-dev.yml`** — desktop removed entirely. CLI publishes to `dev-latest` on its own (`needs: build-cli` only); a slow/scarce desktop runner can never block it again.
- **`desktop.yml`** (new) — builds signed installers **only when `apps/desktop/**` changes** (or manual `workflow_dispatch`) → `desktop-dev-latest` prerelease. Publish tolerates a single OS's signing failure.
- **`deploy-prod.yml`** — desktop is now **best-effort** in the unified `vX.Y.Z` release: `build-cli` + `retag-images` are required; a desktop signing failure no longer aborts the API/frontend/CLI release (installers attached if they built).

## Versioning unchanged
One `VERSION` file still ties **API + frontend + CLI + desktop** into a single `vX.Y.Z` release at promote — they never get separate versions. Dev builds ride rolling channels (`dev-latest`, `desktop-dev-latest`).

## Net behavior
- Normal code push → only API/frontend/CLI move. **Desktop does not run.**
- Touch `apps/desktop/**` (or click Run) → desktop builds on its own track.
- Promote → one unified `vX.Y.Z` release (desktop best-effort).

7 workflows total. Validated with `actionlint` (clean). No app code touched.

> Note: the desktop **signing secrets** are still broken/missing (Windows cert absent; macOS `APPLE_CERTIFICATE_PASSWORD` mismatch → `PKCS12 wrong password`). That's a separate secrets fix — this PR just stops it from blocking everything else.
