### PR TITLE
infra: colocate all envs in eu-west-2 (with prod DB)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -192,7 +192,7 @@ jobs:
       id-token: write # OIDC → read the dev cluster
       contents: write # push the values bump to main
     env:
-      AWS_REGION: us-west-2
+      AWS_REGION: eu-west-2
       CLUSTER: kortix-dev-eks
       NAMESPACE: kortix-dev
       APP: kortix-api

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -471,7 +471,7 @@ jobs:
       id-token: write # OIDC → read the cluster
       contents: read
     env:
-      AWS_REGION: us-west-2
+      AWS_REGION: eu-west-2
       CLUSTER: kortix-prod-eks
       NAMESPACE: kortix-prod
       APP: kortix-api

--- a/infra/CICD.md
+++ b/infra/CICD.md
@@ -137,9 +137,10 @@ release; `KORTIX_CHANNEL=dev` → `dev-latest` prerelease.
 | DEV  | `main` | dev.kortix.com (Vercel) | dev-api.kortix.com → `kortix-dev`  |
 | PROD | `prod` | kortix.com (Vercel)     | api-prod.kortix.com → `kortix-prod`|
 
-AWS: account `935064898258`, region `us-west-2`. State in S3
-(`kortix-terraform-state` + DynamoDB locks). Terraform under `infra/terraform`
-(modules `network`, `acm-cloudflare`, `cloudflare-dns`, `ecs-api`).
+AWS: account `935064898258`, region `eu-west-2` (colocated with the prod
+Supabase DB — see `infra/REGION-MIGRATION.md` for the us-west-2 → eu-west-2 move).
+State in S3 (`kortix-terraform-state` + DynamoDB locks). Terraform under
+`infra/terraform` (modules `network`, `acm-cloudflare`, `cloudflare-dns`, `ecs-api`).
 
 ### api.kortix.com — the Cloudflare Worker cutover switch
 

--- a/infra/EKS.md
+++ b/infra/EKS.md
@@ -94,7 +94,7 @@ terraform apply                                 # ~5 min (Helm releases)
 cd ../cluster
 ROLE_ARN=$(terraform output -raw app_irsa_role_arn)
 CERT_ARN=$(terraform output -raw acm_certificate_arn)
-aws eks update-kubeconfig --name kortix-prod-eks --region us-west-2
+aws eks update-kubeconfig --name kortix-prod-eks --region eu-west-2
 helm upgrade --install kortix-api ../../../k8s/charts/kortix-api \
   --namespace kortix-prod \
   --set image.tag="$(tr -d '[:space:]' < ../../../../VERSION)" \
