### PR TITLE
fix: default email connectors to profile inbox

### DIFF
--- a/apps/api/src/__tests__/unit-executor-channels.test.ts
+++ b/apps/api/src/__tests__/unit-executor-channels.test.ts
@@ -128,6 +128,13 @@ describe('channelCatalog(email)', () => {
     expect(a.risk).toBe('write');
   });
 
+  test('profile-scoped actions do not require agents to supply inbox_id', () => {
+    expect(objectSchema(action('list_messages').inputSchema).required ?? []).not.toContain('inbox_id');
+    expect(objectSchema(action('list_threads').inputSchema).required ?? []).not.toContain('inbox_id');
+    expect(objectSchema(action('send_message').inputSchema).required ?? []).toEqual(['to']);
+    expect(objectSchema(action('reply_message').inputSchema).required ?? []).toEqual(['message_id']);
+  });
+
   test('api base + default slug', () => {
     expect(channelApiBase('email')).toBe('https://api.agentmail.to/v0');
     expect(channelDefaultSlug('email')).toBe(EMAIL_CHANNEL_CONNECTOR_SLUG);
@@ -262,6 +269,20 @@ const EMAIL_REPLY: GatewayAction = {
   },
   risk: 'write',
   binding: { kind: 'http', method: 'POST', path: '/inboxes/{inbox_id}/messages/{message_id}/reply' },
+};
+
+const EMAIL_LIST_MESSAGES: GatewayAction = {
+  path: 'email.list_messages',
+  relPath: 'list_messages',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      inbox_id: { 'x-in': 'path' },
+      limit: {},
+    },
+  },
+  risk: 'read',
+  binding: { kind: 'http', method: 'GET', path: '/inboxes/{inbox_id}/messages' },
 };
 
 function makeDeps(body: string, status = 200) {
@@ -471,5 +492,52 @@ describe('handleCall — channel (email)', () => {
     expect(call.url).toBe('https://api.agentmail.to/v0/inboxes/inb_active/messages/msg_active/reply');
     expect(call.headers.Authorization).toBe('Bearer am_active_inbox_token');
     expect(JSON.parse(expectDefined(call.body))).toEqual({ text: 'Thanks' });
+  });
+
+  test('email profile connector calls use the installed inbox instead of caller-provided inbox_id', async () => {
+    const profileConnector: GatewayConnector = {
+      ...EMAIL,
+      connectorId: 'conn-email-profile',
+      slug: 'email_fabian_u7vq',
+    };
+    const fetchCalls: Array<{
+      url: string;
+      method: string;
+      headers: Record<string, string>;
+      body?: string;
+    }> = [];
+    const deps: GatewayDeps = {
+      loadConnectorBySlug: async (_projectId, slug) =>
+        slug === 'email_fabian_u7vq' ? profileConnector : null,
+      loadAction: async (connectorId, relPath) =>
+        connectorId === profileConnector.connectorId && relPath === 'list_messages'
+          ? EMAIL_LIST_MESSAGES
+          : null,
+      resolveCredential: async () => 'am_profile_token',
+      loadEmailConnectorContext: async (_projectId, connectorSlug) =>
+        connectorSlug === 'email_fabian_u7vq' ? { inboxId: 'email-inbox@agentmail.to' } : null,
+      loadPolicies: async () => [],
+      loadProjectPolicies: async () => [],
+      loadDefaultMode: async () => 'allow_all',
+      recordExecution: async () => {},
+      fetchImpl: async (url, init) => {
+        fetchCalls.push({ url, ...init });
+        return { status: 200, ok: true, text: async () => '{"messages":[]}' };
+      },
+    };
+
+    const res = await handleCall(deps, {
+      ...input,
+      sessionId: null,
+      connectorSlug: 'email_fabian_u7vq',
+      actionPath: 'list_messages',
+      args: { inbox_id: 'email_fabian_u7vq', limit: 1 },
+    });
+
+    expect(res.status).toBe('ok');
+    expect(fetchCalls).toHaveLength(1);
+    const call = expectDefined(fetchCalls[0]);
+    expect(call.url).toBe('https://api.agentmail.to/v0/inboxes/email-inbox%40agentmail.to/messages?limit=1');
+    expect(call.headers.Authorization).toBe('Bearer am_profile_token');
   });
 });

