### PR TITLE
feat(billing): per-seat plan to $40/mo

### DIFF
--- a/apps/api/src/billing/services/tiers.ts
+++ b/apps/api/src/billing/services/tiers.ts
@@ -42,7 +42,7 @@ export function llmPriceMarkup(): number {
 // pricing page as "roughly N hours of compute or M tokens" rough guidance,
 // not enforced anywhere.
 
-export const PER_SEAT_PRICE_USD = 20;
+export const PER_SEAT_PRICE_USD = 40;
 /** Display-only: rough indication for pricing-page copy. */
 export const TYPICAL_COMPUTE_BUDGET_PER_SEAT_USD = 12;
 /** Display-only: rough indication for pricing-page copy. */
@@ -238,7 +238,7 @@ const STRIPE_PRICES_PROD: StripePriceConfig = {
   subscriptions: {
     free: { monthly: 'price_1RIGvuG6l1KZGqIrw14abxeL' },
     pro:  { monthly: 'price_1RILb4G6l1KZGqIrhomjgDnO' }, // TODO: create prod Pro price and replace
-    per_seat: { monthly: 'price_1TcrQJG6l1KZGqIry1K1cqZY' }, // live "Kortix seat" $20/mo
+    per_seat: { monthly: 'price_1TdyruG6l1KZGqIrMzPVmQSO' }, // live "Kortix seat" $40/mo
     // Legacy price → tier mappings (for webhook resolution of existing subs)
     tier_2_20:     { monthly: 'price_1RILb4G6l1KZGqIrhomjgDnO', yearly: 'price_1ReHB5G6l1KZGqIrD70I1xqM', yearlyCommitment: 'price_1RqtqiG6l1KZGqIrhjVPtE1s' },
     tier_6_50:     { monthly: 'price_1RILb4G6l1KZGqIr5q0sybWn', yearly: 'price_1ReHAsG6l1KZGqIrlAog487C', yearlyCommitment: 'price_1Rqtr8G6l1KZGqIrQ0ql0qHi' },
@@ -264,11 +264,11 @@ const STRIPE_PRICES_STAGING: StripePriceConfig = {
   subscriptions: {
     free: { monthly: 'price_1RIGvuG6l1KZGqIrw14abxeL' },
     pro:  { monthly: 'price_1T7yiuG6CaZppiKc7VsgnlKI' },
-    // Billing v2 — $20/month per-seat in the staging Stripe account (acct_…G6CaZppiKc),
+    // Billing v2 — $40/month per-seat in the staging Stripe account (acct_…G6CaZppiKc),
     // the same account the staging customers + their legacy subs live in (so the
     // migration can actually find/cancel them). The old …G6l1KZGqIr price was in a
     // different account and is being deprecated.
-    per_seat: { monthly: 'price_1TdSdvG6CaZppiKctAZXPPY0' },
+    per_seat: { monthly: 'price_1TdyscG6CaZppiKcilrApKgB' },
   },
   credits: {
     10:  'price_1RxXOvG6l1KZGqIrMqsiYQvk',

--- a/apps/web/src/components/billing/claim-per-seat-card.tsx
+++ b/apps/web/src/components/billing/claim-per-seat-card.tsx
@@ -16,7 +16,7 @@ export function ClaimPerSeatCard({ accountState }: { accountState?: AccountState
         <div className="space-y-1 min-w-0">
           <p className="text-sm font-medium">Switch to seat-based pricing</p>
           <p className="text-xs text-muted-foreground">
-            Move off per-machine billing to the new $20/seat plan. We cancel your machine
+            Move off per-machine billing to the new $40/seat plan. We cancel your machine
             subscriptions, put your unused balance toward your first seat, and return the
             rest as <span className="font-medium text-foreground">non-expiring credit</span>.
           </p>

--- a/apps/web/src/components/billing/team-plan-checkout.tsx
+++ b/apps/web/src/components/billing/team-plan-checkout.tsx
@@ -32,7 +32,7 @@ export function TeamPlanCheckout({
 }: TeamPlanCheckoutProps) {
   const createPerSeat = useCreatePerSeatCheckout();
 
-  const pricePerSeat = accountState?.seats?.price_per_seat_usd ?? 20;
+  const pricePerSeat = accountState?.seats?.price_per_seat_usd ?? 40;
   const seatCount = accountState?.seats?.count ?? 1;
   const monthlyTotal = pricePerSeat * seatCount;
   const hasSeatMath = seatCount > 1;
@@ -113,7 +113,7 @@ export function TeamPlanCheckout({
             </>
           ) : (
             <>
-              {hasSeatMath ? `Subscribe — $${monthlyTotal}/month` : 'Subscribe — $20 / user / month'}
+              {hasSeatMath ? `Subscribe — $${monthlyTotal}/month` : 'Subscribe — $40 / user / month'}
               <ArrowRight className="size-4 transition-transform group-hover:translate-x-0.5" />
             </>
           )}
@@ -150,7 +150,7 @@ export function TeamPlanDialog({ open, onOpenChange, accountState }: TeamPlanDia
       <DialogContent className="gap-0 overflow-hidden bg-card p-0 sm:max-w-[420px]">
         <DialogTitle className="sr-only">Subscribe to Kortix Team</DialogTitle>
         <DialogDescription className="sr-only">
-          $20 per user per month. LLM compute and AI Computers for every teammate.
+          $40 per user per month. LLM compute and AI Computers for every teammate.
         </DialogDescription>
         <TeamPlanCheckout accountState={accountState} embedded />
       </DialogContent>

--- a/apps/web/src/hooks/billing/use-account-state.ts
+++ b/apps/web/src/hooks/billing/use-account-state.ts
@@ -245,7 +245,7 @@ export function useCreatePerSeatCheckout() {
         useUpgradeDialogStore.getState().closeUpgradeDialog();
         await invalidateAccountState(queryClient, true, true, accountId);
         toast.success('Subscription activated', {
-          description: `${data.seat_count} seat${data.seat_count === 1 ? '' : 's'} active · $20 of usage credit deposited.`,
+          description: `${data.seat_count} seat${data.seat_count === 1 ? '' : 's'} active · $40 of usage credit deposited.`,
         });
         return;
       }

--- a/apps/web/src/lib/api/billing.ts
+++ b/apps/web/src/lib/api/billing.ts
@@ -453,7 +453,7 @@ export const billingApi = {
   },
 
   // Billing v2 — legacy → per-seat voluntary claim. Runs the migration server-side
-  // (create the $20/seat sub, cancel the machine subs, pre-pay the first seat out
+  // (create the $40/seat sub, cancel the machine subs, pre-pay the first seat out
   // of the unused machine value + return the rest as non-expiring credit, flip to
   // per_seat) and returns the result.
   async claimPerSeat(accountId?: string) {


### PR DESCRIPTION
Bump PER_SEAT_PRICE_USD 20 → 40 and point the per-seat subscription at the new $40 Stripe prices (prod price_1TdyruG6l1KZGqIrMzPVmQSO, staging price_1TdyscG6CaZppiKcilrApKgB). Seat math, monthly credit grant, and proration all derive from the constant, so they follow automatically; updated the hardcoded "$20" copy in the team-plan checkout, claim card, and activation toast to match.