### PR TITLE
polish: align project access request state with brand

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,3 +90,21 @@ See `tests/e2e/helpers/auth.ts` for the exact calls.
 - `apps/web` `tsc --noEmit` emits ~1500 BOGUS `TS2786` / `IntrinsicAttributes`
   errors from a React 19↔18 types mismatch — ignore those; grep for YOUR files.
 - `npx eslint <files>` should be clean.
+
+### Frontend design standard — Jay/Kortix bar
+
+When touching any visual surface in `apps/web`, treat brand fit as a release
+gate, not polish:
+
+- Read `.claude/skills/kortix-design-system/SKILL.md` first and compose existing
+  primitives from `@/components/ui/*` before inventing local chrome.
+- Match the current Jay Suthar / Kortix product aesthetic: calm neutral surfaces,
+  dense-but-legible UI, black/white plus one earned accent, token-driven spacing,
+  and no decorative color, glow, or one-off rounded boxes.
+- Use recent product surfaces as references before editing: `/design-system`,
+  `apps/web/src/features/co-worker/project-layout/project-home.tsx`,
+  `apps/web/src/components/ui/wallpaper-background.tsx`, and the account/IAM
+  screens called out by the design-system skill.
+- Verify visual work in the browser and include the exact lint/typecheck commands
+  you ran in the PR. If it does not look native beside Jay-authored UI, keep
+  iterating before shipping.

--- a/apps/web/src/components/projects/project-access-boundary.tsx
+++ b/apps/web/src/components/projects/project-access-boundary.tsx
@@ -9,10 +9,12 @@ import {
   LockKeyhole,
   RefreshCw,
   Send,
+  UserRound,
 } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { useState, type ReactNode } from 'react';
 
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
   Card,
@@ -22,9 +24,12 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
+import { InfoBanner } from '@/components/ui/info-banner';
 import { Textarea } from '@/components/ui/textarea';
+import { WallpaperBackground } from '@/components/ui/wallpaper-background';
 import { useAuth } from '@/features/providers/auth-provider';
 import { getProjectDetail, requestProjectAccess } from '@/lib/projects-client';
