### PR TITLE
fix(web): stop React #418 hydration mismatch from timezone-dependent dates

### DIFF
--- a/apps/web/src/app/(home)/changelog/page.tsx
+++ b/apps/web/src/app/(home)/changelog/page.tsx
@@ -6,6 +6,13 @@ import rehypeSanitize from 'rehype-sanitize';
 
 import { Reveal } from '@/components/home/reveal';
 import { Badge } from '@/components/ui/badge';
+import { LocalTime } from '@/components/ui/local-time';
+
+const RELEASE_DATE_FORMAT: Intl.DateTimeFormatOptions = {
+  year: 'numeric',
+  month: 'long',
+  day: 'numeric',
+};
 
 export const metadata: Metadata = {
   title: 'Changelog',
@@ -64,15 +71,6 @@ async function getReleases(): Promise<GitHubRelease[]> {
   } catch {
     return [];
   }
-}
-
-function formatDate(iso: string | null): string {
-  if (!iso) return '';
-  return new Date(iso).toLocaleDateString('en-US', {
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-  });
 }
 
 function ReleaseNotes({ body }: { body: string }) {
@@ -181,9 +179,17 @@ export default async function ChangelogPage() {
                         Pre-release
                       </Badge>
                     )}
-                    <time className="text-xs text-muted-foreground">
-                      {formatDate(release.published_at)}
-                    </time>
+                    {release.published_at && (
+                      <time
+                        dateTime={release.published_at}
+                        className="text-xs text-muted-foreground"
+                      >
+                        <LocalTime
+                          value={release.published_at}
+                          options={RELEASE_DATE_FORMAT}
+                        />
+                      </time>
+                    )}
                   </div>
 
                   {release.body?.trim() ? (

--- a/apps/web/src/app/maintenance/page.tsx
+++ b/apps/web/src/app/maintenance/page.tsx
@@ -1,6 +1,15 @@
 import { getHardcodedUiServerText } from '@/lib/hardcoded-ui-server';
 import { Wrench } from 'lucide-react';
 import { getMaintenanceConfig } from '@/lib/maintenance-store';
+import { LocalTime } from '@/components/ui/local-time';
+
+const SCHEDULE_FORMAT: Intl.DateTimeFormatOptions = {
+  weekday: 'short',
+  month: 'short',
+  day: 'numeric',
+  hour: 'numeric',
+  minute: '2-digit',
+};
 
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
@@ -39,7 +48,17 @@ export default async function MaintenancePage() {
           <div className="inline-flex items-center gap-2 rounded-lg bg-muted px-4 py-2.5 text-sm text-muted-foreground">
             <span className="font-medium">Scheduled:</span>
             <span>
-              {formatDateTime(config.startTime!)} – {formatDateTime(config.endTime!)}
+              <LocalTime
+                value={config.startTime!}
+                options={SCHEDULE_FORMAT}
+                fallback={config.startTime!}
+              />{' '}
+              –{' '}
+              <LocalTime
+                value={config.endTime!}
+                options={SCHEDULE_FORMAT}
+                fallback={config.endTime!}
+              />
             </span>
           </div>
         )}
@@ -74,20 +93,4 @@ function AutoRefresh() {
       }}
     />
   );
-}
-
-function formatDateTime(iso: string): string {
-  try {
-    const d = new Date(iso);
-    if (isNaN(d.getTime())) return iso;
-    return d.toLocaleString('en-US', {
-      weekday: 'short',
-      month: 'short',
-      day: 'numeric',
-      hour: 'numeric',
-      minute: '2-digit',
-    });
-  } catch {
-    return iso;
-  }
 }

