### PR TITLE
fix(web): project-home chat input starts (bind boot agent at create) + unify new-session empty state

### DIFF
--- a/apps/web/src/app/(app)/projects/[id]/page.tsx
+++ b/apps/web/src/app/(app)/projects/[id]/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { buildNewSessionCreateInput } from '@/features/co-worker/project-layout/new-session-create';
 import {
   ProjectHome,
   type ProjectHomeSendOptions,
@@ -72,8 +73,12 @@ export default function ProjectIndexPage() {
       // id, paint the instant shell, and let the session page auto-send `text` once
       // the box is ready. No server-side initial_prompt — the shell shows the
       // message + inline boot status, matching the global dashboard composer.
+      // Bind the chosen agent at session birth so it matches the `agent` the
+      // composer sends on the first prompt — sessions are agent-immutable and the
+      // API proxy 409s any prompt whose agent differs from the bound one, which
+      // defaults to "default" when unset (see buildNewSessionCreateInput).
       newSession({
-        create: options?.sandbox_slug ? { sandbox_slug: options.sandbox_slug } : undefined,
+        create: buildNewSessionCreateInput(options),
         onNavigate: (sessionId) => {
           sessionStorage.setItem(`project_pending_prompt:${sessionId}`, text);
           if (files?.length) {

--- a/apps/web/src/features/co-worker/project-layout/new-session-create.test.ts
+++ b/apps/web/src/features/co-worker/project-layout/new-session-create.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'bun:test';
+
+import { buildNewSessionCreateInput } from './new-session-create';
+
+describe('buildNewSessionCreateInput', () => {
+  it('binds the picked agent as agent_name so it matches the first prompt', () => {
+    // The whole bug: the composer sends agent="veyris" on the first prompt, so
+    // the session MUST be created bound to "veyris" — otherwise the proxy 409s
+    // (AGENT_SWITCH_REQUIRES_NEW_SESSION) and the task never starts.
+    expect(buildNewSessionCreateInput({ agent: 'veyris' })).toEqual({
+      agent_name: 'veyris',
+    });
+  });
+
+  it('carries the sandbox slug through alongside the agent', () => {
+    expect(
+      buildNewSessionCreateInput({ agent: 'builder', sandbox_slug: 'node22' }),
+    ).toEqual({ agent_name: 'builder', sandbox_slug: 'node22' });
+  });
+
+  it('binds only the sandbox slug when no agent is picked', () => {
+    expect(buildNewSessionCreateInput({ sandbox_slug: 'node22' })).toEqual({
+      sandbox_slug: 'node22',
+    });
+  });
+
+  it('returns undefined when there is nothing to override', () => {
+    // No agent and the default sandbox → omit the create overrides entirely.
+    expect(buildNewSessionCreateInput({})).toBeUndefined();
+    expect(buildNewSessionCreateInput()).toBeUndefined();
+  });
+
+  it('ignores an empty-string agent (never binds agent_name="")', () => {
+    // An empty agent must NOT become agent_name:"" — that would mismatch the
+    // proxy's `?? "default"` and 409 the first prompt.
+    expect(buildNewSessionCreateInput({ agent: '' })).toBeUndefined();
+  });
+});

--- a/apps/web/src/features/co-worker/project-layout/new-session-create.ts
+++ b/apps/web/src/features/co-worker/project-layout/new-session-create.ts
@@ -1,0 +1,31 @@
+import type { ComposerOptions } from '@/features/session/composer-chat-input';
+
+export interface NewSessionCreateInput {
+  sandbox_slug?: string;
+  agent_name?: string;
+}
+
+/**
+ * Build the session-create payload from the composer's send options.
+ *
+ * A project session's boot agent is IMMUTABLE and bound at creation. The API
+ * preview proxy rejects any prompt whose `agent` differs from the session's
+ * bound agent with 409 AGENT_SWITCH_REQUIRES_NEW_SESSION — and the bound agent
+ * defaults to "default" when none is set at create. So the agent the composer
+ * will send on the very first prompt MUST be bound here, at session birth, or
+ * the first message fails to start the task at all.
+ *
+ * `agent_name` therefore mirrors `options.agent` exactly: the create-time bind
+ * and the first-prompt send read the same value, so they can never disagree.
+ *
+ * Returns `undefined` when there is nothing to bind (sandbox stays default and
+ * no agent was picked), so callers can omit the create overrides entirely.
+ */
+export function buildNewSessionCreateInput(
+  options: Pick<ComposerOptions, 'agent'> & { sandbox_slug?: string } = {},
+): NewSessionCreateInput | undefined {
+  const input: NewSessionCreateInput = {};
+  if (options.sandbox_slug) input.sandbox_slug = options.sandbox_slug;
+  if (options.agent) input.agent_name = options.agent;
+  return Object.keys(input).length > 0 ? input : undefined;
+}

--- a/apps/web/src/features/co-worker/project-layout/project-home.tsx
+++ b/apps/web/src/features/co-worker/project-layout/project-home.tsx
@@ -72,13 +72,6 @@ export function ProjectHome({
   busy: boolean;
 }) {
   const tI18nHardcoded = useTranslations('hardcodedUi');
-  const detail = useQuery({
-    queryKey: ['project-detail', projectId],
-    queryFn: () => getProjectDetail(projectId),
-    ...Q,
-  });
-  const name = detail.data?.project?.name ?? '';
-  const displayName = name.trim() || 'this project';
 
   const [selectedSlug, setSelectedSlug] = useState<string | null>(null);
   const [prefill, setPrefill] = useState<{ text: string; id: number } | null>(null);
@@ -163,18 +156,7 @@ export function ProjectHome({
         </div>
       ) : null}
 
-      <div className="relative z-10 flex min-h-0 flex-1 flex-col items-center justify-center overflow-y-auto">
-        <div className="flex w-full max-w-3xl items-center justify-start py-8 xl:py-8">
-          <h1 className="text-muted-foreground text-left text-[2.3rem] leading-[1.2] tracking-tight text-balance max-sm:text-3xl">
-            Give <span className="text-foreground">{displayName}</span>{' '}
-            {tI18nHardcoded.raw(
-              'autoFeaturesCoWorkerProjectLayoutProjectHomeJsxTextSomething18ab9904',
-            )}
-          </h1>
-        </div>
-
-        <ProjectHomeSections projectId={projectId} />
-      </div>
+      <ProjectHomeWelcomeBody projectId={projectId} />
 
       <div className="relative z-10 shrink-0">
         <div className="mx-auto mb-4 w-full max-w-[52rem] px-2 sm:px-4">
@@ -206,7 +188,38 @@ export function ProjectHome({
   );
 }
 
-function StarterPromptsCarousel({ onPick }: { onPick: (text: string) => void }) {
+/**
+ * The project-home empty-state body: the welcome heading + the "set up your
+ * project" tiles. Shared by the project index page AND the instant session
+ * shell's empty state so a brand-new session opens onto the identical surface.
+ */
+export function ProjectHomeWelcomeBody({ projectId }: { projectId: string }) {
+  const tI18nHardcoded = useTranslations('hardcodedUi');
+  const detail = useQuery({
+    queryKey: ['project-detail', projectId],
+    queryFn: () => getProjectDetail(projectId),
+    ...Q,
+  });
+  const name = detail.data?.project?.name ?? '';
+  const displayName = name.trim() || 'this project';
+
+  return (
+    <div className="relative z-10 flex min-h-0 flex-1 flex-col items-center justify-center overflow-y-auto">
+      <div className="flex w-full max-w-3xl items-center justify-start py-8 xl:py-8">
+        <h1 className="text-muted-foreground text-left text-[2.3rem] leading-[1.2] tracking-tight text-balance max-sm:text-3xl">
+          Give <span className="text-foreground">{displayName}</span>{' '}
+          {tI18nHardcoded.raw(
+            'autoFeaturesCoWorkerProjectLayoutProjectHomeJsxTextSomething18ab9904',
+          )}
+        </h1>
+      </div>
+
+      <ProjectHomeSections projectId={projectId} />
+    </div>
+  );
+}
+
+export function StarterPromptsCarousel({ onPick }: { onPick: (text: string) => void }) {
   const tI18nHardcoded = useTranslations('hardcodedUi');
   const scrollRef = useRef<HTMLDivElement>(null);
   const [showLeftFade, setShowLeftFade] = useState(false);

--- a/apps/web/src/features/session/instant-session-shell.tsx
+++ b/apps/web/src/features/session/instant-session-shell.tsx
@@ -7,6 +7,10 @@ import { createPortal } from 'react-dom';
 import { GridFileCard } from '@/components/thread/file-attachment/GridFileCard';
 import { AnimatedThinkingText } from '@/components/ui/animated-thinking-text';
 import { AssistantPendingRow } from '@/features/session/assistant-pending-row';
+import {
+  ProjectHomeWelcomeBody,
+  StarterPromptsCarousel,
+} from '@/features/co-worker/project-layout/project-home';
 import { ComposerChatInput, type ComposerOptions } from '@/features/session/composer-chat-input';
 import { SessionSiteHeader } from '@/features/session/header/session-site-header';
 import type { AttachedFile } from '@/features/session/session-chat-input';
@@ -84,6 +88,12 @@ export function InstantSessionShell({
   });
   const submitted = submission?.text ?? null;
 
+  // Starter-prompt → composer prefill, identical to the project-home composer.
+  const [prefill, setPrefill] = useState<{ text: string; id: number } | null>(null);
+  const applySuggestion = useCallback((text: string) => {
+    setPrefill({ text, id: Date.now() });
+  }, []);
+
   const handleSend = useCallback(
     (text: string, files: AttachedFile[] | undefined, options: ComposerOptions) => {
       if ((!text.trim() && !files?.length) || submitted) return;
@@ -142,8 +152,22 @@ export function InstantSessionShell({
         }}
       />
 
-      <div className="relative z-10 min-h-0 flex-1">
-        <div className="scrollbar-hide relative z-10 h-full flex-1 overflow-y-auto px-4 py-4">
+      <div className="relative z-10 flex min-h-0 flex-1 flex-col">
+        {/* Empty new session → the identical project-home empty state (welcome
+            heading + setup tiles), so a fresh session opens onto the same
+            surface as the project index page. Swapped out for the optimistic
+            turn the moment a first message is sent (the crossfade is unchanged). */}
+        {!submitted && (
+          <div className="flex min-h-0 flex-1 flex-col px-4.5">
+            <ProjectHomeWelcomeBody projectId={projectId} />
+          </div>
+        )}
+        <div
+          className={cn(
+            'scrollbar-hide relative z-10 overflow-y-auto px-4 py-4',
+            submitted ? 'h-full flex-1' : 'hidden',
+          )}
+        >
           <div className="mx-auto w-full max-w-3xl min-w-0 px-3 sm:px-6">
             {submission && (
               <div className="flex min-w-0 flex-col">
@@ -193,11 +217,18 @@ export function InstantSessionShell({
         </div>
       </div>
 
+      {!submitted && (
+        <div className="relative z-10 mx-auto mb-4 w-full max-w-[52rem] px-2 sm:px-4">
+          <StarterPromptsCarousel onPick={applySuggestion} />
+        </div>
+      )}
+
       <ComposerChatInput
         onSend={handleSend}
         onCommand={handleCommand}
         sessionId={sessionId}
         projectId={projectId}
+        prefill={prefill}
         // While the computer boots after the first send the input stays fully
         // normal (typeable) — only the send button flips to a stop button. The
         // stop is disabled because there's nothing running to stop yet; the real

--- a/apps/web/src/hooks/projects/use-new-project-session.ts
+++ b/apps/web/src/hooks/projects/use-new-project-session.ts
@@ -36,7 +36,14 @@ export function useNewProjectSession(projectId: string | undefined) {
   const openUpgradeDialog = useUpgradeDialogStore((state) => state.openUpgradeDialog);
 
   return useCallback(
-    (opts?: { onNavigate?: (sessionId: string) => void; create?: { sandbox_slug?: string } }) => {
+    (opts?: {
+      onNavigate?: (sessionId: string) => void;
+      // `agent_name` binds the session's immutable boot agent at birth. It MUST
+      // match the agent the composer sends on the first prompt — the API proxy
+      // rejects any prompt whose `agent` differs from the session's bound agent
+      // with 409 AGENT_SWITCH_REQUIRES_NEW_SESSION (sessions are agent-immutable).
+      create?: { sandbox_slug?: string; agent_name?: string };
+    }) => {
       if (!projectId || creatingRef.current) return;
 
       if (isBillingEnabled() && billingLoading) return;


### PR DESCRIPTION
## Problem

Typing a task in the **project index / home page** chat input failed to start the session — it surfaced `agent switch requires a new session` (HTTP 409 `AGENT_SWITCH_REQUIRES_NEW_SESSION`) in dev/prod.

### Root cause
The runtime-governance change (`c21209bf`, deployed) made sessions **agent-immutable**. The API preview proxy now rejects any prompt whose `agent` differs from the session's **bound boot agent** (`apps/api/src/sandbox-proxy/routes/preview.ts`):

```js
const requestedAgent = requestedPromptAgent(body);   // prompt's `agent`
const sessionAgent   = record.agentName ?? 'default'; // bound at create
if (requestedAgent && requestedAgent !== sessionAgent) return 409;
```

The project-home flow created the session **without** `agent_name` → bound to `"default"`, but the composer sent the *real* picked agent (e.g. `kortix`) on the first prompt → `"kortix" !== "default"` → 409 → task never started. This is the spec's unshipped follow-up ("Land UI behavior for 409 agent switch").

## Fix

Bind the chosen agent **at session creation** so it matches the agent every prompt carries.

- `buildNewSessionCreateInput()` — single source mirroring `options.agent` → `agent_name`, so the create-bind and the first-prompt send read the same value and can never disagree.
- `useNewProjectSession` `create` now accepts `agent_name` (already forwarded by `createProjectSession`).
- Project index `handleSend` binds the agent at create.

## Also: unify the empty state

A fresh/empty session now renders the **identical** project-home empty state (welcome heading + setup tiles + starter prompts), so the new-session page == the project index page.

- Extracted `ProjectHomeWelcomeBody` + `StarterPromptsCarousel` from `project-home.tsx`.
- Rendered them in the instant session shell's empty state with starter-prompt → composer prefill. The optimistic-turn crossfade path is untouched; setup tiles work because `ProjectShell` (mounts `CustomizeOverlay`) wraps the session route too.

## Tests
- Unit tests for the create-payload invariant, incl. the empty-agent guard (`new-session-create.test.ts`).
- Local typecheck + eslint + the new test were green on the working branch with these exact edits.

## Verification note
The 409 enforcement lives in the deployed gateway/API, so the real 409 can't be triggered against a fresh local backend — verified by tracing the enforcement + create-binding code end-to-end plus unit tests. Final confirmation: on dev, type a task on `/projects/[id]` → it should start instead of erroring.