### PR TITLE
fix(sandbox): web tool proxies work on Daytona via KORTIX_API_URL-derived router

### DIFF
--- a/.kortix/opencode/tools/image_search.ts
+++ b/.kortix/opencode/tools/image_search.ts
@@ -1,11 +1,11 @@
 import { tool } from "@opencode-ai/plugin";
 import Replicate from "replicate";
-import { getEnv } from "./lib/get-env";
+import { getEnv, getKortixRouterBase } from "./lib/get-env";
 
 const SERPER_DEFAULT_URL = "https://google.serper.dev";
 
 function getSerperImagesUrl(): string {
-  const override = getEnv("SERPER_API_URL");
+  const override = getKortixRouterBase("serper");
   const base = override || SERPER_DEFAULT_URL;
   return `${base.replace(/\/+$/, "")}/images`;
 }
@@ -88,9 +88,9 @@ async function describeImage(
 }
 
 async function enrichImages(images: EnrichedImage[]): Promise<EnrichedImage[]> {
-  const replicateBaseUrl = getEnv("REPLICATE_API_URL");
-  // When routed through the Kortix proxy (REPLICATE_API_URL is set), use KORTIX_TOKEN
-  // for auth — the proxy validates it and injects the real Replicate API token.
+  const replicateBaseUrl = getKortixRouterBase("replicate") ?? undefined;
+  // Route through the Kortix router (derived from KORTIX_API_URL); auth with
+  // KORTIX_TOKEN. Fall back to a raw REPLICATE_API_TOKEN only when unset.
   const replicateToken = replicateBaseUrl
     ? getEnv("KORTIX_TOKEN")
     : getEnv("REPLICATE_API_TOKEN");
@@ -138,9 +138,9 @@ export default tool({
       ),
   },
   async execute(args, _context) {
-    const serperUrlOverride = getEnv("SERPER_API_URL");
-    // When routed through the Kortix proxy (SERPER_API_URL is set), use KORTIX_TOKEN
-    // for auth — the proxy validates it and injects the real Serper API key.
+    const serperUrlOverride = getKortixRouterBase("serper") ?? undefined;
+    // Route through the Kortix router (derived from KORTIX_API_URL); auth with
+    // KORTIX_TOKEN. Fall back to a raw SERPER_API_KEY only when unset.
     const apiKey = serperUrlOverride
       ? getEnv("KORTIX_TOKEN")
       : getEnv("SERPER_API_KEY");

--- a/.kortix/opencode/tools/lib/get-env.ts
+++ b/.kortix/opencode/tools/lib/get-env.ts
@@ -111,3 +111,37 @@ export function getEnv(key: string): string | undefined {
 
   return undefined;
 }
+
+/**
+ * Base URL for a Kortix router-proxied upstream service, derived from
+ * KORTIX_API_URL. The sandbox only ever holds KORTIX_API_URL + KORTIX_TOKEN;
+ * tools build their proxy endpoint from those two. Normalizes so it works
+ * whether KORTIX_API_URL is a bare origin or already ends in /v1 or /v1/router.
+ * Returns null when KORTIX_API_URL is unset.
+ */
+export function getKortixRouterBase(service: string): string | null {
+  const raw = getEnv("KORTIX_API_URL");
+  if (!raw) return null;
+  const root = raw
+    .replace(/\/+$/, "")
+    .replace(/\/v1\/router$/, "")
+    .replace(/\/v1$/, "");
+  return `${root}/v1/router/${service}`;
+}
+
+/**
+ * Base URL for a Kortix router-proxied upstream service, derived from
+ * KORTIX_API_URL. The sandbox only ever holds KORTIX_API_URL + KORTIX_TOKEN;
+ * tools build their proxy endpoint from those two. Normalizes so it works
+ * whether KORTIX_API_URL is a bare origin or already ends in /v1 or /v1/router.
+ * Returns null when KORTIX_API_URL is unset.
+ */
+export function getKortixRouterBase(service: string): string | null {
+  const raw = getEnv("KORTIX_API_URL");
+  if (!raw) return null;
+  const root = raw
+    .replace(/\/+$/, "")
+    .replace(/\/v1\/router$/, "")
+    .replace(/\/v1$/, "");
+  return `${root}/v1/router/${service}`;
+}

--- a/.kortix/opencode/tools/scrape_webpage.ts
+++ b/.kortix/opencode/tools/scrape_webpage.ts
@@ -1,6 +1,6 @@
 import { tool } from "@opencode-ai/plugin";
 import FirecrawlApp from "@mendable/firecrawl-js";
-import { getEnv } from "./lib/get-env";
+import { getEnv, getKortixRouterBase } from "./lib/get-env";
 
 interface ScrapeResult {
   url: string;
@@ -78,10 +78,10 @@ export default tool({
       .describe("Include raw HTML alongside markdown. Default: false"),
   },
   async execute(args, _context) {
-    const apiBaseURL = getEnv("FIRECRAWL_API_URL");
-    // When routed through the Kortix proxy (FIRECRAWL_API_URL is set), use KORTIX_TOKEN
-    // for auth — the proxy validates it and injects the real Firecrawl API key.
-    // When hitting the real Firecrawl API directly, use the user's own FIRECRAWL_API_KEY.
+    // Route through the Kortix router (derived from KORTIX_API_URL) and auth with
+    // KORTIX_TOKEN; the router injects the real upstream key. Fall back to a raw
+    // FIRECRAWL_API_KEY only when KORTIX_API_URL is unset (self-host/direct).
+    const apiBaseURL = getKortixRouterBase("firecrawl") ?? undefined;
     const apiKey = apiBaseURL
       ? getEnv("KORTIX_TOKEN")
       : getEnv("FIRECRAWL_API_KEY");

--- a/.kortix/opencode/tools/web_search.ts
+++ b/.kortix/opencode/tools/web_search.ts
@@ -1,6 +1,6 @@
 import { tool } from "@opencode-ai/plugin";
 import { tavily } from "@tavily/core";
-import { getEnv } from "./lib/get-env";
+import { getEnv, getKortixRouterBase } from "./lib/get-env";
 
 interface SearchResult {
   title: string;
@@ -77,10 +77,10 @@ export default tool({
       ),
   },
   async execute(args, _context) {
-    const apiBaseURL = getEnv("TAVILY_API_URL");
-    // When routed through the Kortix proxy (TAVILY_API_URL is set), use KORTIX_TOKEN
-    // for auth — the proxy validates it and injects the real Tavily API key.
-    // When hitting the real Tavily API directly, use the user's own TAVILY_API_KEY.
+    // Route through the Kortix router (derived from KORTIX_API_URL) and auth with
+    // KORTIX_TOKEN; the router injects the real upstream key. Fall back to a raw
+    // TAVILY_API_KEY only when KORTIX_API_URL is unset (self-host/direct).
+    const apiBaseURL = getKortixRouterBase("tavily") ?? undefined;
     const apiKey = apiBaseURL
       ? getEnv("KORTIX_TOKEN")
       : getEnv("TAVILY_API_KEY");

--- a/apps/api/src/__tests__/unit-sandbox-env.test.ts
+++ b/apps/api/src/__tests__/unit-sandbox-env.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'bun:test';
+import { isForbiddenSandboxEnv } from '../platform/sandbox-env';
+
+describe('isForbiddenSandboxEnv', () => {
+  it('forbids every raw upstream provider key', () => {
+    for (const key of [
+      'OPENROUTER_API_KEY',
+      'ANTHROPIC_API_KEY',
+      'OPENAI_API_KEY',
+      'TAVILY_API_KEY',
+      'SERPER_API_KEY',
+      'FIRECRAWL_API_KEY',
+      'REPLICATE_API_TOKEN',
+      'CONTEXT7_API_KEY',
+    ]) {
+      expect(isForbiddenSandboxEnv(key)).toBe(true);
+    }
+  });
+
+  it('forbids secret-shaped infra vars that may live in the server .env', () => {
+    for (const key of [
+      'STRIPE_SECRET_KEY',
+      'SUPABASE_SERVICE_ROLE_KEY',
+      'DATABASE_URL',
+      'ENCRYPTION_KEY',
+      'SOME_PRIVATE_KEY',
+      'MAILTRAP_API_TOKEN',
+      'DAYTONA_API_KEY',
+    ]) {
+      expect(isForbiddenSandboxEnv(key)).toBe(true);
+    }
+  });
+
+  it('allows the credentials we inject on purpose', () => {
+    for (const key of [
+      'KORTIX_TOKEN',
+      'INTERNAL_SERVICE_KEY',
+      'TUNNEL_TOKEN',
+      'KORTIX_CLI_TOKEN',
+      'KORTIX_EXECUTOR_TOKEN',
+    ]) {
+      expect(isForbiddenSandboxEnv(key)).toBe(false);
+    }
+  });
+
+  it('allows KORTIX_API_URL and plain operational vars', () => {
+    for (const key of [
+      'KORTIX_API_URL',
+      'PROJECT_ID',
+      'KORTIX_WORKSPACE',
+      'TZ',
+    ]) {
+      expect(isForbiddenSandboxEnv(key)).toBe(false);
+    }
+  });
+});

--- a/apps/api/src/platform/providers/daytona.ts
+++ b/apps/api/src/platform/providers/daytona.ts
@@ -70,16 +70,25 @@ export class DaytonaProvider implements SandboxProvider {
       Number.parseInt(process.env.KORTIX_DAYTONA_CREATE_TIMEOUT_SECONDS || '30', 10) || 30,
     );
 
+    const envVars: Record<string, string> = {
+      // Guarantee the sandbox contract even if a caller forgets: the runtime only
+      // needs KORTIX_API_URL + KORTIX_TOKEN; tools derive every router endpoint
+      // from KORTIX_API_URL and auth with KORTIX_TOKEN.
+      KORTIX_API_URL: `${sandboxApiBase}/v1`,
+      // Session identity, git context, KORTIX_TOKEN, and the project's own
+      // secrets (incl. provider keys set via `kortix providers`, picked up by
+      // opencode at boot) — see buildSessionSandboxEnvVars() and
+      // provisionSessionSandbox().
+      ...opts.envVars,
+    };
+    if (!envVars.KORTIX_TOKEN) {
+      throw new Error('[daytona] create() called without KORTIX_TOKEN — sandbox cannot authenticate to the Kortix router.');
+    }
+
     const daytonaSandbox = await daytona.create(
       {
         snapshot,
-        envVars: {
-          // Session identity, git context, KORTIX_API_URL + KORTIX_TOKEN, and
-          // the project's own secrets (incl. provider keys set via `kortix
-          // providers`, picked up by opencode at boot) — see
-          // buildSessionSandboxEnvVars() and provisionSessionSandbox().
-          ...opts.envVars,
-        },
+        envVars,
         autoStopInterval: 15,
         autoArchiveInterval: 30,
         public: false,

--- a/apps/api/src/platform/providers/local-docker.ts
+++ b/apps/api/src/platform/providers/local-docker.ts
@@ -5,6 +5,7 @@ import { resolve } from 'path';
 import { config, SANDBOX_VERSION } from '../../config';
 import { generateSandboxKeyPair } from '../../shared/crypto';
 import { getAuthCandidates, getSandboxServiceKeyByExternalId } from '../services/sandbox-auth';
+import { isForbiddenSandboxEnv } from '../sandbox-env';
 import type {
   SandboxProvider,
   ProviderName,
@@ -572,16 +573,9 @@ export class LocalDockerProvider implements SandboxProvider {
     }
 
     const sandboxApiBase = getSandboxInternalApiUrl();
-    const routerBase = `${sandboxApiBase}/v1/router`;
     const desired: Record<string, string> = {
       KORTIX_API_URL: sandboxApiBase,
       TUNNEL_API_URL: sandboxApiBase,
-      // Tool proxy URLs — route through kortix-api router so sandbox tools
-      // auth with KORTIX_TOKEN and the router injects real upstream API keys.
-      TAVILY_API_URL: `${routerBase}/tavily`,
-      REPLICATE_API_URL: `${routerBase}/replicate`,
-      SERPER_API_URL: `${routerBase}/serper`,
-      FIRECRAWL_API_URL: `${routerBase}/firecrawl`,
     };
 
     // Read current state from the live master env (s6 env dir) — NOT from
@@ -858,26 +852,40 @@ export class LocalDockerProvider implements SandboxProvider {
 
     const serviceKey = authToken;
 
+    // Vars we set explicitly below — don't let the forwarded .env duplicate them.
     const MANAGED_VARS = new Set([
       'KORTIX_TOKEN',
       'KORTIX_API_URL',
+      'TUNNEL_API_URL',
+      'TUNNEL_TOKEN',
       'SANDBOX_ID',
+      'SANDBOX_VERSION',
       'INTERNAL_SERVICE_KEY',
       'PROJECT_ID',
       'CORS_ALLOWED_ORIGINS',
-      'TAVILY_API_URL',
-      'REPLICATE_API_URL',
-      'SERPER_API_URL',
-      'FIRECRAWL_API_URL',
     ]);
 
+    // Forward the developer's non-secret env, but NEVER a real provider secret.
+    // The sandbox reaches every upstream (LLM gateway, Tavily, …) through the
+    // kortix-api router with its KORTIX_TOKEN — it must not hold raw keys.
+    const droppedSecrets: string[] = [];
     const filteredSandboxEnv = sandboxEnvVars.filter((entry) => {
       const varName = entry.split('=')[0];
-      return !MANAGED_VARS.has(varName);
+      if (MANAGED_VARS.has(varName)) return false;
+      if (isForbiddenSandboxEnv(varName)) {
+        droppedSecrets.push(varName);
+        return false;
+      }
+      return true;
     });
+    if (droppedSecrets.length > 0) {
+      console.log(
+        `[LOCAL-DOCKER] Not injecting ${droppedSecrets.length} secret(s) into sandbox ` +
+        `(reached via router with KORTIX_TOKEN): ${droppedSecrets.join(', ')}`,
+      );
+    }
 
     const sandboxApiBase = getSandboxInternalApiUrl();
-    const routerBase = `${sandboxApiBase}/v1/router`;
 
     const env = [
       'PUID=911',
@@ -907,13 +915,6 @@ export class LocalDockerProvider implements SandboxProvider {
       // All components share one version (set by deploy-zero-downtime.sh from image tag).
       `SANDBOX_VERSION=${SANDBOX_VERSION}`,
       'PROJECT_ID=local',
-      // ── Tool proxy URLs — route through kortix-api router ─────────────
-      // Sandbox tools use KORTIX_TOKEN to auth; the router injects the real
-      // upstream API key. Matches managed-provider env injection.
-      `TAVILY_API_URL=${routerBase}/tavily`,
-      `REPLICATE_API_URL=${routerBase}/replicate`,
-      `SERPER_API_URL=${routerBase}/serper`,
-      `FIRECRAWL_API_URL=${routerBase}/firecrawl`,
       ...(config.KORTIX_LOCAL_IMAGES ? ['KORTIX_LOCAL_SOURCE=1'] : []),
       `CORS_ALLOWED_ORIGINS=${[config.FRONTEND_URL, config.KORTIX_URL].filter(Boolean).join(',')}`,
       ...filteredSandboxEnv,

--- a/apps/api/src/platform/sandbox-env.ts
+++ b/apps/api/src/platform/sandbox-env.ts
@@ -1,0 +1,67 @@
+/**
+ * Single source of truth for what a sandbox is allowed to receive in its
+ * environment.
+ *
+ * Hard rule: a sandbox NEVER holds a real upstream provider secret, and no
+ * provider injects the per-service router URLs. The runtime needs only
+ * `KORTIX_TOKEN` + `KORTIX_API_URL`; the tools derive every router endpoint
+ * (`${KORTIX_API_URL}/v1/router/{service}`) from those two and authenticate
+ * with `KORTIX_TOKEN`, and the kortix-api router injects the real upstream key
+ * server-side. The only credentials that legitimately live inside a sandbox
+ * are that `KORTIX_TOKEN` (and its auth aliases) plus per-session tokens we
+ * mint explicitly.
+ *
+ * See router/config/proxy-services.ts for the upstream keys these map to.
+ */
+
+/**
+ * Auth/identity credentials we DO set into the sandbox on purpose — the
+ * sandbox service key (+ its aliases) and per-session tokens. Everything else
+ * matching a secret shape is stripped.
+ */
+const SANDBOX_ALLOWED_CREDENTIALS: ReadonlySet<string> = new Set([
+  'KORTIX_TOKEN',
+  'INTERNAL_SERVICE_KEY',
+  'TUNNEL_TOKEN',
+  'KORTIX_CLI_TOKEN',
+  'KORTIX_EXECUTOR_TOKEN',
+]);
+
+/**
+ * Raw upstream provider secrets that must NEVER be injected into a sandbox.
+ * These are reached through the router with `KORTIX_TOKEN`. Mirrors the
+ * `getKortixApiKey` keys in router/config/proxy-services.ts.
+ */
+const SANDBOX_FORBIDDEN_KEYS: ReadonlySet<string> = new Set([
+  'OPENROUTER_API_KEY',
+  'ANTHROPIC_API_KEY',
+  'OPENAI_API_KEY',
+  'TAVILY_API_KEY',
+  'SERPER_API_KEY',
+  'FIRECRAWL_API_KEY',
+  'REPLICATE_API_TOKEN',
+  'CONTEXT7_API_KEY',
+  // Platform infra secrets that never belong in a sandbox and don't match the
+  // pattern below.
+  'DATABASE_URL',
+  'DAYTONA_API_KEY',
+]);
+
+/**
+ * Conservative secret-shaped suffix match — catches anything secret-looking
+ * (Stripe, Supabase service-role keys, encryption keys, …) that may live in
+ * the API server's env file, so none of it can leak into a sandbox. The
+ * credentials we inject on purpose are exempted in `isForbiddenSandboxEnv`.
+ */
+const SANDBOX_SECRET_PATTERN = /(_KEY|_TOKEN|_SECRET|_PASSWORD|_SALT|_CREDENTIALS?)$/i;
+
+/**
+ * Whether an env var must NOT be forwarded into a sandbox. The auth credentials
+ * we set explicitly are exempt; everything that names a provider key or matches
+ * a secret shape is forbidden.
+ */
+export function isForbiddenSandboxEnv(name: string): boolean {
+  if (SANDBOX_ALLOWED_CREDENTIALS.has(name)) return false;
+  if (SANDBOX_FORBIDDEN_KEYS.has(name)) return true;
+  return SANDBOX_SECRET_PATTERN.test(name);
+}

--- a/packages/starter/templates/base/.kortix/opencode/tools/image_search.ts
+++ b/packages/starter/templates/base/.kortix/opencode/tools/image_search.ts
@@ -1,11 +1,11 @@
 import { tool } from "@opencode-ai/plugin";
 import Replicate from "replicate";
-import { getEnv } from "./lib/get-env";
+import { getEnv, getKortixRouterBase } from "./lib/get-env";
 
 const SERPER_DEFAULT_URL = "https://google.serper.dev";
 
 function getSerperImagesUrl(): string {
-  const override = getEnv("SERPER_API_URL");
+  const override = getKortixRouterBase("serper");
   const base = override || SERPER_DEFAULT_URL;
   return `${base.replace(/\/+$/, "")}/images`;
 }
@@ -88,9 +88,9 @@ async function describeImage(
 }
 
 async function enrichImages(images: EnrichedImage[]): Promise<EnrichedImage[]> {
-  const replicateBaseUrl = getEnv("REPLICATE_API_URL");
-  // When routed through the Kortix proxy (REPLICATE_API_URL is set), use KORTIX_TOKEN
-  // for auth — the proxy validates it and injects the real Replicate API token.
+  const replicateBaseUrl = getKortixRouterBase("replicate") ?? undefined;
+  // Route through the Kortix router (derived from KORTIX_API_URL); auth with
+  // KORTIX_TOKEN. Fall back to a raw REPLICATE_API_TOKEN only when unset.
   const replicateToken = replicateBaseUrl
     ? getEnv("KORTIX_TOKEN")
     : getEnv("REPLICATE_API_TOKEN");
@@ -138,9 +138,9 @@ export default tool({
       ),
   },
   async execute(args, _context) {
-    const serperUrlOverride = getEnv("SERPER_API_URL");
-    // When routed through the Kortix proxy (SERPER_API_URL is set), use KORTIX_TOKEN
-    // for auth — the proxy validates it and injects the real Serper API key.
+    const serperUrlOverride = getKortixRouterBase("serper") ?? undefined;
+    // Route through the Kortix router (derived from KORTIX_API_URL); auth with
+    // KORTIX_TOKEN. Fall back to a raw SERPER_API_KEY only when unset.
     const apiKey = serperUrlOverride
       ? getEnv("KORTIX_TOKEN")
       : getEnv("SERPER_API_KEY");

--- a/packages/starter/templates/base/.kortix/opencode/tools/lib/get-env.ts
+++ b/packages/starter/templates/base/.kortix/opencode/tools/lib/get-env.ts
@@ -111,3 +111,20 @@ export function getEnv(key: string): string | undefined {
 
   return undefined;
 }
+
+/**
+ * Base URL for a Kortix router-proxied upstream service, derived from
+ * KORTIX_API_URL. The sandbox only ever holds KORTIX_API_URL + KORTIX_TOKEN;
+ * tools build their proxy endpoint from those two. Normalizes so it works
+ * whether KORTIX_API_URL is a bare origin or already ends in /v1 or /v1/router.
+ * Returns null when KORTIX_API_URL is unset.
+ */
+export function getKortixRouterBase(service: string): string | null {
+  const raw = getEnv("KORTIX_API_URL");
+  if (!raw) return null;
+  const root = raw
+    .replace(/\/+$/, "")
+    .replace(/\/v1\/router$/, "")
+    .replace(/\/v1$/, "");
+  return `${root}/v1/router/${service}`;
+}

--- a/packages/starter/templates/base/.kortix/opencode/tools/scrape_webpage.ts
+++ b/packages/starter/templates/base/.kortix/opencode/tools/scrape_webpage.ts
@@ -1,6 +1,6 @@
 import { tool } from "@opencode-ai/plugin";
 import FirecrawlApp from "@mendable/firecrawl-js";
-import { getEnv } from "./lib/get-env";
+import { getEnv, getKortixRouterBase } from "./lib/get-env";
 
 interface ScrapeResult {
   url: string;
@@ -78,10 +78,10 @@ export default tool({
       .describe("Include raw HTML alongside markdown. Default: false"),
   },
   async execute(args, _context) {
-    const apiBaseURL = getEnv("FIRECRAWL_API_URL");
-    // When routed through the Kortix proxy (FIRECRAWL_API_URL is set), use KORTIX_TOKEN
-    // for auth — the proxy validates it and injects the real Firecrawl API key.
-    // When hitting the real Firecrawl API directly, use the user's own FIRECRAWL_API_KEY.
+    // Route through the Kortix router (derived from KORTIX_API_URL) and auth with
+    // KORTIX_TOKEN; the router injects the real upstream key. Fall back to a raw
+    // FIRECRAWL_API_KEY only when KORTIX_API_URL is unset (self-host/direct).
+    const apiBaseURL = getKortixRouterBase("firecrawl") ?? undefined;
     const apiKey = apiBaseURL
       ? getEnv("KORTIX_TOKEN")
       : getEnv("FIRECRAWL_API_KEY");

--- a/packages/starter/templates/base/.kortix/opencode/tools/web_search.ts
+++ b/packages/starter/templates/base/.kortix/opencode/tools/web_search.ts
@@ -1,6 +1,6 @@
 import { tool } from "@opencode-ai/plugin";
 import { tavily } from "@tavily/core";
-import { getEnv } from "./lib/get-env";
+import { getEnv, getKortixRouterBase } from "./lib/get-env";
 
 interface SearchResult {
   title: string;
@@ -77,10 +77,10 @@ export default tool({
       ),
   },
   async execute(args, _context) {
-    const apiBaseURL = getEnv("TAVILY_API_URL");
-    // When routed through the Kortix proxy (TAVILY_API_URL is set), use KORTIX_TOKEN
-    // for auth — the proxy validates it and injects the real Tavily API key.
-    // When hitting the real Tavily API directly, use the user's own TAVILY_API_KEY.
+    // Route through the Kortix router (derived from KORTIX_API_URL) and auth with
+    // KORTIX_TOKEN; the router injects the real upstream key. Fall back to a raw
+    // TAVILY_API_KEY only when KORTIX_API_URL is unset (self-host/direct).
+    const apiBaseURL = getKortixRouterBase("tavily") ?? undefined;
     const apiKey = apiBaseURL
       ? getEnv("KORTIX_TOKEN")
       : getEnv("TAVILY_API_KEY");


### PR DESCRIPTION
## Problem

Web tools (`web_search`, `image_search`, `scrape_webpage`) failed in production with `TAVILY_API_KEY not set` / `SERPER_API_KEY not set`.

**Root cause:** the tools switched into proxy mode only when the per-service `*_API_URL` env vars were present, and **only the local-docker provider injected them**. On the Daytona (cloud/prod) path those vars were never set, so the tools fell back to direct mode and had no raw key.

## Fix — one clean contract

A sandbox runtime now needs only **`KORTIX_TOKEN` + `KORTIX_API_URL`**. Everything else is derived.

- **Tools** (both `.kortix/opencode/tools/` and the starter template tree): new `getKortixRouterBase(service)` derives `${KORTIX_API_URL}/v1/router/{service}` (normalizes a bare origin, `/v1`, or `/v1/router`) and the tools auth with `KORTIX_TOKEN`. No tool reads a `*_API_URL` var anymore. The derived string is byte-identical to what local-docker used to inject, so downstream SDK/fetch behavior is unchanged. Falls back to a raw `*_API_KEY` only when `KORTIX_API_URL` is unset (self-host/direct).
- **`daytona.ts`** `create()` now **guarantees** the contract: sets `KORTIX_API_URL` and **throws if `KORTIX_TOKEN` is missing**, so a sandbox can never silently provision unable to reach the router.
- **`local-docker.ts`**: stops injecting the four `*_API_URL` vars entirely, and filters real provider secrets out of the forwarded `core/docker/.env` (new `isForbiddenSandboxEnv`) so raw keys can't leak into a local sandbox either.
- **`apps/api/src/platform/sandbox-env.ts`** (new) + unit test for the secret blocklist.

## Verification
- `bun test unit-sandbox-env + unit-router-provider-trace` → **6/6 pass**
- `bunx tsc --noEmit` (apps/api) → **0 errors**

## ⚠️ Still required server-side
For the proxy to actually return data, the **apps/api** environment must hold the real `TAVILY_API_KEY` / `SERPER_API_KEY` / `FIRECRAWL_API_KEY` / `REPLICATE_API_TOKEN`, or the router returns `503 {service} not configured`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)