### PR TITLE
fix(api): stop GET /accounts timing out on slow invite auto-claim

### DIFF
--- a/apps/api/src/__tests__/unit-auto-claim-invites.test.ts
+++ b/apps/api/src/__tests__/unit-auto-claim-invites.test.ts
@@ -1,0 +1,180 @@
+// Regression test for the production incident where `GET /v1/accounts` timed out
+// (frontend `ApiError: Request timed out after 30s: /accounts`).
+//
+// Root cause: the list handler `await`s `autoClaimPendingInvites` before listing,
+// and that function claimed pending invites with serial, unbounded DB round-trips.
+// A slow/contended DB (or a caller with many pending invites) made it run past the
+// frontend's 30s request timeout, stalling account listing — which fires on nearly
+// every authenticated page (account-switcher, user-menu, project-switcher, …).
+//
+// The fix bounds auto-claim with AUTO_CLAIM_TIMEOUT_MS and claims invites
+// concurrently. These tests pin both behaviours.
+
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+const accounts = { __table: 'accounts', accountId: 'accountId' };
+const accountMembers = {
+  __table: 'accountMembers',
+  accountId: 'accountId',
+  userId: 'userId',
+};
+const accountInvitations = {
+  __table: 'accountInvitations',
+  email: 'email',
+  acceptedAt: 'acceptedAt',
+  expiresAt: 'expiresAt',
+  inviteId: 'inviteId',
+};
+
+const state = {
+  pendingInvites: [] as Array<{
+    inviteId: string;
+    accountId: string;
+    initialRole: string;
+    email: string;
+  }>,
+  // Per-write artificial latency, simulating a slow/contended DB.
+  writeDelayMs: 0,
+  // Whether the initial SELECT of pending invites should hang forever.
+  selectHangs: false,
+};
+
+const insertValuesCalls: Array<Record<string, unknown>> = [];
+const updateCalls: Array<unknown> = [];
+// In-flight insert count — lets us assert claims run concurrently, not serially.
+let inFlightInserts = 0;
+let maxConcurrentInserts = 0;
+
+function sleep(ms: number) {
+  return new Promise<void>((resolve) => setTimeout(resolve, ms));
+}
+
+const fakeDb = {
+  select: () => ({
+    from: (_table: { __table: string }) => ({
+      where: async () => {
+        if (state.selectHangs) {
+          await sleep(60_000);
+        }
+        return state.pendingInvites;
+      },
+    }),
+  }),
+  insert: (_table: { __table: string }) => ({
+    values: (data: Record<string, unknown>) => {
+      insertValuesCalls.push(data);
+      return {
+        onConflictDoNothing: async () => {
+          inFlightInserts += 1;
+          maxConcurrentInserts = Math.max(maxConcurrentInserts, inFlightInserts);
+          if (state.writeDelayMs) await sleep(state.writeDelayMs);
+          inFlightInserts -= 1;
+          return undefined;
+        },
+      };
+    },
+  }),
+  update: (_table: { __table: string }) => ({
+    set: () => ({
+      where: async (clause: unknown) => {
+        updateCalls.push(clause);
+        if (state.writeDelayMs) await sleep(state.writeDelayMs);
+        return undefined;
+      },
+    }),
+  }),
+};
+
+mock.module('drizzle-orm', () => ({
+  and: (...parts: unknown[]) => ({ op: 'and', parts }),
+  eq: (column: string, value: unknown) => ({ op: 'eq', column, value }),
+  gt: (column: string, value: unknown) => ({ op: 'gt', column, value }),
+  isNull: (column: string) => ({ op: 'isNull', column }),
+  count: () => ({ op: 'count' }),
+  sql: (...args: unknown[]) => ({ op: 'sql', args }),
+}));
+
+mock.module('@kortix/db', () => ({
+  accounts,
+  accountMembers,
+  accountInvitations,
+}));
+
+mock.module('../shared/db', () => ({ db: fakeDb }));
+
+// app.ts also imports these (transitively) — stub so importing it stays cheap.
+mock.module('../openapi', () => ({
+  makeOpenApiApp: () => ({ openapi: () => undefined }),
+}));
+mock.module('../shared/supabase', () => ({ getSupabase: () => ({}) }));
+mock.module('../shared/resolve-account', () => ({
+  resolveAccountId: async () => 'acc-resolved',
+}));
+
+const { autoClaimPendingInvites, AUTO_CLAIM_TIMEOUT_MS } = await import(
+  '../accounts/core/app'
+);
+
+beforeEach(() => {
+  state.pendingInvites = [];
+  state.writeDelayMs = 0;
+  state.selectHangs = false;
+  insertValuesCalls.length = 0;
+  updateCalls.length = 0;
+  inFlightInserts = 0;
+  maxConcurrentInserts = 0;
+});
+
+afterEach(() => {
+  mock.restore();
+});
+
+describe('autoClaimPendingInvites', () => {
+  test('is a no-op for empty/blank email', async () => {
+    await autoClaimPendingInvites('user-1', '');
+    await autoClaimPendingInvites('user-1', '   ');
+    expect(insertValuesCalls).toHaveLength(0);
+  });
+
+  test('claims each pending invite (membership insert + accept stamp)', async () => {
+    state.pendingInvites = [
+      { inviteId: 'i1', accountId: 'a1', initialRole: 'member', email: 'u@x.io' },
+      { inviteId: 'i2', accountId: 'a2', initialRole: 'admin', email: 'u@x.io' },
+    ];
+    await autoClaimPendingInvites('user-1', 'U@X.io');
+    expect(insertValuesCalls).toHaveLength(2);
+    expect(insertValuesCalls[0]).toMatchObject({ userId: 'user-1', accountId: 'a1' });
+    expect(updateCalls).toHaveLength(2);
+  });
+
+  test('claims invites concurrently, not serially', async () => {
+    state.writeDelayMs = 40;
+    state.pendingInvites = Array.from({ length: 6 }, (_, i) => ({
+      inviteId: `i${i}`,
+      accountId: `a${i}`,
+      initialRole: 'member',
+      email: 'u@x.io',
+    }));
+    await autoClaimPendingInvites('user-1', 'u@x.io');
+    // Serial would peak at 1 in-flight; concurrent fans out across all invites.
+    expect(maxConcurrentInserts).toBeGreaterThan(1);
+  });
+
+  // The core regression: a slow/hung DB must NOT make auto-claim run unbounded.
+  // Before the fix this awaited forever (or for the serial sum of all writes),
+  // which is what pushed GET /accounts past the frontend's 30s timeout.
+  test('returns within the timeout budget even if the DB hangs', async () => {
+    state.selectHangs = true; // the invite SELECT never resolves
+    const start = Date.now();
+    await autoClaimPendingInvites('user-1', 'u@x.io');
+    const elapsed = Date.now() - start;
+    // Generous upper bound: must be near the budget, nowhere near the 60s hang.
+    expect(elapsed).toBeLessThan(AUTO_CLAIM_TIMEOUT_MS + 2000);
+  });
+
+  test('exposes a sane (sub-request-timeout) budget', () => {
+    expect(AUTO_CLAIM_TIMEOUT_MS).toBeGreaterThan(0);
+    // Must be well under the frontend's 30s request timeout.
+    expect(AUTO_CLAIM_TIMEOUT_MS).toBeLessThan(30_000);
+  });
+});

