### PR TITLE
fix(llm): don't gate the 'set default model' control behind paid tier

### DIFF
--- a/apps/web/src/features/session/model-selector.tsx
+++ b/apps/web/src/features/session/model-selector.tsx
@@ -107,8 +107,6 @@ type ModelRef = { providerID: string; modelID: string };
 export interface ModelDefaultControls {
   /** Current agent name; enables the per-agent default action when set. */
   agentName?: string;
-  /** True when the account can't use managed models (free tier) — hides "default" hints. */
-  freeTier?: boolean;
   onSetAccountDefault: (model: ModelRef) => void;
   onSetAgentDefault?: (model: ModelRef) => void;
 }
@@ -521,7 +519,7 @@ export function ModelSelector({
                   </div>
                 )}
               </CommandList>
-              {defaultControls && selectedModel && !defaultControls.freeTier ? (
+              {defaultControls && selectedModel ? (
                 <div className="border-border/60 flex flex-col gap-0.5 border-t p-1.5">
                   <button
                     type="button"

--- a/apps/web/src/features/session/session-chat.tsx
+++ b/apps/web/src/features/session/session-chat.tsx
@@ -5850,7 +5850,6 @@ export function SessionChat({
           onModelChange={(m) => local.model.set(m ?? undefined, { recent: true })}
           modelDefaultControls={{
             agentName: local.agent.current?.name,
-            freeTier: local.model.defaults.freeTier,
             onSetAccountDefault: (m) => {
               void local.model.defaults.setAccountDefault(m);
             },


### PR DESCRIPTION
The model picker's **Set as my default model** / **Set as default for {agent}** footer was hidden for free-tier accounts (`!defaultControls.freeTier`). That was wrong — free-tier users can connect their own provider (BYOK) and want a default among those, and the server already validates the chosen model on save. The gate was incorrect *and* redundant, and made the control invisible. Now shown whenever a model is selected, regardless of tier.

Follow-up to #3903. One-line behavior change (removed the tier gate + the now-dead `freeTier` plumbing).