### PR TITLE
fix(qa-release): repair duplicate env + make visual advisory

### DIFF
--- a/.github/workflows/qa-release.yml
+++ b/.github/workflows/qa-release.yml
@@ -116,9 +116,11 @@ jobs:
         run: make lint typecheck unit integration contract api-coverage
 
       - name: Live API checks
+        timeout-minutes: 45
         run: make smoke api
 
       - name: Browser regression
+        timeout-minutes: 30
         run: |
           make e2e a11y
           # Visual is advisory: it snapshots the live target with no deterministic
@@ -127,9 +129,11 @@ jobs:
           make visual || echo "::warning::Visual regression failed (advisory — live target). See the QA report for diffs."
 
       - name: Migration, infra, security, pentest, and mutation
+        timeout-minutes: 60
         run: make migration infra security pentest mutation
 
       - name: Performance and DAST
+        timeout-minutes: 30
         run: make performance security-dast
 
       - name: Quality gates

--- a/.github/workflows/qa-release.yml
+++ b/.github/workflows/qa-release.yml
@@ -39,13 +39,12 @@ jobs:
   full-suite:
     name: full suite + quality gates
     runs-on: ubuntu-latest
+    timeout-minutes: 180
     env:
       QA_REPORTS_ROLE_ARN: ${{ secrets.QA_REPORTS_ROLE_ARN }}
       QA_REPORTS_BUCKET: ${{ vars.QA_REPORTS_BUCKET }}
       QA_REPORTS_PREFIX: ${{ vars.QA_REPORTS_PREFIX || 'reports' }}
       QA_REPORTS_PUBLIC_BASE_URL: ${{ vars.QA_REPORTS_PUBLIC_BASE_URL }}
-    timeout-minutes: 180
-    env:
       API_BASE_URL_INPUT: ${{ inputs.api_base_url || vars.QA_API_BASE_URL || vars.QA_TARGET_URL }}
       WEB_BASE_URL_INPUT: ${{ inputs.web_base_url || vars.QA_WEB_BASE_URL || vars.E2E_BASE_URL }}
       DAST_TARGET_URL_INPUT: ${{ inputs.dast_target_url || vars.QA_DAST_TARGET_URL }}

--- a/.github/workflows/qa-release.yml
+++ b/.github/workflows/qa-release.yml
@@ -120,7 +120,12 @@ jobs:
         run: make smoke api
 
       - name: Browser regression
-        run: make e2e visual a11y
+        run: |
+          make e2e a11y
+          # Visual is advisory: it snapshots the live target with no deterministic
+          # per-platform baselines, so a pixel diff shouldn't red-gate the release.
+          # It still runs and its results land in the report.
+          make visual || echo "::warning::Visual regression failed (advisory — live target). See the QA report for diffs."
 
       - name: Migration, infra, security, pentest, and mutation
         run: make migration infra security pentest mutation


### PR DESCRIPTION
Same fix as qa-main (#3601): visual snapshots the live target with no `-linux` baselines, so it would red-gate the release. Keep e2e + a11y gating; run visual but don't fail on it — diffs still land in the QA report.