### PR TITLE
fix(billing): point staging per-seat price at the staging Stripe account

### DIFF
--- a/apps/api/src/billing/services/tiers.ts
+++ b/apps/api/src/billing/services/tiers.ts
@@ -251,8 +251,11 @@ const STRIPE_PRICES_STAGING: StripePriceConfig = {
   subscriptions: {
     free: { monthly: 'price_1RIGvuG6l1KZGqIrw14abxeL' },
     pro:  { monthly: 'price_1T7yiuG6CaZppiKc7VsgnlKI' },
-    // Billing v2 — $20/month recurring under product prod_UAFOsPU765hNnu (test mode).
-    per_seat: { monthly: 'price_1TbQv8G6l1KZGqIrdRLsUnCz' },
+    // Billing v2 — $20/month per-seat in the staging Stripe account (acct_…G6CaZppiKc),
+    // the same account the staging customers + their legacy subs live in (so the
+    // migration can actually find/cancel them). The old …G6l1KZGqIr price was in a
+    // different account and is being deprecated.
+    per_seat: { monthly: 'price_1TdSdvG6CaZppiKctAZXPPY0' },
   },
   credits: {
     10:  'price_1RxXOvG6l1KZGqIrMqsiYQvk',


### PR DESCRIPTION
The staging per-seat price was price_1TbQv8…G6l1KZGqIr in the old "Kortix" account (acct_…G6l1KZGqIr) — a different account than the one holding staging's customers + their legacy subs (acct_…G6CaZppiKc). The seat-migration couldn't find/cancel customers or create the seat sub there. Use the staging-account price price_1TdSdv…G6CaZppiKc. Prod (price_1TcrQJ…) is unchanged. Old price deprecated.

<!--
  Every change to a protected branch goes through this PR + review (SOC 2 CC8.1).
  Fill out each section. PRs cannot be merged without a passing CI check and an
  approving review from someone other than the author.
-->

## Summary

<!-- What does this change do, and why? Link the issue/ticket if there is one. -->

Closes #

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / chore
- [ ] Infrastructure / CI
- [ ] Security fix
- [ ] Breaking change

## How was this tested?

<!-- Commands run, manual steps, screenshots. State what you verified. -->

## Security & data review

- [ ] No secrets, keys, or credentials are committed (verified by secret scan / review)
- [ ] Authorization checks are in place for any new/changed endpoints (IAM / access control)
- [ ] User input is validated (e.g. Zod) and output is safe
- [ ] No sensitive data (tokens, PII, secrets) is written to logs
- [ ] DB schema / migration changes are reviewed and reversible
- [ ] Touches auth / IAM / crypto / billing / migrations → requested the relevant code owner

## Rollout / rollback

<!-- Migrations, feature flags, env vars, and how to revert if this misbehaves. -->

## Reviewer checklist

- [ ] Change is scoped and understandable
- [ ] Tests/CI pass and cover the change
- [ ] Security & data review above is satisfied
