### PR TITLE
test(dev): temporary /v1/health marker to verify the EKS deploy pipeline

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -306,6 +306,7 @@ const healthHandler = (c: any) =>
     warm_snapshots: warmSnapshotsEnabled(),
     tunnel: getTunnelServiceStatus(),
     leader: isLeader(),
+    e2e_check: 'eks-pipeline-1', // TEMP: verify the dev EKS deploy pipeline e2e; revert after
   });
 
 app.openapi(


### PR DESCRIPTION
Adds a temporary `e2e_check` field to `GET /v1/health` to verify the dev EKS deploy pipeline end-to-end.

**Merge AFTER #3422** (which restores the deploy job). On merge: Deploy Dev sees `apps/api` changed → builds `:dev-<sha8>` → `deploy-api` bumps `envs/dev/values.yaml` → Argo CD rolls the dev Deployment → `dev-api.kortix.com/v1/health` shows `e2e_check: eks-pipeline-1` (and a new `commit`).

**Revert right after** confirming — this is a throwaway test marker.