### PR TITLE
fix(billing): self-heal missing seat subscription item on seat sync

### DIFF
--- a/apps/api/src/billing/services/seat-management.ts
+++ b/apps/api/src/billing/services/seat-management.ts
@@ -21,6 +21,7 @@ import {
   isPerSeatAccount,
   defaultAutoTopupForSeats,
   MAX_SEATS_PER_ACCOUNT,
+  resolvePerSeatPriceId,
 } from './tiers';
 
 export async function countActiveMembers(accountId: string): Promise<number> {
@@ -29,6 +30,35 @@ export async function countActiveMembers(accountId: string): Promise<number> {
     .from(accountMembers)
     .where(eq(accountMembers.accountId, accountId));
   return rows.length;
+}
+
+/**
+ * Resolve (and persist) the per-seat subscription item id for a per_seat account
+ * whose `seat_subscription_item_id` was never recorded. Looks up the live
+ * subscription and finds the item on the per-seat price. Returns null — and
+ * leaves the account untouched — when the subscription has no per-seat item (the
+ * account isn't really on a seat plan) or the lookup fails; the caller then skips
+ * the Stripe sync rather than acting on a wrong item.
+ */
+async function resolveSeatSubscriptionItemId(
+  accountId: string,
+  subscriptionId: string,
+): Promise<string | null> {
+  const priceId = resolvePerSeatPriceId();
+  if (!priceId) return null;
+  try {
+    const sub = await getStripe().subscriptions.retrieve(subscriptionId);
+    const item = sub.items.data.find((i) => i.price?.id === priceId);
+    if (!item) return null;
+    await updateCreditAccount(accountId, { seatSubscriptionItemId: item.id } as any);
+    return item.id;
+  } catch (err) {
+    console.error(
+      `[seat-management] failed to resolve seat item for ${accountId} (sub ${subscriptionId}):`,
+      err instanceof Error ? err.message : String(err),
+    );
+    return null;
+  }
 }
 
 /**
@@ -52,7 +82,22 @@ export async function syncSeatQuantity(accountId: string): Promise<{
   if (!account?.stripeSubscriptionId) {
     return { synced: false, seatCount: 0, skipped: 'no-subscription' };
   }
-  if (!account.seatSubscriptionItemId) {
+  // seat_subscription_item_id can be missing if the account reached per_seat via
+  // a path that never recorded it — the lazy-migration "flip the flag" shortcut,
+  // or before the subscription.updated webhook landed. Self-heal: resolve the
+  // per-seat item from the live subscription and persist it, so seat changes
+  // actually propagate to Stripe instead of silently no-op'ing.
+  let seatItemId = account.seatSubscriptionItemId;
+  if (!seatItemId) {
+    seatItemId = await resolveSeatSubscriptionItemId(accountId, account.stripeSubscriptionId);
+  }
+  if (!seatItemId) {
+    // per_seat + has a subscription, but it carries no per-seat item — the
+    // account is half-migrated (flipped to per_seat without a real seat sub).
+    // Surface it; it needs a per-seat subscription before seats can bill.
+    console.warn(
+      `[seat-management] ${accountId} is per_seat but its subscription ${account.stripeSubscriptionId} has no per-seat item; seat sync skipped`,
+    );
     return { synced: false, seatCount: 0, skipped: 'no-item' };
   }
 
@@ -60,7 +105,7 @@ export async function syncSeatQuantity(accountId: string): Promise<{
 
   const stripe = getStripe();
   try {
-    await stripe.subscriptionItems.update(account.seatSubscriptionItemId, {
+    await stripe.subscriptionItems.update(seatItemId, {
       quantity: seatCount,
       // proration_behavior defaults to 'create_prorations' which is what we
       // want — Stripe creates an invoice line item for the delta on next bill.


### PR DESCRIPTION
A per_seat account could end up with seat_subscription_item_id=null (e.g. the lazy-migration "no active subs → flip the flag" shortcut, or before the subscription.updated webhook lands). syncSeatQuantity then silently skipped with 'no-item', so adding/removing a member never propagated the new quantity to Stripe — the customer kept paying for the old seat count.

Now, when the item id is missing but a subscription exists, resolve the per-seat item from the live Stripe subscription and persist it before pushing the quantity. If the subscription genuinely has no per-seat item (account is half-migrated — flipped to per_seat without a real seat sub), warn instead of silently no-op'ing so it's visible and can be re-subscribed.

<!--
  Every change to a protected branch goes through this PR + review (SOC 2 CC8.1).
  Fill out each section. PRs cannot be merged without a passing CI check and an
  approving review from someone other than the author.
-->

## Summary

<!-- What does this change do, and why? Link the issue/ticket if there is one. -->

Closes #

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / chore
- [ ] Infrastructure / CI
- [ ] Security fix
- [ ] Breaking change

## How was this tested?

<!-- Commands run, manual steps, screenshots. State what you verified. -->

## Security & data review

- [ ] No secrets, keys, or credentials are committed (verified by secret scan / review)
- [ ] Authorization checks are in place for any new/changed endpoints (IAM / access control)
- [ ] User input is validated (e.g. Zod) and output is safe
- [ ] No sensitive data (tokens, PII, secrets) is written to logs
- [ ] DB schema / migration changes are reviewed and reversible
- [ ] Touches auth / IAM / crypto / billing / migrations → requested the relevant code owner

## Rollout / rollback

<!-- Migrations, feature flags, env vars, and how to revert if this misbehaves. -->

## Reviewer checklist

- [ ] Change is scoped and understandable
- [ ] Tests/CI pass and cover the change
- [ ] Security & data review above is satisfied
