### PR TITLE
fix(ci): raise frontend build heap

### DIFF
--- a/.github/workflows/build-staging.yml
+++ b/.github/workflows/build-staging.yml
@@ -154,6 +154,7 @@ jobs:
       - name: Build frontend standalone output
         run: pnpm --filter ./apps/web build
         env:
+          NODE_OPTIONS: --max-old-space-size=6144
           NEXT_PUBLIC_BACKEND_URL: http://localhost:8008/v1
           NEXT_PUBLIC_SUPABASE_URL: https://placeholder.supabase.co
           NEXT_PUBLIC_SUPABASE_ANON_KEY: local-build-placeholder-anon-key

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,7 @@ jobs:
       - name: Build standalone frontend
         run: pnpm --filter ./apps/web build
         env:
+          NODE_OPTIONS: --max-old-space-size=6144
           NEXT_PUBLIC_BACKEND_URL: http://localhost:8008/v1
           NEXT_PUBLIC_SUPABASE_URL: https://placeholder.supabase.co
           NEXT_PUBLIC_SUPABASE_ANON_KEY: local-build-placeholder-anon-key

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -658,6 +658,7 @@ jobs:
       - name: Build frontend standalone output
         run: pnpm --filter ./apps/web build
         env:
+          NODE_OPTIONS: --max-old-space-size=6144
           NEXT_PUBLIC_BACKEND_URL: http://localhost:8008/v1
           NEXT_PUBLIC_SUPABASE_URL: https://placeholder.supabase.co
           NEXT_PUBLIC_SUPABASE_ANON_KEY: local-build-placeholder-anon-key

--- a/.github/workflows/hotfix-prod.yml
+++ b/.github/workflows/hotfix-prod.yml
@@ -197,6 +197,7 @@ jobs:
           pnpm install --frozen-lockfile
           pnpm --filter ./apps/web build
         env:
+          NODE_OPTIONS: --max-old-space-size=6144
           npm_config_engine_strict: "false"
           NEXT_PUBLIC_BACKEND_URL: https://api.kortix.com/v1
           NEXT_PUBLIC_SUPABASE_URL: https://placeholder.supabase.co


### PR DESCRIPTION
## Summary
- raise Node heap for frontend Next.js builds in CI, dev, staging, and hotfix build workflows
- fixes the staging artifact OOM observed in Build Staging Artifacts run 28213080406

## Verification
- git diff --check