### PR TITLE
chore: downscale dev + preview for low traffic (≤100 users)

### DIFF
--- a/infra/k8s/envs/dev/values.yaml
+++ b/infra/k8s/envs/dev/values.yaml
@@ -16,12 +16,21 @@ env:
 # data plane). At cutover, flip this to true here AND disable the ECS dev service.
 workers:
   enabled: false
-# Dev sizing (smaller than prod's 3-replica / 3→12 HPA).
-replicas: 2
+# Dev sizing (≤100 users): 1 replica floor, burst to 2. Far below prod's 3→12.
+replicas: 1
 autoscaling:
   enabled: true
-  minReplicas: 2
-  maxReplicas: 4
+  minReplicas: 1
+  maxReplicas: 2
+# Smaller pod envelope than prod (500m/1Gi) — light dev load packs onto fewer
+# nodes. ephemeral-storage (2Gi/8Gi) is inherited from the chart base.
+resources:
+  requests:
+    cpu: "250m"
+    memory: "512Mi"
+  limits:
+    cpu: "1"
+    memory: "512Mi"
 serviceAccount:
   name: kortix-api
   # IRSA role from the dev-eks cluster layer (module.app_irsa, name

--- a/infra/k8s/envs/preview/values.yaml
+++ b/infra/k8s/envs/preview/values.yaml
@@ -31,13 +31,15 @@ pdb:
   enabled: false
 topologySpread:
   enabled: false
+# Tiny, throwaway env: pack many previews per node. ephemeral-storage (2Gi/8Gi)
+# is inherited from the chart base.
 resources:
   requests:
-    cpu: "250m"
-    memory: "512Mi"
+    cpu: "100m"
+    memory: "256Mi"
   limits:
-    cpu: "1"
-    memory: "1Gi"
+    cpu: "500m"
+    memory: "512Mi"
 
 serviceAccount:
   name: kortix-api

--- a/infra/terraform/environments/dev-eks/cluster/variables.tf
+++ b/infra/terraform/environments/dev-eks/cluster/variables.tf
@@ -32,17 +32,17 @@ variable "node_instance_types" {
 variable "node_desired_size" {
   description = "Initial node count."
   type        = number
-  default     = 2
+  default     = 1
 }
 
 variable "node_min_size" {
-  description = "Node autoscaling floor."
+  description = "Node autoscaling floor. 1 for dev (≤100 users) — the cluster-autoscaler bursts up for preview envs and scales back to a single node when idle."
   type        = number
-  default     = 2
+  default     = 1
 }
 
 variable "node_max_size" {
-  description = "Node autoscaling ceiling."
+  description = "Node autoscaling ceiling (headroom for concurrent preview envs)."
   type        = number
   default     = 4
 }


### PR DESCRIPTION
dev/preview were provisioned like prod. Right-sized for ≤100 users — **prod untouched**.

| | before | after |
|---|---|---|
| **dev** replicas | 2 (HPA 2–4) | 1 (HPA 1–2) |
| **dev** requests | 500m / 1Gi | 250m / 512Mi |
| **preview** requests | 250m / 512Mi | 100m / 256Mi |
| **preview** limits | 1 / 1Gi | 500m / 512Mi |
| **dev-eks nodes** | min 2 / desired 2 | **min 1 / desired 1** (max 4) |

The node-group floor is the real saver: dev-eks idles at **1 node** (~**−$70/mo**), and the cluster-autoscaler still bursts to 2–4 when preview envs spin up. Instance type unchanged (m6i.large) for headroom; `ephemeral-storage` caps inherited from the chart base (deep-merge verified via `helm template`).

### Apply
- **k8s values** (dev + preview): deploy via Argo on merge — dev re-syncs, previews pick it up on next PR.
- **node group floor**: needs Terraform —
  ```bash
  terraform -chdir=infra/terraform/environments/dev-eks/cluster apply
  ```
  (drops desired 2→1; the autoscaler removes the extra node once pods reschedule.)

Note: dev/preview memory limit is 512Mi (app idles ~205MB). If dev ever OOMs under real test load, bump to 768Mi.