### PR TITLE
revert(prod): roll back FE & BE to v0.9.68 [INCIDENT]

### DIFF
--- a/infra/k8s/envs/prod/gateway-values.yaml
+++ b/infra/k8s/envs/prod/gateway-values.yaml
@@ -4,8 +4,9 @@
 # deploy; git revert is the rollback.
 
 # Immutable release tag (promote bumps this). NOT :latest in GitOps.
+# ROLLBACK 2026-06-23: pinned to the existing :0.9.68 release image (zero rebuild).
 image:
-  tag: "0.9.77"
+  tag: "0.9.68"
 # Prod HA: 3-replica floor, burst to 12 (matches the API's envelope).
 replicas: 3
 autoscaling:

--- a/infra/k8s/envs/prod/values.yaml
+++ b/infra/k8s/envs/prod/values.yaml
@@ -4,9 +4,13 @@
 # `git revert` is the rollback. Verified by `argocd app get kortix-prod`.
 
 # Immutable release tag (promote bumps this). NOT :latest / :dev-latest in GitOps.
+# ROLLBACK 2026-06-23: pinned to the existing :0.9.68 release image (Argo pulls it,
+# zero rebuild). The root VERSION file is left at 0.9.77 on purpose so deploy-prod's
+# retag job targets :0.9.77 and can NEVER overwrite this :0.9.68 rollback image.
+# The next promote of latest `main` supersedes this (merge -s ours) and moves forward.
 image:
-  tag: "0.9.77"
-kortixVersion: "0.9.77"
+  tag: "0.9.68"
+kortixVersion: "0.9.68"
 env:
   internalKortixEnv: prod
 # Explicit container env (overrides the kortix-prod-env secret bundle — k8s env


### PR DESCRIPTION
## 🔴 Production rollback → v0.9.68 (incident)

Rolls **backend** (EKS) to the existing `:0.9.68` release image. Frontend is rolled back in parallel on Vercel (see below) — this PR is the BE half.

### What this does
- `infra/k8s/envs/prod/values.yaml` — `image.tag` + `kortixVersion` → **0.9.68** (kortix-api)
- `infra/k8s/envs/prod/gateway-values.yaml` — `image.tag` → **0.9.68** (kortix-gateway)
- On merge, **Argo CD** reconciles both Deployments to the prebuilt `:0.9.68` images — **zero rebuild**.

### Why it's safe
- **DB:** every migration since v0.9.68 is additive or a no-op (`drop-discontinued-tables` hit already-absent, unused tables; the rest only `ADD COLUMN/VALUE`/`CREATE … IF NOT EXISTS`). Live schema is a strict **superset** of what 0.9.68 needs → **no down-migration, leave the DB as-is**.
- **Canary/pod-health:** if a `:0.9.68` image were somehow missing, new pods never go Ready and current pods keep serving — the rollback **cannot cause an outage**.
- **VERSION left at 0.9.77** on purpose → deploy-prod's retag job targets `:0.9.77`, so it can **never overwrite** the `:0.9.68` rollback image.

### Expected noise on merge (cosmetic, ignore)
`deploy-prod` fires on the prod push and will go **partly red**: the version-watch job waits for `0.9.77` but pods report `0.9.68`, and the release-create step re-hits the existing `v0.9.77` release. **Argo does the actual roll independently of deploy-prod** — judge success by Argo health + `api.kortix.com/health`, not by the deploy-prod run.

### ⚠️ Coordinate before merging
**A `v0.9.77` release was merged to prod minutes ago (#3727)** — someone may be fixing *forward*. Confirm the team wants to roll *back* to 0.9.68 before merging this.

### Recovery path
Next `promote` of latest `main` supersedes this cleanly (`merge -s ours`) and moves prod forward — no manual cleanup of the branch state needed.

### Frontend (do AFTER merging this)
Vercel → **kortix.com** project → Deployments → the **v0.9.68** production deployment (prod branch, ~2026-06-21) → **⋯ → Instant Rollback / Promote to Production**. Do this *after* the merge so a Vercel rebuild can't clobber it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)