### PR TITLE
fix(api): clean up stopped sessions and warm pool

### DIFF
--- a/apps/api/src/platform/services/warm-pool.ts
+++ b/apps/api/src/platform/services/warm-pool.ts
@@ -18,12 +18,14 @@ import { accountMembers, projects, sessionSandboxes } from '@kortix/db';
 import { db } from '../../shared/db';
 import { config } from '../../config';
 import { getProvider } from '../providers';
+import { selectProvider } from './provider-balancer';
 import { provisionSessionSandbox } from './session-sandbox';
 
 const POOL_BOOT_TIMEOUT_MS = 8 * 60 * 1000; // booting longer than this → failed → reap
 const POOL_MAX_AGE_MS = 6 * 60 * 60 * 1000; // parked longer than this → cycle (snapshot drift)
 const READY_PROBE_TIMEOUT_MS = 5 * 60 * 1000;
 const READY_PROBE_INTERVAL_MS = 3000;
+const resumedPromotions = new Set<string>();
 
 // Warm pool is ON by default — there's no enable flag. The fleet-wide kill
 // switch is KORTIX_WARM_POOL_MAX_TOTAL=0. Each project can still opt in/out and
@@ -249,6 +251,7 @@ async function spawnWarmSandbox(project: {
   const ownerUserId = await getProjectOwnerUserId(project.accountId);
   if (!ownerUserId || !project.repoUrl) return false;
   const W = randomUUID();
+  const provider = await selectProvider();
   // Lazy import to avoid a load-time cycle with projects/index.ts.
   const { buildSessionSandboxEnvVars } = await import('../../projects');
   const extraEnvVars = await buildSessionSandboxEnvVars({
@@ -257,6 +260,7 @@ async function spawnWarmSandbox(project: {
     sessionId: W,
     userId: ownerUserId,
     repoUrl: project.repoUrl,
+    sandboxProvider: provider,
     baseRef: project.defaultBranch,
     agentName: 'default',
     initialPrompt: null,
@@ -266,6 +270,7 @@ async function spawnWarmSandbox(project: {
     accountId: project.accountId,
     projectId: project.projectId,
     userId: ownerUserId,
+    provider,
     extraEnvVars,
     poolState: 'booting',
     metadata: {
@@ -384,6 +389,14 @@ export async function reconcileWarmPool(now = new Date()): Promise<{ reaped: num
     if (reason) {
       await reapWarmSandbox(row);
       reaped++;
+      continue;
+    }
+    if (row.poolState === 'booting' && row.status === 'active' && !resumedPromotions.has(row.sandboxId)) {
+      resumedPromotions.add(row.sandboxId);
+      void promoteWhenReady(row.sandboxId)
+        .catch(() => {})
+        .finally(() => resumedPromotions.delete(row.sandboxId));
+      console.log(`[warm-pool] resumed promotion ${row.sandboxId.slice(0, 8)}`);
     }
   }
 

--- a/apps/api/src/projects/routes/r7.ts
+++ b/apps/api/src/projects/routes/r7.ts
@@ -370,15 +370,41 @@ projectsApp.openapi(
     .where(and(eq(projectSessions.projectId, projectId), eq(projectSessions.accountId, loaded.row.accountId)))
     .orderBy(desc(projectSessions.updatedAt));
 
+  const resumableStoppedSessionIds = rows.length
+    ? new Set(
+        (
+          await db
+            .select({ sessionId: sessionSandboxes.sessionId })
+            .from(sessionSandboxes)
+            .where(
+              and(
+                eq(sessionSandboxes.projectId, projectId),
+                eq(sessionSandboxes.accountId, loaded.row.accountId),
+                eq(sessionSandboxes.status, 'stopped'),
+                inArray(sessionSandboxes.sessionId, rows.map((r) => r.sessionId)),
+              ),
+            )
+        )
+          .map((r) => r.sessionId)
+          .filter((id): id is string => !!id),
+      )
+    : new Set<string>();
+
+  const listableRows = rows.filter((r) => {
+    const meta = (r.metadata ?? {}) as Record<string, unknown>;
+    if (typeof meta.deletedAt === 'string') return false;
+    return r.status !== 'stopped' || resumableStoppedSessionIds.has(r.sessionId);
+  });
+
   // Filter to sessions the viewer may see: their own, project-wide, or ones
   // shared with them (restricted + grant). Then surface owner + sharing so the
   // list can show "shared by X".
   const subject = await resolveShareSubject(loaded.userId);
   const canManageProject = roleAllows(loaded.effectiveRole, 'manage');
   const grantsBySession = await loadSessionGrants(
-    rows.filter((r) => r.visibility === 'restricted').map((r) => r.sessionId),
+    listableRows.filter((r) => r.visibility === 'restricted').map((r) => r.sessionId),
   );
-  const visible = rows.filter((r) =>
+  const visible = listableRows.filter((r) =>
     isSessionVisibleTo(
       r.visibility as 'private' | 'project' | 'restricted',
       r.createdBy,
@@ -755,6 +781,13 @@ projectsApp.openapi(
   // kickProvisionOnOpen) guards against re-kicking on subsequent 404 polls.
   const usable = row && (row.status === 'provisioning' || row.status === 'active');
   if (!usable) {
+    if (['failed', 'stopped', 'completed'].includes(sandboxVisible.row.status)) {
+      return c.json({
+        error: `Session is ${sandboxVisible.row.status}`,
+        session_status: sandboxVisible.row.status,
+        retriable: false,
+      }, 409);
+    }
     if (sandboxVisible.row.status !== 'provisioning') {
       if (row) {
         await db.delete(sessionSandboxes).where(eq(sessionSandboxes.sandboxId, sessionId)).catch(() => {});
@@ -826,9 +859,18 @@ projectsApp.openapi(
     ))
     .limit(1);
 
+  const deletedAt = new Date();
   const [row] = await db
     .update(projectSessions)
-    .set({ status: 'stopped', updatedAt: new Date() })
+    .set({
+      status: 'stopped',
+      metadata: {
+        ...(visible.row.metadata ?? {}),
+        deletedAt: deletedAt.toISOString(),
+        deletedBy: loaded.userId,
+      },
+      updatedAt: deletedAt,
+    })
     .where(and(
       eq(projectSessions.sessionId, sessionId),
       eq(projectSessions.projectId, projectId),
@@ -851,7 +893,7 @@ projectsApp.openapi(
         status: 'archived',
         metadata: {
           ...(sandbox.metadata ?? {}),
-          stoppedAt: new Date().toISOString(),
+          stoppedAt: deletedAt.toISOString(),
           initStatus: sandbox.status === 'active' ? 'ready' : 'failed',
           ...(sandbox.status === 'active'
             ? {}


### PR DESCRIPTION
## Summary
- resume in-flight warm-pool promotions after API restarts
- mark deleted project sessions in metadata instead of leaving stopped sessions visible forever
- hide deleted or non-resumable stopped sessions from the project session list

## Tests
- `git diff --check`
- `bunx tsc -p apps/api/tsconfig.json --noEmit --ignoreDeprecations 6.0`