### PR TITLE
fix(worktree): heal stale slot ports on start (old worktrees missing the gateway port)

### DIFF
--- a/scripts/worktree/__tests__/pure.test.ts
+++ b/scripts/worktree/__tests__/pure.test.ts
@@ -132,4 +132,24 @@ describe('launch envs', () => {
     expect(env.WEB_PORT).toBe(String(ports.web));
     expect(env.KORTIX_API_PROXY_TARGET).toBe(`http://localhost:${ports.api}`);
   });
+
+  test('no launch-env value is ever the string "undefined" (a missing port stringifies to "undefined")', () => {
+    for (let slot = 0; slot < 6; slot++) {
+      const p = computePorts(slot);
+      const c = slotCredsFromStatus(p, {});
+      const envs = [apiLaunchEnv(p, c), gatewayLaunchEnv(p), webLaunchEnv(p, c)];
+      for (const env of envs) {
+        for (const [k, v] of Object.entries(env)) {
+          expect(v, `slot ${slot} ${k}="${v}"`).not.toContain('undefined');
+        }
+      }
+    }
+  });
+
+  test('computePorts(slot) always carries the gateway port (the field whose absence caused the 8090 fallback)', () => {
+    for (let slot = 0; slot < 6; slot++) {
+      expect(typeof computePorts(slot).gateway).toBe('number');
+      expect(gatewayLaunchEnv(computePorts(slot)).PORT).toMatch(/^\d+$/);
+    }
+  });
 });

--- a/scripts/worktree/cli.ts
+++ b/scripts/worktree/cli.ts
@@ -338,6 +338,20 @@ async function cmdStart(a: Args) {
   if (!sh(['docker', 'info']).ok) die('Docker daemon not running — start Docker and retry');
   const e = entry!;
 
+  // Heal a stale ports cache. The registry stores a denormalized copy of
+  // computePorts(slot), so a worktree created before a port was added to BASE
+  // (e.g. the standalone gateway) has that field missing — String(undefined)
+  // then makes the gateway fall back to its default 8090 and the API lose its
+  // proxy (LLM_GATEWAY_PROXY_PORT="undefined"). The slot is the source of truth:
+  // recompute every port from it, and persist so the entry is fixed for good.
+  const freshPorts = computePorts(e.slot);
+  if (JSON.stringify(freshPorts) !== JSON.stringify(e.ports)) {
+    const added = (Object.keys(freshPorts) as (keyof typeof freshPorts)[]).filter((k) => e.ports[k] !== freshPorts[k]);
+    e.ports = freshPorts;
+    await withLock(() => { const r = loadRegistry(); if (r.slots[name]) { r.slots[name].ports = freshPorts; saveRegistry(r); } });
+    sub(`refreshed slot ${e.slot} ports from BASE (${added.join(', ')}) → gateway :${freshPorts.gateway}`);
+  }
+
   renderSupabaseProject(name, e.path, e.projectId, e.ports);
   step(`Starting Postgres for "${name}"`);
   if (await startSupabaseDb(name) !== 0) die('supabase db start failed');


### PR DESCRIPTION
## Root cause of the gateway falling back to 8090

Follow-up to #3666. That PR made the gateway start *loudly*; this fixes *why* it was on 8090 for pre-existing worktrees.

The registry stores a **denormalized copy** of `computePorts(slot)`. A worktree created *before* the standalone gateway port was added to `BASE` has a `ports` object with `web`/`api`/`sb*` but **no `gateway`**. On `start` the launcher trusted that stale cache, so:

```
🚀 ms-teams   web :13200 · api :13208 · studio :13523
   llm gateway http://localhost:undefined   ← e.ports.gateway is undefined
```

- `gatewayLaunchEnv` set `PORT = String(undefined) = "undefined"` → the gateway parsed NaN → **fell back to its default 8090** (→ EADDRINUSE against the primary dev gateway).
- `apiLaunchEnv` set `LLM_GATEWAY_PROXY_PORT = "undefined"` → config parsed it as 0 → **"no proxy configured"** → sandboxes degraded to the single-model passthrough.

### Fix
The **slot** is the source of truth. On `start`, recompute every port from `computePorts(e.slot)` and persist it back to the registry — healing the stale entry permanently. Any future field added to `BASE` is picked up the same way. New worktrees were already fine (create computes fresh).

### Tests
- No launch-env value is ever the literal string `"undefined"` across slots (directly guards `String(missingPort)`).
- `computePorts(slot)` always carries a numeric `gateway` port.

21 worktree unit/contract tests green; typecheck clean.

> Note: an already-running worktree heals itself the next time you `pnpm worktree start <name>` with this launcher.