### PR TITLE
feat(cli): add compact session digests

### DIFF
--- a/apps/api/src/projects/lib/session-transcript.ts
+++ b/apps/api/src/projects/lib/session-transcript.ts
@@ -1,0 +1,252 @@
+import { sessionSandboxes } from '@kortix/db';
+import { and, desc, eq } from 'drizzle-orm';
+
+import { db } from '../../shared/db';
+import {
+  ensureOpencodeSessionPin,
+  sandboxOpencodeEndpoint,
+} from '../opencode-mapping';
+import type { ProjectSessionRow } from './serializers';
+
+const WORKSPACE_DIRECTORY = '/workspace';
+
+export interface CompactToolCall {
+  tool: string;
+  status: string | null;
+}
+
+export interface CompactMessage {
+  role: string;
+  created: string | null;
+  completed: string | null;
+  text: string;
+  tools: CompactToolCall[];
+  files: Array<{ filename: string | null; mime: string | null }>;
+  reasoning_omitted: boolean;
+  error: { name?: string; message?: string } | null;
+}
+
+export interface SessionTranscriptDigest {
+  available: boolean;
+  reason: string | null;
+  opencode_session_id: string | null;
+  message_count: number;
+  messages: CompactMessage[];
+}
+
+type RawOpencodeMessage = {
+  info?: {
+    role?: string;
+    time?: { created?: number; completed?: number };
+    error?: { name?: string; message?: string } | null;
+  };
+  role?: string;
+  time?: { created?: number; completed?: number };
+  error?: { name?: string; message?: string } | null;
+  parts?: RawOpencodePart[];
+};
+
+type RawOpencodePart = {
+  type?: string;
+  text?: string;
+  synthetic?: boolean;
+  tool?: string;
+  state?: { status?: string };
+  filename?: string;
+  mime?: string;
+};
+
+export async function buildSessionTranscriptDigest(input: {
+  session: ProjectSessionRow;
+  projectId: string;
+  accountId: string;
+  userId: string;
+  limit: number;
+  maxChars: number;
+}): Promise<SessionTranscriptDigest> {
+  const { session, projectId, accountId, userId, limit, maxChars } = input;
+  const unavailable = (reason: string): SessionTranscriptDigest => ({
+    available: false,
+    reason,
+    opencode_session_id: session.opencodeSessionId,
+    message_count: 0,
+    messages: [],
+  });
+
+  if (session.status !== 'running') {
+    return unavailable(`session is ${session.status}; live transcript requires a running sandbox`);
+  }
+
+  const externalId = await resolveSessionExternalId({ session, projectId, accountId });
+  if (!externalId) {
+    return unavailable('session has no reachable sandbox external id yet');
+  }
+
+  const ensured = await ensureOpencodeSessionPin({
+    projectId,
+    sessionId: session.sessionId,
+    accountId,
+    externalId,
+    userId,
+    currentPin: session.opencodeSessionId,
+  });
+  const opencodeSessionId = ensured.pin;
+  if (!opencodeSessionId) {
+    return {
+      ...unavailable(opencodeReason(ensured.reason)),
+      opencode_session_id: null,
+    };
+  }
+
+  const endpoint = await sandboxOpencodeEndpoint(externalId, userId);
+  if (!endpoint) {
+    return {
+      ...unavailable('sandbox service key unavailable'),
+      opencode_session_id: opencodeSessionId,
+    };
+  }
+
+  try {
+    const url = new URL(
+      `${endpoint.url}/session/${encodeURIComponent(opencodeSessionId)}/message`,
+    );
+    url.searchParams.set('directory', WORKSPACE_DIRECTORY);
+    url.searchParams.set('limit', String(limit));
+    const res = await fetch(url, {
+      method: 'GET',
+      headers: endpoint.headers,
+      signal: AbortSignal.timeout(8_000),
+    });
+    if (!res.ok) {
+      return {
+        ...unavailable(await messageReadReason(res)),
+        opencode_session_id: opencodeSessionId,
+      };
+    }
+    const payload = (await res.json().catch(() => null)) as unknown;
+    const rawMessages = normalizeMessageList(payload).slice(-limit);
+    return {
+      available: true,
+      reason: null,
+      opencode_session_id: opencodeSessionId,
+      message_count: rawMessages.length,
+      messages: rawMessages.map((m) => compactMessage(m, maxChars)),
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      ...unavailable(`could not read sandbox transcript: ${message}`),
+      opencode_session_id: opencodeSessionId,
+    };
+  }
+}
+
+async function resolveSessionExternalId(input: {
+  session: ProjectSessionRow;
+  projectId: string;
+  accountId: string;
+}): Promise<string | null> {
+  const fromUrl = externalIdFromSandboxUrl(input.session.sandboxUrl);
+  if (fromUrl) return fromUrl;
+
+  const [row] = await db
+    .select({ externalId: sessionSandboxes.externalId })
+    .from(sessionSandboxes)
+    .where(
+      and(
+        eq(sessionSandboxes.sessionId, input.session.sessionId),
+        eq(sessionSandboxes.projectId, input.projectId),
+        eq(sessionSandboxes.accountId, input.accountId),
+      ),
+    )
+    .orderBy(desc(sessionSandboxes.updatedAt))
+    .limit(1);
+  return row?.externalId ?? null;
+}
+
+function externalIdFromSandboxUrl(url: string | null): string | null {
+  if (!url) return null;
+  const match = url.match(/\/p\/([^/]+)\//);
+  return match?.[1] ?? null;
+}
+
+function opencodeReason(reason: string): string {
+  switch (reason) {
+    case 'not_ready':
+      return 'OpenCode session not ready in the sandbox';
+    case 'unreachable':
+      return 'OpenCode session list unreachable in the sandbox';
+    case 'healed':
+    case 'unchanged':
+      return 'no OpenCode session id found in the sandbox';
+    default:
+      return `OpenCode session unavailable: ${reason}`;
+  }
+}
+
+async function messageReadReason(res: Response): Promise<string> {
+  let payload: unknown = null;
+  try {
+    payload = await res.json();
+  } catch {
+    // Ignore non-JSON bodies from upstreams.
+  }
+  const detail =
+    typeof payload === 'object' && payload && 'error' in payload && typeof (payload as { error?: unknown }).error === 'string'
+      ? (payload as { error: string }).error
+      : typeof payload === 'object' && payload && 'message' in payload && typeof (payload as { message?: unknown }).message === 'string'
+        ? (payload as { message: string }).message
+        : null;
+  if (res.status === 503) return detail ?? 'OpenCode not ready in the sandbox';
+  if (res.status === 404) return detail ?? 'OpenCode session messages not found';
+  return detail ? `OpenCode messages unavailable: ${detail}` : `OpenCode messages unavailable: HTTP ${res.status}`;
+}
+
+function normalizeMessageList(payload: unknown): RawOpencodeMessage[] {
+  const list = Array.isArray(payload)
+    ? payload
+    : typeof payload === 'object' && payload && 'messages' in payload && Array.isArray((payload as { messages?: unknown }).messages)
+      ? (payload as { messages: unknown[] }).messages
+      : [];
+  return list.filter((m): m is RawOpencodeMessage => typeof m === 'object' && m !== null);
+}
+
+function compactMessage(msg: RawOpencodeMessage, maxChars: number): CompactMessage {
+  const info = msg.info ?? msg;
+  const parts = Array.isArray(msg.parts) ? msg.parts : [];
+  const text = parts
+    .filter((p) => p.type === 'text' && !p.synthetic && typeof p.text === 'string')
+    .map((p) => p.text as string)
+    .filter(Boolean)
+    .join('\n');
+  const tools = parts
+    .filter((p) => p.type === 'tool')
+    .map((p) => ({
+      tool: p.tool ?? 'tool',
+      status: p.state?.status ?? null,
+    }));
+  const files = parts
+    .filter((p) => p.type === 'file')
+    .map((p) => ({
+      filename: p.filename ?? null,
+      mime: p.mime ?? null,
+    }));
+  return {
+    role: info.role ?? 'unknown',
+    created: info.time?.created ? new Date(info.time.created).toISOString() : null,
+    completed: info.time?.completed ? new Date(info.time.completed).toISOString() : null,
+    text: truncate(normalizeWhitespace(text), maxChars),
+    tools,
+    files,
+    reasoning_omitted: parts.some((p) => p.type === 'reasoning'),
+    error: info.error ?? null,
+  };
+}
+
+function normalizeWhitespace(s: string): string {
+  return s.replace(/\s+/g, ' ').trim();
+}
+
+function truncate(s: string, max: number): string {
+  return s.length <= max ? s : `${s.slice(0, Math.max(0, max - 1))}…`;
+}

--- a/apps/api/src/projects/routes/r7.ts
+++ b/apps/api/src/projects/routes/r7.ts
@@ -10,8 +10,24 @@ import { loadProjectForUser, loadVisibleSession, lookupEmailsByUserIds, parseExp
 import { AnyObject, GroupGrantSchema, SessionSchema, projectsApp } from '../lib/app';
 import { UUID_V4_REGEX, hasOwn, isProjectRole, normalizeString, readBody, requestAuditContext, serializeSession, serializeSessionSandboxConfig } from '../lib/serializers';
 import { sendSessionCreateError } from '../lib/sessions';
+import { buildSessionTranscriptDigest } from '../lib/session-transcript';
 import { createSession, deleteSession } from '../session-lifecycle';
 import { syncOpencodeSessionsHandler } from './shared';
+
+function parseBoundedPositiveInt(
+  raw: string | undefined,
+  fallback: number,
+  min: number,
+  max: number,
+  label: string,
+): { ok: true; value: number } | { ok: false; error: string } {
+  if (raw === undefined || raw === '') return { ok: true, value: fallback };
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value < min || value > max) {
+    return { ok: false, error: `${label} must be an integer between ${min} and ${max}` };
+  }
+  return { ok: true, value };
+}
 
 projectsApp.openapi(
   createRoute({
@@ -476,6 +492,59 @@ projectsApp.openapi(
     canManageProject: visible.canManageProject,
     ownerEmail,
   }));
+},
+);
+
+
+// GET /v1/projects/:projectId/sessions/:sessionId/transcript
+// Compact server-side transcript read for project automation. Unlike the raw
+// /v1/p sandbox proxy, this endpoint is callable with project-scoped session
+// tokens and strips tool inputs/outputs before returning messages.
+
+projectsApp.openapi(
+  createRoute({
+    method: 'get',
+    path: '/{projectId}/sessions/{sessionId}/transcript',
+    tags: ['sessions'],
+    summary: 'GET /:projectId/sessions/:sessionId/transcript',
+    ...auth,
+      request: {
+        params: z.object({ projectId: z.string(), sessionId: z.string() }),
+        query: z.object({
+          limit: z.string().optional(),
+          chars: z.string().optional(),
+        }),
+      },
+    responses: {
+        200: json(AnyObject, 'Compact session transcript'),
+        ...errors(400, 404),
+    },
+  }),
+  async (c: any) => {
+  const projectId = c.req.param('projectId');
+  const sessionId = c.req.param('sessionId');
+  if (!UUID_V4_REGEX.test(sessionId)) return c.json({ error: 'Invalid session id' }, 400);
+
+  const limit = parseBoundedPositiveInt(c.req.query('limit'), 40, 1, 500, 'limit');
+  if (!limit.ok) return c.json({ error: limit.error }, 400);
+  const maxChars = parseBoundedPositiveInt(c.req.query('chars'), 700, 80, 5000, 'chars');
+  if (!maxChars.ok) return c.json({ error: maxChars.error }, 400);
+
+  const loaded = await loadProjectForUser(c, projectId, 'read');
+  if (!loaded) return c.json({ error: 'Not found' }, 404);
+
+  const visible = await loadVisibleSession(loaded, sessionId);
+  if (!visible) return c.json({ error: 'Not found' }, 404);
+
+  const transcript = await buildSessionTranscriptDigest({
+    session: visible.row,
+    projectId,
+    accountId: loaded.row.accountId,
+    userId: loaded.userId,
+    limit: limit.value,
+    maxChars: maxChars.value,
+  });
+  return c.json(transcript);
 },
 );
 

