### PR TITLE
Fix native Zen free model selection

### DIFF
--- a/apps/kortix-sandbox-agent-server/src/__tests__/resolve-opencode-model.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/resolve-opencode-model.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+
+import { resolveOpencodeModel } from '../main'
+
+const ORIGINAL_MODEL = process.env.KORTIX_OPENCODE_MODEL
+
+afterEach(() => {
+  if (ORIGINAL_MODEL === undefined) delete process.env.KORTIX_OPENCODE_MODEL
+  else process.env.KORTIX_OPENCODE_MODEL = ORIGINAL_MODEL
+})
+
+describe('resolveOpencodeModel', () => {
+  test('normalizes prefixed native OpenCode Zen free models for prompt_async', () => {
+    process.env.KORTIX_OPENCODE_MODEL = 'opencode/deepseek-v4-flash-free'
+
+    expect(resolveOpencodeModel()).toEqual({
+      providerID: 'opencode',
+      modelID: 'deepseek-v4-flash-free',
+    })
+  })
+
+  test('accepts bare native OpenCode Zen free model ids', () => {
+    process.env.KORTIX_OPENCODE_MODEL = 'deepseek-v4-flash-free'
+
+    expect(resolveOpencodeModel()).toEqual({
+      providerID: 'opencode',
+      modelID: 'deepseek-v4-flash-free',
+    })
+  })
+
+  test('keeps normal provider/model overrides as OpenCode model objects', () => {
+    process.env.KORTIX_OPENCODE_MODEL = 'anthropic/claude-sonnet-4-6'
+
+    expect(resolveOpencodeModel()).toEqual({
+      providerID: 'anthropic',
+      modelID: 'claude-sonnet-4-6',
+    })
+  })
+})

--- a/apps/kortix-sandbox-agent-server/src/main.ts
+++ b/apps/kortix-sandbox-agent-server/src/main.ts
@@ -38,6 +38,12 @@ import { startStaticWebServer } from './static-web'
 // prompts into the same opencode conversation instead of opening a fresh
 // session with no context.
 export const OPENCODE_SESSION_PIN_PATH = '/var/run/kortix/opencode-session-id'
+const OPENCODE_ZEN_FREE_MODELS = new Set([
+  'deepseek-v4-flash-free',
+  'mimo-v2.5-free',
+  'nemotron-3-ultra-free',
+  'north-mini-code-free',
+])
 
 async function main() {
   const bootTime = Date.now()
@@ -1235,15 +1241,18 @@ async function isRootOpencodeSession(
   }
 }
 
