### PR TITLE
fix(worktree): align schema build with node-pg-migrate (db:migrate is gone)

### DIFF
--- a/packages/db/scripts/test-prereqs.sql
+++ b/packages/db/scripts/test-prereqs.sql
@@ -1,7 +1,11 @@
--- External prerequisites the baseline assumes, for EPHEMERAL TEST/CI databases
--- on vanilla Postgres. In real environments these are provided by the platform
--- (Supabase Auth + Storage + Basejump). This is NOT a migration — it only
--- creates the minimal stubs needed for the baseline's FKs/policies to apply.
+-- External prerequisites the baseline assumes. In deployed environments these
+-- come from the platform (Supabase Auth + Storage + Basejump). This is NOT a
+-- migration — it only creates the minimal objects the baseline's FKs/policies
+-- need, and is fully idempotent + NON-CLOBBERING, so it is safe on both:
+--   • vanilla Postgres (ephemeral test/CI DBs) — creates everything, and
+--   • a fresh Supabase-local (dev worktrees) — keeps the platform's real
+--     roles/auth/storage untouched and only adds Basejump, which Supabase does
+--     not ship (it used to be created by the retired supabase/migrations).
 --
 --   psql "$DATABASE_URL" -f scripts/test-prereqs.sql
 --
@@ -13,11 +17,20 @@ DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname='authenticated')
 DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname='service_role')  THEN CREATE ROLE service_role NOLOGIN;  END IF; END $$;
 
 -- Supabase Auth stubs (signatures only — these don't need to be functional to
--- create the schema; FKs/policies just need them to resolve).
+-- create the schema; FKs/policies just need them to resolve). Created ONLY when
+-- absent, so a real Supabase's own auth.uid()/auth.role() are never overwritten.
 CREATE SCHEMA IF NOT EXISTS auth;
 CREATE TABLE IF NOT EXISTS auth.users (id uuid PRIMARY KEY);
-CREATE OR REPLACE FUNCTION auth.uid()  RETURNS uuid LANGUAGE sql STABLE AS $$ SELECT NULL::uuid $$;
-CREATE OR REPLACE FUNCTION auth.role() RETURNS text LANGUAGE sql STABLE AS $$ SELECT NULL::text $$;
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace
+                 WHERE n.nspname='auth' AND p.proname='uid') THEN
+    CREATE FUNCTION auth.uid() RETURNS uuid LANGUAGE sql STABLE AS $f$ SELECT NULL::uuid $f$;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace
+                 WHERE n.nspname='auth' AND p.proname='role') THEN
+    CREATE FUNCTION auth.role() RETURNS text LANGUAGE sql STABLE AS $f$ SELECT NULL::text $f$;
+  END IF;
+END $$;
 
 -- Basejump accounts stub
 CREATE SCHEMA IF NOT EXISTS basejump;

