### PR TITLE
fix(config): accept 1/yes/on as truthy (warm pool clone_at_park was silently off)

### DIFF
--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -37,9 +37,17 @@ const optInt = (def: number) =>
     return Number.isNaN(n) ? def : n;
   });
 
-/** Optional boolean — 'true' → true, anything else → false. */
+/** Optional boolean. optBoolFalse accepts the common truthy spellings
+ * (case-insensitive) so a "1" / "yes" / "on" from a k8s env or secret bundle
+ * isn't silently dropped — the bug that left KORTIX_WARM_POOL_CLONE_AT_PARK="1"
+ * parsing as false (Stage-1, re-clone on claim) even though the daemon itself
+ * sets that env to '1'. optBoolTrue keeps its original 'anything but false' rule. */
 const optBoolTrue = z.string().optional().default('true').transform((v) => v !== 'false');
-const optBoolFalse = z.string().optional().default('false').transform((v) => v === 'true');
+const optBoolFalse = z
+  .string()
+  .optional()
+  .default('false')
+  .transform((v) => ['true', '1', 'yes', 'on'].includes(v.trim().toLowerCase()));
 
 // ─── Env Schema ─────────────────────────────────────────────────────────────
 //

--- a/infra/k8s/envs/dev/values.yaml
+++ b/infra/k8s/envs/dev/values.yaml
@@ -31,7 +31,7 @@ extraEnv:
   # unit-warm-pool.test.ts asserts the pool is off there.
   KORTIX_WARM_POOL_MAX_TOTAL: "3"
   KORTIX_WARM_POOL_SIZE: "1"
-  KORTIX_WARM_POOL_CLONE_AT_PARK: "1"
+  KORTIX_WARM_POOL_CLONE_AT_PARK: "true"
   KORTIX_WARM_POOL_PRESENCE_MINUTES: "15"
 # PRE-CUTOVER: dev-api-eks is the candidate while dev-api.kortix.com is still
 # served by ECS, so EKS runs API-only and ECS keeps ownership of the dev-tier


### PR DESCRIPTION
The new `/health` `warm_pool` field exposed the last blocker: on dev `warm_pool.clone_at_park` was **false** despite `values.yaml` setting `KORTIX_WARM_POOL_CLONE_AT_PARK="1"`.

Cause: `optBoolFalse` only matched the literal `'true'`, so `"1"` → false. The pool ran **Stage-1** (re-clone on claim, ~9s) instead of **Stage-2** (clone at park → local checkout claim, <6s). The daemon itself sets that env to `'1'` (`warm-pool.ts:186`), so `'1'` must mean true.

Fix: `optBoolFalse` accepts `true/1/yes/on` (case-insensitive); `optBoolTrue` unchanged. Also set dev `CLONE_AT_PARK: "true"` for clarity.

Verified locally: `1/true/yes/on → true`, `0/false/unset → false`; `unit-warm-pool` 9/9 green; typecheck clean. As a config.ts (API) change it also forces a real deploy.

After deploy, `/health` should read `warm_pool.clone_at_park: true` and returning sessions should warm-claim <6s.