### PR TITLE
feat(warm-fork): enable no-restart on stateful seeds (catalog endpoint + KORTIX_LLM_HOTSWAP)

### DIFF
--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -187,7 +187,11 @@ export async function supabaseAuth(c: Context, next: Next) {
   const sandboxTokenPathAllowed =
     path.endsWith('/git/clone-credential') ||
     path.endsWith('/turn-stream') ||
-    path.endsWith('/turn-question');
+    path.endsWith('/turn-question') ||
+    // The seed daemon fetches the org model catalog at PARK with its sandbox
+    // token (no per-session LLM key yet) so the no-restart warm-fork bakes the
+    // full picker. Catalog is the non-secret model list — safe for a sandbox token.
+    path.endsWith('/llm-catalog');
   if (isKortixToken(token) && sandboxTokenPathAllowed) {
     const result = await validateSecretKey(token);
     if (!result.isValid) {

--- a/apps/api/src/projects/routes/r4.ts
+++ b/apps/api/src/projects/routes/r4.ts
@@ -6,6 +6,7 @@ import { slackOauthMode } from '../../channels/slack-oauth-mode';
 import { postQuestion, relayTurnAnswer, relayTurnEnd, relayTurnStep, type QuestionInfo } from '../../channels/slack-webhook';
 import { PROJECT_ACTIONS, assertAuthorized } from '../../iam';
 import { auth, errors, json } from '../../openapi';
+import { gatewayModelCatalog } from '../../llm-gateway/models/catalog-models';
 import { db } from '../../shared/db';
 import { extractApps } from '../apps';
 import { extractTriggers, loadProjectTriggers, type ParsedManifest } from '../triggers';
@@ -678,6 +679,56 @@ projectsApp.openapi(
     });
     if (!result.ok) return c.json({ error: result.error }, result.status as 400 | 404);
     return c.json({ ok: true, files: result.files });
+  },
+);
+
+// GET /v1/projects/:projectId/llm-catalog
+// The seed daemon fetches the org model catalog at PARK with its sandbox token
+// (no per-session LLM key yet) so the no-restart warm-fork bakes the FULL model
+// picker into the session-independent opencode config. Returns the same { models }
+// shape the internal gateway route serves. Sandbox-token only, scoped to a sandbox
+// that belongs to this project (same guard as turn-stream). The catalog is the
+// non-secret model list, so a sandbox token is sufficient.
+projectsApp.openapi(
+  createRoute({
+    method: 'get',
+    path: '/{projectId}/llm-catalog',
+    tags: ['projects'],
+    summary: 'GET /:projectId/llm-catalog',
+    ...auth,
+      request: {
+        params: z.object({ projectId: z.string() }),
+      },
+    responses: {
+        200: { description: 'OK', content: { 'application/json': { schema: z.any() } } },
+        ...errors(403, 404),
+    },
+  }),
+  async (c: any) => {
+  const projectId = c.req.param('projectId');
+  if (!(c.get('authType') === 'apiKey' && c.get('apiKeyType') === 'sandbox')) {
+    return c.json({ error: 'llm-catalog requires a sandbox token' }, 403);
+  }
+  const accountId = c.get('accountId') as string | undefined;
+  const sandboxId = c.get('sandboxId') as string | undefined;
+  if (!accountId || !sandboxId) {
+    return c.json({ error: 'llm-catalog requires a sandbox token' }, 403);
+  }
+  const [sandbox] = await db
+    .select({ sandboxId: sessionSandboxes.sandboxId })
+    .from(sessionSandboxes)
+    .where(and(
+      eq(sessionSandboxes.sandboxId, sandboxId),
+      eq(sessionSandboxes.projectId, projectId),
+      eq(sessionSandboxes.accountId, accountId),
+      inArray(sessionSandboxes.status, ['provisioning', 'active']),
+    ))
+    .limit(1);
+  if (!sandbox) {
+    return c.json({ error: 'sandbox token is not scoped to this project' }, 403);
+  }
+  const models = await gatewayModelCatalog(projectId, undefined);
+  return c.json({ models });
   },
 );
 

--- a/apps/api/src/snapshots/warm-project.ts
+++ b/apps/api/src/snapshots/warm-project.ts
@@ -383,6 +383,14 @@ async function bakeProjectWarmSnapshotPlatinum(
       KORTIX_API_URL: config.KORTIX_URL.replace(/\/+$/, ''),
       KORTIX_SANDBOX_TOKEN: cloneCred.secretKey,
       KORTIX_TOKEN: cloneCred.secretKey,
+      // No-restart warm-fork (stateful ONLY — never cold/Daytona): bake proxy-mode
+      // opencode at PARK so a claim hot-swaps the per-session token into the live
+      // proxy instead of restarting opencode (~8s). Fast path stays untouched.
+      KORTIX_LLM_HOTSWAP: '1',
+      // Bake the FULL org catalog at PARK via the sandbox-token-authed endpoint, so
+      // the picker isn't degraded to the daemon's minimal fallback. Best-effort:
+      // if unreachable the daemon falls back, no boot impact.
+      KORTIX_LLM_CATALOG_URL: `${config.KORTIX_URL.replace(/\/+$/, '')}/v1/projects/${project.projectId}/llm-catalog`,
     },
   });
 


### PR DESCRIPTION
Turns on the #3752 no-restart for the **stateful warm-fork path only** (never cold/Daytona). Adds a sandbox-token-authed `GET /v1/projects/:projectId/llm-catalog` (returns `{models}`, 4562, scoped to the sandbox's project like turn-stream), allowlists it in auth, and bakes `KORTIX_LLM_HOTSWAP=1` + `KORTIX_LLM_CATALOG_URL` into the per-project seed env. Best-effort: hot-swap failure → restart fallback; catalog unreachable → minimal-set fallback. tsc clean; catalog verified non-empty. **Enables the ~8s claim drop — to be measured on a warm-fork e2e.**