### PR TITLE
fix(api): bound Daytona snapshot.get so /sandbox-health can't hang

### DIFF
--- a/apps/api/src/__tests__/unit-with-timeout.test.ts
+++ b/apps/api/src/__tests__/unit-with-timeout.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Unit coverage for `withTimeout` — the wall-clock guard that bounds upstream
+ * SDK calls with no native timeout (notably Daytona's `snapshot.get`).
+ *
+ * Regression context: a hung `snapshot.get` behind the `/sandbox-health`
+ * polling endpoint left the request pending until the frontend's 30s client
+ * timeout fired, surfacing as the Sentry/Better Stack error
+ * "ApiError — Request timed out after 30s: /projects/<id>/sandbox-health".
+ * The guard turns that unbounded hang into a fast, catchable rejection so the
+ * handler can degrade gracefully.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { TimeoutError, withTimeout } from '../shared/with-timeout';
+
+const never = <T>() => new Promise<T>(() => {});
+
+describe('withTimeout', () => {
+  test('resolves with the value when the promise wins the race', async () => {
+    await expect(withTimeout(Promise.resolve(42), 1_000)).resolves.toBe(42);
+  });
+
+  test('propagates rejection when the promise rejects before the deadline', async () => {
+    await expect(withTimeout(Promise.reject(new Error('boom')), 1_000)).rejects.toThrow(
+      'boom',
+    );
+  });
+
+  test('rejects with TimeoutError when the promise never settles (the hang)', async () => {
+    const start = Date.now();
+    let caught: unknown;
+    try {
+      await withTimeout(never<string>(), 20, 'Daytona snapshot.get(foo)');
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(TimeoutError);
+    expect((caught as TimeoutError).timeoutMs).toBe(20);
+    expect((caught as Error).message).toContain('Daytona snapshot.get(foo)');
+    // It must give up promptly, not block anywhere near a real request timeout.
+    expect(Date.now() - start).toBeLessThan(1_000);
+  });
+
+  test('a non-positive budget disables the bound (returns the promise as-is)', async () => {
+    await expect(withTimeout(Promise.resolve('ok'), 0)).resolves.toBe('ok');
+    await expect(withTimeout(Promise.resolve('ok'), -5)).resolves.toBe('ok');
+  });
+
+  test('a slow-but-within-budget promise still resolves', async () => {
+    const slow = new Promise<string>((r) => setTimeout(() => r('late'), 10));
+    await expect(withTimeout(slow, 1_000)).resolves.toBe('late');
+  });
+});

--- a/apps/api/src/projects/routes/r2.ts
+++ b/apps/api/src/projects/routes/r2.ts
@@ -3,6 +3,7 @@ import { auth, errors, json } from '../../openapi';
 import { DEFAULT_SANDBOX_SLUG, deleteSandboxImage, kickPreBuild, kickProjectTemplatePrebuilds, listSandboxTemplates, listSnapshotBuilds, reconcileStaleBuilds } from '../../snapshots/builder';
 import { classifySnapshotError, describeSnapshotError } from '../../snapshots/error-classify';
 import { getSandboxProvider } from '../../snapshots/providers';
+import { withTimeout } from '../../shared/with-timeout';
 import { createTemplate, deleteTemplate, getTemplateById, updateTemplate } from '../../snapshots/templates';
 import { commitFile, createRepo, getFileSha } from '../github';
 import { buildStarterFiles, normalizeStarterTemplateId } from '../starter';
@@ -418,6 +419,11 @@ projectsApp.openapi(
 // GET /v1/projects/:projectId/sandbox-health
 // Cheap polling endpoint for the sidebar alert. Surfaces the platform default
 // template's live state + the most recent failed build (across any template).
+//
+// Overall budget for the (potentially Daytona-bound) templates lookup. Kept
+// comfortably under the frontend's 30s request timeout so a degraded provider
+// degrades the alert to "no templates" instead of timing the poll out.
+const SANDBOX_HEALTH_BUDGET_MS = 12_000;
 
 projectsApp.openapi(
   createRoute({
@@ -442,9 +448,18 @@ projectsApp.openapi(
   const project = await loadGitProject(loaded);
   let templates: Awaited<ReturnType<typeof listSandboxTemplates>> = [];
   try {
-    templates = await listSandboxTemplates(project);
+    // Defense-in-depth: even though each Daytona state lookup is now bounded,
+    // cap the whole templates fetch so this frequently-polled endpoint can
+    // never hang past the frontend's request timeout. A slow lookup degrades
+    // to the same "no templates" fallback as a repo/manifest error.
+    templates = await withTimeout(
+      listSandboxTemplates(project),
+      SANDBOX_HEALTH_BUDGET_MS,
+      'sandbox-health listSandboxTemplates',
+    );
   } catch {
-    // Repo unreachable / manifest broken — render as "no templates".
+    // Repo unreachable / manifest broken / lookup too slow — render as
+    // "no templates".
   }
   const primary = templates[0] ?? null;
   const builds = await listSnapshotBuilds(projectId, { limit: 10 }).catch(() => []);

--- a/apps/api/src/shared/with-timeout.ts
+++ b/apps/api/src/shared/with-timeout.ts
@@ -1,0 +1,53 @@
+/**
+ * Bound a promise with a wall-clock timeout.
+ *
+ * Some upstream SDK calls (notably the Daytona SDK) take a request but expose
+ * no per-call timeout / AbortSignal, so a degraded upstream can leave the
+ * promise pending indefinitely. `Promise.race`-ing it against a timer turns an
+ * unbounded hang into a deterministic, catchable failure — which the caller can
+ * then degrade gracefully on instead of blocking a request forever.
+ *
+ * The losing branch (the slow promise) is left to settle in the background and
+ * its result/rejection is intentionally ignored; the timer is always cleared so
+ * a fast win doesn't keep the event loop alive.
+ */
+
+export class TimeoutError extends Error {
+  readonly timeoutMs: number;
+  constructor(timeoutMs: number, label?: string) {
+    super(
+      label
+        ? `${label} timed out after ${timeoutMs}ms`
+        : `Operation timed out after ${timeoutMs}ms`,
+    );
+    this.name = 'TimeoutError';
+    this.timeoutMs = timeoutMs;
+  }
+}
+
+/**
+ * Resolve with `promise` if it settles within `timeoutMs`, otherwise reject
+ * with a {@link TimeoutError}.
+ *
+ * @param promise   the work to bound
+ * @param timeoutMs how long to wait before giving up (must be > 0)
+ * @param label     optional context for the error message
+ */
+export function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  label?: string,
+): Promise<T> {
+  if (!(timeoutMs > 0)) {
+    // A non-positive budget means "no bound" — just return the promise as-is
+    // rather than rejecting immediately, so callers can disable the guard.
+    return promise;
+  }
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new TimeoutError(timeoutMs, label)), timeoutMs);
+  });
+  return Promise.race([promise, timeout]).finally(() => {
+    if (timer) clearTimeout(timer);
+  }) as Promise<T>;
+}

--- a/apps/api/src/snapshots/providers/daytona.ts
+++ b/apps/api/src/snapshots/providers/daytona.ts
@@ -17,6 +17,7 @@ import { createGzip } from 'node:zlib';
 import { tmpdir } from 'node:os';
 import { Image } from '@daytonaio/sdk';
 import { getDaytona, isDaytonaConfigured } from '../../shared/daytona';
+import { withTimeout } from '../../shared/with-timeout';
 import { buildLayeredDockerfile } from '../dockerfile-layer';
 import type {
   BuildableTemplate,
@@ -63,6 +64,13 @@ function readPositiveIntEnv(name: string, fallback: number): number {
  * Daytona dashboard surfaces in under a minute.
  */
 const SNAPSHOT_STATE_CACHE_TTL_MS = 60_000;
+/**
+ * Per-call wall-clock budget for the (timeout-less) Daytona `snapshot.get`.
+ * A healthy call is ~50-200ms; 8s is generous headroom for a slow-but-alive
+ * upstream while keeping us well under the frontend's 30s request timeout even
+ * if several templates are checked back-to-back.
+ */
+const SNAPSHOT_STATE_TIMEOUT_MS = 8_000;
 const snapshotStateCache = new Map<string, { state: ProviderState; expiresAt: number }>();
 
 class DaytonaAdapter implements SandboxProviderAdapter {
@@ -149,7 +157,17 @@ class DaytonaAdapter implements SandboxProviderAdapter {
     const cached = snapshotStateCache.get(snapshotName);
     if (cached && Date.now() < cached.expiresAt) return cached.state;
     try {
-      const snap = await getDaytona().snapshot.get(snapshotName);
+      // The Daytona SDK takes no per-call timeout, so a degraded upstream can
+      // leave `snapshot.get` pending indefinitely. This runs on the warm boot
+      // path and behind the `/sandbox-health` polling endpoint, where an
+      // unbounded hang stalls the request until the *client* gives up (the
+      // frontend's 30s timeout → "Request timed out after 30s"). Bound it so a
+      // slow Daytona degrades to the same safe `missing` fallback as an error.
+      const snap = await withTimeout(
+        getDaytona().snapshot.get(snapshotName),
+        SNAPSHOT_STATE_TIMEOUT_MS,
+        `Daytona snapshot.get(${snapshotName})`,
+      );
       const state = (snap
         ? String((snap as { state?: string }).state ?? 'missing')
         : 'missing'
@@ -164,6 +182,9 @@ class DaytonaAdapter implements SandboxProviderAdapter {
       }
       return state;
     } catch {
+      // Error *or* timeout (TimeoutError) → treat as unknown/missing. We never
+      // poison the positive cache here, so the next poll re-checks once Daytona
+      // recovers.
       snapshotStateCache.delete(snapshotName);
       return 'missing';
     }


### PR DESCRIPTION
## Incident

Better Stack error (prod, Kortix Frontend):

> **ApiError — Request timed out after 30s: `/projects/<id>/sandbox-health`**

- Event: `new_error` · env: `prod` · app: Kortix Frontend (prod)
- Error id: `2cae94207f5dee89ff9396bb8b743bb514d204110341c701af4ef7584e636bdb`
- Error URL: https://errors.betterstack.com/team/t502678/errors/2cae94207f5dee89ff9396bb8b743bb514d204110341c701af4ef7584e636bdb

## Root cause (one line)

The `/sandbox-health` poll reads live Daytona snapshot state via the Daytona SDK's `snapshot.get`, which has **no per-call timeout** — when Daytona is degraded the call hangs unbounded, the request never returns, and the frontend's 30s client timeout fires.

## Evidence

- **Frontend**: `useSandboxHealth` (`apps/web/src/components/projects/sandbox-health-alert.tsx:76`) polls `getProjectSandboxHealth` → `backendApi.get('/projects/{id}/sandbox-health')` on **every project page**, every **8–30s** (`refetchInterval`).
- **Web client**: default request timeout is **30s** (`apps/web/src/lib/api-client.ts:27`); when it fires, the message is built as `` `Request timed out after ${30}s: ${endpoint}` `` (`api-client.ts:200`) — exactly the reported error string + endpoint.
- **API handler** (`apps/api/src/projects/routes/r2.ts:437`) is documented as a "Cheap polling endpoint" but calls `listSandboxTemplates(project)` → `toView` → `provider.getSnapshotState()` **per template** (`apps/api/src/snapshots/builder.ts:329`).
- **Daytona provider** (`apps/api/src/snapshots/providers/daytona.ts:139`): `getSnapshotState` calls `getDaytona().snapshot.get(snapshotName)` with **no timeout**. Only `active` is cached (60s) — non-active / cache-miss hits Daytona live on every poll. The surrounding `try/catch` catches *thrown* errors but **not a hang**: a pending promise is never rejected, so the handler blocks past 30s and the client times out.

This is a code defect (an unbounded external call behind a frequent polling endpoint), not infra/config/data.

## Fix

Added a small reusable `withTimeout(promise, ms, label)` guard (`apps/api/src/shared/with-timeout.ts`) that `Promise.race`s the work against a timer and rejects with a `TimeoutError`, and applied it at the two unbounded upstream call sites:

1. **`getSnapshotState`** — bound `snapshot.get` at **8s**. On timeout it falls through to the **same safe `missing` fallback** as an error. The positive cache is never poisoned, so the next poll re-checks once Daytona recovers. (8s is generous vs the healthy ~50–200ms, and stays well under the 30s client budget.)
2. **`/sandbox-health` handler** — defense-in-depth **12s budget** on the whole templates lookup, degrading to the existing "no templates" fallback so the endpoint can never hang past the client timeout even with many templates.

## Verification

- `bun run typecheck` (apps/api) — **clean**.
- New unit test `apps/api/src/__tests__/unit-with-timeout.test.ts` — **5/5 pass** (resolve / propagate rejection / the hang → prompt `TimeoutError` under budget / disabled budget / slow-but-within-budget).
- Ran the full `unit-*` API suite: the only failures (`unit-resolve-account`, `unit-stripe-webhook-canonicalization`) are **pre-existing on clean `main`** (env-dependent Stripe/billing tests) and unrelated to this change — confirmed by stashing the diff and re-running.

## How to confirm resolution

After merge + promote, the Better Stack error `2cae9420…` should stop seeing new occurrences (auto-resolves once no longer seen). Concretely: even during a Daytona slowdown, `GET /projects/:id/sandbox-health` now returns within ~12s with `building`/`ready` degraded to a safe default instead of timing the poll out at the client.
