### PR TITLE
fix(api): stop POST /ensure-opencode timing out on a slow sandbox provider control plane

### DIFF
--- a/apps/api/src/__tests__/unit-preview-link-timeout.test.ts
+++ b/apps/api/src/__tests__/unit-preview-link-timeout.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Regression test for the Better Stack incident
+ *   ApiError — Request timed out after 30s:
+ *     /projects/:id/sessions/:sid/ensure-opencode
+ *   (error id ff961d2053e66c7c318276031e6c779dc6a6ce20d9b1e800a86771125fa590b3)
+ *
+ * Root cause: `resolvePreviewLink()` (sandbox-proxy/backend.ts) calls into the
+ * provider control plane (Daytona SDK `get()` + `getPreviewLink()`), which take
+ * no AbortSignal. On a cache miss with a slow/hung provider it hung with no
+ * upper bound — past the frontend's 30s request timeout. `ensure-opencode`
+ * resolves the endpoint via this path *before* its own bounded fetch, so it was
+ * the most visible victim.
+ *
+ * The fix bounds the provider round-trip with a timeout race, and makes
+ * `sandboxOpencodeEndpoint()` degrade a resolution failure to `null` (→ the
+ * route returns a fast, retryable `unreachable` instead of hanging / 500ing).
+ *
+ * These tests pin both behaviours: a hung provider must reject/return quickly
+ * rather than wait indefinitely. The timeout is driven short via env so the
+ * test is deterministic and fast.
+ */
+
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+// Drive the bound down to 50ms so a "hung" provider trips it in milliseconds.
+process.env.PREVIEW_LINK_RESOLVE_TIMEOUT_MS = '50';
+
+const SANDBOX_ID = 'sbx-ensure-opencode';
+
+// A provider whose resolvePreviewLink never settles — models a slow/hung
+// Daytona control plane (the SDK call that took no AbortSignal).
+const hungProvider = {
+  resolvePreviewLink: () => new Promise<never>(() => {}),
+};
+
+mock.module('../shared/db', () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          // loadSandbox: one row with a service key + daytona provider.
+          limit: async () => [
+            {
+              sandboxId: SANDBOX_ID,
+              externalId: SANDBOX_ID,
+              projectId: 'proj',
+              accountId: 'acct',
+              provider: 'daytona',
+              status: 'active',
+              baseUrl: '',
+              config: { serviceKey: 'svc-key' },
+            },
+          ],
+        }),
+      }),
+    }),
+  },
+}));
+
+mock.module('../platform/providers', () => ({
+  getProvider: () => hungProvider,
+}));
+
+mock.module('../shared/daytona', () => ({ getDaytona: () => ({}) }));
+mock.module('../shared/preview-ownership', () => ({
+  resolvePreviewUserContext: async () => null,
+}));
+mock.module('../shared/kortix-user-context', () => ({
+  KORTIX_USER_CONTEXT_HEADER: 'X-Kortix-User-Context',
+  encodeKortixUserContext: () => 'signed',
+}));
+
+const { resolvePreviewLink, invalidateSandbox } = await import(
+  '../sandbox-proxy/backend'
+);
+const { sandboxOpencodeEndpoint } = await import('../projects/opencode-mapping');
+
+beforeEach(() => {
+  // Clear any cached link/key so each call re-hits the (hung) provider.
+  invalidateSandbox(SANDBOX_ID);
+});
+
+describe('resolvePreviewLink provider timeout (ensure-opencode 30s hang)', () => {
+  test('rejects well under the client 30s timeout when the provider hangs', async () => {
+    const started = Date.now();
+    await expect(resolvePreviewLink(SANDBOX_ID, 8000)).rejects.toThrow(
+      /timed out/i,
+    );
+    const elapsed = Date.now() - started;
+    // Must be bounded by the (test) timeout, not hang indefinitely.
+    expect(elapsed).toBeLessThan(5_000);
+  });
+
+  test('sandboxOpencodeEndpoint degrades to null (→ retryable unreachable) on a hung provider', async () => {
+    const started = Date.now();
+    const ep = await sandboxOpencodeEndpoint(SANDBOX_ID, 'user-1');
+    const elapsed = Date.now() - started;
+    expect(ep).toBeNull();
+    expect(elapsed).toBeLessThan(5_000);
+  });
+});

