### PR TITLE
feat(dev-eks): clone the prod EKS stack for dev (retire ECS dev)

### DIFF
--- a/.github/workflows/deploy-dev-eks.yml
+++ b/.github/workflows/deploy-dev-eks.yml
@@ -1,0 +1,157 @@
+name: Deploy Dev (EKS / GitOps)
+
+# EKS dev is deployed by Argo CD on the dev-eks cluster (tracks `main`). This
+# workflow is the dev equivalent of the promote+watch flow:
+#   - it runs AFTER "Deploy Dev" succeeds (so the :dev-<sha8> API image exists),
+#   - bumps infra/k8s/envs/dev/values.yaml image.tag to that immutable sha and
+#     commits it to main with [skip ci] — that commit IS the deploy,
+#   - Argo CD reconciles the bump → rolling Deployment update,
+#   - then it WATCHES the Deployment finish rolling out :dev-<sha8>.
+#
+# git revert of the bump is the rollback. No canary (same as prod-eks). ECS dev
+# (deploy-dev.yml) stays separate and is removed at the dev-api.kortix.com cutover.
+
+on:
+  workflow_run:
+    workflows: ["Deploy Dev"]
+    types: [completed]
+
+concurrency:
+  group: deploy-dev-eks
+  cancel-in-progress: false
+
+permissions:
+  id-token: write # OIDC → read the cluster
+  contents: write # push the values bump to main
+
+env:
+  AWS_REGION: us-west-2
+  CLUSTER: kortix-dev-eks
+  NAMESPACE: kortix-dev
+  APP: kortix-api
+  IMAGE: kortix/kortix-api
+  API_HOST: dev-api-eks.kortix.com
+  VALUES: infra/k8s/envs/dev/values.yaml
+  ROLE: arn:aws:iam::935064898258:role/kortix-gha-eks-deploy-dev
+
+jobs:
+  gitops-deploy:
+    name: Bump + watch EKS dev
+    runs-on: ubuntu-latest
+    # Only on a SUCCESSFUL dev build of the main branch.
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_branch == 'main'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve dev image tag
+        id: meta
+        env:
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+          SHA8="${HEAD_SHA:0:8}"
+          echo "tag=dev-${SHA8}" >> "$GITHUB_OUTPUT"
+          echo "Triggering build sha: ${HEAD_SHA} → image tag dev-${SHA8}"
+
+      # The dev build only publishes :dev-<sha8> when the API actually changed.
+      # If there's no such image for this sha, there's nothing to deploy — skip
+      # cleanly rather than bumping to a tag that would ImagePullBackOff.
+      - name: Guard — :dev-<sha8> image exists
+        id: img
+        env:
+          TAG: ${{ steps.meta.outputs.tag }}
+        run: |
+          set -uo pipefail
+          if docker manifest inspect "${IMAGE}:${TAG}" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No ${IMAGE}:${TAG} image (API unchanged this push) — nothing to deploy."
+          fi
+
+      - name: Bump dev image tag + commit
+        if: steps.img.outputs.exists == 'true'
+        env:
+          TAG: ${{ steps.meta.outputs.tag }}
+        run: |
+          set -euo pipefail
+          current="$(yq '.image.tag' "$VALUES")"
+          if [ "$current" = "$TAG" ]; then
+            echo "values already at $TAG — no commit needed."
+            exit 0
+          fi
+          TAG="$TAG" yq -i '.image.tag = strenv(TAG)' "$VALUES"
+          git config user.name  "kortix-ci[bot]"
+          git config user.email "kortix-ci[bot]@users.noreply.github.com"
+          git add "$VALUES"
+          git commit -m "chore(dev-eks): deploy ${TAG} [skip ci]"
+          # main moves fast; rebase onto any concurrent pushes before pushing.
+          for attempt in 1 2 3; do
+            git pull --rebase --autostash origin main && git push origin main && exit 0
+            echo "push attempt ${attempt} lost a race — retrying"
+            sleep 3
+          done
+          echo "::error::could not push dev image bump after 3 attempts"; exit 1
+
+      - name: Configure AWS credentials (OIDC)
+        if: steps.img.outputs.exists == 'true'
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ env.ROLE }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Guard — cluster exists
+        if: steps.img.outputs.exists == 'true'
+        id: guard
+        run: |
+          if aws eks describe-cluster --name "$CLUSTER" --region "$AWS_REGION" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::dev-eks cluster not found — skipping watch (not applied yet)."
+          fi
+
+      - name: Update kubeconfig
+        if: steps.img.outputs.exists == 'true' && steps.guard.outputs.exists == 'true'
+        run: aws eks update-kubeconfig --name "$CLUSTER" --region "$AWS_REGION"
+
+      # Wait for Argo CD to reconcile the bump and the Deployment to finish its
+      # rolling update on exactly :dev-<sha8> — Argo applied the new spec
+      # (observedGeneration caught up) AND every replica is updated + available.
+      - name: Wait for Deployment rolled out @ ${{ steps.meta.outputs.tag }}
+        if: steps.img.outputs.exists == 'true' && steps.guard.outputs.exists == 'true'
+        env:
+          TAG: ${{ steps.meta.outputs.tag }}
+        run: |
+          set -uo pipefail
+          for i in $(seq 1 60); do
+            img="$(kubectl -n "$NAMESPACE" get deploy "$APP" -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null || true)"
+            gen="$(kubectl -n "$NAMESPACE" get deploy "$APP" -o jsonpath='{.metadata.generation}' 2>/dev/null || true)"
+            obs="$(kubectl -n "$NAMESPACE" get deploy "$APP" -o jsonpath='{.status.observedGeneration}' 2>/dev/null || true)"
+            desired="$(kubectl -n "$NAMESPACE" get deploy "$APP" -o jsonpath='{.spec.replicas}' 2>/dev/null || true)"
+            updated="$(kubectl -n "$NAMESPACE" get deploy "$APP" -o jsonpath='{.status.updatedReplicas}' 2>/dev/null || true)"
+            avail="$(kubectl -n "$NAMESPACE" get deploy "$APP" -o jsonpath='{.status.availableReplicas}' 2>/dev/null || true)"
+            echo "($i/60) image=${img:-?} gen=${obs:-?}/${gen:-?} updated=${updated:-0}/${desired:-?} available=${avail:-0}"
+            if printf '%s' "$img" | grep -q ":${TAG}$" \
+               && [ -n "$desired" ] && [ "${obs:-0}" -ge "${gen:-1}" ] \
+               && [ "${updated:-0}" = "$desired" ] && [ "${avail:-0}" = "$desired" ]; then
+              echo "✓ EKS dev rolled out on :${TAG} (${avail}/${desired} ready)"
+              exit 0
+            fi
+            sleep 15
+          done
+          echo "::error::dev Deployment did not roll out to :${TAG} within ~15m (Argo lag, stuck, or pods never Ready)."
+          exit 1
+
+      - name: Read live /v1/health
+        if: steps.img.outputs.exists == 'true' && steps.guard.outputs.exists == 'true'
+        run: |
+          set -uo pipefail
+          h="$(curl -s --max-time 10 "https://${API_HOST}/v1/health" || true)"
+          echo "dev /v1/health → $(printf '%s' "$h" | jq -c '{version,commit,environment,ok}' 2>/dev/null || printf '%s' "$h")"

