### PR TITLE
Make legacy machine + billing migration work end-to-end (robustness + Stripe-account fixes)

### DIFF
--- a/apps/api/src/billing/repositories/customers.ts
+++ b/apps/api/src/billing/repositories/customers.ts
@@ -175,3 +175,12 @@ export async function upsertCustomer(data: {
     active: data.active ?? null,
   };
 }
+
+/**
+ * Remove a stored Stripe customer row by its id. Used to drop a stale mapping —
+ * a customer id created under a different Stripe account (e.g. after the key was
+ * repointed) that no longer exists, so a fresh one can be created and persisted.
+ */
+export async function deleteCustomerByStripeId(stripeCustomerId: string): Promise<void> {
+  await db.delete(billingCustomers).where(eq(billingCustomers.id, stripeCustomerId));
+}

--- a/apps/api/src/billing/services/legacy-account-migration.ts
+++ b/apps/api/src/billing/services/legacy-account-migration.ts
@@ -29,7 +29,7 @@ import { sandboxes } from '@kortix/db';
 import { db } from '../../shared/db';
 import { getStripe } from '../../shared/stripe';
 import { getCreditAccount, updateCreditAccount } from '../repositories/credit-accounts';
-import { getCustomerByAccountId } from '../repositories/customers';
+import { resolveLiveStripeCustomerId } from './subscriptions';
 import { countActiveMembers } from './seat-management';
 import { grantCredits } from './credits';
 import { resolvePerSeatPriceId, defaultAutoTopupForSeats, MAX_SEATS_PER_ACCOUNT } from './tiers';
@@ -85,13 +85,17 @@ export async function maybeMigrateLegacyAccount(accountId: string): Promise<Migr
       return defaultResult('skipped:already_per_seat');
     }
 
-    const customer = await getCustomerByAccountId(accountId);
+    // Resolve a LIVE customer in the current Stripe account (drops a stale
+    // mapping from a different account and returns null). A stale/absent customer
+    // means no reachable subs → it falls through to the no-subs path below rather
+    // than 500ing on "No such customer".
+    const customerId = await resolveLiveStripeCustomerId(accountId);
     const stripe = getStripe();
     const now = Math.floor(Date.now() / 1000);
 
     // 1. Inventory active Stripe subs (may be none if the user is on free tier)
-    const activeSubs: Stripe.Subscription[] = customer
-      ? (await stripe.subscriptions.list({ customer: customer.id, status: 'active', limit: 100 })).data
+    const activeSubs: Stripe.Subscription[] = customerId
+      ? (await stripe.subscriptions.list({ customer: customerId, status: 'active', limit: 100 })).data
       : [];
 
     if (activeSubs.length === 0) {
@@ -110,7 +114,7 @@ export async function maybeMigrateLegacyAccount(accountId: string): Promise<Migr
       console.error(`[lazy-migrate] refusing migration for ${accountId}: per-seat price not configured`);
       return defaultResult('failed', 'per-seat price not configured');
     }
