### PR TITLE
feat(projects): duplicate ("clone") a project + rename from the dashboard

### DIFF
--- a/apps/api/src/projects/git-backends/clone.ts
+++ b/apps/api/src/projects/git-backends/clone.ts
@@ -1,0 +1,85 @@
+/**
+ * Provider-neutral repo duplicator: copy the contents of one repo's default
+ * branch into a freshly-created (empty) managed repo.
+ *
+ * Used by the project "Duplicate" flow. Unlike `seedRepoViaGitPush` (which lays
+ * down a fixed starter), this clones the *source* project's repo and pushes a
+ * single fresh commit (history is intentionally flattened — a duplicate is a new
+ * project, not a fork) to the destination. Both ends authenticate with the same
+ * `x-access-token` basic scheme, injected per-invocation through
+ * http.extraHeader so neither token ever lands in a git config file.
+ */
+import { execFile } from 'node:child_process';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+function extraHeaderArgs(upstreamUrl: string, token: string | null): string[] {
+  if (!token) return [];
+  const host = new URL(upstreamUrl).host;
+  const encoded = Buffer.from(`x-access-token:${token}`).toString('base64');
+  return ['-c', `http.https://${host}/.extraheader=AUTHORIZATION: basic ${encoded}`];
+}
+
+/**
+ * Clone the source repo's branch and push its tree as a single fresh commit to
+ * the destination repo's branch. The destination must already exist (empty).
+ */
+export async function cloneRepoContents(input: {
+  sourceUrl: string;
+  sourceToken: string | null;
+  sourceBranch: string;
+  destUrl: string;
+  destToken: string | null;
+  destBranch?: string;
+  commitMessage?: string;
+  authorName?: string;
+  authorEmail?: string;
+}): Promise<void> {
+  const destBranch = input.destBranch || input.sourceBranch || 'main';
+  const name = input.authorName || 'Kortix';
+  const email = input.authorEmail || 'noreply@kortix.ai';
+  const dir = await mkdtemp(join(tmpdir(), 'kortix-clone-'));
+
+  const env = { ...process.env, GIT_TERMINAL_PROMPT: '0' };
+  const run = (args: string[], extra: string[] = []) =>
+    execFileAsync('git', [...extra, ...args], { cwd: dir, env, timeout: 120_000, maxBuffer: 64 * 1024 * 1024 });
+
+  try {
+    // Shallow single-branch clone of the source — we only need the current tree,
+    // not its history (a duplicate starts fresh).
+    await run(
+      [
+        'clone',
+        '--depth', '1',
+        '--single-branch',
+        '--branch', input.sourceBranch,
+        input.sourceUrl,
+        '.',
+      ],
+      extraHeaderArgs(input.sourceUrl, input.sourceToken),
+    );
+
+    // Drop the source's git history: re-init so the duplicate has exactly one
+    // clean commit and no link back to the original repo.
+    await rm(join(dir, '.git'), { recursive: true, force: true });
+    await run(['init', '-b', destBranch]);
+    await run(['config', 'user.name', name]);
+    await run(['config', 'user.email', email]);
+    await run(['add', '-A']);
+    await run(['commit', '-m', input.commitMessage || 'chore: duplicate Kortix project']);
+    await run(
+      ['push', input.destUrl, `${destBranch}:refs/heads/${destBranch}`],
+      extraHeaderArgs(input.destUrl, input.destToken),
+    );
+  } catch (error) {
+    const err = error as { stderr?: Buffer | string; message?: string };
+    const detail = (err.stderr?.toString() || err.message || 'git failed').trim();
+    throw new Error(`git duplicate failed — ${detail}`);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}

--- a/apps/api/src/projects/git-backends/index.ts
+++ b/apps/api/src/projects/git-backends/index.ts
@@ -2,3 +2,4 @@ export * from './types';
 export { getBackend, getDefaultManagedBackend, hasBackend } from './registry';
 export { githubBackend, managedGithubInstallId, managedGithubToken } from './github';
 export { seedRepoViaGitPush } from './seed';
+export { cloneRepoContents } from './clone';

--- a/apps/api/src/projects/routes/r1.ts
+++ b/apps/api/src/projects/routes/r1.ts
@@ -6,6 +6,7 @@ import { db } from '../../shared/db';
 import { kickProjectTemplatePrebuilds } from '../../snapshots/builder';
 import { isAccountManager, type ProjectRole } from '../access';
 import { getBackend, hasBackend, type GitScope } from '../git-backends';
+import { cloneRepoContents } from '../git-backends/clone';
 import { seedRepoViaGitPush } from '../git-backends/seed';
 import { createRepo, getGitHubAppInstallation, listInstallationRepositories, verifyGitHubAppInstallStatePayload } from '../github';
 import { getProjectSecretValue } from '../secrets';
@@ -486,6 +487,214 @@ projectsApp.openapi(
       push_token: pushToken,
       repo_id: provisioned.externalRepoId,
       seeded,
+    },
+    201,
+  );
+},
+);
+
+// POST /v1/projects/:projectId/duplicate
+// Duplicate ("clone") an existing project: provision a fresh managed repo, copy
+// the source repo's default-branch tree into it as a single clean commit (no
+// history, no link back), and register it as a brand-new project under the same
+// account. Source can be any project the caller can read; the duplicate is
+// always a fresh MANAGED repo regardless of how the source is hosted.
+
+projectsApp.openapi(
+  createRoute({
+    method: 'post',
+    path: '/{projectId}/duplicate',
+    tags: ['projects'],
+    summary: 'POST /:projectId/duplicate',
+    ...auth,
+      request: {
+        params: z.object({ projectId: z.string() }),
+        body: { content: { 'application/json': { schema: AnyObject } } },
+      },
+    responses: {
+        201: json(z.any(), 'OK'),
+        ...errors(400, 403, 404, 502, 503),
+    },
+  }),
+  async (c: any) => {
+  const sourceProjectId = c.req.param('projectId');
+  const body = await readBody(c);
+
+  // Caller must be able to READ the source, and CREATE projects in the account.
+  const loaded = await loadProjectForUser(c, sourceProjectId, 'read');
+  if (!loaded) return c.json({ error: 'Not found' }, 404);
+  const source = loaded.row;
+  if (!(await authorize(loaded.userId, source.accountId, ACCOUNT_ACTIONS.PROJECT_CREATE)).allowed) {
+    return c.json({ error: 'Owner or admin role required' }, 403);
+  }
+
+  // Resolve the SOURCE upstream + a read credential up front so we fail fast
+  // (before provisioning anything) if we can't reach the source repo.
+  const sourceRemote = getProjectGitRemote(source, await getProjectGitConnection(source.projectId));
+  const sourceRef = buildConnectionRef(source, sourceRemote);
+  if (!sourceRef.upstreamUrl) {
+    return c.json({ error: 'Source project has no repository to duplicate' }, 400);
+  }
+  const sourceToken = (await resolveProjectGitAuth(source)).auth?.token ?? null;
+  const sourceBranch = source.defaultBranch || 'main';
+
+  // The duplicate always lands on the managed backend (provider-agnostic via the
+  // registry), same as POST /provision.
+  const provider =
+    normalizeString(body.provider) ??
+    (process.env.MANAGED_GIT_PROVIDER?.trim() || 'github');
+  if (!hasBackend(provider)) {
+    return c.json({ error: `Unsupported managed git provider "${provider}"` }, 400);
+  }
+  const backend = getBackend(provider);
+  if (!(await backend.isConfigured())) {
+    return c.json(
+      { error: `Managed git provider "${provider}" is not configured on this server` },
+      503,
+    );
+  }
+
+  // Default the duplicate's name to "<source> (copy)" unless the caller renames.
+  const name =
+    normalizeString(body.name) ??
+    normalizeString(body.project_name ?? body.projectName) ??
+    `${source.name} (copy)`;
+  if (!/^[a-zA-Z0-9._ -]+$/.test(name)) {
+    return c.json(
+      { error: 'name must contain only letters, numbers, spaces, hyphens, underscores or dots' },
+      400,
+    );
+  }
+
+  const projectId = randomUUID();
+  const baseSlug = (
+    name.trim().toLowerCase().replace(/[^a-z0-9._-]+/g, '-').replace(/^-+|-+$/g, '') ||
+    'kortix-project'
+  ).slice(0, 40);
+  const repoSlug = `${baseSlug}-${projectId}`;
+  const defaultBranch = sourceBranch;
+
+  const dupQuota = await enforceProjectQuota(c, source.accountId);
+  if (dupQuota) return dupQuota;
+
+  let provisioned: Awaited<ReturnType<typeof backend.createRepo>>;
+  try {
+    provisioned = await backend.createRepo({
+      accountId: source.accountId,
+      projectId,
+      slug: repoSlug,
+      defaultBranch,
+      isPrivate: true,
+    });
+  } catch (error) {
+    return c.json({ error: (error as Error).message || 'Failed to provision managed repo' }, 502);
+  }
+
+  const authMethod = provider === 'github' ? 'github_app' : 'managed';
+  const now = new Date();
+  const [row] = await db
+    .insert(projects)
+    .values({
+      projectId,
+      accountId: source.accountId,
+      name,
+      repoUrl: provisioned.upstreamUrl,
+      defaultBranch: provisioned.defaultBranch,
+      // Preserve the source's manifest path so the duplicate boots identically.
+      manifestPath: source.manifestPath || 'kortix.toml',
+      status: 'active',
+      metadata: {
+        git: {
+          url: provisioned.upstreamUrl,
+          upstream_url: provisioned.upstreamUrl,
+          default_branch: provisioned.defaultBranch,
+          provider,
+          managed: true,
+          auth: {
+            method: authMethod,
+            ref: provisioned.credentialRef,
+            installation_id: provisioned.installationId,
+          },
+          repo_id: provisioned.externalRepoId,
+          owner: provisioned.repoOwner,
+          name: provisioned.repoName,
+        },
+        duplicated_from: source.projectId,
+      },
+      updatedAt: now,
+    })
+    .onConflictDoUpdate({
+      target: [projects.accountId, projects.repoUrl],
+      set: { name, defaultBranch: provisioned.defaultBranch, status: 'active', updatedAt: now },
+    })
+    .returning();
+
+  await grantProjectRole({
+    accountId: source.accountId,
+    projectId: row.projectId,
+    userId: loaded.userId,
+    role: 'manager',
+    grantedBy: loaded.userId,
+  });
+  await upsertProjectGitConnection({
+    accountId: source.accountId,
+    projectId: row.projectId,
+    provider,
+    repoUrl: provisioned.upstreamUrl,
+    upstreamUrl: provisioned.upstreamUrl,
+    managed: true,
+    repoOwner: provisioned.repoOwner,
+    repoName: provisioned.repoName,
+    externalRepoId: provisioned.externalRepoId,
+    defaultBranch: provisioned.defaultBranch,
+    authMethod,
+    installationId: provisioned.installationId,
+    credentialRef: provisioned.credentialRef,
+    visibility: 'private',
+    status: 'connected',
+    metadata: { seeded: false, duplicated_from: source.projectId },
+  });
+
+  // Resolve a push credential for the destination, then copy the source tree
+  // over. If the copy fails we roll back the orphan repo + project so we never
+  // leave a half-created duplicate behind.
+  let pushToken = provisioned.initialToken;
+  if (!pushToken) {
+    pushToken = (await resolveProjectGitAuth(row)).auth?.token ?? null;
+  }
+  const connRef = buildConnectionRef(row, getProjectGitRemote(row, await getProjectGitConnection(row.projectId)));
+  try {
+    if (!pushToken) throw new Error('no push credential resolved for duplication');
+    await cloneRepoContents({
+      sourceUrl: sourceRef.upstreamUrl,
+      sourceToken,
+      sourceBranch,
+      destUrl: connRef.upstreamUrl,
+      destToken: pushToken,
+      destBranch: provisioned.defaultBranch,
+      commitMessage: `chore: duplicate from ${source.name}`,
+    });
+  } catch (error) {
+    try { await backend.deleteRepo(connRef); } catch { /* best effort */ }
+    await db.delete(projects).where(eq(projects.projectId, row.projectId)).catch(() => {});
+    return c.json({ error: (error as Error).message || 'Failed to duplicate project repo' }, 502);
+  }
+
+  kickProjectTemplatePrebuilds(
+    {
+      projectId: row.projectId,
+      repoUrl: row.repoUrl,
+      defaultBranch: row.defaultBranch,
+      manifestPath: row.manifestPath,
+      gitAuthToken: pushToken,
+    },
+    { accountId: source.accountId, source: 'project-create' },
+  );
+
+  return c.json(
+    {
+      ...serializeProject(row, { projectRole: 'manager', effectiveRole: 'manager' }),
+      duplicated_from: source.projectId,
     },
     201,
   );

--- a/apps/web/src/app/projects/page.tsx
+++ b/apps/web/src/app/projects/page.tsx
@@ -6,9 +6,11 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useMutation, useQueries, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
+  Copy,
   FolderPlus,
   Loader2,
   MoreHorizontal,
+  Pencil,
   Plus,
   Search,
   Trash2,
@@ -18,12 +20,14 @@ import { useAuth } from '@/components/AuthProvider';
 import { ConnectingScreen } from '@/components/dashboard/connecting-screen';
 import { AppHeader } from '@/components/layout/app-header';
 import { ProjectCreateModal } from '@/components/projects/project-create-modal';
+import { RenameProjectDialog } from '@/components/projects/rename-project-dialog';
 import { LegacyMachineCard } from '@/components/projects/legacy-machine-card';
 import { SunaMigrationBanner } from '@/components/projects/suna-migration-banner';
 import { PersonalOnboardingWelcome } from '@/components/projects/personal-onboarding-welcome';
 import { useLegacyMachines, useStartLegacyMigration } from '@/hooks/legacy/use-legacy-machine-migration';
 import {
   archiveProject,
+  duplicateProject,
   listAccounts,
   listProjectsForAccount,
   type KortixAccount,
@@ -71,12 +75,18 @@ function ProjectCard({
   project,
   onOpen,
   onArchive,
+  onRename,
+  onDuplicate,
   archiving,
+  duplicating,
 }: {
   project: KortixProject;
   onOpen: () => void;
   onArchive: () => void;
+  onRename: () => void;
+  onDuplicate: () => void;
   archiving: boolean;
+  duplicating: boolean;
 }) {
   const tHardcodedUi = useTranslations('hardcodedUi');
   const updatedLabel = relativeTime(project.updated_at);
@@ -122,6 +132,27 @@ function ProjectCard({
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end" className="w-44">
             <DropdownMenuItem onSelect={onOpen}>{tHardcodedUi.raw('appProjectsPage.line109JsxTextOpenProject')}</DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              onSelect={onRename}
+              disabled={!canManageProject}
+              className="gap-2"
+            >
+              <Pencil className="h-3.5 w-3.5" />
+              Rename
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onSelect={onDuplicate}
+              disabled={duplicating || !canManageProject}
+              className="gap-2"
+            >
+              {duplicating ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <Copy className="h-3.5 w-3.5" />
+              )}
+              Duplicate
+            </DropdownMenuItem>
             <DropdownMenuSeparator />
             <DropdownMenuItem
               onSelect={onArchive}
@@ -236,6 +267,8 @@ export default function ProjectsPage() {
   const { viewMode, setViewMode } = useProjectsViewStore();
   const [query, setQuery] = useState('');
   const [archivingId, setArchivingId] = useState<string | null>(null);
+  const [duplicatingId, setDuplicatingId] = useState<string | null>(null);
+  const [renameTarget, setRenameTarget] = useState<KortixProject | null>(null);
   const [modalOpen, setModalOpen] = useState(false);
   // Which account a newly-created project lands in. In "all accounts" view the
   // user picks it via the New-project dropdown; otherwise it's the active one.
@@ -393,6 +426,25 @@ export default function ProjectsPage() {
     },
     onError: (error: Error) => {
       toast.error(error.message || 'Failed to archive project');
+    },
+  });
+
+  const duplicateMutation = useMutation({
+    mutationFn: (projectId: string) => duplicateProject(projectId),
+    onMutate: (projectId) => setDuplicatingId(projectId),
+    onSettled: () => setDuplicatingId(null),
+    onSuccess: (project) => {
+      queryClient.invalidateQueries({ queryKey: ['projects'] });
+      toast.success('Project duplicated', {
+        description: `Created "${project.name}".`,
+        action: {
+          label: 'Open',
+          onClick: () => router.push(`/projects/${project.project_id}`),
+        },
+      });
+    },
+    onError: (error: Error) => {
+      toast.error(error.message || 'Failed to duplicate project');
     },
   });
 
@@ -574,13 +626,16 @@ export default function ProjectsPage() {
                       onOpenProject={(projectId) => router.push(`/projects/${projectId}`)}
                     />
                   ))}
-                  {filtered.map((project) => (
+                   {filtered.map((project) => (
                     <ProjectCard
                       key={project.project_id}
                       project={project}
                       onOpen={() => router.push(`/projects/${project.project_id}`)}
                       onArchive={() => archiveMutation.mutate(project.project_id)}
+                      onRename={() => setRenameTarget(project)}
+                      onDuplicate={() => duplicateMutation.mutate(project.project_id)}
                       archiving={archivingId === project.project_id}
+                      duplicating={duplicatingId === project.project_id}
                     />
                   ))}
                 </div>
@@ -668,7 +723,10 @@ export default function ProjectsPage() {
                             router.push(`/projects/${project.project_id}`);
                           }}
                           onArchive={() => archiveMutation.mutate(project.project_id)}
+                          onRename={() => setRenameTarget(project)}
+                          onDuplicate={() => duplicateMutation.mutate(project.project_id)}
                           archiving={archivingId === project.project_id}
+                          duplicating={duplicatingId === project.project_id}
                         />
                       ))}
                     </div>
@@ -686,6 +744,15 @@ export default function ProjectsPage() {
           if (!o) setCreateAccountId(null);
         }}
         accountId={createAccountId ?? activeAccountId}
