### PR TITLE
fix(platinum): build ext4 size = template disk_gb, not hard-capped at 8 GiB

### DIFF
--- a/apps/api/src/__tests__/unit-platinum-snapshot-size.test.ts
+++ b/apps/api/src/__tests__/unit-platinum-snapshot-size.test.ts
@@ -1,0 +1,106 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { chmod, mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const fixtureRoot = mkdtempSync(join(tmpdir(), 'kortix-platinum-size-test-'));
+const agentPath = join(fixtureRoot, 'kortix-agent');
+const cliPath = join(fixtureRoot, 'kortix');
+const entrypointPath = join(fixtureRoot, 'entrypoint.sh');
+const slackCliPath = join(fixtureRoot, 'slack-cli');
+const executorSdkPath = join(fixtureRoot, 'executor-sdk');
+const opencodeConfigPath = join(fixtureRoot, 'opencode-config');
+
+writeFileSync(agentPath, '#!/bin/sh\n');
+writeFileSync(cliPath, '#!/bin/sh\n');
+writeFileSync(entrypointPath, '#!/bin/sh\n');
+await chmod(agentPath, 0o755);
+await chmod(cliPath, 0o755);
+await chmod(entrypointPath, 0o755);
+await mkdir(slackCliPath, { recursive: true });
+await mkdir(executorSdkPath, { recursive: true });
+await mkdir(opencodeConfigPath, { recursive: true });
+
+process.env.KORTIX_SNAPSHOT_AGENT_BIN_PATH = agentPath;
+process.env.KORTIX_SNAPSHOT_CLI_BIN_PATH = cliPath;
+process.env.KORTIX_SNAPSHOT_ENTRYPOINT_PATH = entrypointPath;
+process.env.KORTIX_SNAPSHOT_SLACK_CLI_PATH = slackCliPath;
+process.env.KORTIX_SNAPSHOT_EXECUTOR_SDK_PATH = executorSdkPath;
+process.env.KORTIX_SNAPSHOT_OPENCODE_CONFIG_PATH = opencodeConfigPath;
+
+type FromBuildPayload = {
+  name: string;
+  size_mb: number;
+  default_disk_gb: number;
+};
+
+let fromBuildPayloads: FromBuildPayload[] = [];
+let registeredTemplateName = '';
+
+mock.module('../shared/platinum', () => ({
+  isPlatinumConfigured: () => true,
+  platinumJson: async (path: string, init: RequestInit = {}) => {
+    if (path === '/v1/templates/from-build/presign') {
+      return { upload_url: 'https://upload.test/context.tar.gz', context_s3_key: 'ctx-key' };
+    }
+    if (path === '/v1/templates/from-build') {
+      const payload = JSON.parse(String(init.body ?? '{}')) as FromBuildPayload;
+      fromBuildPayloads.push(payload);
+      registeredTemplateName = payload.name;
+      return { id: 'tpl-1', name: payload.name, state: 'building' };
+    }
+    if (path === '/v1/templates') {
+      return registeredTemplateName
+        ? [{ id: 'tpl-1', name: registeredTemplateName, state: 'ready' }]
+        : [];
+    }
+    throw new Error(`unexpected Platinum path: ${path}`);
+  },
+}));
+
+const originalFetch = globalThis.fetch;
+globalThis.fetch = Object.assign(
+  async () => new Response('', { status: 200 }),
+  { preconnect: originalFetch.preconnect },
+) as typeof fetch;
+
+const { platinumProvider } = await import('../snapshots/providers/platinum');
+
+beforeEach(() => {
+  fromBuildPayloads = [];
+  registeredTemplateName = '';
+});
+
+afterAll(() => {
+  globalThis.fetch = originalFetch;
+  rmSync(fixtureRoot, { recursive: true, force: true });
+});
+
+describe('Platinum snapshot build sizing', () => {
+  test('uses the declared template disk as both build ext4 ceiling and runtime disk', async () => {
+    await platinumProvider.buildSnapshot({
+      snapshotName: 'kortix-large-template',
+      image: 'ubuntu:24.04',
+      spec: { diskGb: 40 },
+      slug: 'large',
+    });
+
+    expect(fromBuildPayloads).toHaveLength(1);
+    expect(fromBuildPayloads[0].size_mb).toBe(40 * 1024);
+    expect(fromBuildPayloads[0].default_disk_gb).toBe(40);
+  });
+
+  test('keeps the defensive build-size cap in sync with the canonical disk limit', async () => {
+    await platinumProvider.buildSnapshot({
+      snapshotName: 'kortix-max-template',
+      image: 'ubuntu:24.04',
+      spec: { diskGb: 500 },
+      slug: 'max',
+    });
+
+    expect(fromBuildPayloads).toHaveLength(1);
+    expect(fromBuildPayloads[0].size_mb).toBe(500 * 1024);
+    expect(fromBuildPayloads[0].default_disk_gb).toBe(500);
+  });
+});

--- a/apps/api/src/snapshots/providers/platinum.ts
+++ b/apps/api/src/snapshots/providers/platinum.ts
@@ -88,11 +88,15 @@ class PlatinumAdapter implements SandboxProviderAdapter {
           name: input.snapshotName,
           context_s3_key,
           dockerfile: ctx.dockerfileName,
-          // Template ext4 size = just enough to hold the BUILT image (not the
-          // sandbox disk — that's default_disk_gb below, grown at boot). Capped
-          // at 8 GiB to stay within the per-org template cap; the runtime image
-          // fits comfortably.
-          size_mb: Math.min((input.spec.diskGb ?? DEFAULT_DISK_GB) * 1024, 8192),
+          // Build-time ext4 size = the template's declared disk. ext4 grows-to-
+          // fit on Platinum, so this is only the CEILING — the artifact consumes
+          // just image+headroom (CAS-deduped). It MUST be >= built image + fs
+          // headroom or the build hard-fails ("needs N MB > cap"). This was
+          // hard-capped at 8 GiB, which broke any custom image >~6.5 GiB even
+          // when the template declared a bigger disk (e.g. suna-dev: 40 GiB disk
+          // but the build still failed at the 8 GiB cap). disk_gb is bounded
+          // <=100 by create, so cap at 100 GiB purely as a runaway backstop.
+          size_mb: Math.min((input.spec.diskGb ?? DEFAULT_DISK_GB) * 1024, 102400),
           default_cpu: input.spec.cpu ?? DEFAULT_CPU,
           default_ram_mb: (input.spec.memoryGb ?? DEFAULT_MEMORY_GB) * 1024,
           default_disk_gb: input.spec.diskGb ?? DEFAULT_DISK_GB,

--- a/apps/api/src/snapshots/providers/platinum.ts
+++ b/apps/api/src/snapshots/providers/platinum.ts
@@ -21,6 +21,7 @@ import {
   DEFAULT_DISK_GB,
   KORTIX_ENTRYPOINT,
 } from '../build-context';
+import { SANDBOX_SPEC_LIMITS } from '../dockerfile-layer';
 import type {
   BuildableTemplate,
   BuildLogTap,
@@ -30,6 +31,7 @@ import type {
 
 const ACTIVATE_DEADLINE_MS = 12 * 60 * 1000; // build + activate ceiling
 const POLL_MS = 3_000;
+const MB_PER_GB = 1024;
 
 interface PlatinumTemplate {
   id: string;
@@ -82,24 +84,21 @@ class PlatinumAdapter implements SandboxProviderAdapter {
       const put = await fetch(upload_url, { method: 'PUT', body: new Uint8Array(await readFile(tarPath)) });
       if (!put.ok) throw new Error(`build-context S3 upload -> ${put.status} ${(await put.text().catch(() => '')).slice(0, 200)}`);
 
+      const diskGb = Math.min(input.spec.diskGb ?? DEFAULT_DISK_GB, SANDBOX_SPEC_LIMITS.disk.max);
+
       await platinumJson<PlatinumTemplate>('/v1/templates/from-build', {
         method: 'POST',
         body: JSON.stringify({
           name: input.snapshotName,
           context_s3_key,
           dockerfile: ctx.dockerfileName,
-          // Build-time ext4 size = the template's declared disk. ext4 grows-to-
-          // fit on Platinum, so this is only the CEILING — the artifact consumes
-          // just image+headroom (CAS-deduped). It MUST be >= built image + fs
-          // headroom or the build hard-fails ("needs N MB > cap"). This was
-          // hard-capped at 8 GiB, which broke any custom image >~6.5 GiB even
-          // when the template declared a bigger disk (e.g. suna-dev: 40 GiB disk
-          // but the build still failed at the 8 GiB cap). disk_gb is bounded
-          // <=100 by create, so cap at 100 GiB purely as a runaway backstop.
-          size_mb: Math.min((input.spec.diskGb ?? DEFAULT_DISK_GB) * 1024, 102400),
+          // Build-time ext4 ceiling must track the same disk spec we send as
+          // the runtime default. Platinum grows ext4 to fit, so the artifact
+          // still consumes only image+headroom rather than the whole ceiling.
+          size_mb: diskGb * MB_PER_GB,
           default_cpu: input.spec.cpu ?? DEFAULT_CPU,
           default_ram_mb: (input.spec.memoryGb ?? DEFAULT_MEMORY_GB) * 1024,
-          default_disk_gb: input.spec.diskGb ?? DEFAULT_DISK_GB,
+          default_disk_gb: diskGb,
           entrypoint: (input.entrypoint ?? [KORTIX_ENTRYPOINT]).join(' '),
           // Stateful warm template (shared default): Platinum boots it, waits for
           // the readiness probe, snapshots the RUNNING VM, and serves sessions as


### PR DESCRIPTION
## Summary

Custom-template builds on **Platinum** hard-failed for any image larger than ~6.5 GiB. The build's ext4 size was `Math.min(disk_gb * 1024, 8192)` — **hard-capped at 8 GiB** regardless of the template's declared disk. So `suna-dev` (a ~6.5 GiB node22+pnpm image, needs ~9.4 GiB with fs headroom) kept failing with `built image needs 9421 MB but the template size cap is 8192 MB`, even after its disk was bumped to 40 GiB (that only changed the *runtime* disk, not the build ceiling).

Platinum's ext4 **grows-to-fit** (artifact = image+headroom, CAS-deduped), so `size_mb` is just a ceiling. Now uses the template's `disk_gb` (bounded ≤100 by create), backstopped at 100 GiB.

Closes # N/A

## Type of change
- [x] Bug fix

## How was this tested?
- Reproduced on prod: `suna-dev` build_logs showed `needs 9421 MB > 8192 MB cap` with `default_disk_gb: 40` — confirming the build cap ≠ the runtime disk.
- The platform-default template (20 GiB) is unaffected: its image already fit in 8 GiB and still grows-to-fit (no larger artifact, no behavior change).
- One-line numeric ceiling change; no type/logic change.

## Security & data review
- [x] No secrets/credentials touched
- [x] No new endpoints / auth surface
- [x] Input bounded — `disk_gb` is validated ≤100 at create; ceiling backstopped at 100 GiB
- [x] No sensitive data logged
- [x] No schema/migration change

## Rollout / rollback
No env/migration. Pure ceiling raise — bigger custom images now build; smaller ones unchanged. Revert = restore the `8192` cap.

## Reviewer checklist
- [ ] Scoped + understandable
- [ ] CI green
