### PR TITLE
fix(suna-migration): name opencode archive entry opencode.db so rehydrate finds it

### DIFF
--- a/apps/api/src/projects/legacy-migration-rehydrate.ts
+++ b/apps/api/src/projects/legacy-migration-rehydrate.ts
@@ -14,7 +14,7 @@
  * opencode so it serves the original conversations.
  */
 import { Database } from 'bun:sqlite';
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { and, eq, isNotNull } from 'drizzle-orm';
@@ -128,7 +128,14 @@ export async function rehydrateSessionChat(input: RehydrateInput): Promise<void>
     writeFileSync(join(workDir, 'oc.tar.gz'), tarball);
     const untar = Bun.spawnSync(['tar', 'xzf', join(workDir, 'oc.tar.gz'), '-C', workDir]);
     if (untar.exitCode !== 0) throw new Error(`unpack failed: ${new TextDecoder().decode(untar.stderr)}`);
-    const local = new Database(join(workDir, 'opencode.db'));
+    // Legacy archives store the db as `opencode.db`; Suna-migration archives store
+    // it as `<projectId>.opencode.db`. Locate it by suffix rather than a fixed name.
+    const dbName = existsSync(join(workDir, 'opencode.db'))
+      ? 'opencode.db'
+      : readdirSync(workDir).find((f) => f.endsWith('opencode.db'));
+    if (!dbName) throw new Error(`no opencode.db in archive (got: ${readdirSync(workDir).join(', ')})`);
+    const dbPath = join(workDir, dbName);
+    const local = new Database(dbPath);
     try {
       local.exec('PRAGMA foreign_keys=OFF');
       local.prepare('UPDATE project SET id = ?').run(newProjectId);
@@ -137,7 +144,7 @@ export async function rehydrateSessionChat(input: RehydrateInput): Promise<void>
     } finally {
       local.close();
     }
-    dbBuf = readFileSync(join(workDir, 'opencode.db'));
+    dbBuf = readFileSync(dbPath);
   } finally {
     rmSync(workDir, { recursive: true, force: true });
   }

--- a/apps/api/src/projects/suna-migration/suna-migration-phases.ts
+++ b/apps/api/src/projects/suna-migration/suna-migration-phases.ts
@@ -14,7 +14,7 @@
  * and the uploaded opencode archive + the DB rows. A crash before `repo`
  * re-extracts (idempotent: un-archive + tar again).
  */
-import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { copyFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { sql } from 'drizzle-orm';
@@ -105,11 +105,15 @@ export async function repoStep(ctx: SunaMigrationContext): Promise<void> {
   const out = bundlePath(ctx.migrationId);
   const repo = await pushBundleAsRepo(ctx.accountId, out);
 
-  // opencode.db was moved aside by pushBundleAsRepo → tar it in the legacy
-  // archive format and upload keyed by projectId; on-open rehydrate downloads it.
+  // opencode.db was moved aside by pushBundleAsRepo. Tar it with the db named
+  // exactly `opencode.db` (same convention legacy archives use, which is what
+  // rehydrateSessionChat opens) and upload keyed by projectId for on-open ship.
   const dbAside = join(tmpdir(), `${repo.projectId}.opencode.db`);
-  const tar = Bun.spawnSync(['tar', 'czf', '-', '-C', tmpdir(), `${repo.projectId}.opencode.db`]);
+  const stageDir = mkdtempSync(join(tmpdir(), `suna-oc-${repo.projectId}-`));
+  copyFileSync(dbAside, join(stageDir, 'opencode.db'));
+  const tar = Bun.spawnSync(['tar', 'czf', '-', '-C', stageDir, 'opencode.db']);
   if (tar.exitCode === 0) await uploadOpencodeArchive(repo.projectId, Buffer.from(tar.stdout));
+  rmSync(stageDir, { recursive: true, force: true });
   rmSync(dbAside, { force: true });
 
   await ctx.checkpoint({


### PR DESCRIPTION
The Suna repo phase tarred the chat db as <projectId>.opencode.db, but rehydrateSessionChat opens a file literally named opencode.db (the convention legacy/machine-migration archives use). So the on-open ship opened a missing name → empty db → 'no such table: project' → it threw before shipping → opencode served an empty store → migrated chats never loaded.

- suna-migration-phases: tar the db as opencode.db (matches the rehydrate contract)
- legacy-migration-rehydrate: locate the db by suffix as a backward-compatible safety net (opencode.db-first, so machine migrations are byte-for-byte unchanged; the fallback only fires for already-uploaded mis-named Suna archives)

Verified live: re-running rehydrate restored all 25 sessions (db 4096 → 4.4MB).