### PR TITLE
fix(web): reconcile stuck tool result on run-complete (no hard refresh)

### DIFF
--- a/apps/web/src/hooks/opencode/idle-reconcile.store.test.ts
+++ b/apps/web/src/hooks/opencode/idle-reconcile.store.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+
+import type { Message, Part } from '@opencode-ai/sdk/v2/client';
+
+import { useSyncStore } from '@/stores/opencode-sync-store';
+
+import { hasUnsettledToolPart } from './idle-reconcile';
+
+// Integration test for the run-complete reconcile MECHANISM, end to end at the
+// store level: it drives the real `useSyncStore.hydrate` — exactly what
+// `reconcileSessionFromServer` calls with the server's authoritative messages —
+// and proves that a tool result left stuck in `pending` at the SSE stream-end
+// boundary snaps to `completed`, which is what makes the hard refresh
+// unnecessary. No mocks: this is the production store reducer.
+
+const SID = 'ses_test';
+const MID = 'msg_assistant_1';
+const PID = 'prt_show_1';
+
+function assistant(): Message {
+  return {
+    id: MID,
+    sessionID: SID,
+    role: 'assistant',
+    time: { created: 1 },
+  } as unknown as Message;
+}
+
+function showPart(state: {
+  status: string;
+  input?: Record<string, unknown>;
+  output?: string;
+}): Part {
+  return {
+    id: PID,
+    messageID: MID,
+    sessionID: SID,
+    type: 'tool',
+    tool: 'show',
+    callID: 'call_1',
+    state,
+  } as unknown as Part;
+}
+
+const partStatus = () =>
+  (useSyncStore.getState().parts[MID]?.[0] as any)?.state?.status as string | undefined;
+
+const predicate = () => {
+  const s = useSyncStore.getState();
+  return hasUnsettledToolPart(s.messages[SID] ?? [], s.parts);
+};
+
+describe('run-complete reconcile (store integration)', () => {
+  beforeEach(() => useSyncStore.getState().reset());
+
+  test('a stuck pending tool result is reconciled to completed by hydrate', () => {
+    // 1) Stream-end left the `show` tool part frozen in `pending` (its completed
+    //    result event was dropped) — the spinner that hangs until a refresh.
+    useSyncStore
+      .getState()
+      .hydrate(SID, [
+        { info: assistant(), parts: [showPart({ status: 'pending', input: { url: 'x' } })] },
+      ]);
+    expect(partStatus()).toBe('pending');
+    // The reconcile gate fires: a genuinely-unsettled tool part is present.
+    expect(predicate()).toBe(true);
+
+    // 2) reconcileSessionFromServer fetches the authoritative messages and
+    //    hydrates them — the same data a hard refresh loads. The server has the
+    //    SAME part id, now `completed` with output.
+    useSyncStore.getState().hydrate(SID, [
+      {
+        info: assistant(),
+        parts: [showPart({ status: 'completed', input: { url: 'x' }, output: '{"ok":true}' })],
+      },
+    ]);
+
+    // 3) The stuck spinner is gone — server's completed snapshot won, no refresh.
+    expect(partStatus()).toBe('completed');
+    expect((useSyncStore.getState().parts[MID]?.[0] as any)?.state?.output).toBe('{"ok":true}');
+    expect(predicate()).toBe(false);
+  });
+
+  test('reconcile is idempotent: hydrating an already-completed part is a no-op', () => {
+    const completed = {
+      info: assistant(),
+      parts: [showPart({ status: 'completed', input: { url: 'x' }, output: 'done' })],
+    };
+    useSyncStore.getState().hydrate(SID, [completed]);
+    expect(predicate()).toBe(false);
+    // A second reconcile (e.g. a redundant idle edge) must not regress it.
+    useSyncStore.getState().hydrate(SID, [completed]);
+    expect(partStatus()).toBe('completed');
+    expect(predicate()).toBe(false);
+  });
+});

