### PR TITLE
fix(web): suppress third-party Promise.then tampering noise from Sentry

### DIFF
--- a/apps/web/sentry.client.config.ts
+++ b/apps/web/sentry.client.config.ts
@@ -57,6 +57,10 @@ if (SENTRY_DSN) {
       'MetaMask extension not found',
       'Looks like your website URL has changed',
       'CookieYes account',
+      // Injected scripts / extensions / scanner bots monkey-patching the native
+      // (read-only) Promise prototype, e.g. `promise.then = ...`. Always external.
+      "Cannot assign to read only property 'then' of object '#<Promise>'",
+      'Cannot assign to read only property',
       // Test-only synthetic events
       'E2E FINAL:',
       'E2E test:',

--- a/apps/web/src/lib/browser-error-noise.test.mts
+++ b/apps/web/src/lib/browser-error-noise.test.mts
@@ -61,3 +61,37 @@ test('does not suppress real application errors', () => {
     false,
   )
 })
+
+test('matches third-party Promise.then tampering noise', () => {
+  assert.equal(
+    isKnownBrowserNoiseMessage(
+      "Cannot assign to read only property 'then' of object '#<Promise>'",
+    ),
+    true,
+  )
+})
+
+test('suppresses the Better Stack Promise.then incident event', () => {
+  // Reproduces error c4085f6b...256290 (Kortix Frontend prod): an
+  // onunhandledrejection from a scanner bot monkey-patching native Promise.then
+  // on the marketing homepage. The de-minified frame points at our own chunk,
+  // so this must be matched by message, not by source.
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      request: { url: 'https://kortix.com/' },
+      exception: {
+        values: [
+          {
+            value: "Cannot assign to read only property 'then' of object '#<Promise>'",
+            stacktrace: {
+              frames: [
+                { filename: 'app:///_next/static/chunks/14129-864d9f9be69080bf.js' },
+              ],
+            },
+          },
+        ],
+      },
+    }),
+    true,
+  )
+})

--- a/apps/web/src/lib/browser-error-noise.ts
+++ b/apps/web/src/lib/browser-error-noise.ts
@@ -5,6 +5,13 @@ const KNOWN_BROWSER_NOISE_MESSAGES = [
   'MetaMask extension not found',
   'Looks like your website URL has changed',
   'CookieYes account',
+  // Third-party injected scripts / extensions / scanner bots that monkey-patch
+  // native Promise internals (e.g. `promise.then = ...`). The native Promise
+  // prototype is read-only, so the assignment throws a TypeError that surfaces
+  // via onunhandledrejection — it is never our code. Seen from headless
+  // tech-detection crawlers hitting the marketing site.
+  "Cannot assign to read only property 'then' of object '#<Promise>'",
+  'Cannot assign to read only property',
 ] as const;
 
 const KNOWN_TEST_NOISE_MESSAGES = [


### PR DESCRIPTION
## Incident

Better Stack flagged a **new** prod frontend error:

- **Error**: `TypeError — Cannot assign to read only property 'then' of object '#<Promise>'`
- **App**: Kortix Frontend (prod) · **env**: `prod` · **id**: `c4085f6b80e1a4b25c2c372f473f55cad81f4a78dd30cbdf5004be2ffc256290`
- **Better Stack**: https://errors.betterstack.com/team/t502678/errors/c4085f6b80e1a4b25c2c372f473f55cad81f4a78dd30cbdf5004be2ffc256290?s=2346967

## Root cause (one line)

A third-party injected script / extension / scanner bot monkey-patches the **native, read-only Promise prototype** (`promise.then = …`); the assignment throws and bubbles to `onunhandledrejection`. **It is never our code** — it's environmental noise that slipped past our Sentry filters.

## Evidence (from Better Stack telemetry / ClickHouse)

Pulled the raw exception occurrence for this pattern from the `t502678_kortix_frontend` source:

- **1 occurrence, 0 unique users** — first & last seen `2026-06-07 20:10:55 UTC`.
- **`mechanism: auto.browser.global_handlers.onunhandledrejection`** — an unhandled promise rejection, not a thrown error in app code.
- **URL `https://kortix.com/`** (marketing homepage), `transaction: /`, `user: anonymous`.
- **User-Agent**: `Mozilla/5.0 … (compatible; TechDetect/1.0) HeadlessChrome/145.0.7632.46` — a **headless tech-stack-detection crawler**, exactly the kind of client that injects scripts that tamper with `Promise`.
- The de-minified frames point at our own bundled chunk (`14129-…js`) because the patched `.then` is invoked from inside our code path — so this **must be matched by message, not by source** (the existing extension-source / injected-source filters don't catch it).

This message (`Cannot assign to read only property …`) is a native-immutability error that legitimate app code never produces — the same class as the wallet/extension/`runtime.sendMessage` noise we already suppress.

## Fix

- `apps/web/src/lib/browser-error-noise.ts` — add the Promise-tampering message to `KNOWN_BROWSER_NOISE_MESSAGES` (caught by both `shouldIgnoreBrowserRuntimeNoise` and the Sentry `beforeSend` path via `shouldIgnoreSentryBrowserNoise`).
- `apps/web/sentry.client.config.ts` — add the same message to the SDK `ignoreErrors` list (defense-in-depth, filtered before `beforeSend`).
- `apps/web/src/lib/browser-error-noise.test.mts` — two regression tests, one reproducing the exact incident event shape (prod, `https://kortix.com/`, our chunk filename, the precise message).

No over-suppression: verified that normal app errors (e.g. `Cannot read properties of undefined (reading 'then')`, generic `TypeError`) are **not** matched.

## Verification

- `node --experimental-strip-types --test apps/web/src/lib/browser-error-noise.test.mts` → **7/7 pass** (incl. the 2 new repro tests).
- `pnpm --filter ./apps/web build` → **green** (same job CI's "Frontend build" runs).

## Confirming resolution

After merge + promote, this error should drop to **zero new occurrences** in Better Stack (the SDK + `beforeSend` filter discards it client-side). Better Stack will auto-resolve the pattern once it's no longer seen.

---
Resolves Better Stack error `c4085f6b80e1a4b25c2c372f473f55cad81f4a78dd30cbdf5004be2ffc256290`.
