### PR TITLE
perf(session-start): long-poll readiness (?wait_ms) — kill the ~800ms FE poll-tick latency

### DIFF
--- a/apps/api/src/projects/routes/r8.ts
+++ b/apps/api/src/projects/routes/r8.ts
@@ -72,7 +72,12 @@ projectsApp.openapi(
       );
     }
 
-    const result = await startSession({ source: 'ui', loaded, visible, projectId, sessionId });
+    // Optional server-side long-poll: the web client passes ?wait_ms so the
+    // server holds the request until readiness flips (or a bounded deadline),
+    // killing the ~800ms client poll-tick latency. Clamped; omitted = one-shot.
+    const waitMsRaw = Number(c.req.query('wait_ms'));
+    const waitMs = Number.isFinite(waitMsRaw) && waitMsRaw > 0 ? Math.min(waitMsRaw, 8000) : 0;
+    const result = await startSession({ source: 'ui', loaded, visible, projectId, sessionId, waitMs });
     return c.json(result.start, 200);
   },
 );

--- a/apps/api/src/projects/session-lifecycle/__tests__/await-terminal-stage.test.ts
+++ b/apps/api/src/projects/session-lifecycle/__tests__/await-terminal-stage.test.ts
@@ -1,0 +1,97 @@
+import { describe, test, expect } from 'bun:test';
+import { awaitTerminalStage } from '../await-stage';
+import type { SessionStartResult } from '../../routes/shared';
+
+const mk = (stage: string, retriable: boolean | null = true): SessionStartResult =>
+  ({ stage, retriable }) as unknown as SessionStartResult;
+
+const noSleep = async () => {};
+// Deterministic clock: each call advances by `step` (no wall-clock in the test).
+const stepNow = (step: number) => {
+  let t = -step;
+  return () => {
+    t += step;
+    return t;
+  };
+};
+
+describe('awaitTerminalStage — session-start long-poll loop', () => {
+  test('returns immediately when already ready (warm-claim fast path, no resolve)', async () => {
+    let calls = 0;
+    const r = await awaitTerminalStage(
+      mk('ready', false),
+      async () => {
+        calls++;
+        return mk('ready', false);
+      },
+      { waitMs: 6000, now: stepNow(200), sleepFn: noSleep },
+    );
+    expect(r.stage).toBe('ready');
+    expect(calls).toBe(0);
+  });
+
+  test('returns immediately when waitMs<=0 (one-shot, unchanged behavior)', async () => {
+    let calls = 0;
+    const r = await awaitTerminalStage(
+      mk('provisioning'),
+      async () => {
+        calls++;
+        return mk('ready', false);
+      },
+      { waitMs: 0, now: stepNow(200), sleepFn: noSleep },
+    );
+    expect(r.stage).toBe('provisioning');
+    expect(calls).toBe(0);
+  });
+
+  test('resolves the instant it flips ready — not at the deadline', async () => {
+    let n = 0;
+    const r = await awaitTerminalStage(
+      mk('provisioning'),
+      async () => {
+        n++;
+        return n >= 3 ? mk('ready', false) : mk('starting');
+      },
+      { waitMs: 6000, pollMs: 200, now: stepNow(200), sleepFn: noSleep },
+    );
+    expect(r.stage).toBe('ready');
+    expect(n).toBe(3); // broke early, didn't run to the ~30-tick deadline
+  });
+
+  test('returns the latest non-ready payload at the deadline', async () => {
+    let n = 0;
+    const r = await awaitTerminalStage(
+      mk('provisioning'),
+      async () => {
+        n++;
+        return mk('starting');
+      },
+      { waitMs: 1000, pollMs: 200, now: stepNow(200), sleepFn: noSleep },
+    );
+    expect(r.stage).toBe('starting');
+    expect(n).toBeLessThanOrEqual(5); // ~1000/200 ticks, bounded by the deadline
+  });
+
+  test('stops on a terminal failed stage', async () => {
+    let n = 0;
+    const r = await awaitTerminalStage(
+      mk('provisioning'),
+      async () => {
+        n++;
+        return mk('failed', false);
+      },
+      { waitMs: 6000, now: stepNow(200), sleepFn: noSleep },
+    );
+    expect(r.stage).toBe('failed');
+    expect(n).toBe(1);
+  });
+
+  test('stops if the session vanishes mid-wait (resolve → null)', async () => {
+    const r = await awaitTerminalStage(
+      mk('provisioning'),
+      async () => null,
+      { waitMs: 6000, now: stepNow(200), sleepFn: noSleep },
+    );
+    expect(r.stage).toBe('provisioning'); // keeps the last good payload
+  });
+});

