### PR TITLE
chore(dev-eks): deploy dev-4a456508 [skip ci]

### DIFF
--- a/infra/k8s/envs/dev/values.yaml
+++ b/infra/k8s/envs/dev/values.yaml
@@ -6,7 +6,7 @@
 # Immutable dev tag (CI bumps to dev-<sha8> on each main push). Bootstrap value
 # is :dev-latest until the first deploy-dev-eks run pins an immutable sha.
 image:
-  tag: "dev-a634ac8b"
+  tag: "dev-4a456508"
 kortixVersion: ""
 env:
   internalKortixEnv: dev


### PR DESCRIPTION
GitOps bump for the API image built locally for Email channel verification: kortix/kortix-api:dev-4a456508.