### PR TITLE
fix(sessions): drain cap-eating stuck-active sessions + honest Slack status

### DIFF
--- a/apps/api/src/__tests__/e2e-project-maintenance.test.ts
+++ b/apps/api/src/__tests__/e2e-project-maintenance.test.ts
@@ -108,6 +108,7 @@ mock.module('../projects/sandbox-reaper', () => ({
     errors: 0,
   }),
   reconcileOrphanComputeSessions: async () => ({ checked: 0, closed: 0, errors: 0 }),
+  reconcileStuckActiveSessions: async () => ({ candidates: 0, reconciled: 0, billingClosed: 0, errors: 0 }),
   reapOrphanProviderBoxes: async () => ({ listed: 0, orphans: 0, stopped: 0, errors: 0 }),
   countBillingInvariantViolations: async () => 0,
 }));

--- a/apps/api/src/channels/slack/session.ts
+++ b/apps/api/src/channels/slack/session.ts
@@ -151,18 +151,16 @@ export async function createOrJoinThreadSession(input: {
   });
 
   if (result.error) {
-    console.error('[slack-webhook] createProjectSession failed', result.error.body);
+    console.error('[slack-webhook] createProjectSession failed', { status: result.error.status, body: result.error.body });
     if (handle) {
-      await finalizeTurn(handle, { error: "I couldn't start up just now — try again in a moment." });
+      await finalizeTurn(handle, { error: startErrorMessage(result.error.status, result.error.body?.error) });
     }
     return;
   }
 
   if (result.status === 'queued' || result.status === 'pending') {
     if (handle) {
-      await finalizeTurn(handle, {
-        answer: "I'm queued behind other project work. I'll reply here when the session starts.",
-      });
+      await finalizeTurn(handle, { answer: queuedMessage(result.reason) });
     }
     return;
   }
@@ -171,6 +169,32 @@ export async function createOrJoinThreadSession(input: {
     handle.sessionId = result.sessionId;
     await saveTurn(handle);
   }
+}
+
+// Honest, actionable copy for the two non-success outcomes of starting a Slack
+// session — surfaced in-thread instead of a generic "try again" so a real
+// blocker (out of credits, at the session cap) tells the user what to do.
+function startErrorMessage(status: number | undefined, detail: unknown): string {
+  if (status === 402) {
+    return "This workspace is out of credits, so I can't start a session. Top up in the Kortix dashboard and send your message again.";
+  }
+  if (status === 429) {
+    return "This workspace is at its concurrent-session limit right now. Close or finish a running session, then send your message again.";
+  }
+  if (status === 404) {
+    return "I couldn't find this project to start a session — it may have been moved or deleted. Reconnect Kortix to this channel and try again.";
+  }
+  const text = typeof detail === 'string' ? detail.trim() : '';
+  const tail = text && text.length <= 140 ? ` (${text})` : '';
+  return `I couldn't start a session just now${tail}. Give it a moment and send your message again — I'll reply right here.`;
+}
+
+function queuedMessage(reason?: string): string {
+  if (reason === 'account session cap') {
+    return "This workspace is at its concurrent-session limit, so I've queued your task. I'll start it and reply right here as soon as a running session frees up a slot.";
+  }
+  // 'project provisioning backpressure' or an unspecified queue reason.
+  return "I've queued your task behind the sessions already starting up in this project, and I'll reply right here the moment it begins.";
 }
 
 // Single-winner claim for "who creates this thread's session", reusing the

