### PR TITLE
ci(qa-release): slim the blocking gate (move exhaustive scans to nightly)

### DIFF
--- a/.github/workflows/qa-release.yml
+++ b/.github/workflows/qa-release.yml
@@ -136,13 +136,13 @@ jobs:
           # It still runs and its results land in the report.
           make visual || echo "::warning::Visual regression failed (advisory — live target). See the QA report for diffs."
 
-      - name: Migration, infra, security, pentest, and mutation
-        timeout-minutes: 60
-        run: make migration infra security pentest mutation
-
-      - name: Performance and DAST
+      - name: Migration, infra, and static security
         timeout-minutes: 30
-        run: make performance security-dast
+        run: make migration infra security
+      # The exhaustive, scan-the-whole-app lanes — mutation (Stryker), black-box
+      # pentest, k6 performance, and DAST — run in qa-nightly, not on every
+      # release: they add ~40-60min and duplicate the scheduled suite. The
+      # blocking gate stays fast + deterministic.
 
       - name: Quality gates
         run: make gates


### PR DESCRIPTION
The release gate ran the full exhaustive suite — **mutation (Stryker), black-box pentest, k6 performance, DAST** — adding ~40-60min and **duplicating qa-nightly**, which already runs all four on a schedule.

Drop them from the *blocking* release gate. It keeps the fast, deterministic, release-critical lanes: lint/typecheck/unit/integration/contract, smoke, e2e/a11y, migration, infra, static security (SAST), and quality gates. The exhaustive scans keep running nightly.

Release gate **~60-90min -> ~20-25min**.