### PR TITLE
feat(slack): shim vendor calls → Executor SDK (KORTIX-206 Phase C1)

### DIFF
--- a/apps/sandbox/agent-cli/channels/slack.ts
+++ b/apps/sandbox/agent-cli/channels/slack.ts
@@ -13,6 +13,10 @@ import {
   kortixGet,
   kortixPost,
 } from '../lib';
+// The published Kortix Executor SDK — baked into the sandbox at the mirrored
+// path (/opt/kortix/packages/executor-sdk). Using it here both keeps the shim's
+// gateway calls clean AND dogfoods the SDK in a real in-sandbox consumer.
+import { createExecutorClient, ExecutorError } from '../../../../packages/executor-sdk/src/index';
 
 // Relay a checkpoint or the final answer into this turn's live Slack stream.
 // apps/api owns the streamed message; here we just hand it the content.
@@ -68,25 +72,63 @@ function slackApiBase(): string {
   return (getEnv('SLACK_API_URL') ?? 'https://slack.com/api').replace(/\/$/, '');
 }
 
+// Slack Web API methods → their Kortix `channel` connector action paths. The
+// shim speaks Slack method names; the Executor speaks connector actions.
+const SLACK_CONNECTOR = 'slack';
+const METHOD_TO_ACTION: Record<string, string> = {
+  'chat.postMessage': 'send_message',
+  'chat.update': 'update_message',
+  'chat.delete': 'delete_message',
+  'reactions.add': 'add_reaction',
+  'conversations.history': 'get_history',
+  'conversations.replies': 'get_thread',
+  'conversations.list': 'list_channels',
+  'conversations.info': 'channel_info',
+  'conversations.join': 'join_channel',
+  'users.list': 'list_users',
+  'users.info': 'user_info',
+  'auth.test': 'auth_test',
+  'search.messages': 'search_messages',
+  'files.info': 'file_info',
+};
+
+// The Executor SDK client, built from this sandbox's env. Setting projectId
+// makes the SDK use the project-explicit gateway route
+// (/executor/projects/:id/call), which accepts the in-sandbox session token.
+function executorClient() {
+  const apiUrl = getEnv('KORTIX_API_URL');
+  const token = getEnv('KORTIX_CLI_TOKEN') ?? getEnv('KORTIX_TOKEN');
+  if (!apiUrl || !token) {
+    throw new CliError('KORTIX_API_URL / KORTIX_CLI_TOKEN not set — cannot reach the Executor.');
+  }
+  return createExecutorClient({ apiUrl, token, projectId: kortixProjectId() });
+}
+
+// Route a Slack Web API call through the Kortix Executor (via the SDK): the bot
+// token is resolved + attached SERVER-SIDE (never in this sandbox), the call is
+// audited + policy-gated, and Slack's response comes back as `data`. The gateway
+// maps Slack's `{ok:false}` envelope to an error, so the SDK throws on failure
+// (surfacing the Slack error); on success it returns `{ ok:true, data:<slack> }`.
+// Args keep Slack's native names, so the existing callers + `data.ok` reads are
+// unchanged.
+async function executorCall(method: string, args: Record<string, unknown>): Promise<any> {
+  const action = METHOD_TO_ACTION[method];
+  if (!action) throw new CliError(`No Executor action mapped for Slack method "${method}"`);
+  try {
+    const res = await executorClient().call(SLACK_CONNECTOR, action, args);
+    return res.data ?? res;
+  } catch (err) {
+    if (err instanceof ExecutorError) throw new CliError(err.message);
+    throw err;
+  }
+}
+
 async function apiPost(method: string, body: Record<string, unknown>): Promise<any> {
-  const token = requireEnv('SLACK_BOT_TOKEN');
-  const res = await fetch(`${slackApiBase()}/${method}`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
-    body: JSON.stringify(body),
-    signal: AbortSignal.timeout(15_000),
-  });
-  return res.json();
+  return executorCall(method, body);
 }
 
 async function apiGet(method: string, params: Record<string, string>): Promise<any> {
-  const token = requireEnv('SLACK_BOT_TOKEN');
-  const qs = new URLSearchParams(params).toString();
-  const res = await fetch(`${slackApiBase()}/${method}?${qs}`, {
-    headers: { Authorization: `Bearer ${token}` },
-    signal: AbortSignal.timeout(15_000),
-  });
-  return res.json();
+  return executorCall(method, params);
 }
 
 async function send(opts: {


### PR DESCRIPTION
The in-sandbox `slack` shim's 14 Web API ops now route through the **Kortix Executor** (via `@kortix/executor-sdk`) instead of calling slack.com directly. The bot token is resolved + attached **server-side** by the gateway, so these ops are audited + policy-gated and the sandbox never holds the raw token for them.

- `apiPost`/`apiGet` → `executorCall(method,args)`: maps Slack method → channel-connector action, calls the SDK (`projectId` set → project-explicit route, which accepts the in-sandbox session token). Args keep Slack's native names; callers + `data.ok` reads unchanged. Slack `{ok:false}` → `ExecutorError` → `CliError`.
- **Dogfoods** the published SDK in a real in-sandbox consumer.
- **Unchanged:** `step`/`answer` relay (turn-stream), `typing` (noop), `manifest`. `download` + `send --file` still use the token this phase.

### Phasing
This is **C1**: token is **kept** (file ops still use it), so it's backwards-compatible and the agent's primary reply path (relay) is untouched. **C2** adds server-side file proxies for `download`/`send --file` and removes `SLACK_BOT_TOKEN` from the sandbox.

### Verified e2e
Ran the **actual shim** against the live stack with `SLACK_BOT_TOKEN` **unset**: `slack me` → real bot identity, `slack channels` → real channels — both via the executor. SDK unit (18) + live e2e (4) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)