### PR TITLE
fix(migration): make extract backup tar robust + lean

### DIFF
--- a/apps/api/src/projects/legacy-migration-steps.ts
+++ b/apps/api/src/projects/legacy-migration-steps.ts
@@ -154,9 +154,23 @@ export async function extractStep(ctx: MigrationContext): Promise<void> {
       'BUNDLE=/tmp/kortix-migration-bundle.tar.gz',
       // basename of WS becomes "workspace" and of OC becomes "opencode" for the
       // canonical paths; tar stores them as those top-level dirs.
-      'tar czf "$BUNDLE" --exclude=node_modules --exclude=.git --warning=no-file-changed' +
+      'tar czf "$BUNDLE" --warning=no-file-changed --warning=no-file-ignored' +
+        // Lean safety copy of the workspace + opencode store, NOT a full disk
+        // image: drop regenerable caches/build dirs, secrets, and big browser
+        // state. A full-home tar of a live machine is ~1GB and times out the
+        // CF proxy (502). The opencode store is captured by its own -C below.
+        // .persistent-system holds the browser profile, runtime sockets and
+        // redundant opencode snapshots (often >1G); the LIVE opencode store under
+        // it is captured separately by the -C below (stored as "opencode/..."),
+        // so excluding the dir here drops the weight without losing the chat.
+        ' --exclude=node_modules --exclude=.git --exclude=.persistent-system' +
+        ' --exclude=.cache --exclude=.local --exclude=.config --exclude=.browser-profile' +
+        ' --exclude=.npm --exclude=.bun --exclude=.cargo --exclude=.ssh --exclude=.gnupg' +
         ' -C "$(dirname "$WS")" "$(basename "$WS")"' +
-        ' ${OC:+-C "$(dirname "$OC")" "$(basename "$OC")"}',
+        ' ${OC:+-C "$(dirname "$OC")" "$(basename "$OC")"}' +
+        // tar exits 1 on ignored sockets / files that change mid-read (both normal
+        // on a live machine); only a fatal error (exit >= 2) should fail the backup.
+        ' || [ $? -le 1 ]',
       `curl -fsS -X PUT -H 'x-upsert: true' -H 'Content-Type: application/octet-stream' --data-binary @"$BUNDLE" ${sq(target.url)}`,
       'rm -f "$BUNDLE"',
       'echo OK',


### PR DESCRIPTION
extract failed on live machines two ways once the store resolved:
- tar exits 1 on ignored sockets (.gnupg/.ssh agents, at-spi bus) and on files that change mid-read — both normal on a running box — and `set -euo pipefail` turned that into a hard failure. Tolerate exit 1 (only a fatal >=2 fails), and silence the socket warnings.
- the full-home tar was ~1.7G (mostly .persistent-system/browser-profile), which timed out the CF proxy (502). Exclude .persistent-system (the live opencode store under it is captured by its own -C), caches and secrets. Bundle dropped from 217M to 11M (6s).

Verified against a failing machine: 11M bundle, opencode store + .kortix + files present, no browser junk.

<!--
  Every change to a protected branch goes through this PR + review (SOC 2 CC8.1).
  Fill out each section. PRs cannot be merged without a passing CI check and an
  approving review from someone other than the author.
-->

## Summary

<!-- What does this change do, and why? Link the issue/ticket if there is one. -->

Closes #

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / chore
- [ ] Infrastructure / CI
- [ ] Security fix
- [ ] Breaking change

## How was this tested?

<!-- Commands run, manual steps, screenshots. State what you verified. -->

## Security & data review

- [ ] No secrets, keys, or credentials are committed (verified by secret scan / review)
- [ ] Authorization checks are in place for any new/changed endpoints (IAM / access control)
- [ ] User input is validated (e.g. Zod) and output is safe
- [ ] No sensitive data (tokens, PII, secrets) is written to logs
- [ ] DB schema / migration changes are reviewed and reversible
- [ ] Touches auth / IAM / crypto / billing / migrations → requested the relevant code owner

## Rollout / rollback

<!-- Migrations, feature flags, env vars, and how to revert if this misbehaves. -->

## Reviewer checklist

- [ ] Change is scoped and understandable
- [ ] Tests/CI pass and cover the change
- [ ] Security & data review above is satisfied
