### PR TITLE
fix(migration): keep the git push lean (exclude .persistent-system + kortix/services)

### DIFF
--- a/apps/api/src/projects/legacy-migration-steps.ts
+++ b/apps/api/src/projects/legacy-migration-steps.ts
@@ -243,7 +243,13 @@ export async function repoStep(ctx: MigrationContext): Promise<void> {
 // via .git/info/exclude (local, never committed) AND a committed .gitignore (so
 // future sessions in the new project don't re-add the junk).
 const PUSH_EXCLUDES = [
-  // Caches / regenerable
+  // Caches / regenerable. .persistent-system is the big one (often >1G of browser
+  // profile + runtime sockets + redundant opencode snapshots); the chat store is
+  // rehydrated separately, so the project repo never needs any of it.
+  // .kortix/services + backups are runtime service state/logs (can be 100M+); the
+  // new sandbox regenerates them. Keep the small, meaningful .kortix/* (config,
+  // memory, triggers, kortix.db, agent-triggers).
+  '.persistent-system', '.kortix/services', '.kortix/backups',
   'node_modules', '.cache', '.npm', '.npm-global', '.bun', '.cargo', '.rustup',
   '.pnpm-store', '.local', '.config', '.mozilla', '.browser-profile',
   '.cursor-server', '.vscode-server', '.dbus', '.XDG', '__pycache__', '.venv', 'venv',


### PR DESCRIPTION
(step 3) failed with a toolbox 502: `git add -A` was staging the 1.7G .persistent-system/browser-profile and 117M .kortix/services (runtime state/logs), so the exec ran long and the CF proxy dropped it. PUSH_EXCLUDES listed `.browser-profile` at the home root but the weight is under .persistent-system; add .persistent-system, .kortix/services and .kortix/backups. The push set drops from ~1.7G to 3.5M while keeping .opencode, the small .kortix/* (config, memory, triggers, kortix.db, agent-triggers) and the user's files. Mirrors the extract-bundle exclusions.

<!--
  Every change to a protected branch goes through this PR + review (SOC 2 CC8.1).
  Fill out each section. PRs cannot be merged without a passing CI check and an
  approving review from someone other than the author.
-->

## Summary

<!-- What does this change do, and why? Link the issue/ticket if there is one. -->

Closes #

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / chore
- [ ] Infrastructure / CI
- [ ] Security fix
- [ ] Breaking change

## How was this tested?

<!-- Commands run, manual steps, screenshots. State what you verified. -->

## Security & data review

- [ ] No secrets, keys, or credentials are committed (verified by secret scan / review)
- [ ] Authorization checks are in place for any new/changed endpoints (IAM / access control)
- [ ] User input is validated (e.g. Zod) and output is safe
- [ ] No sensitive data (tokens, PII, secrets) is written to logs
- [ ] DB schema / migration changes are reviewed and reversible
- [ ] Touches auth / IAM / crypto / billing / migrations → requested the relevant code owner

## Rollout / rollback

<!-- Migrations, feature flags, env vars, and how to revert if this misbehaves. -->

## Reviewer checklist

- [ ] Change is scoped and understandable
- [ ] Tests/CI pass and cover the change
- [ ] Security & data review above is satisfied
