### PR TITLE
feat(sandbox-agent): no-restart warm-fork claim via credential-injecting proxies (flag-off)

### DIFF
--- a/apps/kortix-sandbox-agent-server/src/__tests__/llm-proxy.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/llm-proxy.test.ts
@@ -1,0 +1,148 @@
+import { describe, test, expect, afterEach } from 'bun:test'
+import { writeFileSync, mkdtempSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import {
+  startLlmProxy,
+  setLlmProxyToken,
+  llmProxyReady,
+  llmProxyBaseUrl,
+  stopLlmProxy,
+  LLM_PROXY_PLACEHOLDER_KEY,
+  startExecutorProxy,
+  setExecutorProxyToken,
+  executorProxyReady,
+  executorProxyBaseUrl,
+  stopExecutorProxy,
+  EXECUTOR_PROXY_PLACEHOLDER_KEY,
+} from '../llm-proxy'
+import { buildOpencodeConfigContent } from '../opencode'
+
+// A mock upstream that echoes back the Authorization header + path it received,
+// so we can prove the proxy injects the live token (not the placeholder).
+function mockUpstream() {
+  const server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      const u = new URL(req.url)
+      return new Response(
+        JSON.stringify({ auth: req.headers.get('authorization'), path: u.pathname + u.search }),
+        { headers: { 'content-type': 'application/json' } },
+      )
+    },
+  })
+  return { url: `http://127.0.0.1:${server.port}`, stop: () => server.stop(true) }
+}
+
+describe('credential proxy — live token swap (the no-restart mechanism)', () => {
+  afterEach(() => {
+    stopLlmProxy()
+    stopExecutorProxy()
+  })
+
+  test('fails closed (503) before any token is set — never an open relay', async () => {
+    const up = mockUpstream()
+    try {
+      // fresh proxy, never tokened (the pre-claim window) → must fail closed
+      startLlmProxy(14319, up.url)
+      expect(llmProxyReady()).toBe(false)
+      const res = await fetch(`${llmProxyBaseUrl()}/v1/llm/models`)
+      expect(res.status).toBe(503)
+    } finally {
+      up.stop()
+    }
+  })
+
+  test('LLM proxy injects the live token and SWAPS it without a restart', async () => {
+    const up = mockUpstream()
+    try {
+      startLlmProxy(14319, up.url, 'token-A')
+      const base = llmProxyBaseUrl()
+      expect(base).toBe('http://127.0.0.1:14319')
+      expect(llmProxyReady()).toBe(true)
+
+      // request 1 → upstream sees token-A, path preserved
+      const r1 = await (await fetch(`${base}/v1/llm/models`)).json()
+      expect(r1.auth).toBe('Bearer token-A')
+      expect(r1.path).toBe('/v1/llm/models')
+
+      // swap the token LIVE — same proxy process, no restart
+      setLlmProxyToken('token-B')
+      const r2 = await (await fetch(`${base}/v1/llm/chat/completions`)).json()
+      expect(r2.auth).toBe('Bearer token-B')
+      expect(r2.path).toBe('/v1/llm/chat/completions')
+    } finally {
+      up.stop()
+    }
+  })
+
+  test('executor proxy injects + swaps its token independently', async () => {
+    const up = mockUpstream()
+    try {
+      startExecutorProxy(14320, up.url, 'exec-A')
+      const base = executorProxyBaseUrl()
+      expect(base).toBe('http://127.0.0.1:14320')
+      expect(executorProxyReady()).toBe(true)
+
+      const r1 = await (await fetch(`${base}/v1/projects/p/exec`)).json()
+      expect(r1.auth).toBe('Bearer exec-A')
+
+      setExecutorProxyToken('exec-B')
+      const r2 = await (await fetch(`${base}/v1/projects/p/exec`)).json()
+      expect(r2.auth).toBe('Bearer exec-B')
+    } finally {
+      up.stop()
+    }
+  })
+
+})
+
+describe('buildOpencodeConfigContent — proxy mode vs direct mode', () => {
+  const catalog = join(mkdtempSync(join(tmpdir(), 'cat-')), 'catalog.json')
+  writeFileSync(
+    catalog,
+    JSON.stringify({ models: { 'kortix/test-model': { id: 'kortix/test-model', name: 'Test' } } }),
+  )
+
+  test('PROXY mode: session-independent provider + executor MCP (placeholders + proxy URLs)', async () => {
+    const json = await buildOpencodeConfigContent({
+      KORTIX_LLM_PROXY_URL: 'http://127.0.0.1:4319',
+      KORTIX_EXECUTOR_PROXY_URL: 'http://127.0.0.1:4320',
+      KORTIX_API_URL: 'https://api.kortix.test/v1',
+      KORTIX_LLM_BASE_URL: 'https://gateway.kortix.test/v1/llm',
+      KORTIX_LLM_API_KEY: 'real-session-llm-key',
+      KORTIX_EXECUTOR_TOKEN: 'real-session-exec-token',
+      KORTIX_LLM_CATALOG_FILE: catalog,
+    } as NodeJS.ProcessEnv)
+    expect(json).toBeDefined()
+    const cfg = JSON.parse(json!)
+
+    // gateway provider points at the proxy with a placeholder — NO real key baked
+    expect(cfg.provider.kortix.options.baseURL).toBe('http://127.0.0.1:4319')
+    expect(cfg.provider.kortix.options.apiKey).toBe(LLM_PROXY_PLACEHOLDER_KEY)
+    expect(cfg.provider.kortix.options.apiKey).not.toBe('real-session-llm-key')
+
+    // executor MCP baked even though token-independent → points at executor proxy
+    expect(cfg.mcp['kortix-executor'].environment.KORTIX_API_URL).toBe('http://127.0.0.1:4320')
+    expect(cfg.mcp['kortix-executor'].environment.KORTIX_EXECUTOR_TOKEN).toBe(EXECUTOR_PROXY_PLACEHOLDER_KEY)
+    expect(cfg.mcp['kortix-executor'].environment.KORTIX_EXECUTOR_TOKEN).not.toBe('real-session-exec-token')
+
+    // full catalog came from the baked file
+    expect(Object.keys(cfg.provider.kortix.models)).toContain('kortix/test-model')
+  })
+
+  test('DIRECT mode (cold/Daytona): real key + token baked, unchanged', async () => {
+    const json = await buildOpencodeConfigContent({
+      KORTIX_API_URL: 'https://api.kortix.test/v1',
+      KORTIX_LLM_BASE_URL: 'https://gateway.kortix.test/v1/llm',
+      KORTIX_LLM_API_KEY: 'real-session-llm-key',
+      KORTIX_EXECUTOR_TOKEN: 'real-session-exec-token',
+      KORTIX_LLM_CATALOG_FILE: catalog,
+    } as NodeJS.ProcessEnv)
+    expect(json).toBeDefined()
+    const cfg = JSON.parse(json!)
+    expect(cfg.provider.kortix.options.baseURL).toBe('https://gateway.kortix.test/v1/llm')
+    expect(cfg.provider.kortix.options.apiKey).toBe('real-session-llm-key')
+    expect(cfg.mcp['kortix-executor'].environment.KORTIX_EXECUTOR_TOKEN).toBe('real-session-exec-token')
+  })
+})

