### PR TITLE
fix(db): reconcile faked-baseline prod drift + live-schema presence gate

### DIFF
--- a/.github/workflows/db-drift.yml
+++ b/.github/workflows/db-drift.yml
@@ -89,3 +89,61 @@ jobs:
             exit 1
           fi
           echo "OK — ${{ matrix.env }} matches the committed migrations."
+
+  # PROD is a legacy database that predates the migration system: it carries
+  # cosmetic differences by the hundreds (auto- vs explicitly-named constraints,
+  # `0` vs `0.00` defaults, leftover legacy tables), so the strict signature diff
+  # above is all-false-positives against it. Instead gate prod on PRESENCE only —
+  # every table+column the migrations define must EXIST on prod (extras ignored).
+  # This is the nightly counterpart to the deploy-prod verify-schema gate; it also
+  # catches drift introduced out-of-band BETWEEN deploys.
+  prod-presence:
+    name: Prod has every table+column the migrations define
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+    env:
+      CANONICAL_DB_URL: postgres://postgres:postgres@localhost:5432/postgres
+      LIVE_DB_URL: ${{ secrets.PROD_DATABASE_URL }}
+    steps:
+      - name: Skip if prod is not configured
+        id: gate
+        run: |
+          if [ -z "${LIVE_DB_URL:-}" ]; then
+            echo "No PROD_DATABASE_URL secret — skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          fi
+      - if: steps.gate.outputs.skip != 'true'
+        uses: actions/checkout@v4
+      - if: steps.gate.outputs.skip != 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - if: steps.gate.outputs.skip != 'true'
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - if: steps.gate.outputs.skip != 'true'
+        run: corepack enable pnpm
+      - if: steps.gate.outputs.skip != 'true'
+        run: pnpm install --frozen-lockfile --filter "@kortix/db..." --filter "kortix"
+        env:
+          npm_config_engine_strict: "false"
+      - if: steps.gate.outputs.skip != 'true'
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends postgresql-client
+      - name: Build canonical from migrations + assert prod is a superset
+        if: steps.gate.outputs.skip != 'true'
+        run: |
+          psql "$CANONICAL_DB_URL" -v ON_ERROR_STOP=1 -f packages/db/scripts/test-prereqs.sql
+          pnpm --filter @kortix/db migrate
+          bun packages/db/scripts/verify-live-schema.ts

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -580,6 +580,60 @@ jobs:
           fi
           pnpm --filter @kortix/db migrate
 
