### PR TITLE
Recreate Rauch particle page with Kortix symbol

### DIFF
--- a/apps/web/src/app/rauch/kortix-particle-mark.tsx
+++ b/apps/web/src/app/rauch/kortix-particle-mark.tsx
@@ -1,18 +1,13 @@
 'use client';
 
 import { useEffect, useRef } from 'react';
-
-type Particle = {
-  x: number;
-  y: number;
-  vx: number;
-  vy: number;
-  hx: number;
-  hy: number;
-  delay: number;
-};
-
-const BRANDMARK_SRC = '/brandkit/Logo/Brandmark/SVG/Brandmark Black.svg';
+import {
+  advanceParticle,
+  BRANDMARK_SRC,
+  buildBrandmarkParticles,
+  getParticleMarkSize,
+  type Particle,
+} from './particle-mark';
 
 /**
  * A Rauch-style hard-pixel particle canvas that resolves into the Kortix
@@ -60,13 +55,13 @@ export function KortixParticleMark() {
       canvas.style.height = `${viewportHeight}px`;
       ctx.imageSmoothingEnabled = false;
 
-      const aspectRatio = brandmark.naturalWidth / brandmark.naturalHeight;
-      const targetWidthCss = Math.max(
-        132,
-        Math.min(244, viewportWidth * 0.54, viewportHeight * 0.7 * aspectRatio),
-      );
-      const targetWidth = Math.round(targetWidthCss * dpr);
-      const targetHeight = Math.round(targetWidth / aspectRatio);
+      const { width: targetWidth, height: targetHeight } = getParticleMarkSize({
+        sourceWidth: brandmark.naturalWidth,
+        sourceHeight: brandmark.naturalHeight,
+        viewportWidth,
+        viewportHeight,
+        dpr,
+      });
 
       const offscreen = document.createElement('canvas');
       offscreen.width = targetWidth;
@@ -81,28 +76,16 @@ export function KortixParticleMark() {
       const imageData = offscreenCtx.getImageData(0, 0, targetWidth, targetHeight);
       const offsetX = (canvas.width - targetWidth) / 2;
       const offsetY = (canvas.height - targetHeight) / 2;
-      const nextParticles: Particle[] = [];
-
-      for (let y = 0; y < targetHeight; y += particleStride) {
-        for (let x = 0; x < targetWidth; x += particleStride) {
-          const alpha = imageData.data[(y * targetWidth + x) * 4 + 3];
-          if (alpha <= 32) continue;
-
-          const hx = Math.round((offsetX + x) / particleStride) * particleStride;
-          const hy = Math.round((offsetY + y) / particleStride) * particleStride;
-          nextParticles.push({
-            x: hx,
-            y: -(Math.random() * canvas.height * 0.6 + 100 * dpr),
-            vx: 0,
-            vy: 0,
-            hx,
-            hy,
-            delay: ((targetHeight - y) / targetHeight) * 220 + Math.random() * 90,
-          });
-        }
-      }
-
-      particles = nextParticles;
+      particles = buildBrandmarkParticles({
+        targetWidth,
+        targetHeight,
+        particleStride,
+        offsetX,
+        offsetY,
+        canvasHeight: canvas.height,
+        dpr,
+        alphaAt: (x, y) => imageData.data[(y * targetWidth + x) * 4 + 3],
+      });
       sceneStartedAt = performance.now();
     };
 
@@ -111,61 +94,17 @@ export function KortixParticleMark() {
       ctx.clearRect(0, 0, canvas.width, canvas.height);
       ctx.fillStyle = '#000000';
 
-      const influenceRadius = 36 * dpr;
-      const influenceRadiusSquared = influenceRadius * influenceRadius;
-      const pointerForce = 2.6 * dpr;
-      const maxVelocity = 28 * dpr;
-      const homeForce = 0.02;
-      const fallGravity = 2.4 * dpr;
-
       for (const particle of particles) {
         if (elapsed < particle.delay) continue;
-
-        if (particle.y < particle.hy - 1 && elapsed < particle.delay + 900) {
-          particle.vy += fallGravity;
-          particle.vx += (particle.hx - particle.x) * homeForce;
-          particle.vx *= 0.86;
-          particle.x += particle.vx;
-          particle.y += particle.vy;
-
-          if (particle.y >= particle.hy) {
-            particle.x = particle.hx;
-            particle.y = particle.hy;
-            particle.vx = 0;
-            particle.vy = 0;
-          }
-        } else {
-          const dx = particle.x - pointerX;
-          const dy = particle.y - pointerY;
-          const distanceSquared = dx * dx + dy * dy;
-
-          if (isPointerActive && distanceSquared < influenceRadiusSquared) {
-            const distance = Math.sqrt(distanceSquared) || 0.0001;
-            const falloff = 1 - distance / influenceRadius;
-            const force = falloff * falloff;
-            particle.vx += (dx / distance) * force * pointerForce;
-            particle.vy += (dy / distance) * force * pointerForce;
-            particle.vx += pointerVelocityX * force * 0.9;
-            particle.vy += pointerVelocityY * force * 0.9;
-          } else {
-            particle.vx += (particle.hx - particle.x) * homeForce;
-            particle.vy += (particle.hy - particle.y) * homeForce;
-          }
-
-          particle.vx *= 0.86;
-          particle.vy *= 0.86;
-
-          const velocity = Math.sqrt(
-            particle.vx * particle.vx + particle.vy * particle.vy,
-          );
-          if (velocity > maxVelocity) {
-            particle.vx = (particle.vx / velocity) * maxVelocity;
-            particle.vy = (particle.vy / velocity) * maxVelocity;
-          }
-
-          particle.x += particle.vx;
-          particle.y += particle.vy;
-        }
+        advanceParticle(particle, {
+          elapsed,
+          dpr,
+          isPointerActive,
+          pointerX,
+          pointerY,
+          pointerVelocityX,
+          pointerVelocityY,
+        });
 
         const pixelX = Math.round(particle.x / dpr) * dpr;
         const pixelY = Math.round(particle.y / dpr) * dpr;

--- a/apps/web/src/app/rauch/kortix-particle-mark.tsx
+++ b/apps/web/src/app/rauch/kortix-particle-mark.tsx
@@ -1,0 +1,256 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+type Particle = {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  hx: number;
+  hy: number;
+  delay: number;
+};
+
+const BRANDMARK_SRC = '/brandkit/Logo/Brandmark/SVG/Brandmark Black.svg';
+
+/**
+ * A Rauch-style hard-pixel particle canvas that resolves into the Kortix
+ * brandmark, then lets pointer/touch movement disturb and settle the mark.
+ */
+export function KortixParticleMark() {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const animationRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const ctx = canvas.getContext('2d', { alpha: true });
+    if (!ctx) return;
+
+    let dpr = Math.max(1, Math.round(window.devicePixelRatio || 1));
+    let particleStride = 2 * dpr;
+    let particleSize = dpr;
+    let particles: Particle[] = [];
+    let sceneStartedAt = performance.now();
+    let isPointerActive = false;
+    let pointerX = 0;
+    let pointerY = 0;
+    let pointerVelocityX = 0;
+    let pointerVelocityY = 0;
+    let isDisposed = false;
+
+    const brandmark = new Image();
+    brandmark.decoding = 'async';
+    brandmark.src = BRANDMARK_SRC;
+
+    const rebuildParticles = () => {
+      if (!brandmark.complete || brandmark.naturalWidth === 0) return;
+
+      dpr = Math.max(1, Math.round(window.devicePixelRatio || 1));
+      particleStride = 2 * dpr;
+      particleSize = dpr;
+
+      const viewportWidth = window.innerWidth;
+      const viewportHeight = window.innerHeight;
+      canvas.width = viewportWidth * dpr;
+      canvas.height = viewportHeight * dpr;
+      canvas.style.width = `${viewportWidth}px`;
+      canvas.style.height = `${viewportHeight}px`;
+      ctx.imageSmoothingEnabled = false;
+
+      const aspectRatio = brandmark.naturalWidth / brandmark.naturalHeight;
+      const targetWidthCss = Math.max(
+        132,
+        Math.min(244, viewportWidth * 0.54, viewportHeight * 0.7 * aspectRatio),
+      );
+      const targetWidth = Math.round(targetWidthCss * dpr);
+      const targetHeight = Math.round(targetWidth / aspectRatio);
+
+      const offscreen = document.createElement('canvas');
+      offscreen.width = targetWidth;
+      offscreen.height = targetHeight;
+
+      const offscreenCtx = offscreen.getContext('2d');
+      if (!offscreenCtx) return;
+
+      offscreenCtx.imageSmoothingEnabled = true;
+      offscreenCtx.drawImage(brandmark, 0, 0, targetWidth, targetHeight);
+
+      const imageData = offscreenCtx.getImageData(0, 0, targetWidth, targetHeight);
+      const offsetX = (canvas.width - targetWidth) / 2;
+      const offsetY = (canvas.height - targetHeight) / 2;
+      const nextParticles: Particle[] = [];
+
+      for (let y = 0; y < targetHeight; y += particleStride) {
+        for (let x = 0; x < targetWidth; x += particleStride) {
+          const alpha = imageData.data[(y * targetWidth + x) * 4 + 3];
+          if (alpha <= 32) continue;
+
+          const hx = Math.round((offsetX + x) / particleStride) * particleStride;
+          const hy = Math.round((offsetY + y) / particleStride) * particleStride;
+          nextParticles.push({
+            x: hx,
+            y: -(Math.random() * canvas.height * 0.6 + 100 * dpr),
+            vx: 0,
+            vy: 0,
+            hx,
+            hy,
+            delay: ((targetHeight - y) / targetHeight) * 220 + Math.random() * 90,
+          });
+        }
+      }
+
+      particles = nextParticles;
+      sceneStartedAt = performance.now();
+    };
+
+    const drawFrame = (now: number) => {
+      const elapsed = now - sceneStartedAt;
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      ctx.fillStyle = '#000000';
+
+      const influenceRadius = 36 * dpr;
+      const influenceRadiusSquared = influenceRadius * influenceRadius;
+      const pointerForce = 2.6 * dpr;
+      const maxVelocity = 28 * dpr;
+      const homeForce = 0.02;
+      const fallGravity = 2.4 * dpr;
+
+      for (const particle of particles) {
+        if (elapsed < particle.delay) continue;
+
+        if (particle.y < particle.hy - 1 && elapsed < particle.delay + 900) {
+          particle.vy += fallGravity;
+          particle.vx += (particle.hx - particle.x) * homeForce;
+          particle.vx *= 0.86;
+          particle.x += particle.vx;
+          particle.y += particle.vy;
+
+          if (particle.y >= particle.hy) {
+            particle.x = particle.hx;
+            particle.y = particle.hy;
+            particle.vx = 0;
+            particle.vy = 0;
+          }
+        } else {
+          const dx = particle.x - pointerX;
+          const dy = particle.y - pointerY;
+          const distanceSquared = dx * dx + dy * dy;
+
+          if (isPointerActive && distanceSquared < influenceRadiusSquared) {
+            const distance = Math.sqrt(distanceSquared) || 0.0001;
+            const falloff = 1 - distance / influenceRadius;
+            const force = falloff * falloff;
+            particle.vx += (dx / distance) * force * pointerForce;
+            particle.vy += (dy / distance) * force * pointerForce;
+            particle.vx += pointerVelocityX * force * 0.9;
+            particle.vy += pointerVelocityY * force * 0.9;
+          } else {
+            particle.vx += (particle.hx - particle.x) * homeForce;
+            particle.vy += (particle.hy - particle.y) * homeForce;
+          }
+
+          particle.vx *= 0.86;
+          particle.vy *= 0.86;
+
+          const velocity = Math.sqrt(
+            particle.vx * particle.vx + particle.vy * particle.vy,
+          );
+          if (velocity > maxVelocity) {
+            particle.vx = (particle.vx / velocity) * maxVelocity;
+            particle.vy = (particle.vy / velocity) * maxVelocity;
+          }
+
+          particle.x += particle.vx;
+          particle.y += particle.vy;
+        }
+
+        const pixelX = Math.round(particle.x / dpr) * dpr;
+        const pixelY = Math.round(particle.y / dpr) * dpr;
+        ctx.fillRect(pixelX, pixelY, particleSize, particleSize);
+      }
+
+      pointerVelocityX *= 0.6;
+      pointerVelocityY *= 0.6;
+      animationRef.current = requestAnimationFrame(drawFrame);
+    };
+
+    const resize = debounce(rebuildParticles, 150);
+
+    const pointerPosition = (event: PointerEvent) => {
+      const bounds = canvas.getBoundingClientRect();
+      return {
+        x: (event.clientX - bounds.left) * dpr,
+        y: (event.clientY - bounds.top) * dpr,
+      };
+    };
+
+    const handlePointerDown = (event: PointerEvent) => {
+      isPointerActive = true;
+      const position = pointerPosition(event);
+      pointerX = position.x;
+      pointerY = position.y;
+      pointerVelocityX = 0;
+      pointerVelocityY = 0;
+      canvas.setPointerCapture?.(event.pointerId);
+    };
+
+    const handlePointerMove = (event: PointerEvent) => {
+      if (!isPointerActive) return;
+      const position = pointerPosition(event);
+      pointerVelocityX += position.x - pointerX;
+      pointerVelocityY += position.y - pointerY;
+      pointerX = position.x;
+      pointerY = position.y;
+    };
+
+    const handlePointerUp = () => {
+      isPointerActive = false;
+      pointerVelocityX = 0;
+      pointerVelocityY = 0;
+    };
+
+    brandmark.onload = () => {
+      if (isDisposed) return;
+      rebuildParticles();
+    };
+
+    rebuildParticles();
+    animationRef.current = requestAnimationFrame(drawFrame);
+    window.addEventListener('resize', resize);
+    canvas.addEventListener('pointerdown', handlePointerDown);
+    canvas.addEventListener('pointermove', handlePointerMove);
+    window.addEventListener('pointerup', handlePointerUp);
+    window.addEventListener('pointercancel', handlePointerUp);
+
+    return () => {
+      isDisposed = true;
+      if (animationRef.current) {
+        cancelAnimationFrame(animationRef.current);
+      }
+      window.removeEventListener('resize', resize);
+      canvas.removeEventListener('pointerdown', handlePointerDown);
+      canvas.removeEventListener('pointermove', handlePointerMove);
+      window.removeEventListener('pointerup', handlePointerUp);
+      window.removeEventListener('pointercancel', handlePointerUp);
+    };
+  }, []);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      aria-label="Kortix symbol rendered as hard subpixel particles"
+      className="block h-full w-full touch-none [image-rendering:pixelated]"
+    />
+  );
+}
+
+function debounce<T extends (...args: never[]) => void>(func: T, wait: number) {
+  let timeout: ReturnType<typeof setTimeout>;
+  return function executedFunction(...args: Parameters<T>) {
+    clearTimeout(timeout);
+    timeout = setTimeout(() => func(...args), wait);
+  };
+}