--- a/apps/api/src/accounts/core/accounts.ts
+++ b/apps/api/src/accounts/core/accounts.ts
@@ -38,6 +38,8 @@ accountsRouter.openapi(
   const userId = c.get('userId') as string;
   const userEmail = c.get('userEmail') as string;
 
+  // Best-effort, time-bounded (see AUTO_CLAIM_TIMEOUT_MS): claiming pending
+  // invites must never delay the listing below past the client request timeout.
   await autoClaimPendingInvites(userId, userEmail);
 
   try {

--- a/apps/api/src/accounts/core/app.ts
+++ b/apps/api/src/accounts/core/app.ts
@@ -212,47 +212,84 @@ export function serializeAccount(row: typeof accounts.$inferSelect) {
   };
 }
 
+// Hard cap on how long auto-claim may run. It is best-effort housekeeping that
+// must never hold an interactive request (esp. account listing) hostage — a slow
+// DB or a caller with many pending invites must not push the response past the
+// frontend's request timeout. See `autoClaimPendingInvites`.
+export const AUTO_CLAIM_TIMEOUT_MS = 5000;
+
+// Resolve to `null` if `promise` hasn't settled within `ms`. The underlying work
+// keeps running in the background; we just stop waiting on it.
+function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T | null> {
+  return new Promise<T | null>((resolve) => {
+    const timer = setTimeout(() => resolve(null), ms);
+    if (typeof timer === 'object' && timer && 'unref' in timer) {
+      (timer as { unref: () => void }).unref();
+    }
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      () => {
+        clearTimeout(timer);
+        resolve(null);
+      },
+    );
+  });
+}
+
 // Auto-claim any pending invitations matching the caller's email. Each invite
 // becomes an account_members row (skipped on duplicate) and its accepted_at is