+  # ── Verify prod actually matches the migrations (live-schema presence gate) ──
+  # migrate-db proves the migrations RAN; this proves they TOOK. A faked baseline
+  # (migrate.ts autoBaselineIfNeeded marks-applied-without-running on a pre-existing
+  # schema) can leave holes the migration step never notices — exactly how
+  # project_session_public_shares went missing on prod until a user hit a 500.
+  # Builds the canonical schema fresh from the committed migrations in a sidecar
+  # Postgres, then asserts prod contains every table+column it defines. Presence-
+  # only (canonical ⊆ live): tolerant of prod's legacy/cosmetic differences,
+  # strict about missing objects. deploy-api gates on this — drift blocks the roll.
+  verify-schema:
+    name: Verify prod schema matches migrations
+    needs: migrate-db
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+    env:
+      CANONICAL_DB_URL: postgres://postgres:postgres@localhost:5432/postgres
+      LIVE_DB_URL: ${{ secrets.PROD_DATABASE_URL }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - run: corepack enable pnpm
+      - run: pnpm install --frozen-lockfile --filter "@kortix/db..." --filter "kortix"
+        env:
+          npm_config_engine_strict: "false"
+      - run: sudo apt-get update && sudo apt-get install -y --no-install-recommends postgresql-client
+      - name: Build canonical schema from migrations (sidecar)
+        run: |
+          psql "$CANONICAL_DB_URL" -v ON_ERROR_STOP=1 -f packages/db/scripts/test-prereqs.sql
+          pnpm --filter @kortix/db migrate
+      - name: Assert prod contains every table+column the migrations define
+        run: |
+          set -euo pipefail
+          if [ -z "${LIVE_DB_URL:-}" ]; then
+            echo "::error::PROD_DATABASE_URL secret is not set — cannot verify prod schema."
+            exit 1
+          fi
+          bun packages/db/scripts/verify-live-schema.ts
+
   # ── Deploy API to prod (EKS / Argo CD GitOps) ───────────────────────────────
   # The promote PR merge already bumped infra/k8s/envs/prod/values.yaml (image tag
   # + kortixVersion), so Argo CD on the prod-eks cluster rolls the Deployment.
@@ -588,7 +642,7 @@ jobs:
   # X.Y.Z — no task-def version stamping like the old ECS roll needed.
   deploy-api:
     name: Deploy API to prod (EKS / GitOps)
-    needs: [version, retag-images, migrate-db]
+    needs: [version, retag-images, migrate-db, verify-schema]
     runs-on: ubuntu-latest
     permissions:
       id-token: write # OIDC → read the cluster

--- a/packages/db/migrations/20260622154500000_reconcile_faked_baseline_drift.sql
+++ b/packages/db/migrations/20260622154500000_reconcile_faked_baseline_drift.sql
@@ -1,0 +1,103 @@
+-- Up Migration
+--
+-- Reconcile objects the FAKED baseline left missing on environments that were
+-- baselined while their schema predated the migration system (prod).
+--
+-- Background: on an environment whose schema already existed, migrate.ts's
+-- autoBaselineIfNeeded marks the baseline applied WITHOUT running it. That
+-- assumes the pre-existing schema is a complete superset of the baseline. On
+-- prod it was NOT — historical drift (a migration recorded-but-rolled-back under
+-- the retired apply-migrations.sh, e.g. project_session_public_shares) left
+-- holes the fake then cemented. The deployed code references these objects, so
+-- the gaps surface as runtime 500s ("relation/column does not exist").
+--
+-- Everything here is idempotent (IF NOT EXISTS): a no-op on a fresh build and on
+-- dev (both already have the baseline), and a backfill on prod. This is the
+-- repo-native, CI-verified counterpart to the live-schema presence gate added in
+-- deploy-prod.yml (verify-live-schema.ts) — together they guarantee a deployed
+-- DB always contains every table+column the migrations define.
+
+-- ── Tables the faked baseline never created on prod ─────────────────────────
+-- (project_session_public_shares = the public preview/file share links table;
+--  provider_events = sandbox provision/migrate telemetry for the admin tab.)
+
+CREATE TABLE IF NOT EXISTS kortix.project_session_public_shares (
+  share_id        uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  token_hash      text NOT NULL,
+  session_id      text NOT NULL REFERENCES kortix.project_sessions(session_id) ON DELETE CASCADE,
+  project_id      uuid NOT NULL REFERENCES kortix.projects(project_id) ON DELETE CASCADE,
+  account_id      uuid NOT NULL REFERENCES kortix.accounts(account_id) ON DELETE CASCADE,
+  created_by      uuid,
+  resource_type   text NOT NULL DEFAULT 'preview',
+  label           text NOT NULL DEFAULT 'App preview',
+  port            integer,
+  path            text NOT NULL DEFAULT '/',
+  file_path       text,
+  mode            text NOT NULL DEFAULT 'view',
+  allow_websocket boolean NOT NULL DEFAULT false,
+  expires_at      timestamptz,
+  revoked_at      timestamptz,
+  last_used_at    timestamptz,
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  updated_at      timestamptz NOT NULL DEFAULT now()
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_project_session_public_shares_token_hash ON kortix.project_session_public_shares USING btree (token_hash);
+CREATE INDEX IF NOT EXISTS idx_project_session_public_shares_session ON kortix.project_session_public_shares USING btree (session_id);
+CREATE INDEX IF NOT EXISTS idx_project_session_public_shares_project ON kortix.project_session_public_shares USING btree (project_id);
+
+CREATE TABLE IF NOT EXISTS kortix.provider_events (
+  id            uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  provider      text NOT NULL,
+  kind          text NOT NULL,
+  outcome       text NOT NULL,
+  total_ms      integer,
+  marks         jsonb DEFAULT '[]'::jsonb,
+  attempts      integer DEFAULT 1,
+  error_class   text,
+  error         text,
+  from_provider text,
+  session_id    text,
+  account_id    uuid,
+  created_at    timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_provider_events_provider ON kortix.provider_events USING btree (provider);
+CREATE INDEX IF NOT EXISTS idx_provider_events_kind     ON kortix.provider_events USING btree (kind);
+CREATE INDEX IF NOT EXISTS idx_provider_events_outcome  ON kortix.provider_events USING btree (outcome);
+CREATE INDEX IF NOT EXISTS idx_provider_events_created  ON kortix.provider_events USING btree (created_at);
+
+-- ── Columns the faked baseline never added on prod ──────────────────────────
+
+ALTER TABLE kortix.account_deletion_requests ADD COLUMN IF NOT EXISTS created_at timestamptz DEFAULT now();
+ALTER TABLE kortix.account_deletion_requests ADD COLUMN IF NOT EXISTS updated_at timestamptz DEFAULT now();
+ALTER TABLE kortix.account_deletion_requests ADD COLUMN IF NOT EXISTS deleted_at timestamptz;
+ALTER TABLE kortix.account_deletion_requests ADD COLUMN IF NOT EXISTS is_cancelled boolean DEFAULT false;
+ALTER TABLE kortix.account_deletion_requests ADD COLUMN IF NOT EXISTS is_deleted boolean DEFAULT false;
+-- canonical is NOT NULL, but prod has 353 existing rows with no value to backfill,
+-- so it is added NULLABLE here; the deletion feature populates it on every insert.
+ALTER TABLE kortix.account_deletion_requests ADD COLUMN IF NOT EXISTS deletion_scheduled_for timestamptz;
+
+ALTER TABLE kortix.chat_channel_bindings ADD COLUMN IF NOT EXISTS agent_model varchar;
+
+ALTER TABLE kortix.credit_accounts ADD COLUMN IF NOT EXISTS last_reconciled_at timestamptz;
+ALTER TABLE kortix.credit_accounts ADD COLUMN IF NOT EXISTS needs_reconciliation boolean DEFAULT false;
+ALTER TABLE kortix.credit_accounts ADD COLUMN IF NOT EXISTS reconciliation_discrepancy numeric DEFAULT 0;
+
+ALTER TABLE kortix.credit_ledger ADD COLUMN IF NOT EXISTS locked_at timestamptz;
+ALTER TABLE kortix.credit_ledger ADD COLUMN IF NOT EXISTS message_id uuid;
+ALTER TABLE kortix.credit_ledger ADD COLUMN IF NOT EXISTS team_member_email text;
+ALTER TABLE kortix.credit_ledger ADD COLUMN IF NOT EXISTS thread_id uuid;
+ALTER TABLE kortix.credit_ledger ADD COLUMN IF NOT EXISTS triggered_by_user_id uuid;
+
+ALTER TABLE kortix.credit_purchases ADD COLUMN IF NOT EXISTS expires_at timestamptz;
+ALTER TABLE kortix.credit_purchases ADD COLUMN IF NOT EXISTS last_reconciliation_attempt timestamptz;
+ALTER TABLE kortix.credit_purchases ADD COLUMN IF NOT EXISTS reconciled_at timestamptz;
+ALTER TABLE kortix.credit_purchases ADD COLUMN IF NOT EXISTS reconciliation_attempts integer DEFAULT 0;
+
+ALTER TABLE kortix.credit_usage ADD COLUMN IF NOT EXISTS message_id uuid;
+ALTER TABLE kortix.credit_usage ADD COLUMN IF NOT EXISTS thread_id uuid;
+
+ALTER TABLE kortix.sandboxes ADD COLUMN IF NOT EXISTS pooled_at timestamptz;
+
+-- Down Migration
+-- Forward-only: this migration only fills gaps that should never have existed;
+-- dropping the backfilled columns/tables would re-introduce the drift.

--- a/packages/db/scripts/verify-live-schema.test.ts
+++ b/packages/db/scripts/verify-live-schema.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from 'bun:test';
+import { diffMissing, type SchemaObjects } from './verify-live-schema';
+
+const objs = (tables: string[], columns: string[]): SchemaObjects => ({
+  tables: new Set(tables),
+  columns: new Set(columns),
+});
+
+describe('diffMissing (presence: canonical ⊆ live)', () => {
+  test('identical schemas → nothing missing', () => {
+    const s = objs(['accounts', 'projects'], ['accounts.id', 'projects.id']);
+    expect(diffMissing(s, s)).toEqual({ missingTables: [], missingColumns: [] });
+  });
+
+  test('a table the migrations define but the live DB lacks is reported', () => {
+    const canon = objs(['accounts', 'public_shares'], ['accounts.id', 'public_shares.id']);
+    const live = objs(['accounts'], ['accounts.id']);
+    const { missingTables, missingColumns } = diffMissing(canon, live);
+    expect(missingTables).toEqual(['public_shares']);
+    // The column on the missing table is NOT double-reported.
+    expect(missingColumns).toEqual([]);
+  });
+
+  test('a missing column on an existing table is reported', () => {
+    const canon = objs(['credit_accounts'], ['credit_accounts.id', 'credit_accounts.needs_reconciliation']);
+    const live = objs(['credit_accounts'], ['credit_accounts.id']);
+    expect(diffMissing(canon, live)).toEqual({
+      missingTables: [],
+      missingColumns: ['credit_accounts.needs_reconciliation'],
+    });
+  });
+
+  test('EXTRA tables/columns on live (legacy leftovers) are ignored', () => {
+    const canon = objs(['accounts'], ['accounts.id']);
+    const live = objs(['accounts', 'legacy_integrations'], ['accounts.id', 'accounts.extra_col', 'legacy_integrations.x']);
+    expect(diffMissing(canon, live)).toEqual({ missingTables: [], missingColumns: [] });
+  });
+
+  test('reports both missing tables and columns, each sorted', () => {
+    const canon = objs(
+      ['a', 'ztable', 'mtable'],
+      ['a.x', 'a.y', 'a.b'],
+    );
+    const live = objs(['a'], ['a.x']);
+    const { missingTables, missingColumns } = diffMissing(canon, live);
+    expect(missingTables).toEqual(['mtable', 'ztable']);
+    expect(missingColumns).toEqual(['a.b', 'a.y']);
+  });
+});

--- a/packages/db/scripts/verify-live-schema.ts
+++ b/packages/db/scripts/verify-live-schema.ts
@@ -1,0 +1,128 @@
+#!/usr/bin/env bun
+/**
+ * Live-schema PRESENCE gate.
+ *
+ * Asserts that a live database contains every TABLE and COLUMN the committed
+ * migrations define. It is the missing half of the migration safety net: the PR
+ * gates (db-migrations.yml) prove the migrations REPRODUCE the schema on a fresh
+ * DB, but nothing verified that a real environment ACTUALLY MATCHES them — which
+ * is exactly how a faked baseline (see migrate.ts autoBaselineIfNeeded) let
+ * `project_session_public_shares` go missing on prod until a user hit a 500.
+ *
+ *   CANONICAL_DB_URL=<freshly-migrated db>  LIVE_DB_URL=<target>  bun scripts/verify-live-schema.ts
+ *   # or: bun scripts/verify-live-schema.ts --canonical <url> --live <url>
+ *
+ * Exit 0 = live is a superset of canonical (no missing objects).
+ * Exit 1 = live is MISSING canonical tables/columns → drift; fail the deploy.
+ *
+ * Deliberately PRESENCE-ONLY (canonical ⊆ live): it ignores object NAMES
+ * (constraints/indexes), type/default rendering, nullability, and EXTRA objects
+ * on the live DB. A legacy production database carries cosmetic differences
+ * (auto- vs explicitly-named constraints, `0` vs `0.00` defaults, leftover
+ * legacy tables) by the hundreds; gating on full structural equality would be
+ * all false positives. Missing tables/columns are unambiguous and are the class
+ * of drift that actually breaks deployed code.
+ */
+import pg from 'pg';
+
+export type SchemaObjects = { tables: Set<string>; columns: Set<string> };
+
+const SCHEMA = 'kortix';
+
+const OBJECTS_SQL = `
+  SELECT 'T'::text AS k, table_name AS a, ''::text AS b
+    FROM information_schema.tables
+   WHERE table_schema = $1 AND table_type = 'BASE TABLE'
+  UNION ALL
+  SELECT 'C'::text, table_name, column_name
+    FROM information_schema.columns
+   WHERE table_schema = $1
+`;
+
+export async function readSchemaObjects(databaseUrl: string): Promise<SchemaObjects> {
+  const client = new pg.Client({ connectionString: databaseUrl });
+  await client.connect();
+  try {
+    const { rows } = await client.query<{ k: string; a: string; b: string }>(OBJECTS_SQL, [SCHEMA]);
+    const tables = new Set<string>();
+    const columns = new Set<string>();
+    for (const r of rows) {
+      if (r.k === 'T') tables.add(r.a);
+      else columns.add(`${r.a}.${r.b}`);
+    }
+    return { tables, columns };
+  } finally {
+    await client.end();
+  }
+}
+
+/** Pure: objects in `canonical` that are absent from `live`. */
+export function diffMissing(canonical: SchemaObjects, live: SchemaObjects): {
+  missingTables: string[];
+  missingColumns: string[];
+} {
+  const missingTables = [...canonical.tables].filter((t) => !live.tables.has(t)).sort();
+  // A column on a table that is itself missing is reported via the table, not twice.
+  const missingColumns = [...canonical.columns]
+    .filter((c) => !live.columns.has(c) && live.tables.has(c.split('.')[0]))
+    .sort();
+  return { missingTables, missingColumns };
+}
+
+function resolveUrls(argv: string[]): { canonical: string; live: string } {
+  const flag = (name: string) => {
+    const i = argv.indexOf(name);
+    return i >= 0 ? argv[i + 1] : undefined;
+  };
+  const canonical = flag('--canonical') ?? process.env.CANONICAL_DB_URL;
+  const live = flag('--live') ?? process.env.LIVE_DB_URL;
+  if (!canonical || !live) {
+    console.error(
+      'Usage: CANONICAL_DB_URL=<fresh-migrated> LIVE_DB_URL=<target> bun scripts/verify-live-schema.ts\n' +
+        '   or: bun scripts/verify-live-schema.ts --canonical <url> --live <url>',
+    );
+    process.exit(2);
+  }
+  return { canonical, live };
+}
+
+async function main() {
+  const { canonical, live } = resolveUrls(process.argv.slice(2));
+  // The live read is strictly read-only.
+  const liveRo = live.includes('?') ? `${live}&options=-c%20default_transaction_read_only%3Don` : live;
+  const [canon, target] = await Promise.all([
+    readSchemaObjects(canonical),
+    readSchemaObjects(liveRo).catch(() => readSchemaObjects(live)),
+  ]);
+
+  const { missingTables, missingColumns } = diffMissing(canon, target);
+  console.log(
+    `Canonical: ${canon.tables.size} tables / ${canon.columns.size} columns.  ` +
+      `Live: ${target.tables.size} tables / ${target.columns.size} columns.`,
+  );
+
+  if (missingTables.length === 0 && missingColumns.length === 0) {
+    console.log('OK — live database contains every table and column the migrations define.');
+    return;
+  }
+
+  console.error('::error::Live-schema drift — the database is MISSING objects the migrations define.');
+  if (missingTables.length) {
+    console.error(`\nMissing TABLES (${missingTables.length}):`);
+    for (const t of missingTables) console.error(`  - ${SCHEMA}.${t}`);
+  }
+  if (missingColumns.length) {
+    console.error(`\nMissing COLUMNS (${missingColumns.length}):`);
+    for (const c of missingColumns) console.error(`  - ${SCHEMA}.${c}`);
+  }
+  console.error('\nReconcile by adding an idempotent migration (CREATE TABLE / ADD COLUMN IF NOT EXISTS).');
+  process.exit(1);
+}
+
+// Only run when invoked directly (so the pure helpers can be unit-tested).
+if (import.meta.main) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(2);
+  });
+}


