### PR TITLE
fix(api): pin Kortix identity on Contents-API commits

### DIFF
--- a/apps/api/src/__tests__/e2e-github-app-projects.test.ts
+++ b/apps/api/src/__tests__/e2e-github-app-projects.test.ts
@@ -196,5 +196,12 @@ describe('GitHub App project repository auth', () => {
     expect((repoCreate?.init?.headers as Record<string, string>).Authorization).toBe('Bearer installation-token');
     expect((readFile?.init?.headers as Record<string, string>).Authorization).toBe('Bearer installation-token');
     expect((writeFile?.init?.headers as Record<string, string>).Authorization).toBe('Bearer installation-token');
+
+    // Contents-API commits MUST pin the Kortix identity explicitly. Otherwise
+    // GitHub attributes the commit to whoever owns the token (a personal PAT
+    // surfaces "<user> committed" instead of Kortix).
+    const writeBody = JSON.parse(String(writeFile?.init?.body));
+    expect(writeBody.author).toEqual({ name: 'Kortix', email: 'noreply@kortix.ai' });
+    expect(writeBody.committer).toEqual({ name: 'Kortix', email: 'noreply@kortix.ai' });
   });
 });

--- a/apps/api/src/projects/github.ts
+++ b/apps/api/src/projects/github.ts
@@ -467,11 +467,24 @@ export async function commitFile(opts: {
   message: string;
   branch?: string;
   existingSha?: string;
+  authorName?: string;
+  authorEmail?: string;
   auth?: GitHubAuthContext;
 }): Promise<void> {
+  // Pin the commit identity explicitly. Without an `author`/`committer` the
+  // Contents API attributes the commit to whoever owns the token — which, on a
+  // server-side PAT, surfaces a personal GitHub user (e.g. "markokraemer
+  // committed") instead of Kortix. Defaulting here mirrors the identity used by
+  // every git-CLI commit path (branches.ts / merge.ts / seed.ts).
+  const ident = {
+    name: opts.authorName || 'Kortix',
+    email: opts.authorEmail || 'noreply@kortix.ai',
+  };
   const body: Record<string, unknown> = {
     message: opts.message,
     content: Buffer.from(opts.content, 'utf8').toString('base64'),
+    author: ident,
+    committer: ident,
   };
   if (opts.branch) body.branch = opts.branch;
   if (opts.existingSha) body.sha = opts.existingSha;


### PR DESCRIPTION
## What

Commits made through the GitHub **Contents API** (`commitFile()` in `apps/api/src/projects/github.ts`) sent **no `author`/`committer`**, so GitHub attributed them to whoever owns the server-side token. In prod that token resolves to a **personal GitHub user**, which is why commits intermittently show *"<user> committed"* instead of **Kortix**.

This path is used for:
- manifest edits (triggers / connectors / apps) — `projects/lib/triggers.ts`
- starter scaffold on repo create — `projects/routes/r2.ts`

## Fix

Default `author` + `committer` to **Kortix &lt;noreply@kortix.ai&gt;** in `commitFile()` (overridable via new optional `authorName`/`authorEmail` args). This matches the identity already pinned by every git-CLI commit path (`branches.ts`, `merge.ts`, `seed.ts`), and makes attribution **independent of which token is configured**.

## Why it matters

Even after the token is rotated to an org/bot credential, the Contents-API path would *still* inherit the token owner's name. Pinning the identity in code is the durable fix; the secret change is complementary.

## Test

Extended `e2e-github-app-projects.test.ts` to assert the write body pins `author`/`committer` to Kortix. `pnpm typecheck` + the suite pass (5/5).

## Operational follow-up (not in this PR)

Separately, `kortix-prod-env` has `MANAGED_GIT_GITHUB_TOKEN` and `KORTIX_GITHUB_TOKEN` both pointing at a personal account (`markokraemer`), and `KORTIX_GITHUB_TOKEN` carries very broad scopes (`admin:org`, `admin:enterprise`, `delete_repo`, …). The managed-org GitHub App (`kortix-private-repo-access`, install `140097279` on `managed-kortix`, `contents: write`) can serve managed git without any PAT — recommend dropping `MANAGED_GIT_GITHUB_TOKEN` so it falls back to the App (commits as `kortix-private-repo-access[bot]`), or replacing it with a least-privilege org/bot PAT.
