### PR TITLE
fix(web)+perf(dev): live streaming on reveal + warm-pool Stage-2 for <6s starts

### DIFF
--- a/apps/web/src/stores/sandbox-connection-store.ts
+++ b/apps/web/src/stores/sandbox-connection-store.ts
@@ -202,25 +202,29 @@ export function resetForServerSwitch() {
 	clearProvisionVerified();
 
 	if (runtimeReady) {
-		// /start proved the runtime healthy server-side, so we start `connected`
-		// (no blocking provisioning overlay) — BUT we do NOT pre-assert health.
-		// Seeding healthy=true here flipped the `runtimeReady` selector
-		// (connected && healthy===true) synchronously, hiding the loading screen
-		// and crossfading the chat in BEFORE the client confirmed the runtime was
-		// actually reachable — so users saw the bootstrap agent already mid-turn.
-		// healthy=null keeps the loading screen up until the fast (~350ms) health
-		// poller confirms /kortix/health, while still skipping the blocking
-		// provisioning overlay — preserving most of the warm-path speedup.
+		// /start already resolved stage==='ready' (markRuntimeReadyVerified is set
+		// ONLY then — page.tsx), which the backend returns only after it reached the
+		// daemon and OpenCode answered: the runtime is PROVEN healthy server-side.
+		// So seed healthy=true (optimistic) — NOT healthy=null. The SSE event stream
+		// (use-opencode-events) AND message sync (use-session-sync) both gate on this
+		// same `healthy` flag, so seeding null left the FE UNSUBSCRIBED until the
+		// ~350ms client health poll flipped it green — by which point the server-side
+		// first turn (KORTIX_INITIAL_PROMPT, delivered during boot) had accumulated
+		// and bulk-rendered AT ONCE instead of streaming. healthy=true subscribes at
+		// the switch, so part.updated events render token-by-token, and also reclaims
+		// the redundant health RTT. The 350ms poller still runs and self-corrects to
+		// healthy=false (reconnect pill) if the browser genuinely can't reach the box,
+		// so this only narrows to the ready path where health was actually proven.
 		useSandboxConnectionStore.setState({
 			status: "connected",
 			failCount: 0,
-			initialCheckDone: false,
+			initialCheckDone: true,
 			wasConnected: true,
 			reconnectAttempts: 0,
 			disconnectedAt: null,
 			sandboxVersion: null,
 			openCodeVersion: null,
-			healthy: null,
+			healthy: true,
 			runtimeError: null,
 			recoveryPhase: "idle",
 			restartRequestedAt: null,

--- a/infra/k8s/envs/dev/values.yaml
+++ b/infra/k8s/envs/dev/values.yaml
@@ -18,6 +18,21 @@ env:
 # experimental region.
 extraEnv:
   KORTIX_WARM_SNAPSHOT_ENABLED: "false"
+  # Warm pool, Stage-2 (clone-at-park) — the lever that restores <6s starts for
+  # returning/2nd+ sessions, now that dev serves from EKS (reliable region). It's
+  # a pure accelerator: any claim miss/error falls through to the unchanged cold
+  # provision (session-runtime-allocator.ts:83-88), so it can only speed starts
+  # up. CLONE_AT_PARK=1 is REQUIRED for <6s: the spare clones the repo + warms
+  # opencode AT PARK (off the hot path), so a claim is a local `git checkout -B`
+  # (~0.5s, no network) instead of re-cloning (~9s). MAX_TOTAL is the hard fleet
+  # cap (also the master enable: warmPoolEnabled() = MAX_TOTAL>0) — kept low for
+  # the small dev pod; SIZE=1 spare per present project. Does NOT help a brand-new
+  # project's first session (cold). Must live here (k8s env), NOT in .env.dev —
+  # unit-warm-pool.test.ts asserts the pool is off there.
+  KORTIX_WARM_POOL_MAX_TOTAL: "3"
+  KORTIX_WARM_POOL_SIZE: "1"
+  KORTIX_WARM_POOL_CLONE_AT_PARK: "1"
+  KORTIX_WARM_POOL_PRESENCE_MINUTES: "15"
 # PRE-CUTOVER: dev-api-eks is the candidate while dev-api.kortix.com is still
 # served by ECS, so EKS runs API-only and ECS keeps ownership of the dev-tier
 # singleton workers (one Postgres leader lease is shared across both on the dev


### PR DESCRIPTION
Fixes the two remaining session-start problems on dev (now that dev serves from the healthy EKS backend).

## 1. Streaming reveal (fix, web) — `sandbox-connection-store.ts`
The project composer sends the first prompt **server-side** (`KORTIX_INITIAL_PROMPT`, delivered during boot). The SSE event stream (`use-opencode-events.ts:325`) **and** message sync (`use-session-sync.ts:162`) both gate on the `healthy` flag. `resetForServerSwitch` seeded `healthy:null` even on the ready path, so the FE stayed unsubscribed until the ~350ms client health poll flipped green — by then the first turn had accumulated and **bulk-rendered at once**.

Fix: on the **ready path only**, seed `healthy:true` + `initialCheckDone:true`. `/start` already proved health server-side (`markRuntimeReadyVerified` is set only on `stage==='ready'`+pin), so SSE + sync subscribe at the switch → token-by-token streaming. The 350ms poller still self-corrects to `healthy:false` if the browser truly can't reach the box (narrow, ready-path-only scope).

## 2. <6s warm start (perf, infra) — `dev/values.yaml`
The ~30s comes from the awaited in-box git clone. **Warm-pool Stage-2** (`CLONE_AT_PARK=1`) clones + warms opencode **at park** (off the hot path), so a claim is a local `git remote set-url` + `checkout` (~0.5s, no network — `git.ts:595-618`). `MAX_TOTAL=3` = master-enable + hard cap (small dev pod), `SIZE=1`, `PRESENCE_MINUTES=15`. **Pure accelerator**: any claim miss/error → unchanged cold provision (`session-runtime-allocator.ts:83-88`), so it can only speed starts up. Helps returning/2nd+ sessions (not a brand-new project's first). Kill switch: `MAX_TOTAL=0`.

## Local verification (before push)
- Web typecheck: clean (no `error TS` beyond the pre-existing `.next/types` baseline).
- SSE + sync gating confirmed to key off the same `healthy` flag (un-gated by `healthy:true`).
- Warm-pool gating math: `warmPoolEnabled()` → `true` with the env override (`{enabled:true, size:1}`), `false` with `MAX_TOTAL=0`.
- `unit-warm-pool.test.ts`: **9 pass, 0 fail** (CI stays green — `.env.dev` keeps the pool off).
- Warm-claim mechanism is local-git-only (no network) verified in `git.ts`.

## Validate on dev after deploy
- New session on a returning project: `project_sessions.metadata.session_start_timeline` shows a `warm-claim` mark, no clone gap, total <6s.
- First agent reply streams token-by-token (loader fades as the first token lands), not a bulk render.