### PR TITLE
fix staging deploy dispatch path

### DIFF
--- a/.github/workflows/build-staging.yml
+++ b/.github/workflows/build-staging.yml
@@ -186,10 +186,10 @@ jobs:
   dispatch-deploy:
     name: Dispatch staging deploy
     needs: [version, build-api, build-gateway, build-frontend]
-    if: github.event_name == 'workflow_dispatch' && github.actor == 'github-actions[bot]'
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
-      - name: Start Deploy Staging for bot-dispatched build
+      - name: Start Deploy Staging for completed manual build
         env:
           GH_TOKEN: ${{ github.token }}
         run: |


### PR DESCRIPTION
Targeted staging PR for the build-staging dispatch cleanup. This keeps staging fixed-head and avoids staging unrelated active main commits.