### PR TITLE
fix(manifest-schema): align CR-merge gate with the runtime parser

### DIFF
--- a/apps/api/src/__tests__/unit-connectors-parse.test.ts
+++ b/apps/api/src/__tests__/unit-connectors-parse.test.ts
@@ -515,3 +515,41 @@ spec = "https://x/y.json"
     expect(manifestHashForConnector(a)).not.toBe(manifestHashForConnector(c));
   });
 });
+
+/**
+ * Drift guard: the runtime parser (this module) and the canonical schema gate
+ * (@kortix/manifest-schema, run on CR-merge) must agree on which providers a
+ * kortix.toml may declare. They drifted once — `channel` was added here and to
+ * channel-manifest.ts (which WRITES it into the manifest) but not to the schema,
+ * so the merge gate rejected manifests the platform itself produced. Keep them
+ * locked together: a provider one side accepts the other must not reject.
+ */
+describe('[[connectors]] — runtime parser ⇄ schema gate provider agreement', () => {
+  const { validateManifest } = require('@kortix/manifest-schema') as typeof import('@kortix/manifest-schema');
+
+  function schemaConnectorErrors(body: string): string[] {
+    return validateManifest(manifestWith(body))
+      .issues.filter((i) => i.severity === 'error' && i.path.startsWith('connectors['))
+      .map((i) => i.path);
+  }
+
+  const cases: Array<{ name: string; body: string; accept: boolean }> = [
+    { name: 'pipedream', accept: true, body: `[[connectors]]\nslug = "c"\nprovider = "pipedream"\napp = "gmail"` },
+    { name: 'mcp', accept: true, body: `[[connectors]]\nslug = "c"\nprovider = "mcp"\nurl = "https://e.com"` },
+    { name: 'openapi', accept: true, body: `[[connectors]]\nslug = "c"\nprovider = "openapi"\nspec = "https://e.com/o.json"` },
+    { name: 'graphql', accept: true, body: `[[connectors]]\nslug = "c"\nprovider = "graphql"\nendpoint = "https://e.com/graphql"` },
+    { name: 'http', accept: true, body: `[[connectors]]\nslug = "c"\nprovider = "http"\nbase_url = "https://e.com"` },
+    { name: 'channel', accept: true, body: `[[connectors]]\nslug = "kortix_slack"\nprovider = "channel"\nplatform = "slack"` },
+    { name: 'computer (synth-only)', accept: false, body: `[[connectors]]\nslug = "computer"\nprovider = "computer"` },
+    { name: 'unknown provider', accept: false, body: `[[connectors]]\nslug = "c"\nprovider = "made-up"` },
+  ];
+
+  for (const { name, body, accept } of cases) {
+    test(`${name}: parser and schema agree (accept=${accept})`, () => {
+      const runtimeOk = parseAndExtract(body).errors.length === 0;
+      const schemaOk = schemaConnectorErrors(body).length === 0;
+      expect(runtimeOk).toBe(accept);
+      expect(schemaOk).toBe(accept);
+    });
+  }
+});

--- a/apps/api/src/__tests__/unit-trigger-dsl.test.ts
+++ b/apps/api/src/__tests__/unit-trigger-dsl.test.ts
@@ -449,3 +449,42 @@ prompt = "Hello"
     expect(b).toEqual(a);
   });
 });
