### PR TITLE
fix(gateway): env-correct curl host + keyboard log viewer + session names

### DIFF
--- a/apps/api/src/llm-gateway/public-url.test.ts
+++ b/apps/api/src/llm-gateway/public-url.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from 'bun:test';
+
+import { publicGatewayBaseUrl } from './public-url';
+
+describe('publicGatewayBaseUrl', () => {
+  test('derives the public origin from the configured base url', () => {
+    expect(publicGatewayBaseUrl('https://gateway-dev.kortix.com/v1/llm')).toBe(
+      'https://gateway-dev.kortix.com',
+    );
+    expect(publicGatewayBaseUrl('https://gateway.kortix.com/v1/llm')).toBe(
+      'https://gateway.kortix.com',
+    );
+  });
+
+  test('returns null when unset or malformed', () => {
+    expect(publicGatewayBaseUrl(undefined)).toBeNull();
+    expect(publicGatewayBaseUrl(null)).toBeNull();
+    expect(publicGatewayBaseUrl('')).toBeNull();
+    expect(publicGatewayBaseUrl('not a url')).toBeNull();
+  });
+});

--- a/apps/api/src/llm-gateway/public-url.ts
+++ b/apps/api/src/llm-gateway/public-url.ts
@@ -1,0 +1,17 @@
+/**
+ * The public origin a customer should call the gateway at, derived from the
+ * environment's `LLM_GATEWAY_BASE_URL`
+ * (e.g. `https://gateway-dev.kortix.com/v1/llm` → `https://gateway-dev.kortix.com`).
+ *
+ * The frontend uses this to render an env-correct curl example on the API-keys
+ * screen instead of hardcoding the prod host. Returns null when unset (local
+ * dev) so callers can fall back gracefully.
+ */
+export function publicGatewayBaseUrl(raw: string | undefined | null): string | null {
+  if (!raw) return null;
+  try {
+    return new URL(raw).origin;
+  } catch {
+    return null;
+  }
+}

--- a/apps/api/src/projects/routes/gateway.ts
+++ b/apps/api/src/projects/routes/gateway.ts
@@ -12,6 +12,8 @@ import { loadProjectForUser, lookupEmailsByUserIds } from '../lib/access';
 import { projectsApp } from '../lib/app';
 import { UUID_V4_REGEX } from '../lib/serializers';
 import { createGatewayKey, listGatewayKeys, revokeGatewayKey } from '../../llm-gateway/gateway-keys';
