### PR TITLE
docs: refresh EKS and migration runbooks

### DIFF
--- a/.claude/skills/migration/SKILL.md
+++ b/.claude/skills/migration/SKILL.md
@@ -1,120 +1,58 @@
 ---
 name: migration
-description: "How to change the database schema in this repo — Drizzle, and ONLY Drizzle. Covers the two-lane model (generated `kortix.*` DDL vs hand-written `--custom` SQL for functions/RLS/grants/backfills), every `db:*` command, and the mandatory safety drill: review the generated SQL, scan for destructive statements, validate, and apply to a throwaway DB first. Load WHENEVER you add/alter/drop a table, column, enum, index, or constraint; edit `packages/db/src/schema/*.ts`; write or apply anything under `packages/db/drizzle/**`; run `db:generate`/`db:migrate`; or plan a schema/data change. ENFORCES: Drizzle-only (never `db:push`/hand-applied SQL), every migration reviewed before apply, and ZERO data loss."
+description: "How to change the database schema in this repo. Current engine: node-pg-migrate, with SQL generated from Drizzle schema changes when possible. Load whenever you add/alter/drop a table, column, enum, index, constraint, RLS/function/grant, or any file under packages/db/migrations."
 ---
 
-# Migrations (Drizzle only)
+# Database migrations
 
-This repo's schema is owned by **Drizzle**, in `packages/db`. There is exactly
-one migration pipeline and one source of truth — never edit the live DB by hand,
-never run ad-hoc `ALTER`/`CREATE` against it, never use `drizzle-kit push`.
+The canonical, detailed runbook is `packages/db/MIGRATIONS.md`. This skill is a
+short safety wrapper; if anything here seems incomplete, trust that file and the
+current `package.json` scripts.
 
-- Schema source: `packages/db/src/schema/kortix.ts` (the `kortix` schema — the
-  only thing Drizzle diffs; `drizzle.config.ts` has `schemaFilter: ['kortix']`,
-  `tablesFilter: ['kortix.*']`).
-- Migration files: `packages/db/drizzle/*.sql` + the `meta/_journal.json` ledger
-  and `meta/*_snapshot.json` (the recorded schema state). All three are
-  committed and append-only.
-- New migrations get **timestamp-prefixed** filenames (`prefix: 'timestamp'`),
-  so two engineers branching off `main` don't both produce `0003_*.sql` and
-  collide. The `0000/0001/0002` files are the curated baseline.
+## Current model
 
-## THE RULES
+- **Engine:** node-pg-migrate, invoked by `packages/db/scripts/migrate.ts`.
+- **Schema source:** `packages/db/src/schema/kortix.ts` for the Drizzle-modeled
+  `kortix` schema.
+- **Migration files:** immutable SQL files in `packages/db/migrations/`, named
+  with a 17-digit UTC timestamp (`YYYYMMDDHHMMSSmmm_slug.sql`).
+- **Applied-state table:** `kortix_migrations.pgmigrations` (node-pg-migrate
+  tracks migration names; it does not checksum file contents).
+- **Deploy:** `deploy-dev.yml` and `deploy-prod.yml` run `pnpm --filter
+  @kortix/db migrate` before the EKS GitOps rollout. The disabled Helm PreSync
+  hook is not the live migration path.
 
