### PR TITLE
fix(web): suppress frozen-Promise RSC then-assignment noise from wallet/SES extensions

### DIFF
--- a/apps/web/sentry.client.config.ts
+++ b/apps/web/sentry.client.config.ts
@@ -57,6 +57,11 @@ if (SENTRY_DSN) {
       'MetaMask extension not found',
       'Looks like your website URL has changed',
       'CookieYes account',
+      // Wallet/SES extensions freeze Promise.prototype before our JS runs, so
+      // React's bundled RSC Flight runtime throws when it assigns Chunk.then.
+      // Uncontrollable extension damage, not an app bug — see browser-error-noise.ts.
+      "Cannot assign to read only property 'then'",
+      "Attempted to assign to readonly property",
       // Test-only synthetic events
       'E2E FINAL:',
       'E2E test:',

--- a/apps/web/src/lib/browser-error-noise.test.mts
+++ b/apps/web/src/lib/browser-error-noise.test.mts
@@ -3,6 +3,7 @@ import test from 'node:test'
 
 import {
   isExtensionSource,
+  isFrozenIntrinsicsNoiseMessage,
   isKnownBrowserNoiseMessage,
   shouldIgnoreBrowserRuntimeNoise,
   shouldIgnoreSentryBrowserNoise,
@@ -58,6 +59,75 @@ test('does not suppress real application errors', () => {
       message: 'TypeError: Cannot read properties of undefined (reading id)',
       filename: 'https://app.kortix.com/_next/static/chunk.js',
     }),
+    false,
+  )
+})
+
+// Wallet/SES browser extensions freeze Promise.prototype before our JS runs;
+// React's bundled RSC Flight runtime then throws assigning Chunk.prototype.then.
+// The throwing frame is our own _next chunk, so the extension-source filter
+// misses it — match on the message instead. See vercel/next.js#78823.
+test('detects the frozen-Promise (SES/wallet extension) RSC then-assignment noise', () => {
+  assert.equal(
+    isFrozenIntrinsicsNoiseMessage(
+      "Cannot assign to read only property 'then' of object '#<Promise>'",
+    ),
+    true,
+  )
+})
+
+test('classifies the frozen-intrinsics then-assignment as known browser noise', () => {
+  assert.equal(
+    isKnownBrowserNoiseMessage(
+      "TypeError: Cannot assign to read only property 'then' of object '#<Promise>'",
+    ),
+    true,
+  )
+})
+
+test('suppresses the frozen-Promise error coming from our own _next chunk', () => {
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      request: { url: 'https://www.kortix.com/projects' },
+      exception: {
+        values: [
+          {
+            value: "Cannot assign to read only property 'then' of object '#<Promise>'",
+            stacktrace: {
+              frames: [
+                { filename: 'app:///_next/static/chunks/14129-864d9f9be69080bf.js' },
+              ],
+            },
+          },
+        ],
+      },
+    }),
+    true,
+  )
+})
+
+test('also matches the WebKit "Attempted to assign to readonly property" wording', () => {
+  assert.equal(
+    isFrozenIntrinsicsNoiseMessage(
+      "TypeError: Attempted to assign to readonly property 'then'",
+    ),
+    true,
+  )
+})
+
+// Guard against over-suppression: a read-only-assignment error that does NOT
+// target a frozen intrinsic `then` is a genuine app bug and must still report.
+test('does not suppress a real read-only-property error on app state', () => {
+  assert.equal(
+    isFrozenIntrinsicsNoiseMessage(
+      "Cannot assign to read only property 'count' of object '#<Object>'",
+    ),
+    false,
+  )
+  assert.equal(
+    isKnownBrowserNoiseMessage(
+      "Cannot assign to read only property 'count' of object '#<Object>'",
+    ),
     false,
   )
 })

--- a/apps/web/src/lib/browser-error-noise.ts
+++ b/apps/web/src/lib/browser-error-noise.ts
@@ -12,6 +12,29 @@ const KNOWN_TEST_NOISE_MESSAGES = [
   'E2E test:',
 ] as const;
 