+      />
+
+      <RenameProjectDialog
+        projectId={renameTarget?.project_id ?? null}
+        currentName={renameTarget?.name}
+        open={!!renameTarget}
+        onOpenChange={(o) => {
+          if (!o) setRenameTarget(null);
+        }}
       />
 
       <PersonalOnboardingWelcome />

--- a/apps/web/src/components/projects/rename-project-dialog.tsx
+++ b/apps/web/src/components/projects/rename-project-dialog.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { toast } from '@/lib/toast';
+import { updateProject } from '@/lib/projects-client';
+
+interface RenameProjectDialogProps {
+  projectId: string | null;
+  /** Current name, prefilled into the input. */
+  currentName?: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSaved?: () => void;
+}
+
+const MAX_NAME_LENGTH = 120;
+// Mirrors the API's project-name guard (letters, numbers, spaces, . - _).
+const NAME_PATTERN = /^[a-zA-Z0-9._ -]+$/;
+
+export function RenameProjectDialog({
+  projectId,
+  currentName,
+  open,
+  onOpenChange,
+  onSaved,
+}: RenameProjectDialogProps) {
+  const queryClient = useQueryClient();
+  const [value, setValue] = useState(currentName ?? '');
+
+  // Reset the field whenever a new project opens the dialog.
+  useEffect(() => {
+    if (open) setValue(currentName ?? '');
+  }, [open, currentName]);
+
+  const renameMutation = useMutation({
+    mutationFn: (name: string) => {
+      if (!projectId) throw new Error('No project selected');
+      return updateProject(projectId, { name });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['projects'] });
+      toast.success('Project renamed');
+      onSaved?.();
+      onOpenChange(false);
+    },
+    onError: (err) => {
+      toast.error(err instanceof Error ? err.message : 'Failed to rename project');
+    },
+  });
+
+  const trimmed = value.trim();
+  const isUnchanged = trimmed === (currentName ?? '').trim();
+  const isValid = trimmed.length > 0 && NAME_PATTERN.test(trimmed);
+
+  const submit = () => {
+    if (!projectId || renameMutation.isPending || isUnchanged || !isValid) return;
+    renameMutation.mutate(trimmed);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Rename project</DialogTitle>
+          <DialogDescription>
+            Give this project a new name. This only changes its display name, not
+            its repository.
+          </DialogDescription>
+        </DialogHeader>
+        <Input
+          autoFocus
+          value={value}
+          maxLength={MAX_NAME_LENGTH}
+          placeholder="Project name"
+          onChange={(e) => setValue(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              submit();
+            }
+          }}
+        />
+        {trimmed.length > 0 && !isValid && (
+          <p className="text-xs text-destructive">
+            Use only letters, numbers, spaces, hyphens, underscores or dots.
+          </p>
+        )}
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            onClick={submit}
+            disabled={renameMutation.isPending || isUnchanged || !isValid}
+          >
+            {renameMutation.isPending ? 'Saving…' : 'Save'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/lib/projects-client.ts
+++ b/apps/web/src/lib/projects-client.ts
@@ -2145,6 +2145,23 @@ export async function provisionProject(input: ProvisionProjectInput) {
   );
 }
 