-// stamped so subsequent calls are no-ops. Errors are swallowed — auto-claim is
-// best-effort and must never block account listing.
+// stamped so subsequent calls are no-ops. Errors are swallowed and the whole
+// thing is time-bounded — auto-claim is best-effort and must never block account
+// listing (a slow/contended DB here previously stalled GET /accounts past the
+// frontend's 30s timeout, surfacing as `ApiError: Request timed out: /accounts`).
 export async function autoClaimPendingInvites(userId: string, email: string): Promise<void> {
   if (!email) return;
   const normalized = email.trim().toLowerCase();
   if (!normalized) return;
 
+  await withTimeout(runAutoClaim(userId, normalized), AUTO_CLAIM_TIMEOUT_MS);
+}
+
+async function runAutoClaim(userId: string, normalizedEmail: string): Promise<void> {
   try {
     const pending = await db
       .select()
       .from(accountInvitations)
       .where(
         and(
-          sql`lower(${accountInvitations.email}) = ${normalized}`,
+          sql`lower(${accountInvitations.email}) = ${normalizedEmail}`,
           isNull(accountInvitations.acceptedAt),
           gt(accountInvitations.expiresAt, new Date()),
         ),
       );
 
-    for (const invite of pending) {
-      try {
-        await db
-          .insert(accountMembers)
-          .values({
-            userId,
-            accountId: invite.accountId,
-            accountRole: invite.initialRole,
-          })
-          .onConflictDoNothing({
-            target: [accountMembers.userId, accountMembers.accountId],
-          });
-        await db
-          .update(accountInvitations)
-          .set({ acceptedAt: new Date() })
-          .where(eq(accountInvitations.inviteId, invite.inviteId));
-      } catch {
-        // Skip individual invite failures; keep processing the rest.
-      }
-    }
+    // Claim invites concurrently rather than serially: serial round-trips made
+    // total latency scale with invite count, which is the path that timed out.
+    await Promise.all(
+      pending.map(async (invite) => {
+        try {
+          await db
+            .insert(accountMembers)
+            .values({
+              userId,
+              accountId: invite.accountId,
+              accountRole: invite.initialRole,
+            })
+            .onConflictDoNothing({
+              target: [accountMembers.userId, accountMembers.accountId],
+            });
+          await db
+            .update(accountInvitations)
+            .set({ acceptedAt: new Date() })
+            .where(eq(accountInvitations.inviteId, invite.inviteId));
+        } catch {
+          // Skip individual invite failures; keep processing the rest.
+        }
+      }),
+    );
   } catch {
     // Table may not exist yet — fall through.
   }


### PR DESCRIPTION
## Incident

Better Stack error-tracking fired a `new_error` in **prod** on **Kortix Frontend (prod)**:

> **ApiError — Request timed out after 30s: `/accounts`**

- Better Stack error id: `209747e30bb599646e9be51a9d16c22f5ed5d047949df40fdb87646b94c29c1a`
- Error URL: https://errors.betterstack.com/team/t502678/errors/209747e30bb599646e9be51a9d16c22f5ed5d047949df40fdb87646b94c29c1a?s=2346967

## One-line root cause

`GET /v1/accounts` unconditionally `await`s `autoClaimPendingInvites()` **before** the membership-list query, and that function claimed invites with **serial, unbounded** DB round-trips — so a slow/contended DB (or a caller with many pending invites) pushed the response past the frontend's 30s request timeout.

## Evidence

- The frontend timeout message is generated in `apps/web/src/lib/api-client.ts:200` — and only for a **genuine** timer-fired timeout (`didTimeout`); the recent fix `515ebc91f` already stopped client-navigation/abort cancellations from being mislabeled as timeouts. So the remaining `/accounts` timeouts are **real** >30s stalls, not abort noise.
- The endpoint in the message (`/accounts`, no suffix) maps to exactly one frontend call: `apps/web/src/lib/projects-client.ts:382` → `backendApi.get<KortixAccount[]>('/accounts')` = `listAccounts()`.
- `listAccounts()` is mounted on nearly every authenticated surface — `account-switcher`, `user-menu`, `project-switcher`, `command-palette`, `/accounts`, `/projects` — so a slow `/accounts` degrades the whole app, not just one route. High blast radius.
- Backend handler `apps/api/src/accounts/core/accounts.ts:41` `await`s `autoClaimPendingInvites(userId, userEmail)` before the cheap list query.
- `autoClaimPendingInvites` (`apps/api/src/accounts/core/app.ts`) iterated pending invites and, **per invite, awaited two DB writes serially** (insert membership + stamp `accepted_at`). Latency scaled with invite count and had **no upper bound**. Its errors were swallowed, but its latency was not — and the handler's own comment claimed it "must never block account listing," which structurally it did.
- Confirmed via Better Stack Telemetry/ClickHouse that team `t502678` owns the `kortix_api` (prod) + `kortix_frontend` (prod) sources, matching the incident's app/env. (Ad-hoc free-form ClickHouse `SELECT`s on the per-request-obfuscated physical log tables were ACL-restricted for the injected read-only credential, so the code path above is the conclusive evidence.)

## Fix

Auto-claim is best-effort housekeeping, so make it impossible for it to block listing:

1. **Bound the whole operation** with `AUTO_CLAIM_TIMEOUT_MS` (5s — well under the 30s client timeout) via a `withTimeout()` race. The underlying work keeps running in the background; the request just stops waiting on it.
2. **Claim invites concurrently** (`Promise.all`) instead of one-at-a-time, so latency no longer scales linearly with invite count.

Behaviour is otherwise unchanged: on a healthy DB, invites are still claimed and reflected in the same response.

## Verification

- `apps/api`: `tsc --noEmit` clean.
- New regression test `apps/api/src/__tests__/unit-auto-claim-invites.test.ts` (5 tests) green. **Verified it genuinely guards the bug**: against the pre-fix code the "DB hangs" case timed out at 5000ms (would have hung) and the "concurrent" case observed serial execution (`maxConcurrentInserts === 1`).
- Full `unit-*.test.ts` suite green; no regressions introduced.
- Note: `e2e-accounts-contract.test.ts` fails on a missing `buildInviteUrl` export — this failure **pre-exists on clean `main`** and is unrelated to this change.

## How to confirm resolution

After merge + promote to prod, the Better Stack error `…b94c29c1a` ("Request timed out after 30s: /accounts") should drop to zero new occurrences and auto-resolve once it's no longer seen. Watch `GET /v1/accounts` p99 latency in the `kortix_api` (prod) source — it should no longer approach 30s.
