### PR TITLE
fix: deliver email channel initial prompt

### DIFF
--- a/apps/api/src/__tests__/unit-email-channel.test.ts
+++ b/apps/api/src/__tests__/unit-email-channel.test.ts
@@ -204,9 +204,15 @@ describe("dispatchAgentMailEvent", () => {
         workspaceId: "inb-1",
         threadId: "thr-1",
       },
+      expect.objectContaining({
+        type: "deliver_prompt",
+        source: "email",
+        userId: "user-1",
+      }),
     ]);
+    expect(createCalls[0].postCreate[1].text).toContain("Need help");
     expect(createCalls[0].extraEnvVars.KORTIX_EMAIL_INBOX_ID).toBe("inb-1");
-    expect(createCalls[0].body.initial_prompt).toContain("Need help");
+    expect(createCalls[0].body.initial_prompt).toBeUndefined();
   });
 
   test("accepts AgentMail's unwrapped message.received payload without top-level thread metadata", async () => {
@@ -242,7 +248,7 @@ describe("dispatchAgentMailEvent", () => {
 
     expect(createCalls).toHaveLength(1);
     expect(createCalls[0].metadata.email.subject).toBe("Actual AgentMail payload");
-    expect(createCalls[0].body.initial_prompt).toContain("Thread ID:  thr-unwrapped");
+    expect(createCalls[0].postCreate[1].text).toContain("Thread ID:  thr-unwrapped");
   });
 
   test("routes unauthenticated inbound mail through the same sender policy and session path", async () => {

--- a/apps/api/src/channels/email/session.ts
+++ b/apps/api/src/channels/email/session.ts
@@ -174,6 +174,7 @@ async function createThreadSession(
     return;
   }
 
+  const initialPrompt = renderAgentPrompt(event, revived);
   const result = await emailSessionLifecycle.createSession({
     source: "email",
     project,
@@ -181,7 +182,6 @@ async function createThreadSession(
     body: {
       base_ref: project.defaultBranch,
       agent_name: "default",
-      initial_prompt: renderAgentPrompt(event, revived),
     },
     enforceAccountCap: false,
     queuePolicy: "on_backpressure",
@@ -192,6 +192,12 @@ async function createThreadSession(
         platform: "email",
         workspaceId: inboxId,
         threadId,
+      },
+      {
+        type: "deliver_prompt",
+        source: "email",
+        text: initialPrompt,
+        userId,
       },
     ],
     visibility: "project",

--- a/apps/api/src/projects/session-lifecycle/engine.ts
+++ b/apps/api/src/projects/session-lifecycle/engine.ts
@@ -442,6 +442,16 @@ async function applyPostCreateActions(input: {
           .onConflictDoNothing({
             target: [chatThreads.platform, chatThreads.workspaceId, chatThreads.threadId],
           });
+      } else if (action.type === 'deliver_prompt') {
+        const outcome = await continueSession({
+          source: action.source,
+          sessionId: input.sessionId,
+          text: action.text,
+          userId: action.userId ?? undefined,
+        });
+        if (outcome !== 'delivered') {
+          return { ok: false, error: `initial prompt delivery ${outcome}` };
+        }
       }
     }
     return { ok: true };

--- a/apps/api/src/projects/session-lifecycle/types.ts
+++ b/apps/api/src/projects/session-lifecycle/types.ts
@@ -23,6 +23,12 @@ export type SessionLifecyclePostCreateAction =
       platform: 'slack' | 'telegram' | string;
       workspaceId: string;
       threadId: string;
+    }
+  | {
+      type: 'deliver_prompt';
+      source: SessionInvocationSource;
+      text: string;
+      userId?: string | null;
     };
 
 export type SessionLifecycleStatus =


### PR DESCRIPTION
## Summary
- Deliver first email-channel prompts through the session lifecycle post-create path after binding the AgentMail thread
- Avoid relying on boot-time KORTIX_INITIAL_PROMPT for email sessions
- Cover the email webhook session creation behavior in unit tests

## Tests
- KORTIX_URL=https://dev-api.kortix.com pnpm exec dotenvx run -f apps/api/.env -- bun test apps/api/src/__tests__/unit-email-channel.test.ts apps/api/src/__tests__/unit-executor-channels.test.ts
- cd apps/api && pnpm exec tsc --noEmit --pretty false