### PR TITLE
feat(preview): per-PR preview environments — ApplicationSet + ALB-group + IRSA/cert (phase 2)

### DIFF
--- a/infra/k8s/argocd/applicationsets/preview.yaml
+++ b/infra/k8s/argocd/applicationsets/preview.yaml
@@ -1,0 +1,99 @@
+# Ephemeral per-PR preview environments on the dev-eks cluster.
+#
+# Applied to the hub Argo CD (ops.kortix.com). The PullRequest generator watches
+# kortix-ai/suna for OPEN PRs labeled `preview` and creates one Application per
+# PR; when the PR closes/merges it deletes the Application, which prunes the
+# namespace + everything in it (truly ephemeral).
+#
+# Each preview = the kortix-api chart rendered at the PR's head commit with the
+# preview base values, overlaid with the PR's image (pr-<head_sha>, built by
+# .github/workflows/preview-build.yml) and host (pr-<n>.preview-api.kortix.com,
+# served off the shared `kortix-previews` ALB + the *.preview-api wildcard cert).
+#
+# Requires (one-time): a GitHub token secret `preview-pr-generator-github` in the
+# argocd namespace, and the dev-eks cluster registered in the hub as `kortix-dev-eks`.
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: preview
+  namespace: argocd
+spec:
+  description: Ephemeral per-PR preview APIs on dev-eks.
+  sourceRepos:
+    - https://github.com/kortix-ai/suna.git
+  destinations:
+    - name: kortix-dev-eks
+      namespace: 'kortix-pr-*'
+  clusterResourceWhitelist:
+    - group: ''
+      kind: Namespace
+  namespaceResourceWhitelist:
+    - group: '*'
+      kind: '*'
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: kortix-previews
+  namespace: argocd
+spec:
+  goTemplate: true
+  goTemplateOptions: ["missingkey=error"]
+  generators:
+    - pullRequest:
+        github:
+          owner: kortix-ai
+          repo: suna
+          tokenRef:
+            secretName: preview-pr-generator-github
+            key: token
+          # Only PRs carrying the `preview` label spin up an environment.
+          labels:
+            - preview
+        requeueAfterSeconds: 120
+  template:
+    metadata:
+      name: 'kortix-pr-{{.number}}'
+      labels:
+        env: preview
+        pr-number: '{{.number}}'
+    spec:
+      project: preview
+      source:
+        repoURL: https://github.com/kortix-ai/suna.git
+        targetRevision: '{{.head_sha}}'
+        path: infra/k8s/charts/kortix-api
+        helm:
+          releaseName: kortix-api
+          valueFiles:
+            - ../../envs/preview/values.yaml
+          parameters:
+            - name: image.tag
+              value: 'pr-{{.head_sha}}'
+            - name: ingress.host
+              value: 'pr-{{.number}}.preview-api.kortix.com'
+      destination:
+        name: kortix-dev-eks
+        namespace: 'kortix-pr-{{.number}}'
+      # ESO's admission webhook injects defaults into the ExternalSecret that git
+      # doesn't carry — ignore them so previews aren't perpetually OutOfSync.
+      ignoreDifferences:
+        - group: external-secrets.io
+          kind: ExternalSecret
+          jqPathExpressions:
+            - .spec.dataFrom[]?.extract.conversionStrategy
+            - .spec.dataFrom[]?.extract.decodingStrategy
+            - .spec.dataFrom[]?.extract.metadataPolicy
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true   # the kortix-pr-<n> namespace is made on the fly
+          - ServerSideApply=true
+        retry:
+          limit: 5
+          backoff:
+            duration: 10s
+            factor: 2
+            maxDuration: 3m

--- a/infra/k8s/charts/kortix-api/templates/ingress.yaml
+++ b/infra/k8s/charts/kortix-api/templates/ingress.yaml
@@ -15,6 +15,11 @@ metadata:
     {{- include "kortix-api.labels" . | nindent 4 }}
   annotations:
     alb.ingress.kubernetes.io/scheme: internet-facing
+    {{- if .Values.ingress.albGroup }}
+    # Join a shared ALB (one LB, host-routed) instead of provisioning one per
+    # Ingress — used by PR previews so N ephemeral envs share a single ALB.
+    alb.ingress.kubernetes.io/group.name: {{ .Values.ingress.albGroup | quote }}
+    {{- end }}
     alb.ingress.kubernetes.io/target-type: ip
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80},{"HTTPS":443}]'
     alb.ingress.kubernetes.io/ssl-redirect: "443"