--- a/apps/api/src/executor/channels.ts
+++ b/apps/api/src/executor/channels.ts
@@ -309,7 +309,7 @@ const EMAIL_ACTIONS: ChannelActionDef[] = [
       html: { type: 'string', description: 'HTML body.' },
       attachments: { type: 'array', description: 'Optional AgentMail send attachments.' },
     },
-    required: ['inbox_id', 'to'],
+    required: ['to'],
   },
   {
     path: 'reply_message',
@@ -329,7 +329,7 @@ const EMAIL_ACTIONS: ChannelActionDef[] = [
       html: { type: 'string', description: 'HTML body.' },
       attachments: { type: 'array', description: 'Optional AgentMail send attachments.' },
     },
-    required: ['inbox_id', 'message_id'],
+    required: ['message_id'],
   },
   {
     path: 'reply_all_message',
@@ -345,7 +345,7 @@ const EMAIL_ACTIONS: ChannelActionDef[] = [
       html: { type: 'string', description: 'HTML body.' },
       attachments: { type: 'array', description: 'Optional AgentMail send attachments.' },
     },
-    required: ['inbox_id', 'message_id'],
+    required: ['message_id'],
   },
   {
     path: 'list_messages',
@@ -358,7 +358,7 @@ const EMAIL_ACTIONS: ChannelActionDef[] = [
       inbox_id: { type: 'string', description: 'AgentMail inbox ID.' },
       limit: { type: 'number', description: 'Maximum messages to return.' },
     },
-    required: ['inbox_id'],
+    required: [],
   },
   {
     path: 'get_message',
@@ -371,7 +371,7 @@ const EMAIL_ACTIONS: ChannelActionDef[] = [
       inbox_id: { type: 'string', description: 'AgentMail inbox ID.' },
       message_id: { type: 'string', description: 'AgentMail message ID.' },
     },
-    required: ['inbox_id', 'message_id'],
+    required: ['message_id'],
   },
   {
     path: 'search_messages',
@@ -385,7 +385,7 @@ const EMAIL_ACTIONS: ChannelActionDef[] = [
       query: { type: 'string', description: 'Search query.' },
       limit: { type: 'number', description: 'Maximum messages to return.' },
     },
-    required: ['inbox_id', 'query'],
+    required: ['query'],
   },
   {
     path: 'list_threads',
@@ -398,7 +398,7 @@ const EMAIL_ACTIONS: ChannelActionDef[] = [
       inbox_id: { type: 'string', description: 'AgentMail inbox ID.' },
       limit: { type: 'number', description: 'Maximum threads to return.' },
     },
-    required: ['inbox_id'],
+    required: [],
   },
   {
     path: 'get_thread',
@@ -411,7 +411,7 @@ const EMAIL_ACTIONS: ChannelActionDef[] = [
       inbox_id: { type: 'string', description: 'AgentMail inbox ID.' },
       thread_id: { type: 'string', description: 'AgentMail thread ID.' },
     },
-    required: ['inbox_id', 'thread_id'],
+    required: ['thread_id'],
   },
   {
     path: 'get_message_attachment',
@@ -425,7 +425,7 @@ const EMAIL_ACTIONS: ChannelActionDef[] = [
       message_id: { type: 'string', description: 'AgentMail message ID.' },
       attachment_id: { type: 'string', description: 'AgentMail attachment ID.' },
     },
-    required: ['inbox_id', 'message_id', 'attachment_id'],
+    required: ['message_id', 'attachment_id'],
   },
 ];
 

--- a/apps/api/src/executor/db-deps.ts
+++ b/apps/api/src/executor/db-deps.ts
@@ -222,6 +222,10 @@ function makeDbGatewayDeps(): GatewayDeps {
         messageId: typeof email.message_id === 'string' ? email.message_id : null,
       };
     },
+    loadEmailConnectorContext: async (projectId, connectorSlug) => {
+      const install = await loadAgentMailInstall(projectId, connectorSlug).catch(() => null);
+      return install?.inboxId ? { inboxId: install.inboxId } : null;
+    },
     resolveEmailCredentialForInbox: async (projectId, inboxId) =>
       resolveAgentMailApiKey(await loadAgentMailApiKeyForInbox(projectId, inboxId)),
     loadPolicies: loadConnectorPoliciesFor,

--- a/apps/api/src/executor/gateway.ts
+++ b/apps/api/src/executor/gateway.ts
@@ -73,6 +73,10 @@ export interface EmailSessionContext {
   messageId?: string | null;
 }
 
