### PR TITLE
ci(qa-release): make ke2e API flow suite opt-in

### DIFF
--- a/.github/workflows/qa-release.yml
+++ b/.github/workflows/qa-release.yml
@@ -115,9 +115,17 @@ jobs:
       - name: Static + local functional checks
         run: make lint typecheck unit integration contract api-coverage
 
-      - name: Live API checks
+      - name: Live API smoke
+        timeout-minutes: 10
+        run: make smoke
+      # The full ke2e API flow suite (~278 live flows) is OFF by default: dev is
+      # already exercised by its own tests, and running the funded suite against
+      # it adds load + time. Opt in by setting repo var QA_RUN_API_SUITE=true once
+      # we wire it against a dedicated target.
+      - name: API flow suite (opt-in)
+        if: vars.QA_RUN_API_SUITE == 'true'
         timeout-minutes: 45
-        run: make smoke api
+        run: make api
 
       - name: Browser regression
         timeout-minutes: 30


### PR DESCRIPTION
dev.kortix already has its own test coverage, and running the ~278-flow funded ke2e suite against it in the release gate (a) adds ~18 min and (b) overloads dev-api (the 502s we saw under the higher concurrency). 

Keep the cheap **smoke liveness** check as a gate; make the full **`make api`** ke2e suite **opt-in** via repo var `QA_RUN_API_SUITE=true` (off by default). The suite + reporting stay intact — just not blocking releases until we wire it against a dedicated target. Reverts the release gate to fast + deterministic.