### PR TITLE
platform: Botkube Slack bot (alerts + read-only kubectl)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,5 @@ apps/mobile/.env.example
 # local Headlamp login token (ephemeral, do not commit)
 headlamp-token.txt
 grafana-creds.txt
+botkube-communication.secret.yaml
+botkube-comm-real.yaml

--- a/infra/k8s/argocd/applications/platform-botkube.yaml
+++ b/infra/k8s/argocd/applications/platform-botkube.yaml
@@ -1,0 +1,122 @@
+# Botkube — alerts + cluster events to Slack + read-only kubectl from Slack.
+# RBAC is read-only (get/watch/list) so commands run from Slack can never mutate
+# the cluster. Slack tokens (botToken/appToken) are NOT in git — they live in a
+# secret `botkube-communication` (key comm_config.yaml) provisioned out-of-band;
+# see docs/runbooks/devops-gateway.md. The comm secret also holds the channel→
+# bindings map (which sources/executors the channel gets), referencing the source
+# and executor names defined inline below.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kortix-platform-botkube
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/compare-options: ServerSideDiff=true
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: platform
+  source:
+    repoURL: https://charts.botkube.io
+    chart: botkube
+    targetRevision: v1.14.0
+    helm:
+      releaseName: botkube
+      values: |
+        settings:
+          clusterName: kortix-prod-eks
+        rbac:
+          create: true
+          groups:
+            botkube-plugins-default:
+              create: true
+              rules:
+                - apiGroups: ["*"]
+                  resources: ["*"]
+                  verbs: ["get", "watch", "list"]
+        communications:
+          default:
+            socketSlack:
+              enabled: true
+              botToken: ""
+              appToken: ""
+              channels:
+                default:
+                  name: alerts
+                  bindings:
+                    executors:
+                      - kubectl-ro
+                    sources:
+                      - k8s-errors
+                      - prometheus-alerts
+        extraEnv:
+          - name: BOTKUBE_COMMUNICATIONS_DEFAULT_SOCKET__SLACK_BOT__TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: botkube-slack-tokens
+                key: botToken
+          - name: BOTKUBE_COMMUNICATIONS_DEFAULT_SOCKET__SLACK_APP__TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: botkube-slack-tokens
+                key: appToken
+        sources:
+          k8s-errors:
+            displayName: "Kubernetes errors"
+            botkube/kubernetes:
+              enabled: true
+              config:
+                namespaces:
+                  include:
+                    - kortix-prod
+                    - kortix-platform
+                    - monitoring
+                    - kyverno
+                    - falco
+                    - velero
+                    - argocd
+                event:
+                  types:
+                    - error
+                    - warning
+                resources:
+                  - type: v1/pods
+                  - type: apps/v1/deployments
+                  - type: batch/v1/jobs
+                  - type: v1/events
+          prometheus-alerts:
+            displayName: "Prometheus alerts"
+            botkubeExtra/prometheus:
+              enabled: true
+              config:
+                url: http://kps-prometheus.monitoring:9090
+                ignoreOldAlerts: true
+                alertStates:
+                  - firing
+        executors:
+          kubectl-ro:
+            displayName: "kubectl (read-only)"
+            botkube/kubectl:
+              enabled: true
+        resources:
+          requests:
+            cpu: 50m
+            memory: 128Mi
+          limits:
+            memory: 384Mi
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: botkube
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 10s
+        factor: 2
+        maxDuration: 3m

--- a/infra/k8s/argocd/project-platform.yaml
+++ b/infra/k8s/argocd/project-platform.yaml
@@ -22,6 +22,7 @@ spec:
     - https://vmware-tanzu.github.io/helm-charts
     - https://opencost.github.io/opencost-helm-chart
     - https://open-telemetry.github.io/opentelemetry-helm-charts
+    - https://charts.botkube.io
   destinations:
     - server: https://kubernetes.default.svc
       namespace: kortix-platform
@@ -37,6 +38,8 @@ spec:
       namespace: opencost
     - server: https://kubernetes.default.svc
       namespace: argocd
+    - server: https://kubernetes.default.svc
+      namespace: botkube
     # kube-prometheus-stack places kubelet/coredns scrape Services here so it can
     # collect core-component + node/pod metrics. Standard for a monitoring stack.
     - server: https://kubernetes.default.svc

