### PR TITLE
feat(api): static-token auth for webhook triggers (unblock non-HMAC sources)

### DIFF
--- a/apps/api/src/__tests__/e2e-project-triggers.test.ts
+++ b/apps/api/src/__tests__/e2e-project-triggers.test.ts
@@ -742,4 +742,42 @@ describe('git-backed triggers — runtime fire paths', () => {
     expect(sandboxProvisionCalls).toBe(1);
     expect(lastProvisionEnv?.KORTIX_INITIAL_PROMPT).toBe('New opened');
   });
+
+  test('webhook accepts a valid static token (no HMAC) and rejects a wrong one', async () => {
+    seedManifest(webhookEntry({
+      slug: 'hook',
+      name: 'Hook',
+      secretEnv: 'HOOK_SECRET',
+      prompt: 'New {{ body.action }}',
+    }));
+    secretValues.set('HOOK_SECRET', 'shhh');
+    const app = createApp();
+    const rawBody = JSON.stringify({ action: 'opened' });
+
+    // Wrong token → 401, no provision.
+    const wrong = await app.request(`/v1/webhooks/projects/${PROJECT_ID}/hook`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-Kortix-Token': 'nope' },
+      body: rawBody,
+    });
+    expect(wrong.status).toBe(401);
+    expect(sandboxProvisionCalls).toBe(0);
+
+    // Correct X-Kortix-Token (no signature header) → fires.
+    const viaHeader = await app.request(`/v1/webhooks/projects/${PROJECT_ID}/hook`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-Kortix-Token': 'shhh' },
+      body: rawBody,
+    });
+    expect(viaHeader.status).toBe(202);
+    expect((await viaHeader.json()).status).toBe('fired');
+
+    // Same secret via Authorization: Bearer also works.
+    const viaBearer = await app.request(`/v1/webhooks/projects/${PROJECT_ID}/hook`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer shhh' },
+      body: rawBody,
+    });
+    expect(viaBearer.status).toBe(202);
+  });
 });

--- a/apps/api/src/projects/lib/triggers.ts
+++ b/apps/api/src/projects/lib/triggers.ts
@@ -33,6 +33,45 @@ export function verifyWebhookSignature(rawBody: string, secret: string, signatur
   return timingSafeEqual(actualBuffer, expectedBuffer);
 }
 
