### PR TITLE
fix(preview): retry transient env sync failures

### DIFF
--- a/apps/api/src/__tests__/e2e-preview-proxy.test.ts
+++ b/apps/api/src/__tests__/e2e-preview-proxy.test.ts
@@ -551,7 +551,7 @@ describe('Preview proxy: forwarding', () => {
     );
   });
 
-  test('fails prompt forwarding when project env sync is rejected', async () => {
+  test('returns a clean proxy error when project env sync is rejected', async () => {
     mockFetchResponses = [{ status: 401, body: '{"error":"unauthorized"}' }];
     const app = createProxyTestApp();
     const res = await app.request(`/v1/p/${TEST_SANDBOX_ID}/8000/session/ses_123/prompt_async`, {
@@ -565,9 +565,34 @@ describe('Preview proxy: forwarding', () => {
 
     expect(res.status).toBe(502);
     const body = await res.json();
-    expect(body.message).toContain('env sync failed: 401');
+    expect(body.error).toContain('env sync failed: 401');
     expect(mockFetchCalls).toHaveLength(1);
     expect(mockFetchCalls[0].url).toBe('https://preview.daytona.io/proxy-url/kortix/env');
+  });
+
+  test('retries transient project env sync failures before forwarding prompt_async', async () => {
+    mockFetchResponses = [
+      { status: 502, body: 'Bad Gateway' },
+      { status: 200, body: '{"ok":true,"changed":true,"revision":"rev"}' },
+      { status: 204, body: '' },
+    ];
+    const app = createProxyTestApp();
+    const res = await app.request(`/v1/p/${TEST_SANDBOX_ID}/8000/session/ses_123/prompt_async`, {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer test',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ parts: [{ type: 'text', text: 'hi' }] }),
+    });
+
+    expect(res.status).toBe(204);
+    expect(mockWakeCalls).toEqual([TEST_SANDBOX_ID]);
+    expect(mockFetchCalls.map((call) => call.url)).toEqual([
+      'https://preview.daytona.io/proxy-url/kortix/env',
+      'https://preview.daytona.io/proxy-url/kortix/env',
+      'https://preview.daytona.io/proxy-url/session/ses_123/prompt_async',
+    ]);
   });
 
   test('strips hop, auth, trace, and forces identity compression for forwarded request', async () => {

--- a/apps/api/src/sandbox-proxy/routes/preview.ts
+++ b/apps/api/src/sandbox-proxy/routes/preview.ts
@@ -34,6 +34,17 @@ function jsonProxyError(body: Record<string, unknown>, status: number): Response
   });
 }
 
+function errorMessage(error: unknown, fallback: string): string {
+  return error instanceof Error ? error.message : String(error || fallback);
+}
+
+function isRetryableEnvSyncFailure(message: string): boolean {
+  return (
+    /\benv sync failed: (502|503|504)\b/i.test(message) ||
+    /\b(operation timed out|timeout|aborterror)\b/i.test(message)
+  );
+}
+
 // Remove the `frame-ancestors` directive from a CSP value, preserving the rest.
 // Returns null if nothing meaningful remains (so the header can be dropped).
 function stripFrameAncestors(csp: string): string | null {
@@ -343,9 +354,17 @@ export async function forwardToSandbox(
             previewToken,
           });
         } catch (err) {
-          throw new HTTPException(502, {
-            message: (err as Error).message || 'project env sync failed',
-          });
+          const message = errorMessage(err, 'project env sync failed');
+          if (isRetryableEnvSyncFailure(message)) {
+            // Treat daemon/preview-transient env-sync failures like any other
+            // sandbox-port reachability miss: retry/wake in the outer loop, then
+            // return the friendly port-unreachable response if the sandbox never
+            // recovers. Throwing HTTPException here bypassed that retry path and
+            // turned expected 502/timeouts from Daytona into Better Stack errors.
+            throw new Error(message);
+          }
+          console.warn(`[PREVIEW] Project env sync failed for ${sandboxId}:${port}: ${message}`);
+          return jsonProxyError({ error: message }, 502);
         }
       }
 


### PR DESCRIPTION
## Summary
- Retry/wake transient project env sync failures (`502`/`503`/`504`/timeouts) through the preview proxy's existing sandbox reachability loop.
- Return a clean JSON proxy error for non-retryable env sync rejections instead of throwing `HTTPException` from the forwarding path.
- Add regression coverage for both clean non-retryable handling and successful retry after an env sync `502`.

## Better Stack evidence
- API prod pattern `3954fcaca290dba4593c9aa63c4d9d61d6b16dc0a2132e3c5062ae5c823e06db` (`forwardToSandbox`, `apps/api/src/sandbox-proxy/routes/preview.ts`).
- Messages in the group include `env sync failed: 502` and `The operation timed out.`
- Occurrence count at triage: 165 across 12 users, last seen 2026-06-20 18:39:04 UTC.
- Recent raw occurrence: `POST /v1/p/<sandbox>/8000/session/<session>/prompt_async` failed before prompt forwarding because `/kortix/env` returned `502`.

## Root cause
`syncSandboxEnvForPrompt` errors were converted to `HTTPException(502)` inside `forwardToSandbox`. That bypassed the preview proxy's existing retry/wake/unreachable handling and caused transient Daytona daemon/port readiness failures to be captured as application exceptions.

## Fix
Retryable env sync failures are now ordinary retry-loop errors, so the proxy retries/wakes and, if still unreachable, returns the existing friendly port-unreachable response without emitting a handled exception. Non-retryable rejections (for example 401 from the daemon) return a clean 502 JSON proxy error without throwing.

## Verification
- `LLM_GATEWAY_ENABLED=false PORT=8008 INTERNAL_KORTIX_ENV=dev KORTIX_BILLING_INTERNAL_ENABLED=false DATABASE_URL=postgres://postgres:postgres@localhost:54322/postgres SUPABASE_URL=http://localhost:54321 SUPABASE_SERVICE_ROLE_KEY=test API_KEY_SECRET=0123456789abcdef0123456789abcdef TUNNEL_SIGNING_SECRET=0123456789abcdef0123456789abcdef ALLOWED_SANDBOX_PROVIDERS=local_docker DOCKER_HOST=unix:///var/run/docker.sock KORTIX_URL=http://localhost:8008 FRONTEND_URL=http://localhost:3000 FREESTYLE_API_URL=http://localhost:3001 bun test src/__tests__/e2e-preview-proxy.test.ts`
- `pnpm --filter kortix-api typecheck`

## Preview validation plan
After the `preview` label deploys: verify `https://pr-<PR>.preview-api.kortix.com/v1/health` reports `environment=preview`. The regression test exercises the authenticated prompt proxy path with a transient `/kortix/env` 502 followed by a successful retry.
