### PR TITLE
fix(iam): make project Viewer a usable base role (start + run sessions)

### DIFF
--- a/apps/api/src/__tests__/e2e-projects-contract.test.ts
+++ b/apps/api/src/__tests__/e2e-projects-contract.test.ts
@@ -292,6 +292,8 @@ mock.module('../iam/dispatcher', () => {
     const pm = projectMemberRows.find((r) => r.userId === userId && r.projectId === PROJECT_ID);
     const pr = pm?.projectRole ?? null;
     if (action === 'project.read') return pr === 'viewer' || pr === 'editor' || pr === 'manager';
+    // Session lifecycle: any project member (viewer included) may run sessions.
+    if (action.startsWith('project.session.')) return pr === 'viewer' || pr === 'editor' || pr === 'manager';
     if (action === 'project.write') return pr === 'editor' || pr === 'manager';
     return pr === 'manager';
   };

--- a/apps/api/src/__tests__/unit-iam-v2-role-perms.test.ts
+++ b/apps/api/src/__tests__/unit-iam-v2-role-perms.test.ts
@@ -59,10 +59,22 @@ describe('IAM V2 — project role table', () => {
     }
   });
 
-  test('viewer has only read-ish actions', () => {
+  test('viewer is the base usable role: reads + runs sessions, no customization', () => {
+    // Every viewer action is either a read or a session-lifecycle action —
+    // viewer can use the agent/chat but never edit, deploy, or manage.
     for (const a of PROJECT_ROLE_PERMS.viewer) {
-      expect(a).toMatch(/\.(read)$/);
+      expect(a).toMatch(/\.(read|start|exec|stop)$/);
     }
+    // Can start / run / stop sessions (the default role must be able to USE Kortix).
+    expect(projectRoleAllows('viewer', PROJECT_ACTIONS.PROJECT_SESSION_START)).toBe(true);
+    expect(projectRoleAllows('viewer', PROJECT_ACTIONS.PROJECT_SESSION_EXEC)).toBe(true);
+    expect(projectRoleAllows('viewer', PROJECT_ACTIONS.PROJECT_SESSION_STOP)).toBe(true);
+    // ...but cannot customize the project in any way.
+    expect(projectRoleAllows('viewer', PROJECT_ACTIONS.PROJECT_WRITE)).toBe(false);
+    expect(projectRoleAllows('viewer', PROJECT_ACTIONS.PROJECT_DEPLOY)).toBe(false);
+    expect(projectRoleAllows('viewer', PROJECT_ACTIONS.PROJECT_TRIGGER_CREATE)).toBe(false);
+    expect(projectRoleAllows('viewer', PROJECT_ACTIONS.PROJECT_MEMBERS_MANAGE)).toBe(false);
+    expect(projectRoleAllows('viewer', PROJECT_ACTIONS.PROJECT_DELETE)).toBe(false);
   });
 
   test('editor can fire and write triggers but not manage members or delete project', () => {

--- a/apps/api/src/__tests__/unit-project-access.test.ts
+++ b/apps/api/src/__tests__/unit-project-access.test.ts
@@ -9,7 +9,7 @@ import {
   type ProjectAccessAction,
   type ProjectRole,
 } from '../projects/access';
-import { isUuid } from '../projects/lib/access';
+import { iamActionForProjectAccess, isUuid } from '../projects/lib/access';
 
 describe('isUuid project-id guard', () => {
   test.each([
@@ -46,19 +46,35 @@ describe('project access roles', () => {
 
   test.each([
     ['viewer', 'read', true],
+    ['viewer', 'session', true], // viewer is the base usable role — can run sessions
     ['viewer', 'write', false],
     ['viewer', 'manage', false],
     ['editor', 'read', true],
+    ['editor', 'session', true],
     ['editor', 'write', true],
     ['editor', 'manage', false],
     ['manager', 'read', true],
+    ['manager', 'session', true],
     ['manager', 'write', true],
     ['manager', 'manage', true],
     [null, 'read', false],
+    [null, 'session', false], // no role → no session
   ] as Array<[ProjectRole | null, ProjectAccessAction, boolean]>)(
     '%s can %s => %p',
     (role, action, expected) => {
       expect(roleAllows(role, action)).toBe(expected);
+    },
+  );
+
+  test.each([
+    ['read', 'project.read'],
+    ['session', 'project.session.start'],
+    ['write', 'project.write'],
+    ['manage', 'project.write'],
+  ] as Array<[ProjectAccessAction, string]>)(
+    'iamActionForProjectAccess(%p) === %p',
+    (action, expected) => {
+      expect(iamActionForProjectAccess(action)).toBe(expected);
     },
   );
 

--- a/apps/api/src/iam/role-perms.ts
+++ b/apps/api/src/iam/role-perms.ts
@@ -69,15 +69,13 @@ const MANAGER_ONLY: readonly string[] = [
   PROJECT_ACTIONS.PROJECT_GATEWAY_KEYS_MANAGE,
 ];
 
-/** Actions an editor gets on top of viewer. Triggers and sessions
- *  are part of "content" — editor manages them. */
+/** Actions an editor gets on top of viewer. Editing the project,
+ *  deploying, triggers, and gateway routing are "customization" — that's
+ *  what separates an editor from a viewer. Running sessions is NOT here:
+ *  it's part of the viewer baseline (see below). */
 const EDITOR_EXTRAS: readonly string[] = [
   PROJECT_ACTIONS.PROJECT_WRITE,
   PROJECT_ACTIONS.PROJECT_DEPLOY,
-
-  PROJECT_ACTIONS.PROJECT_SESSION_START,
-  PROJECT_ACTIONS.PROJECT_SESSION_EXEC,
-  PROJECT_ACTIONS.PROJECT_SESSION_STOP,
 
   PROJECT_ACTIONS.PROJECT_TRIGGER_CREATE,
   PROJECT_ACTIONS.PROJECT_TRIGGER_UPDATE,
@@ -88,12 +86,22 @@ const EDITOR_EXTRAS: readonly string[] = [
   PROJECT_ACTIONS.PROJECT_GATEWAY_BUDGET_SET,
 ];
 
-/** Read-only baseline. */
+/** Baseline for the default project role. Viewer is the base *usable* role:
+ *  it can read everything AND start / run / stop sessions — i.e. actually use
+ *  the agent and the chat. A read-only viewer that can't open a session is
+ *  useless, and this is the role new members get by default, so it has to be
+ *  able to drive Kortix. What it CANNOT do is customize the project: edit
+ *  settings, deploy, manage members/triggers, or change gateway routing —
+ *  those live in EDITOR_EXTRAS / MANAGER_ONLY above. */
 const VIEWER_BASELINE: readonly string[] = [
   PROJECT_ACTIONS.PROJECT_READ,
   PROJECT_ACTIONS.PROJECT_SESSION_READ,
   PROJECT_ACTIONS.PROJECT_MEMBERS_READ,
   PROJECT_ACTIONS.PROJECT_TRIGGER_READ,
+
+  PROJECT_ACTIONS.PROJECT_SESSION_START,
+  PROJECT_ACTIONS.PROJECT_SESSION_EXEC,
+  PROJECT_ACTIONS.PROJECT_SESSION_STOP,
 
   PROJECT_ACTIONS.PROJECT_GATEWAY_LOGS_READ,
   PROJECT_ACTIONS.PROJECT_GATEWAY_SPEND_READ,

--- a/apps/api/src/projects/access.ts
+++ b/apps/api/src/projects/access.ts
@@ -1,6 +1,8 @@
 export type ProjectRole = 'manager' | 'editor' | 'viewer';
 export type AccountRole = 'owner' | 'admin' | 'member';
-export type ProjectAccessAction = 'read' | 'write' | 'manage';
+// 'session' sits between 'read' and 'write': any project member (viewer
+// included) may start and run sessions, but not customize the project.
+export type ProjectAccessAction = 'read' | 'session' | 'write' | 'manage';
 
 export function isAccountManager(role: AccountRole): boolean {
   return role === 'owner' || role === 'admin';
@@ -9,6 +11,8 @@ export function isAccountManager(role: AccountRole): boolean {
 export function roleAllows(role: ProjectRole | null, action: ProjectAccessAction): boolean {
   if (!role) return false;
   if (action === 'read') return true;
+  // Every project role can use sessions — viewer is the base *usable* role.
+  if (action === 'session') return true;
   if (action === 'write') return role === 'editor' || role === 'manager';
   return role === 'manager';
 }

--- a/apps/api/src/projects/lib/access.ts
+++ b/apps/api/src/projects/lib/access.ts
@@ -238,6 +238,11 @@ export function iamActionForProjectAccess(action: ProjectAccessAction): string {
   switch (action) {
     case 'read':
       return 'project.read';
+    case 'session':
+      // Starting / running / stopping a session. Granted to every project
+      // role (viewer included) so the default role can actually use Kortix,
+      // while project customization stays behind project.write.
+      return 'project.session.start';
     case 'write':
       return 'project.write';
     case 'manage':

--- a/apps/api/src/projects/routes/r7.ts
+++ b/apps/api/src/projects/routes/r7.ts
@@ -332,7 +332,7 @@ projectsApp.openapi(
   async (c: any) => {
   const projectId = c.req.param('projectId');
   const body = await readBody(c);
-  const loaded = await loadProjectForUser(c, projectId, 'write');
+  const loaded = await loadProjectForUser(c, projectId, 'session');
   if (!loaded) return c.json({ error: 'Not found' }, 404);
   const result = await createSession({
     source: 'ui',
@@ -634,7 +634,7 @@ projectsApp.openapi(
   if (!UUID_V4_REGEX.test(sessionId)) return c.json({ error: 'Invalid session id' }, 400);
 
   const body = await readBody(c);
-  const loaded = await loadProjectForUser(c, projectId, 'write');
+  const loaded = await loadProjectForUser(c, projectId, 'session');
   if (!loaded) return c.json({ error: 'Not found' }, 404);
 
   const serverManagedFields = ['status', 'sandbox_url', 'sandboxUrl', 'error'];
@@ -729,7 +729,7 @@ projectsApp.openapi(
   const sessionId = c.req.param('sessionId');
   if (!UUID_V4_REGEX.test(sessionId)) return c.json({ error: 'Invalid session id' }, 400);
 
-  const loaded = await loadProjectForUser(c, projectId, 'write');
+  const loaded = await loadProjectForUser(c, projectId, 'session');
   if (!loaded) return c.json({ error: 'Not found' }, 404);
 
   // Stopping a session is reserved for its owner or a project manager.

--- a/apps/api/src/projects/routes/r8.ts
+++ b/apps/api/src/projects/routes/r8.ts
@@ -108,7 +108,7 @@ projectsApp.openapi(
     if (!UUID_V4_REGEX.test(sessionId))
       return c.json({ error: 'Invalid session id' }, 400);
 
-    const loaded = await loadProjectForUser(c, projectId, 'write');
+    const loaded = await loadProjectForUser(c, projectId, 'session');
     if (!loaded) return c.json({ error: 'Not found' }, 404);
 
     // Restart is reserved for the session owner or a project manager.

--- a/apps/web/src/components/iam/project-role-descriptors.test.ts
+++ b/apps/web/src/components/iam/project-role-descriptors.test.ts
@@ -47,10 +47,12 @@ describe('PROJECT_ROLE_DESCRIPTORS', () => {
     }
   });
 
-  test('viewer blurb communicates read-only', () => {
-    // Marko: "What does a viewer in a project do?" — if this assertion
-    // ever fails, we've regressed on the whole point of the descriptor.
-    expect(PROJECT_ROLE_DESCRIPTORS.viewer.blurb.toLowerCase()).toContain('read');
+  test('viewer blurb communicates it can use the project (start sessions)', () => {
+    // Viewer is the base *usable* role — it can start sessions and use the
+    // agent chat, NOT a read-only role. Marko: "What does a viewer in a
+    // project do?" — if this fails, we've regressed the whole point of the
+    // descriptor (a viewer that can't open a session is useless).
+    expect(PROJECT_ROLE_DESCRIPTORS.viewer.blurb.toLowerCase()).toMatch(/session|chat|use/);
   });
 
   test('manager blurb communicates member management', () => {

--- a/apps/web/src/components/iam/project-role-descriptors.ts
+++ b/apps/web/src/components/iam/project-role-descriptors.ts
@@ -27,15 +27,15 @@ export interface ProjectRoleDescriptor {
 export const PROJECT_ROLE_DESCRIPTORS: Record<ProjectRole, ProjectRoleDescriptor> = {
   viewer: {
     label: 'Viewer',
-    blurb: 'Read-only. See the project, sessions, triggers, and members.',
+    blurb: 'Use the project: start sessions and chat with the agent.',
     summary:
-      'Can open the project and read its sessions, triggers, and member list. Cannot edit anything, run sessions, or change settings.',
+      'The base role. Can open the project, start and run sessions, and use the agent chat. Cannot customize the project — no editing settings, deploying, managing members, or changing triggers.',
   },
   editor: {
     label: 'Editor',
-    blurb: 'Everything a viewer sees, plus edit the project and run sessions.',
+    blurb: 'Everything a viewer does, plus edit and customize the project.',
     summary:
-      'Everything a viewer can do, plus edit the project, deploy, start/stop sessions, and create or fire triggers. Cannot invite members or change project settings.',
+      'Everything a viewer can do, plus edit the project, deploy, and create or fire triggers. Cannot invite members, change member roles, or delete the project.',
   },
   manager: {
     label: 'Manager',

--- a/tests/e2e/specs/08-accounts-project-access.spec.ts
+++ b/tests/e2e/specs/08-accounts-project-access.spec.ts
@@ -254,6 +254,12 @@ test.describe('08 — Accounts, invites, and project access', () => {
       `/projects/${project.project_id}`,
     );
     expect(readableProject.effective_project_role).toBe('viewer');
+    // A viewer is the base *usable* role: it can start sessions and use the agent
+    // chat (this previously 403'd, which made the default project role useless).
+    // It reaches provider validation just like an owner — an invalid provider is a
+    // 400, NOT the old role 403 (and avoids actually provisioning a sandbox here).
+    expect(await apiStatus(memberSession.access_token, 'POST', `/projects/${project.project_id}/sessions`, { provider: 'justavps' })).toBe(400);
+    // ...but it still cannot customize the project.
     expect(await apiStatus(memberSession.access_token, 'PATCH', `/projects/${project.project_id}`, { name: 'blocked' })).toBe(403);
 
     await api<{ ok: true }>(

--- a/tests/e2e/specs/11-production-boundaries.spec.ts
+++ b/tests/e2e/specs/11-production-boundaries.spec.ts
@@ -140,7 +140,10 @@ test.describe.serial('11 - SPEC auth boundaries, concurrency, and SLOs', () => {
     );
     expect(viewerGrant.effective_project_role).toBe('viewer');
     expect(await apiStatus(memberSession.access_token, 'GET', `/projects/${project.project_id}`)).toBe(200);
-    expect(await apiStatus(memberSession.access_token, 'POST', `/projects/${project.project_id}/sessions`, {})).toBe(403);
+    // A viewer is the base *usable* role: it CAN start sessions (use the chat), so
+    // the role gate no longer blocks session create. It reaches provider validation
+    // like an owner — an invalid provider is a 400, not the old role 403.
+    expect(await apiStatus(memberSession.access_token, 'POST', `/projects/${project.project_id}/sessions`, { provider: 'justavps' })).toBe(400);
 
     await api<{ ok: true }>(
       ownerSession.access_token,

--- a/tests/spec/end-to-end.md
+++ b/tests/spec/end-to-end.md
@@ -27,7 +27,7 @@ Stack: TypeScript/Hono on Bun (`apps/api`), Drizzle→Postgres (`kortix` schema)
 | `OWNER` | account owner (super-admin, bypasses policy) | full access |
 | `ADMIN` | account `admin` (Administrator policy) | all but account.delete / billing.write / owner-grant |
 | `MEMBER` | account `member`, **no** project grant | account-reads only; cannot see projects |
-| `M_VIEWER` `M_EDITOR` `M_MANAGER` | member + project_members row (viewer/editor/manager) | per-project read / write / manage |
+| `M_VIEWER` `M_EDITOR` `M_MANAGER` | member + project_members row (viewer/editor/manager) | per-project (read + run-sessions) / +customize (write) / +manage. Viewer is the base *usable* role: it can read AND start/run/stop sessions (use the agent chat) — it just can't customize the project. So POST `/projects/:id/sessions` is allowed for M_VIEWER; PATCH `/projects/:id` is not |
 | `BILLING` | `billing_manager` policy | billing read+write only |
 | `AUDITOR` | `auditor` policy | reads + audit only |
 | `RO_ADMIN` | `administrator_read_only` | read-only everywhere |
@@ -176,15 +176,15 @@ DB `projects` (`status active|archived`, unique `(account_id, repo_url)`). Soft 
 
 DB `project_sessions` (`status queued|branching|provisioning|running|stopped|failed|completed`, unique `(project_id, branch_name)`). Branch name = `session_id`.
 
-`SESS-1` `POST /projects/:id/sessions {agent_name?,initial_prompt?,base_ref?,provider?,name?,session_id?,branch_already_created?}` → `write` (M_EDITOR/M_MANAGER) → 201 status `provisioning` (fire-and-forget sandbox). M_VIEWER → 403.
+`SESS-1` `POST /projects/:id/sessions {agent_name?,initial_prompt?,base_ref?,provider?,name?,session_id?,branch_already_created?}` → `session` (any project member, **M_VIEWER included** — viewer is the base usable role) → 201 status `provisioning` (fire-and-forget sandbox). MEMBER with no project grant / NONMEMBER → 403. (An invalid `provider` for an allowed caller → 400, proving the role gate passed before provider validation.)
 `SESS-2` concurrency cap — Nth session over tier cap → **429** + `X-RateLimit-Limit/-Remaining` headers.
 `SESS-3` CLI client-branch optimization — `kortix sessions new`: if server can't self-create branch (not managed-freestyle, not GitHub app/pat) AND local `origin` == `project.repo_url`, CLI mints uuid, `git push origin HEAD:refs/heads/<uuid>`, then posts `session_id`+`branch_already_created:true`+`base_ref`.
 `SESS-4` `GET /projects/:id/sessions` → `read` → list (updatedAt desc).
 `SESS-5` `GET /projects/:id/sessions/:sid` → `read` → 200; non-uuid `sid` → 400.
-`SESS-6` `PATCH /projects/:id/sessions/:sid {name?,metadata?}` → `write`; attempting `status`/`sandbox_url`/`error`/`opencode_session_id` → 400 (server-managed); any other field → 400 (not user-editable). `name` sets a sticky USER override stored in `metadata.custom_name` (NOT clobbered by the server-side OpenCode title mirror, which only writes the auto title `metadata.name` during session reads); `name:""`/null clears it. Response `name` = resolved display (`custom_name ?? metadata.name`); `custom_name` exposed separately (authoritative override or null).
-`SESS-7` `DELETE /projects/:id/sessions/:sid` → `write` → 200 soft-delete status `stopped`; **remote branch preserved**.
+`SESS-6` `PATCH /projects/:id/sessions/:sid {name?,metadata?}` → `session` (any project member, M_VIEWER included); attempting `status`/`sandbox_url`/`error`/`opencode_session_id` → 400 (server-managed); any other field → 400 (not user-editable). `name` sets a sticky USER override stored in `metadata.custom_name` (NOT clobbered by the server-side OpenCode title mirror, which only writes the auto title `metadata.name` during session reads); `name:""`/null clears it. Response `name` = resolved display (`custom_name ?? metadata.name`); `custom_name` exposed separately (authoritative override or null).
+`SESS-7` `DELETE /projects/:id/sessions/:sid` → `session` (then **owner or project manager** only — a viewer can stop sessions they own) → 200 soft-delete status `stopped`; **remote branch preserved**.
 `SESS-8` `GET /projects/:id/sessions/:sid/sandbox` → `read` → `session_sandboxes` row; **404 while row not yet inserted** (frontend polls); then status `provisioning`→`active` with `base_url`/`external_id`.
-`SESS-9` `POST /projects/:id/sessions/:sid/restart` → `write` → **202**; tears down container, revokes sandbox keys, re-provisions with rotated git/LLM/CLI tokens (status→`provisioning`); branch preserved.
+`SESS-9` `POST /projects/:id/sessions/:sid/restart` → `session` (then **owner or project manager** only) → **202**; tears down container, revokes sandbox keys, re-provisions with rotated git/LLM/CLI tokens (status→`provisioning`); branch preserved.
 `SESS-10` OpenCode title/tree mirror is server-owned: `GET /projects/:id/sessions` and `GET /projects/:id/sessions/:sid` read the sandbox's OpenCode sessions server-side and mirror `metadata.name`/`metadata.opencode_sessions`; there is no browser-write sync endpoint.
 
 ---
@@ -413,8 +413,9 @@ Run these against representative endpoints from each domain.
 | Action level | OWNER | ADMIN | M_MANAGER | M_EDITOR | M_VIEWER | MEMBER (no grant) | NONMEMBER |
 |---|---|---|---|---|---|---|---|
 | `read` (GET project/files/sessions) | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ 403 | ✗ 403 |
-| `write` (session create/CR merge/PATCH session) | ✓ | ✓ | ✓ | ✓ | ✗ 403 | ✗ 403 | ✗ 403 |
-| `manage` (PATCH/DELETE project, secrets, triggers, access) | ✓ | ✓ | ✓ | ✗ 403 | ✗ 403 | ✗ 403 | ✗ 403 |
+| `session` (create/PATCH/DELETE/restart session — use the chat) | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ 403 | ✗ 403 |
+| `write` (PATCH project, CR merge, deploy, triggers) | ✓ | ✓ | ✓ | ✓ | ✗ 403 | ✗ 403 | ✗ 403 |
+| `manage` (DELETE project, secrets, members/access) | ✓ | ✓ | ✓ | ✗ 403 | ✗ 403 | ✗ 403 | ✗ 403 |
 
 ### Role × account-action grid
 
@@ -442,7 +443,7 @@ Run these against representative endpoints from each domain.
 ## 21. Known gaps (don't write tests for these — they don't exist)
 
 - No account-level vault — secrets are project-scoped, all-or-nothing per project (the `vault_items`/per-member-scope design was reversed).
-- Granular IAM actions `project.trigger.*`, `channel.*`, `trigger.*`, `project.session.*` exist in the catalog but project routes only enforce coarse `read|write|manage` — test the coarse gate, not the fine actions.
+- Granular IAM actions `project.trigger.*`, `channel.*`, `trigger.*` exist in the catalog but those project routes only enforce coarse `read|write|manage` — test the coarse gate, not the fine actions. **Exception:** session lifecycle routes (create/PATCH/DELETE/restart) now enforce `project.session.start` via the `session` access tier, which every project role (viewer included) holds — so a viewer CAN run sessions but still can't `write`/`manage`.
 - No inbound GitHub event webhook (no push/PR receiver) — see `TRG-9`.
 - CLI `providers`, `doctor`, `proxy`, `sessions-chat` source files exist but are **not wired** into the dispatcher and not in the reserved list — so `kortix providers …` is **treated as a new-project name** (`runCreate`), not an "unknown command" error. Don't test for an error here.
 - Cron scheduler scans only first 200 active projects/tick.


### PR DESCRIPTION
## Why

**Viewer is the default project role**, but it was read-only — it couldn't even open a session, so a viewer literally could not use Kortix or the agent chat. That makes the default role useless (the thing this PR exists to fix). There's a larger role-system PR coming; this is the minimal change so **production is functional with the Viewer role today**.

## What changed

Viewer becomes the base **usable** role: it can read everything **and start / run / restart / stop sessions** (i.e. use the agent + chat). It still **cannot customize** the project — editing settings, deploy, members, triggers, gateway routing, and CR merge stay Editor/Manager.

- **`iam/role-perms.ts`** — move `project.session.{start,exec,stop}` from `EDITOR_EXTRAS` into `VIEWER_BASELINE`. (These granular actions already existed but were never wired to routes.)
- **`projects/access.ts`** — add a `'session'` `ProjectAccessAction` (allowed for *any* project member) that maps to `project.session.start`.
- **`projects/lib/access.ts`** — `iamActionForProjectAccess('session') → 'project.session.start'`.
- **Session lifecycle routes re-gated `'write'` → `'session'`**: create (`r7` POST), rename (`r7` PATCH), delete (`r7` DELETE), restart (`r8`). The existing **owner-or-manager** checks on delete & restart are unchanged, so a viewer can only stop/restart sessions they own.
- Customization routes (project PATCH/DELETE, secrets, marketplace installs, CR merge, gateway config, triggers, members) are untouched — still `write`/`manage`.

Chat itself is already gated by sandbox/account membership (`canAccessPreviewSandbox`), so once a viewer can create a session, the chat works. The frontend never gated session creation by role (it relied on the API 403), so no FE logic change is needed beyond the role-descriptor copy.

## Tests / spec

- `unit-iam-v2-role-perms`, `unit-project-access` (+ `iamActionForProjectAccess` mapping), `e2e-projects-contract` mock updated.
- ke2e: `08-accounts-project-access` + `11-production-boundaries` now assert a viewer **can** start a session (invalid-provider → 400, proving the role gate passes without provisioning a real sandbox) while PATCH project stays 403.
- `tests/spec/end-to-end.md`: SESS-1/6/7/9, role table + role×action grid, and the known-gaps note updated.

Verified locally: `tsc --noEmit` clean for the change; affected unit suites green (56 pass).