+export interface EmailConnectorContext {
+  inboxId: string;
+}
+
 export interface GatewayDeps {
   loadConnectorBySlug(projectId: string, slug: string): Promise<GatewayConnector | null>;
   loadAction(connectorId: string, relPath: string): Promise<GatewayAction | null>;
@@ -85,6 +89,8 @@ export interface GatewayDeps {
   resolveCredential(connector: GatewayConnector, userId: string | null): Promise<string | null>;
   /** Email-originated sessions pin native Email channel calls to the inbound inbox/thread. */
   loadEmailSessionContext?(projectId: string, sessionId: string): Promise<EmailSessionContext | null>;
+  /** Email connector profiles represent one installed AgentMail inbox. */
+  loadEmailConnectorContext?(projectId: string, connectorSlug: string): Promise<EmailConnectorContext | null>;
   /** Resolve the AgentMail credential for the install that owns this inbox. */
   resolveEmailCredentialForInbox?(projectId: string, inboxId: string): Promise<string | null>;
   /** Connector-scoped policies (relative patterns over the connector's tool paths). */
@@ -218,35 +224,41 @@ async function resolveEmailExecutionContext(
   deps: GatewayDeps,
   input: CallInput,
   connector: GatewayConnector,
+  connectorSlug: string,
 ): Promise<{ args: Record<string, unknown>; secretOverride: string | null }> {
   const args = { ...(input.args ?? {}) };
   if (
     connector.provider !== 'channel' ||
     connector.platform !== 'email' ||
-    !EMAIL_CHANNEL_ACTIONS.has(input.actionPath) ||
-    !input.sessionId ||
-    !deps.loadEmailSessionContext
+    !EMAIL_CHANNEL_ACTIONS.has(input.actionPath)
   ) {
     return { args, secretOverride: null };
   }
 
-  const context = await deps.loadEmailSessionContext(input.projectId, input.sessionId);
+  const sessionContext = input.sessionId && deps.loadEmailSessionContext
+    ? await deps.loadEmailSessionContext(input.projectId, input.sessionId)
+    : null;
+  const connectorContext = !sessionContext?.inboxId && deps.loadEmailConnectorContext
+    ? await deps.loadEmailConnectorContext(input.projectId, connectorSlug)
+    : null;
+  const context = sessionContext?.inboxId ? sessionContext : connectorContext;
   if (!context?.inboxId) return { args, secretOverride: null };
 
   args.inbox_id = context.inboxId;
-  if ((input.actionPath === 'get_thread') && context.threadId) {
+  if ('threadId' in context && (input.actionPath === 'get_thread') && context.threadId) {
     args.thread_id = context.threadId;
   }
   if (
     (input.actionPath === 'reply_message' ||
       input.actionPath === 'reply_all_message' ||
       input.actionPath === 'get_message') &&
+    'messageId' in context &&
     context.messageId
   ) {
     args.message_id = context.messageId;
   }
 
-  const secretOverride = deps.resolveEmailCredentialForInbox
+  const secretOverride = sessionContext?.inboxId && deps.resolveEmailCredentialForInbox
     ? await deps.resolveEmailCredentialForInbox(input.projectId, context.inboxId)
     : null;
   return { args, secretOverride };
@@ -269,7 +281,7 @@ export async function handleCall(deps: GatewayDeps, input: CallInput): Promise<C
     return { status: 'denied', reason: 'action_not_found' };
   }
 
-  const emailExecution = await resolveEmailExecutionContext(deps, input, connector);
+  const emailExecution = await resolveEmailExecutionContext(deps, input, connector, resolved.slug);
   const usable = await connectorUsable(
     deps,
     connector,


### PR DESCRIPTION
## Summary
- Default AgentMail channel calls to the installed inbox for the selected email connector profile
- Keep email-originated sessions pinned to their active inbound inbox/thread/message
- Stop advertising inbox_id as required for profile-scoped Email actions

## Verification
- KORTIX_URL=https://dev-api.kortix.com pnpm exec dotenvx run -f apps/api/.env -- bun test apps/api/src/__tests__/unit-executor-channels.test.ts apps/api/src/__tests__/unit-email-channel.test.ts
- cd apps/api && pnpm exec tsc --noEmit --pretty false

## Live investigation
- Dev project 241ea317-bf83-471f-ae6e-f828d45c5d40 has email_email_inbox_bjgk and email_fabian_u7vq active, both pointed at email-inbox@agentmail.to
- AgentMail direct probes for messages/threads on email-inbox@agentmail.to returned HTTP 200 with the stored profile key
