### PR TITLE
fix(db): test-prereqs is permission-safe on platform-owned (Supabase) DBs

### DIFF
--- a/packages/db/scripts/test-prereqs.sql
+++ b/packages/db/scripts/test-prereqs.sql
@@ -1,7 +1,8 @@
 -- External prerequisites the baseline assumes. In deployed environments these
 -- come from the platform (Supabase Auth + Storage + Basejump). This is NOT a
 -- migration — it only creates the minimal objects the baseline's FKs/policies
--- need, and is fully idempotent + NON-CLOBBERING, so it is safe on both:
+-- need, and is fully idempotent + NON-CLOBBERING + permission-safe, so it is
+-- safe on both:
 --   • vanilla Postgres (ephemeral test/CI DBs) — creates everything, and
 --   • a fresh Supabase-local (dev worktrees) — keeps the platform's real
 --     roles/auth/storage untouched and only adds Basejump, which Supabase does
@@ -16,33 +17,40 @@ DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname='anon')         
 DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname='authenticated') THEN CREATE ROLE authenticated NOLOGIN; END IF; END $$;
 DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname='service_role')  THEN CREATE ROLE service_role NOLOGIN;  END IF; END $$;
 
--- Supabase Auth stubs (signatures only — these don't need to be functional to
--- create the schema; FKs/policies just need them to resolve). Created ONLY when
--- absent, so a real Supabase's own auth.uid()/auth.role() are never overwritten.
-CREATE SCHEMA IF NOT EXISTS auth;
-CREATE TABLE IF NOT EXISTS auth.users (id uuid PRIMARY KEY);
-DO $$ BEGIN
+-- Supabase Auth stubs (signatures only — FKs/policies just need them to resolve).
+-- Wrapped so it is NON-CLOBBERING + permission-safe: on a real Supabase DB the
+-- connecting role usually can't write into the platform-owned `auth` schema
+-- (insufficient_privilege is caught → real schema used as-is), and the function
+-- guards mean a real auth.uid()/auth.role() is never overwritten.
+DO $prereq$ BEGIN
+  CREATE SCHEMA IF NOT EXISTS auth;
+  CREATE TABLE IF NOT EXISTS auth.users (id uuid PRIMARY KEY);
   IF NOT EXISTS (SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace
                  WHERE n.nspname='auth' AND p.proname='uid') THEN
-    CREATE FUNCTION auth.uid() RETURNS uuid LANGUAGE sql STABLE AS $f$ SELECT NULL::uuid $f$;
+    CREATE FUNCTION auth.uid() RETURNS uuid LANGUAGE sql STABLE AS 'SELECT NULL::uuid';
   END IF;
   IF NOT EXISTS (SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace
                  WHERE n.nspname='auth' AND p.proname='role') THEN
-    CREATE FUNCTION auth.role() RETURNS text LANGUAGE sql STABLE AS $f$ SELECT NULL::text $f$;
+    CREATE FUNCTION auth.role() RETURNS text LANGUAGE sql STABLE AS 'SELECT NULL::text';
   END IF;
-END $$;
+EXCEPTION WHEN insufficient_privilege THEN
+  RAISE NOTICE '[test-prereqs] auth is platform-owned (Supabase) — using it as-is, stubs skipped';
+END $prereq$;
 
--- Basejump accounts stub
-CREATE SCHEMA IF NOT EXISTS basejump;
-DO $$ BEGIN
+-- Basejump accounts stub (same treatment — Supabase doesn't ship basejump, so on
+-- a fresh Supabase-local this is what actually creates it).
+DO $prereq$ BEGIN
+  CREATE SCHEMA IF NOT EXISTS basejump;
   IF NOT EXISTS (SELECT 1 FROM pg_type t JOIN pg_namespace n ON n.oid=t.typnamespace
                  WHERE n.nspname='basejump' AND t.typname='account_role') THEN
     CREATE TYPE basejump.account_role AS ENUM ('owner','member');
   END IF;
-END $$;
-CREATE TABLE IF NOT EXISTS basejump.account_user (
-  user_id uuid NOT NULL,
-  account_id uuid NOT NULL,
-  account_role basejump.account_role NOT NULL,
-  PRIMARY KEY (user_id, account_id)
-);
+  CREATE TABLE IF NOT EXISTS basejump.account_user (
+    user_id uuid NOT NULL,
+    account_id uuid NOT NULL,
+    account_role basejump.account_role NOT NULL,
+    PRIMARY KEY (user_id, account_id)
+  );
+EXCEPTION WHEN insufficient_privilege THEN
+  RAISE NOTICE '[test-prereqs] basejump is platform-owned — using it as-is, stubs skipped';
+END $prereq$;


### PR DESCRIPTION
## Worktree migrate broke on Supabase DBs

`pnpm migrate` runs `packages/db/scripts/test-prereqs.sql`, which on a real Supabase DB (dev worktrees) aborts:
```
psql:test-prereqs.sql: ERROR: permission denied for schema auth
LINE 1: CREATE TABLE IF NOT EXISTS auth.users (id uuid PRIMARY KEY);
```
The `auth` (and `basejump`) schemas are platform-owned, so the connecting role can't write into them — and `IF NOT EXISTS` doesn't help because the privilege check happens first. (The prior fix guarded the *functions* but left `CREATE TABLE auth.users` unguarded.)

## Fix
Wrap the auth + basejump stubs in `DO` blocks that catch `insufficient_privilege` and use the real platform schema as-is, keeping the `IF NOT EXISTS` function guards (non-clobbering). Bare CI Postgres still gets full stubs created.

Verified clean against a Supabase-local worktree DB (exit 0, prints `auth is platform-owned … skipped`).