### PR TITLE
fix(slack): DM project picker + /kortix commands in DMs

### DIFF
--- a/apps/api/src/channels/slack/commands.ts
+++ b/apps/api/src/channels/slack/commands.ts
@@ -22,6 +22,10 @@ export interface SlashCtx {
   // reply for subcommands too slow for the synchronous 3s window (agent list
   // touches git). DB-only subcommands answer synchronously and ignore it.
   responseUrl?: string;
+  // DM fallback path: the Assistant pane delivers `/kortix …` as a plain message
+  // (no response_url), so deferred subcommands post their result through this
+  // instead of `respondViaUrl`. Set only by the DM command runner.
+  deferredDeliver?: (resp: SlashResponse) => Promise<void>;
 }
 
 export async function handleSlashCommand(
@@ -506,7 +510,8 @@ async function slashAgents(ctx: SlashCtx, arg: string): Promise<SlashResponse> {
     };
   }
   // Listing agents touches git — too slow for the synchronous 3s window. Ack
-  // immediately and post the real picker to the response_url.
+  // immediately and post the real picker out-of-band: to the response_url for a
+  // real slash command, or straight into the DM for the message-fallback path.
   void (async () => {
     let agents: Awaited<ReturnType<typeof listProjectAgents>> = [];
     try {
@@ -514,11 +519,12 @@ async function slashAgents(ctx: SlashCtx, arg: string): Promise<SlashResponse> {
     } catch (err) {
       console.warn('[slack-webhook] listProjectAgents failed', err);
     }
-    await respondViaUrl(ctx.responseUrl, {
-      response_type: 'ephemeral',
-      replace_original: true,
-      blocks: buildAgentPickerBlocks(ctx, selection.agentName, agents),
-    });
+    const blocks = buildAgentPickerBlocks(ctx, selection.agentName, agents);
+    if (ctx.deferredDeliver) {
+      await ctx.deferredDeliver({ response_type: 'ephemeral', blocks });
+    } else {
+      await respondViaUrl(ctx.responseUrl, { response_type: 'ephemeral', replace_original: true, blocks });
+    }
   })();
   return { response_type: 'ephemeral', text: 'Loading agents…' };
 }

--- a/apps/api/src/channels/slack/dispatch.ts
+++ b/apps/api/src/channels/slack/dispatch.ts
@@ -18,6 +18,7 @@ import {
   postMessage,
 } from '../slack-api';
 import { PICKER_TTL_MS } from './app';
