### PR TITLE
chore(release): unblock Slack identity release gates

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -33,3 +33,14 @@ paths = [
 regexes = [
   '''enterprise[A-Za-z0-9]+''',
 ]
+
+[[allowlists]]
+description = "False-positive UUID defaults in the local Slack auth fixture seeder. These are deterministic local fixture IDs, not credentials. Keep the exception scoped to the script and the two literal UUIDs so any real secret still fails."
+condition = "AND"
+paths = [
+  '''apps/api/scripts/slack-auth-fixtures\.ts$''',
+]
+regexes = [
+  '''95788432-f5df-4ffe-af9e-0ed4e03cf96e''',
+  '''b4a01f33-d46c-4a96-8a1d-0a265e48978f''',
+]

--- a/apps/api/scripts/slack-auth-fixtures.ts
+++ b/apps/api/scripts/slack-auth-fixtures.ts
@@ -279,7 +279,7 @@ Usage:
 Workspace: ${workspaceId}
 Slack user: ${slackUserId}
 Project: ${projectId}
-Fixture password: ${password}
+Fixture password: set by SLACK_AUTH_FIXTURE_PASSWORD or the local fixture default
 `);
 }
 

--- a/packages/shared/src/utils/format-relative.test.ts
+++ b/packages/shared/src/utils/format-relative.test.ts
@@ -91,15 +91,15 @@ describe('formatRelative future times', () => {
   });
 
   test('renders future minutes when future is enabled', () => {
-    expect(formatRelative(ahead(5 * MINUTE), { future: true })).toBe('in 5m');
+    expect(formatRelative(ahead(5 * MINUTE + 5 * SECOND), { future: true })).toBe('in 5m');
   });
 
   test('renders future hours when future is enabled', () => {
-    expect(formatRelative(ahead(3 * HOUR), { future: true })).toBe('in 3h');
+    expect(formatRelative(ahead(3 * HOUR + 5 * SECOND), { future: true })).toBe('in 3h');
   });
 
   test('renders future days when future is enabled', () => {
-    expect(formatRelative(ahead(2 * DAY), { future: true })).toBe('in 2d');
+    expect(formatRelative(ahead(2 * DAY + 5 * SECOND), { future: true })).toBe('in 2d');
   });
 
   test('uses the default sub-minute future label', () => {

--- a/tests/performance/session-start/daytona-spike-repro.mjs
+++ b/tests/performance/session-start/daytona-spike-repro.mjs
@@ -28,7 +28,7 @@ const sdkVersion = (() => { try { return createRequire(import.meta.url)('@dayton
   for (let i = 0; i < N; i++) {
     const startedAt = new Date().toISOString();
     const t0 = Date.now();
-    let id = null, ms = null, err = null, state = null;
+    let id = null, ms, err = null, state = null;
     try {
       const sb = await d.create({ snapshot: SNAPSHOT }, { timeout: 120 });
       ms = Date.now() - t0;
@@ -36,9 +36,10 @@ const sdkVersion = (() => { try { return createRequire(import.meta.url)('@dayton
       state = sb.state ?? null;
       orgId = orgId || sb.organizationId || sb.orgId || null;
     } catch (e) { err = e.message?.slice(0, 160); ms = Date.now() - t0; }
-    const spike = ms != null && ms >= SPIKE_MS;
+    const hasTiming = typeof ms === 'number';
+    const spike = hasTiming && ms >= SPIKE_MS;
     rows.push({ i: i + 1, startedAt, id, ms, state, err, spike });
-    console.log(`#${String(i + 1).padStart(2)} ${startedAt} create->running=${ms != null ? ms + 'ms' : 'FAIL'}${spike ? '  <<< SPIKE' : ''}  id=${id ?? '-'}${err ? `  err=${err}` : ''}`);
+    console.log(`#${String(i + 1).padStart(2)} ${startedAt} create->running=${hasTiming ? ms + 'ms' : 'FAIL'}${spike ? '  <<< SPIKE' : ''}  id=${id ?? '-'}${err ? `  err=${err}` : ''}`);
     if (id) { try { await d.delete(await d.get(id), 30); } catch {} }
     await sleep(1200);
   }

--- a/tests/performance/session-start/platinum-bench.mjs
+++ b/tests/performance/session-start/platinum-bench.mjs
@@ -51,7 +51,7 @@ const j = async (p, o = {}) => {
       s.error = `${e.name}: ${e.message?.slice(0, 120)}`;
       console.log(`#${i + 1} ERR ${s.error}`);
     } finally {
-      if (id) { const d = await j(`/v1/sandboxes/${id}`, { method: 'DELETE' }).catch(() => null); }
+      if (id) { await j(`/v1/sandboxes/${id}`, { method: 'DELETE' }).catch(() => null); }
     }
     samples.push(s);
     if (i < N - 1) await sleep(1500);


### PR DESCRIPTION
## Summary
- Add a narrow gitleaks allowlist for deterministic local Slack auth fixture UUIDs, scoped to the Slack fixture seeder and literal fixture IDs only.
- Make future relative-time tests avoid exact minute/hour/day boundaries so CI cannot drift from `in 5m` to `in 4m` during assertion timing.

## Verification
- `bun test packages/shared/src/utils/format-relative.test.ts`
- `gitleaks 8.30.1 git --log-opts=origin/main..HEAD --redact --verbose --exit-code 1`

## Release context
This keeps the latest Slack identity-required release path green on main before promoting the same head to staging and production.
