### PR TITLE
test(report): include co-located bun suites (~830) + ke2e flows in Allure

### DIFF
--- a/.github/workflows/qa-pr.yml
+++ b/.github/workflows/qa-pr.yml
@@ -39,11 +39,17 @@ jobs:
           node-version: 22
       - name: Install test dependencies
         run: cd tests && bun install --frozen-lockfile
+      - name: Install workspace dependencies
+        run: corepack enable pnpm && pnpm install --frozen-lockfile
       - name: PR cadence
         run: make ci-pr
       - name: Build Allure report from PR results
         if: always()
         run: |
+          # Fold the co-located bun:test unit suites (~830) into the report, not
+          # just the cross-cutting vitest/pact suites. package-tests.yml is the
+          # gate for these; here it's report-only, so failures don't abort.
+          bash tests/scripts/collect-bun-junit.sh || true
           npm --prefix tests run allure:junit
           cd tests
           rm -rf test-results/allure-report

--- a/.github/workflows/qa-release.yml
+++ b/.github/workflows/qa-release.yml
@@ -102,6 +102,8 @@ jobs:
 
       - name: Install test dependencies
         run: cd tests && bun install --frozen-lockfile
+      - name: Install workspace dependencies
+        run: corepack enable pnpm && pnpm install --frozen-lockfile
       - name: Install Playwright Chromium
         run: cd tests && npx playwright install --with-deps chromium
 
@@ -126,7 +128,12 @@ jobs:
       - name: Build report artifacts
         if: always()
         run: |
+          # Co-located bun:test unit suites (~830) into the report.
+          bash tests/scripts/collect-bun-junit.sh || true
+          # vitest/pact/bun JUnit -> allure-results.
           npm --prefix tests run allure:junit
+          # ke2e API flows (283) -> allure-results (native exporter, same dir).
+          npm --prefix tests run allure || true
           cd tests
           rm -rf test-results/allure-report
           npx allure generate test-results/allure-results -o test-results/allure-report || true

--- a/tests/scripts/collect-bun-junit.sh
+++ b/tests/scripts/collect-bun-junit.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Run every co-located bun:test suite with the JUnit reporter, one XML per
+# workspace under tests/test-results/bun/, so the QA Allure report includes the
+# ~830 unit tests — not just the cross-cutting vitest/pact suites.
+#
+# Each suite is run from its own workspace dir so its bunfig.toml (preloads,
+# env scrubbing) applies. Failures don't abort the sweep (we want every suite's
+# results in the report); the script exits non-zero if any suite failed so a
+# caller can still gate on it.
+set -uo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+OUT="$ROOT/tests/test-results/bun"
+mkdir -p "$OUT"
+status=0
+
+# Workspaces under packages/* and apps/* whose `test` script runs `bun test`.
+while IFS= read -r pkg; do
+  dir="$(dirname "$pkg")"
+  test_script="$(node -e "try{process.stdout.write(require('$pkg').scripts?.test||'')}catch(e){}" 2>/dev/null)"
+  case "$test_script" in *"bun test"*) ;; *) continue ;; esac
+  # only run workspaces that actually have a bun test file
+  find "$dir" -path '*/node_modules' -prune -o -name '*.test.ts' -print -quit | grep -q . || continue
+  slug="$(echo "${dir#"$ROOT"/}" | tr '/' '_')"
+  echo "▶ bun test: ${dir#"$ROOT"/}"
+  ( cd "$dir" && bun test --reporter=junit --reporter-outfile="$OUT/${slug}.xml" ) || status=1
+done < <(find "$ROOT/packages" "$ROOT/apps" -maxdepth 2 -name package.json -not -path '*/node_modules/*' 2>/dev/null)
+
+count="$(find "$OUT" -name '*.xml' 2>/dev/null | wc -l | tr -d ' ')"
+echo "collect-bun-junit: wrote ${count} JUnit file(s) -> ${OUT#"$ROOT"/}"
+exit $status

--- a/tests/scripts/junit-to-allure.mjs
+++ b/tests/scripts/junit-to-allure.mjs
@@ -91,8 +91,15 @@ for (const file of files) {
     const start = Math.max(0, Math.round(stop - durationMs));
     const id = stableId(category, className, name);
     const details = statusDetails(body);
+    const uuid = randomUUID();
+    const attachments = [];
+    if (details?.trace) {
+      const source = `${uuid}-failure.txt`;
+      writeFileSync(join(outDir, source), `${details.trace}\n`);
+      attachments.push({ name: 'Failure output', source, type: 'text/plain' });
+    }
     const result = {
-      uuid: randomUUID(),
+      uuid,
       historyId: id,
       testCaseId: id,
       name,
@@ -106,11 +113,40 @@ for (const file of files) {
         { name: 'suite', value: category },
         { name: 'package', value: className },
       ],
+      ...(attachments.length ? { attachments } : {}),
       ...(details ? { statusDetails: details } : {}),
     };
-    writeFileSync(join(outDir, `${result.uuid}-result.json`), `${JSON.stringify(result, null, 2)}\n`);
+    writeFileSync(join(outDir, `${uuid}-result.json`), `${JSON.stringify(result, null, 2)}\n`);
     written += 1;
   }
 }