@@ -133,7 +133,7 @@ Discontinue ECS only after EKS is proven; until then both serve in parallel.
 ## Operations
 
 ```bash
-aws eks update-kubeconfig --name kortix-prod-eks --region us-west-2
+aws eks update-kubeconfig --name kortix-prod-eks --region eu-west-2
 
 kubectl -n kortix-prod get pods -o wide          # placement across AZs/nodes
 kubectl -n kortix-prod rollout status deploy/kortix-api

--- a/infra/REGION-MIGRATION.md
+++ b/infra/REGION-MIGRATION.md
@@ -1,0 +1,86 @@
+# Region migration: us-west-2 (Oregon) → eu-west-2 (London)
+
+## Why
+
+Prod compute (EKS + ECS) runs in `us-west-2` but the prod Postgres (Supabase
+`supa.kortix.com` → project `jbriwassebxdwoieikga`) lives in `eu-west-2`. Every
+DB round-trip crosses the Atlantic (~130ms+ RTT), which inflates p95 latency and,
+under load or a transient cross-region blip, stacks up request handlers until
+they time out — while the shallow `/health` probe (no DB) stays green, so EKS and
+Better Stack never register the incident.
+
+**Decision: colocate everything in `eu-west-2`** (move the compute to the DB —
+the DB is the harder thing to move). This brings DB latency to single-digit ms.
+
+## What this PR changes (code)
+
+A pure region-literal flip across the infra-as-code so a *fresh* `terraform
+apply` + GitOps reconcile stands the whole stack up in `eu-west-2`:
+
+- **Terraform** — every `aws_region` default, every S3 backend `region`, the
+  `terraform_remote_state` region, every provider `region`, and the
+  region-bound ARNs (DynamoDB lock table, Secrets Manager examples) →
+  `eu-west-2`. The CloudTrail KMS `use1` (`us-east-1`) provider alias is
+  deliberately left as-is (multi-region trail homed in us-east-1).
+- **k8s GitOps values** (`infra/k8s/envs/*`) — `externalSecrets.region` →
+  `eu-west-2`. ACM `certificateArn`s are **placeholdered**
+  (`REPLACE_WITH_EU_WEST_2_CERT`) because an ACM cert is region-bound: the old
+  us-west-2 cert UUIDs cannot front an eu-west-2 ALB. They must be set to the new
+  cert ARNs that apply emits (step 4).
+- **Deploy workflows** (`deploy-dev.yml`, `deploy-prod.yml`) — `AWS_REGION` →
+  `eu-west-2`.
+- **Docs** (`CICD.md`, `EKS.md`, terraform READMEs, security-baseline README).
+
+> ⚠️ **The code change alone does NOT move the live stack.** Terraform state,
+> S3/DynamoDB state backend, ACM certs, Secrets Manager, ECR images and the
+> running clusters are all region-scoped. Merging this PR is step 1 of the
+> runbook below — the cutover is a deliberate, ordered, operator-run migration.
+
+## Runbook (ordered, operator-run)
+
+Pre-req: AWS creds for account `935064898258`; a maintenance window; the prod
+Supabase project already lives in eu-west-2 (it does), so the DB does **not**
+move — only compute + state + supporting AWS resources.
+
+1. **State backend in eu-west-2.** The S3 state bucket + DynamoDB lock table are
+   region-bound. Either (a) create new ones in eu-west-2 and migrate state, or
+   (b) keep the existing bucket if it's acceptable cross-region for *state only*
+   (state access is infrequent and not latency-sensitive). Recommended (a):
+   ```sh
+   AWS_REGION=eu-west-2 TF_STATE_BUCKET=kortix-terraform-state-euw2 \
+     infra/terraform/scripts/bootstrap-state.sh
+   # then per stack: terraform init -migrate-state -backend-config=...
+   ```
+   Update each `backend.tf` bucket name if you use a new bucket.
+2. **ECR / image registry.** Confirm the API image is pullable from eu-west-2
+   (Docker Hub `kortix/*` is region-agnostic — no change; if any ECR is used,
+   replicate the repo to eu-west-2 first).
+3. **Apply the foundational stacks in eu-west-2** (new VPCs, subnets, NAT, EKS
+   cluster, node groups):
+   ```sh
+   cd infra/terraform/environments/prod-eks/cluster && terraform init -reconfigure && terraform apply
+   cd ../platform && terraform init -reconfigure && terraform apply
+   # (dev-eks the same; ECS prod/dev stacks if still in use)
+   ```
+4. **New ACM certs.** The acm-cloudflare module requests fresh certs in
+   eu-west-2 and emits their ARNs. Copy each into the matching
+   `infra/k8s/envs/*/values.yaml` `certificateArn` (replacing
+   `REPLACE_WITH_EU_WEST_2_CERT`) and commit — that commit is what lets Argo CD
+   bring up the eu-west-2 ingress with a valid cert.
+5. **Secrets Manager.** Recreate the `kortix-{prod,dev}-env` secret bundle in
+   eu-west-2 (Secrets Manager is regional). External Secrets in the new cluster
+   reads it via the IRSA role (already region-flipped in values).
+6. **Bring up the app on eu-west-2, verify against the prod DB** (now in-region —
+   confirm p95 DB latency drops to single-digit ms) while `api.kortix.com` still
+   points at the old stack. `manage_dns=false` keeps the live record untouched.
+7. **Cutover.** Repoint `api.kortix.com` (and `dev-api`) Cloudflare CNAME → the
+   new eu-west-2 ALB. Instantly reversible (flip the CNAME back).
+8. **Decommission us-west-2** once stable: destroy the old stacks, delete old
+   certs/secrets, remove the old state objects.
+
+## Rollback
+
+Every step is reversible until step 8. The DNS cutover (step 7) is the only
+user-visible flip and is a single Cloudflare record change back to the old ALB.
+Do not run step 8 until the eu-west-2 stack has been stable through a full
+business-day peak.

--- a/infra/k8s/charts/kortix-api/values.yaml
+++ b/infra/k8s/charts/kortix-api/values.yaml
@@ -80,7 +80,7 @@ serviceAccount:
 # Deployment consumes via envFrom. This is the SAME secret the ECS task reads.
 externalSecrets:
   enabled: true
-  region: us-west-2
+  region: eu-west-2
   secretName: kortix-prod-env # Secrets Manager source bundle (friendly name; ECS references the same secret by its full ARN kortix-prod-env-omifd2)
   targetSecretName: kortix-api-env # synced k8s Secret
   refreshInterval: 1h

--- a/infra/k8s/envs/dev/values.yaml
+++ b/infra/k8s/envs/dev/values.yaml
@@ -52,7 +52,7 @@ serviceAccount:
   roleArn: arn:aws:iam::935064898258:role/kortix-dev-eks-app
 externalSecrets:
   enabled: true
-  region: us-west-2
+  region: eu-west-2
   secretName: kortix-dev-env
   targetSecretName: kortix-api-env
 ingress:
@@ -64,7 +64,9 @@ ingress:
   # own cert (57eed8f4) — it no longer serves dev-api or borrows the ECS dev ALB
   # cert (a9af6fd8), which is now free for the ECS dev stack alone.
   host: dev-api-eks.kortix.com
-  certificateArn: arn:aws:acm:us-west-2:935064898258:certificate/57eed8f4-cba4-4d6a-94ea-1b948708989b
+  # REGION MIGRATION: replace with the NEW eu-west-2 ACM cert ARN (apply emits it).
+  # The old us-west-2 cert (57eed8f4) cannot front an eu-west-2 ALB. See infra/REGION-MIGRATION.md.
+  certificateArn: arn:aws:acm:eu-west-2:935064898258:certificate/REPLACE_WITH_EU_WEST_2_CERT
   cloudflareProxied: true
 # Plain rolling Deployment (no canary) — same delivery model as prod-eks:
 # probe-based auto-healing, HPA autoscaling, zero-downtime rolling deploys.

--- a/infra/k8s/envs/preview/values.yaml
+++ b/infra/k8s/envs/preview/values.yaml
@@ -50,7 +50,7 @@ serviceAccount:
 
 externalSecrets:
   enabled: true
-  region: us-west-2
+  region: eu-west-2
   secretName: kortix-preview-env
   targetSecretName: kortix-api-env
 
@@ -58,7 +58,9 @@ ingress:
   enabled: true
   host: preview.preview-api.kortix.com # overridden per-PR by the ApplicationSet
   # Wildcard cert *.preview-api.kortix.com (TF module.acm_preview).
-  certificateArn: arn:aws:acm:us-west-2:935064898258:certificate/8e5ec220-77d9-450f-abe9-21d5322afa78
+  # REGION MIGRATION: replace with the NEW eu-west-2 wildcard ACM cert ARN that
+  # apply emits; the old us-west-2 cert (8e5ec220) can't front an eu-west-2 ALB.
+  certificateArn: arn:aws:acm:eu-west-2:935064898258:certificate/REPLACE_WITH_EU_WEST_2_CERT
   # All previews share ONE host-routed ALB (no ALB-per-PR cost/latency).
   albGroup: kortix-previews
   # DNS-only (grey cloud): external-dns creates pr-<n>.preview-api.kortix.com →

--- a/infra/k8s/envs/prod/values.yaml
+++ b/infra/k8s/envs/prod/values.yaml
@@ -31,14 +31,18 @@ serviceAccount:
 
 externalSecrets:
   enabled: true
-  region: us-west-2
+  region: eu-west-2
   secretName: kortix-prod-env
   targetSecretName: kortix-api-env
 
 ingress:
   enabled: true
   host: api-eks.kortix.com
-  certificateArn: arn:aws:acm:us-west-2:935064898258:certificate/2b74aa18-1fe1-4cc8-a6c1-7012a0823d27
+  # REGION MIGRATION (us-west-2 → eu-west-2): an ACM cert is region-bound, so the
+  # old us-west-2 cert can't front an eu-west-2 ALB. Replace this with the NEW
+  # eu-west-2 cert ARN that `terraform apply` (prod-eks) emits before Argo CD
+  # reconciles this ingress. See infra/REGION-MIGRATION.md step 4.
+  certificateArn: arn:aws:acm:eu-west-2:935064898258:certificate/REPLACE_WITH_EU_WEST_2_CERT
   cloudflareProxied: true
 
 # Plain rolling Deployment (no canary). The EKS wins we actually want —

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -13,7 +13,7 @@ infra/terraform/
     cloudflare-dns/    # Cloudflare DNS records
     eks/               # EKS prod (cluster / platform / irsa) — see infra/EKS.md
   environments/
-    dev/               # dev-api.kortix.com  (ECS, us-west-2)
+    dev/               # dev-api.kortix.com  (ECS, eu-west-2)
     prod/              # api-prod.kortix.com (ECS)
     prod-eks/          # api-eks.kortix.com  (EKS, parallel to prod) — infra/EKS.md
 ```
