### PR TITLE
docs(worktree): refresh node-pg-migrate guidance

### DIFF
--- a/.claude/skills/worktree/SKILL.md
+++ b/.claude/skills/worktree/SKILL.md
@@ -77,11 +77,11 @@ In shared-DB mode this leaves the primary Supabase DB running and untouched.
 
 Current migrations live in `packages/db/migrations` and are applied with
 node-pg-migrate (`pnpm --filter @kortix/db migrate`; see
-`packages/db/MIGRATIONS.md`). The worktree runner still has an open bug from the
-cutover where it calls the old `db:migrate` script and emits Drizzle-era error
-text; if worktree schema setup fails there, track/fix
-https://github.com/kortix-ai/suna/issues/3630 rather than treating the old command
-as authoritative.
+`packages/db/MIGRATIONS.md`). The worktree runner applies
+`packages/db/scripts/test-prereqs.sql` first, then calls that `migrate` script.
+If isolated schema setup fails, debug the prereqs and
+`packages/db/migrations/*.sql` rather than looking for the retired
+`db:migrate`/Drizzle path.
 
 ## All commands (non-interactive)
 


### PR DESCRIPTION
## Summary

Updates the worktree skill's isolated-DB migration guidance now that the runner has moved to node-pg-migrate on main. It no longer tells agents that issue #3630 is still open or points them at the retired `db:migrate`/Drizzle path; instead it documents the current `test-prereqs.sql` + `pnpm --filter @kortix/db migrate` flow.

Fixes #3630

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / chore
- [ ] Infrastructure / CI
- [ ] Security fix
- [ ] Breaking change

## How was this tested?

- `bun test scripts/worktree/__tests__/contract.test.ts`
- `git diff --check`

## Security & data review

- [x] No secrets, keys, or credentials are committed (reviewed docs-only diff)
- [x] Authorization checks are not applicable; no endpoints changed
- [x] User input validation is not applicable; no runtime code changed
- [x] No sensitive data is written to logs; no runtime code changed
- [x] DB schema / migration changes are not included
- [x] Does not touch auth / IAM / crypto / billing / migrations

## Rollout / rollback

Docs-only agent guidance update. Roll back by reverting this commit.

## Reviewer checklist

- [ ] Change is scoped and understandable
- [ ] Tests/CI pass and cover the change
- [ ] Security & data review above is satisfied
