### PR TITLE
feat(ci): live preview status as a sticky PR comment (frontend + backend)

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -35,6 +35,7 @@ concurrency:
 
 permissions:
   contents: read
+  pull-requests: write   # the `announce` job posts/updates a sticky status comment
 
 env:
   VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
@@ -83,6 +84,77 @@ jobs:
             echo "Image: \`kortix/kortix-api:pr-${{ github.event.pull_request.head.sha }}\`"
             echo "Argo CD deploys it to \`kortix-pr-${{ github.event.pull_request.number }}\` → \`pr-${{ github.event.pull_request.number }}.preview-api.kortix.com\`."
           } >> "$GITHUB_STEP_SUMMARY"
+
+  # ── Post a sticky PR comment + poll until the backend is actually live ──────
+  # The k8s deploy is done by Argo CD (async, outside CI), so a green build does
+  # NOT mean the preview is serving. This job posts a status comment immediately,
+  # then polls the PUBLIC health URL (reachable from the runner) until it reports
+  # environment=preview, flips the comment to ✅, and adds the Vercel frontend URL.
+  announce:
+    name: Announce preview status
+    if: >-
+      contains(github.event.pull_request.labels.*.name, 'preview') &&
+      contains(fromJSON('["labeled","opened","synchronize","reopened"]'), github.event.action)
+    runs-on: ubuntu-latest
+    env:
+      NUM: ${{ github.event.pull_request.number }}
+      GH_TOKEN: ${{ github.token }}
+      REPO: ${{ github.repository }}
+    steps:
+      - name: Sticky status comment (deploying → live)
+        run: |
+          set -uo pipefail
+          MARKER="<!-- preview-status -->"
+          HOST="pr-${NUM}.preview-api.kortix.com"
+
+          upsert() {
+            local body="$1"
+            local id
+            id=$(gh api "repos/${REPO}/issues/${NUM}/comments" --paginate \
+                 --jq "map(select(.body | startswith(\"${MARKER}\"))) | .[0].id // empty" | head -1)
+            if [ -n "$id" ]; then
+              gh api -X PATCH "repos/${REPO}/issues/comments/${id}" -f body="$body" >/dev/null
+            else
+              gh api -X POST "repos/${REPO}/issues/${NUM}/comments" -f body="$body" >/dev/null
+            fi
+          }
+
+          comment() { # $1=status line  $2=backend detail  $3=frontend line
+            upsert "$(printf '%s\n' \
+              "$MARKER" \
+              "## 🔭 Preview environment — $1" \
+              "" \
+              "- **Backend:** \`https://${HOST}\` — $2" \
+              "- **Frontend:** $3" \
+              "- **Health:** https://${HOST}/v1/health" \
+              "" \
+              "_Ephemeral; torn down automatically when this PR closes._")
+          }
+
+          comment "⏳ deploying" "building image + Argo CD rollout…" "wiring to the preview backend…"
+
+          status="⚠️ still rolling out after ~12m — check Argo CD (ops.kortix.com)"
+          detail="not serving yet"
+          for i in $(seq 1 36); do
+            j=$(curl -s --max-time 8 "https://${HOST}/v1/health" 2>/dev/null || true)
+            envv=$(printf '%s' "$j" | jq -r '.environment // empty' 2>/dev/null || true)
+            if [ "$envv" = "preview" ]; then
+              ver=$(printf '%s' "$j" | jq -r '.version // "?"')
+              status="✅ live"; detail="serving \`${ver}\`"; break
+            fi
+            sleep 20
+          done
+
+          # Best-effort: resolve this branch's Vercel preview URL.
+          fline="wired → it calls \`https://${HOST}/v1\` (see Vercel's preview comment for the URL)"
+          if [ -n "${VERCEL_TOKEN:-}" ] && [ -n "${PROJECT_ID:-}" ] && [ -n "${TEAM_ID:-}" ]; then
+            url=$(curl -s "https://api.vercel.com/v6/deployments?projectId=${PROJECT_ID}&teamId=${TEAM_ID}&target=preview&limit=50" \
+                  -H "Authorization: Bearer ${VERCEL_TOKEN}" \
+                  | jq -r --arg b "$BRANCH" '[.deployments[]|select(.meta.githubCommitRef==$b)]|sort_by(.created)|last|.url // empty' 2>/dev/null || true)
+            [ -n "$url" ] && fline="https://${url}  ·  \`/preview-demo\` shows the wired backend"
+          fi
+
+          comment "$status" "$detail" "$fline"
 
   # ── Point the PR's preview frontend at its preview backend ──────────────────
   wire:
@@ -151,7 +223,20 @@ jobs:
       github.event.action == 'closed' ||
       (github.event.action == 'unlabeled' && github.event.label.name == 'preview')
     runs-on: ubuntu-latest
+    env:
+      NUM: ${{ github.event.pull_request.number }}
+      GH_TOKEN: ${{ github.token }}
+      REPO: ${{ github.repository }}
     steps:
+      - name: Mark the sticky comment torn down
+        run: |
+          set -uo pipefail
+          MARKER="<!-- preview-status -->"
+          id=$(gh api "repos/${REPO}/issues/${NUM}/comments" --paginate \
+               --jq "map(select(.body | startswith(\"${MARKER}\"))) | .[0].id // empty" | head -1)
+          body="$(printf '%s\n' "$MARKER" "## 🔭 Preview environment — 🧹 torn down" "" \
+                  "The preview API + namespace were pruned and the Vercel branch override removed.")"
+          if [ -n "$id" ]; then gh api -X PATCH "repos/${REPO}/issues/comments/${id}" -f body="$body" >/dev/null; fi
       - name: Delete the branch-scoped env var
         run: |
           set -uo pipefail


### PR DESCRIPTION
Right now, labeling a PR `preview` gives no signal on the PR page — status is buried in the Actions tab, and a green build doesn't even mean the backend is serving (the k8s rollout is done by Argo CD, async, outside CI).

This adds an **`announce`** job to `deploy-preview.yml` that:
1. Posts a **sticky comment** the moment the PR is labeled: `🔭 Preview environment — ⏳ deploying`.
2. **Polls the public** `pr-<n>.preview-api.kortix.com/v1/health` (reachable from the runner) until it reports `environment=preview` — the real "it's actually up" signal — then updates the same comment to **✅ live**, showing the running `version`.
3. Resolves and links the **Vercel preview URL** for the branch (best-effort via the Vercel API), pointing at `/preview-demo`.
4. On close/unlabel, `teardown` flips the comment to **🧹 torn down**.

One comment, edited in place (no thread spam). Requires `pull-requests: write` (added). No new secrets.

Example states:
> 🔭 Preview environment — ⏳ deploying
> - Backend: `https://pr-3450.preview-api.kortix.com` — building image + Argo CD rollout…

> 🔭 Preview environment — ✅ live
> - Backend: `https://pr-3450.preview-api.kortix.com` — serving `pr-<sha>`
> - Frontend: https://suna-git-…vercel.app · `/preview-demo` shows the wired backend