### PR TITLE
fix(sandbox): provider-authoritative orphan-box reaper (auto-stop leaked running boxes)

### DIFF
--- a/apps/api/src/__tests__/e2e-project-maintenance.test.ts
+++ b/apps/api/src/__tests__/e2e-project-maintenance.test.ts
@@ -108,6 +108,7 @@ mock.module('../projects/sandbox-reaper', () => ({
     errors: 0,
   }),
   reconcileOrphanComputeSessions: async () => ({ checked: 0, closed: 0, errors: 0 }),
+  reapOrphanProviderBoxes: async () => ({ listed: 0, orphans: 0, stopped: 0, errors: 0 }),
   countBillingInvariantViolations: async () => 0,
 }));
 

--- a/apps/api/src/platform/providers/daytona.ts
+++ b/apps/api/src/platform/providers/daytona.ts
@@ -5,6 +5,7 @@
  * Extracted from the original account.ts provisioning logic.
  */
 
+import { SandboxState } from '@daytonaio/sdk';
 import { getDaytona, getDaytonaWarm } from '../../shared/daytona';
 import { warmRestoreScript, WARM_RESTORE_MARKERS, noteWarmPathFailure } from '../../snapshots/warm-bake';
 import { serviceKeyForExternalId } from '../service-key';
@@ -14,6 +15,16 @@ import { config, SANDBOX_VERSION } from '../../config';
 // own per-project snapshot, resolved by the snapshot builder. Callers
 // must pass `opts.snapshot`; there is no shared platform-wide image.)
 import { WarmRuntimeUnavailableError } from './index';
