### PR TITLE
fix(triggers): make per-project pause kill-switch reachable + add UI toggle

### DIFF
--- a/apps/api/src/__tests__/unit-trigger-activation-route.test.ts
+++ b/apps/api/src/__tests__/unit-trigger-activation-route.test.ts
@@ -1,0 +1,92 @@
+// Regression guard for the project-level trigger kill-switch route.
+//
+// `PATCH /projects/:projectId/triggers/activation` (pause/resume all of a
+// project's triggers) is a STATIC route that lives in the same namespace as the
+// per-trigger `PATCH /projects/:projectId/triggers/:slug` route. OpenAPIHono
+// matches routes in registration order, so if the `:slug` route is registered
+// first it captures `activation` as a slug — the activation handler is shadowed
+// and the request 404s ("no trigger named 'activation'"). That silently breaks
+// the entire pause feature: the CLI `kortix triggers pause/resume`, the web
+// toggle, and the only way to stop a repo deployed to two control planes from
+// double-firing its crons.
+//
+// This shipped broken once (the activation route was declared AFTER `:slug`),
+// so these tests lock the invariant from two angles:
+//   1. behavioural — prove the bug exists with `:slug`-first and is fixed with
+//      `activation`-first, using a real OpenAPIHono router;
+//   2. structural — assert the real r4.ts registers `activation` BEFORE `:slug`.
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { OpenAPIHono, createRoute, z } from '@hono/zod-openapi';
+
+type Order = 'slug-first' | 'activation-first';
+
+function buildRouter(order: Order): OpenAPIHono {
+  const app = new OpenAPIHono();
+  const slugRoute = createRoute({
+    method: 'patch',
+    path: '/{projectId}/triggers/{slug}',
+    request: { params: z.object({ projectId: z.string(), slug: z.string() }) },
+    responses: { 200: { description: 'ok' } },
+  });
+  const activationRoute = createRoute({
+    method: 'patch',
+    path: '/{projectId}/triggers/activation',
+    request: { params: z.object({ projectId: z.string() }) },
+    responses: { 200: { description: 'ok' } },
+  });
+  const slugHandler = (c: any) => c.json({ handler: 'slug', slug: c.req.param('slug') });
+  const activationHandler = (c: any) => c.json({ handler: 'activation' });
+  // Registration order is the whole point of this test.
+  if (order === 'slug-first') {
+    app.openapi(slugRoute, slugHandler);
+    app.openapi(activationRoute, activationHandler);
+  } else {
+    app.openapi(activationRoute, activationHandler);
+    app.openapi(slugRoute, slugHandler);
+  }
+  return app;
+}
+
+async function patch(app: OpenAPIHono, path: string): Promise<{ handler: string; slug?: string }> {
+  const res = await app.request(path, {
+    method: 'PATCH',
+    headers: { 'content-type': 'application/json' },
+    body: '{}',
+  });
+  return (await res.json()) as { handler: string; slug?: string };
+}
+
+describe('trigger activation route ordering', () => {
+  test('activation-first: /triggers/activation reaches the activation handler', async () => {
+    const app = buildRouter('activation-first');
+    expect(await patch(app, '/p1/triggers/activation')).toEqual({ handler: 'activation' });
+  });
+
+  test('activation-first: a real slug still reaches the per-trigger handler', async () => {
+    const app = buildRouter('activation-first');
+    expect(await patch(app, '/p1/triggers/error-sweep')).toEqual({ handler: 'slug', slug: 'error-sweep' });
+  });
+
+  test('slug-first reproduces the shadowing bug (activation captured as a slug)', async () => {
+    // Documents WHY order matters — declaring `:slug` first shadows the static
+    // route, which is the exact regression this file guards against.
+    const app = buildRouter('slug-first');
+    expect(await patch(app, '/p1/triggers/activation')).toEqual({ handler: 'slug', slug: 'activation' });
+  });
+
+  test('r4.ts registers the static activation route BEFORE the :slug routes', () => {
+    const source = readFileSync(
+      join(import.meta.dir, '..', 'projects', 'routes', 'r4.ts'),
+      'utf8',
+    );
+    const activationIdx = source.indexOf("path: '/{projectId}/triggers/activation'");
+    const slugIdx = source.indexOf("path: '/{projectId}/triggers/{slug}'");
+    expect(activationIdx).toBeGreaterThan(-1);
+    expect(slugIdx).toBeGreaterThan(-1);
+    // If this fails, the activation kill-switch is shadowed and unreachable —
+    // move the activation route above the `:slug` routes in r4.ts.
+    expect(activationIdx).toBeLessThan(slugIdx);
+  });
+});

