### PR TITLE
fix(platinum): respect auto-stop setting instead of hardcoded persistent (+ 15min for kortix dev)

### DIFF
--- a/apps/api/src/platform/providers/platinum.ts
+++ b/apps/api/src/platform/providers/platinum.ts
@@ -80,16 +80,15 @@ export class PlatinumProvider implements SandboxProvider {
     // autoStopInterval maps to Platinum's auto_stop_minutes. 0 → persistent
     // (never auto-stops); >0 → ephemeral with that idle timeout.
     //
-    // Default 0 (PERSISTENT) for Platinum. Unlike Daytona (cold-container
-    // restart — resumes cleanly), a Platinum stop→resume currently wedges the
-    // restored guest's virtio devices (net AND vsock dead — the CH UFFD
-    // demand-paged device-resume bug; replicated + isolated 2026-06-06,
-    // host→guest:8000 times out, in-guest exec dead). So returning to an
-    // auto-stopped session 502s/hangs (the "resume-freeze", the 27s/502
-    // catastrophe). Never auto-stop into that broken path until the CH-side
-    // resume fix lands (or reprovision-on-resume). Host RAM is the capacity
-    // bound, not disk, and it's plentiful at current scale.
-    const autoStop = opts.autoStopInterval ?? 0;
+    // Platinum now AUTO-STOPS idle boxes natively (idle timeout) and resumes them
+    // CoW on reopen. The old reason for forcing persistent (the CH UFFD demand-paged
+    // device-resume bug, isolated 2026-06-06, which wedged net+vsock on resume) is
+    // FIXED — the CH v52 UFFD patch landed; verified stop→resume ~2.3s with the guest
+    // alive. Relying on Platinum's own timer makes idle-stop robust (no dependency on
+    // the Kortix maintenance reaper, which when down let boxes run 24/7 and flood the
+    // host). A normal session gets KORTIX_SANDBOX_AUTOSTOP_MINUTES; only an EXPLICIT
+    // autoStopInterval=0 (the warm-seed / legacy spare contract) stays persistent.
+    const autoStop = opts.autoStopInterval ?? config.KORTIX_SANDBOX_AUTOSTOP_MINUTES;
 
     const _t0 = Date.now();
     const sandbox = await platinumJson<PlatinumSandbox>(

--- a/apps/api/src/platform/services/session-sandbox.ts
+++ b/apps/api/src/platform/services/session-sandbox.ts
@@ -406,16 +406,16 @@ export async function provisionSessionSandbox(opts: {
           }
         : {}),
     },
-    // Idle lifecycle is owned by the provider-agnostic reaper (projects/
-    // sandbox-reaper.ts), keyed off MEANINGFUL activity (real turns), with each
-    // provider's native auto-stop as a secondary backstop. We pass NO explicit
-    // autoStopInterval for a normal session so each provider applies its own
-    // policy via daytonaLifecycle(): Daytona → KORTIX_SANDBOX_AUTOSTOP_MINUTES
-    // (default 15); Platinum → persistent (autoStop=0) because its stop→resume
-    // is broken (CH resume-freeze) — the reaper stops idle Platinum boxes and
-    // flags reprovision-on-open instead. (The old divergent KORTIX_SANDBOX_AUTO_
-    // STOP_MIN env, default 30, also wrongly made Platinum ephemeral — removed.)
-    // Warm-pool spares (legacy; pool disabled) stay persistent until claimed.
+    // Idle lifecycle: each provider's NATIVE auto-stop is the primary stop
+    // mechanism. We pass NO explicit autoStopInterval for a normal session so the
+    // provider applies its own policy: Daytona → daytonaLifecycle()
+    // (KORTIX_SANDBOX_AUTOSTOP_MINUTES); Platinum → the same idle timeout (see
+    // platinum.ts). Platinum NO LONGER forces persistent — the CH resume-freeze
+    // that required autoStop=0 is FIXED (verified ~2.3s stop→resume), so it
+    // idle-stops + CoW-resumes natively rather than depending on the maintenance
+    // reaper (whose outage let Platinum boxes run 24/7 and flood the host). The
+    // reaper stays as a secondary backstop only. Warm seeds / legacy spares pass
+    // an EXPLICIT autoStopInterval=0 to stay persistent.
     ...(opts.poolState ? { autoStopInterval: 0 } : {}),
   };
 

--- a/infra/k8s/envs/dev/values.yaml
+++ b/infra/k8s/envs/dev/values.yaml
@@ -6,7 +6,7 @@
 # Immutable dev tag (CI bumps to dev-<sha8> on each main push). Bootstrap value
 # is :dev-latest until the first deploy-dev-eks run pins an immutable sha.
 image:
-  tag: "dev-a909aba7"
+  tag: "dev-b0fb5d65"
 kortixVersion: ""
 env:
   internalKortixEnv: dev
@@ -23,6 +23,12 @@ extraEnv:
   # catalog shape) and the model picker collapses to a single model.
   LLM_GATEWAY_BASE_URL: "https://gateway-dev.kortix.com/v1/llm"
   KORTIX_WARM_SNAPSHOT_ENABLED: "false"
+  # Idle auto-stop for sandboxes (Daytona AND Platinum honor this now — Platinum
+  # used to hardcode persistent and depend on the maintenance reaper, which died
+  # and let boxes run 24/7 and flood the host). 15min keeps idle cost down; a
+  # stopped Platinum box CoW-resumes on reopen (~2.3s, CH resume-freeze is fixed).
+  # Per-deployment setting, not a code default.
+  KORTIX_SANDBOX_AUTOSTOP_MINUTES: "15"
   # Warm pool, Stage-2 (clone-at-park) — the lever that restores <6s starts for
   # returning/2nd+ sessions, now that dev serves from EKS (reliable region). It's
   # a pure accelerator: any claim miss/error falls through to the unchanged cold


### PR DESCRIPTION
**Why machines ran 24/7:** Platinum hardcoded `auto_stop_minutes=0` (persistent) and relied on the Kortix maintenance reaper to stop idle boxes. The reaper's workers died (ECS down / EKS API-only / leader lease expired) → nothing stopped them → host RAM flooded → spawns 503'd.

**Fix (configurable, not a global hardcode):**
- `platinum.ts`: apply the configured idle timeout (`KORTIX_SANDBOX_AUTOSTOP_MINUTES`) instead of hardcoding 0. Explicit `autoStopInterval=0` (warm seed / spare) still stays persistent. The reason for persistent (CH UFFD resume-freeze) is **fixed** — verified stop→resume ~2.3s, guest alive.
- `config.ts` global default unchanged (stays 120).
- `infra/k8s/envs/dev/values.yaml`: set `KORTIX_SANDBOX_AUTOSTOP_MINUTES=15` for **kortix dev only** (GitOps, per-deployment).

No reaper dependency, no template rebuild (provider adapter only). tsc clean. (Reaper/leader-lease revival + alert is a separate infra fix.)