### PR TITLE
fix(web): retry transient "opencode not ready" on first prompt send

### DIFF
--- a/apps/web/src/features/session/opencode-send-retry.test.ts
+++ b/apps/web/src/features/session/opencode-send-retry.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  extractSendErrorMessage,
+  getSendRetryDelayMs,
+  isOpenCodeNotReadyError,
+  isTransientSendStatus,
+} from './opencode-send-retry';
+
+describe('extractSendErrorMessage', () => {
+  test('reads thrown Error messages', () => {
+    expect(extractSendErrorMessage(new Error('opencode not ready'))).toBe('opencode not ready');
+  });
+
+  test('reads plain strings', () => {
+    expect(extractSendErrorMessage('opencode not ready')).toBe('opencode not ready');
+  });
+
+  test('reads the SDK response-error shape ({ data: { message } })', () => {
+    expect(extractSendErrorMessage({ data: { message: 'opencode not ready' } })).toBe(
+      'opencode not ready',
+    );
+  });
+
+  test('reads a top-level message / error field', () => {
+    expect(extractSendErrorMessage({ message: 'boom' })).toBe('boom');
+    expect(extractSendErrorMessage({ error: 'nope' })).toBe('nope');
+  });
+
+  test('returns empty string for nullish input', () => {
+    expect(extractSendErrorMessage(null)).toBe('');
+    expect(extractSendErrorMessage(undefined)).toBe('');
+  });
+});
+
+describe('isOpenCodeNotReadyError', () => {
+  test('matches the boot 503 across shapes and casing', () => {
+    expect(isOpenCodeNotReadyError(new Error('opencode not ready'))).toBe(true);
+    expect(isOpenCodeNotReadyError('OpenCode Not Ready')).toBe(true);
+    expect(isOpenCodeNotReadyError({ data: { message: 'opencode not ready' } })).toBe(true);
+    expect(
+      isOpenCodeNotReadyError('Failed to perform action: opencode not ready'),
+    ).toBe(true);
+  });
+
+  test('does not match unrelated errors', () => {
+    expect(isOpenCodeNotReadyError(new Error('Insufficient credits'))).toBe(false);
+    expect(isOpenCodeNotReadyError({ data: { message: 'Bad request' } })).toBe(false);
+    expect(isOpenCodeNotReadyError(null)).toBe(false);
+  });
+});
+
+describe('isTransientSendStatus', () => {
+  test('treats missing status (thrown transport error) as transient', () => {
+    expect(isTransientSendStatus(undefined)).toBe(true);
+  });
+
+  test('treats 5xx / 408 / 429 as transient', () => {
+    expect(isTransientSendStatus(500)).toBe(true);
+    expect(isTransientSendStatus(503)).toBe(true);
+    expect(isTransientSendStatus(408)).toBe(true);
+    expect(isTransientSendStatus(429)).toBe(true);
+  });
+
+  test('treats other 4xx as terminal', () => {
+    expect(isTransientSendStatus(400)).toBe(false);
+    expect(isTransientSendStatus(401)).toBe(false);
+    expect(isTransientSendStatus(404)).toBe(false);
+  });
+});
+
+describe('getSendRetryDelayMs', () => {
+  test('retries "opencode not ready" across the full boot window', () => {
+    const err = new Error('opencode not ready');
+    // 503 status is reported alongside the boot message.
+    const delays: number[] = [];
+    for (let attempt = 1; ; attempt++) {
+      const delay = getSendRetryDelayMs(attempt, 503, err);
+      if (delay === null) break;
+      delays.push(delay);
+      if (attempt > 20) throw new Error('retry schedule did not terminate');
+    }
+    // 7 retries → 8 total attempts, covering ~16s of cold boot.
+    expect(delays.length).toBe(7);
+    expect(delays.reduce((a, b) => a + b, 0)).toBeGreaterThanOrEqual(15000);
+  });
+
+  test('retries a generic transient 5xx, but only briefly', () => {
+    const err = { data: { message: 'upstream blip' } };
+    expect(getSendRetryDelayMs(1, 502, err)).toBe(400);
+    expect(getSendRetryDelayMs(2, 502, err)).toBe(1000);
+    expect(getSendRetryDelayMs(3, 502, err)).toBe(2000);
+    // Generic transient window exhausts after 3 retries (4 attempts total).
+    expect(getSendRetryDelayMs(4, 502, err)).toBeNull();
+  });
+
+  test('retries a thrown transport error (no status)', () => {
+    const err = new Error('Failed to fetch');
+    expect(getSendRetryDelayMs(1, undefined, err)).toBe(400);
+    expect(getSendRetryDelayMs(3, undefined, err)).toBe(2000);
+    expect(getSendRetryDelayMs(4, undefined, err)).toBeNull();
+  });
+
+  test('never retries a real 4xx client error', () => {
+    const err = { data: { message: 'Bad request' } };
+    expect(getSendRetryDelayMs(1, 400, err)).toBeNull();
+    expect(getSendRetryDelayMs(1, 401, err)).toBeNull();
+    expect(getSendRetryDelayMs(1, 404, err)).toBeNull();
+  });
+
+  test('"opencode not ready" wins even when surfaced as a non-transient status', () => {
+    // Defensive: if the boot 503 is ever relabeled with a 4xx-ish status, the
+    // message still drives a boot-window retry.
+    const err = new Error('opencode not ready');
+    expect(getSendRetryDelayMs(1, 400, err)).toBe(400);
+  });
+});

