### PR TITLE
feat(git): code.storage (Pierre) managed git backend

### DIFF
--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -113,6 +113,16 @@ const envSchema = z.object({
   // over the GitHub App for managed-org admin ops (create/delete repo, invite
   // collaborator). Leave blank to use the App installation instead.
   MANAGED_GIT_GITHUB_TOKEN:        optStr,
+  // code.storage (Pierre) managed backend (apps/api/src/projects/git-backends/code-storage.md).
+  // Real git repos behind customer-signed ES256 JWTs — we hold the private key,
+  // code.storage verifies with the public key registered in the Pierre Admin
+  // Panel. _ORG is the org slug (the JWT `iss` + the `<org>.code.storage`
+  // subdomain); _PRIVATE_KEY is the EC P-256 PEM. _API_URL / _GIT_HOST override
+  // the derived `https://api.<org>.code.storage` / `<org>.code.storage` hosts.
+  MANAGED_GIT_CODESTORAGE_ORG:         optStr,
+  MANAGED_GIT_CODESTORAGE_PRIVATE_KEY: optStr,
+  MANAGED_GIT_CODESTORAGE_API_URL:     optStr,
+  MANAGED_GIT_CODESTORAGE_GIT_HOST:    optStr,
   // When true, runtime clients (sandbox + `kortix` CLI) use the Kortix git
   // proxy as their git origin (auth = KORTIX_TOKEN) instead of the real host —
   // so a real GitHub credential never reaches a sandbox. Requires a
@@ -483,6 +493,10 @@ export const config = {
   MANAGED_GIT_GITHUB_OWNER: env.MANAGED_GIT_GITHUB_OWNER,
   MANAGED_GIT_GITHUB_INSTALL_ID: env.MANAGED_GIT_GITHUB_INSTALL_ID,
   MANAGED_GIT_GITHUB_TOKEN: env.MANAGED_GIT_GITHUB_TOKEN,
+  MANAGED_GIT_CODESTORAGE_ORG: env.MANAGED_GIT_CODESTORAGE_ORG,
+  MANAGED_GIT_CODESTORAGE_PRIVATE_KEY: env.MANAGED_GIT_CODESTORAGE_PRIVATE_KEY,
+  MANAGED_GIT_CODESTORAGE_API_URL: env.MANAGED_GIT_CODESTORAGE_API_URL,
+  MANAGED_GIT_CODESTORAGE_GIT_HOST: env.MANAGED_GIT_CODESTORAGE_GIT_HOST,
   KORTIX_GIT_PROXY: env.KORTIX_GIT_PROXY,
   KORTIX_WARM_POOL_SIZE: env.KORTIX_WARM_POOL_SIZE,
   KORTIX_WARM_POOL_MAX_TOTAL: env.KORTIX_WARM_POOL_MAX_TOTAL,

--- a/apps/api/src/projects/git-backends/code-storage.md
+++ b/apps/api/src/projects/git-backends/code-storage.md
@@ -1,0 +1,391 @@
+# code.storage (Pierre) managed git backend — spec
+
+Status: **proposed** · Owner: marko · Date: 2026-06-15
+
+Add **code.storage** (by [Pierre](https://pierre.co), package `@pierre/storage`) as a
+`GitHostBackend` so Kortix-provisioned ("managed") repos live on code.storage instead of
+the `managed-kortix` GitHub org. This is a drop-in alongside the existing `github` backend —
+the registry, proxy, sandbox, CLI, and DB schema are already provider-agnostic.
+
+---
+
+## 1. What code.storage is (investigation summary)
+
+A **managed git infrastructure layer**: real git repos with standard semantics, exposed via
+an HTTP API + SDKs (TS `@pierre/storage`, Python, Go) **and** smart-HTTP git transport over
+HTTPS. It's built for exactly our use case — programmatic repo creation and agent/sandbox
+workflows — and the docs ship first-class **Daytona / E2B / Modal sandbox** examples.
+
+Key properties that matter to us:
+
+- **Repos**: created via API/SDK with a custom id that may be namespaced with `/`
+  (e.g. `kortix/<projectId>`). `createRepo({ id })` → `{ repo_id, http_url }`.
+- **Auth = customer-signed JWT.** *We* hold the private key; code.storage verifies with the
+  public key we register in the Pierre Admin Panel. Algorithm **ES256** (our key is EC P-256)
+  or RS256. No OAuth, no installation tokens, no per-request network round-trip to mint creds.
+  - JWT claims: `iss` (org), `sub` (agent identity, for audit), `repo` (target repo; omitted
+    only for `org:read`), `scopes` (array), `iat`, `exp` (TTL, default 1y, set short for us).
+  - Scopes: `git:read` (clone/fetch/pull), `git:write` (push, includes read),
+    `repo:write` (create repos), `org:read` (list repos, org-wide).
+- **Git transport**: `https://t:<JWT>@<org>.code.storage/<repoId>.git` — basic auth, username
+  literal `t`, password = the signed JWT. Standard `git clone/fetch/push`.
+- **HTTP API base**: `https://api.<org>.code.storage/api`, `Authorization: Bearer <JWT>`,
+  cursor pagination, error `{ "error": "..." }` (branch on status, not message). `409` =
+  "repository sync in progress, retry shortly" during initial sync.
+- **Ephemeral branches**: first-class temporary namespace + `getEphemeralRemoteURL()` +
+  `promoteEphemeralBranch({ baseBranch, targetBranch })`. **This maps 1:1 onto Kortix
+  sessions** (a session = an ephemeral branch promoted into a change-request branch).
+- **Forking**: `createRepo({ baseRepo: { id, ref?|sha?, operation: 'fork' } })` — independent
+  copy at a point in time. Useful for warm-snapshot / template provisioning.
+- **GitHub integration (optional)**: code.storage can *sync bidirectionally* with a GitHub
+  repo via a GitHub App you configure in its dashboard (App ID + private key + webhook secret —
+  the "Integrations" screen). `createRepo({ baseRepo: { provider:'github', owner, name,
+  operation:'sync' } })` + `pullUpstream()`. GitHub stays authoritative; pushes to code.storage
+  are proxied through to GitHub. **This is how we keep a github.com/managed-kortix mirror if we
+  want one — but it is optional and a later phase, not required.**
+- **Imports**: migrate an existing repo (history + tags) by pushing to a `<repoId>+import.git`
+  remote (`getImportRemoteURL()`), then it's cold-archived to S3.
+- **Webhooks**: `push`, `repo.sync.{started,succeeded,failed}`. HMAC-SHA256 over
+  `timestamp + "." + payload`, header `X-Pierre-Signature: t=<ts>,sha256=<sig>`,
+  `X-Pierre-Event: <type>`. SDK `validateWebhook()`.
+- **MCP / docs**: `claude mcp add --transport http code-storage https://code.storage/docs/mcp`
+  (docs search only — not an action surface).
+
+Full doc index: `https://code.storage/docs/llms.txt`.
+
+---
+
+## 2. Architecture decision
+
+**Recommended: Model A — code.storage *is* the managed host.** New managed repos are created on
+code.storage; sandboxes clone/push code.storage; GitHub `managed-kortix` is no longer in the
+provisioning path. Optional Model-B GitHub mirroring (code.storage→GitHub sync) is a later,
+additive phase that does not change the core integration.
+
+Why A:
+
+- **Clean fit.** The whole point of the `GitHostBackend` interface + Kortix git proxy is
+  provider independence. code.storage slots in with **zero changes** to the proxy, sandbox
+  daemon, sessions, CLI, or DB schema.
+- **Removes the recent failure mode.** Managed GitHub provisioning has bitten us twice (502s
+  from quoted private keys / installation-token + org-PAT capability gaps — see
+  `project_provision_502_managed_git`). code.storage `buildUpstream` **self-signs a JWT
+  locally** — no network call, no installation/PAT dance, no external token store.
+- **Ephemeral branches = sessions.** code.storage's ephemeral-branch + promote model is exactly
+  Kortix's session→change-request model. Strong long-term lever.
+- **Forking** is first-class → cheaper warm-snapshot / templated project provisioning.
+
+Trade-offs / risks to accept:
+
+- New external dependency on code.storage availability for provisioning + git transport. The
+  proxy already centralizes this, so failures are observable in one place.
+- `409 sync in progress` on first create — needs retry/poll (only relevant if we use Model-B
+  GitHub-backed repos; pure code.storage repos create immediately).
+- Public-key registration is a **manual, out-of-band step** in the Pierre Admin Panel.
+
+---
+
+## 3. Integration design
+
+### 3.1 New file: `apps/api/src/projects/git-backends/code-storage.ts`
+
+Implements `GitHostBackend` (`id: 'codestorage'`). Self-contained: a tiny ES256 JWT signer +
+raw `fetch` HTTP client, matching house style (the GitHub backend hand-rolls RS256 + `ghFetch`,
+no Octokit). No `@pierre/storage` dependency required (see §3.6 for the SDK alternative).
+
+```ts
+// env helpers
+function csOrg(): string | null            // MANAGED_GIT_CODESTORAGE_ORG  (e.g. "kortix")
+function csPrivateKey(): string | null     // MANAGED_GIT_CODESTORAGE_PRIVATE_KEY (PEM, EC P-256)
+function csApiBase(): string               // MANAGED_GIT_CODESTORAGE_API_URL ?? `https://api.${org}.code.storage`
+function csGitHost(): string               // MANAGED_GIT_CODESTORAGE_GIT_HOST ?? `${org}.code.storage`
+
+// ES256 JWT — NOTE the dsaEncoding gotcha (§3.3)
+function signCsJwt(claims: { sub?: string; repo?: string; scopes: string[]; ttlSec: number }): string
+
+const codeStorageBackend: GitHostBackend = {
+  id: 'codestorage',
+
+  async isConfigured() { return Boolean(csOrg() && csPrivateKey()); },
+
+  // POST {apiBase}/repos  Bearer <org JWT scopes:['repo:write']>
+  // body: { id: `kortix/${input.projectId}`, default_branch: input.defaultBranch }
+  // → { repo_id, http_url }
+  async createRepo(input) {
+    const repoId = `kortix/${input.projectId}`;
+    const res = await csFetch('/repos', { method:'POST', body:{ id: repoId, default_branch: input.defaultBranch } },
+                              signCsJwt({ scopes:['repo:write'], ttlSec: 120 }));
+    return {
+      provider: 'codestorage',
+      upstreamUrl: `https://${csGitHost()}/${repoId}.git`,   // canonical https git url (no creds)
+      externalRepoId: res.repo_id,
+      repoOwner: csOrg(), repoName: repoId,
+      installationId: null, credentialRef: null,
+      defaultBranch: input.defaultBranch, initialToken: null,
+    };
+  },
+
+  // DELETE {apiBase}/repos/{repoId}
+  async deleteRepo(ref) { /* signCsJwt repo-scoped repo:write, DELETE */ },
+
+  // The seam the proxy consumes. SELF-SIGNS a short-TTL repo+scope JWT and returns
+  // basic-auth headers. `token` arg is ignored (resolveProjectGitAuth returns 'none' for us).
+  buildUpstream(ref, _token, scope) {
+    const jwt = signCsJwt({
+      repo: ref.repoName ?? repoIdFromUrl(ref.upstreamUrl),
+      scopes: scope === 'write' ? ['git:read','git:write'] : ['git:read'],
+      ttlSec: 300,
+    });
+    const basic = Buffer.from(`t:${jwt}`).toString('base64');
+    return { url: ref.upstreamUrl, headers: { Authorization: `Basic ${basic}` } };
+  },
+
+  // Reuse seedRepoViaGitPush (it just does an https git push with header auth) —
+  // pass it a self-signed write JWT instead of a GitHub token.
+  async seedFiles(ref, _token, files, opts) {
+    const jwt = signCsJwt({ repo: ref.repoName, scopes:['git:read','git:write'], ttlSec: 300 });
+    await seedRepoViaGitPush({ upstreamUrl: ref.upstreamUrl, token: jwt, /* username 't' */ ... });
+  },
+
+  // authedPushUrl: `https://t:${jwt}@${gitHost}/${repoId}.git`  (for legacy/external push)
+  // inviteCollaborator: N/A for code.storage (no per-user github accounts) — omit.
+};
+```
+
+### 3.2 Register it — `registry.ts`
+
+```ts
+import { codeStorageBackend } from './code-storage';
+const backends = new Map<string, GitHostBackend>([
+  [githubBackend.id, githubBackend],
+  [codeStorageBackend.id, codeStorageBackend],   // <-- add
+]);
+```
+
+Set `MANAGED_GIT_PROVIDER=codestorage` to make NEW projects provision on code.storage.
+Existing GitHub-managed projects keep resolving through the `github` backend because
+`provider` is stored per-row in `project_git_connections` — **both run simultaneously**.
+
+### 3.3 The ES256 JWT gotcha (must-fix footgun)
+
+Node's `crypto.sign` for EC keys emits a **DER-encoded** signature, but JOSE/ES256 requires the
+**raw `R||S`** form (64 bytes). Use `dsaEncoding: 'ieee-p1363'`:
+
+```ts
+const sig = crypto.sign('sha256', Buffer.from(`${b64(header)}.${b64(payload)}`),
+                        { key: privateKey, dsaEncoding: 'ieee-p1363' });
+// header: { alg: 'ES256', typ: 'JWT' }   payload: { iss: org, sub, repo, scopes, iat, exp }
+```
+
+Alternatively depend on `jose` (`new SignJWT(...).setProtectedHeader({alg:'ES256'}).sign(key)`),
+which handles this correctly — preferred if we don't want to hand-roll. (Check whether `jose`
+is already in the api workspace before adding.)
+
+### 3.4 Config / env — `apps/api/src/config.ts`
+
+Add to the env schema (~line 108) and the export (~line 485), mirroring the `MANAGED_GIT_GITHUB_*` block:
+
+| Var | Meaning | Example |
+|---|---|---|
+| `MANAGED_GIT_PROVIDER` | switch default managed backend | `codestorage` |
+| `MANAGED_GIT_CODESTORAGE_ORG` | code.storage org slug (the `iss` + subdomain) | `kortix` |
+| `MANAGED_GIT_CODESTORAGE_PRIVATE_KEY` | EC P-256 PEM, signs JWTs | *(stored, encrypted)* |
+| `MANAGED_GIT_CODESTORAGE_API_URL` | optional API base override | `https://api.kortix.code.storage` |
+| `MANAGED_GIT_CODESTORAGE_GIT_HOST` | optional git host override | `kortix.code.storage` |
+
+**Already done:** `MANAGED_GIT_CODESTORAGE_PRIVATE_KEY` is stored (dotenvx-encrypted) in
+`apps/api/.env` and `.env.dev`. Prod = AWS Secrets Manager (not yet set). The registered
+**public key** is in §6.
+
+### 3.5 No changes needed in proxy / sandbox / sessions / DB
+
+Verified read-through of the live code:
+
+- **Proxy** (`git-proxy/index.ts`) calls `resolveProjectUpstream` → `getBackend(ref.provider)`
+  → `buildUpstream`. Provider-neutral. ✔
+- **`resolveProjectUpstream`** (`lib/git.ts:513`) already calls `getBackend(ref.provider)`. It
+  calls `resolveProjectGitAuth` first; for `codestorage` that returns `{ authSource:'none' }`
+  (token `null`) — fine, because our `buildUpstream` self-signs. ✔
+- **Sandbox** (`sessions.ts:200`, daemon `git.ts`) uses proxy mode (`KORTIX_GIT_PROXY=true`):
+  `KORTIX_REPO_URL = <api>/v1/git/<projectId>.git`, auth = `KORTIX_TOKEN`. The real code.storage
+  JWT never enters the sandbox. **Zero sandbox changes** when proxy mode is on. ✔
+  - The proxy forwards to code.storage with `fetch` (not a `git` subprocess) using
+    `buildUpstream`'s `Authorization: Basic <base64('t:'+jwt)>` header. **Validated live**:
+    code.storage's `info/refs` + upload-pack/receive-pack return `200` to header auth via fetch
+    (see §10). The sandbox's `git` only ever speaks to the Kortix proxy with `KORTIX_TOKEN`.
+- **DB** (`project_git_connections`, `projects.metadata.git`) stores `provider`, `managed`,
+  `upstreamUrl`, `externalRepoId`, `repoOwner`, `repoName`, `authMethod`. All provider-opaque —
+  **no migration**. Managed code.storage rows: `provider:'codestorage'`, `managed:true`,
+  `authMethod:'managed'`, `upstreamUrl: https://kortix.code.storage/<projectId>.git`
+  (bare projectId — the org is the subdomain; no path namespace). ✔
+
+### 3.6 SDK alternative (`@pierre/storage`)
+
+Instead of hand-rolling, depend on `@pierre/storage` and back the methods with
+`new GitStorage({ name: org, key: privateKey })`: `store.createRepo({ id })`,
+`repo.getRemoteURL({ permissions, ttl })`, `repo.getEphemeralRemoteURL(...)`,
+`repo.promoteEphemeralBranch(...)`, `validateWebhook(...)`. Pros: handles ES256 + 409 retries +
+URL building. Cons: new dep, async `buildUpstream` (interface is sync today — would need the URL
+pre-minted or the method made async). **Recommendation:** hand-roll the 2 hot paths
+(`buildUpstream` sign + `createRepo` POST) to keep `buildUpstream` synchronous and dependency-free,
+and optionally pull the SDK in later for ephemeral/promote/webhook helpers.
+
+---
+
+## 4. Direct-mode clone credential (only if `KORTIX_GIT_PROXY=false`)
+
+Today only managed GitHub returns a token from `resolveProjectGitAuth`. If we ever run sandboxes
+in direct mode (no proxy), add a `codestorage` branch to `resolveProjectGitAuth` (and the
+`/projects/:id/git/clone-credential` endpoint) that returns a self-signed repo-scoped
+`git:read[,git:write]` JWT. **Not needed for proxy mode**, which is the default.
+
+⚠️ **Direct-mode `git` gotcha (validated):** code.storage works with a real `git clone/push`
+**only with creds embedded in the URL** (`https://t:<jwt>@kortix.code.storage/<id>.git`), so
+libcurl answers the `401 Basic realm="Git Repository"` challenge natively. The daemon's current
+`http.extraheader` scheme (`buildGitAuthArgs`, lowercase `basic`) does **not** satisfy that
+challenge and `git` stalls/then asks for a password. So a future direct-mode codestorage path must
+use creds-in-URL (which `authedPushUrl` already produces), not extraheader. The proxy path is
+unaffected — it uses `fetch`, and header auth (capital `Basic`) returns `200`.
+
+### 4.1 Host-side mirror (`projects/git/mirror.ts`) — FIXED for code.storage
+
+`mirror.ts` keeps a host-side bare clone per project (used by the **template prebuild** AND the
+**file/version/checkpoint viewer**). It authenticated with `http.extraheader` — which code.storage
+rejects (401 Basic challenge), and it *prompted* via an inherited `GIT_ASKPASS` (VS Code/Cursor).
+
+- **Defensive:** `runGit`/`runGitCapture` force `GIT_ASKPASS=''`+`SSH_ASKPASS=''` (+ existing
+  `GIT_TERMINAL_PROMPT=0`) — server-side git can never prompt.
+- **Functional (done):** the mirror now clones/fetches code.storage via **creds-in-URL** (username
+  `t`, password = a freshly-minted repo-scoped JWT) instead of extraheader. The JWT comes from
+  `resolveProjectGitAuth`'s new `codestorage` branch (`mintCodeStorageGitToken`, fresh per call);
+  the bare clone uses the creds-URL then `set-url origin` back to the clean URL (token never
+  persisted), and refresh fetches by explicit creds-URL + refspec. **Verified live:** bare-clone of
+  a real seeded repo returned `[.gitignore, .kortix, README.md, kortix.toml]`. GitHub repos are
+  unchanged (still extraheader).
+
+### 4.2 Clone-URL surfaced to users (web "Develop on your own machine") — FIXED
+
+The dev-view (`apps/web/.../sections/dev-view.tsx`) showed the raw upstream (`repo_url`) — useless
+for code.storage (users can't auth against it). Now: for proxy-backed managed projects
+(`git_origin_url` contains `/v1/git/`) it shows the **Kortix proxy URL** with a token —
+`git clone https://x-access-token:<KORTIX_TOKEN>@<api>/v1/git/<projectId>.git <dir>` — skips the
+GitHub-collaborator step, and notes the token stays in `origin` so push/CR work. `KortixProject`
+gained `git_origin_url`. GitHub/BYO projects keep their existing flow.
+
+---
+
+## 5. Migration of existing managed-kortix GitHub repos
+
+New projects go to code.storage immediately once `MANAGED_GIT_PROVIDER=codestorage`. Existing
+GitHub-managed projects keep working unchanged (per-row `provider`). To move them:
+
+1. `createRepo({ id: '<projectId>' })` on code.storage.
+2. Mirror history via the import remote: clone the GitHub repo `--mirror`, add
+   `https://t:<jwt>@kortix.code.storage/<projectId>+import.git`, `git push import --all && --tags`
+   (creds-in-URL, per §4).
+3. Flip the `project_git_connections` row: `provider→codestorage`, `upstreamUrl→…`, `managed→true`,
+   `authMethod→managed`, null out `installationId`. Update `projects.metadata.git` to match.
+
+A one-off backfill script under `apps/api/scripts/` (dev first). Decide whether to migrate at all
+or only forward-provision new projects (open question §7).
+
+---
+
+## 6. Public key to register in the Pierre Admin Panel
+
+Derived from the stored private key (`openssl pkey -pubout`):
+
+```
+-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEFDBTES98d1mim8WoRyLhwcPa5heN
+hyx2/O46P4aKTtwn1SZdWGbOZxzhRDu20vZjdokXGoWwqMTu4ZmUKPrd7g==
+-----END PUBLIC KEY-----
+```
+
+**Status: registered ✓** — verified live: an `org:read` JWT signed with this key is accepted by
+`https://api.kortix.code.storage` (`200`). No `kid` is required (the JWT header is `alg`+`typ` only).
+
+---
+
+## 7. Decisions (all resolved 2026-06-15)
+
+1. **Org slug** = `kortix` (from the dashboard `new GitStorage({ name: 'kortix' })`). Set in
+   `MANAGED_GIT_CODESTORAGE_ORG`. ✔
+2. **Public key** = registered in the Pierre Admin Panel (verified, §6). ✔
+3. **Model A** (pure code.storage host). ✔
+4. **Forward-only** — existing managed-kortix GitHub projects stay on the `github` backend. ✔
+5. **Hand-rolled JWT** (no `@pierre/storage` dep) — keeps `buildUpstream` synchronous; validated
+   live. ✔
+
+---
+
+## 8. Phased plan
+
+- **P0 — backend + provisioning (core). ✅ BUILT + VALIDATED LIVE (§10).** `code-storage.ts`
+  (`isConfigured`, `createRepo`, `buildUpstream`, `deleteRepo`, `seedFiles` via commit-pack,
+  `authedPushUrl`), registered in `registry.ts`, config env added. **Remaining to go live:** set
+  `MANAGED_GIT_PROVIDER=codestorage` on the target env (deployed dev = ECS/Secrets Manager, not
+  `.env.dev`), then a real provision → session boots → clone/push through the proxy → CR. ke2e.
+- **P1 — sessions on ephemeral branches.** Map session create → `getEphemeralRemoteURL` namespace;
+  CR merge → `promoteEphemeralBranch`. (Optimization; proxy already works without it.)
+- **P2 — GitHub mirror (optional, Model B).** Configure code.storage→GitHub sync + the GitHub
+  App; provision with `baseRepo` sync; handle `409`/sync webhooks.
+- **P3 — migrate existing managed repos** (if decided) via the import-remote backfill.
+
+## 9. Testing
+
+Black-box ke2e (live API, no mocks) per the ke2e suite: provision → repo exists → clone via proxy
+→ push → CR. Run on dev with `MANAGED_GIT_PROVIDER=codestorage`. Keep the GitHub provisioning flow
+green in parallel (both backends registered). Per repo rule, update `spec/end-to-end.md` + route
+manifest if any route shape changes (it should not — provisioning is provider-param'd already).
+
+---
+
+## 10. Validation log (2026-06-15, live against org `kortix`)
+
+Exercised the real backend module (and raw probes) against `api.kortix.code.storage`:
+
+| Fact | Result |
+|---|---|
+| ES256 sign→verify with the stored key | ✓ 64-byte raw R||S (`dsaEncoding:'ieee-p1363'`), verifies vs derived pubkey |
+| Public key registered (org:read accepted) | ✓ `200` |
+| API base | `https://api.kortix.code.storage/api` (NOT `/repos` at root → 404) |
+| Git host | `kortix.code.storage` (`git.code.storage` does NOT resolve) |
+| Repo id / clone url | bare id, `https://kortix.code.storage/<id>.git`; **no** path namespace |
+| Repos addressed by | the human `url` id (what we send as `id`), NOT the opaque `repo_id` |
+| `createRepo` (`POST /api/repos`) | ✓ `201` — needs scope `repo:write` **+ `repo` claim = the new id** (org-wide token → 403) |
+| `commit-pack` seed (`POST /api/repos/{id}/commit-pack`, NDJSON, base64 blobs) | ✓ `201`, `main` then advertised — this is the FIRST-commit path |
+| `info/refs` read/write advertisement via fetch + `Basic` header | ✓ `200` (with or without `Git-Protocol: version=2`) |
+| Raw upload-pack POST via curl + `Basic` header | ✓ `200` in ~0.4s |
+| `deleteRepo` (`DELETE /api/repos/{id}`, `repo:write`+claim) | ✓ `200`; post-delete `info/refs` → `404` |
+| `git clone/push` with creds-in-URL (`t:<jwt>@…`) | ✓ OK (v0 and v2) |
+| `git clone/push` with `http.extraheader` (lowercase `basic`) | ✗ stalls — 401 challenge unsatisfiable (see §4) — **not used by the proxy** |
+
+Net: the entire P0 path (provision → seed → proxy read/write → delete) works with `fetch`-based
+header auth and the commit-pack API. The only thing that doesn't is a *direct* `git` subprocess
+using extraheader — which the proxy architecture never does.
+
+### 10.1 Full-stack local e2e (2026-06-15) — PASSED
+
+Ran the **real Kortix stack** (`pnpm dev`, local Supabase, `MANAGED_GIT_PROVIDER=codestorage`)
+and drove the actual route + proxy with a synth account (ke2e fixtures, flow-registry bypassed):
+
+```
+POST /v1/projects/provision {seed_starter:true}  → 201, project on https://kortix.code.storage/<projectId>.git
+  (backend.createRepo → commit-pack seed of the starter)
+git clone <api>/v1/git/<projectId>.git  (via Kortix proxy, PAT auth)  → OK: [.kortix, kortix.toml, README.md, .gitignore]
+git push origin HEAD:main  (via Kortix proxy)                          → OK
+```
+
+This caught + fixed **two real bugs** (both in `code-storage.ts`, validated):
+1. **PEM normalization** — `dev-local.sh` loads env via `dotenvx get --format eval` + shell `eval`,
+   which delivers the key with **literal `\n`**; Bun's BoringSSL then throws `BAD_END_LINE`.
+   `csPrivateKey()` now `.replace(/\\n/g,'\n')` + strips CR + ensures a trailing newline (mirrors
+   `normalizeGitHubPrivateKey`). Also covers AWS Secrets Manager single-line PEMs.
+2. **Seeding `initialToken`** — the provision route requires a non-null push credential before
+   seeding (`pushToken = provisioned.initialToken ?? resolveProjectGitAuth(...)`); both were null
+   for codestorage. `createRepo` now returns a real repo-scoped `git:write` JWT as `initialToken`
+   (1h TTL), which also serves the response's `push_token` (CLI first push / prebuild clone).
+
+**Still not run:** a real **Daytona session boot + CR** — but that exercises the *same* proxy-git
+data path (proven above) plus Daytona/opencode/funding, none of which is code.storage-specific.

--- a/apps/api/src/projects/git-backends/code-storage.ts
+++ b/apps/api/src/projects/git-backends/code-storage.ts
@@ -1,0 +1,323 @@
+/**
+ * code.storage (Pierre) managed git backend — see ./code-storage.md.
+ *
+ * Managed repos live on code.storage instead of a GitHub org. Auth is a
+ * customer-signed ES256 JWT: WE hold the EC P-256 private key
+ * (MANAGED_GIT_CODESTORAGE_PRIVATE_KEY) and code.storage verifies it against the
+ * public key registered in the Pierre Admin Panel. Unlike the GitHub backend,
+ * there is no installation-token round-trip — `buildUpstream` signs a
+ * short-TTL, repo-scoped JWT locally (synchronous, no network, no token store).
+ *
+ * URL/host shapes below follow the public docs but MUST be confirmed against the
+ * real org during integration (the docs show both `<org>.code.storage/<id>` and
+ * `git.code.storage/<org>/<id>`). All host/path construction is centralized in
+ * the `cs*` helpers so a correction is a one-line change. `createRepo` already
+ * prefers the `http_url` returned by the API as the canonical clone URL.
+ */
+import { createSign } from 'node:crypto';
+import type {
+  GitConnectionRef,
+  GitHostBackend,
+  GitScope,
+  ProvisionInput,
+  ProvisionedRepo,
+  SeedFile,
+  UpstreamGit,
+} from './types';
+
+// ── env ──────────────────────────────────────────────────────────────────────
+function csOrg(): string | null {
+  return process.env.MANAGED_GIT_CODESTORAGE_ORG?.trim() || null;
+}
+function csPrivateKey(): string | null {
+  const raw = process.env.MANAGED_GIT_CODESTORAGE_PRIVATE_KEY?.trim();
+  if (!raw) return null;
+  // Env transports (shell `eval` of `dotenvx --format eval`, AWS Secrets
+  // Manager, .env files) routinely deliver the PEM with literal `\n` and/or no
+  // trailing newline → BoringSSL `BAD_END_LINE`. Normalize to real newlines,
+  // strip CRs, ensure a trailing newline. (Mirrors `normalizeGitHubPrivateKey`.)
+  const key = raw.replace(/\\n/g, '\n').replace(/\r/g, '');
+  return key.endsWith('\n') ? key : `${key}\n`;
+}
+/** API root (no trailing `/api`). e.g. `https://api.<org>.code.storage`. */
+function csApiRoot(): string {
+  const override = process.env.MANAGED_GIT_CODESTORAGE_API_URL?.trim();
+  const root = override || `https://api.${requireOrg()}.code.storage`;
+  return root.replace(/\/+$/, '').replace(/\/api$/, '');
+}
+/** Git transport host. e.g. `<org>.code.storage`. */
+function csGitHost(): string {
+  return process.env.MANAGED_GIT_CODESTORAGE_GIT_HOST?.trim() || `${requireOrg()}.code.storage`;
+}
+
+function requireOrg(): string {
+  const org = csOrg();
+  if (!org) throw new Error('code.storage not configured (MANAGED_GIT_CODESTORAGE_ORG)');
+  return org;
+}
+function requireKey(): string {
+  const key = csPrivateKey();
+  if (!key) throw new Error('code.storage not configured (MANAGED_GIT_CODESTORAGE_PRIVATE_KEY)');
+  return key;
+}
+
+// ── repo id / url helpers ─────────────────────────────────────────────────────
+/**
+ * The repo's human id == the Kortix projectId (a UUID, globally unique). The org
+ * is the `<org>.code.storage` subdomain, so no extra namespace is needed; the
+ * git path + API path + JWT `repo` claim all use this id verbatim.
+ */
+function csRepoId(projectId: string): string {
+  return projectId;
+}
+function csCloneUrl(repoId: string): string {
+  return `https://${csGitHost()}/${repoId}.git`;
+}
+/** Recover the repo id (`kortix/<id>`) from a stored clone URL. */
+function repoIdFromUrl(url: string): string {
+  try {
+    return new URL(url).pathname.replace(/^\/+/, '').replace(/\.git$/, '');
+  } catch {
+    return url;
+  }
+}
+
+// ── ES256 JWT ──────────────────────────────────────────────────────────────────
+function b64url(input: Buffer | string): string {
+  return Buffer.from(input).toString('base64url');
+}
+
+interface JwtClaims {
+  /** Target repo id; omit only for org-wide tokens (e.g. repo:write to create). */
+  repo?: string;
+  scopes: string[];
+  ttlSec: number;
+  /** Audit identity. */
+  sub?: string;
+}
+
+/**
+ * Sign an ES256 JWT. NOTE: Node's EC signatures are DER by default, but
+ * JOSE/ES256 requires the raw R||S (IEEE P1363) form — hence `dsaEncoding`.
+ */
+function signCsJwt(claims: JwtClaims, nowMs = Date.now()): string {
+  const now = Math.floor(nowMs / 1000);
+  const header = { alg: 'ES256', typ: 'JWT' };
+  const payload: Record<string, unknown> = {
+    iss: requireOrg(),
+    sub: claims.sub ?? 'kortix-api',
+    scopes: claims.scopes,
+    iat: now - 30,
+    exp: now + claims.ttlSec,
+  };
+  if (claims.repo) payload.repo = claims.repo;
+
+  const signingInput = `${b64url(JSON.stringify(header))}.${b64url(JSON.stringify(payload))}`;
+  const signer = createSign('sha256');
+  signer.update(signingInput);
+  signer.end();
+  const signature = signer.sign({ key: requireKey(), dsaEncoding: 'ieee-p1363' });
+  return `${signingInput}.${b64url(signature)}`;
+}
+
+/** Basic-auth header for git transport: username `t`, password = signed JWT. */
+function csGitAuthHeader(jwt: string): Record<string, string> {
+  return { Authorization: `Basic ${Buffer.from(`t:${jwt}`).toString('base64')}` };
+}
+
+/**
+ * Mint a fresh repo-scoped code.storage git JWT — for host-side `git` that must
+ * embed creds in the URL (the mirror; direct-mode clone-credential). Short-lived;
+ * callers mint per use. Throws if code.storage isn't configured.
+ */
+export function mintCodeStorageGitToken(repoId: string, scope: GitScope = 'write', ttlSec = 3600): string {
+  return signCsJwt({
+    repo: repoId,
+    scopes: scope === 'write' ? ['git:read', 'git:write'] : ['git:read'],
+    ttlSec,
+  });
+}
+
+/** True when a host is served by code.storage (so git must use creds-in-URL, not extraheader). */
+export function isCodeStorageHost(host: string): boolean {
+  return host === 'code.storage' || host.endsWith('.code.storage');
+}
+
+// ── HTTP API ───────────────────────────────────────────────────────────────────
+async function csFetch<T>(
+  path: string,
+  init: { method?: string; body?: unknown },
+  jwt: string,
+): Promise<T> {
+  const url = `${csApiRoot()}/api${path}`;
+  const res = await fetch(url, {
+    method: init.method ?? 'GET',
+    headers: {
+      Authorization: `Bearer ${jwt}`,
+      ...(init.body !== undefined ? { 'Content-Type': 'application/json' } : {}),
+    },
+    body: init.body !== undefined ? JSON.stringify(init.body) : undefined,
+  });
+  const text = await res.text();
+  if (!res.ok) {
+    let message = text;
+    try {
+      message = (JSON.parse(text) as { error?: string }).error ?? text;
+    } catch {
+      /* non-JSON body */
+    }
+    throw new Error(`code.storage ${init.method ?? 'GET'} ${path} → ${res.status}: ${message}`);
+  }
+  return (text ? JSON.parse(text) : {}) as T;
+}
+
+/** POST a pre-serialized body (e.g. NDJSON commit-pack) with an explicit content-type. */
+async function csPostRaw(path: string, body: string, contentType: string, jwt: string): Promise<void> {
+  const res = await fetch(`${csApiRoot()}/api${path}`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${jwt}`, 'Content-Type': contentType },
+    body,
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    let message = text;
+    try {
+      message = (JSON.parse(text) as { error?: string }).error ?? text;
+    } catch {
+      /* non-JSON body */
+    }
+    throw new Error(`code.storage POST ${path} → ${res.status}: ${message}`);
+  }
+}
+
+interface CreateRepoResponse {
+  /** Opaque internal id (reference only — NOT used to address the repo). */
+  repo_id?: string;
+  /** Human id the git/API paths use; echoes the `id` we sent. */
+  url?: string;
+  /** Full clone URL, when the API returns one. */
+  http_url?: string;
+  message?: string;
+}
+
+// ── backend ──────────────────────────────────────────────────────────────────
+export const codeStorageBackend: GitHostBackend = {
+  id: 'codestorage',
+
+  async isConfigured(): Promise<boolean> {
+    return Boolean(csOrg() && csPrivateKey());
+  },
+
+  async createRepo(input: ProvisionInput): Promise<ProvisionedRepo> {
+    const repoId = csRepoId(input.projectId);
+    // `repo:write` MUST carry the `repo` claim set to the id being created
+    // (verified against the live API — org-wide repo:write tokens are rejected).
+    const res = await csFetch<CreateRepoResponse>(
+      '/repos',
+      { method: 'POST', body: { id: repoId, default_branch: input.defaultBranch } },
+      signCsJwt({ repo: repoId, scopes: ['repo:write'], ttlSec: 120 }),
+    );
+    // The addressable human id comes back as `url` (get/list) or `http_url`
+    // (create — a bare id in practice, not a URL). Always derive the clone URL
+    // from it, unless the API ever returns a genuine absolute http(s) URL.
+    const httpUrlIsAbsolute = !!res.http_url && /^https?:\/\//i.test(res.http_url);
+    const resolvedId = res.url || (httpUrlIsAbsolute ? null : res.http_url) || repoId;
+    const upstreamUrl = httpUrlIsAbsolute
+      ? res.http_url!.endsWith('.git')
+        ? res.http_url!
+        : `${res.http_url}.git`
+      : csCloneUrl(resolvedId);
+    return {
+      provider: this.id,
+      upstreamUrl,
+      externalRepoId: res.repo_id ?? null,
+      repoOwner: csOrg(),
+      repoName: resolvedId,
+      installationId: null,
+      credentialRef: null,
+      defaultBranch: input.defaultBranch,
+      // A real repo-scoped git:write JWT — satisfies the route's seeding guard
+      // and is a usable push credential for the CLI's first push / prebuild clone.
+      initialToken: signCsJwt({ repo: resolvedId, scopes: ['git:read', 'git:write'], ttlSec: 3600 }),
+    };
+  },
+
+  async deleteRepo(ref: GitConnectionRef): Promise<void> {
+    const repoId = ref.repoName ?? repoIdFromUrl(ref.upstreamUrl);
+    if (!repoId) return;
+    await csFetch<unknown>(
+      `/repos/${repoId}`,
+      { method: 'DELETE' },
+      signCsJwt({ repo: repoId, scopes: ['repo:write'], ttlSec: 120 }),
+    );
+  },
+
+  /**
+   * Self-signs a short-TTL, repo-scoped JWT and returns git basic-auth headers.
+   * `_token` is ignored — `resolveProjectGitAuth` returns no token for
+   * code.storage; the credential is minted here.
+   */
+  buildUpstream(ref: GitConnectionRef, _token: string | null, scope: GitScope): UpstreamGit {
+    const repoId = ref.repoName ?? repoIdFromUrl(ref.upstreamUrl);
+    const jwt = signCsJwt({
+      repo: repoId,
+      scopes: scope === 'write' ? ['git:read', 'git:write'] : ['git:read'],
+      ttlSec: 300,
+    });
+    return { url: ref.upstreamUrl, headers: csGitAuthHeader(jwt) };
+  },
+
+  /**
+   * Seed the FIRST commit via the commit-pack API (NDJSON: one metadata line +
+   * one base64 `blob_chunk` per file), NOT `git push`. code.storage writes the
+   * initial commit to an empty repo through this endpoint; it's also network-
+   * robust (a plain fetch, no git subprocess / temp clone).
+   */
+  async seedFiles(
+    ref: GitConnectionRef,
+    _token: string,
+    files: SeedFile[],
+    opts: { branch: string; message: string },
+  ): Promise<void> {
+    const repoId = ref.repoName ?? repoIdFromUrl(ref.upstreamUrl);
+    const metadata = {
+      metadata: {
+        target_branch: opts.branch,
+        commit_message: opts.message,
+        author: { name: 'Kortix', email: 'noreply@kortix.ai' },
+        files: files.map((f, i) => ({
+          path: f.path,
+          operation: 'upsert',
+          content_id: `b${i}`,
+          mode: '100644',
+        })),
+      },
+    };
+    const lines = [
+      JSON.stringify(metadata),
+      ...files.map((f, i) =>
+        JSON.stringify({
+          blob_chunk: { content_id: `b${i}`, data: Buffer.from(f.content).toString('base64'), eof: true },
+        }),
+      ),
+    ];
+    await csPostRaw(
+      `/repos/${repoId}/commit-pack`,
+      `${lines.join('\n')}\n`,
+      'application/x-ndjson',
+      signCsJwt({ repo: repoId, scopes: ['git:write'], ttlSec: 300 }),
+    );
+  },
+
+  /** Credential-embedded push URL for external/legacy contexts (a SECRET — never log). */
+  async authedPushUrl(ref: GitConnectionRef): Promise<string> {
+    const repoId = ref.repoName ?? repoIdFromUrl(ref.upstreamUrl);
+    const jwt = signCsJwt({ repo: repoId, scopes: ['git:read', 'git:write'], ttlSec: 600 });
+    const u = new URL(ref.upstreamUrl);
+    u.username = 't';
+    u.password = jwt;
+    return u.toString();
+  },
+
+  // inviteCollaborator: N/A — code.storage has no per-user host accounts.
+};

--- a/apps/api/src/projects/git-backends/registry.ts
+++ b/apps/api/src/projects/git-backends/registry.ts
@@ -5,15 +5,18 @@
  * Forgejo/Artifacts project resolves through its own — all behind the same
  * Kortix git proxy.
  *
- * GitHub is the default + only currently-active managed backend. Forgejo /
- * Cloudflare Artifacts slot in here as drop-ins (same `GitHostBackend`
- * interface) with zero changes to the proxy, sandbox, or CLI.
+ * GitHub and code.storage (Pierre) are both active managed backends; the one
+ * NEW projects provision on is `MANAGED_GIT_PROVIDER`. Forgejo / Cloudflare
+ * Artifacts slot in here as further drop-ins (same `GitHostBackend` interface)
+ * with zero changes to the proxy, sandbox, or CLI.
  */
+import { codeStorageBackend } from './code-storage';
 import { githubBackend } from './github';
 import type { GitHostBackend } from './types';
 
 const backends = new Map<string, GitHostBackend>([
   [githubBackend.id, githubBackend],
+  [codeStorageBackend.id, codeStorageBackend],
   // ['forgejo', forgejoBackend],
   // ['artifacts', artifactsBackend],
 ]);

--- a/apps/api/src/projects/git/mirror.ts
+++ b/apps/api/src/projects/git/mirror.ts
@@ -12,6 +12,7 @@ import { mkdir, mkdtemp, rm } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { promisify } from 'node:util';
 import { validateRef } from '../git-ref';
+import { isCodeStorageHost } from '../git-backends/code-storage';
 import type { GitBackedProject } from './types';
 
 export const execFileAsync = promisify(execFile);
@@ -64,6 +65,27 @@ function gitAuthEnv(token?: string | null, authHost = 'github.com'): Record<stri
   };
 }
 
+/**
+ * code.storage rejects `http.extraheader` Basic auth (its `401 Basic realm`
+ * challenge isn't satisfied by a static header — git then stalls/prompts), so
+ * its `git` transport needs creds embedded in the URL (username `t`, password =
+ * JWT). Returns a creds-in-URL for code.storage hosts; `null` otherwise (those
+ * authenticate via the `gitAuthEnv` extraheader). The token is short-lived, so
+ * callers build this per fetch (never persist it in the repo's `origin`).
+ */
+function codeStorageCloneUrl(repoUrl: string, token?: string | null): string | null {
+  if (!token) return null;
+  try {
+    const u = new URL(repoUrl);
+    if (!isCodeStorageHost(u.host)) return null;
+    u.username = 't';
+    u.password = token;
+    return u.toString();
+  } catch {
+    return null;
+  }
+}
+
 export async function runGit(
   args: string[],
   cwd?: string,
@@ -76,7 +98,11 @@ export async function runGit(
   try {
     const result = await execFileAsync('git', args, {
       cwd,
-      env: { ...process.env, GIT_TERMINAL_PROMPT: '0', ...authEnv, ...(extraEnv || {}) },
+      // Server-side git must NEVER prompt. GIT_TERMINAL_PROMPT=0 alone isn't
+      // enough when the parent process injects GIT_ASKPASS (e.g. VS Code/Cursor's
+      // git integration) — git would pop the editor's credential dialog. Force
+      // both off so an auth failure fails fast instead of hanging on a prompt.
+      env: { ...process.env, GIT_TERMINAL_PROMPT: '0', GIT_ASKPASS: '', SSH_ASKPASS: '', ...authEnv, ...(extraEnv || {}) },
       maxBuffer: 10 * 1024 * 1024,
       timeout: 30_000,
     });
@@ -108,7 +134,7 @@ export async function runGitCapture(
   try {
     const result = await execFileAsync('git', args, {
       cwd,
-      env: { ...process.env, GIT_TERMINAL_PROMPT: '0', ...gitAuthEnv(authToken, authHost), ...(extraEnv || {}) },
+      env: { ...process.env, GIT_TERMINAL_PROMPT: '0', GIT_ASKPASS: '', SSH_ASKPASS: '', ...gitAuthEnv(authToken, authHost), ...(extraEnv || {}) },
       maxBuffer: 10 * 1024 * 1024,
       timeout: 30_000,
     });
@@ -137,6 +163,7 @@ async function doRefreshMirror(project: GitBackedProject, force = false) {
   if (existsSync(join(repoPath, 'shallow'))) {
     await rm(repoPath, { recursive: true, force: true });
   }
+  const csCloneUrl = codeStorageCloneUrl(project.repoUrl, project.gitAuthToken);
   if (!existsSync(repoPath)) {
     // Bare clone with ALL branches — required for the version/checkpoint
     // viewer. Older callers cloned --single-branch; we self-heal those on
@@ -144,9 +171,11 @@ async function doRefreshMirror(project: GitBackedProject, force = false) {
     await runGit([
       'clone',
       '--bare',
-      project.repoUrl,
+      csCloneUrl ?? project.repoUrl,
       repoPath,
-    ], undefined, true, project.gitAuthToken, undefined, hostFromRepoUrl(project.repoUrl));
+    ], undefined, !csCloneUrl, project.gitAuthToken, undefined, hostFromRepoUrl(project.repoUrl));
+    // Don't persist the short-lived code.storage JWT in the bare repo's origin.
+    if (csCloneUrl) await runGit(['remote', 'set-url', 'origin', project.repoUrl], repoPath, false);
     lastRefreshAt.set(project.projectId, Date.now());
     return repoPath;
   }
@@ -157,7 +186,13 @@ async function doRefreshMirror(project: GitBackedProject, force = false) {
   await runGit(['remote', 'set-url', 'origin', project.repoUrl], repoPath);
   // Heal any legacy single-branch clones by widening the refspec.
   await runGit(['config', 'remote.origin.fetch', '+refs/heads/*:refs/heads/*'], repoPath, false);
-  await runGit(['fetch', '--prune', 'origin'], repoPath, true, project.gitAuthToken, undefined, hostFromRepoUrl(project.repoUrl));
+  if (csCloneUrl) {
+    // code.storage: fetch by creds-in-URL (origin stays token-free); refspec
+    // must be explicit since we're not fetching the named remote.
+    await runGit(['fetch', '--prune', csCloneUrl, '+refs/heads/*:refs/heads/*'], repoPath, false);
+  } else {
+    await runGit(['fetch', '--prune', 'origin'], repoPath, true, project.gitAuthToken, undefined, hostFromRepoUrl(project.repoUrl));
+  }
   lastRefreshAt.set(project.projectId, Date.now());
   return repoPath;
 }

--- a/apps/api/src/projects/lib/git.ts
+++ b/apps/api/src/projects/lib/git.ts
@@ -4,6 +4,7 @@ import { validateSecretKey } from '../../repositories/api-keys';
 import { isAccountToken, isKortixToken } from '../../shared/crypto';
 import { db } from '../../shared/db';
 import { getBackend, managedGithubInstallId, managedGithubToken, type GitConnectionRef, type GitScope, type UpstreamGit } from '../git-backends';
+import { mintCodeStorageGitToken } from '../git-backends/code-storage';
 import { buildGitHubAppInstallUrl, createInstallationToken, getRepo, isGithubAppConfigured, type GitHubAuthContext, type GitHubRepo } from '../github';
 import { decryptProjectSecret, encryptProjectSecret } from '../secrets';
 import { accountGithubInstallationStates, accountGithubInstallations, accountMembers, projectGitConnections, projectGitCredentials, projects, sessionSandboxes } from '@kortix/db';
@@ -408,6 +409,28 @@ export async function resolveProjectGitAuth(project: ProjectRow): Promise<{
   authSource: 'app_installation' | 'pat' | 'managed' | 'project_credential' | 'none';
 }> {
   const remote = getProjectGitRemote(project, await getProjectGitConnection(project.projectId));
+
+  // Managed code.storage: mint a fresh repo-scoped git JWT (self-signed, no
+  // network). Used by host-side git that can't self-sign per-request — the
+  // mirror (file viewer / prebuild) and the direct-mode clone-credential. The
+  // proxy path doesn't rely on this (its buildUpstream self-signs).
+  if (remote.provider === 'codestorage') {
+    let repoId = remote.repoName;
+    if (!repoId) {
+      try {
+        repoId = new URL(remote.upstreamUrl ?? project.repoUrl).pathname.replace(/^\/+/, '').replace(/\.git$/, '');
+      } catch {
+        repoId = null;
+      }
+    }
+    if (!repoId) return { authSource: 'none' };
+    try {
+      return { auth: { token: mintCodeStorageGitToken(repoId, 'write'), source: 'managed' }, authSource: 'managed' };
+    } catch (err) {
+      console.warn(`[projects] failed to mint code.storage token for ${project.projectId}:`, err);
+      return { authSource: 'none' };
+    }
+  }
 
   // Managed GitHub repos (Kortix-provisioned, under the managed org). Two
   // server-side credential models:

--- a/apps/web/src/components/projects/customize/sections/dev-view.tsx
+++ b/apps/web/src/components/projects/customize/sections/dev-view.tsx
@@ -85,8 +85,20 @@ function DevSteps({
 }: {
   project: Awaited<ReturnType<typeof getProject>>;
 }) {
-  const cloneUrl = cloneUrlFor(project.repo_url);
-  const repoDir = repoDirFor(project.repo_url) || 'my-project';
+  // Managed projects are served through the Kortix git proxy — clone the PROXY
+  // URL with a Kortix token (the real upstream, e.g. code.storage, isn't
+  // directly reachable by users). BYO GitHub projects clone their own URL.
+  const proxyOrigin =
+    project.git_origin_url && /\/v1\/git\//.test(project.git_origin_url)
+      ? project.git_origin_url
+      : null;
+  const repoDir =
+    (proxyOrigin
+      ? project.name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-+|-+$)/g, '')
+      : repoDirFor(project.repo_url)) || 'my-project';
+  const cloneUrl = proxyOrigin
+    ? proxyOrigin.replace('://', '://x-access-token:<KORTIX_TOKEN>@')
+    : cloneUrlFor(project.repo_url);
   const managed = isManagedGithubProject(project);
   const branch = project.default_branch || 'main';
 
@@ -112,14 +124,31 @@ function DevSteps({
         n={next()}
         title="Clone the repo"
         hint={
-          managed
-            ? 'Once your invite is accepted, clone it like any other repo.'
-            : 'You need read access to the repo to clone it.'
+          proxyOrigin
+            ? 'Clone through the Kortix git proxy with an access token — no host account or collaborator invite needed.'
+            : managed
+              ? 'Once your invite is accepted, clone it like any other repo.'
+              : 'You need read access to the repo to clone it.'
         }
       >
-        <CommandBlock
-          lines={[`git clone ${cloneUrl}`, `cd ${repoDir}`]}
-        />
+        <CommandBlock lines={[`git clone ${cloneUrl} ${repoDir}`, `cd ${repoDir}`]} />
+        {proxyOrigin && (
+          <p className="mt-2 text-xs leading-relaxed text-muted-foreground">
+            Replace{' '}
+            <code className="rounded bg-muted px-1 py-0.5 font-mono text-[0.7rem] text-foreground">
+              &lt;KORTIX_TOKEN&gt;
+            </code>{' '}
+            with a Kortix access token — run{' '}
+            <code className="rounded bg-muted px-1 py-0.5 font-mono text-[0.7rem] text-foreground">
+              kortix login
+            </code>{' '}
+            (below) or create one in Settings. It stays in your local{' '}
+            <code className="rounded bg-muted px-1 py-0.5 font-mono text-[0.7rem] text-foreground">
+              origin
+            </code>
+            , so pushes and change requests work too.
+          </p>
+        )}
       </Step>
 
       <Step

--- a/apps/web/src/lib/projects-client.ts
+++ b/apps/web/src/lib/projects-client.ts
@@ -24,6 +24,10 @@ export interface KortixProject {
   account_id: string;
   name: string;
   repo_url: string;
+  /** Client-facing git origin. When the Kortix git proxy is on, this is the
+   *  proxy URL (`…/v1/git/<projectId>.git`) you clone with a Kortix token —
+   *  the real upstream (`repo_url`) is never directly reachable by users. */
+  git_origin_url?: string;
   default_branch: string;
   manifest_path: string;
   status: 'active' | 'archived';


### PR DESCRIPTION
## code.storage (Pierre) managed git backend

Adds **code.storage** as a managed git backend (`GitHostBackend`) so Kortix-provisioned repos can live on code.storage instead of the `managed-kortix` GitHub org. It's a drop-in alongside the existing `github` backend — `provider` is stored per `project_git_connections` row, so both run side by side. **Provisioning stays on GitHub until `MANAGED_GIT_PROVIDER=codestorage` is set per environment**, so this is inert by default.

### What's here
- **`code-storage.ts`** — new `codestorage` backend. `buildUpstream` self-signs a short-TTL, repo-scoped **ES256 JWT** locally (no installation-token round-trip). `createRepo` (`repo:write` + `repo` claim), `seedFiles` via the **commit-pack API** (NDJSON + base64 blobs), `deleteRepo`, `authedPushUrl` (creds-in-URL). PEM normalized for Bun/BoringSSL (`\n` → real newlines, `ieee-p1363`).
- **`registry.ts`** — register `codeStorageBackend`.
- **`config.ts`** — `MANAGED_GIT_CODESTORAGE_ORG / _PRIVATE_KEY / _API_URL / _GIT_HOST`.
- **`lib/git.ts`** — `resolveProjectGitAuth` `codestorage` branch (mints a fresh repo-scoped JWT for host-side git).
- **`mirror.ts`** — clone/fetch code.storage via **creds-in-URL** (its `401 Basic` challenge isn't satisfied by `http.extraheader`); force `GIT_ASKPASS=''`/`SSH_ASKPASS=''` so server-side git can never prompt.
- **web `dev-view.tsx`** — "Develop on your own machine" now clones via the **Kortix proxy URL + token** for managed projects (was showing the raw, unauthable upstream); adds `git_origin_url` to `KortixProject`.

### Verified live (against the `kortix` code.storage org)
- Provision → commit-pack seed → clone **and** push through the Kortix proxy.
- File viewer (`listRepoFiles` → mirror) returns the full seeded tree.
- ES256 sign/verify roundtrip; API + web typecheck clean.

Spec + validation log: `apps/api/src/projects/git-backends/code-storage.md`.
