### PR TITLE
fix(gateway): keep streaming connections alive (heartbeat + idle timeouts)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1121,6 +1121,13 @@ export default {
       server.timeout(req, 0);
     }
 
+    // The standalone-gateway reverse proxy streams chat completions (SSE). Let
+    // the gateway's own keep-alive / upstream timeout govern it instead of Bun
+    // closing the client socket at idleTimeout with an empty reply.
+    if (url.pathname.startsWith('/v1/llm-gateway')) {
+      server.timeout(req, 0);
+    }
+
     // ── Subdomain preview routing ──────────────────────────────────────
     // Matches `p{port}-{sandboxId}.localhost:{apiPort}` regardless of path.
     // Same per-request long-poll/SSE timeout posture as /v1/p/.

--- a/apps/api/src/middleware/request-deadline.ts
+++ b/apps/api/src/middleware/request-deadline.ts
@@ -57,6 +57,7 @@ const EXEMPT_PREFIXES = [
   '/v1/git',      // git smart-HTTP (large packfile up/download)
   '/v1/router',   // LLM gateway — streamed chat completions
   '/v1/llm',      // LLM chat completions (streamed; p99 >10s is normal)
+  '/v1/llm-gateway', // reverse proxy to the standalone gateway (streamed SSE)
   '/v1/executor', // connector proxy — forwards to arbitrary upstream APIs
   '/v1/webhooks', // inbound webhooks (Slack, …) — callers retry, don't truncate
   '/v1/billing/webhooks',   // Stripe webhook processing (observed >60s, legit)

--- a/apps/llm-gateway/src/main.ts
+++ b/apps/llm-gateway/src/main.ts
@@ -5,6 +5,12 @@ const { app, traces } = buildServer();
 
 const server = Bun.serve({
   port: config.port,
+  // Bun's default idleTimeout is 10s: a streaming chat completion that pauses
+  // longer than that between tokens (reasoning models, slow first token) gets
+  // its socket killed mid-stream with an empty reply — which opencode reports as
+  // "Connection reset by server". relayStream emits a keep-alive every 10s so it
+  // never actually idles; this is the backstop ceiling (255 = Bun's max).
+  idleTimeout: 255,
   fetch: app.fetch,
 });
 

--- a/packages/llm-gateway/src/pipeline/streaming.test.ts
+++ b/packages/llm-gateway/src/pipeline/streaming.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from 'bun:test';
+import { relayStream } from './streaming';
+
+const enc = new TextEncoder();
+const dec = new TextDecoder();
+
+function controllableUpstream() {
+  let controller!: ReadableStreamDefaultController<Uint8Array>;
+  const stream = new ReadableStream<Uint8Array>({ start(c) { controller = c; } });
+  return {
+    stream,
+    push: (s: string) => controller.enqueue(enc.encode(s)),
+    close: () => controller.close(),
+  };
+}
+
+async function drain(rs: ReadableStream<Uint8Array>): Promise<string> {
+  const reader = rs.getReader();
+  let out = '';
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (value) out += dec.decode(value, { stream: true });
+  }
+  return out;
+}
+
+const delay = (ms: number) => new Promise((r) => setTimeout(r, ms));
+const noop = { warn: () => {} };
+
+describe('relayStream', () => {
+  test('forwards upstream chunks verbatim and settles usage', async () => {
+    const up = controllableUpstream();
+    const out = relayStream({
+      upstreamBody: up.stream,
+      captureBodies: false,
+      requestId: 'r1',
+      logger: noop,
+      settle: async () => {},
+      heartbeatMs: 10_000,
+    });
+    up.push('data: {"choices":[{"delta":{"content":"hi"}}]}\n\n');
+    up.push('data: [DONE]\n\n');
+    up.close();
+    const text = await drain(out);
+    expect(text).toBe('data: {"choices":[{"delta":{"content":"hi"}}]}\n\ndata: [DONE]\n\n');
+    expect(text).not.toContain('keep-alive');
+  });
+
+  test('emits a keep-alive when upstream goes silent past the interval', async () => {
+    const up = controllableUpstream();
+    const out = relayStream({
+      upstreamBody: up.stream,
+      captureBodies: false,
+      requestId: 'r2',
+      logger: noop,
+      settle: async () => {},
+      heartbeatMs: 20,
+    });
+    const collected = drain(out);
+    up.push('data: a\n\n');
+    await delay(70); // > heartbeatMs with no upstream data → keep-alive(s)
+    up.push('data: b\n\n');
+    up.close();
+    const text = await collected;
+    expect(text).toContain(': keep-alive\n\n');
+    // data frames survive intact and in order around the heartbeat(s)
+    expect(text.indexOf('data: a')).toBeLessThan(text.indexOf('data: b'));
+  });
+
+  test('never splits a partial event — no heartbeat injected mid-frame', async () => {
+    const up = controllableUpstream();
+    const out = relayStream({
+      upstreamBody: up.stream,
+      captureBodies: false,
+      requestId: 'r3',
+      logger: noop,
+      settle: async () => {},
+      heartbeatMs: 20,
+    });
+    const collected = drain(out);
+    up.push('data: par'); // partial event — buffer does NOT end in \n\n
+    await delay(70); // heartbeat fires internally, but must be suppressed here
+    up.push('tial\n\n');
+    up.close();
+    const text = await collected;
+    expect(text).toContain('data: partial\n\n');
+    // the partial frame is contiguous: nothing inserted between "par" and "tial"
+    expect(text).not.toMatch(/par[^]*keep-alive[^]*tial/);
+  });
+});

