### PR TITLE
fix(external-dns): pin kortix.com zone via --zone-id-filter (was managing nothing)

### DIFF
--- a/infra/terraform/environments/dev-eks/platform/main.tf
+++ b/infra/terraform/environments/dev-eks/platform/main.tf
@@ -90,8 +90,9 @@ module "platform" {
   oidc_provider_url = local.cluster.oidc_provider_url
   api_domain        = local.cluster.api_domain
   # Let external-dns also auto-manage per-PR preview records
-  # (pr-<n>.preview-api.kortix.com) — created/deleted with each preview Ingress.
-  extra_domain_filters = ["preview-api.kortix.com"]
+  # (pr-<n>.preview-api.kortix.com) — created/deleted with each preview Ingress —
+  # and the standalone LLM gateway host (gateway-dev.kortix.com).
+  extra_domain_filters = ["preview-api.kortix.com", "gateway-dev.kortix.com"]
 
   cloudflare_api_token = var.cloudflare_api_token
   cloudflare_zone_id   = var.cloudflare_zone_id

--- a/infra/terraform/environments/prod-eks/platform/main.tf
+++ b/infra/terraform/environments/prod-eks/platform/main.tf
@@ -89,6 +89,8 @@ module "platform" {
   oidc_provider_arn = local.cluster.oidc_provider_arn
   oidc_provider_url = local.cluster.oidc_provider_url
   api_domain        = local.cluster.api_domain
+  # Let external-dns also manage the standalone LLM gateway host.
+  extra_domain_filters = ["gateway.kortix.com"]
 
   cloudflare_api_token = var.cloudflare_api_token
   cloudflare_zone_id   = var.cloudflare_zone_id

--- a/infra/terraform/modules/eks/platform/main.tf
+++ b/infra/terraform/modules/eks/platform/main.tf
@@ -131,8 +131,13 @@ resource "helm_release" "external_dns" {
       }
     }]
     domainFilters = concat([var.api_domain], var.extra_domain_filters)
-    zoneIdFilters = var.cloudflare_zone_id != "" ? [var.cloudflare_zone_id] : []
-    policy        = "sync"
+    # Pin the kortix.com zone by ID via extraArgs (the chart silently drops a
+    # top-level `zoneIdFilters` value, so it never reached the container). REQUIRED:
+    # the domainFilters are subdomains, so without --zone-id-filter external-dns
+    # matches the zone NAME (kortix.com) against them, finds no match, discards the
+    # zone, and manages nothing.
+    extraArgs = var.cloudflare_zone_id != "" ? ["--zone-id-filter=${var.cloudflare_zone_id}"] : []
+    policy    = "sync"
     registry      = "txt"
     txtOwnerId    = var.cluster_name
     # Cloudflare proxying is decided per-record via the Ingress annotation


### PR DESCRIPTION
## The bug
external-dns was a **no-op cluster-wide** — it managed **zero** DNS records (not `dev-api-eks`, not previews, nothing). Every record on the cluster has actually been created by hand.

**Why:** the `domainFilters` are subdomains (`dev-api-eks…`, `preview-api…`, `gateway-dev…`). With no zone-id filter, external-dns matches the **zone name** (`kortix.com`) against those subdomain filters, finds no match, **discards the whole zone**, and skips every record:
```
no zoneIDFilter configured, looking at all zones
zone kortix.com not in domain filter
Skipping record dev-api-eks.kortix.com because no hosted zone matching record DNS Name was detected
```

The module *tried* to fix this with a top-level `zoneIdFilters` value — but the external-dns chart **doesn't surface that key**, so helm silently dropped it and `--zone-id-filter` never reached the container. (`domainFilters` works because the chart *does* expose it.)

## The fix
Pass `--zone-id-filter=<kortix.com zone id>` via **`extraArgs`** (the chart's escape hatch), and add the gateway hosts to the dev/prod domain filters.

**Verified on dev:** the arg now lands in the deployment, and external-dns went from "skipping everything" to actively creating + owning records — I deleted a manual `gateway-dev` record and it recreated the CNAME + TXT ownership itself. So all cluster DNS is now self-healing.

## Apply
Requires `TF_VAR_cloudflare_zone_id` (the kortix.com zone id) at platform apply — already applied to **dev**; **prod platform** needs the same apply.