### PR TITLE
feat(gateway): BYOK fallback to a managed model on rate-limit/quota

### DIFF
--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -208,6 +208,10 @@ const envSchema = z.object({
   // Empty = the in-API gateway at `${KORTIX_URL}/v1/llm`. Set to a standalone
   // gateway's public base (…/v1/llm) to route every sandbox model call there.
   LLM_GATEWAY_BASE_URL:        optStr,
+  // BYOK resilience: when a user's own provider key hits a rate-limit / quota /
+  // billing error (429/402/403), fall over to THIS managed model (billed as
+  // Kortix credits) so the turn survives instead of erroring. Empty disables.
+  LLM_GATEWAY_BYOK_FALLBACK_MODEL: optStrDefault('claude-sonnet-4.6'),
   // Dev: reverse-proxy /v1/llm-gateway/* to a standalone gateway on this port,
   // so sandboxes reach it through the API's own tunnel (no separate tunnel).
   LLM_GATEWAY_PROXY_PORT:      optInt(0),
@@ -599,6 +603,7 @@ export const config = {
   OPENROUTER_API_KEY: env.OPENROUTER_API_KEY,
   LLM_GATEWAY_ENABLED: env.LLM_GATEWAY_ENABLED,
   LLM_GATEWAY_BASE_URL: env.LLM_GATEWAY_BASE_URL,
+  LLM_GATEWAY_BYOK_FALLBACK_MODEL: env.LLM_GATEWAY_BYOK_FALLBACK_MODEL,
   LLM_GATEWAY_PROXY_PORT: env.LLM_GATEWAY_PROXY_PORT,
   LLM_GATEWAY_PROXY_TARGET: env.LLM_GATEWAY_PROXY_TARGET,
   AWS_BEDROCK_REGION: env.AWS_BEDROCK_REGION,

--- a/apps/api/src/llm-gateway/resolution/resolve-candidates.ts
+++ b/apps/api/src/llm-gateway/resolution/resolve-candidates.ts
@@ -11,6 +11,18 @@ import { codexDescriptor, livePricing, managedCandidates } from './descriptors';
 
 const PLATFORM_FEE_MARKUP = 0.1;
 
+// A managed model to fall over to when a BYOK key hits a limit (429/402/403).
+// Gated on the managed gateway being on + a configured, resolvable fallback
+// model. managedCandidates() is itself empty when no managed key is set, so a
+// self-host with no Bedrock/OpenRouter key naturally has no fallback.
+function byokFallbackCandidates(): UpstreamDescriptor[] {
+  if (!config.LLM_GATEWAY_ENABLED) return [];
+  const fallbackId = config.LLM_GATEWAY_BYOK_FALLBACK_MODEL;
+  if (!fallbackId) return [];
+  const managed = getManagedModel(fallbackId);
+  return managed ? managedCandidates(managed) : [];
+}
+
 export async function resolveCandidates(
   principal: AuthedPrincipal,
   model: string,
@@ -28,18 +40,20 @@ export async function resolveCandidates(
   if (byok && principal.projectId) {
     const key = await getProjectSecretValue(principal.projectId, byok.envVar);
     if (key) {
-      return [
-        {
-          provider,
-          kind: byok.kind,
-          baseUrl: byok.baseUrl,
-          apiKey: key,
-          billingMode: config.KORTIX_BILLING_INTERNAL_ENABLED ? 'platform-fee' : 'none',
-          markup: PLATFORM_FEE_MARKUP,
-          resolvedModel: model.slice(provider.length + 1),
-          pricing: livePricing(model.slice(provider.length + 1)),
-        },
-      ];
+      const byokDescriptor: UpstreamDescriptor = {
+        provider,
+        kind: byok.kind,
+        baseUrl: byok.baseUrl,
+        apiKey: key,
+        billingMode: config.KORTIX_BILLING_INTERNAL_ENABLED ? 'platform-fee' : 'none',
+        markup: PLATFORM_FEE_MARKUP,
+        resolvedModel: model.slice(provider.length + 1),
+        pricing: livePricing(model.slice(provider.length + 1)),
+      };
+      // Queue a managed model behind the BYOK key: if the user's key hits a
+      // rate-limit / quota / billing error, the failover loop falls over to it
+      // (billed as Kortix credits) so the turn doesn't die.
+      return [byokDescriptor, ...byokFallbackCandidates()];
     }
   }
 

--- a/packages/llm-gateway/src/pipeline/failover.ts
+++ b/packages/llm-gateway/src/pipeline/failover.ts
@@ -4,6 +4,11 @@ import { callUpstream, type FetchImpl } from '../http';
 import type { GatewayConfig, UpstreamDescriptor } from '../domain';
 import type { TraceEmitter, TraceFields } from './trace';
 
+// 4xx statuses that mean "this upstream won't serve you right now" rather than
+// "your request is wrong" — rate limit, payment required, quota/forbidden. These
+// are the ones worth failing over (e.g. BYOK out of quota → managed fallback).
+const LIMIT_STATUSES = new Set([402, 403, 429]);
+
 function json(data: unknown, status = 200): Response {
   return new Response(JSON.stringify(data), {
     status,
@@ -43,7 +48,9 @@ export async function runFailover(ctx: FailoverContext): Promise<FailoverResult>
   let chosen: UpstreamDescriptor | null = null;
   let lastError: unknown;
 
-  for (const descriptor of candidates) {
+  for (let i = 0; i < candidates.length; i += 1) {
+    const descriptor = candidates[i];
+    const hasFallback = i < candidates.length - 1;
     tried.push(descriptor.provider);
     attempts += 1;
     try {
@@ -57,6 +64,15 @@ export async function runFailover(ctx: FailoverContext): Promise<FailoverResult>
     } catch (err) {
       lastError = err;
       if (err instanceof UpstreamHttpError && err.status >= 400 && err.status < 500) {
+        // A rate-limit / quota / billing error (429/402/403) on a candidate that
+        // has a fallback behind it — e.g. a user's BYOK key out of quota, with a
+        // managed model queued next — falls over instead of failing the turn.
+        // (429 was already retried on this candidate by callUpstream, so reaching
+        // here means it's persistent, not a transient blip.) Other 4xx — bad
+        // request, auth, model-not-found — are the caller's to fix: return as-is.
+        if (LIMIT_STATUSES.has(err.status) && hasFallback) {
+          continue;
+        }
         emit({
           ...trace, resolvedModel: descriptor.resolvedModel, provider: descriptor.provider,
           billingMode: descriptor.billingMode, status: err.status, ok: false,

--- a/packages/llm-gateway/src/pipeline/handler.test.ts
+++ b/packages/llm-gateway/src/pipeline/handler.test.ts
@@ -239,4 +239,71 @@ describe('gateway.chatCompletions', () => {
     expect(second.status).toBe(503);
     expect((await second.json()).code).toBe('upstream_unavailable');
   });
+
+  // BYOK-out-of-quota → managed fallback. resolveUpstream queues a managed model
+  // behind the user's own key; a 429/402/403 on the key falls over to it.
+  const byok: UpstreamDescriptor = {
+    provider: 'anthropic',
+    kind: 'openai-compat',
+    baseUrl: 'https://byok.test/v1',
+    apiKey: 'user-key',
+    billingMode: 'none',
+    markup: 0,
+  };
+  const completion = JSON.stringify({
+    id: 'x',
+    choices: [{ message: { content: 'ok' } }],
+    usage: { prompt_tokens: 1, completion_tokens: 1 },
+  });
+  const byokBody = '{"model":"anthropic/claude","messages":[]}';
+
+  test('a BYOK rate-limit (429) falls over to the managed fallback', async () => {
+    const { hooks, traces } = makeHooks({ resolveUpstream: async () => [byok, managed] });
+    const fetchImpl: FetchImpl = async (url) =>
+      String(url).includes('byok.test')
+        ? new Response('{"error":"rate_limit"}', { status: 429 })
+        : new Response(completion, { status: 200, headers: { 'content-type': 'application/json' } });
+    const res = await createGateway(hooks, { retry: fastRetry }, { fetchImpl }).chatCompletions({
+      authorization: 'Bearer good',
+      rawBody: byokBody,
+    });
+    expect(res.status).toBe(200);
+    await flush();
+    const ok = traces.find((t) => t.ok);
+    expect(ok?.provider).toBe('openrouter'); // fell over from byok(anthropic) → managed
+    expect(ok?.candidatesTried).toEqual(['anthropic', 'openrouter']);
+  });
+
+  test('a quota error (402) also falls over to the fallback', async () => {
+    const { hooks } = makeHooks({ resolveUpstream: async () => [byok, managed] });
+    const fetchImpl: FetchImpl = async (url) =>
+      String(url).includes('byok.test')
+        ? new Response('{"error":"insufficient_quota"}', { status: 402 })
+        : new Response(completion, { status: 200, headers: { 'content-type': 'application/json' } });
+    const res = await createGateway(hooks, { retry: fastRetry }, { fetchImpl }).chatCompletions({
+      authorization: 'Bearer good',
+      rawBody: byokBody,
+    });
+    expect(res.status).toBe(200);
+  });
+
+  test('a non-limit BYOK 4xx (400 bad request) returns as-is — no fallback', async () => {
+    const { hooks } = makeHooks({ resolveUpstream: async () => [byok, managed] });
+    const fetchImpl: FetchImpl = async () => new Response('{"error":"bad_request"}', { status: 400 });
+    const res = await createGateway(hooks, { retry: fastRetry }, { fetchImpl }).chatCompletions({
+      authorization: 'Bearer good',
+      rawBody: byokBody,
+    });
+    expect(res.status).toBe(400);
+  });
+
+  test('a 429 with no fallback candidate is returned, not swallowed', async () => {
+    const { hooks } = makeHooks({ resolveUpstream: async () => [byok] });
+    const fetchImpl: FetchImpl = async () => new Response('{"error":"rate_limit"}', { status: 429 });
+    const res = await createGateway(hooks, { retry: { ...fastRetry, maxAttempts: 1 } }, { fetchImpl }).chatCompletions({
+      authorization: 'Bearer good',
+      rawBody: byokBody,
+    });
+    expect(res.status).toBe(429);
+  });
 });


### PR DESCRIPTION
## BYOK out of quota → fall over to a Kortix managed model

When a user brings their own provider key (BYOK) and it hits a **rate-limit / quota / billing** error, the agent turn currently just dies. Now it falls over to a Kortix managed model so the work continues.

### How it works
1. **Resolution** queues a managed model behind the BYOK key:
   ```
   resolveCandidates(...) → [ byokDescriptor, ...managed(claude-sonnet-4.6) ]
   ```
   Gated on the managed gateway being on + a configured, resolvable fallback model (`LLM_GATEWAY_BYOK_FALLBACK_MODEL`, default `claude-sonnet-4.6`; empty disables). A self-host with no Bedrock/OpenRouter key has no fallback (managed candidates are empty), so this is naturally off there.
2. **Failover** now treats `429 / 402 / 403` as *fail-over-able* when a fallback exists, instead of returning every 4xx immediately. `429` is still retried on the BYOK key first (transient blips), so reaching the fallover means the limit is **persistent**. Genuine client errors (`400` bad request, `401` auth, `404` model-not-found) still return as-is — a fallback would only hide the caller's bug.

### Billing / observability
The managed fallback is **credits-billed**, so when the user's own key is exhausted they pay Kortix credits (the intended trade — keep working vs. hard-stop). The success trace records the fallover: `provider=<managed>`, `candidatesTried=[<byok>, <managed>]`, so it's visible in logs/spend.

### Tests
4 new (in `handler.test.ts`): `429` and `402` fall over to managed and return 200; a non-limit `400` returns as-is (no fallback); a `429` with no fallback candidate is returned, not swallowed. 64 gateway-core tests green; core + api typecheck clean.

> Independent of the catalog/transport PRs — touches only the resolve/failover path. Branched off `main`.
