### PR TITLE
fix(slack): notify a dead thread's session error once (with a link), not on every message

### DIFF
--- a/apps/api/src/__tests__/unit-slack-dispatch-session.test.ts
+++ b/apps/api/src/__tests__/unit-slack-dispatch-session.test.ts
@@ -156,12 +156,31 @@ describe('spawnAgentTurn — permanent 1:1 thread↔session, never a second sess
     expect(finalizeCalls.at(-1)?.error).toContain('waking');
   });
 
-  test('failed (genuine error) → surface it, keep mapping, NEVER recreate', async () => {
+  test('failed (genuine error) → surface it ONCE with a session link, keep mapping, NEVER recreate', async () => {
     deliverOutcome = 'failed';
-    dbResults = [[{ sessionId: 'sess-1' }]];
+    dbResults = [
+      [{ sessionId: 'sess-1' }], // chat_threads lookup (known thread)
+      [{ eventId: 'notice' }], // claimThreadErrorNotice → WON (first failure for this thread)
+    ];
     await spawnAgentTurn('proj-1', envelope, event);
     expect(createSessionCalls).toBe(0);
     expect(finalizeCalls.at(-1)?.error).toContain('error');
+    // The notice links straight to the session so the thread isn't a dead end.
+    expect(finalizeCalls.at(-1)?.error).toContain('proj-1/sessions/sess-1');
+    expect(finalizeCalls.at(-1)?.error).toContain('Open it in Kortix');
+  });
+
+  test('failed AGAIN → notice already claimed → stay silent (no repeat, the thread isn’t spammed)', async () => {
+    deliverOutcome = 'failed';
+    dbResults = [
+      [{ sessionId: 'sess-1' }], // chat_threads lookup (known thread)
+      [], // claimThreadErrorNotice → LOST (we already told this thread once)
+    ];
+    await spawnAgentTurn('proj-1', envelope, event);
+    expect(createSessionCalls).toBe(0);
+    // We still finalize (to clear the ⏳ ack) but with NO error — silence, not a repeat.
+    expect(finalizeCalls.length).toBe(1);
+    expect(finalizeCalls.at(-1)?.error).toBeUndefined();
   });
 
   test('no-session (session deleted) → replace it (the ONLY create path for a known thread)', async () => {
@@ -169,6 +188,7 @@ describe('spawnAgentTurn — permanent 1:1 thread↔session, never a second sess
     dbResults = [
       [{ sessionId: 'sess-1' }], // chat_threads lookup (known thread)
       [], // delete the stale chat_threads mapping
+      [], // clearThreadErrorNotice → re-arm the failure notice for the new session
       [{ projectId: 'proj-1', accountId: 'acc-1', defaultBranch: 'main', repoUrl: 'r', name: 'P', manifestPath: 'kortix.toml' }], // projects lookup
       [{ eventId: 'claim' }], // claimThreadCreate → WON
       [], // re-check chat_threads → none

--- a/apps/api/src/channels/slack/dedup.ts
+++ b/apps/api/src/channels/slack/dedup.ts
@@ -1,3 +1,4 @@
+import { eq } from 'drizzle-orm';
 import { chatEventDedup } from '@kortix/db';
 import { db } from '../../shared/db';
 import { EVENT_DEDUPE_TTL_MS } from './app';
@@ -59,5 +60,58 @@ export async function claimInboundMessage(key: string): Promise<boolean> {
   } catch (err) {
     console.error('[slack-webhook] inbound message claim failed (fail-open)', err);
     return true;
+  }
+}
+
+// ── One-shot "this thread's session terminally failed" notice ────────────────
+// A thread whose session hit a terminal fault KEEPS its mapping — we never
+// silently recreate, because a fresh session wouldn't fix a real fault. But that
+// means every later message in the thread re-runs the turn, re-hits the same
+// `failed` outcome, and would re-post the identical "session hit an error" line —
+// the thread stuck on repeat forever (exactly the "ok bro is going to say it
+// every time now" report). So we tell the user ONCE: the first failed delivery
+// claims this key and posts the notice (with a link to open the session); every
+// later one finds the claim already held and stays silent. Unlike the 5-minute
+// inbound-message gate, the claim is long-lived so the quiet sticks — but it is
+// NOT permanent: a month on, a lone message earns one fresh reminder. Reuses the
+// same single-winner dedup table as `claimThreadCreate`, so no migration.
+//
+// Fail-CLOSED (suppress) on a DB hiccup — the entire purpose here is to NOT spam,
+// so when the claim can't be resolved, stay quiet rather than risk re-posting.
+const ERROR_NOTICE_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+
+function threadErrorNoticeKey(teamId: string, threadId: string): string {
+  return `slack:threaderror:${teamId}:${threadId}`;
+}
+
+export async function claimThreadErrorNotice(teamId: string, threadId: string): Promise<boolean> {
+  if (!teamId || !threadId) return false;
+  try {
+    const inserted = await db
+      .insert(chatEventDedup)
+      .values({
+        eventId: threadErrorNoticeKey(teamId, threadId),
+        expiresAt: new Date(Date.now() + ERROR_NOTICE_TTL_MS),
+      })
+      .onConflictDoNothing({ target: chatEventDedup.eventId })
+      .returning({ eventId: chatEventDedup.eventId });
+    return inserted.length > 0;
+  } catch (err) {
+    console.warn('[slack-webhook] thread error-notice claim failed (suppressing notice)', err);
+    return false;
+  }
+}
+
+// Re-arm the notice when this thread is revived onto a genuinely NEW session (the
+// `no-session` replace path), so that session's OWN first failure is surfaced
+// instead of being swallowed by the prior session's still-held claim. Best-effort.
+export async function clearThreadErrorNotice(teamId: string, threadId: string): Promise<void> {
+  if (!teamId || !threadId) return;
+  try {
+    await db
+      .delete(chatEventDedup)
+      .where(eq(chatEventDedup.eventId, threadErrorNoticeKey(teamId, threadId)));
+  } catch (err) {
+    console.warn('[slack-webhook] thread error-notice clear failed', err);
   }
 }

--- a/apps/api/src/channels/slack/dispatch.ts
+++ b/apps/api/src/channels/slack/dispatch.ts
@@ -31,8 +31,14 @@ import {
   saveTurn,
   startTurn,
 } from './turn';
-import { claimInboundMessage, inboundMessageKey } from './dedup';
-import { stripMentions } from './util';
+import {
+  claimInboundMessage,
+  claimThreadErrorNotice,
+  clearThreadErrorNotice,
+  inboundMessageKey,
+} from './dedup';
+import { sessionWebUrl, stripMentions } from './util';
+import { config } from '../../config';
 import type {
   EventClass,
   ProjectResolution,
@@ -527,11 +533,23 @@ export async function spawnAgentTurn(
         // the one honest failure — surface it; KEEP the mapping and never recreate
         // (a new session wouldn't fix a real fault, and silently recreating is what
         // we're eliminating). The thread stays bound to its session.
+        //
+        // But surface it ONCE. Because we keep the mapping, every later message in
+        // the thread lands right back here (`session.status === 'failed'` is sticky)
+        // and, unguarded, re-posts the identical line — the thread jammed on repeat.
+        // The first failure claims a durable per-thread notice and posts it with a
+        // direct link to open the session in Kortix; every later one just clears its
+        // ⏳ ack and stays silent, so the thread isn't spammed forever.
         if (handle) {
           await deleteTurn(existing.sessionId);
-          await finalizeTurn(handle, {
-            error: "This thread's session hit an error and couldn't start. Open it in Kortix to see what happened.",
-          });
+          if (await claimThreadErrorNotice(teamId, threadId)) {
+            const url = sessionWebUrl(config.FRONTEND_URL, projectId, existing.sessionId);
+            await finalizeTurn(handle, {
+              error: `This thread's session hit an error and couldn't start. <${url}|Open it in Kortix> to see what happened.`,
+            });
+          } else {
+            await finalizeTurn(handle, {});
+          }
         }
         return;
       }
@@ -558,6 +576,9 @@ export async function spawnAgentTurn(
             eq(chatThreads.threadId, threadId),
           ),
         );
+      // Reviving onto a brand-new session — re-arm the failure notice so that
+      // session's own first fault is reported, not swallowed by the dead one's claim.
+      await clearThreadErrorNotice(teamId, threadId);
     }
   }
 


### PR DESCRIPTION
## What

A Slack thread whose session is in a terminal `failed` state keeps its thread→session mapping (we deliberately never silently recreate — a fresh session won't fix a real fault). But `continueSession` returns `failed` on **every** delivery (`session.status === 'failed'` is sticky), so each follow-up message re-hit the same branch and re-posted the identical:

> This thread's session hit an error and couldn't start. Open it in Kortix to see what happened.

…jamming the thread on repeat forever. (Reported in #new-kortix: *"ok bro is going to say it every time now"*.)

## Fix

- **Notify once.** The first failure claims a durable per-thread notice and posts the message; every later message just clears its ⏳ ack and stays **silent**.
- **Include the session link.** The one notice now links straight to the session: `…<…/projects/…/sessions/…|Open it in Kortix>…` so the thread isn't a dead end.
- **No migration.** The claim reuses the existing single-winner `chat_event_dedup` table (same pattern as `claimThreadCreate`/`claimInboundMessage`) — multi-replica safe, 30-day TTL (a month later a lone message earns one fresh reminder, not eternal silence).
- **Re-armed on revive.** The `no-session` replace path clears the notice so a brand-new session's own first failure is still reported.
- **Fail-closed** on a DB hiccup — the whole point is to *not* spam.

## Files

- `apps/api/src/channels/slack/dedup.ts` — `claimThreadErrorNotice` / `clearThreadErrorNotice`
- `apps/api/src/channels/slack/dispatch.ts` — `failed` branch notifies once + links; `no-session` re-arms
- `apps/api/src/__tests__/unit-slack-dispatch-session.test.ts` — updated + new `failed AGAIN → silent` regression test

## Verification

- `unit-slack-dispatch-session.test.ts`: **11/11** (every slack test file green in isolation)
- `tsc --noEmit`: clean
- Full default suite neutral vs. baseline (757/196 both ways — the 196 are pre-existing cross-file `mock.module` leakage in the naive all-files run, every file passes alone)

🤖 Generated with [Claude Code](https://claude.com/claude-code)