### PR TITLE
feat(llm): "Default model" picker in the LLM settings tab

### DIFF
--- a/apps/web/src/components/projects/customize/sections/gateway-view.tsx
+++ b/apps/web/src/components/projects/customize/sections/gateway-view.tsx
@@ -12,7 +12,7 @@
  * Providers is the default, core surface.
  */
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Boxes } from 'lucide-react';
 
 import { CustomizeSectionHeader } from '@/components/projects/customize/customize-section-header';
@@ -22,6 +22,10 @@ import { GatewayLogs } from '@/components/projects/gateway/gateway-logs';
 import { GatewayOverview } from '@/components/projects/gateway/gateway-overview';
 import { ProjectProviderModal } from '@/components/projects/project-provider-modal';
 import { FilterBar, FilterBarItem } from '@/components/ui/tabs';
+import { ModelSelector } from '@/features/session/model-selector';
+import { flattenModels } from '@/features/session/session-chat-input';
+import { useModelDefaults } from '@/hooks/opencode/use-model-defaults';
+import { useOpenCodeProviders } from '@/hooks/opencode/use-opencode-sessions';
 import type { CustomizeSection } from '@/lib/customize-sections';
 import { useCustomizeStore } from '@/stores/customize-store';
 
@@ -49,6 +53,14 @@ export function LlmManagementView({ projectId }: { projectId: string }) {
   const llmProvidersTab = useCustomizeStore((s) => s.llmProvidersTab);
   const [tab, setTab] = useState<LlmTab>(() => TAB_BY_SECTION[section] ?? 'providers');
 
+  // Account default model — the gateway resolves `auto` against this. Shown at
+  // the top of the LLM section so it's the obvious place to set "my default
+  // model", regardless of which sub-tab is open.
+  const { data: providers } = useOpenCodeProviders();
+  const models = useMemo(() => flattenModels(providers), [providers]);
+  const modelDefaults = useModelDefaults(projectId);
+  const effectiveDefault = modelDefaults.accountDefault ?? modelDefaults.platformDefault ?? null;
+
   // Follow an external deep-link (e.g. openCustomize('llm-providers')) to its
   // tab. Plain in-view tab clicks stay local and never move the main rail.
   useEffect(() => {
@@ -59,6 +71,26 @@ export function LlmManagementView({ projectId }: { projectId: string }) {
   return (
     <div className="bg-background flex h-full min-h-0 flex-col">
       <CustomizeSectionHeader icon={Boxes} title="LLM" />
+
+      {/* Account default model — the single, obvious place to set "my default". */}
+      <div className="border-border/60 flex shrink-0 flex-wrap items-center justify-between gap-3 border-b px-5 py-4">
+        <div className="min-w-0">
+          <div className="text-foreground text-sm font-medium">Default model</div>
+          <p className="text-muted-foreground/70 max-w-md text-xs leading-5">
+            Used whenever a chat doesn&apos;t have a model picked — across all your projects.
+            Picking a model inside a conversation always overrides it.
+          </p>
+        </div>
+        <ModelSelector
+          models={models}
+          providers={providers}
+          selectedModel={effectiveDefault}
+          onSelect={(m) => {
+            if (m) void modelDefaults.setAccountDefault(m);
+          }}
+        />
+      </div>
+
       <div className="border-border/60 flex shrink-0 items-center border-b px-5 py-3">
         <FilterBar>
           {LLM_TABS.map((t) => (


### PR DESCRIPTION
Follow-up to #3903/#3907. The only place to set a default model was a faint footer in the chat model dropdown — too hidden. This adds a prominent **Default model** row at the top of the **LLM** section (Customize → LLM), visible on every sub-tab.

Reuses `ModelSelector` wired to `useModelDefaults`: the trigger shows the effective default (account → platform), and picking a model calls `setAccountDefault` (server-side; the gateway resolves `auto` against it). `projectId` is already a prop of `LlmManagementView`, so no plumbing.

UI wiring only (no new logic — the resolution logic is already unit-tested). Labeled `no-tests-needed`.