### PR TITLE
fix(slack): share turn-stream state across replicas (DB-backed)

### DIFF
--- a/apps/api/src/channels/slack-webhook.ts
+++ b/apps/api/src/channels/slack-webhook.ts
@@ -1,10 +1,12 @@
 import { Hono } from 'hono';
 import { createHmac, randomUUID, timingSafeEqual } from 'node:crypto';
-import { and, desc, eq, inArray, sql } from 'drizzle-orm';
+import { and, desc, eq, inArray, lt, sql } from 'drizzle-orm';
 import {
   chatChannelBindings,
+  chatEventDedup,
   chatInstalls,
   chatThreads,
+  chatTurnStreams,
   projects,
   projectSessions,
   sessionSandboxes,
@@ -42,22 +44,35 @@ export const slackWebhookApp = new Hono();
 const FIVE_MINUTES = 5 * 60;
 
 const EVENT_DEDUPE_TTL_MS = 5 * 60 * 1000;
-const seenEventIds = new Map<string, number>();
 
-function alreadyHandled(eventId: string | undefined): boolean {
+// Cross-replica dedup. Slack can redeliver the same event_id (retries); with >1
+// API replica an in-memory set only dedups within one process, so a redelivery
+// to another replica re-fires the turn. An INSERT … ON CONFLICT DO NOTHING makes
+// "already handled?" one shared decision: a row came back ⇒ we're the first to
+// claim it; empty ⇒ someone already has.
+async function alreadyHandled(eventId: string | undefined): Promise<boolean> {
   if (!eventId) return false;
-  const now = Date.now();
-  for (const [id, expiry] of seenEventIds) {
-    if (expiry < now) seenEventIds.delete(id);
+  try {
+    const inserted = await db
+      .insert(chatEventDedup)
+      .values({ eventId, expiresAt: new Date(Date.now() + EVENT_DEDUPE_TTL_MS) })
+      .onConflictDoNothing({ target: chatEventDedup.eventId })
+      .returning({ eventId: chatEventDedup.eventId });
+    return inserted.length === 0;
+  } catch (err) {
+    // Never let a dedup hiccup wedge the webhook — fail open (process the event).
+    console.warn('[slack-webhook] event dedup check failed', err);
+    return false;
   }
-  if (seenEventIds.has(eventId)) return true;
-  seenEventIds.set(eventId, now + EVENT_DEDUPE_TTL_MS);
-  return false;
 }
 
 const WORKING_EMOJI = 'hourglass_flowing_sand';
 const STREAM_TTL_MS = 15 * 60 * 1000;
 
+// In-memory representation of one live turn stream. NOT a process-global cache —
+// it's loaded from / saved to kortix.chat_turn_streams on every relay so any API
+// replica can advance or finalize the stream (see loadStream/saveStream). `token`
+// is loaded per-project, never persisted.
 interface TurnStream {
   channel: string;
   ts: string;
@@ -70,21 +85,112 @@ interface TurnStream {
   finalized: boolean;
   projectId: string;
   sessionId: string;
-  stopped: boolean;
   teamId: string;
   originatingEvent: SlackEvent;
 }
 
-const activeStreams = new Map<string, TurnStream>();
+function rowToHandle(row: typeof chatTurnStreams.$inferSelect, token: string): TurnStream {
+  return {
+    channel: row.channel,
+    ts: row.messageTs ?? '',
+    token,
+    triggerTs: row.triggerTs,
+    steps: (row.steps as StreamTaskChunk[]) ?? [],
+    streaming: row.streaming,
+    placeholderActive: row.placeholderActive,
+    expiry: new Date(row.expiresAt).getTime(),
+    finalized: row.finalized,
+    projectId: row.projectId,
+    sessionId: row.sessionId,
+    teamId: row.teamId,
+    originatingEvent: row.originatingEvent as SlackEvent,
+  };
+}
 
+/** Hydrate a DB row into a usable handle (loads the bot token for its project). */
+async function loadStream(sessionId: string): Promise<TurnStream | null> {
+  if (!sessionId) return null;
+  const [row] = await db
+    .select()
+    .from(chatTurnStreams)
+    .where(eq(chatTurnStreams.sessionId, sessionId))
+    .limit(1);
+  if (!row) return null;
+  const token = await loadSlackTokenForProject(row.projectId);
+  if (!token) return null;
+  return rowToHandle(row, token);
+}
+
+/** Upsert the handle (minus the token) so the next relay — on any replica — sees it. */
+async function saveStream(handle: TurnStream): Promise<void> {
+  if (!handle.sessionId) return;
+  const values = {
+    sessionId: handle.sessionId,
+    projectId: handle.projectId,
+    teamId: handle.teamId,
+    channel: handle.channel,
+    triggerTs: handle.triggerTs,
+    messageTs: handle.ts || null,
+    streaming: handle.streaming,
+    placeholderActive: handle.placeholderActive,
+    finalized: handle.finalized,
+    steps: handle.steps,
+    originatingEvent: handle.originatingEvent as unknown,
+    expiresAt: new Date(handle.expiry),
+    updatedAt: new Date(),
+  };
+  await db
+    .insert(chatTurnStreams)
+    .values(values as typeof chatTurnStreams.$inferInsert)
+    .onConflictDoUpdate({ target: chatTurnStreams.sessionId, set: values as Partial<typeof chatTurnStreams.$inferInsert> });
+}
+
+async function deleteStream(sessionId: string): Promise<void> {
+  if (!sessionId) return;
+  await db.delete(chatTurnStreams).where(eq(chatTurnStreams.sessionId, sessionId));
+}
+
+/**
+ * Atomically claim a stream for finalization so only one replica runs stopStream
+ * (the answer relay and the expiry watchdog can race). Returns true to the winner.
+ */
+async function claimFinalize(sessionId: string): Promise<boolean> {
+  const rows = await db
+    .update(chatTurnStreams)
+    .set({ finalized: true, updatedAt: new Date() })
+    .where(and(eq(chatTurnStreams.sessionId, sessionId), eq(chatTurnStreams.finalized, false)))
+    .returning({ sessionId: chatTurnStreams.sessionId });
+  return rows.length > 0;
+}
+
+// Watchdog: finalize streams whose agent died/never sent, and GC expired dedup
+// rows. Every replica runs it; claimFinalize makes the work single-winner.
 setInterval(() => {
-  const now = Date.now();
-  for (const [sessionId, handle] of activeStreams) {
-    if (!handle.finalized && handle.expiry < now) {
-      activeStreams.delete(sessionId);
-      void finalizeStream(handle, { error: '_The run stopped unexpectedly — try again._' });
+  void (async () => {
+    try {
+      const now = new Date();
+      const expired = await db
+        .select()
+        .from(chatTurnStreams)
+        .where(and(eq(chatTurnStreams.finalized, false), lt(chatTurnStreams.expiresAt, now)))
+        .limit(50);
+      for (const row of expired) {
+        // claimFinalize flips the DB row to finalized; build the handle from the
+        // row we already read (still finalized=false) so finalizeStream runs once.
+        if (!(await claimFinalize(row.sessionId))) continue;
+        const token = await loadSlackTokenForProject(row.projectId);
+        if (token) {
+          await finalizeStream(rowToHandle(row, token), {
+            error: '_The run stopped unexpectedly — try again._',
+          });
+        }
+        await deleteStream(row.sessionId);
+      }
+      await db.delete(chatEventDedup).where(lt(chatEventDedup.expiresAt, now));
+    } catch (err) {
+      console.warn('[slack-webhook] stream watchdog tick failed', err);
     }
-  }
+  })();
 }, 60_000).unref();
 
 async function startTurnStream(
@@ -119,7 +225,6 @@ async function startTurnStream(
     finalized: false,
     projectId,
     sessionId: '',
-    stopped: false,
     teamId,
     originatingEvent: event,
     ts: placeholderTs,
@@ -206,7 +311,7 @@ export async function postQuestionAndWait(
   sessionId: string,
   questions: QuestionInfo[],
 ): Promise<{ ok: boolean; ask_id?: string; answers?: string[][]; error?: string }> {
-  const handle = activeStreams.get(sessionId);
+  const handle = await loadStream(sessionId);
   if (!handle) {
     return { ok: false, error: 'No active Slack turn for this session.' };
   }
@@ -215,7 +320,7 @@ export async function postQuestionAndWait(
   const originatingEvent = handle.originatingEvent;
 
   await finalizeStream(handle, { answer: '_Waiting on your answer below…_' });
-  activeStreams.delete(sessionId);
+  await deleteStream(sessionId);
 
   const askId = randomUUID();
   const blocks = buildQuestionBlocks(askId, questions);
@@ -313,7 +418,7 @@ export async function relayTurnStep(
     sourcesForPrev?: Array<{ url: string; text: string }>;
   } = {},
 ): Promise<boolean> {
-  const handle = activeStreams.get(sessionId);
+  const handle = await loadStream(sessionId);
   if (!handle || handle.finalized) {
     console.warn('[slack-webhook] turn-stream step relay dropped — no active stream', {
       sessionId,
@@ -334,6 +439,7 @@ export async function relayTurnStep(
     const opened = await openStreamWithFirstStep(handle, firstStep);
     if (!opened) return false;
     handle.expiry = Date.now() + STREAM_TTL_MS;
+    await saveStream(handle);
     return true;
   }
   const chunks: StreamTaskChunk[] = [];
@@ -368,6 +474,7 @@ export async function relayTurnStep(
   chunks.push(next);
   handle.expiry = Date.now() + STREAM_TTL_MS;
   await appendStream(handle.token, handle.channel, handle.ts, chunks);
+  await saveStream(handle);
   return true;
 }
 
@@ -376,10 +483,13 @@ export async function relayTurnAnswer(
   text: string,
   blocks?: unknown[],
 ): Promise<boolean> {
-  const handle = activeStreams.get(sessionId);
+  const handle = await loadStream(sessionId);
   if (!handle || handle.finalized) return false;
-  activeStreams.delete(sessionId);
+  // Win the finalize race against the watchdog / a duplicate send before we
+  // run stopStream, so the message is closed exactly once.
+  if (!(await claimFinalize(sessionId))) return false;
   await finalizeStream(handle, { answer: text, blocks });
+  await deleteStream(sessionId);
   return true;
 }
 
@@ -427,7 +537,7 @@ async function finalizeStream(
     }
   }
   await removeReaction(handle.token, handle.channel, handle.triggerTs, WORKING_EMOJI);
-  if (opts.answer && !opts.error && !handle.stopped) {
+  if (opts.answer && !opts.error) {
     await addReaction(handle.token, handle.channel, handle.triggerTs, 'white_check_mark');
   }
 }
@@ -499,7 +609,7 @@ slackWebhookApp.post('/', async (c) => {
   if (!envelope) return c.json({ error: 'Invalid JSON' }, 400);
   if (envelope.type === 'url_verification') return c.json({ challenge: envelope.challenge });
   if (envelope.type !== 'event_callback' || !envelope.event) return c.json({ ok: true });
-  if (alreadyHandled(envelope.event_id)) return c.json({ ok: true });
+  if (await alreadyHandled(envelope.event_id)) return c.json({ ok: true });
 
   void (async () => {
     const teamId = envelope.team_id ?? envelope.event?.team ?? '';
@@ -1183,7 +1293,7 @@ async function handleAskSubmit(payload: SlackInteractionPayload, askId: string):
     );
     if (newHandle) {
       newHandle.sessionId = pending.sessionId;
-      activeStreams.set(pending.sessionId, newHandle);
+      await saveStream(newHandle);
     }
   } catch (err) {
     console.warn('[slack-webhook] post-question stream re-open failed', err);
@@ -1449,7 +1559,7 @@ slackWebhookApp.post('/:projectId', async (c) => {
   if (!envelope) return c.json({ error: 'Invalid JSON' }, 400);
   if (envelope.type === 'url_verification') return c.json({ challenge: envelope.challenge });
   if (envelope.type !== 'event_callback' || !envelope.event) return c.json({ ok: true });
-  if (alreadyHandled(envelope.event_id)) return c.json({ ok: true });
+  if (await alreadyHandled(envelope.event_id)) return c.json({ ok: true });
 
   void dispatchSlackEvent(projectId, envelope).catch((err) =>
     console.error('[slack-webhook] byo handler failed', err),
@@ -1857,7 +1967,7 @@ async function spawnAgentTurn(
       const handle = await startTurnStream(projectId, teamId, event, 'On it');
       if (handle) {
         handle.sessionId = existing.sessionId;
-        activeStreams.set(existing.sessionId, handle);
+        await saveStream(handle);
       }
       const outcome = await deliverFollowUpToSandbox(existing.sessionId, envelope, event);
       if (outcome === 'delivered') {
@@ -1874,7 +1984,7 @@ async function spawnAgentTurn(
         return;
       }
       if (handle) {
-        activeStreams.delete(existing.sessionId);
+        await deleteStream(existing.sessionId);
         await finalizeStream(handle, { error: "I couldn't reach the sandbox — try again." });
       }
       if (outcome === 'transient') return;
@@ -1940,7 +2050,7 @@ async function spawnAgentTurn(
 
   if (result.row && handle) {
     handle.sessionId = result.row.sessionId;
-    activeStreams.set(result.row.sessionId, handle);
+    await saveStream(handle);
   }
 
   if (result.row && teamId && threadId) {

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -41,6 +41,8 @@ export {
   chatChannelBindings,
   chatInstalls,
   chatThreads,
+  chatTurnStreams,
+  chatEventDedup,
   projectSessions,
   projectSessionGrants,
   projectSessionVisibilityEnum,

--- a/packages/db/src/schema/kortix.ts
+++ b/packages/db/src/schema/kortix.ts
@@ -636,6 +636,47 @@ export const chatThreads = kortixSchema.table(
   ],
 );
 
+// Live Slack turn-stream state, shared across API replicas. The agent's
+// `slack step` / `slack send` relays land on ANY instance behind the load
+// balancer, so the stream handle (which Slack message to update, the steps so
+// far, placeholder vs streaming) CANNOT live in one process's memory — a relay
+// hitting the non-owning replica would drop (and the final `send` would never
+// close the stream). One row per session; upserted per relay, deleted on
+// finalize, swept on expiry.
+export const chatTurnStreams = kortixSchema.table(
+  'chat_turn_streams',
+  {
+    sessionId: text('session_id').primaryKey(),
+    projectId: uuid('project_id').notNull(),
+    teamId: varchar('team_id', { length: 128 }).notNull(),
+    channel: varchar('channel', { length: 128 }).notNull(),
+    triggerTs: varchar('trigger_ts', { length: 64 }).notNull(),
+    messageTs: varchar('message_ts', { length: 64 }),
+    streaming: boolean('streaming').notNull().default(false),
+    placeholderActive: boolean('placeholder_active').notNull().default(false),
+    finalized: boolean('finalized').notNull().default(false),
+    steps: jsonb('steps').notNull().default([]),
+    originatingEvent: jsonb('originating_event').notNull(),
+    expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => [index('idx_chat_turn_streams_expiry').on(table.expiresAt)],
+);
+
+// Cross-replica dedup of inbound Slack event deliveries. Slack can deliver the
+// same event_id more than once (retries); with >1 replica an in-memory set
+// dedups per-process only, so a redelivery to another replica re-fires the turn
+// (the "random reply in a dead thread" bug). Insert-on-conflict-do-nothing here
+// makes "have I handled this event_id?" a single shared decision.
+export const chatEventDedup = kortixSchema.table(
+  'chat_event_dedup',
+  {
+    eventId: text('event_id').primaryKey(),
+    expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
+  },
+  (table) => [index('idx_chat_event_dedup_expiry').on(table.expiresAt)],
+);
+
 // Per-session sandbox runtime row. Decoupled from `kortix.sandboxes` (the
 // legacy /instances table) on purpose: project sessions carry no billing
 // state, no sandbox_members roster, and no team membership semantics — their

--- a/supabase/migrations/00000000000108_slack_turn_streams.sql
+++ b/supabase/migrations/00000000000108_slack_turn_streams.sql
@@ -1,0 +1,26 @@
+-- Shared (cross-replica) Slack streaming state. The agent's slack step/send
+-- relays land on any API replica behind the load balancer, so the per-turn
+-- stream handle + the inbound-event dedup set must be shared, not in-process.
+
+create table if not exists kortix.chat_turn_streams (
+  session_id         text primary key,
+  project_id         uuid not null,
+  team_id            varchar(128) not null,
+  channel            varchar(128) not null,
+  trigger_ts         varchar(64) not null,
+  message_ts         varchar(64),
+  streaming          boolean not null default false,
+  placeholder_active boolean not null default false,
+  finalized          boolean not null default false,
+  steps              jsonb not null default '[]'::jsonb,
+  originating_event  jsonb not null,
+  expires_at         timestamptz not null,
+  updated_at         timestamptz not null default now()
+);
+create index if not exists idx_chat_turn_streams_expiry on kortix.chat_turn_streams (expires_at);
+
+create table if not exists kortix.chat_event_dedup (
+  event_id   text primary key,
+  expires_at timestamptz not null
+);
+create index if not exists idx_chat_event_dedup_expiry on kortix.chat_event_dedup (expires_at);


### PR DESCRIPTION
The Slack streaming state lived in two in-process Maps (activeStreams, seenEventIds), but the API runs 2+ replicas behind a load balancer. The agent's slack step/send relays land on ANY replica round-robin, so:
- steps/finalize hitting the non-owning replica were dropped ("relay dropped — no active stream") — the stream stuck on "On it…" and never showed "Task complete" (proven in prod logs).
- event dedup was per-process, so a Slack redelivery to another replica re-fired the turn (random reply in a dead thread).

Move both to shared Postgres tables (kortix.chat_turn_streams + chat_event_dedup, migration 108):
- relayTurnStep/Answer, postQuestionAndWait, the dispatch paths and the expiry watchdog now load/save/delete the handle from the DB — any replica can advance or finalize a stream. The bot token is loaded per-project, never persisted.
- finalize is single-winner via an atomic claim (UPDATE … WHERE finalized=false RETURNING), so the answer relay and the watchdog can't double-close.
- dedup is INSERT … ON CONFLICT DO NOTHING — one shared "handled this event?" decision; fails open on DB error so a hiccup never wedges the webhook.

Verified: tsc clean, migration applied to prod, claim semantics single-winner against the live table.