### PR TITLE
feat(llm-gateway): prefix prompt caching (fixes latency growing with chat length)

### DIFF
--- a/packages/llm-gateway/src/transports/anthropic/anthropic.test.ts
+++ b/packages/llm-gateway/src/transports/anthropic/anthropic.test.ts
@@ -32,10 +32,14 @@ describe('buildAnthropicRequest', () => {
     expect(req.headers['x-api-key']).toBe('sk-ant-test');
     expect(req.headers['anthropic-version']).toBeTruthy();
     expect(req.payload.model).toBe('claude-sonnet-4-6');
-    expect(req.payload.system).toBe('be nice');
+    expect(req.payload.system).toEqual([
+      { type: 'text', text: 'be nice', cache_control: { type: 'ephemeral' } },
+    ]);
     expect(req.payload.max_tokens).toBeGreaterThan(0);
     expect(req.payload.stream).toBe(true);
-    expect(req.payload.messages).toEqual([{ role: 'user', content: 'hi' }]);
+    expect(req.payload.messages).toEqual([
+      { role: 'user', content: [{ type: 'text', text: 'hi', cache_control: { type: 'ephemeral' } }] },
+    ]);
   });
 
   test('normalizes dotted catalog ids to Anthropic dashed model names', () => {
@@ -57,6 +61,59 @@ describe('buildAnthropicRequest', () => {
       descriptor,
     );
     expect((req.payload.tools as any[])[0]).toMatchObject({ name: 'search', description: 'd' });
+  });
+});
+
+describe('buildAnthropicRequest — prompt caching', () => {
+  test('marks system, the last tool, and the conversation tail as cacheable', () => {
+    const req = buildAnthropicRequest(
+      {
+        messages: [
+          { role: 'system', content: 'a long stable system prompt' },
+          { role: 'user', content: 'first' },
+          { role: 'assistant', content: 'ok' },
+          { role: 'user', content: 'second' },
+        ],
+        tools: [
+          { type: 'function', function: { name: 'a', parameters: { type: 'object' } } },
+          { type: 'function', function: { name: 'b', parameters: { type: 'object' } } },
+        ],
+      },
+      descriptor,
+    );
+    const p = req.payload as any;
+    expect(p.system).toEqual([
+      { type: 'text', text: 'a long stable system prompt', cache_control: { type: 'ephemeral' } },
+    ]);
+    expect(p.tools[0].cache_control).toBeUndefined();
+    expect(p.tools[1].cache_control).toEqual({ type: 'ephemeral' });
+    const lastMsg = p.messages[p.messages.length - 1];
+    expect(lastMsg.content).toEqual([
+      { type: 'text', text: 'second', cache_control: { type: 'ephemeral' } },
+    ]);
+    const firstUser = p.messages[0];
+    expect(firstUser.content).toBe('first');
+  });
+
+  test('adds the breakpoint to the final block of an array-content tail message', () => {
+    const req = buildAnthropicRequest(
+      {
+        messages: [
+          { role: 'user', content: 'hi' },
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'look' },
+              { type: 'text', text: 'at this' },
+            ],
+          },
+        ],
+      },
+      descriptor,
+    );
+    const tail = (req.payload as any).messages.at(-1).content;
+    expect(tail[0].cache_control).toBeUndefined();
+    expect(tail[1].cache_control).toEqual({ type: 'ephemeral' });
   });
 });
 

--- a/packages/llm-gateway/src/transports/anthropic/request.ts
+++ b/packages/llm-gateway/src/transports/anthropic/request.ts
@@ -105,6 +105,33 @@ function translateToolChoice(tc: unknown): unknown {
   return undefined;
 }
 
