### PR TITLE
feat(dev-eks): EKS serves dev-api.kortix.com (cutover step 1)

### DIFF
--- a/infra/k8s/charts/kortix-api/templates/ingress.yaml
+++ b/infra/k8s/charts/kortix-api/templates/ingress.yaml
@@ -19,7 +19,8 @@ metadata:
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80},{"HTTPS":443}]'
     alb.ingress.kubernetes.io/ssl-redirect: "443"
     alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS13-1-2-2021-06
-    alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.certificateArn | quote }}
+    # Primary cert + any extra certs (multi-host ALB serves the right one via SNI).
+    alb.ingress.kubernetes.io/certificate-arn: {{ prepend (.Values.ingress.extraCertificateArns | default list) .Values.ingress.certificateArn | join "," | quote }}
     alb.ingress.kubernetes.io/healthcheck-protocol: HTTP
     alb.ingress.kubernetes.io/healthcheck-path: {{ .Values.health.path | quote }}
     alb.ingress.kubernetes.io/healthcheck-interval-seconds: "15"
@@ -32,20 +33,22 @@ metadata:
     {{- if .Values.ingress.inboundCidrs }}
     alb.ingress.kubernetes.io/inbound-cidrs: {{ .Values.ingress.inboundCidrs | quote }}
     {{- end }}
-    # external-dns: create the proxied Cloudflare record for this host -> the ALB.
-    external-dns.alpha.kubernetes.io/hostname: {{ .Values.ingress.host | quote }}
+    # external-dns: create the proxied Cloudflare record(s) for these host(s) -> the ALB.
+    external-dns.alpha.kubernetes.io/hostname: {{ prepend (.Values.ingress.extraHosts | default list) .Values.ingress.host | join "," | quote }}
     external-dns.alpha.kubernetes.io/cloudflare-proxied: {{ .Values.ingress.cloudflareProxied | quote }}
 spec:
   ingressClassName: alb
   rules:
-    - host: {{ .Values.ingress.host | quote }}
+    {{- range prepend (.Values.ingress.extraHosts | default list) .Values.ingress.host }}
+    - host: {{ . | quote }}
       http:
         paths:
           - path: /
             pathType: Prefix
             backend:
               service:
-                name: {{ include "kortix-api.name" . }}
+                name: {{ include "kortix-api.name" $ }}
                 port:
                   name: http
+    {{- end }}
 {{- end }}

--- a/infra/k8s/charts/kortix-api/values.yaml
+++ b/infra/k8s/charts/kortix-api/values.yaml
@@ -96,6 +96,12 @@ ingress:
   host: api-eks.kortix.com
   # ACM cert ARN for the ALB HTTPS listener (from TF output acm_certificate_arn).
   certificateArn: ""
+  # Extra hostnames this ALB should also serve (each gets an Ingress rule), and
+  # the extra ACM cert ARNs to attach for them (ALB picks the right cert by SNI).
+  # Used for cutover: serve the real domain (e.g. dev-api.kortix.com) alongside
+  # the EKS-direct name (dev-api-eks.kortix.com). Empty = single-host (default).
+  extraHosts: []
+  extraCertificateArns: []
   # Cloudflare proxies the record (orange cloud) — external-dns sets this.
   cloudflareProxied: true
   # ALB idle timeout (s) — raise for long-lived/streaming requests (matches ECS).

--- a/infra/k8s/envs/dev/values.yaml
+++ b/infra/k8s/envs/dev/values.yaml
@@ -41,8 +41,15 @@ externalSecrets:
 
 ingress:
   enabled: true
-  host: dev-api-eks.kortix.com
-  certificateArn: arn:aws:acm:us-west-2:935064898258:certificate/57eed8f4-cba4-4d6a-94ea-1b948708989b
+  # Primary = the real dev domain (cutover target), reusing the existing ACM cert
+  # the ECS dev ALB uses (a9af6fd8). The EKS-direct name dev-api-eks stays served
+  # too (its own cert) as a stable test endpoint independent of the cutover.
+  host: dev-api.kortix.com
+  certificateArn: arn:aws:acm:us-west-2:935064898258:certificate/a9af6fd8-d214-4cbe-a525-107a44e893fb
+  extraHosts:
+    - dev-api-eks.kortix.com
+  extraCertificateArns:
+    - arn:aws:acm:us-west-2:935064898258:certificate/57eed8f4-cba4-4d6a-94ea-1b948708989b
   cloudflareProxied: true
 
 # Plain rolling Deployment (no canary) — same delivery model as prod-eks:


### PR DESCRIPTION
First of the dev cutover. Makes the EKS dev ALB **serve `dev-api.kortix.com`** so we can repoint Cloudflare to it; **no traffic moves on merge** (Cloudflare still → ECS until we flip it).

- **Chart:** ingress gains `ingress.extraHosts` + `ingress.extraCertificateArns` (multi-host ALB; ALB picks the cert by SNI). Empty by default → **prod render unchanged** (verified).
- **Dev values:** primary host → `dev-api.kortix.com` reusing the **existing ECS ACM cert** (`a9af6fd8`, account/region-scoped so the EKS ALB can reference it); `dev-api-eks.kortix.com` kept as `extraHosts` (stable EKS-direct test name + the deploy-dev-eks health check).

After merge → Argo rolls the dev ingress → I verify EKS answers for `dev-api.kortix.com` (Host header), then:
2. ECS dev: `terraform state rm 'module.dns[0]'` + `manage_dns = false` (release the record, no destroy).
3. Repoint Cloudflare `dev-api` → EKS ALB.