### PR TITLE
fix(api): support SSE MCP connectors

### DIFF
--- a/apps/api/src/__tests__/unit-connectors-parse.test.ts
+++ b/apps/api/src/__tests__/unit-connectors-parse.test.ts
@@ -149,6 +149,29 @@ url = "https://mcp.example.com"
     expect(specs[0]).toMatchObject({ transport: 'http' });
   });
 
+  test('mcp /sse URL infers sse transport', () => {
+    const { specs } = parseAndExtract(`
+[[connectors]]
+slug = "vault"
+provider = "mcp"
+url = "https://mcp.example.com/sse"
+`);
+    expect(specs[0]).toMatchObject({ transport: 'sse' });
+  });
+
+  test('mcp URL normalizes scheme whitespace before transport inference', () => {
+    const { specs } = parseAndExtract(`
+[[connectors]]
+slug = "vault"
+provider = "mcp"
+url = "https ://mcp.example.com/sse"
+`);
+    expect(specs[0]).toMatchObject({
+      url: 'https://mcp.example.com/sse',
+      transport: 'sse',
+    });
+  });
+
   test('http — base_url + custom query auth + prefix', () => {
     const { specs, errors } = parseAndExtract(`
 [[connectors]]

--- a/apps/api/src/executor/db-deps.ts
+++ b/apps/api/src/executor/db-deps.ts
@@ -94,6 +94,12 @@ function baseUrlOf(row: ConnectorRow): string | null {
   }
 }
 
+function mcpTransportOf(row: ConnectorRow): 'http' | 'sse' | null {
+  if (row.providerType !== 'mcp') return null;
+  const cfg = (row.config ?? {}) as Record<string, any>;
+  return cfg.transport === 'sse' ? 'sse' : 'http';
+}
+
 function toGatewayConnector(row: ConnectorRow, grants: Awaited<ReturnType<typeof loadConnectorGrants>>): GatewayConnector {
   const { auth, hasAuth } = authOf(row);
   return {
@@ -101,6 +107,7 @@ function toGatewayConnector(row: ConnectorRow, grants: Awaited<ReturnType<typeof
     slug: row.slug,
     provider: row.providerType,
     baseUrl: baseUrlOf(row),
+    mcpTransport: mcpTransportOf(row),
     auth,
     hasAuth,
     shareScope: row.shareScope as 'project' | 'restricted',

--- a/apps/api/src/executor/execute.ts
+++ b/apps/api/src/executor/execute.ts
@@ -33,6 +33,7 @@ export interface ExecResult {
 }
 
 const NO_AUTH: ExecutorAuth = { type: 'none', in: 'header', name: null, prefix: null };
+export type McpTransport = 'http' | 'sse';
 
 /** Attach a credential to a request per the connector's auth method. */
 export function applyAuth(
@@ -196,6 +197,46 @@ export function buildGraphqlRequest(opts: {
   return { url, method: 'POST', headers, body: JSON.stringify({ query }) };
 }
 
+function withAuth(
+  url: string,
+  headers: Record<string, string>,
+  auth: ExecutorAuth,
+  secret: string | null,
+): { url: string; headers: Record<string, string> } {
+  const query = new URLSearchParams();
+  const nextHeaders = { ...headers };
+  applyAuth(nextHeaders, query, auth, secret);
+  const qs = query.toString();
+  return {
+    url: qs ? `${url}${url.includes('?') ? '&' : '?'}${qs}` : url,
+    headers: nextHeaders,
+  };
+}
+
+/** Build a JSON-RPC request for an MCP streamable-HTTP connector. */
+export function buildMcpJsonRpcRequest(opts: {
+  url: string;
+  auth?: ExecutorAuth;
+  secret?: string | null;
+  id?: number;
+  method: string;
+  params?: Record<string, unknown>;
+}): BuiltRequest {
+  const req = withAuth(
+    opts.url,
+    { 'Content-Type': 'application/json', Accept: 'application/json, text/event-stream' },
+    opts.auth ?? NO_AUTH,
+    opts.secret ?? null,
+  );
+  const body = JSON.stringify({
+    jsonrpc: '2.0',
+    id: opts.id ?? 1,
+    method: opts.method,
+    params: opts.params ?? {},
+  });
+  return { url: req.url, method: 'POST', headers: req.headers, body };
+}
+
 /** Build a JSON-RPC `tools/call` request for an MCP (http transport) connector. */
 export function buildMcpRequest(opts: {
   url: string;
@@ -204,22 +245,13 @@ export function buildMcpRequest(opts: {
   toolName: string;
   args?: Record<string, unknown>;
 }): BuiltRequest {
-  const headers: Record<string, string> = {
-    'Content-Type': 'application/json',
-    Accept: 'application/json, text/event-stream',
-  };
-  const query = new URLSearchParams();
-  applyAuth(headers, query, opts.auth ?? NO_AUTH, opts.secret ?? null);
-  let url = opts.url;
-  const qs = query.toString();
-  if (qs) url += (url.includes('?') ? '&' : '?') + qs;
-  const body = JSON.stringify({
-    jsonrpc: '2.0',
-    id: 1,
+  return buildMcpJsonRpcRequest({
+    url: opts.url,
+    auth: opts.auth,
+    secret: opts.secret,
     method: 'tools/call',
     params: { name: opts.toolName, arguments: opts.args ?? {} },
   });
-  return { url, method: 'POST', headers, body };
 }
 
 export type FetchImpl = (url: string, init: { method: string; headers: Record<string, string>; body?: string }) => Promise<{
@@ -259,6 +291,201 @@ export async function performRequest(req: BuiltRequest, fetchImpl: FetchImpl): P
   return { status: res.status, ok: res.ok, data: parseResponseBody(text) };
 }
 
+interface SseState {
+  buffer: string;
+}
+
+interface SseFrame {
+  event: string;
+  data: string;
+}
+
+function shiftSseFrame(state: SseState): SseFrame | null {
+  const match = state.buffer.match(/\r?\n\r?\n/);
+  if (!match || match.index === undefined) return null;
+  const raw = state.buffer.slice(0, match.index);
+  state.buffer = state.buffer.slice(match.index + match[0].length);
+
+  const frame: SseFrame = { event: 'message', data: '' };
+  for (const line of raw.split(/\r?\n/)) {
+    if (line.startsWith('event:')) frame.event = line.slice(6).trim();
+    if (line.startsWith('data:')) {
+      frame.data += `${frame.data ? '\n' : ''}${line.slice(5).trim()}`;
+    }
+  }
+  return frame;
+}
+
+async function readSseFrame(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  decoder: TextDecoder,
+  state: SseState,
+  timeoutMs: number,
+): Promise<SseFrame> {
+  const queued = shiftSseFrame(state);
+  if (queued) return queued;
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    const chunk = await Promise.race([
+      reader.read(),
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error('timed out waiting for MCP SSE response')), timeoutMs);
+      }),
+    ]);
+    if (chunk.done) throw new Error('MCP SSE stream closed');
+    state.buffer += decoder.decode(chunk.value, { stream: true });
+    const frame = shiftSseFrame(state);
+    if (frame) return frame;
+    return readSseFrame(reader, decoder, state, timeoutMs);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+async function waitForSseJsonRpc(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  decoder: TextDecoder,
+  state: SseState,
+  id: number,
+  timeoutMs: number,
+): Promise<any> {
+  for (;;) {
+    const frame = await readSseFrame(reader, decoder, state, timeoutMs);
+    if (!frame.data) continue;
+    try {
+      const parsed = JSON.parse(frame.data);
+      if (parsed?.id === id) return parsed;
+    } catch {
+      // Ignore non-JSON keepalive/data frames.
+    }
+  }
+}
+
+async function waitForSseEndpoint(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  decoder: TextDecoder,
+  state: SseState,
+  timeoutMs: number,
+): Promise<string> {
+  for (;;) {
+    const frame = await readSseFrame(reader, decoder, state, timeoutMs);
+    if (frame.event === 'endpoint' && frame.data) return frame.data;
+  }
+}
+
+async function postSseJsonRpc(
+  endpointUrl: string,
+  auth: ExecutorAuth,
+  secret: string | null,
+  message: Record<string, unknown>,
+): Promise<void> {
+  const req = withAuth(
+    endpointUrl,
+    { 'Content-Type': 'application/json', Accept: 'application/json, text/event-stream' },
+    auth,
+    secret,
+  );
+  const res = await fetch(req.url, {
+    method: 'POST',
+    headers: req.headers,
+    body: JSON.stringify(message),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`MCP SSE message POST failed (${res.status}): ${text || res.statusText}`);
+  }
+}
+
+async function performMcpSseJsonRpc(opts: {
+  url: string;
+  auth?: ExecutorAuth;
+  secret?: string | null;
+  method: string;
+  params?: Record<string, unknown>;
+  timeoutMs?: number;
+}): Promise<ExecResult> {
+  const timeoutMs = opts.timeoutMs ?? 30_000;
+  const auth = opts.auth ?? NO_AUTH;
+  const secret = opts.secret ?? null;
+  const controller = new AbortController();
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  let reader: ReadableStreamDefaultReader<Uint8Array> | null = null;
+
+  try {
+    timeout = setTimeout(() => controller.abort(), timeoutMs);
+    const sseReq = withAuth(opts.url, { Accept: 'text/event-stream' }, auth, secret);
+    const sse = await fetch(sseReq.url, { method: 'GET', headers: sseReq.headers, signal: controller.signal });
+    if (!sse.ok) {
+      const text = await sse.text().catch(() => '');
+      return { status: sse.status, ok: false, data: parseResponseBody(text) };
+    }
+    if (!sse.body) throw new Error('MCP SSE response had no body');
+
+    reader = sse.body.getReader();
+    const decoder = new TextDecoder();
+    const state: SseState = { buffer: '' };
+    const endpointPath = await waitForSseEndpoint(reader, decoder, state, timeoutMs);
+    const endpointUrl = new URL(endpointPath, sseReq.url).href;
+
+    await postSseJsonRpc(endpointUrl, auth, secret, {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2024-11-05',
+        capabilities: {},
+        clientInfo: { name: 'kortix-executor', version: '1' },
+      },
+    });
+    await waitForSseJsonRpc(reader, decoder, state, 1, timeoutMs);
+    await postSseJsonRpc(endpointUrl, auth, secret, {
+      jsonrpc: '2.0',
+      method: 'notifications/initialized',
+      params: {},
+    });
+    await postSseJsonRpc(endpointUrl, auth, secret, {
+      jsonrpc: '2.0',
+      id: 2,
+      method: opts.method,
+      params: opts.params ?? {},
+    });
+    const data = await waitForSseJsonRpc(reader, decoder, state, 2, timeoutMs);
+    return { status: 200, ok: !data?.error, data };
+  } catch (err) {
+    const message = err instanceof Error && err.name === 'AbortError'
+      ? 'MCP SSE request timed out'
+      : (err as Error).message;
+    return { status: 0, ok: false, data: message };
+  } finally {
+    if (timeout) clearTimeout(timeout);
+    await reader?.cancel().catch(() => undefined);
+    controller.abort();
+  }
+}
+
+export async function performMcpJsonRpc(opts: {
+  url: string;
+  auth?: ExecutorAuth;
+  secret?: string | null;
+  method: string;
+  params?: Record<string, unknown>;
+  transport?: McpTransport | null;
+  fetchImpl: FetchImpl;
+}): Promise<ExecResult> {
+  if ((opts.transport ?? 'http') === 'sse') {
+    return performMcpSseJsonRpc(opts);
+  }
+  const req = buildMcpJsonRpcRequest({
+    url: opts.url,
+    auth: opts.auth,
+    secret: opts.secret,
+    method: opts.method,
+    params: opts.params,
+  });
+  return performRequest(req, opts.fetchImpl);
+}
+
 /**
  * Top-level execute — dispatch by binding kind, build the request, perform it.
  * `secret` is the resolved plaintext credential (server-side only).
@@ -270,6 +497,7 @@ export async function executeCall(opts: {
   secret?: string | null;
   args?: Record<string, unknown>;
   paramHints?: Record<string, ParamLoc>;
+  mcpTransport?: McpTransport | null;
   fetchImpl: FetchImpl;
 }): Promise<ExecResult> {
   const { binding } = opts;
@@ -305,14 +533,15 @@ export async function executeCall(opts: {
 
   if (binding.kind === 'mcp') {
     if (!opts.baseUrl) throw new Error('mcp connector has no url');
-    const req = buildMcpRequest({
+    return performMcpJsonRpc({
       url: opts.baseUrl,
       auth: opts.auth,
       secret: opts.secret,
-      toolName: binding.tool,
-      args: opts.args,
+      method: 'tools/call',
+      params: { name: binding.tool, arguments: opts.args ?? {} },
+      transport: opts.mcpTransport,
+      fetchImpl: opts.fetchImpl,
     });
-    return performRequest(req, opts.fetchImpl);
   }
 
   if (binding.kind === 'graphql') {

--- a/apps/api/src/executor/gateway.ts
+++ b/apps/api/src/executor/gateway.ts
@@ -30,6 +30,8 @@ export interface GatewayConnector {
   provider: 'pipedream' | 'mcp' | 'openapi' | 'graphql' | 'http';
   /** server / base_url / endpoint / url, per provider (null for some). */
   baseUrl: string | null;
+  /** MCP transport. Non-MCP connectors leave this unset. */
+  mcpTransport?: 'http' | 'sse' | null;
   auth: ExecutorAuth;
   /** Whether this connector needs a credential at all (false = public/no-auth). */
   hasAuth: boolean;
@@ -229,6 +231,7 @@ export async function handleCall(deps: GatewayDeps, input: CallInput): Promise<C
         secret: usable.secret,
         args: input.args ?? {},
         paramHints: paramHintsFromSchema(action.inputSchema),
+        mcpTransport: connector.mcpTransport,
         fetchImpl: deps.fetchImpl,
       });
     }

--- a/apps/api/src/executor/manifest-crud.ts
+++ b/apps/api/src/executor/manifest-crud.ts
@@ -9,7 +9,14 @@ import { and, eq } from 'drizzle-orm';
 import { executorConnectors, projects } from '@kortix/db';
 import { db } from '../shared/db';
 import { commitManifest, loadManifestForEdit } from '../projects/index';
-import { extractConnectors, type ConnectorPolicySpec, type ConnectorPolicyAction, type ConnectorSpec } from '../projects/connectors';
+import {
+  extractConnectors,
+  inferMcpTransport,
+  normalizeMcpUrl,
+  type ConnectorPolicySpec,
+  type ConnectorPolicyAction,
+  type ConnectorSpec,
+} from '../projects/connectors';
 import { isValidMatcher } from './policy';
 import {
   extractProjectPolicies,
@@ -50,8 +57,10 @@ function draftToEntry(d: ConnectorDraft): Record<string, unknown> {
     if (d.app) entry.app = d.app;
     if (d.account) entry.account = d.account;
   } else if (d.provider === 'mcp') {
-    if (d.url) entry.url = d.url;
+    const url = d.url ? normalizeMcpUrl(d.url) : null;
+    if (url) entry.url = url;
     if (d.transport) entry.transport = d.transport;
+    else if (url && inferMcpTransport(url) === 'sse') entry.transport = 'sse';
   } else if (d.provider === 'graphql') {
     if (d.endpoint) entry.endpoint = d.endpoint;
     if (d.spec) entry.spec = d.spec;

--- a/apps/api/src/executor/sync.ts
+++ b/apps/api/src/executor/sync.ts
@@ -31,7 +31,7 @@ import {
   normalizePipedream,
 } from './normalize';
 import type { NormalizedAction, HttpRouteSpec } from './types';
-import { parseResponseBody } from './execute';
+import { performMcpJsonRpc, type FetchImpl, type McpTransport } from './execute';
 import { connectorConfig, toPolicyRows, toProjectPolicyRows } from './materialize';
 import { pipedreamCatalog, pipedreamConfigured } from './pipedream';
 
@@ -228,7 +228,7 @@ export async function resolveCatalog(project: GitBackedProject, spec: ConnectorS
         return { actions: normalizeGraphql(introspection), server: spec.endpoint };
       }
       case 'mcp': {
-        const tools = await listMcpTools(spec.url!);
+        const tools = await listMcpTools(spec.url!, spec.transport ?? 'http');
         return { actions: normalizeMcp(tools), server: spec.url };
       }
       case 'pipedream': {
@@ -303,13 +303,24 @@ async function reconcileProjectPolicies(
     });
 }
 
-async function listMcpTools(url: string): Promise<any[]> {
-  const res = await fetch(url, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json', Accept: 'application/json, text/event-stream' },
-    body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} }),
+const nodeFetch: FetchImpl = async (url, init) => {
+  const res = await fetch(url, { method: init.method, headers: init.headers, body: init.body });
+  return { status: res.status, ok: res.ok, text: () => res.text() };
+};
+
+async function listMcpTools(url: string, transport: McpTransport): Promise<any[]> {
+  const result = await performMcpJsonRpc({
+    url,
+    method: 'tools/list',
+    params: {},
+    transport,
+    fetchImpl: nodeFetch,
   });
-  // Streamable-HTTP MCP responds with SSE-framed JSON, not plain JSON.
-  const json: any = parseResponseBody(await res.text());
-  return json?.result?.tools ?? [];
+  if (!result.ok) {
+    const reason = typeof result.data === 'string'
+      ? result.data
+      : JSON.stringify(result.data ?? {});
+    throw new Error(reason || `MCP tools/list failed (${result.status})`);
+  }
+  return (result.data as any)?.result?.tools ?? [];
 }

--- a/apps/api/src/projects/connectors.ts
+++ b/apps/api/src/projects/connectors.ts
@@ -115,6 +115,19 @@ export interface LoadedConnectors {
 
 const NO_AUTH: ConnectorAuthSpec = { type: 'none', in: 'header', name: null, prefix: null, secret: null };
 
+export function inferMcpTransport(url: string): 'http' | 'sse' {
+  try {
+    const parsed = new URL(url);
+    return /(^|\/)sse\/?$/i.test(parsed.pathname) ? 'sse' : 'http';
+  } catch {
+    return /\/sse\/?(?:[?#]|$)/i.test(url) ? 'sse' : 'http';
+  }
+}
+
+export function normalizeMcpUrl(url: string): string {
+  return url.trim().replace(/^([a-z][a-z0-9+.-]*)\s*:\s*\/\//i, '$1://');
+}
+
 /**
  * Pull `[[connectors]]` out of a parsed manifest. Never throws.
  */
@@ -340,9 +353,10 @@ function parseProviderFields(
   }
 
   if (provider === 'mcp') {
-    const url = str(row.url);
-    if (!url) return err(slug, 'provider="mcp" requires `url` (the MCP server endpoint)');
-    const t = typeof row.transport === 'string' ? row.transport.trim().toLowerCase() : 'http';
+    const rawUrl = str(row.url);
+    if (!rawUrl) return err(slug, 'provider="mcp" requires `url` (the MCP server endpoint)');
+    const url = normalizeMcpUrl(rawUrl);
+    const t = typeof row.transport === 'string' ? row.transport.trim().toLowerCase() : inferMcpTransport(url);
     if (t !== 'http' && t !== 'sse') {
       return err(slug, `transport must be "http" or "sse" (got "${t}")`);
     }


### PR DESCRIPTION
## Summary
- add MCP SSE JSON-RPC transport support for discovery and execution
- infer SSE transport for `/sse` MCP endpoints and normalize malformed URL schemes before parsing
- persist inferred MCP transport in connector manifests and gateway wiring

## Tests
- `git diff --check`
- `bun test apps/api/src/__tests__/unit-connectors-parse.test.ts apps/api/src/__tests__/unit-executor-execute.test.ts apps/api/src/__tests__/unit-executor-materialize.test.ts`
- `bunx tsc -p apps/api/tsconfig.json --noEmit --ignoreDeprecations 6.0`