+
+// Environments tab: surface the run context (commit, branch, target, runner).
+const env = process.env;
+const envLines = Object.entries({
+  Commit: (env.GITHUB_SHA ?? '').slice(0, 12),
+  Branch: env.GITHUB_REF_NAME ?? '',
+  Repository: env.GITHUB_REPOSITORY ?? '',
+  Run: env.GITHUB_RUN_ID ? `${env.GITHUB_REPOSITORY ?? ''}#${env.GITHUB_RUN_ID}` : '',
+  Target: env.QA_WEB_BASE_URL || env.KE2E_API_URL || 'local (no live target)',
+  Node: process.version,
+}).filter(([, v]) => v);
+if (envLines.length) {
+  writeFileSync(join(outDir, 'environment.properties'), `${envLines.map(([k, v]) => `${k}=${v}`).join('\n')}\n`);
+}
+
+// Defect categories: split real product failures from broken/skipped.
+writeFileSync(
+  join(outDir, 'categories.json'),
+  `${JSON.stringify(
+    [
+      { name: 'Product defects', matchedStatuses: ['failed'] },
+      { name: 'Broken tests', matchedStatuses: ['broken'] },
+      { name: 'Skipped', matchedStatuses: ['skipped'] },
+    ],
+    null,
+    2,
+  )}\n`,
+);
 
 console.log(`junit-to-allure: wrote ${written} result(s) from ${files.length} JUnit file(s) -> ${outDir}`);

--- a/tests/scripts/junit-to-allure.mjs
+++ b/tests/scripts/junit-to-allure.mjs
@@ -80,8 +80,8 @@ for (const file of files) {
   const category = categoryFromPath(file);
   const mtime = statSync(file).mtimeMs;
 
-  for (const match of xml.matchAll(/<testcase\b([^>]*)>([\s\S]*?)<\/testcase>|<testcase\b([^/>]*)\/>/g)) {
-    const testAttrs = attrs(match[1] ?? match[3] ?? '');
+  for (const match of xml.matchAll(/<testcase\b([^>]*?)(?:\/>|>([\s\S]*?)<\/testcase>)/g)) {
+    const testAttrs = attrs(match[1] ?? '');
     const body = match[2] ?? '';
     const name = testAttrs.name || 'unnamed test';
     const className = testAttrs.classname || category;


### PR DESCRIPTION
The QA report only showed the cross-cutting vitest/pact suites (11 tests). Two gaps fixed:

1. **`junit-to-allure` dropped bun's self-closing `<testcase .../>` tags** — the regex excluded `/`, which broke on file-path attributes (`file="src/..."`). Consolidated to one regex handling both self-closing and body forms, so the ~830 co-located bun unit tests convert.
2. **Nothing collected them** — added `collect-bun-junit.sh` (runs each workspace's bun suite with `--reporter=junit`) and wired it + workspace install into `qa-pr` (report-only; `package-tests` stays the gate). PR report **11 → ~835**.

Also folds ke2e's native Allure export (283 flows) + the bun suites into the `qa-release` funded report.