### PR TITLE
feat(slack): token out of the sandbox — file proxies + strip SLACK_BOT_TOKEN (KORTIX-206 Phase C2)

### DIFF
--- a/apps/api/src/channels/slack/file-proxy.ts
+++ b/apps/api/src/channels/slack/file-proxy.ts
@@ -1,0 +1,87 @@
+/**
+ * Server-side Slack file proxy — the binary/multipart ops the Executor gateway
+ * (JSON in/out) can't carry, done with the bot token SERVER-SIDE so the sandbox
+ * never holds it. Backs the in-sandbox `slack download` + `slack send --file`
+ * once the token is pulled from the box (KORTIX-206 Phase C2).
+ */
+import { loadSlackTokenForProject } from '../install-store';
+
+const SLACK_API = 'https://slack.com/api';
+// Only ever attach the bot token to Slack's own hosts — `url` is caller-supplied,
+// so this is the SSRF guard that stops the token leaking to an arbitrary origin.
+const SLACK_HOST = /(^|\.)slack\.com$/i;
+
+export type FileProxyError = { ok: false; error: string; status: number };
+
+/** Fetch a Slack-hosted file with the project's bot token. SSRF-guarded. */
+export async function downloadSlackFile(
+  projectId: string,
+  url: string,
+): Promise<{ ok: true; body: ArrayBuffer; contentType: string } | FileProxyError> {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return { ok: false, error: 'invalid url', status: 400 };
+  }
+  if (parsed.protocol !== 'https:' || !SLACK_HOST.test(parsed.hostname)) {
+    return { ok: false, error: 'url must be an https://*.slack.com file URL', status: 400 };
+  }
+  const token = await loadSlackTokenForProject(projectId);
+  if (!token) return { ok: false, error: 'Slack not connected for this project', status: 404 };
+
+  const res = await fetch(parsed.href, {
+    headers: { Authorization: `Bearer ${token}` },
+    signal: AbortSignal.timeout(60_000),
+  });
+  if (!res.ok) return { ok: false, error: `download failed: HTTP ${res.status}`, status: 502 };
+  return {
+    ok: true,
+    body: await res.arrayBuffer(),
+    contentType: res.headers.get('content-type') ?? 'application/octet-stream',
+  };
+}
+
+/** Upload a file to Slack (the 3-step external-upload flow), token server-side. */
+export async function uploadSlackFile(
+  projectId: string,
+  args: { channel: string; filename: string; contentBase64: string; comment?: string; threadTs?: string },
+): Promise<{ ok: true; files: unknown } | FileProxyError> {
+  if (!args.channel || !args.filename || !args.contentBase64) {
+    return { ok: false, error: 'channel, filename and content_base64 are required', status: 400 };
+  }
+  const token = await loadSlackTokenForProject(projectId);
+  if (!token) return { ok: false, error: 'Slack not connected for this project', status: 404 };
+
+  const bytes = Buffer.from(args.contentBase64, 'base64');
+
+  // 1. Reserve an upload URL (form-encoded — Slack's API for this method).
+  const reserve = (await fetch(`${SLACK_API}/files.getUploadURLExternal`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({ filename: args.filename, length: String(bytes.length) }),
+    signal: AbortSignal.timeout(15_000),
+  }).then((r) => r.json())) as { ok?: boolean; error?: string; upload_url?: string; file_id?: string };
+  if (!reserve.ok || !reserve.upload_url || !reserve.file_id) {
+    return { ok: false, error: reserve.error ?? 'getUploadURLExternal failed', status: 502 };
+  }
+
+  // 2. PUT the bytes to the reserved URL (no token — it's pre-signed).
+  const put = await fetch(reserve.upload_url, { method: 'POST', body: bytes, signal: AbortSignal.timeout(60_000) });
+  if (!put.ok) return { ok: false, error: `upload failed: HTTP ${put.status}`, status: 502 };
+
+  // 3. Finalize → posts the file into the channel/thread.
+  const complete = (await fetch(`${SLACK_API}/files.completeUploadExternal`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      files: [{ id: reserve.file_id, title: args.filename }],
+      channel_id: args.channel,
+      ...(args.comment ? { initial_comment: args.comment } : {}),
+      ...(args.threadTs ? { thread_ts: args.threadTs } : {}),
+    }),
+    signal: AbortSignal.timeout(15_000),
+  }).then((r) => r.json())) as { ok?: boolean; error?: string; files?: unknown };
+  if (!complete.ok) return { ok: false, error: complete.error ?? 'completeUploadExternal failed', status: 502 };
+  return { ok: true, files: complete.files };
+}