--- a/apps/web/src/app/rauch/page.tsx
+++ b/apps/web/src/app/rauch/page.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from 'next';
+import { KortixParticleMark } from './kortix-particle-mark';
+
+export const metadata: Metadata = {
+  title: 'Particle Mark — Kortix',
+  description: 'A Rauch-style hard-pixel particle rendering of the Kortix symbol.',
+  robots: { index: false, follow: false },
+};
+
+export default function RauchPage() {
+  return (
+    <main className="fixed inset-0 overflow-hidden bg-background">
+      <KortixParticleMark />
+    </main>
+  );
+}

--- a/apps/web/src/app/rauch/particle-mark.test.ts
+++ b/apps/web/src/app/rauch/particle-mark.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  advanceParticle,
+  buildBrandmarkParticles,
+  getParticleMarkSize,
+  type Particle,
+} from './particle-mark';
+
+describe('getParticleMarkSize', () => {
+  test('keeps the Kortix brandmark aspect ratio at desktop scale', () => {
+    expect(
+      getParticleMarkSize({
+        sourceWidth: 164,
+        sourceHeight: 140,
+        viewportWidth: 1280,
+        viewportHeight: 720,
+        dpr: 1,
+      }),
+    ).toEqual({ width: 244, height: 208 });
+  });
+
+  test('scales by device pixel ratio without changing css geometry', () => {
+    expect(
+      getParticleMarkSize({
+        sourceWidth: 164,
+        sourceHeight: 140,
+        viewportWidth: 375,
+        viewportHeight: 812,
+        dpr: 2,
+      }),
+    ).toEqual({ width: 405, height: 346 });
+  });
+});
+
+describe('buildBrandmarkParticles', () => {
+  test('samples only opaque mask cells into hard-pixel home positions', () => {
+    const particles = buildBrandmarkParticles({
+      targetWidth: 6,
+      targetHeight: 6,
+      particleStride: 2,
+      offsetX: 10,
+      offsetY: 20,
+      canvasHeight: 100,
+      dpr: 1,
+      random: () => 0,
+      alphaAt: (x, y) => (x === y ? 255 : 0),
+    });
+
+    expect(particles).toHaveLength(3);
+    expect(particles.map(({ hx, hy }) => ({ hx, hy }))).toEqual([
+      { hx: 10, hy: 20 },
+      { hx: 12, hy: 22 },
+      { hx: 14, hy: 24 },
+    ]);
+    expect(particles.every((particle) => particle.x === particle.hx)).toBe(true);
+    expect(particles.every((particle) => particle.y === -100)).toBe(true);
+  });
+
+  test('stages lower particles first like the Rauch reference', () => {
+    const particles = buildBrandmarkParticles({
+      targetWidth: 2,
+      targetHeight: 6,
+      particleStride: 2,
+      offsetX: 0,
+      offsetY: 0,
+      canvasHeight: 100,
+      dpr: 1,
+      random: () => 0,
+      alphaAt: () => 255,
+    });
+
+    const delays = particles.map((particle) => particle.delay);
+    expect(delays[0]).toBe(220);
+    expect(delays[1]).toBeCloseTo(440 / 3);
+    expect(delays[2]).toBeCloseTo(220 / 3);
+  });
+});
+
+describe('advanceParticle', () => {
+  test('lands falling particles exactly on their home cell', () => {
+    const particle: Particle = {
+      x: 20,
+      y: 18,
+      vx: 0,
+      vy: 8,
+      hx: 20,
+      hy: 20,
+      delay: 0,
+    };
+
+    advanceParticle(particle, {
+      elapsed: 10,
+      dpr: 1,
+      isPointerActive: false,
+      pointerX: 0,
+      pointerY: 0,
+      pointerVelocityX: 0,
+      pointerVelocityY: 0,
+    });
+
+    expect(particle).toMatchObject({ x: 20, y: 20, vx: 0, vy: 0 });
+  });
+
+  test('pushes settled particles away from an active pointer', () => {
+    const particle: Particle = {
+      x: 30,
+      y: 20,
+      vx: 0,
+      vy: 0,
+      hx: 30,
+      hy: 20,
+      delay: 0,
+    };
+
+    advanceParticle(particle, {
+      elapsed: 1000,
+      dpr: 1,
+      isPointerActive: true,
+      pointerX: 20,
+      pointerY: 20,
+      pointerVelocityX: 4,
+      pointerVelocityY: 0,
+    });
+
+    expect(particle.x).toBeGreaterThan(30);
+    expect(particle.vx).toBeGreaterThan(0);
+  });
+});

