### PR TITLE
fix(gateway): flush langfuse trace after each record (traces never delivered under Bun)

### DIFF
--- a/apps/llm-gateway/src/observability/langfuse.ts
+++ b/apps/llm-gateway/src/observability/langfuse.ts
@@ -104,6 +104,7 @@ export function createLangfuseSink(
       try {
         const { trace: traceBody, generation } = traceToLangfuse(trace);
         client.trace(traceBody).generation(generation);
+        await client.flushAsync();
       } catch (err) {
         logger.warn('[gateway] failed to record trace to langfuse', err);
       }


### PR DESCRIPTION
## Symptom
The dev gateway is healthy and answers requests, but **emits zero Langfuse traces** — even after keys were correctly wired (verified: keys auth to the \`kortix-dev\` project, pod egress to cloud.langfuse.com is 200, the \`tracing disabled\` warning is gone).

## Root cause
Traces are **enqueued but never flushed** during normal operation. The Langfuse JS SDK batches events and relies on a background auto-flush (`flushAt: 15` / `flushInterval` timer) that **does not fire reliably under Bun**. The only flush wired was on process shutdown.

Proven end-to-end: a forced `missing_token` request recorded nothing in Langfuse for 18s, then **appeared the instant the pod was restarted** (shutdown's `flushAsync()` drained the queue). So the pipeline is correct — it just never flushes while running.

## Fix
Flush after each record. `recordTrace` is fire-and-forget (`void hooks.recordTrace(...).catch(...)` in `pipeline/trace.ts`), so awaiting `flushAsync()` inside `record()` guarantees delivery **without adding latency** to the request path. `flushAsync()` is the exact call that's proven to work in this runtime.

```ts
client.trace(traceBody).generation(generation);
await client.flushAsync();
```

## Verification
- Observability tests pass (3/3).
- Once merged, `deploy-dev` rebuilds `kortix-gateway` (path filter `apps/llm-gateway/**`) and Argo rolls it; the next agent message will trace to the `kortix-dev` project.