--- a/apps/web/src/components/ui/local-time.test.ts
+++ b/apps/web/src/components/ui/local-time.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from 'bun:test';
+
+import { formatInTimeZone } from './local-time';
+
+/**
+ * Regression test for React hydration error #418 (Better Stack incident
+ * 8bc2dce807e38e8d6e7548d6be722bdbb58ecb32af7848cd2a5013144b0384f8).
+ *
+ * Root cause: server components rendered dates with `toLocaleString` /
+ * `toLocaleDateString`, which format in the runtime's *default* timezone. The
+ * server (UTC) and the browser (the viewer's timezone) then emit different text
+ * for the same instant, so React's hydration text comparison fails.
+ *
+ * The fix renders a timezone-stable UTC string on the server (via
+ * `formatInTimeZone(..., 'UTC')`) and only localizes after mount. These tests
+ * pin that invariant: the server-rendered text must be identical no matter what
+ * the host's default timezone is.
+ */
+
+// An instant late in the UTC day — the worst case, where the calendar day and
+// the time-of-day both differ across timezones.
+const NEAR_MIDNIGHT_UTC = new Date('2026-06-07T23:30:00.000Z');
+
+const DATE_FORMAT: Intl.DateTimeFormatOptions = {
+  year: 'numeric',
+  month: 'long',
+  day: 'numeric',
+};
+
+const DATETIME_FORMAT: Intl.DateTimeFormatOptions = {
+  weekday: 'short',
+  month: 'short',
+  day: 'numeric',
+  hour: 'numeric',
+  minute: '2-digit',
+};
+
+describe('formatInTimeZone — hydration-safe server rendering', () => {
+  test('UTC date format is stable for a near-midnight-UTC instant', () => {
+    // This is what the server (and the first client render) produces. It must
+    // be a fixed, well-known string — never timezone-dependent.
+    expect(formatInTimeZone(NEAR_MIDNIGHT_UTC, DATE_FORMAT, 'UTC')).toBe(
+      'June 7, 2026',
+    );
+  });
+
+  test('UTC datetime format is stable for a near-midnight-UTC instant', () => {
+    expect(formatInTimeZone(NEAR_MIDNIGHT_UTC, DATETIME_FORMAT, 'UTC')).toBe(
+      'Sun, Jun 7, 11:30 PM',
+    );
+  });
+
+  test('output does not depend on the runtime default timezone', () => {
+    // Same instant + same explicit zone ⇒ identical text, regardless of how the
+    // host machine is configured. (The pre-fix code, which relied on the
+    // default zone, would diverge here between server and client.)
+    const baseline = formatInTimeZone(NEAR_MIDNIGHT_UTC, DATETIME_FORMAT, 'UTC');
+    const original = process.env.TZ;
+    try {
+      for (const tz of ['UTC', 'America/Los_Angeles', 'Asia/Tokyo', 'Pacific/Kiritimati']) {
+        process.env.TZ = tz;
+        expect(formatInTimeZone(NEAR_MIDNIGHT_UTC, DATETIME_FORMAT, 'UTC')).toBe(
+          baseline,
+        );
+      }
+    } finally {
+      if (original === undefined) delete process.env.TZ;
+      else process.env.TZ = original;
+    }
+  });
+
+  test('demonstrates the bug it guards against: default-zone formatting diverges', () => {
+    // Sanity-check that the timezones we picked actually produce different
+    // wall-clock text — i.e. the old `toLocale*` approach really was unsafe.
+    const utc = formatInTimeZone(NEAR_MIDNIGHT_UTC, DATETIME_FORMAT, 'UTC');
+    const tokyo = formatInTimeZone(NEAR_MIDNIGHT_UTC, DATETIME_FORMAT, 'Asia/Tokyo');
+    expect(tokyo).not.toBe(utc); // Jun 7 11:30 PM (UTC) vs Jun 8 8:30 AM (JST)
+  });
+});

