### PR TITLE
feat(cli): multi-account model + global default project + always-visible context

### DIFF
--- a/apps/cli/src/__tests__/account-project-config.test.ts
+++ b/apps/cli/src/__tests__/account-project-config.test.ts
@@ -1,0 +1,221 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  activeAccount,
+  clearDefaultProject,
+  defaultProject,
+  loadConfig,
+  setActiveAccount,
+  setDefaultProject,
+} from '../api/config.ts';
+import { resolveProjectId, saveLink } from '../project-link.ts';
+import { renderContext, renderHostNotice } from '../host-notice.ts';
+import { stripAnsi } from '../style.ts';
+
+const ENV_KEYS = [
+  'KORTIX_CLI_TOKEN',
+  'KORTIX_EXECUTOR_TOKEN',
+  'KORTIX_TOKEN',
+  'KORTIX_API_URL',
+  'KORTIX_PROJECT_ID',
+  'BASH_ENV',
+  'KORTIX_DISABLE_SANDBOX_ENV_FILE',
+  'KORTIX_CONFIG_FILE',
+  'KORTIX_AUTH_FILE',
+] as const;
+
+let saved: Record<string, string | undefined>;
+let tmp: string;
+let originalCwd: string;
+
+function writeConfig(hosts: Record<string, unknown>, active = 'test'): void {
+  const file = join(tmp, 'config.json');
+  writeFileSync(file, JSON.stringify({ active, hosts }, null, 2));
+  process.env.KORTIX_CONFIG_FILE = file;
+}
+
+function loggedInHost(extra: Record<string, unknown> = {}) {
+  return {
+    url: 'https://api.test',
+    token: 'tok_test',
+    user_id: 'user_1',
+    user_email: 'user@example.test',
+    account_id: 'account_1',
+    logged_in_at: '2026-01-01T00:00:00.000Z',
+    ...extra,
+  };
+}
+
+beforeEach(() => {
+  saved = {};
+  for (const key of ENV_KEYS) {
+    saved[key] = process.env[key];
+    delete process.env[key];
+  }
+  process.env.KORTIX_DISABLE_SANDBOX_ENV_FILE = '1';
+  originalCwd = process.cwd();
+  tmp = mkdtempSync(join(tmpdir(), 'kortix-acct-cfg-'));
+});
+
+afterEach(() => {
+  process.chdir(originalCwd);
+  for (const key of ENV_KEYS) {
+    if (saved[key] === undefined) delete process.env[key];
+    else process.env[key] = saved[key];
+  }
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+describe('config: account + default-project state', () => {
+  test('old config without the new fields still loads (back-compat)', () => {
+    writeConfig({ test: loggedInHost() });
+    const config = loadConfig();
+    expect(config.active).toBe('test');
+    expect(config.hosts.test.account_id).toBe('account_1');
+    expect(config.hosts.test.default_project).toBeUndefined();
+    expect(activeAccount()).toEqual({ id: 'account_1', slug: 'account_', name: '' });
+  });
+
+  test('setActiveAccount persists display fields and round-trips', () => {
+    writeConfig({ test: loggedInHost({ account_id: '' }) });
+    setActiveAccount({ id: 'acc_kortix', slug: 'kortix', name: 'Kortix' });
+    expect(activeAccount()).toEqual({ id: 'acc_kortix', slug: 'kortix', name: 'Kortix' });
+    // Persisted to disk, not just in memory.
+    const onDisk = JSON.parse(readFileSync(process.env.KORTIX_CONFIG_FILE!, 'utf8'));
+    expect(onDisk.hosts.test.account_slug).toBe('kortix');
+    expect(onDisk.hosts.test.account_name).toBe('Kortix');
+  });
+
+  test('setDefaultProject + defaultProject round-trip and clearDefaultProject removes it', () => {
+    writeConfig({ test: loggedInHost() });
+    setDefaultProject({ project_id: 'proj_a', account_id: 'account_1', name: 'Alpha' });
+    expect(defaultProject()).toEqual({ project_id: 'proj_a', account_id: 'account_1', name: 'Alpha' });
+    expect(clearDefaultProject()).toBe(true);
+    expect(defaultProject()).toBeNull();
+    expect(clearDefaultProject()).toBe(false);
+  });
+
+  test('switching to a different account drops a now-foreign default project', () => {
+    writeConfig({
+      test: loggedInHost({
+        default_project: { project_id: 'proj_a', account_id: 'account_1', name: 'Alpha' },
+      }),
+    });
+    expect(defaultProject()?.project_id).toBe('proj_a');
+    setActiveAccount({ id: 'account_2', slug: 'two', name: 'Two' });
+    expect(defaultProject()).toBeNull();
+  });
+
+  test('switching to the SAME account keeps the default project', () => {
+    writeConfig({
+      test: loggedInHost({
+        default_project: { project_id: 'proj_a', account_id: 'account_1', name: 'Alpha' },
+      }),
+    });
+    setActiveAccount({ id: 'account_1', slug: 'one', name: 'One' });
+    expect(defaultProject()?.project_id).toBe('proj_a');
+  });
+});
+
+describe('resolveProjectId fallback order', () => {
+  test('falls back to the active host default project when no link / env', () => {
+    writeConfig({
+      test: loggedInHost({
+        default_project: { project_id: 'proj_default', account_id: 'account_1' },
+      }),
+    });
+    process.chdir(tmp); // linkless dir
+    expect(resolveProjectId()).toBe('proj_default');
+  });
+
+  test('explicit arg and KORTIX_PROJECT_ID outrank the default', () => {
+    writeConfig({
+      test: loggedInHost({
+        default_project: { project_id: 'proj_default', account_id: 'account_1' },
+      }),
+    });
+    process.chdir(tmp);
+    expect(resolveProjectId('explicit')).toBe('explicit');
+    process.env.KORTIX_PROJECT_ID = 'env_proj';
+    expect(resolveProjectId()).toBe('env_proj');
+  });
+
+  test('a directory link outranks the default project', () => {
+    writeConfig({
+      test: loggedInHost({
+        default_project: { project_id: 'proj_default', account_id: 'account_1' },
+      }),
+    });
+    mkdirSync(join(tmp, '.kortix'), { recursive: true });
+    process.chdir(tmp);
+    saveLink(
+      { project_id: 'proj_linked', account_id: 'account_1', linked_at: '2026-01-01T00:00:00.000Z' },
+      tmp,
+    );
+    expect(existsSync(join(tmp, '.kortix', 'link.json'))).toBe(true);
+    expect(resolveProjectId()).toBe('proj_linked');
+  });
+});
+
+describe('renderContext + host notice', () => {
+  test('context block shows host, account, and default project', () => {
+    writeConfig({
+      test: loggedInHost({
+        account_slug: 'kortix',
+        account_name: 'Kortix',
+        default_project: { project_id: 'proj_a', account_id: 'account_1', name: 'Alpha' },
+      }),
+    });
+    process.chdir(tmp);
+    const out = stripAnsi(renderContext());
+    expect(out).toContain('host');
+    expect(out).toContain('test');
+    expect(out).toContain('account');
+    expect(out).toContain('Kortix');
+    expect(out).toContain('project');
+    expect(out).toContain('Alpha');
+    expect(out).toContain('(default)');
+  });
+
+  test('context block nudges when account / default project are unset', () => {
+    writeConfig({ test: loggedInHost({ account_id: '' }) });
+    process.chdir(tmp);
+    const out = stripAnsi(renderContext());
+    expect(out).toContain('kortix accounts use');
+    expect(out).toContain('kortix projects use');
+  });
+
+  test('subcommand host notice appends account + default project', () => {
+    writeConfig({
+      test: loggedInHost({
+        account_slug: 'kortix',
+        account_name: 'Kortix',
+        default_project: { project_id: 'proj_a', account_id: 'account_1', name: 'Alpha' },
+      }),
+    });
+    process.chdir(tmp);
+    const notice = stripAnsi(renderHostNotice(['whoami']) ?? '');
+    expect(notice).toContain('host test');
+    expect(notice).toContain('account Kortix');
+    expect(notice).toContain('project Alpha');
+    expect(notice).toContain('(default)');
+  });
+
+  test('--host override does not claim the active account / project', () => {
+    writeConfig({
+      test: loggedInHost({
+        account_slug: 'kortix',
+        account_name: 'Kortix',
+        default_project: { project_id: 'proj_a', account_id: 'account_1', name: 'Alpha' },
+      }),
+    });
+    process.chdir(tmp);
+    const notice = stripAnsi(renderHostNotice(['whoami', '--host', 'cloud']) ?? '');
+    expect(notice).toContain('host cloud');
+    expect(notice).not.toContain('account Kortix');
+    expect(notice).not.toContain('project Alpha');
+  });
+});

--- a/apps/cli/src/__tests__/accounts.test.ts
+++ b/apps/cli/src/__tests__/accounts.test.ts
@@ -1,0 +1,216 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { runAccounts } from '../commands/accounts.ts';
+import { runProjects } from '../commands/projects.ts';
+import { activeAccount, defaultProject } from '../api/config.ts';
+import { stripAnsi } from '../style.ts';
+
+const ORIGINAL_FETCH = globalThis.fetch;
+const ORIGINAL_STDOUT_WRITE = process.stdout.write;
+const ORIGINAL_STDERR_WRITE = process.stderr.write;
+
+const ENV_KEYS = [
+  'KORTIX_CLI_TOKEN',
+  'KORTIX_EXECUTOR_TOKEN',
+  'KORTIX_TOKEN',
+  'KORTIX_API_URL',
+  'KORTIX_FRONTEND_URL',
+  'KORTIX_PROJECT_ID',
+  'BASH_ENV',
+  'KORTIX_DISABLE_SANDBOX_ENV_FILE',
+  'KORTIX_CONFIG_FILE',
+  'KORTIX_AUTH_FILE',
+] as const;
+
+let saved: Record<string, string | undefined>;
+let tmp: string;
+let originalCwd: string;
+let stdout = '';
+let stderr = '';
+let requests: string[] = [];
+
+const ACCOUNTS = [
+  { account_id: 'account_1', slug: 'personal', name: 'Personal', personal_account: true, role: 'owner' },
+  { account_id: 'account_2', slug: 'kortix', name: 'Kortix', personal_account: false, role: 'owner' },
+];
+
+function writeConfig(activeAccountId = 'account_1'): void {
+  const file = join(tmp, 'config.json');
+  writeFileSync(
+    file,
+    JSON.stringify({
+      active: 'test',
+      hosts: {
+        test: {
+          url: 'https://api.test',
+          token: 'tok_test',
+          user_id: 'user_1',
+          user_email: 'user@example.test',
+          account_id: activeAccountId,
+          logged_in_at: '2026-01-01T00:00:00.000Z',
+        },
+      },
+    }),
+    'utf8',
+  );
+  process.env.KORTIX_CONFIG_FILE = file;
+}
+
+function captureOutput() {
+  stdout = '';
+  stderr = '';
+  (process.stdout as any).write = (chunk: unknown) => {
+    stdout += String(chunk);
+    return true;
+  };
+  (process.stderr as any).write = (chunk: unknown) => {
+    stderr += String(chunk);
+    return true;
+  };
+}
+
+function mockApi(extra?: (url: string) => Response | undefined) {
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = String(input);
+    requests.push(url);
+    const custom = extra?.(url);
+    if (custom) return custom;
+    if (url === 'https://api.test/v1/accounts/me') {
+      return new Response(
+        JSON.stringify({ user_id: 'user_1', email: 'user@example.test', accounts: ACCOUNTS }),
+        { status: 200 },
+      );
+    }
+    return new Response(JSON.stringify({ error: `unexpected ${url}` }), { status: 500 });
+  }) as typeof fetch;
+}
+
+beforeEach(() => {
+  saved = {};
+  for (const key of ENV_KEYS) {
+    saved[key] = process.env[key];
+    delete process.env[key];
+  }
+  process.env.KORTIX_DISABLE_SANDBOX_ENV_FILE = '1';
+  originalCwd = process.cwd();
+  tmp = mkdtempSync(join(tmpdir(), 'kortix-accounts-test-'));
+  process.chdir(tmp);
+  writeConfig();
+  captureOutput();
+  requests = [];
+});
+
+afterEach(() => {
+  globalThis.fetch = ORIGINAL_FETCH;
+  (process.stdout as any).write = ORIGINAL_STDOUT_WRITE;
+  (process.stderr as any).write = ORIGINAL_STDERR_WRITE;
+  process.chdir(originalCwd);
+  for (const key of ENV_KEYS) {
+    if (saved[key] === undefined) delete process.env[key];
+    else process.env[key] = saved[key];
+  }
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+describe('kortix accounts', () => {
+  test('ls lists accounts and marks the active one (no account scoping on /me)', async () => {
+    mockApi();
+    const code = await runAccounts(['ls']);
+    expect(code).toBe(0);
+    expect(requests).toEqual(['https://api.test/v1/accounts/me']);
+    const out = stripAnsi(stdout);
+    expect(out).toContain('Personal');
+    expect(out).toContain('Kortix');
+    // The active account (account_1 = Personal) is bulleted.
+    expect(out).toMatch(/●\s+Personal/);
+  });
+
+  test('ls --json reports the active flag', async () => {
+    mockApi();
+    const code = await runAccounts(['ls', '--json']);
+    expect(code).toBe(0);
+    const parsed = JSON.parse(stdout) as Array<{ slug: string; active: boolean }>;
+    expect(parsed.find((a) => a.slug === 'personal')?.active).toBe(true);
+    expect(parsed.find((a) => a.slug === 'kortix')?.active).toBe(false);
+  });
+
+  test('use <slug> switches the active account', async () => {
+    mockApi();
+    const code = await runAccounts(['use', 'kortix']);
+    expect(code).toBe(0);
+    expect(activeAccount()).toEqual({ id: 'account_2', slug: 'kortix', name: 'Kortix' });
+    expect(stripAnsi(stdout)).toContain('Active account is now Kortix');
+  });
+
+  test('use rejects an unknown account', async () => {
+    mockApi();
+    const code = await runAccounts(['use', 'nope']);
+    expect(code).toBe(1);
+    expect(stripAnsi(stderr)).toContain('No account "nope"');
+    // Active account is unchanged.
+    expect(activeAccount()?.id).toBe('account_1');
+  });
+
+  test('current prints the active account', async () => {
+    mockApi();
+    await runAccounts(['use', 'kortix']);
+    stdout = '';
+    const code = await runAccounts(['current']);
+    expect(code).toBe(0);
+    expect(stripAnsi(stdout)).toContain('Kortix');
+  });
+});
+
+describe('kortix projects use', () => {
+  test('sets the default project and switches the active account to its account', async () => {
+    mockApi((url) => {
+      if (url === 'https://api.test/v1/projects/proj_x') {
+        return new Response(
+          JSON.stringify({
+            project_id: 'proj_x',
+            account_id: 'account_2',
+            name: 'Beta',
+            repo_url: 'https://github.com/x/beta.git',
+            default_branch: 'main',
+            manifest_path: 'kortix.toml',
+            status: 'active',
+            last_opened_at: null,
+            created_at: '2026-01-01T00:00:00.000Z',
+            updated_at: '2026-01-01T00:00:00.000Z',
+          }),
+          { status: 200 },
+        );
+      }
+      return undefined;
+    });
+
+    const code = await runProjects(['use', 'proj_x']);
+    expect(code).toBe(0);
+    // The by-id GET is NOT account-scoped (the project may be in any account).
+    expect(requests).toContain('https://api.test/v1/projects/proj_x');
+    // Default project recorded …
+    expect(defaultProject()).toEqual({ project_id: 'proj_x', account_id: 'account_2', name: 'Beta' });
+    // … and the active account followed it to Kortix (account_2).
+    expect(activeAccount()).toEqual({ id: 'account_2', slug: 'kortix', name: 'Kortix' });
+    const out = stripAnsi(stdout);
+    expect(out).toContain('Default project: Beta');
+    expect(out).toContain('now active');
+  });
+});
+
+describe('kortix projects ls scoping', () => {
+  test('scopes the list to the active account', async () => {
+    mockApi((url) => {
+      if (url.startsWith('https://api.test/v1/projects')) {
+        return new Response(JSON.stringify([]), { status: 200 });
+      }
+      return undefined;
+    });
+    const code = await runProjects(['ls', '--json']);
+    expect(code).toBe(0);
+    expect(requests).toEqual(['https://api.test/v1/projects?account_id=account_1']);
+  });
+});

--- a/apps/cli/src/__tests__/cli-blackbox.test.ts
+++ b/apps/cli/src/__tests__/cli-blackbox.test.ts
@@ -512,7 +512,8 @@ describe('kortix CLI black-box behavior', () => {
     expect(existsSync(join(root, '.kortix', 'link.json'))).toBe(false);
 
     expect(requests.map((r) => [r.method, r.path, r.body ?? null])).toEqual([
-      ['GET', '/v1/projects', null],
+      // `projects ls` is scoped to the active account; by-id routes are not.
+      ['GET', '/v1/projects?account_id=account_1', null],
       ['GET', '/v1/projects/proj_e2e', null],
       ['GET', '/v1/projects/proj_e2e', null],
       ['GET', '/v1/marketplace/items?query=agent-browser&source=kortix', null],

--- a/apps/cli/src/api/client.ts
+++ b/apps/cli/src/api/client.ts
@@ -22,6 +22,11 @@ export interface ApiClient {
 export interface ClientOptions {
   apiBase?: string;
   token?: string;
+  /** When set (non-empty), every request is scoped to this account via a
+   *  `?account_id=` query param. The API honors it in resolveProjectAccount
+   *  (and validates membership); project-id routes ignore it. Without it the
+   *  server falls back to the caller's earliest-joined account. */
+  accountId?: string;
 }
 
 function joinUrl(base: string, path: string): string {
@@ -38,13 +43,22 @@ function joinUrl(base: string, path: string): string {
   return `${b}${versioned}`;
 }
 
+/** Append `account_id=<id>` to a URL, merging with any existing query, but
+ *  never duplicating a param the caller already set explicitly. */
+function withAccountId(url: string, accountId?: string): string {
+  if (!accountId) return url;
+  if (/[?&]account_id=/.test(url)) return url;
+  const sep = url.includes('?') ? '&' : '?';
+  return `${url}${sep}account_id=${encodeURIComponent(accountId)}`;
+}
+
 async function request<T>(
   method: string,
   path: string,
   body: unknown,
-  opts: { apiBase: string; token?: string },
+  opts: { apiBase: string; token?: string; accountId?: string },
 ): Promise<T> {
-  const url = joinUrl(opts.apiBase, path);
+  const url = withAccountId(joinUrl(opts.apiBase, path), opts.accountId);
   const headers: Record<string, string> = {};
   if (opts.token) headers['Authorization'] = `Bearer ${opts.token}`;
   if (body !== undefined) headers['Content-Type'] = 'application/json';
@@ -85,19 +99,31 @@ async function request<T>(
 
 export function createApiClient(opts: ClientOptions): ApiClient {
   const apiBase = opts.apiBase ?? 'https://api.kortix.com';
+  const accountId = opts.accountId || undefined;
+  const base = { apiBase, token: opts.token, accountId };
   return {
     apiBase,
-    get: <T>(path: string) => request<T>('GET', path, undefined, { apiBase, token: opts.token }),
-    post: <T>(path: string, body?: unknown) =>
-      request<T>('POST', path, body ?? {}, { apiBase, token: opts.token }),
-    put: <T>(path: string, body?: unknown) =>
-      request<T>('PUT', path, body ?? {}, { apiBase, token: opts.token }),
-    patch: <T>(path: string, body?: unknown) =>
-      request<T>('PATCH', path, body ?? {}, { apiBase, token: opts.token }),
-    delete: <T>(path: string) => request<T>('DELETE', path, undefined, { apiBase, token: opts.token }),
+    get: <T>(path: string) => request<T>('GET', path, undefined, base),
+    post: <T>(path: string, body?: unknown) => request<T>('POST', path, body ?? {}, base),
+    put: <T>(path: string, body?: unknown) => request<T>('PUT', path, body ?? {}, base),
+    patch: <T>(path: string, body?: unknown) => request<T>('PATCH', path, body ?? {}, base),
+    delete: <T>(path: string) => request<T>('DELETE', path, undefined, base),
   };
 }
 
-export function clientFromAuth(auth: Auth): ApiClient {
-  return createApiClient({ apiBase: auth.api_base, token: auth.token });
+export interface ClientFromAuthOptions {
+  /** Scope every request to this account via `?account_id=`. Opt-in: pass it
+   *  only for account-scoped LISTs (e.g. `projects ls`). Project-id routes
+   *  (`/projects/<id>/…`) already determine the account from the id, and
+   *  identity calls (`/accounts/me`) must stay account-agnostic — leave it
+   *  unset for those. */
+  accountId?: string;
+}
+
+export function clientFromAuth(auth: Auth, opts: ClientFromAuthOptions = {}): ApiClient {
+  return createApiClient({
+    apiBase: auth.api_base,
+    token: auth.token,
+    accountId: opts.accountId || undefined,
+  });
 }

--- a/apps/cli/src/api/config.ts
+++ b/apps/cli/src/api/config.ts
@@ -60,13 +60,35 @@ const LEGACY_DEV_HOST_NAME = 'dev'; // → local-dev (localhost:8008)
 const LEGACY_LOCAL_HOST_NAME = 'local'; // → selfhost (localhost:13738)
 const LEGACY_LOCAL_API_BASE = 'http://localhost:13738';
 
+/** The global default project for a host — used by every project-scoped
+ *  command (executor, connectors, sessions, …) when the cwd is not bound
+ *  to a project via `.kortix/link.json`. Carries its account_id so the
+ *  default always resolves under the right account. */
+export interface DefaultProjectRef {
+  project_id: string;
+  account_id: string;
+  name?: string;
+}
+
 export interface Host {
   url: string;
   token: string;
   user_id: string;
   user_email: string;
+  /** The host's active account id — every account-scoped call defaults to it. */
   account_id: string;
+  /** Active account display fields, captured at login / `accounts use`. */
+  account_slug?: string;
+  account_name?: string;
+  /** Global default project for this host (see DefaultProjectRef). */
+  default_project?: DefaultProjectRef;
   logged_in_at: string;
+}
+
+export interface ActiveAccount {
+  id: string;
+  slug: string;
+  name: string;
 }
 
 export interface Config {
@@ -237,6 +259,83 @@ export function activeHostName(): string | null {
   return config.hosts[config.active] ? config.active : null;
 }
 
+// ─── Active account + default project ───────────────────────────────────────
+
+/** The active account for the current invocation (the active host's
+ *  stored account), or null when there's no host / no account yet (e.g.
+ *  inside a sandbox, where the env host carries no account). */
+export function activeAccount(): ActiveAccount | null {
+  const host = activeHost();
+  if (!host || !host.account_id) return null;
+  return {
+    id: host.account_id,
+    slug: host.account_slug || host.account_id.slice(0, 8),
+    name: host.account_name || '',
+  };
+}
+
+/** The active host's global default project, or null when none is set. */
+export function defaultProject(): DefaultProjectRef | null {
+  const host = activeHost();
+  return host?.default_project ?? null;
+}
+
+/** Plain "Name (slug)" label, or just the slug when no name is known (a
+ *  pre-name-capture login). Avoids the ugly "slug (slug)" duplication. */
+export function accountLabel(a: { name?: string; slug: string }): string {
+  return a.name ? `${a.name} (${a.slug})` : a.slug;
+}
+
+/** Switch the active account on a host (default: the active host). A
+ *  default project that no longer lives in the active account is dropped —
+ *  the default must always be reachable under the active account. */
+export function setActiveAccount(
+  account: { id: string; slug?: string; name?: string },
+  hostName?: string,
+): void {
+  const config = loadConfig();
+  const name = resolveTargetHostName(config, hostName);
+  const host = config.hosts[name];
+  if (!host) return;
+  host.account_id = account.id;
+  host.account_slug = account.slug ?? account.id.slice(0, 8);
+  host.account_name = account.name ?? '';
+  if (host.default_project && host.default_project.account_id !== account.id) {
+    delete host.default_project;
+  }
+  saveConfig(config);
+}
+
+/** Set the global default project on a host (default: the active host). */
+export function setDefaultProject(project: DefaultProjectRef, hostName?: string): void {
+  const config = loadConfig();
+  const name = resolveTargetHostName(config, hostName);
+  const host = config.hosts[name];
+  if (!host) return;
+  host.default_project = {
+    project_id: project.project_id,
+    account_id: project.account_id,
+    ...(project.name ? { name: project.name } : {}),
+  };
+  saveConfig(config);
+}
+
+/** Clear the global default project. Returns true if one was removed. */
+export function clearDefaultProject(hostName?: string): boolean {
+  const config = loadConfig();
+  const name = resolveTargetHostName(config, hostName);
+  const host = config.hosts[name];
+  if (!host?.default_project) return false;
+  delete host.default_project;
+  saveConfig(config);
+  return true;
+}
+
+function resolveTargetHostName(config: Config, hostName?: string): string {
+  if (hostName) return hostName;
+  return config.hosts[config.active] ? config.active : DEFAULT_HOST_NAME;
+}
+
 // ─── Mutations ────────────────────────────────────────────────────────────
 
 export function upsertHost(name: string, host: Host, makeActive = false): void {
@@ -309,6 +408,11 @@ function normalizeConfig(parsed: Partial<Config>): Config {
       user_email: h.user_email ?? '',
       account_id: h.account_id ?? '',
       logged_in_at: h.logged_in_at ?? new Date().toISOString(),
+      // New optional fields — carried through verbatim when present so an
+      // older config (without them) still loads, and a newer one round-trips.
+      ...(typeof h.account_slug === 'string' ? { account_slug: h.account_slug } : {}),
+      ...(typeof h.account_name === 'string' ? { account_name: h.account_name } : {}),
+      ...(isDefaultProjectRef(h.default_project) ? { default_project: h.default_project } : {}),
     };
   }
   // Tracks which old names were folded into new ones so we can retarget the
@@ -369,6 +473,12 @@ function normalizeConfig(parsed: Partial<Config>): Config {
     active = cleaned[DEFAULT_HOST_NAME] ? DEFAULT_HOST_NAME : Object.keys(cleaned)[0]!;
   }
   return { active, hosts: cleaned };
+}
+
+function isDefaultProjectRef(value: unknown): value is DefaultProjectRef {
+  if (!value || typeof value !== 'object') return false;
+  const v = value as Record<string, unknown>;
+  return typeof v.project_id === 'string' && typeof v.account_id === 'string';
 }
 
 function defaultHost(url: string): Host {

--- a/apps/cli/src/commands/accounts.ts
+++ b/apps/cli/src/commands/accounts.ts
@@ -1,0 +1,267 @@
+import { loadAuth } from '../api/auth.ts';
+import {
+  accountLabel,
+  activeAccount,
+  defaultProject,
+  setActiveAccount,
+} from '../api/config.ts';
+import { ApiError, clientFromAuth } from '../api/client.ts';
+import { selectFromList } from '../tui-select.ts';
+import { emitJson, takeFlagBool } from '../command-helpers.ts';
+import { C, pad, status } from '../style.ts';
+import type { AccountMembership, MeResponse } from '../api/types.ts';
+
+const HELP = `Usage: kortix accounts <subcommand> [options]
+
+One Kortix login can belong to many accounts (your personal account, a
+company account, …). Exactly one is "active" — every account-scoped
+command (\`projects ls\`, \`ship\`, …) operates on it unless overridden.
+
+Subcommands:
+  ls                   List the accounts you belong to (--json)
+  use [<slug|id>]      Switch the active account (interactive if omitted)
+  current              Print the active account (--json)
+  info [<slug|id>]     Show one account (defaults to the active one) (--json)
+
+Global options:
+  --json         Machine-readable JSON output (read subcommands).
+  -h, --help     Show this help.
+
+Examples:
+  kortix accounts ls
+  kortix accounts use kortix
+  kortix projects ls          # lists the active account's projects
+`;
+
+export async function runAccounts(argv: string[]): Promise<number> {
+  if (argv.length === 0 || argv[0] === '-h' || argv[0] === '--help') {
+    process.stdout.write(HELP);
+    return argv.length === 0 ? 2 : 0;
+  }
+
+  const sub = argv[0];
+  const rest = argv.slice(1);
+  switch (sub) {
+    case 'ls':
+    case 'list':
+      return accountsLs(takeFlagBool([...rest], ['--json']));
+    case 'use':
+    case 'switch':
+      return accountsUse(rest.find((a) => !a.startsWith('-')));
+    case 'current':
+      return accountsCurrent(takeFlagBool([...rest], ['--json']));
+    case 'info':
+    case 'show': {
+      const restCopy = [...rest];
+      const json = takeFlagBool(restCopy, ['--json']);
+      return accountsInfo(restCopy.find((a) => !a.startsWith('-')), json);
+    }
+    default:
+      process.stderr.write(`${status.err(`unknown subcommand "${sub}"`)}\n\n${HELP}`);
+      return 2;
+  }
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────
+
+function requireAuth() {
+  const auth = loadAuth();
+  if (!auth?.token) {
+    process.stderr.write(`${status.err('Not logged in. Run `kortix login`.')}\n`);
+    return null;
+  }
+  return auth;
+}
+
+/** Fetch the caller's account memberships. `/accounts/me` is identity-scoped,
+ *  so it stays unscoped (no account_id query param). */
+async function fetchAccounts(): Promise<{ me: MeResponse } | number> {
+  const auth = requireAuth();
+  if (!auth) return 1;
+  const client = clientFromAuth(auth);
+  try {
+    const me = await client.get<MeResponse>('/accounts/me');
+    return { me };
+  } catch (err) {
+    return surface(err);
+  }
+}
+
+function accountJson(a: AccountMembership, active: boolean) {
+  return {
+    account_id: a.account_id,
+    slug: a.slug,
+    name: a.name,
+    role: a.role,
+    personal_account: a.personal_account,
+    active,
+  };
+}
+
+// ── ls ─────────────────────────────────────────────────────────────────────
+
+async function accountsLs(json = false): Promise<number> {
+  const result = await fetchAccounts();
+  if (typeof result === 'number') return result;
+  const { me } = result;
+  const activeId = activeAccount()?.id ?? loadAuth()?.account_id ?? '';
+
+  if (json) {
+    emitJson(me.accounts.map((a) => accountJson(a, a.account_id === activeId)));
+    return 0;
+  }
+
+  if (me.accounts.length === 0) {
+    process.stdout.write(`${C.dim}You don't belong to any accounts.${C.reset}\n`);
+    return 0;
+  }
+
+  const nameW = Math.max(...me.accounts.map((a) => a.name.length), 4);
+  const slugW = Math.max(...me.accounts.map((a) => a.slug.length), 4);
+  process.stdout.write('\n');
+  process.stdout.write(
+    `  ${C.dim}${pad('   NAME', nameW + 3)}   ${pad('SLUG', slugW)}   ROLE${C.reset}\n`,
+  );
+  for (const a of me.accounts) {
+    const mark = a.account_id === activeId ? `${C.green}● ${C.reset}` : '  ';
+    process.stdout.write(
+      `${mark}${pad(a.name, nameW)}   ${pad(a.slug, slugW)}   ${C.faded}${a.role}${C.reset}\n`,
+    );
+  }
+  const active = me.accounts.find((a) => a.account_id === activeId);
+  process.stdout.write(`\n  ${C.green}●${C.reset}${C.dim} active${C.reset}`);
+  if (active) {
+    process.stdout.write(`${C.dim}: ${C.reset}${C.bold}${active.name}${C.reset}`);
+  }
+  process.stdout.write(
+    `\n  ${C.dim}Switch with ${C.reset}${C.cyan}kortix accounts use <slug>${C.reset}\n\n`,
+  );
+  return 0;
+}
+
+// ── use ──────────────────────────────────────────────────────────────────
+
+async function accountsUse(arg?: string): Promise<number> {
+  const result = await fetchAccounts();
+  if (typeof result === 'number') return result;
+  const { me } = result;
+  if (me.accounts.length === 0) {
+    process.stderr.write(`${status.err('You don\'t belong to any accounts.')}\n`);
+    return 1;
+  }
+
+  let target: AccountMembership | undefined;
+  if (arg) {
+    target = me.accounts.find((a) => a.account_id === arg || a.slug === arg);
+    if (!target) {
+      const known = me.accounts.map((a) => a.slug).join(', ');
+      process.stderr.write(
+        `${status.err(`No account "${arg}". You belong to: ${known}`)}\n`,
+      );
+      return 1;
+    }
+  } else {
+    const activeId = activeAccount()?.id ?? loadAuth()?.account_id ?? '';
+    const picked = await selectFromList<AccountMembership>({
+      title: 'Switch active account',
+      items: me.accounts.map((a) => ({
+        value: a,
+        label: a.account_id === activeId ? `${a.name}  ${C.green}●${C.reset}` : a.name,
+        sublabel: `${a.slug} · ${a.role}`,
+      })),
+      initialIndex: Math.max(0, me.accounts.findIndex((a) => a.account_id === activeId)),
+    });
+    if (!picked) {
+      process.stdout.write(`${C.dim}Cancelled.${C.reset}\n`);
+      return 0;
+    }
+    target = picked;
+  }
+
+  // Capture whether switching will orphan the current default project.
+  const prevDefault = defaultProject();
+  setActiveAccount({ id: target.account_id, slug: target.slug, name: target.name });
+
+  process.stdout.write(
+    `${status.ok(`Active account is now ${C.bold}${target.name}${C.reset} ${C.faded}(${target.slug}, ${target.role})${C.reset}`)}\n`,
+  );
+  if (prevDefault && prevDefault.account_id !== target.account_id) {
+    process.stdout.write(
+      `  ${C.dim}Cleared default project ${prevDefault.name ?? prevDefault.project_id} (it lived in another account).${C.reset}\n` +
+        `  ${C.dim}Set a new one with ${C.reset}${C.cyan}kortix projects use <id>${C.reset}\n`,
+    );
+  }
+  return 0;
+}
+
+// ── current ──────────────────────────────────────────────────────────────
+
+function accountsCurrent(json = false): number {
+  const auth = requireAuth();
+  if (!auth) return 1;
+  const active = activeAccount();
+  if (!active) {
+    if (json) {
+      emitJson(null);
+      return 0;
+    }
+    process.stderr.write(
+      `${status.err('No active account.')} Run ${C.cyan}kortix accounts use <slug>${C.reset}.\n`,
+    );
+    return 1;
+  }
+  if (json) {
+    emitJson({ account_id: active.id, slug: active.slug, name: active.name });
+    return 0;
+  }
+  process.stdout.write(`${accountLabel(active)}\n`);
+  return 0;
+}
+
+// ── info ───────────────────────────────────────────────────────────────────
+
+async function accountsInfo(arg?: string, json = false): Promise<number> {
+  const result = await fetchAccounts();
+  if (typeof result === 'number') return result;
+  const { me } = result;
+  const activeId = activeAccount()?.id ?? loadAuth()?.account_id ?? '';
+  const wanted = arg ?? activeId;
+  const a = me.accounts.find((x) => x.account_id === wanted || x.slug === wanted);
+  if (!a) {
+    process.stderr.write(`${status.err(`No account "${wanted}".`)}\n`);
+    return 1;
+  }
+  if (json) {
+    emitJson(accountJson(a, a.account_id === activeId));
+    return 0;
+  }
+  process.stdout.write('\n');
+  process.stdout.write(
+    `  ${C.bold}${a.name}${C.reset}${a.account_id === activeId ? `  ${C.green}● active${C.reset}` : ''}\n`,
+  );
+  process.stdout.write(`  ${C.dim}slug       ${C.reset}${a.slug}\n`);
+  process.stdout.write(`  ${C.dim}account_id ${C.reset}${a.account_id}\n`);
+  process.stdout.write(`  ${C.dim}role       ${C.reset}${a.role}\n`);
+  if (a.personal_account) {
+    process.stdout.write(`  ${C.dim}personal   ${C.reset}yes\n`);
+  }
+  process.stdout.write('\n');
+  return 0;
+}
+
+// ── error surface ──────────────────────────────────────────────────────────
+
+function surface(err: unknown): number {
+  if (err instanceof ApiError) {
+    if (err.status === 401) {
+      process.stderr.write(
+        `${status.err('Token rejected. Run `kortix login` to re-authenticate.')}\n`,
+      );
+    } else {
+      process.stderr.write(`${status.err(`HTTP ${err.status}: ${err.message}`)}\n`);
+    }
+    return 1;
+  }
+  process.stderr.write(`${status.err((err as Error).message)}\n`);
+  return 1;
+}

--- a/apps/cli/src/commands/login.ts
+++ b/apps/cli/src/commands/login.ts
@@ -6,6 +6,7 @@ import {
   DEFAULT_HOST_NAME,
   activeHostName,
   getHost,
+  setActiveAccount,
   validateHostName,
 } from '../api/config.ts';
 import { ApiError, createApiClient } from '../api/client.ts';
@@ -147,6 +148,14 @@ export async function runLogin(argv: string[]): Promise<number> {
     },
     /* makeActive */ true,
   );
+  // Persist the active account's display fields (and reconcile any default
+  // project) so the context block + `accounts ls` read correctly offline.
+  if (primary) {
+    setActiveAccount(
+      { id: primary.account_id, slug: primary.slug, name: primary.name },
+      hostName,
+    );
+  }
 
   process.stdout.write(
     `\n${status.ok(`Logged in to host ${C.bold}${hostName}${C.reset} as ${C.bold}${me.email || me.user_id}${C.reset}`)}\n`,

--- a/apps/cli/src/commands/projects.ts
+++ b/apps/cli/src/commands/projects.ts
@@ -1,6 +1,13 @@
 import { spawnSync } from 'node:child_process';
 import { loadAuth } from '../api/auth.ts';
-import { activeHostName } from '../api/config.ts';
+import {
+  activeAccount,
+  activeHostName,
+  clearDefaultProject,
+  defaultProject,
+  setActiveAccount,
+  setDefaultProject,
+} from '../api/config.ts';
 import { ApiError, clientFromAuth } from '../api/client.ts';
 import { confirm } from '../prompts.ts';
 import {
@@ -14,19 +21,27 @@ import { selectFromList } from '../tui-select.ts';
 import { emitJson, takeFlagBool } from '../command-helpers.ts';
 import { C, pad, status } from '../style.ts';
 import { projectWebUrl } from '../web-url.ts';
-import type { ProjectSummary } from '../api/types.ts';
+import type { Auth } from '../api/auth.ts';
+import type { AccountMembership, MeResponse, ProjectSummary } from '../api/types.ts';
 
 const HELP = `Usage: kortix projects <subcommand>
 
 Subcommands:
-  ls                   List projects in your active account (--json)
-  info [<id>]          Show one project (defaults to the linked one) (--json)
+  ls [--all]           List projects in the active account (--all spans every
+                       account, grouped). (--json)
+  info [<id>]          Show one project (defaults to the linked/default) (--json)
+  use [<id>]           Set the global DEFAULT project (interactive if omitted).
+                       Switches the active account to the project's account.
+  unset                Clear the global default project.
   link [<id>]          Bind cwd to a remote project (writes .kortix/link.json)
   unlink               Remove .kortix/link.json from cwd
   open [<id>]          Open the dashboard URL for one project
   rm [<id>]            Archive a project (defaults to the linked one).
                        --purge also deletes its managed git repo (irreversible).
                        -y / --yes skips the confirmation.
+
+A directory link (.kortix/link.json) always wins over the default; the
+default is what commands use anywhere else on your machine.
 
 Run \`kortix projects <subcommand> --help\` for options.
 `;
@@ -42,14 +57,22 @@ export async function runProjects(argv: string[]): Promise<number> {
   switch (sub) {
     case 'ls':
     case 'list': {
-      const json = takeFlagBool([...rest], ['--json']);
-      return projectsLs(json);
+      const restCopy = [...rest];
+      const all = takeFlagBool(restCopy, ['--all', '-a']);
+      const json = takeFlagBool(restCopy, ['--json']);
+      return projectsLs(json, all);
     }
     case 'info': {
       const restCopy = [...rest];
       const json = takeFlagBool(restCopy, ['--json']);
       return projectsInfo(restCopy[0], json);
     }
+    case 'use':
+    case 'default':
+      return projectsUse(rest.find((a) => !a.startsWith('-')));
+    case 'unset':
+    case 'clear':
+      return projectsUnset();
     case 'link':
       return projectsLink(rest[0]);
     case 'unlink':
@@ -74,11 +97,21 @@ function requireAuth() {
   return auth;
 }
 
-async function projectsLs(json = false): Promise<number> {
+/** The account `projects ls` should be scoped to: the active account, falling
+ *  back to the host's stored account id. Undefined lets the server pick its
+ *  earliest-joined-account default (pre-feature behavior). */
+function scopeAccountId(auth: Auth): string | undefined {
+  return activeAccount()?.id ?? auth.account_id ?? undefined;
+}
+
+async function projectsLs(json = false, all = false): Promise<number> {
   const auth = requireAuth();
   if (!auth) return 1;
-  const client = clientFromAuth(auth);
+  if (all) return projectsLsAll(auth, json);
 
+  // Scope to the active account so this lists exactly that account's projects
+  // (not the server's earliest-joined-account default).
+  const client = clientFromAuth(auth, { accountId: scopeAccountId(auth) });
   let projects: ProjectSummary[];
   try {
     projects = await client.get<ProjectSummary[]>('/projects');
@@ -91,27 +124,124 @@ async function projectsLs(json = false): Promise<number> {
     return 0;
   }
 
+  const acct = activeAccount();
+  const linked = loadLink()?.project_id;
+  const def = defaultProject()?.project_id;
+
+  process.stdout.write('\n');
+  if (acct) {
+    const label = acct.name
+      ? `${C.bold}${acct.name}${C.reset} ${C.faded}(${acct.slug})${C.reset}`
+      : `${C.bold}${acct.slug}${C.reset}`;
+    process.stdout.write(`  ${C.dim}account  ${C.reset}${label}\n\n`);
+  }
+
   if (projects.length === 0) {
-    process.stdout.write(`${C.dim}No projects in this account.${C.reset}\n`);
+    process.stdout.write(`  ${C.dim}No projects in this account.${C.reset}\n\n`);
     return 0;
   }
 
+  renderProjectTable(projects, { linked, def });
+  process.stdout.write(
+    `\n  ${C.dim}${projects.length} project${projects.length === 1 ? '' : 's'}` +
+      `${acct ? ` in ${acct.name || acct.slug}` : ''} · spans all accounts: ${C.reset}` +
+      `${C.cyan}kortix projects ls --all${C.reset}\n\n`,
+  );
+  return 0;
+}
+
+async function projectsLsAll(auth: Auth, json = false): Promise<number> {
+  let me: MeResponse;
+  try {
+    me = await clientFromAuth(auth).get<MeResponse>('/accounts/me');
+  } catch (err) {
+    return surface(err);
+  }
+
+  const activeId = activeAccount()?.id ?? auth.account_id;
   const linked = loadLink()?.project_id;
+  const def = defaultProject()?.project_id;
+
+  const sections: { account: AccountMembership; projects: ProjectSummary[] }[] = [];
+  for (const a of me.accounts) {
+    let projects: ProjectSummary[] = [];
+    try {
+      projects = await clientFromAuth(auth, { accountId: a.account_id }).get<ProjectSummary[]>(
+        '/projects',
+      );
+    } catch {
+      /* skip accounts we can't read; leave the section empty */
+    }
+    sections.push({ account: a, projects });
+  }
+
+  if (json) {
+    emitJson(
+      sections.map((s) => ({
+        account: {
+          account_id: s.account.account_id,
+          slug: s.account.slug,
+          name: s.account.name,
+          role: s.account.role,
+          active: s.account.account_id === activeId,
+        },
+        projects: s.projects,
+      })),
+    );
+    return 0;
+  }
+
+  let total = 0;
+  for (const s of sections) {
+    const activeMark =
+      s.account.account_id === activeId ? `   ${C.green}← active${C.reset}` : '';
+    process.stdout.write('\n');
+    process.stdout.write(
+      `  ${C.bold}${s.account.name || s.account.slug}${C.reset} ${C.faded}(${s.account.slug}, ${s.account.role})${C.reset}${activeMark}\n`,
+    );
+    if (s.projects.length === 0) {
+      process.stdout.write(`  ${C.dim}— no projects${C.reset}\n`);
+      continue;
+    }
+    renderProjectTable(s.projects, { linked, def });
+    total += s.projects.length;
+  }
+  process.stdout.write(
+    `\n  ${C.dim}${total} project${total === 1 ? '' : 's'} across ${me.accounts.length} ` +
+      `account${me.accounts.length === 1 ? '' : 's'}${C.reset}\n\n`,
+  );
+  return 0;
+}
+
+/** Render a project table. `●` marks the global default, `◆` the cwd's
+ *  directory link; a trailing tag spells it out. */
+function renderProjectTable(
+  projects: ProjectSummary[],
+  marks: { linked?: string; def?: string },
+): void {
   const nameW = Math.max(...projects.map((p) => p.name.length), 4);
-  process.stdout.write('\n');
   process.stdout.write(
     `  ${C.dim}${pad('NAME', nameW)}   ${pad('REPO', 40)}   BRANCH    UPDATED${C.reset}\n`,
   );
   for (const p of projects) {
-    const marker = p.project_id === linked ? `${C.green}● ${C.reset}` : '  ';
+    const isDefault = p.project_id === marks.def;
+    const isLinked = p.project_id === marks.linked;
+    const marker = isDefault
+      ? `${C.green}● ${C.reset}`
+      : isLinked
+        ? `${C.cyan}◆ ${C.reset}`
+        : '  ';
+    const tag = isDefault
+      ? `   ${C.green}default${C.reset}`
+      : isLinked
+        ? `   ${C.cyan}linked${C.reset}`
+        : '';
     const repo = trimMid(p.repo_url, 40);
     const updated = formatRelative(p.updated_at);
     process.stdout.write(
-      `${marker}${pad(p.name, nameW)}   ${pad(repo, 40)}   ${pad(p.default_branch, 8)}  ${C.faded}${updated}${C.reset}\n`,
+      `${marker}${pad(p.name, nameW)}   ${pad(repo, 40)}   ${pad(p.default_branch, 8)}  ${C.faded}${updated}${C.reset}${tag}\n`,
     );
   }
-  process.stdout.write(`\n  ${C.dim}${projects.length} project${projects.length === 1 ? '' : 's'}${C.reset}\n\n`);
-  return 0;
 }
 
 async function projectsInfo(arg?: string, json = false): Promise<number> {
@@ -144,6 +274,99 @@ async function projectsInfo(arg?: string, json = false): Promise<number> {
   process.stdout.write(`  ${C.dim}manifest   ${C.reset}${p.manifest_path}\n`);
   process.stdout.write(`  ${C.dim}status     ${C.reset}${p.status}\n`);
   process.stdout.write(`  ${C.dim}updated    ${C.reset}${formatRelative(p.updated_at)}\n\n`);
+  return 0;
+}
+
+async function projectsUse(arg?: string): Promise<number> {
+  const auth = requireAuth();
+  if (!auth) return 1;
+
+  let target: ProjectSummary | null = null;
+  if (arg) {
+    // An explicit id may live in any account — resolve it unscoped.
+    try {
+      target = await clientFromAuth(auth).get<ProjectSummary>(`/projects/${arg}`);
+    } catch (err) {
+      return surface(err);
+    }
+  } else {
+    // Pick from the active account's projects.
+    let list: ProjectSummary[];
+    try {
+      list = await clientFromAuth(auth, { accountId: scopeAccountId(auth) }).get<ProjectSummary[]>(
+        '/projects',
+      );
+    } catch (err) {
+      return surface(err);
+    }
+    if (list.length === 0) {
+      process.stderr.write(
+        `${status.err('No projects in the active account.')} Switch with \`kortix accounts use\`.\n`,
+      );
+      return 1;
+    }
+    const picked = await selectFromList<ProjectSummary>({
+      title: 'Set the global default project',
+      items: list.map((p) => ({ value: p, label: p.name, sublabel: p.project_id })),
+    });
+    if (!picked) {
+      process.stdout.write(`${C.dim}Cancelled.${C.reset}\n`);
+      return 0;
+    }
+    target = picked;
+  }
+
+  if (!target) {
+    process.stderr.write(`${status.err('Could not resolve a project.')}\n`);
+    return 1;
+  }
+
+  // A default project pins its account. If it lives in a different account
+  // than the active one, switch the active account to it (resolving the
+  // account's display name best-effort) before recording the default.
+  const switched = target.account_id !== (activeAccount()?.id ?? auth.account_id);
+  let accountLabel = target.account_id.slice(0, 8);
+  if (switched) {
+    let slug = target.account_id.slice(0, 8);
+    let name: string | undefined;
+    try {
+      const me = await clientFromAuth(auth).get<MeResponse>('/accounts/me');
+      const m = me.accounts.find((a) => a.account_id === target!.account_id);
+      if (m) {
+        slug = m.slug;
+        name = m.name;
+      }
+    } catch {
+      /* fall back to the truncated id */
+    }
+    setActiveAccount({ id: target.account_id, slug, name });
+    accountLabel = name ? `${name} (${slug})` : slug;
+  }
+  setDefaultProject({
+    project_id: target.project_id,
+    account_id: target.account_id,
+    name: target.name,
+  });
+
+  process.stdout.write(`${status.ok(`Default project: ${C.bold}${target.name}${C.reset}`)}\n`);
+  if (switched) {
+    process.stdout.write(`  ${C.dim}account → ${C.reset}${accountLabel} ${C.dim}(now active)${C.reset}\n`);
+  }
+  process.stdout.write(
+    `  ${C.dim}Used by connectors/executor/sessions when a directory isn't linked.${C.reset}\n`,
+  );
+  return 0;
+}
+
+async function projectsUnset(): Promise<number> {
+  const existing = defaultProject();
+  if (clearDefaultProject()) {
+    process.stdout.write(
+      `${status.ok(`Cleared the default project${existing?.name ? ` ${C.dim}(was ${existing.name})${C.reset}` : ''}`)}\n`,
+    );
+  } else {
+    process.stdout.write(`${C.dim}No default project set. Nothing to do.${C.reset}\n`);
+  }
   return 0;
 }
 

--- a/apps/cli/src/commands/whoami.ts
+++ b/apps/cli/src/commands/whoami.ts
@@ -1,5 +1,5 @@
 import { loadAuth, loadAuthForHost } from '../api/auth.ts';
-import { activeHostName, listHosts } from '../api/config.ts';
+import { activeHostName, defaultProject, listHosts } from '../api/config.ts';
 import { ApiError, clientFromAuth } from '../api/client.ts';
 import { emitJson } from '../command-helpers.ts';
 import { C, status } from '../style.ts';
@@ -86,6 +86,9 @@ export async function runWhoami(argv: string[]): Promise<number> {
 
   const resolvedHost = flags.host ?? activeHostName();
   const active = me.accounts.find((a) => a.account_id === auth.account_id) ?? me.accounts[0];
+  // Default project is read from the active host only (a --host probe shows
+  // the other host's identity, not this machine's active default).
+  const def = flags.host ? null : defaultProject();
 
   if (flags.json) {
     emitJson({
@@ -97,6 +100,7 @@ export async function runWhoami(argv: string[]): Promise<number> {
       account: active ?? null,
       accounts: me.accounts,
       token_context: me.token_context ?? null,
+      default_project: def,
     });
     return 0;
   }
@@ -134,7 +138,12 @@ export async function runWhoami(argv: string[]): Promise<number> {
   }
   if (me.accounts.length > 1) {
     process.stdout.write(
-      `  ${C.dim}${me.accounts.length} accounts total — target one with ${C.reset}${C.cyan}kortix ship --account <slug>${C.reset}\n`,
+      `  ${C.dim}${me.accounts.length} accounts total — switch with ${C.reset}${C.cyan}kortix accounts use <slug>${C.reset}\n`,
+    );
+  }
+  if (def) {
+    process.stdout.write(
+      `  ${C.dim}project   ${C.reset}${def.name || def.project_id} ${C.faded}(default)${C.reset}\n`,
     );
   }
   process.stdout.write(`  ${C.dim}host      ${C.reset}${resolvedHost ?? '—'} ${C.faded}(${auth.api_base})${C.reset}\n`);

--- a/apps/cli/src/host-notice.ts
+++ b/apps/cli/src/host-notice.ts
@@ -1,10 +1,13 @@
 import {
+  activeAccount,
   activeHostEntry,
+  defaultProject,
   getHost,
   hasEnvTokenHost,
   type Host,
 } from './api/config.ts';
-import { C } from './style.ts';
+import { loadLink } from './project-link.ts';
+import { C, pad } from './style.ts';
 
 export interface HostNotice {
   name: string;
@@ -53,6 +56,73 @@ export function resolveHostNotice(hostArg?: string): HostNotice {
 export function renderHostNotice(commandArgv: readonly string[]): string | null {
   const command = commandArgv[0];
   if (!command || ['help', '--help', '-h', 'version'].includes(command)) return null;
-  const notice = resolveHostNotice(findHostArg(commandArgv.slice(1)));
-  return `${C.dim}host ${C.reset}${C.bold}${notice.name}${C.reset}${C.dim} (${notice.url}, ${notice.authState})${C.reset}\n`;
+  const hostArg = findHostArg(commandArgv.slice(1));
+  const notice = resolveHostNotice(hostArg);
+  let line = `${C.dim}host ${C.reset}${C.bold}${notice.name}${C.reset}${C.dim} (${notice.url}, ${notice.authState})${C.reset}`;
+  // Append account + project for the active host only. With an explicit
+  // `--host`, the active-config account/project may belong to a different
+  // host, so we don't claim them.
+  if (!hostArg) {
+    const acct = activeAccountLabel();
+    if (acct) line += `${C.dim} · account ${C.reset}${acct}`;
+    const proj = activeProjectLabel();
+    if (proj) line += `${C.dim} · project ${C.reset}${proj.label}${C.dim} (${proj.source})${C.reset}`;
+  }
+  return `${line}\n`;
+}
+
+/** Active account as a short display string, or null when none/sandbox. */
+function activeAccountLabel(): string | null {
+  const acct = activeAccount();
+  if (!acct) return null;
+  return acct.name || acct.slug;
+}
+
+/** Active project: the cwd's directory link wins over the global default. */
+function activeProjectLabel(): { label: string; source: 'linked' | 'default' } | null {
+  const link = loadLink();
+  if (link?.project_id) {
+    return { label: shortId(link.project_id), source: 'linked' };
+  }
+  const def = defaultProject();
+  if (def) return { label: def.name || shortId(def.project_id), source: 'default' };
+  return null;
+}
+
+function shortId(id: string): string {
+  return id.length > 8 ? id.slice(0, 8) : id;
+}
+
+/**
+ * A compact context block for the bare-`kortix` landing screen: which
+ * host / account / project every command will act on. All local reads
+ * (config + cwd link) — no network, no latency.
+ */
+export function renderContext(): string {
+  const { name, host } = activeHostEntry();
+  const authState = hostAuthState(host, hasEnvTokenHost() ? 'env' : 'stored');
+  const acct = activeAccount();
+  const proj = activeProjectLabel();
+  const labelW = 7; // "account".length
+  const rows: string[] = [];
+  rows.push(
+    `  ${C.dim}${pad('host', labelW)}${C.reset}  ${C.bold}${name}${C.reset}  ${C.faded}(${host.url}, ${authState})${C.reset}`,
+  );
+  rows.push(
+    `  ${C.dim}${pad('account', labelW)}${C.reset}  ${
+      acct
+        ? acct.name
+          ? `${C.bold}${acct.name}${C.reset}  ${C.faded}(${acct.slug})${C.reset}`
+          : `${C.bold}${acct.slug}${C.reset}`
+        : `${C.faded}— none (run \`kortix accounts use\`)${C.reset}`
+    }`,
+  );
+  rows.push(
+    `  ${C.dim}${pad('project', labelW)}${C.reset}  ${
+      proj
+        ? `${C.bold}${proj.label}${C.reset}  ${C.faded}(${proj.source})${C.reset}`
+        : `${C.faded}— none (run \`kortix projects use\`)${C.reset}`
+    }`,
+  );
+  return rows.join('\n') + '\n';
 }

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env bun
 import { runAccess } from './commands/access.ts';
+import { runAccounts } from './commands/accounts.ts';
 import { runApps } from './commands/apps.ts';
 import { runChannels } from './commands/channels.ts';
 import { runConnectors } from './commands/connectors.ts';
@@ -30,7 +31,7 @@ import { runValidate } from './commands/validate.ts';
 import { runWhoami } from './commands/whoami.ts';
 import { printBanner } from './banner.ts';
 import { getUpdateNotice } from './update-check.ts';
-import { renderHostNotice } from './host-notice.ts';
+import { renderContext, renderHostNotice } from './host-notice.ts';
 import { C, header, pad, rule } from './style.ts';
 
 // CI bakes the real version via --define process.env.KORTIX_CLI_VERSION (the
@@ -56,7 +57,8 @@ const COMMANDS: readonly Command[] = [
   { name: 'whoami', blurb: 'Show the currently authenticated user' },
   { name: 'token', blurb: 'Show the active token context (project/session/agent grants)' },
   { name: 'hosts', args: '<subcommand>', blurb: 'Manage + switch Kortix API hosts' },
-  { name: 'projects', args: '<subcommand>', blurb: 'List, link, open Kortix cloud projects' },
+  { name: 'accounts', args: '<subcommand>', blurb: 'List + switch the active account (multi-account logins)' },
+  { name: 'projects', args: '<subcommand>', blurb: 'List, link, set-default, open Kortix cloud projects' },
   { name: 'secrets', args: '<subcommand>', blurb: 'Manage project secrets (project-scoped)' },
   { name: 'env', args: '<subcommand>', blurb: 'Pull/push project secrets as a dotenv file' },
   { name: 'sessions', args: '<subcommand>', blurb: 'List, create, restart project sessions' },
@@ -113,6 +115,8 @@ async function main(argv: string[]): Promise<number> {
   if (argv.length === 0) {
     // No args — show the big ASCII banner above the help, like `vercel`.
     printBanner();
+    // Always surface what host/account/project commands will act on.
+    process.stdout.write(`${renderContext()}\n`);
     const notice = await getUpdateNotice(VERSION, { allowFetch: true, style: 'box' });
     if (notice) process.stdout.write(`${notice}\n`);
     process.stdout.write(renderHelp());
@@ -167,6 +171,9 @@ async function main(argv: string[]): Promise<number> {
   }
   if (argv[0] === 'hosts') {
     return runHosts(argv.slice(1));
+  }
+  if (argv[0] === 'accounts') {
+    return runAccounts(argv.slice(1));
   }
   if (argv[0] === 'secrets') {
     return runSecrets(argv.slice(1));
@@ -230,7 +237,6 @@ async function main(argv: string[]): Promise<number> {
   // through to the project scaffold (`kortix <new-project-name>`), which
   // would otherwise create a directory called `deploy/`, etc.
   const RESERVED_FUTURE_COMMANDS = new Set([
-    'accounts',
     'add',
     'mcp',
     'logs',
@@ -266,10 +272,27 @@ async function printUpdateNoticeForCommand(command: string): Promise<void> {
   if (notice) process.stderr.write(`${notice}\n`);
 }
 
+// `process.exit()` does NOT wait for a piped stdout/stderr to flush — on large
+// output (e.g. `kortix projects ls --all --json | jq`, or executor JSON the
+// in-sandbox agent parses) it drops everything past the ~64KiB pipe buffer,
+// producing truncated/invalid output. Instead set the exit code and let the
+// runtime flush both streams and exit naturally. Release stdin first so an
+// interactive raw-mode read (tui-select / prompts) can't keep the event loop
+// alive after the command is done.
+function finish(code: number): void {
+  process.exitCode = code;
+  try {
+    process.stdin.pause();
+    (process.stdin as unknown as { unref?: () => void }).unref?.();
+  } catch {
+    /* stdin may not support pause/unref in every environment */
+  }
+}
+
 main(process.argv.slice(2))
-  .then((code) => process.exit(code))
+  .then((code) => finish(code))
   .catch((err: unknown) => {
     const msg = err instanceof Error ? err.message : String(err);
     process.stderr.write(`${C.red}kortix:${C.reset} ${msg}\n`);
-    process.exit(1);
+    finish(1);
   });

--- a/apps/cli/src/project-link.ts
+++ b/apps/cli/src/project-link.ts
@@ -1,5 +1,6 @@
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
+import { defaultProject } from './api/config.ts';
 import { sandboxEnvValue } from './api/sandbox-env.ts';
 
 /**
@@ -75,8 +76,9 @@ export function clearLink(cwd = process.cwd()): void {
 /**
  * Resolve which project a CLI command should operate on, in order:
  *   1. --project / projectArg
- *   2. KORTIX_PROJECT_ID env
- *   3. .kortix/link.json in cwd
+ *   2. KORTIX_PROJECT_ID env (platform-injected inside a sandbox)
+ *   3. .kortix/link.json in cwd (per-repo binding)
+ *   4. the active host's global default project (`kortix projects use`)
  * Returns null if none of those are set.
  */
 export function resolveProjectId(projectArg?: string): string | null {
@@ -84,5 +86,6 @@ export function resolveProjectId(projectArg?: string): string | null {
   const envProjectId = sandboxEnvValue('KORTIX_PROJECT_ID');
   if (envProjectId) return envProjectId;
   const link = loadLink();
-  return link?.project_id ?? null;
+  if (link?.project_id) return link.project_id;
+  return defaultProject()?.project_id ?? null;
 }


### PR DESCRIPTION
## Why

Running the `kortix` CLI against multiple cloud accounts was confusing and partly invisible:

- **One login can belong to many accounts**, but the CLI had no account model — it pinned one `account_id` at login with no way to see or switch it.
- **`kortix projects ls` silently showed only ONE account's projects.** The CLI never sent an account id, so the server fell back to the *earliest-joined* account — which didn't even match what `whoami` called the "active account". Projects in every other account were invisible.
- **Bare `kortix` showed no context** about which host/account/project commands would act on.

## What

Make the CLI's **host → account → project** context explicit, switchable, and always shown. Exactly one of each is active; a directory link (`.kortix/link.json`) still overrides per-repo.

- **`kortix accounts`** (new): `ls` / `use` / `current` / `info` — mirrors `hosts`. One active account per host, captured at login and on `accounts use` (and it heals the display name for pre-existing logins).
- **`kortix projects`**: `ls` is now scoped to the active account (account header + `●` default / `◆` linked markers); `ls --all` lists every account grouped. New **`projects use`** sets a global default project *and* switches the active account to that project's account; **`projects unset`** clears it.
- The **default project** is wired into `resolveProjectId()` as the fallback after a directory link, so `executor` / `connectors` / `sessions` use it outside a linked repo.
- **Context** is always visible: bare `kortix` prints a host/account/project block; the subcommand one-liner and `whoami` show account + default project.
- Account scoping is **opt-in** on the client (only `projects ls` sends `?account_id=`), so project-id routes and `/accounts/me` are untouched. No server changes — the API already supports `account_id` scoping.

## Also: fix a latent piped-stdout truncation bug

`process.exit()` doesn't flush a piped stdout, so large `--json` output (e.g. `kortix projects ls --all --json | jq`, or executor JSON the in-sandbox agent parses) was silently truncated at the ~64 KiB pipe buffer — producing invalid JSON. Verified: `projects ls --all --json` was 180 KB to a file but exactly 65,536 bytes through a pipe. Fixed by setting `process.exitCode` and letting the streams flush naturally, releasing stdin so interactive reads can't hang. Now pipe == file, valid JSON.

## Testing

- New suites: account/default-project config + `resolveProjectId` fallback + `renderContext`; `accounts` and `projects use` command behavior. Updated the black-box expectation for the now account-scoped `projects ls`. **93/93 pass, typecheck clean.**
- Manually exercised end-to-end against the real cloud (isolated config): bare context, `accounts ls/use/current/info`, scoped `projects ls` + `ls --all`, `projects use` (same- and cross-account), `unset`, the `resolveProjectId` default fallback, error paths/exit codes, and the JSON pipe-integrity fix.