--- a/apps/web/src/app/rauch/particle-mark.ts
+++ b/apps/web/src/app/rauch/particle-mark.ts
@@ -1,0 +1,159 @@
+export type Particle = {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  hx: number;
+  hy: number;
+  delay: number;
+};
+
+export type ParticleMarkSize = {
+  width: number;
+  height: number;
+};
+
+export const BRANDMARK_SRC = '/brandkit/Logo/Brandmark/SVG/Brandmark Black.svg';
+
+export function getParticleMarkSize({
+  sourceWidth,
+  sourceHeight,
+  viewportWidth,
+  viewportHeight,
+  dpr,
+}: {
+  sourceWidth: number;
+  sourceHeight: number;
+  viewportWidth: number;
+  viewportHeight: number;
+  dpr: number;
+}): ParticleMarkSize {
+  const aspectRatio = sourceWidth / sourceHeight;
+  const targetWidthCss = Math.max(
+    132,
+    Math.min(244, viewportWidth * 0.54, viewportHeight * 0.7 * aspectRatio),
+  );
+  const width = Math.round(targetWidthCss * dpr);
+
+  return {
+    width,
+    height: Math.round(width / aspectRatio),
+  };
+}
+
+export function buildBrandmarkParticles({
+  targetWidth,
+  targetHeight,
+  particleStride,
+  offsetX,
+  offsetY,
+  canvasHeight,
+  dpr,
+  alphaAt,
+  random = Math.random,
+}: {
+  targetWidth: number;
+  targetHeight: number;
+  particleStride: number;
+  offsetX: number;
+  offsetY: number;
+  canvasHeight: number;
+  dpr: number;
+  alphaAt: (x: number, y: number) => number;
+  random?: () => number;
+}): Particle[] {
+  const particles: Particle[] = [];
+
+  for (let y = 0; y < targetHeight; y += particleStride) {
+    for (let x = 0; x < targetWidth; x += particleStride) {
+      if (alphaAt(x, y) <= 32) continue;
+
+      const hx = Math.round((offsetX + x) / particleStride) * particleStride;
+      const hy = Math.round((offsetY + y) / particleStride) * particleStride;
+      particles.push({
+        x: hx,
+        y: -(random() * canvasHeight * 0.6 + 100 * dpr),
+        vx: 0,
+        vy: 0,
+        hx,
+        hy,
+        delay: ((targetHeight - y) / targetHeight) * 220 + random() * 90,
+      });
+    }
+  }
+
+  return particles;
+}
+
+export function advanceParticle(
+  particle: Particle,
+  {
+    elapsed,
+    dpr,
+    isPointerActive,
+    pointerX,
+    pointerY,
+    pointerVelocityX,
+    pointerVelocityY,
+  }: {
+    elapsed: number;
+    dpr: number;
+    isPointerActive: boolean;
+    pointerX: number;
+    pointerY: number;
+    pointerVelocityX: number;
+    pointerVelocityY: number;
+  },
+) {
+  const influenceRadius = 36 * dpr;
+  const influenceRadiusSquared = influenceRadius * influenceRadius;
+  const pointerForce = 2.6 * dpr;
+  const maxVelocity = 28 * dpr;
+  const homeForce = 0.02;
+  const fallGravity = 2.4 * dpr;
+
+  if (particle.y < particle.hy - 1 && elapsed < particle.delay + 900) {
+    particle.vy += fallGravity;
+    particle.vx += (particle.hx - particle.x) * homeForce;
+    particle.vx *= 0.86;
+    particle.x += particle.vx;
+    particle.y += particle.vy;
+
+    if (particle.y >= particle.hy) {
+      particle.x = particle.hx;
+      particle.y = particle.hy;
+      particle.vx = 0;
+      particle.vy = 0;
+    }
+    return;
+  }
+
+  const dx = particle.x - pointerX;
+  const dy = particle.y - pointerY;
+  const distanceSquared = dx * dx + dy * dy;
+
+  if (isPointerActive && distanceSquared < influenceRadiusSquared) {
+    const distance = Math.sqrt(distanceSquared) || 0.0001;
+    const falloff = 1 - distance / influenceRadius;
+    const force = falloff * falloff;
+    particle.vx += (dx / distance) * force * pointerForce;
+    particle.vy += (dy / distance) * force * pointerForce;
+    particle.vx += pointerVelocityX * force * 0.9;
+    particle.vy += pointerVelocityY * force * 0.9;
+  } else {
+    particle.vx += (particle.hx - particle.x) * homeForce;
+    particle.vy += (particle.hy - particle.y) * homeForce;
+  }
+
+  particle.vx *= 0.86;
+  particle.vy *= 0.86;
+
+  const velocity = Math.sqrt(particle.vx * particle.vx + particle.vy * particle.vy);
+  if (velocity > maxVelocity) {
+    particle.vx = (particle.vx / velocity) * maxVelocity;
+    particle.vy = (particle.vy / velocity) * maxVelocity;
+  }
+
+  particle.x += particle.vx;
+  particle.y += particle.vy;
+}

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -38,6 +38,7 @@ const PUBLIC_ROUTES = [
   '/download', // Desktop installer redirector (per-platform latest)
   '/design-system', // Living design system / brand guidelines should be public
   '/presentation', // Standalone product deck (/presentation) should be public
+  '/rauch', // Rauch-style particle rendering of the Kortix symbol — public, unauthenticated
   '/contact', // Request-a-demo / contact page should be public
   '/developers', // Developer walkthrough landing page should be public
   '/countryerror', // Country restriction error page should be public
@@ -54,6 +55,13 @@ const PUBLIC_ROUTES = [
   ...locales.flatMap((locale) =>
     MARKETING_ROUTES.map((route) => `/${locale}${route === '/' ? '' : route}`),
   ),
+];
+
+// Visual, static public canvases do not need Supabase session reads. Keep them
+// reachable even when local encrypted env vars are not available.
+const STATIC_PUBLIC_ROUTES = [
+  '/game-of-life',
+  '/rauch',
 ];
 
 // Routes that require authentication but are related to billing/setup
@@ -196,6 +204,10 @@ export async function middleware(request: NextRequest) {
 
       return response;
     }
+  }
+
+  if (STATIC_PUBLIC_ROUTES.some((route) => pathname === route || pathname.startsWith(route + '/'))) {
+    return NextResponse.next();
   }
 
   // Create a single Supabase client instance that we'll reuse

