### PR TITLE
fix(rollouts): min-request guard (no false canary aborts at low traffic)

### DIFF
--- a/infra/k8s/charts/kortix-api/templates/analysistemplate.yaml
+++ b/infra/k8s/charts/kortix-api/templates/analysistemplate.yaml
@@ -1,9 +1,13 @@
 {{- if and .Values.rollout.enabled .Values.rollout.analysis.enabled }}
-# CloudWatch analysis for the canary. Two metrics over the ALB target group —
-# 5xx error-rate and p95 target latency — each evaluated every minute; two
-# consecutive breaches (failureLimit) abort the rollout (auto-rollback). The ALB
-# dimensions come from rollout.analysis.{lb,tg}ArnSuffix (set once from the live
-# ALB). The Argo Rollouts controller reads CloudWatch via its IRSA role.
+# CloudWatch analysis for the canary: 5xx error-rate + p95 target latency.
+#
+# Metric-based canary analysis is only meaningful with TRAFFIC — at low volume a
+# single transient 5xx is a huge error-RATE %, causing false aborts. So each
+# metric is guarded: it only ASSESSES the threshold once request volume in the
+# window clears `min-requests`; below that it passes (not enough signal to judge).
+# So a no/low-traffic env (pre-cutover api-eks) sails through, while a real
+# environment gets genuine 5xx/latency auto-rollback. result is []MetricDataResult
+# (value in .Values); result[0]=the metric, result[1]=request count.
 apiVersion: argoproj.io/v1alpha1
 kind: AnalysisTemplate
 metadata:
@@ -17,19 +21,29 @@ spec:
     - name: tg-arn-suffix
     - name: error-rate-threshold
     - name: p95-latency-threshold
+    - name: min-requests
   metrics:
     - name: error-rate
       interval: {{ .Values.rollout.analysis.interval }}
       failureLimit: 2
-      # CloudWatch provider returns result as []MetricDataResult; the value is in
-      # .Values. No datapoints (e.g. no traffic) = pass.
-      successCondition: "len(result) == 0 || len(result[0].Values) == 0 || result[0].Values[0] < {{`{{args.error-rate-threshold}}`}}"
+      successCondition: "len(result) == 0 || len(result[0].Values) == 0 || len(result[1].Values) == 0 || result[1].Values[0] < {{`{{args.min-requests}}`}} || result[0].Values[0] < {{`{{args.error-rate-threshold}}`}}"
       provider:
         cloudWatch:
           metricDataQueries:
             - id: errorRate
               expression: "IF(requests > 0, 100 * errors / requests, 0)"
               returnData: true
+            - id: requests
+              returnData: true
+              metricStat:
+                metric:
+                  namespace: AWS/ApplicationELB
+                  metricName: RequestCountPerTarget
+                  dimensions:
+                    - name: TargetGroup
+                      value: "{{`{{args.tg-arn-suffix}}`}}"
+                period: 60
+                stat: Sum
             - id: errors
               returnData: false
               metricStat:
@@ -43,21 +57,10 @@ spec:
                       value: "{{`{{args.tg-arn-suffix}}`}}"
                 period: 60
                 stat: Sum
-            - id: requests
-              returnData: false
-              metricStat:
-                metric:
-                  namespace: AWS/ApplicationELB
-                  metricName: RequestCountPerTarget
-                  dimensions:
-                    - name: TargetGroup
-                      value: "{{`{{args.tg-arn-suffix}}`}}"
-                period: 60
-                stat: Sum
     - name: p95-latency
       interval: {{ .Values.rollout.analysis.interval }}
       failureLimit: 2
-      successCondition: "len(result) == 0 || len(result[0].Values) == 0 || result[0].Values[0] < {{`{{args.p95-latency-threshold}}`}}"
+      successCondition: "len(result) == 0 || len(result[0].Values) == 0 || len(result[1].Values) == 0 || result[1].Values[0] < {{`{{args.min-requests}}`}} || result[0].Values[0] < {{`{{args.p95-latency-threshold}}`}}"
       provider:
         cloudWatch:
           metricDataQueries:
@@ -74,4 +77,15 @@ spec:
                       value: "{{`{{args.tg-arn-suffix}}`}}"
                 period: 60
                 stat: p95
+            - id: requests
+              returnData: true
+              metricStat:
+                metric:
+                  namespace: AWS/ApplicationELB
+                  metricName: RequestCountPerTarget
+                  dimensions:
+                    - name: TargetGroup
+                      value: "{{`{{args.tg-arn-suffix}}`}}"
+                period: 60
+                stat: Sum
 {{- end }}

--- a/infra/k8s/charts/kortix-api/templates/rollout.yaml
+++ b/infra/k8s/charts/kortix-api/templates/rollout.yaml
@@ -36,6 +36,8 @@ spec:
             value: {{ .Values.rollout.analysis.errorRatePercentThreshold | quote }}
           - name: p95-latency-threshold
             value: {{ .Values.rollout.analysis.p95LatencySecondsThreshold | quote }}
+          - name: min-requests
+            value: {{ .Values.rollout.analysis.minRequests | quote }}
       {{- end }}
       steps:
 {{ toYaml .Values.rollout.steps | indent 8 }}

--- a/infra/k8s/charts/kortix-api/values.yaml
+++ b/infra/k8s/charts/kortix-api/values.yaml
@@ -132,3 +132,7 @@ rollout:
     tgArnSuffix: "" # targetgroup/<tg-name>/<hex>
     errorRatePercentThreshold: "1" # fail canary if 5xx rate >= this %
     p95LatencySecondsThreshold: "1.5" # fail canary if p95 target latency >= this
+    # Only ASSESS the thresholds once the window has this many requests — below
+    # it the sample is too small to judge (a single 5xx = huge rate %), so it
+    # passes. Keeps a low-traffic env (pre-cutover) from false-aborting.
+    minRequests: "20"


### PR DESCRIPTION
Releases were false-aborting on EKS: the (now-correct) CloudWatch analysis judged error-RATE at near-zero traffic, where one transient 5xx = a huge %. Each metric now only assesses thresholds once request volume clears `min-requests` (20/window); below that it passes (too small a sample). Low-traffic envs sail through; real traffic gets genuine auto-rollback. Analysis stays enabled + cutover-ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)