### PR TITLE
fix(slack): answer in-thread mentions + stop dropping follow-ups during session wake

### DIFF
--- a/apps/api/src/__tests__/unit-slack-classify-event.test.ts
+++ b/apps/api/src/__tests__/unit-slack-classify-event.test.ts
@@ -1,0 +1,129 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+// Regression guard for "@Kortix goes silent when re-tagged in an existing thread."
+//
+// Slack does NOT reliably deliver an `app_mention` for a mention made INSIDE an
+// existing thread — notably a thread that predates the bot joining the channel.
+// There the mention arrives ONLY as a plain `message` event (with `thread_ts`)
+// via our `message.channels` / `message.groups` subscription. classifyEvent must
+// treat a `message` that @-mentions the bot AS a mention; it previously discarded
+// it (assuming an `app_mention` sibling that, in threads, never comes), so the bot
+// answered only in fresh top-level threads. The exactly-once inboundMessageKey
+// gate (keyed on the shared team/channel/ts) collapses the app_mention+message
+// pair on the common top-level path, so honoring the message here never
+// double-answers.
+
+// ─── DB mock: FIFO of query results (only threadIsOwned touches the DB) ───────
+let dbResults: unknown[][] = [];
+function makeChain(): any {
+  const chain: any = {};
+  for (const m of ['from', 'where', 'limit']) chain[m] = () => chain;
+  chain.then = (resolve: (rows: unknown[]) => unknown) => Promise.resolve(resolve(dbResults.shift() ?? []));
+  return chain;
+}
+mock.module('../shared/db', () => ({
+  db: { select: () => makeChain() },
+  hasDatabase: () => true,
+}));
+
+// ─── Mocks so importing dispatch.ts (and its module graph) loads cleanly ──────
+mock.module('../channels/slack/turn', () => ({
+  claimFinalize: async () => true,
+  openPlanMessage: async () => true,
+  repaintLivePlan: async () => {},
+  loadTurn: async () => null,
+  startTurn: async () => ({ sessionId: '', channel: 'C1', token: 'xoxb', ts: '', steps: [] }),
+  saveTurn: async () => {},
+  deleteTurn: async () => {},
+  finalizeTurn: async () => {},
+  buildSlackTurnEnv: () => ({}),
+  relayTurnAnswer: async () => {},
+  relayTurnEnd: async () => {},
+  relayTurnStep: async () => {},
+  rowToHandle: () => ({ sessionId: '', channel: 'C1', token: 'xoxb', ts: '', steps: [] }),
+}));
+mock.module('../channels/install-store', () => ({
+  loadSlackBotUserIdForProject: async () => 'B1',
+  loadSlackTokenForProject: async () => 'xoxb-test',
+  loadSlackSigningSecretForProject: async () => null,
+  loadSlackTeamNameForProject: async () => null,
+  listProjectsForWorkspace: async () => ['proj-1'],
+  loadSlackInstall: async () => null,
+}));
+mock.module('../channels/slack-api', () => ({
+  addReaction: async () => {},
+  appendStream: async () => {},
+  deleteMessage: async () => {},
+  getChannelName: async () => 'general',
+  joinChannel: async () => true,
+  openDmChannel: async () => 'D1',
+  postBlocks: async () => 'ts',
+  postMessage: async () => 'ts',
+  publishHomeView: async () => {},
+  removeReaction: async () => {},
+  startStream: async () => 'ts',
+  stopStream: async () => {},
+  updateBlocks: async () => {},
+  updateMessage: async () => {},
+}));
+
+const { classifyEvent } = await import('../channels/slack/dispatch');
+
+const BOT = 'B1';
+const ev = (e: Record<string, unknown>) => ({ type: 'message', ...e }) as any;
+
+afterAll(() => mock.restore());
+beforeEach(() => {
+  dbResults = [];
+});
+
+describe('classifyEvent — a message that @-mentions the bot is a mention', () => {
+  test('THE FIX: message with the bot mention inside a thread → mention (was wrongly ignored)', async () => {
+    const cls = await classifyEvent('T1', ev({ thread_ts: '90.0', channel_type: 'channel', text: '<@B1> do a thing' }), BOT);
+    expect(cls).toBe('mention');
+  });
+
+  test('message with the bot mention at channel root → mention', async () => {
+    const cls = await classifyEvent('T1', ev({ channel_type: 'channel', text: '<@B1> do a thing' }), BOT);
+    expect(cls).toBe('mention');
+  });
+
+  test('a real app_mention event is still a mention', async () => {
+    const cls = await classifyEvent('T1', { type: 'app_mention', thread_ts: '90.0', text: '<@B1> hi' } as any, BOT);
+    expect(cls).toBe('mention');
+  });
+
+  test('an edited/system message (has a subtype) is ignored even if it contains the mention', async () => {
+    const cls = await classifyEvent('T1', ev({ subtype: 'message_changed', thread_ts: '90.0', text: '<@B1> edited' }), BOT);
+    expect(cls).toBe('ignore');
+  });
+});
+
+describe('classifyEvent — non-mention routing is unchanged', () => {
+  test('DM (im) message without a mention → dm', async () => {
+    const cls = await classifyEvent('T1', ev({ channel_type: 'im', text: 'hello' }), BOT);
+    expect(cls).toBe('dm');
+  });
+
+  test('thread reply without a mention, in an OWNED thread → follow_up', async () => {
+    dbResults = [[{ id: 'thread-row' }]]; // threadIsOwned → found
+    const cls = await classifyEvent('T1', ev({ thread_ts: '90.0', channel_type: 'channel', text: 'make it concise' }), BOT);
+    expect(cls).toBe('follow_up');
+  });
+
+  test('thread reply without a mention, in an UNKNOWN thread → ignore (no chatter pickup)', async () => {
+    dbResults = [[]]; // threadIsOwned → not found
+    const cls = await classifyEvent('T1', ev({ thread_ts: '90.0', channel_type: 'channel', text: 'just chatting' }), BOT);
+    expect(cls).toBe('ignore');
+  });
+
+  test('channel-root message without a mention → ignore', async () => {
+    const cls = await classifyEvent('T1', ev({ channel_type: 'channel', text: 'random channel chatter' }), BOT);
+    expect(cls).toBe('ignore');
+  });
+
+  test('a non-message, non-app_mention event → ignore', async () => {
+    const cls = await classifyEvent('T1', { type: 'reaction_added', text: '<@B1>' } as any, BOT);
+    expect(cls).toBe('ignore');
+  });
+});

