### PR TITLE
feat(gateway): run-path logging + small_model pin + longer sandbox autostop

### DIFF
--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -320,7 +320,7 @@ const envSchema = z.object({
   //   autodelete → NEVER (-1). A sandbox is only ever removed when a user
   //                explicitly deletes the session — auto-stop + cold archive
   //                make an idle box nearly free, so we never destroy disk.
-  KORTIX_SANDBOX_AUTOSTOP_MINUTES:    optInt(15),
+  KORTIX_SANDBOX_AUTOSTOP_MINUTES:    optInt(120),
   KORTIX_SANDBOX_AUTOARCHIVE_MINUTES: optInt(4320),   // 3 days
   KORTIX_SANDBOX_AUTODELETE_MINUTES:  optInt(-1),     // never auto-delete
 

--- a/apps/kortix-sandbox-agent-server/src/opencode.ts
+++ b/apps/kortix-sandbox-agent-server/src/opencode.ts
@@ -101,6 +101,9 @@ export async function buildOpencodeConfigContent(env: NodeJS.ProcessEnv): Promis
     if (!('model' in out) || typeof out.model !== 'string') {
       out.model = DEFAULT_KORTIX_MODEL
     }
+    if (!('small_model' in out) || typeof out.small_model !== 'string') {
+      out.small_model = DEFAULT_KORTIX_MODEL
+    }
     // Lock opencode to the gateway as the ONLY LLM path. enabled_providers is an
     // allowlist — opencode loads ONLY these and ignores every provider it would
     // otherwise auto-detect from env (e.g. GITHUB_TOKEN → GitHub Models,

--- a/apps/llm-gateway/src/observability/logger.ts
+++ b/apps/llm-gateway/src/observability/logger.ts
@@ -1,0 +1,46 @@
+import type { GatewayLogger } from '@kortix/llm-gateway';
+
+type Level = 'debug' | 'info' | 'warn' | 'error';
+
+const DEBUG_ENABLED = process.env.GATEWAY_DEBUG_LOGS !== 'false';
+
+function serialize(arg: unknown): unknown {
+  if (arg instanceof Error) return { error: arg.message, stack: arg.stack };
+  return arg;
+}
+
+function line(level: Level, args: unknown[]): string {
+  const [first, ...rest] = args;
+  const record: Record<string, unknown> = {
+    ts: new Date().toISOString(),
+    level,
+    msg: typeof first === 'string' ? first : undefined,
+  };
+  const details = (typeof first === 'string' ? rest : args).map(serialize);
+  if (details.length === 1 && details[0] && typeof details[0] === 'object') {
+    Object.assign(record, details[0]);
+  } else if (details.length) {
+    record.details = details;
+  }
+  return `${JSON.stringify(record)}\n`;
+}
+
+export function createGatewayLogger(): GatewayLogger {
+  const write = (level: Level, args: unknown[]) => {
+    const stream = level === 'warn' || level === 'error' ? process.stderr : process.stdout;
+    try {
+      stream.write(line(level, args));
+    } catch {
+      // a transient write failure must never break a request.
+    }
+  };
+
+  return {
+    debug: (...args) => {
+      if (DEBUG_ENABLED) write('debug', args);
+    },
+    info: (...args) => write('info', args),
+    warn: (...args) => write('warn', args),
+    error: (...args) => write('error', args),
+  };
+}

--- a/apps/llm-gateway/src/server.ts
+++ b/apps/llm-gateway/src/server.ts
@@ -3,6 +3,7 @@ import { createGateway } from '@kortix/llm-gateway';
 import { config } from './config';
 import { createApiClient } from './clients/api-client';
 import { createLangfuseSink, type TraceSink } from './observability/langfuse';
+import { createGatewayLogger } from './observability/logger';
 
 const STARTED_AT = Date.now();
 const SERVICE_VERSION = process.env.KORTIX_VERSION ?? 'dev';
@@ -20,6 +21,8 @@ export interface GatewayServer {
 
 export function buildServer(): GatewayServer {
   const api = createApiClient({ baseUrl: config.apiUrl, token: config.apiToken });
+
+  const logger = createGatewayLogger();
 
   const traces =
     config.langfuse.publicKey && config.langfuse.secretKey
@@ -52,6 +55,7 @@ export function buildServer(): GatewayServer {
       captureBodies: config.captureBodies,
       maxCapturedBodyBytes: config.maxCapturedBodyBytes,
     },
+    { logger },
   );
 
   // Rolling per-second traffic buckets feeding the health endpoint's error-rate

--- a/packages/llm-gateway/src/domain/logger.ts
+++ b/packages/llm-gateway/src/domain/logger.ts
@@ -2,4 +2,5 @@ export interface GatewayLogger {
   info(...args: unknown[]): void;
   warn(...args: unknown[]): void;
   error(...args: unknown[]): void;
+  debug?(...args: unknown[]): void;
 }

--- a/packages/llm-gateway/src/index.ts
+++ b/packages/llm-gateway/src/index.ts
@@ -45,6 +45,7 @@ export type {
   BillingMode,
   GatewayConfig,
   GatewayHooks,
+  GatewayLogger,
   GatewayTrace,
   ModelCatalog,
   ModelInfo,

--- a/packages/llm-gateway/src/pipeline/failover.ts
+++ b/packages/llm-gateway/src/pipeline/failover.ts
@@ -1,7 +1,7 @@
 import { CircuitOpenError, UpstreamHttpError } from '../errors';
 import { CircuitBreaker } from '../resilience';
 import { callUpstream, type FetchImpl } from '../http';
-import type { GatewayConfig, UpstreamDescriptor } from '../domain';
+import type { GatewayConfig, GatewayLogger, UpstreamDescriptor } from '../domain';
 import type { TraceEmitter, TraceFields } from './trace';
 
 // 4xx statuses that mean "this upstream won't serve you right now" rather than
@@ -27,6 +27,8 @@ export interface FailoverContext {
   fetchImpl?: FetchImpl;
   breakerFor: (provider: string) => CircuitBreaker;
   emit: TraceEmitter;
+  logger: GatewayLogger;
+  requestId: string;
   trace: Partial<TraceFields>;
   capturedRequest: unknown;
 }
@@ -41,28 +43,66 @@ export interface FailoverSuccess {
 export type FailoverResult = { kind: 'response'; response: Response } | { kind: 'success'; value: FailoverSuccess };
 
 export async function runFailover(ctx: FailoverContext): Promise<FailoverResult> {
-  const { candidates, payload, config, fetchImpl, breakerFor, emit, trace, capturedRequest } = ctx;
+  const { candidates, payload, config, fetchImpl, breakerFor, emit, logger, requestId, trace, capturedRequest } = ctx;
   const tried: string[] = [];
   let attempts = 0;
   let upstream: Response | null = null;
   let chosen: UpstreamDescriptor | null = null;
   let lastError: unknown;
 
+  const debug = (event: string, fields?: Record<string, unknown>): void =>
+    logger.debug?.(`[gateway] · ${requestId} ${event}`, { requestId, event, ...fields });
+
   for (let i = 0; i < candidates.length; i += 1) {
     const descriptor = candidates[i];
     const hasFallback = i < candidates.length - 1;
     tried.push(descriptor.provider);
     attempts += 1;
+    const breaker = breakerFor(descriptor.provider);
+    const attemptStart = Date.now();
+    debug('upstream_attempt', {
+      candidate: i,
+      provider: descriptor.provider,
+      kind: descriptor.kind,
+      resolvedModel: descriptor.resolvedModel,
+      baseUrl: descriptor.baseUrl,
+      breakerState: breaker.current,
+      hasFallback,
+    });
     try {
       upstream = await callUpstream(payload, descriptor, {
-        retry: { ...config.retry, onRetry: (info) => { attempts += 1; config.retry?.onRetry?.(info); } },
-        binding: { provider: descriptor.provider, breaker: breakerFor(descriptor.provider) },
+        retry: {
+          ...config.retry,
+          onRetry: (info) => {
+            attempts += 1;
+            debug('upstream_retry', {
+              provider: descriptor.provider,
+              attempt: info.attempt,
+              delayMs: info.delayMs,
+              reason: errorMessage(info.error),
+            });
+            config.retry?.onRetry?.(info);
+          },
+        },
+        binding: { provider: descriptor.provider, breaker },
         fetchImpl,
       });
       chosen = descriptor;
+      debug('upstream_attempt_ok', {
+        provider: descriptor.provider,
+        status: upstream.status,
+        ms: Date.now() - attemptStart,
+      });
       break;
     } catch (err) {
       lastError = err;
+      debug('upstream_attempt_failed', {
+        provider: descriptor.provider,
+        ms: Date.now() - attemptStart,
+        status: err instanceof UpstreamHttpError ? err.status : undefined,
+        error: errorMessage(err),
+        breakerState: breaker.current,
+      });
       if (err instanceof UpstreamHttpError && err.status >= 400 && err.status < 500) {
         // A rate-limit / quota / billing error (429/402/403) on a candidate that
         // has a fallback behind it — e.g. a user's BYOK key out of quota, with a
@@ -71,8 +111,10 @@ export async function runFailover(ctx: FailoverContext): Promise<FailoverResult>
         // here means it's persistent, not a transient blip.) Other 4xx — bad
         // request, auth, model-not-found — are the caller's to fix: return as-is.
         if (LIMIT_STATUSES.has(err.status) && hasFallback) {
+          debug('failover_to_next', { fromProvider: descriptor.provider, status: err.status });
           continue;
         }
+        debug('upstream_client_error_return', { provider: descriptor.provider, status: err.status });
         emit({
           ...trace, resolvedModel: descriptor.resolvedModel, provider: descriptor.provider,
           billingMode: descriptor.billingMode, status: err.status, ok: false,
@@ -88,6 +130,7 @@ export async function runFailover(ctx: FailoverContext): Promise<FailoverResult>
     const open = lastError instanceof CircuitOpenError;
     const status = open ? 503 : 502;
     const errorCode = open ? 'upstream_unavailable' : 'upstream_unreachable';
+    debug('all_upstreams_exhausted', { circuitOpen: open, status, tried, attempts, error: errorMessage(lastError) });
     emit({
       ...trace, provider: tried[tried.length - 1] ?? '', status, ok: false,
       errorCode, errorMessage: errorMessage(lastError), attempts, candidatesTried: tried,

--- a/packages/llm-gateway/src/pipeline/handler.ts
+++ b/packages/llm-gateway/src/pipeline/handler.ts
@@ -65,17 +65,43 @@ export async function handleChatCompletions(
 
   const emit = createTraceEmitter(hooks, logger, requestId, startedAt, startMs);
 
+  let lastMark = startMs;
+  const lap = (): number => {
+    const now = Date.now();
+    const delta = now - lastMark;
+    lastMark = now;
+    return delta;
+  };
+  const step = (event: string, fields?: Record<string, unknown>): void =>
+    logger.debug?.(`[gateway] · ${requestId} ${event}`, {
+      requestId,
+      event,
+      sinceStartMs: Date.now() - startMs,
+      ...fields,
+    });
+
+  step('received', { bytes: req.rawBody.length, hasAuthHeader: Boolean(req.authorization) });
+
   const token = bearer(req.authorization);
   if (!token) {
+    step('reject_no_token');
     emit({ status: 401, ok: false, errorCode: 'missing_token' });
     return json({ error: 'Missing bearer token' }, 401);
   }
 
   const principal = await hooks.authenticate(token);
   if (!principal) {
+    step('auth_failed', { ms: lap() });
     emit({ status: 401, ok: false, errorCode: 'invalid_token' });
     return json({ error: 'Invalid token' }, 401);
   }
+  step('authenticated', {
+    ms: lap(),
+    accountId: principal.accountId,
+    projectId: principal.projectId,
+    userId: principal.userId,
+    keyId: principal.keyId,
+  });
 
   const id = {
     accountId: principal.accountId,
@@ -87,7 +113,9 @@ export async function handleChatCompletions(
 
   try {
     await hooks.assertBillingActive(principal.accountId);
+    step('billing_ok', { ms: lap() });
   } catch (err) {
+    step('billing_inactive', { ms: lap(), reason: errorMessage(err) });
     emit({
       ...id,
       status: 402,
@@ -102,7 +130,9 @@ export async function handleChatCompletions(
   if (hooks.assertBudget) {
     try {
       await hooks.assertBudget(principal);
+      step('budget_ok', { ms: lap() });
     } catch (err) {
+      step('budget_exceeded', { ms: lap(), reason: errorMessage(err) });
       // 402, not 429: a budget cap is a terminal condition (it won't clear by
       // waiting), so it must NOT be retried like a transient rate limit. Mirrors
       // the billing-inactive gate above.
@@ -122,11 +152,18 @@ export async function handleChatCompletions(
   try {
     body = JSON.parse(req.rawBody) as Record<string, unknown>;
   } catch {
+    step('invalid_json');
     emit({ ...id, status: 400, ok: false, errorCode: 'invalid_json' });
     return json({ error: 'Invalid JSON body' }, 400);
   }
 
   const requestedModel = typeof body.model === 'string' ? body.model : '';
+  step('body_parsed', {
+    model: requestedModel,
+    stream: body.stream === true,
+    messages: Array.isArray(body.messages) ? body.messages.length : 0,
+    tools: Array.isArray(body.tools) ? body.tools.length : 0,
+  });
   const metadata =
     body.metadata && typeof body.metadata === 'object'
       ? (body.metadata as Record<string, unknown>)
@@ -137,7 +174,18 @@ export async function handleChatCompletions(
   );
 
   const candidates = await hooks.resolveUpstream(principal, requestedModel);
+  step('resolved_candidates', {
+    ms: lap(),
+    count: candidates.length,
+    candidates: candidates.map((c) => ({
+      provider: c.provider,
+      kind: c.kind,
+      resolvedModel: c.resolvedModel,
+      billingMode: c.billingMode,
+    })),
+  });
   if (!candidates.length) {
+    step('model_unavailable', { model: requestedModel });
     emit({
       ...id,
       requestedModel,
@@ -165,6 +213,7 @@ export async function handleChatCompletions(
     ? { ...body, stream: true, stream_options: { include_usage: true } }
     : body;
 
+  step('dispatch_upstream', { streaming, candidateCount: candidates.length });
   const result = await runFailover({
     candidates,
     payload,
@@ -172,13 +221,26 @@ export async function handleChatCompletions(
     fetchImpl,
     breakerFor,
     emit,
+    logger,
+    requestId,
     trace: { ...id, requestedModel, streaming, metadata },
     capturedRequest: capture(payload),
   });
 
-  if (result.kind === 'response') return result.response;
+  if (result.kind === 'response') {
+    step('upstream_failed', { ms: lap(), status: result.response.status });
+    return result.response;
+  }
 
   const { upstream, chosen: descriptor, tried, attempts } = result.value;
+  step('upstream_ok', {
+    ms: lap(),
+    provider: descriptor.provider,
+    resolvedModel: descriptor.resolvedModel,
+    upstreamStatus: upstream.status,
+    attempts,
+    tried,
+  });
 
   const settle = async (usage: ExtractedUsage | null, response: unknown): Promise<void> => {
     const usedModel = (
@@ -221,6 +283,17 @@ export async function handleChatCompletions(
       }
     }
 
+    step('settled', {
+      resolvedModel: usedModel,
+      provider: descriptor.provider,
+      promptTokens: counts.promptTokens,
+      completionTokens: counts.completionTokens,
+      cachedTokens: counts.cachedTokens,
+      upstreamCost,
+      finalCost,
+      streaming,
+    });
+
     emit({
       ...id,
       requestedModel,
@@ -243,14 +316,18 @@ export async function handleChatCompletions(
 
   if (!streaming) {
     const data = await upstream.json();
+    step('non_stream_body', { ms: lap() });
     void settle(extractUsageFromJson(data), data);
     return json(data);
   }
 
   if (!upstream.body) {
+    step('empty_stream');
     void settle(null, null);
     return json({ error: 'Upstream returned an empty stream' }, 502);
   }
+
+  step('stream_begin');
 
   const readable = relayStream({
     upstreamBody: upstream.body,

--- a/packages/llm-gateway/src/pipeline/streaming.ts
+++ b/packages/llm-gateway/src/pipeline/streaming.ts
@@ -4,7 +4,7 @@ export interface StreamRelayOptions {
   upstreamBody: ReadableStream<Uint8Array>;
   captureBodies: boolean;
   requestId: string;
-  logger: { warn: (...args: unknown[]) => void };
+  logger: { warn: (...args: unknown[]) => void; debug?: (...args: unknown[]) => void };
   settle: (usage: ExtractedUsage | null, response: unknown) => Promise<void>;
   /** Keep-alive interval in ms (overridable for tests). */
   heartbeatMs?: number;
@@ -27,12 +27,21 @@ export function relayStream(opts: StreamRelayOptions): ReadableStream<Uint8Array
   const decoder = new TextDecoder();
   let sseBuffer = '';
 
+  const startMs = Date.now();
+  const debug = (event: string, fields?: Record<string, unknown>): void =>
+    logger.debug?.(`[gateway] · ${requestId} ${event}`, { requestId, event, ...fields });
+
   void (async () => {
     const reader = upstreamBody.getReader();
     let downstreamAlive = true;
+    let firstByteAt = 0;
+    let bytes = 0;
+    let chunks = 0;
+    let heartbeats = 0;
     // Keep exactly one read in flight; race it against a heartbeat timer so a
     // long token gap emits a keep-alive without ever issuing a second read.
     let pending = reader.read();
+    debug('stream_open');
     try {
       while (true) {
         let timer: ReturnType<typeof setTimeout> | undefined;
@@ -49,6 +58,8 @@ export function relayStream(opts: StreamRelayOptions): ReadableStream<Uint8Array
           if (downstreamAlive && (sseBuffer === '' || sseBuffer.endsWith('\n\n'))) {
             try {
               await writer.write(HEARTBEAT_FRAME);
+              heartbeats += 1;
+              debug('stream_heartbeat', { sinceStartMs: Date.now() - startMs, heartbeats });
             } catch {
               downstreamAlive = false;
             }
@@ -60,6 +71,12 @@ export function relayStream(opts: StreamRelayOptions): ReadableStream<Uint8Array
         if (done) break;
         pending = reader.read();
         if (!value) continue;
+        if (!firstByteAt) {
+          firstByteAt = Date.now();
+          debug('stream_first_byte', { ttfbMs: firstByteAt - startMs });
+        }
+        chunks += 1;
+        bytes += value.byteLength;
         sseBuffer += decoder.decode(value, { stream: true });
         if (downstreamAlive) {
           try {
@@ -71,12 +88,21 @@ export function relayStream(opts: StreamRelayOptions): ReadableStream<Uint8Array
       }
     } catch (err) {
       logger.warn(`[llm-gateway] stream read error ${requestId}:`, err);
+      debug('stream_error', { error: err instanceof Error ? err.message : String(err), bytes, chunks });
     } finally {
       try {
         await writer.close();
       } catch {
         // writer already closed / downstream gone — nothing to do here.
       }
+      debug('stream_end', {
+        totalMs: Date.now() - startMs,
+        ttfbMs: firstByteAt ? firstByteAt - startMs : null,
+        bytes,
+        chunks,
+        heartbeats,
+        downstreamAlive,
+      });
       await settle(extractUsageFromSseBuffer(sseBuffer), captureBodies ? sseBuffer : null);
     }
   })();


### PR DESCRIPTION
Bundles three independent gateway/runtime improvements (one combined PR by request).

## 1. Structured run-path logging (observability)
Detailed, timed, structured logging threaded through the **entire gateway request path**:
`received → authenticated → billing_ok → budget_ok → body_parsed → resolved_candidates → dispatch_upstream → upstream_attempt (→ retry / failover) → upstream_ok → stream_open/first_byte/heartbeat/end → settled`.

- Emitted as **JSON lines to stdout** (debug/info) and **stderr** (warn/error) — **no file I/O**, so prod's log pipeline captures it directly.
- Verbose `debug` step-events gate on **`GATEWAY_DEBUG_LOGS`** (default on; set `=false` to quiet prod if volume is heavy). `info`/`warn`/`error` always emit.
- Adds an optional `debug()` to `GatewayLogger`.

This logging already paid off — it proved **caching works** (96–99.9% cache-hit per turn) and that the gateway itself is *not* the bottleneck (auth ~35ms, resolve ~3ms, prefill 2–8s). The real cost/latency driver is **250k–350k-token opencode contexts** (no compaction), plus one pathology: a request that hung 244s emitting only heartbeats and settled with 0 tokens.

## 2. `small_model` pin (fixes a 400 loop)
opencode auto-selected an **unservable BYOK catalog model** (`302ai/claude-haiku-4-5`) for its title/summary "small model" — the gateway has no key for it → `400 model_unavailable` on every aux call. Pin `small_model` to the managed default (`kortix/claude-sonnet-4.6`) so it always resolves.

## 3. Sandbox autostop 15 → 120 min
Idle sandboxes were stopping too quickly mid-session. Raises the default `KORTIX_SANDBOX_AUTOSTOP_MINUTES` baseline (still overridable per-env / runtime settings; applies to sandboxes created after deploy).

## Tests
`bun test packages/llm-gateway/src` → 85 pass. `executor-mcp-config.test.ts` → 21 pass. tsc clean.

Note: prefix **prompt caching** is a separate PR (#3724); this PR does not include it.
