### PR TITLE
fix(triggers): make the cron scheduler unwedgeable (timeouts + self-heal + no dead-weight leader)

### DIFF
--- a/apps/api/src/__tests__/unit-leader-election.test.ts
+++ b/apps/api/src/__tests__/unit-leader-election.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { interpretAcquireResult, shouldDemote } from '../shared/leader-election';
+import { interpretAcquireResult, runsSingletonWorkers, shouldDemote } from '../shared/leader-election';
 
 const ME = 'host-123-abc';
 const OTHER = 'host-999-xyz';
@@ -33,5 +33,50 @@ describe('shouldDemote', () => {
     const last = 1_000_000;
     expect(shouldDemote(last, last + 60_000, TTL)).toBe(true);
     expect(shouldDemote(last, last + 120_000, TTL)).toBe(true);
+  });
+});
+
+describe('runsSingletonWorkers (dead-weight-leader guard)', () => {
+  test('default (no flags set) → owner, so single-node/self-host still elects', () => {
+    expect(runsSingletonWorkers({})).toBe(true);
+  });
+
+  test('API-only profile (ALL four worker flags "false") → NOT an owner', () => {
+    // This is the helm workers.enabled=false profile. Such a pod must never join
+    // the election — otherwise it can win the lease and dead-weight-starve crons.
+    expect(
+      runsSingletonWorkers({
+        KORTIX_TRIGGER_SCHEDULER_ENABLED: 'false',
+        KORTIX_PROJECT_MAINTENANCE_ENABLED: 'false',
+        KORTIX_LEGACY_MIGRATION_WORKER_ENABLED: 'false',
+        KORTIX_SUNA_MIGRATION_WORKER_ENABLED: 'false',
+      }),
+    ).toBe(false);
+  });
+
+  test('any single worker still enabled → owner', () => {
+    expect(
+      runsSingletonWorkers({
+        KORTIX_TRIGGER_SCHEDULER_ENABLED: 'false',
+        KORTIX_PROJECT_MAINTENANCE_ENABLED: 'false',
+        KORTIX_LEGACY_MIGRATION_WORKER_ENABLED: 'false',
+        KORTIX_SUNA_MIGRATION_WORKER_ENABLED: 'true',
+      }),
+    ).toBe(true);
+  });
+
+  test('only the scheduler enabled (others off) → owner', () => {
+    expect(
+      runsSingletonWorkers({
+        KORTIX_TRIGGER_SCHEDULER_ENABLED: 'true',
+        KORTIX_PROJECT_MAINTENANCE_ENABLED: 'false',
+        KORTIX_LEGACY_MIGRATION_WORKER_ENABLED: 'false',
+        KORTIX_SUNA_MIGRATION_WORKER_ENABLED: 'false',
+      }),
+    ).toBe(true);
+  });
+
+  test('only literal "false" disables a flag — "0"/"no"/"" still count as on', () => {
+    expect(runsSingletonWorkers({ KORTIX_TRIGGER_SCHEDULER_ENABLED: '0' })).toBe(true);
   });
 });

