### PR TITLE
feat(qa-portal): publish release/nightly + landing page

### DIFF
--- a/.github/workflows/qa-nightly.yml
+++ b/.github/workflows/qa-nightly.yml
@@ -214,3 +214,58 @@ jobs:
           name: qa-nightly-chaos
           path: tests/test-results/chaos/**
           retention-days: 30
+
+  publish-report:
+    name: publish nightly report
+    needs: [static-security, performance, dast, pentest, mutation, chaos]
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      QA_REPORTS_ROLE_ARN: ${{ secrets.QA_REPORTS_ROLE_ARN }}
+      QA_REPORTS_BUCKET: ${{ vars.QA_REPORTS_BUCKET }}
+      QA_REPORTS_PREFIX: ${{ vars.QA_REPORTS_PREFIX || 'reports' }}
+      QA_REPORTS_PUBLIC_BASE_URL: ${{ vars.QA_REPORTS_PUBLIC_BASE_URL }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Install test dependencies
+        run: cd tests && bun install --frozen-lockfile
+      - name: Download lane results
+        uses: actions/download-artifact@v4
+        with:
+          pattern: qa-nightly-*
+          path: tests/test-results
+      - name: Build Allure report
+        run: |
+          npm --prefix tests run allure:junit
+          cd tests
+          rm -rf test-results/allure-report
+          npx allure generate test-results/allure-results -o test-results/allure-report || true
+      - name: AWS auth for report publish
+        if: env.QA_REPORTS_ROLE_ARN != '' && env.QA_REPORTS_BUCKET != '' && env.QA_REPORTS_PUBLIC_BASE_URL != ''
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.QA_REPORTS_ROLE_ARN }}
+          aws-region: ${{ vars.QA_AWS_REGION }}
+      - name: Publish nightly Allure report
+        if: env.QA_REPORTS_ROLE_ARN != '' && env.QA_REPORTS_BUCKET != '' && env.QA_REPORTS_PUBLIC_BASE_URL != ''
+        run: |
+          set -euo pipefail
+          run_key="nightly/${{ github.run_id }}"
+          aws s3 sync tests/test-results/allure-report \
+            "s3://${QA_REPORTS_BUCKET}/${QA_REPORTS_PREFIX}/${run_key}/" \
+            --delete --only-show-errors
+          url="${QA_REPORTS_PUBLIC_BASE_URL%/}/${QA_REPORTS_PREFIX}/${run_key}/index.html"
+          {
+            echo "### Nightly Allure report"
+            echo ""
+            echo "Report: $url"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/qa-release.yml
+++ b/.github/workflows/qa-release.yml
@@ -33,11 +33,17 @@ concurrency:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   full-suite:
     name: full suite + quality gates
     runs-on: ubuntu-latest
+    env:
+      QA_REPORTS_ROLE_ARN: ${{ secrets.QA_REPORTS_ROLE_ARN }}
+      QA_REPORTS_BUCKET: ${{ vars.QA_REPORTS_BUCKET }}
+      QA_REPORTS_PREFIX: ${{ vars.QA_REPORTS_PREFIX || 'reports' }}
+      QA_REPORTS_PUBLIC_BASE_URL: ${{ vars.QA_REPORTS_PUBLIC_BASE_URL }}
     timeout-minutes: 180
     env:
       API_BASE_URL_INPUT: ${{ inputs.api_base_url || vars.QA_API_BASE_URL || vars.QA_TARGET_URL }}
@@ -138,6 +144,26 @@ jobs:
           rm -rf test-results/allure-report
           npx allure generate test-results/allure-results -o test-results/allure-report || true
           npm run catalog || true
+      - name: AWS auth for report publish
+        if: always() && env.QA_REPORTS_ROLE_ARN != '' && env.QA_REPORTS_BUCKET != '' && env.QA_REPORTS_PUBLIC_BASE_URL != ''
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.QA_REPORTS_ROLE_ARN }}
+          aws-region: ${{ vars.QA_AWS_REGION }}
+      - name: Publish release Allure report
+        if: always() && env.QA_REPORTS_ROLE_ARN != '' && env.QA_REPORTS_BUCKET != '' && env.QA_REPORTS_PUBLIC_BASE_URL != ''
+        run: |
+          set -euo pipefail
+          run_key="release/${{ github.run_id }}"
+          aws s3 sync tests/test-results/allure-report \
+            "s3://${QA_REPORTS_BUCKET}/${QA_REPORTS_PREFIX}/${run_key}/" \
+            --delete --only-show-errors
+          url="${QA_REPORTS_PUBLIC_BASE_URL%/}/${QA_REPORTS_PREFIX}/${run_key}/index.html"
+          {
+            echo "### Full-suite Allure report"
+            echo ""
+            echo "Report: $url"
+          } >> "$GITHUB_STEP_SUMMARY"
       - uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/infra/k8s/charts/qa-portal/templates/deployment.yaml
+++ b/infra/k8s/charts/qa-portal/templates/deployment.yaml
@@ -39,6 +39,9 @@ spec:
         - name: landing
           configMap:
             name: {{ include "qa-portal.name" . }}-landing
+        - name: nginx-conf
+          configMap:
+            name: {{ include "qa-portal.name" . }}-nginx
       initContainers:
         # Prime the volume before nginx serves — readiness then gates the ALB on
         # the report (or a placeholder) being present.
@@ -82,6 +85,10 @@ spec:
           volumeMounts:
             - name: html
               mountPath: /usr/share/nginx/html
+              readOnly: true
+            - name: nginx-conf
+              mountPath: /etc/nginx/conf.d/default.conf
+              subPath: default.conf
               readOnly: true
           readinessProbe:
             httpGet:

--- a/infra/k8s/charts/qa-portal/templates/deployment.yaml
+++ b/infra/k8s/charts/qa-portal/templates/deployment.yaml
@@ -36,6 +36,9 @@ spec:
         - name: html
           emptyDir:
             sizeLimit: {{ .Values.htmlVolumeSizeLimit }}
+        - name: landing
+          configMap:
+            name: {{ include "qa-portal.name" . }}-landing
       initContainers:
         # Prime the volume before nginx serves — readiness then gates the ALB on
         # the report (or a placeholder) being present.
@@ -49,20 +52,23 @@ spec:
               # Sync the whole reports/ tree so per-PR reports (reports/pr/<n>/<run>/)
               # and history are served too, not just latest/.
               aws s3 sync "s3://{{ .Values.bucket }}/{{ .Values.s3Prefix }}/" "/html/{{ .Values.s3Prefix }}" --delete --region {{ .Values.region }}
-              # Root redirects to the latest report; the qa-pr comment links deep to
-              # /{{ .Values.s3Prefix }}/pr/<n>/<run>/index.html.
-              printf '<!doctype html><meta http-equiv="refresh" content="0; url=/{{ .Values.s3Prefix }}/latest/">\n' > /html/index.html
               # First-run safety: placeholder so nginx is healthy before any publish.
               if [ -z "$(ls -A "/html/{{ .Values.s3Prefix }}/latest" 2>/dev/null)" ]; then
                 mkdir -p "/html/{{ .Values.s3Prefix }}/latest"
                 echo "<h1>QA report portal</h1><p>No report has been published yet.</p>" > "/html/{{ .Values.s3Prefix }}/latest/index.html"
               fi
+              # Build the landing page (/) listing every lane's reports. The qa-pr
+              # comment still links deep to /{{ .Values.s3Prefix }}/pr/<n>/<run>/.
+              sh /scripts/gen-index.sh /html
           env:
             - name: AWS_REGION
               value: {{ .Values.region | quote }}
           volumeMounts:
             - name: html
               mountPath: /html
+            - name: landing
+              mountPath: /scripts
+              readOnly: true
           resources:
             {{- toYaml .Values.resources.sync | nindent 12 }}
       containers:
@@ -103,6 +109,7 @@ spec:
               while true; do
                 sleep {{ .Values.syncIntervalSeconds }}
                 aws s3 sync "s3://{{ .Values.bucket }}/{{ .Values.s3Prefix }}/" "/html/{{ .Values.s3Prefix }}" --delete --region {{ .Values.region }} || true
+                sh /scripts/gen-index.sh /html || true
               done
           env:
             - name: AWS_REGION
@@ -110,5 +117,8 @@ spec:
           volumeMounts:
             - name: html
               mountPath: /html
+            - name: landing
+              mountPath: /scripts
+              readOnly: true
           resources:
             {{- toYaml .Values.resources.sync | nindent 12 }}

--- a/infra/k8s/charts/qa-portal/templates/landing-configmap.yaml
+++ b/infra/k8s/charts/qa-portal/templates/landing-configmap.yaml
@@ -1,0 +1,100 @@
+{{/*
+Landing-page generator. The portal's init + sidecar run this after each S3 sync
+to (re)build <root>/index.html by scanning the synced reports/ tree, so the root
+of qa.kortix.com lists every lane's reports instead of redirecting to latest.
+Kept here (not baked into the aws-cli image) so the chart stays self-contained.
+*/}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "qa-portal.name" . }}-landing
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "qa-portal.labels" . | nindent 4 }}
+data:
+  gen-index.sh: |
+    #!/bin/sh
+    # Build <root>/index.html from the synced reports/ tree. POSIX sh only.
+    set -u
+    ROOT="${1:-/usr/share/nginx/html}"
+    REPORTS="$ROOT/reports"
+    OUT="$ROOT/index.html"
+    TMP="$OUT.tmp.$$"
+
+    # cards <dir-of-run-subdirs> <url-base> <label> — newest run id first
+    cards() {
+      d="$1"; ubase="$2"; label="$3"
+      [ -d "$d" ] || return 0
+      for run in $(ls -1 "$d" 2>/dev/null | sort -rn | head -12); do
+        [ -f "$d/$run/index.html" ] || continue
+        printf '<a class="card" href="%s/%s/index.html"><span class="t">%s</span><span class="r">%s</span><span class="go">Open &rarr;</span></a>' "$ubase" "$run" "$label" "$run"
+      done
+    }
+
+    {
+      cat <<'HEAD'
+    <!doctype html>
+    <html lang="en"><head><meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width,initial-scale=1"/>
+    <title>Kortix QA Reports</title>
+    <style>
+      :root{--bg:#1b1a26;--panel:#23222f;--panel2:#2a2937;--line:#36344a;--line2:#454262;--text:#ecebf5;--muted:#9b99b6;--accent:#4ac78a}
+      *{box-sizing:border-box}
+      body{margin:0;background:var(--bg);color:var(--text);font:15px/1.55 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif}
+      .wrap{max-width:1000px;margin:0 auto;padding:48px 24px 96px}
+      header{display:flex;align-items:center;gap:14px;margin-bottom:6px}
+      .logo{width:38px;height:38px;border-radius:9px;background:var(--panel2);border:1px solid var(--line2);display:flex;align-items:center;justify-content:center;color:var(--accent);font-weight:700}
+      h1{font-size:22px;margin:0;letter-spacing:.2px}
+      .sub{color:var(--muted);margin:2px 0 0;font-size:13px}
+      section{margin-top:34px}
+      h2{font-size:13px;text-transform:uppercase;letter-spacing:.10em;color:var(--muted);margin:0 0 14px;font-weight:600}
+      .grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(260px,1fr));gap:12px}
+      .card{display:flex;flex-direction:column;gap:4px;padding:16px 18px;background:var(--panel);border:1px solid var(--line);border-radius:12px;text-decoration:none;color:var(--text)}
+      .card:hover{border-color:var(--accent);background:var(--panel2)}
+      .card .t{font-size:13px;color:var(--muted)}
+      .card .r{font-size:15px;font-weight:600;font-variant-numeric:tabular-nums;word-break:break-all}
+      .card .go{margin-top:6px;font-size:12px;color:var(--accent)}
+      .card.primary{border-color:var(--accent)}
+      .empty{color:var(--muted);font-size:13px;border:1px dashed var(--line2);border-radius:12px;padding:16px 18px}
+      footer{margin-top:48px;color:var(--muted);font-size:12px;border-top:1px solid var(--line);padding-top:16px}
+    </style></head><body><div class="wrap">
+    <header><div class="logo">Q</div><div><h1>Kortix QA Reports</h1><p class="sub">Allure reports across every test lane &middot; refreshes automatically</p></div></header>
+    HEAD
+
+      # Latest (main)
+      printf '<section><h2>Latest &middot; main</h2><div class="grid">'
+      if [ -f "$REPORTS/latest/index.html" ]; then
+        printf '<a class="card primary" href="/reports/latest/index.html"><span class="t">main</span><span class="r">latest</span><span class="go">Open &rarr;</span></a>'
+      else
+        printf '<div class="empty">No latest report yet.</div>'
+      fi
+      printf '</div></section>'
+
+      # Release (full suite incl. ke2e)
+      printf '<section><h2>Release &middot; full suite</h2><div class="grid">'
+      out=$(cards "$REPORTS/release" "/reports/release" "release run")
+      [ -n "$out" ] && printf '%s' "$out" || printf '<div class="empty">No release reports yet.</div>'
+      printf '</div></section>'
+
+      # Nightly
+      printf '<section><h2>Nightly &middot; security / perf / chaos</h2><div class="grid">'
+      out=$(cards "$REPORTS/nightly" "/reports/nightly" "nightly run")
+      [ -n "$out" ] && printf '%s' "$out" || printf '<div class="empty">No nightly reports yet.</div>'
+      printf '</div></section>'
+
+      # Pull requests (newest run per PR)
+      printf '<section><h2>Pull requests &middot; fast checks</h2><div class="grid">'
+      any=""
+      if [ -d "$REPORTS/pr" ]; then
+        for pr in $(ls -1 "$REPORTS/pr" 2>/dev/null | sort -rn | head -12); do
+          run=$(ls -1 "$REPORTS/pr/$pr" 2>/dev/null | sort -rn | head -1)
+          [ -n "$run" ] && [ -f "$REPORTS/pr/$pr/$run/index.html" ] || continue
+          printf '<a class="card" href="/reports/pr/%s/%s/index.html"><span class="t">pull request</span><span class="r">#%s</span><span class="go">run %s &rarr;</span></a>' "$pr" "$run" "$pr" "$run"
+          any="y"
+        done
+      fi
+      [ -n "$any" ] || printf '<div class="empty">No PR reports yet.</div>'
+      printf '</div></section>'
+
+      printf '<footer>Served by the QA portal &middot; behind Cloudflare Access</footer></div></body></html>'
+    } > "$TMP" && mv "$TMP" "$OUT"

