### PR TITLE
fix(web): restrict non-prod auth access

### DIFF
--- a/apps/web/src/app/(auth)/auth/actions.ts
+++ b/apps/web/src/app/(auth)/auth/actions.ts
@@ -3,6 +3,7 @@
 import { accountHasAppAccess } from '@/lib/auth/account-access';
 import { resolveFirstProjectPathForNewUser } from '@/lib/auth/bootstrap-first-project';
 import { buildMobileSessionHandoffUrl } from '@/lib/auth/mobile-handoff';
+import { restrictedAuthDecision } from '@/lib/auth/nonprod-access';
 import { sanitizeAuthReturnUrl } from '@/lib/auth/return-url';
 import { getServerPublicEnv } from '@/lib/public-env-server';
 import { createClient } from '@/lib/supabase/server';
@@ -44,6 +45,15 @@ function mobileCallbackState(formData: FormData): string | null {
   if (formData.get('mobileCallback') !== 'true') return null;
   const state = formData.get('mobileCallbackState');
   return typeof state === 'string' && state.length > 0 ? state : null;
+}
+
+function authAccessError(email: string | null | undefined, origin: string | null | undefined) {
+  const decision = restrictedAuthDecision({
+    email,
+    origin,
+    appUrl: getServerPublicEnv().APP_URL,
+  });
+  return decision.allowed ? null : { message: decision.message };
 }
 
 function emailRedirectUrl({
@@ -88,8 +98,11 @@ export async function signIn(prevState: any, formData: FormData) {
     return { message: 'Please enter a valid email address' };
   }
 
-  const supabase = await createClient();
   const normalizedEmail = email.trim().toLowerCase();
+  const accessError = authAccessError(normalizedEmail, origin);
+  if (accessError) return accessError;
+
+  const supabase = await createClient();
 
   // Use magic link (passwordless) authentication
   // For desktop app, use custom protocol (kortix://auth/callback) - same as mobile
@@ -151,6 +164,8 @@ export async function signUp(prevState: any, formData: FormData) {
   }
 
   const normalizedEmail = email.trim().toLowerCase();
+  const accessError = authAccessError(normalizedEmail, origin);
+  if (accessError) return accessError;
 
   // Check access control — if signups are closed and email isn't allowlisted, block
   let shouldCreateUser = true;
@@ -258,6 +273,9 @@ export async function forgotPassword(prevState: any, formData: FormData) {
     return { message: 'Please enter a valid email address' };
   }
 
+  const accessError = authAccessError(email.trim().toLowerCase(), origin);
+  if (accessError) return accessError;
+
   const supabase = await createClient();
 
   const { error } = await supabase.auth.resetPasswordForEmail(email, {
@@ -314,8 +332,11 @@ export async function resendMagicLink(prevState: any, formData: FormData) {
     return { message: 'Please enter a valid email address' };
   }
 
-  const supabase = await createClient();
   const normalizedEmail = email.trim().toLowerCase();
+  const accessError = authAccessError(normalizedEmail, origin);
+  if (accessError) return accessError;
+
+  const supabase = await createClient();
 
   // Use magic link (passwordless) authentication
   // For desktop app, use custom protocol (kortix://auth/callback) - same as mobile
@@ -370,8 +391,11 @@ export async function sendOtpCode(prevState: any, formData: FormData) {
     return { message: 'Please enter a valid email address' };
   }
 
-  const supabase = await createClient();
   const normalizedEmail = email.trim().toLowerCase();
+  const accessError = authAccessError(normalizedEmail, origin);
+  if (accessError) return accessError;
+
+  const supabase = await createClient();
 
   let emailRedirectTo: string;
   if (isDesktopApp && origin.startsWith('kortix://')) {
@@ -419,10 +443,14 @@ export async function signInWithPassword(prevState: any, formData: FormData) {
     return { message: 'Password must be at least 6 characters' };
   }
 
+  const normalizedEmail = email.trim().toLowerCase();
+  const accessError = authAccessError(normalizedEmail, origin);
+  if (accessError) return accessError;
+
   const supabase = await createClient();
 
   const { data, error } = await supabase.auth.signInWithPassword({
-    email: email.trim().toLowerCase(),
+    email: normalizedEmail,
     password,
   });
 
@@ -483,6 +511,9 @@ export async function signUpWithPassword(prevState: any, formData: FormData) {
   if (password !== confirmPassword) {
     return { message: 'Passwords do not match' };
   }
+
+  const accessError = authAccessError(email, origin);
+  if (accessError) return accessError;
 
   const supabase = await createClient();
   const emailRedirectTo = emailRedirectUrl({
@@ -622,10 +653,14 @@ export async function verifyOtp(prevState: any, formData: FormData) {
     return { message: 'Please enter the 6-digit code from your email' };
   }
 
+  const normalizedEmail = email.trim().toLowerCase();
+  const accessError = authAccessError(normalizedEmail, origin);
+  if (accessError) return accessError;
+
   const supabase = await createClient();
 
   const { data, error } = await supabase.auth.verifyOtp({
-    email: email.trim().toLowerCase(),
+    email: normalizedEmail,
     token: token.trim(),
     type: 'magiclink',
   });

--- a/apps/web/src/app/(auth)/auth/callback/route.ts
+++ b/apps/web/src/app/(auth)/auth/callback/route.ts
@@ -1,6 +1,7 @@
 import { accountHasAppAccess } from '@/lib/auth/account-access';
 import { resolveFirstProjectPathForNewUser } from '@/lib/auth/bootstrap-first-project';
 import { buildDesktopBounceHtml, buildMobileBounceHtml } from '@/lib/auth/desktop-bounce';
+import { restrictedAuthDecision } from '@/lib/auth/nonprod-access';
 import { sanitizeAuthReturnUrl } from '@/lib/auth/return-url';
 import { ACTIVE_INSTANCE_COOKIE } from '@/lib/instance-routes';
 import { getServerPublicEnv } from '@/lib/public-env-server';
@@ -143,6 +144,19 @@ export async function GET(request: NextRequest) {
       let authMethod = 'email';
 
       if (data.user) {
+        const accessDecision = restrictedAuthDecision({
+          email: data.user.email,
+          origin: request.nextUrl.origin,
+          appUrl: runtimeEnv.APP_URL,
+        });
+        if (!accessDecision.allowed) {
+          await supabase.auth.signOut();
+          const restrictedUrl = new URL(`${baseUrl}/auth`);
+          restrictedUrl.searchParams.set('error', 'restricted_environment');
+          if (next) restrictedUrl.searchParams.set('returnUrl', next);
+          return NextResponse.redirect(restrictedUrl);
+        }
+
         // Determine if this is a new user (for analytics tracking)
         const createdAt = new Date(data.user.created_at).getTime();
         const now = Date.now();

--- a/apps/web/src/app/(auth)/auth/page.tsx
+++ b/apps/web/src/app/(auth)/auth/page.tsx
@@ -79,9 +79,11 @@ function LiveClock() {
 function AuthCardForm({
   returnUrl,
   mobileCallbackState,
+  initialError,
 }: {
   returnUrl: string;
   mobileCallbackState: string | null;
+  initialError?: string | null;
 }) {
   const tI18nHardcoded = useTranslations('hardcodedUi');
   const tHardcodedUi = useTranslations('hardcodedUi');
@@ -99,7 +101,7 @@ function AuthCardForm({
   const passwordEnabled = enabledMethods.includes('password');
   const [method, setMethod] = useState<AuthMethod>(magicLinkEnabled ? 'magic' : 'password');
   const [pending, setPending] = useState(false);
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(initialError || null);
   const [info, setInfo] = useState<string | null>(null);
   // After a magic-link email is sent, the same email also carries a 6-digit
   // code. We keep the sent-to address around so the user can paste the code
@@ -125,6 +127,10 @@ function AuthCardForm({
       .filter(Boolean);
   }, []);
   const googleEnabled = enabledProviders.includes('google');
+
+  useEffect(() => {
+    setErrorMessage(initialError || null);
+  }, [initialError]);
 
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -563,6 +569,10 @@ function AuthContent() {
   const returnUrl = sanitizeAuthReturnUrl(
     searchParams.get('returnUrl') || searchParams.get('redirect'),
   );
+  const authError =
+    searchParams.get('error') === 'restricted_environment'
+      ? 'This environment is restricted to the Kortix team. Use your Kortix email address.'
+      : null;
   const mobileCallbackState =
     searchParams.get('mobile_callback') === '1' ? searchParams.get('state') : null;
   const [phase, setPhase] = useState<'lock' | 'form'>('lock');
@@ -702,7 +712,11 @@ function AuthContent() {
               transition={{ duration: 0.45, ease: [0.16, 1, 0.3, 1] }}
             >
               <div className="bg-background/75 dark:bg-background/70 border-foreground/[0.08] max-h-[calc(100vh-4rem)] overflow-y-auto rounded-2xl border p-7 backdrop-blur-2xl">
-                <AuthCardForm returnUrl={returnUrl} mobileCallbackState={mobileCallbackState} />
+                <AuthCardForm
+                  returnUrl={returnUrl}
+                  mobileCallbackState={mobileCallbackState}
+                  initialError={authError}
+                />
               </div>
             </motion.div>
           </motion.div>

--- a/apps/web/src/lib/auth/nonprod-access.test.ts
+++ b/apps/web/src/lib/auth/nonprod-access.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+import { restrictedAuthDecision } from './nonprod-access';
+
+const ENV_KEYS = [
+  'KORTIX_AUTH_ACCESS_MODE',
+  'KORTIX_AUTH_ALLOWED_EMAILS',
+  'KORTIX_AUTH_ALLOWED_EMAIL_DOMAINS',
+  'KORTIX_PUBLIC_APP_URL',
+  'NEXT_PUBLIC_APP_URL',
+  'NEXT_PUBLIC_URL',
+  'PUBLIC_URL',
+  'VERCEL_URL',
+];
+
+describe('restrictedAuthDecision', () => {
+  beforeEach(() => {
+    for (const key of ENV_KEYS) delete process.env[key];
+  });
+
+  test('leaves production and local auth open by default', () => {
+    expect(
+      restrictedAuthDecision({
+        email: 'someone@example.com',
+        origin: 'https://kortix.com',
+      }).allowed,
+    ).toBe(true);
+    expect(
+      restrictedAuthDecision({
+        email: 'someone@example.com',
+        origin: 'http://localhost:3000',
+      }).allowed,
+    ).toBe(true);
+  });
+
+  test('restricts dev and staging hosts by default', () => {
+    expect(
+      restrictedAuthDecision({
+        email: 'someone@example.com',
+        origin: 'https://dev.kortix.com',
+      }),
+    ).toMatchObject({ restricted: true, allowed: false });
+    expect(
+      restrictedAuthDecision({
+        email: 'someone@example.com',
+        origin: 'https://staging.kortix.com',
+      }),
+    ).toMatchObject({ restricted: true, allowed: false });
+  });
+
+  test('allows Kortix team domains on restricted hosts', () => {
+    expect(
+      restrictedAuthDecision({
+        email: 'marko@kortix.ai',
+        origin: 'https://staging.kortix.com',
+      }).allowed,
+    ).toBe(true);
+    expect(
+      restrictedAuthDecision({
+        email: 'marko@kortix.com',
+        origin: 'https://dev.kortix.com',
+      }).allowed,
+    ).toBe(true);
+  });
+
+  test('supports exact-email and domain overrides', () => {
+    process.env.KORTIX_AUTH_ACCESS_MODE = 'restricted';
+    process.env.KORTIX_AUTH_ALLOWED_EMAILS = 'person@example.com';
+    process.env.KORTIX_AUTH_ALLOWED_EMAIL_DOMAINS = 'internal.example';
+
+    expect(restrictedAuthDecision({ email: 'person@example.com' }).allowed).toBe(true);
+    expect(restrictedAuthDecision({ email: 'teammate@internal.example' }).allowed).toBe(true);
+    expect(restrictedAuthDecision({ email: 'other@example.com' }).allowed).toBe(false);
+  });
+
+  test('explicit open mode disables the non-prod host gate', () => {
+    process.env.KORTIX_AUTH_ACCESS_MODE = 'open';
+
+    expect(
+      restrictedAuthDecision({
+        email: 'someone@example.com',
+        origin: 'https://staging.kortix.com',
+      }).allowed,
+    ).toBe(true);
+  });
+});

--- a/apps/web/src/lib/auth/nonprod-access.ts
+++ b/apps/web/src/lib/auth/nonprod-access.ts
@@ -1,0 +1,80 @@
+const DEFAULT_RESTRICTED_DOMAINS = ['kortix.ai', 'kortix.com'];
+const RESTRICTED_HOSTS = new Set(['dev.kortix.com', 'staging.kortix.com']);
+
+export const RESTRICTED_ENV_AUTH_MESSAGE =
+  'This environment is restricted to the Kortix team. Use your Kortix email address.';
+
+function splitList(value?: string | null): string[] {
+  return (value || '')
+    .split(',')
+    .map((item) => item.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+function originHost(value?: string | null): string | null {
+  if (!value || value.startsWith('encrypted:')) return null;
+  try {
+    const candidate = value.startsWith('http') ? value : `https://${value}`;
+    return new URL(candidate).hostname.toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+export function isRestrictedAuthEnvironment({
+  origin,
+  appUrl,
+}: {
+  origin?: string | null;
+  appUrl?: string | null;
+}): boolean {
+  const mode = (process.env.KORTIX_AUTH_ACCESS_MODE || '').trim().toLowerCase();
+  if (mode === 'open') return false;
+  if (mode === 'restricted') return true;
+
+  const hosts = [
+    originHost(origin),
+    originHost(appUrl),
+    originHost(process.env.KORTIX_PUBLIC_APP_URL),
+    originHost(process.env.NEXT_PUBLIC_APP_URL),
+    originHost(process.env.NEXT_PUBLIC_URL),
+    originHost(process.env.PUBLIC_URL),
+    originHost(process.env.VERCEL_URL),
+  ].filter(Boolean);
+
+  return hosts.some((host) => host !== null && RESTRICTED_HOSTS.has(host));
+}
+
+export function isEmailAllowedForRestrictedAuth(email?: string | null): boolean {
+  const normalized = (email || '').trim().toLowerCase();
+  const at = normalized.lastIndexOf('@');
+  if (at <= 0) return false;
+
+  const exactEmails = splitList(process.env.KORTIX_AUTH_ALLOWED_EMAILS);
+  if (exactEmails.includes(normalized)) return true;
+
+  const configuredDomains = splitList(process.env.KORTIX_AUTH_ALLOWED_EMAIL_DOMAINS);
+  const domains = configuredDomains.length > 0 ? configuredDomains : DEFAULT_RESTRICTED_DOMAINS;
+  const domain = normalized.slice(at + 1);
+
+  return domains.includes(domain);
+}
+
+export function restrictedAuthDecision({
+  email,
+  origin,
+  appUrl,
+}: {
+  email?: string | null;
+  origin?: string | null;
+  appUrl?: string | null;
+}): { restricted: boolean; allowed: boolean; message?: string } {
+  const restricted = isRestrictedAuthEnvironment({ origin, appUrl });
+  if (!restricted) return { restricted: false, allowed: true };
+  if (isEmailAllowedForRestrictedAuth(email)) return { restricted: true, allowed: true };
+  return {
+    restricted: true,
+    allowed: false,
+    message: RESTRICTED_ENV_AUTH_MESSAGE,
+  };
+}


### PR DESCRIPTION
Blocks non-Kortix emails from signing up or signing in on dev/staging frontends while leaving production/local open. Covers magic links, password auth, OTP, password reset request, and OAuth/magic callback.