### PR TITLE
revert(prod): rollback to v0.9.84 and disable Slack identity

### DIFF
--- a/infra/k8s/envs/prod/gateway-values.yaml
+++ b/infra/k8s/envs/prod/gateway-values.yaml
@@ -5,7 +5,7 @@
 
 # Immutable release tag (promote bumps this). NOT :latest in GitOps.
 image:
-  tag: "0.9.85"
+  tag: "0.9.84"
 # Prod HA: 3-replica floor, burst to 12 (matches the API's envelope).
 replicas: 3
 autoscaling:

--- a/infra/k8s/envs/prod/values.yaml
+++ b/infra/k8s/envs/prod/values.yaml
@@ -5,17 +5,16 @@
 
 # Immutable release tag (promote bumps this). NOT :latest / :dev-latest in GitOps.
 image:
-  tag: "0.9.85"
-kortixVersion: "0.9.85"
+  tag: "0.9.84"
+kortixVersion: "0.9.84"
 env:
   internalKortixEnv: prod
 # Explicit container env (overrides the kortix-prod-env secret bundle — k8s env
 # wins over envFrom).
 extraEnv:
-  # Slack identity gate ON in prod so Slack @mentions require the caller to
-  # connect their Kortix account and pass project access checks. Kept explicit
-  # here so k8s env overrides any stale value in the synced secret bundle.
-  SLACK_REQUIRE_USER_IDENTITY: "true"
+  # Incident rollback: keep Slack identity enforcement disabled until the Slack
+  # auth/interactivity bug is fixed and re-tested.
+  SLACK_REQUIRE_USER_IDENTITY: "false"
   # Point sandboxes at the standalone LLM gateway. Must be the PUBLIC host —
   # sandboxes are remote Daytona VMs that can't resolve cluster DNS. Without it
   # the API falls back to its in-API /v1/llm passthrough (OpenRouter-only, wrong


### PR DESCRIPTION
## Production incident rollback

- Pins prod API image/kortixVersion to `0.9.84`.
- Pins prod gateway image to `0.9.84`.
- Sets `SLACK_REQUIRE_USER_IDENTITY=false` while the Slack auth/interactivity bug is fixed.
- DB untouched.

This is intentionally narrow and GitOps-only so Argo reconciles prod cleanly.