### PR TITLE
feat(slack,gateway): one /kortix panel + real model picker + project model defaults

### DIFF
--- a/apps/api/src/__tests__/unit-slack-selection.test.ts
+++ b/apps/api/src/__tests__/unit-slack-selection.test.ts
@@ -32,10 +32,8 @@ mock.module('../projects/git', () => ({
 }));
 
 const {
-  RECOMMENDED_MODELS,
   currentChannelSelection,
   isValidModelId,
-  modelLabel,
   setChannelAgent,
   setChannelModel,
 } = await import('../channels/slack/selection');
@@ -56,26 +54,6 @@ describe('isValidModelId — provider/model shape only (no stale-catalog gate)',
     expect(isValidModelId('trailing/')).toBe(false);
     expect(isValidModelId('has space/model')).toBe(false);
     expect(isValidModelId('')).toBe(false);
-  });
-});
-
-describe('modelLabel', () => {
-  test('uses the friendly label for a recommended model', () => {
-    expect(modelLabel('anthropic/claude-opus-4-8')).toBe('Claude Opus 4.8');
-  });
-  test('falls back to the raw id for an unknown model', () => {
-    expect(modelLabel('exotic/model-x')).toBe('exotic/model-x');
-  });
-});
-
-describe('RECOMMENDED_MODELS', () => {
-  test('every entry is a valid id with a label + hint', () => {
-    expect(RECOMMENDED_MODELS.length).toBeGreaterThan(0);
-    for (const m of RECOMMENDED_MODELS) {
-      expect(isValidModelId(m.id)).toBe(true);
-      expect(m.label.length).toBeGreaterThan(0);
-      expect(m.hint.length).toBeGreaterThan(0);
-    }
   });
 });
 

--- a/apps/api/src/channels/slack/__tests__/commands-identity-on.test.ts
+++ b/apps/api/src/channels/slack/__tests__/commands-identity-on.test.ts
@@ -24,10 +24,9 @@ mock.module('../selection', () => ({
   setChannelConversationPolicy: async () => true,
   setChannelModel: async () => true,
   listProjectAgents: async () => [],
-  RECOMMENDED_MODELS: [],
   isValidModelId: () => true,
-  modelLabel: (id: string) => id,
 }));