-1. **Drizzle is the only way schema changes happen.** No `psql ... ALTER`, no
-   Supabase Studio edits, no `drizzle-kit push`. Every change is a committed
-   migration file applied by `db:migrate`.
-2. **Never `db:push`.** It diffs the live DB and applies directly with no file
-   and no review — it will silently DROP columns/tables to match the schema.
-   The script was removed on purpose. Don't add it back or run `bunx
-   drizzle-kit push`.
-3. **Read every generated migration before applying it.** `generate` is a
-   *diff*: if you removed or renamed something in `kortix.ts`, it emits
-   `DROP COLUMN` / `DROP TABLE` = permanent data loss. The file is the preview.
-4. **Zero data loss, always.** Apply to a throwaway/worktree DB first and verify
-   data survives, before dev, before prod. Renames and NOT-NULL additions use
-   the safe patterns below — never the naive drop+recreate Drizzle defaults to.
-5. **Migrations are forward-only and append-only.** Once a migration is applied
-   anywhere, never edit or delete its file — its hash is recorded in
-   `drizzle.__drizzle_migrations` and editing it breaks the checksum. To change
-   shipped schema, write a NEW migration.
-6. **Prod is gated.** The prod DB is live. Applying to prod requires showing the
-   exact SQL and getting explicit go-ahead first; probes against prod are
-   read-only until then. Choosing the target DB = picking `DATABASE_URL`; see
-   the `dotenvx-secrets` skill (local vs dev vs prod).
+## Rules
 
-## The two lanes
+1. Never edit a migration that has been applied anywhere. Write a new migration.
+2. Never use `drizzle-kit push` or hand-apply production DDL outside the migration
+   flow.
+3. Review every generated SQL file before it reaches a shared DB.
+4. Prefer expand/contract for destructive or compatibility-sensitive changes.
+5. Prod is live: show the exact SQL and get explicit go-ahead before any manual
+   prod migration action.
 
-Both lanes write files into `packages/db/drizzle/` and are applied together, in
-journal order, by one `db:migrate`.
+## Commands from repo root
 
-- **Lane A — generated (`kortix.*` tables).** Edit `packages/db/src/schema/
-  kortix.ts`, then `db:generate`. Drizzle authors the `CREATE/ALTER TABLE` DDL
-  for the `kortix` schema automatically.
-- **Lane B — hand-written (`--custom`).** Anything Drizzle can't author —
-  Postgres functions, RLS policies, GRANTs, triggers, extensions, data
-  backfills, or any object in `basejump`/`public`/`auth`/`storage`. Run
-  `db:generate --custom --name <desc>` to create an empty timestamped migration,
-  then write the SQL by hand with `--> statement-breakpoint` between statements.
+| Command | What it does |
+| --- | --- |
+| `pnpm migrate` | Apply pending migrations using node-pg-migrate. |
+| `pnpm migrate:status` | Dry-run/list pending migrations; exits non-zero if any are pending. |
+| `pnpm migrate:create <slug>` | Create an empty hand-written SQL migration. |
+| `pnpm migrate:generate <slug>` | Generate SQL from a `kortix.ts` schema change and update the Drizzle snapshot. |
+| `pnpm migrate:fake` | Mark pending migrations as applied without running them (for baselining existing envs). |
+| `pnpm migrate:lint` | Validate migration filename/order rules. |
 
-## Commands
+## Safe schema-change loop
 
-Run from `packages/db`, or from the repo root with `pnpm --filter @kortix/db
-<script>`. (There are no root-level `db:*` scripts.)
+1. Edit `packages/db/src/schema/kortix.ts` for schema-shape changes, or create a
+   hand-written migration for data/RLS/functions/grants/custom SQL.
+2. Run `pnpm migrate:generate <slug>` or `pnpm migrate:create <slug>`.
+3. Read the SQL top-to-bottom. Stop on accidental `DROP`, unsafe type changes,
+   immediate `NOT NULL` on populated tables, or non-idempotent backfills.
+4. Run `pnpm migrate:lint` and the relevant package tests/checks.
+5. Apply to a local/throwaway DB before dev/prod when the change is non-trivial.
+6. Commit both the migration SQL and any generated Drizzle snapshot changes.
 
-| Command | Needs DB? | What it does |
-| --- | --- | --- |
-| `pnpm --filter @kortix/db db:generate` | no (offline, diffs snapshots) | Diff `kortix.ts` vs the last snapshot → write a new timestamped migration + update `_journal.json` + snapshot. |
-| `pnpm --filter @kortix/db db:generate --custom --name <desc>` | no | Create an **empty** timestamped migration to hand-write (functions/RLS/grants/backfills). |
-| `pnpm --filter @kortix/db db:check` | no | Validate the migration set is consistent (journal/snapshots intact, no conflicts). Run after every generate. |
-| `pnpm --filter @kortix/db db:migrate` | **yes** (`DATABASE_URL`) | Apply all pending migrations and record them in `drizzle.__drizzle_migrations`. |
-| `pnpm --filter @kortix/db db:studio` | yes | Browse the DB to verify data after applying. |
-
-`DATABASE_URL` selects the target: local Supabase for `pnpm dev`, the worktree's
-Postgres in a worktree, or the dev/prod URL via `dotenvx` (prod = gated).
-Worktrees run `db:migrate` automatically on create/start, so the usual loop is:
-edit schema → `db:generate` → review → let the worktree apply it.
-
-## The pre-apply drill (run EVERY time, before `db:migrate`)
-
-1. **Generate, then open the file.** `db:generate`, then read the new
-   `packages/db/drizzle/<timestamp>_*.sql` top to bottom. Confirm it contains
-   only the change you intended.
-2. **Scan for destructive statements.** Grep the new migration for:
-   `DROP TABLE`, `DROP COLUMN`, `DROP CONSTRAINT`, `TRUNCATE`,
-   `ALTER COLUMN ... TYPE`, `SET NOT NULL`, `DROP DEFAULT`, dropping an enum
-   value. Any hit → stop and apply the safe pattern below; do not apply as-is.
-3. **Check consistency.** `db:check` — must pass.
-4. **Apply to a throwaway DB first.** A worktree (`pnpm worktree create …`) or
-   local Supabase. Confirm it applies with no error AND data is intact
-   (`db:studio` / a `psql` count on affected tables).
-5. **Diff the snapshot.** Ensure `meta/*_snapshot.json` changed only as expected.
-6. **Only then** widen to dev; and to prod **only** after showing the SQL and
-   getting explicit go-ahead.
-
-## No-data-loss patterns
-
-- **Rename a column/table.** Drizzle models a rename as drop+create (data loss).
-  Either hand-edit the generated migration to `ALTER TABLE … RENAME COLUMN old
-  TO new;`, or do expand/contract: add the new column → backfill → switch the
-  app → drop the old column in a *later* migration.
-- **Add a NOT NULL column to a populated table.** A bare `ADD COLUMN … NOT NULL`
-  fails on non-empty tables. Add it nullable (or `DEFAULT <v>`), backfill in a
-  `--custom` migration, then `SET NOT NULL` in a follow-up.
-- **New UNIQUE / PRIMARY KEY on existing data.** Verify there are no duplicates
-  first (the migration aborts mid-apply otherwise).
-- **Type changes.** `ALTER COLUMN … TYPE` can fail or truncate. Prefer add-new +
-  backfill + drop-old over an in-place narrowing cast.
-- **Backfills.** Put them in their own `--custom` migration, idempotent where
-  possible (`WHERE col IS NULL`, `IF NOT EXISTS`), safe to re-run.
-- **Ordering.** Dependent + destructive changes must be ordered so each
-  intermediate state is valid; split statements with `--> statement-breakpoint`.
-
-## Don't
-
-- Don't `drizzle-kit push` or hand-apply SQL to any DB.
-- Don't edit or delete an already-applied migration file or its snapshot/journal
-  entry — write a new migration instead.
-- Don't point `db:migrate` at prod without showing the SQL and getting the go.
-- Don't manage `basejump`/`public`/`auth`/`storage` objects in `kortix.ts` —
-  those are Lane B (`--custom`), outside Drizzle's `tablesFilter`.
+See `packages/db/MIGRATIONS.md` for the full baseline, preview/prod behavior,
+self-hosting command, and failure drill.

--- a/.claude/skills/worktree/SKILL.md
+++ b/.claude/skills/worktree/SKILL.md
@@ -53,15 +53,15 @@ git -C "$WT" add -A && git -C "$WT" commit -m "..."
 
 When the branch is merged/pushed and you're done: `pnpm worktree nuke <feat>`.
 
-## Prerequisite: the base branch must carry Drizzle migrations
+## Prerequisite: the base branch must carry database migrations
 
-`create` builds the schema with `pnpm db:migrate` and **fails loudly** if the
-base ref has no Drizzle migrations (`packages/db/drizzle/*.sql`). Fork from a
-base that has them. If you see *"schema not built — branch X has no Drizzle
-migrations"*, recreate with `--from <branch-with-migrations>` (e.g.
-`--from migrations/drizzle-rebuild`, or merge that into `main` first). The
-default base is `HEAD`, so if you're already on a branch that has the
-migrations, plain `create` inherits them.
+Current migrations live in `packages/db/migrations` and are applied with
+node-pg-migrate (`pnpm --filter @kortix/db migrate`; see
+`packages/db/MIGRATIONS.md`). The worktree runner still has an open bug from the
+cutover where it calls the old `db:migrate` script and emits Drizzle-era error
+text; if worktree schema setup fails there, track/fix
+https://github.com/kortix-ai/suna/issues/3630 rather than treating the old command
+as authoritative.
 
 ## All commands (non-interactive)
 
@@ -79,7 +79,7 @@ pnpm worktree create <n>        [flags]   # positional name also works
 | --- | --- | --- |
 | `--name <n>` / positional `<n>` | — (required) | Worktree name → branch name + `kortix-wt-<n>` Supabase project. |
 | `--branch <b>` | `<n>` | Branch to use. If it already exists it's checked out; otherwise created from `--from`. |
-| `--from <ref>` | `HEAD` | Base ref for a newly created branch. Must carry Drizzle migrations (see above). |
+| `--from <ref>` | `HEAD` | Base ref for a newly created branch. Must carry current `packages/db/migrations` (see above). |
 | `--no-start` | off | **Provision only, don't boot servers.** Use this for agent/CI runs. |
 | `--yes` | off | Auto-install missing deps; non-interactive. |
 | `--no-tunnel` | off | Skip the Cloudflare tunnel (offline; cloud sandboxes won't be reachable). |
@@ -87,9 +87,9 @@ pnpm worktree create <n>        [flags]   # positional name also works
 What it does, in order: toolchain preflight → allocate the lowest free slot
 (probing ports, skipping any in use) → `git worktree add` (new branch from
 `--from`, or checkout existing `--branch`) → render an isolated Supabase project
-→ `pnpm install` into the worktree's own store → `supabase start` → `pnpm
-db:migrate` → verify the `kortix` schema exists → (unless `--no-start`) boot the
-stack. Re-running `create` for an existing name resumes it idempotently.
+→ `pnpm install` into the worktree's own store → `supabase start` → apply
+database migrations → verify the `kortix` schema exists → (unless `--no-start`)
+boot the stack. Re-running `create` for an existing name resumes it idempotently.
 
 ### `start` — boot an existing worktree (FOREGROUND, BLOCKS)
 

--- a/docs/CI_CD.md
+++ b/docs/CI_CD.md
@@ -13,16 +13,17 @@ PR opened ─┬─ ci.yml ............. build/typecheck per app + Trivy fs + de
            ├─ codeql.yml ......... SAST (security-and-quality)
            └─ secret-scan.yml .... gitleaks on the PR range
                  │  (all must pass)
-merge to main ─── qa-main.yml ..... e2e·visual·a11y (vs deployed target) + migration + publish Allure
+merge to main ─── deploy-dev.yml ... build image + node-pg-migrate dev DB + GitOps dev roll
+                  qa-main.yml ..... e2e·visual·a11y (vs deployed target) + migration checks + publish Allure
                  │
 nightly cron ──── qa-nightly.yml .. performance(k6)·DAST(ZAP)·pentest·mutation·chaos·static-security
                  │
 PR → prod ─────── qa-release.yml .. full suite in sequence + gates (blocking pre-prod)
                  │  promote.yml gates on all-green check-runs
-merge to prod ─── deploy-prod.yml . retag dev→version images, publish, deploy
+merge to prod ─── deploy-prod.yml . retag dev→version images, node-pg-migrate prod DB, publish, GitOps prod roll
 ```
 
-Deploy lanes: `deploy-dev.yml` (push→dev, Trivy CRITICAL gate + SBOM + cosign), `deploy-preview.yml` (PR→Vercel preview), `deploy-prod.yml`, `hotfix-prod.yml` (break-glass — see below). IaC: `terraform-ci.yml`, `drata-compliance.yml`, `security-scan.yml` (weekly).
+Deploy lanes: `deploy-dev.yml` (push→dev, Trivy CRITICAL gate + SBOM + cosign + dev DB migrations + EKS GitOps), `deploy-preview.yml` (PR→Vercel preview), `deploy-prod.yml` (prod DB migrations + EKS GitOps), `hotfix-prod.yml` (break-glass — see below). IaC: `terraform-ci.yml`, `drata-compliance.yml`, `security-scan.yml` (weekly).
 
 ## Emergency hotfix (break-glass)
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -44,8 +44,9 @@ Please include affected version/commit, reproduction steps, impact, and any PoC.
 1. Report received at the security contact and acknowledged.
 2. Triaged and severity-rated (CVSS); a private tracking issue is opened.
 3. Fix developed and merged to `main`, exercised on dev.
-4. Promoted to `prod` (`promote` → `deploy-prod` / `deploy-prod-eks`), Argo CD
-   rolls EKS. Affected secrets are rotated (see ADR-004) if exposure is suspected.
+4. Promoted to `prod` (`promote` opens the release PR; merge triggers
+   `deploy-prod`), Argo CD rolls EKS. Affected secrets are rotated (see ADR-004)
+   if exposure is suspected.
 5. A `vX.Y.Z` release and advisory are published; reporter credited.
 
 ## Security Controls In Place

--- a/docs/WHATS_MISSING.md
+++ b/docs/WHATS_MISSING.md
@@ -41,10 +41,11 @@ feature works.
   cutover**, simultaneously with disabling the corresponding ECS service (one
   Postgres leader lease is shared across ECS+EKS). Premature flip = double
   singleton workers.
-- **`migrate.enabled: false`** on prod — the Drizzle migrate PreSync hook is off
-  until the prod Drizzle ledger is baselined (prod schema was built out-of-band;
-  `drizzle.__drizzle_migrations` records 1 of 11). Needs a one-time gated baseline
-  (`migration` skill) before enabling.
+- **Disabled Helm migration hook drift** — live dev/prod migrations are applied
+  by GitHub Actions `migrate-db` jobs with node-pg-migrate before EKS rolls. The
+  chart-level `migrate.enabled` hook remains disabled and still points at the old
+  Drizzle-era command; port or remove it before anyone enables it
+  (https://github.com/kortix-ai/suna/issues/3628).
 - **Grafana admin / OIDC + `devops.<domain>` ingress** — Grafana has no real
   admin secret in git and no SSO root-url yet; it serves behind a tunnel today.
   Headlamp's `devops.<domain>` OIDC ingress is "Phase 3" in

--- a/docs/runbooks/deployment-procedure.md
+++ b/docs/runbooks/deployment-procedure.md
@@ -34,8 +34,9 @@ Steps:
 1. Open a PR into `main`. `ci.yml`, `codeql.yml`, `secret-scan.yml` run.
 2. Merge. The `deploy-dev.yml` workflow (`.github/workflows/deploy-dev.yml`)
    triggers on the push to `main`. Only surfaces whose paths changed rebuild
-   (path-filtered: `apps/api`, `packages`, `supabase/migrations`, lockfiles,
-   `VERSION`, etc.).
+   (path-filtered: `apps/api`, `packages`, `packages/db/migrations`, lockfiles,
+   `VERSION`, etc.). If the API surface changed, the `migrate-db` job applies
+   pending node-pg-migrate migrations against dev before the GitOps rollout.
 3. The `deploy-api` job (name: **Deploy API to dev (EKS / GitOps)**) builds and
    pushes `kortix/kortix-api:dev-<sha8>`, then bumps
    `infra/k8s/envs/dev/values.yaml` `image.tag` to that immutable tag and commits
@@ -99,6 +100,9 @@ Steps:
      `:latest` (no rebuild — what was tested on dev is what ships).
    - `version` / CLI / desktop jobs: cut the GitHub Release `vX.Y.Z` (desktop is
      best-effort, never blocks).
+   - `migrate-db` job: applies pending `packages/db/migrations` with
+     node-pg-migrate (`pnpm --filter @kortix/db migrate`) against prod before any
+     new API pods serve.
    - `deploy-api` job (name: **Deploy API to prod (EKS / GitOps)**): assumes
      `arn:aws:iam::935064898258:role/kortix-gha-eks-deploy`, runs `aws eks
      update-kubeconfig --name kortix-prod-eks --region eu-west-2`, and **watches**
@@ -137,11 +141,11 @@ curl -fsS https://api-eks.kortix.com/v1/health | jq .version       # → "X.Y.Z"
 
 ## Notes & gotchas
 
-- **Migrations**: the Drizzle migrate PreSync hook
-  (`templates/migrate-job.yaml`) is **`migrate.enabled: false` on prod** until
-  the prod Drizzle ledger is baselined (prod schema was built out-of-band). Do
-  not flip it without the gated baseline — see `infra/k8s/envs/prod/values.yaml`
-  and the `migration` skill.
+- **Migrations**: live dev/prod deploys use the GitHub Actions `migrate-db` jobs
+  and node-pg-migrate (`packages/db/MIGRATIONS.md`), before the EKS GitOps roll.
+  The chart-level PreSync hook is disabled and still reflects the old Drizzle
+  path; do **not** enable `migrate.enabled` until the hook is ported or removed
+  (https://github.com/kortix-ai/suna/issues/3628).
 - **Preview envs**: per-PR ephemeral APIs deploy via the Argo CD ApplicationSet
   (`infra/k8s/argocd/applicationsets/preview.yaml`) into `kortix-pr-<n>`
   namespaces on dev-eks when a PR is labelled `preview`. See `docs/ONBOARDING.md`.

--- a/infra/CICD.md
+++ b/infra/CICD.md
@@ -8,7 +8,7 @@ branches, one version number, four artifacts.
 ## TL;DR
 
 - **`main`** = DEV. Every push auto-deploys to dev.
-- **`prod`** = PROD. Only advanced by the **Promote** button; deploys the new ECS stack.
+- **`prod`** = PROD. Only advanced by the **Promote** button + reviewed release PR; deploys EKS by GitOps.
 - **`VERSION`** file (repo root) = one number for the whole platform.
 - A release = one `vX.Y.Z` GitHub Release bundling **API + Frontend + CLI + Desktop**.
 - **Retag, don't rebuild**: prod ships the exact image bytes tested on dev.
@@ -17,11 +17,11 @@ branches, one version number, four artifacts.
 PR ─► ci · codeql · secret-scan
  │ merge
  ▼
-main (DEV) ──push──► dev-api.kortix.com (ECS) + dev.kortix.com (Vercel) + CLI dev-latest
+main (DEV) ──push──► dev-api.kortix.com (Worker → EKS) + dev.kortix.com (Vercel) + CLI dev-latest
  │
- │  "Promote to Production"  (bump VERSION · tag vX.Y.Z · fast-forward prod)
+ │  "Promote to Production"  (open release/vX.Y.Z PR into prod; nothing publishes yet)
  ▼
-prod (PROD) ─push─► api-prod.kortix.com (ECS) + kortix.com (Vercel)
+prod (PROD) ─push─► api.kortix.com (Worker → EKS) + kortix.com (Vercel)
                     + GitHub Release vX.Y.Z (CLI + desktop) + Docker :X.Y.Z/:latest
 ```
 
@@ -35,14 +35,14 @@ There is no per-component version.
 | Context        | Version string        | How it gets there                                            |
 | -------------- | --------------------- | ------------------------------------------------------------ |
 | Dev (on main)  | `0.9.0-dev.<sha8>`    | `deploy-dev` build-args / env, computed from `VERSION` + sha |
-| Release (prod) | `0.9.0`               | `promote` writes `VERSION`; `deploy-prod` stamps it          |
-| Git tag        | `v0.9.0`              | created by `promote`                                         |
+| Release (prod) | `0.9.0`               | `promote` writes `VERSION` on the release PR; `deploy-prod` stamps it after merge |
+| Git tag        | `v0.9.0`              | created by `deploy-prod` after the release PR merges         |
 
 **Where each surface reports it:**
 
 - **API** — `GET /v1/health` → `version`. Reads `process.env.KORTIX_VERSION`
-  (baked into the image via the Dockerfile `ARG KORTIX_VERSION`; prod overrides
-  it to the clean `X.Y.Z` via the ECS task-def env).
+  (baked into the image via the Dockerfile `ARG KORTIX_VERSION`; prod also stamps
+  `infra/k8s/envs/prod/values.yaml` `kortixVersion` so EKS reports clean `X.Y.Z`).
   - ⚠️ This is a **separate** var from `SANDBOX_VERSION`. `SANDBOX_VERSION` is
     load-bearing for sandbox snapshot content-hashing — never repurpose it for the
     app version or every project's sandbox image rebuilds.
@@ -76,19 +76,18 @@ There is no per-component version.
 | `ci.yml`          | PR → main/prod                       | typecheck · web build · sandbox/cli/desktop smoke                   |
 | `codeql.yml`      | push/PR main+prod, weekly            | SAST                                                                |
 | `secret-scan.yml` | PR → main/prod                       | gitleaks                                                            |
-| `deploy-dev.yml`  | push → `main`                        | build+push dev API/frontend images, roll ECS `kortix-dev`, publish CLI `dev-latest` |
+| `deploy-dev.yml`  | push → `main`                        | build+push dev API/frontend images, run dev DB migrations, bump EKS GitOps values, publish CLI `dev-latest` |
 | `desktop.yml`     | push → main (`apps/desktop/**`) / dispatch | signed desktop installers → `desktop-dev-latest`              |
-| `promote.yml`     | manual dispatch                      | bump `VERSION` · tag `vX.Y.Z` · fast-forward `prod`                 |
-| `deploy-prod.yml` | push → `prod`                        | retag images → `:X.Y.Z`+`:latest`, cut Release, roll ECS `kortix-prod` |
-| `deploy-prod-eks.yml` | push → `prod`                    | PARALLEL EKS path: `helm upgrade` `kortix-api` on `kortix-prod-eks` → `api-eks.kortix.com` (no-ops until the EKS stack is applied; never touches ECS). See `infra/EKS.md`. |
+| `promote.yml`     | manual dispatch                      | open a reviewed `release/vX.Y.Z` PR into `prod`; no tag/release/deploy until merge |
+| `deploy-prod.yml` | push → `prod`                        | retag images → `:X.Y.Z`+`:latest`, run prod DB migrations, cut Release, watch EKS GitOps rollout |
 
 ### Path-filtering (deploy-dev)
 
 Only the surfaces whose paths changed rebuild:
 
 - **api**: `apps/api`, `apps/kortix-sandbox-agent-server`, `apps/sandbox`,
-  `apps/cli` (baked into the image), `packages`, `supabase/migrations`
-  (run by `ensureSchema` at boot — must redeploy to apply), lockfiles, `VERSION`.
+  `apps/cli` (baked into the image), `packages`, `packages/db/migrations`
+  (applied by the `migrate-db` jobs before the EKS roll), lockfiles, `VERSION`.
 - **frontend**: `apps/web`, `packages`, lockfiles, `VERSION`.
 - **cli**: `apps/cli`, `packages/starter`, `scripts/install.sh`, lockfiles, `VERSION`.
 
@@ -96,8 +95,9 @@ A docs-only push to main = a no-op CI run.
 
 ### Two deploy mechanisms (always parallel on a main push)
 
-- **Backend** (dev-api / api-prod): GitHub Actions → **ECS Fargate** roll (OIDC,
-  role `kortix-gha-ecs-deploy`).
+- **Backend** (dev-api / api): GitHub Actions builds/retags images and bumps
+  `infra/k8s/envs/<env>/values.yaml`; Argo CD rolls EKS. ECS Fargate remains a
+  warm standby behind the Cloudflare Worker, not the primary deploy path.
 - **Frontend** (dev.kortix.com / kortix.com): **Vercel git integration** —
   auto-builds from the branch, *not* a workflow step.
 
@@ -115,12 +115,13 @@ best-effort. Desktop can never block or delay a release.
 
 1. Actions → **Promote to Production** → Run workflow.
 2. Pick a `bump` (patch/minor/major) — or set an explicit `version`.
-3. It bumps `VERSION`, commits to `main`, tags `vX.Y.Z`, and fast-forwards `prod`.
-4. The push to `prod` triggers `deploy-prod.yml`:
+3. It freezes `release/vX.Y.Z`, stamps `VERSION` / `RELEASE_NOTES.md` /
+   `RELEASE_SOURCE_SHA`, bumps prod GitOps values, and opens a PR into `prod`.
+4. A reviewer merges the PR. The push to `prod` triggers `deploy-prod.yml`:
    - retag dev images → `:X.Y.Z` + `:latest` (no rebuild)
    - build prod CLI (clean version) → cut **GitHub Release `vX.Y.Z`**
-   - register a task-def revision stamping `KORTIX_VERSION=X.Y.Z` → roll
-     `kortix-prod` ECS (api-prod reports the clean version)
+   - run node-pg-migrate against prod before pods roll
+   - watch Argo CD roll `kortix-prod` on EKS (api reports the clean version)
    - attach desktop installers (best-effort)
    - Vercel auto-deploys `prod` → kortix.com
 
@@ -132,14 +133,15 @@ release; `KORTIX_CHANNEL=dev` → `dev-latest` prerelease.
 
 ## Environments & hosts
 
-| Env  | Branch | Frontend                | API (ECS Fargate)                  |
+| Env  | Branch | Frontend                | Public API                         |
 | ---- | ------ | ----------------------- | ---------------------------------- |
-| DEV  | `main` | dev.kortix.com (Vercel) | dev-api.kortix.com → `kortix-dev`  |
-| PROD | `prod` | kortix.com (Vercel)     | api-prod.kortix.com → `kortix-prod`|
+| DEV  | `main` | dev.kortix.com (Vercel) | dev-api.kortix.com → Worker → EKS `kortix-dev` |
+| PROD | `prod` | kortix.com (Vercel)     | api.kortix.com → Worker → EKS `kortix-prod` |
 
-AWS: account `935064898258`, region `us-west-2`. State in S3
-(`kortix-terraform-state` + DynamoDB locks). Terraform under `infra/terraform`
-(modules `network`, `acm-cloudflare`, `cloudflare-dns`, `ecs-api`).
+AWS: account `935064898258`; dev EKS runs in `us-west-2`, prod EKS in
+`eu-west-2`. Terraform state lives in S3 (`kortix-terraform-state` + DynamoDB
+locks). Terraform under `infra/terraform` owns EKS, ECS standby, networking,
+ACM/Cloudflare DNS, and platform add-ons.
 
 ### api.kortix.com — the Cloudflare Worker cutover switch
 
@@ -148,18 +150,13 @@ whose `ACTIVE_BACKEND` plain-text var selects the origin:
 
 ```
 api.kortix.com ─► api-kortix-router Worker ─► ACTIVE_BACKEND
-    new          → new-api.kortix.com   (old Lightsail box, v0.8.x)   ← live now
-    ecs-fargate  → api-prod.kortix.com  (new ECS prod stack)          ← ready
-    eks          → api-eks.kortix.com   (EKS prod stack)              ← parallel, see infra/EKS.md
+    eks          → api-eks.kortix.com          ← live primary
+    ecs-fargate  → api-ecs-fargate.kortix.com  ← warm standby
 ```
 
-**Apex cutover = flip `ACTIVE_BACKEND` → `ecs-fargate`** (one Worker var; instant,
-sub-second, fully reversible — flip back to `new` to roll back). No DNS surgery.
-The EKS stack (`infra/EKS.md`) adds an `eks` backend on the same switch: prove it
-under `api-eks.kortix.com`, then flip `ACTIVE_BACKEND → eks`; roll back to
-`ecs-fargate` anytime. ECS keeps running in parallel until EKS is proven.
-`kortix.com` (Vercel) will likewise be pointed at the `prod`-branch frontend at
-cutover. Until then api.kortix.com / kortix.com stay on the old box, untouched.
+Failover = flip `ACTIVE_BACKEND` to `ecs-fargate` (one Worker var; instant and
+reversible), then flip back to `eks` after recovery. Verify with the `X-Backend`
+header on `/v1/health`. ECS stays available as standby; EKS is the primary path.
 
 ---
 
@@ -168,9 +165,9 @@ cutover. Until then api.kortix.com / kortix.com stay on the old box, untouched.
 - **`SANDBOX_VERSION` ≠ app version.** It hashes sandbox snapshots; changing it
   rebuilds every project's image. App version uses `KORTIX_VERSION`.
 - **Retag, never rebuild** between dev and prod — what you tested is what ships.
-- **OIDC role perms**: `kortix-gha-ecs-deploy` needs `ecs:UpdateService`,
-  `RegisterTaskDefinition`, `DescribeTaskDefinition`, and `iam:PassRole` on the
-  task/exec roles (granted for both `kortix-dev` and `kortix-prod`).
+- **OIDC role perms**: the EKS deploy roles (`kortix-gha-eks-deploy-dev` /
+  `kortix-gha-eks-deploy`) need cluster read/watch access plus contents write
+  where the workflow pushes GitOps value changes.
 - **Concurrency zombies**: `deploy-prod` has `cancel-in-progress: false`; a stuck
   queued run blocks new ones. Cancel the zombie, then re-dispatch.
 - **`.env` files** (`apps/api/.env`, `apps/web/.env`) are gitignored, multi-profile

--- a/infra/EKS.md
+++ b/infra/EKS.md
@@ -1,10 +1,9 @@
-# Kortix API on EKS (prod) — `api-eks.kortix.com`
+# Kortix API on EKS — `api-eks.kortix.com` / `dev-api-eks.kortix.com`
 
-A production EKS stack for the Kortix API that runs **in parallel** with the
-existing ECS prod stack. Nothing here touches ECS: dev stays on ECS, prod ECS
-keeps serving `api-prod` / `api.kortix.com`, and EKS comes up under
-`api-eks.kortix.com`. Once EKS is proven in prod, `api.kortix.com` is flipped to
-it via the existing Cloudflare Worker switch — instantly and reversibly.
+EKS is the active API runtime for prod and dev (`X-Backend: eks` on
+`api.kortix.com/v1/health` and `dev-api.kortix.com/v1/health`, verified
+2026-06-21). ECS Fargate remains available as the Cloudflare Worker warm standby;
+do not delete it as "legacy" while it is still the failover origin.
 
 ## Why EKS, and why it auto-heals better
 
@@ -52,14 +51,15 @@ infra/terraform/
   environments/prod-eks/
     cluster/                 # state 1: AWS-only (VPC, EKS, ACM, IAM/IRSA, access)
     platform/                # state 2: in-cluster controllers + app namespace
-infra/k8s/charts/kortix-api/ # the app workload (deployed by CI / helm)
-.github/workflows/deploy-prod-eks.yml
+infra/k8s/charts/kortix-api/ # the app workload (reconciled by Argo CD)
+.github/workflows/deploy-dev.yml / deploy-prod.yml
 ```
 
 Two Terraform states on purpose: the kubernetes/helm providers can't be
 configured until the cluster endpoint exists, so the cluster (`cluster`) and the
 in-cluster controllers (`platform`) are separate states. The app itself is a
-Helm chart that CI rolls — Terraform owns infra, CI owns the app, mirroring ECS.
+Helm chart that Argo CD reconciles from `infra/k8s/envs/<env>/values.yaml` —
+Terraform owns infra, GitOps owns the app.
 
 ## Bring-up (one time)
 
@@ -90,11 +90,11 @@ cd ../platform
 terraform init
 terraform apply                                 # ~5 min (Helm releases)
 
-# 3) First app deploy (CI does this automatically on every prod push afterward).
+# 3) First app deploy (Argo CD / CI owns this automatically afterward).
 cd ../cluster
 ROLE_ARN=$(terraform output -raw app_irsa_role_arn)
 CERT_ARN=$(terraform output -raw acm_certificate_arn)
-aws eks update-kubeconfig --name kortix-prod-eks --region us-west-2
+aws eks update-kubeconfig --name kortix-prod-eks --region eu-west-2
 helm upgrade --install kortix-api ../../../k8s/charts/kortix-api \
   --namespace kortix-prod \
   --set image.tag="$(tr -d '[:space:]' < ../../../../VERSION)" \
@@ -107,33 +107,33 @@ helm upgrade --install kortix-api ../../../k8s/charts/kortix-api \
 curl -fsS https://api-eks.kortix.com/v1/health
 ```
 
-After bring-up, every push to `prod` deploys to EKS automatically via
-`deploy-prod-eks.yml` (parallel to the ECS pipeline; it no-ops until the cluster
-exists).
+After bring-up, a reviewed promote PR merged to `prod` deploys to EKS via
+`deploy-prod.yml`; a push to `main` deploys dev via `deploy-dev.yml`.
 
 ## Switch-back / coexistence
 
-- **EKS** → `api-eks.kortix.com` (this stack).
-- **ECS** → keep it permanently reachable at `api-ecs.kortix.com` by adding that
-  host to ECS prod's `extra_api_hostnames` (the module already supports it):
+- **EKS** → `api-eks.kortix.com` / `dev-api-eks.kortix.com` (active).
+- **ECS** → keep it permanently reachable at `api-ecs-fargate.kortix.com` /
+  `dev-api-ecs-fargate.kortix.com` as standby (the module supports extra hostnames):
 
   ```hcl
   # infra/terraform/environments/prod/terraform.tfvars
-  extra_api_hostnames = ["api-ecs.kortix.com"]
+  extra_api_hostnames = ["api-ecs-fargate.kortix.com"]
   ```
   then `terraform apply` in `environments/prod` (adds an ACM SAN + proxied CNAME;
   does not disturb anything else).
-- **`api.kortix.com`** keeps flipping via the Cloudflare Worker `ACTIVE_BACKEND`
-  var (see `infra/CICD.md`): add an `eks → api-eks.kortix.com` case next to the
-  existing `ecs-fargate → api-prod.kortix.com`. Flip to `eks` to cut over, back
-  to `ecs-fargate` to roll back — sub-second, no DNS surgery.
+- **`api.kortix.com` / `dev-api.kortix.com`** flip via the Cloudflare Worker
+  `ACTIVE_BACKEND` var (see `infra/CICD.md` and
+  `infra/cloudflare/workers/api-router`): `eks` is active, `ecs-fargate` is
+  rollback/standby — sub-second, no DNS surgery.
 
-Discontinue ECS only after EKS is proven; until then both serve in parallel.
+Discontinue ECS only after the standby decision is explicit; until then keep both
+origins healthy.
 
 ## Operations
 
 ```bash
-aws eks update-kubeconfig --name kortix-prod-eks --region us-west-2
+aws eks update-kubeconfig --name kortix-prod-eks --region eu-west-2
 
 kubectl -n kortix-prod get pods -o wide          # placement across AZs/nodes
 kubectl -n kortix-prod rollout status deploy/kortix-api
@@ -143,8 +143,8 @@ kubectl -n kortix-prod get externalsecret         # SecretSynced=True when healt
 kubectl -n kortix-prod get ingress                # ADDRESS = the ALB hostname
 
 # Rollback to a previous release:
-helm -n kortix-prod history kortix-api
-helm -n kortix-prod rollback kortix-api <REVISION>
+git revert <prod values/release commit>   # preferred GitOps rollback
+# or, for emergency operator rollback: argocd app rollback kortix-prod <REVISION>
 ```
 
 ## Teardown (if abandoning EKS)

--- a/infra/GITOPS.md
+++ b/infra/GITOPS.md
@@ -19,7 +19,7 @@ infra/k8s/
 - **Deploy** = a commit/PR that bumps `image.tag` in `infra/k8s/envs/<env>/values.yaml`. Argo CD syncs it onto the cluster.
 - **Rollback** = `git revert` that commit. Argo CD reconciles back.
 - **Drift** (anyone `kubectl edit`s a managed resource) is auto-reverted (`selfHeal: true`).
-- The Application tracks a branch per env: **prod → `prod`**, dev → `main` (Phase 3).
+- The Applications track a branch per env: **prod → `prod`**, dev → `main`.
 
 ## Bootstrap (one time)
 
@@ -76,25 +76,24 @@ CLI through the gateway uses gRPC-Web: `argocd login ops.kortix.com --grpc-web`.
 
 ## Release flow & the GitHub Actions
 
-Promotion keeps its good bones (one `VERSION`, retag-don't-rebuild, review-gated
-promote). What changes is how the deploy *happens*:
+Promotion keeps one `VERSION`, retag-don't-rebuild, and a review gate at the
+prod boundary:
 
-| Workflow | Role now (dual-run) | At api.kortix.com cutover |
-| --- | --- | --- |
-| `deploy-prod-eks.yml` | After the image is retagged, **bumps `envs/prod/values.yaml` → Argo CD deploys EKS** (gated by GitHub Environment `production`). No kubectl/helm. | becomes the **sole** prod deploy |
-| `deploy-prod.yml` | unchanged — retag · CLI · desktop · GitHub Release · **rolls ECS** (ECS still serves api.kortix.com) | **drop the `deploy-api` (ECS roll) job** |
-| `deploy-dev.yml` | unchanged — builds + rolls ECS dev | Phase 3: drop ECS roll, bump `envs/dev/values.yaml` |
-| `e2e.yml` | unchanged (WIP, non-gating) | wire as a required gate when ready |
+| Workflow | Role |
+| --- | --- |
+| `deploy-dev.yml` | On `main`, build/push `dev-<sha8>`, apply dev node-pg-migrate migrations, bump `infra/k8s/envs/dev/values.yaml`, and watch Argo CD roll `kortix-dev`. |
+| `promote.yml` | Manual dispatch that opens a reviewed `release/vX.Y.Z` PR into `prod`; it does not tag, release, retag, or deploy. |
+| `deploy-prod.yml` | On the `prod` merge, retag the tested dev image, apply prod node-pg-migrate migrations, cut the GitHub Release, and watch Argo CD roll `kortix-prod`. |
 
-A release = merge the promote PR → `deploy-prod` retags + cuts the release →
-`deploy-prod-eks` bumps the prod values → Argo CD rolls EKS. **Rollback = `git
-revert`** the values bump (or `argocd app rollback`).
+A release = merge the promote PR → `deploy-prod` retags + migrates + publishes →
+Argo CD rolls EKS from the values committed on `prod`. **Rollback = `git revert`**
+the values/release commit (or `argocd app rollback`).
 
-**Approval gate:** create the `production` GitHub Environment (Settings →
-Environments) with required reviewers — the `deploy-prod-eks` job then pauses for
-sign-off before it touches prod. Branch protection note: the job pushes the bump
-commit to `prod`; allow the Actions bot to push (or relax the rule for it), the
-same way `deploy-prod`'s `sync-main-version` pushes to `main`.
+**Approval gate:** today the enforced human gate is the reviewed promote PR into
+the protected `prod` branch. If Kortix wants a second runtime approval in Actions,
+create the `production` GitHub Environment and add `environment: production` to
+the `deploy-api` job in `deploy-prod.yml`; otherwise the environment gate does not
+pause the workflow.
 
 ## Canary (Phase 2)
 
@@ -122,17 +121,15 @@ Watch a canary: `kubectl argo rollouts get rollout kortix-api -n kortix-prod --w
 PRs merge to main  ─►  DEV only        (dev Argo app tracks `main`)
                        prod untouched
 
-Actions → Promote   ─►  merges main → `prod` branch (reviewed)
-   └─ deploy-prod-eks bumps image.tag in prod's envs/prod/values.yaml
-        (GitHub Environment `production` approval)
+Actions → Promote   ─►  opens reviewed release PR into `prod`
+   └─ release PR already bumps image.tag in prod's envs/prod/values.yaml
+        (deploy-prod migrates + watches the EKS roll after merge)
                        └─►  prod Argo app (tracks `prod`) syncs ─► PROD
 ```
 
 The **prod Application tracks the `prod` branch** — so nothing on `main` can
-touch prod. Prod moves *only* when someone runs **Promote** (merges to `prod`)
-and the image bump lands on `prod`. (Bootstrap note: the app currently tracks
-`main` until the first promote puts the GitOps manifests on `prod`; then repoint
-`spec.sources[].targetRevision` from `main` → `prod` — a one-line change.)
+touch prod. Prod moves *only* when someone runs **Promote** and the reviewed
+release PR merges into `prod` with the image/value bump.
 
 ## GitHub-org SSO + retiring admin
 

--- a/infra/cloudflare/workers/api-router/README.md
+++ b/infra/cloudflare/workers/api-router/README.md
@@ -8,12 +8,17 @@ backend `ACTIVE_BACKEND` names. One source (`worker.mjs`), two envs (`wrangler.t
 | `prod` | `api.kortix.com`     | `api-kortix-router`     | `api-eks.kortix.com`     | `api-ecs-fargate.kortix.com`     |
 | `dev`  | `dev-api.kortix.com` | `dev-api-kortix-router` | `dev-api-eks.kortix.com` | `dev-api-ecs-fargate.kortix.com` |
 
-ECS Fargate is the active backend (`ACTIVE_BACKEND=ecs-fargate`); EKS is the
-always-warm standby. CI deploys **both** every release (EKS via Argo CD GitOps,
-ECS via a parallel `deploy-api-ecs` job that pins the exact released image), and
-both run the same image against the same DB — background-worker leadership is a
-single global DB lease (`apps/api/src/shared/leader-election.ts`), so only one
-side ever runs cron. That makes a flip safe and instantly reversible.
+EKS is the active backend for both public API hostnames (`X-Backend: eks` on
+`/v1/health`, verified 2026-06-21); ECS Fargate is the warm standby. CI deploys
+the EKS services via Argo CD GitOps (`deploy-dev.yml` / `deploy-prod.yml`). Keep
+the ECS origins available for failover, but do not treat them as the primary
+runtime. Background-worker leadership is guarded by a single global DB lease
+(`apps/api/src/shared/leader-election.ts`), so only one side ever runs cron.
+
+The checked-in Worker vars are deploy defaults; the live Worker plain-text var is
+the runtime source of truth. If a checked-in default disagrees with the live
+`X-Backend` header, fix the config drift before redeploying the Worker (tracking:
+https://github.com/kortix-ai/suna/issues/3629).
 
 ## Deploy (code or var changes)
 
@@ -26,7 +31,7 @@ wrangler deploy --env dev       # dev-api.kortix.com
 ## Fail over (no code change) — flip the active backend
 
 ```bash
-# prod → ECS Fargate, then back to EKS
+# prod → ECS Fargate standby, then back to EKS
 wrangler deploy --env prod --var ACTIVE_BACKEND:ecs-fargate
 wrangler deploy --env prod --var ACTIVE_BACKEND:eks
 ```

--- a/infra/k8s/charts/kortix-api/README.md
+++ b/infra/k8s/charts/kortix-api/README.md
@@ -1,9 +1,9 @@
 # kortix-api Helm chart
 
-The Kortix API workload on EKS. Deployed by `.github/workflows/deploy-prod-eks.yml`
-(and for first bring-up, by hand — see `infra/EKS.md`). Terraform owns the
-cluster + controllers; this chart owns the app, mirroring how CI rolls the ECS
-service while Terraform owns the ECS infra.
+The Kortix API workload on EKS. Dev is deployed by `.github/workflows/deploy-dev.yml`
+through a GitOps values bump on `main`; prod is deployed by `.github/workflows/deploy-prod.yml`
+after a reviewed promote PR lands on `prod`. Terraform owns the clusters and
+controllers; this chart owns the application objects that Argo CD reconciles.
 
 ## What it renders
 
@@ -15,11 +15,12 @@ service while Terraform owns the ECS infra.
 | `HorizontalPodAutoscaler` | CPU+memory target tracking, 3→12 replicas. |
 | `PodDisruptionBudget` | `minAvailable: 50%` — disruptions never drop below half. |
 | `ServiceAccount` | Annotated with the IRSA role (Secrets Manager read). |
-| `SecretStore` + `ExternalSecret` | Sync the shared `kortix-prod-env-omifd2` bundle → `kortix-api-env`, consumed via `envFrom`. |
+| `SecretStore` + `ExternalSecret` | Sync the per-env AWS Secrets Manager bundle → `kortix-api-env`, consumed via `envFrom`. |
 
 ## Required deploy-time values
 
-These come from `terraform -chdir=environments/prod-eks/cluster output`:
+These come from the corresponding EKS Terraform environment outputs and the
+GitOps value files under `infra/k8s/envs/<env>/`:
 
 | Value | From TF output |
 | ----- | -------------- |
@@ -30,3 +31,9 @@ These come from `terraform -chdir=environments/prod-eks/cluster output`:
 
 The chart `fail`s fast if `serviceAccount.roleArn` or `ingress.certificateArn`
 are unset, so a misconfigured deploy never reaches the cluster.
+
+Database migrations are **not** applied by this chart in the current live deploy
+path. The GitHub Actions `migrate-db` jobs run `pnpm --filter @kortix/db migrate`
+(node-pg-migrate) before the GitOps rollout. The chart still contains a disabled
+legacy PreSync hook; do not enable it until it is ported or removed
+(https://github.com/kortix-ai/suna/issues/3628).

--- a/infra/k8s/charts/kortix-gateway/README.md
+++ b/infra/k8s/charts/kortix-gateway/README.md
@@ -1,32 +1,31 @@
-# kortix-api Helm chart
+# kortix-gateway Helm chart
 
-The Kortix API workload on EKS. Deployed by `.github/workflows/deploy-prod-eks.yml`
-(and for first bring-up, by hand — see `infra/EKS.md`). Terraform owns the
-cluster + controllers; this chart owns the app, mirroring how CI rolls the ECS
-service while Terraform owns the ECS infra.
+The standalone Kortix LLM gateway workload on EKS. It runs alongside
+`kortix-api` in the same namespace, reusing the API ServiceAccount and the
+already-synced `kortix-api-env` secret bundle. Dev is reconciled from `main` via
+`infra/k8s/argocd/applications/gateway-dev.yaml`; prod is reconciled from `prod`
+via `gateway-prod.yaml`.
 
 ## What it renders
 
 | Object | Purpose |
 | ------ | ------- |
-| `Deployment` | The API. Startup/liveness/readiness probes, `preStop` drain, 3-AZ `topologySpreadConstraints`, `maxUnavailable: 0` rolling deploys. |
-| `Service` (ClusterIP) | Backend for the ALB target group. |
-| `Ingress` (`alb`) | AWS Load Balancer Controller → internet-facing ALB, ACM TLS, `:80→:443`, IP targets, `/v1/health` checks. external-dns → proxied `api-eks.kortix.com`. |
-| `HorizontalPodAutoscaler` | CPU+memory target tracking, 3→12 replicas. |
-| `PodDisruptionBudget` | `minAvailable: 50%` — disruptions never drop below half. |
-| `ServiceAccount` | Annotated with the IRSA role (Secrets Manager read). |
-| `SecretStore` + `ExternalSecret` | Sync the shared `kortix-prod-env-omifd2` bundle → `kortix-api-env`, consumed via `envFrom`. |
+| `Deployment` | Gateway process on port `8090`; streaming-safe termination (`preStop` + 300s grace). |
+| `Service` (ClusterIP) | Backend for the ALB target group and in-cluster callers. |
+| `Ingress` (`alb`) | Public gateway host (`gateway-dev.kortix.com` / `gateway.kortix.com`) with long idle timeout for LLM streams. |
+| `HorizontalPodAutoscaler` | Memory/CPU target tracking for long-lived stream load. |
+| `PodDisruptionBudget` | Keeps at least half the replicas available during disruptions. |
 
 ## Required deploy-time values
 
-These come from `terraform -chdir=environments/prod-eks/cluster output`:
+Per-environment values live in `infra/k8s/envs/<env>/gateway-values.yaml`:
 
-| Value | From TF output |
-| ----- | -------------- |
-| `serviceAccount.roleArn` | `app_irsa_role_arn` |
-| `ingress.certificateArn` | `acm_certificate_arn` |
-| `image.tag` | the released version (e.g. `0.9.36`) |
-| `kortixVersion` | same version string (reported by `/v1/health`) |
+| Value | Purpose |
+| ----- | ------- |
+| `image.tag` | Gateway image tag deployed by GitOps. |
+| `ingress.host` | Public gateway hostname. |
+| `ingress.certificateArn` | ACM certificate for the gateway ALB. |
 
-The chart `fail`s fast if `serviceAccount.roleArn` or `ingress.certificateArn`
-are unset, so a misconfigured deploy never reaches the cluster.
+The chart intentionally has no ServiceAccount or ExternalSecret of its own; it
+depends on the API chart having created `kortix-api` and `kortix-api-env` first,
+and Argo CD retries until those dependencies exist.

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -13,30 +13,27 @@ separate root module under `environments/` with its own state.
 ```
 infra/terraform/
   modules/
-    api-host/          # legacy: a Lightsail box that serves the kortix-api
     network/           # shared VPC (public/private subnets + NAT)
     ecs-api/           # ECS Fargate API service behind an ALB
     acm-cloudflare/    # ACM cert validated via Cloudflare DNS
     cloudflare-dns/    # Cloudflare DNS records
     eks/               # EKS prod (cluster / platform / irsa) — see infra/EKS.md
   environments/
-    dev/               # dev-api.kortix.com  (ECS, us-west-2)
-    prod/              # api-prod.kortix.com (ECS)
-    prod-eks/          # api-eks.kortix.com  (EKS, parallel to prod) — infra/EKS.md
+    dev/               # dev ECS warm-standby origin (dev-api-ecs-fargate)
+    prod/              # prod ECS warm-standby origin (api-ecs-fargate)
+    prod-eks/          # api-eks.kortix.com  (active EKS prod) — infra/EKS.md
 ```
 
-> The EKS prod stack runs **in parallel** with ECS and never touches it. Full
-> architecture + bring-up + switch-back runbook: **`infra/EKS.md`**.
+> EKS is active; ECS remains available as the Cloudflare Worker standby. Full
+> architecture + switch-back runbook: **`infra/EKS.md`**.
 
-## Why Lightsail (today) → ECS (later)
+## Current topology
 
-The dev + prod APIs currently run as Docker containers on AWS **Lightsail**
-instances behind nginx (blue/green on ports 8008/8009), deployed over SSH by
-`.github/workflows/deploy-dev.yml` / `release.yml`. This Terraform **adopts the
-existing live boxes** (via `terraform import`) so the infra is reproducible and
-the nginx/keepalive config can't be lost on a rebuild — it does NOT recreate
-them. The longer-term SOC2 target (autoscaling, no OS to patch) is ECS Fargate
-+ ALB; that migration is a separate environment module added once dev is stable.
+Dev and prod public API traffic are fronted by Cloudflare Workers and route to
+EKS (`X-Backend: eks` on `/v1/health`, verified 2026-06-21). The ECS Fargate
+environment modules remain in Terraform as warm standby origins for the Worker;
+they are not legacy Lightsail adoption code and should not be deleted just
+because EKS is active.
 
 ## State
 
@@ -50,28 +47,14 @@ table if absent), then `terraform init`.
 ```bash
 cd infra/terraform/environments/dev
 terraform init
-terraform plan      # should show NO changes against the live box
+terraform plan
 terraform apply     # only after a clean plan
-```
-
-## Importing the existing dev box (one-time)
-
-Already-running resources are adopted, never recreated:
-
-```bash
-cd infra/terraform/environments/dev
-bash import.sh      # imports the Lightsail instance, static IP, attachment, ports
-terraform plan      # confirm parity (empty/near-empty diff)
 ```
 
 ## What is NOT in Terraform (yet)
 
-- **Cloudflare DNS** (`dev-api.kortix.com` → box IP, orange-cloud) — needs a
-  `CLOUDFLARE_API_TOKEN`; wired as an optional module, disabled until the token
-  is provided as `TF_VAR_cloudflare_api_token`.
-- **The Vercel frontend** (dev.kortix.com) — managed by Vercel's own GitHub
-  integration, not Terraform.
-- **In-box provisioning** (nginx config, Docker, deploy scripts) — currently
-  applied via `cloud-init`/user-data is NOT retroactively settable on a running
-  Lightsail box; the canonical nginx config is committed at
-  `modules/api-host/files/nginx-kortix-api.conf` so a rebuild restores it.
+- **Cloudflare DNS / Worker plain-text vars** — some records and Worker vars are
+  still operationally managed outside Terraform; verify live `X-Backend` before
+  redeploying Worker defaults (see `infra/cloudflare/workers/api-router`).
+- **Hosted frontend** (`dev.kortix.com`, `kortix.com`) — managed by Vercel's own
+  GitHub integration, not Terraform.

--- a/infra/terraform/environments/dev-eks/README.md
+++ b/infra/terraform/environments/dev-eks/README.md
@@ -1,6 +1,7 @@
 # environments/dev-eks
 
-Dev EKS stack for `dev-api-eks.kortix.com`, run in parallel with ECS dev. A
+Dev EKS stack for `dev-api-eks.kortix.com`, the active dev API origin behind
+`dev-api.kortix.com` (verified by `X-Backend: eks` on 2026-06-21). A
 faithful clone of `prod-eks` (same modules), **fully isolated** — its own VPC
 (`10.40.0.0/16`), cluster (`kortix-dev-eks`), and Argo CD — trimmed for dev:
 a single NAT gateway, a 2-node floor, and Argo CD running **headless** (UI +
@@ -19,9 +20,10 @@ Two Terraform states, applied in order (identical flow to prod-eks):
 
 The app workload is the Helm chart at `infra/k8s/charts/kortix-api`, rendered
 with `infra/k8s/envs/dev/values.yaml` and deployed by Argo CD (app:
-`infra/k8s/argocd/applications/dev.yaml`, tracks `main`). CI
-(`.github/workflows/deploy-dev-eks.yml`) bumps the image tag on every push to
-`main` — Terraform owns infra, GitOps owns the app.
+`infra/k8s/argocd/applications/dev.yaml`, tracks `main`).
+`.github/workflows/deploy-dev.yml` applies dev database migrations, bumps the
+image tag on every API push to `main`, and watches the EKS rollout — Terraform
+owns infra, GitOps owns the app.
 
 ## Apply
 
@@ -70,9 +72,9 @@ cd ../platform && terraform init && terraform apply
 
 5. **Verify**: `curl https://dev-api-eks.kortix.com/v1/health` → `environment: dev`.
 
-## Cutover (later)
+## Active route / standby
 
-Flip `dev-api.kortix.com` → dev-eks (Cloudflare), set `workers.enabled: true` in
-`envs/dev/values.yaml`, and disable the ECS dev service. Until then EKS dev runs
-**API-only** so ECS keeps the dev-tier singleton workers (shared Postgres leader
-lease). Full architecture + coexistence notes: **`infra/EKS.md`**.
+`dev-api.kortix.com` currently routes to EKS. ECS remains the Worker standby via
+`dev-api-ecs-fargate.kortix.com`; keep the Worker config aligned with the live
+route before redeploying it (tracking: https://github.com/kortix-ai/suna/issues/3629).
+Full architecture + coexistence notes: **`infra/EKS.md`**.

--- a/infra/terraform/environments/prod-eks/README.md
+++ b/infra/terraform/environments/prod-eks/README.md
@@ -1,6 +1,7 @@
 # environments/prod-eks
 
-Production EKS stack for `api-eks.kortix.com`, run in parallel with ECS prod.
+Production EKS stack for `api-eks.kortix.com`, the active prod API origin behind
+the Cloudflare Worker. ECS Fargate remains the warm standby origin.
 Two Terraform states, applied in order:
 
 1. **`cluster/`** — AWS-only: the isolated VPC, EKS control plane + managed node
@@ -12,8 +13,9 @@ Two Terraform states, applied in order:
    and the app namespace.
 
 The app workload itself is the Helm chart at `infra/k8s/charts/kortix-api`,
-deployed by `.github/workflows/deploy-prod-eks.yml` (Terraform owns infra, CI
-owns the app — same split as ECS).
+reconciled by Argo CD from `infra/k8s/argocd/applications/prod.yaml`. The reviewed
+promote PR bumps prod values, and `.github/workflows/deploy-prod.yml` applies
+database migrations and watches the EKS rollout.
 
 Full runbook, architecture, and switch-back/coexistence notes: **`infra/EKS.md`**.
 


### PR DESCRIPTION
## Summary
- Refresh EKS/GitOps, Cloudflare Worker, Terraform, and release docs to match current active EKS routing and deploy-dev/deploy-prod workflows.
- Update migration docs/skills from Drizzle-era `db:migrate`/PreSync language to node-pg-migrate, with explicit links to source issues for code/config drift (#3628, #3629, #3630).
- Replace the copied `kortix-gateway` chart README with gateway-specific documentation.

## Audit window
- Fallback baseline: commits since 2026-06-14 UTC (first docs-maintainer sweep).
- Suna window inspected: `553fd3082ab66da45b04516645d6f1920ab7eb7c` → `81937601878137c5b35ed25b1b6e84458bb8211a`; GitHub search reported 165 merged PRs in the window.

## Source-of-truth evidence
- `.github/workflows/deploy-dev.yml`, `.github/workflows/deploy-prod.yml`, `.github/workflows/promote.yml`.
- `packages/db/package.json` and `packages/db/MIGRATIONS.md`.
- `infra/k8s/argocd/applications/{dev,prod,gateway-dev,gateway-prod}.yaml`.
- Live health probes returned `X-Backend: eks` for both `https://api.kortix.com/v1/health` and `https://dev-api.kortix.com/v1/health`.

## Verification
- `git diff --check`
- Python source-reference check for edited workflow/path/script claims
- Live API probes for prod/dev `X-Backend: eks`

Docs-only PR. No product code changed.