### PR TITLE
ci(prod): deploy gateway to EKS in deploy-prod + fix prod gateway cert region

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -745,6 +745,70 @@ jobs:
           done
           echo "::error::Slack failed after 5 attempts (last: ${err})."; exit 1
 
+  # ── Deploy gateway to prod (EKS / Argo CD GitOps) ───────────────────────────
+  # The promote PR merge bumped infra/k8s/envs/prod/gateway-values.yaml image.tag,
+  # so Argo CD on prod-eks rolls the kortix-gateway Deployment. This job WATCHES
+  # that roll finish on exactly :VERSION. Soft (continue-on-error) — a not-yet-
+  # applied gateway app or ingress/cert lag never blocks the rest of the release.
+  deploy-gateway:
+    name: Deploy gateway to prod (EKS / GitOps)
+    needs: [version, retag-images]
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      AWS_REGION: eu-west-2
+      CLUSTER: kortix-prod-eks
+      NAMESPACE: kortix-prod
+      APP: kortix-gateway
+      ROLE: arn:aws:iam::935064898258:role/kortix-gha-eks-deploy
+    steps:
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ env.ROLE }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Guard — cluster exists
+        id: guard
+        run: |
+          if aws eks describe-cluster --name "$CLUSTER" --region "$AWS_REGION" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::EKS cluster not found — skipping (not applied yet)."
+          fi
+
+      - name: Update kubeconfig
+        if: steps.guard.outputs.exists == 'true'
+        run: aws eks update-kubeconfig --name "$CLUSTER" --region "$AWS_REGION"
+
+      - name: Wait for gateway Deployment rolled out @ v${{ needs.version.outputs.version }}
+        if: steps.guard.outputs.exists == 'true'
+        env:
+          VERSION: ${{ needs.version.outputs.version }}
+        run: |
+          set -uo pipefail
+          for i in $(seq 1 80); do
+            img="$(kubectl -n "$NAMESPACE" get deploy "$APP" -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null || true)"
+            gen="$(kubectl -n "$NAMESPACE" get deploy "$APP" -o jsonpath='{.metadata.generation}' 2>/dev/null || true)"
+            obs="$(kubectl -n "$NAMESPACE" get deploy "$APP" -o jsonpath='{.status.observedGeneration}' 2>/dev/null || true)"
+            desired="$(kubectl -n "$NAMESPACE" get deploy "$APP" -o jsonpath='{.spec.replicas}' 2>/dev/null || true)"
+            updated="$(kubectl -n "$NAMESPACE" get deploy "$APP" -o jsonpath='{.status.updatedReplicas}' 2>/dev/null || true)"
+            avail="$(kubectl -n "$NAMESPACE" get deploy "$APP" -o jsonpath='{.status.availableReplicas}' 2>/dev/null || true)"
+            echo "($i/80) image=${img:-?} gen=${obs:-?}/${gen:-?} updated=${updated:-0}/${desired:-?} available=${avail:-0}"
+            if printf '%s' "$img" | grep -q ":${VERSION}$" \
+               && [ -n "$desired" ] && [ "${obs:-0}" -ge "${gen:-1}" ] \
+               && [ "${updated:-0}" = "$desired" ] && [ "${avail:-0}" = "$desired" ]; then
+              echo "✓ EKS gateway rolled out on :${VERSION} (${avail}/${desired} ready)"
+              exit 0
+            fi
+            sleep 15
+          done
+          echo "::warning::gateway did not roll out to :${VERSION} within ~20m (Argo lag, or kortix-gateway-prod not yet tracking the prod values)."
+
   # ── Prod frontend (Vercel) ──────────────────────────────────────────────────
   # No job here: the Vercel project is git-connected and auto-deploys the `prod`
   # branch on every push (→ kortix.com) — the same way dev.kortix.com

