### PR TITLE
fix(slack): match partial unique index on project_secrets upsert (OAu…

### DIFF
--- a/apps/api/src/channels/install-store.ts
+++ b/apps/api/src/channels/install-store.ts
@@ -1,4 +1,4 @@
-import { and, eq } from 'drizzle-orm';
+import { and, eq, sql } from 'drizzle-orm';
 import { chatInstalls, projectSecrets } from '@kortix/db';
 import { db } from '../shared/db';
 import {
@@ -160,7 +160,11 @@ async function upsertSecret(projectId: string, name: string, value: string): Pro
     .insert(projectSecrets)
     .values({ projectId, name, valueEnc })
     .onConflictDoUpdate({
+      // owner_user_id is left NULL here (a SHARED secret), so the conflict must
+      // target the PARTIAL unique index `(project_id, name) WHERE owner_user_id
+      // IS NULL` — a bare ON CONFLICT (project_id, name) matches no index and 500s.
       target: [projectSecrets.projectId, projectSecrets.name],
+      targetWhere: sql`${projectSecrets.ownerUserId} is null`,
       set: { valueEnc, updatedAt: new Date() },
     });
 }


### PR DESCRIPTION
…th 500)

The Slack OAuth callback stores SLACK_BOT_TOKEN via upsertSecret, which left owner_user_id NULL (a shared secret) but did a bare ON CONFLICT (project_id, name). project_secrets has only PARTIAL unique indexes — (project_id, name) WHERE owner_user_id IS NULL and (project_id, name, owner_user_id) WHERE NOT NULL — so Postgres matched no index and 500'd, failing every Slack install. Add targetWhere owner_user_id IS NULL to hit the shared partial index (matches the canonical upsert in projects/index.ts).