### PR TITLE
fix(sessions): sync OpenCode titles server-side

### DIFF
--- a/apps/api/src/__tests__/unit-opencode-title-sync.test.ts
+++ b/apps/api/src/__tests__/unit-opencode-title-sync.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+
+import { projectSessions, sessionSandboxes } from '@kortix/db';
+
+const sandboxRows: Array<{ sessionId: string; externalId: string | null }> = [];
+const dbUpdates: Array<Record<string, unknown>> = [];
+let listedSessions: any[] = [];
+
+mock.module('../shared/db', () => ({
+  db: {
+    select: () => ({
+      from: (table: unknown) => ({
+        where: async () => {
+          if (table === sessionSandboxes) return sandboxRows;
+          return [];
+        },
+      }),
+    }),
+    update: (table: unknown) => ({
+      set: (updates: Record<string, unknown>) => ({
+        where: () => ({
+          returning: async () => {
+            if (table === projectSessions) dbUpdates.push(updates);
+            return [];
+          },
+        }),
+      }),
+    }),
+  },
+}));
+
+mock.module('../projects/opencode-mapping', () => ({
+  listSandboxOpencodeSessions: async () => ({
+    ok: true,
+    sessions: listedSessions,
+  }),
+  resolveRootSessionId: ({
+    pinnedRootId,
+    sessions,
+  }: {
+    pinnedRootId: string | null;
+    sessions: Array<{ id: string; parentID?: string | null }>;
+  }) =>
+    pinnedRootId && sessions.some((session) => session.id === pinnedRootId)
+      ? pinnedRootId
+      : sessions.find((session) => !session.parentID)?.id ?? null,
+}));
+
+const { syncOpenCodeTitlesForSessions } = await import('../projects/opencode-title-sync');
+
+afterEach(() => {
+  sandboxRows.length = 0;
+  dbUpdates.length = 0;
+  listedSessions = [];
+});
+
+function row(overrides: Record<string, unknown> = {}) {
+  return {
+    sessionId: 'session-1',
+    projectId: 'project-1',
+    accountId: 'account-1',
+    opencodeSessionId: null,
+    metadata: {},
+    ...overrides,
+  } as any;
+}
+
+describe('syncOpenCodeTitlesForSessions', () => {
+  test('fetches OpenCode sessions server-side and mirrors the root title/tree', async () => {
+    sandboxRows.push({ sessionId: 'session-1', externalId: 'sandbox-ext-1' });
+    listedSessions = [
+      { id: 'root-1', title: 'Generated title', time: { created: 1, updated: 10 } },
+      {
+        id: 'child-1',
+        title: 'Follow-up',
+        parentID: 'root-1',
+        time: { created: 2, updated: 20 },
+      },
+    ];
+
+    const [synced] = await syncOpenCodeTitlesForSessions({
+      rows: [row()],
+      projectId: 'project-1',
+      accountId: 'account-1',
+      userId: 'user-1',
+    });
+
+    expect(synced.opencodeSessionId).toBe('root-1');
+    const metadata = synced.metadata as Record<string, unknown>;
+    expect(metadata.name).toBe('Generated title');
+    expect(metadata.opencode_sessions).toEqual([
+      {
+        id: 'child-1',
+        title: 'Follow-up',
+        parent_id: 'root-1',
+        project_id: null,
+        created_at: 2,
+        updated_at: 20,
+        archived_at: null,
+      },
+      {
+        id: 'root-1',
+        title: 'Generated title',
+        parent_id: null,
+        project_id: null,
+        created_at: 1,
+        updated_at: 10,
+        archived_at: null,
+      },
+    ]);
+    expect(dbUpdates.at(-1)).toMatchObject({
+      opencodeSessionId: 'root-1',
+      metadata,
+    });
+  });
+
+  test('does not erase an existing mirrored name when OpenCode has no title yet', async () => {
+    sandboxRows.push({ sessionId: 'session-1', externalId: 'sandbox-ext-1' });
+    listedSessions = [{ id: 'root-1', title: null, time: { created: 1, updated: 1 } }];
+
+    const [synced] = await syncOpenCodeTitlesForSessions({
+      rows: [row({ metadata: { name: 'Previous title' } })],
+      projectId: 'project-1',
+      accountId: 'account-1',
+      userId: 'user-1',
+    });
+
+    const metadata = synced.metadata as Record<string, unknown>;
+    expect(metadata.name).toBe('Previous title');
+    expect(dbUpdates.at(-1)?.metadata).toMatchObject({ name: 'Previous title' });
+  });
+});

