### PR TITLE
feat(dev): run web via next dev for in-sandbox `pnpm dev` (hot reload)

### DIFF
--- a/scripts/dev-local.sh
+++ b/scripts/dev-local.sh
@@ -391,13 +391,18 @@ NEXT_PUBLIC_KORTIX_PERSONAL_CONTACT=false
 EDGE_CONFIG=
 EOF
 
-  # Export the web env into THIS process so the production frontend build + start
-  # see them. `next build` / `next start` (unlike the `dev` script) do NOT run
-  # dotenvx, and Next does not reliably auto-load apps/web/.env.local for the
-  # standalone/production server — so without exporting, `next start` boots with
-  # NO BACKEND_URL / Supabase vars and every SSR request 500s on the runtime-env
-  # Zod parse. Exporting makes NEXT_PUBLIC_* inline at BUILD time and puts the
-  # server-only vars (BACKEND_URL, …) in process.env for `next start`'s SSR.
+  # Export the SANDBOX-generated web env into THIS process so both the
+  # production (build + start) and the dev (`next dev`) paths see the right
+  # values: relative NEXT_PUBLIC_BACKEND_URL=/v1 and the in-sandbox Supabase
+  # trio. For build+start, `next build` / `next start` (unlike the web's `dev`
+  # npm script) do NOT run dotenvx, and Next does not reliably auto-load
+  # apps/web/.env.local for the standalone/production server — so without
+  # exporting, `next start` boots with NO BACKEND_URL / Supabase vars and every
+  # SSR request 500s on the runtime-env Zod parse. Exporting makes NEXT_PUBLIC_*
+  # inline at BUILD time and puts the server-only vars (BACKEND_URL, …) in
+  # process.env for SSR. For the dev path we invoke `next dev` DIRECTLY (not the
+  # web's `dev` script, which wraps `dotenvx run -f .env` and would inject the
+  # committed laptop `localhost` values), so it relies on this same export.
   set -a
   # shellcheck disable=SC1091
   source "$ROOT_DIR/apps/web/.env.local"
@@ -412,13 +417,25 @@ EOF
     (cd "$ROOT_DIR" && pnpm install) || echo "[dev] ⚠️  pnpm install reported issues — continuing"
   fi
 
-  echo "[dev] Building frontend (pnpm build)…"
-  if pnpm --filter Kortix-Computer-Frontend build; then
-    echo "[dev] Frontend built — serving (pnpm start) on :3000"
-    pnpm --filter Kortix-Computer-Frontend start &
-    FRONTEND_PID=$!
+  if [[ "$BUILD_MODE" == "1" ]]; then
+    # `pnpm preview` → production parity: full build then `next start`.
+    echo "[dev] Building frontend (pnpm build)…"
+    if pnpm --filter Kortix-Computer-Frontend build; then
+      echo "[dev] Frontend built — serving (pnpm start) on :3000"
+      pnpm --filter Kortix-Computer-Frontend start &
+      FRONTEND_PID=$!
+    else
+      echo "[dev] ⚠️  Frontend build failed — continuing with API only"
+    fi
   else
-    echo "[dev] ⚠️  Frontend build failed — continuing with API only"
+    # `pnpm dev` → fast hot-reload via `next dev`. No heavy `next build`.
+    # Invoke next DIRECTLY (not the web's `dev` npm script, which wraps
+    # `dotenvx run -f .env` and would inject committed laptop `localhost`
+    # values); the sandbox `.env.local` is already exported above (relative
+    # NEXT_PUBLIC_BACKEND_URL=/v1, in-sandbox Supabase).
+    echo "[dev] Starting frontend (next dev, hot reload) on :${WEB_PORT:-3000}"
+    (cd "$ROOT_DIR/apps/web" && pnpm exec next dev --turbopack --port "${WEB_PORT:-3000}") &
+    FRONTEND_PID=$!
   fi
 
   echo "[dev] Starting API (dev) on :8008"


### PR DESCRIPTION
## What

In a Kortix sandbox, `run_sandbox_dev()` in `scripts/dev-local.sh` **always** did `next build` + `next start` for the web app, ignoring `BUILD_MODE`. So `pnpm dev` paid a multi-minute production build with **no hot reload**, identical to `pnpm preview`.

This makes the sandbox honor `BUILD_MODE` for the web, matching the laptop path:

- **`pnpm preview`** (`BUILD_MODE=1`) → unchanged: `pnpm --filter Kortix-Computer-Frontend build` + `start` (production parity).
- **`pnpm dev`** (`BUILD_MODE` unset) → fast hot-reload **`next dev --turbopack`** on `${WEB_PORT:-3000}`. No heavy `next build`.

## Why direct `next dev` (not the web's `dev` npm script)

The web's `dev` script wraps `dotenvx run -f .env`, which would inject the **committed, encrypted laptop `.env`** values (`localhost` BACKEND_URL etc.) — wrong for a sandbox. Instead the dev path runs next **directly** (`cd apps/web && pnpm exec next dev`) and relies on the already-exported **sandbox-generated `apps/web/.env.local`** (relative `NEXT_PUBLIC_BACKEND_URL=/v1`, in-sandbox Supabase). The env-export comment is updated to document that both paths depend on it. The API path is unchanged.

## Verification (run in-sandbox via `pnpm dev`)

Log confirmed the new branch: `[dev] Starting frontend (next dev, hot reload) on :3000` — **no** `next build` / "Creating an optimized production build". Next reported `Next.js 15.5.18 (Turbopack)`, `Ready in 4.3s`, and **on-demand** `Compiling / ...` then `Compiled / in 17.7s` on first request (dev-server behavior; a prod `next start` would not compile per-request).

HTTP codes:

| Endpoint | Code |
|---|---|
| web `GET /` | **200** |
| web `GET /auth` | **200** |
| web `GET /dashboard` | **307** (auth redirect, unauthenticated) |
| web `GET /v1/health` (via Next rewrite to in-sandbox API) | **200** |
| api `GET /health` | **200** (`{"status":"ok","service":"kortix-api",...}`) |

(`api GET /` is `404` — root isn't a registered route; the server is healthy via `/health`, same as under `pnpm preview`.)

Stability over a ~3.5 min soak (~300 requests across `/`, `/auth`, `/dashboard`, `/v1/health`):
- **Zero** non-2xx/3xx responses.
- **No** `ZodError` / `BACKEND_URL` env-parse error.
- **No OOM**: cgroup `memory.events` `oom_kill 0`, `oom 0`. Real working set (cgroup `anon`) **~8.2 GiB** against the **12 GiB** cgroup limit (~3.8 GiB headroom). `next dev` server RSS ~6.8 GB.

`pnpm preview`'s build+start path is left intact (code-path verified; `preview` still hits the `BUILD_MODE=1` branch).