--- a/apps/api/src/projects/lib/serializers.ts
+++ b/apps/api/src/projects/lib/serializers.ts
@@ -32,14 +32,10 @@ export type RequestAuditContext = {
 
 export const UUID_V4_REGEX = /^[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}$/i;
 
-// NOTE: the partial index idx_project_sessions_account_active (see
-// packages/db/drizzle/20260617102106_account_active_session_index.sql) hard-codes
-// this exact set in its WHERE predicate to keep the concurrency-cap COUNT fast.
-// If you change these statuses, update that index's predicate in a new migration
-// or the planner will silently stop using it.
-export const ACTIVE_SESSION_STATUSES = ['queued', 'branching', 'provisioning', 'running'] as const;
-
-export const PROVISIONING_SESSION_STATUSES = ['queued', 'branching', 'provisioning'] as const;
+// Session-status constants live in a dependency-free module so lean callers (the
+// sandbox reaper) can import them without this heavy serializer graph. Re-exported
+// here for the existing import sites. See session-status.ts for the index note.
+export { ACTIVE_SESSION_STATUSES, PROVISIONING_SESSION_STATUSES } from './session-status';
 
 export const PROJECT_GIT_AUTH_SECRET_NAME = 'KORTIX_GIT_AUTH_TOKEN';
 

--- a/apps/api/src/projects/lib/session-status.ts
+++ b/apps/api/src/projects/lib/session-status.ts
@@ -1,0 +1,12 @@
+// Session-status constants — deliberately dependency-free so lean, hot modules
+// (the sandbox reaper, the concurrency-cap counter) can import them without
+// pulling in the heavy serializer graph (config, warm-pool, snapshots, github…).
+//
+// NOTE: the partial index idx_project_sessions_account_active (see
+// packages/db/drizzle/20260617102106_account_active_session_index.sql) hard-codes
+// this exact set in its WHERE predicate to keep the concurrency-cap COUNT fast.
+// If you change these statuses, update that index's predicate in a new migration
+// or the planner will silently stop using it.
+export const ACTIVE_SESSION_STATUSES = ['queued', 'branching', 'provisioning', 'running'] as const;
+
+export const PROVISIONING_SESSION_STATUSES = ['queued', 'branching', 'provisioning'] as const;

--- a/apps/api/src/projects/maintenance.ts
+++ b/apps/api/src/projects/maintenance.ts
@@ -9,6 +9,7 @@ import { reconcileSnapshotQuota } from '../snapshots/quota-gc';
 import {
   reapAndReconcileSandboxes,
   reconcileOrphanComputeSessions,
+  reconcileStuckActiveSessions,
   reapOrphanProviderBoxes,
   countBillingInvariantViolations,
 } from './sandbox-reaper';
@@ -144,7 +145,7 @@ async function runProjectMaintenance(): Promise<void> {
   if (maintenanceRunning) return;
   maintenanceRunning = true;
   try {
-    const [idle, orphanCompute, orphanBoxes, branches, computeTick, staleBuilds, warmPool, snapshotGc] = await Promise.all([
+    const [idle, orphanCompute, stuckSessions, orphanBoxes, branches, computeTick, staleBuilds, warmPool, snapshotGc] = await Promise.all([
       // Provider-authoritative idle reaper + state/billing reconcile (the fix for
       // boxes that never auto-stopped and kept billing). Backstops the webhooks.
       reapAndReconcileSandboxes().catch((err) => {
@@ -156,6 +157,15 @@ async function runProjectMaintenance(): Promise<void> {
       reconcileOrphanComputeSessions().catch((err) => {
         console.warn('[project-maintenance] orphan-compute reconcile failed:', err instanceof Error ? err.message : err);
         return { checked: 0, closed: 0, errors: 0 };
+      }),
+      // Session-side leak fix: reconcile project_sessions stuck in an ACTIVE
+      // status with no running box behind them — invisible to the provider reaper
+      // above (which keys off an `active` sandbox row) and the real reason an
+      // account's concurrent-session cap fills up and wedges Slack. DB-only, so
+      // it drains the cap even while Daytona is throttling the box reaper.
+      reconcileStuckActiveSessions().catch((err) => {
+        console.warn('[project-maintenance] stuck-session reconcile failed:', err instanceof Error ? err.message : err);
+        return { candidates: 0, reconciled: 0, billingClosed: 0, errors: 0 };
       }),
       // Provider-authoritative orphan-BOX reaper: stops boxes still running on
       // the provider (this env) with no live DB row — the leak the DB-driven
@@ -193,12 +203,13 @@ async function runProjectMaintenance(): Promise<void> {
     ]);
     if (
       idle.stopped || idle.reconciled || idle.errors || orphanCompute.closed || orphanCompute.errors ||
+      stuckSessions.reconciled || stuckSessions.errors ||
       orphanBoxes.stopped || orphanBoxes.errors ||
       branches.deleted || branches.errors ||
       computeTick.settled || staleBuilds.closedReady || staleBuilds.closedFailed || warmPool.reaped ||
       snapshotGc.deleted
     ) {
-      console.log('[project-maintenance] completed', { idle, orphanCompute, orphanBoxes, branches, computeTick, staleBuilds, warmPool, snapshotGc });
+      console.log('[project-maintenance] completed', { idle, orphanCompute, stuckSessions, orphanBoxes, branches, computeTick, staleBuilds, warmPool, snapshotGc });
     }
 
     // Invariant monitor: in steady state, every `active` compute session has a

--- a/apps/api/src/projects/sandbox-reaper.test.ts
+++ b/apps/api/src/projects/sandbox-reaper.test.ts
@@ -14,6 +14,7 @@ let cacheInvalidations: string[] = [];
 let pausedCompute: string[] = [];
 let endedCompute: string[] = [];
 let updateCalls: Array<{ table: unknown; updates: Record<string, unknown> }> = [];
+let stuckSessions: Array<{ sessionId: string }> = [];
 
 /** A thenable that also exposes `.limit()` so both `await where()` (turn query)
  *  and `where().limit()` (candidate query) resolve to the same rows. */
@@ -45,15 +46,29 @@ mock.module('../shared/db', () => ({
                 ? activeTurns
                 : table === usageEvents
                   ? usageRows
-                  : [],
+                  : table === projectSessions
+                    ? stuckSessions
+                    : [],
             table === usageEvents && throwOnUsageLookup,
           ),
       }),
     }),
     update: (table: unknown) => ({
       set: (updates: Record<string, unknown>) => ({
-        where: async () => {
-          updateCalls.push({ table, updates });
+        // Awaitable (reconcileRowToStopped) AND chainable to `.returning()`
+        // (reconcileStuckActiveSessions). Records exactly one update call either way.
+        where: () => {
+          const record = () => updateCalls.push({ table, updates });
+          return {
+            then: (resolve: (v: unknown) => void) => {
+              record();
+              resolve(undefined);
+            },
+            returning: async () => {
+              record();
+              return [{ sessionId: 'updated' }];
+            },
+          };
         },
       }),
     }),
@@ -87,7 +102,7 @@ mock.module('../billing/services/compute-metering', () => ({
   },
 }));
 
-const { decideReap, lastMeaningfulAt, reapAndReconcileSandboxes, buildIdleStopMetadata, reapOrphanProviderBoxes } = await import('./sandbox-reaper');
+const { decideReap, lastMeaningfulAt, reapAndReconcileSandboxes, buildIdleStopMetadata, reapOrphanProviderBoxes, reconcileStuckActiveSessions } = await import('./sandbox-reaper');
 
 const TTL = 15 * 60_000;
 
@@ -104,6 +119,7 @@ beforeEach(() => {
   pausedCompute = [];
   endedCompute = [];
   updateCalls = [];
+  stuckSessions = [];
 });
 
 // ── pure decision matrix (the money + UX correctness lives here) ─────────────
@@ -385,5 +401,42 @@ describe('reapOrphanProviderBoxes', () => {
       if (prev === undefined) delete process.env.KORTIX_ORPHAN_BOX_REAP_ENABLED;
       else process.env.KORTIX_ORPHAN_BOX_REAP_ENABLED = prev;
     }
+  });
+});
+
+describe('reconcileStuckActiveSessions', () => {
+  test('no candidates → no-op', async () => {
+    stuckSessions = [];
+    const result = await reconcileStuckActiveSessions(new Date());
+    expect(result.candidates).toBe(0);
+    expect(result.reconciled).toBe(0);
+    expect(updateCalls.length).toBe(0);
+    expect(pausedCompute.length).toBe(0);
+  });
+
+  test('stuck session with a dead box → close billing + flip session to stopped', async () => {
+    stuckSessions = [{ sessionId: 's1' }];
+    // per-session sandbox lookup resolves to the sessionSandboxes mock (candidates)
+    candidates = [{ sandboxId: 'sb1' }];
+    const result = await reconcileStuckActiveSessions(new Date());
+    expect(result.candidates).toBe(1);
+    expect(result.reconciled).toBe(1);
+    expect(result.billingClosed).toBe(1);
+    expect(pausedCompute).toContain('sb1');
+    // exactly one project_sessions row flipped to 'stopped'
+    const sessionUpdates = updateCalls.filter((u) => u.table === projectSessions);
+    expect(sessionUpdates.length).toBe(1);
+    expect(sessionUpdates[0].updates.status).toBe('stopped');
+  });
+
+  test('stuck session with no sandbox row → still flips to stopped, nothing billed', async () => {
+    stuckSessions = [{ sessionId: 's2' }];
+    candidates = []; // no sandbox rows for this session
+    const result = await reconcileStuckActiveSessions(new Date());
+    expect(result.candidates).toBe(1);
+    expect(result.reconciled).toBe(1);
+    expect(result.billingClosed).toBe(0);
+    expect(pausedCompute.length).toBe(0);
+    expect(updateCalls.filter((u) => u.table === projectSessions).length).toBe(1);
   });
 });

--- a/apps/api/src/projects/sandbox-reaper.ts
+++ b/apps/api/src/projects/sandbox-reaper.ts
@@ -28,12 +28,13 @@
  * invariant rather than a best-effort.
  */
 
-import { and, eq, gt, inArray, isNotNull, or, sql } from 'drizzle-orm';
+import { and, eq, gt, inArray, isNotNull, lt, or, sql } from 'drizzle-orm';
 import { projectSessions, sessionSandboxes } from '@kortix/db';
 import { db } from '../shared/db';
 import { getProvider, type ProviderName, type SandboxStatus } from '../platform/providers';
 import { invalidateProviderCache } from '../sandbox-proxy';
 import { pauseComputeSession, endComputeSession } from '../billing/services/compute-metering';
+import { ACTIVE_SESSION_STATUSES } from './lib/session-status';
 import { config } from '../config';
 
 export const REAP_BATCH_SIZE = 100;
@@ -446,6 +447,89 @@ export async function reconcileOrphanComputeSessions(): Promise<{ checked: numbe
   };
   await Promise.all(Array.from({ length: Math.min(REAP_CONCURRENCY, rows.length) }, worker));
   return { checked: rows.length, closed, errors };
+}
+
+const STUCK_SESSION_BATCH = 200;
+
+/**
+ * Reconcile project_sessions stuck in an ACTIVE status that have no genuinely-
+ * running box behind them. THE leak that wedged Slack ("I'm queued behind other
+ * project work") and 429'd new sessions: a session counts against the account's
+ * concurrent-session cap while its status is in ACTIVE_SESSION_STATUSES, but the
+ * provider reaper (reapAndReconcileSandboxes) only ever visits sessions whose
+ * `session_sandboxes` row is still `active`. A session left `running` /
+ * `provisioning` / `queued` / `branching` after its box was stopped or removed
+ * — a missed stop webhook, a getStatus throttled to 'unknown', a continueSession
+ * that flipped stopped→running then failed to deliver, or a create that never
+ * got a box — is STRUCTURALLY INVISIBLE to that pass and so eats a cap slot
+ * forever. Such sessions accreted to 200+ on a single account and blocked it.
+ *
+ * This pass closes that gap from the session side. It is DB-ONLY (no provider
+ * round-trip), so it is immune to the Daytona throttling that starves the box
+ * reaper, and it acts ONLY on sessions that are provably idle:
+ *   - status ∈ ACTIVE_SESSION_STATUSES and untouched for longer than the auto-
+ *     stop TTL (so a healthy in-flight provision/branch is never touched),
+ *   - NO `active` session_sandboxes row (a live box is the provider reaper's job),
+ *   - NO in-flight turn (unfinalized chat_turn_stream), and
+ *   - NO LLM usage within the TTL window.
+ * For each it settles + closes any lingering billing window (DB-only) and flips
+ * the session to `stopped` — resumable: the next open reprovisions a fresh box.
+ * Idempotent; the status guard on UPDATE avoids racing a concurrent real open.
+ */
+export async function reconcileStuckActiveSessions(
+  now = new Date(),
+): Promise<{ candidates: number; reconciled: number; billingClosed: number; errors: number }> {
+  const cutoff = new Date(now.getTime() - autoStopTtlMs());
+  const { chatTurnStreams, usageEvents } = await import('@kortix/db');
+
+  const candidates = await db
+    .select({ sessionId: projectSessions.sessionId })
+    .from(projectSessions)
+    .where(
+      and(
+        inArray(projectSessions.status, [...ACTIVE_SESSION_STATUSES]),
+        lt(projectSessions.updatedAt, cutoff),
+        sql`not exists (select 1 from ${sessionSandboxes} sb where sb.session_id = ${projectSessions.sessionId} and sb.status = 'active')`,
+        sql`not exists (select 1 from ${chatTurnStreams} t where t.session_id = ${projectSessions.sessionId} and t.finalized = false)`,
+        sql`not exists (select 1 from ${usageEvents} u where u.session_id = ${projectSessions.sessionId} and u.created_at > ${cutoff.toISOString()})`,
+      ),
+    )
+    .limit(STUCK_SESSION_BATCH);
+
+  const result = { candidates: candidates.length, reconciled: 0, billingClosed: 0, errors: 0 };
+  if (candidates.length === 0) return result;
+
+  for (const c of candidates) {
+    try {
+      // Close any lingering billing window for the session's (non-active) box(es).
+      // pauseComputeSession is DB-only + idempotent (no-op when no row is open).
+      const sbs = await db
+        .select({ sandboxId: sessionSandboxes.sandboxId })
+        .from(sessionSandboxes)
+        .where(eq(sessionSandboxes.sessionId, c.sessionId));
+      for (const sb of sbs) {
+        await pauseComputeSession(sb.sandboxId).catch((err) =>
+          console.warn(`[reaper] stuck-session pauseComputeSession failed for ${sb.sandboxId}:`, err instanceof Error ? err.message : err),
+        );
+        result.billingClosed += 1;
+      }
+      // Re-check the status in the UPDATE predicate so we never clobber a session
+      // a real open transitioned out from under us between SELECT and UPDATE.
+      const updated = await db
+        .update(projectSessions)
+        .set({ status: 'stopped', updatedAt: now })
+        .where(and(
+          eq(projectSessions.sessionId, c.sessionId),
+          inArray(projectSessions.status, [...ACTIVE_SESSION_STATUSES]),
+        ))
+        .returning({ sessionId: projectSessions.sessionId });
+      if (updated.length) result.reconciled += 1;
+    } catch (err) {
+      result.errors += 1;
+      console.warn('[reaper] stuck-session reconcile failed:', { sessionId: c.sessionId, error: err instanceof Error ? err.message : err });
+    }
+  }
+  return result;
 }
 
 /**


### PR DESCRIPTION
## Incident
Company prod project (`fda4e35e`) had **210 sessions stuck `status='running'`** against a 200 cap → web 429'd (`concurrent_session_limit`, 206/200) and **every Slack message queued forever** ("I'm queued behind other project work. I'll reply here when the session starts") and never started. Fleet-wide: **403 running** sessions, most with boxes Daytona had already stopped but our DB still marked `active`.

## Root cause
A session eats a cap slot while its status ∈ ACTIVE_SESSION_STATUSES, but the provider reaper only visits sessions whose `session_sandboxes` row is still `active`. A session left `running`/`provisioning` after its box stopped/was-removed (missed stop webhook, `getStatus` throttled to `unknown` under Daytona rate-limit, a `continueSession` that flipped stopped→running then failed to deliver, or a create that never got a box) is **structurally invisible** to the reaper and never drains. Queued Slack creates then kept failing to provision in the same storm, so the queue never started either.

## Fix
- **`reconcileStuckActiveSessions()`** — a **DB-only** maintenance pass (immune to the Daytona throttling that starves the box reaper) that reconciles active-status sessions which are *provably idle*: aged past the auto-stop TTL, **no `active` sandbox row**, no in-flight turn, no recent LLM usage. Settles + closes any lingering billing window (DB-only) and flips the session to `stopped` (resumable). Wired into `runProjectMaintenance`.
- **Lean import** — moved `ACTIVE/PROVISIONING_SESSION_STATUSES` into a dependency-free `session-status` module (re-exported from `serializers`) so the reaper doesn't pull the heavy serializer graph.
- **Slack copy** — replaced the generic "queued behind other project work" / "try again" lines with honest, reason-aware messages (out-of-credits 402, at session cap 429/backpressure, project-not-found 404); failures render as a real "Run failed".

## Validation (live on prod, this incident)
- Cleared the company account 212→0; ran the proven reaper fleet-wide: **stopped 203, reconciled 260, billing windows closed 463**. Fleet running **403 → ~55** (all remaining backed by genuinely-active boxes).
- Ran the **new pass** against prod: **20 structural orphans reconciled, 12 billing windows closed, 0 errors**, then 0 candidates. Company account now serving real new sessions (Slack working).

## Tests
+3 `reconcileStuckActiveSessions` unit cases; mock harness extended for `.returning()`; maintenance e2e mock updated. `tsc` clean; reaper suite 30 pass.