### PR TITLE
perf(release): ~1m canary + CodeQL off the release gate

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -117,16 +117,20 @@ jobs:
           #      the same name (e.g. a `cancelled` CodeQL "Analyze" next to a
           #      later `success`). Keep only the latest run per name (max
           #      started_at) so a stale cancelled/failed attempt can't block.
-          #   3. NON-CI noise that has nothing to do with releasability:
+          #   3. NON-CI noise / non-release gates that shouldn't block a deploy:
           #      - "Dependabot*" — GitHub's background dependency-update jobs,
           #        which fail routinely (lockfile/monorepo) and are irrelevant.
+          #      - "Analyze*" — CodeQL security scans. They run on every push for
+          #        visibility but are SLOW (~15m) and a security scan shouldn't gate
+          #        a release. The gate still waits for the build + typecheck (its
+          #        real purpose: guaranteeing the dev image exists to retag).
           #      - "Open review-gated release PR" — a PRIOR promote attempt's own
           #        check (the current run is already excluded via run_id, but an
           #        earlier failed attempt would otherwise self-block the retry).
           NOT_GREEN="$(RID="${{ github.run_id }}" gh api "repos/${{ github.repository }}/commits/$SHA/check-runs?per_page=100" --paginate \
             --jq '[ .check_runs[]
                     | select((.details_url // "") | contains("/runs/" + env.RID + "/") | not)
-                    | select(((.name | ascii_downcase | startswith("dependabot")) or (.name == "Open review-gated release PR")) | not) ]
+                    | select(((.name | ascii_downcase | startswith("dependabot")) or (.name | ascii_downcase | startswith("analyze")) or (.name == "Open review-gated release PR")) | not) ]
                   | group_by(.name) | map(max_by(.started_at // ""))
                   | .[]
                   | select((.status != "completed") or (((.conclusion // "") | IN("success","skipped","neutral")) | not))

--- a/infra/k8s/charts/kortix-api/templates/analysistemplate.yaml
+++ b/infra/k8s/charts/kortix-api/templates/analysistemplate.yaml
@@ -19,7 +19,7 @@ spec:
     - name: p95-latency-threshold
   metrics:
     - name: error-rate
-      interval: 1m
+      interval: {{ .Values.rollout.analysis.interval }}
       failureLimit: 2
       # CloudWatch provider returns result as []MetricDataResult; the value is in
       # .Values. No datapoints (e.g. no traffic) = pass.
@@ -55,7 +55,7 @@ spec:
                 period: 60
                 stat: Sum
     - name: p95-latency
-      interval: 1m
+      interval: {{ .Values.rollout.analysis.interval }}
       failureLimit: 2
       successCondition: "len(result) == 0 || len(result[0].Values) == 0 || result[0].Values[0] < {{`{{args.p95-latency-threshold}}`}}"
       provider:

--- a/infra/k8s/charts/kortix-api/values.yaml
+++ b/infra/k8s/charts/kortix-api/values.yaml
@@ -113,17 +113,19 @@ topologySpread:
 # (auto-rollback to stable) on breach. Per-env (prod enables it post-adoption).
 rollout:
   enabled: false
+  # FAST canary: a brief soak at each weight while the background analysis watches
+  # 5xx/latency. ~1 min total. At prod traffic, 30s yields plenty of metric data;
+  # lengthen the pauses if you ever want a longer soak window for a risky release.
   steps:
-    - setWeight: 10
-    - pause: { duration: 2m }
     - setWeight: 25
-    - pause: { duration: 2m }
+    - pause: { duration: 30s }
     - setWeight: 50
-    - pause: { duration: 3m }
+    - pause: { duration: 30s }
     - setWeight: 100
   analysis:
     enabled: false
     startingStep: 1 # begin analysis after the first setWeight
+    interval: 30s # how often the analysis samples CloudWatch
     # ALB CloudWatch dimensions — set once from the live ALB/target group (stable
     # for the life of the ingress). See infra/GITOPS.md.
     lbArnSuffix: "" # app/<alb-name>/<hex>


### PR DESCRIPTION
Releases were ~30m (15m CodeQL gate + 7m canary). Now ~5m:
- **Canary** 7m → ~1m (`25→30s→50→30s→100`, 30s analysis interval). Configurable per release for a longer soak.
- **CodeQL** removed from the promote pre-flight gate — it's a slow security scan that still runs for visibility but shouldn't block deploys. The gate still requires the dev image build + typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)