### PR TITLE
fix(db): backfill executor channel provider enum

### DIFF
--- a/packages/db/migrations/20260622185000000_executor_channel_provider.sql
+++ b/packages/db/migrations/20260622185000000_executor_channel_provider.sql
@@ -1,0 +1,12 @@
+-- Up Migration
+--
+-- Prod was baselined with an executor_connector_provider enum that predated
+-- the native Slack channel connector. Fresh databases get `channel` from the
+-- baseline, but faked-baseline environments need this forward-only enum backfill
+-- before `syncProjectConnectors` can materialize provider_type='channel'.
+
+ALTER TYPE kortix.executor_connector_provider ADD VALUE IF NOT EXISTS 'channel';
+
+-- Down Migration
+-- PostgreSQL enum values are intentionally forward-only here. Removing `channel`
+-- would break the native Slack connector rows and any future channel providers.

--- a/packages/db/scripts/verify-live-schema.test.ts
+++ b/packages/db/scripts/verify-live-schema.test.ts
@@ -4,12 +4,19 @@ import { diffMissing, type SchemaObjects } from './verify-live-schema';
 const objs = (tables: string[], columns: string[]): SchemaObjects => ({
   tables: new Set(tables),
   columns: new Set(columns),
+  enumValues: new Set(),
+});
+
+const objsWithEnums = (tables: string[], columns: string[], enumValues: string[]): SchemaObjects => ({
+  tables: new Set(tables),
+  columns: new Set(columns),
+  enumValues: new Set(enumValues),
 });
 
 describe('diffMissing (presence: canonical ⊆ live)', () => {
   test('identical schemas → nothing missing', () => {
     const s = objs(['accounts', 'projects'], ['accounts.id', 'projects.id']);
-    expect(diffMissing(s, s)).toEqual({ missingTables: [], missingColumns: [] });
+    expect(diffMissing(s, s)).toEqual({ missingTables: [], missingColumns: [], missingEnumValues: [] });
   });
 
   test('a table the migrations define but the live DB lacks is reported', () => {
@@ -27,13 +34,32 @@ describe('diffMissing (presence: canonical ⊆ live)', () => {
     expect(diffMissing(canon, live)).toEqual({
       missingTables: [],
       missingColumns: ['credit_accounts.needs_reconciliation'],
+      missingEnumValues: [],
+    });
+  });
+
+  test('a missing enum value is reported', () => {
+    const canon = objsWithEnums(
+      ['executor_connectors'],
+      ['executor_connectors.provider_type'],
+      ['executor_connector_provider.pipedream', 'executor_connector_provider.channel'],
+    );
+    const live = objsWithEnums(
+      ['executor_connectors'],
+      ['executor_connectors.provider_type'],
+      ['executor_connector_provider.pipedream'],
+    );
+    expect(diffMissing(canon, live)).toEqual({
+      missingTables: [],
+      missingColumns: [],
+      missingEnumValues: ['executor_connector_provider.channel'],
     });
   });
 
   test('EXTRA tables/columns on live (legacy leftovers) are ignored', () => {
     const canon = objs(['accounts'], ['accounts.id']);
     const live = objs(['accounts', 'legacy_integrations'], ['accounts.id', 'accounts.extra_col', 'legacy_integrations.x']);
-    expect(diffMissing(canon, live)).toEqual({ missingTables: [], missingColumns: [] });
+    expect(diffMissing(canon, live)).toEqual({ missingTables: [], missingColumns: [], missingEnumValues: [] });
   });
 
   test('reports both missing tables and columns, each sorted', () => {

--- a/packages/db/scripts/verify-live-schema.ts
+++ b/packages/db/scripts/verify-live-schema.ts
@@ -2,30 +2,32 @@
 /**
  * Live-schema PRESENCE gate.
  *
- * Asserts that a live database contains every TABLE and COLUMN the committed
- * migrations define. It is the missing half of the migration safety net: the PR
- * gates (db-migrations.yml) prove the migrations REPRODUCE the schema on a fresh
- * DB, but nothing verified that a real environment ACTUALLY MATCHES them — which
- * is exactly how a faked baseline (see migrate.ts autoBaselineIfNeeded) let
- * `project_session_public_shares` go missing on prod until a user hit a 500.
+ * Asserts that a live database contains every TABLE, COLUMN, and ENUM VALUE the
+ * committed migrations define. It is the missing half of the migration safety
+ * net: the PR gates (db-migrations.yml) prove the migrations REPRODUCE the schema
+ * on a fresh DB, but nothing verified that a real environment ACTUALLY MATCHES
+ * them — which is exactly how a faked baseline (see migrate.ts
+ * autoBaselineIfNeeded) let `project_session_public_shares` go missing on prod
+ * until a user hit a 500.
  *
  *   CANONICAL_DB_URL=<freshly-migrated db>  LIVE_DB_URL=<target>  bun scripts/verify-live-schema.ts
  *   # or: bun scripts/verify-live-schema.ts --canonical <url> --live <url>
  *
  * Exit 0 = live is a superset of canonical (no missing objects).
- * Exit 1 = live is MISSING canonical tables/columns → drift; fail the deploy.
+ * Exit 1 = live is MISSING canonical tables/columns/enum values → drift; fail
+ * the deploy.
  *
  * Deliberately PRESENCE-ONLY (canonical ⊆ live): it ignores object NAMES
  * (constraints/indexes), type/default rendering, nullability, and EXTRA objects
  * on the live DB. A legacy production database carries cosmetic differences
  * (auto- vs explicitly-named constraints, `0` vs `0.00` defaults, leftover
  * legacy tables) by the hundreds; gating on full structural equality would be
- * all false positives. Missing tables/columns are unambiguous and are the class
- * of drift that actually breaks deployed code.
+ * all false positives. Missing tables/columns/enum values are unambiguous and
+ * are the class of drift that actually breaks deployed code.
  */
 import pg from 'pg';
 
-export type SchemaObjects = { tables: Set<string>; columns: Set<string> };
+export type SchemaObjects = { tables: Set<string>; columns: Set<string>; enumValues: Set<string> };
 
 const SCHEMA = 'kortix';
 
@@ -36,7 +38,13 @@ const OBJECTS_SQL = `
   UNION ALL
   SELECT 'C'::text, table_name, column_name
     FROM information_schema.columns
-   WHERE table_schema = $1
+    WHERE table_schema = $1
+  UNION ALL
+  SELECT 'E'::text, t.typname, e.enumlabel
+    FROM pg_type t
+    JOIN pg_enum e ON e.enumtypid = t.oid
+    JOIN pg_namespace n ON n.oid = t.typnamespace
+   WHERE n.nspname = $1
 `;
 
 export async function readSchemaObjects(databaseUrl: string): Promise<SchemaObjects> {
@@ -46,11 +54,13 @@ export async function readSchemaObjects(databaseUrl: string): Promise<SchemaObje
     const { rows } = await client.query<{ k: string; a: string; b: string }>(OBJECTS_SQL, [SCHEMA]);
     const tables = new Set<string>();
     const columns = new Set<string>();
+    const enumValues = new Set<string>();
     for (const r of rows) {
       if (r.k === 'T') tables.add(r.a);
-      else columns.add(`${r.a}.${r.b}`);
+      else if (r.k === 'C') columns.add(`${r.a}.${r.b}`);
+      else if (r.k === 'E') enumValues.add(`${r.a}.${r.b}`);
     }
-    return { tables, columns };
+    return { tables, columns, enumValues };
   } finally {
     await client.end();
   }
@@ -60,13 +70,15 @@ export async function readSchemaObjects(databaseUrl: string): Promise<SchemaObje
 export function diffMissing(canonical: SchemaObjects, live: SchemaObjects): {
   missingTables: string[];
   missingColumns: string[];
+  missingEnumValues: string[];
 } {
   const missingTables = [...canonical.tables].filter((t) => !live.tables.has(t)).sort();
   // A column on a table that is itself missing is reported via the table, not twice.
   const missingColumns = [...canonical.columns]
     .filter((c) => !live.columns.has(c) && live.tables.has(c.split('.')[0]))
     .sort();
-  return { missingTables, missingColumns };
+  const missingEnumValues = [...canonical.enumValues].filter((v) => !live.enumValues.has(v)).sort();
+  return { missingTables, missingColumns, missingEnumValues };
 }
 
 function resolveUrls(argv: string[]): { canonical: string; live: string } {
@@ -95,14 +107,16 @@ async function main() {
     readSchemaObjects(liveRo).catch(() => readSchemaObjects(live)),
   ]);
 
-  const { missingTables, missingColumns } = diffMissing(canon, target);
+  const { missingTables, missingColumns, missingEnumValues } = diffMissing(canon, target);
   console.log(
     `Canonical: ${canon.tables.size} tables / ${canon.columns.size} columns.  ` +
-      `Live: ${target.tables.size} tables / ${target.columns.size} columns.`,
+      `${canon.enumValues.size} enum values.  ` +
+      `Live: ${target.tables.size} tables / ${target.columns.size} columns / ` +
+      `${target.enumValues.size} enum values.`,
   );
 
-  if (missingTables.length === 0 && missingColumns.length === 0) {
-    console.log('OK — live database contains every table and column the migrations define.');
+  if (missingTables.length === 0 && missingColumns.length === 0 && missingEnumValues.length === 0) {
+    console.log('OK — live database contains every table, column, and enum value the migrations define.');
     return;
   }
 
@@ -115,7 +129,11 @@ async function main() {
     console.error(`\nMissing COLUMNS (${missingColumns.length}):`);
     for (const c of missingColumns) console.error(`  - ${SCHEMA}.${c}`);
   }
-  console.error('\nReconcile by adding an idempotent migration (CREATE TABLE / ADD COLUMN IF NOT EXISTS).');
+  if (missingEnumValues.length) {
+    console.error(`\nMissing ENUM VALUES (${missingEnumValues.length}):`);
+    for (const v of missingEnumValues) console.error(`  - ${SCHEMA}.${v}`);
+  }
+  console.error('\nReconcile by adding an idempotent migration (CREATE TABLE / ADD COLUMN / ALTER TYPE ADD VALUE IF NOT EXISTS).');
   process.exit(1);
 }
 


### PR DESCRIPTION
## Summary
- add a forward-only migration to backfill executor_connector_provider = channel on faked-baseline prod DBs
- extend the live-schema drift gate to compare enum values, not just tables/columns
- add regression coverage for missing enum values

## Verification
- pnpm --filter @kortix/db migrate:lint
- bun test packages/db/scripts/verify-live-schema.test.ts
- env DATABASE_URL=postgres://postgres:postgres@127.0.0.1:54322/postgres SUPABASE_URL=http://127.0.0.1:54321 SUPABASE_SERVICE_ROLE_KEY=test-service-role API_KEY_SECRET=test-api-key-secret INTERNAL_KORTIX_ENV=dev FREESTYLE_API_URL=https://api.freestyle.sh FRONTEND_URL=http://localhost:3000 ALLOWED_SANDBOX_PROVIDERS=daytona DAYTONA_API_KEY=test DAYTONA_SERVER_URL=https://example.com DAYTONA_TARGET=us bun test src/__tests__/e2e-slack-cli.test.ts src/__tests__/unit-channel-consolidation.test.ts src/__tests__/unit-executor-channels.test.ts
- pnpm --filter @kortix/db typecheck
- pnpm --filter kortix-api typecheck

## Production symptom
Live connector sync currently fails inserting the native Slack channel connector because prod lacks enum value channel; this blocks slack thread/history/search with connector_not_found.
