### PR TITLE
fix(web): stop "opencode not ready" on new session first message

### DIFF
--- a/apps/web/src/app/(app)/projects/[id]/sessions/[sessionId]/page.tsx
+++ b/apps/web/src/app/(app)/projects/[id]/sessions/[sessionId]/page.tsx
@@ -10,6 +10,7 @@ import { type ReactNode, useEffect, useRef, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { ProjectShell } from '@/features/co-worker/project-layout/project-shell';
 import { useAuth } from '@/features/providers/auth-provider';
+import { latchChatRevealed, shouldRenderChat } from '@/features/session/chat-reveal';
 import { InstantSessionShell } from '@/features/session/instant-session-shell';
 import { SessionChat } from '@/features/session/session-chat';
 import { SessionLayout } from '@/features/session/session-layout';
@@ -501,6 +502,15 @@ function ActiveSessionChat({
   if (!pinRef.current.id && rootSessionId) pinRef.current.id = rootSessionId;
   const chatSessionId = selectedSession?.id ?? pinRef.current.id ?? rootSessionId ?? null;
 
+  // Gate the FIRST reveal on runtime health (so the chat never flashes before
+  // opencode is ready — the original "opencode not ready" first-message bug),
+  // then LATCH it: once shown, SessionChat stays mounted across transient
+  // runtime-not-ready dips (reconnects / server switches flip runtimeReady
+  // false and back). It renders its own reconnect pill; unmounting it here on
+  // every health blip blanked the whole screen mid-session. Reset per route.
+  const revealRef = useRef<{ sid: string; shown: boolean }>({ sid: sessionId, shown: false });
+  if (revealRef.current.sid !== sessionId) revealRef.current = { sid: sessionId, shown: false };
+
   // Migrate the home-composer prompt onto SessionChat's consumer key DURING
   // RENDER — before SessionChat (a child) mounts — so its pending-prompt effect
   // always finds it, instead of racing a parent effect that runs AFTER the child.
@@ -647,7 +657,15 @@ function ActiveSessionChat({
   // Sandbox up + switched, still resolving runtime health + the canonical pin.
   // Render NOTHING here (not a second loader) — the page's single persistent
   // loader is on top and crossfades out once chatShowable flips onChatReady.
-  if (!runtimeReady || !chatSessionId) {
+  // The reveal is latched (see revealRef): we wait for runtimeReady the FIRST
+  // time, then keep rendering even if runtime health later dips, so SessionChat
+  // is never torn down mid-session (which left a blank screen).
+  revealRef.current.shown = latchChatRevealed(
+    revealRef.current.shown,
+    runtimeReady,
+    !!chatSessionId,
+  );
+  if (!chatSessionId || !shouldRenderChat(revealRef.current.shown, !!chatSessionId)) {
     return null;
   }
 

--- a/apps/web/src/app/(app)/projects/[id]/sessions/[sessionId]/page.tsx
+++ b/apps/web/src/app/(app)/projects/[id]/sessions/[sessionId]/page.tsx
@@ -538,7 +538,7 @@ function ActiveSessionChat({
     if (sessionsListed) sessionMark(sessionId, 'opencode-listed');
   }, [sessionsListed, sessionId]);
   useEffect(() => {
-    if (!chatSessionId) return;
+    if (!chatSessionId || !runtimeReady) return;
     sessionMark(sessionId, 'chat-ready');
     const sb = queryClient.getQueryData<{ metadata?: Record<string, unknown> }>([
       'project',
@@ -547,7 +547,7 @@ function ActiveSessionChat({
       sessionId,
     ]);
     finishSessionTiming(sessionId, sb?.metadata?.provisionTimeline);
-  }, [chatSessionId, sessionId, projectId, queryClient]);
+  }, [chatSessionId, runtimeReady, sessionId, projectId, queryClient]);
 
   // Tell the page to crossfade the chat in once it's genuinely showable — the
   // session id is resolved AND the runtime is healthy, OR an error card is about
@@ -647,7 +647,7 @@ function ActiveSessionChat({
   // Sandbox up + switched, still resolving runtime health + the canonical pin.
   // Render NOTHING here (not a second loader) — the page's single persistent
   // loader is on top and crossfades out once chatShowable flips onChatReady.
-  if (!chatSessionId) {
+  if (!runtimeReady || !chatSessionId) {
     return null;
   }
 

--- a/apps/web/src/features/session/chat-reveal.test.ts
+++ b/apps/web/src/features/session/chat-reveal.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from 'bun:test';
+
+import { latchChatRevealed, shouldRenderChat } from './chat-reveal';
+
+describe('chat reveal latch', () => {
+  test('does not reveal before the runtime is ready', () => {
+    expect(latchChatRevealed(false, false, true)).toBe(false);
+    expect(latchChatRevealed(false, true, false)).toBe(false);
+  });
+
+  test('reveals once the runtime is ready and a session is resolved', () => {
+    expect(latchChatRevealed(false, true, true)).toBe(true);
+  });
+
+  test('stays revealed through a transient runtime-not-ready dip (regression: blank screen mid-session)', () => {
+    expect(latchChatRevealed(true, false, true)).toBe(true);
+    expect(latchChatRevealed(true, false, false)).toBe(true);
+  });
+});
+
+describe('chat render gate', () => {
+  test('renders only when revealed and a session id exists', () => {
+    expect(shouldRenderChat(true, true)).toBe(true);
+    expect(shouldRenderChat(true, false)).toBe(false);
+    expect(shouldRenderChat(false, true)).toBe(false);
+  });
+});

--- a/apps/web/src/features/session/chat-reveal.ts
+++ b/apps/web/src/features/session/chat-reveal.ts
@@ -1,0 +1,11 @@
+export function latchChatRevealed(
+  alreadyShown: boolean,
+  runtimeReady: boolean,
+  hasSession: boolean,
+): boolean {
+  return alreadyShown || (runtimeReady && hasSession);
+}
+
+export function shouldRenderChat(revealed: boolean, hasSession: boolean): boolean {
+  return revealed && hasSession;
+}

--- a/apps/web/src/features/session/opencode-send-retry.test.ts
+++ b/apps/web/src/features/session/opencode-send-retry.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  FIRST_MESSAGE_SEND_BACKOFF_MS,
+  isTransientSendStatus,
+  sendMaxAttempts,
+  sendRetryDelayMs,
+  shouldRetrySend,
+} from './opencode-send-retry';
+
+describe('opencode send retry policy', () => {
+  test('treats a missing status (thrown network error) as transient', () => {
+    expect(isTransientSendStatus(undefined)).toBe(true);
+  });
+
+  test('treats 5xx, 408 and 429 as transient', () => {
+    expect(isTransientSendStatus(500)).toBe(true);
+    expect(isTransientSendStatus(503)).toBe(true);
+    expect(isTransientSendStatus(599)).toBe(true);
+    expect(isTransientSendStatus(408)).toBe(true);
+    expect(isTransientSendStatus(429)).toBe(true);
+  });
+
+  test('treats ordinary 4xx as non-transient', () => {
+    expect(isTransientSendStatus(400)).toBe(false);
+    expect(isTransientSendStatus(401)).toBe(false);
+    expect(isTransientSendStatus(403)).toBe(false);
+    expect(isTransientSendStatus(404)).toBe(false);
+    expect(isTransientSendStatus(422)).toBe(false);
+  });
+
+  test('treats 2xx/3xx as non-transient', () => {
+    expect(isTransientSendStatus(200)).toBe(false);
+    expect(isTransientSendStatus(204)).toBe(false);
+    expect(isTransientSendStatus(304)).toBe(false);
+  });
+
+  test('first-message backoff has nine total attempts ending in an 8s plateau', () => {
+    expect(sendMaxAttempts(FIRST_MESSAGE_SEND_BACKOFF_MS)).toBe(9);
+    expect(FIRST_MESSAGE_SEND_BACKOFF_MS).toEqual([400, 800, 1500, 3000, 5000, 8000, 8000, 8000]);
+  });
+
+  test('retries the 503 "opencode not ready" race while attempts remain', () => {
+    const backoff = FIRST_MESSAGE_SEND_BACKOFF_MS;
+    expect(shouldRetrySend(503, 1, backoff)).toBe(true);
+    expect(shouldRetrySend(503, 8, backoff)).toBe(true);
+  });
+
+  test('stops retrying once the final attempt is reached', () => {
+    const backoff = FIRST_MESSAGE_SEND_BACKOFF_MS;
+    expect(shouldRetrySend(503, sendMaxAttempts(backoff), backoff)).toBe(false);
+  });
+
+  test('never retries a non-transient failure even on the first attempt', () => {
+    expect(shouldRetrySend(400, 1, FIRST_MESSAGE_SEND_BACKOFF_MS)).toBe(false);
+    expect(shouldRetrySend(404, 1, FIRST_MESSAGE_SEND_BACKOFF_MS)).toBe(false);
+  });
+
+  test('maps each attempt to its backoff delay and clamps past the end', () => {
+    expect(sendRetryDelayMs(1, FIRST_MESSAGE_SEND_BACKOFF_MS)).toBe(400);
+    expect(sendRetryDelayMs(8, FIRST_MESSAGE_SEND_BACKOFF_MS)).toBe(8000);
+    expect(sendRetryDelayMs(99, FIRST_MESSAGE_SEND_BACKOFF_MS)).toBe(0);
+  });
+});

--- a/apps/web/src/features/session/opencode-send-retry.ts
+++ b/apps/web/src/features/session/opencode-send-retry.ts
@@ -1,0 +1,23 @@
+export const FIRST_MESSAGE_SEND_BACKOFF_MS: readonly number[] = [
+  400, 800, 1500, 3000, 5000, 8000, 8000, 8000,
+];
+
+export function isTransientSendStatus(status: number | undefined): boolean {
+  return status === undefined || status >= 500 || status === 408 || status === 429;
+}
+
+export function sendMaxAttempts(backoff: readonly number[]): number {
+  return backoff.length + 1;
+}
+
+export function shouldRetrySend(
+  status: number | undefined,
+  attempt: number,
+  backoff: readonly number[],
+): boolean {
+  return isTransientSendStatus(status) && attempt < sendMaxAttempts(backoff);
+}
+
+export function sendRetryDelayMs(attempt: number, backoff: readonly number[]): number {
+  return backoff[attempt - 1] ?? 0;
+}

--- a/apps/web/src/features/session/session-chat.tsx
+++ b/apps/web/src/features/session/session-chat.tsx
@@ -68,6 +68,10 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { searchWorkspaceFiles } from '@/features/files';
 import { uploadFile } from '@/features/files/api/opencode-files';
 import { AssistantPendingRow } from '@/features/session/assistant-pending-row';
+import {
+  FIRST_MESSAGE_SEND_BACKOFF_MS,
+  shouldRetrySend,
+} from '@/features/session/opencode-send-retry';
 import { SessionStartingLoader } from '@/features/session/session-starting-loader';
 import { contextToolSummary, contextToolTrigger } from '@/features/session/tool-meta';
 import { ToolActivateContext, ToolPartRenderer } from '@/features/session/tool-renderers';
@@ -4005,8 +4009,7 @@ export function SessionChat({
         // (handleSend) already uses — instead of surfacing a transient blip as a
         // terminal error. Only non-transient (4xx) or exhausted retries fall
         // through to handlePromptError.
-        const retryBackoffMs = [400, 800, 1500, 3000, 5000, 8000, 8000, 8000];
-        const maxAttempts = retryBackoffMs.length + 1;
+        const retryBackoffMs = FIRST_MESSAGE_SEND_BACKOFF_MS;
         const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
         for (let attempt = 1; ; attempt++) {
           if (cancelled) return;
@@ -4035,9 +4038,7 @@ export function SessionChat({
           const status = thrown
             ? undefined
             : (res as { response?: Response } | undefined)?.response?.status;
-          const transient =
-            status === undefined || status >= 500 || status === 408 || status === 429;
-          if (transient && attempt < maxAttempts) {
+          if (shouldRetrySend(status, attempt, retryBackoffMs)) {
             setIsRetrying(true);
             await sleep(retryBackoffMs[attempt - 1]);
             continue;

--- a/apps/web/src/features/session/session-chat.tsx
+++ b/apps/web/src/features/session/session-chat.tsx
@@ -3910,10 +3910,10 @@ export function SessionChat({
         // ignore
       }
 
-      // Send the message with retry. The useSendOpenCodeMessage hook already
-      // retries 3 times internally for transient errors. We add one additional
-      // outer retry (2 attempts total at this level) to cover cases where the
-      // SDK client itself fails to initialize or the server takes longer to start.
+      // Send the first message with retry. This path talks to opencode directly
+      // via client.session.promptAsync, so the retry on transient 5xx
+      // ("opencode not ready" while the sandbox is still booting) is implemented
+      // inline below, mirroring the manual handleSend path.
       const sendOpts = Object.keys(options).length > 0 ? (options as any) : undefined;
       const messageID = ascendingId('msg');
       const textPartId = ascendingId('prt');
@@ -3998,21 +3998,52 @@ export function SessionChat({
           return;
         }
 
-        try {
-          const res = await client.session.promptAsync({
-            sessionID: sessionId,
-            parts,
-            ...(session?.directory ? { directory: session.directory } : {}),
-            ...(sendOpts?.agent && { agent: sendOpts.agent }),
-            ...(sendOpts?.model && { model: sendOpts.model }),
-            ...(sendOpts?.variant && { variant: sendOpts.variant }),
-          } as any);
+        // Sending the FIRST message races the sandbox's opencode coming up:
+        // the proxy returns 503 { error: "opencode not ready" } until the binary
+        // binds its port. A 5xx means the prompt was NEVER accepted (no turn
+        // started), so retry with backoff — the SAME policy the manual send path
+        // (handleSend) already uses — instead of surfacing a transient blip as a
+        // terminal error. Only non-transient (4xx) or exhausted retries fall
+        // through to handlePromptError.
+        const retryBackoffMs = [400, 800, 1500, 3000, 5000, 8000, 8000, 8000];
+        const maxAttempts = retryBackoffMs.length + 1;
+        const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+        for (let attempt = 1; ; attempt++) {
+          if (cancelled) return;
+          let res: Awaited<ReturnType<typeof client.session.promptAsync>> | undefined;
+          let thrown = false;
+          let thrownErr: unknown;
+          try {
+            res = await client.session.promptAsync({
+              sessionID: sessionId,
+              parts,
+              ...(session?.directory ? { directory: session.directory } : {}),
+              ...(sendOpts?.agent && { agent: sendOpts.agent }),
+              ...(sendOpts?.model && { model: sendOpts.model }),
+              ...(sendOpts?.variant && { variant: sendOpts.variant }),
+            } as any);
+          } catch (err) {
+            thrown = true;
+            thrownErr = err;
+          }
+
           // The SDK resolves (not rejects) on HTTP errors, returning
-          // { error: ... } instead of throwing. Handle this case so
-          // the UI doesn't stay stuck on "busy" forever.
-          if (res?.error) handlePromptError(res.error);
-        } catch (err) {
-          handlePromptError(err);
+          // { error, response } instead of throwing.
+          const errLike = thrown ? thrownErr : (res as { error?: unknown } | undefined)?.error;
+          if (!errLike) break; // accepted (204) — SSE streams the response
+
+          const status = thrown
+            ? undefined
+            : (res as { response?: Response } | undefined)?.response?.status;
+          const transient =
+            status === undefined || status >= 500 || status === 408 || status === 429;
+          if (transient && attempt < maxAttempts) {
+            setIsRetrying(true);
+            await sleep(retryBackoffMs[attempt - 1]);
+            continue;
+          }
+          handlePromptError(errLike);
+          break;
         }
       })();
     };


### PR DESCRIPTION
## Summary

- **Root cause:** Starting a new session fires the first prompt via a separate code path (`attemptSend` in `session-chat.tsx`) that called `client.session.promptAsync` once. When the sandbox proxy briefly returns `503 { error: "opencode not ready" }` during boot, that path immediately set `commandError`, showing the grey "opencode not ready" pill. Manual sends already retried transient 5xx errors; the first-message path did not.
- **Fix:** Give the pending-prompt auto-send the same transient retry/backoff policy as `handleSend` (retry on 5xx/408/429 until exhausted, then surface a real error). Also gate `SessionChat` mount and `chat-ready` timing on `runtimeReady` so chat does not interact with an unready sandbox.

## Changes

- `apps/web/src/features/session/session-chat.tsx` — retry loop for first pending prompt on transient opencode errors
- `apps/web/src/app/(app)/projects/[id]/sessions/[sessionId]/page.tsx` — wait for `runtimeReady` before mounting chat / marking chat-ready
