### PR TITLE
fix(web): drop "read only property 'then'" Promise noise from Sentry

### DIFF
--- a/apps/web/sentry.client.config.ts
+++ b/apps/web/sentry.client.config.ts
@@ -57,6 +57,9 @@ if (SENTRY_DSN) {
       'MetaMask extension not found',
       'Looks like your website URL has changed',
       'CookieYes account',
+      // Third-party scripts / scanner bots patching a native Promise's `.then`
+      // (we never assign Promise#then); surfaces as an external unhandled rejection.
+      "read only property 'then'",
       // Test-only synthetic events
       'E2E FINAL:',
       'E2E test:',

--- a/apps/web/src/lib/browser-error-noise.test.ts
+++ b/apps/web/src/lib/browser-error-noise.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  isKnownBrowserNoiseMessage,
+  shouldIgnoreBrowserRuntimeNoise,
+  shouldIgnoreSentryNoiseEvent,
+} from './browser-error-noise';
+
+// Regression: a tech-detection scanner bot (UA "TechDetect/1.0 HeadlessChrome")
+// hit https://kortix.com/ and triggered an unhandled rejection from injected code
+// that tried to reassign `.then` on a native Promise. Kortix never assigns
+// Promise#then, so this is pure third-party/bot noise and must not page us.
+// Better Stack pattern df06367391b6cd5b562c5da7c5a028963cc3d9edede59dcc379f596955ada9ae
+const PROMISE_THEN_READONLY_MESSAGE =
+  "Cannot assign to read only property 'then' of object '#<Promise>'";
+
+describe('isKnownBrowserNoiseMessage — read-only Promise#then', () => {
+  test('matches the V8 "Cannot assign to read only property \'then\'" message', () => {
+    expect(isKnownBrowserNoiseMessage(PROMISE_THEN_READONLY_MESSAGE)).toBe(true);
+  });
+
+  test('does not match an unrelated genuine error', () => {
+    expect(
+      isKnownBrowserNoiseMessage('Cannot read properties of undefined (reading then)'),
+    ).toBe(false);
+  });
+});
+
+describe('shouldIgnoreSentryNoiseEvent — read-only Promise#then', () => {
+  test('drops the bot-triggered unhandled rejection event', () => {
+    const event = {
+      environment: 'prod',
+      request: { url: 'https://kortix.com/' },
+      exception: {
+        values: [
+          {
+            value: PROMISE_THEN_READONLY_MESSAGE,
+            stacktrace: {
+              frames: [
+                { filename: 'app:///_next/static/chunks/14129-864d9f9be69080bf.js' },
+              ],
+            },
+          },
+        ],
+      },
+    };
+    expect(shouldIgnoreSentryNoiseEvent(event)).toBe(true);
+  });
+
+  test('keeps a real first-party TypeError', () => {
+    const event = {
+      environment: 'prod',
+      request: { url: 'https://kortix.com/projects' },
+      exception: {
+        values: [
+          {
+            value: "Cannot read properties of null (reading 'id')",
+            stacktrace: {
+              frames: [
+                { filename: 'app:///_next/static/chunks/app/projects-abc123.js' },
+              ],
+            },
+          },
+        ],
+      },
+    };
+    expect(shouldIgnoreSentryNoiseEvent(event)).toBe(false);
+  });
+});
+
+describe('shouldIgnoreBrowserRuntimeNoise — read-only Promise#then', () => {
+  test('drops an onunhandledrejection reason with the read-only Promise#then message', () => {
+    expect(
+      shouldIgnoreBrowserRuntimeNoise({
+        reason: new TypeError(PROMISE_THEN_READONLY_MESSAGE),
+      }),
+    ).toBe(true);
+  });
+});

