### PR TITLE
feat(preview): external-dns auto-manages per-PR DNS (proper setup, no manual steps)

### DIFF
--- a/infra/k8s/envs/preview/values.yaml
+++ b/infra/k8s/envs/preview/values.yaml
@@ -54,7 +54,11 @@ ingress:
   certificateArn: arn:aws:acm:us-west-2:935064898258:certificate/8e5ec220-77d9-450f-abe9-21d5322afa78
   # All previews share ONE host-routed ALB (no ALB-per-PR cost/latency).
   albGroup: kortix-previews
-  cloudflareProxied: true
+  # DNS-only (grey cloud): external-dns creates pr-<n>.preview-api.kortix.com →
+  # the shared preview ALB, which serves the *.preview-api ACM cert directly.
+  # NOT proxied — Cloudflare Universal SSL doesn't cover the multi-level
+  # *.preview-api wildcard, so proxying would fail the edge TLS handshake.
+  cloudflareProxied: false
 
 # Plain rolling Deployment (no canary).
 rollout:

--- a/infra/terraform/environments/dev-eks/platform/main.tf
+++ b/infra/terraform/environments/dev-eks/platform/main.tf
@@ -89,6 +89,9 @@ module "platform" {
   oidc_provider_arn = local.cluster.oidc_provider_arn
   oidc_provider_url = local.cluster.oidc_provider_url
   api_domain        = local.cluster.api_domain
+  # Let external-dns also auto-manage per-PR preview records
+  # (pr-<n>.preview-api.kortix.com) — created/deleted with each preview Ingress.
+  extra_domain_filters = ["preview-api.kortix.com"]
 
   cloudflare_api_token = var.cloudflare_api_token
 

--- a/infra/terraform/modules/eks/platform/main.tf
+++ b/infra/terraform/modules/eks/platform/main.tf
@@ -123,7 +123,7 @@ resource "helm_release" "external_dns" {
         }
       }
     }]
-    domainFilters = [var.api_domain]
+    domainFilters = concat([var.api_domain], var.extra_domain_filters)
     policy        = "sync"
     registry      = "txt"
     txtOwnerId    = var.cluster_name

--- a/infra/terraform/modules/eks/platform/variables.tf
+++ b/infra/terraform/modules/eks/platform/variables.tf
@@ -28,6 +28,12 @@ variable "api_domain" {
   type        = string
 }
 
+variable "extra_domain_filters" {
+  description = "Extra external-dns domain filters beyond api_domain — e.g. preview-api.kortix.com so external-dns auto-manages per-PR preview records. Empty by default (single-host)."
+  type        = list(string)
+  default     = []
+}
+
 variable "cloudflare_api_token" {
   description = "Cloudflare API token external-dns uses to manage the record (DNS edit on the kortix.com zone)."
   type        = string


### PR DESCRIPTION
Makes preview DNS **fully automatic + robust** — the answer to "I won't run commands after every preview." No per-deploy work, no wildcard, no staleness.

external-dns on dev-eks is healthy (`policy=sync`, reconciling every minute) but scoped to `--domain-filter=dev-api-eks.kortix.com`, so it ignored preview hosts. This widens it:

- **platform module**: new `extra_domain_filters` (default `[]` → **prod/dev unchanged**); `domainFilters = [api_domain] + extras`.
- **dev-eks platform**: `extra_domain_filters = ["preview-api.kortix.com"]` → external-dns now **auto-creates `pr-<n>.preview-api.kortix.com` when a preview Ingress appears and deletes it when the PR closes** (policy=sync, self-cleaning). Survives the shared ALB being recreated (it reconciles to the current target).
- **preview values**: `cloudflareProxied: false` → DNS-only records that hit the shared ALB directly, whose `*.preview-api` ACM cert serves TLS. (Cloudflare Universal SSL doesn't cover the multi-level `*.preview-api` wildcard, so proxying fails the edge handshake; DNS-only is the right call for ephemeral previews.)

**After merge:** `terraform apply` dev-eks/**platform** (re-applies external-dns with the wider filter) → previews self-manage DNS forever. Then delete the temporary manual `*.preview-api` wildcard record (superseded). New PRs labeled `preview` are fully zero-touch end to end.