### PR TITLE
feat(llm-gateway): reintroduce AWS Bedrock backend under the kortix provider

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -18,6 +18,7 @@
     "test:all": "bun run test"
   },
   "dependencies": {
+    "@aws-sdk/client-bedrock-runtime": "^3.700.0",
     "@daytonaio/sdk": "^0.184.0",
     "@hono/zod-openapi": "^0.19.10",
     "@kortix/db": "workspace:*",

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -167,6 +167,16 @@ const envSchema = z.object({
   // Managed LLM gateway (/v1/llm) — the `kortix` OpenCode provider routes every
   // sandbox model call here. Off by default; needs OPENROUTER_API_KEY when on.
   LLM_GATEWAY_ENABLED:         optBoolFalse,
+  // ── AWS Bedrock backend for the managed gateway ──────────────────────────
+  // When enabled, gateway models prefixed `bedrock/` (e.g.
+  // `kortix/bedrock/anthropic/claude-opus-4.8`) are served via Bedrock Converse
+  // instead of OpenRouter. Credentials fall back to the AWS default chain
+  // (EKS IRSA / instance role) when the explicit keys are unset.
+  BEDROCK_ENABLED:             optBoolFalse,
+  BEDROCK_REGION:              optStrDefault('us-west-2'),
+  AWS_ACCESS_KEY_ID:           optStr,
+  AWS_SECRET_ACCESS_KEY:       optStr,
+  AWS_SESSION_TOKEN:           optStr,
   ANTHROPIC_API_URL:           optUrl('https://api.anthropic.com/v1'),
   ANTHROPIC_API_KEY:           optStr,
   OPENAI_API_URL:              optUrl('https://api.openai.com/v1'),
@@ -381,6 +391,9 @@ function validateEnv(): z.infer<typeof envSchema> {
       issues.push({ var: 'LLM_GATEWAY_ENABLED', message: 'Gateway is on but OPENROUTER_API_KEY is unset — /v1/llm will 500 "openrouterApiKey missing"', level: 'warn' });
     }
   }
+  if (raw.BEDROCK_ENABLED === 'true' && !raw.AWS_ACCESS_KEY_ID && !raw.AWS_SECRET_ACCESS_KEY) {
+    issues.push({ var: 'BEDROCK_ENABLED', message: 'Bedrock backend is on with no static AWS creds — relying on the default credential chain (EKS IRSA / instance role). Ensure the pod/role can call bedrock:InvokeModel.', level: 'warn' });
+  }
 
   // ── Print results ─────────────────────────────────────────────────────
   const errors = issues.filter((i) => i.level === 'error');
@@ -508,6 +521,11 @@ export const config = {
   OPENROUTER_API_URL: env.OPENROUTER_API_URL,
   OPENROUTER_API_KEY: env.OPENROUTER_API_KEY,
   LLM_GATEWAY_ENABLED: env.LLM_GATEWAY_ENABLED,
+  BEDROCK_ENABLED: env.BEDROCK_ENABLED,
+  BEDROCK_REGION: env.BEDROCK_REGION,
+  AWS_ACCESS_KEY_ID: env.AWS_ACCESS_KEY_ID,
+  AWS_SECRET_ACCESS_KEY: env.AWS_SECRET_ACCESS_KEY,
+  AWS_SESSION_TOKEN: env.AWS_SESSION_TOKEN,
   ANTHROPIC_API_URL: env.ANTHROPIC_API_URL,
   ANTHROPIC_API_KEY: env.ANTHROPIC_API_KEY,
   OPENAI_API_URL: env.OPENAI_API_URL,

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -529,6 +529,13 @@ app.route('/v1/router', router);        // /v1/router/chat/completions, /v1/rout
         markup: llmPriceMarkup(),
         appName: 'Kortix',
         appReferer: config.KORTIX_URL,
+        bedrock: {
+          enabled: config.BEDROCK_ENABLED,
+          region: config.BEDROCK_REGION,
+          accessKeyId: config.AWS_ACCESS_KEY_ID,
+          secretAccessKey: config.AWS_SECRET_ACCESS_KEY,
+          sessionToken: config.AWS_SESSION_TOKEN,
+        },
       },
       {
         authenticateToken: async (token) => {

--- a/apps/api/src/llm-gateway/README.md
+++ b/apps/api/src/llm-gateway/README.md
@@ -1,8 +1,57 @@
 # llm-gateway
 
-OpenAI-compatible LLM proxy backed by OpenRouter. Self-contained,
-dependency-injected module — the host wires it up with three hooks (auth,
-billing gate, usage sink) and mounts it under any path.
+OpenAI-compatible LLM proxy backed by OpenRouter, with an optional **AWS
+Bedrock** backend. Self-contained, dependency-injected module — the host wires
+it up with three hooks (auth, billing gate, usage sink) and mounts it under any
+path.
+
+## Backends
+
+| Model id pattern | Backend |
+|---|---|
+| `bedrock/*` (e.g. `bedrock/anthropic/claude-opus-4.8`) | AWS Bedrock Converse — *only when `config.bedrock.enabled`* |
+| everything else | OpenRouter |
+
+Both backends run behind the same `/chat/completions` route, the same auth +
+billing gate, and the same usage-accounting pipeline (`recordUsage`). Usage
+events carry `provider: 'bedrock'` vs `provider: 'openrouter'` so spend is
+attributable per backend.
+
+### AWS Bedrock
+
+When `config.bedrock.enabled` is true, any request whose `model` starts with
+`bedrock/` is served via the Bedrock Runtime **Converse / ConverseStream** API
+instead of OpenRouter:
+
+- `services/bedrock-models.ts` — maps the logical id (e.g.
+  `bedrock/anthropic/claude-opus-4.8`) to a Bedrock inference-profile id
+  (`us.anthropic.claude-opus-4-5-...`) plus per-model fallback pricing.
+- `services/bedrock-translate.ts` — **pure** OpenAI↔Converse translation
+  (messages, system prompts, tools/tool-calls, images, reasoning/extended
+  thinking, streaming → OpenAI SSE chunks). No SDK imports, fully unit-tested.
+- `services/bedrock-client.ts` — thin `@aws-sdk/client-bedrock-runtime` wrapper
+  (lazy, memoized client; swappable senders for tests).
+- `services/bedrock-handler.ts` — orchestrates a completion, mirroring the
+  OpenRouter handler's streaming-disconnect handling so usage is still captured
+  if the client drops mid-stream.
+
+Credentials use the AWS default chain (env vars, EKS IRSA / instance role) when
+`accessKeyId`/`secretAccessKey` are omitted — the production path on our EKS
+nodes. The region defaults to `us-west-2`.
+
+Config (env, read in `apps/api/src/config.ts`, wired in `apps/api/src/index.ts`):
+
+```
+BEDROCK_ENABLED=true
+BEDROCK_REGION=us-west-2
+AWS_ACCESS_KEY_ID=...        # optional — default chain used when unset
+AWS_SECRET_ACCESS_KEY=...    # optional
+AWS_SESSION_TOKEN=...        # optional
+```
+
+The `bedrock/*` model ids are also declared in the sandbox `kortix` OpenCode
+provider (`apps/kortix-sandbox-agent-server/src/opencode.ts`) so they show up in
+the model selector.
 
 ## Routes
 

--- a/apps/api/src/llm-gateway/__tests__/bedrock-gateway.test.ts
+++ b/apps/api/src/llm-gateway/__tests__/bedrock-gateway.test.ts
@@ -1,0 +1,175 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { createLlmGateway } from '..';
+import type { LlmGatewayConfig, LlmGatewayHooks, UsageEvent } from '../types';
+import { __setSenders } from '../services/bedrock-client';
+import { resolveBedrockModel, isBedrockModel, BEDROCK_MODELS } from '../services/bedrock-models';
+import { calculateCost } from '../services/pricing';
+
+function makeHooks(): { hooks: LlmGatewayHooks; recorded: UsageEvent[] } {
+  const recorded: UsageEvent[] = [];
+  const hooks: LlmGatewayHooks = {
+    authenticateToken: async (token) =>
+      token === 'good' ? { userId: 'u1', accountId: 'a1' } : null,
+    assertBillingActive: async () => {},
+    recordUsage: async (e) => {
+      recorded.push(e);
+    },
+  };
+  return { hooks, recorded };
+}
+
+const bedrockConfig: LlmGatewayConfig = {
+  enabled: true,
+  openrouterApiKey: 'sk-or-test',
+  baseUrl: 'https://test.openrouter.example/v1',
+  markup: 1.5,
+  bedrock: { enabled: true, region: 'us-west-2' },
+};
+
+function req(body: unknown): Request {
+  return new Request('http://local.test/chat/completions', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', Authorization: 'Bearer good' },
+    body: JSON.stringify(body),
+  });
+}
+
+let restore = () => {};
+afterEach(() => restore());
+
+describe('bedrock model registry', () => {
+  test('isBedrockModel keys off the bedrock/ prefix', () => {
+    expect(isBedrockModel('bedrock/anthropic/claude-opus-4.8')).toBe(true);
+    expect(isBedrockModel('anthropic/claude-opus-4.8')).toBe(false);
+  });
+
+  test('resolveBedrockModel returns the inference profile id', () => {
+    const entry = resolveBedrockModel('bedrock/anthropic/claude-opus-4.8');
+    expect(entry?.bedrockId).toContain('anthropic.claude-opus');
+    expect(resolveBedrockModel('bedrock/nope/nope')).toBeNull();
+    expect(resolveBedrockModel('anthropic/claude-opus-4.8')).toBeNull();
+  });
+
+  test('pricing uses the bedrock registry entry', () => {
+    const m = 'bedrock/anthropic/claude-sonnet-4.6';
+    const entry = BEDROCK_MODELS['anthropic/claude-sonnet-4.6'];
+    const { upstreamCost, finalCost } = calculateCost(
+      m,
+      { promptTokens: 1_000_000, completionTokens: 0, cachedTokens: 0 },
+      1.5,
+    );
+    expect(upstreamCost).toBeCloseTo(entry.inputPerMillion, 6);
+    expect(finalCost).toBeCloseTo(entry.inputPerMillion * 1.5, 6);
+  });
+});
+
+describe('gateway — bedrock routing (non-streaming)', () => {
+  test('routes a bedrock/ model to Bedrock and records usage with provider=bedrock', async () => {
+    let sentReq: any = null;
+    restore = __setSenders({
+      converse: async (_cfg, r) => {
+        sentReq = r;
+        return {
+          output: { message: { role: 'assistant', content: [{ text: 'hi from bedrock' }] } },
+          stopReason: 'end_turn',
+          usage: { inputTokens: 20, outputTokens: 10, cacheReadInputTokens: 4 },
+        };
+      },
+    });
+
+    const { hooks, recorded } = makeHooks();
+    const app = createLlmGateway(bedrockConfig, hooks);
+    const res = await app.fetch(
+      req({
+        model: 'bedrock/anthropic/claude-opus-4.8',
+        messages: [{ role: 'user', content: 'hi' }],
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as any;
+    expect(json.object).toBe('chat.completion');
+    expect(json.choices[0].message.content).toBe('hi from bedrock');
+
+    // It hit Bedrock with the resolved inference-profile id, not OpenRouter.
+    expect(sentReq.modelId).toContain('anthropic.claude-opus');
+
+    await new Promise((r) => setTimeout(r, 5));
+    expect(recorded).toHaveLength(1);
+    expect(recorded[0].provider).toBe('bedrock');
+    expect(recorded[0].promptTokens).toBe(20);
+    expect(recorded[0].completionTokens).toBe(10);
+    expect(recorded[0].cachedTokens).toBe(4);
+    expect(recorded[0].model).toBe('bedrock/anthropic/claude-opus-4.8');
+  });
+
+  test('does NOT route to bedrock when bedrock.enabled is false', async () => {
+    const originalFetch = globalThis.fetch;
+    let fetchUrl = '';
+    globalThis.fetch = (async (url: any) => {
+      fetchUrl = String(url);
+      return new Response(JSON.stringify({ model: 'm', usage: {} }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as typeof fetch;
+    restore = () => {
+      globalThis.fetch = originalFetch;
+    };
+
+    const { hooks } = makeHooks();
+    const app = createLlmGateway({ ...bedrockConfig, bedrock: { enabled: false, region: 'us-west-2' } }, hooks);
+    const res = await app.fetch(
+      req({ model: 'bedrock/anthropic/claude-opus-4.8', messages: [{ role: 'user', content: 'hi' }] }),
+    );
+    expect(res.status).toBe(200);
+    // fell through to OpenRouter
+    expect(fetchUrl).toContain('openrouter');
+  });
+
+  test('400 on unknown bedrock model id', async () => {
+    restore = __setSenders({ converse: async () => ({}) });
+    const { hooks } = makeHooks();
+    const app = createLlmGateway(bedrockConfig, hooks);
+    const res = await app.fetch(
+      req({ model: 'bedrock/made/up', messages: [{ role: 'user', content: 'hi' }] }),
+    );
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('gateway — bedrock routing (streaming)', () => {
+  test('streams OpenAI SSE chunks and records usage at the end', async () => {
+    async function* fakeStream() {
+      yield { contentBlockDelta: { contentBlockIndex: 0, delta: { text: 'Hello' } } };
+      yield { messageStop: { stopReason: 'end_turn' } };
+      yield { metadata: { usage: { inputTokens: 3, outputTokens: 2, cacheReadInputTokens: 0 } } };
+    }
+    restore = __setSenders({
+      converseStream: async () => ({ stream: fakeStream() }),
+    });
+
+    const { hooks, recorded } = makeHooks();
+    const app = createLlmGateway(bedrockConfig, hooks);
+    const res = await app.fetch(
+      req({
+        model: 'bedrock/anthropic/claude-sonnet-4.6',
+        messages: [{ role: 'user', content: 'hi' }],
+        stream: true,
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('text/event-stream');
+    const text = await res.text();
+    expect(text).toContain('"content":"Hello"');
+    expect(text).toContain('"finish_reason":"stop"');
+    expect(text.trim().endsWith('[DONE]')).toBe(true);
+
+    await new Promise((r) => setTimeout(r, 10));
+    expect(recorded).toHaveLength(1);
+    expect(recorded[0].provider).toBe('bedrock');
+    expect(recorded[0].streaming).toBe(true);
+    expect(recorded[0].promptTokens).toBe(3);
+    expect(recorded[0].completionTokens).toBe(2);
+  });
+});

--- a/apps/api/src/llm-gateway/__tests__/bedrock-translate.test.ts
+++ b/apps/api/src/llm-gateway/__tests__/bedrock-translate.test.ts
@@ -1,0 +1,277 @@
+import { describe, test, expect } from 'bun:test';
+import {
+  openaiToConverse,
+  converseToOpenai,
+  mapStopReason,
+  usageFromConverse,
+  makeStreamTranslator,
+} from '../services/bedrock-translate';
+
+describe('openaiToConverse — messages', () => {
+  test('splits system messages into the system field', () => {
+    const req = openaiToConverse(
+      {
+        model: 'x',
+        messages: [
+          { role: 'system', content: 'be terse' },
+          { role: 'user', content: 'hi' },
+        ],
+      },
+      'us.anthropic.claude-opus-4-5-20251101-v1:0',
+    );
+    expect(req.system).toEqual([{ text: 'be terse' }]);
+    expect(req.messages).toEqual([{ role: 'user', content: [{ text: 'hi' }] }]);
+  });
+
+  test('merges consecutive same-role turns (tool result + user)', () => {
+    const req = openaiToConverse(
+      {
+        model: 'x',
+        messages: [
+          { role: 'user', content: 'q' },
+          {
+            role: 'assistant',
+            content: null,
+            tool_calls: [
+              { id: 't1', type: 'function', function: { name: 'getWeather', arguments: '{"city":"NYC"}' } },
+            ],
+          },
+          { role: 'tool', tool_call_id: 't1', content: 'sunny' },
+        ],
+      },
+      'model',
+    );
+    // user → assistant(toolUse) → user(toolResult)
+    expect(req.messages).toHaveLength(3);
+    expect(req.messages.map((m) => m.role)).toEqual(['user', 'assistant', 'user']);
+    expect((req.messages[1].content[0] as any).toolUse).toMatchObject({
+      toolUseId: 't1',
+      name: 'getWeather',
+      input: { city: 'NYC' },
+    });
+    expect((req.messages[2].content[0] as any).toolResult).toMatchObject({ toolUseId: 't1' });
+  });
+
+  test('merges a tool result followed by a user message into one user turn', () => {
+    const req = openaiToConverse(
+      {
+        model: 'x',
+        messages: [
+          { role: 'tool', tool_call_id: 't1', content: 'sunny' },
+          { role: 'user', content: 'thanks' },
+        ],
+      },
+      'model',
+    );
+    expect(req.messages).toHaveLength(1);
+    expect(req.messages[0].role).toBe('user');
+    expect(req.messages[0].content).toHaveLength(2);
+  });
+
+  test('maps tool result back into a user turn', () => {
+    const req = openaiToConverse(
+      {
+        model: 'x',
+        messages: [{ role: 'tool', tool_call_id: 'abc', content: 'result text' }],
+      },
+      'model',
+    );
+    expect(req.messages[0].role).toBe('user');
+    expect((req.messages[0].content[0] as any).toolResult).toMatchObject({
+      toolUseId: 'abc',
+      content: [{ text: 'result text' }],
+    });
+  });
+
+  test('decodes base64 data-url images into image blocks', () => {
+    // "hi" base64 = aGk=
+    const dataUrl = 'data:image/png;base64,aGk=';
+    const req = openaiToConverse(
+      {
+        model: 'x',
+        messages: [
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'what is this' },
+              { type: 'image_url', image_url: { url: dataUrl } },
+            ],
+          },
+        ],
+      },
+      'model',
+    );
+    const blocks = req.messages[0].content;
+    expect((blocks[0] as any).text).toBe('what is this');
+    expect((blocks[1] as any).image.format).toBe('png');
+    expect((blocks[1] as any).image.source.bytes).toBeInstanceOf(Uint8Array);
+  });
+});
+
+describe('openaiToConverse — inference config & tools', () => {
+  test('maps max_tokens / temperature / top_p / stop', () => {
+    const req = openaiToConverse(
+      { model: 'x', messages: [], max_tokens: 100, temperature: 0.5, top_p: 0.9, stop: ['END'] },
+      'model',
+    );
+    expect(req.inferenceConfig).toEqual({
+      maxTokens: 100,
+      temperature: 0.5,
+      topP: 0.9,
+      stopSequences: ['END'],
+    });
+  });
+
+  test('translates tools and required tool_choice', () => {
+    const req = openaiToConverse(
+      {
+        model: 'x',
+        messages: [],
+        tools: [
+          {
+            type: 'function',
+            function: { name: 'lookup', description: 'find', parameters: { type: 'object' } },
+          },
+        ],
+        tool_choice: 'required',
+      },
+      'model',
+    );
+    expect(req.toolConfig?.tools[0].toolSpec.name).toBe('lookup');
+    expect(req.toolConfig?.toolChoice).toEqual({ any: {} });
+  });
+
+  test('reasoning budget forces temperature=1 and adds thinking field', () => {
+    const req = openaiToConverse(
+      { model: 'x', messages: [], temperature: 0.2 },
+      'model',
+      4096,
+    );
+    expect(req.inferenceConfig?.temperature).toBe(1);
+    expect(req.inferenceConfig?.topP).toBeUndefined();
+    expect(req.additionalModelRequestFields?.thinking).toEqual({
+      type: 'enabled',
+      budget_tokens: 4096,
+    });
+  });
+});
+
+describe('converseToOpenai', () => {
+  test('builds an OpenAI completion with text + usage', () => {
+    const out = converseToOpenai(
+      {
+        output: { message: { role: 'assistant', content: [{ text: 'hello world' }] } },
+        stopReason: 'end_turn',
+        usage: { inputTokens: 12, outputTokens: 7, cacheReadInputTokens: 3 },
+      },
+      'bedrock/anthropic/claude-opus-4.8',
+      'req123',
+    );
+    expect(out.object).toBe('chat.completion');
+    const choice = (out.choices as any[])[0];
+    expect(choice.message.content).toBe('hello world');
+    expect(choice.finish_reason).toBe('stop');
+    expect((out.usage as any).prompt_tokens).toBe(12);
+    expect((out.usage as any).completion_tokens).toBe(7);
+    expect((out.usage as any).prompt_tokens_details.cached_tokens).toBe(3);
+  });
+
+  test('surfaces tool calls', () => {
+    const out = converseToOpenai(
+      {
+        output: {
+          message: {
+            role: 'assistant',
+            content: [{ toolUse: { toolUseId: 'tu1', name: 'search', input: { q: 'x' } } }],
+          },
+        },
+        stopReason: 'tool_use',
+      },
+      'm',
+      'r',
+    );
+    const choice = (out.choices as any[])[0];
+    expect(choice.finish_reason).toBe('tool_calls');
+    expect(choice.message.tool_calls[0]).toMatchObject({
+      id: 'tu1',
+      type: 'function',
+      function: { name: 'search', arguments: '{"q":"x"}' },
+    });
+  });
+});
+
+describe('mapStopReason / usageFromConverse', () => {
+  test('maps known stop reasons', () => {
+    expect(mapStopReason('end_turn')).toBe('stop');
+    expect(mapStopReason('max_tokens')).toBe('length');
+    expect(mapStopReason('tool_use')).toBe('tool_calls');
+    expect(mapStopReason('guardrail_intervened')).toBe('content_filter');
+    expect(mapStopReason(undefined)).toBe('stop');
+  });
+
+  test('usageFromConverse normalizes fields', () => {
+    expect(usageFromConverse({ inputTokens: 5, outputTokens: 2, cacheReadInputTokens: 1 })).toEqual({
+      promptTokens: 5,
+      completionTokens: 2,
+      cachedTokens: 1,
+    });
+    expect(usageFromConverse(undefined)).toEqual({
+      promptTokens: 0,
+      completionTokens: 0,
+      cachedTokens: 0,
+    });
+  });
+});
+
+describe('makeStreamTranslator', () => {
+  test('emits role chunk, text deltas, tool calls, and usage', () => {
+    const t = makeStreamTranslator('m', 'r');
+    const out: string[] = [];
+    out.push(t.start());
+    out.push(...t.event({ contentBlockDelta: { contentBlockIndex: 0, delta: { text: 'Hel' } } }));
+    out.push(...t.event({ contentBlockDelta: { contentBlockIndex: 0, delta: { text: 'lo' } } }));
+    out.push(
+      ...t.event({
+        contentBlockStart: { contentBlockIndex: 1, start: { toolUse: { toolUseId: 'tu', name: 'fn' } } },
+      }),
+    );
+    out.push(
+      ...t.event({
+        contentBlockDelta: { contentBlockIndex: 1, delta: { toolUse: { input: '{"a":1}' } } },
+      }),
+    );
+    out.push(...t.event({ messageStop: { stopReason: 'end_turn' } }));
+    out.push(
+      ...t.event({ metadata: { usage: { inputTokens: 4, outputTokens: 6, cacheReadInputTokens: 0 } } }),
+    );
+    out.push(t.done());
+
+    const joined = out.join('');
+    expect(joined).toContain('"role":"assistant"');
+    expect(joined).toContain('"content":"Hel"');
+    expect(joined).toContain('"content":"lo"');
+    // tool call start carries name + index
+    expect(joined).toContain('"name":"fn"');
+    expect(joined).toContain('"arguments":"{\\"a\\":1}"');
+    expect(joined).toContain('"finish_reason":"stop"');
+    expect(joined).toContain('"prompt_tokens":4');
+    expect(joined).toContain('"completion_tokens":6');
+    expect(joined.trim().endsWith('[DONE]')).toBe(true);
+  });
+
+  test('maps multiple tool-use blocks to distinct tool_call indices', () => {
+    const t = makeStreamTranslator('m', 'r');
+    const a = t.event({
+      contentBlockStart: { contentBlockIndex: 2, start: { toolUse: { toolUseId: 'a', name: 'fa' } } },
+    });
+    const b = t.event({
+      contentBlockStart: { contentBlockIndex: 5, start: { toolUse: { toolUseId: 'b', name: 'fb' } } },
+    });
+    const da = t.event({ contentBlockDelta: { contentBlockIndex: 2, delta: { toolUse: { input: 'x' } } } });
+    const db = t.event({ contentBlockDelta: { contentBlockIndex: 5, delta: { toolUse: { input: 'y' } } } });
+    expect(a.join('')).toContain('"index":0');
+    expect(b.join('')).toContain('"index":1');
+    expect(da.join('')).toContain('"index":0');
+    expect(db.join('')).toContain('"index":1');
+  });
+});

--- a/apps/api/src/llm-gateway/routes/chat-completions.ts
+++ b/apps/api/src/llm-gateway/routes/chat-completions.ts
@@ -4,6 +4,8 @@ import type { AppEnv } from '../../types';
 import { callOpenRouter } from '../services/openrouter-client';
 import { calculateCost } from '../services/pricing';
 import { extractUsageFromJson, extractUsageFromSseBuffer, type ExtractedUsage } from '../services/usage-extractor';
+import { isBedrockModel } from '../services/bedrock-models';
+import { handleBedrockCompletion } from '../services/bedrock-handler';
 import { makeOpenApiApp, errors } from '../../openapi';
 
 function newRequestId(): string {
@@ -108,12 +110,71 @@ export function createChatCompletionsRoute(
     if (!hasReasoning && supportsReasoning(modelId)) {
       body.reasoning = { effort: 'medium' };
     }
+    const useBedrock = config.bedrock?.enabled === true && isBedrockModel(modelId);
     console.info(
-      `[llm-gateway] ${requestId} model=${modelId} stream=${streaming} reasoning=${
+      `[llm-gateway] ${requestId} model=${modelId} backend=${useBedrock ? 'bedrock' : 'openrouter'} stream=${streaming} reasoning=${
         hasReasoning ? 'forwarded' : supportsReasoning(modelId) ? 'injected' : 'n/a'
       } keys=${Object.keys(body).join(',')}`,
     );
 
+    const finalize = async (
+      usage: ExtractedUsage | null,
+      provider: string,
+      modelHint?: string,
+    ) => {
+      if (!usage || usage.promptTokens + usage.completionTokens === 0) return;
+
+      const model = (usage.model ?? modelHint ?? (body.model as string) ?? 'unknown').toString();
+      const { upstreamCost, finalCost } = calculateCost(
+        model,
+        {
+          promptTokens: usage.promptTokens,
+          completionTokens: usage.completionTokens,
+          cachedTokens: usage.cachedTokens,
+        },
+        config.markup ?? 1,
+        usage.upstreamCostHint,
+      );
+
+      const event: UsageEvent = {
+        accountId: principal.accountId,
+        actorUserId: principal.userId,
+        provider,
+        model,
+        promptTokens: usage.promptTokens,
+        completionTokens: usage.completionTokens,
+        cachedTokens: usage.cachedTokens,
+        upstreamCost,
+        finalCost,
+        streaming,
+        requestId,
+      };
+      try {
+        await hooks.recordUsage(event);
+      } catch (err) {
+        console.warn(`[llm-gateway] recordUsage failed for ${requestId}:`, err);
+      }
+    };
+
+    // ── AWS Bedrock backend (kortix/bedrock/* models) ────────────────────
+    if (useBedrock) {
+      const bedrock = config.bedrock!;
+      return handleBedrockCompletion({
+        body,
+        modelId,
+        streaming,
+        requestId,
+        clientConfig: {
+          region: bedrock.region,
+          accessKeyId: bedrock.accessKeyId,
+          secretAccessKey: bedrock.secretAccessKey,
+          sessionToken: bedrock.sessionToken,
+        },
+        onUsage: (usage, model) => void finalize(usage, 'bedrock', model),
+      });
+    }
+
+    // ── OpenRouter backend (default) ─────────────────────────────────────
     const upstream = await callOpenRouter(
       streaming ? { ...body, stream: true, stream_options: { include_usage: true } } : body,
       {
@@ -132,45 +193,10 @@ export function createChatCompletionsRoute(
       );
     }
 
-    const finalize = async (usage: ExtractedUsage | null, modelHint?: string) => {
-      if (!usage || usage.promptTokens + usage.completionTokens === 0) return;
-
-      const model = (usage.model ?? modelHint ?? (body.model as string) ?? 'unknown').toString();
-      const { upstreamCost, finalCost } = calculateCost(
-        model,
-        {
-          promptTokens: usage.promptTokens,
-          completionTokens: usage.completionTokens,
-          cachedTokens: usage.cachedTokens,
-        },
-        config.markup ?? 1,
-        usage.upstreamCostHint,
-      );
-
-      const event: UsageEvent = {
-        accountId: principal.accountId,
-        actorUserId: principal.userId,
-        provider: 'openrouter',
-        model,
-        promptTokens: usage.promptTokens,
-        completionTokens: usage.completionTokens,
-        cachedTokens: usage.cachedTokens,
-        upstreamCost,
-        finalCost,
-        streaming,
-        requestId,
-      };
-      try {
-        await hooks.recordUsage(event);
-      } catch (err) {
-        console.warn(`[llm-gateway] recordUsage failed for ${requestId}:`, err);
-      }
-    };
-
     if (!streaming) {
       const json = await upstream.json();
       const usage = extractUsageFromJson(json);
-      void finalize(usage, body.model as string | undefined);
+      void finalize(usage, 'openrouter', body.model as string | undefined);
       return c.json(json);
     }
 
@@ -211,7 +237,7 @@ export function createChatCompletionsRoute(
         } catch {
         }
         const usage = extractUsageFromSseBuffer(sseBuffer);
-        void finalize(usage, body.model as string | undefined);
+        void finalize(usage, 'openrouter', body.model as string | undefined);
       }
     })().catch(() => {});
 

--- a/apps/api/src/llm-gateway/routes/health.ts
+++ b/apps/api/src/llm-gateway/routes/health.ts
@@ -20,6 +20,10 @@ export function createHealthRoute(config: LlmGatewayConfig) {
             baseUrl: z.string(),
             markup: z.number(),
             keyConfigured: z.boolean(),
+            bedrock: z.object({
+              enabled: z.boolean(),
+              region: z.string().optional(),
+            }),
           }),
           'Gateway health',
         ),
@@ -32,6 +36,10 @@ export function createHealthRoute(config: LlmGatewayConfig) {
         baseUrl: config.baseUrl ?? 'https://openrouter.ai/api/v1',
         markup: config.markup ?? 1,
         keyConfigured: !!config.openrouterApiKey,
+        bedrock: {
+          enabled: config.bedrock?.enabled ?? false,
+          region: config.bedrock?.region,
+        },
       }),
   );
 

--- a/apps/api/src/llm-gateway/services/bedrock-client.ts
+++ b/apps/api/src/llm-gateway/services/bedrock-client.ts
@@ -1,0 +1,76 @@
+// Thin wrapper around the AWS Bedrock Runtime SDK. Isolated here so the rest of
+// the gateway never imports the SDK directly (keeps bedrock-translate.ts pure
+// and unit-testable). The client is created lazily and memoized per-region so a
+// gateway with Bedrock disabled never instantiates the SDK.
+
+import {
+  BedrockRuntimeClient,
+  ConverseCommand,
+  ConverseStreamCommand,
+} from '@aws-sdk/client-bedrock-runtime';
+import type { ConverseRequest } from './bedrock-translate';
+
+export interface BedrockClientConfig {
+  region: string;
+  accessKeyId?: string;
+  secretAccessKey?: string;
+  sessionToken?: string;
+}
+
+const clients = new Map<string, BedrockRuntimeClient>();
+
+function getClient(cfg: BedrockClientConfig): BedrockRuntimeClient {
+  const cacheKey = `${cfg.region}:${cfg.accessKeyId ?? 'default'}`;
+  let client = clients.get(cacheKey);
+  if (!client) {
+    client = new BedrockRuntimeClient({
+      region: cfg.region,
+      // When no explicit keys are provided, the SDK's default credential chain
+      // (env vars, IRSA / instance role on EKS, etc.) is used — which is the
+      // production path on our EKS nodes.
+      ...(cfg.accessKeyId && cfg.secretAccessKey
+        ? {
+            credentials: {
+              accessKeyId: cfg.accessKeyId,
+              secretAccessKey: cfg.secretAccessKey,
+              sessionToken: cfg.sessionToken,
+            },
+          }
+        : {}),
+    });
+    clients.set(cacheKey, client);
+  }
+  return client;
+}
+
+// Senders are swappable so tests can inject a fake without the AWS SDK doing I/O.
+export type ConverseSender = (cfg: BedrockClientConfig, req: ConverseRequest) => Promise<any>;
+
+let converseSender: ConverseSender = (cfg, req) =>
+  getClient(cfg).send(new ConverseCommand(req as any));
+
+let converseStreamSender: ConverseSender = (cfg, req) =>
+  getClient(cfg).send(new ConverseStreamCommand(req as any));
+
+export function bedrockConverse(cfg: BedrockClientConfig, req: ConverseRequest): Promise<any> {
+  return converseSender(cfg, req);
+}
+
+export function bedrockConverseStream(cfg: BedrockClientConfig, req: ConverseRequest): Promise<any> {
+  return converseStreamSender(cfg, req);
+}
+
+/** Test seam — override the underlying senders; returns a restore fn. */
+export function __setSenders(overrides: {
+  converse?: ConverseSender;
+  converseStream?: ConverseSender;
+}): () => void {
+  const prevConverse = converseSender;
+  const prevStream = converseStreamSender;
+  if (overrides.converse) converseSender = overrides.converse;
+  if (overrides.converseStream) converseStreamSender = overrides.converseStream;
+  return () => {
+    converseSender = prevConverse;
+    converseStreamSender = prevStream;
+  };
+}

--- a/apps/api/src/llm-gateway/services/bedrock-handler.ts
+++ b/apps/api/src/llm-gateway/services/bedrock-handler.ts
@@ -1,0 +1,162 @@
+import { bedrockConverse, bedrockConverseStream, type BedrockClientConfig } from './bedrock-client';
+import {
+  openaiToConverse,
+  converseToOpenai,
+  makeStreamTranslator,
+} from './bedrock-translate';
+import { resolveBedrockModel } from './bedrock-models';
+import type { ExtractedUsage } from './usage-extractor';
+
+const REASONING_BUDGET_BY_EFFORT: Record<string, number> = {
+  low: 1024,
+  medium: 4096,
+  high: 16384,
+};
+
+/** Derive an Anthropic thinking budget (tokens) from the OpenAI-style body. */
+function reasoningBudget(body: Record<string, unknown>, modelReasoning: boolean): number {
+  if (!modelReasoning) return 0;
+  // Explicit Anthropic-style thinking block wins.
+  const thinking = body.thinking as { type?: string; budget_tokens?: number } | undefined;
+  if (thinking?.type === 'enabled' && typeof thinking.budget_tokens === 'number') {
+    return thinking.budget_tokens;
+  }
+  const effort =
+    (typeof body.reasoning_effort === 'string' && body.reasoning_effort) ||
+    (typeof (body.reasoning as { effort?: string })?.effort === 'string' &&
+      (body.reasoning as { effort?: string }).effort) ||
+    '';
+  if (effort) return REASONING_BUDGET_BY_EFFORT[effort] ?? REASONING_BUDGET_BY_EFFORT.medium;
+  return 0;
+}
+
+export interface BedrockHandlerResult {
+  response: Response;
+}
+
+/**
+ * Serve a chat-completions request via AWS Bedrock. `onUsage` is invoked once
+ * with token usage (so the caller can run the shared billing/usage pipeline,
+ * exactly as the OpenRouter path does). Mirrors the OpenRouter handler's
+ * streaming-disconnect handling: keep draining upstream after the client drops
+ * so we still capture the final usage.
+ */
+export async function handleBedrockCompletion(args: {
+  body: Record<string, unknown>;
+  modelId: string;
+  streaming: boolean;
+  clientConfig: BedrockClientConfig;
+  requestId: string;
+  onUsage: (usage: ExtractedUsage, model: string) => void;
+}): Promise<Response> {
+  const { body, modelId, streaming, clientConfig, requestId, onUsage } = args;
+
+  const entry = resolveBedrockModel(modelId);
+  if (!entry) {
+    return new Response(JSON.stringify({ error: `Unknown Bedrock model: ${modelId}` }), {
+      status: 400,
+      headers: { 'content-type': 'application/json' },
+    });
+  }
+
+  const budget = reasoningBudget(body, !!entry.reasoning);
+  const converseReq = openaiToConverse(body, entry.bedrockId, budget);
+
+  if (!streaming) {
+    let out: Awaited<ReturnType<typeof bedrockConverse>>;
+    try {
+      out = await bedrockConverse(clientConfig, converseReq);
+    } catch (err) {
+      return bedrockError(err);
+    }
+    const json = converseToOpenai(out, modelId, requestId);
+    const usage = (json.usage ?? {}) as { prompt_tokens?: number; completion_tokens?: number; prompt_tokens_details?: { cached_tokens?: number } };
+    onUsage(
+      {
+        promptTokens: usage.prompt_tokens ?? 0,
+        completionTokens: usage.completion_tokens ?? 0,
+        cachedTokens: usage.prompt_tokens_details?.cached_tokens ?? 0,
+      },
+      modelId,
+    );
+    return new Response(JSON.stringify(json), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  }
+
+  // Streaming
+  let streamOut: Awaited<ReturnType<typeof bedrockConverseStream>>;
+  try {
+    streamOut = await bedrockConverseStream(clientConfig, converseReq);
+  } catch (err) {
+    return bedrockError(err);
+  }
+
+  const translator = makeStreamTranslator(modelId, requestId);
+  const encoder = new TextEncoder();
+  const passthrough = new TransformStream<Uint8Array, Uint8Array>();
+  const writer = passthrough.writable.getWriter();
+
+  let captured: ExtractedUsage | null = null;
+
+  (async () => {
+    let downstreamAlive = true;
+    const write = async (s: string) => {
+      if (!downstreamAlive) return;
+      try {
+        await writer.write(encoder.encode(s));
+      } catch {
+        downstreamAlive = false;
+      }
+    };
+    try {
+      await write(translator.start());
+      const events = streamOut.stream as AsyncIterable<Record<string, any>> | undefined;
+      if (events) {
+        for await (const ev of events) {
+          if (ev?.metadata?.usage) {
+            const u = ev.metadata.usage;
+            captured = {
+              promptTokens: u.inputTokens ?? 0,
+              completionTokens: u.outputTokens ?? 0,
+              cachedTokens: u.cacheReadInputTokens ?? 0,
+            };
+          }
+          for (const s of translator.event(ev)) await write(s);
+        }
+      }
+      await write(translator.done());
+    } catch (err) {
+      console.warn(`[llm-gateway] bedrock stream error ${requestId}:`, err);
+    } finally {
+      try {
+        await writer.close();
+      } catch {
+      }
+      if (captured && captured.promptTokens + captured.completionTokens > 0) {
+        onUsage(captured, modelId);
+      }
+    }
+  })().catch(() => {});
+
+  return new Response(passthrough.readable, {
+    status: 200,
+    headers: {
+      'content-type': 'text/event-stream',
+      'cache-control': 'no-cache',
+      connection: 'keep-alive',
+    },
+  });
+}
+
+function bedrockError(err: unknown): Response {
+  const e = err as { name?: string; message?: string; $metadata?: { httpStatusCode?: number } };
+  const status = e?.$metadata?.httpStatusCode ?? 502;
+  const message = e?.message || 'Bedrock upstream error';
+  console.warn('[llm-gateway] bedrock error:', e?.name, message);
+  return new Response(JSON.stringify({ error: message, code: e?.name }), {
+    status: status >= 400 && status < 600 ? status : 502,
+    headers: { 'content-type': 'application/json' },
+  });
+}

--- a/apps/api/src/llm-gateway/services/bedrock-models.ts
+++ b/apps/api/src/llm-gateway/services/bedrock-models.ts
@@ -1,0 +1,89 @@
+// Maps the gateway's logical model IDs (as exposed under the `kortix` opencode
+// provider, e.g. `bedrock/anthropic/claude-opus-4.8`) to AWS Bedrock inference
+// profile / model IDs, plus per-model fallback pricing (USD per 1M tokens).
+//
+// The `bedrock/` prefix is the routing key: any model whose id starts with
+// `bedrock/` is served by the Bedrock backend instead of OpenRouter.
+
+export const BEDROCK_PREFIX = 'bedrock/';
+
+export interface BedrockModelEntry {
+  /** Bedrock inference profile ID or model ID used in the Converse call. */
+  bedrockId: string;
+  /** Whether to enable Anthropic extended thinking when the caller asks for reasoning. */
+  reasoning?: boolean;
+  inputPerMillion: number;
+  outputPerMillion: number;
+  cachedInputPerMillion?: number;
+}
+
+// Keyed by the logical id WITHOUT the `bedrock/` prefix. Uses cross-region
+// inference profiles (the `us.` prefix) which is the supported invocation path
+// for these models in us-west-2.
+export const BEDROCK_MODELS: Record<string, BedrockModelEntry> = {
+  'anthropic/claude-opus-4.8': {
+    bedrockId: 'us.anthropic.claude-opus-4-5-20251101-v1:0',
+    reasoning: true,
+    inputPerMillion: 5,
+    outputPerMillion: 25,
+    cachedInputPerMillion: 0.5,
+  },
+  'anthropic/claude-sonnet-4.6': {
+    bedrockId: 'us.anthropic.claude-sonnet-4-5-20250929-v1:0',
+    reasoning: true,
+    inputPerMillion: 3,
+    outputPerMillion: 15,
+    cachedInputPerMillion: 0.3,
+  },
+  'anthropic/claude-haiku-4.5': {
+    bedrockId: 'us.anthropic.claude-haiku-4-5-20251001-v1:0',
+    reasoning: true,
+    inputPerMillion: 1,
+    outputPerMillion: 5,
+    cachedInputPerMillion: 0.1,
+  },
+  'meta/llama-4-maverick': {
+    bedrockId: 'us.meta.llama4-maverick-17b-instruct-v1:0',
+    inputPerMillion: 0.24,
+    outputPerMillion: 0.97,
+  },
+  'meta/llama-4-scout': {
+    bedrockId: 'us.meta.llama4-scout-17b-instruct-v1:0',
+    inputPerMillion: 0.17,
+    outputPerMillion: 0.66,
+  },
+  'amazon/nova-pro': {
+    bedrockId: 'us.amazon.nova-pro-v1:0',
+    inputPerMillion: 0.8,
+    outputPerMillion: 3.2,
+    cachedInputPerMillion: 0.2,
+  },
+  'amazon/nova-lite': {
+    bedrockId: 'us.amazon.nova-lite-v1:0',
+    inputPerMillion: 0.06,
+    outputPerMillion: 0.24,
+    cachedInputPerMillion: 0.015,
+  },
+  'deepseek/deepseek-r1': {
+    bedrockId: 'us.deepseek.r1-v1:0',
+    reasoning: true,
+    inputPerMillion: 1.35,
+    outputPerMillion: 5.4,
+  },
+};
+
+/** Strip the routing prefix if present. Returns null if not a Bedrock model. */
+export function stripBedrockPrefix(model: string): string | null {
+  if (!model.startsWith(BEDROCK_PREFIX)) return null;
+  return model.slice(BEDROCK_PREFIX.length);
+}
+
+export function isBedrockModel(model: string): boolean {
+  return model.startsWith(BEDROCK_PREFIX);
+}
+
+export function resolveBedrockModel(model: string): BedrockModelEntry | null {
+  const key = stripBedrockPrefix(model);
+  if (key == null) return null;
+  return BEDROCK_MODELS[key] ?? null;
+}

--- a/apps/api/src/llm-gateway/services/bedrock-translate.ts
+++ b/apps/api/src/llm-gateway/services/bedrock-translate.ts
@@ -1,0 +1,438 @@
+// Pure translation between the OpenAI/OpenRouter chat-completions wire format
+// (what opencode's `@ai-sdk/openai-compatible` provider sends) and the AWS
+// Bedrock Converse API shape. No AWS SDK / no I/O here so this stays trivially
+// unit-testable; the SDK calls live in bedrock-client.ts.
+
+import type { ExtractedUsage } from './usage-extractor';
+
+/* ────────────────────────────── request ────────────────────────────── */
+
+interface OpenAiTextPart {
+  type: 'text';
+  text: string;
+}
+interface OpenAiImagePart {
+  type: 'image_url';
+  image_url: { url: string };
+}
+type OpenAiContentPart = OpenAiTextPart | OpenAiImagePart | Record<string, unknown>;
+
+interface OpenAiToolCall {
+  id?: string;
+  type?: string;
+  function?: { name?: string; arguments?: string };
+}
+
+interface OpenAiMessage {
+  role: string;
+  content?: string | OpenAiContentPart[] | null;
+  tool_calls?: OpenAiToolCall[];
+  tool_call_id?: string;
+  name?: string;
+}
+
+// Loosely-typed mirrors of the Bedrock Converse types we emit. We avoid
+// importing the SDK's types here so this module has zero runtime deps.
+export interface ConverseRequest {
+  modelId: string;
+  messages: Array<{ role: 'user' | 'assistant'; content: unknown[] }>;
+  system?: Array<{ text: string }>;
+  inferenceConfig?: {
+    maxTokens?: number;
+    temperature?: number;
+    topP?: number;
+    stopSequences?: string[];
+  };
+  toolConfig?: {
+    tools: Array<{
+      toolSpec: { name: string; description?: string; inputSchema: { json: unknown } };
+    }>;
+    toolChoice?: Record<string, unknown>;
+  };
+  additionalModelRequestFields?: Record<string, unknown>;
+}
+
+const IMAGE_FORMATS: Record<string, string> = {
+  'image/png': 'png',
+  'image/jpeg': 'jpeg',
+  'image/jpg': 'jpeg',
+  'image/gif': 'gif',
+  'image/webp': 'webp',
+};
+
+function decodeImagePart(url: string): { format: string; bytes: Uint8Array } | null {
+  // data:image/png;base64,XXXX
+  const m = url.match(/^data:([^;]+);base64,(.+)$/);
+  if (!m) return null;
+  const format = IMAGE_FORMATS[m[1].toLowerCase()];
+  if (!format) return null;
+  try {
+    const bin = atob(m[2]);
+    const bytes = new Uint8Array(bin.length);
+    for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+    return { format, bytes };
+  } catch {
+    return null;
+  }
+}
+
+function contentToBlocks(content: OpenAiMessage['content']): unknown[] {
+  if (content == null) return [];
+  if (typeof content === 'string') {
+    return content.length ? [{ text: content }] : [];
+  }
+  const blocks: unknown[] = [];
+  for (const part of content) {
+    if (!part || typeof part !== 'object') continue;
+    const type = (part as { type?: string }).type;
+    if (type === 'text' && typeof (part as OpenAiTextPart).text === 'string') {
+      if ((part as OpenAiTextPart).text.length) blocks.push({ text: (part as OpenAiTextPart).text });
+    } else if (type === 'image_url') {
+      const url = (part as OpenAiImagePart).image_url?.url;
+      const img = typeof url === 'string' ? decodeImagePart(url) : null;
+      if (img) blocks.push({ image: { format: img.format, source: { bytes: img.bytes } } });
+    }
+  }
+  return blocks;
+}
+
+function parseToolArguments(args: string | undefined): unknown {
+  if (!args) return {};
+  try {
+    return JSON.parse(args);
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Translate an OpenAI chat-completions body into a Bedrock Converse request.
+ * `reasoningBudget` (when > 0) enables Anthropic extended thinking.
+ */
+export function openaiToConverse(
+  body: Record<string, unknown>,
+  modelId: string,
+  reasoningBudget?: number,
+): ConverseRequest {
+  const messages = Array.isArray(body.messages) ? (body.messages as OpenAiMessage[]) : [];
+
+  const system: Array<{ text: string }> = [];
+  const converseMessages: ConverseRequest['messages'] = [];
+
+  const pushMessage = (role: 'user' | 'assistant', content: unknown[]) => {
+    if (!content.length) return;
+    const last = converseMessages[converseMessages.length - 1];
+    // Bedrock requires strictly alternating roles; merge consecutive same-role
+    // turns (e.g. a tool result followed by a user message) into one.
+    if (last && last.role === role) {
+      last.content.push(...content);
+    } else {
+      converseMessages.push({ role, content });
+    }
+  };
+
+  for (const msg of messages) {
+    if (!msg || typeof msg !== 'object') continue;
+    const role = msg.role;
+
+    if (role === 'system' || role === 'developer') {
+      const text =
+        typeof msg.content === 'string'
+          ? msg.content
+          : contentToBlocks(msg.content)
+              .map((b) => (b as { text?: string }).text ?? '')
+              .join('');
+      if (text) system.push({ text });
+      continue;
+    }
+
+    if (role === 'tool') {
+      const toolResult = {
+        toolResult: {
+          toolUseId: msg.tool_call_id ?? '',
+          content:
+            typeof msg.content === 'string'
+              ? [{ text: msg.content }]
+              : contentToBlocks(msg.content),
+        },
+      };
+      pushMessage('user', [toolResult]);
+      continue;
+    }
+
+    if (role === 'assistant') {
+      const blocks = contentToBlocks(msg.content);
+      if (Array.isArray(msg.tool_calls)) {
+        for (const call of msg.tool_calls) {
+          if (call?.function?.name) {
+            blocks.push({
+              toolUse: {
+                toolUseId: call.id ?? call.function.name,
+                name: call.function.name,
+                input: parseToolArguments(call.function.arguments),
+              },
+            });
+          }
+        }
+      }
+      pushMessage('assistant', blocks);
+      continue;
+    }
+
+    // user (and any other role) → user turn
+    pushMessage('user', contentToBlocks(msg.content));
+  }
+
+  const req: ConverseRequest = { modelId, messages: converseMessages };
+  if (system.length) req.system = system;
+
+  const inferenceConfig: NonNullable<ConverseRequest['inferenceConfig']> = {};
+  if (typeof body.max_tokens === 'number') inferenceConfig.maxTokens = body.max_tokens;
+  else if (typeof body.max_completion_tokens === 'number')
+    inferenceConfig.maxTokens = body.max_completion_tokens;
+  // Extended thinking requires temperature=1 and no topP; honor that.
+  if (reasoningBudget && reasoningBudget > 0) {
+    inferenceConfig.temperature = 1;
+  } else {
+    if (typeof body.temperature === 'number') inferenceConfig.temperature = body.temperature;
+    if (typeof body.top_p === 'number') inferenceConfig.topP = body.top_p;
+  }
+  if (typeof body.stop === 'string') inferenceConfig.stopSequences = [body.stop];
+  else if (Array.isArray(body.stop))
+    inferenceConfig.stopSequences = body.stop.filter((s): s is string => typeof s === 'string');
+  if (Object.keys(inferenceConfig).length) req.inferenceConfig = inferenceConfig;
+
+  // Tools
+  const tools = Array.isArray(body.tools) ? body.tools : [];
+  if (tools.length) {
+    const toolSpecs = tools
+      .map((t) => {
+        const fn = (t as { function?: { name?: string; description?: string; parameters?: unknown } })
+          .function;
+        if (!fn?.name) return null;
+        return {
+          toolSpec: {
+            name: fn.name,
+            description: fn.description,
+            inputSchema: { json: fn.parameters ?? { type: 'object', properties: {} } },
+          },
+        };
+      })
+      .filter((t): t is NonNullable<typeof t> => t !== null);
+    if (toolSpecs.length) {
+      req.toolConfig = { tools: toolSpecs };
+      const tc = body.tool_choice;
+      if (tc === 'required' || tc === 'any') req.toolConfig.toolChoice = { any: {} };
+      else if (tc === 'auto') req.toolConfig.toolChoice = { auto: {} };
+      else if (tc && typeof tc === 'object') {
+        const name = (tc as { function?: { name?: string } }).function?.name;
+        if (name) req.toolConfig.toolChoice = { tool: { name } };
+      }
+    }
+  }
+
+  if (reasoningBudget && reasoningBudget > 0) {
+    req.additionalModelRequestFields = {
+      ...(req.additionalModelRequestFields ?? {}),
+      thinking: { type: 'enabled', budget_tokens: reasoningBudget },
+    };
+  }
+
+  return req;
+}
+
+/* ────────────────────────────── response ───────────────────────────── */
+
+const STOP_REASON_MAP: Record<string, string> = {
+  end_turn: 'stop',
+  stop_sequence: 'stop',
+  max_tokens: 'length',
+  tool_use: 'tool_calls',
+  content_filtered: 'content_filter',
+  guardrail_intervened: 'content_filter',
+};
+
+export function mapStopReason(reason: string | undefined): string {
+  if (!reason) return 'stop';
+  return STOP_REASON_MAP[reason] ?? 'stop';
+}
+
+export function usageFromConverse(
+  usage: { inputTokens?: number; outputTokens?: number; cacheReadInputTokens?: number } | undefined,
+): ExtractedUsage {
+  return {
+    promptTokens: usage?.inputTokens ?? 0,
+    completionTokens: usage?.outputTokens ?? 0,
+    cachedTokens: usage?.cacheReadInputTokens ?? 0,
+  };
+}
+
+interface ConverseContentBlock {
+  text?: string;
+  toolUse?: { toolUseId?: string; name?: string; input?: unknown };
+  reasoningContent?: { reasoningText?: { text?: string } };
+}
+
+/**
+ * Translate a (non-streaming) Bedrock Converse response into an OpenAI
+ * chat.completion object, including a usage block in OpenAI shape so the
+ * gateway's shared usage-extractor handles it unchanged.
+ */
+export function converseToOpenai(
+  output: {
+    output?: { message?: { role?: string; content?: ConverseContentBlock[] } };
+    stopReason?: string;
+    usage?: { inputTokens?: number; outputTokens?: number; cacheReadInputTokens?: number };
+  },
+  model: string,
+  requestId: string,
+): Record<string, unknown> {
+  const blocks = output.output?.message?.content ?? [];
+  let text = '';
+  let reasoning = '';
+  const toolCalls: Array<{
+    id: string;
+    type: 'function';
+    function: { name: string; arguments: string };
+  }> = [];
+
+  for (const b of blocks) {
+    if (typeof b.text === 'string') text += b.text;
+    else if (b.reasoningContent?.reasoningText?.text)
+      reasoning += b.reasoningContent.reasoningText.text;
+    else if (b.toolUse?.name) {
+      toolCalls.push({
+        id: b.toolUse.toolUseId ?? b.toolUse.name,
+        type: 'function',
+        function: { name: b.toolUse.name, arguments: JSON.stringify(b.toolUse.input ?? {}) },
+      });
+    }
+  }
+
+  const message: Record<string, unknown> = { role: 'assistant', content: text || null };
+  if (reasoning) message.reasoning_content = reasoning;
+  if (toolCalls.length) message.tool_calls = toolCalls;
+
+  const u = output.usage ?? {};
+  return {
+    id: `chatcmpl-${requestId}`,
+    object: 'chat.completion',
+    created: Math.floor(Date.now() / 1000),
+    model,
+    choices: [
+      {
+        index: 0,
+        message,
+        finish_reason: mapStopReason(output.stopReason),
+      },
+    ],
+    usage: {
+      prompt_tokens: u.inputTokens ?? 0,
+      completion_tokens: u.outputTokens ?? 0,
+      total_tokens: (u.inputTokens ?? 0) + (u.outputTokens ?? 0),
+      prompt_tokens_details: { cached_tokens: u.cacheReadInputTokens ?? 0 },
+    },
+  };
+}
+
+/* ─────────────────────────────── streaming ─────────────────────────── */
+
+function sse(obj: unknown): string {
+  return `data: ${JSON.stringify(obj)}\n\n`;
+}
+
+/**
+ * Stateful translator for a Bedrock ConverseStream into OpenAI SSE
+ * `chat.completion.chunk` events. Feed each Converse stream event; collect the
+ * emitted SSE strings. Call `done()` to flush the terminating `[DONE]`.
+ */
+export function makeStreamTranslator(model: string, requestId: string) {
+  const id = `chatcmpl-${requestId}`;
+  const created = Math.floor(Date.now() / 1000);
+  // Maps a Bedrock contentBlockIndex → the OpenAI tool_call index (only for
+  // toolUse blocks), so streamed argument deltas attach to the right call.
+  const toolIndexByBlock = new Map<number, number>();
+  let nextToolIndex = 0;
+
+  const chunk = (delta: Record<string, unknown>, finish_reason: string | null = null) =>
+    sse({
+      id,
+      object: 'chat.completion.chunk',
+      created,
+      model,
+      choices: [{ index: 0, delta, finish_reason }],
+    });
+
+  return {
+    /** Emit the leading role chunk. */
+    start(): string {
+      return chunk({ role: 'assistant', content: '' });
+    },
+
+    /** Translate one Bedrock stream event; returns 0+ SSE strings. */
+    event(ev: Record<string, any>): string[] {
+      const out: string[] = [];
+
+      if (ev.contentBlockStart) {
+        const idx = ev.contentBlockStart.contentBlockIndex;
+        const tu = ev.contentBlockStart.start?.toolUse;
+        if (tu) {
+          const toolIndex = nextToolIndex++;
+          toolIndexByBlock.set(idx, toolIndex);
+          out.push(
+            chunk({
+              tool_calls: [
+                {
+                  index: toolIndex,
+                  id: tu.toolUseId,
+                  type: 'function',
+                  function: { name: tu.name, arguments: '' },
+                },
+              ],
+            }),
+          );
+        }
+      } else if (ev.contentBlockDelta) {
+        const idx = ev.contentBlockDelta.contentBlockIndex;
+        const d = ev.contentBlockDelta.delta ?? {};
+        if (typeof d.text === 'string') {
+          out.push(chunk({ content: d.text }));
+        } else if (d.reasoningContent?.text) {
+          out.push(chunk({ reasoning_content: d.reasoningContent.text }));
+        } else if (d.toolUse && typeof d.toolUse.input === 'string') {
+          const toolIndex = toolIndexByBlock.get(idx) ?? 0;
+          out.push(
+            chunk({
+              tool_calls: [{ index: toolIndex, function: { arguments: d.toolUse.input } }],
+            }),
+          );
+        }
+      } else if (ev.messageStop) {
+        out.push(chunk({}, mapStopReason(ev.messageStop.stopReason)));
+      } else if (ev.metadata?.usage) {
+        const u = ev.metadata.usage;
+        out.push(
+          sse({
+            id,
+            object: 'chat.completion.chunk',
+            created,
+            model,
+            choices: [],
+            usage: {
+              prompt_tokens: u.inputTokens ?? 0,
+              completion_tokens: u.outputTokens ?? 0,
+              total_tokens: (u.inputTokens ?? 0) + (u.outputTokens ?? 0),
+              prompt_tokens_details: { cached_tokens: u.cacheReadInputTokens ?? 0 },
+            },
+          }),
+        );
+      }
+
+      return out;
+    },
+
+    done(): string {
+      return 'data: [DONE]\n\n';
+    },
+  };
+}

--- a/apps/api/src/llm-gateway/services/pricing.ts
+++ b/apps/api/src/llm-gateway/services/pricing.ts
@@ -1,3 +1,5 @@
+import { resolveBedrockModel } from './bedrock-models';
+
 interface PriceEntry {
   inputPerMillion: number;
   outputPerMillion: number;
@@ -21,6 +23,15 @@ const FALLBACK_PRICING: Record<string, PriceEntry> = {
 const DEFAULT_PRICING: PriceEntry = { inputPerMillion: 2, outputPerMillion: 10 };
 
 function getPricing(model: string): PriceEntry {
+  // Bedrock models carry their own pricing in the model registry.
+  const bedrock = resolveBedrockModel(model);
+  if (bedrock) {
+    return {
+      inputPerMillion: bedrock.inputPerMillion,
+      outputPerMillion: bedrock.outputPerMillion,
+      cachedInputPerMillion: bedrock.cachedInputPerMillion,
+    };
+  }
   if (FALLBACK_PRICING[model]) return FALLBACK_PRICING[model];
   for (const [key, pricing] of Object.entries(FALLBACK_PRICING)) {
     if (model.startsWith(key)) return pricing;

--- a/apps/api/src/llm-gateway/types.ts
+++ b/apps/api/src/llm-gateway/types.ts
@@ -23,6 +23,16 @@ export interface LlmGatewayHooks {
   recordUsage: (event: UsageEvent) => Promise<void>;
 }
 
+export interface BedrockConfig {
+  enabled: boolean;
+  region: string;
+  /** Optional static creds. When omitted, the AWS default credential chain
+   * (env vars, EKS IRSA / instance role) is used. */
+  accessKeyId?: string;
+  secretAccessKey?: string;
+  sessionToken?: string;
+}
+
 export interface LlmGatewayConfig {
   enabled: boolean;
   openrouterApiKey: string;
@@ -30,4 +40,7 @@ export interface LlmGatewayConfig {
   markup?: number;
   appName?: string;
   appReferer?: string;
+  /** AWS Bedrock backend. When enabled, models prefixed `bedrock/` are routed
+   * to Bedrock instead of OpenRouter. */
+  bedrock?: BedrockConfig;
 }

--- a/apps/kortix-sandbox-agent-server/src/__tests__/executor-mcp-config.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/executor-mcp-config.test.ts
@@ -109,6 +109,17 @@ describe('buildExecutorMcpConfigContent — Kortix LLM gateway provider', () => 
     expect(models['minimax/minimax-m3'].tool_call).toBe(true)
   })
 
+  test('exposes AWS Bedrock models under the kortix provider', () => {
+    const config = JSON.parse(buildExecutorMcpConfigContent(GATEWAY_ENV)!)
+    const models = config.provider.kortix.models
+    // bedrock/ prefixed ids are routed to the gateway's Bedrock backend.
+    expect(models['bedrock/anthropic/claude-opus-4.8']).toBeDefined()
+    expect(models['bedrock/anthropic/claude-opus-4.8'].reasoning).toBe(true)
+    expect(models['bedrock/anthropic/claude-opus-4.8'].tool_call).toBe(true)
+    expect(models['bedrock/meta/llama-4-maverick'].tool_call).toBe(true)
+    expect(models['bedrock/amazon/nova-pro'].tool_call).toBe(true)
+  })
+
   test('merges provider onto pre-existing inline provider block', () => {
     const existing = JSON.stringify({
       provider: { anthropic: { options: { timeout: 600000 } } },

--- a/apps/kortix-sandbox-agent-server/src/opencode.ts
+++ b/apps/kortix-sandbox-agent-server/src/opencode.ts
@@ -188,6 +188,67 @@ const KORTIX_GATEWAY_MODELS: Record<string, KortixGatewayModel> = {
     temperature: true,
     limit: { context: 1_000_000, output: 64_000 },
   },
+  // ── AWS Bedrock models (served by the gateway's Bedrock backend) ──────────
+  // `bedrock/` prefix routes these to AWS Bedrock Converse instead of OpenRouter.
+  'bedrock/anthropic/claude-opus-4.8': {
+    name: 'Claude Opus 4.8 (Bedrock)',
+    reasoning: true,
+    tool_call: true,
+    attachment: true,
+    temperature: true,
+    limit: { context: 1_000_000, output: 64_000 },
+  },
+  'bedrock/anthropic/claude-sonnet-4.6': {
+    name: 'Claude Sonnet 4.6 (Bedrock)',
+    reasoning: true,
+    tool_call: true,
+    attachment: true,
+    temperature: true,
+    limit: { context: 1_000_000, output: 64_000 },
+  },
+  'bedrock/anthropic/claude-haiku-4.5': {
+    name: 'Claude Haiku 4.5 (Bedrock)',
+    reasoning: true,
+    tool_call: true,
+    attachment: true,
+    temperature: true,
+    limit: { context: 200_000, output: 64_000 },
+  },
+  'bedrock/meta/llama-4-maverick': {
+    name: 'Llama 4 Maverick (Bedrock)',
+    tool_call: true,
+    attachment: true,
+    temperature: true,
+    limit: { context: 1_000_000, output: 8_192 },
+  },
+  'bedrock/meta/llama-4-scout': {
+    name: 'Llama 4 Scout (Bedrock)',
+    tool_call: true,
+    attachment: true,
+    temperature: true,
+    limit: { context: 3_500_000, output: 8_192 },
+  },
+  'bedrock/amazon/nova-pro': {
+    name: 'Nova Pro (Bedrock)',
+    tool_call: true,
+    attachment: true,
+    temperature: true,
+    limit: { context: 300_000, output: 5_120 },
+  },
+  'bedrock/amazon/nova-lite': {
+    name: 'Nova Lite (Bedrock)',
+    tool_call: true,
+    attachment: true,
+    temperature: true,
+    limit: { context: 300_000, output: 5_120 },
+  },
+  'bedrock/deepseek/deepseek-r1': {
+    name: 'DeepSeek R1 (Bedrock)',
+    reasoning: true,
+    tool_call: true,
+    temperature: true,
+    limit: { context: 163_840, output: 32_768 },
+  },
 }
 
 function materializeOpencodeAuth(env: NodeJS.ProcessEnv) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,9 @@ importers:
 
   apps/api:
     dependencies:
+      '@aws-sdk/client-bedrock-runtime':
+        specifier: ^3.700.0
+        version: 3.1068.0
       '@daytonaio/sdk':
         specifier: ^0.184.0
         version: 0.184.0(ws@8.21.0)
@@ -1430,7 +1433,7 @@ packages:
     engines: {node: '>=16.0.0'}
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.9
+      '@aws-sdk/types': 3.973.12
       tslib: 2.8.1
     dev: false
 
@@ -1459,7 +1462,7 @@ packages:
       '@aws-crypto/sha256-js': 5.2.0
       '@aws-crypto/supports-web-crypto': 5.2.0
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.9
+      '@aws-sdk/types': 3.973.12
       '@aws-sdk/util-locate-window': 3.965.5
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
@@ -1470,7 +1473,7 @@ packages:
     engines: {node: '>=16.0.0'}
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.9
+      '@aws-sdk/types': 3.973.12
       tslib: 2.8.1
     dev: false
 
@@ -1483,8 +1486,28 @@ packages:
   /@aws-crypto/util@5.2.0:
     resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
     dependencies:
-      '@aws-sdk/types': 3.973.9
+      '@aws-sdk/types': 3.973.12
       '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/client-bedrock-runtime@3.1068.0:
+    resolution: {integrity: sha512-0p4XoL8a6k5K+dF6mLByOEoOaF+BwRzSWLF87Xnxrs5xvrTezOmytNq+TZxZ3a2XuTW8JcLijchXeOlTZK+VPA==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.20
+      '@aws-sdk/credential-provider-node': 3.972.55
+      '@aws-sdk/eventstream-handler-node': 3.972.21
+      '@aws-sdk/middleware-eventstream': 3.972.17
+      '@aws-sdk/middleware-websocket': 3.972.28
+      '@aws-sdk/token-providers': 3.1068.0
+      '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.7
+      '@smithy/fetch-http-handler': 5.4.7
+      '@smithy/node-http-handler': 4.7.8
+      '@smithy/types': 4.14.4
       tslib: 2.8.1
     dev: false
 
@@ -1526,6 +1549,20 @@ packages:
       tslib: 2.8.1
     dev: false
 
+  /@aws-sdk/core@3.974.20:
+    resolution: {integrity: sha512-7sDi2B2N3mc3nf1nz6FyEx/FCrJ1N1QnBmraHHQNabFaeAh2IaOOLml48/rHOD1bICHgTRkbBgNTvUzEr5Z35g==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      '@aws-sdk/types': 3.973.12
+      '@aws-sdk/xml-builder': 3.972.29
+      '@aws/lambda-invoke-store': 0.2.4
+      '@smithy/core': 3.24.7
+      '@smithy/signature-v4': 5.4.7
+      '@smithy/types': 4.14.4
+      bowser: 2.14.1
+      tslib: 2.8.1
+    dev: false
+
   /@aws-sdk/crc64-nvme@3.972.9:
     resolution: {integrity: sha512-P+QGozmXn2mZZI7sDgk+aUm+RTI61MPSFB+Ir2vjEjEbEsE4e7hYtzrDvAUxZy9ko81h53e11+F/GYlvwDkaOQ==}
     engines: {node: '>=20.0.0'}
@@ -1545,6 +1582,17 @@ packages:
       tslib: 2.8.1
     dev: false
 
+  /@aws-sdk/credential-provider-env@3.972.46:
+    resolution: {integrity: sha512-+GPXVS2srMOlH74S+SmC1gVuP2TvUZ0siuC0onKO93q+udP+M72dmY8wJfVQ5CX9z/9X5A1HHwz5yRIGBtskvQ==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      '@aws-sdk/core': 3.974.20
+      '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.7
+      '@smithy/types': 4.14.4
+      tslib: 2.8.1
+    dev: false
+
   /@aws-sdk/credential-provider-http@3.972.43:
     resolution: {integrity: sha512-TT76RN1NkI9WoyZqCNxOw6/WBMF7pYOTJcXbMokNFU+euSG40Kaf/t/FhDACVZWP+43wEM6ZynIPIkzS1wR1iA==}
     engines: {node: '>=20.0.0'}
@@ -1555,6 +1603,19 @@ packages:
       '@smithy/fetch-http-handler': 5.4.5
       '@smithy/node-http-handler': 4.7.5
       '@smithy/types': 4.14.2
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/credential-provider-http@3.972.48:
+    resolution: {integrity: sha512-fA5loSdlocacRxyUXtpoHSMuk5rsIKRDzQYVMnMxjcmFeZshaJlJ8lymy/hYKji6sne/UmNGj5pxuEs6kq/Qcg==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      '@aws-sdk/core': 3.974.20
+      '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.7
+      '@smithy/fetch-http-handler': 5.4.7
+      '@smithy/node-http-handler': 4.7.8
+      '@smithy/types': 4.14.4
       tslib: 2.8.1
     dev: false
 
@@ -1577,6 +1638,25 @@ packages:
       tslib: 2.8.1
     dev: false
 
+  /@aws-sdk/credential-provider-ini@3.972.53:
+    resolution: {integrity: sha512-ZfdhIOR41q8TcWEnUac+gCOb+O2LBWdHLmjedXpXz4IEFW2ppNuFcm6p0sMTavpM+zD5TYfpH5Gp7guRyqSgsQ==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      '@aws-sdk/core': 3.974.20
+      '@aws-sdk/credential-provider-env': 3.972.46
+      '@aws-sdk/credential-provider-http': 3.972.48
+      '@aws-sdk/credential-provider-login': 3.972.52
+      '@aws-sdk/credential-provider-process': 3.972.46
+      '@aws-sdk/credential-provider-sso': 3.972.52
+      '@aws-sdk/credential-provider-web-identity': 3.972.52
+      '@aws-sdk/nested-clients': 3.997.20
+      '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.7
+      '@smithy/credential-provider-imds': 4.3.9
+      '@smithy/types': 4.14.4
+      tslib: 2.8.1
+    dev: false
+
   /@aws-sdk/credential-provider-login@3.972.45:
     resolution: {integrity: sha512-MZQv4SNjByk1iOKmrqmzcUF/uCB05wjvEHyXKxmGQTUANTIVayX6HPUF0bzkWLvtnkH7sAn9kUCfkXbSpj9sDA==}
     engines: {node: '>=20.0.0'}
@@ -1586,6 +1666,18 @@ packages:
       '@aws-sdk/types': 3.973.9
       '@smithy/core': 3.24.5
       '@smithy/types': 4.14.2
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/credential-provider-login@3.972.52:
+    resolution: {integrity: sha512-9hu2oR0qH7Fst5Tzdx+UWxm+w5zCXtErTLtOOW5hwwQc170CLwOeniRxyFY6s9mHfGEfC5zFukNBdKBwJR8mhQ==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      '@aws-sdk/core': 3.974.20
+      '@aws-sdk/nested-clients': 3.997.20
+      '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.7
+      '@smithy/types': 4.14.4
       tslib: 2.8.1
     dev: false
 
@@ -1606,6 +1698,23 @@ packages:
       tslib: 2.8.1
     dev: false
 
+  /@aws-sdk/credential-provider-node@3.972.55:
+    resolution: {integrity: sha512-zMGLa/dhESVqmCD7mmIFFKSwSFrJGScvCXcjvBZEVOOMauFS5JRQvLTMukFpMEFWiV6dTAlsen2ATDBulLPtbg==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.46
+      '@aws-sdk/credential-provider-http': 3.972.48
+      '@aws-sdk/credential-provider-ini': 3.972.53
+      '@aws-sdk/credential-provider-process': 3.972.46
+      '@aws-sdk/credential-provider-sso': 3.972.52
+      '@aws-sdk/credential-provider-web-identity': 3.972.52
+      '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.7
+      '@smithy/credential-provider-imds': 4.3.9
+      '@smithy/types': 4.14.4
+      tslib: 2.8.1
+    dev: false
+
   /@aws-sdk/credential-provider-process@3.972.41:
     resolution: {integrity: sha512-7I/n1zkysouLOWvkEhjNEP4vMnD2v4kzzr3/3QBdrripEpn7ap1/I5DF3Hou1SUqkKWo1f3oPGMyFAA1FAMvsQ==}
     engines: {node: '>=20.0.0'}
@@ -1614,6 +1723,17 @@ packages:
       '@aws-sdk/types': 3.973.9
       '@smithy/core': 3.24.5
       '@smithy/types': 4.14.2
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/credential-provider-process@3.972.46:
+    resolution: {integrity: sha512-VUoNFBIjWrUN8NbFiQiuxQEgFjvziAlBRPK+ddh27aj65gk0BYu6bLZnrdrNZwpW6vAihtSUtEMQ1PUJ32QRPA==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      '@aws-sdk/core': 3.974.20
+      '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.7
+      '@smithy/types': 4.14.4
       tslib: 2.8.1
     dev: false
 
@@ -1630,6 +1750,19 @@ packages:
       tslib: 2.8.1
     dev: false
 
+  /@aws-sdk/credential-provider-sso@3.972.52:
+    resolution: {integrity: sha512-nb2/n4o/HQf+FVpVbZe9vCTFngmuDoIsltMgLAtjixaKzvzhB4J8WSDFyWgnErgLHk55ctWH+I4PU+LIHhyffg==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      '@aws-sdk/core': 3.974.20
+      '@aws-sdk/nested-clients': 3.997.20
+      '@aws-sdk/token-providers': 3.1066.0
+      '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.7
+      '@smithy/types': 4.14.4
+      tslib: 2.8.1
+    dev: false
+
   /@aws-sdk/credential-provider-web-identity@3.972.45:
     resolution: {integrity: sha512-CDhzKdb2onv5bpnjn/acgdNmJOQthPDLsPizU7rZflsEcgMMp8Mlri+U5hdxf8ldvZJpvM3vLU6D56vfJm5AMQ==}
     engines: {node: '>=20.0.0'}
@@ -1639,6 +1772,28 @@ packages:
       '@aws-sdk/types': 3.973.9
       '@smithy/core': 3.24.5
       '@smithy/types': 4.14.2
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/credential-provider-web-identity@3.972.52:
+    resolution: {integrity: sha512-lKj6aRSGbqLmpYmM24bY7a1Xmfcq2vkE3hv8CSPYfc1yCu0BPu/XEJ1L4Fm61MsU6ULLNSG8UGsffNoFUBjESA==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      '@aws-sdk/core': 3.974.20
+      '@aws-sdk/nested-clients': 3.997.20
+      '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.7
+      '@smithy/types': 4.14.4
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/eventstream-handler-node@3.972.21:
+    resolution: {integrity: sha512-mVC0hOmwGJmNFezZ+wM8Sqfap/LjsMavEf2Evl0YWrLAcrdZOEdjnY8nRvgakVViWJSGm2eJxLuPVHGdeV06kA==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.7
+      '@smithy/types': 4.14.4
       tslib: 2.8.1
     dev: false
 
@@ -1665,6 +1820,16 @@ packages:
       '@aws-sdk/types': 3.973.9
       '@smithy/core': 3.24.5
       '@smithy/types': 4.14.2
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/middleware-eventstream@3.972.17:
+    resolution: {integrity: sha512-tdbnXbw73ww62ABWP0G0Z/euvFowEEvAoi/zG4NaZo7HJFpfGho/Z65HyVzkJLT1cMsUregr4pTyxljlarT0wA==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.7
+      '@smithy/types': 4.14.4
       tslib: 2.8.1
     dev: false
 
@@ -1723,6 +1888,19 @@ packages:
       tslib: 2.8.1
     dev: false
 
+  /@aws-sdk/middleware-websocket@3.972.28:
+    resolution: {integrity: sha512-SCW06Zjugn86pq7+dxGnFcyWJuEWHT753HTU/Vj/OzVxP+NoShwdAr4ynxAcvWL883OgRVbSqW3ohnjIxwXjjw==}
+    engines: {node: '>= 14.0.0'}
+    dependencies:
+      '@aws-sdk/core': 3.974.20
+      '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.7
+      '@smithy/fetch-http-handler': 5.4.7
+      '@smithy/signature-v4': 5.4.7
+      '@smithy/types': 4.14.4
+      tslib: 2.8.1
+    dev: false
+
   /@aws-sdk/nested-clients@3.997.13:
     resolution: {integrity: sha512-2pA6eyb5nSo/ZD2cayhOTEMoGQYgspq0RI05GDLkzQ3ajZ6isS6waV6E92Am/hz4LIlLUTrbwPLurJ/fuiHvkg==}
     engines: {node: '>=20.0.0'}
@@ -1739,6 +1917,22 @@ packages:
       tslib: 2.8.1
     dev: false
 
+  /@aws-sdk/nested-clients@3.997.20:
+    resolution: {integrity: sha512-IYJuLpXp2DEILVQpQOy0PMpkftv0AHEOCn52o0atyOaumA0CdWQ3klPyXdViGYLbNpESsVFMVybvHUeZAuiGxA==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.20
+      '@aws-sdk/signature-v4-multi-region': 3.996.34
+      '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.7
+      '@smithy/fetch-http-handler': 5.4.7
+      '@smithy/node-http-handler': 4.7.8
+      '@smithy/types': 4.14.4
+      tslib: 2.8.1
+    dev: false
+
   /@aws-sdk/signature-v4-multi-region@3.996.30:
     resolution: {integrity: sha512-HULDLMVzkmTSEv6//7kx2kRevp/VYUpm8hJNNFbmhxDn0fUiGTxVcM9yg31TukvTq8nyOBDUN2gH0o5IRbKjdw==}
     engines: {node: '>=20.0.0'}
@@ -1746,6 +1940,16 @@ packages:
       '@aws-sdk/types': 3.973.9
       '@smithy/signature-v4': 5.4.5
       '@smithy/types': 4.14.2
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/signature-v4-multi-region@3.996.34:
+    resolution: {integrity: sha512-mx1L5qlumSOt/nKM3BFaHE2HVkWwz0i4Bw0pyYO42FfX/FeLlo8YI6csC0gSPprEk6fTIqI+CZN9RwUwKd5krQ==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      '@aws-sdk/types': 3.973.12
+      '@smithy/signature-v4': 5.4.7
+      '@smithy/types': 4.14.4
       tslib: 2.8.1
     dev: false
 
@@ -1758,6 +1962,38 @@ packages:
       '@aws-sdk/types': 3.973.9
       '@smithy/core': 3.24.5
       '@smithy/types': 4.14.2
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/token-providers@3.1066.0:
+    resolution: {integrity: sha512-UqEUJq7dqa44hneLDUcX7UJy95cg8YqEWyakRpvIPnrNS3Mq+UlQHgCDGu5pvwAPtlIW4qcYbvW6reG6++FyvA==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      '@aws-sdk/core': 3.974.20
+      '@aws-sdk/nested-clients': 3.997.20
+      '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.7
+      '@smithy/types': 4.14.4
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/token-providers@3.1068.0:
+    resolution: {integrity: sha512-GWJ20HF5SBa5pSwMdxlZG/5kjncao4nxUYcNjOA/Xw/t/rATxc7bRk9A4U1HYdDO1a1CK1pswliVxcV8IJvmjw==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      '@aws-sdk/core': 3.974.20
+      '@aws-sdk/nested-clients': 3.997.20
+      '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.7
+      '@smithy/types': 4.14.4
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/types@3.973.12:
+    resolution: {integrity: sha512-43ajd1NF0RMgX5k0hxCNUyEdrtFUsb2aHT2QvpktSC/2Eyb2Jr/JPVqdp0XIoaHWikZJq5tNWSLO6kB5q2eMCA==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      '@smithy/types': 4.14.4
       tslib: 2.8.1
     dev: false
 
@@ -1781,6 +2017,15 @@ packages:
     engines: {node: '>=20.0.0'}
     dependencies:
       '@smithy/types': 4.14.2
+      fast-xml-parser: 5.7.3
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/xml-builder@3.972.29:
+    resolution: {integrity: sha512-fk0niuGFxfi8yIJuMVM4mhwObkiQSuwZFj3tAPrLVx64Pk3BkrEIpqjzHKY4hKoEBUD6Jg/S74Zj9jy+5F3DnQ==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      '@smithy/types': 4.14.4
       fast-xml-parser: 5.7.3
       tslib: 2.8.1
     dev: false
@@ -10422,6 +10667,15 @@ packages:
       tslib: 2.8.1
     dev: false
 
+  /@smithy/core@3.24.7:
+    resolution: {integrity: sha512-KoUi4M1f3BG6kzN1FnCwL7oyFptTbyBJKjR6yhSib+JHRdUmM1o+VwsFtJ66NZCkCzVfJMWRHJNo0R0jznp0Pg==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@smithy/types': 4.14.4
+      tslib: 2.8.1
+    dev: false
+
   /@smithy/credential-provider-imds@4.3.6:
     resolution: {integrity: sha512-tHhdiWZfG1ZIh2YcRfPJmY2gHcBmqbAzqm3ER4TIDFYsSEqTD5tICT7cgQ/kI8LRakxp12myOYyK68XPn7MnHw==}
     engines: {node: '>=18.0.0'}
@@ -10431,12 +10685,30 @@ packages:
       tslib: 2.8.1
     dev: false
 
+  /@smithy/credential-provider-imds@4.3.9:
+    resolution: {integrity: sha512-ZlfJ/4Fa3jYb+3eaohPfG9utX9HmdhFNcFtpoGAhUhdynAOmGXtmigbi7eEiONKM+ykHw8RwKuDEb85Lx7t7fA==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/core': 3.24.7
+      '@smithy/types': 4.14.4
+      tslib: 2.8.1
+    dev: false
+
   /@smithy/fetch-http-handler@5.4.5:
     resolution: {integrity: sha512-SK3VMeH0fibgdTg2QeB+O4p7Yy/2E5HBOHJeC58FshkDdeuX8lOgO7PfjYfLyPLP1ch55j91cQqKBzDS0mRjSQ==}
     engines: {node: '>=18.0.0'}
     dependencies:
       '@smithy/core': 3.24.5
       '@smithy/types': 4.14.2
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/fetch-http-handler@5.4.7:
+    resolution: {integrity: sha512-NslaM2ir0N2hisDmzXLstPaVINZheh8SokyOC++kzFPloZucL2R7Y7bS57mSzx/1Fc/fqmn7twjkeezTTrV0EA==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/core': 3.24.7
+      '@smithy/types': 4.14.4
       tslib: 2.8.1
     dev: false
 
@@ -10456,6 +10728,15 @@ packages:
       tslib: 2.8.1
     dev: false
 
+  /@smithy/node-http-handler@4.7.8:
+    resolution: {integrity: sha512-f+DbsWUwSbtMu1a/j8Y93KiU1SRg9nyzfjereqn1BJ33QOTUXxdlYvVXMhAYl1vuR1Kmna5aIJe09KSIfyFNYw==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/core': 3.24.7
+      '@smithy/types': 4.14.4
+      tslib: 2.8.1
+    dev: false
+
   /@smithy/signature-v4@5.4.5:
     resolution: {integrity: sha512-QBJKWGqIknH0dc9LWpfH1mkdokAx6iXYN3UcQ3eY6uIEyScuoQAhfl94ge7ozUy9WgFUdE8xsvwBjaYBbWmPNA==}
     engines: {node: '>=18.0.0'}
@@ -10465,8 +10746,24 @@ packages:
       tslib: 2.8.1
     dev: false
 
+  /@smithy/signature-v4@5.4.7:
+    resolution: {integrity: sha512-LwQZazFayImv+IOm0S0enoLeUJwmAlhGC5O6YCcLWezyu08dF46GOxPOq35OpBIHkgd7OvNvBStIFwVNyrvoBw==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/core': 3.24.7
+      '@smithy/types': 4.14.4
+      tslib: 2.8.1
+    dev: false
+
   /@smithy/types@4.14.2:
     resolution: {integrity: sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/types@4.14.4:
+    resolution: {integrity: sha512-B2S9+UGm1+/pHkcx3ZoLVX1a+pmSk8rqxRR+ZsNqZaJ5q9FWX9AFGQVM4qG5+OBeQUZVy99HY8HqW8gK/wgXzQ==}
     engines: {node: '>=18.0.0'}
     dependencies:
       tslib: 2.8.1


### PR DESCRIPTION
## What

Reintroduces **AWS Bedrock** as a backend for the managed LLM Gateway (`/v1/llm`), surfaced under the existing **`kortix/`** OpenCode provider. OpenRouter stays the default; any model whose id starts with `bedrock/` (e.g. `kortix/bedrock/anthropic/claude-opus-4.8`) is served via Bedrock's **Converse / ConverseStream** API when `BEDROCK_ENABLED=true`.

Both backends run behind the **same** route, auth, billing gate, and usage-accounting pipeline. Usage events are tagged `provider: 'bedrock'` vs `provider: 'openrouter'` so spend is attributable per backend.

## How

New files under `apps/api/src/llm-gateway/services/`:

- **`bedrock-translate.ts`** — *pure* OpenAI↔Converse translation (no SDK imports, fully unit-tested): messages, system prompts, tools & tool-calls, base64 images, Anthropic extended thinking, and a streaming translator that turns Converse stream events into OpenAI `chat.completion.chunk` SSE.
- **`bedrock-models.ts`** — maps logical ids → Bedrock cross-region inference-profile ids (`us.anthropic.claude-...`) + per-model fallback pricing. The `bedrock/` prefix is the routing key.
- **`bedrock-client.ts`** — thin `@aws-sdk/client-bedrock-runtime` wrapper (lazy, memoized client; swappable senders for tests).
- **`bedrock-handler.ts`** — completion orchestration, mirroring the OpenRouter handler's stream-disconnect handling so usage is still captured if the client drops mid-stream.

Wiring:
- `routes/chat-completions.ts` branches on backend; `finalize()` is now provider-aware.
- `pricing.ts` consults the Bedrock registry for `bedrock/*` models.
- `config.ts` + `index.ts`: `BEDROCK_ENABLED`, `BEDROCK_REGION` (default `us-west-2`), `AWS_ACCESS_KEY_ID/SECRET/SESSION_TOKEN`. Creds fall back to the **AWS default chain** (env vars, EKS IRSA / instance role) when static keys are unset — the prod path on our EKS nodes.
- `opencode.ts`: `bedrock/*` models added to the `kortix` provider catalog so they appear in the model selector.
- `routes/health.ts` surfaces `{ bedrock: { enabled, region } }`.

## Models exposed

Claude Opus 4.8 / Sonnet 4.6 / Haiku 4.5, Llama 4 Maverick & Scout, Amazon Nova Pro & Lite, DeepSeek R1 — all via Bedrock inference profiles in `us-west-2`.

## Testing

- **21 new tests** (`bedrock-translate.test.ts`, `bedrock-gateway.test.ts`): translation (messages/tools/images/reasoning), streaming SSE, end-to-end routing (non-stream + stream), the disabled-fallthrough path, unknown-model 400, and pricing.
- Registry assertions added to `executor-mcp-config.test.ts`.
- Full gateway suite (56 pass) + sandbox-agent-server suite green; `tsc --noEmit` clean for both packages.

## Config to enable

```
BEDROCK_ENABLED=true
BEDROCK_REGION=us-west-2
# AWS creds optional — default chain (EKS IRSA / instance role) used when unset.
# The role needs bedrock:InvokeModel / InvokeModelWithResponseStream.
```