--- a/infra/k8s/charts/kortix-api/values.yaml
+++ b/infra/k8s/charts/kortix-api/values.yaml
@@ -102,6 +102,10 @@ ingress:
   # the EKS-direct name (dev-api-eks.kortix.com). Empty = single-host (default).
   extraHosts: []
   extraCertificateArns: []
+  # Join a shared ALB by group name (one LB host-routed across many Ingresses).
+  # Empty = a dedicated ALB per Ingress (default). PR previews set this so all
+  # ephemeral envs share one ALB instead of one-per-PR.
+  albGroup: ""
   # Cloudflare proxies the record (orange cloud) — external-dns sets this.
   cloudflareProxied: true
   # ALB idle timeout (s) — raise for long-lived/streaming requests (matches ECS).

--- a/infra/k8s/envs/preview/values.yaml
+++ b/infra/k8s/envs/preview/values.yaml
@@ -1,0 +1,62 @@
+# Base values for an ephemeral per-PR preview API on dev-eks. The Argo CD
+# ApplicationSet (infra/k8s/argocd/applicationsets/preview.yaml) overlays the
+# per-PR bits: image.tag (pr-<head_sha>) and ingress.host
+# (pr-<number>.preview-api.kortix.com).
+#
+# Shares the DEV data plane via the kortix-preview-env bundle and NEVER migrates
+# it (INTERNAL_KORTIX_ENV=preview → ensureSchema skipped in code). API-only,
+# workers off, single tiny replica. A PR that needs a schema change applies the
+# migration to dev deliberately (it's the shared dev DB).
+
+image:
+  tag: preview # overridden per-PR by the ApplicationSet → pr-<head_sha>
+
+env:
+  internalKortixEnv: preview
+
+# API-only — an ephemeral preview must never run the dev-tier singleton workers.
+workers:
+  enabled: false
+
+# Ephemeral + low-traffic: one small replica, no HPA/PDB/spread.
+replicas: 1
+autoscaling:
+  enabled: false
+pdb:
+  enabled: false
+topologySpread:
+  enabled: false
+resources:
+  requests:
+    cpu: "250m"
+    memory: "512Mi"
+  limits:
+    cpu: "1"
+    memory: "1Gi"
+
+serviceAccount:
+  name: kortix-api
+  # Preview IRSA (TF: aws_iam_role.preview_app, name kortix-dev-eks-preview-app)
+  # — trusts any kortix-pr-*/kortix-api SA to read kortix-preview-env. Predictable
+  # from the role name; verify with `terraform output preview_app_irsa_role_arn`.
+  roleArn: arn:aws:iam::935064898258:role/kortix-dev-eks-preview-app
+
+externalSecrets:
+  enabled: true
+  region: us-west-2
+  secretName: kortix-preview-env
+  targetSecretName: kortix-api-env
+
+ingress:
+  enabled: true
+  host: preview.preview-api.kortix.com # overridden per-PR by the ApplicationSet
+  # Wildcard cert *.preview-api.kortix.com (TF module.acm_preview). FILL from:
+  #   terraform -chdir=infra/terraform/environments/dev-eks/cluster output -raw acm_preview_certificate_arn
+  certificateArn: REPLACE_WITH_preview_wildcard_acm_arn
+  # All previews share ONE host-routed ALB (no ALB-per-PR cost/latency).
+  albGroup: kortix-previews
+  cloudflareProxied: true
+
+# Plain rolling Deployment (no canary).
+rollout:
+  enabled: false

