### PR TITLE
platform: all-green (ServerSideDiff, app-of-apps, runAsUser fix)

### DIFF
--- a/infra/k8s/argocd/applications/platform-console.yaml
+++ b/infra/k8s/argocd/applications/platform-console.yaml
@@ -13,6 +13,8 @@ kind: Application
 metadata:
   name: kortix-platform-console
   namespace: argocd
+  annotations:
+    argocd.argoproj.io/compare-options: ServerSideDiff=true
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:
@@ -89,6 +91,21 @@ spec:
   destination:
     server: https://kubernetes.default.svc
     namespace: kortix-platform
+  ignoreDifferences:
+    - kind: Service
+      jqPathExpressions:
+        - .spec.clusterIP
+        - .spec.clusterIPs
+        - .spec.ipFamilies
+        - .spec.ipFamilyPolicy
+        - .spec.internalTrafficPolicy
+        - .spec.sessionAffinity
+    - group: apps
+      kind: Deployment
+      jqPathExpressions:
+        - .spec.progressDeadlineSeconds
+        - .spec.revisionHistoryLimit
+        - .spec.strategy.rollingUpdate
   syncPolicy:
     automated:
       prune: true

--- a/infra/k8s/argocd/applications/platform-kyverno-policies.yaml
+++ b/infra/k8s/argocd/applications/platform-kyverno-policies.yaml
@@ -7,6 +7,8 @@ kind: Application
 metadata:
   name: kortix-platform-kyverno-policies
   namespace: argocd
+  annotations:
+    argocd.argoproj.io/compare-options: ServerSideDiff=true
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:
@@ -20,6 +22,11 @@ spec:
   destination:
     server: https://kubernetes.default.svc
     namespace: kyverno
+  ignoreDifferences:
+    - group: kyverno.io
+      kind: ClusterPolicy
+      managedFieldsManagers:
+        - kyverno
   syncPolicy:
     automated:
       prune: true

--- a/infra/k8s/argocd/applications/platform-kyverno.yaml
+++ b/infra/k8s/argocd/applications/platform-kyverno.yaml
@@ -7,6 +7,8 @@ kind: Application
 metadata:
   name: kortix-platform-kyverno
   namespace: argocd
+  annotations:
+    argocd.argoproj.io/compare-options: ServerSideDiff=true
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:
@@ -50,6 +52,11 @@ spec:
   destination:
     server: https://kubernetes.default.svc
     namespace: kyverno
+  ignoreDifferences:
+    - group: apiextensions.k8s.io
+      kind: CustomResourceDefinition
+      managedFieldsManagers:
+        - kube-apiserver
   syncPolicy:
     automated:
       prune: true

--- a/infra/k8s/argocd/applications/platform-logs.yaml
+++ b/infra/k8s/argocd/applications/platform-logs.yaml
@@ -11,6 +11,8 @@ kind: Application
 metadata:
   name: kortix-platform-logs
   namespace: argocd
+  annotations:
+    argocd.argoproj.io/compare-options: ServerSideDiff=true
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:
@@ -54,6 +56,25 @@ spec:
   destination:
     server: https://kubernetes.default.svc
     namespace: monitoring
+  ignoreDifferences:
+    - kind: Service
+      jqPathExpressions:
+        - .spec.clusterIP
+        - .spec.clusterIPs
+        - .spec.ipFamilies
+        - .spec.ipFamilyPolicy
+        - .spec.internalTrafficPolicy
+        - .spec.sessionAffinity
+    - kind: Secret
+      jqPathExpressions:
+        - .type
+    - group: apps
+      kind: StatefulSet
+      jqPathExpressions:
+        - .spec.persistentVolumeClaimRetentionPolicy
+        - .spec.revisionHistoryLimit
+        - .spec.podManagementPolicy
+        - .spec.updateStrategy
   syncPolicy:
     automated:
       prune: true

--- a/infra/k8s/argocd/applicationsets/preview.yaml
+++ b/infra/k8s/argocd/applicationsets/preview.yaml
@@ -22,7 +22,7 @@ spec:
   sourceRepos:
     - https://github.com/kortix-ai/suna.git
   destinations:
