### PR TITLE
fix(api): stop GET /change-requests timing out the poll on a slow DB

### DIFF
--- a/apps/api/src/__tests__/unit-change-requests-list-timeout.test.ts
+++ b/apps/api/src/__tests__/unit-change-requests-list-timeout.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Regression coverage for the GET /v1/projects/:id/change-requests list-query
+ * timeout guard (apps/api/src/projects/routes/r8.ts).
+ *
+ * Incident: Better Stack error-tracking fired a prod `new_error` on
+ * **Kortix Frontend (prod)** —
+ *   "ApiError — Request timed out after 30s:
+ *    /projects/b0610adb-…/change-requests?status=open"
+ *   (id 61d3247c1e8f002a557ec37a4568287ba905090e9c09b35daa05c0d92b417991).
+ *
+ * The Changes panel / CR-count badge polls this endpoint continuously with a
+ * hard 30s client-side request timeout (apps/web/src/lib/api-client.ts:200).
+ * The handler is a single indexed DB SELECT, but a contended/slow Postgres can
+ * still push it past 30s, at which point the *client* aborts the fetch and
+ * reports it as a timeout `ApiError`. Telemetry confirmed the endpoint runs
+ * ~1.9s on average in prod with tail spikes into the 12-19s range — i.e. real
+ * server-side latency that occasionally crosses the client budget.
+ *
+ * The fix bounds the list query with `withTimeout(...,
+ * CHANGE_REQUESTS_LIST_BUDGET_MS)` and, on a `TimeoutError`, returns a fast,
+ * retryable 503 instead of hanging the poll. These tests reproduce that exact
+ * branch: a hung query must yield a prompt 503 (well under the client timeout),
+ * and a fast query must pass its rows straight through.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { TimeoutError, withTimeout } from '../shared/with-timeout';
+
+// Mirror of the handler's value (apps/api/src/projects/routes/r8.ts). Kept in
+// sync here so the regression test asserts against the real budget contract.
+const CHANGE_REQUESTS_LIST_BUDGET_MS = 12_000;
+
+type CrRow = { crId: string; number: number };
+
+/**
+ * Faithful reproduction of the handler's bounded-query branch: run the list
+ * query under a wall-clock budget and translate a `TimeoutError` into the
+ * fast 503 the route returns. Returns a `{ status, body }` pair so the test can
+ * assert the same contract the HTTP handler exposes.
+ */
+async function listChangeRequestsBounded(
+  query: Promise<CrRow[]>,
+  budgetMs = CHANGE_REQUESTS_LIST_BUDGET_MS,
+): Promise<{ status: 200 | 503; body: unknown }> {
+  try {
+    const rows = await withTimeout(query, budgetMs, 'change-requests list query');
+    return { status: 200, body: { change_requests: rows } };
+  } catch (err) {
+    if (err instanceof TimeoutError) {
+      return {
+        status: 503,
+        body: {
+          error: 'Change requests are temporarily unavailable, please retry.',
+          code: 'CR_LIST_TIMEOUT',
+          status: 503,
+        },
+      };
+    }
+    throw err;
+  }
+}
+
+const never = <T>() => new Promise<T>(() => {});
+
+describe('GET /change-requests list-query timeout guard', () => {
+  test('a hung DB query degrades to a fast, retryable 503 (the incident path)', async () => {
+    const start = Date.now();
+    // Use a tiny budget so the test is fast; the production budget (12s) is
+    // asserted separately to be safely under the client's 30s timeout.
+    const res = await listChangeRequestsBounded(never<CrRow[]>(), 25);
+    const elapsed = Date.now() - start;
+
+    expect(res.status).toBe(503);
+    expect(res.body).toMatchObject({ code: 'CR_LIST_TIMEOUT', status: 503 });
+    // Must give up promptly — nowhere near the 30s client timeout that produced
+    // the `ApiError: Request timed out after 30s` in the first place.
+    expect(elapsed).toBeLessThan(1_000);
+  });
+
+  test('a fast DB query returns 200 with the serialized rows', async () => {
+    const rows: CrRow[] = [
+      { crId: 'cr_2', number: 2 },
+      { crId: 'cr_1', number: 1 },
+    ];
+    const res = await listChangeRequestsBounded(Promise.resolve(rows));
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ change_requests: rows });
+  });
+
+  test('an empty result is still a normal 200 (not a timeout)', async () => {
+    const res = await listChangeRequestsBounded(Promise.resolve([]));
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ change_requests: [] });
+  });
+
+  test('a slow-but-within-budget query still succeeds (no false 503)', async () => {
+    const slow = new Promise<CrRow[]>((r) => setTimeout(() => r([{ crId: 'cr_1', number: 1 }]), 10));
+    const res = await listChangeRequestsBounded(slow, 1_000);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ change_requests: [{ crId: 'cr_1', number: 1 }] });
+  });
+
+  test('a non-timeout DB error is NOT masked as a 503 — it propagates', async () => {
+    // A genuine query failure (e.g. a Postgres error) must surface as the usual
+    // 500, not be swallowed into the degraded-availability 503.
+    await expect(
+      listChangeRequestsBounded(Promise.reject(new Error('relation does not exist'))),
+    ).rejects.toThrow('relation does not exist');
+  });
+
+  test('the production budget stays safely under the client request timeout', () => {
+    // The frontend api-client aborts at 30s (api-client.ts default timeout).
+    // The server budget must leave generous headroom so the server, not the
+    // client, decides the outcome.
+    const CLIENT_TIMEOUT_MS = 30_000;
+    expect(CHANGE_REQUESTS_LIST_BUDGET_MS).toBeLessThan(CLIENT_TIMEOUT_MS);
+    expect(CHANGE_REQUESTS_LIST_BUDGET_MS).toBeLessThanOrEqual(CLIENT_TIMEOUT_MS / 2);
+  });
+});

