### PR TITLE
ci(qa-main): make visual regression advisory

### DIFF
--- a/.github/workflows/qa-main.yml
+++ b/.github/workflows/qa-main.yml
@@ -47,7 +47,11 @@ jobs:
             echo "::notice::QA_WEB_BASE_URL/E2E_BASE_URL is not set; skipping browser regression."
             exit 0
           fi
-          make e2e visual a11y
+          make e2e a11y
+          # Visual is advisory: it snapshots the live target (no deterministic
+          # per-platform baselines), so a pixel diff shouldn't red-gate qa-main.
+          # It still runs and its results land in the report.
+          make visual || echo "::warning::Visual regression failed (advisory — live target). See the QA report for diffs."
       - uses: actions/upload-artifact@v4
         if: always()
         with:


### PR DESCRIPTION
Visual regression red-gated qa-main: it snapshots **live dev.kortix.com** but only `-darwin` baselines exist (no `-linux` for CI), and a live marketing site won't pixel-stabilize. Keep **e2e + a11y gating**; run **visual** but don't fail the job on it — diffs still land in the QA report.

Pairs with #3600 (migration bun) to get qa-main green. True visual gating against a deterministic build is a follow-up.