### PR TITLE
fix(qa-main): install pnpm for the migration job

### DIFF
--- a/.github/workflows/qa-main.yml
+++ b/.github/workflows/qa-main.yml
@@ -61,6 +61,11 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Install workspace dependencies
+        run: corepack enable pnpm && pnpm install --frozen-lockfile
       - name: Run migration tests
         run: make migration
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
qa-main's `db migration tests` job failed with **`pnpm: command not found`** — `migrate-up.sh` runs `pnpm --filter @kortix/db migrate` but the job only did `checkout` (no node/pnpm/workspace deps). Add setup-node + corepack pnpm + `pnpm install`, matching qa-pr/qa-release.

Run: https://github.com/kortix-ai/suna/actions/runs/27904909771