### PR TITLE
Route Zen free models natively

### DIFF
--- a/apps/api/src/__tests__/unit-resolve-candidates-free-tier.test.ts
+++ b/apps/api/src/__tests__/unit-resolve-candidates-free-tier.test.ts
@@ -142,17 +142,16 @@ describe('resolveCandidates free-tier premium gate', () => {
     expect(accountTierCalls).toBe(1);
   });
 
-  test('resolves raw auto to a FREE managed upstream for free accounts', async () => {
-    // A free account's `auto` must NOT land on the paid fusion target (which it
-    // has no upstream for) — it resolves to a free model and yields a candidate.
+  test('does not resolve raw auto to a gateway upstream for free accounts', async () => {
+    // Free Zen models are native sandbox models now. A stale gateway caller that
+    // asks for raw `auto` must not silently route Zen through the gateway IP.
     accountTier = 'free';
     const candidates = await resolveCandidates(
       { ...principal('free-auto'), freeModelsOnly: true },
       'auto',
     );
-    expect(candidates).toHaveLength(1);
-    expect(candidates[0]?.resolvedModel).toBe('deepseek-v4-flash-free');
-    expect(accountTierCalls).toBe(1);
+    expect(candidates).toEqual([]);
+    expect(accountTierCalls).toBe(0);
   });
 
   test('waives BYOK platform fee and disables managed fallback for free accounts', async () => {

--- a/apps/api/src/llm-gateway/models/catalog-models.test.ts
+++ b/apps/api/src/llm-gateway/models/catalog-models.test.ts
@@ -27,10 +27,9 @@ describe('gatewayModelCatalog — served catalog', () => {
     expect(Object.keys(full).length).toBeGreaterThan(Object.keys(managedOnly).length);
   });
 
-  test('OpenCode Zen free models are managed, not leaked as native opencode catalog entries', () => {
+  test('OpenCode Zen free models are not served by the gateway catalog', () => {
     for (const id of DEFAULT_OPENCODE_ZEN_FREE_MODEL_IDS) {
-      expect(full[id], id).toBeDefined();
-      expect(full[id]?.free, id).toBe(true);
+      expect(full[id], id).toBeUndefined();
       expect(full[`opencode/${id}`], `opencode/${id}`).toBeUndefined();
     }
     expect(full['big-pickle']).toBeUndefined();
@@ -53,15 +52,11 @@ describe('gatewayModelCatalog — served catalog', () => {
 describe('gatewayModelCatalog — free-tier visibility', () => {
   const freeFull = gatewayModelCatalog('proj', { freeManagedOnly: true });
 
-  test('free tier sees ONLY free managed models (paid managed hidden)', () => {
-    // Every free OpenCode-Zen model present...
+  test('free tier sees no managed gateway models', () => {
     for (const id of DEFAULT_OPENCODE_ZEN_FREE_MODEL_IDS) {
-      expect(freeFull[id], id).toBeDefined();
-      expect(freeFull[id]?.free, id).toBe(true);
+      expect(freeFull[id], id).toBeUndefined();
     }
-    // ...and AUTO stays (it resolves to a free model for free accounts)...
-    expect(freeFull.auto).toBeDefined();
-    // ...but every paid managed model is gone.
+    expect(freeFull.auto).toBeUndefined();
     for (const id of ['claude-opus-4.8', 'claude-sonnet-4.6', 'fusion', 'qwen3.7-max']) {
       expect(freeFull[id], id).toBeUndefined();
     }
@@ -71,9 +66,10 @@ describe('gatewayModelCatalog — free-tier visibility', () => {
     expect(freeFull['anthropic/claude-opus-4-8']).toBeDefined();
   });
 
-  test('anonymous + free-only = free managed lineup with no BYOK', () => {
+  test('anonymous + free-only = empty managed catalog with no BYOK', () => {
     const managedFree = gatewayModelCatalog(undefined, { freeManagedOnly: true });
-    expect(managedFree.auto).toBeDefined();
+    expect(Object.keys(managedFree)).toEqual([]);
+    expect(managedFree.auto).toBeUndefined();
     expect(managedFree['fusion']).toBeUndefined();
     expect(managedFree['anthropic/claude-opus-4-8']).toBeUndefined();
   });

--- a/apps/api/src/llm-gateway/models/catalog-models.ts
+++ b/apps/api/src/llm-gateway/models/catalog-models.ts
@@ -90,22 +90,24 @@ export function managedModels(opts?: {
   const out: Record<string, GatewayModel> = {};
   // AUTO is synthetic (not a real model): it accepts images because pickAutoModel
   // routes image-bearing requests to a vision-capable model. Its window matches
-  // its default target (Fusion) so OpenCode sizes conversations the same. It stays
-  // available to every tier — for a free account it resolves to a free model
-  // (see pickAutoModel), so the default still works without exposing paid ones.
-  out[AUTO_MODEL_ID] = {
-    name: "Auto",
-    reasoning: false,
-    tool_call: true,
-    attachment: true,
-    temperature: true,
-    limit: { context: 1_000_000, output: 128_000 },
-  };
+  // its default target (Fusion) so OpenCode sizes conversations the same. Free
+  // tier omits AUTO because Zen free models now run through the native sandbox
+  // `opencode` provider, not the Kortix gateway.
+  if (!opts?.freeOnly) {
+    out[AUTO_MODEL_ID] = {
+      name: "Auto",
+      reasoning: false,
+      tool_call: true,
+      attachment: true,
+      temperature: true,
+      limit: { context: 1_000_000, output: 128_000 },
+    };
+  }
   // The managed lineup is curated and its slugs don't all exist on models.dev
   // (z-ai≠zhipuai, dotted vs dashed Claude ids), so vision + limit are explicit
   // on each model. All current managed models support reasoning/tools/temperature.
-  // `freeOnly` drops the paid managed models so a free-tier account only ever sees
-  // the free OpenCode-Zen lineup through the Kortix gateway.
+  // `freeOnly` drops all managed models. Free-tier Zen is a native session model,
+  // while BYOK/Codex still widen the gateway catalog when a project is scoped.
   for (const m of MANAGED_MODELS) {
     if (opts?.freeOnly && !m.free) continue;
     out[m.id] = {

--- a/apps/api/src/llm-gateway/resolution/descriptors.ts
+++ b/apps/api/src/llm-gateway/resolution/descriptors.ts
@@ -54,31 +54,11 @@ function bedrockManagedDescriptor(managed: ManagedModel): UpstreamDescriptor | n
   };
 }
 
-function opencodeZenManagedDescriptor(managed: ManagedModel): UpstreamDescriptor {
-  return {
-    provider: 'opencode-zen',
-    kind: 'openai-compat',
-    baseUrl: 'https://opencode.ai/zen/v1',
-    apiKey: '',
-    omitAuthorization: true,
-    billingMode: 'none',
-    markup: 0,
-    resolvedModel: managed.upstreamModelId,
-    pricing: {
-      inputPerMillion: 0,
-      outputPerMillion: 0,
-      cachedInputPerMillion: 0,
-    },
-  };
-}
-
 export function managedCandidates(managed: ManagedModel): UpstreamDescriptor[] {
   const d =
-    managed.transport === 'opencode-zen'
-      ? opencodeZenManagedDescriptor(managed)
-      : managed.transport === 'openrouter'
-        ? openRouterManagedDescriptor(managed)
-        : bedrockManagedDescriptor(managed);
+    managed.transport === 'openrouter'
+      ? openRouterManagedDescriptor(managed)
+      : bedrockManagedDescriptor(managed);
   return d ? [d] : [];
 }
 

--- a/apps/api/src/llm-gateway/wire.ts
+++ b/apps/api/src/llm-gateway/wire.ts
@@ -23,8 +23,8 @@ export function mountLlmGateway(app: OpenAPIHono): void {
     // One gateway instance per process — its circuit breakers are long-lived.
     const gateway = createGateway(createInProcessGatewayHooks(), {
       captureBodies: true,
-      // Tier-aware: a free account's `auto` resolves to a free model, not a paid
-      // one it has no upstream for. freeModelsOnly is set on the principal at auth.
+      // Tier-aware: free accounts do not get a gateway AUTO target; their free
+      // Zen default is the sandbox-native `opencode` provider.
       autoRouter: (model, body, principal) =>
         pickAutoModel(model, body, { free: !!principal.freeModelsOnly }),
     });

--- a/apps/api/src/projects/routes/r4.ts
+++ b/apps/api/src/projects/routes/r4.ts
@@ -1330,8 +1330,9 @@ projectsApp.openapi(
         404,
       );
     }
-    // Free-tier accounts only see free managed models in the picker (their own
-    // BYOK-connected models still show). Mirrors the gateway's resolve-time gate.
+    // Free-tier accounts do not see Kortix managed paid/AUTO gateway models.
+    // Their own BYOK-connected models still show; OpenCode Zen free models come
+    // from the running sandbox's native provider, not this project catalog.
     const freeManagedOnly =
       config.KORTIX_BILLING_INTERNAL_ENABLED && ownerAccountId
         ? !tierGrantsAllModels(await getCachedAccountTier(ownerAccountId))

--- a/apps/kortix-sandbox-agent-server/src/__tests__/executor-mcp-config.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/executor-mcp-config.test.ts
@@ -176,37 +176,37 @@ describe('buildOpencodeConfigContent — Kortix LLM gateway provider', () => {
   })
 })
 
-describe('buildOpencodeConfigContent — gateway is the sole LLM path (enabled_providers)', () => {
+describe('buildOpencodeConfigContent — gateway plus native OpenCode Zen allowlist', () => {
   const GATEWAY_ENV = {
     KORTIX_LLM_BASE_URL: 'https://api.kortix.test/v1/llm',
     KORTIX_LLM_API_KEY: 'kyolo_abc123',
   }
 
-  test('locks opencode to ONLY the kortix provider when the gateway is active', async () => {
+  test('allows only kortix plus native opencode when the gateway is active', async () => {
     stubGatewayModels(GATEWAY_CATALOG)
     const config = JSON.parse((await buildOpencodeConfigContent(GATEWAY_ENV))!)
-    expect(config.enabled_providers).toEqual(['kortix'])
+    expect(config.enabled_providers).toEqual(['kortix', 'opencode'])
   })
 
-  test('a leaked native key (e.g. GITHUB_TOKEN) cannot open a native provider — only kortix is enabled', async () => {
+  test('a leaked native key (e.g. GITHUB_TOKEN) cannot open its native provider', async () => {
     stubGatewayModels(GATEWAY_CATALOG)
     const config = JSON.parse(
       (await buildOpencodeConfigContent({ ...GATEWAY_ENV, GITHUB_TOKEN: 'ghp_x', OPENAI_API_KEY: 'sk-x' }))!,
     )
-    expect(config.enabled_providers).toEqual(['kortix'])
+    expect(config.enabled_providers).toEqual(['kortix', 'opencode'])
   })
 
-  test('ignores connected Codex/OpenCode subscription providers while gateway is active', async () => {
+  test('does not enable codex/openai subscription providers while gateway is active', async () => {
     stubGatewayModels(GATEWAY_CATALOG)
     const authJson = JSON.stringify({ openai: { type: 'oauth', access: 'x' }, opencode: { key: 'y' } })
     const config = JSON.parse((await buildOpencodeConfigContent({ ...GATEWAY_ENV, CODEX_AUTH_JSON: authJson }))!)
-    expect(config.enabled_providers).toEqual(['kortix'])
+    expect(config.enabled_providers).toEqual(['kortix', 'opencode'])
   })
 
-  test('ignores malformed auth.json and still locks to kortix', async () => {
+  test('ignores malformed auth.json and still keeps the explicit allowlist', async () => {
     stubGatewayModels(GATEWAY_CATALOG)
     const config = JSON.parse((await buildOpencodeConfigContent({ ...GATEWAY_ENV, OPENCODE_AUTH_JSON: 'not json{' }))!)
-    expect(config.enabled_providers).toEqual(['kortix'])
+    expect(config.enabled_providers).toEqual(['kortix', 'opencode'])
   })
 
   test('does NOT set an allowlist when there is no gateway (subscription-only session stays native)', async () => {

--- a/apps/kortix-sandbox-agent-server/src/opencode.ts
+++ b/apps/kortix-sandbox-agent-server/src/opencode.ts
@@ -143,16 +143,12 @@ export async function buildOpencodeConfigContent(env: NodeJS.ProcessEnv): Promis
     if (!('small_model' in out) || typeof out.small_model !== 'string') {
       out.small_model = DEFAULT_KORTIX_MODEL
     }
-    // Lock opencode to the gateway as the ONLY LLM path. enabled_providers is an
-    // allowlist — opencode loads ONLY these and ignores every provider it would
-    // otherwise auto-detect from env (e.g. GITHUB_TOKEN → GitHub Models,
-    // OPENAI_API_KEY → openai), so a leaked key can't open a native path that
-    // bypasses budgets/logging/spend. This is the robust complement to the env
-    // deny-strip in spawnChild (which can be defeated if a key reaches opencode
-    // by some path the deny-list didn't enumerate). Gateway mode is a hard cut:
-    // even project-scoped Codex/OpenCode subscription auth.json must not expose a
-    // native provider here, otherwise usage bypasses gateway logs/budgets.
-    out.enabled_providers = ['kortix']
+    // Gateway mode still allowlists providers so leaked provider keys cannot
+    // open native Anthropic/OpenAI/GitHub/etc paths that bypass gateway budgets,
+    // logs, and BYOK handling. The one intentional native session provider is
+    // OpenCode Zen: its free models should egress from the sandbox instead of the
+    // Kortix gateway IP.
+    out.enabled_providers = ['kortix', 'opencode']
   }
 
   // (3) Slack sessions: DENY opencode's blocking `question` tool. A Slack thread

--- a/apps/web/src/features/session/model-selector.tsx
+++ b/apps/web/src/features/session/model-selector.tsx
@@ -33,7 +33,6 @@ import { useProviderModalStore } from '@/stores/provider-modal-store';
 import {
   AUTO_MODEL_ID,
   DEFAULT_MANAGED_MODEL_IDS,
-  DEFAULT_OPENCODE_ZEN_FREE_MODEL_IDS,
 } from '@kortix/shared/llm-catalog';
 import { accountStateSelectors, useAccountState } from '@/hooks/billing';
 import { useQuery } from '@tanstack/react-query';
@@ -78,10 +77,13 @@ import { Tag } from '@/components/ui/tag';
 // Kortix and always shown, but rendered as a special "smart routing" affordance.
 const MANAGED_MODEL_IDS = new Set<string>([...DEFAULT_MANAGED_MODEL_IDS, AUTO_MODEL_ID]);
 
-// Free-tier (no active paid sub) only gets the free Kortix-managed models. `auto`
-// and the paid managed models are hidden, and the default lands on a free model.
-const FREE_MANAGED_MODEL_IDS = new Set<string>(DEFAULT_OPENCODE_ZEN_FREE_MODEL_IDS);
-const FREE_DEFAULT_MODEL_ID = 'deepseek-v4-flash-free';
+// Free-tier (no active paid sub) cannot use the Kortix managed paid lineup or
+// synthetic AUTO. The fallback free model lives under OpenCode's native provider
+// once a session sandbox has loaded it.
+const FREE_DEFAULT_MODEL = {
+  providerID: 'opencode',
+  modelID: 'deepseek-v4-flash-free',
+};
 
 // The gateway exposes its whole catalog through a single `kortix` provider, with
 // model ids namespaced as `<provider>/<model>`. For the picker we split that
@@ -159,8 +161,9 @@ export function ModelSelector({ models, selectedModel, onSelect }: ModelSelector
     return connectedGatewayProviderIdsFromSecretNames(secretNames);
   }, [llmGatewayEnabled, secretNames]);
 
-  // Free tier (free/no plan AND no active subscription) only sees free managed
-  // models through the Kortix gateway. BYOK/connected providers are unaffected.
+  // Free tier (free/no plan AND no active subscription) hides Kortix managed
+  // paid/AUTO models. Native OpenCode Zen and connected BYOK providers remain
+  // available through their own routing.
   const { data: accountState } = useAccountState();
   const freeTier = useMemo(() => {
     const tierKey = accountStateSelectors.tierKey(accountState).toLowerCase();
@@ -249,11 +252,17 @@ export function ModelSelector({ models, selectedModel, onSelect }: ModelSelector
     [baseModels, llmGatewayEnabled, freeTier],
   );
 
-  // Free tier can't use `auto` or paid managed models — if one is selected (the
-  // inherited default), switch to the free default so the first message doesn't
-  // 400 with "no upstream configured for model fusion".
+  // Free tier can't use gateway `auto` or paid managed models. If one is
+  // selected and the session-native OpenCode Zen provider is available, switch
+  // to the native free default so the first message never routes through the
+  // gateway Zen path.
   const freeDefaultModel = useMemo(
-    () => baseModels.find((m) => m.providerID === 'kortix' && m.modelID === FREE_DEFAULT_MODEL_ID),
+    () =>
+      baseModels.find(
+        (m) =>
+          m.providerID === FREE_DEFAULT_MODEL.providerID &&
+          m.modelID === FREE_DEFAULT_MODEL.modelID,
+      ),
     [baseModels],
   );
   useEffect(() => {
@@ -262,8 +271,7 @@ export function ModelSelector({ models, selectedModel, onSelect }: ModelSelector
     const disallowed =
       !!sel &&
       sel.providerID === 'kortix' &&
-      MANAGED_MODEL_IDS.has(sel.modelID) &&
-      !FREE_MANAGED_MODEL_IDS.has(sel.modelID);
+      MANAGED_MODEL_IDS.has(sel.modelID);
     if (disallowed) {
       onSelect({ providerID: freeDefaultModel.providerID, modelID: freeDefaultModel.modelID });
     }

--- a/apps/web/src/features/session/model-tags.test.ts
+++ b/apps/web/src/features/session/model-tags.test.ts
@@ -47,7 +47,7 @@ describe('modelVisibilityKeyForProviderModel', () => {
 
   test('keeps managed kortix model ids bare in gateway mode', () => {
     expect(
-      modelVisibilityKeyForProviderModel('kortix', 'deepseek-v4-flash-free', true),
-    ).toEqual({ providerID: 'kortix', modelID: 'deepseek-v4-flash-free' });
+      modelVisibilityKeyForProviderModel('kortix', 'claude-opus-4.8', true),
+    ).toEqual({ providerID: 'kortix', modelID: 'claude-opus-4.8' });
   });
 });

--- a/apps/web/src/hooks/opencode/provider-selection.test.ts
+++ b/apps/web/src/hooks/opencode/provider-selection.test.ts
@@ -5,6 +5,7 @@ import {
   filterToGatewayProviders,
   filterToNativeProviders,
   mergeProjectSecretConnectedProviders,
+  mergeProviderLists,
   normalizeProviderList,
   projectLlmCatalogToProviderList,
   providerListHasGateway,
@@ -54,8 +55,8 @@ describe('provider-selection', () => {
   test('keeps gateway providers only when the running runtime exposes kortix', () => {
     const mixed = providers(['kortix', 'opencode', 'anthropic']);
     expect(providerListHasGateway(mixed)).toBe(true);
-    expect(filterToGatewayProviders(mixed).connected).toEqual(['kortix']);
-    expect(filterToGatewayProviders(mixed).all?.map((p) => p.id)).toEqual(['kortix']);
+    expect(filterToGatewayProviders(mixed).connected).toEqual(['kortix', 'opencode']);
+    expect(filterToGatewayProviders(mixed).all?.map((p) => p.id)).toEqual(['kortix', 'opencode']);
 
     const native = providers(['anthropic', 'openai']);
     expect(providerListHasGateway(native)).toBe(false);
@@ -78,7 +79,7 @@ describe('provider-selection', () => {
           { id: 'opencode', name: 'OpenCode Zen', models: { zen: { name: 'Zen' } } },
           { id: 'anthropic', name: 'Anthropic', models: { claude: { name: 'Claude' } } },
         ],
-      } as ProviderListResponse,
+      } as unknown as ProviderListResponse,
       new Set(['ANTHROPIC_API_KEY']),
       [{ id: 'anthropic', envVars: ['ANTHROPIC_API_KEY'] }],
     );
@@ -100,14 +101,28 @@ describe('provider-selection', () => {
     const list = projectLlmCatalogToProviderList({
       models: {
         auto: { name: 'Auto' },
-        'deepseek-v4-flash-free': { name: 'DeepSeek V4 Flash Free', free: true },
+        'claude-opus-4.8': { name: 'Claude Opus 4.8' },
       },
     });
 
     expect(list.connected).toEqual(['kortix']);
     expect(list.default).toEqual({ kortix: 'auto' });
     expect(list.all?.[0]?.id).toBe('kortix');
-    expect(Object.keys(list.all?.[0]?.models ?? {})).toEqual(['auto', 'deepseek-v4-flash-free']);
-    expect((list.all?.[0]?.models as any)?.['deepseek-v4-flash-free']?.free).toBe(true);
+    expect(Object.keys(list.all?.[0]?.models ?? {})).toEqual(['auto', 'claude-opus-4.8']);
+    expect((list.all?.[0]?.models as any)?.['deepseek-v4-flash-free']).toBeUndefined();
+  });
+
+  test('merges project gateway catalog with session-native OpenCode Zen provider', () => {
+    const project = projectLlmCatalogToProviderList({
+      models: {
+        auto: { name: 'Auto' },
+      },
+    });
+    const session = filterToGatewayProviders(providers(['opencode', 'anthropic']));
+    const merged = mergeProviderLists(project, session);
+
+    expect(merged.connected).toEqual(['kortix', 'opencode']);
+    expect(merged.all?.map((p) => p.id)).toEqual(['kortix', 'opencode']);
+    expect((merged.all?.find((p) => p.id === 'opencode')?.models as any)?.['opencode-model']).toBeDefined();
   });
 });

--- a/apps/web/src/hooks/opencode/provider-selection.ts
+++ b/apps/web/src/hooks/opencode/provider-selection.ts
@@ -5,9 +5,12 @@ import { LLM_PROVIDERS } from '@/lib/llm-providers';
 
 export type ProviderListResponse = SdkProviderListResponse;
 
-// In gateway mode OpenCode must see Kortix as the single LLM provider. Native
-// providers, including OpenCode Zen, belong only to native mode.
 export const GATEWAY_PROVIDER_IDS = new Set(['kortix']);
+export const SESSION_NATIVE_PROVIDER_IDS = new Set(['opencode']);
+export const GATEWAY_SESSION_PROVIDER_IDS = new Set([
+  ...GATEWAY_PROVIDER_IDS,
+  ...SESSION_NATIVE_PROVIDER_IDS,
+]);
 const NATIVE_EXCLUDED_PROVIDER_IDS = new Set(['kortix']);
 
 export function normalizeProviderList(
@@ -74,8 +77,28 @@ export function filterToGatewayProviders(providers: ProviderListResponse): Provi
   const connected = Array.isArray(normalized.connected) ? normalized.connected : [];
   return {
     ...normalized,
-    all: all.filter((p) => GATEWAY_PROVIDER_IDS.has(p.id)),
-    connected: connected.filter((id) => GATEWAY_PROVIDER_IDS.has(id)),
+    all: all.filter((p) => GATEWAY_SESSION_PROVIDER_IDS.has(p.id)),
+    connected: connected.filter((id) => GATEWAY_SESSION_PROVIDER_IDS.has(id)),
+  };
+}
+
+export function mergeProviderLists(
+  primary: ProviderListResponse,
+  secondary: ProviderListResponse,
+): ProviderListResponse {
+  const a = normalizeProviderList(primary);
+  const b = normalizeProviderList(secondary);
+  const all = new Map<string, NonNullable<ProviderListResponse['all']>[number]>();
+  for (const provider of Array.isArray(a.all) ? a.all : []) all.set(provider.id, provider);
+  for (const provider of Array.isArray(b.all) ? b.all : []) all.set(provider.id, provider);
+  const connected = new Set<string>();
+  for (const id of Array.isArray(a.connected) ? a.connected : []) connected.add(id);
+  for (const id of Array.isArray(b.connected) ? b.connected : []) connected.add(id);
+  return {
+    ...a,
+    all: [...all.values()],
+    connected: [...connected],
+    default: { ...(a.default ?? {}), ...(b.default ?? {}) },
   };
 }
 

--- a/apps/web/src/hooks/opencode/use-model-store.ts
+++ b/apps/web/src/hooks/opencode/use-model-store.ts
@@ -18,7 +18,6 @@ import { safeSetItem } from '@/lib/storage/managed-storage';
 import {
   AUTO_MODEL_ID,
   DEFAULT_MANAGED_MODEL_IDS,
-  DEFAULT_OPENCODE_ZEN_FREE_MODEL_IDS,
   MANAGED_FLAGSHIP_MODEL_ID,
 } from '@kortix/shared/llm-catalog';
 import { useCallback, useMemo, useSyncExternalStore } from 'react';
@@ -179,12 +178,6 @@ const SUBSCRIPTION_PROVIDER_ID = 'codex';
 // Includes the synthetic `auto` entry so it's always offered in the picker.
 const MANAGED_MODEL_IDS = new Set<string>([...DEFAULT_MANAGED_MODEL_IDS, AUTO_MODEL_ID]);
 
-// The free Kortix-managed models (the only ones a free-tier / no-active-sub
-// account may use). A free account sees ONLY these under the `kortix` provider —
-// the paid managed models (and the synthetic `auto`) are hidden. Mirrors the
-// gateway's resolve-time tier gate so the picker can't offer a model that 400s.
-const FREE_MANAGED_MODEL_IDS = new Set<string>(DEFAULT_OPENCODE_ZEN_FREE_MODEL_IDS);
-
 function subProviderOf(modelID: string): string {
   const slash = modelID.indexOf('/');
   return slash === -1 ? modelID : modelID.slice(0, slash);
@@ -260,7 +253,7 @@ export function useModelStore(
   allModels: FlatModel[],
   opts?: {
     connectedProviderIds?: Set<string>;
-    // Free tier (no active paid sub): only the free managed models are visible.
+    // Free tier (no active paid sub): hides Kortix managed paid/AUTO models.
     freeTier?: boolean;
   },
 ) {
@@ -302,9 +295,9 @@ export function useModelStore(
             ? (connectedProviderIds?.has(SUBSCRIPTION_PROVIDER_ID) ?? false)
             : (connectedProviderIds?.has(sub) ?? false);
         if (MANAGED_MODEL_IDS.has(model.modelID)) {
-          // Free tier sees ONLY the free managed models — paid managed and the
-          // synthetic `auto` are hidden (they have no upstream for the account).
-          if (freeTier && !FREE_MANAGED_MODEL_IDS.has(model.modelID)) return false;
+          // Free tier cannot use Kortix managed paid models or synthetic AUTO.
+          // Zen free models are native `opencode` session models now.
+          if (freeTier) return false;
           return true;
         }
         if (!connected) return false;

--- a/apps/web/src/hooks/opencode/use-opencode-local.ts
+++ b/apps/web/src/hooks/opencode/use-opencode-local.ts
@@ -155,8 +155,8 @@ export function useOpenCodeLocal({
   config,
   sessionId,
 }: UseOpenCodeLocalOptions): OpenCodeLocal {
-  // ---- Flatten models from providers (shared with the chat input, so the
-  // gateway-only allowlist applies here too — native providers never leak in) ----
+  // ---- Flatten models from providers (shared with the chat input). Gateway
+  // sessions include Kortix plus the native OpenCode Zen provider. ----
   const flatModels = useMemo<FlatModel[]>(() => flattenModels(providers), [providers]);
   const params = useParams();
   const projectId = typeof params?.id === 'string' ? params.id : null;

--- a/apps/web/src/hooks/opencode/use-opencode-sessions.ts
+++ b/apps/web/src/hooks/opencode/use-opencode-sessions.ts
@@ -21,6 +21,7 @@ import {
   filterToGatewayProviders,
   filterToNativeProviders,
   GATEWAY_PROVIDER_IDS,
+  mergeProviderLists,
   mergeProjectSecretConnectedProviders,
   normalizeProviderList,
   projectLlmCatalogToProviderList,
@@ -1087,12 +1088,26 @@ export function useOpenCodeProviders() {
     : CACHE_SCOPE_GLOBAL;
   return useQuery<ProviderListResponse>({
     queryKey: projectId
-      ? ['project-providers', projectId, projectGatewayEnabled ? 'gateway' : 'native']
+      ? [
+          'project-providers',
+          projectId,
+          projectGatewayEnabled
+            ? runtimeReady
+              ? 'gateway-runtime'
+              : 'gateway-catalog'
+            : 'native',
+        ]
       : opencodeKeys.providers(),
     queryFn: async () => {
       if (projectId && projectGatewayEnabled) {
         const catalog = await getProjectLlmCatalog(projectId);
-        const providers = projectLlmCatalogToProviderList(catalog);
+        let providers = projectLlmCatalogToProviderList(catalog);
+        if (runtimeReady) {
+          const client = getClient();
+          const result = await client.provider.list();
+          const sessionProviders = filterToGatewayProviders(normalizeProviderList(unwrap(result)));
+          providers = mergeProviderLists(providers, sessionProviders);
+        }
         setLSCache(LS_PROVIDERS, providers, cacheScope);
         return providers;
       }

--- a/packages/shared/src/llm-catalog/index.ts
+++ b/packages/shared/src/llm-catalog/index.ts
@@ -40,13 +40,11 @@ export interface ManagedModel {
   // The upstream's own model id, interpreted per `transport`:
   //   'bedrock'      → a Bedrock id (`us.anthropic.claude-opus-4-8`)
   //   'openrouter'   → an OpenRouter slug (`openrouter/fusion`)
-  //   'opencode-zen' → an OpenCode Zen public model id (`deepseek-v4-flash-free`)
   upstreamModelId: string;
   // Which upstream + wire format carries it:
   //   'bedrock'      → Anthropic-on-Bedrock InvokeModel payload (Claude only)
   //   'openrouter'   → OpenRouter openai-compatible chat completions
-  //   'opencode-zen' → OpenCode Zen openai-compatible chat completions (no auth)
-  transport: "bedrock" | "openrouter" | "opencode-zen";
+  transport: "bedrock" | "openrouter";
   // models.dev id for live pricing — upstream ids don't always match the catalog.
   pricingRef: string;
   tier: "flagship" | "balanced" | "fast" | "free";
@@ -69,66 +67,19 @@ export interface ManagedModel {
 // (`claude-opus-4.8` → our keys, credits-billed) apart from a BYOK one
 // (`anthropic/claude-...` → the user's own key) without the two ever colliding.
 //
-// Every managed paid model runs through OUR keys and is billed as Kortix credits
-// with markup, so the gateway enforces budgets/logging/spend on all of them.
-// Claude runs on Bedrock (the proven Anthropic-payload InvokeModel transport);
-// everything else paid (GLM, Qwen, DeepSeek) goes via OpenRouter. The curated
-// OpenCode Zen free set is also managed here: it is exposed under the `kortix`
-// provider and recorded by the gateway, not shown as a separate native
-// `opencode` provider in the gateway picker.
+// Every managed model runs through OUR keys and is billed as Kortix credits with
+// markup, so the gateway enforces budgets/logging/spend on all of them. Claude
+// runs on Bedrock (the proven Anthropic-payload InvokeModel transport);
+// everything else goes via OpenRouter. OpenCode Zen free models are intentionally
+// NOT managed here: running sessions expose them through OpenCode's native
+// `opencode` provider so their traffic originates from the sandbox, not the
+// Kortix gateway.
 export const DEFAULT_OPENCODE_ZEN_FREE_MODEL_IDS = [
   "deepseek-v4-flash-free",
   "mimo-v2.5-free",
   "nemotron-3-ultra-free",
   "north-mini-code-free",
 ] as const;
-
-const OPENCODE_ZEN_FREE_MODELS: ManagedModel[] = [
-  {
-    id: "deepseek-v4-flash-free",
-    name: "DeepSeek V4 Flash Free",
-    upstreamModelId: "deepseek-v4-flash-free",
-    transport: "opencode-zen",
-    pricingRef: "opencode/deepseek-v4-flash-free",
-    tier: "free",
-    free: true,
-    vision: false,
-    limit: { context: 200_000, output: 128_000 },
-  },
-  {
-    id: "mimo-v2.5-free",
-    name: "MiMo V2.5 Free",
-    upstreamModelId: "mimo-v2.5-free",
-    transport: "opencode-zen",
-    pricingRef: "opencode/mimo-v2.5-free",
-    tier: "free",
-    free: true,
-    vision: true,
-    limit: { context: 200_000, output: 32_000 },
-  },
-  {
-    id: "nemotron-3-ultra-free",
-    name: "Nemotron 3 Ultra Free",
-    upstreamModelId: "nemotron-3-ultra-free",
-    transport: "opencode-zen",
-    pricingRef: "opencode/nemotron-3-ultra-free",
-    tier: "free",
-    free: true,
-    vision: false,
-    limit: { context: 1_000_000, output: 128_000 },
-  },
-  {
-    id: "north-mini-code-free",
-    name: "North Mini Code Free",
-    upstreamModelId: "north-mini-code-free",
-    transport: "opencode-zen",
-    pricingRef: "opencode/north-mini-code-free",
-    tier: "free",
-    free: true,
-    vision: false,
-    limit: { context: 256_000, output: 64_000 },
-  },
-];
 
 export const MANAGED_MODELS: ManagedModel[] = [
   {
@@ -191,7 +142,6 @@ export const MANAGED_MODELS: ManagedModel[] = [
     vision: false,
     limit: { context: 1_048_576, output: 64_000 },
   },
-  ...OPENCODE_ZEN_FREE_MODELS,
 ];
 
 const MANAGED_BY_ID = new Map(MANAGED_MODELS.map((m) => [m.id, m] as const));
@@ -224,13 +174,6 @@ export const AUTO_MODEL_ID = "auto";
 
 const AUTO_TARGET_MODEL = "fusion"; // text-only default
 const AUTO_VISION_MODEL = "claude-sonnet-4.6"; // when the request has image content
-
-// Free-tier AUTO targets. A free account can't route to the paid targets above
-// (they'd 400 with "no upstream configured"), so AUTO resolves to the curated
-// free OpenCode-Zen lineup instead: a text default + the single free vision
-// model, so even image requests stay on a model the account can actually use.
-const AUTO_FREE_MODEL = "deepseek-v4-flash-free"; // free text default
-const AUTO_FREE_VISION_MODEL = "mimo-v2.5-free"; // the only free vision model
 
 function requestHasImage(body: Record<string, unknown>): boolean {
   const messages = Array.isArray(body.messages) ? body.messages : [];
@@ -266,13 +209,14 @@ export function pickAutoModel(
     return null;
   const hasImage = requestHasImage(body);
   if (opts?.free) {
-    return hasImage ? AUTO_FREE_VISION_MODEL : AUTO_FREE_MODEL;
+    return null;
   }
   return hasImage ? AUTO_VISION_MODEL : AUTO_TARGET_MODEL;
 }
 
 export const MODEL_SELECTOR_PROVIDER_IDS = [
   "kortix",
+  "opencode",
   "anthropic",
   "openai",
   "github-copilot",

--- a/packages/shared/src/llm-catalog/managed.test.ts
+++ b/packages/shared/src/llm-catalog/managed.test.ts
@@ -17,7 +17,6 @@ describe("managed catalog", () => {
       "qwen3.7-max",
       "deepseek-v4-pro",
       "deepseek-v4-flash",
-      ...DEFAULT_OPENCODE_ZEN_FREE_MODEL_IDS,
     ]);
   });
 
@@ -41,7 +40,7 @@ describe("managed catalog", () => {
         m.pricingRef.length,
         `${m.id} needs a pricing ref`,
       ).toBeGreaterThan(0);
-      expect(["bedrock", "openrouter", "opencode-zen"]).toContain(m.transport);
+      expect(["bedrock", "openrouter"]).toContain(m.transport);
     }
   });
 
@@ -52,18 +51,15 @@ describe("managed catalog", () => {
         expect(m.upstreamModelId, `${m.id} (Bedrock) → Anthropic`).toContain(
           "anthropic.claude",
         );
-      } else if (m.transport === "openrouter") {
+      } else {
         // OpenRouter slugs are provider/model.
         expect(m.transport, `${m.id} transport`).toBe("openrouter");
         expect(m.upstreamModelId, `${m.id} OpenRouter slug`).toContain("/");
-      } else {
-        expect(m.transport, `${m.id} transport`).toBe("opencode-zen");
-        expect(m.upstreamModelId, `${m.id} Zen id`).not.toContain("/");
       }
     }
   });
 
-  test("curated OpenCode Zen free ids are managed Kortix models", () => {
+  test("curated OpenCode Zen free ids are native session models, not managed Kortix models", () => {
     expect(DEFAULT_OPENCODE_ZEN_FREE_MODEL_IDS).toEqual([
       "deepseek-v4-flash-free",
       "mimo-v2.5-free",
@@ -80,11 +76,8 @@ describe("managed catalog", () => {
 
     for (const id of DEFAULT_OPENCODE_ZEN_FREE_MODEL_IDS) {
       const model = getManagedModel(id);
-      expect(model, `${id} should resolve`).toBeDefined();
-      expect(model?.transport).toBe("opencode-zen");
-      expect(model?.upstreamModelId).toBe(id);
-      expect(model?.tier).toBe("free");
-      expect(model?.free).toBe(true);
+      expect(model, `${id} should not resolve as managed`).toBeUndefined();
+      expect(isManagedModelId(id), `${id} should not be managed`).toBe(false);
     }
   });
 });

--- a/packages/shared/src/llm-catalog/pick-auto.test.ts
+++ b/packages/shared/src/llm-catalog/pick-auto.test.ts
@@ -57,12 +57,13 @@ describe("pickAutoModel", () => {
     ).toBeDefined();
   });
 
-  test("free tier resolves auto to a FREE model, never a paid one", () => {
-    // Text → free text default; image → the one free vision model. A free
-    // account has no upstream for fusion/claude-sonnet, so auto must not pick them.
+  test("free tier does not resolve auto through the managed gateway", () => {
+    // A free account's Zen default is a native sandbox `opencode` model, not a
+    // Kortix-managed gateway model. Returning null makes raw auto yield no
+    // gateway candidate instead of silently using a gateway IP for Zen.
     expect(
       pickAutoModel("auto", { messages: [msg("hello there")] }, { free: true }),
-    ).toBe("deepseek-v4-flash-free");
+    ).toBeNull();
     const withImage = {
       messages: [
         {
@@ -77,16 +78,12 @@ describe("pickAutoModel", () => {
         },
       ],
     };
-    expect(pickAutoModel("auto", withImage, { free: true })).toBe(
-      "mimo-v2.5-free",
-    );
+    expect(pickAutoModel("auto", withImage, { free: true })).toBeNull();
   });
 
-  test("both free auto targets are real FREE managed models", () => {
+  test("free Zen defaults are not managed gateway models", () => {
     for (const id of ["deepseek-v4-flash-free", "mimo-v2.5-free"]) {
-      const m = getManagedModel(id);
-      expect(m, `${id} must exist`).toBeDefined();
-      expect(m?.free, `${id} must be free`).toBe(true);
+      expect(getManagedModel(id), `${id} must stay native`).toBeUndefined();
     }
   });
 


### PR DESCRIPTION
## Summary
- remove OpenCode Zen free models from the Kortix managed/gateway catalog
- expose native OpenCode Zen beside Kortix in gateway sessions only
- keep BYOK/Codex routed through the Kortix gateway catalog and project secrets
- switch free-tier model fallback from kortix/deepseek-v4-flash-free to native opencode/deepseek-v4-flash-free when the sandbox provider is available

## Verification
- bun test packages/shared/src/llm-catalog/managed.test.ts packages/shared/src/llm-catalog/pick-auto.test.ts
- bun test apps/api/src/llm-gateway/models/catalog-models.test.ts apps/api/src/__tests__/unit-resolve-candidates-free-tier.test.ts
- bun test apps/kortix-sandbox-agent-server/src/__tests__/executor-mcp-config.test.ts
- cd apps/web && bun test src/hooks/opencode/provider-selection.test.ts src/hooks/opencode/use-opencode-local.test.ts src/features/session/model-tags.test.ts
- cd apps/web && npx eslint src/hooks/opencode/provider-selection.ts src/hooks/opencode/use-opencode-sessions.ts src/hooks/opencode/use-model-store.ts src/hooks/opencode/use-opencode-local.ts src/features/session/model-selector.tsx src/features/session/model-tags.test.ts
- pnpm --filter @kortix/shared typecheck && pnpm --filter kortix-api typecheck && pnpm --filter @kortix/sandbox-agent-server typecheck
- cd apps/web && npx tsc --noEmit --pretty false | rg touched files (no matches)
- live local E2E on worktree stack: provisioned project/session, verified /llm-catalog excludes Zen gateway entries, runtime /provider includes opencode+kortix, opencode/deepseek-v4-flash-free replied PONG, and gateway logs stayed at zero for deepseek-v4-flash-free