### PR TITLE
fix(docker): copy packages/registry into api + sandbox image builds

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -34,10 +34,11 @@ WORKDIR /cli
 
 ARG KORTIX_AGENT_BUN_TARGET=bun-linux-x64
 
-# Minimal workspace so bun resolves the two `@kortix/*` packages the CLI imports
+# Minimal workspace so bun resolves the `@kortix/*` packages the CLI imports
 # to their source, then compile (inlines them + smol-toml into one binary).
 COPY apps/cli ./apps/cli
 COPY packages/manifest-schema ./packages/manifest-schema
+COPY packages/registry ./packages/registry
 COPY packages/starter ./packages/starter
 RUN printf '{"name":"kortix-cli-build","private":true,"workspaces":["apps/cli","packages/*"]}\n' > package.json \
     && bun install --no-save \
@@ -61,6 +62,7 @@ COPY packages/db ./packages/db
 COPY packages/agent-tunnel ./packages/agent-tunnel
 COPY packages/starter ./packages/starter
 COPY packages/manifest-schema ./packages/manifest-schema
+COPY packages/registry ./packages/registry
 COPY packages/llm-gateway ./packages/llm-gateway
 
 # Install pnpm and deps for this app + workspace packages it depends on.
@@ -125,6 +127,9 @@ COPY --from=deps /app/packages/starter/templates ./packages/starter/templates
 COPY --from=deps /app/packages/manifest-schema/src ./packages/manifest-schema/src
 COPY --from=deps /app/packages/manifest-schema/package.json ./packages/manifest-schema/package.json
 COPY --from=deps /app/packages/manifest-schema/tsconfig.json ./packages/manifest-schema/tsconfig.json
+COPY --from=deps /app/packages/registry/src ./packages/registry/src
+COPY --from=deps /app/packages/registry/package.json ./packages/registry/package.json
+COPY --from=deps /app/packages/registry/tsconfig.json ./packages/registry/tsconfig.json
 COPY --from=deps /app/packages/llm-gateway/src ./packages/llm-gateway/src
 COPY --from=deps /app/packages/llm-gateway/package.json ./packages/llm-gateway/package.json
 COPY --from=deps /app/packages/llm-gateway/tsconfig.json ./packages/llm-gateway/tsconfig.json

--- a/apps/sandbox/Dockerfile
+++ b/apps/sandbox/Dockerfile
@@ -61,6 +61,7 @@ ARG TARGETARCH
 WORKDIR /cli
 COPY apps/cli ./apps/cli
 COPY packages/manifest-schema ./packages/manifest-schema
+COPY packages/registry ./packages/registry
 COPY packages/starter ./packages/starter
 RUN printf '{"name":"kortix-cli-build","private":true,"workspaces":["apps/cli","packages/*"]}\n' > package.json \
     && case "${TARGETARCH:-}" in \


### PR DESCRIPTION
The marketplace merge (#3485) broke **Deploy Dev** — the API image's `sandbox-cli` build stage failed with `Workspace dependency "@kortix/registry" not found`.

`apps/cli` + `apps/api` now depend on `@kortix/registry` (workspace:*), but the Dockerfiles COPY only the specific packages each stage needs. This adds `packages/registry` to:
- api: cli-build + deps + runtime stages
- sandbox: cli-build stage

mirroring `@kortix/manifest-schema`. **Verified locally** — the `sandbox-cli` stage now resolves `@kortix/registry` and compiles the CLI binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)