### PR TITLE
feat(web): rename a project from the dashboard 3-dots menu

### DIFF
--- a/apps/web/src/app/projects/page.tsx
+++ b/apps/web/src/app/projects/page.tsx
@@ -9,6 +9,7 @@ import {
   FolderPlus,
   Loader2,
   MoreHorizontal,
+  Pencil,
   Plus,
   Search,
   Trash2,
@@ -18,6 +19,7 @@ import { useAuth } from '@/components/AuthProvider';
 import { ConnectingScreen } from '@/components/dashboard/connecting-screen';
 import { AppHeader } from '@/components/layout/app-header';
 import { ProjectCreateModal } from '@/components/projects/project-create-modal';
+import { RenameProjectDialog } from '@/components/projects/rename-project-dialog';
 import { LegacyMachineCard } from '@/components/projects/legacy-machine-card';
 import { SunaMigrationBanner } from '@/components/projects/suna-migration-banner';
 import { PersonalOnboardingWelcome } from '@/components/projects/personal-onboarding-welcome';
@@ -70,11 +72,13 @@ function relativeTime(input: string) {
 function ProjectCard({
   project,
   onOpen,
+  onRename,
   onArchive,
   archiving,
 }: {
   project: KortixProject;
   onOpen: () => void;
+  onRename: () => void;
   onArchive: () => void;
   archiving: boolean;
 }) {
@@ -122,6 +126,14 @@ function ProjectCard({
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end" className="w-44">
             <DropdownMenuItem onSelect={onOpen}>{tHardcodedUi.raw('appProjectsPage.line109JsxTextOpenProject')}</DropdownMenuItem>
+            <DropdownMenuItem
+              onSelect={onRename}
+              disabled={!canManageProject}
+              className="gap-2"
+            >
+              <Pencil className="h-3.5 w-3.5" />
+              Rename
+            </DropdownMenuItem>
             <DropdownMenuSeparator />
             <DropdownMenuItem
               onSelect={onArchive}
@@ -236,6 +248,7 @@ export default function ProjectsPage() {
   const { viewMode, setViewMode } = useProjectsViewStore();
   const [query, setQuery] = useState('');
   const [archivingId, setArchivingId] = useState<string | null>(null);
+  const [renameTarget, setRenameTarget] = useState<KortixProject | null>(null);
   const [modalOpen, setModalOpen] = useState(false);
   // Which account a newly-created project lands in. In "all accounts" view the
   // user picks it via the New-project dropdown; otherwise it's the active one.
@@ -579,6 +592,7 @@ export default function ProjectsPage() {
                       key={project.project_id}
                       project={project}
                       onOpen={() => router.push(`/projects/${project.project_id}`)}
+                      onRename={() => setRenameTarget(project)}
                       onArchive={() => archiveMutation.mutate(project.project_id)}
                       archiving={archivingId === project.project_id}
                     />
@@ -667,6 +681,7 @@ export default function ProjectsPage() {
                             setSelectedAccountId(group.account.account_id);
                             router.push(`/projects/${project.project_id}`);
                           }}
+                          onRename={() => setRenameTarget(project)}
                           onArchive={() => archiveMutation.mutate(project.project_id)}
                           archiving={archivingId === project.project_id}
                         />
@@ -686,6 +701,15 @@ export default function ProjectsPage() {
           if (!o) setCreateAccountId(null);
         }}
         accountId={createAccountId ?? activeAccountId}
+      />
+
+      <RenameProjectDialog
+        projectId={renameTarget?.project_id ?? null}
+        currentName={renameTarget?.name}
+        open={!!renameTarget}
+        onOpenChange={(o) => {
+          if (!o) setRenameTarget(null);
+        }}
       />
 
       <PersonalOnboardingWelcome />

--- a/apps/web/src/components/projects/rename-project-dialog.tsx
+++ b/apps/web/src/components/projects/rename-project-dialog.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { toast } from '@/lib/toast';
+import { updateProject } from '@/lib/projects-client';
+
+interface RenameProjectDialogProps {
+  projectId: string | null;
+  /** Current project name, prefilled into the input. */
+  currentName?: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSaved?: () => void;
+}
+
+const MAX_NAME_LENGTH = 120;
+
+export function RenameProjectDialog({
+  projectId,
+  currentName,
+  open,
+  onOpenChange,
+  onSaved,
+}: RenameProjectDialogProps) {
+  const queryClient = useQueryClient();
+  const [value, setValue] = useState(currentName ?? '');
+
+  // Reset the field whenever a new project opens the dialog.
+  useEffect(() => {
+    if (open) setValue(currentName ?? '');
+  }, [open, currentName]);
+
+  const renameMutation = useMutation({
+    mutationFn: (name: string) => {
+      if (!projectId) throw new Error('No project selected');
+      return updateProject(projectId, { name });
+    },
+    onSuccess: (updated) => {
+      if (projectId) {
+        queryClient.setQueryData(['project', projectId], updated);
+      }
+      queryClient.invalidateQueries({ queryKey: ['projects'] });
+      toast.success('Project renamed');
+      onSaved?.();
+      onOpenChange(false);
+    },
+    onError: (err) => {
+      toast.error(err instanceof Error ? err.message : 'Failed to rename project');
+    },
+  });
+
+  const trimmed = value.trim();
+  const isUnchanged = trimmed === (currentName ?? '').trim();
+  const isEmpty = trimmed.length === 0;
+
+  const submit = () => {
+    if (!projectId || renameMutation.isPending || isUnchanged || isEmpty) return;
+    renameMutation.mutate(trimmed);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Rename project</DialogTitle>
+          <DialogDescription>
+            Give this project a new name.
+          </DialogDescription>
+        </DialogHeader>
+        <Input
+          autoFocus
+          value={value}
+          maxLength={MAX_NAME_LENGTH}
+          placeholder="Project name"
+          onChange={(e) => setValue(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              submit();
+            }
+          }}
+        />
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            onClick={submit}
+            disabled={renameMutation.isPending || isUnchanged || isEmpty}
+          >
+            {renameMutation.isPending ? 'Saving…' : 'Save'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## What

Adds a **Rename** action to each project card's overflow (⋯) menu on the `/projects` dashboard — right where you'd expect it, next to *Open project* and *Archive*. Clicking it opens a small dialog prefilled with the current name; hit Enter or Save to rename.

Requested in Slack: rename a project straight from the dashboard via the 3-dots menu, instead of having to dig into Settings.

## How

- `ProjectCard` gains an `onRename` callback and a `Rename` menu item (pencil icon), gated by `canManageProject` so it mirrors the existing Archive permission.
- New `RenameProjectDialog` component PATCHes the name through the existing `updateProject` client (`PATCH /projects/:id` already accepts `name`), then optimistically updates the `['project', id]` cache and invalidates `['projects']`.
- Wired into both the single-account and all-accounts views.

## Notes

- No API or schema changes — the backend already supported `name` on `PATCH /projects/:id`.
- Empty / unchanged names are disabled; max length 120.

## Test plan

- [x] `pnpm --filter ./apps/web build` passes
- [ ] On `/projects`, open the ⋯ menu on a project card → **Rename** → change the name → card updates, toast confirms
- [ ] Verify a non-manager sees Rename disabled
