### PR TITLE
review: retry fetch-level env sync failures

### DIFF
--- a/apps/api/src/__tests__/e2e-preview-proxy.test.ts
+++ b/apps/api/src/__tests__/e2e-preview-proxy.test.ts
@@ -39,7 +39,12 @@ let mockDbMembership: any = { accountRole: 'member' };
 let mockPreviewUrl = 'https://preview.daytona.io/proxy-url';
 let mockPreviewToken: string | null = 'daytona-preview-token-123';
 let mockWakeCalls: string[] = [];
-let mockFetchResponses: Array<{ status: number; body: string; headers?: Record<string, string> }> = [];
+let mockFetchResponses: Array<{
+  status: number;
+  body: string;
+  headers?: Record<string, string>;
+  error?: Error;
+}> = [];
 let mockFetchCallCount = 0;
 let mockFetchCalls: Array<{ url: string; method: string; headers: Record<string, string>; body: string | null }> = [];
 let mockDbUpdateCalls: Array<{ table: unknown; updates: Record<string, unknown> }> = [];
@@ -245,6 +250,10 @@ function mockFetch(url: string | URL | Request, init?: RequestInit): Promise<Res
 
   if (!responseConfig) {
     return Promise.resolve(new Response('OK', { status: 200 }));
+  }
+
+  if (responseConfig.error) {
+    return Promise.reject(responseConfig.error);
   }
 
   return Promise.resolve(
@@ -573,6 +582,35 @@ describe('Preview proxy: forwarding', () => {
   test('retries transient project env sync failures before forwarding prompt_async', async () => {
     mockFetchResponses = [
       { status: 502, body: 'Bad Gateway' },
+      { status: 200, body: '{"ok":true,"changed":true,"revision":"rev"}' },
+      { status: 204, body: '' },
+    ];
+    const app = createProxyTestApp();
+    const res = await app.request(`/v1/p/${TEST_SANDBOX_ID}/8000/session/ses_123/prompt_async`, {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer test',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ parts: [{ type: 'text', text: 'hi' }] }),
+    });
+
+    expect(res.status).toBe(204);
+    expect(mockWakeCalls).toEqual([TEST_SANDBOX_ID]);
+    expect(mockFetchCalls.map((call) => call.url)).toEqual([
+      'https://preview.daytona.io/proxy-url/kortix/env',
+      'https://preview.daytona.io/proxy-url/kortix/env',
+      'https://preview.daytona.io/proxy-url/session/ses_123/prompt_async',
+    ]);
+  });
+
+  test('retries fetch-level project env sync connection failures before forwarding prompt_async', async () => {
+    mockFetchResponses = [
+      {
+        status: 0,
+        body: '',
+        error: new Error('Unable to connect. Is the computer able to access the url?'),
+      },
       { status: 200, body: '{"ok":true,"changed":true,"revision":"rev"}' },
       { status: 204, body: '' },
     ];

--- a/apps/api/src/__tests__/e2e-preview-proxy.test.ts
+++ b/apps/api/src/__tests__/e2e-preview-proxy.test.ts
@@ -579,6 +579,26 @@ describe('Preview proxy: forwarding', () => {
     expect(mockFetchCalls[0].url).toBe('https://preview.daytona.io/proxy-url/kortix/env');
   });
 
+  test('does not retry non-transient project env sync HTTP errors that mention network failures', async () => {
+    mockFetchResponses = [{ status: 500, body: '{"error":"connection refused to metadata store"}' }];
+    const app = createProxyTestApp();
+    const res = await app.request(`/v1/p/${TEST_SANDBOX_ID}/8000/session/ses_123/prompt_async`, {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer test',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ parts: [{ type: 'text', text: 'hi' }] }),
+    });
+
+    expect(res.status).toBe(502);
+    const body = await res.json();
+    expect(body.error).toContain('env sync failed: 500');
+    expect(mockWakeCalls).toEqual([]);
+    expect(mockFetchCalls).toHaveLength(1);
+    expect(mockFetchCalls[0].url).toBe('https://preview.daytona.io/proxy-url/kortix/env');
+  });
+
   test('retries transient project env sync failures before forwarding prompt_async', async () => {
     mockFetchResponses = [
       { status: 502, body: 'Bad Gateway' },

--- a/apps/api/src/sandbox-proxy/routes/preview.ts
+++ b/apps/api/src/sandbox-proxy/routes/preview.ts
@@ -42,10 +42,12 @@ const RETRYABLE_ENV_SYNC_NETWORK_ERROR_RE =
   /\b(operation timed out|timeout|aborterror|unable to connect|connection refused|econnrefused|econnreset|socket hang up)\b/i;
 
 function isRetryableEnvSyncFailure(message: string): boolean {
-  return (
-    /\benv sync failed: (502|503|504)\b/i.test(message) ||
-    RETRYABLE_ENV_SYNC_NETWORK_ERROR_RE.test(message)
-  );
+  if (/\benv sync failed: (502|503|504)\b/i.test(message)) return true;
+  // Fetch rejections are bare network errors. HTTP failures include the daemon
+  // response body, so don't classify a non-retryable status as transient just
+  // because its JSON/body happens to mention a connection failure.
+  if (/^env sync failed:/i.test(message)) return false;
+  return RETRYABLE_ENV_SYNC_NETWORK_ERROR_RE.test(message);
 }
 
 // Remove the `frame-ancestors` directive from a CSP value, preserving the rest.

--- a/apps/api/src/sandbox-proxy/routes/preview.ts
+++ b/apps/api/src/sandbox-proxy/routes/preview.ts
@@ -38,10 +38,13 @@ function errorMessage(error: unknown, fallback: string): string {
   return error instanceof Error ? error.message : String(error || fallback);
 }
 
+const RETRYABLE_ENV_SYNC_NETWORK_ERROR_RE =
+  /\b(operation timed out|timeout|aborterror|unable to connect|connection refused|econnrefused|econnreset|socket hang up)\b/i;
+
 function isRetryableEnvSyncFailure(message: string): boolean {
   return (
     /\benv sync failed: (502|503|504)\b/i.test(message) ||
-    /\b(operation timed out|timeout|aborterror)\b/i.test(message)
+    RETRYABLE_ENV_SYNC_NETWORK_ERROR_RE.test(message)
   );
 }
 


### PR DESCRIPTION
Follow-up from the PR #3538 review.

PR #3538 handled HTTP 502/503/504 env-sync responses, but Bun fetch-level connection failures (for example `Unable to connect. Is the computer able to access the url?`) still returned an immediate 502 instead of using the preview proxy wake/retry path. This keeps the same retry behavior for that concrete transient daemon reachability case and adds coverage.

Verified locally:
- `pnpm --filter kortix-api typecheck`
- `pnpm --filter kortix-api exec bun test src/__tests__/e2e-preview-proxy.test.ts`
