### PR TITLE
chore(slack): enable identity gate on staging

### DIFF
--- a/infra/k8s/envs/staging/values.yaml
+++ b/infra/k8s/envs/staging/values.yaml
@@ -11,6 +11,9 @@ kortixVersion: "0.9.82-staging.f1f1ebf2"
 env:
   internalKortixEnv: staging
 extraEnv:
+  # Slack identity gate ON in staging so release candidates exercise the same
+  # per-user account-linking and project-access flow expected before prod.
+  SLACK_REQUIRE_USER_IDENTITY: "true"
   LLM_GATEWAY_BASE_URL: "https://gateway-staging.kortix.com/v1/llm"
   KORTIX_WARM_SNAPSHOT_ENABLED: "false"
   KORTIX_WARM_POOL_MAX_TOTAL: "10"


### PR DESCRIPTION
## Summary
- Add explicit `SLACK_REQUIRE_USER_IDENTITY=true` to the live staging GitOps values.
- Keep existing staging image pins and staging-only warm pool settings intact.

## Verification
- `git diff --check`
- `helm template kortix-api infra/k8s/charts/kortix-api -f infra/k8s/envs/staging/values.yaml | rg -n -C 2 "SLACK_REQUIRE_USER_IDENTITY"` rendered `value: "true"`.

## Deployment note
- Staging Argo tracks the `staging` branch, so this PR is the one that actually enables the flag for live staging after merge/reconcile.