--- a/apps/web/src/hooks/opencode/idle-reconcile.test.ts
+++ b/apps/web/src/hooks/opencode/idle-reconcile.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from 'bun:test';
+
+import type { Part } from '@opencode-ai/sdk/v2/client';
+
+import { hasUnsettledToolPart } from './idle-reconcile';
+
+// Minimal tool-part factory — only the fields the predicate reads.
+function toolPart(
+  id: string,
+  state: {
+    status: string;
+    input?: Record<string, unknown>;
+    raw?: unknown;
+    output?: string;
+  },
+): Part {
+  return { id, type: 'tool', tool: 'show', state } as unknown as Part;
+}
+
+const msgs = [{ id: 'm1' }];
+
+describe('hasUnsettledToolPart', () => {
+  test('running tool part → unsettled', () => {
+    const parts = { m1: [toolPart('p1', { status: 'running', input: { a: 1 } })] };
+    expect(hasUnsettledToolPart(msgs, parts)).toBe(true);
+  });
+
+  test('pending WITH input → unsettled (the stuck-spinner bug)', () => {
+    const parts = { m1: [toolPart('p1', { status: 'pending', input: { url: 'x' } })] };
+    expect(hasUnsettledToolPart(msgs, parts)).toBe(true);
+  });
+
+  test('pending with raw but empty input → unsettled', () => {
+    const parts = { m1: [toolPart('p1', { status: 'pending', input: {}, raw: '{partial' })] };
+    expect(hasUnsettledToolPart(msgs, parts)).toBe(true);
+  });
+
+  test('stale-pending (empty input, no raw) → settled (excluded)', () => {
+    const parts = { m1: [toolPart('p1', { status: 'pending', input: {} })] };
+    expect(hasUnsettledToolPart(msgs, parts)).toBe(false);
+  });
+
+  test('completed tool part → settled (the happy path: no refetch)', () => {
+    const parts = {
+      m1: [toolPart('p1', { status: 'completed', input: { url: 'x' }, output: 'done' })],
+    };
+    expect(hasUnsettledToolPart(msgs, parts)).toBe(false);
+  });
+
+  test('non-tool parts are ignored', () => {
+    const textPart = { id: 'p1', type: 'text', text: 'hello' } as unknown as Part;
+    expect(hasUnsettledToolPart(msgs, { m1: [textPart] })).toBe(false);
+  });
+
+  test('message with no parts → settled', () => {
+    expect(hasUnsettledToolPart(msgs, {})).toBe(false);
+  });
+
+  test('empty message list → settled even if stray parts exist', () => {
+    const parts = { m1: [toolPart('p1', { status: 'running' })] };
+    expect(hasUnsettledToolPart([], parts)).toBe(false);
+  });
+
+  test('mixed across messages: one completed + one running → unsettled', () => {
+    const messages = [{ id: 'm1' }, { id: 'm2' }];
+    const parts = {
+      m1: [toolPart('p1', { status: 'completed', input: { a: 1 }, output: 'ok' })],
+      m2: [toolPart('p2', { status: 'running', input: { b: 2 } })],
+    };
+    expect(hasUnsettledToolPart(messages, parts)).toBe(true);
+  });
+
+  test('all completed across messages → settled', () => {
+    const messages = [{ id: 'm1' }, { id: 'm2' }];
+    const parts = {
+      m1: [toolPart('p1', { status: 'completed', input: { a: 1 }, output: 'ok' })],
+      m2: [toolPart('p2', { status: 'completed', input: { b: 2 }, output: 'ok' })],
+    };
+    expect(hasUnsettledToolPart(messages, parts)).toBe(false);
+  });
+});

