### PR TITLE
feat(preview): preview env groundwork — INTERNAL_KORTIX_ENV=preview + per-PR image build

### DIFF
--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -1,0 +1,63 @@
+name: Preview Build (PR)
+
+# Builds the API image for a per-PR preview environment:
+#   kortix/kortix-api:pr-<head-sha>   (FULL head commit SHA — matches the Argo CD
+#   ApplicationSet PullRequest generator's {{.head_sha}}, which deploys this image
+#   into an ephemeral kortix-pr-<number> namespace on dev-eks).
+#
+# Gated on the `preview` label, so only opted-in PRs build + deploy. The preview
+# runs API-only against the shared dev data plane (kortix-preview-env): workers
+# off, ensureSchema skipped (INTERNAL_KORTIX_ENV=preview). Image + namespace are
+# torn down automatically when the PR is closed/merged (the ApplicationSet prunes).
+#
+# amd64-only: dev-eks nodes are x86 (m6i), so we skip the slow arm64 build.
+# Internal-branch PRs only (needs Docker Hub secrets, unavailable to forks).
+
+on:
+  pull_request:
+    types: [labeled, opened, synchronize, reopened]
+
+concurrency:
+  group: preview-build-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build-api:
+    name: Build preview API image
+    if: contains(github.event.pull_request.labels.*.name, 'preview')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          submodules: false
+      - run: git submodule sync --recursive && git submodule update --init --recursive --remote
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push :pr-<head-sha> (amd64)
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: apps/api/Dockerfile
+          platforms: linux/amd64
+          push: true
+          build-args: |
+            SERVICE=apps/api
+            KORTIX_VERSION=pr-${{ github.event.pull_request.number }}
+            KORTIX_COMMIT=${{ github.event.pull_request.head.sha }}
+          tags: |
+            kortix/kortix-api:pr-${{ github.event.pull_request.head.sha }}
+      - name: Summary
+        run: |
+          {
+            echo "### Preview API image built"
+            echo "Image: \`kortix/kortix-api:pr-${{ github.event.pull_request.head.sha }}\`"
+            echo "Argo CD deploys it to \`kortix-pr-${{ github.event.pull_request.number }}\` → \`pr-${{ github.event.pull_request.number }}.preview-api.kortix.com\`."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -12,7 +12,7 @@ export const SANDBOX_VERSION = process.env.SANDBOX_VERSION || 'unknown';
 // ─── Types ──────────────────────────────────────────────────────────────────
 
 export type SandboxProviderName = 'daytona' | 'local_docker' | 'platinum';
-type InternalKortixEnv = 'dev' | 'staging' | 'prod';
+type InternalKortixEnv = 'dev' | 'staging' | 'prod' | 'preview';
 
 // ─── Zod Helpers ────────────────────────────────────────────────────────────
 
@@ -67,7 +67,9 @@ const envSchema = z.object({
   API_KEY_SECRET: z.string().min(1, 'API_KEY_SECRET is required — API key hashing will fail'),
 
   // ── Internal Deployment Controls (optional, safe defaults for self-hosted) ─
-  INTERNAL_KORTIX_ENV:              z.enum(['dev', 'staging', 'prod']).optional().default('dev'),
+  // `preview` = ephemeral per-PR API on EKS (shares the dev data plane, never
+  // migrates it, workers off, allows preview frontends in CORS). See ensure-schema.ts + the CORS block in index.ts.
+  INTERNAL_KORTIX_ENV:              z.enum(['dev', 'staging', 'prod', 'preview']).optional().default('dev'),
   // Master switch: turns on real billing (Stripe + credit ledger), makes
   // KORTIX_URL fatal-required, mounts the proxy-auth gate, hides /v1/setup.
   // Set to true on managed/cloud deployments; leave false for self-host + dev.

--- a/apps/api/src/ensure-schema.ts
+++ b/apps/api/src/ensure-schema.ts
@@ -40,9 +40,11 @@ export async function ensureSchema(): Promise<void> {
     return;
   }
 
-  // Production: schema managed externally (CI/CD migrations)
-  if (config.INTERNAL_KORTIX_ENV === 'prod') {
-    console.log('[schema] Production mode — skipping auto-push (managed externally)');
+  // Production: schema managed externally (CI/CD migrations). Preview: ephemeral
+  // per-PR API shares the dev DB and must NEVER migrate it — schema changes are
+  // applied to dev deliberately, not by every preview pod at boot.
+  if (config.INTERNAL_KORTIX_ENV === 'prod' || config.INTERNAL_KORTIX_ENV === 'preview') {
+    console.log(`[schema] ${config.INTERNAL_KORTIX_ENV} mode — skipping auto-push (DB managed elsewhere)`);
     return;
   }
 

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -127,10 +127,23 @@ const corsOrigins = [
   ]),
 ];
 
+// Preview env (ephemeral per-PR API): also allow the matching preview frontends.
+// Their origins are dynamic per PR (Vercel deploy URLs + *.preview.kortix.com
+// aliases) so they can't be enumerated above. Scoped to INTERNAL_KORTIX_ENV=preview
+// only — dev/prod keep the strict static allowlist.
+const allowPreviewOrigins = config.INTERNAL_KORTIX_ENV === 'preview';
+const PREVIEW_ORIGIN = /^https:\/\/[a-z0-9-]+\.(vercel\.app|preview\.kortix\.com)$/i;
+
 app.use(
   '*',
   cors({
-    origin: corsOrigins,
+    origin: (origin) => {
+      // No Origin header (same-origin, curl, server-to-server) → not a CORS request.
+      if (!origin) return origin;
+      if (corsOrigins.includes(origin)) return origin;
+      if (allowPreviewOrigins && PREVIEW_ORIGIN.test(origin)) return origin;
+      return null; // not allowed → no Access-Control-Allow-Origin
+    },
     allowMethods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
     allowHeaders: ['Content-Type', 'Authorization', 'X-Kortix-Token', 'X-Api-Key', 'Accept', 'X-Kortix-Signature', 'X-Hub-Signature-256', 'traceparent', 'tracestate', 'X-Request-Id'],
     credentials: true,


### PR DESCRIPTION
**Phase 1** of PR preview environments (code only — no deploy wiring yet, no behavior change for dev/prod).

- **`config.ts`** — add `preview` to `INTERNAL_KORTIX_ENV`.
- **`ensure-schema.ts`** — `preview` skips the schema auto-push (a per-PR preview shares the **dev DB** and must never migrate it; schema changes land on dev deliberately).
- **`index.ts` CORS** — in `preview` mode only, also allow the dynamic preview frontends (`*.vercel.app` / `*.preview.kortix.com`); dev/prod keep the strict static allowlist. CORS is now an origin function (additive).
- **`preview-build.yml`** — on a PR labeled **`preview`**, build `kortix/kortix-api:pr-<head-sha>` (amd64-only; dev-eks is x86) for the Argo ApplicationSet to deploy.

Self-configures: a preview pod just sets `INTERNAL_KORTIX_ENV=preview` → schema-skip + preview-CORS. Workers stay off via the chart (`workers.enabled=false`).

**Next (separate PRs):** Phase 2 = chart ALB-group support + `envs/preview/values.yaml` + the Argo `ApplicationSet` (PullRequest generator, label-gated, auto-prune on close); Phase 3 = make `ops.kortix.com` the multi-cluster hub showing prod + dev + previews. One-time infra (you): `kortix-preview-env` secret, preview IRSA, wildcard cert + DNS.