### PR TITLE
fix(warm-template): admin toggle is the only control — default OFF/opt-in, honored from boot

### DIFF
--- a/apps/api/src/__tests__/unit-warm-snapshot-toggle.test.ts
+++ b/apps/api/src/__tests__/unit-warm-snapshot-toggle.test.ts
@@ -24,7 +24,6 @@ const cfg = {
   DAYTONA_WARM_TARGET: '',
   KORTIX_WARM_POOL_ENABLED: false,
   KORTIX_WARM_POOL_SIZE: 0,
-  KORTIX_WARM_SNAPSHOT_ENABLED: true,
 };
 let platinumConfigured = false;
 
@@ -50,6 +49,7 @@ async function loadRows(rows: Array<{ key: string; value: unknown }>): Promise<v
   await refreshRuntimeSettings();
 }
 const MASTER_OFF = [{ key: WARM_SNAPSHOT_KEY, value: { enabled: false } }];
+const MASTER_ON = [{ key: WARM_SNAPSHOT_KEY, value: { enabled: true } }];
 
 beforeEach(() => {
   // Clean per-provider sub-gate baseline; each test sets what it needs.
@@ -58,34 +58,30 @@ beforeEach(() => {
   platinumConfigured = false;
 });
 
-describe('warmSnapshotSetting (DB-backed admin master, default ON)', () => {
-  test('no warm_snapshot row → enabled:true (ON by default)', async () => {
+describe('warmSnapshotSetting (admin-panel toggle, OFF by default / opt-in)', () => {
+  test('no warm_snapshot row → OFF (opt-in; the admin panel must explicitly enable it)', async () => {
     await loadRows([]);
-    expect(warmSnapshotSetting().enabled).toBe(true);
+    expect(warmSnapshotSetting().enabled).toBe(false);
   });
 
-  test('row { enabled: false } → master OFF', async () => {
+  test('row { enabled: false } → OFF', async () => {
     await loadRows(MASTER_OFF);
     expect(warmSnapshotSetting().enabled).toBe(false);
   });
 
-  test('row { enabled: true } → master ON', async () => {
-    await loadRows([{ key: WARM_SNAPSHOT_KEY, value: { enabled: true } }]);
+  test('row { enabled: true } → ON (admin opted in)', async () => {
+    await loadRows(MASTER_ON);
     expect(warmSnapshotSetting().enabled).toBe(true);
   });
 
-  test('cold cache (before first DB read) follows KORTIX_WARM_SNAPSHOT_ENABLED, not a hardcoded ON', () => {
-    // Regression for the 2026-06-26 opencode wedge: a fresh pod served warm-snapshot
-    // ON for the ~30s cold-cache window despite an operator "off", warm-forking a
-    // stale seed. The cold default is now the env, so a deployment pinned OFF stays
-    // OFF before any DB refresh. (invalidate → cache=null → sync read = envDefaults.)
-    dbRows = [];
-    cfg.KORTIX_WARM_SNAPSHOT_ENABLED = false;
-    invalidateRuntimeSettings();
+  test('cold cache (before first DB read) is OFF — never warm-fork before the toggle loads', () => {
+    // Regression for the 2026-06-26 opencode wedge: a fresh pod served warm ON for
+    // the ~30s cold-cache window despite the admin "off", warm-forking a stale seed.
+    // An unloaded cache now resolves OFF even when the row is ON — boot warms the
+    // cache before serving, so the row is read before any session is created.
+    dbRows = MASTER_ON;
+    invalidateRuntimeSettings(); // cache=null → sync read = OFF defaults
     expect(warmSnapshotSetting().enabled).toBe(false);
-    cfg.KORTIX_WARM_SNAPSHOT_ENABLED = true;
-    invalidateRuntimeSettings();
-    expect(warmSnapshotSetting().enabled).toBe(true);
   });
 });
 
@@ -99,8 +95,17 @@ describe('warmSnapshotsEnabledFor (master AND per-provider sub-gate)', () => {
     expect(warmSnapshotsEnabledFor('platinum')).toBe(false);
   });
 
+  test('no row (default OFF) → false for every provider even with sub-gates satisfied', async () => {
+    await loadRows([]);
+    cfg.DAYTONA_API_KEY = 'k';
+    cfg.DAYTONA_WARM_TARGET = 'experimental';
+    platinumConfigured = true;
+    expect(warmSnapshotsEnabledFor('daytona')).toBe(false);
+    expect(warmSnapshotsEnabledFor('platinum')).toBe(false);
+  });
+
   test('master ON + daytona: requires DAYTONA_WARM_TARGET (+ API key)', async () => {
-    await loadRows([]); // master ON (default)
+    await loadRows(MASTER_ON);
     cfg.DAYTONA_API_KEY = 'k';
     cfg.DAYTONA_WARM_TARGET = 'experimental';
     expect(warmSnapshotsEnabledFor('daytona')).toBe(true);
@@ -112,7 +117,7 @@ describe('warmSnapshotsEnabledFor (master AND per-provider sub-gate)', () => {
   });
 
   test('master ON + platinum: requires isPlatinumConfigured()', async () => {
-    await loadRows([]); // master ON
+    await loadRows(MASTER_ON);
     platinumConfigured = true;
     expect(warmSnapshotsEnabledFor('platinum')).toBe(true);
     platinumConfigured = false;
@@ -120,7 +125,7 @@ describe('warmSnapshotsEnabledFor (master AND per-provider sub-gate)', () => {
   });
 
   test('platinum does NOT depend on the daytona warm target', async () => {
-    await loadRows([]); // master ON
+    await loadRows(MASTER_ON);
     cfg.DAYTONA_API_KEY = '';
     cfg.DAYTONA_WARM_TARGET = ''; // daytona would be OFF…
     platinumConfigured = true; // …but platinum only needs a configured host
@@ -129,14 +134,14 @@ describe('warmSnapshotsEnabledFor (master AND per-provider sub-gate)', () => {
   });
 
   test('unknown provider → false even with master ON', async () => {
-    await loadRows([]); // master ON
+    await loadRows(MASTER_ON);
     expect(warmSnapshotsEnabledFor('local_docker' as never)).toBe(false);
   });
 
   test('warmSnapshotsEnabled() (daytona helper) tracks master AND warm target', async () => {
     cfg.DAYTONA_API_KEY = 'k';
     cfg.DAYTONA_WARM_TARGET = 'experimental';
-    await loadRows([]); // master ON
+    await loadRows(MASTER_ON);
     expect(warmSnapshotsEnabled()).toBe(true);
     await loadRows(MASTER_OFF); // master OFF gates it off despite the target
     expect(warmSnapshotsEnabled()).toBe(false);
@@ -144,11 +149,11 @@ describe('warmSnapshotsEnabledFor (master AND per-provider sub-gate)', () => {
 });
 
 // LAST: the unloaded-cache sync fallback. This read kicks a background refresh,
-// so it goes last with dbRows=[] (that refresh also resolves to ON) → harmless.
+// so it goes last with dbRows=[] → harmless.
 describe('warmSnapshotSetting (unloaded-cache fallback)', () => {
-  test('an unloaded cache returns the env default (enabled:true) synchronously', () => {
+  test('an unloaded cache returns OFF synchronously (fail-safe; never warm before the row loads)', () => {
     dbRows = [];
     invalidateRuntimeSettings();
-    expect(warmSnapshotSetting().enabled).toBe(true);
+    expect(warmSnapshotSetting().enabled).toBe(false);
   });
 });

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -140,14 +140,6 @@ const envSchema = z.object({
   // from the admin Providers panel (runtime-settings.ts → warmPoolEnabled()).
   // When OFF the allocator skips the claim path and every create cold-provisions.
   KORTIX_WARM_POOL_ENABLED:        optBoolFalse,
-  // Master on/off for per-project warm-fork SNAPSHOTS (the ~2s warm start). The
-  // FALLBACK default read when the DB `warm_snapshot` row is absent OR the
-  // runtime-settings cache is still cold (fresh pod / DB hiccup). Previously this
-  // default was hardcoded ON in runtime-settings.ts, so a just-started pod ignored
-  // an operator's "off" for ~30s and could warm-fork a stale seed (the 2026-06-26
-  // opencode-wedge incident). Default ON (warm-fork is a latency win); the live
-  // control surface is the admin `warm_snapshot` toggle (warmSnapshotSetting()).
-  KORTIX_WARM_SNAPSHOT_ENABLED:    optBoolTrue,
   // Stage-2 pre-warm: provision each spare WITH its project identity (repo, no
   // session) and tell the daemon (KORTIX_WARM_POOL_CLONE_AT_PARK) to clone the
   // base branch + warm the opencode project plugin AT PARK — so a claim only
@@ -597,7 +589,6 @@ export const config = {
   KORTIX_GIT_PROXY: env.KORTIX_GIT_PROXY,
   KORTIX_WARM_POOL_SIZE: env.KORTIX_WARM_POOL_SIZE,
   KORTIX_WARM_POOL_ENABLED: env.KORTIX_WARM_POOL_ENABLED,
-  KORTIX_WARM_SNAPSHOT_ENABLED: env.KORTIX_WARM_SNAPSHOT_ENABLED,
   KORTIX_WARM_POOL_CLONE_AT_PARK: env.KORTIX_WARM_POOL_CLONE_AT_PARK,
   KORTIX_WARM_POOL_PRESENCE_MINUTES: env.KORTIX_WARM_POOL_PRESENCE_MINUTES,
   KORTIX_PRERESUME_ENABLED: env.KORTIX_PRERESUME_ENABLED,

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -983,13 +983,12 @@ let schemaReady = false;
 async function startReplicaServices() {
   startAccessControlCache();
   startTunnelService();
-  // Warm the runtime-settings cache BEFORE serving traffic so the DB-backed admin
+  // Warm the runtime-settings cache BEFORE serving traffic so the admin-panel
   // toggles (warm_snapshot / warm_pool / provider_fallback) are honored from
-  // request #1. Without this a fresh pod serves the cold-cache env defaults for
-  // the first ~30s — which on a deploy let warm_snapshot resolve to the (old
-  // hardcoded) ON despite an operator "off", warm-forking a stale seed: the
-  // 2026-06-26 opencode-wedge incident. Best-effort: a DB hiccup leaves the env
-  // defaults, which now honor KORTIX_WARM_SNAPSHOT_ENABLED.
+  // request #1. Without this a fresh pod serves the cold-cache defaults for the
+  // first ~30s — which on a deploy let warm_snapshot resolve to the (old hardcoded)
+  // ON despite the admin "off", warm-forking a stale seed: the 2026-06-26 opencode
+  // wedge. Best-effort: a DB hiccup leaves the fail-safe OFF defaults.
   await import('./platform/services/runtime-settings')
     .then((m) => m.refreshRuntimeSettings())
     .catch(() => {});

--- a/apps/api/src/platform/services/runtime-settings.ts
+++ b/apps/api/src/platform/services/runtime-settings.ts
@@ -11,15 +11,15 @@ import { config } from '../../config';
  * after writing, so a toggle takes effect immediately for the writing process;
  * other processes pick it up within the TTL.
  *
- * Defaults come from envDefaults() — the env IS read (KORTIX_WARM_POOL_ENABLED /
- * KORTIX_WARM_SNAPSHOT_ENABLED), so an operator can pin a whole deployment OFF
- * without ever writing a DB row. warm_pool + provider_fallback ship OFF;
- * warm_snapshot follows KORTIX_WARM_SNAPSHOT_ENABLED (ON unless pinned off).
- * A cold cache / missing row resolves to that env default — NOT a hardcoded ON.
- * (Previously warm_snapshot hardcoded ON here on the theory "a failed bake just
- * degrades to a cold clone"; the 2026-06-26 opencode wedge disproved it — a STALE
- * warm seed can hang a session — so "on" is not unconditionally safe and the
- * operator's setting must win even before the first DB refresh.)
+ * The admin DB row is the ONLY control surface for all three — NOT env vars.
+ * warm_pool, provider_fallback AND warm_snapshot all default OFF and are opt-in
+ * via the panel (the panel writes { enabled: true }). A cold cache / DB hiccup /
+ * missing row resolves to OFF, so a fresh pod (e.g. right after a deploy) is
+ * never warm on against the admin's setting before the first DB read completes —
+ * boot awaits refreshRuntimeSettings() so the row is loaded before serving.
+ * (Previously warm_snapshot hardcoded ON on the theory "a failed bake just
+ * cold-clones"; the 2026-06-26 opencode wedge disproved it — a STALE warm seed
+ * can hang a session — so off-until-explicitly-enabled is the safe direction.)
  */
 
 export const WARM_POOL_KEY = 'warm_pool';
@@ -49,9 +49,13 @@ export interface WarmSnapshotSetting {
 const TTL_MS = 30_000;
 const MAX_WARM_SIZE = 25;
 
-/** Env is the FALLBACK default; the DB row is the live control surface, so
- *  operators flip the admin toggle without a redeploy. warm_pool/fallback ship
- *  OFF; warm_snapshot follows KORTIX_WARM_SNAPSHOT_ENABLED (ON unless pinned off). */
+/** Fallback defaults used until the DB rows load and whenever the DB can't be
+ *  read. ALL default OFF (fail-safe): warm_snapshot is now admin-OPT-IN — the
+ *  admin Providers panel turns it on/off and that DB row is the ONLY control
+ *  surface (no env knob). A cold cache / DB hiccup / no row therefore resolves to
+ *  OFF, so a fresh pod (e.g. right after a deploy) never warm-forks against the
+ *  admin's "off" — the 2026-06-26 stale-seed opencode wedge. The old "default ON,
+ *  a failed bake just cold-clones" premise was wrong: a stale warm seed can hang. */
 function envDefaults(): {
   warmPool: WarmPoolSetting;
   fallback: ProviderFallbackSetting;
@@ -60,7 +64,7 @@ function envDefaults(): {
   return {
     warmPool: { enabled: config.KORTIX_WARM_POOL_ENABLED, size: Math.max(0, config.KORTIX_WARM_POOL_SIZE) },
     fallback: { enabled: false },
-    warmSnapshot: { enabled: config.KORTIX_WARM_SNAPSHOT_ENABLED },
+    warmSnapshot: { enabled: false },
   };
 }
 
@@ -98,14 +102,14 @@ export async function refreshRuntimeSettings(): Promise<void> {
         } else if (r.key === PROVIDER_FALLBACK_KEY) {
           fallback = { enabled: v.enabled === true };
         } else if (r.key === WARM_SNAPSHOT_KEY) {
-          // A row is authoritative (enabled may be explicitly false). With NO row,
-          // the env default (ON) stands — warm-fork is on out of the box.
+          // The admin row is the ONLY control. With NO row warm-fork stays OFF
+          // (envDefaults) — it is opt-in; the admin panel writes { enabled: true }.
           warmSnapshot = { enabled: v.enabled === true };
         }
       }
     }
   } catch {
-    /* DB hiccup -> env defaults (warm_pool/fallback OFF, warm_snapshot ON) */
+    /* DB hiccup -> fail-safe defaults: warm_pool/fallback/warm_snapshot all OFF */
   }
   cache = { warmPool, fallback, warmSnapshot, at: Date.now() };
 }

--- a/infra/k8s/envs/dev/values.yaml
+++ b/infra/k8s/envs/dev/values.yaml
@@ -6,7 +6,7 @@
 # Immutable dev tag (CI bumps to dev-<sha8> on each main push). Bootstrap value
 # is :dev-latest until the first deploy-dev-eks run pins an immutable sha.
 image:
-  tag: "dev-23c0bb4d"
+  tag: "dev-9e7248dc"
 kortixVersion: ""
 env:
   internalKortixEnv: dev
@@ -22,7 +22,8 @@ extraEnv:
   # the API falls back to its in-API /v1/llm passthrough (OpenRouter-only, wrong
   # catalog shape) and the model picker collapses to a single model.
   LLM_GATEWAY_BASE_URL: "https://gateway-dev.kortix.com/v1/llm"
-  KORTIX_WARM_SNAPSHOT_ENABLED: "false"
+  # NOTE: warm-template (warm_snapshot) is NOT an env — it's the admin Providers
+  # panel toggle (DB row), default OFF / opt-in. Don't reintroduce an env knob.
   # Idle auto-stop for sandboxes (Daytona AND Platinum honor this now — Platinum
   # used to hardcode persistent and depend on the maintenance reaper, which died
   # and let boxes run 24/7 and flood the host). 15min keeps idle cost down; a


### PR DESCRIPTION
Follow-up to #3831. The warm-template (`warm_snapshot`) control is the **admin Providers panel toggle (DB row), not an env**. Two defects behind the 2026-06-26 opencode wedge:

1. **Cold cache ignored the toggle:** runtime-settings is a lazy 30s-TTL cache, so a fresh pod (e.g. right after a deploy) served the default for ~30s regardless of the admin OFF — long enough to warm-fork a stale-seed OpenCode that wedged its config routes.
2. The cold/fallback default was ON; #3831 briefly papered over it with an env knob.

**Fix (admin-row-only, fail-safe):**
- `config.ts`: drop `KORTIX_WARM_SNAPSHOT_ENABLED` — no env knob.
- `runtime-settings.ts`: `warm_snapshot` defaults **OFF**, opt-in via the admin row `{enabled:true}`; cold cache / DB hiccup / missing row resolve **OFF**, so warm never turns on against the admin setting before the row loads.
- `index.ts`: `await refreshRuntimeSettings()` at boot so the row is read before serving — no cold-cache window.
- `values.yaml`: remove the dead env line.

tsc clean; 12/12 toggle tests pass (incl. a cold-cache=OFF regression test).