### PR TITLE
fix(desktop): give electron-builder a publish provider (fixes build crash)

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -390,6 +390,11 @@ jobs:
           CSC_KEY_PASSWORD: ${{ steps.sign.outputs.enabled == 'true' && secrets.APPLE_CERTIFICATE_PASSWORD || '' }}
           APPLE_API_KEY_ID: ${{ steps.sign.outputs.enabled == 'true' && secrets.APPLE_API_KEY || '' }}
           APPLE_API_ISSUER: ${{ steps.sign.outputs.enabled == 'true' && secrets.APPLE_API_ISSUER || '' }}
+          # Apple-ID notarization fallback — electron-builder uses whichever set
+          # is populated (API key above OR Apple-ID here).
+          APPLE_ID: ${{ steps.sign.outputs.enabled == 'true' && secrets.APPLE_ID || '' }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ steps.sign.outputs.enabled == 'true' && (secrets.APPLE_APP_SPECIFIC_PASSWORD || secrets.APPLE_PASSWORD) || '' }}
+          APPLE_TEAM_ID: ${{ steps.sign.outputs.enabled == 'true' && secrets.APPLE_TEAM_ID || '' }}
           WIN_CSC_LINK: ${{ steps.sign.outputs.enabled == 'true' && secrets.WINDOWS_CERTIFICATE || '' }}
           WIN_CSC_KEY_PASSWORD: ${{ steps.sign.outputs.enabled == 'true' && secrets.WINDOWS_CERTIFICATE_PASSWORD || '' }}
           CSC_IDENTITY_AUTO_DISCOVERY: ${{ steps.sign.outputs.enabled }}

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -130,6 +130,11 @@ jobs:
           CSC_KEY_PASSWORD: ${{ steps.sign.outputs.enabled == 'true' && secrets.APPLE_CERTIFICATE_PASSWORD || '' }}
           APPLE_API_KEY_ID: ${{ steps.sign.outputs.enabled == 'true' && secrets.APPLE_API_KEY || '' }}
           APPLE_API_ISSUER: ${{ steps.sign.outputs.enabled == 'true' && secrets.APPLE_API_ISSUER || '' }}
+          # Apple-ID notarization fallback — electron-builder uses whichever set
+          # is populated (API key above OR Apple-ID here).
+          APPLE_ID: ${{ steps.sign.outputs.enabled == 'true' && secrets.APPLE_ID || '' }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ steps.sign.outputs.enabled == 'true' && (secrets.APPLE_APP_SPECIFIC_PASSWORD || secrets.APPLE_PASSWORD) || '' }}
+          APPLE_TEAM_ID: ${{ steps.sign.outputs.enabled == 'true' && secrets.APPLE_TEAM_ID || '' }}
           # Windows signing (pfx via CSC_*). Both runners read CSC_*; only the
           # matching platform's secret is non-empty.
           WIN_CSC_LINK: ${{ steps.sign.outputs.enabled == 'true' && secrets.WINDOWS_CERTIFICATE || '' }}

--- a/apps/desktop-electron/electron-builder.yml
+++ b/apps/desktop-electron/electron-builder.yml
@@ -9,6 +9,15 @@ appId: com.kortix.desktop
 productName: Kortix
 copyright: © Kortix
 
+# Publish target. We never auto-publish from electron-builder (CI uploads the
+# artifacts itself with --publish never), but a concrete provider is REQUIRED:
+# without it electron-builder can't infer one ("Cannot detect repository") and
+# crashes generating update metadata (computeChannelNames → channel of null).
+publish:
+  provider: github
+  owner: kortix-ai
+  repo: suna
+
 directories:
   output: dist
   buildResources: build

--- a/apps/desktop-electron/package.json
+++ b/apps/desktop-electron/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "description": "Kortix desktop shell — Electron wrapper around the web app",
   "author": "Kortix",
+  "repository": "https://github.com/kortix-ai/suna",
   "main": "src/main.js",
   "scripts": {
     "setup": "node scripts/ensure-runtime.js",


### PR DESCRIPTION
Follow-up to #3928. All three desktop CI legs built their installers (.dmg/.exe/.AppImage) but crashed at the end in electron-builder's update-info step (`computeChannelNames → Cannot read 'channel' of null`) because CI's git checkout can't auto-detect a publish provider ("Cannot detect repository by .git/config").

Fix: set an explicit `publish: github` provider in electron-builder.yml (we still pass `--publish never`; this only lets the update-info file generate). Verified locally — now builds the dmg **and** `latest-mac.yml` with no crash. Also adds `repository` to package.json and an Apple-ID notarization env fallback.