### PR TITLE
Fix auto model upstream routing

### DIFF
--- a/apps/api/src/__tests__/unit-resolve-candidates-free-tier.test.ts
+++ b/apps/api/src/__tests__/unit-resolve-candidates-free-tier.test.ts
@@ -16,8 +16,11 @@ mock.module('@kortix/llm-gateway', () => ({
 }));
 
 mock.module('@kortix/shared/llm-catalog', () => ({
+  pickAutoModel: (model: string) => (model === 'auto' || model === 'kortix/auto' ? 'owl-alpha' : null),
   getManagedModel: (model: string) =>
-    model === 'claude-sonnet-4.6' ? { id: model, transport: 'openrouter' } : null,
+    model === 'claude-sonnet-4.6' || model === 'owl-alpha'
+      ? { id: model, transport: 'openrouter' }
+      : null,
 }));
 
 mock.module('../config', () => ({
@@ -102,6 +105,15 @@ describe('resolveCandidates free-tier premium gate', () => {
     const candidates = await resolveCandidates(principal('team-managed'), 'claude-sonnet-4.6');
     expect(candidates).toHaveLength(1);
     expect(candidates[0]?.billingMode).toBe('credits');
+    expect(accountTierCalls).toBe(1);
+  });
+
+  test('resolves raw auto to a concrete managed upstream for stale gateway callers', async () => {
+    accountTier = 'per_seat';
+    const candidates = await resolveCandidates(principal('team-auto'), 'auto');
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]?.provider).toBe('openrouter');
+    expect(candidates[0]?.resolvedModel).toBe('owl-alpha');
     expect(accountTierCalls).toBe(1);
   });
 

--- a/apps/api/src/llm-gateway/models/catalog-models.ts
+++ b/apps/api/src/llm-gateway/models/catalog-models.ts
@@ -76,14 +76,14 @@ export function managedModels(): Record<string, GatewayModel> {
   const out: Record<string, GatewayModel> = {};
   // AUTO is synthetic (not a real model): it accepts images because pickAutoModel
   // routes image-bearing requests to a vision-capable model. Its window matches
-  // its default target (GLM 5.2) so OpenCode sizes conversations the same.
+  // its default target (Owl Alpha) so OpenCode sizes conversations the same.
   out[AUTO_MODEL_ID] = {
     name: 'Auto',
-    reasoning: true,
+    reasoning: false,
     tool_call: true,
     attachment: true,
     temperature: true,
-    limit: { context: 1_048_576, output: 64_000 },
+    limit: { context: 1_048_756, output: 262_144 },
   };
   // The managed lineup is curated and its slugs don't all exist on models.dev
   // (z-ai≠zhipuai, dotted vs dashed Claude ids), so vision + limit are explicit

--- a/apps/api/src/llm-gateway/resolution/resolve-candidates.ts
+++ b/apps/api/src/llm-gateway/resolution/resolve-candidates.ts
@@ -3,7 +3,7 @@ import {
   type UpstreamDescriptor,
   resolveCatalogUpstream,
 } from '@kortix/llm-gateway';
-import { getManagedModel } from '@kortix/shared/llm-catalog';
+import { getManagedModel, pickAutoModel } from '@kortix/shared/llm-catalog';
 import { getAccountTier } from '../../billing/services/entitlements';
 import { tierGrantsAllModels } from '../../billing/services/tiers';
 import { config } from '../../config';
@@ -41,12 +41,16 @@ export async function resolveCandidates(
   principal: AuthedPrincipal,
   model: string,
 ): Promise<UpstreamDescriptor[]> {
-  const provider = model.includes('/') ? model.split('/')[0] : '';
+  // The gateway package normally applies pickAutoModel before calling this hook.
+  // Keep the same fallback here so a stale standalone gateway that asks the API
+  // to resolve raw "auto" still gets a concrete upstream instead of 400ing.
+  const effectiveModel = pickAutoModel(model, {}) ?? model;
+  const provider = effectiveModel.includes('/') ? effectiveModel.split('/')[0] : '';
 
   if (provider === 'codex') {
     if (!principal.projectId) return [];
     const credential = await resolveCodexCredential(principal.projectId, principal.userId);
-    return credential ? [codexDescriptor(credential, model)] : [];
+    return credential ? [codexDescriptor(credential, effectiveModel)] : [];
   }
 
   const byok = resolveCatalogUpstream(provider);
@@ -66,8 +70,8 @@ export async function resolveCandidates(
         billingMode:
           config.KORTIX_BILLING_INTERNAL_ENABLED && !isFreeTier ? 'platform-fee' : 'none',
         markup: isFreeTier ? 0 : PLATFORM_FEE_MARKUP,
-        resolvedModel: model.slice(provider.length + 1),
-        pricing: livePricing(model.slice(provider.length + 1)),
+        resolvedModel: effectiveModel.slice(provider.length + 1),
+        pricing: livePricing(effectiveModel.slice(provider.length + 1)),
       };
       // Queue a managed model behind the BYOK key: if the user's key hits a
       // rate-limit / quota / billing error, the failover loop falls over to it
@@ -82,7 +86,7 @@ export async function resolveCandidates(
   // `provider/model`) is handled above and requires the user's own key; it never
   // falls through here. A non-managed, non-connected model yields no candidate →
   // clear "model not available" error.
-  const managed = getManagedModel(model);
+  const managed = getManagedModel(effectiveModel);
   if (managed && config.LLM_GATEWAY_ENABLED) {
     if (config.KORTIX_BILLING_INTERNAL_ENABLED) {
       const tier = await resolveCachedAccountTier(principal.accountId);

--- a/packages/llm-gateway/src/pipeline/handler.test.ts
+++ b/packages/llm-gateway/src/pipeline/handler.test.ts
@@ -428,14 +428,17 @@ describe('gateway.chatCompletions — combined authorize hook', () => {
         return [managed];
       },
     });
-    const fetchImpl = okFetch({ model: 'glm', usage: { prompt_tokens: 1, completion_tokens: 1 } });
+    const fetchImpl = okFetch({
+      model: 'openrouter/owl-alpha',
+      usage: { prompt_tokens: 1, completion_tokens: 1 },
+    });
     const res = await createGateway(
       hooks,
-      { retry: fastRetry, autoRouter: (model) => (model === 'auto' ? 'glm-5.2' : null) },
+      { retry: fastRetry, autoRouter: (model) => (model === 'auto' ? 'owl-alpha' : null) },
       { fetchImpl },
     ).chatCompletions({ authorization: 'Bearer good', rawBody: '{"model":"auto"}' });
     expect(res.status).toBe(200);
-    expect(resolvedWith).toBe('glm-5.2'); // resolution saw the routed model, not "auto"
+    expect(resolvedWith).toBe('owl-alpha'); // resolution saw the routed model, not "auto"
     await flush();
     expect(traces[0].requestedModel).toBe('auto'); // trace records what the client asked for
   });
@@ -451,7 +454,7 @@ describe('gateway.chatCompletions — combined authorize hook', () => {
     const fetchImpl = okFetch({ usage: { prompt_tokens: 1, completion_tokens: 1 } });
     await createGateway(
       hooks,
-      { retry: fastRetry, autoRouter: (model) => (model === 'auto' ? 'glm-5.2' : null) },
+      { retry: fastRetry, autoRouter: (model) => (model === 'auto' ? 'owl-alpha' : null) },
       { fetchImpl },
     ).chatCompletions({ authorization: 'Bearer good', rawBody: '{"model":"claude-x"}' });
     expect(resolvedWith).toBe('claude-x');

--- a/packages/shared/src/llm-catalog/index.ts
+++ b/packages/shared/src/llm-catalog/index.ts
@@ -39,7 +39,7 @@ export interface ManagedModel {
   name: string;
   // The upstream's own model id, interpreted per `transport`:
   //   'bedrock'    → a Bedrock id (`us.anthropic.claude-opus-4-8`)
-  //   'openrouter' → an OpenRouter slug (`z-ai/glm-5.2`)
+  //   'openrouter' → an OpenRouter slug (`openrouter/owl-alpha`)
   upstreamModelId: string;
   // Which upstream + wire format carries it:
   //   'bedrock'    → Anthropic-on-Bedrock InvokeModel payload (Claude only)
@@ -92,14 +92,14 @@ export const MANAGED_MODELS: ManagedModel[] = [
     limit: { context: 1_000_000, output: 64_000 },
   },
   {
-    id: 'glm-5.2',
-    name: 'GLM 5.2',
-    upstreamModelId: 'z-ai/glm-5.2',
+    id: 'owl-alpha',
+    name: 'Owl Alpha',
+    upstreamModelId: 'openrouter/owl-alpha',
     transport: 'openrouter',
-    pricingRef: 'z-ai/glm-5.2',
+    pricingRef: 'openrouter/owl-alpha',
     tier: 'balanced',
     vision: false,
-    limit: { context: 1_048_576, output: 64_000 },
+    limit: { context: 1_048_756, output: 262_144 },
   },
   {
     id: 'qwen3.7-max',
@@ -155,13 +155,13 @@ export const MANAGED_FLAGSHIP_MODEL_ID = (
 // request asks for it, the gateway resolves it to a concrete managed model and
 // bills it as the resolved model.
 //
-// For now AUTO is GLM 5.2 (cheap + smart) — except a request that carries images
-// is routed to a vision-capable model so attachments aren't silently ignored
-// (GLM 5.2 is text-only). The `autoRouter` hook and this single indirection point
+// For now AUTO is Owl Alpha (OpenRouter's agentic default) — except a request
+// that carries images is routed to a vision-capable model so attachments aren't
+// silently ignored (Owl Alpha is text-only). The `autoRouter` hook and this single indirection point
 // are the seam where a future, more sophisticated per-task handler plugs in.
 export const AUTO_MODEL_ID = 'auto';
 
-const AUTO_TARGET_MODEL = 'glm-5.2'; // text-only default
+const AUTO_TARGET_MODEL = 'owl-alpha'; // text-only default
 const AUTO_VISION_MODEL = 'claude-sonnet-4.6'; // when the request has image content
 
 function requestHasImage(body: Record<string, unknown>): boolean {

--- a/packages/shared/src/llm-catalog/managed.test.ts
+++ b/packages/shared/src/llm-catalog/managed.test.ts
@@ -12,7 +12,7 @@ describe('managed catalog', () => {
     expect(DEFAULT_MANAGED_MODEL_IDS).toEqual([
       'claude-opus-4.8',
       'claude-sonnet-4.6',
-      'glm-5.2',
+      'owl-alpha',
       'qwen3.7-max',
       'deepseek-v4-pro',
       'deepseek-v4-flash',
@@ -55,8 +55,8 @@ describe('managed resolution + back-compat aliases', () => {
   test('resolves current ids', () => {
     expect(getManagedModel('claude-opus-4.8')?.name).toBe('Claude Opus 4.8');
     expect(getManagedModel('claude-opus-4.8')?.transport).toBe('bedrock');
-    expect(getManagedModel('glm-5.2')?.transport).toBe('openrouter');
-    expect(getManagedModel('glm-5.2')?.upstreamModelId).toBe('z-ai/glm-5.2');
+    expect(getManagedModel('owl-alpha')?.transport).toBe('openrouter');
+    expect(getManagedModel('owl-alpha')?.upstreamModelId).toBe('openrouter/owl-alpha');
     expect(getManagedModel('qwen3.7-max')?.upstreamModelId).toBe('qwen/qwen3.7-max');
     expect(getManagedModel('deepseek-v4-pro')?.upstreamModelId).toBe('deepseek/deepseek-v4-pro');
   });
@@ -67,6 +67,7 @@ describe('managed resolution + back-compat aliases', () => {
       'kortix-basic',
       'glm-4.6',
       'glm-5.1',
+      'glm-5.2',
       'qwen3-max',
       'minimax-m2.5',
       'kimi-k2',

--- a/packages/shared/src/llm-catalog/pick-auto.test.ts
+++ b/packages/shared/src/llm-catalog/pick-auto.test.ts
@@ -15,11 +15,11 @@ describe('pickAutoModel', () => {
     expect(pickAutoModel('kortix/auto', { messages: [msg('hi')] })).not.toBeNull();
   });
 
-  test('text requests resolve to GLM 5.2 (regardless of size / tools)', () => {
-    expect(pickAutoModel('auto', { messages: [msg('hello there')] })).toBe('glm-5.2');
+  test('text requests resolve to Owl Alpha (regardless of size / tools)', () => {
+    expect(pickAutoModel('auto', { messages: [msg('hello there')] })).toBe('owl-alpha');
     expect(
       pickAutoModel('auto', { messages: [msg('x'.repeat(250_000))], tools: [{ name: 'edit' }] }),
-    ).toBe('glm-5.2');
+    ).toBe('owl-alpha');
   });
 
   test('image requests route to a vision model (not blind GLM)', () => {
@@ -38,7 +38,7 @@ describe('pickAutoModel', () => {
   });
 
   test('both auto targets are real managed models', () => {
-    expect(getManagedModel('glm-5.2'), 'glm-5.2 must exist').toBeDefined();
+    expect(getManagedModel('owl-alpha'), 'owl-alpha must exist').toBeDefined();
     expect(getManagedModel('claude-sonnet-4.6'), 'claude-sonnet-4.6 must exist').toBeDefined();
   });
 


### PR DESCRIPTION
## Summary
- route synthetic auto to managed Owl Alpha backed by OpenRouter
- replace retired GLM 5.2 managed entry with openrouter/owl-alpha catalog metadata
- add API-side raw auto fallback for stale standalone gateway resolve-upstream callers

## Verification
- bun test src/llm-catalog/pick-auto.test.ts src/llm-catalog/managed.test.ts (packages/shared)
- bun test src/__tests__/unit-resolve-candidates-free-tier.test.ts (apps/api)
- bun test src/pipeline/handler.test.ts src/transports/openai-compat/openai-compat.test.ts (packages/llm-gateway)
- pnpm exec tsc --noEmit --pretty false (packages/shared)
- pnpm exec tsc --noEmit --pretty false (apps/api)
- pnpm exec tsc --noEmit --pretty false (packages/llm-gateway)
- pnpm exec tsc --noEmit --pretty false (apps/llm-gateway)
- git diff --check