--- a/scripts/worktree/cli.ts
+++ b/scripts/worktree/cli.ts
@@ -10,7 +10,7 @@
  *   pnpm worktree list · doctor
  *
  * One command from a fresh clone sets up EVERYTHING (deps, git worktree, unique
- * ports, isolated Supabase, install, Drizzle migrate) and boots the stack. Many
+ * ports, isolated Supabase, install, prereqs + node-pg-migrate) and boots the stack. Many
  * worktrees run at once with zero collisions; the primary `pnpm dev` is untouched.
  */
 import {
@@ -265,9 +265,9 @@ async function cmdCreate(a: Args) {
   step(`Starting isolated Postgres on db ${entry.ports.sbDb}`);
   if (await startSupabaseDb(name) !== 0) die('supabase db start failed');
 
-  step('Building schema (pnpm db:migrate)');
-  if (await runMigrate(wtPath, entry.ports) !== 0) die(`db:migrate failed — fix and re-run \`pnpm worktree create --name ${name}\``);
-  if (!hasKortixSchema(entry.ports)) die(`schema not built — branch "${branch}" has no Drizzle migrations.\n  Recreate from a branch that has them: --from migrations/drizzle-rebuild (or merge it into main).`);
+  step('Building schema (prereqs + pnpm migrate)');
+  if (await runMigrate(wtPath, entry.ports) !== 0) die(`migrate failed — fix and re-run \`pnpm worktree create --name ${name}\``);
+  if (!hasKortixSchema(entry.ports)) die(`schema not built — \`pnpm migrate\` produced no kortix schema on branch "${branch}".\n  Check packages/db/migrations/*.sql exist on this branch and the Supabase prereqs applied (psql + Basejump).`);
 
   step(`Starting isolated Supabase on api ${entry.ports.sbApi}`);
   if (await startSupabaseFullStack(name, entry.ports) !== 0) die('supabase start failed');
@@ -301,8 +301,8 @@ async function cmdStart(a: Args) {
   renderSupabaseProject(name, e.path, e.projectId, e.ports);
   step(`Starting Postgres for "${name}"`);
   if (await startSupabaseDb(name) !== 0) die('supabase db start failed');
-  step('Applying pending migrations (pnpm db:migrate)');
-  if (await runMigrate(e.path, e.ports) !== 0) die('db:migrate failed');
+  step('Applying pending migrations (pnpm migrate)');
+  if (await runMigrate(e.path, e.ports) !== 0) die('migrate failed');
   if (!hasKortixSchema(e.ports)) die(`schema not built for "${name}"`);
   if (!sh(['supabase', '--workdir', supaWorkdir(name), 'status']).ok) {
     step(`Starting Supabase for "${name}"`);

--- a/scripts/worktree/lib.ts
+++ b/scripts/worktree/lib.ts
@@ -187,9 +187,22 @@ export function renderSupabaseProject(name: string, worktreePath: string, projec
 }
 
 export async function runMigrate(worktreePath: string, ports: Ports): Promise<number> {
-  return run(['pnpm', '--filter', '@kortix/db', 'db:migrate'], {
+  const url = `postgresql://postgres:postgres@127.0.0.1:${ports.sbDb}/postgres`;
+  // Provision the Supabase-platform objects the baseline assumes. On a fresh
+  // Supabase-local the roles + auth already exist (the script is non-clobbering),
+  // but Basejump does NOT — Supabase doesn't ship it and the old supabase/
+  // migrations that used to create it are gone. This fills that gap before
+  // node-pg-migrate applies the baseline.
+  const prereqs = join(worktreePath, 'packages', 'db', 'scripts', 'test-prereqs.sql');
+  if (existsSync(prereqs)) {
+    const pre = await run(['psql', url, '-v', 'ON_ERROR_STOP=1', '-f', prereqs]);
+    if (pre !== 0) return pre;
+  }
+  // node-pg-migrate (the same `pnpm migrate` the deploy pipeline runs) builds the
+  // schema from packages/db/migrations/*.sql, tracked in kortix_migrations.pgmigrations.
+  return run(['pnpm', '--filter', '@kortix/db', 'migrate'], {
     cwd: worktreePath,
-    env: { DATABASE_URL: `postgresql://postgres:postgres@127.0.0.1:${ports.sbDb}/postgres` },
+    env: { DATABASE_URL: url },
   });
 }
 


### PR DESCRIPTION
## Problem
`pnpm worktree create` fails at the schema step:
```
✗ schema not built — branch "fe" has no Drizzle migrations.
  Recreate from a branch that has them: --from migrations/drizzle-rebuild
```
The worktree's `runMigrate` still ran `pnpm --filter @kortix/db db:migrate` — a script that **no longer exists** (replaced by node-pg-migrate). It built no schema, so the `hasKortixSchema` check failed with a stale, misleading error.

## Root cause (two gaps)
1. `db:migrate` (old drizzle/supabase path) → the new command is `migrate` (node-pg-migrate over `packages/db/migrations/*.sql`).
2. The old `supabase/migrations` used to create **Basejump**; the new baseline *assumes* it exists. A fresh Supabase-local has real auth/storage/roles but **no Basejump**, so the baseline can't apply without provisioning it.

## Fix
`runMigrate` now:
1. applies `packages/db/scripts/test-prereqs.sql` (idempotent — adds Basejump; on Supabase-local the roles/auth/storage already exist and are left untouched), then
2. runs `pnpm --filter @kortix/db migrate`.

Also made `test-prereqs.sql` **non-clobbering**: `auth.uid()`/`auth.role()` are now created only when absent (was `CREATE OR REPLACE`), so a real Supabase's auth is never overwritten — this matters now that the script also serves dev worktrees, not just vanilla CI Postgres. Updated the worktree step labels + the stale "Drizzle migrations" message.

## Verified
On a throwaway simulating Supabase-local (a real `auth.uid()` returning a fixed UUID):
- ✅ `auth.uid()` **preserved** after prereqs (non-clobber)
- ✅ idempotent (applied twice cleanly)
- ✅ Basejump provisioned; real `auth.users` kept
- ✅ full build (prereqs + `pnpm migrate`) = **85 kortix tables**

> 🙏 Please merge with a normal merge commit (not squash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
