### PR TITLE
test: preview env e2e v2 (do not merge)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -323,6 +323,7 @@ const healthHandler = (c: any) =>
     warm_snapshots: warmSnapshotsEnabled(),
     tunnel: getTunnelServiceStatus(),
     leader: isLeader(),
+    preview_smoke: 'v2', // TEMP preview-env smoke test (do not merge)
   });
 
 app.openapi(


### PR DESCRIPTION
Fresh preview smoke test off current main — exercises external-dns auto-DNS (DNS-only) + the frontend wiring. Adds temp `preview_smoke: v2` to /v1/health. Close when verified → auto-teardown (env + DNS).