### PR TITLE
fix(api): honor warm-path cooldown for per-project snapshots + bound snapshot.get

### DIFF
--- a/apps/api/src/platform/services/session-sandbox.ts
+++ b/apps/api/src/platform/services/session-sandbox.ts
@@ -37,7 +37,7 @@ import {
   DEFAULT_SANDBOX_SLUG,
   type EnsureSandboxImageResult,
 } from '../../snapshots/builder';
-import { ensureWarmBaseReady } from '../../snapshots/warm-bake';
+import { ensureWarmBaseReady, warmPathPaused } from '../../snapshots/warm-bake';
 import { config } from '../../config';
 import { selectProvider } from './provider-balancer';
 import { ProvisionTimeline } from './provision-timeline';
@@ -185,20 +185,36 @@ export async function provisionSessionSandbox(opts: {
   // must still boot its own per-project image.
   let warmBase: string | null = null;
   let warmIsProjectSnapshot = false;
-  if (providerName === 'daytona' && slug === DEFAULT_SANDBOX_SLUG && !opts.disableWarmSnapshot) {
+  // Skip ALL warm routes while the warm path is in post-failure cooldown — a
+  // degraded warm region (experimental "internal error" streaks) must not make
+  // every session pay a doomed warm attempt before falling back to cold. The
+  // generic base path already honors this; the per-project branch must too.
+  if (
+    providerName === 'daytona' &&
+    slug === DEFAULT_SANDBOX_SLUG &&
+    !opts.disableWarmSnapshot &&
+    !warmPathPaused()
+  ) {
     if (opts.projectWarmSnapshot) {
       try {
         const { getDaytonaWarm, warmSnapshotsEnabled } = await import('../../shared/daytona');
         if (warmSnapshotsEnabled()) {
           const { warmBaseUsable } = await import('../../snapshots/warm-bake');
-          const snap = await getDaytonaWarm().snapshot.get(opts.projectWarmSnapshot);
+          // Bound the provider lookup — a degraded region must not hang the
+          // (request-blocking) provision path waiting on snapshot.get.
+          const snap = await Promise.race([
+            getDaytonaWarm().snapshot.get(opts.projectWarmSnapshot),
+            new Promise((_, reject) =>
+              setTimeout(() => reject(new Error('snapshot.get timeout')), 4_000),
+            ),
+          ]);
           if (warmBaseUsable(snap)) {
             warmBase = opts.projectWarmSnapshot;
             warmIsProjectSnapshot = true;
           }
         }
       } catch {
-        // pointer is stale (snapshot gone) — fall through to the generic base
+        // pointer is stale / lookup slow → fall through to the generic base
       }
     }
     if (!warmBase) warmBase = await ensureWarmBaseReady();

--- a/apps/api/src/snapshots/warm-bake.ts
+++ b/apps/api/src/snapshots/warm-bake.ts
@@ -413,6 +413,13 @@ export function noteWarmPathFailure(): void {
   warmPathPausedUntil = Date.now() + WARM_FAILURE_COOLDOWN_MS;
 }
 
+/** True while the warm path is in its post-failure cooldown — callers must skip
+ *  EVERY warm route (generic base AND per-project snapshot) so a degraded region
+ *  doesn't make each session pay a doomed warm attempt before falling back. */
+export function warmPathPaused(): boolean {
+  return Date.now() < warmPathPausedUntil;
+}
+
 /** Snapshot state, lowercased ('' when null). */
 function snapState(snap: unknown): string {
   return String((snap as { state?: string } | null)?.state ?? '').toLowerCase();


### PR DESCRIPTION
## Why

Follow-up to #3416 — this fix landed ~3 minutes after that PR merged, so it missed the train.

While Daytona's experimental (warm) region is degraded (recurring "Sandbox failed to start: internal error" streaks), warm session creates fail and fall back to cold. There's a 5-minute cooldown (`noteWarmPathFailure` / `warmPathPausedUntil`) that's supposed to make subsequent sessions skip warm and go straight to cold after the first failure. The generic warm-base path honored it, but the **per-project warm-snapshot branch (added in #3416) did not** — so during an outage every session re-tried the dead region and slow-failed before falling back, instead of just the first one.

## What changed

- Export `warmPathPaused()` and gate the **entire** warm block in `session-sandbox.ts` on it (per-project snapshot AND generic base), so a degraded region makes at most one session per 5 min pay a doomed warm attempt.
- Bound the per-project `snapshot.get` provider lookup with a 4s `Promise.race` timeout — it sits on the request-blocking provision path, so a slow/degraded region must not hang it.

## Impact

Pure resilience: when warm is healthy, behavior is unchanged. When the region is degraded, sessions degrade gracefully to the normal cold path at full speed instead of slow-failing on every create. No schema or API changes; flag-gated like the rest of the warm path.

API typecheck clean; cooldown gate verified (flips to paused after a failure, skips warm for 5 min).