--- a/apps/api/src/projects/routes/r4.ts
+++ b/apps/api/src/projects/routes/r4.ts
@@ -170,6 +170,12 @@ projectsApp.openapi(
     const body = await readBody(c);
     const loaded = await loadProjectForUser(c, projectId, 'manage');
     if (!loaded) return c.json({ error: 'Not found' }, 404);
+    await assertAuthorized(
+      loaded.userId,
+      loaded.row.accountId,
+      PROJECT_ACTIONS.PROJECT_TRIGGER_UPDATE,
+      { type: 'project', id: projectId },
+    );
     const paused = body.paused;
     if (typeof paused !== 'boolean') {
       return c.json({ error: 'paused must be a boolean' }, 400);

--- a/apps/api/src/projects/routes/r4.ts
+++ b/apps/api/src/projects/routes/r4.ts
@@ -135,6 +135,55 @@ projectsApp.openapi(
 },
 );
 
+// PATCH /:projectId/triggers/activation — server-side, per-project trigger
+// kill-switch. Body { paused: boolean }. When paused, the platform won't
+// auto-run any of this project's triggers (the cron sweep skips it, inbound
+// webhooks are ignored) regardless of each trigger's repo `enabled`. Use it to
+// stop ONE repo deployed to TWO control planes (e.g. dev + prod) from
+// double-firing every cron — pause the deployment you don't want firing. A
+// manual `…/triggers/:slug/fire` is explicit and still runs.
+//
+// ⚠️ ORDER MATTERS: this static route MUST stay registered BEFORE the
+// `…/triggers/{slug}` routes below. OpenAPIHono matches in registration order,
+// so when `…/triggers/{slug}` is declared first it captures `activation` as a
+// slug and this handler is shadowed — the PATCH 404s because no trigger is
+// named "activation", which silently breaks the whole pause kill-switch.
+// Covered by unit-trigger-activation-route.test.ts.
+projectsApp.openapi(
+  createRoute({
+    method: 'patch',
+    path: '/{projectId}/triggers/activation',
+    tags: ['triggers'],
+    summary: 'Pause or resume all of a project\'s triggers server-side',
+    ...auth,
+    request: {
+      params: z.object({ projectId: z.string() }),
+      body: { content: { 'application/json': { schema: AnyObject } } },
+    },
+    responses: {
+      200: json(AnyObject, 'Updated triggers (includes triggers_paused)'),
+      ...errors(400, 401, 403, 404),
+    },
+  }),
+  async (c: any) => {
+    const projectId = c.req.param('projectId');
+    const body = await readBody(c);
+    const loaded = await loadProjectForUser(c, projectId, 'manage');
+    if (!loaded) return c.json({ error: 'Not found' }, 404);
+    const paused = body.paused;
+    if (typeof paused !== 'boolean') {
+      return c.json({ error: 'paused must be a boolean' }, 400);
+    }
+    const [row] = await db
+      .update(projects)
+      .set({ metadata: withTriggersPaused(loaded.row.metadata, paused), updatedAt: new Date() })
+      .where(eq(projects.projectId, projectId))
+      .returning();
+    if (!row || row.status === 'archived') return c.json({ error: 'Not found' }, 404);
+    return c.json(await loadTriggersForResponse(projectId, row));
+  },
+);
+
 // PATCH /v1/projects/:projectId/triggers/:slug
 
 projectsApp.openapi(
@@ -790,48 +839,6 @@ projectsApp.openapi(
     deduped: result.deduped ?? false,
   }, 202);
 },