--- a/infra/k8s/argocd/applications/dev.yaml
+++ b/infra/k8s/argocd/applications/dev.yaml
@@ -1,0 +1,54 @@
+# Argo CD Application for EKS dev (dev-api-eks.kortix.com).
+#
+# Applied to the dev-eks cluster's OWN Argo CD (separate from prod-eks). Tracks
+# the `main` branch — deploy-dev-eks.yml bumps infra/k8s/envs/dev/values.yaml
+# image.tag on every push to main, and Argo reconciles it onto dev.
+#
+# SINGLE source (same rationale as prod): one revision, so it can't race a
+# multi-source $values resolution. A commit bumping image.tag IS the deploy;
+# git revert is the rollback.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kortix-dev
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/kortix-ai/suna.git
+    targetRevision: main
+    path: infra/k8s/charts/kortix-api
+    helm:
+      releaseName: kortix-api
+      valueFiles:
+        - ../../envs/dev/values.yaml
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kortix-dev
+  # External Secrets Operator's admission webhook injects defaults
+  # (conversionStrategy/decodingStrategy/metadataPolicy) into the ExternalSecret,
+  # which git doesn't carry — ignore those fields so the app isn't perpetually
+  # OutOfSync. ESO owns them; this changes diffing only, nothing in-cluster.
+  ignoreDifferences:
+    - group: external-secrets.io
+      kind: ExternalSecret
+      jqPathExpressions:
+        - .spec.dataFrom[]?.extract.conversionStrategy
+        - .spec.dataFrom[]?.extract.decodingStrategy
+        - .spec.dataFrom[]?.extract.metadataPolicy
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=false
+      - ServerSideApply=true
+      - ApplyOutOfSyncOnly=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 10s
+        factor: 2
+        maxDuration: 3m

--- a/infra/k8s/envs/dev/values.yaml
+++ b/infra/k8s/envs/dev/values.yaml
@@ -1,0 +1,53 @@
+# Dev environment values for the kortix-api chart, deployed by Argo CD
+# (infra/k8s/argocd/applications/dev.yaml) onto the dev-eks cluster. GitOps
+# source of truth for what runs on EKS dev — deploy-dev-eks.yml bumps `image.tag`
+# on every push to `main`; `git revert` is the rollback.
+
+# Immutable dev tag (CI bumps to dev-<sha8> on each main push). Bootstrap value
+# is :dev-latest until the first deploy-dev-eks run pins an immutable sha.
+image:
+  tag: "dev-latest"
+kortixVersion: ""
+
+env:
+  internalKortixEnv: dev
+
+# PRE-CUTOVER: dev-api-eks is the candidate while dev-api.kortix.com is still
+# served by ECS, so EKS runs API-only and ECS keeps ownership of the dev-tier
+# singleton workers (one Postgres leader lease is shared across both on the dev
+# data plane). At cutover, flip this to true here AND disable the ECS dev service.
+workers:
+  enabled: false
+
+# Dev sizing (smaller than prod's 3-replica / 3→12 HPA).
+replicas: 2
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 4
+
+serviceAccount:
+  name: kortix-api
+  # IRSA role from the dev-eks cluster layer (module.app_irsa, name
+  # "kortix-dev-eks-app"). Predictable from the role name; verify with
+  # `terraform -chdir=infra/terraform/environments/dev-eks/cluster output app_irsa_role_arn`.
+  roleArn: arn:aws:iam::935064898258:role/kortix-dev-eks-app
+
+externalSecrets:
+  enabled: true
+  region: us-west-2
+  secretName: kortix-dev-env
+  targetSecretName: kortix-api-env
+
+ingress:
+  enabled: true
+  host: dev-api-eks.kortix.com
+  # FILL AFTER `terraform apply` of dev-eks/cluster:
+  #   terraform -chdir=infra/terraform/environments/dev-eks/cluster output acm_certificate_arn
+  certificateArn: REPLACE_WITH_dev-eks_acm_certificate_arn
+  cloudflareProxied: true
+
+# Plain rolling Deployment (no canary) — same delivery model as prod-eks:
+# probe-based auto-healing, HPA autoscaling, zero-downtime rolling deploys.
+rollout:
+  enabled: false

