### PR TITLE
fix(web): same-origin /supabase proxy so browser auth works in sandbox preview

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -176,6 +176,22 @@ const nextConfig = (): NextConfig => ({
         source: '/v1/:path*',
         destination: `${process.env.KORTIX_API_PROXY_TARGET ?? 'http://localhost:8008'}/v1/:path*`,
       },
+      // Same-origin Supabase proxy for the sandbox preview. ENV-GATED: only
+      // active when KORTIX_SUPABASE_PROXY_TARGET is set (scripts/dev-local.sh
+      // run_sandbox_dev), so prod/normal deployments are untouched. The browser
+      // is served SUPABASE_URL=/supabase (same origin it loaded from, reachable
+      // through whatever preview proxy), and this rewrite forwards it to the
+      // in-sandbox Supabase (e.g. http://127.0.0.1:54321) which the browser
+      // cannot reach directly. Covers auth (/supabase/auth/v1/*) and rest
+      // (/supabase/rest/v1/*) and storage paths. Mirrors the /v1 API proxy.
+      ...(process.env.KORTIX_SUPABASE_PROXY_TARGET
+        ? [
+            {
+              source: '/supabase/:path*',
+              destination: `${process.env.KORTIX_SUPABASE_PROXY_TARGET}/:path*`,
+            },
+          ]
+        : []),
       {
         source: '/ingest/static/:path*',
         destination: 'https://eu-assets.i.posthog.com/static/:path*',

--- a/apps/web/src/lib/env-config.ts
+++ b/apps/web/src/lib/env-config.ts
@@ -18,8 +18,15 @@ function readRawEnv(): Partial<RuntimeEnv> {
     }
   }
 
+  // SERVER branch (the browser returns from the window.__*_CONFIG block above):
+  // prefer the ABSOLUTE `SUPABASE_URL` over the public values, which may be
+  // root-relative (e.g. "/supabase") in the sandbox preview. Server-side the
+  // runtime reaches Supabase directly and needs an absolute base; the relative
+  // value is only correct for the BROWSER (same-origin proxy). Mirrors how the
+  // server-side Supabase clients (supabase/server.ts, middleware.ts) prefer the
+  // absolute process.env.SUPABASE_URL.
   return {
-    SUPABASE_URL: process.env.KORTIX_PUBLIC_SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_PUBLIC_URL || process.env.SUPABASE_URL,
+    SUPABASE_URL: process.env.SUPABASE_URL || process.env.SUPABASE_PUBLIC_URL || process.env.KORTIX_PUBLIC_SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
     SUPABASE_ANON_KEY: process.env.KORTIX_PUBLIC_SUPABASE_ANON_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || process.env.SUPABASE_ANON_KEY,
     BACKEND_URL: process.env.KORTIX_PUBLIC_BACKEND_URL || process.env.NEXT_PUBLIC_BACKEND_URL || process.env.BACKEND_URL,
     BILLING_ENABLED: (process.env.KORTIX_PUBLIC_BILLING_ENABLED || process.env.NEXT_PUBLIC_BILLING_ENABLED) === 'true',

--- a/apps/web/src/lib/env-schema.ts
+++ b/apps/web/src/lib/env-schema.ts
@@ -25,8 +25,34 @@ const backendUrlSchema = z
     'BACKEND_URL must be an absolute http(s) URL or a root-relative path (e.g. "/v1")',
   )
 
+/**
+ * SUPABASE_URL may be EITHER:
+ *  - an absolute http(s) URL (e.g. "http://127.0.0.1:54321") — used server-side
+ *    where the runtime reaches Supabase directly, and in normal deployments; or
+ *  - a root-relative path (e.g. "/supabase") — used in the sandbox preview so the
+ *    BROWSER hits the SAME origin it's served from and the preview proxy rewrites
+ *    it to the in-sandbox Supabase (single-origin proxy, no CORS, no exposed
+ *    port). The browser client resolves the relative value against
+ *    `window.location.origin` before handing it to supabase-js (which requires an
+ *    absolute URL). Mirrors BACKEND_URL above.
+ */
+const supabaseUrlSchema = z
+  .string()
+  .refine(
+    (value) => {
+      if (value.startsWith('/')) return true // root-relative (same-origin proxy)
+      try {
+        const parsed = new URL(value)
+        return parsed.protocol === 'http:' || parsed.protocol === 'https:'
+      } catch {
+        return false
+      }
+    },
+    'SUPABASE_URL must be an absolute http(s) URL or a root-relative path (e.g. "/supabase")',
+  )
+
 const RuntimeEnvSchema = z.object({
-  SUPABASE_URL: z.string().url('SUPABASE_URL must be a valid URL'),
+  SUPABASE_URL: supabaseUrlSchema,
   SUPABASE_ANON_KEY: z.string().min(1, 'SUPABASE_ANON_KEY is required'),
   BACKEND_URL: backendUrlSchema,
   /** Whether billing/paywall UI is enabled. Mirrors the backend's

--- a/apps/web/src/lib/supabase/client.ts
+++ b/apps/web/src/lib/supabase/client.ts
@@ -2,9 +2,26 @@ import { createBrowserClient } from '@supabase/ssr'
 import { KORTIX_SUPABASE_AUTH_COOKIE } from './constants'
 import { getEnv } from '@/lib/env-config'
 
+/**
+ * Resolve the browser-facing Supabase URL as an ABSOLUTE URL.
+ *
+ * `getEnv().SUPABASE_URL` may be root-relative (e.g. "/supabase") in the sandbox
+ * preview, where the browser deliberately hits the same origin it was served
+ * from and the preview proxy (next.config.ts: /supabase/* -> in-sandbox
+ * Supabase) forwards the request. supabase-js requires an ABSOLUTE URL, so
+ * resolve the relative value against the current origin. Mirrors
+ * getAbsoluteBackendUrl() in opencode-sdk.ts.
+ */
+function resolveBrowserSupabaseUrl(url: string): string {
+  if (url.startsWith('/') && typeof window !== 'undefined') {
+    return new URL(url, window.location.origin).toString().replace(/\/$/, '')
+  }
+  return url
+}
+
 export function createClient() {
   const runtimeEnv = getEnv()
-  const url = runtimeEnv.SUPABASE_URL
+  const url = resolveBrowserSupabaseUrl(runtimeEnv.SUPABASE_URL)
   const key = runtimeEnv.SUPABASE_ANON_KEY
 
   if (!url || !key) {

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -68,6 +68,7 @@ export async function middleware(request: NextRequest) {
     pathname.startsWith('/_next') ||
     pathname.startsWith('/favicon') ||
     pathname.startsWith('/v1/') ||
+    pathname.startsWith('/supabase/') || // same-origin Supabase proxy (sandbox preview) — must reach the next.config rewrite, never the auth-gate
     pathname.includes('.') ||
     pathname.startsWith('/api/') ||
     pathname.startsWith('/monitoring') ||    // Sentry error tracking tunnel (Better Stack)

--- a/scripts/dev-local.sh
+++ b/scripts/dev-local.sh
@@ -379,9 +379,19 @@ EOF
   # server-side (SSR) fetches, which talk to the in-sandbox API directly.
   # Write to apps/web/.env.LOCAL (gitignored), never apps/web/.env — that file is
   # dotenvx-encrypted + tracked, and Next loads .env.local at higher precedence.
+  # NEXT_PUBLIC_SUPABASE_URL is RELATIVE (/supabase) for the SAME reason as
+  # NEXT_PUBLIC_BACKEND_URL above: the browser loads the app through the preview
+  # proxy (a dynamic origin like p3000-<sandbox>.localhost:8008) and 127.0.0.1:54321
+  # is the sandbox loopback — unreachable from the user's browser. So the browser
+  # hits the SAME origin (/supabase) and next.config.ts's env-gated rewrite
+  # (/supabase/* -> ${SB_API_URL}/*, active via KORTIX_SUPABASE_PROXY_TARGET below)
+  # proxies it to the in-sandbox Supabase. SUPABASE_URL stays ABSOLUTE so the
+  # server-side Supabase clients (supabase/server.ts, middleware.ts) reach
+  # 127.0.0.1:54321 directly. Mirrors the /v1 BACKEND_URL split.
   cat > "$ROOT_DIR/apps/web/.env.local" <<EOF
 NEXT_PUBLIC_BILLING_ENABLED=false
-NEXT_PUBLIC_SUPABASE_URL=${SB_API_URL}
+NEXT_PUBLIC_SUPABASE_URL=/supabase
+SUPABASE_URL=${SB_API_URL}
 NEXT_PUBLIC_SUPABASE_ANON_KEY=${SB_ANON_KEY}
 NEXT_PUBLIC_BACKEND_URL=/v1
 BACKEND_URL=http://localhost:8008/v1
@@ -390,6 +400,12 @@ NEXT_PUBLIC_URL=http://localhost:3000
 NEXT_PUBLIC_KORTIX_PERSONAL_CONTACT=false
 EDGE_CONFIG=
 EOF
+
+  # Activate the same-origin Supabase proxy rewrite (next.config.ts). Env-gated
+  # so it ONLY exists in the sandbox: forwards the browser's same-origin
+  # /supabase/* to the in-sandbox Supabase. Exported (not just in .env.local) so
+  # both `next dev` and `next build`/`next start` see it.
+  export KORTIX_SUPABASE_PROXY_TARGET="${SB_API_URL}"
 
   # Export the SANDBOX-generated web env into THIS process so both the
   # production (build + start) and the dev (`next dev`) paths see the right


### PR DESCRIPTION
## The bug
In a session sandbox the browser loads the web app through the preview proxy (a dynamic origin like `p3000-<sandbox>.localhost:8008`), but `apps/web/src/lib/supabase/client.ts` created the browser client with `getEnv().SUPABASE_URL = http://127.0.0.1:54321` — the sandbox loopback, **unreachable from the user's browser**. So web login/auth calls failed. (Server-side Supabase was fine: the API reaches `127.0.0.1:54321` directly.)

This is the **same fix as the merged BACKEND_URL one (#3344)**, applied to `SUPABASE_URL` — mirroring that pattern exactly.

## Changes
1. **`apps/web/next.config.ts`** `rewrites()`: ENV-GATED Supabase proxy, active only when `KORTIX_SUPABASE_PROXY_TARGET` is set (prod untouched): `/supabase/:path*` → `${KORTIX_SUPABASE_PROXY_TARGET}/:path*` (covers auth + rest + storage). Mirrors the `/v1` API proxy.
2. **`apps/web/src/lib/env-schema.ts`**: `SUPABASE_URL` accepts an absolute http(s) URL **OR** a root-relative path (`/...`), same as `BACKEND_URL`.
3. **`apps/web/src/lib/supabase/client.ts`** (browser): if `SUPABASE_URL` is root-relative, resolve it to `window.location.origin + url` before `createBrowserClient`. Mirrors `getAbsoluteBackendUrl()` in `opencode-sdk.ts`.
4. **Server keeps the ABSOLUTE Supabase URL** (`127.0.0.1:54321`): `env-config.ts` `readRawEnv` server branch prefers `process.env.SUPABASE_URL`; `supabase/server.ts` + `middleware.ts` already did. `middleware.ts` also skips `/supabase/*` (like `/v1/*`) so the proxy reaches the rewrite, never the auth-gate.
5. **`scripts/dev-local.sh`** `run_sandbox_dev`: `.env.local` sets `NEXT_PUBLIC_SUPABASE_URL=/supabase` (browser) + absolute `SUPABASE_URL=${SB_API_URL}` (server), exports `KORTIX_SUPABASE_PROXY_TARGET=${SB_API_URL}`, keeps `NEXT_PUBLIC_SUPABASE_ANON_KEY=${SB_ANON_KEY}`.

## Verification (`pnpm dev` in a sandbox)
```
GET  /supabase/auth/v1/health   -> 200   (browser-path proxy reaches Supabase auth; NOT connection-refused)
POST /supabase/auth/v1/signup   -> 200   real Supabase auth JSON: access_token + refresh_token + created user
                                         (JWT iss = http://127.0.0.1:54321/auth/v1)
web  /                          -> 200   (no regression)
api  /v1/health                 -> 200   (no regression)
/supabase/rest/v1/              -> 404   (reaches PostgREST, not connection-refused)
browser runtime-config          -> SUPABASE_URL="/supabase", BACKEND_URL="/v1"
```
Signup body (truncated): `{"access_token":"eyJhbGciOiJFUzI1Ni...","token_type":"bearer","expires_in":3600,"refresh_token":"t3bhe3csju3k","user":{"id":"000520e0-c8d2-4558-a22b-48caa4a2386e","aud":"authenticated","role":"authenticated","email":"t@example.com",...}}`

## Follow-up
Supabase **realtime over WebSocket** is not covered by this HTTP rewrite. Web **login only needs HTTP auth**, which works end-to-end with this change.
