### PR TITLE
fix(executor): install-driven channel materialization + missing Channels i18n key (KORTIX-206)

### DIFF
--- a/apps/api/src/executor/sync.ts
+++ b/apps/api/src/executor/sync.ts
@@ -92,29 +92,42 @@ export async function syncProjectConnectors(projectId: string, accountId: string
 
   const gitProject = await withProjectGitAuth(row);
   const manifest = await readManifest(gitProject).catch(() => null);
-  if (!manifest) return { synced: 0, errors: [{ slug: '(manifest)', error: 'kortix.toml not found or unreadable' }] };
 
-  const { specs, errors: parseErrors } = extractConnectors(manifest);
-  const errors: SyncResult['errors'] = parseErrors.map((e) => ({ slug: e.slug, error: e.error }));
+  // Manifest-declared connectors + project policies are only reconciled when the
+  // kortix.toml is actually readable. A NULL manifest can mean "no repo / no
+  // kortix.toml" OR a transient git error — either way we must not treat it as
+  // "zero declared connectors" and delete the project's real ones below.
+  const errors: SyncResult['errors'] = [];
+  let declaredSpecs: ConnectorSpec[] = [];
+  if (manifest) {
+    const parsed = extractConnectors(manifest);
+    declaredSpecs = parsed.specs;
+    errors.push(...parsed.errors.map((e) => ({ slug: e.slug, error: e.error })));
 
-  // Auto-materialize channel connectors (e.g. Slack) for any platform this
-  // project has installed but hasn't explicitly declared in kortix.toml. This
-  // is what makes "connect Slack → the `slack` connector just appears" work
-  // with zero manifest editing — the install IS the registration. Synthetic
-  // specs are materialized like any other connector but never written back to
-  // the manifest (the install is the source of truth, not git).
-  const channelSpecs = await synthesizeChannelConnectors(projectId, specs);
-  specs.push(...channelSpecs);
-
-  // Project-level policies + settings — separate scope, always reconciled (cheap).
-  const projectPoliciesParsed = extractProjectPolicies(manifest);
-  for (const e of projectPoliciesParsed.errors) {
-    errors.push({ slug: '(policies)', error: e.error });
+    // Project-level policies + settings — separate scope, reconciled (cheap).
+    const projectPoliciesParsed = extractProjectPolicies(manifest);
+    for (const e of projectPoliciesParsed.errors) {
+      errors.push({ slug: '(policies)', error: e.error });
+    }
+    await reconcileProjectPolicies(projectId, projectPoliciesParsed);
   }
-  await reconcileProjectPolicies(projectId, projectPoliciesParsed);
+
+  // Channel connectors (e.g. Slack) are INSTALL-driven, not manifest-driven:
+  // connecting the platform IS the registration. So they materialize even when
+  // the project has no readable kortix.toml — "connect Slack → the `slack`
+  // connector just appears" must hold for any project. Synthetic specs are
+  // materialized like any other connector but never written back to git.
+  const channelSpecs = await synthesizeChannelConnectors(projectId, declaredSpecs);
+  const specs = [...declaredSpecs, ...channelSpecs];
+
+  // No readable manifest AND nothing installed → bail WITHOUT deleting (a
+  // transient git error must never wipe a project's connectors).
+  if (!manifest && channelSpecs.length === 0) {
+    return { synced: 0, errors: [{ slug: '(manifest)', error: 'kortix.toml not found or unreadable' }] };
+  }
 
   const existing = await db
-    .select({ slug: executorConnectors.slug, connectorId: executorConnectors.connectorId, manifestHash: executorConnectors.manifestHash, status: executorConnectors.status })
+    .select({ slug: executorConnectors.slug, connectorId: executorConnectors.connectorId, manifestHash: executorConnectors.manifestHash, status: executorConnectors.status, providerType: executorConnectors.providerType })
     .from(executorConnectors)
     .where(eq(executorConnectors.projectId, projectId));
   const existingBySlug = new Map(existing.map((e) => [e.slug, e]));
@@ -140,9 +153,14 @@ export async function syncProjectConnectors(projectId: string, accountId: string
     }
   }
 
-  // Delete connectors no longer in the manifest.
+  // Reconcile deletions. When the manifest is readable it's the source of truth
+  // for declared connectors — drop any it no longer lists (channel specs are in
+  // desiredSlugs, so they're kept). When the manifest is UNREADABLE we must not
+  // touch manifest-declared connectors (could be a transient git error) — only
+  // reconcile CHANNEL rows whose install is gone, so a disconnect still cleans up.
   for (const e of existing) {
-    if (!desiredSlugs.has(e.slug)) {
+    if (desiredSlugs.has(e.slug)) continue;
+    if (manifest || e.providerType === 'channel') {
       await db.delete(executorConnectors).where(eq(executorConnectors.connectorId, e.connectorId));
     }
   }

--- a/apps/web/src/components/projects/customize/sections/connectors-view.tsx
+++ b/apps/web/src/components/projects/customize/sections/connectors-view.tsx
@@ -20,6 +20,7 @@ import {
   Globe,
   KeyRound,
   Loader2,
+  MessageSquare,
   Pencil,
   Plug,
   Plus,
@@ -31,6 +32,7 @@ import {
   Zap,
   type LucideIcon,
 } from 'lucide-react';
+import { useCustomizeStore } from '@/stores/customize-store';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useEffect, useMemo, useState } from 'react';
 
@@ -105,6 +107,7 @@ const PROVIDER_ICON: Record<AdminConnector['provider'], LucideIcon> = {
   openapi: Globe,
   graphql: Globe,
   http: Globe,
+  channel: MessageSquare,
 };
 
 const RISK_VARIANT: Record<ConnectorAction['risk'], 'outline' | 'secondary' | 'destructive'> = {
@@ -115,7 +118,9 @@ const RISK_VARIANT: Record<ConnectorAction['risk'], 'outline' | 'secondary' | 'd
 
 /** Forward-facing provider label — "App" for the 1-click (Pipedream) connectors. */
 function providerLabel(p: AdminConnector['provider']): string {
-  return p === 'pipedream' ? 'App' : p.toUpperCase();
+  if (p === 'pipedream') return 'App';
+  if (p === 'channel') return 'Channel';
+  return p.toUpperCase();
 }
 
 // ─── Pipedream Connect overlay escape (used by the connect flow) ─────────────
@@ -648,6 +653,10 @@ function ConnectorDetail({
   const tI18nHardcoded = useTranslations('hardcodedUi');
   const Icon = PROVIDER_ICON[connector.provider] ?? Plug;
   const isPipedream = connector.provider === 'pipedream';
+  // Channel connectors (Slack) are credentialed + connected/removed via their
+  // platform install in the Channels tab — not the generic credential UI here.
+  const isChannel = connector.provider === 'channel';
+  const setSection = useCustomizeStore((s) => s.setSection);
   const connected = connector.secretSet;
   const reconnect = usePipedreamConnect(projectId, connector.slug, onChanged);
   const [credOpen, setCredOpen] = useState(false);
@@ -763,9 +772,11 @@ function ConnectorDetail({
         </div>
         {/* When connected, a compact Reconnect/Replace lives in the header.
             When NOT connected, the connect action is a big CTA below — not a
-            small header button buried next to the title. */}
+            small header button buried next to the title. (Channel connectors
+            are managed from the Channels tab, so neither shows.) */}
         {connector.authSecret &&
           connected &&
+          !isChannel &&
           (isPipedream ? (
             <Button
               size="sm"
@@ -795,8 +806,32 @@ function ConnectorDetail({
       </div>
 
       <div className="mt-7 space-y-5">
+        {/* Channel connectors (Slack) are credentialed + connected via their
+            platform install — point management at the Channels tab instead of
+            the generic credential / connection / remove controls. */}
+        {isChannel && (
+          <InfoBanner
+            tone="info"
+            icon={MessageSquare}
+            title={`${displayName} is managed in Channels`}
+            action={
+              <Button
+                size="sm"
+                variant="outline"
+                className="shrink-0 gap-1.5"
+                onClick={() => setSection('channels')}
+              >
+                <MessageSquare className="h-4 w-4" />
+                Open Channels
+              </Button>
+            }
+          >
+            Connecting or disconnecting the workspace, and the bot token, live in the Channels
+            tab. Here you control who can use it and review its tools.
+          </InfoBanner>
+        )}
         {/* Prominent connect CTA — the first thing you see on an unconnected connector. */}
-        {connector.authSecret && !connected && (
+        {connector.authSecret && !connected && !isChannel && (
           <InfoBanner
             tone="info"
             icon={KeyRound}
@@ -818,32 +853,34 @@ function ConnectorDetail({
               : `Add the credential so the agent and your triggers can use ${displayName}.`}
           </InfoBanner>
         )}
-        {!isPipedream && (
+        {!isPipedream && !isChannel && (
           <ConnectionSection projectId={projectId} connector={connector} onChanged={onChanged} />
         )}
         <ProfileSection projectId={projectId} connector={connector} onChanged={onChanged} />
         <PermissionsSection projectId={projectId} connector={connector} />
 
-        <SectionCard
-          tone="destructive"
-          title={tI18nHardcoded.raw(
-            'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrTitleRemove74be1411',
-          )}
-          description={tI18nHardcoded.raw(
-            'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrDescriptionDeletes0a130396',
-          )}
-          action={
-            <Button
-              size="sm"
-              variant="outline"
-              className="gap-1.5"
-              onClick={() => setConfirmDelete(true)}
-            >
-              <Trash2 className="h-3.5 w-3.5" />
-              Remove
-            </Button>
-          }
-        />
+        {!isChannel && (
+          <SectionCard
+            tone="destructive"
+            title={tI18nHardcoded.raw(
+              'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrTitleRemove74be1411',
+            )}
+            description={tI18nHardcoded.raw(
+              'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrDescriptionDeletes0a130396',
+            )}
+            action={
+              <Button
+                size="sm"
+                variant="outline"
+                className="gap-1.5"
+                onClick={() => setConfirmDelete(true)}
+              >
+                <Trash2 className="h-3.5 w-3.5" />
+                Remove
+              </Button>
+            }
+          />
+        )}
       </div>
 
       <ConfirmDialog
@@ -901,6 +938,10 @@ function ProfileSection({
   onChanged: () => void;
 }) {
   const tI18nHardcoded = useTranslations('hardcodedUi');
+  // Channel connectors (Slack) are always one shared install token — the
+  // per-user credential mode doesn't apply, so we hide that choice and keep
+  // only "who can use it".
+  const isChannel = connector.provider === 'channel';
   const [credential, setCredential] = useState<'shared' | 'per_user'>(connector.credentialMode);
   const initialAccess = sharingToAccess(connector.sharing);
   const [access, setAccess] = useState(initialAccess.mode);
@@ -955,30 +996,32 @@ function ProfileSection({
         'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrDescriptionThe33be3829',
       )}
     >
-      <RadioGroup
-        value={credential}
-        onValueChange={(v) => setCredential(v as 'shared' | 'per_user')}
-        className="space-y-2"
-      >
-        <ShareOption
-          value="shared"
-          label={tI18nHardcoded.raw(
-            'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrLabelOnec565aa8b',
-          )}
-          desc={tI18nHardcoded.raw(
-            'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrDescConnect5c9357c5',
-          )}
-        />
-        <ShareOption
-          value="per_user"
-          label={tI18nHardcoded.raw(
-            'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrLabelEache6c3d706',
-          )}
-          desc={tI18nHardcoded.raw(
-            'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrDescEvery9811ed05',
-          )}
-        />
-      </RadioGroup>
+      {!isChannel && (
+        <RadioGroup
+          value={credential}
+          onValueChange={(v) => setCredential(v as 'shared' | 'per_user')}
+          className="space-y-2"
+        >
+          <ShareOption
+            value="shared"
+            label={tI18nHardcoded.raw(
+              'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrLabelOnec565aa8b',
+            )}
+            desc={tI18nHardcoded.raw(
+              'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrDescConnect5c9357c5',
+            )}
+          />
+          <ShareOption
+            value="per_user"
+            label={tI18nHardcoded.raw(
+              'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrLabelEache6c3d706',
+            )}
+            desc={tI18nHardcoded.raw(
+              'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrDescEvery9811ed05',
+            )}
+          />
+        </RadioGroup>
+      )}
 
       {modeChanged && (
         <InfoBanner

--- a/apps/web/src/lib/projects-client.ts
+++ b/apps/web/src/lib/projects-client.ts
@@ -949,7 +949,7 @@ export type ConnectorSharing =
 export interface AdminConnector {
   slug: string;
   name: string;
-  provider: 'pipedream' | 'mcp' | 'openapi' | 'graphql' | 'http';
+  provider: 'pipedream' | 'mcp' | 'openapi' | 'graphql' | 'http' | 'channel';
   status: 'active' | 'disabled' | 'needs_auth' | 'error';
   /** Credential storage model — one shared project credential vs each member's own. */
   credentialMode: 'shared' | 'per_user';

--- a/apps/web/translations/en.json
+++ b/apps/web/translations/en.json
@@ -7594,6 +7594,7 @@
     "autoComponentsProjectsCustomizeSectionsChannelsViewJsxAttrTitleBringbd0857f4": "Bring your own Slack app",
     "autoComponentsProjectsCustomizeSectionsChannelsViewJsxAttrDescriptionSelf7c5e4adb": "Self-hosted setups don't have OAuth wired up — paste a manifest and tokens to finish the install. Stored encrypted in this project's secrets",
     "autoComponentsProjectsCustomizeSectionsChannelsViewJsxTextAddKortix0e416aa2": "Add Kortix to your Slack workspace",
+    "autoComponentsProjectsCustomizeSectionsChannelsViewJsxTextOneClick68f102dc": "One-click install — authorize Kortix in your workspace, no setup required.",
     "autoComponentsProjectsCustomizeSectionsChannelsViewJsxTextOneClicke1160263": "One click — approve scopes in Slack and we'll wire this project to the workspace you choose. Tokens stay encrypted in this project&apos",
     "autoComponentsProjectsCustomizeSectionsChannelsViewJsxTextAddTo1729c1b6": "Add to Slack",
     "autoComponentsProjectsCustomizeSectionsChannelsViewJsxTextBringYourc7326733": "Bring your own Slack app",


### PR DESCRIPTION
Two bugs caught by **live Slack e2e testing** of the channel connector.

### 1. Channel connector didn't materialize without a readable `kortix.toml`
`syncProjectConnectors` returned at `if (!manifest) return …` **before** the channel synth, so:
- a project with no readable manifest never got its auto-materialized Slack connector, and
- a *transient* git read failure (null manifest) was treated as "zero declared connectors" → could **delete** a project's connectors.

Fix — channel connectors are **install-driven, not manifest-driven**:
- manifest-declared specs + project policies reconcile only when the manifest is readable;
- the channel synth **always** runs (connecting Slack *is* the registration);
- bail without deleting when there's no manifest **and** nothing installed;
- deletion is guarded — a readable manifest is source-of-truth for declared connectors; when it's unreadable we only reap stale **channel** rows, so a transient git error can never wipe real connectors.

### 2. Missing i18n key crashed the Channels "Connect" panel
`…ChannelsViewJsxTextOneClick68f102dc` was referenced but absent from every locale → `MISSING_MESSAGE`. Added to `en.json` (source/fallback locale).

### Verified
Live Slack workspace: the `slack` connector materializes with all **14 actions**, and `executor call slack auth_test` / `list_channels` return real data through the server-side gateway. api typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)