--- a/infra/terraform/environments/dev-eks/cluster/preview.tf
+++ b/infra/terraform/environments/dev-eks/cluster/preview.tf
@@ -1,0 +1,83 @@
+# ── PR preview environments (ephemeral per-PR API on dev-eks) ─────────────────
+# Each open PR labeled `preview` gets a kortix-pr-<n> namespace (created by Argo
+# CD) running the API against the shared dev data plane via the kortix-preview-env
+# bundle. AWS prerequisites:
+#   1. a wildcard ACM cert for *.preview-api.kortix.com (one shared preview ALB), and
+#   2. an IRSA role any kortix-pr-*/kortix-api ServiceAccount can assume to read
+#      kortix-preview-env — StringLike on the OIDC sub, since the wildcard
+#      namespace can't be expressed by the exact-match modules/eks/irsa.
+
+locals {
+  preview_secret_name     = "kortix-preview-env"
+  preview_wildcard_domain = "*.preview-api.kortix.com"
+  # Any preview namespace's app SA: system:serviceaccount:kortix-pr-<n>:kortix-api
+  preview_sa_subject = "system:serviceaccount:kortix-pr-*:${var.app_service_account}"
+}
+
+# Wildcard cert for the shared preview ALB (all PR hosts served via SNI).
+module "acm_preview" {
+  source      = "../../../modules/acm-cloudflare"
+  domain_name = local.preview_wildcard_domain
+  zone_id     = var.cloudflare_zone_id
+  tags        = local.tags
+  providers = {
+    aws        = aws
+    cloudflare = cloudflare
+  }
+}
+
+data "aws_secretsmanager_secret" "preview_env" {
+  name = local.preview_secret_name
+}
+
+data "aws_iam_policy_document" "preview_assume" {
+  statement {
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+    effect  = "Allow"
+    principals {
+      type        = "Federated"
+      identifiers = [module.eks.oidc_provider_arn]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "${module.eks.oidc_provider_url}:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+    # Wildcard namespace — trusts every ephemeral kortix-pr-<n> preview's app SA.
+    condition {
+      test     = "StringLike"
+      variable = "${module.eks.oidc_provider_url}:sub"
+      values   = [local.preview_sa_subject]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "preview_secrets_read" {
+  statement {
+    effect    = "Allow"
+    actions   = ["secretsmanager:GetSecretValue", "secretsmanager:DescribeSecret"]
+    resources = [data.aws_secretsmanager_secret.preview_env.arn]
+  }
+}
+
+resource "aws_iam_role" "preview_app" {
+  name               = "${local.name}-preview-app"
+  assume_role_policy = data.aws_iam_policy_document.preview_assume.json
+  tags               = local.tags
+}
+
+resource "aws_iam_role_policy" "preview_secrets_read" {
+  name   = "${local.name}-preview-secrets-read"
+  role   = aws_iam_role.preview_app.id
+  policy = data.aws_iam_policy_document.preview_secrets_read.json
+}
+
+output "preview_app_irsa_role_arn" {
+  description = "IRSA role any kortix-pr-*/kortix-api SA assumes to read kortix-preview-env."
+  value       = aws_iam_role.preview_app.arn
+}
+
+output "acm_preview_certificate_arn" {
+  description = "Wildcard cert for *.preview-api.kortix.com (shared preview ALB ingress annotation)."
+  value       = module.acm_preview.certificate_arn
+}


### PR DESCRIPTION
**Phase 2** of PR preview environments — builds on #3428 (the `preview` env code). All manifests/TF; nothing live until the one-time infra below is applied.

### What's here
- **Chart** — `ingress.albGroup` → joins a shared ALB via `group.name` (N previews, one host-routed LB). Empty default ⇒ **dev/prod render unchanged** (verified).
- **`envs/preview/values.yaml`** — API-only (workers off), 1 tiny replica, no HPA/PDB/spread, `kortix-preview-env`, `INTERNAL_KORTIX_ENV=preview` (ensureSchema skipped), `albGroup=kortix-previews`. The ApplicationSet overlays per-PR `image.tag` + `ingress.host`.
- **`argocd/applicationsets/preview.yaml`** — PullRequest generator (label **`preview`**) → one Application per open PR on dev-eks in `kortix-pr-<n>` (CreateNamespace), **auto-pruned when the PR closes**. Plus a `preview` AppProject.
- **`dev-eks/cluster/preview.tf`** — wildcard ACM cert `*.preview-api.kortix.com` + IRSA role (`kortix-dev-eks-preview-app`, `StringLike kortix-pr-*:kortix-api`) reading `kortix-preview-env`.

### One-time setup (you)
1. **Create `kortix-preview-env`** (copy of `kortix-dev-env`).
2. **`terraform apply`** dev-eks/cluster → fill `ingress.certificateArn` in `envs/preview/values.yaml` from `terraform output acm_preview_certificate_arn` (IRSA role ARN already pinned).
3. **Cloudflare**: proxied wildcard CNAME `*.preview-api` → the shared preview ALB (appears once the first preview Ingress provisions it).
4. **Hub (Phase 3)**: register dev-eks into `ops.kortix.com` as `kortix-dev-eks` (`argocd cluster add`), create the `preview-pr-generator-github` token secret in `argocd`, then `kubectl apply` this ApplicationSet to the hub.

### Flow once live
Label a PR `preview` → `preview-build.yml` builds `:pr-<sha>` → ApplicationSet deploys `kortix-pr-<n>` → `pr-<n>.preview-api.kortix.com` → tear-down on close. Shared dev DB, no migrations.