--- a/apps/api/src/projects/lib/sessions.ts
+++ b/apps/api/src/projects/lib/sessions.ts
@@ -193,6 +193,12 @@ export async function buildSessionSandboxEnvVars(input: {
   // The Slack signing secret only verifies inbound webhooks (an apps/api job).
   // The in-sandbox agent never needs it — keep it out of the sandbox env.
   delete runtimeSecrets.env.SLACK_SIGNING_SECRET;
+  // The Slack BOT TOKEN no longer belongs in the sandbox either: the `slack`
+  // shim now runs every Web API call through the Executor (server-side token)
+  // and its file ops through the server-side file proxy. Keeping it out means a
+  // compromised/prompt-injected agent can't exfiltrate the raw bot token — only
+  // make scoped, audited, policy-gated channel calls. (KORTIX-206 Phase C2.)
+  delete runtimeSecrets.env.SLACK_BOT_TOKEN;
   // Guardrail: drop any project secret whose name would clobber the sandbox's
   // own runtime env (PORT/PATH/KORTIX_*/…). Without this, one stray secret
   // silently breaks every session — and `kortix env push` of a server .env

--- a/apps/api/src/projects/routes/r4.ts
+++ b/apps/api/src/projects/routes/r4.ts
@@ -1,5 +1,6 @@
 import { deleteSlackInstall, loadSlackInstall, saveSlackInstall } from '../../channels/install-store';
 import { reconcileChannelConnectors } from '../../executor/sync';
+import { downloadSlackFile, uploadSlackFile } from '../../channels/slack/file-proxy';
 import { buildSlackInstallUrl } from '../../channels/slack-oauth';
 import { slackOauthMode } from '../../channels/slack-oauth-mode';
 import { postQuestion, relayTurnAnswer, relayTurnEnd, relayTurnStep, type QuestionInfo } from '../../channels/slack-webhook';
@@ -539,6 +540,73 @@ projectsApp.openapi(
       : await relayTurnStep(sessionId, text, { detail, outputForPrev, sourcesForPrev });
   return c.json({ ok });
 },
+);
+
+// GET /v1/projects/:projectId/channels/slack/file?url=...
+// Server-side download proxy: fetch a Slack-hosted file with the bot token
+// (SSRF-guarded to *.slack.com) so the sandbox never holds the token. Backs
+// `slack download` once the token is out of the box (KORTIX-206 Phase C2).
+projectsApp.openapi(
+  createRoute({
+    method: 'get',
+    path: '/{projectId}/channels/slack/file',
+    tags: ['channels'],
+    summary: 'GET /:projectId/channels/slack/file (download proxy)',
+    ...auth,
+    request: {
+      params: z.object({ projectId: z.string() }),
+      query: z.object({ url: z.string() }),
+    },
+    responses: {
+      200: { description: 'File bytes', content: { 'application/octet-stream': { schema: z.any() } } },
+      ...errors(400, 404),
+    },
+  }),
+  async (c: any) => {
+    const projectId = c.req.param('projectId');
+    const loaded = await loadProjectForUser(c, projectId, 'read');
+    if (!loaded) return c.json({ error: 'Not found' }, 404);
+    const result = await downloadSlackFile(projectId, c.req.query('url') ?? '');
+    if (!result.ok) return c.json({ error: result.error }, result.status as 400 | 404);
+    c.header('Content-Type', result.contentType);
+    return c.body(result.body);
+  },
+);
+
+// POST /v1/projects/:projectId/channels/slack/file/upload
+// Server-side upload proxy: the 3-step external upload, bot token server-side.
+// Backs `slack send --file` once the token is out of the box.
+projectsApp.openapi(
+  createRoute({
+    method: 'post',
+    path: '/{projectId}/channels/slack/file/upload',
+    tags: ['channels'],
+    summary: 'POST /:projectId/channels/slack/file/upload (upload proxy)',
+    ...auth,
+    request: {
+      params: z.object({ projectId: z.string() }),
+      body: { content: { 'application/json': { schema: AnyObject } } },
+    },
+    responses: {
+      200: json(z.object({ ok: z.boolean(), files: z.any() }).passthrough(), 'Uploaded'),
+      ...errors(400, 404),
+    },
+  }),
+  async (c: any) => {
+    const projectId = c.req.param('projectId');
+    const loaded = await loadProjectForUser(c, projectId, 'read');
+    if (!loaded) return c.json({ error: 'Not found' }, 404);
+    const body = await readBody(c);
+    const result = await uploadSlackFile(projectId, {
+      channel: String(body.channel ?? ''),
+      filename: String(body.filename ?? ''),
+      contentBase64: String(body.content_base64 ?? body.contentBase64 ?? ''),
+      comment: typeof body.comment === 'string' ? body.comment : undefined,
+      threadTs: typeof body.thread_ts === 'string' ? body.thread_ts : (typeof body.threadTs === 'string' ? body.threadTs : undefined),
+    });
+    if (!result.ok) return c.json({ error: result.error }, result.status as 400 | 404);
+    return c.json({ ok: true, files: result.files });
+  },
 );
 
 // POST /v1/projects/:projectId/turn-question

--- a/apps/sandbox/agent-cli/channels/slack.ts
+++ b/apps/sandbox/agent-cli/channels/slack.ts
@@ -5,7 +5,6 @@ import {
   out,
   CliError,
   handleError,
-  requireEnv,
   validateRequired,
   getEnv,
   kortixProjectId,
@@ -66,10 +65,6 @@ function readSourcesFlag(flags: Record<string, string>): Array<{ url: string; te
       return { url: line.slice(0, i).trim(), text: line.slice(i + 1).trim() };
     })
     .filter((s) => /^https?:\/\//.test(s.url));
-}
-
-function slackApiBase(): string {
-  return (getEnv('SLACK_API_URL') ?? 'https://slack.com/api').replace(/\/$/, '');
 }
 
 // Slack Web API methods → their Kortix `channel` connector action paths. The
@@ -138,37 +133,25 @@ async function send(opts: {
   file?: string;
   blocks?: unknown[];
 }) {
-  const token = requireEnv('SLACK_BOT_TOKEN');
-
   if (opts.file) {
     if (!existsSync(opts.file)) throw new CliError(`File not found: ${opts.file}`);
     const fileData = readFileSync(opts.file);
     const fileName = opts.file.split('/').pop() || 'file';
-
-    const getUrlRes = await fetch(`${slackApiBase()}/files.getUploadURLExternal`, {
-      method: 'POST',
-      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/x-www-form-urlencoded' },
-      body: new URLSearchParams({ filename: fileName, length: String(fileData.length) }),
-      signal: AbortSignal.timeout(15_000),
-    }).then((r) => r.json()) as any;
-    if (!getUrlRes.ok) throw new CliError(getUrlRes.error ?? 'getUploadURL failed');
-
-    const uploadRes = await fetch(getUrlRes.upload_url, {
-      method: 'POST',
-      body: fileData,
-      signal: AbortSignal.timeout(60_000),
-    });
-    if (!uploadRes.ok) throw new CliError(`Upload failed: ${uploadRes.status}`);
-
-    const completeBody: Record<string, unknown> = {
-      files: [{ id: getUrlRes.file_id, title: fileName }],
-      channel_id: opts.channel,
-    };
-    if (opts.text) completeBody.initial_comment = opts.text;
-    if (opts.threadTs) completeBody.thread_ts = opts.threadTs;
-    const completeRes = await apiPost('files.completeUploadExternal', completeBody);
-    if (!completeRes.ok) throw new CliError(completeRes.error ?? 'completeUpload failed');
-    return { ok: true, files: completeRes.files, channel: opts.channel };
+    // Upload via the server-side proxy — the bot token stays on the server (the
+    // 3-step external-upload + form-encoding can't ride the JSON Executor gateway).
+    const projectId = kortixProjectId();
+    if (!projectId) throw new CliError('KORTIX_PROJECT_ID not set — cannot upload.');
+    const res = await kortixPost<{ ok?: boolean; files?: unknown }>(
+      `/projects/${projectId}/channels/slack/file/upload`,
+      {
+        channel: opts.channel,
+        filename: fileName,
+        content_base64: fileData.toString('base64'),
+        ...(opts.text ? { comment: opts.text } : {}),
+        ...(opts.threadTs ? { thread_ts: opts.threadTs } : {}),
+      },
+    );
+    return { ok: true, files: res.files, channel: opts.channel };
   }
 
   if (!opts.text && (!opts.blocks || opts.blocks.length === 0)) {
@@ -297,12 +280,27 @@ async function fileInfo(opts: { fileId: string }) {
 }
 
 async function download(opts: { url: string; out: string }) {
-  const token = requireEnv('SLACK_BOT_TOKEN');
-  const res = await fetch(opts.url, {
-    headers: { Authorization: `Bearer ${token}` },
+  // Fetch via the server-side proxy — the bot token stays on the server. Binary,
+  // so a raw fetch (not the JSON kortix client), authed with the session token.
+  const apiUrl = getEnv('KORTIX_API_URL');
+  const tok = getEnv('KORTIX_CLI_TOKEN') ?? getEnv('KORTIX_TOKEN');
+  const projectId = kortixProjectId();
+  if (!apiUrl || !tok || !projectId) {
+    throw new CliError('KORTIX_API_URL / KORTIX_CLI_TOKEN / KORTIX_PROJECT_ID not set — cannot download.');
+  }
+  const proxyUrl = new URL(
+    `/v1/projects/${projectId}/channels/slack/file?url=${encodeURIComponent(opts.url)}`,
+    apiUrl,
+  ).href;
+  const res = await fetch(proxyUrl, {
+    headers: { Authorization: `Bearer ${tok}` },
     signal: AbortSignal.timeout(60_000),
   });
-  if (!res.ok) throw new CliError(`Download failed: ${res.status}`);
+  if (!res.ok) {
+    let msg = `Download failed: HTTP ${res.status}`;
+    try { const j = (await res.json()) as { error?: string }; if (j?.error) msg = j.error; } catch { /* keep */ }
+    throw new CliError(msg);
+  }
   const buf = await res.arrayBuffer();
   const dir = opts.out.split('/').slice(0, -1).join('/');
   if (dir) mkdirSync(dir, { recursive: true });
@@ -488,7 +486,7 @@ async function main(): Promise<void> {
       console.log(`
 slack — Slack Web API adapter
 
-Auth: SLACK_BOT_TOKEN env (injected from project_secrets at sandbox spawn).
+Auth: none in-sandbox — calls run through the Kortix Executor (server-side bot token).
 
 Turn commands (use these when answering a Slack message):
   step         "<checkpoint>"            # narrate a live plan step as you work


### PR DESCRIPTION
Completes the cutover (after #3577 C1): the in-sandbox `slack` shim no longer needs the bot token, so we stop injecting it. A prompt-injected agent can now only make scoped, audited, policy-gated channel calls — never read/exfiltrate the raw token.

- **`channels/slack/file-proxy.ts`** — server-side download + upload, bot token resolved server-side. `download` is **SSRF-guarded to `https://*.slack.com`** (the url is caller-supplied). `upload` runs the 3-step external-upload flow server-side.
- **`r4.ts`** — `GET /:projectId/channels/slack/file` (download proxy) + `POST /:projectId/channels/slack/file/upload` (upload proxy), auth mirrors turn-stream.
- **shim** — `download` + `send --file` now call the proxies; removed all `SLACK_BOT_TOKEN` usage + the dead `slackApiBase()`/`requireEnv`.
- **sessions.ts** — `delete runtimeSecrets.env.SLACK_BOT_TOKEN` (it's a project_secret → auto-injected today; this is the line that keeps it out, mirroring `SLACK_SIGNING_SECRET`).

### Verified
api typecheck + shim parse clean. Proxy routes + **SSRF guard** exercised live: non-slack url → `400`, slack url → authed fetch, empty upload → `400`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)