+const EPHEMERAL = { type: 'ephemeral' } as const;
+
+function cacheTailBlock(message: any): void {
+  if (!message) return;
+  const content = message.content;
+  if (typeof content === 'string') {
+    if (content) message.content = [{ type: 'text', text: content, cache_control: EPHEMERAL }];
+    return;
+  }
+  if (Array.isArray(content) && content.length) {
+    const last = content[content.length - 1];
+    if (last && typeof last === 'object') last.cache_control = EPHEMERAL;
+  }
+}
+
+function applyPromptCaching(payload: Record<string, any>): void {
+  if (typeof payload.system === 'string' && payload.system) {
+    payload.system = [{ type: 'text', text: payload.system, cache_control: EPHEMERAL }];
+  }
+  if (Array.isArray(payload.tools) && payload.tools.length) {
+    payload.tools[payload.tools.length - 1].cache_control = EPHEMERAL;
+  }
+  if (Array.isArray(payload.messages) && payload.messages.length) {
+    cacheTailBlock(payload.messages[payload.messages.length - 1]);
+  }
+}
+
 export function buildAnthropicCorePayload(body: Record<string, any>): Record<string, unknown> {
   const { system, messages } = translateMessages(body.messages ?? []);
 
@@ -122,6 +149,7 @@ export function buildAnthropicCorePayload(body: Record<string, any>): Record<str
   const toolChoice = translateToolChoice(body.tool_choice);
   if (toolChoice) payload.tool_choice = toolChoice;
 
+  applyPromptCaching(payload);
   return payload;
 }
 

--- a/packages/llm-gateway/src/transports/bedrock-converse/bedrock-converse.test.ts
+++ b/packages/llm-gateway/src/transports/bedrock-converse/bedrock-converse.test.ts
@@ -52,6 +52,29 @@ describe('buildBedrockConverseRequest', () => {
   });
 });
 
+describe('buildBedrockConverseRequest — prompt caching (gated)', () => {
+  const body = {
+    messages: [
+      { role: 'system', content: 'stable preamble' },
+      { role: 'user', content: 'question' },
+    ],
+    tools: [{ function: { name: 'wx', parameters: { type: 'object' } } }],
+  };
+
+  test('inserts cachePoint blocks for a cache-supporting family', () => {
+    const p = buildBedrockConverseRequest(body, { ...descriptor, resolvedModel: 'anthropic.claude-sonnet-4' }).payload as any;
+    expect(p.system.at(-1)).toEqual({ cachePoint: { type: 'default' } });
+    expect(p.toolConfig.tools.at(-1)).toEqual({ cachePoint: { type: 'default' } });
+    expect(p.messages.at(-1).content.at(-1)).toEqual({ cachePoint: { type: 'default' } });
+  });
+
+  test('does NOT insert cachePoint for a model that rejects it', () => {
+    const p = buildBedrockConverseRequest(body, { ...descriptor, resolvedModel: 'deepseek.v3.2' }).payload as any;
+    expect(p.system).toEqual([{ text: 'stable preamble' }]);
+    expect(JSON.stringify(p)).not.toContain('cachePoint');
+  });
+});
+
 const enc = new TextEncoder();
 
 // One AWS event-stream string header: 1B name-len · name · 1B type(7) · 2B val-len · val.

--- a/packages/llm-gateway/src/transports/bedrock-converse/request.ts
+++ b/packages/llm-gateway/src/transports/bedrock-converse/request.ts
@@ -109,6 +109,23 @@ function toolConfig(body: Record<string, any>): Record<string, unknown> | undefi
   return cfg;
 }
 
