### PR TITLE
feat(slack): in-thread connect + request-access flow

### DIFF
--- a/apps/api/src/__tests__/unit-slack-access-request.test.ts
+++ b/apps/api/src/__tests__/unit-slack-access-request.test.ts
@@ -1,0 +1,102 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+// Stage A of the Slack access-flow redesign: connecting your Kortix account is
+// decoupled from having access, and a connected-but-no-access user requests
+// access right in the thread (no DM wall). These tests pin (1) the action_id
+// contract the interactivity router dispatches on, and (2) the branch logic of
+// filing an access request.
+
+// ─── DB mock: FIFO of query results ──────────────────────────────────────────
+let dbResults: unknown[][] = [];
+function makeChain(): any {
+  const chain: any = {};
+  for (const m of ['from', 'where', 'limit', 'values', 'returning', 'onConflictDoNothing', 'onConflictDoUpdate', 'set']) {
+    chain[m] = () => chain;
+  }
+  chain.then = (resolve: (rows: unknown[]) => unknown) => Promise.resolve(resolve(dbResults.shift() ?? []));
+  return chain;
+}
+mock.module('../shared/db', () => ({
+  db: { select: () => makeChain(), insert: () => makeChain(), update: () => makeChain() },
+  hasDatabase: () => true,
+}));
+
+// lookupEmailsByUserIds hits Supabase — mock it so the 'created' path stays offline.
+mock.module('../projects/lib/access', () => ({
+  lookupEmailsByUserIds: async () => new Map<string, string | null>(),
+}));
+
+const { connectAccountBlocks, requestAccessBlocks, createSlackAccessRequest } = await import(
+  '../channels/slack/identity'
+);
+
+afterAll(() => mock.restore());
+beforeEach(() => {
+  dbResults = [];
+});
+
+// Pull the first button out of an actions block.
+const firstButton = (blocks: any[]) =>
+  blocks.find((b) => b.type === 'actions')?.elements?.find((e: any) => e.type === 'button');
+
+describe('access nudge blocks — the action_id contract the router relies on', () => {
+  test('connect block carries the login URL and the slack_login_connect action_id', () => {
+    const btn = firstButton(connectAccountBlocks('https://kortix.com/login?x=1') as any[]);
+    expect(btn.action_id).toBe('slack_login_connect');
+    expect(btn.url).toBe('https://kortix.com/login?x=1');
+  });
+
+  test('request-access block carries slack_request_access and the projectId in its value', () => {
+    const btn = firstButton(requestAccessBlocks('proj-1') as any[]);
+    expect(btn.action_id).toBe('slack_request_access');
+    expect(JSON.parse(btn.value)).toEqual({ projectId: 'proj-1' });
+    expect(btn.url).toBeUndefined(); // it's an action button, not a link
+  });
+});
+
+describe('createSlackAccessRequest — file (or find) a project access request', () => {
+  test('unlinked Slack user → no-identity (nothing to request as)', async () => {
+    dbResults = [[]]; // lookupSlackIdentity → none
+    const r = await createSlackAccessRequest({ teamId: 'T1', slackUserId: 'U1', projectId: 'proj-1' });
+    expect(r.status).toBe('no-identity');
+  });
+
+  test('unknown project → no-project', async () => {
+    dbResults = [[{ userId: 'u1' }], []]; // identity ok, project missing
+    const r = await createSlackAccessRequest({ teamId: 'T1', slackUserId: 'U1', projectId: 'proj-1' });
+    expect(r.status).toBe('no-project');
+  });
+
+  test('already a member → already-member (no request filed)', async () => {
+    dbResults = [
+      [{ userId: 'u1' }], // identity
+      [{ accountId: 'a1' }], // project
+      [{ userId: 'u1' }], // isAccountMember → member
+    ];
+    const r = await createSlackAccessRequest({ teamId: 'T1', slackUserId: 'U1', projectId: 'proj-1' });
+    expect(r).toEqual({ status: 'already-member', requesterUserId: 'u1', accountId: 'a1' });
+  });
+
+  test('already has a pending request → pending (idempotent, no duplicate)', async () => {
+    dbResults = [
+      [{ userId: 'u1' }], // identity
+      [{ accountId: 'a1' }], // project
+      [], // not a member
+      [{ requestId: 'r1' }], // existing pending request
+    ];
+    const r = await createSlackAccessRequest({ teamId: 'T1', slackUserId: 'U1', projectId: 'proj-1' });
+    expect(r).toEqual({ status: 'pending', requesterUserId: 'u1', accountId: 'a1' });
+  });
+
+  test('connected non-member, none pending → created', async () => {
+    dbResults = [
+      [{ userId: 'u1' }], // identity
+      [{ accountId: 'a1' }], // project
+      [], // not a member
+      [], // no existing pending
+      [], // insert
+    ];
+    const r = await createSlackAccessRequest({ teamId: 'T1', slackUserId: 'U1', projectId: 'proj-1' });
+    expect(r).toEqual({ status: 'created', requesterUserId: 'u1', accountId: 'a1' });
+  });
+});

