### PR TITLE
fix(ci): dev gateway deploy via GitOps PR (+ bump gateway 0.2.0 to redeploy)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -509,7 +509,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write # OIDC → read the dev cluster
-      contents: write # push the values bump to main
+      contents: write # push the values-bump branch
+      pull-requests: write # open/merge the GitOps bump PR into protected main
     env:
       AWS_REGION: us-west-2
       CLUSTER: kortix-dev-eks
@@ -517,6 +518,7 @@ jobs:
       APP: kortix-gateway
       VALUES: infra/k8s/envs/dev/gateway-values.yaml
       ROLE: arn:aws:iam::935064898258:role/kortix-gha-eks-deploy-dev
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -524,24 +526,55 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Bump dev gateway image tag + commit
+      # main is protected ("changes through PR"), so a direct `git push origin
+      # main` is silently rejected — which left gateway-values pinned at a stale
+      # tag while the watch span 40× on the old healthy pods. Bump through a PR
+      # exactly like the API job, then verify origin/main actually carries the
+      # new tag before watching (so a failed bump fails the job, loudly).
+      - name: Bump dev gateway image tag through GitOps PR
         id: bump
         run: |
           set -euo pipefail
           TAG="dev-${GITHUB_SHA::8}"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+          verify_remote_tag() {
+            git fetch origin main --quiet
+            remote_tag="$(git show origin/main:"$VALUES" | yq '.image.tag')"
+            if [ "$remote_tag" != "$TAG" ]; then
+              echo "::error::GitOps source is still at '$remote_tag', expected '$TAG'. Refusing to watch old healthy pods."
+              return 1
+            fi
+            echo "GitOps source verified: origin/main:$VALUES image.tag=$TAG"
+          }
+
           if [ "$(yq '.image.tag' "$VALUES")" = "$TAG" ]; then
             echo "values already at $TAG — no commit needed."
+            verify_remote_tag
           else
+            BR="chore/dev-eks-deploy-gateway-${TAG}"
             TAG="$TAG" yq -i '.image.tag = strenv(TAG)' "$VALUES"
             git config user.name  "kortix-ci[bot]"
             git config user.email "kortix-ci[bot]@users.noreply.github.com"
+            git checkout -B "$BR"
             git add "$VALUES"
             git commit -m "chore(dev-eks): deploy gateway ${TAG} [skip ci]"
-            for attempt in 1 2 3; do
-              git pull --rebase --autostash origin main && git push origin main && break
-              echo "push attempt ${attempt} lost a race — retrying"; sleep 3
-            done
+            git push -f origin "HEAD:$BR"
+
+            body="GitOps bump for the gateway image built by ${GITHUB_RUN_ID}: ${TAG}."
+            gh pr create --base main --head "$BR" \
+              --title "chore(dev-eks): deploy gateway ${TAG} [skip ci]" \
+              --body "$body" || true
+            PR="$(gh pr view "$BR" --json number --jq '.number')"
+
+            gh pr merge "$PR" --squash --delete-branch \
+              --subject "chore(dev-eks): deploy gateway ${TAG} [skip ci]" \
+              --body "" \
+              || gh pr merge "$PR" --squash --delete-branch --admin \
+                --subject "chore(dev-eks): deploy gateway ${TAG} [skip ci]" \
+                --body ""
+
+            verify_remote_tag
           fi
 
       - name: Configure AWS credentials (OIDC)


### PR DESCRIPTION
## The dev gateway never rolls out the latest build

The gateway rollout watch spins 40× on the **old** image (`available=1/1` on a stale tag like `dev-e68eb79a`) and never picks up the latest build (`dev-71a27bae`).

### Root cause
The dev **gateway** deploy bumps its image tag with a bare `git push origin main`:
```
git pull --rebase --autostash origin main && git push origin main && break
```
But `main` is protected ("changes through PR"), so the push is **silently rejected** — and the retry loop never exits non-zero, so the step "succeeds." `gateway-values.yaml` is never updated, ArgoCD faithfully keeps the old image, and the watch (which has no source-of-truth verification) polls the old healthy pods 40× and just warns.

Both the **API-dev** bump and the **prod-gateway** bump already avoid this — they bump through a PR. The dev gateway job was the lone exception.

### Fix
Switch the dev gateway bump to the same PR-based GitOps flow:
1. Commit the `image.tag` bump on a `chore/dev-eks-deploy-gateway-<tag>` branch (namespaced so it can't collide with the API bump's branch).
2. `gh pr create` + `gh pr merge --squash` (with `--admin` fallback) into protected main.
3. **`verify_remote_tag`** then asserts `origin/main:gateway-values.yaml` actually carries the new tag *before* the watch — so a failed bump **fails the job loudly** instead of polling stale pods for 10 minutes.

Adds `pull-requests: write` + `GH_TOKEN` to the job. No app code — workflow only.

After merge, the next push that touches `apps/llm-gateway/**` or `packages/llm-gateway/**` will bump-via-PR and roll correctly. (To ship the already-merged #3697 gateway build now, re-run the deploy or push a trivial gateway change.)

---
**This PR also bumps `apps/llm-gateway/package.json` to 0.2.0**, which trips the `apps/llm-gateway/**` deploy filter. So merging it does two things in one shot: lands the workflow fix, and triggers a gateway rebuild that the *fixed* flow deploys — exercising the fix end-to-end (and shipping #3697's keep-alive + catalog to dev).
