### PR TITLE
fix(ke2e): time-bound Supabase auth so setup can't hang silently

### DIFF
--- a/tests/src/fixtures/supabase.ts
+++ b/tests/src/fixtures/supabase.ts
@@ -3,12 +3,31 @@
  * create/confirm synthetic users and exchange password for a real JWT. Everything
  * else (accounts, members, policies, tokens) is provisioned through the Kortix API
  * so fixtures stay honest.
+ *
+ * Every call is time-bounded: a raw fetch with no timeout against an unreachable
+ * or misconfigured KE2E_SUPABASE_URL hangs the whole run silently at world setup
+ * (before any flow logs), so a hang must surface as a fast, clear failure instead.
  */
 import type { Env } from "../core/env";
 
+const SUPABASE_TIMEOUT_MS = Number(process.env.KE2E_SUPABASE_TIMEOUT_MS ?? 15_000);
+
+async function supaFetch(url: string, init: RequestInit): Promise<Response> {
+  try {
+    return await fetch(url, { ...init, signal: AbortSignal.timeout(SUPABASE_TIMEOUT_MS) });
+  } catch (err) {
+    if (err instanceof DOMException && err.name === "TimeoutError") {
+      throw new Error(
+        `Supabase request timed out after ${SUPABASE_TIMEOUT_MS}ms: ${url} — is KE2E_SUPABASE_URL reachable from CI?`,
+      );
+    }
+    throw new Error(`Supabase request failed: ${url} — ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
 export async function passwordGrant(env: Env, email: string, password: string): Promise<string> {
   if (!env.supabaseAnonKey) throw new Error("KE2E_SUPABASE_ANON_KEY required for password grant");
-  const res = await fetch(`${env.supabaseUrl}/auth/v1/token?grant_type=password`, {
+  const res = await supaFetch(`${env.supabaseUrl}/auth/v1/token?grant_type=password`, {
     method: "POST",
     headers: { apikey: env.supabaseAnonKey, "content-type": "application/json" },
     body: JSON.stringify({ email, password }),
@@ -27,7 +46,7 @@ export async function adminCreateUser(env: Env, email: string, password: string)
   if (!env.supabaseServiceRoleKey || !env.supabaseAnonKey) {
     throw new Error("Supabase service-role + anon keys required to create test users");
   }
-  const res = await fetch(`${env.supabaseUrl}/auth/v1/admin/users`, {
+  const res = await supaFetch(`${env.supabaseUrl}/auth/v1/admin/users`, {
     method: "POST",
     headers: {
       apikey: env.supabaseAnonKey,
@@ -43,7 +62,7 @@ export async function adminCreateUser(env: Env, email: string, password: string)
 
 export async function adminDeleteUser(env: Env, userId: string): Promise<void> {
   if (!env.supabaseServiceRoleKey || !env.supabaseAnonKey) return;
-  const res = await fetch(`${env.supabaseUrl}/auth/v1/admin/users/${userId}`, {
+  const res = await supaFetch(`${env.supabaseUrl}/auth/v1/admin/users/${userId}`, {
     method: "DELETE",
     headers: {
       apikey: env.supabaseAnonKey,


### PR DESCRIPTION
**Root cause of the qa-release hang.** ke2e's world setup (`provisionMatrix`) creates synthetic users via Supabase *before any flow runs*. Its three helpers (`passwordGrant`, `adminCreateUser`, `adminDeleteUser`) used raw `fetch` with **no timeout** — so an unreachable/misconfigured `KE2E_SUPABASE_URL` hangs the whole run silently (zero output → 180-min job timeout). That's exactly what we saw on the release dry-run.

Wrap all three in a 15s `AbortSignal.timeout` (`KE2E_SUPABASE_TIMEOUT_MS` override) that throws a clear error. It propagates to ke2e's top-level `process.exit(2)`, so the lane **fails fast and red with a diagnostic**, never hangs and never silently skips (verified: `world.ts:69` awaits provisioning with no catch; `ke2e.ts` main().catch → exit 2).