### PR TITLE
fix(billing): treat active per-seat accounts as paid for tier-gated l…

### DIFF
--- a/apps/api/src/shared/account-limits.ts
+++ b/apps/api/src/shared/account-limits.ts
@@ -1,6 +1,6 @@
 import { config } from '../config';
 import { getSubscriptionInfo } from '../billing/repositories/credit-accounts';
-import { getTier, isPaidTier, MAX_PROJECTS_PER_ACCOUNT } from '../billing/services/tiers';
+import { getTier, isPaidTier, isPerSeatAccount, MAX_PROJECTS_PER_ACCOUNT } from '../billing/services/tiers';
 import type { RateLimitPolicy } from './rate-limit';
 
 // Free accounts may own a single project. Any paid plan (pro or the per-seat
@@ -35,7 +35,22 @@ export async function resolveAccountTier(accountId: string): Promise<string | nu
 
   try {
     const subscription = await getSubscriptionInfo(accountId);
-    const tier = subscription?.tier ?? 'free';
+    let tier = subscription?.tier ?? 'free';
+    // Per-seat teams are paid by virtue of an active seat subscription, but a
+    // number of rows still carry a stale tier='free' — the seat-billing
+    // migration set billing_model='per_seat' without backfilling tier. Deriving
+    // the paid tier from billing_model + an active subscription here means stale
+    // tier data can't mis-gate paying teams as free (e.g. the 1-project cap),
+    // and it self-heals every tier-based limit (projects, sessions, rate).
+    if (
+      !isPaidTier(tier) &&
+      isPerSeatAccount(subscription?.billingModel) &&
+      !!subscription?.stripeSubscriptionId &&
+      subscription.stripeSubscriptionStatus !== 'canceled' &&
+      subscription.stripeSubscriptionStatus !== 'unpaid'
+    ) {
+      tier = 'per_seat';
+    }
     tierCache.set(accountId, { tier, expiresAt: Date.now() + 60_000 });
     return tier;
   } catch {


### PR DESCRIPTION
resolveAccountTier() returned credit_accounts.tier verbatim, but the seat-billing migration set billing_model='per_seat' on paying teams without backfilling tier — leaving many paid accounts on the stale tier='free'. Because every tier gate (project cap, concurrent sessions, session-LLM rate) keys off isPaidTier(tier), those teams were treated as free. The user-visible symptom: "Free accounts are limited to 1 project. Upgrade to a paid plan to create more." on a paid account (maxProjectsForAccount -> isPaidTier('free') === false -> FREE_TIER_PROJECT_LIMIT).

Derive the paid tier from billing_model + an active subscription: when the stored tier is non-paid but the account is per-seat with a live (non-canceled/unpaid) Stripe subscription, resolve it to 'per_seat'. This self-heals all tier-based limits without a prod data migration, and is robust to stale tier rows.

Observed on prod: 5 of 6 per_seat accounts carried tier='free'.