--- a/apps/api/src/channels/slack/dispatch.ts
+++ b/apps/api/src/channels/slack/dispatch.ts
@@ -335,7 +335,7 @@ export async function maybeHandleDmCommand(
   return true;
 }
 
-async function classifyEvent(
+export async function classifyEvent(
   teamId: string,
   event: SlackEvent,
   botUserId: string | null,
@@ -343,7 +343,17 @@ async function classifyEvent(
   if (event.type === 'app_mention') return 'mention';
   if (event.type !== 'message') return 'ignore';
   if (event.subtype) return 'ignore';
-  if (botUserId && (event.text ?? '').includes(`<@${botUserId}>`)) return 'ignore';
+  // A `message` that @-mentions the bot IS a mention. Slack does NOT reliably
+  // deliver an `app_mention` for a mention made INSIDE an existing thread —
+  // notably a thread that predates the bot joining the channel — there it arrives
+  // ONLY as a `message` (with `thread_ts`) via our `message.channels` /
+  // `message.groups` subscription. Treating it as a mention is what lets the bot
+  // answer when it's re-tagged in an old thread instead of going silent until you
+  // start a fresh one. When Slack DOES send both siblings (the common top-level
+  // case), the exactly-once `inboundMessageKey` gate — keyed on the shared
+  // (team, channel, ts) — collapses them into a single run, so this never
+  // double-answers.
+  if (botUserId && (event.text ?? '').includes(`<@${botUserId}>`)) return 'mention';
   if (event.channel_type === 'im') return 'dm';
   if (event.thread_ts && (await threadIsOwned(teamId, event.thread_ts))) return 'follow_up';
   return 'ignore';

--- a/apps/api/src/projects/session-lifecycle/__tests__/deliver.test.ts
+++ b/apps/api/src/projects/session-lifecycle/__tests__/deliver.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from 'bun:test';
+import { deliverWithRetry, type DeliveryTarget } from '../deliver';
+
+// Regression guard for "@Kortix replied 'Still waking this thread's session back
+// up — send that again' on a session that was already awake." The runtime was
+// ready; the prompt hand-off just had a transient post-wake hiccup (a rotated
+// opencode session 404, a daemon 5xx, a briefly-null externalId). The old path
+// bounced to 'pending' on the first miss and dropped the message. deliverWithRetry
+// must heal + retry through that window and only surface 'pending' if it truly
+// never lands.
+
+const ready = (externalId: string | null, opencodeSessionId: string | null): DeliveryTarget => ({
+  stage: 'ready',
+  externalId,
+  opencodeSessionId,
+});
+
+const noSleep = async () => {};
+// Deterministic clock: each call advances by `step` (no wall-clock in the test).
+const stepNow = (step: number) => {
+  let t = -step;
+  return () => {
+    t += step;
+    return t;
+  };
+};
+
+describe('deliverWithRetry — hand the prompt off through the post-wake flake', () => {
+  test('happy path: first send accepted → delivered, never reopens', async () => {
+    let sends = 0;
+    let reopens = 0;
+    const outcome = await deliverWithRetry({
+      opened: ready('ext-1', 'oc-1'),
+      reopen: async () => {
+        reopens++;
+        return ready('ext-1', 'oc-1');
+      },
+      send: async () => {
+        sends++;
+        return true;
+      },
+      now: stepNow(1000),
+      sleepFn: noSleep,
+    });
+    expect(outcome).toBe('delivered');
+    expect(sends).toBe(1);
+    expect(reopens).toBe(0);
+  });
+
+  test('THE FIX: a transient send failure is healed + retried → delivered (not pending)', async () => {
+    let sends = 0;
+    const outcome = await deliverWithRetry({
+      opened: ready('ext-1', 'oc-1'),
+      reopen: async () => ready('ext-1', 'oc-2'), // rotated opencode session
+      send: async (_ext, oc) => {
+        sends++;
+        return oc === 'oc-2'; // first id 404s, healed id is accepted
+      },
+      now: stepNow(1000),
+      sleepFn: noSleep,
+    });
+    expect(outcome).toBe('delivered');
+    expect(sends).toBe(2);
+  });
+
+  test('externalId briefly null at ready → waits for the resume to surface it, then delivers', async () => {
+    const outcome = await deliverWithRetry({
+      opened: ready(null, 'oc-1'), // mid-resume: no external id yet → cannot send
+      reopen: async () => ready('ext-1', 'oc-1'),
+      send: async () => true,
+      now: stepNow(1000),
+      sleepFn: noSleep,
+    });
+    expect(outcome).toBe('delivered');
+  });
+
+  test('send never succeeds before the deadline → pending (the honest last resort)', async () => {
+    let sends = 0;
+    const outcome = await deliverWithRetry({
+      opened: ready('ext-1', 'oc-1'),
+      reopen: async () => ready('ext-1', 'oc-1'),
+      send: async () => {
+        sends++;
+        return false;
+      },
+      now: stepNow(10_000),
+      sleepFn: noSleep,
+      deadlineMs: 45_000,
+    });
+    expect(outcome).toBe('pending');
+    expect(sends).toBeGreaterThan(1); // it really did retry, not bounce on the first miss
+  });
+
+  test('reopen finds the session gone → no-session', async () => {
+    const outcome = await deliverWithRetry({
+      opened: ready('ext-1', 'oc-1'),
+      reopen: async () => null,
+      send: async () => false,
+      now: stepNow(1000),
+      sleepFn: noSleep,
+    });
+    expect(outcome).toBe('no-session');
+  });
+
+  test('reopen reports a terminal failure → failed (do not keep retrying a dead box)', async () => {
+    const outcome = await deliverWithRetry({
+      opened: ready('ext-1', 'oc-1'),
+      reopen: async () => ({ stage: 'failed', externalId: null, opencodeSessionId: null }),
+      send: async () => false,
+      now: stepNow(1000),
+      sleepFn: noSleep,
+    });
+    expect(outcome).toBe('failed');
+  });
+});

--- a/apps/api/src/projects/session-lifecycle/deliver.ts
+++ b/apps/api/src/projects/session-lifecycle/deliver.ts
@@ -1,0 +1,64 @@
+import type { SessionDeliveryOutcome } from './types';
+
+// After a session's runtime reports `ready` we still have to hand the prompt to
+// the opencode daemon — and a just-woken sandbox is flaky for a beat: the
+// rotated opencode session 404s, the daemon 5xx/refuses while it finishes
+// binding, or externalId/opencode_session_id read briefly null mid-resume. The
+// old delivery path bounced to `pending` on the FIRST such hiccup, which on
+// Slack told the user "still waking… send that again" and dropped their message
+// even though the session was up. Slack/email delivery runs AFTER the inbound
+// webhook is acked, so we are NOT racing a 3s budget here — keep healing and
+// retrying the hand-off through the transient post-wake window before giving up.
+const DELIVER_DEADLINE_MS = 45_000;
+const DELIVER_RETRY_INTERVAL_MS = 1_500;
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+export interface DeliveryTarget {
+  stage: string;
+  externalId: string | null;
+  opencodeSessionId: string | null;
+}
+
+// Pure, fully-injectable retry loop (mirrors awaitTerminalStage) so the wake/heal
+// behavior is testable without wall-clock sleeps or sandbox mocks. `send` posts
+// the prompt and returns whether the daemon accepted it; `reopen` re-resolves the
+// session (which heals a rotated/expired opencode session — the 404 case) and is
+// only called after a failed attempt.
+export async function deliverWithRetry(input: {
+  opened: DeliveryTarget;
+  reopen: () => Promise<DeliveryTarget | null>;
+  send: (externalId: string, opencodeSessionId: string) => Promise<boolean>;
+  sessionId?: string;
+  now?: () => number;
+  sleepFn?: (ms: number) => Promise<void>;
+  deadlineMs?: number;
+  intervalMs?: number;
+}): Promise<SessionDeliveryOutcome> {
+  const now = input.now ?? Date.now;
+  const sleepFn = input.sleepFn ?? sleep;
+  const deadlineMs = input.deadlineMs ?? DELIVER_DEADLINE_MS;
+  const intervalMs = input.intervalMs ?? DELIVER_RETRY_INTERVAL_MS;
+
+  let current = input.opened;
+  const deadline = now() + deadlineMs;
+  for (;;) {
+    if (current.externalId && current.opencodeSessionId) {
+      if (await input.send(current.externalId, current.opencodeSessionId)) return 'delivered';
+    }
+    if (now() >= deadline) {
+      console.warn('[session-lifecycle] could not deliver prompt before deadline', {
+        sessionId: input.sessionId,
+        stage: current.stage,
+        hasExternalId: !!current.externalId,
+        hasOpencodeSession: !!current.opencodeSessionId,
+      });
+      return 'pending';
+    }
+    await sleepFn(intervalMs);
+    const healed = await input.reopen();
+    if (!healed) return 'no-session';
+    if (healed.stage === 'failed' || healed.stage === 'stopped') return 'failed';
+    current = healed;
+  }
+}

--- a/apps/api/src/projects/session-lifecycle/engine.ts
+++ b/apps/api/src/projects/session-lifecycle/engine.ts
@@ -6,6 +6,7 @@ import { db } from '../../shared/db';
 import { createProjectSession } from '../lib/sessions';
 import { openSession } from '../routes/shared';
 import { awaitTerminalStage } from './await-stage';
+import { deliverWithRetry, type DeliveryTarget } from './deliver';
 import { resolveProjectAutomationActor } from './actor';
 import { sessionBackpressureState } from './backpressure';
 import {
@@ -263,18 +264,29 @@ export async function continueSession(
     await sleep(POLL_INTERVAL_MS);
   }
 
-  const externalId = sandboxExternalId(opened);
-  if (!externalId || !opened.opencode_session_id) return 'pending';
-  if (await postPrompt(externalId, opened.opencode_session_id, text, userId)) return 'delivered';
+  // Runtime is ready — hand off the prompt, healing + retrying through the
+  // transient failures a freshly-woken sandbox throws (rotated opencode session
+  // 404, daemon 5xx while it binds, externalId/opencode_session_id briefly
+  // null). Bounce to 'pending' only after the bounded window genuinely exhausts;
+  // the old code gave up on the first hiccup and dropped the user's message.
+  const toTarget = (
+    o: NonNullable<Awaited<ReturnType<typeof openOnce>>>,
+  ): DeliveryTarget => ({
+    stage: o.stage,
+    externalId: sandboxExternalId(o),
+    opencodeSessionId: o.opencode_session_id,
+  });
 
-  const healed = await openOnce();
-  const healedId = healed?.opencode_session_id;
-  if (healed?.stage === 'ready' && healedId && healedId !== opened.opencode_session_id) {
-    if (await postPrompt(sandboxExternalId(healed) ?? externalId, healedId, text, userId)) {
-      return 'delivered';
-    }
-  }
-  return 'pending';
+  return deliverWithRetry({
+    sessionId,
+    opened: toTarget(opened),
+    reopen: async () => {
+      const healed = await openOnce();
+      return healed ? toTarget(healed) : null;
+    },
+    send: (externalId, opencodeSessionId) =>
+      postPrompt(externalId, opencodeSessionId, text, userId),
+  });
 }
 
 export async function drainSessionLifecycleQueue(input: {
@@ -482,18 +494,26 @@ async function postPrompt(
   userId: string,
 ): Promise<boolean> {
   const body = new TextEncoder().encode(JSON.stringify({ parts: [{ type: 'text', text }] }));
-  const res = await forwardToSandbox(
-    externalId,
-    DAEMON_PORT,
-    { kind: 'principal', userId },
-    'POST',
-    `/session/${encodeURIComponent(opencodeSessionId)}/prompt_async`,
-    `?directory=${encodeURIComponent(WORKSPACE)}`,
-    new Headers({ 'Content-Type': 'application/json' }),
-    body.buffer as ArrayBuffer,
-    config.KORTIX_URL ?? '',
-  );
-  if (res.ok || res.status === 204) return true;
-  if (res.status !== 404) console.warn('[session-lifecycle] prompt_async non-ok', { status: res.status });
-  return false;
+  try {
+    const res = await forwardToSandbox(
+      externalId,
+      DAEMON_PORT,
+      { kind: 'principal', userId },
+      'POST',
+      `/session/${encodeURIComponent(opencodeSessionId)}/prompt_async`,
+      `?directory=${encodeURIComponent(WORKSPACE)}`,
+      new Headers({ 'Content-Type': 'application/json' }),
+      body.buffer as ArrayBuffer,
+      config.KORTIX_URL ?? '',
+    );
+    if (res.ok || res.status === 204) return true;
+    if (res.status !== 404) console.warn('[session-lifecycle] prompt_async non-ok', { status: res.status });
+    return false;
+  } catch (err) {
+    // A connection refused/reset while the sandbox finishes resuming — treat as a
+    // retryable miss (the deliver loop will heal + retry) instead of letting it
+    // bubble up and silently drop the turn.
+    console.warn('[session-lifecycle] prompt_async threw (will retry)', { error: String(err) });
+    return false;
+  }
 }


### PR DESCRIPTION
## Summary
Two Slack-channel bugs, both surfaced from a live demo thread.

### 1. In-thread @mentions went silent
`classifyEvent` discarded any `message` event that @-mentioned the bot, assuming an `app_mention` sibling would always handle it. Slack does **not** reliably send `app_mention` for a mention made *inside an existing thread* — there it arrives only as a `message` with `thread_ts` (via `message.channels`/`message.groups`). So re-tagging `@Kortix` in a thread that predated the bot joining the channel went silent, while fresh top-level mentions worked.

**Fix:** treat a mention-bearing `message` as a mention. The existing exactly-once `inboundMessageKey` gate (team/channel/ts) collapses the `app_mention`+`message` pair on the top-level path, so it never double-answers.

### 2. "Still waking this thread's session back up — send that again"
`continueSession` bounced to `pending` on the **first** prompt hand-off hiccup after a session woke (rotated opencode session 404, daemon 5xx while it binds, briefly-null `externalId` mid-resume), dropping the user's message even though the runtime was ready. The Slack webhook already acks *before* delivery runs, so delivery is **not** on a 3s budget — there was no reason to give up instantly.

**Fix:** extract a pure, injectable `deliverWithRetry` helper (mirrors `awaitTerminalStage`) that heals + retries the hand-off through the transient post-wake window for up to 45s before surfacing `pending`, and harden `postPrompt` against connection throws. Happy path is unchanged (first send → `delivered`).

## Tests
- `unit-slack-classify-event.test.ts` — 9 tests (the fix + non-mention routing unchanged)
- `session-lifecycle/__tests__/deliver.test.ts` — 6 deterministic tests (injected clock, no wall-clock sleeps)

Full `apps/api` typecheck clean (0 errors).

## Notes
- Internal behavior only — no API route/status/contract changes (ke2e unaffected).