### PR TITLE
feat(triggers): server-side per-project trigger pause toggle

### DIFF
--- a/apps/api/src/__tests__/unit-trigger-pause.test.ts
+++ b/apps/api/src/__tests__/unit-trigger-pause.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from 'bun:test';
+
+import { triggersPausedForProject, withTriggersPaused } from '../projects/lib/triggers';
+
+describe('server-side per-project trigger kill-switch', () => {
+  test('triggersPausedForProject reads metadata.triggers_paused (default off)', () => {
+    expect(triggersPausedForProject({ triggers_paused: true })).toBe(true);
+    expect(triggersPausedForProject({ triggers_paused: false })).toBe(false);
+    expect(triggersPausedForProject({})).toBe(false);
+    expect(triggersPausedForProject(null)).toBe(false);
+    expect(triggersPausedForProject(undefined)).toBe(false);
+    expect(triggersPausedForProject('nope')).toBe(false);
+    // only strict `true` pauses — a truthy-but-not-true value does not
+    expect(triggersPausedForProject({ triggers_paused: 1 })).toBe(false);
+  });
+
+  test('withTriggersPaused sets/clears the flag, preserving other metadata', () => {
+    expect(withTriggersPaused({ foo: 1 }, true)).toEqual({ foo: 1, triggers_paused: true });
+    expect(withTriggersPaused({ foo: 1, triggers_paused: true }, false)).toEqual({ foo: 1 });
+    expect(withTriggersPaused(null, true)).toEqual({ triggers_paused: true });
+    expect(withTriggersPaused(undefined, false)).toEqual({});
+    // round-trips with the reader
+    expect(triggersPausedForProject(withTriggersPaused({}, true))).toBe(true);
+    expect(triggersPausedForProject(withTriggersPaused({ triggers_paused: true }, false))).toBe(false);
+  });
+});

