### PR TITLE
fix(warm-snapshot): honor the OFF toggle on a cold cache (admin switch silently re-enabled it)

### DIFF
--- a/apps/api/src/__tests__/unit-warm-snapshot-toggle.test.ts
+++ b/apps/api/src/__tests__/unit-warm-snapshot-toggle.test.ts
@@ -24,6 +24,7 @@ const cfg = {
   DAYTONA_WARM_TARGET: '',
   KORTIX_WARM_POOL_ENABLED: false,
   KORTIX_WARM_POOL_SIZE: 0,
+  KORTIX_WARM_SNAPSHOT_ENABLED: true,
 };
 let platinumConfigured = false;
 
@@ -70,6 +71,20 @@ describe('warmSnapshotSetting (DB-backed admin master, default ON)', () => {
 
   test('row { enabled: true } → master ON', async () => {
     await loadRows([{ key: WARM_SNAPSHOT_KEY, value: { enabled: true } }]);
+    expect(warmSnapshotSetting().enabled).toBe(true);
+  });
+
+  test('cold cache (before first DB read) follows KORTIX_WARM_SNAPSHOT_ENABLED, not a hardcoded ON', () => {
+    // Regression for the 2026-06-26 opencode wedge: a fresh pod served warm-snapshot
+    // ON for the ~30s cold-cache window despite an operator "off", warm-forking a
+    // stale seed. The cold default is now the env, so a deployment pinned OFF stays
+    // OFF before any DB refresh. (invalidate → cache=null → sync read = envDefaults.)
+    dbRows = [];
+    cfg.KORTIX_WARM_SNAPSHOT_ENABLED = false;
+    invalidateRuntimeSettings();
+    expect(warmSnapshotSetting().enabled).toBe(false);
+    cfg.KORTIX_WARM_SNAPSHOT_ENABLED = true;
+    invalidateRuntimeSettings();
     expect(warmSnapshotSetting().enabled).toBe(true);
   });
 });

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -140,6 +140,14 @@ const envSchema = z.object({
   // from the admin Providers panel (runtime-settings.ts → warmPoolEnabled()).
   // When OFF the allocator skips the claim path and every create cold-provisions.
   KORTIX_WARM_POOL_ENABLED:        optBoolFalse,
+  // Master on/off for per-project warm-fork SNAPSHOTS (the ~2s warm start). The
+  // FALLBACK default read when the DB `warm_snapshot` row is absent OR the
+  // runtime-settings cache is still cold (fresh pod / DB hiccup). Previously this
+  // default was hardcoded ON in runtime-settings.ts, so a just-started pod ignored
+  // an operator's "off" for ~30s and could warm-fork a stale seed (the 2026-06-26
+  // opencode-wedge incident). Default ON (warm-fork is a latency win); the live
+  // control surface is the admin `warm_snapshot` toggle (warmSnapshotSetting()).
+  KORTIX_WARM_SNAPSHOT_ENABLED:    optBoolTrue,
   // Stage-2 pre-warm: provision each spare WITH its project identity (repo, no
   // session) and tell the daemon (KORTIX_WARM_POOL_CLONE_AT_PARK) to clone the
   // base branch + warm the opencode project plugin AT PARK — so a claim only
@@ -589,6 +597,7 @@ export const config = {
   KORTIX_GIT_PROXY: env.KORTIX_GIT_PROXY,
   KORTIX_WARM_POOL_SIZE: env.KORTIX_WARM_POOL_SIZE,
   KORTIX_WARM_POOL_ENABLED: env.KORTIX_WARM_POOL_ENABLED,
+  KORTIX_WARM_SNAPSHOT_ENABLED: env.KORTIX_WARM_SNAPSHOT_ENABLED,
   KORTIX_WARM_POOL_CLONE_AT_PARK: env.KORTIX_WARM_POOL_CLONE_AT_PARK,
   KORTIX_WARM_POOL_PRESENCE_MINUTES: env.KORTIX_WARM_POOL_PRESENCE_MINUTES,
   KORTIX_PRERESUME_ENABLED: env.KORTIX_PRERESUME_ENABLED,

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -49,7 +49,6 @@ import { accessControlApp } from './access-control';
 import { startAccessControlCache, stopAccessControlCache } from './shared/access-control-cache';
 import { startTmpReaper, stopTmpReaper } from './snapshots/tmp-reaper';
 import { startLeaderElection, stopLeaderElection, isLeader, runsSingletonWorkers } from './shared/leader-election';
-import { API_INSTANCE, API_STARTED_AT } from './shared/instance';
 import { marketplaceApp } from './marketplace';
 import { oauthApp } from './oauth';
 import {
@@ -334,6 +333,11 @@ const API_VERSION = process.env.KORTIX_VERSION || 'dev';
 // the prod retag — unlike KORTIX_VERSION which prod overrides to the clean tag).
 // Lets the team verify precisely which code is live. 'unknown' for local dev.
 const API_COMMIT = process.env.KORTIX_COMMIT || 'unknown';
+// When this process booted — confirms a deploy actually rolled fresh pods.
+const STARTED_AT = new Date().toISOString();
+// Which replica answered (pod name in k8s, task/container id in ECS).
+const API_INSTANCE = process.env.HOSTNAME || 'unknown';
+
 // OpenAPI spec (/v1/openapi.json) + Scalar API reference (/v1/docs). Typed routes
 // register into the spec as each sub-router is migrated to @hono/zod-openapi.
 mountOpenApiDocs(app, API_VERSION);
@@ -373,7 +377,7 @@ const healthHandler = (c: any) =>
     commit: API_COMMIT,
     environment: config.INTERNAL_KORTIX_ENV,
     instance: API_INSTANCE,
-    started_at: API_STARTED_AT,
+    started_at: STARTED_AT,
     uptime_seconds: Math.round(process.uptime()),
     // Resident memory (MB) for this pod — a quick leak/OOM-risk signal against
     // the container's memory limit, without needing metrics-server/dashboards.
@@ -642,10 +646,121 @@ app.openapi(
 app.route('/v1/router', router);        // /v1/router/chat/completions, /v1/router/models, /v1/router/web-search, /v1/router/tavily/*, etc.
 
 {
-  // LLM gateway surfaces: in-API /v1/llm (full pipeline), /internal/gateway
-  // control-plane RPC, and the /v1/llm-gateway reverse proxy. See ./llm-gateway/wire.
-  const { mountLlmGateway } = await import('./llm-gateway/wire');
-  mountLlmGateway(app);
+  const { createLlmGateway } = await import('./llm-gateway');
+  const { attributeYoloToken } = await import('./billing/services/yolo-tokens');
+  const { validateAccountToken } = await import('./repositories/account-tokens');
+  const { assertBillingActive } = await import('./billing/services/billing-gate');
+  const { deductForLlmUsage } = await import('./billing/services/credits');
+  const { recordUsageEvent } = await import('./shared/usage-events');
+  const { llmPriceMarkup } = await import('./billing/services/tiers');
+
+  app.route(
+    '/v1/llm',
+    createLlmGateway(
+      {
+        enabled: config.LLM_GATEWAY_ENABLED,
+        openrouterApiKey: config.OPENROUTER_API_KEY,
+        markup: llmPriceMarkup(),
+        appName: 'Kortix',
+        appReferer: config.KORTIX_URL,
+      },
+      {
+        authenticateToken: async (token) => {
+          // Legacy per-member YOLO token (prod per-seat path) takes priority.
+          const yolo = await attributeYoloToken(token);
+          if (yolo) return yolo;
+          // YOLO is discontinued; sandboxes now present their account token
+          // (a kortix_pat_ minted at provision). Resolve it to {userId, accountId}
+          // so the managed gateway works for self-hosted / billing-off deploys.
+          const acct = await validateAccountToken(token);
+          if (acct.isValid && acct.userId && acct.accountId) {
+            // projectId/sessionId attribute LLM usage to the calling session
+            // (sandbox executor token is minted per-session with session_id =
+            // sandbox_id) — the reaper's reliable activity signal + precise
+            // per-session billing.
+            return {
+              userId: acct.userId,
+              accountId: acct.accountId,
+              projectId: acct.projectId ?? null,
+              sessionId: acct.sessionId ?? null,
+            };
+          }
+          return null;
+        },
+        assertBillingActive,
+        recordUsage: async (event) => {
+          // Always record usage_events for observability (token counts, model,
+          // request id) — useful in self-hosted for debugging even with no
+          // wallet deduction.
+          const usageEventId = await recordUsageEvent({
+            accountId: event.accountId,
+            actorUserId: event.actorUserId,
+            projectId: event.projectId ?? null,
+            sessionId: event.sessionId ?? null,
+            provider: event.provider,
+            model: event.model,
+            route: '/v1/llm/chat/completions',
+            inputTokens: event.promptTokens,
+            outputTokens: event.completionTokens,
+            cachedTokens: event.cachedTokens,
+            costUsd: event.finalCost,
+            streaming: event.streaming,
+            metadata: {
+              upstreamCostUsd: event.upstreamCost,
+              markup: llmPriceMarkup(),
+              requestId: event.requestId,
+            },
+          });
+          // Hard gate: never debit the wallet when billing is disabled.
+          if (!config.KORTIX_BILLING_INTERNAL_ENABLED) return;
+          await deductForLlmUsage({
+            accountId: event.accountId,
+            costUsd: event.finalCost,
+            model: event.model,
+            provider: event.provider,
+            actorUserId: event.actorUserId,
+            usageEventId,
+            upstreamCostUsd: event.upstreamCost,
+            markup: llmPriceMarkup(),
+          });
+        },
+      },
+    ),
+  );
+
+  const { createInternalGatewayRoutes } = await import('./llm-gateway/internal-routes');
+  app.route('/internal/gateway', createInternalGatewayRoutes());
+
+  if (
+    config.LLM_GATEWAY_ENABLED &&
+    !config.LLM_GATEWAY_BASE_URL &&
+    !config.LLM_GATEWAY_PROXY_PORT &&
+    !config.LLM_GATEWAY_PROXY_TARGET
+  ) {
+    appLogger.error(
+      '[gateway] LLM_GATEWAY_BASE_URL is unset and no proxy is configured — sandboxes will fall back to the in-API /v1/llm passthrough (OpenRouter-only, wrong catalog shape → single-model picker). Set LLM_GATEWAY_BASE_URL to the standalone gateway URL (e.g. https://gateway.kortix.com/v1/llm).',
+    );
+  }
+
+  if (config.LLM_GATEWAY_PROXY_PORT || config.LLM_GATEWAY_PROXY_TARGET) {
+    const proxyBase = (
+      config.LLM_GATEWAY_PROXY_TARGET || `http://127.0.0.1:${config.LLM_GATEWAY_PROXY_PORT}`
+    ).replace(/\/+$/, '');
+    app.all('/v1/llm-gateway/*', async (c) => {
+      const tail = c.req.path.slice('/v1/llm-gateway'.length) || '/';
+      const target = `${proxyBase}${tail}`;
+      const init: RequestInit & { duplex?: 'half' } = {
+        method: c.req.method,
+        headers: c.req.raw.headers,
+      };
+      if (c.req.method !== 'GET' && c.req.method !== 'HEAD') {
+        init.body = c.req.raw.body;
+        init.duplex = 'half';
+      }
+      const upstream = await fetch(target, init);
+      return new Response(upstream.body, { status: upstream.status, headers: upstream.headers });
+    });
+  }
 }
 
 app.route('/v1/billing', billingApp);   // /v1/billing/account-state, /v1/billing/webhooks/*
@@ -676,11 +791,9 @@ app.route('/v1/marketplace', marketplaceApp); // /v1/marketplace — browse the 
 
 app.route('/v1/webhooks', projectWebhooksApp); // /v1/webhooks/:triggerId — signed project trigger fires
 
-const { slackWebhookApp, telegramWebhookApp, slackOauthApp, slackIdentityApp, emailWebhookApp } = await import('./channels');
+const { slackWebhookApp, telegramWebhookApp, slackOauthApp } = await import('./channels');
 app.route('/v1/webhooks/slack/oauth', slackOauthApp); // /v1/webhooks/slack/oauth/callback — OAuth dance
 app.route('/v1/webhooks/slack', slackWebhookApp); // /v1/webhooks/slack/:projectId — raw Slack events (BYO mode)
-app.route('/v1/channels/slack/identity', slackIdentityApp); // /v1/channels/slack/identity/bind — authed /login bind
-app.route('/v1/webhooks/email', emailWebhookApp); // /v1/webhooks/email/agentmail — raw AgentMail events
 app.route('/v1/webhooks/telegram', telegramWebhookApp); // /v1/webhooks/telegram/:projectId — Telegram updates
 
 const { sandboxWebhooksApp } = await import('./platform/webhooks/routes');
@@ -870,6 +983,16 @@ let schemaReady = false;
 async function startReplicaServices() {
   startAccessControlCache();
   startTunnelService();
+  // Warm the runtime-settings cache BEFORE serving traffic so the DB-backed admin
+  // toggles (warm_snapshot / warm_pool / provider_fallback) are honored from
+  // request #1. Without this a fresh pod serves the cold-cache env defaults for
+  // the first ~30s — which on a deploy let warm_snapshot resolve to the (old
+  // hardcoded) ON despite an operator "off", warm-forking a stale seed: the
+  // 2026-06-26 opencode-wedge incident. Best-effort: a DB hiccup leaves the env
+  // defaults, which now honor KORTIX_WARM_SNAPSHOT_ENABLED.
+  await import('./platform/services/runtime-settings')
+    .then((m) => m.refreshRuntimeSettings())
+    .catch(() => {});
   // Every replica stages snapshot/session-boot build contexts in tmpdir and can
   // leak them on error paths; sweep stale ones so they don't fill node disk and
   // trip DiskPressure evictions. Runs on all replicas (not leader-gated).
@@ -1008,12 +1131,10 @@ export default {
       server.timeout(req, 0);
     }
 
-    // LLM chat completions stream SSE — both the in-API /v1/llm pipeline and the
-    // /v1/llm-gateway reverse proxy to the standalone pod. Let the gateway's own
-    // keep-alive / upstream timeout govern them instead of Bun closing the client
-    // socket at idleTimeout with an empty reply. (startsWith('/v1/llm') covers
-    // both /v1/llm and /v1/llm-gateway.)
-    if (url.pathname.startsWith('/v1/llm')) {
+    // The standalone-gateway reverse proxy streams chat completions (SSE). Let
+    // the gateway's own keep-alive / upstream timeout govern it instead of Bun
+    // closing the client socket at idleTimeout with an empty reply.
+    if (url.pathname.startsWith('/v1/llm-gateway')) {
       server.timeout(req, 0);
     }
 
@@ -1139,7 +1260,7 @@ export default {
 
     close(ws: { data: any }) {
       if (ws.data?.type === 'tunnel-agent') {
-        tunnelWsHandlers.onClose(ws.data.tunnelId, ws as any);
+        tunnelWsHandlers.onClose(ws.data.tunnelId);
         return;
       }
       if (ws.data?.type === 'preview-ws') {

--- a/apps/api/src/platform/services/runtime-settings.ts
+++ b/apps/api/src/platform/services/runtime-settings.ts
@@ -11,10 +11,15 @@ import { config } from '../../config';
  * after writing, so a toggle takes effect immediately for the writing process;
  * other processes pick it up within the TTL.
  *
- * Fail-safe defaults: warm_pool + provider_fallback default OFF (spares/handoff
- * cost resources). warm_snapshot defaults ON — it's a pure latency optimization
- * (a failed bake degrades to a cold clone, never a broken session), so a DB
- * hiccup / missing row / cold cache resolving to "on" is the SAFE direction.
+ * Defaults come from envDefaults() — the env IS read (KORTIX_WARM_POOL_ENABLED /
+ * KORTIX_WARM_SNAPSHOT_ENABLED), so an operator can pin a whole deployment OFF
+ * without ever writing a DB row. warm_pool + provider_fallback ship OFF;
+ * warm_snapshot follows KORTIX_WARM_SNAPSHOT_ENABLED (ON unless pinned off).
+ * A cold cache / missing row resolves to that env default — NOT a hardcoded ON.
+ * (Previously warm_snapshot hardcoded ON here on the theory "a failed bake just
+ * degrades to a cold clone"; the 2026-06-26 opencode wedge disproved it — a STALE
+ * warm seed can hang a session — so "on" is not unconditionally safe and the
+ * operator's setting must win even before the first DB refresh.)
  */
 
 export const WARM_POOL_KEY = 'warm_pool';
@@ -44,9 +49,9 @@ export interface WarmSnapshotSetting {
 const TTL_MS = 30_000;
 const MAX_WARM_SIZE = 25;
 
-/** Env is only the FALLBACK default now; the DB row is the real control surface,
- *  so operators never redeploy to toggle these. warm_pool/fallback ship OFF,
- *  warm_snapshot ships ON. */
+/** Env is the FALLBACK default; the DB row is the live control surface, so
+ *  operators flip the admin toggle without a redeploy. warm_pool/fallback ship
+ *  OFF; warm_snapshot follows KORTIX_WARM_SNAPSHOT_ENABLED (ON unless pinned off). */
 function envDefaults(): {
   warmPool: WarmPoolSetting;
   fallback: ProviderFallbackSetting;
@@ -55,7 +60,7 @@ function envDefaults(): {
   return {
     warmPool: { enabled: config.KORTIX_WARM_POOL_ENABLED, size: Math.max(0, config.KORTIX_WARM_POOL_SIZE) },
     fallback: { enabled: false },
-    warmSnapshot: { enabled: true },
+    warmSnapshot: { enabled: config.KORTIX_WARM_SNAPSHOT_ENABLED },
   };
 }
 


### PR DESCRIPTION
**The admin warm-template toggle didn't stick.** It wrote `{enabled:false}` to `platform_settings` correctly, but `runtime-settings.envDefaults()` **hardcoded** `warmSnapshot.enabled=true`, and `KORTIX_WARM_SNAPSHOT_ENABLED` wasn't in `config` at all. So whenever the 30s cache was cold — **every fresh pod, e.g. right after a deploy** — `warmSnapshotSetting()` returned `true` regardless of the operator's OFF, for ~30s. Long enough to warm-fork a **stale seed OpenCode**, which after the `kortix/auto` default change (#3765) wedged its config routes — the 2026-06-26 incident.

- `config.ts`: add `KORTIX_WARM_SNAPSHOT_ENABLED` (schema + config object) so the env is actually read (was dead code).
- `runtime-settings.ts`: `envDefaults().warmSnapshot` reads the config instead of hardcoded `true`.
- `index.ts`: warm the runtime-settings cache at boot (before serving) so the DB toggle is honored from request #1 — no cold-cache window.
- test: regression for the cold-cache env default.

tsc clean; 11/11 toggle tests pass. (The `kortix/auto` default revert is separate — #3765 / Marko.)