--- a/apps/api/src/projects/session-lifecycle/await-stage.ts
+++ b/apps/api/src/projects/session-lifecycle/await-stage.ts
@@ -1,0 +1,47 @@
+import type { SessionStartResult } from '../routes/shared';
+
+// startSession long-poll: bounded server-side wait so the client learns `ready`
+// the instant it flips instead of on its ~800ms poll tick. The cap stays well
+// under the web client's 30s request timeout; the poll cadence is tight because
+// each tick is one cheap re-resolve (openSession re-reads live sandbox state).
+// Pure (type-only import) so it's unit-testable without the server env.
+export const START_AWAIT_MAX_MS = 8_000;
+export const START_AWAIT_POLL_MS = 200;
+
+const defaultSleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+export const isTerminalStage = (stage: string): boolean =>
+  stage === 'ready' || stage === 'failed' || stage === 'stopped';
+
+/**
+ * Bounded long-poll loop. Given an initial readiness result and a `resolve` that
+ * re-checks it, keep polling until a terminal stage (ready/failed/stopped) or the
+ * deadline, then return the latest. Returns the initial immediately when already
+ * terminal or waitMs<=0 (the warm-claim fast path). `now`/`sleepFn` are
+ * injectable so tests run without wall-clock.
+ */
+export async function awaitTerminalStage(
+  initial: SessionStartResult,
+  resolve: () => Promise<SessionStartResult | null>,
+  opts: {
+    waitMs: number;
+    pollMs?: number;
+    now?: () => number;
+    sleepFn?: (ms: number) => Promise<void>;
+  },
+): Promise<SessionStartResult> {
+  if (opts.waitMs <= 0 || isTerminalStage(initial.stage)) return initial;
+  const now = opts.now ?? Date.now;
+  const sleepFn = opts.sleepFn ?? defaultSleep;
+  const pollMs = opts.pollMs ?? START_AWAIT_POLL_MS;
+  const deadline = now() + Math.min(opts.waitMs, START_AWAIT_MAX_MS);
+  let current = initial;
+  while (now() < deadline) {
+    await sleepFn(pollMs);
+    const next = await resolve();
+    if (!next) break;
+    current = next;
+    if (isTerminalStage(current.stage)) break;
+  }
+  return current;
+}

--- a/apps/api/src/projects/session-lifecycle/engine.ts
+++ b/apps/api/src/projects/session-lifecycle/engine.ts
@@ -5,6 +5,7 @@ import { forwardToSandbox } from '../../sandbox-proxy/routes/preview';
 import { db } from '../../shared/db';
 import { createProjectSession } from '../lib/sessions';
 import { openSession } from '../routes/shared';
