### PR TITLE
fix(staging): prefer daytona sandbox provider

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -167,6 +167,7 @@ jobs:
               KORTIX_URL: $api,
               CORS_ALLOWED_ORIGINS: $frontend,
               LLM_GATEWAY_BASE_URL: $gateway,
+              ALLOWED_SANDBOX_PROVIDERS: "daytona,platinum",
               KORTIX_WARM_SNAPSHOT_ENABLED: "false"
             }')"
 


### PR DESCRIPTION
## Summary\n- Keep staging sandbox provider order as Daytona first with Platinum as fallback when syncing the staging AWS secret bundle.\n- Prevent future staging deploys from inheriting dev's provider order from kortix-dev-env.\n\n## Verification\n- Live AWS Secrets Manager kortix-staging-env: ALLOWED_SANDBOX_PROVIDERS=daytona,platinum\n- Live Kubernetes secret kortix-api-env: ALLOWED_SANDBOX_PROVIDERS=daytona,platinum\n- Running staging API pods: ALLOWED_SANDBOX_PROVIDERS=daytona,platinum\n- Staging API health: ok\n