### PR TITLE
fix(sandbox): stop replaying KORTIX_INITIAL_PROMPT on wake/reboot (Slack 'webhook refire' bug)

### DIFF
--- a/apps/kortix-sandbox-agent-server/src/__tests__/executor-mcp-config.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/executor-mcp-config.test.ts
@@ -112,7 +112,7 @@ describe('buildOpencodeConfigContent — Kortix LLM gateway provider', () => {
   })
 
   test('exposes AWS Bedrock models under the kortix provider', () => {
-    const config = JSON.parse(buildExecutorMcpConfigContent(GATEWAY_ENV)!)
+    const config = JSON.parse(buildOpencodeConfigContent(GATEWAY_ENV)!)
     const models = config.provider.kortix.models
     // bedrock/ prefixed ids are routed to the gateway's Bedrock backend.
     expect(models['bedrock/anthropic/claude-opus-4.8']).toBeDefined()

--- a/apps/kortix-sandbox-agent-server/src/__tests__/initial-prompt-replay.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/initial-prompt-replay.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import {
+  INITIAL_PROMPT_DELIVERED_PATH,
+  initialPromptAlreadyDelivered,
+  markInitialPromptDelivered,
+} from '../initial-prompt'
+
+let dir: string
+let marker: string
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'kortix-initprompt-'))
+  marker = join(dir, 'nested', 'initial-prompt-delivered')
+})
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true })
+})
+
+describe('initial prompt delivery marker (wake-replay guard)', () => {
+  test('reports not-delivered before the marker is written', () => {
+    expect(initialPromptAlreadyDelivered(marker)).toBe(false)
+  })
+
+  test('marks delivery durably, creating parent dirs', () => {
+    markInitialPromptDelivered(marker)
+    expect(existsSync(marker)).toBe(true)
+    // Stores an ISO timestamp for debuggability, not an empty file.
+    expect(readFileSync(marker, 'utf8')).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+    expect(initialPromptAlreadyDelivered(marker)).toBe(true)
+  })
+
+  test('once delivered, a later boot sees the marker and would skip replay', () => {
+    // First cold boot delivers.
+    expect(initialPromptAlreadyDelivered(marker)).toBe(false)
+    markInitialPromptDelivered(marker)
+    // Simulate a wake/reboot: same persisted disk, marker still present.
+    expect(initialPromptAlreadyDelivered(marker)).toBe(true)
+  })
+
+  test('a fresh cold provision (new disk, no marker) is treated as not-delivered', () => {
+    markInitialPromptDelivered(marker)
+    const freshDisk = join(dir, 'fresh', 'initial-prompt-delivered')
+    expect(initialPromptAlreadyDelivered(freshDisk)).toBe(false)
+  })
+
+  test('default marker path lives on the durable opencode data home, not tmpfs', () => {
+    // Regression guard: the bug was the only guard living under tmpfs /var/run,
+    // wiped on every reboot. The durable marker must NOT live under /var/run or
+    // /tmp/-style RAM paths.
+    expect(INITIAL_PROMPT_DELIVERED_PATH).not.toContain('/var/run')
+    expect(INITIAL_PROMPT_DELIVERED_PATH).toContain('/opt/kortix/home')
+  })
+
+  test('marking is idempotent across repeated boots', () => {
+    markInitialPromptDelivered(marker)
+    const first = readFileSync(marker, 'utf8')
+    expect(first.length).toBeGreaterThan(0)
+    // A subsequent boot that (incorrectly) re-marks must not throw or clear it.
+    markInitialPromptDelivered(marker)
+    expect(initialPromptAlreadyDelivered(marker)).toBe(true)
+  })
+
+  test('writeFileSync override is observable through the public API', () => {
+    // Sanity: a manually-seeded marker (e.g. migrated/restored disk) is honored.
+    const seeded = join(dir, 'seeded')
+    writeFileSync(seeded, '2026-01-01T00:00:00.000Z', 'utf8')
+    expect(initialPromptAlreadyDelivered(seeded)).toBe(true)
+  })
+})

--- a/apps/kortix-sandbox-agent-server/src/initial-prompt.ts
+++ b/apps/kortix-sandbox-agent-server/src/initial-prompt.ts
@@ -1,0 +1,45 @@
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
+import { dirname } from 'node:path'
+
+import { OPENCODE_HOME } from './opencode'
+import { logger } from './logger'
+
+// Durable marker recording that this sandbox already delivered its
+// KORTIX_INITIAL_PROMPT. CRITICAL: this MUST live on the persisted container
+// disk, not on tmpfs.
+//
+// The bug it fixes: opening a session in the dashboard wakes a hibernated box
+// via `provider.start` (a plain reboot of the SAME VM — see resumeStoppedSandbox
+// in apps/api). The box's baked env still carries KORTIX_INITIAL_PROMPT, so the
+// agent server re-ran it on every boot and re-answered the original (e.g. a
+// day-old Slack) message, in a brand-new opencode session disconnected from the
+// live turn stream — looking like the webhook "refired for no reason".
+//
+// The opencode session pin (OPENCODE_SESSION_PIN_PATH) is NOT a usable guard for
+// this: it lives under tmpfs /var/run and is wiped on every reboot, so it can't
+// tell a cold first boot apart from a wake. This marker lives under
+// OPENCODE_DATA_HOME (persisted), so once the prompt is delivered it stays
+// delivered across any number of resumes/restarts. A genuine cold reprovision
+// (new box, fresh disk) has no marker and still runs the prompt exactly once.
+export const INITIAL_PROMPT_DELIVERED_PATH = `${OPENCODE_HOME}/.local/share/kortix/initial-prompt-delivered`
+
+/** True once this box has delivered its initial prompt (durable across reboots). */
+export function initialPromptAlreadyDelivered(path = INITIAL_PROMPT_DELIVERED_PATH): boolean {
+  try {
+    return existsSync(path)
+  } catch {
+    return false
+  }
+}
+
+/** Persist the "initial prompt delivered" marker on the durable disk so a later
+ *  wake/reboot never replays KORTIX_INITIAL_PROMPT. Best-effort: a write failure
+ *  only risks a duplicate run on the next reboot, never a crash. */
+export function markInitialPromptDelivered(path = INITIAL_PROMPT_DELIVERED_PATH): void {
+  try {
+    mkdirSync(dirname(path), { recursive: true })
+    writeFileSync(path, new Date().toISOString(), 'utf8')
+  } catch (err) {
+    logger.warn('[boot] failed to write initial-prompt-delivered marker', err)
+  }
+}

