### PR TITLE
fix(sandbox): wire managed LLM gateway into sandboxes without YOLO

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -463,6 +463,7 @@ app.route('/v1/router', router);        // /v1/router/chat/completions, /v1/rout
 {
   const { createLlmGateway } = await import('./llm-gateway');
   const { attributeYoloToken } = await import('./billing/services/yolo-tokens');
+  const { validateAccountToken } = await import('./repositories/account-tokens');
   const { assertBillingActive } = await import('./billing/services/billing-gate');
   const { deductForLlmUsage } = await import('./billing/services/credits');
   const { recordUsageEvent } = await import('./shared/usage-events');
@@ -479,7 +480,19 @@ app.route('/v1/router', router);        // /v1/router/chat/completions, /v1/rout
         appReferer: config.KORTIX_URL,
       },
       {
-        authenticateToken: (token) => attributeYoloToken(token),
+        authenticateToken: async (token) => {
+          // Legacy per-member YOLO token (prod per-seat path) takes priority.
+          const yolo = await attributeYoloToken(token);
+          if (yolo) return yolo;
+          // YOLO is discontinued; sandboxes now present their account token
+          // (a kortix_pat_ minted at provision). Resolve it to {userId, accountId}
+          // so the managed gateway works for self-hosted / billing-off deploys.
+          const acct = await validateAccountToken(token);
+          if (acct.isValid && acct.userId && acct.accountId) {
+            return { userId: acct.userId, accountId: acct.accountId };
+          }
+          return null;
+        },
         assertBillingActive,
         recordUsage: async (event) => {
           // Always record usage_events for observability (token counts, model,

--- a/apps/api/src/platform/services/session-sandbox.ts
+++ b/apps/api/src/platform/services/session-sandbox.ts
@@ -242,6 +242,21 @@ export async function provisionSessionSandbox(opts: {
 
   const llmBaseUrl = `${config.KORTIX_URL.replace(/\/+$/, '')}/v1/llm`;
 
+  // The sandbox's OpenCode `kortix` provider only mounts when KORTIX_LLM_* is
+  // injected (otherwise OpenCode falls back to showing only its built-in Zen
+  // catalog). Per-seat members get a metered gateway token (llmApiKey) above.
+  // YOLO is discontinued, so when the gateway is enabled but billing is OFF
+  // (local dev / self-hosted) there is no per-member token — fall back to the
+  // sandbox's own account token, which the gateway authenticates via
+  // validateAccountToken and, with billing off, records-but-never-debits. We
+  // keep the per-seat path untouched when billing is on so prod behaviour (paid
+  // members only) is unchanged.
+  const gatewayLlmKey: string | null =
+    llmApiKey ??
+    (config.LLM_GATEWAY_ENABLED && !config.KORTIX_BILLING_INTERNAL_ENABLED
+      ? executorToken
+      : null);
+
   const providerCreateInput: CreateSandboxOpts = {
     accountId,
     userId,
@@ -260,11 +275,11 @@ export async function provisionSessionSandbox(opts: {
       ...(executorToken
         ? { KORTIX_EXECUTOR_TOKEN: executorToken, KORTIX_CLI_TOKEN: executorToken }
         : {}),
-      ...(llmApiKey
+      ...(gatewayLlmKey
         ? {
-            KORTIX_LLM_API_KEY: llmApiKey,
+            KORTIX_LLM_API_KEY: gatewayLlmKey,
             KORTIX_LLM_BASE_URL: llmBaseUrl,
-            KORTIX_YOLO_API_KEY: llmApiKey,
+            KORTIX_YOLO_API_KEY: gatewayLlmKey,
             KORTIX_YOLO_URL: llmBaseUrl,
           }
         : {}),


### PR DESCRIPTION
The OpenCode `kortix` provider only mounts when KORTIX_LLM_BASE_URL + KORTIX_LLM_API_KEY are present in the sandbox env. Today those are injected only for per-seat accounts with an active subscription — the sandbox presents a `kyolo_` token the gateway authenticates via attributeYoloToken. On billing-disabled deploys (local dev, self-hosted) no such token is minted, so the provider is never configured and OpenCode falls back to its built-in Zen catalog. The managed gateway is unreachable even when LLM_GATEWAY_ENABLED=true and OPENROUTER_API_KEY is set.

Decouple gateway access from the (discontinued) YOLO/billing path:

- session-sandbox.ts: when the gateway is enabled but billing is OFF, fall back to the sandbox's own account token (already minted as KORTIX_EXECUTOR_TOKEN) as the gateway key. The per-seat path is untouched, so billing-on/prod behaviour is identical.
- index.ts: the gateway's authenticateToken additively accepts that account token via validateAccountToken (resolving {userId, accountId}) alongside the legacy kyolo_ path. assertBillingActive still runs, so there is no free-access regression when billing is on; with billing off it records-but-never-debits.

Verified end-to-end on a local sandbox: KORTIX_LLM_* is injected into a freshly provisioned box, and the gateway returns a real completion when called with the account token.