-);
-
-// PATCH /:projectId/triggers/activation — server-side, per-project trigger
-// kill-switch. Body { paused: boolean }. When paused, the platform won't
-// auto-run any of this project's triggers (the cron sweep skips it, inbound
-// webhooks are ignored) regardless of each trigger's repo `enabled`. Use it to
-// stop ONE repo deployed to TWO control planes (e.g. dev + prod) from
-// double-firing every cron — pause the deployment you don't want firing. A
-// manual `…/triggers/:slug/fire` is explicit and still runs.
-projectsApp.openapi(
-  createRoute({
-    method: 'patch',
-    path: '/{projectId}/triggers/activation',
-    tags: ['triggers'],
-    summary: 'Pause or resume all of a project\'s triggers server-side',
-    ...auth,
-    request: {
-      params: z.object({ projectId: z.string() }),
-      body: { content: { 'application/json': { schema: AnyObject } } },
-    },
-    responses: {
-      200: json(AnyObject, 'Updated triggers (includes triggers_paused)'),
-      ...errors(400, 401, 403, 404),
-    },
-  }),
-  async (c: any) => {
-    const projectId = c.req.param('projectId');
-    const body = await readBody(c);
-    const loaded = await loadProjectForUser(c, projectId, 'manage');
-    if (!loaded) return c.json({ error: 'Not found' }, 404);
-    const paused = body.paused;
-    if (typeof paused !== 'boolean') {
-      return c.json({ error: 'paused must be a boolean' }, 400);
-    }
-    const [row] = await db
-      .update(projects)
-      .set({ metadata: withTriggersPaused(loaded.row.metadata, paused), updatedAt: new Date() })
-      .where(eq(projects.projectId, projectId))
-      .returning();
-    if (!row || row.status === 'archived') return c.json({ error: 'Not found' }, 404);
-    return c.json(await loadTriggersForResponse(projectId, row));
-  },
 );
 
 // ── [[apps]] CRUD + deploy ──────────────────────────────────────────────────

--- a/apps/web/src/components/projects/triggers-view.tsx
+++ b/apps/web/src/components/projects/triggers-view.tsx
@@ -76,6 +76,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { List, ListRow } from '@/components/ui/list';
 import { SectionCard } from '@/components/ui/section-card';
