### PR TITLE
fix(slack): isolate CLI channel connector

### DIFF
--- a/apps/api/src/__tests__/e2e-slack-cli.test.ts
+++ b/apps/api/src/__tests__/e2e-slack-cli.test.ts
@@ -1,0 +1,387 @@
+/**
+ * End-to-end coverage for the in-sandbox `slack` CLI surface. The test runs the
+ * real Bun entrypoint against a live fake Kortix API so command parsing,
+ * project-explicit Executor routing, turn-stream relays, file upload/download,
+ * and manifest fetching are all exercised without touching real Slack.
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { SLACK_CHANNEL_CONNECTOR_SLUG } from '../executor/channels';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../../..');
+const CLI_ENTRY = resolve(REPO_ROOT, 'apps/sandbox/slack-cli/channels/slack.ts');
+
+const PROJECT = 'proj-slack-cli';
+const SESSION = 'sess-slack-cli';
+const TOKEN = 'kortix_test_slack_cli';
+
+interface World {
+  executor: Array<{ connector: string; action: string; args: Record<string, unknown> }>;
+  turns: Array<Record<string, unknown>>;
+  uploads: Array<Record<string, unknown>>;
+  downloads: string[];
+  manifests: string[];
+  reservedFailure: null | 'connector_not_found' | 'action_not_found' | 'needs_auth';
+}
+
+let world: World;
+let server: ReturnType<typeof Bun.serve>;
+let apiUrl: string;
+let tempDir: string;
+
+type CliObject = Record<string, unknown>;
+type CliOutput = CliObject | string;
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function slackDataFor(action: string, args: Record<string, unknown>): unknown {
+  switch (action) {
+    case 'send_message':
+      return { ok: true, ts: '111.222', channel: args.channel };
+    case 'update_message':
+      return { ok: true, ts: args.ts, channel: args.channel };
+    case 'delete_message':
+    case 'add_reaction':
+      return { ok: true };
+    case 'get_history':
+      return { ok: true, messages: [{ type: 'message', text: 'history', channel: args.channel }] };
+    case 'get_thread':
+      return {
+        ok: true,
+        messages: [
+          { type: 'message', text: 'root', ts: args.ts },
+          { type: 'message', text: 'reply' },
+        ],
+      };
+    case 'list_channels':
+      return { ok: true, channels: [{ id: 'C1', name: 'general' }] };
+    case 'channel_info':
+      return { ok: true, channel: { id: args.channel, name: 'incidents' } };
+    case 'join_channel':
+      return { ok: true, channel: { id: args.channel, name: 'joined' } };
+    case 'list_users':
+      return { ok: true, members: [{ id: 'U1', name: 'alice' }] };
+    case 'user_info':
+      return { ok: true, user: { id: args.user, name: 'alice' } };
+    case 'auth_test':
+      return {
+        ok: true,
+        user_id: 'Ubot',
+        user: 'kortix',
+        team: 'Kortix',
+        team_id: 'T1',
+        bot_id: 'B1',
+      };
+    case 'search_messages':
+      return { ok: true, messages: { matches: [{ text: 'hit', channel: { id: 'C1' } }] } };
+    case 'file_info':
+      return { ok: true, file: { id: args.file, name: 'report.md' } };
+    default:
+      return { ok: false, error: `unhandled_test_action:${action}` };
+  }
+}
+
+function asObject(value: CliOutput): CliObject {
+  expect(typeof value).toBe('object');
+  return value as CliObject;
+}
+
+async function runSlack(args: string[], opts: { ok?: boolean } = {}): Promise<CliOutput> {
+  const expectOk = opts.ok ?? true;
+  const proc = Bun.spawn({
+    cmd: ['bun', CLI_ENTRY, ...args],
+    cwd: REPO_ROOT,
+    env: {
+      PATH: process.env.PATH,
+      HOME: process.env.HOME,
+      KORTIX_API_URL: apiUrl,
+      KORTIX_CLI_TOKEN: TOKEN,
+      KORTIX_PROJECT_ID: PROJECT,
+      KORTIX_SESSION_ID: SESSION,
+    },
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  expect(stderr).toBe('');
+  if (expectOk) expect(exitCode).toBe(0);
+  else expect(exitCode).not.toBe(0);
+
+  const trimmed = stdout.trim();
+  if (!trimmed.startsWith('{') && !trimmed.startsWith('[')) return trimmed;
+  return JSON.parse(trimmed);
+}
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), 'kortix-slack-cli-test-'));
+  world = {
+    executor: [],
+    turns: [],
+    uploads: [],
+    downloads: [],
+    manifests: [],
+    reservedFailure: null,
+  };
+  server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const url = new URL(req.url);
+      if (req.headers.get('authorization') !== `Bearer ${TOKEN}`) {
+        return json({ error: 'unauthorized' }, 401);
+      }
+
+      if (url.pathname === `/v1/projects/${PROJECT}/turn-stream`) {
+        const body = (await req.json()) as Record<string, unknown>;
+        world.turns.push(body);
+        return json({ ok: true });
+      }
+
+      if (url.pathname === `/v1/executor/projects/${PROJECT}/call`) {
+        const body = (await req.json()) as {
+          connector: string;
+          action: string;
+          args?: Record<string, unknown>;
+        };
+        const call = { connector: body.connector, action: body.action, args: body.args ?? {} };
+        world.executor.push(call);
+        if (body.connector === SLACK_CHANNEL_CONNECTOR_SLUG && world.reservedFailure) {
+          return json(
+            { ok: false, status: 'denied', reason: world.reservedFailure },
+            world.reservedFailure === 'needs_auth' ? 403 : 404,
+          );
+        }
+        if (body.connector !== SLACK_CHANNEL_CONNECTOR_SLUG && body.connector !== 'slack') {
+          return json({ ok: false, status: 'denied', reason: 'connector_not_found' }, 404);
+        }
+        return json({ ok: true, data: slackDataFor(body.action, body.args ?? {}), risk: 'read' });
+      }
+
+      if (url.pathname === `/v1/projects/${PROJECT}/channels/slack/file/upload`) {
+        const body = (await req.json()) as Record<string, unknown>;
+        world.uploads.push(body);
+        return json({ ok: true, files: [{ id: 'F1', name: body.filename }] });
+      }
+
+      if (url.pathname === `/v1/projects/${PROJECT}/channels/slack/file`) {
+        world.downloads.push(url.searchParams.get('url') ?? '');
+        return new Response('downloaded from slack', { status: 200 });
+      }
+
+      if (url.pathname === `/v1/webhooks/slack/${PROJECT}/manifest`) {
+        world.manifests.push(url.searchParams.get('name') ?? '');
+        return json({ display_information: { name: url.searchParams.get('name') ?? 'Kortix' } });
+      }
+
+      return json({ error: `unexpected ${url.pathname}` }, 404);
+    },
+  });
+  apiUrl = `http://127.0.0.1:${server.port}`;
+});
+
+afterEach(() => {
+  server.stop(true);
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe('slack CLI', () => {
+  test('maps every Slack Web API command to the reserved channel connector', async () => {
+    const cases: Array<{
+      args: string[];
+      action: string;
+      expectedArgs: Record<string, unknown>;
+      expectOutput?: Record<string, unknown>;
+    }> = [
+      {
+        args: ['send', '--channel', 'C1', '--text', 'hi', '--thread', '123.45'],
+        action: 'send_message',
+        expectedArgs: { channel: 'C1', mrkdwn: true, text: 'hi', thread_ts: '123.45' },
+        expectOutput: { ts: '111.222', channel: 'C1' },
+      },
+      {
+        args: ['edit', '--channel', 'C1', '--ts', '111.222', '--text', 'updated'],
+        action: 'update_message',
+        expectedArgs: { channel: 'C1', ts: '111.222', text: 'updated' },
+      },
+      {
+        args: ['delete', '--channel', 'C1', '--ts', '111.222'],
+        action: 'delete_message',
+        expectedArgs: { channel: 'C1', ts: '111.222' },
+      },
+      {
+        args: ['react', '--channel', 'C1', '--ts', '111.222', '--emoji', 'white_check_mark'],
+        action: 'add_reaction',
+        expectedArgs: { channel: 'C1', timestamp: '111.222', name: 'white_check_mark' },
+      },
+      {
+        args: ['history', '--channel', 'C1', '--limit', '3'],
+        action: 'get_history',
+        expectedArgs: { channel: 'C1', limit: '3' },
+      },
+      {
+        args: ['thread', '--channel', 'C1', '--ts', '111.222', '--limit', '2'],
+        action: 'get_thread',
+        expectedArgs: { channel: 'C1', ts: '111.222', limit: '2' },
+      },
+      {
+        args: ['channels', '--limit', '4'],
+        action: 'list_channels',
+        expectedArgs: {
+          limit: '4',
+          types: 'public_channel,private_channel',
+          exclude_archived: 'true',
+        },
+      },
+      {
+        args: ['channel-info', '--channel', 'C1'],
+        action: 'channel_info',
+        expectedArgs: { channel: 'C1' },
+      },
+      {
+        args: ['join', '--channel', 'C1'],
+        action: 'join_channel',
+        expectedArgs: { channel: 'C1' },
+      },
+      { args: ['users', '--limit', '5'], action: 'list_users', expectedArgs: { limit: '5' } },
+      { args: ['user', '--id', 'U1'], action: 'user_info', expectedArgs: { user: 'U1' } },
+      { args: ['me'], action: 'auth_test', expectedArgs: {} },
+      {
+        args: ['search', '--query', 'from:@marko'],
+        action: 'search_messages',
+        expectedArgs: { query: 'from:@marko' },
+      },
+      { args: ['file-info', '--file', 'F1'], action: 'file_info', expectedArgs: { file: 'F1' } },
+    ];
+
+    for (const c of cases) {
+      world.executor = [];
+      const out = asObject(await runSlack(c.args));
+      expect(out.ok).toBe(true);
+      if (c.expectOutput) expect(out).toMatchObject(c.expectOutput);
+      expect(world.executor).toHaveLength(1);
+      expect(world.executor[0]).toEqual({
+        connector: SLACK_CHANNEL_CONNECTOR_SLUG,
+        action: c.action,
+        args: c.expectedArgs,
+      });
+    }
+  });
+
+  test('covers non-Executor commands: help, typing, turn stream, file upload/download, manifest', async () => {
+    expect(String(await runSlack(['help']))).toContain('slack — Slack Web API adapter');
+
+    const typing = asObject(await runSlack(['typing', '--channel', 'C1']));
+    expect(typing.ok).toBe(true);
+    expect(String(typing.note)).toContain('typing indicators');
+    expect(world.executor).toHaveLength(0);
+
+    const step = asObject(
+      await runSlack([
+        'step',
+        'Reading logs',
+        '--detail',
+        'Last hour',
+        '--output',
+        '2 errors',
+        '--source',
+        'https://example.com/logs|Logs',
+      ]),
+    );
+    expect(step).toMatchObject({ ok: true, relayed: true });
+    expect(world.turns.at(-1)).toMatchObject({
+      session_id: SESSION,
+      kind: 'step',
+      text: 'Reading logs',
+      detail: 'Last hour',
+      output: '2 errors',
+    });
+    expect(world.turns.at(-1)?.sources).toEqual([
+      { url: 'https://example.com/logs', text: 'Logs' },
+    ]);
+
+    const answer = asObject(
+      await runSlack([
+        'send',
+        '--text',
+        'Done',
+        '--blocks',
+        '[{"type":"section","text":{"type":"mrkdwn","text":"*Done*"}}]',
+      ]),
+    );
+    expect(answer).toMatchObject({ ok: true, delivered: 'stream', mode: 'blocks' });
+    expect(world.turns.at(-1)).toMatchObject({ session_id: SESSION, kind: 'answer', text: 'Done' });
+
+    const uploadPath = join(tempDir, 'report.txt');
+    writeFileSync(uploadPath, 'hello slack');
+    const uploaded = asObject(
+      await runSlack([
+        'send',
+        '--channel',
+        'C1',
+        '--thread',
+        '111.222',
+        '--file',
+        uploadPath,
+        '--text',
+        'Report',
+      ]),
+    );
+    expect(uploaded).toMatchObject({ ok: true, channel: 'C1' });
+    expect(world.uploads[0]).toMatchObject({
+      channel: 'C1',
+      filename: 'report.txt',
+      comment: 'Report',
+      thread_ts: '111.222',
+    });
+    expect(Buffer.from(String(world.uploads[0]?.content_base64), 'base64').toString()).toBe(
+      'hello slack',
+    );
+
+    const downloadPath = join(tempDir, 'download.txt');
+    const downloaded = asObject(
+      await runSlack(['download', '--url', 'https://files.slack.com/F1', '--out', downloadPath]),
+    );
+    expect(downloaded).toMatchObject({ ok: true, path: downloadPath, size: 21 });
+    expect(readFileSync(downloadPath, 'utf8')).toBe('downloaded from slack');
+    expect(world.downloads).toEqual(['https://files.slack.com/F1']);
+
+    const manifest = asObject(await runSlack(['manifest', '--name', 'Test Slack App']));
+    expect(manifest).toMatchObject({
+      ok: true,
+      manifest: { display_information: { name: 'Test Slack App' } },
+    });
+    expect(world.manifests).toEqual(['Test Slack App']);
+  });
+
+  test('falls back to legacy slack only while the reserved channel connector rolls out', async () => {
+    world.reservedFailure = 'action_not_found';
+    const out = asObject(await runSlack(['thread', '--channel', 'C1', '--ts', '111.222']));
+    expect(out.ok).toBe(true);
+    expect(world.executor.map((c) => `${c.connector}.${c.action}`)).toEqual([
+      `${SLACK_CHANNEL_CONNECTOR_SLUG}.get_thread`,
+      'slack.get_thread',
+    ]);
+  });
+
+  test('does not fall back to a user-defined slack connector when the reserved channel needs auth', async () => {
+    world.reservedFailure = 'needs_auth';
+    const out = asObject(
+      await runSlack(['thread', '--channel', 'C1', '--ts', '111.222'], { ok: false }),
+    );
+    expect(out).toMatchObject({ ok: false, error: 'needs_auth' });
+    expect(world.executor.map((c) => `${c.connector}.${c.action}`)).toEqual([
+      `${SLACK_CHANNEL_CONNECTOR_SLUG}.get_thread`,
+    ]);
+  });
+});

--- a/apps/api/src/__tests__/e2e-slack-cli.test.ts
+++ b/apps/api/src/__tests__/e2e-slack-cli.test.ts
@@ -24,7 +24,12 @@ interface World {
   uploads: Array<Record<string, unknown>>;
   downloads: string[];
   manifests: string[];
-  reservedFailure: null | 'connector_not_found' | 'action_not_found' | 'needs_auth';
+  reservedFailure:
+    | null
+    | 'connector_not_found'
+    | 'action_not_found'
+    | 'needs_auth'
+    | 'missing_auth_token';
 }
 
 let world: World;
@@ -157,6 +162,9 @@ beforeEach(() => {
         const call = { connector: body.connector, action: body.action, args: body.args ?? {} };
         world.executor.push(call);
         if (body.connector === SLACK_CHANNEL_CONNECTOR_SLUG && world.reservedFailure) {
+          if (world.reservedFailure === 'missing_auth_token') {
+            return json({ error: true, message: 'Missing authentication token' }, 401);
+          }
           return json(
             { ok: false, status: 'denied', reason: world.reservedFailure },
             world.reservedFailure === 'needs_auth' ? 403 : 404,
@@ -380,6 +388,17 @@ describe('slack CLI', () => {
       await runSlack(['thread', '--channel', 'C1', '--ts', '111.222'], { ok: false }),
     );
     expect(out).toMatchObject({ ok: false, error: 'needs_auth' });
+    expect(world.executor.map((c) => `${c.connector}.${c.action}`)).toEqual([
+      `${SLACK_CHANNEL_CONNECTOR_SLUG}.get_thread`,
+    ]);
+  });
+
+  test('surfaces structured Executor auth errors instead of the boolean error field', async () => {
+    world.reservedFailure = 'missing_auth_token';
+    const out = asObject(
+      await runSlack(['thread', '--channel', 'C1', '--ts', '111.222'], { ok: false }),
+    );
+    expect(out).toMatchObject({ ok: false, error: 'Missing authentication token' });
     expect(world.executor.map((c) => `${c.connector}.${c.action}`)).toEqual([
       `${SLACK_CHANNEL_CONNECTOR_SLUG}.get_thread`,
     ]);

--- a/apps/api/src/__tests__/unit-executor-channels.test.ts
+++ b/apps/api/src/__tests__/unit-executor-channels.test.ts
@@ -9,25 +9,43 @@
  *     surfaced as a real error (parity with the in-sandbox CLI's throw).
  */
 import { describe, expect, test } from 'bun:test';