--- a/infra/terraform/environments/dev-eks/README.md
+++ b/infra/terraform/environments/dev-eks/README.md
@@ -1,0 +1,78 @@
+# environments/dev-eks
+
+Dev EKS stack for `dev-api-eks.kortix.com`, run in parallel with ECS dev. A
+faithful clone of `prod-eks` (same modules), **fully isolated** — its own VPC
+(`10.40.0.0/16`), cluster (`kortix-dev-eks`), and Argo CD — trimmed for dev:
+a single NAT gateway, a 2-node floor, and Argo CD running **headless** (UI +
+GitHub SSO off; access via port-forward).
+
+Two Terraform states, applied in order (identical flow to prod-eks):
+
+1. **`cluster/`** — AWS-only: the isolated VPC, EKS control plane + managed node
+   group, ACM certs, the app's secret-read IRSA role (reads `kortix-dev-env`),
+   and the GitHub Actions deploy role (`kortix-gha-eks-deploy-dev`, trusts
+   `main`) + EKS access entries.
+2. **`platform/`** — configures the kubernetes/helm providers from `cluster/`'s
+   remote state, then installs the in-cluster controllers (AWS Load Balancer
+   Controller, External Secrets, external-dns, metrics-server, cluster-autoscaler,
+   Argo CD, Argo Rollouts) and the `kortix-dev` namespace.
+
+The app workload is the Helm chart at `infra/k8s/charts/kortix-api`, rendered
+with `infra/k8s/envs/dev/values.yaml` and deployed by Argo CD (app:
+`infra/k8s/argocd/applications/dev.yaml`, tracks `main`). CI
+(`.github/workflows/deploy-dev-eks.yml`) bumps the image tag on every push to
+`main` — Terraform owns infra, GitOps owns the app.
+
+## Apply
+
+```bash
+export TF_VAR_cloudflare_api_token=...   # scoped token, DNS:Edit on kortix.com
+export TF_VAR_cloudflare_zone_id=...     # kortix.com zone id
+
+cd cluster     && terraform init && terraform apply
+cd ../platform && terraform init && terraform apply
+```
+
+## Post-apply wiring (one-time)
+
+1. **Fill the cert ARN** in `infra/k8s/envs/dev/values.yaml`
+   (`ingress.certificateArn`, currently a placeholder):
+   ```bash
+   terraform -chdir=cluster output -raw acm_certificate_arn
+   ```
+   Also sanity-check the IRSA role ARN already in that file matches:
+   ```bash
+   terraform -chdir=cluster output -raw app_irsa_role_arn   # expect .../kortix-dev-eks-app
+   ```
+   Commit the values change to `main`.
+
+2. **Confirm the dev secret bundle** has the keys the app needs (External
+   Secrets syncs `kortix-dev-env` → the `kortix-api-env` k8s Secret):
+   ```bash
+   aws secretsmanager get-secret-value --secret-id kortix-dev-env \
+     --query SecretString --output text | jq 'keys | length'
+   ```
+
+3. **Bootstrap the dev Argo CD app** (one-time; thereafter GitOps owns it):
+   ```bash
+   aws eks update-kubeconfig --region us-west-2 --name kortix-dev-eks
+   kubectl apply -f ../../../k8s/argocd/applications/dev.yaml
+   # watch it: kubectl -n argocd port-forward svc/argocd-server 8080:443
+   ```
+
+4. **DNS** — add a Cloudflare **proxied** CNAME `dev-api-eks` → the dev ALB
+   hostname (external-dns is wedged cluster-wide, so this is manual, same as
+   prod-eks):
+   ```bash
+   kubectl -n kortix-dev get ingress kortix-api \
+     -o jsonpath='{.status.loadBalancer.ingress[0].hostname}'
+   ```
+
+5. **Verify**: `curl https://dev-api-eks.kortix.com/v1/health` → `environment: dev`.
+
+## Cutover (later)
+
+Flip `dev-api.kortix.com` → dev-eks (Cloudflare), set `workers.enabled: true` in
+`envs/dev/values.yaml`, and disable the ECS dev service. Until then EKS dev runs
+**API-only** so ECS keeps the dev-tier singleton workers (shared Postgres leader
+lease). Full architecture + coexistence notes: **`infra/EKS.md`**.

--- a/infra/terraform/environments/dev-eks/cluster/backend.tf
+++ b/infra/terraform/environments/dev-eks/cluster/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket         = "kortix-terraform-state"
+    key            = "dev-eks/cluster.tfstate"
+    region         = "us-west-2"
+    dynamodb_table = "kortix-terraform-locks"
+    encrypt        = true
+  }
+}

