### PR TITLE
hotfix(prod): 2Gi memory + earlier HPA — stop OOM restarts

### DIFF
--- a/infra/k8s/envs/prod/values.yaml
+++ b/infra/k8s/envs/prod/values.yaml
@@ -21,6 +21,25 @@ autoscaling:
   enabled: true
   minReplicas: 3
   maxReplicas: 12
+  # Scale out a bit earlier on memory (was 70%) so the HPA adds a pod and spreads
+  # load BEFORE individual pods approach their ceiling. HPA acts on the average,
+  # so this is the proactive half; the per-pod OOM ceiling is raised below.
+  targetCPUUtilizationPercentage: 60
+  targetMemoryUtilizationPercentage: 60
+
+# The app sits at ~840Mi steady and spiked past the old 1Gi limit → OOMKilled
+# (exit 137) → random restarts. HPA can't prevent that (it scales on the average;
+# OOM is per-pod + instant). Give each pod real headroom: 2Gi, request==limit so
+# QoS is Guaranteed — no per-pod OOM under normal spikes, never evicted under node
+# memory pressure. CPU unchanged.
+resources:
+  requests:
+    cpu: "500m"
+    memory: "2Gi"
+  limits:
+    cpu: "1"
+    memory: "2Gi"
+
 serviceAccount:
   name: kortix-api
   roleArn: arn:aws:iam::935064898258:role/kortix-prod-eks-app


### PR DESCRIPTION
Direct values-only hotfix onto the **`prod` branch** (what Argo tracks) so the OOM fix goes live without waiting for a full release. Same change as #3497 (which lands it on `main` so future releases keep it) — this is the surgical cherry-pick for immediate effect.

Diff: only `infra/k8s/envs/prod/values.yaml` — memory `1Gi → 2Gi` (req==limit, Guaranteed QoS) + HPA cpu/mem targets `70% → 60%`.

**On merge:** prod Argo (auto-sync on) renders the new values and does a rolling update — pods come back with a 2Gi ceiling. Zero-downtime (maxSurge 1 / maxUnavailable 0). ~2 min.