### PR TITLE
Fix forbidden project access state

### DIFF
--- a/apps/api/src/projects/routes/r6.ts
+++ b/apps/api/src/projects/routes/r6.ts
@@ -1,17 +1,34 @@
 import { buildInviteUrl, isInviteEmailConfigured, sendAccountInviteEmail } from '../../accounts/email';
-import { PROJECT_ACTIONS, assertAuthorized } from '../../iam';
+import { PROJECT_ACTIONS, assertAuthorized, authorize } from '../../iam';
+import { deriveRequestContext } from '../../iam/cache';
 import { auth, errors, json } from '../../openapi';
 import { db } from '../../shared/db';
 import { lookupUserIdByEmail } from '../../shared/users';
 import { foldEffectiveProjectAccess, isAccountManager, parseProjectRole, roleAllows, type AccountRole, type ProjectRole } from '../access';
 import { createRoute, z } from '@hono/zod-openapi';
-import { accountGroupMembers, accountGroups, accountInvitations, accountMembers, accounts, projectGroupGrants, projectMembers, projects } from '@kortix/db';
-import { and, eq, inArray, isNull, sql } from 'drizzle-orm';
+import { accountGroupMembers, accountGroups, accountInvitations, accountMembers, accounts, projectAccessRequests, projectGroupGrants, projectMembers, projects } from '@kortix/db';
+import { and, desc, eq, inArray, isNull, sql } from 'drizzle-orm';
 import { ensureOrgMembership, grantProjectRole, loadProjectForUser, lookupEmailsByUserIds, parseExpiresAtBody } from '../lib/access';
 import { AccessMemberSchema, AnyObject, projectsApp } from '../lib/app';
 import { getAccountMembership } from '../lib/git';
 import { readBody, serializeProject } from '../lib/serializers';
 import { applyExperimentalOverride, isExperimentalFeatureKey } from '../../experimental/features';
+
+function serializeProjectAccessRequest(row: typeof projectAccessRequests.$inferSelect) {
+  return {
+    request_id: row.requestId,
+    account_id: row.accountId,
+    project_id: row.projectId,
+    requester_user_id: row.requesterUserId,
+    requester_email: row.requesterEmail,
+    message: row.message ?? null,
+    status: row.status,
+    reviewed_by: row.reviewedBy ?? null,
+    reviewed_at: row.reviewedAt?.toISOString() ?? null,
+    created_at: row.createdAt.toISOString(),
+    updated_at: row.updatedAt.toISOString(),
+  };
+}
 
 projectsApp.openapi(
   createRoute({
@@ -240,6 +257,263 @@ projectsApp.openapi(
     viewer_user_id: loaded.userId,
     members,
   });
+},
+);
+
+// POST /v1/projects/:projectId/access-requests
+// Lets a signed-in user with a project link ask the project's managers for
+// access without mounting the normal project shell (which would otherwise fan
+// out into many 403s). Mirrors the Figma-style "Request access" affordance.
+
+projectsApp.openapi(
+  createRoute({
+    method: 'post',
+    path: '/{projectId}/access-requests',
+    tags: ['access'],
+    summary: 'POST /:projectId/access-requests',
+    ...auth,
+      request: {
+        params: z.object({ projectId: z.string() }),
+        body: { content: { 'application/json': { schema: AnyObject } } },
+      },
+    responses: {
+        200: json(z.any(), 'Existing access request or access state'),
+        201: json(z.any(), 'Access request created'),
+        ...errors(404),
+    },
+  }),
+  async (c: any) => {
+  const projectId = c.req.param('projectId');
+  const userId = c.get('userId') as string;
+  const requesterEmail = ((c.get('userEmail') as string | undefined) ?? '').trim().toLowerCase();
+  const body = await readBody(c);
+  const messageRaw = typeof body.message === 'string' ? body.message.trim() : '';
+  const message = messageRaw ? messageRaw.slice(0, 2000) : null;
+
+  const [project] = await db
+    .select({
+      accountId: projects.accountId,
+      projectId: projects.projectId,
+      status: projects.status,
+    })
+    .from(projects)
+    .where(eq(projects.projectId, projectId))
+    .limit(1);
+  if (!project || project.status === 'archived') return c.json({ error: 'Not found' }, 404);
+
+  const membership = await getAccountMembership(userId, project.accountId);
+  if (membership) {
+    const actingTokenId =
+      ((c as unknown as { get(k: string): unknown }).get('iamTokenId') as
+        | string
+        | undefined) ?? undefined;
+    const verdict = await authorize(
+      userId,
+      project.accountId,
+      PROJECT_ACTIONS.PROJECT_READ,
+      { type: 'project', id: projectId },
+      actingTokenId,
+      deriveRequestContext(c),
+    );
+    if (verdict.allowed) {
+      return c.json({ status: 'already_has_access', project_id: projectId });
+    }
+  }
+
+  const [existing] = await db
+    .select()
+    .from(projectAccessRequests)
+    .where(and(
+      eq(projectAccessRequests.projectId, projectId),
+      eq(projectAccessRequests.requesterUserId, userId),
+      eq(projectAccessRequests.status, 'pending'),
+    ))
+    .limit(1);
+
+  if (existing) {
+    return c.json({ status: 'pending', request: serializeProjectAccessRequest(existing) });
+  }
+
+  const [created] = await db
+    .insert(projectAccessRequests)
+    .values({
+      accountId: project.accountId,
+      projectId,
+      requesterUserId: userId,
+      requesterEmail: requesterEmail || userId,
+      message,
+    })
+    .returning();
+
+  return c.json({ status: 'created', request: serializeProjectAccessRequest(created) }, 201);
+},
+);
+
+// GET /v1/projects/:projectId/access-requests
+// Managers review pending "request access" asks from the Members screen.
+
+projectsApp.openapi(
+  createRoute({
+    method: 'get',
+    path: '/{projectId}/access-requests',
+    tags: ['access'],
+    summary: 'GET /:projectId/access-requests',
+    ...auth,
+      request: {
+        params: z.object({ projectId: z.string() }),
+      },
+    responses: {
+        200: json(z.any(), 'Pending access requests'),
+        ...errors(404),
+    },
+  }),
+  async (c: any) => {
+  const projectId = c.req.param('projectId');
+  const loaded = await loadProjectForUser(c, projectId, 'manage');
+  if (!loaded) return c.json({ error: 'Not found' }, 404);
+
+  const rows = await db
+    .select()
+    .from(projectAccessRequests)
+    .where(and(
+      eq(projectAccessRequests.projectId, projectId),
+      eq(projectAccessRequests.status, 'pending'),
+    ))
+    .orderBy(desc(projectAccessRequests.createdAt));
+
+  return c.json({ requests: rows.map(serializeProjectAccessRequest) });
+},
+);
+
+// POST /v1/projects/:projectId/access-requests/:requestId/approve
+
+projectsApp.openapi(
+  createRoute({
+    method: 'post',
+    path: '/{projectId}/access-requests/{requestId}/approve',
+    tags: ['access'],
+    summary: 'POST /:projectId/access-requests/:requestId/approve',
+    ...auth,
+      request: {
+        params: z.object({ projectId: z.string(), requestId: z.string() }),
+        body: { content: { 'application/json': { schema: AnyObject } } },
+      },
+    responses: {
+      200: json(z.any(), 'Access request approved'),
+        ...errors(400, 404, 409),
+    },
+  }),
+  async (c: any) => {
+  const projectId = c.req.param('projectId');
+  const requestId = c.req.param('requestId');
+  const loaded = await loadProjectForUser(c, projectId, 'manage');
+  if (!loaded) return c.json({ error: 'Not found' }, 404);
+
+  const body = await readBody(c);
+  const role = body.role === undefined ? 'viewer' : parseProjectRole(body.role);
+  if (!role) return c.json({ error: 'role must be one of manager|editor|viewer' }, 400);
+
+  const [request] = await db
+    .select()
+    .from(projectAccessRequests)
+    .where(and(
+      eq(projectAccessRequests.requestId, requestId),
+      eq(projectAccessRequests.projectId, projectId),
+    ))
+    .limit(1);
+  if (!request) return c.json({ error: 'Not found' }, 404);
+  if (request.status !== 'pending') {
+    return c.json({ error: 'Access request has already been reviewed' }, 409);
+  }
+
+  const targetAccountRole = await ensureOrgMembership(
+    loaded.row.accountId,
+    request.requesterUserId,
+  );
+
+  if (!isAccountManager(targetAccountRole)) {
+    await grantProjectRole({
+      accountId: loaded.row.accountId,
+      projectId,
+      userId: request.requesterUserId,
+      role,
+      grantedBy: loaded.userId,
+    });
+  }
+
+  const [updated] = await db
+    .update(projectAccessRequests)
+    .set({
+      status: 'approved',
+      reviewedBy: loaded.userId,
+      reviewedAt: new Date(),
+      updatedAt: new Date(),
+    })
+    .where(eq(projectAccessRequests.requestId, requestId))
+    .returning();
+
+  return c.json({
+    request: serializeProjectAccessRequest(updated),
+    member: {
+      user_id: request.requesterUserId,
+      email: request.requesterEmail,
+      account_role: targetAccountRole,
+      project_role: isAccountManager(targetAccountRole) ? null : role,
+      effective_project_role: isAccountManager(targetAccountRole) ? 'manager' : role,
+      has_implicit_access: isAccountManager(targetAccountRole),
+    },
+  });
+},
+);
+
+// POST /v1/projects/:projectId/access-requests/:requestId/reject
+
+projectsApp.openapi(
+  createRoute({
+    method: 'post',
+    path: '/{projectId}/access-requests/{requestId}/reject',
+    tags: ['access'],
+    summary: 'POST /:projectId/access-requests/:requestId/reject',
+    ...auth,
+      request: {
+        params: z.object({ projectId: z.string(), requestId: z.string() }),
+      },
+    responses: {
+      200: json(z.any(), 'Access request rejected'),
+        ...errors(404, 409),
+    },
+  }),
+  async (c: any) => {
+  const projectId = c.req.param('projectId');
+  const requestId = c.req.param('requestId');
+  const loaded = await loadProjectForUser(c, projectId, 'manage');
+  if (!loaded) return c.json({ error: 'Not found' }, 404);
+
+  const [request] = await db
+    .select()
+    .from(projectAccessRequests)
+    .where(and(
+      eq(projectAccessRequests.requestId, requestId),
+      eq(projectAccessRequests.projectId, projectId),
+    ))
+    .limit(1);
+  if (!request) return c.json({ error: 'Not found' }, 404);
+  if (request.status !== 'pending') {
+    return c.json({ error: 'Access request has already been reviewed' }, 409);
+  }
+
+  const [updated] = await db
+    .update(projectAccessRequests)
+    .set({
+      status: 'rejected',
+      reviewedBy: loaded.userId,
+      reviewedAt: new Date(),
+      updatedAt: new Date(),
+    })
+    .where(eq(projectAccessRequests.requestId, requestId))
+    .returning();
+
+  return c.json({ request: serializeProjectAccessRequest(updated) });
 },
 );
 