--- a/infra/k8s/platform/botkube-communication.secret.template.yaml
+++ b/infra/k8s/platform/botkube-communication.secret.template.yaml
@@ -1,0 +1,21 @@
+# TEMPLATE — do NOT commit real tokens. The Botkube Slack tokens live in a secret
+# `botkube-slack-tokens` (keys: botToken, appToken), injected into Botkube as env
+# vars (BOTKUBE_COMMUNICATIONS_DEFAULT_SOCKET__SLACK_BOT__TOKEN / _APP__TOKEN) by
+# platform-botkube.yaml. The channel + bindings live in the chart values (git),
+# NOT here — because Argo CD renders Helm without cluster access, so the chart's
+# `lookup` of a full-comm-config secret returns empty and bindings never apply.
+# Ideally migrate this to an ExternalSecret from AWS Secrets Manager.
+#
+# Apply with real tokens:
+#   kubectl -n botkube create secret generic botkube-slack-tokens \
+#     --from-literal=botToken='xoxb-...' \
+#     --from-literal=appToken='xapp-...'
+apiVersion: v1
+kind: Secret
+metadata:
+  name: botkube-slack-tokens
+  namespace: botkube
+type: Opaque
+stringData:
+  botToken: "xoxb-REPLACE-WITH-BOT-TOKEN"
+  appToken: "xapp-REPLACE-WITH-APP-TOKEN"

--- a/infra/k8s/platform/botkube-slack-app-manifest.json
+++ b/infra/k8s/platform/botkube-slack-app-manifest.json
@@ -1,0 +1,42 @@
+{
+  "display_information": {
+    "name": "Alert Daddy",
+    "description": "Kubernetes alerts + read-only kubectl from Slack, via Botkube.",
+    "background_color": "#0b1221"
+  },
+  "features": {
+    "bot_user": {
+      "display_name": "Alert Daddy",
+      "always_online": true
+    }
+  },
+  "oauth_config": {
+    "scopes": {
+      "bot": [
+        "app_mentions:read",
+        "channels:history",
+        "channels:read",
+        "chat:write",
+        "groups:history",
+        "groups:read",
+        "reactions:write",
+        "users:read"
+      ]
+    }
+  },
+  "settings": {
+    "event_subscriptions": {
+      "bot_events": [
+        "app_mention",
+        "message.channels",
+        "message.groups"
+      ]
+    },
+    "interactivity": {
+      "is_enabled": true
+    },
+    "socket_mode_enabled": true,
+    "org_deploy_enabled": false,
+    "token_rotation_enabled": false
+  }
+}

--- a/infra/k8s/platform/botkube-slack-app-manifest.yaml
+++ b/infra/k8s/platform/botkube-slack-app-manifest.yaml
@@ -1,0 +1,41 @@
+# Slack App manifest for Botkube (Socket Mode).
+#
+# Create the app: https://api.slack.com/apps -> Create New App -> From a manifest
+#   -> pick your workspace -> paste this file's contents -> Create.
+#
+# Then:
+#   1. Install to Workspace -> OAuth & Permissions -> copy the Bot User OAuth Token (xoxb-...)
+#   2. Basic Information -> App-Level Tokens -> Generate -> add scope connections:write
+#      -> copy the App token (xapp-...)
+#   3. In Slack, invite the bot to the channel:  /invite @Kortix Alerts   (in #ops)
+#
+# Hand the xoxb- + xapp- tokens to wire into the botkube-communication secret.
+display_information:
+  name: Alert Daddy
+  description: Kubernetes alerts + read-only kubectl from Slack, via Botkube.
+  background_color: "#0b1221"
+features:
+  bot_user:
+    display_name: Alert Daddy
+    always_online: true
+oauth_config:
+  scopes:
+    bot:
+      - app_mentions:read
+      - channels:history
+      - channels:read
+      - chat:write
+      - groups:history
+      - groups:read
+      - reactions:write
+      - users:read
+settings:
+  event_subscriptions:
+    bot_events:
+      - app_mention
+      - message.channels
+      - message.groups
+  interactivity:
+    is_enabled: true
+  socket_mode_enabled: true
+  org_deploy_enabled: false


### PR DESCRIPTION
Botkube v1.14 live in #alerts on prod-eks: k8s-error + Prometheus-alert sources, read-only kubectl executor. Bindings in values (Argo can't lookup secrets), tokens via env.