+import { handleSlashCommand } from './commands';
 import {
   createOrJoinThreadSession,
   deliverSlackFollowUpToSession,
@@ -36,6 +37,7 @@ import type {
   ProjectResolution,
   SlackEnvelope,
   SlackEvent,
+  SlashResponse,
 } from './types';
 
 export const pendingPickers = new Map<string, { envelope: SlackEnvelope; expiry: number }>();
@@ -94,7 +96,33 @@ export async function maybePostPicker(
   const isDm = event.type === 'message' && event.channel_type === 'im' && !event.subtype;
   if (!isMention && !isDm) return;
 
-  const channelId = event.channel;
+  await postProjectPicker({
+    teamId,
+    projectIds,
+    channelId: event.channel,
+    threadTs: event.thread_ts ?? event.ts,
+    isDm,
+    envelope,
+  });
+}
+
+// Post the "which project should this conversation use?" picker — the SAME
+// affordance, byte-for-byte, for channels (first @mention) and DMs (assistant
+// open / first message). It guarantees a binding row exists FIRST (projectId
+// null) so the pick handler, which UPDATEs by channelId, has a row to write
+// into, and keeps at most one live picker per channel. `envelope`, when present,
+// is replayed after the pick so the message that triggered it runs.
+async function postProjectPicker(opts: {
+  teamId: string;
+  projectIds: string[];
+  channelId: string;
+  threadTs?: string;
+  isDm: boolean;
+  envelope?: SlackEnvelope;
+}): Promise<void> {
+  const { teamId, projectIds, channelId, threadTs, isDm, envelope } = opts;
+  if (!channelId || projectIds.length === 0) return;
+
   const claimed = await db
     .insert(chatChannelBindings)
     .values({ platform: 'slack', workspaceId: teamId, channelId, projectId: null })
@@ -137,7 +165,7 @@ export async function maybePostPicker(
       type: 'section',
       text: {
         type: 'mrkdwn',
-        text: `*Which project should ${channelLabel} use?*\nAsked once — I'll remember it for this channel.`,
+        text: `*Which project should ${channelLabel} use?*\nAsked once — I'll remember it for ${isDm ? 'this DM' : 'this channel'}.`,
       },
     },
     {
@@ -155,14 +183,18 @@ export async function maybePostPicker(
   for (const [k, v] of pendingPickers) {
     if (v.expiry < now) pendingPickers.delete(k);
   }
-  pendingPickers.set(pickerId, { envelope, expiry: now + PICKER_TTL_MS });
+  // Only register a replay when a message triggered the picker. On DM/assistant
+  // open there's no message to replay — the pick just binds + confirms.
+  if (envelope) {
+    pendingPickers.set(pickerId, { envelope, expiry: now + PICKER_TTL_MS });
+  }
 
   const pickerTs = await postBlocks(
     token,
     channelId,
     `Which project should ${channelLabel} use?`,
     blocks,
-    event.thread_ts ?? event.ts,
+    threadTs,
   );
   if (pickerTs) {
     await db
@@ -176,6 +208,121 @@ export async function maybePostPicker(
         ),
       );
   }
+}
+
+// The AI-Assistant DM pane fires `assistant_thread_started` when a user opens
+// (or starts a new) Kortix DM — the natural "which project is this connected
+// to?" moment, exactly like inviting the bot to a channel. We run the IDENTICAL
+// resolution the channel path uses (resolveOauthProject): one project →
+// auto-bind silently, two+ unbound → the same project picker right in the
+// assistant thread, already bound → nothing. So a DM user gets the exact same
+// "choose your Kortix project" experience as a channel, without needing a slash
+// command (which the Assistant pane can't run).
+export async function handleAssistantThreadStarted(
+  teamId: string,
+  event: SlackEvent,
+): Promise<void> {
+  const channelId = event.assistant_thread?.channel_id;
+  const threadTs = event.assistant_thread?.thread_ts;
+  if (!teamId || !channelId) return;
+
+  const resolution = await resolveOauthProject(teamId, channelId);
+  if (resolution.kind === 'ambiguous') {
+    await postProjectPicker({ teamId, projectIds: resolution.projectIds, channelId, threadTs, isDm: true });
+  } else if (resolution.kind === 'pending') {
+    const installs = await db
+      .select({ projectId: chatInstalls.projectId })
+      .from(chatInstalls)
+      .where(and(eq(chatInstalls.platform, 'slack'), eq(chatInstalls.workspaceId, teamId)));
+    if (installs.length > 0) {
+      await postProjectPicker({ teamId, projectIds: installs.map((i) => i.projectId), channelId, threadTs, isDm: true });
+    }
+  }
+  // 'project' (bound, or auto-bound when there's exactly one) and 'none' →
+  // no picker, identical to a channel that's already resolved.
+}
+
+// ── DM slash-command fallback ────────────────────────────────────────────────
+// Slack does NOT run slash commands inside the AI-Assistant DM pane (or any
+// message thread) — typing `/kortix switch` there is delivered to us as a plain
+// `message.im` instead of a slash payload. So when a DM message IS a `/kortix …`
+// command, run it through the EXACT same handler the real slash endpoint uses
+// and post the reply right back into the DM. This makes the commands work in
+// DMs even though Slack's native slash mechanism can't reach the assistant pane.
+const DM_COMMAND_RE = /^\/(kortix(?:-dev)?)\b[ \t]*([\s\S]*)$/i;
+
+async function postSlashResponseToChannel(
+  token: string,
+  channelId: string,
+  threadTs: string | undefined,
+  resp: SlashResponse,
+): Promise<void> {
+  if (resp.blocks && resp.blocks.length > 0) {
+    await postBlocks(token, channelId, resp.text ?? 'Kortix', resp.blocks, threadTs);
+  } else if (resp.text) {
+    await postMessage(token, channelId, resp.text, threadTs);
+  }
+}
+
+export async function maybeHandleDmCommand(
+  teamId: string,
+  event: SlackEvent,
+  fallbackProjectId?: string,
+): Promise<boolean> {
+  if (event.type !== 'message' || event.channel_type !== 'im' || event.subtype || event.bot_id) {
+    return false;
+  }
+  const channelId = event.channel;
+  if (!channelId) return false;
+  const match = (event.text ?? '').trim().match(DM_COMMAND_RE);
+  if (!match) return false;
+
+  const command = `/${match[1].toLowerCase()}`;
+  const [subRaw, ...rest] = (match[2] ?? '').trim().split(/\s+/);
+  const sub = (subRaw || 'help').toLowerCase();
+  const arg = rest.join(' ').trim();
+  const threadTs = event.thread_ts ?? event.ts;
+
+  // A bot token to reply with: prefer the channel's bound project, else the BYO
+  // project this webhook serves, else any workspace install.
+  let tokenProjectId: string | null = null;
+  const [binding] = await db
+    .select({ projectId: chatChannelBindings.projectId })
+    .from(chatChannelBindings)
+    .where(and(
+      eq(chatChannelBindings.platform, 'slack'),
+      eq(chatChannelBindings.workspaceId, teamId),
+      eq(chatChannelBindings.channelId, channelId),
+    ))
+    .limit(1);
+  tokenProjectId = binding?.projectId ?? fallbackProjectId ?? null;
+  if (!tokenProjectId) {
+    const [install] = await db
+      .select({ projectId: chatInstalls.projectId })
+      .from(chatInstalls)
+      .where(and(eq(chatInstalls.platform, 'slack'), eq(chatInstalls.workspaceId, teamId)))
+      .limit(1);
+    tokenProjectId = install?.projectId ?? null;
+  }
+  if (!tokenProjectId) return true; // it WAS a command — just nothing to reply with
+  const token = await loadSlackTokenForProject(tokenProjectId);
+  if (!token) return true;
+
+  // The Assistant pane has no 3s ACK window and no response_url, so a command
+  // that normally defers (the agent list touches git) posts its result straight
+  // into the DM instead.
+  const deferredDeliver = (body: SlashResponse): Promise<void> =>
+    postSlashResponseToChannel(token, channelId, threadTs, body);
+
+  let resp: SlashResponse;
+  try {
+    resp = await handleSlashCommand(sub, arg, { teamId, channelId, command, deferredDeliver });
+  } catch (err) {
+    console.error('[slack-webhook] dm command failed', err);
+    resp = { response_type: 'ephemeral', text: 'Something went wrong handling that command. Try again in a moment.' };
+  }
+  await postSlashResponseToChannel(token, channelId, threadTs, resp);
+  return true;
 }
 
 async function classifyEvent(

--- a/apps/api/src/channels/slack/interactivity.ts
+++ b/apps/api/src/channels/slack/interactivity.ts
@@ -369,11 +369,14 @@ export async function handleBlockAction(payload: SlackInteractionPayload): Promi
     .where(eq(projects.projectId, projectId))
     .limit(1);
   if (token && pickerTs) {
+    // DM channel ids start with 'D' — a <#D…> mention renders as a dead link
+    // there, so phrase it as "this DM" instead of a channel mention.
+    const target = channelId.startsWith('D') ? 'this DM' : `<#${channelId}>`;
     await updateMessage(
       token,
       channelId,
       pickerTs,
-      `✓ Linked <#${channelId}> to *${proj?.name ?? 'project'}*.`,
+      `✓ Linked ${target} to *${proj?.name ?? 'project'}*.`,
     );
   }
 

--- a/apps/api/src/channels/slack/routes.ts
+++ b/apps/api/src/channels/slack/routes.ts
@@ -12,6 +12,8 @@ import { alreadyHandled } from './dedup';
 import { parseEnvelope, verifySlackSignature } from './util';
 import {
   dispatchSlackEvent,
+  handleAssistantThreadStarted,
+  maybeHandleDmCommand,
   maybePostChannelIntro,
   maybePostPicker,
   resolveOauthProject,
@@ -113,6 +115,18 @@ slackWebhookApp.openapi(
       envelope.event.user
     ) {
       await publishHomeForUser(teamId, envelope.event.user);
+      return;
+    }
+    // Opening the Kortix DM (AI-Assistant pane) → greet with the project picker.
+    // The channel/thread live on event.assistant_thread, NOT the top-level event,
+    // so resolveOauthProject can't see it — handle it before that branch.
+    if (envelope.event?.type === 'assistant_thread_started') {
+      await handleAssistantThreadStarted(teamId, envelope.event);
+      return;
+    }
+    // A `/kortix …` typed in a DM (the Assistant pane can't run real slash
+    // commands) arrives as a plain message — run it as the command it is.
+    if (envelope.event && (await maybeHandleDmCommand(teamId, envelope.event))) {
       return;
     }
     const resolution = await resolveOauthProject(teamId, envelope.event?.channel);
@@ -231,9 +245,13 @@ slackWebhookApp.openapi(
   if (envelope.type !== 'event_callback' || !envelope.event) return c.json({ ok: true });
   if (await alreadyHandled(envelope.event_id)) return c.json({ ok: true });
 
-  void dispatchSlackEvent(projectId, envelope).catch((err) =>
-    console.error('[slack-webhook] byo handler failed', err),
-  );
+  void (async () => {
+    const teamId = envelope.team_id ?? envelope.event?.team ?? '';
+    if (envelope.event && (await maybeHandleDmCommand(teamId, envelope.event, projectId))) {
+      return;
+    }
+    await dispatchSlackEvent(projectId, envelope);
+  })().catch((err) => console.error('[slack-webhook] byo handler failed', err));
   return c.json({ ok: true });
 },
 );

--- a/apps/api/src/channels/slack/types.ts
+++ b/apps/api/src/channels/slack/types.ts
@@ -69,6 +69,15 @@ export interface SlackEvent {
   subtype?: string;
   team?: string;
   tab?: 'home' | 'messages';
+  // Present on assistant_thread_started / assistant_thread_context_changed.
+  // The AI-Assistant DM pane delivers its own thread coordinates here (NOT on
+  // the top-level event), so the picker has to read channel/thread from this.
+  assistant_thread?: {
+    user_id?: string;
+    channel_id?: string;
+    thread_ts?: string;
+    context?: Record<string, unknown>;
+  };
 }
 
 export interface SlackInteractionPayload {


### PR DESCRIPTION
## Problem

In a Slack DM with Kortix, a user had no way to steer it:

- The DM (AI-Assistant pane) **never asked which Kortix project** to connect to — `assistant_thread_started` was subscribed in the manifest but handled nowhere, so opening the DM was a no-op.
- **`/kortix` slash commands don't work in DMs.** This is a Slack platform limitation: slash commands [cannot be invoked in message threads / assistant containers](https://api.slack.com/interactivity/slash-commands), and the Kortix DM is an Assistant container (because `assistant_view` is enabled). So the only controls Kortix offered were unreachable in a DM.

Net effect: a DM user was stranded — never prompted for a project, and unable to run commands to fix it.

## Changes

**1. DM project picker — identical to the channel picker.**
`assistant_thread_started` now greets with the **same** project picker a channel shows on first @mention. One shared `postProjectPicker` renders both surfaces (only the label word differs — "this DM" vs "#channel"), and the DM runs the **identical** `resolveOauthProject` resolution:

| Workspace state | Channel | DM (now) |
|---|---|---|
| 1 project | auto-binds silently | auto-binds silently |
| 2+ projects, unbound | shows picker | shows picker (on DM open) |
| already bound | nothing | nothing |

**2. `/kortix` commands work in DMs (via message fallback).**
When Slack can't run a slash command in the Assistant pane, it delivers `/kortix switch` as a plain `message.im`. New `maybeHandleDmCommand` catches a `/kortix` (or `/kortix-dev`) DM message and runs it through the **exact same `handleSlashCommand`** the slash endpoint uses, posting the reply back into the DM. Works bound or unbound; covers `projects`, `switch`, `whoami`, `sessions`, `session`, `agents`, `models`, `agent <name>`, `model <id>`, `unbind`, `help`. Deferred commands (the `agents` list touches git) deliver straight into the DM since the message path has no 3s ACK window.

**3. DM-friendly pick confirmation** — no dead `<#D…>` channel mention in a DM.

Wired into both the canonical and per-project (BYO) Slack webhooks.

> Caveat: Slack won't show `/kortix` **autocomplete** in the Assistant pane (platform limitation), but typing the command works.

## Verification

- `tsc --noEmit` — zero errors in `channels/slack` (pre-existing `@kortix/registry` resolution errors are unrelated/environmental)
- Slack unit tests, file-by-file: dispatch 6/6, commands 17/17, interactivity 8/8, manifest 10/10 — no regression
- Command-parsing regex spot-checked: handles args, `-dev`, case-insensitivity, leading whitespace; rejects mid-sentence `/kortix` and `/kortixx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)