### PR TITLE
fix(api): claimed warm-pool sessions stuck at 'provisioning' in the sidebar

### DIFF
--- a/apps/api/src/platform/services/warm-pool.ts
+++ b/apps/api/src/platform/services/warm-pool.ts
@@ -123,7 +123,7 @@ export async function getWarmPoolCounts(projectId: string): Promise<{ ready: num
 export async function claimWarmSandbox(input: {
   projectId: string;
   userId: string;
-}): Promise<{ sandboxId: string; externalId: string | null; accountId: string; opencodeSessionId: string | null } | null> {
+}): Promise<{ sandboxId: string; externalId: string | null; accountId: string; sandboxStatus: string; opencodeSessionId: string | null } | null> {
   if (!warmPoolEnabled()) return null;
   // Single statement, locked with SKIP LOCKED so concurrent claims never
   // collide. Prefer parked over booting, and oldest-first (= most booted).
@@ -143,7 +143,7 @@ export async function claimWarmSandbox(input: {
       LIMIT 1
       FOR UPDATE SKIP LOCKED
     )
-    RETURNING sandbox_id, external_id, account_id, metadata
+    RETURNING sandbox_id, external_id, account_id, status, metadata
   `);
   const r = (claimed as unknown as { rows?: any[] }).rows ?? (claimed as unknown as any[]);
   const row = Array.isArray(r) ? r[0] : undefined;
@@ -153,6 +153,7 @@ export async function claimWarmSandbox(input: {
     sandboxId: row.sandbox_id as string,
     externalId: (row.external_id ?? null) as string | null,
     accountId: row.account_id as string,
+    sandboxStatus: (row.status ?? 'provisioning') as string,
     // Pin pre-warmed at park time (see promoteWhenReady) → claim skips ensure-opencode.
     opencodeSessionId: (meta.warmPool?.opencodeSessionId ?? null) as string | null,
   };

--- a/apps/api/src/projects/lib/sessions.ts
+++ b/apps/api/src/projects/lib/sessions.ts
@@ -407,7 +407,13 @@ export async function createProjectSession(input: {
             sandboxProvider: providerName,
             sandboxId: W,
             agentName,
-            status: 'provisioning',
+            // A parked box is already booted (runtimeReady), so the session is
+            // born 'running' — the provisioning mirror that normally does this
+            // flip ran at pool-SPAWN time, before this row existed, and would
+            // never fire again (the sidebar spinner used to spin forever). For
+            // a greedy claim of a still-booting box keep 'provisioning'; the
+            // spawn IIFE's mirror now finds this row and flips it on readiness.
+            status: claimed.sandboxStatus === 'active' ? 'running' : 'provisioning',
             createdBy: userId,
             visibility: 'private',
             // Pin the opencode session pre-created at park time so the client


### PR DESCRIPTION
Sessions claimed from the warm pool are inserted with `status: 'provisioning'` and nothing ever flips them to `running`: the mirror that does the flip runs in the provisioning IIFE at pool-SPAWN time — before the `project_sessions` row exists — so it no-ops, and the sidebar spinner spins forever even though the session is fully usable.

Fix: `claimWarmSandbox` now returns the claimed box's sandbox status; the claim insert births the session as `running` when the box is already `active` (the normal parked case). For a greedy claim of a still-booting box it stays `provisioning`, and the spawn IIFE's mirror — which fires at provider-create completion — now finds the row and flips it, matching cold-path semantics exactly.

Pre-existing warm-pool bug, surfaced by faster session creates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)