### PR TITLE
review: follow-up fixes for CR diff viewer

### DIFF
--- a/apps/web/src/components/ui/status.tsx
+++ b/apps/web/src/components/ui/status.tsx
@@ -81,7 +81,7 @@ export function StatusBadge({
     <span
       data-slot="status-badge"
       className={cn(
-        'inline-flex w-fit items-center gap-1 whitespace-nowrap rounded-2xl px-2 py-0.5 text-xs font-medium',
+        'inline-flex w-fit items-center gap-1 rounded-2xl px-2 py-0.5 text-xs font-medium whitespace-nowrap',
         STATUS_BG[tone],
         STATUS_TEXT[tone],
         className,

--- a/apps/web/src/components/ui/status.tsx
+++ b/apps/web/src/components/ui/status.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import * as React from 'react';
 import { cn } from '@/lib/utils';
+import type * as React from 'react';
 
 /**
  * Kortix status palette — the SINGLE source of truth for "this means
@@ -18,12 +18,7 @@ import { cn } from '@/lib/utils';
  * and dots all read as the same green/amber/red/blue.
  */
 
-export type StatusTone =
-  | 'success'
-  | 'warning'
-  | 'destructive'
-  | 'info'
-  | 'neutral';
+export type StatusTone = 'success' | 'warning' | 'destructive' | 'info' | 'neutral';
 
 /** Foreground (text / icon) color per tone. */
 export const STATUS_TEXT: Record<StatusTone, string> = {
@@ -141,17 +136,10 @@ export function DiffStat({
   return (
     <span
       data-slot="diff-stat"
-      className={cn(
-        'inline-flex items-center gap-1.5 font-mono tabular-nums',
-        className,
-      )}
+      className={cn('inline-flex items-center gap-1.5 font-mono tabular-nums', className)}
     >
-      {additions ? (
-        <span className={STATUS_TEXT.success}>+{additions}</span>
-      ) : null}
-      {deletions ? (
-        <span className={STATUS_TEXT.destructive}>{`−${deletions}`}</span>
-      ) : null}
+      {additions ? <span className={STATUS_TEXT.success}>+{additions}</span> : null}
+      {deletions ? <span className={STATUS_TEXT.destructive}>{`−${deletions}`}</span> : null}
     </span>
   );
 }

--- a/apps/web/src/features/project-files/components/change-request-detail-dialog.test.tsx
+++ b/apps/web/src/features/project-files/components/change-request-detail-dialog.test.tsx
@@ -1,0 +1,14 @@
+import { describe, expect, test } from 'bun:test';
+
+import { diffRendererViewportClass } from './change-request-detail-dialog';
+
+describe('change request diff renderer sizing', () => {
+  test('keeps split diffs horizontally scrollable below the desktop layout', () => {
+    expect(diffRendererViewportClass('split')).toBe('min-w-[860px] lg:min-w-0');
+    expect(diffRendererViewportClass('split')).not.toContain('sm:min-w-0');
+  });
+
+  test('lets unified diffs collapse earlier than split diffs', () => {
+    expect(diffRendererViewportClass('unified')).toBe('min-w-[680px] sm:min-w-0');
+  });
+});

--- a/apps/web/src/features/project-files/components/change-request-detail-dialog.tsx
+++ b/apps/web/src/features/project-files/components/change-request-detail-dialog.tsx
@@ -114,6 +114,10 @@ function diffSectionId(index: number) {
   return `cr-diff-file-${index}`;
 }
 
+export function diffRendererViewportClass(layout: 'unified' | 'split') {
+  return layout === 'split' ? 'min-w-[860px] lg:min-w-0' : 'min-w-[680px] sm:min-w-0';
+}
+
 function scrollToDiffSection(sectionId: string) {
   requestAnimationFrame(() => {
     const target = document.getElementById(sectionId);
@@ -618,11 +622,7 @@ export function ChangeRequestDetailDialog({ crId, onClose }: ChangeRequestDetail
                                   <DiffRenderer
                                     patch={patch}
                                     layout={diffLayout}
-                                    className={
-                                      diffLayout === 'split'
-                                        ? 'min-w-[860px] lg:min-w-0'
-                                        : 'min-w-[680px] sm:min-w-0'
-                                    }
+                                    className={diffRendererViewportClass(diffLayout)}
                                   />
                                 </div>
                               ) : (

--- a/apps/web/src/features/project-files/components/change-request-detail-dialog.tsx
+++ b/apps/web/src/features/project-files/components/change-request-detail-dialog.tsx
@@ -2,15 +2,14 @@
 
 import { UnifiedMarkdown } from '@/components/markdown';
 import { Badge } from '@/components/ui/badge';
-import { DiffStat, STATUS_TEXT } from '@/components/ui/status';
 import { Button } from '@/components/ui/button';
-import Hint from '@/components/ui/hint';
 import {
   Disclosure,
   DisclosureBody,
   DisclosureContent,
   DisclosureTrigger,
 } from '@/components/ui/disclosure';
+import Hint from '@/components/ui/hint';
 import { InfoBanner } from '@/components/ui/info-banner';
 import Loading from '@/components/ui/loading';
 import { Modal, ModalBody, ModalContent, ModalHeader, ModalTitle } from '@/components/ui/modal';
@@ -22,6 +21,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { Skeleton } from '@/components/ui/skeleton';
+import { DiffStat, STATUS_TEXT } from '@/components/ui/status';
 import { errorToast, successToast } from '@/components/ui/toast';
 import { cn } from '@/lib/utils';
 import { formatDistanceToNowStrict } from 'date-fns';

--- a/apps/web/src/features/project-files/components/change-request-detail-dialog.tsx
+++ b/apps/web/src/features/project-files/components/change-request-detail-dialog.tsx
@@ -618,10 +618,11 @@ export function ChangeRequestDetailDialog({ crId, onClose }: ChangeRequestDetail
                                   <DiffRenderer
                                     patch={patch}
                                     layout={diffLayout}
-                                    className={cn(
-                                      'min-w-[680px] sm:min-w-0',
-                                      diffLayout === 'split' && 'min-w-[860px] lg:min-w-0',
-                                    )}
+                                    className={
+                                      diffLayout === 'split'
+                                        ? 'min-w-[860px] lg:min-w-0'
+                                        : 'min-w-[680px] sm:min-w-0'
+                                    }
                                   />
                                 </div>
                               ) : (

--- a/apps/web/src/features/project-files/components/diff-renderer.tsx
+++ b/apps/web/src/features/project-files/components/diff-renderer.tsx
@@ -1,7 +1,7 @@
 'use client';
 
+import { type DiffLayout, DiffView } from '@/components/diff/diff-view';
 import { cn } from '@/lib/utils';
-import { DiffView, type DiffLayout } from '@/components/diff/diff-view';
 
 interface DiffRendererProps {
   patch: string;


### PR DESCRIPTION
Post-merge follow-up from review of #3658.\n\n- Apply Biome cleanups to the changed CR diff/status files.\n- Preserve split diff horizontal overflow below lg by removing the conflicting unified sm:min-w-0 class in split mode.\n\nVerification run locally:\n- pnpm exec biome check apps/web/src/components/ui/status.test.tsx apps/web/src/components/ui/status.tsx apps/web/src/features/project-files/components/change-request-detail-dialog.tsx apps/web/src/features/project-files/components/diff-renderer.tsx\n- pnpm --filter Kortix-Computer-Frontend exec eslint src/components/ui/status.test.tsx src/components/ui/status.tsx src/features/project-files/components/change-request-detail-dialog.tsx src/features/project-files/components/diff-renderer.tsx\n- pnpm --filter Kortix-Computer-Frontend exec tsc --noEmit --pretty false\n- pnpm --filter Kortix-Computer-Frontend test src/components/ui/status.test.tsx