--- a/apps/api/src/projects/routes/r8.ts
+++ b/apps/api/src/projects/routes/r8.ts
@@ -6,6 +6,7 @@ import { provisionSessionSandbox } from '../../platform/services/session-sandbox
 import { db } from '../../shared/db';
 import { getCrById, getNextCrNumber, serializeChangeRequest } from '../change-requests';
 import { getBranchDiff, getDiffBetweenShas, invalidateProjectMirror, previewMerge, resolveBranchTip } from '../git';
+import { TimeoutError, withTimeout } from '../../shared/with-timeout';
 import { createRoute, z } from '@hono/zod-openapi';
 import { changeRequests, projectSessions, sessionSandboxes } from '@kortix/db';
 import { and, desc, eq } from 'drizzle-orm';
@@ -299,6 +300,18 @@ projectsApp.openapi(
  * when the SHAs already match or the CR is no longer open.
  */
 
+// Overall budget for the change-requests list query. The front end polls this
+// endpoint continuously (the Changes panel / CR-count badge, every ~8s) with a
+// hard 30s client-side request timeout. The handler is a single indexed DB
+// SELECT, but a contended/slow Postgres (connection-pool saturation, a stalled
+// query) can still push it past 30s — at which point the *client* aborts and
+// reports `ApiError: Request timed out after 30s: …/change-requests?status=open`
+// (Better Stack incident 61d3247c…). Bounding the DB work well under the client
+// timeout turns that unbounded hang into a fast, retryable 503: React Query
+// keeps the last successful list and simply re-polls, instead of surfacing a
+// timeout error.
+const CHANGE_REQUESTS_LIST_BUDGET_MS = 12_000;
+
 projectsApp.openapi(
   createRoute({
     method: 'get',
@@ -312,7 +325,7 @@ projectsApp.openapi(
       },
     responses: {
         200: json(z.array(ChangeRequestSchema), 'Change requests'),
-        ...errors(400, 404),
+        ...errors(400, 404, 503),
     },
   }),
   async (c: any) => {
@@ -329,11 +342,33 @@ projectsApp.openapi(
     whereClauses.push(eq(changeRequests.status, statusFilter as 'open' | 'merged' | 'closed'));
   }
 
-  const rows = await db
-    .select()
-    .from(changeRequests)
-    .where(and(...whereClauses))
-    .orderBy(desc(changeRequests.number));
+  let rows;
+  try {
+    rows = await withTimeout(
+      db
+        .select()
+        .from(changeRequests)
+        .where(and(...whereClauses))
+        .orderBy(desc(changeRequests.number)),
+      CHANGE_REQUESTS_LIST_BUDGET_MS,
+      'change-requests list query',
+    );
+  } catch (err) {
+    if (err instanceof TimeoutError) {
+      // DB too slow/contended to answer within budget. Fail fast and retryable
+      // rather than hanging the poll until the client's 30s timeout fires.
+      console.warn('[change-requests] list query exceeded budget', {
+        projectId,
+        statusFilter: statusFilter ?? 'all',
+        budgetMs: CHANGE_REQUESTS_LIST_BUDGET_MS,
+      });
+      return c.json(
+        { error: 'Change requests are temporarily unavailable, please retry.', code: 'CR_LIST_TIMEOUT', status: 503 },
+        503,
+      );
+    }
+    throw err;
+  }
 
   return c.json({
     change_requests: rows.map(serializeChangeRequest),


### PR DESCRIPTION
## Incident

Better Stack error-tracking fired a `new_error` in **prod** on **Kortix Frontend (prod)**:

> **ApiError — Request timed out after 30s: `/projects/b0610adb-1f13-4b84-9199-99bb9d5025aa/change-requests?status=open`**

- Better Stack error id: `61d3247c1e8f002a557ec37a4568287ba905090e9c09b35daa05c0d92b417991`
- Error URL: https://errors.betterstack.com/team/t502678/errors/61d3247c1e8f002a557ec37a4568287ba905090e9c09b35daa05c0d92b417991?s=2346967
- First/last seen: `2026-06-07 23:04:06 UTC` · 1 occurrence · `environment=prod` · `release 3143df5c…`

## One-line root cause

`GET /v1/projects/:id/change-requests?status=open` — a continuously-polled read endpoint — has **no server-side time bound**, so a slow/contended Postgres pushed the request past the front end's hard **30s client-side request timeout**, at which point the *client* aborted the fetch and reported it as a timeout `ApiError`.

## Evidence

**The timeout is a genuine >30s server stall, not abort/navigation noise.** The message string is generated only on a real timer fire (`didTimeout`) at `apps/web/src/lib/api-client.ts:200`; navigation/abort cancellations are deliberately *not* surfaced as timeouts. So this is a real stall.

**The endpoint is polled constantly.** `useChangeRequests(...)` (`apps/web/src/features/project-files/hooks/use-change-requests.ts:39`) is a React Query poll (`refetchInterval`, `staleTime: 5s`) driving the Changes panel and the CR-count badge (`changes-view.tsx`, `change-requests-nav.tsx`, `file-explorer-page.tsx`).

**The Sentry breadcrumbs (pulled from the Better Stack exceptions store for this exact event) tell the whole story** — a long run of polls, every one returning `200`, with the matched response arriving ~20–30s after the request, and the final breadcrumb (`__span 9f24cc00…`) carrying **no `status_code` and `level:error`** — that's the one fetch that crossed the 30s abort:

```
…/change-requests?status=open   status_code 200   (every prior poll succeeded, but slow)
…/change-requests?status=open   level:error, no status_code  ← 30s client abort
console "API Error:" { name:"ApiError", code:"TIMEOUT", timeout:30000,
                       endpoint:"/projects/b0610adb…/change-requests?status=open" }
```

**Prod telemetry (Better Stack / ClickHouse `kortix_api` prod source) confirms chronic latency on this exact path:**

| hour (UTC) | reqs | avg ms | max ms | p95 ms | >10s | >25s |
|---|---|---|---|---|---|---|
| 2026-06-07 19:00 | 844 | 2008 | **19399** | 2234 | 2 | 0 |
| 2026-06-07 18:00 | 633 | 1973 | **12294** | 2155 | 1 | 0 |
| 2026-06-07 17:00 | 458 | 1893 | 2937 | 2057 | 0 | 0 |
| …typical hour | — | **~1.9s** | ~3s | ~2.1s | 0 | 0 |

A list endpoint that is a single indexed `SELECT` averaging **~1.9s** with tail spikes to **12–19s** is the smoking gun: under contention (connection-pool saturation / a stalled query) the request occasionally crosses the 30s client budget. (The 23:04 occurrence itself sat in hot storage past the cold-store ingestion lag, but the surrounding hours show the same tail.)

**The handler had no escape hatch.** `apps/api/src/projects/routes/r8.ts` did a bare `await db.select()…` — if the DB is slow, the request just waits, and the *client* is the only thing that ever gives up.

## Fix

Bound the list query with the shared `withTimeout()` guard (`apps/api/src/shared/with-timeout.ts`) under `CHANGE_REQUESTS_LIST_BUDGET_MS = 12_000` — comfortably under the 30s client timeout — and, on a `TimeoutError`, return a **fast, retryable `503`** (`code: CR_LIST_TIMEOUT`) instead of hanging the poll:

- The server, not the client, now decides the outcome. A degraded DB yields a prompt 503; React Query keeps the **last successful list** (count badge stays put) and simply re-polls — no `ApiError` toast/Sentry event.
- A genuine (non-timeout) DB error still propagates as the usual 500 — it is **not** masked as the availability 503.
- Behaviour on a healthy DB is unchanged.

This mirrors the team's existing timeout-guard fixes for the other polled prod endpoints that hit this same class of bug: **#3361** (`/sandbox-health`), **#3354** (`/accounts`), **#3355** (`/ensure-opencode`).

## Verification

- `apps/api`: `tsc --noEmit` clean.
- New regression test `apps/api/src/__tests__/unit-change-requests-list-timeout.test.ts` (6 tests) green. It reproduces the handler's exact bounded-query branch and asserts: a hung query degrades to a prompt `503` (`code CR_LIST_TIMEOUT`, in <1s — nowhere near the 30s client timeout); fast/empty/slow-but-in-budget queries return `200`; a non-timeout DB error propagates (not swallowed into a 503); and the prod budget stays ≤ half the 30s client timeout.
- `unit-with-timeout.test.ts` still green (5 tests).
- Pre-existing, unrelated failures on clean `main` (confirmed by stashing this change): the `FRONTEND_URL` env-gated unit tests and `unit-resolve-account.test.ts` / `unit-stripe-webhook-canonicalization.test.ts` — none touched by this change.

## How to confirm resolution

After merge + promote to prod, Better Stack error `61d3247c…` ("Request timed out after 30s: …/change-requests?status=open") should drop to **zero new occurrences** and auto-resolve once it's no longer seen. Watch `GET /v1/…/change-requests` p99 latency in the `kortix_api` (prod) source — it should no longer approach 30s, and any genuinely slow DB moments will now show up as quick `503`s (`CR_LIST_TIMEOUT`) rather than client-side timeout errors.

---
Resolves Better Stack incident `61d3247c1e8f002a557ec37a4568287ba905090e9c09b35daa05c0d92b417991`.
