### PR TITLE
ci(promote): block stale-image promotes (green gate + SHA-pinned prod image)

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -44,6 +44,7 @@ jobs:
       tag: ${{ steps.v.outputs.tag }}
       title: ${{ steps.v.outputs.title }}
       notes: ${{ steps.v.outputs.notes }}
+      source_sha: ${{ steps.v.outputs.source_sha }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -73,6 +74,17 @@ jobs:
             { echo 'notes<<KORTIX_NOTES_EOF'; echo 'KORTIX_NOTES_EOF'; } >> "$GITHUB_OUTPUT"
           fi
 
+          # The exact source commit this release was cut from (stamped by
+          # promote.yml). Empty for legacy releases that predate SHA stamping.
+          if [ -f RELEASE_SOURCE_SHA ]; then
+            SRC="$(tr -d '[:space:]' < RELEASE_SOURCE_SHA)"
+            echo "source_sha=$SRC" >> "$GITHUB_OUTPUT"
+            echo "Release source commit: $SRC"
+          else
+            echo "source_sha=" >> "$GITHUB_OUTPUT"
+            echo "No RELEASE_SOURCE_SHA (legacy release) — will retag :dev-latest"
+          fi
+
   # ── Retag dev images → versioned + latest (no rebuild) ──────────────────────
   retag-images:
     name: Re-tag dev → v${{ needs.version.outputs.version }}
@@ -89,14 +101,29 @@ jobs:
       - name: Re-tag release images
         env:
           VERSION: ${{ needs.version.outputs.version }}
+          SOURCE_SHA: ${{ needs.version.outputs.source_sha }}
         run: |
           set -euo pipefail
+          # Pin to the dev image built from the EXACT promoted commit. If that
+          # image isn't pushed yet (dev build not finished), imagetools create
+          # fails fast — prod can NEVER ship a stale image. Fall back to the
+          # floating :dev-latest only for legacy releases with no stamped SHA.
+          if [ -n "${SOURCE_SHA:-}" ]; then
+            SRC_TAG="dev-${SOURCE_SHA:0:8}"
+          else
+            SRC_TAG="dev-latest"
+          fi
+          echo "Source image tag: $SRC_TAG"
           for IMAGE in kortix/kortix-api kortix/kortix-frontend; do
-            echo "Re-tagging $IMAGE:dev-latest → $IMAGE:${VERSION} + $IMAGE:latest"
+            if ! docker buildx imagetools inspect "$IMAGE:$SRC_TAG" >/dev/null 2>&1; then
+              echo "::error::$IMAGE:$SRC_TAG not found — the dev image for this commit isn't published. Refusing to ship a stale image."
+              exit 1
+            fi
+            echo "Re-tagging $IMAGE:$SRC_TAG → $IMAGE:${VERSION} + $IMAGE:latest"
             docker buildx imagetools create \
               --tag "$IMAGE:${VERSION}" \
               --tag "$IMAGE:latest" \
-              "$IMAGE:dev-latest"
+              "$IMAGE:$SRC_TAG"
             echo "✓ $IMAGE:${VERSION}"
           done
       - name: Summary

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -96,6 +96,30 @@ jobs:
           echo "tag=v$NEW" >> "$GITHUB_OUTPUT"
           echo "Proposing v$NEW"
 
+      - name: Pre-flight — refuse to promote unless this commit is fully green
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          SHA="$(git rev-parse HEAD)"
+          echo "Promote source ${{ inputs.ref }} @ $SHA"
+          # Every check-run on this commit must be completed + success (skipped /
+          # neutral OK). Crucially this INCLUDES deploy-dev, which builds the
+          # :dev-<sha8> image that deploy-prod retags — so an all-green commit
+          # guarantees that image exists. This blocks the race where prod retags a
+          # stale :dev-latest because the new dev image hadn't finished building.
+          NOT_GREEN="$(gh api "repos/${{ github.repository }}/commits/$SHA/check-runs" --paginate \
+            --jq '.check_runs[]
+                  | select((.status != "completed") or (((.conclusion // "") | IN("success","skipped","neutral")) | not))
+                  | "\(.name): \(.status)/\(.conclusion)"' || true)"
+          if [ -n "$NOT_GREEN" ]; then
+            echo "::error::Refusing to promote — $SHA is not all-green (this includes the dev image build):"
+            echo "$NOT_GREEN"
+            echo "Wait for these to finish/pass on '${{ inputs.ref }}', then re-run promote." >&2
+            exit 1
+          fi
+          echo "✓ All checks green on $SHA — safe to promote."
+
       - name: Freeze release branch + open PR into prod
         env:
           GH_TOKEN: ${{ github.token }}
@@ -106,6 +130,9 @@ jobs:
           NEW="${{ steps.ver.outputs.new }}"
           TAG="${{ steps.ver.outputs.tag }}"
           RELBR="release/$TAG"
+          # The commit being promoted (the source ref's HEAD, BEFORE we branch +
+          # merge prod). deploy-prod pins the dev image to this exact SHA.
+          SRC_SHA="$(git rev-parse HEAD)"
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -122,7 +149,8 @@ jobs:
           # is published here.
           printf '%s\n' "$NEW" > VERSION
           printf '%s\n\n%s\n' "$IN_TITLE" "$IN_NOTES" > RELEASE_NOTES.md
-          git add VERSION RELEASE_NOTES.md
+          printf '%s\n' "$SRC_SHA" > RELEASE_SOURCE_SHA
+          git add VERSION RELEASE_NOTES.md RELEASE_SOURCE_SHA
           git commit -m "release: $TAG"
           git push -f origin "HEAD:refs/heads/$RELBR"
 


### PR DESCRIPTION
## Why
We just shipped a release that briefly ran **stale code stamped as the new version**. Root cause: `deploy-prod` retags the dev image (`:dev-latest`, no rebuild), but `deploy-dev` builds that image **asynchronously**. Promoting ~6 min before the dev build finished made prod retag the *previous* `:dev-latest`.

## What (two guards, belt + suspenders)
1. **Pre-flight green gate** (`promote.yml`): refuses to open the release PR unless **every check-run on the source commit is completed + success** (skipped/neutral OK). This includes `deploy-dev` — whose job is building the `:dev-<sha>` image — so an all-green commit guarantees the image exists.
2. **SHA-pinned prod image** (`deploy-prod.yml`): `promote` stamps the source commit into `RELEASE_SOURCE_SHA`; `deploy-prod` retags **`:dev-<source-sha>`** instead of floating `:dev-latest`, and **fails fast** if that image isn't published. Prod can never ship a stale image, even if `:dev-latest` moved.

## Compatibility
Legacy releases without `RELEASE_SOURCE_SHA` fall back to `:dev-latest` (current behavior). No happy-path change when things are already correct.

## Test
YAML validated. Logic is guard-only/additive. Will exercise on the next promote.