--- a/apps/web/src/components/ui/local-time.tsx
+++ b/apps/web/src/components/ui/local-time.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+/**
+ * Formats an instant in an explicit, fixed timezone so the output is
+ * deterministic regardless of the runtime's default timezone. Used for the
+ * server-rendered fallback (we always render in UTC on the server).
+ *
+ * Exported for tests: this is the invariant that prevents React hydration
+ * mismatch #418 — the server-rendered text must not depend on `process.env.TZ`.
+ */
+export function formatInTimeZone(
+  date: Date,
+  options: Intl.DateTimeFormatOptions,
+  timeZone: string,
+): string {
+  return new Intl.DateTimeFormat('en-US', { ...options, timeZone }).format(date);
+}
+
+export interface LocalTimeProps {
+  /** The instant to render — an ISO string, epoch ms, or Date. */
+  value: string | number | Date;
+  /** Intl formatting options (weekday/month/day/hour/minute/…). */
+  options?: Intl.DateTimeFormatOptions;
+  /** Rendered (verbatim) when `value` can't be parsed into a valid date. */
+  fallback?: string;
+  className?: string;
+}
+
+/**
+ * Renders a date/time that is safe to server-render.
+ *
+ * `toLocaleString`/`toLocaleDateString` format using the runtime's *default*
+ * timezone. During SSR that's the server (UTC); in the browser it's the user's
+ * timezone — so the two produce different text for the same instant and React
+ * throws a hydration mismatch (minified error #418, e.g. for a release dated
+ * near midnight UTC, or any time-of-day on the maintenance page).
+ *
+ * This component sidesteps that the same way `SessionTimeLabel` does: it renders
+ * a **timezone-stable UTC string on the server**, and only switches to the
+ * viewer's local timezone *after mount* (in `useEffect`, which never runs on the
+ * server). `suppressHydrationWarning` covers the one intentional, post-hydration
+ * text swap on this single element.
+ */
+export function LocalTime({ value, options, fallback, className }: LocalTimeProps) {
+  const date = value instanceof Date ? value : new Date(value);
+  const isValid = !Number.isNaN(date.getTime());
+
+  const fmtOptions: Intl.DateTimeFormatOptions = options ?? {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  };
+
+  // Server + first client render: a stable UTC string (identical in both).
+  const serverText = isValid ? formatInTimeZone(date, fmtOptions, 'UTC') : '';
+  const [text, setText] = useState(serverText);
+
+  useEffect(() => {
+    if (!isValid) return;
+    // After hydration, re-render in the viewer's own timezone/locale.
+    setText(new Intl.DateTimeFormat('en-US', fmtOptions).format(date));
+    // date / options are derived from props; stringify options for a stable dep.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [date.getTime(), JSON.stringify(fmtOptions), isValid]);
+
+  if (!isValid) {
+    return fallback !== undefined ? <span className={className}>{fallback}</span> : null;
+  }
+
+  return (
+    <span className={className} suppressHydrationWarning>
+      {text}
+    </span>
+  );
+}


### PR DESCRIPTION
## What

Fixes a production **React hydration mismatch (minified error #418)** caused by timezone-dependent date rendering in server components.

> Triage of Better Stack incident `8bc2dce807e38e8d6e7548d6be722bdbb58ecb32af7848cd2a5013144b0384f8`
> ([error page](https://errors.betterstack.com/team/t502678/errors/8bc2dce807e38e8d6e7548d6be722bdbb58ecb32af7848cd2a5013144b0384f8?s=2346967)) · env `prod` · app **Kortix Frontend (prod)** · event `new_error`.

## Root cause (one line)

Server components rendered dates with `toLocaleString` / `toLocaleDateString`, which format in the runtime's **default timezone** — UTC on the server, the viewer's zone in the browser — so the same instant produced **different text** and React's hydration text comparison failed.

## Evidence

- The error is React **#418** with `args[]=HTML`, `args[]=` (empty) → the "text content does not match server-rendered HTML" hydration family; the tree gets regenerated on the client. Reported frame `rD` in shared chunk `414c69f9-…js`.
- ClickHouse / Better Stack telemetry only carries the **API** source (`kortix_api`); there is no frontend logs source and **no correlated backend error** — confirming a purely client-side SSR hydration bug, not an API failure.
- Two server components rendered timezone-dependent text directly into SSR HTML:
  - **`/maintenance`** — rendered the scheduled window with `weekday`/`hour`/`minute`, so it diverged on essentially **every non-UTC visit**.
  - **`/changelog`** — rendered release dates that flip a **calendar day** across timezones for releases published near midnight UTC.
- Reproduced the divergence for `2026-06-07T23:30:00Z`:

  | timezone | datetime (maintenance) | date (changelog) |
  |---|---|---|
  | UTC (server) | `Sun, Jun 7, 11:30 PM` | `June 7, 2026` |
  | America/Los_Angeles | `Sun, Jun 7, 4:30 PM` | `June 7, 2026` |
  | Asia/Tokyo (client) | `Mon, Jun 8, 8:30 AM` | `June 8, 2026` |

  Server text ≠ client text ⇒ #418.
- The local `next build` emitted the **exact** chunk from the incident — `chunks/414c69f9-e0c657363ae93f0c.js` — confirming the fix targets the right surface.

## The fix

Adds a small client component `LocalTime` (`apps/web/src/components/ui/local-time.tsx`) that follows the repo's existing `SessionTimeLabel` pattern:

1. render a **timezone-stable UTC string on the server** (identical on the first client render), then
2. localize to the viewer's timezone **after mount** (`useEffect`, which never runs on the server), with
3. `suppressHydrationWarning` on the single element that intentionally swaps.

`/maintenance` and `/changelog` now render their dates through `LocalTime`; the old TZ-dependent `formatDateTime` / `formatDate` helpers are removed.

## Verification

- `pnpm --filter ./apps/web build` — ✅ green (the frontend CI gate; runs typecheck + lint).
- `bun test src/components/ui/local-time.test.ts` — ✅ 4/4. The regression test pins the invariant that the server-rendered text **does not depend on the host's default timezone**, and sanity-checks that the old default-zone approach really did diverge.
- `next lint` on all changed files — ✅ no warnings or errors.

## How to confirm resolution

After merge + promote, Better Stack error `8bc2dce…` should stop seeing new occurrences (auto-resolves once no longer observed). The `/maintenance` and `/changelog` pages should hydrate cleanly from any timezone.