### PR TITLE
feat(web): Activity section — run observability (Customize → Workspace)

### DIFF
--- a/apps/web/src/components/projects/customize/customize-overlay.tsx
+++ b/apps/web/src/components/projects/customize/customize-overlay.tsx
@@ -25,6 +25,7 @@
 import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import {
+  Activity,
   Bot,
   Container,
   FolderOpen,
@@ -64,6 +65,7 @@ import type { CustomizeSection } from '@/lib/customize-sections';
 import { cn } from '@/lib/utils';
 import { useCustomizeStore } from '@/stores/customize-store';
 
+import { ActivityView } from '@/features/activity/activity-view';
 import { ChangesView } from './sections/changes-view';
 import { DevView } from './sections/dev-view';
 import { FilesSection } from './sections/files-section';
@@ -111,6 +113,7 @@ const GROUPS: readonly RailGroup[] = [
   {
     label: 'Workspace',
     items: [
+      { section: 'activity', label: 'Activity', icon: Activity },
       { section: 'changes', label: 'Changes', icon: GitPullRequest },
       { section: 'files', label: 'Files', icon: FolderOpen },
       { section: 'sandbox', label: 'Sandbox', icon: Container },
@@ -351,6 +354,8 @@ function SectionContent({
   // down the previous tree (matches the per-route behavior the legacy pages
   // had).
   switch (section) {
+    case 'activity':
+      return <ActivityView projectId={projectId} />;
     case 'changes':
       return <ChangesView projectId={projectId} />;
     case 'files':

--- a/apps/web/src/components/projects/customize/customize-overlay.tsx
+++ b/apps/web/src/components/projects/customize/customize-overlay.tsx
@@ -22,7 +22,6 @@
  *   └──────────┴────────────────────────────────────┘
  */
 
-import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import {
   Activity,
@@ -45,7 +44,9 @@ import {
   X,
   type LucideIcon,
 } from 'lucide-react';
+import { useMemo } from 'react';
 
+import { MarketplaceView } from '@/components/marketplace/marketplace-view';
 import { AgentsView } from '@/components/projects/customize/sections/agents-view';
 import { ChannelsView } from '@/components/projects/customize/sections/channels-view';
 import { CommandsView } from '@/components/projects/customize/sections/commands-view';
@@ -56,12 +57,11 @@ import { SandboxView } from '@/components/projects/customize/sections/sandbox-vi
 import { SecretsView } from '@/components/projects/customize/sections/secrets-view';
 import { SettingsView } from '@/components/projects/customize/sections/settings-view';
 import { SkillsView } from '@/components/projects/customize/sections/skills-view';
-import { MarketplaceView } from '@/components/marketplace/marketplace-view';
 import { TriggersView } from '@/components/projects/triggers-view';
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
 import { useIsMobile } from '@/hooks/utils';
-import { getProjectDetail } from '@/lib/projects-client';
 import type { CustomizeSection } from '@/lib/customize-sections';
+import { getProjectDetail } from '@/lib/projects-client';
 import { cn } from '@/lib/utils';
 import { useCustomizeStore } from '@/stores/customize-store';
 
@@ -205,21 +205,19 @@ export function CustomizeOverlay({ projectId }: { projectId: string }) {
           'h-[100dvh] w-screen max-w-none rounded-none border-0 shadow-none sm:max-w-none sm:rounded-none',
         )}
       >
-        <DialogTitle className="sr-only">
-          Customize {projectName || 'project'}
-        </DialogTitle>
+        <DialogTitle className="sr-only">Customize {projectName || 'project'}</DialogTitle>
 
         {/* Header. `kx-customize-header` indents the title past the OS window
             controls on desktop (macOS traffic lights left; Win/Linux controls
             right) without adding vertical space. No-op on the web. */}
-        <div className="kx-customize-header flex h-12 shrink-0 items-center justify-between border-b border-border/60 pl-4 pr-2">
+        <div className="kx-customize-header border-border/60 flex h-12 shrink-0 items-center justify-between border-b pr-2 pl-4">
           <div className="flex min-w-0 items-center gap-2 text-sm">
-            <SlidersHorizontal className="size-4 shrink-0 text-muted-foreground" />
-            <span className="font-medium text-foreground">Customize</span>
+            <SlidersHorizontal className="text-muted-foreground size-4 shrink-0" />
+            <span className="text-foreground font-medium">Customize</span>
             {projectName && (
               <>
                 <span className="text-muted-foreground/40">·</span>
-                <span className="truncate text-muted-foreground">{projectName}</span>
+                <span className="text-muted-foreground truncate">{projectName}</span>
               </>
             )}
           </div>
@@ -227,7 +225,7 @@ export function CustomizeOverlay({ projectId }: { projectId: string }) {
             type="button"
             onClick={close}
             aria-label="Close"
-            className="flex size-8 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            className="text-muted-foreground hover:bg-muted hover:text-foreground flex size-8 items-center justify-center rounded-lg transition-colors"
           >
             <X className="size-4" />
           </button>
@@ -238,9 +236,9 @@ export function CustomizeOverlay({ projectId }: { projectId: string }) {
           {isMobile ? (
             <nav
               aria-label="Customize"
-              className="w-full shrink-0 border-b border-border/60 bg-background"
+              className="border-border/60 bg-background w-full shrink-0 border-b"
             >
-              <ul className="flex items-center gap-1 overflow-x-auto px-2 py-2 [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]">
+              <ul className="flex [scrollbar-width:none] items-center gap-1 overflow-x-auto px-2 py-2 [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden">
                 {allItems.map((item) => (
                   <li key={item.section} className="shrink-0">
                     <RailButton
@@ -256,13 +254,13 @@ export function CustomizeOverlay({ projectId }: { projectId: string }) {
           ) : (
             <nav
               aria-label="Customize"
-              className="flex w-[196px] shrink-0 flex-col border-r border-border/60 bg-muted/20"
+              className="border-border/60 bg-muted/20 flex w-[196px] shrink-0 flex-col border-r"
             >
-              <div className="flex-1 overflow-y-auto px-2.5 py-3 [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]">
+              <div className="flex-1 [scrollbar-width:none] overflow-y-auto px-2.5 py-3 [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden">
                 {groups.map((group, idx) => (
                   <div key={group.label ?? idx} className={idx > 0 ? 'mt-4' : undefined}>
                     {group.label && (
-                      <div className="px-2 pb-1.5 text-xs font-medium uppercase tracking-wider text-muted-foreground/50">
+                      <div className="text-muted-foreground/50 px-2 pb-1.5 text-xs font-medium tracking-wider uppercase">
                         {group.label}
                       </div>
                     )}
@@ -283,7 +281,7 @@ export function CustomizeOverlay({ projectId }: { projectId: string }) {
             </nav>
           )}
 
-          <main className="min-h-0 min-w-0 flex-1 overflow-hidden bg-background">
+          <main className="bg-background min-h-0 min-w-0 flex-1 overflow-hidden">
             {open && <SectionContent section={section} projectId={projectId} />}
           </main>
         </div>
@@ -312,7 +310,7 @@ function RailButton({
       aria-current={active ? 'page' : undefined}
       className={cn(
         'group relative flex cursor-pointer items-center gap-2.5 rounded-lg text-sm font-medium transition-colors',
-        horizontal ? 'whitespace-nowrap px-3 py-2' : 'w-full px-2.5 py-1.5 text-left',
+        horizontal ? 'px-3 py-2 whitespace-nowrap' : 'w-full px-2.5 py-1.5 text-left',
         // On-brand selected state: tinted primary (themed), never a flat grey
         // or floating card chip. Hover stays a soft neutral wash.
         active
@@ -343,13 +341,7 @@ function RailButton({
   );
 }
 
-function SectionContent({
-  section,
-  projectId,
-}: {
-  section: CustomizeSection;
-  projectId: string;
-}) {
+function SectionContent({ section, projectId }: { section: CustomizeSection; projectId: string }) {
   // Each branch is a separate component instance, so switching sections tears
   // down the previous tree (matches the per-route behavior the legacy pages
   // had).

--- a/apps/web/src/components/projects/customize/customize-overlay.tsx
+++ b/apps/web/src/components/projects/customize/customize-overlay.tsx
@@ -30,6 +30,7 @@ import {
   FolderOpen,
   GitPullRequest,
   KeyRound,
+  type LucideIcon,
   MessageSquare,
   Monitor,
   Plug,
@@ -42,7 +43,6 @@ import {
   Users,
   Webhook,
   X,
-  type LucideIcon,
 } from 'lucide-react';
 import { useMemo } from 'react';
 

--- a/apps/web/src/features/activity/activity-status.test.ts
+++ b/apps/web/src/features/activity/activity-status.test.ts
@@ -7,9 +7,11 @@ import {
   formatUsd,
   isLiveRun,
   matchesRunStatus,
+  rangeDays,
   runStatusLabel,
   runStatusTone,
   sortRuns,
+  withinRange,
 } from './activity-status';
 
 describe('activity-status', () => {
@@ -74,5 +76,18 @@ describe('activity-status', () => {
     expect(sortRuns(runs, 'recent', cost).map((r) => r.session_id)).toEqual(['b', 'c', 'a']);
     expect(sortRuns(runs, 'cost', cost).map((r) => r.session_id)).toEqual(['a', 'c', 'b']);
     expect(sortRuns(runs, 'duration', cost).map((r) => r.session_id)).toEqual(['b', 'c', 'a']);
+  });
+
+  test('withinRange respects the window with a fixed now', () => {
+    const now = Date.parse('2026-01-31T00:00:00Z');
+    const recent = '2026-01-29T12:00:00Z'; // 1.5d ago
+    const old = '2026-01-01T00:00:00Z'; // 30d ago
+    expect(withinRange(recent, '1d', now)).toBe(false);
+    expect(withinRange(recent, '7d', now)).toBe(true);
+    expect(withinRange(old, '30d', now)).toBe(true);
+    expect(withinRange(old, '7d', now)).toBe(false);
+    expect(withinRange(old, 'all', now)).toBe(true);
+    expect(rangeDays('all')).toBeNull();
+    expect(rangeDays('7d')).toBe(7);
   });
 });

--- a/apps/web/src/features/activity/activity-status.test.ts
+++ b/apps/web/src/features/activity/activity-status.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test';
 
 import {
   formatRunDuration,
+  formatUsd,
   isLiveRun,
   matchesRunStatus,
   runStatusLabel,
@@ -49,5 +50,12 @@ describe('activity-status', () => {
     expect(formatRunDuration(t0, '2026-01-01T02:05:00.000Z')).toBe('2h 5m');
     expect(formatRunDuration(t0, t0)).toBeNull();
     expect(formatRunDuration('2026-01-01T00:01:00.000Z', t0)).toBeNull();
+  });
+
+  test('formats USD with extra precision for cheap runs', () => {
+    expect(formatUsd(0)).toBe('$0.00');
+    expect(formatUsd(0.0012)).toBe('$0.0012');
+    expect(formatUsd(0.123)).toBe('$0.123');
+    expect(formatUsd(12.5)).toBe('$12.50');
   });
 });

--- a/apps/web/src/features/activity/activity-status.test.ts
+++ b/apps/web/src/features/activity/activity-status.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, test } from 'bun:test';
 
-import { isLiveRun, runStatusLabel, runStatusTone } from './activity-status';
+import {
+  formatRunDuration,
+  isLiveRun,
+  matchesRunStatus,
+  runStatusLabel,
+  runStatusTone,
+} from './activity-status';
 
 describe('activity-status', () => {
   test('maps terminal and live statuses to the right tone', () => {
@@ -24,5 +30,24 @@ describe('activity-status', () => {
     expect(runStatusLabel('provisioning')).toBe('Provisioning');
     expect(runStatusLabel('completed')).toBe('Completed');
     expect(runStatusLabel('failed')).toBe('Failed');
+  });
+
+  test('filters by outcome (running / failed / completed / all)', () => {
+    expect(matchesRunStatus('running', 'running')).toBe(true);
+    expect(matchesRunStatus('provisioning', 'running')).toBe(true);
+    expect(matchesRunStatus('completed', 'running')).toBe(false);
+    expect(matchesRunStatus('failed', 'failed')).toBe(true);
+    expect(matchesRunStatus('completed', 'failed')).toBe(false);
+    expect(matchesRunStatus('completed', 'completed')).toBe(true);
+    expect(matchesRunStatus('failed', 'all')).toBe(true);
+  });
+
+  test('formats run duration deterministically', () => {
+    const t0 = '2026-01-01T00:00:00.000Z';
+    expect(formatRunDuration(t0, '2026-01-01T00:00:45.000Z')).toBe('45s');
+    expect(formatRunDuration(t0, '2026-01-01T00:01:23.000Z')).toBe('1m 23s');
+    expect(formatRunDuration(t0, '2026-01-01T02:05:00.000Z')).toBe('2h 5m');
+    expect(formatRunDuration(t0, t0)).toBeNull();
+    expect(formatRunDuration('2026-01-01T00:01:00.000Z', t0)).toBeNull();
   });
 });

--- a/apps/web/src/features/activity/activity-status.test.ts
+++ b/apps/web/src/features/activity/activity-status.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from 'bun:test';
+
+import { isLiveRun, runStatusLabel, runStatusTone } from './activity-status';
+
+describe('activity-status', () => {
+  test('maps terminal and live statuses to the right tone', () => {
+    expect(runStatusTone('completed')).toBe('success');
+    expect(runStatusTone('failed')).toBe('destructive');
+    expect(runStatusTone('running')).toBe('info');
+    expect(runStatusTone('provisioning')).toBe('warning');
+    expect(runStatusTone('stopped')).toBe('neutral');
+  });
+
+  test('flags still-working runs and not terminal ones', () => {
+    expect(isLiveRun('running')).toBe(true);
+    expect(isLiveRun('provisioning')).toBe(true);
+    expect(isLiveRun('queued')).toBe(true);
+    expect(isLiveRun('completed')).toBe(false);
+    expect(isLiveRun('failed')).toBe(false);
+    expect(isLiveRun('stopped')).toBe(false);
+  });
+
+  test('humanizes status labels', () => {
+    expect(runStatusLabel('provisioning')).toBe('Provisioning');
+    expect(runStatusLabel('completed')).toBe('Completed');
+    expect(runStatusLabel('failed')).toBe('Failed');
+  });
+});

--- a/apps/web/src/features/activity/activity-status.test.ts
+++ b/apps/web/src/features/activity/activity-status.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 
+import type { ProjectSession } from '@/lib/projects-client';
+
 import {
   formatRunDuration,
   formatUsd,
@@ -7,6 +9,7 @@ import {
   matchesRunStatus,
   runStatusLabel,
   runStatusTone,
+  sortRuns,
 } from './activity-status';
 
 describe('activity-status', () => {
@@ -57,5 +60,19 @@ describe('activity-status', () => {
     expect(formatUsd(0.0012)).toBe('$0.0012');
     expect(formatUsd(0.123)).toBe('$0.123');
     expect(formatUsd(12.5)).toBe('$12.50');
+  });
+
+  test('sortRuns orders by recency, cost, or duration', () => {
+    const mk = (id: string, created: string, updated: string) =>
+      ({ session_id: id, created_at: created, updated_at: updated }) as unknown as ProjectSession;
+    const a = mk('a', '2026-01-01T00:00:00Z', '2026-01-01T00:00:30Z'); // 30s
+    const b = mk('b', '2026-01-02T00:00:00Z', '2026-01-02T00:10:00Z'); // 10m, newest
+    const c = mk('c', '2026-01-01T12:00:00Z', '2026-01-01T12:01:00Z'); // 1m
+    const runs = [a, b, c];
+    const cost = (id: string) => ({ a: 5, b: 1, c: 2 })[id] ?? 0;
+
+    expect(sortRuns(runs, 'recent', cost).map((r) => r.session_id)).toEqual(['b', 'c', 'a']);
+    expect(sortRuns(runs, 'cost', cost).map((r) => r.session_id)).toEqual(['a', 'c', 'b']);
+    expect(sortRuns(runs, 'duration', cost).map((r) => r.session_id)).toEqual(['b', 'c', 'a']);
   });
 });

--- a/apps/web/src/features/activity/activity-status.ts
+++ b/apps/web/src/features/activity/activity-status.ts
@@ -133,9 +133,7 @@ export function sortRuns(
 ): ProjectSession[] {
   const arr = [...runs];
   if (sort === 'cost') {
-    arr.sort(
-      (a, b) => costOf(b.session_id) - costOf(a.session_id) || recencyMs(b) - recencyMs(a),
-    );
+    arr.sort((a, b) => costOf(b.session_id) - costOf(a.session_id) || recencyMs(b) - recencyMs(a));
   } else if (sort === 'duration') {
     arr.sort((a, b) => durationMs(b) - durationMs(a) || recencyMs(b) - recencyMs(a));
   } else {

--- a/apps/web/src/features/activity/activity-status.ts
+++ b/apps/web/src/features/activity/activity-status.ts
@@ -1,5 +1,5 @@
 import type { StatusTone } from '@/components/ui/status';
-import type { ProjectSessionStatus } from '@/lib/projects-client';
+import type { ProjectSession, ProjectSessionStatus } from '@/lib/projects-client';
 
 const LIVE_STATUSES: readonly ProjectSessionStatus[] = [
   'queued',
@@ -105,4 +105,41 @@ export function formatUsd(n: number): string {
   if (n < 0.01) return `$${n.toFixed(4)}`;
   if (n < 1) return `$${n.toFixed(3)}`;
   return `$${n.toFixed(2)}`;
+}
+
+export type RunSort = 'recent' | 'cost' | 'duration';
+
+export const RUN_SORTS: ReadonlyArray<{ value: RunSort; label: string }> = [
+  { value: 'recent', label: 'Most recent' },
+  { value: 'cost', label: 'Highest cost' },
+  { value: 'duration', label: 'Longest' },
+];
+
+function recencyMs(s: ProjectSession): number {
+  const t = Date.parse(s.created_at);
+  return Number.isFinite(t) ? t : 0;
+}
+
+function durationMs(s: ProjectSession): number {
+  const d = Date.parse(s.updated_at) - Date.parse(s.created_at);
+  return Number.isFinite(d) && d > 0 ? d : 0;
+}
+
+/** Sort runs by recency (default), gateway cost, or duration — newest breaks ties. */
+export function sortRuns(
+  runs: ProjectSession[],
+  sort: RunSort,
+  costOf: (sessionId: string) => number,
+): ProjectSession[] {
+  const arr = [...runs];
+  if (sort === 'cost') {
+    arr.sort(
+      (a, b) => costOf(b.session_id) - costOf(a.session_id) || recencyMs(b) - recencyMs(a),
+    );
+  } else if (sort === 'duration') {
+    arr.sort((a, b) => durationMs(b) - durationMs(a) || recencyMs(b) - recencyMs(a));
+  } else {
+    arr.sort((a, b) => recencyMs(b) - recencyMs(a));
+  }
+  return arr;
 }

--- a/apps/web/src/features/activity/activity-status.ts
+++ b/apps/web/src/features/activity/activity-status.ts
@@ -98,3 +98,11 @@ export function formatRunDuration(startIso: string, endIso: string): string | nu
   if (m > 0) return `${m}m ${s}s`;
   return `${s}s`;
 }
+
+/** Compact USD for a per-run cost — more precision for cheap runs. */
+export function formatUsd(n: number): string {
+  if (!Number.isFinite(n) || n <= 0) return '$0.00';
+  if (n < 0.01) return `$${n.toFixed(4)}`;
+  if (n < 1) return `$${n.toFixed(3)}`;
+  return `$${n.toFixed(2)}`;
+}

--- a/apps/web/src/features/activity/activity-status.ts
+++ b/apps/web/src/features/activity/activity-status.ts
@@ -1,0 +1,55 @@
+import type { StatusTone } from '@/components/ui/status';
+import type { ProjectSessionStatus } from '@/lib/projects-client';
+
+const LIVE_STATUSES: readonly ProjectSessionStatus[] = [
+  'queued',
+  'branching',
+  'provisioning',
+  'running',
+];
+
+/** A run that is still booting or working — drives polling + the pulsing dot. */
+export function isLiveRun(status: ProjectSessionStatus): boolean {
+  return LIVE_STATUSES.includes(status);
+}
+
+/** Map a run's status to a design-system status tone (StatusBadge / StatusDot). */
+export function runStatusTone(status: ProjectSessionStatus): StatusTone {
+  switch (status) {
+    case 'completed':
+      return 'success';
+    case 'failed':
+      return 'destructive';
+    case 'running':
+      return 'info';
+    case 'queued':
+    case 'branching':
+    case 'provisioning':
+      return 'warning';
+    case 'stopped':
+      return 'neutral';
+    default:
+      return 'neutral';
+  }
+}
+
+export function runStatusLabel(status: ProjectSessionStatus): string {
+  switch (status) {
+    case 'queued':
+      return 'Queued';
+    case 'branching':
+      return 'Branching';
+    case 'provisioning':
+      return 'Provisioning';
+    case 'running':
+      return 'Running';
+    case 'stopped':
+      return 'Stopped';
+    case 'failed':
+      return 'Failed';
+    case 'completed':
+      return 'Completed';
+    default:
+      return status;
+  }
+}

--- a/apps/web/src/features/activity/activity-status.ts
+++ b/apps/web/src/features/activity/activity-status.ts
@@ -53,3 +53,48 @@ export function runStatusLabel(status: ProjectSessionStatus): string {
       return status;
   }
 }
+
+export type RunStatusFilter = 'all' | 'running' | 'failed' | 'completed';
+
+export const RUN_STATUS_FILTERS: ReadonlyArray<{ value: RunStatusFilter; label: string }> = [
+  { value: 'all', label: 'All' },
+  { value: 'running', label: 'Running' },
+  { value: 'failed', label: 'Failed' },
+  { value: 'completed', label: 'Completed' },
+];
+
+/** Outcome filter for the Activity list. `running` = any still-live run. */
+export function matchesRunStatus(status: ProjectSessionStatus, filter: RunStatusFilter): boolean {
+  switch (filter) {
+    case 'all':
+      return true;
+    case 'running':
+      return isLiveRun(status);
+    case 'failed':
+      return status === 'failed';
+    case 'completed':
+      return status === 'completed';
+    default:
+      return true;
+  }
+}
+
+/**
+ * Human duration between two ISO timestamps — "45s", "1m 23s", "2h 5m".
+ * Pure + deterministic (no wall-clock); returns null for an invalid or
+ * non-positive span, so it's only meaningful for a finished run.
+ */
+export function formatRunDuration(startIso: string, endIso: string): string | null {
+  const start = Date.parse(startIso);
+  const end = Date.parse(endIso);
+  if (!Number.isFinite(start) || !Number.isFinite(end)) return null;
+  const ms = end - start;
+  if (ms <= 0) return null;
+  const totalSec = Math.round(ms / 1000);
+  const h = Math.floor(totalSec / 3600);
+  const m = Math.floor((totalSec % 3600) / 60);
+  const s = totalSec % 60;
+  if (h > 0) return `${h}h ${m}m`;
+  if (m > 0) return `${m}m ${s}s`;
+  return `${s}s`;
+}

--- a/apps/web/src/features/activity/activity-status.ts
+++ b/apps/web/src/features/activity/activity-status.ts
@@ -143,3 +143,35 @@ export function sortRuns(
   }
   return arr;
 }
+
+export type RunRange = '1d' | '7d' | '30d' | 'all';
+
+export const RUN_RANGES: ReadonlyArray<{ value: RunRange; label: string }> = [
+  { value: '1d', label: '24h' },
+  { value: '7d', label: '7d' },
+  { value: '30d', label: '30d' },
+  { value: 'all', label: 'All time' },
+];
+
+/** Days for a range, or null for "all time" (used to scope the gateway cost query). */
+export function rangeDays(range: RunRange): number | null {
+  switch (range) {
+    case '1d':
+      return 1;
+    case '7d':
+      return 7;
+    case '30d':
+      return 30;
+    default:
+      return null;
+  }
+}
+
+/** Whether a run's createdAt falls within the range. Pure — pass `nowMs` in. */
+export function withinRange(createdAtIso: string, range: RunRange, nowMs: number): boolean {
+  const days = rangeDays(range);
+  if (days === null) return true;
+  const t = Date.parse(createdAtIso);
+  if (!Number.isFinite(t)) return true;
+  return nowMs - t <= days * 86_400_000;
+}

--- a/apps/web/src/features/activity/activity-view.tsx
+++ b/apps/web/src/features/activity/activity-view.tsx
@@ -4,7 +4,15 @@ import { useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useQuery } from '@tanstack/react-query';
 import { formatDistanceToNowStrict } from 'date-fns';
-import { Activity, CalendarClock, MessageSquare, Receipt, Search, Webhook } from 'lucide-react';
+import {
+  Activity,
+  CalendarClock,
+  ExternalLink,
+  MessageSquare,
+  Receipt,
+  Search,
+  Webhook,
+} from 'lucide-react';
 
 import {
   matchesSessionFilter,
@@ -273,21 +281,37 @@ function RunRow({
         </InlineMeta>
       }
       trailing={
-        <div className="flex flex-col items-end gap-1">
-          {run.status === 'failed' && run.error ? (
-            <Hint label={run.error}>{statusBadge}</Hint>
-          ) : (
-            statusBadge
-          )}
-          {cost && cost.total_cost > 0 && (
-            <Hint
-              label={`LLM ${formatUsd(cost.llm_cost)} · compute ${formatUsd(cost.compute_cost)}`}
-            >
-              <span className="text-muted-foreground text-xs tabular-nums">
-                {formatUsd(cost.total_cost)}
-              </span>
+        <div className="flex items-center gap-1.5">
+          {live && run.sandbox_url && (
+            <Hint label="Open this run's live workspace">
+              <a
+                href={run.sandbox_url}
+                target="_blank"
+                rel="noreferrer"
+                onClick={(e) => e.stopPropagation()}
+                aria-label="Open run workspace"
+                className="text-muted-foreground hover:text-foreground hover:bg-muted/60 flex size-7 shrink-0 cursor-pointer items-center justify-center rounded-md transition-colors"
+              >
+                <ExternalLink className="size-3.5" />
+              </a>
             </Hint>
           )}
+          <div className="flex flex-col items-end gap-1">
+            {run.status === 'failed' && run.error ? (
+              <Hint label={run.error}>{statusBadge}</Hint>
+            ) : (
+              statusBadge
+            )}
+            {cost && cost.total_cost > 0 && (
+              <Hint
+                label={`LLM ${formatUsd(cost.llm_cost)} · compute ${formatUsd(cost.compute_cost)}`}
+              >
+                <span className="text-muted-foreground text-xs tabular-nums">
+                  {formatUsd(cost.total_cost)}
+                </span>
+              </Hint>
+            )}
+          </div>
         </div>
       }
     />

--- a/apps/web/src/features/activity/activity-view.tsx
+++ b/apps/web/src/features/activity/activity-view.tsx
@@ -29,6 +29,13 @@ import Hint from '@/components/ui/hint';
 import { Input } from '@/components/ui/input';
 import { InlineMeta } from '@/components/ui/inline-meta';
 import { List, ListRow } from '@/components/ui/list';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import { Skeleton } from '@/components/ui/skeleton';
 import { StatusBadge, StatusDot } from '@/components/ui/status';
 import { FilterBar, FilterBarItem } from '@/components/ui/tabs';
@@ -46,7 +53,10 @@ import {
   matchesRunStatus,
   runStatusLabel,
   runStatusTone,
+  sortRuns,
+  RUN_SORTS,
   RUN_STATUS_FILTERS,
+  type RunSort,
   type RunStatusFilter,
 } from './activity-status';
 
@@ -79,6 +89,7 @@ export function ActivityView({ projectId }: { projectId: string }) {
   const [source, setSource] = useState<SessionFilterValue>('all');
   const [status, setStatus] = useState<RunStatusFilter>('all');
   const [search, setSearch] = useState('');
+  const [sort, setSort] = useState<RunSort>('recent');
 
   const sessionsQuery = useQuery({
     queryKey: ['project-sessions', projectId],
@@ -96,16 +107,15 @@ export function ActivityView({ projectId }: { projectId: string }) {
   }, [gateway.data]);
   const openGateway = useGatewayOverlayStore((s) => s.openGateway);
 
-  const runs = useMemo(
-    () =>
-      (sessionsQuery.data ?? []).filter(
-        (s) =>
-          matchesSessionFilter(s, source) &&
-          matchesRunStatus(s.status, status) &&
-          matchesSearch(s, search),
-      ),
-    [sessionsQuery.data, source, status, search],
-  );
+  const runs = useMemo(() => {
+    const filtered = (sessionsQuery.data ?? []).filter(
+      (s) =>
+        matchesSessionFilter(s, source) &&
+        matchesRunStatus(s.status, status) &&
+        matchesSearch(s, search),
+    );
+    return sortRuns(filtered, sort, (id) => costBySession.get(id)?.total_cost ?? 0);
+  }, [sessionsQuery.data, source, status, search, sort, costBySession]);
 
   const stats = useMemo(() => {
     const all = sessionsQuery.data ?? [];
@@ -177,6 +187,18 @@ export function ActivityView({ projectId }: { projectId: string }) {
             {opt.label}
           </Button>
         ))}
+        <Select value={sort} onValueChange={(v) => setSort(v as RunSort)}>
+          <SelectTrigger className="ml-auto h-8 w-[150px] shrink-0 text-sm">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {RUN_SORTS.map((opt) => (
+              <SelectItem key={opt.value} value={opt.value}>
+                {opt.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
       </div>
 
       <div className="min-h-0 flex-1 overflow-y-auto">

--- a/apps/web/src/features/activity/activity-view.tsx
+++ b/apps/web/src/features/activity/activity-view.tsx
@@ -146,6 +146,7 @@ export function ActivityView({ projectId }: { projectId: string }) {
       failed: all.filter((s) => s.status === 'failed').length,
     };
   }, [sessionsQuery.data, range]);
+  const sessionLoadFailed = sessionsQuery.isError && !sessionsQuery.data;
 
   return (
     <div className="bg-background flex h-full min-h-0 flex-col">
@@ -240,7 +241,7 @@ export function ActivityView({ projectId }: { projectId: string }) {
             <InfoBanner
               tone="destructive"
               icon={AlertTriangle}
-              title="Activity failed to load"
+              title={sessionLoadFailed ? 'Activity failed to load' : 'Activity refresh failed'}
               className="mb-3"
             >
               {errorMessage(sessionsQuery.error, 'Refresh and try again.')}
@@ -277,7 +278,7 @@ export function ActivityView({ projectId }: { projectId: string }) {
               )}
             </div>
           )}
-          {sessionsQuery.isError ? null : sessionsQuery.isLoading ? (
+          {sessionLoadFailed ? null : sessionsQuery.isLoading ? (
             <List>
               {Array.from({ length: 6 }).map((_, i) => (
                 <ListRow

--- a/apps/web/src/features/activity/activity-view.tsx
+++ b/apps/web/src/features/activity/activity-view.tsx
@@ -1,0 +1,164 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import Link from 'next/link';
+import { useQuery } from '@tanstack/react-query';
+import { formatDistanceToNowStrict } from 'date-fns';
+import { Activity, CalendarClock, MessageSquare, Webhook } from 'lucide-react';
+
+import {
+  matchesSessionFilter,
+  sessionDisplayLabel,
+  sessionSource,
+  SESSION_FILTER_OPTIONS,
+  type SessionFilterValue,
+  type SessionSourceKind,
+} from '@/components/projects/session-label';
+import { CustomizeSectionHeader } from '@/components/projects/customize/customize-section-header';
+import { Button } from '@/components/ui/button';
+import { EmptyState } from '@/components/ui/empty-state';
+import Hint from '@/components/ui/hint';
+import { InlineMeta } from '@/components/ui/inline-meta';
+import { List, ListRow } from '@/components/ui/list';
+import { Skeleton } from '@/components/ui/skeleton';
+import { StatusBadge, StatusDot } from '@/components/ui/status';
+import { Icon } from '@/features/icon/icon';
+import { listProjectSessions, type ProjectSession } from '@/lib/projects-client';
+import { cn } from '@/lib/utils';
+
+import { isLiveRun, runStatusLabel, runStatusTone } from './activity-status';
+
+const SOURCE_LABEL: Record<SessionSourceKind, string> = {
+  chat: 'Chat',
+  slack: 'Slack',
+  telegram: 'Telegram',
+  schedule: 'Scheduled',
+  webhook: 'Webhook',
+};
+
+function SourceIcon({ kind, className }: { kind: SessionSourceKind; className?: string }) {
+  if (kind === 'slack') return <Icon.Slack className={className} />;
+  if (kind === 'telegram') return <Icon.Telegram className={className} />;
+  if (kind === 'schedule') return <CalendarClock className={className} />;
+  if (kind === 'webhook') return <Webhook className={className} />;
+  return <MessageSquare className={className} />;
+}
+
+export function ActivityView({ projectId }: { projectId: string }) {
+  const [filter, setFilter] = useState<SessionFilterValue>('all');
+
+  const sessionsQuery = useQuery({
+    queryKey: ['project-sessions', projectId],
+    queryFn: () => listProjectSessions(projectId),
+    enabled: !!projectId,
+    refetchInterval: (query) =>
+      (query.state.data ?? []).some((s) => isLiveRun(s.status)) ? 5000 : false,
+  });
+
+  const runs = useMemo(
+    () => (sessionsQuery.data ?? []).filter((s) => matchesSessionFilter(s, filter)),
+    [sessionsQuery.data, filter],
+  );
+
+  return (
+    <div className="bg-background flex h-full min-h-0 flex-col">
+      <CustomizeSectionHeader
+        icon={Activity}
+        title="Activity"
+        count={sessionsQuery.data ? runs.length : undefined}
+      />
+
+      <div className="border-border/60 flex shrink-0 items-center gap-1 overflow-x-auto border-b px-3 py-2 [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]">
+        {SESSION_FILTER_OPTIONS.map((opt) => (
+          <Button
+            key={opt.value}
+            type="button"
+            size="sm"
+            variant="ghost"
+            onClick={() => setFilter(opt.value)}
+            aria-pressed={filter === opt.value}
+            className={cn(
+              'h-7 shrink-0 rounded-full',
+              filter === opt.value && 'bg-primary/10 text-primary',
+            )}
+          >
+            {opt.label}
+          </Button>
+        ))}
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        <div className="mx-auto w-full max-w-3xl px-4 py-5">
+          {sessionsQuery.isLoading ? (
+            <List>
+              {Array.from({ length: 6 }).map((_, i) => (
+                <ListRow
+                  key={i}
+                  leading={<Skeleton className="size-8 rounded-lg" />}
+                  title={<Skeleton className="h-4 w-48" />}
+                  subtitle={<Skeleton className="mt-1 h-3 w-32" />}
+                />
+              ))}
+            </List>
+          ) : runs.length === 0 ? (
+            <EmptyState
+              icon={Activity}
+              title={filter === 'all' ? 'No runs yet' : 'No runs match this filter'}
+              description={
+                filter === 'all'
+                  ? 'Sessions you start, and ones fired by schedules, webhooks or channels, will show up here.'
+                  : 'Try a different filter to see other runs.'
+              }
+            />
+          ) : (
+            <List>
+              {runs.map((run) => (
+                <RunRow key={run.session_id} projectId={projectId} run={run} />
+              ))}
+            </List>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function RunRow({ projectId, run }: { projectId: string; run: ProjectSession }) {
+  const kind = sessionSource(run).kind;
+  const tone = runStatusTone(run.status);
+  const live = isLiveRun(run.status);
+  const statusBadge = (
+    <StatusBadge tone={tone}>
+      <StatusDot tone={tone} pulse={live} />
+      {runStatusLabel(run.status)}
+    </StatusBadge>
+  );
+
+  return (
+    <ListRow
+      leading={
+        <span className="bg-muted/60 text-muted-foreground flex size-8 shrink-0 items-center justify-center rounded-lg">
+          <SourceIcon kind={kind} className="size-4" />
+        </span>
+      }
+      title={
+        <Link
+          href={`/projects/${projectId}/sessions/${run.session_id}`}
+          className="hover:text-primary truncate font-medium"
+        >
+          {sessionDisplayLabel(run)}
+        </Link>
+      }
+      subtitle={
+        <InlineMeta>
+          {SOURCE_LABEL[kind]}
+          {run.agent_name || null}
+          {formatDistanceToNowStrict(new Date(run.created_at), { addSuffix: true })}
+        </InlineMeta>
+      }
+      trailing={
+        run.status === 'failed' && run.error ? <Hint label={run.error}>{statusBadge}</Hint> : statusBadge
+      }
+    />
+  );
+}

--- a/apps/web/src/features/activity/activity-view.tsx
+++ b/apps/web/src/features/activity/activity-view.tsx
@@ -51,11 +51,15 @@ import {
   formatUsd,
   isLiveRun,
   matchesRunStatus,
+  rangeDays,
   runStatusLabel,
   runStatusTone,
   sortRuns,
+  withinRange,
+  RUN_RANGES,
   RUN_SORTS,
   RUN_STATUS_FILTERS,
+  type RunRange,
   type RunSort,
   type RunStatusFilter,
 } from './activity-status';
@@ -90,6 +94,7 @@ export function ActivityView({ projectId }: { projectId: string }) {
   const [status, setStatus] = useState<RunStatusFilter>('all');
   const [search, setSearch] = useState('');
   const [sort, setSort] = useState<RunSort>('recent');
+  const [range, setRange] = useState<RunRange>('30d');
 
   const sessionsQuery = useQuery({
     queryKey: ['project-sessions', projectId],
@@ -99,7 +104,7 @@ export function ActivityView({ projectId }: { projectId: string }) {
       (query.state.data ?? []).some((s) => isLiveRun(s.status)) ? 5000 : false,
   });
 
-  const gateway = useGatewaySessions(projectId);
+  const gateway = useGatewaySessions(projectId, rangeDays(range) ?? 365);
   const costBySession = useMemo(() => {
     const m = new Map<string, GatewaySessionStat>();
     for (const s of gateway.data?.sessions ?? []) m.set(s.session_id, s);
@@ -108,23 +113,26 @@ export function ActivityView({ projectId }: { projectId: string }) {
   const openGateway = useGatewayOverlayStore((s) => s.openGateway);
 
   const runs = useMemo(() => {
+    const nowMs = Date.now();
     const filtered = (sessionsQuery.data ?? []).filter(
       (s) =>
+        withinRange(s.created_at, range, nowMs) &&
         matchesSessionFilter(s, source) &&
         matchesRunStatus(s.status, status) &&
         matchesSearch(s, search),
     );
     return sortRuns(filtered, sort, (id) => costBySession.get(id)?.total_cost ?? 0);
-  }, [sessionsQuery.data, source, status, search, sort, costBySession]);
+  }, [sessionsQuery.data, source, status, search, sort, range, costBySession]);
 
   const stats = useMemo(() => {
-    const all = sessionsQuery.data ?? [];
+    const nowMs = Date.now();
+    const all = (sessionsQuery.data ?? []).filter((s) => withinRange(s.created_at, range, nowMs));
     return {
       total: all.length,
       running: all.filter((s) => isLiveRun(s.status)).length,
       failed: all.filter((s) => s.status === 'failed').length,
     };
-  }, [sessionsQuery.data]);
+  }, [sessionsQuery.data, range]);
 
   return (
     <div className="bg-background flex h-full min-h-0 flex-col">
@@ -187,8 +195,20 @@ export function ActivityView({ projectId }: { projectId: string }) {
             {opt.label}
           </Button>
         ))}
+        <Select value={range} onValueChange={(v) => setRange(v as RunRange)}>
+          <SelectTrigger className="ml-auto h-8 w-[92px] shrink-0 text-sm">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {RUN_RANGES.map((opt) => (
+              <SelectItem key={opt.value} value={opt.value}>
+                {opt.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
         <Select value={sort} onValueChange={(v) => setSort(v as RunSort)}>
-          <SelectTrigger className="ml-auto h-8 w-[150px] shrink-0 text-sm">
+          <SelectTrigger className="h-8 w-[150px] shrink-0 text-sm">
             <SelectValue />
           </SelectTrigger>
           <SelectContent>

--- a/apps/web/src/features/activity/activity-view.tsx
+++ b/apps/web/src/features/activity/activity-view.tsx
@@ -4,7 +4,7 @@ import { useMemo, useState } from 'react';
 import Link from 'next/link';
 import { useQuery } from '@tanstack/react-query';
 import { formatDistanceToNowStrict } from 'date-fns';
-import { Activity, CalendarClock, MessageSquare, Webhook } from 'lucide-react';
+import { Activity, CalendarClock, MessageSquare, Search, Webhook } from 'lucide-react';
 
 import {
   matchesSessionFilter,
@@ -18,15 +18,25 @@ import { CustomizeSectionHeader } from '@/components/projects/customize/customiz
 import { Button } from '@/components/ui/button';
 import { EmptyState } from '@/components/ui/empty-state';
 import Hint from '@/components/ui/hint';
+import { Input } from '@/components/ui/input';
 import { InlineMeta } from '@/components/ui/inline-meta';
 import { List, ListRow } from '@/components/ui/list';
 import { Skeleton } from '@/components/ui/skeleton';
 import { StatusBadge, StatusDot } from '@/components/ui/status';
+import { FilterBar, FilterBarItem } from '@/components/ui/tabs';
 import { Icon } from '@/features/icon/icon';
 import { listProjectSessions, type ProjectSession } from '@/lib/projects-client';
 import { cn } from '@/lib/utils';
 
-import { isLiveRun, runStatusLabel, runStatusTone } from './activity-status';
+import {
+  formatRunDuration,
+  isLiveRun,
+  matchesRunStatus,
+  runStatusLabel,
+  runStatusTone,
+  RUN_STATUS_FILTERS,
+  type RunStatusFilter,
+} from './activity-status';
 
 const SOURCE_LABEL: Record<SessionSourceKind, string> = {
   chat: 'Chat',
@@ -44,8 +54,19 @@ function SourceIcon({ kind, className }: { kind: SessionSourceKind; className?: 
   return <MessageSquare className={className} />;
 }
 
+function matchesSearch(run: ProjectSession, query: string): boolean {
+  const q = query.trim().toLowerCase();
+  if (!q) return true;
+  return (
+    sessionDisplayLabel(run).toLowerCase().includes(q) ||
+    (run.agent_name?.toLowerCase().includes(q) ?? false)
+  );
+}
+
 export function ActivityView({ projectId }: { projectId: string }) {
-  const [filter, setFilter] = useState<SessionFilterValue>('all');
+  const [source, setSource] = useState<SessionFilterValue>('all');
+  const [status, setStatus] = useState<RunStatusFilter>('all');
+  const [search, setSearch] = useState('');
 
   const sessionsQuery = useQuery({
     queryKey: ['project-sessions', projectId],
@@ -56,8 +77,14 @@ export function ActivityView({ projectId }: { projectId: string }) {
   });
 
   const runs = useMemo(
-    () => (sessionsQuery.data ?? []).filter((s) => matchesSessionFilter(s, filter)),
-    [sessionsQuery.data, filter],
+    () =>
+      (sessionsQuery.data ?? []).filter(
+        (s) =>
+          matchesSessionFilter(s, source) &&
+          matchesRunStatus(s.status, status) &&
+          matchesSearch(s, search),
+      ),
+    [sessionsQuery.data, source, status, search],
   );
 
   return (
@@ -66,20 +93,43 @@ export function ActivityView({ projectId }: { projectId: string }) {
         icon={Activity}
         title="Activity"
         count={sessionsQuery.data ? runs.length : undefined}
+        actions={
+          <div className="relative">
+            <Search className="text-muted-foreground/60 pointer-events-none absolute top-1/2 left-2 size-3.5 -translate-y-1/2" />
+            <Input
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Search runs…"
+              className="h-8 w-44 pl-7 text-sm"
+            />
+          </div>
+        }
       />
 
-      <div className="border-border/60 flex shrink-0 items-center gap-1 overflow-x-auto border-b px-3 py-2 [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]">
+      <div className="border-border/60 flex shrink-0 flex-wrap items-center gap-2 overflow-x-auto border-b px-3 py-2 [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]">
+        <FilterBar className="h-8">
+          {RUN_STATUS_FILTERS.map((opt) => (
+            <FilterBarItem
+              key={opt.value}
+              data-state={status === opt.value ? 'active' : 'inactive'}
+              onClick={() => setStatus(opt.value)}
+            >
+              {opt.label}
+            </FilterBarItem>
+          ))}
+        </FilterBar>
+        <span className="bg-border/60 mx-1 h-4 w-px shrink-0" aria-hidden />
         {SESSION_FILTER_OPTIONS.map((opt) => (
           <Button
             key={opt.value}
             type="button"
             size="sm"
             variant="ghost"
-            onClick={() => setFilter(opt.value)}
-            aria-pressed={filter === opt.value}
+            onClick={() => setSource(opt.value)}
+            aria-pressed={source === opt.value}
             className={cn(
               'h-7 shrink-0 rounded-full',
-              filter === opt.value && 'bg-primary/10 text-primary',
+              source === opt.value && 'bg-primary/10 text-primary',
             )}
           >
             {opt.label}
@@ -103,11 +153,13 @@ export function ActivityView({ projectId }: { projectId: string }) {
           ) : runs.length === 0 ? (
             <EmptyState
               icon={Activity}
-              title={filter === 'all' ? 'No runs yet' : 'No runs match this filter'}
+              title={
+                sessionsQuery.data?.length ? 'No runs match these filters' : 'No runs yet'
+              }
               description={
-                filter === 'all'
-                  ? 'Sessions you start, and ones fired by schedules, webhooks or channels, will show up here.'
-                  : 'Try a different filter to see other runs.'
+                sessionsQuery.data?.length
+                  ? 'Try a different status, source, or search.'
+                  : 'Sessions you start, and ones fired by schedules, webhooks or channels, will show up here.'
               }
             />
           ) : (
@@ -127,6 +179,7 @@ function RunRow({ projectId, run }: { projectId: string; run: ProjectSession }) 
   const kind = sessionSource(run).kind;
   const tone = runStatusTone(run.status);
   const live = isLiveRun(run.status);
+  const duration = live ? null : formatRunDuration(run.created_at, run.updated_at);
   const statusBadge = (
     <StatusBadge tone={tone}>
       <StatusDot tone={tone} pulse={live} />
@@ -154,10 +207,15 @@ function RunRow({ projectId, run }: { projectId: string; run: ProjectSession }) 
           {SOURCE_LABEL[kind]}
           {run.agent_name || null}
           {formatDistanceToNowStrict(new Date(run.created_at), { addSuffix: true })}
+          {duration}
         </InlineMeta>
       }
       trailing={
-        run.status === 'failed' && run.error ? <Hint label={run.error}>{statusBadge}</Hint> : statusBadge
+        run.status === 'failed' && run.error ? (
+          <Hint label={run.error}>{statusBadge}</Hint>
+        ) : (
+          statusBadge
+        )
       }
     />
   );

--- a/apps/web/src/features/activity/activity-view.tsx
+++ b/apps/web/src/features/activity/activity-view.tsx
@@ -4,6 +4,7 @@ import { useQuery } from '@tanstack/react-query';
 import { formatDistanceToNowStrict } from 'date-fns';
 import {
   Activity,
+  AlertTriangle,
   CalendarClock,
   ExternalLink,
   MessageSquare,
@@ -26,6 +27,7 @@ import {
 import { Button } from '@/components/ui/button';
 import { EmptyState } from '@/components/ui/empty-state';
 import Hint from '@/components/ui/hint';
+import { InfoBanner } from '@/components/ui/info-banner';
 import { InlineMeta } from '@/components/ui/inline-meta';
 import { Input } from '@/components/ui/input';
 import { List, ListRow } from '@/components/ui/list';
@@ -44,6 +46,7 @@ import { useGatewaySessions } from '@/hooks/projects/use-project-gateway';
 import { listProjectSessions, type ProjectSession } from '@/lib/projects-client';
 import type { GatewaySessionStat } from '@/lib/projects-gateway-client';
 import { cn } from '@/lib/utils';
+import { useCustomizeStore } from '@/stores/customize-store';
 import { useGatewayOverlayStore } from '@/stores/gateway-overlay-store';
 
 import {
@@ -87,6 +90,16 @@ function matchesSearch(run: ProjectSession, query: string): boolean {
     sessionDisplayLabel(run).toLowerCase().includes(q) ||
     (run.agent_name?.toLowerCase().includes(q) ?? false)
   );
+}
+
+function errorMessage(error: unknown, fallback: string): string {
+  return error instanceof Error && error.message ? error.message : fallback;
+}
+
+function formatRunRelativeTime(createdAt: string): string | null {
+  const date = new Date(createdAt);
+  if (!Number.isFinite(date.getTime())) return null;
+  return formatDistanceToNowStrict(date, { addSuffix: true });
 }
 
 export function ActivityView({ projectId }: { projectId: string }) {
@@ -223,6 +236,28 @@ export function ActivityView({ projectId }: { projectId: string }) {
 
       <div className="min-h-0 flex-1 overflow-y-auto">
         <div className="mx-auto w-full max-w-3xl px-4 py-5">
+          {sessionsQuery.isError ? (
+            <InfoBanner
+              tone="destructive"
+              icon={AlertTriangle}
+              title="Activity failed to load"
+              className="mb-3"
+            >
+              {errorMessage(sessionsQuery.error, 'Refresh and try again.')}
+            </InfoBanner>
+          ) : gateway.isError ? (
+            <InfoBanner
+              tone="warning"
+              icon={AlertTriangle}
+              title="Spend data unavailable"
+              className="mb-3"
+            >
+              {errorMessage(
+                gateway.error,
+                'Run history loaded, but cost totals could not be fetched.',
+              )}
+            </InfoBanner>
+          ) : null}
           {!sessionsQuery.isLoading && stats.total > 0 && (
             <div className="text-muted-foreground mb-3 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs">
               <span className="text-foreground font-medium">
@@ -242,13 +277,7 @@ export function ActivityView({ projectId }: { projectId: string }) {
               )}
             </div>
           )}
-          {sessionsQuery.isError ? (
-            <EmptyState
-              icon={Activity}
-              title="Couldn’t load activity"
-              description="Refresh this section or try again in a moment."
-            />
-          ) : sessionsQuery.isLoading ? (
+          {sessionsQuery.isError ? null : sessionsQuery.isLoading ? (
             <List>
               {Array.from({ length: 6 }).map((_, i) => (
                 <ListRow
@@ -297,10 +326,12 @@ function RunRow({
   cost?: GatewaySessionStat;
 }) {
   const router = useRouter();
+  const closeCustomize = useCustomizeStore((s) => s.close);
   const kind = sessionSource(run).kind;
   const tone = runStatusTone(run.status);
   const live = isLiveRun(run.status);
   const duration = live ? null : formatRunDuration(run.created_at, run.updated_at);
+  const relative = formatRunRelativeTime(run.created_at);
   const statusBadge = (
     <StatusBadge tone={tone}>
       <StatusDot tone={tone} pulse={live} />
@@ -311,7 +342,10 @@ function RunRow({
   return (
     <ListRow
       className="cursor-pointer"
-      onClick={() => router.push(`/projects/${projectId}/sessions/${run.session_id}`)}
+      onClick={() => {
+        closeCustomize();
+        router.push(`/projects/${projectId}/sessions/${run.session_id}`);
+      }}
       leading={
         <span className="bg-muted/60 text-muted-foreground flex size-8 shrink-0 items-center justify-center rounded-lg">
           <SourceIcon kind={kind} className="size-4" />
@@ -322,7 +356,7 @@ function RunRow({
         <InlineMeta>
           {SOURCE_LABEL[kind]}
           {run.agent_name || null}
-          {formatDistanceToNowStrict(new Date(run.created_at), { addSuffix: true })}
+          {relative}
           {duration}
         </InlineMeta>
       }

--- a/apps/web/src/features/activity/activity-view.tsx
+++ b/apps/web/src/features/activity/activity-view.tsx
@@ -17,12 +17,12 @@ import { useMemo, useState } from 'react';
 
 import { CustomizeSectionHeader } from '@/components/projects/customize/customize-section-header';
 import {
-  matchesSessionFilter,
   SESSION_FILTER_OPTIONS,
-  sessionDisplayLabel,
-  sessionSource,
   type SessionFilterValue,
   type SessionSourceKind,
+  matchesSessionFilter,
+  sessionDisplayLabel,
+  sessionSource,
 } from '@/components/projects/session-label';
 import { Button } from '@/components/ui/button';
 import { EmptyState } from '@/components/ui/empty-state';
@@ -43,28 +43,28 @@ import { StatusBadge, StatusDot } from '@/components/ui/status';
 import { FilterBar, FilterBarItem } from '@/components/ui/tabs';
 import { Icon } from '@/features/icon/icon';
 import { useGatewaySessions } from '@/hooks/projects/use-project-gateway';
-import { listProjectSessions, type ProjectSession } from '@/lib/projects-client';
+import { type ProjectSession, listProjectSessions } from '@/lib/projects-client';
 import type { GatewaySessionStat } from '@/lib/projects-gateway-client';
 import { cn } from '@/lib/utils';
 import { useCustomizeStore } from '@/stores/customize-store';
 import { useGatewayOverlayStore } from '@/stores/gateway-overlay-store';
 
 import {
+  RUN_RANGES,
+  RUN_SORTS,
+  RUN_STATUS_FILTERS,
+  type RunRange,
+  type RunSort,
+  type RunStatusFilter,
   formatRunDuration,
   formatUsd,
   isLiveRun,
   matchesRunStatus,
   rangeDays,
-  RUN_RANGES,
-  RUN_SORTS,
-  RUN_STATUS_FILTERS,
   runStatusLabel,
   runStatusTone,
   sortRuns,
   withinRange,
-  type RunRange,
-  type RunSort,
-  type RunStatusFilter,
 } from './activity-status';
 
 const SOURCE_LABEL: Record<SessionSourceKind, string> = {
@@ -74,6 +74,15 @@ const SOURCE_LABEL: Record<SessionSourceKind, string> = {
   schedule: 'Scheduled',
   webhook: 'Webhook',
 };
+
+const ACTIVITY_SKELETON_ROWS = [
+  'activity-skeleton-1',
+  'activity-skeleton-2',
+  'activity-skeleton-3',
+  'activity-skeleton-4',
+  'activity-skeleton-5',
+  'activity-skeleton-6',
+] as const;
 
 function SourceIcon({ kind, className }: { kind: SessionSourceKind; className?: string }) {
   if (kind === 'slack') return <Icon.Slack className={className} />;
@@ -280,9 +289,9 @@ export function ActivityView({ projectId }: { projectId: string }) {
           )}
           {sessionLoadFailed ? null : sessionsQuery.isLoading ? (
             <List>
-              {Array.from({ length: 6 }).map((_, i) => (
+              {ACTIVITY_SKELETON_ROWS.map((key) => (
                 <ListRow
-                  key={i}
+                  key={key}
                   leading={<Skeleton className="size-8 rounded-lg" />}
                   title={<Skeleton className="h-4 w-48" />}
                   subtitle={<Skeleton className="mt-1 h-3 w-32" />}

--- a/apps/web/src/features/activity/activity-view.tsx
+++ b/apps/web/src/features/activity/activity-view.tsx
@@ -99,6 +99,15 @@ export function ActivityView({ projectId }: { projectId: string }) {
     [sessionsQuery.data, source, status, search],
   );
 
+  const stats = useMemo(() => {
+    const all = sessionsQuery.data ?? [];
+    return {
+      total: all.length,
+      running: all.filter((s) => isLiveRun(s.status)).length,
+      failed: all.filter((s) => s.status === 'failed').length,
+    };
+  }, [sessionsQuery.data]);
+
   return (
     <div className="bg-background flex h-full min-h-0 flex-col">
       <CustomizeSectionHeader
@@ -164,6 +173,25 @@ export function ActivityView({ projectId }: { projectId: string }) {
 
       <div className="min-h-0 flex-1 overflow-y-auto">
         <div className="mx-auto w-full max-w-3xl px-4 py-5">
+          {!sessionsQuery.isLoading && stats.total > 0 && (
+            <div className="text-muted-foreground mb-3 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs">
+              <span className="text-foreground font-medium">
+                {stats.total} {stats.total === 1 ? 'run' : 'runs'}
+              </span>
+              {stats.running > 0 && (
+                <span className="flex items-center gap-1.5">
+                  <StatusDot tone="info" pulse />
+                  {stats.running} running
+                </span>
+              )}
+              {stats.failed > 0 && (
+                <span className="flex items-center gap-1.5">
+                  <StatusDot tone="destructive" />
+                  {stats.failed} failed
+                </span>
+              )}
+            </div>
+          )}
           {sessionsQuery.isLoading ? (
             <List>
               {Array.from({ length: 6 }).map((_, i) => (

--- a/apps/web/src/features/activity/activity-view.tsx
+++ b/apps/web/src/features/activity/activity-view.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-import { useMemo, useState } from 'react';
-import { useRouter } from 'next/navigation';
 import { useQuery } from '@tanstack/react-query';
 import { formatDistanceToNowStrict } from 'date-fns';
 import {
@@ -13,21 +11,23 @@ import {
   Search,
   Webhook,
 } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import { useMemo, useState } from 'react';
 
+import { CustomizeSectionHeader } from '@/components/projects/customize/customize-section-header';
 import {
   matchesSessionFilter,
+  SESSION_FILTER_OPTIONS,
   sessionDisplayLabel,
   sessionSource,
-  SESSION_FILTER_OPTIONS,
   type SessionFilterValue,
   type SessionSourceKind,
 } from '@/components/projects/session-label';
-import { CustomizeSectionHeader } from '@/components/projects/customize/customize-section-header';
 import { Button } from '@/components/ui/button';
 import { EmptyState } from '@/components/ui/empty-state';
 import Hint from '@/components/ui/hint';
-import { Input } from '@/components/ui/input';
 import { InlineMeta } from '@/components/ui/inline-meta';
+import { Input } from '@/components/ui/input';
 import { List, ListRow } from '@/components/ui/list';
 import {
   Select,
@@ -41,10 +41,10 @@ import { StatusBadge, StatusDot } from '@/components/ui/status';
 import { FilterBar, FilterBarItem } from '@/components/ui/tabs';
 import { Icon } from '@/features/icon/icon';
 import { useGatewaySessions } from '@/hooks/projects/use-project-gateway';
-import { useGatewayOverlayStore } from '@/stores/gateway-overlay-store';
 import { listProjectSessions, type ProjectSession } from '@/lib/projects-client';
 import type { GatewaySessionStat } from '@/lib/projects-gateway-client';
 import { cn } from '@/lib/utils';
+import { useGatewayOverlayStore } from '@/stores/gateway-overlay-store';
 
 import {
   formatRunDuration,
@@ -52,13 +52,13 @@ import {
   isLiveRun,
   matchesRunStatus,
   rangeDays,
+  RUN_RANGES,
+  RUN_SORTS,
+  RUN_STATUS_FILTERS,
   runStatusLabel,
   runStatusTone,
   sortRuns,
   withinRange,
-  RUN_RANGES,
-  RUN_SORTS,
-  RUN_STATUS_FILTERS,
   type RunRange,
   type RunSort,
   type RunStatusFilter,
@@ -166,7 +166,7 @@ export function ActivityView({ projectId }: { projectId: string }) {
         }
       />
 
-      <div className="border-border/60 flex shrink-0 flex-wrap items-center gap-2 overflow-x-auto border-b px-3 py-2 [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]">
+      <div className="border-border/60 flex shrink-0 [scrollbar-width:none] flex-wrap items-center gap-2 overflow-x-auto border-b px-3 py-2 [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden">
         <FilterBar className="h-8">
           {RUN_STATUS_FILTERS.map((opt) => (
             <FilterBarItem
@@ -242,7 +242,13 @@ export function ActivityView({ projectId }: { projectId: string }) {
               )}
             </div>
           )}
-          {sessionsQuery.isLoading ? (
+          {sessionsQuery.isError ? (
+            <EmptyState
+              icon={Activity}
+              title="Couldn’t load activity"
+              description="Refresh this section or try again in a moment."
+            />
+          ) : sessionsQuery.isLoading ? (
             <List>
               {Array.from({ length: 6 }).map((_, i) => (
                 <ListRow
@@ -256,9 +262,7 @@ export function ActivityView({ projectId }: { projectId: string }) {
           ) : runs.length === 0 ? (
             <EmptyState
               icon={Activity}
-              title={
-                sessionsQuery.data?.length ? 'No runs match these filters' : 'No runs yet'
-              }
+              title={sessionsQuery.data?.length ? 'No runs match these filters' : 'No runs yet'}
               description={
                 sessionsQuery.data?.length
                   ? 'Try a different status, source, or search.'
@@ -331,6 +335,7 @@ function RunRow({
                 target="_blank"
                 rel="noreferrer"
                 onClick={(e) => e.stopPropagation()}
+                onKeyDown={(e) => e.stopPropagation()}
                 aria-label="Open run workspace"
                 className="text-muted-foreground hover:text-foreground hover:bg-muted/60 flex size-7 shrink-0 cursor-pointer items-center justify-center rounded-md transition-colors"
               >

--- a/apps/web/src/features/activity/activity-view.tsx
+++ b/apps/web/src/features/activity/activity-view.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useMemo, useState } from 'react';
-import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import { useQuery } from '@tanstack/react-query';
 import { formatDistanceToNowStrict } from 'date-fns';
 import { Activity, CalendarClock, MessageSquare, Receipt, Search, Webhook } from 'lucide-react';
@@ -214,6 +214,7 @@ function RunRow({
   run: ProjectSession;
   cost?: GatewaySessionStat;
 }) {
+  const router = useRouter();
   const kind = sessionSource(run).kind;
   const tone = runStatusTone(run.status);
   const live = isLiveRun(run.status);
@@ -227,19 +228,14 @@ function RunRow({
 
   return (
     <ListRow
+      className="cursor-pointer"
+      onClick={() => router.push(`/projects/${projectId}/sessions/${run.session_id}`)}
       leading={
         <span className="bg-muted/60 text-muted-foreground flex size-8 shrink-0 items-center justify-center rounded-lg">
           <SourceIcon kind={kind} className="size-4" />
         </span>
       }
-      title={
-        <Link
-          href={`/projects/${projectId}/sessions/${run.session_id}`}
-          className="hover:text-primary truncate font-medium"
-        >
-          {sessionDisplayLabel(run)}
-        </Link>
-      }
+      title={<span className="truncate font-medium">{sessionDisplayLabel(run)}</span>}
       subtitle={
         <InlineMeta>
           {SOURCE_LABEL[kind]}

--- a/apps/web/src/features/activity/activity-view.tsx
+++ b/apps/web/src/features/activity/activity-view.tsx
@@ -4,7 +4,7 @@ import { useMemo, useState } from 'react';
 import Link from 'next/link';
 import { useQuery } from '@tanstack/react-query';
 import { formatDistanceToNowStrict } from 'date-fns';
-import { Activity, CalendarClock, MessageSquare, Search, Webhook } from 'lucide-react';
+import { Activity, CalendarClock, MessageSquare, Receipt, Search, Webhook } from 'lucide-react';
 
 import {
   matchesSessionFilter,
@@ -25,11 +25,15 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { StatusBadge, StatusDot } from '@/components/ui/status';
 import { FilterBar, FilterBarItem } from '@/components/ui/tabs';
 import { Icon } from '@/features/icon/icon';
+import { useGatewaySessions } from '@/hooks/projects/use-project-gateway';
+import { useGatewayOverlayStore } from '@/stores/gateway-overlay-store';
 import { listProjectSessions, type ProjectSession } from '@/lib/projects-client';
+import type { GatewaySessionStat } from '@/lib/projects-gateway-client';
 import { cn } from '@/lib/utils';
 
 import {
   formatRunDuration,
+  formatUsd,
   isLiveRun,
   matchesRunStatus,
   runStatusLabel,
@@ -76,6 +80,14 @@ export function ActivityView({ projectId }: { projectId: string }) {
       (query.state.data ?? []).some((s) => isLiveRun(s.status)) ? 5000 : false,
   });
 
+  const gateway = useGatewaySessions(projectId);
+  const costBySession = useMemo(() => {
+    const m = new Map<string, GatewaySessionStat>();
+    for (const s of gateway.data?.sessions ?? []) m.set(s.session_id, s);
+    return m;
+  }, [gateway.data]);
+  const openGateway = useGatewayOverlayStore((s) => s.openGateway);
+
   const runs = useMemo(
     () =>
       (sessionsQuery.data ?? []).filter(
@@ -94,14 +106,27 @@ export function ActivityView({ projectId }: { projectId: string }) {
         title="Activity"
         count={sessionsQuery.data ? runs.length : undefined}
         actions={
-          <div className="relative">
-            <Search className="text-muted-foreground/60 pointer-events-none absolute top-1/2 left-2 size-3.5 -translate-y-1/2" />
-            <Input
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              placeholder="Search runs…"
-              className="h-8 w-44 pl-7 text-sm"
-            />
+          <div className="flex items-center gap-2">
+            <div className="relative">
+              <Search className="text-muted-foreground/60 pointer-events-none absolute top-1/2 left-2 size-3.5 -translate-y-1/2" />
+              <Input
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                placeholder="Search runs…"
+                className="h-8 w-44 pl-7 text-sm"
+              />
+            </div>
+            <Hint label="Open the gateway spend view">
+              <Button
+                size="sm"
+                variant="ghost"
+                className="h-8 shrink-0 gap-1.5"
+                onClick={() => openGateway({ section: 'cost' })}
+              >
+                <Receipt className="size-3.5" />
+                Spend
+              </Button>
+            </Hint>
           </div>
         }
       />
@@ -165,7 +190,12 @@ export function ActivityView({ projectId }: { projectId: string }) {
           ) : (
             <List>
               {runs.map((run) => (
-                <RunRow key={run.session_id} projectId={projectId} run={run} />
+                <RunRow
+                  key={run.session_id}
+                  projectId={projectId}
+                  run={run}
+                  cost={costBySession.get(run.session_id)}
+                />
               ))}
             </List>
           )}
@@ -175,7 +205,15 @@ export function ActivityView({ projectId }: { projectId: string }) {
   );
 }
 
-function RunRow({ projectId, run }: { projectId: string; run: ProjectSession }) {
+function RunRow({
+  projectId,
+  run,
+  cost,
+}: {
+  projectId: string;
+  run: ProjectSession;
+  cost?: GatewaySessionStat;
+}) {
   const kind = sessionSource(run).kind;
   const tone = runStatusTone(run.status);
   const live = isLiveRun(run.status);
@@ -211,11 +249,22 @@ function RunRow({ projectId, run }: { projectId: string; run: ProjectSession }) 
         </InlineMeta>
       }
       trailing={
-        run.status === 'failed' && run.error ? (
-          <Hint label={run.error}>{statusBadge}</Hint>
-        ) : (
-          statusBadge
-        )
+        <div className="flex flex-col items-end gap-1">
+          {run.status === 'failed' && run.error ? (
+            <Hint label={run.error}>{statusBadge}</Hint>
+          ) : (
+            statusBadge
+          )}
+          {cost && cost.total_cost > 0 && (
+            <Hint
+              label={`LLM ${formatUsd(cost.llm_cost)} · compute ${formatUsd(cost.compute_cost)}`}
+            >
+              <span className="text-muted-foreground text-xs tabular-nums">
+                {formatUsd(cost.total_cost)}
+              </span>
+            </Hint>
+          )}
+        </div>
       }
     />
   );

--- a/apps/web/src/lib/customize-sections.ts
+++ b/apps/web/src/lib/customize-sections.ts
@@ -51,7 +51,5 @@ export const CUSTOMIZE_SECTIONS: readonly CustomizeSection[] = [
 
 export function parseCustomizeSection(raw: string | null | undefined): CustomizeSection | null {
   if (!raw) return null;
-  return (CUSTOMIZE_SECTIONS as readonly string[]).includes(raw)
-    ? (raw as CustomizeSection)
-    : null;
+  return (CUSTOMIZE_SECTIONS as readonly string[]).includes(raw) ? (raw as CustomizeSection) : null;
 }

--- a/apps/web/src/lib/customize-sections.ts
+++ b/apps/web/src/lib/customize-sections.ts
@@ -9,6 +9,7 @@
  */
 
 export type CustomizeSection =
+  | 'activity'
   | 'changes'
   | 'files'
   | 'skills'
@@ -29,6 +30,7 @@ export type CustomizeSection =
 export const DEFAULT_CUSTOMIZE_SECTION: CustomizeSection = 'files';
 
 export const CUSTOMIZE_SECTIONS: readonly CustomizeSection[] = [
+  'activity',
   'changes',
   'files',
   'skills',


### PR DESCRIPTION
**WIP — new Activity section for run observability.**

## What this adds
A **Customize → Workspace → Activity** section: a filterable list of every run (session) in the project — chat, scheduled, webhook, channel — showing source, status, agent and start time, with a live pulse + polling for in-flight runs and click-through to the session.

## Why
For an automation product, unattended (cron / webhook) runs fire with no dedicated place to see what happened. This is the "Observe" surface — sessions are the runs, but there was no observability view.

## Status / next
- Per-run **cost/tokens deferred** — needs a customer-facing usage read over `usage_events` (separate PR).
- Pure status→tone mapping is unit-tested; `tsc` clean for touched files; the `/customize/activity` route compiles.
- Not yet visually reviewed against live data.