@@ -34,7 +34,7 @@ them. The longer-term SOC2 target (autoscaling, no OS to patch) is ECS Fargate
 ## State
 
 State lives in S3 (`kortix-terraform-state`) with a DynamoDB lock table
-(`kortix-terraform-locks`), both in us-west-2 — see `environments/*/backend.tf`.
+(`kortix-terraform-locks`), both in eu-west-2 — see `environments/*/backend.tf`.
 Bootstrap once with `bash scripts/bootstrap-state.sh` (creates the bucket +
 table if absent), then `terraform init`.
 

--- a/infra/terraform/environments/dev-eks/README.md
+++ b/infra/terraform/environments/dev-eks/README.md
@@ -55,7 +55,7 @@ cd ../platform && terraform init && terraform apply
 
 3. **Bootstrap the dev Argo CD app** (one-time; thereafter GitOps owns it):
    ```bash
-   aws eks update-kubeconfig --region us-west-2 --name kortix-dev-eks
+   aws eks update-kubeconfig --region eu-west-2 --name kortix-dev-eks
    kubectl apply -f ../../../k8s/argocd/applications/dev.yaml
    # watch it: kubectl -n argocd port-forward svc/argocd-server 8080:443
    ```

--- a/infra/terraform/environments/dev-eks/cluster/backend.tf
+++ b/infra/terraform/environments/dev-eks/cluster/backend.tf
@@ -2,7 +2,7 @@ terraform {
   backend "s3" {
     bucket         = "kortix-terraform-state"
     key            = "dev-eks/cluster.tfstate"
-    region         = "us-west-2"
+    region         = "eu-west-2"
     dynamodb_table = "kortix-terraform-locks"
     encrypt        = true
   }

--- a/infra/terraform/environments/dev-eks/cluster/variables.tf
+++ b/infra/terraform/environments/dev-eks/cluster/variables.tf
@@ -1,7 +1,7 @@
 variable "aws_region" {
   description = "AWS region for the EKS dev resources."
   type        = string
-  default     = "us-west-2"
+  default     = "eu-west-2"
 }
 
 variable "vpc_cidr" {

--- a/infra/terraform/environments/dev-eks/platform/backend.tf
+++ b/infra/terraform/environments/dev-eks/platform/backend.tf
@@ -2,7 +2,7 @@ terraform {
   backend "s3" {
     bucket         = "kortix-terraform-state"
     key            = "dev-eks/platform.tfstate"
-    region         = "us-west-2"
+    region         = "eu-west-2"
     dynamodb_table = "kortix-terraform-locks"
     encrypt        = true
   }

--- a/infra/terraform/environments/dev-eks/platform/main.tf
+++ b/infra/terraform/environments/dev-eks/platform/main.tf
@@ -32,7 +32,7 @@ data "terraform_remote_state" "cluster" {
   config = {
     bucket         = "kortix-terraform-state"
     key            = "dev-eks/cluster.tfstate"
-    region         = "us-west-2"
+    region         = "eu-west-2"
     dynamodb_table = "kortix-terraform-locks"
   }
 }

--- a/infra/terraform/environments/dev/README.md
+++ b/infra/terraform/environments/dev/README.md
@@ -32,7 +32,7 @@ autoscaling), `cloudflare-dns` (the `dev-api` CNAME → ALB).
 ```bash
 cd infra/terraform/environments/dev
 
-export AWS_PROFILE=...                          # us-west-2 creds
+export AWS_PROFILE=...                          # eu-west-2 creds
 export TF_VAR_cloudflare_api_token=...           # = CLOUDFLARE_API_TOKEN secret
 export TF_VAR_cloudflare_zone_id=$(curl -s \
   -H "Authorization: Bearer $TF_VAR_cloudflare_api_token" \

--- a/infra/terraform/environments/dev/backend.tf
+++ b/infra/terraform/environments/dev/backend.tf
@@ -8,7 +8,7 @@ terraform {
   backend "s3" {
     bucket         = "kortix-terraform-state"
     key            = "dev/ecs-api.tfstate"
-    region         = "us-west-2"
+    region         = "eu-west-2"
     dynamodb_table = "kortix-terraform-locks"
     encrypt        = true
   }

--- a/infra/terraform/environments/dev/terraform.tfvars.example
+++ b/infra/terraform/environments/dev/terraform.tfvars.example
@@ -9,7 +9,7 @@
 #     -H "Authorization: Bearer $TF_VAR_cloudflare_api_token" \
 #     'https://api.cloudflare.com/client/v4/zones?name=kortix.com' | jq -r '.result[0].id')
 
-aws_region = "us-west-2"
+aws_region = "eu-west-2"
 
 # The image CI publishes (pin to a tag/sha for reproducible deploys).
 api_image      = "ghcr.io/kortix-ai/kortix-api:latest"
@@ -26,7 +26,7 @@ api_environment = {
 # Secret env vars -> Secrets Manager / SSM ARNs. Recommended: store the dev
 # secret bundle once in Secrets Manager and reference each key's ARN here.
 # Example single-key form:
-#   API_KEY_SECRET = "arn:aws:secretsmanager:us-west-2:ACCT:secret:kortix-dev/api-WXyz:API_KEY_SECRET::"
+#   API_KEY_SECRET = "arn:aws:secretsmanager:eu-west-2:ACCT:secret:kortix-dev/api-WXyz:API_KEY_SECRET::"
 api_secrets = {
   # API_KEY_SECRET   = "arn:aws:secretsmanager:...:API_KEY_SECRET::"
   # SUPABASE_SERVICE_ROLE_KEY = "arn:aws:secretsmanager:...:SUPABASE_SERVICE_ROLE_KEY::"

--- a/infra/terraform/environments/dev/variables.tf
+++ b/infra/terraform/environments/dev/variables.tf
@@ -1,7 +1,7 @@
 variable "aws_region" {
   description = "AWS region for the dev resources."
   type        = string
-  default     = "us-west-2"
+  default     = "eu-west-2"
 }
 
 variable "cloudflare_zone_id" {

--- a/infra/terraform/environments/prod-eks/cluster/backend.tf
+++ b/infra/terraform/environments/prod-eks/cluster/backend.tf
@@ -2,7 +2,7 @@ terraform {
   backend "s3" {
     bucket         = "kortix-terraform-state"
     key            = "prod-eks/cluster.tfstate"
-    region         = "us-west-2"
+    region         = "eu-west-2"
     dynamodb_table = "kortix-terraform-locks"
     encrypt        = true
   }

--- a/infra/terraform/environments/prod-eks/cluster/terraform.tfvars.example
+++ b/infra/terraform/environments/prod-eks/cluster/terraform.tfvars.example
@@ -4,7 +4,7 @@
 #   export TF_VAR_cloudflare_api_token=...
 #   export TF_VAR_cloudflare_zone_id=...
 
-aws_region = "us-west-2"
+aws_region = "eu-west-2"
 vpc_cidr   = "10.30.0.0/16" # must not overlap ECS (10.10/16 dev, 10.20/16 prod)
 
 cluster_version = "1.32"

--- a/infra/terraform/environments/prod-eks/cluster/variables.tf
+++ b/infra/terraform/environments/prod-eks/cluster/variables.tf
@@ -1,7 +1,7 @@
 variable "aws_region" {
   description = "AWS region for the EKS prod resources."
   type        = string
-  default     = "us-west-2"
+  default     = "eu-west-2"
 }
 
 variable "vpc_cidr" {

--- a/infra/terraform/environments/prod-eks/platform/backend.tf
+++ b/infra/terraform/environments/prod-eks/platform/backend.tf
@@ -2,7 +2,7 @@ terraform {
   backend "s3" {
     bucket         = "kortix-terraform-state"
     key            = "prod-eks/platform.tfstate"
-    region         = "us-west-2"
+    region         = "eu-west-2"
     dynamodb_table = "kortix-terraform-locks"
     encrypt        = true
   }

--- a/infra/terraform/environments/prod-eks/platform/main.tf
+++ b/infra/terraform/environments/prod-eks/platform/main.tf
@@ -32,7 +32,7 @@ data "terraform_remote_state" "cluster" {
   config = {
     bucket         = "kortix-terraform-state"
     key            = "prod-eks/cluster.tfstate"
-    region         = "us-west-2"
+    region         = "eu-west-2"
     dynamodb_table = "kortix-terraform-locks"
   }
 }

--- a/infra/terraform/environments/prod/backend.tf
+++ b/infra/terraform/environments/prod/backend.tf
@@ -2,7 +2,7 @@ terraform {
   backend "s3" {
     bucket         = "kortix-terraform-state"
     key            = "prod/ecs-api.tfstate"
-    region         = "us-west-2"
+    region         = "eu-west-2"
     dynamodb_table = "kortix-terraform-locks"
     encrypt        = true
   }

--- a/infra/terraform/environments/prod/terraform.tfvars.example
+++ b/infra/terraform/environments/prod/terraform.tfvars.example
@@ -4,7 +4,7 @@
 #   export TF_VAR_cloudflare_api_token=...
 #   export TF_VAR_cloudflare_zone_id=...
 
-aws_region = "us-west-2"
+aws_region = "eu-west-2"
 
 # PIN prod to an immutable release tag/sha (not :latest).
 api_image      = "ghcr.io/kortix-ai/kortix-api:vX.Y.Z"

--- a/infra/terraform/environments/prod/variables.tf
+++ b/infra/terraform/environments/prod/variables.tf
@@ -1,7 +1,7 @@
 variable "aws_region" {
   description = "AWS region for the prod resources."
   type        = string
-  default     = "us-west-2"
+  default     = "eu-west-2"
 }
 
 variable "cloudflare_zone_id" {

--- a/infra/terraform/modules/api-host/variables.tf
+++ b/infra/terraform/modules/api-host/variables.tf
@@ -4,7 +4,7 @@ variable "instance_name" {
 }
 
 variable "availability_zone" {
-  description = "Lightsail AZ, e.g. us-west-2a."
+  description = "Lightsail AZ, e.g. eu-west-2a."
   type        = string
 }
 

--- a/infra/terraform/modules/ecs-api/variables.tf
+++ b/infra/terraform/modules/ecs-api/variables.tf
@@ -6,7 +6,7 @@ variable "name" {
 variable "aws_region" {
   description = "AWS region (used for the awslogs log driver)."
   type        = string
-  default     = "us-west-2"
+  default     = "eu-west-2"
 }
 
 # ── Networking (from modules/network) ─────────────────────────────────────────

--- a/infra/terraform/scripts/bootstrap-state.sh
+++ b/infra/terraform/scripts/bootstrap-state.sh
@@ -3,7 +3,7 @@
 # Idempotent — skips anything that already exists. Run once per AWS account.
 set -euo pipefail
 
-REGION="${AWS_REGION:-us-west-2}"
+REGION="${AWS_REGION:-eu-west-2}"
 BUCKET="${TF_STATE_BUCKET:-kortix-terraform-state}"
 TABLE="${TF_LOCK_TABLE:-kortix-terraform-locks}"
 

--- a/infra/terraform/security-baseline/README.md
+++ b/infra/terraform/security-baseline/README.md
@@ -6,7 +6,7 @@ Account-global SOC 2 / Drata compliance controls as Terraform. Sibling to the
 ## What it manages
 - IAM account password policy (DCF-68 / DCF-350)
 - CloudTrail KMS CMK + multi-region trail + log-file validation + S3 data events (DCF-54 / DCF-478 / DCF-406)
-- GuardDuty detectors, us-west-2 + us-east-1 (DCF-87)
+- GuardDuty detectors, eu-west-2 + us-east-1 (DCF-87)
 - S3 account-level public access block (DCF-55/78/406 backstop)
 - AWS Backup vault + daily plan + selection + service role (DCF-99)
 - VPC Flow Logs delivery role + log group (DCF-406)
@@ -17,10 +17,10 @@ These were one-time or region-spanning and live outside the stack; documented
 in `../../compliance/SOC2-DRATA-REMEDIATION.md`:
 - GuardDuty in the other 15 regions
 - Deletion of 15 empty regional default VPCs
-- Per-VPC flow logs, default-SG stripping, and NACL deny (22/3389) for the 5 us-west-2 VPCs
+- Per-VPC flow logs, default-SG stripping, and NACL deny (22/3389) for the 5 eu-west-2 VPCs
 - S3 per-bucket versioning / TLS-deny policy / access-logging
 - ALB CloudWatch alarms + WAFv2 WebACL (app-tier; candidates to fold into the `ecs-api` module)
-  - WebACL `kortix-alb-waf` (REGIONAL, us-west-2) is associated with BOTH `kortix-prod-alb`
+  - WebACL `kortix-alb-waf` (REGIONAL, eu-west-2) is associated with BOTH `kortix-prod-alb`
     and `kortix-dev-alb`, and fronts `api(-prod)/dev-api.kortix.com` behind Cloudflare.
   - DO NOT block on the `*_BODY` managed sub-rules: this is an API that legitimately carries
     arbitrary user/agent payloads (prompts full of code, file paths like `/etc/passwd`, IPs

--- a/infra/terraform/security-baseline/backend.tf
+++ b/infra/terraform/security-baseline/backend.tf
@@ -2,7 +2,7 @@ terraform {
   backend "s3" {
     bucket         = "kortix-terraform-state"
     key            = "security/baseline.tfstate"
-    region         = "us-west-2"
+    region         = "eu-west-2"
     dynamodb_table = "kortix-terraform-locks"
     encrypt        = true
   }

--- a/infra/terraform/security-baseline/main.tf
+++ b/infra/terraform/security-baseline/main.tf
@@ -132,7 +132,7 @@ resource "aws_backup_selection" "daily" {
   name         = "kortix-daily-sel"
   plan_id      = aws_backup_plan.daily.id
   iam_role_arn = aws_iam_role.backup.arn
-  resources    = ["arn:aws:dynamodb:us-west-2:${local.account_id}:table/kortix-terraform-locks"]
+  resources    = ["arn:aws:dynamodb:eu-west-2:${local.account_id}:table/kortix-terraform-locks"]
   selection_tag {
     type  = "STRINGEQUALS"
     key   = "backup"

--- a/infra/terraform/security-baseline/providers.tf
+++ b/infra/terraform/security-baseline/providers.tf
@@ -25,7 +25,7 @@ terraform {
 }
 
 provider "aws" {
-  region = "us-west-2"
+  region = "eu-west-2"
 }
 
 # CloudTrail is multi-region but homed in us-east-1; its KMS key must live there.


### PR DESCRIPTION
## Why

Prod compute (EKS + ECS) runs in **us-west-2 (Oregon)**, but the prod Postgres (Supabase `supa.kortix.com` → project `jbriwassebxdwoieikga`) lives in **eu-west-2 (London)**. Every DB round-trip crosses the Atlantic (~130ms+ RTT). Under load or a transient cross-region blip, request handlers stack up and time out — while the shallow `/health` probe (which touches no DB) keeps returning 200, so EKS and Better Stack never register the incident. This is the "pods healthy, app erroring" pattern from today's `kortix down`.

**Fix: colocate everything in `eu-west-2`** — move the compute to the DB (the DB is the harder thing to move, and it's already in eu-west-2).

## What this PR changes (code only)

A pure region-literal flip across infra-as-code so a fresh `terraform apply` + GitOps reconcile stands the stack up in eu-west-2:

- **Terraform** — every `aws_region` default, S3 backend `region`, `terraform_remote_state` region, provider `region`, and region-bound ARNs (DynamoDB lock table, Secrets Manager examples) → `eu-west-2`. The CloudTrail KMS `us-east-1` provider alias is deliberately left intact (multi-region trail homed there).
- **k8s GitOps values** (`infra/k8s/envs/*`) — `externalSecrets.region` → `eu-west-2`. ACM `certificateArn`s are **placeholdered** (`REPLACE_WITH_EU_WEST_2_CERT`): a cert is region-bound, so the old us-west-2 cert UUIDs can't front an eu-west-2 ALB — they're set to the new cert ARNs `apply` emits.
- **Deploy workflows** (`deploy-dev.yml`, `deploy-prod.yml`) — `AWS_REGION` → `eu-west-2`.
- **Docs** — `CICD.md`, `EKS.md`, terraform READMEs, security-baseline README.

## ⚠️ This PR is step 1, not the cutover

The literal flip alone does **not** move the live stack — Terraform state, the S3/DynamoDB backend, ACM certs, Secrets Manager, and the running clusters are all region-scoped. The ordered, operator-run migration is documented in **`infra/REGION-MIGRATION.md`** (new): state backend → ECR → foundational apply → new certs/secrets → bring up + verify in-region against the prod DB → DNS cutover (instantly reversible) → decommission us-west-2.

## Verification

- Region flip is mechanical and complete: no `us-west-2` remains in infra/workflows except intentional migration-note comments; `us-east-1` (CloudTrail KMS) preserved.
- CI here is path-filtered to app code (api/web/cli/sandbox/desktop), so this infra-only PR won't trigger app jobs — terraform isn't validated in CI. Plan/validate happen during the runbook's `terraform apply` steps against real AWS creds.

🤖 Drafted by the Kortix agent from the #incident thread.
