### PR TITLE
fix(triggers): kill 500 on bad project id + make the cron scheduler reliable & diagnosable

### DIFF
--- a/apps/api/src/__tests__/unit-project-access.test.ts
+++ b/apps/api/src/__tests__/unit-project-access.test.ts
@@ -9,6 +9,19 @@ import {
   type ProjectAccessAction,
   type ProjectRole,
 } from '../projects/access';
+import { isUuid } from '../projects/lib/access';
+
+describe('isUuid project-id guard', () => {
+  test.each([
+    ['fda4e35e', false], // truncated id — used to 500 via Postgres 22P02
+    ['not-a-uuid', false],
+    ['', false],
+    ['fda4e35e-1234-4abc-89ef-0123456789ab', true],
+    ['FDA4E35E-1234-4ABC-89EF-0123456789AB', true], // case-insensitive
+  ])('isUuid(%p) === %p', (value, expected) => {
+    expect(isUuid(value)).toBe(expected);
+  });
+});
 
 describe('project access roles', () => {
   test.each([

--- a/apps/api/src/__tests__/unit-trigger-dsl.test.ts
+++ b/apps/api/src/__tests__/unit-trigger-dsl.test.ts
@@ -129,6 +129,34 @@ prompt = "x"
     expect(errors[0]!.error).toMatch(/expression or a one-off/);
   });
 
+  test('a bad IANA timezone is rejected at parse time', () => {
+    const parsed = parseManifestString(manifestWith(`
+[[triggers]]
+slug = "bad-tz"
+type = "cron"
+cron = "0 0 9 * * 1"
+timezone = "Not/AZone"
+prompt = "x"
+`));
+    const { errors } = extractTriggers(parsed);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]!.error).toMatch(/timezone must be a valid IANA name/);
+  });
+
+  test('a valid named timezone is accepted', () => {
+    const parsed = parseManifestString(manifestWith(`
+[[triggers]]
+slug = "good-tz"
+type = "cron"
+cron = "0 0 9 * * 1"
+timezone = "America/New_York"
+prompt = "x"
+`));
+    const { specs, errors } = extractTriggers(parsed);
+    expect(errors).toEqual([]);
+    expect(specs[0]!.timezone).toBe('America/New_York');
+  });
+
   test('parses a webhook trigger with secret_env reference', () => {
     const parsed = parseManifestString(manifestWith(`
 [[triggers]]

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -56,6 +56,7 @@ import {
   projectsApp,
   startProjectTriggerScheduler,
   stopProjectTriggerScheduler,
+  getTriggerSchedulerHealth,
 } from './projects';
 import { startProjectMaintenance, stopProjectMaintenance } from './projects/maintenance';
 import { kickStartupPreBuild } from './snapshots/builder';
@@ -363,6 +364,7 @@ const HealthSchema = z
     }),
     tunnel: z.any(),
     leader: z.boolean(),
+    trigger_scheduler: z.any(),
   })
   .openapi('Health');
 
@@ -398,6 +400,10 @@ const healthHandler = (c: any) =>
     },
     tunnel: getTunnelServiceStatus(),
     leader: isLeader(),
+    // The leader pod's trigger-sweep heartbeat: when it last ran, how long it
+    // took, and what it did. On a non-leader pod the fields are null (the sweep
+    // only runs on the leader) — so "all pods null" = no leader = no triggers.
+    trigger_scheduler: getTriggerSchedulerHealth(),
   });
 
 app.openapi(

--- a/apps/api/src/projects/index.ts
+++ b/apps/api/src/projects/index.ts
@@ -63,6 +63,7 @@ export {
   resolveGitTriggerActor,
   startProjectTriggerScheduler,
   stopProjectTriggerScheduler,
+  getTriggerSchedulerHealth,
   loadManifestForEdit,
   commitManifest,
 } from './lib/triggers';

--- a/apps/api/src/projects/lib/access.ts
+++ b/apps/api/src/projects/lib/access.ts
@@ -252,8 +252,19 @@ export function iamActionForProjectAccess(action: ProjectAccessAction): string {
 }
 
 
+// `projects.project_id` is a Postgres `uuid` column, so a malformed id
+// (e.g. a truncated "fda4e35e") makes the lookup throw `invalid input syntax
+// for type uuid` (SQLSTATE 22P02) before any guard runs — surfacing as an
+// opaque 500. Validate the shape first so a bad id is a clean 404, not a 500.
+const PROJECT_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function isUuid(value: string): boolean {
+  return PROJECT_ID_RE.test(value);
+}
+
 export async function loadProjectForUser(c: Context, projectId: string, action: ProjectAccessAction) {
   const userId = c.get('userId') as string;
+  if (!isUuid(projectId)) return null;
   const [row] = await db
     .select()
     .from(projects)

--- a/apps/api/src/projects/lib/triggers.ts
+++ b/apps/api/src/projects/lib/triggers.ts
@@ -148,6 +148,28 @@ export let triggerSchedulerTimer: TriggerSchedulerTimer | null = null;
 
 export let triggerSweepRunning = false;
 
+// In-memory heartbeat for the trigger scheduler, surfaced at /health so an
+// operator can tell at a glance whether the leader's sweep is alive and what
+// the last pass did. Lives on the leader pod; resets on restart. This is the
+// answer to "how would anyone know the scheduler stopped firing?".
+export interface TriggerSchedulerHealth {
+  lastSweepStartedAt: string | null;
+  lastSweepCompletedAt: string | null;
+  lastSweepDurationMs: number | null;
+  lastResult: { scanned: number; fired: number; queued: number; failed: number; skipped: number } | null;
+  lastError: string | null;
+}
+const schedulerHealth: TriggerSchedulerHealth = {
+  lastSweepStartedAt: null,
+  lastSweepCompletedAt: null,
+  lastSweepDurationMs: null,
+  lastResult: null,
+  lastError: null,
+};
+export function getTriggerSchedulerHealth(): TriggerSchedulerHealth {
+  return schedulerHealth;
+}
+
 // Connector reconcile sweep — runs on a slower cadence than the trigger sweep.
 
 export let connectorSweepRunning = false;
@@ -186,14 +208,21 @@ export async function runProjectTriggerSweep(now = new Date()): Promise<{
 }> {
   if (triggerSweepRunning) return { scanned: 0, fired: 0, queued: 0, failed: 0, skipped: 0 };
   triggerSweepRunning = true;
+  const startedMs = Date.now();
+  schedulerHealth.lastSweepStartedAt = now.toISOString();
   const result = { scanned: 0, fired: 0, queued: 0, failed: 0, skipped: 0 };
   try {
     await runGitTriggerSweep(now, result);
+    schedulerHealth.lastError = null;
     return result;
   } catch (err) {
+    schedulerHealth.lastError = err instanceof Error ? err.message : String(err);
     console.error('[project-triggers/git] sweep failed', err);
     return result;
   } finally {
+    schedulerHealth.lastSweepCompletedAt = new Date().toISOString();
+    schedulerHealth.lastSweepDurationMs = Date.now() - startedMs;
+    schedulerHealth.lastResult = result;
     triggerSweepRunning = false;
   }
 }
@@ -208,17 +237,35 @@ export async function runProjectTriggerSweep(now = new Date()): Promise<{
  * so unchanged connectors cost a manifest read, not a catalog re-fetch.
  */
 
+/**
+ * Page through EVERY active project. The sweeps used to `LIMIT 200`, which
+ * silently dropped every active project past the 200th once the platform grew
+ * beyond that many — their triggers / connectors just never ran, with no error
+ * and no log. Paging keeps coverage complete while bounding each query.
+ */
+async function selectActiveProjects(pageSize = 500): Promise<ProjectRow[]> {
+  const all: ProjectRow[] = [];
+  for (let offset = 0; ; offset += pageSize) {
+    const batch = await db
+      .select()
+      .from(projects)
+      .where(eq(projects.status, 'active'))
+      .orderBy(projects.projectId)
+      .limit(pageSize)
+      .offset(offset);
+    all.push(...batch);
+    if (batch.length < pageSize) break;
+  }
+  return all;
+}
+
 export async function runProjectConnectorSweep(): Promise<{ scanned: number; synced: number; errors: number }> {
   if (connectorSweepRunning) return { scanned: 0, synced: 0, errors: 0 };
   connectorSweepRunning = true;
   const out = { scanned: 0, synced: 0, errors: 0 };
   try {
     const { syncProjectConnectors } = await import('../../executor/sync');
-    const projectsForSweep = await db
-      .select()
-      .from(projects)
-      .where(eq(projects.status, 'active'))
-      .limit(200);
+    const projectsForSweep = await selectActiveProjects();
     for (const project of projectsForSweep) {
       out.scanned += 1;
       try {
@@ -290,13 +337,39 @@ export async function getGitTriggerRuntime(projectId: string, slug: string) {
 }
 
 
-export async function markGitTriggerFired(projectId: string, slug: string, when: Date) {
+export async function markGitTriggerFired(
+  projectId: string,
+  slug: string,
+  when: Date,
+  status: 'fired' | 'queued' = 'fired',
+) {
   await db
     .insert(projectTriggerRuntime)
-    .values({ projectId, slug, lastFiredAt: when, updatedAt: when })
+    .values({ projectId, slug, lastFiredAt: when, lastStatus: status, lastError: null, lastAttemptAt: when, updatedAt: when })
     .onConflictDoUpdate({
       target: [projectTriggerRuntime.projectId, projectTriggerRuntime.slug],
-      set: { lastFiredAt: when, updatedAt: when },
+      set: { lastFiredAt: when, lastStatus: status, lastError: null, lastAttemptAt: when, updatedAt: when },
+    });
+}
+
+/**
+ * Record a failed attempt (fire error or parse error) WITHOUT advancing
+ * `last_fired_at`, so the trigger is still due and retries next sweep — but the
+ * reason is now visible in the triggers API/UI instead of vanishing into a log.
+ */
+export async function markGitTriggerAttemptFailed(
+  projectId: string,
+  slug: string,
+  when: Date,
+  error: string,
+) {
+  const lastError = error.slice(0, 1000);
+  await db
+    .insert(projectTriggerRuntime)
+    .values({ projectId, slug, lastStatus: 'failed', lastError, lastAttemptAt: when, updatedAt: when })
+    .onConflictDoUpdate({
+      target: [projectTriggerRuntime.projectId, projectTriggerRuntime.slug],
+      set: { lastStatus: 'failed', lastError, lastAttemptAt: when, updatedAt: when },
     });
 }
 
@@ -451,17 +524,21 @@ export function summarizeTriggerPayload(payload: Record<string, unknown>): Recor
 export async function runGitTriggerSweep(now: Date, accumulator: {
   scanned: number; fired: number; queued: number; failed: number; skipped: number;
 }): Promise<void> {
-  const projectsForSweep = await db
-    .select()
-    .from(projects)
-    .where(eq(projects.status, 'active'))
-    .limit(200);
+  const projectsForSweep = await selectActiveProjects();
 
   for (const project of projectsForSweep) {
     let specs: GitTriggerSpec[];
     try {
       const loaded = await loadProjectTriggers(await withProjectGitAuth(project));
       specs = loaded.specs;
+      // Surface parse errors instead of dropping them: record each bad entry
+      // against its slug so it shows up in the triggers API/UI, and log it.
+      // Previously a malformed `[[triggers]]` entry just vanished from the
+      // sweep with zero feedback — a prime "my trigger isn't running" trap.
+      for (const e of loaded.errors) {
+        console.warn('[project-triggers/git] parse error', project.projectId, e.slug, e.error);
+        await markGitTriggerAttemptFailed(project.projectId, e.slug, now, `parse error: ${e.error}`);
+      }
     } catch (err) {
       console.warn('[project-triggers/git] load failed', project.projectId, err instanceof Error ? err.message : err);
       continue;
@@ -499,14 +576,22 @@ export async function runGitTriggerSweep(now: Date, accumulator: {
         idempotencyKey: `trigger:cron:${project.projectId}:${spec.slug}:${scheduledAt}`,
       });
       if (result.status === 'fired') {
-        await markGitTriggerFired(project.projectId, spec.slug, now);
+        await markGitTriggerFired(project.projectId, spec.slug, now, 'fired');
         accumulator.fired += 1;
       }
       else if (result.status === 'queued') {
-        await markGitTriggerFired(project.projectId, spec.slug, now);
+        await markGitTriggerFired(project.projectId, spec.slug, now, 'queued');
         accumulator.queued += 1;
       }
-      else accumulator.failed += 1;
+      else {
+        // A failed fire is NOT stamped as fired, so it retries next tick — but
+        // we record why so "trigger isn't running" is diagnosable from the API.
+        await markGitTriggerAttemptFailed(
+          project.projectId, spec.slug, now,
+          result.error ?? result.reason ?? 'trigger fire failed',
+        );
+        accumulator.failed += 1;
+      }
     }
   }
 }
@@ -597,9 +682,7 @@ export async function loadTriggersForResponse(projectId: string, project: Projec
         .select()
         .from(projectTriggerRuntime)
         .where(eq(projectTriggerRuntime.projectId, projectId));
-  const lastFiredBySlug = new Map(
-    runtimeRows.map((row) => [row.slug, row.lastFiredAt?.toISOString() ?? null]),
-  );
+  const runtimeBySlug = new Map(runtimeRows.map((row) => [row.slug, row]));
 
   return {
     triggers: specs.map((spec) => ({
@@ -615,7 +698,10 @@ export async function loadTriggersForResponse(projectId: string, project: Projec
       secret_env: spec.secretEnv,
       prompt_template: spec.promptTemplate,
       session_mode: spec.sessionMode,
-      last_fired_at: lastFiredBySlug.get(spec.slug) ?? null,
+      last_fired_at: runtimeBySlug.get(spec.slug)?.lastFiredAt?.toISOString() ?? null,
+      last_status: runtimeBySlug.get(spec.slug)?.lastStatus ?? null,
+      last_error: runtimeBySlug.get(spec.slug)?.lastError ?? null,
+      last_attempt_at: runtimeBySlug.get(spec.slug)?.lastAttemptAt?.toISOString() ?? null,
       webhook_url:
         spec.type === 'webhook'
           ? buildPublicWebhookUrl(projectId, spec.slug)

--- a/apps/api/src/projects/triggers.ts
+++ b/apps/api/src/projects/triggers.ts
@@ -297,6 +297,20 @@ interface ParseErr {
   error: GitTriggerParseError;
 }
 
+// A bad IANA timezone (typo, or an abbreviation like "PST") otherwise slips
+// through parsing and only fails later inside the cron due-check, where it's
+// swallowed to `false` — the trigger then silently never fires. Catch it at
+// parse time so it surfaces as a visible trigger error instead.
+function isValidTimeZone(tz: string): boolean {
+  if (tz === 'UTC') return true;
+  try {
+    new Intl.DateTimeFormat('en-US', { timeZone: tz });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function parseTriggerEntry(entry: unknown, index: number): ParseOk | ParseErr {
   if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
     return err('(invalid)', `[[triggers]] entry #${index + 1} is not a table`);
@@ -358,6 +372,9 @@ function parseTriggerEntry(entry: unknown, index: number): ParseOk | ParseErr {
     const timezone = typeof row.timezone === 'string' && row.timezone.trim()
       ? row.timezone.trim()
       : 'UTC';
+    if (!isValidTimeZone(timezone)) {
+      return err(slug, `timezone must be a valid IANA name like "UTC" or "America/New_York" (got "${timezone}")`);
+    }
 
     // A one-off ("run once") schedule carries `run_at` instead of `cron`.
     if (runAtRaw) {

--- a/apps/api/src/shared/leader-election.ts
+++ b/apps/api/src/shared/leader-election.ts
@@ -135,7 +135,22 @@ async function promote(): Promise<void> {
   try {
     await handlers?.onAcquire();
   } catch (err) {
-    logger.error('[leader] onAcquire failed', { error: err instanceof Error ? err.message : String(err) });
+    // If startup of the singleton workers throws, do NOT stay leader=true with
+    // nothing running — that silently halts every cron trigger fleet-wide and
+    // no peer takes over (we'd hold the lease forever). Step down + clean up;
+    // the next tick re-acquires the (still-held) lease and retries onAcquire,
+    // so a transient failure self-heals instead of becoming a permanent stall.
+    logger.error('[leader] onAcquire failed — stepping down to retry next tick', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    leader = false;
+    try {
+      await handlers?.onRelease();
+    } catch (releaseErr) {
+      logger.error('[leader] onRelease during onAcquire recovery failed', {
+        error: releaseErr instanceof Error ? releaseErr.message : String(releaseErr),
+      });
+    }
   }
 }
 

--- a/packages/db/src/schema/kortix.ts
+++ b/packages/db/src/schema/kortix.ts
@@ -634,6 +634,13 @@ export const projectTriggerRuntime = kortixSchema.table(
       .references(() => projects.projectId, { onDelete: 'cascade' }),
     slug: varchar('slug', { length: 128 }).notNull(),
     lastFiredAt: timestamp('last_fired_at', { withTimezone: true }),
+    // Observability for "why isn't my trigger running": outcome of the most
+    // recent attempt ('fired' | 'queued' | 'failed'), the error if it failed
+    // (or a parse error), and when that attempt happened (distinct from
+    // last_fired_at, which only advances on a successful/queued fire).
+    lastStatus: varchar('last_status', { length: 32 }),
+    lastError: text('last_error'),
+    lastAttemptAt: timestamp('last_attempt_at', { withTimezone: true }),
     updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
   },
   (table) => [

--- a/supabase/migrations/00000000000122_trigger_runtime_observability.sql
+++ b/supabase/migrations/00000000000122_trigger_runtime_observability.sql
@@ -1,0 +1,17 @@
+-- Trigger observability: record the OUTCOME of each trigger's most recent
+-- attempt so "why isn't my trigger running?" is answerable from the triggers
+-- API/UI instead of vanishing into the scheduler logs. last_status is
+-- 'fired' | 'queued' | 'failed'; last_error holds the failure / parse-error
+-- reason; last_attempt_at is when that attempt happened (distinct from
+-- last_fired_at, which only advances on a successful or queued fire, so a
+-- failing trigger keeps a stale last_fired_at but a fresh last_attempt_at +
+-- last_error). See apps/api/src/projects/lib/triggers.ts (markGitTriggerFired,
+-- markGitTriggerAttemptFailed, loadTriggersForResponse).
+ALTER TABLE "kortix"."project_trigger_runtime"
+  ADD COLUMN IF NOT EXISTS "last_status" varchar(32);
+
+ALTER TABLE "kortix"."project_trigger_runtime"
+  ADD COLUMN IF NOT EXISTS "last_error" text;
+
+ALTER TABLE "kortix"."project_trigger_runtime"
+  ADD COLUMN IF NOT EXISTS "last_attempt_at" timestamptz;


### PR DESCRIPTION
## Why
Two symptoms, one subsystem:
1. A manual `kortix triggers fire` (and `sessions ls` / `projects info`) returned an opaque **HTTP 500** for a company project.
2. A report that **cron triggers weren't firing**.

Tracing both turned up a real correctness bug plus several silent-failure modes in the scheduler with no way to diagnose them.

## What changed

**Correctness**
- **Kill the 500.** `loadProjectForUser` now validates the project id is a UUID *before* the DB lookup. A non-UUID id (e.g. a truncated `fda4e35e`) made Postgres throw `22P02 invalid input syntax for type uuid` → unhandled → generic 500. It's now a clean **404**.
- **Timezone validated at parse time.** A bad IANA tz (typo / `PST`) used to slip through and only fail inside the cron due-check, where it was swallowed to `false` — the trigger then **silently never fired**. Now it's a visible trigger parse error.
- **Removed the `LIMIT 200` active-project cap** in the trigger + connector sweeps. Past the 200th active project, triggers/connectors silently never ran. The sweeps now **page through every active project**.

**Observability — "why isn't my trigger running?"**
- Persist **`last_status` / `last_error` / `last_attempt_at`** per trigger and surface them in the triggers API. Failed fires + parse errors are recorded against the slug (without advancing `last_fired_at`, so they still retry) instead of vanishing into logs.
- **`/health` trigger-sweep heartbeat** (last sweep time, duration, result counts, last error) so a stalled scheduler is visible. All-pods-null ⇒ no leader ⇒ no triggers.

**Leader hardening**
- If `onAcquire` (singleton-worker startup) throws, the leader now **steps down + cleans up** instead of stranding `leader=true` with nothing running — which silently halted every cron fleet-wide and let no peer take over. Next tick re-acquires and retries, so transient failures self-heal.

## Test plan
- `tsc --noEmit` clean (apps/api + @kortix/db).
- Full unit suite green; **+7 new cases** (UUID guard, timezone validation).
- Migration is idempotent (`ADD COLUMN IF NOT EXISTS`); schema reaches dev via `ensureSchema`'s `drizzle-kit push`, prod via the numbered `supabase/migrations` SQL.
- Verify on the preview: `/health.trigger_scheduler` populates; a malformed project id returns 404 (not 500); a trigger with a bad timezone surfaces a parse error.

## Note
`drizzle-kit db:generate` is separately blocked by a **pre-existing** journal/snapshot collision (two 06-17 migrations) — unrelated to this PR. This change deliberately uses the `supabase/migrations` + `drizzle-kit push` path that the runtime actually applies, so it's unaffected.
