### PR TITLE
perf(web): defer session route workbench loading

### DIFF
--- a/apps/web/src/app/projects/[id]/sessions/[sessionId]/page.tsx
+++ b/apps/web/src/app/projects/[id]/sessions/[sessionId]/page.tsx
@@ -3,6 +3,7 @@
 import { useTranslations } from 'next-intl';
 
 import { useEffect, useRef, type ReactNode } from 'react';
+import dynamic from 'next/dynamic';
 import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Loader2, RotateCcw } from 'lucide-react';
@@ -11,8 +12,6 @@ import { useAuth } from '@/components/AuthProvider';
 import { useAccountState } from '@/hooks/billing';
 import { useUpgradeDialogStore } from '@/stores/upgrade-dialog-store';
 import { isBillingEnabled } from '@/lib/config';
-import { SessionChat } from '@/components/session/session-chat';
-import { SessionLayout } from '@/components/session/session-layout';
 import { SessionLoadingSkeleton } from '@/components/session/session-loading-skeleton';
 import { ProjectShell } from '@/components/projects/project-shell';
 import { Button } from '@/components/ui/button';
@@ -37,6 +36,16 @@ import {
   useCanonicalOpenCodeSession,
 } from '@/hooks/opencode/use-canonical-opencode-session';
 import { finishSessionTiming, sessionMark } from '@/lib/session-timing';
