### PR TITLE
fix(ke2e): fund the OWNER at provision time (clears ~64 release failures)

### DIFF
--- a/tests/src/fixtures/principals.ts
+++ b/tests/src/fixtures/principals.ts
@@ -12,7 +12,9 @@
  */
 import { Client } from "../core/client";
 import type { Env } from "../core/env";
+import { log } from "../core/log";
 import type { Principal, Principals } from "../core/types";
+import { subscribe } from "./billing";
 import { adminCreateUser, passwordGrant, type AdminUser } from "./supabase";
 
 export interface Provisioned {
@@ -53,6 +55,22 @@ export async function provisionMatrix(env: Env, runId: string): Promise<Provisio
   const ownerClient = new Client(env.apiUrl).as(owner.principal);
   const tok = await ownerClient.post("/v1/accounts/tokens", { name: `e2e-${runId}-owner-bootstrap` });
   const patAcctSecret = tok.json<any>()?.secret_key as string | undefined;
+
+  // Fund the OWNER's personal account so flows aren't blocked by the free-tier
+  // 1-project / 402 limits — real Stripe test-mode subscribe → paid tier + credits.
+  // Non-fatal: a funding failure degrades to the unfunded behaviour with a clear
+  // warning rather than sinking the whole run.
+  if (env.capabilities.stripe) {
+    try {
+      await subscribe(env, ownerClient, owner.principal.accountId!);
+      env.capabilities.funded = true;
+      log.step(`provision: OWNER ${owner.principal.accountId} funded (pro tier + credits)`);
+    } catch (err) {
+      log.warn(
+        `provision: OWNER funding failed — paid-tier flows will hit project_limit/402: ${(err as Error)?.message ?? err}`,
+      );
+    }
+  }
 
   const nonmember = await synthUser(env, "NONMEMBER", runId);
   supabaseUserIds.push(nonmember.user.id);


### PR DESCRIPTION
On the first real release run (27907350139): **163/278 passed, 86 failed** — and **74% of the failures were one cause**: synthesized OWNER accounts land on the **FREE plan** (1-project limit), so multi-project/session flows died with `project_limit_reached` (57) or HTTP `402` (7).

`provisionMatrix` never funded the OWNER. This calls the existing `subscribe()` fixture (real Stripe **test-mode** inline checkout → paid tier + $50 credits, waits for balance) right after the OWNER account is created, and sets `capabilities.funded` so funded-gated flows run too.

Non-fatal by design: a funding failure logs a clear warning and the suite continues (same as today's unfunded behaviour) instead of hanging/sinking the run. Should turn ~64 of the 86 red flows green; the remaining ~22 (500/502s + assertion diffs) are real findings to triage from the published report.