### PR TITLE
Route auto to Fusion and harden AgentMail email channel

### DIFF
--- a/apps/api/src/__tests__/unit-email-channel.test.ts
+++ b/apps/api/src/__tests__/unit-email-channel.test.ts
@@ -1,51 +1,69 @@
-import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
-import { createHmac } from 'node:crypto';
-import { config } from '../config';
-import { resolveAgentMailApiKey } from '../channels/agentmail-api';
-import { verifyAgentMailSignature } from '../channels/email/verify';
-import type { AgentMailMessageReceivedEvent } from '../channels/email/types';
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { createHmac } from "node:crypto";
+import { config } from "../config";
+import { resolveAgentMailApiKey } from "../channels/agentmail-api";
+import { verifyAgentMailSignature } from "../channels/email/verify";
+import type { AgentMailMessageReceivedEvent } from "../channels/email/types";
 
 let dbResults: unknown[][] = [];
 
 function makeChain(): any {
   const chain: any = {};
-  for (const m of ['from', 'where', 'limit', 'set', 'values', 'onConflictDoNothing', 'returning']) {
+  for (const m of [
+    "from",
+    "where",
+    "limit",
+    "set",
+    "values",
+    "onConflictDoNothing",
+    "returning",
+  ]) {
     chain[m] = () => chain;
   }
-  chain.then = (resolve: (rows: unknown[]) => unknown) => Promise.resolve(resolve(dbResults.shift() ?? []));
+  chain.then = (resolve: (rows: unknown[]) => unknown) =>
+    Promise.resolve(resolve(dbResults.shift() ?? []));
   return chain;
 }
 
-mock.module('../shared/db', () => ({
-  db: { select: () => makeChain(), insert: () => makeChain(), update: () => makeChain(), delete: () => makeChain() },
+mock.module("../shared/db", () => ({
+  db: {
+    select: () => makeChain(),
+    insert: () => makeChain(),
+    update: () => makeChain(),
+    delete: () => makeChain(),
+  },
   hasDatabase: () => true,
 }));
 
 let continueCalls: Array<{ sessionId: string; text: string }> = [];
 let createCalls: Array<any> = [];
 
-const { dispatchAgentMailEvent, resetEmailSessionLifecycleForTest, setEmailSessionLifecycleForTest } =
-  await import('../channels/email/session');
+const {
+  dispatchAgentMailEvent,
+  isAgentMailSenderAllowedForTest,
+  resetEmailSessionLifecycleForTest,
+  setEmailSessionLifecycleForTest,
+} = await import("../channels/email/session");
 
 const event: AgentMailMessageReceivedEvent = {
-  type: 'event',
-  event_type: 'message.received',
-  event_id: 'evt-1',
+  type: "event",
+  event_type: "message.received",
+  event_id: "evt-1",
   message: {
-    inbox_id: 'inb-1',
-    thread_id: 'thr-1',
-    message_id: 'msg-1',
-    from: 'Customer <customer@example.com>',
-    to: ['agent@example.com'],
-    subject: 'Need help',
-    text: 'Can you help?',
-    extracted_text: 'Can you help?',
+    inbox_id: "inb-1",
+    thread_id: "thr-1",
+    message_id: "msg-1",
+    from: "Customer <customer@example.com>",
+    to: ["agent@example.com"],
+    subject: "Need help",
+    text: "Can you help?",
+    extracted_text: "Can you help?",
     attachments: [],
   },
   thread: {
-    inbox_id: 'inb-1',
-    thread_id: 'thr-1',
-    subject: 'Need help',
+    inbox_id: "inb-1",
+    thread_id: "thr-1",
+    subject: "Need help",
     message_count: 1,
   },
 };
@@ -60,98 +78,164 @@ beforeEach(() => {
   continueCalls = [];
   createCalls = [];
   setEmailSessionLifecycleForTest({
-    resolveProjectAutomationActor: async () => 'user-1',
+    resolveProjectAutomationActor: async () => "user-1",
     continueSession: async (input) => {
       continueCalls.push({ sessionId: input.sessionId, text: input.text });
-      return 'delivered';
+      return "delivered";
     },
     createSession: async (input) => {
       createCalls.push(input);
-      return { status: 'created', sessionId: 'sess-1', row: { sessionId: 'sess-1' } as any };
+      return {
+        status: "created",
+        sessionId: "sess-1",
+        row: { sessionId: "sess-1" } as any,
+      };
     },
   });
 });
 
-describe('AgentMail webhook verification', () => {
-  test('accepts valid Svix v1 signatures and rejects tampering', () => {
-    const secret = `whsec_${Buffer.from('test-signing-key').toString('base64')}`;
+describe("AgentMail webhook verification", () => {
+  test("accepts valid Svix v1 signatures and rejects tampering", () => {
+    const secret = `whsec_${Buffer.from("test-signing-key").toString("base64")}`;
     const rawBody = JSON.stringify({ ok: true });
-    const svixId = 'msg_123';
+    const svixId = "msg_123";
     const svixTimestamp = String(Math.floor(Date.now() / 1000));
-    const sig = createHmac('sha256', Buffer.from('test-signing-key'))
+    const sig = createHmac("sha256", Buffer.from("test-signing-key"))
       .update(`${svixId}.${svixTimestamp}.${rawBody}`)
-      .digest('base64');
+      .digest("base64");
 
-    expect(verifyAgentMailSignature({
-      rawBody,
-      secret,
-      svixId,
-      svixTimestamp,
-      svixSignature: `v1,${sig}`,
-    })).toBe(true);
-    expect(verifyAgentMailSignature({
-      rawBody: `${rawBody} `,
-      secret,
-      svixId,
-      svixTimestamp,
-      svixSignature: `v1,${sig}`,
-    })).toBe(false);
+    expect(
+      verifyAgentMailSignature({
+        rawBody,
+        secret,
+        svixId,
+        svixTimestamp,
+        svixSignature: `v1,${sig}`,
+      }),
+    ).toBe(true);
+    expect(
+      verifyAgentMailSignature({
+        rawBody: `${rawBody} `,
+        secret,
+        svixId,
+        svixTimestamp,
+        svixSignature: `v1,${sig}`,
+      }),
+    ).toBe(false);
   });
 });
 
-describe('AgentMail credential resolution', () => {
-  test('supports both project BYO keys and server-managed fallback keys', () => {
+describe("AgentMail credential resolution", () => {
+  test("supports both project BYO keys and server-managed fallback keys", () => {
     const original = config.AGENTMAIL_API_KEY;
     try {
-      (config as { AGENTMAIL_API_KEY: string | undefined }).AGENTMAIL_API_KEY = 'server-managed-key';
-      expect(resolveAgentMailApiKey('project-byo-key')).toBe('project-byo-key');
-      expect(resolveAgentMailApiKey(null)).toBe('server-managed-key');
-      expect(resolveAgentMailApiKey(undefined)).toBe('server-managed-key');
+      (config as { AGENTMAIL_API_KEY: string | undefined }).AGENTMAIL_API_KEY =
+        "server-managed-key";
+      expect(resolveAgentMailApiKey("project-byo-key")).toBe("project-byo-key");
+      expect(resolveAgentMailApiKey(null)).toBe("server-managed-key");
+      expect(resolveAgentMailApiKey(undefined)).toBe("server-managed-key");
 
-      (config as { AGENTMAIL_API_KEY: string | undefined }).AGENTMAIL_API_KEY = undefined;
+      (config as { AGENTMAIL_API_KEY: string | undefined }).AGENTMAIL_API_KEY =
+        undefined;
       expect(resolveAgentMailApiKey(null)).toBeNull();
     } finally {
-      (config as { AGENTMAIL_API_KEY: string | undefined }).AGENTMAIL_API_KEY = original;
+      (config as { AGENTMAIL_API_KEY: string | undefined }).AGENTMAIL_API_KEY =
+        original;
     }
   });
 });
 
-describe('dispatchAgentMailEvent', () => {
-  test('first message creates one project-visible session bound to the email thread', async () => {
+describe("dispatchAgentMailEvent", () => {
+  test("first message creates one project-visible session bound to the email thread", async () => {
     dbResults = [
-      [{ eventId: 'email:event:evt-1' }],
-      [{ projectId: 'proj-1' }],
-      [{ eventId: 'email:msg:inb-1:msg-1' }],
+      [{ eventId: "email:event:evt-1" }],
+      [{ projectId: "proj-1" }],
       [],
-      [{ projectId: 'proj-1', accountId: 'acc-1', defaultBranch: 'main', name: 'Support' }],
-      [{ eventId: 'email:threadcreate:inb-1:thr-1' }],
+      [{ eventId: "email:msg:inb-1:msg-1" }],
+      [],
+      [
+        {
+          projectId: "proj-1",
+          accountId: "acc-1",
+          defaultBranch: "main",
+          name: "Support",
+        },
+      ],
+      [{ eventId: "email:threadcreate:inb-1:thr-1" }],
     ];
 
     await dispatchAgentMailEvent(event);
 
     expect(continueCalls).toHaveLength(0);
     expect(createCalls).toHaveLength(1);
-    expect(createCalls[0].source).toBe('email');
+    expect(createCalls[0].source).toBe("email");
     expect(createCalls[0].postCreate).toEqual([
-      { type: 'bind_chat_thread', platform: 'email', workspaceId: 'inb-1', threadId: 'thr-1' },
+      {
+        type: "bind_chat_thread",
+        platform: "email",
+        workspaceId: "inb-1",
+        threadId: "thr-1",
+      },
     ]);
-    expect(createCalls[0].extraEnvVars.KORTIX_EMAIL_INBOX_ID).toBe('inb-1');
-    expect(createCalls[0].body.initial_prompt).toContain('Need help');
+    expect(createCalls[0].extraEnvVars.KORTIX_EMAIL_INBOX_ID).toBe("inb-1");
+    expect(createCalls[0].body.initial_prompt).toContain("Need help");
   });
 
-  test('known thread routes a new email into the existing session', async () => {
+  test("known thread routes a new email into the existing session", async () => {
     dbResults = [
-      [{ eventId: 'email:event:evt-1' }],
-      [{ projectId: 'proj-1' }],
-      [{ eventId: 'email:msg:inb-1:msg-1' }],
-      [{ sessionId: 'sess-1' }],
+      [{ eventId: "email:event:evt-1" }],
+      [{ projectId: "proj-1" }],
+      [],
+      [{ eventId: "email:msg:inb-1:msg-1" }],
+      [{ sessionId: "sess-1" }],
     ];
 
     await dispatchAgentMailEvent(event);
 
     expect(createCalls).toHaveLength(0);
     expect(continueCalls).toHaveLength(1);
-    expect(continueCalls[0].sessionId).toBe('sess-1');
-    expect(continueCalls[0].text).toContain('Customer <customer@example.com>');
+    expect(continueCalls[0].sessionId).toBe("sess-1");
+    expect(continueCalls[0].text).toContain("Customer <customer@example.com>");
+  });
+
+  test("sender allow policy supports exact emails, domains, and regex", () => {
+    const policy = {
+      mode: "restricted" as const,
+      allowedEmails: ["customer@example.com"],
+      allowedDomains: ["kortix.com"],
+      allowedRegex: "^vip-[0-9]+@example\\.org$",
+    };
+
+    expect(isAgentMailSenderAllowedForTest(event, policy)).toBe(true);
+    expect(
+      isAgentMailSenderAllowedForTest(
+        {
+          ...event,
+          message: {
+            ...event.message,
+            from: "Teammate <person@ops.kortix.com>",
+          },
+        },
+        policy,
+      ),
+    ).toBe(true);
+    expect(
+      isAgentMailSenderAllowedForTest(
+        {
+          ...event,
+          message: { ...event.message, from: "vip-12@example.org" },
+        },
+        policy,
+      ),
+    ).toBe(true);
+    expect(
+      isAgentMailSenderAllowedForTest(
+        {
+          ...event,
+          message: { ...event.message, from: "Other <other@external.test>" },
+        },
+        policy,
+      ),
+    ).toBe(false);
   });
 });

--- a/apps/api/src/__tests__/unit-resolve-candidates-free-tier.test.ts
+++ b/apps/api/src/__tests__/unit-resolve-candidates-free-tier.test.ts
@@ -1,82 +1,98 @@
-import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
 let billingEnabled = true;
-let accountTier = 'free';
+let accountTier = "free";
 let accountTierCalls = 0;
 
-mock.module('@kortix/llm-gateway', () => ({
+mock.module("@kortix/llm-gateway", () => ({
   resolveCatalogUpstream: (provider: string) =>
-    provider === 'openai'
+    provider === "openai"
       ? {
-          envVar: 'OPENAI_API_KEY',
-          kind: 'openai-chat',
-          baseUrl: 'https://api.openai.com/v1',
+          envVar: "OPENAI_API_KEY",
+          kind: "openai-chat",
+          baseUrl: "https://api.openai.com/v1",
         }
       : null,
 }));
 
-mock.module('@kortix/shared/llm-catalog', () => ({
-  pickAutoModel: (model: string) => (model === 'auto' || model === 'kortix/auto' ? 'owl-alpha' : null),
-  getManagedModel: (model: string) =>
-    model === 'claude-sonnet-4.6' || model === 'owl-alpha'
-      ? { id: model, transport: 'openrouter' }
-      : null,
-}));
-
-mock.module('../config', () => ({
+mock.module("../config", () => ({
+  SANDBOX_VERSION: "test",
+  KORTIX_MARKUP: 1.2,
+  PLATFORM_FEE_MARKUP: 0.1,
   config: new Proxy(
     {},
     {
-      get: (_target, key) => {
-        if (key === 'KORTIX_BILLING_INTERNAL_ENABLED') return billingEnabled;
-        if (key === 'LLM_GATEWAY_ENABLED') return true;
-        if (key === 'LLM_GATEWAY_BYOK_FALLBACK_MODEL') return 'claude-sonnet-4.6';
-        return undefined;
+      get: (target: Record<PropertyKey, unknown>, key) => {
+        if (key === "KORTIX_BILLING_INTERNAL_ENABLED") return billingEnabled;
+        if (key === "LLM_GATEWAY_ENABLED") return true;
+        if (key === "LLM_GATEWAY_BYOK_FALLBACK_MODEL")
+          return "claude-sonnet-4.6";
+        return target[key];
       },
     },
   ),
+  getToolCost: () => 0,
 }));
 
-mock.module('../billing/services/entitlements', () => ({
+mock.module("../billing/services/entitlements", () => ({
   getAccountTier: async () => {
     accountTierCalls += 1;
     return accountTier;
   },
 }));
 
-mock.module('../projects/secrets', () => ({
-  getProjectSecretValue: async () => 'user-key',
+mock.module("../projects/secrets", () => ({
+  decryptProjectSecret: (_projectId: string, value: string) => value,
+  encryptProjectSecret: (_projectId: string, value: string) => value,
+  getProjectSecretValue: async () => "user-key",
+  listProjectSecrets: async () => ({}),
+  listProjectSecretsForUser: async () => ({}),
+  listProjectSecretsSnapshot: async () => ({
+    env: {},
+    names: [],
+    revision: "empty",
+  }),
+  listProjectSecretsSnapshotForUser: async () => ({
+    env: {},
+    names: [],
+    revision: "empty",
+  }),
+  projectSecretsRevision: () => "empty",
 }));
 
-mock.module('../llm-gateway/credentials/codex', () => ({
-  resolveCodexCredential: async () => ({ access: 'codex-token', accountId: 'chatgpt-account' }),
+mock.module("../llm-gateway/credentials/codex", () => ({
+  resolveCodexCredential: async () => ({
+    access: "codex-token",
+    accountId: "chatgpt-account",
+  }),
 }));
 
-mock.module('../llm-gateway/resolution/descriptors', () => ({
+mock.module("../llm-gateway/resolution/descriptors", () => ({
   codexDescriptor: (_credential: unknown, model: string) => ({
-    provider: 'openai-codex',
-    kind: 'openai-responses',
-    baseUrl: 'https://chatgpt.com/backend-api/codex',
-    apiKey: 'codex-token',
-    billingMode: 'none',
+    provider: "openai-codex",
+    kind: "openai-responses",
+    baseUrl: "https://chatgpt.com/backend-api/codex",
+    apiKey: "codex-token",
+    billingMode: "none",
     markup: 0,
-    resolvedModel: model.replace(/^codex\//, ''),
+    resolvedModel: model.replace(/^codex\//, ""),
   }),
   livePricing: () => undefined,
   managedCandidates: (managed: { id: string }) => [
     {
-      provider: 'openrouter',
-      kind: 'openai-chat',
-      baseUrl: 'https://openrouter.ai/api/v1',
-      apiKey: 'managed-key',
-      billingMode: 'credits',
+      provider: "openrouter",
+      kind: "openai-chat",
+      baseUrl: "https://openrouter.ai/api/v1",
+      apiKey: "managed-key",
+      billingMode: "credits",
       markup: 1.2,
       resolvedModel: managed.id,
     },
   ],
 }));
 
-const { resolveCandidates } = await import('../llm-gateway/resolution/resolve-candidates');
+const { resolveCandidates } =
+  await import("../llm-gateway/resolution/resolve-candidates");
 
 function principal(accountId: string) {
   return {
@@ -86,69 +102,91 @@ function principal(accountId: string) {
   };
 }
 
-describe('resolveCandidates free-tier premium gate', () => {
+describe("resolveCandidates free-tier premium gate", () => {
+  afterAll(() => {
+    mock.restore();
+  });
+
   beforeEach(() => {
     billingEnabled = true;
-    accountTier = 'free';
+    accountTier = "free";
     accountTierCalls = 0;
   });
 
-  test('blocks managed premium candidates for free accounts', async () => {
-    accountTier = 'free';
-    const candidates = await resolveCandidates(principal('free-managed'), 'claude-sonnet-4.6');
+  test("blocks managed premium candidates for free accounts", async () => {
+    accountTier = "free";
+    const candidates = await resolveCandidates(
+      principal("free-managed"),
+      "claude-sonnet-4.6",
+    );
     expect(candidates).toEqual([]);
     expect(accountTierCalls).toBe(1);
   });
 
-  test('allows managed premium candidates for Team accounts', async () => {
-    accountTier = 'per_seat';
-    const candidates = await resolveCandidates(principal('team-managed'), 'claude-sonnet-4.6');
+  test("allows managed premium candidates for Team accounts", async () => {
+    accountTier = "per_seat";
+    const candidates = await resolveCandidates(
+      principal("team-managed"),
+      "claude-sonnet-4.6",
+    );
     expect(candidates).toHaveLength(1);
-    expect(candidates[0]?.billingMode).toBe('credits');
+    expect(candidates[0]?.billingMode).toBe("credits");
     expect(accountTierCalls).toBe(1);
   });
 
-  test('resolves raw auto to a concrete managed upstream for stale gateway callers', async () => {
-    accountTier = 'per_seat';
-    const candidates = await resolveCandidates(principal('team-auto'), 'auto');
+  test("resolves raw auto to a concrete managed upstream for stale gateway callers", async () => {
+    accountTier = "per_seat";
+    const candidates = await resolveCandidates(principal("team-auto"), "auto");
     expect(candidates).toHaveLength(1);
-    expect(candidates[0]?.provider).toBe('openrouter');
-    expect(candidates[0]?.resolvedModel).toBe('owl-alpha');
+    expect(candidates[0]?.provider).toBe("openrouter");
+    expect(candidates[0]?.resolvedModel).toBe("fusion");
     expect(accountTierCalls).toBe(1);
   });
 
-  test('waives BYOK platform fee and disables managed fallback for free accounts', async () => {
-    accountTier = 'free';
-    const candidates = await resolveCandidates(principal('free-byok'), 'openai/gpt-4.1');
+  test("waives BYOK platform fee and disables managed fallback for free accounts", async () => {
+    accountTier = "free";
+    const candidates = await resolveCandidates(
+      principal("free-byok"),
+      "openai/gpt-4.1",
+    );
     expect(candidates).toHaveLength(1);
-    expect(candidates[0]?.billingMode).toBe('none');
+    expect(candidates[0]?.billingMode).toBe("none");
     expect(candidates[0]?.markup).toBe(0);
-    expect(candidates[0]?.apiKey).toBe('user-key');
+    expect(candidates[0]?.apiKey).toBe("user-key");
     expect(accountTierCalls).toBe(1);
   });
 
-  test('keeps BYOK platform fee and managed fallback for Team accounts', async () => {
-    accountTier = 'per_seat';
-    const candidates = await resolveCandidates(principal('team-byok'), 'openai/gpt-4.1');
+  test("keeps BYOK platform fee and managed fallback for Team accounts", async () => {
+    accountTier = "per_seat";
+    const candidates = await resolveCandidates(
+      principal("team-byok"),
+      "openai/gpt-4.1",
+    );
     expect(candidates).toHaveLength(2);
-    expect(candidates[0]?.billingMode).toBe('platform-fee');
+    expect(candidates[0]?.billingMode).toBe("platform-fee");
     expect(candidates[0]?.markup).toBe(0.1);
-    expect(candidates[1]?.billingMode).toBe('credits');
+    expect(candidates[1]?.billingMode).toBe("credits");
     expect(accountTierCalls).toBe(1);
   });
 
-  test('does not tier-gate ChatGPT subscription candidates', async () => {
-    accountTier = 'free';
-    const candidates = await resolveCandidates(principal('free-codex'), 'codex/gpt-5');
+  test("does not tier-gate ChatGPT subscription candidates", async () => {
+    accountTier = "free";
+    const candidates = await resolveCandidates(
+      principal("free-codex"),
+      "codex/gpt-5",
+    );
     expect(candidates).toHaveLength(1);
-    expect(candidates[0]?.billingMode).toBe('none');
+    expect(candidates[0]?.billingMode).toBe("none");
     expect(accountTierCalls).toBe(0);
   });
 
-  test('keeps managed candidates available when internal billing is disabled', async () => {
+  test("keeps managed candidates available when internal billing is disabled", async () => {
     billingEnabled = false;
-    accountTier = 'free';
-    const candidates = await resolveCandidates(principal('self-host-managed'), 'claude-sonnet-4.6');
+    accountTier = "free";
+    const candidates = await resolveCandidates(
+      principal("self-host-managed"),
+      "claude-sonnet-4.6",
+    );
     expect(candidates).toHaveLength(1);
     expect(accountTierCalls).toBe(0);
   });

--- a/apps/api/src/channels/email/session.ts
+++ b/apps/api/src/channels/email/session.ts
@@ -1,14 +1,23 @@
-import { and, eq } from 'drizzle-orm';
-import { chatEventDedup, chatInstalls, chatThreads, projects } from '@kortix/db';
-import { db } from '../../shared/db';
+import { and, eq } from "drizzle-orm";
+import {
+  chatEventDedup,
+  chatInstalls,
+  chatThreads,
+  projects,
+} from "@kortix/db";
+import { db } from "../../shared/db";
+import {
+  type AgentMailSenderPolicy,
+  loadAgentMailSenderPolicyForInbox,
+} from "../install-store";
 import {
   continueSession as continueLifecycleSession,
   createSession as createLifecycleSession,
   resolveProjectAutomationActor as resolveLifecycleAutomationActor,
-} from '../../projects/session-lifecycle';
-import { config } from '../../config';
-import { EMAIL_EVENT_DEDUPE_TTL_MS } from './app';
-import type { AgentMailMessageReceivedEvent } from './types';
+} from "../../projects/session-lifecycle";
+import { config } from "../../config";
+import { EMAIL_EVENT_DEDUPE_TTL_MS } from "./app";
+import type { AgentMailMessageReceivedEvent } from "./types";
 
 const defaultEmailSessionLifecycle = {
   continueSession: continueLifecycleSession,
@@ -18,7 +27,9 @@ const defaultEmailSessionLifecycle = {
 
 let emailSessionLifecycle = defaultEmailSessionLifecycle;
 
-export function setEmailSessionLifecycleForTest(overrides: Partial<typeof defaultEmailSessionLifecycle>) {
+export function setEmailSessionLifecycleForTest(
+  overrides: Partial<typeof defaultEmailSessionLifecycle>,
+) {
   emailSessionLifecycle = { ...defaultEmailSessionLifecycle, ...overrides };
 }
 
@@ -26,23 +37,46 @@ export function resetEmailSessionLifecycleForTest() {
   emailSessionLifecycle = defaultEmailSessionLifecycle;
 }
 
-export async function resolveProjectForAgentMailInbox(inboxId: string): Promise<string | null> {
+export async function resolveProjectForAgentMailInbox(
+  inboxId: string,
+): Promise<string | null> {
   const [row] = await db
     .select({ projectId: chatInstalls.projectId })
     .from(chatInstalls)
-    .where(and(eq(chatInstalls.platform, 'email'), eq(chatInstalls.workspaceId, inboxId)))
+    .where(
+      and(
+        eq(chatInstalls.platform, "email"),
+        eq(chatInstalls.workspaceId, inboxId),
+      ),
+    )
     .limit(1);
   return row?.projectId ?? null;
 }
 
-export async function dispatchAgentMailEvent(event: AgentMailMessageReceivedEvent): Promise<void> {
-  if (event.event_type !== 'message.received') return;
+export async function dispatchAgentMailEvent(
+  event: AgentMailMessageReceivedEvent,
+): Promise<void> {
+  if (event.event_type !== "message.received") return;
   if (await alreadyHandled(`email:event:${event.event_id}`)) return;
-  const projectId = await resolveProjectForAgentMailInbox(event.message.inbox_id);
+  const projectId = await resolveProjectForAgentMailInbox(
+    event.message.inbox_id,
+  );
   if (!projectId) {
-    console.warn('[email-webhook] no project install for AgentMail inbox', {
+    console.warn("[email-webhook] no project install for AgentMail inbox", {
       inboxId: event.message.inbox_id,
       eventId: event.event_id,
+    });
+    return;
+  }
+  const policy = await loadAgentMailSenderPolicyForInbox(
+    projectId,
+    event.message.inbox_id,
+  );
+  if (!senderAllowed(event, policy)) {
+    console.warn("[email-webhook] sender rejected by AgentMail inbox policy", {
+      inboxId: event.message.inbox_id,
+      eventId: event.event_id,
+      sender: messageSender(event),
     });
     return;
   }
@@ -50,7 +84,10 @@ export async function dispatchAgentMailEvent(event: AgentMailMessageReceivedEven
   await spawnEmailAgentTurn(projectId, event);
 }
 
-async function spawnEmailAgentTurn(projectId: string, event: AgentMailMessageReceivedEvent): Promise<void> {
+async function spawnEmailAgentTurn(
+  projectId: string,
+  event: AgentMailMessageReceivedEvent,
+): Promise<void> {
   const inboxId = event.message.inbox_id;
   const threadId = event.message.thread_id;
   if (!inboxId || !threadId) return;
@@ -60,7 +97,7 @@ async function spawnEmailAgentTurn(projectId: string, event: AgentMailMessageRec
     .from(chatThreads)
     .where(
       and(
-        eq(chatThreads.platform, 'email'),
+        eq(chatThreads.platform, "email"),
         eq(chatThreads.workspaceId, inboxId),
         eq(chatThreads.threadId, threadId),
       ),
@@ -69,27 +106,27 @@ async function spawnEmailAgentTurn(projectId: string, event: AgentMailMessageRec
 
   if (existing) {
     const outcome = await emailSessionLifecycle.continueSession({
-      source: 'email',
+      source: "email",
       sessionId: existing.sessionId,
       text: renderFollowUpPrompt(event),
     });
-    if (outcome === 'delivered') {
+    if (outcome === "delivered") {
       await db
         .update(chatThreads)
         .set({ lastMessageAt: new Date() })
         .where(
           and(
-            eq(chatThreads.platform, 'email'),
+            eq(chatThreads.platform, "email"),
             eq(chatThreads.workspaceId, inboxId),
             eq(chatThreads.threadId, threadId),
           ),
         );
-    } else if (outcome === 'no-session') {
+    } else if (outcome === "no-session") {
       await db
         .delete(chatThreads)
         .where(
           and(
-            eq(chatThreads.platform, 'email'),
+            eq(chatThreads.platform, "email"),
             eq(chatThreads.workspaceId, inboxId),
             eq(chatThreads.threadId, threadId),
           ),
@@ -116,9 +153,11 @@ async function createThreadSession(
     .limit(1);
   if (!project) return;
 
-  const userId = await emailSessionLifecycle.resolveProjectAutomationActor(project.accountId);
+  const userId = await emailSessionLifecycle.resolveProjectAutomationActor(
+    project.accountId,
+  );
   if (!userId) {
-    console.warn('[email-webhook] no actor for project', projectId);
+    console.warn("[email-webhook] no actor for project", projectId);
     return;
   }
 
@@ -127,7 +166,7 @@ async function createThreadSession(
     const sessionId = await waitForThreadSession(inboxId, threadId);
     if (sessionId) {
       await emailSessionLifecycle.continueSession({
-        source: 'email',
+        source: "email",
         sessionId,
         text: renderFollowUpPrompt(event),
       });
@@ -136,26 +175,33 @@ async function createThreadSession(
   }
 
   const result = await emailSessionLifecycle.createSession({
-    source: 'email',
+    source: "email",
     project,
     userId,
     body: {
       base_ref: project.defaultBranch,
-      agent_name: 'default',
+      agent_name: "default",
       initial_prompt: renderAgentPrompt(event, revived),
     },
     enforceAccountCap: false,
-    queuePolicy: 'on_backpressure',
+    queuePolicy: "on_backpressure",
     idempotencyKey: claimKey,
-    postCreate: [{ type: 'bind_chat_thread', platform: 'email', workspaceId: inboxId, threadId }],
-    visibility: 'project',
+    postCreate: [
+      {
+        type: "bind_chat_thread",
+        platform: "email",
+        workspaceId: inboxId,
+        threadId,
+      },
+    ],
+    visibility: "project",
     metadata: {
-      source: 'email',
+      source: "email",
       email: {
         inbox_id: inboxId,
         thread_id: threadId,
         message_id: event.message.message_id,
-        from: event.message.from,
+        from: messageSender(event),
         subject: event.message.subject ?? event.thread.subject ?? null,
       },
     },
@@ -163,13 +209,13 @@ async function createThreadSession(
       KORTIX_EMAIL_INBOX_ID: inboxId,
       KORTIX_EMAIL_THREAD_ID: threadId,
       KORTIX_EMAIL_MESSAGE_ID: event.message.message_id,
-      KORTIX_EMAIL_ADDRESS: event.message.to?.[0] ?? '',
+      KORTIX_EMAIL_ADDRESS: event.message.to?.[0] ?? "",
       KORTIX_FRONTEND_URL: config.FRONTEND_URL,
     },
   });
 
   if (result.error) {
-    console.error('[email-webhook] createProjectSession failed', {
+    console.error("[email-webhook] createProjectSession failed", {
       status: result.error.status,
       body: result.error.body,
     });
@@ -180,27 +226,38 @@ async function alreadyHandled(key: string): Promise<boolean> {
   try {
     const inserted = await db
       .insert(chatEventDedup)
-      .values({ eventId: key, expiresAt: new Date(Date.now() + EMAIL_EVENT_DEDUPE_TTL_MS) })
+      .values({
+        eventId: key,
+        expiresAt: new Date(Date.now() + EMAIL_EVENT_DEDUPE_TTL_MS),
+      })
       .onConflictDoNothing({ target: chatEventDedup.eventId })
       .returning({ eventId: chatEventDedup.eventId });
     return inserted.length === 0;
   } catch (err) {
-    console.warn('[email-webhook] event dedup check failed', err);
+    console.warn("[email-webhook] event dedup check failed", err);
     return false;
   }
 }
 
-async function claimInboundMessage(event: AgentMailMessageReceivedEvent): Promise<boolean> {
+async function claimInboundMessage(
+  event: AgentMailMessageReceivedEvent,
+): Promise<boolean> {
   const key = `email:msg:${event.message.inbox_id}:${event.message.message_id}`;
   try {
     const inserted = await db
       .insert(chatEventDedup)
-      .values({ eventId: key, expiresAt: new Date(Date.now() + EMAIL_EVENT_DEDUPE_TTL_MS) })
+      .values({
+        eventId: key,
+        expiresAt: new Date(Date.now() + EMAIL_EVENT_DEDUPE_TTL_MS),
+      })
       .onConflictDoNothing({ target: chatEventDedup.eventId })
       .returning({ eventId: chatEventDedup.eventId });
     return inserted.length > 0;
   } catch (err) {
-    console.error('[email-webhook] inbound message claim failed (fail-open)', err);
+    console.error(
+      "[email-webhook] inbound message claim failed (fail-open)",
+      err,
+    );
     return true;
   }
 }
@@ -209,17 +266,23 @@ async function claimThreadCreate(key: string): Promise<boolean> {
   try {
     const inserted = await db
       .insert(chatEventDedup)
-      .values({ eventId: key, expiresAt: new Date(Date.now() + EMAIL_EVENT_DEDUPE_TTL_MS) })
+      .values({
+        eventId: key,
+        expiresAt: new Date(Date.now() + EMAIL_EVENT_DEDUPE_TTL_MS),
+      })
       .onConflictDoNothing({ target: chatEventDedup.eventId })
       .returning({ eventId: chatEventDedup.eventId });
     return inserted.length > 0;
   } catch (err) {
-    console.warn('[email-webhook] thread-create claim failed (fail-open)', err);
+    console.warn("[email-webhook] thread-create claim failed (fail-open)", err);
     return true;
   }
 }
 
-async function waitForThreadSession(inboxId: string, threadId: string): Promise<string | null> {
+async function waitForThreadSession(
+  inboxId: string,
+  threadId: string,
+): Promise<string | null> {
   const deadline = Date.now() + 8_000;
   for (;;) {
     const [row] = await db
@@ -227,7 +290,7 @@ async function waitForThreadSession(inboxId: string, threadId: string): Promise<
       .from(chatThreads)
       .where(
         and(
-          eq(chatThreads.platform, 'email'),
+          eq(chatThreads.platform, "email"),
           eq(chatThreads.workspaceId, inboxId),
           eq(chatThreads.threadId, threadId),
         ),
@@ -240,61 +303,128 @@ async function waitForThreadSession(inboxId: string, threadId: string): Promise<
 }
 
 const EMAIL_TURN_INSTRUCTIONS = [
-  'How to work:',
-  '- You are operating an AgentMail inbox assigned to this Kortix project.',
-  '- Use the built-in `email` Executor connector for inbox operations. The AgentMail API key is resolved server-side; do not look for it in the sandbox.',
-  '- Read the current thread before replying when context matters: `email.get_thread` with `inbox_id` and `thread_id`.',
-  '- To answer in the same conversation, call `email.reply_message` with `inbox_id`, `message_id`, `text` or `html`, and attachments when needed.',
-  '- For a brand-new outbound email, call `email.send_message` with `inbox_id`, `to`, `subject`, and body.',
-  '- If you need the user to clarify something, reply by email and end the turn. Their next reply will resume this same session.',
-].join('\n');
+  "How to work:",
+  "- You are operating an AgentMail inbox assigned to this Kortix project.",
+  "- Use the built-in `email` Executor connector for inbox operations. The AgentMail API key is resolved server-side; do not look for it in the sandbox.",
+  "- Read the current thread before replying when context matters: `email.get_thread` with `inbox_id` and `thread_id`.",
+  "- To answer in the same conversation, call `email.reply_message` with `inbox_id`, `message_id`, `text` or `html`, and attachments when needed.",
+  "- For a brand-new outbound email, call `email.send_message` with `inbox_id`, `to`, `subject`, and body.",
+  "- If you need the user to clarify something, reply by email and end the turn. Their next reply will resume this same session.",
+].join("\n");
 
 function renderFollowUpPrompt(event: AgentMailMessageReceivedEvent): string {
   return [
-    `New email reply from ${event.message.from} in the same thread:`,
-    '',
+    `New email reply from ${messageSender(event)} in the same thread:`,
+    "",
     messageSummary(event),
-    '',
+    "",
     EMAIL_TURN_INSTRUCTIONS,
-  ].join('\n');
+  ].join("\n");
 }
 
-function renderAgentPrompt(event: AgentMailMessageReceivedEvent, revived: boolean): string {
+function renderAgentPrompt(
+  event: AgentMailMessageReceivedEvent,
+  revived: boolean,
+): string {
   const lines: string[] = [];
   if (revived) {
     lines.push(
-      'NOTE: This email thread had an earlier conversation, but that session was deleted.',
-      'Pick the thread back up from the current email context.',
-      '',
+      "NOTE: This email thread had an earlier conversation, but that session was deleted.",
+      "Pick the thread back up from the current email context.",
+      "",
     );
   }
   lines.push(
     "You're answering an email thread as the Kortix agent.",
-    '',
+    "",
     `Inbox ID:   ${event.message.inbox_id}`,
     `Thread ID:  ${event.message.thread_id}`,
     `Message ID: ${event.message.message_id}`,
-    `From:       ${event.message.from}`,
-    `To:         ${(event.message.to ?? []).join(', ')}`,
-    `Subject:    ${event.message.subject ?? event.thread.subject ?? '(no subject)'}`,
-    '',
+    `From:       ${messageSender(event)}`,
+    `To:         ${(event.message.to ?? []).join(", ")}`,
+    `Subject:    ${event.message.subject ?? event.thread.subject ?? "(no subject)"}`,
+    "",
     messageSummary(event),
-    '',
+    "",
     EMAIL_TURN_INSTRUCTIONS,
   );
-  return lines.join('\n');
+  return lines.join("\n");
 }
 
 function messageSummary(event: AgentMailMessageReceivedEvent): string {
-  const body = event.message.extracted_text || event.message.text || event.message.preview || '';
+  const body =
+    event.message.extracted_text ||
+    event.message.text ||
+    event.message.preview ||
+    "";
   const attachments = event.message.attachments?.length
     ? [
-        '',
-        'Attachments:',
-        ...event.message.attachments.map((a) =>
-          `- ${a.filename ?? a.attachment_id} (${a.content_type ?? 'unknown'}, ${a.size} bytes)`,
+        "",
+        "Attachments:",
+        ...event.message.attachments.map(
+          (a) =>
+            `- ${a.filename ?? a.attachment_id} (${a.content_type ?? "unknown"}, ${a.size} bytes)`,
         ),
-      ].join('\n')
-    : '';
-  return [`Email body:`, body || '(empty)', attachments].filter(Boolean).join('\n');
+      ].join("\n")
+    : "";
+  return [`Email body:`, body || "(empty)", attachments]
+    .filter(Boolean)
+    .join("\n");
+}
+
+function messageSender(event: AgentMailMessageReceivedEvent): string {
+  if (typeof event.message.from === "string" && event.message.from.trim()) {
+    return event.message.from.trim();
+  }
+  const from = event.message.from_;
+  if (typeof from === "string") return from.trim();
+  if (Array.isArray(from)) {
+    const first = from[0];
+    if (typeof first === "string") return first.trim();
+    if (first && typeof first === "object") {
+      return (first.email ?? first.address ?? first.name ?? "").trim();
+    }
+  }
+  return "";
+}
+
+function senderEmail(event: AgentMailMessageReceivedEvent): string | null {
+  const sender = messageSender(event).toLowerCase();
+  const match = sender.match(
+    /[a-z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-z0-9-]+(?:\.[a-z0-9-]+)+/i,
+  );
+  return match?.[0]?.toLowerCase() ?? null;
+}
+
+export function isAgentMailSenderAllowedForTest(
+  event: AgentMailMessageReceivedEvent,
+  policy: AgentMailSenderPolicy,
+): boolean {
+  if (policy.mode !== "restricted") return true;
+  const email = senderEmail(event);
+  if (!email) return false;
+  if (policy.allowedEmails.includes(email)) return true;
+  const domain = email.split("@")[1] ?? "";
+  if (
+    policy.allowedDomains.some(
+      (allowed) => domain === allowed || domain.endsWith(`.${allowed}`),
+    )
+  ) {
+    return true;
+  }
+  if (policy.allowedRegex) {
+    try {
+      return new RegExp(policy.allowedRegex, "i").test(email);
+    } catch {
+      return false;
+    }
+  }
+  return false;
+}
+
+function senderAllowed(
+  event: AgentMailMessageReceivedEvent,
+  policy: AgentMailSenderPolicy,
+): boolean {
+  return isAgentMailSenderAllowedForTest(event, policy);
 }

--- a/apps/api/src/channels/email/types.ts
+++ b/apps/api/src/channels/email/types.ts
@@ -3,7 +3,11 @@ export interface AgentMailAddressedMessage {
   thread_id: string;
   message_id: string;
   timestamp?: string;
-  from: string;
+  from?: string;
+  from_?:
+    | string
+    | string[]
+    | Array<{ email?: string; address?: string; name?: string }>;
   reply_to?: string[];
   to: string[];
   cc?: string[];
@@ -31,12 +35,12 @@ export interface AgentMailThread {
 }
 
 export interface AgentMailMessageReceivedEvent {
-  type: 'event';
+  type: "event";
   event_type:
-    | 'message.received'
-    | 'message.received.spam'
-    | 'message.received.blocked'
-    | 'message.received.unauthenticated';
+    | "message.received"
+    | "message.received.spam"
+    | "message.received.blocked"
+    | "message.received.unauthenticated";
   event_id: string;
   message: AgentMailAddressedMessage;
   thread: AgentMailThread;

--- a/apps/api/src/channels/index.ts
+++ b/apps/api/src/channels/index.ts
@@ -9,6 +9,8 @@ export {
   loadSlackTokenForProject,
   loadAgentMailApiKeyForProject,
   loadAgentMailWebhookSecretForProject,
+  loadAgentMailSenderPolicyForInbox,
+  updateAgentMailSenderPolicy,
   loadSlackSigningSecretForProject,
   loadSlackBotUserIdForProject,
   loadSlackTeamNameForProject,
@@ -23,11 +25,13 @@ export {
   AGENTMAIL_INBOX_DISPLAY_NAME,
   AGENTMAIL_WEBHOOK_ID,
   AGENTMAIL_WEBHOOK_SECRET,
+  AGENTMAIL_SENDER_POLICY,
   type SlackInstallSummary,
   type SlackInstallInput,
   type AgentMailInstallSummary,
   type AgentMailInstallInput,
-} from './install-store';
+  type AgentMailSenderPolicy,
+} from "./install-store";
 export {
   buildSlackManifest,
   generateSlackManifest,
@@ -38,10 +42,15 @@ export {
   type SlackManifest,
   type GenerateManifestInput,
   type BuildManifestConfig,
-} from './slack-manifest';
-export { slackWebhookApp, relayTurnStep, relayTurnAnswer, relayTurnEnd } from './slack-webhook';
-export { emailWebhookApp } from './email-webhook';
-export { telegramWebhookApp } from './telegram-webhook';
-export { slackOauthApp, buildSlackInstallUrl } from './slack-oauth';
-export { slackIdentityApp } from './slack/identity-routes';
-export { slackOauthMode } from './slack-oauth-mode';
+} from "./slack-manifest";
+export {
+  slackWebhookApp,
+  relayTurnStep,
+  relayTurnAnswer,
+  relayTurnEnd,
+} from "./slack-webhook";
+export { emailWebhookApp } from "./email-webhook";
+export { telegramWebhookApp } from "./telegram-webhook";
+export { slackOauthApp, buildSlackInstallUrl } from "./slack-oauth";
+export { slackIdentityApp } from "./slack/identity-routes";
+export { slackOauthMode } from "./slack-oauth-mode";

--- a/apps/api/src/channels/install-store.ts
+++ b/apps/api/src/channels/install-store.ts
@@ -1,31 +1,34 @@
-import { and, eq, isNull, like } from 'drizzle-orm';
-import { chatInstalls, projectSecrets } from '@kortix/db';
-import { db } from '../shared/db';
+import { and, eq, isNull, like } from "drizzle-orm";
+import { chatInstalls, projectSecrets } from "@kortix/db";
+import { db } from "../shared/db";
 import {
   decryptProjectSecret,
   encryptProjectSecret,
   listProjectSecrets,
-} from '../projects/secrets';
+} from "../projects/secrets";
 
-export const SLACK_BOT_TOKEN = 'SLACK_BOT_TOKEN';
-export const SLACK_SIGNING_SECRET = 'SLACK_SIGNING_SECRET';
-export const SLACK_TEAM_ID = 'SLACK_TEAM_ID';
-export const SLACK_BOT_USER_ID = 'SLACK_BOT_USER_ID';
-export const SLACK_TEAM_NAME = 'SLACK_TEAM_NAME';
+export const SLACK_BOT_TOKEN = "SLACK_BOT_TOKEN";
+export const SLACK_SIGNING_SECRET = "SLACK_SIGNING_SECRET";
+export const SLACK_TEAM_ID = "SLACK_TEAM_ID";
+export const SLACK_BOT_USER_ID = "SLACK_BOT_USER_ID";
+export const SLACK_TEAM_NAME = "SLACK_TEAM_NAME";
 
-export const TELEGRAM_BOT_TOKEN = 'TELEGRAM_BOT_TOKEN';
-export const TELEGRAM_WEBHOOK_SECRET = 'TELEGRAM_WEBHOOK_SECRET';
+export const TELEGRAM_BOT_TOKEN = "TELEGRAM_BOT_TOKEN";
+export const TELEGRAM_WEBHOOK_SECRET = "TELEGRAM_WEBHOOK_SECRET";
 
-export async function loadTelegramWebhookSecretForProject(projectId: string): Promise<string | null> {
+export async function loadTelegramWebhookSecretForProject(
+  projectId: string,
+): Promise<string | null> {
   return readSecret(projectId, TELEGRAM_WEBHOOK_SECRET);
 }
 
-export const AGENTMAIL_API_KEY = 'AGENTMAIL_API_KEY';
-export const AGENTMAIL_INBOX_ID = 'AGENTMAIL_INBOX_ID';
-export const AGENTMAIL_INBOX_EMAIL = 'AGENTMAIL_INBOX_EMAIL';
-export const AGENTMAIL_INBOX_DISPLAY_NAME = 'AGENTMAIL_INBOX_DISPLAY_NAME';
-export const AGENTMAIL_WEBHOOK_ID = 'AGENTMAIL_WEBHOOK_ID';
-export const AGENTMAIL_WEBHOOK_SECRET = 'AGENTMAIL_WEBHOOK_SECRET';
+export const AGENTMAIL_API_KEY = "AGENTMAIL_API_KEY";
+export const AGENTMAIL_INBOX_ID = "AGENTMAIL_INBOX_ID";
+export const AGENTMAIL_INBOX_EMAIL = "AGENTMAIL_INBOX_EMAIL";
+export const AGENTMAIL_INBOX_DISPLAY_NAME = "AGENTMAIL_INBOX_DISPLAY_NAME";
+export const AGENTMAIL_WEBHOOK_ID = "AGENTMAIL_WEBHOOK_ID";
+export const AGENTMAIL_WEBHOOK_SECRET = "AGENTMAIL_WEBHOOK_SECRET";
+export const AGENTMAIL_SENDER_POLICY = "AGENTMAIL_SENDER_POLICY";
 
 const SLACK_KEYS = [
   SLACK_BOT_TOKEN,
@@ -42,7 +45,22 @@ const AGENTMAIL_KEYS = [
   AGENTMAIL_INBOX_DISPLAY_NAME,
   AGENTMAIL_WEBHOOK_ID,
   AGENTMAIL_WEBHOOK_SECRET,
+  AGENTMAIL_SENDER_POLICY,
 ] as const;
+
+export interface AgentMailSenderPolicy {
+  mode: "allow_all" | "restricted";
+  allowedEmails: string[];
+  allowedDomains: string[];
+  allowedRegex: string | null;
+}
+
+export const DEFAULT_AGENTMAIL_SENDER_POLICY: AgentMailSenderPolicy = {
+  mode: "allow_all",
+  allowedEmails: [],
+  allowedDomains: [],
+  allowedRegex: null,
+};
 
 export interface SlackInstallSummary {
   workspaceId: string;
@@ -66,6 +84,7 @@ export interface AgentMailInstallSummary {
   email: string;
   displayName: string | null;
   webhookId: string | null;
+  senderPolicy: AgentMailSenderPolicy;
   installedAt: string;
 }
 
@@ -78,12 +97,16 @@ export interface AgentMailInstallInput {
   displayName?: string | null;
   webhookId?: string | null;
   webhookSecret?: string | null;
+  senderPolicy?: AgentMailSenderPolicy | null;
 }
 
 function agentMailProfileSuffix(profileSlug?: string | null): string {
-  const slug = (profileSlug || 'kortix_email').trim();
-  if (!slug || slug === 'kortix_email') return '';
-  return `_${slug.toUpperCase().replace(/[^A-Z0-9]+/g, '_').replace(/^_+|_+$/g, '')}`;
+  const slug = (profileSlug || "kortix_email").trim();
+  if (!slug || slug === "kortix_email") return "";
+  return `_${slug
+    .toUpperCase()
+    .replace(/[^A-Z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "")}`;
 }
 
 function agentMailKeys(profileSlug?: string | null) {
@@ -95,16 +118,65 @@ function agentMailKeys(profileSlug?: string | null) {
     displayName: `${AGENTMAIL_INBOX_DISPLAY_NAME}${suffix}`,
     webhookId: `${AGENTMAIL_WEBHOOK_ID}${suffix}`,
     webhookSecret: `${AGENTMAIL_WEBHOOK_SECRET}${suffix}`,
+    senderPolicy: `${AGENTMAIL_SENDER_POLICY}${suffix}`,
   };
 }
 
-export async function saveSlackInstall(input: SlackInstallInput): Promise<SlackInstallSummary> {
+function uniqueStrings(values: unknown): string[] {
+  if (!Array.isArray(values)) return [];
+  return Array.from(
+    new Set(
+      values
+        .map((value) =>
+          typeof value === "string" ? value.trim().toLowerCase() : "",
+        )
+        .filter(Boolean),
+    ),
+  );
+}
+
+export function normalizeSenderPolicy(
+  input?: Partial<AgentMailSenderPolicy> | null,
+): AgentMailSenderPolicy {
+  const allowedEmails = uniqueStrings(input?.allowedEmails);
+  const allowedDomains = uniqueStrings(input?.allowedDomains).map((domain) =>
+    domain.replace(/^@+/, ""),
+  );
+  const rawRegex =
+    typeof input?.allowedRegex === "string" ? input.allowedRegex.trim() : "";
+  const restricted =
+    input?.mode === "restricted" ||
+    allowedEmails.length > 0 ||
+    allowedDomains.length > 0 ||
+    rawRegex.length > 0;
+  return {
+    mode: restricted ? "restricted" : "allow_all",
+    allowedEmails,
+    allowedDomains,
+    allowedRegex: rawRegex || null,
+  };
+}
+
+function parseSenderPolicy(raw: string | null): AgentMailSenderPolicy {
+  if (!raw) return DEFAULT_AGENTMAIL_SENDER_POLICY;
+  try {
+    return normalizeSenderPolicy(
+      JSON.parse(raw) as Partial<AgentMailSenderPolicy>,
+    );
+  } catch {
+    return DEFAULT_AGENTMAIL_SENDER_POLICY;
+  }
+}
+
+export async function saveSlackInstall(
+  input: SlackInstallInput,
+): Promise<SlackInstallSummary> {
   const { projectId } = input;
   await upsertSecret(projectId, SLACK_BOT_TOKEN, input.botToken);
   await upsertSecret(projectId, SLACK_SIGNING_SECRET, input.signingSecret);
   await upsertSecret(projectId, SLACK_TEAM_ID, input.teamId);
   await upsertSecret(projectId, SLACK_BOT_USER_ID, input.botUserId);
-  await upsertSecret(projectId, SLACK_TEAM_NAME, input.teamName ?? '');
+  await upsertSecret(projectId, SLACK_TEAM_NAME, input.teamName ?? "");
   return {
     workspaceId: input.teamId,
     workspaceName: input.teamName,
@@ -117,40 +189,63 @@ export async function deleteSlackInstall(projectId: string): Promise<void> {
   for (const name of SLACK_KEYS) {
     await db
       .delete(projectSecrets)
-      .where(and(eq(projectSecrets.projectId, projectId), eq(projectSecrets.name, name)));
+      .where(
+        and(
+          eq(projectSecrets.projectId, projectId),
+          eq(projectSecrets.name, name),
+        ),
+      );
   }
   await db
     .delete(chatInstalls)
-    .where(and(eq(chatInstalls.platform, 'slack'), eq(chatInstalls.projectId, projectId)));
+    .where(
+      and(
+        eq(chatInstalls.platform, "slack"),
+        eq(chatInstalls.projectId, projectId),
+      ),
+    );
 }
 
-export async function saveAgentMailInstall(input: AgentMailInstallInput): Promise<AgentMailInstallSummary> {
+export async function saveAgentMailInstall(
+  input: AgentMailInstallInput,
+): Promise<AgentMailInstallSummary> {
   const { projectId } = input;
-  const profileSlug = input.profileSlug || 'kortix_email';
+  const profileSlug = input.profileSlug || "kortix_email";
   const keys = agentMailKeys(profileSlug);
   const previous = await loadAgentMailInstall(projectId, profileSlug);
   if (input.apiKey) await upsertSecret(projectId, keys.apiKey, input.apiKey);
   await upsertSecret(projectId, keys.inboxId, input.inboxId);
   await upsertSecret(projectId, keys.email, input.email);
-  await upsertSecret(projectId, keys.displayName, input.displayName ?? '');
-  await upsertSecret(projectId, keys.webhookId, input.webhookId ?? '');
+  await upsertSecret(projectId, keys.displayName, input.displayName ?? "");
+  await upsertSecret(projectId, keys.webhookId, input.webhookId ?? "");
+  await upsertSecret(
+    projectId,
+    keys.senderPolicy,
+    JSON.stringify(normalizeSenderPolicy(input.senderPolicy)),
+  );
   if (input.webhookSecret) {
     await upsertSecret(projectId, keys.webhookSecret, input.webhookSecret);
   }
   if (previous?.inboxId) {
     await db
       .delete(chatInstalls)
-      .where(and(
-        eq(chatInstalls.platform, 'email'),
-        eq(chatInstalls.projectId, projectId),
-        eq(chatInstalls.workspaceId, previous.inboxId),
-      ));
+      .where(
+        and(
+          eq(chatInstalls.platform, "email"),
+          eq(chatInstalls.projectId, projectId),
+          eq(chatInstalls.workspaceId, previous.inboxId),
+        ),
+      );
   }
   await db
     .insert(chatInstalls)
-    .values({ platform: 'email', workspaceId: input.inboxId, projectId })
+    .values({ platform: "email", workspaceId: input.inboxId, projectId })
     .onConflictDoNothing({
-      target: [chatInstalls.platform, chatInstalls.workspaceId, chatInstalls.projectId],
+      target: [
+        chatInstalls.platform,
+        chatInstalls.workspaceId,
+        chatInstalls.projectId,
+      ],
     });
   return {
     profileSlug,
@@ -158,49 +253,69 @@ export async function saveAgentMailInstall(input: AgentMailInstallInput): Promis
     email: input.email,
     displayName: input.displayName ?? null,
     webhookId: input.webhookId ?? null,
+    senderPolicy: normalizeSenderPolicy(input.senderPolicy),
     installedAt: new Date().toISOString(),
   };
 }
 
-export async function deleteAgentMailInstall(projectId: string, profileSlug?: string | null): Promise<void> {
+export async function deleteAgentMailInstall(
+  projectId: string,
+  profileSlug?: string | null,
+): Promise<void> {
   const keys = agentMailKeys(profileSlug);
   const install = await loadAgentMailInstall(projectId, profileSlug);
   for (const name of Object.values(keys)) {
     await db
       .delete(projectSecrets)
-      .where(and(eq(projectSecrets.projectId, projectId), eq(projectSecrets.name, name)));
+      .where(
+        and(
+          eq(projectSecrets.projectId, projectId),
+          eq(projectSecrets.name, name),
+        ),
+      );
   }
   if (install?.inboxId) {
     await db
       .delete(chatInstalls)
-      .where(and(
-        eq(chatInstalls.platform, 'email'),
-        eq(chatInstalls.projectId, projectId),
-        eq(chatInstalls.workspaceId, install.inboxId),
-      ));
-  } else if (!profileSlug || profileSlug === 'kortix_email') {
+      .where(
+        and(
+          eq(chatInstalls.platform, "email"),
+          eq(chatInstalls.projectId, projectId),
+          eq(chatInstalls.workspaceId, install.inboxId),
+        ),
+      );
+  } else if (!profileSlug || profileSlug === "kortix_email") {
     await db
       .delete(chatInstalls)
-      .where(and(eq(chatInstalls.platform, 'email'), eq(chatInstalls.projectId, projectId)));
+      .where(
+        and(
+          eq(chatInstalls.platform, "email"),
+          eq(chatInstalls.projectId, projectId),
+        ),
+      );
   }
 }
 
 function agentMailProfileSlugFromInboxSecret(name: string): string | null {
   if (!name.startsWith(AGENTMAIL_INBOX_ID)) return null;
   const suffix = name.slice(AGENTMAIL_INBOX_ID.length);
-  if (!suffix) return 'kortix_email';
-  return suffix.replace(/^_+/, '').toLowerCase() || null;
+  if (!suffix) return "kortix_email";
+  return suffix.replace(/^_+/, "").toLowerCase() || null;
 }
 
-export async function listAgentMailInstalls(projectId: string): Promise<AgentMailInstallSummary[]> {
+export async function listAgentMailInstalls(
+  projectId: string,
+): Promise<AgentMailInstallSummary[]> {
   const rows = await db
     .select({ name: projectSecrets.name, valueEnc: projectSecrets.valueEnc })
     .from(projectSecrets)
-    .where(and(
-      eq(projectSecrets.projectId, projectId),
-      like(projectSecrets.name, `${AGENTMAIL_INBOX_ID}%`),
-      isNull(projectSecrets.ownerUserId),
-    ));
+    .where(
+      and(
+        eq(projectSecrets.projectId, projectId),
+        like(projectSecrets.name, `${AGENTMAIL_INBOX_ID}%`),
+        isNull(projectSecrets.ownerUserId),
+      ),
+    );
 
   const installs: AgentMailInstallSummary[] = [];
   for (const row of rows) {
@@ -218,54 +333,84 @@ export async function listAgentMailInstalls(projectId: string): Promise<AgentMai
   return installs.sort((a, b) => a.profileSlug.localeCompare(b.profileSlug));
 }
 
+export async function updateAgentMailSenderPolicy(
+  projectId: string,
+  profileSlug: string | null | undefined,
+  senderPolicy: AgentMailSenderPolicy,
+): Promise<AgentMailInstallSummary | null> {
+  const install = await loadAgentMailInstall(projectId, profileSlug);
+  if (!install) return null;
+  await upsertSecret(
+    projectId,
+    agentMailKeys(profileSlug).senderPolicy,
+    JSON.stringify(normalizeSenderPolicy(senderPolicy)),
+  );
+  return loadAgentMailInstall(projectId, profileSlug);
+}
+
 export async function loadAgentMailInstall(
   projectId: string,
   profileSlug?: string | null,
 ): Promise<AgentMailInstallSummary | null> {
   const keys = agentMailKeys(profileSlug);
-  const [inboxId, email, displayName, webhookId] = await Promise.all([
-    readSecret(projectId, keys.inboxId),
-    readSecret(projectId, keys.email),
-    readSecret(projectId, keys.displayName),
-    readSecret(projectId, keys.webhookId),
-  ]);
+  const [inboxId, email, displayName, webhookId, senderPolicyRaw] =
+    await Promise.all([
+      readSecret(projectId, keys.inboxId),
+      readSecret(projectId, keys.email),
+      readSecret(projectId, keys.displayName),
+      readSecret(projectId, keys.webhookId),
+      readSecret(projectId, keys.senderPolicy),
+    ]);
   if (!inboxId || !email) return null;
   const [row] = await db
     .select({ updatedAt: projectSecrets.updatedAt })
     .from(projectSecrets)
-    .where(and(
-      eq(projectSecrets.projectId, projectId),
-      eq(projectSecrets.name, keys.inboxId),
-      isNull(projectSecrets.ownerUserId),
-    ))
+    .where(
+      and(
+        eq(projectSecrets.projectId, projectId),
+        eq(projectSecrets.name, keys.inboxId),
+        isNull(projectSecrets.ownerUserId),
+      ),
+    )
     .limit(1);
   return {
-    profileSlug: profileSlug || 'kortix_email',
+    profileSlug: profileSlug || "kortix_email",
     inboxId,
     email,
     displayName: displayName || null,
     webhookId: webhookId || null,
+    senderPolicy: parseSenderPolicy(senderPolicyRaw),
     installedAt: row?.updatedAt?.toISOString() ?? new Date().toISOString(),
   };
 }
 
-export async function loadAgentMailApiKeyForProject(projectId: string, profileSlug?: string | null): Promise<string | null> {
+export async function loadAgentMailApiKeyForProject(
+  projectId: string,
+  profileSlug?: string | null,
+): Promise<string | null> {
   return readSecret(projectId, agentMailKeys(profileSlug).apiKey);
 }
 
-export async function loadAgentMailWebhookSecretForProject(projectId: string): Promise<string | null> {
+export async function loadAgentMailWebhookSecretForProject(
+  projectId: string,
+): Promise<string | null> {
   return readSecret(projectId, AGENTMAIL_WEBHOOK_SECRET);
 }
 
-export async function loadAgentMailWebhookSecretForInbox(projectId: string, inboxId: string): Promise<string | null> {
+export async function loadAgentMailWebhookSecretForInbox(
+  projectId: string,
+  inboxId: string,
+): Promise<string | null> {
   const rows = await db
     .select({ name: projectSecrets.name, valueEnc: projectSecrets.valueEnc })
     .from(projectSecrets)
-    .where(and(
-      eq(projectSecrets.projectId, projectId),
-      like(projectSecrets.name, `${AGENTMAIL_INBOX_ID}%`),
-      isNull(projectSecrets.ownerUserId),
-    ));
+    .where(
+      and(
+        eq(projectSecrets.projectId, projectId),
+        like(projectSecrets.name, `${AGENTMAIL_INBOX_ID}%`),
+        isNull(projectSecrets.ownerUserId),
+      ),
+    );
 
   for (const row of rows) {
     let value: string | null = null;
@@ -279,6 +424,37 @@ export async function loadAgentMailWebhookSecretForInbox(projectId: string, inbo
     return readSecret(projectId, `${AGENTMAIL_WEBHOOK_SECRET}${suffix}`);
   }
   return null;
+}
+
+export async function loadAgentMailSenderPolicyForInbox(
+  projectId: string,
+  inboxId: string,
+): Promise<AgentMailSenderPolicy> {
+  const rows = await db
+    .select({ name: projectSecrets.name, valueEnc: projectSecrets.valueEnc })
+    .from(projectSecrets)
+    .where(
+      and(
+        eq(projectSecrets.projectId, projectId),
+        like(projectSecrets.name, `${AGENTMAIL_INBOX_ID}%`),
+        isNull(projectSecrets.ownerUserId),
+      ),
+    );
+
+  for (const row of rows) {
+    let value: string | null = null;
+    try {
+      value = decryptProjectSecret(projectId, row.valueEnc);
+    } catch {
+      continue;
+    }
+    if (value !== inboxId) continue;
+    const suffix = row.name.slice(AGENTMAIL_INBOX_ID.length);
+    return parseSenderPolicy(
+      await readSecret(projectId, `${AGENTMAIL_SENDER_POLICY}${suffix}`),
+    );
+  }
+  return DEFAULT_AGENTMAIL_SENDER_POLICY;
 }
 
 export interface SlackOauthInstallInput {
@@ -299,16 +475,20 @@ export async function saveSlackOauthInstall(
 ): Promise<SlackInstallSummary> {
   await db
     .insert(chatInstalls)
-    .values({ platform: 'slack', workspaceId: input.workspaceId, projectId: input.projectId })
+    .values({
+      platform: "slack",
+      workspaceId: input.workspaceId,
+      projectId: input.projectId,
+    })
     .onConflictDoNothing();
 
-  const projectIds = await listProjectsForWorkspace('slack', input.workspaceId);
+  const projectIds = await listProjectsForWorkspace("slack", input.workspaceId);
   if (!projectIds.includes(input.projectId)) projectIds.push(input.projectId);
   for (const projectId of projectIds) {
     await upsertSecret(projectId, SLACK_BOT_TOKEN, input.botToken);
     await upsertSecret(projectId, SLACK_TEAM_ID, input.workspaceId);
     await upsertSecret(projectId, SLACK_BOT_USER_ID, input.botUserId);
-    await upsertSecret(projectId, SLACK_TEAM_NAME, input.teamName ?? '');
+    await upsertSecret(projectId, SLACK_TEAM_NAME, input.teamName ?? "");
   }
 
   return {
@@ -326,7 +506,12 @@ export async function listProjectsForWorkspace(
   const rows = await db
     .select({ projectId: chatInstalls.projectId })
     .from(chatInstalls)
-    .where(and(eq(chatInstalls.platform, platform), eq(chatInstalls.workspaceId, workspaceId)));
+    .where(
+      and(
+        eq(chatInstalls.platform, platform),
+        eq(chatInstalls.workspaceId, workspaceId),
+      ),
+    );
   return rows.map((r) => r.projectId);
 }
 
@@ -339,7 +524,12 @@ export async function loadSlackInstall(
   const [row] = await db
     .select({ updatedAt: projectSecrets.updatedAt })
     .from(projectSecrets)
-    .where(and(eq(projectSecrets.projectId, projectId), eq(projectSecrets.name, SLACK_TEAM_ID)))
+    .where(
+      and(
+        eq(projectSecrets.projectId, projectId),
+        eq(projectSecrets.name, SLACK_TEAM_ID),
+      ),
+    )
     .limit(1);
   return {
     workspaceId: teamId,
@@ -349,23 +539,35 @@ export async function loadSlackInstall(
   };
 }
 
-export async function loadSlackTokenForProject(projectId: string): Promise<string | null> {
+export async function loadSlackTokenForProject(
+  projectId: string,
+): Promise<string | null> {
   return readSecret(projectId, SLACK_BOT_TOKEN);
 }
 
-export async function loadSlackSigningSecretForProject(projectId: string): Promise<string | null> {
+export async function loadSlackSigningSecretForProject(
+  projectId: string,
+): Promise<string | null> {
   return readSecret(projectId, SLACK_SIGNING_SECRET);
 }
 
-export async function loadSlackBotUserIdForProject(projectId: string): Promise<string | null> {
+export async function loadSlackBotUserIdForProject(
+  projectId: string,
+): Promise<string | null> {
   return readSecret(projectId, SLACK_BOT_USER_ID);
 }
 
-export async function loadSlackTeamNameForProject(projectId: string): Promise<string | null> {
+export async function loadSlackTeamNameForProject(
+  projectId: string,
+): Promise<string | null> {
   return readSecret(projectId, SLACK_TEAM_NAME);
 }
 
-async function upsertSecret(projectId: string, name: string, value: string): Promise<void> {
+async function upsertSecret(
+  projectId: string,
+  name: string,
+  value: string,
+): Promise<void> {
   const valueEnc = encryptProjectSecret(projectId, value);
   const updated = await updateSharedSecret(projectId, name, valueEnc);
   if (updated) return;
@@ -379,36 +581,47 @@ async function upsertSecret(projectId: string, name: string, value: string): Pro
   }
 }
 
-async function updateSharedSecret(projectId: string, name: string, valueEnc: string): Promise<boolean> {
+async function updateSharedSecret(
+  projectId: string,
+  name: string,
+  valueEnc: string,
+): Promise<boolean> {
   const rows = await db
     .update(projectSecrets)
     .set({ valueEnc, updatedAt: new Date() })
-    .where(and(
-      eq(projectSecrets.projectId, projectId),
-      eq(projectSecrets.name, name),
-      isNull(projectSecrets.ownerUserId),
-    ))
+    .where(
+      and(
+        eq(projectSecrets.projectId, projectId),
+        eq(projectSecrets.name, name),
+        isNull(projectSecrets.ownerUserId),
+      ),
+    )
     .returning({ secretId: projectSecrets.secretId });
   return rows.length > 0;
 }
 
 function isUniqueConflict(err: unknown): boolean {
   return (
-    (err as any)?.code === '23505' ||
-    (err as any)?.cause?.code === '23505' ||
-    (err as any)?.cause?.cause?.code === '23505'
+    (err as any)?.code === "23505" ||
+    (err as any)?.cause?.code === "23505" ||
+    (err as any)?.cause?.cause?.code === "23505"
   );
 }
 
-async function readSecret(projectId: string, name: string): Promise<string | null> {
+async function readSecret(
+  projectId: string,
+  name: string,
+): Promise<string | null> {
   const [row] = await db
     .select({ valueEnc: projectSecrets.valueEnc })
     .from(projectSecrets)
-    .where(and(
-      eq(projectSecrets.projectId, projectId),
-      eq(projectSecrets.name, name),
-      isNull(projectSecrets.ownerUserId),
-    ))
+    .where(
+      and(
+        eq(projectSecrets.projectId, projectId),
+        eq(projectSecrets.name, name),
+        isNull(projectSecrets.ownerUserId),
+      ),
+    )
     .limit(1);
   if (!row?.valueEnc) return null;
   try {

--- a/apps/api/src/llm-gateway/models/catalog-models.ts
+++ b/apps/api/src/llm-gateway/models/catalog-models.ts
@@ -1,11 +1,11 @@
-import { resolveCatalogUpstream } from '@kortix/llm-gateway';
+import { resolveCatalogUpstream } from "@kortix/llm-gateway";
 import {
   AUTO_MODEL_ID,
   CATALOG,
   type CatalogModel,
   MANAGED_MODELS,
-} from '@kortix/shared/llm-catalog';
-import { codexModelIds } from './codex-models';
+} from "@kortix/shared/llm-catalog";
+import { codexModelIds } from "./codex-models";
 
 interface GatewayModel {
   name: string;
@@ -25,8 +25,8 @@ for (const provider of CATALOG.providers) {
 }
 
 function humanize(id: string): string {
-  const tail = id.split('/').pop() ?? id;
-  return tail.replace(/[-_]/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+  const tail = id.split("/").pop() ?? id;
+  return tail.replace(/[-_]/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
 }
 
 // Conservative context window for any model models.dev doesn't declare one for.
@@ -44,8 +44,14 @@ function servedLimit(limit?: { context?: number; output?: number }): {
   output: number;
 } {
   return {
-    context: limit?.context && limit.context > 0 ? limit.context : DEFAULT_SERVED_LIMIT.context,
-    output: limit?.output && limit.output > 0 ? limit.output : DEFAULT_SERVED_LIMIT.output,
+    context:
+      limit?.context && limit.context > 0
+        ? limit.context
+        : DEFAULT_SERVED_LIMIT.context,
+    output:
+      limit?.output && limit.output > 0
+        ? limit.output
+        : DEFAULT_SERVED_LIMIT.output,
   };
 }
 
@@ -53,7 +59,9 @@ function servedLimit(limit?: { context?: number; output?: number }): {
 // an enriched catalog entry (capabilities present) is used verbatim; a model
 // models.dev doesn't carry falls back to permissive legacy defaults so it isn't
 // crippled. See apps/web/scripts/enrich-llm-catalog-capabilities.ts.
-function capabilitiesOf(model: CatalogModel | undefined): Omit<GatewayModel, 'name'> {
+function capabilitiesOf(
+  model: CatalogModel | undefined,
+): Omit<GatewayModel, "name"> {
   if (model && model.attachment !== undefined) {
     return {
       reasoning: !!model.reasoning,
@@ -76,14 +84,14 @@ export function managedModels(): Record<string, GatewayModel> {
   const out: Record<string, GatewayModel> = {};
   // AUTO is synthetic (not a real model): it accepts images because pickAutoModel
   // routes image-bearing requests to a vision-capable model. Its window matches
-  // its default target (Owl Alpha) so OpenCode sizes conversations the same.
+  // its default target (Fusion) so OpenCode sizes conversations the same.
   out[AUTO_MODEL_ID] = {
-    name: 'Auto',
+    name: "Auto",
     reasoning: false,
     tool_call: true,
     attachment: true,
     temperature: true,
-    limit: { context: 1_048_756, output: 262_144 },
+    limit: { context: 1_000_000, output: 128_000 },
   };
   // The managed lineup is curated and its slugs don't all exist on models.dev
   // (z-ai≠zhipuai, dotted vs dashed Claude ids), so vision + limit are explicit
@@ -107,7 +115,10 @@ export function gatewayModelsAll(): Record<string, GatewayModel> {
     if (!resolveCatalogUpstream(provider.id)) continue;
     for (const model of provider.models) {
       // BYOK models ARE catalog entries — capabilities come straight from models.dev.
-      out[`${provider.id}/${model.id}`] = { name: model.name, ...capabilitiesOf(model) };
+      out[`${provider.id}/${model.id}`] = {
+        name: model.name,
+        ...capabilitiesOf(model),
+      };
     }
   }
   return out;
@@ -144,6 +155,8 @@ const FULL_CATALOG: Record<string, GatewayModel> = {
 
 // `projectId` gates BYOK/codex visibility (anonymous callers see managed only) —
 // it is NOT a per-project filter, so both shapes are shared singletons.
-export function gatewayModelCatalog(projectId: string | undefined): Record<string, GatewayModel> {
+export function gatewayModelCatalog(
+  projectId: string | undefined,
+): Record<string, GatewayModel> {
   return projectId ? FULL_CATALOG : MANAGED_ONLY;
 }

--- a/apps/api/src/projects/routes/r4.ts
+++ b/apps/api/src/projects/routes/r4.ts
@@ -3,41 +3,103 @@ import {
   deleteSlackInstall,
   loadAgentMailInstall,
   loadSlackInstall,
+  normalizeSenderPolicy,
   saveAgentMailInstall,
   saveSlackInstall,
-} from '../../channels/install-store';
-import { reconcileChannelConnectors } from '../../executor/sync';
-import { createAgentMailInbox, createAgentMailWebhook, resolveAgentMailApiKey } from '../../channels/agentmail-api';
-import { config } from '../../config';
-import { downloadSlackFile, uploadSlackFile } from '../../channels/slack/file-proxy';
-import { buildSlackInstallUrl } from '../../channels/slack-oauth';
-import { slackOauthMode } from '../../channels/slack-oauth-mode';
-import { postQuestion, relayTurnAnswer, relayTurnEnd, relayTurnStep, type QuestionInfo } from '../../channels/slack-webhook';
-import { PROJECT_ACTIONS, assertAuthorized } from '../../iam';
-import { auth, errors, json } from '../../openapi';
-import { gatewayModelCatalog } from '../../llm-gateway/models/catalog-models';
-import { resolveExperimentalFeature } from '../../experimental/features';
-import { db } from '../../shared/db';
-import { extractApps } from '../apps';
-import { extractTriggers, loadProjectTriggers, type ParsedManifest } from '../triggers';
-import { createRoute, z } from '@hono/zod-openapi';
-import { projectSessions, projectTriggerRuntime, projects, sessionSandboxes } from '@kortix/db';
-import { and, eq, inArray } from 'drizzle-orm';
-import { loadProjectForUser } from '../lib/access';
-import { AnyObject, AppSchema, TriggerSchema, projectsApp } from '../lib/app';
-import { APPS_DISABLED_BODY, SlackAuthTest, draftToAppSpec, loadAppsForResponse, parseAppDraft, projectAppsEnabled, removeAppFromManifest, specToAppBody, upsertAppInManifest } from '../lib/apps-helpers';
-import { getAccountMembership, withProjectGitAuth } from '../lib/git';
-import { readBody, requestAuditContext } from '../lib/serializers';
-import { commitManifest, draftToSpec, fireGitTrigger, loadManifestForEdit, loadTriggersForResponse, markGitTriggerFired, parseTriggerDraft, removeTriggerFromManifest, renderPromptTemplate, setGitTriggerOwner, specToBody, triggersPausedForProject, upsertTriggerInManifest, withTriggersPaused } from '../lib/triggers';
+  updateAgentMailSenderPolicy,
+  type AgentMailSenderPolicy,
+} from "../../channels/install-store";
+import { reconcileChannelConnectors } from "../../executor/sync";
+import {
+  createAgentMailInbox,
+  createAgentMailWebhook,
+  resolveAgentMailApiKey,
+} from "../../channels/agentmail-api";
+import { config } from "../../config";
+import {
+  downloadSlackFile,
+  uploadSlackFile,
+} from "../../channels/slack/file-proxy";
+import { buildSlackInstallUrl } from "../../channels/slack-oauth";
+import { slackOauthMode } from "../../channels/slack-oauth-mode";
+import {
+  postQuestion,
+  relayTurnAnswer,
+  relayTurnEnd,
+  relayTurnStep,
+  type QuestionInfo,
+} from "../../channels/slack-webhook";
+import { PROJECT_ACTIONS, assertAuthorized } from "../../iam";
+import { auth, errors, json } from "../../openapi";
+import { gatewayModelCatalog } from "../../llm-gateway/models/catalog-models";
+import { resolveExperimentalFeature } from "../../experimental/features";
+import { db } from "../../shared/db";
+import { extractApps } from "../apps";
+import {
+  extractTriggers,
+  loadProjectTriggers,
+  type ParsedManifest,
+} from "../triggers";
+import { createRoute, z } from "@hono/zod-openapi";
+import {
+  projectSessions,
+  projectTriggerRuntime,
+  projects,
+  sessionSandboxes,
+} from "@kortix/db";
+import { and, eq, inArray } from "drizzle-orm";
+import { loadProjectForUser } from "../lib/access";
+import { AnyObject, AppSchema, TriggerSchema, projectsApp } from "../lib/app";
+import {
+  APPS_DISABLED_BODY,
+  SlackAuthTest,
+  draftToAppSpec,
+  loadAppsForResponse,
+  parseAppDraft,
+  projectAppsEnabled,
+  removeAppFromManifest,
+  specToAppBody,
+  upsertAppInManifest,
+} from "../lib/apps-helpers";
+import { getAccountMembership, withProjectGitAuth } from "../lib/git";
+import { readBody, requestAuditContext } from "../lib/serializers";
+import {
+  commitManifest,
+  draftToSpec,
+  fireGitTrigger,
+  loadManifestForEdit,
+  loadTriggersForResponse,
+  markGitTriggerFired,
+  parseTriggerDraft,
+  removeTriggerFromManifest,
+  renderPromptTemplate,
+  setGitTriggerOwner,
+  specToBody,
+  triggersPausedForProject,
+  upsertTriggerInManifest,
+  withTriggersPaused,
+} from "../lib/triggers";
 
 // Body keys that change the trigger's *repo manifest* (committed to git). An
 // owner-only edit touches none of these, so we can skip the manifest commit and
 // just update the DB-side owner — owner lives in project_trigger_runtime, never
 // in the portable kortix.toml.
 const TRIGGER_MANIFEST_KEYS = [
-  'name', 'type', 'agent', 'enabled', 'prompt_template', 'promptTemplate',
-  'cron', 'schedule', 'run_at', 'runAt', 'timezone', 'secret_env', 'secretEnv',
-  'session_mode', 'sessionMode',
+  "name",
+  "type",
+  "agent",
+  "enabled",
+  "prompt_template",
+  "promptTemplate",
+  "cron",
+  "schedule",
+  "run_at",
+  "runAt",
+  "timezone",
+  "secret_env",
+  "secretEnv",
+  "session_mode",
+  "sessionMode",
 ] as const;
 
 /**
@@ -50,100 +112,121 @@ const TRIGGER_MANIFEST_KEYS = [
 async function resolveOwnerFromBody(
   body: Record<string, unknown>,
   accountId: string,
-): Promise<{ skip: true } | { ownerUserId: string | null } | { error: string }> {
-  if (!('owner_user_id' in body) && !('ownerUserId' in body)) return { skip: true };
+): Promise<
+  { skip: true } | { ownerUserId: string | null } | { error: string }
+> {
+  if (!("owner_user_id" in body) && !("ownerUserId" in body))
+    return { skip: true };
   const raw = (body as any).owner_user_id ?? (body as any).ownerUserId;
-  const ownerUserId = typeof raw === 'string' && raw.trim() ? raw.trim() : null;
+  const ownerUserId = typeof raw === "string" && raw.trim() ? raw.trim() : null;
   if (ownerUserId) {
-    const membership = await getAccountMembership(ownerUserId, accountId).catch(() => null);
-    if (!membership) return { error: 'owner_user_id must be a member of this account' };
+    const membership = await getAccountMembership(ownerUserId, accountId).catch(
+      () => null,
+    );
+    if (!membership)
+      return { error: "owner_user_id must be a member of this account" };
   }
   return { ownerUserId };
 }
 
 projectsApp.openapi(
   createRoute({
-    method: 'get',
-    path: '/{projectId}/triggers',
-    tags: ['triggers'],
-    summary: 'GET /:projectId/triggers',
+    method: "get",
+    path: "/{projectId}/triggers",
+    tags: ["triggers"],
+    summary: "GET /:projectId/triggers",
     ...auth,
-      request: {
-        params: z.object({ projectId: z.string() }),
-      },
+    request: {
+      params: z.object({ projectId: z.string() }),
+    },
     responses: {
-        200: json(z.array(TriggerSchema), 'Triggers'),
-        ...errors(404),
+      200: json(z.array(TriggerSchema), "Triggers"),
+      ...errors(404),
     },
   }),
   async (c: any) => {
-  const projectId = c.req.param('projectId');
-  const loaded = await loadProjectForUser(c, projectId, 'read');
-  if (!loaded) return c.json({ error: 'Not found' }, 404);
+    const projectId = c.req.param("projectId");
+    const loaded = await loadProjectForUser(c, projectId, "read");
+    if (!loaded) return c.json({ error: "Not found" }, 404);
 
-  return c.json(await loadTriggersForResponse(projectId, loaded.row));
-},
+    return c.json(await loadTriggersForResponse(projectId, loaded.row));
+  },
 );
-
 
 projectsApp.openapi(
   createRoute({
-    method: 'post',
-    path: '/{projectId}/triggers',
-    tags: ['triggers'],
-    summary: 'POST /:projectId/triggers',
+    method: "post",
+    path: "/{projectId}/triggers",
+    tags: ["triggers"],
+    summary: "POST /:projectId/triggers",
     ...auth,
-      request: {
-        params: z.object({ projectId: z.string() }),
-        body: { content: { 'application/json': { schema: AnyObject } } },
-      },
+    request: {
+      params: z.object({ projectId: z.string() }),
+      body: { content: { "application/json": { schema: AnyObject } } },
+    },
     responses: {
-        201: json(TriggerSchema, 'The created trigger'),
-        ...errors(400, 404, 409),
+      201: json(TriggerSchema, "The created trigger"),
+      ...errors(400, 404, 409),
     },
   }),
   async (c: any) => {
-  const projectId = c.req.param('projectId');
-  const body = await readBody(c);
-  const loaded = await loadProjectForUser(c, projectId, 'manage');
-  if (!loaded) return c.json({ error: 'Not found' }, 404);
-  // Specific IAM gate so the audit trail records the precise action.
-  await assertAuthorized(loaded.userId, loaded.row.accountId, PROJECT_ACTIONS.PROJECT_TRIGGER_CREATE, { type: 'project', id: projectId });
+    const projectId = c.req.param("projectId");
+    const body = await readBody(c);
+    const loaded = await loadProjectForUser(c, projectId, "manage");
+    if (!loaded) return c.json({ error: "Not found" }, 404);
+    // Specific IAM gate so the audit trail records the precise action.
+    await assertAuthorized(
+      loaded.userId,
+      loaded.row.accountId,
+      PROJECT_ACTIONS.PROJECT_TRIGGER_CREATE,
+      { type: "project", id: projectId },
+    );
 
-  const draft = parseTriggerDraft(body, { existingSlug: null });
-  if ('error' in draft) return c.json({ error: draft.error }, 400);
+    const draft = parseTriggerDraft(body, { existingSlug: null });
+    if ("error" in draft) return c.json({ error: draft.error }, 400);
 
-  // Owner: default to the creator (so a per_user connector in this trigger's
-  // automated runs uses the creator's accounts), unless an explicit, valid
-  // owner_user_id is supplied. Validate BEFORE committing the manifest.
-  const ownerReq = await resolveOwnerFromBody(body, loaded.row.accountId);
-  if ('error' in ownerReq) return c.json({ error: ownerReq.error }, 400);
-  const ownerUserId = 'skip' in ownerReq ? loaded.userId : ownerReq.ownerUserId;
+    // Owner: default to the creator (so a per_user connector in this trigger's
+    // automated runs uses the creator's accounts), unless an explicit, valid
+    // owner_user_id is supplied. Validate BEFORE committing the manifest.
+    const ownerReq = await resolveOwnerFromBody(body, loaded.row.accountId);
+    if ("error" in ownerReq) return c.json({ error: ownerReq.error }, 400);
+    const ownerUserId =
+      "skip" in ownerReq ? loaded.userId : ownerReq.ownerUserId;
 
-  let manifest: ParsedManifest;
-  try {
-    manifest = await loadManifestForEdit(loaded.row);
-  } catch (err) {
-    return c.json({ error: (err as Error).message || 'Failed to read manifest' }, 400);
-  }
+    let manifest: ParsedManifest;
+    try {
+      manifest = await loadManifestForEdit(loaded.row);
+    } catch (err) {
+      return c.json(
+        { error: (err as Error).message || "Failed to read manifest" },
+        400,
+      );
+    }
 
-  if (extractTriggers(manifest).specs.some((s) => s.slug === draft.slug)) {
-    return c.json({
-      error: `A trigger with slug "${draft.slug}" already exists. Pick a different name.`,
-    }, 409);
-  }
+    if (extractTriggers(manifest).specs.some((s) => s.slug === draft.slug)) {
+      return c.json(
+        {
+          error: `A trigger with slug "${draft.slug}" already exists. Pick a different name.`,
+        },
+        409,
+      );
+    }
 
-  const next = upsertTriggerInManifest(manifest, draftToSpec(draft));
-  const result = await commitManifest(loaded.row, next, `chore: add trigger ${draft.slug}`);
-  if ('error' in result) {
-    return c.json({ error: result.error }, result.status as 400 | 502);
-  }
+    const next = upsertTriggerInManifest(manifest, draftToSpec(draft));
+    const result = await commitManifest(
+      loaded.row,
+      next,
+      `chore: add trigger ${draft.slug}`,
+    );
+    if ("error" in result) {
+      return c.json({ error: result.error }, result.status as 400 | 502);
+    }
 
-  // Persist the owner (DB-side) after the manifest commit succeeds.
-  await setGitTriggerOwner(projectId, draft.slug, ownerUserId);
+    // Persist the owner (DB-side) after the manifest commit succeeds.
+    await setGitTriggerOwner(projectId, draft.slug, ownerUserId);
 
-  return c.json(await loadTriggersForResponse(projectId, loaded.row), 201);
-},
+    return c.json(await loadTriggersForResponse(projectId, loaded.row), 201);
+  },
 );
 
 // PATCH /:projectId/triggers/activation — server-side, per-project trigger
@@ -162,41 +245,45 @@ projectsApp.openapi(
 // Covered by unit-trigger-activation-route.test.ts.
 projectsApp.openapi(
   createRoute({
-    method: 'patch',
-    path: '/{projectId}/triggers/activation',
-    tags: ['triggers'],
-    summary: 'Pause or resume all of a project\'s triggers server-side',
+    method: "patch",
+    path: "/{projectId}/triggers/activation",
+    tags: ["triggers"],
+    summary: "Pause or resume all of a project's triggers server-side",
     ...auth,
     request: {
       params: z.object({ projectId: z.string() }),
-      body: { content: { 'application/json': { schema: AnyObject } } },
+      body: { content: { "application/json": { schema: AnyObject } } },
     },
     responses: {
-      200: json(AnyObject, 'Updated triggers (includes triggers_paused)'),
+      200: json(AnyObject, "Updated triggers (includes triggers_paused)"),
       ...errors(400, 401, 403, 404),
     },
   }),
   async (c: any) => {
-    const projectId = c.req.param('projectId');
+    const projectId = c.req.param("projectId");
     const body = await readBody(c);
-    const loaded = await loadProjectForUser(c, projectId, 'manage');
-    if (!loaded) return c.json({ error: 'Not found' }, 404);
+    const loaded = await loadProjectForUser(c, projectId, "manage");
+    if (!loaded) return c.json({ error: "Not found" }, 404);
     await assertAuthorized(
       loaded.userId,
       loaded.row.accountId,
       PROJECT_ACTIONS.PROJECT_TRIGGER_UPDATE,
-      { type: 'project', id: projectId },
+      { type: "project", id: projectId },
     );
     const paused = body.paused;
-    if (typeof paused !== 'boolean') {
-      return c.json({ error: 'paused must be a boolean' }, 400);
+    if (typeof paused !== "boolean") {
+      return c.json({ error: "paused must be a boolean" }, 400);
     }
     const [row] = await db
       .update(projects)
-      .set({ metadata: withTriggersPaused(loaded.row.metadata, paused), updatedAt: new Date() })
+      .set({
+        metadata: withTriggersPaused(loaded.row.metadata, paused),
+        updatedAt: new Date(),
+      })
       .where(eq(projects.projectId, projectId))
       .returning();
-    if (!row || row.status === 'archived') return c.json({ error: 'Not found' }, 404);
+    if (!row || row.status === "archived")
+      return c.json({ error: "Not found" }, 404);
     return c.json(await loadTriggersForResponse(projectId, row));
   },
 );
@@ -205,151 +292,178 @@ projectsApp.openapi(
 
 projectsApp.openapi(
   createRoute({
-    method: 'patch',
-    path: '/{projectId}/triggers/{slug}',
-    tags: ['triggers'],
-    summary: 'PATCH /:projectId/triggers/:slug',
+    method: "patch",
+    path: "/{projectId}/triggers/{slug}",
+    tags: ["triggers"],
+    summary: "PATCH /:projectId/triggers/:slug",
     ...auth,
-      request: {
-        params: z.object({ projectId: z.string(), slug: z.string() }),
-        body: { content: { 'application/json': { schema: AnyObject } } },
-      },
+    request: {
+      params: z.object({ projectId: z.string(), slug: z.string() }),
+      body: { content: { "application/json": { schema: AnyObject } } },
+    },
     responses: {
-        200: json(z.any(), 'OK'),
-        ...errors(400, 404),
+      200: json(z.any(), "OK"),
+      ...errors(400, 404),
     },
   }),
   async (c: any) => {
-  const projectId = c.req.param('projectId');
-  const slug = c.req.param('slug');
-  const body = await readBody(c);
-  const loaded = await loadProjectForUser(c, projectId, 'manage');
-  if (!loaded) return c.json({ error: 'Not found' }, 404);
-  await assertAuthorized(loaded.userId, loaded.row.accountId, PROJECT_ACTIONS.PROJECT_TRIGGER_UPDATE, { type: 'project', id: projectId });
-
-  let manifest: ParsedManifest;
-  try {
-    manifest = await loadManifestForEdit(loaded.row);
-  } catch (err) {
-    return c.json({ error: (err as Error).message || 'Failed to read manifest' }, 400);
-  }
-  const current = extractTriggers(manifest).specs.find((s) => s.slug === slug);
-  if (!current) return c.json({ error: 'Not found' }, 404);
-
-  // Owner lives in the DB, not the manifest — validate it up front.
-  const ownerReq = await resolveOwnerFromBody(body, loaded.row.accountId);
-  if ('error' in ownerReq) return c.json({ error: ownerReq.error }, 400);
-
-  // Only commit the repo manifest when a manifest field actually changed. An
-  // owner-only PATCH skips git entirely (owner is a pure platform concern).
-  const touchesManifest = TRIGGER_MANIFEST_KEYS.some((k) => k in body);
-  if (touchesManifest) {
-    // Merge the patch onto the current spec so callers can send partial bodies
-    // (e.g. just `{ enabled: false }`). The parsed result becomes the new entry.
-    const draft = parseTriggerDraft(
-      { ...specToBody(current), ...body, slug: slug },
-      { existingSlug: slug },
+    const projectId = c.req.param("projectId");
+    const slug = c.req.param("slug");
+    const body = await readBody(c);
+    const loaded = await loadProjectForUser(c, projectId, "manage");
+    if (!loaded) return c.json({ error: "Not found" }, 404);
+    await assertAuthorized(
+      loaded.userId,
+      loaded.row.accountId,
+      PROJECT_ACTIONS.PROJECT_TRIGGER_UPDATE,
+      { type: "project", id: projectId },
     );
-    if ('error' in draft) return c.json({ error: draft.error }, 400);
 
-    const next = upsertTriggerInManifest(manifest, draftToSpec(draft));
-    const result = await commitManifest(loaded.row, next, `chore: update trigger ${slug}`);
-    if ('error' in result) {
-      return c.json({ error: result.error }, result.status as 400 | 502);
+    let manifest: ParsedManifest;
+    try {
+      manifest = await loadManifestForEdit(loaded.row);
+    } catch (err) {
+      return c.json(
+        { error: (err as Error).message || "Failed to read manifest" },
+        400,
+      );
     }
-  }
+    const current = extractTriggers(manifest).specs.find(
+      (s) => s.slug === slug,
+    );
+    if (!current) return c.json({ error: "Not found" }, 404);
 
-  // Apply the owner change (if the body specified one) after any manifest commit.
-  if (!('skip' in ownerReq)) {
-    await setGitTriggerOwner(projectId, slug, ownerReq.ownerUserId);
-  }
+    // Owner lives in the DB, not the manifest — validate it up front.
+    const ownerReq = await resolveOwnerFromBody(body, loaded.row.accountId);
+    if ("error" in ownerReq) return c.json({ error: ownerReq.error }, 400);
 
-  return c.json(await loadTriggersForResponse(projectId, loaded.row));
-},
+    // Only commit the repo manifest when a manifest field actually changed. An
+    // owner-only PATCH skips git entirely (owner is a pure platform concern).
+    const touchesManifest = TRIGGER_MANIFEST_KEYS.some((k) => k in body);
+    if (touchesManifest) {
+      // Merge the patch onto the current spec so callers can send partial bodies
+      // (e.g. just `{ enabled: false }`). The parsed result becomes the new entry.
+      const draft = parseTriggerDraft(
+        { ...specToBody(current), ...body, slug: slug },
+        { existingSlug: slug },
+      );
+      if ("error" in draft) return c.json({ error: draft.error }, 400);
+
+      const next = upsertTriggerInManifest(manifest, draftToSpec(draft));
+      const result = await commitManifest(
+        loaded.row,
+        next,
+        `chore: update trigger ${slug}`,
+      );
+      if ("error" in result) {
+        return c.json({ error: result.error }, result.status as 400 | 502);
+      }
+    }
+
+    // Apply the owner change (if the body specified one) after any manifest commit.
+    if (!("skip" in ownerReq)) {
+      await setGitTriggerOwner(projectId, slug, ownerReq.ownerUserId);
+    }
+
+    return c.json(await loadTriggersForResponse(projectId, loaded.row));
+  },
 );
 
 // DELETE /v1/projects/:projectId/triggers/:slug
 
 projectsApp.openapi(
   createRoute({
-    method: 'delete',
-    path: '/{projectId}/triggers/{slug}',
-    tags: ['triggers'],
-    summary: 'DELETE /:projectId/triggers/:slug',
+    method: "delete",
+    path: "/{projectId}/triggers/{slug}",
+    tags: ["triggers"],
+    summary: "DELETE /:projectId/triggers/:slug",
     ...auth,
-      request: {
-        params: z.object({ projectId: z.string(), slug: z.string() }),
-      },
+    request: {
+      params: z.object({ projectId: z.string(), slug: z.string() }),
+    },
     responses: {
-        200: json(z.any(), 'OK'),
-        ...errors(400, 404),
+      200: json(z.any(), "OK"),
+      ...errors(400, 404),
     },
   }),
   async (c: any) => {
-  const projectId = c.req.param('projectId');
-  const slug = c.req.param('slug');
-  const loaded = await loadProjectForUser(c, projectId, 'manage');
-  if (!loaded) return c.json({ error: 'Not found' }, 404);
-  await assertAuthorized(loaded.userId, loaded.row.accountId, PROJECT_ACTIONS.PROJECT_TRIGGER_DELETE, { type: 'project', id: projectId });
+    const projectId = c.req.param("projectId");
+    const slug = c.req.param("slug");
+    const loaded = await loadProjectForUser(c, projectId, "manage");
+    if (!loaded) return c.json({ error: "Not found" }, 404);
+    await assertAuthorized(
+      loaded.userId,
+      loaded.row.accountId,
+      PROJECT_ACTIONS.PROJECT_TRIGGER_DELETE,
+      { type: "project", id: projectId },
+    );
 
-  if (!/^[a-z0-9][a-z0-9_-]{0,127}$/.test(slug)) {
-    return c.json({ error: 'Invalid slug' }, 400);
-  }
+    if (!/^[a-z0-9][a-z0-9_-]{0,127}$/.test(slug)) {
+      return c.json({ error: "Invalid slug" }, 400);
+    }
 
-  let manifest: ParsedManifest;
-  try {
-    manifest = await loadManifestForEdit(loaded.row);
-  } catch (err) {
-    return c.json({ error: (err as Error).message || 'Failed to read manifest' }, 400);
-  }
-  if (!extractTriggers(manifest).specs.some((s) => s.slug === slug)) {
-    return c.json({ error: 'Not found' }, 404);
-  }
+    let manifest: ParsedManifest;
+    try {
+      manifest = await loadManifestForEdit(loaded.row);
+    } catch (err) {
+      return c.json(
+        { error: (err as Error).message || "Failed to read manifest" },
+        400,
+      );
+    }
+    if (!extractTriggers(manifest).specs.some((s) => s.slug === slug)) {
+      return c.json({ error: "Not found" }, 404);
+    }
 
-  const next = removeTriggerFromManifest(manifest, slug);
-  const result = await commitManifest(loaded.row, next, `chore: delete trigger ${slug}`);
-  if ('error' in result) {
-    return c.json({ error: result.error }, result.status as 400 | 502);
-  }
+    const next = removeTriggerFromManifest(manifest, slug);
+    const result = await commitManifest(
+      loaded.row,
+      next,
+      `chore: delete trigger ${slug}`,
+    );
+    if ("error" in result) {
+      return c.json({ error: result.error }, result.status as 400 | 502);
+    }
 
-  // Drop runtime state too — a re-created trigger of the same slug should
-  // start with a clean last_fired_at.
-  await db
-    .delete(projectTriggerRuntime)
-    .where(and(
-      eq(projectTriggerRuntime.projectId, projectId),
-      eq(projectTriggerRuntime.slug, slug),
-    ));
+    // Drop runtime state too — a re-created trigger of the same slug should
+    // start with a clean last_fired_at.
+    await db
+      .delete(projectTriggerRuntime)
+      .where(
+        and(
+          eq(projectTriggerRuntime.projectId, projectId),
+          eq(projectTriggerRuntime.slug, slug),
+        ),
+      );
 
-  return c.json({ ok: true });
-},
+    return c.json({ ok: true });
+  },
 );
 
 // ─── Slack install — per project, secrets live in project_secrets ────────
 
-
 projectsApp.openapi(
   createRoute({
-    method: 'get',
-    path: '/{projectId}/channels/slack/installation',
-    tags: ['channels'],
-    summary: 'GET /:projectId/channels/slack/installation',
+    method: "get",
+    path: "/{projectId}/channels/slack/installation",
+    tags: ["channels"],
+    summary: "GET /:projectId/channels/slack/installation",
     ...auth,
-      request: {
-        params: z.object({ projectId: z.string() }),
-      },
+    request: {
+      params: z.object({ projectId: z.string() }),
+    },
     responses: {
-        200: json(z.any(), 'OK'),
-        ...errors(404),
+      200: json(z.any(), "OK"),
+      ...errors(404),
     },
   }),
   async (c: any) => {
-  const projectId = c.req.param('projectId');
-  const loaded = await loadProjectForUser(c, projectId, 'read');
-  if (!loaded) return c.json({ error: 'Not found' }, 404);
-  const install = await loadSlackInstall(projectId);
-  return c.json(install ?? null);
-},
+    const projectId = c.req.param("projectId");
+    const loaded = await loadProjectForUser(c, projectId, "read");
+    if (!loaded) return c.json({ error: "Not found" }, 404);
+    const install = await loadSlackInstall(projectId);
+    return c.json(install ?? null);
+  },
 );
 
 // GET /v1/projects/:projectId/channels/slack/mode
@@ -359,159 +473,176 @@ projectsApp.openapi(
 
 projectsApp.openapi(
   createRoute({
-    method: 'get',
-    path: '/{projectId}/channels/slack/mode',
-    tags: ['channels'],
-    summary: 'GET /:projectId/channels/slack/mode',
+    method: "get",
+    path: "/{projectId}/channels/slack/mode",
+    tags: ["channels"],
+    summary: "GET /:projectId/channels/slack/mode",
     ...auth,
-      request: {
-        params: z.object({ projectId: z.string() }),
-      },
+    request: {
+      params: z.object({ projectId: z.string() }),
+    },
     responses: {
-        200: json(z.any(), 'OK'),
-        ...errors(404),
+      200: json(z.any(), "OK"),
+      ...errors(404),
     },
   }),
   async (c: any) => {
-  const projectId = c.req.param('projectId');
-  const loaded = await loadProjectForUser(c, projectId, 'read');
-  if (!loaded) return c.json({ error: 'Not found' }, 404);
-  const mode = slackOauthMode();
-  if (!mode.available) {
-    return c.json({ oauth_available: false, install_url: null });
-  }
-  try {
-    const installUrl = buildSlackInstallUrl(projectId, loaded.userId);
-    return c.json({ oauth_available: true, install_url: installUrl });
-  } catch {
-    return c.json({ oauth_available: false, install_url: null });
-  }
-},
+    const projectId = c.req.param("projectId");
+    const loaded = await loadProjectForUser(c, projectId, "read");
+    if (!loaded) return c.json({ error: "Not found" }, 404);
+    const mode = slackOauthMode();
+    if (!mode.available) {
+      return c.json({ oauth_available: false, install_url: null });
+    }
+    try {
+      const installUrl = buildSlackInstallUrl(projectId, loaded.userId);
+      return c.json({ oauth_available: true, install_url: installUrl });
+    } catch {
+      return c.json({ oauth_available: false, install_url: null });
+    }
+  },
 );
 
 // POST /v1/projects/:projectId/channels/slack/connect
 
 projectsApp.openapi(
   createRoute({
-    method: 'post',
-    path: '/{projectId}/channels/slack/connect',
-    tags: ['channels'],
-    summary: 'POST /:projectId/channels/slack/connect',
+    method: "post",
+    path: "/{projectId}/channels/slack/connect",
+    tags: ["channels"],
+    summary: "POST /:projectId/channels/slack/connect",
     ...auth,
-      request: {
-        params: z.object({ projectId: z.string() }),
-        body: { content: { 'application/json': { schema: AnyObject } } },
-      },
+    request: {
+      params: z.object({ projectId: z.string() }),
+      body: { content: { "application/json": { schema: AnyObject } } },
+    },
     responses: {
-        200: json(z.any(), 'OK'),
-        ...errors(400, 404, 502),
+      200: json(z.any(), "OK"),
+      ...errors(400, 404, 502),
     },
   }),
   async (c: any) => {
-  const projectId = c.req.param('projectId');
-  const loaded = await loadProjectForUser(c, projectId, 'manage');
-  if (!loaded) return c.json({ error: 'Not found' }, 404);
+    const projectId = c.req.param("projectId");
+    const loaded = await loadProjectForUser(c, projectId, "manage");
+    if (!loaded) return c.json({ error: "Not found" }, 404);
 
-  let body: { bot_token?: string; signing_secret?: string };
-  try {
-    body = (await c.req.json()) as { bot_token?: string; signing_secret?: string };
-  } catch {
-    return c.json({ error: 'Invalid JSON body' }, 400);
-  }
-  const botToken = body.bot_token?.trim();
-  const signingSecret = body.signing_secret?.trim();
-  if (!botToken || !botToken.startsWith('xoxb-')) {
-    return c.json({ error: 'bot_token is required and must start with xoxb-' }, 400);
-  }
-  if (!signingSecret) {
-    return c.json({ error: 'signing_secret is required' }, 400);
-  }
+    let body: { bot_token?: string; signing_secret?: string };
+    try {
+      body = (await c.req.json()) as {
+        bot_token?: string;
+        signing_secret?: string;
+      };
+    } catch {
+      return c.json({ error: "Invalid JSON body" }, 400);
+    }
+    const botToken = body.bot_token?.trim();
+    const signingSecret = body.signing_secret?.trim();
+    if (!botToken || !botToken.startsWith("xoxb-")) {
+      return c.json(
+        { error: "bot_token is required and must start with xoxb-" },
+        400,
+      );
+    }
+    if (!signingSecret) {
+      return c.json({ error: "signing_secret is required" }, 400);
+    }
 
-  let authTest: SlackAuthTest;
-  try {
-    const res = await fetch('https://slack.com/api/auth.test', {
-      method: 'POST',
-      headers: {
-        authorization: `Bearer ${botToken}`,
-        'content-type': 'application/x-www-form-urlencoded',
-      },
+    let authTest: SlackAuthTest;
+    try {
+      const res = await fetch("https://slack.com/api/auth.test", {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${botToken}`,
+          "content-type": "application/x-www-form-urlencoded",
+        },
+      });
+      authTest = (await res.json()) as SlackAuthTest;
+    } catch (err) {
+      return c.json(
+        { error: `Failed to reach Slack: ${(err as Error).message}` },
+        502,
+      );
+    }
+    if (!authTest.ok || !authTest.team_id || !authTest.user_id) {
+      return c.json(
+        {
+          error: `Slack rejected the token: ${authTest.error ?? "unknown error"}`,
+        },
+        400,
+      );
+    }
+
+    const summary = await saveSlackInstall({
+      projectId,
+      botToken,
+      signingSecret,
+      teamId: authTest.team_id,
+      teamName: authTest.team ?? null,
+      botUserId: authTest.user_id,
     });
-    authTest = (await res.json()) as SlackAuthTest;
-  } catch (err) {
-    return c.json({ error: `Failed to reach Slack: ${(err as Error).message}` }, 502);
-  }
-  if (!authTest.ok || !authTest.team_id || !authTest.user_id) {
-    return c.json({ error: `Slack rejected the token: ${authTest.error ?? 'unknown error'}` }, 400);
-  }
-
-  const summary = await saveSlackInstall({
-    projectId,
-    botToken,
-    signingSecret,
-    teamId: authTest.team_id,
-    teamName: authTest.team ?? null,
-    botUserId: authTest.user_id,
-  });
-  await reconcileChannelConnectors(projectId);
-  return c.json(summary);
-},
+    await reconcileChannelConnectors(projectId);
+    return c.json(summary);
+  },
 );
 
 // DELETE /v1/projects/:projectId/channels/slack/installation
 
 projectsApp.openapi(
   createRoute({
-    method: 'delete',
-    path: '/{projectId}/channels/slack/installation',
-    tags: ['channels'],
-    summary: 'DELETE /:projectId/channels/slack/installation',
+    method: "delete",
+    path: "/{projectId}/channels/slack/installation",
+    tags: ["channels"],
+    summary: "DELETE /:projectId/channels/slack/installation",
     ...auth,
     request: {
       params: z.object({ projectId: z.string() }),
     },
     responses: {
-      200: json(z.any(), 'OK'),
+      200: json(z.any(), "OK"),
       ...errors(404),
     },
   }),
   async (c: any) => {
-    const projectId = c.req.param('projectId');
-    const loaded = await loadProjectForUser(c, projectId, 'manage');
-    if (!loaded) return c.json({ error: 'Not found' }, 404);
+    const projectId = c.req.param("projectId");
+    const loaded = await loadProjectForUser(c, projectId, "manage");
+    if (!loaded) return c.json({ error: "Not found" }, 404);
     await deleteSlackInstall(projectId);
     // Tear down the auto-materialized Slack connector now that the install is gone.
     await reconcileChannelConnectors(projectId);
-    return c.json({ status: 'disconnected' });
+    return c.json({ status: "disconnected" });
   },
 );
 
 // ─── Email install — AgentMail-backed inbox per project ─────────────────────
 
 function emailChannelEnabled(metadata: unknown): boolean {
-  return resolveExperimentalFeature(metadata, 'agentmail_email');
+  return resolveExperimentalFeature(metadata, "agentmail_email");
 }
 
 projectsApp.openapi(
   createRoute({
-    method: 'get',
-    path: '/{projectId}/channels/email/installation',
-    tags: ['channels'],
-    summary: 'GET /:projectId/channels/email/installation',
+    method: "get",
+    path: "/{projectId}/channels/email/installation",
+    tags: ["channels"],
+    summary: "GET /:projectId/channels/email/installation",
     ...auth,
     request: {
       params: z.object({ projectId: z.string() }),
     },
     responses: {
-      200: json(z.any(), 'OK'),
+      200: json(z.any(), "OK"),
       ...errors(404),
     },
   }),
   async (c: any) => {
-    const projectId = c.req.param('projectId');
-    const loaded = await loadProjectForUser(c, projectId, 'read');
-    if (!loaded) return c.json({ error: 'Not found' }, 404);
+    const projectId = c.req.param("projectId");
+    const loaded = await loadProjectForUser(c, projectId, "read");
+    if (!loaded) return c.json({ error: "Not found" }, 404);
     if (!emailChannelEnabled(loaded.row.metadata)) return c.json(null);
-    const connectorSlug = c.req.query('connector_slug') || c.req.query('profile_slug') || 'kortix_email';
+    const connectorSlug =
+      c.req.query("connector_slug") ||
+      c.req.query("profile_slug") ||
+      "kortix_email";
     const install = await loadAgentMailInstall(projectId, connectorSlug);
     return c.json(install ?? null);
   },
@@ -519,26 +650,26 @@ projectsApp.openapi(
 
 projectsApp.openapi(
   createRoute({
-    method: 'get',
-    path: '/{projectId}/channels/email/mode',
-    tags: ['channels'],
-    summary: 'GET /:projectId/channels/email/mode',
+    method: "get",
+    path: "/{projectId}/channels/email/mode",
+    tags: ["channels"],
+    summary: "GET /:projectId/channels/email/mode",
     ...auth,
     request: {
       params: z.object({ projectId: z.string() }),
     },
     responses: {
-      200: json(z.any(), 'OK'),
+      200: json(z.any(), "OK"),
       ...errors(404),
     },
   }),
   async (c: any) => {
-    const projectId = c.req.param('projectId');
-    const loaded = await loadProjectForUser(c, projectId, 'read');
-    if (!loaded) return c.json({ error: 'Not found' }, 404);
+    const projectId = c.req.param("projectId");
+    const loaded = await loadProjectForUser(c, projectId, "read");
+    if (!loaded) return c.json({ error: "Not found" }, 404);
     const enabled = emailChannelEnabled(loaded.row.metadata);
     return c.json({
-      provider: 'agentmail',
+      provider: "agentmail",
       enabled,
       managed_available: enabled && Boolean(config.AGENTMAIL_API_KEY),
     });
@@ -547,26 +678,32 @@ projectsApp.openapi(
 
 projectsApp.openapi(
   createRoute({
-    method: 'post',
-    path: '/{projectId}/channels/email/connect',
-    tags: ['channels'],
-    summary: 'POST /:projectId/channels/email/connect',
+    method: "post",
+    path: "/{projectId}/channels/email/connect",
+    tags: ["channels"],
+    summary: "POST /:projectId/channels/email/connect",
     ...auth,
     request: {
       params: z.object({ projectId: z.string() }),
-      body: { content: { 'application/json': { schema: AnyObject } } },
+      body: { content: { "application/json": { schema: AnyObject } } },
     },
     responses: {
-      200: json(z.any(), 'OK'),
-      ...errors(400, 404, 502, 503),
+      200: json(z.any(), "OK"),
+      ...errors(400, 403, 404, 502, 503),
     },
   }),
   async (c: any) => {
-    const projectId = c.req.param('projectId');
-    const loaded = await loadProjectForUser(c, projectId, 'manage');
-    if (!loaded) return c.json({ error: 'Not found' }, 404);
+    const projectId = c.req.param("projectId");
+    const loaded = await loadProjectForUser(c, projectId, "manage");
+    if (!loaded) return c.json({ error: "Not found" }, 404);
     if (!emailChannelEnabled(loaded.row.metadata)) {
-      return c.json({ error: 'AgentMail Email is experimental and must be enabled for this project' }, 403);
+      return c.json(
+        {
+          error:
+            "AgentMail Email is experimental and must be enabled for this project",
+        },
+        403,
+      );
     }
 
     let body: {
@@ -577,22 +714,41 @@ projectsApp.openapi(
       domain?: string;
       display_name?: string;
       displayName?: string;
+      sender_policy?: Partial<AgentMailSenderPolicy>;
     };
     try {
       body = (await c.req.json()) as typeof body;
     } catch {
-      return c.json({ error: 'Invalid JSON body' }, 400);
+      return c.json({ error: "Invalid JSON body" }, 400);
     }
 
     const apiKey = resolveAgentMailApiKey(body.api_key?.trim());
     if (!apiKey) {
-      return c.json({ error: 'AgentMail API key is not configured' }, 503);
+      return c.json({ error: "AgentMail API key is not configured" }, 503);
     }
 
-    const connectorSlug = (body.connector_slug ?? body.profile_slug ?? 'kortix_email').trim() || 'kortix_email';
-    const displayName = (body.display_name ?? body.displayName ?? loaded.row.name ?? 'Kortix Agent').trim();
-    const username = normalizeAgentMailUsername(body.username ?? loaded.row.name);
-    const domain = typeof body.domain === 'string' && body.domain.trim() ? body.domain.trim() : undefined;
+    const connectorSlug =
+      (body.connector_slug ?? body.profile_slug ?? "kortix_email").trim() ||
+      "kortix_email";
+    const displayName = (
+      body.display_name ??
+      body.displayName ??
+      loaded.row.name ??
+      "Kortix Agent"
+    ).trim();
+    const username = normalizeAgentMailUsername(
+      body.username ?? loaded.row.name,
+    );
+    const domain =
+      typeof body.domain === "string" && body.domain.trim()
+        ? body.domain.trim()
+        : undefined;
+    let senderPolicy: AgentMailSenderPolicy;
+    try {
+      senderPolicy = parseSenderPolicyBody(body.sender_policy);
+    } catch (err) {
+      return c.json({ error: (err as Error).message }, 400);
+    }
     const clientId = `kortix-project-${projectId}`;
 
     let inbox: Awaited<ReturnType<typeof createAgentMailInbox>>;
@@ -604,17 +760,20 @@ projectsApp.openapi(
         displayName,
         clientId,
         metadata: {
-          provider: 'kortix',
+          provider: "kortix",
           project_id: projectId,
           account_id: loaded.row.accountId,
         },
       });
     } catch (err) {
-      return c.json({ error: `AgentMail inbox create failed: ${(err as Error).message}` }, 502);
+      return c.json(
+        { error: `AgentMail inbox create failed: ${(err as Error).message}` },
+        502,
+      );
     }
 
-    let webhookId: string | null = null;
-    let webhookSecret: string | null = null;
+    let webhookId: string;
+    let webhookSecret: string;
     try {
       const webhook = await createAgentMailWebhook({
         apiKey,
@@ -625,10 +784,10 @@ projectsApp.openapi(
       webhookId = webhook.webhook_id;
       webhookSecret = webhook.secret;
     } catch (err) {
-      console.warn('[email-channel] AgentMail webhook create failed', {
-        projectId,
-        error: (err as Error).message,
-      });
+      return c.json(
+        { error: `AgentMail webhook create failed: ${(err as Error).message}` },
+        502,
+      );
     }
 
     const summary = await saveAgentMailInstall({
@@ -640,6 +799,7 @@ projectsApp.openapi(
       displayName: inbox.display_name ?? displayName,
       webhookId,
       webhookSecret,
+      senderPolicy,
     });
     await reconcileChannelConnectors(projectId);
     return c.json(summary);
@@ -648,38 +808,122 @@ projectsApp.openapi(
 
 projectsApp.openapi(
   createRoute({
-    method: 'delete',
-    path: '/{projectId}/channels/email/installation',
-    tags: ['channels'],
-    summary: 'DELETE /:projectId/channels/email/installation',
+    method: "patch",
+    path: "/{projectId}/channels/email/installation",
+    tags: ["channels"],
+    summary: "PATCH /:projectId/channels/email/installation",
+    ...auth,
+    request: {
+      params: z.object({ projectId: z.string() }),
+      body: { content: { "application/json": { schema: AnyObject } } },
+    },
+    responses: {
+      200: json(z.any(), "OK"),
+      ...errors(400, 403, 404),
+    },
+  }),
+  async (c: any) => {
+    const projectId = c.req.param("projectId");
+    const loaded = await loadProjectForUser(c, projectId, "manage");
+    if (!loaded) return c.json({ error: "Not found" }, 404);
+    if (!emailChannelEnabled(loaded.row.metadata)) {
+      return c.json(
+        {
+          error:
+            "AgentMail Email is experimental and must be enabled for this project",
+        },
+        403,
+      );
+    }
+    let body: {
+      connector_slug?: string;
+      profile_slug?: string;
+      sender_policy?: Partial<AgentMailSenderPolicy>;
+    };
+    try {
+      body = (await c.req.json()) as typeof body;
+    } catch {
+      return c.json({ error: "Invalid JSON body" }, 400);
+    }
+    const connectorSlug =
+      (body.connector_slug ?? body.profile_slug ?? "kortix_email").trim() ||
+      "kortix_email";
+    let senderPolicy: AgentMailSenderPolicy;
+    try {
+      senderPolicy = parseSenderPolicyBody(body.sender_policy);
+    } catch (err) {
+      return c.json({ error: (err as Error).message }, 400);
+    }
+    const summary = await updateAgentMailSenderPolicy(
+      projectId,
+      connectorSlug,
+      senderPolicy,
+    );
+    if (!summary)
+      return c.json({ error: "Email channel profile not found" }, 404);
+    return c.json(summary);
+  },
+);
+
+projectsApp.openapi(
+  createRoute({
+    method: "delete",
+    path: "/{projectId}/channels/email/installation",
+    tags: ["channels"],
+    summary: "DELETE /:projectId/channels/email/installation",
     ...auth,
     request: {
       params: z.object({ projectId: z.string() }),
     },
     responses: {
-      200: json(z.any(), 'OK'),
+      200: json(z.any(), "OK"),
       ...errors(404),
     },
   }),
   async (c: any) => {
-    const projectId = c.req.param('projectId');
-    const loaded = await loadProjectForUser(c, projectId, 'manage');
-    if (!loaded) return c.json({ error: 'Not found' }, 404);
-    const connectorSlug = c.req.query('connector_slug') || c.req.query('profile_slug') || 'kortix_email';
+    const projectId = c.req.param("projectId");
+    const loaded = await loadProjectForUser(c, projectId, "manage");
+    if (!loaded) return c.json({ error: "Not found" }, 404);
+    const connectorSlug =
+      c.req.query("connector_slug") ||
+      c.req.query("profile_slug") ||
+      "kortix_email";
     await deleteAgentMailInstall(projectId, connectorSlug);
-    await reconcileChannelConnectors(projectId, { platform: 'email', slug: connectorSlug });
-    return c.json({ status: 'disconnected' });
+    await reconcileChannelConnectors(projectId, {
+      platform: "email",
+      slug: connectorSlug,
+    });
+    return c.json({ status: "disconnected" });
   },
 );
 
 function agentMailWebhookBaseUrl(requestUrl: string): string {
-  return (config.KORTIX_URL || new URL(requestUrl).origin).replace(/\/+$/, '');
+  return (config.KORTIX_URL || new URL(requestUrl).origin).replace(/\/+$/, "");
 }
 
-function normalizeAgentMailUsername(input: string | null | undefined): string | null {
-  const raw = (input ?? '').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
-  const trimmed = raw.slice(0, 48).replace(/-+$/g, '');
+function normalizeAgentMailUsername(
+  input: string | null | undefined,
+): string | null {
+  const raw = (input ?? "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  const trimmed = raw.slice(0, 48).replace(/-+$/g, "");
   return trimmed || null;
+}
+
+function parseSenderPolicyBody(
+  input: Partial<AgentMailSenderPolicy> | undefined,
+): AgentMailSenderPolicy {
+  const policy = normalizeSenderPolicy(input);
+  if (policy.allowedRegex) {
+    try {
+      new RegExp(policy.allowedRegex);
+    } catch {
+      throw new Error("Email sender regex is invalid");
+    }
+  }
+  return policy;
 }
 
 // POST /v1/projects/:projectId/turn-stream
@@ -688,138 +932,178 @@ function normalizeAgentMailUsername(input: string | null | undefined): string | 
 
 projectsApp.openapi(
   createRoute({
-    method: 'post',
-    path: '/{projectId}/turn-stream',
-    tags: ['projects'],
-    summary: 'POST /:projectId/turn-stream',
+    method: "post",
+    path: "/{projectId}/turn-stream",
+    tags: ["projects"],
+    summary: "POST /:projectId/turn-stream",
     ...auth,
-      request: {
-        params: z.object({ projectId: z.string() }),
-        body: { content: { 'application/json': { schema: AnyObject } } },
-      },
+    request: {
+      params: z.object({ projectId: z.string() }),
+      body: { content: { "application/json": { schema: AnyObject } } },
+    },
     responses: {
-        200: { description: 'Event stream', content: { 'text/event-stream': { schema: z.any() } } },
-        ...errors(400, 403, 404),
+      200: {
+        description: "Event stream",
+        content: { "text/event-stream": { schema: z.any() } },
+      },
+      ...errors(400, 403, 404),
     },
   }),
   async (c: any) => {
-  const projectId = c.req.param('projectId');
+    const projectId = c.req.param("projectId");
 
-  // Two valid callers: a project-scoped PAT (dashboard or operator) and the
-  // session sandbox's own KORTIX_TOKEN (so the in-sandbox agent CLI can relay
-  // its plan steps without a second token). Each is scoped to one projectId.
-  const authType = (c as any).get('authType') as string | undefined;
-  if (authType === 'apiKey' && (c as any).get('apiKeyType') === 'sandbox') {
-    const accountId = (c as any).get('accountId') as string | undefined;
-    const sandboxId = (c as any).get('sandboxId') as string | undefined;
-    if (!accountId || !sandboxId) {
-      return c.json({ error: 'turn-stream requires a sandbox token' }, 403);
+    // Two valid callers: a project-scoped PAT (dashboard or operator) and the
+    // session sandbox's own KORTIX_TOKEN (so the in-sandbox agent CLI can relay
+    // its plan steps without a second token). Each is scoped to one projectId.
+    const authType = (c as any).get("authType") as string | undefined;
+    if (authType === "apiKey" && (c as any).get("apiKeyType") === "sandbox") {
+      const accountId = (c as any).get("accountId") as string | undefined;
+      const sandboxId = (c as any).get("sandboxId") as string | undefined;
+      if (!accountId || !sandboxId) {
+        return c.json({ error: "turn-stream requires a sandbox token" }, 403);
+      }
+      const [sandbox] = await db
+        .select({ sandboxId: sessionSandboxes.sandboxId })
+        .from(sessionSandboxes)
+        .where(
+          and(
+            eq(sessionSandboxes.sandboxId, sandboxId),
+            eq(sessionSandboxes.projectId, projectId),
+            eq(sessionSandboxes.accountId, accountId),
+            inArray(sessionSandboxes.status, ["provisioning", "active"]),
+          ),
+        )
+        .limit(1);
+      if (!sandbox) {
+        return c.json(
+          { error: "sandbox token is not scoped to this project" },
+          403,
+        );
+      }
+    } else {
+      const loaded = await loadProjectForUser(c, projectId, "read");
+      if (!loaded) return c.json({ error: "Not found" }, 404);
     }
-    const [sandbox] = await db
-      .select({ sandboxId: sessionSandboxes.sandboxId })
-      .from(sessionSandboxes)
-      .where(and(
-        eq(sessionSandboxes.sandboxId, sandboxId),
-        eq(sessionSandboxes.projectId, projectId),
-        eq(sessionSandboxes.accountId, accountId),
-        inArray(sessionSandboxes.status, ['provisioning', 'active']),
-      ))
-      .limit(1);
-    if (!sandbox) {
-      return c.json({ error: 'sandbox token is not scoped to this project' }, 403);
+
+    let body: {
+      session_id?: string;
+      kind?: string;
+      text?: string;
+      detail?: string;
+      output?: string;
+      sources?: Array<{ url?: string; text?: string }>;
+      blocks?: unknown[];
+      status?: string;
+      opencode_session_id?: string;
+      // Turn-end error detail (opencode AssistantMessage.error / session.error),
+      // so Slack can render "out of credits" / rate-limit / the real error.
+      error_name?: string;
+      error_message?: string;
+      error_status?: number;
+      error_retryable?: boolean;
+      error_provider?: string;
+    };
+    try {
+      body = (await c.req.json()) as typeof body;
+    } catch {
+      return c.json({ error: "Invalid JSON body" }, 400);
     }
-  } else {
-    const loaded = await loadProjectForUser(c, projectId, 'read');
-    if (!loaded) return c.json({ error: 'Not found' }, 404);
-  }
+    const sessionId = body.session_id?.trim();
+    if (!sessionId) {
+      return c.json({ error: "session_id is required" }, 400);
+    }
 
-  let body: {
-    session_id?: string;
-    kind?: string;
-    text?: string;
-    detail?: string;
-    output?: string;
-    sources?: Array<{ url?: string; text?: string }>;
-    blocks?: unknown[];
-    status?: string;
-    opencode_session_id?: string;
-    // Turn-end error detail (opencode AssistantMessage.error / session.error),
-    // so Slack can render "out of credits" / rate-limit / the real error.
-    error_name?: string;
-    error_message?: string;
-    error_status?: number;
-    error_retryable?: boolean;
-    error_provider?: string;
-  };
-  try {
-    body = (await c.req.json()) as typeof body;
-  } catch {
-    return c.json({ error: 'Invalid JSON body' }, 400);
-  }
-  const sessionId = body.session_id?.trim();
-  if (!sessionId) {
-    return c.json({ error: 'session_id is required' }, 400);
-  }
+    // `end` / `turn_end` carry no text — the sandbox observed the opencode turn
+    // finish (idle) or die (error) without the agent closing its Slack message;
+    // finalize it gracefully instead of letting it rot into a timeout failure.
+    // (`turn_end` is the alias newer sandboxes send, with status + the opencode
+    // session id for the server-side root-session guard.)
+    if (body.kind === "end" || body.kind === "turn_end") {
+      const status = body.status === "error" ? "error" : "idle";
+      const errorInfo =
+        body.error_name ||
+        body.error_message ||
+        typeof body.error_status === "number"
+          ? {
+              name:
+                typeof body.error_name === "string"
+                  ? body.error_name
+                  : undefined,
+              message:
+                typeof body.error_message === "string"
+                  ? body.error_message
+                  : undefined,
+              statusCode:
+                typeof body.error_status === "number"
+                  ? body.error_status
+                  : undefined,
+              isRetryable:
+                typeof body.error_retryable === "boolean"
+                  ? body.error_retryable
+                  : undefined,
+              providerID:
+                typeof body.error_provider === "string"
+                  ? body.error_provider
+                  : undefined,
+            }
+          : undefined;
+      const ok = await relayTurnEnd(sessionId, status, errorInfo);
+      return c.json({ ok });
+    }
 
-  // `end` / `turn_end` carry no text — the sandbox observed the opencode turn
-  // finish (idle) or die (error) without the agent closing its Slack message;
-  // finalize it gracefully instead of letting it rot into a timeout failure.
-  // (`turn_end` is the alias newer sandboxes send, with status + the opencode
-  // session id for the server-side root-session guard.)
-  if (body.kind === 'end' || body.kind === 'turn_end') {
-    const status = body.status === 'error' ? 'error' : 'idle';
-    const errorInfo =
-      body.error_name || body.error_message || typeof body.error_status === 'number'
-        ? {
-            name: typeof body.error_name === 'string' ? body.error_name : undefined,
-            message: typeof body.error_message === 'string' ? body.error_message : undefined,
-            statusCode: typeof body.error_status === 'number' ? body.error_status : undefined,
-            isRetryable: typeof body.error_retryable === 'boolean' ? body.error_retryable : undefined,
-            providerID: typeof body.error_provider === 'string' ? body.error_provider : undefined,
-          }
+    // `opencode_session` carries the canonical opencode ROOT id the sandbox just
+    // bootstrapped (or reused after a restart). Persist it as the durable pin so
+    // the Kortix session resolves to the LIVE root with NO dependency on a browser
+    // ever opening it — closing the null-pin gap that left Slack/trigger/cron
+    // sessions resolving lazily onto the wrong (orphaned) root. The sandbox token
+    // is already scoped to this project (checked above); the daemon only ever
+    // reports its own pin-file root, never a subagent.
+    if (body.kind === "opencode_session") {
+      const ocId = body.opencode_session_id?.trim();
+      if (!ocId)
+        return c.json({ error: "opencode_session_id is required" }, 400);
+      const updated = await db
+        .update(projectSessions)
+        .set({ opencodeSessionId: ocId, updatedAt: new Date() })
+        .where(
+          and(
+            eq(projectSessions.sessionId, sessionId),
+            eq(projectSessions.projectId, projectId),
+          ),
+        )
+        .returning({ sessionId: projectSessions.sessionId });
+      return c.json({ ok: updated.length > 0 });
+    }
+
+    const text = (body.text ?? "").trim();
+    if (!text) {
+      return c.json({ error: "text is required" }, 400);
+    }
+
+    const detail = body.detail?.trim() || undefined;
+    const outputForPrev = body.output?.trim() || undefined;
+    const sourcesForPrev = Array.isArray(body.sources)
+      ? body.sources
+          .filter(
+            (s): s is { url: string; text: string } => !!s?.url && !!s?.text,
+          )
+          .map((s) => ({ url: s.url, text: s.text }))
+      : undefined;
+    const blocks =
+      Array.isArray(body.blocks) && body.blocks.length > 0
+        ? body.blocks
         : undefined;
-    const ok = await relayTurnEnd(sessionId, status, errorInfo);
+
+    const ok =
+      body.kind === "answer"
+        ? await relayTurnAnswer(sessionId, text, blocks)
+        : await relayTurnStep(sessionId, text, {
+            detail,
+            outputForPrev,
+            sourcesForPrev,
+          });
     return c.json({ ok });
-  }
-
-  // `opencode_session` carries the canonical opencode ROOT id the sandbox just
-  // bootstrapped (or reused after a restart). Persist it as the durable pin so
-  // the Kortix session resolves to the LIVE root with NO dependency on a browser
-  // ever opening it — closing the null-pin gap that left Slack/trigger/cron
-  // sessions resolving lazily onto the wrong (orphaned) root. The sandbox token
-  // is already scoped to this project (checked above); the daemon only ever
-  // reports its own pin-file root, never a subagent.
-  if (body.kind === 'opencode_session') {
-    const ocId = body.opencode_session_id?.trim();
-    if (!ocId) return c.json({ error: 'opencode_session_id is required' }, 400);
-    const updated = await db
-      .update(projectSessions)
-      .set({ opencodeSessionId: ocId, updatedAt: new Date() })
-      .where(and(eq(projectSessions.sessionId, sessionId), eq(projectSessions.projectId, projectId)))
-      .returning({ sessionId: projectSessions.sessionId });
-    return c.json({ ok: updated.length > 0 });
-  }
-
-  const text = (body.text ?? '').trim();
-  if (!text) {
-    return c.json({ error: 'text is required' }, 400);
-  }
-
-  const detail = body.detail?.trim() || undefined;
-  const outputForPrev = body.output?.trim() || undefined;
-  const sourcesForPrev = Array.isArray(body.sources)
-    ? body.sources
-        .filter((s): s is { url: string; text: string } => !!s?.url && !!s?.text)
-        .map((s) => ({ url: s.url, text: s.text }))
-    : undefined;
-  const blocks = Array.isArray(body.blocks) && body.blocks.length > 0 ? body.blocks : undefined;
-
-  const ok =
-    body.kind === 'answer'
-      ? await relayTurnAnswer(sessionId, text, blocks)
-      : await relayTurnStep(sessionId, text, { detail, outputForPrev, sourcesForPrev });
-  return c.json({ ok });
-},
+  },
 );
 
 // GET /v1/projects/:projectId/channels/slack/file?url=...
@@ -828,27 +1112,31 @@ projectsApp.openapi(
 // `slack download` once the token is out of the box (KORTIX-206 Phase C2).
 projectsApp.openapi(
   createRoute({
-    method: 'get',
-    path: '/{projectId}/channels/slack/file',
-    tags: ['channels'],
-    summary: 'GET /:projectId/channels/slack/file (download proxy)',
+    method: "get",
+    path: "/{projectId}/channels/slack/file",
+    tags: ["channels"],
+    summary: "GET /:projectId/channels/slack/file (download proxy)",
     ...auth,
     request: {
       params: z.object({ projectId: z.string() }),
       query: z.object({ url: z.string() }),
     },
     responses: {
-      200: { description: 'File bytes', content: { 'application/octet-stream': { schema: z.any() } } },
+      200: {
+        description: "File bytes",
+        content: { "application/octet-stream": { schema: z.any() } },
+      },
       ...errors(400, 404),
     },
   }),
   async (c: any) => {
-    const projectId = c.req.param('projectId');
-    const loaded = await loadProjectForUser(c, projectId, 'read');
-    if (!loaded) return c.json({ error: 'Not found' }, 404);
-    const result = await downloadSlackFile(projectId, c.req.query('url') ?? '');
-    if (!result.ok) return c.json({ error: result.error }, result.status as 400 | 404);
-    c.header('Content-Type', result.contentType);
+    const projectId = c.req.param("projectId");
+    const loaded = await loadProjectForUser(c, projectId, "read");
+    if (!loaded) return c.json({ error: "Not found" }, 404);
+    const result = await downloadSlackFile(projectId, c.req.query("url") ?? "");
+    if (!result.ok)
+      return c.json({ error: result.error }, result.status as 400 | 404);
+    c.header("Content-Type", result.contentType);
     return c.body(result.body);
   },
 );
@@ -858,33 +1146,42 @@ projectsApp.openapi(
 // Backs `slack send --file` once the token is out of the box.
 projectsApp.openapi(
   createRoute({
-    method: 'post',
-    path: '/{projectId}/channels/slack/file/upload',
-    tags: ['channels'],
-    summary: 'POST /:projectId/channels/slack/file/upload (upload proxy)',
+    method: "post",
+    path: "/{projectId}/channels/slack/file/upload",
+    tags: ["channels"],
+    summary: "POST /:projectId/channels/slack/file/upload (upload proxy)",
     ...auth,
     request: {
       params: z.object({ projectId: z.string() }),
-      body: { content: { 'application/json': { schema: AnyObject } } },
+      body: { content: { "application/json": { schema: AnyObject } } },
     },
     responses: {
-      200: json(z.object({ ok: z.boolean(), files: z.any() }).passthrough(), 'Uploaded'),
+      200: json(
+        z.object({ ok: z.boolean(), files: z.any() }).passthrough(),
+        "Uploaded",
+      ),
       ...errors(400, 404),
     },
   }),
   async (c: any) => {
-    const projectId = c.req.param('projectId');
-    const loaded = await loadProjectForUser(c, projectId, 'read');
-    if (!loaded) return c.json({ error: 'Not found' }, 404);
+    const projectId = c.req.param("projectId");
+    const loaded = await loadProjectForUser(c, projectId, "read");
+    if (!loaded) return c.json({ error: "Not found" }, 404);
     const body = await readBody(c);
     const result = await uploadSlackFile(projectId, {
-      channel: String(body.channel ?? ''),
-      filename: String(body.filename ?? ''),
-      contentBase64: String(body.content_base64 ?? body.contentBase64 ?? ''),
-      comment: typeof body.comment === 'string' ? body.comment : undefined,
-      threadTs: typeof body.thread_ts === 'string' ? body.thread_ts : (typeof body.threadTs === 'string' ? body.threadTs : undefined),
+      channel: String(body.channel ?? ""),
+      filename: String(body.filename ?? ""),
+      contentBase64: String(body.content_base64 ?? body.contentBase64 ?? ""),
+      comment: typeof body.comment === "string" ? body.comment : undefined,
+      threadTs:
+        typeof body.thread_ts === "string"
+          ? body.thread_ts
+          : typeof body.threadTs === "string"
+            ? body.threadTs
+            : undefined,
     });
-    if (!result.ok) return c.json({ error: result.error }, result.status as 400 | 404);
+    if (!result.ok)
+      return c.json({ error: result.error }, result.status as 400 | 404);
     return c.json({ ok: true, files: result.files });
   },
 );
@@ -898,44 +1195,54 @@ projectsApp.openapi(
 // non-secret model list, so a sandbox token is sufficient.
 projectsApp.openapi(
   createRoute({
-    method: 'get',
-    path: '/{projectId}/llm-catalog',
-    tags: ['projects'],
-    summary: 'GET /:projectId/llm-catalog',
+    method: "get",
+    path: "/{projectId}/llm-catalog",
+    tags: ["projects"],
+    summary: "GET /:projectId/llm-catalog",
     ...auth,
-      request: {
-        params: z.object({ projectId: z.string() }),
-      },
+    request: {
+      params: z.object({ projectId: z.string() }),
+    },
     responses: {
-        200: { description: 'OK', content: { 'application/json': { schema: z.any() } } },
-        ...errors(403, 404),
+      200: {
+        description: "OK",
+        content: { "application/json": { schema: z.any() } },
+      },
+      ...errors(403, 404),
     },
   }),
   async (c: any) => {
-  const projectId = c.req.param('projectId');
-  if (!(c.get('authType') === 'apiKey' && c.get('apiKeyType') === 'sandbox')) {
-    return c.json({ error: 'llm-catalog requires a sandbox token' }, 403);
-  }
-  const accountId = c.get('accountId') as string | undefined;
-  const sandboxId = c.get('sandboxId') as string | undefined;
-  if (!accountId || !sandboxId) {
-    return c.json({ error: 'llm-catalog requires a sandbox token' }, 403);
-  }
-  const [sandbox] = await db
-    .select({ sandboxId: sessionSandboxes.sandboxId })
-    .from(sessionSandboxes)
-    .where(and(
-      eq(sessionSandboxes.sandboxId, sandboxId),
-      eq(sessionSandboxes.projectId, projectId),
-      eq(sessionSandboxes.accountId, accountId),
-      inArray(sessionSandboxes.status, ['provisioning', 'active']),
-    ))
-    .limit(1);
-  if (!sandbox) {
-    return c.json({ error: 'sandbox token is not scoped to this project' }, 403);
-  }
-  const models = gatewayModelCatalog(projectId);
-  return c.json({ models });
+    const projectId = c.req.param("projectId");
+    if (
+      !(c.get("authType") === "apiKey" && c.get("apiKeyType") === "sandbox")
+    ) {
+      return c.json({ error: "llm-catalog requires a sandbox token" }, 403);
+    }
+    const accountId = c.get("accountId") as string | undefined;
+    const sandboxId = c.get("sandboxId") as string | undefined;
+    if (!accountId || !sandboxId) {
+      return c.json({ error: "llm-catalog requires a sandbox token" }, 403);
+    }
+    const [sandbox] = await db
+      .select({ sandboxId: sessionSandboxes.sandboxId })
+      .from(sessionSandboxes)
+      .where(
+        and(
+          eq(sessionSandboxes.sandboxId, sandboxId),
+          eq(sessionSandboxes.projectId, projectId),
+          eq(sessionSandboxes.accountId, accountId),
+          inArray(sessionSandboxes.status, ["provisioning", "active"]),
+        ),
+      )
+      .limit(1);
+    if (!sandbox) {
+      return c.json(
+        { error: "sandbox token is not scoped to this project" },
+        403,
+      );
+    }
+    const models = gatewayModelCatalog(projectId);
+    return c.json({ models });
   },
 );
 
@@ -949,105 +1256,118 @@ projectsApp.openapi(
 
 projectsApp.openapi(
   createRoute({
-    method: 'post',
-    path: '/{projectId}/turn-question',
-    tags: ['projects'],
-    summary: 'POST /:projectId/turn-question',
+    method: "post",
+    path: "/{projectId}/turn-question",
+    tags: ["projects"],
+    summary: "POST /:projectId/turn-question",
     ...auth,
-      request: {
-        params: z.object({ projectId: z.string() }),
-        body: { content: { 'application/json': { schema: AnyObject } } },
-      },
+    request: {
+      params: z.object({ projectId: z.string() }),
+      body: { content: { "application/json": { schema: AnyObject } } },
+    },
     responses: {
-        200: json(z.any(), 'OK'),
-        ...errors(400, 403, 404, 409),
+      200: json(z.any(), "OK"),
+      ...errors(400, 403, 404, 409),
     },
   }),
   async (c: any) => {
-  const projectId = c.req.param('projectId');
+    const projectId = c.req.param("projectId");
 
-  const authType = (c as any).get('authType') as string | undefined;
-  if (authType === 'apiKey' && (c as any).get('apiKeyType') === 'sandbox') {
-    const accountId = (c as any).get('accountId') as string | undefined;
-    const sandboxId = (c as any).get('sandboxId') as string | undefined;
-    if (!accountId || !sandboxId) {
-      return c.json({ error: 'turn-question requires a sandbox token' }, 403);
+    const authType = (c as any).get("authType") as string | undefined;
+    if (authType === "apiKey" && (c as any).get("apiKeyType") === "sandbox") {
+      const accountId = (c as any).get("accountId") as string | undefined;
+      const sandboxId = (c as any).get("sandboxId") as string | undefined;
+      if (!accountId || !sandboxId) {
+        return c.json({ error: "turn-question requires a sandbox token" }, 403);
+      }
+      const [sandbox] = await db
+        .select({ sandboxId: sessionSandboxes.sandboxId })
+        .from(sessionSandboxes)
+        .where(
+          and(
+            eq(sessionSandboxes.sandboxId, sandboxId),
+            eq(sessionSandboxes.projectId, projectId),
+            eq(sessionSandboxes.accountId, accountId),
+            inArray(sessionSandboxes.status, ["provisioning", "active"]),
+          ),
+        )
+        .limit(1);
+      if (!sandbox) {
+        return c.json(
+          { error: "sandbox token is not scoped to this project" },
+          403,
+        );
+      }
+    } else {
+      const loaded = await loadProjectForUser(c, projectId, "read");
+      if (!loaded) return c.json({ error: "Not found" }, 404);
     }
-    const [sandbox] = await db
-      .select({ sandboxId: sessionSandboxes.sandboxId })
-      .from(sessionSandboxes)
-      .where(and(
-        eq(sessionSandboxes.sandboxId, sandboxId),
-        eq(sessionSandboxes.projectId, projectId),
-        eq(sessionSandboxes.accountId, accountId),
-        inArray(sessionSandboxes.status, ['provisioning', 'active']),
-      ))
-      .limit(1);
-    if (!sandbox) {
-      return c.json({ error: 'sandbox token is not scoped to this project' }, 403);
+
+    let body: {
+      session_id?: string;
+      request_id?: string;
+      questions?: unknown[];
+    };
+    try {
+      body = (await c.req.json()) as typeof body;
+    } catch {
+      return c.json({ error: "Invalid JSON body" }, 400);
     }
-  } else {
-    const loaded = await loadProjectForUser(c, projectId, 'read');
-    if (!loaded) return c.json({ error: 'Not found' }, 404);
-  }
+    const sessionId = body.session_id?.trim();
+    if (!sessionId) {
+      return c.json({ error: "session_id is required" }, 400);
+    }
+    if (!Array.isArray(body.questions) || body.questions.length === 0) {
+      return c.json({ error: "at least one question is required" }, 400);
+    }
 
-  let body: {
-    session_id?: string;
-    request_id?: string;
-    questions?: unknown[];
-  };
-  try {
-    body = (await c.req.json()) as typeof body;
-  } catch {
-    return c.json({ error: 'Invalid JSON body' }, 400);
-  }
-  const sessionId = body.session_id?.trim();
-  if (!sessionId) {
-    return c.json({ error: 'session_id is required' }, 400);
-  }
-  if (!Array.isArray(body.questions) || body.questions.length === 0) {
-    return c.json({ error: 'at least one question is required' }, 400);
-  }
+    // Validate + coerce to QuestionInfo[]. Tolerate the v2 SDK schema variants.
+    const questions: QuestionInfo[] = [];
+    for (const q of body.questions) {
+      if (!q || typeof q !== "object") continue;
+      const obj = q as Record<string, unknown>;
+      const question = String(obj.question ?? "").trim();
+      if (!question) continue;
+      const optionsRaw = Array.isArray(obj.options) ? obj.options : [];
+      const options = optionsRaw
+        .map((o) =>
+          o && typeof o === "object" ? (o as Record<string, unknown>) : null,
+        )
+        // opencode's QuestionInfo carries `value` (required) + optional `label`. The
+        // harness `question` tool uses `label`. Accept EITHER so an option that only
+        // has `value` still renders a button instead of silently vanishing.
+        .filter(
+          (o): o is Record<string, unknown> =>
+            !!o && (typeof o.label === "string" || typeof o.value === "string"),
+        )
+        .map((o) => ({
+          label: String(o.label ?? o.value),
+          description:
+            typeof o.description === "string"
+              ? String(o.description)
+              : undefined,
+        }));
+      questions.push({
+        question,
+        header: obj.header ? String(obj.header) : undefined,
+        options,
+        multiple: !!obj.multiple,
+        custom: obj.custom === false ? false : true,
+      });
+    }
+    if (questions.length === 0) {
+      return c.json({ error: "no valid questions provided" }, 400);
+    }
 
-  // Validate + coerce to QuestionInfo[]. Tolerate the v2 SDK schema variants.
-  const questions: QuestionInfo[] = [];
-  for (const q of body.questions) {
-    if (!q || typeof q !== 'object') continue;
-    const obj = q as Record<string, unknown>;
-    const question = String(obj.question ?? '').trim();
-    if (!question) continue;
-    const optionsRaw = Array.isArray(obj.options) ? obj.options : [];
-    const options = optionsRaw
-      .map((o) => (o && typeof o === 'object' ? (o as Record<string, unknown>) : null))
-      // opencode's QuestionInfo carries `value` (required) + optional `label`. The
-      // harness `question` tool uses `label`. Accept EITHER so an option that only
-      // has `value` still renders a button instead of silently vanishing.
-      .filter((o): o is Record<string, unknown> => !!o && (typeof o.label === 'string' || typeof o.value === 'string'))
-      .map((o) => ({
-        label: String(o.label ?? o.value),
-        description: typeof o.description === 'string' ? String(o.description) : undefined,
-      }));
-    questions.push({
-      question,
-      header: obj.header ? String(obj.header) : undefined,
-      options,
-      multiple: !!obj.multiple,
-      custom: obj.custom === false ? false : true,
-    });
-  }
-  if (questions.length === 0) {
-    return c.json({ error: 'no valid questions provided' }, 400);
-  }
-
-  // Non-blocking: post the question(s) into the thread and return immediately
-  // with sentinel `answers`. The agent does NOT wait for an inline answer — the
-  // user's in-thread reply arrives as a follow-up turn. Returning `answers` keeps
-  // BOTH the new sandbox (ignores them, uses its own sentinel) and an old sandbox
-  // image (resumes opencode from them) unblocked.
-  const result = await postQuestion(sessionId, questions);
-  if (!result.ok) return c.json({ ok: false, error: result.error }, 409);
-  return c.json({ ok: true, answers: result.answers });
-},
+    // Non-blocking: post the question(s) into the thread and return immediately
+    // with sentinel `answers`. The agent does NOT wait for an inline answer — the
+    // user's in-thread reply arrives as a follow-up turn. Returning `answers` keeps
+    // BOTH the new sandbox (ignores them, uses its own sentinel) and an old sandbox
+    // image (resumes opencode from them) unblocked.
+    const result = await postQuestion(sessionId, questions);
+    if (!result.ok) return c.json({ ok: false, error: result.error }, 409);
+    return c.json({ ok: true, answers: result.answers });
+  },
 );
 
 // POST /v1/projects/:projectId/triggers/:slug/fire
@@ -1057,69 +1377,77 @@ projectsApp.openapi(
 
 projectsApp.openapi(
   createRoute({
-    method: 'post',
-    path: '/{projectId}/triggers/{slug}/fire',
-    tags: ['triggers'],
-    summary: 'POST /:projectId/triggers/:slug/fire',
+    method: "post",
+    path: "/{projectId}/triggers/{slug}/fire",
+    tags: ["triggers"],
+    summary: "POST /:projectId/triggers/:slug/fire",
     ...auth,
-      request: {
-        params: z.object({ projectId: z.string(), slug: z.string() }),
-      },
+    request: {
+      params: z.object({ projectId: z.string(), slug: z.string() }),
+    },
     responses: {
-        202: json(z.any(), 'OK'),
-        ...errors(404, 500),
+      202: json(z.any(), "OK"),
+      ...errors(404, 500),
     },
   }),
   async (c: any) => {
-  const projectId = c.req.param('projectId');
-  const slug = c.req.param('slug');
-  const loaded = await loadProjectForUser(c, projectId, 'manage');
-  if (!loaded) return c.json({ error: 'Not found' }, 404);
+    const projectId = c.req.param("projectId");
+    const slug = c.req.param("slug");
+    const loaded = await loadProjectForUser(c, projectId, "manage");
+    if (!loaded) return c.json({ error: "Not found" }, 404);
 
-  const { specs } = await loadProjectTriggers(await withProjectGitAuth(loaded.row));
-  const spec = specs.find((s) => s.slug === slug);
-  if (!spec) return c.json({ error: 'Not found' }, 404);
+    const { specs } = await loadProjectTriggers(
+      await withProjectGitAuth(loaded.row),
+    );
+    const spec = specs.find((s) => s.slug === slug);
+    if (!spec) return c.json({ error: "Not found" }, 404);
 
-  const now = new Date();
-  const payload = {
-    trigger: { slug: spec.slug, type: spec.type, kind: 'git' },
-    fired_at: now.toISOString(),
-    source: 'manual',
-    actor: loaded.userId,
-    message: { text: '', source: 'manual_test' },
-  };
-  const renderedPrompt = renderPromptTemplate(spec.promptTemplate, payload);
+    const now = new Date();
+    const payload = {
+      trigger: { slug: spec.slug, type: spec.type, kind: "git" },
+      fired_at: now.toISOString(),
+      source: "manual",
+      actor: loaded.userId,
+      message: { text: "", source: "manual_test" },
+    };
+    const renderedPrompt = renderPromptTemplate(spec.promptTemplate, payload);
 
-  const result = await fireGitTrigger({
-    spec,
-    project: loaded.row,
-    payload,
-    renderedPrompt,
-    source: 'manual',
-    request: requestAuditContext(c),
-  });
+    const result = await fireGitTrigger({
+      spec,
+      project: loaded.row,
+      payload,
+      renderedPrompt,
+      source: "manual",
+      request: requestAuditContext(c),
+    });
 
-  if (result.status === 'queued') {
+    if (result.status === "queued") {
+      await markGitTriggerFired(projectId, slug, now);
+      return c.json(
+        {
+          status: "queued",
+          command_id: result.commandId ?? null,
+          session_id: result.sessionId ?? null,
+          reason: result.reason ?? null,
+          deduped: result.deduped ?? false,
+        },
+        202,
+      );
+    }
+    if (result.status === "failed") {
+      return c.json({ error: result.error ?? "Failed to fire trigger" }, 500);
+    }
     await markGitTriggerFired(projectId, slug, now);
-    return c.json({
-      status: 'queued',
-      command_id: result.commandId ?? null,
-      session_id: result.sessionId ?? null,
-      reason: result.reason ?? null,
-      deduped: result.deduped ?? false,
-    }, 202);
-  }
-  if (result.status === 'failed') {
-    return c.json({ error: result.error ?? 'Failed to fire trigger' }, 500);
-  }
-  await markGitTriggerFired(projectId, slug, now);
-  return c.json({
-    status: result.deduped ? 'deduped' : 'fired',
-    command_id: result.commandId ?? null,
-    session_id: result.sessionId ?? null,
-    deduped: result.deduped ?? false,
-  }, 202);
-},
+    return c.json(
+      {
+        status: result.deduped ? "deduped" : "fired",
+        command_id: result.commandId ?? null,
+        session_id: result.sessionId ?? null,
+        deduped: result.deduped ?? false,
+      },
+      202,
+    );
+  },
 );
 
 // ── [[apps]] CRUD + deploy ──────────────────────────────────────────────────
@@ -1136,144 +1464,159 @@ projectsApp.openapi(
 // it. This middleware loads the project's gate and short-circuits before any
 // of the handlers below run.
 
-
-projectsApp.use('/:projectId/apps/*', async (c, next) => {
-  if (!(await projectAppsEnabled(c.req.param('projectId')))) {
+projectsApp.use("/:projectId/apps/*", async (c, next) => {
+  if (!(await projectAppsEnabled(c.req.param("projectId")))) {
     return c.json(APPS_DISABLED_BODY, 404);
   }
   await next();
 });
 
-projectsApp.use('/:projectId/apps', async (c, next) => {
-  if (!(await projectAppsEnabled(c.req.param('projectId')))) {
+projectsApp.use("/:projectId/apps", async (c, next) => {
+  if (!(await projectAppsEnabled(c.req.param("projectId")))) {
     return c.json(APPS_DISABLED_BODY, 404);
   }
   await next();
 });
-
 
 projectsApp.openapi(
   createRoute({
-    method: 'get',
-    path: '/{projectId}/apps',
-    tags: ['apps'],
-    summary: 'GET /:projectId/apps',
+    method: "get",
+    path: "/{projectId}/apps",
+    tags: ["apps"],
+    summary: "GET /:projectId/apps",
     ...auth,
-      request: {
-        params: z.object({ projectId: z.string() }),
-      },
+    request: {
+      params: z.object({ projectId: z.string() }),
+    },
     responses: {
-        200: json(z.array(AppSchema), 'Apps'),
-        ...errors(404),
+      200: json(z.array(AppSchema), "Apps"),
+      ...errors(404),
     },
   }),
   async (c: any) => {
-  const projectId = c.req.param('projectId');
-  const loaded = await loadProjectForUser(c, projectId, 'read');
-  if (!loaded) return c.json({ error: 'Not found' }, 404);
+    const projectId = c.req.param("projectId");
+    const loaded = await loadProjectForUser(c, projectId, "read");
+    if (!loaded) return c.json({ error: "Not found" }, 404);
 
-  return c.json(await loadAppsForResponse(projectId, loaded.row));
-},
+    return c.json(await loadAppsForResponse(projectId, loaded.row));
+  },
 );
 
 // POST /v1/projects/:projectId/apps — add a new app to kortix.toml
 
 projectsApp.openapi(
   createRoute({
-    method: 'post',
-    path: '/{projectId}/apps',
-    tags: ['apps'],
-    summary: 'POST /:projectId/apps',
+    method: "post",
+    path: "/{projectId}/apps",
+    tags: ["apps"],
+    summary: "POST /:projectId/apps",
     ...auth,
-      request: {
-        params: z.object({ projectId: z.string() }),
-        body: { content: { 'application/json': { schema: AnyObject } } },
-      },
+    request: {
+      params: z.object({ projectId: z.string() }),
+      body: { content: { "application/json": { schema: AnyObject } } },
+    },
     responses: {
-        201: json(AppSchema, 'The created app'),
-        ...errors(400, 404, 409),
+      201: json(AppSchema, "The created app"),
+      ...errors(400, 404, 409),
     },
   }),
   async (c: any) => {
-  const projectId = c.req.param('projectId');
-  const body = await readBody(c);
-  const loaded = await loadProjectForUser(c, projectId, 'manage');
-  if (!loaded) return c.json({ error: 'Not found' }, 404);
+    const projectId = c.req.param("projectId");
+    const body = await readBody(c);
+    const loaded = await loadProjectForUser(c, projectId, "manage");
+    if (!loaded) return c.json({ error: "Not found" }, 404);
 
-  const draft = parseAppDraft(body, { existingSlug: null });
-  if ('error' in draft) return c.json({ error: draft.error }, 400);
+    const draft = parseAppDraft(body, { existingSlug: null });
+    if ("error" in draft) return c.json({ error: draft.error }, 400);
 
-  let manifest: ParsedManifest;
-  try {
-    manifest = await loadManifestForEdit(loaded.row);
-  } catch (err) {
-    return c.json({ error: (err as Error).message || 'Failed to read manifest' }, 400);
-  }
+    let manifest: ParsedManifest;
+    try {
+      manifest = await loadManifestForEdit(loaded.row);
+    } catch (err) {
+      return c.json(
+        { error: (err as Error).message || "Failed to read manifest" },
+        400,
+      );
+    }
 
-  if (extractApps(manifest).specs.some((s) => s.slug === draft.slug)) {
-    return c.json({
-      error: `An app with slug "${draft.slug}" already exists. Pick a different name.`,
-    }, 409);
-  }
+    if (extractApps(manifest).specs.some((s) => s.slug === draft.slug)) {
+      return c.json(
+        {
+          error: `An app with slug "${draft.slug}" already exists. Pick a different name.`,
+        },
+        409,
+      );
+    }
 
-  const next = upsertAppInManifest(manifest, draftToAppSpec(draft));
-  const result = await commitManifest(loaded.row, next, `chore: add app ${draft.slug}`);
-  if ('error' in result) {
-    return c.json({ error: result.error }, result.status as 400 | 502);
-  }
+    const next = upsertAppInManifest(manifest, draftToAppSpec(draft));
+    const result = await commitManifest(
+      loaded.row,
+      next,
+      `chore: add app ${draft.slug}`,
+    );
+    if ("error" in result) {
+      return c.json({ error: result.error }, result.status as 400 | 502);
+    }
 
-  return c.json(await loadAppsForResponse(projectId, loaded.row), 201);
-},
+    return c.json(await loadAppsForResponse(projectId, loaded.row), 201);
+  },
 );
 
 // PATCH /v1/projects/:projectId/apps/:slug — partial update merged onto current
 
 projectsApp.openapi(
   createRoute({
-    method: 'patch',
-    path: '/{projectId}/apps/{slug}',
-    tags: ['apps'],
-    summary: 'PATCH /:projectId/apps/:slug',
+    method: "patch",
+    path: "/{projectId}/apps/{slug}",
+    tags: ["apps"],
+    summary: "PATCH /:projectId/apps/:slug",
     ...auth,
-      request: {
-        params: z.object({ projectId: z.string(), slug: z.string() }),
-        body: { content: { 'application/json': { schema: AnyObject } } },
-      },
+    request: {
+      params: z.object({ projectId: z.string(), slug: z.string() }),
+      body: { content: { "application/json": { schema: AnyObject } } },
+    },
     responses: {
-        200: json(z.any(), 'OK'),
-        ...errors(400, 404),
+      200: json(z.any(), "OK"),
+      ...errors(400, 404),
     },
   }),
   async (c: any) => {
-  const projectId = c.req.param('projectId');
-  const slug = c.req.param('slug');
-  const body = await readBody(c);
-  const loaded = await loadProjectForUser(c, projectId, 'manage');
-  if (!loaded) return c.json({ error: 'Not found' }, 404);
+    const projectId = c.req.param("projectId");
+    const slug = c.req.param("slug");
+    const body = await readBody(c);
+    const loaded = await loadProjectForUser(c, projectId, "manage");
+    if (!loaded) return c.json({ error: "Not found" }, 404);
 
-  let manifest: ParsedManifest;
-  try {
-    manifest = await loadManifestForEdit(loaded.row);
-  } catch (err) {
-    return c.json({ error: (err as Error).message || 'Failed to read manifest' }, 400);
-  }
-  const current = extractApps(manifest).specs.find((s) => s.slug === slug);
-  if (!current) return c.json({ error: 'Not found' }, 404);
+    let manifest: ParsedManifest;
+    try {
+      manifest = await loadManifestForEdit(loaded.row);
+    } catch (err) {
+      return c.json(
+        { error: (err as Error).message || "Failed to read manifest" },
+        400,
+      );
+    }
+    const current = extractApps(manifest).specs.find((s) => s.slug === slug);
+    if (!current) return c.json({ error: "Not found" }, 404);
 
-  const draft = parseAppDraft(
-    { ...specToAppBody(current), ...body, slug },
-    { existingSlug: slug },
-  );
-  if ('error' in draft) return c.json({ error: draft.error }, 400);
+    const draft = parseAppDraft(
+      { ...specToAppBody(current), ...body, slug },
+      { existingSlug: slug },
+    );
+    if ("error" in draft) return c.json({ error: draft.error }, 400);
 
-  const next = upsertAppInManifest(manifest, draftToAppSpec(draft));
-  const result = await commitManifest(loaded.row, next, `chore: update app ${slug}`);
-  if ('error' in result) {
-    return c.json({ error: result.error }, result.status as 400 | 502);
-  }
+    const next = upsertAppInManifest(manifest, draftToAppSpec(draft));
+    const result = await commitManifest(
+      loaded.row,
+      next,
+      `chore: update app ${slug}`,
+    );
+    if ("error" in result) {
+      return c.json({ error: result.error }, result.status as 400 | 502);
+    }
 
-  return c.json(await loadAppsForResponse(projectId, loaded.row));
-},
+    return c.json(await loadAppsForResponse(projectId, loaded.row));
+  },
 );
 
 // DELETE /v1/projects/:projectId/apps/:slug — remove from manifest. Does
@@ -1281,46 +1624,53 @@ projectsApp.openapi(
 
 projectsApp.openapi(
   createRoute({
-    method: 'delete',
-    path: '/{projectId}/apps/{slug}',
-    tags: ['apps'],
-    summary: 'DELETE /:projectId/apps/:slug',
+    method: "delete",
+    path: "/{projectId}/apps/{slug}",
+    tags: ["apps"],
+    summary: "DELETE /:projectId/apps/:slug",
     ...auth,
-      request: {
-        params: z.object({ projectId: z.string(), slug: z.string() }),
-      },
+    request: {
+      params: z.object({ projectId: z.string(), slug: z.string() }),
+    },
     responses: {
-        200: json(z.any(), 'OK'),
-        ...errors(400, 404),
+      200: json(z.any(), "OK"),
+      ...errors(400, 404),
     },
   }),
   async (c: any) => {
-  const projectId = c.req.param('projectId');
-  const slug = c.req.param('slug');
-  const loaded = await loadProjectForUser(c, projectId, 'manage');
-  if (!loaded) return c.json({ error: 'Not found' }, 404);
+    const projectId = c.req.param("projectId");
+    const slug = c.req.param("slug");
+    const loaded = await loadProjectForUser(c, projectId, "manage");
+    if (!loaded) return c.json({ error: "Not found" }, 404);
 
-  if (!/^[a-z0-9][a-z0-9_-]{0,127}$/.test(slug)) {
-    return c.json({ error: 'Invalid slug' }, 400);
-  }
+    if (!/^[a-z0-9][a-z0-9_-]{0,127}$/.test(slug)) {
+      return c.json({ error: "Invalid slug" }, 400);
+    }
 
-  let manifest: ParsedManifest;
-  try {
-    manifest = await loadManifestForEdit(loaded.row);
-  } catch (err) {
-    return c.json({ error: (err as Error).message || 'Failed to read manifest' }, 400);
-  }
-  if (!extractApps(manifest).specs.some((s) => s.slug === slug)) {
-    return c.json({ error: 'Not found' }, 404);
-  }
+    let manifest: ParsedManifest;
+    try {
+      manifest = await loadManifestForEdit(loaded.row);
+    } catch (err) {
+      return c.json(
+        { error: (err as Error).message || "Failed to read manifest" },
+        400,
+      );
+    }
+    if (!extractApps(manifest).specs.some((s) => s.slug === slug)) {
+      return c.json({ error: "Not found" }, 404);
+    }
 
-  const next = removeAppFromManifest(manifest, slug);
-  const result = await commitManifest(loaded.row, next, `chore: delete app ${slug}`);
-  if ('error' in result) {
-    return c.json({ error: result.error }, result.status as 400 | 502);
-  }
-  return c.json({ ok: true });
-},
+    const next = removeAppFromManifest(manifest, slug);
+    const result = await commitManifest(
+      loaded.row,
+      next,
+      `chore: delete app ${slug}`,
+    );
+    if ("error" in result) {
+      return c.json({ error: result.error }, result.status as 400 | 502);
+    }
+    return c.json({ ok: true });
+  },
 );
 
 // POST /v1/projects/:projectId/apps/:slug/deploy — manual deploy. Mirrors

--- a/apps/web/src/components/projects/customize/sections/connectors-view.tsx
+++ b/apps/web/src/components/projects/customize/sections/connectors-view.tsx
@@ -10,9 +10,9 @@ import { useTranslations } from 'next-intl';
  * app — the model is App → Profile → Tools → Permissions.
  */
 
+import { useCustomizeStore } from '@/stores/customize-store';
 import { createFrontendClient } from '@pipedream/sdk/browser';
 import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import Image from 'next/image';
 import {
   Boxes,
   Check,
@@ -38,7 +38,7 @@ import {
   Zap,
   type LucideIcon,
 } from 'lucide-react';
-import { useCustomizeStore } from '@/stores/customize-store';
+import Image from 'next/image';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useEffect, useMemo, useState, type ReactNode } from 'react';
 
@@ -47,6 +47,7 @@ import { PoliciesPanel } from '@/components/projects/policies-panel';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
+import { CodeBlockCode } from '@/components/ui/code-block';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import {
   Dialog,
@@ -64,7 +65,6 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { EmptyState } from '@/components/ui/empty-state';
 import { EntityAvatar } from '@/components/ui/entity-avatar';
-import { CodeBlockCode } from '@/components/ui/code-block';
 import { InfoBanner } from '@/components/ui/info-banner';
 import { InlineMeta } from '@/components/ui/inline-meta';
 import { Input } from '@/components/ui/input';
@@ -92,18 +92,20 @@ import {
   useSlackInstall,
   useSlackManifest,
   useSlackMode,
+  useUpdateEmailPolicy,
   type EmailInstallation,
+  type EmailSenderPolicy,
   type SlackInstallation,
 } from '@/hooks/channels/use-channels-installations';
 import {
   createConnector,
   deleteConnector,
-  getProject,
   getConnectorConfig,
   getConnectorPolicies,
+  getConnectStatus,
+  getProject,
   listConnectors,
   listPipedreamApps,
-  getConnectStatus,
   pipedreamConnect,
   pipedreamFinalize,
   setConnectorCredential,
@@ -949,8 +951,8 @@ function ConnectorDetail({
               </Button>
             }
           >
-            Connect a machine, and grant or revoke per-capability access, in the Computers
-            tab. Here you control who can use it and review its tools.
+            Connect a machine, and grant or revoke per-capability access, in the Computers tab. Here
+            you control who can use it and review its tools.
           </InfoBanner>
         )}
         {/* Prominent connect CTA — the first thing you see on an unconnected connector. */}
@@ -982,8 +984,9 @@ function ConnectorDetail({
             <TabsTrigger value="permissions">Permissions</TabsTrigger>
           </TabsList>
           <TabsContent value="profile" className="space-y-5">
-            {!isPipedream && !isManaged && (
-              isChannel ? (
+            {!isPipedream &&
+              !isManaged &&
+              (isChannel ? (
                 <ChannelConnectionSection
                   projectId={projectId}
                   connector={connector}
@@ -996,8 +999,7 @@ function ConnectorDetail({
                   connector={connector}
                   onChanged={onChanged}
                 />
-              )
-            )}
+              ))}
             <ProfileSection projectId={projectId} connector={connector} onChanged={onChanged} />
           </TabsContent>
           <TabsContent value="permissions">
@@ -1098,7 +1100,9 @@ function ChannelConnectionSection({
     );
   }
   if (platform === 'slack') {
-    return <SlackChannelProfile projectId={projectId} onChanged={onChanged} onRemoved={onRemoved} />;
+    return (
+      <SlackChannelProfile projectId={projectId} onChanged={onChanged} onRemoved={onRemoved} />
+    );
   }
   return (
     <SectionCard title="Connection">
@@ -1135,7 +1139,11 @@ function EmailChannelProfile({
           onRemoved={onRemoved}
         />
       ) : (
-        <EmailConnectForm projectId={projectId} connectorSlug={connector.slug} onConnected={onChanged} />
+        <EmailConnectForm
+          projectId={projectId}
+          connectorSlug={connector.slug}
+          onConnected={onChanged}
+        />
       )}
     </SectionCard>
   );
@@ -1160,7 +1168,17 @@ function ConnectedEmailProfile({
       <InfoBanner tone="success" icon={Check} title="Email connected">
         Address <code className="font-mono">{installation.email}</code>
         {' · '}Inbox <code className="font-mono">{installation.inboxId}</code>
+        {installation.webhookId ? (
+          <>
+            {' · '}Webhook <code className="font-mono">{installation.webhookId}</code>
+          </>
+        ) : null}
       </InfoBanner>
+      <EmailSenderPolicyEditor
+        projectId={projectId}
+        connectorSlug={connectorSlug}
+        policy={installation.senderPolicy}
+      />
       <div className="flex items-center justify-end gap-2">
         {confirming ? (
           <>
@@ -1175,12 +1193,15 @@ function ConnectedEmailProfile({
               size="sm"
               disabled={disconnect.isPending}
               onClick={() =>
-                disconnect.mutate({ projectId, connectorSlug }, {
-                  onSuccess: () => {
-                    setConfirming(false);
-                    onRemoved();
+                disconnect.mutate(
+                  { projectId, connectorSlug },
+                  {
+                    onSuccess: () => {
+                      setConfirming(false);
+                      onRemoved();
+                    },
                   },
-                })
+                )
               }
             >
               {disconnect.isPending ? <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" /> : null}
@@ -1192,6 +1213,148 @@ function ConnectedEmailProfile({
             Disconnect
           </Button>
         )}
+      </div>
+    </div>
+  );
+}
+
+function splitPolicyList(value: string): string[] {
+  return Array.from(
+    new Set(
+      value
+        .split(/[\n,]+/)
+        .map((item) => item.trim().toLowerCase())
+        .filter(Boolean),
+    ),
+  );
+}
+
+function normalizeEmailSenderPolicy(
+  policy: EmailSenderPolicy | null | undefined,
+): EmailSenderPolicy {
+  return {
+    mode: policy?.mode === 'restricted' ? 'restricted' : 'allow_all',
+    allowedEmails: policy?.allowedEmails ?? [],
+    allowedDomains: policy?.allowedDomains ?? [],
+    allowedRegex: policy?.allowedRegex ?? null,
+  };
+}
+
+function EmailSenderPolicyEditor({
+  projectId,
+  connectorSlug,
+  policy,
+}: {
+  projectId: string;
+  connectorSlug: string;
+  policy: EmailSenderPolicy | null | undefined;
+}) {
+  const update = useUpdateEmailPolicy();
+  const initial = normalizeEmailSenderPolicy(policy);
+  const [restricted, setRestricted] = useState(initial.mode === 'restricted');
+  const [emails, setEmails] = useState(initial.allowedEmails.join('\n'));
+  const [domains, setDomains] = useState(initial.allowedDomains.join('\n'));
+  const [regex, setRegex] = useState(initial.allowedRegex ?? '');
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const next = normalizeEmailSenderPolicy(policy);
+    setRestricted(next.mode === 'restricted');
+    setEmails(next.allowedEmails.join('\n'));
+    setDomains(next.allowedDomains.join('\n'));
+    setRegex(next.allowedRegex ?? '');
+    setError(null);
+  }, [policy]);
+
+  const nextPolicy = (): EmailSenderPolicy => ({
+    mode: restricted ? 'restricted' : 'allow_all',
+    allowedEmails: splitPolicyList(emails),
+    allowedDomains: splitPolicyList(domains).map((domain) => domain.replace(/^@+/, '')),
+    allowedRegex: regex.trim() || null,
+  });
+
+  const save = () => {
+    setError(null);
+    const sender_policy = nextPolicy();
+    if (sender_policy.allowedRegex) {
+      try {
+        new RegExp(sender_policy.allowedRegex);
+      } catch {
+        setError('Regex is invalid');
+        return;
+      }
+    }
+    update.mutate(
+      { projectId, connectorSlug, sender_policy },
+      { onError: (e) => setError((e as Error).message) },
+    );
+  };
+
+  const dirty =
+    restricted !== (initial.mode === 'restricted') ||
+    emails !== initial.allowedEmails.join('\n') ||
+    domains !== initial.allowedDomains.join('\n') ||
+    regex !== (initial.allowedRegex ?? '');
+
+  return (
+    <div className="border-border/60 bg-card rounded-2xl border p-4">
+      <div className="flex items-start gap-3">
+        <Checkbox
+          id="email-sender-restricted"
+          checked={restricted}
+          onCheckedChange={(checked) => setRestricted(Boolean(checked))}
+          className="mt-0.5"
+        />
+        <div className="min-w-0 flex-1 space-y-3">
+          <div>
+            <Label htmlFor="email-sender-restricted">Restrict who can start email sessions</Label>
+            <p className="text-muted-foreground mt-1 text-xs">
+              Leave off to accept every inbound sender. Turn on to allow exact emails, domains, or a
+              regex.
+            </p>
+          </div>
+          {restricted ? (
+            <div className="grid gap-3 sm:grid-cols-2">
+              <Field label="Allowed emails">
+                <Input
+                  value={emails}
+                  onChange={(e) => setEmails(e.target.value)}
+                  placeholder="person@example.com"
+                />
+              </Field>
+              <Field label="Allowed domains">
+                <Input
+                  value={domains}
+                  onChange={(e) => setDomains(e.target.value)}
+                  placeholder="example.com"
+                />
+              </Field>
+              <div className="sm:col-span-2">
+                <Field label="Allowed sender regex">
+                  <Input
+                    value={regex}
+                    onChange={(e) => setRegex(e.target.value)}
+                    placeholder=".*@customer-[0-9]+\\.com$"
+                    spellCheck={false}
+                  />
+                </Field>
+              </div>
+            </div>
+          ) : null}
+          {error ? <InfoBanner tone="destructive">{error}</InfoBanner> : null}
+          <SaveBar
+            dirty={dirty}
+            saving={update.isPending}
+            onSave={save}
+            onReset={() => {
+              setRestricted(initial.mode === 'restricted');
+              setEmails(initial.allowedEmails.join('\n'));
+              setDomains(initial.allowedDomains.join('\n'));
+              setRegex(initial.allowedRegex ?? '');
+            }}
+            label="Save policy"
+          />
+        </div>
       </div>
     </div>
   );
@@ -1217,6 +1380,10 @@ function EmailConnectForm({
   );
   const [apiKey, setApiKey] = useState('');
   const [customKeyOpen, setCustomKeyOpen] = useState(false);
+  const [restricted, setRestricted] = useState(false);
+  const [emails, setEmails] = useState('');
+  const [domains, setDomains] = useState('');
+  const [regex, setRegex] = useState('');
   const [error, setError] = useState<string | null>(null);
   const managedAvailable = mode.data?.managed_available === true;
   const useCustomKey = customKeyOpen && apiKey.trim();
@@ -1226,8 +1393,24 @@ function EmailConnectForm({
     setError(null);
     if (!canCreate) {
       setCustomKeyOpen(true);
-      setError('Managed Email is not configured on this deployment. Use a custom AgentMail key to continue.');
+      setError(
+        'Managed Email is not configured on this deployment. Use a custom AgentMail key to continue.',
+      );
       return;
+    }
+    const sender_policy: EmailSenderPolicy = {
+      mode: restricted ? 'restricted' : 'allow_all',
+      allowedEmails: splitPolicyList(emails),
+      allowedDomains: splitPolicyList(domains).map((domain) => domain.replace(/^@+/, '')),
+      allowedRegex: regex.trim() || null,
+    };
+    if (sender_policy.allowedRegex) {
+      try {
+        new RegExp(sender_policy.allowedRegex);
+      } catch {
+        setError('Regex is invalid');
+        return;
+      }
     }
     connect.mutate(
       {
@@ -1236,6 +1419,7 @@ function EmailConnectForm({
         api_key: useCustomKey ? apiKey.trim() : undefined,
         display_name: displayName.trim() || undefined,
         username: username.trim() || undefined,
+        sender_policy,
       },
       {
         onSuccess: onConnected,
@@ -1278,7 +1462,8 @@ function EmailConnectForm({
             spellCheck={false}
           />
           <p className="text-muted-foreground text-xs">
-            AgentMail will create this prefix when available, for example {username || 'support'}@agentmail.
+            AgentMail will create this prefix when available, for example {username || 'support'}
+            @agentmail.
           </p>
         </Field>
       </div>
@@ -1313,6 +1498,57 @@ function EmailConnectForm({
             </p>
           </Field>
         ) : null}
+      </div>
+      <div className="border-border/60 bg-card rounded-2xl border p-4">
+        <div className="flex items-start gap-3">
+          <Checkbox
+            id="email-channel-restrict-senders"
+            checked={restricted}
+            onCheckedChange={(checked) => setRestricted(Boolean(checked))}
+            className="mt-0.5"
+          />
+          <div className="min-w-0 flex-1 space-y-3">
+            <div>
+              <Label htmlFor="email-channel-restrict-senders">
+                Restrict who can start sessions
+              </Label>
+              <p className="text-muted-foreground mt-1 text-xs">
+                Optional. Allow exact emails, domains, or a regex before inbound mail can trigger
+                the agent.
+              </p>
+            </div>
+            {restricted ? (
+              <div className="grid gap-3 sm:grid-cols-2">
+                <Field label="Allowed emails">
+                  <Input
+                    value={emails}
+                    onChange={(e) => setEmails(e.target.value)}
+                    placeholder="person@example.com"
+                    spellCheck={false}
+                  />
+                </Field>
+                <Field label="Allowed domains">
+                  <Input
+                    value={domains}
+                    onChange={(e) => setDomains(e.target.value)}
+                    placeholder="example.com"
+                    spellCheck={false}
+                  />
+                </Field>
+                <div className="sm:col-span-2">
+                  <Field label="Allowed sender regex">
+                    <Input
+                      value={regex}
+                      onChange={(e) => setRegex(e.target.value)}
+                      placeholder=".*@customer-[0-9]+\\.com$"
+                      spellCheck={false}
+                    />
+                  </Field>
+                </div>
+              </div>
+            ) : null}
+          </div>
+        </div>
       </div>
       {error ? <InfoBanner tone="destructive">{error}</InfoBanner> : null}
       <div className="flex justify-end">
@@ -1369,7 +1605,8 @@ function ConnectedSlackProfile({
   return (
     <div className="space-y-4">
       <InfoBanner tone="success" icon={Check} title="Slack connected">
-        Workspace <code className="font-mono">{installation.workspaceName || installation.workspaceId}</code>
+        Workspace{' '}
+        <code className="font-mono">{installation.workspaceName || installation.workspaceId}</code>
       </InfoBanner>
       <div className="flex items-center justify-end gap-2">
         {confirming ? (
@@ -1407,7 +1644,13 @@ function ConnectedSlackProfile({
   );
 }
 
-function SlackConnectForm({ projectId, onConnected }: { projectId: string; onConnected: () => void }) {
+function SlackConnectForm({
+  projectId,
+  onConnected,
+}: {
+  projectId: string;
+  onConnected: () => void;
+}) {
   const mode = useSlackMode(projectId);
   const manifest = useSlackManifest(projectId);
   const connect = useConnectSlack();
@@ -1481,7 +1724,7 @@ function SlackConnectForm({ projectId, onConnected }: { projectId: string; onCon
           Use custom Slack app
         </Button>
         {showCustom ? (
-          <div className="space-y-5 rounded-2xl border border-border/60 bg-card p-4">
+          <div className="border-border/60 bg-card space-y-5 rounded-2xl border p-4">
             <div className="space-y-1">
               <h3 className="text-foreground text-base font-semibold">Bring your own Slack app</h3>
               <p className="text-muted-foreground text-sm">
@@ -1540,7 +1783,7 @@ function SlackConnectForm({ projectId, onConnected }: { projectId: string; onCon
                   'On the next screen, click Install to Workspace and approve.',
                   'Copy the Bot User OAuth Token (xoxb-...) and Signing Secret.',
                 ].map((step, index) => (
-                  <li key={step} className="flex gap-2 text-xs text-muted-foreground">
+                  <li key={step} className="text-muted-foreground flex gap-2 text-xs">
                     <span className="border-border/60 bg-muted/40 text-foreground flex h-5 w-5 shrink-0 items-center justify-center rounded-full border text-xs font-medium">
                       {index + 1}
                     </span>
@@ -2303,10 +2546,7 @@ function PermissionsSection({
                             <span className="text-muted-foreground text-xs">{t.description}</span>
                           )}
                         </div>
-                        <CodeSnippet
-                          code={tsSignature(connector.slug, t)}
-                          language="typescript"
-                        />
+                        <CodeSnippet code={tsSignature(connector.slug, t)} language="typescript" />
                         <CodeSnippet
                           code={JSON.stringify(
                             t.inputSchema ?? { type: 'object', properties: {} },
@@ -2757,7 +2997,8 @@ function AddEmailProfileCard({
           <Plus className="text-muted-foreground/40 group-hover:text-primary size-4 shrink-0 transition-colors" />
         </div>
         <p className="text-muted-foreground mt-2 line-clamp-3 min-h-[3rem] text-xs leading-relaxed">
-          Add a separate AgentMail inbox profile for support, sales, founders, or any mailbox the agent should run.
+          Add a separate AgentMail inbox profile for support, sales, founders, or any mailbox the
+          agent should run.
         </p>
       </button>
       <Dialog open={open} onOpenChange={(next) => !add.isPending && setOpen(next)}>
@@ -2765,7 +3006,8 @@ function AddEmailProfileCard({
           <DialogHeader className="border-border/60 border-b px-6 pt-6 pb-4">
             <DialogTitle>Add Email inbox</DialogTitle>
             <DialogDescription>
-              Create a separate connector profile. You choose the AgentMail address when connecting it.
+              Create a separate connector profile. You choose the AgentMail address when connecting
+              it.
             </DialogDescription>
           </DialogHeader>
           <div className="space-y-4 px-6 py-5">
@@ -2783,7 +3025,9 @@ function AddEmailProfileCard({
                 id="email-profile-prefix"
                 name="email-profile-prefix"
                 value={username}
-                onChange={(e) => setUsername(e.target.value.toLowerCase().replace(/[^a-z0-9._-]/g, ''))}
+                onChange={(e) =>
+                  setUsername(e.target.value.toLowerCase().replace(/[^a-z0-9._-]/g, ''))
+                }
                 placeholder="support"
                 autoComplete="off"
                 spellCheck={false}
@@ -3128,7 +3372,9 @@ function ConnectorConfigFields({
                 provider,
                 platform:
                   provider === 'channel'
-                    ? (draft.platform === 'email' && !emailChannelEnabled ? 'slack' : (draft.platform ?? (emailChannelEnabled ? 'email' : 'slack')))
+                    ? draft.platform === 'email' && !emailChannelEnabled
+                      ? 'slack'
+                      : (draft.platform ?? (emailChannelEnabled ? 'email' : 'slack'))
                     : undefined,
                 auth: provider === 'channel' ? { type: 'none' } : draft.auth,
               });
@@ -3151,7 +3397,11 @@ function ConnectorConfigFields({
         <div className="space-y-1.5">
           <Label>Channel</Label>
           <Select
-            value={draft.platform === 'email' && !emailChannelEnabled ? 'slack' : (draft.platform ?? (emailChannelEnabled ? 'email' : 'slack'))}
+            value={
+              draft.platform === 'email' && !emailChannelEnabled
+                ? 'slack'
+                : (draft.platform ?? (emailChannelEnabled ? 'email' : 'slack'))
+            }
             onValueChange={(v) => set({ platform: v as ChannelPlatform, auth: { type: 'none' } })}
           >
             <SelectTrigger>

--- a/apps/web/src/components/projects/session-label.ts
+++ b/apps/web/src/components/projects/session-label.ts
@@ -25,12 +25,13 @@ export function directSubsessions(session: ProjectSession): ProjectOpenCodeSessi
 
 /**
  * Where a session came from, derived from the creation metadata stamped by
- * the API: channel sessions carry `metadata.source` ('slack' | 'telegram'),
+ * the API: channel sessions carry `metadata.source` ('slack' | 'telegram' |
+ * 'email'),
  * trigger fires carry `metadata.trigger_source` ('cron' | 'webhook' |
  * 'manual') + `trigger_type`/`trigger_slug`. Everything else is a regular
  * chat the user started.
  */
-export type SessionSourceKind = 'chat' | 'slack' | 'telegram' | 'schedule' | 'webhook';
+export type SessionSourceKind = 'chat' | 'slack' | 'telegram' | 'email' | 'schedule' | 'webhook';
 
 export interface SessionSource {
   kind: SessionSourceKind;
@@ -45,6 +46,7 @@ export function sessionSource(session: ProjectSession): SessionSource {
   const source = typeof meta.source === 'string' ? meta.source : null;
   if (source === 'slack') return { kind: 'slack', label: 'Slack', triggerSlug: null };
   if (source === 'telegram') return { kind: 'telegram', label: 'Telegram', triggerSlug: null };
+  if (source === 'email') return { kind: 'email', label: 'Email', triggerSlug: null };
   if (typeof meta.trigger_source === 'string') {
     const triggerSlug = typeof meta.trigger_slug === 'string' ? meta.trigger_slug : null;
     // Classify by the trigger's kind (cron|webhook) when present so a manual
@@ -67,6 +69,7 @@ export type SessionFilterValue =
   | 'mine'
   | 'shared'
   | 'slack'
+  | 'email'
   | 'schedule'
   | 'webhook';
 
@@ -75,6 +78,7 @@ export const SESSION_FILTER_OPTIONS: Array<{ value: SessionFilterValue; label: s
   { value: 'mine', label: 'My Chats' },
   { value: 'shared', label: 'Shared' },
   { value: 'slack', label: 'Slack' },
+  { value: 'email', label: 'Email' },
   { value: 'schedule', label: 'Scheduled' },
   { value: 'webhook', label: 'Webhook' },
 ];
@@ -103,10 +107,5 @@ export function sessionDisplayLabel(session: ProjectSession): string {
   const fallback = session.branch_name
     ? session.branch_name.slice(0, 14)
     : session.session_id.slice(0, 8);
-  return (
-    session.custom_name?.trim() ||
-    session.name?.trim() ||
-    metadataName?.trim() ||
-    fallback
-  );
+  return session.custom_name?.trim() || session.name?.trim() || metadataName?.trim() || fallback;
 }

--- a/apps/web/src/features/co-worker/project-sidebar/project-session-list.tsx
+++ b/apps/web/src/features/co-worker/project-sidebar/project-session-list.tsx
@@ -34,7 +34,14 @@ import { cn } from '@/lib/utils';
 import { Icon as IconMynauiType, Pencil, Share, TrashSolid } from '@mynaui/icons-react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { formatDistanceToNowStrict } from 'date-fns';
-import { CalendarClock, MoreHorizontal, RotateCcw, Webhook, type LucideIcon } from 'lucide-react';
+import {
+  CalendarClock,
+  Mail,
+  MoreHorizontal,
+  RotateCcw,
+  Webhook,
+  type LucideIcon,
+} from 'lucide-react';
 import Link from 'next/link';
 import { usePathname, useSearchParams } from 'next/navigation';
 import { useState } from 'react';
@@ -56,6 +63,7 @@ const SOURCE_ICONS: Record<
 > = {
   slack: Icon.Slack,
   telegram: Icon.Telegram,
+  email: Mail,
   schedule: CalendarClock,
   webhook: Webhook,
 };
@@ -461,9 +469,7 @@ function getSessionDisplayTitle(session: ProjectSession): string {
       ? (session.metadata.session_name as string)
       : null;
   const titleCandidate =
-    session.custom_name?.trim() ||
-    session.name?.trim() ||
-    legacyMetadataName?.trim();
+    session.custom_name?.trim() || session.name?.trim() || legacyMetadataName?.trim();
 
   if (titleCandidate) return titleCandidate;
   return session.branch_name ? session.branch_name.slice(0, 14) : 'session';

--- a/apps/web/src/features/co-worker/project-sidebar/project-sidebar.tsx
+++ b/apps/web/src/features/co-worker/project-sidebar/project-sidebar.tsx
@@ -68,6 +68,7 @@ import {
   CalendarClock,
   ChevronRight,
   List,
+  Mail,
   MessagesSquare,
   PanelLeft,
   Plus,
@@ -91,6 +92,7 @@ const SESSION_FILTER_ICONS: Record<SessionFilterValue, LucideIcon | IconMynauiTy
   mine: MessagesSquare,
   shared: UsersSolid,
   slack: Icon.Slack,
+  email: Mail,
   schedule: CalendarClock,
   webhook: Webhook,
 };

--- a/apps/web/src/hooks/channels/use-channels-installations.ts
+++ b/apps/web/src/hooks/channels/use-channels-installations.ts
@@ -1,7 +1,7 @@
 'use client';
 
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { backendApi } from '@/lib/api-client';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 export interface SlackInstallation {
   workspaceId: string;
@@ -129,7 +129,15 @@ export interface EmailInstallation {
   email: string;
   displayName: string | null;
   webhookId: string | null;
+  senderPolicy: EmailSenderPolicy;
   installedAt: string;
+}
+
+export interface EmailSenderPolicy {
+  mode: 'allow_all' | 'restricted';
+  allowedEmails: string[];
+  allowedDomains: string[];
+  allowedRegex: string | null;
 }
 
 export interface EmailMode {
@@ -189,6 +197,7 @@ interface ConnectEmailInput {
   display_name?: string;
   username?: string;
   domain?: string;
+  sender_policy?: EmailSenderPolicy;
 }
 
 export function useConnectEmail() {
@@ -228,6 +237,34 @@ export function useDisconnectEmail() {
       return { projectId, connectorSlug };
     },
     onSuccess: ({ projectId, connectorSlug }) => {
+      qc.invalidateQueries({ queryKey: emailKey(projectId, connectorSlug) });
+      qc.invalidateQueries({ queryKey: ['project-connectors', projectId] });
+    },
+  });
+}
+
+export function useUpdateEmailPolicy() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async ({
+      projectId,
+      connectorSlug,
+      sender_policy,
+    }: {
+      projectId: string;
+      connectorSlug?: string | null;
+      sender_policy: EmailSenderPolicy;
+    }) => {
+      const res = await backendApi.patch<EmailInstallation>(
+        `/projects/${encodeURIComponent(projectId)}/channels/email/installation`,
+        { connector_slug: connectorSlug ?? 'kortix_email', sender_policy },
+        { showErrors: false },
+      );
+      if (!res.success || !res.data)
+        throw new Error(res.error?.message ?? 'Failed to update email policy');
+      return res.data;
+    },
+    onSuccess: (_data, { projectId, connectorSlug }) => {
       qc.invalidateQueries({ queryKey: emailKey(projectId, connectorSlug) });
       qc.invalidateQueries({ queryKey: ['project-connectors', projectId] });
     },

--- a/packages/llm-gateway/src/pipeline/handler.test.ts
+++ b/packages/llm-gateway/src/pipeline/handler.test.ts
@@ -1,27 +1,42 @@
-import { describe, expect, test } from 'bun:test';
+import { describe, expect, test } from "bun:test";
 
-import { createGateway } from '../create-gateway';
-import type { GatewayHooks, GatewayTrace, UpstreamDescriptor, UsageEvent } from '../domain';
-import type { FetchImpl } from '../http';
+import { createGateway } from "../create-gateway";
+import type {
+  GatewayHooks,
+  GatewayTrace,
+  UpstreamDescriptor,
+  UsageEvent,
+} from "../domain";
+import type { FetchImpl } from "../http";
 
-const principal = { userId: 'u1', accountId: 'a1', projectId: 'p1', keyId: 'k1' };
+const principal = {
+  userId: "u1",
+  accountId: "a1",
+  projectId: "p1",
+  keyId: "k1",
+};
 
 const managed: UpstreamDescriptor = {
-  provider: 'openrouter',
-  kind: 'openai-compat',
-  baseUrl: 'https://up.test/v1',
-  apiKey: 'sk',
-  billingMode: 'credits',
+  provider: "openrouter",
+  kind: "openai-compat",
+  baseUrl: "https://up.test/v1",
+  apiKey: "sk",
+  billingMode: "credits",
   markup: 2,
 };
 
-const fastRetry = { sleep: async () => {}, rand: () => 0.5, baseDelayMs: 1, maxAttempts: 2 };
+const fastRetry = {
+  sleep: async () => {},
+  rand: () => 0.5,
+  baseDelayMs: 1,
+  maxAttempts: 2,
+};
 
 function makeHooks(over: Partial<GatewayHooks> = {}) {
   const usage: UsageEvent[] = [];
   const traces: GatewayTrace[] = [];
   const hooks: GatewayHooks = {
-    authenticate: async (token) => (token === 'good' ? principal : null),
+    authenticate: async (token) => (token === "good" ? principal : null),
     resolveUpstream: async () => [managed],
     assertBillingActive: async () => {},
     recordUsage: async (event) => {
@@ -39,75 +54,89 @@ function okFetch(data: unknown): FetchImpl {
   return async () =>
     new Response(JSON.stringify(data), {
       status: 200,
-      headers: { 'content-type': 'application/json' },
+      headers: { "content-type": "application/json" },
     });
 }
 
 const flush = () => new Promise((resolve) => setTimeout(resolve, 5));
 
-describe('gateway.chatCompletions', () => {
-  test('401 without a bearer token, still traced', async () => {
+describe("gateway.chatCompletions", () => {
+  test("401 without a bearer token, still traced", async () => {
     const { hooks, traces } = makeHooks();
-    const res = await createGateway(hooks, { retry: fastRetry }).chatCompletions({
+    const res = await createGateway(hooks, {
+      retry: fastRetry,
+    }).chatCompletions({
       authorization: undefined,
-      rawBody: '{}',
+      rawBody: "{}",
     });
     expect(res.status).toBe(401);
     await flush();
     expect(traces[0].ok).toBe(false);
-    expect(traces[0].errorCode).toBe('missing_token');
+    expect(traces[0].errorCode).toBe("missing_token");
   });
 
-  test('401 for an invalid token', async () => {
+  test("401 for an invalid token", async () => {
     const { hooks } = makeHooks();
-    const res = await createGateway(hooks, { retry: fastRetry }).chatCompletions({
-      authorization: 'Bearer nope',
-      rawBody: '{}',
+    const res = await createGateway(hooks, {
+      retry: fastRetry,
+    }).chatCompletions({
+      authorization: "Bearer nope",
+      rawBody: "{}",
     });
     expect(res.status).toBe(401);
   });
 
-  test('402 when billing is inactive', async () => {
+  test("402 when billing is inactive", async () => {
     const { hooks } = makeHooks({
       assertBillingActive: async () => {
-        throw new Error('subscription required');
+        throw new Error("subscription required");
       },
     });
-    const res = await createGateway(hooks, { retry: fastRetry }).chatCompletions({
-      authorization: 'Bearer good',
+    const res = await createGateway(hooks, {
+      retry: fastRetry,
+    }).chatCompletions({
+      authorization: "Bearer good",
       rawBody: '{"model":"x"}',
     });
     expect(res.status).toBe(402);
-    expect((await res.json()).code).toBe('subscription_required');
+    expect((await res.json()).code).toBe("subscription_required");
   });
 
-  test('400 on invalid JSON', async () => {
+  test("400 on invalid JSON", async () => {
     const { hooks } = makeHooks();
-    const res = await createGateway(hooks, { retry: fastRetry }).chatCompletions({
-      authorization: 'Bearer good',
-      rawBody: 'not json',
+    const res = await createGateway(hooks, {
+      retry: fastRetry,
+    }).chatCompletions({
+      authorization: "Bearer good",
+      rawBody: "not json",
     });
     expect(res.status).toBe(400);
   });
 
-  test('400 when no upstream resolves for the model', async () => {
+  test("400 when no upstream resolves for the model", async () => {
     const { hooks } = makeHooks({ resolveUpstream: async () => [] });
-    const res = await createGateway(hooks, { retry: fastRetry }).chatCompletions({
-      authorization: 'Bearer good',
+    const res = await createGateway(hooks, {
+      retry: fastRetry,
+    }).chatCompletions({
+      authorization: "Bearer good",
       rawBody: '{"model":"ghost"}',
     });
     expect(res.status).toBe(400);
-    expect((await res.json()).code).toBe('model_unavailable');
+    expect((await res.json()).code).toBe("model_unavailable");
   });
 
-  test('200 success records usage and a full trace', async () => {
+  test("200 success records usage and a full trace", async () => {
     const { hooks, usage, traces } = makeHooks();
     const fetchImpl = okFetch({
-      model: 'kortix/x',
+      model: "kortix/x",
       usage: { prompt_tokens: 100, completion_tokens: 50, cost: 0.01 },
     });
-    const res = await createGateway(hooks, { retry: fastRetry }, { fetchImpl }).chatCompletions({
-      authorization: 'Bearer good',
+    const res = await createGateway(
+      hooks,
+      { retry: fastRetry },
+      { fetchImpl },
+    ).chatCompletions({
+      authorization: "Bearer good",
       rawBody: '{"model":"kortix/x","metadata":{"tag":"demo"}}',
     });
     expect(res.status).toBe(200);
@@ -115,18 +144,18 @@ describe('gateway.chatCompletions', () => {
 
     expect(usage).toHaveLength(1);
     expect(usage[0].finalCost).toBeCloseTo(0.02);
-    expect(usage[0].billingMode).toBe('credits');
+    expect(usage[0].billingMode).toBe("credits");
 
     expect(traces).toHaveLength(1);
     const t = traces[0];
     expect(t.ok).toBe(true);
     expect(t.status).toBe(200);
-    expect(t.provider).toBe('openrouter');
-    expect(t.accountId).toBe('a1');
-    expect(t.projectId).toBe('p1');
+    expect(t.provider).toBe("openrouter");
+    expect(t.accountId).toBe("a1");
+    expect(t.projectId).toBe("p1");
     expect(t.usage.promptTokens).toBe(100);
     expect(t.finalCost).toBeCloseTo(0.02);
-    expect(t.metadata).toEqual({ tag: 'demo' });
+    expect(t.metadata).toEqual({ tag: "demo" });
     expect(t.request).toBeDefined();
     expect(t.response).toBeDefined();
     expect(t.latencyMs).toBeGreaterThanOrEqual(0);
@@ -135,41 +164,50 @@ describe('gateway.chatCompletions', () => {
   test('BYOK billingMode "none" records zero final cost', async () => {
     const byok: UpstreamDescriptor = {
       ...managed,
-      provider: 'anthropic',
-      billingMode: 'none',
+      provider: "anthropic",
+      billingMode: "none",
       markup: 2,
     };
     const { hooks, usage } = makeHooks({ resolveUpstream: async () => [byok] });
     const fetchImpl = okFetch({
-      model: 'anthropic/x',
+      model: "anthropic/x",
       usage: { prompt_tokens: 100, completion_tokens: 50, cost: 0.5 },
     });
-    await createGateway(hooks, { retry: fastRetry }, { fetchImpl }).chatCompletions({
-      authorization: 'Bearer good',
+    await createGateway(
+      hooks,
+      { retry: fastRetry },
+      { fetchImpl },
+    ).chatCompletions({
+      authorization: "Bearer good",
       rawBody: '{"model":"anthropic/x"}',
     });
     await flush();
-    expect(usage[0].billingMode).toBe('none');
+    expect(usage[0].billingMode).toBe("none");
     expect(usage[0].finalCost).toBe(0);
   });
 
-  test('fails over to the next candidate when the first provider is down', async () => {
+  test("fails over to the next candidate when the first provider is down", async () => {
     const down: UpstreamDescriptor = {
       ...managed,
-      provider: 'primary',
-      baseUrl: 'https://down.test/v1',
+      provider: "primary",
+      baseUrl: "https://down.test/v1",
     };
     const up: UpstreamDescriptor = {
       ...managed,
-      provider: 'secondary',
-      baseUrl: 'https://up.test/v1',
+      provider: "secondary",
+      baseUrl: "https://up.test/v1",
     };
-    const { hooks, traces } = makeHooks({ resolveUpstream: async () => [down, up] });
+    const { hooks, traces } = makeHooks({
+      resolveUpstream: async () => [down, up],
+    });
     const fetchImpl: FetchImpl = async (url) =>
-      new URL(url).hostname === 'down.test'
-        ? new Response('boom', { status: 500 })
+      new URL(url).hostname === "down.test"
+        ? new Response("boom", { status: 500 })
         : new Response(
-            JSON.stringify({ model: 'm', usage: { prompt_tokens: 1, completion_tokens: 1 } }),
+            JSON.stringify({
+              model: "m",
+              usage: { prompt_tokens: 1, completion_tokens: 1 },
+            }),
             { status: 200 },
           );
 
@@ -178,50 +216,67 @@ describe('gateway.chatCompletions', () => {
       { retry: { ...fastRetry, maxAttempts: 1 } },
       { fetchImpl },
     ).chatCompletions({
-      authorization: 'Bearer good',
+      authorization: "Bearer good",
       rawBody: '{"model":"x"}',
     });
     expect(res.status).toBe(200);
     await flush();
     expect(traces[0].ok).toBe(true);
-    expect(traces[0].provider).toBe('secondary');
-    expect(traces[0].candidatesTried).toEqual(['primary', 'secondary']);
+    expect(traces[0].provider).toBe("secondary");
+    expect(traces[0].candidatesTried).toEqual(["primary", "secondary"]);
   });
 
-  test('surfaces an upstream 4xx immediately without failover', async () => {
-    const a: UpstreamDescriptor = { ...managed, provider: 'a', baseUrl: 'https://a.test/v1' };
-    const b: UpstreamDescriptor = { ...managed, provider: 'b', baseUrl: 'https://b.test/v1' };
+  test("surfaces an upstream 4xx immediately without failover", async () => {
+    const a: UpstreamDescriptor = {
+      ...managed,
+      provider: "a",
+      baseUrl: "https://a.test/v1",
+    };
+    const b: UpstreamDescriptor = {
+      ...managed,
+      provider: "b",
+      baseUrl: "https://b.test/v1",
+    };
     let bCalled = false;
     const fetchImpl: FetchImpl = async (url) => {
-      if (new URL(url).hostname === 'b.test') {
+      if (new URL(url).hostname === "b.test") {
         bCalled = true;
-        return new Response('{}', { status: 200 });
+        return new Response("{}", { status: 200 });
       }
-      return new Response('bad request', { status: 400 });
+      return new Response("bad request", { status: 400 });
     };
     const { hooks } = makeHooks({ resolveUpstream: async () => [a, b] });
-    const res = await createGateway(hooks, { retry: fastRetry }, { fetchImpl }).chatCompletions({
-      authorization: 'Bearer good',
+    const res = await createGateway(
+      hooks,
+      { retry: fastRetry },
+      { fetchImpl },
+    ).chatCompletions({
+      authorization: "Bearer good",
       rawBody: '{"model":"x"}',
     });
     expect(res.status).toBe(400);
     expect(bCalled).toBe(false);
   });
 
-  test('returns 502 when all candidates are down', async () => {
-    const fetchImpl: FetchImpl = async () => new Response('boom', { status: 500 });
+  test("returns 502 when all candidates are down", async () => {
+    const fetchImpl: FetchImpl = async () =>
+      new Response("boom", { status: 500 });
     const { hooks } = makeHooks();
     const res = await createGateway(
       hooks,
       { retry: { ...fastRetry, maxAttempts: 1 } },
       { fetchImpl },
-    ).chatCompletions({ authorization: 'Bearer good', rawBody: '{"model":"x"}' });
+    ).chatCompletions({
+      authorization: "Bearer good",
+      rawBody: '{"model":"x"}',
+    });
     expect(res.status).toBe(502);
-    expect((await res.json()).code).toBe('upstream_unreachable');
+    expect((await res.json()).code).toBe("upstream_unreachable");
   });
 
-  test('returns 503 once the provider circuit opens', async () => {
-    const fetchImpl: FetchImpl = async () => new Response('boom', { status: 500 });
+  test("returns 503 once the provider circuit opens", async () => {
+    const fetchImpl: FetchImpl = async () =>
+      new Response("boom", { status: 500 });
     const { hooks } = makeHooks();
     const gateway = createGateway(
       hooks,
@@ -231,80 +286,101 @@ describe('gateway.chatCompletions', () => {
       },
       { fetchImpl },
     );
-    await gateway.chatCompletions({ authorization: 'Bearer good', rawBody: '{"model":"x"}' });
+    await gateway.chatCompletions({
+      authorization: "Bearer good",
+      rawBody: '{"model":"x"}',
+    });
     const second = await gateway.chatCompletions({
-      authorization: 'Bearer good',
+      authorization: "Bearer good",
       rawBody: '{"model":"x"}',
     });
     expect(second.status).toBe(503);
-    expect((await second.json()).code).toBe('upstream_unavailable');
+    expect((await second.json()).code).toBe("upstream_unavailable");
   });
 
   // BYOK-out-of-quota → managed fallback. resolveUpstream queues a managed model
   // behind the user's own key; a 429/402/403 on the key falls over to it.
   const byok: UpstreamDescriptor = {
-    provider: 'anthropic',
-    kind: 'openai-compat',
-    baseUrl: 'https://byok.test/v1',
-    apiKey: 'user-key',
-    billingMode: 'none',
+    provider: "anthropic",
+    kind: "openai-compat",
+    baseUrl: "https://byok.test/v1",
+    apiKey: "user-key",
+    billingMode: "none",
     markup: 0,
   };
   const completion = JSON.stringify({
-    id: 'x',
-    choices: [{ message: { content: 'ok' } }],
+    id: "x",
+    choices: [{ message: { content: "ok" } }],
     usage: { prompt_tokens: 1, completion_tokens: 1 },
   });
   const byokBody = '{"model":"anthropic/claude","messages":[]}';
 
-  test('a BYOK rate-limit (429) falls over to the managed fallback', async () => {
-    const { hooks, traces } = makeHooks({ resolveUpstream: async () => [byok, managed] });
+  test("a BYOK rate-limit (429) falls over to the managed fallback", async () => {
+    const { hooks, traces } = makeHooks({
+      resolveUpstream: async () => [byok, managed],
+    });
     const fetchImpl: FetchImpl = async (url) =>
-      String(url).includes('byok.test')
+      String(url).includes("byok.test")
         ? new Response('{"error":"rate_limit"}', { status: 429 })
         : new Response(completion, {
             status: 200,
-            headers: { 'content-type': 'application/json' },
+            headers: { "content-type": "application/json" },
           });
-    const res = await createGateway(hooks, { retry: fastRetry }, { fetchImpl }).chatCompletions({
-      authorization: 'Bearer good',
+    const res = await createGateway(
+      hooks,
+      { retry: fastRetry },
+      { fetchImpl },
+    ).chatCompletions({
+      authorization: "Bearer good",
       rawBody: byokBody,
     });
     expect(res.status).toBe(200);
     await flush();
     const ok = traces.find((t) => t.ok);
-    expect(ok?.provider).toBe('openrouter'); // fell over from byok(anthropic) → managed
-    expect(ok?.candidatesTried).toEqual(['anthropic', 'openrouter']);
+    expect(ok?.provider).toBe("openrouter"); // fell over from byok(anthropic) → managed
+    expect(ok?.candidatesTried).toEqual(["anthropic", "openrouter"]);
   });
 
-  test('a quota error (402) also falls over to the fallback', async () => {
-    const { hooks } = makeHooks({ resolveUpstream: async () => [byok, managed] });
+  test("a quota error (402) also falls over to the fallback", async () => {
+    const { hooks } = makeHooks({
+      resolveUpstream: async () => [byok, managed],
+    });
     const fetchImpl: FetchImpl = async (url) =>
-      String(url).includes('byok.test')
+      String(url).includes("byok.test")
         ? new Response('{"error":"insufficient_quota"}', { status: 402 })
         : new Response(completion, {
             status: 200,
-            headers: { 'content-type': 'application/json' },
+            headers: { "content-type": "application/json" },
           });
-    const res = await createGateway(hooks, { retry: fastRetry }, { fetchImpl }).chatCompletions({
-      authorization: 'Bearer good',
+    const res = await createGateway(
+      hooks,
+      { retry: fastRetry },
+      { fetchImpl },
+    ).chatCompletions({
+      authorization: "Bearer good",
       rawBody: byokBody,
     });
     expect(res.status).toBe(200);
   });
 
-  test('a non-limit BYOK 4xx (400 bad request) returns as-is — no fallback', async () => {
-    const { hooks } = makeHooks({ resolveUpstream: async () => [byok, managed] });
+  test("a non-limit BYOK 4xx (400 bad request) returns as-is — no fallback", async () => {
+    const { hooks } = makeHooks({
+      resolveUpstream: async () => [byok, managed],
+    });
     const fetchImpl: FetchImpl = async () =>
       new Response('{"error":"bad_request"}', { status: 400 });
-    const res = await createGateway(hooks, { retry: fastRetry }, { fetchImpl }).chatCompletions({
-      authorization: 'Bearer good',
+    const res = await createGateway(
+      hooks,
+      { retry: fastRetry },
+      { fetchImpl },
+    ).chatCompletions({
+      authorization: "Bearer good",
       rawBody: byokBody,
     });
     expect(res.status).toBe(400);
   });
 
-  test('a 429 with no fallback candidate is returned, not swallowed', async () => {
+  test("a 429 with no fallback candidate is returned, not swallowed", async () => {
     const { hooks } = makeHooks({ resolveUpstream: async () => [byok] });
     const fetchImpl: FetchImpl = async () =>
       new Response('{"error":"rate_limit"}', { status: 429 });
@@ -313,7 +389,7 @@ describe('gateway.chatCompletions', () => {
       { retry: { ...fastRetry, maxAttempts: 1 } },
       { fetchImpl },
     ).chatCompletions({
-      authorization: 'Bearer good',
+      authorization: "Bearer good",
       rawBody: byokBody,
     });
     expect(res.status).toBe(429);
@@ -324,7 +400,7 @@ describe('gateway.chatCompletions', () => {
   // breaker keyed by provider and shared across tenants, repeated 429s must NOT
   // open it — otherwise one tenant's exhausted key 503s everyone else's healthy
   // key on the same provider.
-  test('a persistent 429 never opens the shared provider breaker', async () => {
+  test("a persistent 429 never opens the shared provider breaker", async () => {
     const { hooks } = makeHooks({ resolveUpstream: async () => [byok] });
     const fetchImpl: FetchImpl = async () =>
       new Response('{"error":"rate_limit"}', { status: 429 });
@@ -338,21 +414,22 @@ describe('gateway.chatCompletions', () => {
     );
     // First request: 429 passes straight through (would have tripped a threshold=1 breaker under the old logic).
     const first = await gateway.chatCompletions({
-      authorization: 'Bearer good',
+      authorization: "Bearer good",
       rawBody: byokBody,
     });
     expect(first.status).toBe(429);
     // Second request still reaches upstream and gets the upstream 429 — NOT a 503 circuit-open.
     const second = await gateway.chatCompletions({
-      authorization: 'Bearer good',
+      authorization: "Bearer good",
       rawBody: byokBody,
     });
     expect(second.status).toBe(429);
   });
 
-  test('a persistent 5xx still opens the breaker (502 → 503)', async () => {
+  test("a persistent 5xx still opens the breaker (502 → 503)", async () => {
     const { hooks } = makeHooks({ resolveUpstream: async () => [managed] });
-    const fetchImpl: FetchImpl = async () => new Response('boom', { status: 500 });
+    const fetchImpl: FetchImpl = async () =>
+      new Response("boom", { status: 500 });
     const gateway = createGateway(
       hooks,
       {
@@ -362,12 +439,12 @@ describe('gateway.chatCompletions', () => {
       { fetchImpl },
     );
     const first = await gateway.chatCompletions({
-      authorization: 'Bearer good',
+      authorization: "Bearer good",
       rawBody: '{"model":"x"}',
     });
     expect(first.status).toBe(502);
     const second = await gateway.chatCompletions({
-      authorization: 'Bearer good',
+      authorization: "Bearer good",
       rawBody: '{"model":"x"}',
     });
     expect(second.status).toBe(503);
@@ -378,24 +455,28 @@ describe('gateway.chatCompletions', () => {
 // call (the standalone gateway uses it to cut three cross-process RPCs to one).
 // When present it fully replaces the three granular hooks; behavior + traces are
 // identical to the granular path.
-describe('gateway.chatCompletions — combined authorize hook', () => {
-  test('authorize ok → proceeds to dispatch and records usage', async () => {
+describe("gateway.chatCompletions — combined authorize hook", () => {
+  test("authorize ok → proceeds to dispatch and records usage", async () => {
     const { hooks, usage } = makeHooks({
       authorize: async () => ({ ok: true, principal }),
       // authenticate/assertBillingActive must NOT be consulted when authorize is set.
       authenticate: async () => {
-        throw new Error('authenticate should not be called');
+        throw new Error("authenticate should not be called");
       },
       assertBillingActive: async () => {
-        throw new Error('assertBillingActive should not be called');
+        throw new Error("assertBillingActive should not be called");
       },
     });
     const fetchImpl = okFetch({
-      model: 'kortix/x',
+      model: "kortix/x",
       usage: { prompt_tokens: 10, completion_tokens: 5 },
     });
-    const res = await createGateway(hooks, { retry: fastRetry }, { fetchImpl }).chatCompletions({
-      authorization: 'Bearer good',
+    const res = await createGateway(
+      hooks,
+      { retry: fastRetry },
+      { fetchImpl },
+    ).chatCompletions({
+      authorization: "Bearer good",
       rawBody: '{"model":"kortix/x"}',
     });
     expect(res.status).toBe(200);
@@ -403,25 +484,27 @@ describe('gateway.chatCompletions — combined authorize hook', () => {
     expect(usage).toHaveLength(1);
   });
 
-  test('authorize denies with 401 invalid_token', async () => {
+  test("authorize denies with 401 invalid_token", async () => {
     const { hooks } = makeHooks({
       authorize: async () => ({
         ok: false,
         status: 401,
-        errorCode: 'invalid_token',
-        message: 'Invalid token',
+        errorCode: "invalid_token",
+        message: "Invalid token",
       }),
     });
-    const res = await createGateway(hooks, { retry: fastRetry }).chatCompletions({
-      authorization: 'Bearer nope',
+    const res = await createGateway(hooks, {
+      retry: fastRetry,
+    }).chatCompletions({
+      authorization: "Bearer nope",
       rawBody: '{"model":"x"}',
     });
     expect(res.status).toBe(401);
-    expect((await res.json()).code).toBe('invalid_token');
+    expect((await res.json()).code).toBe("invalid_token");
   });
 
-  test('autoRouter resolves a synthetic model before resolveUpstream; trace keeps the requested id', async () => {
-    let resolvedWith = '';
+  test("autoRouter resolves a synthetic model before resolveUpstream; trace keeps the requested id", async () => {
+    let resolvedWith = "";
     const { hooks, traces } = makeHooks({
       resolveUpstream: async (_p, model) => {
         resolvedWith = model;
@@ -429,58 +512,74 @@ describe('gateway.chatCompletions — combined authorize hook', () => {
       },
     });
     const fetchImpl = okFetch({
-      model: 'openrouter/owl-alpha',
+      model: "openrouter/fusion",
       usage: { prompt_tokens: 1, completion_tokens: 1 },
     });
     const res = await createGateway(
       hooks,
-      { retry: fastRetry, autoRouter: (model) => (model === 'auto' ? 'owl-alpha' : null) },
+      {
+        retry: fastRetry,
+        autoRouter: (model) => (model === "auto" ? "fusion" : null),
+      },
       { fetchImpl },
-    ).chatCompletions({ authorization: 'Bearer good', rawBody: '{"model":"auto"}' });
+    ).chatCompletions({
+      authorization: "Bearer good",
+      rawBody: '{"model":"auto"}',
+    });
     expect(res.status).toBe(200);
-    expect(resolvedWith).toBe('owl-alpha'); // resolution saw the routed model, not "auto"
+    expect(resolvedWith).toBe("fusion"); // resolution saw the routed model, not "auto"
     await flush();
-    expect(traces[0].requestedModel).toBe('auto'); // trace records what the client asked for
+    expect(traces[0].requestedModel).toBe("auto"); // trace records what the client asked for
   });
 
-  test('autoRouter is a no-op for a concrete model', async () => {
-    let resolvedWith = '';
+  test("autoRouter is a no-op for a concrete model", async () => {
+    let resolvedWith = "";
     const { hooks } = makeHooks({
       resolveUpstream: async (_p, model) => {
         resolvedWith = model;
         return [managed];
       },
     });
-    const fetchImpl = okFetch({ usage: { prompt_tokens: 1, completion_tokens: 1 } });
+    const fetchImpl = okFetch({
+      usage: { prompt_tokens: 1, completion_tokens: 1 },
+    });
     await createGateway(
       hooks,
-      { retry: fastRetry, autoRouter: (model) => (model === 'auto' ? 'owl-alpha' : null) },
+      {
+        retry: fastRetry,
+        autoRouter: (model) => (model === "auto" ? "fusion" : null),
+      },
       { fetchImpl },
-    ).chatCompletions({ authorization: 'Bearer good', rawBody: '{"model":"claude-x"}' });
-    expect(resolvedWith).toBe('claude-x');
+    ).chatCompletions({
+      authorization: "Bearer good",
+      rawBody: '{"model":"claude-x"}',
+    });
+    expect(resolvedWith).toBe("claude-x");
   });
 
-  test('authorize denies with 402 and the trace stays attributed to the principal', async () => {
+  test("authorize denies with 402 and the trace stays attributed to the principal", async () => {
     const { hooks, traces } = makeHooks({
       authorize: async () => ({
         ok: false,
         status: 402,
-        errorCode: 'budget_exceeded',
-        message: 'budget exhausted',
+        errorCode: "budget_exceeded",
+        message: "budget exhausted",
         principal,
       }),
     });
-    const res = await createGateway(hooks, { retry: fastRetry }).chatCompletions({
-      authorization: 'Bearer good',
+    const res = await createGateway(hooks, {
+      retry: fastRetry,
+    }).chatCompletions({
+      authorization: "Bearer good",
       rawBody: '{"model":"x"}',
     });
     expect(res.status).toBe(402);
     const body = await res.json();
-    expect(body.code).toBe('budget_exceeded');
-    expect(body.message).toBe('budget exhausted');
+    expect(body.code).toBe("budget_exceeded");
+    expect(body.message).toBe("budget exhausted");
     await flush();
     expect(traces[0].ok).toBe(false);
-    expect(traces[0].errorCode).toBe('budget_exceeded');
-    expect(traces[0].accountId).toBe('a1'); // attributed even on denial
+    expect(traces[0].errorCode).toBe("budget_exceeded");
+    expect(traces[0].accountId).toBe("a1"); // attributed even on denial
   });
 });

--- a/packages/shared/src/llm-catalog/index.ts
+++ b/packages/shared/src/llm-catalog/index.ts
@@ -1,4 +1,4 @@
-import catalogJson from './catalog.generated.json' with { type: 'json' };
+import catalogJson from "./catalog.generated.json" with { type: "json" };
 
 export interface CatalogModel {
   id: string;
@@ -39,15 +39,15 @@ export interface ManagedModel {
   name: string;
   // The upstream's own model id, interpreted per `transport`:
   //   'bedrock'    → a Bedrock id (`us.anthropic.claude-opus-4-8`)
-  //   'openrouter' → an OpenRouter slug (`openrouter/owl-alpha`)
+  //   'openrouter' -> an OpenRouter slug (`openrouter/fusion`)
   upstreamModelId: string;
   // Which upstream + wire format carries it:
   //   'bedrock'    → Anthropic-on-Bedrock InvokeModel payload (Claude only)
   //   'openrouter' → OpenRouter (openai-compat) for everything else
-  transport: 'bedrock' | 'openrouter';
+  transport: "bedrock" | "openrouter";
   // models.dev id for live pricing — upstream ids don't always match the catalog.
   pricingRef: string;
-  tier: 'flagship' | 'balanced' | 'fast';
+  tier: "flagship" | "balanced" | "fast";
   // Vision (image input). Curated explicitly: managed slugs don't all exist on
   // models.dev (z-ai≠zhipuai, qwen≠alibaba, dotted vs dashed Claude ids), so
   // unlike BYOK models these can't derive it from the generated catalog.
@@ -72,62 +72,62 @@ export interface ManagedModel {
 // else (GLM, Qwen, DeepSeek) goes via OpenRouter.
 export const MANAGED_MODELS: ManagedModel[] = [
   {
-    id: 'claude-opus-4.8',
-    name: 'Claude Opus 4.8',
-    upstreamModelId: 'us.anthropic.claude-opus-4-8',
-    transport: 'bedrock',
-    pricingRef: 'anthropic/claude-opus-4.8',
-    tier: 'flagship',
+    id: "claude-opus-4.8",
+    name: "Claude Opus 4.8",
+    upstreamModelId: "us.anthropic.claude-opus-4-8",
+    transport: "bedrock",
+    pricingRef: "anthropic/claude-opus-4.8",
+    tier: "flagship",
     vision: true,
     limit: { context: 1_000_000, output: 64_000 },
   },
   {
-    id: 'claude-sonnet-4.6',
-    name: 'Claude Sonnet 4.6',
-    upstreamModelId: 'us.anthropic.claude-sonnet-4-6',
-    transport: 'bedrock',
-    pricingRef: 'anthropic/claude-sonnet-4.6',
-    tier: 'balanced',
+    id: "claude-sonnet-4.6",
+    name: "Claude Sonnet 4.6",
+    upstreamModelId: "us.anthropic.claude-sonnet-4-6",
+    transport: "bedrock",
+    pricingRef: "anthropic/claude-sonnet-4.6",
+    tier: "balanced",
     vision: true,
     limit: { context: 1_000_000, output: 64_000 },
   },
   {
-    id: 'owl-alpha',
-    name: 'Owl Alpha',
-    upstreamModelId: 'openrouter/owl-alpha',
-    transport: 'openrouter',
-    pricingRef: 'openrouter/owl-alpha',
-    tier: 'balanced',
+    id: "fusion",
+    name: "Fusion",
+    upstreamModelId: "openrouter/fusion",
+    transport: "openrouter",
+    pricingRef: "openrouter/fusion",
+    tier: "balanced",
     vision: false,
-    limit: { context: 1_048_756, output: 262_144 },
+    limit: { context: 1_000_000, output: 128_000 },
   },
   {
-    id: 'qwen3.7-max',
-    name: 'Qwen3.7 Max',
-    upstreamModelId: 'qwen/qwen3.7-max',
-    transport: 'openrouter',
-    pricingRef: 'qwen/qwen3.7-max',
-    tier: 'balanced',
-    vision: false,
-    limit: { context: 1_048_576, output: 64_000 },
-  },
-  {
-    id: 'deepseek-v4-pro',
-    name: 'DeepSeek V4 Pro',
-    upstreamModelId: 'deepseek/deepseek-v4-pro',
-    transport: 'openrouter',
-    pricingRef: 'deepseek/deepseek-v4-pro',
-    tier: 'balanced',
+    id: "qwen3.7-max",
+    name: "Qwen3.7 Max",
+    upstreamModelId: "qwen/qwen3.7-max",
+    transport: "openrouter",
+    pricingRef: "qwen/qwen3.7-max",
+    tier: "balanced",
     vision: false,
     limit: { context: 1_048_576, output: 64_000 },
   },
   {
-    id: 'deepseek-v4-flash',
-    name: 'DeepSeek V4 Flash',
-    upstreamModelId: 'deepseek/deepseek-v4-flash',
-    transport: 'openrouter',
-    pricingRef: 'deepseek/deepseek-v4-flash',
-    tier: 'balanced',
+    id: "deepseek-v4-pro",
+    name: "DeepSeek V4 Pro",
+    upstreamModelId: "deepseek/deepseek-v4-pro",
+    transport: "openrouter",
+    pricingRef: "deepseek/deepseek-v4-pro",
+    tier: "balanced",
+    vision: false,
+    limit: { context: 1_048_576, output: 64_000 },
+  },
+  {
+    id: "deepseek-v4-flash",
+    name: "DeepSeek V4 Flash",
+    upstreamModelId: "deepseek/deepseek-v4-flash",
+    transport: "openrouter",
+    pricingRef: "deepseek/deepseek-v4-flash",
+    tier: "balanced",
     vision: false,
     limit: { context: 1_048_576, output: 64_000 },
   },
@@ -146,7 +146,7 @@ export function isManagedModelId(id: string): boolean {
 export const DEFAULT_MANAGED_MODEL_IDS = MANAGED_MODELS.map((m) => m.id);
 
 export const MANAGED_FLAGSHIP_MODEL_ID = (
-  MANAGED_MODELS.find((m) => m.tier === 'flagship') ?? MANAGED_MODELS[0]
+  MANAGED_MODELS.find((m) => m.tier === "flagship") ?? MANAGED_MODELS[0]
 ).id;
 
 // ─── AUTO: managed model selection ──────────────────────────────────────────
@@ -155,14 +155,14 @@ export const MANAGED_FLAGSHIP_MODEL_ID = (
 // request asks for it, the gateway resolves it to a concrete managed model and
 // bills it as the resolved model.
 //
-// For now AUTO is Owl Alpha (OpenRouter's agentic default) — except a request
-// that carries images is routed to a vision-capable model so attachments aren't
-// silently ignored (Owl Alpha is text-only). The `autoRouter` hook and this single indirection point
-// are the seam where a future, more sophisticated per-task handler plugs in.
-export const AUTO_MODEL_ID = 'auto';
+// For now AUTO is Fusion (OpenRouter's multi-model router) except a request that
+// carries images is routed to a vision-capable model so attachments aren't
+// silently ignored (Fusion is text-only). The `autoRouter` hook and this single
+// indirection point are where a future, more sophisticated per-task handler plugs in.
+export const AUTO_MODEL_ID = "auto";
 
-const AUTO_TARGET_MODEL = 'owl-alpha'; // text-only default
-const AUTO_VISION_MODEL = 'claude-sonnet-4.6'; // when the request has image content
+const AUTO_TARGET_MODEL = "fusion"; // text-only default
+const AUTO_VISION_MODEL = "claude-sonnet-4.6"; // when the request has image content
 
 function requestHasImage(body: Record<string, unknown>): boolean {
   const messages = Array.isArray(body.messages) ? body.messages : [];
@@ -172,7 +172,9 @@ function requestHasImage(body: Record<string, unknown>): boolean {
       Array.isArray(content) &&
       content.some(
         (part) =>
-          !!part && typeof part === 'object' && (part as { type?: unknown }).type === 'image_url',
+          !!part &&
+          typeof part === "object" &&
+          (part as { type?: unknown }).type === "image_url",
       )
     ) {
       return true;
@@ -187,95 +189,99 @@ function requestHasImage(body: Record<string, unknown>): boolean {
  * the caller treats as "use the requested model as-is"). Pure + dependency-free
  * so both the in-process mount and the standalone gateway can call it locally.
  */
-export function pickAutoModel(model: string, body: Record<string, unknown>): string | null {
-  if (model !== AUTO_MODEL_ID && model !== `kortix/${AUTO_MODEL_ID}`) return null;
+export function pickAutoModel(
+  model: string,
+  body: Record<string, unknown>,
+): string | null {
+  if (model !== AUTO_MODEL_ID && model !== `kortix/${AUTO_MODEL_ID}`)
+    return null;
   return requestHasImage(body) ? AUTO_VISION_MODEL : AUTO_TARGET_MODEL;
 }
 
 export const MODEL_SELECTOR_PROVIDER_IDS = [
-  'kortix',
-  'anthropic',
-  'openai',
-  'github-copilot',
-  'google',
-  'openrouter',
-  'vercel',
+  "kortix",
+  "anthropic",
+  "openai",
+  "github-copilot",
+  "google",
+  "openrouter",
+  "vercel",
 ] as const;
 
 export const PROVIDER_LABELS: Record<string, string> = {
-  anthropic: 'Anthropic',
-  openai: 'OpenAI',
-  codex: 'ChatGPT',
-  google: 'Google',
-  xai: 'xAI',
-  moonshotai: 'Moonshot',
-  'moonshotai-cn': 'Moonshot',
-  opencode: 'OpenCode Zen',
-  kortix: 'Kortix',
-  firmware: 'Firmware',
-  bedrock: 'AWS Bedrock',
-  openrouter: 'OpenRouter',
-  'github-copilot': 'GitHub Copilot',
-  vercel: 'Vercel',
-  groq: 'Groq',
-  deepseek: 'DeepSeek',
-  mistral: 'Mistral',
-  cohere: 'Cohere',
-  llama: 'Llama',
-  huggingface: 'Hugging Face',
-  cerebras: 'Cerebras',
-  togetherai: 'Together AI',
-  fireworks: 'Fireworks',
-  deepinfra: 'DeepInfra',
-  nvidia: 'NVIDIA',
-  cloudflare: 'Cloudflare',
-  azure: 'Azure',
-  ollama: 'Ollama',
-  perplexity: 'Perplexity',
-  lmstudio: 'LM Studio',
-  v0: 'v0',
-  wandb: 'W&B',
-  baseten: 'Baseten',
-  minimax: 'Moonshot',
-  'minimax-cn': 'Moonshot',
-  siliconflow: 'SiliconFlow',
-  'siliconflow-cn': 'SiliconFlow',
-  zhipuai: 'ZhipuAI',
-  'zhipuai-cn': 'ZhipuAI',
-  'google-vertex': 'Google Vertex',
-  'google-vertex-anthropic': 'Vertex Anthropic',
-  'azure-cognitive-services': 'Azure Cognitive',
-  'cloudflare-ai-gateway': 'Cloudflare Gateway',
-  'github-models': 'GitHub Models',
-  'ollama-cloud': 'Ollama Cloud',
-  'kai Coding Plan': 'AI21',
-  zaicodingplan: 'AI21',
-  venice: 'Venice',
-  upstage: 'Upstage',
-  nebius: 'Nebius',
-  vultr: 'Vultr',
-  friendli: 'Friendli',
-  poe: 'Poe',
-  requesty: 'Requesty',
-  'sap-ai-core': 'SAP AI Core',
-  scaleway: 'Scaleway',
-  inception: 'Inception',
-  morph: 'Morph',
-  abacus: 'Abacus',
-  bailing: 'Bailing',
-  chutes: 'Chutes',
-  fastrouter: 'FastRouter',
-  helicone: 'Helicone',
-  iflowcn: 'iFlytek',
-  inference: 'Inference',
-  'io-net': 'IO.net',
-  'kimi-for-coding': 'Kimi',
-  lucidquery: 'LucidQuery',
-  modelscope: 'ModelScope',
-  'nano-gpt': 'NanoGPT',
-  ovhcloud: 'OVHcloud',
-  submodel: 'Submodel',
-  synthetic: 'Synthetic',
-  xiaomi: 'Xiaomi',
-  zenmux: 'Zenmux',
+  anthropic: "Anthropic",
+  openai: "OpenAI",
+  codex: "ChatGPT",
+  google: "Google",
+  xai: "xAI",
+  moonshotai: "Moonshot",
+  "moonshotai-cn": "Moonshot",
+  opencode: "OpenCode Zen",
+  kortix: "Kortix",
+  firmware: "Firmware",
+  bedrock: "AWS Bedrock",
+  openrouter: "OpenRouter",
+  "github-copilot": "GitHub Copilot",
+  vercel: "Vercel",
+  groq: "Groq",
+  deepseek: "DeepSeek",
+  mistral: "Mistral",
+  cohere: "Cohere",
+  llama: "Llama",
+  huggingface: "Hugging Face",
+  cerebras: "Cerebras",
+  togetherai: "Together AI",
+  fireworks: "Fireworks",
+  deepinfra: "DeepInfra",
+  nvidia: "NVIDIA",
+  cloudflare: "Cloudflare",
+  azure: "Azure",
+  ollama: "Ollama",
+  perplexity: "Perplexity",
+  lmstudio: "LM Studio",
+  v0: "v0",
+  wandb: "W&B",
+  baseten: "Baseten",
+  minimax: "Moonshot",
+  "minimax-cn": "Moonshot",
+  siliconflow: "SiliconFlow",
+  "siliconflow-cn": "SiliconFlow",
+  zhipuai: "ZhipuAI",
+  "zhipuai-cn": "ZhipuAI",
+  "google-vertex": "Google Vertex",
+  "google-vertex-anthropic": "Vertex Anthropic",
+  "azure-cognitive-services": "Azure Cognitive",
+  "cloudflare-ai-gateway": "Cloudflare Gateway",
+  "github-models": "GitHub Models",
+  "ollama-cloud": "Ollama Cloud",
+  "kai Coding Plan": "AI21",
+  zaicodingplan: "AI21",
+  venice: "Venice",
+  upstage: "Upstage",
+  nebius: "Nebius",
+  vultr: "Vultr",
+  friendli: "Friendli",
+  poe: "Poe",
+  requesty: "Requesty",
+  "sap-ai-core": "SAP AI Core",
+  scaleway: "Scaleway",
+  inception: "Inception",
+  morph: "Morph",
+  abacus: "Abacus",
+  bailing: "Bailing",
+  chutes: "Chutes",
+  fastrouter: "FastRouter",
+  helicone: "Helicone",
+  iflowcn: "iFlytek",
+  inference: "Inference",
+  "io-net": "IO.net",
+  "kimi-for-coding": "Kimi",
+  lucidquery: "LucidQuery",
+  modelscope: "ModelScope",
+  "nano-gpt": "NanoGPT",
+  ovhcloud: "OVHcloud",
+  submodel: "Submodel",
+  synthetic: "Synthetic",
+  xiaomi: "Xiaomi",
+  zenmux: "Zenmux",
 };

--- a/packages/shared/src/llm-catalog/managed.test.ts
+++ b/packages/shared/src/llm-catalog/managed.test.ts
@@ -1,90 +1,104 @@
-import { describe, expect, test } from 'bun:test';
+import { describe, expect, test } from "bun:test";
 import {
   DEFAULT_MANAGED_MODEL_IDS,
   MANAGED_FLAGSHIP_MODEL_ID,
   MANAGED_MODELS,
   getManagedModel,
   isManagedModelId,
-} from './index';
+} from "./index";
 
-describe('managed catalog', () => {
-  test('exposes the managed lineup', () => {
+describe("managed catalog", () => {
+  test("exposes the managed lineup", () => {
     expect(DEFAULT_MANAGED_MODEL_IDS).toEqual([
-      'claude-opus-4.8',
-      'claude-sonnet-4.6',
-      'owl-alpha',
-      'qwen3.7-max',
-      'deepseek-v4-pro',
-      'deepseek-v4-flash',
+      "claude-opus-4.8",
+      "claude-sonnet-4.6",
+      "fusion",
+      "qwen3.7-max",
+      "deepseek-v4-pro",
+      "deepseek-v4-flash",
     ]);
   });
 
-  test('the haiku/sonnet branded ids are gone from the served catalog', () => {
-    expect(DEFAULT_MANAGED_MODEL_IDS).not.toContain('kortix-power');
-    expect(DEFAULT_MANAGED_MODEL_IDS).not.toContain('kortix-basic');
+  test("the haiku/sonnet branded ids are gone from the served catalog", () => {
+    expect(DEFAULT_MANAGED_MODEL_IDS).not.toContain("kortix-power");
+    expect(DEFAULT_MANAGED_MODEL_IDS).not.toContain("kortix-basic");
   });
 
-  test('Opus is the single flagship', () => {
-    expect(MANAGED_FLAGSHIP_MODEL_ID).toBe('claude-opus-4.8');
-    expect(MANAGED_MODELS.filter((m) => m.tier === 'flagship')).toHaveLength(1);
+  test("Opus is the single flagship", () => {
+    expect(MANAGED_FLAGSHIP_MODEL_ID).toBe("claude-opus-4.8");
+    expect(MANAGED_MODELS.filter((m) => m.tier === "flagship")).toHaveLength(1);
   });
 
-  test('every model has an upstream id, transport, and pricing ref', () => {
+  test("every model has an upstream id, transport, and pricing ref", () => {
     for (const m of MANAGED_MODELS) {
-      expect(m.upstreamModelId.length, `${m.id} needs an upstream id`).toBeGreaterThan(0);
-      expect(m.pricingRef.length, `${m.id} needs a pricing ref`).toBeGreaterThan(0);
-      expect(['bedrock', 'openrouter']).toContain(m.transport);
+      expect(
+        m.upstreamModelId.length,
+        `${m.id} needs an upstream id`,
+      ).toBeGreaterThan(0);
+      expect(
+        m.pricingRef.length,
+        `${m.id} needs a pricing ref`,
+      ).toBeGreaterThan(0);
+      expect(["bedrock", "openrouter"]).toContain(m.transport);
     }
   });
 
-  test('transport matches the upstream id shape', () => {
+  test("transport matches the upstream id shape", () => {
     for (const m of MANAGED_MODELS) {
-      if (m.transport === 'bedrock') {
+      if (m.transport === "bedrock") {
         // Bedrock managed models are Claude via the Anthropic InvokeModel transport.
-        expect(m.upstreamModelId, `${m.id} (Bedrock) → Anthropic`).toContain('anthropic.claude');
+        expect(m.upstreamModelId, `${m.id} (Bedrock) → Anthropic`).toContain(
+          "anthropic.claude",
+        );
       } else {
         // OpenRouter slugs are provider/model.
-        expect(m.transport, `${m.id} transport`).toBe('openrouter');
-        expect(m.upstreamModelId, `${m.id} OpenRouter slug`).toContain('/');
+        expect(m.transport, `${m.id} transport`).toBe("openrouter");
+        expect(m.upstreamModelId, `${m.id} OpenRouter slug`).toContain("/");
       }
     }
   });
 });
 
-describe('managed resolution + back-compat aliases', () => {
-  test('resolves current ids', () => {
-    expect(getManagedModel('claude-opus-4.8')?.name).toBe('Claude Opus 4.8');
-    expect(getManagedModel('claude-opus-4.8')?.transport).toBe('bedrock');
-    expect(getManagedModel('owl-alpha')?.transport).toBe('openrouter');
-    expect(getManagedModel('owl-alpha')?.upstreamModelId).toBe('openrouter/owl-alpha');
-    expect(getManagedModel('qwen3.7-max')?.upstreamModelId).toBe('qwen/qwen3.7-max');
-    expect(getManagedModel('deepseek-v4-pro')?.upstreamModelId).toBe('deepseek/deepseek-v4-pro');
+describe("managed resolution + back-compat aliases", () => {
+  test("resolves current ids", () => {
+    expect(getManagedModel("claude-opus-4.8")?.name).toBe("Claude Opus 4.8");
+    expect(getManagedModel("claude-opus-4.8")?.transport).toBe("bedrock");
+    expect(getManagedModel("fusion")?.transport).toBe("openrouter");
+    expect(getManagedModel("fusion")?.upstreamModelId).toBe(
+      "openrouter/fusion",
+    );
+    expect(getManagedModel("qwen3.7-max")?.upstreamModelId).toBe(
+      "qwen/qwen3.7-max",
+    );
+    expect(getManagedModel("deepseek-v4-pro")?.upstreamModelId).toBe(
+      "deepseek/deepseek-v4-pro",
+    );
   });
 
-  test('retired / superseded model ids no longer resolve (aliases removed)', () => {
+  test("retired / superseded model ids no longer resolve (aliases removed)", () => {
     for (const old of [
-      'kortix-power',
-      'kortix-basic',
-      'glm-4.6',
-      'glm-5.1',
-      'glm-5.2',
-      'qwen3-max',
-      'minimax-m2.5',
-      'kimi-k2',
+      "kortix-power",
+      "kortix-basic",
+      "glm-4.6",
+      "glm-5.1",
+      "glm-5.2",
+      "qwen3-max",
+      "minimax-m2.5",
+      "kimi-k2",
     ]) {
       expect(getManagedModel(old), `${old} should be gone`).toBeUndefined();
       expect(isManagedModelId(old), `${old} should be gone`).toBe(false);
     }
   });
 
-  test('a BYOK provider/model string is never treated as managed', () => {
-    expect(isManagedModelId('anthropic/claude-opus-4.8')).toBe(false);
-    expect(getManagedModel('anthropic/claude-opus-4.8')).toBeUndefined();
-    expect(isManagedModelId('deepseek/deepseek-v3.2')).toBe(false);
+  test("a BYOK provider/model string is never treated as managed", () => {
+    expect(isManagedModelId("anthropic/claude-opus-4.8")).toBe(false);
+    expect(getManagedModel("anthropic/claude-opus-4.8")).toBeUndefined();
+    expect(isManagedModelId("deepseek/deepseek-v3.2")).toBe(false);
   });
 
-  test('unknown ids do not resolve', () => {
-    expect(getManagedModel('nope')).toBeUndefined();
-    expect(isManagedModelId('nope')).toBe(false);
+  test("unknown ids do not resolve", () => {
+    expect(getManagedModel("nope")).toBeUndefined();
+    expect(isManagedModelId("nope")).toBe(false);
   });
 });

--- a/packages/shared/src/llm-catalog/pick-auto.test.ts
+++ b/packages/shared/src/llm-catalog/pick-auto.test.ts
@@ -1,48 +1,63 @@
-import { describe, expect, test } from 'bun:test';
-import { AUTO_MODEL_ID, getManagedModel, pickAutoModel } from './index';
+import { describe, expect, test } from "bun:test";
+import { AUTO_MODEL_ID, getManagedModel, pickAutoModel } from "./index";
 
-const msg = (content: string) => ({ role: 'user', content });
+const msg = (content: string) => ({ role: "user", content });
 
-describe('pickAutoModel', () => {
-  test('returns null for any non-auto model (pass-through)', () => {
-    expect(pickAutoModel('claude-opus-4.8', { messages: [msg('hi')] })).toBeNull();
-    expect(pickAutoModel('anthropic/claude-x', {})).toBeNull();
-    expect(pickAutoModel('', {})).toBeNull();
+describe("pickAutoModel", () => {
+  test("returns null for any non-auto model (pass-through)", () => {
+    expect(
+      pickAutoModel("claude-opus-4.8", { messages: [msg("hi")] }),
+    ).toBeNull();
+    expect(pickAutoModel("anthropic/claude-x", {})).toBeNull();
+    expect(pickAutoModel("", {})).toBeNull();
   });
 
   test('accepts both "auto" and "kortix/auto"', () => {
-    expect(pickAutoModel('auto', { messages: [msg('hi')] })).not.toBeNull();
-    expect(pickAutoModel('kortix/auto', { messages: [msg('hi')] })).not.toBeNull();
-  });
-
-  test('text requests resolve to Owl Alpha (regardless of size / tools)', () => {
-    expect(pickAutoModel('auto', { messages: [msg('hello there')] })).toBe('owl-alpha');
+    expect(pickAutoModel("auto", { messages: [msg("hi")] })).not.toBeNull();
     expect(
-      pickAutoModel('auto', { messages: [msg('x'.repeat(250_000))], tools: [{ name: 'edit' }] }),
-    ).toBe('owl-alpha');
+      pickAutoModel("kortix/auto", { messages: [msg("hi")] }),
+    ).not.toBeNull();
   });
 
-  test('image requests route to a vision model (not blind GLM)', () => {
+  test("text requests resolve to Fusion (regardless of size / tools)", () => {
+    expect(pickAutoModel("auto", { messages: [msg("hello there")] })).toBe(
+      "fusion",
+    );
+    expect(
+      pickAutoModel("auto", {
+        messages: [msg("x".repeat(250_000))],
+        tools: [{ name: "edit" }],
+      }),
+    ).toBe("fusion");
+  });
+
+  test("image requests route to a vision model (not blind GLM)", () => {
     const withImage = {
       messages: [
         {
-          role: 'user',
+          role: "user",
           content: [
-            { type: 'text', text: 'what is this?' },
-            { type: 'image_url', image_url: { url: 'data:image/png;base64,AAAA' } },
+            { type: "text", text: "what is this?" },
+            {
+              type: "image_url",
+              image_url: { url: "data:image/png;base64,AAAA" },
+            },
           ],
         },
       ],
     };
-    expect(pickAutoModel('auto', withImage)).toBe('claude-sonnet-4.6');
+    expect(pickAutoModel("auto", withImage)).toBe("claude-sonnet-4.6");
   });
 
-  test('both auto targets are real managed models', () => {
-    expect(getManagedModel('owl-alpha'), 'owl-alpha must exist').toBeDefined();
-    expect(getManagedModel('claude-sonnet-4.6'), 'claude-sonnet-4.6 must exist').toBeDefined();
+  test("both auto targets are real managed models", () => {
+    expect(getManagedModel("fusion"), "fusion must exist").toBeDefined();
+    expect(
+      getManagedModel("claude-sonnet-4.6"),
+      "claude-sonnet-4.6 must exist",
+    ).toBeDefined();
   });
 
-  test('AUTO_MODEL_ID is the bare synthetic id', () => {
-    expect(AUTO_MODEL_ID).toBe('auto');
+  test("AUTO_MODEL_ID is the bare synthetic id", () => {
+    expect(AUTO_MODEL_ID).toBe("auto");
   });
 });


### PR DESCRIPTION
## Summary
- route the synthetic auto model to OpenRouter Fusion instead of Owl Alpha
- make AgentMail inbox connection fail if webhook registration fails, so connected email profiles cannot silently miss inbound events
- add AgentMail sender policy storage/enforcement plus UI to restrict email session starters by address, domain, or regex
- surface Email as a first-class session source with sidebar/filter icon metadata while keeping Email behind the experimental flag

## Verification
- bun test src/__tests__/unit-resolve-candidates-free-tier.test.ts src/__tests__/unit-email-channel.test.ts
- bun test src/llm-catalog/pick-auto.test.ts src/llm-catalog/managed.test.ts
- bun test src/pipeline/handler.test.ts src/transports/openai-compat/openai-compat.test.ts
- pnpm exec eslint src/components/projects/customize/sections/connectors-view.tsx src/hooks/channels/use-channels-installations.ts src/components/projects/session-label.ts src/features/co-worker/project-sidebar/project-session-list.tsx src/features/co-worker/project-sidebar/project-sidebar.tsx --max-warnings=0
- pnpm exec tsc --noEmit --pretty false (packages/shared, packages/llm-gateway, apps/api)
- dotenvx run -f .env -- env RUN_LIVE_LLM_TESTS=1 LIVE_TEST_MODEL=openrouter/fusion bun test src/llm-gateway/__tests__/gateway.live.test.ts
- local web smoke at http://localhost:3000: Projects loads, Customize > Connectors loads, Channels shows Slack with Email gated off, Slack one-click + custom manifest flow render cleanly