+
+// Labels stamped on every Kortix-managed Daytona box at create time. The
+// Daytona org is SHARED across environments (prod / dev / laptops), so the
+// orphan-box reaper MUST scope its sweep to this deployment's own boxes —
+// otherwise one env would stop another env's sandboxes. `kortix.managed` marks
+// "we created it"; `kortix.env` pins the owning environment. The reaper lists
+// by exactly these labels (see listManagedRunningSandboxes).
+function managedSandboxLabels(): Record<string, string> {
+  return { 'kortix.managed': 'true', 'kortix.env': config.INTERNAL_KORTIX_ENV };
+}
 import type {
   SandboxProvider,
   ProviderName,
@@ -186,6 +197,7 @@ export class DaytonaProvider implements SandboxProvider {
         // (KORTIX_SANDBOX_AUTO*). A warm-pool spare passes autoStopInterval=0 →
         // persistent (it manages its own lifecycle via reconcileWarmPool).
         ...daytonaLifecycle(opts.autoStopInterval),
+        labels: managedSandboxLabels(),
         public: false,
       },
       { timeout: createTimeoutSeconds },
@@ -239,6 +251,7 @@ export class DaytonaProvider implements SandboxProvider {
           {
             snapshot: warmBaseSnapshot,
             ...daytonaLifecycle(opts.autoStopInterval),
+            labels: managedSandboxLabels(),
             public: false,
           },
           { timeout },
@@ -343,6 +356,31 @@ export class DaytonaProvider implements SandboxProvider {
     const daytona = getDaytona();
     const sandbox = await daytona.get(externalId);
     await daytona.delete(sandbox);
+  }
+
+  /**
+   * List THIS environment's running boxes, for the orphan-box reaper. Scoped by
+   * the managed labels — the Daytona org is shared across environments, so an
+   * unscoped sweep would reap other deployments' sandboxes. Returns id +
+   * createdAt so the reaper can age-gate (never stop a box inside its grace
+   * window, which would race a box mid-provision before its DB row lands).
+   */
+  async listManagedRunningSandboxes(): Promise<Array<{ externalId: string; createdAt: Date | null }>> {
+    const out: Array<{ externalId: string; createdAt: Date | null }> = [];
+    for await (const box of getDaytona().list({
+      states: [SandboxState.STARTED],
+      labels: managedSandboxLabels(),
+      limit: 100,
+    } as any)) {
+      const externalId = (box as { id?: string }).id;
+      if (!externalId) continue;
+      const raw =
+        (box as { createdAt?: string | Date }).createdAt ??
+        (box as { info?: { createdAt?: string | Date } }).info?.createdAt ??
+        null;
+      out.push({ externalId, createdAt: raw ? new Date(raw) : null });
+    }
+    return out;
   }
 
   async getStatus(externalId: string): Promise<SandboxStatus> {

--- a/apps/api/src/platform/providers/index.ts
+++ b/apps/api/src/platform/providers/index.ts
@@ -113,6 +113,16 @@ export interface SandboxProvider {
   resolvePreviewLink(externalId: string, port: number): Promise<{ url: string; token: string | null }>;
   ensureRunning(externalId: string): Promise<void>;
   getProvisioningStatus(sandboxId: string): Promise<ProvisioningStatus | null>;
+  /**
+   * List the running boxes this deployment owns, for the orphan-box reaper
+   * (boxes still running on the provider with no live DB row). OPTIONAL: a
+   * provider that can't enumerate — or where boxes are inherently per-host and
+   * can't leak org-wide (local Docker) — simply omits it and the reaper skips
+   * that provider. Implementations MUST scope the result to THIS environment
+   * (the provider org may be shared across prod/dev/local) and return
+   * `createdAt` so the reaper can age-gate.
+   */
+  listManagedRunningSandboxes?(): Promise<Array<{ externalId: string; createdAt: Date | null }>>;
 }
 
 const providers = new Map<ProviderName, SandboxProvider>();

--- a/apps/api/src/projects/maintenance.ts
+++ b/apps/api/src/projects/maintenance.ts
@@ -9,6 +9,7 @@ import { reconcileSnapshotQuota } from '../snapshots/quota-gc';
 import {
   reapAndReconcileSandboxes,
   reconcileOrphanComputeSessions,
+  reapOrphanProviderBoxes,
   countBillingInvariantViolations,
 } from './sandbox-reaper';
 
@@ -143,7 +144,7 @@ async function runProjectMaintenance(): Promise<void> {
   if (maintenanceRunning) return;
   maintenanceRunning = true;
   try {
-    const [idle, orphanCompute, branches, computeTick, staleBuilds, warmPool, snapshotGc] = await Promise.all([
+    const [idle, orphanCompute, orphanBoxes, branches, computeTick, staleBuilds, warmPool, snapshotGc] = await Promise.all([
       // Provider-authoritative idle reaper + state/billing reconcile (the fix for
       // boxes that never auto-stopped and kept billing). Backstops the webhooks.
       reapAndReconcileSandboxes().catch((err) => {
@@ -155,6 +156,13 @@ async function runProjectMaintenance(): Promise<void> {
       reconcileOrphanComputeSessions().catch((err) => {
         console.warn('[project-maintenance] orphan-compute reconcile failed:', err instanceof Error ? err.message : err);
         return { checked: 0, closed: 0, errors: 0 };
+      }),
+      // Provider-authoritative orphan-BOX reaper: stops boxes still running on
+      // the provider (this env) with no live DB row — the leak the DB-driven
+      // reaper above structurally can't see. STOP-only, label-scoped, age-gated.
+      reapOrphanProviderBoxes().catch((err) => {
+        console.warn('[project-maintenance] orphan-box reaper failed:', err instanceof Error ? err.message : err);
+        return { listed: 0, orphans: 0, stopped: 0, errors: 0 };
       }),
       sweepExpiredSessionBranches(),
       // Billing v2 — partial-bill any active compute sessions that haven't
@@ -185,11 +193,12 @@ async function runProjectMaintenance(): Promise<void> {
     ]);
     if (
       idle.stopped || idle.reconciled || idle.errors || orphanCompute.closed || orphanCompute.errors ||
+      orphanBoxes.stopped || orphanBoxes.errors ||
       branches.deleted || branches.errors ||
       computeTick.settled || staleBuilds.closedReady || staleBuilds.closedFailed || warmPool.reaped ||
       snapshotGc.deleted
     ) {
-      console.log('[project-maintenance] completed', { idle, orphanCompute, branches, computeTick, staleBuilds, warmPool, snapshotGc });
+      console.log('[project-maintenance] completed', { idle, orphanCompute, orphanBoxes, branches, computeTick, staleBuilds, warmPool, snapshotGc });
     }
 
     // Invariant monitor: in steady state, every `active` compute session has a

--- a/apps/api/src/projects/sandbox-reaper.test.ts
+++ b/apps/api/src/projects/sandbox-reaper.test.ts
@@ -9,6 +9,7 @@ let throwOnUsageLookup = false;
 let statusByExternal: Record<string, 'running' | 'stopped' | 'removed' | 'unknown'> = {};
 let stopErrorByExternal: Record<string, Error> = {};
 let stops: string[] = [];
+let managedBoxes: Array<{ externalId: string; createdAt: Date | null }> = [];
 let cacheInvalidations: string[] = [];
 let pausedCompute: string[] = [];
 let endedCompute: string[] = [];
@@ -30,7 +31,7 @@ function hybrid(rows: any[], throwOnGroupBy = false) {
 // test doesn't import the real config, which calls process.exit on incomplete
 // local env. Run this file in its own `bun test <file>` invocation (as CI does)
 // so the mock never leaks into a sibling file that uses the real config.
-mock.module('../config', () => ({ config: { KORTIX_SANDBOX_AUTOSTOP_MINUTES: 15 } }));
+mock.module('../config', () => ({ config: { KORTIX_SANDBOX_AUTOSTOP_MINUTES: 15, DAYTONA_API_KEY: 'test-key' } }));
 
 mock.module('../shared/db', () => ({
   db: {
@@ -67,6 +68,7 @@ mock.module('../platform/providers', () => ({
       const err = stopErrorByExternal[externalId];
       if (err) throw err;
     },
+    listManagedRunningSandboxes: async () => managedBoxes,
   }),
 }));
 
@@ -85,7 +87,7 @@ mock.module('../billing/services/compute-metering', () => ({
   },
 }));
 
-const { decideReap, lastMeaningfulAt, reapAndReconcileSandboxes, buildIdleStopMetadata } = await import('./sandbox-reaper');
+const { decideReap, lastMeaningfulAt, reapAndReconcileSandboxes, buildIdleStopMetadata, reapOrphanProviderBoxes } = await import('./sandbox-reaper');
 
 const TTL = 15 * 60_000;
 
@@ -97,6 +99,7 @@ beforeEach(() => {
   statusByExternal = {};
   stopErrorByExternal = {};
   stops = [];
+  managedBoxes = [];
   cacheInvalidations = [];
   pausedCompute = [];
   endedCompute = [];
@@ -326,5 +329,61 @@ describe('reapAndReconcileSandboxes', () => {
     expect(stops).toEqual([]); // uncertain → do not stop
     expect(pausedCompute).toEqual([]);
     expect(r.stopped).toBe(0);
+  });
+});
+
+// ── orphan-box reaper: stops provider boxes the DB sweep can't see ────────────
+describe('reapOrphanProviderBoxes', () => {
+  const NOW2 = new Date('2026-06-21T12:00:00Z');
+  const hoursAgo = (h: number) => new Date(NOW2.getTime() - h * 3_600_000);
+
+  test('stops boxes with no live DB row; spares kept, too-young, and unknown-age boxes', async () => {
+    // keepSet (the DB's view of live boxes) comes from the sessionSandboxes query.
+    candidates = [{ externalId: 'keep-1' }];
+    managedBoxes = [
+      { externalId: 'keep-1', createdAt: hoursAgo(48) }, // in keepSet → spare
+      { externalId: 'orphan-1', createdAt: hoursAgo(48) }, // orphan + old → STOP
+      { externalId: 'orphan-2', createdAt: hoursAgo(3) }, // orphan + old → STOP
+      { externalId: 'young-1', createdAt: hoursAgo(0.2) }, // orphan but <1h → spare (provision race)
+      { externalId: 'nodate', createdAt: null }, // unknown age → spare (fail-safe)
+    ];
+
+    const r = await reapOrphanProviderBoxes(NOW2);
+
+    expect([...stops].sort()).toEqual(['orphan-1', 'orphan-2']);
+    expect(r.listed).toBe(5);
+    expect(r.orphans).toBe(2);
+    expect(r.stopped).toBe(2);
+    expect(r.errors).toBe(0);
+  });
+
+  test('continues past a stop failure (bad box never sinks the sweep)', async () => {
+    candidates = [];
+    managedBoxes = [
+      { externalId: 'orphan-a', createdAt: hoursAgo(10) },
+      { externalId: 'orphan-b', createdAt: hoursAgo(10) },
+    ];
+    stopErrorByExternal['orphan-a'] = new Error('429 too many requests');
+
+    const r = await reapOrphanProviderBoxes(NOW2);
+
+    expect(stops).toContain('orphan-a'); // attempted
+    expect(stops).toContain('orphan-b'); // and the next one still ran
+    expect(r.stopped).toBe(1);
+    expect(r.errors).toBe(1);
+  });
+
+  test('env flag off → no-op (never lists or stops)', async () => {
+    const prev = process.env.KORTIX_ORPHAN_BOX_REAP_ENABLED;
+    process.env.KORTIX_ORPHAN_BOX_REAP_ENABLED = 'false';
+    try {
+      managedBoxes = [{ externalId: 'orphan-x', createdAt: hoursAgo(48) }];
+      const r = await reapOrphanProviderBoxes(NOW2);
+      expect(stops).toEqual([]);
+      expect(r).toEqual({ listed: 0, orphans: 0, stopped: 0, errors: 0 });
+    } finally {
+      if (prev === undefined) delete process.env.KORTIX_ORPHAN_BOX_REAP_ENABLED;
+      else process.env.KORTIX_ORPHAN_BOX_REAP_ENABLED = prev;
+    }
   });
 });

--- a/apps/api/src/projects/sandbox-reaper.ts
+++ b/apps/api/src/projects/sandbox-reaper.ts
@@ -28,7 +28,7 @@
  * invariant rather than a best-effort.
  */
 
-import { and, eq, inArray, isNotNull, sql } from 'drizzle-orm';
+import { and, eq, gt, inArray, isNotNull, or, sql } from 'drizzle-orm';
 import { projectSessions, sessionSandboxes } from '@kortix/db';
 import { db } from '../shared/db';
 import { getProvider, type ProviderName, type SandboxStatus } from '../platform/providers';
@@ -520,4 +520,108 @@ export async function countBillingInvariantViolations(): Promise<number> {
       sql`(${sessionSandboxes.status} IS NULL OR ${sessionSandboxes.status} <> 'active')`,
     ));
   return Number(row?.n ?? 0);
+}
+
+// ── Orphan provider-box reaper ───────────────────────────────────────────────
+//
+// The passes above are DB-driven: they reconcile boxes that HAVE a
+// session_sandboxes row. A box that loses its row (migration, a dropped create,
+// a pre-clamp leftover) — or a persistent (autoStop=0) box nothing else reaps —
+// keeps running on the provider forever, invisible to the DB sweep, burning
+// compute (the leak observed 2026-06-21: ~85 running boxes the DB didn't track).
+// This pass closes the gap from the OTHER side: it lists the boxes THIS
+// environment owns on the provider and stops any with no live DB row.
+//
+// Safety:
+//  - Scoped to this env via provider labels (the org is shared across
+//    prod/dev/local) — see DaytonaProvider.listManagedRunningSandboxes.
+//  - keepSet = every box the DB considers live (active/provisioning) OR touched
+//    within ORPHAN_KEEP_RECENT_MS, so an in-flight session is never stopped.
+//  - Age grace: a box younger than ORPHAN_BOX_GRACE_MS (or whose createdAt we
+//    can't read) is skipped — covers the window between provider-create and the
+//    DB row landing.
+//  - STOP only, never delete (Daytona auto-archives stopped boxes); bounded per
+//    pass; failures are logged and the sweep continues.
+const ORPHAN_KEEP_RECENT_MS = 15 * 60_000; // don't stop a just-touched box
+const ORPHAN_BOX_GRACE_MS = 60 * 60_000; // a box must be this old to qualify
+const ORPHAN_REAP_MAX_PER_PASS = 50; // bound provider stop() calls per pass
+
+export interface OrphanReapResult {
+  listed: number;
+  orphans: number;
+  stopped: number;
+  errors: number;
+}
+
+export async function reapOrphanProviderBoxes(now = new Date()): Promise<OrphanReapResult> {
+  const zero: OrphanReapResult = { listed: 0, orphans: 0, stopped: 0, errors: 0 };
+  if (process.env.KORTIX_ORPHAN_BOX_REAP_ENABLED === 'false') return zero;
+  // Daytona is the only org-shared provider that leaks this way; local_docker
+  // boxes are per-host and Platinum is reconciled on its own path.
+  if (!config.DAYTONA_API_KEY) return zero;
+  let listManaged: (() => Promise<Array<{ externalId: string; createdAt: Date | null }>>) | undefined;
+  try {
+    const provider = getProvider('daytona');
+    listManaged = provider.listManagedRunningSandboxes?.bind(provider);
+  } catch {
+    return zero;
+  }
+  if (!listManaged) return zero;
+
+  let boxes: Array<{ externalId: string; createdAt: Date | null }>;
+  try {
+    boxes = await listManaged();
+  } catch (err) {
+    console.warn('[reaper] orphan-box list failed:', err instanceof Error ? err.message : err);
+    return zero;
+  }
+  if (boxes.length === 0) return zero;
+
+  // keepSet: never stop a box the DB considers live or touched recently.
+  const keepRows = await db
+    .select({ externalId: sessionSandboxes.externalId })
+    .from(sessionSandboxes)
+    .where(
+      and(
+        isNotNull(sessionSandboxes.externalId),
+        or(
+          inArray(sessionSandboxes.status, ['active', 'provisioning']),
+          gt(sessionSandboxes.updatedAt, new Date(now.getTime() - ORPHAN_KEEP_RECENT_MS)),
+        ),
+      ),
+    );
+  const keep = new Set(keepRows.map((r) => r.externalId).filter((x): x is string => !!x));
+
+  const cutoff = now.getTime() - ORPHAN_BOX_GRACE_MS;
+  const orphans = boxes.filter(
+    (b) => !keep.has(b.externalId) && b.createdAt != null && b.createdAt.getTime() <= cutoff,
+  );
+
+  let stopped = 0;
+  let errors = 0;
+  let cursor = 0;
+  const worker = async () => {
+    while (cursor < orphans.length && stopped + errors < ORPHAN_REAP_MAX_PER_PASS) {
+      const box = orphans[cursor++];
+      try {
+        await getProvider('daytona').stop(box.externalId);
+        // Reconcile any DB row (state drift) + close billing; no-op when there's none.
+        await reconcileSandboxStoppedByExternalId(box.externalId, now).catch(() => {});
+        stopped += 1;
+      } catch (err) {
+        errors += 1;
+        if (errors <= 5) {
+          console.warn(
+            `[reaper] orphan-box stop failed for ${box.externalId}:`,
+            err instanceof Error ? err.message : err,
+          );
+        }
+      }
+    }
+  };
+  await Promise.all(Array.from({ length: Math.min(REAP_CONCURRENCY, orphans.length) }, worker));
+  if (stopped || errors) {
+    console.log('[reaper] orphan-box sweep', { listed: boxes.length, orphans: orphans.length, stopped, errors });
+  }
+  return { listed: boxes.length, orphans: orphans.length, stopped, errors };
 }


### PR DESCRIPTION
## What & why

Follow-up to the Daytona incident. The existing reaper is **DB-driven** — it reconciles boxes that *have* a `session_sandboxes` row. A box that loses its row (migration, dropped create, pre-clamp leftover), or a persistent `autoStop=0` box nothing else reaps, **keeps running on the provider forever, invisible to the DB sweep, burning compute.**

**Observed 2026-06-21:** Kortix DB tracked **66 live boxes**, but Daytona had **~150 Started** → **~85 orphans**, mostly days old, **65+ with auto-stop disabled**. The DB-driven reaper structurally couldn't see them. (Those were already stopped out-of-band via a one-time cleanup — `92 started → 36`, `autoStop=0: 65 → 0`. This PR stops it recurring.)

## The fix — the missing half, from the provider side
- `DaytonaProvider.listManagedRunningSandboxes()` — lists *this env's* running boxes (id + createdAt).
- `reapOrphanProviderBoxes()` in the maintenance loop — stops any listed box with **no live DB row**.

## Safety (the Daytona org is shared across prod/dev/local — a naive sweep would reap other envs' boxes)
- **Env-scoped by labels.** Every box is now **labeled at create** with `{ kortix.managed, kortix.env }`, and the sweep lists by exactly those labels → one env can never stop another env's boxes. (Pre-existing unlabeled boxes aren't enumerated; the manual cleanup handled those.)
- **keepSet** = every box the DB considers live (`active`/`provisioning`) **or** touched in the last 15m → an in-flight session is never stopped.
- **Age grace** — a box younger than 1h (or with unknown `createdAt`) is skipped, covering the window between provider-create and the DB row landing.
- **Stop only, never delete** (Daytona auto-archives stopped boxes); **bounded to 50/pass**; per-box failures are logged and the sweep continues.
- **Kill switch**: `KORTIX_ORPHAN_BOX_REAP_ENABLED=false`.

The provider interface gains an **optional** `listManagedRunningSandboxes()` — `local_docker` (per-host, can't leak org-wide) and `Platinum` (reconciled separately) omit it and the sweep skips them.

## Tests
`reapOrphanProviderBoxes`: stops only orphans (spares kept / too-young / unknown-age), survives a per-box stop failure (one bad box doesn't sink the sweep), no-ops when disabled. `tsc --noEmit` clean; `sandbox-reaper` (27) + `e2e-project-maintenance` (3) green.

## Verify on preview
Confirm `/v1/health` boots; the sweep is a background maintenance job (logs `[reaper] orphan-box sweep …` only when it acts). Safe by construction on the shared org via the label scope.

## Relation to #3567
#3567 (merged) stopped the title-sync fan-out from 500ing the list and amplifying Daytona 429s. This PR removes the *accumulation* of orphan boxes that inflated that fan-out and the bill. Both are needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)