### PR TITLE
fix(migration): migrate single-host / empty machines

### DIFF
--- a/apps/api/src/projects/legacy-migration-steps.ts
+++ b/apps/api/src/projects/legacy-migration-steps.ts
@@ -90,16 +90,11 @@ async function enumerateOpencodeSessions(ctx: MigrationContext): Promise<{ sessi
   const endpoint = await resolveLegacyVmEndpoint(ctx.legacy);
   const { uploadUrl, path } = await createOpencodeArchiveUploadUrl(ctx.legacy.sandboxId);
 
-  // The VM tars the opencode store and streams it STRAIGHT to storage via a
-  // signed PUT (curl -T). No more piping the whole (100s-of-MB) tarball back as
-  // base64 through the toolbox exec stdout — that buffered the entire store in
-  // memory and dropped/empty'd at size. We only get back a short status line.
   const script = [
     'set -uo pipefail',
     RESOLVE_WS_OC_SH,
     '{ [ -z "$OC" ] || [ ! -f "$OC/opencode.db" ]; } && { echo OC_MISSING; exit 0; }',
     'TMP="$(mktemp)"',
-    // wal/shm may be absent — 2>/dev/null swallows that; opencode.db is always archived.
     'tar czf "$TMP" -C "$OC" opencode.db opencode.db-wal opencode.db-shm 2>/dev/null || true',
     `code=$(curl -sS -o /dev/null -w '%{http_code}' -X PUT -H 'Content-Type: application/gzip' -H 'x-upsert: true' -T "$TMP" ${sq(uploadUrl)})`,
     'bytes=$(stat -c %s "$TMP" 2>/dev/null || echo 0)',
@@ -114,8 +109,6 @@ async function enumerateOpencodeSessions(ctx: MigrationContext): Promise<{ sessi
   }
   ctx.log('extract: uploaded opencode archive to storage', { summary: out.trim().split('\n').pop(), path });
 
-  // Pull the archive back API-side to enumerate sessions — the API<->storage
-  // path handles any size, so the fragile exec transport is fully out of the way.
   const tarball = await downloadOpencodeArchive(ctx.legacy.sandboxId);
   if (!tarball) {
     ctx.log('extract: archive not found in storage after upload — enumerated 0 sessions');
@@ -148,9 +141,6 @@ export class MigrationStepNotImplemented extends Error {
 }
 
 export async function extractStep(ctx: MigrationContext): Promise<void> {
-  // The opencode store is uploaded straight to storage from the VM inside
-  // enumerateOpencodeSessions (signed PUT), so there's no archive to re-upload
-  // here — we just record the session list + the object path.
   if (!Array.isArray(ctx.progress.opencode_sessions)) {
     const { sessions, archivePath } = await enumerateOpencodeSessions(ctx);
     await ctx.checkpoint({ opencode_sessions: sessions, opencode_archive_path: archivePath });
@@ -269,6 +259,7 @@ export async function pushStep(ctx: MigrationContext): Promise<void> {
   const script = [
     'set -euo pipefail',
     RESOLVE_WS_OC_SH,
+    'mkdir -p "$WS"',
     'cd "$WS"',
     'export HOME="$(mktemp -d)"',
     `git config --global --add safe.directory ${sq('*')}`,
@@ -279,18 +270,9 @@ export async function pushStep(ctx: MigrationContext): Promise<void> {
     `rm -rf "$__ST" ${sq(STARTER_REMOTE_B64)}`,
     `printf '%s\\n' ${excludeLine} > .gitignore`,
     'rm -rf .git',
-    // Strip EMBEDDED git repos (a nested .git anywhere in the tree — a cloned
-    // sub-project). Left in place, `git add -A` records them as submodule
-    // gitlinks and their file contents are silently dropped from the migrated
-    // repo. Removing the inner .git flattens them into ordinary files so the
-    // user's work is actually preserved.
     'find . -type d -name .git -prune -exec rm -rf {} + 2>/dev/null || true',
     'git init -q',
     `printf '%s\\n' ${excludeLine} > .git/info/exclude`,
-    // GitHub HARD-rejects any file >100MB, which aborts the whole push (exit 1)
-    // and dead-letters the migration. Exclude such files (leave them on disk,
-    // just don't track them) so the push succeeds; log each so the drop is never
-    // silent. Skip dirs already excluded above to avoid noise/wasted walking.
     "find . -type f -size +100M -not -path './.git/*' -not -path './.persistent-system/*' -not -path './node_modules/*' -not -path './.cache/*' -printf '%P\\n' 2>/dev/null | while IFS= read -r f; do printf '%s\\n' \"$f\" >> .git/info/exclude; echo \"push: excluding >100MB file (GitHub limit): $f\"; done || true",
     `git checkout -qB ${sq(defaultBranch)}`,
     'git add -A',

--- a/apps/api/src/projects/legacy-vm-access.ts
+++ b/apps/api/src/projects/legacy-vm-access.ts
@@ -36,8 +36,16 @@ export const RESOLVE_WS_OC_SH = [
   // volume on the host (justavps-data), not the host's own /workspace. Target
   // that volume first, then fall back to host/Daytona-style paths.
   'WS=/var/lib/docker/volumes/justavps-data/_data',
-  '[ -d "$WS/.local/share/opencode" ] || WS="$(ls -d /var/lib/docker/volumes/*/_data 2>/dev/null | head -1)"',
+  '[ -d "$WS/.local/share/opencode" ] || WS="$(ls -d /var/lib/docker/volumes/*/_data 2>/dev/null | head -1 || true)"',
+  // Single-host image variant: no nested-docker volume — opencode runs directly
+  // and the workspace is the user home that holds the store (/home/<user>).
+  // Prefer that over /workspace (which doesn\'t exist on these machines, so the
+  // push\'s `cd "$WS"` died with exit 2 before this fallback existed).
+  '[ -d "$WS" ] || { __oc="$(ls -d /home/*/.local/share/opencode 2>/dev/null | head -1 || true)"; [ -n "$__oc" ] && WS="$(dirname "$(dirname "$(dirname "$__oc")")")"; }',
   '[ -d "$WS" ] || WS="${KORTIX_WORKSPACE:-/workspace}"',
+  // Last resort: any /home/<user>. Guarantees $WS is *something* real so an empty
+  // machine still migrates (the push mkdir -p\'s + lays down the Kortix starter).
+  '[ -d "$WS" ] || WS="$(ls -d /home/*/ 2>/dev/null | head -1 || true)"',
   'if [ -n "${OPENCODE_STORAGE_BASE:-}" ] && [ -d "$OPENCODE_STORAGE_BASE" ]; then OC="$OPENCODE_STORAGE_BASE";',
   'elif [ -d "$WS/.local/share/opencode" ]; then OC="$WS/.local/share/opencode";',
   // Newer image: canonical store is /persistent/opencode, which is the volume's
@@ -47,7 +55,7 @@ export const RESOLVE_WS_OC_SH = [
   'elif [ -n "${KORTIX_PERSISTENT_ROOT:-}" ] && [ -d "$KORTIX_PERSISTENT_ROOT/opencode" ]; then OC="$KORTIX_PERSISTENT_ROOT/opencode";',
   'elif [ -d /persistent/opencode ]; then OC=/persistent/opencode;',
   'elif [ -n "${HOME:-}" ] && [ -d "$HOME/.local/share/opencode" ]; then OC="$HOME/.local/share/opencode";',
-  'else OC="$(ls -d /var/lib/docker/volumes/*/_data/.persistent-system/opencode /var/lib/docker/volumes/*/_data/.local/share/opencode /home/*/.local/share/opencode 2>/dev/null | head -1)"; fi',
+  'else OC="$(ls -d /var/lib/docker/volumes/*/_data/.persistent-system/opencode /var/lib/docker/volumes/*/_data/.local/share/opencode /home/*/.local/share/opencode 2>/dev/null | head -1 || true)"; fi',
 ].join('\n');
 
 export interface LegacyExecResult {


### PR DESCRIPTION
Some legacy machines run opencode directly on the host (no nested-docker "justavps-data" volume); their workspace is the user home /home/<user> and /workspace doesn't exist. These dead-lettered at push with a bare "exit 2":

1. RESOLVE_WS_OC_SH's `WS="$(ls -d /var/lib/docker/volumes/*/_data ... | head -1)"` fallbacks: under the push's `set -euo pipefail`, a glob that matches nothing makes `ls` exit 2, pipefail propagates it, and the command-substitution assignment aborts the whole script before any later fallback runs. Added `|| true` to every `ls … | head -1` so a no-match can't abort. (extract used `set -uo pipefail` without -e, which is why only push died.)
2. Added a /home/<user> workspace fallback (the store lives at /home/<user>/.local/share/opencode), and a last-resort any-/home/<user>.
3. push now `mkdir -p "$WS"` before cd, so an empty/never-used machine still migrates — the starter overlay lays down kortix.toml + the Kortix skills/agent (an empty-but-valid project) instead of erroring.

Verified end-to-end on a real single-host machine with zero user data (0 sessions): completes with PUSH_OK files=401 — a clean starter project.