### PR TITLE
fix(api): bundle migrations into the image (image build broken on main)

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -68,8 +68,12 @@ COPY packages/registry ./packages/registry
 # Install pnpm and deps for this app + workspace packages it depends on.
 # --shamefully-hoist flattens node_modules (no symlinks) so COPY works on all Docker versions.
 # Include devDeps because the API runs TypeScript source directly under Bun.
+# Also install the root project's deps (--filter kortix) so the migration runner
+# (node-pg-migrate, pg) is bundled in the image — self-hosters apply migrations
+# with `bun packages/db/scripts/migrate.ts up`. node-pg-migrate lives at the root
+# (not @kortix/db) to keep the db package's drizzle-orm resolution single.
 RUN corepack enable pnpm && \
-    pnpm install --filter ./${SERVICE}... --shamefully-hoist --prod=false --ignore-scripts
+    pnpm install --filter ./${SERVICE}... --filter kortix --shamefully-hoist --prod=false --ignore-scripts
 
 # ---- Runner Stage ----
 FROM base AS runner
@@ -115,6 +119,11 @@ COPY --from=deps /app/packages/db/src ./packages/db/src
 COPY --from=deps /app/packages/db/drizzle.config.ts ./packages/db/drizzle.config.ts
 COPY --from=deps /app/packages/db/package.json ./packages/db/package.json
 COPY --from=deps /app/packages/db/tsconfig.json ./packages/db/tsconfig.json
+# Migrations + the node-pg-migrate runner — so the image can apply migrations.
+# Self-hosters (no CI pipeline): `docker run <image> bun packages/db/scripts/migrate.ts up`.
+# Kortix cloud applies them in the deploy pipeline's migrate-db job instead.
+COPY --from=deps /app/packages/db/migrations ./packages/db/migrations
+COPY --from=deps /app/packages/db/scripts/migrate.ts ./packages/db/scripts/migrate.ts
 COPY --from=deps /app/packages/agent-tunnel/src ./packages/agent-tunnel/src
 COPY --from=deps /app/packages/agent-tunnel/package.json ./packages/agent-tunnel/package.json
 COPY --from=deps /app/packages/starter/src ./packages/starter/src
@@ -132,8 +141,9 @@ COPY --from=deps /app/packages/registry/src ./packages/registry/src
 COPY --from=deps /app/packages/registry/package.json ./packages/registry/package.json
 COPY --from=deps /app/packages/registry/tsconfig.json ./packages/registry/tsconfig.json
 
-# Copy SQL migrations used by ensureSchema() at runtime.
-COPY supabase/migrations ./supabase/migrations
+# Migrations are NOT bundled into the image: deployed ensureSchema() is warn-only
+# (it never applies at boot), and migrations run in the deploy pipeline's
+# migrate-db job (pnpm migrate, from the checkout) before the new code serves.
 
 # Copy runtime artifacts used by the layered snapshot builder.
 COPY --from=sandbox-agent /agent/dist/kortix-agent ./apps/kortix-sandbox-agent-server/dist/kortix-agent

--- a/packages/db/MIGRATIONS.md
+++ b/packages/db/MIGRATIONS.md
@@ -90,12 +90,24 @@ Target a specific DB (secrets never go through the shell): the adapter reads `DA
 
 | Env | How | When |
 |---|---|---|
-| **local** | `ensureSchema()` at API boot (only when `KORTIX_LOCAL_DEV=1`/`ENV_MODE=local`), or `pnpm migrate` | every `pnpm dev` |
-| **dev** | CI/CD step against `DEV_DB_URL` | on merge to the dev branch, before new code serves |
+| **local** | `ensureSchema()` at API boot (`KORTIX_LOCAL_DEV=1`/`ENV_MODE=local`), or `pnpm migrate` | every `pnpm dev` |
+| **dev** | CI/CD `migrate-db` job against `DEV_DATABASE_URL` | on merge to the dev branch, before new code serves |
 | **preview** | **never runs migrations** — previews share the dev DB and consume its schema | n/a |
-| **prod** | CI/CD step against `PROD_DB_URL` | every release, after build, before the new version boots |
+| **prod** | CI/CD `migrate-db` job against `PROD_DATABASE_URL` | every release, after build, before the new version boots |
+| **self-host** | one-shot `migrate` from the image (below) | before/with the app |
 
-Deployed app boot **never** applies migrations (only local does). A deployed pod that finds a missing critical table logs a loud `[schema]` warning instead of mutating a shared database.
+By default a deployed app boot **never** applies migrations — concurrent replicas (and preview branches sharing the dev DB) would race a half-applied state. A pod that finds a missing critical table logs a loud `[schema]` warning instead of mutating a shared database.
+
+### Self-hosting (running the published image)
+
+The image bundles the migrations + the node-pg-migrate runner, so you don't need this repo or a CI pipeline. Apply migrations as a **one-shot**, before/with the app (the standard release-phase pattern):
+
+```bash
+docker run --rm -e DATABASE_URL="postgres://…" kortix/kortix-api \
+  bun packages/db/scripts/migrate.ts up
+```
+
+In docker-compose, make this a `migrate` service the `api` service `depends_on`. Prerequisite: your database must already have the Supabase Auth + Basejump objects the schema references.
 
 ### Preview branches share the dev database
 


### PR DESCRIPTION
## ⚠️ Fixes a broken image build on `main`

#3588 (node-pg-migrate) removed `supabase/migrations/`, but `apps/api/Dockerfile` still has `COPY supabase/migrations ./supabase/migrations` — so the API image build now fails on `main`:

```
ERROR: "/supabase/migrations": not found
```

(The Dockerfile fix was on the #3588 branch but landed **after** the squash-merge captured it, so it didn't make it in.)

## What this does
- Replace the dead `COPY supabase/migrations` with **`COPY packages/db/migrations` + the `migrate.ts` runner**, so the image bundles its migrations.
- Add `--filter kortix` to the deps install so **node-pg-migrate** (a root devDep — kept off `@kortix/db` to keep its drizzle-orm resolution single) is present in the image.
- Self-hosters (no CI pipeline) apply migrations as a one-shot:
  ```bash
  docker run --rm -e DATABASE_URL=… kortix/kortix-api  bun packages/db/scripts/migrate.ts up
  ```
- Docs: `MIGRATIONS.md` self-hosting section.

Only `Dockerfile` + `MIGRATIONS.md` change — no source/test surface.

> 🙏 Please **merge with a normal merge commit (not squash)**.

Follow-up (separate PR): optional `KORTIX_AUTO_MIGRATE=1` boot-apply for single-instance self-hosters, with its unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
