### PR TITLE
fix(api): bundle snapshot-builder source so ECS image can list sandbox templates

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -124,6 +124,16 @@ COPY apps/sandbox/entrypoint.sh ./apps/sandbox/entrypoint.sh
 COPY apps/sandbox/agent-cli ./apps/sandbox/agent-cli
 COPY packages/executor-sdk ./packages/executor-sdk
 
+# Source the layered-snapshot builder fingerprints at RUNTIME. It hashes the
+# SOURCE (not the compiled binaries above, which `bun build --compile` produces
+# non-deterministically — see apps/api/src/snapshots/templates.ts), so these
+# trees + package.json must be present in the image. Without them the Sandbox
+# panel throws "Failed to list sandbox templates: ENOENT … package.json".
+COPY apps/kortix-sandbox-agent-server/package.json ./apps/kortix-sandbox-agent-server/package.json
+COPY apps/kortix-sandbox-agent-server/src ./apps/kortix-sandbox-agent-server/src
+COPY apps/cli/package.json ./apps/cli/package.json
+COPY apps/cli/src ./apps/cli/src
+
 # Copy the app (source + its node_modules if any)
 COPY --from=deps /app/${SERVICE} ./${SERVICE}
 


### PR DESCRIPTION
Fixes the live dev error **"Failed to list sandbox templates: ENOENT … lstat '/app/apps/kortix-sandbox-agent-server/package.json'"**.

**Root cause:** the layered-snapshot builder fingerprints the *source* of the sandbox runtime (`templates.ts` → `runtime-fingerprint.ts` walks `apps/kortix-sandbox-agent-server/src`+`package.json` and `apps/cli/src`+`package.json`), deliberately hashing source rather than the non-deterministic `bun build --compile` binaries. `GET /v1/projects/:id/sandboxes` → `listSandboxTemplates` → `computeTemplateIdentity` → `currentRuntimeArtifactFingerprint` reads these at runtime. The old Lightsail box ran from a full checkout so they existed; the ECS Docker image only copied the compiled `dist` binaries → ENOENT.

**Fix:** `COPY` the four runtime-read source paths into the runner stage (mirrors the existing `packages/starter/templates` runtime-read COPY just above). The other 4 fingerprint artifacts (sandbox/entrypoint.sh, sandbox/agent-cli, executor-sdk, manifest-schema/src) were already present.

**Verified:** built the image locally and asserted all 10 runtime-read paths exist inside it (agent src 21 files, cli src 44 files).

Note: `.dockerignore` strips `__tests__`/`*.test.ts`, so the image fingerprint differs from the old box's → a one-time, self-healing snapshot rebuild wave. All ECS deploys (dev + prod) compute the same fingerprint → they share snapshots.

Auto-deploys to dev ECS on merge (`apps/api/**` triggers the API build + roll).
