### PR TITLE
fix(prod): 2Gi memory (Guaranteed) + earlier HPA scale-out — stop OOM restarts

### DIFF
--- a/infra/k8s/envs/prod/values.yaml
+++ b/infra/k8s/envs/prod/values.yaml
@@ -24,6 +24,24 @@ autoscaling:
   enabled: true
   minReplicas: 3
   maxReplicas: 12
+  # Scale out a bit earlier on memory (was 70%) so the HPA adds a pod and spreads
+  # load BEFORE individual pods approach their ceiling. HPA acts on the average,
+  # so this is the proactive half; the per-pod OOM ceiling is raised below.
+  targetCPUUtilizationPercentage: 60
+  targetMemoryUtilizationPercentage: 60
+
+# The app sits at ~840Mi steady and spiked past the old 1Gi limit → OOMKilled
+# (exit 137) → random restarts. HPA can't prevent that (it scales on the average;
+# OOM is per-pod + instant). Give each pod real headroom: 2Gi, request==limit so
+# QoS is Guaranteed — no per-pod OOM under normal spikes, never evicted under node
+# memory pressure. CPU unchanged.
+resources:
+  requests:
+    cpu: "500m"
+    memory: "2Gi"
+  limits:
+    cpu: "1"
+    memory: "2Gi"
 
 serviceAccount:
   name: kortix-api


### PR DESCRIPTION
**Symptom:** prod kortix-api pods restart at random — `OOMKilled` (exit 137). One pod restarted twice in 39h.

**Why:** the app sits at **~840Mi steady against a 1Gi limit** (req==limit). A load spike crosses 1Gi → kubelet OOM-kills it instantly. The **HPA can't save it** — it scales on the *average* (which read 61%/70% because a just-restarted pod at 172Mi dragged the mean down) while individual hot pods at 840Mi cross the ceiling. OOM is per-pod and instant; HPA is average-based and minutes-slow.

**Fix (prod only):**
- **memory 1Gi → 2Gi, request==limit** → **Guaranteed** QoS: ~2.4× headroom over steady state, so pods don't OOM on normal spikes and are never evicted under node memory pressure.
- **HPA targets 70% → 60%** (cpu+mem): adds a pod and spreads load *before* pods get hot — the proactive half the HPA can actually do.

Capacity: 3×2Gi=6Gi across 5×7.4Gi nodes (max 12 within the node-autoscaler range) — no Pending risk; rolling update (surge 1 / unavailable 0) fits. dev/preview untouched.

> ⚠️ Delivery: prod Argo tracks the **`prod` branch**, so this must land there to take effect — it rides your next release/promote, or cherry-pick to `prod` for an immediate hotfix (see comment).

If OOMs ever recur at 2Gi it points to a slow leak (pod OOM'd after ~24h) — that's a separate app investigation, but 2Gi removes the routine outages now.