### PR TITLE
fix(web): enable Vercel deploys from prod branch

### DIFF
--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -12,7 +12,7 @@
     "deploymentEnabled": {
       "main": true,
       "staging": true,
-      "PRODUCTION": true
+      "prod": true
     }
   }
 }


### PR DESCRIPTION
Fixes the Vercel git deployment branch key so production frontend deploys trigger from the actual `prod` branch instead of the unused `PRODUCTION` key.\n\nManual prod frontend deploy for v0.9.78 was already completed; this carries the config fix into staging for future staging -> prod releases.