### PR TITLE
fix(connectors): stop 500 when creating a connector with private sharing

### DIFF
--- a/apps/api/src/executor/router.ts
+++ b/apps/api/src/executor/router.ts
@@ -338,6 +338,11 @@ export function createExecutorRouter(deps: ExecutorRouterDeps): OpenAPIHono {
       if (!deps.createConnector) return c.json({ error: 'not supported' }, 501);
       let body: any;
       try { body = await c.req.json(); } catch { return c.json({ error: 'invalid_json' }, 400); }
+      if (body?.sharing !== undefined) {
+        const intent = parseSharingIntent(body.sharing, admin.userId);
+        if (!intent) return c.json({ error: 'invalid sharing — mode must be project|private|members' }, 400);
+        body.sharing = intent;
+      }
       const result = await deps.createConnector(projectId, admin.accountId, body);
       return result.ok ? c.json({ ok: true, sync: result.sync }) : c.json({ error: result.error }, result.status as 400);
     },


### PR DESCRIPTION
POST /connectors passed the raw sharing body straight to intentToScope, so a 'private' intent with an empty ownerId produced a grant with an empty principal_id (uuid NOT NULL) and the insert 500'd. Normalize the body through parseSharingIntent with the acting user as fallback owner, matching the PUT .../sharing route.