-/** Per-session model override from KORTIX_OPENCODE_MODEL (provider/model form,
- *  e.g. `anthropic/claude-sonnet-4-6`). Returned in opencode's
- *  `{ providerID, modelID }` shape, or undefined when unset/malformed so
- *  opencode falls back to its configured default. */
+/** Per-session model override from KORTIX_OPENCODE_MODEL. Most models use
+ *  provider/model form and are returned in OpenCode's `{ providerID, modelID }`
+ *  shape. Bare native Zen ids are normalized onto the OpenCode provider so the
+ *  boot prompt uses the schema accepted by `prompt_async`. */
 export function resolveOpencodeModel(): { providerID: string; modelID: string } | undefined {
   const raw = (process.env.KORTIX_OPENCODE_MODEL ?? '').trim()
+  if (OPENCODE_ZEN_FREE_MODELS.has(raw)) return { providerID: 'opencode', modelID: raw }
   const slash = raw.indexOf('/')
   if (slash <= 0 || slash === raw.length - 1) return undefined
-  return { providerID: raw.slice(0, slash), modelID: raw.slice(slash + 1) }
+  const providerID = raw.slice(0, slash)
+  const modelID = raw.slice(slash + 1)
+  return { providerID, modelID }
 }
 
 /** Read the pinned opencode session id (set at boot when KORTIX_INITIAL_PROMPT

--- a/apps/web/src/features/session/model-selector.tsx
+++ b/apps/web/src/features/session/model-selector.tsx
@@ -323,6 +323,10 @@ export function ModelSelector({ models, selectedModel, onSelect }: ModelSelector
     [projectId, llmGatewayEnabled, openProviderModal, openCustomize],
   );
 
+  if (!autoModel && visibleModels.length === 0) {
+    return null;
+  }
+
   return (
     <>
       {projectId && (

--- a/apps/web/src/features/session/session-chat.tsx
+++ b/apps/web/src/features/session/session-chat.tsx
@@ -84,8 +84,10 @@ import {
 } from '@/features/session/uploaded-file-refs';
 import { useOpenCodeConfig } from '@/hooks/opencode/use-opencode-config';
 import {
+  formatPromptModel,
   formatModelString,
   parseModelKey,
+  type ModelKey,
   useOpenCodeLocal,
 } from '@/hooks/opencode/use-opencode-local';
 import type { PromptPart, ProviderListResponse } from '@/hooks/opencode/use-opencode-sessions';
@@ -3780,6 +3782,12 @@ export function SessionChat({
 
   // ---- Unified model/agent/variant state (1:1 port of SolidJS local.tsx) ----
   const local = useOpenCodeLocal({ agents, providers, config, sessionId });
+  const localAgentSet = local.agent.set;
+  const localModelCurrentKey = local.model.currentKey;
+  const localModelList = local.model.list;
+  const localModelSet = local.model.set;
+  const localModelVisible = local.model.visible;
+  const localVariantSet = local.model.variant.set;
 
   // Default the agent picker to whichever agent owns the latest assistant
   // turn in this session. Catches PM onboarding sessions (first turn was PM),
@@ -3899,15 +3907,13 @@ export function SessionChat({
         // Exhausted retries — no pending prompt
         return;
       }
-      pendingPromptHandled.current = true;
-      setPollingActive(true);
-      setPendingSendInFlight(true);
-      useSyncStore.getState().setStatus(sessionId, { type: 'busy' });
-      sessionStorage.removeItem(`opencode_pending_prompt:${sessionId}`);
-      sessionStorage.removeItem(`opencode_pending_send_failed:${sessionId}`);
-
       // Restore agent/model/variant selections from the dashboard
       const options: Record<string, unknown> = {};
+      let selectedModelForSend: ModelKey | undefined;
+      const isSelectableModel = (model: ModelKey): boolean =>
+        localModelList.some(
+          (m) => m.providerID === model.providerID && m.modelID === model.modelID,
+        ) && localModelVisible(model);
       try {
         const raw = sessionStorage.getItem(`opencode_pending_options:${sessionId}`);
         if (raw) {
@@ -3915,23 +3921,45 @@ export function SessionChat({
           sessionStorage.removeItem(`opencode_pending_options:${sessionId}`);
           if (pendingOptions?.agent) {
             options.agent = pendingOptions.agent;
-            local.agent.set(pendingOptions.agent as string);
+            localAgentSet(pendingOptions.agent as string);
           }
           if (pendingOptions?.model) {
             const parsedPendingModel = parseModelKey(pendingOptions.model);
-            if (parsedPendingModel) {
+            if (parsedPendingModel && isSelectableModel(parsedPendingModel)) {
               options.model = parsedPendingModel;
-              local.model.set(parsedPendingModel);
+              selectedModelForSend = parsedPendingModel;
+              localModelSet(parsedPendingModel);
             }
           }
           if (pendingOptions?.variant) {
             options.variant = pendingOptions.variant;
-            local.model.variant.set(pendingOptions.variant as string);
+            localVariantSet(pendingOptions.variant as string);
           }
         }
       } catch {
         // ignore
       }
+
+      if (!selectedModelForSend && localModelCurrentKey) {
+        options.model = localModelCurrentKey;
+        selectedModelForSend = localModelCurrentKey;
+      }
+
+      if (!selectedModelForSend) {
+        if (attempt < 120) {
+          retryTimer = setTimeout(() => attemptSend(attempt + 1), 250);
+          return;
+        }
+        setCommandError('No model is available for this session yet. Change model or try again.');
+        return;
+      }
+
+      pendingPromptHandled.current = true;
+      setPollingActive(true);
+      setPendingSendInFlight(true);
+      useSyncStore.getState().setStatus(sessionId, { type: 'busy' });
+      sessionStorage.removeItem(`opencode_pending_prompt:${sessionId}`);
+      sessionStorage.removeItem(`opencode_pending_send_failed:${sessionId}`);
 
       // Send the message with retry. The useSendOpenCodeMessage hook already
       // retries 3 times internally for transient errors. We add one additional
@@ -4026,7 +4054,7 @@ export function SessionChat({
           parts,
           ...(session?.directory ? { directory: session.directory } : {}),
           ...(sendOpts?.agent && { agent: sendOpts.agent }),
-          ...(sendOpts?.model && { model: sendOpts.model }),
+          ...(sendOpts?.model && { model: formatPromptModel(sendOpts.model as ModelKey) }),
           ...(sendOpts?.variant && { variant: sendOpts.variant }),
         } as any;
 
@@ -4068,8 +4096,18 @@ export function SessionChat({
       cancelled = true;
       if (retryTimer) clearTimeout(retryTimer);
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sessionId, addOptimisticUserMessage, removeOptimisticUserMessage]);
+  }, [
+    sessionId,
+    addOptimisticUserMessage,
+    removeOptimisticUserMessage,
+    localAgentSet,
+    localModelCurrentKey,
+    localModelList,
+    localModelSet,
+    localModelVisible,
+    localVariantSet,
+    session?.directory,
+  ]);
 
   // Clear optimistic prompt once real messages arrive
   useEffect(() => {
@@ -5032,7 +5070,7 @@ export function SessionChat({
         // when the user picked a project agent from the picker.
         ...(session?.directory ? { directory: session.directory } : {}),
         ...(sendOpts?.agent ? { agent: sendOpts.agent } : {}),
-        ...(sendOpts?.model ? { model: sendOpts.model } : {}),
+        ...(sendOpts?.model ? { model: formatPromptModel(sendOpts.model as ModelKey) } : {}),
         ...(sendOpts?.variant ? { variant: sendOpts.variant } : {}),
       } as any;
 

--- a/apps/web/src/hooks/opencode/use-model-store.test.ts
+++ b/apps/web/src/hooks/opencode/use-model-store.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 
 import type { FlatModel } from '@/features/session/session-chat-input';
-import { computeLatestSet } from './use-model-store';
+import { computeLatestSet, isDefaultVisible } from './use-model-store';
 
 function monthsAgo(months: number): string {
   const date = new Date();
@@ -50,5 +50,12 @@ describe('model-store visibility policy', () => {
     expect(latest.has('openai:gpt-current')).toBe(true);
     expect(latest.has('anthropic:claude-old')).toBe(false);
     expect(latest.has('anthropic:claude-legacy')).toBe(false);
+  });
+
+  test('native OpenCode Zen free models are visible without release metadata', () => {
+    expect(
+      isDefaultVisible({ providerID: 'opencode', modelID: 'deepseek-v4-flash-free' }),
+    ).toBe(true);
+    expect(isDefaultVisible({ providerID: 'opencode', modelID: 'paid-model' })).toBe(false);
   });
 });

--- a/apps/web/src/hooks/opencode/use-model-store.ts
+++ b/apps/web/src/hooks/opencode/use-model-store.ts
@@ -18,6 +18,7 @@ import { safeSetItem } from '@/lib/storage/managed-storage';
 import {
   AUTO_MODEL_ID,
   DEFAULT_MANAGED_MODEL_IDS,
+  DEFAULT_OPENCODE_ZEN_FREE_MODEL_IDS,
   MANAGED_FLAGSHIP_MODEL_ID,
 } from '@kortix/shared/llm-catalog';
 import { useCallback, useMemo, useSyncExternalStore } from 'react';
@@ -156,6 +157,9 @@ export function setGlobalDefaultModel(model: ModelKey | undefined): void {
  * "Manage models".
  */
 const DEFAULT_VISIBLE_MODEL_IDS = new Set<string>([MANAGED_FLAGSHIP_MODEL_ID]);
