### PR TITLE
demo(preview): full-stack per-PR preview (frontend + backend together)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -299,6 +299,7 @@ const HealthSchema = z
     warm_snapshots: z.boolean(),
     tunnel: z.any(),
     leader: z.boolean(),
+    demo_marker: z.string().optional(),
   })
   .openapi('Health');
 
@@ -323,6 +324,7 @@ const healthHandler = (c: any) =>
     warm_snapshots: warmSnapshotsEnabled(),
     tunnel: getTunnelServiceStatus(),
     leader: isLeader(),
+    demo_marker: 'fullstack-preview-demo',
   });
 
 app.openapi(

--- a/apps/web/src/app/preview-demo/page.tsx
+++ b/apps/web/src/app/preview-demo/page.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+// Full-stack preview demo: this page calls whatever backend NEXT_PUBLIC_BACKEND_URL
+// points at and shows it. On a per-PR Vercel preview the wiring sets that to
+// https://pr-<n>.preview-api.kortix.com/v1, so this should report
+// environment="preview", version="pr-<sha>", demo_marker="fullstack-preview-demo"
+// — proving the preview frontend talks to its OWN preview backend.
+
+const BACKEND = process.env.NEXT_PUBLIC_BACKEND_URL || '';
+
+export default function PreviewDemoPage() {
+  const [health, setHealth] = useState<Record<string, unknown> | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const url = `${BACKEND.replace(/\/$/, '')}/health`;
+    fetch(url)
+      .then((r) => r.json())
+      .then(setHealth)
+      .catch((e) => setError(String(e)));
+  }, []);
+
+  return (
+    <main style={{ maxWidth: 640, margin: '64px auto', padding: 24, fontFamily: 'ui-monospace, monospace' }}>
+      <h1 style={{ fontSize: 20, marginBottom: 8 }}>Full-stack preview demo</h1>
+      <p style={{ opacity: 0.7, marginBottom: 24 }}>
+        This frontend is calling backend: <strong>{BACKEND || '(NEXT_PUBLIC_BACKEND_URL unset)'}</strong>
+      </p>
+
+      {error && <pre style={{ color: '#c00' }}>error: {error}</pre>}
+
+      {health ? (
+        <table style={{ borderCollapse: 'collapse', width: '100%' }}>
+          <tbody>
+            {(['environment', 'version', 'demo_marker', 'commit', 'memory_mb', 'instance', 'status'] as const).map((k) => (
+              <tr key={k}>
+                <td style={{ padding: '6px 12px', opacity: 0.6, borderBottom: '1px solid #eee' }}>{k}</td>
+                <td style={{ padding: '6px 12px', borderBottom: '1px solid #eee' }}>
+                  <strong>{String(health[k] ?? '—')}</strong>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      ) : (
+        !error && <p>loading…</p>
+      )}
+    </main>
+  );
+}


### PR DESCRIPTION
End-to-end demo of the per-PR preview platform in a **single PR** — both halves at once.

## What this exercises
- **Backend preview**: `preview-build.yml` builds `kortix-api:pr-<sha>` → Argo ApplicationSet deploys `kortix-pr-<n>` on dev-eks → external-dns auto-publishes `pr-<n>.preview-api.kortix.com` (DNS-only) → `/v1/health` now returns `demo_marker: "fullstack-preview-demo"`.
- **Frontend preview**: `preview-frontend.yml` sets this branch's Vercel env `NEXT_PUBLIC_BACKEND_URL=https://pr-<n>.preview-api.kortix.com/v1` and redeploys. The new **`/preview-demo`** page renders whatever backend it's wired to.

## How to verify both at once
1. **Backend**: `curl https://pr-<n>.preview-api.kortix.com/v1/health` → `environment: preview`, `version: pr-<sha>`, `demo_marker: fullstack-preview-demo`.
2. **Frontend**: open the Vercel preview's **`/preview-demo`** → it should display the same backend URL + `environment=preview`, `version=pr-<sha>`, `demo_marker=fullstack-preview-demo`. That proves the preview frontend is talking to **its own** preview backend (not dev).

Close the PR → both the preview API (Argo prune + external-dns record cleanup) and the Vercel branch env are torn down automatically.

_Demo PR — not for merge; close it after verifying._