### PR DESCRIPTION
## What & why

`POST /projects/:id/sessions/:id/public-shares` was returning **500 on prod**: `kortix.project_session_public_shares` did not exist there. Root cause — its migration was *recorded-but-rolled-back* under the retired `apply-migrations.sh`, then the `node-pg-migrate` baseline was **faked** over the gap (`autoBaselineIfNeeded` marks the baseline applied without running it on a pre-existing schema), cementing the hole. Nothing ever verified the live DB against the migrations.

A full **dev / prod / canonical** diff showed:
- **dev == the committed migrations, exactly (0 drift).**
- prod was *also* missing `provider_events` and **22 columns** the faked baseline never created — latent landmines that would 500 the same way once their feature code promotes.

Existing CI (`db-migrations.yml`, `db-drift.yml`) only checks **fresh** databases — nothing verified the **live prod** DB. This PR adds that missing layer.

## Changes

1. **`migrations/…_reconcile_faked_baseline_drift.sql`** — idempotent `CREATE TABLE / ADD COLUMN IF NOT EXISTS` for the 2 tables + 22 columns. No-op on fresh/dev, backfill on prod (`deletion_scheduled_for` added NULLABLE since prod has live rows).
2. **`scripts/verify-live-schema.ts`** (+ unit test) — **presence gate**: every canonical table+column must exist on the live DB (`canonical ⊆ live`). Ignores object *names*, type/default rendering, and *extras*, so it's **noise-free on a legacy prod DB** while still catching the only drift class that breaks deployed code.
3. **`deploy-prod.yml`** — new `verify-schema` job runs the gate against prod **right after migrations**; `deploy-api` now depends on it, so **drift blocks the rollout**.
4. **`db-drift.yml`** — nightly `prod-presence` job (catches out-of-band drift between deploys).

## Verification

- Proven e2e: drifted DB → verifier **RED (24 missing)** → reconciliation migration → verifier **GREEN**.
- `@kortix/db` typecheck clean, **94 tests pass**, migration lint green, shadow-db build clean (all 4 migrations apply, no pending).
- The reconciliation SQL has **already been applied to prod live** (3.5s, metadata-only) — prod matches canonical *now*; this migration formalizes it through the pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)