### PR TITLE
fix(web): filter frozen-Promise webpack-runtime noise from Sentry

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,6 +10,7 @@
     "i18n:audit": "node scripts/audit-i18n.mjs",
     "i18n:strict": "node scripts/audit-i18n.mjs --max-hardcoded=0",
     "test:workspace-search": "node --experimental-strip-types --test src/features/files/search/workspace-search-core.test.mts",
+    "test:noise": "node --experimental-strip-types --test src/lib/browser-error-noise.test.mts",
     "test:e2e": "bash ./scripts/run-e2e.sh",
     "test:e2e:ui": "bash ./scripts/run-e2e.sh --ui",
     "test:e2e:full": "bash ../../tests/e2e/scripts/run-full-self-hosted-e2e.sh",

--- a/apps/web/sentry.client.config.ts
+++ b/apps/web/sentry.client.config.ts
@@ -60,6 +60,10 @@ if (SENTRY_DSN) {
       // Test-only synthetic events
       'E2E FINAL:',
       'E2E test:',
+      // Injected scripts / automated scanners that freeze the native Promise,
+      // making the webpack runtime throw when it assigns `.then` (not an app bug)
+      "Cannot assign to read only property 'then' of object '#<Promise>'",
+      '"then" is read-only',
     ],
 
     // Filter out internal/low-value errors before sending

--- a/apps/web/src/lib/browser-error-noise.test.mts
+++ b/apps/web/src/lib/browser-error-noise.test.mts
@@ -3,6 +3,7 @@ import test from 'node:test'
 
 import {
   isExtensionSource,
+  isFrozenPromiseNoise,
   isKnownBrowserNoiseMessage,
   shouldIgnoreBrowserRuntimeNoise,
   shouldIgnoreSentryBrowserNoise,
@@ -52,11 +53,72 @@ test('suppresses extension-backed Sentry events', () => {
   )
 })
 
+test('matches the frozen-Promise webpack-runtime noise (V8)', () => {
+  assert.equal(
+    isFrozenPromiseNoise(
+      "Cannot assign to read only property 'then' of object '#<Promise>'",
+    ),
+    true,
+  )
+})
+
+test('matches the frozen-Promise noise reported by Firefox', () => {
+  assert.equal(isFrozenPromiseNoise('TypeError: "then" is read-only'), true)
+})
+
+test('suppresses the frozen-Promise Sentry event from an injected scanner', () => {
+  // Real prod event: a TechDetect/1.0 HeadlessChrome scanner froze the native
+  // Promise, so webpack's runtime threw while loading chunks on the homepage.
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      request: { url: 'https://kortix.com/' },
+      exception: {
+        values: [
+          {
+            value:
+              "Cannot assign to read only property 'then' of object '#<Promise>'",
+            stacktrace: {
+              frames: [
+                { filename: 'app:///_next/static/chunks/webpack-f184a7555004bb8b.js' },
+              ],
+            },
+          },
+        ],
+      },
+    }),
+    true,
+  )
+})
+
 test('does not suppress real application errors', () => {
   assert.equal(
     shouldIgnoreBrowserRuntimeNoise({
       message: 'TypeError: Cannot read properties of undefined (reading id)',
       filename: 'https://app.kortix.com/_next/static/chunk.js',
+    }),
+    false,
+  )
+})
+
+test('does not suppress an app error that merely mentions then', () => {
+  // A genuine bug ("foo.then is not a function") must still be reported — only
+  // the exact engine-emitted read-only-Promise signature is treated as noise.
+  assert.equal(isFrozenPromiseNoise('foo.then is not a function'), false)
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      request: { url: 'https://app.kortix.com/dashboard' },
+      exception: {
+        values: [
+          {
+            value: 'TypeError: result.then is not a function',
+            stacktrace: {
+              frames: [
+                { filename: 'app:///_next/static/chunks/dashboard.js' },
+              ],
+            },
+          },
+        ],
+      },
     }),
     false,
   )

--- a/apps/web/src/lib/browser-error-noise.ts
+++ b/apps/web/src/lib/browser-error-noise.ts
@@ -22,6 +22,20 @@ const KNOWN_HYDRATION_NOISE_MESSAGES = [
   "Hydration failed because the server rendered",
 ] as const;
 
