### PR TITLE
fix(shared): never render credits as "-0"

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -15,6 +15,7 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
+    "@types/bun": "^1.3.9",
     "typescript": "^5.0.0"
   }
 }

--- a/packages/shared/src/utils/credit-formatter.test.ts
+++ b/packages/shared/src/utils/credit-formatter.test.ts
@@ -1,0 +1,88 @@
+import { describe, test, expect } from 'bun:test';
+import {
+  CREDITS_PER_DOLLAR,
+  dollarsToCredits,
+  creditsToDollars,
+  formatCredits,
+  formatCreditsWithSign,
+  formatDollarsAsCredits,
+} from './credit-formatter';
+
+describe('dollarsToCredits / creditsToDollars', () => {
+  test('converts dollars to credits and back', () => {
+    expect(dollarsToCredits(1)).toBe(CREDITS_PER_DOLLAR);
+    expect(dollarsToCredits(2.5)).toBe(250);
+    expect(creditsToDollars(100)).toBe(1);
+    expect(creditsToDollars(250)).toBe(2.5);
+  });
+
+  test('rounds fractional credits when converting from dollars', () => {
+    expect(dollarsToCredits(0.005)).toBe(1); // 0.5 credits -> rounds to 1
+    expect(dollarsToCredits(0.004)).toBe(0); // 0.4 credits -> rounds to 0
+  });
+});
+
+describe('formatCredits', () => {
+  test('formats integers with thousand separators', () => {
+    expect(formatCredits(1000)).toBe('1,000');
+    expect(formatCredits(1234567)).toBe('1,234,567');
+    expect(formatCredits(0)).toBe('0');
+  });
+
+  test('handles null / undefined / NaN', () => {
+    expect(formatCredits(null)).toBe('0');
+    expect(formatCredits(undefined)).toBe('0');
+    expect(formatCredits(NaN)).toBe('0');
+  });
+
+  test('never renders negative zero for tiny negatives', () => {
+    // Math.round(-0.4) === -0, which used to stringify as "-0".
+    expect(formatCredits(-0.4)).toBe('0');
+    expect(formatCredits(-0.49)).toBe('0');
+    expect(formatCredits(-0)).toBe('0');
+  });
+
+  test('rounds to nearest integer by default', () => {
+    expect(formatCredits(12.4)).toBe('12');
+    expect(formatCredits(12.5)).toBe('13');
+    expect(formatCredits(-12.4)).toBe('-12');
+  });
+
+  test('shows two decimals when requested', () => {
+    expect(formatCredits(1234.5, { showDecimals: true })).toBe('1,234.50');
+    expect(formatCredits(0, { showDecimals: true })).toBe('0.00');
+  });
+});
+
+describe('formatCreditsWithSign', () => {
+  test('prefixes a sign based on value', () => {
+    expect(formatCreditsWithSign(100)).toBe('+100');
+    expect(formatCreditsWithSign(-100)).toBe('-100');
+    expect(formatCreditsWithSign(0)).toBe('+0');
+  });
+
+  test('handles null / undefined / NaN', () => {
+    expect(formatCreditsWithSign(null)).toBe('0');
+    expect(formatCreditsWithSign(undefined)).toBe('0');
+    expect(formatCreditsWithSign(NaN)).toBe('0');
+  });
+
+  test('tiny negatives that round to zero read as "+0", never "-0"', () => {
+    expect(formatCreditsWithSign(-0.4)).toBe('+0');
+    expect(formatCreditsWithSign(-0.49)).toBe('+0');
+    expect(formatCreditsWithSign(-0)).toBe('+0');
+  });
+
+  test('keeps the sign for amounts that round to a nonzero magnitude', () => {
+    expect(formatCreditsWithSign(-0.5)).toBe('-1');
+    expect(formatCreditsWithSign(-12.4)).toBe('-12');
+    expect(formatCreditsWithSign(12.4)).toBe('+12');
+  });
+});
+
+describe('formatDollarsAsCredits', () => {
+  test('converts dollars to a formatted credit string', () => {
+    expect(formatDollarsAsCredits(1)).toBe('100');
+    expect(formatDollarsAsCredits(12.34)).toBe('1,234');
+  });
+});

--- a/packages/shared/src/utils/credit-formatter.ts
+++ b/packages/shared/src/utils/credit-formatter.ts
@@ -37,7 +37,9 @@ export function formatCredits(credits: number | null | undefined, options?: { sh
     return '0';
   }
   
-  const rounded = Math.round(credits);
+  // `+ 0` normalizes negative zero (e.g. Math.round(-0.4) === -0) so it never
+  // renders as the string "-0".
+  const rounded = Math.round(credits) + 0;
   
   if (options?.showDecimals) {
     // Format with decimals and thousand separators
@@ -64,7 +66,10 @@ export function formatCreditsWithSign(credits: number | null | undefined, option
   }
   
   const formatted = formatCredits(Math.abs(credits), options);
-  return credits >= 0 ? `+${formatted}` : `-${formatted}`;
+  // Base the sign on the displayed magnitude: a tiny negative that rounds to 0
+  // (e.g. -0.4) should read "+0", never "-0".
+  const isNegative = credits < 0 && parseFloat(formatted.replace(/,/g, '')) !== 0;
+  return isNegative ? `-${formatted}` : `+${formatted}`;
 }
 
 /**

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "lib": ["ES2023", "DOM"],
+    "types": ["@types/bun"],
     "noEmit": true
   },
   "include": ["src/**/*"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1401,6 +1401,9 @@ importers:
 
   packages/shared:
     devDependencies:
+      '@types/bun':
+        specifier: ^1.3.9
+        version: 1.3.10
       typescript:
         specifier: ^5.0.0
         version: 5.9.3


### PR DESCRIPTION
## What

`Math.round(-0.4)` returns **negative zero** (`-0`), which `toLocaleString` stringifies as the literal `"-0"`. As a result:

- `formatCredits(-0.4)` returned `"-0"` (and `formatCredits(-0)` → `"-0"`).
- `formatCreditsWithSign(-0.4)` returned `"-0"` — a small negative that rounds to zero showed a minus sign with a zero magnitude.

These surface in the UI anywhere a near-zero credit delta is shown (balances, usage deltas, transaction lines).

## Fix

- `formatCredits`: normalize negative zero with `+ 0` so it never renders as `"-0"`.
- `formatCreditsWithSign`: derive the sign from the *displayed* magnitude, so a value that rounds to `0` reads `"+0"` (never `"-0"`), while genuine nonzero negatives keep their `-`.

## Tests

Adds the first unit tests for `credit-formatter` (12 cases) covering conversions, separators, null/NaN handling, decimals, sign prefixing, and the negative-zero edge cases. Wired `@types/bun` into `@kortix/shared` (mirroring `agent-tunnel`/`starter`) so the colocated `bun:test` file typechecks.

```
12 pass / 0 fail   ·   pnpm --filter @kortix/shared typecheck → green
```

The `pnpm-lock.yaml` change is the single `packages/shared` importer entry for `@types/bun@1.3.10` (already resolved elsewhere in the lockfile); verified with `pnpm install --frozen-lockfile --filter "@kortix/shared..."`.

---
_Sample PR opened from a Kortix session._