--- a/apps/web/src/app/(app)/projects/[id]/layout.tsx
+++ b/apps/web/src/app/(app)/projects/[id]/layout.tsx
@@ -2,6 +2,7 @@ import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 
 import { SessionStreamKeeper } from '@/components/projects/session-stream-keeper';
+import { ProjectAccessBoundary } from '@/components/projects/project-access-boundary';
 import { createClient } from '@/lib/supabase/server';
 
 interface ProjectLayoutProps {
@@ -21,9 +22,9 @@ export default async function ProjectLayout({ children, params }: ProjectLayoutP
   const { id: projectId } = await params;
 
   return (
-    <>
+    <ProjectAccessBoundary projectId={projectId}>
       <SessionStreamKeeper projectId={projectId} />
       {children}
-    </>
+    </ProjectAccessBoundary>
   );
 }

--- a/apps/web/src/components/projects/customize/sections/members-view.tsx
+++ b/apps/web/src/components/projects/customize/sections/members-view.tsx
@@ -4,7 +4,7 @@ import { useTranslations } from 'next-intl';
 
 import { FormEvent, useMemo, useRef, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { Clock, Loader2, Mail, RefreshCw, Shield, UserPlus, Users, X } from 'lucide-react';
+import { Check, Clock, Loader2, Mail, MessageSquare, RefreshCw, Shield, UserPlus, Users, X } from 'lucide-react';
 import { toast } from '@/lib/toast';
 import { CustomizeSectionHeader } from '@/components/projects/customize/customize-section-header';
 
@@ -33,10 +33,13 @@ import {
 } from '@/components/ui/dropdown-menu';
 import {
   getProject,
+  approveProjectAccessRequest,
   inviteProjectMember,
   isInviteSent,
+  listProjectAccessRequests,
   listPendingProjectInvites,
   listProjectAccess,
+  rejectProjectAccessRequest,
   resendPendingProjectInvite,
   revokePendingProjectInvite,
   revokeProjectAccess,
@@ -130,6 +133,8 @@ function ProjectMembersBody({ projectId }: { projectId: string }) {
         </header>
 
         {canManage && <InviteMemberCard projectId={projectId} />}
+
+        {canManage && <PendingAccessRequestsCard projectId={projectId} />}
 
         {canManage && <PendingInvitesCard projectId={projectId} />}
 
@@ -896,6 +901,121 @@ function AccountRoleBadge({ role }: { role: ProjectAccessMember['account_role'] 
   );
 }
 
+function PendingAccessRequestsCard({ projectId }: { projectId: string }) {
+  const queryClient = useQueryClient();
+  const queryKey = ['project-access-requests', projectId];
+  const [busyIds, setBusyIds] = useState<Set<string>>(() => new Set());
+  const markBusy = (id: string) => setBusyIds((prev) => new Set(prev).add(id));
+  const clearBusy = (id: string) =>
+    setBusyIds((prev) => {
+      const next = new Set(prev);
+      next.delete(id);
+      return next;
+    });
+
+  const requestsQuery = useQuery({
+    queryKey,
+    queryFn: () => listProjectAccessRequests(projectId),
+    staleTime: 10_000,
+  });
+
+  const approveMutation = useMutation({
+    mutationFn: (requestId: string) =>
+      approveProjectAccessRequest(projectId, requestId, 'viewer'),
+    onMutate: (requestId) => markBusy(requestId),
+    onSettled: (_data, _error, requestId) => clearBusy(requestId),
+    onSuccess: (result) => {
+      toast.success(`${result.member.email ?? 'Requester'} can now view this project`);
+      queryClient.invalidateQueries({ queryKey });
+      queryClient.invalidateQueries({ queryKey: ['project-access', projectId] });
+    },
+    onError: (err: Error) => toast.error(err.message || 'Failed to approve request'),
+  });
+
+  const rejectMutation = useMutation({
+    mutationFn: (requestId: string) => rejectProjectAccessRequest(projectId, requestId),
+    onMutate: (requestId) => markBusy(requestId),
+    onSettled: (_data, _error, requestId) => clearBusy(requestId),
+    onSuccess: () => {
+      toast.success('Access request declined');
+      queryClient.invalidateQueries({ queryKey });
+    },
+    onError: (err: Error) => toast.error(err.message || 'Failed to decline request'),
+  });
+
+  const requests = requestsQuery.data?.requests ?? [];
+
+  if (!requestsQuery.isLoading && requests.length === 0) return null;
+
+  return (
+    <SectionCard
+      flush
+      title="Access requests"
+      description="People who opened a private project link and asked to join. Approving grants Viewer access; you can raise their role after."
+      count={requests.length}
+    >
+      {requestsQuery.isLoading && (
+        <div className="px-6 py-5">
+          <Skeleton className="h-8 w-full" />
+        </div>
+      )}
+
+      {!requestsQuery.isLoading && requests.length > 0 && (
+        <List>
+          {requests.map((request) => {
+            const busy = busyIds.has(request.request_id);
+            return (
+              <ListRow
+                key={request.request_id}
+                leading={
+                  <span className="flex h-8 w-8 items-center justify-center rounded-full bg-blue-500/10 text-blue-700 dark:text-blue-400">
+                    <MessageSquare className="h-4 w-4" />
+                  </span>
+                }
+                title={request.requester_email}
+                subtitle={
+                  <InlineMeta>
+                    <span>Requested {formatDate(request.created_at)}</span>
+                    {request.message ? <span>“{request.message}”</span> : null}
+                  </InlineMeta>
+                }
+                trailing={
+                  busy ? (
+                    <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+                  ) : (
+                    <div className="flex items-center gap-1">
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="ghost"
+                        onClick={() => approveMutation.mutate(request.request_id)}
+                        className="gap-1.5"
+                      >
+                        <Check className="h-3.5 w-3.5" />
+                        Approve
+                      </Button>
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="ghost"
+                        onClick={() => rejectMutation.mutate(request.request_id)}
+                        className="gap-1.5"
+                      >
+                        <X className="h-3.5 w-3.5" />
+                        Decline
+                      </Button>
+                    </div>
+                  )
+                }
+              />
+            );
+          })}
+        </List>
+      )}
+    </SectionCard>
+  );
+}
+
 // ─── Pending invitations (non-Kortix users who haven't signed up yet) ─────
 //
 // Bridges the gap between "I invited foo@example.com" and "foo joined the
@@ -1136,7 +1256,7 @@ function ProjectGroupGrantsCard({
       return t !== 0 ? t : a.group_id.localeCompare(b.group_id);
     });
   }, [grantsQuery.data]);
-  const groups: AccountGroup[] = groupsQuery.data ?? [];
+  const groups: AccountGroup[] = useMemo(() => groupsQuery.data ?? [], [groupsQuery.data]);
   const attachedIds = useMemo(() => new Set(grants.map((g) => g.group_id)), [grants]);
   const available = useMemo(
     () => groups.filter((g) => !attachedIds.has(g.group_id)),

--- a/apps/web/src/components/projects/project-access-boundary.tsx
+++ b/apps/web/src/components/projects/project-access-boundary.tsx
@@ -1,0 +1,232 @@
+'use client';
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  AlertCircle,
+  ArrowLeft,
+  CheckCircle2,
+  Loader2,
+  LockKeyhole,
+  RefreshCw,
+  Send,
+} from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import { useState, type ReactNode } from 'react';
+
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Textarea } from '@/components/ui/textarea';
+import { useAuth } from '@/features/providers/auth-provider';
+import { getProjectDetail, requestProjectAccess } from '@/lib/projects-client';
+
+interface ProjectAccessBoundaryProps {
+  projectId: string;
+  children: ReactNode;
+}
+
+function errorStatus(error: unknown): number | undefined {
+  return (error as { status?: number; response?: { status?: number } } | null)?.status ??
+    (error as { response?: { status?: number } } | null)?.response?.status;
+}
+
+export function ProjectAccessBoundary({ projectId, children }: ProjectAccessBoundaryProps) {
+  const query = useQuery({
+    queryKey: ['project-detail', projectId],
+    queryFn: () => getProjectDetail(projectId, { showErrors: false }),
+    enabled: !!projectId,
+    retry: false,
+  });
+
+  if (query.isLoading) {
+    return <ProjectAccessLoading />;
+  }
+
+  if (query.isError) {
+    const status = errorStatus(query.error);
+    if (status === 403) {
+      return <ForbiddenProjectState projectId={projectId} />;
+    }
+
+    if (status === 404) {
+      return (
+        <ProjectAccessStateFrame
+          icon={<AlertCircle className="h-5 w-5" />}
+          title="Project not found"
+          description="This project may have been deleted, archived, or the link is no longer valid."
+        />
+      );
+    }
+
+    return (
+      <ProjectAccessStateFrame
+        icon={<AlertCircle className="h-5 w-5" />}
+        title="Couldn't load this project"
+        description="Something went wrong before the project workspace opened. Try again, or go back to your projects."
+        footer={
+          <Button type="button" variant="outline" onClick={() => query.refetch()}>
+            <RefreshCw className="h-4 w-4" />
+            Retry
+          </Button>
+        }
+      />
+    );
+  }
+
+  return <>{children}</>;
+}
+
+function ProjectAccessLoading() {
+  return (
+    <div className="bg-background flex min-h-screen items-center justify-center">
+      <div className="text-muted-foreground flex items-center gap-2 text-sm">
+        <Loader2 className="h-4 w-4 animate-spin" />
+        Opening project…
+      </div>
+    </div>
+  );
+}
+
+function ForbiddenProjectState({ projectId }: { projectId: string }) {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const { user } = useAuth();
+  const [message, setMessage] = useState('');
+  const [sent, setSent] = useState(false);
+  const [inlineError, setInlineError] = useState<string | null>(null);
+
+  const requestMutation = useMutation({
+    mutationFn: () => requestProjectAccess(projectId, message),
+    onMutate: () => setInlineError(null),
+    onSuccess: (result) => {
+      if (result.status === 'already_has_access') {
+        void queryClient.invalidateQueries({ queryKey: ['project-detail', projectId] });
+        return;
+      }
+      setSent(true);
+    },
+    onError: (error: Error) => {
+      setInlineError(error.message || 'Could not send access request.');
+    },
+  });
+
+  return (
+    <ProjectAccessStateFrame
+      icon={<LockKeyhole className="h-5 w-5" />}
+      title="You need access to open this project"
+      description="This link points to a private Kortix project. Ask a project manager to approve your access request, then refresh this page."
+      content={
+        <div className="space-y-4">
+          <div className="border-border/70 bg-muted/35 rounded-xl border px-3 py-2 text-xs text-muted-foreground">
+            Signed in as{' '}
+            <span className="font-medium text-foreground">
+              {user?.email ?? user?.id ?? 'this account'}
+            </span>
+          </div>
+
+          {sent ? (
+            <div className="border-emerald-500/25 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300 flex items-start gap-2 rounded-xl border px-3 py-3 text-sm">
+              <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0" />
+              <div>
+                <p className="font-medium">Request sent</p>
+                <p className="text-xs opacity-80">
+                  Project managers will see it in the Members screen and can approve you as a viewer.
+                </p>
+              </div>
+            </div>
+          ) : (
+            <div className="space-y-2">
+              <label className="text-xs font-medium text-foreground" htmlFor="project-access-message">
+                Message (optional)
+              </label>
+              <Textarea
+                id="project-access-message"
+                value={message}
+                onChange={(event) => setMessage(event.target.value)}
+                minHeight={92}
+                maxHeight={160}
+                placeholder="Tell the project manager why you need access…"
+                disabled={requestMutation.isPending}
+              />
+              {inlineError ? <p className="text-xs text-destructive">{inlineError}</p> : null}
+            </div>
+          )}
+        </div>
+      }
+      footer={
+        <div className="flex w-full flex-col-reverse gap-2 sm:flex-row sm:justify-between">
+          <Button type="button" variant="ghost" onClick={() => router.push('/projects')}>
+            <ArrowLeft className="h-4 w-4" />
+            Back to projects
+          </Button>
+          {sent ? (
+            <Button type="button" variant="outline" onClick={() => window.location.reload()}>
+              <RefreshCw className="h-4 w-4" />
+              Check again
+            </Button>
+          ) : (
+            <Button
+              type="button"
+              onClick={() => requestMutation.mutate()}
+              disabled={requestMutation.isPending}
+            >
+              {requestMutation.isPending ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Send className="h-4 w-4" />
+              )}
+              Request access
+            </Button>
+          )}
+        </div>
+      }
+    />
+  );
+}
+
+function ProjectAccessStateFrame({
+  icon,
+  title,
+  description,
+  content,
+  footer,
+}: {
+  icon: ReactNode;
+  title: string;
+  description: string;
+  content?: ReactNode;
+  footer?: ReactNode;
+}) {
+  const router = useRouter();
+  return (
+    <div className="bg-background relative flex min-h-screen items-center justify-center overflow-hidden px-4 py-10">
+      <div className="bg-kortix-blue/10 absolute -top-24 left-1/2 h-64 w-64 -translate-x-1/2 rounded-full blur-3xl" />
+      <Card variant="glass" className="relative w-full max-w-lg border-border/70 shadow-xl">
+        <CardHeader className="items-center text-center">
+          <div className="bg-muted text-foreground mb-2 flex h-11 w-11 items-center justify-center rounded-2xl border">
+            {icon}
+          </div>
+          <CardTitle className="text-lg">{title}</CardTitle>
+          <CardDescription className="max-w-sm text-sm leading-relaxed">
+            {description}
+          </CardDescription>
+        </CardHeader>
+        {content ? <CardContent>{content}</CardContent> : null}
+        <CardFooter className="justify-center">
+          {footer ?? (
+            <Button type="button" variant="outline" onClick={() => router.push('/projects')}>
+              <ArrowLeft className="h-4 w-4" />
+              Back to projects
+            </Button>
+          )}
+        </CardFooter>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/src/hooks/platform/use-project-presence.ts
+++ b/apps/web/src/hooks/platform/use-project-presence.ts
@@ -29,11 +29,11 @@ export function useProjectPresence(projectId: string | null | undefined): void {
       // spare is reaped after the staleness window. A quick tab-switch (back
       // within that window) never loses the spare; a long-hidden tab does.
       if (typeof document !== 'undefined' && document.visibilityState === 'hidden') return;
-      void backendApi.post(base).catch(() => {});
+      void backendApi.post(base, undefined, { showErrors: false }).catch(() => {});
     };
     const leave = () => {
       // keepalive lets the request survive the page unload.
-      void backendApi.post(`${base}/leave`, undefined, { keepalive: true }).catch(() => {});
+      void backendApi.post(`${base}/leave`, undefined, { keepalive: true, showErrors: false }).catch(() => {});
     };
 
     ping();

--- a/apps/web/src/lib/projects-client.ts
+++ b/apps/web/src/lib/projects-client.ts
@@ -1,6 +1,6 @@
 import type { QueryClient } from '@tanstack/react-query';
 
-import { backendApi } from '@/lib/api-client';
+import { backendApi, type ApiClientOptions } from '@/lib/api-client';
 import { getSupabaseAccessTokenWithRetry } from '@/lib/auth-token';
 import { getEnv } from '@/lib/env-config';
 import { markSessionFresh } from '@/lib/fresh-sessions';
@@ -131,6 +131,25 @@ export interface ProjectAccessResponse {
   viewer_user_id: string;
   members: ProjectAccessMember[];
 }
+
+export interface ProjectAccessRequest {
+  request_id: string;
+  account_id: string;
+  project_id: string;
+  requester_user_id: string;
+  requester_email: string;
+  message: string | null;
+  status: 'pending' | 'approved' | 'rejected';
+  reviewed_by: string | null;
+  reviewed_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export type RequestProjectAccessResult =
+  | { status: 'created'; request: ProjectAccessRequest }
+  | { status: 'pending'; request: ProjectAccessRequest }
+  | { status: 'already_has_access'; project_id: string };
 
 export type InviteMemberResult =
   | {
@@ -501,8 +520,8 @@ export async function leaveAccount(accountId: string) {
   );
 }
 
-export async function getProject(projectId: string) {
-  return unwrap(await backendApi.get<KortixProject>(`/projects/${projectId}`));
+export async function getProject(projectId: string, options?: ApiClientOptions) {
+  return unwrap(await backendApi.get<KortixProject>(`/projects/${projectId}`, options));
 }
 
 export interface RepoCollaboratorInvite {
@@ -536,9 +555,49 @@ export function isManagedGithubProject(project: { metadata?: Record<string, unkn
   return git?.provider === 'github' && git?.managed === true;
 }
 
-export async function getProjectDetail(projectId: string) {
+export async function getProjectDetail(projectId: string, options?: ApiClientOptions) {
   return unwrap(
-    await backendApi.get<ProjectDetail>(`/projects/${projectId}/detail`),
+    await backendApi.get<ProjectDetail>(`/projects/${projectId}/detail`, options),
+  );
+}
+
+export async function requestProjectAccess(projectId: string, message?: string) {
+  return unwrap(
+    await backendApi.post<RequestProjectAccessResult>(
+      `/projects/${projectId}/access-requests`,
+      { message: message?.trim() || undefined },
+      { showErrors: false },
+    ),
+  );
+}
+
+export async function listProjectAccessRequests(projectId: string) {
+  return unwrap(
+    await backendApi.get<{ requests: ProjectAccessRequest[] }>(
+      `/projects/${projectId}/access-requests`,
+    ),
+  );
+}
+
+export async function approveProjectAccessRequest(
+  projectId: string,
+  requestId: string,
+  role: ProjectRole = 'viewer',
+) {
+  return unwrap(
+    await backendApi.post<{
+      request: ProjectAccessRequest;
+      member: ProjectAccessMember;
+    }>(`/projects/${projectId}/access-requests/${requestId}/approve`, { role }),
+  );
+}
+
+export async function rejectProjectAccessRequest(projectId: string, requestId: string) {
+  return unwrap(
+    await backendApi.post<{ request: ProjectAccessRequest }>(
+      `/projects/${projectId}/access-requests/${requestId}/reject`,
+      {},
+    ),
   );
 }
 

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -14,6 +14,7 @@ export {
 	  projectSessionStatusEnum,
 	  sessionLifecycleCommandStatusEnum,
 	  projectRoleEnum,
+  projectAccessRequestStatusEnum,
   apiKeyStatusEnum,
   apiKeyTypeEnum,
   // Kortix tables — accounts
@@ -33,6 +34,7 @@ export {
   projectGitConnections,
   projectGitCredentials,
   projectMembers,
+  projectAccessRequests,
   projectSecrets,
   projectSecretGrants,
   secretShareScopeEnum,

--- a/packages/db/src/schema/kortix.ts
+++ b/packages/db/src/schema/kortix.ts
@@ -82,6 +82,12 @@ export const projectRoleEnum = kortixSchema.enum('project_role', [
   'viewer',
 ]);
 
+export const projectAccessRequestStatusEnum = kortixSchema.enum('project_access_request_status', [
+  'pending',
+  'approved',
+  'rejected',
+]);
+
 export const apiKeyStatusEnum = kortixSchema.enum('api_key_status', [
   'active',
   'revoked',
@@ -377,6 +383,36 @@ export const projectMembers = kortixSchema.table(
     index('idx_project_members_account_user').on(table.accountId, table.userId),
     index('idx_project_members_project').on(table.projectId),
     uniqueIndex('idx_project_members_project_user').on(table.projectId, table.userId),
+  ],
+);
+
+export const projectAccessRequests = kortixSchema.table(
+  'project_access_requests',
+  {
+    requestId: uuid('request_id').defaultRandom().primaryKey(),
+    accountId: uuid('account_id')
+      .notNull()
+      .references(() => accounts.accountId, { onDelete: 'cascade' }),
+    projectId: uuid('project_id')
+      .notNull()
+      .references(() => projects.projectId, { onDelete: 'cascade' }),
+    requesterUserId: uuid('requester_user_id').notNull(),
+    requesterEmail: varchar('requester_email', { length: 255 }).notNull(),
+    message: text('message'),
+    status: projectAccessRequestStatusEnum('status').default('pending').notNull(),
+    reviewedBy: uuid('reviewed_by'),
+    reviewedAt: timestamp('reviewed_at', { withTimezone: true }),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => [
+    index('idx_project_access_requests_project').on(table.projectId),
+    index('idx_project_access_requests_account').on(table.accountId),
+    index('idx_project_access_requests_requester').on(table.requesterUserId),
+    index('idx_project_access_requests_status').on(table.status),
+    uniqueIndex('idx_project_access_requests_pending_unique')
+      .on(table.projectId, table.requesterUserId)
+      .where(sql`${table.status} = 'pending'`),
   ],
 );
 

--- a/supabase/migrations/00000000000092_atomic_use_credits_ledger_type.sql
+++ b/supabase/migrations/00000000000092_atomic_use_credits_ledger_type.sql
@@ -27,57 +27,59 @@
 -- metadata, so downstream usage reports that filter on type='usage' are unchanged.
 -- Idempotent + re-runnable (this file is re-applied on every dev boot).
 
-DROP FUNCTION IF EXISTS public.atomic_use_credits(uuid, numeric, text, text, text, text);
-
-CREATE OR REPLACE FUNCTION public.atomic_use_credits(
-    p_account_id uuid,
-    p_amount numeric,
-    p_description text,
-    p_ledger_type text
-)
-RETURNS jsonb
-LANGUAGE plpgsql
-SECURITY DEFINER
-SET search_path TO ''
-AS $function$
-    DECLARE
-      v_daily NUMERIC(10,2); v_exp NUMERIC(10,2); v_nonexp NUMERIC(10,2); v_total NUMERIC(10,2);
-      v_fd NUMERIC(10,2):=0; v_fe NUMERIC(10,2):=0; v_fn NUMERIC(10,2):=0;
-      v_rem NUMERIC(10,2); v_nd NUMERIC(10,2); v_ne NUMERIC(10,2); v_nn NUMERIC(10,2); v_nt NUMERIC(10,2);
-      v_tid UUID;
-    BEGIN
-      SELECT COALESCE(daily_credits_balance,0),COALESCE(expiring_credits,0),
-             COALESCE(non_expiring_credits,0),COALESCE(balance,0)
-      INTO v_daily,v_exp,v_nonexp,v_total
-      FROM kortix.credit_accounts WHERE account_id=p_account_id FOR UPDATE;
-      IF NOT FOUND THEN RETURN jsonb_build_object('success',false,'error','No credit account found','required',p_amount,'available',0); END IF;
-      v_rem:=p_amount;
-      IF v_rem>0 AND v_daily>0 THEN IF v_daily>=v_rem THEN v_fd:=v_rem;v_rem:=0; ELSE v_fd:=v_daily;v_rem:=v_rem-v_daily; END IF; END IF;
-      IF v_rem>0 AND v_exp>0 THEN IF v_exp>=v_rem THEN v_fe:=v_rem;v_rem:=0; ELSE v_fe:=v_exp;v_rem:=v_rem-v_exp; END IF; END IF;
-      IF v_rem>0 THEN v_fn:=v_rem;v_rem:=0; END IF;
-      v_nd:=v_daily-v_fd; v_ne:=v_exp-v_fe; v_nn:=v_nonexp-v_fn; v_nt:=v_nd+v_ne+v_nn;
-      UPDATE kortix.credit_accounts SET daily_credits_balance=v_nd,expiring_credits=v_ne,
-        non_expiring_credits=v_nn,balance=v_nt,updated_at=NOW() WHERE account_id=p_account_id;
-      INSERT INTO kortix.credit_ledger(account_id,amount,balance_after,type,description,metadata)
-      VALUES(p_account_id,-p_amount,v_nt,'usage',p_description,
-        jsonb_build_object('from_daily',v_fd,'from_monthly',v_fe,'from_extra',v_fn,'ledger_type',p_ledger_type))
-      RETURNING id INTO v_tid;
-      RETURN jsonb_build_object('success',true,'amount_deducted',p_amount,'new_total',v_nt,
-        'new_daily',v_nd,'new_expiring',v_ne,'new_non_expiring',v_nn,
-        'from_daily',v_fd,'from_monthly',v_fe,'from_extra',v_fn,
-        'from_expiring',v_fe,'from_non_expiring',v_fn,'transaction_id',v_tid);
-    END;
-$function$;
-
--- Grant EXECUTE to the backend service role only (skip cleanly on a bare local
--- Postgres that has no Supabase roles, so the function still gets created there).
 DO $$
 BEGIN
+  EXECUTE 'DROP FUNCTION IF EXISTS public.atomic_use_credits(uuid, numeric, text, text, text, text)';
+
+  EXECUTE $sql$
+    CREATE OR REPLACE FUNCTION public.atomic_use_credits(
+        p_account_id uuid,
+        p_amount numeric,
+        p_description text,
+        p_ledger_type text
+    )
+    RETURNS jsonb
+    LANGUAGE plpgsql
+    SECURITY DEFINER
+    SET search_path TO ''
+    AS $function$
+        DECLARE
+          v_daily NUMERIC(10,2); v_exp NUMERIC(10,2); v_nonexp NUMERIC(10,2); v_total NUMERIC(10,2);
+          v_fd NUMERIC(10,2):=0; v_fe NUMERIC(10,2):=0; v_fn NUMERIC(10,2):=0;
+          v_rem NUMERIC(10,2); v_nd NUMERIC(10,2); v_ne NUMERIC(10,2); v_nn NUMERIC(10,2); v_nt NUMERIC(10,2);
+          v_tid UUID;
+        BEGIN
+          SELECT COALESCE(daily_credits_balance,0),COALESCE(expiring_credits,0),
+                 COALESCE(non_expiring_credits,0),COALESCE(balance,0)
+          INTO v_daily,v_exp,v_nonexp,v_total
+          FROM kortix.credit_accounts WHERE account_id=p_account_id FOR UPDATE;
+          IF NOT FOUND THEN RETURN jsonb_build_object('success',false,'error','No credit account found','required',p_amount,'available',0); END IF;
+          v_rem:=p_amount;
+          IF v_rem>0 AND v_daily>0 THEN IF v_daily>=v_rem THEN v_fd:=v_rem;v_rem:=0; ELSE v_fd:=v_daily;v_rem:=v_rem-v_daily; END IF; END IF;
+          IF v_rem>0 AND v_exp>0 THEN IF v_exp>=v_rem THEN v_fe:=v_rem;v_rem:=0; ELSE v_fe:=v_exp;v_rem:=v_rem-v_exp; END IF; END IF;
+          IF v_rem>0 THEN v_fn:=v_rem;v_rem:=0; END IF;
+          v_nd:=v_daily-v_fd; v_ne:=v_exp-v_fe; v_nn:=v_nonexp-v_fn; v_nt:=v_nd+v_ne+v_nn;
+          UPDATE kortix.credit_accounts SET daily_credits_balance=v_nd,expiring_credits=v_ne,
+            non_expiring_credits=v_nn,balance=v_nt,updated_at=NOW() WHERE account_id=p_account_id;
+          INSERT INTO kortix.credit_ledger(account_id,amount,balance_after,type,description,metadata)
+          VALUES(p_account_id,-p_amount,v_nt,'usage',p_description,
+            jsonb_build_object('from_daily',v_fd,'from_monthly',v_fe,'from_extra',v_fn,'ledger_type',p_ledger_type))
+          RETURNING id INTO v_tid;
+          RETURN jsonb_build_object('success',true,'amount_deducted',p_amount,'new_total',v_nt,
+            'new_daily',v_nd,'new_expiring',v_ne,'new_non_expiring',v_nn,
+            'from_daily',v_fd,'from_monthly',v_fe,'from_extra',v_fn,
+            'from_expiring',v_fe,'from_non_expiring',v_fn,'transaction_id',v_tid);
+        END;
+    $function$;
+  $sql$;
+
+  -- Grant EXECUTE to the backend service role only (skip cleanly on a bare local
+  -- Postgres that has no Supabase roles, so the function still gets created there).
   IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'service_role') THEN
     EXECUTE 'REVOKE ALL ON FUNCTION public.atomic_use_credits(uuid,numeric,text,text) FROM PUBLIC';
     EXECUTE 'GRANT EXECUTE ON FUNCTION public.atomic_use_credits(uuid,numeric,text,text) TO service_role';
   END IF;
-END $$;
 
--- Tell PostgREST to refresh its schema cache so the new signature resolves.
-NOTIFY pgrst, 'reload schema';
+  -- Tell PostgREST to refresh its schema cache so the new signature resolves.
+  PERFORM pg_notify('pgrst', 'reload schema');
+END $$;

--- a/supabase/migrations/00000000000121_project_access_requests.sql
+++ b/supabase/migrations/00000000000121_project_access_requests.sql
@@ -1,0 +1,38 @@
+DO $$
+BEGIN
+  BEGIN
+    CREATE TYPE "kortix"."project_access_request_status" AS ENUM ('pending', 'approved', 'rejected');
+  EXCEPTION
+    WHEN duplicate_object THEN NULL;
+  END;
+
+  CREATE TABLE IF NOT EXISTS "kortix"."project_access_requests" (
+    "request_id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+    "account_id" uuid NOT NULL REFERENCES "kortix"."accounts"("account_id") ON DELETE cascade,
+    "project_id" uuid NOT NULL REFERENCES "kortix"."projects"("project_id") ON DELETE cascade,
+    "requester_user_id" uuid NOT NULL,
+    "requester_email" varchar(255) NOT NULL,
+    "message" text,
+    "status" "kortix"."project_access_request_status" NOT NULL DEFAULT 'pending',
+    "reviewed_by" uuid,
+    "reviewed_at" timestamptz,
+    "created_at" timestamptz NOT NULL DEFAULT now(),
+    "updated_at" timestamptz NOT NULL DEFAULT now()
+  );
+
+  CREATE INDEX IF NOT EXISTS "idx_project_access_requests_project"
+    ON "kortix"."project_access_requests" USING btree ("project_id");
+
+  CREATE INDEX IF NOT EXISTS "idx_project_access_requests_account"
+    ON "kortix"."project_access_requests" USING btree ("account_id");
+
+  CREATE INDEX IF NOT EXISTS "idx_project_access_requests_requester"
+    ON "kortix"."project_access_requests" USING btree ("requester_user_id");
+
+  CREATE INDEX IF NOT EXISTS "idx_project_access_requests_status"
+    ON "kortix"."project_access_requests" USING btree ("status");
+
+  CREATE UNIQUE INDEX IF NOT EXISTS "idx_project_access_requests_pending_unique"
+    ON "kortix"."project_access_requests" USING btree ("project_id", "requester_user_id")
+    WHERE "status" = 'pending';
+END $$;

--- a/tests/spec/routes.generated.json
+++ b/tests/spec/routes.generated.json
@@ -1,10 +1,14 @@
 {
   "generatedAt": "static",
-  "count": 333,
+  "count": 384,
   "routes": [
     {
       "method": "GET",
       "path": "/health"
+    },
+    {
+      "method": "GET",
+      "path": "/health/live"
     },
     {
       "method": "GET",
@@ -339,8 +343,48 @@
       "path": "/v1/admin/api/accounts/:id/ledger"
     },
     {
+      "method": "POST",
+      "path": "/v1/admin/api/accounts/:id/tier"
+    },
+    {
       "method": "GET",
       "path": "/v1/admin/api/accounts/:id/users"
+    },
+    {
+      "method": "GET",
+      "path": "/v1/admin/api/provider-analytics"
+    },
+    {
+      "method": "GET",
+      "path": "/v1/admin/api/provider-distribution"
+    },
+    {
+      "method": "PUT",
+      "path": "/v1/admin/api/provider-distribution"
+    },
+    {
+      "method": "GET",
+      "path": "/v1/admin/api/provider-fallback"
+    },
+    {
+      "method": "PUT",
+      "path": "/v1/admin/api/provider-fallback"
+    },
+    {
+      "method": "GET",
+      "path": "/v1/admin/api/sandboxes"
+    },
+    {
+      "method": "POST",
+      "path": "/v1/admin/api/sandboxes/:sessionId/migrate"
+    },
+    {
+      "method": "GET",
+      "path": "/v1/admin/api/warm-pool-config"
+    },
+    {
+      "method": "PUT",
+      "path": "/v1/admin/api/warm-pool-config"
     },
     {
       "method": "POST",
@@ -535,8 +579,28 @@
       "path": "/v1/executor/projects/:projectId/connectors/:slug/connect/finalize"
     },
     {
+      "method": "DELETE",
+      "path": "/v1/executor/projects/:projectId/connectors/:slug/credential"
+    },
+    {
       "method": "PUT",
       "path": "/v1/executor/projects/:projectId/connectors/:slug/credential"
+    },
+    {
+      "method": "PUT",
+      "path": "/v1/executor/projects/:projectId/connectors/:slug/credential-mode"
+    },
+    {
+      "method": "PUT",
+      "path": "/v1/executor/projects/:projectId/connectors/:slug/name"
+    },
+    {
+      "method": "GET",
+      "path": "/v1/executor/projects/:projectId/connectors/:slug/policies"
+    },
+    {
+      "method": "PUT",
+      "path": "/v1/executor/projects/:projectId/connectors/:slug/policies"
     },
     {
       "method": "PUT",
@@ -580,6 +644,42 @@
     },
     {
       "method": "GET",
+      "path": "/v1/health/live"
+    },
+    {
+      "method": "GET",
+      "path": "/v1/marketplace/items"
+    },
+    {
+      "method": "GET",
+      "path": "/v1/marketplace/items/:id"
+    },
+    {
+      "method": "GET",
+      "path": "/v1/marketplace/items/:id/file"
+    },
+    {
+      "method": "GET",
+      "path": "/v1/marketplace/marketplaces"
+    },
+    {
+      "method": "GET",
+      "path": "/v1/marketplace/marketplaces/featured"
+    },
+    {
+      "method": "GET",
+      "path": "/v1/marketplace/sources"
+    },
+    {
+      "method": "POST",
+      "path": "/v1/marketplace/sources"
+    },
+    {
+      "method": "DELETE",
+      "path": "/v1/marketplace/sources/:id"
+    },
+    {
+      "method": "GET",
       "path": "/v1/oauth/authorize"
     },
     {
@@ -617,6 +717,10 @@
     {
       "method": "POST",
       "path": "/v1/p/auth"
+    },
+    {
+      "method": "GET",
+      "path": "/v1/p/public-share/:token"
     },
     {
       "method": "GET",
@@ -697,6 +801,22 @@
     {
       "method": "GET",
       "path": "/v1/projects/:projectId/access"
+    },
+    {
+      "method": "GET",
+      "path": "/v1/projects/:projectId/access-requests"
+    },
+    {
+      "method": "POST",
+      "path": "/v1/projects/:projectId/access-requests"
+    },
+    {
+      "method": "POST",
+      "path": "/v1/projects/:projectId/access-requests/:requestId/approve"
+    },
+    {
+      "method": "POST",
+      "path": "/v1/projects/:projectId/access-requests/:requestId/reject"
     },
     {
       "method": "DELETE",
@@ -835,6 +955,10 @@
       "path": "/v1/projects/:projectId/commits/:sha/diff"
     },
     {
+      "method": "POST",
+      "path": "/v1/projects/:projectId/connect-requests"
+    },
+    {
       "method": "GET",
       "path": "/v1/projects/:projectId/detail"
     },
@@ -919,6 +1043,34 @@
       "path": "/v1/projects/:projectId/onboarding"
     },
     {
+      "method": "POST",
+      "path": "/v1/projects/:projectId/presence"
+    },
+    {
+      "method": "POST",
+      "path": "/v1/projects/:projectId/presence/leave"
+    },
+    {
+      "method": "GET",
+      "path": "/v1/projects/:projectId/registry"
+    },
+    {
+      "method": "DELETE",
+      "path": "/v1/projects/:projectId/registry/:name"
+    },
+    {
+      "method": "POST",
+      "path": "/v1/projects/:projectId/registry/install"
+    },
+    {
+      "method": "POST",
+      "path": "/v1/projects/:projectId/registry/update"
+    },
+    {
+      "method": "GET",
+      "path": "/v1/projects/:projectId/registry/updates"
+    },
+    {
       "method": "GET",
       "path": "/v1/projects/:projectId/sandbox-health"
     },
@@ -945,6 +1097,10 @@
     {
       "method": "GET",
       "path": "/v1/projects/:projectId/sandboxes"
+    },
+    {
+      "method": "POST",
+      "path": "/v1/projects/:projectId/secret-requests"
     },
     {
       "method": "GET",
@@ -991,16 +1147,24 @@
       "path": "/v1/projects/:projectId/sessions/:sessionId/commit-push"
     },
     {
+      "method": "GET",
+      "path": "/v1/projects/:projectId/sessions/:sessionId/previews"
+    },
+    {
+      "method": "GET",
+      "path": "/v1/projects/:projectId/sessions/:sessionId/public-shares"
+    },
+    {
       "method": "POST",
-      "path": "/v1/projects/:projectId/sessions/:sessionId/ensure-opencode"
+      "path": "/v1/projects/:projectId/sessions/:sessionId/public-shares"
+    },
+    {
+      "method": "DELETE",
+      "path": "/v1/projects/:projectId/sessions/:sessionId/public-shares/:shareId"
     },
     {
       "method": "POST",
       "path": "/v1/projects/:projectId/sessions/:sessionId/restart"
-    },
-    {
-      "method": "GET",
-      "path": "/v1/projects/:projectId/sessions/:sessionId/sandbox"
     },
     {
       "method": "PUT",
@@ -1008,7 +1172,7 @@
     },
     {
       "method": "POST",
-      "path": "/v1/projects/:projectId/sessions/:sessionId/wake"
+      "path": "/v1/projects/:projectId/sessions/:sessionId/start"
     },
     {
       "method": "GET",
@@ -1111,6 +1275,18 @@
       "path": "/v1/projects/provision"
     },
     {
+      "method": "GET",
+      "path": "/v1/projects/suna-migration/eligibility"
+    },
+    {
+      "method": "POST",
+      "path": "/v1/projects/suna-migration/start"
+    },
+    {
+      "method": "GET",
+      "path": "/v1/projects/suna-migration/status"
+    },
+    {
       "method": "POST",
       "path": "/v1/projects/sync-opencode-sessions"
     },
@@ -1173,6 +1349,22 @@
     {
       "method": "PUT",
       "path": "/v1/servers/sync"
+    },
+    {
+      "method": "GET",
+      "path": "/v1/setup-links/connector/:token"
+    },
+    {
+      "method": "POST",
+      "path": "/v1/setup-links/connector/:token/start"
+    },
+    {
+      "method": "GET",
+      "path": "/v1/setup-links/secret/:token"
+    },
+    {
+      "method": "POST",
+      "path": "/v1/setup-links/secret/:token"
     },
     {
       "method": "POST",
@@ -1317,6 +1509,18 @@
     {
       "method": "POST",
       "path": "/v1/webhooks/slack/:projectId"
+    },
+    {
+      "method": "POST",
+      "path": "/v1/webhooks/slack/:projectId/commands"
+    },
+    {
+      "method": "POST",
+      "path": "/v1/webhooks/slack/:projectId/interactivity"
+    },
+    {
+      "method": "GET",
+      "path": "/v1/webhooks/slack/:projectId/manifest"
     },
     {
       "method": "POST",


### PR DESCRIPTION
## Summary
- Add a route-level ProjectAccessBoundary so forbidden project/session links render a stable request-access screen instead of mounting the full project shell.
- Add persisted project access requests with manager approve/decline controls in Customize → Members.
- Suppress noisy 403 presence heartbeat toasts and make the local credits migration compatible with the sandbox Supabase runner.

## Verification
- `pnpm --filter kortix-api typecheck`
- `pnpm --filter @kortix/db typecheck`
- Frontend ESLint on changed files from `apps/web`
- Filtered frontend `tsc --noEmit`: no changed-file errors
- `bun run apps/api/scripts/dump-routes.ts`
- `git diff --check`
- Local stack: Supabase migrations applied through 121; API/web booted
- Local API flow: requester 403 → access request created/deduped → manager approval → requester gets viewer access
- Browser check: forbidden project/session route shows Request access state and transitions to Request sent