+import { Switch } from '@/components/ui/switch';
 import {
   Select,
   SelectContent,
@@ -100,6 +101,7 @@ import {
   fireProjectTrigger,
   listProjectAccess,
   listProjectTriggers,
+  setProjectTriggersActivation,
   updateProjectTrigger,
   upsertProjectSecret,
   type ProjectAccessMember,
@@ -321,6 +323,61 @@ export function TriggersView({ projectId, type }: { projectId: string; type: Tri
   );
 }
 
+/**
+ * Project-wide trigger kill-switch. Presentational — the parent owns the
+ * mutation. When paused, the platform auto-runs none of this project's triggers
+ * (cron sweep skips it, inbound webhooks are acknowledged-but-ignored); manual
+ * test-fires still work. The amber banner explains the silence so an operator
+ * doesn't wonder why scheduled runs stopped.
+ */
+function TriggersActivationControl({
+  paused,
+  pending,
+  onToggle,
+}: {
+  paused: boolean;
+  pending: boolean;
+  onToggle: (paused: boolean) => void;
+}) {
+  return (
+    <div
+      className={cn(
+        'rounded-2xl border px-4 py-3.5 transition-colors',
+        paused ? 'border-amber-500/40 bg-amber-500/[0.05]' : 'border-border bg-card',
+      )}
+    >
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0 space-y-1">
+          <div className="flex items-center gap-2">
+            <Pause className="text-muted-foreground h-3.5 w-3.5" />
+            <p className="text-foreground text-sm font-medium">Pause all triggers</p>
+          </div>
+          <p className="text-muted-foreground text-xs">
+            Stop the platform from auto-running this project&apos;s schedules and webhooks.
+            Manual test-fires still work. Use this when the same repo also runs in another
+            environment that should own the triggers.
+          </p>
+        </div>
+        <Switch
+          checked={paused}
+          disabled={pending}
+          onCheckedChange={onToggle}
+          aria-label="Pause all triggers for this project"
+        />
+      </div>
+      {paused && (
+        <div className="mt-3 flex items-start gap-2 rounded-lg border border-amber-500/30 bg-amber-500/[0.06] px-3 py-2">
+          <AlertTriangle className="mt-0.5 h-3.5 w-3.5 flex-shrink-0 text-amber-600 dark:text-amber-400" />
+          <p className="text-xs text-amber-700 dark:text-amber-400">
+            Triggers are paused. Scheduled runs and incoming webhooks are ignored for this
+            project until you resume — test-firing a trigger manually still works.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
+
 function ProjectTriggersBody({
   projectId,
   type,
@@ -353,6 +410,27 @@ function ProjectTriggersBody({
     [queryClient, queryKey],
   );
 
+  // Project-level kill-switch (server-side `triggers_paused`). When on, the
+  // platform auto-runs NONE of this project's triggers regardless of each
+  // trigger's repo `enabled` — used to stop a repo deployed to two control
+  // planes from double-firing. Shared across the Schedules + Webhooks views;
+  // toggling here writes back to the same `['project-triggers', projectId]`
+  // cache both pages read.
+  const triggersPaused = triggersQuery.data?.triggers_paused ?? false;
+  const setActivation = useMutation({
+    mutationFn: (paused: boolean) => setProjectTriggersActivation(projectId, paused),
+    onSuccess: (data, paused) => {
+      queryClient.setQueryData(queryKey, data);
+      toast.success(
+        paused ? 'All triggers paused for this project' : 'Triggers resumed',
+      );
+    },
+    onError: (err) =>
+      toast.error(
+        err instanceof Error ? err.message : 'Failed to update trigger activation',
+      ),
+  });
+
   // Filter to just this view's type — the API returns every trigger
   // because they share one `kortix.toml`, but each page is scoped.
   const allTriggers = triggersQuery.data?.triggers ?? [];
@@ -368,6 +446,14 @@ function ProjectTriggersBody({
           <h2 className="text-foreground text-base font-semibold">{meta.pageTitle}</h2>
           <p className="text-muted-foreground text-xs">{meta.description}</p>
         </header>
+
+        {!triggersQuery.isLoading && !isForbidden && !triggersQuery.isError && (allTriggers.length > 0 || triggersPaused) && (
+          <TriggersActivationControl
+            paused={triggersPaused}
+            pending={setActivation.isPending}
+            onToggle={(paused) => setActivation.mutate(paused)}
+          />
+        )}
 
         {triggersQuery.isLoading ? (
           <TriggersSkeleton />

--- a/apps/web/src/components/projects/triggers-view.tsx
+++ b/apps/web/src/components/projects/triggers-view.tsx
@@ -71,6 +71,7 @@ import {
 } from '@/components/ui/dialog';
 import { EmptyState as EmptyStateBox } from '@/components/ui/empty-state';
 import { EntityAvatar } from '@/components/ui/entity-avatar';
+import { InfoBanner } from '@/components/ui/info-banner';
 import { InlineMeta } from '@/components/ui/inline-meta';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -340,41 +341,31 @@ function TriggersActivationControl({
   onToggle: (paused: boolean) => void;
 }) {
   return (
-    <div
-      className={cn(
-        'rounded-2xl border px-4 py-3.5 transition-colors',
-        paused ? 'border-amber-500/40 bg-amber-500/[0.05]' : 'border-border bg-card',
+    <SectionCard
+      title={(
+        <span className="flex items-center gap-2">
+          <Pause className="text-muted-foreground h-3.5 w-3.5" />
+          Pause all triggers
+        </span>
       )}
-    >
-      <div className="flex items-start justify-between gap-4">
-        <div className="min-w-0 space-y-1">
-          <div className="flex items-center gap-2">
-            <Pause className="text-muted-foreground h-3.5 w-3.5" />
-            <p className="text-foreground text-sm font-medium">Pause all triggers</p>
-          </div>
-          <p className="text-muted-foreground text-xs">
-            Stop the platform from auto-running this project&apos;s schedules and webhooks.
-            Manual test-fires still work. Use this when the same repo also runs in another
-            environment that should own the triggers.
-          </p>
-        </div>
+      description="Stop the platform from auto-running this project's schedules and webhooks. Manual test-fires still work. Use this when another environment should own the triggers."
+      action={(
         <Switch
           checked={paused}
           disabled={pending}
           onCheckedChange={onToggle}
           aria-label="Pause all triggers for this project"
         />
-      </div>
-      {paused && (
-        <div className="mt-3 flex items-start gap-2 rounded-lg border border-amber-500/30 bg-amber-500/[0.06] px-3 py-2">
-          <AlertTriangle className="mt-0.5 h-3.5 w-3.5 flex-shrink-0 text-amber-600 dark:text-amber-400" />
-          <p className="text-xs text-amber-700 dark:text-amber-400">
-            Triggers are paused. Scheduled runs and incoming webhooks are ignored for this
-            project until you resume — test-firing a trigger manually still works.
-          </p>
-        </div>
       )}
-    </div>
+      bodyClassName={paused ? 'py-4' : 'hidden'}
+    >
+      {paused && (
+        <InfoBanner tone="warning" icon={AlertTriangle}>
+          Triggers are paused. Scheduled runs and incoming webhooks are ignored for this
+          project until you resume — test-firing a trigger manually still works.
+        </InfoBanner>
+      )}
+    </SectionCard>
   );
 }
 

--- a/apps/web/src/components/projects/triggers-view.tsx
+++ b/apps/web/src/components/projects/triggers-view.tsx
@@ -328,7 +328,7 @@ export function TriggersView({ projectId, type }: { projectId: string; type: Tri
  * Project-wide trigger kill-switch. Presentational — the parent owns the
  * mutation. When paused, the platform auto-runs none of this project's triggers
  * (cron sweep skips it, inbound webhooks are acknowledged-but-ignored); manual
- * test-fires still work. The amber banner explains the silence so an operator
+ * test-fires still work. The warning banner explains the silence so an operator
  * doesn't wonder why scheduled runs stopped.
  */
 function TriggersActivationControl({

--- a/apps/web/src/lib/projects-client.ts
+++ b/apps/web/src/lib/projects-client.ts
@@ -2148,6 +2148,14 @@ export interface ProjectTriggerParseError {
 export interface ProjectTriggerListing {
   triggers: ProjectTrigger[];
   errors: ProjectTriggerParseError[];
+  /**
+   * Server-side, per-project kill-switch (`projects.metadata.triggers_paused`).
+   * When true the platform auto-runs NONE of this project's triggers — the cron
+   * sweep skips it and inbound webhooks are acknowledged-but-ignored, regardless
+   * of each trigger's repo `enabled`. Manual `fire` still works. Use it to stop
+   * ONE repo deployed to two control planes (e.g. dev + prod) from double-firing.
+   */
+  triggers_paused?: boolean;
 }
 
 export interface CreateProjectTriggerInput {
@@ -2225,6 +2233,23 @@ export async function deleteProjectTrigger(projectId: string, slug: string) {
   return unwrap(
     await backendApi.delete<{ ok: boolean }>(
       `/projects/${projectId}/triggers/${slug}`,
+    ),
+  );
+}
+
+/**
+ * Pause or resume ALL of a project's triggers server-side (the per-project
+ * kill-switch — see {@link ProjectTriggerListing.triggers_paused}). Returns the
+ * updated trigger listing, including the new `triggers_paused` value.
+ */
+export async function setProjectTriggersActivation(
+  projectId: string,
+  paused: boolean,
+) {
+  return unwrap(
+    await backendApi.patch<ProjectTriggerListing>(
+      `/projects/${projectId}/triggers/activation`,
+      { paused },
     ),
   );
 }


### PR DESCRIPTION
## Problem

The per-project trigger kill-switch (`projects.metadata.triggers_paused`, shipped in #3532) **was never reachable over HTTP**. `PATCH /projects/:id/triggers/activation` is a *static* route registered **after** the dynamic `PATCH /projects/:id/triggers/:slug` route. OpenAPIHono matches in **registration order**, so `activation` was captured as a `:slug` → the slug handler ran → no trigger is named `"activation"` → **404**.

`kortix triggers pause/resume` and any API/UI client all hit the same dead route, so the switch never paused anything. **This is the root cause of one repo deployed to two control planes (e.g. dev + prod) double-firing every cron.**

Reproduced with the real router:
```
[slug-first]      PATCH /triggers/activation -> { handler: 'slug', slug: 'activation' }   # 🐛
[activation-first] PATCH /triggers/activation -> { handler: 'activation' }                # ✅
                   PATCH /triggers/error-sweep -> { handler: 'slug', slug: 'error-sweep' } # ✅ real slugs still route
```

## Fix
- **Backend** (`r4.ts`): register the static `…/triggers/activation` route **before** the `…/triggers/{slug}` routes, with an ⚠️ ORDER-MATTERS comment so it can't be reordered back into shadow.
- **Test** (`unit-trigger-activation-route.test.ts`): behavioural router test (reproduces the bug slug-first, proves activation-first fixes it and real slugs still route) **plus** a structural guard asserting `r4.ts` keeps `activation` before `:slug`.
- **Web**: surface the kill-switch as a **"Pause all triggers"** switch at the top of Customize → Schedules/Webhooks (shared `['project-triggers', projectId]` cache), with an amber *"triggers are paused"* banner so an operator isn't left wondering why scheduled runs stopped. New `setProjectTriggersActivation` client + `triggers_paused` on the listing type.

## Verification
- ✅ Regression test green (4/4)
- ✅ `apps/api` tsc clean; `apps/web` tsc clean for changed files (only pre-existing unrelated errors remain)
- ⏳ Will verify on the `preview` deploy: `PATCH /triggers/activation` returns 200 + pauses, and the UI toggle round-trips.

## Why now
dev.kortix.com runs a copy of the prod company repo, so every cron fires twice. Once this is on dev, pausing project `9cfd79ad` stops dev from auto-running triggers while prod keeps ownership.

🤖 Generated with [Claude Code](https://claude.com/claude-code)