--- a/tests/src/flows/new-routes-coverage.flow.ts
+++ b/tests/src/flows/new-routes-coverage.flow.ts
@@ -250,3 +250,69 @@ flow(
     });
   },
 );
+
+flow(
+  'COV-8',
+  {
+    domain: 'coverage',
+    routes: [
+      'GET /v1/projects/:projectId/llm-catalog',
+      'GET /v1/projects/:projectId/marketplace',
+      'GET /v1/projects/:projectId/marketplace/updates',
+      'POST /v1/projects/:projectId/marketplace/install',
+      'POST /v1/projects/:projectId/marketplace/update',
+      'POST /v1/projects/:projectId/marketplace/update-all',
+      'DELETE /v1/projects/:projectId/marketplace/:name',
+      'POST /v1/projects/:projectId/registry/update-all',
+      'PATCH /v1/projects/:projectId/channels/email/installation',
+      'POST /v1/channels/slack/identity/bind',
+      'POST /internal/gateway/authorize',
+    ],
+  },
+  async (ctx) => {
+    const params = { projectId: ZERO_UUID };
+
+    await ctx.step('unauthenticated project marketplace and catalog routes are gated', async () => {
+      for (const route of [
+        '/v1/projects/:projectId/llm-catalog',
+        '/v1/projects/:projectId/marketplace',
+        '/v1/projects/:projectId/marketplace/updates',
+      ]) {
+        const r = await ctx.client.as(ctx.P.ANON).get(route, { params });
+        r.status(401);
+      }
+    });
+
+    await ctx.step('unauthenticated marketplace mutation routes are gated', async () => {
+      for (const route of [
+        '/v1/projects/:projectId/marketplace/install',
+        '/v1/projects/:projectId/marketplace/update',
+        '/v1/projects/:projectId/marketplace/update-all',
+        '/v1/projects/:projectId/registry/update-all',
+      ]) {
+        const r = await ctx.client.as(ctx.P.ANON).post(route, {}, { params });
+        r.status(401);
+      }
+
+      const del = await ctx.client.as(ctx.P.ANON).del('/v1/projects/:projectId/marketplace/:name', {
+        params: { ...params, name: 'missing' },
+      });
+      del.status(401);
+    });
+
+    await ctx.step('unauthenticated email and Slack identity mutations are gated', async () => {
+      const email = await ctx.client
+        .as(ctx.P.ANON)
+        .patch('/v1/projects/:projectId/channels/email/installation', {}, { params });
+      email.status(401);
+
+      const slack = await ctx.client.as(ctx.P.ANON).post('/v1/channels/slack/identity/bind', {});
+      slack.status(401);
+    });
+
+    await ctx.step('internal gateway authorization rejects missing internal credentials', async () => {
+      const r = await ctx.client.as(ctx.P.ANON).post('/internal/gateway/authorize', {});
+      r.status([401, 503]);
+    });
+  },
+);


### PR DESCRIPTION
## Summary
- Adds a public `/rauch` page that recreates rauch.com's hard-pixel particle canvas interaction.
- Uses the Kortix brandmark as the particle source instead of the Rauch triangle.
- Adds a middleware fast-path for static public canvas routes so they do not require Supabase session reads.

## Verification
- `pnpm --filter Kortix-Computer-Frontend exec eslint src/app/rauch/kortix-particle-mark.tsx src/app/rauch/page.tsx src/middleware.ts`
- `pnpm --filter Kortix-Computer-Frontend exec tsc --noEmit --pretty false` *(currently blocked by existing unrelated repo errors in src/lib/source.ts, src/lib/blog-source.ts, src/lib/model-pricing.test.ts, and src/ui/turns.test.ts)*
- Browser: opened `http://localhost:3000/rauch`, confirmed the page title, rendered canvas, 6,571 dark particle pixels, and pointer disturbance handler execution.
