### PR TITLE
fix(cli): show effective sandbox auth in host banner

### DIFF
--- a/apps/cli/src/__tests__/host-notice.test.ts
+++ b/apps/cli/src/__tests__/host-notice.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { renderHostNotice } from '../host-notice.ts';
+
+const ENV_KEYS = [
+  'KORTIX_CLI_TOKEN',
+  'KORTIX_EXECUTOR_TOKEN',
+  'KORTIX_TOKEN',
+  'KORTIX_API_URL',
+  'KORTIX_PROJECT_ID',
+  'BASH_ENV',
+  'KORTIX_CONFIG_FILE',
+  'KORTIX_AUTH_FILE',
+] as const;
+
+let saved: Record<string, string | undefined>;
+
+beforeEach(() => {
+  saved = {};
+  for (const key of ENV_KEYS) {
+    saved[key] = process.env[key];
+    delete process.env[key];
+  }
+});
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    if (saved[key] === undefined) delete process.env[key];
+    else process.env[key] = saved[key];
+  }
+});
+
+function writeConfig(hosts: Record<string, unknown>, active = 'cloud'): string {
+  const dir = mkdtempSync(join(tmpdir(), 'kortix-cli-banner-'));
+  const file = join(dir, 'config.json');
+  writeFileSync(file, JSON.stringify({ active, hosts }, null, 2));
+  process.env.KORTIX_CONFIG_FILE = file;
+  return dir;
+}
+
+describe('host notice', () => {
+  test('shows env-provided sandbox host and project-token auth instead of logged-out config host', () => {
+    const dir = writeConfig({
+      cloud: {
+        url: 'https://api.kortix.com',
+        token: '',
+        user_id: '',
+        user_email: '',
+        account_id: '',
+        logged_in_at: '',
+      },
+    });
+    try {
+      process.env.KORTIX_API_URL = 'https://dev-api.kortix.com/v1';
+      process.env.KORTIX_CLI_TOKEN = 'kortix_pat_project';
+      process.env.KORTIX_PROJECT_ID = 'proj_123';
+
+      const notice = renderHostNotice(['whoami']);
+      expect(notice).toContain('host sandbox');
+      expect(notice).toContain('https://dev-api.kortix.com/v1');
+      expect(notice).toContain('authenticated (project token)');
+      expect(notice).not.toContain('https://api.kortix.com');
+      expect(notice).not.toContain('not logged in');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('shows KORTIX_API_URL override for stored user auth', () => {
+    const dir = writeConfig({
+      cloud: {
+        url: 'https://api.kortix.com',
+        token: 'kortix_pat_user',
+        user_id: 'user_123',
+        user_email: 'user@example.com',
+        account_id: 'acct_123',
+        logged_in_at: '2026-01-01T00:00:00.000Z',
+      },
+    });
+    try {
+      process.env.KORTIX_API_URL = 'https://dev-api.kortix.com/v1';
+
+      const notice = renderHostNotice(['whoami']);
+      expect(notice).toContain('host env');
+      expect(notice).toContain('https://dev-api.kortix.com/v1');
+      expect(notice).toContain('user@example.com (user)');
+      expect(notice).not.toContain('https://api.kortix.com');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('--host display uses the requested stored host instead of sandbox env auth', () => {
+    const dir = writeConfig(
+      {
+        customdev: {
+          url: 'https://dev-api.kortix.com/v1',
+          token: 'kortix_pat_user',
+          user_id: 'user_123',
+          user_email: 'dev@example.com',
+          account_id: 'acct_123',
+          logged_in_at: '2026-01-01T00:00:00.000Z',
+        },
+      },
+      'customdev',
+    );
+    try {
+      process.env.KORTIX_API_URL = 'https://sandbox-api.kortix.test/v1';
+      process.env.KORTIX_CLI_TOKEN = 'kortix_pat_project';
+
+      const notice = renderHostNotice(['whoami', '--host', 'customdev']);
+      expect(notice).toContain('host customdev');
+      expect(notice).toContain('https://dev-api.kortix.com/v1');
+      expect(notice).toContain('dev@example.com (user)');
+      expect(notice).not.toContain('https://sandbox-api.kortix.test/v1');
+      expect(notice).not.toContain('project token');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/cli/src/api/config.ts
+++ b/apps/cli/src/api/config.ts
@@ -172,8 +172,9 @@ export function deleteConfig(): void {
  *      — KORTIX_SANDBOX_TOKEN / its legacy KORTIX_TOKEN alias — is deliberately
  *      NOT used here: it's the daemon's identity, not the user's, and does not
  *      authenticate against the project-scoped API routes the CLI calls.)
- *   2. `--host` flag (handled at the call site via `getHost(name)`)
- *   3. The `active` host in config.json
+ *   2. KORTIX_API_URL env var (URL override for the stored active host)
+ *   3. `--host` flag (handled at the call site via `getHost(name)`)
+ *   4. The `active` host in config.json
  */
 /**
  * True when the platform-injected sandbox token (KORTIX_CLI_TOKEN /
@@ -204,7 +205,10 @@ export function activeHost(): Host | null {
   }
   const config = loadConfig();
   const host = config.hosts[config.active];
-  return host ?? null;
+  if (!host) return null;
+  const envApiUrl = sandboxEnvValue('KORTIX_API_URL');
+  if (envApiUrl) return { ...host, url: envApiUrl };
+  return host;
 }
 
 export function getHost(name: string): Host | null {
@@ -222,6 +226,7 @@ export function listHosts(): { name: string; host: Host; active: boolean }[] {
 export function activeHostEntry(): { name: string; host: Host } {
   const envHost = activeHost();
   if (sandboxCliToken() && envHost) return { name: 'sandbox', host: envHost };
+  if (sandboxEnvValue('KORTIX_API_URL') && envHost) return { name: 'env', host: envHost };
   const config = loadConfig();
   const name = config.hosts[config.active] ? config.active : DEFAULT_HOST_NAME;
   return { name, host: config.hosts[name] ?? defaultHost(DEFAULT_API_BASE) };

--- a/apps/cli/src/host-notice.ts
+++ b/apps/cli/src/host-notice.ts
@@ -1,0 +1,54 @@
+import {
+  activeHostEntry,
+  getHost,
+  hasEnvTokenHost,
+  type Host,
+} from './api/config.ts';
+import { C } from './style.ts';
+
+export interface HostNotice {
+  name: string;
+  url: string;
+  authState: string;
+}
+
+function hostAuthState(host: Host, mode: 'env' | 'stored'): string {
+  if (!host.token) return 'not logged in';
+  if (mode === 'env') return 'authenticated (project token)';
+  if (host.user_email || host.user_id) return `${host.user_email || host.user_id} (user)`;
+  return 'authenticated';
+}
+
+export function findHostArg(argv: readonly string[]): string | undefined {
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--host') return argv[i + 1];
+    if (arg.startsWith('--host=')) return arg.slice('--host='.length);
+  }
+  return undefined;
+}
+
+export function resolveHostNotice(hostArg?: string): HostNotice {
+  if (hostArg) {
+    const host = getHost(hostArg);
+    return {
+      name: hostArg,
+      url: host?.url ?? 'unconfigured',
+      authState: host ? hostAuthState(host, 'stored') : 'not logged in',
+    };
+  }
+
+  const { name, host } = activeHostEntry();
+  return {
+    name,
+    url: host.url,
+    authState: hostAuthState(host, hasEnvTokenHost() ? 'env' : 'stored'),
+  };
+}
+
+export function renderHostNotice(commandArgv: readonly string[]): string | null {
+  const command = commandArgv[0];
+  if (!command || ['help', '--help', '-h', 'version'].includes(command)) return null;
+  const notice = resolveHostNotice(findHostArg(commandArgv.slice(1)));
+  return `${C.dim}host ${C.reset}${C.bold}${notice.name}${C.reset}${C.dim} (${notice.url}, ${notice.authState})${C.reset}\n`;
+}

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -29,8 +29,8 @@ import { runUpdate } from './commands/update.ts';
 import { runValidate } from './commands/validate.ts';
 import { runWhoami } from './commands/whoami.ts';
 import { printBanner } from './banner.ts';
-import { activeHostEntry } from './api/config.ts';
 import { getUpdateNotice } from './update-check.ts';
+import { renderHostNotice } from './host-notice.ts';
 import { C, header, pad, rule } from './style.ts';
 
 // CI bakes the real version via --define process.env.KORTIX_CLI_VERSION (the
@@ -134,7 +134,7 @@ async function main(argv: string[]): Promise<number> {
   // and `executor mcp` speaks JSON-RPC on stdout). Skip the human-oriented host
   // + update notices so its output stays clean.
   if (argv[0] !== 'executor') {
-    printActiveHostNotice(argv[0]);
+    printActiveHostNotice(argv);
     await printUpdateNoticeForCommand(argv[0]);
   }
   if (argv[0] === 'init') {
@@ -247,13 +247,9 @@ async function main(argv: string[]): Promise<number> {
   return runCreate(argv);
 }
 
-function printActiveHostNotice(command: string): void {
-  if (['help', '--help', '-h', 'version'].includes(command)) return;
-  const { name, host } = activeHostEntry();
-  const loginState = host.token ? host.user_email || host.user_id || 'logged in' : 'not logged in';
-  process.stderr.write(
-    `${C.dim}host ${C.reset}${C.bold}${name}${C.reset}${C.dim} (${host.url}, ${loginState})${C.reset}\n`,
-  );
+function printActiveHostNotice(argv: readonly string[]): void {
+  const notice = renderHostNotice(argv);
+  if (notice) process.stderr.write(notice);
 }
 
 // Passive, cache-only nudge for subcommands (never touches the network, so it


### PR DESCRIPTION
## Summary
- move the CLI host banner into a small resolver that uses the same effective host/auth path as CLI requests
- show sandbox env auth as authenticated (project token) and preserve explicit --host display
- make KORTIX_API_URL override the stored active host URL even when auth comes from stored user config

## Test plan
- pnpm test ./src/__tests__/host-notice.test.ts ./src/__tests__/sandbox-auth.test.ts
- pnpm --filter @kortix/cli typecheck
- pnpm --filter @kortix/cli test
- smoke: KORTIX_CONFIG_FILE=<temp cloud config> KORTIX_API_URL=https://dev-api.kortix.com/v1 KORTIX_CLI_TOKEN=kortix_pat_cli bun run apps/cli/src/index.ts hosts current
  - stderr: host sandbox (https://dev-api.kortix.com/v1, authenticated (project token))