### PR TITLE
test(e2e): accept OAuth/SSO on the sign-in reachability check

### DIFF
--- a/tests/e2e/examples/landing-or-login.spec.ts
+++ b/tests/e2e/examples/landing-or-login.spec.ts
@@ -25,12 +25,14 @@ test.describe('Example — landing or login flow', () => {
     await expect(signIn).toBeVisible();
     await signIn.click();
 
-    const emailField = page
+    const authAffordance = page
       .getByRole('textbox', { name: /email/i })
-      .or(page.locator('input[type="email"], input[name="email"]'))
+      .or(page.locator('input[type="email"], input[name="email"], input[type="password"]'))
+      .or(page.getByRole('button', { name: /continue with|sign in with|log ?in with|google|github|sso|continue/i }))
+      .or(page.getByRole('link', { name: /continue with|sign in with|google|github|sso/i }))
       .first();
 
-    await expect(emailField).toBeVisible();
+    await expect(authAffordance).toBeVisible();
   });
 
   test('login form rejects an empty submission', async ({ page }) => {


### PR DESCRIPTION
qa-main's `e2e` job was perma-red: the example `landing-or-login.spec.ts` clicked sign-in then required an **email textbox**, but Kortix's auth is OAuth-first (no email/password form there). Broaden the assertion to the test's real intent — *a sign-in affordance is reachable* — accepting an email/password field **or** an OAuth/SSO/continue control. Still fails on a blank/broken screen.

Pairs with #3598 (migration job) to get qa-main green.