### PR TITLE
ops(prod): complete EKS cutover — restore fleet-wide crons

### DIFF
--- a/infra/k8s/envs/prod/values.yaml
+++ b/infra/k8s/envs/prod/values.yaml
@@ -9,12 +9,16 @@ image:
 kortixVersion: "0.9.68"
 env:
   internalKortixEnv: prod
-# PRE-CUTOVER: api-eks is the candidate while api.kortix.com is still served by
-# ECS, so EKS runs API-only and ECS keeps ownership of the singleton workers
-# (one Postgres leader lease is shared across both). At cutover, flip this to
-# true here AND disable the ECS service — EKS then owns the background work.
+# CUTOVER COMPLETE (2026-06-21): api.kortix.com is served by api-eks, and EKS now
+# OWNS the singleton workers (cron scheduler, project maintenance, migrations).
+# ECS Fargate is scaled to 0 — it had been holding the worker lease while running
+# stale 0.9.63 code whose trigger sweep silently skipped every cron fleet-wide
+# (pre-#3530), so no cron fired for ~18h. One Postgres leader lease is shared, so
+# exactly one EKS pod is leader. KEEP THIS true. If ECS is ever brought back as a
+# standby it MUST stay workers-disabled (KORTIX_TRIGGER_SCHEDULER_ENABLED=false) so
+# it can never grab the worker lease and starve the scheduler again.
 workers:
-  enabled: false
+  enabled: true
 # Drizzle migrations as a PreSync hook before each rollout (gates the release on
 # schema). The hook (templates/migrate-job.yaml) is in place and ready, but is
 # DISABLED on prod until the prod Drizzle ledger is baselined: prod's schema was


### PR DESCRIPTION
**Emergency cutover.** Cron triggers have been dead fleet-wide for ~18h.

**Root cause:** the worker leader lease is held by an ECS Fargate task on stale `0.9.63` (three releases before #3530, the cron-scheduler reliability fix). Its scheduler ticks (connector sweeps run) but the trigger sweep **silently skips every trigger fleet-wide** — the exact pre-#3530 bug. The fix is in `0.9.66+` / EKS `0.9.68`, but EKS had `workers.enabled=false`, so the fixed code never ran the scheduler.

**This change:** flips prod EKS `workers.enabled=true` so the fixed 0.9.68 code owns the singleton workers. ECS is scaled to 0 out-of-band so its broken task releases the shared lease and an EKS pod takes over.

Reversible. ECS serves no public traffic (CF routes api.kortix.com → EKS), so zero user impact. Reliability refactor (dead-weight-leader fix + sweep watchdog + staleness alert) follows as a separate PR.