--- a/apps/kortix-sandbox-agent-server/src/__tests__/llm-proxy.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/llm-proxy.test.ts
@@ -34,6 +34,13 @@ function mockUpstream() {
   return { url: `http://127.0.0.1:${server.port}`, stop: () => server.stop(true) }
 }
 
+// Typed read of the mock's echo body — global fetch().json() is `unknown` under
+// strict tsc, which the daemon CI's `tsc --noEmit` (not just `bun test`) enforces.
+async function fetchJson(url: string): Promise<{ auth: string | null; path: string }> {
+  const res = await fetch(url)
+  return (await res.json()) as { auth: string | null; path: string }
+}
+
 describe('credential proxy — live token swap (the no-restart mechanism)', () => {
   afterEach(() => {
     stopLlmProxy()
@@ -62,13 +69,13 @@ describe('credential proxy — live token swap (the no-restart mechanism)', () =
       expect(llmProxyReady()).toBe(true)
 
       // request 1 → upstream sees token-A, path preserved
-      const r1 = await (await fetch(`${base}/v1/llm/models`)).json()
+      const r1 = await fetchJson(`${base}/v1/llm/models`)
       expect(r1.auth).toBe('Bearer token-A')
       expect(r1.path).toBe('/v1/llm/models')
 
       // swap the token LIVE — same proxy process, no restart
       setLlmProxyToken('token-B')
-      const r2 = await (await fetch(`${base}/v1/llm/chat/completions`)).json()
+      const r2 = await fetchJson(`${base}/v1/llm/chat/completions`)
       expect(r2.auth).toBe('Bearer token-B')
       expect(r2.path).toBe('/v1/llm/chat/completions')
     } finally {
@@ -84,11 +91,11 @@ describe('credential proxy — live token swap (the no-restart mechanism)', () =
       expect(base).toBe('http://127.0.0.1:14320')
       expect(executorProxyReady()).toBe(true)
 
-      const r1 = await (await fetch(`${base}/v1/projects/p/exec`)).json()
+      const r1 = await fetchJson(`${base}/v1/projects/p/exec`)
       expect(r1.auth).toBe('Bearer exec-A')
 
       setExecutorProxyToken('exec-B')
-      const r2 = await (await fetch(`${base}/v1/projects/p/exec`)).json()
+      const r2 = await fetchJson(`${base}/v1/projects/p/exec`)
       expect(r2.auth).toBe('Bearer exec-B')
     } finally {
       up.stop()

--- a/apps/kortix-sandbox-agent-server/src/llm-proxy.ts
+++ b/apps/kortix-sandbox-agent-server/src/llm-proxy.ts
@@ -1,0 +1,190 @@
+import { logger } from './logger'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Localhost credential-injecting reverse proxy (the warm-fork "no restart on
+// claim" mechanism). Two instances run when KORTIX_LLM_HOTSWAP=1:
+//   • the LLM gateway proxy   (opencode's kortix provider baseURL → here)
+//   • the executor MCP proxy  (kortix-executor MCP's KORTIX_API_URL → here)
+//
+// WHY: a stateful warm-fork session attach ("claim") used to KILL + respawn
+// opencode purely to swap in the per-session tokens (LLM gateway key + executor
+// token) — re-paying ~8s of opencode init that the snapshot already baked.
+// opencode reads its config (provider.options.apiKey, mcp.environment) only at
+// spawn, so swapping a token forced a config rebuild + restart.
+//
+// Fix: make those credentials SESSION-INDEPENDENT in the baked config. The config
+// points the relevant baseURL/api-url at THIS localhost proxy with a fixed
+// placeholder Bearer; the proxy holds the real per-session token in memory and
+// rewrites the Authorization header on the way upstream. On claim the daemon just
+// calls setToken() — opencode is never restarted.
+//
+// SCOPE: stateful warm-fork only (the caller gates it). Cold templates + Daytona
+// never start these proxies and keep their direct config unchanged.
+// ─────────────────────────────────────────────────────────────────────────────
+
+type ProxyState = {
+  /** The real upstream base, e.g. https://gateway-dev.kortix.com/v1/llm (LLM) or
+   *  the real KORTIX_API_URL (executor). */
+  upstreamBase: string | null
+  /** The live per-session bearer token sent upstream. */
+  token: string | null
+}
+
+/** Hop-by-hop headers that must not be forwarded (RFC 7230 §6.1) + host/auth/len
+ *  which we set ourselves. Lower-cased for case-insensitive matching. */
+const STRIP_REQ_HEADERS = new Set([
+  'host',
+  'authorization',
+  'connection',
+  'keep-alive',
+  'proxy-authenticate',
+  'proxy-authorization',
+  'te',
+  'trailer',
+  'transfer-encoding',
+  'upgrade',
+  'content-length',
+])
+
+export type CredentialProxy = {
+  /** Start on a fixed port (idempotent). Best-effort: bind failure → null (caller
+   *  falls back to the direct-config + restart path). Returns the localhost URL. */
+  start(port: number, upstreamBase?: string, token?: string): string | null
+  /** Update the live token (+ optional upstream). Instant, NO opencode restart. */
+  setToken(token: string | undefined, upstreamBase?: string | undefined): void
+  /** True once listening AND a usable upstream + token are set. */
+  ready(): boolean
+  /** The localhost URL the baked config should point at (stable across forks). */
+  baseUrl(): string | null
+  /** Stop (tests / shutdown). */
+  stop(): void
+  /** The non-secret placeholder Bearer baked into the config. */
+  readonly placeholderKey: string
+}
+
+function createCredentialProxy(name: string, placeholderKey: string): CredentialProxy {
+  const state: ProxyState = { upstreamBase: null, token: null }
+  let server: ReturnType<typeof Bun.serve> | null = null
+  let boundPort = 0
+
+  function setToken(token: string | undefined, upstreamBase?: string | undefined): void {
+    if (typeof token === 'string' && token.length > 0) state.token = token
+    if (typeof upstreamBase === 'string' && upstreamBase.length > 0) {
+      state.upstreamBase = upstreamBase.replace(/\/+$/, '')
+    }
+  }
+
+  function ready(): boolean {
+    return !!server && !!state.upstreamBase && !!state.token
+  }
+
+  function baseUrl(): string | null {
+    return server ? `http://127.0.0.1:${boundPort}` : null
+  }
+
+  function start(port: number, upstreamBase?: string, token?: string): string | null {
+    setToken(token, upstreamBase)
+    if (server) return baseUrl()
+    try {
+      server = Bun.serve({
+        port,
+        hostname: '127.0.0.1',
+        // Model streams can run minutes. 0 = no idle timeout.
+        idleTimeout: 0,
+        async fetch(req) {
+          const upstream = state.upstreamBase
+          const tok = state.token
+          if (!upstream || !tok) {
+            // Not claimed yet (or token cleared) — fail closed; never an open relay.
+            return new Response(JSON.stringify({ error: `${name} proxy not ready` }), {
+              status: 503,
+              headers: { 'content-type': 'application/json' },
+            })
+          }
+          const inUrl = new URL(req.url)
+          const target = `${upstream}${inUrl.pathname}${inUrl.search}`
+
+          const headers = new Headers()
+          req.headers.forEach((v, k) => {
+            if (!STRIP_REQ_HEADERS.has(k.toLowerCase())) headers.set(k, v)
+          })
+          headers.set('authorization', `Bearer ${tok}`)
+
+          try {
+            // duplex:'half' is required by Bun/undici when a request carries a
+            // streaming body; valid at runtime even where the RequestInit type
+            // omits it, so build + cast rather than inline.
+            const init: RequestInit & { duplex?: 'half' } = {
+              method: req.method,
+              headers,
+              body: req.body ?? undefined,
+              redirect: 'manual',
+            }
+            if (req.body) init.duplex = 'half'
+            const upstreamRes = await fetch(target, init)
+            const outHeaders = new Headers()
+            upstreamRes.headers.forEach((v, k) => {
+              const lk = k.toLowerCase()
+              if (lk === 'transfer-encoding' || lk === 'connection') return
+              outHeaders.set(k, v)
+            })
+            return new Response(upstreamRes.body, {
+              status: upstreamRes.status,
+              statusText: upstreamRes.statusText,
+              headers: outHeaders,
+            })
+          } catch (err) {
+            logger.warn(`[${name}-proxy] upstream error`, { target, err: (err as Error).message })
+            return new Response(JSON.stringify({ error: `${name} proxy upstream error` }), {
+              status: 502,
+              headers: { 'content-type': 'application/json' },
+            })
+          }
+        },
+      })
+      boundPort = server.port ?? port
+      logger.info(`[${name}-proxy] listening`, { port: boundPort, hasUpstream: !!state.upstreamBase })
+      return baseUrl()
+    } catch (err) {
+      logger.warn(`[${name}-proxy] failed to start; warm hot-swap disabled, falling back to restart path`, {
+        err: (err as Error).message,
+      })
+      server = null
+      return null
+    }
+  }
+
+  function stop(): void {
+    try {
+      server?.stop(true)
+    } catch {}
+    server = null
+    boundPort = 0
+  }
+
+  return { start, setToken, ready, baseUrl, stop, placeholderKey }
+}
+
+// ── instances ────────────────────────────────────────────────────────────────
+const llm = createCredentialProxy('llm', 'kortix-llm-proxy-injected')
+const executor = createCredentialProxy('executor', 'kortix-executor-proxy-injected')
+
+// LLM gateway proxy.
+export const LLM_PROXY_PLACEHOLDER_KEY = llm.placeholderKey
+export const startLlmProxy = (port: number, upstreamBase?: string, token?: string) =>
+  llm.start(port, upstreamBase, token)
+export const setLlmProxyToken = (token: string | undefined, upstreamBase?: string | undefined) =>
+  llm.setToken(token, upstreamBase)
+export const llmProxyReady = () => llm.ready()
+export const llmProxyBaseUrl = () => llm.baseUrl()
+export const stopLlmProxy = () => llm.stop()
+
+// Executor MCP proxy.
+export const EXECUTOR_PROXY_PLACEHOLDER_KEY = executor.placeholderKey
+export const startExecutorProxy = (port: number, upstreamBase?: string, token?: string) =>
+  executor.start(port, upstreamBase, token)
+export const setExecutorProxyToken = (token: string | undefined, upstreamBase?: string | undefined) =>
+  executor.setToken(token, upstreamBase)
+export const executorProxyReady = () => executor.ready()
+export const executorProxyBaseUrl = () => executor.baseUrl()
+export const stopExecutorProxy = () => executor.stop()

--- a/apps/kortix-sandbox-agent-server/src/main.ts
+++ b/apps/kortix-sandbox-agent-server/src/main.ts
@@ -18,6 +18,16 @@ import { ensureOpencodeConfigDeps } from './opencode-config-deps'
 import { startOpencodeEventLoop, flattenOpencodeError, type QuestionRequest, type OpencodeTurnError } from './opencode-events'
 import { createProjectEnvStore } from './project-env'
 import { startProxy } from './proxy'
+import {
+  startLlmProxy,
+  setLlmProxyToken,
+  llmProxyReady,
+  llmProxyBaseUrl,
+  startExecutorProxy,
+  setExecutorProxyToken,
+  executorProxyReady,
+  executorProxyBaseUrl,
+} from './llm-proxy'
 import type { SandboxBootState } from './routes/health'
 import { installShutdownHandlers } from './shutdown'
 import { startStaticWebServer } from './static-web'
@@ -389,6 +399,40 @@ function reloadSessionEnv(paths: string[] = ['/etc/pt-env', '/tmp/pt-env']): voi
 //     warmed by a readiness PROBE (a /session read that resolves the /workspace
 //     Instance + loads pty-tools.ts) — never a bootstrap session, since there is
 //     no KORTIX_SESSION_ID to relay at park.
+
+// Fetch the FULL org model catalog at PARK and write it to KORTIX_LLM_CATALOG_FILE
+// so the (tokenless) seed's opencode config bakes the full picker instead of the
+// ~11-model fallback. The seed can't reach the gateway /models (no per-session
+// gateway key), so it asks an apps/api endpoint authed by the sandbox token.
+// Best-effort + idempotent: a no-op unless KORTIX_LLM_CATALOG_URL is set, and any
+// failure just leaves the fallback catalog (LLM + tools still work via proxies).
+//
+// ENDPOINT CONTRACT (apps/api, to be added deliberately — NOT done here because
+// the PARK auth path is subtle): GET KORTIX_LLM_CATALOG_URL with
+// `Authorization: Bearer <KORTIX_SANDBOX_TOKEN>` → `{ models: {...} }` ==
+// gatewayModelCatalog(projectId, userId). At PARK there is NO live sessionSandboxes
+// row (it's a template build), and the token is a type='user' account key, so the
+// route must authorize by validateAccountToken→accountId/projectId (like the git
+// proxy at park), NOT by the sandbox-row check clone-credential uses.
+async function prefetchSeedCatalog(cfg: Config): Promise<void> {
+  const url = process.env.KORTIX_LLM_CATALOG_URL
+  if (!url || !cfg.sandboxToken) return
+  const file = process.env.KORTIX_LLM_CATALOG_FILE || `${OPENCODE_HOME}/.config/kortix-llm-catalog.json`
+  const res = await fetch(url, {
+    headers: { Authorization: `Bearer ${cfg.sandboxToken}`, Accept: 'application/json' },
+    signal: AbortSignal.timeout(8_000),
+  })
+  if (!res.ok) throw new Error(`catalog http ${res.status}`)
+  const body = await res.text()
+  const parsed = JSON.parse(body) as { models?: Record<string, unknown> }
+  const count = parsed.models ? Object.keys(parsed.models).length : 0
+  if (count === 0) throw new Error('empty catalog')
+  mkdirSync(dirname(file), { recursive: true })
+  writeFileSync(file, body, { mode: 0o600 })
+  process.env.KORTIX_LLM_CATALOG_FILE = file
+  logger.info('[pool] baked full model catalog for seed', { file, models: count })
+}
+
 async function runPoolMode(
   cfg: Config,
   bootTime: number,
@@ -420,6 +464,46 @@ async function runPoolMode(
     ? await resolveOpencodeConfigDir(cfg)
     : cfg.defaultOpencodeConfigDir
   await ensureOpencodeConfigDeps(opencodeConfigDir).catch(() => {})
+
+  // Warm-fork NO-RESTART path (opt-in KORTIX_LLM_HOTSWAP=1; stateful/warm-pool
+  // only — this whole function is the warm path; cold + Daytona never run it).
+  // Start TWO localhost credential proxies (LLM gateway + executor MCP) and point
+  // opencode's baked config at them, so the SEED bakes a SESSION-INDEPENDENT
+  // config (placeholder tokens + proxied URLs) and CLAIM can inject the real
+  // per-session tokens live, skipping the ~8s opencode restart. Best-effort: a
+  // bind failure leaves the *_PROXY_URL unset → that contributor bakes nothing
+  // session-independent and claim falls back to the restart path.
+  const llmHotswap = (process.env.KORTIX_LLM_HOTSWAP ?? '').trim() === '1'
+  if (llmHotswap) {
+    const llmPort = Number(process.env.KORTIX_LLM_PROXY_PORT) || 4319
+    const llmUrl = startLlmProxy(llmPort)
+    if (llmUrl) {
+      // Seen by buildOpencodeConfigContent (via process.env) at the seed spawn
+      // below → provider.kortix routes through the proxy.
+      process.env.KORTIX_LLM_PROXY_URL = llmUrl
+      bootMark('pool-llm-proxy-started')
+      logger.info('[pool] llm hot-swap proxy up; seed bakes proxied gateway provider', { llmUrl })
+    }
+    const exPort = Number(process.env.KORTIX_EXECUTOR_PROXY_PORT) || 4320
+    const exUrl = startExecutorProxy(exPort)
+    if (exUrl) {
+      // Seen by buildOpencodeConfigContent → mcp.kortix-executor.KORTIX_API_URL
+      // routes through the proxy, so the tokenless seed bakes a working MCP.
+      process.env.KORTIX_EXECUTOR_PROXY_URL = exUrl
+      bootMark('pool-executor-proxy-started')
+      logger.info('[pool] executor hot-swap proxy up; seed bakes proxied executor MCP', { exUrl })
+    }
+    // Catalog prefetch (best-effort): the seed is tokenless and can't hit the
+    // gateway /models, so fetch the FULL org catalog from an apps/api endpoint
+    // authed by the sandbox token and write it to KORTIX_LLM_CATALOG_FILE BEFORE
+    // opencode spawns → the seed bakes the FULL model picker, not the ~11-model
+    // fallback. No-op unless KORTIX_LLM_CATALOG_URL is wired (see report for the
+    // endpoint contract); any failure → fallback models (LLM + tools still work).
+    await prefetchSeedCatalog(cfg).catch((err) =>
+      logger.warn('[pool] catalog prefetch failed; seed uses fallback models', { err: (err as Error).message }),
+    )
+  }
+
   const opencode = createOpencodeSupervisor(cfg, opencodeConfigDir, projectEnv)
   await opencode.start().catch((err) => logger.warn('[pool] opencode.start() rejected', { err: err instanceof Error ? err.message : String(err) }))
   bootMark('pool-opencode-spawned')
@@ -501,13 +585,52 @@ async function runPoolMode(
       await ensureOpencodeConfigDeps(claimOpencodeConfigDir).catch((err) =>
         logger.warn('[pool] claim config deps failed', { err: (err as Error).message }),
       )
-      opencode.reconfigure(cfg2, claimOpencodeConfigDir, projectEnv)
-      await opencode.restart().catch((err) =>
-        logger.warn('[pool] claim opencode restart failed', { err: (err as Error).message }),
-      )
-      bootMark('claim-opencode-restarted')
+      // NO-RESTART fast path (opt-in, stateful warm-fork only): the seed baked a
+      // session-independent opencode config routed through the localhost LLM +
+      // executor proxies, so inject the per-session tokens LIVE and reuse the
+      // already-warm opencode — skipping the ~8s restart. Engages only when
+      // hot-swap is on, the LLM proxy is up + the seed baked the proxied provider
+      // (KORTIX_LLM_PROXY_URL set), opencode is currently healthy, and the repo
+      // materialized cleanly (Stage-2 baked-checkout → projectTarget unchanged, so
+      // reconfigure is unnecessary). Anything missing → fall through to restart.
+      let hotSwapped = false
+      if (
+        llmHotswap &&
+        !!process.env.KORTIX_LLM_PROXY_URL &&
+        llmProxyBaseUrl() != null &&
+        opencode.getState() === 'ok' &&
+        !bootState.repoMaterializationError
+      ) {
+        // LLM gateway: required for the session to function.
+        setLlmProxyToken(process.env.KORTIX_LLM_API_KEY, process.env.KORTIX_LLM_BASE_URL)
+        // Executor MCP: the seed baked the MCP pointing at the executor proxy, so
+        // the running MCP already exposes the tools; injecting the real token here
+        // makes the first tool call work — no restart. Best-effort: a session with
+        // no executor token leaves the proxy un-tokened (the MCP stays exposed but
+        // 503s a tool call, exactly like a no-executor session).
+        if (process.env.KORTIX_EXECUTOR_PROXY_URL && executorProxyBaseUrl() != null) {
+          setExecutorProxyToken(process.env.KORTIX_EXECUTOR_TOKEN, process.env.KORTIX_API_URL)
+        }
+        if (llmProxyReady()) {
+          hotSwapped = true
+          bootMark('claim-opencode-hotswapped')
+          // Observability: confirms the executor proxy has a live token, i.e.
+          // tools are callable on this hot-swapped claim (not just exposed).
+          if (executorProxyReady()) bootMark('claim-executor-tools-ready')
+          logger.info('[pool] claim hot-swap: per-session tokens injected via proxies, opencode NOT restarted', {
+            executorReady: executorProxyReady(),
+          })
+        }
+      }
+      if (!hotSwapped) {
+        opencode.reconfigure(cfg2, claimOpencodeConfigDir, projectEnv)
+        await opencode.restart().catch((err) =>
+          logger.warn('[pool] claim opencode restart failed', { err: (err as Error).message }),
+        )
+        bootMark('claim-opencode-restarted')
+      }
       await startSessionRuntime(opencode, cfg2, bootState, bootMark)
-      logger.info('[pool] claim complete', { claimMs: Date.now() - t0, timeline: bootState.timeline })
+      logger.info('[pool] claim complete', { claimMs: Date.now() - t0, hotSwapped, timeline: bootState.timeline })
     })()
   }
   process.on('SIGHUP', () => claim('sighup'))

--- a/apps/kortix-sandbox-agent-server/src/opencode.ts
+++ b/apps/kortix-sandbox-agent-server/src/opencode.ts
@@ -1,9 +1,10 @@
 import { spawn, type ChildProcess } from 'node:child_process'
-import { chmodSync, mkdirSync, readdirSync, unlinkSync, writeFileSync } from 'node:fs'
+import { chmodSync, mkdirSync, readdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { access, constants, stat } from 'node:fs/promises'
 
 import { AGENT_ENV_SH } from './agent-env-file'
+import { LLM_PROXY_PLACEHOLDER_KEY, EXECUTOR_PROXY_PLACEHOLDER_KEY } from './llm-proxy'
 import type { Config } from './config'
 import { buildGitIdentityEnv } from './git'
 import { logger } from './logger'
@@ -42,8 +43,27 @@ export async function buildOpencodeConfigContent(env: NodeJS.ProcessEnv): Promis
   const llmBaseUrl = env.KORTIX_LLM_BASE_URL
   const llmApiKey = env.KORTIX_LLM_API_KEY
 
-  const hasExecutor = !!executorToken && !!apiUrl
-  const hasLlmGateway = !!llmBaseUrl && !!llmApiKey
+  // Warm-fork no-restart path (stateful only). When the daemon runs the localhost
+  // LLM proxy it exports KORTIX_LLM_PROXY_URL; the provider then points baseURL at
+  // the proxy with a placeholder key, making the gateway provider config
+  // SESSION-INDEPENDENT (the real per-session token is injected by the proxy, not
+  // baked here). This lets a tokenless warm seed bake a usable provider so claim
+  // can hot-swap the token with NO opencode restart. Cold/Daytona never set this
+  // env → unchanged direct-provider behavior below.
+  const llmProxyUrl = env.KORTIX_LLM_PROXY_URL
+  const proxyMode = !!llmProxyUrl
+  // Same trick for the executor MCP: when the daemon runs the executor proxy it
+  // exports KORTIX_EXECUTOR_PROXY_URL; the MCP's KORTIX_API_URL points at the
+  // proxy with a placeholder token so the tokenless warm seed can bake a working
+  // kortix-executor MCP (tools exposed; the proxy injects the real per-session
+  // token on the first tool call after claim — no opencode restart).
+  const executorProxyUrl = env.KORTIX_EXECUTOR_PROXY_URL
+  const executorProxyMode = !!executorProxyUrl
+
+  // Direct mode needs both token+url; proxy mode needs only the proxy URL (the
+  // per-session token arrives live at request time via the proxy).
+  const hasExecutor = executorProxyMode || (!!executorToken && !!apiUrl)
+  const hasLlmGateway = proxyMode || (!!llmBaseUrl && !!llmApiKey)
   // A Slack-provisioned session carries SLACK_CHANNEL_ID / SLACK_THREAD_TS (the
   // session identity the API hands us at boot; also what the in-sandbox `slack`
   // CLI uses to post back to the thread). Contributor #3 keys off it.
@@ -77,11 +97,16 @@ export async function buildOpencodeConfigContent(env: NodeJS.ProcessEnv): Promis
         command: ['kortix', 'executor', 'mcp'],
         enabled: true,
         environment: {
-          KORTIX_EXECUTOR_TOKEN: executorToken,
-          KORTIX_API_URL: apiUrl,
+          // Proxy mode: the MCP talks to the localhost executor proxy with a
+          // placeholder token; the proxy injects the real per-session token
+          // upstream (so the baked config is session-independent → no restart on
+          // claim). Direct mode (cold/Daytona): the real token + api url, as before.
+          KORTIX_EXECUTOR_TOKEN: executorProxyMode ? EXECUTOR_PROXY_PLACEHOLDER_KEY : executorToken!,
+          KORTIX_API_URL: executorProxyMode ? executorProxyUrl! : apiUrl!,
           // Lets the CLI target the project-explicit gateway route. Optional —
           // the session token also pins the project for the legacy flat route,
-          // so this is belt-and-suspenders.
+          // so this is belt-and-suspenders. Project id is session-independent so
+          // it's safe to bake at seed.
           ...(env.KORTIX_PROJECT_ID ? { KORTIX_PROJECT_ID: env.KORTIX_PROJECT_ID } : {}),
         },
       },
@@ -96,7 +121,19 @@ export async function buildOpencodeConfigContent(env: NodeJS.ProcessEnv): Promis
         : {}
     out.provider = {
       ...provider,
-      kortix: await buildKortixProvider(llmBaseUrl!, llmApiKey!),
+      kortix: await buildKortixProvider({
+        // In proxy mode opencode talks to the localhost proxy with a placeholder
+        // key; the proxy injects the real per-session token upstream. In direct
+        // mode (cold/Daytona) it's the real gateway base + key, as before.
+        baseURL: proxyMode ? llmProxyUrl! : llmBaseUrl!,
+        apiKey: proxyMode ? LLM_PROXY_PLACEHOLDER_KEY : llmApiKey!,
+        // Catalog is org-stable: prefer a baked file (lets the warm seed bake the
+        // full catalog with no per-session token), else fetch from the real
+        // gateway (needs a real base+key — only available in direct mode).
+        catalogFile: env.KORTIX_LLM_CATALOG_FILE,
+        fetchBaseURL: llmBaseUrl,
+        fetchApiKey: llmApiKey,
+      }),
     }
     if (!('model' in out) || typeof out.model !== 'string') {
       out.model = DEFAULT_KORTIX_MODEL
@@ -154,16 +191,56 @@ function gatewayEnabledProviders(env: NodeJS.ProcessEnv): string[] {
   return [...allow]
 }
 
-async function buildKortixProvider(llmBaseUrl: string, llmApiKey: string): Promise<Record<string, unknown>> {
+type KortixProviderOpts = {
+  /** baseURL opencode sends LLM requests to (real gateway, or localhost proxy). */
+  baseURL: string
+  /** apiKey baked into the config (real key, or the proxy placeholder). */
+  apiKey: string
+  /** Optional baked catalog file (org-stable models JSON) — preferred source. */
+  catalogFile?: string
+  /** Real gateway base/key for fetching the catalog when no file is baked. */
+  fetchBaseURL?: string
+  fetchApiKey?: string
+}
+
+async function buildKortixProvider(opts: KortixProviderOpts): Promise<Record<string, unknown>> {
   return {
     npm: '@ai-sdk/openai-compatible',
     name: 'Kortix',
     options: {
-      baseURL: llmBaseUrl,
-      apiKey: llmApiKey,
+      baseURL: opts.baseURL,
+      apiKey: opts.apiKey,
     },
-    models: withModelLimits(await fetchGatewayModels(llmBaseUrl, llmApiKey)),
+    models: withModelLimits(await loadGatewayCatalog(opts)),
   }
+}
+
+// Resolve the model catalog. A baked file (org-stable, written by a step that has
+// the catalog without a per-session token) wins — that's what lets a tokenless
+// warm seed bake the FULL catalog. Otherwise fetch from the real gateway (needs a
+// real base+key; only present in direct mode). Falls back to the minimal set.
+async function loadGatewayCatalog(opts: KortixProviderOpts): Promise<Record<string, KortixGatewayModel>> {
+  if (opts.catalogFile) {
+    try {
+      const raw = readFileSync(opts.catalogFile, 'utf8')
+      const parsed = JSON.parse(raw) as { models?: Record<string, KortixGatewayModel> } | Record<string, KortixGatewayModel>
+      const models = (parsed && typeof parsed === 'object' && 'models' in parsed
+        ? (parsed as { models?: Record<string, KortixGatewayModel> }).models
+        : (parsed as Record<string, KortixGatewayModel>)) ?? {}
+      if (Object.keys(models).length > 0) {
+        logger.info(`[opencode] loaded ${Object.keys(models).length} gateway models from baked catalog ${opts.catalogFile}`)
+        return models
+      }
+      logger.warn(`[opencode] baked catalog ${opts.catalogFile} was empty; falling back`)
+    } catch (err) {
+      logger.warn(`[opencode] baked catalog read failed (${opts.catalogFile}): ${(err as Error).message}; falling back`)
+    }
+  }
+  if (opts.fetchBaseURL && opts.fetchApiKey) {
+    return fetchGatewayModels(opts.fetchBaseURL, opts.fetchApiKey)
+  }
+  logger.warn('[opencode] no baked catalog and no gateway credentials to fetch; using minimal fallback')
+  return MINIMAL_FALLBACK_MODELS
 }
 
 export const buildExecutorMcpConfigContent = buildOpencodeConfigContent


### PR DESCRIPTION
**Flag-off (`KORTIX_LLM_HOTSWAP`, default OFF) — zero behavior change until enabled.**

Warm-fork attach restarted opencode (~8s measured) purely to swap the per-session gateway + executor tokens into config opencode only reads at spawn — discarding the snapshot's baked-warm opencode. Under the flag, the seed bakes a **session-independent** opencode config: gateway provider + executor MCP point at two localhost credential-injecting proxies (placeholder keys); on claim the daemon swaps the real per-session tokens into the proxies **live and skips the restart**. The executor MCP makes no network call until a tool is invoked, so a tokenless seed bakes the full tool surface and the first post-claim tool call carries the injected token.

- Stateful/warm-pool path only; opt-in; **best-effort** — any missing precondition falls through to the **exact existing** `reconfigure()+restart()`.
- Cold platinum + Daytona **byte-identical** (direct provider/MCP config unchanged; 21/21 executor-mcp-config tests pass). Daemon typecheck clean.
- bootMarks: `pool-llm-proxy-started`, `pool-executor-proxy-started`, `claim-opencode-hotswapped`, `claim-executor-tools-ready`.

**Before flipping the flag on (follow-ups, not in this PR):**
1. apps/api **PARK-authed catalog endpoint** (`KORTIX_LLM_CATALOG_URL`) so the seed bakes the full model picker (else ~11-model fallback; LLM + tools unaffected). Security-bearing — authorize via `validateAccountToken`→accountId/projectId like the git proxy at park, return `gatewayModelCatalog(projectId,userId)`.
2. Wire `KORTIX_LLM_CATALOG_URL` into the warm-fork captureEnv.
3. Proxy unit test (token-injection + proxy-mode config) for the CI gate.
4. Local e2e with the flag on → confirm `claim-opencode-hotswapped` + tools + ~3-5s.