### PR TITLE
fix(slack): DM + in-thread notice for access nudges; identity gate off on dev

### DIFF
--- a/apps/api/src/__tests__/unit-slack-access-request.test.ts
+++ b/apps/api/src/__tests__/unit-slack-access-request.test.ts
@@ -26,13 +26,38 @@ mock.module('../projects/lib/access', () => ({
   lookupEmailsByUserIds: async () => new Map<string, string | null>(),
 }));
 
-const { connectAccountBlocks, requestAccessBlocks, createSlackAccessRequest } = await import(
-  '../channels/slack/identity'
-);
+// Capture what postIdentityPrompt sends. The fix sends BOTH an in-thread
+// ephemeral AND a DM so the nudge is never missed.
+let ephemeralCalls = 0;
+let postBlocksCalls = 0;
+let openDmCalls = 0;
+mock.module('../channels/slack-api', () => ({
+  postEphemeral: async () => {
+    ephemeralCalls++;
+    return true;
+  },
+  openDmChannel: async () => {
+    openDmCalls++;
+    return 'D1';
+  },
+  postBlocks: async () => {
+    postBlocksCalls++;
+    return 'ts';
+  },
+}));
+mock.module('../channels/install-store', () => ({
+  loadSlackTokenForProject: async () => 'xoxb-test',
+}));
+
+const { connectAccountBlocks, requestAccessBlocks, createSlackAccessRequest, postIdentityPrompt } =
+  await import('../channels/slack/identity');
 
 afterAll(() => mock.restore());
 beforeEach(() => {
   dbResults = [];
+  ephemeralCalls = 0;
+  postBlocksCalls = 0;
+  openDmCalls = 0;
 });
 
 // Pull the first button out of an actions block.
@@ -51,6 +76,33 @@ describe('access nudge blocks — the action_id contract the router relies on', 
     expect(btn.action_id).toBe('slack_request_access');
     expect(JSON.parse(btn.value)).toEqual({ projectId: 'proj-1' });
     expect(btn.url).toBeUndefined(); // it's an action button, not a link
+  });
+});
+
+describe('postIdentityPrompt — never invisible: in-thread ephemeral AND a DM', () => {
+  test('not_member prompt posts BOTH an ephemeral and a DM', async () => {
+    await postIdentityPrompt({
+      projectId: 'proj-1',
+      teamId: 'T1',
+      channel: 'C1',
+      threadTs: '90.0',
+      slackUserId: 'U1',
+      reason: 'not_member',
+    });
+    expect(ephemeralCalls).toBe(1); // in-thread notice
+    expect(openDmCalls).toBe(1);
+    expect(postBlocksCalls).toBe(1); // the DM (the part you can't miss)
+  });
+
+  test('still DMs even with no channel to post the ephemeral into', async () => {
+    await postIdentityPrompt({
+      projectId: 'proj-1',
+      teamId: 'T1',
+      slackUserId: 'U1',
+      reason: 'not_member',
+    });
+    expect(ephemeralCalls).toBe(0);
+    expect(postBlocksCalls).toBe(1);
   });
 });
 

--- a/apps/api/src/channels/slack/identity.ts
+++ b/apps/api/src/channels/slack/identity.ts
@@ -177,31 +177,30 @@ export async function postIdentityPrompt(input: {
   slackUserId: string;
   reason: 'unlinked' | 'not_member';
 }): Promise<void> {
-  if (!input.channel) return;
   const token = await loadSlackTokenForProject(input.projectId);
   if (!token) return;
 
-  if (input.reason === 'unlinked') {
-    const url = buildSlackLoginUrl({ teamId: input.teamId, slackUserId: input.slackUserId });
-    await postEphemeral(
-      token,
-      input.channel,
-      input.slackUserId,
-      'Connect your Kortix account to continue.',
-      connectAccountBlocks(url),
-      input.threadTs,
-    );
-    return;
-  }
+  const { blocks, fallback } =
+    input.reason === 'unlinked'
+      ? {
+          blocks: connectAccountBlocks(
+            buildSlackLoginUrl({ teamId: input.teamId, slackUserId: input.slackUserId }),
+          ),
+          fallback: 'Connect your Kortix account to continue.',
+        }
+      : {
+          blocks: requestAccessBlocks(input.projectId),
+          fallback: "You're connected, but don't have access to this project yet.",
+        };
 
-  await postEphemeral(
-    token,
-    input.channel,
-    input.slackUserId,
-    "You're connected, but don't have access to this project yet.",
-    requestAccessBlocks(input.projectId),
-    input.threadTs,
-  );
+  // Send BOTH: an in-thread ephemeral for context right where they asked, AND a
+  // DM. The DM pushes a real notification and persists — an ephemeral alone is
+  // silent and vanishes on reload, so on its own it reads as "no response."
+  if (input.channel) {
+    await postEphemeral(token, input.channel, input.slackUserId, fallback, blocks, input.threadTs);
+  }
+  const dm = await openDmChannel(token, input.slackUserId);
+  if (dm) await postBlocks(token, dm, fallback, blocks);
 }
 
 export type AccessRequestOutcome =

--- a/infra/k8s/envs/dev/values.yaml
+++ b/infra/k8s/envs/dev/values.yaml
@@ -17,6 +17,14 @@ env:
 # wins over envFrom). Flip back to "true" only once Daytona stabilizes the
 # experimental region.
 extraEnv:
+  # Identity gate OFF on dev. With it on, an @mention from anyone whose Kortix
+  # account isn't a member of this workspace's project is blocked (nudged to
+  # connect / request access) instead of running — which makes dogfooding in dev
+  # painful (you get no agent reply until you're added). Off → @mentions run as
+  # the project owner, like prod-lite. Rendered as explicit k8s env so it
+  # OVERRIDES the synced kortix-dev-env secret bundle. Flip to "true" to exercise
+  # the per-user identity / request-access flow. (Prod/staging keep it on.)
+  SLACK_REQUIRE_USER_IDENTITY: "false"
   # Point sandboxes at the standalone LLM gateway. Must be the PUBLIC host —
   # sandboxes are remote Daytona VMs that can't resolve cluster DNS. Without it
   # the API falls back to its in-API /v1/llm passthrough (OpenRouter-only, wrong


### PR DESCRIPTION
## Why
After the in-thread access flow shipped, an @mention in dev read as **"no response at all."** Two causes:

1. **dev runs with the identity gate ON** and the tester's Kortix account isn't a member of the workspace's project → the @mention is gated, not run.
2. The gate's nudge was **in-thread ephemeral only** — silent, no notification, vanishes on reload → invisible, so it looked dead.

## Changes
- **`postIdentityPrompt` now sends BOTH** an in-thread ephemeral **and** a DM. The DM pushes a real notification and persists, so the connect / request-access nudge can't be missed. (Reverses the "in-thread only" call — it had exactly this invisibility problem.)
- **`SLACK_REQUIRE_USER_IDENTITY` OFF on dev** via `infra/k8s/envs/dev/values.yaml` `extraEnv` (k8s env overrides the synced `kortix-dev-env` secret bundle; Argo CD deploys it — no manual AWS edit). With it off, dev @mentions run as the project owner (prod-lite) so we can dogfood without membership gating. **Prod/staging keep the gate on.**

## Tests
`unit-slack-access-request` adds `postIdentityPrompt` coverage: sends both an ephemeral and a DM; still DMs when there's no channel for the ephemeral. Typecheck clean.

## Note
Landed via an isolated worktree off `main` (the primary checkout was mid-work on another branch).