--- a/infra/terraform/environments/dev-eks/cluster/iam-deploy.tf
+++ b/infra/terraform/environments/dev-eks/cluster/iam-deploy.tf
@@ -1,0 +1,102 @@
+# ── GitHub Actions OIDC deploy role + EKS access ──────────────────────────────
+# Same shape as the prod-eks deploy role, but trusts the `main` branch (dev
+# deploys on every push to main) and is scoped to the dev cluster + namespace.
+#   1. IAM: trust GitHub OIDC for the repo's `main` ref + DescribeCluster.
+#   2. EKS access entry: cluster-wide READ + write ONLY in the app namespace.
+
+data "aws_iam_openid_connect_provider" "github" {
+  url = "https://token.actions.githubusercontent.com"
+}
+
+data "aws_iam_policy_document" "ci_assume" {
+  statement {
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+    effect  = "Allow"
+    principals {
+      type        = "Federated"
+      identifiers = [data.aws_iam_openid_connect_provider.github.arn]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+    # Restrict to the main branch of the canonical repo (the branch that deploys
+    # dev — mirrors prod-eks's role, which is pinned to refs/heads/prod).
+    condition {
+      test     = "StringLike"
+      variable = "token.actions.githubusercontent.com:sub"
+      values   = ["repo:${var.github_repo}:ref:refs/heads/main"]
+    }
+  }
+}
+
+resource "aws_iam_role" "ci_deploy" {
+  name               = var.ci_deploy_role_name
+  assume_role_policy = data.aws_iam_policy_document.ci_assume.json
+  tags               = local.tags
+}
+
+resource "aws_iam_role_policy" "ci_describe_cluster" {
+  name = "${var.ci_deploy_role_name}-describe"
+  role = aws_iam_role.ci_deploy.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["eks:DescribeCluster"]
+      Resource = module.eks.cluster_arn
+    }]
+  })
+}
+
+# ── Kubernetes RBAC via EKS access entries ────────────────────────────────────
+resource "aws_eks_access_entry" "ci_deploy" {
+  cluster_name  = module.eks.cluster_name
+  principal_arn = aws_iam_role.ci_deploy.arn
+  type          = "STANDARD"
+}
+
+# Cluster-wide read (lets helm discover CRDs / existing objects safely)...
+resource "aws_eks_access_policy_association" "ci_view" {
+  cluster_name  = module.eks.cluster_name
+  principal_arn = aws_iam_role.ci_deploy.arn
+  policy_arn    = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSAdminViewPolicy"
+  access_scope {
+    type = "cluster"
+  }
+  depends_on = [aws_eks_access_entry.ci_deploy]
+}
+
+# ...but write only inside the app namespace.
+resource "aws_eks_access_policy_association" "ci_app_admin" {
+  cluster_name  = module.eks.cluster_name
+  principal_arn = aws_iam_role.ci_deploy.arn
+  policy_arn    = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSAdminPolicy"
+  access_scope {
+    type       = "namespace"
+    namespaces = [var.app_namespace]
+  }
+  depends_on = [aws_eks_access_entry.ci_deploy]
+}
+
+# ── Optional extra human cluster-admins ───────────────────────────────────────
+# (The principal that runs `terraform apply` is already a cluster admin via
+# bootstrap_cluster_creator_admin_permissions.)
+resource "aws_eks_access_entry" "admins" {
+  for_each      = toset(var.admin_principal_arns)
+  cluster_name  = module.eks.cluster_name
+  principal_arn = each.value
+  type          = "STANDARD"
+}
+
+resource "aws_eks_access_policy_association" "admins" {
+  for_each      = toset(var.admin_principal_arns)
+  cluster_name  = module.eks.cluster_name
+  principal_arn = each.value
+  policy_arn    = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
+  access_scope {
+    type = "cluster"
+  }
+  depends_on = [aws_eks_access_entry.admins]
+}

