### PR TITLE
Deploy dev API image dev-c9fda83d [skip ci]

### DIFF
--- a/infra/k8s/envs/dev/values.yaml
+++ b/infra/k8s/envs/dev/values.yaml
@@ -6,7 +6,7 @@
 # Immutable dev tag (CI bumps to dev-<sha8> on each main push). Bootstrap value
 # is :dev-latest until the first deploy-dev-eks run pins an immutable sha.
 image:
-  tag: "dev-fd3be7d4"
+  tag: "dev-c9fda83d"
 kortixVersion: ""
 env:
   internalKortixEnv: dev


### PR DESCRIPTION
GitOps-only bump for dev EKS after the deploy workflow's bump step did not update origin/main. This points Argo at the API image built from c9fda83d.