### PR TITLE
fix(api): support self-host sandbox git endpoints

### DIFF
--- a/apps/api/src/projects/lib/sandbox-env-sync.ts
+++ b/apps/api/src/projects/lib/sandbox-env-sync.ts
@@ -55,6 +55,7 @@ function isSecureOrPrivateTarget(rawUrl: string): boolean {
   if (u.protocol !== 'http:') return false;
   const h = u.hostname;
   if (['localhost', '127.0.0.1', '0.0.0.0', '::1'].includes(h)) return true;
+  if (h.endsWith('.localhost')) return true; // Daytona self-host preview proxy.
   if (!h.includes('.')) return true; // single-label docker/service name on a private bridge
   if (/\.(local|internal|svc|cluster\.local)$/.test(h)) return true;
   // RFC1918 / link-local — anchored to full IPv4 literals so a public hostname

--- a/apps/api/src/projects/lib/sessions.ts
+++ b/apps/api/src/projects/lib/sessions.ts
@@ -136,6 +136,7 @@ export async function buildSessionSandboxEnvVars(input: {
   sessionId: string;
   userId: string;
   repoUrl: string;
+  sandboxProvider?: SandboxProviderName;
   baseRef: string;
   agentName: string;
   initialPrompt?: string | null;
@@ -180,7 +181,7 @@ export async function buildSessionSandboxEnvVars(input: {
     // git proxy with its own KORTIX_TOKEN — a real host credential never lands
     // in the sandbox. The daemon's credential helper returns KORTIX_TOKEN for
     // the proxy host. OFF → direct clone of the real repo (legacy token flow).
-    KORTIX_REPO_URL: config.KORTIX_GIT_PROXY ? proxyGitUrl(input.projectId) : input.repoUrl,
+    KORTIX_REPO_URL: config.KORTIX_GIT_PROXY ? proxyGitUrl(input.projectId) : repoUrlForSandbox(input.repoUrl, input.sandboxProvider),
     KORTIX_DEFAULT_BRANCH: input.baseRef,
     KORTIX_BASE_REF: input.baseRef,
     KORTIX_BRANCH_NAME: input.sessionId,
@@ -215,6 +216,21 @@ export function deriveKortixApiBase(): string {
 
 export function proxyGitUrl(projectId: string): string {
   return `${deriveKortixApiRoot(config.KORTIX_URL)}/v1/git/${projectId}.git`;
+}
+
+function repoUrlForSandbox(repoUrl: string, provider?: SandboxProviderName): string {
+  try {
+    const parsed = new URL(repoUrl);
+    if (parsed.protocol !== 'git:') return repoUrl;
+    if (parsed.hostname !== '127.0.0.1' && parsed.hostname !== 'localhost') return repoUrl;
+    const fallbackHost = provider === 'local_docker'
+      ? 'host.docker.internal'
+      : config.MANAGED_GIT_LOCAL_HOST || '127.0.0.1';
+    parsed.hostname = config.MANAGED_GIT_LOCAL_CONTAINER_HOST || fallbackHost;
+    return parsed.toString();
+  } catch {
+    return repoUrl;
+  }
 }
 
 /**
@@ -487,6 +503,7 @@ export async function createProjectSession(input: {
         sessionId,
         userId,
         repoUrl: project.repoUrl,
+        sandboxProvider: providerName,
         baseRef,
         agentName,
         initialPrompt,

--- a/apps/api/src/snapshots/dockerfile-layer.ts
+++ b/apps/api/src/snapshots/dockerfile-layer.ts
@@ -29,6 +29,11 @@
  */
 const DEFAULT_AGENT_BROWSER_VERSION = '0.27.0';
 
+const DOCKERFILE_SYNTAX_IMAGE =
+  process.env.KORTIX_DOCKERFILE_SYNTAX_IMAGE?.trim() || 'docker/dockerfile:1.7';
+const PLATFORM_DEFAULT_BASE_IMAGE =
+  process.env.KORTIX_PLATFORM_DEFAULT_BASE_IMAGE?.trim() || 'ubuntu:24.04';
+
 /**
  * Hardcoded "platform default" Dockerfile. Used when a session boots from
  * Kortix's default template — no user customization, just Ubuntu plus the
@@ -38,11 +43,11 @@ const DEFAULT_AGENT_BROWSER_VERSION = '0.27.0';
  * Exposed so the snapshot identity hash treats it as a stable input.
  */
 export const PLATFORM_DEFAULT_USER_DOCKERFILE = [
-  '# syntax=docker/dockerfile:1.7',
+  `# syntax=${DOCKERFILE_SYNTAX_IMAGE}`,
   '# Kortix platform default sandbox base.',
   '# Sessions clone the project workspace at boot — nothing project-specific',
   '# is baked in here. Customize via `[[sandbox.templates]]` in kortix.toml.',
-  'FROM ubuntu:24.04',
+  `FROM ${PLATFORM_DEFAULT_BASE_IMAGE}`,
   '',
   'WORKDIR /workspace',
   '',


### PR DESCRIPTION
## Summary
- rewrite loopback `git://` repo URLs for sandbox providers that cannot reach the API host loopback directly
- treat `.localhost` preview/proxy hosts as local-safe sandbox hosts
- allow sandbox Dockerfile syntax and base image overrides for self-host deployments

## Tests
- `git diff --check`
- `bunx tsc -p apps/api/tsconfig.json --noEmit --ignoreDeprecations 6.0`