### PR TITLE
fix(warm-pool): preserve runtime auth on claim

### DIFF
--- a/apps/api/src/platform/services/warm-pool.ts
+++ b/apps/api/src/platform/services/warm-pool.ts
@@ -28,7 +28,7 @@
  */
 import { and, eq, gte, inArray, lt, sql } from 'drizzle-orm';
 
-import { projects, projectSessions, sessionSandboxes, warmPoolPresence } from '@kortix/db';
+import { kortixApiKeys, projects, projectSessions, sessionSandboxes, warmPoolPresence } from '@kortix/db';
 import { config, type SandboxProviderName } from '../../config';
 import { db } from '../../shared/db';
 import { getProvider } from '../providers';
@@ -430,10 +430,18 @@ async function bindClaimedSpare(input: {
     return false;
   }
   try {
-    // ATOMIC: insert the session row + delete the spare row in ONE tx. Both rows
-    // share the same external_id; if the spare row lingered (insert ok, delete
-    // failed) a later claim-timeout reap would provider.remove() the box out
-    // from under the now-bound session. The tx makes "bound" ⇒ "spare row gone".
+    // ATOMIC: insert the session row, re-scope the spare's sandbox token to that
+    // session row, then delete the spare row in ONE tx. Both rows share the same
+    // external_id; if the spare row lingered (insert ok, delete failed) a later
+    // claim-timeout reap would provider.remove() the box out from under the
+    // now-bound session. The tx makes "bound" ⇒ "spare row gone".
+    //
+    // The box keeps the same KORTIX_TOKEN bytes it received while parked. Git
+    // proxy auth resolves those bytes via api_keys.sandbox_id, then requires a
+    // live session_sandboxes row for that sandbox id. If we delete the spare row
+    // without moving the api_key scope, post-claim clones/fetches fail with
+    // "sandbox token is not scoped to this project". Re-scope before the delete
+    // so old-token bytes authenticate as the real session id after commit.
     // The delete is GUARDED on poolState='claiming': if reconcileWarmPool reaped
     // the spare row mid-claim (claim outran CLAIM_STALE_MS), the guard deletes 0
     // rows → we throw → the whole bind rolls back → cold fallback, so we never
@@ -457,6 +465,19 @@ async function bindClaimedSpare(input: {
         metadata: { ...input.sessionMetadata, claimed_from_spare: input.spare.spareSandboxId },
         lastUsedAt: new Date(),
       });
+      const movedKeys = await tx
+        .update(kortixApiKeys)
+        .set({ sandboxId: input.sessionId })
+        .where(and(
+          eq(kortixApiKeys.sandboxId, input.spare.spareSandboxId),
+          eq(kortixApiKeys.accountId, input.accountId),
+          eq(kortixApiKeys.type, 'sandbox'),
+          eq(kortixApiKeys.status, 'active'),
+        ))
+        .returning({ id: kortixApiKeys.keyId });
+      if (movedKeys.length === 0) {
+        throw new Error('spare sandbox token missing — rolling back bind');
+      }
       const removed = await tx
         .delete(sessionSandboxes)
         .where(and(eq(sessionSandboxes.sandboxId, input.spare.spareSandboxId), eq(sessionSandboxes.poolState, 'claiming')))

--- a/apps/kortix-sandbox-agent-server/src/main.ts
+++ b/apps/kortix-sandbox-agent-server/src/main.ts
@@ -368,6 +368,22 @@ async function runPoolMode(
         bootMark('claim-repo-materialized')
         if (!bootState.repoMaterializationError) await configureRepoCredentialHelper(cfg2, cfg2.projectTarget).catch(() => {})
       }
+
+      // A warm spare's opencode process is started before claim, when it has no
+      // session-scoped Executor/CLI/LLM env and (for Stage-1) before the project
+      // config dir exists. Restart it after adopting the claimant env + repo so
+      // OPENCODE_CONFIG_CONTENT includes the Executor MCP and project config.
+      const claimOpencodeConfigDir = bootState.repoMaterializationError
+        ? cfg2.defaultOpencodeConfigDir
+        : await resolveOpencodeConfigDir(cfg2)
+      await ensureOpencodeConfigDeps(claimOpencodeConfigDir).catch((err) =>
+        logger.warn('[pool] claim config deps failed', { err: (err as Error).message }),
+      )
+      opencode.reconfigure(cfg2, claimOpencodeConfigDir, projectEnv)
+      await opencode.restart().catch((err) =>
+        logger.warn('[pool] claim opencode restart failed', { err: (err as Error).message }),
+      )
+      bootMark('claim-opencode-restarted')
       await startSessionRuntime(opencode, cfg2, bootState, bootMark)
       logger.info('[pool] claim complete', { claimMs: Date.now() - t0, timeline: bootState.timeline })
     })()