+// Frozen-intrinsics noise: some hardened wallet / privacy browser extensions
+// (MetaMask "lockdown"/SES, Rabby, Pocket Universe, etc.) call
+// `Object.freeze(Promise.prototype)` (and other intrinsics) to harden the page
+// *before* our app's JavaScript runs. When Next.js's bundled
+// `react-server-dom-webpack/client` (the RSC Flight runtime) then initializes
+// its internal `Chunk` thenable with `Chunk.prototype.then = function () {…}`,
+// the assignment to the now read-only inherited `then` throws:
+//
+//   TypeError: Cannot assign to read only property 'then' of object '#<Promise>'
+//
+// The throwing frame is our own bundle (`app:///_next/static/chunks/…`), not an
+// `extension://` URL, so the extension-source filter below never sees it. This
+// is uncontrollable third-party-extension damage with no actionable fix on our
+// side, so we suppress it explicitly. See vercel/next.js#78823.
+//
+// The exact wording varies by engine and by which intrinsic the extension froze
+// ('then', 'push', etc.), so we match the stable, distinctive substrings rather
+// than a single full message.
+const FROZEN_INTRINSICS_NOISE_MARKERS = [
+  'Cannot assign to read only property',
+  'Attempted to assign to readonly property',
+] as const;
+
 const KNOWN_DOM_MUTATION_NOISE_MESSAGES = [
   "Failed to execute 'insertBefore' on 'Node': The node before which the new node is to be inserted is not a child of this node.",
   "Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.",
@@ -51,9 +74,25 @@ function extractMessage(value: unknown): string {
   return '';
 }
 
+// A read-only-assignment TypeError is only noise when it targets a frozen JS
+// *intrinsic* (Promise/RSC `Chunk`) rather than one of our own objects — that
+// signature is the wallet/SES extension hardening the page (see
+// FROZEN_INTRINSICS_NOISE_MARKERS above). Requiring the `'then'` target keeps
+// genuine app bugs (e.g. writing to our own `Object.freeze`'d state) reportable.
+export function isFrozenIntrinsicsNoiseMessage(message: unknown): boolean {
+  const normalized = normalizeString(message);
+  return (
+    containsKnownPattern(normalized, FROZEN_INTRINSICS_NOISE_MARKERS) &&
+    normalized.includes("'then'")
+  );
+}
+
 export function isKnownBrowserNoiseMessage(message: unknown): boolean {
   const normalized = normalizeString(message);
-  return containsKnownPattern(normalized, KNOWN_BROWSER_NOISE_MESSAGES);
+  return (
+    containsKnownPattern(normalized, KNOWN_BROWSER_NOISE_MESSAGES) ||
+    isFrozenIntrinsicsNoiseMessage(normalized)
+  );
 }
 
 export function isExtensionSource(filename: unknown): boolean {


### PR DESCRIPTION
## Incident

Better Stack error-tracking webhook (prod, `new_error`):

> **TypeError — Cannot assign to read only property 'then' of object '#<Promise>'**
> env: prod · app: Kortix Frontend (prod) · location `90830` in `app:///_next/static/chunks/14129-864d9f9be69080bf.js`
> error id `bdb58f07f6b2faa3b92a3b71fbe9c81a4de8a21d3a8a593bc5aa4633313ec96e`
> https://errors.betterstack.com/team/t502678/errors/bdb58f07f6b2faa3b92a3b71fbe9c81a4de8a21d3a8a593bc5aa4633313ec96e

## Root cause (one line)

A hardened wallet/privacy **browser extension** (MetaMask "lockdown"/SES, Rabby, Pocket Universe, …) calls `Object.freeze(Promise.prototype)` **before our JS runs**; Next.js's bundled `react-server-dom-webpack/client` (the RSC Flight runtime) then throws when it assigns `Chunk.prototype.then`, because the inherited `then` is now read-only.

## Evidence

- **Bundle de-minification.** Fetched the exact deployed chunk (`https://www.kortix.com/_next/static/chunks/14129-864d9f9be69080bf.js`, same hash as the error). It contains React's RSC Flight client `Chunk` class:
  ```js
  P.prototype = Object.create(Promise.prototype),
  P.prototype.then = function (e, t) { … }   // ← throws when Promise.prototype is frozen
  ```
  `P.prototype` inherits `then` from `Promise.prototype`; if an extension froze that intrinsic, assigning `P.prototype.then` throws `Cannot assign to read only property 'then'` in strict mode. The throwing frame is **our own `_next` chunk**, not an `extension://` URL — so the existing extension-source noise filter never sees it.
- **Reproduced exactly** (Node, identical message):
  ```js
  'use strict';
  Object.freeze(Promise.prototype);
  function Chunk(s,v,r){ this.status=s; this.value=v; this.reason=r; }
  Chunk.prototype = Object.create(Promise.prototype);
  Chunk.prototype.then = function () {};      // throws
  // → TypeError: Cannot assign to read only property 'then' of object '#<Promise>'
  ```
  Without the `Object.freeze`, no error — so our code is correct in normal browsers.
- **Known/expected.** [vercel/next.js#78823](https://github.com/vercel/next.js/issues/78823): *"This issue may be related to browser extensions or other security features that prevent JavaScript from modifying global objects."* Widely reported with the identical RSC/`'then'` signature.
- **Not a backend issue.** The only prod logs source reachable via ClickHouse is the API metrics source (`t502678.kortix_api_2_*`); this is a pure client-side intrinsics failure with no correlated server log.

## Why this is noise, not a code bug

It's **uncontrollable third-party-extension damage**: we can't un-freeze `Promise.prototype` before React loads, and we don't own React's bundled runtime. There is no actionable code fix — the right action (per the error-triage playbook) is to stop it paging us.

## The fix

- `apps/web/src/lib/browser-error-noise.ts`: new `isFrozenIntrinsicsNoiseMessage()` matcher that requires **both** the read-only-assignment wording (`Cannot assign to read only property` / WebKit's `Attempted to assign to readonly property`) **and** a `'then'` target. Wired into `isKnownBrowserNoiseMessage()`, so it covers Sentry `beforeSend` *and* the global `window` error/unhandledrejection guards.
- `apps/web/sentry.client.config.ts`: same messages added to `ignoreErrors` for SDK-level defense-in-depth.
- **Over-suppression guard:** a read-only-assignment error targeting our own object (e.g. `'count'`) still reports — covered by a regression test.

## Verification

- `node --test apps/web/src/lib/browser-error-noise.test.mts` → **10/10 pass** (4 new + over-suppression guard).
- Full CI frontend gate `pnpm --filter ./apps/web build` → **exit 0** (chunk `14129` rebuilt with the change).
- No new typecheck errors introduced (the pre-existing `tsc` errors on `@/.source`/project-shell/etc. are present on clean `main`).

## How to confirm resolution

After merge + promote, this Better Stack error should drop to **zero new occurrences** and auto-resolve once no longer seen.

Resolves Better Stack incident `bdb58f07f6b2faa3b92a3b71fbe9c81a4de8a21d3a8a593bc5aa4633313ec96e`.