### PR TITLE
fix(web): accept relative BACKEND_URL in sandbox preview / resolve absolute server-side

### DIFF
--- a/apps/web/src/lib/env-schema.ts
+++ b/apps/web/src/lib/env-schema.ts
@@ -1,9 +1,34 @@
 import { z } from 'zod'
 
+/**
+ * BACKEND_URL may be EITHER:
+ *  - an absolute http(s) URL (e.g. "http://localhost:8008/v1") — used server-side
+ *    where `new URL(...)` needs an absolute base, and in normal deployments; or
+ *  - a root-relative path (e.g. "/v1") — used in the sandbox preview so the
+ *    BROWSER hits the SAME origin it's served from and the preview proxy rewrites
+ *    it to the in-sandbox API (single-origin proxy, no CORS, no exposed port).
+ * Server-side callers that build a URL must resolve the absolute
+ * `process.env.BACKEND_URL` rather than this (possibly relative) public value.
+ */
+const backendUrlSchema = z
+  .string()
+  .refine(
+    (value) => {
+      if (value.startsWith('/')) return true // root-relative (same-origin proxy)
+      try {
+        const parsed = new URL(value)
+        return parsed.protocol === 'http:' || parsed.protocol === 'https:'
+      } catch {
+        return false
+      }
+    },
+    'BACKEND_URL must be an absolute http(s) URL or a root-relative path (e.g. "/v1")',
+  )
+
 const RuntimeEnvSchema = z.object({
   SUPABASE_URL: z.string().url('SUPABASE_URL must be a valid URL'),
   SUPABASE_ANON_KEY: z.string().min(1, 'SUPABASE_ANON_KEY is required'),
-  BACKEND_URL: z.string().url('BACKEND_URL must be a valid URL'),
+  BACKEND_URL: backendUrlSchema,
   /** Whether billing/paywall UI is enabled. Mirrors the backend's
    *  KORTIX_BILLING_INTERNAL_ENABLED. Set via NEXT_PUBLIC_BILLING_ENABLED. */
   BILLING_ENABLED: z.boolean().default(false),

--- a/apps/web/src/lib/opencode-sdk.ts
+++ b/apps/web/src/lib/opencode-sdk.ts
@@ -21,6 +21,26 @@ let cachedClient: OpencodeClient | null = null;
 let cachedUrl: string | null = null;
 
 /**
+ * Resolve the backend base URL as an ABSOLUTE URL.
+ *
+ * `getEnv().BACKEND_URL` may be root-relative (e.g. "/v1") in the sandbox
+ * preview, where the browser deliberately hits the same origin. Server-side
+ * (SSR), prefer the absolute `process.env.BACKEND_URL` so `new URL(...)` has a
+ * valid base; in the browser, fall back to resolving the relative value against
+ * the current origin. Mirrors the pattern in platform-client.ts.
+ */
+function getAbsoluteBackendUrl(): string {
+	if (typeof process !== "undefined" && process.env?.BACKEND_URL) {
+		return process.env.BACKEND_URL;
+	}
+	const value = getEnv().BACKEND_URL;
+	if (value.startsWith("/") && typeof window !== "undefined") {
+		return new URL(value, window.location.origin).toString();
+	}
+	return value;
+}
+
+/**
  * Per-URL client cache. Unlike `getClient()` (which tracks only the single
  * active server), this keeps one client alive PER sandbox URL so we can talk to
  * several session sandboxes in parallel — every open session stays connected to
@@ -31,7 +51,7 @@ const clientsByUrl = new Map<string, OpencodeClient>();
 function shouldUsePlatformAuth(baseUrl: string): boolean {
 	try {
 		const target = new URL(baseUrl);
-		const backend = new URL(getEnv().BACKEND_URL);
+		const backend = new URL(getAbsoluteBackendUrl());
 		const backendPath = backend.pathname.replace(/\/+$/, "");
 		return target.origin === backend.origin &&
 			(target.pathname === backendPath || target.pathname.startsWith(`${backendPath}/`));

--- a/scripts/dev-local.sh
+++ b/scripts/dev-local.sh
@@ -391,6 +391,18 @@ NEXT_PUBLIC_KORTIX_PERSONAL_CONTACT=false
 EDGE_CONFIG=
 EOF
 
+  # Export the web env into THIS process so the production frontend build + start
+  # see them. `next build` / `next start` (unlike the `dev` script) do NOT run
+  # dotenvx, and Next does not reliably auto-load apps/web/.env.local for the
+  # standalone/production server — so without exporting, `next start` boots with
+  # NO BACKEND_URL / Supabase vars and every SSR request 500s on the runtime-env
+  # Zod parse. Exporting makes NEXT_PUBLIC_* inline at BUILD time and puts the
+  # server-only vars (BACKEND_URL, …) in process.env for `next start`'s SSR.
+  set -a
+  # shellcheck disable=SC1091
+  source "$ROOT_DIR/apps/web/.env.local"
+  set +a
+
   kill_dev_ports 3000 8008 "${PORT:-8008}"
 
   # A freshly-cloned session has no node_modules — install first. (Warm volumes


### PR DESCRIPTION
## The bug

In a session sandbox, `pnpm preview` served web on **:3000** but every request **500'd** with a ZodError `BACKEND_URL must be a valid URL`.

## Root cause (two compounding issues)

**1. The preview frontend ran with no env at all.**
`scripts/dev-local.sh` `run_sandbox_dev()` writes `apps/web/.env.local` (with `NEXT_PUBLIC_BACKEND_URL=/v1` + `BACKEND_URL=http://localhost:8008/v1`) but never exported those vars. Unlike the `dev` script, `next build` / `next start` do **not** run dotenvx, and Next does not reliably auto-load `.env.local` for the production/standalone server — so `next start` booted with **no** `BACKEND_URL` / Supabase vars and every SSR runtime-env parse failed. The `BUILD_MODE` block that *does* export env is never reached on the sandbox path (`run_sandbox_dev` exits first).

**2. The schema rejected the intentional relative value.**
The browser legitimately needs the **relative** `/v1` (same-origin preview proxy — single origin, no CORS, no exposed port), but `env-schema.ts` validated `BACKEND_URL` with `z.string().url()`, which rejects `/v1`.

## Fix

- **`scripts/dev-local.sh`** — `set -a; source apps/web/.env.local; set +a` before the frontend build + start, so `NEXT_PUBLIC_*` inline at build time and the server-only vars (`BACKEND_URL`, Supabase) land in `process.env` for `next start`'s SSR. No longer depends on `.env.local` auto-loading under standalone output.
- **`apps/web/src/lib/env-schema.ts`** — `BACKEND_URL` now accepts **either** an absolute http(s) URL **or** a root-relative path (`/...`).
- **`apps/web/src/lib/opencode-sdk.ts`** — the `new URL(...)` caller now resolves the absolute `process.env.BACKEND_URL` server-side (mirrors the existing pattern in `platform-client.ts`); in the browser it resolves a relative value against `window.location.origin`. The serialized **browser** runtime-config value stays `/v1` so same-origin proxying still works.

No prod behavior change: absolute URLs validate exactly as before, and server-side URL builders still get an absolute base.

## Verification (`pnpm preview` in a sandbox)

| endpoint | code |
|---|---|
| web `http://localhost:3000/` | **200** |
| web `http://localhost:3000/auth` (SSR-heavy) | **200** |
| api `http://localhost:8008/v1/health` | **200** |
| api `http://localhost:8008/health` | **200** |

- Page renders the real `<title>Kortix …</title>` (not an error page).
- Serialized browser runtime config keeps `"BACKEND_URL":"/v1"` (intended same-origin proxy value).
- **No** `ZodError`, no `BACKEND_URL must be …`, no URL-parse errors in the preview logs.