--- a/apps/api/src/__tests__/unit-slack-classify-event.test.ts
+++ b/apps/api/src/__tests__/unit-slack-classify-event.test.ts
@@ -57,6 +57,7 @@ mock.module('../channels/slack-api', () => ({
   getChannelName: async () => 'general',
   joinChannel: async () => true,
   openDmChannel: async () => 'D1',
+  postEphemeral: async () => true,
   postBlocks: async () => 'ts',
   postMessage: async () => 'ts',
   publishHomeView: async () => {},

--- a/apps/api/src/channels/slack-api.ts
+++ b/apps/api/src/channels/slack-api.ts
@@ -158,6 +158,43 @@ export async function postBlocks(
   }
 }
 
+// Post a message visible ONLY to `user`, in-channel (and in-thread when
+// `threadTs` is set). Used for the identity/access nudges so they appear right
+// where the user @-mentioned Kortix instead of in a separate DM. Returns whether
+// it landed. Note: an ephemeral cannot be edited by ts later — to update it after
+// a button click, respond via the interaction's response_url.
+export async function postEphemeral(
+  token: string,
+  channel: string,
+  user: string,
+  text: string,
+  blocks?: unknown[],
+  threadTs?: string,
+): Promise<boolean> {
+  try {
+    const r = await slackApiCall(
+      token,
+      'chat.postEphemeral',
+      {
+        channel,
+        user,
+        text,
+        ...(blocks ? { blocks } : {}),
+        ...(threadTs ? { thread_ts: threadTs } : {}),
+      },
+      { idempotent: false },
+    );
+    if (!r.ok) {
+      console.warn('[slack-api] chat.postEphemeral failed', { error: r.error });
+      return false;
+    }
+    return true;
+  } catch (err) {
+    console.warn('[slack-api] chat.postEphemeral error', err);
+    return false;
+  }
+}
+
 export async function updateMessage(
   token: string,
   channel: string,

--- a/apps/api/src/channels/slack/dispatch.ts
+++ b/apps/api/src/channels/slack/dispatch.ts
@@ -25,7 +25,7 @@ import {
   deliverSlackFollowUpToSession,
   renderFollowUpPrompt,
 } from './session';
-import { postLoginPrompt, resolveSlackActor } from './identity';
+import { postIdentityPrompt, resolveSlackActor } from './identity';
 import { resolveProjectAutomationActor } from '../../projects/session-lifecycle';
 import {
   deleteTurn,
@@ -494,10 +494,11 @@ export async function spawnAgentTurn(
     const slackUserId = event.user ?? '';
     const actor = await resolveSlackActor(teamId, slackUserId, project.accountId);
     if ('reason' in actor) {
-      await postLoginPrompt({
+      await postIdentityPrompt({
         projectId,
         teamId,
         channel: event.channel,
+        threadTs: event.thread_ts ?? event.ts,
         slackUserId,
         reason: actor.reason,
       });

--- a/apps/api/src/channels/slack/identity-routes.ts
+++ b/apps/api/src/channels/slack/identity-routes.ts
@@ -24,7 +24,15 @@ import { isAccountMember, linkSlackIdentity } from './identity';
 export const slackIdentityApp = makeOpenApiApp();
 
 const BindBody = z.object({ token: z.string().min(1) });
-const BindResult = z.object({ ok: z.boolean(), workspaceName: z.string().nullable() });
+const BindResult = z.object({
+  ok: z.boolean(),
+  workspaceName: z.string().nullable(),
+  // Whether the now-linked user is actually a member of the workspace's account.
+  // Connecting is decoupled from access: a non-member links successfully
+  // (hasAccess=false) and then requests access in-thread. The runtime gate still
+  // blocks any agent run until they're an approved member.
+  hasAccess: z.boolean(),
+});
 
 slackIdentityApp.openapi(
   createRoute({
@@ -63,18 +71,19 @@ slackIdentityApp.openapi(
       .where(inArray(projects.projectId, projectIds));
     const accountIds = Array.from(new Set(accountRows.map((r) => r.accountId)));
     const memberships = await Promise.all(accountIds.map((a) => isAccountMember(userId, a)));
-    if (!memberships.some(Boolean)) {
-      return c.json(
-        { error: "You're not a member of this workspace's Kortix account. Ask an admin to add you, then try again." },
-        403,
-      );
-    }
+    const hasAccess = memberships.some(Boolean);
 
+    // Link regardless of membership. Connecting your Kortix account is decoupled
+    // from having access: we establish WHO this Slack user is so a non-member can
+    // request access right in the thread. This is safe — the link grants nothing
+    // on its own; the runtime gate (resolveSlackActor) still requires membership
+    // before any agent runs, so a linked non-member can do nothing until an admin
+    // approves. The workspace-must-be-connected check above still stands.
     await linkSlackIdentity({ teamId: payload.teamId, slackUserId: payload.slackUserId, userId });
 
     const workspaceName = projectIds.length
       ? await loadSlackTeamNameForProject(projectIds[0]).catch(() => null)
       : null;
-    return c.json({ ok: true, workspaceName: workspaceName || null });
+    return c.json({ ok: true, workspaceName: workspaceName || null, hasAccess });
   },
 );

--- a/apps/api/src/channels/slack/identity.ts
+++ b/apps/api/src/channels/slack/identity.ts
@@ -1,9 +1,12 @@
-import { and, eq, isNull } from 'drizzle-orm';
-import { accountMembers, chatUserIdentities } from '@kortix/db';
+import { and, eq, inArray, isNull } from 'drizzle-orm';
+import { accountMembers, chatUserIdentities, projectAccessRequests, projects } from '@kortix/db';
 import { db } from '../../shared/db';
+import { config } from '../../config';
+import { lookupEmailsByUserIds } from '../../projects/lib/access';
 import { loadSlackTokenForProject } from '../install-store';
-import { openDmChannel, postBlocks } from '../slack-api';
+import { openDmChannel, postBlocks, postEphemeral } from '../slack-api';
 import { buildSlackLoginUrl } from './login';
+import { dashboardBase } from './util';
 
 const PLATFORM = 'slack';
 
@@ -109,31 +112,24 @@ export async function revokeSlackIdentity(teamId: string, slackUserId: string): 
   return rows.length > 0;
 }
 
-// Nudge an unlinked / non-member sender to connect their own Kortix account.
-// Sent as a DM — it pushes a notification and persists, so the user actually
-// sees it (an ephemeral in the channel/thread is silent and easy to miss). The
-// `<#channel>` link gives them context for where they triggered it.
-export async function postLoginPrompt(input: {
-  projectId: string;
-  teamId: string;
-  channel?: string;
-  slackUserId: string;
-  reason: 'unlinked' | 'not_member';
-}): Promise<void> {
-  const token = await loadSlackTokenForProject(input.projectId);
-  if (!token) return;
-  const dm = await openDmChannel(token, input.slackUserId);
-  if (!dm) return;
+// ── In-thread identity / access nudges ───────────────────────────────────────
+// When an unlinked or no-access sender @-mentions Kortix we answer right where
+// they asked — an ephemeral (“only visible to you”) message in the same thread —
+// instead of a separate DM. Two states, two affordances:
+//   • unlinked   → "Connect your Kortix account" (opens the /login web flow)
+//   • not_member → "Request access" (files a project access request for an admin)
+// Connecting is decoupled from access, so a brand-new user connects once and then
+// requests access in-thread without bouncing off a hard "ask an admin" wall.
 
-  const url = buildSlackLoginUrl({ teamId: input.teamId, slackUserId: input.slackUserId });
-  const where = input.channel ? ` in <#${input.channel}>` : '';
-  const text =
-    input.reason === 'not_member'
-      ? `You messaged Kortix${where}, but that Kortix account isn't a member of this workspace's project. Ask an admin to add you, then connect again.`
-      : `You messaged Kortix${where}. Kortix runs as *your own* Kortix account — connect it once to continue.`;
-
-  await postBlocks(token, dm, text, [
-    { type: 'section', text: { type: 'mrkdwn', text } },
+export function connectAccountBlocks(url: string): unknown[] {
+  return [
+    {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: 'Kortix runs as *your own* Kortix account — connect it once to continue. _Only you can see this._',
+      },
+    },
     {
       type: 'actions',
       elements: [
@@ -146,5 +142,193 @@ export async function postLoginPrompt(input: {
         },
       ],
     },
-  ]);
+  ];
+}
+
+export function requestAccessBlocks(projectId: string): unknown[] {
+  return [
+    {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: "You're connected, but your Kortix account doesn't have access to this project yet. Request access and an admin will approve it. _Only you can see this._",
+      },
+    },
+    {
+      type: 'actions',
+      elements: [
+        {
+          type: 'button',
+          text: { type: 'plain_text', text: 'Request access', emoji: true },
+          style: 'primary',
+          value: JSON.stringify({ projectId }),
+          action_id: 'slack_request_access',
+        },
+      ],
+    },
+  ];
+}
+
+export async function postIdentityPrompt(input: {
+  projectId: string;
+  teamId: string;
+  channel?: string;
+  threadTs?: string;
+  slackUserId: string;
+  reason: 'unlinked' | 'not_member';
+}): Promise<void> {
+  if (!input.channel) return;
+  const token = await loadSlackTokenForProject(input.projectId);
+  if (!token) return;
+
+  if (input.reason === 'unlinked') {
+    const url = buildSlackLoginUrl({ teamId: input.teamId, slackUserId: input.slackUserId });
+    await postEphemeral(
+      token,
+      input.channel,
+      input.slackUserId,
+      'Connect your Kortix account to continue.',
+      connectAccountBlocks(url),
+      input.threadTs,
+    );
+    return;
+  }
+
+  await postEphemeral(
+    token,
+    input.channel,
+    input.slackUserId,
+    "You're connected, but don't have access to this project yet.",
+    requestAccessBlocks(input.projectId),
+    input.threadTs,
+  );
+}
+
+export type AccessRequestOutcome =
+  | { status: 'created' | 'pending' | 'already-member'; requesterUserId: string; accountId: string }
+  | { status: 'no-identity' | 'no-project' };
+
+// File (or find the existing pending) project access request for the Slack sender,
+// reusing the same projectAccessRequests table the web "Request access" flow uses.
+// Idempotent: a second click while one is pending returns 'pending', not a dupe.
+export async function createSlackAccessRequest(input: {
+  teamId: string;
+  slackUserId: string;
+  projectId: string;
+}): Promise<AccessRequestOutcome> {
+  const identity = await lookupSlackIdentity(input.teamId, input.slackUserId);
+  if (!identity) return { status: 'no-identity' };
+
+  const [project] = await db
+    .select({ accountId: projects.accountId })
+    .from(projects)
+    .where(eq(projects.projectId, input.projectId))
+    .limit(1);
+  if (!project) return { status: 'no-project' };
+
+  const base = { requesterUserId: identity.userId, accountId: project.accountId };
+  if (await isAccountMember(identity.userId, project.accountId)) {
+    return { status: 'already-member', ...base };
+  }
+
+  const [existing] = await db
+    .select({ requestId: projectAccessRequests.requestId })
+    .from(projectAccessRequests)
+    .where(
+      and(
+        eq(projectAccessRequests.projectId, input.projectId),
+        eq(projectAccessRequests.requesterUserId, identity.userId),
+        eq(projectAccessRequests.status, 'pending'),
+      ),
+    )
+    .limit(1);
+  if (existing) return { status: 'pending', ...base };
+
+  const email = (await lookupEmailsByUserIds([identity.userId]).catch(() => null))?.get(identity.userId);
+  await db.insert(projectAccessRequests).values({
+    accountId: project.accountId,
+    projectId: input.projectId,
+    requesterUserId: identity.userId,
+    requesterEmail: email || identity.userId,
+    message: null,
+  });
+  return { status: 'created', ...base };
+}
+
+// DM every account admin (owner/admin) who has a linked Slack identity in this
+// workspace that a new access request is waiting, with a link to review it in
+// Kortix. Best-effort — an admin without a Slack link still sees it on the web
+// Members screen (the same request row powers both).
+export async function notifyAdminsOfAccessRequest(input: {
+  teamId: string;
+  projectId: string;
+  accountId: string;
+  requesterUserId: string;
+  requesterSlackUserId: string;
+}): Promise<void> {
+  const token = await loadSlackTokenForProject(input.projectId);
+  if (!token) return;
+
+  const admins = await db
+    .select({ userId: accountMembers.userId })
+    .from(accountMembers)
+    .where(
+      and(
+        eq(accountMembers.accountId, input.accountId),
+        inArray(accountMembers.accountRole, ['owner', 'admin']),
+      ),
+    );
+  if (admins.length === 0) return;
+
+  const email = (await lookupEmailsByUserIds([input.requesterUserId]).catch(() => null))?.get(
+    input.requesterUserId,
+  );
+  const who = email ? `*${email}*` : `<@${input.requesterSlackUserId}>`;
+  const projectUrl = `${dashboardBase(config.FRONTEND_URL)}/projects/${input.projectId}`;
+  const text = `${who} requested access to a Kortix project in this workspace.`;
+  const blocks = [
+    {
+      type: 'section',
+      text: { type: 'mrkdwn', text: `${text}\nOpen *Members* in Kortix to approve.` },
+    },
+    {
+      type: 'actions',
+      elements: [
+        {
+          type: 'button',
+          text: { type: 'plain_text', text: 'Review in Kortix', emoji: true },
+          style: 'primary',
+          url: projectUrl,
+          action_id: 'slack_open_access_review',
+        },
+      ],
+    },
+  ];
+
+  for (const admin of admins) {
+    if (admin.userId === input.requesterUserId) continue;
+    const slackId = await lookupSlackUserIdForKortixUser(input.teamId, admin.userId);
+    if (!slackId) continue;
+    const dm = await openDmChannel(token, slackId);
+    if (!dm) continue;
+    await postBlocks(token, dm, text, blocks);
+  }
+}
+
+// Reverse of lookupSlackIdentity: the Slack user a Kortix user is linked to in a
+// given workspace, so we can DM admins about access requests.
+async function lookupSlackUserIdForKortixUser(teamId: string, userId: string): Promise<string | null> {
+  const [row] = await db
+    .select({ slackUserId: chatUserIdentities.platformUserId })
+    .from(chatUserIdentities)
+    .where(
+      and(
+        eq(chatUserIdentities.platform, PLATFORM),
+        eq(chatUserIdentities.workspaceId, teamId),
+        eq(chatUserIdentities.userId, userId),
+        isNull(chatUserIdentities.revokedAt),
+      ),
+    )
+    .limit(1);
+  return row?.slackUserId ?? null;
 }

--- a/apps/api/src/channels/slack/interactivity.ts
+++ b/apps/api/src/channels/slack/interactivity.ts
@@ -5,6 +5,7 @@ import { config } from '../../config';
 import { loadSlackTokenForProject } from '../install-store';
 import { updateMessage } from '../slack-api';
 import { dispatchSlackEvent, pendingPickers, spawnAgentTurn } from './dispatch';
+import { createSlackAccessRequest, notifyAdminsOfAccessRequest } from './identity';
 import { escapeMrkdwn, respondViaUrl, sessionWebUrl } from './util';
 import { modelLabel, setChannelAgent, setChannelModel } from './selection';
 import type { SlackEnvelope, SlackEvent, SlackInteractionPayload } from './types';
@@ -278,6 +279,43 @@ export async function handleMessageShortcut(payload: SlackInteractionPayload): P
   });
 }
 
+// "Request access" (the ephemeral nudge for a connected-but-no-access user) →
+// file a project access request and ping the account's admins. Replaces the
+// ephemeral in place via the interaction's response_url so the user gets an
+// immediate, only-visible-to-them confirmation.
+async function handleRequestAccess(payload: SlackInteractionPayload, value: string): Promise<void> {
+  const teamId = payload.team?.id ?? '';
+  const slackUserId = payload.user?.id ?? '';
+  let projectId = '';
+  try {
+    projectId = (JSON.parse(value || '{}') as { projectId?: string }).projectId ?? '';
+  } catch {
+    projectId = '';
+  }
+  if (!teamId || !slackUserId || !projectId) return;
+
+  const result = await createSlackAccessRequest({ teamId, slackUserId, projectId });
+  const message =
+    result.status === 'created'
+      ? "Access requested ✓ — an admin will review it. I'll pick up your message once you're approved."
+      : result.status === 'pending'
+        ? "You've already requested access — it's pending an admin's review."
+        : result.status === 'already-member'
+          ? 'You already have access — send your message again and I’ll get on it.'
+          : 'I couldn’t request access — connect your Kortix account first, then try again.';
+  await respondViaUrl(payload.response_url, { replace_original: true, text: message });
+
+  if (result.status === 'created') {
+    await notifyAdminsOfAccessRequest({
+      teamId,
+      projectId,
+      accountId: result.accountId,
+      requesterUserId: result.requesterUserId,
+      requesterSlackUserId: slackUserId,
+    });
+  }
+}
+
 export async function handleBlockAction(payload: SlackInteractionPayload): Promise<void> {
   const action = payload.actions?.[0];
   if (!action?.action_id) return;
@@ -299,6 +337,17 @@ export async function handleBlockAction(payload: SlackInteractionPayload): Promi
 
   // A plain "Open session ↗" link button carries a `url` and needs no handling.
   if (action.action_id === 'session_open') return;
+
+  // Identity / access nudges. "Connect" and "Review in Kortix" are URL buttons —
+  // they open a link, so swallow their block_action so it doesn't fall through to
+  // the agent-click catch-all below. "Request access" does real work.
+  if (action.action_id === 'slack_login_connect' || action.action_id === 'slack_open_access_review') {
+    return;
+  }
+  if (action.action_id === 'slack_request_access') {
+    await handleRequestAccess(payload, action.value ?? '');
+    return;
+  }
 
   if (action.action_id.startsWith('switch_project_')) {
     await handleSwitchProject(payload, action.value ?? '');


### PR DESCRIPTION
## Summary
Reworks the Slack identity/access UX from a DM wall into an **in-thread, only-visible-to-you** flow, and wires Slack into the **existing** project access-request system. Stage A of a 2-stage effort (Stage B = one-click Approve in Slack + auto-replay).

### Before
@mention while unlinked/non-member → a **DM** with a Connect button. `/bind` then **refused** to link non-members ("You're not a member of this workspace's Kortix account. Ask an admin…") — a dead end.

### After
- **Connect is decoupled from access.** `/bind` links anyone (returns `hasAccess`); the link grants nothing on its own — the runtime gate still requires membership before any agent runs.
- The gate posts an **ephemeral in the thread** (not a DM), with two states:
  - unlinked → **Connect my Kortix account**
  - connected, no access → **Request access**
- Clicking **Request access** files a row in the existing `projectAccessRequests` table (idempotent) and **DMs the account's admins** a "Review in Kortix" link. The same row already powers the web Members screen, so admins can approve there today.

## Changes
- `slack-api`: `postEphemeral`
- `identity-routes` `/bind`: link regardless of membership, return `hasAccess`
- `identity`: `postIdentityPrompt` (in-thread ephemeral, 2 states), `createSlackAccessRequest`, `notifyAdminsOfAccessRequest`
- `dispatch`: post the in-thread ephemeral (passes `threadTs`)
- `interactivity`: handle `slack_request_access`; stop connect/review URL buttons falling into the agent-click catch-all

## Tests
`unit-slack-access-request` (7) — all request branches + the `action_id` contract the router dispatches on. Typecheck clean; existing green slack tests unaffected.

## Follow-ups
- **Stage B:** one-click **Approve in Slack** button + auto-replay the requester's original message on approval.
- **Stage C:** web `/login` page copy for the "connected but no access" state.