### PR TITLE
feat(infra): add EKS prod stack (api-eks.kortix.com) in parallel with ECS

### DIFF
--- a/infra/GITOPS.md
+++ b/infra/GITOPS.md
@@ -116,6 +116,44 @@ ALB=$(kubectl -n kortix-prod get ingress kortix-api -o jsonpath='{.status.loadBa
 
 Watch a canary: `kubectl argo rollouts get rollout kortix-api -n kortix-prod --watch`.
 
+## Branch = environment (why constant merges to main are safe)
+
+```
+PRs merge to main  ─►  DEV only        (dev Argo app tracks `main`)
+                       prod untouched
+
+Actions → Promote   ─►  merges main → `prod` branch (reviewed)
+   └─ deploy-prod-eks bumps image.tag in prod's envs/prod/values.yaml
+        (GitHub Environment `production` approval)
+                       └─►  prod Argo app (tracks `prod`) syncs ─► PROD
+```
+
+The **prod Application tracks the `prod` branch** — so nothing on `main` can
+touch prod. Prod moves *only* when someone runs **Promote** (merges to `prod`)
+and the image bump lands on `prod`. (Bootstrap note: the app currently tracks
+`main` until the first promote puts the GitOps manifests on `prod`; then repoint
+`spec.sources[].targetRevision` from `main` → `prod` — a one-line change.)
+
+## GitHub-org SSO + retiring admin
+
+1. **Create a GitHub OAuth App** (org `kortix-ai` → Settings → Developer settings
+   → OAuth Apps → New):
+   - Homepage `https://ops.kortix.com`
+   - Authorization callback `https://ops.kortix.com/api/dex/callback`
+   - copy the **Client ID**, generate a **Client Secret**.
+2. In the `platform` tfvars / env:
+   ```
+   argocd_github_sso_enabled = true
+   argocd_github_client_id   = "<client id>"
+   argocd_admin_team         = "<github team that gets admin>"   # e.g. eng
+   export TF_VAR_argocd_github_client_secret=<client secret>
+   ```
+   `terraform apply`. Org members can now **Log in via GitHub**; the admin team
+   gets admin, everyone else read-only.
+3. **Verify** GitHub login + that your admin team has admin in the UI.
+4. **Only then** retire the shared password: set `argocd_disable_admin = true`
+   and `terraform apply`. (Doing this before step 3 locks you out.)
+
 ## Environment profiles
 
 `envs/<env>/values.yaml` sets `env.internalKortixEnv` and `workers.enabled`.

--- a/infra/terraform/environments/prod-eks/platform/main.tf
+++ b/infra/terraform/environments/prod-eks/platform/main.tf
@@ -97,6 +97,14 @@ module "platform" {
   argocd_domain          = local.cluster.argocd_domain
   argocd_certificate_arn = local.cluster.acm_argocd_certificate_arn
 
+  # GitHub-org SSO for Argo CD login.
+  argocd_github_sso_enabled   = var.argocd_github_sso_enabled
+  argocd_github_org           = var.argocd_github_org
+  argocd_admin_team           = var.argocd_admin_team
+  argocd_github_client_id     = var.argocd_github_client_id
+  argocd_github_client_secret = var.argocd_github_client_secret
+  argocd_disable_admin        = var.argocd_disable_admin
+
   tags = {
     Environment = "prod"
     Service     = "kortix-api"

--- a/infra/terraform/environments/prod-eks/platform/variables.tf
+++ b/infra/terraform/environments/prod-eks/platform/variables.tf
@@ -9,6 +9,43 @@ variable "argocd_ui_enabled" {
   default     = false
 }
 
+variable "argocd_github_sso_enabled" {
+  description = "Enable GitHub-org SSO for Argo CD login."
+  type        = bool
+  default     = false
+}
+
+variable "argocd_github_org" {
+  description = "GitHub org whose members may log in to Argo CD."
+  type        = string
+  default     = "kortix-ai"
+}
+
+variable "argocd_admin_team" {
+  description = "GitHub team granted Argo CD admin (others in the org are read-only)."
+  type        = string
+  default     = "eng"
+}
+
+variable "argocd_github_client_id" {
+  description = "GitHub OAuth App client ID for Argo CD SSO."
+  type        = string
+  default     = ""
+}
+
+variable "argocd_github_client_secret" {
+  description = "GitHub OAuth App client secret. Supply via TF_VAR_argocd_github_client_secret."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "argocd_disable_admin" {
+  description = "Disable Argo CD's built-in admin account (set true ONLY after SSO is verified)."
+  type        = bool
+  default     = false
+}
+
 variable "cloudflare_api_token" {
   description = <<-EOT
     Cloudflare API token external-dns uses to manage the api-eks.kortix.com

--- a/infra/terraform/modules/eks/platform/main.tf
+++ b/infra/terraform/modules/eks/platform/main.tf
@@ -203,11 +203,84 @@ resource "helm_release" "cluster_autoscaler" {
   }
 }
 
+# ── Argo CD values (built up: HA + optional UI ingress + optional GitHub SSO) ──
+locals {
+  argocd_alb_annotations = {
+    "alb.ingress.kubernetes.io/scheme"                    = "internet-facing"
+    "alb.ingress.kubernetes.io/target-type"               = "ip"
+    "alb.ingress.kubernetes.io/listen-ports"              = "[{\"HTTP\":80},{\"HTTPS\":443}]"
+    "alb.ingress.kubernetes.io/ssl-redirect"              = "443"
+    "alb.ingress.kubernetes.io/ssl-policy"                = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+    "alb.ingress.kubernetes.io/certificate-arn"           = var.argocd_certificate_arn
+    "alb.ingress.kubernetes.io/backend-protocol"          = "HTTP"
+    "alb.ingress.kubernetes.io/healthcheck-path"          = "/healthz"
+    "alb.ingress.kubernetes.io/success-codes"             = "200"
+    "alb.ingress.kubernetes.io/inbound-cidrs"             = join(",", var.cloudflare_inbound_cidrs)
+    "external-dns.alpha.kubernetes.io/hostname"           = var.argocd_domain
+    "external-dns.alpha.kubernetes.io/cloudflare-proxied" = "true"
+  }
+
+  # Dex GitHub-org connector: log in with GitHub, restricted to the org. The
+  # client secret is referenced from argocd-secret ($dex.github.clientSecret).
+  argocd_dex_config = <<-EOT
+    connectors:
+      - type: github
+        id: github
+        name: GitHub
+        config:
+          clientID: ${var.argocd_github_client_id}
+          clientSecret: $dex.github.clientSecret
+          orgs:
+            - name: ${var.argocd_github_org}
+  EOT
+
+  argocd_values = {
+    "redis-ha"     = { enabled = false }
+    applicationSet = { replicas = 2 }
+    repoServer     = { replicas = 2 }
+    server = merge(
+      { replicas = 2 },
+      var.argocd_ui_enabled ? {
+        ingress = {
+          enabled          = true
+          ingressClassName = "alb"
+          hostname         = var.argocd_domain
+          path             = "/"
+          pathType         = "Prefix"
+          tls              = false
+          annotations      = local.argocd_alb_annotations
+        }
+      } : {}
+    )
+    configs = {
+      # server.insecure: HTTP behind the TLS-terminating ALB (UI mode).
+      params = var.argocd_ui_enabled ? { "server.insecure" = true } : {}
+      cm = merge(
+        var.argocd_ui_enabled ? { url = "https://${var.argocd_domain}" } : {},
+        var.argocd_github_sso_enabled ? {
+          "dex.config"    = local.argocd_dex_config
+          "admin.enabled" = tostring(!var.argocd_disable_admin)
+        } : {}
+      )
+      # Org members get read-only; the admin team gets full admin. Dex returns
+      # GitHub groups as "org:team" in the groups claim (Argo's default scope),
+      # so the admin team maps via "org:team". Tighten/expand later.
+      rbac = var.argocd_github_sso_enabled ? {
+        "policy.default" = "role:readonly"
+        "policy.csv"     = "g, ${var.argocd_github_org}:${var.argocd_admin_team}, role:admin\n"
+      } : {}
+      secret = var.argocd_github_sso_enabled ? {
+        extra = { "dex.github.clientSecret" = var.argocd_github_client_secret }
+      } : {}
+    }
+  }
+}
+
 # ── Argo CD (GitOps deploy engine) ────────────────────────────────────────────
 # The single deploy engine: it reconciles the cluster to the manifests in
 # infra/k8s/ (app-of-apps), replacing imperative `helm upgrade`/`aws ecs` calls.
-# Installed once here; thereafter it self-manages via the app-of-apps. Server is
-# ClusterIP (reach it with `kubectl -n argocd port-forward svc/argocd-server`).
+# UI at ops.kortix.com (Cloudflare-Access gated) when argocd_ui_enabled; GitHub-
+# org SSO + admin retirement when argocd_github_sso_enabled.
 resource "helm_release" "argo_cd" {
   name             = "argo-cd"
   repository       = "https://argoproj.github.io/argo-helm"
@@ -218,58 +291,7 @@ resource "helm_release" "argo_cd" {
   atomic           = true
   timeout          = 900
 
-  # Expose the UI on its own ALB (ops.kortix.com) when enabled. server.insecure
-  # = the server speaks HTTP behind the TLS-terminating ALB; the ALB only accepts
-  # Cloudflare IPs so the Cloudflare Access gate can't be bypassed.
-  values = var.argocd_ui_enabled ? [yamlencode({
-    configs = {
-      params = {
-        "server.insecure" = true
-      }
-    }
-    server = {
-      ingress = {
-        enabled          = true
-        ingressClassName = "alb"
-        hostname         = var.argocd_domain
-        path             = "/"
-        pathType         = "Prefix"
-        tls              = false
-        annotations = {
-          "alb.ingress.kubernetes.io/scheme"                    = "internet-facing"
-          "alb.ingress.kubernetes.io/target-type"               = "ip"
-          "alb.ingress.kubernetes.io/listen-ports"              = "[{\"HTTP\":80},{\"HTTPS\":443}]"
-          "alb.ingress.kubernetes.io/ssl-redirect"              = "443"
-          "alb.ingress.kubernetes.io/ssl-policy"                = "ELBSecurityPolicy-TLS13-1-2-2021-06"
-          "alb.ingress.kubernetes.io/certificate-arn"           = var.argocd_certificate_arn
-          "alb.ingress.kubernetes.io/backend-protocol"          = "HTTP"
-          "alb.ingress.kubernetes.io/healthcheck-path"          = "/healthz"
-          "alb.ingress.kubernetes.io/success-codes"             = "200"
-          "alb.ingress.kubernetes.io/inbound-cidrs"             = join(",", var.cloudflare_inbound_cidrs)
-          "external-dns.alpha.kubernetes.io/hostname"           = var.argocd_domain
-          "external-dns.alpha.kubernetes.io/cloudflare-proxied" = "true"
-        }
-      }
-    }
-  })] : []
-
-  # Run the core controllers with 2 replicas where the chart supports it (HA-lite).
-  set {
-    name  = "redis-ha.enabled"
-    value = "false"
-  }
-  set {
-    name  = "applicationSet.replicas"
-    value = "2"
-  }
-  set {
-    name  = "server.replicas"
-    value = "2"
-  }
-  set {
-    name  = "repoServer.replicas"
-    value = "2"
-  }
+  values = [yamlencode(local.argocd_values)]
 }
 
 # ── Argo Rollouts (progressive delivery) ──────────────────────────────────────

--- a/infra/terraform/modules/eks/platform/variables.tf
+++ b/infra/terraform/modules/eks/platform/variables.tf
@@ -89,6 +89,44 @@ variable "argocd_certificate_arn" {
   default     = ""
 }
 
+# ── Argo CD GitHub-org SSO ────────────────────────────────────────────────────
+variable "argocd_github_sso_enabled" {
+  description = "Enable GitHub-org SSO (Dex) for Argo CD login."
+  type        = bool
+  default     = false
+}
+
+variable "argocd_github_org" {
+  description = "GitHub org whose members may log in to Argo CD."
+  type        = string
+  default     = "kortix-ai"
+}
+
+variable "argocd_admin_team" {
+  description = "GitHub team (within the org) granted Argo CD admin; everyone else in the org is read-only."
+  type        = string
+  default     = "eng"
+}
+
+variable "argocd_github_client_id" {
+  description = "GitHub OAuth App client ID for Argo CD SSO."
+  type        = string
+  default     = ""
+}
+
+variable "argocd_github_client_secret" {
+  description = "GitHub OAuth App client secret. Supply via TF_VAR_argocd_github_client_secret."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "argocd_disable_admin" {
+  description = "Disable the built-in Argo CD admin account (do this ONLY after SSO login is verified, or you'll lock yourself out)."
+  type        = bool
+  default     = false
+}
+
 variable "cloudflare_inbound_cidrs" {
   description = "CIDRs allowed to hit the Argo CD ALB — locked to Cloudflare's ranges so the Cloudflare Access gate can't be bypassed via the raw ALB DNS."
   type        = list(string)


### PR DESCRIPTION
Hand-rolled, modular Terraform + a Helm chart for a production EKS API stack that runs alongside the existing ECS stacks (ECS untouched: dev + prod stay on Fargate). Live and healthy at api-eks.kortix.com; api.kortix.com still served by ECS until a deliberate, reversible cutover.

- modules/eks/{cluster,platform,irsa}: EKS control plane + managed node group (3 AZ, on-demand, node auto-repair), core add-ons, OIDC/IRSA, and in-cluster controllers (AWS Load Balancer Controller, External Secrets, external-dns, metrics-server, cluster-autoscaler) via pinned Helm charts.
- environments/prod-eks/{cluster,platform}: two-state roots (own VPC 10.30.0.0/16, 3 AZ, NAT per AZ; ACM cert; app IRSA reading the SAME kortix-prod-env Secrets Manager bundle ECS uses; GitHub OIDC deploy role + EKS access entries).
- k8s/charts/kortix-api: Deployment with liveness/readiness/startup probes, preStop drain, 3-AZ topology spread, HPA 3..12, PDB 50%, and an ExternalSecret syncing the shared bundle via IRSA (envFrom).
- deploy-prod-eks.yml: parallel prod deploy (no-ops until the cluster exists; never touches ECS).
- network module: optional EKS subnet-discovery tags (no-op for the ECS envs).
- docs: infra/EKS.md runbook + CICD.md / README updates.