### PR TITLE
feat(web): add a 'hey it works' page

### DIFF
--- a/apps/web/src/app/hey-it-works/page.tsx
+++ b/apps/web/src/app/hey-it-works/page.tsx
@@ -1,0 +1,28 @@
+import { CheckCircle2 } from 'lucide-react';
+
+export const metadata = {
+  title: 'Hey, it works!',
+};
+
+export default function HeyItWorksPage() {
+  return (
+    <div className="min-h-screen bg-background flex items-center justify-center p-6">
+      <div className="max-w-lg w-full text-center space-y-6">
+        {/* Icon */}
+        <div className="mx-auto flex h-20 w-20 items-center justify-center rounded-2xl bg-emerald-500/10 border border-emerald-500/20">
+          <CheckCircle2 className="h-10 w-10 text-emerald-500" />
+        </div>
+
+        {/* Title */}
+        <div className="space-y-2">
+          <h1 className="text-2xl font-semibold tracking-tight text-foreground">
+            Hey, it works!
+          </h1>
+          <p className="text-sm text-muted-foreground leading-relaxed max-w-md mx-auto">
+            If you can see this page, the web app is up and serving routes correctly.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## What

Adds a small `/hey-it-works` page to the web app — a minimal, health-check style page that renders a green checkmark + "Hey, it works!" when the web app is up and serving routes.

## Why

Handy as a quick smoke-test endpoint to confirm the web app is alive and routing correctly, without depending on auth or data.

## Notes

- Single self-contained server component at `apps/web/src/app/hey-it-works/page.tsx`.
- Follows existing layout conventions (mirrors `maintenance/page.tsx`); only uses `lucide-react`, already a project dependency.
- No new deps, no config changes.

## Verification

- `tsc --noEmit` over `apps/web`: identical error count (all pre-existing) with and without this change — 0 new errors introduced.