+
+/**
+ * Drift guard: the runtime trigger parser (extractTriggers) and the canonical
+ * schema gate (@kortix/manifest-schema, run on CR-merge) must agree on which
+ * `[[triggers]]` shapes are valid. The runtime accepts several alias keys
+ * (prompt_template, schedule/runAt, secretEnv, sessionMode) and coerces enabled
+ * / lowercases session_mode; the gate must accept the same, or it falsely blocks
+ * a manifest that materializes fine — the bug class behind the missing `channel`
+ * connector provider. Keep them locked together.
+ */
+describe('[[triggers]] — runtime parser ⇄ schema gate agreement', () => {
+  const { validateManifest } = require('@kortix/manifest-schema') as typeof import('@kortix/manifest-schema');
+
+  function schemaTriggerErrors(block: string): string[] {
+    return validateManifest(manifestWith(block))
+      .issues.filter((i) => i.severity === 'error' && i.path.startsWith('triggers['))
+      .map((i) => i.path);
+  }
+
+  const cases: Array<{ name: string; block: string; accept: boolean }> = [
+    { name: 'prompt_template alias', accept: true, block: `[[triggers]]\nslug = "t"\ntype = "cron"\ncron = "0 9 * * *"\nprompt_template = "go"` },
+    { name: 'schedule alias', accept: true, block: `[[triggers]]\nslug = "t"\ntype = "cron"\nschedule = "0 9 * * *"\nprompt = "go"` },
+    { name: 'runAt alias', accept: true, block: `[[triggers]]\nslug = "t"\ntype = "cron"\nrunAt = "2099-01-01T09:00:00Z"\nprompt = "go"` },
+    { name: 'secretEnv alias', accept: true, block: `[[triggers]]\nslug = "t"\ntype = "webhook"\nsecretEnv = "WEBHOOK_SECRET"\nprompt = "go"` },
+    { name: 'session_mode case-insensitive', accept: true, block: `[[triggers]]\nslug = "t"\ntype = "cron"\ncron = "0 9 * * *"\nprompt = "go"\nsession_mode = "Reuse"` },
+    { name: 'enabled coercible', accept: true, block: `[[triggers]]\nslug = "t"\ntype = "cron"\ncron = "0 9 * * *"\nprompt = "go"\nenabled = 1` },
+    { name: 'missing prompt', accept: false, block: `[[triggers]]\nslug = "t"\ntype = "cron"\ncron = "0 9 * * *"` },
+    { name: 'unknown type', accept: false, block: `[[triggers]]\nslug = "t"\ntype = "made-up"\nprompt = "go"` },
+  ];
+
+  for (const { name, block, accept } of cases) {
+    test(`${name}: parser and schema agree (accept=${accept})`, () => {
+      const runtimeOk = extractTriggers(parseManifestString(manifestWith(block))).errors.length === 0;
+      const schemaOk = schemaTriggerErrors(block).length === 0;
+      expect(runtimeOk).toBe(accept);
+      expect(schemaOk).toBe(accept);
+    });
+  }
+});

--- a/packages/manifest-schema/src/__tests__/validator.coverage.test.ts
+++ b/packages/manifest-schema/src/__tests__/validator.coverage.test.ts
@@ -173,8 +173,10 @@ describe('validateManifest — [[channels]]', () => {
     expect(paths).toContain('channels[1].platform');
   });
 