--- a/infra/terraform/environments/dev-eks/cluster/main.tf
+++ b/infra/terraform/environments/dev-eks/cluster/main.tf
@@ -1,0 +1,156 @@
+# ── dev-eks (cluster layer) — dev-api-eks.kortix.com on EKS ───────────────────
+#
+#   dev-api-eks.kortix.com → Cloudflare (proxied, Full strict) → ALB → EKS pods
+#   (managed node group) in private subnets, egress via a single NAT.
+#
+# A faithful clone of prod-eks (same modules), trimmed for dev: a single NAT
+# gateway and a smaller node floor (dev doesn't need per-AZ NAT HA). Fully
+# isolated from prod-eks — its own VPC (10.40/16), cluster, and Argo CD — so a
+# dev experiment can never touch the prod cluster.
+#
+# This layer is AWS-only (no kubernetes/helm providers), so it plans/applies
+# against a cluster that does not exist yet. It builds:
+#   - an isolated VPC (own /16, 3 AZ, single NAT),
+#   - the EKS control plane + managed node group (modules/eks/cluster),
+#   - the ACM cert for dev-api-eks.kortix.com (validated via Cloudflare DNS),
+#   - the app's IRSA role (reads the kortix-dev-env Secrets Manager bundle),
+#   - the GitHub Actions OIDC deploy role (trusts `main`) + its EKS access entry.
+#
+# The in-cluster controllers + the app live in the sibling `platform` layer and
+# the Helm chart, applied AFTER this. ECS dev is entirely untouched; this runs
+# in parallel under dev-api-eks.kortix.com until dev-api.kortix.com is flipped.
+
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.79"
+    }
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = ">= 4.0, < 5.0"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = ">= 4.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+provider "cloudflare" {
+  # Same auth precedence as the ECS envs: scoped token → global key → dummy
+  # (so a plan with no CF creds doesn't reject an empty token).
+  api_token = var.cloudflare_api_token != "" ? var.cloudflare_api_token : (var.cloudflare_api_key != "" ? null : "0000000000000000000000000000000000000000")
+  email     = var.cloudflare_api_key != "" ? var.cloudflare_email : null
+  api_key   = var.cloudflare_api_key != "" ? var.cloudflare_api_key : null
+}
+
+locals {
+  name   = "kortix-dev-eks"
+  domain = var.api_domain
+  tags = {
+    Environment = "dev"
+    Service     = "kortix-api"
+    Platform    = "eks"
+    ManagedBy   = "terraform"
+  }
+}
+
+# ── Network (own VPC; EKS subnet-discovery tags via the shared module) ─────────
+module "network" {
+  source             = "../../../modules/network"
+  name               = local.name
+  cidr               = var.vpc_cidr
+  az_count           = 3
+  single_nat_gateway = true # dev: one NAT (cost over per-AZ egress HA)
+  tags               = local.tags
+
+  extra_vpc_tags = { "kubernetes.io/cluster/${local.name}" = "shared" }
+  extra_public_subnet_tags = {
+    "kubernetes.io/role/elb"              = "1"
+    "kubernetes.io/cluster/${local.name}" = "shared"
+  }
+  extra_private_subnet_tags = {
+    "kubernetes.io/role/internal-elb"     = "1"
+    "kubernetes.io/cluster/${local.name}" = "shared"
+  }
+}
+
+# ── EKS control plane + managed node group ────────────────────────────────────
+module "eks" {
+  source          = "../../../modules/eks/cluster"
+  name            = local.name
+  cluster_version = var.cluster_version
+
+  control_plane_subnet_ids = concat(module.network.public_subnet_ids, module.network.private_subnet_ids)
+  node_subnet_ids          = module.network.private_subnet_ids
+
+  endpoint_public_access       = true
+  endpoint_public_access_cidrs = var.cluster_endpoint_public_access_cidrs
+
+  node_instance_types = var.node_instance_types
+  node_desired_size   = var.node_desired_size
+  node_min_size       = var.node_min_size
+  node_max_size       = var.node_max_size
+
+  tags = local.tags
+}
+
+# ── TLS cert for dev-api-eks.kortix.com (ACM, validated via Cloudflare DNS) ────
+module "acm" {
+  source      = "../../../modules/acm-cloudflare"
+  domain_name = local.domain
+  zone_id     = var.cloudflare_zone_id
+  tags        = local.tags
+  providers = {
+    aws        = aws
+    cloudflare = cloudflare
+  }
+}
+
+# ── TLS cert for the Argo CD UI (dev-ops.kortix.com) ──────────────────────────
+# Created for parity with prod-eks, but the dev Argo CD UI is OFF by default
+# (argocd_ui_enabled=false in the platform layer) — dev access is via
+# `kubectl -n argocd port-forward`. Flip the UI on later if you want it; the
+# cert is then already in place. ACM certs are free.
+module "acm_argocd" {
+  source      = "../../../modules/acm-cloudflare"
+  domain_name = var.argocd_domain
+  zone_id     = var.cloudflare_zone_id
+  tags        = local.tags
+  providers = {
+    aws        = aws
+    cloudflare = cloudflare
+  }
+}
+
+# ── App IRSA role: read the kortix-dev-env Secrets Manager bundle ──────────────
+# The app's ServiceAccount (kube ns/SA below) assumes this to let External
+# Secrets pull `var.app_secret_name` into the cluster. Scoped to that one secret.
+data "aws_secretsmanager_secret" "app_env" {
+  name = var.app_secret_name
+}
+
+data "aws_iam_policy_document" "app_secrets_read" {
+  statement {
+    effect    = "Allow"
+    actions   = ["secretsmanager:GetSecretValue", "secretsmanager:DescribeSecret"]
+    resources = [data.aws_secretsmanager_secret.app_env.arn]
+  }
+}
+
+module "app_irsa" {
+  source            = "../../../modules/eks/irsa"
+  name              = "${local.name}-app"
+  oidc_provider_arn = module.eks.oidc_provider_arn
+  oidc_provider_url = module.eks.oidc_provider_url
+  namespace         = var.app_namespace
+  service_accounts  = [var.app_service_account]
+  policy_json       = data.aws_iam_policy_document.app_secrets_read.json
+  tags              = local.tags
+}

