### PR TITLE
feat(web): attach pasted images (Cmd+V) in the composer

### DIFF
--- a/apps/web/src/features/session/clipboard-files.test.ts
+++ b/apps/web/src/features/session/clipboard-files.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from 'bun:test';
+
+import { type ClipboardItemLike, extractClipboardFiles } from './clipboard-files';
+
+function png(name = 'image.png'): File {
+  return new File([new Uint8Array([1, 2, 3])], name, { type: 'image/png' });
+}
+
+function fileItem(file: File | null): ClipboardItemLike {
+  return { kind: 'file', getAsFile: () => file };
+}
+
+function stringItem(): ClipboardItemLike {
+  return { kind: 'string', getAsFile: () => null };
+}
+
+describe('extractClipboardFiles', () => {
+  test('returns files from the files list (copied image / screenshot paste)', () => {
+    const file = png();
+    const result = extractClipboardFiles({ files: [file], items: [] });
+    expect(result).toEqual([file]);
+  });
+
+  test('falls back to file items when the files list is empty', () => {
+    const file = png('screenshot.png');
+    const result = extractClipboardFiles({ files: [], items: [fileItem(file)] });
+    expect(result).toEqual([file]);
+  });
+
+  test('prefers the files list and does not double-count items', () => {
+    const file = png();
+    const result = extractClipboardFiles({ files: [file], items: [fileItem(file)] });
+    expect(result).toEqual([file]);
+  });
+
+  test('ignores non-file items and null getAsFile results', () => {
+    const result = extractClipboardFiles({
+      files: [],
+      items: [stringItem(), fileItem(null)],
+    });
+    expect(result).toEqual([]);
+  });
+
+  test('returns an empty array for a plain-text paste (no files, no file items)', () => {
+    expect(extractClipboardFiles({ files: [], items: [stringItem()] })).toEqual([]);
+  });
+
+  test('returns an empty array when the clipboard payload is missing', () => {
+    expect(extractClipboardFiles(null)).toEqual([]);
+    expect(extractClipboardFiles(undefined)).toEqual([]);
+  });
+
+  test('keeps every pasted file when multiple are present', () => {
+    const a = png('a.png');
+    const b = png('b.png');
+    expect(extractClipboardFiles({ files: [a, b], items: [] })).toEqual([a, b]);
+  });
+});

--- a/apps/web/src/features/session/clipboard-files.ts
+++ b/apps/web/src/features/session/clipboard-files.ts
@@ -1,0 +1,26 @@
+export interface ClipboardItemLike {
+  readonly kind: string;
+  getAsFile(): File | null;
+}
+
+export interface ClipboardPayload {
+  readonly files: ArrayLike<File>;
+  readonly items: ArrayLike<ClipboardItemLike>;
+}
+
+/**
+ * Pull pasted files off a clipboard payload. Prefers the `files` list — which
+ * covers copied image files and most screenshot pastes — and falls back to
+ * `items` of kind `'file'` for browsers that only expose a pasted image there.
+ * Returns an empty array for a plain-text paste so callers can let the browser
+ * handle the text itself.
+ */
+export function extractClipboardFiles(data: ClipboardPayload | null | undefined): File[] {
+  if (!data) return [];
+  const fromFiles = Array.from(data.files);
+  if (fromFiles.length > 0) return fromFiles;
+  return Array.from(data.items)
+    .filter((item) => item.kind === 'file')
+    .map((item) => item.getAsFile())
+    .filter((file): file is File => file !== null);
+}

--- a/apps/web/src/features/session/session-chat-input.tsx
+++ b/apps/web/src/features/session/session-chat-input.tsx
@@ -53,6 +53,7 @@ import {
   useOpenCodeSessionTodo,
 } from '@/hooks/opencode/use-opencode-sessions';
 import { AnimatePresence, motion } from 'motion/react';
+import { extractClipboardFiles } from './clipboard-files';
 import { ModelSelector } from './model-selector';
 
 import {
@@ -1824,6 +1825,18 @@ export function SessionChatInput({
     [appendAttachedFiles, disabled, lockForQuestion, dragHasFiles],
   );
 
+  const handlePaste = useCallback(
+    (e: React.ClipboardEvent<HTMLTextAreaElement>) => {
+      if (disabled || lockForQuestion) return;
+      const files = extractClipboardFiles(e.clipboardData);
+      // No files on the clipboard — let the browser handle the text paste.
+      if (files.length === 0) return;
+      e.preventDefault();
+      appendAttachedFiles(files);
+    },
+    [appendAttachedFiles, disabled, lockForQuestion],
+  );
+
   const removeAttachedFile = (index: number) => {
     setAttachedFiles((prev) => {
       const removed = prev[index];
@@ -2463,6 +2476,7 @@ export function SessionChatInput({
                 value={text}
                 onChange={handleInput}
                 onKeyDown={handleKeyDown}
+                onPaste={handlePaste}
                 onScroll={() => {
                   if (highlightRef.current && textareaRef.current) {
                     highlightRef.current.scrollTop = textareaRef.current.scrollTop;


### PR DESCRIPTION
## What

You couldn't paste an image into the chat input. The composer supported the file picker and drag-and-drop, but the textarea had **no paste handler**, so copying an image (a screenshot, a copied image file, or "copy image" from a page) and hitting ⌘V did nothing.

## Change

- Add an `onPaste` handler to the composer textarea that pulls files off the clipboard and routes them through the **existing `appendAttachedFiles` pipeline** — the exact path drag-and-drop and the picker already use — so pasted images attach, preview, and send identically.
- Plain-text pastes are left untouched: the handler only calls `preventDefault()` when the clipboard actually carries files.
- Extraction logic is factored into a pure `extractClipboardFiles` helper: prefer `clipboardData.files` (copied image files + most screenshot pastes), fall back to `items` of kind `'file'` (browsers that only expose a pasted image there).

## Scope

Every composer surface (dashboard, project home, session thread) renders the shared `SessionChatInput`, so paste-to-attach now works in **all of them**.

## Tests

`clipboard-files.test.ts` — 7 cases covering: files list, items fallback, no double-counting, ignoring non-file/null items, plain-text passthrough, missing payload, and multiple files. All pass (`bun test`).

## Verification

- `bun test`: 7/7 pass.
- `tsc --noEmit`: no errors in changed files.
- Biome: no new diagnostics; new files fully clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)