### PR TITLE
fix(web): keep legacy-migration dialog within its width

### DIFF
--- a/apps/web/src/components/projects/legacy-migration-dialog.tsx
+++ b/apps/web/src/components/projects/legacy-migration-dialog.tsx
@@ -54,7 +54,7 @@ export function LegacyMigrationDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-lg">
+      <DialogContent className="max-w-lg sm:max-w-lg">
         <DialogHeader>
           <DialogTitle>Migrate legacy machines</DialogTitle>
           <DialogDescription>
@@ -63,7 +63,7 @@ export function LegacyMigrationDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <div className="flex flex-col gap-2.5">
+        <div className="flex max-h-[60vh] min-w-0 flex-col gap-2.5 overflow-y-auto">
           {isLoading && (
             <div className="flex items-center justify-center py-10 text-muted-foreground">
               <Loader2 className="h-5 w-5 animate-spin" />
@@ -120,7 +120,7 @@ function MachineRow({
   const failed = migration?.status === 'failed';
 
   return (
-    <div className="flex items-center gap-3 rounded-2xl border bg-card p-3">
+    <div className="flex min-w-0 items-center gap-3 rounded-2xl border bg-card p-3">
       <div
         className={cn(
           'flex h-9 w-9 shrink-0 items-center justify-center rounded-xl',
@@ -149,7 +149,7 @@ function MachineRow({
           )}
         </div>
         {failed && migration?.error && (
-          <div className="mt-1 truncate text-xs text-destructive/80" title={migration.error}>
+          <div className="mt-1 line-clamp-2 break-words text-xs text-destructive/80" title={migration.error}>
             {migration.error}
           </div>
         )}


### PR DESCRIPTION
The migration dialog overflowed the viewport: the base DialogContent is a CSS grid with sm:max-w-5xl, so the local max-w-lg only applied below sm, and the grid item's default min-width:auto let the long failed-migration error (a nowrap `truncate` line) stretch the dialog off-screen. Fixes:
- cap width on desktop too (max-w-lg sm:max-w-lg)
- min-w-0 on the body grid item + the row so children can shrink
- the error now line-clamp-2 + break-words (wraps to 2 lines) instead of a single nowrap line; long machine names still truncate
- max-h-[60vh] + overflow-y-auto so long machine lists scroll, not overflow

<!--
  Every change to a protected branch goes through this PR + review (SOC 2 CC8.1).
  Fill out each section. PRs cannot be merged without a passing CI check and an
  approving review from someone other than the author.
-->

## Summary

<!-- What does this change do, and why? Link the issue/ticket if there is one. -->

Closes #

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / chore
- [ ] Infrastructure / CI
- [ ] Security fix
- [ ] Breaking change

## How was this tested?

<!-- Commands run, manual steps, screenshots. State what you verified. -->

## Security & data review

- [ ] No secrets, keys, or credentials are committed (verified by secret scan / review)
- [ ] Authorization checks are in place for any new/changed endpoints (IAM / access control)
- [ ] User input is validated (e.g. Zod) and output is safe
- [ ] No sensitive data (tokens, PII, secrets) is written to logs
- [ ] DB schema / migration changes are reviewed and reversible
- [ ] Touches auth / IAM / crypto / billing / migrations → requested the relevant code owner

## Rollout / rollback

<!-- Migrations, feature flags, env vars, and how to revert if this misbehaves. -->

## Reviewer checklist

- [ ] Change is scoped and understandable
- [ ] Tests/CI pass and cover the change
- [ ] Security & data review above is satisfied
