### PR TITLE
feat(billing): self-service 'claim seat-based pricing' for legacy users

### DIFF
--- a/apps/api/src/billing/routes/subscriptions.ts
+++ b/apps/api/src/billing/routes/subscriptions.ts
@@ -17,8 +17,31 @@ import {
 } from '../services/subscriptions';
 import { resolveScopedAccountId } from '../../shared/resolve-account';
 import { syncSeatQuantity } from '../services/seat-management';
+import { maybeMigrateLegacyAccount } from '../services/legacy-account-migration';
 
 export const subscriptionsRouter = new Hono<AppEnv>();
+
+// Billing v2 — legacy → per-seat voluntary "claim". Runs the SAME migration as
+// the lazy sign-in path (create the $20/seat sub, cancel the legacy machine subs,
+// pre-pay the first seat period out of the unused machine value + return the
+// leftover as non-expiring credit, flip to per_seat) — but synchronously, so the
+// billing UI can show the result. Lets legacy users who weren't auto-migrated
+// (or where it silently skipped/failed) move themselves over with feedback.
+subscriptionsRouter.post('/claim-per-seat', async (c) => {
+  const accountId = await resolveScopedAccountId(c, 'body');
+  const result = await maybeMigrateLegacyAccount(accountId);
+  if (result.status === 'failed') {
+    return c.json({ ok: false, status: result.status, error: result.reason ?? 'Migration failed' }, 400);
+  }
+  return c.json({
+    ok: true,
+    status: result.status, // 'migrated' | 'skipped:already_per_seat' | 'skipped:no_subs' | …
+    credited_usd: result.proratedCreditUsd,
+    first_seat_covered_usd: result.firstSeatCoveredUsd,
+    cancelled_subscriptions: result.cancelledSubIds.length,
+    reason: result.reason ?? null,
+  });
+});
 
 subscriptionsRouter.post('/create-checkout-session', async (c) => {
   const accountId = await resolveScopedAccountId(c, 'body');

--- a/apps/api/src/billing/services/legacy-account-migration.ts
+++ b/apps/api/src/billing/services/legacy-account-migration.ts
@@ -32,12 +32,11 @@ import { getCreditAccount, updateCreditAccount } from '../repositories/credit-ac
 import { resolveLiveStripeCustomerId } from './subscriptions';
 import { countActiveMembers } from './seat-management';
 import { grantCredits } from './credits';
-import { resolvePerSeatPriceId, defaultAutoTopupForSeats, MAX_SEATS_PER_ACCOUNT } from './tiers';
+import { resolvePerSeatPriceId, defaultAutoTopupForSeats, MAX_SEATS_PER_ACCOUNT, PER_SEAT_PRICE_USD } from './tiers';
 
 const ADVISORY_LOCK_NS = 'lazy_migrate';
 
 function lockKey(accountId: string): bigint {
-  // Hash accountId UUID into a stable 63-bit key for pg_advisory_lock.
   let h = 14695981039346656037n;
   for (const ch of `${ADVISORY_LOCK_NS}:${accountId}`) {
     h ^= BigInt(ch.charCodeAt(0));
@@ -49,6 +48,7 @@ function lockKey(accountId: string): bigint {
 interface MigrationResult {
   status: 'migrated' | 'skipped:already_per_seat' | 'skipped:yearly_commitment' | 'skipped:no_subs' | 'skipped:no_legacy_machine' | 'failed';
   proratedCreditUsd: number;
+  firstSeatCoveredUsd: number;
   cancelledSubIds: string[];
   newSubscriptionId: string | null;
   stoppedSandboxIds: string[];
@@ -70,44 +70,29 @@ export async function maybeMigrateLegacyAccount(accountId: string): Promise<Migr
     }
   }
 
-  // Only customers who actually own a legacy machine (a kortix.sandboxes
-  // instance) are migrated to seat-based billing. A legacy-billing account with
-  // no machine is left untouched — we never cancel a subscription for someone
-  // who has no legacy instance to move off of.
   if (!(await accountHasLegacyMachine(accountId))) {
     return defaultResult('skipped:no_legacy_machine');
   }
 
   return await withAdvisoryLock(accountId, async () => {
-    // Re-read inside the lock — another worker may have raced ahead.
     const fresh = await getCreditAccount(accountId);
     if (!fresh || fresh.billingModel === 'per_seat') {
       return defaultResult('skipped:already_per_seat');
     }
 
-    // Resolve a LIVE customer in the current Stripe account (drops a stale
-    // mapping from a different account and returns null). A stale/absent customer
-    // means no reachable subs → it falls through to the no-subs path below rather
-    // than 500ing on "No such customer".
     const customerId = await resolveLiveStripeCustomerId(accountId);
     const stripe = getStripe();
     const now = Math.floor(Date.now() / 1000);
 
-    // 1. Inventory active Stripe subs (may be none if the user is on free tier)
     const activeSubs: Stripe.Subscription[] = customerId
       ? (await stripe.subscriptions.list({ customer: customerId, status: 'active', limit: 100 })).data
       : [];
 
     if (activeSubs.length === 0) {
-      // No paid history — just flip the flag, they'll subscribe via the new
-      // per-seat checkout flow whenever they want to.
       await updateCreditAccount(accountId, { billingModel: 'per_seat' } as any);
       return defaultResult('skipped:no_subs');
     }
 
-    // Pre-flight: refuse to cancel any legacy sub until we've confirmed we can
-    // create the replacement. Otherwise a missing per-seat price ID would leave
-    // the customer with no subscription at all.
     const seatCount = Math.min(MAX_SEATS_PER_ACCOUNT, Math.max(1, await countActiveMembers(accountId)));
     const priceId = resolvePerSeatPriceId();
     if (!priceId) {
@@ -119,10 +104,39 @@ export async function maybeMigrateLegacyAccount(accountId: string): Promise<Migr
       return defaultResult('failed', 'no Stripe customer for account with active subs');
     }
 
-    // 2. Create the per-seat sub FIRST — BEFORE cancelling anything. This is the
-    //    critical safety property: if the charge can't be set up (no payment
-    //    method, card declined, Stripe error, …) we abort with the customer's
-    //    legacy subs still intact, never leaving them with no subscription at all.
+    // The unused (prorated) value of the legacy machine subs is returned IN FULL,
+    // split so the move costs nothing out of pocket now:
+    //   • the FIRST seat period is pre-paid from it (a Stripe customer-balance
+    //     credit that offsets the first per-seat invoice), and
+    //   • the leftover is granted as non-expiring wallet credit.
+    // e.g. $100 remaining, 1 seat → $20 covers the first seat month + $80 credit.
+    const totalProratedUsd = round2(
+      activeSubs.reduce((sum, sub) => sum + computeProratedRemaining(sub, now), 0),
+    );
+    const seatCostUsd = PER_SEAT_PRICE_USD * seatCount;
+    const firstSeatCoveredUsd = round2(Math.min(seatCostUsd, totalProratedUsd));
+    const walletCreditUsd = round2(totalProratedUsd - firstSeatCoveredUsd);
+
+    // Apply the first-seat offset as a customer-balance credit BEFORE creating the
+    // sub so the first invoice picks it up (often → $0, so no payment method is
+    // even required). Non-fatal: if it errors, the seat just bills normally.
+    if (firstSeatCoveredUsd > 0) {
+      try {
+        await stripe.customers.createBalanceTransaction(customerId, {
+          amount: -Math.round(firstSeatCoveredUsd * 100), // negative = credit to the customer
+          currency: 'usd',
+          description: 'Legacy machine credit applied to first seat period',
+        });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error(`[lazy-migrate] failed to apply first-seat balance credit for ${accountId}: ${msg}`);
+      }
+    }
+
+    // 2. Create the per-seat sub — BEFORE cancelling anything. Critical safety
+    //    property: if the charge can't be set up we abort with the customer's
+    //    legacy subs intact, never leaving them with no subscription. The first
+    //    invoice is offset by the balance credit above.
     let newSubscription: Stripe.Subscription;
     try {
       newSubscription = await stripe.subscriptions.create({
@@ -142,14 +156,11 @@ export async function maybeMigrateLegacyAccount(accountId: string): Promise<Migr
       return defaultResult('failed', `create per-seat sub: ${msg}`);
     }
 
-    // 3. The seat sub is now active — cancel the legacy subs and sum their
-    //    prorated remainder. A cancel failure here is non-fatal: the replacement
-    //    is already in place, so we log it for manual cleanup and continue rather
-    //    than stranding the account.
-    let totalProratedUsd = 0;
+    // 3. The seat sub is now active — cancel the legacy subs (prorate:false; we've
+    //    already computed + returned their remainder). A cancel failure here is
+    //    non-fatal: the replacement is already in place, so we log for cleanup.
     const cancelledSubIds: string[] = [];
     for (const sub of activeSubs) {
-      totalProratedUsd += computeProratedRemaining(sub, now);
       try {
         await stripe.subscriptions.cancel(sub.id, { prorate: false } as any);
         cancelledSubIds.push(sub.id);
@@ -159,13 +170,12 @@ export async function maybeMigrateLegacyAccount(accountId: string): Promise<Migr
       }
     }
 
-    // 4. Grant the prorated credit (non-expiring) — credit_ledger is the audit log.
-    // Refuse to flip billing_model if the grant fails, otherwise the customer
-    // would lose their prorated credit silently.
-    if (totalProratedUsd > 0) {
-      const description = `Legacy migration credit (cancelled ${cancelledSubIds.length} subscription${cancelledSubIds.length === 1 ? '' : 's'})`;
+    // 4. Grant the leftover as non-expiring wallet credit. Refuse to flip
+    //    billing_model if the grant fails, otherwise the credit is lost silently.
+    if (walletCreditUsd > 0) {
+      const description = `Legacy migration credit (cancelled ${cancelledSubIds.length} subscription${cancelledSubIds.length === 1 ? '' : 's'}; first seat period pre-paid)`;
       try {
-        const granted = await grantCredits(accountId, totalProratedUsd, 'legacy_migration', description, false);
+        const granted = await grantCredits(accountId, walletCreditUsd, 'legacy_migration', description, false);
         if (granted && typeof granted === 'object' && 'success' in granted && (granted as any).success === false) {
           console.error(`[lazy-migrate] grantCredits returned success=false for ${accountId}: ${JSON.stringify(granted)}`);
           return defaultResult('failed', 'credit grant returned success=false');
@@ -196,7 +206,8 @@ export async function maybeMigrateLegacyAccount(accountId: string): Promise<Migr
 
     return {
       status: 'migrated',
-      proratedCreditUsd: round2(totalProratedUsd),
+      proratedCreditUsd: walletCreditUsd,
+      firstSeatCoveredUsd,
       cancelledSubIds,
       newSubscriptionId: newSubscription?.id ?? null,
       stoppedSandboxIds,
@@ -277,6 +288,7 @@ function defaultResult(
   return {
     status,
     proratedCreditUsd: 0,
+    firstSeatCoveredUsd: 0,
     cancelledSubIds: [],
     newSubscriptionId: null,
     stoppedSandboxIds: [],

--- a/apps/web/src/components/billing/claim-per-seat-card.tsx
+++ b/apps/web/src/components/billing/claim-per-seat-card.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { ArrowRight, Loader2, Sparkles } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { useClaimPerSeat } from '@/hooks/billing/use-account-state';
+import type { AccountState } from '@/lib/api/billing';
+
+export function ClaimPerSeatCard({ accountState }: { accountState?: AccountState }) {
+  const claim = useClaimPerSeat();
+  if (!accountState || accountState.billing_model !== 'legacy') return null;
+
+  return (
+    <div className="rounded-xl border border-primary/20 bg-primary/5 p-4 space-y-3">
+      <div className="flex items-start gap-2.5">
+        <Sparkles className="size-4 text-primary mt-0.5 shrink-0" />
+        <div className="space-y-1 min-w-0">
+          <p className="text-sm font-medium">Switch to seat-based pricing</p>
+          <p className="text-xs text-muted-foreground">
+            Move off per-machine billing to the new $20/seat plan. We cancel your machine
+            subscriptions, put your unused balance toward your first seat, and return the
+            rest as <span className="font-medium text-foreground">non-expiring credit</span>.
+          </p>
+        </div>
+      </div>
+      <Button
+        size="sm"
+        onClick={() => claim.mutate()}
+        disabled={claim.isPending}
+        className="w-full sm:w-auto"
+      >
+        {claim.isPending ? (
+          <><Loader2 className="size-3.5 animate-spin mr-1.5" />Switching…</>
+        ) : (
+          <>Claim seat-based pricing<ArrowRight className="size-3.5 ml-1.5" /></>
+        )}
+      </Button>
+      {claim.isError && (
+        <p className="text-xs text-destructive break-words">
+          {(claim.error as Error)?.message ?? 'Could not switch. Try again or contact support.'}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/settings/user-settings-modal.tsx
+++ b/apps/web/src/components/settings/user-settings-modal.tsx
@@ -58,6 +58,7 @@ import { useAuth } from '@/components/AuthProvider';
 import { useUserSettingsModalStore } from '@/stores/user-settings-modal-store';
 import { AutoTopupCard } from '@/components/billing/auto-topup-card';
 import { SeatManagementCard } from '@/components/billing/seat-management-card';
+import { ClaimPerSeatCard } from '@/components/billing/claim-per-seat-card';
 import { AccountOverviewTab } from '@/components/billing/account-overview';
 import { useUpgradeDialogStore } from '@/stores/upgrade-dialog-store';
 import {
@@ -1484,6 +1485,9 @@ export function BillingTab({ returnUrl, isActive }: { returnUrl: string; isActiv
 
                     {/* Plan / wallet / spend / limits */}
                     <AccountOverviewTab accountId={billingAccountId} />
+
+                    {/* Legacy machine-billed users — claim the new seat-based plan */}
+                    {accountState?.billing_model === 'legacy' && <ClaimPerSeatCard accountState={accountState} />}
 
                     {/* Team seats — when on the per-seat plan */}
                     {subscribedToTeam && <SeatManagementCard accountState={accountState} />}

--- a/apps/web/src/hooks/billing/use-account-state.ts
+++ b/apps/web/src/hooks/billing/use-account-state.ts
@@ -267,6 +267,44 @@ export function useCreatePerSeatCheckout() {
   });
 }
 
+// Billing v2 — legacy → per-seat voluntary claim. Runs the migration synchronously
+// (the lazy sign-in path can silently skip/fail, leaving legacy users stuck with
+// no way to switch), then refreshes account state so the new plan + wallet credit
+// show immediately.
+export function useClaimPerSeat() {
+  const queryClient = useQueryClient();
+  const accountId = useBillingAccountId();
+  return useMutation({
+    mutationFn: () => billingApi.claimPerSeat(accountId),
+    onSuccess: async (data) => {
+      await invalidateAccountState(queryClient, true, true, accountId);
+      if (data.status === 'migrated') {
+        const parts: string[] = [];
+        if (data.first_seat_covered_usd > 0) parts.push(`$${data.first_seat_covered_usd.toFixed(2)} covered your first seat`);
+        if (data.credited_usd > 0) parts.push(`$${data.credited_usd.toFixed(2)} added as non-expiring credit`);
+        toast.success("You're on seat-based pricing", { description: parts.join(' · ') || undefined });
+      } else if (data.status === 'skipped:already_per_seat' || data.status === 'skipped:no_subs') {
+        // no_subs flips the flag with no Stripe work — they're now on per-seat.
+        toast.success("You're on seat-based pricing");
+      } else if (data.status === 'skipped:yearly_commitment') {
+        toast.message('Still on a yearly commitment', {
+          description: data.reason || 'You can switch once your committed term ends.',
+        });
+      } else {
+        // skipped:no_legacy_machine — nothing to move off of.
+        toast.message('Nothing to switch', {
+          description: 'No active machine subscription to move to seat-based pricing.',
+        });
+      }
+    },
+    onError: (err: any) => {
+      toast.error('Could not switch plans', {
+        description: err?.message || 'Try again, or contact support if this keeps happening.',
+      });
+    },
+  });
+}
+
 export function useCreatePortalSession() {
   const accountId = useBillingAccountId();
   return useMutation({

--- a/apps/web/src/lib/api/billing.ts
+++ b/apps/web/src/lib/api/billing.ts
@@ -452,6 +452,23 @@ export const billingApi = {
     return response.data!;
   },
 
+  // Billing v2 — legacy → per-seat voluntary claim. Runs the migration server-side
+  // (create the $20/seat sub, cancel the machine subs, pre-pay the first seat out
+  // of the unused machine value + return the rest as non-expiring credit, flip to
+  // per_seat) and returns the result.
+  async claimPerSeat(accountId?: string) {
+    const response = await backendApi.post<{
+      ok: boolean;
+      status: string;
+      credited_usd: number;
+      first_seat_covered_usd: number;
+      cancelled_subscriptions: number;
+      reason?: string | null;
+    }>('/billing/claim-per-seat', accountId ? { account_id: accountId } : {});
+    if (response.error) throw response.error;
+    return response.data!;
+  },
+
   async createPortalSession(request: CreatePortalSessionRequest, accountId?: string) {
     const response = await backendApi.post<CreatePortalSessionResponse>(
       '/billing/create-portal-session',


### PR DESCRIPTION
Legacy machine-billed users whose lazy sign-in migration silently skipped or failed had no way to move to per-seat billing. Add an explicit Claim button + endpoint, and make the proration return the full unused machine value at no extra cost now:
  - compute the prorated remainder of the machine subs up front,
  - pre-pay the first seat from it via a Stripe customer-balance credit (offsets the first per-seat invoice; often $0 so no card needed),
  - create the $20/seat sub, cancel the machine subs,
  - grant the leftover as non-expiring wallet credit, flip to per_seat. e.g. $100 remaining, 1 seat -> $20 covers the first seat + $80 credit.

- maybeMigrateLegacyAccount: reworked split (firstSeatCovered + walletCredit); same logic now drives both the lazy path and the explicit claim.
- POST /v1/billing/claim-per-seat: runs it synchronously, returns the result.
- web: billingApi.claimPerSeat + useClaimPerSeat hook + ClaimPerSeatCard, mounted on the billing tab when billing_model === 'legacy'.