### PR TITLE
fix(slack): require user identity by default

### DIFF
--- a/apps/api/src/__tests__/unit-slack-commands.test.ts
+++ b/apps/api/src/__tests__/unit-slack-commands.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
 
 // Slash command handlers for agent/model selection + session visibility.
 
@@ -47,6 +47,7 @@ mock.module('../accounts/core/app', () => ({
     new Map(ids.map((id) => [id, `${id}@example.com`])),
 }));
 
+const { config } = await import('../config');
 const { handleSlashCommand } = await import('../channels/slack/commands');
 
 const ctx = { teamId: 'T1', channelId: 'C1', slackUserId: 'U1', command: '/kortix' };
@@ -91,10 +92,17 @@ describe('unknown subcommand', () => {
   });
 });
 
-// Per-user identity is OFF by default (SLACK_REQUIRE_USER_IDENTITY unset in the
-// test env), so the whole feature is dark: login/logout are not real subcommands
-// and help never advertises them.
 describe('identity feature gated OFF', () => {
+  const originalRequireIdentity = config.SLACK_REQUIRE_USER_IDENTITY;
+
+  beforeEach(() => {
+    config.SLACK_REQUIRE_USER_IDENTITY = false;
+  });
+
+  afterEach(() => {
+    config.SLACK_REQUIRE_USER_IDENTITY = originalRequireIdentity;
+  });
+
   test('/login is an unknown subcommand', async () => {
     const resp = await handleSlashCommand('login', '', ctx);
     expect(resp.text).toContain('Unknown subcommand');

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -168,13 +168,11 @@ const envSchema = z.object({
   // Optional banner image rendered at the top of the App Home tab. Must be a
   // public HTTPS URL Slack can fetch (no auth). Recommended 1600×400 PNG.
   SLACK_HOME_HERO_URL:         optStr,
-  // Feature flag for per-Slack-user identity. OFF (default): every Slack message
-  // runs as the account owner (legacy behavior). ON: each sender must link their
-  // own Kortix account via `/kortix login` (a member of the project's account)
-  // and the agent runs AS them; unlinked senders are blocked. `/kortix login`
-  // and the bind endpoint stay available regardless, so users can pre-link
-  // before the flag is flipped on.
-  SLACK_REQUIRE_USER_IDENTITY: optBoolFalse,
+  // Per-Slack-user identity. Default-on: each sender must link their own Kortix
+  // account via `/kortix login` and the agent runs AS them; unlinked senders
+  // are blocked. Set explicitly to "false" only for legacy fallback where
+  // Slack messages should run as the bound project owner.
+  SLACK_REQUIRE_USER_IDENTITY: optBoolTrue,
 
   // ── Channels — AgentMail email adapter (optional) ────────────────────────
   AGENTMAIL_API_URL:           optUrl('https://api.agentmail.to/v0'),

--- a/infra/k8s/envs/prod/values.yaml
+++ b/infra/k8s/envs/prod/values.yaml
@@ -14,6 +14,10 @@ env:
 # Explicit container env (overrides the kortix-prod-env secret bundle — k8s env
 # wins over envFrom).
 extraEnv:
+  # Slack identity gate ON in prod so Slack @mentions require the caller to
+  # connect their Kortix account and pass project access checks. Kept explicit
+  # here so k8s env overrides any stale value in the synced secret bundle.
+  SLACK_REQUIRE_USER_IDENTITY: "true"
   # Point sandboxes at the standalone LLM gateway. Must be the PUBLIC host —
   # sandboxes are remote Daytona VMs that can't resolve cluster DNS. Without it
   # the API falls back to its in-API /v1/llm passthrough (OpenRouter-only, wrong


### PR DESCRIPTION
## Summary
- Make `SLACK_REQUIRE_USER_IDENTITY` default to true in API config.
- Keep the legacy off-path available by explicitly setting the flag to `false`.
- Add explicit prod GitOps env override so production cannot inherit a stale `false` from the synced secret bundle.
- Update Slack command tests so the gated-off behavior is explicit instead of relying on an unset env.

## Verification
- `DATABASE_URL=postgres://user:pass@localhost:5432/test SUPABASE_URL=http://localhost:54321 SUPABASE_SERVICE_ROLE_KEY=test API_KEY_SECRET=test TUNNEL_ENABLED=false DAYTONA_API_KEY=test DAYTONA_SERVER_URL=https://daytona.test DAYTONA_TARGET=test bun test apps/api/src/__tests__/unit-slack-commands.test.ts apps/api/src/channels/slack/__tests__/commands-identity-on.test.ts apps/api/src/__tests__/unit-slack-dispatch-session.test.ts apps/api/src/__tests__/unit-slack-session-selection.test.ts`
- Same dummy env: `bun -e "const { config } = await import('./apps/api/src/config.ts'); if (config.SLACK_REQUIRE_USER_IDENTITY !== true) throw new Error('expected true'); console.log('SLACK_REQUIRE_USER_IDENTITY default', config.SLACK_REQUIRE_USER_IDENTITY)"`
- `helm template` for dev, staging, and prod values all renders `SLACK_REQUIRE_USER_IDENTITY` as `true`.