### PR TITLE
fix(web): surface sub-agent errors/retries in parent thread + sub-session modal UX

### DIFF
--- a/apps/web/src/features/session/session-error-banner.tsx
+++ b/apps/web/src/features/session/session-error-banner.tsx
@@ -35,8 +35,57 @@ function isInsufficientCreditsError(text: string): boolean {
   const lower = text.toLowerCase();
   return (
     lower.includes('insufficient credits') ||
+    lower.includes('out of credits') ||
     (lower.includes('payment required') && lower.includes('credit')) ||
     (lower.includes('402') && lower.includes('credit'))
+  );
+}
+
+// ============================================================================
+// Usage-limit / subscription-required detection — the free tier running dry, an
+// inactive subscription, or an exhausted budget surfaces as messages like
+// "Free usage exceeded, subscribe to Go" or "Subscribe to activate your seat".
+// These are NOT a credit top-up situation, so they get their own subscribe CTA.
+// ============================================================================
+
+function isUsageLimitError(text: string): boolean {
+  const lower = text.toLowerCase();
+  return (
+    lower.includes('free usage') ||
+    lower.includes('usage exceeded') ||
+    lower.includes('subscription required') ||
+    lower.includes('subscription_required') ||
+    lower.includes('budget exceeded') ||
+    lower.includes('budget_exceeded') ||
+    lower.includes('subscribe to') ||
+    lower.includes('billing inactive')
+  );
+}
+
+function UsageLimitCard({ errorText, className }: { errorText: string; className?: string }) {
+  const openAccountSettings = useAccountSettingsModalStore((s) => s.openAccountSettings);
+  const openBilling = () => openAccountSettings({ tab: 'billing' });
+
+  return (
+    <InfoBanner
+      tone="warning"
+      icon={Zap}
+      title="Usage limit reached"
+      className={cn('flex-col gap-2.5', className)}
+    >
+      <p className="break-words">{errorText}</p>
+      <div className="flex items-center gap-1.5 mt-2">
+        <Button
+          size="sm"
+          variant="default"
+          className="h-7 text-xs px-2.5"
+          onClick={openBilling}
+        >
+          <Zap className="size-3 mr-1" />
+          Upgrade plan
+        </Button>
+      </div>
+    </InfoBanner>
   );
 }
 
