### PR TITLE
fix(gateway): make the gateway the only LLM path opencode can use

### DIFF
--- a/apps/kortix-sandbox-agent-server/src/__tests__/executor-mcp-config.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/executor-mcp-config.test.ts
@@ -148,6 +148,45 @@ describe('buildOpencodeConfigContent — Kortix LLM gateway provider', () => {
   })
 })
 
+describe('buildOpencodeConfigContent — gateway is the sole LLM path (enabled_providers)', () => {
+  const GATEWAY_ENV = {
+    KORTIX_LLM_BASE_URL: 'https://api.kortix.test/v1/llm',
+    KORTIX_LLM_API_KEY: 'kyolo_abc123',
+  }
+
+  test('locks opencode to ONLY the kortix provider when the gateway is active', async () => {
+    stubGatewayModels(GATEWAY_CATALOG)
+    const config = JSON.parse((await buildOpencodeConfigContent(GATEWAY_ENV))!)
+    expect(config.enabled_providers).toEqual(['kortix'])
+  })
+
+  test('a leaked native key (e.g. GITHUB_TOKEN) cannot open a native provider — only kortix is enabled', async () => {
+    stubGatewayModels(GATEWAY_CATALOG)
+    const config = JSON.parse(
+      (await buildOpencodeConfigContent({ ...GATEWAY_ENV, GITHUB_TOKEN: 'ghp_x', OPENAI_API_KEY: 'sk-x' }))!,
+    )
+    expect(config.enabled_providers).toEqual(['kortix'])
+  })
+
+  test('keeps providers a connected Codex/OpenCode subscription declares in auth.json', async () => {
+    stubGatewayModels(GATEWAY_CATALOG)
+    const authJson = JSON.stringify({ openai: { type: 'oauth', access: 'x' }, opencode: { key: 'y' } })
+    const config = JSON.parse((await buildOpencodeConfigContent({ ...GATEWAY_ENV, CODEX_AUTH_JSON: authJson }))!)
+    expect(new Set(config.enabled_providers)).toEqual(new Set(['kortix', 'openai', 'opencode']))
+  })
+
+  test('ignores malformed auth.json and still locks to kortix', async () => {
+    stubGatewayModels(GATEWAY_CATALOG)
+    const config = JSON.parse((await buildOpencodeConfigContent({ ...GATEWAY_ENV, OPENCODE_AUTH_JSON: 'not json{' }))!)
+    expect(config.enabled_providers).toEqual(['kortix'])
+  })
+
+  test('does NOT set an allowlist when there is no gateway (subscription-only session stays native)', async () => {
+    const config = JSON.parse((await buildOpencodeConfigContent({ ...ENV, SLACK_CHANNEL_ID: 'C1' }))!)
+    expect(config.enabled_providers).toBeUndefined()
+  })
+})
+
 describe('buildOpencodeConfigContent — Slack sessions deny the question tool', () => {
   test('denies `question` when the session carries Slack thread/channel env', async () => {
     const config = JSON.parse((await buildOpencodeConfigContent({ ...ENV, SLACK_THREAD_TS: '1700000000.0001' }))!)

--- a/apps/kortix-sandbox-agent-server/src/__tests__/executor-mcp-config.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/executor-mcp-config.test.ts
@@ -26,15 +26,19 @@ function stubGatewayModels(catalog: Record<string, unknown>) {
   }) as typeof fetch
 }
 
+async function buildConfig(env: NodeJS.ProcessEnv) {
+  const raw = await buildOpencodeConfigContent(env)
+  if (!raw) throw new Error('expected opencode config content')
+  return JSON.parse(raw)
+}
+
 afterEach(() => {
   globalThis.fetch = realFetch
 })
 
 describe('buildOpencodeConfigContent — executor MCP server', () => {
   test('registers the executor MCP server with resolved credentials', async () => {
-    const raw = await buildOpencodeConfigContent(ENV)
-    expect(raw).toBeDefined()
-    const config = JSON.parse(raw!)
+    const config = await buildConfig(ENV)
     const server = config.mcp['kortix-executor']
     expect(server).toMatchObject({
       type: 'local',
@@ -55,14 +59,14 @@ describe('buildOpencodeConfigContent — executor MCP server', () => {
       theme: 'dark',
       mcp: { other: { type: 'local', command: ['echo'], enabled: true } },
     })
-    const config = JSON.parse((await buildOpencodeConfigContent({ ...ENV, OPENCODE_CONFIG_CONTENT: existing }))!)
+    const config = await buildConfig({ ...ENV, OPENCODE_CONFIG_CONTENT: existing })
     expect(config.theme).toBe('dark')
     expect(config.mcp.other).toBeDefined()
     expect(config.mcp['kortix-executor']).toBeDefined()
   })
 
   test('survives malformed pre-existing inline config', async () => {
-    const config = JSON.parse((await buildOpencodeConfigContent({ ...ENV, OPENCODE_CONFIG_CONTENT: 'not json{' }))!)
+    const config = await buildConfig({ ...ENV, OPENCODE_CONFIG_CONTENT: 'not json{' })
     expect(config.mcp['kortix-executor']).toBeDefined()
   })
 })
@@ -75,7 +79,7 @@ describe('buildOpencodeConfigContent — Kortix LLM gateway provider', () => {
 
   test('registers the kortix provider when gateway env present', async () => {
     stubGatewayModels(GATEWAY_CATALOG)
-    const config = JSON.parse((await buildOpencodeConfigContent(GATEWAY_ENV))!)
+    const config = await buildConfig(GATEWAY_ENV)
     expect(config.provider.kortix).toMatchObject({
       npm: '@ai-sdk/openai-compatible',
       name: 'Kortix',
@@ -89,7 +93,7 @@ describe('buildOpencodeConfigContent — Kortix LLM gateway provider', () => {
 
   test('populates the provider models from the gateway /models fetch', async () => {
     stubGatewayModels(GATEWAY_CATALOG)
-    const config = JSON.parse((await buildOpencodeConfigContent(GATEWAY_ENV))!)
+    const config = await buildConfig(GATEWAY_ENV)
     const models = config.provider.kortix.models
     expect(models['anthropic/claude-opus-4.8'].reasoning).toBe(true)
     expect(models['anthropic/claude-sonnet-4.6'].reasoning).toBe(true)
@@ -100,7 +104,7 @@ describe('buildOpencodeConfigContent — Kortix LLM gateway provider', () => {
 
   test('falls back to a minimal catalog when the gateway /models fetch fails', async () => {
     globalThis.fetch = (async () => new Response('boom', { status: 503 })) as unknown as typeof fetch
-    const config = JSON.parse((await buildOpencodeConfigContent(GATEWAY_ENV))!)
+    const config = await buildConfig(GATEWAY_ENV)
     const models = config.provider.kortix.models
     expect(Object.keys(models).length).toBeGreaterThan(0)
     expect(models['kortix-power']).toBeDefined()
@@ -108,29 +112,27 @@ describe('buildOpencodeConfigContent — Kortix LLM gateway provider', () => {
 
   test('sets default model to kortix/* when none in pre-existing config', async () => {
     stubGatewayModels(GATEWAY_CATALOG)
-    const config = JSON.parse((await buildOpencodeConfigContent(GATEWAY_ENV))!)
+    const config = await buildConfig(GATEWAY_ENV)
     expect(config.model).toMatch(/^kortix\//)
   })
 
   test('preserves user-set default model from pre-existing config', async () => {
     stubGatewayModels(GATEWAY_CATALOG)
     const existing = JSON.stringify({ model: 'anthropic/claude-sonnet-4.6' })
-    const config = JSON.parse(
-      (await buildOpencodeConfigContent({ ...GATEWAY_ENV, OPENCODE_CONFIG_CONTENT: existing }))!,
-    )
+    const config = await buildConfig({ ...GATEWAY_ENV, OPENCODE_CONFIG_CONTENT: existing })
     expect(config.model).toBe('anthropic/claude-sonnet-4.6')
   })
 
   test('coexists with the executor MCP server in one config', async () => {
     stubGatewayModels(GATEWAY_CATALOG)
-    const config = JSON.parse((await buildOpencodeConfigContent({ ...ENV, ...GATEWAY_ENV }))!)
+    const config = await buildConfig({ ...ENV, ...GATEWAY_ENV })
     expect(config.mcp['kortix-executor']).toBeDefined()
     expect(config.provider.kortix).toBeDefined()
   })
 
   test('returns config with provider only (no mcp) when executor env missing', async () => {
     stubGatewayModels(GATEWAY_CATALOG)
-    const config = JSON.parse((await buildOpencodeConfigContent(GATEWAY_ENV))!)
+    const config = await buildConfig(GATEWAY_ENV)
     expect(config.provider.kortix).toBeDefined()
     expect(config.mcp).toBeUndefined()
   })
@@ -140,9 +142,7 @@ describe('buildOpencodeConfigContent — Kortix LLM gateway provider', () => {
     const existing = JSON.stringify({
       provider: { anthropic: { options: { timeout: 600000 } } },
     })
-    const config = JSON.parse(
-      (await buildOpencodeConfigContent({ ...GATEWAY_ENV, OPENCODE_CONFIG_CONTENT: existing }))!,
-    )
+    const config = await buildConfig({ ...GATEWAY_ENV, OPENCODE_CONFIG_CONTENT: existing })
     expect(config.provider.anthropic).toBeDefined()
     expect(config.provider.kortix).toBeDefined()
   })
@@ -156,61 +156,62 @@ describe('buildOpencodeConfigContent — gateway is the sole LLM path (enabled_p
 
   test('locks opencode to ONLY the kortix provider when the gateway is active', async () => {
     stubGatewayModels(GATEWAY_CATALOG)
-    const config = JSON.parse((await buildOpencodeConfigContent(GATEWAY_ENV))!)
+    const config = await buildConfig(GATEWAY_ENV)
     expect(config.enabled_providers).toEqual(['kortix'])
   })
 
   test('a leaked native key (e.g. GITHUB_TOKEN) cannot open a native provider — only kortix is enabled', async () => {
     stubGatewayModels(GATEWAY_CATALOG)
-    const config = JSON.parse(
-      (await buildOpencodeConfigContent({ ...GATEWAY_ENV, GITHUB_TOKEN: 'ghp_x', OPENAI_API_KEY: 'sk-x' }))!,
-    )
+    const config = await buildConfig({ ...GATEWAY_ENV, GITHUB_TOKEN: 'ghp_x', OPENAI_API_KEY: 'sk-x' })
     expect(config.enabled_providers).toEqual(['kortix'])
   })
 
   test('keeps providers a connected Codex/OpenCode subscription declares in auth.json', async () => {
     stubGatewayModels(GATEWAY_CATALOG)
     const authJson = JSON.stringify({ openai: { type: 'oauth', access: 'x' }, opencode: { key: 'y' } })
-    const config = JSON.parse((await buildOpencodeConfigContent({ ...GATEWAY_ENV, CODEX_AUTH_JSON: authJson }))!)
+    const config = await buildConfig({ ...GATEWAY_ENV, CODEX_AUTH_JSON: authJson })
     expect(new Set(config.enabled_providers)).toEqual(new Set(['kortix', 'openai', 'opencode']))
   })
 
   test('ignores malformed auth.json and still locks to kortix', async () => {
     stubGatewayModels(GATEWAY_CATALOG)
-    const config = JSON.parse((await buildOpencodeConfigContent({ ...GATEWAY_ENV, OPENCODE_AUTH_JSON: 'not json{' }))!)
+    const config = await buildConfig({ ...GATEWAY_ENV, OPENCODE_AUTH_JSON: 'not json{' })
     expect(config.enabled_providers).toEqual(['kortix'])
   })
 
   test('does NOT set an allowlist when there is no gateway (subscription-only session stays native)', async () => {
-    const config = JSON.parse((await buildOpencodeConfigContent({ ...ENV, SLACK_CHANNEL_ID: 'C1' }))!)
+    const config = await buildConfig({ ...ENV, SLACK_CHANNEL_ID: 'C1' })
     expect(config.enabled_providers).toBeUndefined()
   })
 })
 
 describe('buildOpencodeConfigContent — Slack sessions deny the question tool', () => {
   test('denies `question` when the session carries Slack thread/channel env', async () => {
-    const config = JSON.parse((await buildOpencodeConfigContent({ ...ENV, SLACK_THREAD_TS: '1700000000.0001' }))!)
+    const config = await buildConfig({ ...ENV, SLACK_THREAD_TS: '1700000000.0001' })
     expect(config.permission.question).toBe('deny')
-    const byChannel = JSON.parse((await buildOpencodeConfigContent({ ...ENV, SLACK_CHANNEL_ID: 'C123' }))!)
+    const byChannel = await buildConfig({ ...ENV, SLACK_CHANNEL_ID: 'C123' })
     expect(byChannel.permission.question).toBe('deny')
   })
 
   test('builds the config for a Slack session even with no executor/gateway env', async () => {
     const raw = await buildOpencodeConfigContent({ SLACK_CHANNEL_ID: 'C123' })
     expect(raw).toBeDefined()
-    expect(JSON.parse(raw!).permission.question).toBe('deny')
+    if (!raw) throw new Error('expected opencode config content')
+    expect(JSON.parse(raw).permission.question).toBe('deny')
   })
 
   test('does NOT touch permissions for a non-Slack (web) session — tool stays native', async () => {
-    const config = JSON.parse((await buildOpencodeConfigContent(ENV))!)
+    const config = await buildConfig(ENV)
     expect(config.permission).toBeUndefined()
   })
 
   test('merges the deny onto a pre-existing permission block', async () => {
     const existing = JSON.stringify({ permission: { bash: 'ask' } })
-    const config = JSON.parse(
-      (await buildOpencodeConfigContent({ ...ENV, SLACK_THREAD_TS: '1700000000.0001', OPENCODE_CONFIG_CONTENT: existing }))!,
-    )
+    const config = await buildConfig({
+      ...ENV,
+      SLACK_THREAD_TS: '1700000000.0001',
+      OPENCODE_CONFIG_CONTENT: existing,
+    })
     expect(config.permission.bash).toBe('ask')
     expect(config.permission.question).toBe('deny')
   })

--- a/apps/kortix-sandbox-agent-server/src/opencode.ts
+++ b/apps/kortix-sandbox-agent-server/src/opencode.ts
@@ -101,6 +101,16 @@ export async function buildOpencodeConfigContent(env: NodeJS.ProcessEnv): Promis
     if (!('model' in out) || typeof out.model !== 'string') {
       out.model = DEFAULT_KORTIX_MODEL
     }
+    // Lock opencode to the gateway as the ONLY LLM path. enabled_providers is an
+    // allowlist — opencode loads ONLY these and ignores every provider it would
+    // otherwise auto-detect from env (e.g. GITHUB_TOKEN → GitHub Models,
+    // OPENAI_API_KEY → openai), so a leaked key can't open a native path that
+    // bypasses budgets/logging/spend. This is the robust complement to the env
+    // deny-strip in spawnChild (which can be defeated if a key reaches opencode
+    // by some path the deny-list didn't enumerate). We keep `kortix` plus any
+    // providers the Codex/OpenCode subscription auth.json enables — those are the
+    // user's own subscription (consumed into auth.json, intentionally not gated).
+    out.enabled_providers = gatewayEnabledProviders(env)
   }
 
   // (3) Slack sessions: DENY opencode's blocking `question` tool. A Slack thread
@@ -119,6 +129,26 @@ export async function buildOpencodeConfigContent(env: NodeJS.ProcessEnv): Promis
   }
 
   return JSON.stringify(out)
+}
+
+// The opencode provider allowlist when the gateway is active: always `kortix`,
+// plus any providers the Codex/OpenCode subscription auth.json declares (its
+// top-level keys are provider ids) so a connected subscription keeps working.
+// The auth secret is still present on the env passed here — materializeOpencodeAuth
+// strips it from the spawned process env later, not from this copy.
+function gatewayEnabledProviders(env: NodeJS.ProcessEnv): string[] {
+  const allow = new Set<string>(['kortix'])
+  const authJson = env[CODEX_AUTH_JSON_SECRET] ?? env[OPENCODE_AUTH_JSON_SECRET]
+  if (authJson?.trim()) {
+    try {
+      const parsed = JSON.parse(authJson)
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        for (const provider of Object.keys(parsed)) allow.add(provider)
+      }
+    } catch {
+    }
+  }
+  return [...allow]
 }
 
 async function buildKortixProvider(llmBaseUrl: string, llmApiKey: string): Promise<Record<string, unknown>> {


### PR DESCRIPTION
## The gateway must be the sole path, or it enforces nothing

If the agent can reach a model *without* going through the gateway, then budgets, spend tracking, and request logging don't apply to it — the whole point is lost. opencode breaks this by **auto-detecting provider keys from its environment** and opening *native* providers that bypass the gateway. Concretely, it sees `GITHUB_TOKEN` and renders GitHub Models directly.

### Why the current defense leaks
Today the daemon strips native-provider env vars from the opencode process (the API computes every `provider.env` name from the catalog → `KORTIX_OPENCODE_DENY_ENV` → the daemon deletes them). A **deny-list is inherently leaky**: it only removes the names it enumerated, from the one env it mutates. Anything that reaches opencode's env by a path the list didn't cover still auto-registers a native provider.

### The fix: an allowlist
opencode's config supports **`enabled_providers`** — *"when set, ONLY these providers will be enabled; all others are ignored."* When the gateway is active, we set:

```
enabled_providers = ["kortix", ...providers the subscription auth.json declares]
```

- **`kortix`** is our gateway provider (it already serves the full managed + BYOK + codex catalog), so nothing the user should see is lost.
- A connected **Codex/OpenCode subscription** keeps working — we add the providers its `auth.json` declares (its own subscription, intentionally not gated).
- Every other provider opencode would auto-detect (github-copilot, openai, anthropic, …) is **ignored**, regardless of how a key reached the env.

The env deny-strip stays as defense-in-depth. Subscription-only sessions (no gateway) are untouched, so BYO-subscription still works natively.

### Tests
5 new cases in `executor-mcp-config.test.ts`: locks to `kortix`; a leaked `GITHUB_TOKEN`/`OPENAI_API_KEY` can't open a native provider; subscription `auth.json` providers are preserved; malformed auth.json is ignored; no allowlist is set when there's no gateway. 21/21 pass.