### PR TITLE
ci: drop ECS Fargate fallback deploy jobs (deprecating ECS)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -6,14 +6,12 @@ name: Deploy Dev
 # release tag (see the dev-version job). So dev tracks prod automatically and
 # `main` carries no release-version bump.
 #
-#   - API image   → kortix/kortix-api:dev-<sha8> + :dev-latest, then deployed to
-#                   BOTH dev backends in parallel: EKS (primary) via GitOps (the
-#                   deploy-api job bumps infra/k8s/envs/dev/values.yaml to
-#                   :dev-<sha8> and Argo CD rolls the Deployment; the workflow
-#                   waits for it), and the ECS Fargate hot-standby (deploy-api-ecs
-#                   force-rolls kortix-dev on :dev-latest). dev-api.kortix.com is a
-#                   Cloudflare Worker that routes to either (dev-api-eks /
-#                   dev-api-ecs-fargate) — see infra/cloudflare/workers/api-router.
+#   - API image   → kortix/kortix-api:dev-<sha8> + :dev-latest, deployed to dev
+#                   EKS via GitOps: the deploy-api job bumps
+#                   infra/k8s/envs/dev/values.yaml to :dev-<sha8> and Argo CD rolls
+#                   the Deployment (the workflow waits for it). dev-api.kortix.com
+#                   is a Cloudflare Worker routing to dev-api-eks
+#                   (see infra/cloudflare/workers/api-router).
 #   - Frontend    → kortix/kortix-frontend:dev-<sha8> + :dev-latest (image is for
 #                   self-hosters). dev.kortix.com itself is deployed by Vercel
 #                   from `main` via Vercel's own Git integration — no deploy step.
