### PR TITLE
infra(eks): Argo CD UI on ops.kortix.com + GitOps OutOfSync fix

### DIFF
--- a/infra/GITOPS.md
+++ b/infra/GITOPS.md
@@ -43,12 +43,36 @@ takes over.
 
 ## Access Argo CD
 
+Quick (no setup):
+
 ```bash
-kubectl -n argocd port-forward svc/argocd-server 8080:443   # then https://localhost:8080
+kubectl -n argocd port-forward svc/argo-cd-argocd-server 8080:443   # https://localhost:8080
 kubectl -n argocd get secret argocd-initial-admin-secret -o jsonpath='{.data.password}' | base64 -d  # admin pw
 argocd app get kortix-prod        # Synced / Healthy
 argocd app history kortix-prod    # releases; `argocd app rollback` or git revert
 ```
+
+### Company domain — `ops.kortix.com` (gated)
+
+Argo CD is an admin control plane, so the public URL is **Cloudflare-Access
+gated** and the ALB is **locked to Cloudflare IPs** (so the gate can't be
+bypassed via the raw ALB DNS). Bring it up in this order so it's never reachable
+unauthenticated:
+
+1. **Apply the cert** — `environments/prod-eks/cluster` (adds the `ops.kortix.com`
+   ACM cert; validates via Cloudflare DNS).
+2. **Apply the ingress** — set `argocd_ui_enabled = true` in the `platform`
+   tfvars and apply. The ALB comes up; `ops.kortix.com` does NOT resolve yet.
+3. **Cloudflare Access** (Zero Trust dashboard → Access → Applications → Add):
+   - Type **Self-hosted**, Application domain `ops.kortix.com`.
+   - Policy: **Allow**, Include → *Emails ending in* `@kortix.com` (or a group).
+   - (Optional) shorter session duration for an admin app.
+4. **Add the DNS record** — proxied CNAME `ops.kortix.com` → the Argo CD ALB
+   hostname (`kubectl -n argocd get ingress`). Now it resolves AND is gated.
+5. (Recommended) wire **Argo CD GitHub-org SSO** so logins map to people, then
+   disable the shared `admin` account.
+
+CLI through the gateway uses gRPC-Web: `argocd login ops.kortix.com --grpc-web`.
 
 ## Release flow & the GitHub Actions
 

--- a/infra/k8s/argocd/applications/prod.yaml
+++ b/infra/k8s/argocd/applications/prod.yaml
@@ -31,6 +31,17 @@ spec:
   destination:
     server: https://kubernetes.default.svc
     namespace: kortix-prod
+  # External Secrets Operator's admission webhook injects defaults
+  # (conversionStrategy/decodingStrategy/metadataPolicy) into the ExternalSecret,
+  # which git doesn't carry — ignore those fields so the app isn't perpetually
+  # OutOfSync. ESO owns them; this changes diffing only, nothing in-cluster.
+  ignoreDifferences:
+    - group: external-secrets.io
+      kind: ExternalSecret
+      jqPathExpressions:
+        - .spec.dataFrom[]?.extract.conversionStrategy
+        - .spec.dataFrom[]?.extract.decodingStrategy
+        - .spec.dataFrom[]?.extract.metadataPolicy
   syncPolicy:
     automated:
       prune: true

--- a/infra/terraform/environments/prod-eks/cluster/main.tf
+++ b/infra/terraform/environments/prod-eks/cluster/main.tf
@@ -108,6 +108,21 @@ module "acm" {
   }
 }
 
+# ── TLS cert for the Argo CD UI (ops.kortix.com) ──────────────────────────────
+# The Argo CD admin UI is exposed via its own ALB (configured in the platform
+# layer). It is an admin control plane, so the public path MUST be gated by
+# Cloudflare Access + a Cloudflare-IP-locked ALB — see infra/GITOPS.md.
+module "acm_argocd" {
+  source      = "../../../modules/acm-cloudflare"
+  domain_name = var.argocd_domain
+  zone_id     = var.cloudflare_zone_id
+  tags        = local.tags
+  providers = {
+    aws        = aws
+    cloudflare = cloudflare
+  }
+}
+
 # ── App IRSA role: read the SAME Secrets Manager bundle ECS uses ───────────────
 # The app's ServiceAccount (kube ns/SA below) assumes this to let External
 # Secrets pull `var.app_secret_name` into the cluster. Scoped to that one secret.

