### PR TITLE
fix(deploy-prod): set DATABASE_URL for sidecar canonical-schema migrate

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -622,6 +622,8 @@ jobs:
           npm_config_engine_strict: "false"
       - run: sudo apt-get update && sudo apt-get install -y --no-install-recommends postgresql-client
       - name: Build canonical schema from migrations (sidecar)
+        env:
+          DATABASE_URL: ${{ env.CANONICAL_DB_URL }}
         run: |
           psql "$CANONICAL_DB_URL" -v ON_ERROR_STOP=1 -f packages/db/scripts/test-prereqs.sql
           pnpm --filter @kortix/db migrate


### PR DESCRIPTION
## Problem

The in-flight prod deploy (`v0.9.74`) failed in the **verify-schema** job:

```
> @kortix/db migrate
> bun scripts/migrate.ts up
No DB URL. Set $DATABASE_URL or pass --target=<env>.
ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  @kortix/db@1.0.0 migrate
```

`verify-schema` builds a canonical schema in a sidecar Postgres and runs `node-pg-migrate` against it to assert prod has every table+column the migrations define. But the step only set `CANONICAL_DB_URL` in the job env — `node-pg-migrate` reads `DATABASE_URL`, which was never set. This is a leftover from the Drizzle → node-pg-migrate engine switch.

`deploy-api` **needs** `verify-schema`, so this one broken step blocked the prod **API** roll. (`deploy-gateway` doesn't depend on it, so the gateway rolled fine.)

## Fix

Set `DATABASE_URL: ${{ env.CANONICAL_DB_URL }}` on the sidecar migrate step so it migrates the throwaway canonical DB. The real prod migrate (`migrate-db` job) already sets `DATABASE_URL=PROD_DATABASE_URL` and is untouched.

One-line workflow fix, no app code.
