### PR TITLE
fix(slack): finalize turn stream on session.idle; drop the "On it…" placeholder

### DIFF
--- a/apps/api/src/__tests__/unit-slack-turn-finalize.test.ts
+++ b/apps/api/src/__tests__/unit-slack-turn-finalize.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+
+// Capture every slack-api side effect so we can assert exactly what a turn
+// finalization posts to Slack. finalizeStream only talks to slack-api (never the
+// DB), so mocking this module is enough to unit-test its behavior.
+const calls: Array<{ fn: string; args: unknown[] }> = [];
+const rec = (fn: string) => (...args: unknown[]) => {
+  calls.push({ fn, args });
+  // startStream/postMessage/postBlocks return a ts; others return void.
+  if (fn === 'startStream' || fn === 'postMessage' || fn === 'postBlocks') return Promise.resolve('ts.posted');
+  return Promise.resolve();
+};
+
+mock.module('../channels/slack-api', () => ({
+  addReaction: rec('addReaction'),
+  removeReaction: rec('removeReaction'),
+  joinChannel: rec('joinChannel'),
+  postMessage: rec('postMessage'),
+  postBlocks: rec('postBlocks'),
+  deleteMessage: rec('deleteMessage'),
+  startStream: rec('startStream'),
+  appendStream: rec('appendStream'),
+  stopStream: rec('stopStream'),
+  updateBlocks: rec('updateBlocks'),
+}));
+
+const { finalizeStream } = await import('../channels/slack/streams');
+import type { TurnStream } from '../channels/slack/types';
+
+function makeHandle(over: Partial<TurnStream> = {}): TurnStream {
+  return {
+    channel: 'C1',
+    ts: '',
+    token: 'xoxb-test',
+    triggerTs: '100.1',
+    steps: [],
+    streaming: false,
+    placeholderActive: false,
+    expiry: Date.now() + 60_000,
+    finalized: false,
+    projectId: 'p1',
+    sessionId: 's1',
+    teamId: 'T1',
+    originatingEvent: { channel: 'C1', ts: '100.1', user: 'U1', thread_ts: '100.0' } as never,
+    ...over,
+  };
+}
+
+const fns = () => calls.map((c) => c.fn);
+afterEach(() => {
+  calls.length = 0;
+});
+
+describe('finalizeStream — silent turn (the stuck "On it…" fix)', () => {
+  test('bare handle + no content posts NOTHING to the thread', async () => {
+    await finalizeStream(makeHandle(), {});
+    // No message, no blocks, no stream — only the working reaction is cleared.
+    expect(fns()).not.toContain('postMessage');
+    expect(fns()).not.toContain('postBlocks');
+    expect(fns()).not.toContain('stopStream');
+    expect(fns()).toContain('removeReaction');
+  });
+
+  test('bare handle + answer posts the reply + check reaction', async () => {
+    await finalizeStream(makeHandle(), { answer: 'here you go' });
+    const post = calls.find((c) => c.fn === 'postMessage');
+    expect(post).toBeDefined();
+    expect(post!.args[2]).toBe('here you go');
+    expect(fns()).toContain('removeReaction');
+    // success reaction only on a real answer
+    expect(calls.some((c) => c.fn === 'addReaction' && c.args[3] === 'white_check_mark')).toBe(true);
+  });
+
+  test('streaming handle + no content closes the plan WITHOUT a filler message', async () => {
+    const handle = makeHandle({
+      streaming: true,
+      ts: 'stream.ts',
+      steps: [{ type: 'task_update', id: 'step-0', title: 'Working', status: 'in_progress' }],
+    });
+    await finalizeStream(handle, {});
+    expect(fns()).toContain('stopStream');
+    // The stop chunks must not contain a markdown_text body (no "_Done._").
+    const stop = calls.find((c) => c.fn === 'stopStream')!;
+    const chunks = stop.args[3] as Array<{ type: string }>;
+    expect(chunks.some((ch) => ch.type === 'markdown_text')).toBe(false);
+    // Last in-progress step is closed as complete.
+    expect(chunks.some((ch) => ch.type === 'task_update')).toBe(true);
+  });
+
+  test('streaming handle + error closes the plan as error with the message', async () => {
+    const handle = makeHandle({
+      streaming: true,
+      ts: 'stream.ts',
+      steps: [{ type: 'task_update', id: 'step-0', title: 'Working', status: 'in_progress' }],
+    });
+    await finalizeStream(handle, { error: 'boom' });
+    const stop = calls.find((c) => c.fn === 'stopStream')!;
+    const chunks = stop.args[3] as Array<{ type: string; status?: string }>;
+    expect(chunks.some((ch) => ch.type === 'markdown_text')).toBe(true);
+    expect(chunks.some((ch) => ch.status === 'error')).toBe(true);
+    // an error is not a success — no check reaction
+    expect(calls.some((c) => c.fn === 'addReaction' && c.args[3] === 'white_check_mark')).toBe(false);
+  });
+
+  test('legacy placeholder still up + no content is deleted (cross-deploy cleanup)', async () => {
+    await finalizeStream(makeHandle({ placeholderActive: true, ts: 'old.placeholder' }), {});
+    expect(fns()).toContain('deleteMessage');
+    expect(fns()).not.toContain('postMessage');
+  });
+
+  test('already finalized is a no-op', async () => {
+    await finalizeStream(makeHandle({ finalized: true }), { answer: 'ignored' });
+    expect(calls.length).toBe(0);
+  });
+});