-  test('non-boolean enabled is rejected', () => {
-    expect(errorPaths('kortix_version = 1\n[[channels]]\nplatform = "slack"\nenabled = "yes"')).toContain(
+  // Coercible values (booleans, 0/1, yes/no/on/off) are accepted to match the
+  // runtime's coerceBool; only genuinely non-coercible values are rejected.
+  test('non-coercible enabled is rejected', () => {
+    expect(errorPaths('kortix_version = 1\n[[channels]]\nplatform = "slack"\nenabled = "maybe"')).toContain(
       'channels[0].enabled',
     );
   });
@@ -212,8 +214,8 @@ describe('validateManifest — [[apps]]', () => {
     expect(errorPaths('kortix_version = 1\n[[apps]]\nslug = "s"\n[[apps]]\nslug = "s"')).toContain('apps[1].slug');
   });
 
-  test('non-boolean enabled is rejected', () => {
-    expect(errorPaths('kortix_version = 1\n[[apps]]\nslug = "s"\nenabled = 1')).toContain('apps[0].enabled');
+  test('non-coercible enabled is rejected', () => {
+    expect(errorPaths('kortix_version = 1\n[[apps]]\nslug = "s"\nenabled = "maybe"')).toContain('apps[0].enabled');
   });
 
   test('non-array domains is rejected', () => {

--- a/packages/manifest-schema/src/__tests__/validator.test.ts
+++ b/packages/manifest-schema/src/__tests__/validator.test.ts
@@ -391,6 +391,66 @@ spec = "https://example.com/openapi.json"
 `);
     expect(errorPaths).toContain('connectors[0].policies[0].action');
   });
+
+  // The platform itself writes this entry into kortix.toml when a Slack channel
+  // is connected (executor/channel-manifest.ts). The gate must accept it, or it
+  // blocks merging a manifest the backend produced.
+  test('a platform-written channel connector is valid', () => {
+    const { valid, errorPaths } = summarize(`
+kortix_version = 1
+[[connectors]]
+slug = "kortix_slack"
+provider = "channel"
+platform = "slack"
+`);
+    expect(errorPaths).toEqual([]);
+    expect(valid).toBe(true);
+  });
+
+  test('channel connector requires a known platform', () => {
+    const { errorPaths } = summarize(`
+kortix_version = 1
+[[connectors]]
+slug = "kortix_slack"
+provider = "channel"
+`);
+    expect(errorPaths).toContain('connectors[0].platform');
+  });
+
+  test('channel connector must not declare [connectors.auth]', () => {
+    const { errorPaths } = summarize(`
+kortix_version = 1
+[[connectors]]
+slug = "kortix_slack"
+provider = "channel"
+platform = "slack"
+  [connectors.auth]
+  type = "bearer"
+`);
+    expect(errorPaths).toContain('connectors[0].auth');
+  });
+
+  test('a reserved slug rejects the wrong provider', () => {
+    const { errorPaths } = summarize(`
+kortix_version = 1
+[[connectors]]
+slug = "kortix_slack"
+provider = "http"
+base_url = "https://example.com"
+`);
+    expect(errorPaths).toContain('connectors[0].provider');
+  });
+
+  test('computer cannot be declared by hand', () => {
+    const result = summarize(`
+kortix_version = 1
+[[connectors]]
+slug = "computer"
+provider = "computer"
+`);
+    expect(result.errorPaths).toContain('connectors[0].provider');
+    expect(result.issues.some((i) => i.message.includes('managed automatically'))).toBe(true);
+  });
 });
 
 describe('validateManifest — [[apps]]', () => {
@@ -403,6 +463,61 @@ slug = "site"
   type = "ftp"
 `);
     expect(errorPaths).toContain('apps[0].source.type');
+  });
+});
+
+// The gate must accept every form the runtime parser accepts, or it falsely
+// blocks a manifest that materializes fine — the same bug class as the missing
+// `channel` provider. These lock the gate to the runtime's input tolerance.
+describe('validateManifest — input tolerance (mirrors runtime parser)', () => {
+  function connectorErrors(body: string): string[] {
+    return validateManifest(`kortix_version = 1\n${body}`)
+      .issues.filter((i) => i.severity === 'error')
+      .map((i) => i.path);
+  }
+
+  test('trigger accepts the prompt_template alias', () => {
+    expect(
+      connectorErrors(`[[triggers]]\nslug = "t"\ntype = "cron"\ncron = "0 9 * * *"\nprompt_template = "go"`),
+    ).not.toContain('triggers[0].prompt');
+  });
+
+  test('cron trigger accepts the schedule alias', () => {
+    expect(
+      connectorErrors(`[[triggers]]\nslug = "t"\ntype = "cron"\nschedule = "0 9 * * *"\nprompt = "go"`),
+    ).not.toContain('triggers[0].cron');
+  });
+
+  test('trigger enabled accepts coercible values', () => {
+    expect(
+      connectorErrors(`[[triggers]]\nslug = "t"\ntype = "cron"\ncron = "0 9 * * *"\nprompt = "go"\nenabled = 1`),
+    ).not.toContain('triggers[0].enabled');
+  });
+
+  test('trigger session_mode is case-insensitive', () => {
+    expect(
+      connectorErrors(`[[triggers]]\nslug = "t"\ntype = "cron"\ncron = "0 9 * * *"\nprompt = "go"\nsession_mode = "Reuse"`),
+    ).not.toContain('triggers[0].session_mode');
+  });
+
+  test('connector provider is case-insensitive', () => {
+    expect(connectorErrors(`[[connectors]]\nslug = "m"\nprovider = "MCP"\nurl = "https://e.com"`)).toEqual([]);
+  });
+
+  test('http connector accepts the baseUrl alias', () => {
+    expect(connectorErrors(`[[connectors]]\nslug = "h"\nprovider = "http"\nbaseUrl = "https://e.com"`)).toEqual([]);
+  });
+
+  test('an empty-string grant is accepted as deny', () => {
+    expect(
+      connectorErrors(`[[agents]]\nname = "a"\nkortix_cli = ""\nconnectors = ""`),
+    ).toEqual([]);
+  });
+
+  test('app enabled accepts coercible values', () => {
+    expect(
+      connectorErrors(`[[apps]]\nslug = "s"\nenabled = "yes"\n  [apps.source]\n  type = "git"`),
+    ).not.toContain('apps[0].enabled');
   });
 });
 

--- a/packages/manifest-schema/src/index.ts
+++ b/packages/manifest-schema/src/index.ts
@@ -30,9 +30,43 @@ const SLUG_RE = /^[a-z0-9][a-z0-9_-]{0,127}$/;
 export const ENV_NAME_RE = /^[A-Z_][A-Z0-9_]*$/;
 
 const TRIGGER_TYPES = ['cron', 'webhook'] as const;
-const CONNECTOR_PROVIDERS = ['pipedream', 'mcp', 'openapi', 'graphql', 'http'] as const;
+// Providers a kortix.toml may declare. `channel` is included because the
+// platform itself writes `[[connectors]] provider="channel"` into the manifest
+// when a Slack/email channel is connected (see executor/channel-manifest.ts), so
+// the gate must accept what the backend produces. MUST stay in sync with the
+// runtime parser's PROVIDERS in apps/api/src/projects/connectors.ts — enforced
+// by apps/api/src/__tests__/unit-connectors-parse.test.ts. `computer` is
+// deliberately absent: it is synth-only and never written to a manifest.
+const CONNECTOR_PROVIDERS = ['pipedream', 'mcp', 'openapi', 'graphql', 'http', 'channel'] as const;
 const CONNECTOR_AUTH_TYPES = ['bearer', 'basic', 'custom', 'none'] as const;
+/** Platforms a `channel` connector can target — mirrors connectors.ts CHANNEL_PLATFORMS. */
+const CHANNEL_PLATFORMS = ['slack', 'email'] as const;
+/**
+ * Platform-owned slugs and the only provider allowed to use each — mirrors
+ * connectors.ts RESERVED_SLUG_PROVIDERS so a user app can't shadow the built-in
+ * catalog (the bug that made `slack thread` 404; see KORTIX-206).
+ */
+const RESERVED_SLUG_PROVIDERS: Readonly<Record<string, string>> = {
+  kortix_slack: 'channel',
+  kortix_email: 'channel',
+  computer: 'computer',
+};
 const CONNECTOR_POLICY_ACTIONS = ['always_run', 'require_approval', 'block'] as const;
+
+/**
+ * True when `v` is a value the runtime's `coerceBool` recognizes for an
+ * `enabled` flag (apps/api/.../triggers.ts coerceBool). The runtime accepts
+ * booleans, 0/1, and the strings true/false/1/0/yes/no/on/off (case-insensitive)
+ * — the gate must accept the same set or it falsely rejects manifests that
+ * materialize fine. Genuine garbage (e.g. "maybe", a table) is still flagged.
+ */
+function isEnabledValue(v: unknown): boolean {
+  if (typeof v === 'boolean' || typeof v === 'number') return true;
+  if (typeof v === 'string') {
+    return ['true', 'false', '1', '0', 'yes', 'no', 'on', 'off'].includes(v.trim().toLowerCase());
+  }
+  return false;
+}
 
 const SANDBOX_CPU_BOUNDS = { min: 1, max: 32 } as const;
 const SANDBOX_MEMORY_BOUNDS = { min: 1, max: 128 } as const;
@@ -162,8 +196,9 @@ function validateGrantList(
 ): void {
   if (value === undefined || value === null) return;
   if (typeof value === 'string') {
+    // Runtime parseGrantSet treats "" the same as "none" (default-deny).
     const v = value.trim().toLowerCase();
-    if (v !== 'all' && v !== 'none') {
+    if (v !== '' && v !== 'all' && v !== 'none') {
       issues.push({ path: where, message: `${label} string must be "all" or "none" (or an array of names).`, severity: 'error' });
     }
     return;
@@ -532,8 +567,16 @@ function validateTriggers(node: unknown, path: string, issues: ManifestIssue[]):
         severity: 'error',
       });
     }
-    const prompt = typeof entry.prompt === 'string' ? entry.prompt : '';
-    if (!prompt.trim()) {
+    // Aliases below mirror the runtime parser's input tolerance
+    // (apps/api/.../triggers.ts parseTriggerEntry): `prompt`/`prompt_template`,
+    // `cron`/`schedule`, `run_at`/`runAt`, `secret_env`/`secretEnv`,
+    // `session_mode`/`sessionMode`. The gate must accept whatever the runtime
+    // accepts, or it falsely blocks a manifest that materializes fine.
+    const promptRaw =
+      typeof entry.prompt === 'string' ? entry.prompt
+      : typeof entry.prompt_template === 'string' ? entry.prompt_template
+      : '';
+    if (!promptRaw.trim()) {
       issues.push({
         path: `${where}.prompt`,
         message: 'prompt is required and may not be empty.',
@@ -541,10 +584,16 @@ function validateTriggers(node: unknown, path: string, issues: ManifestIssue[]):
       });
     }
     if (type === 'cron') {
-      const cron = typeof entry.cron === 'string' ? entry.cron.trim() : '';
+      const cron =
+        typeof entry.cron === 'string' ? entry.cron.trim()
+        : typeof entry.schedule === 'string' ? entry.schedule.trim()
+        : '';
       // A one-off ("run once") schedule carries `run_at` (ISO-8601 instant)
       // instead of a recurring `cron` expression — exactly one must be set.
-      const runAt = typeof entry.run_at === 'string' ? entry.run_at.trim() : '';
+      const runAt =
+        typeof entry.run_at === 'string' ? entry.run_at.trim()
+        : typeof entry.runAt === 'string' ? entry.runAt.trim()
+        : '';
       if (runAt) {
         if (Number.isNaN(Date.parse(runAt))) {
           issues.push({
@@ -568,7 +617,10 @@ function validateTriggers(node: unknown, path: string, issues: ManifestIssue[]):
         });
       }
     } else if (type === 'webhook') {
-      const secret = typeof entry.secret_env === 'string' ? entry.secret_env.trim() : '';
+      const secret =
+        typeof entry.secret_env === 'string' ? entry.secret_env.trim()
+        : typeof entry.secretEnv === 'string' ? entry.secretEnv.trim()
+        : '';
       if (!secret) {
         issues.push({
           path: `${where}.secret_env`,
@@ -583,16 +635,19 @@ function validateTriggers(node: unknown, path: string, issues: ManifestIssue[]):
         });
       }
     }
-    if (entry.enabled !== undefined && typeof entry.enabled !== 'boolean') {
+    if (entry.enabled !== undefined && !isEnabledValue(entry.enabled)) {
       issues.push({
         path: `${where}.enabled`,
         message: 'enabled must be a boolean.',
         severity: 'error',
       });
     }
-    if (entry.session_mode !== undefined) {
-      const sessionMode =
-        typeof entry.session_mode === 'string' ? entry.session_mode.trim() : '';
+    const sessionModeRaw =
+      typeof entry.session_mode === 'string' ? entry.session_mode
+      : typeof entry.sessionMode === 'string' ? entry.sessionMode
+      : undefined;
+    if (sessionModeRaw !== undefined) {
+      const sessionMode = sessionModeRaw.trim().toLowerCase();
       if (sessionMode !== 'fresh' && sessionMode !== 'reuse') {
         issues.push({
           path: `${where}.session_mode`,
@@ -635,11 +690,31 @@ function validateConnectors(
     } else {
       seenSlugs.add(slug);
     }
-    const provider = typeof entry.provider === 'string' ? entry.provider : '';
-    if (!(CONNECTOR_PROVIDERS as readonly string[]).includes(provider)) {
+    // Runtime parser lowercases provider/auth.type/policy.action/platform before
+    // matching — mirror that so a manifest using "MCP" or "Slack" isn't blocked.
+    const provider = typeof entry.provider === 'string' ? entry.provider.trim().toLowerCase() : '';
+    if (provider === 'computer') {
+      // Synth-only: a `computer` connector materializes when a machine is
+      // connected over the Agent Computer Tunnel — it is never declared by hand.
+      issues.push({
+        path: `${where}.provider`,
+        message:
+          'provider="computer" is managed automatically when you connect a machine (Computers) — it cannot be declared in kortix.toml.',
+        severity: 'error',
+      });
+    } else if (!(CONNECTOR_PROVIDERS as readonly string[]).includes(provider)) {
       issues.push({
         path: `${where}.provider`,
         message: `provider must be one of: ${CONNECTOR_PROVIDERS.join(', ')} (got "${provider || 'unset'}").`,
+        severity: 'error',
+      });
+    }
+    // Reserved platform-owned slugs accept only their built-in provider.
+    const reservedProvider = RESERVED_SLUG_PROVIDERS[slug];
+    if (reservedProvider && provider !== reservedProvider) {
+      issues.push({
+        path: `${where}.provider`,
+        message: `"${slug}" is reserved for the built-in ${reservedProvider} connector (provider="${reservedProvider}").`,
         severity: 'error',
       });
     }
@@ -664,12 +739,22 @@ function validateConnectors(
         severity: 'error',
       });
     }
-    if (provider === 'http' && typeof entry.base_url !== 'string') {
+    if (provider === 'http' && typeof entry.base_url !== 'string' && typeof entry.baseUrl !== 'string') {
       issues.push({
         path: `${where}.base_url`,
         message: 'http connectors require `base_url`.',
         severity: 'error',
       });
+    }
+    if (provider === 'channel') {
+      const platform = typeof entry.platform === 'string' ? entry.platform.trim().toLowerCase() : '';
+      if (!(CHANNEL_PLATFORMS as readonly string[]).includes(platform)) {
+        issues.push({
+          path: `${where}.platform`,
+          message: `channel connectors require \`platform\` one of: ${CHANNEL_PLATFORMS.join(', ')} (got "${platform || 'unset'}").`,
+          severity: 'error',
+        });
+      }
     }
     // Optional [connectors.auth]
     if (entry.auth !== undefined) {
@@ -677,11 +762,18 @@ function validateConnectors(
       if (!isTable(auth)) {
         issues.push({ path: `${where}.auth`, message: 'auth must be a table.', severity: 'error' });
       } else {
-        const t = typeof auth.type === 'string' ? auth.type : '';
+        const t = typeof auth.type === 'string' ? auth.type.trim().toLowerCase() : '';
         if (!(CONNECTOR_AUTH_TYPES as readonly string[]).includes(t)) {
           issues.push({
             path: `${where}.auth.type`,
             message: `auth.type must be one of: ${CONNECTOR_AUTH_TYPES.join(', ')} (got "${t || 'unset'}").`,
+            severity: 'error',
+          });
+        }
+        if (provider === 'channel' && t !== 'none') {
+          issues.push({
+            path: `${where}.auth`,
+            message: 'channel connectors authenticate via the platform install token — omit [connectors.auth].',
             severity: 'error',
           });
         }
@@ -717,7 +809,7 @@ function validateConnectors(
               severity: 'error',
             });
           }
-          const action = typeof p.action === 'string' ? p.action : '';
+          const action = typeof p.action === 'string' ? p.action.trim().toLowerCase() : '';
           if (!(CONNECTOR_POLICY_ACTIONS as readonly string[]).includes(action)) {
             issues.push({
               path: `${pwhere}.action`,
@@ -760,7 +852,7 @@ function validateChannels(node: unknown, path: string, issues: ManifestIssue[]):
     } else {
       seenPlatforms.add(platform);
     }
-    if (entry.enabled !== undefined && typeof entry.enabled !== 'boolean') {
+    if (entry.enabled !== undefined && !isEnabledValue(entry.enabled)) {
       issues.push({ path: `${where}.enabled`, message: 'enabled must be a boolean.', severity: 'error' });
     }
     if (entry.events !== undefined) {
@@ -806,7 +898,7 @@ function validateApps(node: unknown, path: string, issues: ManifestIssue[]): voi
     }
     expectStringOrAbsent(entry.name, `${where}.name`, issues);
     expectStringOrAbsent(entry.framework, `${where}.framework`, issues);
-    if (entry.enabled !== undefined && typeof entry.enabled !== 'boolean') {
+    if (entry.enabled !== undefined && !isEnabledValue(entry.enabled)) {
       issues.push({ path: `${where}.enabled`, message: 'enabled must be a boolean.', severity: 'error' });
     }
     if (entry.domains !== undefined) {


### PR DESCRIPTION
## Problem

The canonical `kortix.toml` validator (`@kortix/manifest-schema`, run as the **CR-merge gate** in `apps/api/.../routes/r9.ts`) had drifted from the **runtime parser** in `apps/api/src/projects/`. The gate was rejecting manifests the platform itself produces and the runtime happily materializes.

**Reported bug:** the platform writes `[[connectors]] provider="channel"` into `kortix.toml` when a Slack/email channel is connected (`executor/channel-manifest.ts`), but `channel` was missing from the schema's provider enum. So once you connected Slack, *every* subsequent CR merge failed with:

> `connectors[0].provider: provider must be one of: pipedream, mcp, openapi, graphql, http (got "channel")`

## What changed

**Connectors:** added `channel` (requires `platform`, must omit `[connectors.auth]`), the reserved-slug pairing (`kortix_slack`/`kortix_email` → `channel`), and a specific message for the synth-only `computer` provider.

**Full audit + same-class fixes:** I audited *every* manifest section against its runtime source of truth. Fixed the same bug class (gate rejects what the runtime accepts) for **triggers** and **grants**:
- alias keys: `prompt_template`, `schedule`/`runAt`, `secretEnv`, `sessionMode`
- `enabled` coercion (booleans, `0/1`, `yes/no/on/off`)
- case-insensitive `provider` / `auth.type` / `policy.action` / `platform` / `session_mode`
- http `baseUrl` alias, empty-string grants as default-deny

All changes are **accept-more** — no previously-valid manifest is newly blocked. The grant-action set, `[env]`, `[opencode]`, and `[project]` were already in sync.

**Drift guards:** new tests feed the same provider/trigger shapes through *both* the runtime parser and the schema gate and assert they agree, so the two enums can't silently diverge again.

## Not in this PR (deliberate)

The audit also found *too-lax* gaps (gate passes what the runtime rejects: `[[apps]]` source/env required, sandbox template slug length, mcp `transport`, `credential`, openapi `spec`). These don't block valid work — they fail later at runtime. Tightening the gate is the risky direction, so I left them out; they're better added as **warnings** if we want them surfaced. Happy to follow up.

## Tests

- `packages/manifest-schema` validator: 52 pass (+8 tolerance tests)
- `unit-connectors-parse` drift guard: 40 pass
- `unit-trigger-dsl` drift guard: 40 pass
- `unit-agents-parse` (grant-action sync): 21 pass · `unit-apps-parse`: 31 pass
- `tsc --noEmit` clean