### PR TITLE
fix(warm-pool): claim parked spares — status filter never matched (pool never claimed)

### DIFF
--- a/apps/api/src/platform/services/warm-pool.ts
+++ b/apps/api/src/platform/services/warm-pool.ts
@@ -271,7 +271,14 @@ async function claimSpare(projectId: string): Promise<ClaimedSpare | null> {
       SELECT s.sandbox_id FROM kortix.session_sandboxes s
       WHERE s.project_id = ${projectId}
         AND s.pool_state = 'parked'
-        AND s.status = 'provisioning'
+        -- A parked spare's box has finished provisioning, so its status is
+        -- 'active' (the box-ready finish in session-sandbox.ts sets it); it is
+        -- 'provisioning' only in the brief window before that finish lands. The
+        -- old 'provisioning'-only filter never matched a parked spare, so EVERY
+        -- claim missed and fell back to a cold create — the pool never worked.
+        -- Accept both healthy states; pool_state='parked' already scopes to
+        -- session-less spares, and error/failed/stopped are excluded.
+        AND s.status IN ('active', 'provisioning')
         AND s.external_id IS NOT NULL
       ORDER BY s.created_at ASC
       LIMIT 1


### PR DESCRIPTION
**The root cause of "no warm at all."** `claimSpare` selects `WHERE pool_state='parked' AND status='provisioning'`, but a parked spare's box has finished provisioning, so its status is **`active`** (set by the box-ready finish in session-sandbox.ts:503/508). The `(parked, provisioning)` combination never exists → **every claim returned null → cold fallback every time.** The warm pool has never successfully claimed since it shipped (725633d52); spares park and pre-warm perfectly but are never used.

Confirmed end-to-end on live dev: parked spare box was `runtimeReady=true` (opencode-ready@1588ms), yet a new session got `warm-claim=false` + a fresh cold box (18.9s).

Fix: accept `status IN ('active','provisioning')`. `pool_state='parked'` already scopes to session-less spares and excludes error/failed/stopped.

Verified read-only on dev DB: old filter → **0** claimable spares for an active project, new filter → **1**. Typecheck clean. After deploy I'll confirm a real returning session warm-claims in <6s.