### PR TITLE
fix(qa-main): install bun for the migration job

### DIFF
--- a/.github/workflows/qa-main.yml
+++ b/.github/workflows/qa-main.yml
@@ -64,6 +64,9 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
       - name: Install workspace dependencies
         run: corepack enable pnpm && pnpm install --frozen-lockfile
       - name: Run migration tests


### PR DESCRIPTION
Follow-up to #3598. With pnpm now present, the migration runs `pnpm --filter @kortix/db migrate` -> `bun scripts/migrate.ts up`, which failed with `sh: 1: bun: not found`. Add `oven-sh/setup-bun` to the migration job.