--- a/infra/terraform/environments/dev-eks/cluster/outputs.tf
+++ b/infra/terraform/environments/dev-eks/cluster/outputs.tf
@@ -1,0 +1,73 @@
+output "cluster_name" {
+  value = module.eks.cluster_name
+}
+
+output "cluster_endpoint" {
+  value = module.eks.cluster_endpoint
+}
+
+output "cluster_ca_data" {
+  value     = module.eks.cluster_ca_data
+  sensitive = true
+}
+
+output "oidc_provider_arn" {
+  value = module.eks.oidc_provider_arn
+}
+
+output "oidc_provider_url" {
+  value = module.eks.oidc_provider_url
+}
+
+output "vpc_id" {
+  value = module.network.vpc_id
+}
+
+output "aws_region" {
+  value = var.aws_region
+}
+
+output "api_domain" {
+  value = var.api_domain
+}
+
+output "acm_certificate_arn" {
+  description = "Cert ARN for the ALB HTTPS listener (Ingress annotation)."
+  value       = module.acm.certificate_arn
+}
+
+output "acm_argocd_certificate_arn" {
+  description = "Cert ARN reserved for the dev Argo CD UI ALB (dev-ops.kortix.com)."
+  value       = module.acm_argocd.certificate_arn
+}
+
+output "argocd_domain" {
+  value = var.argocd_domain
+}
+
+output "app_irsa_role_arn" {
+  description = "IRSA role ARN for the app ServiceAccount (Secrets Manager read)."
+  value       = module.app_irsa.role_arn
+}
+
+output "app_namespace" {
+  value = var.app_namespace
+}
+
+output "app_service_account" {
+  value = var.app_service_account
+}
+
+output "app_secret_name" {
+  value = var.app_secret_name
+}
+
+output "ci_deploy_role_arn" {
+  description = "Role GitHub Actions assumes to deploy (put in deploy-dev-eks.yml)."
+  value       = aws_iam_role.ci_deploy.arn
+}
+
+output "configure_kubectl" {
+  description = "Command to get a local kubeconfig for this cluster."
+  value       = "aws eks update-kubeconfig --region ${var.aws_region} --name ${module.eks.cluster_name}"
+}

--- a/infra/terraform/environments/dev-eks/cluster/terraform.tfvars.example
+++ b/infra/terraform/environments/dev-eks/cluster/terraform.tfvars.example
@@ -1,0 +1,12 @@
+# Copy to terraform.tfvars (gitignored: infra/terraform/**/*.tfvars) and fill in.
+# Cloudflare creds are better supplied via the environment so they never touch
+# disk:
+#   export TF_VAR_cloudflare_api_token=...   # scoped token, DNS:Edit on kortix.com
+#   export TF_VAR_cloudflare_zone_id=...     # kortix.com zone id
+#
+# All dev-specific config (VPC 10.40/16, kortix-dev namespace, kortix-dev-env
+# bundle, dev-api-eks.kortix.com, kortix-gha-eks-deploy-dev) is defaulted in
+# variables.tf — this file only needs the Cloudflare zone + token.
+
+cloudflare_zone_id   = ""
+cloudflare_api_token = ""

--- a/infra/terraform/environments/dev-eks/cluster/variables.tf
+++ b/infra/terraform/environments/dev-eks/cluster/variables.tf
@@ -1,0 +1,125 @@
+variable "aws_region" {
+  description = "AWS region for the EKS dev resources."
+  type        = string
+  default     = "us-west-2"
+}
+
+variable "vpc_cidr" {
+  description = "CIDR for the EKS VPC. MUST NOT overlap the other VPCs (ECS dev 10.10/16, ECS prod 10.20/16, prod-eks 10.30/16)."
+  type        = string
+  default     = "10.40.0.0/16"
+}
+
+variable "cluster_version" {
+  description = "EKS Kubernetes minor version."
+  type        = string
+  default     = "1.32"
+}
+
+variable "cluster_endpoint_public_access_cidrs" {
+  description = "CIDRs allowed to reach the public Kubernetes API endpoint."
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}
+
+# ── Node group (dev-sized; smaller floor than prod's 3) ───────────────────────
+variable "node_instance_types" {
+  description = "Managed node group instance types."
+  type        = list(string)
+  default     = ["m6i.large"]
+}
+
+variable "node_desired_size" {
+  description = "Initial node count."
+  type        = number
+  default     = 2
+}
+
+variable "node_min_size" {
+  description = "Node autoscaling floor."
+  type        = number
+  default     = 2
+}
+
+variable "node_max_size" {
+  description = "Node autoscaling ceiling."
+  type        = number
+  default     = 4
+}
+
+# ── App / secrets wiring ──────────────────────────────────────────────────────
+variable "app_namespace" {
+  description = "Kubernetes namespace the API runs in."
+  type        = string
+  default     = "kortix-dev"
+}
+
+variable "app_service_account" {
+  description = "ServiceAccount the API pods + the SecretStore use (gets the secret-read IRSA role)."
+  type        = string
+  default     = "kortix-api"
+}
+
+variable "app_secret_name" {
+  description = "Secrets Manager secret the app reads — the dev bundle (FRIENDLY name, no random ARN suffix). Same bundle the ECS dev tier sources its secrets from."
+  type        = string
+  default     = "kortix-dev-env"
+}
+
+# ── DNS / TLS (Cloudflare) ────────────────────────────────────────────────────
+variable "api_domain" {
+  description = "Public FQDN for the EKS dev API (parallel to ECS's dev-api.kortix.com)."
+  type        = string
+  default     = "dev-api-eks.kortix.com"
+}
+
+variable "argocd_domain" {
+  description = "FQDN reserved for the dev Argo CD UI (UI is OFF by default; cert created for parity)."
+  type        = string
+  default     = "dev-ops.kortix.com"
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID for kortix.com. Supply via TF_VAR_cloudflare_zone_id."
+  type        = string
+  default     = ""
+}
+
+variable "cloudflare_api_token" {
+  description = "Cloudflare scoped API token. Supply via TF_VAR_cloudflare_api_token."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "cloudflare_email" {
+  description = "Cloudflare account email (for global-API-key auth)."
+  type        = string
+  default     = ""
+}
+
+variable "cloudflare_api_key" {
+  description = "Cloudflare global API key (alternative to a scoped token)."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+# ── CI / access ───────────────────────────────────────────────────────────────
+variable "github_repo" {
+  description = "owner/repo allowed to assume the CI deploy role via OIDC."
+  type        = string
+  default     = "kortix-ai/suna"
+}
+
+variable "ci_deploy_role_name" {
+  description = "Name of the GitHub Actions EKS dev deploy role."
+  type        = string
+  default     = "kortix-gha-eks-deploy-dev"
+}
+
+variable "admin_principal_arns" {
+  description = "Extra IAM principal ARNs to grant cluster-admin (besides whoever applies)."
+  type        = list(string)
+  default     = []
+}

--- a/infra/terraform/environments/dev-eks/platform/backend.tf
+++ b/infra/terraform/environments/dev-eks/platform/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket         = "kortix-terraform-state"
+    key            = "dev-eks/platform.tfstate"
+    region         = "us-west-2"
+    dynamodb_table = "kortix-terraform-locks"
+    encrypt        = true
+  }
+}

