### PR TITLE
revert(dev): remove temporary /v1/health e2e_check marker

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -306,7 +306,6 @@ const healthHandler = (c: any) =>
     warm_snapshots: warmSnapshotsEnabled(),
     tunnel: getTunnelServiceStatus(),
     leader: isLeader(),
-    e2e_check: 'eks-pipeline-1', // TEMP: verify the dev EKS deploy pipeline e2e; revert after
   });
 
 app.openapi(


### PR DESCRIPTION
Removes the throwaway `e2e_check` field added in #3423. The dev EKS pipeline is verified end-to-end — `dev-api.kortix.com/v1/health` served `e2e_check: eks-pipeline-1` with commit `6a99b0da` after the GitOps deploy.

Merging this re-exercises the same pipeline (and removes the marker from dev).