### PR TITLE
fix(api): allow tokenless manifest git writes

### DIFF
--- a/apps/api/src/projects/lib/triggers.ts
+++ b/apps/api/src/projects/lib/triggers.ts
@@ -821,9 +821,6 @@ export async function commitManifest(
   } catch (err) {
     return { error: `Git auth unavailable: ${(err as Error).message || String(err)}`, status: 502 };
   }
-  if (!gitProject.gitAuthToken) {
-    return { error: 'No git credentials available to write to the project repo', status: 502 };
-  }
 
   try {
     await commitFileToBranch(gitProject, {


### PR DESCRIPTION
## Summary
- allow manifest commits to proceed for tokenless git remotes instead of failing before git runs
- keep private/non-interactive remotes protected by the existing `GIT_TERMINAL_PROMPT=0` git behavior

## Tests
- `git diff --check`
- `bunx tsc -p apps/api/tsconfig.json --noEmit --ignoreDeprecations 6.0`