-import { channelApiBase, channelCatalog, channelDefaultSlug, SLACK_CHANNEL_CONNECTOR_SLUG } from '../executor/channels';
 import {
-  extractConnectors,
-  connectorSpecToTomlEntry,
-} from '../projects/connectors';
-import { parseManifestString, KNOWN_SCHEMA_VERSION } from '../projects/triggers';
+  SLACK_CHANNEL_CONNECTOR_SLUG,
+  channelApiBase,
+  channelCatalog,
+  channelDefaultSlug,
+} from '../executor/channels';
 import {
-  handleCall,
   type CallInput,
-  type GatewayConnector,
   type GatewayAction,
+  type GatewayConnector,
   type GatewayDeps,
+  handleCall,
 } from '../executor/gateway';
+import type { NormalizedAction } from '../executor/types';
+import { connectorSpecToTomlEntry, extractConnectors } from '../projects/connectors';
+import { KNOWN_SCHEMA_VERSION, parseManifestString } from '../projects/triggers';
+
+function expectDefined<T>(value: T | null | undefined): T {
+  expect(value).toBeDefined();
+  if (value == null) throw new Error('expected value to be defined');
+  return value;
+}
+
+function objectSchema(schema: NormalizedAction['inputSchema']): {
+  properties: Record<string, unknown>;
+  required?: string[];
+} {
+  expect(schema).toBeTruthy();
+  return schema as { properties: Record<string, unknown>; required?: string[] };
+}
 
 /* ─── catalog ─────────────────────────────────────────────────────────────── */
 
 describe('channelCatalog(slack)', () => {
   const actions = channelCatalog('slack');
   const byPath = new Map(actions.map((a) => [a.path, a]));
+  const action = (path: string) => expectDefined(byPath.get(path));
 
   test('exposes the full native Slack surface as http bindings', () => {
     // 14 native Web API methods (relay/typing/download/manifest/file-upload are CLI-side).
@@ -39,27 +57,27 @@ describe('channelCatalog(slack)', () => {
   });
 
   test('send_message → POST /chat.postMessage, write, channel required', () => {
-    const a = byPath.get('send_message')!;
+    const a = action('send_message');
     expect(a.binding).toEqual({ kind: 'http', method: 'POST', path: '/chat.postMessage' });
     expect(a.risk).toBe('write');
-    expect((a.inputSchema as any).required).toContain('channel');
+    expect(objectSchema(a.inputSchema).required).toContain('channel');
   });
 
   test('get_history → GET /conversations.history, read', () => {
-    const a = byPath.get('get_history')!;
+    const a = action('get_history');
     expect(a.binding).toEqual({ kind: 'http', method: 'GET', path: '/conversations.history' });
     expect(a.risk).toBe('read');
   });
 
   test('delete_message is destructive; reactions use Slack native param names', () => {
-    expect(byPath.get('delete_message')!.risk).toBe('destructive');
-    const react = byPath.get('add_reaction')!;
-    const props = Object.keys((react.inputSchema as any).properties);
+    expect(action('delete_message').risk).toBe('destructive');
+    const react = action('add_reaction');
+    const props = Object.keys(objectSchema(react.inputSchema).properties);
     expect(props).toEqual(['channel', 'timestamp', 'name']); // not ts/emoji — Slack's own names
   });
 
   test('auth_test has no inputs; unknown platform → empty', () => {
-    expect(byPath.get('auth_test')!.inputSchema).toBeNull();
+    expect(action('auth_test').inputSchema).toBeNull();
     expect(channelCatalog('nope')).toEqual([]);
   });
 
@@ -76,7 +94,9 @@ describe('channelCatalog(slack)', () => {
 /* ─── parse ───────────────────────────────────────────────────────────────── */
 
 function parse(body: string) {
-  const src = [`kortix_version = ${KNOWN_SCHEMA_VERSION}`, '\n[project]\nname = "t"\n', body].join('\n');
+  const src = [`kortix_version = ${KNOWN_SCHEMA_VERSION}`, '\n[project]\nname = "t"\n', body].join(
+    '\n',
+  );
   return extractConnectors(parseManifestString(src));
 }
 
@@ -90,21 +110,32 @@ platform = "slack"
 `);
     expect(errors).toEqual([]);
     expect(specs[0]).toMatchObject({ slug: 'slack', provider: 'channel', platform: 'slack' });
-    expect(connectorSpecToTomlEntry(specs[0]!)).toMatchObject({ provider: 'channel', platform: 'slack' });
+    expect(connectorSpecToTomlEntry(expectDefined(specs[0]))).toMatchObject({
+      provider: 'channel',
+      platform: 'slack',
+    });
   });
 
   test('missing / unknown platform is rejected', () => {
-    expect(parse(`
+    expect(
+      expectDefined(
+        parse(`
 [[connectors]]
 slug = "x"
 provider = "channel"
-`).errors[0]!.error).toMatch(/platform/);
-    expect(parse(`
+`).errors[0],
+      ).error,
+    ).toMatch(/platform/);
+    expect(
+      expectDefined(
+        parse(`
 [[connectors]]
 slug = "x"
 provider = "channel"
 platform = "discord"
-`).errors[0]!.error).toMatch(/platform/);
+`).errors[0],
+      ).error,
+    ).toMatch(/platform/);
   });
 
   test('declaring [connectors.auth] is rejected (credential is the install token)', () => {
@@ -117,7 +148,7 @@ platform = "slack"
   [connectors.auth]
   type = "bearer"
 `);
-    expect(errors[0]!.error).toMatch(/install token/);
+    expect(expectDefined(errors[0]).error).toMatch(/install token/);
   });
 });
 
@@ -145,7 +176,12 @@ const SEND: GatewayAction = {
 };
 
 function makeDeps(body: string, status = 200) {
-  const fetchCalls: Array<{ url: string; method: string; headers: Record<string, string>; body?: string }> = [];
+  const fetchCalls: Array<{
+    url: string;
+    method: string;
+    headers: Record<string, string>;
+    body?: string;
+  }> = [];
   const deps: GatewayDeps = {
     loadConnectorBySlug: async () => SLACK,
     loadAction: async () => SEND,
@@ -177,10 +213,11 @@ describe('handleCall — channel (slack)', () => {
     const { deps, fetchCalls } = makeDeps('{"ok":true,"ts":"123.45","channel":"C123"}');
     const res = await handleCall(deps, input);
     expect(res.status).toBe('ok');
-    expect(fetchCalls[0]!.url).toBe('https://slack.com/api/chat.postMessage');
-    expect(fetchCalls[0]!.method).toBe('POST');
-    expect(fetchCalls[0]!.headers.Authorization).toBe('Bearer xoxb-install-token');
-    expect(JSON.parse(fetchCalls[0]!.body!)).toEqual({ channel: 'C123', text: 'hi' });
+    const call = expectDefined(fetchCalls[0]);
+    expect(call.url).toBe('https://slack.com/api/chat.postMessage');
+    expect(call.method).toBe('POST');
+    expect(call.headers.Authorization).toBe('Bearer xoxb-install-token');
+    expect(JSON.parse(expectDefined(call.body))).toEqual({ channel: 'C123', text: 'hi' });
   });
 
   test('Slack {ok:false} (HTTP 200) is surfaced as an error, not a silent ok', async () => {
@@ -206,19 +243,30 @@ describe('handleCall — channel (slack)', () => {
     const getThread: GatewayAction = {
       path: `${SLACK_CHANNEL_CONNECTOR_SLUG}.get_thread`,
       relPath: 'get_thread',
-      inputSchema: { type: 'object', properties: { channel: {}, ts: {} }, required: ['channel', 'ts'] },
+      inputSchema: {
+        type: 'object',
+        properties: { channel: {}, ts: {} },
+        required: ['channel', 'ts'],
+      },
       risk: 'read',
       binding: { kind: 'http', method: 'GET', path: '/conversations.replies' },
     };
-    const fetchCalls: Array<{ url: string; method: string; headers: Record<string, string>; body?: string }> = [];
+    const fetchCalls: Array<{
+      url: string;
+      method: string;
+      headers: Record<string, string>;
+      body?: string;
+    }> = [];
     const deps: GatewayDeps = {
       loadConnectorBySlug: async (_projectId, slug) => {
         if (slug === SLACK_CHANNEL_CONNECTOR_SLUG) return SLACK;
         if (slug === 'slack') return pipedreamSlack;
         return null;
       },
-      loadAction: async (connectorId, relPath) => connectorId === SLACK.connectorId && relPath === 'get_thread' ? getThread : null,
-      resolveCredential: async (connector) => connector.provider === 'channel' ? 'xoxb-install-token' : 'pipedream-account-id',
+      loadAction: async (connectorId, relPath) =>
+        connectorId === SLACK.connectorId && relPath === 'get_thread' ? getThread : null,
+      resolveCredential: async (connector) =>
+        connector.provider === 'channel' ? 'xoxb-install-token' : 'pipedream-account-id',
       loadPolicies: async () => [],
       loadProjectPolicies: async () => [],
       loadDefaultMode: async () => 'allow_all',

--- a/apps/api/src/__tests__/unit-executor-channels.test.ts
+++ b/apps/api/src/__tests__/unit-executor-channels.test.ts
@@ -9,7 +9,7 @@
  *     surfaced as a real error (parity with the in-sandbox CLI's throw).
  */
 import { describe, expect, test } from 'bun:test';
-import { channelApiBase, channelCatalog } from '../executor/channels';
+import { channelApiBase, channelCatalog, channelDefaultSlug, SLACK_CHANNEL_CONNECTOR_SLUG } from '../executor/channels';
 import {
   extractConnectors,
   connectorSpecToTomlEntry,
@@ -66,6 +66,11 @@ describe('channelCatalog(slack)', () => {
   test('api base', () => {
     expect(channelApiBase('slack')).toBe('https://slack.com/api');
   });
+
+  test('default slack channel slug is platform-owned, not the user connector namespace', () => {
+    expect(channelDefaultSlug('slack')).toBe(SLACK_CHANNEL_CONNECTOR_SLUG);
+    expect(SLACK_CHANNEL_CONNECTOR_SLUG).toBe('kortix_slack');
+  });
 });
 
 /* ─── parse ───────────────────────────────────────────────────────────────── */
@@ -120,7 +125,7 @@ platform = "slack"
 
 const SLACK: GatewayConnector = {
   connectorId: 'conn-slack',
-  slug: 'slack',
+  slug: SLACK_CHANNEL_CONNECTOR_SLUG,
   provider: 'channel',
   baseUrl: 'https://slack.com/api',
   auth: { type: 'bearer', in: 'header', name: null, prefix: null },
@@ -183,5 +188,58 @@ describe('handleCall — channel (slack)', () => {
     const res = await handleCall(deps, input);
     expect(res.status).toBe('error');
     if (res.status === 'error') expect(res.reason).toMatch(/channel_not_found/);
+  });
+
+  test('legacy connector="slack" calls use the reserved channel connector before a user-defined slack connector', async () => {
+    const pipedreamSlack: GatewayConnector = {
+      connectorId: 'conn-user-pipedream-slack',
+      slug: 'slack',
+      provider: 'pipedream',
+      baseUrl: null,
+      auth: { type: 'none', in: 'header', name: null, prefix: null },
+      hasAuth: true,
+      shareScope: 'project',
+      grants: [],
+      credentialMode: 'shared',
+      enabled: true,
+    };
+    const getThread: GatewayAction = {
+      path: `${SLACK_CHANNEL_CONNECTOR_SLUG}.get_thread`,
+      relPath: 'get_thread',
+      inputSchema: { type: 'object', properties: { channel: {}, ts: {} }, required: ['channel', 'ts'] },
+      risk: 'read',
+      binding: { kind: 'http', method: 'GET', path: '/conversations.replies' },
+    };
+    const fetchCalls: Array<{ url: string; method: string; headers: Record<string, string>; body?: string }> = [];
+    const deps: GatewayDeps = {
+      loadConnectorBySlug: async (_projectId, slug) => {
+        if (slug === SLACK_CHANNEL_CONNECTOR_SLUG) return SLACK;
+        if (slug === 'slack') return pipedreamSlack;
+        return null;
+      },
+      loadAction: async (connectorId, relPath) => connectorId === SLACK.connectorId && relPath === 'get_thread' ? getThread : null,
+      resolveCredential: async (connector) => connector.provider === 'channel' ? 'xoxb-install-token' : 'pipedream-account-id',
+      loadPolicies: async () => [],
+      loadProjectPolicies: async () => [],
+      loadDefaultMode: async () => 'allow_all',
+      recordExecution: async () => {},
+      fetchImpl: async (url, init) => {
+        fetchCalls.push({ url, ...init });
+        return { status: 200, ok: true, text: async () => '{"ok":true,"messages":[]}' };
+      },
+    };
+
+    const res = await handleCall(deps, {
+      ...input,
+      connectorSlug: 'slack',
+      actionPath: 'get_thread',
+      args: { channel: 'C123', ts: '111.222' },
+    });
+
+    expect(res.status).toBe('ok');
+    expect(fetchCalls).toHaveLength(1);
+    const [call] = fetchCalls;
+    expect(call?.url).toBe('https://slack.com/api/conversations.replies?channel=C123&ts=111.222');
+    expect(call?.headers.Authorization).toBe('Bearer xoxb-install-token');
   });
 });

--- a/apps/api/src/executor/channel-materialize.ts
+++ b/apps/api/src/executor/channel-materialize.ts
@@ -1,3 +1,4 @@
+import { loadSlackInstall } from '../channels/install-store';
 /**
  * Auto-materialize channel connectors from platform installs.
  *
@@ -11,9 +12,8 @@
  * executor_credentials row, no migration. See KORTIX-206.
  */
 import type { ChannelPlatform, ConnectorSpec } from '../projects/connectors';
-import { channelLabel } from './channels';
-import { loadSlackInstall } from '../channels/install-store';
 import { MANIFEST_FILENAME } from '../projects/triggers';
+import { channelDefaultSlug, channelLabel } from './channels';
 
 function channelSpec(platform: ChannelPlatform, slug: string): ConnectorSpec {
   return {
@@ -36,9 +36,9 @@ function channelSpec(platform: ChannelPlatform, slug: string): ConnectorSpec {
   };
 }
 
-/** True if a channel for `platform` (or anything on its default slug) is already declared. */
-function alreadyDeclared(declared: ConnectorSpec[], platform: ChannelPlatform, slug: string): boolean {
-  return declared.some((s) => s.slug === slug || (s.provider === 'channel' && s.platform === platform));
+/** True if any declared connector already owns this exact reserved channel slug. */
+function slugAlreadyDeclared(declared: ConnectorSpec[], slug: string): boolean {
+  return declared.some((s) => s.slug === slug);
 }
 
 /**
@@ -52,9 +52,13 @@ export async function synthesizeChannelConnectors(
   declared: ConnectorSpec[],
 ): Promise<ConnectorSpec[]> {
   // Slack (Telegram/Teams slot in here the same way — see KORTIX-206 Phase D).
-  if (!alreadyDeclared(declared, 'slack', 'slack')) {
+  // Use the reserved platform-owned slug so user-defined connectors like
+  // `[[connectors]] slug="slack" provider="pipedream" app="slack"` cannot
+  // shadow the built-in Slack CLI's channel catalog.
+  const slackSlug = channelDefaultSlug('slack');
+  if (!slugAlreadyDeclared(declared, slackSlug)) {
     const install = await loadSlackInstall(projectId).catch(() => null);
-    if (install) return [channelSpec('slack', 'slack')];
+    if (install) return [channelSpec('slack', slackSlug)];
   }
   return [];
 }

--- a/apps/api/src/executor/channel-materialize.ts
+++ b/apps/api/src/executor/channel-materialize.ts
@@ -36,9 +36,15 @@ function channelSpec(platform: ChannelPlatform, slug: string): ConnectorSpec {
   };
 }
 
-/** True if any declared connector already owns this exact reserved channel slug. */
-function slugAlreadyDeclared(declared: ConnectorSpec[], slug: string): boolean {
-  return declared.some((s) => s.slug === slug);
+/** True if this platform is explicitly declared, or if anything owns the reserved slug. */
+function channelAlreadyDeclared(
+  declared: ConnectorSpec[],
+  platform: ChannelPlatform,
+  slug: string,
+): boolean {
+  return declared.some(
+    (s) => s.slug === slug || (s.provider === 'channel' && s.platform === platform),
+  );
 }
 
 /**
@@ -56,7 +62,7 @@ export async function synthesizeChannelConnectors(
   // `[[connectors]] slug="slack" provider="pipedream" app="slack"` cannot
   // shadow the built-in Slack CLI's channel catalog.
   const slackSlug = channelDefaultSlug('slack');
-  if (!slugAlreadyDeclared(declared, slackSlug)) {
+  if (!channelAlreadyDeclared(declared, 'slack', slackSlug)) {
     const install = await loadSlackInstall(projectId).catch(() => null);
     if (install) return [channelSpec('slack', slackSlug)];
   }

--- a/apps/api/src/executor/channels.ts
+++ b/apps/api/src/executor/channels.ts
@@ -91,11 +91,16 @@ const SLACK_ACTIONS: ChannelActionDef[] = [
     method: 'chat.postMessage',
     verb: 'POST',
     name: 'Send message',
-    description: 'Post a message to a Slack channel or thread. Provide `channel` plus `text` and/or Block Kit `blocks`; set `thread_ts` to reply in a thread.',
+    description:
+      'Post a message to a Slack channel or thread. Provide `channel` plus `text` and/or Block Kit `blocks`; set `thread_ts` to reply in a thread.',
     risk: 'write',
     properties: {
       channel: { type: 'string', description: 'Channel ID (e.g. C0123) or user ID for a DM.' },
-      text: { type: 'string', description: 'Message text (mrkdwn). Also used as the notification fallback when sending blocks.' },
+      text: {
+        type: 'string',
+        description:
+          'Message text (mrkdwn). Also used as the notification fallback when sending blocks.',
+      },
       blocks: { type: 'array', description: 'Optional Block Kit blocks for a rich message.' },
       thread_ts: { type: 'string', description: 'Optional parent message ts to reply in-thread.' },
     },
@@ -134,7 +139,8 @@ const SLACK_ACTIONS: ChannelActionDef[] = [
     method: 'reactions.add',
     verb: 'POST',
     name: 'Add reaction',
-    description: 'Add an emoji reaction to a message. Requires `channel`, the message `timestamp`, and the emoji `name` (without colons).',
+    description:
+      'Add an emoji reaction to a message. Requires `channel`, the message `timestamp`, and the emoji `name` (without colons).',
     risk: 'write',
     properties: {
       channel: { type: 'string', description: 'Channel ID the message is in.' },
@@ -148,7 +154,8 @@ const SLACK_ACTIONS: ChannelActionDef[] = [
     method: 'conversations.history',
     verb: 'GET',
     name: 'Get channel history',
-    description: 'Fetch recent messages from a channel. Provide `channel`; optional `limit` (default 20).',
+    description:
+      'Fetch recent messages from a channel. Provide `channel`; optional `limit` (default 20).',
     risk: 'read',
     properties: {
       channel: { type: 'string', description: 'Channel ID to read.' },
@@ -161,7 +168,8 @@ const SLACK_ACTIONS: ChannelActionDef[] = [
     method: 'conversations.replies',
     verb: 'GET',
     name: 'Get thread replies',
-    description: 'Fetch the replies in a thread. Requires `channel` and the thread root `ts`; optional `limit`.',
+    description:
+      'Fetch the replies in a thread. Requires `channel` and the thread root `ts`; optional `limit`.',
     risk: 'read',
     properties: {
       channel: { type: 'string', description: 'Channel ID the thread is in.' },
@@ -175,12 +183,19 @@ const SLACK_ACTIONS: ChannelActionDef[] = [
     method: 'conversations.list',
     verb: 'GET',
     name: 'List channels',
-    description: 'List public + private channels the bot can see (excludes archived). Optional `limit`.',
+    description:
+      'List public + private channels the bot can see (excludes archived). Optional `limit`.',
     risk: 'read',
     properties: {
       limit: { type: 'number', description: 'Max channels to return (default 100).' },
-      types: { type: 'string', description: 'Comma-separated channel types (default "public_channel,private_channel").' },
-      exclude_archived: { type: 'boolean', description: 'Exclude archived channels (default true).' },
+      types: {
+        type: 'string',
+        description: 'Comma-separated channel types (default "public_channel,private_channel").',
+      },
+      exclude_archived: {
+        type: 'boolean',
+        description: 'Exclude archived channels (default true).',
+      },
     },
     required: [],
   },
@@ -237,7 +252,8 @@ const SLACK_ACTIONS: ChannelActionDef[] = [
     method: 'auth.test',
     verb: 'POST',
     name: 'Identify bot (auth.test)',
-    description: 'Return the authenticated bot identity (user_id, team, bot_id) — the "who am I" call.',
+    description:
+      'Return the authenticated bot identity (user_id, team, bot_id) — the "who am I" call.',
     risk: 'read',
     properties: {},
     required: [],
@@ -271,7 +287,11 @@ const SLACK_ACTIONS: ChannelActionDef[] = [
 function toAction(def: ChannelActionDef): NormalizedAction {
   const binding: ActionBinding = { kind: 'http', method: def.verb, path: `/${def.method}` };
   const inputSchema = Object.keys(def.properties).length
-    ? { type: 'object', properties: def.properties, ...(def.required.length ? { required: def.required } : {}) }
+    ? {
+        type: 'object',
+        properties: def.properties,
+        ...(def.required.length ? { required: def.required } : {}),
+      }
     : null;
   return {
     path: def.path,

--- a/apps/api/src/executor/channels.ts
+++ b/apps/api/src/executor/channels.ts
@@ -11,6 +11,27 @@
  */
 import type { ActionBinding, NormalizedAction, Risk } from './types';
 
+/**
+ * Reserved, platform-owned connector slug for the built-in Slack channel.
+ *
+ * Do NOT use the public `slack` slug here: projects are allowed to add their
+ * own `[[connectors]] slug = "slack"` (for example a Pipedream Slack connector).
+ * The in-sandbox `slack` CLI needs a deterministic namespace that cannot be
+ * shadowed by those user-defined connectors, otherwise read commands such as
+ * `slack thread` resolve against the wrong catalog and fail with
+ * `action_not_found`.
+ */
+export const SLACK_CHANNEL_CONNECTOR_SLUG = 'kortix_slack';
+
+export function channelDefaultSlug(platform: string): string {
+  switch (platform) {
+    case 'slack':
+      return SLACK_CHANNEL_CONNECTOR_SLUG;
+    default:
+      return platform;
+  }
+}
+
 // `ChannelPlatform` + the platform allow-list are owned by projects/connectors.ts
 // (the parser layer the executor builds on). This module just maps a platform
 // string → its catalog / API base, so it takes plain strings and returns []/''

--- a/apps/api/src/executor/gateway.ts
+++ b/apps/api/src/executor/gateway.ts
@@ -1,3 +1,12 @@
+import { logger } from '../lib/logger';
+import { SLACK_CHANNEL_CONNECTOR_SLUG, channelCatalog } from './channels';
+import {
+  type ExecResult,
+  type ExecutorAuth,
+  type FetchImpl,
+  executeCall,
+  paramHintsFromSchema,
+} from './execute';
 /**
  * Executor gateway — the chokepoint every tool call goes through. Resolves the
  * connector + action, checks the acting user can use it (project-secret
@@ -14,14 +23,8 @@
  * (router.ts) wires real DB/secret deps. `enforcePolicies` exists for back-compat
  * with the original allow-all engine; production sets it true.
  */
-import {
-  resolveEffectiveAction,
-  type DefaultMode,
-  type Policy,
-} from './policy';
-import { isSecretUsableBy, type SecretGrant, type ShareScope, type ShareSubject } from './share';
-import { executeCall, paramHintsFromSchema, type ExecResult, type ExecutorAuth, type FetchImpl } from './execute';
-import { logger } from '../lib/logger';
+import { type DefaultMode, type Policy, resolveEffectiveAction } from './policy';
+import { type SecretGrant, type ShareScope, type ShareSubject, isSecretUsableBy } from './share';
 import type { ActionBinding, Risk } from './types';
 
 export interface GatewayConnector {
@@ -123,6 +126,33 @@ export type CallResult =
   | { status: 'pending_approval'; reason: string }
   | { status: 'error'; reason: string };
 
+const SLACK_CHANNEL_ACTIONS = new Set(channelCatalog('slack').map((a) => a.path));
+
+async function resolveConnectorForCall(
+  deps: GatewayDeps,
+  input: CallInput,
+): Promise<{ slug: string; connector: GatewayConnector | null }> {
+  // Back-compat for sandboxes baked before the reserved channel slug existed:
+  // old `slack` CLI shims call connector="slack" with the fixed channel action
+  // names. A project may also have a user-defined Pipedream connector named
+  // `slack`; prefer the platform-owned channel connector for those native Slack
+  // CLI actions so the user connector cannot shadow thread/history/search reads.
+  if (input.connectorSlug === 'slack' && SLACK_CHANNEL_ACTIONS.has(input.actionPath)) {
+    const channelConnector = await deps.loadConnectorBySlug(
+      input.projectId,
+      SLACK_CHANNEL_CONNECTOR_SLUG,
+    );
+    if (channelConnector?.enabled && channelConnector.provider === 'channel') {
+      return { slug: SLACK_CHANNEL_CONNECTOR_SLUG, connector: channelConnector };
+    }
+  }
+
+  return {
+    slug: input.connectorSlug,
+    connector: await deps.loadConnectorBySlug(input.projectId, input.connectorSlug),
+  };
+}
+
 /** Is this connector usable by the subject? Access (connector sharing) + credential (by mode). */
 async function connectorUsable(
   deps: GatewayDeps,
@@ -143,9 +173,10 @@ async function connectorUsable(
 
 /** Run one executor call through the full gateway path. */
 export async function handleCall(deps: GatewayDeps, input: CallInput): Promise<CallResult> {
-  const fullPath = `${input.connectorSlug}.${input.actionPath}`;
+  const resolved = await resolveConnectorForCall(deps, input);
+  const fullPath = `${resolved.slug}.${input.actionPath}`;
 
-  const connector = await deps.loadConnectorBySlug(input.projectId, input.connectorSlug);
+  const connector = resolved.connector;
   if (!connector || !connector.enabled) {
     await audit(deps, input, null, 'denied', null, { reason: 'connector_not_found' });
     return { status: 'denied', reason: 'connector_not_found' };
@@ -159,7 +190,9 @@ export async function handleCall(deps: GatewayDeps, input: CallInput): Promise<C
 
   const usable = await connectorUsable(deps, connector, input.subject);
   if (!usable.ok) {
-    await audit(deps, input, connector.connectorId, 'denied', action.risk, { reason: usable.reason });
+    await audit(deps, input, connector.connectorId, 'denied', action.risk, {
+      reason: usable.reason,
+    });
     return { status: 'denied', reason: usable.reason };
   }
 
@@ -199,7 +232,9 @@ export async function handleCall(deps: GatewayDeps, input: CallInput): Promise<C
     if (connector.provider === 'pipedream') {
       const b = action.binding;
       if (!usable.secret) {
-        throw new Error('pipedream connector has no connected account (run `kortix connectors connect`)');
+        throw new Error(
+          'pipedream connector has no connected account (run `kortix connectors connect`)',
+        );
       }
       const userId = connector.credentialMode === 'per_user' ? input.subject.userId : null;
       if (b.kind === 'pipedream') {
@@ -242,7 +277,9 @@ export async function handleCall(deps: GatewayDeps, input: CallInput): Promise<C
       if (connector.provider === 'channel') result = mapChannelEnvelope(result);
     }
     if (result.ok) {
-      await audit(deps, input, connector.connectorId, 'ok', action.risk, { http_status: result.status });
+      await audit(deps, input, connector.connectorId, 'ok', action.risk, {
+        http_status: result.status,
+      });
       return { status: 'ok', data: result.data, risk: action.risk };
     }
     const reason = upstreamReason(result) + fallbackHint(connector, action.binding);
@@ -250,11 +287,15 @@ export async function handleCall(deps: GatewayDeps, input: CallInput): Promise<C
       http_status: result.status,
       reason: reason.slice(0, 500),
     });
-    logger.warn(`[executor] ${fullPath} failed (upstream ${result.status}): ${reason.slice(0, 500)}`);
+    logger.warn(
+      `[executor] ${fullPath} failed (upstream ${result.status}): ${reason.slice(0, 500)}`,
+    );
     return { status: 'error', reason };
   } catch (e) {
     const reason = (e as Error).message + fallbackHint(connector, action.binding);
-    await audit(deps, input, connector.connectorId, 'error', action.risk, { reason: reason.slice(0, 500) });
+    await audit(deps, input, connector.connectorId, 'error', action.risk, {
+      reason: reason.slice(0, 500),
+    });
     logger.warn(`[executor] ${fullPath} threw: ${reason.slice(0, 500)}`);
     return { status: 'error', reason };
   }
@@ -286,7 +327,9 @@ function upstreamReason(result: ExecResult): string {
       if (body && body !== '{}' && body !== 'null' && body !== '[]') {
         return `upstream_${result.status}: ${body.slice(0, 2000)}`;
       }
-    } catch { /* unserializable body — fall through to the bare status */ }
+    } catch {
+      /* unserializable body — fall through to the bare status */
+    }
   }
   return `upstream_${result.status}`;
 }

--- a/apps/api/src/executor/sync.ts
+++ b/apps/api/src/executor/sync.ts
@@ -47,7 +47,8 @@ export interface SyncResult {
  * Best-effort re-materialization after a channel platform install changes
  * (connect / disconnect). Resolves the project's account, then runs the normal
  * sweep so the auto-materialized channel connector (dis)appears immediately —
- * "connect Slack → the `slack` connector shows up" with no manifest edit.
+ * "connect Slack → the platform-owned Slack connector shows up" with no
+ * manifest edit.
  * Never throws: a sync hiccup must not fail the install/uninstall request.
  */
 export async function reconcileChannelConnectors(projectId: string): Promise<void> {
@@ -114,8 +115,8 @@ export async function syncProjectConnectors(projectId: string, accountId: string
 
   // Channel connectors (e.g. Slack) are INSTALL-driven, not manifest-driven:
   // connecting the platform IS the registration. So they materialize even when
-  // the project has no readable kortix.toml — "connect Slack → the `slack`
-  // connector just appears" must hold for any project. Synthetic specs are
+  // the project has no readable kortix.toml — "connect Slack → the built-in
+  // Slack connector just appears" must hold for any project. Synthetic specs are
   // materialized like any other connector but never written back to git.
   const channelSpecs = await synthesizeChannelConnectors(projectId, declaredSpecs);
   const specs = [...declaredSpecs, ...channelSpecs];

--- a/apps/api/src/executor/sync.ts
+++ b/apps/api/src/executor/sync.ts
@@ -47,8 +47,7 @@ export interface SyncResult {
  * Best-effort re-materialization after a channel platform install changes
  * (connect / disconnect). Resolves the project's account, then runs the normal
  * sweep so the auto-materialized channel connector (dis)appears immediately —
- * "connect Slack → the platform-owned Slack connector shows up" with no
- * manifest edit.
+ * "connect Slack → the `slack` connector shows up" with no manifest edit.
  * Never throws: a sync hiccup must not fail the install/uninstall request.
  */
 export async function reconcileChannelConnectors(projectId: string): Promise<void> {
@@ -115,8 +114,8 @@ export async function syncProjectConnectors(projectId: string, accountId: string
 
   // Channel connectors (e.g. Slack) are INSTALL-driven, not manifest-driven:
   // connecting the platform IS the registration. So they materialize even when
-  // the project has no readable kortix.toml — "connect Slack → the built-in
-  // Slack connector just appears" must hold for any project. Synthetic specs are
+  // the project has no readable kortix.toml — "connect Slack → the `slack`
+  // connector just appears" must hold for any project. Synthetic specs are
   // materialized like any other connector but never written back to git.
   const channelSpecs = await synthesizeChannelConnectors(projectId, declaredSpecs);
   const specs = [...declaredSpecs, ...channelSpecs];

--- a/apps/sandbox/slack-cli/channels/slack.ts
+++ b/apps/sandbox/slack-cli/channels/slack.ts
@@ -1,21 +1,21 @@
 #!/usr/bin/env bun
-import { readFileSync, existsSync, writeFileSync, mkdirSync } from 'node:fs';
-import {
-  parseArgs,
-  out,
-  CliError,
-  handleError,
-  validateRequired,
-  getEnv,
-  kortixProjectId,
-  kortixSessionId,
-  kortixGet,
-  kortixPost,
-} from '../lib';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 // The published Kortix Executor SDK — baked into the sandbox at the mirrored
 // path (/opt/kortix/packages/executor-sdk). Using it here both keeps the shim's
 // gateway calls clean AND dogfoods the SDK in a real in-sandbox consumer.
-import { createExecutorClient, ExecutorError } from '../../../../packages/executor-sdk/src/index';
+import { ExecutorError, createExecutorClient } from '../../../../packages/executor-sdk/src/index';
+import {
+  CliError,
+  getEnv,
+  handleError,
+  kortixGet,
+  kortixPost,
+  kortixProjectId,
+  kortixSessionId,
+  out,
+  parseArgs,
+  validateRequired,
+} from '../lib';
 
 // Relay a checkpoint or the final answer into this turn's live Slack stream.
 // apps/api owns the streamed message; here we just hand it the content.
@@ -92,6 +92,23 @@ const METHOD_TO_ACTION: Record<string, string> = {
   'files.info': 'file_info',
 };
 
+type SlackWebApiResponse = Record<string, unknown> & {
+  ok?: boolean;
+  error?: string;
+};
+
+function requiredFlags<const K extends string>(
+  flags: Record<string, string>,
+  ...keys: K[]
+): Record<K, string> {
+  validateRequired(flags, ...keys);
+  return Object.fromEntries(keys.map((key) => [key, flags[key] ?? ''])) as Record<K, string>;
+}
+
+function optionalInt(value: string | undefined): number | undefined {
+  return value ? Number.parseInt(value, 10) : undefined;
+}
+
 // The Executor SDK client, built from this sandbox's env. Setting projectId
 // makes the SDK use the project-explicit gateway route
 // (/executor/projects/:id/call), which accepts the in-sandbox session token.
@@ -111,14 +128,17 @@ function executorClient() {
 // (surfacing the Slack error); on success it returns `{ ok:true, data:<slack> }`.
 // Args keep Slack's native names, so the existing callers + `data.ok` reads are
 // unchanged.
-async function executorCall(method: string, args: Record<string, unknown>): Promise<any> {
+async function executorCall(
+  method: string,
+  args: Record<string, unknown>,
+): Promise<SlackWebApiResponse> {
   const action = METHOD_TO_ACTION[method];
   if (!action) throw new CliError(`No Executor action mapped for Slack method "${method}"`);
   let lastErr: ExecutorError | null = null;
   for (const connector of SLACK_CONNECTORS) {
     try {
       const res = await executorClient().call(connector, action, args);
-      return res.data ?? res;
+      return (res.data ?? res) as SlackWebApiResponse;
     } catch (err) {
       if (!(err instanceof ExecutorError)) throw err;
       lastErr = err;
@@ -126,7 +146,10 @@ async function executorCall(method: string, args: Record<string, unknown>): Prom
       // Try the legacy `slack` namespace only when the reserved channel connector
       // is absent/not yet materialized. Do not fall back on `needs_auth` or
       // upstream Slack errors — those are real results from the right connector.
-      if (connector === SLACK_CONNECTORS[0] && (reason === 'connector_not_found' || reason === 'action_not_found')) {
+      if (
+        connector === SLACK_CONNECTORS[0] &&
+        (reason === 'connector_not_found' || reason === 'action_not_found')
+      ) {
         continue;
       }
       throw new CliError(err.message);
@@ -151,11 +174,17 @@ function executorErrorReason(err: ExecutorError): string | null {
   return err.message || null;
 }
 
-async function apiPost(method: string, body: Record<string, unknown>): Promise<any> {
+async function apiPost(
+  method: string,
+  body: Record<string, unknown>,
+): Promise<SlackWebApiResponse> {
   return executorCall(method, body);
 }
 
-async function apiGet(method: string, params: Record<string, string>): Promise<any> {
+async function apiGet(
+  method: string,
+  params: Record<string, string>,
+): Promise<SlackWebApiResponse> {
   return executorCall(method, params);
 }
 
@@ -234,20 +263,29 @@ async function del(opts: { channel: string; ts: string }) {
 }
 
 async function react(opts: { channel: string; ts: string; emoji: string }) {
-  const data = await apiPost('reactions.add', { channel: opts.channel, timestamp: opts.ts, name: opts.emoji });
+  const data = await apiPost('reactions.add', {
+    channel: opts.channel,
+    timestamp: opts.ts,
+    name: opts.emoji,
+  });
   if (!data.ok) throw new CliError(data.error ?? 'react failed');
   return { ok: true };
 }
 
 async function history(opts: { channel: string; limit?: number }) {
-  const data = await apiGet('conversations.history', { channel: opts.channel, limit: String(opts.limit ?? 20) });
+  const data = await apiGet('conversations.history', {
+    channel: opts.channel,
+    limit: String(opts.limit ?? 20),
+  });
   if (!data.ok) throw new CliError(data.error ?? 'history failed');
   return { ok: true, messages: data.messages };
 }
 
 async function thread(opts: { channel: string; ts: string; limit?: number }) {
   const data = await apiGet('conversations.replies', {
-    channel: opts.channel, ts: opts.ts, limit: String(opts.limit ?? 20),
+    channel: opts.channel,
+    ts: opts.ts,
+    limit: String(opts.limit ?? 20),
   });
   if (!data.ok) throw new CliError(data.error ?? 'thread failed');
   return { ok: true, messages: data.messages };
@@ -319,7 +357,9 @@ async function download(opts: { url: string; out: string }) {
   const tok = getEnv('KORTIX_CLI_TOKEN') ?? getEnv('KORTIX_TOKEN');
   const projectId = kortixProjectId();
   if (!apiUrl || !tok || !projectId) {
-    throw new CliError('KORTIX_API_URL / KORTIX_CLI_TOKEN / KORTIX_PROJECT_ID not set — cannot download.');
+    throw new CliError(
+      'KORTIX_API_URL / KORTIX_CLI_TOKEN / KORTIX_PROJECT_ID not set — cannot download.',
+    );
   }
   const proxyUrl = new URL(
     `/v1/projects/${projectId}/channels/slack/file?url=${encodeURIComponent(opts.url)}`,
@@ -331,7 +371,12 @@ async function download(opts: { url: string; out: string }) {
   });
   if (!res.ok) {
     let msg = `Download failed: HTTP ${res.status}`;
-    try { const j = (await res.json()) as { error?: string }; if (j?.error) msg = j.error; } catch { /* keep */ }
+    try {
+      const j = (await res.json()) as { error?: string };
+      if (j?.error) msg = j.error;
+    } catch {
+      /* keep */
+    }
     throw new CliError(msg);
   }
   const buf = await res.arrayBuffer();
@@ -359,8 +404,11 @@ async function manifest(opts: { url?: string; projectId?: string; name?: string 
 
 function readTextFlag(flags: Record<string, string>): string | undefined {
   if (flags['text-file']) {
-    try { return readFileSync(flags['text-file'], 'utf-8'); }
-    catch { throw new CliError(`Cannot read --text-file: ${flags['text-file']}`); }
+    try {
+      return readFileSync(flags['text-file'], 'utf-8');
+    } catch {
+      throw new CliError(`Cannot read --text-file: ${flags['text-file']}`);
+    }
   }
   return flags.text;
 }
@@ -368,20 +416,26 @@ function readTextFlag(flags: Record<string, string>): string | undefined {
 function readBlocksFlag(flags: Record<string, string>): unknown[] | undefined {
   let raw: string | undefined;
   if (flags['blocks-file']) {
-    try { raw = readFileSync(flags['blocks-file'], 'utf-8'); }
-    catch { throw new CliError(`Cannot read --blocks-file: ${flags['blocks-file']}`); }
+    try {
+      raw = readFileSync(flags['blocks-file'], 'utf-8');
+    } catch {
+      throw new CliError(`Cannot read --blocks-file: ${flags['blocks-file']}`);
+    }
   } else if (flags.blocks) {
     raw = flags.blocks === '-' ? readFileSync(0, 'utf-8') : flags.blocks;
   }
   if (!raw) return undefined;
   let parsed: unknown;
-  try { parsed = JSON.parse(raw); }
-  catch (err) { throw new CliError(`--blocks is not valid JSON: ${(err as Error).message}`); }
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new CliError(`--blocks is not valid JSON: ${(err as Error).message}`);
+  }
   const arr = Array.isArray(parsed)
     ? parsed
-    : (parsed && typeof parsed === 'object' && Array.isArray((parsed as { blocks?: unknown }).blocks)
-        ? (parsed as { blocks: unknown[] }).blocks
-        : null);
+    : parsed && typeof parsed === 'object' && Array.isArray((parsed as { blocks?: unknown }).blocks)
+      ? (parsed as { blocks: unknown[] }).blocks
+      : null;
   if (!arr) throw new CliError('--blocks must be a JSON array (or `{ "blocks": [...] }`)');
   if (arr.length === 0) throw new CliError('--blocks cannot be empty');
   return arr;
@@ -431,75 +485,70 @@ async function main(): Promise<void> {
       if (!text && !flags.file && !blocks) {
         throw new CliError('--text, --text-file, --blocks, --blocks-file, and/or --file required');
       }
-      out(await send({
-        channel: flags.channel!,
-        text,
-        blocks,
-        threadTs: flags.thread,
-        file: flags.file,
-      }));
+      const { channel } = requiredFlags(flags, 'channel');
+      out(
+        await send({
+          channel,
+          text,
+          blocks,
+          threadTs: flags.thread,
+          file: flags.file,
+        }),
+      );
       break;
     }
     case 'edit': {
-      validateRequired(flags, 'channel', 'ts');
+      const { channel, ts } = requiredFlags(flags, 'channel', 'ts');
       const text = readTextFlag(flags);
       const blocks = readBlocksFlag(flags);
       if (!text && !blocks) throw new CliError('--text, --text-file, or --blocks required');
-      out(await edit({ channel: flags.channel!, ts: flags.ts!, text, blocks }));
+      out(await edit({ channel, ts, text, blocks }));
       break;
     }
     case 'delete':
-      validateRequired(flags, 'channel', 'ts');
-      out(await del({ channel: flags.channel!, ts: flags.ts! }));
+      out(await del(requiredFlags(flags, 'channel', 'ts')));
       break;
     case 'react':
-      validateRequired(flags, 'channel', 'ts', 'emoji');
-      out(await react({ channel: flags.channel!, ts: flags.ts!, emoji: flags.emoji! }));
+      out(await react(requiredFlags(flags, 'channel', 'ts', 'emoji')));
       break;
     case 'typing':
       validateRequired(flags, 'channel');
       out({ ok: true, note: 'Slack Web API does not support typing indicators for bots' });
       break;
     case 'history':
-      validateRequired(flags, 'channel');
-      out(await history({ channel: flags.channel!, limit: flags.limit ? parseInt(flags.limit, 10) : undefined }));
+      out(await history({ ...requiredFlags(flags, 'channel'), limit: optionalInt(flags.limit) }));
       break;
     case 'thread':
-      validateRequired(flags, 'channel', 'ts');
-      out(await thread({ channel: flags.channel!, ts: flags.ts!, limit: flags.limit ? parseInt(flags.limit, 10) : undefined }));
+      out(
+        await thread({ ...requiredFlags(flags, 'channel', 'ts'), limit: optionalInt(flags.limit) }),
+      );
       break;
     case 'channels':
-      out(await listChannels({ limit: flags.limit ? parseInt(flags.limit, 10) : undefined }));
+      out(await listChannels({ limit: optionalInt(flags.limit) }));
       break;
     case 'channel-info':
-      validateRequired(flags, 'channel');
-      out(await channelInfo({ channel: flags.channel! }));
+      out(await channelInfo(requiredFlags(flags, 'channel')));
       break;
     case 'join':
-      validateRequired(flags, 'channel');
-      out(await join({ channel: flags.channel! }));
+      out(await join(requiredFlags(flags, 'channel')));
       break;
     case 'users':
-      out(await listUsers({ limit: flags.limit ? parseInt(flags.limit, 10) : undefined }));
+      out(await listUsers({ limit: optionalInt(flags.limit) }));
       break;
     case 'user':
-      validateRequired(flags, 'id');
-      out(await user({ id: flags.id! }));
+      out(await user(requiredFlags(flags, 'id')));
       break;
     case 'me':
       out(await me());
       break;
     case 'search':
-      validateRequired(flags, 'query');
-      out(await search({ query: flags.query! }));
+      out(await search(requiredFlags(flags, 'query')));
       break;
     case 'file-info':
-      validateRequired(flags, 'file');
-      out(await fileInfo({ fileId: flags.file! }));
+      out(await fileInfo({ fileId: requiredFlags(flags, 'file').file }));
       break;
     case 'download':
-      validateRequired(flags, 'url', 'out');
-      out(await download({ url: flags.url!, out: flags.out! }));
+      out(await download(requiredFlags(flags, 'url', 'out')));
       break;
     case 'manifest':
       out(await manifest({ url: flags.url, projectId: flags['project-id'], name: flags.name }));
@@ -511,10 +560,9 @@ async function main(): Promise<void> {
       // sandbox-side event subscriber. The CLI keeps this case so older
       // workflows fail loud instead of pretending to work.
       throw new CliError(
-        '`slack ask` was removed — use opencode\'s built-in `question` tool. ' +
-        'The Slack form is rendered automatically by the sandbox\'s opencode-events subscriber.',
+        "`slack ask` was removed — use opencode's built-in `question` tool. " +
+          "The Slack form is rendered automatically by the sandbox's opencode-events subscriber.",
       );
-    case 'help':
     default:
       console.log(`
 slack — Slack Web API adapter

--- a/apps/sandbox/slack-cli/channels/slack.ts
+++ b/apps/sandbox/slack-cli/channels/slack.ts
@@ -152,7 +152,7 @@ async function executorCall(
       ) {
         continue;
       }
-      throw new CliError(err.message);
+      throw new CliError(reason ?? err.message);
     }
   }
   try {
@@ -170,6 +170,8 @@ function executorErrorReason(err: ExecutorError): string | null {
     if (typeof reason === 'string') return reason;
     const error = (body as { error?: unknown }).error;
     if (typeof error === 'string') return error;
+    const message = (body as { message?: unknown }).message;
+    if (typeof message === 'string') return message;
   }
   return err.message || null;
 }

--- a/apps/sandbox/slack-cli/channels/slack.ts
+++ b/apps/sandbox/slack-cli/channels/slack.ts
@@ -69,7 +69,12 @@ function readSourcesFlag(flags: Record<string, string>): Array<{ url: string; te
 
 // Slack Web API methods → their Kortix `channel` connector action paths. The
 // shim speaks Slack method names; the Executor speaks connector actions.
-const SLACK_CONNECTOR = 'slack';
+//
+// Use the reserved platform-owned channel slug first. Projects may define their
+// own `[[connectors]] slug="slack"` (often Pipedream Slack), which must not
+// shadow the built-in Slack CLI. Keep the legacy `slack` fallback so old API
+// deployments / old materialized rows continue to work during rollout.
+const SLACK_CONNECTORS = ['kortix_slack', 'slack'] as const;
 const METHOD_TO_ACTION: Record<string, string> = {
   'chat.postMessage': 'send_message',
   'chat.update': 'update_message',
@@ -109,13 +114,41 @@ function executorClient() {
 async function executorCall(method: string, args: Record<string, unknown>): Promise<any> {
   const action = METHOD_TO_ACTION[method];
   if (!action) throw new CliError(`No Executor action mapped for Slack method "${method}"`);
+  let lastErr: ExecutorError | null = null;
+  for (const connector of SLACK_CONNECTORS) {
+    try {
+      const res = await executorClient().call(connector, action, args);
+      return res.data ?? res;
+    } catch (err) {
+      if (!(err instanceof ExecutorError)) throw err;
+      lastErr = err;
+      const reason = executorErrorReason(err);
+      // Try the legacy `slack` namespace only when the reserved channel connector
+      // is absent/not yet materialized. Do not fall back on `needs_auth` or
+      // upstream Slack errors — those are real results from the right connector.
+      if (connector === SLACK_CONNECTORS[0] && (reason === 'connector_not_found' || reason === 'action_not_found')) {
+        continue;
+      }
+      throw new CliError(err.message);
+    }
+  }
   try {
-    const res = await executorClient().call(SLACK_CONNECTOR, action, args);
-    return res.data ?? res;
+    throw lastErr ?? new CliError(`Slack connector action "${action}" was not found`);
   } catch (err) {
     if (err instanceof ExecutorError) throw new CliError(err.message);
     throw err;
   }
+}
+
+function executorErrorReason(err: ExecutorError): string | null {
+  const body = err.body;
+  if (body && typeof body === 'object') {
+    const reason = (body as { reason?: unknown }).reason;
+    if (typeof reason === 'string') return reason;
+    const error = (body as { error?: unknown }).error;
+    if (typeof error === 'string') return error;
+  }
+  return err.message || null;
 }
 
 async function apiPost(method: string, body: Record<string, unknown>): Promise<any> {


### PR DESCRIPTION
## Summary
- reserve a platform-owned `kortix_slack` channel connector for the built-in Slack CLI so user-defined `slack` connectors cannot shadow it
- keep server-side compatibility for older sandbox CLI shims that still call connector `slack`
- add fake-Kortix-API e2e coverage for the Slack CLI command surface, including thread/history/search/file/manifest paths

## Verification
- `DATABASE_URL=postgres://user:pass@localhost:5432/db SUPABASE_URL=http://localhost:54321 SUPABASE_SERVICE_ROLE_KEY=test API_KEY_SECRET=test INTERNAL_KORTIX_ENV=dev FREESTYLE_API_URL=https://api.freestyle.sh FRONTEND_URL=http://localhost:3000 ALLOWED_SANDBOX_PROVIDERS=local_docker DOCKER_HOST=unix:///var/run/docker.sock TUNNEL_ENABLED=false KORTIX_BILLING_INTERNAL_ENABLED=false bun test apps/api/src/__tests__/e2e-slack-cli.test.ts apps/api/src/__tests__/unit-executor-channels.test.ts`
- `pnpm --filter kortix-api typecheck`