+
+const SessionLayout = dynamic(
+  () => import('@/components/session/session-layout').then((mod) => mod.SessionLayout),
+  { loading: () => <SessionLoadingSkeleton /> },
+);
+
+const SessionChat = dynamic(
+  () => import('@/components/session/session-chat').then((mod) => mod.SessionChat),
+  { loading: () => <SessionLoadingSkeleton /> },
+);
 
 /**
  * /projects/[id]/sessions/[sessionId] — project-scoped session view.

--- a/apps/web/src/components/projects/project-session-list.tsx
+++ b/apps/web/src/components/projects/project-session-list.tsx
@@ -2,9 +2,9 @@
 
 import { useTranslations } from 'next-intl';
 
-import { useState, memo } from 'react';
+import { useCallback, useEffect, useState, memo } from 'react';
 import Link from 'next/link';
-import { usePathname, useSearchParams } from 'next/navigation';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { Loader2, MoreHorizontal, Pencil, RotateCcw, Share2, Trash2 } from 'lucide-react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { formatDistanceToNowStrict } from 'date-fns';
@@ -34,13 +34,14 @@ import { cn } from '@/lib/utils';
 import { toast } from '@/lib/toast';
 import {
   deleteProjectSession,
+  getProjectSessionSandbox,
   listProjectSessions,
   restartProjectSession,
   type ProjectSession,
   type ProjectOpenCodeSession,
   type ProjectSessionStatus,
 } from '@/lib/projects-client';
-import { SessionShareDialog } from '@/components/projects/session-share-dialog';
+import { SessionShareDialog, SessionVisibilityBadge } from '@/components/projects/session-share-dialog';
 import { RenameSessionDialog } from '@/components/projects/rename-session-dialog';
 
 interface ProjectSessionListProps {
@@ -72,6 +73,7 @@ function directSubsessions(session: ProjectSession): ProjectOpenCodeSession[] {
 
 export function ProjectSessionList({ projectId }: ProjectSessionListProps) {
   const tHardcodedUi = useTranslations('hardcodedUi');
+  const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const activeOpenCodeSessionId = searchParams.get('oc');
@@ -79,6 +81,7 @@ export function ProjectSessionList({ projectId }: ProjectSessionListProps) {
   const [sessionToDelete, setSessionToDelete] = useState<{ id: string; label: string } | null>(null);
   const [sessionToShare, setSessionToShare] = useState<ProjectSession | null>(null);
   const [sessionToRename, setSessionToRename] = useState<{ id: string; name: string } | null>(null);
+  const [pendingHref, setPendingHref] = useState<string | null>(null);
 
   const { data, isLoading, error } = useQuery({
     queryKey: ['project-sessions', projectId],
@@ -92,24 +95,41 @@ export function ProjectSessionList({ projectId }: ProjectSessionListProps) {
   const deleteMutation = useMutation({
     mutationFn: (sessionId: string) => deleteProjectSession(projectId, sessionId),
     onSuccess: () => {
-      toast.success('Session deleted');
+      toast.success(tHardcodedUi.raw('componentsProjectsProjectSessionList.sessionDeleted'));
       queryClient.invalidateQueries({ queryKey: ['project-sessions', projectId] });
     },
     onError: (err) => {
-      toast.error(err instanceof Error ? err.message : 'Failed to delete session');
+      toast.error(err instanceof Error ? err.message : tHardcodedUi.raw('componentsProjectsProjectSessionList.failedToDeleteSession'));
     },
   });
 
   const restartMutation = useMutation({
     mutationFn: (sessionId: string) => restartProjectSession(projectId, sessionId),
     onSuccess: () => {
-      toast.success('Restarting session…');
+      toast.success(tHardcodedUi.raw('componentsProjectsProjectSessionList.restartingSession'));
       queryClient.invalidateQueries({ queryKey: ['project-sessions', projectId] });
     },
     onError: (err) => {
-      toast.error(err instanceof Error ? err.message : 'Failed to restart session');
+      toast.error(err instanceof Error ? err.message : tHardcodedUi.raw('componentsProjectsProjectSessionList.failedToRestartSession'));
     },
   });
+
+  useEffect(() => {
+    setPendingHref(null);
+  }, [pathname, activeOpenCodeSessionId]);
+
+  const prefetchProjectSession = useCallback(
+    (sessionId: string, href?: string) => {
+      const nextHref = href ?? `/projects/${projectId}/sessions/${sessionId}`;
+      router.prefetch(nextHref);
+      queryClient.prefetchQuery({
+        queryKey: ['project', 'session-sandbox', projectId, sessionId],
+        queryFn: () => getProjectSessionSandbox(projectId, sessionId),
+        staleTime: 15_000,
+      });
+    },
+    [projectId, queryClient, router],
+  );
 
   if (isLoading) {
     return (
@@ -151,8 +171,11 @@ export function ProjectSessionList({ projectId }: ProjectSessionListProps) {
                 session={session}
                 href={href}
                 isActive={!!isActive && !activeOpenCodeSessionId}
+                isPending={pendingHref === href}
                 titleOverride={root?.title ?? undefined}
                 childCount={children.length}
+                onNavigateStart={() => setPendingHref(href)}
+                onPrefetch={() => prefetchProjectSession(session.session_id, href)}
                 onDelete={(id, label) => setSessionToDelete({ id, label })}
                 onShare={(s) => setSessionToShare(s)}
                 onRename={(id, name) => setSessionToRename({ id, name })}
@@ -171,10 +194,13 @@ export function ProjectSessionList({ projectId }: ProjectSessionListProps) {
                     return (
                       <ProjectSubsessionRow
                         key={child.id}
-                        title={child.title || 'Sub-session'}
+                        title={child.title || tHardcodedUi.raw('componentsProjectsProjectSessionList.subSession')}
                         href={childHref}
                         isActive={activeChild}
+                        isPending={pendingHref === childHref}
                         updatedAt={child.updated_at}
+                        onNavigateStart={() => setPendingHref(childHref)}
+                        onPrefetch={() => prefetchProjectSession(session.session_id, childHref)}
                       />
                     );
                   })}
@@ -212,7 +238,7 @@ export function ProjectSessionList({ projectId }: ProjectSessionListProps) {
               <span className="font-medium text-foreground">{sessionToDelete?.label}</span>{tHardcodedUi.raw('componentsProjectsProjectSessionList.line193JsxTextThisActionCannotBeUndone')}</AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogCancel>{tHardcodedUi.raw('componentsProjectsProjectSessionList.cancel')}</AlertDialogCancel>
             <AlertDialogAction
               onClick={() => {
                 if (sessionToDelete) {
@@ -221,7 +247,7 @@ export function ProjectSessionList({ projectId }: ProjectSessionListProps) {
                 }
               }}
             >
-              Delete
+              {tHardcodedUi.raw('componentsProjectsProjectSessionList.delete')}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
@@ -239,6 +265,9 @@ interface ProjectSessionRowProps {
   onRename: (sessionId: string, currentName: string) => void;
   onRestart: (sessionId: string) => void;
   isRestarting: boolean;
+  isPending: boolean;
+  onNavigateStart: () => void;
+  onPrefetch: () => void;
   titleOverride?: string;
   childCount?: number;
 }
@@ -252,6 +281,9 @@ const ProjectSessionRow = memo(function ProjectSessionRow({
   onRename,
   onRestart,
   isRestarting,
+  isPending,
+  onNavigateStart,
+  onPrefetch,
   titleOverride,
   childCount = 0,
 }: ProjectSessionRowProps) {
@@ -277,7 +309,9 @@ const ProjectSessionRow = memo(function ProjectSessionRow({
     session.name?.trim() ||
     legacyMetadataName?.trim() ||
     null;
-  const fallback = session.branch_name ? session.branch_name.slice(0, 14) : 'session';
+  const fallback = session.branch_name
+    ? session.branch_name.slice(0, 14)
+    : tHardcodedUi.raw('componentsProjectsProjectSessionList.sessionFallback');
   const displayTitle = titleCandidate || fallback;
 
   const relative = (() => {
@@ -292,8 +326,14 @@ const ProjectSessionRow = memo(function ProjectSessionRow({
     <Link
       href={href}
       className="block"
-      onMouseEnter={() => setIsHovering(true)}
+      onMouseEnter={() => {
+        setIsHovering(true);
+        onPrefetch();
+      }}
       onMouseLeave={() => setIsHovering(false)}
+      onFocus={onPrefetch}
+      onPointerDown={onPrefetch}
+      onClick={onNavigateStart}
     >
       <div
         className={cn(
@@ -301,27 +341,33 @@ const ProjectSessionRow = memo(function ProjectSessionRow({
           // Active reads distinctly from hover: solid fill + a left accent bar,
           // while hover is only a half-strength wash. (Before, active and hover
           // shared the same background, so a selected row looked merely hovered.)
-          isActive
+          isActive || isPending
             ? 'bg-sidebar-accent text-sidebar-foreground font-medium'
             : 'text-muted-foreground hover:bg-sidebar-accent/50 hover:text-sidebar-foreground',
         )}
       >
-        {isActive && (
+        {(isActive || isPending) && (
           <span
             aria-hidden
             className="absolute inset-y-1.5 left-0 w-[2px] rounded-r-full bg-foreground"
           />
         )}
-        <SessionStatusDot status={session.status} />
+        {isPending && !isActive ? (
+          <Loader2 className="h-3 w-3 flex-shrink-0 animate-spin text-muted-foreground" />
+        ) : (
+          <SessionStatusDot status={session.status} />
+        )}
 
         <span
           className={cn(
             'flex-1 truncate text-sm',
-            isActive && 'font-medium',
+            (isActive || isPending) && 'font-medium',
           )}
         >
           {displayTitle}
         </span>
+
+        <SessionVisibilityBadge session={session} />
 
         {childCount > 0 && (
           <span className="rounded-full bg-sidebar-accent/60 px-1.5 py-0.5 text-xs tabular-nums text-muted-foreground">
@@ -371,7 +417,7 @@ const ProjectSessionRow = memo(function ProjectSessionRow({
                 }}
               >
                 <Pencil className="h-4 w-4" />
-                Rename…
+                {tHardcodedUi.raw('componentsProjectsProjectSessionList.rename')}
               </DropdownMenuItem>
               {session.can_manage_sharing !== false && (
                 <DropdownMenuItem
@@ -384,7 +430,7 @@ const ProjectSessionRow = memo(function ProjectSessionRow({
                   }}
                 >
                   <Share2 className="h-4 w-4" />
-                  Share…
+                  {tHardcodedUi.raw('componentsProjectsProjectSessionList.share')}
                 </DropdownMenuItem>
               )}
               <DropdownMenuItem
@@ -402,7 +448,7 @@ const ProjectSessionRow = memo(function ProjectSessionRow({
                 ) : (
                   <RotateCcw className="h-4 w-4" />
                 )}
-                Restart
+                {tHardcodedUi.raw('componentsProjectsProjectSessionList.restart')}
               </DropdownMenuItem>
               <DropdownMenuItem
                 className="cursor-pointer"
@@ -414,7 +460,7 @@ const ProjectSessionRow = memo(function ProjectSessionRow({
                 }}
               >
                 <Trash2 className="h-4 w-4" />
-                Delete
+                {tHardcodedUi.raw('componentsProjectsProjectSessionList.delete')}
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
@@ -428,29 +474,46 @@ function ProjectSubsessionRow({
   title,
   href,
   isActive,
+  isPending,
   updatedAt,
+  onNavigateStart,
+  onPrefetch,
 }: {
   title: string;
   href: string;
   isActive: boolean;
+  isPending: boolean;
   updatedAt: number | null;
+  onNavigateStart: () => void;
+  onPrefetch: () => void;
 }) {
   const relative = updatedAt
     ? shortRelative(formatDistanceToNowStrict(new Date(updatedAt), { addSuffix: false }))
     : '';
 
   return (
-    <Link href={href} className="block">
+    <Link
+      href={href}
+      className="block"
+      onMouseEnter={onPrefetch}
+      onFocus={onPrefetch}
+      onPointerDown={onPrefetch}
+      onClick={onNavigateStart}
+    >
       <div
         className={cn(
           'flex h-8 cursor-pointer items-center gap-2 rounded-lg px-2 text-sm transition-colors duration-150',
-          isActive
+          isActive || isPending
             ? 'bg-sidebar-accent text-sidebar-foreground font-medium'
             : 'text-muted-foreground hover:bg-sidebar-accent/50 hover:text-sidebar-foreground',
         )}
       >
-        <span className="h-1 w-1 flex-shrink-0 rounded-full bg-muted-foreground/40" />
-        <span className={cn('flex-1 truncate', isActive && 'font-medium')}>
+        {isPending && !isActive ? (
+          <Loader2 className="h-3 w-3 flex-shrink-0 animate-spin text-muted-foreground" />
+        ) : (
+          <span className="h-1 w-1 flex-shrink-0 rounded-full bg-muted-foreground/40" />
+        )}
+        <span className={cn('flex-1 truncate', (isActive || isPending) && 'font-medium')}>
           {title}
         </span>
         {relative && (
@@ -464,6 +527,7 @@ function ProjectSubsessionRow({
 }
 
 function SessionStatusDot({ status }: { status: ProjectSessionStatus }) {
+  const tHardcodedUi = useTranslations('hardcodedUi');
   const isProvisioning =
     status === 'queued' || status === 'branching' || status === 'provisioning';
 
@@ -486,8 +550,8 @@ function SessionStatusDot({ status }: { status: ProjectSessionStatus }) {
           )}
         </div>
       </TooltipTrigger>
-      <TooltipContent side="right" className="text-xs capitalize">
-        {status}
+      <TooltipContent side="right" className="text-xs">
+        {tHardcodedUi.raw(`componentsProjectsProjectSessionList.status.${status}`)}
       </TooltipContent>
     </Tooltip>
   );

--- a/apps/web/src/components/projects/project-sidebar.tsx
+++ b/apps/web/src/components/projects/project-sidebar.tsx
@@ -25,7 +25,12 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from '@/components/ui/tooltip';
-import { listProjectSessions, type ProjectOpenCodeSession, type ProjectSession } from '@/lib/projects-client';
+import {
+  getProjectSessionSandbox,
+  listProjectSessions,
+  type ProjectOpenCodeSession,
+  type ProjectSession,
+} from '@/lib/projects-client';
 import { useProjectSessionTabsStore } from '@/stores/project-session-tabs-store';
 import { useCustomizeStore } from '@/stores/customize-store';
 
@@ -74,6 +79,7 @@ import { useAuth } from '@/components/AuthProvider';
 import { createProjectSession } from '@/lib/projects-client';
 import { toast } from '@/lib/toast';
 import { beginSessionTiming, markSessionClick, sessionMark } from '@/lib/session-timing';
+import { displayEmailFromUser, displayNameFromUser } from '@/lib/user-display';
 
 const isMac =
   typeof navigator !== 'undefined' &&
@@ -250,8 +256,10 @@ function ProjectSessionsFlyout({ projectId }: { projectId: string }) {
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const router = useRouter();
+  const queryClient = useQueryClient();
   const openTab = useProjectSessionTabsStore((s) => s.openTab);
   const activeOpenCodeSessionId = searchParams.get('oc');
+  const [pendingHref, setPendingHref] = useState<string | null>(null);
 
   const { data, isLoading } = useQuery({
     queryKey: ['project-sessions', projectId],
@@ -274,6 +282,23 @@ function ProjectSessionsFlyout({ projectId }: { projectId: string }) {
       (a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime(),
     );
   }, [data]);
+
+  useEffect(() => {
+    setPendingHref(null);
+  }, [pathname, activeOpenCodeSessionId]);
+
+  const prefetchProjectSession = useCallback(
+    (sessionId: string, href?: string) => {
+      const nextHref = href ?? `/projects/${projectId}/sessions/${sessionId}`;
+      router.prefetch(nextHref);
+      queryClient.prefetchQuery({
+        queryKey: ['project', 'session-sandbox', projectId, sessionId],
+        queryFn: () => getProjectSessionSandbox(projectId, sessionId),
+        staleTime: 15_000,
+      });
+    },
+    [projectId, queryClient, router],
+  );
 
   return (
     <div className="overflow-y-auto py-1 [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]">
@@ -307,17 +332,24 @@ function ProjectSessionsFlyout({ projectId }: { projectId: string }) {
           return (
             <div key={session.session_id}>
               <button
+                onMouseEnter={() => prefetchProjectSession(session.session_id, href)}
+                onFocus={() => prefetchProjectSession(session.session_id, href)}
+                onPointerDown={() => prefetchProjectSession(session.session_id, href)}
                 onClick={() => {
+                  setPendingHref(href);
                   openTab(projectId, session.session_id);
                   router.push(href);
                 }}
                 className={cn(
                   'flex items-center gap-2 w-full px-3 py-1.5 text-sm cursor-pointer transition-colors duration-100',
-                  active && !activeOpenCodeSessionId
+                  (active && !activeOpenCodeSessionId) || pendingHref === href
                     ? 'bg-sidebar-accent text-sidebar-accent-foreground font-medium'
                     : 'text-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-foreground',
                 )}
               >
+                {pendingHref === href && !(active && !activeOpenCodeSessionId) && (
+                  <Loader2 className="h-3 w-3 flex-shrink-0 animate-spin text-muted-foreground" />
+                )}
                 <span className="flex-1 truncate text-left">{label}</span>
                 {children.length > 0 && (
                   <span className="rounded-full bg-sidebar-accent/60 px-1.5 py-0.5 text-xs tabular-nums text-muted-foreground">
@@ -341,19 +373,29 @@ function ProjectSessionsFlyout({ projectId }: { projectId: string }) {
                     return (
                       <button
                         key={child.id}
+                        onMouseEnter={() => prefetchProjectSession(session.session_id, childHref)}
+                        onFocus={() => prefetchProjectSession(session.session_id, childHref)}
+                        onPointerDown={() => prefetchProjectSession(session.session_id, childHref)}
                         onClick={() => {
+                          setPendingHref(childHref);
                           openTab(projectId, session.session_id);
                           router.push(childHref);
                         }}
                         className={cn(
                           'flex h-8 w-full cursor-pointer items-center gap-2 rounded-lg px-2 text-sm transition-colors duration-100',
-                          childActive
+                          childActive || pendingHref === childHref
                             ? 'bg-sidebar-accent text-sidebar-accent-foreground font-medium'
                             : 'text-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-foreground',
                         )}
                       >
-                        <span className="h-1 w-1 flex-shrink-0 rounded-full bg-muted-foreground/40" />
-                        <span className="flex-1 truncate text-left">{child.title || 'Sub-session'}</span>
+                        {pendingHref === childHref && !childActive ? (
+                          <Loader2 className="h-3 w-3 flex-shrink-0 animate-spin text-muted-foreground" />
+                        ) : (
+                          <span className="h-1 w-1 flex-shrink-0 rounded-full bg-muted-foreground/40" />
+                        )}
+                        <span className="flex-1 truncate text-left">
+                          {child.title || tHardcodedUi.raw('componentsProjectsProjectSidebar.subSession')}
+                        </span>
                         {childRelative && (
                           <span className="flex-shrink-0 text-xs tabular-nums text-muted-foreground/60">
                             {childRelative}
@@ -392,11 +434,8 @@ export function ProjectSidebar({ projectId }: { projectId: string }) {
   const { user: authUser } = useAuth();
   const user = useMemo(
     () => ({
-      name:
-        authUser?.user_metadata?.name ||
-        authUser?.email?.split('@')[0] ||
-        'User',
-      email: authUser?.email ?? '',
+      name: displayNameFromUser(authUser),
+      email: displayEmailFromUser(authUser, ''),
       avatar:
         authUser?.user_metadata?.avatar_url ||
         authUser?.user_metadata?.picture ||
@@ -417,7 +456,7 @@ export function ProjectSidebar({ projectId }: { projectId: string }) {
     },
     onError: (err) => {
       if ((err as any)?.code === 'concurrent_session_limit') return;
-      toast.error(err instanceof Error ? err.message : 'Failed to start session');
+      toast.error(err instanceof Error ? err.message : tHardcodedUi.raw('componentsProjectsProjectSidebar.failedToStartSession'));
     },
   });
 
@@ -471,7 +510,7 @@ export function ProjectSidebar({ projectId }: { projectId: string }) {
           <Link
             href="/projects"
             className="flex items-center group-data-[collapsible=icon]:hidden"
-            aria-label="Projects"
+            aria-label={tHardcodedUi.raw('componentsProjectsProjectSidebar.projects')}
           >
             <KortixLogo variant="logomark" size={16} className="flex-shrink-0" />
           </Link>
@@ -482,7 +521,7 @@ export function ProjectSidebar({ projectId }: { projectId: string }) {
               type="button"
               className="group/collapsed absolute inset-0 flex items-center justify-center cursor-pointer"
               onClick={() => (isMobile ? setOpenMobile(true) : setOpen(true))}
-              aria-label="Expand sidebar"
+              aria-label={tHardcodedUi.raw('componentsProjectsProjectSidebar.expandSidebar')}
             >
               <span className="flex items-center justify-center group-hover/collapsed:hidden">
                 <KortixLogo variant="symbol" size={20} className="flex-shrink-0" />
@@ -493,7 +532,9 @@ export function ProjectSidebar({ projectId }: { projectId: string }) {
           <button
             type="button"
             onClick={() => (isMobile ? setOpenMobile(false) : setOpen(false))}
-            aria-label={isMobile ? 'Close menu' : 'Collapse sidebar'}
+            aria-label={isMobile
+              ? tHardcodedUi.raw('componentsProjectsProjectSidebar.closeMenu')
+              : tHardcodedUi.raw('componentsProjectsProjectSidebar.collapseSidebar')}
             className={cn(
               'flex items-center justify-center rounded-md text-sidebar-foreground/60 transition-colors duration-150 hover:bg-sidebar-accent hover:text-sidebar-foreground',
               isMobile ? 'h-8 w-8' : 'h-6 w-6',
@@ -544,7 +585,7 @@ export function ProjectSidebar({ projectId }: { projectId: string }) {
             />
             <CollapsedIconButton
               icon={<ListTree className="h-4 w-4" />}
-              label="Sessions"
+              label={tHardcodedUi.raw('componentsProjectsProjectSidebar.sessions')}
               onClick={() => (isMobile ? setOpenMobile(true) : setOpen(true))}
               flyoutContent={<ProjectSessionsFlyout projectId={projectId} />}
             />
@@ -559,7 +600,7 @@ export function ProjectSidebar({ projectId }: { projectId: string }) {
             <ProjectSetupRailItem projectId={projectId} />
             <CollapsedIconButton
               icon={<SlidersHorizontal className="h-4 w-4" />}
-              label="Customize"
+              label={tHardcodedUi.raw('componentsProjectsProjectSidebar.customize')}
               onClick={goCustomize}
               isActive={customizeOpen}
             />
@@ -585,7 +626,11 @@ export function ProjectSidebar({ projectId }: { projectId: string }) {
                   ) : (
                     <SquarePen />
                   )}
-                  <span>{createSession.isPending ? 'Creating…' : 'New session'}</span>
+                  <span>
+                    {createSession.isPending
+                      ? tHardcodedUi.raw('componentsProjectsProjectSidebar.creating')
+                      : tHardcodedUi.raw('componentsProjectsProjectSidebar.line510JsxAttrLabelNewSession')}
+                  </span>
                   <KbdHint mod={modSymbol} letter="J" />
                 </SidebarMenuButton>
               </SidebarMenuItem>
@@ -603,7 +648,7 @@ export function ProjectSidebar({ projectId }: { projectId: string }) {
             >
               <CollapsibleTrigger asChild>
                 <SidebarGroupLabel className="group/label mt-1 flex h-6 cursor-pointer items-center gap-2 px-2 text-xs font-medium uppercase tracking-wider text-muted-foreground/60 hover:text-sidebar-foreground">
-                  <span className="flex-1 text-left">Sessions</span>
+                  <span className="flex-1 text-left">{tHardcodedUi.raw('componentsProjectsProjectSidebar.sessions')}</span>
                   <ChevronDown className="size-3 transition-transform duration-200 group-data-[state=closed]/sessions:-rotate-90" />
                 </SidebarGroupLabel>
               </CollapsibleTrigger>
@@ -629,7 +674,7 @@ export function ProjectSidebar({ projectId }: { projectId: string }) {
                   className="!text-sm font-normal data-[active=true]:font-normal !transition-none transform-none [&_svg]:!size-4"
                 >
                   <SlidersHorizontal />
-                  <span>Customize</span>
+                  <span>{tHardcodedUi.raw('componentsProjectsProjectSidebar.customize')}</span>
                 </SidebarMenuButton>
               </SidebarMenuItem>
             </SidebarMenu>

--- a/apps/web/src/components/session/session-layout.tsx
+++ b/apps/web/src/components/session/session-layout.tsx
@@ -2,8 +2,8 @@
 
 import { useTranslations } from 'next-intl';
 import React, { useState, useEffect, useRef, useCallback, memo } from 'react';
+import dynamic from 'next/dynamic';
 import * as ResizablePrimitive from 'react-resizable-panels';
-import { PreviewTabContent } from '@/components/tabs/preview-tab-content';
 import { useIsMobile } from '@/hooks/utils';
 import { cn } from '@/lib/utils';
 import {
@@ -26,11 +26,28 @@ import {
   useSessionBrowserStore,
   type SessionPanelView,
 } from '@/stores/session-browser-store';
-import { SessionFilesExplorer } from '@/components/session/session-files-explorer';
-import { SessionTerminalPanel } from '@/components/session/session-terminal-panel';
-import { SessionActionsPanel } from '@/components/session/session-actions-panel';
 import { Drawer, DrawerContent } from '@/components/ui/drawer';
 import { X } from 'lucide-react';
+
+const PreviewTabContent = dynamic(
+  () => import('@/components/tabs/preview-tab-content').then((mod) => mod.PreviewTabContent),
+  { loading: () => null },
+);
+
+const SessionFilesExplorer = dynamic(
+  () => import('@/components/session/session-files-explorer').then((mod) => mod.SessionFilesExplorer),
+  { loading: () => null },
+);
+
+const SessionTerminalPanel = dynamic(
+  () => import('@/components/session/session-terminal-panel').then((mod) => mod.SessionTerminalPanel),
+  { loading: () => null },
+);
+
+const SessionActionsPanel = dynamic(
+  () => import('@/components/session/session-actions-panel').then((mod) => mod.SessionActionsPanel),
+  { loading: () => null },
+);
 
 // ============================================================================
 // Session Layout
@@ -261,7 +278,8 @@ export const SessionLayout = memo(function SessionLayout({
   // uses — so there is exactly one tool-rendering implementation. The terminal
   // is layered on top and toggled with `hidden` (display:none) rather than
   // unmounted, keeping its connection alive across view switches.
-  const nonTerminalBody = showBrowser ? (
+  const shouldRenderNonTerminalBody = shouldShowPanel && !showTerminal;
+  const nonTerminalBody = !shouldRenderNonTerminalBody ? null : showBrowser ? (
     <PreviewTabContent tabId={sessionPreviewTabId(sessionId)} />
   ) : showExplorer ? (
     <SessionFilesExplorer chatSessionId={sessionId} />


### PR DESCRIPTION
## Summary
- defer loading the heavy session layout/chat bundles until the session route actually needs them
- lazy-load side panel bodies and skip closed non-terminal panel content
- prefetch session routes and sandbox metadata from project session lists before navigation

## Tests
- `git diff --check`
- `npx eslint src/app/projects/[id]/sessions/[sessionId]/page.tsx src/components/projects/project-session-list.tsx src/components/projects/project-sidebar.tsx src/components/session/session-layout.tsx` (from `apps/web`)