### PR TITLE
fix(api-image): resolve @kortix/shared/llm-catalog subpath in API image (dev crashloop hotfix)

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -113,12 +113,10 @@ COPY --from=deps /app/node_modules ./node_modules
 
 # Copy workspace packages — source only, skip nested node_modules
 # which may contain stale symlinks to the .pnpm store.
-COPY --from=deps /app/packages/shared/src ./packages/shared/src
-COPY --from=deps /app/packages/shared/package.json ./packages/shared/package.json
-COPY --from=deps /app/packages/shared/tsconfig.json ./packages/shared/tsconfig.json
-COPY --from=deps /app/packages/llm-gateway/src ./packages/llm-gateway/src
-COPY --from=deps /app/packages/llm-gateway/package.json ./packages/llm-gateway/package.json
-COPY --from=deps /app/packages/llm-gateway/tsconfig.json ./packages/llm-gateway/tsconfig.json
+# Full dirs (not src-only): @kortix/llm-gateway resolves the @kortix/shared/llm-catalog
+# subpath transitively, which needs shared's package-resolution intact at runtime.
+COPY --from=deps /app/packages/shared ./packages/shared
+COPY --from=deps /app/packages/llm-gateway ./packages/llm-gateway
 COPY --from=deps /app/packages/db/src ./packages/db/src
 COPY --from=deps /app/packages/db/drizzle.config.ts ./packages/db/drizzle.config.ts
 COPY --from=deps /app/packages/db/package.json ./packages/db/package.json

--- a/infra/k8s/envs/dev/gateway-values.yaml
+++ b/infra/k8s/envs/dev/gateway-values.yaml
@@ -4,7 +4,7 @@
 
 # Immutable dev tag (CI bumps to dev-<sha8>). Bootstrap value until the first run.
 image:
-  tag: "dev-32e8aacc"
+  tag: "dev-44d05a4a"
 # Dev sizing (≤100 users): 1-replica floor, burst to 2.
 replicas: 1
 autoscaling:


### PR DESCRIPTION
## Hotfix — dev API crashloop

The post-merge dev API pod is in `CrashLoopBackOff`:
```
error: Cannot find module '@kortix/shared/llm-catalog' from '/app/packages/llm-gateway/src/catalog/resolver.ts'
```

### Cause
The API now depends on `@kortix/llm-gateway`, which imports the `@kortix/shared/llm-catalog` subpath. pnpm links that transitive workspace dep into `packages/llm-gateway/node_modules` as a symlink. The API Dockerfile copied these packages **src-only**, dropping the symlinks — so `llm-gateway` couldn't find `shared` at runtime. (The gateway image already copies them as full dirs, which is why `gateway-dev.kortix.com` is healthy.)

### Fix
Copy `packages/shared` and `packages/llm-gateway` as **full dirs** in the API runner stage (matching the gateway image).

### Verification
Built the API image locally and imported the exact failing module — both resolve clean:
- `@kortix/shared/llm-catalog` ✓
- `@kortix/llm-gateway` (pulls in resolver.ts → shared/llm-catalog) ✓

Merging this unblocks the dev API rollout.