### PR TITLE
fix(billing): show "Claim seat-based pricing" only to genuine legacy users

### DIFF
--- a/apps/api/src/__tests__/billing/per-seat-pricing.test.ts
+++ b/apps/api/src/__tests__/billing/per-seat-pricing.test.ts
@@ -17,6 +17,7 @@ import {
   grantForSeats,
   isPerSeatAccount,
   isLegacyAccount,
+  canClaimPerSeat,
   llmPriceMarkup,
 } from '../../billing/services/tiers';
 
@@ -64,6 +65,55 @@ describe('billing_model guards', () => {
     expect(isLegacyAccount(null)).toBe(true);
     expect(isLegacyAccount(undefined)).toBe(true);
     expect(isLegacyAccount('per_seat')).toBe(false);
+  });
+});
+
+describe('canClaimPerSeat — the "Claim seat-based pricing" card gate', () => {
+  // The bug this guards against: a brand-new free user (billing_model null/legacy,
+  // no machine) was shown the claim card; clicking it dead-ended on "nothing to
+  // switch", and the card hid the normal top-up path — stranding them out of credits.
+
+  test('NEW free user (legacy default, no machine) → hidden (regression)', () => {
+    expect(canClaimPerSeat({ billingModel: null, hasLegacyMachine: false })).toBe(false);
+    expect(canClaimPerSeat({ billingModel: undefined, hasLegacyMachine: false })).toBe(false);
+    expect(canClaimPerSeat({ billingModel: 'legacy', hasLegacyMachine: false })).toBe(false);
+  });
+
+  test('genuine legacy account with a machine to migrate → shown', () => {
+    expect(canClaimPerSeat({ billingModel: 'legacy', hasLegacyMachine: true })).toBe(true);
+    expect(canClaimPerSeat({ billingModel: null, hasLegacyMachine: true })).toBe(true);
+  });
+
+  test('already on per-seat → hidden, even with a machine', () => {
+    expect(canClaimPerSeat({ billingModel: 'per_seat', hasLegacyMachine: true })).toBe(false);
+    expect(canClaimPerSeat({ billingModel: 'per_seat', hasLegacyMachine: false })).toBe(false);
+  });
+
+  test('active yearly commitment → hidden (migration would no-op)', () => {
+    const future = new Date('2030-01-01T00:00:00Z');
+    const now = new Date('2026-06-05T00:00:00Z');
+    expect(canClaimPerSeat({
+      billingModel: 'legacy', hasLegacyMachine: true,
+      commitmentType: 'yearly_commitment', commitmentEndDate: future, now,
+    })).toBe(false);
+  });
+
+  test('expired yearly commitment → shown again', () => {
+    const past = new Date('2025-01-01T00:00:00Z');
+    const now = new Date('2026-06-05T00:00:00Z');
+    expect(canClaimPerSeat({
+      billingModel: 'legacy', hasLegacyMachine: true,
+      commitmentType: 'yearly_commitment', commitmentEndDate: past, now,
+    })).toBe(true);
+  });
+
+  test('non-yearly commitment does not block the claim', () => {
+    const future = new Date('2030-01-01T00:00:00Z');
+    const now = new Date('2026-06-05T00:00:00Z');
+    expect(canClaimPerSeat({
+      billingModel: 'legacy', hasLegacyMachine: true,
+      commitmentType: 'monthly', commitmentEndDate: future, now,
+    })).toBe(true);
   });
 });
 