--- a/apps/api/src/__tests__/unit-trigger-scheduler-reliability.test.ts
+++ b/apps/api/src/__tests__/unit-trigger-scheduler-reliability.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from 'bun:test';
+import { isSweepStale, withTimeout } from '../projects/lib/triggers';
+
+// These primitives are what keep one hung trigger fire from freezing the entire
+// cron scheduler — the 2026-06-21 fleet-wide outage, where a single
+// continueSession hung forever inside a sequential, un-timed sweep and every
+// cron stopped firing for ~18h with no error.
+
+describe('withTimeout', () => {
+  test('resolves with the value when the promise settles before the timeout', async () => {
+    expect(await withTimeout(Promise.resolve(42), 1000, 'fast')).toBe(42);
+  });
+
+  test('rejects with a labelled timeout error when the promise hangs past ms', async () => {
+    const hang = new Promise<never>(() => {}); // never settles — models a hung fire
+    await expect(withTimeout(hang, 20, 'stuck fire')).rejects.toThrow(/stuck fire timed out after 20ms/);
+  });
+
+  test('a slow-but-completing promise still resolves (no false timeout)', async () => {
+    const slow = new Promise<string>((res) => setTimeout(() => res('done'), 10));
+    expect(await withTimeout(slow, 500, 'slow')).toBe('done');
+  });
+
+  test('propagates the original rejection unchanged when the promise rejects first', async () => {
+    const boom = Promise.reject(new Error('real failure'));
+    await expect(withTimeout(boom, 500, 'x')).rejects.toThrow('real failure');
+  });
+});
+
+describe('isSweepStale (scheduler stall detection)', () => {
+  const T0 = 1_700_000_000_000;
+  const STALE = 300_000; // 5 min window
+
+  test('never stale when this pod is not the leader', () => {
+    expect(
+      isSweepStale({ isLeader: false, lastSweepStartedAt: null, lastSweepCompletedAt: null, nowMs: T0, staleMs: STALE }),
+    ).toBe(false);
+  });
+
+  test('grace: leader but the scheduler has not ticked yet (no start) → not stale', () => {
+    expect(
+      isSweepStale({ isLeader: true, lastSweepStartedAt: null, lastSweepCompletedAt: null, nowMs: T0, staleMs: STALE }),
+    ).toBe(false);
+  });
+
+  test('healthy: leader with a recently completed sweep → not stale', () => {
+    expect(
+      isSweepStale({
+        isLeader: true,
+        lastSweepStartedAt: new Date(T0 - 30_000).toISOString(),
+        lastSweepCompletedAt: new Date(T0 - 29_000).toISOString(),
+        nowMs: T0,
+        staleMs: STALE,
+      }),
+    ).toBe(false);
+  });
+
+  test('WEDGE: leader, a sweep started but never completed → stale (the outage signature)', () => {
+    expect(
+      isSweepStale({
+        isLeader: true,
+        lastSweepStartedAt: new Date(T0 - 20 * 60_000).toISOString(),
+        lastSweepCompletedAt: null,
+        nowMs: T0,
+        staleMs: STALE,
+      }),
+    ).toBe(true);
+  });
+
+  test('stale: leader whose last completed sweep is older than the stale window', () => {
+    expect(
+      isSweepStale({
+        isLeader: true,
+        lastSweepStartedAt: new Date(T0 - 11 * 60_000).toISOString(),
+        lastSweepCompletedAt: new Date(T0 - 10 * 60_000).toISOString(),
+        nowMs: T0,
+        staleMs: STALE,
+      }),
+    ).toBe(true);
+  });
+});

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -48,7 +48,7 @@ import { tunnelApp, wsHandlers as tunnelWsHandlers, startTunnelService, stopTunn
 import { accessControlApp } from './access-control';
 import { startAccessControlCache, stopAccessControlCache } from './shared/access-control-cache';
 import { startTmpReaper, stopTmpReaper } from './snapshots/tmp-reaper';
-import { startLeaderElection, stopLeaderElection, isLeader } from './shared/leader-election';
+import { startLeaderElection, stopLeaderElection, isLeader, runsSingletonWorkers } from './shared/leader-election';
 import { marketplaceApp } from './marketplace';
 import { oauthApp } from './oauth';
 import {
@@ -57,6 +57,7 @@ import {
   startProjectTriggerScheduler,
   stopProjectTriggerScheduler,
   getTriggerSchedulerHealth,
+  schedulerSweepIsStale,
 } from './projects';
 import { startProjectMaintenance, stopProjectMaintenance } from './projects/maintenance';
 import { kickStartupPreBuild } from './snapshots/builder';
@@ -403,7 +404,9 @@ const healthHandler = (c: any) =>
     // The leader pod's trigger-sweep heartbeat: when it last ran, how long it
     // took, and what it did. On a non-leader pod the fields are null (the sweep
     // only runs on the leader) — so "all pods null" = no leader = no triggers.
-    trigger_scheduler: getTriggerSchedulerHealth(),
+    // `stale` is true when we're the leader but the sweep has frozen (started
+    // and not completed within the stale window) — the signal to alert on.
+    trigger_scheduler: { ...getTriggerSchedulerHealth(), stale: schedulerSweepIsStale(isLeader()) },
   });
 
 app.openapi(
@@ -1031,10 +1034,20 @@ async function stopSingletonWorkers() {
 // (self-host single node → sole leader, no coordination).
 async function bootServices() {
   await startReplicaServices();
-  startLeaderElection({
-    onAcquire: () => startSingletonWorkers(),
-    onRelease: () => stopSingletonWorkers(),
-  });
+  // Only pods that actually run singleton workers join the election. An API-only
+  // pod (workers disabled) that won the lease would become a dead-weight leader,
+  // holding it while running nothing and starving the scheduler fleet-wide.
+  const eligible = runsSingletonWorkers();
+  if (!eligible) {
+    appLogger.info('[workers] API-only pod — singleton workers disabled; not joining leader election');
+  }
+  startLeaderElection(
+    {
+      onAcquire: () => startSingletonWorkers(),
+      onRelease: () => stopSingletonWorkers(),
+    },
+    { eligible },
+  );
 }
 
 // Graceful shutdown

--- a/apps/api/src/projects/index.ts
+++ b/apps/api/src/projects/index.ts
@@ -65,6 +65,7 @@ export {
   startProjectTriggerScheduler,
   stopProjectTriggerScheduler,
   getTriggerSchedulerHealth,
+  schedulerSweepIsStale,
   loadManifestForEdit,
   commitManifest,
 } from './lib/triggers';

--- a/apps/api/src/projects/lib/triggers.ts
+++ b/apps/api/src/projects/lib/triggers.ts
@@ -1,6 +1,7 @@
 import { config } from '../../config';
 import { auth, errors } from '../../openapi';
 import { db } from '../../shared/db';
+import { isLeader } from '../../shared/leader-election';
 import { runProjectAppSweep } from '../app-sweep';
 import { commitFileToBranch, invalidateProjectMirror } from '../git';
 import { commitFile, getFileSha, type GitHubAuthContext } from '../github';
@@ -147,6 +148,10 @@ export const globalForProjectTriggers = globalThis as typeof globalThis & {
 export let triggerSchedulerTimer: TriggerSchedulerTimer | null = null;
 
 export let triggerSweepRunning = false;
+// When the in-flight sweep started (epoch ms). Used to reclaim a stuck guard if
+// a sweep hangs past its hard cap, so a single frozen pass can't wedge the
+// scheduler forever (root cause of the 2026-06-21 fleet-wide cron outage).
+export let triggerSweepStartedMs = 0;
 
 // In-memory heartbeat for the trigger scheduler, surfaced at /health so an
 // operator can tell at a glance whether the leader's sweep is alive and what
@@ -168,6 +173,85 @@ const schedulerHealth: TriggerSchedulerHealth = {
 };
 export function getTriggerSchedulerHealth(): TriggerSchedulerHealth {
   return schedulerHealth;
+}
+
+// ─── Reliability: timeouts + stall detection ─────────────────────────────────
+// The 2026-06-21 fleet-wide cron outage: one trigger fire (continueSession
+// resuming a dead sandbox) hung forever inside a SEQUENTIAL sweep that awaited
+// it with no timeout, so the in-flight guard never cleared and EVERY cron
+// stopped firing for ~18h with no error. These bounds make a hung/slow fire
+// survivable: one trigger can fail, the rest of the fleet still fires, and the
+// scheduler can never wedge — no matter what.
+
+/** Hard cap on a single trigger fire (createSession/continueSession). */
+export function triggerFireTimeoutMs(): number {
+  const raw = Number(process.env.KORTIX_TRIGGER_FIRE_TIMEOUT_MS);
+  return Number.isFinite(raw) && raw > 0 ? Math.floor(raw) : 45_000;
+}
+/** Hard cap on loading one project's manifest from its git mirror. */
+export function triggerLoadTimeoutMs(): number {
+  const raw = Number(process.env.KORTIX_TRIGGER_LOAD_TIMEOUT_MS);
+  return Number.isFinite(raw) && raw > 0 ? Math.floor(raw) : 30_000;
+}
+/** Hard cap on a whole sweep pass — backstop so nothing can wedge the guard. */
+export function triggerSweepTimeoutMs(): number {
+  const raw = Number(process.env.KORTIX_TRIGGER_SWEEP_TIMEOUT_MS);
+  return Number.isFinite(raw) && raw > 0 ? Math.floor(raw) : 4 * 60_000;
+}
+
+/**
+ * Resolve `p`, or reject once `ms` elapses. The underlying work is NOT
+ * cancellable (JS has no promise cancellation), but rejecting lets the caller
+ * move on / clear its guard instead of blocking forever on a hung await.
+ */
+export async function withTimeout<T>(p: Promise<T>, ms: number, label: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      p,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+/**
+ * Pure stall check: are we the leader with a sweep that started but hasn't
+ * completed within `staleMs`? Surfaced at /health and used by the in-loop
+ * watchdog so a frozen scheduler is loud, not silent. Returns false before the
+ * first tick (grace right after promotion) and when not leader.
+ */
+export function isSweepStale(opts: {
+  isLeader: boolean;
+  lastSweepStartedAt: string | null;
+  lastSweepCompletedAt: string | null;
+  nowMs: number;
+  staleMs: number;
+}): boolean {
+  if (!opts.isLeader) return false;
+  if (!opts.lastSweepStartedAt) return false;
+  const lastDoneMs = opts.lastSweepCompletedAt ? Date.parse(opts.lastSweepCompletedAt) : 0;
+  return opts.nowMs - lastDoneMs > opts.staleMs;
+}
+
+function schedulerStaleMs(): number {
+  // Generous: several intervals OR one full sweep-timeout window, whichever is
+  // larger, so we never false-alarm on a legitimately long (but completing) pass.
+  return Math.max(5 * triggerSchedulerIntervalMs(), triggerSweepTimeoutMs() + triggerSchedulerIntervalMs());
+}
+
+/** Is the leader's trigger sweep stalled right now? (Wraps the pure check.) */
+export function schedulerSweepIsStale(isLeaderNow: boolean, nowMs: number = Date.now()): boolean {
+  return isSweepStale({
+    isLeader: isLeaderNow,
+    lastSweepStartedAt: schedulerHealth.lastSweepStartedAt,
+    lastSweepCompletedAt: schedulerHealth.lastSweepCompletedAt,
+    nowMs,
+    staleMs: schedulerStaleMs(),
+  });
 }
 
 // Connector reconcile sweep — runs on a slower cadence than the trigger sweep.
@@ -228,13 +312,27 @@ export async function runProjectTriggerSweep(now = new Date()): Promise<{
   failed: number;
   skipped: number;
 }> {
-  if (triggerSweepRunning) return { scanned: 0, fired: 0, queued: 0, failed: 0, skipped: 0 };
+  // In-flight guard with SELF-HEAL: a sweep that hangs past the hard cap must
+  // not freeze the scheduler forever. If the guard is held but the running sweep
+  // is older than its timeout, reclaim it so this tick starts a fresh pass.
+  if (triggerSweepRunning) {
+    if (Date.now() - triggerSweepStartedMs < triggerSweepTimeoutMs()) {
+      return { scanned: 0, fired: 0, queued: 0, failed: 0, skipped: 0 };
+    }
+    console.error(
+      `[project-triggers] reclaiming stuck sweep guard — previous sweep exceeded ${triggerSweepTimeoutMs()}ms without completing (self-heal)`,
+    );
+  }
   triggerSweepRunning = true;
   const startedMs = Date.now();
+  triggerSweepStartedMs = startedMs;
   schedulerHealth.lastSweepStartedAt = now.toISOString();
   const result = { scanned: 0, fired: 0, queued: 0, failed: 0, skipped: 0 };
   try {
-    await runGitTriggerSweep(now, result);
+    // Overall hard cap so a hang anywhere (project scan, mirror load, fire) can
+    // never block the guard indefinitely. The per-item timeouts inside the sweep
+    // keep one bad project/trigger from starving the rest within a single pass.
+    await withTimeout(runGitTriggerSweep(now, result), triggerSweepTimeoutMs(), 'project trigger sweep');
     schedulerHealth.lastError = null;
     return result;
   } catch (err) {
@@ -619,7 +717,13 @@ export async function runGitTriggerSweep(now: Date, accumulator: {
     if (triggersPausedForProject(project.metadata)) continue;
     let specs: GitTriggerSpec[];
     try {
-      const loaded = await loadProjectTriggers(await withProjectGitAuth(project));
+      // Time-bound the mirror load: a hung clone/fetch for one project must not
+      // stall the sweep for everyone else.
+      const loaded = await withTimeout(
+        loadProjectTriggers(await withProjectGitAuth(project)),
+        triggerLoadTimeoutMs(),
+        `load triggers ${project.projectId}`,
+      );
       specs = loaded.specs;
       // Surface parse errors instead of dropping them: record each bad entry
       // against its slug so it shows up in the triggers API/UI, and log it.
@@ -656,15 +760,37 @@ export async function runGitTriggerSweep(now: Date, accumulator: {
       };
       const renderedPrompt = renderPromptTemplate(spec.promptTemplate, payload);
       const scheduledAt = now.toISOString();
+      // Stable idempotency key per DUE SLOT (the cron boundary that made this
+      // trigger due), not per sweep tick — so a fire we timed out on but that
+      // actually lands late isn't duplicated when the next tick retries.
+      const dueSlotKey =
+        (spec.cron ? nextCronRun(spec.cron, lastFired ?? new Date(0), spec.timezone)?.toISOString() : spec.runAt) ??
+        scheduledAt;
 
-      const result = await fireGitTrigger({
-        spec,
-        project,
-        payload,
-        renderedPrompt,
-        source: 'cron',
-        idempotencyKey: `trigger:cron:${project.projectId}:${spec.slug}:${scheduledAt}`,
-      });
+      let result: Awaited<ReturnType<typeof fireGitTrigger>>;
+      try {
+        // Time-bound the fire (createSession/continueSession). A hung or throwing
+        // fire must NOT abort the sweep or wedge the scheduler: record it
+        // (diagnosable, retries next tick) and move on to the next trigger.
+        result = await withTimeout(
+          fireGitTrigger({
+            spec,
+            project,
+            payload,
+            renderedPrompt,
+            source: 'cron',
+            idempotencyKey: `trigger:cron:${project.projectId}:${spec.slug}:${dueSlotKey}`,
+          }),
+          triggerFireTimeoutMs(),
+          `fire ${spec.slug} ${project.projectId}`,
+        );
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error('[project-triggers/git] fire errored', project.projectId, spec.slug, msg);
+        await markGitTriggerAttemptFailed(project.projectId, spec.slug, now, msg).catch(() => {});
+        accumulator.failed += 1;
+        continue;
+      }
       if (result.status === 'fired') {
         await markGitTriggerFired(project.projectId, spec.slug, now, 'fired');
         accumulator.fired += 1;
@@ -693,6 +819,18 @@ export function startProjectTriggerScheduler(): void {
     clearInterval(globalForProjectTriggers.__kortixProjectTriggerSchedulerTimer);
   }
   triggerSchedulerTimer = setInterval(() => {
+    // Watchdog: if we're the leader but the sweep has stalled (started and never
+    // completed within the stale window), make it LOUD. A silent dead scheduler
+    // is what turned a single hung fire into an ~18h fleet-wide outage. The
+    // self-heal guard in runProjectTriggerSweep reclaims the stuck sweep on this
+    // same tick; this console.error is the alert signal for log-based monitoring.
+    if (schedulerSweepIsStale(isLeader())) {
+      console.error('[project-triggers] SCHEDULER STALLED — leader but last sweep has not completed', {
+        lastSweepStartedAt: schedulerHealth.lastSweepStartedAt,
+        lastSweepCompletedAt: schedulerHealth.lastSweepCompletedAt,
+      });
+    }
+
     drainSessionLifecycleQueue({ limit: 10 }).then((result) => {
       if (result.claimed || result.failed) {
         console.log('[session-lifecycle] queue drain completed', result);

--- a/apps/api/src/shared/leader-election.ts
+++ b/apps/api/src/shared/leader-election.ts
@@ -71,6 +71,29 @@ export function shouldDemote(
   return nowMs - lastRenewSuccessMs >= ttlMs;
 }
 
+/**
+ * Does this pod actually OWN singleton work, i.e. should it join the election?
+ *
+ * The helm "API-only" profile (workers.enabled=false) sets every KORTIX_*_ENABLED
+ * worker flag to "false" so the pod serves requests but runs no background loops.
+ * Such a pod MUST NOT join the election: election is independent of those flags,
+ * so a workers-disabled pod can win the shared lease and sit on it as a
+ * DEAD-WEIGHT leader — holding it, renewing it, running nothing — silently
+ * starving the cron scheduler fleet-wide with no error and no churn. That is what
+ * left an EKS API-only pod able to freeze every cron in the 2026-06-21 outage. A
+ * pod is an owner unless ALL four worker flags are explicitly "false"; default
+ * (unset) = owner, so single-node / self-host is unaffected.
+ */
+export function runsSingletonWorkers(env: NodeJS.ProcessEnv = process.env): boolean {
+  const on = (v: string | undefined) => v !== 'false';
+  return (
+    on(env.KORTIX_TRIGGER_SCHEDULER_ENABLED) ||
+    on(env.KORTIX_PROJECT_MAINTENANCE_ENABLED) ||
+    on(env.KORTIX_LEGACY_MIGRATION_WORKER_ENABLED) ||
+    on(env.KORTIX_SUNA_MIGRATION_WORKER_ENABLED)
+  );
+}
+
 // ─── Runtime state ───────────────────────────────────────────────────────────
 
 const ownerId = `${os.hostname()}-${process.pid}-${Math.random().toString(36).slice(2, 8)}`;
@@ -197,8 +220,19 @@ async function tick(): Promise<void> {
  * With no DATABASE_URL (self-host single node) there's nothing to coordinate, so
  * this node is the sole leader immediately.
  */
-export function startLeaderElection(h: LeaderElectionHandlers): void {
+export function startLeaderElection(
+  h: LeaderElectionHandlers,
+  opts: { eligible?: boolean } = {},
+): void {
   if (running) return;
+  // A pod that runs no singleton workers must never hold the lease (see
+  // runsSingletonWorkers): joining the election would let it become a
+  // dead-weight leader and starve the scheduler. Skip election entirely —
+  // isLeader() stays false and onAcquire is never called.
+  if (opts.eligible === false) {
+    logger.info('[leader] API-only pod (singleton workers disabled) — not joining election', { ownerId });
+    return;
+  }
   running = true;
   handlers = h;
 

--- a/infra/k8s/envs/prod/values.yaml
+++ b/infra/k8s/envs/prod/values.yaml
@@ -20,12 +20,16 @@ extraEnv:
   # catalog shape) and the model picker collapses to a single model.
   LLM_GATEWAY_BASE_URL: "https://gateway.kortix.com/v1/llm"
 
-# PRE-CUTOVER: api-eks is the candidate while api.kortix.com is still served by
-# ECS, so EKS runs API-only and ECS keeps ownership of the singleton workers
-# (one Postgres leader lease is shared across both). At cutover, flip this to
-# true here AND disable the ECS service — EKS then owns the background work.
+# CUTOVER COMPLETE (2026-06-21): api.kortix.com is served by api-eks, and EKS now
+# OWNS the singleton workers (cron scheduler, project maintenance, migrations).
+# ECS Fargate is scaled to 0 — it had held the worker lease while running stale
+# 0.9.63 code whose trigger sweep silently skipped every cron fleet-wide
+# (pre-#3530), so no cron fired for ~18h. One Postgres leader lease is shared, so
+# exactly one EKS pod is leader. KEEP THIS true. If ECS is ever brought back as a
+# standby it MUST stay workers-disabled (KORTIX_TRIGGER_SCHEDULER_ENABLED=false)
+# so it can never grab the worker lease and starve the scheduler again.
 workers:
-  enabled: false
+  enabled: true
 
 # Drizzle migrations as a PreSync hook before each rollout (gates the release on
 # schema). The hook (templates/migrate-job.yaml) is in place and ready, but is


### PR DESCRIPTION
## Why
The **2026-06-21 fleet-wide cron outage**: one trigger fire (`continueSession` resuming a dead sandbox) **hung forever** inside a **sequential sweep** that `await`ed each fire with **no timeout**, so `triggerSweepRunning` never cleared and **every cron across the fleet stopped firing for ~18h** with no error. PR #3530 made this *visible* (heartbeat showed a sweep that started and never completed) but never made it *survivable*.

Discovered live while completing the EKS cutover: even the fixed-code leader's first sweep hung on a fire → wedged. So this is a **required** fix, not just hardening.

## What
1. **Per-fire timeout + isolation** (`runGitTriggerSweep`): every `fireGitTrigger` is wrapped in `withTimeout` + `try/catch`. A hung/throwing fire is recorded (diagnosable, retries next tick) and the sweep **moves on** — one bad trigger can't starve the fleet. Mirror loads are time-bounded too. Idempotency key is now per **due-slot** (not per tick) so a timed-out-but-late fire isn't duplicated on retry.
2. **Overall sweep timeout + self-heal guard** (`runProjectTriggerSweep`): hard cap on a whole pass; a guard held past the cap is reclaimed. A hang anywhere can't freeze the scheduler forever.
3. **No dead-weight leader** (`leader-election` + `index`): an API-only pod (all worker flags off) no longer joins the election, so it can't win the shared lease and sit on it running nothing (how an EKS api-only pod could freeze every cron).
4. **Stall watchdog + `/health.trigger_scheduler.stale`**: the leader logs a loud error when its sweep freezes, and `/health` surfaces `stale` — a silent dead scheduler becomes an alert.

All timeouts env-tunable: `KORTIX_TRIGGER_{FIRE,LOAD,SWEEP}_TIMEOUT_MS`.

## Tests
19 new unit tests (`withTimeout`, `isSweepStale`, `runsSingletonWorkers`); full trigger + leader-election suites green (63 tests); `apps/api` typechecks clean.

## Context
Companion to the prod EKS cutover (PR #3622, already on `prod`) that moved the scheduler off stale ECS 0.9.63 onto fixed 0.9.68. This PR is what makes a hung fire survivable so the wedge can never recur.