--- a/apps/web/src/hooks/opencode/idle-reconcile.ts
+++ b/apps/web/src/hooks/opencode/idle-reconcile.ts
@@ -1,0 +1,50 @@
+import type { Part } from '@opencode-ai/sdk/v2/client';
+
+/** Debounce window before the run-complete reconcile fires (ms). */
+export const IDLE_RECONCILE_DELAY_MS = 400;
+
+type ToolPartState = {
+  status?: string;
+  input?: Record<string, unknown>;
+  raw?: unknown;
+};
+
+/** Narrow a part to its tool state, or undefined if it isn't a tool part. */
+function readToolState(part: Part): ToolPartState | undefined {
+  const p = part as { type?: string; state?: ToolPartState };
+  if (p.type !== 'tool') return undefined;
+  return p.state;
+}
+
+/**
+ * True if any tool part in the session is still genuinely awaiting its result
+ * (running, or pending WITH input/raw) — i.e. a spinner that would otherwise
+ * hang after the run completes.
+ *
+ * Stale-pending parts (pending with empty input and no raw, abandoned when a
+ * run ends abruptly) are excluded: the server reports them pending too, so a
+ * refetch can't settle them, and the renderer already treats them as
+ * non-spinning (see ToolPartRenderer `isStalePending`).
+ *
+ * Pure + data-only (takes the session's messages and the parts-by-message map)
+ * so the stream-end reconcile decision is unit-testable without the event hook,
+ * the SDK, or the sync store.
+ */
+export function hasUnsettledToolPart(
+  messages: ReadonlyArray<{ id: string }>,
+  partsByMessageId: Readonly<Record<string, readonly Part[] | undefined>>,
+): boolean {
+  for (const m of messages) {
+    const parts = partsByMessageId[m.id];
+    if (!parts) continue;
+    for (const part of parts) {
+      const state = readToolState(part);
+      if (!state) continue;
+      if (state.status === 'running') return true;
+      if (state.status === 'pending' && (Object.keys(state.input ?? {}).length > 0 || state.raw)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}

--- a/apps/web/src/hooks/opencode/use-opencode-events.ts
+++ b/apps/web/src/hooks/opencode/use-opencode-events.ts
@@ -96,6 +96,84 @@ function scheduleProjectMetadataRefetch(queryClient: QueryClient): void {
   }
 }
 
+// ---- Reconcile-on-idle ----
+// When a run finishes, a tool call whose FINAL `message.part.updated` (the one
+// carrying its completed result) was dropped at the SSE stream-end boundary
+// stays frozen in `pending`/`running` — the tool keeps rendering its loading
+// spinner forever until a manual hard refresh re-fetches the persisted state.
+// (The reconnect rehydrate at the bottom of the stream loop only runs when the
+// gap was >5s, and `session.idle` itself never rehydrates messages.) On the
+// busy/retry → idle completion edge we refetch the authoritative messages and
+// `hydrate` — the same data a refresh loads, and for tool parts the server's
+// `completed` snapshot wins — so the stuck result resolves on its own.
+const IDLE_RECONCILE_DELAY_MS = 400;
+const idleReconcileTimers = new Map<string, ReturnType<typeof setTimeout>>();
+const idleReconcileInFlight = new Set<string>();
+
+/**
+ * True if the session has a tool part still genuinely awaiting its result
+ * (running, or pending WITH input/raw) — i.e. a spinner that would otherwise
+ * hang. Stale-pending parts (pending with empty input and no raw, abandoned
+ * when a run ends abruptly) are excluded: the server reports them pending too,
+ * so a refetch can't settle them and the renderer already treats them as
+ * non-spinning (see ToolPartRenderer `isStalePending`).
+ */
+function sessionHasUnsettledToolPart(sessionID: string): boolean {
+  const s = useSyncStore.getState();
+  const msgs = s.messages[sessionID] ?? [];
+  for (const m of msgs) {
+    const parts = s.parts[m.id];
+    if (!parts) continue;
+    for (const p of parts) {
+      const part = p as any;
+      if (part?.type !== 'tool') continue;
+      const state = part.state;
+      if (!state) continue;
+      if (state.status === 'running') return true;
+      if (state.status === 'pending' && (Object.keys(state.input ?? {}).length > 0 || state.raw)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+function reconcileSessionFromServer(sessionID: string): void {
+  if (idleReconcileInFlight.has(sessionID)) return;
+  idleReconcileInFlight.add(sessionID);
+  getClient()
+    .session.messages({ sessionID })
+    .then((res) => {
+      if (res.data) {
+        useSyncStore.getState().hydrate(sessionID, res.data as any);
+        const s = useSyncStore.getState();
+        const msgs = s.messages[sessionID] ?? [];
+        if (msgs.length > 0) saveSessionToIDB(sessionID, msgs, s.parts);
+      }
+    })
+    .catch(() => {})
+    .finally(() => idleReconcileInFlight.delete(sessionID));
+}
+
+/**
+ * Debounced reconcile fired on the run-complete edge. Re-checks at fire time so
+ * the common case — the completed-result event simply arrived a beat after idle
+ * via SSE — costs nothing; we only hit the network for a part that is STILL
+ * stuck after the settle window.
+ */
+function scheduleIdleReconcile(sessionID: string): void {
+  const existing = idleReconcileTimers.get(sessionID);
+  if (existing) clearTimeout(existing);
+  idleReconcileTimers.set(
+    sessionID,
+    setTimeout(() => {
+      idleReconcileTimers.delete(sessionID);
+      if (!sessionHasUnsettledToolPart(sessionID)) return;
+      reconcileSessionFromServer(sessionID);
+    }, IDLE_RECONCILE_DELAY_MS),
+  );
+}
+
 function refetchKortixSessionMirrors(queryClient: QueryClient): void {
   // OpenCode title/tree mirroring is owned by API session reads. When OpenCode
   // emits a title/tree change, refetch the active Kortix session reads so tabs
@@ -603,10 +681,32 @@ export function useOpenCodeEventStream() {
     }
 
     function handleEvent(event: OpenCodeEvent) {
+      // Detect the run-complete edge (busy/retry → idle) BEFORE applySyncEvent
+      // runs: it sets the session status to idle synchronously, which would
+      // otherwise mask the transition for the reconcile check below.
+      let completedSessionID: string | undefined;
+      if (event.type === 'session.idle' || event.type === 'session.status') {
+        const sid = (event.properties as any)?.sessionID as string | undefined;
+        const nextStatus =
+          event.type === 'session.idle' ? { type: 'idle' } : (event.properties as any)?.status;
+        if (sid && nextStatus?.type === 'idle') {
+          const prev = useSyncStore.getState().sessionStatus[sid];
+          if (prev && prev.type !== 'idle') completedSessionID = sid;
+        }
+      }
+
       // Sync store is the SINGLE source of truth for messages & parts.
       // This matches OpenCode's architecture where the SolidJS store is
       // the only place message/part data lives.
       applySyncEvent(event as OpenCodeSdkEvent);
+
+      // The run just finished. If a tool call is still showing a loading
+      // spinner because its completed-result event was dropped at the
+      // stream-end boundary, reconcile against the server (what a hard refresh
+      // would load) so it resolves without a manual refresh.
+      if (completedSessionID && sessionHasUnsettledToolPart(completedSessionID)) {
+        scheduleIdleReconcile(completedSessionID);
+      }
 
       switch (event.type) {
         // ---- Message events — handled by sync store only ----

--- a/apps/web/src/hooks/opencode/use-opencode-events.ts
+++ b/apps/web/src/hooks/opencode/use-opencode-events.ts
@@ -24,6 +24,7 @@ import { getActiveOpenCodeUrl, useServerStore } from '@/stores/server-store';
 import type { Event as OpenCodeSdkEvent, Part } from '@opencode-ai/sdk/v2/client';
 import { type QueryClient, useQueryClient } from '@tanstack/react-query';
 import { useEffect, useRef } from 'react';
+import { hasUnsettledToolPart, IDLE_RECONCILE_DELAY_MS } from './idle-reconcile';
 import { ptyKeys } from './use-opencode-pty';
 import { type MessageWithParts, opencodeKeys, type Session } from './use-opencode-sessions';
 import { resetPrefetchState } from './use-session-prefetch';
@@ -106,36 +107,13 @@ function scheduleProjectMetadataRefetch(queryClient: QueryClient): void {
 // busy/retry → idle completion edge we refetch the authoritative messages and
 // `hydrate` — the same data a refresh loads, and for tool parts the server's
 // `completed` snapshot wins — so the stuck result resolves on its own.
-const IDLE_RECONCILE_DELAY_MS = 400;
+// The unsettled-part predicate lives in ./idle-reconcile (pure + unit-tested).
 const idleReconcileTimers = new Map<string, ReturnType<typeof setTimeout>>();
 const idleReconcileInFlight = new Set<string>();
 
-/**
- * True if the session has a tool part still genuinely awaiting its result
- * (running, or pending WITH input/raw) — i.e. a spinner that would otherwise
- * hang. Stale-pending parts (pending with empty input and no raw, abandoned
- * when a run ends abruptly) are excluded: the server reports them pending too,
- * so a refetch can't settle them and the renderer already treats them as
- * non-spinning (see ToolPartRenderer `isStalePending`).
- */
 function sessionHasUnsettledToolPart(sessionID: string): boolean {
   const s = useSyncStore.getState();
-  const msgs = s.messages[sessionID] ?? [];
-  for (const m of msgs) {
-    const parts = s.parts[m.id];
-    if (!parts) continue;
-    for (const p of parts) {
-      const part = p as any;
-      if (part?.type !== 'tool') continue;
-      const state = part.state;
-      if (!state) continue;
-      if (state.status === 'running') return true;
-      if (state.status === 'pending' && (Object.keys(state.input ?? {}).length > 0 || state.raw)) {
-        return true;
-      }
-    }
-  }
-  return false;
+  return hasUnsettledToolPart(s.messages[sessionID] ?? [], s.parts);
 }
 
 function reconcileSessionFromServer(sessionID: string): void {
@@ -821,10 +799,7 @@ export function useOpenCodeEventStream() {
               // Shallow check: skip only if BOTH the timestamp and the title are
               // unchanged. Title alone can flip (opencode auto-titles) without a
               // perceptible time bump, and dropping that would keep the tab stale.
-              if (
-                old[idx].time.updated === info.time.updated &&
-                old[idx].title === info.title
-              )
+              if (old[idx].time.updated === info.time.updated && old[idx].title === info.title)
                 return old;
               const next = [...old];
               next[idx] = info;


### PR DESCRIPTION
## The bug

When an agent run finishes, the **last tool call can stay stuck on its loading spinner forever** even though the run is complete and the result is already persisted server-side. A **hard browser refresh fixes it instantly**. Reported against the `show` tool (presentation/URL), but it affects any tool.

> "we literally just finished the entirety of the thread… this was still loading, and then I hard refreshed. And after I hard refreshed, it just all worked perfectly… it just stopped looking into the result."

It's a **client-side reconciliation race at the stream-end boundary** — not a data problem (the server has the completed result, which is why refresh works).

## Root cause

The SSE event stream is the source of truth for live message/part state. A tool call renders its spinner while its part is `pending`/`running` and flips to its result when the **final `message.part.updated`** (carrying `state.status: "completed"`) arrives.

If that final event is dropped right as the stream closes, nothing reconciles it:

- The reconnect rehydrate only runs when the SSE **gap was >5s** (`use-opencode-events.ts`), and on a clean finish the gap is ~0.
- `session.idle` / `session.status → idle` update status and persist to IDB but **never refetch messages** (unlike `session.compacted`, which does refetch + `hydrate`).

So the part is frozen in `pending`/`running` → `ToolPartRenderer` keeps `isRunning = true` → spinner hangs until a manual refresh re-fetches the persisted state.

## The fix

On the **busy/retry → idle** completion edge, if any tool part is still unsettled, refetch the authoritative messages and `hydrate` — exactly the data a hard refresh loads. For tool parts `hydrate` takes the server's `completed` snapshot, so the stuck result resolves on its own.

Details that keep it cheap and safe:

- **Edge captured before `applySyncEvent`** — that call sets status to `idle` synchronously, which would otherwise mask the transition.
- **Gated** on an actually-unsettled tool part (`running`, or `pending` with input/raw). The normal case — everything already `completed` via SSE — does nothing. Stale-pending parts (abandoned when a run ends abruptly; empty input + no raw) are excluded, matching `ToolPartRenderer`'s `isStalePending`.
- **Debounced (~400ms) and re-checked at fire time**, so the common out-of-order case (the completed event simply arrived a beat after `idle`) costs **zero** network — only genuinely-stuck parts hit the server. In-flight guard prevents overlap.

Mirrors the existing `session.compacted` reconcile pattern.

## Files

- `apps/web/src/hooks/opencode/use-opencode-events.ts` — `scheduleIdleReconcile` + `sessionHasUnsettledToolPart` + `reconcileSessionFromServer`, triggered on the idle edge in `handleEvent`. (+100, isolated; no behavior change on the happy path.)

## Test plan

- [x] `tsc --noEmit` clean for the edited file (pre-existing unrelated `.test.ts` errors only).
- [ ] Preview env: run a session that ends on a tool call, confirm the result renders without a hard refresh; confirm normal runs are unaffected (no extra refetch when all parts already completed).
