### PR TITLE
fix(eks): pin external-dns to the kortix.com zone by ID (unwedge DNS automation)

### DIFF
--- a/infra/terraform/environments/dev-eks/platform/main.tf
+++ b/infra/terraform/environments/dev-eks/platform/main.tf
@@ -94,6 +94,7 @@ module "platform" {
   extra_domain_filters = ["preview-api.kortix.com"]
 
   cloudflare_api_token = var.cloudflare_api_token
+  cloudflare_zone_id   = var.cloudflare_zone_id
 
   # Argo CD UI (dev-ops.kortix.com) — OFF by default for dev (headless).
   argocd_ui_enabled      = var.argocd_ui_enabled

--- a/infra/terraform/environments/dev-eks/platform/variables.tf
+++ b/infra/terraform/environments/dev-eks/platform/variables.tf
@@ -55,3 +55,13 @@ variable "cloudflare_api_token" {
   type        = string
   sensitive   = true
 }
+
+variable "cloudflare_zone_id" {
+  description = <<-EOT
+    Cloudflare hosted zone ID for kortix.com. Pins external-dns zone discovery by
+    ID — without it the subdomain domainFilters cause external-dns to discard the
+    zone and manage nothing. Supply via TF_VAR_cloudflare_zone_id (same value the
+    cluster layer already uses).
+  EOT
+  type        = string
+}

--- a/infra/terraform/environments/prod-eks/platform/main.tf
+++ b/infra/terraform/environments/prod-eks/platform/main.tf
@@ -91,6 +91,7 @@ module "platform" {
   api_domain        = local.cluster.api_domain
 
   cloudflare_api_token = var.cloudflare_api_token
+  cloudflare_zone_id   = var.cloudflare_zone_id
 
   # Argo CD UI (ops.kortix.com) — opt-in; gate with Cloudflare Access first.
   argocd_ui_enabled      = var.argocd_ui_enabled

--- a/infra/terraform/environments/prod-eks/platform/variables.tf
+++ b/infra/terraform/environments/prod-eks/platform/variables.tf
@@ -56,3 +56,13 @@ variable "cloudflare_api_token" {
   type        = string
   sensitive   = true
 }
+
+variable "cloudflare_zone_id" {
+  description = <<-EOT
+    Cloudflare hosted zone ID for kortix.com. Pins external-dns zone discovery by
+    ID — without it the subdomain domainFilter causes external-dns to discard the
+    zone and manage nothing. Supply via TF_VAR_cloudflare_zone_id (same value the
+    cluster layer already uses).
+  EOT
+  type        = string
+}

--- a/infra/terraform/modules/eks/platform/main.tf
+++ b/infra/terraform/modules/eks/platform/main.tf
@@ -101,6 +101,13 @@ resource "helm_release" "external_secrets" {
 # records IT created (tagged with the TXT owner), and domainFilters confines it
 # to api-eks.kortix.com — so it can never disturb api.kortix.com, api-ecs, or any
 # other record in the shared zone.
+#
+# zoneIdFilters pins the kortix.com hosted zone by ID. This is REQUIRED: the
+# domainFilters are subdomains (api-eks / preview-api), and external-dns's zone
+# discovery only matches a zone whose NAME equals or is a parent of a filter —
+# "kortix.com" is neither, so without the zone-id pin external-dns finds no
+# hosted zone, logs "no hosted zone matching record DNS Name", and silently
+# manages nothing. The domainFilters still scope which records it may write.
 resource "helm_release" "external_dns" {
   name       = "external-dns"
   repository = "https://kubernetes-sigs.github.io/external-dns/"
@@ -124,6 +131,7 @@ resource "helm_release" "external_dns" {
       }
     }]
     domainFilters = concat([var.api_domain], var.extra_domain_filters)
+    zoneIdFilters = var.cloudflare_zone_id != "" ? [var.cloudflare_zone_id] : []
     policy        = "sync"
     registry      = "txt"
     txtOwnerId    = var.cluster_name

--- a/infra/terraform/modules/eks/platform/variables.tf
+++ b/infra/terraform/modules/eks/platform/variables.tf
@@ -34,6 +34,12 @@ variable "extra_domain_filters" {
   default     = []
 }
 
+variable "cloudflare_zone_id" {
+  description = "Cloudflare hosted zone ID for kortix.com. Pins external-dns zone discovery by ID so subdomain domainFilters (api-eks / preview-api) don't cause it to discard the zone and manage nothing. Empty = unset (no zone-id filter)."
+  type        = string
+  default     = ""
+}
+
 variable "cloudflare_api_token" {
   description = "Cloudflare API token external-dns uses to manage the record (DNS edit on the kortix.com zone)."
   type        = string


### PR DESCRIPTION
## Problem

external-dns has been **wedged on both EKS clusters** since it was installed — it has never actually published a record. `api-eks.kortix.com`, `dev-api-eks.kortix.com`, and the preview wildcard were all created **by hand**; the controller itself manages nothing.

Root cause, confirmed from debug logs on dev-eks:

```
zone kortix.com not in domain filter
Skipping record pr-3435.preview-api.kortix.com because no hosted zone matching record DNS Name was detected
Skipping record dev-api-eks.kortix.com  because no hosted zone matching record DNS Name was detected
```

The `--domain-filter` entries are **subdomains** (`api-eks.kortix.com`, `preview-api.kortix.com`). external-dns's zone discovery only keeps a zone whose **name** equals or is a **parent** of a filter. `kortix.com` is a *parent* of the filters, not a child — so `Match("kortix.com")` is false, the only hosted zone is discarded, and every desired record is skipped with *no error* (metrics: `source_endpoints_total=3`, `registry_endpoints_total=0`).

This is why per-PR preview DNS never appeared and why `pr-<n>.preview-api` fell through to the manually-created proxied wildcard (→ Cloudflare edge TLS cipher mismatch).

## Fix

Add a `cloudflare_zone_id` variable to the platform module, rendered as external-dns **`zoneIdFilters`**. Pinning the zone by ID makes discovery succeed, while the subdomain `domainFilters` still scope *which records* external-dns may write — so the "never touch `api.kortix.com`" safety is preserved.

- `modules/eks/platform`: new `cloudflare_zone_id` var → `zoneIdFilters` (conditional; empty = unset, non-breaking).
- `dev-eks` + `prod-eks` platform: pass `cloudflare_zone_id = var.cloudflare_zone_id` (fed by the `TF_VAR_cloudflare_zone_id` already used by the cluster layer — no new setup).

## Apply / verify

`terraform apply` the **dev-eks/platform** layer (export `TF_VAR_cloudflare_zone_id`). external-dns rolls, and within ~1 sync it should create `pr-<n>.preview-api.kortix.com` (DNS-only) + the `dev-api-eks` records it should have owned all along. Then `pr-3435.preview-api.kortix.com/v1/health` serves directly off the ALB (ACM `*.preview-api` cert). Apply prod-eks/platform the same way to unwedge prod (safe: `policy=sync` + txt registry never deletes unowned records like `api.kortix.com`).

Note: the stale manual proxied `*.preview-api` wildcard was already deleted; remaining manual records can be left for external-dns to adopt.