### PR TITLE
feat(gateway): report version + commit on /health/live

### DIFF
--- a/apps/llm-gateway/src/server.ts
+++ b/apps/llm-gateway/src/server.ts
@@ -88,7 +88,9 @@ export function buildServer(): GatewayServer {
 
   // Shallow liveness: the process is up. The k8s livenessProbe should point here
   // so a dependency outage (which a restart can't fix) doesn't crash-loop the pod.
-  app.get('/health/live', (c) => c.json({ ok: true }));
+  // Includes version/commit so a rollout can be confirmed with one cheap probe
+  // (no deep dependency checks) — `curl /health/live` shows which build is live.
+  app.get('/health/live', (c) => c.json({ ok: true, version: SERVICE_VERSION, commit: SERVICE_COMMIT }));
 
   // Deep health/readiness, built for an external monitor: an overall status, the
   // specific incidents, dependency checks, and a rolling error rate. Returns HTTP


### PR DESCRIPTION
Surfaces `version` + `commit` on the lightweight `/health/live` probe (the deep `/health` already has them, but it runs dependency checks). So a rollout is confirmable with one cheap `curl https://gateway-dev.kortix.com/health/live` → `{"ok":true,"version":"…","commit":"…"}` — exactly what you want when verifying which build is live.

Also serves as the gateway-touching change that trips the `apps/llm-gateway/**` deploy filter, so merging it rebuilds the gateway and ships the keep-alive + catalog build (#3697) to dev through the **now-fixed GitOps-PR deploy flow** (#3699) — the previous attempt's gateway trigger got dropped in the merge, so the gateway is still on the stale image.

Typecheck clean.