### PR TITLE
fix(eks): prod → plain rolling Deployment (drop fragile canary)

### DIFF
--- a/infra/k8s/envs/prod/values.yaml
+++ b/infra/k8s/envs/prod/values.yaml
@@ -35,11 +35,14 @@ ingress:
   certificateArn: arn:aws:acm:us-west-2:935064898258:certificate/2b74aa18-1fe1-4cc8-a6c1-7012a0823d27
   cloudflareProxied: true
 # Argo Rollouts canary + CloudWatch auto-rollback. Health-based abort works now;
-# the load-based 5xx/latency analysis becomes meaningful once api-eks serves real
-# traffic (at the api.kortix.com cutover). ALB dimensions captured from the live
-# target group (stable for the life of the ingress).
+# Plain rolling Deployment (no canary). The EKS wins we actually want —
+# auto-healing (probes restart hung/stale pods), autoscaling (HPA + cluster
+# autoscaler), zero-downtime rolling deploys — all come from the Deployment, not
+# the canary. Progressive delivery (Argo Rollouts canary + CloudWatch analysis)
+# is fragile without real traffic and isn't needed now; flip enabled=true to
+# bring it back (the template + min-request guard are kept + ready).
 rollout:
-  enabled: true
+  enabled: false
   analysis:
     # CloudWatch 5xx + p95-latency, auto-rollback on breach. successCondition
     # short-circuits cleanly on no-data (pre-cutover api-eks has ~no traffic →


### PR DESCRIPTION
## What
Flip EKS prod from an Argo Rollouts **canary** to a plain rolling **Deployment** (`rollout.enabled: false`). Only the rollout block changes — `image.tag` stays `0.9.43`, autoscaling / external-secrets / ingress untouched.

## Why
The canary's CloudWatch analysis kept **false-aborting** during the dual-run (api-eks has ~no traffic, so error-rate and p95-latency are pure noise — 4 distinct false-abort modes hit). Progressive delivery isn't what we moved to EKS for. The EKS wins we actually need all come from the **Deployment**, not the canary:

- 🔁 **Auto-heal stale containers** — liveness/readiness/startup probes → kubelet kills & restarts a hung/stale pod automatically (the #1 ECS gap)
- 📈 **Autoscale** — HPA (3→12) + Cluster Autoscaler
- 🟢 **Zero-downtime deploys** — rolling update, `maxUnavailable: 0` + surge
- 🚀 **GitOps** — deploy = commit, rollback = `git revert`, self-heal

## Effect on the stuck release
The live `0.9.43` Rollout is `Degraded` (canary aborted on cold-start latency, serving stable `0.9.41`). On merge, Argo replaces the Rollout with a Deployment on `0.9.43` → Healthy. **Unsticks the release.**

The canary template + min-request guard are kept in the chart — flip `rollout.enabled: true` at the `api.kortix.com` cutover (when real traffic makes the analysis meaningful) to bring it back.