--- a/infra/terraform/environments/dev-eks/platform/main.tf
+++ b/infra/terraform/environments/dev-eks/platform/main.tf
@@ -1,0 +1,114 @@
+# ── dev-eks (platform layer) — in-cluster controllers + app namespace ─────────
+#
+# Applied AFTER the dev `cluster` layer. Reads that layer's outputs from remote
+# state to configure the kubernetes/helm providers against the LIVE API server,
+# then installs the platform controllers (modules/eks/platform) and creates the
+# app namespace the CI Helm deploy targets.
+#
+# Mirrors prod-eks/platform, but the Argo CD UI + GitHub SSO default OFF for dev
+# (headless; access via `kubectl -n argocd port-forward`). Flip them on in
+# terraform.tfvars if you want a dev Argo UI later.
+
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = ">= 2.12, < 3.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.27, < 3.0"
+    }
+  }
+}
+
+data "terraform_remote_state" "cluster" {
+  backend = "s3"
+  config = {
+    bucket         = "kortix-terraform-state"
+    key            = "dev-eks/cluster.tfstate"
+    region         = "us-west-2"
+    dynamodb_table = "kortix-terraform-locks"
+  }
+}
+
+locals {
+  cluster = data.terraform_remote_state.cluster.outputs
+}
+
+provider "aws" {
+  region = local.cluster.aws_region
+}
+
+# Both providers authenticate to the cluster with a short-lived token minted by
+# the AWS CLI (`aws eks get-token`) — no kubeconfig on disk, no static creds.
+provider "kubernetes" {
+  host                   = local.cluster.cluster_endpoint
+  cluster_ca_certificate = base64decode(local.cluster.cluster_ca_data)
+  exec {
+    api_version = "client.authentication.k8s.io/v1beta1"
+    command     = "aws"
+    args        = ["eks", "get-token", "--cluster-name", local.cluster.cluster_name, "--region", local.cluster.aws_region]
+  }
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = local.cluster.cluster_endpoint
+    cluster_ca_certificate = base64decode(local.cluster.cluster_ca_data)
+    exec {
+      api_version = "client.authentication.k8s.io/v1beta1"
+      command     = "aws"
+      args        = ["eks", "get-token", "--cluster-name", local.cluster.cluster_name, "--region", local.cluster.aws_region]
+    }
+  }
+}
+
+# The app namespace. Pre-created here (not via `helm --create-namespace`) so the
+# CI deploy role — which has write access ONLY inside this namespace — never
+# needs cluster-scoped permission to create it.
+resource "kubernetes_namespace" "app" {
+  metadata {
+    name = local.cluster.app_namespace
+    labels = {
+      "app.kubernetes.io/managed-by" = "terraform"
+    }
+  }
+}
+
+module "platform" {
+  source            = "../../../modules/eks/platform"
+  cluster_name      = local.cluster.cluster_name
+  aws_region        = local.cluster.aws_region
+  vpc_id            = local.cluster.vpc_id
+  oidc_provider_arn = local.cluster.oidc_provider_arn
+  oidc_provider_url = local.cluster.oidc_provider_url
+  api_domain        = local.cluster.api_domain
+
+  cloudflare_api_token = var.cloudflare_api_token
+
+  # Argo CD UI (dev-ops.kortix.com) — OFF by default for dev (headless).
+  argocd_ui_enabled      = var.argocd_ui_enabled
+  argocd_domain          = local.cluster.argocd_domain
+  argocd_certificate_arn = local.cluster.acm_argocd_certificate_arn
+
+  # GitHub-org SSO for Argo CD login — OFF by default for dev.
+  argocd_github_sso_enabled   = var.argocd_github_sso_enabled
+  argocd_github_org           = var.argocd_github_org
+  argocd_admin_team           = var.argocd_admin_team
+  argocd_github_client_id     = var.argocd_github_client_id
+  argocd_github_client_secret = var.argocd_github_client_secret
+  argocd_disable_admin        = var.argocd_disable_admin
+
+  tags = {
+    Environment = "dev"
+    Service     = "kortix-api"
+    Platform    = "eks"
+    ManagedBy   = "terraform"
+  }
+}

--- a/infra/terraform/environments/dev-eks/platform/outputs.tf
+++ b/infra/terraform/environments/dev-eks/platform/outputs.tf
@@ -1,0 +1,8 @@
+output "app_namespace" {
+  value = kubernetes_namespace.app.metadata[0].name
+}
+
+output "controllers" {
+  description = "Installed platform controllers + pinned chart versions."
+  value       = module.platform.controllers
+}