+const DEFAULT_VISIBLE_NATIVE_OPENCODE_MODEL_IDS = new Set<string>(
+  DEFAULT_OPENCODE_ZEN_FREE_MODEL_IDS,
+);
 
 /**
  * Provider id of the managed Kortix LLM gateway (see the sandbox's
@@ -183,7 +187,13 @@ function subProviderOf(modelID: string): string {
   return slash === -1 ? modelID : modelID.slice(0, slash);
 }
 
-function isDefaultVisible(model: ModelKey): boolean {
+export function isDefaultVisible(model: ModelKey): boolean {
+  if (
+    model.providerID === 'opencode' &&
+    DEFAULT_VISIBLE_NATIVE_OPENCODE_MODEL_IDS.has(model.modelID)
+  ) {
+    return true;
+  }
   return DEFAULT_VISIBLE_MODEL_IDS.has(model.modelID);
 }
 

--- a/apps/web/src/hooks/opencode/use-opencode-local.test.ts
+++ b/apps/web/src/hooks/opencode/use-opencode-local.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, test } from 'bun:test';
 
-import { modelProviderMode, scopedModelSelectionKey } from './use-opencode-local';
+import {
+  formatModelString,
+  formatPromptModel,
+  modelProviderMode,
+  parseModelKey,
+  scopedModelSelectionKey,
+} from './use-opencode-local';
 
 describe('OpenCode local model selection scoping', () => {
   test('scopes persisted model selections by provider mode', () => {
@@ -26,5 +32,27 @@ describe('OpenCode local model selection scoping', () => {
         default: { opencode: 'deepseek-v4-flash-free' },
       } as any),
     ).toBe('native');
+  });
+
+  test('parses bare OpenCode Zen free model ids as native opencode models', () => {
+    expect(parseModelKey('deepseek-v4-flash-free')).toEqual({
+      providerID: 'opencode',
+      modelID: 'deepseek-v4-flash-free',
+    });
+  });
+
+  test('formats native OpenCode Zen models correctly for command and prompt calls', () => {
+    const model = { providerID: 'opencode', modelID: 'deepseek-v4-flash-free' };
+    expect(formatModelString(model)).toBe('deepseek-v4-flash-free');
+    expect(formatPromptModel(model)).toEqual(model);
+  });
+
+  test('keeps managed and BYOK model wire formats unchanged', () => {
+    const managed = { providerID: 'kortix', modelID: 'claude-opus-4.8' };
+    const byok = { providerID: 'kortix', modelID: 'anthropic/claude-sonnet-4-6' };
+    expect(formatModelString(managed)).toBe('kortix/claude-opus-4.8');
+    expect(formatPromptModel(managed)).toEqual(managed);
+    expect(formatModelString(byok)).toBe('kortix/anthropic/claude-sonnet-4-6');
+    expect(formatPromptModel(byok)).toEqual(byok);
   });
 });

--- a/apps/web/src/hooks/opencode/use-opencode-local.ts
+++ b/apps/web/src/hooks/opencode/use-opencode-local.ts
@@ -12,9 +12,11 @@
  */
 
 import { flattenModels, type FlatModel } from '@/features/session/session-chat-input';
