### PR TITLE
fix(web): restore dev frontend SSR i18n config

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -3,6 +3,7 @@ import { withSentryConfig } from '@sentry/nextjs';
 import fs from 'fs';
 import { createMDX } from 'fumadocs-mdx/next';
 import type { NextConfig } from 'next';
+import createNextIntlPlugin from 'next-intl/plugin';
 import path from 'path';
 
 // Unified platform version. Prefer the explicit build env (CI passes
@@ -251,9 +252,10 @@ const nextConfig = (): NextConfig => ({
 });
 
 const withMDX = createMDX();
+const withNextIntl = createNextIntlPlugin('./src/i18n/request.ts');
 
-// Compose config wrappers: MDX → Better Stack (structured logs) → Sentry (error tracking)
-export default withSentryConfig(withBetterStack(withMDX(nextConfig())), {
+// Compose config wrappers: next-intl → MDX → Better Stack (structured logs) → Sentry (error tracking)
+export default withSentryConfig(withBetterStack(withMDX(withNextIntl(nextConfig()))), {
   // Suppresses source map uploading logs during build
   silent: true,
 

--- a/apps/web/src/app/(public)/(marketing)/pricing/page.tsx
+++ b/apps/web/src/app/(public)/(marketing)/pricing/page.tsx
@@ -160,7 +160,7 @@ export default function PricingPage() {
             {tI18nHardcoded.raw('autoAppPublicMarketingPricingPageJsxTextSimplePerSeat194cf521')}
           </h1>
           <p className="text-muted-foreground mx-auto mt-4 max-w-2xl text-lg text-balance">
-            {tI18nHardcoded.raw('autoAppPublicMarketingPricingPageJsxTextEverySeatGets907db6fe')}
+            {tI18nHardcoded.raw('autoAppPublicMarketingPricingPageJsxTextEverySeatGets58d131e8')}
           </p>
         </div>
 

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -364,41 +364,41 @@ export default async function RootLayout({ children }: Readonly<{ children: Reac
           disableTransitionOnChange
         >
           <TooltipProvider delayDuration={300}>
-            <BrowserNoiseGuard />
-            <DesktopChrome />
-            <DesktopUrlPrompt />
             <AuthProvider>
               <I18nProvider>
+                <BrowserNoiseGuard />
+                <DesktopChrome />
+                <DesktopUrlPrompt />
                 <ReactQueryProvider>
                   <Toaster />
                   {children}
                 </ReactQueryProvider>
+                {/* Analytics - lazy loaded to not block FCP */}
+                <Suspense fallback={null}>
+                  <Analytics />
+                </Suspense>
+                {process.env.NEXT_PUBLIC_GTM_ID && !isDesktopApp && (
+                  <Suspense fallback={null}>
+                    <GoogleTagManager gtmId={process.env.NEXT_PUBLIC_GTM_ID} />
+                  </Suspense>
+                )}
+                <Suspense fallback={null}>
+                  <SpeedInsights />
+                </Suspense>
+                <Suspense fallback={null}>
+                  <PostHogIdentify />
+                </Suspense>
+                <Suspense fallback={null}>
+                  <RouteChangeTracker />
+                </Suspense>
+                <Suspense fallback={null}>
+                  <AuthEventTracker />
+                </Suspense>
+                <Suspense fallback={null}>
+                  <LocalhostLinkInterceptor />
+                </Suspense>
               </I18nProvider>
             </AuthProvider>
-            {/* Analytics - lazy loaded to not block FCP */}
-            <Suspense fallback={null}>
-              <Analytics />
-            </Suspense>
-            {process.env.NEXT_PUBLIC_GTM_ID && !isDesktopApp && (
-              <Suspense fallback={null}>
-                <GoogleTagManager gtmId={process.env.NEXT_PUBLIC_GTM_ID} />
-              </Suspense>
-            )}
-            <Suspense fallback={null}>
-              <SpeedInsights />
-            </Suspense>
-            <Suspense fallback={null}>
-              <PostHogIdentify />
-            </Suspense>
-            <Suspense fallback={null}>
-              <RouteChangeTracker />
-            </Suspense>
-            <Suspense fallback={null}>
-              <AuthEventTracker />
-            </Suspense>
-            <Suspense fallback={null}>
-              <LocalhostLinkInterceptor />
-            </Suspense>
           </TooltipProvider>
         </ThemeProvider>
       </body>

--- a/apps/web/src/features/marketing/why-kortix.tsx
+++ b/apps/web/src/features/marketing/why-kortix.tsx
@@ -19,7 +19,7 @@ function useRows(): WhyRow[] {
       body: (
         <>
           <p>
-            {tI18nHardcoded.raw('autoFeaturesMarketingWhyKortixJsxTextWithMostToolsYoue0092085')}
+            {tI18nHardcoded.raw('autoFeaturesMarketingWhyKortixJsxTextWithMostToolsYou4b74710a')}
           </p>
           <p>
             <strong>
@@ -38,7 +38,7 @@ function useRows(): WhyRow[] {
       body: (
         <>
           <p>
-            {tI18nHardcoded.raw('autoFeaturesMarketingWhyKortixJsxTextEveryAIAgentYou1a240225')}
+            {tI18nHardcoded.raw('autoFeaturesMarketingWhyKortixJsxTextEveryAIAgentYou7f5d6f06')}
           </p>
           <p>
             {tI18nHardcoded.raw(
@@ -58,7 +58,7 @@ function useRows(): WhyRow[] {
       body: (
         <>
           <p>
-            {tI18nHardcoded.raw('autoFeaturesMarketingWhyKortixJsxTextKortixIsOpenSourcecda1bf14')}
+            {tI18nHardcoded.raw('autoFeaturesMarketingWhyKortixJsxTextKortixIsOpenSource5afa4f64')}
           </p>
           <p>
             {tI18nHardcoded.raw('autoFeaturesMarketingWhyKortixJsxTextYourDataStaysWhere3c5e3923')}
@@ -78,7 +78,7 @@ function useRows(): WhyRow[] {
       body: (
         <>
           <p>
-            {tI18nHardcoded.raw('autoFeaturesMarketingWhyKortixJsxTextYouShouldnTNeed1c26921a')}
+            {tI18nHardcoded.raw('autoFeaturesMarketingWhyKortixJsxTextYouShouldnTNeedae8350b9')}
           </p>
           <p>
             {tI18nHardcoded.raw(


### PR DESCRIPTION
## Incident

Better Stack Uptime incident 980788908: Dev Frontend (`GET https://dev.kortix.com`) returned HTTP 500 starting 2026-06-21 01:26:19 UTC.

## Root cause

Commit `44f0f4800` moved many web surfaces onto `next-intl` server/client translation hooks, but the Next.js app config did not register the `next-intl` plugin/request config. In production SSR this throws `Couldn’t find next-intl config file`, causing the root layout/global error path to return 500 for public routes.

A second follow-on issue surfaced during local verification: global components rendered outside `I18nProvider` used `useTranslations`, producing `NextIntlClientProvider was not found` once the plugin was wired.

## Fix

- Wire `createNextIntlPlugin('./src/i18n/request.ts')` into `apps/web/next.config.ts`.
- Move root layout global client components/analytics under `I18nProvider` so `useTranslations` always has context.
- Correct stale generated translation key references in marketing/pricing surfaces that logged `MISSING_MESSAGE` during verification.

## Verification

- `pnpm --filter Kortix-Computer-Frontend exec eslint src/app/layout.tsx 'src/app/(public)/(marketing)/pricing/page.tsx' src/features/marketing/why-kortix.tsx next.config.ts`
- `pnpm i18n:explicit-language`
- `pnpm i18n:translations`
- Local dev verification with dev runtime config: `GET /`, `GET /auth`, `GET /pricing` all returned HTTP 200 after the patch.
- `next build` compiled and generated all static pages with the patch; the sandbox OOM-killed the final standalone trace phase (exit 137), so CI/Vercel remains the authoritative full production build.
