### PR TITLE
feat(web): instant session shell — kill the new-session loader latency

### DIFF
--- a/apps/web/src/app/(app)/projects/[id]/page.tsx
+++ b/apps/web/src/app/(app)/projects/[id]/page.tsx
@@ -1,27 +1,21 @@
 'use client';
 
-import { errorToast } from '@/components/ui/toast';
 import {
   ProjectHome,
   type ProjectHomeSendOptions,
 } from '@/features/co-worker/project-layout/project-home';
 import { ProjectShell } from '@/features/co-worker/project-layout/project-shell';
 import { useAccountState } from '@/hooks/billing';
+import { useNewProjectSession } from '@/hooks/projects/use-new-project-session';
 import { isBillingEnabled } from '@/lib/config';
-import {
-  createProjectSession,
-  getProjectDetail,
-  prefetchSessionStart,
-} from '@/lib/projects-client';
+import { getProjectDetail } from '@/lib/projects-client';
 import { useUpgradeDialogStore } from '@/stores/upgrade-dialog-store';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { useParams, useRouter } from 'next/navigation';
-import { useCallback, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { useParams } from 'next/navigation';
+import { useCallback } from 'react';
 
 export default function ProjectIndexPage() {
   const { id: projectId } = useParams<{ id: string }>();
-  const router = useRouter();
-  const queryClient = useQueryClient();
 
   const { data: projectDetail } = useQuery({
     queryKey: ['project-detail', projectId],
@@ -32,12 +26,14 @@ export default function ProjectIndexPage() {
   const { data: accountState } = useAccountState({ accountId: projectAccountId });
   const openUpgradeDialog = useUpgradeDialogStore((s) => s.openUpgradeDialog);
 
-  const [busy, setBusy] = useState(false);
+  const newSession = useNewProjectSession(projectId);
 
   const handleSend = useCallback(
-    async (text: string, options?: ProjectHomeSendOptions) => {
-      if (!text.trim() || busy) return;
+    (text: string, options?: ProjectHomeSendOptions) => {
+      if (!text.trim()) return;
 
+      // Gate no-plan accounts before navigating so we never strand the user on a
+      // shell that can't provision — pitch the upgrade in place instead.
       const noPlan =
         isBillingEnabled() && !!accountState && !accountState.subscription?.subscription_id;
       if (noPlan) {
@@ -45,35 +41,23 @@ export default function ProjectIndexPage() {
         return;
       }
 
-      setBusy(true);
-      try {
-        const created = await createProjectSession(projectId, {
-          initial_prompt: text,
-          ...(options?.sandbox_slug ? { sandbox_slug: options.sandbox_slug } : {}),
-        });
-        const sessionId = created.session_id;
-        queryClient.invalidateQueries({ queryKey: ['project-sessions', projectId] });
-        prefetchSessionStart(queryClient, projectId, sessionId);
-        router.prefetch(`/projects/${projectId}/sessions/${sessionId}`);
-        router.push(`/projects/${projectId}/sessions/${sessionId}`);
-      } catch (err) {
-        setBusy(false);
-        const code = (err as any)?.code;
-        if (code === 'concurrent_session_limit') return;
-        if (code === 'subscription_required' || code === 'no_account') {
-          const blockedAccountId = (err as any)?.detail?.account_id ?? projectAccountId;
-          openUpgradeDialog({ reason: code, accountId: blockedAccountId });
-          return;
-        }
-        errorToast(err instanceof Error ? err.message : 'Failed to start session');
-      }
+      // Identical optimistic path to every other new-session entry point: mint the
+      // id, paint the instant shell, and let the session page auto-send `text` once
+      // the box is ready. No server-side initial_prompt — the shell shows the
+      // message + inline boot status, matching the global dashboard composer.
+      newSession({
+        create: options?.sandbox_slug ? { sandbox_slug: options.sandbox_slug } : undefined,
+        onNavigate: (sessionId) => {
+          sessionStorage.setItem(`project_pending_prompt:${sessionId}`, text);
+        },
+      });
     },
-    [projectId, projectAccountId, queryClient, router, accountState, openUpgradeDialog, busy],
+    [accountState, projectAccountId, openUpgradeDialog, newSession],
   );
 
   return (
     <ProjectShell projectId={projectId}>
-      <ProjectHome projectId={projectId} onSend={handleSend} busy={busy} />
+      <ProjectHome projectId={projectId} onSend={handleSend} busy={false} />
     </ProjectShell>
   );
 }

--- a/apps/web/src/app/(app)/projects/[id]/sessions/[sessionId]/page.tsx
+++ b/apps/web/src/app/(app)/projects/[id]/sessions/[sessionId]/page.tsx
@@ -10,6 +10,7 @@ import { useEffect, useRef, useState, type ReactNode } from 'react';
 import { Button } from '@/components/ui/button';
 import { ProjectShell } from '@/features/co-worker/project-layout/project-shell';
 import { useAuth } from '@/features/providers/auth-provider';
+import { InstantSessionShell } from '@/features/session/instant-session-shell';
 import { SessionChat } from '@/features/session/session-chat';
 import { SessionLayout } from '@/features/session/session-layout';
 import { SessionStartingLoader } from '@/features/session/session-starting-loader';
@@ -22,6 +23,7 @@ import { OpenCodeEventStreamProvider } from '@/hooks/opencode/use-opencode-event
 import { useSandboxConnection } from '@/hooks/platform/use-sandbox-connection';
 import { useProjectPresence } from '@/hooks/platform/use-project-presence';
 import { isBillingEnabled } from '@/lib/config';
+import { clearSessionFresh, isSessionFresh } from '@/lib/fresh-sessions';
 import { setActiveInstanceCookie } from '@/lib/instance-routes';
 import { formatOpenCodeRuntimeError } from '@/lib/opencode-errors';
 import {
@@ -196,21 +198,52 @@ export default function ProjectSessionPage() {
     openUpgradeDialog({ reason: 'subscription_required', accountId: projectAccountId });
   }, [noPlan, openUpgradeDialog, projectAccountId]);
 
-  // ── Crossfade: ONE persistent loader fades out as the chat fades in ───────
-  // The loader is rendered at a SINGLE stable tree position for the whole
-  // pre-ready lifecycle, so it never remounts → never re-blanks its delay gate
-  // (the old "disappears for a second then reappears" bug). The chat mounts
-  // UNDER the loader the moment the sandbox is switched, warms up invisibly,
-  // then crossfades in once ActiveSessionChat reports it's actually ready.
+  // ── Crossfade: the instant shell fades out as the real chat fades in ──────
+  // Instead of a blocking full-screen loader, we render a fully-interactive
+  // session shell (welcome wallpaper + live input) at a SINGLE stable tree
+  // position for the whole pre-ready lifecycle, so it never remounts. The user
+  // can read + type immediately; provisioning runs silently underneath. The real
+  // chat mounts UNDER the shell the moment the sandbox is switched, warms up
+  // invisibly, then crossfades in once ActiveSessionChat reports it's ready —
+  // picking up any first message the user sent in the shell via the
+  // pending-prompt handoff.
   const [chatReady, setChatReady] = useState(false);
   const [loaderMounted, setLoaderMounted] = useState(true);
+  // A freshly-created session shows the instant typeable shell instead of a
+  // resume loader; `shellSubmitted` tracks whether a first message exists yet
+  // (typed in the shell, or handed off from the home composer).
+  const [shellSubmitted, setShellSubmitted] = useState(false);
+  const freshRef = useRef<boolean>(false);
   // Reset the crossfade when the route's session changes (render-phase, idempotent).
   const lifecycleForRef = useRef<string | null>(null);
   if (lifecycleForRef.current !== sessionId) {
     lifecycleForRef.current = sessionId;
     if (chatReady) setChatReady(false);
     if (!loaderMounted) setLoaderMounted(true);
+    // Resolve freshness + whether a first message is already pending, ONCE per
+    // route. Fresh = just created (registry set by useCreateOpenCodeSession) OR a
+    // pending prompt is already staged (home composer). Resumes are neither.
+    let fresh = false;
+    let pending = false;
+    if (typeof window !== 'undefined') {
+      pending =
+        !!sessionStorage.getItem(`opencode_pending_prompt:${sessionId}`) ||
+        !!sessionStorage.getItem(`project_pending_prompt:${sessionId}`);
+      fresh = pending || isSessionFresh(sessionId);
+    }
+    freshRef.current = fresh;
+    setShellSubmitted(pending);
   }
+  const isFresh = freshRef.current;
+  // Retire the fresh mark only once the real chat has taken over (NOT on mount —
+  // React StrictMode's dev double-mount would clear it before the persisting
+  // mount reads it, dropping us back to the loader). chatReady fires seconds
+  // later, after the double-mount settles, so freshRef is always captured first.
+  // Until then the in-memory mark survives re-navigation to this still-empty
+  // session; a hard reload clears the whole registry (then it's a resume).
+  useEffect(() => {
+    if (chatReady) clearSessionFresh(sessionId);
+  }, [chatReady, sessionId]);
 
   // Terminal/gated states fully REPLACE the content (no chat to fade to).
   const gated = !authLoading && !!user && noPlan;
@@ -223,6 +256,11 @@ export default function ProjectSessionPage() {
   // every sandbox-coupled hook reads the active server at render time.
   const canMountChat =
     !!sandbox && sandbox.status === 'active' && activeInstanceId === sandbox.sandbox_id;
+  // For a fresh session, hold the real chat until the user actually sends their
+  // first message. The instant shell is the typing surface until then — and the
+  // chat's pending-prompt migration is one-shot, so mounting it before the
+  // message exists would consume the (empty) handoff and drop the send.
+  const mountChat = canMountChat && (!isFresh || shellSubmitted);
 
   // From the first paint we mount ProjectShell so the project's sidebar is
   // always visible — no full-page "Preparing workspace" flash.
@@ -269,7 +307,15 @@ export default function ProjectSessionPage() {
       );
     }
 
-    // Dual-layer: the chat mounts under a persistent loader and crossfades in.
+    // Dual-layer: the real chat mounts under the instant shell (fresh sessions)
+    // or the staged loader (resumes) and crossfades in once it's ready.
+    //
+    // PERF: mount the runtime connection + event stream EAGERLY (as soon as the
+    // sandbox is switched), so the health probe, SSE stream, and OpenCode pin are
+    // already warm by the time the user sends — the first message doesn't pay the
+    // connect cost. The heavy ActiveSessionChat itself still waits for `mountChat`
+    // (a first message exists) so its one-shot pending-prompt handoff isn't
+    // consumed empty.
     return (
       <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden">
         {canMountChat && (
@@ -281,12 +327,14 @@ export default function ProjectSessionPage() {
           >
             <ProjectSessionRuntimeConnection>
               <OpenCodeEventStreamProvider />
-              <ActiveSessionChat
-                projectId={projectId}
-                sessionId={sessionId}
-                pinFromStart={start?.opencode_session_id ?? null}
-                onChatReady={() => setChatReady(true)}
-              />
+              {mountChat && (
+                <ActiveSessionChat
+                  projectId={projectId}
+                  sessionId={sessionId}
+                  pinFromStart={start?.opencode_session_id ?? null}
+                  onChatReady={() => setChatReady(true)}
+                />
+              )}
             </ProjectSessionRuntimeConnection>
           </div>
         )}
@@ -301,7 +349,16 @@ export default function ProjectSessionPage() {
               chatReady ? 'pointer-events-none opacity-0' : 'opacity-100',
             )}
           >
-            <SessionStartingLoader stage={authLoading || !user ? 'provisioning' : startStage} />
+            {isFresh ? (
+              <InstantSessionShell
+                projectId={projectId}
+                sessionId={sessionId}
+                stage={authLoading || !user ? 'provisioning' : startStage}
+                onSubmit={() => setShellSubmitted(true)}
+              />
+            ) : (
+              <SessionStartingLoader stage={authLoading || !user ? 'provisioning' : startStage} />
+            )}
           </div>
         )}
       </div>
@@ -445,6 +502,15 @@ function ActiveSessionChat({
       const toKey = `opencode_pending_prompt:${chatSessionId}`;
       if (sessionStorage.getItem(toKey) === null) sessionStorage.setItem(toKey, pending);
       sessionStorage.removeItem(fromKey);
+    }
+    // Carry the agent/model/variant selections the instant shell stashed too.
+    const fromOptKey = `project_pending_options:${sessionId}`;
+    const pendingOptions = sessionStorage.getItem(fromOptKey);
+    if (pendingOptions) {
+      const toOptKey = `opencode_pending_options:${chatSessionId}`;
+      if (sessionStorage.getItem(toOptKey) === null)
+        sessionStorage.setItem(toOptKey, pendingOptions);
+      sessionStorage.removeItem(fromOptKey);
     }
   }
 

--- a/apps/web/src/components/command-palette.tsx
+++ b/apps/web/src/components/command-palette.tsx
@@ -1,13 +1,12 @@
 'use client';
 
 import { parseCustomizeSection } from '@/lib/customize-sections';
+import { useNewProjectSession } from '@/hooks/projects/use-new-project-session';
 import { normalizeAppPathname } from '@/lib/instance-routes';
 import {
-  createProjectSession,
   listAccounts,
   listProjectSessions,
   listProjectsForAccount,
-  prefetchSessionStart,
   searchProjectFiles,
   type KortixAccount,
   type KortixProject,
@@ -726,22 +725,25 @@ export function CommandPalette() {
 
   // ── Handlers ──
 
-  const handleNewSession = useCallback(async () => {
+  const newSession = useNewProjectSession(projectId ?? undefined);
+  const handleNewSession = useCallback(() => {
+    if (projectId) {
+      // Optimistic + shared — instant shell (see useNewProjectSession). The tab
+      // bar picks the session up from the URL.
+      newSession({
+        onNavigate: (sessionId) => {
+          openProjectTab(projectId, sessionId);
+          close();
+        },
+      });
+      return;
+    }
+    // No project context → the OpenCode-session path (dashboard / global).
     if (isCreating) return;
     setIsCreating(true);
-    try {
-      if (projectId) {
-        // New project shell — create a project session and route to it; the
-        // tab bar picks it up from the URL.
-        const session = await createProjectSession(projectId);
-        queryClient.invalidateQueries({ queryKey: ['project-sessions', projectId] });
-        prefetchSessionStart(queryClient, projectId, session.session_id);
-        openProjectTab(projectId, session.session_id);
-        router.prefetch(`/projects/${projectId}/sessions/${session.session_id}`);
-        router.push(`/projects/${projectId}/sessions/${session.session_id}`);
-        close();
-      } else {
-        const session = await createSession.mutateAsync();
+    createSession
+      .mutateAsync()
+      .then((session) => {
         openTabAndNavigate({
           id: session.id,
           title: 'New session',
@@ -752,13 +754,10 @@ export function CommandPalette() {
           window.dispatchEvent(new CustomEvent('focus-session-textarea'));
         });
         close();
-      }
-    } catch {
-      toast.error('Failed to create session');
-    } finally {
-      setIsCreating(false);
-    }
-  }, [isCreating, projectId, createSession, queryClient, openProjectTab, router, close]);
+      })
+      .catch(() => toast.error('Failed to create session'))
+      .finally(() => setIsCreating(false));
+  }, [isCreating, projectId, newSession, createSession, openProjectTab, close]);
 
   // ── Switch sub-pickers: select handlers + filtered lists ──
   const setSelectedAccountId = useCurrentAccountStore((s) => s.setSelectedAccountId);

--- a/apps/web/src/components/dashboard/dashboard-content.tsx
+++ b/apps/web/src/components/dashboard/dashboard-content.tsx
@@ -5,17 +5,14 @@ import { useTranslations } from 'next-intl';
 import { NoInstanceState } from '@/components/dashboard/no-instance-state';
 import { useSidebar } from '@/components/ui/sidebar';
 import { WallpaperBackground } from '@/components/ui/wallpaper-background';
-import { type AttachedFile, SessionChatInput } from '@/features/session/session-chat-input';
-import { useOpenCodeConfig } from '@/hooks/opencode/use-opencode-config';
-import { formatModelString, useOpenCodeLocal } from '@/hooks/opencode/use-opencode-local';
-import type { Command } from '@/hooks/opencode/use-opencode-sessions';
 import {
-  useCreateOpenCodeSession,
-  useOpenCodeAgents,
-  useOpenCodeCommands,
-  useOpenCodeProviders,
-  useSendOpenCodeMessage,
-} from '@/hooks/opencode/use-opencode-sessions';
+  ComposerChatInput,
+  type ComposerOptions,
+} from '@/features/session/composer-chat-input';
+import type { AttachedFile } from '@/features/session/session-chat-input';
+import { formatModelString } from '@/hooks/opencode/use-opencode-local';
+import type { Command } from '@/hooks/opencode/use-opencode-sessions';
+import { useCreateOpenCodeSession } from '@/hooks/opencode/use-opencode-sessions';
 import { useSandbox } from '@/hooks/platform/use-sandbox';
 import { useIsMobile } from '@/hooks/utils';
 import { getClient } from '@/lib/opencode-sdk';
@@ -44,7 +41,6 @@ export function DashboardContent() {
   const isMobile = useIsMobile();
   const { setOpen: setSidebarOpenState, setOpenMobile } = useSidebar();
   const createSession = useCreateOpenCodeSession();
-  const sendMessage = useSendOpenCodeMessage();
 
   // No-instance fallback: when the user has no sandbox at all, render the
   // claim/onboarding hero in-place instead of bouncing to a dedicated page.
@@ -67,17 +63,8 @@ export function DashboardContent() {
     window.history.replaceState({}, '', `${clean.pathname}${clean.search}`);
   }, [queryClient]);
 
-  // Data
-  const { data: agents } = useOpenCodeAgents();
-  const { data: providers } = useOpenCodeProviders();
-  const { data: commands } = useOpenCodeCommands();
-  const { data: config } = useOpenCodeConfig();
-
-  // Unified model/agent/variant state
-  const local = useOpenCodeLocal({ agents, providers, config });
-
   const handleSend = useCallback(
-    async (text: string, files?: AttachedFile[]) => {
+    async (text: string, files: AttachedFile[] | undefined, options: ComposerOptions) => {
       if ((!text.trim() && !files?.length) || isSending) return;
 
       playSound('send');
@@ -100,10 +87,6 @@ export function DashboardContent() {
           usePendingFilesStore.getState().setPendingFiles(files);
         }
 
-        const options: Record<string, unknown> = {};
-        if (local.agent.current) options.agent = local.agent.current.name;
-        if (local.model.currentKey) options.model = local.model.currentKey;
-        if (local.model.variant.current) options.variant = local.model.variant.current;
         if (Object.keys(options).length > 0) {
           sessionStorage.setItem(`opencode_pending_options:${session.id}`, JSON.stringify(options));
         }
@@ -129,18 +112,11 @@ export function DashboardContent() {
         setIsSending(false);
       }
     },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [
-      isSending,
-      createSession,
-      local.agent.current,
-      local.model.currentKey,
-      local.model.variant.current,
-    ],
+    [isSending, createSession],
   );
 
   const handleCommand = useCallback(
-    async (cmd: Command, args?: string) => {
+    async (cmd: Command, args: string | undefined, options: ComposerOptions) => {
       try {
         const session = await createSession.mutateAsync();
         openTabAndNavigate({
@@ -156,9 +132,9 @@ export function DashboardContent() {
             sessionID: session.id,
             command: cmd.name,
             arguments: args || '',
-            ...(local.agent.current && { agent: local.agent.current.name }),
-            ...(local.model.currentKey && { model: formatModelString(local.model.currentKey) }),
-            ...(local.model.variant.current && { variant: local.model.variant.current }),
+            ...(options.agent && { agent: options.agent }),
+            ...(options.model && { model: formatModelString(options.model) }),
+            ...(options.variant && { variant: options.variant }),
           } as any)
           .catch(() => {
             toast.warning('Failed to execute command');
@@ -167,8 +143,7 @@ export function DashboardContent() {
         toast.warning('Failed to create session');
       }
     },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [createSession, local.agent.current, local.model.currentKey, local.model.variant.current],
+    [createSession],
   );
 
   if (showNoInstanceState) {
@@ -234,23 +209,11 @@ export function DashboardContent() {
       <div className="relative z-10 min-h-0 flex-1" />
 
       {/* Chat Input — pinned to bottom, overlays the wallpaper */}
-      <SessionChatInput
+      <ComposerChatInput
         onSend={handleSend}
-        disabled={isSending}
-        placeholder={tHardcodedUi.raw(
-          'componentsDashboardDashboardContent.line228JsxAttrPlaceholderAskAnything',
-        )}
-        agents={local.agent.list}
-        selectedAgent={local.agent.current?.name ?? null}
-        onAgentChange={(name) => local.agent.set(name ?? undefined)}
-        models={local.model.list}
-        selectedModel={local.model.currentKey ?? null}
-        onModelChange={(m) => local.model.set(m ?? undefined, { recent: true })}
-        variants={local.model.variant.list}
-        selectedVariant={local.model.variant.current ?? null}
-        onVariantChange={(v) => local.model.variant.set(v ?? undefined)}
-        commands={commands || []}
         onCommand={handleCommand}
+        disabled={isSending}
+        placeholder={tHardcodedUi.raw('componentsDashboardDashboardContent.line228JsxAttrPlaceholderAskAnything')}
       />
     </div>
   );

--- a/apps/web/src/components/projects/customize/use-configure-thread.ts
+++ b/apps/web/src/components/projects/customize/use-configure-thread.ts
@@ -14,11 +14,8 @@
  */
 
 import { useCallback, useState } from 'react';
-import { useRouter } from 'next/navigation';
-import { useQueryClient } from '@tanstack/react-query';
 
-import { createProjectSession, prefetchSessionStart } from '@/lib/projects-client';
-import { toast } from '@/lib/toast';
+import { useNewProjectSession } from '@/hooks/projects/use-new-project-session';
 import { useCustomizeStore } from '@/stores/customize-store';
 
 export type ConfigureKind = 'agent' | 'skill' | 'command';
@@ -61,33 +58,30 @@ export interface ConfigureThread {
 }
 
 export function useConfigureThread(projectId: string): ConfigureThread {
-  const router = useRouter();
-  const queryClient = useQueryClient();
   const closeCustomize = useCustomizeStore((s) => s.close);
   const [pending, setPending] = useState(false);
+  const newSession = useNewProjectSession(projectId);
 
   const start = useCallback(
-    async (prompt: string) => {
+    (prompt: string) => {
       // Guard re-entry: ignore extra clicks while a session is being minted so
       // we don't fire two creates (and blow the concurrent-session limit).
       if (pending) return;
       setPending(true);
-      try {
-        const session = await createProjectSession(projectId, { initial_prompt: prompt });
-        queryClient.invalidateQueries({ queryKey: ['project-sessions', projectId] });
-        prefetchSessionStart(queryClient, projectId, session.session_id);
-        closeCustomize();
-        router.prefetch(`/projects/${projectId}/sessions/${session.session_id}`);
-        router.push(`/projects/${projectId}/sessions/${session.session_id}`);
-        // Leave `pending` true on success — we're navigating away and the
-        // overlay is closing; flipping it back would flash the idle button.
-      } catch (err) {
-        setPending(false);
-        if ((err as any)?.code === 'concurrent_session_limit') return;
-        toast.error(err instanceof Error ? err.message : 'Failed to start session');
-      }
+      // Optimistic, identical to the project-home composer: mint the session,
+      // stash the seed prompt, close the overlay, and drop into the instant shell
+      // — which shows the prompt + inline boot status and auto-sends it once the
+      // runtime is ready (the hook persists + bounces on a terminal failure).
+      // Leave `pending` true: we're navigating away and the overlay is closing,
+      // so flipping it back would only flash the idle button.
+      newSession({
+        onNavigate: (sessionId) => {
+          sessionStorage.setItem(`project_pending_prompt:${sessionId}`, prompt);
+          closeCustomize();
+        },
+      });
     },
-    [projectId, router, queryClient, closeCustomize, pending],
+    [pending, newSession, closeCustomize],
   );
 
   return { start, pending };

--- a/apps/web/src/features/co-worker/project-layout/project-shell.tsx
+++ b/apps/web/src/features/co-worker/project-layout/project-shell.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { AnimatePresence, motion } from 'motion/react';
 import { useParams, useRouter } from 'next/navigation';
 import { Suspense, lazy, useCallback, useEffect, useLayoutEffect, useMemo } from 'react';
@@ -10,17 +10,13 @@ import { CustomizeOverlay } from '@/components/projects/customize/customize-over
 import { PersonalOnboardingWelcome } from '@/components/projects/personal-onboarding-welcome';
 import { ProjectOnboardingWizard } from '@/components/projects/project-onboarding-wizard';
 import { useSidebar } from '@/components/ui/sidebar';
-import { errorToast } from '@/components/ui/toast';
 import { ProjectTabBar } from '@/features/co-worker/project-header/project-tab-bar';
 import { ProjectSidebar } from '@/features/co-worker/project-sidebar/project-sidebar';
 import { AppProviders } from '@/features/layout/app-providers';
 import { useAuth } from '@/features/providers/auth-provider';
+import { useNewProjectSession } from '@/hooks/projects/use-new-project-session';
 import { useProjectShellShortcuts } from '@/hooks/projects/use-project-shell-shortcuts';
-import {
-  createProjectSession,
-  getProjectDetail,
-  prefetchSessionStart,
-} from '@/lib/projects-client';
+import { getProjectDetail } from '@/lib/projects-client';
 import { cn } from '@/lib/utils';
 import { BillingAccountProvider } from '@/stores/billing-account-context';
 import { useProjectSessionTabsStore } from '@/stores/project-session-tabs-store';
@@ -41,7 +37,6 @@ interface ProjectShellProps {
 
 export function ProjectShell({ projectId, initialSidebarOpen, children }: ProjectShellProps) {
   const router = useRouter();
-  const queryClient = useQueryClient();
   const { user, isLoading: authLoading } = useAuth();
 
   const { data: projectDetail } = useQuery({
@@ -76,23 +71,13 @@ export function ProjectShell({ projectId, initialSidebarOpen, children }: Projec
     }
   }, []);
 
-  const createSession = useMutation({
-    mutationFn: () => createProjectSession(projectId),
-    onSuccess: (session) => {
-      queryClient.invalidateQueries({ queryKey: ['project-sessions', projectId] });
-      prefetchSessionStart(queryClient, projectId, session.session_id);
-      router.prefetch(`/projects/${projectId}/sessions/${session.session_id}`);
-      router.push(`/projects/${projectId}/sessions/${session.session_id}`);
-    },
-    onError: (err) => {
-      if ((err as any)?.code === 'concurrent_session_limit') return;
-      errorToast(err instanceof Error ? err.message : 'Failed to start session');
-    },
-  });
+  // Optimistic new-session: mint the id client-side and navigate immediately so
+  // the instant shell paints before the create POST returns (see
+  // useNewProjectSession). Shared with the sidebar / ⌘T-⌘J / command palette.
+  const newSession = useNewProjectSession(projectId);
   const handleNewSession = useCallback(() => {
-    if (createSession.isPending) return;
-    createSession.mutate();
-  }, [createSession]);
+    newSession();
+  }, [newSession]);
 
   useProjectShellShortcuts({ projectId, onNewSession: handleNewSession });
 

--- a/apps/web/src/features/co-worker/project-sidebar/project-sidebar.tsx
+++ b/apps/web/src/features/co-worker/project-sidebar/project-sidebar.tsx
@@ -28,7 +28,6 @@ import {
   SidebarRail,
   useSidebar,
 } from '@/components/ui/sidebar';
-import { errorToast } from '@/components/ui/toast';
 import {
   ProjectAppsNavItem,
   ProjectAppsRailItem,
@@ -53,15 +52,12 @@ import { UserMenu } from '@/features/layout/user-menu';
 import { useAuth } from '@/features/providers/auth-provider';
 import { useAdminRole } from '@/hooks/admin';
 import { useIsMobile } from '@/hooks/utils';
-import {
-  createProjectSession,
-  listProjectSessions,
-  prefetchSessionStart,
-} from '@/lib/projects-client';
+import { useNewProjectSession } from '@/hooks/projects/use-new-project-session';
+import { listProjectSessions } from '@/lib/projects-client';
 import { beginSessionTiming, markSessionClick, sessionMark } from '@/lib/session-timing';
 import { cn } from '@/lib/utils';
 import { Icon as IconMynauiType, UsersSolid } from '@mynaui/icons-react';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import {
   CalendarClock,
   ChevronRight,
@@ -95,7 +91,6 @@ export function ProjectSidebar({ projectId }: { projectId: string }) {
   const router = useRouter();
   const { state, setOpenMobile, toggleSidebar } = useSidebar();
   const isExpanded = state === 'expanded';
-  const queryClient = useQueryClient();
   const isMobile = useIsMobile();
   const sessionsGroupRef = useRef<HTMLDivElement>(null);
 
@@ -135,28 +130,19 @@ export function ProjectSidebar({ projectId }: { projectId: string }) {
     [authUser, isAdmin],
   );
 
-  const createSession = useMutation({
-    mutationFn: () => createProjectSession(projectId),
-    onSuccess: (session) => {
-      beginSessionTiming(session.session_id);
-      sessionMark(session.session_id, 'session-created');
-      queryClient.invalidateQueries({ queryKey: ['project-sessions', projectId] });
-      prefetchSessionStart(queryClient, projectId, session.session_id);
-      router.prefetch(`/projects/${projectId}/sessions/${session.session_id}`);
-      router.push(`/projects/${projectId}/sessions/${session.session_id}`);
-      if (isMobile) setOpenMobile(false);
-    },
-    onError: (err) => {
-      if ((err as any)?.code === 'concurrent_session_limit') return;
-      errorToast(err instanceof Error ? err.message : 'Failed to start session');
-    },
-  });
-
+  // Optimistic + shared with every other entry point (see useNewProjectSession).
+  // The timing marks + mobile-drawer close fire on the synchronous navigation.
+  const newSession = useNewProjectSession(projectId);
   const handleNewSession = useCallback(() => {
-    if (createSession.isPending) return;
     markSessionClick();
-    createSession.mutate();
-  }, [createSession]);
+    newSession({
+      onNavigate: (sessionId) => {
+        beginSessionTiming(sessionId);
+        sessionMark(sessionId, 'session-created');
+        if (isMobile) setOpenMobile(false);
+      },
+    });
+  }, [newSession, isMobile, setOpenMobile]);
 
   useEffect(() => {
     const handler = (event: KeyboardEvent) => {
@@ -240,9 +226,7 @@ export function ProjectSidebar({ projectId }: { projectId: string }) {
                 size="icon"
                 aria-label="New session"
                 onClick={handleNewSession}
-                disabled={createSession.isPending}
                 className={cn(
-                  createSession.isPending && 'cursor-not-allowed opacity-50',
                   'text-sidebar-foreground border-border dark:bg-background dark:hover:bg-background/90 bg-background hover:bg-background/90 flex size-8 items-center justify-center border-[1.2px] [&_svg]:size-4!',
                 )}
               >
@@ -270,11 +254,10 @@ export function ProjectSidebar({ projectId }: { projectId: string }) {
               <SidebarMenuItem>
                 <SidebarMenuButton
                   onClick={handleNewSession}
-                  disabled={createSession.isPending}
                   size="md"
                   className="group/menu-button text-sidebar-foreground border-border dark:bg-background dark:hover:bg-background/90 bg-background hover:bg-background/90 flex items-center justify-center border-[1.2px] text-center !text-sm [&_svg]:!size-5"
                 >
-                  {createSession.isPending ? 'Creating…' : 'New session'}
+                  New session
                   <KbdGroup className="absolute top-1/2 right-2 -translate-y-1/2 opacity-0 transition-opacity duration-200 group-hover/menu-button:opacity-100">
                     <Kbd>{modSymbol}</Kbd>
                     <Kbd>J</Kbd>

--- a/apps/web/src/features/session/assistant-pending-row.tsx
+++ b/apps/web/src/features/session/assistant-pending-row.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { useEffect, useRef, useState, type ReactNode } from 'react';
+
+import { AnimatedThinkingText } from '@/components/ui/animated-thinking-text';
+import { formatDuration } from '@/ui/turns';
+import { cn } from '@/lib/utils';
+
+/**
+ * The assistant turn's "pending" shell — the Kortix logomark on top, and beneath
+ * it the EXACT regular assistant-waiting indicator (pulsing dot + thinking text +
+ * elapsed time, identical to SessionChat's in-turn working row). Rendered the
+ * INSTANT a user message is sent so the assistant response area is already
+ * present and never "pops in" / spawns late.
+ *
+ * Shared by SessionChat's optimistic + awaiting states and the instant session
+ * shell so all of them render identically (and seamlessly across the shell →
+ * chat crossfade).
+ */
+export function AssistantPendingRow({
+  status,
+  className,
+}: {
+  /** Replaces the cycling thinking text (e.g. a retry notice, or a boot stage). */
+  status?: ReactNode;
+  className?: string;
+}) {
+  // Elapsed timer — formatted exactly like the in-turn indicator (blank under 1s).
+  const startRef = useRef(Date.now());
+  const [duration, setDuration] = useState('');
+  useEffect(() => {
+    const update = () => setDuration(formatDuration(Date.now() - startRef.current));
+    update();
+    const id = setInterval(update, 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  return (
+    <div className={cn('flex flex-col items-start gap-3', className)}>
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
+        src="/kortix-logomark-white.svg"
+        alt="Kortix"
+        className="dark:invert-0 h-[14px] w-auto flex-shrink-0 invert"
+      />
+      {/* Regular assistant-waiting row: pulsing dot + thinking text + elapsed —
+          identical to SessionChat's in-turn working indicator. */}
+      <div className="text-muted-foreground flex items-center gap-2 py-1 text-xs">
+        <span className="relative flex size-3" aria-hidden>
+          <span className="bg-muted-foreground/30 absolute inline-flex h-full w-full animate-ping rounded-full" />
+          <span className="bg-muted-foreground/50 relative inline-flex size-3 rounded-full" />
+        </span>
+        {status ?? <AnimatedThinkingText className="text-xs" />}
+        {duration && (
+          <>
+            <span className="text-muted-foreground/50">·</span>
+            <span className="text-muted-foreground/70">{duration}</span>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/session/composer-chat-input.tsx
+++ b/apps/web/src/features/session/composer-chat-input.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import type { ReactNode } from 'react';
+
+import {
+  type AttachedFile,
+  SessionChatInput,
+} from '@/features/session/session-chat-input';
+import { useOpenCodeConfig } from '@/hooks/opencode/use-opencode-config';
+import { type ModelKey, useOpenCodeLocal } from '@/hooks/opencode/use-opencode-local';
+import {
+  type Command,
+  useOpenCodeAgents,
+  useOpenCodeCommands,
+  useOpenCodeProviders,
+} from '@/hooks/opencode/use-opencode-sessions';
+
+export interface ComposerOptions {
+  agent?: string;
+  model?: ModelKey;
+  variant?: string;
+}
+
+/**
+ * The canonical "compose a first message" input: {@link SessionChatInput}
+ * pre-wired with the OpenCode model / agent / variant / command selectors (the
+ * four catalog queries + per-session selection state). Used by the home composer
+ * and the instant session shell so neither hand-rolls the selector wiring.
+ *
+ * The current selections are handed to `onSend` / `onCommand` as `options`, so
+ * callers never need their own `useOpenCodeLocal`.
+ */
+export function ComposerChatInput({
+  onSend,
+  onCommand,
+  sessionId,
+  isBusy,
+  disabled,
+  autoFocus,
+  placeholder,
+  inputSlot,
+}: {
+  onSend: (text: string, files: AttachedFile[] | undefined, options: ComposerOptions) => void;
+  onCommand?: (command: Command, args: string | undefined, options: ComposerOptions) => void;
+  sessionId?: string;
+  isBusy?: boolean;
+  disabled?: boolean;
+  autoFocus?: boolean;
+  placeholder?: string;
+  inputSlot?: ReactNode;
+}) {
+  const { data: agents } = useOpenCodeAgents();
+  const { data: providers } = useOpenCodeProviders();
+  const { data: commands } = useOpenCodeCommands();
+  const { data: config } = useOpenCodeConfig();
+  const local = useOpenCodeLocal({ agents, providers, config, sessionId });
+
+  // Read at send-time so the latest selections are captured.
+  const options = (): ComposerOptions => {
+    const o: ComposerOptions = {};
+    if (local.agent.current) o.agent = local.agent.current.name;
+    if (local.model.currentKey) o.model = local.model.currentKey;
+    if (local.model.variant.current) o.variant = local.model.variant.current;
+    return o;
+  };
+
+  return (
+    <SessionChatInput
+      onSend={(text, files) => onSend(text, files, options())}
+      onCommand={onCommand ? (cmd, args) => onCommand(cmd, args, options()) : undefined}
+      isBusy={isBusy}
+      disabled={disabled}
+      autoFocus={autoFocus}
+      placeholder={placeholder}
+      inputSlot={inputSlot}
+      sessionId={sessionId}
+      providers={providers}
+      agents={local.agent.list}
+      selectedAgent={local.agent.current?.name ?? null}
+      onAgentChange={(name) => local.agent.set(name ?? undefined)}
+      models={local.model.list}
+      selectedModel={local.model.currentKey ?? null}
+      onModelChange={(m) => local.model.set(m ?? undefined, { recent: true })}
+      variants={local.model.variant.list}
+      selectedVariant={local.model.variant.current ?? null}
+      onVariantChange={(v) => local.model.variant.set(v ?? undefined)}
+      commands={commands || []}
+    />
+  );
+}

--- a/apps/web/src/features/session/instant-session-shell.tsx
+++ b/apps/web/src/features/session/instant-session-shell.tsx
@@ -1,0 +1,210 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+import { AssistantPendingRow } from '@/features/session/assistant-pending-row';
+import {
+  ComposerChatInput,
+  type ComposerOptions,
+} from '@/features/session/composer-chat-input';
+import type { AttachedFile } from '@/features/session/session-chat-input';
+import { SessionLayout } from '@/features/session/session-layout';
+import { SessionSiteHeader } from '@/features/session/header/session-site-header';
+import { useSessionWallpaperLayer } from '@/features/session/session-wallpaper-layer';
+import { SessionWelcome } from '@/features/session/session-welcome';
+import { AnimatedThinkingText } from '@/components/ui/animated-thinking-text';
+import type { Command } from '@/hooks/opencode/use-opencode-sessions';
+import type { SessionStartStage } from '@/lib/projects-client';
+import { playSound } from '@/lib/sounds';
+import { cn } from '@/lib/utils';
+import { useKortixComputerStore } from '@/stores/kortix-computer-store';
+import { usePendingFilesStore } from '@/stores/pending-files-store';
+
+/** The inline status shown under the Kortix logo while the computer is still
+ *  coming up after a first send — sleek + minimal, reflecting the live stage. */
+function bootLabel(stage: SessionStartStage): string {
+  if (stage === 'provisioning') return 'Provisioning your computer';
+  if (stage === 'ready') return 'Connecting';
+  return 'Starting your computer';
+}
+
+/**
+ * The instant session shell — shown the moment a freshly-created session opens,
+ * BEFORE the sandbox/runtime is ready, in place of the old full-screen loader.
+ *
+ * A faithful, fully-interactive empty session: welcome wallpaper + a live chat
+ * input you can type into immediately (the input needs no runtime — the home
+ * composer proves it). Provisioning runs silently in the background.
+ *
+ * On the FIRST send we stash the message on the `project_pending_*` keys (which
+ * the session page migrates onto the OpenCode pin) so the real {@link SessionChat}
+ * auto-sends it the instant the runtime is healthy — and the thread shows an
+ * inline "starting your computer" status under the assistant logo until the real
+ * chat crossfades in. The boot checklist also lives in the side panel, but only
+ * if the user opens it (never auto-opened); once the runtime is ready the panel
+ * gracefully falls back to the real (empty) Actions view.
+ */
+export function InstantSessionShell({
+  projectId,
+  sessionId,
+  stage,
+  onSubmit,
+}: {
+  projectId: string;
+  /** The route's session id (== the pending-prompt namespace the page migrates). */
+  sessionId: string;
+  stage: SessionStartStage;
+  /** Fired on the first send so the page can mount the real chat (which auto-sends
+   *  the handed-off prompt) and crossfade it in. */
+  onSubmit?: () => void;
+}) {
+  const isSidePanelOpen = useKortixComputerStore((s) => s.isSidePanelOpen);
+  // `ready` is the backend's authoritative "runtime is up" signal (POST /start).
+  // Once ready, we drop boot mode so nothing is stuck on "Connecting" — even with
+  // no message sent.
+  const ready = stage === 'ready';
+
+  // A pending prompt may already be staged (home composer send) → show the
+  // booting view immediately in that case.
+  const [submitted, setSubmitted] = useState<string | null>(() => {
+    if (typeof window === 'undefined') return null;
+    return (
+      sessionStorage.getItem(`opencode_pending_prompt:${sessionId}`) ??
+      sessionStorage.getItem(`project_pending_prompt:${sessionId}`)
+    );
+  });
+
+  const handleSend = useCallback(
+    (text: string, files: AttachedFile[] | undefined, options: ComposerOptions) => {
+      if ((!text.trim() && !files?.length) || submitted) return;
+      playSound('send');
+
+      // Hand the message to the real chat: it auto-sends from these keys once the
+      // runtime is healthy (the session page migrates project_* → opencode_*).
+      sessionStorage.setItem(`project_pending_prompt:${sessionId}`, text);
+      if (Object.keys(options).length > 0) {
+        sessionStorage.setItem(`project_pending_options:${sessionId}`, JSON.stringify(options));
+      }
+      // File objects can't survive sessionStorage — stash them in the store the
+      // real chat consumes (same path the home composer uses).
+      if (files?.length) {
+        usePendingFilesStore.getState().setPendingFiles(files);
+      }
+
+      setSubmitted(text);
+      onSubmit?.();
+    },
+    [sessionId, submitted, onSubmit],
+  );
+
+  const handleCommand = useCallback(
+    (cmd: Command, args: string | undefined, options: ComposerOptions) => {
+      // Defer slash-commands through the same handoff as a normal first message.
+      handleSend(`/${cmd.name}${args ? ` ${args}` : ''}`, undefined, options);
+    },
+    [handleSend],
+  );
+
+  const column = (
+    <div
+      className={cn(
+        'relative flex h-full flex-col',
+        submitted ? 'bg-background' : 'bg-transparent',
+      )}
+    >
+      {/* Welcome wallpaper — portaled into SessionLayout's full-bleed layer so it
+          spans the whole width and never re-crops when the side panel opens
+          (identical to a loaded empty session). Hidden once a first message
+          exists (the thread takes over on a solid background). */}
+      {!submitted && <ShellWallpaper />}
+
+      <SessionSiteHeader
+        sessionId={sessionId}
+        sessionTitle="New session"
+        isSidePanelOpen={isSidePanelOpen}
+        onToggleSidePanel={() => {
+          const s = useKortixComputerStore.getState();
+          s.setActiveSession(sessionId);
+          if (s.isSidePanelOpen) s.closeSidePanel();
+          else s.openSidePanel();
+        }}
+      />
+
+      <div className="relative z-10 min-h-0 flex-1">
+        <div className="scrollbar-hide relative z-10 h-full flex-1 overflow-y-auto px-4 py-4">
+          <div className="mx-auto w-full min-w-0 max-w-3xl px-3 sm:px-6">
+            {submitted && (
+              <div className="flex min-w-0 flex-col">
+                {/* Optimistic turn — the EXACT same DOM shape + spacing as
+                    SessionChat's optimistic block (turn wrapper → justify-end
+                    bubble → pending row) so the bubble + Kortix logo never shift
+                    across the shell → chat crossfade. */}
+                <div className="mt-12 first:mt-0">
+                  <div className="flex justify-end">
+                    <div className="flex max-w-[90%] flex-col overflow-hidden rounded-3xl rounded-br-lg border bg-card">
+                      <p className="whitespace-pre-wrap px-4 py-3 text-sm leading-relaxed">
+                        {submitted}
+                      </p>
+                    </div>
+                  </div>
+                  {/* While the computer is still coming up the status reflects the
+                      boot stage ("Starting your computer"); once ready it's the
+                      regular thinking text. */}
+                  <AssistantPendingRow
+                    className="mt-6"
+                    status={
+                      ready ? undefined : (
+                        <AnimatedThinkingText statusText={bootLabel(stage)} className="text-xs" />
+                      )
+                    }
+                  />
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <ComposerChatInput
+        onSend={handleSend}
+        onCommand={handleCommand}
+        sessionId={sessionId}
+        isBusy={!!submitted}
+        disabled={!!submitted}
+        autoFocus
+      />
+    </div>
+  );
+
+  return (
+    <SessionLayout
+      sessionId={sessionId}
+      projectId={projectId}
+      projectSessionId={sessionId}
+      transient
+      // Side-panel content: the boot checklist while still coming up, then the
+      // real (empty) Actions view once ready — so an open panel is never stuck on
+      // "Connecting". Visibility stays user-controlled (no auto-open).
+      bootStage={ready ? null : stage}
+    >
+      {column}
+    </SessionLayout>
+  );
+}
+
+/**
+ * Portals the welcome wallpaper into SessionLayout's full-bleed layer (exactly
+ * like SessionChat) so it spans the entire session width and never re-crops when
+ * the side panel opens. Falls back to inline on mobile (no layer). Must render
+ * as a descendant of SessionLayout to read the layer from context.
+ */
+function ShellWallpaper() {
+  const layer = useSessionWallpaperLayer();
+  const wallpaper = (
+    <div className="pointer-events-none absolute inset-0 z-0">
+      <SessionWelcome />
+    </div>
+  );
+  return layer ? createPortal(wallpaper, layer) : wallpaper;
+}

--- a/apps/web/src/features/session/pty-terminal.tsx
+++ b/apps/web/src/features/session/pty-terminal.tsx
@@ -7,6 +7,7 @@ import { FitAddon } from '@xterm/addon-fit';
 import { WebLinksAddon } from '@xterm/addon-web-links';
 import '@xterm/xterm/css/xterm.css';
 import { getPtyWebSocketUrl, useUpdatePty } from '@/hooks/opencode/use-opencode-pty';
+import { invalidateTokenCache } from '@/lib/auth-token';
 import type { Pty } from '@opencode-ai/sdk/v2/client';
 
 // ============================================================================
@@ -240,6 +241,13 @@ export const PtyTerminal = forwardRef<PtyTerminalHandle, PtyTerminalProps>(funct
       if (disposedRef.current) return;
       if (reconnectTimeoutRef.current) return;
 
+      // The auth token is baked into the WS URL as a query param (browsers can't
+      // set WS headers), and a failed upgrade is most often a stale/expired JWT —
+      // the browser only ever surfaces it as a bare error + 1006 close, never the
+      // underlying 401. Drop the cached token so the next connect fetches (and
+      // refreshes) a fresh one, instead of looping forever on the dead token.
+      invalidateTokenCache();
+
       reconnectAttemptsRef.current += 1;
       const delay = Math.min(1000 * 2 ** (reconnectAttemptsRef.current - 1), 15000);
       const suffix = reason ? ` (${reason})` : '';
@@ -315,12 +323,15 @@ export const PtyTerminal = forwardRef<PtyTerminalHandle, PtyTerminalProps>(funct
         }
       };
 
-      ws.onerror = (err) => {
+      ws.onerror = () => {
         if (connectionIdRef.current !== myConnectionId || disposedRef.current) return;
-        console.error('[PtyTerminal] WebSocket error:', err);
+        // Browser WS error events carry no detail (always an empty Event) and the
+        // status (e.g. a 401) is never exposed. The onclose that follows drives
+        // backoff/reconnect, so just flag it — don't spam the terminal with red
+        // text on every attempt, and never echo the token-bearing URL into the
+        // visible buffer. The "Reconnecting in Ns..." line gives the user signal.
+        console.warn('[PtyTerminal] WebSocket connection error — will retry');
         hadErrorRef.current = true;
-        term.writeln('\r\n\x1b[31mFailed to connect to terminal.\x1b[0m');
-        term.writeln('\x1b[90mURL: ' + wsUrl + '\x1b[0m');
         updateStatus('error');
       };
 

--- a/apps/web/src/features/session/session-chat.tsx
+++ b/apps/web/src/features/session/session-chat.tsx
@@ -63,6 +63,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { STATUS_BG, STATUS_BORDER, STATUS_TEXT } from '@/components/ui/status';
+import { AssistantPendingRow } from '@/features/session/assistant-pending-row';
 import { Textarea } from '@/components/ui/textarea';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { searchWorkspaceFiles } from '@/features/files';
@@ -5656,21 +5657,15 @@ export function SessionChat({
                         })()}
                       </div>
                     </div>
-                    <div className="flex items-center gap-3">
-                      {/* eslint-disable-next-line @next/next/no-img-element */}
-                      <img
-                        src="/kortix-logomark-white.svg"
-                        alt="Kortix"
-                        className="h-[14px] w-auto flex-shrink-0 invert dark:invert-0"
-                      />
-                      {isRetrying && (
-                        <span className={cn('text-xs', STATUS_TEXT.warning)}>
-                          {tHardcodedUi.raw(
-                            'componentsSessionSessionChat.line5927JsxTextRetryingConnection',
-                          )}
-                        </span>
-                      )}
-                    </div>
+                    <AssistantPendingRow
+                      className="mt-6"
+                      status={
+                        isRetrying ? (
+                          <span className={cn('text-xs', STATUS_TEXT.warning)}>
+                            {tHardcodedUi.raw('componentsSessionSessionChat.line5927JsxTextRetryingConnection')}</span>
+                        ) : undefined
+                      }
+                    />
                   </div>
                 )}
 
@@ -5765,17 +5760,10 @@ export function SessionChat({
                 </ToolActivateContext.Provider>
 
                 {/* Busy indicator when no turns yet but session is busy */}
-                {commandError && <TurnErrorDisplay errorText={commandError} className="mt-2" />}
-                {!showOptimistic && isBusy && turns.length === 0 && (
-                  <div className="flex items-center gap-3">
-                    {/* eslint-disable-next-line @next/next/no-img-element */}
-                    <img
-                      src="/kortix-logomark-white.svg"
-                      alt="Kortix"
-                      className="h-[14px] w-auto flex-shrink-0 invert dark:invert-0"
-                    />
-                  </div>
+                {commandError && (
+                  <TurnErrorDisplay errorText={commandError} className="mt-2" />
                 )}
+                {!showOptimistic && isBusy && turns.length === 0 && <AssistantPendingRow />}
               </div>
               {/* Spacer — ensures the last message can scroll to the top of
 						    the viewport (ChatGPT-style). Without this, scrollToBottom

--- a/apps/web/src/features/session/session-layout.tsx
+++ b/apps/web/src/features/session/session-layout.tsx
@@ -30,8 +30,10 @@ import { SessionFilesExplorer } from '@/features/session/session-files-explorer'
 import { SessionTerminalPanel } from '@/features/session/session-terminal-panel';
 import { SessionActionsPanel } from '@/features/session/session-actions-panel';
 import { SessionWallpaperLayerContext } from '@/features/session/session-wallpaper-layer';
+import { SessionStartingLoader } from '@/features/session/session-starting-loader';
 import { Drawer, DrawerContent } from '@/components/ui/drawer';
 import { X } from 'lucide-react';
+import type { SessionStartStage } from '@/lib/projects-client';
 
 // ============================================================================
 // Session Layout
@@ -42,6 +44,20 @@ interface SessionLayoutProps {
   projectId?: string;
   projectSessionId?: string;
   children: React.ReactNode;
+  /**
+   * When set, the side-panel CONTENT is the centered "Kortix Computer is
+   * starting" loader instead of the runtime-coupled Actions/Files/Terminal/
+   * Browser views (which need a live sandbox). The instant shell clears this once
+   * the runtime is ready, so the panel falls back to the real (empty) Actions
+   * view. Panel VISIBILITY stays user-controlled — this never force-opens it.
+   */
+  bootStage?: SessionStartStage | null;
+  /**
+   * Marks this as the transient instant-session shell: its per-session
+   * active-registration effects are skipped so it never fights the real
+   * SessionLayout that crossfades in over it.
+   */
+  transient?: boolean;
 }
 
 export const SessionLayout = memo(function SessionLayout({
@@ -49,8 +65,11 @@ export const SessionLayout = memo(function SessionLayout({
   projectId,
   projectSessionId,
   children,
+  bootStage = null,
+  transient = false,
 }: SessionLayoutProps) {
   const isMobile = useIsMobile();
+  const booting = !!bootStage;
 
   const { data: messages } = useOpenCodeMessages(sessionId);
 
@@ -73,10 +92,11 @@ export const SessionLayout = memo(function SessionLayout({
   const isActiveTab = useTabStore((s) => s.activeTabId === sessionId);
 
   useEffect(() => {
+    if (transient) return; // transient shell — don't claim the active session
     if (isActiveTab) {
       setActiveSession(sessionId);
     }
-  }, [isActiveTab, sessionId, setActiveSession]);
+  }, [transient, isActiveTab, sessionId, setActiveSession]);
 
   // Right-side panel view — actions (tool calls) or internal browser.
   // Per-session, so each session remembers which view the user prefers.
@@ -116,10 +136,11 @@ export const SessionLayout = memo(function SessionLayout({
   // ref) so SessionChat re-renders the portal once the layer mounts.
   const [wallpaperLayer, setWallpaperLayer] = useState<HTMLDivElement | null>(null);
 
-  // Side panel is visible whenever the user has opened it — full stop. The
-  // panel hosts Actions / Browser / Files / Terminal, all of which are useful
-  // even on an empty session with no tool calls (the Actions view shows its
-  // own empty state), so opening is gated purely on the user's intent.
+  // Side panel is visible whenever the user has opened it — full stop. Opening
+  // is gated purely on the user's intent (the instant shell auto-opens it once a
+  // task is kicked off). While booting, its CONTENT is the "Kortix Computer is
+  // starting" loader instead of Actions — so opening it any time before the
+  // computer is ready shows boot status, switching to Actions once booted.
   const shouldShowPanel = isSidePanelOpen;
 
   // ⌘I / Ctrl+I toggles the side panel open/closed.
@@ -140,6 +161,7 @@ export const SessionLayout = memo(function SessionLayout({
   // if we still own the slot.
   const isVisibleLayout = isInTabSystem ? isActiveTab : true;
   useEffect(() => {
+    if (transient) return; // transient shell — the real layout owns panel routing
     if (!isVisibleLayout) return;
     setActivePanelSession(sessionId);
     return () => {
@@ -147,7 +169,7 @@ export const SessionLayout = memo(function SessionLayout({
         setActivePanelSession(null);
       }
     };
-  }, [isVisibleLayout, sessionId, setActivePanelSession]);
+  }, [transient, isVisibleLayout, sessionId, setActivePanelSession]);
   useEffect(() => {
     if (!shouldHandleHotkey) return;
     const onKey = (e: KeyboardEvent) => {
@@ -318,6 +340,18 @@ export const SessionLayout = memo(function SessionLayout({
     </div>
   );
 
+  // While booting, the panel is JUST the dead-center "Kortix Computer is
+  // starting" loader — no header bar (the loader has its own heading, so a panel
+  // title would be redundant), filling the whole card so it's perfectly
+  // centered. The runtime-coupled views (Actions/Files/Terminal/Browser) need a
+  // live sandbox, so they only render once booted.
+  const effectivePanelHeader = booting ? null : panelHeader;
+  const effectivePanelBody = booting ? (
+    <SessionStartingLoader stage={bootStage ?? 'provisioning'} delayMs={0} />
+  ) : (
+    panelBody
+  );
+
   // Mobile
   if (isMobile) {
     return (
@@ -332,8 +366,8 @@ export const SessionLayout = memo(function SessionLayout({
           }}
         >
           <DrawerContent className="flex h-[85dvh] max-h-[85dvh] flex-col overflow-hidden p-0">
-            {panelHeader}
-            <div className="min-h-0 flex-1 overflow-hidden">{panelBody}</div>
+            {effectivePanelHeader}
+            <div className="min-h-0 flex-1 overflow-hidden">{effectivePanelBody}</div>
           </DrawerContent>
         </Drawer>
       </div>
@@ -405,7 +439,7 @@ export const SessionLayout = memo(function SessionLayout({
               "h-full transition-[padding] duration-300 ease-out bg-background",
               isExpanded ? "p-0" : "pt-3 pb-6 pr-3 sm:pr-4 pl-1.5"
             )}>
-              <SidePanelFrame header={panelHeader}>{panelBody}</SidePanelFrame>
+              <SidePanelFrame header={effectivePanelHeader}>{effectivePanelBody}</SidePanelFrame>
             </div>
           </ResizablePanel>
         </ResizablePanelGroup>

--- a/apps/web/src/features/session/session-starting-loader.tsx
+++ b/apps/web/src/features/session/session-starting-loader.tsx
@@ -7,23 +7,19 @@ import { cn } from '@/lib/utils';
 import type { SessionStartStage } from '@/lib/projects-client';
 
 /**
- * The ONE loader shown while a session's Kortix Computer comes up. All the heavy
- * lifting (provision / wake / OpenCode readiness + pin) is server-side behind
- * POST /sessions/:id/start — this just reports the real stage it returns.
+ * The ONE loader shown while a session's Kortix Computer comes up — full-screen
+ * for resumes, and dead-center in the side panel while a fresh session boots.
+ * All the heavy lifting (provision / wake / OpenCode readiness + pin) is
+ * server-side behind POST /sessions/:id/start; this just reports the real stage.
  *
- * IMPORTANT — layout stability: the outer flex-1 container is ALWAYS rendered so
- * it always occupies the content area. Only the visible loader CONTENT is held
- * back ~700ms (so a warm open / transient re-render never flashes it). Returning
- * null instead collapsed the content area to zero height, which let the chat
- * input snap to the top and then jump back down — the janky "input jumps" bug.
+ * Visual: super-minimal, perfectly centered. A single kortix-green pulse, the
+ * heading, a clean stepped checklist (no connector rails), and one quiet hint.
  */
 const LOADER_DELAY_MS = 700;
 /**
- * How long we sit in the backend `starting` stage before softly advancing the
- * timeline from "Preparing your workspace" to "Starting the agent". Both happen
- * within that one backend stage (clone → OpenCode boot, in that order), so the
- * advance reflects real ordering — and we never mark the LAST sub-step done
- * until the backend actually reports `ready`.
+ * How long we sit in the backend `starting` stage before softly advancing from
+ * "Preparing your workspace" to "Starting the agent". Both happen within that
+ * one backend stage (clone → OpenCode boot), so the advance reflects real order.
  */
 const STARTING_SUBSTEP_MS = 5_000;
 /** After this long, swap the footer copy to set expectations for a cold start. */
@@ -54,14 +50,23 @@ function activeStep(stage: SessionStartStage, msInStage: number): number {
 
 export function SessionStartingLoader({
   stage = 'provisioning',
+  /** Delay before the content fades in. The full-screen resume loader keeps the
+   *  default so a warm open never flashes it; the side panel passes 0 because the
+   *  user opened it deliberately and expects to see status immediately. */
+  delayMs = LOADER_DELAY_MS,
 }: {
   stage?: SessionStartStage;
+  delayMs?: number;
 }) {
-  const [show, setShow] = useState(false);
+  const [show, setShow] = useState(delayMs <= 0);
   useEffect(() => {
-    const t = setTimeout(() => setShow(true), LOADER_DELAY_MS);
+    if (delayMs <= 0) {
+      setShow(true);
+      return;
+    }
+    const t = setTimeout(() => setShow(true), delayMs);
     return () => clearTimeout(t);
-  }, []);
+  }, [delayMs]);
 
   // A 1s tick drives both the in-stage soft-advance and the footer copy.
   const [now, setNow] = useState(() => Date.now());
@@ -84,90 +89,65 @@ export function SessionStartingLoader({
   const slow = now - mountedAt.current >= SLOW_AFTER_MS;
 
   return (
-    <div className="flex min-h-0 flex-1 items-center justify-center px-6">
-      {show && (
-        <div className="flex w-full max-w-xs flex-col gap-6">
-          <div className="flex items-center gap-2.5">
-            <span className="relative flex h-2 w-2" aria-hidden>
-              <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-kortix-green/60" />
-              <span className="relative inline-flex h-2 w-2 rounded-full bg-kortix-green" />
-            </span>
-            <h2 className="text-foreground text-sm font-semibold">Kortix Computer is starting</h2>
-          </div>
-
-          <ol className="flex flex-col" aria-live="polite">
-            {STEPS.map((step, i) => {
-              const done = i < active;
-              const current = i === active;
-              const isLast = i === STEPS.length - 1;
-              return (
-                <li
-                  key={step.label}
-                  className="flex gap-3"
-                  aria-current={current ? 'step' : undefined}
-                >
-                  {/* Node + connector rail */}
-                  <div className="flex flex-col items-center">
-                    <span
-                      className={cn(
-                        'flex h-5 w-5 shrink-0 items-center justify-center rounded-full border transition-colors duration-moderate',
-                        done
-                          ? 'border-kortix-green/30 bg-kortix-green/10 text-kortix-green'
-                          : current
-                            ? 'border-kortix-green/40 text-kortix-green'
-                            : 'border-border bg-transparent',
-                      )}
-                    >
-                      {done ? (
-                        <Check className="h-3 w-3" strokeWidth={2.5} />
-                      ) : current ? (
-                        <Loader2 className="h-3 w-3 animate-spin" />
-                      ) : (
-                        <span className="h-1.5 w-1.5 rounded-full bg-border" />
-                      )}
-                    </span>
-                    {!isLast && (
-                      <span
-                        className={cn(
-                          'mt-1 w-px flex-1 transition-colors duration-moderate',
-                          done ? 'bg-kortix-green/25' : 'bg-border',
-                        )}
-                      />
-                    )}
-                  </div>
-
-                  {/* Label + description */}
-                  <div className={cn('flex flex-col', isLast ? 'pb-0' : 'pb-4')}>
-                    <span
-                      className={cn(
-                        'text-sm leading-5 transition-colors duration-moderate',
-                        current
-                          ? 'text-foreground font-medium'
-                          : done
-                            ? 'text-muted-foreground'
-                            : 'text-muted-foreground/50',
-                      )}
-                    >
-                      {step.label}
-                    </span>
-                    {current && (
-                      <span className="text-muted-foreground/60 text-xs leading-5">
-                        {step.description}
-                      </span>
-                    )}
-                  </div>
-                </li>
-              );
-            })}
-          </ol>
-
-          <p className="text-muted-foreground/50 text-xs leading-relaxed">
-            {slow
-              ? 'Still preparing — a cold start can take a little longer than usual.'
-              : 'This usually takes a few seconds while your workspace and files are prepared.'}
-          </p>
+    <div className="flex h-full min-h-0 w-full flex-1 items-center justify-center px-8">
+      <div
+        className={cn(
+          'flex flex-col items-center gap-9 transition-opacity duration-500',
+          show ? 'opacity-100' : 'opacity-0',
+        )}
+      >
+        {/* Brand heartbeat + heading, grouped. */}
+        <div className="flex flex-col items-center gap-4">
+          <span className="relative flex h-2.5 w-2.5" aria-hidden>
+            <span className="bg-kortix-green/40 absolute inline-flex h-full w-full animate-ping rounded-full" />
+            <span className="bg-kortix-green relative inline-flex h-2.5 w-2.5 rounded-full" />
+          </span>
+          <h2 className="text-foreground text-[13px] font-medium tracking-tight">
+            Kortix Computer is starting
+          </h2>
         </div>
-      )}
+
+        {/* Auto-width so the checklist is a centered block under the heading. */}
+        <ol className="flex flex-col gap-3.5" aria-live="polite">
+          {STEPS.map((step, i) => {
+            const done = i < active;
+            const current = i === active;
+            return (
+              <li
+                key={step.label}
+                className="flex items-center gap-2.5"
+                aria-current={current ? 'step' : undefined}
+              >
+                <span className="flex h-3.5 w-3.5 shrink-0 items-center justify-center">
+                  {done ? (
+                    <Check className="text-kortix-green h-3.5 w-3.5" strokeWidth={2.5} />
+                  ) : current ? (
+                    <Loader2 className="text-kortix-green h-3.5 w-3.5 animate-spin" />
+                  ) : (
+                    <span className="bg-muted-foreground/25 h-1 w-1 rounded-full" />
+                  )}
+                </span>
+                <span
+                  className={cn(
+                    'text-[13px] leading-none tracking-tight transition-colors duration-500',
+                    current
+                      ? 'text-foreground font-medium'
+                      : done
+                        ? 'text-muted-foreground'
+                        : 'text-muted-foreground/40',
+                  )}
+                >
+                  {step.label}
+                </span>
+              </li>
+            );
+          })}
+        </ol>
+
+        <p className="text-muted-foreground/40 text-center text-[11px] leading-relaxed">
+          {slow ? 'A cold start can take a little longer.' : 'This usually takes a few seconds.'}
+        </p>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/hooks/opencode/use-opencode-sessions.ts
+++ b/apps/web/src/hooks/opencode/use-opencode-sessions.ts
@@ -3,6 +3,7 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { getClient } from '@/lib/opencode-sdk';
 import { isOpenCodeConfigInvalidError } from '@/lib/opencode-errors';
+import { markSessionFresh } from '@/lib/fresh-sessions';
 import { useOpenCodeCompactionStore } from '@/stores/opencode-compaction-store';
 import { useSandboxConnectionStore } from '@/stores/sandbox-connection-store';
 import { useSyncStore } from '@/stores/opencode-sync-store';
@@ -296,6 +297,11 @@ export function useCreateOpenCodeSession() {
       // Surgically insert into cache — SSE session.created will also fire
       // but this gives instant UI feedback. Dedup to avoid duplicate keys.
       const session = newSession as Session;
+      // Mark this session as freshly created so the session page shows the
+      // instant typeable shell (not the resume loader). In-memory + synchronous,
+      // so it's reliably set before the create-then-navigate hop. Every create
+      // path flows through this hook; resumes don't.
+      markSessionFresh(session.id);
       queryClient.setQueryData<Session[]>(opencodeKeys.sessions(), (old) => {
         if (!old) return [session];
         const idx = old.findIndex((s) => s.id === session.id);

--- a/apps/web/src/hooks/projects/use-new-project-session.ts
+++ b/apps/web/src/hooks/projects/use-new-project-session.ts
@@ -20,7 +20,11 @@ import { toast } from '@/lib/toast';
  * during the navigation; the session is persisted in the background.
  *
  * `onNavigate(sessionId)` runs synchronously right before the push — use it for
- * entry-point-specific side effects (open a tab, close a drawer, timing marks).
+ * entry-point-specific side effects (open a tab, close a drawer, timing marks,
+ * stashing a pending prompt so the shell auto-sends it once the box is ready).
+ *
+ * `create` carries create-time overrides (e.g. a chosen `sandbox_slug`) straight
+ * to the persist POST without changing the optimistic timing.
  */
 export function useNewProjectSession(projectId: string | undefined) {
   const router = useRouter();
@@ -28,7 +32,10 @@ export function useNewProjectSession(projectId: string | undefined) {
   const creatingRef = useRef(false);
 
   return useCallback(
-    (opts?: { onNavigate?: (sessionId: string) => void }) => {
+    (opts?: {
+      onNavigate?: (sessionId: string) => void;
+      create?: { sandbox_slug?: string };
+    }) => {
       if (!projectId || creatingRef.current) return;
       creatingRef.current = true;
 
@@ -42,7 +49,7 @@ export function useNewProjectSession(projectId: string | undefined) {
       router.push(`/projects/${projectId}/sessions/${sessionId}`);
 
       // Persist in the background — the page is already rendering the shell.
-      createProjectSession(projectId, { session_id: sessionId })
+      createProjectSession(projectId, { session_id: sessionId, ...opts?.create })
         .then(() => {
           queryClient.invalidateQueries({ queryKey: ['project-sessions', projectId] });
         })

--- a/apps/web/src/hooks/projects/use-new-project-session.ts
+++ b/apps/web/src/hooks/projects/use-new-project-session.ts
@@ -1,0 +1,70 @@
+'use client';
+
+import { useCallback, useRef } from 'react';
+import { useRouter } from 'next/navigation';
+import { useQueryClient } from '@tanstack/react-query';
+
+import { markSessionFresh } from '@/lib/fresh-sessions';
+import { createProjectSession, prefetchSessionStart } from '@/lib/projects-client';
+import { toast } from '@/lib/toast';
+
+/**
+ * The fastest possible "new empty session" path, shared by every entry point
+ * (project shell button, ⌘T/⌘J shortcuts, project sidebar, command palette).
+ *
+ * OPTIMISTIC: mint the session id client-side and navigate IMMEDIATELY — the
+ * instant shell paints before the create POST even returns. The backend honors a
+ * client-provided UUID (`session_id` is client-authoritative; the warm pool binds
+ * to it), and the session page's `/start` poll tolerates the sub-second
+ * create-vs-start race by retrying. Provisioning + the route bundle are warmed
+ * during the navigation; the session is persisted in the background.
+ *
+ * `onNavigate(sessionId)` runs synchronously right before the push — use it for
+ * entry-point-specific side effects (open a tab, close a drawer, timing marks).
+ */
+export function useNewProjectSession(projectId: string | undefined) {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const creatingRef = useRef(false);
+
+  return useCallback(
+    (opts?: { onNavigate?: (sessionId: string) => void }) => {
+      if (!projectId || creatingRef.current) return;
+      creatingRef.current = true;
+
+      // The API requires a UUIDv4; crypto.randomUUID is available in every
+      // context this app runs (secure context: https + localhost).
+      const sessionId = crypto.randomUUID();
+      markSessionFresh(sessionId); // → instant shell, not the resume loader
+      prefetchSessionStart(queryClient, projectId, sessionId);
+      router.prefetch(`/projects/${projectId}/sessions/${sessionId}`);
+      opts?.onNavigate?.(sessionId);
+      router.push(`/projects/${projectId}/sessions/${sessionId}`);
+
+      // Persist in the background — the page is already rendering the shell.
+      createProjectSession(projectId, { session_id: sessionId })
+        .then(() => {
+          queryClient.invalidateQueries({ queryKey: ['project-sessions', projectId] });
+        })
+        .catch((err) => {
+          const code = (err as { code?: string })?.code;
+          // No-plan 402 → the session page itself shows the gated screen +
+          // upgrade modal (its billing gate knows this project's account), so
+          // stay put and let it handle the pitch.
+          if (code === 'subscription_required' || code === 'no_account') return;
+          // Any other terminal failure (concurrent-session limit, out-of-credits,
+          // validation, server error) means the session will never exist — we've
+          // already navigated optimistically, so bounce back off the dead shell.
+          // The 429 cap is surfaced by the global handler; others get a toast.
+          if (code !== 'concurrent_session_limit') {
+            toast.error(err instanceof Error ? err.message : 'Failed to start session');
+          }
+          router.replace(`/projects/${projectId}`);
+        })
+        .finally(() => {
+          creatingRef.current = false;
+        });
+    },
+    [projectId, router, queryClient],
+  );
+}

--- a/apps/web/src/lib/auth-token.ts
+++ b/apps/web/src/lib/auth-token.ts
@@ -131,6 +131,23 @@ export function setBootstrapAuthToken(token: string | null): void {
 	}
 }
 
+/**
+ * Decode a JWT's `exp` claim and report whether it's expired — or within
+ * `skewSeconds` of expiring. Returns false when the token can't be parsed: let
+ * the server be the judge rather than discard a token we simply can't read.
+ */
+function isJwtExpired(token: string, skewSeconds = 30): boolean {
+	try {
+		const payload = token.split('.')[1];
+		if (!payload) return false;
+		const json = JSON.parse(atob(payload.replace(/-/g, '+').replace(/_/g, '/')));
+		if (typeof json.exp !== 'number') return false;
+		return Date.now() / 1000 >= json.exp - skewSeconds;
+	} catch {
+		return false;
+	}
+}
+
 /** Internal: actually fetch the token from Supabase with retries. */
 async function fetchToken(): Promise<string | null> {
 	const supabase = createClient();
@@ -140,10 +157,19 @@ async function fetchToken(): Promise<string | null> {
 			const {
 				data: { session },
 			} = await supabase.auth.getSession();
-			if (session?.access_token) return session.access_token;
 
-			// Session is null — token may have expired. Try an explicit refresh.
-			if (attempt === 0) {
+			// A present, non-expired token is good to use directly.
+			if (session?.access_token && !isJwtExpired(session.access_token)) {
+				return session.access_token;
+			}
+
+			// getSession() returns the STORED session even when its access_token
+			// has already expired — it does not refresh here. Handing that dead
+			// token to a caller produces a 401; on surfaces with no 401-recovery
+			// (e.g. the PTY WebSocket) that becomes an endless 1006 reconnect loop.
+			// So an expired-but-present session must be refreshed explicitly — the
+			// old code only refreshed when the session was entirely null.
+			if (attempt <= 1) {
 				const {
 					data: { session: refreshed },
 				} = await supabase.auth.refreshSession();

--- a/apps/web/src/lib/fresh-sessions.ts
+++ b/apps/web/src/lib/fresh-sessions.ts
@@ -1,0 +1,22 @@
+/**
+ * Tracks sessions that were just created in THIS browser session, so the session
+ * page can show the instant typeable shell (not the resume loader) for them.
+ *
+ * An in-memory Set — not sessionStorage — because creation and the subsequent
+ * navigation happen in the same JS context (SPA pushState / client nav), so this
+ * is immune to serialization, key-encoding, and write-ordering quirks. A hard
+ * reload clears it, which is correct: a reloaded session is a resume, not new.
+ */
+const freshSessions = new Set<string>();
+
+export function markSessionFresh(id: string | null | undefined): void {
+  if (id) freshSessions.add(id);
+}
+
+export function isSessionFresh(id: string | null | undefined): boolean {
+  return !!id && freshSessions.has(id);
+}
+
+export function clearSessionFresh(id: string | null | undefined): void {
+  if (id) freshSessions.delete(id);
+}

--- a/apps/web/src/lib/projects-client.ts
+++ b/apps/web/src/lib/projects-client.ts
@@ -3,6 +3,7 @@ import type { QueryClient } from '@tanstack/react-query';
 import { backendApi } from '@/lib/api-client';
 import { getSupabaseAccessTokenWithRetry } from '@/lib/auth-token';
 import { getEnv } from '@/lib/env-config';
+import { markSessionFresh } from '@/lib/fresh-sessions';
 
 /** Stable ids for experimental features (mirrors apps/api experimental/features). */
 export type ExperimentalFeatureKey = 'apps' | 'agent_tunnel' | 'marketplace';
@@ -1959,12 +1960,22 @@ export async function createProjectSession(
     session_id?: string;
   },
 ) {
-  return unwrap(
+  const session = unwrap(
     await backendApi.post<ProjectSession>(
       `/projects/${projectId}/sessions`,
       input ?? {},
     ),
   );
+  // Mark freshly-created EMPTY sessions so the session page shows the instant
+  // typeable shell instead of the resume loader. THE chokepoint for every empty
+  // project-session create path (sidebar button, ⌘T shortcut, command palette).
+  // `session_id` is exactly the route param those navigations land on.
+  // Skip when an initial_prompt is set: those sessions get a server-side reply,
+  // so they must mount the real chat to stream it (the shell would hold it back).
+  if (!input?.initial_prompt) {
+    markSessionFresh((session as ProjectSession | undefined)?.session_id);
+  }
+  return session;
 }
 
 export async function getProjectSession(


### PR DESCRIPTION
## What

Kills the "Kortix Computer is starting" full-screen loader on new sessions. The moment you start a session — **New session** button, ⌘T/⌘J, sidebar, command palette, the global dashboard composer, **and now the project-home composer + Customize "configure" threads** — you land on a fully-interactive session shell instantly: wallpaper + typeable input, or your already-typed message + an inline boot status. Provisioning runs silently underneath; the real chat crossfades in once it's ready and picks up the first message via a pending-prompt handoff. Only the *first* message can feel slightly longer — everything else is instant.

## How

- **Optimistic create** (`useNewProjectSession`): mint the session UUID client-side, mark it fresh, navigate immediately, and persist via `POST /sessions` in the background (the API honors a client-provided `session_id`; the warm pool binds to it). The instant shell paints before the create even returns.
- **`InstantSessionShell`**: a single stable, non-remounting tree for the whole pre-ready lifecycle. Reads `project_/opencode_pending_prompt` to show the message bubble + a shared `AssistantPendingRow` (Kortix logo + the same waiting indicator/elapsed-seconds as a normal turn, pre-rendered so nothing pops in). Full-bleed wallpaper via a portal so the side panel never re-crops it.
- **Eager connection**: the runtime connection + event stream + OpenCode pin warm up as soon as the sandbox switches, so the first send doesn't pay the connect cost. The heavy chat mounts only once a first message exists (its one-shot pending handoff isn't consumed empty).
- **No auto-opened side panel**: boot status is inline in chat; the panel shows the staged loader only if the user opens it.
- **Alignment (latest commit)**: the project-home composer and Customize "configure" threads used a server-side `initial_prompt` (never marked fresh → old loader). Both now route through the same optimistic path, so *every* entry point behaves identically.

Also bundles a PTY terminal WebSocket 1006 reconnect-loop fix on expired JWT (separate commit).

## Test

- `main` reorg (`components → features`) is already reconciled in this branch; `tsc --noEmit` is clean on `apps/web`.
- Manual: start a session from each entry point (New session, ⌘T, sidebar, palette, dashboard composer, project-home composer, Customize → create agent/skill/command) → instant shell, no full-screen loader; type/handed-off message shows immediately; auto-sends once ready; resumes still show the staged loader.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