--- a/apps/web/src/features/session/opencode-send-retry.ts
+++ b/apps/web/src/features/session/opencode-send-retry.ts
@@ -1,0 +1,81 @@
+// Retry policy for sending a prompt to the sandbox's OpenCode server.
+//
+// Two failure shapes flow through here:
+//   1. A thrown error (transport failure — the request never completed). No
+//      HTTP status is available.
+//   2. A resolved SDK response carrying `{ error, response }` (the SDK resolves
+//      rather than rejects on HTTP errors). `response.status` is the status.
+//
+// A freshly-created session points at a sandbox that may still be booting. The
+// proxy comes up before opencode's binary binds its port, so it answers with a
+// `503 "opencode not ready"` for a few seconds. That is a boot signal, not a
+// real failure — retrying across the full boot window lets the first prompt
+// land instead of flashing an "opencode not ready" error banner the user can't
+// act on.
+
+/** Generic transient blips (server restart, tunnel hiccup): short, snappy. */
+const TRANSIENT_BACKOFF_MS = [400, 1000, 2000];
+
+/**
+ * "opencode not ready" boot window — stretched to cover a cold sandbox binding
+ * its opencode port (~16s total), mirroring the create-session retry budget.
+ */
+const BOOT_BACKOFF_MS = [400, 800, 1500, 2500, 4000, 4000, 4000];
+
+/** Pull a human-readable message out of any error/response-error shape. */
+export function extractSendErrorMessage(error: unknown): string {
+  if (!error) return '';
+  if (typeof error === 'string') return error;
+  if (error instanceof Error) return error.message;
+  if (typeof error === 'object') {
+    const err = error as Record<string, any>;
+    const root = err.data ?? err;
+    const msg = root?.message || err.message || root?.error || err.error;
+    if (typeof msg === 'string') return msg;
+    try {
+      return JSON.stringify(err);
+    } catch {
+      return '';
+    }
+  }
+  return String(error);
+}
+
+/**
+ * The sandbox proxy returns `503 "opencode not ready"` while opencode's binary
+ * is still booting inside a freshly-created sandbox.
+ */
+export function isOpenCodeNotReadyError(error: unknown): boolean {
+  return /opencode not ready/i.test(extractSendErrorMessage(error));
+}
+
+/**
+ * A status the server might recover from on its own: no status (thrown
+ * transport error), any 5xx, or a 408/429 backpressure signal. A 4xx is a real
+ * client error (bad request / auth / unknown model) and is never retried.
+ */
+export function isTransientSendStatus(status: number | undefined): boolean {
+  return status === undefined || status >= 500 || status === 408 || status === 429;
+}
+
+/**
+ * Delay (ms) to wait before the next send attempt, or `null` when the send
+ * should stop retrying and surface the error.
+ *
+ * @param attempt 1-based index of the attempt that just failed (1 = first send).
+ *                The returned delay precedes attempt `attempt + 1`.
+ */
+export function getSendRetryDelayMs(
+  attempt: number,
+  status: number | undefined,
+  error: unknown,
+): number | null {
+  const schedule = isOpenCodeNotReadyError(error)
+    ? BOOT_BACKOFF_MS
+    : isTransientSendStatus(status)
+      ? TRANSIENT_BACKOFF_MS
+      : null;
+  if (!schedule) return null;
+  if (attempt < 1 || attempt > schedule.length) return null;
+  return schedule[attempt - 1];
+}

--- a/apps/web/src/features/session/session-chat.tsx
+++ b/apps/web/src/features/session/session-chat.tsx
@@ -47,6 +47,7 @@ import {
 } from '@/features/session/session-chat-input';
 import { SessionContextModal } from '@/features/session/session-context-modal';
 import { SessionRetryDisplay, TurnErrorDisplay } from '@/features/session/session-error-banner';
+import { getSendRetryDelayMs } from '@/features/session/opencode-send-retry';
 import { SessionWelcome } from '@/features/session/session-welcome';
 
 import { SandboxUrlDetector } from '@/components/thread/content/sandbox-url-detector';
