### PR TITLE
Fix AgentMail email channel dispatch

### DIFF
--- a/apps/api/src/__tests__/unit-email-channel.test.ts
+++ b/apps/api/src/__tests__/unit-email-channel.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { createHmac } from "node:crypto";
 import { config } from "../config";
-import { resolveAgentMailApiKey } from "../channels/agentmail-api";
+import { createAgentMailWebhook, resolveAgentMailApiKey } from "../channels/agentmail-api";
 import { verifyAgentMailSignature } from "../channels/email/verify";
 import type { AgentMailMessageReceivedEvent } from "../channels/email/types";
 
@@ -145,6 +145,34 @@ describe("AgentMail credential resolution", () => {
   });
 });
 
+describe("AgentMail webhook provisioning", () => {
+  test("subscribes new inbox webhooks to normal and unauthenticated inbound mail", async () => {
+    const originalFetch = globalThis.fetch;
+    let requestBody: any = null;
+    globalThis.fetch = (async (_url, init) => {
+      requestBody = JSON.parse(String(init?.body ?? "{}"));
+      return new Response(JSON.stringify({ webhook_id: "wh-1", secret: "whsec_test" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as typeof fetch;
+    try {
+      await createAgentMailWebhook({
+        apiKey: "am_test",
+        inboxId: "inb-1",
+        url: "https://api.kortix.test/v1/webhooks/email/agentmail",
+        clientId: "kortix-email-proj-1",
+      });
+      expect(requestBody.event_types).toEqual([
+        "message.received",
+        "message.received.unauthenticated",
+      ]);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});
+
 describe("dispatchAgentMailEvent", () => {
   test("first message creates one project-visible session bound to the email thread", async () => {
     dbResults = [
@@ -179,6 +207,64 @@ describe("dispatchAgentMailEvent", () => {
     ]);
     expect(createCalls[0].extraEnvVars.KORTIX_EMAIL_INBOX_ID).toBe("inb-1");
     expect(createCalls[0].body.initial_prompt).toContain("Need help");
+  });
+
+  test("accepts AgentMail's unwrapped message.received payload without top-level thread metadata", async () => {
+    const { type: _type, thread: _thread, ...unwrappedEvent } = event;
+    const actualAgentMailPayload: AgentMailMessageReceivedEvent = {
+      ...unwrappedEvent,
+      event_id: "evt-unwrapped",
+      message: {
+        ...event.message,
+        thread_id: "thr-unwrapped",
+        message_id: "msg-unwrapped",
+        subject: "Actual AgentMail payload",
+      },
+    };
+    dbResults = [
+      [{ eventId: "email:event:evt-unwrapped" }],
+      [{ projectId: "proj-1" }],
+      [],
+      [{ eventId: "email:msg:inb-1:msg-unwrapped" }],
+      [],
+      [
+        {
+          projectId: "proj-1",
+          accountId: "acc-1",
+          defaultBranch: "main",
+          name: "Support",
+        },
+      ],
+      [{ eventId: "email:threadcreate:inb-1:thr-unwrapped" }],
+    ];
+
+    await dispatchAgentMailEvent(actualAgentMailPayload);
+
+    expect(createCalls).toHaveLength(1);
+    expect(createCalls[0].metadata.email.subject).toBe("Actual AgentMail payload");
+    expect(createCalls[0].body.initial_prompt).toContain("Thread ID:  thr-unwrapped");
+  });
+
+  test("routes unauthenticated inbound mail through the same sender policy and session path", async () => {
+    const unauthenticatedEvent: AgentMailMessageReceivedEvent = {
+      ...event,
+      event_type: "message.received.unauthenticated",
+      event_id: "evt-unauth",
+      message: { ...event.message, message_id: "msg-unauth" },
+    };
+    dbResults = [
+      [{ eventId: "email:event:evt-unauth" }],
+      [{ projectId: "proj-1" }],
+      [],
+      [{ eventId: "email:msg:inb-1:msg-unauth" }],
+      [{ sessionId: "sess-1" }],
+    ];
+
+    await dispatchAgentMailEvent(unauthenticatedEvent);
+
+    expect(createCalls).toHaveLength(0);
+    expect(continueCalls).toHaveLength(1);
+    expect(continueCalls[0].sessionId).toBe("sess-1");
   });
 
   test("known thread routes a new email into the existing session", async () => {

--- a/apps/api/src/channels/agentmail-api.ts
+++ b/apps/api/src/channels/agentmail-api.ts
@@ -80,7 +80,7 @@ export async function createAgentMailWebhook(input: {
     method: 'POST',
     body: {
       url: input.url,
-      event_types: ['message.received'],
+      event_types: ['message.received', 'message.received.unauthenticated'],
       inbox_ids: [input.inboxId],
       client_id: input.clientId,
     },

--- a/apps/api/src/channels/email/routes.ts
+++ b/apps/api/src/channels/email/routes.ts
@@ -29,7 +29,7 @@ emailWebhookApp.openapi(
     } catch {
       return c.json({ error: 'Invalid JSON' }, 400);
     }
-    if (event?.type !== 'event' || !event.event_type) return c.json({ ok: true });
+    if (!event?.event_type || !event.message?.inbox_id) return c.json({ ok: true });
 
     const projectId = event.message?.inbox_id
       ? await resolveProjectForAgentMailInbox(event.message.inbox_id)

--- a/apps/api/src/channels/email/session.ts
+++ b/apps/api/src/channels/email/session.ts
@@ -56,7 +56,7 @@ export async function resolveProjectForAgentMailInbox(
 export async function dispatchAgentMailEvent(
   event: AgentMailMessageReceivedEvent,
 ): Promise<void> {
-  if (event.event_type !== "message.received") return;
+  if (!isInboundMessageEvent(event.event_type)) return;
   if (await alreadyHandled(`email:event:${event.event_id}`)) return;
   const projectId = await resolveProjectForAgentMailInbox(
     event.message.inbox_id,
@@ -202,7 +202,7 @@ async function createThreadSession(
         thread_id: threadId,
         message_id: event.message.message_id,
         from: messageSender(event),
-        subject: event.message.subject ?? event.thread.subject ?? null,
+        subject: messageSubject(event),
       },
     },
     extraEnvVars: {
@@ -342,13 +342,21 @@ function renderAgentPrompt(
     `Message ID: ${event.message.message_id}`,
     `From:       ${messageSender(event)}`,
     `To:         ${(event.message.to ?? []).join(", ")}`,
-    `Subject:    ${event.message.subject ?? event.thread.subject ?? "(no subject)"}`,
+    `Subject:    ${messageSubject(event) ?? "(no subject)"}`,
     "",
     messageSummary(event),
     "",
     EMAIL_TURN_INSTRUCTIONS,
   );
   return lines.join("\n");
+}
+
+function isInboundMessageEvent(eventType: AgentMailMessageReceivedEvent["event_type"]): boolean {
+  return eventType === "message.received" || eventType === "message.received.unauthenticated";
+}
+
+function messageSubject(event: AgentMailMessageReceivedEvent): string | null {
+  return event.message.subject ?? event.thread?.subject ?? null;
 }
 
 function messageSummary(event: AgentMailMessageReceivedEvent): string {

--- a/apps/api/src/channels/email/types.ts
+++ b/apps/api/src/channels/email/types.ts
@@ -35,7 +35,7 @@ export interface AgentMailThread {
 }
 
 export interface AgentMailMessageReceivedEvent {
-  type: "event";
+  type?: "event";
   event_type:
     | "message.received"
     | "message.received.spam"
@@ -43,5 +43,5 @@ export interface AgentMailMessageReceivedEvent {
     | "message.received.unauthenticated";
   event_id: string;
   message: AgentMailAddressedMessage;
-  thread: AgentMailThread;
+  thread?: AgentMailThread;
 }

--- a/apps/api/src/projects/routes/r4.ts
+++ b/apps/api/src/projects/routes/r4.ts
@@ -712,6 +712,9 @@ projectsApp.openapi(
       profile_slug?: string;
       username?: string;
       domain?: string;
+      inbox_id?: string;
+      inboxId?: string;
+      email?: string;
       display_name?: string;
       displayName?: string;
       sender_policy?: Partial<AgentMailSenderPolicy>;
@@ -739,6 +742,18 @@ projectsApp.openapi(
     const username = normalizeAgentMailUsername(
       body.username ?? loaded.row.name,
     );
+    const existingInboxId =
+      typeof (body.inbox_id ?? body.inboxId) === "string"
+        ? (body.inbox_id ?? body.inboxId)!.trim()
+        : "";
+    const existingEmail =
+      typeof body.email === "string" ? body.email.trim() : "";
+    if ((existingInboxId && !existingEmail) || (!existingInboxId && existingEmail)) {
+      return c.json(
+        { error: "Existing AgentMail inbox requires both inbox_id and email" },
+        400,
+      );
+    }
     const domain =
       typeof body.domain === "string" && body.domain.trim()
         ? body.domain.trim()
@@ -752,24 +767,32 @@ projectsApp.openapi(
     const clientId = `kortix-project-${projectId}`;
 
     let inbox: Awaited<ReturnType<typeof createAgentMailInbox>>;
-    try {
-      inbox = await createAgentMailInbox({
-        apiKey,
-        username,
-        domain,
-        displayName,
-        clientId,
-        metadata: {
-          provider: "kortix",
-          project_id: projectId,
-          account_id: loaded.row.accountId,
-        },
-      });
-    } catch (err) {
-      return c.json(
-        { error: `AgentMail inbox create failed: ${(err as Error).message}` },
-        502,
-      );
+    if (existingInboxId && existingEmail) {
+      inbox = {
+        inbox_id: existingInboxId,
+        email: existingEmail,
+        display_name: displayName,
+      };
+    } else {
+      try {
+        inbox = await createAgentMailInbox({
+          apiKey,
+          username,
+          domain,
+          displayName,
+          clientId,
+          metadata: {
+            provider: "kortix",
+            project_id: projectId,
+            account_id: loaded.row.accountId,
+          },
+        });
+      } catch (err) {
+        return c.json(
+          { error: `AgentMail inbox create failed: ${(err as Error).message}` },
+          502,
+        );
+      }
     }
 
     let webhookId: string;

--- a/apps/web/src/components/projects/customize/sections/connectors-view.slack-channel.test.ts
+++ b/apps/web/src/components/projects/customize/sections/connectors-view.slack-channel.test.ts
@@ -22,3 +22,17 @@ describe('Slack channel connector catalogue', () => {
     expect(source).toContain('Copy the Bot User OAuth Token (xoxb-...) and Signing Secret.');
   });
 });
+
+describe('Email channel connector catalogue', () => {
+  test('keeps Email profiles behind the experimental flag', () => {
+    expect(source).toContain('{emailChannelEnabled && <AddEmailProfileCard projectId={projectId} onAdded={onAdded} />}');
+  });
+
+  test('supports managed inbox creation and attaching an existing AgentMail inbox', () => {
+    expect(source).toContain('Create managed Email inbox');
+    expect(source).toContain('Use custom AgentMail key');
+    expect(source).toContain('Attach existing AgentMail inbox');
+    expect(source).toContain('Existing inbox ID');
+    expect(source).toContain('Existing inbox email');
+  });
+});

--- a/apps/web/src/components/projects/customize/sections/connectors-view.tsx
+++ b/apps/web/src/components/projects/customize/sections/connectors-view.tsx
@@ -1378,6 +1378,9 @@ function EmailConnectForm({
       .replace(/_[a-z0-9]{4}$/i, '')
       .replace(/_/g, '-'),
   );
+  const [attachExisting, setAttachExisting] = useState(false);
+  const [existingInboxId, setExistingInboxId] = useState('');
+  const [existingEmail, setExistingEmail] = useState('');
   const [apiKey, setApiKey] = useState('');
   const [customKeyOpen, setCustomKeyOpen] = useState(false);
   const [restricted, setRestricted] = useState(false);
@@ -1396,6 +1399,10 @@ function EmailConnectForm({
       setError(
         'Managed Email is not configured on this deployment. Use a custom AgentMail key to continue.',
       );
+      return;
+    }
+    if (attachExisting && (!existingInboxId.trim() || !existingEmail.trim())) {
+      setError('Existing AgentMail inbox requires both inbox ID and email address.');
       return;
     }
     const sender_policy: EmailSenderPolicy = {
@@ -1418,7 +1425,9 @@ function EmailConnectForm({
         connector_slug: connectorSlug,
         api_key: useCustomKey ? apiKey.trim() : undefined,
         display_name: displayName.trim() || undefined,
-        username: username.trim() || undefined,
+        username: attachExisting ? undefined : username.trim() || undefined,
+        inbox_id: attachExisting ? existingInboxId.trim() : undefined,
+        email: attachExisting ? existingEmail.trim() : undefined,
         sender_policy,
       },
       {
@@ -1450,22 +1459,72 @@ function EmailConnectForm({
             placeholder="Kortix Agent"
           />
         </Field>
-        <Field label="Address prefix">
-          <Input
-            id="email-channel-username"
-            name="email-channel-username"
-            aria-label="Email address prefix"
-            value={username}
-            onChange={(e) => setUsername(e.target.value.toLowerCase().replace(/[^a-z0-9._-]/g, ''))}
-            placeholder="support"
-            autoComplete="off"
-            spellCheck={false}
+        {attachExisting ? (
+          <Field label="Existing inbox email">
+            <Input
+              id="email-channel-existing-email"
+              name="email-channel-existing-email"
+              aria-label="Existing AgentMail email"
+              value={existingEmail}
+              onChange={(e) => setExistingEmail(e.target.value.trim().toLowerCase())}
+              placeholder="support@agentmail.to"
+              autoComplete="off"
+              spellCheck={false}
+            />
+          </Field>
+        ) : (
+          <Field label="Address prefix">
+            <Input
+              id="email-channel-username"
+              name="email-channel-username"
+              aria-label="Email address prefix"
+              value={username}
+              onChange={(e) =>
+                setUsername(e.target.value.toLowerCase().replace(/[^a-z0-9._-]/g, ''))
+              }
+              placeholder="support"
+              autoComplete="off"
+              spellCheck={false}
+            />
+            <p className="text-muted-foreground text-xs">
+              AgentMail will create this prefix when available, for example {username || 'support'}
+              @agentmail.to.
+            </p>
+          </Field>
+        )}
+      </div>
+      <div className="border-border/60 border-t pt-4">
+        <div className="flex items-start gap-3">
+          <Checkbox
+            id="email-channel-existing-inbox"
+            checked={attachExisting}
+            onCheckedChange={(checked) => setAttachExisting(Boolean(checked))}
+            className="mt-0.5"
           />
-          <p className="text-muted-foreground text-xs">
-            AgentMail will create this prefix when available, for example {username || 'support'}
-            @agentmail.
-          </p>
-        </Field>
+          <div className="min-w-0 flex-1 space-y-3">
+            <div>
+              <Label htmlFor="email-channel-existing-inbox">Attach existing AgentMail inbox</Label>
+              <p className="text-muted-foreground mt-1 text-xs">
+                Use this when the mailbox already exists or the AgentMail account has reached its
+                inbox limit. Kortix will still create the webhook for this profile.
+              </p>
+            </div>
+            {attachExisting ? (
+              <Field label="Existing inbox ID">
+                <Input
+                  id="email-channel-existing-inbox-id"
+                  name="email-channel-existing-inbox-id"
+                  aria-label="Existing AgentMail inbox ID"
+                  value={existingInboxId}
+                  onChange={(e) => setExistingInboxId(e.target.value.trim())}
+                  placeholder="support@agentmail.to"
+                  autoComplete="off"
+                  spellCheck={false}
+                />
+              </Field>
+            ) : null}
+          </div>
+        </div>
       </div>
       <div className="space-y-3">
         <Button

--- a/apps/web/src/hooks/channels/use-channels-installations.ts
+++ b/apps/web/src/hooks/channels/use-channels-installations.ts
@@ -197,6 +197,8 @@ interface ConnectEmailInput {
   display_name?: string;
   username?: string;
   domain?: string;
+  inbox_id?: string;
+  email?: string;
   sender_policy?: EmailSenderPolicy;
 }
 

--- a/tests/spec/end-to-end.md
+++ b/tests/spec/end-to-end.md
@@ -277,10 +277,10 @@ Tokens stored as encrypted project secrets; webhooks public + signature-gated.
 `CHN-7` Slack OAuth — `GET /webhooks/slack/oauth/callback` (signed `state`, 10-min TTL) → exchange code → `saveSlackInstall`.
 `CHN-8` Telegram inbound — `POST /webhooks/telegram/:id`: verify `x-telegram-bot-api-secret-token` (missing→404, mismatch→401) → `message`/`edited_message` → spawn session (actor=owner, `visibility:'project'`).
 `CHN-9` bad sig on any channel webhook → 401. Not configured → **503 (Slack OAuth mode + OAuth callback)** but **404 (Slack BYO + Telegram)**.
-`CHN-13` `POST /projects/:id/channels/email/connect {connector_slug?}` → `manage` + project experimental `agentmail_email` enabled → creates an AgentMail inbox + `message.received` webhook, stores inbox/webhook metadata as encrypted per-profile project secrets, and marks that Email connector profile connected. Disabled projects return 403 before AgentMail key validation. Omit `connector_slug` for legacy `kortix_email`; provide an Email connector slug for multiple inboxes.
+`CHN-13` `POST /projects/:id/channels/email/connect {connector_slug?}` → `manage` + project experimental `agentmail_email` enabled → creates or attaches an AgentMail inbox + `message.received`/`message.received.unauthenticated` webhook, stores inbox/webhook metadata as encrypted per-profile project secrets, and marks that Email connector profile connected. Disabled projects return 403 before AgentMail key validation. Omit `connector_slug` for legacy `kortix_email`; provide an Email connector slug for multiple inboxes.
 `CHN-14` `GET /projects/:id/channels/email/installation?connector_slug=...` → `read` → AgentMail inbox id/email/webhook id for that profile or null; disabled projects return null.
 `CHN-15` `DELETE /projects/:id/channels/email/installation?connector_slug=...` → `manage` → removes that profile's inbox binding.
-`CHN-16` AgentMail inbound — `POST /webhooks/email/agentmail`: Svix `svix-*` signature verified against the per-project webhook secret when configured; `message.received` routes by `message.inbox_id` → project, maps `thread_id` 1:1 to a Kortix session, and follow-up emails continue that session.
+`CHN-16` AgentMail inbound — `POST /webhooks/email/agentmail`: Svix `svix-*` signature verified against the per-project webhook secret when configured; AgentMail's real unwrapped `message.received` or `message.received.unauthenticated` payload routes by `message.inbox_id` → project, maps `thread_id` 1:1 to a Kortix session, and follow-up emails continue that session.
 `CHN-17` `GET /projects/:id/channels/email/mode` → `read` → `{provider:"agentmail",enabled:boolean,managed_available:boolean}` so the UI can hide Email until `agentmail_email` is enabled and require a project AgentMail key when no managed server key exists.
 
 ---
@@ -536,10 +536,10 @@ Scale: ~500 exported symbols / ~520 route handlers in `apps/api/src` — a tract
 `CHN-10` `GET /projects/:id/channels/slack/mode` → read → 200; non-member 403/404.
 `CHN-11` `POST /webhooks/slack/commands` → public, OAuth-gated → 503/401.
 `CHN-12` `POST /webhooks/slack/interactivity` → public, OAuth-gated → 503/401.
-`CHN-13` `POST /projects/:id/channels/email/connect` → manage; requires project experimental `agentmail_email`; optional `connector_slug` scopes the inbox to one Email connector profile; disabled → 403, invalid AgentMail key → 502 or no configured key → 503; non-member 403/404.
+`CHN-13` `POST /projects/:id/channels/email/connect` → manage; requires project experimental `agentmail_email`; optional `connector_slug` scopes the inbox to one Email connector profile; optional existing `inbox_id` + `email` attaches an already-created AgentMail inbox; disabled → 403, invalid AgentMail key → 502 or no configured key → 503; non-member 403/404.
 `CHN-14` `GET /projects/:id/channels/email/installation` → read → 200 null/summary for default or requested `connector_slug`; non-member 403/404.
 `CHN-15` `DELETE /projects/:id/channels/email/installation` → manage → 200 for default or requested `connector_slug`; non-member 403/404.
-`CHN-16` `POST /webhooks/email/agentmail` → public; unsigned local/unconfigured may 200, configured bad sig → 401, production without signing → 503.
+`CHN-16` `POST /webhooks/email/agentmail` → public; accepts AgentMail's unwrapped message payload shape; unsigned local/unconfigured may 200, configured bad sig → 401, production without signing → 503.
 `CHN-17` `GET /projects/:id/channels/email/mode` → read → 200 mode with enabled flag; non-member 403/404.
 `Q-5` `GET /queue/sessions/:sid` (unknown) → 200 empty; ANON → 401.
 `Q-6` enqueue → move-up/down + DELETE /messages/:mid → DELETE /sessions/:sid → 200.


### PR DESCRIPTION
## Summary
- Accept AgentMail's real unwrapped inbound payload shape instead of silently ACKing and dropping it.
- Route both message.received and message.received.unauthenticated through the Email session lifecycle.
- Subscribe new AgentMail webhooks to both inbound event types.
- Add an existing-inbox attach option in the Email connector profile for inbox-cap recovery / pre-created mailboxes.

## Verification
- KORTIX_URL=https://dev-api.kortix.com pnpm exec dotenvx run -f apps/api/.env -- bun test apps/api/src/__tests__/unit-email-channel.test.ts
- bun test apps/web/src/components/projects/customize/sections/connectors-view.slack-channel.test.ts
- pnpm exec eslint src/components/projects/customize/sections/connectors-view.tsx src/hooks/channels/use-channels-installations.ts --max-warnings=0 (from apps/web)
- pnpm exec tsc --noEmit --pretty false (from apps/api)
- Live dev repro before fix: POST https://dev-api.kortix.com/v1/webhooks/email/agentmail with AgentMail's unwrapped message.received shape returned 200 {ok:true}, proving the deployed handler ACKs before signature/dispatch.

## Notes
AgentMail account currently has 3/3 inboxes, so creating a fresh managed inbox returns LimitExceededError. This PR adds existing-inbox attach so the channel can be tested/recovered without deleting a mailbox.