+const CACHEABLE_CONVERSE_MODEL = /claude|nova/i;
+
+function applyConverseCaching(payload: Record<string, any>, modelId: string): void {
+  if (!CACHEABLE_CONVERSE_MODEL.test(modelId)) return;
+  if (Array.isArray(payload.system) && payload.system.length) {
+    payload.system.push({ cachePoint: { type: 'default' } });
+  }
+  const tools = payload.toolConfig?.tools;
+  if (Array.isArray(tools) && tools.length) {
+    tools.push({ cachePoint: { type: 'default' } });
+  }
+  if (Array.isArray(payload.messages) && payload.messages.length) {
+    const last = payload.messages[payload.messages.length - 1];
+    if (Array.isArray(last?.content)) last.content.push({ cachePoint: { type: 'default' } });
+  }
+}
+
 export function buildBedrockConverseRequest(
   body: Record<string, any>,
   descriptor: UpstreamDescriptor,
@@ -128,6 +145,7 @@ export function buildBedrockConverseRequest(
   if (tc) payload.toolConfig = tc;
 
   const modelId = descriptor.resolvedModel || String(body.model ?? '');
+  applyConverseCaching(payload, modelId);
   const action = body.stream === true ? 'converse-stream' : 'converse';
 
   const headers: Record<string, string> = {

--- a/packages/llm-gateway/src/transports/bedrock/bedrock.test.ts
+++ b/packages/llm-gateway/src/transports/bedrock/bedrock.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from 'bun:test';
+import type { UpstreamDescriptor } from '../../domain';
+import { buildBedrockRequest } from './request';
+
+const descriptor: UpstreamDescriptor = {
+  provider: 'bedrock',
+  kind: 'bedrock',
+  baseUrl: 'https://bedrock-runtime.us-west-2.amazonaws.com',
+  apiKey: 'bedrock-key',
+  billingMode: 'credits',
+  markup: 1,
+  resolvedModel: 'us.anthropic.claude-sonnet-4-6',
+};
+
+describe('buildBedrockRequest', () => {
+  test('targets the Anthropic InvokeModel endpoint with the bedrock anthropic_version', () => {
+    const req = buildBedrockRequest({ messages: [{ role: 'user', content: 'hi' }] }, descriptor);
+    expect(req.url).toBe(
+      'https://bedrock-runtime.us-west-2.amazonaws.com/model/us.anthropic.claude-sonnet-4-6/invoke',
+    );
+    expect(req.headers.authorization).toBe('Bearer bedrock-key');
+    expect((req.payload as any).anthropic_version).toBe('bedrock-2023-05-31');
+  });
+
+  test('uses the streaming action when stream is set', () => {
+    const req = buildBedrockRequest({ stream: true, messages: [{ role: 'user', content: 'hi' }] }, descriptor);
+    expect(req.url).toEndWith('/invoke-with-response-stream');
+  });
+
+  test('carries prompt-cache breakpoints through to the InvokeModel payload', () => {
+    const req = buildBedrockRequest(
+      {
+        messages: [
+          { role: 'system', content: 'stable preamble' },
+          { role: 'user', content: 'question' },
+        ],
+        tools: [{ function: { name: 'wx', parameters: { type: 'object' } } }],
+      },
+      descriptor,
+    );
+    const p = req.payload as any;
+    expect(p.system).toEqual([
+      { type: 'text', text: 'stable preamble', cache_control: { type: 'ephemeral' } },
+    ]);
+    expect(p.tools.at(-1).cache_control).toEqual({ type: 'ephemeral' });
+    expect(p.messages.at(-1).content.at(-1)).toEqual({
+      type: 'text',
+      text: 'question',
+      cache_control: { type: 'ephemeral' },
+    });
+  });
+});


### PR DESCRIPTION
## Why

Responses got slower (and pricier) the longer a chat ran. Root cause: the gateway transports **reconstruct** the prompt every turn and **never set a cache breakpoint**, so the managed Claude path (Bedrock InvokeModel) re-prefilled the *entire* transcript on every request. Prefill cost scales with prompt length → latency climbs ~linearly instead of plateauing. Confirmed there was **zero** cache support anywhere in `packages/llm-gateway` before this.

## What

**Anthropic + Bedrock InvokeModel** (`buildAnthropicCorePayload`, shared by both transports — this is the default Claude Opus/Sonnet path):
- `cache_control: { type: 'ephemeral' }` on the system block, the last tool, and the tail of the last message.
- Each turn now reads the prior conversation prefix from cache and only prefills the new tokens.
- System (a string) is promoted to Anthropic's array-content form so it can carry the breakpoint.
- Safe unconditionally: below the provider's min-cache token threshold Anthropic just ignores the field.

**Bedrock Converse** (Kimi/MiniMax):
- Inserts Converse `cachePoint` blocks after system, after tools, and at the tail.
- **Gated** to families known to support it (`claude`/`nova`) — unsupported models *reject* `cachePoint` with a validation error, so current Converse models stay untouched until support is confirmed.

## Impact

- Latency stops growing with chat length (prefix is a cache hit within the provider TTL).
- Cached input tokens bill at ~10% of base → managed cost drops too.

## Tests

`bun test packages/llm-gateway/src` → 82 pass. Added cases: breakpoints land on system/last-tool/tail (string + array content), and the Converse gate inserts `cachePoint` for a supported family but **not** for `deepseek.v3.2`. tsc clean.

Note: this is **prefix caching** (in-conversation), distinct from the cross-request "response caching" tracked separately.