@@ -117,6 +166,11 @@ export function TurnErrorDisplay({ errorText, className }: TurnErrorDisplayProps
   // Insufficient credits → actionable card with buy/auto-topup buttons
   if (isInsufficientCreditsError(errorText)) {
     return <InsufficientCreditsCard errorText={errorText} className={className} />;
+  }
+
+  // Free-tier / subscription / budget limit → actionable upgrade card
+  if (isUsageLimitError(errorText)) {
+    return <UsageLimitCard errorText={errorText} className={className} />;
   }
 
   // Real errors → full card

--- a/apps/web/src/features/session/sub-session-modal.tsx
+++ b/apps/web/src/features/session/sub-session-modal.tsx
@@ -1,9 +1,6 @@
 "use client";
 
-import { useTranslations } from 'next-intl';
-
-import { ExternalLink, SquareKanban, X } from "lucide-react";
-import { useCallback } from "react";
+import { SquareKanban, X } from "lucide-react";
 import { SessionChat } from "@/features/session/session-chat";
 import {
 	Dialog,
@@ -11,14 +8,11 @@ import {
 	DialogTitle,
 } from "@/components/ui/dialog";
 import { cn } from "@/lib/utils";
-import { useServerStore } from "@/stores/server-store";
-import { openTabAndNavigate } from "@/stores/tab-store";
 
 interface SubSessionModalProps {
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
 	sessionId: string;
-	parentSessionId?: string;
 	title?: string;
 }
 
@@ -26,29 +20,15 @@ export function SubSessionModal({
 	open,
 	onOpenChange,
 	sessionId,
-	parentSessionId,
 	title,
 }: SubSessionModalProps) {
-  const tHardcodedUi = useTranslations('hardcodedUi');
-	const handleOpenInTab = useCallback(() => {
-		onOpenChange(false);
-		openTabAndNavigate({
-			id: sessionId,
-			title: title || "Sub-agent",
-			type: "session",
-			href: `/sessions/${sessionId}`,
-			parentSessionId,
-			serverId: useServerStore.getState().activeServerId,
-		});
-	}, [sessionId, parentSessionId, title, onOpenChange]);
-
 	return (
 		<Dialog open={open} onOpenChange={onOpenChange}>
 			<DialogContent
 				hideCloseButton
 				className={cn(
 					"flex flex-col p-0 gap-0 overflow-hidden",
-					"w-[90vw] max-w-4xl h-[80vh] max-h-[800px]",
+					"w-[92vw] max-w-5xl h-[80vh] max-h-[840px]",
 				)}
 				aria-describedby={undefined}
 			>
@@ -58,18 +38,6 @@ export function SubSessionModal({
 					<DialogTitle className="text-sm font-medium truncate flex-1">
 						{title || "Sub-session"}
 					</DialogTitle>
-					<button
-						type="button"
-						onClick={handleOpenInTab}
-						className={cn(
-							"flex items-center gap-1.5 px-2 py-1 rounded-md text-xs",
-							"text-muted-foreground hover:text-foreground",
-							"hover:bg-muted/60 transition-colors",
-						)}
-					>
-						<ExternalLink className="size-3" />
-						<span>{tHardcodedUi.raw('componentsSessionSubSessionModal.line68JsxTextOpenInTab')}</span>
-					</button>
 					<button
 						type="button"
 						onClick={() => onOpenChange(false)}

--- a/apps/web/src/features/session/tool-renderers.tsx
+++ b/apps/web/src/features/session/tool-renderers.tsx
@@ -13,6 +13,10 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { useFileContent } from '@/features/files/hooks/use-file-content';
 import { QuestionPrompt } from '@/features/session/question-prompt';
 import { prefersPreviewLink } from '@/features/session/preview-url-fallback';
+import {
+  SessionRetryDisplay,
+  TurnErrorDisplay,
+} from '@/features/session/session-error-banner';
 import { SubSessionModal } from '@/features/session/sub-session-modal';
 import {
   cleanResultSnippet,
@@ -42,6 +46,7 @@ import {
   parseStructuredOutput,
 } from '@/lib/utils/structured-output';
 import { type LspDiagnostic, parseDiagnosticsFromToolOutput } from '@/stores/diagnostics-store';
+import { useSyncStore } from '@/stores/opencode-sync-store';
 import { useFilePreviewStore } from '@/stores/file-preview-store';
 import { useKortixComputerStore } from '@/stores/kortix-computer-store';
 import { useServerStore } from '@/stores/server-store';
@@ -115,12 +120,16 @@ import React, {
 
 import {
   type Diagnostic,
+  getChildSessionError,
   getChildSessionId,
   getChildSessionToolParts,
   getDiagnostics,
   getDirectory,
   getFilename,
+  getRetryInfo,
+  getRetryMessage,
   getToolInfo,
+  type MessageWithParts,
   PERMISSION_LABELS,
   type PermissionRequest,
   type QuestionRequest,
@@ -5475,6 +5484,67 @@ function SubAgentActivity({
   );
 }
 
+/**
+ * Surfaces a sub-agent's failure/retry state up into the parent thread.
+ *
+ * A child (sub-agent) session runs its own LLM turn and streams its own
+ * `session.status` (retry) and `session.error` events. Those reach the browser
+ * on the shared per-server SSE stream and are stored keyed by the CHILD session
+ * id — but the parent's spawn card only ever rendered child *tool activity*. So
+ * when a sub-agent died mid-LLM-call (e.g. "Free usage exceeded, subscribe to
+ * Go") before running any tool, the parent card showed nothing and the thread
+ * looked stuck/collapsed. This banner reads the child's live retry status and
+ * persisted error and renders them inline so the failure is always visible.
+ */
+function SubAgentStatusBanner({
+  childSessionId,
+  childMessages,
+}: {
+  childSessionId?: string;
+  childMessages?: MessageWithParts[];
+}) {
+  // Live status for the child session (retry / busy / idle), keyed by child id.
+  const childStatus = useSyncStore((s) =>
+    childSessionId ? s.sessionStatus[childSessionId] : undefined,
+  );
+  const retryInfo = useMemo(() => getRetryInfo(childStatus), [childStatus]);
+  const retryMessage = useMemo(() => getRetryMessage(childStatus), [childStatus]);
+  const childError = useMemo(() => getChildSessionError(childMessages), [childMessages]);
+
+  // Live countdown for the retry banner (mirrors session-chat's per-second tick).
+  const [secondsLeft, setSecondsLeft] = useState(0);
+  useEffect(() => {
+    if (!retryInfo) {
+      setSecondsLeft(0);
+      return;
+    }
+    const tick = () =>
+      setSecondsLeft(Math.max(0, Math.round((retryInfo.next - Date.now()) / 1000)));
+    tick();
+    const id = setInterval(tick, 1000);
+    return () => clearInterval(id);
+  }, [retryInfo]);
+
+  // A live retry takes precedence — it's the actionable "still trying" signal.
+  if (retryInfo && retryMessage) {
+    return (
+      <SessionRetryDisplay
+        message={retryMessage}
+        attempt={retryInfo.attempt}
+        secondsLeft={secondsLeft}
+        className="mt-2"
+      />
+    );
+  }
+
+  // Otherwise surface the terminal error so it stays visible after the child idles.
+  if (childError) {
+    return <TurnErrorDisplay errorText={childError} className="mt-2" />;
+  }
+
+  return null;
+}
+
 function TaskTool({ part, forceOpen }: ToolProps) {
   const input = partInput(part);
   const status = partStatus(part);
@@ -5530,6 +5600,7 @@ function TaskTool({ part, forceOpen }: ToolProps) {
           <SubAgentActivity childSessionId={childSessionId} parts={childToolParts} />
         ) : undefined}
       </BasicTool>
+      <SubAgentStatusBanner childSessionId={childSessionId} childMessages={childMessages} />
       {childSessionId && (
         <SubSessionModal
           open={modalOpen}
@@ -5604,6 +5675,7 @@ function SessionSpawnTool({ part, forceOpen }: ToolProps) {
           <SubAgentActivity childSessionId={childSessionId} parts={childToolParts} />
         ) : undefined}
       </BasicTool>
+      <SubAgentStatusBanner childSessionId={childSessionId} childMessages={childMessages} />
       {childSessionId && (
         <SubSessionModal
           open={modalOpen}
@@ -6527,6 +6599,12 @@ function AgentSpawnTool({ part, forceOpen }: ToolProps) {
             <SubAgentActivity childSessionId={childSessionId} parts={childToolParts} />
           </div>
         )}
+
+        {/* Sub-agent retry/error — always visible so a failed worker never
+            looks like a silently-stuck/empty card. */}
+        <div className="px-3 pb-3 empty:hidden">
+          <SubAgentStatusBanner childSessionId={childSessionId} childMessages={childMessages} />
+        </div>
       </div>
 
       {hasSession && (

--- a/apps/web/src/ui/turns.test.ts
+++ b/apps/web/src/ui/turns.test.ts
@@ -5,6 +5,7 @@ import type { AssistantMessage, StepFinishPart } from '@opencode-ai/sdk/v2/clien
 import {
   COST_MARKUP,
   formatCost,
+  getChildSessionError,
   getSessionCost,
   getTurnCost,
   type ModelPricingLookup,
@@ -183,5 +184,50 @@ describe('formatCost', () => {
 
   test('formats whole-cent amounts with two decimals', () => {
     expect(formatCost(2.22)).toBe('$2.22');
+  });
+});
+
+describe('getChildSessionError', () => {
+  function childMsg(
+    overrides: Partial<AssistantMessage> & { role?: 'user' | 'assistant' } = {},
+  ): MessageWithParts {
+    return {
+      info: assistantInfo(overrides as Partial<AssistantMessage>),
+      parts: [],
+    };
+  }
+
+  test('returns undefined for no messages', () => {
+    expect(getChildSessionError(undefined)).toBeUndefined();
+    expect(getChildSessionError([])).toBeUndefined();
+  });
+
+  test('returns undefined when no assistant message has an error', () => {
+    expect(getChildSessionError([childMsg(), childMsg()])).toBeUndefined();
+  });
+
+  test('surfaces a sub-agent error string (e.g. free usage exceeded)', () => {
+    const messages = [
+      childMsg(),
+      childMsg({ error: 'Free usage exceeded, subscribe to Go' } as unknown as Partial<AssistantMessage>),
+    ];
+    expect(getChildSessionError(messages)).toBe('Free usage exceeded, subscribe to Go');
+  });
+
+  test('unwraps a structured error onto its message', () => {
+    const messages = [
+      childMsg({
+        error: { data: { message: 'Free usage exceeded, subscribe to Go' } },
+      } as unknown as Partial<AssistantMessage>),
+    ];
+    expect(getChildSessionError(messages)).toBe('Free usage exceeded, subscribe to Go');
+  });
+
+  test('returns the most recent error when several exist', () => {
+    const messages = [
+      childMsg({ error: 'older error' } as unknown as Partial<AssistantMessage>),
+      childMsg({ error: 'newest error' } as unknown as Partial<AssistantMessage>),
+    ];
+    expect(getChildSessionError(messages)).toBe('newest error');
   });
 });

--- a/apps/web/src/ui/turns.ts
+++ b/apps/web/src/ui/turns.ts
@@ -645,6 +645,28 @@ export function getChildSessionId(part: ToolPart): string | undefined {
 }
 
 /**
+ * Extract the error message from a child (sub-agent) session's raw messages.
+ *
+ * Mirrors `getTurnError` but operates over the flat `MessageWithParts` list
+ * returned by `useOpenCodeMessages`, so a parent thread can surface a sub-agent
+ * failure (e.g. "Free usage exceeded, subscribe to Go") that otherwise only
+ * lives on the child session and never reaches the parent's turn renderer.
+ * Scans newest-first so the most recent failure wins.
+ */
+export function getChildSessionError(
+  childMessages: MessageWithParts[] | undefined,
+): string | undefined {
+  if (!childMessages) return undefined;
+  for (let i = childMessages.length - 1; i >= 0; i--) {
+    const info = childMessages[i]?.info as AssistantMessage | undefined;
+    if (info?.role === 'assistant' && info.error) {
+      return unwrapError(info.error);
+    }
+  }
+  return undefined;
+}
+
+/**
  * Collect all tool parts from a child session's assistant messages.
  * Matches SolidJS getSessionToolParts — message-part.tsx:160-174
  */


### PR DESCRIPTION
## What & why

A user's agent thread looked **stuck / collapsed** after a sub-agent (the "explore" agent doing Visual QA of SpaceX deck slides) hit an upstream billing error — `Free usage exceeded, subscribe to Go. Retrying now (#2)`. The retry/error flashed and vanished; they had to send another prompt to surface it.

**Root cause:** a spawned sub-agent runs its own child session and streams its own `session.status` (retry) and `session.error` events. Those events reach the browser on the shared per-server SSE stream and are stored keyed by the **child** session id — but the parent thread's spawn card (`TaskTool` / `SessionSpawnTool` / `AgentSpawnTool`) only ever rendered the child's **tool activity**. So a sub-agent that died mid-LLM-call before running any tool left the card empty and the parent looked stuck. The error was only visible by opening the modal or forcing a re-render with another prompt.

## Changes

- **Surface sub-agent failures in the parent thread (primary fix).** New `SubAgentStatusBanner` reads the child session's live retry status (from the sync store) and its persisted error, and renders them **inline and persistently** in all three sub-agent renderers. A failing/retrying sub-agent is now always visible and **stays** visible after the child idles.
- `getChildSessionError()` helper to pull a child session's error out of its raw messages (+ unit tests).
- **Actionable usage-limit card.** `session-error-banner` now detects free-usage / subscription-required / budget-limit errors ("subscribe to Go") and renders an **Upgrade plan** card; also treats "out of credits" as a credits error. Previously only "insufficient credits" got an actionable card; everything else fell back to raw text.
- **Sub-session modal UX.** Removed the "Open in Tab" action (a sub-agent session isn't a standalone navigable page — it was redirecting to `/projects/.../sessions/...`) and widened the dialog (`max-w-4xl` → `max-w-5xl`).

## Testing

- `bun test src/ui/turns.test.ts` — 17 pass (added 5 cases for `getChildSessionError`).
- `tsc --noEmit` — no new type errors in touched files; remaining `turns.test.ts` errors are pre-existing on `main`.
- `eslint` on all changed files — clean.