### PR TITLE
chore(dev-eks): disable experimental warm snapshots — pool-only on dev

### DIFF
--- a/infra/k8s/envs/dev/values.yaml
+++ b/infra/k8s/envs/dev/values.yaml
@@ -10,6 +10,14 @@ image:
 kortixVersion: ""
 env:
   internalKortixEnv: dev
+# Pool-only mode: disable the experimental Daytona memory-snapshot path on dev.
+# It depends on the flaky experimental region and doesn't beat the warm pool
+# (which runs on the reliable region). Rendered as explicit container env, so it
+# OVERRIDES whatever the synced kortix-dev-env secret bundle carries (k8s env
+# wins over envFrom). Flip back to "true" only once Daytona stabilizes the
+# experimental region.
+extraEnv:
+  KORTIX_WARM_SNAPSHOT_ENABLED: "false"
 # PRE-CUTOVER: dev-api-eks is the candidate while dev-api.kortix.com is still
 # served by ECS, so EKS runs API-only and ECS keeps ownership of the dev-tier
 # singleton workers (one Postgres leader lease is shared across both on the dev


### PR DESCRIPTION
## What
One-line GitOps change: disable the experimental Daytona warm-snapshot path on dev (`KORTIX_WARM_SNAPSHOT_ENABLED=false`) via `infra/k8s/envs/dev/values.yaml` `extraEnv`.

## Why this PR (and why re-deploying didn't work)
The flag was flipped to `false` in the `kortix-dev-env` Secrets Manager bundle, but the live EKS pods never picked it up: a pod reads its env once at startup, and re-running the dev deploy is a no-op (the workflow skips when `image.tag` already matches the current SHA, so Argo reconciles nothing and pods don't restart).

This change edits `values.yaml`, so merging it produces a new commit → new image tag → Argo CD reconciles → pods restart. And because `extraEnv` renders as explicit container env, it **overrides** the secret bundle (k8s `env` wins over `envFrom`), so it takes effect regardless of External-Secrets resync timing.

## Effect
Dev runs pool-only on the reliable region (the warm pool already gives ~1.6s sessions; the experimental path doesn't beat it and depends on the flaky experimental region). Flip back to `"true"` only once Daytona stabilizes experimental.
