### PR TITLE
fix(platinum): clamp build size_mb to from-build hard max (20480)

### DIFF
--- a/apps/api/src/snapshots/providers/platinum.ts
+++ b/apps/api/src/snapshots/providers/platinum.ts
@@ -92,10 +92,13 @@ class PlatinumAdapter implements SandboxProviderAdapter {
           name: input.snapshotName,
           context_s3_key,
           dockerfile: ctx.dockerfileName,
-          // Build-time ext4 ceiling must track the same disk spec we send as
-          // the runtime default. Platinum grows ext4 to fit, so the artifact
-          // still consumes only image+headroom rather than the whole ceiling.
-          size_mb: diskGb * MB_PER_GB,
+          // Build-time ext4 ceiling tracks the disk spec, but clamp to Platinum's
+          // from-build hard max (20480 MB, api/templates.ts size_mb schema): a
+          // template with disk_gb>20 (e.g. 40) would otherwise 400 with
+          // "size_mb max 20480". Platinum grows ext4 to fit, so the artifact still
+          // consumes only image+headroom; the runtime disk (default_disk_gb) is
+          // grown to the full disk_gb at boot regardless of this build ceiling.
+          size_mb: Math.min(diskGb * MB_PER_GB, 20480),
           default_cpu: input.spec.cpu ?? DEFAULT_CPU,
           default_ram_mb: (input.spec.memoryGb ?? DEFAULT_MEMORY_GB) * 1024,
           default_disk_gb: diskGb,


### PR DESCRIPTION
## Summary

#3676 changed the Platinum build to send `size_mb = diskGb * MB_PER_GB` **uncapped**. But Platinum's `POST /v1/templates/from-build` schema caps `size_mb` at **20480 MB (20 GiB)**, so a template with **disk_gb > 20** (e.g. `suna-dev` = 40) sends `40960` → **400 `size_mb max 20480`**.

Clamp to `Math.min(diskGb * MB_PER_GB, 20480)`. The Platinum ext4 grows-to-fit, so 20 GiB is just a ceiling (suna-dev's ~6.5 GiB image needs ~9.4 GiB); the **runtime** disk is still grown to the full `disk_gb` at boot via `default_disk_gb`.

Paired with the prod-side change: `PT_ORG_MAX_TEMPLATE_MB` raised 8192 → 20480 (the per-org cap was below the schema max).

## Type of change
- [x] Bug fix

## How was this tested?
- Confirmed Platinum from-build schema: `size_mb: z.number().int().min(128).max(20480)`.
- Confirmed prod per-org cap raised to 20480 and loaded in the CP process.
- One-line clamp; build artifact unchanged (grows-to-fit), runtime disk unchanged (`default_disk_gb`).

## Security & data review
- [x] No secrets / endpoints / schema change

## Rollout / rollback
No env/migration. Revert = drop the `Math.min`.
