### PR TITLE
test: PR preview env smoke test (do not merge)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -323,6 +323,7 @@ const healthHandler = (c: any) =>
     warm_snapshots: warmSnapshotsEnabled(),
     tunnel: getTunnelServiceStatus(),
     leader: isLeader(),
+    preview_smoke: true, // TEMP smoke test for PR preview envs — this PR is not merged
   });
 
 app.openapi(


### PR DESCRIPTION
Throwaway PR to validate the per-PR preview pipeline end-to-end. Adds a temporary `preview_smoke: true` to `/v1/health`.

Labeled `preview` → builds `:pr-<sha>` → Argo ApplicationSet deploys `kortix-pr-<n>` on dev-eks → `pr-<n>.preview-api.kortix.com`. Expect `environment: preview` + `preview_smoke: true` + `commit: <this PR's sha>`. **Close (don't merge)** when done → the env is auto-pruned.