### PR TITLE
fix(dev-eks): aggressive autoscaler scale-down so dev idles at 1 node

### DIFF
--- a/infra/terraform/environments/dev-eks/platform/main.tf
+++ b/infra/terraform/environments/dev-eks/platform/main.tf
@@ -96,6 +96,10 @@ module "platform" {
   cloudflare_api_token = var.cloudflare_api_token
   cloudflare_zone_id   = var.cloudflare_zone_id
 
+  # Low-traffic dev: let the autoscaler consolidate to a single node when idle
+  # (it otherwise never drains — every node has a local-storage/system pod).
+  autoscaler_aggressive_scaledown = true
+
   # Argo CD UI (dev-ops.kortix.com) — OFF by default for dev (headless).
   argocd_ui_enabled      = var.argocd_ui_enabled
   argocd_domain          = local.cluster.argocd_domain

--- a/infra/terraform/modules/eks/platform/main.tf
+++ b/infra/terraform/modules/eks/platform/main.tf
@@ -209,6 +209,19 @@ resource "helm_release" "cluster_autoscaler" {
     name  = "extraArgs.expander"
     value = "least-waste"
   }
+  # Aggressive scale-down (dev): also reclaim nodes whose only blockers are pods
+  # with local storage (emptyDir caches: argo-cd/argo-rollouts/metrics-server) or
+  # kube-system pods without a PDB (external-dns). Without this the autoscaler
+  # NEVER drains a node — every node has such a pod — so a low-traffic cluster is
+  # pinned at its initial size. Conservative (true) by default; prod keeps it.
+  set {
+    name  = "extraArgs.skip-nodes-with-local-storage"
+    value = var.autoscaler_aggressive_scaledown ? "false" : "true"
+  }
+  set {
+    name  = "extraArgs.skip-nodes-with-system-pods"
+    value = var.autoscaler_aggressive_scaledown ? "false" : "true"
+  }
 }
 
 # ── Argo CD values (built up: HA + optional UI ingress + optional GitHub SSO) ──

--- a/infra/terraform/modules/eks/platform/variables.tf
+++ b/infra/terraform/modules/eks/platform/variables.tf
@@ -34,6 +34,12 @@ variable "extra_domain_filters" {
   default     = []
 }
 
+variable "autoscaler_aggressive_scaledown" {
+  description = "Let the cluster-autoscaler reclaim nodes blocked only by local-storage pods (emptyDir caches) or PDB-less kube-system pods. true for low-traffic dev so it can consolidate to a single node; false (conservative) for prod."
+  type        = bool
+  default     = false
+}
+
 variable "cloudflare_zone_id" {
   description = "Cloudflare hosted zone ID for kortix.com. Pins external-dns zone discovery by ID so subdomain domainFilters (api-eks / preview-api) don't cause it to discard the zone and manage nothing. Empty = unset (no zone-id filter)."
   type        = string


### PR DESCRIPTION
Follow-up to #3451. The node-group floor (`min 1`) didn't shrink dev-eks — it's stuck at 2 nodes because the cluster-autoscaler **never drains a node**:

```
node 138: cannot be removed: pod with local storage present: argo-cd-application-controller-0 / argo-rollouts / metrics-server
node 150: cannot be removed: non-pdb-assigned kube-system pod present: external-dns
```

Both are autoscaler **safety defaults** (`--skip-nodes-with-local-storage=true`, `--skip-nodes-with-system-pods=true`). Every node has an emptyDir pod or a PDB-less kube-system pod, so *every* node is "unremovable" → a low-traffic cluster is pinned at its initial size forever.

All requests fit one m6i.large (**1700m < 1900m** CPU), so for dev we flip both off via a new `autoscaler_aggressive_scaledown` var (default **false** — prod unchanged). The autoscaler can then evict those (emptyDir = recreatable caches; the controllers have a 2nd replica) and consolidate to **1 node**.

### Apply
```bash
terraform -chdir=infra/terraform/environments/dev-eks/platform apply
```
The autoscaler rolls with the new flags and drains the 2nd node within ~10–15 min → **~$70/mo** saved (the saving #3451's floor was meant to unlock).

Note: dev-eks also runs its **own** argo-cd + argo-rollouts even though the prod hub manages it — likely redundant and a further saving if removed; left for a separate change.