### PR TITLE
ci: merge_group triggers (prep for main merge queue)

### DIFF
--- a/.github/workflows/package-tests.yml
+++ b/.github/workflows/package-tests.yml
@@ -3,6 +3,7 @@ name: Package Unit Tests
 on:
   pull_request:
     branches: [main, prod]
+  merge_group: # run in the GitHub merge queue (required checks)
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -9,6 +9,7 @@ name: secret-scan
 on:
   pull_request:
     branches: [main, prod]
+  merge_group: # run in the GitHub merge queue (required check)
 
 permissions:
   contents: read

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -32,8 +32,16 @@ jobs:
           tar -xzf gitleaks.tar.gz gitleaks
           ./gitleaks version
 
-      - name: Scan PR commits for secrets
+      - name: Scan changed commits for secrets
+        env:
+          BASE_SHA: ${{ github.event_name == 'merge_group' && github.event.merge_group.base_sha || github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event_name == 'merge_group' && github.event.merge_group.head_sha || github.event.pull_request.head.sha }}
         run: |
+          set -euo pipefail
+          if [ -z "$BASE_SHA" ] || [ -z "$HEAD_SHA" ]; then
+            echo "::error::Unable to determine commit range for ${GITHUB_EVENT_NAME}."
+            exit 1
+          fi
           ./gitleaks git \
-            --log-opts="${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}" \
+            --log-opts="${BASE_SHA}..${HEAD_SHA}" \
             --redact --verbose --exit-code 1


### PR DESCRIPTION
Sets up a **GitHub merge queue** on `main`, in two parts.

## This PR (safe — no behaviour change today)
Adds `merge_group:` triggers to the workflows carrying the **v1 required-check set**, so they run on the queue's batched commits (a required check that doesn't run on `merge_group` stalls the queue):
- **package-tests.yml** → `bun unit tests (packages + apps)`, `every change ships with tests`
- **secret-scan.yml** → `gitleaks`

These are deliberately **small, fast, deterministic** (all recently green), because the queue serializes merges — a slow/flaky required check would stall everyone. Held out of v1 (add once proven): CodeQL (~5m SaaS latency), `fast checks`/qa-pr (integration+testcontainers, slow), ci typecheck/build (path-conditional).

## Step 2 — enable the queue (repo ruleset, after this merges)
Run once this is in `main` (needs admin):
```bash
gh api -X POST repos/kortix-ai/suna/rulesets --input - <<'JSON'
{
  "name": "main — merge queue",
  "target": "branch",
  "enforcement": "active",
  "conditions": { "ref_name": { "include": ["refs/heads/main"], "exclude": [] } },
  "rules": [
    { "type": "required_status_checks", "parameters": {
        "strict_required_status_checks_policy": false,
        "required_status_checks": [
          { "context": "bun unit tests (packages + apps)" },
          { "context": "every change ships with tests" },
          { "context": "gitleaks" }
        ] } },
    { "type": "merge_queue", "parameters": {
        "merge_method": "SQUASH",
        "grouping_strategy": "ALLGREEN",
        "min_entries_to_merge": 1, "max_entries_to_merge": 5,
        "max_entries_to_build": 5,
        "min_entries_to_merge_wait_minutes": 5,
        "check_response_timeout_minutes": 60 } }
  ]
}
JSON
```
`SQUASH` matches how this repo merges. `ALLGREEN` only merges a batch if every entry is green. Tune `*_entries_*` later for throughput.

**Why now:** today's work made the previously-flaky required checks (embedded snapshot, CodeQL, infra, quality gate) deterministic and green — the prerequisite for a queue that doesn't stall.