### PR TITLE
docs(slack): document the ~5-min stream idle timeout + keep-alive discipline

### DIFF
--- a/.kortix/opencode/skills/kortix-slack/SKILL.md
+++ b/.kortix/opencode/skills/kortix-slack/SKILL.md
@@ -98,6 +98,32 @@ slack send "It was api@a3f1 — the new auth middleware drops the trace header o
 - **Don't `slack step` after you've called `slack send`.** The plan is closed. Further steps drop silently.
 </live-stream>
 
+<keeping-the-stream-alive>
+### The ~5-minute idle timeout (READ THIS — it's the #1 cause of false "errors")
+
+Slack enforces a **hard ~5-minute idle timeout** on a streaming turn. The clock is **idle time since the last stream update**, not total turn length — and it is **not bypassable** from Slack's side. Every `slack step` you emit is a stream update that **resets the timer to zero**. If more than ~5 minutes pass with *no* update, Slack kills the turn and paints a red **error** in the thread — even though your agent is alive and working fine. The work usually still completes in the background; the user just sees a scary "failed" state. (Same root cause as a finished plan block getting stuck on "in_progress" — the stream got severed before the final `slack send`.)
+
+The platform runs a **safety-net heartbeat** (a watchdog touches any quiet-but-alive stream every ~3 min so Slack doesn't auto-fail it). Treat that as a backstop, **not** an excuse to go silent: it only paints a generic "Working on it…" tick, it doesn't help if the watchdog is down/lagging, and a wall of nothing for minutes is bad UX. **You keeping the stream warm with real checkpoints is still the primary fix.**
+
+**So: a turn doesn't fail because the work is slow. It fails when it goes quiet. Don't go quiet.**
+
+### Rules to never trip it
+
+- **Never go >~4 minutes without a `slack step`.** Treat 4 min as your budget; post before you spend it. A step is cheap — emitting one extra is free, tripping the timeout is not.
+- **Before any long-running operation, post a step first.** Anything that can take minutes — `git clone`, `pnpm install`, a test suite, a build, `pnpm preview`, deep web research, a big LLM call, a `task`/subagent — gets a `slack step` *immediately before* you start it, so the timer is fresh going in.
+- **Break long single operations into narrated phases.** Don't do "clone + install + typecheck + test" as one silent 12-minute block. Step between each: `slack step "Installing deps"` → `slack step "Running typecheck"` → `slack step "Running tests"`. Each one resets the clock *and* reads better.
+- **For a genuinely long single command (one >4-min step with nothing to narrate),** stream a heartbeat from a background loop so the timer keeps resetting while it runs:
+  ```sh
+  # keep the Slack stream warm during a long blocking command
+  ( while sleep 200; do slack step "Still working… (running tests)"; done ) &
+  HB=$!
+  pnpm test            # the long thing
+  kill "$HB" 2>/dev/null   # stop the heartbeat as soon as it returns
+  ```
+  Kill the heartbeat the instant the command returns, and **never leave a heartbeat running after `slack send`** (steps after send drop silently, and a stray background loop is a leak — see the "stop long-running processes before you finish" rule).
+- **It's idle-time, not call-count.** Ten steps in one minute then six minutes of silence still trips it. Spacing is what matters, not volume — but err toward more frequent updates on long tasks; it's the single biggest reliability win.
+</keeping-the-stream-alive>
+
 <final-answer>
 ### `slack send "<text>"` — plain-text answer
 

--- a/packages/starter/templates/base/.kortix/opencode/skills/kortix-slack/SKILL.md
+++ b/packages/starter/templates/base/.kortix/opencode/skills/kortix-slack/SKILL.md
@@ -98,6 +98,32 @@ slack send "It was api@a3f1 — the new auth middleware drops the trace header o
 - **Don't `slack step` after you've called `slack send`.** The plan is closed. Further steps drop silently.
 </live-stream>
 
+<keeping-the-stream-alive>
+### The ~5-minute idle timeout (READ THIS — it's the #1 cause of false "errors")
+
+Slack enforces a **hard ~5-minute idle timeout** on a streaming turn. The clock is **idle time since the last stream update**, not total turn length — and it is **not bypassable** from Slack's side. Every `slack step` you emit is a stream update that **resets the timer to zero**. If more than ~5 minutes pass with *no* update, Slack kills the turn and paints a red **error** in the thread — even though your agent is alive and working fine. The work usually still completes in the background; the user just sees a scary "failed" state. (Same root cause as a finished plan block getting stuck on "in_progress" — the stream got severed before the final `slack send`.)
+
+The platform runs a **safety-net heartbeat** (a watchdog touches any quiet-but-alive stream every ~3 min so Slack doesn't auto-fail it). Treat that as a backstop, **not** an excuse to go silent: it only paints a generic "Working on it…" tick, it doesn't help if the watchdog is down/lagging, and a wall of nothing for minutes is bad UX. **You keeping the stream warm with real checkpoints is still the primary fix.**
+
+**So: a turn doesn't fail because the work is slow. It fails when it goes quiet. Don't go quiet.**
+
+### Rules to never trip it
+
+- **Never go >~4 minutes without a `slack step`.** Treat 4 min as your budget; post before you spend it. A step is cheap — emitting one extra is free, tripping the timeout is not.
+- **Before any long-running operation, post a step first.** Anything that can take minutes — `git clone`, `pnpm install`, a test suite, a build, `pnpm preview`, deep web research, a big LLM call, a `task`/subagent — gets a `slack step` *immediately before* you start it, so the timer is fresh going in.
+- **Break long single operations into narrated phases.** Don't do "clone + install + typecheck + test" as one silent 12-minute block. Step between each: `slack step "Installing deps"` → `slack step "Running typecheck"` → `slack step "Running tests"`. Each one resets the clock *and* reads better.
+- **For a genuinely long single command (one >4-min step with nothing to narrate),** stream a heartbeat from a background loop so the timer keeps resetting while it runs:
+  ```sh
+  # keep the Slack stream warm during a long blocking command
+  ( while sleep 200; do slack step "Still working… (running tests)"; done ) &
+  HB=$!
+  pnpm test            # the long thing
+  kill "$HB" 2>/dev/null   # stop the heartbeat as soon as it returns
+  ```
+  Kill the heartbeat the instant the command returns, and **never leave a heartbeat running after `slack send`** (steps after send drop silently, and a stray background loop is a leak — see the "stop long-running processes before you finish" rule).
+- **It's idle-time, not call-count.** Ten steps in one minute then six minutes of silence still trips it. Spacing is what matters, not volume — but err toward more frequent updates on long tasks; it's the single biggest reliability win.
+</keeping-the-stream-alive>
+
 <final-answer>
 ### `slack send "<text>"` — plain-text answer
 


### PR DESCRIPTION
## Why

Turns triggered from Slack sometimes show a red **error** after a few minutes even though the agent finished fine (e.g. a long `git clone` / `pnpm install` / test run / deep research with no checkpoint in between). Root cause: Slack puts a hard **~5-min *idle* timeout** on a streaming turn — it's idle time since the last stream update, not total turn length, and it's not bypassable from Slack's side. Every `slack step` resets that timer; going silent trips it. Same root cause as a finished plan block getting stuck on "in_progress".

Reported by Marko in the team Slack thread ("the 5min timeout… include in the kortix slack skill that updates have to be sent frequently"). This persists that guidance in the core repo so it isn't just a local session edit.

## What

Adds a `<keeping-the-stream-alive>` section to the `kortix-slack` skill:

- the ~5-min **idle** (not total) timeout and why turns falsely error
- never go >~4 min without a `slack step`
- post a step **immediately before** any long op (clone, install, build, tests, `preview`, deep research, subagents)
- narrate long ops in **phases** instead of one silent block
- a background **heartbeat snippet** for a genuinely long single command (killed before `slack send`)

It also documents that the platform **already runs a safety-net heartbeat** (`HEARTBEAT_AFTER_MS`, every ~3 min — see `apps/api/src/channels/slack/streams.ts`, added in 9640ff531) and frames agent-side discipline as the *primary* fix + better UX, with the watchdog as the backstop.

Applied to **both** canonical copies so they don't drift and every newly scaffolded project inherits it:
- `.kortix/opencode/skills/kortix-slack/SKILL.md`
- `packages/starter/templates/base/.kortix/opencode/skills/kortix-slack/SKILL.md`

## Scope

Docs/skill-content only — no code changes, no behavior change to the API.