+import { accountStateSelectors, useAccountState } from '@/hooks/billing';
 import { featureFlags } from '@/lib/feature-flags';
 import { listProjectSecrets } from '@/lib/projects-client';
 import type { Agent, Config, ProviderListResponse } from '@opencode-ai/sdk/v2/client';
+import { DEFAULT_OPENCODE_ZEN_FREE_MODEL_IDS } from '@kortix/shared/llm-catalog';
 import { useQuery } from '@tanstack/react-query';
 import { useParams } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
@@ -115,6 +117,9 @@ export function parseModelKey(model: unknown): ModelKey | undefined {
     }
   }
   if (typeof model === 'string') {
+    if ((DEFAULT_OPENCODE_ZEN_FREE_MODEL_IDS as readonly string[]).includes(model)) {
+      return { providerID: 'opencode', modelID: model };
+    }
     const idx = model.indexOf('/');
     if (idx > 0 && idx < model.length - 1) {
       return { providerID: model.slice(0, idx), modelID: model.slice(idx + 1) };
@@ -124,10 +129,17 @@ export function parseModelKey(model: unknown): ModelKey | undefined {
 }
 
 /**
- * Format a ModelKey as a string "providerID/modelID" for command endpoints.
+ * Format a ModelKey as OpenCode's string model override. Native OpenCode Zen
+ * models are bare ids; prefixing them with `opencode/` is forwarded upstream and
+ * Zen rejects it as an unknown model.
  */
 export function formatModelString(model: ModelKey): string {
+  if (model.providerID === 'opencode') return model.modelID;
   return `${model.providerID}/${model.modelID}`;
+}
+
+export function formatPromptModel(model: ModelKey): ModelKey {
+  return model;
 }
 
 export type ModelProviderMode = 'native' | 'gateway';
@@ -161,6 +173,12 @@ export function useOpenCodeLocal({
   const params = useParams();
   const projectId = typeof params?.id === 'string' ? params.id : null;
   const providerMode = useMemo(() => modelProviderMode(providers), [providers]);
+  const { data: accountState } = useAccountState();
+  const freeTier = useMemo(() => {
+    const tierKey = accountStateSelectors.tierKey(accountState).toLowerCase();
+    const hasActiveSubscription = !!accountState?.subscription?.subscription_id;
+    return (tierKey === 'free' || tierKey === 'none') && !hasActiveSubscription;
+  }, [accountState]);
   const secretsQuery = useQuery({
     queryKey: ['project-secrets', projectId],
     queryFn: () => listProjectSecrets(projectId as string),
@@ -177,7 +195,10 @@ export function useOpenCodeLocal({
   }, [providerMode, secretsQuery.data]);
 
   // ---- Model store (persisted: visibility, recent, variant) ----
-  const modelStore = useModelStore(flatModels, { connectedProviderIds });
+  const modelStore = useModelStore(flatModels, {
+    connectedProviderIds,
+    freeTier: providerMode === 'gateway' && freeTier,
+  });
 
   // ---- Model validation: a model is valid only if it's in the flattened list,
   // which is already filtered to connected + gateway-only providers. This keeps
@@ -301,7 +322,17 @@ export function useOpenCodeLocal({
           const key = { providerID: p.id, modelID: configured };
           if (isModelValid(key) && isModelDefaultVisible(key)) return key;
         }
-        for (const modelID of Object.keys(p.models)) {
+        const modelIDs =
+          p.id === 'opencode'
+            ? [
+                ...DEFAULT_OPENCODE_ZEN_FREE_MODEL_IDS.filter((modelID) => modelID in p.models),
+                ...Object.keys(p.models).filter(
+                  (modelID) =>
+                    !(DEFAULT_OPENCODE_ZEN_FREE_MODEL_IDS as readonly string[]).includes(modelID),
+                ),
+              ]
+            : Object.keys(p.models);
+        for (const modelID of modelIDs) {
           const key = { providerID: p.id, modelID };
           if (isModelValid(key) && isModelDefaultVisible(key)) return key;
         }


### PR DESCRIPTION
## Summary
- Route OpenCode Zen free models through the native `opencode` provider instead of the Kortix gateway model namespace.
- Ignore stale paid/gateway model selections for free-tier sessions and wait for a valid session-native model before first prompt send.
- Make native Zen free models visible/default-selectable and hide the selector when no model exists.
- Normalize boot-time `KORTIX_OPENCODE_MODEL` free IDs into OpenCode prompt model objects.

## Verification
- Live API/OpenCode E2E: created real local Supabase user/project/session, started Daytona sandbox via `POST /projects/:projectId/sessions/:sessionId/start`, asserted `/provider` exposed native `opencode/deepseek-v4-flash-free`, sent `prompt_async` with `{ providerID: "opencode", modelID: "deepseek-v4-flash-free" }`, got 204 and `PONG`, and confirmed gateway logs did not route `deepseek-v4-flash-free`.
- Browser E2E: installed real auth cookie, seeded stale `kortix/claude-opus-4.8` localStorage, opened session page, asserted selector showed `DeepSeek V4 Flash Free`, submitted composer, asserted outgoing `prompt_async` model object and 204 response.
- `cd apps/web && bun test src/hooks/opencode/use-model-store.test.ts src/hooks/opencode/provider-selection.test.ts src/hooks/opencode/use-opencode-local.test.ts src/features/session/model-tags.test.ts`
- `pnpm --filter Kortix-Computer-Frontend exec eslint src/hooks/opencode/use-model-store.ts src/hooks/opencode/use-model-store.test.ts src/hooks/opencode/use-opencode-local.ts src/hooks/opencode/use-opencode-local.test.ts src/features/session/session-chat.tsx src/features/session/model-selector.tsx src/features/session/model-tags.test.ts`
- `pnpm --filter Kortix-Computer-Frontend exec tsc --noEmit --pretty false 2>&1 | rg "use-opencode-local|use-model-store|session-chat\.tsx|model-selector\.tsx"` produced no touched-file diagnostics.
- `cd apps/kortix-sandbox-agent-server && bun test src/__tests__/resolve-opencode-model.test.ts src/__tests__/executor-mcp-config.test.ts && bun tsc --noEmit --pretty false`
- `git diff --check`
