### PR TITLE
fix(web): suppress frozen-native-Promise interop noise from Sentry

### DIFF
--- a/apps/web/sentry.client.config.ts
+++ b/apps/web/sentry.client.config.ts
@@ -57,6 +57,13 @@ if (SENTRY_DSN) {
       'MetaMask extension not found',
       'Looks like your website URL has changed',
       'CookieYes account',
+      // Injected scripts/extensions that freeze the native Promise, making
+      // framework code throw while attaching then/catch/finally handlers.
+      // See @/lib/browser-error-noise (isFrozenPromiseInteropNoise) for the
+      // cross-engine matcher that also covers Firefox/Safari wordings.
+      "read only property 'then' of object '#<Promise>'",
+      "read only property 'catch' of object '#<Promise>'",
+      "read only property 'finally' of object '#<Promise>'",
       // Test-only synthetic events
       'E2E FINAL:',
       'E2E test:',

--- a/apps/web/src/lib/browser-error-noise.test.mts
+++ b/apps/web/src/lib/browser-error-noise.test.mts
@@ -3,6 +3,7 @@ import test from 'node:test'
 
 import {
   isExtensionSource,
+  isFrozenPromiseInteropNoise,
   isKnownBrowserNoiseMessage,
   shouldIgnoreBrowserRuntimeNoise,
   shouldIgnoreSentryBrowserNoise,
@@ -59,5 +60,87 @@ test('does not suppress real application errors', () => {
       filename: 'https://app.kortix.com/_next/static/chunk.js',
     }),
     false,
+  )
+})
+
+test('detects the frozen-native-Promise interop signature (V8 wording)', () => {
+  assert.equal(
+    isFrozenPromiseInteropNoise(
+      "Cannot assign to read only property 'then' of object '#<Promise>'",
+    ),
+    true,
+  )
+})
+
+test('detects the frozen-native-Promise interop signature for catch/finally', () => {
+  assert.equal(
+    isFrozenPromiseInteropNoise(
+      "Cannot assign to read only property 'catch' of object '#<Promise>'",
+    ),
+    true,
+  )
+  assert.equal(
+    isFrozenPromiseInteropNoise(
+      "Cannot assign to read only property 'finally' of object '#<Promise>'",
+    ),
+    true,
+  )
+})
+
+test('detects the frozen-Promise interop signature across engine wordings', () => {
+  // Firefox phrasing
+  assert.equal(isFrozenPromiseInteropNoise('"then" is read-only'), true)
+  // Safari/JSC phrasing
+  assert.equal(
+    isFrozenPromiseInteropNoise(
+      "Attempted to assign to readonly property 'then'.",
+    ),
+    true,
+  )
+})
+
+test('does not treat unrelated read-only-property errors as Promise interop noise', () => {
+  assert.equal(
+    isFrozenPromiseInteropNoise(
+      "Cannot assign to read only property 'id' of object '#<Object>'",
+    ),
+    false,
+  )
+  assert.equal(isFrozenPromiseInteropNoise('"id" is read-only'), false)
+})
+
+test('suppresses the frozen-Promise interop TypeError as browser runtime noise', () => {
+  assert.equal(
+    shouldIgnoreBrowserRuntimeNoise({
+      message:
+        "TypeError: Cannot assign to read only property 'then' of object '#<Promise>'",
+      filename: 'https://app.kortix.com/_next/static/chunks/14129-deadbeef.js',
+    }),
+    true,
+  )
+})
+
+test('suppresses the frozen-Promise interop TypeError in Sentry events', () => {
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      request: { url: 'https://app.kortix.com/projects/abc' },
+      exception: {
+        values: [
+          {
+            value:
+              "Cannot assign to read only property 'then' of object '#<Promise>'",
+            stacktrace: {
+              frames: [
+                {
+                  filename:
+                    'app:///_next/static/chunks/14129-864d9f9be69080bf.js',
+                },
+              ],
+            },
+          },
+        ],
+      },
+    }),
+    true,
   )
 })

