### PR TITLE
feat(suna-migration): windowed migration — latest 25 by default + offset

### DIFF
--- a/apps/api/src/projects/suna-migration/suna-migration-phases.ts
+++ b/apps/api/src/projects/suna-migration/suna-migration-phases.ts
@@ -51,14 +51,16 @@ export async function extractStep(ctx: SunaMigrationContext): Promise<void> {
   rmSync(out, { recursive: true, force: true });
   mkdirSync(join(out, 'legacy'), { recursive: true });
 
-  // Optional cap (testing / very large accounts): KORTIX_SUNA_MIGRATION_LIMIT.
-  const limit = Number(process.env.KORTIX_SUNA_MIGRATION_LIMIT) || 0;
+  // Window over the account's projects, newest-first: plan.{limit,offset}.
+  // Default = latest 25. offset lets a later run grab the next batch (25–50, …).
+  const limit = Number(ctx.plan.limit) > 0 ? Number(ctx.plan.limit) : 25;
+  const offset = Number(ctx.plan.offset) >= 0 ? Number(ctx.plan.offset) : 0;
   const sunaProjects = (await ctx.database.execute(sql`
     SELECT p.project_id, COALESCE(NULLIF(p.name,''),'Untitled') AS name, r.external_id
     FROM public.projects p
     LEFT JOIN public.resources r ON r.id = p.sandbox_resource_id AND r.type = 'sandbox'
     WHERE p.account_id = ${ctx.accountId} ORDER BY p.created_at DESC
-    ${limit > 0 ? sql`LIMIT ${limit}` : sql``}
+    LIMIT ${limit} OFFSET ${offset}
   `)) as unknown as Array<{ project_id: string; name: string; external_id: string | null }>;
 
   const used = new Set<string>();

--- a/apps/api/src/projects/suna-migration/suna-migration-routes.ts
+++ b/apps/api/src/projects/suna-migration/suna-migration-routes.ts
@@ -55,7 +55,6 @@ export function registerSunaMigrationRoutes(app: OpenAPIHono<AppEnv>): void {
     async (c: any) => {
       const accountId = await resolveScopedAccountId(c, 'query');
       const latest = await latestSunaMigration(db, accountId);
-      // Already done or in-flight → not eligible to start (UI shows status/hides).
       if (latest && ['completed', 'running', 'planned'].includes(latest.status)) {
         return c.json({ eligible: false, migration: serialize(latest) });
       }
@@ -68,7 +67,11 @@ export function registerSunaMigrationRoutes(app: OpenAPIHono<AppEnv>): void {
     createRoute({
       method: 'post', path: '/suna-migration/start', tags: ['projects'],
       summary: 'Start the Suna → opencode migration for the account', ...auth,
-      request: { body: { content: { 'application/json': { schema: z.object({ account_id: z.string().optional() }) } } } },
+      request: { body: { content: { 'application/json': { schema: z.object({
+        account_id: z.string().optional(),
+        limit: z.number().int().positive().max(200).optional(),
+        offset: z.number().int().nonnegative().optional(),
+      }) } } } },
       responses: {
         200: json(z.object({ created: z.boolean(), migration: z.any() }), 'Existing in-flight migration'),
         202: json(z.object({ created: z.boolean(), migration: z.any() }), 'Migration started'),
@@ -78,10 +81,15 @@ export function registerSunaMigrationRoutes(app: OpenAPIHono<AppEnv>): void {
     }),
     async (c: any) => {
       const accountId = await resolveScopedAccountId(c, 'body');
+      const body = await c.req.json().catch(() => ({}));
       if ((await countSunaProjects(accountId)) === 0) {
         return c.json({ error: 'No Suna projects found for this account' }, 400);
       }
-      const { migration, created } = await startSunaMigration({ database: db, accountId });
+      const { migration, created } = await startSunaMigration({
+        database: db, accountId,
+        limit: typeof body?.limit === 'number' ? body.limit : undefined,
+        offset: typeof body?.offset === 'number' ? body.offset : undefined,
+      });
       return c.json({ created, migration: serialize(migration) }, created ? 202 : 200);
     },
   );

--- a/apps/api/src/projects/suna-migration/suna-migration-runner.ts
+++ b/apps/api/src/projects/suna-migration/suna-migration-runner.ts
@@ -1,10 +1,3 @@
-/**
- * Durable runner for the user-triggered Suna → opencode account migration.
- * Mirrors legacy-migration-runner exactly (idempotent phases, time-boxed
- * heartbeat lease, resumable by the worker), but keyed on ACCOUNT: one row →
- * one new project with N sessions. The user clicks "Migrate" once; the backend
- * owns it from there and finishes even across redeploys.
- */
 import { and, desc, eq, inArray, lt, or, sql } from 'drizzle-orm';
 import { sunaAccountMigrations, type Database } from '@kortix/db';
 import { logger as appLogger } from '../../lib/logger';
@@ -22,6 +15,7 @@ export interface SunaMigrationContext {
   migrationId: string;
   runId: string;
   accountId: string;
+  plan: Record<string, unknown>;
   progress: Record<string, unknown>;
   checkpoint: (patch: Record<string, unknown>) => Promise<void>;
   heartbeat: () => Promise<void>;
@@ -69,7 +63,7 @@ export async function driveSunaMigration(database: Database, migrationId: string
       .where(eq(sunaAccountMigrations.migrationId, migrationId));
   };
 
-  const ctx: SunaMigrationContext = { database, migrationId, runId: leased.runId, accountId: leased.accountId, progress, checkpoint, heartbeat, log };
+  const ctx: SunaMigrationContext = { database, migrationId, runId: leased.runId, accountId: leased.accountId, plan: asObject(leased.plan), progress, checkpoint, heartbeat, log };
 
   let phaseIndex = Math.max(0, PHASE_ORDER.indexOf((leased.phase as SunaPhase) ?? 'extract'));
   for (; phaseIndex < PHASE_ORDER.length; phaseIndex++) {
@@ -122,15 +116,19 @@ export async function latestSunaMigration(database: Database, accountId: string)
   return row ?? null;
 }
 
-export async function startSunaMigration(input: { database: Database; accountId: string; autoDrive?: boolean }): Promise<{ migration: MigrationRow; created: boolean }> {
+export const DEFAULT_LIMIT = 25;
+
+export async function startSunaMigration(input: { database: Database; accountId: string; limit?: number; offset?: number; autoDrive?: boolean }): Promise<{ migration: MigrationRow; created: boolean }> {
   const { database, accountId } = input;
   const existing = await findActiveSunaMigration(database, accountId);
   if (existing) return { migration: existing, created: false };
 
+  const limit = Number.isFinite(input.limit) && (input.limit as number) > 0 ? Math.min(input.limit as number, 200) : DEFAULT_LIMIT;
+  const offset = Number.isFinite(input.offset) && (input.offset as number) >= 0 ? (input.offset as number) : 0;
   const now = new Date();
   const [migration] = await database.insert(sunaAccountMigrations).values({
     runId: `suna-${accountId}`, accountId, status: 'running', mode: 'apply', phase: 'extract',
-    plan: {}, progress: {}, attempts: 0, startedAt: now, heartbeatAt: null, appliedAt: null, updatedAt: now,
+    plan: { limit, offset }, progress: {}, attempts: 0, startedAt: now, heartbeatAt: null, appliedAt: null, updatedAt: now,
   }).returning();
 
   if (input.autoDrive !== false) {

--- a/apps/api/src/scripts/migrate-suna-account.ts
+++ b/apps/api/src/scripts/migrate-suna-account.ts
@@ -34,7 +34,7 @@ const accountId = arg('--account-id');
 const buildDir = arg('--build');
 const pushDir = arg('--push-repo');
 const limit = arg('--limit');
-if (limit) process.env.KORTIX_SUNA_MIGRATION_LIMIT = limit; // caps discovery (test / huge accounts)
+const offset = arg('--offset');
 const mode = pushDir ? 'push-repo' : Bun.argv.includes('--apply') ? 'apply' : buildDir ? 'build' : 'plan';
 if (!accountId) { console.error('--account-id <uuid> required'); process.exit(2); }
 if (mode === 'build' && !buildDir) { console.error('--build <dir> required'); process.exit(2); }
@@ -166,8 +166,11 @@ async function main() {
   //    Run against STAGING first, bounded with --limit. ──
   if (mode === 'apply') {
     const { startSunaMigration, driveSunaMigration, latestSunaMigration } = await import('../projects/suna-migration/suna-migration-runner');
-    console.log(`Starting migration${limit ? ` (limit ${limit})` : ''} for ${accountId} …`);
-    const { migration } = await startSunaMigration({ database: db, accountId: accountId!, autoDrive: false });
+    console.log(`Starting migration (limit ${limit ?? 25}, offset ${offset ?? 0}) for ${accountId} …`);
+    const { migration } = await startSunaMigration({
+      database: db, accountId: accountId!, autoDrive: false,
+      limit: limit ? Number(limit) : undefined, offset: offset ? Number(offset) : undefined,
+    });
     await driveSunaMigration(db, migration.migrationId); // drive synchronously so the script reports the outcome
     const final = await latestSunaMigration(db, accountId!);
     console.log(`\n  status: ${final?.status}  phase: ${final?.phase}  project_id: ${final?.projectId ?? '—'}`);

--- a/apps/web/src/hooks/legacy/use-suna-migration.ts
+++ b/apps/web/src/hooks/legacy/use-suna-migration.ts
@@ -42,12 +42,15 @@ export function useSunaMigration(accountId?: string | null) {
   });
 }
 
+const DEFAULT_LIMIT = 25;
+
 export function useStartSunaMigration(accountId?: string | null) {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: async () =>
+    mutationFn: async (opts?: { limit?: number; offset?: number }) =>
       unwrap(await backendApi.post<{ created: boolean; migration: SunaMigration }>(
-        '/projects/suna-migration/start', { account_id: accountId ?? undefined },
+        '/projects/suna-migration/start',
+        { account_id: accountId ?? undefined, limit: opts?.limit ?? DEFAULT_LIMIT, offset: opts?.offset ?? 0 },
       )),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: KEY });


### PR DESCRIPTION
Migrate the account's projects newest-first in a window (plan.{limit,offset}):
- default = latest 25 (DEFAULT_LIMIT), max 200.
- offset lets a later run grab the next batch (offset 25 → 25–50, …).
- start route + startSunaMigration accept limit/offset; the extract phase reads them off the migration row's plan (carried into the phase context).
- frontend sends limit:25 (offset wired for future "next 25").
- script: --limit / --offset.