### PR TITLE
Fix Slack manifest and trigger backpressure

### DIFF
--- a/apps/api/src/__tests__/e2e-project-triggers.test.ts
+++ b/apps/api/src/__tests__/e2e-project-triggers.test.ts
@@ -688,6 +688,33 @@ describe('git-backed triggers — runtime fire paths', () => {
     expect(runtimeRows[0]!.lastFiredAt).toBeTruthy();
   });
 
+  test('manual fire returns retryable backpressure instead of pretending to queue', async () => {
+    seedManifest(cronEntry({
+      slug: 'daily',
+      name: 'Daily',
+      cron: '* * * * * *',
+      prompt: 'Run at {{ fired_at }}',
+    }));
+    provisioningSessionCount = 3;
+
+    const app = createApp();
+    const res = await app.request(`/v1/projects/${PROJECT_ID}/triggers/daily/fire`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{}',
+    });
+    expect(res.status).toBe(503);
+    expect(res.headers.get('retry-after')).toBe('30');
+    const body = await res.json();
+    expect(body).toMatchObject({
+      code: 'trigger_backpressure',
+      retryable: true,
+      reason: 'project provisioning backpressure',
+    });
+    expect(sandboxProvisionCalls).toBe(0);
+    expect(runtimeRows).toHaveLength(0);
+  });
+
   test('cron sweep fires due git-backed triggers', async () => {
     seedManifest(cronEntry({
       slug: 'sweep',
@@ -701,6 +728,30 @@ describe('git-backed triggers — runtime fire paths', () => {
     await new Promise((r) => setTimeout(r, 0));
     expect(sandboxProvisionCalls).toBe(1);
     expect(lastProvisionEnv?.KORTIX_INITIAL_PROMPT).toBe('Sweep run');
+  });
+
+  test('cron sweep under backpressure does not advance last_fired_at', async () => {
+    seedManifest(cronEntry({
+      slug: 'sweep',
+      name: 'Sweep',
+      cron: '* * * * * *',
+      prompt: 'Sweep run',
+    }));
+    provisioningSessionCount = 3;
+
+    const result = await runProjectTriggerSweep(new Date('2026-01-01T00:00:30Z'));
+    expect(result).toMatchObject({ scanned: 1, fired: 0, queued: 1, failed: 0 });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(sandboxProvisionCalls).toBe(0);
+    expect(runtimeRows).toHaveLength(0);
+
+    provisioningSessionCount = 0;
+    const retry = await runProjectTriggerSweep(new Date('2026-01-01T00:00:31Z'));
+    expect(retry).toMatchObject({ scanned: 1, fired: 1, queued: 0, failed: 0 });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(sandboxProvisionCalls).toBe(1);
+    expect(runtimeRows).toHaveLength(1);
+    expect(runtimeRows[0]!.lastFiredAt?.toISOString()).toBe('2026-01-01T00:00:31.000Z');
   });
 
   test('webhook fires verify the HMAC signature and reject impostors', async () => {
@@ -758,6 +809,38 @@ describe('git-backed triggers — runtime fire paths', () => {
     await new Promise((r) => setTimeout(r, 0));
     expect(sandboxProvisionCalls).toBe(1);
     expect(lastProvisionEnv?.KORTIX_INITIAL_PROMPT).toBe('New opened');
+  });
+
+  test('webhook under backpressure returns retryable 503 instead of silent queued', async () => {
+    seedManifest(webhookEntry({
+      slug: 'hook',
+      name: 'Hook',
+      secretEnv: 'HOOK_SECRET',
+      prompt: 'New {{ body.action }}',
+    }));
+    secretValues.set('HOOK_SECRET', 'shhh');
+    provisioningSessionCount = 3;
+    const app = createApp();
+
+    const rawBody = JSON.stringify({ action: 'opened' });
+    const res = await app.request(`/v1/webhooks/projects/${PROJECT_ID}/hook`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Kortix-Signature': sign(rawBody, 'shhh'),
+      },
+      body: rawBody,
+    });
+    expect(res.status).toBe(503);
+    expect(res.headers.get('retry-after')).toBe('30');
+    const body = await res.json();
+    expect(body).toMatchObject({
+      code: 'trigger_backpressure',
+      retryable: true,
+      reason: 'project provisioning backpressure',
+    });
+    expect(sandboxProvisionCalls).toBe(0);
+    expect(runtimeRows).toHaveLength(0);
   });
 
   test('webhook accepts a valid static token (no HMAC) and rejects a wrong one', async () => {

--- a/apps/api/src/projects/lib/triggers.ts
+++ b/apps/api/src/projects/lib/triggers.ts
@@ -342,13 +342,13 @@ export async function fireGitTrigger(input: {
   renderedPrompt: string;
   source: 'cron' | 'webhook' | 'manual';
   request?: RequestAuditContext;
-}): Promise<{ status: 'fired' | 'queued' | 'failed'; sessionId?: string; error?: string; reason?: string }> {
+}): Promise<{ status: 'fired' | 'backpressure' | 'failed'; sessionId?: string; error?: string; reason?: string }> {
   const { spec, project, payload, renderedPrompt, source } = input;
   const backpressure = await triggerBackpressureState(project.accountId, project.projectId);
 
   if (backpressure.shouldQueue) {
     return {
-      status: 'queued',
+      status: 'backpressure',
       reason: backpressure.provisioning >= backpressure.projectProvisioningLimit
         ? 'project provisioning backpressure'
         : 'account session cap',
@@ -444,10 +444,6 @@ export async function runGitTriggerSweep(now: Date, accumulator: {
         continue;
       }
 
-      // Mark fired BEFORE the actual fire — a slow tick must never spawn
-      // two sessions for the same scheduled run.
-      await markGitTriggerFired(project.projectId, spec.slug, now);
-
       const payload = {
         cron: {
           schedule: spec.cron ?? spec.runAt,
@@ -466,8 +462,10 @@ export async function runGitTriggerSweep(now: Date, accumulator: {
         renderedPrompt,
         source: 'cron',
       });
-      if (result.status === 'fired') accumulator.fired += 1;
-      else if (result.status === 'queued') accumulator.queued += 1;
+      if (result.status === 'fired') {
+        await markGitTriggerFired(project.projectId, spec.slug, now);
+        accumulator.fired += 1;
+      } else if (result.status === 'backpressure') accumulator.queued += 1;
       else accumulator.failed += 1;
     }
   }

--- a/apps/api/src/projects/routes/r1.ts
+++ b/apps/api/src/projects/routes/r1.ts
@@ -94,8 +94,14 @@ projectWebhooksApp.post('/projects/:projectId/:slug', async (c) => {
     request: requestAuditContext(c),
   });
 
-  if (result.status === 'queued') {
-    return c.json({ status: 'queued', reason: result.reason ?? null }, 202);
+  if (result.status === 'backpressure') {
+    c.header('Retry-After', '30');
+    return c.json({
+      error: 'Trigger is temporarily backpressured',
+      code: 'trigger_backpressure',
+      reason: result.reason ?? null,
+      retryable: true,
+    }, 503);
   }
   if (result.status === 'failed') {
     return c.json({ error: result.error ?? 'Failed to fire trigger' }, 500);

--- a/apps/api/src/projects/routes/r4.ts
+++ b/apps/api/src/projects/routes/r4.ts
@@ -642,8 +642,14 @@ projectsApp.openapi(
     request: requestAuditContext(c),
   });
 
-  if (result.status === 'queued') {
-    return c.json({ status: 'queued', reason: result.reason ?? null }, 202);
+  if (result.status === 'backpressure') {
+    c.header('Retry-After', '30');
+    return c.json({
+      error: 'Trigger is temporarily backpressured',
+      code: 'trigger_backpressure',
+      reason: result.reason ?? null,
+      retryable: true,
+    }, 503);
   }
   if (result.status === 'failed') {
     return c.json({ error: result.error ?? 'Failed to fire trigger' }, 500);

--- a/apps/web/src/components/projects/customize/sections/channels-view.tsx
+++ b/apps/web/src/components/projects/customize/sections/channels-view.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 import {
   Check,
   ChevronDown,
@@ -17,10 +17,10 @@ import { Label } from '@/components/ui/label';
 import { SectionCard } from '@/components/ui/section-card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { cn } from '@/lib/utils';
-import { getEnv } from '@/lib/env-config';
 import { CustomizeSectionHeader } from '@/components/projects/customize/customize-section-header';
 import {
   useSlackInstall,
+  useSlackManifest,
   useSlackMode,
   useConnectSlack,
   useDisconnectSlack,
@@ -221,12 +221,13 @@ function SelfInstall({ projectId }: { projectId: string }) {
   const [signingSecret, setSigningSecret] = useState('');
   const [error, setError] = useState<string | null>(null);
   const connect = useConnectSlack();
+  const manifest = useSlackManifest(projectId);
 
-  const manifest = useMemo(() => buildSlackManifest(projectId), [projectId]);
+  const manifestText = manifest.data ?? '';
 
   const copyManifest = async () => {
-    if (!manifest) return;
-    await navigator.clipboard.writeText(manifest);
+    if (!manifestText) return;
+    await navigator.clipboard.writeText(manifestText);
     setCopied(true);
     setTimeout(() => setCopied(false), 1500);
   };
@@ -260,6 +261,7 @@ function SelfInstall({ projectId }: { projectId: string }) {
                 variant="ghost"
                 size="sm"
                 onClick={copyManifest}
+                disabled={!manifestText}
                 className="h-7 gap-1.5"
               >
                 {copied ? (
@@ -283,7 +285,11 @@ function SelfInstall({ projectId }: { projectId: string }) {
             </div>
           </div>
           <pre className="max-h-64 overflow-auto rounded-2xl border border-border bg-muted/30 p-3 text-xs leading-relaxed">
-            {manifest}
+            {manifest.isLoading
+              ? 'Loading manifest...'
+              : manifest.error
+                ? `Failed to load manifest: ${(manifest.error as Error).message}`
+                : manifestText}
           </pre>
         </div>
 
@@ -375,73 +381,4 @@ function SelfInstall({ projectId }: { projectId: string }) {
       </div>
     </div>
   );
-}
-
-function buildSlackManifest(projectId: string): string {
-  const env = getEnv();
-  // Slack must reach this webhook from the public internet. Prefer the public API
-  // origin (WEBHOOK_BASE_URL — the dev Cloudflare tunnel locally, the real API
-  // origin in prod), because BACKEND_URL in local dev is intentionally localhost
-  // so the BROWSER talks to the API directly. Normalize to the ORIGIN: strip a
-  // trailing slash AND a trailing `/v1`, so either `https://host` or
-  // `https://host/v1` yields a single `/v1/webhooks/...` (was producing
-  // `/v1/v1/webhooks/...` when the base ended in /v1).
-  const apiOrigin = (env.WEBHOOK_BASE_URL || env.BACKEND_URL || '')
-    .replace(/\/+$/, '')
-    .replace(/\/v1$/, '');
-  const requestUrl = apiOrigin
-    ? `${apiOrigin}/v1/webhooks/slack/${projectId}`
-    : `<set BACKEND_URL in env>/v1/webhooks/slack/${projectId}`;
-  const manifest = {
-    display_information: {
-      name: 'Kortix',
-      description: 'Run a Kortix project from Slack',
-      background_color: '#0a0a0a',
-    },
-    features: { bot_user: { display_name: 'kortix', always_online: true } },
-    oauth_config: {
-      scopes: {
-        bot: [
-          'app_mentions:read',
-          'channels:history',
-          'channels:read',
-          'channels:join',
-          'chat:write',
-          'chat:write.public',
-          'files:read',
-          'files:write',
-          'groups:history',
-          'groups:read',
-          'im:history',
-          'im:read',
-          'im:write',
-          'mpim:history',
-          'mpim:read',
-          'reactions:read',
-          'reactions:write',
-          'users:read',
-        ],
-      },
-    },
-    settings: {
-      event_subscriptions: {
-        request_url: requestUrl,
-        bot_events: [
-          'app_mention',
-          'message.im',
-          'message.channels',
-          'message.groups',
-          'message.mpim',
-          'reaction_added',
-          'reaction_removed',
-          'member_joined_channel',
-          'file_shared',
-        ],
-      },
-      org_deploy_enabled: false,
-      socket_mode_enabled: false,
-      token_rotation_enabled: false,
-    },
-  };
-  return JSON.stringify(manifest, null, 2);
 }

--- a/apps/web/src/hooks/channels/use-channels-installations.ts
+++ b/apps/web/src/hooks/channels/use-channels-installations.ts
@@ -83,6 +83,28 @@ export function useSlackMode(projectId: string | null) {
   });
 }
 
+const manifestKey = (projectId: string | null) =>
+  ['channels', 'slack-manifest', projectId ?? 'none'] as const;
+
+export function useSlackManifest(projectId: string | null) {
+  return useQuery({
+    queryKey: manifestKey(projectId),
+    enabled: !!projectId,
+    staleTime: 60_000,
+    queryFn: async () => {
+      if (!projectId) return null;
+      const res = await backendApi.get<Record<string, unknown>>(
+        `/webhooks/slack/${encodeURIComponent(projectId)}/manifest`,
+        { showErrors: false },
+      );
+      if (!res.success || !res.data) {
+        throw new Error(res.error?.message ?? 'Failed to load Slack manifest');
+      }
+      return JSON.stringify(res.data, null, 2);
+    },
+  });
+}
+
 export function useDisconnectSlack() {
   const qc = useQueryClient();
   return useMutation({


### PR DESCRIPTION
## Summary\n- remove the duplicate frontend Slack manifest builder and fetch the API-generated manifest instead\n- return retryable 503 backpressure responses for manual and webhook trigger fires instead of pretending they are durably queued\n- keep cron trigger last_fired_at unchanged under backpressure so due triggers retry on the next sweep\n\n## Verification\n- curl through Cloudflare tunnel: manifest URLs are public HTTPS, signed Slack url_verification returns 200, bad signature returns 401\n- KORTIX_URL=https://test.kortix.local KORTIX_BILLING_INTERNAL_ENABLED=false pnpm --filter kortix-api exec dotenvx run -f .env -- bun test src/__tests__/unit-slack-manifest.test.ts\n- KORTIX_URL=https://test.kortix.local KORTIX_BILLING_INTERNAL_ENABLED=false pnpm --filter kortix-api exec dotenvx run -f .env -- bun test src/__tests__/e2e-project-triggers.test.ts\n- isolated Slack unit files: unit-slack-turn, unit-slack-turn-finalize, unit-slack-dispatch-session + unit-slack-session-selection\n- pnpm --filter kortix-api typecheck\n- pnpm --filter @kortix/sandbox-agent-server typecheck\n- pnpm --filter './apps/web' lint