### PR TITLE
chore(slack): enable identity gate on dev and staging values

### DIFF
--- a/infra/k8s/envs/dev/values.yaml
+++ b/infra/k8s/envs/dev/values.yaml
@@ -11,14 +11,10 @@ kortixVersion: ""
 env:
   internalKortixEnv: dev
 extraEnv:
-  # Identity gate OFF on dev. With it on, an @mention from anyone whose Kortix
-  # account isn't a member of this workspace's project is blocked (nudged to
-  # connect / request access) instead of running — which makes dogfooding in dev
-  # painful (you get no agent reply until you're added). Off → @mentions run as
-  # the project owner, like prod-lite. Rendered as explicit k8s env so it
-  # OVERRIDES the synced kortix-dev-env secret bundle. Flip to "true" to exercise
-  # the per-user identity / request-access flow. (Prod/staging keep it on.)
-  SLACK_REQUIRE_USER_IDENTITY: "false"
+  # Slack identity gate ON in dev so @mentions require the caller to connect
+  # their Kortix account and pass project access checks. Rendered as explicit k8s
+  # env so it OVERRIDES the synced kortix-dev-env secret bundle.
+  SLACK_REQUIRE_USER_IDENTITY: "true"
   # Point sandboxes at the standalone LLM gateway. Must be the PUBLIC host —
   # sandboxes are remote Daytona VMs that can't resolve cluster DNS. Without it
   # the API falls back to its in-API /v1/llm passthrough (OpenRouter-only, wrong

--- a/infra/k8s/envs/staging/values.yaml
+++ b/infra/k8s/envs/staging/values.yaml
@@ -11,6 +11,9 @@ kortixVersion: "0.9.79-staging.52fe1f42"
 env:
   internalKortixEnv: staging
 extraEnv:
+  # Slack identity gate ON in staging so release candidates exercise the same
+  # per-user account-linking and project-access flow expected before prod.
+  SLACK_REQUIRE_USER_IDENTITY: "true"
   LLM_GATEWAY_BASE_URL: "https://gateway-staging.kortix.com/v1/llm"
   KORTIX_WARM_SNAPSHOT_ENABLED: "false"
 # Staging has its own DB/Supabase data plane via `kortix-staging-env`, so the


### PR DESCRIPTION
## Summary
- Flip dev GitOps override `SLACK_REQUIRE_USER_IDENTITY` from `false` to `true`.
- Add an explicit staging values override so the Slack identity gate does not depend on the synced secret bundle.
- Keep this feature flag limited to dev/staging values; prod is unchanged.

## Verification
- `git diff --check`
- `helm template kortix-api infra/k8s/charts/kortix-api -f infra/k8s/envs/dev/values.yaml | rg -n -C 2 "SLACK_REQUIRE_USER_IDENTITY"` rendered `value: "true"`.
- `helm template kortix-api infra/k8s/charts/kortix-api -f infra/k8s/envs/staging/values.yaml | rg -n -C 2 "SLACK_REQUIRE_USER_IDENTITY"` rendered `value: "true"`.

## Deployment note
- Dev Argo tracks `main`, so this PR enables dev after merge and deploy.
- Live staging Argo tracks the `staging` branch, so staging still needs the same values override merged to `staging` or a main-to-staging promotion that includes it.