### PR TITLE
fix(web): tuck 'pause all triggers' kill-switch into Settings (out of the Triggers tab)

### DIFF
--- a/apps/web/src/components/projects/customize/sections/settings-view.tsx
+++ b/apps/web/src/components/projects/customize/sections/settings-view.tsx
@@ -11,6 +11,7 @@ import {
   FlaskConical,
   GitBranch,
   Loader2,
+  Pause,
   Settings,
   Trash2,
   UserPlus,
@@ -38,6 +39,8 @@ import {
   getProject,
   inviteRepoCollaborator,
   isManagedGithubProject,
+  listProjectTriggers,
+  setProjectTriggersActivation,
   updateExperimentalFeature,
   updateProject,
   type ExperimentalFeatureView,
@@ -106,6 +109,7 @@ function ProjectSettingsBody({ projectId }: { projectId: string }) {
             <GeneralProjectCard project={project} canManage={!!canManage} />
             <RepositoryCard project={project} canManage={!!canManage} />
             <ExperimentalCard project={project} canManage={!!canManage} />
+            {canManage && <TriggersActivationCard projectId={projectId} canManage={!!canManage} />}
             {canManage && (
               <SectionCard
                 tone="destructive"
@@ -392,6 +396,69 @@ function ExperimentalFeatureRow({
         onCheckedChange={(v) => mutation.mutate(v)}
       />
     </div>
+  );
+}
+
+/**
+ * Customize → Settings → Pause all triggers. The project-wide trigger
+ * kill-switch (`projects.metadata.triggers_paused`), deliberately tucked away
+ * here as a small dev/debug control rather than advertised on the Triggers tab:
+ * it's only needed when another environment should own this repo's schedules &
+ * webhooks (so they don't double-fire). When on, the platform auto-runs none of
+ * this project's triggers; manual test-fires still work. The Triggers tab shows
+ * a compact "paused" notice that points back here.
+ */
+function TriggersActivationCard({
+  projectId,
+  canManage,
+}: {
+  projectId: string;
+  canManage: boolean;
+}) {
+  const queryClient = useQueryClient();
+  const queryKey = ['project-triggers', projectId];
+  const triggersQuery = useQuery({
+    queryKey,
+    queryFn: () => listProjectTriggers(projectId),
+    staleTime: 10_000,
+  });
+  const paused = triggersQuery.data?.triggers_paused ?? false;
+
+  const mutation = useMutation({
+    mutationFn: (next: boolean) => setProjectTriggersActivation(projectId, next),
+    onSuccess: (data, next) => {
+      queryClient.setQueryData(queryKey, data);
+      toast.success(next ? 'All triggers paused for this project' : 'Triggers resumed');
+    },
+    onError: (error: Error) =>
+      toast.error(error.message || 'Failed to update trigger activation'),
+  });
+
+  return (
+    <SectionCard className="border-dashed">
+      <div className="flex items-center justify-between gap-4">
+        <div className="flex min-w-0 items-center gap-2">
+          <Pause className="text-muted-foreground size-4 shrink-0" />
+          <div className="min-w-0">
+            <p className="text-foreground text-sm font-medium">
+              Pause all triggers
+              {paused && <span className="text-muted-foreground font-normal"> · paused</span>}
+            </p>
+            <p className="text-muted-foreground mt-0.5 text-xs">
+              Dev kill-switch — stop the platform auto-running this project&apos;s schedules &amp;
+              webhooks (manual test-fires still work). Use it when another environment owns the
+              triggers.
+            </p>
+          </div>
+        </div>
+        <Switch
+          checked={paused}
+          disabled={!canManage || mutation.isPending || triggersQuery.isLoading}
+          onCheckedChange={(v) => mutation.mutate(v)}
+          aria-label="Pause all triggers for this project"
+        />
+      </div>
+    </SectionCard>
   );
 }
 

--- a/apps/web/src/components/projects/triggers-view.tsx
+++ b/apps/web/src/components/projects/triggers-view.tsx
@@ -77,7 +77,6 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { List, ListRow } from '@/components/ui/list';
 import { SectionCard } from '@/components/ui/section-card';
-import { Switch } from '@/components/ui/switch';
 import {
   Select,
   SelectContent,
@@ -102,7 +101,6 @@ import {
   fireProjectTrigger,
   listProjectAccess,
   listProjectTriggers,
-  setProjectTriggersActivation,
   updateProjectTrigger,
   upsertProjectSecret,
   type ProjectAccessMember,
@@ -324,51 +322,6 @@ export function TriggersView({ projectId, type }: { projectId: string; type: Tri
   );
 }
 
-/**
- * Project-wide trigger kill-switch. Presentational — the parent owns the
- * mutation. When paused, the platform auto-runs none of this project's triggers
- * (cron sweep skips it, inbound webhooks are acknowledged-but-ignored); manual
- * test-fires still work. The warning banner explains the silence so an operator
- * doesn't wonder why scheduled runs stopped.
- */
-function TriggersActivationControl({
-  paused,
-  pending,
-  onToggle,
-}: {
-  paused: boolean;
-  pending: boolean;
-  onToggle: (paused: boolean) => void;
-}) {
-  return (
-    <SectionCard
-      title={(
-        <span className="flex items-center gap-2">
-          <Pause className="text-muted-foreground h-3.5 w-3.5" />
-          Pause all triggers
-        </span>
-      )}
-      description="Stop the platform from auto-running this project's schedules and webhooks. Manual test-fires still work. Use this when another environment should own the triggers."
-      action={(
-        <Switch
-          checked={paused}
-          disabled={pending}
-          onCheckedChange={onToggle}
-          aria-label="Pause all triggers for this project"
-        />
-      )}
-      bodyClassName={paused ? 'py-4' : 'hidden'}
-    >
-      {paused && (
-        <InfoBanner tone="warning" icon={AlertTriangle}>
-          Triggers are paused. Scheduled runs and incoming webhooks are ignored for this
-          project until you resume — test-firing a trigger manually still works.
-        </InfoBanner>
-      )}
-    </SectionCard>
-  );
-}
-
 function ProjectTriggersBody({
   projectId,
   type,
@@ -407,20 +360,10 @@ function ProjectTriggersBody({
   // planes from double-firing. Shared across the Schedules + Webhooks views;
   // toggling here writes back to the same `['project-triggers', projectId]`
   // cache both pages read.
+  // The kill-switch toggle lives in Customize → Settings now (a small, tucked-
+  // away dev control). Here we only read the paused state to show a compact
+  // notice so an operator viewing triggers knows why scheduled runs are silent.
   const triggersPaused = triggersQuery.data?.triggers_paused ?? false;
-  const setActivation = useMutation({
-    mutationFn: (paused: boolean) => setProjectTriggersActivation(projectId, paused),
-    onSuccess: (data, paused) => {
-      queryClient.setQueryData(queryKey, data);
-      toast.success(
-        paused ? 'All triggers paused for this project' : 'Triggers resumed',
-      );
-    },
-    onError: (err) =>
-      toast.error(
-        err instanceof Error ? err.message : 'Failed to update trigger activation',
-      ),
-  });
 
   // Filter to just this view's type — the API returns every trigger
   // because they share one `kortix.toml`, but each page is scoped.
@@ -438,12 +381,11 @@ function ProjectTriggersBody({
           <p className="text-muted-foreground text-xs">{meta.description}</p>
         </header>
 
-        {!triggersQuery.isLoading && !isForbidden && !triggersQuery.isError && (allTriggers.length > 0 || triggersPaused) && (
-          <TriggersActivationControl
-            paused={triggersPaused}
-            pending={setActivation.isPending}
-            onToggle={(paused) => setActivation.mutate(paused)}
-          />
+        {triggersPaused && !triggersQuery.isLoading && !isForbidden && !triggersQuery.isError && (
+          <InfoBanner tone="warning" icon={AlertTriangle}>
+            Triggers are paused for this project — scheduled runs and incoming webhooks are
+            ignored (manual test-fires still work). Resume in Customize → Settings.
+          </InfoBanner>
         )}
 
         {triggersQuery.isLoading ? (


### PR DESCRIPTION
## Why
The project-wide trigger kill-switch was a big prominent `SectionCard` at the top of every Triggers (Schedules + Webhooks) view — advertising a rarely-used dev/ops control as a first-class feature. It's really only for *"another environment owns this repo's triggers, don't double-fire"*, so it should be small and tucked away.

## What
- **Customize → Settings**: new small, muted (`border-dashed`) `TriggersActivationCard` — one row (icon + label + one-line hint + Switch), **manager-only**, sitting just above the Danger Zone. Same endpoint (`setProjectTriggersActivation` → `projects.metadata.triggers_paused`) and the same shared `['project-triggers']` cache, so toggling stays in sync with the Triggers tab.
- **Triggers tab**: the big control is gone. When paused, it now shows only a compact warning notice (*"Triggers are paused … resume in Customize → Settings"*) so an operator isn't left wondering why scheduled runs went silent.
- Removed the now-unused `TriggersActivationControl` component + `Switch` / `setProjectTriggersActivation` imports from `triggers-view`.

No API or behavior change — purely relocates + shrinks the control. `tsc` clean (only the unrelated pre-existing `billing-history` workspace-resolution error remains).

## Verify on preview
Open a project with triggers → **Triggers tab**: no more big "Pause all triggers" card. **Customize → Settings**: small dashed "Pause all triggers" row above the Danger Zone; toggling it pauses/resumes; the Triggers tab then shows the compact paused notice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)