--- a/apps/api/src/billing/services/account-state.ts
+++ b/apps/api/src/billing/services/account-state.ts
@@ -11,6 +11,7 @@ import {
   isPaidTier,
   isLegacyPaidTier,
   isPerSeatAccount,
+  canClaimPerSeat,
   MINIMUM_CREDIT_FOR_RUN,
   PER_SEAT_PRICE_USD,
   TYPICAL_COMPUTE_BUDGET_PER_SEAT_USD,
@@ -133,6 +134,16 @@ export async function buildMinimalAccountState(accountId: string): Promise<Accou
   const hasActiveMachine = instances.some((i: any) => i.status === 'active' || i.status === 'provisioning');
   const canClaimComputer = isLegacyPaidTier(tierName) && !hasActiveMachine;
 
+  // Only genuine legacy per-machine accounts (with a machine to move off of)
+  // should see the "Claim seat-based pricing" card — never new per-seat-era
+  // free users, whose claim would dead-end on "nothing to switch".
+  const canClaimPerSeatPricing = canClaimPerSeat({
+    billingModel: sub?.billingModel,
+    hasLegacyMachine: instances.length > 0,
+    commitmentType: sub?.commitmentType ?? null,
+    commitmentEndDate: sub?.commitmentEndDate ?? null,
+  });
+
   const state = {
     credits: {
       total: credits.total,
@@ -169,6 +180,7 @@ export async function buildMinimalAccountState(accountId: string): Promise<Accou
     instances,
     can_add_instances: isAdmin || isPaidTier(tierName),
     can_claim_computer: canClaimComputer,
+    can_claim_per_seat: canClaimPerSeatPricing,
     billing_model: (isPerSeatAccount(sub?.billingModel) ? 'per_seat' : 'legacy') as 'per_seat' | 'legacy',
     seats: isPerSeatAccount(sub?.billingModel)
       ? {
@@ -241,6 +253,7 @@ export function buildLocalAccountState(): AccountStateResponse {
     instances: [],
     can_add_instances: false,
     can_claim_computer: false,
+    can_claim_per_seat: false,
     billing_model: 'legacy',
   };
 }

--- a/apps/api/src/billing/services/tiers.ts
+++ b/apps/api/src/billing/services/tiers.ts
@@ -401,6 +401,34 @@ export function isLegacyAccount(billingModel: string | null | undefined): boolea
   return billingModel !== 'per_seat';
 }
 
+/**
+ * Whether to show the "Claim seat-based pricing" card. It must appear ONLY for a
+ * genuine legacy per-machine account that has something to migrate, so clicking
+ * actually does something. A new per-seat-era user (no machine) must NOT see it:
+ * `billing_model` is `'legacy'` for everyone who isn't explicitly `per_seat`
+ * (incl. brand-new free accounts with a null model), so gating the card on
+ * `billing_model === 'legacy'` showed it to new users — whose claim then
+ * dead-ends on "nothing to switch" while the card hides the normal top-up /
+ * subscribe path, stranding them out of credits. Mirrors the preconditions of
+ * maybeMigrateLegacyAccount (not already per-seat; has a legacy machine; not
+ * under an active yearly commitment) so the card never offers a no-op.
+ */
+export function canClaimPerSeat(args: {
+  billingModel: string | null | undefined;
+  hasLegacyMachine: boolean;
+  commitmentType?: string | null;
+  commitmentEndDate?: string | Date | null;
+  now?: Date;
+}): boolean {
+  if (isPerSeatAccount(args.billingModel)) return false;
+  if (!args.hasLegacyMachine) return false;
+  if (args.commitmentType === 'yearly_commitment' && args.commitmentEndDate) {
+    const ends = new Date(args.commitmentEndDate);
+    if (ends > (args.now ?? new Date())) return false;
+  }
+  return true;
+}
+
 /** Legacy paid tiers eligible for the "claim computer" flow. */
 export const LEGACY_PAID_TIERS = ['tier_2_20', 'tier_6_50', 'tier_12_100', 'tier_25_200', 'tier_50_400', 'tier_125_800', 'tier_200_1000', 'tier_150_1200'] as const;
 

--- a/apps/api/src/types.ts
+++ b/apps/api/src/types.ts
@@ -226,6 +226,10 @@ export interface AccountStateResponse {
   can_add_instances: boolean;
   /** True when a legacy paid user has no active machine and can claim one. */
   can_claim_computer?: boolean;
+  /** True only for genuine legacy per-machine accounts with a machine to migrate
+   *  to per-seat — gates the "Claim seat-based pricing" card so new per-seat-era
+   *  users never see a no-op claim. */
+  can_claim_per_seat?: boolean;
 
   // Billing v2 — surfaced for per-seat accounts only. Legacy accounts get
   // billing_model='legacy' here and the frontend renders the legacy UI.

--- a/apps/web/src/components/billing/claim-per-seat-card.tsx
+++ b/apps/web/src/components/billing/claim-per-seat-card.tsx
@@ -7,7 +7,12 @@ import type { AccountState } from '@/lib/api/billing';
 
 export function ClaimPerSeatCard({ accountState }: { accountState?: AccountState }) {
   const claim = useClaimPerSeat();
-  if (!accountState || accountState.billing_model !== 'legacy') return null;
+  // Show ONLY for genuine legacy accounts with a machine to migrate. A plain
+  // `billing_model === 'legacy'` check also matched new per-seat-era free users
+  // (whose model is the legacy default), dead-ending their claim on "nothing to
+  // switch" and hiding the normal top-up path. can_claim_per_seat is computed
+  // server-side to mirror what the claim will actually do.
+  if (!accountState || !accountState.can_claim_per_seat) return null;
 
   return (
     <div className="rounded-2xl border border-primary/20 bg-primary/5 p-4 space-y-3">

--- a/apps/web/src/components/settings/user-settings-modal.tsx
+++ b/apps/web/src/components/settings/user-settings-modal.tsx
@@ -1486,8 +1486,10 @@ export function BillingTab({ returnUrl, isActive }: { returnUrl: string; isActiv
                     {/* Plan / wallet / spend / limits */}
                     <AccountOverviewTab accountId={billingAccountId} />
 
-                    {/* Legacy machine-billed users — claim the new seat-based plan */}
-                    {accountState?.billing_model === 'legacy' && <ClaimPerSeatCard accountState={accountState} />}
+                    {/* Legacy machine-billed users — claim the new seat-based plan.
+                        Gated on can_claim_per_seat (real migration eligibility), NOT
+                        billing_model==='legacy', which also matched new free users. */}
+                    {accountState?.can_claim_per_seat && <ClaimPerSeatCard accountState={accountState} />}
 
                     {/* Team seats — when on the per-seat plan */}
                     {subscribedToTeam && <SeatManagementCard accountState={accountState} />}

--- a/apps/web/src/lib/api/billing.ts
+++ b/apps/web/src/lib/api/billing.ts
@@ -115,6 +115,10 @@ export interface AccountState {
   }>;
   can_add_instances?: boolean;
   can_claim_computer?: boolean;
+  // True only for genuine legacy per-machine accounts that have a machine to
+  // migrate — gates the "Claim seat-based pricing" card (new per-seat-era users
+  // must not see it, or the claim dead-ends on "nothing to switch").
+  can_claim_per_seat?: boolean;
   // Billing v2 — present for accounts on the new per-seat plan.
   billing_model?: 'legacy' | 'per_seat';
   seats?: {


### PR DESCRIPTION
New per-seat-era free users were stranded: out of credits, the billing UI showed only "Claim seat-based pricing", but clicking it dead-ended on "Nothing to switch — no active machine subscription" and the card hid the normal top-up path. Root cause: the card gated on `billing_model === 'legacy'`, and billing_model is 'legacy' for everyone who isn't explicitly 'per_seat' (including brand-new free accounts with a null model).

- add canClaimPerSeat() — a pure predicate mirroring maybeMigrateLegacyAccount's real preconditions (not already per-seat; has a legacy machine to migrate; not under an active yearly commitment), so the card never offers a no-op.
- surface it as account_state.can_claim_per_seat (API types + frontend type).
- gate the claim card (render site + the component's own guard) on can_claim_per_seat instead of billing_model === 'legacy'.
- unit-test the predicate, incl. the regression: new free user (legacy default, no machine) → hidden.

Free users keep the normal "Top up" / "Manage billing" CTAs.