--- a/apps/kortix-sandbox-agent-server/src/opencode.ts
+++ b/apps/kortix-sandbox-agent-server/src/opencode.ts
@@ -287,6 +287,7 @@ export type Opencode = {
   start(): Promise<void>
   stop(signal?: NodeJS.Signals): Promise<void>
   restart(): Promise<void>
+  reconfigure(nextCfg: Config, nextOpencodeConfigDir: string, nextProjectEnv?: ProjectEnvStore): void
   getPid(): number | null
   getInternalUrl(): string
   getBinaryPath(): string | null
@@ -299,6 +300,9 @@ export function createOpencodeSupervisor(
   opencodeConfigDir: string,
   projectEnv?: ProjectEnvStore,
 ): Opencode {
+  let currentCfg = cfg
+  let currentOpencodeConfigDir = opencodeConfigDir
+  let currentProjectEnv = projectEnv
   let child: ChildProcess | null = null
   let binaryPath: string | null = null
   let stopping = false
@@ -338,15 +342,15 @@ export function createOpencodeSupervisor(
         err: (err as Error).message,
       })
     }
-    const baseEnv = projectEnv ? mergeProjectEnv(process.env, projectEnv) : process.env
+    const baseEnv = currentProjectEnv ? mergeProjectEnv(process.env, currentProjectEnv) : process.env
     const env: NodeJS.ProcessEnv = {
       ...baseEnv,
-      ...buildGitIdentityEnv(cfg),
+      ...buildGitIdentityEnv(currentCfg),
       HOME: OPENCODE_HOME,
       XDG_DATA_HOME: OPENCODE_DATA_HOME,
       XDG_CONFIG_HOME: OPENCODE_CONFIG_HOME,
       XDG_CACHE_HOME: OPENCODE_CACHE_HOME,
-      OPENCODE_CONFIG_DIR: opencodeConfigDir,
+      OPENCODE_CONFIG_DIR: currentOpencodeConfigDir,
       // Every non-interactive shell opencode spawns (`bash -c`) sources this,
       // so live project secrets reach the agent's commands without any
       // opencode plugin/config. Interactive shells + terminals get it from the
@@ -375,13 +379,13 @@ export function createOpencodeSupervisor(
     const args = [
       'serve',
       '--port',
-      String(cfg.opencodeInternalPort),
+      String(currentCfg.opencodeInternalPort),
       '--hostname',
       '127.0.0.1',
     ]
 
     const cwd = ensureCwdExists()
-    logger.info('[opencode] spawning', { bin, port: cfg.opencodeInternalPort, cwd })
+    logger.info('[opencode] spawning', { bin, port: currentCfg.opencodeInternalPort, cwd })
     const proc = spawn(bin, args, {
       cwd,
       env,
@@ -415,7 +419,7 @@ export function createOpencodeSupervisor(
   }
 
   async function checkReady(): Promise<boolean> {
-    return probeOpencodeSessionApi(`http://127.0.0.1:${cfg.opencodeInternalPort}`, cfg.projectTarget, 2_000)
+    return probeOpencodeSessionApi(`http://127.0.0.1:${currentCfg.opencodeInternalPort}`, currentCfg.projectTarget, 2_000)
   }
 
   function scheduleReadinessProbe() {
@@ -444,7 +448,7 @@ export function createOpencodeSupervisor(
         return
       }
       binaryPath = bin
-      opencodeCwd = await resolveOpencodeCwd(cfg)
+      opencodeCwd = await resolveOpencodeCwd(currentCfg)
       try {
         spawnChild(bin)
       } catch (err) {
@@ -487,12 +491,23 @@ export function createOpencodeSupervisor(
       await this.start()
     },
 
+    reconfigure(nextCfg: Config, nextOpencodeConfigDir: string, nextProjectEnv?: ProjectEnvStore) {
+      currentCfg = nextCfg
+      currentOpencodeConfigDir = nextOpencodeConfigDir
+      if (nextProjectEnv) currentProjectEnv = nextProjectEnv
+      state = 'starting'
+      logger.info('[opencode] reconfigured', {
+        projectId: nextCfg.projectId,
+        opencodeConfigDir: nextOpencodeConfigDir,
+      })
+    },
+
     getPid() {
       return child?.pid ?? null
     },
 
     getInternalUrl() {
-      return `http://127.0.0.1:${cfg.opencodeInternalPort}`
+      return `http://127.0.0.1:${currentCfg.opencodeInternalPort}`
     },
 
     getBinaryPath() {


### PR DESCRIPTION
## Summary
- Re-scope a claimed warm spare's sandbox API key from the spare id to the real session id before deleting the spare row
- Restart/reconfigure OpenCode after warm-spare claim so claimant env injects Executor MCP/LLM config and project opencode config

## Verification
- `pnpm --filter kortix-api typecheck`
- `pnpm --filter @kortix/sandbox-agent-server typecheck`
- `env DATABASE_URL=postgres://user:pass@localhost:5432/db SUPABASE_URL=http://localhost:54321 SUPABASE_SERVICE_ROLE_KEY=test-service-role API_KEY_SECRET=test-api-key-secret ALLOWED_SANDBOX_PROVIDERS=local_docker DOCKER_HOST=unix:///var/run/docker.sock TUNNEL_SIGNING_SECRET=test-tunnel-secret KORTIX_URL=http://localhost:8008 OPENROUTER_API_KEY=test-openrouter bun test apps/api/src/__tests__/unit-warm-pool.test.ts apps/kortix-sandbox-agent-server/src/__tests__/executor-mcp-config.test.ts`

## Notes
Direct dotenvx package test was blocked locally because the private key env was not exported for encrypted .env values; targeted tests were rerun with dummy unit-test env.