--- a/infra/terraform/environments/dev-eks/platform/terraform.tfvars.example
+++ b/infra/terraform/environments/dev-eks/platform/terraform.tfvars.example
@@ -1,0 +1,17 @@
+# Copy to terraform.tfvars (gitignored: infra/terraform/**/*.tfvars) and fill in.
+# Cloudflare token is better supplied via the environment:
+#   export TF_VAR_cloudflare_api_token=...   # DNS:Edit on kortix.com (external-dns)
+#
+# Dev runs Argo CD headless — the UI + GitHub SSO are OFF (no OAuth app needed).
+# Access Argo with:  kubectl -n argocd port-forward svc/argocd-server 8080:443
+# To expose a dev Argo UI later, set argocd_ui_enabled + the SSO block (mirror
+# prod-eks/platform/terraform.tfvars) AFTER wiring a Cloudflare Access gate.
+
+cloudflare_api_token = ""
+
+# argocd_ui_enabled           = false
+# argocd_github_sso_enabled   = false
+# argocd_github_client_id     = ""
+# argocd_github_client_secret = ""
+# argocd_admin_team           = "ops"
+# argocd_disable_admin        = false

--- a/infra/terraform/environments/dev-eks/platform/variables.tf
+++ b/infra/terraform/environments/dev-eks/platform/variables.tf
@@ -1,0 +1,57 @@
+variable "argocd_ui_enabled" {
+  description = <<-EOT
+    Expose the Argo CD UI on its own ALB at dev-ops.kortix.com. OFF by default
+    for dev (access via `kubectl -n argocd port-forward`). Set true only AFTER
+    setting up the Cloudflare Access gate (see infra/GITOPS.md).
+  EOT
+  type        = bool
+  default     = false
+}
+
+variable "argocd_github_sso_enabled" {
+  description = "Enable GitHub-org SSO for Argo CD login."
+  type        = bool
+  default     = false
+}
+
+variable "argocd_github_org" {
+  description = "GitHub org whose members may log in to Argo CD."
+  type        = string
+  default     = "kortix-ai"
+}
+
+variable "argocd_admin_team" {
+  description = "GitHub team granted Argo CD admin (others in the org are read-only)."
+  type        = string
+  default     = "eng"
+}
+
+variable "argocd_github_client_id" {
+  description = "GitHub OAuth App client ID for Argo CD SSO."
+  type        = string
+  default     = ""
+}
+
+variable "argocd_github_client_secret" {
+  description = "GitHub OAuth App client secret. Supply via TF_VAR_argocd_github_client_secret."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "argocd_disable_admin" {
+  description = "Disable Argo CD's built-in admin account (set true ONLY after SSO is verified)."
+  type        = bool
+  default     = false
+}
+
+variable "cloudflare_api_token" {
+  description = <<-EOT
+    Cloudflare API token external-dns uses to manage the dev-api-eks.kortix.com
+    record on the kortix.com zone (DNS:Edit). Supply via
+    TF_VAR_cloudflare_api_token. Everything else is read from the cluster layer's
+    remote state.
+  EOT
+  type        = string
+  sensitive   = true
+}


### PR DESCRIPTION
Clones the now-proven `prod-eks` setup for **dev**, so we can move dev off ECS. Fully isolated (own VPC `10.40/16`, own cluster `kortix-dev-eks`, own Argo CD) — a dev experiment can never touch the prod cluster.

## What's here (code-complete, `terraform validate`'d, chart renders clean)
- **`infra/terraform/environments/dev-eks/{cluster,platform}`** — same modules as prod-eks, differing only by `locals`, tfvars, backend state keys (`dev-eks/*.tfstate`), and the CI trust branch (`main`). Dev-trimmed: **single NAT**, **2-node floor**, Argo CD **headless** (UI + SSO off → no second OAuth app). App IRSA reads the existing **`kortix-dev-env`** bundle. Deploy role **`kortix-gha-eks-deploy-dev`** trusts `refs/heads/main`.
- **`infra/k8s/envs/dev/values.yaml`** + **`argocd/applications/dev.yaml`** — plain rolling **Deployment** (no canary, same call as prod), **API-only** during the dual-run (`workers.enabled: false`), dev-sized (2 replicas, HPA 2→4), tracks `main`.
- **`.github/workflows/deploy-dev-eks.yml`** — fires on a successful **Deploy Dev**, bumps the immutable `:dev-<sha8>` tag in `envs/dev/values.yaml`, commits to `main` `[skip ci]`, Argo rolls the Deployment, watcher confirms (same Deployment-watch logic as the fixed prod watcher).

## Same EKS wins as prod
Probe-based **auto-healing**, **HPA** + **Cluster Autoscaler**, **node auto-repair**, zero-downtime rolling deploys, GitOps (deploy = commit, rollback = `git revert`).

## Not done here (needs you — mirrors how prod-eks came up)
1. `terraform apply` `cluster/` then `platform/` (with `TF_VAR_cloudflare_*`).
2. Fill `ingress.certificateArn` in `envs/dev/values.yaml` from `terraform output acm_certificate_arn` (the IRSA role ARN is already pinned: `kortix-dev-eks-app`).
3. `kubectl apply` the dev Argo app; add the proxied `dev-api-eks` Cloudflare CNAME → dev ALB (external-dns still wedged → manual, as in prod).

Full steps: **`infra/terraform/environments/dev-eks/README.md`**. ECS dev stays untouched until the `dev-api.kortix.com` cutover (flip `workers.enabled: true` + disable ECS dev).