### PR TITLE
fix(snapshots): clamp Platinum build size_mb to from-build cap (incident RC-2)

### DIFF
--- a/apps/api/src/__tests__/unit-platinum-snapshot-size.test.ts
+++ b/apps/api/src/__tests__/unit-platinum-snapshot-size.test.ts
@@ -65,7 +65,7 @@ globalThis.fetch = Object.assign(
   { preconnect: originalFetch.preconnect },
 ) as typeof fetch;
 
-const { platinumProvider } = await import('../snapshots/providers/platinum');
+const { platinumProvider, PLATINUM_MAX_BUILD_SIZE_MB } = await import('../snapshots/providers/platinum');
 
 beforeEach(() => {
   fromBuildPayloads = [];
@@ -78,7 +78,20 @@ afterAll(() => {
 });
 
 describe('Platinum snapshot build sizing', () => {
-  test('uses the declared template disk as both build ext4 ceiling and runtime disk', async () => {
+  test('a disk under the cap is sent verbatim as the build ceiling', async () => {
+    await platinumProvider.buildSnapshot({
+      snapshotName: 'kortix-small-template',
+      image: 'ubuntu:24.04',
+      spec: { diskGb: 10 },
+      slug: 'small',
+    });
+
+    expect(fromBuildPayloads).toHaveLength(1);
+    expect(fromBuildPayloads[0].size_mb).toBe(10 * 1024); // < cap → unclamped
+    expect(fromBuildPayloads[0].default_disk_gb).toBe(10);
+  });
+
+  test('clamps the build ext4 ceiling to Platinum\'s from-build cap, keeping the full runtime disk', async () => {
     await platinumProvider.buildSnapshot({
       snapshotName: 'kortix-large-template',
       image: 'ubuntu:24.04',
@@ -87,11 +100,13 @@ describe('Platinum snapshot build sizing', () => {
     });
 
     expect(fromBuildPayloads).toHaveLength(1);
-    expect(fromBuildPayloads[0].size_mb).toBe(40 * 1024);
+    // 40 GiB * 1024 = 40960 > cap → clamped so Platinum doesn't 400 "size_mb too_big".
+    expect(fromBuildPayloads[0].size_mb).toBe(PLATINUM_MAX_BUILD_SIZE_MB);
+    // Runtime disk is NOT clamped — build ceiling != runtime disk (ext4 grows to fit).
     expect(fromBuildPayloads[0].default_disk_gb).toBe(40);
   });
 
-  test('keeps the defensive build-size cap in sync with the canonical disk limit', async () => {
+  test('clamps even an extreme disk to the build cap', async () => {
     await platinumProvider.buildSnapshot({
       snapshotName: 'kortix-max-template',
       image: 'ubuntu:24.04',
@@ -100,7 +115,7 @@ describe('Platinum snapshot build sizing', () => {
     });
 
     expect(fromBuildPayloads).toHaveLength(1);
-    expect(fromBuildPayloads[0].size_mb).toBe(500 * 1024);
+    expect(fromBuildPayloads[0].size_mb).toBe(PLATINUM_MAX_BUILD_SIZE_MB);
     expect(fromBuildPayloads[0].default_disk_gb).toBe(500);
   });
 });

--- a/apps/api/src/snapshots/providers/platinum.ts
+++ b/apps/api/src/snapshots/providers/platinum.ts
@@ -32,6 +32,13 @@ import type {
 const ACTIVATE_DEADLINE_MS = 12 * 60 * 1000; // build + activate ceiling
 const POLL_MS = 3_000;
 const MB_PER_GB = 1024;
+// Platinum's POST /v1/templates/from-build hard-caps size_mb at this value (see
+// platinum apps/api/src/api/templates.ts ORG_MAX_SIZE_MB + the from-build zod).
+// The build ext4 is a FLOOR Platinum grows-to-fit, so clamping the build ceiling
+// does NOT shrink the runtime disk (default_disk_gb stays the full spec) — it only
+// stops oversize-disk templates from being rejected with a raw "size_mb too_big"
+// 400. Single source of truth for the build-size contract; keep in sync w/ Platinum.
+export const PLATINUM_MAX_BUILD_SIZE_MB = 20480;
 
 interface PlatinumTemplate {
   id: string;
@@ -92,10 +99,12 @@ class PlatinumAdapter implements SandboxProviderAdapter {
           name: input.snapshotName,
           context_s3_key,
           dockerfile: ctx.dockerfileName,
-          // Build-time ext4 ceiling must track the same disk spec we send as
-          // the runtime default. Platinum grows ext4 to fit, so the artifact
-          // still consumes only image+headroom rather than the whole ceiling.
-          size_mb: diskGb * MB_PER_GB,
+          // Build-time ext4 ceiling, clamped to Platinum's from-build hard cap.
+          // Platinum grows ext4 to fit, so the artifact consumes only image+headroom
+          // (a ~9.4 GiB kortix image builds fine into a 20 GiB ceiling). The runtime
+          // disk (default_disk_gb below) stays the FULL spec — build ceiling != runtime
+          // disk. Without this clamp a >20 GiB-disk template 400s ("size_mb too_big").
+          size_mb: Math.min(diskGb * MB_PER_GB, PLATINUM_MAX_BUILD_SIZE_MB),
           default_cpu: input.spec.cpu ?? DEFAULT_CPU,
           default_ram_mb: (input.spec.memoryGb ?? DEFAULT_MEMORY_GB) * 1024,
           default_disk_gb: diskGb,


### PR DESCRIPTION
## What
Clamp the Platinum build `size_mb` to Platinum's `POST /v1/templates/from-build` hard cap (**20480 MB / 20 GiB**), via a single shared exported const `PLATINUM_MAX_BUILD_SIZE_MB`.

## Why (prod incident RC-2)
comp clamped build disk only to the **500 GiB runtime** limit (`SANDBOX_SPEC_LIMITS.disk.max`) and sent `size_mb = diskGb * 1024`. Platinum hard-caps `size_mb` at 20480, so any template with `disk_gb > 20` failed with a raw `size_mb too_big` 400 (observed on the kortix-dev org → prod Platinum). The two ceilings disagreed by 25×.

**Build ceiling ≠ runtime disk.** Platinum grows the ext4 to fit, so a ~9.4 GiB kortix image builds fine into a 20 GiB ceiling. We clamp only the *build-artifact* ceiling — the **runtime** disk (`default_disk_gb`) is left at the full spec, so a 40 GiB-disk template still runs with 40 GiB.

A complementary platinum-dev fix (already deployed to prod) relaxes the from-build zod wall so the cap now returns a typed `template_size_cap_exceeded` (with `max_size_mb`) instead of a raw zod 400 — so over-cap requests from any client are actionable. This PR makes comp never hit that cap for normal (image fits in 20 GiB) builds.

## Test
`unit-platinum-snapshot-size.test.ts` — **3/3 pass**:
- disk **under** the cap → sent verbatim (`10 GiB → 10240`)
- disk = 40 GiB → `size_mb` clamped to `PLATINUM_MAX_BUILD_SIZE_MB`, `default_disk_gb` stays 40
- disk = 500 GiB → `size_mb` clamped, `default_disk_gb` stays 500

## Pre-merge gate
Final local e2e against the (now-fixed) prod Platinum: build a template with `disk_gb > 20` and confirm it succeeds instead of 400ing.