--- a/apps/api/src/channels/slack-webhook.ts
+++ b/apps/api/src/channels/slack-webhook.ts
@@ -6,5 +6,5 @@
 import './slack/routes';
 
 export { slackWebhookApp } from './slack/app';
-export { postQuestionAndWait, relayTurnStep, relayTurnAnswer } from './slack/questions';
+export { postQuestionAndWait, relayTurnStep, relayTurnAnswer, relayTurnEnd } from './slack/questions';
 export type { QuestionInfo } from './slack/questions';

--- a/apps/api/src/channels/slack/questions.ts
+++ b/apps/api/src/channels/slack/questions.ts
@@ -214,6 +214,21 @@ export async function relayTurnAnswer(
   return true;
 }
 
+// Called when the agent's turn goes idle (opencode `session.idle` on the root
+// session). If the agent already delivered its reply via `slack send`, the
+// stream is gone and there's nothing to do. If it ended WITHOUT sending — e.g.
+// it judged the message needed no reply — we silently close the live stream so
+// the "On it…" placeholder / streaming plan doesn't hang until the 15-min
+// watchdog. No "_Done._" filler is posted (see finalizeStream's silent path).
+export async function relayTurnEnd(sessionId: string): Promise<boolean> {
+  const handle = await loadStream(sessionId);
+  if (!handle || handle.finalized) return false;
+  if (!(await claimFinalize(sessionId))) return false;
+  await finalizeStream(handle, {});
+  await deleteStream(sessionId);
+  return true;
+}
+
 export async function handleAskSubmit(payload: SlackInteractionPayload, askId: string): Promise<void> {
   const pending = pendingAsks.get(askId);
   if (!pending) {

--- a/apps/api/src/channels/slack/streams.ts
+++ b/apps/api/src/channels/slack/streams.ts
@@ -134,17 +134,15 @@ export async function startTurnStream(
   if (!event.channel || !event.ts || !event.user) return null;
   const token = await loadSlackTokenForProject(projectId);
   if (!token) return null;
-  const threadTs = event.thread_ts ?? event.ts;
   await joinChannel(token, event.channel);
+  // The only eager feedback is a ⏳ reaction on the user's own message — a
+  // lightweight "received, working on it" signal that lives ON their message,
+  // not a standalone bot post. We deliberately DON'T post an "On it…" message:
+  // a turn that ends without `slack send` (e.g. nothing worth replying to) then
+  // leaves the thread untouched, and `session.idle` clears the reaction. The
+  // plan stream is opened lazily on the first `slack step`; the final answer is
+  // posted by `slack send`.
   await addReaction(token, event.channel, event.ts, WORKING_EMOJI);
-
-  const placeholderTs = await postMessage(
-    token,
-    event.channel,
-    '⏳  _On it…_',
-    threadTs,
-  );
-  if (!placeholderTs) return null;
 
   return {
     channel: event.channel,
@@ -156,10 +154,10 @@ export async function startTurnStream(
     sessionId: '',
     teamId,
     originatingEvent: event,
-    ts: placeholderTs,
+    ts: '',
     steps: [],
     streaming: false,
-    placeholderActive: true,
+    placeholderActive: false,
   };
 }
 
@@ -201,13 +199,20 @@ export function buildSlackTurnEnv(teamId: string, event: SlackEvent): Record<str
   return env;
 }
 
+// Close out a turn's live stream. Three shapes of finalization:
+//   • answer/error/blocks present → render that as the reply.
+//   • nothing present (a "silent" finalize, e.g. the agent ended its turn
+//     without `slack send`) → DON'T invent a "_Done._" message. If a plan was
+//     streaming, just close it cleanly; if nothing was ever posted, leave the
+//     thread untouched. This is what stops an orphaned "On it…" from lingering.
 export async function finalizeStream(
   handle: TurnStream,
   opts: { answer?: string; error?: string; blocks?: unknown[] },
 ): Promise<void> {
   if (handle.finalized) return;
   handle.finalized = true;
-  const body = (opts.answer ?? opts.error ?? '_Done._').slice(0, 11000);
+  const hasContent = Boolean(opts.answer || opts.error || (opts.blocks && opts.blocks.length > 0));
+  const body = (opts.answer ?? opts.error ?? '').slice(0, 11000);
   const ev = handle.originatingEvent;
   const threadRoot = ev.thread_ts ?? ev.ts ?? handle.triggerTs;
   if (handle.streaming) {
@@ -224,7 +229,7 @@ export async function finalizeStream(
     }
     if (opts.blocks && opts.blocks.length > 0) {
       chunks.push({ type: 'blocks', blocks: opts.blocks });
-    } else {
+    } else if (hasContent) {
       chunks.push({ type: 'markdown_text', text: body });
     }
     await stopStream(handle.token, handle.channel, handle.ts, chunks);
@@ -235,14 +240,22 @@ export async function finalizeStream(
       planTitleFor(opts),
       buildFinalPlanBlocks(handle, body, opts),
     );
-  } else if (handle.placeholderActive && handle.ts) {
-    await deleteMessage(handle.token, handle.channel, handle.ts);
-    handle.placeholderActive = false;
+  } else if (hasContent) {
+    // No plan was streamed, but there's a reply to deliver. Drop any legacy
+    // placeholder first, then post the answer in its place.
+    if (handle.placeholderActive && handle.ts) {
+      await deleteMessage(handle.token, handle.channel, handle.ts);
+      handle.placeholderActive = false;
+    }
     if (opts.blocks && opts.blocks.length > 0) {
       await postBlocks(handle.token, handle.channel, body, opts.blocks, threadRoot);
     } else {
       await postMessage(handle.token, handle.channel, body, threadRoot);
     }
+  } else if (handle.placeholderActive && handle.ts) {
+    // Silent finalize with a legacy placeholder still up → just remove it.
+    await deleteMessage(handle.token, handle.channel, handle.ts);
+    handle.placeholderActive = false;
   }
   await removeReaction(handle.token, handle.channel, handle.triggerTs, WORKING_EMOJI);
   if (opts.answer && !opts.error) {
@@ -291,7 +304,7 @@ function buildFinalPlanBlocks(
   ];
   if (opts.blocks && opts.blocks.length > 0) {
     for (const b of opts.blocks) blocks.push(b as Record<string, unknown>);
-  } else if (body && body !== '_Done._') {
+  } else if (body) {
     blocks.push({ type: 'section', text: { type: 'mrkdwn', text: body } });
   }
   return blocks;

--- a/apps/api/src/projects/routes/r4.ts
+++ b/apps/api/src/projects/routes/r4.ts
@@ -1,7 +1,7 @@
 import { deleteSlackInstall, loadSlackInstall, saveSlackInstall } from '../../channels/install-store';
 import { buildSlackInstallUrl } from '../../channels/slack-oauth';
 import { slackOauthMode } from '../../channels/slack-oauth-mode';
-import { postQuestionAndWait, relayTurnAnswer, relayTurnStep, type QuestionInfo } from '../../channels/slack-webhook';
+import { postQuestionAndWait, relayTurnAnswer, relayTurnEnd, relayTurnStep, type QuestionInfo } from '../../channels/slack-webhook';
 import { PROJECT_ACTIONS, assertAuthorized } from '../../iam';
 import { auth, errors, json } from '../../openapi';
 import { db } from '../../shared/db';
@@ -425,9 +425,21 @@ projectsApp.openapi(
     return c.json({ error: 'Invalid JSON body' }, 400);
   }
   const sessionId = body.session_id?.trim();
+  if (!sessionId) {
+    return c.json({ error: 'session_id is required' }, 400);
+  }
+
+  // `end` carries no text — it just closes the live stream when the agent's turn
+  // went idle without sending a final answer (so a silent turn doesn't leave the
+  // "On it…" placeholder hanging until the watchdog).
+  if (body.kind === 'end') {
+    const ended = await relayTurnEnd(sessionId);
+    return c.json({ ok: ended });
+  }
+
   const text = (body.text ?? '').trim();
-  if (!sessionId || !text) {
-    return c.json({ error: 'session_id and text are required' }, 400);
+  if (!text) {
+    return c.json({ error: 'text is required' }, 400);
   }
 
   const detail = body.detail?.trim() || undefined;

--- a/apps/kortix-sandbox-agent-server/src/main.ts
+++ b/apps/kortix-sandbox-agent-server/src/main.ts
@@ -11,7 +11,7 @@ import {
   runGitCredentialHelper,
 } from './git'
 import { logger } from './logger'
-import { createOpencodeSupervisor, OPENCODE_HOME, waitForOpencodeReady } from './opencode'
+import { createOpencodeSupervisor, OPENCODE_HOME, waitForOpencodeReady, type Opencode } from './opencode'
 import { ensureOpencodeConfigDeps } from './opencode-config-deps'
 import { startOpencodeEventLoop, type QuestionRequest } from './opencode-events'
 import { createProjectEnvStore } from './project-env'
@@ -206,6 +206,11 @@ async function startSessionRuntime(
       logger.warn('[opencode-events] question relay failed', { err: (err as Error).message }),
     )
   }
+  const onSessionIdle = (opencodeSessionId: string) => {
+    void relayTurnEndToApi(opencodeSessionId, opencode, cfg).catch((err) =>
+      logger.warn('[opencode-events] turn-end relay failed', { err: (err as Error).message }),
+    )
+  }
   if (bootState.initialOpenCodeSessionRequired) {
     await maybeCreateInitialOpencodeSession(cfg.opencodeInternalPort, bootState, bootMark).catch((err) => {
       bootState.initialOpenCodeSessionError = err instanceof Error ? err.message : String(err)
@@ -215,7 +220,7 @@ async function startSessionRuntime(
       opencode.markReady()
       bootMark('opencode-ready')
       logger.info('[boot] opencode ready via initial session', { opencodePid: opencode.getPid(), timeline: bootState.timeline })
-      startOpencodeEventLoop(opencode, cfg, { onQuestionAsked })
+      startOpencodeEventLoop(opencode, cfg, { onQuestionAsked, onSessionIdle })
       return
     }
   }
@@ -223,7 +228,7 @@ async function startSessionRuntime(
   if (ready) {
     bootMark('opencode-ready')
     logger.info('[boot] opencode ready', { opencodePid: opencode.getPid(), timeline: bootState.timeline })
-    startOpencodeEventLoop(opencode, cfg, { onQuestionAsked })
+    startOpencodeEventLoop(opencode, cfg, { onQuestionAsked, onSessionIdle })
   } else {
     logger.warn('[boot] opencode did not become ready within deadline; supervisor still retrying', { opencodePid: opencode.getPid() })
   }
@@ -460,6 +465,64 @@ async function relayQuestionToApi(req: QuestionRequest, cfg: Config): Promise<vo
     logger.info('[opencode-events] question replied to opencode', { requestId: req.id })
   } catch (err) {
     logger.warn('[opencode-events] opencode question.reply failed', { err: (err as Error).message })
+  }
+}
+
+// Relay an opencode `session.idle` for the ROOT turn to apps/api so the Slack
+// live stream gets closed even when the agent ends without `slack send`. opencode
+// fires session.idle for every session — including subagent (Task tool) children —
+// so we ignore any idle whose sessionID isn't the pinned root turn session.
+async function relayTurnEndToApi(
+  opencodeSessionId: string,
+  opencode: Pick<Opencode, 'getInternalUrl'>,
+  cfg: Config,
+): Promise<void> {
+  // Only the root turn closes the Slack stream. A subagent going idle mid-task
+  // must NOT finalize the user-facing stream.
+  if (!(await isRootOpencodeSession(opencodeSessionId, opencode, cfg))) return
+
+  const projectId = process.env.KORTIX_PROJECT_ID?.trim()
+  const sessionId = process.env.KORTIX_SESSION_ID?.trim()
+  const token = (process.env.KORTIX_CLI_TOKEN || process.env.KORTIX_TOKEN || '').trim()
+  const apiUrl = process.env.KORTIX_API_URL?.replace(/\/$/, '')
+  if (!projectId || !sessionId || !token || !apiUrl) return
+
+  const apiRoot = apiUrl.endsWith('/v1') ? apiUrl : `${apiUrl}/v1`
+  const url = `${apiRoot}/projects/${encodeURIComponent(projectId)}/turn-stream`
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ session_id: sessionId, kind: 'end' }),
+      signal: AbortSignal.timeout(15_000),
+    })
+    if (!res.ok) {
+      logger.warn('[opencode-events] turn-end relay non-ok', { status: res.status })
+    }
+  } catch (err) {
+    logger.warn('[opencode-events] turn-end relay fetch failed', { err: (err as Error).message })
+  }
+}
+
+// Is this opencode session the root turn session (not a subagent child)? Prefer
+// the boot-pinned id (cheap, no I/O); fall back to asking opencode whether the
+// session has a parentID. On any uncertainty, return false so we never close the
+// stream prematurely — the watchdog remains the backstop.
+async function isRootOpencodeSession(
+  opencodeSessionId: string,
+  opencode: Pick<Opencode, 'getInternalUrl'>,
+  cfg: Config,
+): Promise<boolean> {
+  const pinned = readPinnedOpencodeSessionId()
+  if (pinned) return opencodeSessionId === pinned
+  try {
+    const url = `${opencode.getInternalUrl()}/session/${encodeURIComponent(opencodeSessionId)}?directory=${encodeURIComponent(cfg.workspace)}`
+    const res = await fetch(url, { signal: AbortSignal.timeout(5_000) })
+    if (!res.ok) return false
+    const session = (await res.json()) as { parentID?: string | null }
+    return !session.parentID
+  } catch {
+    return false
   }
 }
 