--- a/infra/terraform/environments/prod-eks/cluster/outputs.tf
+++ b/infra/terraform/environments/prod-eks/cluster/outputs.tf
@@ -36,6 +36,15 @@ output "acm_certificate_arn" {
   value       = module.acm.certificate_arn
 }
 
+output "acm_argocd_certificate_arn" {
+  description = "Cert ARN for the Argo CD UI ALB (ops.kortix.com)."
+  value       = module.acm_argocd.certificate_arn
+}
+
+output "argocd_domain" {
+  value = var.argocd_domain
+}
+
 output "app_irsa_role_arn" {
   description = "IRSA role ARN for the app ServiceAccount (Secrets Manager read)."
   value       = module.app_irsa.role_arn

--- a/infra/terraform/environments/prod-eks/cluster/variables.tf
+++ b/infra/terraform/environments/prod-eks/cluster/variables.tf
@@ -73,6 +73,12 @@ variable "api_domain" {
   default     = "api-eks.kortix.com"
 }
 
+variable "argocd_domain" {
+  description = "Public FQDN for the Argo CD admin UI (gated by Cloudflare Access)."
+  type        = string
+  default     = "ops.kortix.com"
+}
+
 variable "cloudflare_zone_id" {
   description = "Cloudflare zone ID for kortix.com. Supply via TF_VAR_cloudflare_zone_id."
   type        = string

--- a/infra/terraform/environments/prod-eks/platform/main.tf
+++ b/infra/terraform/environments/prod-eks/platform/main.tf
@@ -92,6 +92,11 @@ module "platform" {
 
   cloudflare_api_token = var.cloudflare_api_token
 
+  # Argo CD UI (ops.kortix.com) — opt-in; gate with Cloudflare Access first.
+  argocd_ui_enabled      = var.argocd_ui_enabled
+  argocd_domain          = local.cluster.argocd_domain
+  argocd_certificate_arn = local.cluster.acm_argocd_certificate_arn
+
   tags = {
     Environment = "prod"
     Service     = "kortix-api"

--- a/infra/terraform/environments/prod-eks/platform/variables.tf
+++ b/infra/terraform/environments/prod-eks/platform/variables.tf
@@ -1,3 +1,14 @@
+variable "argocd_ui_enabled" {
+  description = <<-EOT
+    Expose the Argo CD UI on its own ALB at ops.kortix.com. Set true only AFTER
+    setting up the Cloudflare Access gate (see infra/GITOPS.md) — the ALB is
+    locked to Cloudflare IPs, and the DNS record is added last, so the UI is
+    never publicly reachable-by-name before Access is in place.
+  EOT
+  type        = bool
+  default     = false
+}
+
 variable "cloudflare_api_token" {
   description = <<-EOT
     Cloudflare API token external-dns uses to manage the api-eks.kortix.com

--- a/infra/terraform/modules/eks/platform/main.tf
+++ b/infra/terraform/modules/eks/platform/main.tf
@@ -218,6 +218,41 @@ resource "helm_release" "argo_cd" {
   atomic           = true
   timeout          = 900
 
+  # Expose the UI on its own ALB (ops.kortix.com) when enabled. server.insecure
+  # = the server speaks HTTP behind the TLS-terminating ALB; the ALB only accepts
+  # Cloudflare IPs so the Cloudflare Access gate can't be bypassed.
+  values = var.argocd_ui_enabled ? [yamlencode({
+    configs = {
+      params = {
+        "server.insecure" = true
+      }
+    }
+    server = {
+      ingress = {
+        enabled          = true
+        ingressClassName = "alb"
+        hostname         = var.argocd_domain
+        path             = "/"
+        pathType         = "Prefix"
+        tls              = false
+        annotations = {
+          "alb.ingress.kubernetes.io/scheme"                    = "internet-facing"
+          "alb.ingress.kubernetes.io/target-type"               = "ip"
+          "alb.ingress.kubernetes.io/listen-ports"              = "[{\"HTTP\":80},{\"HTTPS\":443}]"
+          "alb.ingress.kubernetes.io/ssl-redirect"              = "443"
+          "alb.ingress.kubernetes.io/ssl-policy"                = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+          "alb.ingress.kubernetes.io/certificate-arn"           = var.argocd_certificate_arn
+          "alb.ingress.kubernetes.io/backend-protocol"          = "HTTP"
+          "alb.ingress.kubernetes.io/healthcheck-path"          = "/healthz"
+          "alb.ingress.kubernetes.io/success-codes"             = "200"
+          "alb.ingress.kubernetes.io/inbound-cidrs"             = join(",", var.cloudflare_inbound_cidrs)
+          "external-dns.alpha.kubernetes.io/hostname"           = var.argocd_domain
+          "external-dns.alpha.kubernetes.io/cloudflare-proxied" = "true"
+        }
+      }
+    }
+  })] : []
+
   # Run the core controllers with 2 replicas where the chart supports it (HA-lite).
   set {
     name  = "redis-ha.enabled"

--- a/infra/terraform/modules/eks/platform/variables.tf
+++ b/infra/terraform/modules/eks/platform/variables.tf
@@ -70,6 +70,36 @@ variable "argo_rollouts_chart_version" {
   default = "2.37.3" # app v1.7.x
 }
 
+# ── Argo CD UI exposure (ops.kortix.com) ──────────────────────────────────────
+variable "argocd_ui_enabled" {
+  description = "Expose the Argo CD UI on its own ALB at argocd_domain. Gate it with Cloudflare Access (see infra/GITOPS.md) before adding the DNS record."
+  type        = bool
+  default     = false
+}
+
+variable "argocd_domain" {
+  description = "Public FQDN for the Argo CD UI."
+  type        = string
+  default     = "ops.kortix.com"
+}
+
+variable "argocd_certificate_arn" {
+  description = "ACM cert ARN for the Argo CD UI ALB (from the cluster layer)."
+  type        = string
+  default     = ""
+}
+
+variable "cloudflare_inbound_cidrs" {
+  description = "CIDRs allowed to hit the Argo CD ALB — locked to Cloudflare's ranges so the Cloudflare Access gate can't be bypassed via the raw ALB DNS."
+  type        = list(string)
+  default = [
+    "173.245.48.0/20", "103.21.244.0/22", "103.22.200.0/22", "103.31.4.0/22",
+    "141.101.64.0/18", "108.162.192.0/18", "190.93.240.0/20", "188.114.96.0/20",
+    "197.234.240.0/22", "198.41.128.0/17", "162.158.0.0/15", "104.16.0.0/13",
+    "104.24.0.0/14", "172.64.0.0/13", "131.0.72.0/22",
+  ]
+}
+
 variable "tags" {
   type    = map(string)
   default = {}


### PR DESCRIPTION
Follow-up to #3387 (EKS prod + GitOps foundation). Adds:

- **Argo CD UI on `ops.kortix.com`** — opt-in (`argocd_ui_enabled`), exposed via its own ALB with ACM TLS, **locked to Cloudflare IP ranges** so the **Cloudflare Access** SSO gate can't be bypassed via the raw ALB DNS. Cert in the cluster layer; secure bring-up order documented in `infra/GITOPS.md`.
- **GitOps OutOfSync fix** — `ignoreDifferences` on the `kortix-prod` Application for the fields External Secrets Operator's webhook injects into the ExternalSecret (`conversionStrategy`/`decodingStrategy`/`metadataPolicy`), so the app reports `Synced` instead of perpetually OutOfSync.

EKS prod is live + GitOps-managed (`api-eks.kortix.com`, Argo CD `Synced/Healthy`, pods on the released tag). ECS untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)