### PR TITLE
fix(api): stop snapshot build-context disk leak (prod DiskPressure evictions)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -39,6 +39,7 @@ import { initModelPricing, stopModelPricing } from './router/config/model-pricin
 import { tunnelApp, wsHandlers as tunnelWsHandlers, startTunnelService, stopTunnelService, getTunnelServiceStatus } from './tunnel';
 import { accessControlApp } from './access-control';
 import { startAccessControlCache, stopAccessControlCache } from './shared/access-control-cache';
+import { startTmpReaper, stopTmpReaper } from './snapshots/tmp-reaper';
 import { startLeaderElection, stopLeaderElection, isLeader } from './shared/leader-election';
 import { oauthApp } from './oauth';
 import {
@@ -798,6 +799,10 @@ let schemaReady = false;
 async function startReplicaServices() {
   startAccessControlCache();
   startTunnelService();
+  // Every replica stages snapshot/session-boot build contexts in tmpdir and can
+  // leak them on error paths; sweep stale ones so they don't fill node disk and
+  // trip DiskPressure evictions. Runs on all replicas (not leader-gated).
+  startTmpReaper();
 }
 
 // Singleton background WORKERS — must run on EXACTLY ONE replica at a time
@@ -862,6 +867,7 @@ async function shutdown(signal: string) {
   stopModelPricing();
   stopTunnelService();
   stopAccessControlCache();
+  stopTmpReaper();
   // Flush observability data before exit
   await Promise.allSettled([appLogger.flush(), flushSentry()]);
   process.exit(0);

--- a/apps/api/src/snapshots/tmp-reaper.ts
+++ b/apps/api/src/snapshots/tmp-reaper.ts
@@ -1,0 +1,67 @@
+// Reaper for stale snapshot/build temp dirs.
+//
+// build-context.ts, warm-bake.ts, and the various CLI/e2e helpers all stage work
+// into mkdtemp(tmpdir(), 'kortix-…-') dirs and hand cleanup back to the caller.
+// Any error path or missed cleanup() leaks a dir full of staged binaries/tarballs
+// into the container's writable layer — which is node ephemeral storage. Over
+// many session-boot/bake builds these accumulate to GBs (observed ~20GB/pod),
+// fill the node disk, and trip kubelet DiskPressure → pods get evicted cluster-
+// wide. quota-gc.ts only reaps Daytona-side warm snapshots, not these local dirs.
+//
+// This sweep runs on EVERY replica (build contexts are created on any pod during
+// on-demand session boot, not just the leader) and removes kortix-* temp dirs
+// whose mtime is older than MAX_AGE — long past the seconds-to-minutes a context
+// is actually needed, so in-flight builds are never touched.
+
+import { readdir, stat, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { logger } from '../lib/logger';
+
+const PREFIX = 'kortix-';
+const MAX_AGE_MS = 30 * 60 * 1000; // older than this ⇒ abandoned
+const SWEEP_INTERVAL_MS = 10 * 60 * 1000;
+
+let timer: ReturnType<typeof setInterval> | null = null;
+
+async function sweepOnce(): Promise<void> {
+  const dir = tmpdir();
+  let entries: string[];
+  try {
+    entries = await readdir(dir);
+  } catch {
+    return;
+  }
+  const now = Date.now();
+  let reclaimed = 0;
+  for (const name of entries) {
+    if (!name.startsWith(PREFIX)) continue;
+    const path = join(dir, name);
+    try {
+      const s = await stat(path);
+      if (now - s.mtimeMs < MAX_AGE_MS) continue; // leave in-flight contexts alone
+      await rm(path, { recursive: true, force: true });
+      reclaimed++;
+    } catch {
+      // racing build, already gone, or perms — skip, retry next sweep
+    }
+  }
+  if (reclaimed > 0) {
+    logger.info('[tmp-reaper] reclaimed stale build contexts', { count: reclaimed });
+  }
+}
+
+export function startTmpReaper(): void {
+  if (timer) return;
+  void sweepOnce();
+  timer = setInterval(() => void sweepOnce(), SWEEP_INTERVAL_MS);
+  // Don't keep the process alive for the reaper.
+  if (typeof timer.unref === 'function') timer.unref();
+}
+
+export function stopTmpReaper(): void {
+  if (timer) {
+    clearInterval(timer);
+    timer = null;
+  }
+}

--- a/infra/k8s/charts/kortix-api/values.yaml
+++ b/infra/k8s/charts/kortix-api/values.yaml
@@ -29,9 +29,17 @@ resources:
   requests:
     cpu: "500m"
     memory: "1Gi"
+    # Reserve disk so the scheduler spreads pods instead of stacking heavy
+    # snapshot-context writers onto one node.
+    ephemeral-storage: "2Gi"
   limits:
     cpu: "1"
     memory: "1Gi"
+    # Cap per-pod ephemeral use: a runaway build-context leak evicts THAT pod
+    # individually, instead of filling the node and tripping DiskPressure that
+    # evicts healthy neighbours cluster-wide. The tmp-reaper keeps steady-state
+    # well under this; the limit is the backstop.
+    ephemeral-storage: "8Gi"
 
 # Disruption budget: never let voluntary disruptions (node drain, roll) drop us
 # below half the replicas.


### PR DESCRIPTION
## Symptom
prod-eks showing **600+ evicted pods** (Argo "Degraded"). Not a cost issue — 5 nodes / 12 running pods unchanged; the evicted objects are `$0` corpses. But they signal a real problem.

## Root cause
Every eviction reason: `The node had condition: [DiskPressure]`. Node disk (50 GB) fills because **kortix-api pods write GBs into their own container filesystem**:
```
pod …-6hw7m: 19.9 GB rootfs-rw   pod …-zltlx: 12.1 GB   pod …-cdkxj: 4.9 GB
```
`build-context.ts` and `warm-bake.ts` (+ 9 other helpers) `mkdtemp(tmpdir(), 'kortix-…-')` to stage build contexts and **return the dir for the caller to clean up**. Any error path / missed `cleanup()` leaks a dir full of staged binaries into `/tmp` (the container writable layer = node ephemeral storage). `quota-gc.ts` only reaps Daytona-side snapshots, not these — so they grow unbounded → DiskPressure → kubelet evicts pods cluster-wide.

## Fix (robust, zero cost)
1. **`tmp-reaper.ts`** — runs on **every replica** (contexts are staged on any pod during on-demand session boot, not just the leader), sweeping `kortix-*` tmp dirs older than 30 min every 10 min. Stops the leak at the source. In-flight builds (seconds–minutes) are never touched.
2. **chart `ephemeral-storage` requests(2Gi)/limits(8Gi)** — defense in depth: a runaway pod is evicted *individually* at its own limit instead of filling the node and DiskPressure-evicting healthy neighbours; the request makes the scheduler spread writers across nodes.

No instance/disk-size change → **bill unchanged**.

## Immediate cleanup (run once)
```bash
kubectl --context kortix-prod-eks -n kortix-prod delete pods --field-selector status.phase=Failed
```