--- a/apps/cli/src/__tests__/sessions.e2e.test.ts
+++ b/apps/cli/src/__tests__/sessions.e2e.test.ts
@@ -15,8 +15,14 @@ let repo = '';
 let origin = '';
 let originalCwd = '';
 let previousConfigFile: string | undefined;
+let previousCliToken: string | undefined;
+let previousExecutorToken: string | undefined;
+let previousApiUrl: string | undefined;
+let previousProjectId: string | undefined;
 let server: ReturnType<typeof Bun.serve> | null = null;
 let sessionCreateBody: Record<string, unknown> | null = null;
+let sessionList: Record<string, unknown>[] = [];
+let transcriptRequests: URL[] = [];
 
 function git(args: string[], cwd?: string): string {
   return execFileSync('git', args, {
@@ -33,7 +39,17 @@ describe('sessions new CLI flow', () => {
     origin = join(root, 'origin.git');
     originalCwd = process.cwd();
     previousConfigFile = process.env.KORTIX_CONFIG_FILE;
+    previousCliToken = process.env.KORTIX_CLI_TOKEN;
+    previousExecutorToken = process.env.KORTIX_EXECUTOR_TOKEN;
+    previousApiUrl = process.env.KORTIX_API_URL;
+    previousProjectId = process.env.KORTIX_PROJECT_ID;
+    delete process.env.KORTIX_CLI_TOKEN;
+    delete process.env.KORTIX_EXECUTOR_TOKEN;
+    delete process.env.KORTIX_API_URL;
+    delete process.env.KORTIX_PROJECT_ID;
     sessionCreateBody = null;
+    sessionList = [];
+    transcriptRequests = [];
 
     mkdirSync(repo, { recursive: true });
     git(['init', '-b', 'main'], repo);
@@ -100,7 +116,43 @@ describe('sessions new CLI flow', () => {
             updated_at: '2026-01-01T00:00:00.000Z',
           });
         }
-        return new Response('not found', { status: 404 });
+        if (req.method === 'GET' && url.pathname === `/v1/projects/${PROJECT_ID}/sessions`) {
+          return Response.json(sessionList);
+        }
+        const transcriptMatch = url.pathname.match(new RegExp(`^/v1/projects/${PROJECT_ID}/sessions/([^/]+)/transcript$`));
+        if (req.method === 'GET' && transcriptMatch) {
+          transcriptRequests.push(url);
+          return Response.json({
+            available: true,
+            reason: null,
+            opencode_session_id: 'ses_test',
+            message_count: 2,
+            messages: [
+              {
+                role: 'user',
+                created: '2026-06-20T00:00:00.000Z',
+                completed: null,
+                text: 'Review recent sessions',
+                tools: [],
+                files: [],
+                reasoning_omitted: false,
+                error: null,
+              },
+              {
+                role: 'assistant',
+                created: '2026-06-20T00:01:00.000Z',
+                completed: '2026-06-20T00:02:00.000Z',
+                text: 'Found the important changes.',
+                tools: [{ tool: 'bash', status: 'completed', output: 'must not leak' }],
+                files: [],
+                reasoning_omitted: true,
+                error: null,
+                output: 'must not leak',
+              },
+            ],
+          });
+        }
+        return Response.json({ error: `not found ${url.pathname}` }, { status: 404 });
       },
     });
 
@@ -131,6 +183,14 @@ describe('sessions new CLI flow', () => {
     process.chdir(originalCwd);
     if (previousConfigFile === undefined) delete process.env.KORTIX_CONFIG_FILE;
     else process.env.KORTIX_CONFIG_FILE = previousConfigFile;
+    if (previousCliToken === undefined) delete process.env.KORTIX_CLI_TOKEN;
+    else process.env.KORTIX_CLI_TOKEN = previousCliToken;
+    if (previousExecutorToken === undefined) delete process.env.KORTIX_EXECUTOR_TOKEN;
+    else process.env.KORTIX_EXECUTOR_TOKEN = previousExecutorToken;
+    if (previousApiUrl === undefined) delete process.env.KORTIX_API_URL;
+    else process.env.KORTIX_API_URL = previousApiUrl;
+    if (previousProjectId === undefined) delete process.env.KORTIX_PROJECT_ID;
+    else process.env.KORTIX_PROJECT_ID = previousProjectId;
     server?.stop(true);
     server = null;
     if (root) rmSync(root, { recursive: true, force: true });
@@ -152,4 +212,82 @@ describe('sessions new CLI flow', () => {
     const sessionSha = git(['--git-dir', origin, 'rev-parse', `refs/heads/${sessionId}`]);
     expect(sessionSha).toBe(baseSha);
   });
+
+  test('digest uses compact project transcript endpoint', async () => {
+    const runningId = '11111111-1111-4111-8111-111111111111';
+    const stoppedId = '22222222-2222-4222-8222-222222222222';
+    sessionList = [
+      {
+        session_id: runningId,
+        account_id: ACCOUNT_ID,
+        project_id: PROJECT_ID,
+        branch_name: runningId,
+        base_ref: 'main',
+        sandbox_provider: 'daytona',
+        sandbox_id: runningId,
+        sandbox_url: `http://127.0.0.1/v1/p/external-${runningId}/8000`,
+        opencode_session_id: 'ses_test',
+        name: 'Digest target',
+        agent_name: 'memory-reflector',
+        status: 'running',
+        error: null,
+        metadata: { opencode_sessions: [{ title: 'Digest target' }] },
+        created_at: '2026-06-20T00:00:00.000Z',
+        updated_at: '2026-06-20T00:05:00.000Z',
+      },
+      {
+        session_id: stoppedId,
+        account_id: ACCOUNT_ID,
+        project_id: PROJECT_ID,
+        branch_name: stoppedId,
+        base_ref: 'main',
+        sandbox_provider: 'daytona',
+        sandbox_id: stoppedId,
+        sandbox_url: null,
+        opencode_session_id: null,
+        name: 'Stopped target',
+        agent_name: 'default',
+        status: 'stopped',
+        error: null,
+        metadata: {},
+        created_at: '2026-06-20T00:00:00.000Z',
+        updated_at: '2026-06-20T00:03:00.000Z',
+      },
+    ];
+
+    const { code, stdout } = await captureStdout(() =>
+      runSessions(['digest', '--all', '--messages', '5', '--chars', '120', '--json']),
+    );
+
+    expect(code).toBe(0);
+    expect(transcriptRequests).toHaveLength(1);
+    expect(transcriptRequests[0]!.searchParams.get('limit')).toBe('5');
+    expect(transcriptRequests[0]!.searchParams.get('chars')).toBe('120');
+
+    const parsed = JSON.parse(stdout) as {
+      sessions: Array<{ transcript: { available: boolean; messages: Array<{ tools: unknown[] }> } }>;
+    };
+    expect(parsed.sessions).toHaveLength(2);
+    expect(parsed.sessions[0]!.transcript.available).toBe(true);
+    expect(parsed.sessions[1]!.transcript.available).toBe(false);
+    expect(JSON.stringify(parsed)).not.toContain('must not leak');
+    expect(parsed.sessions[0]!.transcript.messages[1]!.tools).toEqual([
+      { tool: 'bash', status: 'completed' },
+    ]);
+  });
 });
+
+async function captureStdout(fn: () => Promise<number>): Promise<{ code: number; stdout: string }> {
+  const originalWrite = process.stdout.write;
+  let stdout = '';
+  process.stdout.write = ((chunk: string | Uint8Array, ...args: unknown[]) => {
+    stdout += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8');
+    return true;
+  }) as typeof process.stdout.write;
+  try {
+    const code = await fn();
+    return { code, stdout };
+  } finally {
+    process.stdout.write = originalWrite;
+  }
+}

--- a/apps/cli/src/commands/sessions-digest.ts
+++ b/apps/cli/src/commands/sessions-digest.ts
@@ -1,0 +1,417 @@
+import type { ApiClient } from '../api/client.ts';
+import type { ProjectSession } from '../api/types.ts';
+import {
+  emitJson,
+  resolveProjectContext,
+  surfaceApiError,
+  takeFlagBool,
+  takeFlagValue,
+} from '../command-helpers.ts';
+import { C, pad, status } from '../style.ts';
+
+type CtxOpts = { projectArg?: string; hostArg?: string };
+
+const DIGEST_HELP = `Usage: kortix sessions digest [options]
+
+Compact review of recent sessions for reflection / handoff. It lists sessions
+in a time window and, for running sessions, reads the live OpenCode transcript
+through the project sessions API. Tool calls are compressed to name/status only;
+tool inputs and outputs are intentionally stripped so the digest stays readable.
+
+  --since <when>       Window start (default 7d). Examples: 24h, 7d,
+                       2026-06-20, 2026-06-20T03:00:00Z.
+  --messages, -n <N>   Recent OpenCode messages per running session (default 40).
+  --chars <N>          Max text chars per message after whitespace compaction
+                       (default 700).
+  --all                Ignore --since and include every listable session.
+  --json               Emit structured JSON for scripting.
+  --project <id>       Operate on this project id (default: linked).
+  --host <name>        Operate against a non-default Kortix host.
+  -h, --help           Show this help.
+
+Aliases: review, summary.
+
+Notes:
+- Running sessions include a compact transcript when the sandbox is reachable.
+- Stopped/failed sessions include metadata and any mirrored OpenCode titles, but
+  their transcript is unavailable unless the sandbox is running/resumed.
+`;
+
+interface CompactToolCall {
+  tool: string;
+  status: string | null;
+}
+
+interface CompactMessage {
+  role: string;
+  created: string | null;
+  completed: string | null;
+  text: string;
+  tools: CompactToolCall[];
+  files: Array<{ filename: string | null; mime: string | null }>;
+  reasoning_omitted: boolean;
+  error: { name?: string; message?: string } | null;
+}
+
+interface SessionDigest {
+  session: {
+    session_id: string;
+    name: string | null;
+    agent: string;
+    status: string;
+    branch: string;
+    base_ref: string;
+    provider: string;
+    sandbox_url: string | null;
+    created_at: string;
+    updated_at: string;
+    error: string | null;
+    opencode_session_id: string | null;
+    opencode_titles: string[];
+  };
+  transcript: {
+    available: boolean;
+    reason: string | null;
+    opencode_session_id: string | null;
+    message_count: number;
+    messages: CompactMessage[];
+  };
+}
+
+export async function runSessionsDigest(argv: string[]): Promise<number> {
+  const rest = [...argv];
+  if (rest.includes('-h') || rest.includes('--help')) {
+    process.stdout.write(`${DIGEST_HELP}\n`);
+    return 0;
+  }
+
+  let projectArg: string | undefined;
+  let hostArg: string | undefined;
+  let sinceRaw: string | undefined;
+  let messageLimitRaw: string | undefined;
+  let charsRaw: string | undefined;
+  let json = false;
+  let all = false;
+  try {
+    projectArg = takeFlagValue(rest, ['--project']);
+    hostArg = takeFlagValue(rest, ['--host']);
+    sinceRaw = takeFlagValue(rest, ['--since']);
+    messageLimitRaw = takeFlagValue(rest, ['--messages', '--limit', '-n']);
+    charsRaw = takeFlagValue(rest, ['--chars']);
+    json = takeFlagBool(rest, ['--json']);
+    all = takeFlagBool(rest, ['--all']);
+  } catch (err) {
+    process.stderr.write(`${status.err((err as Error).message)}\n`);
+    return 2;
+  }
+  const positional = rest.filter((a) => !a.startsWith('-'));
+  if (positional.length > 0) {
+    process.stderr.write(`${status.err('sessions digest does not take positional arguments.')}\n`);
+    return 2;
+  }
+
+  const messageLimit = messageLimitRaw === undefined ? 40 : Number(messageLimitRaw);
+  if (!Number.isInteger(messageLimit) || messageLimit <= 0 || messageLimit > 500) {
+    process.stderr.write(`${status.err(`Invalid --messages "${messageLimitRaw}" (use 1-500).`)}\n`);
+    return 2;
+  }
+  const maxChars = charsRaw === undefined ? 700 : Number(charsRaw);
+  if (!Number.isInteger(maxChars) || maxChars < 80 || maxChars > 5000) {
+    process.stderr.write(`${status.err(`Invalid --chars "${charsRaw}" (use 80-5000).`)}\n`);
+    return 2;
+  }
+  const since = all ? null : parseSince(sinceRaw ?? '7d');
+  if (!all && !since) {
+    process.stderr.write(`${status.err(`Could not parse --since "${sinceRaw}".`)}\n`);
+    return 2;
+  }
+
+  const opts: CtxOpts = { projectArg, hostArg };
+  const ctx = resolveProjectContext(opts);
+  if (!ctx) return 1;
+
+  let sessions: ProjectSession[];
+  try {
+    sessions = await ctx.client.get<ProjectSession[]>(
+      `/projects/${ctx.projectId}/sessions`,
+    );
+  } catch (err) {
+    return surfaceApiError(err);
+  }
+
+  const filtered = sessions
+    .filter((s) => all || isInWindow(s, since!))
+    .sort((a, b) => Date.parse(b.updated_at) - Date.parse(a.updated_at));
+
+  const digests = new Map<string, SessionDigest>();
+  await mapLimit(filtered, 6, async (s) => {
+    digests.set(
+      s.session_id,
+      await buildDigest(s, ctx.client, ctx.projectId, messageLimit, maxChars),
+    );
+  });
+  const out = filtered.map((s) => digests.get(s.session_id)!).filter(Boolean);
+
+  if (json) {
+    emitJson({
+      since: since ? since.toISOString() : null,
+      all,
+      messages_per_session: messageLimit,
+      chars_per_message: maxChars,
+      sessions: out,
+    });
+    return 0;
+  }
+
+  printHumanDigest(out, {
+    since,
+    all,
+    messageLimit,
+    maxChars,
+  });
+  return 0;
+}
+
+async function buildDigest(
+  s: ProjectSession,
+  client: ApiClient,
+  projectId: string,
+  messageLimit: number,
+  maxChars: number,
+): Promise<SessionDigest> {
+  const base = baseDigest(s);
+  if (s.status !== 'running') {
+    base.transcript.reason = `session is ${s.status}; live transcript requires a running sandbox`;
+    return base;
+  }
+  try {
+    const transcript = await client.get<unknown>(
+      `/projects/${projectId}/sessions/${s.session_id}/transcript?limit=${messageLimit}&chars=${maxChars}`,
+    );
+    base.transcript = sanitizeTranscript(transcript, s.opencode_session_id);
+    return base;
+  } catch (err) {
+    base.transcript.reason = `could not read session transcript: ${(err as Error).message}`;
+    return base;
+  }
+}
+
+function sanitizeTranscript(raw: unknown, fallbackOpencodeSessionId: string | null): SessionDigest['transcript'] {
+  const obj = typeof raw === 'object' && raw ? raw as Record<string, unknown> : {};
+  const messages = Array.isArray(obj.messages)
+    ? obj.messages.map(sanitizeCompactMessage)
+    : [];
+  const count = typeof obj.message_count === 'number' && Number.isFinite(obj.message_count)
+    ? obj.message_count
+    : messages.length;
+  return {
+    available: obj.available === true,
+    reason: typeof obj.reason === 'string' ? obj.reason : null,
+    opencode_session_id: typeof obj.opencode_session_id === 'string'
+      ? obj.opencode_session_id
+      : fallbackOpencodeSessionId,
+    message_count: count,
+    messages,
+  };
+}
+
+function sanitizeCompactMessage(raw: unknown): CompactMessage {
+  const obj = typeof raw === 'object' && raw ? raw as Record<string, unknown> : {};
+  const tools = Array.isArray(obj.tools)
+    ? obj.tools.map((tool) => {
+        const t = typeof tool === 'object' && tool ? tool as Record<string, unknown> : {};
+        return {
+          tool: typeof t.tool === 'string' ? t.tool : 'tool',
+          status: typeof t.status === 'string' ? t.status : null,
+        };
+      })
+    : [];
+  const files = Array.isArray(obj.files)
+    ? obj.files.map((file) => {
+        const f = typeof file === 'object' && file ? file as Record<string, unknown> : {};
+        return {
+          filename: typeof f.filename === 'string' ? f.filename : null,
+          mime: typeof f.mime === 'string' ? f.mime : null,
+        };
+      })
+    : [];
+  const error = typeof obj.error === 'object' && obj.error
+    ? obj.error as { name?: string; message?: string }
+    : null;
+  return {
+    role: typeof obj.role === 'string' ? obj.role : 'unknown',
+    created: typeof obj.created === 'string' ? obj.created : null,
+    completed: typeof obj.completed === 'string' ? obj.completed : null,
+    text: typeof obj.text === 'string' ? obj.text : '',
+    tools,
+    files,
+    reasoning_omitted: obj.reasoning_omitted === true,
+    error,
+  };
+}
+
+function baseDigest(s: ProjectSession): SessionDigest {
+  return {
+    session: {
+      session_id: s.session_id,
+      name: s.name,
+      agent: s.agent_name,
+      status: s.status,
+      branch: s.branch_name,
+      base_ref: s.base_ref,
+      provider: s.sandbox_provider,
+      sandbox_url: s.sandbox_url,
+      created_at: s.created_at,
+      updated_at: s.updated_at,
+      error: s.error,
+      opencode_session_id: s.opencode_session_id,
+      opencode_titles: opencodeTitles(s),
+    },
+    transcript: {
+      available: false,
+      reason: null,
+      opencode_session_id: s.opencode_session_id,
+      message_count: 0,
+      messages: [],
+    },
+  };
+}
+
+function printHumanDigest(
+  digests: SessionDigest[],
+  opts: {
+    since: Date | null;
+    all: boolean;
+    messageLimit: number;
+    maxChars: number;
+  },
+): void {
+  const window = opts.all ? 'all listable sessions' : `sessions since ${opts.since!.toISOString()}`;
+  process.stdout.write(`\n${C.bold}Session digest${C.reset} ${C.faded}(${window}; last ${opts.messageLimit} messages/session; ${opts.maxChars} chars/message)${C.reset}\n`);
+  process.stdout.write(`${C.dim}Tool inputs/outputs are stripped; only tool names/statuses are shown.${C.reset}\n`);
+  if (digests.length === 0) {
+    process.stdout.write(`\n  ${C.dim}No sessions matched.${C.reset}\n\n`);
+    return;
+  }
+
+  const labelW = Math.max(...digests.map((d) => (d.session.name ?? shortId(d.session.session_id)).length), 4);
+  for (const d of digests) {
+    const s = d.session;
+    const label = s.name ?? shortId(s.session_id);
+    process.stdout.write(`\n${C.bold}${pad(label, labelW)}${C.reset} ${statusLabel(s.status)} ${C.faded}${shortId(s.session_id)} · agent ${s.agent} · updated ${relAge(s.updated_at)}${C.reset}\n`);
+    process.stdout.write(`  ${C.dim}branch${C.reset} ${s.branch}  ${C.dim}base${C.reset} ${s.base_ref}  ${C.dim}provider${C.reset} ${s.provider}\n`);
+    process.stdout.write(`  ${C.dim}created${C.reset} ${s.created_at}  ${C.dim}updated${C.reset} ${s.updated_at}\n`);
+    if (s.error) process.stdout.write(`  ${C.red}error${C.reset} ${s.error}\n`);
+    if (s.opencode_titles.length > 0) {
+      process.stdout.write(`  ${C.dim}opencode titles${C.reset} ${s.opencode_titles.map((t) => truncate(t, 80)).join(' | ')}\n`);
+    }
+
+    if (!d.transcript.available) {
+      process.stdout.write(`  ${C.dim}transcript${C.reset} unavailable — ${d.transcript.reason ?? 'unknown'}\n`);
+      continue;
+    }
+    if (d.transcript.messages.length === 0) {
+      process.stdout.write(`  ${C.dim}transcript${C.reset} no messages\n`);
+      continue;
+    }
+    process.stdout.write(`  ${C.dim}transcript${C.reset} ${d.transcript.message_count} compact message${d.transcript.message_count === 1 ? '' : 's'}\n`);
+    for (const m of d.transcript.messages) {
+      const who = m.role === 'assistant' ? C.cyan : C.green;
+      const at = m.created ? ` ${C.faded}${new Date(m.created).toISOString()}${C.reset}` : '';
+      const toolText = summarizeTools(m.tools);
+      const fileText = m.files.length ? ` files: ${m.files.map((f) => f.filename ?? f.mime ?? 'file').join(', ')}` : '';
+      const reasoning = m.reasoning_omitted ? ' reasoning omitted;' : '';
+      process.stdout.write(`    - ${who}${m.role}${C.reset}${at}: ${m.text || C.dim + '(no text)' + C.reset}\n`);
+      if (toolText || fileText || reasoning || m.error) {
+        const bits = [toolText ? `tools: ${toolText}` : '', fileText.trim(), reasoning.trim(), m.error ? `error: ${m.error.message ?? m.error.name ?? 'unknown'}` : '']
+          .filter(Boolean)
+          .join('; ');
+        process.stdout.write(`      ${C.dim}${bits}${C.reset}\n`);
+      }
+    }
+  }
+  process.stdout.write('\n');
+}
+
+function summarizeTools(tools: CompactToolCall[]): string {
+  if (tools.length === 0) return '';
+  const counts = new Map<string, number>();
+  for (const t of tools) {
+    const key = `${t.tool}${t.status ? `:${t.status}` : ''}`;
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+  const parts = Array.from(counts.entries()).map(([key, count]) => count > 1 ? `${key}×${count}` : key);
+  return parts.length > 12 ? `${parts.slice(0, 12).join(', ')}, … +${parts.length - 12}` : parts.join(', ');
+}
+
+function opencodeTitles(s: ProjectSession): string[] {
+  const raw = s.metadata?.opencode_sessions;
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .map((entry) => {
+      if (!entry || typeof entry !== 'object') return null;
+      const title = (entry as { title?: unknown }).title;
+      return typeof title === 'string' && title.trim() ? title.trim() : null;
+    })
+    .filter((t): t is string => Boolean(t));
+}
+
+function isInWindow(s: ProjectSession, since: Date): boolean {
+  return Date.parse(s.updated_at) >= since.getTime() || Date.parse(s.created_at) >= since.getTime();
+}
+
+export function parseSince(raw: string): Date | null {
+  const trimmed = raw.trim();
+  const rel = trimmed.match(/^(\d+(?:\.\d+)?)(m|h|d|w)$/i);
+  if (rel) {
+    const n = Number(rel[1]);
+    const unit = rel[2]!.toLowerCase();
+    const minutes = unit === 'm' ? n : unit === 'h' ? n * 60 : unit === 'd' ? n * 60 * 24 : n * 60 * 24 * 7;
+    return new Date(Date.now() - minutes * 60_000);
+  }
+  const parsed = Date.parse(trimmed);
+  return Number.isFinite(parsed) ? new Date(parsed) : null;
+}
+
+async function mapLimit<T>(items: T[], limit: number, fn: (item: T) => Promise<void>): Promise<void> {
+  let i = 0;
+  const worker = async (): Promise<void> => {
+    while (i < items.length) {
+      const idx = i;
+      i += 1;
+      await fn(items[idx]!);
+    }
+  };
+  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, () => worker()));
+}
+
+function truncate(s: string, max: number): string {
+  return s.length <= max ? s : `${s.slice(0, Math.max(0, max - 1))}…`;
+}
+
+function shortId(id: string): string {
+  return id.split('-')[0] ?? id;
+}
+
+function relAge(iso: string): string {
+  const m = Math.floor((Date.now() - new Date(iso).getTime()) / 60_000);
+  if (m < 1) return 'just now';
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  return `${Math.floor(h / 24)}d ago`;
+}
+
+function statusLabel(s: string): string {
+  switch (s) {
+    case 'running':
+      return `${C.green}${s}${C.reset}`;
+    case 'failed':
+      return `${C.red}${s}${C.reset}`;
+    case 'stopped':
+    case 'completed':
+      return `${C.faded}${s}${C.reset}`;
+    default:
+      return `${C.yellow}${s}${C.reset}`;
+  }
+}

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -9,6 +9,7 @@ import {
   takeFlagValue,
 } from '../command-helpers.ts';
 import { runSessionsChat, runSessionsLog, runSessionsStatus } from './sessions-chat.ts';
