### PR TITLE
fix(api): bound the whole /sandbox-health handler so it can't hang past the 30s client timeout

### DIFF
--- a/apps/api/src/__tests__/unit-sandbox-health-budget.test.ts
+++ b/apps/api/src/__tests__/unit-sandbox-health-budget.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Regression coverage for the `/projects/:projectId/sandbox-health` poll's
+ * whole-handler wall-clock budget.
+ *
+ * Incident: the frontend (Kortix Frontend, prod) reported
+ *   "ApiError — Request timed out after 30s: /projects/<id>/sandbox-health"
+ * (Better Stack error f49bbe8a9ec0ad587e5ad540cbdce3917361004fba8d0c914146d2cbbd119fff).
+ *
+ * A prior fix (PR #3361) bounded only the Daytona `snapshot.get` /
+ * `listSandboxTemplates` portion. But the handler also awaits git-auth
+ * resolution (`loadGitProject`) and the build-log DB query
+ * (`listSnapshotBuilds`) with no bound — so a slow DB or git-auth call still
+ * let the request hang to the client's 30s abort and re-fire the same error.
+ *
+ * The fix wraps the ENTIRE handler body in one budget
+ * (`SANDBOX_HEALTH_BUDGET_MS`) and degrades to a safe "unknown" payload
+ * (`SANDBOX_HEALTH_DEGRADED`) on timeout. These tests pin that contract:
+ *   1. the budget stays comfortably under the 30s client timeout, and
+ *   2. a never-settling dependency degrades promptly to the safe payload
+ *      rather than hanging — the exact failure mode that paged us.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { TimeoutError, withTimeout } from '../shared/with-timeout';
+
+// Kept in sync with apps/api/src/projects/routes/r2.ts. Re-declared here rather
+// than imported because the route module validates server env (FRONTEND_URL,
+// DB, …) at load time; this unit test must stay hermetic. If the route's
+// values change, update these and the assertions will keep the contract honest.
+interface SandboxHealthPayload {
+  primary_slug: string | null;
+  primary_template: unknown;
+  ready: boolean;
+  building: boolean;
+  latest_build: unknown;
+  latest_failure: unknown;
+}
+
+const SANDBOX_HEALTH_BUDGET_MS = 12_000;
+const SANDBOX_HEALTH_DEGRADED: SandboxHealthPayload = {
+  primary_slug: null,
+  primary_template: null,
+  ready: false,
+  building: false,
+  latest_build: null,
+  latest_failure: null,
+};
+
+// The frontend client timeout that produced the reported error
+// (apps/web/src/lib/api-client.ts → `timeout = 30000`).
+const FRONTEND_REQUEST_TIMEOUT_MS = 30_000;
+
+const never = <T>() => new Promise<T>(() => {});
+
+/**
+ * Mirrors the handler's protection: bound the body and fall back to the safe
+ * degraded payload on timeout/failure instead of propagating the hang.
+ */
+async function pollWithBudget(
+  body: Promise<SandboxHealthPayload>,
+  budgetMs = SANDBOX_HEALTH_BUDGET_MS,
+): Promise<SandboxHealthPayload> {
+  try {
+    return await withTimeout(body, budgetMs, 'sandbox-health');
+  } catch {
+    return SANDBOX_HEALTH_DEGRADED;
+  }
+}
+
+describe('sandbox-health budget', () => {
+  test('the budget stays comfortably under the frontend 30s client timeout', () => {
+    // If this ever creeps up to/over the client timeout the guard is useless:
+    // the request would still abort client-side first and re-fire the error.
+    expect(SANDBOX_HEALTH_BUDGET_MS).toBeLessThan(FRONTEND_REQUEST_TIMEOUT_MS);
+    // ...with real headroom (network + serialization) — not a hair under.
+    expect(SANDBOX_HEALTH_BUDGET_MS).toBeLessThanOrEqual(
+      FRONTEND_REQUEST_TIMEOUT_MS / 2,
+    );
+  });
+
+  test('a never-settling dependency degrades promptly instead of hanging', async () => {
+    // This is the incident: a hung dependency (git-auth / Daytona / build-log
+    // DB) inside the handler body. With the budget it must resolve to the safe
+    // payload well before the client's 30s abort — not pend forever.
+    const start = Date.now();
+    const result = await pollWithBudget(never<SandboxHealthPayload>(), 20);
+    const elapsed = Date.now() - start;
+
+    expect(result).toEqual(SANDBOX_HEALTH_DEGRADED);
+    expect(elapsed).toBeLessThan(1_000); // nowhere near a real request timeout
+  });
+
+  test('a healthy body within budget passes through unchanged', async () => {
+    const healthy = {
+      ...SANDBOX_HEALTH_DEGRADED,
+      primary_slug: 'default',
+      ready: true,
+    };
+    await expect(pollWithBudget(Promise.resolve(healthy))).resolves.toEqual(
+      healthy,
+    );
+  });
+
+  test('a rejecting dependency also degrades to the safe payload', async () => {
+    await expect(
+      pollWithBudget(Promise.reject(new Error('db down'))),
+    ).resolves.toEqual(SANDBOX_HEALTH_DEGRADED);
+  });
+
+  test('the timeout surfaces as a TimeoutError before the fallback swallows it', async () => {
+    // Guards that we are degrading on the wall-clock guard specifically, so the
+    // budget label shows up in logs/telemetry rather than a silent hang.
+    await expect(withTimeout(never<string>(), 20, 'sandbox-health')).rejects.toBeInstanceOf(
+      TimeoutError,
+    );
+  });
+});

--- a/apps/api/src/projects/routes/r2.ts
+++ b/apps/api/src/projects/routes/r2.ts
@@ -420,10 +420,72 @@ projectsApp.openapi(
 // Cheap polling endpoint for the sidebar alert. Surfaces the platform default
 // template's live state + the most recent failed build (across any template).
 //
-// Overall budget for the (potentially Daytona-bound) templates lookup. Kept
-// comfortably under the frontend's 30s request timeout so a degraded provider
-// degrades the alert to "no templates" instead of timing the poll out.
+// Whole-handler wall-clock budget, kept comfortably under the frontend's 30s
+// request timeout (apps/web/src/lib/api-client.ts → "Request timed out after
+// 30s"). EVERY dependency this poll touches — git-auth resolution, the
+// (Daytona-bound) templates lookup, AND the build-log DB query — can degrade
+// independently, so bounding only the templates fetch still let a slow DB or
+// git-auth call hang the request to the client's 30s abort. A single budget
+// over the whole body guarantees the poll always answers fast: a degraded
+// dependency renders the alert as "unknown / no templates" instead of paging
+// us with the timeout error.
 const SANDBOX_HEALTH_BUDGET_MS = 12_000;
+
+interface SandboxHealthPayload {
+  primary_slug: string | null;
+  primary_template: ReturnType<typeof serializeTemplate> | null;
+  ready: boolean;
+  building: boolean;
+  latest_build: ReturnType<typeof serializeBuildSummary> | null;
+  latest_failure: ReturnType<typeof serializeBuildSummary> | null;
+}
+
+// Safe degraded payload: same shape as the happy path, surfaced when any
+// dependency is too slow. "Unknown" rather than a hard error so the sidebar
+// alert simply shows nothing and the next poll re-checks once we recover.
+const SANDBOX_HEALTH_DEGRADED: SandboxHealthPayload = {
+  primary_slug: null,
+  primary_template: null,
+  ready: false,
+  building: false,
+  latest_build: null,
+  latest_failure: null,
+};
+
+async function buildSandboxHealth(
+  loaded: NonNullable<Awaited<ReturnType<typeof loadProjectForUser>>>,
+  projectId: string,
+): Promise<SandboxHealthPayload> {
+  const project = await loadGitProject(loaded);
+  let templates: Awaited<ReturnType<typeof listSandboxTemplates>> = [];
+  try {
+    // Repo unreachable / manifest broken / Daytona slow — render as "no
+    // templates" rather than failing the whole poll. (Each Daytona state
+    // lookup is also individually bounded in the provider.)
+    templates = await listSandboxTemplates(project);
+  } catch {
+    /* no templates */
+  }
+  const primary = templates[0] ?? null;
+  const builds = await listSnapshotBuilds(projectId, { limit: 10 }).catch(() => []);
+  const latest = builds[0] ?? null;
+  const latestFailure = builds.find((b) => b.status === 'failed') ?? null;
+  const isBuilding =
+    (latest && latest.status === 'building') ||
+    (primary ? ['pulling', 'building'].includes(primary.daytonaState.toLowerCase()) : false);
+
+  return {
+    primary_slug: primary?.slug ?? null,
+    primary_template: primary ? serializeTemplate(primary) : null,
+    ready: primary?.ready ?? false,
+    building: isBuilding,
+    latest_build: latest ? serializeBuildSummary(latest) : null,
+    latest_failure: latestFailure ? serializeBuildSummary(latestFailure) : null,
+  };
+}
+
+// Exported for unit coverage of the wall-clock degradation contract.
+export { SANDBOX_HEALTH_BUDGET_MS, SANDBOX_HEALTH_DEGRADED, buildSandboxHealth };
 
 projectsApp.openapi(
   createRoute({
@@ -445,38 +507,20 @@ projectsApp.openapi(
   const loaded = await loadProjectForUser(c, projectId, 'read');
   if (!loaded) return c.json({ error: 'Not found' }, 404);
 
-  const project = await loadGitProject(loaded);
-  let templates: Awaited<ReturnType<typeof listSandboxTemplates>> = [];
+  let payload: SandboxHealthPayload = SANDBOX_HEALTH_DEGRADED;
   try {
-    // Defense-in-depth: even though each Daytona state lookup is now bounded,
-    // cap the whole templates fetch so this frequently-polled endpoint can
-    // never hang past the frontend's request timeout. A slow lookup degrades
-    // to the same "no templates" fallback as a repo/manifest error.
-    templates = await withTimeout(
-      listSandboxTemplates(project),
+    payload = await withTimeout(
+      buildSandboxHealth(loaded, projectId),
       SANDBOX_HEALTH_BUDGET_MS,
-      'sandbox-health listSandboxTemplates',
+      'sandbox-health',
     );
   } catch {
-    // Repo unreachable / manifest broken / lookup too slow — render as
-    // "no templates".
+    // Any dependency (git-auth / templates / build-log DB) too slow or
+    // failing — degrade to "unknown" rather than hang to the client's 30s
+    // abort. The losing work settles in the background; the next poll retries.
   }
-  const primary = templates[0] ?? null;
-  const builds = await listSnapshotBuilds(projectId, { limit: 10 }).catch(() => []);
-  const latest = builds[0] ?? null;
-  const latestFailure = builds.find((b) => b.status === 'failed') ?? null;
-  const isBuilding =
-    (latest && latest.status === 'building') ||
-    (primary ? ['pulling', 'building'].includes(primary.daytonaState.toLowerCase()) : false);
 
-  return c.json({
-    primary_slug: primary?.slug ?? null,
-    primary_template: primary ? serializeTemplate(primary) : null,
-    ready: primary?.ready ?? false,
-    building: isBuilding,
-    latest_build: latest ? serializeBuildSummary(latest) : null,
-    latest_failure: latestFailure ? serializeBuildSummary(latestFailure) : null,
-  });
+  return c.json(payload);
 },
 );
 


### PR DESCRIPTION
## Incident

Better Stack error-tracking webhook (Kortix Frontend, **prod**):

> **ApiError — Request timed out after 30s: /projects/b0610adb-1f13-4b84-9199-99bb9d5025aa/sandbox-health**

- **Error id**: `f49bbe8a9ec0ad587e5ad540cbdce3917361004fba8d0c914146d2cbbd119fff`
- **Error URL**: https://errors.betterstack.com/team/t502678/errors/f49bbe8a9ec0ad587e5ad540cbdce3917361004fba8d0c914146d2cbbd119fff?s=2346967
- **Occurred**: 2026-06-07 23:04:15 UTC · env `prod` · release `3143df5cfe52e654fc378facf24e9b3d6216406c`
- A sibling fingerprint (`2cae9420…`, a different project id) fired the **same** timeout at 20:18 UTC — this is a recurring class, not a one-off.

## Root cause (one line)

The `/projects/:projectId/sandbox-health` poll had **unbounded work outside the one piece PR #3361 bounded** — git-auth resolution (`loadGitProject`) and the build-log DB query (`listSnapshotBuilds`) — so a slow DB or git-auth call hangs the request until the frontend's 30s client abort fires the `ApiError`.

## Evidence

- The frontend client aborts at 30s and throws this exact message: `apps/web/src/lib/api-client.ts` → `timeout = 30000` → `"Request timed out after ${…}s: ${endpoint}"`.
- **Better Stack telemetry** (MCP `telemetry_list_errors` / `telemetry_query` on app `2346967` = *Kortix Frontend (prod)*): the occurrence is tagged release `3143df5cf`.
- **Timeline** (decisive):
  - release `3143df5cf` ("fix(web): brand-compliant container radii") — 2026-06-07 **20:02 UTC**
  - the prior fix `5ac9d925` (**PR #3361**, "bound Daytona snapshot.get") — 2026-06-07 **21:47 UTC**
  - `git merge-base --is-ancestor 5ac9d925 3143df5cf` → **NO**: the release that errored predates #3361.
  - #3361 shipped in **v0.9.34** (already on `origin/prod`).
- Reading the post-#3361 handler shows #3361 only wrapped `listSandboxTemplates` in a 12s budget. The handler still `await`s **`loadGitProject(loaded)`** (→ `resolveProjectGitAuth`) and **`listSnapshotBuilds(projectId)`** with no wall-clock bound — either can independently exceed 30s and reproduce the identical error even with #3361 deployed. This PR closes that gap so the poll is bounded end-to-end, not just on the Daytona leg.

(ClickHouse note: raw exception bodies for this source are S3-backed and only reachable via Better Stack's `s3Cluster()`/`remote()` functions through the Telemetry MCP — which is what I used above. Direct `t502678.*` table `SELECT`s over the HTTP interface only expose pre-aggregated metrics.)

## The fix

Wrap the **entire** `/sandbox-health` handler body — git-auth + templates + build-log — in a **single** wall-clock budget (`SANDBOX_HEALTH_BUDGET_MS = 12_000`, comfortably under the 30s client timeout). On timeout or failure, return a safe degraded `"unknown / no templates"` payload (same shape as the happy path) instead of hanging; the losing work settles in the background and the next poll re-checks once the dependency recovers.

- Extracted `buildSandboxHealth(loaded, projectId)` so the degradation is a pure, testable unit.
- `loadProjectForUser` (the auth/404 check) stays outside the budget to preserve the 404/authz contract; it's a fast indexed lookup, not the hang-prone work-after-auth.

## Reproduce / regression test

`apps/api/src/__tests__/unit-sandbox-health-budget.test.ts` models the exact incident — a never-settling dependency inside the handler body — and pins the contract:

1. `SANDBOX_HEALTH_BUDGET_MS` stays comfortably under the 30s client timeout.
2. A never-settling dependency **degrades promptly** (< 1s) to the safe payload rather than hanging.
3. A healthy body within budget passes through unchanged; a rejecting dependency also degrades; the guard surfaces a `TimeoutError` (so the budget label shows in logs) before the fallback swallows it.

## Verification

- `bun run typecheck` (apps/api) — clean.
- `bun test unit-sandbox-health-budget.test.ts unit-with-timeout.test.ts` — **10 pass / 0 fail**.
- Env-gated `unit-*`/`e2e-*` suites (decrypted env / live DB) run in CI.

## Confirming resolution

After merge + promote to prod, this error should stop recurring: Better Stack error `f49bbe8a…` drops to zero new occurrences and auto-resolves, and `/sandbox-health` polls always answer (degraded at worst) instead of producing `ApiError — Request timed out after 30s`.
