### PR TITLE
fix(triggers): generous overall sweep timeout (stop coverage guillotine) + correct stall check

### DIFF
--- a/apps/api/src/__tests__/unit-trigger-scheduler-reliability.test.ts
+++ b/apps/api/src/__tests__/unit-trigger-scheduler-reliability.test.ts
@@ -55,7 +55,22 @@ describe('isSweepStale (scheduler stall detection)', () => {
     ).toBe(false);
   });
 
-  test('WEDGE: leader, a sweep started but never completed → stale (the outage signature)', () => {
+  test('IN-FLIGHT (fresh leader): first sweep started recently, not yet completed → NOT stale', () => {
+    // Regression: a busy sweep can legitimately run for minutes (loads ~1.7k
+    // project manifests). It must not read as stale the instant it starts just
+    // because no prior sweep has completed yet (lastSweepCompletedAt is null).
+    expect(
+      isSweepStale({
+        isLeader: true,
+        lastSweepStartedAt: new Date(T0 - 30_000).toISOString(), // started 30s ago
+        lastSweepCompletedAt: null,
+        nowMs: T0,
+        staleMs: STALE,
+      }),
+    ).toBe(false);
+  });
+
+  test('WEDGE: leader, a sweep in-flight far longer than the stale window → stale (the outage signature)', () => {
     expect(
       isSweepStale({
         isLeader: true,

--- a/apps/api/src/projects/lib/triggers.ts
+++ b/apps/api/src/projects/lib/triggers.ts
@@ -195,8 +195,15 @@ export function triggerLoadTimeoutMs(): number {
 }
 /** Hard cap on a whole sweep pass — backstop so nothing can wedge the guard. */
 export function triggerSweepTimeoutMs(): number {
+  // GENEROUS backstop, not a routine cap. A full sweep loads every active
+  // project's manifest sequentially (~1.7k projects → ~11min/pass observed), and
+  // the per-fire/per-load timeouts already guarantee no single op hangs forever.
+  // A short cap here would GUILLOTINE a legit long sweep and drop cron coverage
+  // for projects late in the pass (a 4min cap reached only ~10 of ~39 due
+  // triggers). Keep this well above a real sweep so it only fires on a true hang
+  // not bounded by the per-op timeouts (e.g. a wedged DB call); tune via env.
   const raw = Number(process.env.KORTIX_TRIGGER_SWEEP_TIMEOUT_MS);
-  return Number.isFinite(raw) && raw > 0 ? Math.floor(raw) : 4 * 60_000;
+  return Number.isFinite(raw) && raw > 0 ? Math.floor(raw) : 20 * 60_000;
 }
 
 /**
@@ -219,10 +226,15 @@ export async function withTimeout<T>(p: Promise<T>, ms: number, label: string): 
 }
 
 /**
- * Pure stall check: are we the leader with a sweep that started but hasn't
- * completed within `staleMs`? Surfaced at /health and used by the in-loop
- * watchdog so a frozen scheduler is loud, not silent. Returns false before the
- * first tick (grace right after promotion) and when not leader.
+ * Pure stall check: is the leader's scheduler failing to make progress? Surfaced
+ * at /health and used by the in-loop watchdog so a frozen scheduler is loud, not
+ * silent. NOT stale when: not leader, the scheduler hasn't ticked yet (grace
+ * right after promotion), a sweep completed recently, OR a sweep is in-flight and
+ * still within the stale window. Stale only when the latest sweep has been
+ * IN-FLIGHT longer than `staleMs`, or the last COMPLETED sweep is older than
+ * `staleMs` (the interval died). The in-flight case is why we key off the start
+ * time, not a `lastDone=0` sentinel — otherwise a fresh leader's very first
+ * (legitimately long) sweep would read as stale the instant it began.
  */
 export function isSweepStale(opts: {
   isLeader: boolean;
@@ -233,8 +245,13 @@ export function isSweepStale(opts: {
 }): boolean {
   if (!opts.isLeader) return false;
   if (!opts.lastSweepStartedAt) return false;
-  const lastDoneMs = opts.lastSweepCompletedAt ? Date.parse(opts.lastSweepCompletedAt) : 0;
-  return opts.nowMs - lastDoneMs > opts.staleMs;
+  const startedMs = Date.parse(opts.lastSweepStartedAt);
+  const completedMs = opts.lastSweepCompletedAt ? Date.parse(opts.lastSweepCompletedAt) : 0;
+  // The latest sweep already completed → healthy unless the NEXT one is overdue.
+  if (completedMs >= startedMs) return opts.nowMs - completedMs > opts.staleMs;
+  // A sweep is in-flight (started, not yet completed) → stale only if it has been
+  // running longer than the stale window.
+  return opts.nowMs - startedMs > opts.staleMs;
 }
 
 function schedulerStaleMs(): number {


### PR DESCRIPTION
Follow-up to #3626, found verifying 0.9.69 on prod (**1,745 active projects**).

**1. The 4-min overall sweep timeout was a guillotine.** A full sweep loads every active project's manifest sequentially (~11 min/pass at this scale). The per-fire (45s) + per-load (30s) timeouts already prevent any single op from hanging forever, so the overall cap only needs to be a *rare backstop*. At 4 min it cut the sweep mid-pass → dropped cron coverage for projects late in the order (reached ~10 of ~39 due triggers vs 39 before). **Raise default to 20 min** (env-tunable).

**2. `isSweepStale` false-positive.** Null `lastSweepCompletedAt` was treated as epoch 0, so a fresh leader's first (legitimately long) sweep read "stale" the instant it began — spamming the watchdog + `/health.stale=true` every tick. Fix: key the in-flight case off the sweep **start** time.

20 unit tests (added the in-flight-not-stale regression); typecheck clean.

Follow-up noted in the commit: parallelize the per-project loop to cut a pass from ~11 min to ~1-2 min.