### PR TITLE
fix(desktop): name dev builds 'Kortix Dev' (distinct from prod 'Kortix')

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -123,6 +123,8 @@ jobs:
             --publish never \
             --config.extraMetadata.version="${{ steps.ver.outputs.version }}" \
             --config.extraMetadata.kortixDefaultUrl="$DESKTOP_URL" \
+            --config.productName="Kortix Dev" \
+            --config.extraMetadata.productName="Kortix Dev" \
             --config.appId="$DESKTOP_APP_ID"
         env:
           # macOS signing + notarization (electron-builder conventions).

--- a/apps/desktop-electron/package.json
+++ b/apps/desktop-electron/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@kortix/desktop-electron",
+  "productName": "Kortix",
   "version": "0.1.0",
   "private": true,
   "description": "Kortix desktop shell — Electron wrapper around the web app",

--- a/apps/desktop-electron/src/main.js
+++ b/apps/desktop-electron/src/main.js
@@ -26,12 +26,12 @@ const {
 const path = require('node:path');
 const fs = require('node:fs');
 
-// Stable product name → clean UA token. Set before anything reads it.
-app.setName('Kortix');
-// Dedicated data dir. Isolating from the default "Kortix" Application Support
-// folder avoids inheriting another app's stale Chromium state (per-site zoom,
-// GPU cache) — a real cause of blurry rendering.
-app.setPath('userData', path.join(app.getPath('appData'), 'Kortix Desktop'));
+// Name comes from the bundle (productName): "Kortix" for prod, "Kortix Dev" for
+// dev builds. Per-name data dir so dev + prod coexist without sharing a session,
+// and so we never inherit another "Kortix" app's stale Chromium state (per-site
+// zoom / GPU cache) — a real cause of blurry rendering. `${name} Desktop` keeps
+// us off the bare "Kortix" Application Support folder.
+app.setPath('userData', path.join(app.getPath('appData'), `${app.getName()} Desktop`));
 
 /* ─── Config ──────────────────────────────────────────────────────────── */
 
@@ -689,9 +689,12 @@ function registerIpc() {
    append the KortixDesktop marker the web middleware + isDesktop() rely on. */
 
 function applyUserAgent() {
+  // Strip the Electron token and the product token (whatever the app is named —
+  // "Kortix" or "Kortix Dev") before appending the stable KortixDesktop marker.
+  const name = app.getName().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   const ua = app.userAgentFallback
     .replace(/\sElectron\/\S+/, '')
-    .replace(/\sKortix\/\S+/, '');
+    .replace(new RegExp(`\\s${name}\\/\\S+`), '');
   app.userAgentFallback = `${ua} ${UA_TOKEN}`;
 }
 


### PR DESCRIPTION
Follow-up to #3928. Dev installers were named **Kortix** just like prod (only the bundle id differed: `com.kortix.desktop.dev`), so a dev install would collide with prod in /Applications.

Restores the old Tauri behavior:
- **Dev** builds → `Kortix Dev.app` (`com.kortix.desktop.dev`), own data dir `Kortix Dev Desktop`.
- **Prod** builds → `Kortix.app` (`com.kortix.desktop`), data dir `Kortix Desktop` (unchanged).

Sets both `--config.productName` (bundle/CFBundleName) **and** `--config.extraMetadata.productName` (runtime app.getName) for the dev build; drops the hardcoded `app.setName('Kortix')` so the runtime name, userData dir, and UA token all follow the bundle's productName. Verified locally: dev build → `Kortix Dev.app` / CFBundleName `Kortix Dev`; prod → `Kortix.app`.