### PR TITLE
hotfix(web): fix prod SSR crash — guard metadataBase against encrypted env URL

### DIFF
--- a/apps/web/src/lib/site-metadata.ts
+++ b/apps/web/src/lib/site-metadata.ts
@@ -2,7 +2,15 @@
  * Site metadata configuration - SIMPLE AND WORKING
  */
 
-const baseUrl = process.env.KORTIX_PUBLIC_APP_URL || process.env.NEXT_PUBLIC_APP_URL || process.env.NEXT_PUBLIC_URL || 'https://www.kortix.com';
+const DEFAULT_APP_URL = 'https://www.kortix.com';
+// Only accept a real absolute http(s) URL. A missing var — or a non-decrypted
+// dotenvx `encrypted:…` value reaching the Vercel `next build` (which loads the
+// committed apps/web/.env raw) — would otherwise flow into
+// `metadataBase: new URL(...)`, which then crashes SSR on EVERY route when Next
+// resolves relative OG/icon URLs against it (TypeError: Invalid URL).
+const rawAppUrl =
+  process.env.KORTIX_PUBLIC_APP_URL || process.env.NEXT_PUBLIC_APP_URL || process.env.NEXT_PUBLIC_URL || '';
+const baseUrl = /^https?:\/\//.test(rawAppUrl) ? rawAppUrl : DEFAULT_APP_URL;
 
 export const siteMetadata = {
   name: 'Kortix',


### PR DESCRIPTION
Hotfix for the v0.9.17 prod outage: `NEXT_PUBLIC_URL` reached the Vercel build as a dotenvx `encrypted:…` ciphertext → `metadataBase: new URL(...)` → `TypeError: Invalid URL` in MetadataOutlet → Server Components render error on every route. Guards site-metadata to accept only http(s) URLs (else canonical default). Reproduced + verified fixed via standalone build. Cherry-pick of d7b4336bc (already on main).