### PR TITLE
feat(llm): show GLM 5.2 explicitly, hide the Auto model behind a flag

### DIFF
--- a/apps/api/src/__tests__/unit-resolve-candidates-free-tier.test.ts
+++ b/apps/api/src/__tests__/unit-resolve-candidates-free-tier.test.ts
@@ -138,7 +138,7 @@ describe('resolveCandidates free-tier premium gate', () => {
     const candidates = await resolveCandidates(principal('team-auto'), 'auto');
     expect(candidates).toHaveLength(1);
     expect(candidates[0]?.provider).toBe('openrouter');
-    expect(candidates[0]?.resolvedModel).toBe('fusion');
+    expect(candidates[0]?.resolvedModel).toBe('glm-5.2');
     expect(accountTierCalls).toBe(1);
   });
 

--- a/apps/api/src/llm-gateway/models/catalog-models.test.ts
+++ b/apps/api/src/llm-gateway/models/catalog-models.test.ts
@@ -20,6 +20,7 @@ describe('gatewayModelCatalog — served catalog', () => {
   test('AUTO + managed lineup present; anonymous callers get managed-only', () => {
     expect(full.auto).toBeDefined();
     expect(full['claude-opus-4.8']).toBeDefined();
+    expect(full['glm-5.2']).toBeDefined();
 
     const managedOnly = gatewayModelCatalog(undefined);
     expect(managedOnly.auto).toBeDefined();
@@ -57,7 +58,7 @@ describe('gatewayModelCatalog — free-tier visibility', () => {
       expect(freeFull[id], id).toBeUndefined();
     }
     expect(freeFull.auto).toBeUndefined();
-    for (const id of ['claude-opus-4.8', 'claude-sonnet-4.6', 'fusion', 'qwen3.7-max']) {
+    for (const id of ['claude-opus-4.8', 'claude-sonnet-4.6', 'glm-5.2', 'qwen3.7-max']) {
       expect(freeFull[id], id).toBeUndefined();
     }
   });
@@ -70,7 +71,7 @@ describe('gatewayModelCatalog — free-tier visibility', () => {
     const managedFree = gatewayModelCatalog(undefined, { freeManagedOnly: true });
     expect(Object.keys(managedFree)).toEqual([]);
     expect(managedFree.auto).toBeUndefined();
-    expect(managedFree['fusion']).toBeUndefined();
+    expect(managedFree['glm-5.2']).toBeUndefined();
     expect(managedFree['anthropic/claude-opus-4-8']).toBeUndefined();
   });
 

--- a/apps/kortix-sandbox-agent-server/src/opencode.ts
+++ b/apps/kortix-sandbox-agent-server/src/opencode.ts
@@ -313,6 +313,16 @@ const MINIMAL_FALLBACK_MODELS: Record<string, KortixGatewayModel> = {
     temperature: true,
     limit: { context: 1_000_000, output: 64_000 },
   },
+  // Managed default (AUTO's text target + the explicit default a fresh session
+  // opts into). Bare id = Kortix-managed; text-only, so no attachment.
+  'glm-5.2': {
+    name: 'GLM 5.2',
+    reasoning: true,
+    tool_call: true,
+    attachment: false,
+    temperature: true,
+    limit: { context: 1_000_000, output: 131_072 },
+  },
   'openai/gpt-5.5': {
     name: 'GPT-5.5',
     reasoning: true,

--- a/apps/web/src/features/session/model-selector.tsx
+++ b/apps/web/src/features/session/model-selector.tsx
@@ -34,6 +34,7 @@ import {
   AUTO_MODEL_ID,
   DEFAULT_MANAGED_MODEL_IDS,
 } from '@kortix/shared/llm-catalog';
+import { featureFlags } from '@/lib/feature-flags';
 import { accountStateSelectors, useAccountState } from '@/hooks/billing';
 import { useQuery } from '@tanstack/react-query';
 import { AutoModelToggle } from './auto-model-toggle';
@@ -74,7 +75,10 @@ export function ConnectProviderDialog({
 import { Tag } from '@/components/ui/tag';
 
 // `auto` is a synthetic managed entry (not a real upstream model): grouped under
-// Kortix and always shown, but rendered as a special "smart routing" affordance.
+// Kortix and — when exposed (see featureFlags.enableAutoModel) — rendered as a
+// special "smart routing" affordance rather than a normal list item. It stays in
+// this set so it groups under Kortix and is recognised as managed even while the
+// toggle is hidden.
 const MANAGED_MODEL_IDS = new Set<string>([...DEFAULT_MANAGED_MODEL_IDS, AUTO_MODEL_ID]);
 
 // Free-tier (no active paid sub) cannot use the Kortix managed paid lineup or
@@ -246,7 +250,7 @@ export function ModelSelector({ models, selectedModel, onSelect }: ModelSelector
   // the manual model list is hidden unless the user expands it.
   const autoModel = useMemo(
     () =>
-      llmGatewayEnabled && !freeTier
+      featureFlags.enableAutoModel && llmGatewayEnabled && !freeTier
         ? baseModels.find((m) => m.providerID === 'kortix' && m.modelID === AUTO_MODEL_ID)
         : undefined,
     [baseModels, llmGatewayEnabled, freeTier],
@@ -277,7 +281,9 @@ export function ModelSelector({ models, selectedModel, onSelect }: ModelSelector
     }
   }, [freeTier, llmGatewayEnabled, freeDefaultModel, selectedModel, onSelect]);
   const isAutoSelected =
-    selectedModel?.providerID === 'kortix' && selectedModel?.modelID === AUTO_MODEL_ID;
+    featureFlags.enableAutoModel &&
+    selectedModel?.providerID === 'kortix' &&
+    selectedModel?.modelID === AUTO_MODEL_ID;
   // "On" is the collapsed active view; expanding the manual list to pick a
   // specific model reads as off and reveals the providers. So the switch is on
   // exactly when the manual list is hidden.

--- a/apps/web/src/hooks/opencode/use-opencode-local.ts
+++ b/apps/web/src/hooks/opencode/use-opencode-local.ts
@@ -13,6 +13,7 @@
 
 import { flattenModels, type FlatModel } from '@/features/session/session-chat-input';
 import { featureFlags } from '@/lib/feature-flags';
+import { AUTO_DEFAULT_MODEL_ID, AUTO_MODEL_ID } from '@kortix/shared/llm-catalog';
 import { listProjectSecrets } from '@/lib/projects-client';
 import type { Agent, Config, ProviderListResponse } from '@opencode-ai/sdk/v2/client';
 import { useQuery } from '@tanstack/react-query';
@@ -321,7 +322,7 @@ export function useOpenCodeLocal({
     // fallback slots resolve fine without one, and the agent roster can be empty
     // (e.g. a project with no configured agents, or `enableProjects` off). The
     // agent-keyed slots are simply skipped when there's no current agent.
-    return getFirstValidModel(
+    const resolved = getFirstValidModel(
       // 1. Per-session model (user's explicit choice in this session — survives reload)
       () => (scopedSessionModelKey ? modelStore.getSessionModel(scopedSessionModelKey) : undefined),
       // Back-compat: read the old unscoped slot only if it is valid in the
@@ -337,6 +338,22 @@ export function useOpenCodeLocal({
       // 5. Global fallback (config.model > recent > first connected)
       () => fallbackModel,
     );
+    // AUTO is hidden from the picker (see featureFlags.enableAutoModel): never
+    // surface it as the selected model. The sandbox/agent/config still defaults to
+    // `kortix/auto`, so the chain above legitimately resolves to it — substitute
+    // the explicit default model (GLM 5.2) so the picker reflects a concrete,
+    // opt-in model and the request carries it directly. Skipped if that model
+    // isn't available (e.g. non-gateway instance, or a free-tier catalog that
+    // doesn't serve it), which falls back to the resolved value.
+    if (
+      !featureFlags.enableAutoModel &&
+      resolved?.providerID === 'kortix' &&
+      resolved.modelID === AUTO_MODEL_ID
+    ) {
+      const explicit = { providerID: 'kortix', modelID: AUTO_DEFAULT_MODEL_ID };
+      if (isModelValid(explicit)) return explicit;
+    }
+    return resolved;
   }, [
     currentAgent,
     sessionId,
@@ -344,6 +361,7 @@ export function useOpenCodeLocal({
     providerMode,
     modelStore,
     getFirstValidModel,
+    isModelValid,
     fallbackModel,
   ]);
 

--- a/apps/web/src/lib/feature-flags.ts
+++ b/apps/web/src/lib/feature-flags.ts
@@ -1,3 +1,5 @@
+import { AUTO_MODEL_ENABLED } from '@kortix/shared/llm-catalog';
+
 function parseEnvBoolean(value: string | undefined, defaultValue: boolean): boolean {
   if (value == null) return defaultValue;
   const normalized = value.trim().toLowerCase();
@@ -38,6 +40,19 @@ export const featureFlags = {
   enableProjects: parseEnvBoolean(
     process.env.NEXT_PUBLIC_ENABLE_PROJECTS,
     false,
+  ),
+  /**
+   * Expose the AUTO model (the gateway's smart router) in the model picker.
+   *
+   * Default: AUTO_MODEL_ENABLED (false). While off, the picker hides the "Auto"
+   * toggle entirely and every session opts into an explicit model — GLM 5.2 by
+   * default (see AUTO_DEFAULT_MODEL_ID in @kortix/shared/llm-catalog). The gateway
+   * still resolves `auto` server-side, so this only controls the UI: flip it (or
+   * set NEXT_PUBLIC_ENABLE_AUTO_MODEL=true) to bring the toggle back later.
+   */
+  enableAutoModel: parseEnvBoolean(
+    process.env.NEXT_PUBLIC_ENABLE_AUTO_MODEL,
+    AUTO_MODEL_ENABLED,
   ),
 } as const;
 

--- a/packages/shared/src/llm-catalog/index.ts
+++ b/packages/shared/src/llm-catalog/index.ts
@@ -39,7 +39,7 @@ export interface ManagedModel {
   name: string;
   // The upstream's own model id, interpreted per `transport`:
   //   'bedrock'      → a Bedrock id (`us.anthropic.claude-opus-4-8`)
-  //   'openrouter'   → an OpenRouter slug (`openrouter/fusion`)
+  //   'openrouter'   → an OpenRouter slug (`z-ai/glm-5.2`)
   upstreamModelId: string;
   // Which upstream + wire format carries it:
   //   'bedrock'      → Anthropic-on-Bedrock InvokeModel payload (Claude only)
@@ -103,14 +103,14 @@ export const MANAGED_MODELS: ManagedModel[] = [
     limit: { context: 1_000_000, output: 64_000 },
   },
   {
-    id: "fusion",
-    name: "Fusion",
-    upstreamModelId: "openrouter/fusion",
+    id: "glm-5.2",
+    name: "GLM 5.2",
+    upstreamModelId: "z-ai/glm-5.2",
     transport: "openrouter",
-    pricingRef: "openrouter/fusion",
+    pricingRef: "z-ai/glm-5.2",
     tier: "balanced",
     vision: false,
-    limit: { context: 1_000_000, output: 128_000 },
+    limit: { context: 1_000_000, output: 131_072 },
   },
   {
     id: "qwen3.7-max",
@@ -166,13 +166,31 @@ export const MANAGED_FLAGSHIP_MODEL_ID = (
 // request asks for it, the gateway resolves it to a concrete managed model and
 // bills it as the resolved model.
 //
-// For now AUTO is Fusion (OpenRouter's multi-model router) except a request that
-// carries images is routed to a vision-capable model so attachments aren't
-// silently ignored (Fusion is text-only). The `autoRouter` hook and this single
-// indirection point are where a future, more sophisticated per-task handler plugs in.
+// AUTO resolves to GLM 5.2 (text) except a request that carries images, which is
+// routed to a vision-capable model so attachments aren't silently ignored (GLM is
+// text-only). The `autoRouter` hook and this single indirection point are where a
+// future, more sophisticated per-task handler plugs in.
+//
+// AUTO is currently HIDDEN from the picker (see AUTO_MODEL_ENABLED): every session
+// explicitly opts into a concrete model. The resolution path below stays fully
+// intact — the sandbox still defaults `small_model`/headless sessions to `auto`,
+// and a stale gateway caller asking for raw `auto` still resolves — so re-exposing
+// the toggle is a one-line flip.
 export const AUTO_MODEL_ID = "auto";
 
-const AUTO_TARGET_MODEL = "fusion"; // text-only default
+// Whether AUTO is exposed in the model picker. Off for now: we want an explicit
+// opt-in on which model to use, and will bring AUTO back later. The web app reads
+// this through `featureFlags.enableAutoModel`, which can override it per-deploy via
+// NEXT_PUBLIC_ENABLE_AUTO_MODEL. The server keeps serving + resolving `auto`
+// regardless, so this only gates the UI.
+export const AUTO_MODEL_ENABLED = false;
+
+// The single "what to choose for auto" knob: the model AUTO routes text requests
+// to, AND the concrete model a fresh session defaults to while AUTO is hidden.
+// Change this one constant to re-point both.
+export const AUTO_DEFAULT_MODEL_ID = "glm-5.2";
+
+const AUTO_TARGET_MODEL = AUTO_DEFAULT_MODEL_ID; // text-only default
 const AUTO_VISION_MODEL = "claude-sonnet-4.6"; // when the request has image content
 
 function requestHasImage(body: Record<string, unknown>): boolean {

--- a/packages/shared/src/llm-catalog/managed.test.ts
+++ b/packages/shared/src/llm-catalog/managed.test.ts
@@ -13,7 +13,7 @@ describe("managed catalog", () => {
     expect(DEFAULT_MANAGED_MODEL_IDS).toEqual([
       "claude-opus-4.8",
       "claude-sonnet-4.6",
-      "fusion",
+      "glm-5.2",
       "qwen3.7-max",
       "deepseek-v4-pro",
       "deepseek-v4-flash",
@@ -86,10 +86,9 @@ describe("managed resolution + back-compat aliases", () => {
   test("resolves current ids", () => {
     expect(getManagedModel("claude-opus-4.8")?.name).toBe("Claude Opus 4.8");
     expect(getManagedModel("claude-opus-4.8")?.transport).toBe("bedrock");
-    expect(getManagedModel("fusion")?.transport).toBe("openrouter");
-    expect(getManagedModel("fusion")?.upstreamModelId).toBe(
-      "openrouter/fusion",
-    );
+    expect(getManagedModel("glm-5.2")?.name).toBe("GLM 5.2");
+    expect(getManagedModel("glm-5.2")?.transport).toBe("openrouter");
+    expect(getManagedModel("glm-5.2")?.upstreamModelId).toBe("z-ai/glm-5.2");
     expect(getManagedModel("qwen3.7-max")?.upstreamModelId).toBe(
       "qwen/qwen3.7-max",
     );
@@ -104,7 +103,7 @@ describe("managed resolution + back-compat aliases", () => {
       "kortix-basic",
       "glm-4.6",
       "glm-5.1",
-      "glm-5.2",
+      "fusion",
       "qwen3-max",
       "minimax-m2.5",
       "kimi-k2",

--- a/packages/shared/src/llm-catalog/pick-auto.test.ts
+++ b/packages/shared/src/llm-catalog/pick-auto.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "bun:test";
-import { AUTO_MODEL_ID, getManagedModel, pickAutoModel } from "./index";
+import {
+  AUTO_DEFAULT_MODEL_ID,
+  AUTO_MODEL_ENABLED,
+  AUTO_MODEL_ID,
+  getManagedModel,
+  pickAutoModel,
+} from "./index";
 
 const msg = (content: string) => ({ role: "user", content });
 
@@ -19,16 +25,16 @@ describe("pickAutoModel", () => {
     ).not.toBeNull();
   });
 
-  test("text requests resolve to Fusion (regardless of size / tools)", () => {
+  test("text requests resolve to GLM 5.2 (regardless of size / tools)", () => {
     expect(pickAutoModel("auto", { messages: [msg("hello there")] })).toBe(
-      "fusion",
+      "glm-5.2",
     );
     expect(
       pickAutoModel("auto", {
         messages: [msg("x".repeat(250_000))],
         tools: [{ name: "edit" }],
       }),
-    ).toBe("fusion");
+    ).toBe("glm-5.2");
   });
 
   test("image requests route to a vision model (not blind GLM)", () => {
@@ -50,7 +56,7 @@ describe("pickAutoModel", () => {
   });
 
   test("both auto targets are real managed models", () => {
-    expect(getManagedModel("fusion"), "fusion must exist").toBeDefined();
+    expect(getManagedModel("glm-5.2"), "glm-5.2 must exist").toBeDefined();
     expect(
       getManagedModel("claude-sonnet-4.6"),
       "claude-sonnet-4.6 must exist",
@@ -95,5 +101,19 @@ describe("pickAutoModel", () => {
 
   test("AUTO_MODEL_ID is the bare synthetic id", () => {
     expect(AUTO_MODEL_ID).toBe("auto");
+  });
+
+  test("AUTO is hidden by default; its target is the GLM 5.2 explicit default", () => {
+    // The picker hides AUTO for now (explicit opt-in), but the resolution path
+    // stays intact — and AUTO's text target IS the explicit default model.
+    expect(AUTO_MODEL_ENABLED).toBe(false);
+    expect(AUTO_DEFAULT_MODEL_ID).toBe("glm-5.2");
+    expect(
+      getManagedModel(AUTO_DEFAULT_MODEL_ID),
+      "the auto/default target must be a real managed model",
+    ).toBeDefined();
+    expect(pickAutoModel("auto", { messages: [msg("hi")] })).toBe(
+      AUTO_DEFAULT_MODEL_ID,
+    );
   });
 });


### PR DESCRIPTION
Replace the Fusion managed model with **GLM 5.2** (OpenRouter `z-ai/glm-5.2`) and hide the synthetic **Auto** smart-router from the model picker, so every session explicitly opts into a concrete model. Auto can be brought back later.

## Changes
- **packages/shared/llm-catalog**: swap `fusion` → `glm-5.2` in MANAGED_MODELS; add `AUTO_MODEL_ENABLED` (false) + `AUTO_DEFAULT_MODEL_ID` ("glm-5.2"). Auto now resolves text → GLM 5.2 (images still → claude-sonnet-4.6).
- **web**: gate the AutoModelToggle behind `featureFlags.enableAutoModel` (`NEXT_PUBLIC_ENABLE_AUTO_MODEL`, default off); redirect any resolved `kortix/auto` default to the explicit GLM 5.2 model.
- **sandbox-agent-server**: add `glm-5.2` to the cold-start fallback catalog.
- The gateway keeps serving + resolving `auto` (tier-safe small_model / headless default), so re-enabling the toggle is a one-line flip.

## Tests
Updated: managed lineup, pickAutoModel target, resolve-candidates, gateway catalog. GLM 5.2 billing pricing already present in credits.ts. All affected unit suites pass.