### PR TITLE
fix(web): suppress browser-induced React #418 hydration noise on all routes

### DIFF
--- a/apps/web/src/lib/browser-error-noise.test.mts
+++ b/apps/web/src/lib/browser-error-noise.test.mts
@@ -71,6 +71,98 @@ test('matches third-party Promise.then tampering noise', () => {
   )
 })
 
+// Reproduces Better Stack error 8bc2dce8...0384f8 (Kortix Frontend prod):
+// a recoverable React #418 hydration mismatch raised via onerror on a pt-PT
+// user's browser. Chrome's auto-translate (offered because the page renders in
+// English) rewrites text nodes before hydration, which React reports as a
+// server/client mismatch. It fired on the marketing 404 (`/pt`) and on the
+// post-login `/projects` landing — neither contains `/auth`, so the old
+// route-scoped guard let it through. It must now be suppressed everywhere.
+const REACT_418 =
+  'Minified React error #418; visit https://react.dev/errors/418?args[]=HTML&args[]= ' +
+  'for the full message or use the non-minified dev environment for full errors ' +
+  'and additional helpful warnings.'
+
+test('suppresses the React #418 hydration noise on the marketing site (/pt)', () => {
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      request: { url: 'https://kortix.com/pt' },
+      exception: {
+        values: [
+          {
+            value: REACT_418,
+            stacktrace: {
+              frames: [
+                { filename: 'app:///_next/static/chunks/414c69f9-e0c657363ae93f0c.js' },
+              ],
+            },
+          },
+        ],
+      },
+    }),
+    true,
+  )
+})
+
+test('suppresses the React #418 hydration noise on the post-login /projects landing', () => {
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      request: { url: 'https://kortix.com/projects?auth_event=login&auth_method=google' },
+      exception: {
+        values: [
+          {
+            value: REACT_418,
+            stacktrace: {
+              frames: [
+                { filename: 'app:///_next/static/chunks/414c69f9-e0c657363ae93f0c.js' },
+              ],
+            },
+          },
+        ],
+      },
+    }),
+    true,
+  )
+})
+
+test('still suppresses the generic "Hydration failed because the server rendered" message', () => {
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      request: { url: 'https://kortix.com/' },
+      exception: {
+        values: [
+          {
+            value:
+              'Hydration failed because the server rendered HTML didn\'t match the client.',
+            stacktrace: { frames: [{ filename: 'app:///_next/static/chunks/main.js' }] },
+          },
+        ],
+      },
+    }),
+    true,
+  )
+})
+
+test('does NOT suppress a genuine, non-recoverable app hydration error', () => {
+  // React #425 ("Text content does not match server-rendered HTML") is the
+  // deterministic, app-caused hydration class and is not in the noise list, so
+  // it must still reach error tracking even on a non-/auth route.
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      request: { url: 'https://kortix.com/projects' },
+      exception: {
+        values: [
+          {
+            value: 'Minified React error #425; visit https://react.dev/errors/425 for the full message',
+            stacktrace: { frames: [{ filename: 'app:///_next/static/chunks/app.js' }] },
+          },
+        ],
+      },
+    }),
+    false,
+  )
+})
+
 test('suppresses the Better Stack Promise.then incident event', () => {
   // Reproduces error c4085f6b...256290 (Kortix Frontend prod): an
   // onunhandledrejection from a scanner bot monkey-patching native Promise.then

--- a/apps/web/src/lib/browser-error-noise.ts
+++ b/apps/web/src/lib/browser-error-noise.ts
@@ -144,7 +144,25 @@ export function shouldIgnoreSentryBrowserNoise(event: {
     return true;
   }
 
-  if (isLikelyDomMutationNoise(message) && requestUrl.includes('/auth')) {
+  // Recoverable hydration noise (React #418 / "Hydration failed because the
+  // server rendered ...") is virtually always the browser mutating the DOM
+  // before/during hydration — Chrome's auto-translate (offered to users whose
+  // locale differs from the page, e.g. pt-PT visitors on our English-rendered
+  // marketing site) and content-injecting extensions rewrite text nodes, which
+  // React then reports as a server/client mismatch. It is recoverable (React
+  // regenerates the subtree on the client) and is not an app defect.
+  //
+  // This was previously scoped to `/auth` only, but the same browser behaviour
+  // fires everywhere the user navigates — the marketing site (`/`, `/pt`, ...)
+  // and the post-login `/projects` landing — so the route guard let real
+  // browser noise through to error tracking. Suppress this class globally.
+  //
+  // NOTE: this only covers the *recoverable* #418/#423 hydration-text class
+  // listed in KNOWN_HYDRATION_NOISE_MESSAGES. A genuine, deterministic app
+  // hydration bug surfaces as the non-recoverable React #419/#421/#425 ("Text
+  // content does not match" / "There was an error while hydrating") which are
+  // NOT in that list and still report normally.
+  if (isLikelyDomMutationNoise(message)) {
     return true;
   }
 


### PR DESCRIPTION
## Incident

Better Stack error tracking — **Kortix Frontend (prod)**, `new_error`, `environment = prod`.

- **Error:** `Minified React error #418` — *Hydration failed because the server rendered HTML didn't match the client.*
- **Error id:** `8bc2dce807e38e8d6e7548d6be722bdbb58ecb32af7848cd2a5013144b0384f8`
- **Better Stack:** https://errors.betterstack.com/team/t502678/errors/8bc2dce807e38e8d6e7548d6be722bdbb58ecb32af7848cd2a5013144b0384f8?s=2346967
- **Release:** `5512951` (v0.9.34) · **First seen:** 2026-06-07 22:40 UTC

## Root cause — browser-induced noise, not an app defect

Pulled the raw occurrences from Better Stack telemetry (ClickHouse `t502678_kortix_frontend_exceptions`). Both prod hits share a clear signal:

| URL | locale / TZ | browser | mechanism |
|---|---|---|---|
| `https://kortix.com/pt` (marketing 404) | `pt-PT` / `Europe/Lisbon` | Chrome 149 | `auto.browser.global_handlers.onerror`, `handled:false` |
| `https://kortix.com/projects?auth_event=login&auth_method=google` (post-Google-login) | `pt-PT` / `Europe/Lisbon` | Chrome 149 | same |

React **#418** is the *recoverable* hydration class — React regenerates the subtree on the client and continues. It's raised here via `window.onerror` (`handled:false`), which is how a **browser mutating the DOM before/during hydration** surfaces: Chrome's **auto-translate** (offered precisely to a `pt-PT` user viewing our English-rendered pages) and content-injecting extensions rewrite text nodes, and React reports the rewritten text as a server/client mismatch. The `args[]=HTML` in the message is the literal template word, i.e. the generic HTML-mismatch form — not a specific app element.

The app already treats this as noise:
- `apps/web/src/app/layout.tsx` ships `translate="no"`, `notranslate`, `<meta name="google" content="notranslate">` to *prevent* browser translation, and
- `apps/web/src/lib/browser-error-noise.ts` lists `Minified React error #418` / `Hydration failed because the server rendered` in `KNOWN_HYDRATION_NOISE_MESSAGES` and filters them in Sentry `beforeSend`.

**The bug:** `shouldIgnoreSentryBrowserNoise` only suppressed this hydration class when the request URL contained `/auth`. The same browser behaviour fires everywhere the user navigates, so the route guard let real noise through to Better Stack — e.g. this incident, on `/pt` and `/projects`.

> Ruled out an app i18n hydration bug: `next-intl` is **not** wired as a Next plugin (`createNextIntlPlugin` is absent), so `i18n/request.ts`'s server-side `Accept-Language` detection is dead code. All translation flows through the client `I18nProvider`, which first-renders `en` to match the English SSR. So the SSR/client HTML matches for a clean load — the divergence is the browser, post-render.

## Fix

Drop the `/auth`-only route guard for the recoverable **#418/#423** hydration-text class in `shouldIgnoreSentryBrowserNoise`, so it's suppressed on every route. Scope is preserved: genuine, deterministic app hydration bugs surface as the *non-recoverable* **#419/#421/#425** class, which is **not** in `KNOWN_HYDRATION_NOISE_MESSAGES` and continues to report normally.

```diff
- if (isLikelyDomMutationNoise(message) && requestUrl.includes('/auth')) {
-   return true;
- }
+ if (isLikelyDomMutationNoise(message)) {
+   return true;
+ }
```

## Verification

- **Reproduced** both exact incident payloads against the current code → returned `false` (not ignored). After the fix → `true`.
- New regression tests in `browser-error-noise.test.mts` assert: #418 suppressed on `/pt` and on the post-login `/projects` landing, the generic "Hydration failed…" message stays suppressed, and a genuine app **#425** on `/projects` is **still reported** (guard against over-suppression).
- `node --test src/lib/browser-error-noise.test.mts` → **11/11 pass** (7 existing + 4 new).
- `tsc --noEmit` on the touched lib → clean; `next lint` on the file → no warnings/errors.

## Confirming resolution

After merge + promote, this Better Stack error should stop receiving new occurrences and auto-resolve. The signal to watch: zero new `Minified React error #418` events for **Kortix Frontend (prod)** going forward.

---
🤖 Generated for Better Stack incident `8bc2dce8...0384f8`. Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
