### PR TITLE
feat(gateway): Bedrock-only catalog via a new Converse transport (fixes Kimi/OpenRouter)

### DIFF
--- a/apps/api/src/llm-gateway/resolution/descriptors.ts
+++ b/apps/api/src/llm-gateway/resolution/descriptors.ts
@@ -23,11 +23,27 @@ export function livePricing(modelId: string): UpstreamDescriptor['pricing'] | un
   };
 }
 
+function openRouterManagedDescriptor(managed: ManagedModel): UpstreamDescriptor | null {
+  if (!config.OPENROUTER_API_KEY) return null;
+  return {
+    provider: 'openrouter',
+    kind: 'openai-compat',
+    baseUrl: config.OPENROUTER_API_URL,
+    apiKey: config.OPENROUTER_API_KEY,
+    billingMode: 'credits',
+    markup: llmPriceMarkup(),
+    appName: 'Kortix',
+    appReferer: config.KORTIX_URL,
+    resolvedModel: managed.upstreamModelId,
+    pricing: livePricing(managed.pricingRef),
+  };
+}
+
 function bedrockManagedDescriptor(managed: ManagedModel): UpstreamDescriptor | null {
   if (!config.AWS_BEDROCK_API_KEY) return null;
-  // Anthropic models use the InvokeModel/anthropic-payload transport; everything
-  // else (DeepSeek, Kimi) uses the model-agnostic Converse transport. Both hit
-  // Bedrock with the same bearer key — only the request/response shape differs.
+  // 'bedrock' = Anthropic InvokeModel/anthropic-payload; 'bedrock-converse' =
+  // the model-agnostic Converse API (Kimi, MiniMax). Same bearer key, different
+  // request/response shape — the kind selects the transport.
   return {
     provider: 'bedrock',
     kind: managed.transport,
@@ -35,13 +51,17 @@ function bedrockManagedDescriptor(managed: ManagedModel): UpstreamDescriptor | n
     apiKey: config.AWS_BEDROCK_API_KEY,
     billingMode: 'credits',
     markup: llmPriceMarkup(),
-    resolvedModel: managed.bedrockModelId,
+    resolvedModel: managed.upstreamModelId,
     pricing: livePricing(managed.pricingRef),
   };
 }
 
 export function managedCandidates(managed: ManagedModel): UpstreamDescriptor[] {
-  return [bedrockManagedDescriptor(managed)].filter((d): d is UpstreamDescriptor => d !== null);
+  const d =
+    managed.transport === 'openrouter'
+      ? openRouterManagedDescriptor(managed)
+      : bedrockManagedDescriptor(managed);
+  return d ? [d] : [];
 }
 
 export function managedDescriptor(managed: ManagedModel): UpstreamDescriptor | null {

--- a/apps/api/src/llm-gateway/resolution/descriptors.ts
+++ b/apps/api/src/llm-gateway/resolution/descriptors.ts
@@ -24,39 +24,24 @@ export function livePricing(modelId: string): UpstreamDescriptor['pricing'] | un
 }
 
 function bedrockManagedDescriptor(managed: ManagedModel): UpstreamDescriptor | null {
-  if (!config.AWS_BEDROCK_API_KEY || !managed.bedrockModelId) return null;
+  if (!config.AWS_BEDROCK_API_KEY) return null;
+  // Anthropic models use the InvokeModel/anthropic-payload transport; everything
+  // else (DeepSeek, Kimi) uses the model-agnostic Converse transport. Both hit
+  // Bedrock with the same bearer key — only the request/response shape differs.
   return {
     provider: 'bedrock',
-    kind: 'bedrock',
+    kind: managed.transport,
     baseUrl: bedrockBaseUrl(),
     apiKey: config.AWS_BEDROCK_API_KEY,
     billingMode: 'credits',
     markup: llmPriceMarkup(),
     resolvedModel: managed.bedrockModelId,
-    pricing: livePricing(managed.bedrockModelId),
-  };
-}
-
-function openRouterManagedDescriptor(managed: ManagedModel): UpstreamDescriptor | null {
-  if (!config.OPENROUTER_API_KEY) return null;
-  return {
-    provider: 'openrouter',
-    kind: 'openai-compat',
-    baseUrl: config.OPENROUTER_API_URL,
-    apiKey: config.OPENROUTER_API_KEY,
-    billingMode: 'credits',
-    markup: llmPriceMarkup(),
-    appName: 'Kortix',
-    appReferer: config.KORTIX_URL,
-    resolvedModel: managed.openRouterModelId,
-    pricing: livePricing(managed.openRouterModelId),
+    pricing: livePricing(managed.pricingRef),
   };
 }
 
 export function managedCandidates(managed: ManagedModel): UpstreamDescriptor[] {
-  return [bedrockManagedDescriptor(managed), openRouterManagedDescriptor(managed)].filter(
-    (d): d is UpstreamDescriptor => d !== null,
-  );
+  return [bedrockManagedDescriptor(managed)].filter((d): d is UpstreamDescriptor => d !== null);
 }
 
 export function managedDescriptor(managed: ManagedModel): UpstreamDescriptor | null {

--- a/apps/mobile/lib/utils/model-provider.ts
+++ b/apps/mobile/lib/utils/model-provider.ts
@@ -29,7 +29,8 @@ export type ModelProvider =
 export function isKortixMode(modelId: string): boolean {
   const id = modelId.startsWith('kortix/') ? modelId.slice('kortix/'.length) : modelId;
   if (id === 'claude-opus-4.8' || id === 'claude-sonnet-4.6' ||
-      id === 'deepseek-v3.2' || id === 'kimi-k2') {
+      id === 'kimi-k2' || id === 'kimi-k2-thinking' || id === 'minimax-m2.5' ||
+      id === 'glm-4.6' || id === 'glm-4.7' || id === 'qwen3-max') {
     return true;
   }
   // Back-compat: previously branded Kortix modes.

--- a/apps/mobile/lib/utils/model-provider.ts
+++ b/apps/mobile/lib/utils/model-provider.ts
@@ -29,7 +29,7 @@ export type ModelProvider =
 export function isKortixMode(modelId: string): boolean {
   const id = modelId.startsWith('kortix/') ? modelId.slice('kortix/'.length) : modelId;
   if (id === 'claude-opus-4.8' || id === 'claude-sonnet-4.6' ||
-      id === 'deepseek-v3.2' || id === 'qwen3-max' || id === 'glm-4.6' || id === 'kimi-k2') {
+      id === 'deepseek-v3.2' || id === 'kimi-k2') {
     return true;
   }
   // Back-compat: previously branded Kortix modes.

--- a/packages/llm-gateway/src/domain/descriptor.ts
+++ b/packages/llm-gateway/src/domain/descriptor.ts
@@ -1,6 +1,12 @@
 import type { BillingMode } from './principal';
 
-export type ProviderKind = 'openai-compat' | 'openai-responses' | 'anthropic' | 'bedrock' | 'custom';
+export type ProviderKind =
+  | 'openai-compat'
+  | 'openai-responses'
+  | 'anthropic'
+  | 'bedrock'
+  | 'bedrock-converse'
+  | 'custom';
 
 export interface UpstreamPricing {
   inputPerMillion: number;

--- a/packages/llm-gateway/src/transports/bedrock-converse/bedrock-converse.test.ts
+++ b/packages/llm-gateway/src/transports/bedrock-converse/bedrock-converse.test.ts
@@ -52,21 +52,45 @@ describe('buildBedrockConverseRequest', () => {
   });
 });
 
-// Build a single AWS event-stream frame: 4B total · 4B headersLen · 4B preludeCRC
-// · headers · payload · 4B msgCRC. CRCs are unchecked by the parser, so zero them.
-function frame(eventType: string, payload: unknown): Uint8Array {
-  const enc = new TextEncoder();
-  const name = enc.encode(':event-type');
-  const et = enc.encode(eventType);
-  const headers = new Uint8Array(1 + name.length + 1 + 2 + et.length);
+const enc = new TextEncoder();
+
+// One AWS event-stream string header: 1B name-len · name · 1B type(7) · 2B val-len · val.
+function header(name: string, value: string): Uint8Array {
+  const n = enc.encode(name);
+  const v = enc.encode(value);
+  const out = new Uint8Array(1 + n.length + 1 + 2 + v.length);
   let p = 0;
-  headers[p++] = name.length;
-  headers.set(name, p);
-  p += name.length;
-  headers[p++] = 7; // string
-  headers[p++] = (et.length >> 8) & 0xff;
-  headers[p++] = et.length & 0xff;
-  headers.set(et, p);
+  out[p++] = n.length;
+  out.set(n, p);
+  p += n.length;
+  out[p++] = 7; // string type
+  out[p++] = (v.length >> 8) & 0xff;
+  out[p++] = v.length & 0xff;
+  out.set(v, p);
+  return out;
+}
+
+function concatAll(parts: Uint8Array[]): Uint8Array {
+  const len = parts.reduce((a, b) => a + b.length, 0);
+  const out = new Uint8Array(len);
+  let off = 0;
+  for (const p of parts) {
+    out.set(p, off);
+    off += p.length;
+  }
+  return out;
+}
+
+// A realistic AWS event-stream frame: 4B total · 4B headersLen · 4B preludeCRC ·
+// headers · payload · 4B msgCRC. CRCs are unchecked by the parser → zero them.
+// Emits THREE headers in the real Bedrock order (`:event-type` is NOT first) so
+// the header-skipping logic actually runs.
+function frame(eventType: string, payload: unknown, messageType = 'event'): Uint8Array {
+  const headers = concatAll([
+    header(':message-type', messageType),
+    header(':event-type', eventType),
+    header(':content-type', 'application/json'),
+  ]);
   const body = enc.encode(JSON.stringify(payload));
   const total = 16 + headers.length + body.length;
   const out = new Uint8Array(total);
@@ -88,6 +112,19 @@ function eventStreamResponse(frames: Uint8Array[]): Response {
   return new Response(body, { status: 200 });
 }
 
+// Deliver the whole byte stream re-chunked at a fixed size, so frames are split
+// across reads and several can land in one read — exercises the buffering logic.
+function rechunkedResponse(frames: Uint8Array[], chunkSize: number): Response {
+  const all = concatAll(frames);
+  const body = new ReadableStream<Uint8Array>({
+    start(c) {
+      for (let i = 0; i < all.length; i += chunkSize) c.enqueue(all.subarray(i, i + chunkSize));
+      c.close();
+    },
+  });
+  return new Response(body, { status: 200 });
+}
+
 async function drain(rs: ReadableStream<Uint8Array>): Promise<string> {
   const reader = rs.getReader();
   const dec = new TextDecoder();
@@ -100,39 +137,109 @@ async function drain(rs: ReadableStream<Uint8Array>): Promise<string> {
   return out;
 }
 
+function parseChunks(text: string): any[] {
+  return text
+    .split('\n\n')
+    .filter((l) => l.startsWith('data: ') && !l.includes('[DONE]'))
+    .map((l) => JSON.parse(l.slice(6)));
+}
+
+// text "Hello world" + one tool call wx({"city":"Paris"}), tool_use stop, usage.
+const SAMPLE_FRAMES = [
+  frame('messageStart', { role: 'assistant' }),
+  frame('contentBlockDelta', { contentBlockIndex: 0, delta: { text: 'Hello' } }),
+  frame('contentBlockDelta', { contentBlockIndex: 0, delta: { text: ' world' } }),
+  frame('contentBlockStart', { contentBlockIndex: 1, start: { toolUse: { toolUseId: 't1', name: 'wx' } } }),
+  frame('contentBlockDelta', { contentBlockIndex: 1, delta: { toolUse: { input: '{"city":' } } }),
+  frame('contentBlockDelta', { contentBlockIndex: 1, delta: { toolUse: { input: '"Paris"}' } } }),
+  frame('messageStop', { stopReason: 'tool_use' }),
+  frame('metadata', { usage: { inputTokens: 10, outputTokens: 5 } }),
+];
+
+function assertSample(text: string) {
+  const chunks = parseChunks(text);
+  expect(chunks.map((c) => c.choices[0].delta.content).filter(Boolean).join('')).toBe('Hello world');
+  const calls = chunks.flatMap((c) => c.choices[0].delta.tool_calls ?? []);
+  expect(calls.map((t: any) => t.function?.name).filter(Boolean)[0]).toBe('wx');
+  expect(calls.map((t: any) => t.function?.arguments ?? '').join('')).toBe('{"city":"Paris"}');
+  const final = chunks.find((c) => c.choices[0].finish_reason);
+  expect(final.choices[0].finish_reason).toBe('tool_calls');
+  expect(final.usage).toMatchObject({ prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 });
+  expect(text.trimEnd().endsWith('data: [DONE]')).toBe(true);
+}
+
 describe('translateBedrockConverseResponse (streaming)', () => {
-  test('converts a text + tool-call Converse stream to OpenAI SSE', async () => {
-    const resp = eventStreamResponse([
-      frame('messageStart', { role: 'assistant' }),
-      frame('contentBlockDelta', { contentBlockIndex: 0, delta: { text: 'Hello' } }),
-      frame('contentBlockDelta', { contentBlockIndex: 0, delta: { text: ' world' } }),
-      frame('contentBlockStart', { contentBlockIndex: 1, start: { toolUse: { toolUseId: 't1', name: 'wx' } } }),
-      frame('contentBlockDelta', { contentBlockIndex: 1, delta: { toolUse: { input: '{"city":' } } }),
-      frame('contentBlockDelta', { contentBlockIndex: 1, delta: { toolUse: { input: '"Paris"}' } } }),
-      frame('messageStop', { stopReason: 'tool_use' }),
-      frame('metadata', { usage: { inputTokens: 10, outputTokens: 5 } }),
+  test('converts a text + tool-call Converse stream to OpenAI SSE (multi-header frames)', async () => {
+    const out = await translateBedrockConverseResponse(eventStreamResponse(SAMPLE_FRAMES), { streaming: true });
+    assertSample(await drain(out.body!));
+  });
+
+  // The riskiest path: the network splits frames across reads and packs several
+  // into one read. Re-chunk the exact same bytes at hostile sizes and the parser
+  // must produce identical output.
+  test.each([1, 2, 3, 7, 13, 64, 4096])('reassembles frames re-chunked at %i bytes', async (size) => {
+    const out = await translateBedrockConverseResponse(rechunkedResponse(SAMPLE_FRAMES, size), { streaming: true });
+    assertSample(await drain(out.body!));
+  });
+
+  test('emits distinct indices for two tool calls', async () => {
+    const out = await translateBedrockConverseResponse(
+      eventStreamResponse([
+        frame('messageStart', { role: 'assistant' }),
+        frame('contentBlockStart', { contentBlockIndex: 0, start: { toolUse: { toolUseId: 'a', name: 'one' } } }),
+        frame('contentBlockDelta', { contentBlockIndex: 0, delta: { toolUse: { input: '{}' } } }),
+        frame('contentBlockStart', { contentBlockIndex: 1, start: { toolUse: { toolUseId: 'b', name: 'two' } } }),
+        frame('contentBlockDelta', { contentBlockIndex: 1, delta: { toolUse: { input: '{}' } } }),
+        frame('messageStop', { stopReason: 'tool_use' }),
+        frame('metadata', { usage: { inputTokens: 1, outputTokens: 1 } }),
+      ]),
+      { streaming: true },
+    );
+    const calls = parseChunks(await drain(out.body!)).flatMap((c) => c.choices[0].delta.tool_calls ?? []);
+    const starts = calls.filter((t: any) => t.id);
+    expect(starts.map((t: any) => [t.index, t.id, t.function.name])).toEqual([
+      [0, 'a', 'one'],
+      [1, 'b', 'two'],
     ]);
+  });
 
-    const out = await translateBedrockConverseResponse(resp, { streaming: true });
+  test('does not crash on an exception frame; still finalizes', async () => {
+    const out = await translateBedrockConverseResponse(
+      eventStreamResponse([
+        frame('messageStart', { role: 'assistant' }),
+        frame('contentBlockDelta', { contentBlockIndex: 0, delta: { text: 'hi' } }),
+        frame('modelStreamErrorException', { message: 'boom' }, 'exception'),
+      ]),
+      { streaming: true },
+    );
     const text = await drain(out.body!);
-
-    const chunks = text
-      .split('\n\n')
-      .filter((l) => l.startsWith('data: ') && !l.includes('[DONE]'))
-      .map((l) => JSON.parse(l.slice(6)));
-
-    // text deltas concatenate
-    const content = chunks.map((c) => c.choices[0].delta.content).filter(Boolean).join('');
-    expect(content).toBe('Hello world');
-    // tool call: name + concatenated arguments
-    const toolName = chunks.flatMap((c) => c.choices[0].delta.tool_calls ?? []).map((t: any) => t.function?.name).filter(Boolean)[0];
-    expect(toolName).toBe('wx');
-    const args = chunks.flatMap((c) => c.choices[0].delta.tool_calls ?? []).map((t: any) => t.function?.arguments ?? '').join('');
-    expect(args).toBe('{"city":"Paris"}');
-    // final chunk: finish_reason + usage
-    const final = chunks.find((c) => c.choices[0].finish_reason);
-    expect(final.choices[0].finish_reason).toBe('tool_calls');
-    expect(final.usage).toMatchObject({ prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 });
+    expect(parseChunks(text).map((c) => c.choices[0].delta.content).filter(Boolean).join('')).toBe('hi');
     expect(text.trimEnd().endsWith('data: [DONE]')).toBe(true);
+  });
+});
+
+describe('translateBedrockConverseResponse (non-streaming)', () => {
+  test('translates a ConverseResponse to an OpenAI completion', async () => {
+    const resp = new Response(
+      JSON.stringify({
+        output: { message: { role: 'assistant', content: [{ text: 'hi' }, { toolUse: { toolUseId: 't1', name: 'wx', input: { city: 'Paris' } } }] } },
+        stopReason: 'tool_use',
+        usage: { inputTokens: 7, outputTokens: 3 },
+      }),
+      { status: 200, headers: { 'content-type': 'application/json' } },
+    );
+    const out = await translateBedrockConverseResponse(resp, { streaming: false });
+    const body: any = await out.json();
+    expect(body.choices[0].message.content).toBe('hi');
+    expect(body.choices[0].message.tool_calls[0]).toMatchObject({ id: 't1', function: { name: 'wx', arguments: '{"city":"Paris"}' } });
+    expect(body.choices[0].finish_reason).toBe('tool_calls');
+    expect(body.usage).toMatchObject({ prompt_tokens: 7, completion_tokens: 3, total_tokens: 10 });
+  });
+
+  test('surfaces an upstream error as an OpenAI error object', async () => {
+    const resp = new Response(JSON.stringify({ message: 'throttled' }), { status: 429 });
+    const out = await translateBedrockConverseResponse(resp, { streaming: false });
+    expect(out.status).toBe(429);
+    expect((await out.json()).error.message).toBe('throttled');
   });
 });

--- a/packages/llm-gateway/src/transports/bedrock-converse/bedrock-converse.test.ts
+++ b/packages/llm-gateway/src/transports/bedrock-converse/bedrock-converse.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, test } from 'bun:test';
+import type { UpstreamDescriptor } from '../../domain';
+import { buildBedrockConverseRequest } from './request';
+import { translateBedrockConverseResponse } from './response';
+
+const descriptor: UpstreamDescriptor = {
+  provider: 'bedrock',
+  kind: 'bedrock-converse',
+  baseUrl: 'https://bedrock-runtime.us-west-2.amazonaws.com',
+  apiKey: 'bedrock-key',
+  billingMode: 'credits',
+  markup: 1,
+  resolvedModel: 'deepseek.v3.2',
+};
+
+describe('buildBedrockConverseRequest', () => {
+  test('translates messages, system, tools, and tool results to Converse shape', () => {
+    const req = buildBedrockConverseRequest(
+      {
+        stream: true,
+        max_tokens: 100,
+        temperature: 0.5,
+        messages: [
+          { role: 'system', content: 'be terse' },
+          { role: 'user', content: 'weather in Paris?' },
+          { role: 'assistant', content: '', tool_calls: [{ id: 't1', function: { name: 'wx', arguments: '{"city":"Paris"}' } }] },
+          { role: 'tool', tool_call_id: 't1', content: 'sunny' },
+        ],
+        tools: [{ function: { name: 'wx', description: 'weather', parameters: { type: 'object', properties: { city: { type: 'string' } } } } }],
+        tool_choice: 'required',
+      },
+      descriptor,
+    );
+
+    expect(req.url).toBe('https://bedrock-runtime.us-west-2.amazonaws.com/model/deepseek.v3.2/converse-stream');
+    expect(req.headers.authorization).toBe('Bearer bedrock-key');
+    const p = req.payload as any;
+    expect(p.system).toEqual([{ text: 'be terse' }]);
+    expect(p.inferenceConfig).toMatchObject({ maxTokens: 100, temperature: 0.5 });
+    // assistant tool_call → toolUse with parsed input
+    expect(p.messages[1]).toEqual({ role: 'assistant', content: [{ toolUse: { toolUseId: 't1', name: 'wx', input: { city: 'Paris' } } }] });
+    // tool result → user message with toolResult
+    expect(p.messages[2]).toEqual({ role: 'user', content: [{ toolResult: { toolUseId: 't1', content: [{ text: 'sunny' }] } }] });
+    // tools → toolConfig.toolSpec; required → {any:{}}
+    expect(p.toolConfig.tools[0].toolSpec).toMatchObject({ name: 'wx', inputSchema: { json: { type: 'object' } } });
+    expect(p.toolConfig.toolChoice).toEqual({ any: {} });
+  });
+
+  test('non-streaming uses the converse action', () => {
+    const req = buildBedrockConverseRequest({ messages: [{ role: 'user', content: 'hi' }] }, descriptor);
+    expect(req.url).toEndWith('/converse');
+  });
+});
+
+// Build a single AWS event-stream frame: 4B total · 4B headersLen · 4B preludeCRC
+// · headers · payload · 4B msgCRC. CRCs are unchecked by the parser, so zero them.
+function frame(eventType: string, payload: unknown): Uint8Array {
+  const enc = new TextEncoder();
+  const name = enc.encode(':event-type');
+  const et = enc.encode(eventType);
+  const headers = new Uint8Array(1 + name.length + 1 + 2 + et.length);
+  let p = 0;
+  headers[p++] = name.length;
+  headers.set(name, p);
+  p += name.length;
+  headers[p++] = 7; // string
+  headers[p++] = (et.length >> 8) & 0xff;
+  headers[p++] = et.length & 0xff;
+  headers.set(et, p);
+  const body = enc.encode(JSON.stringify(payload));
+  const total = 16 + headers.length + body.length;
+  const out = new Uint8Array(total);
+  const dv = new DataView(out.buffer);
+  dv.setUint32(0, total);
+  dv.setUint32(4, headers.length);
+  out.set(headers, 12);
+  out.set(body, 12 + headers.length);
+  return out;
+}
+
+function eventStreamResponse(frames: Uint8Array[]): Response {
+  const body = new ReadableStream<Uint8Array>({
+    start(c) {
+      for (const f of frames) c.enqueue(f);
+      c.close();
+    },
+  });
+  return new Response(body, { status: 200 });
+}
+
+async function drain(rs: ReadableStream<Uint8Array>): Promise<string> {
+  const reader = rs.getReader();
+  const dec = new TextDecoder();
+  let out = '';
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (value) out += dec.decode(value, { stream: true });
+  }
+  return out;
+}
+
+describe('translateBedrockConverseResponse (streaming)', () => {
+  test('converts a text + tool-call Converse stream to OpenAI SSE', async () => {
+    const resp = eventStreamResponse([
+      frame('messageStart', { role: 'assistant' }),
+      frame('contentBlockDelta', { contentBlockIndex: 0, delta: { text: 'Hello' } }),
+      frame('contentBlockDelta', { contentBlockIndex: 0, delta: { text: ' world' } }),
+      frame('contentBlockStart', { contentBlockIndex: 1, start: { toolUse: { toolUseId: 't1', name: 'wx' } } }),
+      frame('contentBlockDelta', { contentBlockIndex: 1, delta: { toolUse: { input: '{"city":' } } }),
+      frame('contentBlockDelta', { contentBlockIndex: 1, delta: { toolUse: { input: '"Paris"}' } } }),
+      frame('messageStop', { stopReason: 'tool_use' }),
+      frame('metadata', { usage: { inputTokens: 10, outputTokens: 5 } }),
+    ]);
+
+    const out = await translateBedrockConverseResponse(resp, { streaming: true });
+    const text = await drain(out.body!);
+
+    const chunks = text
+      .split('\n\n')
+      .filter((l) => l.startsWith('data: ') && !l.includes('[DONE]'))
+      .map((l) => JSON.parse(l.slice(6)));
+
+    // text deltas concatenate
+    const content = chunks.map((c) => c.choices[0].delta.content).filter(Boolean).join('');
+    expect(content).toBe('Hello world');
+    // tool call: name + concatenated arguments
+    const toolName = chunks.flatMap((c) => c.choices[0].delta.tool_calls ?? []).map((t: any) => t.function?.name).filter(Boolean)[0];
+    expect(toolName).toBe('wx');
+    const args = chunks.flatMap((c) => c.choices[0].delta.tool_calls ?? []).map((t: any) => t.function?.arguments ?? '').join('');
+    expect(args).toBe('{"city":"Paris"}');
+    // final chunk: finish_reason + usage
+    const final = chunks.find((c) => c.choices[0].finish_reason);
+    expect(final.choices[0].finish_reason).toBe('tool_calls');
+    expect(final.usage).toMatchObject({ prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 });
+    expect(text.trimEnd().endsWith('data: [DONE]')).toBe(true);
+  });
+});

--- a/packages/llm-gateway/src/transports/bedrock-converse/index.ts
+++ b/packages/llm-gateway/src/transports/bedrock-converse/index.ts
@@ -1,0 +1,2 @@
+export { buildBedrockConverseRequest } from './request';
+export { translateBedrockConverseResponse } from './response';

--- a/packages/llm-gateway/src/transports/bedrock-converse/request.ts
+++ b/packages/llm-gateway/src/transports/bedrock-converse/request.ts
@@ -1,0 +1,144 @@
+import type { UpstreamDescriptor } from '../../domain';
+import type { UpstreamRequest } from '../openai-compat';
+
+const DEFAULT_MAX_TOKENS = 4096;
+
+function trimTrailingSlash(url: string): string {
+  return url.replace(/\/+$/, '');
+}
+
+function safeParse(value: unknown): unknown {
+  if (typeof value !== 'string') return value ?? {};
+  try {
+    return JSON.parse(value);
+  } catch {
+    return {};
+  }
+}
+
+function textOf(content: unknown): string {
+  if (typeof content === 'string') return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((part) => (part && typeof part === 'object' && 'text' in part ? String((part as any).text ?? '') : ''))
+      .join('');
+  }
+  return '';
+}
+
+// OpenAI user content → Converse content blocks (text + inline base64 images).
+function userContent(content: unknown): any[] {
+  if (typeof content === 'string') return [{ text: content }];
+  if (!Array.isArray(content)) return [{ text: textOf(content) }];
+  const out: any[] = [];
+  for (const part of content as any[]) {
+    if (part?.type === 'text') {
+      out.push({ text: part.text ?? '' });
+    } else if (part?.type === 'image_url') {
+      const url: string = part.image_url?.url ?? '';
+      if (url.startsWith('data:')) {
+        const comma = url.indexOf(',');
+        const mediaType = url.slice(5, comma).split(';')[0] || 'image/png';
+        const format = (mediaType.split('/')[1] || 'png').toLowerCase();
+        out.push({ image: { format, source: { bytes: url.slice(comma + 1) } } });
+      }
+      // Remote image URLs aren't supported by Converse (needs bytes) — dropped.
+    }
+  }
+  return out.length ? out : [{ text: '' }];
+}
+
+// OpenAI messages → Converse messages + system blocks. Converse has only
+// user/assistant roles; tool results go in a user message (same as Anthropic).
+function translate(messages: any[]): { system?: any[]; messages: any[] } {
+  const system: any[] = [];
+  const out: any[] = [];
+  for (const m of messages ?? []) {
+    if (m.role === 'system') {
+      const t = textOf(m.content);
+      if (t) system.push({ text: t });
+      continue;
+    }
+    if (m.role === 'tool') {
+      out.push({
+        role: 'user',
+        content: [
+          {
+            toolResult: {
+              toolUseId: m.tool_call_id,
+              content: [{ text: typeof m.content === 'string' ? m.content : JSON.stringify(m.content) }],
+            },
+          },
+        ],
+      });
+      continue;
+    }
+    if (m.role === 'assistant') {
+      const content: any[] = [];
+      const text = textOf(m.content);
+      if (text) content.push({ text });
+      for (const tc of m.tool_calls ?? []) {
+        content.push({ toolUse: { toolUseId: tc.id, name: tc.function?.name, input: safeParse(tc.function?.arguments) } });
+      }
+      out.push({ role: 'assistant', content: content.length ? content : [{ text: '' }] });
+      continue;
+    }
+    out.push({ role: 'user', content: userContent(m.content) });
+  }
+  return { system: system.length ? system : undefined, messages: out };
+}
+
+function toolConfig(body: Record<string, any>): Record<string, unknown> | undefined {
+  const tools = body.tools;
+  if (!Array.isArray(tools) || tools.length === 0) return undefined;
+  const specs = tools
+    .filter((t) => t?.function?.name)
+    .map((t) => ({
+      toolSpec: {
+        name: t.function.name,
+        description: t.function.description ?? '',
+        inputSchema: { json: t.function.parameters ?? { type: 'object', properties: {} } },
+      },
+    }));
+  if (!specs.length) return undefined;
+  const cfg: Record<string, unknown> = { tools: specs };
+  const tc = body.tool_choice;
+  // Only set toolChoice when forcing — many models reject an explicit {auto:{}}.
+  if (tc === 'required') cfg.toolChoice = { any: {} };
+  else if (typeof tc === 'object' && tc?.function?.name) cfg.toolChoice = { tool: { name: tc.function.name } };
+  return cfg;
+}
+
+export function buildBedrockConverseRequest(
+  body: Record<string, any>,
+  descriptor: UpstreamDescriptor,
+): UpstreamRequest {
+  const { system, messages } = translate(body.messages ?? []);
+
+  const inferenceConfig: Record<string, unknown> = {
+    maxTokens: body.max_tokens ?? body.max_completion_tokens ?? DEFAULT_MAX_TOKENS,
+  };
+  if (body.temperature != null) inferenceConfig.temperature = body.temperature;
+  if (body.top_p != null) inferenceConfig.topP = body.top_p;
+  if (body.stop != null) inferenceConfig.stopSequences = Array.isArray(body.stop) ? body.stop : [body.stop];
+
+  const payload: Record<string, unknown> = { messages, inferenceConfig };
+  if (system) payload.system = system;
+  const tc = toolConfig(body);
+  if (tc) payload.toolConfig = tc;
+
+  const modelId = descriptor.resolvedModel || String(body.model ?? '');
+  const action = body.stream === true ? 'converse-stream' : 'converse';
+
+  const headers: Record<string, string> = {
+    'content-type': 'application/json',
+    authorization: `Bearer ${descriptor.apiKey}`,
+  };
+  if (descriptor.headers) Object.assign(headers, descriptor.headers);
+
+  return {
+    url: `${trimTrailingSlash(descriptor.baseUrl)}/model/${encodeURIComponent(modelId)}/${action}`,
+    headers,
+    payload,
+  };
+}

--- a/packages/llm-gateway/src/transports/bedrock-converse/response.ts
+++ b/packages/llm-gateway/src/transports/bedrock-converse/response.ts
@@ -187,7 +187,10 @@ function translateStreaming(response: Response): Response {
           const { done, value } = await reader.read();
           if (done) break;
           if (!value || !value.length) continue;
-          buf = pos === 0 ? value : concat(buf.subarray(pos), value);
+          // Carry any unconsumed leftover. NB: pos can be 0 with bytes still in
+          // buf (a sub-12-byte tail the inner loop never entered) — keying off
+          // `pos === 0` there would drop it, so test for full consumption.
+          buf = buf.length === pos ? value : concat(buf.subarray(pos), value);
           pos = 0;
           while (buf.length - pos >= 12) {
             const total = readU32(buf, pos);

--- a/packages/llm-gateway/src/transports/bedrock-converse/response.ts
+++ b/packages/llm-gateway/src/transports/bedrock-converse/response.ts
@@ -1,0 +1,261 @@
+// Bedrock Converse → OpenAI chat-completions translation.
+//
+// converse-stream returns an AWS event-stream (binary framing) where each
+// message carries its event name in a `:event-type` header and the payload is
+// the event JSON directly (unlike invoke-with-response-stream, which base64-wraps
+// the payload in a `bytes` field). We parse the framing, read the header, and
+// emit OpenAI `chat.completion.chunk` SSE.
+
+const FINISH_REASON: Record<string, string> = {
+  end_turn: 'stop',
+  tool_use: 'tool_calls',
+  max_tokens: 'length',
+  stop_sequence: 'stop',
+  content_filtered: 'stop',
+  guardrail_intervened: 'stop',
+};
+
+function readU32(b: Uint8Array, off: number): number {
+  return ((b[off] << 24) | (b[off + 1] << 16) | (b[off + 2] << 8) | b[off + 3]) >>> 0;
+}
+
+function concat(a: Uint8Array, b: Uint8Array): Uint8Array {
+  const out = new Uint8Array(a.length + b.length);
+  out.set(a, 0);
+  out.set(b, a.length);
+  return out;
+}
+
+// Extract the `:event-type` value from an AWS event-stream headers block.
+function eventTypeOf(headers: Uint8Array, dec: TextDecoder): string {
+  let p = 0;
+  while (p + 1 < headers.length) {
+    const nameLen = headers[p];
+    p += 1;
+    if (p + nameLen > headers.length) break;
+    const name = dec.decode(headers.subarray(p, p + nameLen));
+    p += nameLen;
+    const type = headers[p];
+    p += 1;
+    let valLen = 0;
+    switch (type) {
+      case 0:
+      case 1:
+        valLen = 0;
+        break; // bool
+      case 2:
+        valLen = 1;
+        break; // byte
+      case 3:
+        valLen = 2;
+        break; // short
+      case 4:
+        valLen = 4;
+        break; // int
+      case 5:
+        valLen = 8;
+        break; // long
+      case 6:
+      case 7: {
+        // bytes / string — 2-byte length prefix
+        valLen = (headers[p] << 8) | headers[p + 1];
+        p += 2;
+        break;
+      }
+      case 8:
+        valLen = 8;
+        break; // timestamp
+      case 9:
+        valLen = 16;
+        break; // uuid
+      default:
+        return ''; // unknown type — can't safely advance
+    }
+    const val = headers.subarray(p, p + valLen);
+    p += valLen;
+    if (name === ':event-type') return dec.decode(val);
+  }
+  return '';
+}
+
+function chunkId(): string {
+  return 'chatcmpl-' + Math.random().toString(36).slice(2);
+}
+
+function nowSec(): number {
+  return Math.floor(Date.now() / 1000);
+}
+
+async function translateNonStreaming(response: Response): Promise<Response> {
+  const data = await response.json().catch(() => null);
+  if (!response.ok || !data) {
+    return new Response(
+      JSON.stringify({
+        error: { message: data?.message ?? data?.Message ?? 'bedrock converse error', type: 'upstream_error' },
+      }),
+      { status: response.status || 502, headers: { 'content-type': 'application/json' } },
+    );
+  }
+  const blocks = Array.isArray(data.output?.message?.content) ? data.output.message.content : [];
+  let text = '';
+  const toolCalls: any[] = [];
+  for (const block of blocks) {
+    if (typeof block?.text === 'string') text += block.text;
+    else if (block?.toolUse) {
+      toolCalls.push({
+        id: block.toolUse.toolUseId,
+        type: 'function',
+        function: { name: block.toolUse.name, arguments: JSON.stringify(block.toolUse.input ?? {}) },
+      });
+    }
+  }
+  const message: Record<string, unknown> = { role: 'assistant', content: text || null };
+  if (toolCalls.length) message.tool_calls = toolCalls;
+
+  const inputTokens = data.usage?.inputTokens ?? 0;
+  const outputTokens = data.usage?.outputTokens ?? 0;
+  const cachedTokens = data.usage?.cacheReadInputTokens ?? 0;
+  const out = {
+    id: chunkId(),
+    object: 'chat.completion',
+    created: nowSec(),
+    model: '',
+    choices: [{ index: 0, message, finish_reason: FINISH_REASON[data.stopReason] ?? 'stop' }],
+    usage: {
+      prompt_tokens: inputTokens,
+      completion_tokens: outputTokens,
+      total_tokens: inputTokens + outputTokens,
+      ...(cachedTokens ? { prompt_tokens_details: { cached_tokens: cachedTokens } } : {}),
+    },
+  };
+  return new Response(JSON.stringify(out), { status: 200, headers: { 'content-type': 'application/json' } });
+}
+
+function translateStreaming(response: Response): Response {
+  if (!response.ok || !response.body) return translateNonStreaming(response) as unknown as Response;
+
+  const created = nowSec();
+  const id = chunkId();
+  const encoder = new TextEncoder();
+  const decoder = new TextDecoder();
+
+  const usage = { prompt_tokens: 0, completion_tokens: 0 };
+  let cachedTokens = 0;
+  let finishReason: string | null = null;
+  // contentBlockIndex → tool_calls index (only set for toolUse blocks).
+  const blockToTool = new Map<number, number>();
+  let toolIndex = -1;
+  let started = false;
+  let finalized = false;
+
+  const stream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      const emit = (delta: unknown, finish: string | null) => {
+        controller.enqueue(
+          encoder.encode(
+            `data: ${JSON.stringify({ id, object: 'chat.completion.chunk', created, model: '', choices: [{ index: 0, delta, finish_reason: finish }] })}\n\n`,
+          ),
+        );
+      };
+      const finalize = () => {
+        if (finalized) return;
+        finalized = true;
+        controller.enqueue(
+          encoder.encode(
+            `data: ${JSON.stringify({
+              id,
+              object: 'chat.completion.chunk',
+              created,
+              model: '',
+              choices: [{ index: 0, delta: {}, finish_reason: finishReason ?? 'stop' }],
+              usage: {
+                ...usage,
+                total_tokens: usage.prompt_tokens + usage.completion_tokens,
+                ...(cachedTokens ? { prompt_tokens_details: { cached_tokens: cachedTokens } } : {}),
+              },
+            })}\n\n`,
+          ),
+        );
+        controller.enqueue(encoder.encode('data: [DONE]\n\n'));
+      };
+
+      const reader = response.body!.getReader();
+      let buf: Uint8Array = new Uint8Array(0);
+      let pos = 0;
+      try {
+        outer: while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          if (!value || !value.length) continue;
+          buf = pos === 0 ? value : concat(buf.subarray(pos), value);
+          pos = 0;
+          while (buf.length - pos >= 12) {
+            const total = readU32(buf, pos);
+            if (total < 16) break outer; // desynced — can't realign
+            if (buf.length - pos < total) break; // wait for the rest of the frame
+            const headersLen = readU32(buf, pos + 4);
+            const headers = buf.subarray(pos + 12, pos + 12 + headersLen);
+            const payloadBytes = buf.subarray(pos + 12 + headersLen, pos + total - 4);
+            pos += total;
+
+            const evtType = eventTypeOf(headers, decoder);
+            let evt: any;
+            try {
+              evt = JSON.parse(decoder.decode(payloadBytes));
+            } catch {
+              continue;
+            }
+
+            if (evtType === 'messageStart') {
+              if (!started) {
+                started = true;
+                emit({ role: 'assistant', content: '' }, null);
+              }
+            } else if (evtType === 'contentBlockStart') {
+              const tu = evt.start?.toolUse;
+              if (tu) {
+                toolIndex += 1;
+                blockToTool.set(evt.contentBlockIndex, toolIndex);
+                emit({ tool_calls: [{ index: toolIndex, id: tu.toolUseId, type: 'function', function: { name: tu.name, arguments: '' } }] }, null);
+              }
+            } else if (evtType === 'contentBlockDelta') {
+              const d = evt.delta;
+              if (typeof d?.text === 'string') {
+                emit({ content: d.text }, null);
+              } else if (d?.toolUse?.input != null) {
+                const ti = blockToTool.get(evt.contentBlockIndex) ?? 0;
+                emit({ tool_calls: [{ index: ti, function: { arguments: String(d.toolUse.input) } }] }, null);
+              }
+            } else if (evtType === 'messageStop') {
+              finishReason = FINISH_REASON[evt.stopReason] ?? 'stop';
+            } else if (evtType === 'metadata') {
+              usage.prompt_tokens = evt.usage?.inputTokens ?? usage.prompt_tokens;
+              usage.completion_tokens = evt.usage?.outputTokens ?? usage.completion_tokens;
+              cachedTokens = evt.usage?.cacheReadInputTokens ?? cachedTokens;
+            } else if (evtType.endsWith('Exception') || evt?.message) {
+              // throttling / model stream / validation error — surface it.
+              console.warn('[bedrock-converse] stream error frame:', evtType, evt?.message ?? '');
+            }
+          }
+        }
+      } catch {
+        // upstream stream broke; finalize with what we have
+      } finally {
+        if (started) finalize();
+        controller.close();
+      }
+    },
+  });
+
+  return new Response(stream, {
+    status: 200,
+    headers: { 'content-type': 'text/event-stream', 'cache-control': 'no-cache', connection: 'keep-alive' },
+  });
+}
+
+export function translateBedrockConverseResponse(
+  response: Response,
+  ctx: { streaming: boolean },
+): Response | Promise<Response> {
+  return ctx.streaming ? translateStreaming(response) : translateNonStreaming(response);
+}

--- a/packages/llm-gateway/src/transports/bedrock/response.ts
+++ b/packages/llm-gateway/src/transports/bedrock/response.ts
@@ -32,7 +32,10 @@ function bedrockEventStreamToSse(response: Response): Response {
           const { done, value } = await reader.read();
           if (done) break;
           if (!value || !value.length) continue;
-          buf = pos === 0 ? value : concat(buf.subarray(pos), value);
+          // Carry any unconsumed leftover. pos can be 0 with bytes still in buf
+          // (a sub-12-byte tail the inner loop never entered) — keying off
+          // `pos === 0` would drop it, so test for full consumption.
+          buf = buf.length === pos ? value : concat(buf.subarray(pos), value);
           pos = 0;
 
           // Parse every complete frame in the buffer, advancing a read offset

--- a/packages/llm-gateway/src/transports/registry.ts
+++ b/packages/llm-gateway/src/transports/registry.ts
@@ -3,6 +3,7 @@ import { buildUpstreamRequest } from './openai-compat';
 import { buildResponsesRequest, translateResponsesResponse } from './openai-responses';
 import { buildAnthropicRequest, translateAnthropicResponse } from './anthropic';
 import { buildBedrockRequest, translateBedrockResponse } from './bedrock';
+import { buildBedrockConverseRequest, translateBedrockConverseResponse } from './bedrock-converse';
 import type { ProviderKind } from '../domain';
 
 const openaiCompat: Transport = {
@@ -25,11 +26,17 @@ const bedrock: Transport = {
   translateResponse: translateBedrockResponse,
 };
 
+const bedrockConverse: Transport = {
+  buildRequest: buildBedrockConverseRequest,
+  translateResponse: translateBedrockConverseResponse,
+};
+
 const registry: Record<ProviderKind, Transport> = {
   'openai-compat': openaiCompat,
   'openai-responses': openaiResponses,
   anthropic,
   bedrock,
+  'bedrock-converse': bedrockConverse,
   custom: openaiCompat,
 };
 

--- a/packages/shared/src/llm-catalog/index.ts
+++ b/packages/shared/src/llm-catalog/index.ts
@@ -29,15 +29,17 @@ export const CATALOG = catalogJson as Catalog;
 export interface ManagedModel {
   id: string;
   name: string;
-  // Bedrock invocation id (a cross-region inference-profile id like
-  // `us.anthropic.claude-opus-4-8`, or a base model id like `deepseek.v3.2`).
-  // Every managed model runs on Bedrock through our own credentials.
-  bedrockModelId: string;
-  // Which Bedrock transport carries it:
+  // The upstream's own model id, interpreted per `transport`:
+  //   'bedrock' / 'bedrock-converse' → a Bedrock id (`us.anthropic.claude-opus-4-8`,
+  //                                    `moonshotai.kimi-k2.5`)
+  //   'openrouter'                   → an OpenRouter slug (`z-ai/glm-4.6`)
+  upstreamModelId: string;
+  // Which upstream + wire format carries it:
   //   'bedrock'          → Anthropic-on-Bedrock InvokeModel payload (Claude only)
-  //   'bedrock-converse' → the model-agnostic Converse API (DeepSeek, Kimi, …)
-  transport: 'bedrock' | 'bedrock-converse';
-  // models.dev id for live pricing — Bedrock ids don't always match the catalog.
+  //   'bedrock-converse' → model-agnostic Bedrock Converse API (Kimi, MiniMax, …)
+  //   'openrouter'       → OpenRouter (openai-compat) for models not on Bedrock
+  transport: 'bedrock' | 'bedrock-converse' | 'openrouter';
+  // models.dev id for live pricing — upstream ids don't always match the catalog.
   pricingRef: string;
   tier: 'flagship' | 'balanced' | 'fast';
 }
@@ -49,17 +51,17 @@ export interface ManagedModel {
 // (`claude-opus-4.8` → our keys, credits-billed) apart from a BYOK one
 // (`anthropic/claude-...` → the user's own key) without the two ever colliding.
 //
-// Bedrock-only: every managed model runs on AWS Bedrock through our own bearer
-// key and is billed as Kortix credits with markup, so the gateway enforces
-// budgets/logging/spend on all of them. Anthropic frontier uses the proven
-// Anthropic-payload transport; DeepSeek/Kimi use the Converse transport.
-// (OpenRouter was dropped — its per-provider availability, e.g. Kimi only on
-// `novita`, made non-Anthropic models flaky; Qwen/GLM aren't on Bedrock at all.)
+// Every managed model runs through OUR keys and is billed as Kortix credits with
+// markup, so the gateway enforces budgets/logging/spend on all of them. Bedrock
+// is preferred (consistent, no per-provider routing surprises): Anthropic via the
+// proven Anthropic-payload transport, Kimi/MiniMax via Converse. Models Bedrock
+// doesn't host (GLM, Qwen) go via OpenRouter. (Kimi is on Bedrock specifically
+// because its only OpenRouter provider, `novita`, is excluded by our data policy.)
 export const MANAGED_MODELS: ManagedModel[] = [
   {
     id: 'claude-opus-4.8',
     name: 'Claude Opus 4.8',
-    bedrockModelId: 'us.anthropic.claude-opus-4-8',
+    upstreamModelId: 'us.anthropic.claude-opus-4-8',
     transport: 'bedrock',
     pricingRef: 'anthropic/claude-opus-4.8',
     tier: 'flagship',
@@ -67,25 +69,57 @@ export const MANAGED_MODELS: ManagedModel[] = [
   {
     id: 'claude-sonnet-4.6',
     name: 'Claude Sonnet 4.6',
-    bedrockModelId: 'us.anthropic.claude-sonnet-4-6',
+    upstreamModelId: 'us.anthropic.claude-sonnet-4-6',
     transport: 'bedrock',
     pricingRef: 'anthropic/claude-sonnet-4.6',
     tier: 'balanced',
   },
   {
-    id: 'deepseek-v3.2',
-    name: 'DeepSeek V3.2',
-    bedrockModelId: 'deepseek.v3.2',
+    id: 'kimi-k2',
+    name: 'Kimi K2',
+    upstreamModelId: 'moonshotai.kimi-k2.5',
     transport: 'bedrock-converse',
-    pricingRef: 'deepseek/deepseek-v3.2',
+    pricingRef: 'moonshotai/kimi-k2',
     tier: 'balanced',
   },
   {
-    id: 'kimi-k2',
-    name: 'Kimi K2',
-    bedrockModelId: 'moonshotai.kimi-k2.5',
+    id: 'kimi-k2-thinking',
+    name: 'Kimi K2 Thinking',
+    upstreamModelId: 'moonshot.kimi-k2-thinking',
     transport: 'bedrock-converse',
-    pricingRef: 'moonshotai/kimi-k2',
+    pricingRef: 'moonshotai/kimi-k2-thinking',
+    tier: 'balanced',
+  },
+  {
+    id: 'minimax-m2.5',
+    name: 'MiniMax M2.5',
+    upstreamModelId: 'minimax.minimax-m2.5',
+    transport: 'bedrock-converse',
+    pricingRef: 'minimax/minimax-m2',
+    tier: 'balanced',
+  },
+  {
+    id: 'glm-4.6',
+    name: 'GLM-4.6',
+    upstreamModelId: 'z-ai/glm-4.6',
+    transport: 'openrouter',
+    pricingRef: 'z-ai/glm-4.6',
+    tier: 'balanced',
+  },
+  {
+    id: 'glm-4.7',
+    name: 'GLM-4.7',
+    upstreamModelId: 'z-ai/glm-4.7',
+    transport: 'openrouter',
+    pricingRef: 'z-ai/glm-4.7',
+    tier: 'balanced',
+  },
+  {
+    id: 'qwen3-max',
+    name: 'Qwen3 Max',
+    upstreamModelId: 'qwen/qwen3-max',
+    transport: 'openrouter',
+    pricingRef: 'qwen/qwen3-max',
     tier: 'balanced',
   },
 ];

--- a/packages/shared/src/llm-catalog/index.ts
+++ b/packages/shared/src/llm-catalog/index.ts
@@ -29,12 +29,16 @@ export const CATALOG = catalogJson as Catalog;
 export interface ManagedModel {
   id: string;
   name: string;
-  // The Bedrock inference-profile id, when the model is reachable on Bedrock.
-  // Only Anthropic models are — our Bedrock transport speaks the Anthropic-on-
-  // Bedrock payload format — so non-Anthropic (Chinese) models omit this and are
-  // served via OpenRouter instead. Absent here ⇒ no Bedrock candidate is built.
-  bedrockModelId?: string;
-  openRouterModelId: string;
+  // Bedrock invocation id (a cross-region inference-profile id like
+  // `us.anthropic.claude-opus-4-8`, or a base model id like `deepseek.v3.2`).
+  // Every managed model runs on Bedrock through our own credentials.
+  bedrockModelId: string;
+  // Which Bedrock transport carries it:
+  //   'bedrock'          → Anthropic-on-Bedrock InvokeModel payload (Claude only)
+  //   'bedrock-converse' → the model-agnostic Converse API (DeepSeek, Kimi, …)
+  transport: 'bedrock' | 'bedrock-converse';
+  // models.dev id for live pricing — Bedrock ids don't always match the catalog.
+  pricingRef: string;
   tier: 'flagship' | 'balanced' | 'fast';
 }
 
@@ -45,46 +49,43 @@ export interface ManagedModel {
 // (`claude-opus-4.8` → our keys, credits-billed) apart from a BYOK one
 // (`anthropic/claude-...` → the user's own key) without the two ever colliding.
 //
-// Every managed model routes through our own provider keys and is billed as
-// Kortix credits with markup, so the gateway enforces budgets/logging/spend on
-// all of them. Anthropic frontier goes via Bedrock; the rest via OpenRouter.
+// Bedrock-only: every managed model runs on AWS Bedrock through our own bearer
+// key and is billed as Kortix credits with markup, so the gateway enforces
+// budgets/logging/spend on all of them. Anthropic frontier uses the proven
+// Anthropic-payload transport; DeepSeek/Kimi use the Converse transport.
+// (OpenRouter was dropped — its per-provider availability, e.g. Kimi only on
+// `novita`, made non-Anthropic models flaky; Qwen/GLM aren't on Bedrock at all.)
 export const MANAGED_MODELS: ManagedModel[] = [
   {
     id: 'claude-opus-4.8',
     name: 'Claude Opus 4.8',
     bedrockModelId: 'us.anthropic.claude-opus-4-8',
-    openRouterModelId: 'anthropic/claude-opus-4.8',
+    transport: 'bedrock',
+    pricingRef: 'anthropic/claude-opus-4.8',
     tier: 'flagship',
   },
   {
     id: 'claude-sonnet-4.6',
     name: 'Claude Sonnet 4.6',
     bedrockModelId: 'us.anthropic.claude-sonnet-4-6',
-    openRouterModelId: 'anthropic/claude-sonnet-4.6',
+    transport: 'bedrock',
+    pricingRef: 'anthropic/claude-sonnet-4.6',
     tier: 'balanced',
   },
   {
     id: 'deepseek-v3.2',
     name: 'DeepSeek V3.2',
-    openRouterModelId: 'deepseek/deepseek-v3.2',
-    tier: 'balanced',
-  },
-  {
-    id: 'qwen3-max',
-    name: 'Qwen3 Max',
-    openRouterModelId: 'qwen/qwen3-max',
-    tier: 'balanced',
-  },
-  {
-    id: 'glm-4.6',
-    name: 'GLM-4.6',
-    openRouterModelId: 'z-ai/glm-4.6',
+    bedrockModelId: 'deepseek.v3.2',
+    transport: 'bedrock-converse',
+    pricingRef: 'deepseek/deepseek-v3.2',
     tier: 'balanced',
   },
   {
     id: 'kimi-k2',
     name: 'Kimi K2',
-    openRouterModelId: 'moonshotai/kimi-k2',
+    bedrockModelId: 'moonshotai.kimi-k2.5',
+    transport: 'bedrock-converse',
+    pricingRef: 'moonshotai/kimi-k2',
     tier: 'balanced',
   },
 ];

--- a/packages/shared/src/llm-catalog/managed.test.ts
+++ b/packages/shared/src/llm-catalog/managed.test.ts
@@ -8,13 +8,11 @@ import {
 } from './index';
 
 describe('managed catalog', () => {
-  test('exposes the expected passthrough lineup', () => {
+  test('exposes the Bedrock-only lineup', () => {
     expect(DEFAULT_MANAGED_MODEL_IDS).toEqual([
       'claude-opus-4.8',
       'claude-sonnet-4.6',
       'deepseek-v3.2',
-      'qwen3-max',
-      'glm-4.6',
       'kimi-k2',
     ]);
   });
@@ -29,20 +27,20 @@ describe('managed catalog', () => {
     expect(MANAGED_MODELS.filter((m) => m.tier === 'flagship')).toHaveLength(1);
   });
 
-  test('only Anthropic models carry a Bedrock id; Chinese models route via OpenRouter', () => {
+  test('every model runs on Bedrock with a pricing ref', () => {
     for (const m of MANAGED_MODELS) {
-      expect(m.openRouterModelId.length).toBeGreaterThan(0);
-      if (m.openRouterModelId.startsWith('anthropic/')) {
-        expect(m.bedrockModelId, `${m.id} should be Bedrock-routable`).toBeDefined();
-      } else {
-        expect(m.bedrockModelId, `${m.id} (non-Anthropic) must not claim a Bedrock id`).toBeUndefined();
-      }
+      expect(m.bedrockModelId.length, `${m.id} needs a Bedrock id`).toBeGreaterThan(0);
+      expect(m.pricingRef.length, `${m.id} needs a pricing ref`).toBeGreaterThan(0);
     }
   });
 
-  test('every Bedrock id is an Anthropic inference profile (our Bedrock transport is Anthropic-only)', () => {
+  test('Anthropic models use the invoke transport, others use Converse', () => {
     for (const m of MANAGED_MODELS) {
-      if (m.bedrockModelId) expect(m.bedrockModelId).toContain('anthropic.claude');
+      if (m.bedrockModelId.includes('anthropic.claude')) {
+        expect(m.transport, `${m.id} (Anthropic) → invoke`).toBe('bedrock');
+      } else {
+        expect(m.transport, `${m.id} (non-Anthropic) → Converse`).toBe('bedrock-converse');
+      }
     }
   });
 });
@@ -50,7 +48,8 @@ describe('managed catalog', () => {
 describe('managed resolution + back-compat aliases', () => {
   test('resolves current ids', () => {
     expect(getManagedModel('claude-opus-4.8')?.name).toBe('Claude Opus 4.8');
-    expect(getManagedModel('kimi-k2')?.openRouterModelId).toBe('moonshotai/kimi-k2');
+    expect(getManagedModel('kimi-k2')?.bedrockModelId).toBe('moonshotai.kimi-k2.5');
+    expect(getManagedModel('kimi-k2')?.transport).toBe('bedrock-converse');
   });
 
   test('retired branded ids still resolve (to the nearest current model) so stored configs do not break', () => {

--- a/packages/shared/src/llm-catalog/managed.test.ts
+++ b/packages/shared/src/llm-catalog/managed.test.ts
@@ -8,12 +8,16 @@ import {
 } from './index';
 
 describe('managed catalog', () => {
-  test('exposes the Bedrock-only lineup', () => {
+  test('exposes the managed lineup', () => {
     expect(DEFAULT_MANAGED_MODEL_IDS).toEqual([
       'claude-opus-4.8',
       'claude-sonnet-4.6',
-      'deepseek-v3.2',
       'kimi-k2',
+      'kimi-k2-thinking',
+      'minimax-m2.5',
+      'glm-4.6',
+      'glm-4.7',
+      'qwen3-max',
     ]);
   });
 
@@ -27,19 +31,23 @@ describe('managed catalog', () => {
     expect(MANAGED_MODELS.filter((m) => m.tier === 'flagship')).toHaveLength(1);
   });
 
-  test('every model runs on Bedrock with a pricing ref', () => {
+  test('every model has an upstream id, transport, and pricing ref', () => {
     for (const m of MANAGED_MODELS) {
-      expect(m.bedrockModelId.length, `${m.id} needs a Bedrock id`).toBeGreaterThan(0);
+      expect(m.upstreamModelId.length, `${m.id} needs an upstream id`).toBeGreaterThan(0);
       expect(m.pricingRef.length, `${m.id} needs a pricing ref`).toBeGreaterThan(0);
+      expect(['bedrock', 'bedrock-converse', 'openrouter']).toContain(m.transport);
     }
   });
 
-  test('Anthropic models use the invoke transport, others use Converse', () => {
+  test('transport matches the upstream id shape', () => {
     for (const m of MANAGED_MODELS) {
-      if (m.bedrockModelId.includes('anthropic.claude')) {
+      if (m.upstreamModelId.includes('anthropic.claude')) {
         expect(m.transport, `${m.id} (Anthropic) → invoke`).toBe('bedrock');
+      } else if (m.transport === 'openrouter') {
+        // OpenRouter slugs are provider/model.
+        expect(m.upstreamModelId, `${m.id} OpenRouter slug`).toContain('/');
       } else {
-        expect(m.transport, `${m.id} (non-Anthropic) → Converse`).toBe('bedrock-converse');
+        expect(m.transport, `${m.id} (non-Anthropic Bedrock) → Converse`).toBe('bedrock-converse');
       }
     }
   });
@@ -48,8 +56,10 @@ describe('managed catalog', () => {
 describe('managed resolution + back-compat aliases', () => {
   test('resolves current ids', () => {
     expect(getManagedModel('claude-opus-4.8')?.name).toBe('Claude Opus 4.8');
-    expect(getManagedModel('kimi-k2')?.bedrockModelId).toBe('moonshotai.kimi-k2.5');
+    expect(getManagedModel('kimi-k2')?.upstreamModelId).toBe('moonshotai.kimi-k2.5');
     expect(getManagedModel('kimi-k2')?.transport).toBe('bedrock-converse');
+    expect(getManagedModel('glm-4.6')?.transport).toBe('openrouter');
+    expect(getManagedModel('glm-4.6')?.upstreamModelId).toBe('z-ai/glm-4.6');
   });
 
   test('retired branded ids still resolve (to the nearest current model) so stored configs do not break', () => {


### PR DESCRIPTION
## Drop OpenRouter, serve everything from Bedrock

The Kimi K2 error — `"No allowed providers are available for the selected model"` (404, `available_providers:["novita"]`) — is OpenRouter's per-provider routing: Kimi only routes through `novita`, which the account's data policy excludes. We don't even set a provider filter; it's OpenRouter account behavior. Bedrock hosts these models natively and behaves consistently, so this moves the managed catalog to **Bedrock-only**.

### Verified live on Bedrock (us-west-2)
- ✅ **DeepSeek V3.2** + **Kimi K2.5** — do tool-calling via the Converse API (returned a real `toolUse`).
- ❌ **DeepSeek R1** — `"This model doesn't support tool use"`; dropped (opencode always sends tools).
- ❌ **Qwen / GLM** — not on Bedrock at all; dropped.

### New `bedrock-converse` transport
Our existing Bedrock transport only speaks the Anthropic InvokeModel payload, so non-Anthropic models need the model-agnostic **Converse API**. The new transport:
- **Request**: OpenAI chat-completions → Converse — messages, system, `inferenceConfig`, and full tool support (`toolConfig`/`toolSpec`, assistant `toolUse`, `toolResult`, `toolChoice`).
- **Response**: parses the AWS **event-stream** binary framing (reads the `:event-type` header — Converse puts the event name there, unlike invoke's base64-`bytes` payload) and translates `messageStart`/`contentBlock*`/`messageStop`/`metadata` → OpenAI SSE, including **streamed `tool_calls`** + usage + `[DONE]`. Boundary-tested with synthetic frames (text + tool call).

### Catalog (Bedrock-only)
| id | Bedrock | transport |
|---|---|---|
| `claude-opus-4.8` | `us.anthropic.claude-opus-4-8` | invoke (unchanged) |
| `claude-sonnet-4.6` | `us.anthropic.claude-sonnet-4-6` | invoke (unchanged) |
| `deepseek-v3.2` | `deepseek.v3.2` | **converse** |
| `kimi-k2` | `moonshotai.kimi-k2.5` | **converse** |

`ManagedModel` now carries an explicit `transport` + `bedrockModelId` + `pricingRef` (models.dev id for live pricing); `openRouterModelId` removed. `managedCandidates` is a single Bedrock descriptor keyed on the model's transport; the OpenRouter descriptor is gone. Anthropic stays on the proven invoke path.

### Tests
3 new transport tests (request translation incl. tools/tool-results; streaming text+tool-call event-stream → OpenAI SSE). 63 gateway-core + 9 catalog tests green; shared/core/api typecheck clean.

> Final streaming-wire validation lands on the dev deploy (CLI has no `converse-stream` op); the non-streaming Converse shape + models + tool support are all confirmed live.
