### PR TITLE
fix(web): skip marketing shader without WebGL

### DIFF
--- a/apps/web/src/components/home/interactive-demo.tsx
+++ b/apps/web/src/components/home/interactive-demo.tsx
@@ -42,6 +42,21 @@ type PageIcon = LucideIcon | IconType;
 const RAIL_ICON = 'size-[1.05rem] lg:size-[1.2rem]';
 const TAB_ICON = 'size-4';
 
+function browserSupportsWebGL(): boolean {
+  if (typeof document === 'undefined') return false;
+
+  try {
+    const canvas = document.createElement('canvas');
+    return Boolean(
+      canvas.getContext('webgl2')
+        ?? canvas.getContext('webgl')
+        ?? canvas.getContext('experimental-webgl'),
+    );
+  } catch {
+    return false;
+  }
+}
+
 type DemoExtras = {
   focusedSkill: string | null;
   onSkillClick: (name: string) => void;
@@ -251,6 +266,7 @@ export function InteractiveDemo({
     if (isDemoPageEnabled(page)) setActiveRaw(page);
   }, []);
   const [focusedSkill, setFocusedSkill] = useState<string | null>(null);
+  const [webGLReady, setWebGLReady] = useState(false);
   const convo = useDemoConversation({ onEnterChat: () => setActive('chat') });
   const rootRef = useRef<HTMLDivElement>(null);
   const autoStarted = useRef(false);
@@ -264,6 +280,11 @@ export function InteractiveDemo({
   useEffect(() => {
     if (active !== 'skills') setFocusedSkill(null);
   }, [active]);
+
+  useEffect(() => {
+    setWebGLReady(browserSupportsWebGL());
+  }, []);
+
   const tabRefs = useRef<Partial<Record<PageId, HTMLButtonElement>>>({});
   const mobileTabRefs = useRef<Partial<Record<PageId, HTMLButtonElement>>>({});
 
@@ -341,7 +362,7 @@ export function InteractiveDemo({
           aside && 'rounded sm:rounded-sm',
         )}
       >
-        {gradientbg && (
+        {gradientbg && webGLReady && (
           <div className="absolute inset-0">
             <Warp
               speed={4.3}


### PR DESCRIPTION
## Root cause
Browsers/WebViews without WebGL support were still mounting the Paper shader in the marketing interactive demo. `@paper-design/shaders-react` throws `Paper Shaders: WebGL is not supported in this browser`, which Better Stack grouped under frontend prod pattern `64db0422eff40fa50107e5fbfa9607e8be2e513917d9364ce16f435e816f3de2`.

## Evidence
- Better Stack app: Kortix Frontend (prod), pattern `64db0422eff40fa50107e5fbfa9607e8be2e513917d9364ce16f435e816f3de2`.
- Count: 72 prod occurrences over the 90d unresolved inventory; last seen 2026-06-16 00:17:05 UTC.
- Raw occurrence: `request.url=https://kortix.com/`, browser `Facebook 557` Android WebView, error value `Paper Shaders: WebGL is not supported in this browser`, transaction `/`.

## Fix
Gate the marketing demo's decorative `<Warp />` shader behind a client-side WebGL capability check. Unsupported browsers keep the neutral demo surface instead of instantiating the shader runtime.

## Verification
- `pnpm --filter ./apps/web exec eslint src/components/home/interactive-demo.tsx` (0 errors; existing hook dependency warnings remain)
- `pnpm --filter ./apps/web exec tsc --noEmit --pretty false` (fails on pre-existing unrelated errors: `creditsToDollars` export and `@/.source` imports; no errors for `interactive-demo.tsx`)

## Better Stack
- https://errors.betterstack.com/team/t502678/errors/64db0422eff40fa50107e5fbfa9607e8be2e513917d9364ce16f435e816f3de2?s=2346967