--- a/apps/kortix-sandbox-agent-server/src/opencode-events.ts
+++ b/apps/kortix-sandbox-agent-server/src/opencode-events.ts
@@ -20,6 +20,10 @@ export interface QuestionRequest {
 
 export type OpencodeEventHandlers = {
   onQuestionAsked?: (req: QuestionRequest) => void
+  // Fired when an opencode session finishes processing a turn. opencode emits
+  // this for EVERY session — including subagent (Task tool) child sessions — so
+  // the handler is responsible for filtering down to the root turn.
+  onSessionIdle?: (sessionID: string) => void
 }
 
 // Subscribe to opencode's SSE event stream and dispatch known event types.
@@ -109,5 +113,10 @@ function dispatch(event: { type?: string; properties?: unknown }, handlers: Open
     if (req?.id && req?.sessionID && Array.isArray(req.questions)) {
       handlers.onQuestionAsked(req)
     }
+    return
+  }
+  if (event.type === 'session.idle' && handlers.onSessionIdle) {
+    const props = event.properties as { sessionID?: string } | undefined
+    if (props?.sessionID) handlers.onSessionIdle(props.sessionID)
   }
 }


### PR DESCRIPTION
## The bug

The Slack bot frequently gets stuck showing **`⏳ On it…`** (or a streaming plan / `Thinking…`) and never clears it — it only "snaps out of it" when you `@mention` it again. Reported in the team thread.

