### PR TITLE
fix(projects): return 404 for missing file content paths

### DIFF
--- a/apps/api/src/__tests__/e2e-projects-contract.test.ts
+++ b/apps/api/src/__tests__/e2e-projects-contract.test.ts
@@ -342,6 +342,9 @@ mock.module('../projects/git', () => ({
   }),
   readRepoFile: async (project: ProjectRow, path: string, ref: string) => {
     readRepoFileCalls.push({ projectId: project.projectId, path, ref });
+    if (path === 'missing.txt') {
+      throw new Error("fatal: path 'missing.txt' does not exist in 'feature'");
+    }
     return `content:${path}@${ref}`;
   },
   archiveRepoSubtree: async (project: ProjectRow, ref: string, path?: string | null) => {
@@ -702,6 +705,11 @@ describe('projects API contract', () => {
       content: 'content:README.md@feature',
     });
     expect(readRepoFileCalls.at(-1)).toEqual({ projectId: PROJECT_ID, path: 'README.md', ref: 'feature' });
+
+    const missingFile = await app.request(`/v1/projects/${PROJECT_ID}/files/content?path=missing.txt&ref=feature`);
+    expect(missingFile.status).toBe(404);
+    expect(await missingFile.json()).toEqual({ error: 'File not found' });
+    expect(readRepoFileCalls.at(-1)).toEqual({ projectId: PROJECT_ID, path: 'missing.txt', ref: 'feature' });
 
     const read = await app.request(`/v1/projects/${PROJECT_ID}`);
     expect(read.status).toBe(200);

--- a/apps/api/src/projects/routes/r5.ts
+++ b/apps/api/src/projects/routes/r5.ts
@@ -14,6 +14,11 @@ import { AnyObject, CommitSchema, ProjectSchema, projectsApp } from '../lib/app'
 import { getProjectGitConnection, withProjectGitAuth } from '../lib/git';
 import { normalizeString, readBody, serializeDeploymentRow, serializeProject, serializeProjectGitConnection } from '../lib/serializers';
 
+function isMissingGitPathError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error || '');
+  return /^fatal: path '.+' does not exist in '.+'$/m.test(message);
+}
+
 projectsApp.openapi(
   createRoute({
     method: 'post',
@@ -387,8 +392,15 @@ projectsApp.openapi(
   if (!loaded) return c.json({ error: 'Not found' }, 404);
 
   const ref = c.req.query('ref') || loaded.row.defaultBranch;
-  const content = await readRepoFile(await withProjectGitAuth(loaded.row), path, ref);
-  return c.json({ path, ref, content });
+  try {
+    const content = await readRepoFile(await withProjectGitAuth(loaded.row), path, ref);
+    return c.json({ path, ref, content });
+  } catch (error) {
+    if (isMissingGitPathError(error)) {
+      return c.json({ error: 'File not found' }, 404);
+    }
+    throw error;
+  }
 },
 );
 


### PR DESCRIPTION
## Summary
- Return a 404 for expected `git show` missing-path failures in `GET /v1/projects/:projectId/files/content` instead of letting them bubble into Sentry.
- Add a regression assertion for the project files contract.

## Better Stack evidence
- API prod pattern `8d0cffbb3c105d61e03c5052bee04f6a1a4ef628a9f7270f9d79789fd8f5f7b1` (`Error` from `/app/apps/api/src/projects/git/mirror.ts:runGit`).
- Recent occurrence: `fatal: path 'postcss.config.js' does not exist in 'my-change'` on `GET /v1/projects/.../files/content`.
- Occurrence count at triage: 26 across 8 users, last seen 2026-06-19 10:00:46 UTC.

## Root cause
The file content route trusted `readRepoFile`; when users asked for a path that does not exist at the requested git ref, `git show <ref>:<path>` raised an expected git error that escaped the route and was captured as a production exception.

## Verification
- `LLM_GATEWAY_ENABLED=false PORT=8008 INTERNAL_KORTIX_ENV=dev KORTIX_BILLING_INTERNAL_ENABLED=false DATABASE_URL=postgres://postgres:postgres@localhost:54322/postgres SUPABASE_URL=http://localhost:54321 SUPABASE_SERVICE_ROLE_KEY=test API_KEY_SECRET=0123456789abcdef0123456789abcdef TUNNEL_SIGNING_SECRET=0123456789abcdef0123456789abcdef ALLOWED_SANDBOX_PROVIDERS=local_docker DOCKER_HOST=unix:///var/run/docker.sock KORTIX_URL=http://localhost:8008 FRONTEND_URL=http://localhost:3000 FREESTYLE_API_URL=http://localhost:3001 bun test src/__tests__/e2e-projects-contract.test.ts`
- `pnpm --filter kortix-api typecheck`

## Preview validation plan
After the `preview` label deploys: call `GET /v1/projects/<projectId>/files/content?path=<missing>&ref=<valid-ref>` on the preview backend and confirm it returns `404 {"error":"File not found"}` with no captured exception.