@@ -291,88 +289,6 @@ jobs:
           {
             echo "### Deployed API → **dev** (EKS / Argo CD GitOps)"
             echo "Image \`kortix/kortix-api:${{ steps.bump.outputs.tag }}\` → \`infra/k8s/envs/dev/values.yaml\` → Argo CD rolled the dev Deployment."
-            echo "Live: \`$(printf '%s' "$h" | jq -c '{version,commit,environment}' 2>/dev/null || echo '?')\`"
-          } >> "$GITHUB_STEP_SUMMARY"
-
-  # ── Roll the dev ECS Fargate FALLBACK onto the same image ───────────────────
-  # EKS is primary (deploy-api above); ECS Fargate is the always-warm standby
-  # behind dev-api-ecs-fargate.kortix.com, so the dev-api Cloudflare Worker can
-  # fail over to it instantly (flip ACTIVE_BACKEND → ecs-fargate). Runs in
-  # PARALLEL with the EKS roll — it never gates or delays the primary deploy.
-  # Both run the same image against the same dev DB; that's safe because
-  # background-worker leadership is a single global DB lease
-  # (apps/api/src/shared/leader-election.ts), so only one side ever runs cron.
-  deploy-api-ecs:
-    name: Deploy API to dev (ECS fallback)
-    needs: [detect-changes, tag-api]
-    if: needs.detect-changes.outputs.api == 'true'
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write # assume the AWS role via GitHub OIDC
-      contents: read
-    env:
-      AWS_REGION: us-west-2
-      CLUSTER: kortix-dev
-      SERVICE: kortix-dev
-      ROLE: arn:aws:iam::935064898258:role/kortix-gha-ecs-deploy
-    steps:
-      - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v6
-        with:
-          role-to-assume: ${{ env.ROLE }}
-          aws-region: ${{ env.AWS_REGION }}
-
-      - name: Guard — ECS service exists
-        id: guard
-        run: |
-          set -uo pipefail
-          st="$(aws ecs describe-services --cluster "$CLUSTER" --services "$SERVICE" \
-                --query 'services[0].status' --output text 2>/dev/null || true)"
-          if [ "$st" = "ACTIVE" ]; then
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "exists=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::ECS fallback service $SERVICE not ACTIVE (status=$st) — skipping."
-          fi
-
-      - name: Roll the ECS fallback onto the freshly-built image
-        if: steps.guard.outputs.exists == 'true'
-        run: |
-          set -euo pipefail
-          # The kortix-dev task definition pins kortix/kortix-api:dev-latest (the
-          # tag-api job just pushed it), so force-new-deployment re-pulls that tag
-          # and rolls the standby — same tracking model as the EKS primary.
-          echo "Rolling ECS fallback $SERVICE onto :dev-latest…"
-          DEP_ID="$(aws ecs update-service --cluster "$CLUSTER" --service "$SERVICE" \
-            --force-new-deployment \
-            --query 'service.deployments[?status==`PRIMARY`]|[0].id' --output text)"
-          # `wait services-stable` returns success even if the deployment circuit
-          # breaker rolled OUR deployment back (the service is "stable" again on
-          # the prior task set). So verify the deployment WE triggered actually
-          # completed and is still PRIMARY — else it was rolled back → go red.
-          aws ecs wait services-stable --cluster "$CLUSTER" --services "$SERVICE" || true
-          STATE="$(aws ecs describe-services --cluster "$CLUSTER" --services "$SERVICE" \
-            --query "services[0].deployments[?id=='$DEP_ID']|[0].rolloutState" --output text)"
-          PRIMARY_ID="$(aws ecs describe-services --cluster "$CLUSTER" --services "$SERVICE" \
-            --query 'services[0].deployments[?status==`PRIMARY`]|[0].id' --output text)"
-          if [ "$STATE" = "FAILED" ] || { [ "$STATE" != "COMPLETED" ] && [ "$PRIMARY_ID" != "$DEP_ID" ]; }; then
-            echo "::error::dev ECS fallback roll failed/rolled back (deployment $DEP_ID state=$STATE, primary=$PRIMARY_ID). Recent events:"
-            aws ecs describe-services --cluster "$CLUSTER" --services "$SERVICE" \
-              --query 'services[0].events[0:6].message' --output text || true
-            exit 1
-          fi
-          echo "✓ ECS fallback rolled (deployment $DEP_ID COMPLETED)"
-          aws ecs describe-services --cluster "$CLUSTER" --services "$SERVICE" \
-            --query 'services[0].{running:runningCount,desired:desiredCount,rollout:deployments[0].rolloutState}' \
-            --output table
-
-      - name: Summary
-        if: always() && steps.guard.outputs.exists == 'true'
-        run: |
-          h="$(curl -s --max-time 10 "https://dev-api-ecs-fargate.kortix.com/v1/health" || true)"
-          {
-            echo "### Deployed API → **dev** (ECS Fargate fallback)"
-            echo "Rolled \`kortix/kortix-api:dev-latest\` onto ECS service \`kortix-dev\` (standby behind dev-api-ecs-fargate)."
             echo "Live: \`$(printf '%s' "$h" | jq -c '{version,commit,environment}' 2>/dev/null || echo '?')\`"
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -10,20 +10,14 @@ name: Deploy Prod
 #      (multi-arch manifest copy, zero rebuilds).
 #   2. Build the prod CLI (4 targets, default api.kortix.com) + prod desktop
 #      installers and cut a single GitHub Release `vX.Y.Z`.
-#   3. EKS deploy (primary): the promote PR merge already bumped
-#      infra/k8s/envs/prod, so Argo CD rolls the prod Deployment — this job
-#      WATCHES it reach vX.Y.Z and announces to Slack.
-#   3b. ECS Fargate deploy (fallback): in PARALLEL, roll the kortix-prod ECS
-#      service onto the same vX.Y.Z so it stays a warm hot-standby (never gates
-#      the release). See the deploy-api-ecs job.
+#   3. EKS deploy: the promote PR merge already bumped infra/k8s/envs/prod, so
+#      Argo CD rolls the prod Deployment — this job WATCHES it reach vX.Y.Z and
+#      announces to Slack.
 #   4. Deploy the prod frontend on Vercel (the `prod` branch → kortix.com).
 #
-# The prod stack is api.kortix.com → EKS (primary) + kortix.com (Vercel).
-# api.kortix.com is a Cloudflare Worker (infra/cloudflare/workers/api-router) that
-# routes to EKS (api-eks, ACTIVE_BACKEND=eks) or the ECS Fargate hot-standby
-# (api-ecs-fargate) — flip ACTIVE_BACKEND to fail over instantly. EKS rolls via
-# Argo CD GitOps; ECS rolls here in parallel. Both run the same image against the
-# same DB (one global worker-leader lease), so a flip is safe.
+# The prod stack is api.kortix.com → EKS + kortix.com (Vercel). api.kortix.com is
+# a Cloudflare Worker (infra/cloudflare/workers/api-router) routing to api-eks.
+# EKS rolls via Argo CD GitOps.
 
 on:
   push:
@@ -627,112 +621,6 @@ jobs:
             sleep $((attempt * 3))
           done
           echo "::error::Slack failed after 5 attempts (last: ${err})."; exit 1
-
-  # ── Roll the prod ECS Fargate FALLBACK onto the new image ───────────────────
-  # EKS is the live prod backend (deploy-api above); ECS Fargate is the always-
-  # warm standby behind api-ecs-fargate.kortix.com, so the api.kortix.com Worker
-  # can fail over to it instantly (flip ACTIVE_BACKEND → ecs-fargate). Runs in
-  # PARALLEL with the EKS watch — it never gates the release. Both run the same
-  # image against the same prod DB; safe because background-worker leadership is a
-  # single global DB lease (apps/api/src/shared/leader-election.ts) → one leader.
-  deploy-api-ecs:
-    name: Deploy API to prod (ECS fallback)
-    needs: [version, retag-images]
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write # assume the AWS role via GitHub OIDC
-      contents: read
-    env:
-      AWS_REGION: us-west-2
-      CLUSTER: kortix-prod
-      SERVICE: kortix-prod
-      ROLE: arn:aws:iam::935064898258:role/kortix-gha-ecs-deploy
-    steps:
-      - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v6
-        with:
-          role-to-assume: ${{ env.ROLE }}
-          aws-region: ${{ env.AWS_REGION }}
-
-      - name: Guard — ECS service exists
-        id: guard
-        run: |
-          set -uo pipefail
-          st="$(aws ecs describe-services --cluster "$CLUSTER" --services "$SERVICE" \
-                --query 'services[0].status' --output text 2>/dev/null || true)"
-          if [ "$st" = "ACTIVE" ]; then
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "exists=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::ECS fallback service $SERVICE not ACTIVE (status=$st) — skipping."
-          fi
-
-      - name: Roll the prod ECS fallback (clean version stamped)
-        if: steps.guard.outputs.exists == 'true'
-        env:
-          VERSION: ${{ needs.version.outputs.version }}
-        run: |
-          set -euo pipefail
-          # The image is retagged (not rebuilt), so it carries the promoted DEV
-          # build's KORTIX_VERSION default. Register a new task-def revision that
-          # stamps the clean X.Y.Z so the fallback's /v1/health reports e.g. 0.9.1
-          # (matching EKS), not 0.9.1-dev.<sha>. Everything else is preserved.
-          echo "Stamping KORTIX_VERSION=$VERSION onto a new kortix-prod task-def revision…"
-          CURRENT_TD=$(aws ecs describe-services --cluster "$CLUSTER" --services "$SERVICE" \
-            --query 'services[0].taskDefinition' --output text)
-          aws ecs describe-task-definition --task-definition "$CURRENT_TD" \
-            --query 'taskDefinition' --output json > td.json
-
-          # Also pin the released image :X.Y.Z (retag-images just created it) so
-          # the standby runs the EXACT same artifact as EKS — not the floating
-          # dev-latest tag the old task def carried.
-          jq --arg v "$VERSION" '
-            del(.taskDefinitionArn, .revision, .status, .requiresAttributes,
-                .compatibilities, .registeredAt, .registeredBy, .deregisteredAt)
-            | .containerDefinitions |= map(
-                (if (.image | test("kortix/kortix-api"))
-                   then .image = "kortix/kortix-api:\($v)" else . end)
-                | .environment = ((.environment // []) | map(select(.name != "KORTIX_VERSION"))
-                                 + [{name: "KORTIX_VERSION", value: $v}]))
-          ' td.json > td-new.json
-
-          NEW_TD=$(aws ecs register-task-definition --cli-input-json file://td-new.json \
-            --query 'taskDefinition.taskDefinitionArn' --output text)
-          echo "Registered $NEW_TD"
-
-          echo "Rolling $SERVICE onto v$VERSION…"
-          aws ecs update-service --cluster "$CLUSTER" --service "$SERVICE" \
-            --task-definition "$NEW_TD" --force-new-deployment >/dev/null
-          # `wait services-stable` returns success even when the deployment
-          # circuit breaker ROLLED BACK to the old task def (the service is
-          # "stable" again — on the old revision). So don't trust it: after it
-          # settles, assert the PRIMARY deployment is actually OUR $NEW_TD and
-          # COMPLETED. Otherwise the roll failed and we must go red.
-          aws ecs wait services-stable --cluster "$CLUSTER" --services "$SERVICE" || true
-          PRIMARY_TD="$(aws ecs describe-services --cluster "$CLUSTER" --services "$SERVICE" \
-            --query 'services[0].deployments[?status==`PRIMARY`]|[0].taskDefinition' --output text)"
-          ROLLOUT="$(aws ecs describe-services --cluster "$CLUSTER" --services "$SERVICE" \
-            --query 'services[0].deployments[?status==`PRIMARY`]|[0].rolloutState' --output text)"
-          if [ "$PRIMARY_TD" != "$NEW_TD" ] || [ "$ROLLOUT" != "COMPLETED" ]; then
-            echo "::error::ECS fallback roll did NOT land — primary=$PRIMARY_TD rollout=$ROLLOUT, expected $NEW_TD/COMPLETED (circuit breaker likely rolled back). Recent events:"
-            aws ecs describe-services --cluster "$CLUSTER" --services "$SERVICE" \
-              --query 'services[0].events[0:6].message' --output text || true
-            exit 1
-          fi
-          echo "✓ ECS fallback on $NEW_TD (COMPLETED)"
-          aws ecs describe-services --cluster "$CLUSTER" --services "$SERVICE" \
-            --query 'services[0].{running:runningCount,desired:desiredCount,rollout:deployments[0].rolloutState}' \
-            --output table
-
-      - name: Summary
-        if: always() && steps.guard.outputs.exists == 'true'
-        run: |
-          h="$(curl -s --max-time 10 "https://api-ecs-fargate.kortix.com/v1/health" || true)"
-          {
-            echo "### Deployed API → **prod** (ECS Fargate fallback)"
-            echo "v${{ needs.version.outputs.version }} rolled onto ECS service \`kortix-prod\` (standby behind api-ecs-fargate)."
-            echo "Live: \`$(printf '%s' "$h" | jq -c '{version,commit,environment}' 2>/dev/null || echo '?')\`"
-          } >> "$GITHUB_STEP_SUMMARY"
 
   # ── Prod frontend (Vercel) ──────────────────────────────────────────────────
   # No job here: the Vercel project is git-connected and auto-deploys the `prod`

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -195,7 +195,7 @@ jobs:
           if [ -n "$existing" ]; then
             echo "Release PR #$existing already open for $RELBR."
           else
-            printf '%s\n\n%s\n\n---\n_Merging this PR **publishes %s**: tags it, cuts the GitHub Release, retags images, rolls the prod ECS service, and — via the bumped `infra/k8s/envs/prod/values.yaml` — has Argo CD deploy EKS prod. Nothing is published until this merges._\n' \
+            printf '%s\n\n%s\n\n---\n_Merging this PR **publishes %s**: tags it, cuts the GitHub Release, retags images, and — via the bumped `infra/k8s/envs/prod/values.yaml` — has Argo CD deploy EKS prod. Nothing is published until this merges._\n' \
               "$IN_TITLE" "$IN_NOTES" "$TAG" \
               | gh pr create --base prod --head "$RELBR" --title "Release $TAG — $IN_TITLE" --body-file -
           fi
@@ -209,5 +209,5 @@ jobs:
             echo "- Proposed version: \`${{ steps.ver.outputs.new }}\`"
             echo "- \`${{ inputs.ref }}\` → \`release/${{ steps.ver.outputs.tag }}\` → PR into \`prod\`"
             echo ""
-            echo "_Nothing is published yet. A reviewer approves + merges the PR; the **merge** publishes the version (tag + GitHub Release + image retag + ECS roll + frontend)._"
+            echo "_Nothing is published yet. A reviewer approves + merges the PR; the **merge** publishes the version (tag + GitHub Release + image retag + EKS roll + frontend)._"
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
EKS is the sole API backend now, so the ECS Fargate hot-standby deploys are dead weight.

- Removes the `deploy-api-ecs` job from **deploy-dev.yml** and **deploy-prod.yml** (nothing `needs:` them — they ran in parallel and never gated the release).
- Updates the workflow header docs + the promote PR-body text to EKS-only (no more "ECS roll" / hot-standby references).

No behavior change to the EKS path. The ECS services/Cloudflare-Worker failover can be torn down separately whenever you're ready.