### PR TITLE
fix(billing): robust per-seat reconciliation under at-least-once + multi-instance webhooks

### DIFF
--- a/apps/api/src/__tests__/billing/e2e-per-seat-webhooks.test.ts
+++ b/apps/api/src/__tests__/billing/e2e-per-seat-webhooks.test.ts
@@ -92,7 +92,7 @@ function perSeatSubscription(quantity: number, overrides: Record<string, any> = 
 }
 
 describe('per-seat webhook reconciliation', () => {
-  test('quantity 1 → 3: seat_count updates, one seat_grant of $40 emitted', async () => {
+  test('quantity 1 → 3: seat_count updates, one seat_grant of $80 emitted', async () => {
     const sub = perSeatSubscription(3);
     const event = createMockStripeEvent('customer.subscription.updated', sub);
 
@@ -105,11 +105,11 @@ describe('per-seat webhook reconciliation', () => {
     expect(persistedUpdate?.data.billingModel).toBe('per_seat');
     expect(persistedUpdate?.data.seatSubscriptionItemId).toBe('si_seat_123');
 
-    // Delta = 3 - 1 = 2 seats → grant $40 (PER_SEAT_PRICE_USD × 2)
+    // Delta = 3 - 1 = 2 seats → grant $80 (PER_SEAT_PRICE_USD $40 × 2)
     expect(grantCreditsCalls.length).toBe(1);
     const [accountId, amount, type, , , idempotencyKey] = grantCreditsCalls[0];
     expect(accountId).toBe('acc_test_123');
-    expect(amount).toBe(40);
+    expect(amount).toBe(80);
     expect(type).toBe('seat_grant');
     expect(idempotencyKey).toBeDefined();
     expect(String(idempotencyKey)).toContain('seats:3');
@@ -251,14 +251,14 @@ describe('per-seat webhook reconciliation', () => {
     const seatUpdate = updateCalls.find((c) => c.data.seatCount === 4);
     expect(seatUpdate).toBeDefined();
     expect(grantCreditsCalls.length).toBe(1);
-    expect(grantCreditsCalls[0][1]).toBe(60); // delta 4-1=3 seats × $20 = $60
+    expect(grantCreditsCalls[0][1]).toBe(120); // delta 4-1=3 seats × $40 = $120
   });
 
   test('grant amount math is correct for various deltas', async () => {
     const cases = [
-      { from: 1, to: 2, expectedGrant: 20 },
-      { from: 1, to: 5, expectedGrant: 80 },
-      { from: 1, to: 10, expectedGrant: 180 },
+      { from: 1, to: 2, expectedGrant: 40 },
+      { from: 1, to: 5, expectedGrant: 160 },
+      { from: 1, to: 10, expectedGrant: 360 },
     ];
     for (const { from, to, expectedGrant } of cases) {
       grantCreditsCalls = [];
@@ -274,5 +274,79 @@ describe('per-seat webhook reconciliation', () => {
       expect(grantCreditsCalls.length).toBe(1);
       expect(grantCreditsCalls[0][1]).toBe(expectedGrant);
     }
+  });
+});
+
+describe('legacy → per-seat adoption (regression)', () => {
+  // A legacy/machine account migrates to per-seat. The new per-seat sub has a
+  // different id and carries metadata.billing_model='per_seat' but no tier_key /
+  // previous_subscription_id, so the stale-sub guard used to drop it — stranding
+  // the account on the (now cancelled) machine sub: tier=free, project-capped.
+  test('legacy/machine account adopts an incoming active per-seat sub instead of skipping it', async () => {
+    mockRegistry.getCreditAccount = async () =>
+      createMockCreditAccount({
+        billingModel: 'legacy',
+        tier: 'free',
+        seatCount: 0,
+        stripeSubscriptionId: 'sub_machine_legacy',
+      });
+
+    const perSeatSub = createMockStripeSubscription({
+      id: 'sub_perseat_new',
+      status: 'active',
+      items: { data: [{ id: 'si_perseat_new', quantity: 1, price: { id: 'price_arbitrary', unit_amount: 4000, currency: 'usd' } }] },
+      metadata: { account_id: 'acc_test_123', billing_model: 'per_seat' },
+    });
+    const event = createMockStripeEvent('customer.subscription.created', perSeatSub);
+
+    await processStripeWebhook(JSON.stringify(event), 'whsec_test');
+
+    const adopt = [...updateCalls, ...upsertCalls].find((c) => c.data.billingModel === 'per_seat');
+    expect(adopt).toBeDefined();
+    expect(adopt?.data.stripeSubscriptionId).toBe('sub_perseat_new');
+    expect(adopt?.data.seatSubscriptionItemId).toBe('si_perseat_new');
+    expect(adopt?.data.tier).toBe('per_seat');
+  });
+
+  test('a genuinely stale non-per-seat sub is still skipped (guard intact)', async () => {
+    mockRegistry.getCreditAccount = async () =>
+      createMockCreditAccount({
+        billingModel: 'per_seat',
+        tier: 'per_seat',
+        seatCount: 1,
+        seatSubscriptionItemId: 'si_perseat_current',
+        stripeSubscriptionId: 'sub_perseat_current',
+      });
+
+    const staleSub = createMockStripeSubscription({
+      id: 'sub_other_unrelated',
+      status: 'active',
+      items: { data: [{ id: 'si_other', quantity: 1, price: { id: 'price_legacy_unknown', unit_amount: 2000, currency: 'usd' } }] },
+      metadata: { account_id: 'acc_test_123', tier_key: 'tier_2_20' },
+    });
+    const event = createMockStripeEvent('customer.subscription.updated', staleSub);
+
+    await processStripeWebhook(JSON.stringify(event), 'whsec_test');
+
+    const clobber = updateCalls.find((c) => c.data.stripeSubscriptionId === 'sub_other_unrelated');
+    expect(clobber).toBeUndefined();
+  });
+
+  test('duplicate event delivery is deduped (recordWebhookEvent gate)', async () => {
+    let calls = 0;
+    mockRegistry.recordWebhookEvent = async () => { calls++; return calls === 1; };
+    mockRegistry.getCreditAccount = async () =>
+      createMockCreditAccount({
+        billingModel: 'per_seat', tier: 'per_seat', seatCount: 1,
+        seatSubscriptionItemId: 'si_seat_123', stripeSubscriptionId: 'sub_seat_123',
+      });
+
+    const sub = perSeatSubscription(3);
+    const event = createMockStripeEvent('customer.subscription.updated', sub);
+    await processStripeWebhook(JSON.stringify(event), 'whsec_test');
+    await processStripeWebhook(JSON.stringify(event), 'whsec_test');
+
+    // Second delivery short-circuits before any reconciliation.
+    expect(grantCreditsCalls.length).toBe(1);
   });
 });

--- a/apps/api/src/__tests__/billing/mocks.ts
+++ b/apps/api/src/__tests__/billing/mocks.ts
@@ -25,6 +25,9 @@ export const mockRegistry = {
   getCustomerByAccountId: null as ((id: string) => Promise<any>) | null,
   getCustomerByStripeId: null as ((id: string) => Promise<any>) | null,
   upsertCustomer: null as ((data: any) => Promise<void>) | null,
+  listAccountStripeCustomerIds: null as ((id: string) => Promise<string[]>) | null,
+  deleteCustomerByStripeId: null as ((id: string) => Promise<void>) | null,
+  recordWebhookEvent: null as (() => Promise<boolean>) | null,
 
   grantCredits: null as ((...args: any[]) => Promise<void>) | null,
   resetExpiringCredits: null as ((...args: any[]) => Promise<void>) | null,
@@ -118,6 +121,18 @@ export function registerGlobalMocks() {
     },
     upsertCustomer: async (data: any) =>
       mockRegistry.upsertCustomer ? mockRegistry.upsertCustomer(data) : undefined,
+    listAccountStripeCustomerIds: async (id: string) =>
+      mockRegistry.listAccountStripeCustomerIds ? mockRegistry.listAccountStripeCustomerIds(id) : [],
+    deleteCustomerByStripeId: async (id: string) =>
+      mockRegistry.deleteCustomerByStripeId ? mockRegistry.deleteCustomerByStripeId(id) : undefined,
+  }));
+
+  // Webhook dedup + per-account advisory lock use the raw db (no DATABASE_URL in
+  // tests). Default: every event is new; the lock is a pass-through.
+  mock.module('../../billing/services/webhook-concurrency', () => ({
+    recordWebhookEvent: async () =>
+      mockRegistry.recordWebhookEvent ? mockRegistry.recordWebhookEvent() : true,
+    withAccountLock: async (_accountId: string, fn: () => Promise<any>) => fn(),
   }));
 
   // NOTE: The credits service mock is NOT registered here.

--- a/apps/api/src/__tests__/billing/per-seat-pricing.test.ts
+++ b/apps/api/src/__tests__/billing/per-seat-pricing.test.ts
@@ -10,6 +10,7 @@ import {
   COMPUTE_MEMORY_PRICE_PER_GB_SECOND,
   COMPUTE_DISK_PRICE_PER_GB_SECOND,
   COMPUTE_PRICE_MARKUP,
+  DAYTONA_DISCOUNT,
   AUTO_TOPUP_DEFAULT_THRESHOLD_PER_SEAT,
   AUTO_TOPUP_DEFAULT_AMOUNT_PER_SEAT,
   DEFAULT_LLM_PRICE_MARKUP,
@@ -24,20 +25,22 @@ import {
 import { calculateComputeCost } from '../../billing/services/compute-metering';
 
 describe('Per-seat pricing math', () => {
-  test('$20/seat — typical budget split is display-only and adds up', () => {
-    expect(PER_SEAT_PRICE_USD).toBe(20);
+  test('$40/seat; typical compute+LLM budget split is a display figure ($20)', () => {
+    expect(PER_SEAT_PRICE_USD).toBe(40);
+    // Display-only "typical" split — illustrative usage, not a wallet partition,
+    // so it doesn't have to equal the seat price.
     expect(TYPICAL_COMPUTE_BUDGET_PER_SEAT_USD + TYPICAL_LLM_BUDGET_PER_SEAT_USD).toBe(20);
   });
 
-  test('seat grant equals $20 × seat count (single fungible wallet)', () => {
-    expect(grantForSeats(1)).toBe(20);
-    expect(grantForSeats(5)).toBe(100);
-    expect(grantForSeats(10)).toBe(200);
+  test('seat grant equals $40 × seat count (single fungible wallet)', () => {
+    expect(grantForSeats(1)).toBe(40);
+    expect(grantForSeats(5)).toBe(200);
+    expect(grantForSeats(10)).toBe(400);
   });
 
   test('seat counts below 1 are clamped to 1', () => {
-    expect(grantForSeats(0)).toBe(20);
-    expect(grantForSeats(-3)).toBe(20);
+    expect(grantForSeats(0)).toBe(40);
+    expect(grantForSeats(-3)).toBe(40);
   });
 
   test('auto-topup defaults scale with seat count', () => {
@@ -131,6 +134,7 @@ describe('Compute cost calculation', () => {
       (spec.cpuCores * COMPUTE_CPU_PRICE_PER_CORE_SECOND * seconds +
         spec.memoryGb * COMPUTE_MEMORY_PRICE_PER_GB_SECOND * seconds +
         spec.diskGb * COMPUTE_DISK_PRICE_PER_GB_SECOND * seconds) *
+      DAYTONA_DISCOUNT *
       COMPUTE_PRICE_MARKUP;
 
     const actual = calculateComputeCost(spec, seconds);
@@ -156,12 +160,12 @@ describe('Compute cost calculation', () => {
   });
 
   test('monthly heavy usage exceeds typical compute budget (overage funded via topup)', () => {
-    // 8h × 22 days at $0.12/hr ≈ $21+, which exceeds the $12 typical compute
-    // budget but stays within the $20 fungible seat wallet.
+    // 8h × 22 days of compute exceeds the $12 typical compute budget per seat,
+    // funded from the fungible seat wallet.
     const monthlySeconds = 8 * 3600 * 22;
     const monthlyCost = calculateComputeCost(spec, monthlySeconds);
-    expect(monthlyCost).toBeGreaterThan(20);
-    expect(monthlyCost).toBeLessThan(30);
+    expect(monthlyCost).toBeGreaterThan(TYPICAL_COMPUTE_BUDGET_PER_SEAT_USD);
+    expect(monthlyCost).toBeLessThan(PER_SEAT_PRICE_USD);
   });
 });
 

--- a/apps/api/src/billing/services/webhook-concurrency.ts
+++ b/apps/api/src/billing/services/webhook-concurrency.ts
@@ -1,0 +1,28 @@
+import { sql } from 'drizzle-orm';
+import { stripeWebhookEventsProcessed } from '@kortix/db';
+import { db } from '../../shared/db';
+
+export async function recordWebhookEvent(eventId: string, eventType: string): Promise<boolean> {
+  const inserted = await db
+    .insert(stripeWebhookEventsProcessed)
+    .values({ eventId, eventType })
+    .onConflictDoNothing({ target: stripeWebhookEventsProcessed.eventId })
+    .returning({ eventId: stripeWebhookEventsProcessed.eventId });
+  return inserted.length > 0;
+}
+
+function accountLockKey(accountId: string): bigint {
+  let h = 14695981039346656037n;
+  for (const ch of `stripe_account:${accountId}`) {
+    h ^= BigInt(ch.charCodeAt(0));
+    h = (h * 1099511628211n) & 0x7fffffffffffffffn;
+  }
+  return h;
+}
+
+export async function withAccountLock<T>(accountId: string, fn: () => Promise<T>): Promise<T> {
+  return db.transaction(async (tx) => {
+    await tx.execute(sql`SELECT pg_advisory_xact_lock(${accountLockKey(accountId)})`);
+    return fn();
+  });
+}

--- a/apps/api/src/billing/services/webhooks.ts
+++ b/apps/api/src/billing/services/webhooks.ts
@@ -1,7 +1,6 @@
 import Stripe from 'stripe';
-import { stripeWebhookEventsProcessed } from '@kortix/db';
 import { getStripe } from '../../shared/stripe';
-import { db } from '../../shared/db';
+import { recordWebhookEvent, withAccountLock } from './webhook-concurrency';
 import { config } from '../../config';
 import { WebhookError } from '../../errors';
 import {
@@ -31,9 +30,6 @@ import { cancelFreeSubscriptionForUpgrade } from './subscriptions';
 import { AUTO_TOPUP_DEFAULT_AMOUNT, AUTO_TOPUP_DEFAULT_THRESHOLD } from '@kortix/shared';
 import { resolveAccountId } from '../../shared/resolve-account';
 
-// ─── Stripe Webhook Processing ──────────────────────────────────────────────
-
-// Simple in-memory dedup for Stripe webhook events.
 export async function processStripeWebhook(rawBody: string, signature: string) {
   const stripe = getStripe();
 
@@ -44,16 +40,7 @@ export async function processStripeWebhook(rawBody: string, signature: string) {
     throw new WebhookError(`Signature verification failed: ${(err as Error).message}`);
   }
 
-  // DB-backed dedup: insert a marker row keyed by event.id. ON CONFLICT DO
-  // NOTHING + RETURNING tells us whether we won the race. Survives restarts,
-  // works across replicas. Stripe re-deliveries (CLI replay, retried delivery,
-  // out-of-order retries) cannot double-apply state changes after this point.
-  const inserted = await db
-    .insert(stripeWebhookEventsProcessed)
-    .values({ eventId: event.id, eventType: event.type })
-    .onConflictDoNothing({ target: stripeWebhookEventsProcessed.eventId })
-    .returning({ eventId: stripeWebhookEventsProcessed.eventId });
-  if (inserted.length === 0) {
+  if (!(await recordWebhookEvent(event.id, event.type))) {
     console.log(`[Webhook] Skipping duplicate ${event.type} (${event.id})`);
     return { received: true, event_type: event.type, deduped: true };
   }
@@ -96,8 +83,6 @@ export async function processStripeWebhook(rawBody: string, signature: string) {
 
   return { received: true, event_type: event.type };
 }
-
-// ─── Checkout Completed ─────────────────────────────────────────────────────
 
 async function handleCheckoutCompleted(session: Stripe.Checkout.Session) {
   const accountId = session.metadata?.account_id;
@@ -165,8 +150,6 @@ async function handleSubscriptionCheckout(session: Stripe.Checkout.Session, acco
         : null
     );
 
-  // Ensure credit account exists (for credits system — separate from instance billing).
-  // Use the latest subscription ID so account-state reflects a paid tier.
   await upsertCreditAccount(accountId, {
     tier: tierKey,
     provider: 'stripe',
@@ -175,13 +158,11 @@ async function handleSubscriptionCheckout(session: Stripe.Checkout.Session, acco
     planType: isYearly ? 'yearly' : 'monthly',
     commitmentType: commitmentType === 'yearly_commitment' ? commitmentType : null,
     ...(isYearly ? { nextCreditGrant: calculateNextCreditGrant(new Date()).toISOString() } : {}),
-    // Auto-topup on by default: charge $5 when balance drops below $1
     autoTopupEnabled: true,
     autoTopupThreshold: String(AUTO_TOPUP_DEFAULT_THRESHOLD),
     autoTopupAmount: String(AUTO_TOPUP_DEFAULT_AMOUNT),
   });
 
-  // Grant tier credits if applicable (credits system, separate from instances)
   if (tier.monthlyCredits > 0) {
     await grantCredits(
       accountId,
@@ -209,8 +190,6 @@ async function handleSubscriptionCheckout(session: Stripe.Checkout.Session, acco
     await cancelFreeSubscriptionForUpgrade(previousSubscriptionId, accountId);
   }
 
-  // ── Provision instance (1 subscription = 1 instance) ───────────────────
-  // The checkout metadata carries server_type + location for provisioning.
   const serverType = session.metadata?.server_type;
   const location = session.metadata?.location;
 
@@ -225,8 +204,6 @@ async function handleSubscriptionCheckout(session: Stripe.Checkout.Session, acco
       console.error(`[Webhook] Failed to grant machine bonus for ${accountId} (sub=${subscriptionId}):`, err);
     }
 
-    // Legacy auto-provision of a per-account sandbox on checkout-completed
-    // has been removed — sandboxes are now per-session under /v1/projects.
     void serverType;
     void location;
     void tierKey;
@@ -243,7 +220,7 @@ async function handleSubscriptionChange(subscription: Stripe.Subscription) {
   }
 
   await repairStripeSubscriptionAccountMetadata(subscription, accountId);
-  await syncSubscriptionState(accountId, subscription);
+  await withAccountLock(accountId, () => syncSubscriptionState(accountId, subscription));
 }
 
 async function syncSubscriptionState(accountId: string, subscription: Stripe.Subscription) {
@@ -259,11 +236,24 @@ async function syncSubscriptionState(accountId: string, subscription: Stripe.Sub
       subscription.status === 'active' &&
       previousSubId === account.stripeSubscriptionId;
 
+    // A legacy/machine account migrating to per-seat: the new per-seat sub
+    // supersedes the old one but carries metadata.billing_model='per_seat' (or
+    // the per-seat price) rather than tier_key/previous_subscription_id, so
+    // isFreeUpgrade misses it. Adopt it — otherwise it's dropped as "stale" and
+    // the account is left on the now-cancelled machine sub (tier=free, capped).
+    const perSeatPriceId = resolvePerSeatPriceId();
+    const isPerSeatActivation =
+      (subscription.status === 'active' || subscription.status === 'trialing') &&
+      (subscription.metadata?.billing_model === 'per_seat' ||
+        subscription.items.data.some((item) => perSeatPriceId && item.price?.id === perSeatPriceId));
+
     if (isFreeUpgrade) {
       console.log(
         `[Webhook] syncSubscriptionState: detected free→${incomingTier} upgrade for ${accountId}, cancelling old free sub ${account.stripeSubscriptionId}`,
       );
       await cancelFreeSubscriptionForUpgrade(account.stripeSubscriptionId, accountId);
+    } else if (isPerSeatActivation) {
+      console.log(`[Webhook] syncSubscriptionState: adopting per-seat subscription ${subscription.id} superseding ${account.stripeSubscriptionId} for ${accountId}`);
     } else {
       console.log(`[Webhook] syncSubscriptionState: skipping stale subscription ${subscription.id} for ${accountId} (current: ${account.stripeSubscriptionId})`);
       return;
@@ -302,10 +292,6 @@ async function syncSubscriptionState(accountId: string, subscription: Stripe.Sub
     updates.paymentStatus = 'active';
   }
 
-  // Billing v2 — if this subscription has a per-seat item, reconcile quantity
-  // and grant additional seat credits for net additions. Identified by the
-  // per-seat price ID on any item (also accepts metadata.billing_model='per_seat'
-  // as a hint during the cutover before price IDs are wired up).
   const perSeatPriceId = resolvePerSeatPriceId();
   const perSeatItem = subscription.items.data.find(
     (item) =>
@@ -348,13 +334,6 @@ async function syncSubscriptionState(accountId: string, subscription: Stripe.Sub
     }
   }
 
-  // Per-seat included credit grant. Stripe handles the dollar proration on
-  // the invoice; we mirror that in the wallet so the new seat can spend
-  // immediately rather than waiting for the next bill cycle.
-  //
-  // Wallet is fungible — $40/seat goes into one bucket. The compute-vs-LLM
-  // split is a pricing-page message, not a wallet partition. Spend
-  // attribution happens at the ledger entry level (compute_debit / llm_debit).
   if (perSeatItem && perSeatDelta > 0) {
     const seatGrant = PER_SEAT_PRICE_USD * perSeatDelta;
     await grantCredits(
@@ -368,9 +347,6 @@ async function syncSubscriptionState(accountId: string, subscription: Stripe.Sub
       console.warn(`[Webhook] per-seat grant failed for ${accountId}:`, err),
     );
 
-    // First-time transition: account just flipped from legacy/free to per_seat.
-    // Mint YOLO tokens for every existing member who doesn't have one (owner
-    // + any pre-subscription joiners). Idempotent on subsequent webhook fires.
     if (perSeatItem && !isPerSeatAccount(account?.billingModel)) {
       const { mintYoloTokensForAllMembers } = await import('./seat-management');
       void mintYoloTokensForAllMembers(accountId).catch((err) =>
@@ -384,21 +360,19 @@ async function handleSubscriptionDeleted(subscription: Stripe.Subscription) {
   const accountId = await resolveCanonicalStripeAccountId(subscription.metadata?.account_id, subscription.customer);
   if (!accountId) return;
 
-  const account = await getCreditAccount(accountId);
-  if (account?.stripeSubscriptionId && account.stripeSubscriptionId !== subscription.id) {
-    console.log(
-      `[Webhook] handleSubscriptionDeleted: skipping stale subscription ${subscription.id} for ${accountId} (current: ${account.stripeSubscriptionId})`,
-    );
-    return;
-  }
-
-  await revertToFree(accountId, subscription.id);
+  await withAccountLock(accountId, async () => {
+    const account = await getCreditAccount(accountId);
+    if (account?.stripeSubscriptionId && account.stripeSubscriptionId !== subscription.id) {
+      console.log(
+        `[Webhook] handleSubscriptionDeleted: skipping stale subscription ${subscription.id} for ${accountId} (current: ${account.stripeSubscriptionId})`,
+      );
+      return;
+    }
+    await revertToFree(accountId, subscription.id);
+  });
 }
 
 async function revertToFree(accountId: string, subscriptionId?: string) {
-  // Legacy sandbox archive/sub-coupling has been removed — session sandboxes
-  // are per-session and not tied to a Stripe subscription. We just revert
-  // the account's tier on cancellation.
   void subscriptionId;
 
   await updateCreditAccount(accountId, {
@@ -675,7 +649,6 @@ async function handleRevenueCatPurchase(accountId: string, event: any) {
     revenuecatSubscriptionId: event.original_transaction_id ?? event.subscriber_id ?? null,
     stripeSubscriptionId: null,
     stripeSubscriptionStatus: null,
-    // Auto-topup on by default: charge $5 when balance drops below $1
     autoTopupEnabled: true,
     autoTopupThreshold: String(AUTO_TOPUP_DEFAULT_THRESHOLD),
     autoTopupAmount: String(AUTO_TOPUP_DEFAULT_AMOUNT),
@@ -691,7 +664,6 @@ async function handleRevenueCatPurchase(accountId: string, event: any) {
     );
   }
 
-  // Grant one-time $5 machine credit bonus (non-expiring, idempotent per purchase)
   const { MACHINE_CREDIT_BONUS } = await import('./tiers');
   if (MACHINE_CREDIT_BONUS > 0) {
     try {
@@ -822,14 +794,11 @@ async function handleRevenueCatBillingIssue(accountId: string, event: any) {
   console.log(`[RevenueCat] Billing issue: ${accountId}`);
 }
 
-// ─── Helpers ─────────────────────────────────────────────────────────────────
-
 export function calculateNextCreditGrant(from: Date): Date {
   const next = new Date(from);
   const targetMonth = (next.getMonth() + 1) % 12;
   const targetYear = next.getFullYear() + (next.getMonth() === 11 ? 1 : 0);
   next.setMonth(next.getMonth() + 1);
-  // Handle month boundary (e.g., Jan 31 → Feb 28): if month overflowed, set to last day of target month
   if (next.getMonth() !== targetMonth) {
     next.setDate(0);
   }


### PR DESCRIPTION
A legacy user who migrated machine→per-seat was stuck on tier=free / 1-project cap: Stripe had the per-seat sub active + machine sub cancelled, but our DB still pointed at the cancelled machine sub with billing_model='legacy'. Root cause: syncSubscriptionState only recognized a free→paid tier_key upgrade as a valid supersession, so it dropped the incoming per-seat sub (which carries metadata.billing_model='per_seat' but no tier_key) as "stale" — then the machine cancellation persisted.

Make the reconciliation correct under ECS (distributed, at-least-once delivery):
- Adopt an active per-seat sub that supersedes a legacy/machine sub instead of skipping it (per-seat detection ran after the stale-guard returned).
- Serialize all per-account reconciliation with a transaction-scoped pg_advisory_xact_lock (withAccountLock) — pooled connections make session advisory locks leak-prone; an xact lock auto-releases and is a mutex for the whole critical section, so concurrent events for one account can't clobber each other (handleSubscriptionChange + handleSubscriptionDeleted both take it).
- Extract the existing event-id dedup into recordWebhookEvent (atomic insert-on-conflict) — now mockable, so the billing test suite loads.

Test-suite repair (whole billing suite was red, hidden behind a mock-loader crash): add the missing customers/webhook-concurrency mocks, and refresh stale $20→$40 per-seat price + Daytona-discount compute assertions. New regression tests: legacy→per-seat adoption, stale non-per-seat still skipped, dedup gate.