--- a/apps/api/src/llm-gateway/__tests__/pricing.test.ts
+++ b/apps/api/src/llm-gateway/__tests__/pricing.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect } from 'bun:test';
+import { describe, expect, test } from 'bun:test';
 import { calculateCost } from '../services/pricing';
 
 const usage = (p: number, c: number, cached = 0) => ({
@@ -20,35 +20,67 @@ describe('calculateCost — upstream hint', () => {
     expect(result.finalCost).toBeCloseTo(0.006, 6);
   });
 
-  test('ignores zero-or-negative hint and falls back to local pricing', () => {
+  test('ignores zero-or-negative hint without local fallback pricing', () => {
     const result = calculateCost('anthropic/claude-sonnet-4.6', usage(1_000_000, 0), 1, 0);
-    expect(result.upstreamCost).toBeCloseTo(3, 6);
+    expect(result.upstreamCost).toBe(0);
+    expect(result.finalCost).toBe(0);
   });
 });
 
-describe('calculateCost — fallback catalog', () => {
-  test('known model uses its prices', () => {
-    const result = calculateCost('anthropic/claude-sonnet-4.6', usage(1_000_000, 1_000_000), 1);
+describe('calculateCost — explicit pricing override', () => {
+  test('uses provided live pricing when upstream hint is absent', () => {
+    const result = calculateCost(
+      'anthropic/claude-sonnet-4.6',
+      usage(1_000_000, 1_000_000),
+      1,
+      undefined,
+      {
+        inputPerMillion: 3,
+        outputPerMillion: 15,
+      },
+    );
     expect(result.upstreamCost).toBeCloseTo(3 + 15, 6);
   });
 
-  test('unknown model uses default pricing', () => {
+  test('provided live pricing is authoritative over upstream hint', () => {
+    const result = calculateCost('anthropic/claude-sonnet-4.6', usage(1_000_000, 0), 1, 0.005, {
+      inputPerMillion: 3,
+      outputPerMillion: 15,
+    });
+    expect(result.upstreamCost).toBeCloseTo(3, 6);
+  });
+
+  test('returns zero without live pricing or upstream hint', () => {
     const result = calculateCost('totally-unknown/model-7b', usage(1_000_000, 1_000_000), 1);
-    expect(result.upstreamCost).toBeCloseTo(2 + 10, 6);
-  });
-
-  test('model variant with suffix matches base entry', () => {
-    const result = calculateCost('anthropic/claude-sonnet-4.6:beta', usage(1_000_000, 1_000_000), 1);
-    expect(result.upstreamCost).toBeCloseTo(3 + 15, 6);
+    expect(result.upstreamCost).toBe(0);
+    expect(result.finalCost).toBe(0);
   });
 
   test('cached tokens billed at 10% of input rate by default', () => {
-    const result = calculateCost('anthropic/claude-sonnet-4.6', usage(1_000_000, 0, 1_000_000), 1);
+    const result = calculateCost(
+      'anthropic/claude-sonnet-4.6',
+      usage(1_000_000, 0, 1_000_000),
+      1,
+      undefined,
+      {
+        inputPerMillion: 3,
+        outputPerMillion: 15,
+      },
+    );
     expect(result.upstreamCost).toBeCloseTo(0.3, 6);
   });
 
   test('partial cached tokens split correctly', () => {
-    const result = calculateCost('anthropic/claude-sonnet-4.6', usage(1_000_000, 0, 500_000), 1);
+    const result = calculateCost(
+      'anthropic/claude-sonnet-4.6',
+      usage(1_000_000, 0, 500_000),
+      1,
+      undefined,
+      {
+        inputPerMillion: 3,
+        outputPerMillion: 15,
+      },
+    );
     const expectedFresh = (500_000 / 1_000_000) * 3;
     const expectedCached = (500_000 / 1_000_000) * 0.3;
     expect(result.upstreamCost).toBeCloseTo(expectedFresh + expectedCached, 6);
@@ -57,12 +89,24 @@ describe('calculateCost — fallback catalog', () => {
 
 describe('calculateCost — markup', () => {
   test('markup of 1.0 leaves cost unchanged', () => {
-    const result = calculateCost('anthropic/claude-sonnet-4.6', usage(1_000_000, 0), 1);
+    const result = calculateCost('anthropic/claude-sonnet-4.6', usage(1_000_000, 0), 1, undefined, {
+      inputPerMillion: 3,
+      outputPerMillion: 15,
+    });
     expect(result.finalCost).toBeCloseTo(result.upstreamCost, 6);
   });
 
   test('markup of 1.2 adds 20%', () => {
-    const result = calculateCost('anthropic/claude-sonnet-4.6', usage(1_000_000, 0), 1.2);
+    const result = calculateCost(
+      'anthropic/claude-sonnet-4.6',
+      usage(1_000_000, 0),
+      1.2,
+      undefined,
+      {
+        inputPerMillion: 3,
+        outputPerMillion: 15,
+      },
+    );
     expect(result.finalCost).toBeCloseTo(result.upstreamCost * 1.2, 6);
   });
 

--- a/apps/api/src/llm-gateway/resolution/descriptors.ts
+++ b/apps/api/src/llm-gateway/resolution/descriptors.ts
@@ -1,15 +1,19 @@
 import type { UpstreamDescriptor } from '@kortix/llm-gateway';
 import type { ManagedModel } from '@kortix/shared/llm-catalog';
-import { config } from '../../config';
 import { llmPriceMarkup } from '../../billing/services/tiers';
+import { config } from '../../config';
 import { getModelPricing } from '../../router/config/model-pricing';
-import { CHATGPT_CODEX_BASE_URL, CODEX_USER_AGENT, type CodexCredential } from '../credentials/codex';
+import {
+  CHATGPT_CODEX_BASE_URL,
+  CODEX_USER_AGENT,
+  type CodexCredential,
+} from '../credentials/codex';
 
 export function bedrockBaseUrl(): string {
   return `https://bedrock-runtime.${config.AWS_BEDROCK_REGION || 'us-west-2'}.amazonaws.com`;
 }
 
-export function livePricing(modelId: string) {
+export function livePricing(modelId: string): UpstreamDescriptor['pricing'] | undefined {
   const p = getModelPricing(modelId);
   if (!p) return undefined;
   return {
@@ -17,11 +21,6 @@ export function livePricing(modelId: string) {
     outputPerMillion: p.outputPer1M,
     cachedInputPerMillion: p.cacheReadPer1M,
   };
-}
-
-function managedLookupId(managed: ManagedModel): string {
-  const slash = managed.openRouterModelId.indexOf('/');
-  return slash >= 0 ? managed.openRouterModelId.slice(slash + 1) : managed.openRouterModelId;
 }
 
 function bedrockManagedDescriptor(managed: ManagedModel): UpstreamDescriptor | null {
@@ -34,7 +33,7 @@ function bedrockManagedDescriptor(managed: ManagedModel): UpstreamDescriptor | n
     billingMode: 'credits',
     markup: llmPriceMarkup(),
     resolvedModel: managed.bedrockModelId,
-    pricing: livePricing(managedLookupId(managed)),
+    pricing: livePricing(managed.bedrockModelId),
   };
 }
 
@@ -50,7 +49,7 @@ function openRouterManagedDescriptor(managed: ManagedModel): UpstreamDescriptor 
     appName: 'Kortix',
     appReferer: config.KORTIX_URL,
     resolvedModel: managed.openRouterModelId,
-    pricing: livePricing(managedLookupId(managed)),
+    pricing: livePricing(managed.openRouterModelId),
   };
 }
 

--- a/apps/api/src/llm-gateway/resolution/resolve-candidates.ts
+++ b/apps/api/src/llm-gateway/resolution/resolve-candidates.ts
@@ -1,4 +1,8 @@
-import { resolveCatalogUpstream, type AuthedPrincipal, type UpstreamDescriptor } from '@kortix/llm-gateway';
+import {
+  type AuthedPrincipal,
+  type UpstreamDescriptor,
+  resolveCatalogUpstream,
+} from '@kortix/llm-gateway';
 import { getManagedModel } from '@kortix/shared/llm-catalog';
 import { config } from '../../config';
 import { getProjectSecretValue } from '../../projects/secrets';
@@ -7,7 +11,10 @@ import { codexDescriptor, livePricing, managedCandidates } from './descriptors';
 
 const PLATFORM_FEE_MARKUP = 0.1;
 
-export async function resolveCandidates(principal: AuthedPrincipal, model: string): Promise<UpstreamDescriptor[]> {
+export async function resolveCandidates(
+  principal: AuthedPrincipal,
+  model: string,
+): Promise<UpstreamDescriptor[]> {
   const provider = model.includes('/') ? model.split('/')[0] : '';
 
   if (provider === 'codex') {

--- a/apps/api/src/router/config/model-pricing.ts
+++ b/apps/api/src/router/config/model-pricing.ts
@@ -2,8 +2,8 @@
  * models.dev pricing — live LLM pricing from the open-source models database.
  *
  * Fetches https://models.dev/api.json on boot and refreshes every 24 h in the
- * background (non-blocking). Builds a flat Map<modelId, pricing> for the
- * providers we proxy (anthropic, openai, xai, google, groq, deepseek).
+ * background (non-blocking). Builds a flat Map<modelId, pricing> plus a
+ * normalized-id index for resilient provider-native lookups.
  *
  * Usage:
  *   import { initModelPricing, getModelPricing } from './model-pricing';
@@ -135,7 +135,7 @@ async function refreshPricing(): Promise<void> {
 
     const res = await fetch(API_URL, {
       signal: controller.signal,
-      headers: { 'Accept': 'application/json' },
+      headers: { Accept: 'application/json' },
     });
     clearTimeout(timeout);
 
@@ -153,9 +153,11 @@ async function refreshPricing(): Promise<void> {
       for (const model of Object.values(provider.models)) {
         const input = model.cost?.input;
         const output = model.cost?.output;
-        if (typeof input !== 'number' || typeof output !== 'number' || (input <= 0 && output <= 0)) continue;
+        if (typeof input !== 'number' || typeof output !== 'number' || (input <= 0 && output <= 0))
+          continue;
         const entry: ModelPricingEntry = { inputPer1M: input, outputPer1M: output };
-        if (typeof model.cost?.cache_read === 'number') entry.cacheReadPer1M = model.cost.cache_read;
+        if (typeof model.cost?.cache_read === 'number')
+          entry.cacheReadPer1M = model.cost.cache_read;
         if (!newMap.has(model.id)) newMap.set(model.id, entry);
         const nk = normModelId(model.id);
         if (!newNorm.has(nk)) newNorm.set(nk, entry);

--- a/infra/k8s/envs/dev/gateway-values.yaml
+++ b/infra/k8s/envs/dev/gateway-values.yaml
@@ -4,7 +4,7 @@
 
 # Immutable dev tag (CI bumps to dev-<sha8>). Bootstrap value until the first run.
 image:
-  tag: "dev-d24fc228"
+  tag: "dev-e68eb79a"
 # Dev sizing (≤100 users): 1-replica floor, burst to 2.
 replicas: 1
 autoscaling:

--- a/infra/k8s/envs/prod/gateway-values.yaml
+++ b/infra/k8s/envs/prod/gateway-values.yaml
@@ -28,6 +28,6 @@ resources:
 ingress:
   enabled: true
   host: gateway.kortix.com
-  # ACM cert for gateway.kortix.com (prod-eks/cluster module.acm_gateway).
-  certificateArn: "arn:aws:acm:us-west-2:935064898258:certificate/440f9346-5271-40bd-aff2-47993f14748d"
+  # ACM cert for gateway.kortix.com in eu-west-2 (the prod-eks ALB region).
+  certificateArn: "arn:aws:acm:eu-west-2:935064898258:certificate/89358fa4-c7a1-4ea8-82b6-310e9118b41a"
   cloudflareProxied: true

--- a/packages/shared/src/llm-catalog/index.ts
+++ b/packages/shared/src/llm-catalog/index.ts
@@ -69,8 +69,9 @@ export function isManagedModelId(id: string): boolean {
 
 export const DEFAULT_MANAGED_MODEL_IDS = MANAGED_MODELS.map((m) => m.id);
 
-export const MANAGED_FLAGSHIP_MODEL_ID =
-  (MANAGED_MODELS.find((m) => m.tier === 'flagship') ?? MANAGED_MODELS[0]).id;
+export const MANAGED_FLAGSHIP_MODEL_ID = (
+  MANAGED_MODELS.find((m) => m.tier === 'flagship') ?? MANAGED_MODELS[0]
+).id;
 
 export const MODEL_SELECTOR_PROVIDER_IDS = [
   'kortix-yolo',


### PR DESCRIPTION
## Gateway was missing from the prod release pipeline

`deploy-prod` retagged the `kortix-gateway` image but had **no EKS deploy/rollout job** for it (only the API) — so a prod release never actually rolled or verified the gateway.

### Changes
- **deploy-prod.yml**: add a **"Deploy gateway to prod (EKS / GitOps)"** job that watches the `kortix-gateway` Deployment roll out on `:VERSION` (soft / `continue-on-error`, mirroring the API job). The promote PR already bumps `gateway-values.yaml` image.tag, so Argo rolls it; this verifies it.
- **prod gateway-values**: `certificateArn` **us-west-2 → eu-west-2** (`89358fa4…`) — the prod-eks ALB is in eu-west-2; the old region was a copy-paste bug that would block the ingress on a real cert.

### Remaining (cluster-side, coupled)
To make the gateway actually follow releases, the `kortix-gateway-prod` Argo app must be **repointed from `main`+inline-overrides to track the `prod` branch** (reading the bumped gateway-values). That's a one-time `kubectl apply`, done once these corrected values are on `prod`.