### PR TITLE
fix(prod): keep gateway on 0.9.77 (un-wedge Argo; gateway not in 0.9.68 stack)

### DIFF
--- a/infra/k8s/envs/prod/gateway-values.yaml
+++ b/infra/k8s/envs/prod/gateway-values.yaml
@@ -4,9 +4,11 @@
 # deploy; git revert is the rollback.
 
 # Immutable release tag (promote bumps this). NOT :latest in GitOps.
-# ROLLBACK 2026-06-23: pinned to the existing :0.9.68 release image (zero rebuild).
+# The 0.9.68 rollback intentionally does NOT touch the gateway: there was no
+# gateway in the 0.9.68 stack (it entered prod EKS at v0.9.72), and no :0.9.68
+# gateway image exists. Kept on its current 0.9.77 so Argo stays healthy.
 image:
-  tag: "0.9.68"
+  tag: "0.9.77"
 # Prod HA: 3-replica floor, burst to 12 (matches the API's envelope).
 replicas: 3
 autoscaling:


### PR DESCRIPTION
Restores the gateway manifest to its **actual running version `0.9.77`**, leaving the API on `0.9.68`.

**Why:** the 0.9.68 rollback (#3729) pinned the gateway to `:0.9.68`, but that image never existed (the gateway entered prod EKS at v0.9.72). Argo wedged on `ImagePullBackOff` while the canary kept the running `0.9.77` pods serving. There was **no gateway in the 0.9.68 stack**, so it isn't part of this rollback — point the manifest back at reality so Argo goes healthy.

- Gateway: `image.tag 0.9.68 → 0.9.77` (its current running version — no behavior change)
- API: **unchanged**, stays on `0.9.68`

🤖 Generated with [Claude Code](https://claude.com/claude-code)