### PR TITLE
fix(slack): survive channel selection schema drift

### DIFF
--- a/apps/api/src/__tests__/unit-slack-dispatch-session.test.ts
+++ b/apps/api/src/__tests__/unit-slack-dispatch-session.test.ts
@@ -58,6 +58,7 @@ mock.module('../channels/slack/turn', () => ({
 mock.module('../channels/install-store', () => ({
   loadSlackBotUserIdForProject: async () => 'B1',
   loadSlackTokenForProject: async () => 'xoxb-test',
+  saveSlackOauthInstall: async () => {},
 }));
 mock.module('../channels/slack-api', () => ({
   deleteMessage: async () => {},

--- a/apps/api/src/__tests__/unit-slack-interactivity-selection.test.ts
+++ b/apps/api/src/__tests__/unit-slack-interactivity-selection.test.ts
@@ -18,7 +18,10 @@ mock.module('../channels/slack/dispatch', () => ({
   pendingPickers: new Map(),
   spawnAgentTurn: async () => {},
 }));
-mock.module('../channels/install-store', () => ({ loadSlackTokenForProject: async () => 'xoxb' }));
+mock.module('../channels/install-store', () => ({
+  loadSlackTokenForProject: async () => 'xoxb',
+  saveSlackOauthInstall: async () => {},
+}));
 mock.module('../channels/slack-api', () => ({ updateMessage: async () => {} }));
 
 const setAgentCalls: Array<string | null> = [];

--- a/apps/api/src/__tests__/unit-slack-oauth.test.ts
+++ b/apps/api/src/__tests__/unit-slack-oauth.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+const PROJECT_ID = '4967754f-867c-45b1-b647-da56f99a55d9';
+const USER_ID = '49851790-41b5-4c3e-a39e-a022d0976255';
+const WORKSPACE_ID = 'T123';
+
+let projectRows: Array<{ projectId: string }> = [];
+let saveError: Error | null = null;
+const saveCalls: Array<Record<string, unknown>> = [];
+
+function makeSelectChain(): any {
+  const chain: any = {};
+  for (const method of ['from', 'where', 'limit']) chain[method] = () => chain;
+  chain.then = (resolve: (rows: Array<{ projectId: string }>) => unknown) =>
+    Promise.resolve(resolve(projectRows));
+  return chain;
+}
+
+mock.module('../shared/db', () => ({
+  db: {
+    select: () => makeSelectChain(),
+  },
+}));
+
+mock.module('../config', () => ({
+  config: {
+    SLACK_SIGNING_SECRET: 'state-secret',
+    SLACK_CLIENT_ID: 'client-id',
+    SLACK_CLIENT_SECRET: 'client-secret',
+    SLACK_REDIRECT_URI: 'https://dev-api.kortix.com/v1/webhooks/slack/oauth/callback',
+    SLACK_OAUTH_SCOPES: 'app_mentions:read,chat:write,commands',
+    FRONTEND_URL: 'https://dev.kortix.com',
+  },
+}));
+
+mock.module('../channels/install-store', () => ({
+  saveSlackOauthInstall: async (input: Record<string, unknown>) => {
+    saveCalls.push(input);
+    if (saveError) throw saveError;
+  },
+}));
+
+const realFetch = globalThis.fetch;
+
+beforeEach(() => {
+  projectRows = [{ projectId: PROJECT_ID }];
+  saveError = null;
+  saveCalls.length = 0;
+  globalThis.fetch = (async () =>
+    new Response(JSON.stringify({
+      ok: true,
+      access_token: 'xoxb-new-token',
+      bot_user_id: 'U_BOT',
+      team: { id: WORKSPACE_ID, name: 'KortixDev' },
+    }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    })) as any;
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+const { slackOauthApp, buildSlackInstallUrl } = await import('../channels/slack-oauth');
+
+function stateFromInstallUrl(): string {
+  const url = new URL(buildSlackInstallUrl(PROJECT_ID, USER_ID));
+  const state = url.searchParams.get('state');
+  if (!state) throw new Error('missing state');
+  return state;
+}
+
+function redirectLocation(res: Response): string {
+  const location = res.headers.get('location');
+  if (!location) throw new Error('missing redirect location');
+  return location;
+}
+
+describe('Slack OAuth callback', () => {
+  test('saves a project-scoped install and redirects to the project channels page', async () => {
+    const res = await slackOauthApp.request(`/callback?code=code-1&state=${stateFromInstallUrl()}`);
+
+    expect(res.status).toBe(302);
+    expect(redirectLocation(res)).toBe(
+      `https://dev.kortix.com/projects/${PROJECT_ID}/customize?projectId=${PROJECT_ID}&success=1&section=channels`,
+    );
+    expect(saveCalls).toEqual([{
+      projectId: PROJECT_ID,
+      workspaceId: WORKSPACE_ID,
+      botToken: 'xoxb-new-token',
+      botUserId: 'U_BOT',
+      teamName: 'KortixDev',
+    }]);
+  });
+
+  test('redirects instead of returning a raw 500 when reconnect persistence fails', async () => {
+    saveError = new Error('duplicate install/schema drift');
+
+    const res = await slackOauthApp.request(`/callback?code=code-2&state=${stateFromInstallUrl()}`);
+
+    expect(res.status).toBe(302);
+    expect(redirectLocation(res)).toBe(
+      `https://dev.kortix.com/projects/${PROJECT_ID}/customize?projectId=${PROJECT_ID}&error=slack_install_save_failed&section=channels`,
+    );
+    expect(saveCalls).toHaveLength(1);
+  });
+
+  test('redirects to the project when Slack token exchange fails unexpectedly', async () => {
+    globalThis.fetch = (async () => {
+      throw new Error('slack unavailable');
+    }) as any;
+
+    const res = await slackOauthApp.request(`/callback?code=code-3&state=${stateFromInstallUrl()}`);
+
+    expect(res.status).toBe(302);
+    expect(redirectLocation(res)).toBe(
+      `https://dev.kortix.com/projects/${PROJECT_ID}/customize?projectId=${PROJECT_ID}&error=oauth_exchange_failed&section=channels`,
+    );
+    expect(saveCalls).toHaveLength(0);
+  });
+});

--- a/apps/api/src/__tests__/unit-slack-questions.test.ts
+++ b/apps/api/src/__tests__/unit-slack-questions.test.ts
@@ -41,6 +41,7 @@ mock.module('../channels/slack/dispatch', () => ({
 
 mock.module('../channels/install-store', () => ({
   loadSlackTokenForProject: async () => 'xoxb-test',
+  saveSlackOauthInstall: async () => {},
 }));
 
 // ─── DB mock (FIFO) ───────────────────────────────────────────────────────────

--- a/apps/api/src/__tests__/unit-slack-selection.test.ts
+++ b/apps/api/src/__tests__/unit-slack-selection.test.ts
@@ -4,13 +4,20 @@ import { beforeEach, describe, expect, mock, test } from 'bun:test';
 // binding read/write helpers (against a FIFO db mock).
 
 // ─── FIFO db mock (same shape as unit-slack-dispatch-session) ─────────────────
-let dbResults: unknown[][] = [];
+let dbResults: Array<unknown[] | Error> = [];
 function makeChain(): any {
   const chain: any = {};
   for (const m of ['select', 'from', 'where', 'limit', 'set', 'values', 'returning', 'update']) {
     chain[m] = () => chain;
   }
-  chain.then = (resolve: (rows: unknown[]) => unknown) => Promise.resolve(resolve(dbResults.shift() ?? []));
+  chain.then = (resolve: (rows: unknown[]) => unknown, reject?: (err: unknown) => unknown) => {
+    const next = dbResults.shift() ?? [];
+    if (next instanceof Error) {
+      if (reject) return Promise.resolve(reject(next));
+      return Promise.reject(next);
+    }
+    return Promise.resolve(resolve(next));
+  };
   return chain;
 }
 mock.module('../shared/db', () => ({
@@ -87,6 +94,14 @@ describe('currentChannelSelection', () => {
     dbResults = [[]];
     expect(await currentChannelSelection({ teamId: 'T1', channelId: 'C1' })).toBeNull();
   });
+  test('missing optional override columns falls back to project-only routing', async () => {
+    dbResults = [
+      new Error('PostgresError: column "agent_name" does not exist'),
+      [{ projectId: 'p1' }],
+    ];
+    const sel = await currentChannelSelection({ teamId: 'T1', channelId: 'C1' });
+    expect(sel).toEqual({ projectId: 'p1', agentName: null, opencodeModel: null });
+  });
   test('no channel id → null (no query)', async () => {
     expect(await currentChannelSelection({ teamId: 'T1', channelId: '' })).toBeNull();
   });
@@ -103,5 +118,9 @@ describe('setChannelAgent / setChannelModel', () => {
   });
   test('no channel id → false (no write)', async () => {
     expect(await setChannelAgent({ teamId: 'T1', channelId: '' }, null)).toBe(false);
+  });
+  test('missing optional override columns returns false instead of crashing', async () => {
+    dbResults = [new Error('PostgresError: column "opencode_model" does not exist')];
+    expect(await setChannelModel({ teamId: 'T1', channelId: 'C1' }, 'anthropic/claude-opus-4-8')).toBe(false);
   });
 });

--- a/apps/api/src/__tests__/unit-slack-session-selection.test.ts
+++ b/apps/api/src/__tests__/unit-slack-session-selection.test.ts
@@ -51,6 +51,7 @@ mock.module('../channels/slack/turn', () => ({
 mock.module('../channels/install-store', () => ({
   loadSlackBotUserIdForProject: async () => 'B1',
   loadSlackTokenForProject: async () => 'xoxb-test',
+  saveSlackOauthInstall: async () => {},
 }));
 mock.module('../channels/slack-api', () => ({
   deleteMessage: async () => {},

--- a/apps/api/src/__tests__/unit-slack-turn.test.ts
+++ b/apps/api/src/__tests__/unit-slack-turn.test.ts
@@ -41,6 +41,7 @@ mock.module('../channels/slack-api', () => ({
 
 mock.module('../channels/install-store', () => ({
   loadSlackTokenForProject: async () => 'xoxb-test',
+  saveSlackOauthInstall: async () => {},
 }));
 
 mock.module('../channels/slack/interactivity', () => ({

--- a/apps/api/src/channels/install-store.ts
+++ b/apps/api/src/channels/install-store.ts
@@ -1,4 +1,4 @@
-import { and, eq, sql } from 'drizzle-orm';
+import { and, eq, isNull } from 'drizzle-orm';
 import { chatInstalls, projectSecrets } from '@kortix/db';
 import { db } from '../shared/db';
 import {
@@ -156,17 +156,37 @@ export async function loadSlackTeamNameForProject(projectId: string): Promise<st
 
 async function upsertSecret(projectId: string, name: string, value: string): Promise<void> {
   const valueEnc = encryptProjectSecret(projectId, value);
-  await db
-    .insert(projectSecrets)
-    .values({ projectId, name, valueEnc })
-    .onConflictDoUpdate({
-      // owner_user_id is left NULL here (a SHARED secret), so the conflict must
-      // target the PARTIAL unique index `(project_id, name) WHERE owner_user_id
-      // IS NULL` — a bare ON CONFLICT (project_id, name) matches no index and 500s.
-      target: [projectSecrets.projectId, projectSecrets.name],
-      targetWhere: sql`${projectSecrets.ownerUserId} is null`,
-      set: { valueEnc, updatedAt: new Date() },
-    });
+  const updated = await updateSharedSecret(projectId, name, valueEnc);
+  if (updated) return;
+
+  try {
+    await db.insert(projectSecrets).values({ projectId, name, valueEnc });
+  } catch (err) {
+    if (!isUniqueConflict(err)) throw err;
+    const retryUpdated = await updateSharedSecret(projectId, name, valueEnc);
+    if (!retryUpdated) throw err;
+  }
+}
+
+async function updateSharedSecret(projectId: string, name: string, valueEnc: string): Promise<boolean> {
+  const rows = await db
+    .update(projectSecrets)
+    .set({ valueEnc, updatedAt: new Date() })
+    .where(and(
+      eq(projectSecrets.projectId, projectId),
+      eq(projectSecrets.name, name),
+      isNull(projectSecrets.ownerUserId),
+    ))
+    .returning({ secretId: projectSecrets.secretId });
+  return rows.length > 0;
+}
+
+function isUniqueConflict(err: unknown): boolean {
+  return (
+    (err as any)?.code === '23505' ||
+    (err as any)?.cause?.code === '23505' ||
+    (err as any)?.cause?.cause?.code === '23505'
+  );
 }
 
 async function readSecret(projectId: string, name: string): Promise<string | null> {

--- a/apps/api/src/channels/slack-oauth.ts
+++ b/apps/api/src/channels/slack-oauth.ts
@@ -103,30 +103,58 @@ slackOauthApp.openapi(
   });
   if (mode.redirectUri) exchangeBody.set('redirect_uri', mode.redirectUri);
 
-  const tokenRes = await fetch('https://slack.com/api/oauth.v2.access', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body: exchangeBody.toString(),
-  });
-  const tokenJson = (await tokenRes.json()) as SlackOauthResponse;
+  let tokenJson: SlackOauthResponse;
+  try {
+    const tokenRes = await fetch('https://slack.com/api/oauth.v2.access', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: exchangeBody.toString(),
+    });
+    tokenJson = (await tokenRes.json()) as SlackOauthResponse;
+  } catch (err) {
+    console.error('[slack-oauth] token exchange failed', {
+      projectId: payload.projectId,
+      error: (err as Error).message,
+    });
+    return redirectToDashboard(c, { projectId: payload.projectId, error: 'oauth_exchange_failed' });
+  }
   if (!tokenJson.ok || !tokenJson.access_token || !tokenJson.team?.id) {
     return redirectToDashboard(c, { error: tokenJson.error ?? 'oauth_exchange_failed' });
   }
 
-  const [project] = await db
-    .select({ projectId: projects.projectId })
-    .from(projects)
-    .where(eq(projects.projectId, payload.projectId))
-    .limit(1);
+  let project: { projectId: string } | undefined;
+  try {
+    [project] = await db
+      .select({ projectId: projects.projectId })
+      .from(projects)
+      .where(eq(projects.projectId, payload.projectId))
+      .limit(1);
+  } catch (err) {
+    console.error('[slack-oauth] project lookup failed', {
+      projectId: payload.projectId,
+      workspaceId: tokenJson.team.id,
+      error: (err as Error).message,
+    });
+    return redirectToDashboard(c, { projectId: payload.projectId, error: 'project_lookup_failed' });
+  }
   if (!project) return redirectToDashboard(c, { error: 'project_not_found' });
 
-  await saveSlackOauthInstall({
-    projectId: payload.projectId,
-    workspaceId: tokenJson.team.id,
-    botToken: tokenJson.access_token,
-    botUserId: tokenJson.bot_user_id ?? '',
-    teamName: tokenJson.team.name ?? null,
-  });
+  try {
+    await saveSlackOauthInstall({
+      projectId: payload.projectId,
+      workspaceId: tokenJson.team.id,
+      botToken: tokenJson.access_token,
+      botUserId: tokenJson.bot_user_id ?? '',
+      teamName: tokenJson.team.name ?? null,
+    });
+  } catch (err) {
+    console.error('[slack-oauth] install save failed', {
+      projectId: payload.projectId,
+      workspaceId: tokenJson.team.id,
+      error: (err as Error).message,
+    });
+    return redirectToDashboard(c, { projectId: payload.projectId, error: 'slack_install_save_failed' });
+  }
 
   return redirectToDashboard(c, { projectId: payload.projectId, success: '1' });
 },

--- a/apps/api/src/channels/slack/selection.ts
+++ b/apps/api/src/channels/slack/selection.ts
@@ -23,19 +23,27 @@ export interface ChannelCtx {
 /** The channel's bound project + its agent/model overrides, or null if unbound. */
 export async function currentChannelSelection(ctx: ChannelCtx): Promise<ChannelSelection | null> {
   if (!ctx.channelId) return null;
-  const [binding] = await db
-    .select({
-      projectId: chatChannelBindings.projectId,
-      agentName: chatChannelBindings.agentName,
-      opencodeModel: chatChannelBindings.opencodeModel,
-    })
-    .from(chatChannelBindings)
-    .where(and(
-      eq(chatChannelBindings.platform, 'slack'),
-      eq(chatChannelBindings.workspaceId, ctx.teamId),
-      eq(chatChannelBindings.channelId, ctx.channelId),
-    ))
-    .limit(1);
+  let binding: { projectId: string | null; agentName: string | null; opencodeModel: string | null } | undefined;
+  try {
+    [binding] = await db
+      .select({
+        projectId: chatChannelBindings.projectId,
+        agentName: chatChannelBindings.agentName,
+        opencodeModel: chatChannelBindings.opencodeModel,
+      })
+      .from(chatChannelBindings)
+      .where(and(
+        eq(chatChannelBindings.platform, 'slack'),
+        eq(chatChannelBindings.workspaceId, ctx.teamId),
+        eq(chatChannelBindings.channelId, ctx.channelId),
+      ))
+      .limit(1);
+  } catch (err) {
+    if (!isMissingSelectionColumnError(err)) throw err;
+    console.warn('[slack-selection] optional channel override columns missing; falling back to project-only routing');
+    const projectId = await currentChannelProjectId(ctx);
+    return projectId ? { projectId, agentName: null, opencodeModel: null } : null;
+  }
   if (!binding?.projectId) return null;
   return {
     projectId: binding.projectId,
@@ -51,31 +59,68 @@ export async function currentChannelSelection(ctx: ChannelCtx): Promise<ChannelS
  */
 export async function setChannelAgent(ctx: ChannelCtx, agentName: string | null): Promise<boolean> {
   if (!ctx.channelId) return false;
-  const rows = await db
-    .update(chatChannelBindings)
-    .set({ agentName })
-    .where(and(
-      eq(chatChannelBindings.platform, 'slack'),
-      eq(chatChannelBindings.workspaceId, ctx.teamId),
-      eq(chatChannelBindings.channelId, ctx.channelId),
-    ))
-    .returning({ id: chatChannelBindings.bindingId });
-  return rows.length > 0;
+  try {
+    const rows = await db
+      .update(chatChannelBindings)
+      .set({ agentName })
+      .where(and(
+        eq(chatChannelBindings.platform, 'slack'),
+        eq(chatChannelBindings.workspaceId, ctx.teamId),
+        eq(chatChannelBindings.channelId, ctx.channelId),
+      ))
+      .returning({ id: chatChannelBindings.bindingId });
+    return rows.length > 0;
+  } catch (err) {
+    if (!isMissingSelectionColumnError(err)) throw err;
+    console.warn('[slack-selection] agent override column missing; ignoring channel override update');
+    return false;
+  }
 }
 
 /** Update the channel binding's model (null clears → project/platform default). */
 export async function setChannelModel(ctx: ChannelCtx, opencodeModel: string | null): Promise<boolean> {
   if (!ctx.channelId) return false;
-  const rows = await db
-    .update(chatChannelBindings)
-    .set({ opencodeModel })
+  try {
+    const rows = await db
+      .update(chatChannelBindings)
+      .set({ opencodeModel })
+      .where(and(
+        eq(chatChannelBindings.platform, 'slack'),
+        eq(chatChannelBindings.workspaceId, ctx.teamId),
+        eq(chatChannelBindings.channelId, ctx.channelId),
+      ))
+      .returning({ id: chatChannelBindings.bindingId });
+    return rows.length > 0;
+  } catch (err) {
+    if (!isMissingSelectionColumnError(err)) throw err;
+    console.warn('[slack-selection] model override column missing; ignoring channel override update');
+    return false;
+  }
+}
+
+async function currentChannelProjectId(ctx: ChannelCtx): Promise<string | null> {
+  const [binding] = await db
+    .select({ projectId: chatChannelBindings.projectId })
+    .from(chatChannelBindings)
     .where(and(
       eq(chatChannelBindings.platform, 'slack'),
       eq(chatChannelBindings.workspaceId, ctx.teamId),
       eq(chatChannelBindings.channelId, ctx.channelId),
     ))
-    .returning({ id: chatChannelBindings.bindingId });
-  return rows.length > 0;
+    .limit(1);
+  return binding?.projectId ?? null;
+}
+
+function isMissingSelectionColumnError(err: unknown): boolean {
+  const parts = [
+    (err as any)?.message,
+    (err as any)?.cause?.message,
+    (err as any)?.cause?.cause?.message,
+  ].filter(Boolean).join('\n');
+  return (
+    parts.includes('column "agent_name" does not exist') ||
+    parts.includes('column "opencode_model" does not exist')
+  );
 }
 
 export interface ProjectAgent {

--- a/supabase/migrations/00000000000118_slack_channel_agent_model.sql
+++ b/supabase/migrations/00000000000118_slack_channel_agent_model.sql
@@ -1,0 +1,10 @@
+-- Keep the Supabase/boot migration stream aligned with the Drizzle schema.
+-- The Slack channel selection code reads these optional overrides from
+-- chat_channel_bindings. Dev/prod databases that only applied the legacy
+-- Supabase migrations can miss the Drizzle-only 20260616161826 migration and
+-- crash async Slack dispatch after adding the hourglass reaction.
+
+ALTER TABLE "kortix"."chat_channel_bindings"
+  ADD COLUMN IF NOT EXISTS "agent_name" varchar(128),
+  ADD COLUMN IF NOT EXISTS "opencode_model" varchar(128);
+


### PR DESCRIPTION
## Summary
- add the missing Supabase/boot migration for Slack channel agent/model override columns
- make Slack channel selection fall back to project-only routing if cloud DBs are briefly missing optional override columns
- replace fragile partial-index ON CONFLICT for Slack OAuth secret persistence with update/insert/retry semantics
- make OAuth callback redirect with explicit error params instead of raw 500s on persistence/token failures

## Root cause
Slack broke in the 0.9.56 line before the invocation-engine PR: `75ba5c534` introduced per-channel agent/model selection and a Drizzle-only migration. Dev/prod Slack handlers then queried `chat_channel_bindings.agent_name` / `opencode_model` while the runtime Supabase migration stream had not added those columns. Async Slack dispatch crashed after adding the hourglass reaction. Dev logs also showed OAuth reconnect failing on the shared `project_secrets` partial-index upsert.

## Verification
- `dotenvx run -- bun test src/__tests__/unit-slack-oauth.test.ts src/__tests__/unit-slack-selection.test.ts`
- `KORTIX_URL=http://localhost:13308 dotenvx run -- bash -c 'for f in src/__tests__/unit-slack-commands.test.ts src/__tests__/unit-slack-interactivity-selection.test.ts src/__tests__/unit-slack-questions.test.ts src/__tests__/unit-slack-turn.test.ts src/__tests__/unit-slack-session-selection.test.ts src/__tests__/unit-slack-dispatch-session.test.ts src/__tests__/unit-slack-manifest.test.ts; do bun test "$f" || exit 1; done'`\n- `pnpm --filter kortix-api typecheck`\n- local DB smoke: applied `00000000000118_slack_channel_agent_model.sql` against worktree DB and verified both columns exist\n- local DB smoke: called actual `saveSlackOauthInstall()` twice against worktree DB and verified one shared row per Slack secret with `ownerUserId: null`\n\nLive dev logs before fix showed both known signatures:\n- `PostgresError: column "agent_name" does not exist` in `[slack-webhook] oauth/byo handler failed`\n- OAuth callback 500 on `project_secrets` insert with partial-index `on conflict (project_id,name) where ... owner_user_id is null`\n