### PR TITLE
feat(web): skip Vercel FE build on infra-only prod pushes (kill rollback clobber)

### DIFF
--- a/apps/web/scripts/vercel-ignore.sh
+++ b/apps/web/scripts/vercel-ignore.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Vercel "Ignored Build Step" for the frontend (apps/web).
+#
+#   exit 1  → BUILD the frontend (Vercel proceeds)
+#   exit 0  → SKIP / cancel the build
+#
+# Default to BUILD on ANY uncertainty — never silently skip a real FE deploy.
+#
+# WHY THIS EXISTS
+# A backend/infra-only push to `prod` (e.g. a rollback that only flips
+# infra/k8s image tags) must NOT rebuild + redeploy the frontend. Vercel
+# auto-deploys the prod branch on every push, so without this an infra-only
+# push would re-deploy the current FE and CLOBBER a Vercel "instant rollback"
+# of the frontend. A real promote changes FE source (apps/web, packages,
+# lockfile, …) so it still builds normally — only EXCLUSIVELY-infra/ pushes skip.
+set -uo pipefail
+
+# Diff paths repo-root-relative regardless of Vercel's rootDirectory (apps/web).
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 1
+cd "$ROOT" || exit 1
+
+# Need the previous commit to diff against. Vercel keeps >=2 commits for the
+# ignore step (its own docs use `git diff HEAD^ HEAD`). If absent → BUILD.
+git rev-parse --verify -q "HEAD^" >/dev/null || exit 1
+
+changed="$(git diff --name-only HEAD^ HEAD 2>/dev/null)" || exit 1
+[ -n "$changed" ] || exit 1   # unknown/empty diff → BUILD
+
+# SKIP (exit 0) only if EVERY changed path is under infra/. Any other path
+# (apps/, packages/, lockfile, root config, …) → BUILD (exit 1).
+if printf '%s\n' "$changed" | awk '/^infra\//{next} {nonInfra=1} END{exit (nonInfra?1:0)}'; then
+  echo "vercel-ignore: only infra/ changed since HEAD^ — skipping frontend build."
+  exit 0
+fi
+echo "vercel-ignore: non-infra changes present — building frontend."
+exit 1

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,6 +1,7 @@
 {
   "buildCommand": "next build",
   "installCommand": "pnpm install --frozen-lockfile",
+  "ignoreCommand": "bash scripts/vercel-ignore.sh",
   "rewrites": [
     {
       "source": "/api/:path*",


### PR DESCRIPTION
## Makes backend rollbacks stop clobbering the frontend

Adds a Vercel **Ignored Build Step** (`apps/web/scripts/vercel-ignore.sh`, wired via `vercel.json` `ignoreCommand`): it **skips** the frontend build when a push changed **exclusively `infra/`** paths, and **builds** otherwise.

### Why
Vercel auto-deploys the `prod` branch on every push. A backend rollback only flips `infra/k8s` image tags — but that push still re-deployed the *current* frontend and **clobbered** a Vercel instant-rollback of the FE (observed live: the values-only PR #3729 spun a fresh prod FE deploy). With this:
- **Backend rollback (infra-only) → FE build skipped** → the FE rollback survives the backend merge. No more "re-run `surfaces=frontend`" step.
- **A real promote** always changes `apps/web` / `packages` / lockfile → **still builds** and ships the latest FE. So *promote still returns prod to the latest frontend, automatically.*

### Safety
Default-to-**build** on any uncertainty (no parent commit, empty diff, git error) — it can never silently skip a real FE deploy.

### Verified end-to-end (ran the actual script at real commits)
- rollback merge `b37fb43a` (only `infra/`) → **SKIP** (exit 0) ✅
- promote merge `980808cf` (touches `apps/web`) → **BUILD** (exit 1) ✅

Takes effect on `prod` once the next promote carries it there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)