### PR TITLE
fix(web): move sandbox template picker inline into composer toolbar

### DIFF
--- a/apps/web/src/features/co-worker/project-layout/project-home.tsx
+++ b/apps/web/src/features/co-worker/project-layout/project-home.tsx
@@ -157,7 +157,7 @@ export function ProjectHome({
             'autoFeaturesCoWorkerProjectLayoutProjectHomeJsxAttrPlaceholder115e6c2d',
           )}
           prefill={prefill}
-          inputSlot={
+          toolbarSlot={
             showSandboxPicker ? (
               <SandboxPicker
                 items={sandboxItems}
@@ -322,18 +322,17 @@ function SandboxPicker({
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button
+        <button
           type="button"
           aria-label={tI18nHardcoded.raw(
             'autoFeaturesCoWorkerProjectLayoutProjectHomeJsxAttrAria4acf4ecd',
           )}
-          variant="secondary"
-          size="sm"
+          className="text-muted-foreground hover:text-foreground hover:bg-muted inline-flex h-8 cursor-pointer items-center gap-1.5 rounded-full px-2.5 text-xs font-medium transition-colors duration-200"
         >
-          <ActiveIcon className="size-3.5" />
-          <span className="max-w-[10rem] truncate">{active.name}</span>
-          <span className={cn('size-1.5 rounded-full', activeStateTone)} />
-        </Button>
+          <ActiveIcon className="size-3.5 shrink-0" />
+          <span className="max-w-[7rem] truncate">{active.name}</span>
+          <span className={cn('size-1.5 shrink-0 rounded-full', activeStateTone)} />
+        </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start" className="w-80">
         <DropdownMenuLabel>

--- a/apps/web/src/features/session/composer-chat-input.tsx
+++ b/apps/web/src/features/session/composer-chat-input.tsx
@@ -41,6 +41,7 @@ export function ComposerChatInput({
   placeholder,
   prefill,
   inputSlot,
+  toolbarSlot,
 }: {
   onSend: (text: string, files: AttachedFile[] | undefined, options: ComposerOptions) => void;
   onCommand?: (command: Command, args: string | undefined, options: ComposerOptions) => void;
@@ -52,6 +53,7 @@ export function ComposerChatInput({
   placeholder?: string;
   prefill?: { text: string; id: number } | null;
   inputSlot?: ReactNode;
+  toolbarSlot?: ReactNode;
 }) {
   const { data: agents } = useOpenCodeAgents({ projectId });
   const { data: providers } = useOpenCodeProviders();
@@ -78,6 +80,7 @@ export function ComposerChatInput({
       placeholder={placeholder}
       prefill={prefill}
       inputSlot={inputSlot}
+      toolbarSlot={toolbarSlot}
       sessionId={sessionId}
       providers={providers}
       agents={local.agent.list}

--- a/apps/web/src/features/session/session-chat-input.tsx
+++ b/apps/web/src/features/session/session-chat-input.tsx
@@ -1442,6 +1442,9 @@ export interface SessionChatInputProps {
   /** Slot rendered inside the input card, above the textarea (e.g. queue chip) */
   inputSlot?: React.ReactNode;
 
+  /** Slot rendered inline in the bottom toolbar, just left of the voice button */
+  toolbarSlot?: React.ReactNode;
+
   /** Reply context — shows a banner in the input indicating what's being replied to */
   replyTo?: { text: string } | null;
   /** Callback to clear the reply context */
@@ -1514,6 +1517,7 @@ export function SessionChatInput({
   threadContext,
   onContextClick,
   inputSlot,
+  toolbarSlot,
   replyTo,
   onClearReply,
   lockForQuestion = false,
@@ -2554,6 +2558,8 @@ export function SessionChatInput({
                 selectedModel={selectedModel}
                 onContextClick={onContextClick}
               />
+
+              {toolbarSlot}
 
               <VoiceRecorder onTranscription={handleTranscription} disabled={disabled || isBusy} />
 


### PR DESCRIPTION
## What

On the project home (project index) composer, the **sandbox template picker** rendered as a full-width "Default" bar above the input that didn't fit the composer style:

It was passed as the composer `inputSlot`, which renders inside a vertical `flex flex-col` chip stack above the textarea. Flexbox's default `align-items: stretch` made the trigger button span the full width and center its label.

## Change

- Add a dedicated `toolbarSlot` to `SessionChatInput` (threaded through `ComposerChatInput`) that renders **inline in the bottom toolbar, just left of the voice/microphone button**.
- Move `project-home`'s `SandboxPicker` from `inputSlot` → `toolbarSlot`.
- Restyle the picker trigger as a **minimal ghost pill** (`h-8 rounded-full`, muted-foreground, hover bg) matching the neighbouring agent/model/variant selectors. Icon + truncated name + build-state dot.
- `inputSlot` keeps its full-width semantics (still used for the session question prompt).

## Scope

The picker is project-scoped (`listProjectSandboxes(projectId)`) and only the project-home composer renders it, so it stays confined to the project index page — it does not appear in active sessions or the new-project dashboard composer (which has no project context).

## Verification

- `tsc --noEmit`: no errors in changed files.
- Biome: no new diagnostics vs baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)