### PR TITLE
perf(dev): enable warm pool + pre-resume + 60m autostop for fast session start

### DIFF
--- a/infra/k8s/envs/dev/values.yaml
+++ b/infra/k8s/envs/dev/values.yaml
@@ -18,6 +18,21 @@ env:
 # experimental region.
 extraEnv:
   KORTIX_WARM_SNAPSHOT_ENABLED: "false"
+  # Warm fast path for NEW sessions — restores the pre-mid-June "fast" start that
+  # was lost when KORTIX_WARM_SNAPSHOT_ENABLED was flipped off (flaky region) with
+  # no replacement enabled (the pool's master switch KORTIX_WARM_POOL_MAX_TOTAL
+  # defaults to 0, so "pool-only mode" was inert). The pool runs on the reliable
+  # region and is a pure accelerator: a claim miss/error falls straight through to
+  # the unchanged cold provision (session-runtime-allocator.ts:83-88), so it can
+  # only speed starts up, never slow them. MAX_TOTAL caps standing spares (cost);
+  # SIZE is per-project (default 2). Tune up if dev runs more concurrent projects.
+  KORTIX_WARM_POOL_MAX_TOTAL: "10"
+  # Overlap the ~8s stopped-box resume with navigation: pre-resume the user's most
+  # recently stopped session on project presence (throttled 30s, 1/project).
+  KORTIX_PRERESUME_ENABLED: "true"
+  # Keep boxes in the instant "running" tier longer so casual returns (>15m idle)
+  # don't pay the resume wall. Dev-only; prod stays at the 15m default for now.
+  KORTIX_SANDBOX_AUTOSTOP_MINUTES: "60"
 # PRE-CUTOVER: dev-api-eks is the candidate while dev-api.kortix.com is still
 # served by ECS, so EKS runs API-only and ECS keeps ownership of the dev-tier
 # singleton workers (one Postgres leader lease is shared across both on the dev


### PR DESCRIPTION
## Why
Session start on dev (and prod) is intermittently slow — "was fast, now way slow." Confirmed against the live services: both `dev-api.kortix.com` and `api.kortix.com` report `warm_snapshots: false`. Warm snapshots were turned off (flaky experimental region) and the intended replacement — the warm **pool** — was never enabled: `KORTIX_WARM_POOL_MAX_TOTAL` defaults to `0`, so the "pool-only mode" the config describes is inert.

With no accelerator, every NEW session pays a full cold create (the in-box `git clone` is awaited before opencode spawns and balloons under contention), and every return hits the resume-tier lottery (running = instant, stopped >15m = ~8s resume, archived >3d = slow unarchive). Same click, very different wall-clock.

## What (EKS dev only)
- `KORTIX_WARM_POOL_MAX_TOTAL: "10"` — activate the reliable-region warm pool for new sessions. **Pure accelerator**: a claim miss/error falls straight through to the unchanged cold provision (`session-runtime-allocator.ts:83-88`), so it can only speed starts up, never slow them. `MAX_TOTAL` caps standing spares (cost); per-project `SIZE` stays at the default 2.
- `KORTIX_PRERESUME_ENABLED: "true"` — overlap the ~8s stopped-box resume with navigation (throttled 30s, 1/project).
- `KORTIX_SANDBOX_AUTOSTOP_MINUTES: "60"` — keep boxes in the instant "running" tier longer for casual returns. Dev-only; prod stays at the 15m default.

## Risk
Low, dev-scoped. Clean cold fallback; pre-resume/autostop are existing tested gated logic. Rollback = `git revert`.

## Verify after deploy
Start a NEW session on an active project: `session_start_timeline` should show a `warm-claim` mark (fast) instead of a cold provider-create. Reopen a stopped session: provider status should be `running` (instant) instead of `runtime_waking`.