--- a/packages/llm-gateway/src/pipeline/streaming.ts
+++ b/packages/llm-gateway/src/pipeline/streaming.ts
@@ -6,10 +6,22 @@ export interface StreamRelayOptions {
   requestId: string;
   logger: { warn: (...args: unknown[]) => void };
   settle: (usage: ExtractedUsage | null, response: unknown) => Promise<void>;
+  /** Keep-alive interval in ms (overridable for tests). */
+  heartbeatMs?: number;
 }
+
+// How long upstream may go silent before we emit a keep-alive. A reasoning model
+// (or a slow first token) can pause longer than the socket idle timeouts on the
+// gateway, the API reverse proxy, AND opencode — any of which would otherwise
+// drop the connection and surface to opencode as "Connection reset by server".
+const HEARTBEAT_MS = 10_000;
+// SSE comment line — ignored by every SSE/OpenAI client, so it's invisible
+// payload that just resets each hop's idle timer.
+const HEARTBEAT_FRAME = new TextEncoder().encode(': keep-alive\n\n');
 
 export function relayStream(opts: StreamRelayOptions): ReadableStream<Uint8Array> {
   const { upstreamBody, captureBodies, requestId, logger, settle } = opts;
+  const heartbeatMs = opts.heartbeatMs ?? HEARTBEAT_MS;
   const transform = new TransformStream<Uint8Array, Uint8Array>();
   const writer = transform.writable.getWriter();
   const decoder = new TextDecoder();
@@ -18,10 +30,35 @@ export function relayStream(opts: StreamRelayOptions): ReadableStream<Uint8Array
   void (async () => {
     const reader = upstreamBody.getReader();
     let downstreamAlive = true;
+    // Keep exactly one read in flight; race it against a heartbeat timer so a
+    // long token gap emits a keep-alive without ever issuing a second read.
+    let pending = reader.read();
     try {
       while (true) {
-        const { done, value } = await reader.read();
+        let timer: ReturnType<typeof setTimeout> | undefined;
+        const beat = new Promise<'beat'>((resolve) => {
+          timer = setTimeout(() => resolve('beat'), heartbeatMs);
+        });
+        const next = await Promise.race([pending.then((r) => ({ read: r })), beat]);
+        if (timer) clearTimeout(timer);
+
+        if (next === 'beat') {
+          // Upstream silent for HEARTBEAT_MS. Inject the comment only at an SSE
+          // event boundary (buffer empty, or ends with the \n\n terminator) so we
+          // never split a partial event mid-flight. `pending` stays in flight.
+          if (downstreamAlive && (sseBuffer === '' || sseBuffer.endsWith('\n\n'))) {
+            try {
+              await writer.write(HEARTBEAT_FRAME);
+            } catch {
+              downstreamAlive = false;
+            }
+          }
+          continue;
+        }
+
+        const { done, value } = next.read;
         if (done) break;
+        pending = reader.read();
         if (!value) continue;
         sseBuffer += decoder.decode(value, { stream: true });
         if (downstreamAlive) {


### PR DESCRIPTION
## "Connection reset by server" → opencode retries the same model forever

The agent's stream kept getting dropped mid-flight and opencode just re-requested the **same** model on a loop ("Retrying in 2s (#2)", "Waiting to retry · 49s").

### Root cause
Nothing kept the SSE connection alive during slow-token gaps, and **every hop has a short socket idle timeout**:
- The **standalone gateway** set *no* `idleTimeout` → Bun's 10s default. A reasoning model (or a slow first token) that pauses >10s gets its socket killed mid-stream with an empty reply.
- The **API reverse proxy** `/v1/llm-gateway/*` was bounded by the 25s request deadline and the 30s `idleTimeout` — it never called `server.timeout(req,0)` like the other streaming routes.

Either kill returns a **truncated HTTP 200**, so the existing connection-time failover (bedrock→openrouter) has nothing to act on, and opencode sees a reset.

### Fix — keep the stream alive end-to-end
1. **Heartbeat** (`relayStream`, gateway-core): when upstream goes silent >10s, emit a `: keep-alive` SSE comment. Invisible to every SSE/OpenAI client but resets each hop's idle timer (gateway → API proxy → opencode). **Boundary-safe** — only injected at an SSE event boundary (buffer empty or ends in `\n\n`), so it can never split a partial frame. Single in-flight read raced against the heartbeat timer (no double-read).
2. **Standalone gateway** `Bun.serve({ idleTimeout: 255 })` — backstop ceiling (Bun's max) for the window before the relay starts.
3. **API proxy** `/v1/llm-gateway/*` — added to the request-deadline `EXEMPT_PREFIXES` and calls `server.timeout(req, 0)`, matching the existing `/v1/p/` streaming posture.

### Tests
`streaming.test.ts`: forwards chunks verbatim with no heartbeat under load; emits a keep-alive on an idle gap; never splits a partial event across a heartbeat. 60 gateway-core tests green; API + gateway typecheck clean.

---
**Note on "auto-default to another model":** connection-time failover across routes (bedrock→openrouter) already exists; this PR removes the *resets* that caused the stuck-retry loop. True **mid-stream** failover (switch after tokens are already sent) or **cross-model** fallback (e.g. Opus→Sonnet when a model is down) is a separate design choice — happy to do it next if you want it.
