### PR TITLE
feat(executor): Slack as a native `channel` connector (KORTIX-206 Phase A)

### DIFF
--- a/apps/api/src/__tests__/e2e-executor.test.ts
+++ b/apps/api/src/__tests__/e2e-executor.test.ts
@@ -88,7 +88,7 @@ function makeGatewayDeps(): GatewayDeps {
   return {
     loadConnectorBySlug: async (_p, slug) => world.connectors.get(slug) ?? null,
     loadAction: async (connectorId, rel) => world.actions.get(`${connectorId}|${rel}`) ?? null,
-    resolveCredential: async (connectorId, userId) => world.credentials.get(credKey(connectorId, userId)) ?? null,
+    resolveCredential: async (connector, userId) => world.credentials.get(credKey(connector.connectorId, userId)) ?? null,
     loadPolicies: async (connectorId) => world.policiesByConnector.get(connectorId) ?? [],
     loadProjectPolicies: async () => world.projectPolicies,
     loadDefaultMode: async () => world.defaultMode,

--- a/apps/api/src/__tests__/unit-executor-channels.test.ts
+++ b/apps/api/src/__tests__/unit-executor-channels.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Channel connectors (Slack as a first-class Executor connector).
+ *   • catalog — the fixed Slack action set normalizes to http bindings against
+ *     the Slack Web API, with native param names + correct verbs/risks.
+ *   • parse   — `provider="channel" platform="slack"` round-trips; bad platform
+ *     and a declared auth table are rejected.
+ *   • gateway — a channel call builds the right slack.com/api request with the
+ *     install token as a bearer, and Slack's HTTP-200 `{ok:false}` envelope is
+ *     surfaced as a real error (parity with the in-sandbox CLI's throw).
+ */
+import { describe, expect, test } from 'bun:test';
+import { channelApiBase, channelCatalog } from '../executor/channels';
+import {
+  extractConnectors,
+  connectorSpecToTomlEntry,
+} from '../projects/connectors';
+import { parseManifestString, KNOWN_SCHEMA_VERSION } from '../projects/triggers';
+import {
+  handleCall,
+  type CallInput,
+  type GatewayConnector,
+  type GatewayAction,
+  type GatewayDeps,
+} from '../executor/gateway';
+
+/* ─── catalog ─────────────────────────────────────────────────────────────── */
+
+describe('channelCatalog(slack)', () => {
+  const actions = channelCatalog('slack');
+  const byPath = new Map(actions.map((a) => [a.path, a]));
+
+  test('exposes the full native Slack surface as http bindings', () => {
+    // 14 native Web API methods (relay/typing/download/manifest/file-upload are CLI-side).
+    expect(actions.length).toBe(14);
+    for (const a of actions) {
+      expect(a.binding.kind).toBe('http');
+      if (a.binding.kind === 'http') expect(a.binding.path.startsWith('/')).toBe(true);
+    }
+  });
+
+  test('send_message → POST /chat.postMessage, write, channel required', () => {
+    const a = byPath.get('send_message')!;
+    expect(a.binding).toEqual({ kind: 'http', method: 'POST', path: '/chat.postMessage' });
+    expect(a.risk).toBe('write');
+    expect((a.inputSchema as any).required).toContain('channel');
+  });
+
+  test('get_history → GET /conversations.history, read', () => {
+    const a = byPath.get('get_history')!;
+    expect(a.binding).toEqual({ kind: 'http', method: 'GET', path: '/conversations.history' });
+    expect(a.risk).toBe('read');
+  });
+
+  test('delete_message is destructive; reactions use Slack native param names', () => {
+    expect(byPath.get('delete_message')!.risk).toBe('destructive');
+    const react = byPath.get('add_reaction')!;
+    const props = Object.keys((react.inputSchema as any).properties);
+    expect(props).toEqual(['channel', 'timestamp', 'name']); // not ts/emoji — Slack's own names
+  });
+
+  test('auth_test has no inputs; unknown platform → empty', () => {
+    expect(byPath.get('auth_test')!.inputSchema).toBeNull();
+    expect(channelCatalog('nope')).toEqual([]);
+  });
+
+  test('api base', () => {
+    expect(channelApiBase('slack')).toBe('https://slack.com/api');
+  });
+});
+
+/* ─── parse ───────────────────────────────────────────────────────────────── */
+
+function parse(body: string) {
+  const src = [`kortix_version = ${KNOWN_SCHEMA_VERSION}`, '\n[project]\nname = "t"\n', body].join('\n');
+  return extractConnectors(parseManifestString(src));
+}
+
+describe('[[connectors]] provider="channel"', () => {
+  test('slack platform parses + round-trips through TOML', () => {
+    const { specs, errors } = parse(`
+[[connectors]]
+slug = "slack"
+provider = "channel"
+platform = "slack"
+`);
+    expect(errors).toEqual([]);
+    expect(specs[0]).toMatchObject({ slug: 'slack', provider: 'channel', platform: 'slack' });
+    expect(connectorSpecToTomlEntry(specs[0]!)).toMatchObject({ provider: 'channel', platform: 'slack' });
+  });
+
+  test('missing / unknown platform is rejected', () => {
+    expect(parse(`
+[[connectors]]
+slug = "x"
+provider = "channel"
+`).errors[0]!.error).toMatch(/platform/);
+    expect(parse(`
+[[connectors]]
+slug = "x"
+provider = "channel"
+platform = "discord"
+`).errors[0]!.error).toMatch(/platform/);
+  });
+
+  test('declaring [connectors.auth] is rejected (credential is the install token)', () => {
+    const { errors } = parse(`
+[[connectors]]
+slug = "slack"
+provider = "channel"
+platform = "slack"
+
+  [connectors.auth]
+  type = "bearer"
+`);
+    expect(errors[0]!.error).toMatch(/install token/);
+  });
+});
+
+/* ─── gateway execution ───────────────────────────────────────────────────── */
+
+const SLACK: GatewayConnector = {
+  connectorId: 'conn-slack',
+  slug: 'slack',
+  provider: 'channel',
+  baseUrl: 'https://slack.com/api',
+  auth: { type: 'bearer', in: 'header', name: null, prefix: null },
+  hasAuth: true,
+  shareScope: 'project',
+  grants: [],
+  credentialMode: 'shared',
+  enabled: true,
+};
+
+const SEND: GatewayAction = {
+  path: 'slack.send_message',
+  relPath: 'send_message',
+  inputSchema: { type: 'object', properties: { channel: {}, text: {} }, required: ['channel'] },
+  risk: 'write',
+  binding: { kind: 'http', method: 'POST', path: '/chat.postMessage' },
+};
+
+function makeDeps(body: string, status = 200) {
+  const fetchCalls: Array<{ url: string; method: string; headers: Record<string, string>; body?: string }> = [];
+  const deps: GatewayDeps = {
+    loadConnectorBySlug: async () => SLACK,
+    loadAction: async () => SEND,
+    resolveCredential: async () => 'xoxb-install-token',
+    loadPolicies: async () => [],
+    loadProjectPolicies: async () => [],
+    loadDefaultMode: async () => 'allow_all',
+    recordExecution: async () => {},
+    fetchImpl: async (url, init) => {
+      fetchCalls.push({ url, ...init });
+      return { status, ok: status >= 200 && status < 300, text: async () => body };
+    },
+  };
+  return { deps, fetchCalls };
+}
+
+const input: CallInput = {
+  projectId: 'proj-1',
+  accountId: 'acct-1',
+  subject: { userId: 'u1', groupIds: [] },
+  sessionId: 'sess-1',
+  connectorSlug: 'slack',
+  actionPath: 'send_message',
+  args: { channel: 'C123', text: 'hi' },
+};
+
+describe('handleCall — channel (slack)', () => {
+  test('builds the slack.com/api request, attaches the install token as bearer', async () => {
+    const { deps, fetchCalls } = makeDeps('{"ok":true,"ts":"123.45","channel":"C123"}');
+    const res = await handleCall(deps, input);
+    expect(res.status).toBe('ok');
+    expect(fetchCalls[0]!.url).toBe('https://slack.com/api/chat.postMessage');
+    expect(fetchCalls[0]!.method).toBe('POST');
+    expect(fetchCalls[0]!.headers.Authorization).toBe('Bearer xoxb-install-token');
+    expect(JSON.parse(fetchCalls[0]!.body!)).toEqual({ channel: 'C123', text: 'hi' });
+  });
+
+  test('Slack {ok:false} (HTTP 200) is surfaced as an error, not a silent ok', async () => {
+    const { deps } = makeDeps('{"ok":false,"error":"channel_not_found"}');
+    const res = await handleCall(deps, input);
+    expect(res.status).toBe('error');
+    if (res.status === 'error') expect(res.reason).toMatch(/channel_not_found/);
+  });
+});

--- a/apps/api/src/__tests__/unit-executor-gateway.test.ts
+++ b/apps/api/src/__tests__/unit-executor-gateway.test.ts
@@ -57,8 +57,8 @@ function makeDeps(o: FakeOpts = {}) {
   const deps: GatewayDeps = {
     loadConnectorBySlug: async () => (o.connector === undefined ? STRIPE : o.connector),
     loadAction: async () => (o.action === undefined ? CREATE_CHARGE : o.action),
-    resolveCredential: async (connectorId, userId) => {
-      credentialCalls.push({ connectorId, userId });
+    resolveCredential: async (connector, userId) => {
+      credentialCalls.push({ connectorId: connector.connectorId, userId });
       return o.secret === undefined ? 'sk_live_123' : o.secret;
     },
     loadPolicies: async () => o.policies ?? [],

--- a/apps/api/src/channels/slack-oauth.ts
+++ b/apps/api/src/channels/slack-oauth.ts
@@ -7,6 +7,7 @@ import { db } from '../shared/db';
 import { config } from '../config';
 import { slackOauthMode } from './slack-oauth-mode';
 import { saveSlackOauthInstall } from './install-store';
+import { reconcileChannelConnectors } from '../executor/sync';
 import { makeOpenApiApp, errors } from '../openapi';
 
 const STATE_TTL_MS = 10 * 60 * 1000;
@@ -155,6 +156,10 @@ slackOauthApp.openapi(
     });
     return redirectToDashboard(c, { projectId: payload.projectId, error: 'slack_install_save_failed' });
   }
+
+  // Materialize the Slack channel connector so it appears in the Executor right
+  // after connecting (best-effort; never blocks the redirect).
+  void reconcileChannelConnectors(payload.projectId);
 
   return redirectToDashboard(c, { projectId: payload.projectId, success: '1' });
 },

--- a/apps/api/src/executor/channel-materialize.ts
+++ b/apps/api/src/executor/channel-materialize.ts
@@ -1,0 +1,60 @@
+/**
+ * Auto-materialize channel connectors from platform installs.
+ *
+ * A channel connector (Slack today) doesn't need a `[[connectors]]` entry in
+ * kortix.toml — connecting the platform IS the registration. When a project has
+ * a Slack install but hasn't explicitly declared a `channel` connector for it,
+ * we synthesize a ConnectorSpec here so the materializer treats it like any
+ * other connector: it gets DB rows, a fixed action catalog, sharing, policies,
+ * and shows up in the Executor/Connectors surface. The credential is the
+ * existing install token (resolved server-side at call time) — no copy, no
+ * executor_credentials row, no migration. See KORTIX-206.
+ */
+import type { ChannelPlatform, ConnectorSpec } from '../projects/connectors';
+import { channelLabel } from './channels';
+import { loadSlackInstall } from '../channels/install-store';
+import { MANIFEST_FILENAME } from '../projects/triggers';
+
+function channelSpec(platform: ChannelPlatform, slug: string): ConnectorSpec {
+  return {
+    slug,
+    path: `${MANIFEST_FILENAME}#connectors.${slug} (auto: ${platform} install)`,
+    name: channelLabel(platform),
+    enabled: true,
+    provider: 'channel',
+    credentialMode: 'shared',
+    app: null,
+    account: null,
+    url: null,
+    transport: null,
+    endpoint: null,
+    baseUrl: null,
+    platform,
+    spec: null,
+    auth: { type: 'none', in: 'header', name: null, prefix: null, secret: null },
+    policies: [],
+  };
+}
+
+/** True if a channel for `platform` (or anything on its default slug) is already declared. */
+function alreadyDeclared(declared: ConnectorSpec[], platform: ChannelPlatform, slug: string): boolean {
+  return declared.some((s) => s.slug === slug || (s.provider === 'channel' && s.platform === platform));
+}
+
+/**
+ * Synthetic channel ConnectorSpecs for platforms this project has installed but
+ * not explicitly declared in kortix.toml — connecting the platform IS the
+ * registration. We never shadow an explicit declaration: a hand-written
+ * `channel` connector (or anything already using the slug) keeps full control.
+ */
+export async function synthesizeChannelConnectors(
+  projectId: string,
+  declared: ConnectorSpec[],
+): Promise<ConnectorSpec[]> {
+  // Slack (Telegram/Teams slot in here the same way — see KORTIX-206 Phase D).
+  if (!alreadyDeclared(declared, 'slack', 'slack')) {
+    const install = await loadSlackInstall(projectId).catch(() => null);
+    if (install) return [channelSpec('slack', 'slack')];
+  }
+  return [];
+}

--- a/apps/api/src/executor/channels.ts
+++ b/apps/api/src/executor/channels.ts
@@ -1,0 +1,274 @@
+/**
+ * Channel connectors — chat platforms (Slack today; Telegram/Teams next) as
+ * first-class Executor connectors. Unlike the spec-driven providers, a channel's
+ * catalog is a FIXED, hand-curated set of actions (the platform's stable API
+ * surface), and its credential is the platform's existing install token,
+ * resolved server-side from the install-store (no executor_credentials row, no
+ * data migration). Each action is a plain `http` binding against the platform's
+ * API base, so the gateway's existing executeCall runs them unchanged. The
+ * Slack catalog mirrors the in-sandbox `slack` CLI 1:1 for full parity. See
+ * KORTIX-206.
+ */
+import type { ActionBinding, NormalizedAction, Risk } from './types';
+
+// `ChannelPlatform` + the platform allow-list are owned by projects/connectors.ts
+// (the parser layer the executor builds on). This module just maps a platform
+// string → its catalog / API base, so it takes plain strings and returns []/''
+// for anything it doesn't know.
+
+/** Per-platform API base — the connector's baseUrl, where http bindings resolve. */
+export function channelApiBase(platform: string): string {
+  switch (platform) {
+    case 'slack':
+      return 'https://slack.com/api';
+    default:
+      return '';
+  }
+}
+
+/** Human label for a channel connector (UI default name). */
+export function channelLabel(platform: string): string {
+  switch (platform) {
+    case 'slack':
+      return 'Slack';
+    default:
+      return platform;
+  }
+}
+
+/** One curated channel action — normalized into an http-bound NormalizedAction. */
+interface ChannelActionDef {
+  /** Connector-relative tool path (the executor namespace tail, e.g. `send_message`). */
+  path: string;
+  /** Slack Web API method name (the URL tail under https://slack.com/api/<method>). */
+  method: string;
+  /** HTTP verb — POST methods send a JSON body; GET methods send a query string. */
+  verb: 'GET' | 'POST';
+  name: string;
+  description: string;
+  risk: Risk;
+  /** JSON-schema properties using Slack's NATIVE param names (passed through verbatim). */
+  properties: Record<string, { type: string; description: string }>;
+  required: string[];
+}
+
+/**
+ * The Slack catalog — one entry per native Web API method the `slack` CLI
+ * exposes. Property names match Slack's API exactly (channel, ts, timestamp,
+ * name, user, query, file…) so executeCall's http builder passes them straight
+ * through: POST → JSON body, GET → query string, with `Authorization: Bearer`.
+ *
+ * NOT included here (handled outside the gateway, by design):
+ *   • step / send(answer) — the turn-stream relay (Kortix-internal, kept as-is).
+ *   • typing               — a Slack Web-API no-op.
+ *   • download / manifest  — sandbox-FS write / server-meta fetch (CLI-side).
+ *   • send --file          — multi-step external upload (CLI-side helper).
+ */
+const SLACK_ACTIONS: ChannelActionDef[] = [
+  {
+    path: 'send_message',
+    method: 'chat.postMessage',
+    verb: 'POST',
+    name: 'Send message',
+    description: 'Post a message to a Slack channel or thread. Provide `channel` plus `text` and/or Block Kit `blocks`; set `thread_ts` to reply in a thread.',
+    risk: 'write',
+    properties: {
+      channel: { type: 'string', description: 'Channel ID (e.g. C0123) or user ID for a DM.' },
+      text: { type: 'string', description: 'Message text (mrkdwn). Also used as the notification fallback when sending blocks.' },
+      blocks: { type: 'array', description: 'Optional Block Kit blocks for a rich message.' },
+      thread_ts: { type: 'string', description: 'Optional parent message ts to reply in-thread.' },
+    },
+    required: ['channel'],
+  },
+  {
+    path: 'update_message',
+    method: 'chat.update',
+    verb: 'POST',
+    name: 'Update message',
+    description: 'Edit an existing message you posted. Requires `channel` and the message `ts`.',
+    risk: 'write',
+    properties: {
+      channel: { type: 'string', description: 'Channel ID the message is in.' },
+      ts: { type: 'string', description: 'Timestamp (ts) of the message to edit.' },
+      text: { type: 'string', description: 'New message text (mrkdwn).' },
+      blocks: { type: 'array', description: 'Optional replacement Block Kit blocks.' },
+    },
+    required: ['channel', 'ts'],
+  },
+  {
+    path: 'delete_message',
+    method: 'chat.delete',
+    verb: 'POST',
+    name: 'Delete message',
+    description: 'Delete a message you posted. Requires `channel` and the message `ts`.',
+    risk: 'destructive',
+    properties: {
+      channel: { type: 'string', description: 'Channel ID the message is in.' },
+      ts: { type: 'string', description: 'Timestamp (ts) of the message to delete.' },
+    },
+    required: ['channel', 'ts'],
+  },
+  {
+    path: 'add_reaction',
+    method: 'reactions.add',
+    verb: 'POST',
+    name: 'Add reaction',
+    description: 'Add an emoji reaction to a message. Requires `channel`, the message `timestamp`, and the emoji `name` (without colons).',
+    risk: 'write',
+    properties: {
+      channel: { type: 'string', description: 'Channel ID the message is in.' },
+      timestamp: { type: 'string', description: 'Timestamp (ts) of the target message.' },
+      name: { type: 'string', description: 'Emoji name without colons, e.g. "white_check_mark".' },
+    },
+    required: ['channel', 'timestamp', 'name'],
+  },
+  {
+    path: 'get_history',
+    method: 'conversations.history',
+    verb: 'GET',
+    name: 'Get channel history',
+    description: 'Fetch recent messages from a channel. Provide `channel`; optional `limit` (default 20).',
+    risk: 'read',
+    properties: {
+      channel: { type: 'string', description: 'Channel ID to read.' },
+      limit: { type: 'number', description: 'Max messages to return (default 20).' },
+    },
+    required: ['channel'],
+  },
+  {
+    path: 'get_thread',
+    method: 'conversations.replies',
+    verb: 'GET',
+    name: 'Get thread replies',
+    description: 'Fetch the replies in a thread. Requires `channel` and the thread root `ts`; optional `limit`.',
+    risk: 'read',
+    properties: {
+      channel: { type: 'string', description: 'Channel ID the thread is in.' },
+      ts: { type: 'string', description: 'Timestamp (ts) of the thread root message.' },
+      limit: { type: 'number', description: 'Max replies to return (default 20).' },
+    },
+    required: ['channel', 'ts'],
+  },
+  {
+    path: 'list_channels',
+    method: 'conversations.list',
+    verb: 'GET',
+    name: 'List channels',
+    description: 'List public + private channels the bot can see (excludes archived). Optional `limit`.',
+    risk: 'read',
+    properties: {
+      limit: { type: 'number', description: 'Max channels to return (default 100).' },
+      types: { type: 'string', description: 'Comma-separated channel types (default "public_channel,private_channel").' },
+      exclude_archived: { type: 'boolean', description: 'Exclude archived channels (default true).' },
+    },
+    required: [],
+  },
+  {
+    path: 'channel_info',
+    method: 'conversations.info',
+    verb: 'GET',
+    name: 'Get channel info',
+    description: 'Fetch metadata for a single channel. Requires `channel`.',
+    risk: 'read',
+    properties: {
+      channel: { type: 'string', description: 'Channel ID to inspect.' },
+    },
+    required: ['channel'],
+  },
+  {
+    path: 'join_channel',
+    method: 'conversations.join',
+    verb: 'POST',
+    name: 'Join channel',
+    description: 'Join a public channel so the bot can post in it. Requires `channel`.',
+    risk: 'write',
+    properties: {
+      channel: { type: 'string', description: 'Channel ID to join.' },
+    },
+    required: ['channel'],
+  },
+  {
+    path: 'list_users',
+    method: 'users.list',
+    verb: 'GET',
+    name: 'List users',
+    description: 'List workspace members. Optional `limit`.',
+    risk: 'read',
+    properties: {
+      limit: { type: 'number', description: 'Max users to return (default 100).' },
+    },
+    required: [],
+  },
+  {
+    path: 'user_info',
+    method: 'users.info',
+    verb: 'GET',
+    name: 'Get user info',
+    description: 'Fetch a single user profile. Requires the `user` ID.',
+    risk: 'read',
+    properties: {
+      user: { type: 'string', description: 'User ID (e.g. U0123).' },
+    },
+    required: ['user'],
+  },
+  {
+    path: 'auth_test',
+    method: 'auth.test',
+    verb: 'POST',
+    name: 'Identify bot (auth.test)',
+    description: 'Return the authenticated bot identity (user_id, team, bot_id) — the "who am I" call.',
+    risk: 'read',
+    properties: {},
+    required: [],
+  },
+  {
+    path: 'search_messages',
+    method: 'search.messages',
+    verb: 'GET',
+    name: 'Search messages',
+    description: 'Search messages across the workspace. Requires a `query` string.',
+    risk: 'read',
+    properties: {
+      query: { type: 'string', description: 'Slack search query (supports in:, from:, etc.).' },
+    },
+    required: ['query'],
+  },
+  {
+    path: 'file_info',
+    method: 'files.info',
+    verb: 'GET',
+    name: 'Get file info',
+    description: 'Fetch metadata for a file. Requires the `file` ID.',
+    risk: 'read',
+    properties: {
+      file: { type: 'string', description: 'File ID (e.g. F0123).' },
+    },
+    required: ['file'],
+  },
+];
+
+function toAction(def: ChannelActionDef): NormalizedAction {
+  const binding: ActionBinding = { kind: 'http', method: def.verb, path: `/${def.method}` };
+  const inputSchema = Object.keys(def.properties).length
+    ? { type: 'object', properties: def.properties, ...(def.required.length ? { required: def.required } : {}) }
+    : null;
+  return {
+    path: def.path,
+    name: def.name,
+    description: def.description,
+    inputSchema,
+    outputSchema: null,
+    risk: def.risk,
+    binding,
+  };
+}
+
+/** The fixed catalog for a channel platform (empty for an unknown platform). */
+export function channelCatalog(platform: string): NormalizedAction[] {
+  switch (platform) {
+    case 'slack':
+      return SLACK_ACTIONS.map(toAction);
+    default:
+      return [];
+  }
+}

--- a/apps/api/src/executor/db-deps.ts
+++ b/apps/api/src/executor/db-deps.ts
@@ -39,6 +39,7 @@ import {
   type Policy,
 } from './policy';
 import { syncProjectConnectors } from './sync';
+import { loadSlackInstall, loadSlackTokenForProject } from '../channels/install-store';
 import { agentMayUseConnector } from '../iam/agent-scope';
 import {
   finalizePipedreamConnection,
@@ -92,8 +93,38 @@ function baseUrlOf(row: ConnectorRow): string | null {
     case 'http': return cfg.baseUrl ?? null;
     case 'graphql': return cfg.endpoint ?? null;
     case 'mcp': return cfg.url ?? null;
+    case 'channel': return cfg.baseUrl ?? null;
     default: return null;
   }
+}
+
+/* ─── channel connectors: credential = the platform install token ──────────────
+ * A channel connector has no executor_credentials row — its credential is the
+ * existing platform install (resolved server-side, always fresh). These three
+ * helpers are the single home for that dispatch; everything else stays generic.
+ */
+function channelPlatform(config: ConnectorRow['config'] | null): string | null {
+  return (config as Record<string, any> | null)?.platform ?? null;
+}
+
+async function channelToken(projectId: string, platform: string | null): Promise<string | null> {
+  return platform === 'slack' ? loadSlackTokenForProject(projectId) : null;
+}
+
+/** Cheap "is it connected?" — the install exists (no decrypt). */
+async function channelInstalled(projectId: string, platform: string | null): Promise<boolean> {
+  return platform === 'slack' ? (await loadSlackInstall(projectId).catch(() => null)) != null : false;
+}
+
+/**
+ * Whether a connector's credential is present for `userId` — channel connectors
+ * check their platform install; everyone else checks executor_credentials. One
+ * place so the catalog + admin listings don't each re-branch on provider.
+ */
+async function connectorConnected(row: ConnectorRow, userId: string | null): Promise<boolean> {
+  return row.providerType === 'channel'
+    ? channelInstalled(row.projectId, channelPlatform(row.config))
+    : credentialExists(row.connectorId, userId);
 }
 
 function toGatewayConnector(row: ConnectorRow, grants: Awaited<ReturnType<typeof loadConnectorGrants>>): GatewayConnector {
@@ -143,7 +174,20 @@ function makeDbGatewayDeps(): GatewayDeps {
         binding: a.binding as unknown as ActionBinding,
       } satisfies GatewayAction;
     },
-    resolveCredential: (connectorId, userId) => resolveCredentialValue(connectorId, userId),
+    resolveCredential: async (connector, userId) => {
+      // Channel connectors resolve to their platform install token (server-side);
+      // the provider is already in hand, so only the channel path does a lookup —
+      // every other connector takes the original executor_credentials path.
+      if (connector.provider === 'channel') {
+        const [row] = await db
+          .select({ projectId: executorConnectors.projectId, config: executorConnectors.config })
+          .from(executorConnectors)
+          .where(eq(executorConnectors.connectorId, connector.connectorId))
+          .limit(1);
+        return row ? channelToken(row.projectId, channelPlatform(row.config)) : null;
+      }
+      return resolveCredentialValue(connector.connectorId, userId);
+    },
     loadPolicies: loadConnectorPoliciesFor,
     loadProjectPolicies: loadProjectPoliciesFor,
     loadDefaultMode: loadDefaultModeFor,
@@ -289,7 +333,7 @@ async function listCatalog(p: ExecutorPrincipal): Promise<CatalogConnector[]> {
     const { hasAuth } = authOf(row);
     if (hasAuth) {
       const uid = row.credentialMode === 'per_user' ? p.userId : null;
-      if (!(await credentialExists(row.connectorId, uid))) continue; // not connected for this user
+      if (!(await connectorConnected(row, uid))) continue; // not connected for this user
     }
     const connectorPolicies = await loadConnectorPoliciesFor(row.connectorId);
     const actions = await db.select().from(executorConnectorActions).where(eq(executorConnectorActions.connectorId, row.connectorId));
@@ -334,7 +378,7 @@ async function listConnectors(projectId: string, viewerUserId: string): Promise<
     const mode = row.credentialMode as 'shared' | 'per_user';
     let secretSet = !hasAuth;
     if (hasAuth) {
-      secretSet = await credentialExists(row.connectorId, mode === 'per_user' ? viewerUserId : null);
+      secretSet = await connectorConnected(row, mode === 'per_user' ? viewerUserId : null);
     }
     const actions = await db.select().from(executorConnectorActions).where(eq(executorConnectorActions.connectorId, row.connectorId));
     out.push({

--- a/apps/api/src/executor/gateway.ts
+++ b/apps/api/src/executor/gateway.ts
@@ -27,7 +27,7 @@ import type { ActionBinding, Risk } from './types';
 export interface GatewayConnector {
   connectorId: string;
   slug: string;
-  provider: 'pipedream' | 'mcp' | 'openapi' | 'graphql' | 'http';
+  provider: 'pipedream' | 'mcp' | 'openapi' | 'graphql' | 'http' | 'channel';
   /** server / base_url / endpoint / url, per provider (null for some). */
   baseUrl: string | null;
   auth: ExecutorAuth;
@@ -66,8 +66,13 @@ export interface ExecutionRecord {
 export interface GatewayDeps {
   loadConnectorBySlug(projectId: string, slug: string): Promise<GatewayConnector | null>;
   loadAction(connectorId: string, relPath: string): Promise<GatewayAction | null>;
-  /** Resolve the credential value/binding. `userId=null` = shared; set = that member's own. */
-  resolveCredential(connectorId: string, userId: string | null): Promise<string | null>;
+  /**
+   * Resolve the credential value/binding for a connector. `userId=null` = shared;
+   * set = that member's own. Receives the loaded connector so the resolver can
+   * pick the credential source by provider (e.g. a channel connector's platform
+   * install token) without re-querying.
+   */
+  resolveCredential(connector: GatewayConnector, userId: string | null): Promise<string | null>;
   /** Connector-scoped policies (relative patterns over the connector's tool paths). */
   loadPolicies(connectorId: string): Promise<Policy[]>;
   /** Project-scoped policies (fully-qualified patterns over <slug>.<path>). */
@@ -131,7 +136,7 @@ async function connectorUsable(
   // 2. Credential — none needed (public), shared, or this member's own (per_user).
   if (!connector.hasAuth) return { ok: true, secret: null };
   const userId = connector.credentialMode === 'per_user' ? subject.userId : null;
-  const secret = await deps.resolveCredential(connector.connectorId, userId);
+  const secret = await deps.resolveCredential(connector, userId);
   if (secret == null) return { ok: false, reason: 'needs_auth' };
   return { ok: true, secret };
 }
@@ -231,6 +236,10 @@ export async function handleCall(deps: GatewayDeps, input: CallInput): Promise<C
         paramHints: paramHintsFromSchema(action.inputSchema),
         fetchImpl: deps.fetchImpl,
       });
+      // Channel platforms (Slack) reply HTTP 200 with an `{ ok:false, error }`
+      // envelope on failure. Surface that as a real error so the agent gets the
+      // cause (matching the in-sandbox CLI, which throws on `!ok`).
+      if (connector.provider === 'channel') result = mapChannelEnvelope(result);
     }
     if (result.ok) {
       await audit(deps, input, connector.connectorId, 'ok', action.risk, { http_status: result.status });
@@ -249,6 +258,19 @@ export async function handleCall(deps: GatewayDeps, input: CallInput): Promise<C
     logger.warn(`[executor] ${fullPath} threw: ${reason.slice(0, 500)}`);
     return { status: 'error', reason };
   }
+}
+
+/**
+ * Slack-style envelope: the Web API returns HTTP 200 even on failure, with the
+ * real outcome in `{ ok: boolean, error? }`. Map `ok:false` to a failed
+ * ExecResult so the gateway's normal error path surfaces the cause.
+ */
+function mapChannelEnvelope(result: ExecResult): ExecResult {
+  const data = result.data as { ok?: unknown } | null;
+  if (result.ok && data && typeof data === 'object' && data.ok === false) {
+    return { ...result, ok: false };
+  }
+  return result;
 }
 
 /**

--- a/apps/api/src/executor/materialize.ts
+++ b/apps/api/src/executor/materialize.ts
@@ -9,6 +9,7 @@
  */
 import type { ConnectorSpec } from '../projects/connectors';
 import type { ProjectPolicySpec } from '../projects/policies';
+import { channelApiBase } from './channels';
 
 export interface DesiredPolicy {
   match: string;
@@ -30,6 +31,15 @@ export function connectorConfig(spec: ConnectorSpec, openapiServer?: string | nu
       return { baseUrl: spec.baseUrl, spec: spec.spec, auth };
     case 'openapi':
       return { spec: spec.spec, server: openapiServer ?? null, auth };
+    case 'channel':
+      // The credential is the platform install token (resolved server-side); the
+      // connector always carries bearer auth + the platform's API base so
+      // authOf()/baseUrlOf() resolve and executeCall attaches `Bearer <token>`.
+      return {
+        platform: spec.platform,
+        baseUrl: channelApiBase(spec.platform ?? ''),
+        auth: { type: 'bearer', in: 'header', name: null, prefix: null },
+      };
     default:
       return {};
   }

--- a/apps/api/src/executor/normalize.ts
+++ b/apps/api/src/executor/normalize.ts
@@ -343,6 +343,7 @@ function pdType(t: string): string {
 /* ─── dispatch ───────────────────────────────────────────────────────────── */
 
 import type { ConnectorProvider } from '../projects/connectors';
+import { channelCatalog } from './channels';
 
 /** Source material a connector needs normalized, by provider. */
 type NormalizeInput =
@@ -350,7 +351,8 @@ type NormalizeInput =
   | { provider: 'graphql'; introspection: any }
   | { provider: 'mcp'; tools: McpToolLike[] }
   | { provider: 'http'; routes: HttpRouteSpec[] }
-  | { provider: 'pipedream'; actions: PipedreamActionLike[]; app: string };
+  | { provider: 'pipedream'; actions: PipedreamActionLike[]; app: string }
+  | { provider: 'channel'; platform: string };
 
 export function normalize(input: NormalizeInput): NormalizedAction[] {
   switch (input.provider) {
@@ -364,6 +366,8 @@ export function normalize(input: NormalizeInput): NormalizedAction[] {
       return normalizePipedream(input.actions, input.app);
     case 'http':
       return normalizeHttp(input.routes);
+    case 'channel':
+      return channelCatalog(input.platform);
     default:
       return [];
   }

--- a/apps/api/src/executor/sync.ts
+++ b/apps/api/src/executor/sync.ts
@@ -30,6 +30,8 @@ import {
   normalizeOpenApi,
   normalizePipedream,
 } from './normalize';
+import { channelApiBase, channelCatalog } from './channels';
+import { synthesizeChannelConnectors } from './channel-materialize';
 import { parseSpecDocument } from './spec-doc';
 import type { NormalizedAction, HttpRouteSpec } from './types';
 import { parseResponseBody } from './execute';
@@ -39,6 +41,27 @@ import { pipedreamCatalog, pipedreamConfigured } from './pipedream';
 export interface SyncResult {
   synced: number;
   errors: Array<{ slug: string; error: string }>;
+}
+
+/**
+ * Best-effort re-materialization after a channel platform install changes
+ * (connect / disconnect). Resolves the project's account, then runs the normal
+ * sweep so the auto-materialized channel connector (dis)appears immediately —
+ * "connect Slack → the `slack` connector shows up" with no manifest edit.
+ * Never throws: a sync hiccup must not fail the install/uninstall request.
+ */
+export async function reconcileChannelConnectors(projectId: string): Promise<void> {
+  try {
+    const [row] = await db
+      .select({ accountId: projects.accountId })
+      .from(projects)
+      .where(eq(projects.projectId, projectId))
+      .limit(1);
+    if (!row) return;
+    await syncProjectConnectors(projectId, row.accountId);
+  } catch (e) {
+    console.warn('[executor] channel connector reconcile failed', { projectId, err: (e as Error).message });
+  }
 }
 
 export interface SyncOptions {
@@ -73,6 +96,15 @@ export async function syncProjectConnectors(projectId: string, accountId: string
 
   const { specs, errors: parseErrors } = extractConnectors(manifest);
   const errors: SyncResult['errors'] = parseErrors.map((e) => ({ slug: e.slug, error: e.error }));
+
+  // Auto-materialize channel connectors (e.g. Slack) for any platform this
+  // project has installed but hasn't explicitly declared in kortix.toml. This
+  // is what makes "connect Slack → the `slack` connector just appears" work
+  // with zero manifest editing — the install IS the registration. Synthetic
+  // specs are materialized like any other connector but never written back to
+  // the manifest (the install is the source of truth, not git).
+  const channelSpecs = await synthesizeChannelConnectors(projectId, specs);
+  specs.push(...channelSpecs);
 
   // Project-level policies + settings — separate scope, always reconciled (cheap).
   const projectPoliciesParsed = extractProjectPolicies(manifest);
@@ -236,6 +268,10 @@ export async function resolveCatalog(project: GitBackedProject, spec: ConnectorS
         if (!pipedreamConfigured() || !spec.app) return { actions: [], server: null };
         const raw = await pipedreamCatalog(spec.app);
         return { actions: normalizePipedream(raw, spec.app), server: null };
+      }
+      case 'channel': {
+        // Fixed, local catalog — no network fetch. Server = the platform API base.
+        return { actions: channelCatalog(spec.platform ?? ''), server: channelApiBase(spec.platform ?? '') };
       }
       default:
         return { actions: [], server: null };

--- a/apps/api/src/projects/connectors.ts
+++ b/apps/api/src/projects/connectors.ts
@@ -40,8 +40,12 @@ import { isValidSecretName } from './secrets';
 
 const SLUG_RE = /^[a-z0-9][a-z0-9_-]{0,127}$/;
 
-export type ConnectorProvider = 'pipedream' | 'mcp' | 'openapi' | 'graphql' | 'http';
-const PROVIDERS: readonly ConnectorProvider[] = ['pipedream', 'mcp', 'openapi', 'graphql', 'http'];
+export type ConnectorProvider = 'pipedream' | 'mcp' | 'openapi' | 'graphql' | 'http' | 'channel';
+const PROVIDERS: readonly ConnectorProvider[] = ['pipedream', 'mcp', 'openapi', 'graphql', 'http', 'channel'];
+
+/** Chat platforms a `channel` connector can target. */
+export type ChannelPlatform = 'slack';
+const CHANNEL_PLATFORMS: readonly ChannelPlatform[] = ['slack'];
 
 type ConnectorAuthType = 'bearer' | 'basic' | 'custom' | 'none';
 const AUTH_TYPES: readonly ConnectorAuthType[] = ['bearer', 'basic', 'custom', 'none'];
@@ -94,6 +98,8 @@ export interface ConnectorSpec {
   endpoint: string | null;
   /** http: base URL for declared routes. */
   baseUrl: string | null;
+  /** channel: chat platform (slack | …) — selects the fixed action catalog + API base. */
+  platform: ChannelPlatform | null;
   /** openapi/graphql/http: a URL or repo-relative file path. Optional for graphql. */
   spec: string | null;
   // ── shared ──
@@ -188,6 +194,8 @@ export function connectorSpecToTomlEntry(spec: ConnectorSpec): Record<string, un
   } else if (spec.provider === 'http') {
     if (spec.baseUrl) entry.base_url = spec.baseUrl;
     if (spec.spec) entry.spec = spec.spec;
+  } else if (spec.provider === 'channel') {
+    if (spec.platform) entry.platform = spec.platform;
   } else if (spec.provider === 'openapi') {
     if (spec.spec) entry.spec = spec.spec;
   }
@@ -226,6 +234,7 @@ export function manifestHashForConnector(spec: ConnectorSpec): string {
     transport: spec.transport,
     endpoint: spec.endpoint,
     baseUrl: spec.baseUrl,
+    platform: spec.platform,
     spec: spec.spec,
     auth: spec.auth,
   });
@@ -281,6 +290,7 @@ function parseConnectorEntry(entry: unknown, index: number): ParseOk | ParseErr 
     transport: null,
     endpoint: null,
     baseUrl: null,
+    platform: null,
     spec: null,
   };
 
@@ -331,6 +341,14 @@ function parseProviderFields(
     return { ok: true, value: { ...base, spec } };
   }
 
+  if (provider === 'channel') {
+    const platform = (str(row.platform) ?? '').toLowerCase();
+    if (!CHANNEL_PLATFORMS.includes(platform as ChannelPlatform)) {
+      return err(slug, `provider="channel" requires platform one of ${CHANNEL_PLATFORMS.join(', ')} (got "${platform || 'unset'}")`);
+    }
+    return { ok: true, value: { ...base, platform: platform as ChannelPlatform } };
+  }
+
   if (provider === 'graphql') {
     const endpoint = str(row.endpoint);
     if (!endpoint) return err(slug, 'provider="graphql" requires `endpoint`');
@@ -362,6 +380,9 @@ function parseAuth(
   }
   if (provider === 'pipedream' && type !== 'none') {
     return err(slug, 'provider="pipedream" authenticates via its connected account — omit [connectors.auth]');
+  }
+  if (provider === 'channel' && type !== 'none') {
+    return err(slug, 'provider="channel" authenticates via its platform install token — omit [connectors.auth]');
   }
 
   if (type === 'none') return { ok: true, value: { ...NO_AUTH } };

--- a/apps/api/src/projects/routes/r4.ts
+++ b/apps/api/src/projects/routes/r4.ts
@@ -1,4 +1,5 @@
 import { deleteSlackInstall, loadSlackInstall, saveSlackInstall } from '../../channels/install-store';
+import { reconcileChannelConnectors } from '../../executor/sync';
 import { buildSlackInstallUrl } from '../../channels/slack-oauth';
 import { slackOauthMode } from '../../channels/slack-oauth-mode';
 import { postQuestion, relayTurnAnswer, relayTurnEnd, relayTurnStep, type QuestionInfo } from '../../channels/slack-webhook';
@@ -329,6 +330,7 @@ projectsApp.openapi(
     teamName: authTest.team ?? null,
     botUserId: authTest.user_id,
   });
+  void reconcileChannelConnectors(projectId);
   return c.json(summary);
 },
 );
@@ -355,6 +357,8 @@ projectsApp.openapi(
   const loaded = await loadProjectForUser(c, projectId, 'manage');
   if (!loaded) return c.json({ error: 'Not found' }, 404);
   await deleteSlackInstall(projectId);
+  // Tear down the auto-materialized Slack connector now that the install is gone.
+  void reconcileChannelConnectors(projectId);
   return c.json({ status: 'disconnected' });
 },
 );

--- a/packages/db/src/schema/kortix.ts
+++ b/packages/db/src/schema/kortix.ts
@@ -2652,6 +2652,10 @@ export const executorConnectorProviderEnum = kortixSchema.enum('executor_connect
   'openapi',
   'graphql',
   'http',
+  // Chat platforms (Slack, later Telegram/Teams) as first-class connectors. The
+  // catalog is a fixed per-platform action set; the credential is the platform's
+  // existing install token (resolved server-side, no executor_credential row).
+  'channel',
 ]);
 
 export const executorConnectorStatusEnum = kortixSchema.enum('executor_connector_status', [

--- a/supabase/migrations/00000000000124_executor_channel_provider.sql
+++ b/supabase/migrations/00000000000124_executor_channel_provider.sql
@@ -1,0 +1,9 @@
+-- Add the `channel` provider to the executor connector provider enum.
+-- Channel connectors (Slack, later Telegram/Teams) are first-class Executor
+-- connectors: a fixed per-platform action catalog whose credential is the
+-- platform's existing install token (resolved server-side from project_secrets
+-- via the install-store — no executor_credentials row). See KORTIX-206.
+--
+-- ALTER TYPE ... ADD VALUE is non-transactional and idempotent here via
+-- IF NOT EXISTS, so this is safe to re-run.
+ALTER TYPE "kortix"."executor_connector_provider" ADD VALUE IF NOT EXISTS 'channel';


### PR DESCRIPTION
## Phase A — Slack as a native `channel` Executor connector (KORTIX-206)

First slice of the epic: a new **`channel`** Executor provider so chat platforms (Slack today, Telegram/Teams next) are first-class connectors usable via CLI / MCP / SDK / locally — while keeping Slack's UX 100% identical.

### What's here
- **New provider `channel`** — db enum + migration `124`, parsed from `[[connectors]] provider="channel" platform="slack"` (auth is implicit — the install token).
- **Fixed Slack catalog** (`channels.ts`) — the 14 native Web API methods (`send_message`, `update_message`, `delete_message`, `add_reaction`, `get_history`, `get_thread`, `list_channels`, `channel_info`, `join_channel`, `list_users`, `user_info`, `auth_test`, `search_messages`, `file_info`) → plain `http` bindings against `slack.com/api`, using Slack's own param names so `executeCall` runs them unchanged.
- **Zero-migration credential** — resolves the *existing* install token via the install-store (server-side, rotation-safe). No `executor_credentials` row, no copy.
- **Auto-materialize** — connecting Slack synthesizes the `slack` connector (no kortix.toml edit); disconnect tears it down. Wired on OAuth + manual install/uninstall.
- **Parity** — gateway maps Slack's HTTP-200 `{ok:false}` envelope to a real error (matching the in-sandbox CLI throw).

### Backwards compatibility
**Purely additive.** The in-sandbox `slack` CLI, the turn-stream relay, the webhook routes, the OAuth flow, the install-store, and the Slack app manifest are all untouched. Existing Slack installs keep working exactly as before.

### Verification
api + db typecheck clean; 11 new channel tests + all executor suites (gateway/normalize/materialize/parse/e2e/faces) green. Passed a thermo-nuclear self-review (fixed a shared-path query regression, platform-list duplication, a dead export, and consolidated the channel special-casing into one block).

### Next in the epic
Phase C (cutover: shim → executor, token out of the sandbox — with the backwards-compat guarantees above) and Phase B (dual-surface web UI: Channels tab + Executor tab).

🤖 Generated with [Claude Code](https://claude.com/claude-code)