-    - name: kortix-dev-eks
+    - server: https://kubernetes.default.svc
       namespace: 'kortix-pr-*'
   clusterResourceWhitelist:
     - group: ''
@@ -73,7 +73,7 @@ spec:
             - name: ingress.host
               value: 'pr-{{.number}}.preview-api.kortix.com'
       destination:
-        name: kortix-dev-eks
+        server: https://kubernetes.default.svc
         namespace: 'kortix-pr-{{.number}}'
       # ESO's admission webhook injects defaults into the ExternalSecret that git
       # doesn't carry — ignore them so previews aren't perpetually OutOfSync.

--- a/infra/k8s/argocd/platform-app-of-apps.yaml
+++ b/infra/k8s/argocd/platform-app-of-apps.yaml
@@ -1,0 +1,38 @@
+# Platform app-of-apps: one Application that manages every platform-*.yaml under
+# applications/ (the DevOps console, observability, security guardrails, cost,
+# gateway). Apply ONCE per platform cluster (prod-eks) to bootstrap; thereafter
+# Argo self-manages the whole stack from git — no more manual kubectl apply.
+#
+# Scoped via directory.include to platform-* only, so it never touches the
+# kortix-dev / kortix-prod workload apps (those are cluster-specific).
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kortix-platform
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: platform
+  source:
+    repoURL: https://github.com/kortix-ai/suna.git
+    targetRevision: main
+    path: infra/k8s/argocd/applications
+    directory:
+      recurse: false
+      include: "platform-*.yaml"
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argocd
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - ServerSideApply=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 10s
+        factor: 2
+        maxDuration: 3m

--- a/infra/k8s/charts/kortix-api/templates/_pod.tpl
+++ b/infra/k8s/charts/kortix-api/templates/_pod.tpl
@@ -20,6 +20,9 @@ spec:
   {{- if .Values.security.enabled }}
   securityContext:
     runAsNonRoot: {{ .Values.security.runAsNonRoot }}
+    runAsUser: {{ .Values.security.runAsUser }}
+    runAsGroup: {{ .Values.security.runAsGroup }}
+    fsGroup: {{ .Values.security.runAsGroup }}
     seccompProfile:
       type: {{ .Values.security.seccompProfile }}
   {{- end }}

--- a/infra/k8s/charts/kortix-api/templates/migrate-job.yaml
+++ b/infra/k8s/charts/kortix-api/templates/migrate-job.yaml
@@ -30,6 +30,8 @@ spec:
       {{- if .Values.security.enabled }}
       securityContext:
         runAsNonRoot: {{ .Values.security.runAsNonRoot }}
+        runAsUser: {{ .Values.security.runAsUser }}
+        runAsGroup: {{ .Values.security.runAsGroup }}
         seccompProfile:
           type: {{ .Values.security.seccompProfile }}
       {{- end }}

--- a/infra/k8s/charts/kortix-api/values.yaml
+++ b/infra/k8s/charts/kortix-api/values.yaml
@@ -166,6 +166,11 @@ topologySpread:
 security:
   enabled: true
   runAsNonRoot: true
+  # Numeric UID/GID of the image's non-root user (oven/bun ships bun=1000). REQUIRED:
+  # with a non-numeric USER (bun) the kubelet can't verify runAsNonRoot and the pod
+  # fails CreateContainerConfigError.
+  runAsUser: 1000
+  runAsGroup: 1000
   seccompProfile: RuntimeDefault
   allowPrivilegeEscalation: false
   dropAllCapabilities: true

--- a/infra/k8s/envs/dev/values.yaml
+++ b/infra/k8s/envs/dev/values.yaml
@@ -6,7 +6,7 @@
 # Immutable dev tag (CI bumps to dev-<sha8> on each main push). Bootstrap value
 # is :dev-latest until the first deploy-dev-eks run pins an immutable sha.
 image:
-  tag: "dev-f6572117"
+  tag: "dev-d36add8a"
 kortixVersion: ""
 env:
   internalKortixEnv: dev


### PR DESCRIPTION
Surgical follow-up to #3519: makes the platform stack 14/14 green + fixes the runAsNonRoot/numeric-UID regression that broke dev. 10 files.