### PR TITLE
fix(suna-migration): db phase — complete project_git_connections insert + resume failed runs

### DIFF
--- a/apps/api/src/projects/suna-migration/suna-migration-phases.ts
+++ b/apps/api/src/projects/suna-migration/suna-migration-phases.ts
@@ -127,6 +127,7 @@ export async function repoStep(ctx: SunaMigrationContext): Promise<void> {
   await ctx.checkpoint({
     project_id: repo.projectId, repo_url: repo.upstreamUrl, repo_owner: repo.repoOwner,
     repo_name: repo.repoName, default_branch: repo.defaultBranch, provider: repo.provider,
+    external_repo_id: repo.externalRepoId, installation_id: repo.installationId, credential_ref: repo.credentialRef,
   });
   ctx.log('repo: pushed + opencode archive uploaded', { repo: repo.upstreamUrl });
 }
@@ -160,7 +161,14 @@ export async function dbStep(ctx: SunaMigrationContext): Promise<void> {
     await tx.insert(projectGitConnections).values({
       accountId: ctx.accountId, projectId, provider, repoUrl, upstreamUrl: repoUrl, managed: true,
       repoOwner: ctx.progress.repo_owner as string, repoName: ctx.progress.repo_name as string,
-    }).onConflictDoNothing();
+      externalRepoId: (ctx.progress.external_repo_id as string) ?? null,
+      defaultBranch,
+      authMethod: provider === 'github' ? 'github_app' : 'managed',
+      installationId: (ctx.progress.installation_id as string) ?? null,
+      credentialRef: (ctx.progress.credential_ref as string) ?? null,
+      visibility: 'private',
+      status: 'connected',
+    } as any).onConflictDoNothing({ target: projectGitConnections.projectId });
 
     for (const s of specs) {
       await tx.insert(projectSessions).values({

--- a/apps/api/src/projects/suna-migration/suna-migration-runner.ts
+++ b/apps/api/src/projects/suna-migration/suna-migration-runner.ts
@@ -123,6 +123,21 @@ export async function startSunaMigration(input: { database: Database; accountId:
   const existing = await findActiveSunaMigration(database, accountId);
   if (existing) return { migration: existing, created: false };
 
+  // Resume a dead-lettered (failed) migration in place rather than starting a
+  // fresh one — keeps the already-created repo + extracted progress, re-driving
+  // from its last phase.
+  const last = await latestSunaMigration(database, accountId);
+  if (last && last.status === 'failed') {
+    await database.update(sunaAccountMigrations)
+      .set({ status: 'running', attempts: 0, error: null, heartbeatAt: null, updatedAt: new Date() })
+      .where(eq(sunaAccountMigrations.migrationId, last.migrationId));
+    if (input.autoDrive !== false) {
+      void driveSunaMigration(database, last.migrationId).catch((err) =>
+        appLogger.error('[suna-migration] resume drive failed', { migrationId: last.migrationId, error: err instanceof Error ? err.message : String(err) }));
+    }
+    return { migration: { ...last, status: 'running' }, created: false };
+  }
+
   const limit = Number.isFinite(input.limit) && (input.limit as number) > 0 ? Math.min(input.limit as number, 200) : DEFAULT_LIMIT;
   const offset = Number.isFinite(input.offset) && (input.offset as number) >= 0 ? (input.offset as number) : 0;
   const now = new Date();

--- a/apps/api/src/projects/suna-migration/suna-push.ts
+++ b/apps/api/src/projects/suna-migration/suna-push.ts
@@ -29,6 +29,9 @@ export interface PushedRepo {
   repoOwner: string | null;
   repoName: string | null;
   defaultBranch: string;
+  externalRepoId: string | null;
+  installationId: string | null;
+  credentialRef: string | null;
 }
 
 export async function pushBundleAsRepo(accountId: string, bundleDir: string): Promise<PushedRepo> {
@@ -70,5 +73,9 @@ export async function pushBundleAsRepo(accountId: string, bundleDir: string): Pr
   git(['commit', '-m', 'Import Suna legacy projects (chats restored as sessions; files under legacy/)'], bundleDir);
   git(['push', pushUrl, `HEAD:${repo.defaultBranch}`], bundleDir, true);
 
-  return { projectId, provider: repo.provider, upstreamUrl: repo.upstreamUrl, repoOwner: repo.repoOwner, repoName: repo.repoName, defaultBranch: repo.defaultBranch };
+  return {
+    projectId, provider: repo.provider, upstreamUrl: repo.upstreamUrl,
+    repoOwner: repo.repoOwner, repoName: repo.repoName, defaultBranch: repo.defaultBranch,
+    externalRepoId: repo.externalRepoId, installationId: repo.installationId, credentialRef: repo.credentialRef,
+  };
 }


### PR DESCRIPTION
- project_git_connections insert was missing NOT-NULL fields (default_branch, auth_method, visibility, status) → "phase db failed". Now matches the legacy dbStep insert; thread external_repo_id/installation_id/credential_ref through pushBundleAsRepo → repo-phase checkpoint → the insert.
- startSunaMigration RESUMES a dead-lettered (failed) migration in place (re-drives from its last phase, reusing the created repo + extracted progress) instead of starting a fresh run — so the Retry button doesn't orphan a repo.