### PR TITLE
fix: restore Slack custom app flow

### DIFF
--- a/apps/api/src/__tests__/unit-slack-oauth.test.ts
+++ b/apps/api/src/__tests__/unit-slack-oauth.test.ts
@@ -17,12 +17,14 @@ function makeSelectChain(): any {
 }
 
 mock.module('../shared/db', () => ({
+  hasDatabase: true,
   db: {
     select: () => makeSelectChain(),
   },
 }));
 
 mock.module('../config', () => ({
+  SANDBOX_VERSION: 'test',
   config: {
     SLACK_SIGNING_SECRET: 'state-secret',
     SLACK_CLIENT_ID: 'client-id',
@@ -38,6 +40,10 @@ mock.module('../channels/install-store', () => ({
     saveCalls.push(input);
     if (saveError) throw saveError;
   },
+}));
+
+mock.module('../executor/sync', () => ({
+  reconcileChannelConnectors: async () => undefined,
 }));
 
 const realFetch = globalThis.fetch;
@@ -78,12 +84,12 @@ function redirectLocation(res: Response): string {
 }
 
 describe('Slack OAuth callback', () => {
-  test('saves a project-scoped install and redirects to the project channels page', async () => {
+  test('saves a project-scoped install and redirects to the project connectors page', async () => {
     const res = await slackOauthApp.request(`/callback?code=code-1&state=${stateFromInstallUrl()}`);
 
     expect(res.status).toBe(302);
     expect(redirectLocation(res)).toBe(
-      `https://dev.kortix.com/projects/${PROJECT_ID}/customize?projectId=${PROJECT_ID}&success=1&section=channels`,
+      `https://dev.kortix.com/projects/${PROJECT_ID}?projectId=${PROJECT_ID}&success=1&customize=connectors`,
     );
     expect(saveCalls).toEqual([{
       projectId: PROJECT_ID,
@@ -101,7 +107,7 @@ describe('Slack OAuth callback', () => {
 
     expect(res.status).toBe(302);
     expect(redirectLocation(res)).toBe(
-      `https://dev.kortix.com/projects/${PROJECT_ID}/customize?projectId=${PROJECT_ID}&error=slack_install_save_failed&section=channels`,
+      `https://dev.kortix.com/projects/${PROJECT_ID}?projectId=${PROJECT_ID}&error=slack_install_save_failed&customize=connectors`,
     );
     expect(saveCalls).toHaveLength(1);
   });
@@ -115,7 +121,23 @@ describe('Slack OAuth callback', () => {
 
     expect(res.status).toBe(302);
     expect(redirectLocation(res)).toBe(
-      `https://dev.kortix.com/projects/${PROJECT_ID}/customize?projectId=${PROJECT_ID}&error=oauth_exchange_failed&section=channels`,
+      `https://dev.kortix.com/projects/${PROJECT_ID}?projectId=${PROJECT_ID}&error=oauth_exchange_failed&customize=connectors`,
+    );
+    expect(saveCalls).toHaveLength(0);
+  });
+
+  test('redirects to the project when Slack rejects the authorization code', async () => {
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ ok: false, error: 'invalid_code' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })) as any;
+
+    const res = await slackOauthApp.request(`/callback?code=code-4&state=${stateFromInstallUrl()}`);
+
+    expect(res.status).toBe(302);
+    expect(redirectLocation(res)).toBe(
+      `https://dev.kortix.com/projects/${PROJECT_ID}?projectId=${PROJECT_ID}&error=invalid_code&customize=connectors`,
     );
     expect(saveCalls).toHaveLength(0);
   });

--- a/apps/api/src/channels/slack-oauth.ts
+++ b/apps/api/src/channels/slack-oauth.ts
@@ -91,10 +91,9 @@ slackOauthApp.openapi(
   const code = c.req.query('code');
   const state = c.req.query('state');
   const slackError = c.req.query('error');
-  if (slackError) return redirectToDashboard(c, { error: slackError });
+  const payload = state ? verifyState(state) : null;
+  if (slackError) return redirectToDashboard(c, { projectId: payload?.projectId, error: slackError });
   if (!code || !state) return c.json({ error: 'Missing code or state' }, 400);
-
-  const payload = verifyState(state);
   if (!payload) return c.json({ error: 'Invalid or expired state' }, 400);
 
   const exchangeBody = new URLSearchParams({
@@ -120,7 +119,10 @@ slackOauthApp.openapi(
     return redirectToDashboard(c, { projectId: payload.projectId, error: 'oauth_exchange_failed' });
   }
   if (!tokenJson.ok || !tokenJson.access_token || !tokenJson.team?.id) {
-    return redirectToDashboard(c, { error: tokenJson.error ?? 'oauth_exchange_failed' });
+    return redirectToDashboard(c, {
+      projectId: payload.projectId,
+      error: tokenJson.error ?? 'oauth_exchange_failed',
+    });
   }
 
   let project: { projectId: string } | undefined;
@@ -138,7 +140,9 @@ slackOauthApp.openapi(
     });
     return redirectToDashboard(c, { projectId: payload.projectId, error: 'project_lookup_failed' });
   }
-  if (!project) return redirectToDashboard(c, { error: 'project_not_found' });
+  if (!project) {
+    return redirectToDashboard(c, { projectId: payload.projectId, error: 'project_not_found' });
+  }
 
   try {
     await saveSlackOauthInstall({
@@ -177,13 +181,12 @@ function redirectToDashboard(
   for (const [k, v] of Object.entries(qs)) {
     if (v) params.set(k, v);
   }
-  // Channels lives in the Customize overlay (no standalone /channels route) — it's
-  // opened via /projects/:id/customize?section=channels. Redirecting to the old
-  // /projects/:id/channels 404'd after a successful install. With no project (an
-  // error before the project resolved) fall back to the dashboard home.
-  if (qs.projectId) params.set('section', 'channels');
+  // Land on the real project page, then let the web shell open Customize from
+  // query params. The /customize shim renders null while client routing runs,
+  // which is too fragile as an external OAuth callback target.
+  if (qs.projectId) params.set('customize', 'connectors');
   const target = qs.projectId
-    ? `${base}/projects/${qs.projectId}/customize?${params.toString()}`
+    ? `${base}/projects/${qs.projectId}?${params.toString()}`
     : `${base}/?${params.toString()}`;
   return c.redirect(target, 302);
 }

--- a/apps/web/src/components/projects/customize/sections/connectors-view.slack-channel.test.ts
+++ b/apps/web/src/components/projects/customize/sections/connectors-view.slack-channel.test.ts
@@ -10,4 +10,15 @@ describe('Slack channel connector catalogue', () => {
     expect(source).toContain('<AddSlackProfileCard projectId={projectId} onAdded={onAdded} />');
     expect(source).not.toMatch(/<ChannelProfileCard[\s\S]*slug="kortix_slack"/);
   });
+
+  test('keeps the full custom Slack app manifest setup before token fields', () => {
+    expect(source).toContain('Use custom Slack app');
+    expect(source).toContain('Bring your own Slack app');
+    expect(source).toContain('App manifest');
+    expect(source).toContain('copyManifest');
+    expect(source).toContain('https://api.slack.com/apps?new_app=1');
+    expect(source).toContain('Click Open Slack, choose "From a manifest", paste the JSON, confirm.');
+    expect(source).toContain('On the next screen, click Install to Workspace and approve.');
+    expect(source).toContain('Copy the Bot User OAuth Token (xoxb-...) and Signing Secret.');
+  });
 });

--- a/apps/web/src/components/projects/customize/sections/connectors-view.tsx
+++ b/apps/web/src/components/projects/customize/sections/connectors-view.tsx
@@ -1478,22 +1478,24 @@ function SlackConnectForm({ projectId, onConnected }: { projectId: string; onCon
           <ChevronDown
             className={cn('h-3.5 w-3.5 transition-transform', showCustom && 'rotate-180')}
           />
-          Bring your own Slack app
+          Use custom Slack app
         </Button>
         {showCustom ? (
-          <div className="space-y-4">
-            <p className="text-muted-foreground text-sm">
-              For self-hosted setups or custom-scoped installs.
-            </p>
-            <div className="space-y-3 rounded-2xl border border-border/60 bg-card p-4">
-              <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-                <div>
+          <div className="space-y-5 rounded-2xl border border-border/60 bg-card p-4">
+            <div className="space-y-1">
+              <h3 className="text-foreground text-base font-semibold">Bring your own Slack app</h3>
+              <p className="text-muted-foreground text-sm">
+                For self-hosted setups or custom-scoped installs.
+              </p>
+            </div>
+
+            <div className="space-y-3">
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+                <div className="space-y-1">
                   <div className="text-foreground text-sm font-medium">
                     Step 1 of 2 - paste the manifest into Slack and install the app.
                   </div>
-                  <p className="text-muted-foreground mt-0.5 text-xs">
-                    Click Open Slack, choose "From a manifest", paste the JSON, then approve the app.
-                  </p>
+                  <div className="text-muted-foreground text-xs font-medium">App manifest</div>
                 </div>
                 <div className="flex shrink-0 items-center gap-2">
                   <Button
@@ -1519,6 +1521,7 @@ function SlackConnectForm({ projectId, onConnected }: { projectId: string; onCon
                   </Button>
                 </div>
               </div>
+
               {manifest.isLoading ? (
                 <Skeleton className="h-52 w-full rounded-2xl" />
               ) : manifest.isError ? (
@@ -1526,12 +1529,28 @@ function SlackConnectForm({ projectId, onConnected }: { projectId: string; onCon
                   {(manifest.error as Error)?.message || 'Failed to load Slack manifest'}
                 </InfoBanner>
               ) : manifest.data ? (
-                <div className="max-h-72 overflow-auto rounded-2xl">
+                <div className="max-h-[26rem] overflow-auto rounded-2xl">
                   <CodeSnippet code={manifest.data} language="json" />
                 </div>
               ) : null}
+
+              <ol className="space-y-2">
+                {[
+                  'Click Open Slack, choose "From a manifest", paste the JSON, confirm.',
+                  'On the next screen, click Install to Workspace and approve.',
+                  'Copy the Bot User OAuth Token (xoxb-...) and Signing Secret.',
+                ].map((step, index) => (
+                  <li key={step} className="flex gap-2 text-xs text-muted-foreground">
+                    <span className="border-border/60 bg-muted/40 text-foreground flex h-5 w-5 shrink-0 items-center justify-center rounded-full border text-xs font-medium">
+                      {index + 1}
+                    </span>
+                    <span className="pt-0.5">{step}</span>
+                  </li>
+                ))}
+              </ol>
             </div>
-            <div className="space-y-3 rounded-2xl border border-border/60 bg-card p-4">
+
+            <div className="space-y-3">
               <div>
                 <div className="text-foreground text-sm font-medium">
                   Step 2 of 2 - paste tokens from Slack.

--- a/apps/web/src/features/co-worker/project-layout/project-shell.tsx
+++ b/apps/web/src/features/co-worker/project-layout/project-shell.tsx
@@ -2,7 +2,7 @@
 
 import { useQuery } from '@tanstack/react-query';
 import { AnimatePresence, motion } from 'motion/react';
-import { useParams, useRouter } from 'next/navigation';
+import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import { Suspense, lazy, useCallback, useEffect, useLayoutEffect, useMemo } from 'react';
 
 import { AppsOverlay } from '@/components/projects/apps/apps-overlay';
@@ -18,9 +18,11 @@ import { useGatewayCatalogSync } from '@/hooks/opencode/use-gateway-catalog-sync
 import { useNewProjectSession } from '@/hooks/projects/use-new-project-session';
 import { useProjectShellShortcuts } from '@/hooks/projects/use-project-shell-shortcuts';
 import { useIsMobile } from '@/hooks/use-mobile';
+import { parseCustomizeSection } from '@/lib/customize-sections';
 import { getProjectDetail } from '@/lib/projects-client';
 import { cn } from '@/lib/utils';
 import { BillingAccountProvider } from '@/stores/billing-account-context';
+import { useCustomizeStore } from '@/stores/customize-store';
 import { useProjectSessionTabsStore } from '@/stores/project-session-tabs-store';
 import { useIsSwitchingProject } from '@/stores/project-switch-store';
 import { useUserPreferencesStore } from '@/stores/user-preferences-store';
@@ -39,6 +41,7 @@ interface ProjectShellProps {
 
 export function ProjectShell({ projectId, initialSidebarOpen, children }: ProjectShellProps) {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const { user, isLoading: authLoading } = useAuth();
 
   const { data: projectDetail } = useQuery({
@@ -52,6 +55,17 @@ export function ProjectShell({ projectId, initialSidebarOpen, children }: Projec
   useEffect(() => {
     if (!authLoading && !user) router.replace('/auth');
   }, [authLoading, user, router]);
+
+  useEffect(() => {
+    const section = parseCustomizeSection(searchParams.get('customize'));
+    if (!section) return;
+    useCustomizeStore.getState().openCustomize(section);
+
+    const next = new URLSearchParams(searchParams.toString());
+    next.delete('customize');
+    const query = next.toString();
+    router.replace(`/projects/${projectId}${query ? `?${query}` : ''}`, { scroll: false });
+  }, [projectId, router, searchParams]);
 
   useEffect(() => {
     try {


### PR DESCRIPTION
## Summary
- restore the full custom Slack app setup flow in Connectors > Channels > Slack: manifest, Copy, Open Slack, numbered Slack install steps, then token fields
- redirect Slack OAuth callbacks to the real project page with customize=connectors so the Customize overlay opens without the blank /customize shim
- preserve valid project state for Slack OAuth error responses like invalid_code so failures also land back on the connector page

## Verification
- cd apps/web && pnpm exec eslint src/components/projects/customize/sections/connectors-view.tsx src/components/projects/customize/sections/connectors-view.slack-channel.test.ts src/features/co-worker/project-layout/project-shell.tsx --max-warnings=0
- cd apps/web && bun test src/components/projects/customize/sections/connectors-view.slack-channel.test.ts
- cd apps/api && bun test src/__tests__/unit-slack-oauth.test.ts
- cd apps/web && pnpm exec tsc --noEmit --pretty false
- git diff --check
- local callback smoke: fake Slack code + valid state returns 302 to /projects/:id?projectId=:id&error=invalid_code&customize=connectors
- browser smoke: /projects/:id?customize=connectors opens Customize > Connectors; Slack dialog shows Add to Slack and restored custom app manifest flow