### PR TITLE
fix(dev): disable PDB on 1-replica dev (unblocks node consolidation)

### DIFF
--- a/infra/k8s/envs/dev/values.yaml
+++ b/infra/k8s/envs/dev/values.yaml
@@ -22,6 +22,11 @@ autoscaling:
   enabled: true
   minReplicas: 1
   maxReplicas: 2
+# No PDB on a 1-replica dev: minAvailable 50% rounds to 1 → 0 allowed disruptions,
+# which blocks node drain (cluster-autoscaler can't consolidate, upgrades stall).
+# A 1-replica deploy has no HA to protect anyway; brief restart on drain is fine.
+pdb:
+  enabled: false
 # Smaller pod envelope than prod (500m/1Gi) — light dev load packs onto fewer
 # nodes. ephemeral-storage (2Gi/8Gi) is inherited from the chart base.
 resources:


### PR DESCRIPTION
Last blocker for dev-eks → 1 node. After #3452's aggressive-scaledown flags, the only PDB with **0 allowed disruptions** is `kortix-dev/kortix-api`: the chart default `minAvailable: 50%` rounds to 1 at a single replica, so the autoscaler can't evict the sole dev pod to drain its node.

A PDB on a 1-replica deploy protects nothing (no HA). Disable it for dev → autoscaler drains the 2nd node → **1 node**. Merge → Argo removes the PDB (no terraform needed). prod/preview unaffected.

helm render confirms 0 PDB objects for dev.