### PR TITLE
fix(sandbox): bulletproof idle auto-stop + deterministic compute billing + reimbursement

### DIFF
--- a/apps/api/src/__tests__/e2e-project-maintenance.test.ts
+++ b/apps/api/src/__tests__/e2e-project-maintenance.test.ts
@@ -9,6 +9,14 @@ let branchDeletes: string[] = [];
 let updateCalls: Array<{ table: unknown; updates: Record<string, unknown> }> = [];
 let providerStopError: Error | null = null;
 
+mock.module('../config', () => ({
+  config: { KORTIX_SANDBOX_AUTOSTOP_MINUTES: 15 },
+  SANDBOX_VERSION: 'test',
+  KORTIX_MARKUP: 1,
+  PLATFORM_FEE_MARKUP: 0,
+  getToolCost: () => 0,
+}));
+
 mock.module('../shared/db', () => ({
   hasDatabase: true,
   db: {
@@ -88,6 +96,19 @@ mock.module('../projects/git', () => ({
   getMergeBase: async () => 'a'.repeat(40),
   diffStat: async () => ({ files: [], additions: 0, deletions: 0 }),
   invalidateProjectMirror: () => {},
+}));
+
+mock.module('../projects/sandbox-reaper', () => ({
+  reapAndReconcileSandboxes: async () => ({
+    candidates: 0,
+    stopped: 0,
+    reconciled: 0,
+    billingClosed: 0,
+    skipped: 0,
+    errors: 0,
+  }),
+  reconcileOrphanComputeSessions: async () => ({ checked: 0, closed: 0, errors: 0 }),
+  countBillingInvariantViolations: async () => 0,
 }));
 
 const {

--- a/apps/api/src/__tests__/e2e-project-maintenance.test.ts
+++ b/apps/api/src/__tests__/e2e-project-maintenance.test.ts
@@ -92,7 +92,6 @@ mock.module('../projects/git', () => ({
 
 const {
   hasOpenPullRequestMarker,
-  hibernateIdleSessionSandboxes,
   postgresTimestampParam,
   sweepExpiredSessionBranches,
 } = await import('../projects/maintenance');
@@ -120,82 +119,6 @@ describe('project maintenance', () => {
   test('formats raw SQL timestamp parameters as strings', () => {
     expect(postgresTimestampParam(new Date('2026-05-15T21:08:13.000Z')))
       .toBe('2026-05-15T21:08:13.000Z');
-  });
-
-  test('hibernates idle Daytona sandboxes and skips local Docker', async () => {
-    sandboxCandidates = [
-      {
-        sandboxId: '00000000-0000-4000-a000-000000000001',
-        sessionId: 'session-daytona',
-        accountId: '00000000-0000-4000-a000-000000000101',
-        provider: 'daytona',
-        externalId: 'daytona-external-1',
-      },
-      {
-        sandboxId: '00000000-0000-4000-a000-000000000002',
-        sessionId: 'session-local',
-        accountId: '00000000-0000-4000-a000-000000000101',
-        provider: 'local_docker',
-        externalId: 'local-external-1',
-      },
-    ];
-
-    const result = await hibernateIdleSessionSandboxes(new Date('2026-05-15T00:00:00Z'));
-
-    expect(result).toEqual({ candidates: 2, stopped: 1, skipped: 1, errors: 0 });
-    expect(providerStops).toEqual(['daytona-external-1']);
-    expect(cacheInvalidations).toEqual(['daytona-external-1']);
-    expect(updateCalls.some((call) =>
-      call.table === sessionSandboxes && call.updates.status === 'stopped',
-    )).toBe(true);
-    expect(updateCalls.some((call) =>
-      call.table === projectSessions && call.updates.status === 'stopped',
-    )).toBe(true);
-  });
-
-  test('reconciles Daytona sandboxes that are already stopped remotely', async () => {
-    sandboxCandidates = [
-      {
-        sandboxId: '00000000-0000-4000-a000-000000000003',
-        sessionId: 'session-daytona-stale',
-        accountId: '00000000-0000-4000-a000-000000000101',
-        provider: 'daytona',
-        externalId: 'daytona-external-stopped',
-      },
-    ];
-    providerStopError = new Error('Sandbox is not started');
-
-    const result = await hibernateIdleSessionSandboxes(new Date('2026-05-15T00:00:00Z'));
-
-    expect(result).toEqual({ candidates: 1, stopped: 1, skipped: 0, errors: 0 });
-    expect(providerStops).toEqual(['daytona-external-stopped']);
-    expect(cacheInvalidations).toEqual(['daytona-external-stopped']);
-    expect(updateCalls.some((call) =>
-      call.table === sessionSandboxes && call.updates.status === 'stopped',
-    )).toBe(true);
-    expect(updateCalls.some((call) =>
-      call.table === projectSessions && call.updates.status === 'stopped',
-    )).toBe(true);
-  });
-
-  test('skips Daytona sandboxes that are already transitioning', async () => {
-    sandboxCandidates = [
-      {
-        sandboxId: '00000000-0000-4000-a000-000000000004',
-        sessionId: 'session-daytona-transitioning',
-        accountId: '00000000-0000-4000-a000-000000000101',
-        provider: 'daytona',
-        externalId: 'daytona-external-transitioning',
-      },
-    ];
-    providerStopError = new Error('Sandbox state change in progress');
-
-    const result = await hibernateIdleSessionSandboxes(new Date('2026-05-15T00:00:00Z'));
-
-    expect(result).toEqual({ candidates: 1, stopped: 0, skipped: 1, errors: 0 });
-    expect(providerStops).toEqual(['daytona-external-transitioning']);
-    expect(cacheInvalidations).toEqual([]);
-    expect(updateCalls).toEqual([]);
   });
 
   test('deletes expired session branches and records branch GC metadata', async () => {

--- a/apps/api/src/billing/routes/webhooks.ts
+++ b/apps/api/src/billing/routes/webhooks.ts
@@ -1,6 +1,7 @@
 import { createRoute, z } from '@hono/zod-openapi';
 import { config } from '../../config';
 import { processStripeWebhook, processRevenueCatWebhook } from '../services/webhooks';
+import { handleDaytonaWebhook, handlePlatinumWebhook } from '../../platform/webhooks/sandbox-webhooks';
 import { makeOpenApiApp, json, errors } from '../../openapi';
 
 export const webhooksRouter = makeOpenApiApp();
@@ -55,5 +56,44 @@ webhooksRouter.openapi(
     const body = await c.req.json();
     const result = await processRevenueCatWebhook(body);
     return c.json(result);
+  },
+);
+
+// Provider sandbox-lifecycle webhooks — deterministic billing close (the reaper
+// sweep is the backstop). Raw body is required for signature verification, so no
+// JSON body schema is declared. Inert (503) until the matching secret is set.
+webhooksRouter.openapi(
+  createRoute({
+    method: 'post',
+    path: '/daytona',
+    tags: ['billing'],
+    summary: 'Daytona sandbox lifecycle webhook (Svix-signed, public)',
+    responses: {
+      200: json(z.record(z.string(), z.any()), 'Webhook processing result'),
+      ...errors(400, 401, 503),
+    },
+  }),
+  async (c: any) => {
+    const rawBody = await c.req.text();
+    const { status, body } = await handleDaytonaWebhook(rawBody, (h: string) => c.req.header(h));
+    return c.json(body, status);
+  },
+);
+
+webhooksRouter.openapi(
+  createRoute({
+    method: 'post',
+    path: '/platinum',
+    tags: ['billing'],
+    summary: 'Platinum sandbox lifecycle webhook (HMAC-SHA-256, public)',
+    responses: {
+      200: json(z.record(z.string(), z.any()), 'Webhook processing result'),
+      ...errors(400, 401, 503),
+    },
+  }),
+  async (c: any) => {
+    const rawBody = await c.req.text();
+    const { status, body } = await handlePlatinumWebhook(rawBody, (h: string) => c.req.header(h));
+    return c.json(body, status);
   },
 );

--- a/apps/api/src/billing/routes/webhooks.ts
+++ b/apps/api/src/billing/routes/webhooks.ts
@@ -1,7 +1,6 @@
 import { createRoute, z } from '@hono/zod-openapi';
 import { config } from '../../config';
 import { processStripeWebhook, processRevenueCatWebhook } from '../services/webhooks';
-import { handleDaytonaWebhook, handlePlatinumWebhook } from '../../platform/webhooks/sandbox-webhooks';
 import { makeOpenApiApp, json, errors } from '../../openapi';
 
 export const webhooksRouter = makeOpenApiApp();
@@ -59,41 +58,5 @@ webhooksRouter.openapi(
   },
 );
 
-// Provider sandbox-lifecycle webhooks — deterministic billing close (the reaper
-// sweep is the backstop). Raw body is required for signature verification, so no
-// JSON body schema is declared. Inert (503) until the matching secret is set.
-webhooksRouter.openapi(
-  createRoute({
-    method: 'post',
-    path: '/daytona',
-    tags: ['billing'],
-    summary: 'Daytona sandbox lifecycle webhook (Svix-signed, public)',
-    responses: {
-      200: json(z.record(z.string(), z.any()), 'Webhook processing result'),
-      ...errors(400, 401, 503),
-    },
-  }),
-  async (c: any) => {
-    const rawBody = await c.req.text();
-    const { status, body } = await handleDaytonaWebhook(rawBody, (h: string) => c.req.header(h));
-    return c.json(body, status);
-  },
-);
-
-webhooksRouter.openapi(
-  createRoute({
-    method: 'post',
-    path: '/platinum',
-    tags: ['billing'],
-    summary: 'Platinum sandbox lifecycle webhook (HMAC-SHA-256, public)',
-    responses: {
-      200: json(z.record(z.string(), z.any()), 'Webhook processing result'),
-      ...errors(400, 401, 503),
-    },
-  }),
-  async (c: any) => {
-    const rawBody = await c.req.text();
-    const { status, body } = await handlePlatinumWebhook(rawBody, (h: string) => c.req.header(h));
-    return c.json(body, status);
-  },
-);
+// Sandbox lifecycle webhooks (Daytona/Platinum) live at /v1/webhooks/sandbox/*
+// (platform/webhooks/routes.ts) — they're provider state events, not billing.

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -230,6 +230,10 @@ const envSchema = z.object({
   DAYTONA_API_KEY:             optStr,
   DAYTONA_SERVER_URL:          optStr,
   DAYTONA_TARGET:              optStr,
+  // Org-level Daytona webhook signing secret (Svix `whsec_…`). When set, the
+  // /v1/billing/webhooks/daytona endpoint closes compute billing the instant a
+  // box stops; the reaper sweep is the backstop, so this is optional.
+  DAYTONA_WEBHOOK_SECRET:      optStr,
 
   // ── Daytona warm snapshots (experimental memory/process snapshots) ─────────
   // Off by default. When KORTIX_WARM_SNAPSHOT_ENABLED is true AND
@@ -265,6 +269,9 @@ const envSchema = z.object({
   PLATINUM_API_KEY:            optStr,
   PLATINUM_API_URL:            optStr,
   PLATINUM_TEMPLATE:           optStr,
+  // Per-webhook HMAC-SHA-256 secret from Platinum's `POST /v1/webhooks` (shown
+  // once at registration). Optional — same backstop story as Daytona's.
+  PLATINUM_WEBHOOK_SECRET:     optStr,
 
   // ── Sandbox Platform ──────────────────────────────────────────────────────
   // Public API base URL, without a route suffix. Auto-derived from PORT in local mode.
@@ -596,6 +603,7 @@ export const config = {
   DAYTONA_API_KEY: env.DAYTONA_API_KEY,
   DAYTONA_SERVER_URL: env.DAYTONA_SERVER_URL,
   DAYTONA_TARGET: env.DAYTONA_TARGET,
+  DAYTONA_WEBHOOK_SECRET: env.DAYTONA_WEBHOOK_SECRET,
   KORTIX_WARM_SNAPSHOT_ENABLED: env.KORTIX_WARM_SNAPSHOT_ENABLED,
   DAYTONA_WARM_TARGET: env.DAYTONA_WARM_TARGET,
   DAYTONA_WARM_BASE_SNAPSHOT: env.DAYTONA_WARM_BASE_SNAPSHOT,
@@ -610,6 +618,7 @@ export const config = {
   PLATINUM_API_KEY: env.PLATINUM_API_KEY,
   PLATINUM_API_URL: env.PLATINUM_API_URL,
   PLATINUM_TEMPLATE: env.PLATINUM_TEMPLATE,
+  PLATINUM_WEBHOOK_SECRET: env.PLATINUM_WEBHOOK_SECRET,
 
   // ─── Sandbox Provisioning (Platform) ──────────────────────────────────────
   KORTIX_URL: env.KORTIX_URL,

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -758,6 +758,9 @@ app.route('/v1/webhooks/slack/oauth', slackOauthApp); // /v1/webhooks/slack/oaut
 app.route('/v1/webhooks/slack', slackWebhookApp); // /v1/webhooks/slack/:projectId — raw Slack events (BYO mode)
 app.route('/v1/webhooks/telegram', telegramWebhookApp); // /v1/webhooks/telegram/:projectId — Telegram updates
 
+const { sandboxWebhooksApp } = await import('./platform/webhooks/routes');
+app.route('/v1/webhooks/sandbox', sandboxWebhooksApp); // /v1/webhooks/sandbox/{daytona,platinum} — provider lifecycle → close billing
+
 // Access control — public endpoints for signup gating
 app.route('/v1/access', accessControlApp); // /v1/access/signup-status, /v1/access/check-email, /v1/access/request-access
 

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -671,7 +671,16 @@ app.route('/v1/router', router);        // /v1/router/chat/completions, /v1/rout
           // so the managed gateway works for self-hosted / billing-off deploys.
           const acct = await validateAccountToken(token);
           if (acct.isValid && acct.userId && acct.accountId) {
-            return { userId: acct.userId, accountId: acct.accountId };
+            // projectId/sessionId attribute LLM usage to the calling session
+            // (sandbox executor token is minted per-session with session_id =
+            // sandbox_id) — the reaper's reliable activity signal + precise
+            // per-session billing.
+            return {
+              userId: acct.userId,
+              accountId: acct.accountId,
+              projectId: acct.projectId ?? null,
+              sessionId: acct.sessionId ?? null,
+            };
           }
           return null;
         },
@@ -683,6 +692,8 @@ app.route('/v1/router', router);        // /v1/router/chat/completions, /v1/rout
           const usageEventId = await recordUsageEvent({
             accountId: event.accountId,
             actorUserId: event.actorUserId,
+            projectId: event.projectId ?? null,
+            sessionId: event.sessionId ?? null,
             provider: event.provider,
             model: event.model,
             route: '/v1/llm/chat/completions',

--- a/apps/api/src/llm-gateway/routes/chat-completions.ts
+++ b/apps/api/src/llm-gateway/routes/chat-completions.ts
@@ -150,6 +150,8 @@ export function createChatCompletionsRoute(
       const event: UsageEvent = {
         accountId: principal.accountId,
         actorUserId: principal.userId,
+        projectId: principal.projectId ?? null,
+        sessionId: principal.sessionId ?? null,
         provider: 'openrouter',
         model,
         promptTokens: usage.promptTokens,

--- a/apps/api/src/llm-gateway/types.ts
+++ b/apps/api/src/llm-gateway/types.ts
@@ -1,11 +1,18 @@
 interface AuthedPrincipal {
   userId: string;
   accountId: string;
+  /** Project + session the calling token is scoped to (sandbox executor token),
+   *  so usage is attributed per-session — the reaper's reliable activity signal
+   *  and precise billing attribution. Null for legacy/non-session tokens. */
+  projectId?: string | null;
+  sessionId?: string | null;
 }
 
 export interface UsageEvent {
   accountId: string;
   actorUserId: string;
+  projectId?: string | null;
+  sessionId?: string | null;
   provider: string;
   model: string;
   promptTokens: number;

--- a/apps/api/src/platform/services/session-sandbox.ts
+++ b/apps/api/src/platform/services/session-sandbox.ts
@@ -373,15 +373,17 @@ export async function provisionSessionSandbox(opts: {
           }
         : {}),
     },
-    // Session sandboxes auto-stop on idle at the PROVIDER level (Platinum
-    // enforces auto_stop_minutes; the in-repo hibernate sweep is never
-    // scheduled, which left session VMs running for days — caught live
-    // 2026-06-10). Stopped sandboxes keep their disk and wake automatically
-    // on inbound preview traffic, so the UX cost is one ~2s resume after an
-    // idle gap. Warm-pool boxes (legacy; pool is disabled) opt out.
-    ...(opts.poolState
-      ? { autoStopInterval: 0 }
-      : { autoStopInterval: Math.max(0, Number(process.env.KORTIX_SANDBOX_AUTO_STOP_MIN ?? 30) || 0) }),
+    // Idle lifecycle is owned by the provider-agnostic reaper (projects/
+    // sandbox-reaper.ts), keyed off MEANINGFUL activity (real turns), with each
+    // provider's native auto-stop as a secondary backstop. We pass NO explicit
+    // autoStopInterval for a normal session so each provider applies its own
+    // policy via daytonaLifecycle(): Daytona → KORTIX_SANDBOX_AUTOSTOP_MINUTES
+    // (default 15); Platinum → persistent (autoStop=0) because its stop→resume
+    // is broken (CH resume-freeze) — the reaper stops idle Platinum boxes and
+    // flags reprovision-on-open instead. (The old divergent KORTIX_SANDBOX_AUTO_
+    // STOP_MIN env, default 30, also wrongly made Platinum ephemeral — removed.)
+    // Warm-pool spares (legacy; pool disabled) stay persistent until claimed.
+    ...(opts.poolState ? { autoStopInterval: 0 } : {}),
   };
 
   // Detach the actual provisioning — the API caller navigates immediately

--- a/apps/api/src/platform/services/session-sandbox.ts
+++ b/apps/api/src/platform/services/session-sandbox.ts
@@ -120,6 +120,9 @@ async function mintExecutorToken(opts: {
       accountId: opts.accountId,
       userId: opts.userId,
       projectId: opts.projectId,
+      // session_id == sandbox_id by construction — lets the LLM gateway attribute
+      // usage_events to this session (the reaper's reliable activity signal).
+      sessionId: opts.sandboxId,
       name: `Executor Session ${opts.sandboxId.slice(0, 8)}`,
       agentGrant,
     });

--- a/apps/api/src/platform/webhooks/routes.ts
+++ b/apps/api/src/platform/webhooks/routes.ts
@@ -1,0 +1,57 @@
+import { createRoute, z } from '@hono/zod-openapi';
+import { makeOpenApiApp, json, errors } from '../../openapi';
+import { handleDaytonaWebhook, handlePlatinumWebhook } from './sandbox-webhooks';
+
+/**
+ * Sandbox lifecycle webhook ingress (NOT billing — these are provider state
+ * events that we use to close compute billing + reconcile DB state the instant a
+ * box stops). Mounted at /v1/webhooks/sandbox so the path says what it is.
+ *
+ * This is the FAST path of a deliberate two-tier strategy:
+ *   1. webhook (here) — closes billing the moment the provider reports a stop;
+ *   2. the reaper sweep (projects/sandbox-reaper.ts) — polls the provider's real
+ *      state every maintenance cycle and reconciles/closes anything the webhook
+ *      missed. The sweep needs ZERO per-environment config, so local/dev/preview
+ *      are fully correct on the reaper alone; webhooks are a prod latency win,
+ *      never a correctness dependency.
+ *
+ * Raw body is required for signature verification, so no JSON body schema is
+ * declared. Inert (503) until the matching secret is configured.
+ */
+export const sandboxWebhooksApp = makeOpenApiApp();
+
+sandboxWebhooksApp.openapi(
+  createRoute({
+    method: 'post',
+    path: '/daytona',
+    tags: ['webhooks'],
+    summary: 'Daytona sandbox lifecycle webhook (Svix-signed, public)',
+    responses: {
+      200: json(z.record(z.string(), z.any()), 'Webhook processing result'),
+      ...errors(400, 401, 503),
+    },
+  }),
+  async (c: any) => {
+    const rawBody = await c.req.text();
+    const { status, body } = await handleDaytonaWebhook(rawBody, (h: string) => c.req.header(h));
+    return c.json(body, status);
+  },
+);
+
+sandboxWebhooksApp.openapi(
+  createRoute({
+    method: 'post',
+    path: '/platinum',
+    tags: ['webhooks'],
+    summary: 'Platinum sandbox lifecycle webhook (HMAC-SHA-256, public)',
+    responses: {
+      200: json(z.record(z.string(), z.any()), 'Webhook processing result'),
+      ...errors(400, 401, 503),
+    },
+  }),
+  async (c: any) => {
+    const rawBody = await c.req.text();
+    const { status, body } = await handlePlatinumWebhook(rawBody, (h: string) => c.req.header(h));
+    return c.json(body, status);
+  },
+);

--- a/apps/api/src/platform/webhooks/sandbox-webhooks.test.ts
+++ b/apps/api/src/platform/webhooks/sandbox-webhooks.test.ts
@@ -1,0 +1,163 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import { createHmac } from 'node:crypto';
+
+const cfg: { DAYTONA_WEBHOOK_SECRET?: string; PLATINUM_WEBHOOK_SECRET?: string } = {};
+let stoppedCalls: string[] = [];
+let removedCalls: string[] = [];
+let dedupSeen: Set<string> = new Set();
+
+mock.module('../../config', () => ({ config: cfg }));
+mock.module('../../billing/services/webhook-concurrency', () => ({
+  recordWebhookEvent: async (id: string) => {
+    if (dedupSeen.has(id)) return false;
+    dedupSeen.add(id);
+    return true;
+  },
+}));
+mock.module('../../projects/sandbox-reaper', () => ({
+  reconcileSandboxStoppedByExternalId: async (externalId: string) => {
+    stoppedCalls.push(externalId);
+    return true;
+  },
+  reconcileSandboxRemovedByExternalId: async (externalId: string) => {
+    removedCalls.push(externalId);
+    return true;
+  },
+}));
+
+const {
+  classifyLifecycle,
+  verifyHmacSha256,
+  verifySvix,
+  handleDaytonaWebhook,
+  handlePlatinumWebhook,
+} = await import('./sandbox-webhooks');
+
+beforeEach(() => {
+  cfg.DAYTONA_WEBHOOK_SECRET = undefined;
+  cfg.PLATINUM_WEBHOOK_SECRET = undefined;
+  stoppedCalls = [];
+  removedCalls = [];
+  dedupSeen = new Set();
+});
+
+describe('classifyLifecycle', () => {
+  test('terminal states → stopped', () => {
+    for (const s of ['stopped', 'stopping', 'archived', 'archiving']) {
+      expect(classifyLifecycle(s, 'sandbox.state.updated')).toBe('stopped');
+    }
+  });
+  test('destroyed/deleted/lost or delete event → removed', () => {
+    expect(classifyLifecycle('deleted', 'x')).toBe('removed');
+    expect(classifyLifecycle('lost', 'x')).toBe('removed');
+    expect(classifyLifecycle(undefined, 'sandbox.deleted')).toBe('removed');
+  });
+  test('started/running/creating → noop', () => {
+    for (const s of ['started', 'running', 'creating', 'resuming']) {
+      expect(classifyLifecycle(s, 'sandbox.state.updated')).toBe('noop');
+    }
+  });
+});
+
+describe('verifyHmacSha256 (Platinum)', () => {
+  const secret = 'whsec_platinum_test';
+  const body = '{"id":"sb1","state":"stopped"}';
+  const sig = createHmac('sha256', secret).update(body, 'utf8').digest('hex');
+  test('accepts a correct hex signature', () => {
+    expect(verifyHmacSha256(body, secret, sig)).toBe(true);
+  });
+  test('accepts sha256= / v1= prefixed', () => {
+    expect(verifyHmacSha256(body, secret, `sha256=${sig}`)).toBe(true);
+    expect(verifyHmacSha256(body, secret, `v1=${sig}`)).toBe(true);
+  });
+  test('rejects a wrong signature / missing header', () => {
+    expect(verifyHmacSha256(body, secret, 'deadbeef')).toBe(false);
+    expect(verifyHmacSha256(body, secret, undefined)).toBe(false);
+    expect(verifyHmacSha256(body + 'x', secret, sig)).toBe(false);
+  });
+});
+
+describe('verifySvix (Daytona)', () => {
+  const secretRaw = Buffer.from('daytona-test-key').toString('base64');
+  const secret = `whsec_${secretRaw}`;
+  const id = 'msg_1';
+  const ts = '1700000000';
+  const body = '{"event":"sandbox.state.updated","id":"sb2","newState":"stopped"}';
+  const expected = createHmac('sha256', Buffer.from(secretRaw, 'base64'))
+    .update(`${id}.${ts}.${body}`, 'utf8')
+    .digest('base64');
+  test('accepts a correct v1 signature', () => {
+    expect(verifySvix(body, secret, { id, timestamp: ts, signature: `v1,${expected}` })).toBe(true);
+  });
+  test('rejects wrong / incomplete', () => {
+    expect(verifySvix(body, secret, { id, timestamp: ts, signature: 'v1,nope' })).toBe(false);
+    expect(verifySvix(body, secret, { id: undefined, timestamp: ts, signature: `v1,${expected}` })).toBe(false);
+  });
+});
+
+function svixHeaders(secret: string, id: string, ts: string, body: string): (h: string) => string | undefined {
+  const sig = createHmac('sha256', Buffer.from(secret.replace(/^whsec_/, ''), 'base64'))
+    .update(`${id}.${ts}.${body}`, 'utf8')
+    .digest('base64');
+  const map: Record<string, string> = {
+    'webhook-id': id,
+    'webhook-timestamp': ts,
+    'webhook-signature': `v1,${sig}`,
+  };
+  return (h: string) => map[h.toLowerCase()];
+}
+
+describe('handleDaytonaWebhook', () => {
+  const secret = `whsec_${Buffer.from('k').toString('base64')}`;
+  test('503 when not configured', async () => {
+    const r = await handleDaytonaWebhook('{}', () => undefined);
+    expect(r.status).toBe(503);
+  });
+  test('401 on bad signature', async () => {
+    cfg.DAYTONA_WEBHOOK_SECRET = secret;
+    const r = await handleDaytonaWebhook('{"id":"sb"}', () => 'bad');
+    expect(r.status).toBe(401);
+  });
+  test('closes billing on a stopped state', async () => {
+    cfg.DAYTONA_WEBHOOK_SECRET = secret;
+    const body = JSON.stringify({ event: 'sandbox.state.updated', id: 'sbA', newState: 'stopped', updatedAt: 't1' });
+    const r = await handleDaytonaWebhook(body, svixHeaders(secret, 'm1', '100', body));
+    expect(r.status).toBe(200);
+    expect(stoppedCalls).toEqual(['sbA']);
+  });
+  test('dedupes a repeated delivery', async () => {
+    cfg.DAYTONA_WEBHOOK_SECRET = secret;
+    const body = JSON.stringify({ event: 'sandbox.state.updated', id: 'sbB', newState: 'stopped', updatedAt: 't1' });
+    const hdr = svixHeaders(secret, 'm2', '100', body);
+    await handleDaytonaWebhook(body, hdr);
+    await handleDaytonaWebhook(body, hdr);
+    expect(stoppedCalls).toEqual(['sbB']); // second is deduped
+  });
+});
+
+describe('handlePlatinumWebhook', () => {
+  const secret = 'whsec_plat';
+  function hmacHeader(body: string): (h: string) => string | undefined {
+    const sig = createHmac('sha256', secret).update(body, 'utf8').digest('hex');
+    return (h: string) => (h.toLowerCase() === 'x-platinum-signature' ? sig : undefined);
+  }
+  test('503 when not configured', async () => {
+    const r = await handlePlatinumWebhook('{}', () => undefined);
+    expect(r.status).toBe(503);
+  });
+  test('removes on a delete event', async () => {
+    cfg.PLATINUM_WEBHOOK_SECRET = secret;
+    const body = JSON.stringify({ event: 'sandbox.deleted', id: 'pX', state: 'deleted' });
+    const r = await handlePlatinumWebhook(body, hmacHeader(body));
+    expect(r.status).toBe(200);
+    expect(removedCalls).toEqual(['pX']);
+  });
+  test('noop on started', async () => {
+    cfg.PLATINUM_WEBHOOK_SECRET = secret;
+    const body = JSON.stringify({ event: 'sandbox.state_updated', id: 'pY', state: 'running' });
+    const r = await handlePlatinumWebhook(body, hmacHeader(body));
+    expect(r.status).toBe(200);
+    expect(stoppedCalls).toEqual([]);
+    expect(removedCalls).toEqual([]);
+  });
+});

--- a/apps/api/src/platform/webhooks/sandbox-webhooks.ts
+++ b/apps/api/src/platform/webhooks/sandbox-webhooks.ts
@@ -1,0 +1,184 @@
+/**
+ * Provider sandbox-lifecycle webhook ingress — the DETERMINISTIC billing-close
+ * path. The reaper sweep (projects/sandbox-reaper.ts) is the backstop; these
+ * webhooks make billing close the instant a provider reports a box stopped,
+ * instead of up to a sweep-interval later.
+ *
+ *  - Daytona: org-level webhook, events `sandbox.created` / `sandbox.state.updated`
+ *    (payload carries `id`, `newState`). Deliveries are signed Svix-style
+ *    (`webhook-id` / `webhook-timestamp` / `webhook-signature`, secret `whsec_…`).
+ *  - Platinum: events `sandbox.created` / `sandbox.state_updated` / `sandbox.deleted`,
+ *    each HMAC-SHA-256 signed with the per-webhook secret shown once at
+ *    registration (`POST /v1/webhooks`).
+ *
+ * Signature header/format specifics for each provider are confirmed against a
+ * live delivery at deploy time — see verify* below. Until the matching secret is
+ * configured the endpoints are inert (503) and the reaper alone keeps billing
+ * correct, so enabling webhooks is purely an upgrade in latency, never a
+ * correctness dependency.
+ */
+
+import { createHmac, timingSafeEqual } from 'node:crypto';
+import { config } from '../../config';
+import { recordWebhookEvent } from '../../billing/services/webhook-concurrency';
+import {
+  reconcileSandboxStoppedByExternalId,
+  reconcileSandboxRemovedByExternalId,
+} from '../../projects/sandbox-reaper';
+
+export type SandboxLifecycleOutcome = 'stopped' | 'removed' | 'noop';
+
+/**
+ * Map a provider state / event name to the billing action. Only the terminal
+ * directions matter for correctness — a `started`/`created`/transitional event
+ * is acked as a no-op (our own resume/provision paths own the active direction).
+ */
+export function classifyLifecycle(state: string | undefined | null, eventType: string): SandboxLifecycleOutcome {
+  const s = (state ?? '').toLowerCase();
+  const e = (eventType ?? '').toLowerCase();
+  if (e.includes('delet') || e.includes('destroy')) return 'removed';
+  if (['destroyed', 'deleted', 'removed', 'lost', 'failed-start'].includes(s)) return 'removed';
+  if (['stopped', 'stopping', 'archived', 'archiving'].includes(s)) return 'stopped';
+  return 'noop';
+}
+
+/** Constant-time hex/base64 compare that never throws on length mismatch. */
+function safeEqual(a: string, b: string): boolean {
+  const ba = Buffer.from(a);
+  const bb = Buffer.from(b);
+  if (ba.length !== bb.length) return false;
+  return timingSafeEqual(ba, bb);
+}
+
+/**
+ * Plain HMAC-SHA-256 over the raw body (Platinum). Accepts the signature header
+ * with or without a `sha256=` / `v1=` prefix, in hex.
+ */
+export function verifyHmacSha256(rawBody: string, secret: string, headerValue: string | undefined): boolean {
+  if (!headerValue) return false;
+  const expected = createHmac('sha256', secret).update(rawBody, 'utf8').digest('hex');
+  // A header may carry multiple comma/space-separated candidates (`v1=…,…`).
+  const candidates = headerValue
+    .split(/[\s,]+/)
+    .map((p) => p.replace(/^(sha256=|v1=)/i, '').trim())
+    .filter(Boolean);
+  return candidates.some((c) => safeEqual(c.toLowerCase(), expected.toLowerCase()));
+}
+
+/**
+ * Svix-style verification (Daytona). signedContent = `${id}.${timestamp}.${body}`;
+ * secret is base64 after the `whsec_` prefix; signature header is one or more
+ * space-separated `v1,<base64>` entries.
+ */
+export function verifySvix(
+  rawBody: string,
+  secret: string,
+  parts: { id: string | undefined; timestamp: string | undefined; signature: string | undefined },
+): boolean {
+  const { id, timestamp, signature } = parts;
+  if (!id || !timestamp || !signature) return false;
+  const key = Buffer.from(secret.replace(/^whsec_/, ''), 'base64');
+  const signedContent = `${id}.${timestamp}.${rawBody}`;
+  const expected = createHmac('sha256', key).update(signedContent, 'utf8').digest('base64');
+  const candidates = signature
+    .split(' ')
+    .map((p) => (p.includes(',') ? p.split(',')[1] : p))
+    .filter(Boolean);
+  return candidates.some((c) => safeEqual(c, expected));
+}
+
+/** Apply the terminal outcome to billing + DB (idempotent, shared with the reaper). */
+export async function applySandboxLifecycle(
+  externalId: string,
+  outcome: SandboxLifecycleOutcome,
+): Promise<{ action: SandboxLifecycleOutcome; changed: boolean }> {
+  if (!externalId) return { action: 'noop', changed: false };
+  if (outcome === 'stopped') {
+    const changed = await reconcileSandboxStoppedByExternalId(externalId);
+    return { action: 'stopped', changed };
+  }
+  if (outcome === 'removed') {
+    const changed = await reconcileSandboxRemovedByExternalId(externalId);
+    return { action: 'removed', changed };
+  }
+  return { action: 'noop', changed: false };
+}
+
+export interface WebhookResult {
+  status: number;
+  body: Record<string, unknown>;
+}
+
+/** Daytona webhook handler. `headers` is a case-insensitive getter. */
+export async function handleDaytonaWebhook(
+  rawBody: string,
+  getHeader: (name: string) => string | undefined,
+): Promise<WebhookResult> {
+  const secret = config.DAYTONA_WEBHOOK_SECRET;
+  if (!secret) return { status: 503, body: { error: 'daytona webhook not configured' } };
+
+  const ok = verifySvix(rawBody, secret, {
+    id: getHeader('webhook-id') ?? getHeader('svix-id'),
+    timestamp: getHeader('webhook-timestamp') ?? getHeader('svix-timestamp'),
+    signature: getHeader('webhook-signature') ?? getHeader('svix-signature'),
+  });
+  if (!ok) return { status: 401, body: { error: 'invalid signature' } };
+
+  let event: any;
+  try {
+    event = JSON.parse(rawBody);
+  } catch {
+    return { status: 400, body: { error: 'invalid json' } };
+  }
+
+  const externalId: string | undefined = event?.id ?? event?.data?.id ?? event?.sandboxId;
+  const eventType: string = event?.event ?? event?.type ?? '';
+  const newState: string | undefined = event?.newState ?? event?.state ?? event?.data?.state;
+  if (!externalId) return { status: 200, body: { ok: true, ignored: 'no sandbox id' } };
+
+  const dedupId = `daytona:${getHeader('webhook-id') ?? `${externalId}:${newState}:${event?.updatedAt ?? ''}`}`;
+  const fresh = await recordWebhookEvent(dedupId, eventType || 'sandbox.event').catch(() => true);
+  if (!fresh) return { status: 200, body: { ok: true, deduped: true } };
+
+  const outcome = classifyLifecycle(newState, eventType);
+  const res = await applySandboxLifecycle(externalId, outcome);
+  return { status: 200, body: { ok: true, externalId, ...res } };
+}
+
+/** Platinum webhook handler. */
+export async function handlePlatinumWebhook(
+  rawBody: string,
+  getHeader: (name: string) => string | undefined,
+): Promise<WebhookResult> {
+  const secret = config.PLATINUM_WEBHOOK_SECRET;
+  if (!secret) return { status: 503, body: { error: 'platinum webhook not configured' } };
+
+  const sig =
+    getHeader('x-platinum-signature') ??
+    getHeader('platinum-signature') ??
+    getHeader('x-signature') ??
+    getHeader('webhook-signature');
+  if (!verifyHmacSha256(rawBody, secret, sig)) {
+    return { status: 401, body: { error: 'invalid signature' } };
+  }
+
+  let event: any;
+  try {
+    event = JSON.parse(rawBody);
+  } catch {
+    return { status: 400, body: { error: 'invalid json' } };
+  }
+
+  const externalId: string | undefined = event?.id ?? event?.sandbox_id ?? event?.data?.id ?? event?.sandboxId;
+  const eventType: string = event?.event ?? event?.type ?? '';
+  const newState: string | undefined = event?.state ?? event?.new_state ?? event?.newState ?? event?.data?.state;
+  if (!externalId) return { status: 200, body: { ok: true, ignored: 'no sandbox id' } };
+
+  const dedupId = `platinum:${event?.id ?? `${externalId}:${eventType}:${event?.timestamp ?? ''}`}`;
+  const fresh = await recordWebhookEvent(dedupId, eventType || 'sandbox.event').catch(() => true);
+  if (!fresh) return { status: 200, body: { ok: true, deduped: true } };
+
+  const outcome = classifyLifecycle(newState, eventType);
+  const res = await applySandboxLifecycle(externalId, outcome);
+  return { status: 200, body: { ok: true, externalId, ...res } };
+}

--- a/apps/api/src/projects/maintenance.ts
+++ b/apps/api/src/projects/maintenance.ts
@@ -1,15 +1,17 @@
-import { and, eq, inArray, isNotNull, lt, ne, sql } from 'drizzle-orm';
-import { projectSessions, projects, sessionSandboxes } from '@kortix/db';
+import { and, eq, inArray, lt, ne } from 'drizzle-orm';
+import { projectSessions, projects } from '@kortix/db';
 import { db } from '../shared/db';
-import { getProvider, type ProviderName } from '../platform/providers';
-import { invalidateProviderCache } from '../sandbox-proxy';
 import { deleteRemoteSessionBranch, type GitBackedProject } from './git';
-import { pauseComputeSession, tickRunningComputeCharges } from '../billing/services/compute-metering';
+import { tickRunningComputeCharges } from '../billing/services/compute-metering';
 import { reconcileStaleBuilds } from '../snapshots/builder';
 import { reconcileWarmPool } from '../platform/services/warm-pool';
 import { reconcileSnapshotQuota } from '../snapshots/quota-gc';
+import {
+  reapAndReconcileSandboxes,
+  reconcileOrphanComputeSessions,
+  countBillingInvariantViolations,
+} from './sandbox-reaper';
 
-const DEFAULT_IDLE_TTL_MS = 60 * 60 * 1000;
 const DEFAULT_BRANCH_RETENTION_DAYS = 90;
 const DEFAULT_MAINTENANCE_INTERVAL_MS = 5 * 60 * 1000;
 const GC_BATCH_SIZE = 50;
@@ -28,10 +30,6 @@ let maintenanceRunning = false;
 function positiveInt(raw: string | undefined, fallback: number): number {
   const parsed = Number.parseInt(raw || '', 10);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
-}
-
-function sandboxIdleTtlMs(): number {
-  return positiveInt(process.env.KORTIX_SANDBOX_IDLE_TTL, DEFAULT_IDLE_TTL_MS);
 }
 
 function branchRetentionDays(): number {
@@ -59,122 +57,11 @@ export function postgresTimestampParam(date: Date): string {
   return date.toISOString();
 }
 
-/**
- * Daytona auto-stops idle sandboxes on its own (autoStopInterval), so by the
- * time this hourly idle GC runs the sandbox is frequently already stopped,
- * archived, or deleted. Those are the desired end state — not failures — so we
- * reconcile our row quietly instead of logging a stack trace per sandbox.
- */
-function isAlreadyNotRunning(err: unknown): boolean {
-  const msg = (err instanceof Error ? err.message : String(err)).toLowerCase();
-  return (
-    msg.includes('not started') ||
-    msg.includes('not running') ||
-    msg.includes('already stopped') ||
-    msg.includes('not found')
-  );
-}
-
-function isLifecycleTransitionInProgress(err: unknown): boolean {
-  const msg = (err instanceof Error ? err.message : String(err)).toLowerCase();
-  return msg.includes('state change in progress') || msg.includes('transition in progress');
-}
-
-export async function hibernateIdleSessionSandboxes(now = new Date()): Promise<{
-  candidates: number;
-  stopped: number;
-  skipped: number;
-  errors: number;
-}> {
-  const cutoff = new Date(now.getTime() - sandboxIdleTtlMs());
-  const cutoffParam = postgresTimestampParam(cutoff);
-  const rows = await db
-    .select({
-      sandboxId: sessionSandboxes.sandboxId,
-      sessionId: sessionSandboxes.sessionId,
-      accountId: sessionSandboxes.accountId,
-      provider: sessionSandboxes.provider,
-      externalId: sessionSandboxes.externalId,
-    })
-    .from(sessionSandboxes)
-    .where(and(
-      eq(sessionSandboxes.status, 'active'),
-      isNotNull(sessionSandboxes.externalId),
-      // Never hibernate an unclaimed warm-pool box (pool_state set) — it has no
-      // session activity by design. Claimed boxes have pool_state cleared and
-      // hibernate normally. See docs/specs/warm-pool.md.
-      sql`${sessionSandboxes.poolState} IS NULL`,
-      sql`coalesce(${sessionSandboxes.lastUsedAt}, ${sessionSandboxes.updatedAt}, ${sessionSandboxes.createdAt}) < ${cutoffParam}::timestamptz`,
-    ))
-    .limit(GC_BATCH_SIZE);
-
-  let stopped = 0;
-  let skipped = 0;
-  let errors = 0;
-
-  for (const row of rows) {
-    if (!row.externalId) {
-      skipped += 1;
-      continue;
-    }
-
-    // Local Docker containers are launched with --rm, so stopping one discards
-    // the runnable container id. Skip until local resume can re-create them.
-    if (row.provider !== 'daytona') {
-      skipped += 1;
-      continue;
-    }
-
-    try {
-      const provider = getProvider(row.provider as ProviderName);
-      await provider.stop(row.externalId);
-      invalidateProviderCache(row.externalId);
-      const stoppedAt = new Date();
-
-      // Billing v2 — close out the compute metering row before flipping
-      // status, so the wall-time delta is computed against an `active` row.
-      void pauseComputeSession(row.sandboxId).catch((err) =>
-        console.warn(`[maintenance] compute pauseComputeSession failed for ${row.sandboxId}:`, err),
-      );
-
-      await db
-        .update(sessionSandboxes)
-        .set({ status: 'stopped', updatedAt: stoppedAt })
-        .where(eq(sessionSandboxes.sandboxId, row.sandboxId));
-      await db
-        .update(projectSessions)
-        .set({ status: 'stopped', updatedAt: stoppedAt })
-        .where(eq(projectSessions.sessionId, row.sessionId));
-
-      stopped += 1;
-    } catch (err) {
-      // Already stopped/archived/gone on Daytona's side — that's success.
-      // Reconcile our row to match and move on without the noisy stack trace.
-      if (isAlreadyNotRunning(err)) {
-        const reconciledAt = new Date();
-        await db
-          .update(sessionSandboxes)
-          .set({ status: 'stopped', updatedAt: reconciledAt })
-          .where(eq(sessionSandboxes.sandboxId, row.sandboxId));
-        await db
-          .update(projectSessions)
-          .set({ status: 'stopped', updatedAt: reconciledAt })
-          .where(eq(projectSessions.sessionId, row.sessionId));
-        invalidateProviderCache(row.externalId);
-        stopped += 1;
-        continue;
-      }
-      if (isLifecycleTransitionInProgress(err)) {
-        skipped += 1;
-        continue;
-      }
-      errors += 1;
-      console.error(`[project-maintenance] Failed to hibernate sandbox ${row.sandboxId}: ${(err as Error)?.message ?? err}`);
-    }
-  }
-
-  return { candidates: rows.length, stopped, skipped, errors };
-}
+// Idle sandbox hibernation + state/billing reconciliation now lives in the
+// provider-agnostic reaper (./sandbox-reaper.ts), which makes the PROVIDER's
+// real state the source of truth and keys idleness off MEANINGFUL activity
+// (real turns) rather than the partial `last_used_at` proxy signal. See that
+// module for the why.
 
 export async function sweepExpiredSessionBranches(now = new Date()): Promise<{
   candidates: number;
@@ -256,8 +143,19 @@ async function runProjectMaintenance(): Promise<void> {
   if (maintenanceRunning) return;
   maintenanceRunning = true;
   try {
-    const [idle, branches, computeTick, staleBuilds, warmPool, snapshotGc] = await Promise.all([
-      hibernateIdleSessionSandboxes(),
+    const [idle, orphanCompute, branches, computeTick, staleBuilds, warmPool, snapshotGc] = await Promise.all([
+      // Provider-authoritative idle reaper + state/billing reconcile (the fix for
+      // boxes that never auto-stopped and kept billing). Backstops the webhooks.
+      reapAndReconcileSandboxes().catch((err) => {
+        console.warn('[project-maintenance] reaper failed:', err instanceof Error ? err.message : err);
+        return { candidates: 0, stopped: 0, reconciled: 0, billingClosed: 0, skipped: 0, errors: 0 };
+      }),
+      // Billing safety net: close metering for any active compute row whose box
+      // is not actually running (catches orphans / missed webhooks).
+      reconcileOrphanComputeSessions().catch((err) => {
+        console.warn('[project-maintenance] orphan-compute reconcile failed:', err instanceof Error ? err.message : err);
+        return { checked: 0, closed: 0, errors: 0 };
+      }),
       sweepExpiredSessionBranches(),
       // Billing v2 — partial-bill any active compute sessions that haven't
       // settled in > 1h, so a missed stop hook can't accrue uncharged compute.
@@ -286,11 +184,24 @@ async function runProjectMaintenance(): Promise<void> {
       }),
     ]);
     if (
-      idle.stopped || idle.errors || branches.deleted || branches.errors ||
+      idle.stopped || idle.reconciled || idle.errors || orphanCompute.closed || orphanCompute.errors ||
+      branches.deleted || branches.errors ||
       computeTick.settled || staleBuilds.closedReady || staleBuilds.closedFailed || warmPool.reaped ||
       snapshotGc.deleted
     ) {
-      console.log('[project-maintenance] completed', { idle, branches, computeTick, staleBuilds, warmPool, snapshotGc });
+      console.log('[project-maintenance] completed', { idle, orphanCompute, branches, computeTick, staleBuilds, warmPool, snapshotGc });
+    }
+
+    // Invariant monitor: in steady state, every `active` compute session has a
+    // running box. A non-zero count means billing is leaking — make it loud so a
+    // silent regression pages instead of accruing $ for days (the original bug).
+    try {
+      const billingLeak = await countBillingInvariantViolations();
+      if (billingLeak > 0) {
+        console.warn(`[project-maintenance] BILLING INVARIANT VIOLATED: ${billingLeak} active compute session(s) with a non-running box`);
+      }
+    } catch (err) {
+      console.warn('[project-maintenance] billing invariant check failed:', err instanceof Error ? err.message : err);
     }
   } finally {
     maintenanceRunning = false;

--- a/apps/api/src/projects/routes/shared.ts
+++ b/apps/api/src/projects/routes/shared.ts
@@ -9,7 +9,7 @@ import { db } from '../../shared/db';
 import { resolveBranchTip } from '../git';
 import { rehydrateSessionChat } from '../legacy-migration-rehydrate';
 import { changeRequests, projectSessions, sessionSandboxes } from '@kortix/db';
-import { and, desc, eq, isNotNull, isNull } from 'drizzle-orm';
+import { and, desc, eq, isNotNull, isNull, sql } from 'drizzle-orm';
 import { resolveProjectGitAuth } from '../lib/git';
 import {
   ProjectRow,
@@ -61,7 +61,14 @@ export async function resumeStoppedSandbox(row: {
   // proceeds to start the VM. Concurrent polls see `active` and just return it.
   const [won] = await db
     .update(sessionSandboxes)
-    .set({ status: 'active', updatedAt: now })
+    .set({
+      status: 'active',
+      updatedAt: now,
+      // Explicit resume clears the reaper's idle-quiesce marker so the resumed
+      // box is treated normally again (passive traffic can keep it warm until
+      // the next idle window).
+      metadata: sql`coalesce(${sessionSandboxes.metadata}, '{}'::jsonb) - 'idleQuiesced' - 'idleQuiescedAt'`,
+    })
     .where(
       and(
         eq(sessionSandboxes.sandboxId, row.sandboxId),
@@ -441,6 +448,13 @@ export async function openSession(args: {
       row.provider,
     )
   ) {
+    // A box the reaper idle-stopped with `needsReprovision` cannot be safely
+    // resumed in place (Platinum's stop→resume wedges the guest — the CH
+    // resume-freeze). Replace it with a fresh box on open instead. This is an
+    // EXPLICIT open, so it clears the idle state by re-provisioning.
+    if ((row.metadata as Record<string, unknown> | null)?.needsReprovision) {
+      return replaceStaleRuntimeOnOpen(loaded, visible, projectId, sessionId, row, 'reprovision_on_open');
+    }
     await resumeStoppedSandbox({
       sandboxId: row.sandboxId,
       sessionId: row.sessionId,

--- a/apps/api/src/projects/sandbox-reaper.test.ts
+++ b/apps/api/src/projects/sandbox-reaper.test.ts
@@ -1,0 +1,276 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import { projectSessions, sessionSandboxes, chatTurnStreams, usageEvents } from '@kortix/db';
+
+// ── mock state ──────────────────────────────────────────────────────────────
+let candidates: any[] = [];
+let activeTurns: Array<{ sessionId: string }> = [];
+let usageRows: Array<{ sessionId: string; last: string }> = [];
+let statusByExternal: Record<string, 'running' | 'stopped' | 'removed' | 'unknown'> = {};
+let stops: string[] = [];
+let cacheInvalidations: string[] = [];
+let pausedCompute: string[] = [];
+let endedCompute: string[] = [];
+let updateCalls: Array<{ table: unknown; updates: Record<string, unknown> }> = [];
+
+/** A thenable that also exposes `.limit()` so both `await where()` (turn query)
+ *  and `where().limit()` (candidate query) resolve to the same rows. */
+function hybrid(rows: any[]) {
+  const p: any = Promise.resolve(rows);
+  p.limit = async () => rows;
+  p.groupBy = async () => rows;
+  return p;
+}
+
+// Mock config (the only field used is KORTIX_SANDBOX_AUTOSTOP_MINUTES) so the
+// test doesn't import the real config, which calls process.exit on incomplete
+// local env. Run this file in its own `bun test <file>` invocation (as CI does)
+// so the mock never leaks into a sibling file that uses the real config.
+mock.module('../config', () => ({ config: { KORTIX_SANDBOX_AUTOSTOP_MINUTES: 15 } }));
+
+mock.module('../shared/db', () => ({
+  db: {
+    select: () => ({
+      from: (table: unknown) => ({
+        where: () =>
+          hybrid(
+            table === sessionSandboxes
+              ? candidates
+              : table === chatTurnStreams
+                ? activeTurns
+                : table === usageEvents
+                  ? usageRows
+                  : [],
+          ),
+      }),
+    }),
+    update: (table: unknown) => ({
+      set: (updates: Record<string, unknown>) => ({
+        where: async () => {
+          updateCalls.push({ table, updates });
+        },
+      }),
+    }),
+  },
+}));
+
+mock.module('../platform/providers', () => ({
+  getProvider: (_name: string) => ({
+    getStatus: async (externalId: string) => statusByExternal[externalId] ?? 'unknown',
+    stop: async (externalId: string) => {
+      stops.push(externalId);
+    },
+  }),
+}));
+
+mock.module('../sandbox-proxy', () => ({
+  invalidateProviderCache: (externalId: string) => {
+    cacheInvalidations.push(externalId);
+  },
+}));
+
+mock.module('../billing/services/compute-metering', () => ({
+  pauseComputeSession: async (sandboxId: string) => {
+    pausedCompute.push(sandboxId);
+  },
+  endComputeSession: async (sandboxId: string) => {
+    endedCompute.push(sandboxId);
+  },
+}));
+
+const { decideReap, lastMeaningfulAt, reapAndReconcileSandboxes, buildIdleStopMetadata } = await import('./sandbox-reaper');
+
+const TTL = 15 * 60_000;
+
+beforeEach(() => {
+  candidates = [];
+  activeTurns = [];
+  usageRows = [];
+  statusByExternal = {};
+  stops = [];
+  cacheInvalidations = [];
+  pausedCompute = [];
+  endedCompute = [];
+  updateCalls = [];
+});
+
+// ── pure decision matrix (the money + UX correctness lives here) ─────────────
+describe('decideReap', () => {
+  test('never acts on unknown provider state', () => {
+    expect(decideReap({ providerStatus: 'unknown', meaningfulIdleMs: 10 * TTL, hasActiveTurn: false, ttlMs: TTL, provider: 'daytona' }).action).toBe('none');
+  });
+
+  test('removed → reconcile-removed + reprovision', () => {
+    const d = decideReap({ providerStatus: 'removed', meaningfulIdleMs: 0, hasActiveTurn: false, ttlMs: TTL, provider: 'platinum' });
+    expect(d.action).toBe('reconcile-removed');
+    expect(d.reprovisionOnResume).toBe(true);
+  });
+
+  test('provider already stopped → reconcile-stopped', () => {
+    expect(decideReap({ providerStatus: 'stopped', meaningfulIdleMs: 0, hasActiveTurn: false, ttlMs: TTL, provider: 'daytona' }).action).toBe('reconcile-stopped');
+  });
+
+  test('running + idle past TTL → stop-idle', () => {
+    expect(decideReap({ providerStatus: 'running', meaningfulIdleMs: TTL + 1, hasActiveTurn: false, ttlMs: TTL, provider: 'daytona' }).action).toBe('stop-idle');
+  });
+
+  test('running + idle but a turn is in flight → none', () => {
+    expect(decideReap({ providerStatus: 'running', meaningfulIdleMs: 10 * TTL, hasActiveTurn: true, ttlMs: TTL, provider: 'daytona' }).action).toBe('none');
+  });
+
+  test('running + within TTL → none', () => {
+    expect(decideReap({ providerStatus: 'running', meaningfulIdleMs: TTL - 1, hasActiveTurn: false, ttlMs: TTL, provider: 'daytona' }).action).toBe('none');
+  });
+
+  test('Daytona idle stop resumes in place; Platinum must reprovision', () => {
+    expect(decideReap({ providerStatus: 'running', meaningfulIdleMs: TTL + 1, hasActiveTurn: false, ttlMs: TTL, provider: 'daytona' }).reprovisionOnResume).toBe(false);
+    expect(decideReap({ providerStatus: 'running', meaningfulIdleMs: TTL + 1, hasActiveTurn: false, ttlMs: TTL, provider: 'platinum' }).reprovisionOnResume).toBe(true);
+  });
+});
+
+describe('lastMeaningfulAt', () => {
+  test('uses stamped lastTurnAt when present and newer than creation', () => {
+    const created = new Date('2026-06-01T00:00:00Z');
+    const turn = new Date('2026-06-01T05:00:00Z');
+    expect(lastMeaningfulAt({ metadata: { lastTurnAt: turn.toISOString() }, createdAt: created }).getTime()).toBe(turn.getTime());
+  });
+  test('falls back to creation when no stamp', () => {
+    const created = new Date('2026-06-01T00:00:00Z');
+    expect(lastMeaningfulAt({ metadata: null, createdAt: created }).getTime()).toBe(created.getTime());
+  });
+  test('ignores a stamp older than creation (clock skew / stale)', () => {
+    const created = new Date('2026-06-01T10:00:00Z');
+    expect(lastMeaningfulAt({ metadata: { lastTurnAt: '2026-06-01T00:00:00Z' }, createdAt: created }).getTime()).toBe(created.getTime());
+  });
+});
+
+describe('buildIdleStopMetadata', () => {
+  const nowIso = '2026-06-21T12:00:00.000Z';
+  test('idle stop quiesces so passive traffic cannot resurrect', () => {
+    const m = buildIdleStopMetadata({ quiesce: true, reprovision: false, nowIso });
+    expect(m.idleQuiesced).toBe(true);
+    expect(m.idleQuiescedAt).toBe(nowIso);
+    expect(m.needsReprovision).toBeUndefined();
+  });
+  test('Platinum idle stop also flags reprovision', () => {
+    const m = buildIdleStopMetadata({ quiesce: true, reprovision: true, nowIso });
+    expect(m.idleQuiesced).toBe(true);
+    expect(m.needsReprovision).toBe(true);
+  });
+  test('no flags → empty patch (nothing merged)', () => {
+    expect(buildIdleStopMetadata({ quiesce: false, reprovision: false, nowIso })).toEqual({});
+  });
+});
+
+// ── orchestration ────────────────────────────────────────────────────────────
+const NOW = new Date('2026-06-21T12:00:00Z');
+function candidate(over: Partial<any> = {}) {
+  return {
+    sandboxId: 'sb-1',
+    sessionId: 'sess-1',
+    accountId: 'acct-1',
+    provider: 'daytona',
+    externalId: 'ext-1',
+    metadata: null,
+    createdAt: new Date(NOW.getTime() - 2 * 60 * 60 * 1000), // 2h ago → idle
+    ...over,
+  };
+}
+
+describe('reapAndReconcileSandboxes', () => {
+  test('stops an idle, running Daytona box and closes billing + quiesces', async () => {
+    candidates = [candidate()];
+    statusByExternal['ext-1'] = 'running';
+
+    const r = await reapAndReconcileSandboxes(NOW);
+
+    expect(r.stopped).toBe(1);
+    expect(r.billingClosed).toBe(1);
+    expect(stops).toEqual(['ext-1']);
+    expect(pausedCompute).toEqual(['sb-1']);
+    expect(cacheInvalidations).toEqual(['ext-1']);
+    const sbUpdate = updateCalls.find((c) => c.table === sessionSandboxes);
+    expect(sbUpdate?.updates.status).toBe('stopped');
+    expect(sbUpdate?.updates.metadata).toBeDefined(); // quiesce flag merged
+    expect(updateCalls.some((c) => c.table === projectSessions && c.updates.status === 'stopped')).toBe(true);
+  });
+
+  test('Platinum idle stop flags reprovision (resume is broken)', async () => {
+    candidates = [candidate({ provider: 'platinum', externalId: 'ext-p', sandboxId: 'sb-p' })];
+    statusByExternal['ext-p'] = 'running';
+
+    const r = await reapAndReconcileSandboxes(NOW);
+
+    expect(r.stopped).toBe(1);
+    expect(stops).toEqual(['ext-p']);
+    // The stop wrote a metadata merge (the reprovision flag content is covered by
+    // the buildIdleStopMetadata unit test below — the SQL object isn't introspectable).
+    const sbUpdate = updateCalls.find((c) => c.table === sessionSandboxes);
+    expect(sbUpdate?.updates.metadata).toBeDefined();
+  });
+
+  test('reconciles a box the provider already stopped — no stop call', async () => {
+    candidates = [candidate()];
+    statusByExternal['ext-1'] = 'stopped';
+
+    const r = await reapAndReconcileSandboxes(NOW);
+
+    expect(r.reconciled).toBe(1);
+    expect(r.billingClosed).toBe(1);
+    expect(stops).toEqual([]); // never poke a stopped box
+    expect(pausedCompute).toEqual(['sb-1']);
+    expect(updateCalls.some((c) => c.table === sessionSandboxes && c.updates.status === 'stopped')).toBe(true);
+  });
+
+  test('leaves a recently-active box running', async () => {
+    candidates = [candidate({ metadata: { lastTurnAt: new Date(NOW.getTime() - 60_000).toISOString() } })];
+    statusByExternal['ext-1'] = 'running';
+
+    const r = await reapAndReconcileSandboxes(NOW);
+
+    expect(r.skipped).toBe(1);
+    expect(stops).toEqual([]);
+    expect(pausedCompute).toEqual([]);
+  });
+
+  test('a recent LLM call keeps an otherwise old box alive', async () => {
+    candidates = [candidate()]; // created 2h ago
+    statusByExternal['ext-1'] = 'running';
+    usageRows = [{ sessionId: 'sess-1', last: new Date(NOW.getTime() - 60_000).toISOString() }];
+
+    const r = await reapAndReconcileSandboxes(NOW);
+
+    expect(r.skipped).toBe(1);
+    expect(stops).toEqual([]);
+  });
+
+  test('never reaps a box with a turn in flight', async () => {
+    candidates = [candidate()]; // idle by timestamp
+    statusByExternal['ext-1'] = 'running';
+    activeTurns = [{ sessionId: 'sess-1' }];
+
+    const r = await reapAndReconcileSandboxes(NOW);
+
+    expect(r.skipped).toBe(1);
+    expect(stops).toEqual([]);
+  });
+
+  test('skips local_docker (--rm, cannot resume)', async () => {
+    candidates = [candidate({ provider: 'local_docker' })];
+
+    const r = await reapAndReconcileSandboxes(NOW);
+
+    expect(r.skipped).toBe(1);
+    expect(stops).toEqual([]);
+  });
+
+  test('does not act on transient unknown provider state', async () => {
+    candidates = [candidate()];
+    statusByExternal['ext-1'] = 'unknown';
+
+    const r = await reapAndReconcileSandboxes(NOW);
+
+    expect(r.skipped).toBe(1);
+    expect(stops).toEqual([]);
+    expect(pausedCompute).toEqual([]);
+  });
+});

--- a/apps/api/src/projects/sandbox-reaper.test.ts
+++ b/apps/api/src/projects/sandbox-reaper.test.ts
@@ -6,6 +6,7 @@ let candidates: any[] = [];
 let activeTurns: Array<{ sessionId: string }> = [];
 let usageRows: Array<{ sessionId: string; last: string }> = [];
 let statusByExternal: Record<string, 'running' | 'stopped' | 'removed' | 'unknown'> = {};
+let stopErrorByExternal: Record<string, Error> = {};
 let stops: string[] = [];
 let cacheInvalidations: string[] = [];
 let pausedCompute: string[] = [];
@@ -58,6 +59,8 @@ mock.module('../platform/providers', () => ({
     getStatus: async (externalId: string) => statusByExternal[externalId] ?? 'unknown',
     stop: async (externalId: string) => {
       stops.push(externalId);
+      const err = stopErrorByExternal[externalId];
+      if (err) throw err;
     },
   }),
 }));
@@ -86,6 +89,7 @@ beforeEach(() => {
   activeTurns = [];
   usageRows = [];
   statusByExternal = {};
+  stopErrorByExternal = {};
   stops = [];
   cacheInvalidations = [];
   pausedCompute = [];
@@ -272,5 +276,22 @@ describe('reapAndReconcileSandboxes', () => {
     expect(r.skipped).toBe(1);
     expect(stops).toEqual([]);
     expect(pausedCompute).toEqual([]);
+  });
+
+  test('does not mark stopped or close billing when provider stop fails', async () => {
+    candidates = [candidate()];
+    statusByExternal['ext-1'] = 'running';
+    stopErrorByExternal['ext-1'] = new Error('provider unavailable');
+
+    const r = await reapAndReconcileSandboxes(NOW);
+
+    expect(r.errors).toBe(1);
+    expect(r.stopped).toBe(0);
+    expect(r.billingClosed).toBe(0);
+    expect(stops).toEqual(['ext-1']);
+    expect(pausedCompute).toEqual([]);
+    expect(
+      updateCalls.some((c) => c.table === sessionSandboxes && c.updates.status === 'stopped'),
+    ).toBe(false);
   });
 });

--- a/apps/api/src/projects/sandbox-reaper.test.ts
+++ b/apps/api/src/projects/sandbox-reaper.test.ts
@@ -5,6 +5,7 @@ import { projectSessions, sessionSandboxes, chatTurnStreams, usageEvents } from 
 let candidates: any[] = [];
 let activeTurns: Array<{ sessionId: string }> = [];
 let usageRows: Array<{ sessionId: string; last: string }> = [];
+let throwOnUsageLookup = false;
 let statusByExternal: Record<string, 'running' | 'stopped' | 'removed' | 'unknown'> = {};
 let stopErrorByExternal: Record<string, Error> = {};
 let stops: string[] = [];
@@ -15,10 +16,13 @@ let updateCalls: Array<{ table: unknown; updates: Record<string, unknown> }> = [
 
 /** A thenable that also exposes `.limit()` so both `await where()` (turn query)
  *  and `where().limit()` (candidate query) resolve to the same rows. */
-function hybrid(rows: any[]) {
+function hybrid(rows: any[], throwOnGroupBy = false) {
   const p: any = Promise.resolve(rows);
   p.limit = async () => rows;
-  p.groupBy = async () => rows;
+  p.groupBy = async () => {
+    if (throwOnGroupBy) throw new Error('db down');
+    return rows;
+  };
   return p;
 }
 
@@ -41,6 +45,7 @@ mock.module('../shared/db', () => ({
                 : table === usageEvents
                   ? usageRows
                   : [],
+            table === usageEvents && throwOnUsageLookup,
           ),
       }),
     }),
@@ -88,6 +93,7 @@ beforeEach(() => {
   candidates = [];
   activeTurns = [];
   usageRows = [];
+  throwOnUsageLookup = false;
   statusByExternal = {};
   stopErrorByExternal = {};
   stops = [];
@@ -293,5 +299,32 @@ describe('reapAndReconcileSandboxes', () => {
     expect(
       updateCalls.some((c) => c.table === sessionSandboxes && c.updates.status === 'stopped'),
     ).toBe(false);
+  });
+
+  test('provider-removed → reconcile to STOPPED (not archived) + needsReprovision, so it can reopen', async () => {
+    candidates = [candidate()];
+    statusByExternal['ext-1'] = 'removed';
+
+    const r = await reapAndReconcileSandboxes(NOW);
+
+    expect(r.reconciled).toBe(1);
+    expect(endedCompute).toEqual(['sb-1']);
+    const sbUpdate = updateCalls.find((c) => c.table === sessionSandboxes);
+    // MUST be 'stopped' — openSession only reprovisions a stopped+needsReprovision row.
+    expect(sbUpdate?.updates.status).toBe('stopped');
+    expect(sbUpdate?.updates.metadata).toBeDefined();
+    expect(stops).toEqual([]); // never poke a removed box
+  });
+
+  test('FAIL-SAFE: when the activity lookup fails, never stop a running box', async () => {
+    candidates = [candidate()]; // idle by timestamp (created 2h ago)
+    statusByExternal['ext-1'] = 'running';
+    throwOnUsageLookup = true; // simulate a DB/transient failure
+
+    const r = await reapAndReconcileSandboxes(NOW);
+
+    expect(stops).toEqual([]); // uncertain → do not stop
+    expect(pausedCompute).toEqual([]);
+    expect(r.stopped).toBe(0);
   });
 });

--- a/apps/api/src/projects/sandbox-reaper.ts
+++ b/apps/api/src/projects/sandbox-reaper.ts
@@ -419,6 +419,55 @@ export async function reconcileOrphanComputeSessions(): Promise<{ checked: numbe
 }
 
 /**
+ * Close billing + reconcile a sandbox the PROVIDER reports stopped/archived,
+ * keyed by external id. The deterministic billing-close path shared by the
+ * provider webhook ingress (fast path) and the reaper sweep (backstop).
+ * Idempotent: a row already stopped/archived is a no-op. Returns true if it
+ * transitioned a live row.
+ */
+export async function reconcileSandboxStoppedByExternalId(externalId: string, now = new Date()): Promise<boolean> {
+  const [row] = await db
+    .select({ sandboxId: sessionSandboxes.sandboxId, sessionId: sessionSandboxes.sessionId, status: sessionSandboxes.status })
+    .from(sessionSandboxes)
+    .where(eq(sessionSandboxes.externalId, externalId))
+    .limit(1);
+  if (!row) return false;
+  if (row.status === 'stopped' || row.status === 'archived') return false;
+  await pauseComputeSession(row.sandboxId).catch((err) =>
+    console.warn(`[reaper] pauseComputeSession failed for ${row.sandboxId}:`, err instanceof Error ? err.message : err),
+  );
+  await db.update(sessionSandboxes).set({ status: 'stopped', updatedAt: now }).where(eq(sessionSandboxes.sandboxId, row.sandboxId));
+  await db.update(projectSessions).set({ status: 'stopped', updatedAt: now }).where(eq(projectSessions.sessionId, row.sessionId));
+  invalidateProviderCache(externalId);
+  return true;
+}
+
+/**
+ * The provider reports the box destroyed/deleted/lost — finalize billing and
+ * flag the row so the next open reprovisions a fresh box. Keyed by external id;
+ * idempotent. Shared by webhook ingress + reaper.
+ */
+export async function reconcileSandboxRemovedByExternalId(externalId: string, now = new Date()): Promise<boolean> {
+  const [row] = await db
+    .select({ sandboxId: sessionSandboxes.sandboxId, sessionId: sessionSandboxes.sessionId, status: sessionSandboxes.status })
+    .from(sessionSandboxes)
+    .where(eq(sessionSandboxes.externalId, externalId))
+    .limit(1);
+  if (!row) return false;
+  if (row.status === 'archived') return false;
+  await endComputeSession(row.sandboxId).catch((err) =>
+    console.warn(`[reaper] endComputeSession failed for ${row.sandboxId}:`, err instanceof Error ? err.message : err),
+  );
+  await db
+    .update(sessionSandboxes)
+    .set({ status: 'archived', updatedAt: now, metadata: mergeMetadata({ needsReprovision: true }) })
+    .where(eq(sessionSandboxes.sandboxId, row.sandboxId));
+  await db.update(projectSessions).set({ status: 'stopped', updatedAt: now }).where(eq(projectSessions.sessionId, row.sessionId));
+  invalidateProviderCache(externalId);
+  return true;
+}
+
+/**
  * Invariant monitor (surfaced on /health + alerting): how many `active` compute
  * sessions have a sandbox that is NOT `active`. In steady state this is 0; a
  * non-zero, growing value means billing is leaking and must page. Cheap, DB-only.

--- a/apps/api/src/projects/sandbox-reaper.ts
+++ b/apps/api/src/projects/sandbox-reaper.ts
@@ -1,0 +1,420 @@
+/**
+ * Provider-agnostic sandbox reaper + state/billing reconciler.
+ *
+ * THE problem this fixes (verified live 2026-06-21): session sandboxes stayed
+ * running for hours/days after work finished, and the compute meter kept billing
+ * them — 1,597 phantom-active compute rows across 23 accounts.
+ *
+ * Root cause was twofold:
+ *   1. Daytona's provider-side auto-stop ("stop after N min of no REQUEST to the
+ *      box") never fired because passive traffic — an open tab streaming opencode
+ *      events, repeated /start, the server-side opencode-pin hit — touched each
+ *      box < auto-stop apart. So "15 min idle" never elapsed.
+ *   2. Kortix's own idle GC keyed off `session_sandboxes.last_used_at`, which is
+ *      bumped ONLY by /v1/p proxy traffic — a partial signal that real turn/
+ *      session traffic never touches — and its stops didn't stick (auto-wake).
+ *
+ * The fix is to stop trusting "any request" as activity. We define MEANINGFUL
+ * activity = a real turn (a prompt / Slack message / agent run), stamped as
+ * `metadata.lastTurnAt` at the turn boundary, and we make the PROVIDER's real
+ * state (getStatus) the source of truth. A box with no meaningful activity for
+ * the TTL is stopped regardless of how much passive traffic it sees, and billing
+ * is closed the moment the provider reports it is no longer running.
+ *
+ * Webhooks (see channels/providers webhook ingress) are the fast path that
+ * closes billing the instant a box stops; this reaper is the deterministic
+ * backstop that runs even if an event is dropped — together they make
+ * "15 min of no real activity → stopped, and never billed while stopped" an
+ * invariant rather than a best-effort.
+ */
+
+import { and, eq, inArray, isNotNull, sql } from 'drizzle-orm';
+import { projectSessions, sessionSandboxes } from '@kortix/db';
+import { db } from '../shared/db';
+import { getProvider, type ProviderName, type SandboxStatus } from '../platform/providers';
+import { invalidateProviderCache } from '../sandbox-proxy';
+import { pauseComputeSession, endComputeSession } from '../billing/services/compute-metering';
+import { config } from '../config';
+
+export const REAP_BATCH_SIZE = 100;
+const REAP_CONCURRENCY = 6;
+const DEFAULT_AUTOSTOP_MINUTES = 15;
+
+/** The single knob for "how long with no real turn before we stop a box". */
+export function autoStopTtlMs(): number {
+  const min = Math.max(1, config.KORTIX_SANDBOX_AUTOSTOP_MINUTES || DEFAULT_AUTOSTOP_MINUTES);
+  return min * 60_000;
+}
+
+export type ReapAction = 'none' | 'stop-idle' | 'reconcile-stopped' | 'reconcile-removed';
+
+export interface ReapDecision {
+  action: ReapAction;
+  /** Platinum stop→resume is broken (CH resume-freeze) → the next open must
+   *  REPROVISION a fresh box rather than start() the stopped one. */
+  reprovisionOnResume: boolean;
+  reason: string;
+}
+
+/**
+ * Pure, deterministic decision from the provider's REAL state + meaningful idle.
+ * Kept side-effect-free so it is exhaustively unit-tested (the money + UX
+ * correctness lives here).
+ */
+export function decideReap(input: {
+  providerStatus: SandboxStatus;
+  meaningfulIdleMs: number;
+  hasActiveTurn: boolean;
+  ttlMs: number;
+  provider: ProviderName;
+}): ReapDecision {
+  const { providerStatus, meaningfulIdleMs, hasActiveTurn, ttlMs, provider } = input;
+
+  // NEVER act on uncertainty. getStatus() returns 'unknown' on a transient
+  // provider error or a transitional state (starting/resuming/migrating);
+  // stopping or reconciling on that could kill a healthy box or fight a wake.
+  if (providerStatus === 'unknown') {
+    return { action: 'none', reprovisionOnResume: false, reason: 'provider-unknown' };
+  }
+  // The external box is gone — finalize billing and mark our row so the next
+  // open reprovisions instead of trying to resume a box that no longer exists.
+  if (providerStatus === 'removed') {
+    return { action: 'reconcile-removed', reprovisionOnResume: true, reason: 'provider-removed' };
+  }
+  // Provider already stopped/archived it (its own auto-stop, an admin, or a
+  // webhook we missed) but our row still says active — reconcile + close billing.
+  if (providerStatus === 'stopped') {
+    return { action: 'reconcile-stopped', reprovisionOnResume: false, reason: 'provider-stopped' };
+  }
+
+  // providerStatus === 'running'
+  // A turn in flight (long agent run / streaming) is meaningful even if the last
+  // stamped lastTurnAt is older than the TTL — never reap an in-progress turn.
+  if (hasActiveTurn) {
+    return { action: 'none', reprovisionOnResume: false, reason: 'active-turn' };
+  }
+  if (meaningfulIdleMs > ttlMs) {
+    return { action: 'stop-idle', reprovisionOnResume: provider === 'platinum', reason: 'meaningful-idle' };
+  }
+  return { action: 'none', reprovisionOnResume: false, reason: 'within-ttl' };
+}
+
+/**
+ * Last MEANINGFUL activity for a sandbox row. Driven by `metadata.lastTurnAt`
+ * (stamped at every turn boundary — the only thing that should keep a box alive)
+ * with a fallback to row creation so a never-used box still ages out after the
+ * grace TTL. Deliberately does NOT consider `last_used_at` (proxy traffic) or
+ * any passive signal.
+ */
+export function lastMeaningfulAt(row: {
+  metadata: Record<string, unknown> | null;
+  createdAt: Date;
+}): Date {
+  const stamped = row.metadata && typeof row.metadata.lastTurnAt === 'string'
+    ? new Date(row.metadata.lastTurnAt as string)
+    : null;
+  if (stamped && !Number.isNaN(stamped.getTime())) {
+    return stamped.getTime() >= row.createdAt.getTime() ? stamped : row.createdAt;
+  }
+  return row.createdAt;
+}
+
+function isLifecycleTransitionInProgress(err: unknown): boolean {
+  const msg = (err instanceof Error ? err.message : String(err)).toLowerCase();
+  return msg.includes('state change in progress') || msg.includes('transition in progress');
+}
+
+/** Merge keys into a jsonb metadata column without clobbering siblings. */
+function mergeMetadata(patch: Record<string, unknown>) {
+  return sql`coalesce(${sessionSandboxes.metadata}, '{}'::jsonb) || ${JSON.stringify(patch)}::jsonb`;
+}
+
+/**
+ * The metadata patch written when the reaper stops a box. `quiesce` marks an
+ * idle-stop so passive traffic can't resurrect it (only an explicit open / new
+ * turn clears it); `reprovision` flags that the next open must REPROVISION
+ * rather than resume (Platinum's broken stop→resume). Pure so it is unit-tested.
+ */
+export function buildIdleStopMetadata(opts: { quiesce: boolean; reprovision: boolean; nowIso: string }): Record<string, unknown> {
+  const meta: Record<string, unknown> = {};
+  if (opts.quiesce) {
+    meta.idleQuiesced = true;
+    meta.idleQuiescedAt = opts.nowIso;
+  }
+  if (opts.reprovision) meta.needsReprovision = true;
+  return meta;
+}
+
+interface ReapCandidate {
+  sandboxId: string;
+  sessionId: string;
+  accountId: string;
+  provider: ProviderName;
+  externalId: string;
+  metadata: Record<string, unknown> | null;
+  createdAt: Date;
+}
+
+async function reconcileRowToStopped(row: ReapCandidate, now: Date, quiesce: boolean, reprovision: boolean): Promise<void> {
+  // Close billing FIRST (computes the wall-clock delta against the still-active
+  // metering row), then flip status, so the final window is billed correctly.
+  await pauseComputeSession(row.sandboxId).catch((err) =>
+    console.warn(`[reaper] pauseComputeSession failed for ${row.sandboxId}:`, err instanceof Error ? err.message : err),
+  );
+  const meta = buildIdleStopMetadata({ quiesce, reprovision, nowIso: now.toISOString() });
+  await db
+    .update(sessionSandboxes)
+    .set({
+      status: 'stopped',
+      updatedAt: now,
+      ...(Object.keys(meta).length ? { metadata: mergeMetadata(meta) } : {}),
+    })
+    .where(eq(sessionSandboxes.sandboxId, row.sandboxId));
+  await db
+    .update(projectSessions)
+    .set({ status: 'stopped', updatedAt: now })
+    .where(eq(projectSessions.sessionId, row.sessionId));
+  invalidateProviderCache(row.externalId);
+}
+
+export interface ReapResult {
+  candidates: number;
+  stopped: number;      // we issued a provider.stop() for an idle box
+  reconciled: number;   // provider already not-running; we synced our row
+  billingClosed: number;
+  skipped: number;
+  errors: number;
+}
+
+/**
+ * One reaper pass over active session sandboxes. For each:
+ *   - ask the provider its REAL state,
+ *   - reconcile our row + close billing if it is not running,
+ *   - stop it (and close billing) if it has had no meaningful activity for the TTL.
+ * Bounded concurrency so a batch of provider round-trips doesn't serialize.
+ */
+export async function reapAndReconcileSandboxes(now = new Date()): Promise<ReapResult> {
+  const ttlMs = autoStopTtlMs();
+
+  const rows = (await db
+    .select({
+      sandboxId: sessionSandboxes.sandboxId,
+      sessionId: sessionSandboxes.sessionId,
+      accountId: sessionSandboxes.accountId,
+      provider: sessionSandboxes.provider,
+      externalId: sessionSandboxes.externalId,
+      metadata: sessionSandboxes.metadata,
+      createdAt: sessionSandboxes.createdAt,
+    })
+    .from(sessionSandboxes)
+    .where(and(
+      eq(sessionSandboxes.status, 'active'),
+      isNotNull(sessionSandboxes.externalId),
+      // Unclaimed warm-pool spares manage their own lifecycle.
+      sql`${sessionSandboxes.poolState} IS NULL`,
+    ))
+    .limit(REAP_BATCH_SIZE)) as ReapCandidate[];
+
+  const result: ReapResult = { candidates: rows.length, stopped: 0, reconciled: 0, billingClosed: 0, skipped: 0, errors: 0 };
+  if (rows.length === 0) return result;
+
+  const sessionIds = rows.map((r) => r.sessionId);
+  // The real activity signals, batched (both lookups are indexed):
+  //  - last LLM call per session (the truest "a real turn happened" signal,
+  //    covering web / Slack / trigger uniformly), and
+  //  - which sessions have a turn IN FLIGHT (unfinalized stream) — never reap those.
+  const [lastUsageBySession, activeTurnSessions] = await Promise.all([
+    loadLastUsageBySession(sessionIds),
+    loadActiveTurnSessions(sessionIds),
+  ]);
+
+  let cursor = 0;
+  const worker = async () => {
+    while (cursor < rows.length) {
+      const row = rows[cursor++];
+      try {
+        // Local Docker containers are --rm; stopping discards them. Skip (as before).
+        if (row.provider === 'local_docker') {
+          result.skipped += 1;
+          continue;
+        }
+        const provider = getProvider(row.provider);
+        const providerStatus: SandboxStatus = await provider.getStatus(row.externalId);
+        // Meaningful = latest of (stamped lastTurnAt | row creation) and the last
+        // LLM call for the session. Passive traffic (proxy/opencode/presence) is
+        // deliberately NOT considered.
+        const base = lastMeaningfulAt(row);
+        const usage = lastUsageBySession.get(row.sessionId);
+        const lastMeaningful = usage && usage.getTime() > base.getTime() ? usage : base;
+        const meaningfulIdleMs = now.getTime() - lastMeaningful.getTime();
+        const decision = decideReap({
+          providerStatus,
+          meaningfulIdleMs,
+          hasActiveTurn: activeTurnSessions.has(row.sessionId),
+          ttlMs,
+          provider: row.provider,
+        });
+
+        switch (decision.action) {
+          case 'none':
+            result.skipped += 1;
+            break;
+          case 'reconcile-stopped':
+            await reconcileRowToStopped(row, now, false, false);
+            result.reconciled += 1;
+            result.billingClosed += 1;
+            break;
+          case 'reconcile-removed':
+            await endComputeSession(row.sandboxId).catch((err) =>
+              console.warn(`[reaper] endComputeSession failed for ${row.sandboxId}:`, err instanceof Error ? err.message : err),
+            );
+            await db
+              .update(sessionSandboxes)
+              .set({ status: 'archived', updatedAt: now, metadata: mergeMetadata({ needsReprovision: true }) })
+              .where(eq(sessionSandboxes.sandboxId, row.sandboxId));
+            await db
+              .update(projectSessions)
+              .set({ status: 'stopped', updatedAt: now })
+              .where(eq(projectSessions.sessionId, row.sessionId));
+            invalidateProviderCache(row.externalId);
+            result.reconciled += 1;
+            result.billingClosed += 1;
+            break;
+          case 'stop-idle':
+            try {
+              await provider.stop(row.externalId);
+            } catch (err) {
+              if (isLifecycleTransitionInProgress(err)) {
+                result.skipped += 1;
+                break;
+              }
+              // Already stopped/gone on the provider side is success — fall through
+              // to reconcile our row + close billing.
+            }
+            await reconcileRowToStopped(row, now, /* quiesce */ true, decision.reprovisionOnResume);
+            result.stopped += 1;
+            result.billingClosed += 1;
+            break;
+        }
+      } catch (err) {
+        result.errors += 1;
+        console.error(`[reaper] failed for sandbox ${row.sandboxId}: ${(err as Error)?.message ?? err}`);
+      }
+    }
+  };
+
+  await Promise.all(Array.from({ length: Math.min(REAP_CONCURRENCY, rows.length) }, worker));
+  return result;
+}
+
+/** Last LLM-usage timestamp per session (the indexed `usage_events.session_id`). */
+async function loadLastUsageBySession(sessionIds: string[]): Promise<Map<string, Date>> {
+  const out = new Map<string, Date>();
+  if (sessionIds.length === 0) return out;
+  try {
+    const { usageEvents } = await import('@kortix/db');
+    const rows = await db
+      .select({ sessionId: usageEvents.sessionId, last: sql<string>`max(${usageEvents.createdAt})` })
+      .from(usageEvents)
+      .where(inArray(usageEvents.sessionId, sessionIds))
+      .groupBy(usageEvents.sessionId);
+    for (const r of rows) {
+      if (r.sessionId && r.last) {
+        const d = new Date(r.last);
+        if (!Number.isNaN(d.getTime())) out.set(r.sessionId, d);
+      }
+    }
+  } catch {
+    // Best-effort — never let the activity lookup block the reaper.
+  }
+  return out;
+}
+
+/** Session ids that currently have an unfinalized turn stream (a turn in flight). */
+async function loadActiveTurnSessions(sessionIds: string[]): Promise<Set<string>> {
+  if (sessionIds.length === 0) return new Set();
+  try {
+    const { chatTurnStreams } = await import('@kortix/db');
+    const rows = await db
+      .select({ sessionId: chatTurnStreams.sessionId })
+      .from(chatTurnStreams)
+      .where(and(inArray(chatTurnStreams.sessionId, sessionIds), eq(chatTurnStreams.finalized, false)));
+    return new Set(rows.map((r) => r.sessionId));
+  } catch {
+    // Best-effort safety signal — never let it block the reaper.
+    return new Set();
+  }
+}
+
+/**
+ * Billing safety net: an `active` compute session whose box is NOT actually
+ * running is over-billing. The reaper pass above closes billing for boxes it
+ * sees, but a compute row can outlive its session_sandbox row (deleted/migrated)
+ * or be left active after the box was reconciled stopped elsewhere. This pass
+ * resolves every still-open metering row against the PROVIDER's real state and
+ * closes any that are not running. Deterministic; idempotent.
+ */
+export async function reconcileOrphanComputeSessions(): Promise<{ checked: number; closed: number; errors: number }> {
+  const { sandboxComputeSessions } = await import('@kortix/db');
+  // Join the metering row to its sandbox to recover provider + externalId.
+  const rows = await db
+    .select({
+      computeId: sandboxComputeSessions.id,
+      sandboxId: sandboxComputeSessions.sandboxId,
+      sbStatus: sessionSandboxes.status,
+      provider: sessionSandboxes.provider,
+      externalId: sessionSandboxes.externalId,
+    })
+    .from(sandboxComputeSessions)
+    .leftJoin(sessionSandboxes, eq(sessionSandboxes.sandboxId, sandboxComputeSessions.sandboxId))
+    .where(eq(sandboxComputeSessions.state, 'active'))
+    .limit(REAP_BATCH_SIZE);
+
+  let closed = 0;
+  let errors = 0;
+  let cursor = 0;
+  const worker = async () => {
+    while (cursor < rows.length) {
+      const row = rows[cursor++];
+      try {
+        // No sandbox row, or no external id → the box can't be billed; close it.
+        if (!row.externalId || !row.provider) {
+          await pauseComputeSession(row.sandboxId);
+          closed += 1;
+          continue;
+        }
+        // The reaper pass already closes billing for boxes whose row is still
+        // active; here we only need to catch rows whose box is NOT running.
+        if (row.provider === 'local_docker') continue;
+        const status = await getProvider(row.provider as ProviderName).getStatus(row.externalId);
+        if (status === 'stopped' || status === 'removed') {
+          await pauseComputeSession(row.sandboxId);
+          closed += 1;
+        }
+      } catch (err) {
+        errors += 1;
+        console.warn(`[reaper] orphan-compute reconcile failed for ${row.sandboxId}:`, err instanceof Error ? err.message : err);
+      }
+    }
+  };
+  await Promise.all(Array.from({ length: Math.min(REAP_CONCURRENCY, rows.length) }, worker));
+  return { checked: rows.length, closed, errors };
+}
+
+/**
+ * Invariant monitor (surfaced on /health + alerting): how many `active` compute
+ * sessions have a sandbox that is NOT `active`. In steady state this is 0; a
+ * non-zero, growing value means billing is leaking and must page. Cheap, DB-only.
+ */
+export async function countBillingInvariantViolations(): Promise<number> {
+  const { sandboxComputeSessions } = await import('@kortix/db');
+  const [row] = await db
+    .select({ n: sql<number>`count(*)::int` })
+    .from(sandboxComputeSessions)
+    .leftJoin(sessionSandboxes, eq(sessionSandboxes.sandboxId, sandboxComputeSessions.sandboxId))
+    .where(and(
+      eq(sandboxComputeSessions.state, 'active'),
+      sql`(${sessionSandboxes.status} IS NULL OR ${sessionSandboxes.status} <> 'active')`,
+    ));
+  return Number(row?.n ?? 0);
+}

--- a/apps/api/src/projects/sandbox-reaper.ts
+++ b/apps/api/src/projects/sandbox-reaper.ts
@@ -281,7 +281,11 @@ export async function reapAndReconcileSandboxes(now = new Date()): Promise<ReapR
             result.skipped += 1;
             break;
           case 'reconcile-stopped':
-            await reconcileRowToStopped(row, now, false, false);
+            // Quiesce even a provider-confirmed stop: a Daytona native auto-stop
+            // (or a webhook/reaper stop) must NOT be resurrected by passive /v1/p
+            // traffic (markSandboxUsed heals unflagged stopped rows). It comes
+            // back only on an explicit open / real turn, which clears the flag.
+            await reconcileRowToStopped(row, now, /* quiesce */ true, false);
             result.reconciled += 1;
             result.billingClosed += 1;
             break;
@@ -462,7 +466,13 @@ export async function reconcileSandboxStoppedByExternalId(externalId: string, no
   await pauseComputeSession(row.sandboxId).catch((err) =>
     console.warn(`[reaper] pauseComputeSession failed for ${row.sandboxId}:`, err instanceof Error ? err.message : err),
   );
-  await db.update(sessionSandboxes).set({ status: 'stopped', updatedAt: now }).where(eq(sessionSandboxes.sandboxId, row.sandboxId));
+  // Quiesce: a provider-confirmed stop must stay stopped — passive /v1/p traffic
+  // (markSandboxUsed heal / wakeSandbox) must not resurrect it. Cleared on an
+  // explicit open / real turn.
+  await db
+    .update(sessionSandboxes)
+    .set({ status: 'stopped', updatedAt: now, metadata: mergeMetadata(buildIdleStopMetadata({ quiesce: true, reprovision: false, nowIso: now.toISOString() })) })
+    .where(eq(sessionSandboxes.sandboxId, row.sandboxId));
   await db.update(projectSessions).set({ status: 'stopped', updatedAt: now }).where(eq(projectSessions.sessionId, row.sessionId));
   invalidateProviderCache(externalId);
   return true;

--- a/apps/api/src/projects/sandbox-reaper.ts
+++ b/apps/api/src/projects/sandbox-reaper.ts
@@ -124,6 +124,16 @@ function isLifecycleTransitionInProgress(err: unknown): boolean {
   return msg.includes('state change in progress') || msg.includes('transition in progress');
 }
 
+function isAlreadyNotRunning(err: unknown): boolean {
+  const msg = (err instanceof Error ? err.message : String(err)).toLowerCase();
+  return (
+    msg.includes('not started') ||
+    msg.includes('not running') ||
+    msg.includes('already stopped') ||
+    msg.includes('not found')
+  );
+}
+
 /** Merge keys into a jsonb metadata column without clobbering siblings. */
 function mergeMetadata(patch: Record<string, unknown>) {
   return sql`coalesce(${sessionSandboxes.metadata}, '{}'::jsonb) || ${JSON.stringify(patch)}::jsonb`;
@@ -288,8 +298,15 @@ export async function reapAndReconcileSandboxes(now = new Date()): Promise<ReapR
                 result.skipped += 1;
                 break;
               }
-              // Already stopped/gone on the provider side is success — fall through
-              // to reconcile our row + close billing.
+              if (!isAlreadyNotRunning(err)) {
+                result.errors += 1;
+                console.error(
+                  `[reaper] provider.stop failed for sandbox ${row.sandboxId}: ${(err as Error)?.message ?? err}`,
+                );
+                break;
+              }
+              // Already stopped/gone on the provider side is success — reconcile
+              // our row + close billing.
             }
             await reconcileRowToStopped(row, now, /* quiesce */ true, decision.reprovisionOnResume);
             result.stopped += 1;

--- a/apps/api/src/projects/sandbox-reaper.ts
+++ b/apps/api/src/projects/sandbox-reaper.ts
@@ -231,12 +231,20 @@ export async function reapAndReconcileSandboxes(now = new Date()): Promise<ReapR
   const sessionIds = rows.map((r) => r.sessionId);
   // The real activity signals, batched (both lookups are indexed):
   //  - last LLM call per session (the truest "a real turn happened" signal,
-  //    covering web / Slack / trigger uniformly), and
+  //    covering web / Slack / trigger uniformly — the gateway stamps session_id
+  //    on usage_events), and
   //  - which sessions have a turn IN FLIGHT (unfinalized stream) — never reap those.
-  const [lastUsageBySession, activeTurnSessions] = await Promise.all([
+  const [usageResult, activeTurnResult] = await Promise.all([
     loadLastUsageBySession(sessionIds),
     loadActiveTurnSessions(sessionIds),
   ]);
+  // FAIL-SAFE: a null result means the lookup itself FAILED (DB/transient). We
+  // then cannot prove a box is idle, so we must NOT stop it on uncertain data —
+  // same "never act on uncertainty" rule the provider-status path follows.
+  // Provider-confirmed stopped/removed reconciliation still proceeds below.
+  const activitySignalReliable = usageResult !== null && activeTurnResult !== null;
+  const lastUsageBySession = usageResult ?? new Map<string, Date>();
+  const activeTurnSessions = activeTurnResult ?? new Set<string>();
 
   let cursor = 0;
   const worker = async () => {
@@ -260,7 +268,10 @@ export async function reapAndReconcileSandboxes(now = new Date()): Promise<ReapR
         const decision = decideReap({
           providerStatus,
           meaningfulIdleMs,
-          hasActiveTurn: activeTurnSessions.has(row.sessionId),
+          // When the activity signal is unreliable this cycle, treat the box as
+          // if a turn is in flight so a running box is never stopped on uncertain
+          // data (provider-confirmed stopped/removed still reconciles).
+          hasActiveTurn: !activitySignalReliable || activeTurnSessions.has(row.sessionId),
           ttlMs,
           provider: row.provider,
         });
@@ -278,9 +289,14 @@ export async function reapAndReconcileSandboxes(now = new Date()): Promise<ReapR
             await endComputeSession(row.sandboxId).catch((err) =>
               console.warn(`[reaper] endComputeSession failed for ${row.sandboxId}:`, err instanceof Error ? err.message : err),
             );
+            // Status MUST be 'stopped' (not 'archived'): openSession only honors
+            // `needsReprovision` in its `row.status === 'stopped'` branch. An
+            // 'archived' row would fall through to a terminal 'stopped' result and
+            // NEVER reprovision — stranding the session. 'stopped' + the marker
+            // makes the next open reprovision a fresh box.
             await db
               .update(sessionSandboxes)
-              .set({ status: 'archived', updatedAt: now, metadata: mergeMetadata({ needsReprovision: true }) })
+              .set({ status: 'stopped', updatedAt: now, metadata: mergeMetadata({ needsReprovision: true }) })
               .where(eq(sessionSandboxes.sandboxId, row.sandboxId));
             await db
               .update(projectSessions)
@@ -324,8 +340,13 @@ export async function reapAndReconcileSandboxes(now = new Date()): Promise<ReapR
   return result;
 }
 
-/** Last LLM-usage timestamp per session (the indexed `usage_events.session_id`). */
-async function loadLastUsageBySession(sessionIds: string[]): Promise<Map<string, Date>> {
+/**
+ * Last LLM-usage timestamp per session (the indexed `usage_events.session_id`).
+ * Returns `null` on a lookup FAILURE so the caller can fail safe (never stop a
+ * box when we can't determine its activity). An empty map = looked up fine, no
+ * usage found.
+ */
+async function loadLastUsageBySession(sessionIds: string[]): Promise<Map<string, Date> | null> {
   const out = new Map<string, Date>();
   if (sessionIds.length === 0) return out;
   try {
@@ -341,14 +362,19 @@ async function loadLastUsageBySession(sessionIds: string[]): Promise<Map<string,
         if (!Number.isNaN(d.getTime())) out.set(r.sessionId, d);
       }
     }
-  } catch {
-    // Best-effort — never let the activity lookup block the reaper.
+    return out;
+  } catch (err) {
+    console.warn('[reaper] usage-activity lookup failed — failing safe (no stops this cycle):', err instanceof Error ? err.message : err);
+    return null;
   }
-  return out;
 }
 
-/** Session ids that currently have an unfinalized turn stream (a turn in flight). */
-async function loadActiveTurnSessions(sessionIds: string[]): Promise<Set<string>> {
+/**
+ * Session ids that currently have an unfinalized turn stream (a turn in flight).
+ * Returns `null` on a lookup FAILURE so the caller fails safe (never reap when
+ * we can't tell if a turn is running). Empty set = looked up fine, none active.
+ */
+async function loadActiveTurnSessions(sessionIds: string[]): Promise<Set<string> | null> {
   if (sessionIds.length === 0) return new Set();
   try {
     const { chatTurnStreams } = await import('@kortix/db');
@@ -357,9 +383,9 @@ async function loadActiveTurnSessions(sessionIds: string[]): Promise<Set<string>
       .from(chatTurnStreams)
       .where(and(inArray(chatTurnStreams.sessionId, sessionIds), eq(chatTurnStreams.finalized, false)));
     return new Set(rows.map((r) => r.sessionId));
-  } catch {
-    // Best-effort safety signal — never let it block the reaper.
-    return new Set();
+  } catch (err) {
+    console.warn('[reaper] active-turn lookup failed — failing safe (no stops this cycle):', err instanceof Error ? err.message : err);
+    return null;
   }
 }
 
@@ -454,13 +480,14 @@ export async function reconcileSandboxRemovedByExternalId(externalId: string, no
     .where(eq(sessionSandboxes.externalId, externalId))
     .limit(1);
   if (!row) return false;
-  if (row.status === 'archived') return false;
   await endComputeSession(row.sandboxId).catch((err) =>
     console.warn(`[reaper] endComputeSession failed for ${row.sandboxId}:`, err instanceof Error ? err.message : err),
   );
+  // 'stopped' (not 'archived') + needsReprovision so openSession's stopped-branch
+  // reprovisions a fresh box on the next open (an archived row would strand it).
   await db
     .update(sessionSandboxes)
-    .set({ status: 'archived', updatedAt: now, metadata: mergeMetadata({ needsReprovision: true }) })
+    .set({ status: 'stopped', updatedAt: now, metadata: mergeMetadata({ needsReprovision: true }) })
     .where(eq(sessionSandboxes.sandboxId, row.sandboxId));
   await db.update(projectSessions).set({ status: 'stopped', updatedAt: now }).where(eq(projectSessions.sessionId, row.sessionId));
   invalidateProviderCache(externalId);

--- a/apps/api/src/repositories/account-tokens.ts
+++ b/apps/api/src/repositories/account-tokens.ts
@@ -20,6 +20,9 @@ export interface AccountTokenValidationResult {
   /** Non-null = this token is scoped to one project; the auth
    *  middleware enforces URL :projectId === this value. */
   projectId?: string | null;
+  /** Non-null = this token belongs to a specific session (sandbox executor
+   *  token, session_id = sandbox_id). Used to attribute LLM usage per-session. */
+  sessionId?: string | null;
   /** Non-null = this is an agent-session token; the running agent's resolved
    *  authorization (which Kortix CLI/API actions + connectors it may use,
    *  already ∩ the launching user). Null = full access (laptop CLI PAT). */
@@ -34,6 +37,9 @@ export interface CreateAccountTokenParams {
   /** Non-null = project-scoped token (sandbox injection). Null/undefined
    *  = user-scoped (laptop CLI). */
   projectId?: string;
+  /** Set for sandbox session tokens (session_id = sandbox_id) so LLM usage
+   *  through the gateway is attributed to the session. */
+  sessionId?: string | null;
   expiresAt?: Date;
   /** Set for agent-session tokens — the resolved per-agent grant to stamp
    *  onto the token (already ∩ the launching user's role). */
@@ -150,6 +156,7 @@ export async function createAccountToken(
       accountId: params.accountId,
       userId: params.userId,
       projectId: params.projectId ?? null,
+      sessionId: params.sessionId ?? null,
       name: params.name,
       publicKey,
       secretKeyHash,
@@ -249,6 +256,7 @@ export async function validateAccountToken(
         accountId: accountTokens.accountId,
         userId: accountTokens.userId,
         projectId: accountTokens.projectId,
+        sessionId: accountTokens.sessionId,
         status: accountTokens.status,
         expiresAt: accountTokens.expiresAt,
         lastUsedAt: accountTokens.lastUsedAt,
@@ -302,6 +310,7 @@ export async function validateAccountToken(
       userId: row.userId,
       tokenId: row.tokenId,
       projectId: row.projectId,
+      sessionId: row.sessionId ?? null,
       agentGrant: row.agentGrant ?? null,
     };
   } catch (err) {

--- a/apps/api/src/sandbox-proxy/backend.ts
+++ b/apps/api/src/sandbox-proxy/backend.ts
@@ -260,10 +260,32 @@ export async function wakeSandbox(externalId: string): Promise<void> {
   try {
     const record = await loadSandbox(externalId);
     if (!record) return;
+    // Don't let passive preview/share traffic resurrect a box the reaper
+    // deliberately idle-stopped (quiesced) — that endless resurrection is what
+    // kept boxes alive past the auto-stop window. A quiesced box returns only on
+    // an explicit open / a real new turn (which clears the flag).
+    if (await isSandboxQuiesced(record.sandboxId)) {
+      console.log(`[PREVIEW] Skipping wake for quiesced (idle-stopped) sandbox ${externalId}`);
+      return;
+    }
     await getProvider(record.provider as ProviderName).ensureRunning(externalId);
     console.log(`[PREVIEW] Wake-up triggered for sandbox ${externalId}`);
   } catch (e) {
     console.error(`[PREVIEW] Failed to wake sandbox ${externalId}:`, e);
+  }
+}
+
+/** True when the sandbox row carries the reaper's idle-quiesce marker. */
+async function isSandboxQuiesced(sandboxId: string): Promise<boolean> {
+  try {
+    const [row] = await db
+      .select({ metadata: sessionSandboxes.metadata })
+      .from(sessionSandboxes)
+      .where(eq(sessionSandboxes.sandboxId, sandboxId))
+      .limit(1);
+    return !!(row?.metadata as Record<string, unknown> | null)?.idleQuiesced;
+  } catch {
+    return false;
   }
 }
 
@@ -285,6 +307,7 @@ export async function markSandboxUsed(sandboxId: string): Promise<void> {
         sandboxId: sessionSandboxes.sandboxId,
         sessionId: sessionSandboxes.sessionId,
         status: sessionSandboxes.status,
+        metadata: sessionSandboxes.metadata,
       })
       .from(sessionSandboxes)
       .where(and(eq(sessionSandboxes.externalId, sandboxId), ne(sessionSandboxes.status, 'archived')))
@@ -296,6 +319,13 @@ export async function markSandboxUsed(sandboxId: string): Promise<void> {
       .update(sessionSandboxes)
       .set({ lastUsedAt: now, updatedAt: now })
       .where(eq(sessionSandboxes.sandboxId, row.sandboxId));
+
+    // A box the reaper idle-stopped is QUIESCED: passive proxy traffic (an open
+    // tab polling opencode, a background stream reconnect) must NOT heal it back
+    // to active — that resurrection is exactly what kept boxes alive forever.
+    // Only an explicit open / a real new turn (which clears the flag in
+    // resumeStoppedSandbox) brings it back.
+    if ((row.metadata as Record<string, unknown> | null)?.idleQuiesced) return;
 
     if (['error', 'stopped'].includes(row.status)) {
       await db

--- a/apps/api/src/scripts/reimburse-compute-leak.ts
+++ b/apps/api/src/scripts/reimburse-compute-leak.ts
@@ -1,0 +1,220 @@
+#!/usr/bin/env bun
+/**
+ * Org-wide reimbursement for the sandbox auto-stop / compute over-billing leak.
+ *
+ * Background: idle sandboxes never auto-stopped and their compute meter never
+ * closed, so accounts were billed for wall-clock long after their last real
+ * activity (see projects/sandbox-reaper.ts for the fix). This script makes the
+ * affected accounts whole.
+ *
+ * Policy (decided): FULL refund of every AFFECTED (leaked) compute session —
+ * not just the overage portion. A session is "affected" if it was billed past
+ * `lastMeaningfulActivity + grace` (default 15 min), where lastMeaningful =
+ * max(last LLM call in usage_events, the session's creation). That flags every
+ * session the auto-stop bug touched (including the still-`active` phantom rows)
+ * while excluding clean short sessions. The refund for each is its FULL
+ * `cost_usd`.
+ *
+ * Deterministic + idempotent:
+ *   - the affected set + amounts are computed purely from the DB (no provider
+ *     calls), so a dry-run and the apply run agree.
+ *   - refunds are keyed `compute_refund:v1:<accountId>` and written via
+ *     grantCredits(..., stripeEventId=<key>), which lands on the UNIQUE
+ *     credit_ledger.stripe_event_id index — re-running can never double-pay.
+ *
+ * Usage (run by a human, with prod env):
+ *   dotenvx run -f apps/api/.env.prod -- bun apps/api/src/scripts/reimburse-compute-leak.ts            # dry-run report
+ *   dotenvx run -f apps/api/.env.prod -- bun apps/api/src/scripts/reimburse-compute-leak.ts --apply    # close affected active rows + issue refunds
+ *   ... [--ttl-minutes 15] [--account <uuid>] [--project <uuid>]
+ *
+ * SAFETY: default is a read-only dry-run. `--apply` mutates billing (closes
+ * compute rows + grants credits). Review the dry-run report first.
+ */
+
+import { sql } from 'drizzle-orm';
+import { db } from '../shared/db';
+import { pauseComputeSession } from '../billing/services/compute-metering';
+import { grantCredits } from '../billing/services/credits';
+
+interface Args {
+  apply: boolean;
+  ttlMinutes: number;
+  account?: string;
+  project?: string;
+}
+
+function parseArgs(argv: string[]): Args {
+  const args: Args = { apply: false, ttlMinutes: 15 };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--apply') args.apply = true;
+    else if (a === '--ttl-minutes') args.ttlMinutes = Number(argv[++i]) || 15;
+    else if (a === '--account') args.account = argv[++i];
+    else if (a === '--project') args.project = argv[++i];
+  }
+  return args;
+}
+
+interface AffectedRow {
+  computeId: string;
+  accountId: string;
+  sessionId: string | null;
+  sandboxId: string;
+  state: string;
+  costUsd: number;
+  overSeconds: number;
+}
+
+/**
+ * Compute the affected set straight from the DB. `last_meaningful` is the last
+ * real LLM call for the session (usage_events, indexed) or the session's start;
+ * `billed_through` is when billing last advanced. Affected = billed_through is
+ * more than `grace` past last_meaningful.
+ */
+async function loadAffected(args: Args): Promise<AffectedRow[]> {
+  const graceSql = sql.raw(`interval '${Math.max(0, Math.floor(args.ttlMinutes))} minutes'`);
+  const accountFilter = args.account ? sql`AND cs.account_id = ${args.account}::uuid` : sql``;
+  const projectFilter = args.project
+    ? sql`AND ss.project_id = ${args.project}::uuid`
+    : sql``;
+
+  const rows: any = await db.execute(sql`
+    WITH usage AS (
+      SELECT session_id, max(created_at) AS last_usage
+      FROM kortix.usage_events
+      GROUP BY session_id
+    )
+    SELECT
+      cs.id            AS compute_id,
+      cs.account_id    AS account_id,
+      cs.session_id    AS session_id,
+      cs.sandbox_id    AS sandbox_id,
+      cs.state         AS state,
+      cs.cost_usd      AS cost_usd,
+      EXTRACT(EPOCH FROM (
+        coalesce(cs.ended_at, cs.last_billed_at)
+        - (GREATEST(coalesce(u.last_usage, cs.started_at), cs.started_at) + ${graceSql})
+      ))::bigint AS over_seconds
+    FROM kortix.sandbox_compute_sessions cs
+    LEFT JOIN kortix.session_sandboxes ss ON ss.sandbox_id = cs.sandbox_id
+    LEFT JOIN usage u ON u.session_id = cs.session_id
+    WHERE cs.cost_usd > 0
+      ${accountFilter}
+      ${projectFilter}
+  `);
+
+  const list: AffectedRow[] = [];
+  for (const r of (rows.rows ?? rows) as any[]) {
+    const overSeconds = Number(r.over_seconds ?? 0);
+    if (overSeconds <= 0) continue; // billed within the grace window → not leaked
+    list.push({
+      computeId: String(r.compute_id),
+      accountId: String(r.account_id),
+      sessionId: r.session_id ? String(r.session_id) : null,
+      sandboxId: String(r.sandbox_id),
+      state: String(r.state),
+      costUsd: Number(r.cost_usd),
+      overSeconds,
+    });
+  }
+  return list;
+}
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+async function alreadyRefunded(accountId: string, key: string): Promise<boolean> {
+  const res: any = await db.execute(sql`
+    SELECT 1 FROM kortix.credit_ledger
+    WHERE account_id = ${accountId}::uuid AND stripe_event_id = ${key}
+    LIMIT 1
+  `);
+  return (res.rows ?? res).length > 0;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  console.log(`[reimburse] mode=${args.apply ? 'APPLY' : 'dry-run'} grace=${args.ttlMinutes}m` +
+    `${args.account ? ` account=${args.account}` : ''}${args.project ? ` project=${args.project}` : ''}`);
+
+  const affected = await loadAffected(args);
+
+  // Aggregate per account.
+  const byAccount = new Map<string, { count: number; refund: number; activeIds: string[] }>();
+  for (const r of affected) {
+    const agg = byAccount.get(r.accountId) ?? { count: 0, refund: 0, activeIds: [] };
+    agg.count += 1;
+    agg.refund += r.costUsd;
+    if (r.state === 'active') agg.activeIds.push(r.sandboxId);
+    byAccount.set(r.accountId, agg);
+  }
+
+  const accounts = [...byAccount.entries()].sort((a, b) => b[1].refund - a[1].refund);
+  const totalRefund = accounts.reduce((s, [, v]) => s + v.refund, 0);
+  const totalSessions = affected.length;
+
+  console.log(`\n[reimburse] affected sessions: ${totalSessions} across ${accounts.length} accounts`);
+  console.log(`[reimburse] total refund: $${round2(totalRefund)}\n`);
+  console.log('account                                 sessions   refund_usd   active_now');
+  for (const [acct, v] of accounts) {
+    console.log(`${acct}  ${String(v.count).padStart(8)}   ${String(round2(v.refund)).padStart(10)}   ${String(v.activeIds.length).padStart(9)}`);
+  }
+
+  if (!args.apply) {
+    console.log('\n[reimburse] DRY-RUN — no changes made. Re-run with --apply to close affected active rows + issue refunds.');
+    return;
+  }
+
+  console.log('\n[reimburse] APPLY: closing affected active compute rows, then issuing idempotent refunds…');
+  let closed = 0;
+  let refundedAccounts = 0;
+  let refundedUsd = 0;
+  let skippedAccounts = 0;
+
+  for (const [acct, v] of accounts) {
+    // 1) Stop further billing on affected rows that are still active.
+    for (const sandboxId of v.activeIds) {
+      try {
+        await pauseComputeSession(sandboxId);
+        closed += 1;
+      } catch (err) {
+        console.warn(`[reimburse] pauseComputeSession failed for ${sandboxId}:`, err instanceof Error ? err.message : err);
+      }
+    }
+
+    // 2) Idempotent full refund for the account.
+    const key = `compute_refund:v1:${acct}`;
+    if (await alreadyRefunded(acct, key)) {
+      skippedAccounts += 1;
+      console.log(`[reimburse] ${acct} already refunded (key ${key}) — skipping`);
+      continue;
+    }
+    const amount = round2(v.refund);
+    if (amount <= 0) continue;
+    try {
+      await grantCredits(
+        acct,
+        amount,
+        'compute_refund',
+        `Compute over-billing reimbursement — full refund of ${v.count} session(s) affected by the sandbox auto-stop bug`,
+        false, // non-expiring
+        key,   // → credit_ledger.stripe_event_id UNIQUE index = permanent idempotency
+      );
+      refundedAccounts += 1;
+      refundedUsd += amount;
+      console.log(`[reimburse] refunded ${acct}: $${amount} (${v.count} sessions)`);
+    } catch (err) {
+      console.error(`[reimburse] refund FAILED for ${acct}:`, err instanceof Error ? err.message : err);
+    }
+  }
+
+  console.log(`\n[reimburse] DONE. closed=${closed} compute rows | refunded ${refundedAccounts} accounts ($${round2(refundedUsd)}) | skipped ${skippedAccounts} already-refunded`);
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error('[reimburse] fatal:', err);
+    process.exit(1);
+  });

--- a/apps/api/src/scripts/reimburse-compute-leak.ts
+++ b/apps/api/src/scripts/reimburse-compute-leak.ts
@@ -31,7 +31,8 @@
  * compute rows + grants credits). Review the dry-run report first.
  */
 
-import { sql } from 'drizzle-orm';
+import { inArray, sql } from 'drizzle-orm';
+import { sandboxComputeSessions } from '@kortix/db';
 import { db } from '../shared/db';
 import { pauseComputeSession } from '../billing/services/compute-metering';
 import { grantCredits } from '../billing/services/credits';
@@ -133,14 +134,46 @@ async function alreadyRefunded(accountId: string, key: string): Promise<boolean>
   return (res.rows ?? res).length > 0;
 }
 
+/** Re-sum cost_usd per account from a set of compute-session ids (post-settle). */
+async function settledTotalsByAccount(computeIds: string[]): Promise<Map<string, { count: number; refund: number }>> {
+  const out = new Map<string, { count: number; refund: number }>();
+  const CHUNK = 1000;
+  for (let i = 0; i < computeIds.length; i += CHUNK) {
+    const chunk = computeIds.slice(i, i + CHUNK);
+    if (chunk.length === 0) continue;
+    const rows = await db
+      .select({ accountId: sandboxComputeSessions.accountId, cost: sandboxComputeSessions.costUsd })
+      .from(sandboxComputeSessions)
+      .where(inArray(sandboxComputeSessions.id, chunk));
+    for (const r of rows) {
+      const acct = String(r.accountId);
+      const cur = out.get(acct) ?? { count: 0, refund: 0 };
+      cur.count += 1;
+      cur.refund += Number(r.cost ?? 0);
+      out.set(acct, cur);
+    }
+  }
+  return out;
+}
+
 async function main() {
   const args = parseArgs(process.argv.slice(2));
+
+  // A filtered --apply would write the account-wide idempotency key
+  // (compute_refund:v1:<account>) for only part of an account, making a later
+  // full-org reimbursement skip the rest of that account as "already refunded".
+  // Filters are for dry-run INSPECTION only; --apply is org-wide.
+  if (args.apply && (args.account || args.project)) {
+    console.error('[reimburse] REFUSING --apply with --account/--project — a partial apply would poison the account-wide idempotency key. Use filters for dry-run only; run --apply org-wide.');
+    process.exit(2);
+  }
+
   console.log(`[reimburse] mode=${args.apply ? 'APPLY' : 'dry-run'} grace=${args.ttlMinutes}m` +
     `${args.account ? ` account=${args.account}` : ''}${args.project ? ` project=${args.project}` : ''}`);
 
   const affected = await loadAffected(args);
 
-  // Aggregate per account.
+  // Pre-settle aggregate for the report (apply re-computes from settled rows).
   const byAccount = new Map<string, { count: number; refund: number; activeIds: string[] }>();
   for (const r of affected) {
     const agg = byAccount.get(r.accountId) ?? { count: 0, refund: 0, activeIds: [] };
@@ -149,45 +182,45 @@ async function main() {
     if (r.state === 'active') agg.activeIds.push(r.sandboxId);
     byAccount.set(r.accountId, agg);
   }
-
   const accounts = [...byAccount.entries()].sort((a, b) => b[1].refund - a[1].refund);
-  const totalRefund = accounts.reduce((s, [, v]) => s + v.refund, 0);
-  const totalSessions = affected.length;
 
-  console.log(`\n[reimburse] affected sessions: ${totalSessions} across ${accounts.length} accounts`);
-  console.log(`[reimburse] total refund: $${round2(totalRefund)}\n`);
+  console.log(`\n[reimburse] affected sessions: ${affected.length} across ${accounts.length} accounts`);
+  console.log(`[reimburse] total (pre-settle estimate): $${round2(accounts.reduce((s, [, v]) => s + v.refund, 0))}\n`);
   console.log('account                                 sessions   refund_usd   active_now');
   for (const [acct, v] of accounts) {
     console.log(`${acct}  ${String(v.count).padStart(8)}   ${String(round2(v.refund)).padStart(10)}   ${String(v.activeIds.length).padStart(9)}`);
   }
 
   if (!args.apply) {
-    console.log('\n[reimburse] DRY-RUN — no changes made. Re-run with --apply to close affected active rows + issue refunds.');
+    console.log('\n[reimburse] DRY-RUN — no changes. Amounts are pre-settle estimates; --apply settles affected active rows FIRST, then refunds the exact settled cost.');
     return;
   }
 
-  console.log('\n[reimburse] APPLY: closing affected active compute rows, then issuing idempotent refunds…');
+  // 1) Settle EVERY affected active row first so cost_usd includes the final
+  //    unbilled window — otherwise the refund under-counts (or never-ticked rows
+  //    would refund as $0).
+  console.log('\n[reimburse] APPLY 1/3: settling affected active compute rows…');
   let closed = 0;
+  const activeSandboxIds = [...new Set(affected.filter((a) => a.state === 'active').map((a) => a.sandboxId))];
+  for (const sid of activeSandboxIds) {
+    try { await pauseComputeSession(sid); closed += 1; }
+    catch (err) { console.warn(`[reimburse] settle failed for ${sid}:`, err instanceof Error ? err.message : err); }
+  }
+
+  // 2) Re-read the SETTLED cost per account from the affected rows.
+  console.log('[reimburse] APPLY 2/3: re-reading settled costs…');
+  const settled = await settledTotalsByAccount(affected.map((a) => a.computeId));
+
+  // 3) Idempotent full refund per account from the settled amounts.
+  console.log('[reimburse] APPLY 3/3: issuing refunds…');
   let refundedAccounts = 0;
   let refundedUsd = 0;
   let skippedAccounts = 0;
-
-  for (const [acct, v] of accounts) {
-    // 1) Stop further billing on affected rows that are still active.
-    for (const sandboxId of v.activeIds) {
-      try {
-        await pauseComputeSession(sandboxId);
-        closed += 1;
-      } catch (err) {
-        console.warn(`[reimburse] pauseComputeSession failed for ${sandboxId}:`, err instanceof Error ? err.message : err);
-      }
-    }
-
-    // 2) Idempotent full refund for the account.
+  for (const [acct, v] of settled) {
     const key = `compute_refund:v1:${acct}`;
     if (await alreadyRefunded(acct, key)) {
       skippedAccounts += 1;
-      console.log(`[reimburse] ${acct} already refunded (key ${key}) — skipping`);
+      console.log(`[reimburse] ${acct} already refunded — skipping`);
       continue;
     }
     const amount = round2(v.refund);
@@ -197,7 +230,7 @@ async function main() {
         acct,
         amount,
         'compute_refund',
-        `Compute over-billing reimbursement — full refund of ${v.count} session(s) affected by the sandbox auto-stop bug`,
+        `Compute over-billing reimbursement — full refund of ${v.count} affected session(s)`,
         false, // non-expiring
         key,   // → credit_ledger.stripe_event_id UNIQUE index = permanent idempotency
       );
@@ -209,7 +242,7 @@ async function main() {
     }
   }
 
-  console.log(`\n[reimburse] DONE. closed=${closed} compute rows | refunded ${refundedAccounts} accounts ($${round2(refundedUsd)}) | skipped ${skippedAccounts} already-refunded`);
+  console.log(`\n[reimburse] DONE. settled=${closed} | refunded ${refundedAccounts} accounts ($${round2(refundedUsd)}) | skipped ${skippedAccounts} already-refunded`);
 }
 
 main()

--- a/apps/web/src/hooks/platform/use-project-presence.ts
+++ b/apps/web/src/hooks/platform/use-project-presence.ts
@@ -1,57 +1,20 @@
 'use client';
 
-import { useEffect } from 'react';
-
-import { backendApi } from '@/lib/api-client';
-
-/** How often to tell the backend "this project tab is still open." The warm pool
- *  keeps a spare parked while presence is fresh and reaps it ~3× this after the
- *  last beat (see POOL_PRESENCE_STALE_MS in warm-pool.ts). */
-const HEARTBEAT_MS = 45_000;
-
 /**
- * Warm-pool presence: while a project page is open + visible, heartbeat the
- * backend so it keeps a pre-warmed spare ready for the user's next session; on
- * close/navigate-away, beacon a "leave" so the spare is reaped immediately.
+ * Warm-pool presence — DISABLED.
  *
- * This is what makes warm spares track *projects open right now* instead of the
- * old "every project touched in the last 6h" age rule — see warm-pool.ts.
- * No-op server-side unless the warm pool is enabled and the member can launch
- * sessions, so it's safe to mount unconditionally on the project/session page.
+ * This used to heartbeat `/projects/:id/presence` every 45s while a project tab
+ * was open, to keep a pre-warmed pool spare ready. The warm pool is off (and has
+ * been by default), so the heartbeat did nothing server-side except generate a
+ * steady stream of requests (one tab ≈ a beat every ~45s) that muddied activity
+ * signals. Idle sandbox lifecycle is now owned by the provider-agnostic reaper
+ * keyed off real turns (apps/api/src/projects/sandbox-reaper.ts), so tab-open
+ * presence is no longer needed to keep anything warm.
+ *
+ * Kept as a no-op (stable import) so callers don't churn. If the warm pool is
+ * ever re-enabled, restore the heartbeat here (and the now-unused
+ * /presence + /presence/leave routes in apps/api/.../routes/r8.ts).
  */
-export function useProjectPresence(projectId: string | null | undefined): void {
-  useEffect(() => {
-    if (!projectId) return;
-    const base = `/projects/${projectId}/presence`;
-
-    const ping = () => {
-      // While the tab is hidden we stop beating; presence goes stale and the
-      // spare is reaped after the staleness window. A quick tab-switch (back
-      // within that window) never loses the spare; a long-hidden tab does.
-      if (typeof document !== 'undefined' && document.visibilityState === 'hidden') return;
-      void backendApi.post(base, undefined, { showErrors: false }).catch(() => {});
-    };
-    const leave = () => {
-      // keepalive lets the request survive the page unload.
-      void backendApi.post(`${base}/leave`, undefined, { keepalive: true, showErrors: false }).catch(() => {});
-    };
-
-    ping();
-    const interval = setInterval(ping, HEARTBEAT_MS);
-    const onVisible = () => {
-      if (typeof document !== 'undefined' && document.visibilityState === 'visible') ping();
-    };
-    document.addEventListener('visibilitychange', onVisible);
-    // pagehide fires on real close / hard navigation (more reliable than
-    // beforeunload, and bfcache-safe) → drop presence + reap now.
-    window.addEventListener('pagehide', leave);
-
-    return () => {
-      clearInterval(interval);
-      document.removeEventListener('visibilitychange', onVisible);
-      window.removeEventListener('pagehide', leave);
-      // SPA navigation away from the project page (unmount) is also a "leave".
-      leave();
-    };
-  }, [projectId]);
+export function useProjectPresence(_projectId: string | null | undefined): void {
+  // intentionally no-op — see module doc.
 }

--- a/packages/db/src/schema/kortix.ts
+++ b/packages/db/src/schema/kortix.ts
@@ -1382,6 +1382,11 @@ export const accountTokens = kortixSchema.table(
      *  launching user's role; the default `kortix` agent = "all" ∩ user). Null
      *  for non-agent tokens (laptop CLI PATs, etc.) — which keep full access. */
     agentGrant: jsonb('agent_grant').$type<AgentGrant>(),
+    /** Session this token belongs to (sandbox executor token, session_id =
+     *  sandbox_id). Lets the LLM gateway attribute usage_events per-session —
+     *  the reaper's reliable activity signal + precise billing. Null for
+     *  non-session tokens (laptop CLI PATs, project-scoped operator tokens). */
+    sessionId: text('session_id'),
   },
   (table) => [
     uniqueIndex('idx_account_tokens_public_key').on(table.publicKey),

--- a/supabase/migrations/00000000000123_account_tokens_session_id.sql
+++ b/supabase/migrations/00000000000123_account_tokens_session_id.sql
@@ -1,0 +1,7 @@
+-- Sandbox executor tokens are minted per session (session_id = sandbox_id).
+-- Recording it on the token lets the LLM gateway attribute usage_events to the
+-- calling session — the sandbox reaper's reliable "real activity" signal and
+-- precise per-session compute/LLM billing. Nullable: laptop CLI PATs and
+-- project-scoped operator tokens have no session. Idempotent.
+alter table kortix.account_tokens
+  add column if not exists session_id text;


### PR DESCRIPTION
## Problem (verified live against prod DB + the Daytona org, read-only)

Idle session sandboxes ran for hours/days after work finished, burning compute, and the meter kept billing them.

- **Auto-stop broken:** Daytona auto-stop = *"stop after N min of no request to the box."* Passive traffic poked each box <15 min apart so the window never elapsed — an open project/session tab streaming opencode events + re-POSTing `/start`, and the server-side `ensureOpencodeSessionPin` → `listSandboxOpencodeSessions` hitting the box **directly via the Daytona preview URL** on every open. The sessions were genuinely finished (0 LLM calls in 90 min, 0% CPU inside).
- **Stops didn't stick:** the preview proxy `wakeSandbox` + `markSandboxUsed` healing + `resumeStoppedSandbox` resurrected stopped boxes on passive traffic.
- **Wrong idle signal:** the in-repo idle GC keyed off `session_sandboxes.last_used_at`, bumped **only** by `/v1/p` proxy traffic — a partial signal real session/turn traffic never touches.
- **Billing never closed:** `tickRunningComputeCharges` partial-bills `active` compute rows hourly but never closes them. Prod snapshot: **1,597 `active` compute rows / 23 accounts / ~$35.8k accrued, oldest 18.6 days**, still billing. The full affected set (incl. closed sessions billed past idle) is **2,431 sessions / 26 accounts / $37.4k**.

Prod is Daytona-only (`ALLOWED_SANDBOX_PROVIDERS=daytona`); Platinum/local are handled for correctness but not active in prod.

## What's in this PR (all landed)

**1. Provider-agnostic reaper + billing close** (`apps/api/src/projects/sandbox-reaper.ts`)
- `provider.getStatus()` is the source of truth; idleness keys off **meaningful activity** (last LLM call in `usage_events` + in-flight-turn guard + creation grace), not `last_used_at`. Stops idle boxes after 15 min, closes compute billing at the stop, reconciles stale rows. Adds an orphan-compute reconcile + a **billing-invariant monitor** (logs loudly when an `active` compute row has a non-running box). On a real `provider.stop()` failure it does NOT mark stopped / close billing (auto-fix from the review bot).
- **Quiesce** so stops stick: idle-stops are marked `idleQuiesced`; `wakeSandbox` + `markSandboxUsed` refuse to resurrect a quiesced box on passive traffic; an explicit open clears it.
- **Platinum** (broken stop→resume): reprovisioned on open instead of resumed. Unified the divergent `KORTIX_SANDBOX_AUTO_STOP_MIN` (which also wrongly made Platinum ephemeral) onto the per-provider `daytonaLifecycle` policy.

**2. Deterministic billing close via webhooks** (`apps/api/src/platform/webhooks/sandbox-webhooks.ts`)
- `/v1/billing/webhooks/daytona` (Svix-signed) + `/v1/billing/webhooks/platinum` (HMAC-SHA-256). Verify signature, dedup, classify state, and call the SAME idempotent close path as the reaper. Closes billing the instant a box stops; the reaper sweep is the backstop. Inert (503) until `DAYTONA_WEBHOOK_SECRET` / `PLATINUM_WEBHOOK_SECRET` is set.

**3. Org-wide reimbursement** (`apps/api/src/scripts/reimburse-compute-leak.ts`)
- Deterministic + idempotent. Default dry-run report; `--apply` closes affected still-active rows then full-refunds every affected (leaked) session via `grantCredits('compute_refund', non-expiring)`, keyed on the UNIQUE `credit_ledger.stripe_event_id` index so re-runs can't double-pay. Prod dry-run: **2,431 sessions / 26 accounts / $37,454.46**.

**4. Frontend cleanup** — disabled the dead warm-pool presence heartbeat (warm pool is off).

**Tests:** 22 reaper + 15 webhook + 3 maintenance, typecheck clean.

## Deploy / ops follow-ups (not code)
- Register the webhook endpoints (Daytona dashboard + Platinum `POST /v1/webhooks`) and set `DAYTONA_WEBHOOK_SECRET` / `PLATINUM_WEBHOOK_SECRET` in AWS Secrets Manager. Confirm the exact signature header/format against a live delivery.
- Run the reimbursement script with prod env (review the dry-run report first), then `--apply`.

## Notes
- The ke2e coverage gate is **pre-existingly red** on `main` (duplicate flow id `BILL-9` across `billing.flow.ts` + `setup-billing-backlog.flow.ts`, from active billing/IAM work) — not caused by this PR. The coverage allowlist for the 2 new webhook routes lives in the gitignored `tests/src/coverage/` (out of repo); regenerate + allowlist when that tooling runs.