+mock.module('../model-gate', () => ({ channelModelContext: async () => null }));
 mock.module('../participants', () => ({
   conversationPolicyLabel: () => 'Owner approval',
   normalizeConversationPolicy: () => 'owner_approval',

--- a/apps/api/src/channels/slack/__tests__/commands-panel.test.ts
+++ b/apps/api/src/channels/slack/__tests__/commands-panel.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+// The consolidated `/kortix` panel + the real-catalog model picker + the
+// servability gate (a stored model can never 404). Heavy deps are mocked; the
+// pure resolver module (effective.ts) is used for real.
+
+process.env.SLACK_REQUIRE_USER_IDENTITY = 'false';
+
+mock.module('../../../config', () => ({
+  config: { FRONTEND_URL: 'https://app.test', SLACK_REQUIRE_USER_IDENTITY: false },
+}));
+
+// FIFO db mock — slashPanel reads one project row.
+let dbResults: Array<unknown[]> = [];
+function makeChain(): any {
+  const chain: any = {};
+  for (const m of ['select', 'from', 'where', 'limit', 'leftJoin', 'orderBy']) chain[m] = () => chain;
+  chain.then = (resolve: (rows: unknown[]) => unknown) => Promise.resolve(resolve(dbResults.shift() ?? []));
+  return chain;
+}
+mock.module('../../../shared/db', () => ({ db: { select: () => makeChain() }, hasDatabase: () => true }));
+
+let selection: any = { projectId: 'p1', agentName: null, opencodeModel: null, conversationPolicy: null };
+mock.module('../selection', () => ({
+  currentChannelSelection: async () => selection,
+  isValidModelId: (s: string) => s.indexOf('/') > 0,
+  listProjectAgents: async () => [],
+  setChannelAgent: async () => true,
+  setChannelConversationPolicy: async () => true,
+  setChannelModel: mock(async () => true),
+}));
+
+let gate: any = { projectId: 'p1', accountId: 'a1', ownerUserId: 'u1', freeManagedOnly: false };
+mock.module('../model-gate', () => ({ channelModelContext: async () => gate }));
+
+mock.module('../../../llm-gateway/models/picker', () => ({
+  listPickerModels: async () => ({
+    models: [
+      { id: 'kortix/glm-5.2', label: 'GLM 5.2', provider: 'kortix', managed: true, hint: 'Balanced, fast' },
+      { id: 'kortix/claude-opus-4.8', label: 'Claude Opus 4.8', provider: 'kortix', managed: true, hint: 'Most capable' },
+    ],
+    projectDefault: { model: 'glm-5.2', source: 'platform', label: 'GLM 5.2' },
+  }),
+  labelForModelRef: (ref: string) => (ref.includes('glm') ? 'GLM 5.2' : ref),
+}));
+
+let servable = true;
+mock.module('../../../llm-gateway/resolution/default-model', () => ({
+  isModelServableForAccount: async () => servable,
+  resolveEffectiveModel: async () => ({ model: 'glm-5.2', source: 'project' }),
+}));
+
+mock.module('../participants', () => ({
+  conversationPolicyLabel: () => 'Owner approval',
+  normalizeConversationPolicy: () => 'owner_approval',
+}));
+mock.module('../identity', () => ({
+  lookupSlackIdentity: async () => null,
+  revokeSlackIdentity: async () => true,
+}));
+mock.module('../../../accounts/core/app', () => ({ lookupEmailsByUserIds: async () => new Map() }));
+
+const { handleSlashCommand } = await import('../commands');
+const { setChannelModel } = (await import('../selection')) as any;
+
+const ctx = { teamId: 'T1', channelId: 'C1', slackUserId: 'U1', command: '/kortix' };
+
+function actionIds(resp: any): string[] {
+  const ids: string[] = [];
+  for (const b of resp.blocks ?? []) {
+    if (b.accessory?.action_id) ids.push(b.accessory.action_id);
+    for (const el of b.elements ?? []) if (el.action_id) ids.push(el.action_id);
+  }
+  return ids;
+}
+
+beforeEach(() => {
+  dbResults = [];
+  selection = { projectId: 'p1', agentName: null, opencodeModel: null, conversationPolicy: null };
+  gate = { projectId: 'p1', accountId: 'a1', ownerUserId: 'u1', freeManagedOnly: false };
+  servable = true;
+  setChannelModel.mockClear();
+});
+
+describe('bare /kortix → channel panel', () => {
+  test('renders the project + inline change buttons (one command for everything)', async () => {
+    dbResults = [[{ projectId: 'p1', name: 'acme/api', repoUrl: 'https://github.com/acme/api', metadata: {} }]];
+    const resp = await handleSlashCommand('', '', ctx);
+    const ids = actionIds(resp);
+    expect(ids).toContain('cfg_open_models');
+    expect(ids).toContain('cfg_open_agents');
+    expect(ids).toContain('cfg_open_projects');
+    // honest effective-model + source line
+    expect(JSON.stringify(resp.blocks)).toContain('project default');
+  });
+
+  test('unconnected channel → a Connect button, not a "type switch" instruction', async () => {
+    selection = null;
+    const resp = await handleSlashCommand('config', '', ctx);
+    expect(actionIds(resp)).toContain('cfg_open_projects');
+  });
+});
+
+describe('/kortix models → real served catalog', () => {
+  test('lists the picker models as set_model_<ref> buttons + a project-default reset', async () => {
+    const resp = await handleSlashCommand('models', '', ctx);
+    const ids = actionIds(resp);
+    expect(ids).toContain('set_model_default');
+    expect(ids).toContain('set_model_kortix/glm-5.2');
+    expect(ids).toContain('set_model_kortix/claude-opus-4.8');
+  });
+});
+
+describe('/kortix model <id> → servability gate (never store a 404)', () => {
+  test('servable id is stored as the opencode ref', async () => {
+    const resp = await handleSlashCommand('model', 'glm-5.2', ctx);
+    expect(setChannelModel).toHaveBeenCalledWith(expect.anything(), 'kortix/glm-5.2');
+    expect(resp.text).toContain('set to');
+  });
+
+  test('unservable id is REJECTED — never written', async () => {
+    servable = false;
+    const resp = await handleSlashCommand('model', 'anthropic/claude-sonnet-4.6', ctx);
+    expect(setChannelModel).not.toHaveBeenCalled();
+    expect(resp.text).toContain("isn't available");
+  });
+
+  test('`default` clears the override', async () => {
+    const resp = await handleSlashCommand('model', 'default', ctx);
+    expect(setChannelModel).toHaveBeenCalledWith(expect.anything(), null);
+    expect(resp.text).toContain('reset to the project default');
+  });
+});

--- a/apps/api/src/channels/slack/commands.ts
+++ b/apps/api/src/channels/slack/commands.ts
@@ -4,15 +4,16 @@ import { db } from '../../shared/db';
 import { config } from '../../config';
 import { escapeMrkdwn, formatRelativeTime, repoLabel, repoOgImage, respondViaUrl, sessionWebUrl } from './util';
 import {
-  RECOMMENDED_MODELS,
   currentChannelSelection,
-  isValidModelId,
   listProjectAgents,
-  modelLabel,
   setChannelAgent,
   setChannelConversationPolicy,
   setChannelModel,
 } from './selection';
+import { channelModelContext } from './model-gate';
+import { listPickerModels, labelForModelRef } from '../../llm-gateway/models/picker';
+import { isModelServableForAccount, resolveEffectiveModel } from '../../llm-gateway/resolution/default-model';
+import { chooseEffectiveAgent, toOpencodeModelRef, toWireModel } from '../../llm-gateway/resolution/effective';
 import { buildSlackLoginUrl } from './login';
 import { lookupSlackIdentity, revokeSlackIdentity } from './identity';
 import { conversationPolicyLabel, normalizeConversationPolicy } from './participants';
@@ -69,9 +70,13 @@ export async function handleSlashCommand(
     case 'logout':
     case 'disconnect':
       return config.SLACK_REQUIRE_USER_IDENTITY ? slashLogout(ctx) : unknownSub(sub, ctx.command);
+    case '':
+    case 'config':
+    case 'channel':
+    case 'settings':
     case 'whoami':
     case 'who':
-      return slashWhoami(ctx);
+      return slashPanel(ctx);
     case 'agents':
       return slashAgents(ctx, arg);
     case 'agent':
@@ -88,7 +93,6 @@ export async function handleSlashCommand(
     case 'conversation':
       return slashPolicy(ctx, arg);
     case 'help':
-    case '':
       return slashHelp(ctx);
     default:
       return unknownSub(sub, ctx.command);
@@ -105,55 +109,35 @@ function unknownSub(sub: string, command: string): SlashResponse {
 function slashHelp(ctx: SlashCtx): SlashResponse {
   const command = ctx.command;
   const isProjectScoped = !!ctx.projectScopedProjectId;
-  const projectRows = isProjectScoped
-    ? [
-        { cmd: `${command} agents`,   desc: 'Pick which project agent answers in this channel.' },
-        { cmd: `${command} agent <name>`, desc: 'Set the channel-wide agent (`default` to reset).' },
-        { cmd: `${command} models`,   desc: 'Pick which model this channel uses.' },
-        { cmd: `${command} model <id>`, desc: 'Set the channel-wide model, e.g. `anthropic/claude-opus-4-8` (`default` to reset).' },
-        { cmd: `${command} policy`,   desc: 'Show or change who can join Slack-started sessions in this channel.' },
-      ]
-    : [
-        { cmd: `${command} projects`, desc: 'List every Kortix project connected to this workspace.' },
-        { cmd: `${command} switch`,   desc: 'Bind this channel to a different project (opens a picker).' },
-        { cmd: `${command} unbind`,   desc: 'Clear this channel\'s project binding.' },
-        { cmd: `${command} agents`,   desc: 'List this project\'s agents and pick which one answers here.' },
-        { cmd: `${command} agent <name>`, desc: 'Set the agent for this channel (`default` to reset).' },
-        { cmd: `${command} models`,   desc: 'List models and pick which one this channel uses.' },
-        { cmd: `${command} model <id>`, desc: 'Set the model, e.g. `anthropic/claude-opus-4-8` (`default` to reset).' },
-        { cmd: `${command} policy`,   desc: 'Show who can join Slack-started sessions in this channel.' },
-      ];
+  // Everything lives behind the one `/kortix` panel; the rest are power-user
+  // shortcuts for people who'd rather type than click.
+  const advanced: Array<{ cmd: string; desc: string }> = [
+    { cmd: `${command} model <id>`, desc: 'Set the channel model directly, e.g. `kortix/glm-5.2` or `anthropic/claude-sonnet-4.6` (`default` to reset).' },
+    { cmd: `${command} agent <name>`, desc: 'Set the channel agent directly (`default` to reset).' },
+    ...(isProjectScoped ? [] : [{ cmd: `${command} switch`, desc: 'Connect this channel to a different project.' }]),
+    { cmd: `${command} policy`,   desc: 'Show or change who can join Slack-started sessions here.' },
+    { cmd: `${command} sessions`, desc: 'Recent sessions started in this workspace.' },
+    ...(config.SLACK_REQUIRE_USER_IDENTITY
+      ? [
+          { cmd: `${command} login`,  desc: 'Connect your own Kortix account so the agent runs as you.' },
+          { cmd: `${command} logout`, desc: 'Disconnect your Kortix account.' },
+        ]
+      : []),
+  ];
   return {
     response_type: 'ephemeral',
     blocks: [
-      {
-        type: 'header',
-        text: { type: 'plain_text', text: '⚡  Kortix slash commands', emoji: true },
-      },
+      { type: 'header', text: { type: 'plain_text', text: '⚡  Kortix', emoji: true } },
       {
         type: 'section',
         text: {
           type: 'mrkdwn',
-          text: isProjectScoped
-            ? 'This Slack app is tied to one Kortix project. Agent, model, and session policy settings are channel-wide.'
-            : 'Drive Kortix from any Slack channel. All responses are private to you.',
+          text: `Run \`${command}\` to open this channel's control panel — connected project, agent, and model, with buttons to change any of them. @-mention me in a thread to put me to work. All responses are private to you.`,
         },
       },
       { type: 'divider' },
-      ...[
-        ...projectRows,
-        // Only advertised when per-user identity is enabled.
-        ...(config.SLACK_REQUIRE_USER_IDENTITY
-          ? [
-              { cmd: `${command} login`,  desc: 'Connect your own Kortix account so the agent runs as you.' },
-              { cmd: `${command} logout`, desc: 'Disconnect your Kortix account from this Slack workspace.' },
-            ]
-          : []),
-        { cmd: `${command} session`,  desc: 'Show this channel\'s most recent session + open it on the web.' },
-        { cmd: `${command} sessions`, desc: 'Show the last 5 sessions started in this workspace.' },
-        { cmd: `${command} whoami`,   desc: 'This channel\'s project, agent, and model' + (config.SLACK_REQUIRE_USER_IDENTITY ? ' + your linked Kortix account.' : '.') },
-        { cmd: `${command} help`,     desc: 'This message.' },
-      ].map((r) => ({
+      { type: 'context', elements: [{ type: 'mrkdwn', text: '*Shortcuts*' }] },
+      ...advanced.map((r) => ({
         type: 'section',
         text: { type: 'mrkdwn', text: `\`${r.cmd}\`\n${r.desc}` },
       })),
@@ -441,8 +425,30 @@ async function buildIdentityContext(ctx: SlashCtx): Promise<Record<string, unkno
   };
 }
 
-async function slashWhoami(ctx: SlashCtx): Promise<SlashResponse> {
-  // Identity line only when the per-user feature is on.
+// Honest source label for an effective model/agent: how the value was decided,
+// so the panel reads "Sonnet 4.6 · project default" instead of implying a pin.
+function sourceLabel(source: string): string {
+  switch (source) {
+    case 'explicit':
+      return 'channel override';
+    case 'agent':
+      return 'agent default';
+    case 'project':
+      return 'project default';
+    case 'account':
+      return 'account default';
+    default:
+      return 'platform default';
+  }
+}
+
+// The single `/kortix` channel control panel. Consolidates project binding +
+// agent + model + join policy + account + sessions into one interactive card,
+// each row showing the EFFECTIVE value and where it came from. Inline buttons
+// open the focused pickers (real-catalog models, live agents, projects). DB-only
+// (no git) so it answers inside Slack's 3s window; the agent picker, opened on
+// demand, is the only git-touching path.
+async function slashPanel(ctx: SlashCtx): Promise<SlashResponse> {
   const identityBlocks = config.SLACK_REQUIRE_USER_IDENTITY ? [await buildIdentityContext(ctx)] : [];
   const selection = await currentChannelSelection(ctx);
   const currentId = selection?.projectId ?? null;
@@ -456,14 +462,26 @@ async function slashWhoami(ctx: SlashCtx): Promise<SlashResponse> {
           type: 'section',
           text: {
             type: 'mrkdwn',
-            text: `*No project bound to this channel.*\nRun \`${ctx.command} switch\` to pick one.`,
+            text: `*No project is connected to this channel yet.*\nConnect one to start working here.`,
           },
+        },
+        {
+          type: 'actions',
+          elements: [
+            {
+              type: 'button',
+              text: { type: 'plain_text', text: 'Connect a project', emoji: true },
+              style: 'primary',
+              action_id: 'cfg_open_projects',
+              value: JSON.stringify({ c: ctx.channelId }),
+            },
+          ],
         },
       ],
     };
   }
   const [p] = await db
-    .select({ projectId: projects.projectId, name: projects.name, repoUrl: projects.repoUrl })
+    .select({ projectId: projects.projectId, name: projects.name, repoUrl: projects.repoUrl, metadata: projects.metadata })
     .from(projects)
     .where(eq(projects.projectId, currentId))
     .limit(1);
@@ -473,20 +491,54 @@ async function slashWhoami(ctx: SlashCtx): Promise<SlashResponse> {
       blocks: [
         {
           type: 'section',
-          text: { type: 'mrkdwn', text: `*This channel's bound project no longer exists.*\nRun \`${ctx.command} switch\` to rebind.` },
+          text: { type: 'mrkdwn', text: `*This channel's connected project no longer exists.*\nReconnect one below.` },
+        },
+        {
+          type: 'actions',
+          elements: [
+            {
+              type: 'button',
+              text: { type: 'plain_text', text: 'Connect a project', emoji: true },
+              style: 'primary',
+              action_id: 'cfg_open_projects',
+              value: JSON.stringify({ c: ctx.channelId }),
+            },
+          ],
         },
       ],
     };
   }
   const og = repoOgImage(p.repoUrl);
-  const agentLabel = selection?.agentName ?? 'default';
-  const modelLabelText = selection?.opencodeModel ? modelLabel(selection.opencodeModel) : 'project default';
+
+  // Effective AGENT (channel override → project default → 'default').
+  const projectDefaultAgent =
+    typeof (p.metadata as Record<string, unknown> | null)?.default_agent === 'string'
+      ? ((p.metadata as Record<string, unknown>).default_agent as string)
+      : null;
+  const agent = chooseEffectiveAgent({ explicit: selection?.agentName ?? null, projectDefault: projectDefaultAgent });
+
+  // Effective MODEL (channel override → project/account/platform), with source.
+  const gate = await channelModelContext(ctx);
+  let modelText = '`auto` · platform default';
+  if (gate) {
+    const eff = await resolveEffectiveModel({
+      userId: gate.ownerUserId,
+      accountId: gate.accountId,
+      projectId: gate.projectId,
+      agentName: selection?.agentName ?? null,
+      explicit: selection?.opencodeModel ?? null,
+      freeModelsOnly: gate.freeManagedOnly,
+    });
+    const label = eff.model ? labelForModelRef(eff.model) : 'Auto';
+    modelText = `*${escapeMrkdwn(label)}* · ${sourceLabel(eff.source)}`;
+  }
+
   const policy = normalizeConversationPolicy(selection?.conversationPolicy);
   const section: Record<string, unknown> = {
     type: 'section',
     text: {
       type: 'mrkdwn',
-      text: `🟢  *${escapeMrkdwn(p.name)}*  ·  ✓ bound to this channel\n_<${p.repoUrl}|${escapeMrkdwn(repoLabel(p.repoUrl))}>_`,
+      text: `🟢  *${escapeMrkdwn(p.name)}*  ·  connected to this channel\n_<${p.repoUrl}|${escapeMrkdwn(repoLabel(p.repoUrl))}>_`,
     },
   };
   if (og) section.accessory = { type: 'image', image_url: og, alt_text: `${p.name} repo` };
@@ -498,10 +550,9 @@ async function slashWhoami(ctx: SlashCtx): Promise<SlashResponse> {
       {
         type: 'context',
         elements: [
-          { type: 'mrkdwn', text: `🤖  Agent: *${escapeMrkdwn(agentLabel)}*` },
-          { type: 'mrkdwn', text: `🧠  Model: *${escapeMrkdwn(modelLabelText)}*` },
+          { type: 'mrkdwn', text: `🤖  Agent: *${escapeMrkdwn(agent.agent)}* · ${sourceLabel(agent.source)}` },
+          { type: 'mrkdwn', text: `🧠  Model: ${modelText}` },
           { type: 'mrkdwn', text: `🔒  Slack sessions: *${conversationPolicyLabel(policy)}*` },
-          { type: 'mrkdwn', text: `Change with \`${ctx.command} agents\` · \`${ctx.command} models\`` },
         ],
       },
       {
@@ -509,16 +560,37 @@ async function slashWhoami(ctx: SlashCtx): Promise<SlashResponse> {
         elements: [
           {
             type: 'button',
-            text: { type: 'plain_text', text: 'Open project', emoji: true },
-            style: 'primary',
-            url: `${dashboardBase}/projects/${p.projectId}`,
-            action_id: `whoami_open_${p.projectId}`,
+            text: { type: 'plain_text', text: 'Change model', emoji: true },
+            action_id: 'cfg_open_models',
+            value: JSON.stringify({ c: ctx.channelId }),
           },
           {
             type: 'button',
-            text: { type: 'plain_text', text: 'View on GitHub', emoji: true },
-            url: p.repoUrl,
-            action_id: `whoami_repo_${p.projectId}`,
+            text: { type: 'plain_text', text: 'Change agent', emoji: true },
+            action_id: 'cfg_open_agents',
+            value: JSON.stringify({ c: ctx.channelId }),
+          },
+          {
+            type: 'button',
+            text: { type: 'plain_text', text: 'Change project', emoji: true },
+            action_id: 'cfg_open_projects',
+            value: JSON.stringify({ c: ctx.channelId }),
+          },
+          {
+            type: 'button',
+            text: { type: 'plain_text', text: 'Open in Kortix ↗', emoji: true },
+            style: 'primary',
+            url: `${dashboardBase}/projects/${p.projectId}`,
+            action_id: `panel_open_${p.projectId}`,
+          },
+        ],
+      },
+      {
+        type: 'context',
+        elements: [
+          {
+            type: 'mrkdwn',
+            text: `Advanced: \`${ctx.command} model <id>\` · \`${ctx.command} policy\` · \`${ctx.command} sessions\` · \`${ctx.command} help\``,
           },
         ],
       },
@@ -815,22 +887,50 @@ async function slashSetAgent(ctx: SlashCtx, arg: string): Promise<SlashResponse>
 // ── Models ───────────────────────────────────────────────────────────────────
 
 async function slashModels(ctx: SlashCtx): Promise<SlashResponse> {
-  const selection = await currentChannelSelection(ctx);
-  if (!selection) {
+  const gate = await channelModelContext(ctx);
+  if (!gate) {
     return {
       response_type: 'ephemeral',
-      blocks: [{ type: 'section', text: { type: 'mrkdwn', text: `*No project bound to this channel.*\nRun \`${ctx.command} switch\` first, then pick a model.` } }],
+      blocks: [{ type: 'section', text: { type: 'mrkdwn', text: `*No project is connected to this channel yet.*\nRun \`${ctx.command}\` to connect one, then pick a model.` } }],
     };
   }
-  const current = selection.opencodeModel;
+  const selection = await currentChannelSelection(ctx);
+  const current = selection?.opencodeModel ?? null;
+  const isCurrent = (id: string) => !!current && toWireModel(current) === toWireModel(id);
+
+  // The REAL served catalog — managed models + the project's connected BYOK
+  // providers — plus the resolved project default. No hardcoded list, so a pick
+  // can never 404.
+  const { models, projectDefault } = await listPickerModels({
+    projectId: gate.projectId,
+    userId: gate.ownerUserId,
+    accountId: gate.accountId,
+    freeManagedOnly: gate.freeManagedOnly,
+    agentName: selection?.agentName ?? null,
+  });
+
   const blocks: Array<Record<string, unknown>> = [
     { type: 'header', text: { type: 'plain_text', text: 'Models', emoji: true } },
-    { type: 'context', elements: [{ type: 'mrkdwn', text: `Pick a model for this channel. Current: *${current ? escapeMrkdwn(modelLabel(current)) : 'project default'}*` }] },
+    {
+      type: 'context',
+      elements: [
+        {
+          type: 'mrkdwn',
+          text: current
+            ? `This channel uses *${escapeMrkdwn(labelForModelRef(current))}*.`
+            : `This channel uses the *project default*${projectDefault.label ? ` (${escapeMrkdwn(projectDefault.label)})` : ''}.`,
+        },
+      ],
+    },
   ];
-  // "Project default" clears the override.
+
+  // "Project default" clears the per-channel override.
   blocks.push({
     type: 'section',
-    text: { type: 'mrkdwn', text: `${current ? '' : '✓ '}*Project default*\n_Whatever the repo's opencode config sets._` },
+    text: {
+      type: 'mrkdwn',
+      text: `${current ? '' : '✓ '}*Use project default*${projectDefault.label ? `  ·  _${escapeMrkdwn(projectDefault.label)}_` : ''}`,
+    },
     accessory: {
       type: 'button',
       text: { type: 'plain_text', text: current ? 'Reset' : '✓ Current', emoji: true },
@@ -839,15 +939,16 @@ async function slashModels(ctx: SlashCtx): Promise<SlashResponse> {
       value: JSON.stringify({ c: ctx.channelId, m: '' }),
     },
   });
-  for (const m of RECOMMENDED_MODELS) {
-    const isCurrent = current === m.id;
+
+  for (const m of models) {
+    const cur = isCurrent(m.id);
     blocks.push({
       type: 'section',
-      text: { type: 'mrkdwn', text: `${isCurrent ? '✓ ' : ''}*${escapeMrkdwn(m.label)}*  ·  _${escapeMrkdwn(m.hint)}_\n\`${escapeMrkdwn(m.id)}\`` },
+      text: { type: 'mrkdwn', text: `${cur ? '✓ ' : ''}*${escapeMrkdwn(m.label)}*${m.hint ? `  ·  _${escapeMrkdwn(m.hint)}_` : ''}\n\`${escapeMrkdwn(m.id)}\`` },
       accessory: {
         type: 'button',
-        text: { type: 'plain_text', text: isCurrent ? '✓ Current' : 'Use this', emoji: true },
-        style: isCurrent ? undefined : 'primary',
+        text: { type: 'plain_text', text: cur ? '✓ Current' : 'Use this', emoji: true },
+        style: cur ? undefined : 'primary',
         action_id: `set_model_${m.id}`.slice(0, 250),
         value: JSON.stringify({ c: ctx.channelId, m: m.id }),
       },
@@ -855,7 +956,7 @@ async function slashModels(ctx: SlashCtx): Promise<SlashResponse> {
   }
   blocks.push({
     type: 'context',
-    elements: [{ type: 'mrkdwn', text: `Any model works: \`${ctx.command} model provider/model-id\` (availability depends on your project's connected providers).` }],
+    elements: [{ type: 'mrkdwn', text: `Any model works: \`${ctx.command} model provider/model-id\` (must be a managed model or a provider you've connected).` }],
   });
   return { response_type: 'ephemeral', blocks };
 }
@@ -863,21 +964,37 @@ async function slashModels(ctx: SlashCtx): Promise<SlashResponse> {
 async function slashSetModel(ctx: SlashCtx, arg: string): Promise<SlashResponse> {
   const id = arg.trim();
   if (!id) return slashModels(ctx);
-  const selection = await currentChannelSelection(ctx);
-  if (!selection) {
-    return { response_type: 'ephemeral', text: `Bind a project first with \`${ctx.command} switch\`.` };
+  const gate = await channelModelContext(ctx);
+  if (!gate) {
+    return { response_type: 'ephemeral', text: `Connect a project first — run \`${ctx.command}\`.` };
   }
   if (id.toLowerCase() === 'default') {
     const ok = await setChannelModel(ctx, null);
-    if (!ok) return { response_type: 'ephemeral', text: `Bind a project first with \`${ctx.command} switch\`.` };
+    if (!ok) return { response_type: 'ephemeral', text: `Connect a project first — run \`${ctx.command}\`.` };
     return { response_type: 'ephemeral', text: 'Model reset to the project default.' };
   }
-  if (!isValidModelId(id)) {
-    return { response_type: 'ephemeral', text: `\`${escapeMrkdwn(id)}\` doesn't look like a model id. Use \`provider/model\`, e.g. \`anthropic/claude-opus-4-8\`.` };
+  if (/\s/.test(id)) {
+    return { response_type: 'ephemeral', text: `\`${escapeMrkdwn(id)}\` doesn't look like a model id. Use \`provider/model\` (e.g. \`anthropic/claude-sonnet-4.6\`) or a managed id (e.g. \`kortix/glm-5.2\` or \`glm-5.2\`).` };
   }
-  const ok = await setChannelModel(ctx, id);
-  if (!ok) return { response_type: 'ephemeral', text: `Bind a project first with \`${ctx.command} switch\`.` };
-  return { response_type: 'ephemeral', text: `Model for this channel set to *${escapeMrkdwn(modelLabel(id))}* (\`${escapeMrkdwn(id)}\`). New sessions will use it.` };
+  // The servability check is the real gate — never store a model that would 404
+  // at request time, whatever shape the id is.
+  const servable = await isModelServableForAccount({
+    userId: gate.ownerUserId,
+    accountId: gate.accountId,
+    projectId: gate.projectId,
+    freeModelsOnly: gate.freeManagedOnly,
+    model: id,
+  });
+  if (!servable) {
+    return {
+      response_type: 'ephemeral',
+      text: `\`${escapeMrkdwn(id)}\` isn't available for this workspace. Pick one from \`${ctx.command} models\`, or connect that provider's API key in Kortix first.`,
+    };
+  }
+  const stored = toOpencodeModelRef(id);
+  const ok = await setChannelModel(ctx, stored);
+  if (!ok) return { response_type: 'ephemeral', text: `Connect a project first — run \`${ctx.command}\`.` };
+  return { response_type: 'ephemeral', text: `Model for this channel set to *${escapeMrkdwn(labelForModelRef(stored))}* (\`${escapeMrkdwn(stored)}\`). New sessions will use it.` };
 }
 
 export async function listWorkspaceProjects(teamId: string): Promise<Array<{ projectId: string; name: string; repoUrl: string }>> {

--- a/apps/api/src/channels/slack/interactivity.ts
+++ b/apps/api/src/channels/slack/interactivity.ts
@@ -10,7 +10,12 @@ import { decideSlackThreadJoin } from './participants';
 import { attachPendingSlackAuthResponseUrl } from './auth-resume';
 import { verifyLoginState } from './login';
 import { escapeMrkdwn, respondViaUrl, sessionWebUrl } from './util';
-import { modelLabel, setChannelAgent, setChannelModel } from './selection';
+import { setChannelAgent, setChannelModel } from './selection';
+import { channelModelContext } from './model-gate';
+import { type SlashCtx, handleSlashCommand } from './commands';
+import { labelForModelRef } from '../../llm-gateway/models/picker';
+import { isModelServableForAccount } from '../../llm-gateway/resolution/default-model';
+import { toOpencodeModelRef } from '../../llm-gateway/resolution/effective';
 import type { SlackEnvelope, SlackEvent, SlackInteractionPayload } from './types';
 
 // Agent-emitted button click (carousel cards, actions blocks). Routes the
@@ -214,17 +219,71 @@ async function handleSetSelection(
     return;
   }
 
-  const model = value.m && value.m.length > 0 ? value.m : null;
-  const ok = await setChannelModel(ctx, model);
+  const requested = value.m && value.m.length > 0 ? value.m : null;
+  if (!requested) {
+    const ok = await setChannelModel(ctx, null);
+    await respondViaUrl(payload.response_url, {
+      response_type: 'ephemeral',
+      replace_original: true,
+      text: ok
+        ? '✓ Model reset to the project default.'
+        : 'That channel is no longer connected to a project — run `/kortix` first.',
+    });
+    return;
+  }
+  // Picker options are already servable, but re-validate before persisting so a
+  // stored model can NEVER 404 at request time ("model isn't available").
+  const gate = await channelModelContext(ctx);
+  if (gate) {
+    const servable = await isModelServableForAccount({
+      userId: gate.ownerUserId,
+      accountId: gate.accountId,
+      projectId: gate.projectId,
+      freeModelsOnly: gate.freeManagedOnly,
+      model: requested,
+    });
+    if (!servable) {
+      await respondViaUrl(payload.response_url, {
+        response_type: 'ephemeral',
+        replace_original: true,
+        text: `⚠️ \`${escapeMrkdwn(requested)}\` isn't available for this workspace. Pick another, or connect that provider's API key in Kortix.`,
+      });
+      return;
+    }
+  }
+  const stored = toOpencodeModelRef(requested);
+  const ok = await setChannelModel(ctx, stored);
   await respondViaUrl(payload.response_url, {
     response_type: 'ephemeral',
     replace_original: true,
-    text: !ok
-      ? 'That channel is no longer bound to a project — run `/kortix switch` first.'
-      : model
-        ? `✓ Model for this channel set to *${escapeMrkdwn(modelLabel(model))}* (\`${escapeMrkdwn(model)}\`). New sessions will use it.`
-        : '✓ Model reset to the project default.',
+    text: ok
+      ? `✓ Model for this channel set to *${escapeMrkdwn(labelForModelRef(stored))}* (\`${escapeMrkdwn(stored)}\`). New sessions will use it.`
+      : 'That channel is no longer connected to a project — run `/kortix` first.',
   });
+}
+
+// A `/kortix` panel "Change model/agent/project" button. Re-runs the matching
+// slash subcommand for the channel and replaces the panel with that picker, so
+// the whole config flow lives behind one command + inline buttons.
+async function handleConfigOpen(
+  payload: SlackInteractionPayload,
+  actionId: 'cfg_open_models' | 'cfg_open_agents' | 'cfg_open_projects',
+): Promise<void> {
+  const teamId = payload.team?.id ?? '';
+  const channelId = payload.channel?.id ?? '';
+  if (!teamId || !channelId || !payload.response_url) return;
+  const sub = actionId === 'cfg_open_models' ? 'models' : actionId === 'cfg_open_agents' ? 'agents' : 'switch';
+  const ctx: SlashCtx = {
+    teamId,
+    channelId,
+    slackUserId: payload.user?.id ?? '',
+    command: '/kortix',
+    responseUrl: payload.response_url,
+  };
+  // `agents` defers internally (git) and posts the real picker via responseUrl;
+  // its sync return is a "Loading…" ack. `models`/`switch` return full blocks.
+  const resp = await handleSlashCommand(sub, '', ctx);
+  await respondViaUrl(payload.response_url, { ...resp, replace_original: true });
 }
 
 // Message shortcut ("Open in Kortix", callback_id `open_session`). Resolves the
@@ -455,6 +514,26 @@ export async function handleBlockAction(payload: SlackInteractionPayload): Promi
 
   if (action.action_id.startsWith('set_model')) {
     await handleSetSelection(payload, action.value ?? '', 'model');
+    return;
+  }
+
+  // `/kortix` panel "Change …" buttons re-render the focused picker in place.
+  if (
+    action.action_id === 'cfg_open_models' ||
+    action.action_id === 'cfg_open_agents' ||
+    action.action_id === 'cfg_open_projects'
+  ) {
+    await handleConfigOpen(payload, action.action_id);
+    return;
+  }
+
+  // URL buttons (open a link) — swallow so they don't fall to the agent-click
+  // catch-all and get echoed back into a thread.
+  if (
+    action.action_id.startsWith('panel_open_') ||
+    action.action_id.startsWith('whoami_open_') ||
+    action.action_id.startsWith('whoami_repo_')
+  ) {
     return;
   }
 

--- a/apps/api/src/channels/slack/model-gate.ts
+++ b/apps/api/src/channels/slack/model-gate.ts
@@ -1,0 +1,50 @@
+import { and, eq } from 'drizzle-orm';
+import { accountMembers, projects } from '@kortix/db';
+import { db } from '../../shared/db';
+import { config } from '../../config';
+import { getAccountTier } from '../../billing/services/entitlements';
+import { tierGrantsAllModels } from '../../billing/services/tiers';
+import { type ChannelCtx, currentChannelSelection } from './selection';
+
+// The account/tier context a channel's model setting resolves against. Kept out
+// of selection.ts (which is intentionally lightweight: just db + git) because it
+// pulls in config + billing — so the per-channel binding helpers stay cheap to
+// unit-test in isolation.
+
+export interface ChannelModelContext {
+  projectId: string;
+  accountId: string;
+  /** A representative project-owner user (for codex credential lookups). */
+  ownerUserId: string;
+  /** The account may not use platform-managed Kortix models. */
+  freeManagedOnly: boolean;
+}
+
+/**
+ * Resolve the project + owner account + tier a channel's model decisions key off.
+ * Used to validate a model (isModelServableForAccount) and to list the real
+ * picker catalog (listPickerModels). Null when the channel is unbound.
+ */
+export async function channelModelContext(ctx: ChannelCtx): Promise<ChannelModelContext | null> {
+  const selection = await currentChannelSelection(ctx);
+  if (!selection?.projectId) return null;
+  const [project] = await db
+    .select({ accountId: projects.accountId })
+    .from(projects)
+    .where(eq(projects.projectId, selection.projectId))
+    .limit(1);
+  if (!project) return null;
+  const [owner] = await db
+    .select({ userId: accountMembers.userId })
+    .from(accountMembers)
+    .where(and(eq(accountMembers.accountId, project.accountId), eq(accountMembers.accountRole, 'owner')))
+    .limit(1);
+  const tier = await getAccountTier(project.accountId);
+  const freeManagedOnly = config.KORTIX_BILLING_INTERNAL_ENABLED && !tierGrantsAllModels(tier);
+  return {
+    projectId: selection.projectId,
+    accountId: project.accountId,
+    ownerUserId: owner?.userId ?? project.accountId,
+    freeManagedOnly,
+  };
+}

--- a/apps/api/src/channels/slack/selection.ts
+++ b/apps/api/src/channels/slack/selection.ts
@@ -181,36 +181,12 @@ export async function listProjectAgents(projectId: string): Promise<ProjectAgent
   }));
 }
 
-// Curated flagship models offered in the `/kortix models` picker. These are the
-// common picks; ANY `provider/model` string is accepted via `/kortix model
-// <id>` (whatever the project's connected providers expose). The list is
-// hand-maintained rather than derived from the bundled models.dev catalog,
-// which lags real availability (e.g. ships claude-opus-4-7, not 4-8).
-export interface RecommendedModel {
-  id: string;
-  label: string;
-  hint: string;
-}
-
-export const RECOMMENDED_MODELS: RecommendedModel[] = [
-  { id: 'anthropic/claude-opus-4-8', label: 'Claude Opus 4.8', hint: 'Most capable' },
-  { id: 'anthropic/claude-sonnet-4-6', label: 'Claude Sonnet 4.6', hint: 'Balanced, fast' },
-  { id: 'openai/gpt-5.5', label: 'GPT-5.5', hint: 'OpenAI flagship' },
-  { id: 'google/gemini-3-pro-preview', label: 'Gemini 3 Pro', hint: 'Google flagship' },
-];
-
 /**
- * A model id is usable if it's a non-empty `provider/model` pair. We don't
- * validate against the bundled catalog — it's a stale snapshot and would reject
- * legitimately-available newer models. The sandbox daemon already falls back to
- * the configured default when the id is malformed or the model is unavailable.
+ * A model id is shaped like a usable ref if it's a non-empty `provider/model`
+ * pair (or `kortix/<id>`). Shape only — real servability is enforced separately
+ * via `isModelServableForAccount` against the account's tier + connected keys.
  */
 export function isValidModelId(s: string): boolean {
   const slash = s.indexOf('/');
   return slash > 0 && slash < s.length - 1 && !/\s/.test(s);
-}
-
-/** Friendly label for a model id — the recommended label, else the raw id. */
-export function modelLabel(id: string): string {
-  return RECOMMENDED_MODELS.find((m) => m.id === id)?.label ?? id;
 }

--- a/apps/api/src/llm-gateway/models/picker-catalog.ts
+++ b/apps/api/src/llm-gateway/models/picker-catalog.ts
@@ -1,0 +1,130 @@
+import { resolveCatalogUpstream } from '@kortix/llm-gateway';
+import { CATALOG, type CatalogModel, MANAGED_MODELS } from '@kortix/shared/llm-catalog';
+import { toWireModel } from '../resolution/effective';
+
+// PURE catalog logic for the model picker — no DB, no config, so it's unit-
+// testable in isolation. The DB-touching assembly (connected BYOK providers +
+// resolved project default) lives in picker.ts and builds on these.
+
+export interface PickerModel {
+  /** Opencode model ref — `kortix/<id>` for managed, `provider/model` for BYOK. */
+  id: string;
+  /** Human label, e.g. "Claude Opus 4.8". */
+  label: string;
+  /** 'kortix' for managed, else the catalog provider id. */
+  provider: string;
+  /** True for platform-managed (credits-billed) models. */
+  managed: boolean;
+  /** Short note, e.g. "Most capable" or "Anthropic". */
+  hint?: string;
+}
+
+// provider/model id → catalog model, and the per-provider model id set, built
+// once at load. Used both to LABEL a ref and to verify a flagship candidate
+// actually exists before we ever offer it (no stale ids).
+const catalogModelById = new Map<string, CatalogModel>();
+const providerModelIds = new Map<string, Set<string>>();
+for (const provider of CATALOG.providers) {
+  const ids = new Set<string>();
+  for (const model of provider.models) {
+    catalogModelById.set(`${provider.id}/${model.id}`, model);
+    ids.add(model.id);
+  }
+  providerModelIds.set(provider.id, ids);
+}
+
+// Curated flagship candidates per provider, in priority order. Every candidate is
+// VERIFIED against the catalog before use, and there's a data-driven fallback
+// (most recently released), so a wrong/renamed guess is dropped rather than
+// offered — the list can never drift into a lie.
+const FLAGSHIP_CANDIDATES: Record<string, string[]> = {
+  anthropic: ['claude-opus-4.8', 'claude-opus-4-8', 'claude-sonnet-4.6', 'claude-sonnet-4-6'],
+  openai: ['gpt-5.5', 'gpt-5.1', 'gpt-5', 'gpt-4.1'],
+  google: ['gemini-3-pro-preview', 'gemini-2.5-pro', 'gemini-2.0-flash'],
+  'x-ai': ['grok-4', 'grok-3'],
+  xai: ['grok-4', 'grok-3'],
+  deepseek: ['deepseek-chat', 'deepseek-reasoner'],
+  mistral: ['mistral-large-latest', 'mistral-large'],
+  groq: ['llama-3.3-70b-versatile'],
+  perplexity: ['sonar-pro', 'sonar'],
+};
+
+/** The flagship BYOK model id (bare, no provider prefix) for a provider, or null. */
+export function providerFlagship(providerId: string): string | null {
+  const ids = providerModelIds.get(providerId);
+  if (!ids || ids.size === 0) return null;
+  for (const candidate of FLAGSHIP_CANDIDATES[providerId] ?? []) {
+    if (ids.has(candidate)) return candidate;
+  }
+  // Fallback: the most recently released model the catalog carries for this
+  // provider (deterministic, real). Released dates sort lexically (YYYY-MM-DD).
+  const provider = CATALOG.providers.find((p) => p.id === providerId);
+  if (!provider || provider.models.length === 0) return null;
+  const sorted = [...provider.models].sort((a, b) =>
+    (b.released ?? '').localeCompare(a.released ?? ''),
+  );
+  return sorted[0]?.id ?? null;
+}
+
+/** Whether a provider exposes a BYOK upstream and is connected for `connectedEnvVars`. */
+export function isProviderConnected(providerId: string, connectedEnvVars: Set<string>): boolean {
+  const upstream = resolveCatalogUpstream(providerId);
+  return !!upstream && connectedEnvVars.has(upstream.envVar.toUpperCase());
+}
+
+/**
+ * The flagship `provider/model` ref for the provider whose primary credential
+ * env var is `envVar` (e.g. `ANTHROPIC_API_KEY` → `anthropic/claude-opus-4.8`),
+ * or null. Used to auto-seed a sensible project default when a user connects
+ * their first provider. Non-provider credentials (CODEX_AUTH_JSON,
+ * OPENCODE_AUTH_JSON) have no catalog upstream → null, so they're skipped.
+ */
+export function flagshipRefForEnvVar(envVar: string): string | null {
+  const upper = envVar.toUpperCase();
+  for (const provider of CATALOG.providers) {
+    const upstream = resolveCatalogUpstream(provider.id);
+    if (!upstream || upstream.envVar.toUpperCase() !== upper) continue;
+    const flagship = providerFlagship(provider.id);
+    if (flagship) return `${provider.id}/${flagship}`;
+  }
+  return null;
+}
+
+/** A friendly label for any model ref (managed, BYOK, codex, or raw). */
+export function labelForModelRef(ref: string): string {
+  const wire = toWireModel(ref);
+  const managed = MANAGED_MODELS.find((m) => m.id === wire);
+  if (managed) return managed.name;
+  if (wire.startsWith('codex/')) {
+    const inner = wire.slice('codex/'.length);
+    return `${catalogModelById.get(`openai/${inner}`)?.name ?? inner} (ChatGPT)`;
+  }
+  const catalog = catalogModelById.get(wire);
+  if (catalog) return catalog.name;
+  return ref;
+}
+
+/** Managed models as opencode refs (`kortix/<id>`), with tier hints. */
+export function managedPickerModels(): PickerModel[] {
+  return MANAGED_MODELS.map((m) => ({
+    id: `kortix/${m.id}`,
+    label: m.name,
+    provider: 'kortix',
+    managed: true,
+    hint:
+      m.tier === 'flagship' ? 'Most capable' : m.tier === 'fast' ? 'Fastest' : 'Balanced, fast',
+  }));
+}
+
+/** Flagship picker entries for the CONNECTED BYOK providers in `connectedEnvVars`. */
+export function connectedByokPickerModels(connectedEnvVars: Set<string>): PickerModel[] {
+  const models: PickerModel[] = [];
+  for (const provider of CATALOG.providers) {
+    if (!isProviderConnected(provider.id, connectedEnvVars)) continue;
+    const flagship = providerFlagship(provider.id);
+    if (!flagship) continue;
+    const id = `${provider.id}/${flagship}`;
+    models.push({ id, label: labelForModelRef(id), provider: provider.id, managed: false, hint: provider.name });
+  }
+  return models;
+}

--- a/apps/api/src/llm-gateway/models/picker.test.ts
+++ b/apps/api/src/llm-gateway/models/picker.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from 'bun:test';
+import { CATALOG, MANAGED_MODELS } from '@kortix/shared/llm-catalog';
+import {
+  connectedByokPickerModels,
+  flagshipRefForEnvVar,
+  labelForModelRef,
+  managedPickerModels,
+  providerFlagship,
+} from './picker-catalog';
+
+const catalogHas = (providerId: string, modelId: string): boolean =>
+  CATALOG.providers.some((p) => p.id === providerId && p.models.some((m) => m.id === modelId));
+
+describe('providerFlagship', () => {
+  test('returns a model id that ACTUALLY exists in the catalog (no lies)', () => {
+    for (const providerId of ['anthropic', 'openai', 'google']) {
+      const flagship = providerFlagship(providerId);
+      expect(flagship).toBeTruthy();
+      expect(catalogHas(providerId, flagship!)).toBe(true);
+    }
+  });
+
+  test('returns null for an unknown provider', () => {
+    expect(providerFlagship('totally-not-a-provider')).toBeNull();
+  });
+});
+
+describe('labelForModelRef', () => {
+  test('managed ref (kortix/<id>) → the managed display name', () => {
+    const sonnet = MANAGED_MODELS.find((m) => m.id === 'claude-sonnet-4.6');
+    expect(labelForModelRef('kortix/claude-sonnet-4.6')).toBe(sonnet!.name);
+    // bare managed id resolves too
+    expect(labelForModelRef('claude-sonnet-4.6')).toBe(sonnet!.name);
+  });
+
+  test('an unknown ref falls back to the raw id (never throws)', () => {
+    expect(labelForModelRef('madeup/model-x')).toBe('madeup/model-x');
+  });
+});
+
+describe('managedPickerModels', () => {
+  test('every managed model is offered as a kortix/<id> opencode ref', () => {
+    const models = managedPickerModels();
+    expect(models.length).toBe(MANAGED_MODELS.length);
+    for (const m of models) {
+      expect(m.id.startsWith('kortix/')).toBe(true);
+      expect(m.managed).toBe(true);
+      expect(m.provider).toBe('kortix');
+    }
+  });
+});
+
+describe('connectedByokPickerModels', () => {
+  test('includes a connected provider flagship, real and provider-prefixed', () => {
+    const models = connectedByokPickerModels(new Set(['ANTHROPIC_API_KEY']));
+    const anthropic = models.find((m) => m.provider === 'anthropic');
+    expect(anthropic).toBeTruthy();
+    expect(anthropic!.id.startsWith('anthropic/')).toBe(true);
+    expect(anthropic!.managed).toBe(false);
+    expect(catalogHas('anthropic', anthropic!.id.slice('anthropic/'.length))).toBe(true);
+  });
+
+  test('no connected providers → no BYOK entries', () => {
+    expect(connectedByokPickerModels(new Set())).toEqual([]);
+  });
+});
+
+describe('flagshipRefForEnvVar (auto-seed mapping)', () => {
+  test('maps a provider credential env var to that provider flagship ref', () => {
+    const ref = flagshipRefForEnvVar('ANTHROPIC_API_KEY');
+    expect(ref).toBeTruthy();
+    expect(ref!.startsWith('anthropic/')).toBe(true);
+    expect(catalogHas('anthropic', ref!.slice('anthropic/'.length))).toBe(true);
+  });
+
+  test('non-provider credentials (codex/opencode auth) map to null → skipped', () => {
+    expect(flagshipRefForEnvVar('CODEX_AUTH_JSON')).toBeNull();
+    expect(flagshipRefForEnvVar('OPENCODE_AUTH_JSON')).toBeNull();
+    expect(flagshipRefForEnvVar('SOME_RANDOM_SECRET')).toBeNull();
+  });
+});

--- a/apps/api/src/llm-gateway/models/picker.ts
+++ b/apps/api/src/llm-gateway/models/picker.ts
@@ -1,0 +1,68 @@
+import { listProjectSecretsSnapshot } from '../../projects/secrets';
+import { resolveEffectiveModel } from '../resolution/default-model';
+import type { ModelSource } from '../resolution/effective';
+import {
+  type PickerModel,
+  connectedByokPickerModels,
+  labelForModelRef,
+  managedPickerModels,
+} from './picker-catalog';
+
+// The REAL served-model source for compact pickers (Slack, and any curated web
+// surface). Built from the gateway's actual catalog — managed Kortix models +
+// the project's CONNECTED BYOK providers — never a hand-maintained list. The
+// previous Slack picker offered four hardcoded ids that didn't match the served
+// catalog (wrong `anthropic/` prefix, dashed vs dotted versions, models that
+// aren't served), so every pick risked a gateway 404 ("model isn't available").
+
+export type { PickerModel } from './picker-catalog';
+export { labelForModelRef, providerFlagship } from './picker-catalog';
+
+/**
+ * The picker's model list for a project: managed models (unless the account is
+ * free-tier-managed-only) + the flagship of each CONNECTED BYOK provider, plus
+ * the resolved project default (what a session uses with no per-channel/session
+ * override) so a surface can offer "Use project default (X)".
+ */
+export async function listPickerModels(params: {
+  projectId: string;
+  userId: string;
+  accountId: string;
+  freeManagedOnly: boolean;
+  agentName?: string | null;
+}): Promise<{
+  models: PickerModel[];
+  projectDefault: { model: string | null; source: ModelSource; label: string | null };
+}> {
+  const models: PickerModel[] = params.freeManagedOnly ? [] : managedPickerModels();
+
+  // CONNECTED BYOK providers: a provider whose first env var is a saved
+  // project-wide secret. We match against the project-wide snapshot because that
+  // is exactly what request-time resolution (resolveCandidates → project-wide
+  // getProjectSecretValue) keys off — so the picker and servability agree.
+  try {
+    const snapshot = await listProjectSecretsSnapshot(params.projectId);
+    const connected = new Set(snapshot.names.map((n) => n.toUpperCase()));
+    models.push(...connectedByokPickerModels(connected));
+  } catch {
+    // Secret read failed — fall back to managed-only rather than erroring the picker.
+  }
+
+  const effective = await resolveEffectiveModel({
+    userId: params.userId,
+    accountId: params.accountId,
+    projectId: params.projectId,
+    agentName: params.agentName,
+    explicit: null,
+    freeModelsOnly: params.freeManagedOnly,
+  });
+
+  return {
+    models,
+    projectDefault: {
+      model: effective.model,
+      source: effective.source,
+      label: effective.model ? labelForModelRef(effective.model) : null,
+    },
+  };
+}

--- a/apps/api/src/llm-gateway/models/seed-default.test.ts
+++ b/apps/api/src/llm-gateway/models/seed-default.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+// Auto-seed-on-first-provider-connect. Only seeds when the account has NO model
+// default yet and the provider flagship is servable; never clobbers an existing
+// default; idempotent. The pure effective.ts (toWireModel) is used for real.
+
+let flagshipRef: string | null = 'anthropic/claude-opus-4.8';
+mock.module('./picker-catalog', () => ({ flagshipRefForEnvVar: () => flagshipRef }));
+
+let defaults: any = { account: null, agents: {}, projects: {} };
+const upsert = mock(async () => {});
+mock.module('../../repositories/model-preferences', () => ({
+  getAccountModelDefaults: async () => defaults,
+  upsertAccountModelPreference: upsert,
+}));
+
+let servable = true;
+const invalidate = mock(() => {});
+mock.module('../resolution/default-model', () => ({
+  isModelServableForAccount: async () => servable,
+  invalidateAccountModelDefaults: invalidate,
+}));
+
+const { seedProjectDefaultModelOnConnect } = await import('./seed-default');
+
+const params = { projectId: 'p1', accountId: 'a1', userId: 'u1', secretName: 'ANTHROPIC_API_KEY' };
+
+beforeEach(() => {
+  flagshipRef = 'anthropic/claude-opus-4.8';
+  defaults = { account: null, agents: {}, projects: {} };
+  servable = true;
+  upsert.mockClear();
+  invalidate.mockClear();
+});
+
+describe('seedProjectDefaultModelOnConnect', () => {
+  test('seeds the provider flagship as the project default when nothing is set', async () => {
+    await seedProjectDefaultModelOnConnect(params);
+    expect(upsert).toHaveBeenCalledTimes(1);
+    expect(upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accountId: 'a1',
+        scope: 'project',
+        scopeKey: 'p1',
+        model: 'anthropic/claude-opus-4.8',
+        onlyIfAbsent: true,
+      }),
+    );
+    expect(invalidate).toHaveBeenCalledWith('a1');
+  });
+
+  test('skips a non-provider credential (flagship ref null)', async () => {
+    flagshipRef = null;
+    await seedProjectDefaultModelOnConnect({ ...params, secretName: 'CODEX_AUTH_JSON' });
+    expect(upsert).not.toHaveBeenCalled();
+  });
+
+  test('never clobbers an existing account default', async () => {
+    defaults = { account: 'glm-5.2', agents: {}, projects: {} };
+    await seedProjectDefaultModelOnConnect(params);
+    expect(upsert).not.toHaveBeenCalled();
+  });
+
+  test('never clobbers an existing project default', async () => {
+    defaults = { account: null, agents: {}, projects: { p1: 'glm-5.2' } };
+    await seedProjectDefaultModelOnConnect(params);
+    expect(upsert).not.toHaveBeenCalled();
+  });
+
+  test('skips when the flagship is not servable', async () => {
+    servable = false;
+    await seedProjectDefaultModelOnConnect(params);
+    expect(upsert).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/llm-gateway/models/seed-default.ts
+++ b/apps/api/src/llm-gateway/models/seed-default.ts
@@ -1,0 +1,56 @@
+import {
+  getAccountModelDefaults,
+  upsertAccountModelPreference,
+} from '../../repositories/model-preferences';
+import { invalidateAccountModelDefaults, isModelServableForAccount } from '../resolution/default-model';
+import { toWireModel } from '../resolution/effective';
+import { flagshipRefForEnvVar } from './picker-catalog';
+
+// Auto-seed a sensible PROJECT default model the first time a workspace connects
+// a model provider — so a brand-new project isn't stuck on the bare platform
+// default and "by default takes the project one" actually means something. Runs
+// detached after a provider secret is saved; never throws into the request.
+//
+// Only seeds when the account has NO model default yet (account- or
+// project-scoped) and the chosen flagship is genuinely servable now that the key
+// exists. Managed-only accounts need no seed — the platform flagship already
+// applies. Idempotent: a concurrent connect or an already-set default is never
+// clobbered (onlyIfAbsent → INSERT … ON CONFLICT DO NOTHING).
+
+export async function seedProjectDefaultModelOnConnect(params: {
+  projectId: string;
+  accountId: string;
+  userId: string;
+  secretName: string;
+}): Promise<void> {
+  try {
+    const flagshipRef = flagshipRefForEnvVar(params.secretName);
+    if (!flagshipRef) return; // not a known provider credential (e.g. codex auth)
+
+    const defaults = await getAccountModelDefaults(params.accountId);
+    if (defaults.account || defaults.projects[params.projectId]) return; // already chosen
+
+    const servable = await isModelServableForAccount({
+      userId: params.userId,
+      accountId: params.accountId,
+      projectId: params.projectId,
+      freeModelsOnly: false, // a BYOK flagship resolves via the just-saved key for any tier
+      model: flagshipRef,
+    });
+    if (!servable) return;
+
+    await upsertAccountModelPreference({
+      accountId: params.accountId,
+      scope: 'project',
+      scopeKey: params.projectId,
+      model: toWireModel(flagshipRef),
+      onlyIfAbsent: true,
+    });
+    invalidateAccountModelDefaults(params.accountId);
+  } catch (err) {
+    console.warn(
+      `[seed-default] failed to seed project default for ${params.projectId}:`,
+      err instanceof Error ? err.message : err,
+    );
+  }
+}

--- a/apps/api/src/llm-gateway/resolution/choose-default-model.ts
+++ b/apps/api/src/llm-gateway/resolution/choose-default-model.ts
@@ -1,32 +1,27 @@
-import { isManagedModelId } from '@kortix/shared/llm-catalog';
+import { chooseEffectiveModel } from './effective';
 
 /**
  * Pure default-model decision used by the gateway's `auto` resolution:
- *   per-agent default → account default → undefined (→ platform default).
+ *   per-agent default → project default → account default → undefined (→ platform).
  *
- * Free tier cannot use managed Kortix models (managed resolution returns [] for
- * them by design), so a managed default is dropped for free-tier principals —
- * they fall back to the platform default, never to an unservable managed id. A
- * BYOK default (`provider/model`) is kept for free tier (resolved via their key).
+ * Thin adapter over `chooseEffectiveModel` (the single precedence definition) that
+ * returns the gateway's `string | undefined` shape. Free tier cannot use managed
+ * Kortix models, so a managed chosen default is dropped to the platform default —
+ * never silently downgraded to a broader layer. A BYOK default (`provider/model`)
+ * is kept for free tier (resolved via their key).
  */
 export function chooseDefaultModel(params: {
   accountDefault: string | null;
   agentDefaults: Record<string, string>;
   agentName?: string | null;
+  projectDefault?: string | null;
   freeModelsOnly?: boolean;
 }): string | undefined {
-  const candidate =
-    (params.agentName ? params.agentDefaults[params.agentName] : undefined) ??
-    params.accountDefault ??
-    undefined;
-  if (!candidate) return undefined;
-
-  if (params.freeModelsOnly) {
-    const bareId = candidate.startsWith('kortix/')
-      ? candidate.slice('kortix/'.length)
-      : candidate;
-    if (isManagedModelId(bareId)) return undefined;
-  }
-
-  return candidate;
+  const { model } = chooseEffectiveModel({
+    agentDefault: params.agentName ? params.agentDefaults[params.agentName] : null,
+    projectDefault: params.projectDefault ?? null,
+    accountDefault: params.accountDefault,
+    freeModelsOnly: params.freeModelsOnly,
+  });
+  return model ?? undefined;
 }

--- a/apps/api/src/llm-gateway/resolution/default-model.ts
+++ b/apps/api/src/llm-gateway/resolution/default-model.ts
@@ -6,16 +6,18 @@ import {
   getSessionAgentContext,
 } from '../../repositories/model-preferences';
 import { chooseDefaultModel } from './choose-default-model';
+import { type ModelSource, chooseEffectiveModel, toWireModel } from './effective';
 import { resolveCandidates } from './resolve-candidates';
 
-// Resolves the account/agent-configured default model for a gateway principal,
-// once at authentication (in withResolvedTier). The result is attached to the
-// principal as `defaultModel` and consumed by `pickAutoModel` to turn a request
-// for the synthetic `auto` into the model the account actually wants.
+// Resolves the account/agent/project-configured default model for a gateway
+// principal, once at authentication (in withResolvedTier). The result is attached
+// to the principal as `defaultModel` and consumed by `pickAutoModel` to turn a
+// request for the synthetic `auto` into the model the account actually wants.
 //
-// Resolution order (most-specific wins): per-agent default → account default →
-// undefined (the caller then falls back to the platform default). Per-session and
-// explicit models never reach here — a concrete model is passed through unchanged.
+// Resolution order (most-specific wins): per-agent default → project default →
+// account default → undefined (the caller then falls back to the platform
+// default). Per-session and explicit models never reach here — a concrete model
+// is passed through unchanged.
 
 const PREFS_TTL_MS = 30_000;
 const SESSION_AGENT_TTL_MS = 60_000;
@@ -50,8 +52,10 @@ export async function resolveDefaultModelForPrincipal(
 ): Promise<string | undefined> {
   const defaults = await cachedAccountDefaults(principal.accountId);
   const hasAgentDefaults = Object.keys(defaults.agents).length > 0;
-  // Fast path: nothing configured → the platform default applies (no session read).
-  if (!defaults.account && !hasAgentDefaults) return undefined;
+  const projectDefault = principal.projectId ? defaults.projects[principal.projectId] : undefined;
+  // Fast path: nothing configured for this account/project → the platform default
+  // applies (no session read needed).
+  if (!defaults.account && !hasAgentDefaults && !projectDefault) return undefined;
 
   let agentName: string | null = null;
   if (hasAgentDefaults && principal.sessionId) {
@@ -62,6 +66,7 @@ export async function resolveDefaultModelForPrincipal(
     accountDefault: defaults.account,
     agentDefaults: defaults.agents,
     agentName,
+    projectDefault,
     freeModelsOnly: principal.freeModelsOnly,
   });
 }
@@ -82,6 +87,9 @@ export async function isModelServableForAccount(params: {
   model: string;
 }): Promise<boolean> {
   if (params.model === AUTO_MODEL_ID || params.model === `kortix/${AUTO_MODEL_ID}`) return false;
+  // Accept either the opencode ref (`kortix/<id>`) or the bare wire id — the
+  // gateway resolves the bare id, so normalize before probing candidates.
+  const wire = toWireModel(params.model);
   const candidates = await resolveCandidates(
     {
       userId: params.userId,
@@ -89,7 +97,45 @@ export async function isModelServableForAccount(params: {
       projectId: params.projectId,
       freeModelsOnly: params.freeModelsOnly,
     },
-    params.model,
+    wire,
   );
   return candidates.length > 0;
+}
+
+/**
+ * The effective model for a project/session AND where it came from — for honest
+ * UI/Slack copy ("Sonnet 4.6 · project default") and the model-defaults GET.
+ *
+ * An `explicit` override (a channel/session pin) wins only when it's actually
+ * servable for the account+project; an unservable pin (e.g. a BYOK model whose
+ * key was disconnected, or a retired managed id) degrades to the project →
+ * account → platform chain instead of producing a dead turn. The returned
+ * `model` is a concrete gateway wire id, or null when only the platform default
+ * applies (the caller omits it and the gateway resolves `auto`).
+ */
+export async function resolveEffectiveModel(params: {
+  userId: string;
+  accountId: string;
+  projectId: string;
+  agentName?: string | null;
+  explicit?: string | null;
+  freeModelsOnly: boolean;
+}): Promise<{ model: string | null; source: ModelSource }> {
+  if (params.explicit) {
+    const servable = await isModelServableForAccount({
+      userId: params.userId,
+      accountId: params.accountId,
+      projectId: params.projectId,
+      freeModelsOnly: params.freeModelsOnly,
+      model: params.explicit,
+    });
+    if (servable) return { model: toWireModel(params.explicit), source: 'explicit' };
+  }
+  const defaults = await getAccountModelDefaults(params.accountId);
+  return chooseEffectiveModel({
+    agentDefault: params.agentName ? defaults.agents[params.agentName] : null,
+    projectDefault: defaults.projects[params.projectId],
+    accountDefault: defaults.account,
+    freeModelsOnly: params.freeModelsOnly,
+  });
 }

--- a/apps/api/src/llm-gateway/resolution/effective.test.ts
+++ b/apps/api/src/llm-gateway/resolution/effective.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  chooseEffectiveAgent,
+  chooseEffectiveModel,
+  toOpencodeModelRef,
+  toWireModel,
+} from './effective';
+
+describe('chooseEffectiveModel', () => {
+  test('most-specific layer wins: agent → project → account', () => {
+    expect(
+      chooseEffectiveModel({
+        agentDefault: 'claude-opus-4.8',
+        projectDefault: 'glm-5.2',
+        accountDefault: 'qwen3.7-max',
+      }),
+    ).toEqual({ model: 'claude-opus-4.8', source: 'agent' });
+  });
+
+  test('project default wins over account when no agent default', () => {
+    expect(
+      chooseEffectiveModel({ projectDefault: 'glm-5.2', accountDefault: 'qwen3.7-max' }),
+    ).toEqual({ model: 'glm-5.2', source: 'project' });
+  });
+
+  test('account default applies when nothing more specific', () => {
+    expect(chooseEffectiveModel({ accountDefault: 'qwen3.7-max' })).toEqual({
+      model: 'qwen3.7-max',
+      source: 'account',
+    });
+  });
+
+  test('nothing configured → platform default', () => {
+    expect(chooseEffectiveModel({})).toEqual({ model: null, source: 'platform' });
+  });
+
+  test('free tier: a managed chosen candidate drops to platform (not downgraded)', () => {
+    // agent (managed) is most specific → dropped entirely, does NOT fall through
+    // to the account BYOK default.
+    expect(
+      chooseEffectiveModel({
+        agentDefault: 'glm-5.2',
+        accountDefault: 'anthropic/claude-sonnet-4.6',
+        freeModelsOnly: true,
+      }),
+    ).toEqual({ model: null, source: 'platform' });
+  });
+
+  test('free tier: a kortix/-prefixed managed default is also dropped', () => {
+    expect(
+      chooseEffectiveModel({ projectDefault: 'kortix/glm-5.2', freeModelsOnly: true }),
+    ).toEqual({ model: null, source: 'platform' });
+  });
+
+  test('free tier: a BYOK project default is kept', () => {
+    expect(
+      chooseEffectiveModel({ projectDefault: 'anthropic/claude-sonnet-4.6', freeModelsOnly: true }),
+    ).toEqual({ model: 'anthropic/claude-sonnet-4.6', source: 'project' });
+  });
+});
+
+describe('toWireModel / toOpencodeModelRef', () => {
+  test('strips the opencode-only kortix/ prefix to the bare wire id', () => {
+    expect(toWireModel('kortix/claude-sonnet-4.6')).toBe('claude-sonnet-4.6');
+    expect(toWireModel('anthropic/claude-sonnet-4.6')).toBe('anthropic/claude-sonnet-4.6');
+    expect(toWireModel('glm-5.2')).toBe('glm-5.2');
+  });
+
+  test('re-prefixes a bare managed id to the opencode ref; leaves BYOK/codex alone', () => {
+    expect(toOpencodeModelRef('glm-5.2')).toBe('kortix/glm-5.2');
+    expect(toOpencodeModelRef('claude-opus-4.8')).toBe('kortix/claude-opus-4.8');
+    expect(toOpencodeModelRef('kortix/glm-5.2')).toBe('kortix/glm-5.2');
+    expect(toOpencodeModelRef('anthropic/claude-sonnet-4.6')).toBe('anthropic/claude-sonnet-4.6');
+    expect(toOpencodeModelRef('codex/gpt-5.5')).toBe('codex/gpt-5.5');
+  });
+
+  test('round-trips a managed id through wire → opencode', () => {
+    expect(toOpencodeModelRef(toWireModel('kortix/glm-5.2'))).toBe('kortix/glm-5.2');
+  });
+});
+
+describe('chooseEffectiveAgent', () => {
+  test('explicit override wins', () => {
+    expect(chooseEffectiveAgent({ explicit: 'reviewer', projectDefault: 'builder' })).toEqual({
+      agent: 'reviewer',
+      source: 'explicit',
+    });
+  });
+
+  test('project default applies when no explicit', () => {
+    expect(chooseEffectiveAgent({ projectDefault: 'builder' })).toEqual({
+      agent: 'builder',
+      source: 'project',
+    });
+  });
+
+  test("falls back to 'default'", () => {
+    expect(chooseEffectiveAgent({})).toEqual({ agent: 'default', source: 'fallback' });
+  });
+});

--- a/apps/api/src/llm-gateway/resolution/effective.ts
+++ b/apps/api/src/llm-gateway/resolution/effective.ts
@@ -1,0 +1,87 @@
+import { isManagedModelId } from '@kortix/shared/llm-catalog';
+
+// One definition of how a default model/agent is chosen across scopes, shared by
+// the gateway's `auto` resolution (chooseDefaultModel → here) and the apps/api
+// display/validation path (resolveEffectiveModel in default-model.ts). Keeping
+// the precedence in ONE pure function means Slack, the web picker, and the
+// gateway can never disagree about what "the default" is.
+
+/** Where an effective model came from — drives honest UI copy ("· project default"). */
+export type ModelSource = 'explicit' | 'agent' | 'project' | 'account' | 'platform';
+/** Where an effective agent came from. */
+export type AgentSource = 'explicit' | 'project' | 'fallback';
+
+const KORTIX_PREFIX = 'kortix/';
+
+/**
+ * The GATEWAY WIRE form of a model ref: a managed model is stored/served bare
+ * (`glm-5.2`), so strip the opencode-only `kortix/` namespace before it reaches
+ * the gateway (pickAutoModel/resolveCandidates/getManagedModel all expect the
+ * bare id). BYOK (`provider/model`) and codex (`codex/<id>`) refs pass through.
+ * This is what `account_model_preferences` stores and what servability checks.
+ */
+export function toWireModel(ref: string): string {
+  return ref.startsWith(KORTIX_PREFIX) ? ref.slice(KORTIX_PREFIX.length) : ref;
+}
+
+/**
+ * The OPENCODE ref form: opencode addresses a managed model as `kortix/<id>` (and
+ * sends the bare id on the wire), so a bare managed id must be re-prefixed before
+ * it's handed to opencode as `opencode_model`. BYOK/codex refs already carry a
+ * provider segment and pass through unchanged.
+ */
+export function toOpencodeModelRef(model: string): string {
+  if (model.startsWith(KORTIX_PREFIX)) return model;
+  return isManagedModelId(model) ? `${KORTIX_PREFIX}${model}` : model;
+}
+
+function isManagedRef(ref: string): boolean {
+  return isManagedModelId(toWireModel(ref));
+}
+
+/**
+ * Pure precedence for the DEFAULT model chain (no explicit/request override —
+ * that's handled by the async resolver, which must validate servability):
+ *   per-agent default → project default → account default → platform default.
+ *
+ * The MOST-SPECIFIC present layer wins; the free-tier managed-drop then applies
+ * to that single chosen candidate (dropping to the platform default rather than
+ * silently downgrading to a less-specific layer — see choose-default-model.test).
+ */
+export function chooseEffectiveModel(params: {
+  agentDefault?: string | null;
+  projectDefault?: string | null;
+  accountDefault?: string | null;
+  freeModelsOnly?: boolean;
+}): { model: string | null; source: ModelSource } {
+  let candidate: string | null = null;
+  let source: ModelSource = 'platform';
+  if (params.agentDefault) {
+    candidate = params.agentDefault;
+    source = 'agent';
+  } else if (params.projectDefault) {
+    candidate = params.projectDefault;
+    source = 'project';
+  } else if (params.accountDefault) {
+    candidate = params.accountDefault;
+    source = 'account';
+  }
+  if (!candidate) return { model: null, source: 'platform' };
+  // Free tier cannot use managed Kortix models; the chosen candidate is dropped
+  // to the platform default rather than falling through to a broader layer.
+  if (params.freeModelsOnly && isManagedRef(candidate)) return { model: null, source: 'platform' };
+  return { model: candidate, source };
+}
+
+/**
+ * Pure precedence for the effective AGENT:
+ *   explicit (channel/session) → project default → 'default'.
+ */
+export function chooseEffectiveAgent(params: {
+  explicit?: string | null;
+  projectDefault?: string | null;
+}): { agent: string; source: AgentSource } {
+  if (params.explicit) return { agent: params.explicit, source: 'explicit' };
+  if (params.projectDefault) return { agent: params.projectDefault, source: 'project' };
+  return { agent: 'default', source: 'fallback' };
+}

--- a/apps/api/src/projects/lib/sessions.ts
+++ b/apps/api/src/projects/lib/sessions.ts
@@ -343,7 +343,15 @@ export async function createProjectSession(input: {
   const accountId = project.accountId;
 
   const baseRef = normalizeString(body.base_ref ?? body.baseRef) ?? project.defaultBranch;
-  const agentName = normalizeString(body.agent_name ?? body.agentName) ?? 'default';
+  // Explicit request wins; otherwise fall back to the project's default agent
+  // (`[opencode] default_agent` in kortix.toml, synced to project metadata, or a
+  // UI/Slack override), so EVERY session — UI, triggers, channels — inherits the
+  // project's chosen agent without each caller passing one. Unset → 'default'.
+  const projectDefaultAgent = normalizeString(
+    (project.metadata as Record<string, unknown> | null | undefined)?.default_agent,
+  );
+  const agentName =
+    normalizeString(body.agent_name ?? body.agentName) ?? projectDefaultAgent ?? 'default';
   // Explicit request wins; otherwise fall back to the project's default sandbox
   // template (`[sandbox] default` in kortix.toml, synced to project metadata),
   // so EVERY session — UI, triggers, channels — inherits the project's chosen

--- a/apps/api/src/projects/routes/r3.ts
+++ b/apps/api/src/projects/routes/r3.ts
@@ -10,6 +10,7 @@ import { pollCodexDeviceAuth, startCodexDeviceAuth } from '../codex-device-auth'
 import { decryptProjectSecret, encryptProjectSecret, isValidSecretName } from '../secrets';
 import { propagateProjectSecretsToActiveSandboxes } from '../lib/sandbox-env-sync';
 import { isGatewayManagedEnv } from '../../llm-gateway/sandbox-credentials';
+import { seedProjectDefaultModelOnConnect } from '../../llm-gateway/models/seed-default';
 import { createRoute, z } from '@hono/zod-openapi';
 import { projectSecrets, projects, sessionSandboxes } from '@kortix/db';
 import { and, eq, inArray, isNull, sql } from 'drizzle-orm';
@@ -513,6 +514,18 @@ projectsApp.openapi(
   if (sharing) await setSecretSharing(secretId, sharing);
 
   void propagateProjectSecretsToActiveSandboxes(projectId, { refreshModels: isGatewayManagedEnv(name) });
+
+  // First provider connect on a default-less project → seed a sensible project
+  // default model (that provider's flagship). Detached + idempotent; never seeds
+  // over an existing default.
+  if (value !== null && isGatewayManagedEnv(name)) {
+    void seedProjectDefaultModelOnConnect({
+      projectId,
+      accountId: loaded.row.accountId,
+      userId: loaded.userId,
+      secretName: name,
+    });
+  }
 
   const subject = await resolveShareSubject(loaded.userId);
   const views = await loadSecretViewsForUser(projectId, subject, true);

--- a/apps/api/src/projects/routes/r4.ts
+++ b/apps/api/src/projects/routes/r4.ts
@@ -40,6 +40,7 @@ import { gatewayModelCatalog } from "../../llm-gateway/models/catalog-models";
 import {
   invalidateAccountModelDefaults,
   isModelServableForAccount,
+  resolveEffectiveModel,
 } from "../../llm-gateway/resolution/default-model";
 import {
   deleteAccountModelPreference,
@@ -1382,25 +1383,36 @@ projectsApp.openapi(
     const loaded = await loadProjectForUser(c, projectId, "read");
     if (!loaded) return c.json({ error: "Not found" }, 404);
     const ownerAccountId = loaded.row.accountId as string;
+    const userId = c.get("userId") as string;
     const defaults = await getAccountModelDefaults(ownerAccountId);
     const freeTier =
       config.KORTIX_BILLING_INTERNAL_ENABLED
         ? !tierGrantsAllModels(await getCachedAccountTier(ownerAccountId))
         : false;
+    // Honest project-level resolution (project → account → platform) + where it
+    // came from, so the UI can show "Sonnet 4.6 · project default". The
+    // authoritative per-request resolution still happens in the gateway.
+    const resolved = await resolveEffectiveModel({
+      userId,
+      accountId: ownerAccountId,
+      projectId,
+      explicit: null,
+      freeModelsOnly: freeTier,
+    });
     return c.json({
       platformDefault: AUTO_DEFAULT_MODEL_ID,
       accountDefault: defaults.account,
       agentDefaults: defaults.agents,
-      // Account-level resolution (agent/vision-agnostic) for picker display; the
-      // authoritative per-request resolution still happens in the gateway.
-      resolvedForCaller: defaults.account ?? AUTO_DEFAULT_MODEL_ID,
+      projectDefault: defaults.projects[projectId] ?? null,
+      resolvedForCaller: resolved.model ?? AUTO_DEFAULT_MODEL_ID,
+      resolvedSource: resolved.source,
       freeTier,
     });
   },
 );
 
 const ModelDefaultBody = z.object({
-  scope: z.enum(["account", "agent"]),
+  scope: z.enum(["account", "agent", "project"]),
   agentName: z.string().min(1).max(128).optional(),
   model: z.string().min(1).max(128),
 });
@@ -1467,7 +1479,8 @@ projectsApp.openapi(
     await upsertAccountModelPreference({
       accountId: ownerAccountId,
       scope,
-      scopeKey: agentName,
+      // agent → agent name; project → the project id; account → '' (in the repo).
+      scopeKey: scope === "agent" ? agentName : scope === "project" ? projectId : undefined,
       model,
       updatedBy: userId,
     });
@@ -1492,7 +1505,7 @@ projectsApp.openapi(
     request: {
       params: z.object({ projectId: z.string() }),
       query: z.object({
-        scope: z.enum(["account", "agent"]),
+        scope: z.enum(["account", "agent", "project"]),
         agentName: z.string().min(1).max(128).optional(),
       }),
     },
@@ -1511,8 +1524,8 @@ projectsApp.openapi(
     const ownerAccountId = loaded.row.accountId as string;
     const scope = c.req.query("scope");
     const agentName = c.req.query("agentName");
-    if (scope !== "account" && scope !== "agent") {
-      return c.json({ error: "scope must be 'account' or 'agent'", code: "invalid_scope" }, 400);
+    if (scope !== "account" && scope !== "agent" && scope !== "project") {
+      return c.json({ error: "scope must be 'account', 'agent', or 'project'", code: "invalid_scope" }, 400);
     }
     if (scope === "agent" && !agentName) {
       return c.json(
@@ -1520,7 +1533,8 @@ projectsApp.openapi(
         400,
       );
     }
-    await deleteAccountModelPreference({ accountId: ownerAccountId, scope, scopeKey: agentName });
+    const scopeKey = scope === "agent" ? agentName : scope === "project" ? projectId : undefined;
+    await deleteAccountModelPreference({ accountId: ownerAccountId, scope, scopeKey });
     invalidateAccountModelDefaults(ownerAccountId);
     return c.json({ ok: true, scope, agentName: scope === "agent" ? agentName : undefined });
   },

--- a/apps/api/src/repositories/model-preferences.test.ts
+++ b/apps/api/src/repositories/model-preferences.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+// Account/agent/PROJECT-scoped default model preferences. A FIFO-ish chain mock
+// captures select rows + insert values without a real DB.
+
+let selectRows: any[] = [];
+let insertedValues: any = null;
+let conflictMode: 'update' | 'nothing' | null = null;
+
+function chain(): any {
+  const c: any = {};
+  for (const m of ['select', 'from', 'where', 'update', 'set', 'delete', 'returning', 'limit']) {
+    c[m] = () => c;
+  }
+  c.values = (v: any) => {
+    insertedValues = v;
+    return c;
+  };
+  c.onConflictDoUpdate = () => {
+    conflictMode = 'update';
+    return Promise.resolve();
+  };
+  c.onConflictDoNothing = () => {
+    conflictMode = 'nothing';
+    return Promise.resolve();
+  };
+  c.then = (resolve: (rows: any[]) => unknown) => Promise.resolve(resolve(selectRows));
+  return c;
+}
+mock.module('../shared/db', () => ({
+  db: { select: () => chain(), insert: () => chain(), delete: () => chain() },
+  hasDatabase: () => true,
+}));
+
+const { getAccountModelDefaults, upsertAccountModelPreference } = await import('./model-preferences');
+
+beforeEach(() => {
+  selectRows = [];
+  insertedValues = null;
+  conflictMode = null;
+});
+
+describe('getAccountModelDefaults', () => {
+  test('buckets account / agent / project rows', async () => {
+    selectRows = [
+      { scope: 'account', scopeKey: '', model: 'glm-5.2' },
+      { scope: 'agent', scopeKey: 'reviewer', model: 'claude-opus-4.8' },
+      { scope: 'project', scopeKey: 'p1', model: 'anthropic/claude-sonnet-4.6' },
+      { scope: 'project', scopeKey: 'p2', model: 'qwen3.7-max' },
+    ];
+    const defaults = await getAccountModelDefaults('a1');
+    expect(defaults.account).toBe('glm-5.2');
+    expect(defaults.agents).toEqual({ reviewer: 'claude-opus-4.8' });
+    expect(defaults.projects).toEqual({ p1: 'anthropic/claude-sonnet-4.6', p2: 'qwen3.7-max' });
+  });
+
+  test('empty → all buckets empty', async () => {
+    expect(await getAccountModelDefaults('a1')).toEqual({ account: null, agents: {}, projects: {} });
+  });
+});
+
+describe('upsertAccountModelPreference', () => {
+  test('project scope writes scope_key = projectId', async () => {
+    await upsertAccountModelPreference({ accountId: 'a1', scope: 'project', scopeKey: 'p1', model: 'glm-5.2' });
+    expect(insertedValues).toMatchObject({ accountId: 'a1', scope: 'project', scopeKey: 'p1', model: 'glm-5.2' });
+    expect(conflictMode).toBe('update');
+  });
+
+  test('account scope pins scope_key to empty string', async () => {
+    await upsertAccountModelPreference({ accountId: 'a1', scope: 'account', model: 'glm-5.2' });
+    expect(insertedValues.scopeKey).toBe('');
+  });
+
+  test('onlyIfAbsent uses INSERT … ON CONFLICT DO NOTHING (idempotent seed)', async () => {
+    await upsertAccountModelPreference({
+      accountId: 'a1',
+      scope: 'project',
+      scopeKey: 'p1',
+      model: 'glm-5.2',
+      onlyIfAbsent: true,
+    });
+    expect(conflictMode).toBe('nothing');
+  });
+});

--- a/apps/api/src/repositories/model-preferences.ts
+++ b/apps/api/src/repositories/model-preferences.ts
@@ -4,18 +4,29 @@ import { db } from '../shared/db';
 
 // Persistent store for account-scoped default model preferences. Drives the
 // server-side resolution of the synthetic `auto` model in the LLM gateway:
-//   per-agent default (scope='agent', key=agent_name) → account default
-//   (scope='account') → platform default.
+//   per-agent default (scope='agent', key=agent_name) → project default
+//   (scope='project', key=project_id) → account default (scope='account') →
+//   platform default.
 // Stored `model` values are gateway wire models (bare managed id like 'glm-5.2',
-// a BYOK 'provider/model', or 'codex/<id>') — never the synthetic `auto`.
+// a BYOK 'provider/model', or 'codex/<id>') — never the synthetic `auto` and
+// never the opencode-only `kortix/` prefix.
 
-export type ModelPreferenceScope = 'account' | 'agent';
+export type ModelPreferenceScope = 'account' | 'agent' | 'project';
+
+// Account-wide is the only scope that pins scope_key to ''. Agent (key=agent_name)
+// and project (key=project_id) both carry a caller-supplied key; the unique index
+// (account_id, scope, scope_key) keeps them from colliding.
+function preferenceScopeKey(scope: ModelPreferenceScope, scopeKey?: string): string {
+  return scope === 'account' ? '' : (scopeKey ?? '');
+}
 
 export interface AccountModelDefaults {
   /** Account-wide default wire model, or null when unset. */
   account: string | null;
   /** Per-agent default wire models, keyed by agent name. */
   agents: Record<string, string>;
+  /** Per-project default wire models, keyed by project id. */
+  projects: Record<string, string>;
 }
 
 export async function getAccountModelDefaults(accountId: string): Promise<AccountModelDefaults> {
@@ -28,10 +39,11 @@ export async function getAccountModelDefaults(accountId: string): Promise<Accoun
     .from(accountModelPreferences)
     .where(eq(accountModelPreferences.accountId, accountId));
 
-  const defaults: AccountModelDefaults = { account: null, agents: {} };
+  const defaults: AccountModelDefaults = { account: null, agents: {}, projects: {} };
   for (const row of rows) {
     if (row.scope === 'account') defaults.account = row.model;
     else if (row.scope === 'agent' && row.scopeKey) defaults.agents[row.scopeKey] = row.model;
+    else if (row.scope === 'project' && row.scopeKey) defaults.projects[row.scopeKey] = row.model;
   }
   return defaults;
 }
@@ -42,9 +54,30 @@ export async function upsertAccountModelPreference(params: {
   scopeKey?: string;
   model: string;
   updatedBy?: string | null;
+  /** Seed-only: skip the write when a row already exists for this scope (first-connect auto-seed). */
+  onlyIfAbsent?: boolean;
 }): Promise<void> {
   const now = new Date();
-  const scopeKey = params.scope === 'agent' ? (params.scopeKey ?? '') : '';
+  const scopeKey = preferenceScopeKey(params.scope, params.scopeKey);
+  if (params.onlyIfAbsent) {
+    await db
+      .insert(accountModelPreferences)
+      .values({
+        accountId: params.accountId,
+        scope: params.scope,
+        scopeKey,
+        model: params.model,
+        updatedBy: params.updatedBy ?? null,
+      })
+      .onConflictDoNothing({
+        target: [
+          accountModelPreferences.accountId,
+          accountModelPreferences.scope,
+          accountModelPreferences.scopeKey,
+        ],
+      });
+    return;
+  }
   await db
     .insert(accountModelPreferences)
     .values({
@@ -69,7 +102,7 @@ export async function deleteAccountModelPreference(params: {
   scope: ModelPreferenceScope;
   scopeKey?: string;
 }): Promise<void> {
-  const scopeKey = params.scope === 'agent' ? (params.scopeKey ?? '') : '';
+  const scopeKey = preferenceScopeKey(params.scope, params.scopeKey);
   await db
     .delete(accountModelPreferences)
     .where(

--- a/apps/web/src/features/session/model-selector.tsx
+++ b/apps/web/src/features/session/model-selector.tsx
@@ -14,7 +14,7 @@ import {
 import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
-import { Bot, Check, ChevronDown, CreditCard, KeyRound, Plus, SlidersHorizontal, Star } from 'lucide-react';
+import { Bot, Check, ChevronDown, CreditCard, FolderGit2, KeyRound, Plus, SlidersHorizontal, Star } from 'lucide-react';
 import { useParams } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
@@ -109,6 +109,8 @@ export interface ModelDefaultControls {
   agentName?: string;
   onSetAccountDefault: (model: ModelRef) => void;
   onSetAgentDefault?: (model: ModelRef) => void;
+  /** When set (in-project picker), pin the model as this project's default. */
+  onSetProjectDefault?: (model: ModelRef) => void;
 }
 
 export interface ModelSelectorProps {
@@ -532,6 +534,19 @@ export function ModelSelector({
                     <Star className="size-3.5 shrink-0" />
                     Set as my default model
                   </button>
+                  {defaultControls.onSetProjectDefault ? (
+                    <button
+                      type="button"
+                      onClick={() => {
+                        defaultControls.onSetProjectDefault?.(selectedModel);
+                        setOpen(false);
+                      }}
+                      className="text-muted-foreground hover:text-foreground hover:bg-foreground/[0.04] flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-xs font-medium transition-colors duration-200"
+                    >
+                      <FolderGit2 className="size-3.5 shrink-0" />
+                      Set as this project&apos;s default
+                    </button>
+                  ) : null}
                   {defaultControls.agentName && defaultControls.onSetAgentDefault ? (
                     <button
                       type="button"

--- a/apps/web/src/features/session/session-chat.tsx
+++ b/apps/web/src/features/session/session-chat.tsx
@@ -5883,6 +5883,9 @@ export function SessionChat({
                   if (name) void local.model.defaults.setAgentDefault(name, m);
                 }
               : undefined,
+            onSetProjectDefault: (m) => {
+              void local.model.defaults.setProjectDefault(m);
+            },
           }}
           variants={local.model.variant.list}
           selectedVariant={local.model.variant.current ?? null}

--- a/apps/web/src/hooks/opencode/use-model-defaults.ts
+++ b/apps/web/src/hooks/opencode/use-model-defaults.ts
@@ -32,14 +32,17 @@ export interface UseModelDefaults {
   isLoading: boolean;
   accountDefault: ModelKey | undefined;
   agentDefaults: Record<string, ModelKey>;
+  projectDefault: ModelKey | undefined;
   platformDefault: ModelKey | undefined;
   freeTier: boolean;
-  /** The configured default for an agent: agent default → account default → platform. */
+  /** The configured default for an agent: agent → project → account → platform. */
   resolveDefaultFor: (agentName: string | undefined) => ModelKey | undefined;
   setAccountDefault: (model: ModelKey) => Promise<void>;
   setAgentDefault: (agentName: string, model: ModelKey) => Promise<void>;
+  setProjectDefault: (model: ModelKey) => Promise<void>;
   clearAccountDefault: () => Promise<void>;
   clearAgentDefault: (agentName: string) => Promise<void>;
+  clearProjectDefault: () => Promise<void>;
 }
 
 export function useModelDefaults(projectId: string | null | undefined): UseModelDefaults {
@@ -68,12 +71,12 @@ export function useModelDefaults(projectId: string | null | undefined): UseModel
   }, [queryClient, queryKey]);
 
   const setMutation = useMutation({
-    mutationFn: (input: { scope: 'account' | 'agent'; agentName?: string; model: string }) =>
+    mutationFn: (input: { scope: 'account' | 'agent' | 'project'; agentName?: string; model: string }) =>
       setModelDefault(projectId as string, input),
     onSuccess: invalidate,
   });
   const clearMutation = useMutation({
-    mutationFn: (params: { scope: 'account' | 'agent'; agentName?: string }) =>
+    mutationFn: (params: { scope: 'account' | 'agent' | 'project'; agentName?: string }) =>
       clearModelDefault(projectId as string, params),
     onSuccess: invalidate,
   });
@@ -89,6 +92,10 @@ export function useModelDefaults(projectId: string | null | undefined): UseModel
     }
     return out;
   }, [data?.agentDefaults]);
+  const projectDefault = useMemo<ModelKey | undefined>(
+    () => (data?.projectDefault ? wireToModelKey(data.projectDefault) : undefined),
+    [data?.projectDefault],
+  );
   const platformDefault = useMemo<ModelKey | undefined>(
     () => (data?.platformDefault ? wireToModelKey(data.platformDefault) : undefined),
     [data?.platformDefault],
@@ -98,11 +105,12 @@ export function useModelDefaults(projectId: string | null | undefined): UseModel
     (agentName: string | undefined): ModelKey | undefined => {
       const wire =
         (agentName ? data?.agentDefaults?.[agentName] : undefined) ??
+        data?.projectDefault ??
         data?.accountDefault ??
         data?.platformDefault;
       return wire ? wireToModelKey(wire) : undefined;
     },
-    [data?.agentDefaults, data?.accountDefault, data?.platformDefault],
+    [data?.agentDefaults, data?.projectDefault, data?.accountDefault, data?.platformDefault],
   );
 
   const setAccountDefault = useCallback(
@@ -118,6 +126,12 @@ export function useModelDefaults(projectId: string | null | undefined): UseModel
     },
     [setMutation],
   );
+  const setProjectDefault = useCallback(
+    async (model: ModelKey) => {
+      await setMutation.mutateAsync({ scope: 'project', model: modelKeyToWire(model) });
+    },
+    [setMutation],
+  );
   const clearAccountDefault = useCallback(async () => {
     setGlobalDefaultModel(undefined);
     await clearMutation.mutateAsync({ scope: 'account' });
@@ -128,18 +142,24 @@ export function useModelDefaults(projectId: string | null | undefined): UseModel
     },
     [clearMutation],
   );
+  const clearProjectDefault = useCallback(async () => {
+    await clearMutation.mutateAsync({ scope: 'project' });
+  }, [clearMutation]);
 
   return {
     data,
     isLoading,
     accountDefault,
     agentDefaults,
+    projectDefault,
     platformDefault,
     freeTier: !!data?.freeTier,
     resolveDefaultFor,
     setAccountDefault,
     setAgentDefault,
+    setProjectDefault,
     clearAccountDefault,
     clearAgentDefault,
+    clearProjectDefault,
   };
 }

--- a/apps/web/src/lib/projects-client.ts
+++ b/apps/web/src/lib/projects-client.ts
@@ -867,6 +867,9 @@ export async function upsertProjectSecret(
 // (operating on the project's owner account). Stored values are gateway wire
 // models (bare managed id, BYOK `provider/model`, or `codex/…`).
 
+export type ModelDefaultScope = 'account' | 'agent' | 'project';
+export type ModelDefaultSource = 'explicit' | 'agent' | 'project' | 'account' | 'platform';
+
 export interface ModelDefaultsResponse {
   /** The platform-wide fallback model (what `auto` resolves to with no override). */
   platformDefault: string;
@@ -874,8 +877,12 @@ export interface ModelDefaultsResponse {
   accountDefault: string | null;
   /** Per-agent default wire models, keyed by agent name. */
   agentDefaults: Record<string, string>;
-  /** Account-level resolution for picker display (agent/vision-agnostic). */
+  /** This project's default wire model, or null when unset. */
+  projectDefault: string | null;
+  /** Honest project-level resolution (project → account → platform) for display. */
   resolvedForCaller: string | null;
+  /** Where `resolvedForCaller` came from — drives "· project default" labels. */
+  resolvedSource?: ModelDefaultSource;
   /** True when the account can't use managed models (free tier). */
   freeTier: boolean;
 }
@@ -888,7 +895,7 @@ export async function getModelDefaults(projectId: string) {
 
 export async function setModelDefault(
   projectId: string,
-  input: { scope: 'account' | 'agent'; agentName?: string; model: string },
+  input: { scope: ModelDefaultScope; agentName?: string; model: string },
 ) {
   return unwrap(
     await backendApi.put<{ ok: boolean; scope: string; agentName?: string; model: string }>(
@@ -900,7 +907,7 @@ export async function setModelDefault(
 
 export async function clearModelDefault(
   projectId: string,
-  params: { scope: 'account' | 'agent'; agentName?: string },
+  params: { scope: ModelDefaultScope; agentName?: string },
 ) {
   const qs = new URLSearchParams({
     scope: params.scope,


### PR DESCRIPTION
## Why

The Slack bot was returning **"The selected model isn't available"** on every mention, the `/kortix model` list was a hardcoded lie disconnected from what the gateway actually serves, the command surface had sprawled to ~14 subcommands, and there was no real per-project default model/agent.

## What

**Slack — one `/kortix` panel.** Bare `/kortix` opens an interactive control panel (project / agent / model / policy / account / sessions), each row showing the **effective value + where it came from** ("Sonnet 4.6 · project default"), with inline Change buttons. Typed shortcuts (`model`/`agent`/`switch`/`policy`/`sessions`/`login`) stay as hidden power paths. Help trimmed.

**Real model picker (kills the lie + the 404).** The picker is now derived from the actual served catalog — `MANAGED_MODELS` as `kortix/<id>` + each *connected* BYOK provider's flagship — replacing the hardcoded `RECOMMENDED_MODELS`. Every model write (picker + free-form `/kortix model <id>`) validates with `isModelServableForAccount` and stores the canonical opencode ref, so a stored model can **never** 404.

**Unified defaults.** New `project` scope in `account_model_preferences` (no migration — reuses the generic `scope`/`scope_key`). The gateway principal now resolves **agent → project → account → platform**. Project default *agent* comes from `projects.metadata.default_agent` at session-create. One shared pure resolver in `llm-gateway/resolution/effective.ts`.

**Web.** `model-selector` gains "Set as this project's default"; the `model-defaults` endpoint + hook gain project scope and return an honest resolved default + source.

**Auto-seed.** Connecting the first BYOK provider on a default-less project seeds that provider's flagship as the project default (idempotent, never clobbers).

## Tests / verification

- API + web typecheck clean.
- Unit tests cover precedence, the picker no-lies guarantee (every offered id exists in the catalog), the servability gate, the `/kortix` panel, auto-seed idempotency, and the repo project scope.
- Live Slack E2E (mentioning the bot) needs a deploy.