### PR TITLE
feat(db): block out-of-sequence / duplicate / malformed migrations in CI

### DIFF
--- a/.github/workflows/db-migrations.yml
+++ b/.github/workflows/db-migrations.yml
@@ -58,6 +58,37 @@ jobs:
           fi
           echo "OK — no existing migration files were modified."
 
+  sequence:
+    name: Migrations are sequential
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: New migrations must come after every merged migration
+        run: |
+          set -euo pipefail
+          BASE='${{ github.event.pull_request.base.sha }}'
+          # Highest 17-digit timestamp already merged (depth-1; _archive is 14-digit, excluded).
+          BASE_MAX=$(git ls-tree -r --name-only "$BASE" -- packages/db/migrations \
+            | sed -n 's#.*/\([0-9]\{17\}\)_.*\.sql$#\1#p' | sort -n | tail -1 || true)
+          # Migrations ADDED by this PR.
+          ADDED=$(git diff --diff-filter=A --name-only "$BASE...HEAD" -- 'packages/db/migrations/*.sql' || true)
+          bad=0
+          for f in $ADDED; do
+            ts=$(basename "$f" | sed -n 's#^\([0-9]\{17\}\)_.*#\1#p')
+            if [ -z "$ts" ]; then
+              echo "::error file=$f::Migration filename has no 17-digit UTC timestamp prefix (old format / hand-written). Use \`pnpm migrate:create\` or \`pnpm migrate:generate\`."
+              bad=1; continue
+            fi
+            if [ -n "${BASE_MAX:-}" ] && [ "$ts" -le "$BASE_MAX" ]; then
+              echo "::error file=$f::Out-of-sequence migration: timestamp $ts is not after the latest merged migration ($BASE_MAX). Regenerate it with a current timestamp so it sorts last."
+              bad=1
+            fi
+          done
+          if [ "$bad" -ne 0 ]; then exit 1; fi
+          echo "OK — every new migration's timestamp comes after the latest merged one."
+
   shadow-db:
     name: Applies cleanly to a fresh DB
     runs-on: ubuntu-latest

--- a/packages/db/scripts/lint-migrations.test.ts
+++ b/packages/db/scripts/lint-migrations.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { lintMigration } from './lint-migrations';
+import { lintMigration, lintMigrationSet } from './lint-migrations';
 
 const GOOD_NAME = '20260101000000000_add_widget.sql';
 
@@ -54,5 +54,25 @@ describe('lintMigration', () => {
   test('does not warn on DELETE that has a WHERE clause', () => {
     const { warnings } = lintMigration(GOOD_NAME, "DELETE FROM kortix.widgets WHERE id = '1';");
     expect(warnings).toEqual([]);
+  });
+});
+
+describe('lintMigrationSet', () => {
+  test('unique timestamps produce no errors', () => {
+    const errors = lintMigrationSet([
+      '20260101000000000_a.sql',
+      '20260101000000001_b.sql',
+      '20260101000000002_c.sql',
+    ]);
+    expect(errors).toEqual([]);
+  });
+
+  test('rejects two migrations sharing a timestamp', () => {
+    const errors = lintMigrationSet(['20260101000000000_a.sql', '20260101000000000_b.sql']);
+    expect(errors.some((e) => e.includes('duplicate migration timestamp'))).toBe(true);
+  });
+
+  test('ignores files without a 17-digit prefix (the per-file lint flags those)', () => {
+    expect(lintMigrationSet(['not_a_migration.sql'])).toEqual([]);
   });
 });

--- a/packages/db/scripts/lint-migrations.ts
+++ b/packages/db/scripts/lint-migrations.ts
@@ -4,11 +4,34 @@ import { join } from 'node:path';
 
 const DIR = join(import.meta.dir, '..', 'migrations');
 const NAME_RE = /^\d{17}_[A-Za-z0-9][A-Za-z0-9_-]*\.sql$/;
+const TS_RE = /^(\d{17})_/;
 const DOWN_MARKER = /^\s*--[\s-]*down\s+migration/im;
 
 export interface LintResult {
   errors: string[];
   warnings: string[];
+}
+
+// Set-level invariant: every migration's 17-digit timestamp must be unique.
+// (Ordering within a checkout is the sorted filename order; "a new migration
+// must come AFTER every merged one" is enforced by the git-aware sequence gate
+// in db-migrations.yml, which a single checkout can't see.)
+export function lintMigrationSet(filenames: string[]): string[] {
+  const errors: string[] = [];
+  const seen = new Map<string, string>();
+  for (const f of filenames) {
+    const ts = TS_RE.exec(f)?.[1];
+    if (!ts) continue;
+    const dup = seen.get(ts);
+    if (dup) {
+      errors.push(
+        `${f}: duplicate migration timestamp ${ts} (also ${dup}). Each migration needs a unique timestamp — regenerate with \`pnpm migrate:create\`.`,
+      );
+    } else {
+      seen.set(ts, f);
+    }
+  }
+  return errors;
 }
 
 function stripComments(text: string): string {
@@ -78,6 +101,7 @@ function main(): void {
     errors.push(...e);
     warnings.push(...w);
   }
+  errors.push(...lintMigrationSet(files));
 
   for (const w of warnings) console.log(`::warning::${w}`);
   for (const e of errors) console.error(`::error::${e}`);


### PR DESCRIPTION
Makes a malformed, old-format, duplicate-timestamp, or out-of-sequence migration **fail CI and block merge**.

## New / strengthened gates (`.github/workflows/db-migrations.yml`)
- **lint** (`Migration files are well-formed`) — already rejects bad filenames (old 14-digit / hand-written / non-`<17-digit>_<slug>.sql`), merge-conflict markers, empty/placeholder/TODO files. **Now also rejects duplicate timestamps** (`lintMigrationSet`).
- **immutability** — already-merged migrations can't be edited.
- **sequence** (NEW) — a migration **added** by the PR must carry a timestamp **later than every already-merged migration**, or the job fails. This blocks hand-written / out-of-order timestamps that would otherwise sort *before* applied migrations.
- **shadow-db** — every migration still applies cleanly from scratch on a fresh Postgres.
- **schema-sync** — `kortix.ts` matches the committed SQL.

Each is a fast, independent job, so a bad file fails immediately.

Unit tests added for `lintMigrationSet` (dup detection). Only `packages/db/scripts/*` + the workflow change — no `src` surface.

## Action for a maintainer
Add **`Migrations are sequential`** (and confirm `Migration files are well-formed` / `Migrations are immutable`) to the branch's **required status checks** so a red gate actually blocks the merge button.

> 🙏 Please merge with a normal merge commit (not squash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