--- a/apps/api/src/middleware/request-deadline.ts
+++ b/apps/api/src/middleware/request-deadline.ts
@@ -81,7 +81,6 @@ const EXEMPT_FRAGMENTS = [
   '/snapshots',               // sandbox template builds
   '/suna-migration',          // OG Suna → opencode migration runs
   '/legacy-migration',        // legacy VM → project migration runs
-  '/sync-opencode-sessions',  // cross-sandbox session sweep (observed ~26s)
   '/oauth/',                  // provider OAuth device flow — `start` spawns
                               // OpenCode + waits for the device challenge, which
                               // can exceed the deadline on a cold replica

--- a/apps/api/src/projects/lib/serializers.ts
+++ b/apps/api/src/projects/lib/serializers.ts
@@ -62,10 +62,10 @@ export function serializeSession(
     : [];
   const isOwner = ctx?.viewerId ? row.createdBy === ctx.viewerId : false;
   // A user-set name (metadata.custom_name) is authoritative and ALWAYS wins
-  // over the auto title (metadata.name) that opencode mirrors via
-  // /v1/projects/sync-opencode-sessions. `name` is the resolved display value;
+  // over the auto title (metadata.name) mirrored from OpenCode server-side
+  // during session reads. `name` is the resolved display value;
   // `custom_name` is exposed separately so clients can tell an override apart
-  // from the auto title (e.g. to beat the live opencode root title).
+  // from the auto title.
   const customName = typeof row.metadata?.custom_name === 'string' ? row.metadata.custom_name : null;
   const autoName = typeof row.metadata?.name === 'string' ? row.metadata.name : null;
   return {

--- a/apps/api/src/projects/opencode-title-sync.ts
+++ b/apps/api/src/projects/opencode-title-sync.ts
@@ -1,0 +1,200 @@
+import { and, eq, inArray } from 'drizzle-orm';
+
+import { projectSessions, sessionSandboxes } from '@kortix/db';
+import { db } from '../shared/db';
+import {
+  listSandboxOpencodeSessions,
+  resolveRootSessionId,
+  type OpencodeSessionLite,
+} from './opencode-mapping';
+import type { ProjectSessionRow } from './lib/serializers';
+
+type OpenCodeSessionSnapshot = {
+  id: string;
+  title: string | null;
+  parent_id: string | null;
+  project_id: string | null;
+  created_at: number | null;
+  updated_at: number | null;
+  archived_at: number | null;
+};
+
+type OpenCodeSessionLike = OpencodeSessionLite & {
+  title?: string | null;
+  parent_id?: string | null;
+  parentId?: string | null;
+  projectID?: string | null;
+  project_id?: string | null;
+  projectId?: string | null;
+  created_at?: number | null;
+  createdAt?: number | null;
+  updated_at?: number | null;
+  updatedAt?: number | null;
+  archived_at?: number | null;
+  archivedAt?: number | null;
+};
+
+function stringOrNull(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+function numberOrNull(...values: unknown[]): number | null {
+  for (const value of values) {
+    if (typeof value === 'number' && Number.isFinite(value)) return value;
+  }
+  return null;
+}
+
+function normalizeSnapshot(session: OpenCodeSessionLike): OpenCodeSessionSnapshot | null {
+  const id = stringOrNull(session.id);
+  if (!id) return null;
+  return {
+    id,
+    title: stringOrNull(session.title),
+    parent_id: stringOrNull(session.parentID ?? session.parent_id ?? session.parentId),
+    project_id: stringOrNull(session.projectID ?? session.project_id ?? session.projectId),
+    created_at: numberOrNull(session.time?.created, session.created_at, session.createdAt),
+    updated_at: numberOrNull(session.time?.updated, session.updated_at, session.updatedAt),
+    archived_at: numberOrNull(session.time?.archived, session.archived_at, session.archivedAt),
+  };
+}
+
+function rootResolver(entries: OpenCodeSessionSnapshot[]) {
+  const byId = new Map(entries.map((entry) => [entry.id, entry]));
+  const rootById = new Map<string, string>();
+
+  const resolveRoot = (id: string): string => {
+    const cached = rootById.get(id);
+    if (cached) return cached;
+    const seen = new Set<string>();
+    let current = id;
+    while (true) {
+      if (seen.has(current)) break;
+      seen.add(current);
+      const parent = byId.get(current)?.parent_id;
+      if (!parent) break;
+      if (!byId.has(parent)) {
+        current = parent;
+        break;
+      }
+      current = parent;
+    }
+    for (const seenId of seen) rootById.set(seenId, current);
+    return current;
+  };
+
+  for (const entry of entries) resolveRoot(entry.id);
+  return resolveRoot;
+}
+
+function sameSessions(a: unknown, b: OpenCodeSessionSnapshot[]): boolean {
+  try {
+    return JSON.stringify(Array.isArray(a) ? a : []) === JSON.stringify(b);
+  } catch {
+    return false;
+  }
+}
+
+async function syncRowFromSandbox(input: {
+  row: ProjectSessionRow;
+  externalId: string;
+  userId?: string;
+}): Promise<ProjectSessionRow> {
+  const listed = await listSandboxOpencodeSessions(input.externalId, input.userId);
+  if (!listed.ok) return input.row;
+
+  const snapshots = listed.sessions
+    .map((session) => normalizeSnapshot(session as OpenCodeSessionLike))
+    .filter((session): session is OpenCodeSessionSnapshot => Boolean(session));
+  if (snapshots.length === 0) return input.row;
+
+  const resolvedRootId = resolveRootSessionId({
+    pinnedRootId: input.row.opencodeSessionId,
+    sessions: listed.sessions,
+  });
+  if (!resolvedRootId) return input.row;
+
+  const resolveRoot = rootResolver(snapshots);
+  const scopedSessions = snapshots
+    .filter((entry) => resolveRoot(entry.id) === resolvedRootId)
+    .sort((a, b) => (b.updated_at ?? 0) - (a.updated_at ?? 0));
+
+  const metadata = (input.row.metadata ?? {}) as Record<string, unknown>;
+  const currentName = typeof metadata.name === 'string' ? metadata.name : null;
+  const rootTitle = snapshots.find((entry) => entry.id === resolvedRootId)?.title ?? null;
+  const nextName = rootTitle ?? currentName;
+  const pinChanged = input.row.opencodeSessionId !== resolvedRootId;
+  const nameChanged = Boolean(nextName) && nextName !== currentName;
+  const sessionsChanged = !sameSessions(metadata.opencode_sessions, scopedSessions);
+  if (!pinChanged && !nameChanged && !sessionsChanged) return input.row;
+
+  const nextMetadata: Record<string, unknown> = { ...metadata };
+  if (nextName) nextMetadata.name = nextName;
+  nextMetadata.opencode_sessions = scopedSessions;
+
+  const [updated] = await db
+    .update(projectSessions)
+    .set({
+      opencodeSessionId: resolvedRootId,
+      metadata: nextMetadata,
+      updatedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(projectSessions.sessionId, input.row.sessionId),
+        eq(projectSessions.projectId, input.row.projectId),
+        eq(projectSessions.accountId, input.row.accountId),
+      ),
+    )
+    .returning();
+
+  return updated ?? {
+    ...input.row,
+    opencodeSessionId: resolvedRootId,
+    metadata: nextMetadata,
+    updatedAt: new Date(),
+  };
+}
+
+export async function syncOpenCodeTitlesForSessions(input: {
+  rows: ProjectSessionRow[];
+  projectId: string;
+  accountId: string;
+  userId?: string;
+}): Promise<ProjectSessionRow[]> {
+  if (input.rows.length === 0) return input.rows;
+  const sessionIds = input.rows.map((row) => row.sessionId);
+  const sandboxRows = await db
+    .select({
+      sessionId: sessionSandboxes.sessionId,
+      externalId: sessionSandboxes.externalId,
+    })
+    .from(sessionSandboxes)
+    .where(
+      and(
+        eq(sessionSandboxes.projectId, input.projectId),
+        eq(sessionSandboxes.accountId, input.accountId),
+        inArray(sessionSandboxes.sessionId, sessionIds),
+        inArray(sessionSandboxes.status, ['active', 'provisioning']),
+      ),
+    );
+
+  const externalBySessionId = new Map(
+    sandboxRows
+      .filter((row): row is { sessionId: string; externalId: string } =>
+        Boolean(row.sessionId && row.externalId),
+      )
+      .map((row) => [row.sessionId, row.externalId]),
+  );
+  if (externalBySessionId.size === 0) return input.rows;
+
+  const updated = await Promise.all(
+    input.rows.map((row) => {
+      const externalId = externalBySessionId.get(row.sessionId);
+      if (!externalId) return row;
+      return syncRowFromSandbox({ row, externalId, userId: input.userId });
+    }),
+  );
+
+  return updated;
+}

--- a/apps/api/src/projects/routes/r7.ts
+++ b/apps/api/src/projects/routes/r7.ts
@@ -11,8 +11,8 @@ import { AnyObject, GroupGrantSchema, SessionSchema, projectsApp } from '../lib/
 import { UUID_V4_REGEX, hasOwn, isProjectRole, normalizeString, readBody, requestAuditContext, serializeSession, serializeSessionSandboxConfig } from '../lib/serializers';
 import { sendSessionCreateError } from '../lib/sessions';
 import { buildSessionTranscriptDigest } from '../lib/session-transcript';
+import { syncOpenCodeTitlesForSessions } from '../opencode-title-sync';
 import { createSession, deleteSession } from '../session-lifecycle';
-import { syncOpencodeSessionsHandler } from './shared';
 
 function parseBoundedPositiveInt(
   raw: string | undefined,
@@ -430,7 +430,7 @@ projectsApp.openapi(
   const grantsBySession = await loadSessionGrants(
     listableRows.filter((r) => r.visibility === 'restricted').map((r) => r.sessionId),
   );
-  const visible = listableRows.filter((r) =>
+  let visible = listableRows.filter((r) =>
     isSessionVisibleTo(
       r.visibility as 'private' | 'project' | 'restricted',
       r.createdBy,
@@ -438,6 +438,12 @@ projectsApp.openapi(
       subject,
     ),
   );
+  visible = await syncOpenCodeTitlesForSessions({
+    rows: visible,
+    projectId,
+    accountId: loaded.row.accountId,
+    userId: loaded.userId,
+  });
   // Owner emails only for sessions someone else owns (for the "shared by" label).
   const ownerIds = [...new Set(visible.map((r) => r.createdBy).filter((id): id is string => !!id && id !== loaded.userId))];
   const emails = await lookupEmailsByUserIds(ownerIds);
@@ -482,11 +488,17 @@ projectsApp.openapi(
 
   const visible = await loadVisibleSession(loaded, sessionId);
   if (!visible) return c.json({ error: 'Not found' }, 404);
+  const [row] = await syncOpenCodeTitlesForSessions({
+    rows: [visible.row],
+    projectId,
+    accountId: loaded.row.accountId,
+    userId: loaded.userId,
+  });
 
   const ownerEmail = visible.row.createdBy && !visible.isOwner
     ? (await lookupEmailsByUserIds([visible.row.createdBy])).get(visible.row.createdBy) ?? null
     : null;
-  return c.json(serializeSession(visible.row, {
+  return c.json(serializeSession(row ?? visible.row, {
     grants: visible.grants,
     viewerId: loaded.userId,
     canManageProject: visible.canManageProject,
@@ -652,8 +664,8 @@ projectsApp.openapi(
   const updates: Partial<typeof projectSessions.$inferInsert> = { updatedAt: new Date() };
 
   // A user-set name is the AUTHORITATIVE display name. It lives in
-  // metadata.custom_name — a separate key from metadata.name (the auto title
-  // mirrored from opencode by /sync-opencode-sessions) so a rename is never
+  // metadata.custom_name — a separate key from metadata.name (the server-side
+  // auto title mirrored from OpenCode during session reads) so a rename is never
   // clobbered by a later sync. Passing name: "" (or null) clears the override
   // and reverts the session to its auto title.
   const hasNameField = hasOwn(body, 'name');
@@ -692,27 +704,6 @@ projectsApp.openapi(
   }));
 },
 );
-
-// POST /v1/projects/sync-opencode-sessions
-// Mirrors session data from the sandbox-local opencode DB into our cloud DB.
-// The project_sessions row remains the branch+sandbox root;
-// metadata.opencode_sessions stores the local OpenCode root/sub-session graph
-// for sidebar/list rendering when the sandbox is not the active runtime.
-
-projectsApp.openapi(
-  createRoute({
-    method: 'post',
-    path: '/sync-opencode-sessions',
-    tags: ['sessions'],
-    summary: 'POST /sync-opencode-sessions',
-    ...auth,
-    responses: {
-        200: json(z.any(), 'OK'),
-    },
-  }),
-  syncOpencodeSessionsHandler as any,
-);
-
 
 // DELETE /v1/projects/:projectId/sessions/:sessionId
 // Soft delete only. We deliberately keep the remote branch so the user can

--- a/apps/api/src/projects/routes/shared.ts
+++ b/apps/api/src/projects/routes/shared.ts
@@ -3,21 +3,16 @@ import {
   reopenComputeForSandbox,
 } from '../../billing/services/compute-metering';
 import { config, type SandboxProviderName } from '../../config';
-import { PROJECT_ACTIONS, authorize } from '../../iam';
-import { deriveRequestContext } from '../../iam/cache';
 import { auth, json } from '../../openapi';
 import { getProvider, type SandboxStatus } from '../../platform/providers';
 import { db } from '../../shared/db';
 import { resolveBranchTip } from '../git';
 import { rehydrateSessionChat } from '../legacy-migration-rehydrate';
 import { changeRequests, projectSessions, sessionSandboxes } from '@kortix/db';
-import { and, desc, eq, inArray, isNotNull, isNull } from 'drizzle-orm';
+import { and, desc, eq, isNotNull, isNull } from 'drizzle-orm';
 import { resolveProjectGitAuth } from '../lib/git';
 import {
   ProjectRow,
-  isPlainObject,
-  normalizeString,
-  readBody,
   serializeSessionSandboxConfig,
 } from '../lib/serializers';
 import { allocateSessionRuntime } from '../lib/session-runtime-allocator';
@@ -26,155 +21,6 @@ import {
   sandboxCallbackUnreachableReason,
 } from '../lib/sessions';
 import { ensureOpencodeSessionPin } from '../opencode-mapping';
-
-export const syncOpencodeSessionsHandler = async (c: any) => {
-  const userId = c.get('userId') as string;
-  const body = await readBody(c);
-  const rawEntries = body.entries;
-  if (!Array.isArray(rawEntries)) {
-    return c.json({ error: 'entries must be an array' }, 400);
-  }
-
-  type OpenCodeSessionSnapshot = {
-    id: string;
-    title: string | null;
-    parent_id: string | null;
-    project_id: string | null;
-    created_at: number | null;
-    updated_at: number | null;
-    archived_at: number | null;
-  };
-
-  const desiredByOcId = new Map<string, OpenCodeSessionSnapshot>();
-  for (const raw of rawEntries) {
-    if (!isPlainObject(raw)) continue;
-    const opencodeSessionId = normalizeString(
-      raw.opencode_session_id ?? raw.opencodeSessionId,
-    );
-    if (!opencodeSessionId) continue;
-    const title = normalizeString(raw.title);
-    const parentId = normalizeString(
-      raw.parent_id ?? raw.parentID ?? raw.parentId,
-    );
-    const projectId = normalizeString(
-      raw.project_id ?? raw.projectID ?? raw.projectId,
-    );
-    const createdAt =
-      typeof raw.created_at === 'number'
-        ? raw.created_at
-        : typeof raw.createdAt === 'number'
-          ? raw.createdAt
-          : null;
-    const updatedAt =
-      typeof raw.updated_at === 'number'
-        ? raw.updated_at
-        : typeof raw.updatedAt === 'number'
-          ? raw.updatedAt
-          : null;
-    const archivedAt =
-      typeof raw.archived_at === 'number'
-        ? raw.archived_at
-        : typeof raw.archivedAt === 'number'
-          ? raw.archivedAt
-          : null;
-    desiredByOcId.set(opencodeSessionId, {
-      id: opencodeSessionId,
-      title,
-      parent_id: parentId,
-      project_id: projectId,
-      created_at: createdAt,
-      updated_at: updatedAt,
-      archived_at: archivedAt,
-    });
-  }
-  if (desiredByOcId.size === 0) return c.json({ updated: 0 });
-
-  const ids = Array.from(desiredByOcId.keys());
-  const rootByOcId = new Map<string, string>();
-  const resolveRoot = (id: string): string => {
-    const cached = rootByOcId.get(id);
-    if (cached) return cached;
-    const seen = new Set<string>();
-    let current = id;
-    while (true) {
-      if (seen.has(current)) break;
-      seen.add(current);
-      const parent = desiredByOcId.get(current)?.parent_id;
-      if (!parent) break;
-      if (!desiredByOcId.has(parent)) {
-        current = parent;
-        break;
-      }
-      current = parent;
-    }
-    for (const seenId of seen) rootByOcId.set(seenId, current);
-    return current;
-  };
-  for (const id of ids) resolveRoot(id);
-  const rootIds = Array.from(new Set(Array.from(rootByOcId.values())));
-  const rows = await db
-    .select()
-    .from(projectSessions)
-    .where(
-      inArray(
-        projectSessions.opencodeSessionId,
-        Array.from(new Set([...ids, ...rootIds])),
-      ),
-    );
-  if (rows.length === 0) return c.json({ updated: 0 });
-
-  // Per-row IAM authz. The engine answers from a per-request cache
-  // (see iam/cache.ts) so duplicate (account, project) probes collapse
-  // to a single SQL pass — N rows over K distinct projects = K
-  // authorize() calls, not N.
-  const requestCtx = deriveRequestContext(c);
-  const actingTokenId =
-    ((c as unknown as { get(k: string): unknown }).get('iamTokenId') as
-      | string
-      | undefined) ?? undefined;
-
-  let updated = 0;
-  for (const row of rows) {
-    const verdict = await authorize(
-      userId,
-      row.accountId,
-      PROJECT_ACTIONS.PROJECT_WRITE,
-      { type: 'project', id: row.projectId },
-      actingTokenId,
-      requestCtx,
-    );
-    if (!verdict.allowed) continue;
-    const ocId = row.opencodeSessionId;
-    if (!ocId) continue;
-    const rootId = rootByOcId.get(ocId) ?? ocId;
-    const current =
-      typeof row.metadata?.name === 'string' ? row.metadata.name : null;
-    const rootEntry = desiredByOcId.get(ocId);
-    // Title mirror is MONOTONIC: a row that's in the snapshot but still has a
-    // null title (OpenCode hasn't auto-titled it yet) must NOT erase a name we
-    // already wrote. `?? current` keeps the existing name until a real title
-    // arrives — fixes "title generated then vanishes on a later list snapshot".
-    const desired = (rootEntry ? rootEntry.title : current) ?? current;
-    const scopedSessions = Array.from(desiredByOcId.values())
-      .filter((entry) => (rootByOcId.get(entry.id) ?? entry.id) === rootId)
-      .sort((a, b) => (b.updated_at ?? 0) - (a.updated_at ?? 0));
-    const currentSessions = JSON.stringify(
-      row.metadata?.opencode_sessions ?? [],
-    );
-    const nextSessions = JSON.stringify(scopedSessions);
-    if (desired === current && currentSessions === nextSessions) continue;
-    const nextMetadata: Record<string, unknown> = { ...(row.metadata ?? {}) };
-    if (desired) nextMetadata.name = desired;
-    // no `else delete` — never wipe an existing name because a snapshot lacked a title.
-    nextMetadata.opencode_sessions = scopedSessions;
-    await db
-      .update(projectSessions)
-      .set({ metadata: nextMetadata, updatedAt: new Date() })
-      .where(eq(projectSessions.sessionId, row.sessionId));
-    updated += 1;
-  }
-  return c.json({ updated });
-};
 
 /**
  * Resume a hibernated (status='stopped') session sandbox IN PLACE instead of

--- a/apps/web/src/app/(app)/projects/[id]/sessions/[sessionId]/page.tsx
+++ b/apps/web/src/app/(app)/projects/[id]/sessions/[sessionId]/page.tsx
@@ -31,7 +31,6 @@ import {
   restartProjectSession,
   sessionStartKey,
   startProjectSession,
-  syncOpencodeSessionData,
 } from '@/lib/projects-client';
 import { finishSessionTiming, sessionMark } from '@/lib/session-timing';
 import { cn } from '@/lib/utils';
@@ -168,7 +167,7 @@ export default function ProjectSessionPage() {
         switchingRef.current = false;
       }
     })();
-  }, [sandbox, projectId, activeInstanceId]);
+  }, [sandbox, projectId, activeInstanceId, start?.stage, start?.opencode_session_id]);
 
   // Belt-and-suspenders: clear the legacy cookie once on mount for this route.
   // setActiveInstanceCookie already force-clears on any /projects path and is the
@@ -572,33 +571,6 @@ function ActiveSessionChat({
     projectId,
     sessionId,
   ]);
-
-  // Mirror the sandbox-local OpenCode session tree into our cloud DB. The
-  // project session row stays the branch/sandbox root; this metadata lets the
-  // project sidebar and session list render sub-sessions without guessing.
-  // Must run BEFORE any conditional return — otherwise the runtimeError branch
-  // below would skip this hook and trigger "rendered fewer hooks than expected".
-  const activeSession = opencodeSessions.find((s) => s.id === chatSessionId);
-  const activeTitle = activeSession?.title || null;
-  useEffect(() => {
-    if (opencodeSessions.length === 0) return;
-    void syncOpencodeSessionData(
-      opencodeSessions.map((session) => ({
-        opencode_session_id: session.id,
-        title: session.title || null,
-        parent_id: session.parentID ?? null,
-        project_id: session.projectID ?? null,
-        created_at: session.time?.created ?? null,
-        updated_at: session.time?.updated ?? null,
-        archived_at: session.time?.archived ?? null,
-      })),
-    )
-      .then(() => {
-        queryClient.invalidateQueries({ queryKey: ['project-sessions', projectId] });
-        queryClient.invalidateQueries({ queryKey: ['project-session', projectId, sessionId] });
-      })
-      .catch(() => {});
-  }, [opencodeSessions, activeTitle, queryClient, projectId, sessionId]);
 
   // (The home-composer first-message handoff is migrated synchronously during
   // render above — see promptMigratedForRef — so SessionChat's consumer always

--- a/apps/web/src/components/projects/session-label.ts
+++ b/apps/web/src/components/projects/session-label.ts
@@ -91,10 +91,9 @@ export function matchesSessionFilter(session: ProjectSession, filter: SessionFil
 
 /**
  * Human display label for a session. Precedence: the user-set rename
- * (custom_name) is AUTHORITATIVE and always wins — even over the live
- * opencode root title (which keeps serving the auto title after a rename).
- * Then: live opencode root title → resolved name (synced auto-title) →
- * legacy metadata.session_name → branch slice → short id.
+ * (custom_name) is AUTHORITATIVE and always wins. Then: server-resolved
+ * session.name (OpenCode auto-title mirrored during session reads) → legacy
+ * metadata.session_name → branch slice → short id.
  */
 export function sessionDisplayLabel(session: ProjectSession): string {
   const metadataName =
@@ -106,7 +105,6 @@ export function sessionDisplayLabel(session: ProjectSession): string {
     : session.session_id.slice(0, 8);
   return (
     session.custom_name?.trim() ||
-    rootOpenCodeSession(session)?.title?.trim() ||
     session.name?.trim() ||
     metadataName?.trim() ||
     fallback

--- a/apps/web/src/features/co-worker/project-sidebar/project-session-list.tsx
+++ b/apps/web/src/features/co-worker/project-sidebar/project-session-list.tsx
@@ -5,7 +5,6 @@ import { useTranslations } from 'next-intl';
 import {
   directSubsessions,
   matchesSessionFilter,
-  rootOpenCodeSession,
   sessionSource,
   type SessionFilterValue,
   type SessionSourceKind,
@@ -148,7 +147,6 @@ export function ProjectSessionList({ projectId, filter = 'all' }: ProjectSession
         {visibleSessions.map((session) => {
           const href = `/projects/${session.project_id}/sessions/${session.session_id}`;
           const isActive = pathname?.includes(`/sessions/${session.session_id}`);
-          const root = rootOpenCodeSession(session);
           const children = directSubsessions(session);
           return (
             <div key={session.session_id} className="space-y-px">
@@ -156,7 +154,7 @@ export function ProjectSessionList({ projectId, filter = 'all' }: ProjectSession
                 session={session}
                 href={href}
                 isActive={!!isActive && !activeOpenCodeSessionId}
-                displayTitle={getSessionDisplayTitle(session, root?.title ?? undefined)}
+                displayTitle={getSessionDisplayTitle(session)}
                 childCount={children.length}
                 onDelete={(id, label) => setSessionToDelete({ id, label })}
                 onShare={(s) => setSessionToShare(s)}
@@ -457,14 +455,13 @@ function SessionStatusDot({ status }: { status: ProjectSessionStatus }) {
   );
 }
 
-function getSessionDisplayTitle(session: ProjectSession, titleOverride?: string): string {
+function getSessionDisplayTitle(session: ProjectSession): string {
   const legacyMetadataName =
     typeof session.metadata?.session_name === 'string'
       ? (session.metadata.session_name as string)
       : null;
   const titleCandidate =
     session.custom_name?.trim() ||
-    titleOverride?.trim() ||
     session.name?.trim() ||
     legacyMetadataName?.trim();
 

--- a/apps/web/src/hooks/opencode/use-opencode-events.ts
+++ b/apps/web/src/hooks/opencode/use-opencode-events.ts
@@ -88,6 +88,14 @@ function scheduleProjectMetadataRefetch(queryClient: QueryClient): void {
   }
 }
 
+function refetchKortixSessionMirrors(queryClient: QueryClient): void {
+  // OpenCode title/tree mirroring is owned by API session reads. When OpenCode
+  // emits a title/tree change, refetch the active Kortix session reads so tabs
+  // and sidebars pick up the server-side mirror without browser-side writes.
+  void queryClient.refetchQueries({ queryKey: ['project-sessions'], type: 'active' });
+  void queryClient.refetchQueries({ queryKey: ['project-session'], type: 'active' });
+}
+
 /**
  * Connects to OpenCode's SSE event stream via the SDK and
  * performs INCREMENTAL cache updates on React Query data.
@@ -677,6 +685,7 @@ export function useOpenCodeEventStream() {
               return [info, ...old].sort((a, b) => b.time.updated - a.time.updated);
             });
             queryClient.setQueryData(opencodeKeys.session(info.id), info);
+            refetchKortixSessionMirrors(queryClient);
           }
           break;
         }
@@ -684,6 +693,16 @@ export function useOpenCodeEventStream() {
         case 'session.updated': {
           const info = readSessionInfo(event);
           if (info) {
+            // OpenCode auto-titles after the first message via session.updated.
+            // Capture the previous title before local cache mutation so we only
+            // force the server-owned mirror read when the title actually changed.
+            const prevTitle =
+              queryClient
+                .getQueryData<Session[]>(opencodeKeys.sessions())
+                ?.find((s) => s.id === info.id)?.title ??
+              queryClient.getQueryData<Session>(opencodeKeys.session(info.id))?.title ??
+              null;
+            const titleChanged = !!info.title && info.title !== prevTitle;
             // Only update individual session cache (cheap, targeted)
             queryClient.setQueryData(opencodeKeys.session(info.id), info);
             // Update session list only if the session actually changed
@@ -703,6 +722,7 @@ export function useOpenCodeEventStream() {
               next[idx] = info;
               return next.sort((a, b) => b.time.updated - a.time.updated);
             });
+            if (titleChanged) refetchKortixSessionMirrors(queryClient);
           }
           break;
         }

--- a/apps/web/src/hooks/opencode/use-opencode-events.ts
+++ b/apps/web/src/hooks/opencode/use-opencode-events.ts
@@ -9,7 +9,6 @@ import { authenticatedFetch, getSupabaseAccessToken, invalidateTokenCache } from
 import { deleteSessionFromIDB, saveSessionToIDB } from '@/lib/idb-sync-cache';
 import { logger } from '@/lib/logger';
 import { getClient, resetClient } from '@/lib/opencode-sdk';
-import { syncOpencodeSessionData } from '@/lib/projects-client';
 import {
   notifyPermissionRequest,
   notifyQuestion,
@@ -35,39 +34,6 @@ const messageRehydrateInFlight = new Set<string>();
 const messageRehydrateLastAt = new Map<string, number>();
 let projectMetadataRefetchLastAt = 0;
 let projectMetadataRefetchTimer: ReturnType<typeof setTimeout> | null = null;
-
-function syncOpenCodeSessionSnapshot(
-  info: Session,
-  queryClient?: QueryClient,
-  // When the opencode-side title changed (e.g. auto-generated after the first
-  // message), refetch the KORTIX session list so the sidebar tabs + project
-  // sidebar pick up the new name immediately — otherwise the name only refreshed
-  // on the next session-create invalidation ("title shows up only after I start
-  // a new session"). project_sessions rows are the mirror target; refetch them
-  // AFTER the mirror POST lands so we read the freshly-written name.
-  refreshKortixSessions = false,
-): void {
-  void syncOpencodeSessionData([
-    {
-      opencode_session_id: info.id,
-      title: info.title || null,
-      parent_id: info.parentID ?? null,
-      project_id: info.projectID ?? null,
-      created_at: info.time?.created ?? null,
-      updated_at: info.time?.updated ?? null,
-      archived_at: info.time?.archived ?? null,
-    },
-  ])
-    .then(() => {
-      if (refreshKortixSessions && queryClient) {
-        // Prefix match → refreshes ['project-sessions', projectId] (tabs +
-        // sidebar) and ['project-session', …] for every active query.
-        queryClient.refetchQueries({ queryKey: ['project-sessions'], type: 'active' });
-        queryClient.refetchQueries({ queryKey: ['project-session'], type: 'active' });
-      }
-    })
-    .catch(() => {});
-}
 
 /**
  * session.created/updated/deleted carry the Session object either nested under
@@ -711,8 +677,6 @@ export function useOpenCodeEventStream() {
               return [info, ...old].sort((a, b) => b.time.updated - a.time.updated);
             });
             queryClient.setQueryData(opencodeKeys.session(info.id), info);
-            // New session → the Kortix session list changed; refresh it.
-            syncOpenCodeSessionSnapshot(info, queryClient, true);
           }
           break;
         }
@@ -720,15 +684,6 @@ export function useOpenCodeEventStream() {
         case 'session.updated': {
           const info = readSessionInfo(event);
           if (info) {
-            // Did the title change? (opencode auto-titles after the first
-            // message via session.updated.) Capture BEFORE we overwrite caches.
-            const prevTitle =
-              queryClient
-                .getQueryData<Session[]>(opencodeKeys.sessions())
-                ?.find((s) => s.id === info.id)?.title ??
-              queryClient.getQueryData<Session>(opencodeKeys.session(info.id))?.title ??
-              null;
-            const titleChanged = !!info.title && info.title !== prevTitle;
             // Only update individual session cache (cheap, targeted)
             queryClient.setQueryData(opencodeKeys.session(info.id), info);
             // Update session list only if the session actually changed
@@ -748,10 +703,6 @@ export function useOpenCodeEventStream() {
               next[idx] = info;
               return next.sort((a, b) => b.time.updated - a.time.updated);
             });
-            // Mirror + (only when the name actually changed) refresh the Kortix
-            // session list so tabs/sidebar show the new title without waiting for
-            // the next create. titleChanged gate keeps streaming churn cheap.
-            syncOpenCodeSessionSnapshot(info, queryClient, titleChanged);
           }
           break;
         }

--- a/apps/web/src/lib/projects-client.ts
+++ b/apps/web/src/lib/projects-client.ts
@@ -1869,13 +1869,12 @@ export interface ProjectSession {
   opencode_session_id: string | null;
   /**
    * Resolved display name: the user-set `custom_name` if present, otherwise the
-   * auto title mirrored from opencode's session.title via
-   * /v1/projects/sync-opencode-sessions (metadata.name in the DB).
+   * auto title mirrored from OpenCode server-side during project session reads.
    */
   name: string | null;
   /**
    * The user-set name override (metadata.custom_name). Authoritative — when
-   * present it always wins over the live opencode root title. null = no
+   * present it always wins over the server-mirrored OpenCode title. null = no
    * override (display falls back to the auto title / branch).
    */
   custom_name: string | null;
@@ -2097,28 +2096,6 @@ export async function restartProjectSession(
     await backendApi.post<{ ok: boolean; session_id: string; status: string }>(
       `/projects/${projectId}/sessions/${sessionId}/restart`,
       {},
-    ),
-  );
-}
-
-export interface SyncOpencodeSessionEntry {
-  opencode_session_id: string;
-  title: string | null;
-  parent_id?: string | null;
-  project_id?: string | null;
-  created_at?: number | null;
-  updated_at?: number | null;
-  archived_at?: number | null;
-}
-
-export async function syncOpencodeSessionData(
-  entries: SyncOpencodeSessionEntry[],
-) {
-  if (entries.length === 0) return { updated: 0 };
-  return unwrap(
-    await backendApi.post<{ updated: number }>(
-      `/projects/sync-opencode-sessions`,
-      { entries },
     ),
   );
 }

--- a/tests/spec/end-to-end.md
+++ b/tests/spec/end-to-end.md
@@ -181,11 +181,11 @@ DB `project_sessions` (`status queued|branching|provisioning|running|stopped|fai
 `SESS-3` CLI client-branch optimization — `kortix sessions new`: if server can't self-create branch (not managed-freestyle, not GitHub app/pat) AND local `origin` == `project.repo_url`, CLI mints uuid, `git push origin HEAD:refs/heads/<uuid>`, then posts `session_id`+`branch_already_created:true`+`base_ref`.
 `SESS-4` `GET /projects/:id/sessions` → `read` → list (updatedAt desc).
 `SESS-5` `GET /projects/:id/sessions/:sid` → `read` → 200; non-uuid `sid` → 400.
-`SESS-6` `PATCH /projects/:id/sessions/:sid {name?,metadata?}` → `write`; attempting `status`/`sandbox_url`/`error`/`opencode_session_id` → 400 (server-managed); any other field → 400 (not user-editable). `name` sets a sticky USER override stored in `metadata.custom_name` (NOT clobbered by `/sync-opencode-sessions`, which only writes the auto title `metadata.name`); `name:""`/null clears it. Response `name` = resolved display (`custom_name ?? metadata.name`); `custom_name` exposed separately (authoritative override or null).
+`SESS-6` `PATCH /projects/:id/sessions/:sid {name?,metadata?}` → `write`; attempting `status`/`sandbox_url`/`error`/`opencode_session_id` → 400 (server-managed); any other field → 400 (not user-editable). `name` sets a sticky USER override stored in `metadata.custom_name` (NOT clobbered by the server-side OpenCode title mirror, which only writes the auto title `metadata.name` during session reads); `name:""`/null clears it. Response `name` = resolved display (`custom_name ?? metadata.name`); `custom_name` exposed separately (authoritative override or null).
 `SESS-7` `DELETE /projects/:id/sessions/:sid` → `write` → 200 soft-delete status `stopped`; **remote branch preserved**.
 `SESS-8` `GET /projects/:id/sessions/:sid/sandbox` → `read` → `session_sandboxes` row; **404 while row not yet inserted** (frontend polls); then status `provisioning`→`active` with `base_url`/`external_id`.
 `SESS-9` `POST /projects/:id/sessions/:sid/restart` → `write` → **202**; tears down container, revokes sandbox keys, re-provisions with rotated git/LLM/CLI tokens (status→`provisioning`); branch preserved.
-`SESS-10` `POST /projects/sync-opencode-titles {entries[]}` → mirrors OpenCode titles → `metadata.name` (per-row write check).
+`SESS-10` OpenCode title/tree mirror is server-owned: `GET /projects/:id/sessions` and `GET /projects/:id/sessions/:sid` read the sandbox's OpenCode sessions server-side and mirror `metadata.name`/`metadata.opencode_sessions`; there is no browser-write sync endpoint.
 
 ---
 

--- a/tests/spec/routes.generated.json
+++ b/tests/spec/routes.generated.json
@@ -1,6 +1,6 @@
 {
   "generatedAt": "static",
-  "count": 384,
+  "count": 383,
   "routes": [
     {
       "method": "GET",
@@ -1285,10 +1285,6 @@
     {
       "method": "GET",
       "path": "/v1/projects/suna-migration/status"
-    },
-    {
-      "method": "POST",
-      "path": "/v1/projects/sync-opencode-sessions"
     },
     {
       "method": "POST",

--- a/tests/src/flows/projects-misc.flow.ts
+++ b/tests/src/flows/projects-misc.flow.ts
@@ -2,11 +2,9 @@
  * Projects — miscellaneous project-scoped surfaces that don't fit the core CRUD
  * flow: BYO-repo create, the CLI-token (project PAT)
  * lifecycle, onboarding state, version-diff preview, ChatGPT headless provider
- * auth, the lazy legacy-migration pipeline, OpenCode session sync, and the
- * Slack-relay turn endpoints.
+ * auth, the lazy legacy-migration pipeline, and the Slack-relay turn endpoints.
  *
- * Maps to spec §13 (PROJ-2 for BYO create; PROJ-9..PROJ-17 minted here) and
- * reuses SESS-10 for sync-opencode-sessions.
+ * Maps to spec §13 (PROJ-2 for BYO create; PROJ-9..PROJ-17 minted here).
  */
 import { flow } from "../core/flow";
 
@@ -279,29 +277,6 @@ flow(
         .as(ctx.P.OWNER)
         .post("/v1/projects/legacy-migration/start", { sandbox_id: "00000000-0000-4000-a000-000000000000" });
       r.status(404);
-    });
-  },
-);
-
-// SESS-10 — sync-opencode-sessions. Spec lists the path as
-// `sync-opencode-titles`; the implemented route is `sync-opencode-sessions`
-// with the same `{entries[]}` body. Empty array → 200 {updated:0}; a non-array
-// `entries` → 400.
-flow(
-  "SESS-10",
-  { domain: "projects", routes: ["POST /v1/projects/sync-opencode-sessions"] },
-  async (ctx) => {
-    await ctx.step("empty entries → 200 updated:0", async () => {
-      const r = await ctx.client.as(ctx.P.OWNER).post("/v1/projects/sync-opencode-sessions", { entries: [] });
-      r.status(200).body().has("$.updated", 0);
-    });
-    await ctx.step("entries not an array → 400", async () => {
-      const r = await ctx.client.as(ctx.P.OWNER).post("/v1/projects/sync-opencode-sessions", { entries: "nope" });
-      r.status(400);
-    });
-    await ctx.step("ANON → 401", async () => {
-      const r = await ctx.client.as(ctx.P.ANON).post("/v1/projects/sync-opencode-sessions", { entries: [] });
-      r.status(401);
     });
   },
 );


### PR DESCRIPTION
## Summary
- move OpenCode title/tree mirroring into API session reads
- remove the browser-write sync endpoint and stale client/test references
- refetch active Kortix session queries after OpenCode title events so the UI picks up server-owned mirrors

## Verification
- pnpm --filter kortix-api typecheck
- pnpm --filter Kortix-Computer-Frontend exec eslint --max-warnings=0 src/hooks/opencode/use-opencode-events.ts src/app/'(app)'/projects/'[id]'/sessions/'[sessionId]'/page.tsx src/lib/projects-client.ts src/components/projects/session-label.ts src/features/co-worker/project-sidebar/project-session-list.tsx
- SUPABASE_URL=http://localhost:54321 INTERNAL_KORTIX_ENV=dev FREESTYLE_API_URL=http://localhost:8000 FRONTEND_URL=http://localhost:3000 ALLOWED_SANDBOX_PROVIDERS=daytona,local_docker pnpm --filter kortix-api exec bun test src/__tests__/unit-opencode-title-sync.test.ts
- SUPABASE_URL=http://localhost:54321 INTERNAL_KORTIX_ENV=dev FREESTYLE_API_URL=http://localhost:8000 FRONTEND_URL=http://localhost:3000 ALLOWED_SANDBOX_PROVIDERS=daytona,local_docker pnpm --filter kortix-api exec bun test src/__tests__/e2e-project-session-contract.test.ts
