### PR TITLE
fix(qa-portal): serve full reports/ tree so per-PR links resolve

### DIFF
--- a/infra/k8s/charts/qa-portal/templates/deployment.yaml
+++ b/infra/k8s/charts/qa-portal/templates/deployment.yaml
@@ -46,11 +46,16 @@ spec:
           args:
             - |
               set -e
-              aws s3 sync "s3://{{ .Values.bucket }}/{{ .Values.s3Prefix }}/" /html --delete --region {{ .Values.region }}
-              # First-run safety: if no report exists yet, leave a placeholder so
-              # nginx is still healthy and the page explains the empty state.
-              if [ -z "$(ls -A /html 2>/dev/null)" ]; then
-                echo "<h1>QA report portal</h1><p>No report has been published yet.</p>" > /html/index.html
+              # Sync the whole reports/ tree so per-PR reports (reports/pr/<n>/<run>/)
+              # and history are served too, not just latest/.
+              aws s3 sync "s3://{{ .Values.bucket }}/{{ .Values.s3Prefix }}/" "/html/{{ .Values.s3Prefix }}" --delete --region {{ .Values.region }}
+              # Root redirects to the latest report; the qa-pr comment links deep to
+              # /{{ .Values.s3Prefix }}/pr/<n>/<run>/index.html.
+              printf '<!doctype html><meta http-equiv="refresh" content="0; url=/{{ .Values.s3Prefix }}/latest/">\n' > /html/index.html
+              # First-run safety: placeholder so nginx is healthy before any publish.
+              if [ -z "$(ls -A "/html/{{ .Values.s3Prefix }}/latest" 2>/dev/null)" ]; then
+                mkdir -p "/html/{{ .Values.s3Prefix }}/latest"
+                echo "<h1>QA report portal</h1><p>No report has been published yet.</p>" > "/html/{{ .Values.s3Prefix }}/latest/index.html"
               fi
           env:
             - name: AWS_REGION
@@ -97,7 +102,7 @@ spec:
             - |
               while true; do
                 sleep {{ .Values.syncIntervalSeconds }}
-                aws s3 sync "s3://{{ .Values.bucket }}/{{ .Values.s3Prefix }}/" /html --delete --region {{ .Values.region }} || true
+                aws s3 sync "s3://{{ .Values.bucket }}/{{ .Values.s3Prefix }}/" "/html/{{ .Values.s3Prefix }}" --delete --region {{ .Values.region }} || true
               done
           env:
             - name: AWS_REGION

--- a/infra/k8s/charts/qa-portal/values.yaml
+++ b/infra/k8s/charts/qa-portal/values.yaml
@@ -21,7 +21,7 @@ awsCli:
 # ── S3 source ─────────────────────────────────────────────────────────────────
 # The sidecar runs `aws s3 sync s3://<bucket>/<prefix> /usr/share/nginx/html`.
 bucket: "" # REQUIRED — kortix-qa-reports (from terraform output bucket_name)
-s3Prefix: "reports/latest" # the generated static report to serve
+s3Prefix: "reports" # the generated static report to serve
 region: us-west-2
 
 # How often the sidecar re-syncs the latest report (seconds).

--- a/infra/k8s/envs/qa/values.yaml
+++ b/infra/k8s/envs/qa/values.yaml
@@ -7,7 +7,7 @@
 
 # S3 bucket holding the Allure results + generated reports (terraform output bucket_name).
 bucket: kortix-qa-reports
-s3Prefix: "reports/latest"
+s3Prefix: "reports"
 region: us-west-2
 
 # Resync the served report from S3 every 2 minutes.


### PR DESCRIPTION
Follow-up to #3590 (pushed just after it merged). The portal synced only `reports/latest/` into the docroot root, so per-PR report URLs (`qa.kortix.com/reports/pr/<n>/<run>/`) 404'd. Sync the whole `reports/` tree into `/html/reports/` and redirect `/` -> `/reports/latest/`.

Already applied live (helm rev 3); this commits the chart so code matches the cluster.