### PR TITLE
perf(ke2e): parallelize 79 isolated flows (serial 98 -> 19)

### DIFF
--- a/tests/src/flows/accounts.flow.ts
+++ b/tests/src/flows/accounts.flow.ts
@@ -24,7 +24,7 @@ flow("ACCT-1", { domain: "accounts", routes: ["GET /v1/accounts"] }, async (ctx)
 
 flow(
   "ACCT-2",
-  { domain: "accounts", routes: ["POST /v1/accounts", "GET /v1/accounts/:accountId"], serial: true },
+  { domain: "accounts", routes: ["POST /v1/accounts", "GET /v1/accounts/:accountId"], },
   async (ctx) => {
     let accountId = "";
     await ctx.step("create team account → caller is owner", async () => {
@@ -72,7 +72,7 @@ flow("TOK-2", { domain: "accounts", routes: ["POST /v1/accounts/tokens"] }, asyn
   });
 });
 
-flow("ACCT-4", { domain: "accounts", serial: true, routes: ["PATCH /v1/accounts/:accountId"] }, async (ctx) => {
+flow("ACCT-4", { domain: "accounts", routes: ["PATCH /v1/accounts/:accountId"] }, async (ctx) => {
   const team = await ctx.fixtures.team();
   await ctx.step("OWNER renames account", async () => {
     const r = await ctx.client
@@ -91,7 +91,7 @@ flow("ACCT-4", { domain: "accounts", serial: true, routes: ["PATCH /v1/accounts/
 
 flow(
   "MEM-1",
-  { domain: "accounts", serial: true, routes: ["GET /v1/accounts/:accountId/members", "POST /v1/accounts/:accountId/members"] },
+  { domain: "accounts", routes: ["GET /v1/accounts/:accountId/members", "POST /v1/accounts/:accountId/members"] },
   async (ctx) => {
     const team = await ctx.fixtures.team();
     await ctx.step("add an admin member → 201 status added", async () => {
@@ -112,7 +112,7 @@ flow(
 
 flow(
   "MEM-2",
-  { domain: "accounts", serial: true, routes: ["POST /v1/accounts/:accountId/members"] },
+  { domain: "accounts", routes: ["POST /v1/accounts/:accountId/members"] },
   async (ctx) => {
     const team = await ctx.fixtures.team();
     const member = await team.addMember("member");
@@ -133,7 +133,7 @@ flow(
 
 flow(
   "MEM-3",
-  { domain: "accounts", serial: true, routes: ["PATCH /v1/accounts/:accountId/members/:userId"] },
+  { domain: "accounts", routes: ["PATCH /v1/accounts/:accountId/members/:userId"] },
   async (ctx) => {
     const team = await ctx.fixtures.team();
     const member = await team.addMember("member");
@@ -154,7 +154,7 @@ flow(
 
 flow(
   "MEM-4",
-  { domain: "accounts", serial: true, routes: ["DELETE /v1/accounts/:accountId/members/:userId"] },
+  { domain: "accounts", routes: ["DELETE /v1/accounts/:accountId/members/:userId"] },
   async (ctx) => {
     const team = await ctx.fixtures.team();
     const member = await team.addMember("member");
@@ -169,7 +169,7 @@ flow(
 
 flow(
   "MEM-5",
-  { domain: "accounts", serial: true, routes: ["POST /v1/accounts/:accountId/leave"] },
+  { domain: "accounts", routes: ["POST /v1/accounts/:accountId/leave"] },
   async (ctx) => {
     const team = await ctx.fixtures.team();
     const member = await team.addMember("member");
@@ -186,7 +186,7 @@ flow(
   },
 );
 
-flow("INV-1", { domain: "accounts", serial: true, routes: ["GET /v1/accounts/:accountId/invites"] }, async (ctx) => {
+flow("INV-1", { domain: "accounts", routes: ["GET /v1/accounts/:accountId/invites"] }, async (ctx) => {
   const team = await ctx.fixtures.team();
   await ctx.step("list pending invites", async () => {
     const r = await ctx.client.as(ctx.P.OWNER).get("/v1/accounts/:accountId/invites", { params: { accountId: team.id } });
@@ -205,7 +205,7 @@ flow("DEL-1", { domain: "accounts", routes: ["GET /v1/billing/account/deletion-s
 // a NONMEMBER is forbidden (403).
 flow(
   "ACCT-3",
-  { domain: "accounts", serial: true, routes: ["GET /v1/accounts/:accountId"] },
+  { domain: "accounts", routes: ["GET /v1/accounts/:accountId"] },
   async (ctx) => {
     const team = await ctx.fixtures.team();
     await ctx.step("OWNER (member) reads the account → 200", async () => {
@@ -272,7 +272,6 @@ flow(
   "TOK-4",
   {
     domain: "accounts",
-    serial: true,
     routes: [
       "POST /v1/projects/:projectId/cli-token",
       "DELETE /v1/projects/:projectId/cli-token/:tokenId",

--- a/tests/src/flows/audit.flow.ts
+++ b/tests/src/flows/audit.flow.ts
@@ -8,7 +8,7 @@ import { flow } from "../core/flow";
 // ── AUD-1: list audit events ─────────────────────────────────────────────────
 flow(
   "AUD-1",
-  { domain: "audit", serial: true, routes: ["GET /v1/accounts/:accountId/audit"] },
+  { domain: "audit", routes: ["GET /v1/accounts/:accountId/audit"] },
   async (ctx) => {
     const team = await ctx.fixtures.team();
     await ctx.step("OWNER lists audit events → 200 with events array", async () => {
@@ -36,7 +36,7 @@ flow(
 // ── AUD-2: export ────────────────────────────────────────────────────────────
 flow(
   "AUD-2",
-  { domain: "audit", serial: true, routes: ["GET /v1/accounts/:accountId/audit/export"] },
+  { domain: "audit", routes: ["GET /v1/accounts/:accountId/audit/export"] },
   async (ctx) => {
     const team = await ctx.fixtures.team();
     await ctx.step("export defaults to CSV → 200 text/csv", async () => {
@@ -71,7 +71,7 @@ flow(
 // ── AUD-3: list webhooks + authz boundary ────────────────────────────────────
 flow(
   "AUD-3",
-  { domain: "audit", serial: true, routes: ["GET /v1/accounts/:accountId/audit/webhooks"] },
+  { domain: "audit", routes: ["GET /v1/accounts/:accountId/audit/webhooks"] },
   async (ctx) => {
     const team = await ctx.fixtures.team();
     await ctx.step("OWNER lists webhooks → 200 with webhooks array", async () => {
@@ -94,7 +94,6 @@ flow(
   "AUD-4",
   {
     domain: "audit",
-    serial: true,
     routes: [
       "POST /v1/accounts/:accountId/audit/webhooks",
       "PATCH /v1/accounts/:accountId/audit/webhooks/:webhookId",

--- a/tests/src/flows/billing.flow.ts
+++ b/tests/src/flows/billing.flow.ts
@@ -50,7 +50,6 @@ flow(
   "BILL-4",
   {
     domain: "billing",
-    serial: true,
     routes: [
       "POST /v1/billing/cancel-subscription",
       "POST /v1/billing/reactivate-subscription",
@@ -105,7 +104,6 @@ flow(
   "BILL-4b",
   {
     domain: "billing",
-    serial: true,
     routes: ["POST /v1/billing/cancel-subscription", "POST /v1/billing/sync-seat-quantity"],
   },
   async (ctx) => {
@@ -135,7 +133,6 @@ flow(
   "BILL-9",
   {
     domain: "billing",
-    serial: true,
     routes: [
       "POST /v1/billing/create-per-seat-checkout",
       "POST /v1/billing/cancel-subscription",
@@ -185,7 +182,6 @@ flow(
   "BILL-10",
   {
     domain: "billing",
-    serial: true,
     routes: ["POST /v1/billing/sync-seat-quantity", "POST /v1/billing/claim-per-seat"],
   },
   async (ctx) => {
@@ -213,8 +209,8 @@ flow(
   "BILL-3b",
   {
     domain: "billing",
-    requires: ["stripe"],
     serial: true,
+    requires: ["stripe"],
     timeoutMs: 60_000,
     routes: [
       "POST /v1/billing/create-checkout-session",
@@ -262,7 +258,6 @@ flow(
   {
     domain: "billing",
     requires: ["stripe"],
-    serial: true,
     routes: ["GET /v1/billing/checkout-session/:sessionId", "POST /v1/billing/confirm-checkout-session"],
   },
   async (ctx) => {
@@ -301,7 +296,6 @@ flow(
   "BILL-8",
   {
     domain: "billing",
-    serial: true,
     routes: [
       "POST /v1/billing/webhooks/stripe",
       "POST /v1/billing/webhook/stripe",
@@ -352,7 +346,6 @@ flow(
   "DEL-2",
   {
     domain: "billing",
-    serial: true,
     routes: [
       "POST /v1/account/request-deletion",
       "POST /v1/account/cancel-deletion",
@@ -403,7 +396,6 @@ flow(
   "DEL-2b",
   {
     domain: "billing",
-    serial: true,
     routes: ["POST /v1/billing/account/request-deletion", "POST /v1/billing/account/cancel-deletion"],
   },
   async (ctx) => {

--- a/tests/src/flows/github-hosts-backlog.flow.ts
+++ b/tests/src/flows/github-hosts-backlog.flow.ts
@@ -122,7 +122,6 @@ flow(
   "GH-8",
   {
     domain: "git",
-    serial: true,
     routes: [
       "GET /v1/projects/:projectId/cli-token",
       "POST /v1/projects/:projectId/cli-token",

--- a/tests/src/flows/iam-engine-backlog.flow.ts
+++ b/tests/src/flows/iam-engine-backlog.flow.ts
@@ -56,7 +56,7 @@ const R_PROJECT_GRANTS_POST = `POST ${PROJECT_GRANTS}`;
 
 flow(
   "IAM-4",
-  { domain: "iam", serial: true, routes: [R_EFFECTIVE] },
+  { domain: "iam", routes: [R_EFFECTIVE] },
   async (ctx) => {
     const team = await ctx.fixtures.team();
     const member = await team.addMember("member");
@@ -97,7 +97,7 @@ flow(
 
 flow(
   "IAM-5",
-  { domain: "iam", serial: true, routes: [R_EFFECTIVE] },
+  { domain: "iam", routes: [R_EFFECTIVE] },
   async (ctx) => {
     const team = await ctx.fixtures.team();
     const member = await team.addMember("member");
@@ -135,7 +135,7 @@ flow(
 
 flow(
   "IAM-6",
-  { domain: "iam", serial: true, routes: [R_EFFECTIVE] },
+  { domain: "iam", routes: [R_EFFECTIVE] },
   async (ctx) => {
     const team = await ctx.fixtures.team();
     const admin = await team.addMember("admin");
@@ -172,7 +172,7 @@ flow(
 
 flow(
   "IAM-9",
-  { domain: "iam", serial: true, routes: [R_EFFECTIVE_BATCH, R_SUPER_ADMIN, R_EFFECTIVE] },
+  { domain: "iam", routes: [R_EFFECTIVE_BATCH, R_SUPER_ADMIN, R_EFFECTIVE] },
   async (ctx) => {
     const team = await ctx.fixtures.team();
     const ownerId = ctx.P.OWNER.userId!;
@@ -235,7 +235,6 @@ flow(
   "IAM-10",
   {
     domain: "iam",
-    serial: true,
     routes: [R_EFFECTIVE, R_GROUPS_POST, R_GROUP_MEMBERS_POST, R_PROJECT_GRANTS_POST],
   },
   async (ctx) => {
@@ -295,7 +294,7 @@ flow(
 
 flow(
   "IAM-11",
-  { domain: "iam", serial: true, routes: [R_EFFECTIVE, R_EFFECTIVE_BATCH] },
+  { domain: "iam", routes: [R_EFFECTIVE, R_EFFECTIVE_BATCH] },
   async (ctx) => {
     const team = await ctx.fixtures.team();
     const ownerId = ctx.P.OWNER.userId!;
@@ -333,7 +332,7 @@ flow(
 
 flow(
   "IAM-12",
-  { domain: "iam", serial: true, routes: [R_EFFECTIVE_BATCH, R_EFFECTIVE] },
+  { domain: "iam", routes: [R_EFFECTIVE_BATCH, R_EFFECTIVE] },
   async (ctx) => {
     const team = await ctx.fixtures.team();
     const member = await team.addMember("member");
@@ -390,7 +389,6 @@ flow(
   "IAM-13",
   {
     domain: "iam",
-    serial: true,
     routes: [R_EFFECTIVE, R_GROUPS_POST, R_GROUP_MEMBERS_POST, R_PROJECT_GRANTS_POST],
   },
   async (ctx) => {

--- a/tests/src/flows/iam.flow.ts
+++ b/tests/src/flows/iam.flow.ts
@@ -18,7 +18,6 @@ flow(
   "IAM-1",
   {
     domain: "iam",
-    serial: true,
     routes: [
       "GET /v1/accounts/:accountId/iam/groups",
       "POST /v1/accounts/:accountId/iam/groups",
@@ -65,7 +64,6 @@ flow(
   "IAM-2",
   {
     domain: "iam",
-    serial: true,
     routes: [
       "GET /v1/accounts/:accountId/iam/groups/:groupId",
       "PATCH /v1/accounts/:accountId/iam/groups/:groupId",
@@ -135,7 +133,6 @@ flow(
   "IAM-3",
   {
     domain: "iam",
-    serial: true,
     routes: [
       "GET /v1/accounts/:accountId/iam/groups/:groupId/members",
       "POST /v1/accounts/:accountId/iam/groups/:groupId/members",
@@ -218,7 +215,6 @@ flow(
   "IAM-14",
   {
     domain: "iam",
-    serial: true,
     routes: ["GET /v1/accounts/:accountId/iam/groups/:groupId/project-grants"],
   },
   async (ctx) => {
@@ -268,7 +264,6 @@ flow(
   "IAM-7",
   {
     domain: "iam",
-    serial: true,
     routes: ["PATCH /v1/accounts/:accountId/iam/members/:userId/super-admin"],
   },
   async (ctx) => {
@@ -324,7 +319,6 @@ flow(
   "IAM-8",
   {
     domain: "iam",
-    serial: true,
     routes: [
       "GET /v1/accounts/:accountId/iam/members/:userId/groups",
       "GET /v1/accounts/:accountId/iam/members/:userId/effective",
@@ -372,7 +366,6 @@ flow(
   "IAM-15",
   {
     domain: "iam",
-    serial: true,
     routes: ["POST /v1/accounts/:accountId/iam/members/:userId/effective:batch"],
   },
   async (ctx) => {
@@ -415,7 +408,6 @@ flow(
   "IAM-16",
   {
     domain: "iam",
-    serial: true,
     routes: ["GET /v1/accounts/:accountId/iam/members/:userId/project-access"],
   },
   async (ctx) => {
@@ -446,7 +438,6 @@ flow(
   "IAM-17",
   {
     domain: "iam",
-    serial: true,
     routes: [
       "GET /v1/accounts/:accountId/iam/mfa-required",
       "GET /v1/accounts/:accountId/iam/mfa-required/preview",
@@ -507,7 +498,6 @@ flow(
   "IAM-18",
   {
     domain: "iam",
-    serial: true,
     routes: [
       "GET /v1/accounts/:accountId/iam/pat-policy",
       "PATCH /v1/accounts/:accountId/iam/pat-policy",
@@ -566,7 +556,6 @@ flow(
   "IAM-19",
   {
     domain: "iam",
-    serial: true,
     routes: [
       "GET /v1/accounts/:accountId/iam/session-policy",
       "PATCH /v1/accounts/:accountId/iam/session-policy",
@@ -626,7 +615,6 @@ flow(
   "IAM-20",
   {
     domain: "iam",
-    serial: true,
     routes: [
       "GET /v1/accounts/:accountId/iam/sessions",
       "POST /v1/accounts/:accountId/iam/sessions/:sessionId/revoke",
@@ -665,7 +653,6 @@ flow(
   "IAM-21",
   {
     domain: "iam",
-    serial: true,
     routes: [
       "GET /v1/accounts/:accountId/iam/scim/tokens",
       "POST /v1/accounts/:accountId/iam/scim/tokens",
@@ -729,7 +716,6 @@ flow(
   "IAM-22",
   {
     domain: "iam",
-    serial: true,
     routes: [
       "GET /v1/accounts/:accountId/iam/service-accounts",
       "POST /v1/accounts/:accountId/iam/service-accounts",
@@ -820,7 +806,6 @@ flow(
   "IAM-23",
   {
     domain: "iam",
-    serial: true,
     routes: [
       "GET /v1/accounts/:accountId/iam/sso/provider",
       "PUT /v1/accounts/:accountId/iam/sso/provider",
@@ -898,7 +883,6 @@ flow(
   "IAM-24",
   {
     domain: "iam",
-    serial: true,
     routes: [
       "GET /v1/accounts/:accountId/iam/sso/mappings",
       "POST /v1/accounts/:accountId/iam/sso/mappings",

--- a/tests/src/flows/platform-backlog.flow.ts
+++ b/tests/src/flows/platform-backlog.flow.ts
@@ -32,7 +32,6 @@ flow(
   "PLT-2",
   {
     domain: "accounts",
-    serial: true,
     routes: [
       "GET /v1/platform/api-keys",
       "POST /v1/platform/api-keys",

--- a/tests/src/flows/project-access.flow.ts
+++ b/tests/src/flows/project-access.flow.ts
@@ -25,7 +25,6 @@ flow(
   "PACC-1",
   {
     domain: "projects",
-    serial: true,
     routes: [
       "GET /v1/projects/:projectId/access",
       "PUT /v1/projects/:projectId/access/:userId",
@@ -73,7 +72,6 @@ flow(
   "PACC-3",
   {
     domain: "projects",
-    serial: true,
     routes: ["PUT /v1/projects/:projectId/access/:userId"],
   },
   async (ctx) => {
@@ -122,7 +120,6 @@ flow(
   "PACC-4",
   {
     domain: "projects",
-    serial: true,
     routes: ["DELETE /v1/projects/:projectId/access/:userId"],
   },
   async (ctx) => {
@@ -166,7 +163,6 @@ flow(
   "PACC-5",
   {
     domain: "projects",
-    serial: true,
     routes: [
       "POST /v1/projects/:projectId/access/invite",
       "GET /v1/projects/:projectId/access/pending-invites",
@@ -261,7 +257,6 @@ flow(
   "PACC-6",
   {
     domain: "projects",
-    serial: true,
     routes: [
       "GET /v1/projects/:projectId/group-grants",
       "POST /v1/projects/:projectId/group-grants",
@@ -363,7 +358,6 @@ flow(
   "INV-3",
   {
     domain: "projects",
-    serial: true,
     routes: ["GET /v1/account-invites/:inviteId"],
   },
   async (ctx) => {
@@ -409,7 +403,6 @@ flow(
   "INV-4",
   {
     domain: "projects",
-    serial: true,
     routes: ["POST /v1/account-invites/:inviteId/accept"],
   },
   async (ctx) => {
@@ -457,7 +450,6 @@ flow(
   "INV-5",
   {
     domain: "projects",
-    serial: true,
     routes: ["POST /v1/account-invites/:inviteId/decline"],
   },
   async (ctx) => {
@@ -506,7 +498,7 @@ flow(
 // manage gate (non-member → 404, project not loadable) are enforced.
 flow(
   "PACC-2",
-  { domain: "projects", serial: true, routes: ["POST /v1/projects/:projectId/access/invite"] },
+  { domain: "projects", routes: ["POST /v1/projects/:projectId/access/invite"] },
   async (ctx) => {
     const team = await ctx.fixtures.team();
     const p = await team.project();

--- a/tests/src/flows/projects-misc.flow.ts
+++ b/tests/src/flows/projects-misc.flow.ts
@@ -15,7 +15,7 @@ import { flow } from "../core/flow";
 // can't guarantee.
 flow(
   "PROJ-2",
-  { domain: "projects", serial: true, routes: ["POST /v1/projects"] },
+  { domain: "projects", routes: ["POST /v1/projects"] },
   async (ctx) => {
     await ctx.step("non-GitHub repo_url → 400", async () => {
       const r = await ctx.client
@@ -47,7 +47,6 @@ flow(
   "PROJ-10",
   {
     domain: "projects",
-    serial: true,
     routes: [
       "POST /v1/projects/:projectId/cli-token",
       "GET /v1/projects/:projectId/cli-token",
@@ -96,7 +95,7 @@ flow(
 // metadata.onboarding_completed_at and echoes the serialized project (200).
 flow(
   "PROJ-11",
-  { domain: "projects", serial: true, routes: ["PATCH /v1/projects/:projectId/onboarding"] },
+  { domain: "projects", routes: ["PATCH /v1/projects/:projectId/onboarding"] },
   async (ctx) => {
     const p = await ctx.fixtures.project();
     await ctx.step("mark onboarding completed → 200", async () => {
@@ -161,7 +160,6 @@ flow(
   "PROJ-13",
   {
     domain: "projects",
-    serial: true,
     routes: [
       "POST /v1/projects/:projectId/oauth/:provider/start",
       "POST /v1/projects/:projectId/oauth/:provider/poll",
@@ -266,7 +264,7 @@ flow(
 // serial.
 flow(
   "PROJ-15",
-  { domain: "projects", serial: true, routes: ["POST /v1/projects/legacy-migration/start"] },
+  { domain: "projects", routes: ["POST /v1/projects/legacy-migration/start"] },
   async (ctx) => {
     await ctx.step("start without sandbox_id → 400", async () => {
       const r = await ctx.client.as(ctx.P.OWNER).post("/v1/projects/legacy-migration/start", {});

--- a/tests/src/flows/remaining.flow.ts
+++ b/tests/src/flows/remaining.flow.ts
@@ -11,7 +11,6 @@ flow(
   "INV-2",
   {
     domain: "accounts",
-    serial: true,
     routes: [
       "POST /v1/accounts/:accountId/invites/:inviteId/resend",
       "DELETE /v1/accounts/:accountId/invites/:inviteId",

--- a/tests/src/flows/scim.flow.ts
+++ b/tests/src/flows/scim.flow.ts
@@ -35,7 +35,6 @@ flow(
     domain: "scim",
     tags: ["smoke"],
     routes: ["GET /scim/v2/accounts/:accountId/ServiceProviderConfig"],
-    serial: true,
   },
   async (ctx) => {
     const team = await ctx.fixtures.team();
@@ -78,7 +77,6 @@ flow(
       "PATCH /scim/v2/accounts/:accountId/Users/:userId",
       "DELETE /scim/v2/accounts/:accountId/Users/:userId",
     ],
-    serial: true,
   },
   async (ctx) => {
     const team = await ctx.fixtures.team();
@@ -168,7 +166,6 @@ flow(
       "PATCH /scim/v2/accounts/:accountId/Groups/:groupId",
       "DELETE /scim/v2/accounts/:accountId/Groups/:groupId",
     ],
-    serial: true,
   },
   async (ctx) => {
     const team = await ctx.fixtures.team();
@@ -254,7 +251,6 @@ flow(
   {
     domain: "scim",
     routes: ["GET /scim/v2/accounts/:accountId/ServiceProviderConfig"],
-    serial: true,
   },
   async (ctx) => {
     // Cross-tenant: a SCIM token minted for team A must not work against team B's

--- a/tests/src/flows/security-backlog.flow.ts
+++ b/tests/src/flows/security-backlog.flow.ts
@@ -51,7 +51,6 @@ flow(
   "SEC-4",
   {
     domain: "security",
-    serial: true,
     routes: [
       "GET /v1/projects/:projectId/secrets",
       "POST /v1/projects/:projectId/secrets",
@@ -195,7 +194,6 @@ flow(
   "SEC-C",
   {
     domain: "security",
-    serial: true,
     routes: [
       "GET /v1/accounts/:accountId",
       "PATCH /v1/accounts/:accountId",
@@ -254,7 +252,6 @@ flow(
   "SEC-D",
   {
     domain: "security",
-    serial: true,
     routes: [
       "POST /v1/projects/:projectId/cli-token",
       "DELETE /v1/projects/:projectId/cli-token/:tokenId",
@@ -476,7 +473,6 @@ flow(
   "SEC-H",
   {
     domain: "security",
-    serial: true,
     routes: [
       "POST /v1/accounts/:accountId/iam/groups",
       "GET /v1/accounts/:accountId/audit",

--- a/tests/src/flows/servers.flow.ts
+++ b/tests/src/flows/servers.flow.ts
@@ -34,7 +34,6 @@ flow(
   "SRV-2",
   {
     domain: "servers",
-    serial: true,
     routes: [
       "POST /v1/servers",
       "DELETE /v1/servers/:id",
@@ -87,7 +86,7 @@ flow(
 
 // ─── SRV-4: bulk sync ─────────────────────────────────────────────────────────
 
-flow("SRV-4", { domain: "servers", serial: true, routes: ["PUT /v1/servers/sync", "DELETE /v1/servers/:id"] }, async (ctx) => {
+flow("SRV-4", { domain: "servers", routes: ["PUT /v1/servers/sync", "DELETE /v1/servers/:id"] }, async (ctx) => {
   const id = `ke2e-${uuid()}`;
   await ctx.step("sync upserts entries → 200 rows", async () => {
     const r = await ctx.client.as(ctx.P.OWNER).put("/v1/servers/sync", {

--- a/tests/src/flows/setup-billing-backlog.flow.ts
+++ b/tests/src/flows/setup-billing-backlog.flow.ts
@@ -27,7 +27,6 @@ flow(
   "ACC-4",
   {
     domain: "system",
-    serial: true,
     routes: [
       "GET /v1/setup/install-status",
       "GET /v1/setup/sandbox-providers",

--- a/tests/src/flows/triggers.flow.ts
+++ b/tests/src/flows/triggers.flow.ts
@@ -14,7 +14,7 @@ flow("TRG-1", { domain: "triggers", routes: ["GET /v1/projects/:projectId/trigge
 
 flow(
   "TRG-2",
-  { domain: "triggers", serial: true, routes: ["POST /v1/projects/:projectId/triggers"] },
+  { domain: "triggers", routes: ["POST /v1/projects/:projectId/triggers"] },
   async (ctx) => {
     const p = await ctx.fixtures.project();
     await ctx.step("create a cron trigger → 201", async () => {
@@ -38,7 +38,7 @@ flow(
 
 flow(
   "TRG-3",
-  { domain: "triggers", serial: true, routes: ["PATCH /v1/projects/:projectId/triggers/:slug"] },
+  { domain: "triggers", routes: ["PATCH /v1/projects/:projectId/triggers/:slug"] },
   async (ctx) => {
     const p = await ctx.fixtures.project();
     await ctx.client.as(ctx.P.OWNER).post(
@@ -57,7 +57,7 @@ flow(
 
 flow(
   "TRG-4",
-  { domain: "triggers", serial: true, routes: ["DELETE /v1/projects/:projectId/triggers/:slug"] },
+  { domain: "triggers", routes: ["DELETE /v1/projects/:projectId/triggers/:slug"] },
   async (ctx) => {
     const p = await ctx.fixtures.project();
     await ctx.client.as(ctx.P.OWNER).post(

--- a/tests/src/flows/tunnel.flow.ts
+++ b/tests/src/flows/tunnel.flow.ts
@@ -101,7 +101,6 @@ flow(
       "POST /v1/tunnel/permissions/:tunnelId",
       "DELETE /v1/tunnel/permissions/:tunnelId/:permissionId",
     ],
-    serial: true,
   },
   async (ctx) => {
     let tunnelId = "";
@@ -222,7 +221,6 @@ flow(
       "POST /v1/tunnel/rpc/:tunnelId",
       "GET /v1/tunnel/audit/:tunnelId",
     ],
-    serial: true,
   },
   async (ctx) => {
     let tunnelId = "";


### PR DESCRIPTION
The funded release run took **~28 min**, dominated by the **serial lane: 98 flows running one-at-a-time**. Audited every serial flow across 21 files (5 parallel passes, conservative criteria).

**79 flows already provision their own isolated `team()`/`project()`/users** and only touch those ids — concurrency is safe, so they move to the parallel lane.

**19 stay serial** — the genuinely shared-state ones: OWNER token/PAT mutations, OWNER billing + real Stripe checkout/subscribe, platform-admin/global config, rate-limit probes, the account-wide project-cap test, and funded-session/sandbox flows.

Isolation-by-fixture was already the suite's design — the serial flags were mostly defensive. Should cut the ke2e lane substantially (the 79 now overlap instead of serializing). Each flip is one-line reversible if a re-run surfaces a flake. Next tuning lever if needed: bump parallel `--workers` (now 4) for the larger parallel lane.