### PR TITLE
fix(web): open dot-directories like .opencode in the file viewer

### DIFF
--- a/apps/web/src/components/tabs/file-tab-content.tsx
+++ b/apps/web/src/components/tabs/file-tab-content.tsx
@@ -5,7 +5,7 @@ import { CircleAlert, AlertTriangle } from 'lucide-react';
 import { useTabStore, openTabAndNavigate } from '@/stores/tab-store';
 import { FileContentRenderer } from '@/features/files/components/file-content-renderer';
 import { useDiagnosticsStore, findDiagnosticsForFile } from '@/stores/diagnostics-store';
-import { listFiles, useFilesStore } from '@/features/files';
+import { hasFileExtension, listFiles, useFilesStore } from '@/features/files';
 
 /**
  * Standalone file viewer for the tab system.
@@ -39,9 +39,11 @@ export function FileTabContent({ tabId, filePath }: FileTabContentProps) {
     if (dirCheckRef.current) return;
     dirCheckRef.current = true;
 
-    // Heuristic: if path has a file extension, skip the directory check
-    const basename = filePath.split('/').pop() || '';
-    if (basename.includes('.')) {
+    // Heuristic: if path has a real file extension, skip the directory check.
+    // A leading dot (dot-directories like `.opencode`, `.github`) is NOT an
+    // extension, so those still get probed below instead of being rendered as
+    // a file (which would fail with "Path is a directory").
+    if (hasFileExtension(filePath)) {
       setIsDir(false);
       return;
     }

--- a/apps/web/src/features/files/index.ts
+++ b/apps/web/src/features/files/index.ts
@@ -43,6 +43,9 @@ export {
   type UploadResult,
 } from './api/opencode-files';
 
+// Pure path heuristics
+export { hasFileExtension } from './path-utils';
+
 // API — semantic search (LSS)
 export { searchLss } from './api/lss-search';
 

--- a/apps/web/src/features/files/path-utils.test.ts
+++ b/apps/web/src/features/files/path-utils.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from 'bun:test';
+
+import { hasFileExtension } from './path-utils';
+
+describe('hasFileExtension', () => {
+  test('detects real extensions on regular files', () => {
+    expect(hasFileExtension('/workspace/src/index.ts')).toBe(true);
+    expect(hasFileExtension('README.md')).toBe(true);
+    expect(hasFileExtension('/a/b/archive.tar.gz')).toBe(true);
+    expect(hasFileExtension('.eslintrc.json')).toBe(true);
+  });
+
+  test('treats dot-directories as having no extension (the .opencode bug)', () => {
+    expect(hasFileExtension('/workspace/.opencode')).toBe(false);
+    expect(hasFileExtension('.github')).toBe(false);
+    expect(hasFileExtension('/repo/.kortix')).toBe(false);
+  });
+
+  test('treats extensionless dotfiles as having no extension', () => {
+    expect(hasFileExtension('.env')).toBe(false);
+    expect(hasFileExtension('/home/user/.gitignore')).toBe(false);
+  });
+
+  test('treats plain extensionless names as having no extension', () => {
+    expect(hasFileExtension('/workspace/src')).toBe(false);
+    expect(hasFileExtension('Makefile')).toBe(false);
+    expect(hasFileExtension('')).toBe(false);
+  });
+});

--- a/apps/web/src/features/files/path-utils.ts
+++ b/apps/web/src/features/files/path-utils.ts
@@ -1,0 +1,21 @@
+/**
+ * Pure path heuristics for the files feature. No I/O — safe to unit test.
+ */
+
+/**
+ * Heuristic: does a path's basename have a real file extension?
+ *
+ * A "real" extension is a dot that is NOT the leading dot of a dotfile or
+ * dot-directory. So `file.ts` and `.eslintrc.json` have extensions, but
+ * dot-directories like `.opencode`, `.github`, `.kortix` — and extensionless
+ * dotfiles like `.env` — do not. Those must still be probed (via listFiles)
+ * for being a directory rather than blindly rendered as a file, otherwise a
+ * dot-directory gets opened as a file and the server returns
+ * "Path is a directory".
+ */
+export function hasFileExtension(path: string): boolean {
+  const basename = path.split('/').pop() || '';
+  // lastIndexOf('.') === 0 means the only dot is the leading one (dotfile/dir);
+  // > 0 means there's a dot after the first char → a real extension.
+  return basename.lastIndexOf('.') > 0;
+}


### PR DESCRIPTION
## Problem
Opening a dot-directory (e.g. `/workspace/.opencode`) in the file viewer showed:

> Failed to load file — `/workspace/.opencode` — Path is a directory

## Root cause
`FileTabContent` decides whether to skip the directory probe with:

```ts
const basename = filePath.split('/').pop() || '';
if (basename.includes('.')) { setIsDir(false); return; }
```

`.opencode`, `.github`, `.kortix` all contain a `.`, so the heuristic treated them as files, skipped the directory check, and the renderer fell through to the sandbox's `400 Path is a directory`.

## Fix
A leading dot is not a real extension. Extracted the heuristic into a pure `hasFileExtension()` helper (`apps/web/src/features/files/path-utils.ts`) that uses `basename.lastIndexOf('.') > 0`, so dot-directories now get probed and correctly redirect to the Files browser. `file.ts` / `.eslintrc.json` still detect as files; extensionless dotfiles like `.env` fall through to the probe (which resolves them as files).

## Tests
New co-located `path-utils.test.ts` — 4 tests / 12 assertions, all passing (`bun test`).