### PR TITLE
fix(web): preserve public origin auth redirects

### DIFF
--- a/apps/web/src/app/auth/callback/route.ts
+++ b/apps/web/src/app/auth/callback/route.ts
@@ -5,6 +5,7 @@ import type { NextRequest } from 'next/server'
 import { ACTIVE_INSTANCE_COOKIE } from '@/lib/instance-routes'
 import { sanitizeAuthReturnUrl } from '@/lib/auth/return-url'
 import { buildDesktopBounceHtml } from '@/lib/auth/desktop-bounce'
+import { getPublicRequestOrigin } from '@/lib/request-origin'
 
 /**
  * Auth Callback Route - Web Handler
@@ -43,10 +44,10 @@ export async function GET(request: NextRequest) {
     })
   }
 
-  // Use request origin for redirects (most reliable for local dev)
-  // This ensures localhost:3000 redirects stay on localhost, not staging
-  const requestOrigin = request.nextUrl.origin
-  const baseUrl = requestOrigin || runtimeEnv.APP_URL || 'http://localhost:3000'
+  // Use the public browser origin for redirects. Behind self-hosted reverse
+  // proxies, Next may see its internal listener (for example localhost:3001)
+  // as request.nextUrl.origin, which must never leak into Location headers.
+  const baseUrl = getPublicRequestOrigin(request, runtimeEnv.APP_URL)
   const error = searchParams.get('error')
   const errorCode = searchParams.get('error_code')
   const errorDescription = searchParams.get('error_description')

--- a/apps/web/src/lib/request-origin.test.mts
+++ b/apps/web/src/lib/request-origin.test.mts
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { getPublicRequestOrigin, getPublicRequestUrl } from './request-origin.ts'
+
+function request(url: string, headers: Record<string, string | undefined> = {}) {
+  const parsed = new URL(url)
+  const lowerHeaders = new Map(
+    Object.entries(headers)
+      .filter((entry): entry is [string, string] => typeof entry[1] === 'string')
+      .map(([key, value]) => [key.toLowerCase(), value]),
+  )
+
+  return {
+    url,
+    nextUrl: {
+      origin: parsed.origin,
+      pathname: parsed.pathname,
+      search: parsed.search,
+    },
+    headers: {
+      get(name: string) {
+        return lowerHeaders.get(name.toLowerCase()) ?? null
+      },
+    },
+  }
+}
+
+test('uses the forwarded public host instead of the internal Next origin', () => {
+  const req = request('https://localhost:3001/projects', {
+    host: 'ai.kplxr.com',
+    'x-forwarded-proto': 'https',
+  })
+
+  assert.equal(getPublicRequestOrigin(req, 'https://ai.kplxr.com'), 'https://ai.kplxr.com')
+  assert.equal(getPublicRequestUrl(req, '/auth').toString(), 'https://ai.kplxr.com/auth')
+})
+
+test('falls back to configured public app origin when only loopback host is visible', () => {
+  const req = request('https://localhost:3001/projects', {
+    host: 'localhost:3001',
+    'x-forwarded-host': 'localhost:3001',
+    'x-forwarded-proto': 'https',
+  })
+
+  assert.equal(getPublicRequestOrigin(req, 'https://ai.kplxr.com'), 'https://ai.kplxr.com')
+})
+
+test('preserves normal localhost development origins', () => {
+  const req = request('http://localhost:3000/projects', {
+    host: 'localhost:3000',
+    'x-forwarded-proto': 'http',
+  })
+
+  assert.equal(getPublicRequestOrigin(req, 'http://localhost:3000'), 'http://localhost:3000')
+})

--- a/apps/web/src/lib/request-origin.ts
+++ b/apps/web/src/lib/request-origin.ts
@@ -1,0 +1,98 @@
+type HeaderMap = {
+  get(name: string): string | null;
+};
+
+type RequestLike = {
+  headers: HeaderMap;
+  url: string;
+  nextUrl?: {
+    origin?: string;
+    pathname?: string;
+    search?: string;
+  };
+};
+
+function firstHeaderValue(value?: string | null): string | null {
+  const first = value?.split(',')[0]?.trim();
+  return first || null;
+}
+
+function normalizeOrigin(value?: string | null): string | null {
+  if (!value || value.startsWith('encrypted:')) return null;
+
+  const candidate = /^https?:\/\//i.test(value) ? value : `https://${value}`;
+  try {
+    const url = new URL(candidate);
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') return null;
+    return url.origin;
+  } catch {
+    return null;
+  }
+}
+
+function originFromUrl(value?: string | null): string | null {
+  try {
+    return value ? new URL(value).origin : null;
+  } catch {
+    return null;
+  }
+}
+
+function isExactLoopbackOrigin(origin?: string | null): boolean {
+  if (!origin) return false;
+  try {
+    const { hostname } = new URL(origin);
+    return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1' || hostname === '[::1]';
+  } catch {
+    return false;
+  }
+}
+
+function originFromRequestHeaders(request: RequestLike): string | null {
+  const hosts = [
+    firstHeaderValue(request.headers.get('x-forwarded-host')),
+    firstHeaderValue(request.headers.get('host')),
+  ].filter((host): host is string => !!host && !/[\s/\\]/.test(host));
+
+  const proto =
+    firstHeaderValue(request.headers.get('x-forwarded-proto')) ||
+    originFromUrl(request.url)?.split(':')[0] ||
+    'https';
+
+  const origins = hosts
+    .map((host) => normalizeOrigin(`${proto}://${host}`))
+    .filter((origin): origin is string => !!origin);
+
+  return origins.find((origin) => !isExactLoopbackOrigin(origin)) || origins[0] || null;
+}
+
+export function getConfiguredPublicAppOrigin(): string | null {
+  return normalizeOrigin(
+    process.env.KORTIX_PUBLIC_APP_URL ||
+      process.env.NEXT_PUBLIC_APP_URL ||
+      process.env.NEXT_PUBLIC_URL ||
+      process.env.PUBLIC_URL,
+  );
+}
+
+export function getPublicRequestOrigin(
+  request: RequestLike,
+  configuredAppUrl: string | null = getConfiguredPublicAppOrigin(),
+): string {
+  const headerOrigin = originFromRequestHeaders(request);
+  const configuredOrigin = normalizeOrigin(configuredAppUrl);
+  const requestOrigin = normalizeOrigin(request.nextUrl?.origin) || originFromUrl(request.url);
+
+  if (headerOrigin && !isExactLoopbackOrigin(headerOrigin)) return headerOrigin;
+  if (isExactLoopbackOrigin(requestOrigin) && configuredOrigin) return configuredOrigin;
+
+  return headerOrigin || requestOrigin || configuredOrigin || 'http://localhost:3000';
+}
+
+export function getPublicRequestUrl(
+  request: RequestLike,
+  path: string = `${request.nextUrl?.pathname || new URL(request.url).pathname}${request.nextUrl?.search || new URL(request.url).search}`,
+  configuredAppUrl?: string | null,
+): URL {
+  return new URL(path, getPublicRequestOrigin(request, configuredAppUrl ?? getConfiguredPublicAppOrigin()));
+}

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -7,6 +7,7 @@ import { detectBestLocaleFromHeaders } from '@/lib/utils/geo-detection-server';
 import { KORTIX_SUPABASE_AUTH_COOKIE } from '@/lib/supabase/constants';
 import { ACTIVE_INSTANCE_COOKIE } from '@/lib/instance-routes';
 import { getMaintenanceConfig, type MaintenanceLevel } from '@/lib/maintenance-store';
+import { getPublicRequestUrl } from '@/lib/request-origin';
 
 // Marketing pages that support locale routing for SEO (/de, /it, etc.)
 const MARKETING_ROUTES = [
@@ -87,6 +88,27 @@ const DESKTOP_ALLOWED_ROUTES = [
   '/debug',
 ];
 
+function clearSupabaseAuthCookies(request: NextRequest, response: NextResponse) {
+  const names = new Set<string>([KORTIX_SUPABASE_AUTH_COOKIE]);
+  for (const cookie of request.cookies.getAll()) {
+    if (
+      cookie.name === KORTIX_SUPABASE_AUTH_COOKIE ||
+      cookie.name.startsWith(`${KORTIX_SUPABASE_AUTH_COOKIE}.`) ||
+      cookie.name.startsWith(`${KORTIX_SUPABASE_AUTH_COOKIE}-`)
+    ) {
+      names.add(cookie.name);
+    }
+  }
+
+  for (const name of names) {
+    response.cookies.set(name, '', {
+      path: '/',
+      maxAge: 0,
+      sameSite: 'lax',
+    });
+  }
+}
+
 export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
@@ -116,7 +138,7 @@ export async function middleware(request: NextRequest) {
     try {
       const config = await getMaintenanceConfig();
       if (config.level === 'blocking') {
-        return NextResponse.redirect(new URL('/maintenance', request.url));
+        return NextResponse.redirect(getPublicRequestUrl(request, '/maintenance'));
       }
     } catch {
       // If Edge Config is unreachable, don't block traffic
@@ -136,7 +158,7 @@ export async function middleware(request: NextRequest) {
     // If we have Supabase auth parameters, redirect to /auth/callback
     // Note: Mobile apps use direct deep links and bypass this route
     if (code || token || type || error) {
-      const callbackUrl = new URL('/auth/callback', request.url);
+      const callbackUrl = getPublicRequestUrl(request, '/auth/callback');
 
       // Preserve all query parameters
       searchParams.forEach((value, key) => {
@@ -164,7 +186,7 @@ export async function middleware(request: NextRequest) {
         route => pathname === route || pathname.startsWith(route + '/'),
       );
     if (!isAllowed) {
-      return NextResponse.redirect(new URL('/projects', request.url));
+      return NextResponse.redirect(getPublicRequestUrl(request, '/projects'));
     }
   }
 
@@ -273,12 +295,12 @@ export async function middleware(request: NextRequest) {
 
   // FAST PATH: authenticated users hitting the homepage go straight to /projects.
   if (pathname === '/' && user) {
-    return NextResponse.redirect(new URL('/projects', request.url));
+    return NextResponse.redirect(getPublicRequestUrl(request, '/projects'));
   }
 
   // Desktop shell never shows the marketing homepage — bounce to /projects.
   if (pathname === '/' && request.headers.get('user-agent')?.includes('KortixDesktop')) {
-    return NextResponse.redirect(new URL('/projects', request.url));
+    return NextResponse.redirect(getPublicRequestUrl(request, '/projects'));
   }
 
   // Auto-redirect based on geo-detection for marketing pages
@@ -309,7 +331,7 @@ export async function middleware(request: NextRequest) {
       // Only redirect if detected locale is not English (default)
       // This prevents unnecessary redirects for English speakers
       if (detectedLocale !== defaultLocale) {
-        const redirectUrl = new URL(request.url);
+        const redirectUrl = getPublicRequestUrl(request);
         redirectUrl.pathname = `/${detectedLocale}${pathname === '/' ? '' : pathname}`;
 
         const redirectResponse = NextResponse.redirect(redirectUrl);
@@ -337,11 +359,13 @@ export async function middleware(request: NextRequest) {
 
     // Redirect to auth if not authenticated (using the user we already fetched)
     if (authError || !user) {
-      const url = request.nextUrl.clone();
+      const url = getPublicRequestUrl(request);
       url.pathname = '/auth';
       const redirectTarget = `${pathname}${request.nextUrl.search || ''}`;
       url.searchParams.set('redirect', redirectTarget);
-      return NextResponse.redirect(url);
+      const redirectResponse = NextResponse.redirect(url);
+      clearSupabaseAuthCookies(request, redirectResponse);
+      return redirectResponse;
     }
 
     // ── Billing-related routes (activate-trial, etc.) ────────────────────


### PR DESCRIPTION
## Summary
- derive auth callback redirects from forwarded/public request origin instead of loopback internal origins
- fall back to configured public app origins when only local/internal hosts are visible
- clear stale Supabase auth cookie chunks when redirecting unauthenticated protected routes

## Tests
- `git diff --check`
- `bun test apps/web/src/lib/request-origin.test.mts`
- `npx eslint src/lib/request-origin.ts src/lib/request-origin.test.mts src/app/auth/callback/route.ts src/middleware.ts` (from `apps/web`)