### PR TITLE
fix(sandbox): harden billing reaper follow-up

### DIFF
--- a/apps/api/src/__tests__/e2e-project-maintenance.test.ts
+++ b/apps/api/src/__tests__/e2e-project-maintenance.test.ts
@@ -98,19 +98,6 @@ mock.module('../projects/git', () => ({
   invalidateProjectMirror: () => {},
 }));
 
-mock.module('../projects/sandbox-reaper', () => ({
-  reapAndReconcileSandboxes: async () => ({
-    candidates: 0,
-    stopped: 0,
-    reconciled: 0,
-    billingClosed: 0,
-    skipped: 0,
-    errors: 0,
-  }),
-  reconcileOrphanComputeSessions: async () => ({ checked: 0, closed: 0, errors: 0 }),
-  countBillingInvariantViolations: async () => 0,
-}));
-
 const {
   hasOpenPullRequestMarker,
   postgresTimestampParam,

--- a/apps/api/src/platform/webhooks/routes.ts
+++ b/apps/api/src/platform/webhooks/routes.ts
@@ -1,6 +1,15 @@
 import { createRoute, z } from '@hono/zod-openapi';
 import { makeOpenApiApp, json, errors } from '../../openapi';
+import { config } from '../../config';
 import { handleDaytonaWebhook, handlePlatinumWebhook } from './sandbox-webhooks';
+
+const MAX_WEBHOOK_BODY_BYTES = 1024 * 1024;
+
+function contentLengthTooLarge(value: string | undefined): boolean {
+  if (!value) return false;
+  const n = Number.parseInt(value, 10);
+  return Number.isFinite(n) && n > MAX_WEBHOOK_BODY_BYTES;
+}
 
 /**
  * Sandbox lifecycle webhook ingress (NOT billing — these are provider state
@@ -28,10 +37,12 @@ sandboxWebhooksApp.openapi(
     summary: 'Daytona sandbox lifecycle webhook (Svix-signed, public)',
     responses: {
       200: json(z.record(z.string(), z.any()), 'Webhook processing result'),
-      ...errors(400, 401, 503),
+      ...errors(400, 401, 413, 503),
     },
   }),
   async (c: any) => {
+    if (!config.DAYTONA_WEBHOOK_SECRET) return c.json({ error: 'daytona webhook not configured' }, 503);
+    if (contentLengthTooLarge(c.req.header('content-length'))) return c.json({ error: 'webhook body too large' }, 413);
     const rawBody = await c.req.text();
     const { status, body } = await handleDaytonaWebhook(rawBody, (h: string) => c.req.header(h));
     return c.json(body, status);
@@ -46,10 +57,12 @@ sandboxWebhooksApp.openapi(
     summary: 'Platinum sandbox lifecycle webhook (HMAC-SHA-256, public)',
     responses: {
       200: json(z.record(z.string(), z.any()), 'Webhook processing result'),
-      ...errors(400, 401, 503),
+      ...errors(400, 401, 413, 503),
     },
   }),
   async (c: any) => {
+    if (!config.PLATINUM_WEBHOOK_SECRET) return c.json({ error: 'platinum webhook not configured' }, 503);
+    if (contentLengthTooLarge(c.req.header('content-length'))) return c.json({ error: 'webhook body too large' }, 413);
     const rawBody = await c.req.text();
     const { status, body } = await handlePlatinumWebhook(rawBody, (h: string) => c.req.header(h));
     return c.json(body, status);

--- a/apps/api/src/platform/webhooks/sandbox-webhooks.test.ts
+++ b/apps/api/src/platform/webhooks/sandbox-webhooks.test.ts
@@ -5,10 +5,12 @@ const cfg: { DAYTONA_WEBHOOK_SECRET?: string; PLATINUM_WEBHOOK_SECRET?: string }
 let stoppedCalls: string[] = [];
 let removedCalls: string[] = [];
 let dedupSeen: Set<string> = new Set();
+let throwDedup = false;
 
 mock.module('../../config', () => ({ config: cfg }));
 mock.module('../../billing/services/webhook-concurrency', () => ({
   recordWebhookEvent: async (id: string) => {
+    if (throwDedup) throw new Error('dedupe down');
     if (dedupSeen.has(id)) return false;
     dedupSeen.add(id);
     return true;
@@ -39,12 +41,18 @@ beforeEach(() => {
   stoppedCalls = [];
   removedCalls = [];
   dedupSeen = new Set();
+  throwDedup = false;
 });
 
 describe('classifyLifecycle', () => {
   test('terminal states → stopped', () => {
-    for (const s of ['stopped', 'stopping', 'archived', 'archiving']) {
+    for (const s of ['stopped', 'archived']) {
       expect(classifyLifecycle(s, 'sandbox.state.updated')).toBe('stopped');
+    }
+  });
+  test('transitional stop/archive states → noop until terminal', () => {
+    for (const s of ['stopping', 'archiving']) {
+      expect(classifyLifecycle(s, 'sandbox.state.updated')).toBe('noop');
     }
   });
   test('destroyed/deleted/lost or delete event → removed', () => {
@@ -81,17 +89,26 @@ describe('verifySvix (Daytona)', () => {
   const secretRaw = Buffer.from('daytona-test-key').toString('base64');
   const secret = `whsec_${secretRaw}`;
   const id = 'msg_1';
-  const ts = '1700000000';
   const body = '{"event":"sandbox.state.updated","id":"sb2","newState":"stopped"}';
-  const expected = createHmac('sha256', Buffer.from(secretRaw, 'base64'))
-    .update(`${id}.${ts}.${body}`, 'utf8')
-    .digest('base64');
+  function sign(ts: string): string {
+    return createHmac('sha256', Buffer.from(secretRaw, 'base64'))
+      .update(`${id}.${ts}.${body}`, 'utf8')
+      .digest('base64');
+  }
   test('accepts a correct v1 signature', () => {
+    const ts = String(Math.floor(Date.now() / 1000));
+    const expected = sign(ts);
     expect(verifySvix(body, secret, { id, timestamp: ts, signature: `v1,${expected}` })).toBe(true);
   });
   test('rejects wrong / incomplete', () => {
+    const ts = String(Math.floor(Date.now() / 1000));
+    const expected = sign(ts);
     expect(verifySvix(body, secret, { id, timestamp: ts, signature: 'v1,nope' })).toBe(false);
     expect(verifySvix(body, secret, { id: undefined, timestamp: ts, signature: `v1,${expected}` })).toBe(false);
+  });
+  test('rejects stale signed deliveries', () => {
+    const ts = String(Math.floor(Date.now() / 1000) - 3600);
+    expect(verifySvix(body, secret, { id, timestamp: ts, signature: `v1,${sign(ts)}` })).toBe(false);
   });
 });
 
@@ -121,17 +138,25 @@ describe('handleDaytonaWebhook', () => {
   test('closes billing on a stopped state', async () => {
     cfg.DAYTONA_WEBHOOK_SECRET = secret;
     const body = JSON.stringify({ event: 'sandbox.state.updated', id: 'sbA', newState: 'stopped', updatedAt: 't1' });
-    const r = await handleDaytonaWebhook(body, svixHeaders(secret, 'm1', '100', body));
+    const r = await handleDaytonaWebhook(body, svixHeaders(secret, 'm1', String(Math.floor(Date.now() / 1000)), body));
     expect(r.status).toBe(200);
     expect(stoppedCalls).toEqual(['sbA']);
   });
   test('dedupes a repeated delivery', async () => {
     cfg.DAYTONA_WEBHOOK_SECRET = secret;
     const body = JSON.stringify({ event: 'sandbox.state.updated', id: 'sbB', newState: 'stopped', updatedAt: 't1' });
-    const hdr = svixHeaders(secret, 'm2', '100', body);
+    const hdr = svixHeaders(secret, 'm2', String(Math.floor(Date.now() / 1000)), body);
     await handleDaytonaWebhook(body, hdr);
     await handleDaytonaWebhook(body, hdr);
     expect(stoppedCalls).toEqual(['sbB']); // second is deduped
+  });
+  test('fails closed when dedupe storage is unavailable', async () => {
+    cfg.DAYTONA_WEBHOOK_SECRET = secret;
+    throwDedup = true;
+    const body = JSON.stringify({ event: 'sandbox.state.updated', id: 'sbC', newState: 'stopped', updatedAt: 't1' });
+    const r = await handleDaytonaWebhook(body, svixHeaders(secret, 'm3', String(Math.floor(Date.now() / 1000)), body));
+    expect(r.status).toBe(503);
+    expect(stoppedCalls).toEqual([]);
   });
 });
 
@@ -158,6 +183,23 @@ describe('handlePlatinumWebhook', () => {
     const r = await handlePlatinumWebhook(body, hmacHeader(body));
     expect(r.status).toBe(200);
     expect(stoppedCalls).toEqual([]);
+    expect(removedCalls).toEqual([]);
+  });
+  test('does not dedupe distinct lifecycle events for the same sandbox id', async () => {
+    cfg.PLATINUM_WEBHOOK_SECRET = secret;
+    const created = JSON.stringify({ event: 'sandbox.created', id: 'pZ', state: 'running' });
+    const deleted = JSON.stringify({ event: 'sandbox.deleted', id: 'pZ', state: 'deleted' });
+    await handlePlatinumWebhook(created, hmacHeader(created));
+    const r = await handlePlatinumWebhook(deleted, hmacHeader(deleted));
+    expect(r.status).toBe(200);
+    expect(removedCalls).toEqual(['pZ']);
+  });
+  test('fails closed when dedupe storage is unavailable', async () => {
+    cfg.PLATINUM_WEBHOOK_SECRET = secret;
+    throwDedup = true;
+    const body = JSON.stringify({ event: 'sandbox.deleted', id: 'pErr', state: 'deleted' });
+    const r = await handlePlatinumWebhook(body, hmacHeader(body));
+    expect(r.status).toBe(503);
     expect(removedCalls).toEqual([]);
   });
 });

--- a/apps/api/src/platform/webhooks/sandbox-webhooks.ts
+++ b/apps/api/src/platform/webhooks/sandbox-webhooks.ts
@@ -27,6 +27,7 @@ import {
 } from '../../projects/sandbox-reaper';
 
 export type SandboxLifecycleOutcome = 'stopped' | 'removed' | 'noop';
+const SVIX_TIMESTAMP_TOLERANCE_SECONDS = 5 * 60;
 
 /**
  * Map a provider state / event name to the billing action. Only the terminal
@@ -38,7 +39,7 @@ export function classifyLifecycle(state: string | undefined | null, eventType: s
   const e = (eventType ?? '').toLowerCase();
   if (e.includes('delet') || e.includes('destroy')) return 'removed';
   if (['destroyed', 'deleted', 'removed', 'lost', 'failed-start'].includes(s)) return 'removed';
-  if (['stopped', 'stopping', 'archived', 'archiving'].includes(s)) return 'stopped';
+  if (['stopped', 'archived'].includes(s)) return 'stopped';
   return 'noop';
 }
 
@@ -77,6 +78,10 @@ export function verifySvix(
 ): boolean {
   const { id, timestamp, signature } = parts;
   if (!id || !timestamp || !signature) return false;
+  const timestampSeconds = Number.parseInt(timestamp, 10);
+  if (!Number.isFinite(timestampSeconds)) return false;
+  const ageSeconds = Math.abs(Math.floor(Date.now() / 1000) - timestampSeconds);
+  if (ageSeconds > SVIX_TIMESTAMP_TOLERANCE_SECONDS) return false;
   const key = Buffer.from(secret.replace(/^whsec_/, ''), 'base64');
   const signedContent = `${id}.${timestamp}.${rawBody}`;
   const expected = createHmac('sha256', key).update(signedContent, 'utf8').digest('base64');
@@ -136,8 +141,12 @@ export async function handleDaytonaWebhook(
   const newState: string | undefined = event?.newState ?? event?.state ?? event?.data?.state;
   if (!externalId) return { status: 200, body: { ok: true, ignored: 'no sandbox id' } };
 
-  const dedupId = `daytona:${getHeader('webhook-id') ?? `${externalId}:${newState}:${event?.updatedAt ?? ''}`}`;
-  const fresh = await recordWebhookEvent(dedupId, eventType || 'sandbox.event').catch(() => true);
+  const dedupId = `daytona:${getHeader('webhook-id') ?? `${externalId}:${eventType}:${newState}:${event?.updatedAt ?? ''}`}`;
+  const fresh = await recordWebhookEvent(dedupId, eventType || 'sandbox.event').catch((err) => {
+    console.warn('[sandbox-webhook] Daytona dedupe store unavailable:', err instanceof Error ? err.message : err);
+    return null;
+  });
+  if (fresh == null) return { status: 503, body: { error: 'webhook dedupe unavailable' } };
   if (!fresh) return { status: 200, body: { ok: true, deduped: true } };
 
   const outcome = classifyLifecycle(newState, eventType);
@@ -174,8 +183,13 @@ export async function handlePlatinumWebhook(
   const newState: string | undefined = event?.state ?? event?.new_state ?? event?.newState ?? event?.data?.state;
   if (!externalId) return { status: 200, body: { ok: true, ignored: 'no sandbox id' } };
 
-  const dedupId = `platinum:${event?.id ?? `${externalId}:${eventType}:${event?.timestamp ?? ''}`}`;
-  const fresh = await recordWebhookEvent(dedupId, eventType || 'sandbox.event').catch(() => true);
+  const deliveryId: string | undefined = event?.event_id ?? event?.delivery_id ?? event?.webhook_id ?? event?.data?.event_id;
+  const dedupId = `platinum:${deliveryId ?? `${externalId}:${eventType}:${newState ?? ''}:${event?.timestamp ?? ''}`}`;
+  const fresh = await recordWebhookEvent(dedupId, eventType || 'sandbox.event').catch((err) => {
+    console.warn('[sandbox-webhook] Platinum dedupe store unavailable:', err instanceof Error ? err.message : err);
+    return null;
+  });
+  if (fresh == null) return { status: 503, body: { error: 'webhook dedupe unavailable' } };
   if (!fresh) return { status: 200, body: { ok: true, deduped: true } };
 
   const outcome = classifyLifecycle(newState, eventType);

--- a/apps/api/src/projects/routes/shared.ts
+++ b/apps/api/src/projects/routes/shared.ts
@@ -1,5 +1,6 @@
 import {
   endComputeSession,
+  pauseComputeSession,
   reopenComputeForSandbox,
 } from '../../billing/services/compute-metering';
 import { config, type SandboxProviderName } from '../../config';
@@ -73,6 +74,7 @@ export async function resumeStoppedSandbox(row: {
       and(
         eq(sessionSandboxes.sandboxId, row.sandboxId),
         eq(sessionSandboxes.status, 'stopped'),
+        sql`NOT (coalesce(${sessionSandboxes.metadata}, '{}'::jsonb) ? 'needsReprovision')`,
       ),
     )
     .returning();
@@ -112,6 +114,12 @@ export async function resumeStoppedSandbox(row: {
     }
     // Revert so a later open retries the resume instead of spinning the health
     // poll against a VM that never came up.
+    await pauseComputeSession(row.sandboxId).catch((billingErr) => {
+      console.warn(
+        `[projects] failed to close reopened compute after resume failure for ${row.sandboxId}:`,
+        billingErr,
+      );
+    });
     await db
       .update(sessionSandboxes)
       .set({ status: 'stopped', updatedAt: new Date() })
@@ -121,6 +129,11 @@ export async function resumeStoppedSandbox(row: {
           eq(sessionSandboxes.externalId, externalId),
         ),
       )
+      .catch(() => {});
+    await db
+      .update(projectSessions)
+      .set({ status: 'stopped', updatedAt: new Date() })
+      .where(eq(projectSessions.sessionId, row.sessionId))
       .catch(() => {});
   });
   return true;
@@ -171,6 +184,7 @@ export async function selectPreResumeTargets(
       eq(sessionSandboxes.status, 'stopped'),
       isNotNull(sessionSandboxes.externalId),
       isNull(sessionSandboxes.poolState),
+      sql`NOT (coalesce(${sessionSandboxes.metadata}, '{}'::jsonb) ? 'needsReprovision')`,
       eq(projectSessions.createdBy, userId),
     ))
     .orderBy(desc(sessionSandboxes.lastUsedAt))

--- a/apps/api/src/projects/sandbox-reaper.test.ts
+++ b/apps/api/src/projects/sandbox-reaper.test.ts
@@ -12,12 +12,14 @@ let stops: string[] = [];
 let cacheInvalidations: string[] = [];
 let pausedCompute: string[] = [];
 let endedCompute: string[] = [];
+let throwPauseCompute = false;
 let updateCalls: Array<{ table: unknown; updates: Record<string, unknown> }> = [];
 
 /** A thenable that also exposes `.limit()` so both `await where()` (turn query)
  *  and `where().limit()` (candidate query) resolve to the same rows. */
 function hybrid(rows: any[], throwOnGroupBy = false) {
   const p: any = Promise.resolve(rows);
+  p.orderBy = () => p;
   p.limit = async () => rows;
   p.groupBy = async () => {
     if (throwOnGroupBy) throw new Error('db down');
@@ -78,6 +80,7 @@ mock.module('../sandbox-proxy', () => ({
 
 mock.module('../billing/services/compute-metering', () => ({
   pauseComputeSession: async (sandboxId: string) => {
+    if (throwPauseCompute) throw new Error('billing down');
     pausedCompute.push(sandboxId);
   },
   endComputeSession: async (sandboxId: string) => {
@@ -100,6 +103,7 @@ beforeEach(() => {
   cacheInvalidations = [];
   pausedCompute = [];
   endedCompute = [];
+  throwPauseCompute = false;
   updateCalls = [];
 });
 
@@ -229,6 +233,19 @@ describe('reapAndReconcileSandboxes', () => {
     expect(stops).toEqual([]); // never poke a stopped box
     expect(pausedCompute).toEqual(['sb-1']);
     expect(updateCalls.some((c) => c.table === sessionSandboxes && c.updates.status === 'stopped')).toBe(true);
+  });
+
+  test('does not write stopped state if billing close fails', async () => {
+    candidates = [candidate()];
+    statusByExternal['ext-1'] = 'stopped';
+    throwPauseCompute = true;
+
+    const r = await reapAndReconcileSandboxes(NOW);
+
+    expect(r.errors).toBe(1);
+    expect(r.reconciled).toBe(0);
+    expect(r.billingClosed).toBe(0);
+    expect(updateCalls.some((c) => c.table === sessionSandboxes && c.updates.status === 'stopped')).toBe(false);
   });
 
   test('leaves a recently-active box running', async () => {

--- a/apps/api/src/projects/sandbox-reaper.ts
+++ b/apps/api/src/projects/sandbox-reaper.ts
@@ -28,7 +28,7 @@
  * invariant rather than a best-effort.
  */
 
-import { and, eq, inArray, isNotNull, sql } from 'drizzle-orm';
+import { and, asc, eq, inArray, isNotNull, sql } from 'drizzle-orm';
 import { projectSessions, sessionSandboxes } from '@kortix/db';
 import { db } from '../shared/db';
 import { getProvider, type ProviderName, type SandboxStatus } from '../platform/providers';
@@ -168,9 +168,7 @@ interface ReapCandidate {
 async function reconcileRowToStopped(row: ReapCandidate, now: Date, quiesce: boolean, reprovision: boolean): Promise<void> {
   // Close billing FIRST (computes the wall-clock delta against the still-active
   // metering row), then flip status, so the final window is billed correctly.
-  await pauseComputeSession(row.sandboxId).catch((err) =>
-    console.warn(`[reaper] pauseComputeSession failed for ${row.sandboxId}:`, err instanceof Error ? err.message : err),
-  );
+  await pauseComputeSession(row.sandboxId);
   const meta = buildIdleStopMetadata({ quiesce, reprovision, nowIso: now.toISOString() });
   await db
     .update(sessionSandboxes)
@@ -223,6 +221,7 @@ export async function reapAndReconcileSandboxes(now = new Date()): Promise<ReapR
       // Unclaimed warm-pool spares manage their own lifecycle.
       sql`${sessionSandboxes.poolState} IS NULL`,
     ))
+    .orderBy(asc(sessionSandboxes.createdAt))
     .limit(REAP_BATCH_SIZE)) as ReapCandidate[];
 
   const result: ReapResult = { candidates: rows.length, stopped: 0, reconciled: 0, billingClosed: 0, skipped: 0, errors: 0 };
@@ -290,9 +289,7 @@ export async function reapAndReconcileSandboxes(now = new Date()): Promise<ReapR
             result.billingClosed += 1;
             break;
           case 'reconcile-removed':
-            await endComputeSession(row.sandboxId).catch((err) =>
-              console.warn(`[reaper] endComputeSession failed for ${row.sandboxId}:`, err instanceof Error ? err.message : err),
-            );
+            await endComputeSession(row.sandboxId);
             // Status MUST be 'stopped' (not 'archived'): openSession only honors
             // `needsReprovision` in its `row.status === 'stopped'` branch. An
             // 'archived' row would fall through to a terminal 'stopped' result and
@@ -415,6 +412,7 @@ export async function reconcileOrphanComputeSessions(): Promise<{ checked: numbe
     .from(sandboxComputeSessions)
     .leftJoin(sessionSandboxes, eq(sessionSandboxes.sandboxId, sandboxComputeSessions.sandboxId))
     .where(eq(sandboxComputeSessions.state, 'active'))
+    .orderBy(asc(sandboxComputeSessions.lastBilledAt))
     .limit(REAP_BATCH_SIZE);
 
   let closed = 0;
@@ -463,9 +461,7 @@ export async function reconcileSandboxStoppedByExternalId(externalId: string, no
     .limit(1);
   if (!row) return false;
   if (row.status === 'stopped' || row.status === 'archived') return false;
-  await pauseComputeSession(row.sandboxId).catch((err) =>
-    console.warn(`[reaper] pauseComputeSession failed for ${row.sandboxId}:`, err instanceof Error ? err.message : err),
-  );
+  await pauseComputeSession(row.sandboxId);
   // Quiesce: a provider-confirmed stop must stay stopped — passive /v1/p traffic
   // (markSandboxUsed heal / wakeSandbox) must not resurrect it. Cleared on an
   // explicit open / real turn.
@@ -490,9 +486,7 @@ export async function reconcileSandboxRemovedByExternalId(externalId: string, no
     .where(eq(sessionSandboxes.externalId, externalId))
     .limit(1);
   if (!row) return false;
-  await endComputeSession(row.sandboxId).catch((err) =>
-    console.warn(`[reaper] endComputeSession failed for ${row.sandboxId}:`, err instanceof Error ? err.message : err),
-  );
+  await endComputeSession(row.sandboxId);
   // 'stopped' (not 'archived') + needsReprovision so openSession's stopped-branch
   // reprovisions a fresh box on the next open (an archived row would strand it).
   await db

--- a/apps/api/src/scripts/reimburse-compute-leak.ts
+++ b/apps/api/src/scripts/reimburse-compute-leak.ts
@@ -7,11 +7,12 @@
  * activity (see projects/sandbox-reaper.ts for the fix). This script makes the
  * affected accounts whole.
  *
- * Policy (decided): FULL refund of every AFFECTED (leaked) compute session —
- * not just the overage portion. A session is "affected" if it was billed past
+ * Policy (decided): FULL refund of every AFFECTED (leaked) compute window —
+ * not just the overage portion. A window is "affected" if it was billed past
  * `lastMeaningfulActivity + grace` (default 15 min), where lastMeaningful =
- * max(last LLM call in usage_events, the session's creation). That flags every
- * session the auto-stop bug touched (including the still-`active` phantom rows)
+ * max(last LLM call in usage_events during that compute window, the window's
+ * start). That flags every window the auto-stop bug touched (including still-
+ * `active` phantom rows)
  * while excluding clean short sessions. The refund for each is its FULL
  * `cost_usd`.
  *
@@ -80,11 +81,6 @@ async function loadAffected(args: Args): Promise<AffectedRow[]> {
     : sql``;
 
   const rows: any = await db.execute(sql`
-    WITH usage AS (
-      SELECT session_id, max(created_at) AS last_usage
-      FROM kortix.usage_events
-      GROUP BY session_id
-    )
     SELECT
       cs.id            AS compute_id,
       cs.account_id    AS account_id,
@@ -98,7 +94,13 @@ async function loadAffected(args: Args): Promise<AffectedRow[]> {
       ))::bigint AS over_seconds
     FROM kortix.sandbox_compute_sessions cs
     LEFT JOIN kortix.session_sandboxes ss ON ss.sandbox_id = cs.sandbox_id
-    LEFT JOIN usage u ON u.session_id = cs.session_id
+    LEFT JOIN LATERAL (
+      SELECT max(ue.created_at) AS last_usage
+      FROM kortix.usage_events ue
+      WHERE ue.session_id = cs.session_id
+        AND ue.created_at >= cs.started_at
+        AND ue.created_at <= coalesce(cs.ended_at, cs.last_billed_at)
+    ) u ON true
     WHERE cs.cost_usd > 0
       ${accountFilter}
       ${projectFilter}

--- a/packages/db/drizzle/20260621043000_account_tokens_session_id.sql
+++ b/packages/db/drizzle/20260621043000_account_tokens_session_id.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "kortix"."account_tokens" ADD COLUMN IF NOT EXISTS "session_id" text;

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1781657425734,
       "tag": "20260617005025_loose_saracen",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1782016200000,
+      "tag": "20260621043000_account_tokens_session_id",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
Follow-up to #3543 after the review branch merged before the remaining hardening fixes landed.

What this tightens:
- fail closed when sandbox webhook dedupe storage is unavailable and avoid acting on transitional stop/archive states
- add Svix timestamp freshness and webhook content-length guards
- keep `needsReprovision` rows out of resume/pre-resume and close reopened compute if provider resume fails
- make reaper reconciliation fail closed when billing close fails, while keeping deterministic batch ordering
- bound reimbursement activity lookup to each compute window
- add the missing Drizzle migration for `account_tokens.session_id`
- remove the maintenance-test sandbox-reaper mock that leaks across Bun test files

Verified locally:
- `pnpm --filter kortix-api typecheck`
- `pnpm --filter @kortix/db typecheck`
- `pnpm --filter kortix-api exec bun test src/platform/webhooks/sandbox-webhooks.test.ts src/projects/sandbox-reaper.test.ts src/__tests__/e2e-project-maintenance.test.ts`
