### PR TITLE
fix: pin email channel executor calls to session inbox

### DIFF
--- a/apps/api/src/__tests__/unit-executor-channels.test.ts
+++ b/apps/api/src/__tests__/unit-executor-channels.test.ts
@@ -230,6 +230,7 @@ const EMAIL: GatewayConnector = {
   connectorId: 'conn-email',
   slug: EMAIL_CHANNEL_CONNECTOR_SLUG,
   provider: 'channel',
+  platform: 'email',
   baseUrl: 'https://api.agentmail.to/v0',
   auth: { type: 'bearer', in: 'header', name: null, prefix: null },
   hasAuth: true,
@@ -417,6 +418,58 @@ describe('handleCall — channel (email)', () => {
     expect(call.url).toBe('https://api.agentmail.to/v0/inboxes/inb_1/messages/msg_1/reply');
     expect(call.method).toBe('POST');
     expect(call.headers.Authorization).toBe('Bearer am_project_token');
+    expect(JSON.parse(expectDefined(call.body))).toEqual({ text: 'Thanks' });
+  });
+
+  test('email-originated sessions pin profile-specific calls to the active AgentMail inbox', async () => {
+    const staleProfileConnector: GatewayConnector = {
+      ...EMAIL,
+      connectorId: 'conn-email-stale-profile',
+      slug: 'email_old_profile',
+    };
+    const fetchCalls: Array<{
+      url: string;
+      method: string;
+      headers: Record<string, string>;
+      body?: string;
+    }> = [];
+    const deps: GatewayDeps = {
+      loadConnectorBySlug: async (_projectId, slug) =>
+        slug === 'email_old_profile' ? staleProfileConnector : null,
+      loadAction: async (connectorId, relPath) =>
+        connectorId === staleProfileConnector.connectorId && relPath === 'reply_message'
+          ? EMAIL_REPLY
+          : null,
+      resolveCredential: async () => 'am_stale_profile_token',
+      loadEmailSessionContext: async () => ({
+        inboxId: 'inb_active',
+        threadId: 'thr_active',
+        messageId: 'msg_active',
+      }),
+      resolveEmailCredentialForInbox: async (_projectId, inboxId) =>
+        inboxId === 'inb_active' ? 'am_active_inbox_token' : null,
+      loadPolicies: async () => [],
+      loadProjectPolicies: async () => [],
+      loadDefaultMode: async () => 'allow_all',
+      recordExecution: async () => {},
+      fetchImpl: async (url, init) => {
+        fetchCalls.push({ url, ...init });
+        return { status: 200, ok: true, text: async () => '{"message_id":"msg-reply"}' };
+      },
+    };
+
+    const res = await handleCall(deps, {
+      ...input,
+      connectorSlug: 'email_old_profile',
+      actionPath: 'reply_message',
+      args: { inbox_id: 'inb_deleted', message_id: 'msg_deleted', text: 'Thanks' },
+    });
+
+    expect(res.status).toBe('ok');
+    expect(fetchCalls).toHaveLength(1);
+    const call = expectDefined(fetchCalls[0]);
+    expect(call.url).toBe('https://api.agentmail.to/v0/inboxes/inb_active/messages/msg_active/reply');
+    expect(call.headers.Authorization).toBe('Bearer am_active_inbox_token');
     expect(JSON.parse(expectDefined(call.body))).toEqual({ text: 'Thanks' });
   });
 });

--- a/apps/api/src/channels/install-store.ts
+++ b/apps/api/src/channels/install-store.ts
@@ -399,6 +399,35 @@ export async function loadAgentMailApiKeyForProject(
   return readSecret(projectId, agentMailKeys(profileSlug).apiKey);
 }
 