+// Pull a static shared-secret token from a webhook request's headers, for
+// sources that can't HMAC-sign the body (e.g. Better Stack error webhooks, which
+// only allow custom headers / basic auth). Order: X-Kortix-Token, then
+// Authorization (Bearer <token> or Basic <base64(user:token)> → password).
+export function extractWebhookToken(
+  kortixToken: string | null | undefined,
+  authorization: string | null | undefined,
+): string | null {
+  if (kortixToken && kortixToken.trim()) return kortixToken.trim();
+  if (authorization && authorization.trim()) {
+    const trimmed = authorization.trim();
+    const sep = trimmed.indexOf(' ');
+    const scheme = (sep === -1 ? trimmed : trimmed.slice(0, sep)).toLowerCase();
+    const value = sep === -1 ? '' : trimmed.slice(sep + 1).trim();
+    if (scheme === 'bearer' && value) return value;
+    if (scheme === 'basic' && value) {
+      try {
+        const decoded = Buffer.from(value, 'base64').toString('utf8');
+        const colon = decoded.indexOf(':');
+        const password = colon >= 0 ? decoded.slice(colon + 1) : decoded;
+        return password || null;
+      } catch {
+        return null;
+      }
+    }
+  }
+  return null;
+}
+
+// Static-token fallback auth (only consulted when no HMAC signature header is
+// present). The token must equal the trigger's secret; constant-time compared.
+export function verifyWebhookToken(token: string | null, secret: string): boolean {
+  if (!token) return false;
+  const actual = Buffer.from(token);
+  const expected = Buffer.from(secret);
+  if (actual.length !== expected.length) return false;
+  return timingSafeEqual(actual, expected);
+}
+
 
 export function parseWebhookJsonBody(rawBody: string): unknown {
   if (!rawBody.trim()) return {};

--- a/apps/api/src/projects/routes/r1.ts
+++ b/apps/api/src/projects/routes/r1.ts
@@ -19,7 +19,7 @@ import { enforceProjectQuota, grantProjectRole, loadProjectForUser, resolveProje
 import { AnyObject, ProjectSchema, projectWebhooksApp, projectsApp } from '../lib/app';
 import { GitHubInstallationRequiredError, buildConnectionRef, consumeGitHubInstallationState, createGitHubInstallationInstallUrl, getAccountGitHubInstallation, getProjectGitConnection, getProjectGitRemote, listAccountGitHubInstallations, registerGitHubLinkedProject, resolveGitHubImport, resolveProjectGitAuth, resolveProjectUpstream, upsertProjectGitConnection, withProjectGitAuth } from '../lib/git';
 import { UUID_V4_REGEX, deriveProjectName, normalizeRepoUrl, normalizeString, readBody, requestAuditContext, serializeGitHubInstallation, serializeGitHubInstallations, serializeGitHubRepo, serializeProject } from '../lib/serializers';
-import { fireGitTrigger, markGitTriggerFired, renderPromptTemplate, verifyWebhookSignature, webhookPayload } from '../lib/triggers';
+import { extractWebhookToken, fireGitTrigger, markGitTriggerFired, renderPromptTemplate, verifyWebhookSignature, verifyWebhookToken, webhookPayload } from '../lib/triggers';
 
 projectsApp.use('/*', supabaseAuth);
 
@@ -56,9 +56,21 @@ projectWebhooksApp.post('/projects/:projectId/:slug', async (c) => {
     return c.json({ error: 'Webhook secret is not configured' }, 409);
   }
 
+  // Primary auth: HMAC-SHA256 signature over the raw body (GitHub-compatible).
+  // Fallback, ONLY when no signature header is present: a static shared token in
+  // X-Kortix-Token or Authorization, for sources that can't HMAC-sign their body
+  // (e.g. Better Stack error webhooks — custom headers / basic auth only). Both
+  // paths require knowing the trigger's secret, so security is equivalent to a
+  // shared bearer token; signed senders are unaffected.
   const signatureHeader =
     c.req.header('x-kortix-signature') || c.req.header('x-hub-signature-256') || null;
-  if (!verifyWebhookSignature(rawBody, secret, signatureHeader)) {
+  const authed = signatureHeader
+    ? verifyWebhookSignature(rawBody, secret, signatureHeader)
+    : verifyWebhookToken(
+        extractWebhookToken(c.req.header('x-kortix-token'), c.req.header('authorization')),
+        secret,
+      );
+  if (!authed) {
     return c.json({ error: 'Invalid webhook signature' }, 401);
   }
 


### PR DESCRIPTION
## Why
Webhook triggers (`POST /v1/webhooks/projects/:id/:slug`) only accepted an **HMAC-SHA256** signature (`X-Kortix-Signature` / `X-Hub-Signature-256`). That excludes alert sources that **can't HMAC-sign their body** — notably **Better Stack error/incident webhooks**, whose advanced settings only allow custom headers + basic auth. We hit this wiring up the `company` operator's incident-triage automation.

## What
A **static shared-token fallback**, consulted **only when no signature header is present**:
- Token is read from **`X-Kortix-Token`**, or **`Authorization: Bearer <token>`**, or **`Authorization: Basic <base64(user:token)>`** (password component).
- It must equal the trigger's `secret_env` value, compared with `timingSafeEqual`.

HMAC stays the **primary** path — signed senders (GitHub, etc.) are completely unaffected. Both paths require knowing the secret, so security is equivalent to a shared bearer token (the tradeoff vs HMAC is no body-integrity/replay protection, acceptable for alert webhooks).

## Test
Adds cases to `e2e-project-triggers.test.ts`: wrong token → 401; valid `X-Kortix-Token` (no signature) → fires; same secret via `Authorization: Bearer` → fires. Existing HMAC tests unchanged + still pass. Pure helpers verified in isolation; `tsc --noEmit` clean.

## Follow-up
Lets Better Stack point its error webhook straight at the trigger with an `X-Kortix-Token` header — no relay needed.