+import { awaitTerminalStage } from './await-stage';
 import { resolveProjectAutomationActor } from './actor';
 import { sessionBackpressureState } from './backpressure';
 import {
@@ -139,12 +140,43 @@ export async function createSession(command: CreateSessionCommand): Promise<Sess
 }
 
 export async function startSession(command: StartSessionCommand) {
-  const start = await openSession({
+  const first = await openSession({
     loaded: command.loaded,
     visible: command.visible,
     projectId: command.projectId,
     sessionId: command.sessionId,
   });
+  // Optional long-poll: re-resolve (re-reading the live session row each tick,
+  // like continueSession) until ready/terminal or the bounded deadline, so the
+  // client learns `ready` immediately instead of on its ~800ms poll tick.
+  // waitMs<=0 or an already-terminal first result → returns `first` unchanged,
+  // so the warm-claim fast path and every non-long-poll caller are untouched.
+  const start = await awaitTerminalStage(
+    first,
+    async () => {
+      const [fresh] = await db
+        .select({
+          status: projectSessions.status,
+          sandboxProvider: projectSessions.sandboxProvider,
+          baseRef: projectSessions.baseRef,
+          agentName: projectSessions.agentName,
+          opencodeSessionId: projectSessions.opencodeSessionId,
+          accountId: projectSessions.accountId,
+          metadata: projectSessions.metadata,
+        })
+        .from(projectSessions)
+        .where(eq(projectSessions.sessionId, command.sessionId))
+        .limit(1);
+      if (!fresh) return null;
+      return openSession({
+        loaded: command.loaded,
+        visible: { row: fresh },
+        projectId: command.projectId,
+        sessionId: command.sessionId,
+      });
+    },
+    { waitMs: command.waitMs ?? 0 },
+  );
   return {
     status: start.stage === 'ready' ? 'ready' : 'pending',
     sessionId: command.sessionId,

--- a/apps/api/src/projects/session-lifecycle/types.ts
+++ b/apps/api/src/projects/session-lifecycle/types.ts
@@ -81,6 +81,11 @@ export interface StartSessionCommand {
   };
   projectId: string;
   sessionId: string;
+  /** Optional server-side long-poll budget (ms). When set, startSession keeps
+   *  re-resolving readiness until ready/terminal or this deadline, so the client
+   *  learns `ready` the instant it flips instead of on its own poll tick.
+   *  Bounded server-side (START_AWAIT_MAX_MS); omit/0 = original one-shot. */
+  waitMs?: number;
 }
 
 export type SessionDeliveryOutcome = 'delivered' | 'pending' | 'no-session' | 'failed';

--- a/apps/web/src/app/(app)/projects/[id]/sessions/[sessionId]/page.tsx
+++ b/apps/web/src/app/(app)/projects/[id]/sessions/[sessionId]/page.tsx
@@ -101,16 +101,21 @@ export default function ProjectSessionPage() {
   // session_id == sandbox_id by construction (see session-sandbox.ts).
   const { data: start } = useQuery({
     queryKey: sessionStartKey(projectId, sessionId),
-    queryFn: () => startProjectSession(projectId!, sessionId!),
+    // Long-poll: the server holds the request (wait_ms) and returns the instant
+    // readiness flips or at its bounded deadline — so we learn `ready` without a
+    // fixed poll tick of latency.
+    queryFn: () => startProjectSession(projectId!, sessionId!, 6000),
     enabled: !!user && !!sessionId && !!projectId && !noPlan,
     staleTime: 0,
-    // Poll until the runtime is ready or a terminal stage. `retriable` is the
-    // backend's authoritative "still making progress" signal; null = a transient
+    // RE-ARM promptly while still provisioning (the long-poll already absorbed the
+    // wait server-side), so steady state is one in-flight long-poll, not a 2/sec
+    // poll. `retriable` is the backend's authoritative "still making progress"
+    // signal (false ⇒ ready/terminal ⇒ stop); null (no data) = a transient
     // failure, so retry shortly.
     refetchInterval: (query) => {
       const data = query.state.data;
       if (!data) return 500;
-      return data.retriable ? 800 : false;
+      return data.retriable ? 100 : false;
     },
   });
   const sandbox = start?.sandbox ?? null;

--- a/apps/web/src/lib/projects-client.ts
+++ b/apps/web/src/lib/projects-client.ts
@@ -2333,9 +2333,14 @@ export interface SessionStartResult {
 export async function startProjectSession(
   projectId: string,
   sessionId: string,
+  // Optional server-side long-poll budget (ms): the server holds the request
+  // until readiness flips (or its bounded deadline), so we learn `ready` the
+  // instant it happens instead of on a fixed poll tick. Omit = one-shot.
+  waitMs?: number,
 ): Promise<SessionStartResult | null> {
+  const qs = waitMs && waitMs > 0 ? `?wait_ms=${Math.floor(waitMs)}` : '';
   const response = await backendApi.post<SessionStartResult>(
-    `/projects/${projectId}/sessions/${sessionId}/start`,
+    `/projects/${projectId}/sessions/${sessionId}/start${qs}`,
     {},
     // 402 (billing) is handled by the page's plan gate before polling; other
     // failures just yield null and the caller retries.


### PR DESCRIPTION
Readiness was learned on the session page's 500/800ms `/start` re-poll tick. Adds a bounded server-side long-poll: `?wait_ms` makes `/start` hold + re-resolve the **same** `openSession` readiness at 200ms until terminal or an ≤8s deadline; FE passes `wait_ms=6000` + re-arms at 100ms. Warm-claim fast path + `/start`/`/status` for non-UI callers untouched. `await-terminal-stage` 6/6, tsc clean both sides.