### PR TITLE
Fix Email inbox binding ownership

### DIFF
--- a/apps/api/src/channels/install-store.ts
+++ b/apps/api/src/channels/install-store.ts
@@ -238,6 +238,14 @@ export async function saveAgentMailInstall(
       );
   }
   await db
+    .delete(chatInstalls)
+    .where(
+      and(
+        eq(chatInstalls.platform, "email"),
+        eq(chatInstalls.workspaceId, input.inboxId),
+      ),
+    );
+  await db
     .insert(chatInstalls)
     .values({ platform: "email", workspaceId: input.inboxId, projectId })
     .onConflictDoNothing({


### PR DESCRIPTION
## Summary
- Ensure an AgentMail inbox has only one active Email chat install binding before inserting the new project/profile binding.
- This prevents existing-inbox attach from resolving webhook signatures against an older project secret when the same AgentMail inbox was previously attached elsewhere.

## Verification
- KORTIX_URL=https://dev-api.kortix.com pnpm exec dotenvx run -f apps/api/.env -- bun test apps/api/src/__tests__/unit-email-channel.test.ts
- pnpm exec tsc --noEmit --pretty false (from apps/api)

## Live finding
Actual AgentMail delivery reached /v1/webhooks/email/agentmail on dev but returned 401 because the same existing inbox had multiple chat_installs rows from earlier attach attempts, causing project-secret ambiguity. This patch makes the binding single-owner for Email inboxes.