### PR TITLE
fix(billing): point staging Stripe catalog at the main test account

### DIFF
--- a/apps/api/src/__tests__/billing/webhooks.test.ts
+++ b/apps/api/src/__tests__/billing/webhooks.test.ts
@@ -273,7 +273,7 @@ describe('subscription changes', () => {
     const sub = createMockStripeSubscription({
       metadata: { account_id: 'acc_test_123' },
       items: {
-        data: [{ id: 'si_123', price: { id: 'price_1T7yiuG6CaZppiKc7VsgnlKI' } }],
+        data: [{ id: 'si_123', price: { id: 'price_1TeyA7G6l1KZGqIr7ZhEpoVm' } }],
       },
     });
     const event = createMockStripeEvent('customer.subscription.updated', sub);

--- a/apps/api/src/billing/services/tiers.ts
+++ b/apps/api/src/billing/services/tiers.ts
@@ -417,15 +417,18 @@ const STRIPE_PRICES_PROD: StripePriceConfig = {
   computeProductId: 'prod_SCl7AQ2C8kK1CD', // TODO: create prod compute product
 };
 
+// Staging shares the MAIN Kortix Stripe account TEST mode (acct_1R5BVvG6l1KZGqIr)
+// — the same test sandbox as STRIPE_PRICES_DEV, which is the account staging's
+// deployed STRIPE_SECRET_KEY (sk_test_…) actually points at. The subscription
+// price + product ids therefore mirror the dev test catalog. The older
+// …G6CaZppiKc ids lived in a different account and 404 ("No such price") under
+// the staging key, which broke Pro/per-seat checkout creation. The credit ids
+// below are main-account test ids and already resolve.
 const STRIPE_PRICES_STAGING: StripePriceConfig = {
   subscriptions: {
     free: { monthly: 'price_1RIGvuG6l1KZGqIrw14abxeL' },
-    pro: { monthly: 'price_1T7yiuG6CaZppiKc7VsgnlKI' },
-    // Billing v2 — $40/month per-seat in the staging Stripe account (acct_…G6CaZppiKc),
-    // the same account the staging customers + their legacy subs live in (so the
-    // migration can actually find/cancel them). The old …G6l1KZGqIr price was in a
-    // different account and is being deprecated.
-    per_seat: { monthly: 'price_1TdyscG6CaZppiKcilrApKgB' },
+    pro: { monthly: 'price_1TeyA7G6l1KZGqIr7ZhEpoVm' },
+    per_seat: { monthly: 'price_1TeyA7G6l1KZGqIrTb2DKGS0' }, // test "Kortix seat" $40/mo
   },
   credits: {
     10: 'price_1RxXOvG6l1KZGqIrMqsiYQvk',
@@ -435,8 +438,8 @@ const STRIPE_PRICES_STAGING: StripePriceConfig = {
     250: 'price_1RxmO6G6l1KZGqIrBF8Kx87G',
     500: 'price_1RxmOFG6l1KZGqIrn4wgORnH',
   },
-  productId: 'prod_U3CxqRenahYVvj',
-  computeProductId: 'prod_U6B5Gh1aMPdnLO',
+  productId: 'prod_UeGhOr4r0v9gna',
+  computeProductId: 'prod_UeGh9sa2UA2wRR',
 };
 
 // Local-dev Stripe TEST-mode sandbox. Every id here lives in the test mode of
@@ -513,7 +516,7 @@ function registerPriceId(priceId: string, tierName: string) {
 }
 
 function initPriceIdMap() {
-  for (const priceConfig of [STRIPE_PRICES_PROD, STRIPE_PRICES_STAGING]) {
+  for (const priceConfig of [STRIPE_PRICES_PROD, STRIPE_PRICES_STAGING, STRIPE_PRICES_DEV]) {
     for (const [tierName, tierPrices] of Object.entries(priceConfig.subscriptions)) {
       if (tierPrices.monthly) registerPriceId(tierPrices.monthly, tierName);
       if (tierPrices.yearly) registerPriceId(tierPrices.yearly, tierName);
@@ -537,7 +540,7 @@ export function getTierByPriceId(priceId: string): TierConfig | null {
 export function getBillingPeriodByPriceId(
   priceId: string,
 ): 'monthly' | 'yearly' | 'yearly_commitment' | null {
-  for (const priceConfig of [STRIPE_PRICES_PROD, STRIPE_PRICES_STAGING]) {
+  for (const priceConfig of [STRIPE_PRICES_PROD, STRIPE_PRICES_STAGING, STRIPE_PRICES_DEV]) {
     for (const tierPrices of Object.values(priceConfig.subscriptions)) {
       if (tierPrices.monthly === priceId) return 'monthly';
       if (tierPrices.yearly === priceId) return 'yearly';


### PR DESCRIPTION
## Why
Investigating a report that **Stripe checkouts don't work on dev.kortix.com** uncovered that **dev and staging Stripe billing were both broken end-to-end**. Root cause was in *infra* (no enabled Stripe webhook endpoints); this PR fixes the remaining *code* half for **staging**.

## Infra already applied (live, verified — not in this PR)
Same Stripe account `acct_1R5BVvG6l1KZGqIr`, **test mode**, has had **no enabled webhook endpoint** since the dev API moved to EKS — the only endpoint pointed at the now-dead `computer-preview-api.kortix.com` and was disabled. So completed checkouts fired `checkout.session.completed` to nobody → tiers/credits never activated.

- ✅ Created enabled test-mode endpoint → `https://dev-api.kortix.com/v1/billing/webhooks/stripe` (8 events) + rotated `STRIPE_WEBHOOK_SECRET` in AWS Secrets Manager `kortix-dev-env` + rolled `kortix-dev/kortix-api`. Verified: valid sig → `200 {received:true}`, bad sig → `400`.
- ✅ Same for staging → `https://staging-api.kortix.com/v1/billing/webhooks/stripe` + `kortix-staging-env` + rolled `kortix-staging/kortix-api`. Verified `200`/`400`.

## What this PR changes (the staging *price* half)
Staging's deployed `STRIPE_SECRET_KEY` is a **main-account test key**, but `STRIPE_PRICES_STAGING.pro` / `.per_seat` + `productId` / `computeProductId` referenced a different account (`…G6CaZppiKc`) that **404s under the staging key** → Pro/per-seat checkout failed at *session creation* on staging. Verified via Stripe API: `pro`, `per_seat`, both products → `No such price/product`; `free` + all 6 credit ids → resolve fine.

- Repoint staging `pro` / `per_seat` / `productId` / `computeProductId` to the active main-account **test** catalog (mirrors `STRIPE_PRICES_DEV`).
- Register `STRIPE_PRICES_DEV` in `initPriceIdMap()` / `getBillingPeriodByPriceId()` (they only iterated PROD + STAGING) so webhook price→tier fallback resolves on dev/staging too.

## Tests
`apps/api/src/__tests__/billing/webhooks.test.ts` → **47/47 pass**. Full billing suite is unchanged (162 pass / 21 pre-existing cross-file-pollution fails, identical with and without this change). Updated the one test that hardcoded the old staging pro id to the current pro test id.

## Deploy note
Dev is fully live already (dev prices were always correct). **Staging Pro/per-seat checkout-creation stays broken until this merges to `main` (dev) and is promoted to staging.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)