--- a/infra/k8s/charts/qa-portal/templates/nginx-configmap.yaml
+++ b/infra/k8s/charts/qa-portal/templates/nginx-configmap.yaml
@@ -1,0 +1,27 @@
+{{/*
+nginx server config. Forces revalidation (Cache-Control: no-cache) so browsers
+always check with the server before reusing the landing page or a report — a
+stale meta-redirect or an out-of-date report can never get pinned in cache. The
+report assets are small and revalidation is a cheap 304.
+*/}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "qa-portal.name" . }}-nginx
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "qa-portal.labels" . | nindent 4 }}
+data:
+  default.conf: |
+    server {
+        listen       {{ .Values.containerPort }};
+        server_name  _;
+        root         /usr/share/nginx/html;
+        index        index.html;
+
+        add_header Cache-Control "no-cache" always;
+
+        location / {
+            try_files $uri $uri/ =404;
+        }
+    }


### PR DESCRIPTION
Follow-on to the merged #3594 (these 3 commits were pushed just after it merged — moving them to their own PR).

- **Publish release + nightly reports** to the portal: qa-release -> `reports/release/<run>/` (full suite incl. 283 ke2e flows), and a new qa-nightly aggregator job -> `reports/nightly/<run>/`.
- **Landing page at `/`** listing latest / release / nightly / recent PRs (dark, Allure-style, solid panels). Generated by a ConfigMap script the portal runs after each S3 sync.
- **no-cache HTML** so the landing page can't be pinned as a stale redirect.

All already applied live (helm rev 5); this commits the chart + workflow changes.