--- a/apps/web/src/lib/browser-error-noise.ts
+++ b/apps/web/src/lib/browser-error-noise.ts
@@ -5,6 +5,13 @@ const KNOWN_BROWSER_NOISE_MESSAGES = [
   'MetaMask extension not found',
   'Looks like your website URL has changed',
   'CookieYes account',
+  // Third-party scripts / extensions / scanner bots that try to patch a native
+  // (frozen) Promise by reassigning its `.then`, e.g. instrumentation injected by
+  // tech-detection crawlers. Surfaces as an unhandled rejection from code that is
+  // not ours — Kortix never assigns `Promise#then`. The wording differs slightly
+  // per JS engine ("Cannot assign to read only property 'then'" in V8), so match
+  // on the stable substring.
+  "read only property 'then'",
 ] as const;
 
 const KNOWN_TEST_NOISE_MESSAGES = [


### PR DESCRIPTION
## Incident

Better Stack error-tracking alert (Kortix Frontend, **prod**).

- **Type / message:** `TypeError: Cannot assign to read only property 'then' of object '#<Promise>'`
- **Error id:** `df06367391b6cd5b562c5da7c5a028963cc3d9edede59dcc379f596955ada9ae`
- **Error page:** https://errors.betterstack.com/team/t502678/errors/df06367391b6cd5b562c5da7c5a028963cc3d9edede59dcc379f596955ada9ae?s=2346967
- **Release:** `e179aceaf` (v0.9.33)

## Root cause — third-party / bot noise, not a Kortix defect

Pulled the single recorded occurrence from Better Stack (ClickHouse exceptions
source, app `2346967`). The full event:

| field | value |
| --- | --- |
| environment | `prod` |
| url | `https://kortix.com/` (homepage) |
| user | `anonymous` (0 unique users) |
| mechanism | `auto.browser.global_handlers.onunhandledrejection`, `handled: false` |
| **User-Agent** | `Mozilla/5.0 ... TechDetect/1.0 ... HeadlessChrome/145.0.7632.46` |
| occurrences | **1** total, ever (hot + S3 historical both checked over 7d) |

The UA is a **tech-stack-detection scanner bot**, not a real user. The last
breadcrumb before the throw is our harmless `[runtime-env]` `console.info` from
`env-config.ts` (just an env dump — it does **not** touch promises). The actual
throw comes from code the bot injected that tries to reassign `.then` on a
native (frozen) `Promise`, which then bubbles to Sentry's global
`onunhandledrejection` handler.

**Kortix never assigns `Promise#then`** — `grep -rn "\.then\s*=" apps/web/src`
returns nothing. So there is no first-party bug to fix here; this is classic
third-party/extension/scanner noise (same category as the existing
`MetaMask extension not found` / `runtime.sendMessage` / `webkitPresentationMode`
entries) that slipped past Sentry's filters because it arrives as an unhandled
rejection.

## Fix

Treat it as noise so it stops paging:

- Add the stable, engine-agnostic substring **`read only property 'then'`** to
  `KNOWN_BROWSER_NOISE_MESSAGES` in `apps/web/src/lib/browser-error-noise.ts` —
  the shared list consumed by both the Sentry `beforeSend` filter
  (`shouldIgnoreSentryNoiseEvent`) and the runtime handler
  (`shouldIgnoreBrowserRuntimeNoise`).
- Mirror it in the Sentry `ignoreErrors` list in
  `apps/web/sentry.client.config.ts` (defense in depth — drops it before
  `beforeSend` even runs).

Matching the substring (not the full V8 wording) also covers the slightly
different phrasings other engines emit for the same frozen-Promise assignment.

## Verification

- `bun test apps/web/src/lib/browser-error-noise.test.ts` → **5 pass** — new
  regression reconstructs the exact recorded event and asserts it is dropped,
  while a genuine first-party `TypeError` on `/projects` is still reported.
- `bun test apps/web/src/lib/` → **33 pass** (no regressions).
- `pnpm --filter ./apps/web build` (the CI `frontend-build` gate) → **succeeds**.

## Confirming resolution

After merge + promote to prod, this error should drop to **zero new
occurrences** — Better Stack auto-resolves
`df06367391b6cd5b562c5da7c5a028963cc3d9edede59dcc379f596955ada9ae` once it is no
longer seen. (It was already a one-off, so the practical effect is that any
future hits from the same scanner pattern are filtered before ingestion.)