+import { runSessionsDigest } from './sessions-digest.ts';
 import { C, pad, status } from '../style.ts';
 import { sessionWebUrl } from '../web-url.ts';
 import type { ProjectSession, ProjectSummary } from '../api/types.ts';
@@ -33,6 +34,11 @@ Subcommands:
                                     (read-only) — peek at what an agent is
                                     doing without sending it anything.
                                     --limit <N>, --json. Aliases: messages.
+  digest                            Compact review of recent sessions for
+                                    reflection: metadata + compressed
+                                    transcript snippets with tool outputs
+                                    stripped. --since <7d>, --json.
+                                    Aliases: review, summary.
   info <session-id>                 Show one session. --json.
   preview <session-id> [port]       Print a clickable preview URL for a port
                                     in the session's sandbox (default 3000).
@@ -68,6 +74,10 @@ export async function runSessions(argv: string[]): Promise<number> {
   // `status` fans out live per-session reads; owns its own flag parsing.
   if (sub === 'status' || sub === 'overview' || sub === 'ps') {
     return runSessionsStatus(argv.slice(1));
+  }
+  // `digest` owns its own time-window + compaction flags.
+  if (sub === 'digest' || sub === 'review' || sub === 'summary') {
+    return runSessionsDigest(argv.slice(1));
   }
   const rest = argv.slice(1);
   const json = takeFlagBool(rest, ['--json']);

--- a/apps/cli/src/commands/ship.ts
+++ b/apps/cli/src/commands/ship.ts
@@ -7,7 +7,7 @@ import { ApiError, clientFromAuth, type ApiClient } from '../api/client.ts';
 import { isKortixProject, loadLink, saveLink, resolveProjectId } from '../project-link.ts';
 import { takeFlagValue, takeFlagBool } from '../command-helpers.ts';
 import { selectFromList } from '../tui-select.ts';
-import { confirm, promptSecret } from '../prompts.ts';
+import { confirm, prompt, promptSecret } from '../prompts.ts';
 import { loadLocalManifest, lintManifest, type EnvSpec, type LocalManifest } from '../manifest.ts';
 import { C, status } from '../style.ts';
 import { projectWebUrl } from '../web-url.ts';


### PR DESCRIPTION
## Summary
- add a project-scoped session transcript endpoint that reads OpenCode server-side and strips tool inputs/outputs
- add `kortix sessions digest` / `review` / `summary` for compact multi-session reflection output
- add CLI coverage for digest JSON and ensure project-scoped env tokens do not leak into tests

## Verification
- `pnpm --filter kortix-api typecheck`
- `pnpm --filter @kortix/cli typecheck`
- `bun test apps/cli/src/__tests__/sessions.e2e.test.ts`
- `pnpm --filter @kortix/cli cli -- sessions digest --help`