### PR TITLE
feat(slack): DM the login prompt instead of a silent threaded ephemeral

### DIFF
--- a/apps/api/src/channels/slack-api.ts
+++ b/apps/api/src/channels/slack-api.ts
@@ -114,27 +114,21 @@ export async function postMessage(
   }
 }
 
-// Posts an ephemeral message — visible only to `userId` in the channel/thread.
-// Used to nudge an unlinked sender to run `/login` without leaking the prompt to
-// the whole channel. Best-effort: a failure just means the nudge didn't show.
-export async function postEphemeral(
-  token: string,
-  channel: string,
-  userId: string,
-  text: string,
-  opts?: { blocks?: unknown[]; threadTs?: string },
-): Promise<void> {
+// Opens (or returns) the bot's DM channel with a user so we can message them
+// directly — a real DM notifies and persists, unlike an ephemeral. Returns the
+// IM channel id, or null on failure.
+export async function openDmChannel(token: string, userId: string): Promise<string | null> {
   try {
-    const r = await slackApiCall(token, 'chat.postEphemeral', {
-      channel,
-      user: userId,
-      text,
-      ...(opts?.blocks ? { blocks: opts.blocks } : {}),
-      ...(opts?.threadTs ? { thread_ts: opts.threadTs } : {}),
-    });
-    if (!r.ok) console.warn('[slack-api] chat.postEphemeral failed', { error: r.error });
+    const r = await slackApiCall(token, 'conversations.open', { users: userId });
+    if (!r.ok) {
+      console.warn('[slack-api] conversations.open failed', { error: r.error });
+      return null;
+    }
+    const ch = r.channel as { id?: string } | undefined;
+    return ch?.id ?? null;
   } catch (err) {
-    console.warn('[slack-api] chat.postEphemeral error', err);
+    console.warn('[slack-api] conversations.open error', err);
+    return null;
   }
 }
 

--- a/apps/api/src/channels/slack/dispatch.ts
+++ b/apps/api/src/channels/slack/dispatch.ts
@@ -25,7 +25,7 @@ import {
   deliverSlackFollowUpToSession,
   renderFollowUpPrompt,
 } from './session';
-import { postEphemeralLoginPrompt, resolveSlackActor } from './identity';
+import { postLoginPrompt, resolveSlackActor } from './identity';
 import { resolveProjectAutomationActor } from '../../projects/session-lifecycle';
 import {
   deleteTurn,
@@ -484,11 +484,10 @@ export async function spawnAgentTurn(
     const slackUserId = event.user ?? '';
     const actor = await resolveSlackActor(teamId, slackUserId, project.accountId);
     if ('reason' in actor) {
-      await postEphemeralLoginPrompt({
+      await postLoginPrompt({
         projectId,
         teamId,
         channel: event.channel,
-        threadTs: event.thread_ts ?? event.ts,
         slackUserId,
         reason: actor.reason,
       });

--- a/apps/api/src/channels/slack/identity.ts
+++ b/apps/api/src/channels/slack/identity.ts
@@ -2,7 +2,7 @@ import { and, eq, isNull } from 'drizzle-orm';
 import { accountMembers, chatUserIdentities } from '@kortix/db';
 import { db } from '../../shared/db';
 import { loadSlackTokenForProject } from '../install-store';
-import { postEphemeral } from '../slack-api';
+import { openDmChannel, postBlocks } from '../slack-api';
 import { buildSlackLoginUrl } from './login';
 
 const PLATFORM = 'slack';
@@ -110,41 +110,41 @@ export async function revokeSlackIdentity(teamId: string, slackUserId: string): 
 }
 
 // Nudge an unlinked / non-member sender to connect their own Kortix account.
-// Ephemeral, so it never leaks the prompt to the rest of the channel.
-export async function postEphemeralLoginPrompt(input: {
+// Sent as a DM — it pushes a notification and persists, so the user actually
+// sees it (an ephemeral in the channel/thread is silent and easy to miss). The
+// `<#channel>` link gives them context for where they triggered it.
+export async function postLoginPrompt(input: {
   projectId: string;
   teamId: string;
   channel?: string;
-  threadTs?: string;
   slackUserId: string;
   reason: 'unlinked' | 'not_member';
 }): Promise<void> {
-  if (!input.channel) return;
   const token = await loadSlackTokenForProject(input.projectId);
   if (!token) return;
+  const dm = await openDmChannel(token, input.slackUserId);
+  if (!dm) return;
 
   const url = buildSlackLoginUrl({ teamId: input.teamId, slackUserId: input.slackUserId });
+  const where = input.channel ? ` in <#${input.channel}>` : '';
   const text =
     input.reason === 'not_member'
-      ? "You're signed in, but that Kortix account isn't a member of this workspace's project. Ask an admin to add you, then connect again."
-      : 'Kortix now runs as *your own* Kortix account — connect it once to continue.';
+      ? `You messaged Kortix${where}, but that Kortix account isn't a member of this workspace's project. Ask an admin to add you, then connect again.`
+      : `You messaged Kortix${where}. Kortix runs as *your own* Kortix account — connect it once to continue.`;
 
-  await postEphemeral(token, input.channel, input.slackUserId, text, {
-    threadTs: input.threadTs,
-    blocks: [
-      { type: 'section', text: { type: 'mrkdwn', text } },
-      {
-        type: 'actions',
-        elements: [
-          {
-            type: 'button',
-            text: { type: 'plain_text', text: 'Connect my Kortix account', emoji: true },
-            style: 'primary',
-            url,
-            action_id: 'slack_login_connect',
-          },
-        ],
-      },
-    ],
-  });
+  await postBlocks(token, dm, text, [
+    { type: 'section', text: { type: 'mrkdwn', text } },
+    {
+      type: 'actions',
+      elements: [
+        {
+          type: 'button',
+          text: { type: 'plain_text', text: 'Connect my Kortix account', emoji: true },
+          style: 'primary',
+          url,
+          action_id: 'slack_login_connect',
+        },
+      ],
+    },
+  ]);
 }


### PR DESCRIPTION
Follow-up to #3768 (per-Slack-user identity).

## Problem

When an unlinked user @mentions the bot, the "connect your Kortix account" nudge was posted as an **ephemeral message inside the message thread**. In practice that's easy to miss: ephemerals push **no notification**, vanish on reload, and being nested in a thread meant you had to open the thread to even see it.

## Fix

Send the prompt as a **direct message** instead (`conversations.open` → `chat.postMessage`):

- Pushes a real notification and persists (you'll actually see it).
- Stays private — the channel isn't spammed with "X needs to log in."
- Includes a `<#channel>` link back to where it was triggered for context.

Both reasons (`unlinked` and `not_member`) DM. The now-unused `postEphemeral` helper is removed; `im:write` + `chat:write` are already in the bot scopes.

Gated by the same `SLACK_REQUIRE_USER_IDENTITY` flag — no behavior change when off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
