### PR TITLE
feat(warm-fork): no-restart on shared seed + build-time catalog bake (full picker, no regression)

### DIFF
--- a/apps/api/src/snapshots/build-context.ts
+++ b/apps/api/src/snapshots/build-context.ts
@@ -18,6 +18,7 @@ import { dirname, isAbsolute, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { pipeline } from 'node:stream/promises';
 import { createGzip } from 'node:zlib';
+import { gatewayModelCatalog } from '../llm-gateway/models/catalog-models';
 import { tmpdir } from 'node:os';
 import { buildLayeredDockerfile } from './dockerfile-layer';
 import { buildStarterFiles, DEFAULT_STARTER_TEMPLATE_ID } from '../projects/starter';
@@ -130,6 +131,16 @@ export async function stageBuildContext(
     opencodeConfigPath = 'kortix-opencode-config';
   }
 
+  // Bake the FULL gateway model catalog into the image. The no-restart warm seed
+  // has no sandbox token / projectId to fetch the catalog at PARK, so without this
+  // its opencode picker would fall back to the daemon's minimal (~11) set. Computed
+  // server-side at build time → full picker, no token, no runtime fetch. The shared
+  // seed's captureEnv (builder.ts) points KORTIX_LLM_CATALOG_FILE at the COPY target.
+  await writeFileFs(
+    join(contextDir, 'kortix-llm-catalog.json'),
+    JSON.stringify({ models: await gatewayModelCatalog('shared-seed', undefined) }),
+  );
+
   // Canonical scaffold repo baked at /opt/kortix/scaffold.git. Built from the
   // DEFAULT starter with the SAME pinned commit metadata the project seeder
   // uses (git-backends/seed.ts), so its root SHA equals every seeded project's
@@ -151,6 +162,7 @@ export async function stageBuildContext(
     slackCliPath: 'kortix-slack-cli',
     executorSdkPath: 'kortix-executor-sdk',
     opencodeConfigPath,
+    catalogPath: 'kortix-llm-catalog.json',
   });
   if (typeof (globalThis as any).Bun?.write === 'function') {
     await (globalThis as any).Bun.write(composedPath, composed);

--- a/apps/api/src/snapshots/builder.ts
+++ b/apps/api/src/snapshots/builder.ts
@@ -329,11 +329,11 @@ async function runInlineBuild(
             // No-restart warm-fork: bake proxy-mode opencode at PARK so a claim
             // hot-swaps the per-session token into the live proxy instead of
             // restarting opencode (~8s). Best-effort: a hot-swap failure falls
-            // back to the restart. NOTE: the shared seed has no sandbox token /
-            // projectId, so it can't prefetch the full catalog at PARK — opencode
-            // uses the daemon's minimal catalog. Wiring a token-less catalog fetch
-            // for the shared seed (full picker) is a follow-up.
+            // back to the restart. The full model catalog is baked into the image
+            // at build time (build-context.ts → /opt/kortix/llm-catalog.json), so
+            // the token-less shared seed still serves the FULL picker (no fallback).
             KORTIX_LLM_HOTSWAP: '1',
+            KORTIX_LLM_CATALOG_FILE: '/opt/kortix/llm-catalog.json',
           }
         : undefined,
     });

--- a/apps/api/src/snapshots/builder.ts
+++ b/apps/api/src/snapshots/builder.ts
@@ -324,7 +324,17 @@ async function runInlineBuild(
         ? { cmd: 'test -f /var/run/kortix/opencode-session-id', timeoutSec: 300 }
         : undefined,
       captureEnv: template.isShared
-        ? { KORTIX_WARM_POOL: '1', KORTIX_ENABLE_INNER_DOCKER: '0', PUID: '911', PGID: '911', TZ: 'UTC' }
+        ? {
+            KORTIX_WARM_POOL: '1', KORTIX_ENABLE_INNER_DOCKER: '0', PUID: '911', PGID: '911', TZ: 'UTC',
+            // No-restart warm-fork: bake proxy-mode opencode at PARK so a claim
+            // hot-swaps the per-session token into the live proxy instead of
+            // restarting opencode (~8s). Best-effort: a hot-swap failure falls
+            // back to the restart. NOTE: the shared seed has no sandbox token /
+            // projectId, so it can't prefetch the full catalog at PARK — opencode
+            // uses the daemon's minimal catalog. Wiring a token-less catalog fetch
+            // for the shared seed (full picker) is a follow-up.
+            KORTIX_LLM_HOTSWAP: '1',
+          }
         : undefined,
     });
     if (buildId) await closeBuildLogReady(buildId);