--- a/apps/web/src/lib/browser-error-noise.ts
+++ b/apps/web/src/lib/browser-error-noise.ts
@@ -22,6 +22,29 @@ const KNOWN_HYDRATION_NOISE_MESSAGES = [
   "Hydration failed because the server rendered",
 ] as const;
 
+// Third-party-script / browser-extension interference: an injected script (a
+// wallet/translation/ad-block extension, a tag-manager snippet, etc.) freezes
+// `Promise.prototype` or redefines `then`/`catch`/`finally` as non-writable.
+// Framework code (Next.js' RSC client / router, Sentry's event pipeline) then
+// throws while attaching one of those handlers to a *native* Promise. This is
+// not an application bug — it originates entirely outside our bundle — so it is
+// pure noise. The wording differs per JS engine, hence the multiple patterns.
+const FROZEN_PROMISE_HANDLER_PROPERTIES = ['then', 'catch', 'finally'] as const;
+
+function buildFrozenPromiseNoisePatterns(): RegExp[] {
+  const props = FROZEN_PROMISE_HANDLER_PROPERTIES.join('|');
+  return [
+    // V8 / Chrome / Node: Cannot assign to read only property 'then' of object '#<Promise>'
+    new RegExp(`read[ -]?only property '(?:${props})' of object '#<Promise>'`, 'i'),
+    // SpiderMonkey / Firefox: "then" is read-only
+    new RegExp(`"(?:${props})" is read-only`, 'i'),
+    // JavaScriptCore / Safari: Attempted to assign to readonly property 'then'.
+    new RegExp(`assign to read[ -]?only property '(?:${props})'`, 'i'),
+  ];
+}
+
+const FROZEN_PROMISE_NOISE_PATTERNS = buildFrozenPromiseNoisePatterns();
+
 const EXTENSION_PROTOCOL_PREFIXES = [
   'chrome-extension://',
   'moz-extension://',
@@ -71,6 +94,20 @@ export function isKnownTestNoiseMessage(message: unknown): boolean {
   return containsKnownPattern(normalized, KNOWN_TEST_NOISE_MESSAGES);
 }
 
+/**
+ * True when the message is the "cannot assign a Promise handler" signature that
+ * a third-party script / browser extension produces by freezing the native
+ * Promise (e.g. `Cannot assign to read only property 'then' of object
+ * '#<Promise>'`). Matched across Chrome/V8, Firefox and Safari wordings, and
+ * restricted to the `then`/`catch`/`finally` handlers so genuine read-only
+ * property bugs in app objects are not swallowed.
+ */
+export function isFrozenPromiseInteropNoise(message: unknown): boolean {
+  const normalized = normalizeString(message);
+  if (!normalized) return false;
+  return FROZEN_PROMISE_NOISE_PATTERNS.some((pattern) => pattern.test(normalized));
+}
+
 export function isLikelyDomMutationNoise(message: unknown): boolean {
   const normalized = normalizeString(message);
   return containsKnownPattern(normalized, KNOWN_DOM_MUTATION_NOISE_MESSAGES)
@@ -91,6 +128,10 @@ export function shouldIgnoreBrowserRuntimeNoise(input: {
   }
 
   if (isKnownTestNoiseMessage(message)) {
+    return true;
+  }
+
+  if (isFrozenPromiseInteropNoise(message)) {
     return true;
   }
 
@@ -122,6 +163,10 @@ export function shouldIgnoreSentryBrowserNoise(event: {
   }
 
   if (isKnownTestNoiseMessage(message)) {
+    return true;
+  }
+
+  if (isFrozenPromiseInteropNoise(message)) {
     return true;
   }
 


### PR DESCRIPTION
## Incident

A Better Stack error-tracking webhook fired for **Kortix Frontend (prod)**:

> **TypeError — Cannot assign to read only property 'then' of object '#<Promise>'**
> `event: new_error` · `env: prod` · location `90830` in `app:///_next/static/chunks/14129-864d9f9be69080bf.js`

- **Error id:** `c4085f6b80e1a4b25c2c372f473f55cad81f4a78dd30cbdf5004be2ffc256290`
- **Error URL:** https://errors.betterstack.com/team/t502678/errors/c4085f6b80e1a4b25c2c372f473f55cad81f4a78dd30cbdf5004be2ffc256290?s=2346967

## Root cause (one line)

A **third-party injected script / browser extension froze the native Promise** (e.g. `Object.freeze(Promise.prototype)` or redefined `then`/`catch`/`finally` as non-writable); framework code then throws when it attaches a handler to a native Promise. This originates entirely **outside our bundle** — it is environmental noise, not an application bug.

## Evidence

1. **The error target is a *native* `#<Promise>`** whose `then` is read-only. That only happens when something makes the Promise (or `Promise.prototype`) non-writable/frozen.
2. **No application code mutates a Promise.** Exhaustive search of `apps/web/src` found **zero** `.then=`/`.catch=`/`.finally=` assignments, no `Object.assign(promise, …)`, no `Object.defineProperty(promise, 'then', …)`, no Promise polyfill, and no `Object.freeze(Promise…)`. Every Promise use is standard (`.finally(...)`, reassigning a module variable that *holds* a Promise — never mutating the Promise object).
3. **The reported frame is shared framework/library code, not ours.** I fetched the exact prod chunk (`14129-864d9f9be69080bf.js`) and de-resolved the location: the only `.then=` assignment in the chunk is React's RSC Flight client (`P.prototype = Object.create(Promise.prototype), P.prototype.then = …`), and the reported column lands in Next.js' client router + Sentry's event-processing pipeline. None of these would mutate a native Promise unless an external script had frozen it first.
4. This is the well-documented **"frozen Promise / read-only `then`" interference** class (cf. [vercel/next.js#84512](https://github.com/vercel/next.js/discussions/84512) — same `Cannot assign to read only property … of object '#<…>'` family caused by external interference, not app logic).

This is exactly the noise category our triage playbook says to suppress via the Sentry noise filter (`apps/web/src/lib/browser-error-noise.ts` + Sentry `ignoreErrors`), rather than chasing a non-existent code defect.

> Note on telemetry access: the read-only ClickHouse user only exposes a `shared.empty` placeholder (per-source log tables aren't granted), and the Better Stack errors REST API isn't reachable with the injected tokens — so the diagnosis is grounded in the exact error signature + the **real production bundle** I fetched and analysed, plus a full source audit.

## The fix

- Add `isFrozenPromiseInteropNoise()` — a **cross-engine** matcher (Chrome/V8, Firefox, Safari/JSC wordings) **scoped to the `then`/`catch`/`finally` handlers on a Promise**, so genuine read-only-property bugs on app objects are **not** swallowed.
- Wire it into **both** noise gates: `shouldIgnoreBrowserRuntimeNoise` (window error/rejection handler) and `shouldIgnoreSentryBrowserNoise` (Sentry `beforeSend`).
- Add the literal strings to Sentry's `ignoreErrors` in `sentry.client.config.ts` as a defense-in-depth layer (Sentry drops these before `beforeSend` runs).

The matcher is deliberately narrow: it requires the property to be one of `then`/`catch`/`finally` **and** the read-only/frozen wording — so `Cannot assign to read only property 'id' of object '#<Object>'` (a real app bug) is **not** suppressed (explicit negative tests cover this).

## Verification

- `node --experimental-strip-types --test src/lib/browser-error-noise.test.mts` → **11/11 pass** (5 pre-existing + 6 new, including the exact prod signature and negative cases).
- `next lint` on the changed files → **no warnings or errors**.
- `tsc --noEmit`: changed files are clean; the repo's pre-existing baseline (`@types/react` v18 `bigint`/`ReactNode` JSX typing) is **1224 errors on `main` and 1224 with this change** — i.e. **zero new** type errors introduced.

## How to confirm resolution

After this promotes to prod, this Better Stack error should drop to **zero new occurrences** and auto-resolve once it's no longer seen.
