### PR TITLE
fix(sessions): one bad sandbox no longer 500s the session list (+ stop Daytona rate-limit amplification)

### DIFF
--- a/apps/api/src/__tests__/unit-opencode-title-sync.test.ts
+++ b/apps/api/src/__tests__/unit-opencode-title-sync.test.ts
@@ -5,6 +5,9 @@ import { projectSessions, sessionSandboxes } from '@kortix/db';
 const sandboxRows: Array<{ sessionId: string; externalId: string | null }> = [];
 const dbUpdates: Array<Record<string, unknown>> = [];
 let listedSessions: any[] = [];
+// Externals whose sandbox lookup should THROW (e.g. provider rate limit /
+// archived box) — used to prove one bad sandbox never sinks the whole batch.
+const throwForExternalIds = new Set<string>();
 
 mock.module('../shared/db', () => ({
   db: {
@@ -30,10 +33,15 @@ mock.module('../shared/db', () => ({
 }));
 
 mock.module('../projects/opencode-mapping', () => ({
-  listSandboxOpencodeSessions: async () => ({
-    ok: true,
-    sessions: listedSessions,
-  }),
+  listSandboxOpencodeSessions: async (externalId: string) => {
+    if (throwForExternalIds.has(externalId)) {
+      throw new Error(`DaytonaRateLimitError: ThrottlerException: Too Many Requests (${externalId})`);
+    }
+    return {
+      ok: true,
+      sessions: listedSessions,
+    };
+  },
   resolveRootSessionId: ({
     pinnedRootId,
     sessions,
@@ -52,6 +60,7 @@ afterEach(() => {
   sandboxRows.length = 0;
   dbUpdates.length = 0;
   listedSessions = [];
+  throwForExternalIds.clear();
 });
 
 function row(overrides: Record<string, unknown> = {}) {
@@ -128,5 +137,37 @@ describe('syncOpenCodeTitlesForSessions', () => {
     const metadata = synced.metadata as Record<string, unknown>;
     expect(metadata.name).toBe('Previous title');
     expect(dbUpdates.at(-1)?.metadata).toMatchObject({ name: 'Previous title' });
+  });
+
+  test('one throttled/unreachable sandbox does not reject the batch; other rows still sync', async () => {
+    // Regression: a single sandbox whose lookup throws (provider rate limit /
+    // archived box) used to reject the whole `Promise.all`, 500ing GET /sessions.
+    // The batch must now resolve, keeping the bad row unchanged and syncing the rest.
+    sandboxRows.push(
+      { sessionId: 'ok-session', externalId: 'sandbox-ok' },
+      { sessionId: 'bad-session', externalId: 'sandbox-bad' },
+    );
+    throwForExternalIds.add('sandbox-bad');
+    listedSessions = [{ id: 'root-ok', title: 'Synced', time: { created: 1, updated: 10 } }];
+
+    const result = await syncOpenCodeTitlesForSessions({
+      rows: [
+        row({ sessionId: 'ok-session', metadata: {} }),
+        row({ sessionId: 'bad-session', metadata: { name: 'Kept' }, opencodeSessionId: 'pin-bad' }),
+      ],
+      projectId: 'project-1',
+      accountId: 'account-1',
+      userId: 'user-1',
+    });
+
+    // Batch resolved (no throw), order preserved, both rows returned.
+    expect(result).toHaveLength(2);
+    expect(result.map((r) => r.sessionId)).toEqual(['ok-session', 'bad-session']);
+    // The reachable sandbox synced its root/title.
+    expect(result[0].opencodeSessionId).toBe('root-ok');
+    expect((result[0].metadata as Record<string, unknown>).name).toBe('Synced');
+    // The throwing sandbox's row is returned UNCHANGED (best-effort fallback).
+    expect(result[1].opencodeSessionId).toBe('pin-bad');
+    expect((result[1].metadata as Record<string, unknown>).name).toBe('Kept');
   });
 });

--- a/apps/api/src/projects/opencode-mapping.ts
+++ b/apps/api/src/projects/opencode-mapping.ts
@@ -75,9 +75,13 @@ export async function listSandboxOpencodeSessions(
   externalId: string,
   userId: string | undefined,
 ): Promise<ListResult> {
-  const ep = await sandboxOpencodeEndpoint(externalId, userId);
-  if (!ep) return { ok: false, reason: 'no_key' };
   try {
+    // Endpoint resolution itself can throw (provider preview-link API errors,
+    // rate limits, archived/deleted sandboxes). Keep it INSIDE the try so any
+    // failure degrades to a clean `unreachable` instead of rejecting up the
+    // call stack and 500ing the caller (e.g. the session list title-sync).
+    const ep = await sandboxOpencodeEndpoint(externalId, userId);
+    if (!ep) return { ok: false, reason: 'no_key' };
     const res = await fetch(
       `${ep.url}/session?directory=${encodeURIComponent(WORKSPACE)}`,
       // Fail FAST: a healthy daemon answers this list in <300ms; an 8s budget

--- a/apps/api/src/projects/opencode-title-sync.ts
+++ b/apps/api/src/projects/opencode-title-sync.ts
@@ -2,12 +2,46 @@ import { and, eq, inArray } from 'drizzle-orm';
 
 import { projectSessions, sessionSandboxes } from '@kortix/db';
 import { db } from '../shared/db';
+import { logger as appLogger } from '../lib/logger';
 import {
   listSandboxOpencodeSessions,
   resolveRootSessionId,
   type OpencodeSessionLite,
 } from './opencode-mapping';
 import type { ProjectSessionRow } from './lib/serializers';
+
+// Title-sync is best-effort enrichment that runs on every session list/read. It
+// fans out one sandbox round-trip per active sandbox (preview-link resolution +
+// an OpenCode `/session` fetch). Two hard rules keep it from taking down the
+// list endpoint or the shared sandbox provider:
+//   1. BOUNDED concurrency — never fire N unbounded provider calls at once. A
+//      busy project can hold dozens of active sandboxes; an unbounded `Promise.all`
+//      burst-hammers the (org-shared) provider API and trips its rate limiter
+//      (`DaytonaRateLimitError` / 429), which then throws and 500s the list,
+//      which the browser retries, which fires the burst again — a self-sustaining
+//      amplification loop. A small worker pool spreads the calls instead.
+//   2. PER-ITEM isolation — one unreachable / throttled / archived sandbox must
+//      never reject the whole batch. Each row falls back to its unchanged value.
+const TITLE_SYNC_CONCURRENCY = 6;
+
+/** Map with a bounded worker pool, preserving input order. Never rejects: a
+ *  failing item resolves via the caller's own try/catch to a fallback value. */
+async function mapBounded<T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let cursor = 0;
+  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
+    while (cursor < items.length) {
+      const i = cursor++;
+      results[i] = await fn(items[i], i);
+    }
+  });
+  await Promise.all(workers);
+  return results;
+}
 
 type OpenCodeSessionSnapshot = {
   id: string;
@@ -188,13 +222,23 @@ export async function syncOpenCodeTitlesForSessions(input: {
   );
   if (externalBySessionId.size === 0) return input.rows;
 
-  const updated = await Promise.all(
-    input.rows.map((row) => {
-      const externalId = externalBySessionId.get(row.sessionId);
-      if (!externalId) return row;
-      return syncRowFromSandbox({ row, externalId, userId: input.userId });
-    }),
-  );
+  const updated = await mapBounded(input.rows, TITLE_SYNC_CONCURRENCY, async (row) => {
+    const externalId = externalBySessionId.get(row.sessionId);
+    if (!externalId) return row;
+    try {
+      return await syncRowFromSandbox({ row, externalId, userId: input.userId });
+    } catch (err) {
+      // Best-effort: a single unreachable / throttled / archived sandbox must
+      // not 500 the list. Keep the row's current state and move on.
+      appLogger.warn('[title-sync] per-sandbox sync failed; keeping row unchanged', {
+        sessionId: row.sessionId,
+        projectId: input.projectId,
+        externalId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return row;
+    }
+  });
 
   return updated;
 }


### PR DESCRIPTION
## What & why

`GET /v1/projects/:id/sessions` was intermittently returning **500 Internal server error** in prod (reported on the company project `fda4e35e…`). Root-caused live, not guessed.

### Root cause
The list handler calls `syncOpenCodeTitlesForSessions`, which fans out **one sandbox round-trip per active sandbox** to mirror OpenCode titles. Two flaws turned a single flaky sandbox into a full-list 500 **and** a self-sustaining Daytona rate-limit loop:

1. **No failure isolation.** Unbounded `Promise.all` where any one rejection sinks the whole batch. `listSandboxOpencodeSessions` resolved its endpoint (`sandboxOpencodeEndpoint` → `resolvePreviewLink` → Daytona `getPreviewLink`) **outside** its `try/catch`, so a Daytona error — archived/deleted box, or a **`DaytonaRateLimitError` / 429 `ThrottlerException`** — threw, rejected the `Promise.all`, and 500'd the endpoint even when every other session was fine.
2. **Unbounded concurrency.** A busy project (the company project has **30 active sandboxes**) fired 30 simultaneous Daytona preview-link calls per list load. Across tabs/polls against the **org-shared** Daytona account this trips the rate limiter; the resulting 500 makes the browser retry → fires the burst again → **amplification loop** that keeps Daytona throttled.

### Evidence (verified against prod)
- `kortix.project_sessions` schema intact — reproduced the handler's queries on the prod DB (320 sessions, all columns present). Not a missing-migration 500.
- `kortix.session_sandboxes` for the project: **30 `active` daytona rows** in the fan-out set.
- `DaytonaRateLimitError` (`ThrottlerException: Too Many Requests`) confirmed firing in prod.

## The fix
- **Per-item isolation** — each sandbox sync is wrapped; on any error the row is returned **unchanged** (title-sync is best-effort enrichment) and logged. One bad/throttled/archived sandbox can never reject the batch.
- **Bounded concurrency** — replace the unbounded `Promise.all` with a **6-worker pool** (input order preserved), cutting the per-request Daytona burst ~5×.
- **Harden `listSandboxOpencodeSessions`** — move endpoint resolution **inside** the `try` so a provider throw degrades to `{ok:false,'unreachable'}` instead of bubbling.

## Test
New regression test: a sandbox whose lookup throws (simulated 429) no longer rejects `syncOpenCodeTitlesForSessions`; the batch resolves, the bad row is kept unchanged, and the reachable rows still sync. `tsc --noEmit` clean; `unit-opencode-title-sync` + `unit-opencode-mapping` green.

## Verify on preview
Drive `GET /v1/projects/:id/sessions` against a project with ≥1 active sandbox; confirm 200 + the list renders even when a sandbox is unreachable.

## Follow-ups (separate PRs / ops)
- Global Daytona concurrency limiter + backoff across **all** call sites (reaper `getStatus`, warm-pool health, env-sync), since title-sync is the #1 but not the only source.
- Longer preview-link cache TTL (currently 5m).
- Clean up the ~150 leaked Daytona boxes still `Started` with **auto-stop disabled** (old billing-leak bug) + verify the `daytonaLifecycle()` autoStop clamp + reaper are actually live in prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)