### PR TITLE
fix(ci): reconcile the gateway ArgoCD Application from the repo on every deploy

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -597,6 +597,23 @@ jobs:
         if: steps.guard.outputs.exists == 'true'
         run: aws eks update-kubeconfig --name "$CLUSTER" --region "$AWS_REGION"
 
+      # Code is the first-class copy: keep the live Argo CD Application in lockstep
+      # with the committed manifest. On dev-eks these Applications are NOT owned by
+      # an app-of-apps, so a stale field — e.g. targetRevision left on the retired
+      # `gateway` branch — silently freezes the gateway on an old image while Argo
+      # reports Synced/Healthy against the dead branch. Re-applying the manifest
+      # every deploy means the cluster always derives from the repo. Best-effort:
+      # if the deploy role lacks argocd-namespace RBAC it warns (then grant it),
+      # but it never blocks the rollout watch below.
+      - name: Reconcile Argo CD Application from repo (code is source of truth)
+        if: steps.guard.outputs.exists == 'true'
+        continue-on-error: true
+        run: |
+          kubectl apply -f infra/k8s/argocd/applications/gateway-dev.yaml \
+            || echo "::warning::could not apply gateway-dev Application (argocd RBAC for the deploy role?) — live app may be drifted from the repo"
+          kubectl -n argocd annotate application kortix-gateway-dev \
+            argocd.argoproj.io/refresh=hard --overwrite 2>/dev/null || true
+
       # Soft wait: the gateway Ingress chart fails to render until gateway-values
       # carries the ACM cert ARN, so the FIRST deploy (pre-cert) can't roll out.
       # Tolerate it — the tag bump is committed regardless, and once the cert ARN

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -839,6 +839,21 @@ jobs:
         if: steps.guard.outputs.exists == 'true'
         run: aws eks update-kubeconfig --name "$CLUSTER" --region "$AWS_REGION"
 
+      # Code is the first-class copy: re-apply the committed Argo CD Application so
+      # the live app always tracks what the repo says (path / targetRevision /
+      # values). Without this, a hand-applied app that drifted (e.g. left tracking
+      # an old branch) silently freezes the gateway on a stale image while Argo
+      # reports Synced/Healthy — exactly the "not yet tracking the prod values"
+      # case the watch warns about below. Best-effort on RBAC; never blocks.
+      - name: Reconcile Argo CD Application from repo (code is source of truth)
+        if: steps.guard.outputs.exists == 'true'
+        continue-on-error: true
+        run: |
+          kubectl apply -f infra/k8s/argocd/applications/gateway-prod.yaml \
+            || echo "::warning::could not apply gateway-prod Application (argocd RBAC for the deploy role?) — live app may be drifted from the repo"
+          kubectl -n argocd annotate application kortix-gateway-prod \
+            argocd.argoproj.io/refresh=hard --overwrite 2>/dev/null || true
+
       - name: Wait for gateway Deployment rolled out @ v${{ needs.version.outputs.version }}
         if: steps.guard.outputs.exists == 'true'
         env:


### PR DESCRIPTION
## Why the gateway never rolled, even after the bump landed

Diagnosed live on dev-eks: the `kortix-gateway-dev` Application was `Synced`/`Healthy` — but to `targetRevision: gateway`, the **retired branch** (frozen at the bootstrap `e68eb79a`). The committed manifest says `main`. So ArgoCD was perfectly synced to a dead branch and never saw any of the `main` bumps CI makes. On dev-eks these Applications aren't owned by an app-of-apps (`kortix-apps` runs on central, tracking `prod`), so the hand-applied dev apps drifted and nothing pulled them back.

## Fix — code is the first-class copy
Each gateway deploy now re-applies the committed Application manifest and hard-refreshes ArgoCD:
```
kubectl apply -f infra/k8s/argocd/applications/gateway-{dev,prod}.yaml
kubectl -n argocd annotate application kortix-gateway-{dev,prod} argocd.argoproj.io/refresh=hard --overwrite
```
so the live app always tracks exactly what the repo says (path / targetRevision / values). Best-effort on argocd-namespace RBAC (warns, never blocks the rollout watch). Applied to both dev and prod — the prod watch already warned about "kortix-gateway-prod not yet tracking the prod values," the same class of drift.

Paired with the live cluster being re-applied from the committed manifest to fix the current drift.