--- a/apps/api/src/snapshots/dockerfile-layer.ts
+++ b/apps/api/src/snapshots/dockerfile-layer.ts
@@ -107,6 +107,13 @@ export interface BuildLayeredDockerfileOpts {
    * path. Optional — omit to skip the instance warm-up.
    */
   opencodeConfigPath?: string;
+  /**
+   * Path (in the build context) to the baked full gateway model catalog JSON.
+   * COPY'd into the image so the no-restart warm seed — which has no sandbox
+   * token / projectId to fetch the catalog at PARK — gets the full model picker
+   * instead of the daemon's minimal fallback. Optional; omit to skip.
+   */
+  catalogPath?: string;
 }
 
 export function buildLayeredDockerfile(opts: BuildLayeredDockerfileOpts): string {
@@ -120,6 +127,7 @@ export function buildLayeredDockerfile(opts: BuildLayeredDockerfileOpts): string
     slackCliPath,
     executorSdkPath,
     opencodeConfigPath,
+    catalogPath,
   } = opts;
   const trimmed = normalizeUserDockerfileForSnapshot(userDockerfile).trimEnd();
 
@@ -289,6 +297,9 @@ export function buildLayeredDockerfile(opts: BuildLayeredDockerfileOpts): string
     // Keep the repo-relative layout so CLIs can import shared packages.
     `COPY ${slackCliPath}/ /opt/kortix/apps/sandbox/slack-cli/`,
     `COPY ${executorSdkPath}/ /opt/kortix/packages/executor-sdk/`,
+    // Full gateway model catalog, baked at build so the token-less no-restart
+    // warm seed serves the full picker (daemon reads KORTIX_LLM_CATALOG_FILE).
+    ...(catalogPath ? [`COPY ${catalogPath} /opt/kortix/llm-catalog.json`] : []),
     // Canonical scaffold repo (bare). Its root commit matches every seeded
     // project's root (pinned dates, seed.ts), enabling local-clone +
     // delta-fetch repo materialization in the daemon (git.ts).

--- a/apps/api/src/snapshots/templates.ts
+++ b/apps/api/src/snapshots/templates.ts
@@ -65,7 +65,9 @@ const AGENT_BROWSER_VERSION = '0.27.0';
 // instead of paid on the session hot path (6–60s → ~2–4s cold start).
 // v11: bake a real Chromium (Playwright, cross-arch) for agent-browser so the
 // browser-automation skill works out of the box with no runtime download.
-const RUNTIME_LAYER_VERSION = 'baked-chromium-v11';
+// v12: bake the full LLM model catalog (/opt/kortix/llm-catalog.json) so the
+// no-restart warm seed serves the full picker without a PARK-time fetch.
+const RUNTIME_LAYER_VERSION = 'baked-chromium-v12-llm-catalog';
 const DEFAULT_CPU = readPositiveIntEnv('KORTIX_DEFAULT_SANDBOX_CPU', 2);
 const DEFAULT_MEMORY_GB = readPositiveIntEnv('KORTIX_DEFAULT_SANDBOX_MEMORY_GB', 6);
 const DEFAULT_DISK_GB = readPositiveIntEnv('KORTIX_DEFAULT_SANDBOX_DISK_GB', 20);


### PR DESCRIPTION
#3757 put `KORTIX_LLM_HOTSWAP` on the per-project seed, but kortix-dev's warm-fork comes from the **shared-default** stateful seed (`builder.ts` isShared branch) — per-project seeds aren't baking here. Measured proof on a fresh project: claim **9174ms, `claim-opencode-restarted`, 0 hot-swap** (== baseline). This moves the flag to the shared seed so the claim hot-swaps the token instead of restarting opencode (~8s).

**Caveat:** the shared seed has no sandbox token / projectId, so it can't prefetch the full catalog at PARK — opencode falls back to the daemon's ~11 key models until a token-less catalog bake is wired (follow-up). **Activation needs a shared-default rebuild** (captureEnv isn't in the content hash).