+// Environmental interference, not an app defect: some injected scripts and
+// automated scanners/crawlers (e.g. tech-stack detectors) freeze the native
+// Promise — or `Promise.prototype` — before our bundle runs. The webpack runtime
+// (`__webpack_require__.O`) and async chunk loaders then throw when they assign
+// `.then` on the now read-only promise. We can't fix the third party's frozen
+// environment, and a real app `then` bug would surface a different, code-specific
+// message, so this exact engine-emitted signature is safe to drop.
+const KNOWN_FROZEN_PROMISE_NOISE_MESSAGES = [
+  // V8 / Chromium
+  "Cannot assign to read only property 'then' of object '#<Promise>'",
+  // SpiderMonkey / Firefox
+  '"then" is read-only',
+] as const;
+
 const EXTENSION_PROTOCOL_PREFIXES = [
   'chrome-extension://',
   'moz-extension://',
@@ -77,6 +91,11 @@ export function isLikelyDomMutationNoise(message: unknown): boolean {
     || containsKnownPattern(normalized, KNOWN_HYDRATION_NOISE_MESSAGES);
 }
 
+export function isFrozenPromiseNoise(message: unknown): boolean {
+  const normalized = normalizeString(message);
+  return containsKnownPattern(normalized, KNOWN_FROZEN_PROMISE_NOISE_MESSAGES);
+}
+
 export function shouldIgnoreBrowserRuntimeNoise(input: {
   message?: unknown;
   filename?: unknown;
@@ -91,6 +110,10 @@ export function shouldIgnoreBrowserRuntimeNoise(input: {
   }
 
   if (isKnownTestNoiseMessage(message)) {
+    return true;
+  }
+
+  if (isFrozenPromiseNoise(message)) {
     return true;
   }
 
@@ -122,6 +145,10 @@ export function shouldIgnoreSentryBrowserNoise(event: {
   }
 
   if (isKnownTestNoiseMessage(message)) {
+    return true;
+  }
+
+  if (isFrozenPromiseNoise(message)) {
     return true;
   }
 


### PR DESCRIPTION
## Incident

A Better Stack / Sentry error fired in **prod** on the marketing homepage:

> **TypeError — Cannot assign to read only property `then` of object `#<Promise>`**

- **Better Stack error id:** `514a8dcf0c8c0f0cde9ef4ee4682087ef48dd86ab7864949ec981608a8128cab`
- **Error page:** https://errors.betterstack.com/team/t502678/errors/514a8dcf0c8c0f0cde9ef4ee4682087ef48dd86ab7864949ec981608a8128cab?s=2346967
- **App:** Kortix Frontend (prod) · **env:** `prod` · **release:** `e179aceaf` (v0.9.33)

## Root cause (one line)

A third-party / automated scanner froze the native `Promise` before our bundle loaded, so the **webpack runtime** threw when it assigned `.then` on a deferred-load promise — environmental interference, not an app bug.

## Evidence (from the raw exception payload)

Pulled the raw event from Better Stack telemetry (hot exceptions collection, the event was still in hot storage):

- **Reporter is a bot, not a user** — `User-Agent: "Mozilla/5.0 ... (compatible; TechDetect/1.0) HeadlessChrome/145.0.7632.46"`. `user: anonymous`.
- **Single occurrence, 0 identified users**, `transaction: "/"`, `url: https://kortix.com/`.
- **Mechanism:** `auto.browser.global_handlers.onerror`, `handled: false`.
- **Stack is entirely the bundler runtime** — `webpack-*.js` `c` / `d.O` (`__webpack_require__.O`, the deferred-chunk/onChunksLoaded path), `main-app-*.js`, then the vendor chunk module factories. No app source frame at the top.

The webpack runtime assigns `.then` on the promise it uses to defer module execution. When an injected script / scanner has frozen the native `Promise` (or `Promise.prototype`), that assignment throws `Cannot assign to read only property 'then'` under strict mode. We can't fix the third party's frozen environment, and a genuine app `then` bug surfaces a *different*, code-specific message (e.g. `result.then is not a function`). This belongs with the other known browser-noise classes we already filter, not in our error budget / on-call.

## Fix

- Adds a tightly-scoped `KNOWN_FROZEN_PROMISE_NOISE_MESSAGES` category in `apps/web/src/lib/browser-error-noise.ts` matching the exact engine wordings:
  - V8/Chromium: `Cannot assign to read only property 'then' of object '#<Promise>'`
  - Firefox/SpiderMonkey: `"then" is read-only`
- Wires it into `shouldIgnoreBrowserRuntimeNoise` and `shouldIgnoreSentryBrowserNoise`, and adds the messages to Sentry `ignoreErrors` (defense in depth — `beforeSend` already routes through the shared filter).
- **Conservative by design:** only the exact read-only-`then`-on-`Promise` signature is dropped. Real app errors that merely mention `then` (e.g. `result.then is not a function`) are still reported — covered by a regression test.

## Verification

- `node --experimental-strip-types --test src/lib/browser-error-noise.test.mts` → **9/9 pass** (added a `test:noise` script wiring this suite into a runnable command).
- New regression tests: the V8 + Firefox signatures are suppressed; the real prod scanner event (`kortix.com/` + webpack frame) is suppressed; a genuine `then` bug is **not** suppressed.
- `pnpm --filter ./apps/web lint` — no new errors/warnings from the touched files.
- Touched files typecheck clean.

## How to confirm resolution

After this promotes to prod, this Better Stack error should stop accruing new occurrences and auto-resolve (it was already a 1-off from a bot). Watch the error id above for zero new events.