@@ -3998,21 +3999,43 @@ export function SessionChat({
           return;
         }
 
-        try {
-          const res = await client.session.promptAsync({
-            sessionID: sessionId,
-            parts,
-            ...(session?.directory ? { directory: session.directory } : {}),
-            ...(sendOpts?.agent && { agent: sendOpts.agent }),
-            ...(sendOpts?.model && { model: sendOpts.model }),
-            ...(sendOpts?.variant && { variant: sendOpts.variant }),
-          } as any);
-          // The SDK resolves (not rejects) on HTTP errors, returning
-          // { error: ... } instead of throwing. Handle this case so
-          // the UI doesn't stay stuck on "busy" forever.
-          if (res?.error) handlePromptError(res.error);
-        } catch (err) {
-          handlePromptError(err);
+        const promptBody = {
+          sessionID: sessionId,
+          parts,
+          ...(session?.directory ? { directory: session.directory } : {}),
+          ...(sendOpts?.agent && { agent: sendOpts.agent }),
+          ...(sendOpts?.model && { model: sendOpts.model }),
+          ...(sendOpts?.variant && { variant: sendOpts.variant }),
+        } as any;
+
+        // A freshly-created session points at a sandbox that may still be
+        // booting opencode — the proxy answers `503 "opencode not ready"` until
+        // the binary binds its port. Retry transient failures (especially that
+        // boot signal) across the full boot window so the very first prompt
+        // lands on its own instead of flashing an "opencode not ready" banner
+        // the user can't act on. The optimistic message + busy status stay up
+        // across retries, so the UI shows the send in progress the whole time.
+        for (let attempt = 1; ; attempt++) {
+          let status: number | undefined;
+          let error: unknown;
+          try {
+            // The SDK resolves (not rejects) on HTTP errors, returning
+            // { error, response } instead of throwing.
+            const res = await client.session.promptAsync(promptBody);
+            if (!res?.error) return; // 204 — server accepted the prompt.
+            error = res.error;
+            status = res?.response?.status as number | undefined;
+          } catch (err) {
+            error = err; // thrown = transport failure (no status).
+          }
+
+          const delay = getSendRetryDelayMs(attempt, status, error);
+          if (delay === null) {
+            handlePromptError(error);
+            return;
+          }
+          await new Promise((r) => setTimeout(r, delay));
+          if (cancelled) return;
         }
       })();
     };
@@ -5002,10 +5025,10 @@ export function SessionChat({
       // thrown network error (request never completed) or a 5xx/429/408
       // response — so an already-queued prompt is never double-sent. A 4xx
       // (bad request, auth, missing model key) is a real failure and surfaces
-      // immediately. The optimistic user message + busy status stay up across
-      // retries, so the UI shows the send in progress the whole time.
-      const retryBackoffMs = [400, 1000, 2000];
-      const maxAttempts = retryBackoffMs.length + 1;
+      // immediately. The lone exception is the sandbox proxy's "opencode not
+      // ready" 503 boot signal, which retries across the full boot window (see
+      // getSendRetryDelayMs). The optimistic user message + busy status stay up
+      // across retries, so the UI shows the send in progress the whole time.
       const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
       let res: any;
@@ -5032,8 +5055,9 @@ export function SessionChat({
               error: caughtErr,
             },
           );
-          if (attempt < maxAttempts) {
-            await sleep(retryBackoffMs[attempt - 1]);
+          const delay = getSendRetryDelayMs(attempt, undefined, caughtErr);
+          if (delay !== null) {
+            await sleep(delay);
             continue;
           }
           handleSendError();
@@ -5059,10 +5083,9 @@ export function SessionChat({
               error: res?.error,
             },
           );
-          const transient =
-            status === undefined || status >= 500 || status === 408 || status === 429;
-          if (transient && attempt < maxAttempts) {
-            await sleep(retryBackoffMs[attempt - 1]);
+          const delay = getSendRetryDelayMs(attempt, status, res?.error);
+          if (delay !== null) {
+            await sleep(delay);
             continue;
           }
           handleSendError();


### PR DESCRIPTION
## Problem

Starting a **new** session flashed an `opencode not ready` error banner on the session page.

The dashboard stashes the prompt and the session page auto-sends it on mount. That auto-send path called `client.session.promptAsync(...)` with **no retry**, so the transient `503 "opencode not ready"` the sandbox proxy returns while a freshly-created sandbox is still booting its opencode binary (port not yet bound) went straight to `setCommandError(...)` and rendered the banner. The create-session hook and the React Query toast layer already tolerate this 503 — this one send path didn't.

## Fix

- **New `opencode-send-retry.ts`** — a pure, testable retry policy (`isOpenCodeNotReadyError`, `isTransientSendStatus`, `getSendRetryDelayMs`). The boot signal gets a full ~16s boot-window backoff (mirroring the create-session budget); generic 5xx/transport blips keep the short ~3.4s window; real 4xx never retry.
- **Pending-prompt auto-send** now loops on that policy — the first prompt self-heals while the sandbox boots, keeping the optimistic message + busy state up (no banner). Bails out if the effect is cancelled (navigation away).
- **Manual send path** reuses the same helper, so a slow cold boot rides the full boot window too.

## Tests

- New `opencode-send-retry.test.ts` (15 cases): boot 503 retried across the full window across error shapes/casing; generic 5xx and transport errors retried briefly; 4xx never retried; boot-message wins even if mislabeled with a non-transient status.
- `bun test src/features/session/` → 38 pass, 0 fail; `tsc` + `eslint` clean on touched files.

