### PR TITLE
Test preview URL fallback detection

### DIFF
--- a/apps/web/src/features/session/preview-url-fallback.test.ts
+++ b/apps/web/src/features/session/preview-url-fallback.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from 'bun:test';
+
+import { prefersPreviewLink } from './preview-url-fallback';
+
+describe('prefersPreviewLink', () => {
+  test('uses a link-only preview for document urls', () => {
+    expect(prefersPreviewLink('https://api.kortix.com/v1/p/sandbox/3210/deck.pdf')).toBe(true);
+    expect(prefersPreviewLink('https://api.kortix.com/v1/p/sandbox/3210/deck.pptx?download=1')).toBe(true);
+    expect(prefersPreviewLink('/v1/p/sandbox/3210/report.doc#page=2')).toBe(true);
+    expect(prefersPreviewLink('/v1/p/sandbox/3210/sheet.xlsx')).toBe(true);
+  });
+
+  test('keeps regular web previews in iframes', () => {
+    expect(prefersPreviewLink('https://api.kortix.com/v1/p/sandbox/3000/')).toBe(false);
+    expect(prefersPreviewLink('https://api.kortix.com/v1/p/sandbox/3000/index.html')).toBe(false);
+    expect(prefersPreviewLink('/v1/p/sandbox/3210/presentation.pdf/preview')).toBe(false);
+    expect(prefersPreviewLink(null)).toBe(false);
+  });
+});

--- a/apps/web/src/features/session/preview-url-fallback.ts
+++ b/apps/web/src/features/session/preview-url-fallback.ts
@@ -1,0 +1,11 @@
+const LINK_ONLY_PREVIEW_EXT_RE = /\.(pdf|docx?|pptx?|xlsx?)(?:[?#]|$)/i;
+
+export function prefersPreviewLink(candidateUrl: string | null): boolean {
+  if (!candidateUrl) return false;
+  try {
+    const url = new URL(candidateUrl);
+    return LINK_ONLY_PREVIEW_EXT_RE.test(`${url.pathname}${url.search}`);
+  } catch {
+    return LINK_ONLY_PREVIEW_EXT_RE.test(candidateUrl);
+  }
+}

--- a/apps/web/src/features/session/tool-renderers.tsx
+++ b/apps/web/src/features/session/tool-renderers.tsx
@@ -12,6 +12,7 @@ import { TextShimmer } from '@/components/ui/text-shimmer';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { useFileContent } from '@/features/files/hooks/use-file-content';
 import { QuestionPrompt } from '@/features/session/question-prompt';
+import { prefersPreviewLink } from '@/features/session/preview-url-fallback';
 import { SubSessionModal } from '@/features/session/sub-session-modal';
 import {
   extractReadableHtml,
@@ -299,18 +300,6 @@ function useServicePreview(url: string, label?: string, sessionId?: string) {
 }
 
 type ServicePreviewState = ReturnType<typeof useServicePreview>;
-
-const LINK_ONLY_PREVIEW_EXT_RE = /\.(pdf|docx?|pptx?|xlsx?)(?:[?#]|$)/i;
-
-function prefersPreviewLink(candidateUrl: string | null): boolean {
-  if (!candidateUrl) return false;
-  try {
-    const url = new URL(candidateUrl);
-    return LINK_ONLY_PREVIEW_EXT_RE.test(`${url.pathname}${url.search}`);
-  } catch {
-    return LINK_ONLY_PREVIEW_EXT_RE.test(candidateUrl);
-  }
-}
 
 function ServicePreviewUrlFallback({ preview }: { preview: ServicePreviewState }) {
   const { previewUrl, displayLabel, handleRefresh, openInBrowser } = preview;


### PR DESCRIPTION
## Summary
- extract preview link-only detection into a focused helper
- add bun:test coverage for PDF/Office URLs defaulting to link-only previews and regular web URLs staying iframe previews

## Verification
- pnpm --dir apps/web exec bun test src/features/session/preview-url-fallback.test.ts
- pnpm --dir apps/web exec eslint src/features/session/tool-renderers.tsx src/features/session/preview-url-fallback.ts src/features/session/preview-url-fallback.test.ts --max-warnings=0
- pnpm --dir apps/web exec tsc --noEmit --pretty false | rg "src/features/session/(tool-renderers|preview-url-fallback)(\.test)?\.tsx?|features/session/(tool-renderers|preview-url-fallback)(\.test)?\.tsx?"