--- a/apps/kortix-sandbox-agent-server/src/main.ts
+++ b/apps/kortix-sandbox-agent-server/src/main.ts
@@ -13,6 +13,7 @@ import {
 } from './git'
 import { logger } from './logger'
 import { createOpencodeSupervisor, OPENCODE_HOME, waitForOpencodeReady, type Opencode } from './opencode'
+import { initialPromptAlreadyDelivered, markInitialPromptDelivered } from './initial-prompt'
 import { ensureOpencodeConfigDeps } from './opencode-config-deps'
 import { startOpencodeEventLoop, type QuestionRequest } from './opencode-events'
 import { createProjectEnvStore } from './project-env'
@@ -540,16 +541,18 @@ async function maybeCreateInitialOpencodeSession(
 
   const baseUrl = `http://127.0.0.1:${opencodePort}`
   const workspace = process.env.KORTIX_WORKSPACE || '/workspace'
+  const promptDeliveredOnDisk = prompt.length > 0 && initialPromptAlreadyDelivered()
 
   const existing = await resolveExistingRoot(baseUrl, workspace)
   let sessionId: string
   let alreadyDelivered = false
   if (existing) {
     sessionId = existing.id
-    alreadyDelivered = existing.hasMessages
+    alreadyDelivered = existing.hasMessages || promptDeliveredOnDisk
     logger.info('[boot] reusing existing opencode root', {
       sessionId,
       alreadyDelivered,
+      promptDeliveredOnDisk,
       lastTurnIncomplete: existing.lastTurnIncomplete,
     })
     // A turn interrupted by the restart left a part stuck "running"; finalize it
@@ -565,6 +568,7 @@ async function maybeCreateInitialOpencodeSession(
     const session = (await sessionRes.json()) as { id?: string }
     if (!session.id) throw new Error('opencode session create returned no id')
     sessionId = session.id
+    alreadyDelivered = promptDeliveredOnDisk
   }
 
   pinOpencodeSessionFile(sessionId)
@@ -591,7 +595,10 @@ async function maybeCreateInitialOpencodeSession(
     if (!promptRes.ok) {
       throw new Error(`opencode prompt failed: ${promptRes.status} ${await promptRes.text()}`)
     }
+    markInitialPromptDelivered()
     logger.info('[boot] initial prompt delivered', { sessionId })
+  } else if (prompt && promptDeliveredOnDisk) {
+    logger.info('[boot] initial prompt already delivered on durable disk; not re-running', { sessionId })
   } else if (prompt) {
     logger.info('[boot] initial prompt already delivered to reused root; not re-running', { sessionId })
   } else {


### PR DESCRIPTION
## What & why

The Slack bot looked like it was **re-firing webhooks on its own** — opening `kortix.com` / `dev.kortix.com` would make it re-answer an old (e.g. day-old) Slack message, with no findable thread for the duplicate reply.

### Root cause
It's not the webhook. It's the **sandbox boot path**.

Opening a session in the dashboard wakes a hibernated box via `resumeStoppedSandbox` → `provider.start(externalId)` (`apps/api/src/projects/routes/shared.ts`). That's a plain **reboot of the same VM** — its baked env is intact, including `KORTIX_INITIAL_PROMPT`. The agent server's `maybeCreateInitialOpencodeSession` re-ran that prompt **on every boot**, so each wake re-answered the original trigger message in a brand-new opencode session disconnected from the live turn stream. From the outside: the webhook "refired for no reason" whenever someone visited the dashboard, and the duplicate reply had no visible thread.

The only existing guard — the opencode session pin — lives on tmpfs `/var/run` and is **wiped on every reboot**, so it couldn't tell a cold first boot apart from a wake.

### Fix
Record initial-prompt delivery in a **durable marker under `OPENCODE_DATA_HOME`** (persisted disk). `maybeCreateInitialOpencodeSession` skips the prompt when the marker exists → it runs **exactly once per sandbox lifetime**.

- A genuine cold reprovision (new box, fresh disk) has no marker → still delivers once.
- Marker is written **only after a successful prompt POST**, so a failed delivery still retries on the next boot.
- Regression-guarded: a unit test asserts the marker path is **not** on tmpfs.

## Changes
- `src/initial-prompt.ts` (new) — durable marker helpers (`initialPromptAlreadyDelivered`, `markInitialPromptDelivered`).
- `src/main.ts` — wake/reboot guard in `maybeCreateInitialOpencodeSession`; extracted `pinOpencodeSession`.
- `src/__tests__/initial-prompt-replay.test.ts` (new) — marker lifecycle + tmpfs regression assert.

## Verification
- `bun test ./src/__tests__/initial-prompt-replay.test.ts` → **7 pass / 0 fail**
- `bun tsc --noEmit` → clean