--- a/apps/api/src/projects/opencode-mapping.ts
+++ b/apps/api/src/projects/opencode-mapping.ts
@@ -51,7 +51,18 @@ export async function sandboxOpencodeEndpoint(
 ): Promise<{ url: string; headers: Record<string, string> } | null> {
   const serviceKey = await resolveServiceKey(externalId);
   if (!serviceKey) return null;
-  const { url, token } = await resolvePreviewLink(externalId, DAEMON_PORT);
+  // resolvePreviewLink hits the provider control plane and is now bounded by a
+  // timeout (see sandbox-proxy/backend.ts). A slow/hung provider therefore
+  // rejects fast rather than hanging past the client's 30s timeout — treat that
+  // (and any resolution error) as "unreachable" so the caller returns a quick,
+  // retryable response instead of a 500 or a wedged request.
+  let url: string;
+  let token: string | null;
+  try {
+    ({ url, token } = await resolvePreviewLink(externalId, DAEMON_PORT));
+  } catch {
+    return null;
+  }
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
     Authorization: `Bearer ${serviceKey}`,

--- a/apps/api/src/sandbox-proxy/backend.ts
+++ b/apps/api/src/sandbox-proxy/backend.ts
@@ -33,6 +33,42 @@ import {
 const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 const SANDBOX_TOUCH_INTERVAL_MS = 60 * 1000;
 
+// Upper bound on resolving a sandbox's upstream preview link from the provider
+// control plane (Daytona SDK `get()` + `getPreviewLink()`). Those SDK calls take
+// no AbortSignal, so without this race a slow/hung provider made every caller
+// that needs a fresh (cache-missed) link hang indefinitely. The frontend gives
+// up at 30s and surfaces "Request timed out after 30s" — most visibly on
+// POST /projects/:id/sessions/:sid/ensure-opencode, whose endpoint resolution
+// runs *before* its own bounded fetch into the sandbox. Keep this well under the
+// 30s client timeout so a provider blip fails fast (and retryably) instead.
+// Read per-call (not at module load) so it stays tunable via env for ops and
+// deterministic in tests regardless of import order.
+const DEFAULT_PREVIEW_LINK_RESOLVE_TIMEOUT_MS = 12_000;
+function previewLinkResolveTimeoutMs(): number {
+  const raw = Number(process.env.PREVIEW_LINK_RESOLVE_TIMEOUT_MS);
+  return Number.isFinite(raw) && raw > 0
+    ? raw
+    : DEFAULT_PREVIEW_LINK_RESOLVE_TIMEOUT_MS;
+}
+
+/** Reject with a timeout error if `p` doesn't settle within `ms`. */
+async function withTimeout<T>(p: Promise<T>, ms: number, label: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      p,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () => reject(new Error(`${label} timed out after ${ms}ms`)),
+          ms,
+        );
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
 /** Everything the proxy needs to know about a sandbox, from one row fetch. */
 export interface SandboxRecord {
   /** Internal session-sandbox uuid. */
@@ -163,7 +199,15 @@ export async function resolvePreviewLink(
 
   const record = await loadSandbox(externalId);
   if (!record) throw new Error(`[proxy] no sandbox row for ${externalId}`);
-  const { url, token } = await getProvider(record.provider as ProviderName).resolvePreviewLink(externalId, port);
+  // Bound the provider control-plane round-trip — the Daytona SDK calls below
+  // take no AbortSignal, so a slow/hung provider would otherwise hang this
+  // (and every request waiting on a fresh preview link) past the 30s client
+  // timeout. On timeout we throw; callers degrade to a fast, retryable failure.
+  const { url, token } = await withTimeout(
+    getProvider(record.provider as ProviderName).resolvePreviewLink(externalId, port),
+    previewLinkResolveTimeoutMs(),
+    `[proxy] resolvePreviewLink(${externalId}:${port})`,
+  );
 
   previewLinkCache.set(key, { url, token, expiresAt: Date.now() + CACHE_TTL_MS });
   return { url, token };


### PR DESCRIPTION
## Incident

Better Stack error-tracking fired a `new_error` on **Kortix Frontend (prod)**:

> **ApiError — Request timed out after 30s:** `/projects/f2d0e8a1-…/sessions/cccbcb87-…/ensure-opencode`

- Better Stack error id: `ff961d2053e66c7c318276031e6c779dc6a6ce20d9b1e800a86771125fa590b3`
- Error URL: https://errors.betterstack.com/team/t502678/errors/ff961d2053e66c7c318276031e6c779dc6a6ce20d9b1e800a86771125fa590b3?s=2346967

Distinct from #3354 (`/accounts` timeout, different endpoint + root cause): same client-side timeout *mechanism*, different server path.

## One-line root cause

`POST .../ensure-opencode` has **no end-to-end bound**: it resolves the sandbox endpoint via `resolvePreviewLink()`, which calls the **provider control plane** (Daytona SDK `get()` + `getPreviewLink()`) with **no `AbortSignal`** — so on a cache miss with a slow/hung provider it hangs indefinitely, blowing past the frontend's 30s request timeout.

## Evidence

- The timeout string is produced in `apps/web/src/lib/api-client.ts:200`, and **only** for a genuine timer-fired timeout (`didTimeout`) — external aborts/navigations are already swallowed (`api-client.ts:185`). So this is a **real >30s server stall**, not abort noise.
- The endpoint maps to exactly one frontend call: `ensureOpencodeSession()` → `POST .../ensure-opencode` (`apps/web/src/lib/projects-client.ts:1883`), fired by `use-canonical-opencode-session.ts` on every session open.
- Backend route `apps/api/src/projects/routes/r7.ts:489` → `ensureOpencodeSessionPin()` → `listSandboxOpencodeSessions()` → **`sandboxOpencodeEndpoint()`** (`apps/api/src/projects/opencode-mapping.ts:54`) → **`resolvePreviewLink()`** (`apps/api/src/sandbox-proxy/backend.ts:153`).
- The inner fetches into the sandbox are bounded (`AbortSignal.timeout(8_000)` / `15_000`), giving a false sense of safety — but **endpoint resolution runs first and is unbounded**. `daytona.ts:149-153` (`daytona.get()` + `getPreviewLink()`) take no signal. `resolvePreviewLink` is cached 5 min, so most calls are fast; a **cache miss during a Daytona control-plane blip** is the hang.
- Worse, `sandboxOpencodeEndpoint()` called `resolvePreviewLink()` **outside** any try/catch, so when it eventually threw it surfaced as an unhandled 500 rather than a retryable response.
- ClickHouse note: the team's prod logs live in source `kortix_api` (`t502678`), but the read-only credential's per-request shard tables aren't reliably queryable for ad-hoc `SELECT`s (same limitation documented in #3354). The de-minified call site + the code path above are the conclusive evidence; the message itself names the exact endpoint.

## Fix

1. **Bound the provider round-trip** in `resolvePreviewLink()` with a `withTimeout()` race — default **12s** (well under the 30s client timeout), env-tunable via `PREVIEW_LINK_RESOLVE_TIMEOUT_MS`, read per-call. A slow/hung provider now fails fast instead of hanging. This protects **every** proxy path (HTTP forward, WS, ensure-opencode), not just this endpoint.
2. **Degrade gracefully** in `sandboxOpencodeEndpoint()`: a resolution timeout/error returns `null` → `ensureOpencodeSessionPin()` maps it to `reason: 'unreachable'` → the route responds in seconds, and the frontend already **retries `unreachable`/`not_ready` with backoff** (`use-canonical-opencode-session.ts:107-115`). No 500, no wedged request.

Healthy path is unchanged (cache hit, or provider responds quickly).

## Verification

- New regression test `apps/api/src/__tests__/unit-preview-link-timeout.test.ts`: with a provider whose `resolvePreviewLink` **never settles**, both `resolvePreviewLink()` (rejects with a timeout) and `sandboxOpencodeEndpoint()` (returns `null`) now return in **ms**. Confirmed the test **hangs indefinitely on pre-fix code** (reverting the `backend.ts` change makes `bun test` never complete) and passes (`354ms`) with the fix.
- `bun run typecheck` (apps/api) — clean.
- Full `unit-*` suite: 49/52 files pass; the 3 failures (`unit-resolve-account`, `unit-stripe-webhook-canonicalization`, `unit-warm-pool`) are **pre-existing on clean `main`** in this sandbox (need a real `DATABASE_URL` / full secrets) and don't touch the changed files.

## Confirming resolution

After merge + promote, the Better Stack error above should stop seeing new occurrences and auto-resolve. Operationally: `POST .../ensure-opencode` should never exceed ~12s server-side; during a Daytona blip it now returns `ensure.reason: "unreachable"` (retried by the client) instead of timing out.