+import { publicGatewayBaseUrl } from '../../llm-gateway/public-url';
+import { config } from '../../config';
 
 async function canDo(c: any, projectId: string, accountId: string, action: string): Promise<boolean> {
   const verdict = await authorize(
@@ -686,6 +688,9 @@ projectsApp.openapi(
     }
     const keys = await listGatewayKeys(projectId);
     return c.json({
+      // Env-correct public host (dev vs prod) so the UI's curl example points at
+      // the right gateway instead of a hardcoded one.
+      gateway_url: publicGatewayBaseUrl(config.LLM_GATEWAY_BASE_URL),
       keys: keys.map((k) => ({
         key_id: k.keyId,
         name: k.name,

--- a/apps/web/src/components/projects/gateway/gateway-keys.tsx
+++ b/apps/web/src/components/projects/gateway/gateway-keys.tsx
@@ -183,18 +183,28 @@ export function GatewayKeys({ projectId }: { projectId: string }) {
         </Dialog>
       )}
 
-      {created && <RevealKeyDialog created={created} onClose={() => setCreated(null)} />}
+      {created && (
+        <RevealKeyDialog
+          created={created}
+          gatewayUrl={data?.gateway_url ?? null}
+          onClose={() => setCreated(null)}
+        />
+      )}
     </div>
   );
 }
 
 function RevealKeyDialog({
   created,
+  gatewayUrl,
   onClose,
 }: {
   created: CreatedGatewayKey;
+  /** Env-correct public gateway origin (dev vs prod); falls back to prod. */
+  gatewayUrl: string | null;
   onClose: () => void;
 }) {
+  const base = gatewayUrl ?? 'https://gateway.kortix.com';
   const [copied, setCopied] = useState(false);
   const copy = () => {
     void navigator.clipboard.writeText(created.secret_key);
@@ -228,9 +238,9 @@ function RevealKeyDialog({
           <div>
             <div className="mb-1.5 text-xs font-medium text-muted-foreground">Use it</div>
             <pre className="overflow-x-auto rounded-xl border border-border/60 bg-muted/30 p-3 font-mono text-xs leading-relaxed text-foreground">
-{`curl https://gateway.kortix.com/v1/chat/completions \\
-  -H "Authorization: Bearer ${created.key_prefix}…" \\
-  -d '{"model":"claude-sonnet-4.6","messages":[...]}'`}
+{`curl ${base}/v1/chat/completions \\
+  -H "Authorization: Bearer ${created.secret_key}" \\
+  -d '{"model":"claude-sonnet-4.6","messages":[{"role":"user","content":"Hello"}]}'`}
             </pre>
           </div>
         </div>

--- a/apps/web/src/components/projects/gateway/gateway-logs.tsx
+++ b/apps/web/src/components/projects/gateway/gateway-logs.tsx
@@ -3,15 +3,18 @@
 import {
   Activity,
   ArrowLeft,
+  ChevronDown,
   ChevronRight,
+  ChevronUp,
   Clock,
   Coins,
   DollarSign,
   ScrollText,
 } from 'lucide-react';
-import { type ReactNode, useState } from 'react';
+import { forwardRef, type ReactNode, useEffect, useRef, useState } from 'react';
 
 import { EmptyState } from '@/components/ui/empty-state';
+import Hint from '@/components/ui/hint';
 import { useGatewayLog, useGatewayLogs } from '@/hooks/projects/use-project-gateway';
 import type { GatewayLogRow } from '@/lib/projects-gateway-client';
 import { cn } from '@/lib/utils';
@@ -49,13 +52,22 @@ const FILTERS: { key: 'all' | 'ok' | 'err'; label: string }[] = [
   { key: 'err', label: 'Errors' },
 ];
 
-function LogRow({ row, onClick }: { row: GatewayLogRow; onClick: () => void }) {
+const LogRow = forwardRef<
+  HTMLButtonElement,
+  { row: GatewayLogRow; focused: boolean; onClick: () => void; onHover: () => void }
+>(function LogRow({ row, focused, onClick, onHover }, ref) {
   const accent = modelAccent(row.requested_model || row.resolved_model);
   return (
     <button
+      ref={ref}
       type="button"
       onClick={onClick}
-      className="group grid w-full grid-cols-[auto_1fr_auto_auto_auto_auto] items-center gap-3 border-b border-border/40 px-4 py-2.5 text-left transition-colors duration-150 hover:bg-muted/50"
+      onMouseMove={onHover}
+      aria-current={focused ? 'true' : undefined}
+      className={cn(
+        'group grid w-full scroll-mt-2 grid-cols-[auto_1fr_auto_auto_auto_auto] items-center gap-3 border-b border-border/40 px-4 py-2.5 text-left transition-colors duration-150',
+        focused ? 'bg-primary/[0.06]' : 'hover:bg-muted/50',
+      )}
     >
       <span className="size-2 shrink-0 rounded-full" style={{ backgroundColor: accent }} />
       <div className="min-w-0">
@@ -78,11 +90,16 @@ function LogRow({ row, onClick }: { row: GatewayLogRow; onClick: () => void }) {
         <span className="w-16 text-right text-xs tabular-nums text-foreground">
           ${row.final_cost.toFixed(4)}
         </span>
-        <ChevronRight className="size-4 text-muted-foreground/40 transition-transform duration-150 group-hover:translate-x-0.5 group-hover:text-muted-foreground" />
+        <ChevronRight
+          className={cn(
+            'size-4 text-muted-foreground/40 transition-transform duration-150',
+            focused ? 'translate-x-0.5 text-muted-foreground' : 'group-hover:translate-x-0.5',
+          )}
+        />
       </span>
     </button>
   );
-}
+});
 
 function StatTile({
   icon: Icon,
@@ -134,20 +151,54 @@ function JsonBlock({ title, value }: { title: string; value: unknown }) {
   );
 }
 
+function NavButton({
+  icon: Icon,
+  label,
+  disabled,
+  onClick,
+}: {
+  icon: typeof ChevronUp;
+  label: string;
+  disabled: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <Hint label={label}>
+      <button
+        type="button"
+        onClick={onClick}
+        disabled={disabled}
+        aria-label={label}
+        className="flex size-7 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:pointer-events-none disabled:opacity-30"
+      >
+        <Icon className="size-4" />
+      </button>
+    </Hint>
+  );
+}
+
 function GatewayLogDetail({
   projectId,
   logId,
+  index,
+  total,
   onBack,
+  onPrev,
+  onNext,
 }: {
   projectId: string;
   logId: string;
+  index: number;
+  total: number;
   onBack: () => void;
+  onPrev: () => void;
+  onNext: () => void;
 }) {
   const { data, isLoading } = useGatewayLog(projectId, logId);
 
   return (
     <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
-      <div className="sticky top-0 z-10 flex items-center gap-2 border-b border-border/50 bg-background/95 px-4 py-2.5 backdrop-blur">
+      <div className="sticky top-0 z-10 flex items-center justify-between gap-2 border-b border-border/50 bg-background/95 px-4 py-2.5 backdrop-blur">
         <button
           type="button"
           onClick={onBack}
@@ -155,6 +206,18 @@ function GatewayLogDetail({
         >
           <ArrowLeft className="size-4" /> Logs
         </button>
+        <div className="flex items-center gap-1.5">
+          <span className="text-xs tabular-nums text-muted-foreground/70">
+            {index + 1} / {total}
+          </span>
+          <NavButton icon={ChevronUp} label="Previous (↑)" disabled={index <= 0} onClick={onPrev} />
+          <NavButton
+            icon={ChevronDown}
+            label="Next (↓)"
+            disabled={index >= total - 1}
+            onClick={onNext}
+          />
+        </div>
       </div>
       {isLoading || !data ? (
         <div className="space-y-3 p-5">
@@ -243,20 +306,95 @@ function GatewayLogDetail({
 export function GatewayLogs({ projectId }: { projectId: string }) {
   const [selectedLogId, setSelectedLogId] = useState<string | null>(null);
   const [filter, setFilter] = useState<'all' | 'ok' | 'err'>('all');
+  const [focused, setFocused] = useState(0);
   const { data, isLoading } = useGatewayLogs(
     projectId,
     filter === 'all' ? undefined : { ok: filter === 'ok' },
   );
   const logs = data?.logs ?? [];
 
-  if (selectedLogId)
+  // Keep focus in-bounds as the live list grows/shrinks or the filter changes.
+  useEffect(() => {
+    setFocused((i) => Math.min(i, Math.max(0, logs.length - 1)));
+  }, [logs.length]);
+  useEffect(() => setFocused(0), [filter]);
+
+  const focusedRowRef = useRef<HTMLButtonElement>(null);
+  useEffect(() => {
+    if (!selectedLogId) focusedRowRef.current?.scrollIntoView({ block: 'nearest' });
+  }, [focused, selectedLogId]);
+
+  // One global key handler reading the latest state through refs — full keyboard
+  // control: ↑/↓ or j/k to move, ↵ to open, ↑/↓ to step through an open entry,
+  // Esc/← to go back.
+  const state = useRef({ logs, selectedLogId, focused });
+  state.current = { logs, selectedLogId, focused };
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      const t = e.target as HTMLElement | null;
+      if (t && (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.isContentEditable)) return;
+      const { logs: ls, selectedLogId: sel, focused: fi } = state.current;
+      if (ls.length === 0) return;
+      const down = e.key === 'ArrowDown' || e.key === 'j';
+      const up = e.key === 'ArrowUp' || e.key === 'k';
+
+      if (sel) {
+        const idx = ls.findIndex((l) => l.log_id === sel);
+        if (e.key === 'Escape' || e.key === 'ArrowLeft' || e.key === 'h') {
+          e.preventDefault();
+          setSelectedLogId(null);
+        } else if (down && idx < ls.length - 1) {
+          e.preventDefault();
+          setSelectedLogId(ls[idx + 1].log_id);
+          setFocused(idx + 1);
+        } else if (up && idx > 0) {
+          e.preventDefault();
+          setSelectedLogId(ls[idx - 1].log_id);
+          setFocused(idx - 1);
+        }
+        return;
+      }
+
+      if (down) {
+        e.preventDefault();
+        setFocused((i) => Math.min(ls.length - 1, i + 1));
+      } else if (up) {
+        e.preventDefault();
+        setFocused((i) => Math.max(0, i - 1));
+      } else if (e.key === 'Enter') {
+        e.preventDefault();
+        const row = ls[fi];
+        if (row) setSelectedLogId(row.log_id);
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, []);
+
+  if (selectedLogId) {
+    const idx = logs.findIndex((l) => l.log_id === selectedLogId);
     return (
       <GatewayLogDetail
         projectId={projectId}
         logId={selectedLogId}
+        index={idx}
+        total={logs.length}
         onBack={() => setSelectedLogId(null)}
+        onPrev={() => {
+          if (idx > 0) {
+            setSelectedLogId(logs[idx - 1].log_id);
+            setFocused(idx - 1);
+          }
+        }}
+        onNext={() => {
+          if (idx < logs.length - 1) {
+            setSelectedLogId(logs[idx + 1].log_id);
+            setFocused(idx + 1);
+          }
+        }}
       />
     );
+  }
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
@@ -305,11 +443,26 @@ export function GatewayLogs({ projectId }: { projectId: string }) {
             description="Every LLM call routed through the gateway shows up here — model, status, latency, tokens, and cost."
           />
         ) : (
-          logs.map((row) => (
-            <LogRow key={row.log_id} row={row} onClick={() => setSelectedLogId(row.log_id)} />
+          logs.map((row, i) => (
+            <LogRow
+              key={row.log_id}
+              ref={i === focused ? focusedRowRef : undefined}
+              row={row}
+              focused={i === focused}
+              onHover={() => setFocused(i)}
+              onClick={() => setSelectedLogId(row.log_id)}
+            />
           ))
         )}
       </div>
+
+      {logs.length > 0 && (
+        <div className="flex shrink-0 items-center gap-3 border-t border-border/50 px-4 py-1.5 text-xs text-muted-foreground/60">
+          <span><kbd className="font-sans">↑↓</kbd> navigate</span>
+          <span><kbd className="font-sans">↵</kbd> open</span>
+          <span><kbd className="font-sans">esc</kbd> back</span>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/projects/gateway/gateway-overview.tsx
+++ b/apps/web/src/components/projects/gateway/gateway-overview.tsx
@@ -1,10 +1,12 @@
 'use client';
 
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { AlertTriangle, Coins, Cpu, DollarSign, Sparkles, Zap } from 'lucide-react';
 
 import { SectionCard } from '@/components/ui/section-card';
 import { cn } from '@/lib/utils';
+import { listProjectSessions } from '@/lib/projects-client';
 import {
   useGatewayBreakdown,
   useGatewayErrors,
@@ -52,6 +54,26 @@ export function GatewayOverview({ projectId }: { projectId: string }) {
   const { data: breakdown } = useGatewayBreakdown(projectId, days);
   const { data: sessionsData } = useGatewaySessions(projectId, days);
   const { data: errorData } = useGatewayErrors(projectId, days);
+
+  // Resolve session ids → human names so spend reads as "Fix login bug", not a
+  // raw uuid. Map both the kortix and opencode ids since the gateway may key on
+  // either.
+  const { data: projectSessions } = useQuery({
+    queryKey: ['project-sessions', projectId],
+    queryFn: () => listProjectSessions(projectId),
+    enabled: !!projectId,
+    staleTime: 30_000,
+  });
+  const sessionNames = useMemo(() => {
+    const m = new Map<string, string>();
+    for (const s of projectSessions ?? []) {
+      const label = s.name ?? s.custom_name ?? null;
+      if (!label) continue;
+      m.set(s.session_id, label);
+      if (s.opencode_session_id) m.set(s.opencode_session_id, label);
+    }
+    return m;
+  }, [projectSessions]);
 
   const requests = overview?.requests ?? 0;
   const errors = overview?.errors ?? 0;
@@ -183,34 +205,53 @@ export function GatewayOverview({ projectId }: { projectId: string }) {
               <p className="py-6 text-center text-sm text-muted-foreground">No sessions yet.</p>
             ) : (
               <div className="space-y-0.5">
-                {sessions.slice(0, 6).map((s, i) => (
-                  <MeterRow
-                    key={s.session_id}
-                    rank={i + 1}
-                    accent={modelAccent(s.session_id)}
-                    label={s.session_id.slice(0, 8)}
-                    value={<span className="font-semibold text-foreground">{fmtUsd(s.total_cost)}</span>}
-                    sub={
-                      <>
-                        <span className="inline-flex items-center gap-1">
-                          <Sparkles className="size-3 text-kortix-blue" />
-                          {fmtUsd(s.llm_cost)}
-                        </span>
-                        <span className="inline-flex items-center gap-1">
-                          <Cpu className="size-3 text-muted-foreground" />
-                          {fmtUsd(s.compute_cost)}
-                        </span>
-                        <span className="text-muted-foreground/50">
-                          {s.requests.toLocaleString()} req
-                        </span>
-                      </>
-                    }
-                    segments={[
-                      { pct: (s.llm_cost / maxSessionCost) * 100, color: 'var(--kortix-blue)' },
-                      { pct: (s.compute_cost / maxSessionCost) * 100, color: 'var(--muted-foreground)' },
-                    ]}
-                  />
-                ))}
+                {sessions.slice(0, 6).map((s, i) => {
+                  const name = sessionNames.get(s.session_id);
+                  return (
+                    <MeterRow
+                      key={s.session_id}
+                      rank={i + 1}
+                      accent={modelAccent(s.session_id)}
+                      label={
+                        name ? (
+                          <span className="font-sans">{name}</span>
+                        ) : (
+                          s.session_id.slice(0, 8)
+                        )
+                      }
+                      value={
+                        <span className="font-semibold text-foreground">{fmtUsd(s.total_cost)}</span>
+                      }
+                      sub={
+                        <>
+                          {name && (
+                            <span className="font-mono text-muted-foreground/40">
+                              {s.session_id.slice(0, 8)}
+                            </span>
+                          )}
+                          <span className="inline-flex items-center gap-1">
+                            <Sparkles className="size-3 text-kortix-blue" />
+                            {fmtUsd(s.llm_cost)}
+                          </span>
+                          <span className="inline-flex items-center gap-1">
+                            <Cpu className="size-3 text-muted-foreground" />
+                            {fmtUsd(s.compute_cost)}
+                          </span>
+                          <span className="text-muted-foreground/50">
+                            {s.requests.toLocaleString()} req
+                          </span>
+                        </>
+                      }
+                      segments={[
+                        { pct: (s.llm_cost / maxSessionCost) * 100, color: 'var(--kortix-blue)' },
+                        {
+                          pct: (s.compute_cost / maxSessionCost) * 100,
+                          color: 'var(--muted-foreground)',
+                        },
+                      ]}
+                    />
+                  );
+                })}
               </div>
             )}
           </SectionCard>

--- a/apps/web/src/lib/projects-gateway-client.ts
+++ b/apps/web/src/lib/projects-gateway-client.ts
@@ -236,8 +236,14 @@ export async function deleteGatewayBudget(
   );
 }
 
-export async function getGatewayKeys(projectId: string): Promise<{ keys: GatewayKeyRow[] }> {
-  return unwrap(await backendApi.get<{ keys: GatewayKeyRow[] }>(`/projects/${projectId}/gateway/keys`));
+export async function getGatewayKeys(
+  projectId: string,
+): Promise<{ keys: GatewayKeyRow[]; gateway_url?: string | null }> {
+  return unwrap(
+    await backendApi.get<{ keys: GatewayKeyRow[]; gateway_url?: string | null }>(
+      `/projects/${projectId}/gateway/keys`,
+    ),
+  );
 }
 
 export async function createGatewayKey(


### PR DESCRIPTION
Follow-up to #3811.

## Why
A dev gateway key appeared "broken" because the key-reveal screen **hardcoded the prod host** (`gateway.kortix.com`) in its curl example — so a dev key was sent to the wrong environment. Verified: the same key returns **HTTP 200** against `gateway-dev.kortix.com`. This PR fixes that plus two UX asks.

## Changes
- **Env-correct curl example.** The API now returns the public gateway origin for the current env (derived from `LLM_GATEWAY_BASE_URL`) in `GET /:projectId/gateway/keys`; the reveal dialog renders it. The example is now copy-paste runnable (full one-time key + valid JSON body).
- **Keyboard-navigable log viewer.** `↑/↓` (or `j/k`) move, `↵` opens, `Esc/←` back; `↑/↓` step through entries while reading one; focused row highlights + scrolls into view; prev/next + "i / N" in the detail header; a footer hint.
- **Session attribution.** Dashboard "Top sessions" shows the session **name** (resolved from project sessions, matching either the kortix or opencode id) with the short id as secondary.

## Tests
- `apps/api`: `public-url` origin derivation. Both ends typecheck-clean; eslint clean.

## NOT in this PR — separate prod incident
Prod gateway (`gateway.kortix.com`, build `f1e6a7e8`) is logging `ApiUnavailableError: /internal/gateway/authenticate unavailable (404)` on every authed request — the prod gateway can't reach the prod API's `/internal/gateway` control-plane route. That's an **infra/config** issue (not this change, and not the dev #3811 merge). Flagged for a separate, careful prod fix.