--- a/apps/api/src/projects/lib/triggers.ts
+++ b/apps/api/src/projects/lib/triggers.ts
@@ -194,6 +194,28 @@ export function nextCronRun(schedule: string, from: Date, timezone?: string): Da
 }
 
 /**
+ * Server-side, per-project trigger kill-switch (`projects.metadata.triggers_paused`).
+ * When paused, the platform does NOT auto-run any of the project's triggers —
+ * the cron sweep skips it and inbound webhooks are ignored — even though each
+ * trigger is still `enabled` in the repo. This is how you stop ONE repo
+ * deployed to TWO independent control planes (e.g. dev.kortix.com + kortix.com,
+ * separate DBs/schedulers with no cross-platform dedup) from double-firing every
+ * cron: pause it on the deployment you don't want firing. A manual
+ * `…/triggers/:slug/fire` is an explicit action and still runs. Toggle via
+ * `PATCH /:projectId/triggers/activation`.
+ */
+export function triggersPausedForProject(metadata: unknown): boolean {
+  return isPlainObject(metadata) && (metadata as Record<string, unknown>).triggers_paused === true;
+}
+
+export function withTriggersPaused(metadata: unknown, paused: boolean): Record<string, unknown> {
+  const base = isPlainObject(metadata) ? { ...(metadata as Record<string, unknown>) } : {};
+  if (paused) base.triggers_paused = true;
+  else delete base.triggers_paused;
+  return base;
+}
+
+/**
  * Walks every active project's git repo for `.opencode/triggers/*.md` and
  * fires due cron triggers. Triggers are 100% file-defined now (kortix.toml);
  * the old DB-backed trigger tables have been removed.
@@ -527,6 +549,11 @@ export async function runGitTriggerSweep(now: Date, accumulator: {
   const projectsForSweep = await selectActiveProjects();
 
   for (const project of projectsForSweep) {
+    // Server-side per-project kill-switch — skip the whole project (no manifest
+    // read, no session spin) when its triggers are paused, so a repo deployed
+    // to two control planes only fires on the un-paused one. See
+    // triggersPausedForProject.
+    if (triggersPausedForProject(project.metadata)) continue;
     let specs: GitTriggerSpec[];
     try {
       const loaded = await loadProjectTriggers(await withProjectGitAuth(project));
@@ -707,6 +734,10 @@ export async function loadTriggersForResponse(projectId: string, project: Projec
           ? buildPublicWebhookUrl(projectId, spec.slug)
           : null,
     })),
+    // Server-side activation state for this project's whole trigger set. When
+    // true, the platform won't auto-run any of them (cron sweep skips, webhooks
+    // ignored), regardless of each trigger's own `enabled`.
+    triggers_paused: triggersPausedForProject(project.metadata),
     errors,
   };
 }

--- a/apps/api/src/projects/routes/r1.ts
+++ b/apps/api/src/projects/routes/r1.ts
@@ -21,7 +21,7 @@ import { enforceProjectQuota, grantProjectRole, loadProjectForUser, resolveProje
 import { AnyObject, ProjectSchema, projectWebhooksApp, projectsApp } from '../lib/app';
 import { GitHubInstallationRequiredError, buildConnectionRef, consumeGitHubInstallationState, createGitHubInstallationInstallUrl, getAccountGitHubInstallation, getProjectGitConnection, getProjectGitRemote, listAccountGitHubInstallations, registerGitHubLinkedProject, resolveGitHubImport, resolveProjectGitAuth, resolveProjectUpstream, upsertProjectGitConnection, withProjectGitAuth } from '../lib/git';
 import { UUID_V4_REGEX, deriveProjectName, normalizeRepoUrl, normalizeString, readBody, requestAuditContext, serializeGitHubInstallation, serializeGitHubInstallations, serializeGitHubRepo, serializeProject } from '../lib/serializers';
-import { extractWebhookToken, fireGitTrigger, markGitTriggerFired, renderPromptTemplate, verifyWebhookSignature, verifyWebhookToken, webhookPayload } from '../lib/triggers';
+import { extractWebhookToken, fireGitTrigger, markGitTriggerFired, renderPromptTemplate, triggersPausedForProject, verifyWebhookSignature, verifyWebhookToken, webhookPayload } from '../lib/triggers';
 
 projectsApp.use('/*', supabaseAuth);
 
@@ -100,6 +100,13 @@ projectWebhooksApp.post('/projects/:projectId/:slug', async (c) => {
         .update(signatureHeader ?? '')
         .update(staticAuthFingerprint)
         .digest('hex')}`;
+
+  // Server-side per-project kill-switch: a paused project ignores inbound
+  // webhooks (acknowledged, not fired) so a repo deployed to two control planes
+  // doesn't double-fire. Manual `…/fire` is unaffected. See triggersPausedForProject.
+  if (triggersPausedForProject(project.metadata)) {
+    return c.json({ status: 'skipped', reason: 'triggers are paused server-side for this project' }, 200);
+  }
 
   const result = await fireGitTrigger({
     spec,

--- a/apps/api/src/projects/routes/r4.ts
+++ b/apps/api/src/projects/routes/r4.ts
@@ -8,14 +8,14 @@ import { db } from '../../shared/db';
 import { extractApps } from '../apps';
 import { extractTriggers, loadProjectTriggers, type ParsedManifest } from '../triggers';
 import { createRoute, z } from '@hono/zod-openapi';
-import { projectSessions, projectTriggerRuntime, sessionSandboxes } from '@kortix/db';
+import { projectSessions, projectTriggerRuntime, projects, sessionSandboxes } from '@kortix/db';
 import { and, eq, inArray } from 'drizzle-orm';
 import { loadProjectForUser } from '../lib/access';
 import { AnyObject, AppSchema, TriggerSchema, projectsApp } from '../lib/app';
 import { APPS_DISABLED_BODY, SlackAuthTest, draftToAppSpec, loadAppsForResponse, parseAppDraft, projectAppsEnabled, removeAppFromManifest, specToAppBody, upsertAppInManifest } from '../lib/apps-helpers';
 import { withProjectGitAuth } from '../lib/git';
 import { readBody, requestAuditContext } from '../lib/serializers';
-import { commitManifest, draftToSpec, fireGitTrigger, loadManifestForEdit, loadTriggersForResponse, markGitTriggerFired, parseTriggerDraft, removeTriggerFromManifest, renderPromptTemplate, specToBody, upsertTriggerInManifest } from '../lib/triggers';
+import { commitManifest, draftToSpec, fireGitTrigger, loadManifestForEdit, loadTriggersForResponse, markGitTriggerFired, parseTriggerDraft, removeTriggerFromManifest, renderPromptTemplate, specToBody, triggersPausedForProject, upsertTriggerInManifest, withTriggersPaused } from '../lib/triggers';
 
 projectsApp.openapi(
   createRoute({
@@ -663,6 +663,48 @@ projectsApp.openapi(
     deduped: result.deduped ?? false,
   }, 202);
 },
+);
+
+// PATCH /:projectId/triggers/activation — server-side, per-project trigger
+// kill-switch. Body { paused: boolean }. When paused, the platform won't
+// auto-run any of this project's triggers (the cron sweep skips it, inbound
+// webhooks are ignored) regardless of each trigger's repo `enabled`. Use it to
+// stop ONE repo deployed to TWO control planes (e.g. dev + prod) from
+// double-firing every cron — pause the deployment you don't want firing. A
+// manual `…/triggers/:slug/fire` is explicit and still runs.
+projectsApp.openapi(
+  createRoute({
+    method: 'patch',
+    path: '/{projectId}/triggers/activation',
+    tags: ['triggers'],
+    summary: 'Pause or resume all of a project\'s triggers server-side',
+    ...auth,
+    request: {
+      params: z.object({ projectId: z.string() }),
+      body: { content: { 'application/json': { schema: AnyObject } } },
+    },
+    responses: {
+      200: json(AnyObject, 'Updated triggers (includes triggers_paused)'),
+      ...errors(400, 401, 403, 404),
+    },
+  }),
+  async (c: any) => {
+    const projectId = c.req.param('projectId');
+    const body = await readBody(c);
+    const loaded = await loadProjectForUser(c, projectId, 'manage');
+    if (!loaded) return c.json({ error: 'Not found' }, 404);
+    const paused = body.paused;
+    if (typeof paused !== 'boolean') {
+      return c.json({ error: 'paused must be a boolean' }, 400);
+    }
+    const [row] = await db
+      .update(projects)
+      .set({ metadata: withTriggersPaused(loaded.row.metadata, paused), updatedAt: new Date() })
+      .where(eq(projects.projectId, projectId))
+      .returning();
+    if (!row || row.status === 'archived') return c.json({ error: 'Not found' }, 404);
+    return c.json(await loadTriggersForResponse(projectId, row));
+  },
 );
 
 // ── [[apps]] CRUD + deploy ──────────────────────────────────────────────────

--- a/apps/cli/src/api/types.ts
+++ b/apps/cli/src/api/types.ts
@@ -142,6 +142,10 @@ export interface ProjectTrigger {
 
 export interface ProjectTriggersResponse {
   triggers: ProjectTrigger[];
+  // Server-side per-project activation state. When true, the platform won't
+  // auto-run ANY of this project's triggers (cron sweep skips, webhooks ignored)
+  // regardless of each trigger's own `enabled`. Toggle with `triggers pause/resume`.
+  triggers_paused?: boolean;
   errors: Array<{ path: string; error: string }>;
 }
 

--- a/apps/cli/src/commands/triggers.ts
+++ b/apps/cli/src/commands/triggers.ts
@@ -22,7 +22,8 @@ const HELP = `Usage: kortix triggers <subcommand> [options]
 Manage the [[triggers]] declared in your project's kortix.toml — cron
 schedules and webhooks. add/rm/enable/disable edit the LOCAL kortix.toml
 (the source of truth); \`kortix ship\` applies them. ls/fire/info read live
-state from the cloud.
+state from the cloud. pause/resume are a SERVER-SIDE activation switch
+(cloud state, not the manifest).
 
 Subcommands:
   ls [--json]              List triggers + runtime state.
@@ -31,6 +32,11 @@ Subcommands:
   fire <slug>              Manually fire a trigger now.
   enable <slug>            Set enabled = true on a trigger.
   disable <slug>           Set enabled = false on a trigger.
+  pause                    Deactivate ALL of this project's triggers server-side
+                           (crons + webhooks stop auto-running). Use it on one
+                           of two deployments of the same repo to stop double-
+                           firing. Manual \`fire\` still works.
+  resume                   Re-activate this project's triggers server-side.
   info <slug> [--json]     Show one trigger in full.
 
 Add options:
@@ -100,6 +106,10 @@ export async function runTriggers(argv: string[]): Promise<number> {
       return triggersToggle(rest[0], true);
     case 'disable':
       return triggersToggle(rest[0], false);
+    case 'pause':
+      return triggersActivation(ctxOpts, true);
+    case 'resume':
+      return triggersActivation(ctxOpts, false);
     case 'info':
     case 'show':
       return triggersInfo(rest[0], ctxOpts, json);
@@ -127,6 +137,12 @@ async function triggersLs(opts: CtxOpts, json = false): Promise<number> {
   if (json) {
     emitJson(resp);
     return 0;
+  }
+
+  if (resp.triggers_paused) {
+    process.stdout.write(
+      `\n  ${status.warn('Triggers are PAUSED server-side for this project')} ${C.dim}— crons + webhooks won't auto-run (manual \`fire\` still works). \`kortix triggers resume\` to re-activate.${C.reset}\n`,
+    );
   }
 
   if (resp.triggers.length === 0) {
@@ -186,6 +202,29 @@ async function triggersFire(slug: string | undefined, opts: CtxOpts): Promise<nu
   } else {
     process.stdout.write(`${status.ok(`Fired ${C.bold}${slug}${C.reset}`)}\n`);
   }
+  return 0;
+}
+
+// Server-side activation switch (cloud state in projects.metadata, NOT the
+// manifest). Pause = the platform stops auto-running this project's triggers.
+async function triggersActivation(opts: CtxOpts, paused: boolean): Promise<number> {
+  const ctx = resolveProjectContext(opts);
+  if (!ctx) return 1;
+
+  try {
+    await ctx.client.patch<ProjectTriggersResponse>(
+      `/projects/${ctx.projectId}/triggers/activation`,
+      { paused },
+    );
+  } catch (err) {
+    return surfaceApiError(err);
+  }
+
+  process.stdout.write(
+    paused
+      ? `${status.ok('Triggers PAUSED server-side')} ${C.dim}— this project's crons + webhooks won't auto-run. Manual \`fire\` still works.${C.reset}\n`
+      : `${status.ok('Triggers RESUMED server-side')} ${C.dim}— this project's triggers will auto-run again.${C.reset}\n`,
+  );
   return 0;
 }
 


### PR DESCRIPTION
## Why
The company repo (and any repo) can be deployed as a project on **two independent Kortix control planes** — e.g. `dev.kortix.com` and `kortix.com`. They have separate databases, schedulers, and leader election, so there's **no cross-platform dedup**: every cron fires twice (two leaderboard posts, duplicate error-sweep PRs, double memory CRs, etc.). The repo's `kortix.toml` is shared, so flipping a trigger's `enabled` turns it off on *both*.

## What
A **server-side, per-project trigger kill-switch** (`projects.metadata.triggers_paused`) — independent of the repo. Pause it on the deployment you don't want auto-running; keep that deployment fully usable for interactive testing.

- **Paused** → the cron sweep **skips the project entirely** (no manifest read, no session spin) and inbound **webhooks are acknowledged but not fired**.
- A **manual** `…/triggers/:slug/fire` is an explicit action and **still runs** (so you can test on a paused deployment).
- New **`PATCH /:projectId/triggers/activation { paused }`**; the triggers API now returns `triggers_paused`.
- **kortix CLI**: `kortix triggers pause` / `kortix triggers resume`, plus a paused banner in `kortix triggers ls`.

No schema change — reuses the existing `projects.metadata` JSONB (same pattern as `apps_enabled` / experimental flags), so nothing to migrate.

## Test plan
- `tsc --noEmit` green (apps/api). +2 unit tests for the metadata helpers (`triggersPausedForProject` / `withTriggersPaused`, incl. round-trip).
- On the preview: `PATCH …/triggers/activation {paused:true}` → `triggers ls` shows paused + the sweep stops firing that project; `{paused:false}` resumes. Manual `…/fire` works either way.

## Usage (fixes the dual-host double-fire)
```sh
kortix triggers pause   --project <dev-project-id>   # dev stops auto-running
# prod keeps firing; dev still usable for interactive testing
```