+export async function loadAgentMailApiKeyForInbox(
+  projectId: string,
+  inboxId: string,
+): Promise<string | null> {
+  const rows = await db
+    .select({ name: projectSecrets.name, valueEnc: projectSecrets.valueEnc })
+    .from(projectSecrets)
+    .where(
+      and(
+        eq(projectSecrets.projectId, projectId),
+        like(projectSecrets.name, `${AGENTMAIL_INBOX_ID}%`),
+        isNull(projectSecrets.ownerUserId),
+      ),
+    );
+
+  for (const row of rows) {
+    let value: string | null = null;
+    try {
+      value = decryptProjectSecret(projectId, row.valueEnc);
+    } catch {
+      continue;
+    }
+    if (value !== inboxId) continue;
+    const suffix = row.name.slice(AGENTMAIL_INBOX_ID.length);
+    return readSecret(projectId, `${AGENTMAIL_API_KEY}${suffix}`);
+  }
+  return null;
+}
+
 export async function loadAgentMailWebhookSecretForProject(
   projectId: string,
 ): Promise<string | null> {

--- a/apps/api/src/executor/db-deps.ts
+++ b/apps/api/src/executor/db-deps.ts
@@ -14,6 +14,7 @@ import {
   executorExecutions,
   executorProjectPolicies,
   executorProjectSettings,
+  projectSessions,
   projects,
 } from '@kortix/db';
 import { db } from '../shared/db';
@@ -43,6 +44,7 @@ import { syncProjectConnectors } from './sync';
 import { executeComputerCall } from '../tunnel/core/rpc-core';
 import {
   loadAgentMailApiKeyForProject,
+  loadAgentMailApiKeyForInbox,
   loadAgentMailInstall,
   loadSlackInstall,
   loadSlackTokenForProject,
@@ -148,6 +150,7 @@ function toGatewayConnector(row: ConnectorRow, grants: Awaited<ReturnType<typeof
     connectorId: row.connectorId,
     slug: row.slug,
     provider: row.providerType,
+    platform: channelPlatform(row.config),
     baseUrl: baseUrlOf(row),
     auth,
     hasAuth,
@@ -203,6 +206,24 @@ function makeDbGatewayDeps(): GatewayDeps {
       }
       return resolveCredentialValue(connector.connectorId, userId);
     },
+    loadEmailSessionContext: async (projectId, sessionId) => {
+      const [row] = await db
+        .select({ metadata: projectSessions.metadata })
+        .from(projectSessions)
+        .where(and(eq(projectSessions.projectId, projectId), eq(projectSessions.sessionId, sessionId)))
+        .limit(1);
+      const email = (row?.metadata as Record<string, any> | undefined)?.email;
+      if (!email || typeof email !== 'object') return null;
+      const inboxId = typeof email.inbox_id === 'string' ? email.inbox_id : null;
+      if (!inboxId) return null;
+      return {
+        inboxId,
+        threadId: typeof email.thread_id === 'string' ? email.thread_id : null,
+        messageId: typeof email.message_id === 'string' ? email.message_id : null,
+      };
+    },
+    resolveEmailCredentialForInbox: async (projectId, inboxId) =>
+      resolveAgentMailApiKey(await loadAgentMailApiKeyForInbox(projectId, inboxId)),
     loadPolicies: loadConnectorPoliciesFor,
     loadProjectPolicies: loadProjectPoliciesFor,
     loadDefaultMode: loadDefaultModeFor,

--- a/apps/api/src/executor/gateway.ts
+++ b/apps/api/src/executor/gateway.ts
@@ -31,6 +31,7 @@ export interface GatewayConnector {
   connectorId: string;
   slug: string;
   provider: 'pipedream' | 'mcp' | 'openapi' | 'graphql' | 'http' | 'channel' | 'computer';
+  platform?: string | null;
   /** server / base_url / endpoint / url, per provider (null for some). */
   baseUrl: string | null;
   auth: ExecutorAuth;
@@ -66,6 +67,12 @@ export interface ExecutionRecord {
   resultSummary: Record<string, unknown> | null;
 }
 
+export interface EmailSessionContext {
+  inboxId: string;
+  threadId?: string | null;
+  messageId?: string | null;
+}
+
 export interface GatewayDeps {
   loadConnectorBySlug(projectId: string, slug: string): Promise<GatewayConnector | null>;
   loadAction(connectorId: string, relPath: string): Promise<GatewayAction | null>;
@@ -76,6 +83,10 @@ export interface GatewayDeps {
    * install token) without re-querying.
    */
   resolveCredential(connector: GatewayConnector, userId: string | null): Promise<string | null>;
+  /** Email-originated sessions pin native Email channel calls to the inbound inbox/thread. */
+  loadEmailSessionContext?(projectId: string, sessionId: string): Promise<EmailSessionContext | null>;
+  /** Resolve the AgentMail credential for the install that owns this inbox. */
+  resolveEmailCredentialForInbox?(projectId: string, inboxId: string): Promise<string | null>;
   /** Connector-scoped policies (relative patterns over the connector's tool paths). */
   loadPolicies(connectorId: string): Promise<Policy[]>;
   /** Project-scoped policies (fully-qualified patterns over <slug>.<path>). */
@@ -188,6 +199,7 @@ async function connectorUsable(
   deps: GatewayDeps,
   connector: GatewayConnector,
   subject: ShareSubject,
+  credentialOverride?: string | null,
 ): Promise<{ ok: true; secret: string | null } | { ok: false; reason: string }> {
   // 1. Access — who can use this connector.
   if (!isSecretUsableBy(connector.shareScope, connector.grants, subject)) {
@@ -195,10 +207,49 @@ async function connectorUsable(
   }
   // 2. Credential — none needed (public), shared, or this member's own (per_user).
   if (!connector.hasAuth) return { ok: true, secret: null };
+  if (credentialOverride != null) return { ok: true, secret: credentialOverride };
   const userId = connector.credentialMode === 'per_user' ? subject.userId : null;
   const secret = await deps.resolveCredential(connector, userId);
   if (secret == null) return { ok: false, reason: 'needs_auth' };
   return { ok: true, secret };
+}
+
+async function resolveEmailExecutionContext(
+  deps: GatewayDeps,
+  input: CallInput,
+  connector: GatewayConnector,
+): Promise<{ args: Record<string, unknown>; secretOverride: string | null }> {
+  const args = { ...(input.args ?? {}) };
+  if (
+    connector.provider !== 'channel' ||
+    connector.platform !== 'email' ||
+    !EMAIL_CHANNEL_ACTIONS.has(input.actionPath) ||
+    !input.sessionId ||
+    !deps.loadEmailSessionContext
+  ) {
+    return { args, secretOverride: null };
+  }
+
+  const context = await deps.loadEmailSessionContext(input.projectId, input.sessionId);
+  if (!context?.inboxId) return { args, secretOverride: null };
+
+  args.inbox_id = context.inboxId;
+  if ((input.actionPath === 'get_thread') && context.threadId) {
+    args.thread_id = context.threadId;
+  }
+  if (
+    (input.actionPath === 'reply_message' ||
+      input.actionPath === 'reply_all_message' ||
+      input.actionPath === 'get_message') &&
+    context.messageId
+  ) {
+    args.message_id = context.messageId;
+  }
+
+  const secretOverride = deps.resolveEmailCredentialForInbox
+    ? await deps.resolveEmailCredentialForInbox(input.projectId, context.inboxId)
+    : null;
+  return { args, secretOverride };
 }
 
 /** Run one executor call through the full gateway path. */
@@ -218,13 +269,22 @@ export async function handleCall(deps: GatewayDeps, input: CallInput): Promise<C
     return { status: 'denied', reason: 'action_not_found' };
   }
 
-  const usable = await connectorUsable(deps, connector, input.subject);
+  const emailExecution = await resolveEmailExecutionContext(deps, input, connector);
+  const usable = await connectorUsable(
+    deps,
+    connector,
+    input.subject,
+    emailExecution.secretOverride,
+  );
   if (!usable.ok) {
     await audit(deps, input, connector.connectorId, 'denied', action.risk, {
       reason: usable.reason,
     });
     return { status: 'denied', reason: usable.reason };
   }
+
+  const executionArgs = emailExecution.args;
+  const executionSecret = usable.secret;
 
   // Layered policy enforcement: project policies first → connector → risk default.
   if (deps.enforcePolicies !== false) {
@@ -265,7 +325,7 @@ export async function handleCall(deps: GatewayDeps, input: CallInput): Promise<C
         throw new Error(`computer connector has unexpected binding kind "${action.binding.kind}"`);
       }
       if (!deps.executeComputerCall) throw new Error('computer runner not wired');
-      const { computer: selectorRaw, ...rest } = input.args ?? {};
+      const { computer: selectorRaw, ...rest } = executionArgs;
       const selector = typeof selectorRaw === 'string' && selectorRaw.trim() ? selectorRaw.trim() : null;
       const outcome = await deps.executeComputerCall({
         accountId: input.accountId,
@@ -308,7 +368,7 @@ export async function handleCall(deps: GatewayDeps, input: CallInput): Promise<C
           connectorSlug: input.connectorSlug,
           app: b.app,
           actionKey: b.actionKey,
-          args: input.args ?? {},
+          args: executionArgs,
           accountId: usable.secret, // the resolved binding = Pipedream account id
           userId,
         });
@@ -318,7 +378,7 @@ export async function handleCall(deps: GatewayDeps, input: CallInput): Promise<C
           projectId: input.projectId,
           connectorSlug: input.connectorSlug,
           app: b.app,
-          args: input.args ?? {},
+          args: executionArgs,
           accountId: usable.secret,
           userId,
         });
@@ -330,8 +390,8 @@ export async function handleCall(deps: GatewayDeps, input: CallInput): Promise<C
         binding: action.binding,
         baseUrl: connector.baseUrl,
         auth: connector.auth,
-        secret: usable.secret,
-        args: input.args ?? {},
+        secret: executionSecret,
+        args: executionArgs,
         paramHints: paramHintsFromSchema(action.inputSchema),
         fetchImpl: deps.fetchImpl,
       });


### PR DESCRIPTION
## Summary
- Pin native Email channel executor calls from Email-originated sessions to the session inbox/thread/message context.
- Resolve the AgentMail credential from the install that owns the active inbox, so managed and BYO multi-inbox profiles work even if the model calls a stale profile namespace.
- Add a regression test for profile-specific Email calls using stale inbox/message args.

## Tests
- KORTIX_URL=https://dev-api.kortix.com pnpm exec dotenvx run -f apps/api/.env -- bun test apps/api/src/__tests__/unit-executor-channels.test.ts apps/api/src/__tests__/unit-email-channel.test.ts
- cd apps/api && pnpm exec tsc --noEmit --pretty false

Note: ESLint could not run in this checkout because ESLint 9 could not find an eslint.config.* file.