## Root cause

The live turn stream is only ever finalized by **three** things: the agent calling `slack send` (`relayTurnAnswer`), the `question` tool (`postQuestionAndWait`), or the **15-min TTL watchdog**. There is **no "turn ended / session idle" signal** wired to finalization.

So when the agent ends a turn *without* sending a final answer — exactly what it's instructed to do when a message needs no reply — the `On it…` placeholder is orphaned and hangs until the watchdog reaps it (or the next `@mention`'s `slack send` clears the stale row). Worse by design: the bot is told to stay silent on non-actionable messages, so *every* silent turn orphans a placeholder.

## The fix (two parts)

**1. Finalize on `session.idle`.** The sandbox agent-server already subscribes to opencode's SSE event loop (for `question.asked`). Add an `onSessionIdle` handler that relays a `turn-stream { kind: 'end' }` to apps/api. apps/api's new `relayTurnEnd` silently closes the stream **iff** the agent never sent a reply (no `_Done._` filler).
- opencode fires `session.idle` for **every** session including subagent (Task tool) children, so we finalize only for the **root** turn session — identified via the boot-pinned session id, falling back to the session's `parentID`. On any uncertainty we *don't* finalize, leaving the watchdog as the backstop.

**2. Drop the standalone `⏳ On it…` message** (per the ask in-thread: "just send message if you're sending"). The only eager feedback is now the ⏳ **reaction** on the user's own message — lightweight, lives on their message, auto-clears on idle. The plan stream still opens lazily on the first `slack step`; the answer is posted by `slack send`. A silent turn now leaves the thread **completely clean**.
- `finalizeStream` gained a "silent" path (no answer/error/blocks → close the plan cleanly / delete any legacy placeholder, post nothing). Legacy-placeholder cleanup branches are kept so streams opened by pre-deploy code still clear across the rollout.

## Tests / verification

- New unit suite `unit-slack-turn-finalize.test.ts` covering finalizeStream's silent / answer / error / legacy-placeholder / already-finalized paths (6 tests, all green).
- `pnpm --filter kortix-api typecheck` ✅ and `pnpm --filter @kortix/sandbox-agent-server typecheck` ✅.
- Full `unit-*` suite run; the only failures are pre-existing on `main` (env-dependent: resolve-account, sandbox-backend, stripe-webhook-canonicalization).