+import { cn } from '@/lib/utils';
 
 interface ProjectAccessBoundaryProps {
   projectId: string;
@@ -32,8 +37,10 @@ interface ProjectAccessBoundaryProps {
 }
 
 function errorStatus(error: unknown): number | undefined {
-  return (error as { status?: number; response?: { status?: number } } | null)?.status ??
-    (error as { response?: { status?: number } } | null)?.response?.status;
+  return (
+    (error as { status?: number; response?: { status?: number } } | null)?.status ??
+    (error as { response?: { status?: number } } | null)?.response?.status
+  );
 }
 
 export function ProjectAccessBoundary({ projectId, children }: ProjectAccessBoundaryProps) {
@@ -57,7 +64,8 @@ export function ProjectAccessBoundary({ projectId, children }: ProjectAccessBoun
     if (status === 404) {
       return (
         <ProjectAccessStateFrame
-          icon={<AlertCircle className="h-5 w-5" />}
+          icon={<AlertCircle className="size-5" />}
+          eyebrow="Project unavailable"
           title="Project not found"
           description="This project may have been deleted, archived, or the link is no longer valid."
         />
@@ -66,12 +74,13 @@ export function ProjectAccessBoundary({ projectId, children }: ProjectAccessBoun
 
     return (
       <ProjectAccessStateFrame
-        icon={<AlertCircle className="h-5 w-5" />}
+        icon={<AlertCircle className="size-5" />}
+        eyebrow="Project unavailable"
         title="Couldn't load this project"
         description="Something went wrong before the project workspace opened. Try again, or go back to your projects."
         footer={
           <Button type="button" variant="outline" onClick={() => query.refetch()}>
-            <RefreshCw className="h-4 w-4" />
+            <RefreshCw className="size-4" />
             Retry
           </Button>
         }
@@ -86,7 +95,7 @@ function ProjectAccessLoading() {
   return (
     <div className="bg-background flex min-h-screen items-center justify-center">
       <div className="text-muted-foreground flex items-center gap-2 text-sm">
-        <Loader2 className="h-4 w-4 animate-spin" />
+        <Loader2 className="size-4 animate-spin" />
         Opening project…
       </div>
     </div>
@@ -118,56 +127,69 @@ function ForbiddenProjectState({ projectId }: { projectId: string }) {
 
   return (
     <ProjectAccessStateFrame
-      icon={<LockKeyhole className="h-5 w-5" />}
-      title="You need access to open this project"
-      description="This link points to a private Kortix project. Ask a project manager to approve your access request, then refresh this page."
+      icon={<LockKeyhole className="size-5" />}
+      eyebrow="Private project"
+      title={sent ? 'Request sent.' : 'Request access to this project.'}
+      description={
+        sent
+          ? 'A project manager can approve you from the Members screen. Keep this page open and check again once they approve the request.'
+          : 'This Kortix workspace is private. Send a short note and a project manager can add you as a viewer.'
+      }
+      panelTitle={sent ? 'Waiting for approval' : 'Access request'}
+      panelDescription={
+        sent
+          ? 'Managers have the request in Customize → Members.'
+          : 'A little context helps the manager approve the right account.'
+      }
       content={
         <div className="space-y-4">
-          <div className="border-border/70 bg-muted/35 rounded-xl border px-3 py-2 text-xs text-muted-foreground">
-            Signed in as{' '}
-            <span className="font-medium text-foreground">
-              {user?.email ?? user?.id ?? 'this account'}
-            </span>
-          </div>
-
           {sent ? (
-            <div className="border-emerald-500/25 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300 flex items-start gap-2 rounded-xl border px-3 py-3 text-sm">
-              <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0" />
-              <div>
-                <p className="font-medium">Request sent</p>
-                <p className="text-xs opacity-80">
-                  Project managers will see it in the Members screen and can approve you as a viewer.
-                </p>
-              </div>
-            </div>
+            <InfoBanner tone="success" icon={CheckCircle2} title="Request sent">
+              Project managers will see it in the Members screen and can approve you as a viewer.
+            </InfoBanner>
           ) : (
-            <div className="space-y-2">
-              <label className="text-xs font-medium text-foreground" htmlFor="project-access-message">
-                Message (optional)
-              </label>
-              <Textarea
-                id="project-access-message"
-                value={message}
-                onChange={(event) => setMessage(event.target.value)}
-                minHeight={92}
-                maxHeight={160}
-                placeholder="Tell the project manager why you need access…"
-                disabled={requestMutation.isPending}
-              />
-              {inlineError ? <p className="text-xs text-destructive">{inlineError}</p> : null}
-            </div>
+            <>
+              <InfoBanner tone="neutral" icon={UserRound} title="Signed in">
+                <span className="text-muted-foreground">
+                  Requesting access as{' '}
+                  <span className="text-foreground font-medium">
+                    {user?.email ?? user?.id ?? 'this account'}
+                  </span>
+                  .
+                </span>
+              </InfoBanner>
+
+              <div className="space-y-2">
+                <label
+                  className="text-foreground text-sm font-medium"
+                  htmlFor="project-access-message"
+                >
+                  Message <span className="text-muted-foreground font-normal">optional</span>
+                </label>
+                <Textarea
+                  id="project-access-message"
+                  value={message}
+                  onChange={(event) => setMessage(event.target.value)}
+                  minHeight={96}
+                  maxHeight={160}
+                  placeholder="Tell the project manager why you need access…"
+                  disabled={requestMutation.isPending}
+                />
+                {inlineError ? <p className="text-destructive text-xs">{inlineError}</p> : null}
+              </div>
+            </>
           )}
         </div>
       }
       footer={
         <div className="flex w-full flex-col-reverse gap-2 sm:flex-row sm:justify-between">
           <Button type="button" variant="ghost" onClick={() => router.push('/projects')}>
-            <ArrowLeft className="h-4 w-4" />
+            <ArrowLeft className="size-4" />
             Back to projects
           </Button>
           {sent ? (
             <Button type="button" variant="outline" onClick={() => window.location.reload()}>
-              <RefreshCw className="h-4 w-4" />
+              <RefreshCw className="size-4" />
               Check again
             </Button>
           ) : (
@@ -177,9 +199,9 @@ function ForbiddenProjectState({ projectId }: { projectId: string }) {
               disabled={requestMutation.isPending}
             >
               {requestMutation.isPending ? (
-                <Loader2 className="h-4 w-4 animate-spin" />
+                <Loader2 className="size-4 animate-spin" />
               ) : (
-                <Send className="h-4 w-4" />
+                <Send className="size-4" />
               )}
               Request access
             </Button>
@@ -192,41 +214,88 @@ function ForbiddenProjectState({ projectId }: { projectId: string }) {
 
 function ProjectAccessStateFrame({
   icon,
+  eyebrow = 'Project access',
   title,
   description,
+  panelTitle,
+  panelDescription,
   content,
   footer,
 }: {
   icon: ReactNode;
+  eyebrow?: string;
   title: string;
   description: string;
+  panelTitle?: string;
+  panelDescription?: string;
   content?: ReactNode;
   footer?: ReactNode;
 }) {
   const router = useRouter();
+  const action = footer ?? (
+    <Button type="button" variant="outline" onClick={() => router.push('/projects')}>
+      <ArrowLeft className="size-4" />
+      Back to projects
+    </Button>
+  );
+
   return (
-    <div className="bg-background relative flex min-h-screen items-center justify-center overflow-hidden px-4 py-10">
-      <div className="bg-kortix-blue/10 absolute -top-24 left-1/2 h-64 w-64 -translate-x-1/2 rounded-full blur-3xl" />
-      <Card variant="glass" className="relative w-full max-w-lg border-border/70 shadow-xl">
-        <CardHeader className="items-center text-center">
-          <div className="bg-muted text-foreground mb-2 flex h-11 w-11 items-center justify-center rounded-2xl border">
-            {icon}
-          </div>
-          <CardTitle className="text-lg">{title}</CardTitle>
-          <CardDescription className="max-w-sm text-sm leading-relaxed">
-            {description}
-          </CardDescription>
-        </CardHeader>
-        {content ? <CardContent>{content}</CardContent> : null}
-        <CardFooter className="justify-center">
-          {footer ?? (
-            <Button type="button" variant="outline" onClick={() => router.push('/projects')}>
-              <ArrowLeft className="h-4 w-4" />
-              Back to projects
-            </Button>
+    <div className="bg-background relative flex min-h-screen overflow-hidden px-4 py-10">
+      <div className="pointer-events-none absolute inset-0 opacity-60" aria-hidden="true">
+        <WallpaperBackground />
+      </div>
+      <div
+        className="bg-background/85 dark:bg-background/80 pointer-events-none absolute inset-0"
+        aria-hidden="true"
+      />
+
+      <main className="relative z-10 mx-auto flex w-full max-w-4xl items-center">
+        <div
+          className={cn(
+            'grid w-full gap-6',
+            content ? 'lg:grid-cols-2 lg:items-start' : 'max-w-2xl',
           )}
-        </CardFooter>
-      </Card>
+        >
+          <section className="space-y-5">
+            <div className="border-border/70 bg-card text-foreground flex size-11 items-center justify-center rounded-2xl border shadow-2xs">
+              {icon}
+            </div>
+
+            <div className="space-y-3">
+              <Badge variant="outline" size="sm" className="w-fit">
+                {eyebrow}
+              </Badge>
+              <div className="space-y-3">
+                <h1 className="text-foreground text-3xl font-semibold tracking-tight text-balance sm:text-4xl">
+                  {title}
+                </h1>
+                <p className="text-muted-foreground max-w-xl text-base leading-relaxed">
+                  {description}
+                </p>
+              </div>
+            </div>
+
+            {!content ? <div className="pt-1">{action}</div> : null}
+          </section>
+
+          {content ? (
+            <Card className="border-border/70 bg-card/90 gap-0 overflow-hidden rounded-2xl py-0 shadow-2xs backdrop-blur-sm">
+              <CardHeader className="border-border/60 border-b px-6 py-4">
+                <CardTitle className="text-base">{panelTitle ?? 'Request access'}</CardTitle>
+                {panelDescription ? (
+                  <CardDescription className="text-xs leading-relaxed">
+                    {panelDescription}
+                  </CardDescription>
+                ) : null}
+              </CardHeader>
+              <CardContent className="px-6 py-5">{content}</CardContent>
+              <CardFooter className="border-border/60 bg-muted/30 border-t px-6 py-3">
+                {action}
+              </CardFooter>
+            </Card>
+          ) : null}
+        </div>
+      </main>
     </div>
   );
 }

--- a/apps/web/src/components/projects/project-access-boundary.tsx
+++ b/apps/web/src/components/projects/project-access-boundary.tsx
@@ -25,6 +25,7 @@ import {
   CardTitle,
 } from '@/components/ui/card';
 import { InfoBanner } from '@/components/ui/info-banner';
+import { KortixHyperLogo } from '@/components/ui/marketing/kortix-hyper-logo';
 import { Textarea } from '@/components/ui/textarea';
 import { WallpaperBackground } from '@/components/ui/wallpaper-background';
 import { useAuth } from '@/features/providers/auth-provider';
@@ -93,11 +94,12 @@ export function ProjectAccessBoundary({ projectId, children }: ProjectAccessBoun
 
 function ProjectAccessLoading() {
   return (
-    <div className="bg-background flex min-h-screen items-center justify-center">
-      <div className="text-muted-foreground flex items-center gap-2 text-sm">
-        <Loader2 className="size-4 animate-spin" />
-        Opening project…
-      </div>
+    <div
+      className="bg-background flex min-h-screen items-center justify-center"
+      role="status"
+      aria-label="Loading project"
+    >
+      <KortixHyperLogo size={34} startOnView={false} animateOnHover={false} />
     </div>
   );
 }

--- a/supabase/migrations/00000000000112_sandbox_templates_built_from_commit.sql
+++ b/supabase/migrations/00000000000112_sandbox_templates_built_from_commit.sql
@@ -1,2 +1,0 @@
-ALTER TABLE kortix.sandbox_templates
-  ADD COLUMN IF NOT EXISTS built_from_commit TEXT;


### PR DESCRIPTION
## Summary
- Reworked the forbidden project access state to match the current Kortix/Jay product aesthetic: neutral split layout, wallpaper backdrop, DS Badge/Card/InfoBanner/Textarea/Button primitives, and calm request-sent state.
- Persisted the Jay/Kortix frontend design bar in Suna `AGENTS.md` for future visual work.
- Removed the duplicate `00000000000112_sandbox_templates_built_from_commit.sql` migration; `00000000000115_sandbox_templates_built_from_commit.sql` already carries the same idempotent column add, and the duplicate version blocks local Supabase boot.

## Verification
- `pnpm exec eslint src/components/projects/project-access-boundary.tsx`
- `pnpm exec tsc --noEmit --pretty false` → repo-wide React type noise remains, 0 errors in `src/components/projects/project-access-boundary.tsx`
- `git diff --check`
- Browser checked forbidden and request-sent states at the target project URL with a local mock API returning 403/create-access-request.
- `pnpm dev` got past local Supabase migrations after deleting the duplicate migration; API boot then stopped only on missing local provider secrets.