-    if (!customer) {
+    if (!customerId) {
       console.error(`[lazy-migrate] refusing migration for ${accountId}: no Stripe customer record`);
       return defaultResult('failed', 'no Stripe customer for account with active subs');
     }
@@ -122,7 +126,7 @@ export async function maybeMigrateLegacyAccount(accountId: string): Promise<Migr
     let newSubscription: Stripe.Subscription;
     try {
       newSubscription = await stripe.subscriptions.create({
-        customer: customer.id,
+        customer: customerId,
         items: [{ price: priceId, quantity: seatCount }],
         collection_method: 'charge_automatically',
         metadata: {

--- a/apps/api/src/billing/services/subscriptions.ts
+++ b/apps/api/src/billing/services/subscriptions.ts
@@ -15,37 +15,47 @@ import { isPlatformAdmin } from '../../shared/platform-roles';
 import Stripe from 'stripe';
 import { AUTO_TOPUP_DEFAULT_AMOUNT, AUTO_TOPUP_DEFAULT_THRESHOLD } from '@kortix/shared';
 
+/** True for Stripe's "No such customer" (resource_missing). */
+function isStripeNoSuchCustomer(err: unknown): boolean {
+  const e = err as { statusCode?: number; code?: string; raw?: { code?: string }; message?: string };
+  return e?.statusCode === 404
+    || e?.code === 'resource_missing'
+    || e?.raw?.code === 'resource_missing'
+    || /no such customer/i.test(e?.message ?? '');
+}
+
+/**
+ * The account's Stripe customer id — but ONLY if it still exists in the CURRENT
+ * Stripe account. The env key can point at a different account than the one the
+ * id was created in (e.g. after the key is repointed), leaving a stale id that
+ * 500s every downstream call ("No such customer"). On a missing customer we drop
+ * the stale mapping and return null so callers can recreate (checkout) or skip
+ * (read-only paths). Only a non-missing (transient) Stripe error throws.
+ */
+export async function resolveLiveStripeCustomerId(accountId: string): Promise<string | null> {
+  const existing = await getCustomerByAccountId(accountId);
+  if (!existing) return null;
+  try {
+    const cust = await getStripe().customers.retrieve(existing.id);
+    if (!('deleted' in cust) || !cust.deleted) return existing.id;
+  } catch (err) {
+    if (!isStripeNoSuchCustomer(err)) throw err;
+  }
+  console.warn(
+    `[billing] Stripe customer ${existing.id} for ${accountId} not found in the current Stripe account; dropping stale mapping`,
+  );
+  await deleteCustomerByStripeId(existing.id);
+  return null;
+}
+
 export async function getOrCreateStripeCustomer(
   accountId: string,
   email: string,
 ): Promise<string> {
-  const stripe = getStripe();
+  const live = await resolveLiveStripeCustomerId(accountId);
+  if (live) return live;
 
-  const existing = await getCustomerByAccountId(accountId);
-  if (existing) {
-    // Verify the stored customer still exists in the CURRENT Stripe account. The
-    // env key can point at a different account than the one the id was created
-    // in (e.g. after the key is repointed), leaving a stale id that 500s every
-    // downstream call (checkout, subscription create, …) with "No such customer".
-    // If it's gone, drop the stale mapping and recreate below.
-    try {
-      const cust = await stripe.customers.retrieve(existing.id);
-      if (!('deleted' in cust) || !cust.deleted) return existing.id;
-    } catch (err) {
-      const code = (err as { code?: string; raw?: { code?: string } })?.code
-        ?? (err as { raw?: { code?: string } })?.raw?.code;
-      const missing = (err as { statusCode?: number })?.statusCode === 404
-        || code === 'resource_missing'
-        || /no such customer/i.test((err as Error)?.message ?? '');
-      if (!missing) throw err;
-      console.warn(
-        `[billing] Stripe customer ${existing.id} for ${accountId} not found in the current Stripe account; recreating`,
-      );
-      await deleteCustomerByStripeId(existing.id);
-    }
-  }
-
-  const customer = await stripe.customers.create({
+  const customer = await getStripe().customers.create({
     email,
     metadata: { account_id: accountId },
   });
@@ -421,8 +431,9 @@ export async function confirmInlineCheckout(params: {
 }
 
 export async function createPortalSession(accountId: string, returnUrl: string, email?: string) {
-  let customer = await getCustomerByAccountId(accountId);
-  let customerId = customer?.id ?? null;
+  // Verify the stored customer exists in the current Stripe account (drops a
+  // stale id); recreate it if missing so the portal never 500s on "No such customer".
+  let customerId = await resolveLiveStripeCustomerId(accountId);
   if (!customerId) {
     if (!email) throw new BillingError('No billing customer found');
     customerId = await getOrCreateStripeCustomer(accountId, email);

--- a/apps/api/src/billing/services/subscriptions.ts
+++ b/apps/api/src/billing/services/subscriptions.ts
@@ -6,7 +6,7 @@ import {
   updateCreditAccount,
   upsertCreditAccount,
 } from '../repositories/credit-accounts';
-import { getCustomerByAccountId, upsertCustomer } from '../repositories/customers';
+import { getCustomerByAccountId, upsertCustomer, deleteCustomerByStripeId } from '../repositories/customers';
 import { BillingError, SubscriptionError } from '../../errors';
 import { getTier, isUpgrade, resolvePriceId, getComputeDisplayPriceCents, getComputeProductId, getComputeDescription, resolvePerSeatPriceId, MAX_SEATS_PER_ACCOUNT } from './tiers';
 import { countActiveMembers } from './seat-management';
@@ -19,10 +19,32 @@ export async function getOrCreateStripeCustomer(
   accountId: string,
   email: string,
 ): Promise<string> {
-  const existing = await getCustomerByAccountId(accountId);
-  if (existing) return existing.id;
-
   const stripe = getStripe();
+
+  const existing = await getCustomerByAccountId(accountId);
+  if (existing) {
+    // Verify the stored customer still exists in the CURRENT Stripe account. The
+    // env key can point at a different account than the one the id was created
+    // in (e.g. after the key is repointed), leaving a stale id that 500s every
+    // downstream call (checkout, subscription create, …) with "No such customer".
+    // If it's gone, drop the stale mapping and recreate below.
+    try {
+      const cust = await stripe.customers.retrieve(existing.id);
+      if (!('deleted' in cust) || !cust.deleted) return existing.id;
+    } catch (err) {
+      const code = (err as { code?: string; raw?: { code?: string } })?.code
+        ?? (err as { raw?: { code?: string } })?.raw?.code;
+      const missing = (err as { statusCode?: number })?.statusCode === 404
+        || code === 'resource_missing'
+        || /no such customer/i.test((err as Error)?.message ?? '');
+      if (!missing) throw err;
+      console.warn(
+        `[billing] Stripe customer ${existing.id} for ${accountId} not found in the current Stripe account; recreating`,
+      );
+      await deleteCustomerByStripeId(existing.id);
+    }
+  }
+
   const customer = await stripe.customers.create({
     email,
     metadata: { account_id: accountId },


### PR DESCRIPTION
Hardens the legacy-sandbox migration and the legacy→per-seat billing migration so they actually complete on staging/prod, plus a couple of UI fixes surfaced along the way. Each commit is a self-contained fix; this is the set landed in this pass.

### Migration (JustAVPS machine → project)
- **`extract` is robust + lean.** `tar` was aborting under `set -euo pipefail` on ignored sockets (`.gnupg`/`.ssh` agents, at-spi) and on files that change mid-read — both normal on a live box. Now tolerate tar exit 1 (only a fatal ≥2 fails), and exclude the ~1.7G `.persistent-system` (browser profile + runtime sockets + redundant opencode snapshots) so the backup doesn't time out the CF proxy. Bundle dropped from 217M to ~11M.
- **`push` is lean.** `git add -A` was staging the same 1.7G `.persistent-system` plus 117M `.kortix/services` (runtime state), timing out the toolbox exec (502). Excluding those drops the push from ~1.7G to ~3.5M while keeping files, `.opencode` agents/skills, and the meaningful `.kortix/*` (config, memory, triggers, kortix.db, agent-triggers).

### Billing (legacy → per-seat)
- **Staging per-seat price pointed at the right Stripe account.** The staging price lived in a *different* Stripe account than the one holding staging's customers + their legacy subs, so the migration/checkout couldn't find/cancel customers or create the seat sub. Repointed to the staging-account price; prod is unchanged.
- **Create the seat sub BEFORE cancelling legacy subs.** The migration cancelled all legacy subs first, then created the seat sub — so a create failure (no payment method, declined card, …) left the customer with *no subscription at all*. Now it creates first and only cancels on success; a create failure aborts with the legacy subs intact.
- **Self-heal a missing `seat_subscription_item_id`.** An account could reach `per_seat` without a recorded seat item (the "no-subs flip" shortcut), so `syncSeatQuantity` silently skipped and seat changes never reached Stripe. Now it resolves the per-seat item from the live subscription and persists it.
- **Every Stripe-customer path is resilient to a stale customer id.** Accounts whose `billing_customers` id was created under a different Stripe account (after the key was repointed) 500'd with "No such customer" — including freshly-created accounts. Centralized into `resolveLiveStripeCustomerId(accountId)` (verify-in-current-account → drop-stale → null); applied to checkout (`getOrCreateStripeCustomer`), the billing portal, and the migration. `legacy-stripe-sync` and `auto-topup` already guarded.

### Web
- **Account billing "Subscribe to Team plan" now works.** The button opens the upgrade-dialog store, but the renderer (`GlobalUpgradeDialog`) was only mounted on share pages — never on `/accounts/[id]`, so the click did nothing. Mount it inside the billing tab's `BillingAccountProvider` so the dialog appears and is scoped to the viewed account.
- **Migration dialog stays within its width.** The failed-migration error stretched the dialog off-screen; clamp it (wrap to 2 lines), cap the dialog at `lg`, `min-w-0` the grid item, and scroll long machine lists.

### Verified
- Migration extract/push run cleanly on the previously-failing JustAVPS machines (lean bundle/push, all meaningful content preserved).
- Billing migration run end-to-end against staging Stripe: legacy subs cancelled → seat sub created → prorated remainder granted as non-expiring credit → flipped to `per_seat`.

### Deploy notes
- These need to be deployed for the cloud (`dev-api`) to pick them up.
- **Stripe config must be consistent per environment:** `STRIPE_SECRET_KEY` and the per-seat price id must belong to the **same** Stripe account (the one holding that env's customers). The self-heal masks a mismatch but ideally the key + price are the same account.
- The billing migration requires the env's Stripe key to match the customers' account, or every run aborts at the customer lookup.

### Known follow-ups (not in this PR)
- The durable migration runner retries with a fixed 60s interval / 5-attempt cap and no backoff, so a transient provider outage (Freestyle 502) dead-letters a migration. Add exponential backoff.
- `withAdvisoryLock` can leak a `pg_advisory_lock` when lock/unlock land on different pooled connections; pin a reserved connection.
- Move the captured opencode chat archive from the Postgres column to S3 so decommissioned VMs scale.
