### PR TITLE
fix(rollouts): CloudWatch canary analysis successCondition

### DIFF
--- a/infra/k8s/charts/kortix-api/templates/analysistemplate.yaml
+++ b/infra/k8s/charts/kortix-api/templates/analysistemplate.yaml
@@ -21,7 +21,9 @@ spec:
     - name: error-rate
       interval: 1m
       failureLimit: 2
-      successCondition: "len(result) == 0 || result[0] < {{`{{args.error-rate-threshold}}`}}"
+      # CloudWatch provider returns result as []MetricDataResult; the value is in
+      # .Values. No datapoints (e.g. no traffic) = pass.
+      successCondition: "len(result) == 0 || len(result[0].Values) == 0 || result[0].Values[0] < {{`{{args.error-rate-threshold}}`}}"
       provider:
         cloudWatch:
           metricDataQueries:
@@ -55,7 +57,7 @@ spec:
     - name: p95-latency
       interval: 1m
       failureLimit: 2
-      successCondition: "len(result) == 0 || result[0] < {{`{{args.p95-latency-threshold}}`}}"
+      successCondition: "len(result) == 0 || len(result[0].Values) == 0 || result[0].Values[0] < {{`{{args.p95-latency-threshold}}`}}"
       provider:
         cloudWatch:
           metricDataQueries:

--- a/infra/k8s/envs/prod/values.yaml
+++ b/infra/k8s/envs/prod/values.yaml
@@ -48,6 +48,9 @@ ingress:
 rollout:
   enabled: true
   analysis:
+    # CloudWatch 5xx + p95-latency, auto-rollback on breach. successCondition
+    # short-circuits cleanly on no-data (pre-cutover api-eks has ~no traffic →
+    # passes), and does real assessment once api.kortix.com cuts over to EKS.
     enabled: true
     lbArnSuffix: "app/k8s-kortixpr-kortixap-b24c15d61b/a294c0dfce97d54d"
     tgArnSuffix: "targetgroup/k8s-kortixpr-kortixap-0d85bef361/b3b73cd646a9caf2"


### PR DESCRIPTION
The canary analysis aborted every rollout with `invalid operation: < (mismatched types types.MetricDataResult and int)`. The Argo Rollouts CloudWatch provider returns `result` as `[]MetricDataResult` (value in `.Values`), so `result[0] < threshold` is a type error. Fixed to `result[0].Values[0]` with a no-data short-circuit (so a no-traffic env passes, a real env gets auto-rollback). Surfaced by the first end-to-end EKS release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)