+/**
+ * Duplicate ("clone") an existing project — provisions a fresh managed repo,
+ * copies the source's default-branch tree into it as a single clean commit, and
+ * returns the new project. Defaults the name to "<source> (copy)" when omitted.
+ */
+export async function duplicateProject(
+  projectId: string,
+  input?: { name?: string },
+) {
+  return unwrap(
+    await backendApi.post<KortixProject & { duplicated_from?: string }>(
+      `/projects/${projectId}/duplicate`,
+      input ?? {},
+    ),
+  );
+}
+
 export async function linkRepository(input: LinkRepositoryInput) {
   return unwrap(
     await backendApi.post<LinkRepositoryResponse>(


### PR DESCRIPTION
Adds two project-management actions to the projects dashboard.

## What

**Duplicate ("clone") a project**
- New `POST /v1/projects/:projectId/duplicate` endpoint:
  - Provisions a fresh **managed** repo (provider-agnostic via the backend registry — always managed regardless of how the source is hosted).
  - Copies the source repo's default-branch tree into it as a **single clean commit** (history flattened, no link back to the original).
  - Registers it as a brand-new project under the same account, grants the caller `manager`, wires the git connection, and kicks template prebuilds.
  - Rolls back the orphan repo + project row if the tree copy fails, so a failed duplicate never leaves half-created state.
  - AuthZ: caller needs **read** on the source and **project-create** on the account. Enforces the account project quota.
- New `cloneRepoContents()` git-backend helper: provider-neutral shallow single-branch clone -> re-init -> single commit -> push to the (empty) destination. Tokens are injected per-invocation via `http.extraHeader` so neither source nor dest credential is ever written to a git config file.
- Client: `duplicateProject(projectId, { name? })`; name defaults to `"<source> (copy)"`.

**Rename from the dashboard**
- The project card menu now has **Rename** (reuses the existing `RenameProjectDialog`, display-name only) and **Duplicate**, both gated on manage permission, with inline spinners. Duplicate fires a success toast that deep-links straight into the new project.

## Verification
- `apps/api` `tsc --noEmit` — clean.
- `apps/web` `tsc --noEmit` — no errors in the changed files (`projects/page.tsx`, `projects-client.ts`, `rename-project-dialog.tsx`). Pre-existing unrelated errors in `tool-icons.ts` and the build-generated `@/.source` module remain.
