### PR TITLE
fix(web): hide dead `show` tool cards instead of a "File not found" card

### DIFF
--- a/apps/web/src/components/file-renderers/show-content-renderer.tsx
+++ b/apps/web/src/components/file-renderers/show-content-renderer.tsx
@@ -26,7 +26,7 @@
  *    → hero link card or proxied iframe
  */
 
-import React, { useCallback, useMemo, useState, lazy, Suspense } from 'react';
+import React, { useCallback, useEffect, useMemo, useState, lazy, Suspense } from 'react';
 import {
   AlertTriangle,
   ChevronLeft,
@@ -182,6 +182,13 @@ export interface ShowContentProps {
    * to fill; text/code scroll internally rather than capping at a fixed height.
    */
   fill?: boolean;
+  /**
+   * Optional: report load status up to the parent so a single-item `show` whose
+   * artifact failed to load (renamed/deleted file → 404) can be hidden instead
+   * of rendering a broken card. Fired for fetch-backed types (image/video/
+   * audio/pdf/csv/docx/pptx) and forwarded from the generic-file renderer.
+   */
+  onStatusChange?: (status: 'loading' | 'ready' | 'error') => void;
 }
 
 // ── Component ──────────────────────────────────────────────────────────────
@@ -197,6 +204,7 @@ export function ShowContentRenderer({
   aspectRatio = '',
   LocalhostPreview,
   fill = false,
+  onStatusChange,
 }: ShowContentProps) {
   const arCSS = showAspectRatioToCSS(aspectRatio);
 
@@ -302,6 +310,56 @@ export function ShowContentRenderer({
       </div>
     );
   }, [title, path]);
+
+  // ═════════════════════════════════════════════════════════════════════════
+  // Load-status reporting — lets the parent (ShowTool) hide a dead reference
+  // (renamed/deleted file → 404) instead of rendering a broken card.
+  // `null` = a child renderer owns the reporting (the generic-file branch
+  // forwards `onStatusChange` straight to FileContentRenderer below). The branch
+  // selection here mirrors the render cascade further down.
+  // ═════════════════════════════════════════════════════════════════════════
+  const ownStatus = useMemo<'loading' | 'ready' | 'error' | null>(() => {
+    // Generic file → FileContentRenderer reports via its own onStatusChange.
+    if (effectiveType === 'file' && path && sandboxPath) return null;
+    // Binary/media types backed by useBinaryBlob.
+    if ((isImage || isVideo || isAudio || isDocx || isPptx) && path) {
+      if (blobError) return 'error';
+      if (blobLoading || (isImage && heicConverting)) return 'loading';
+      return 'ready';
+    }
+    // PDF backed by useFileContent (base64).
+    if (isPdf && path) {
+      if (pdfError) return 'error';
+      if (pdfLoading) return 'loading';
+      return 'ready';
+    }
+    // CSV backed by useFileContent (text).
+    if (isCsv && path) return csvLoading ? 'loading' : 'ready';
+    // Everything else (url link, xlsx self-loading, code/markdown/text/html/
+    // error, localhost/html iframe, fallback) renders without a fetch we track.
+    return 'ready';
+  }, [
+    effectiveType,
+    path,
+    sandboxPath,
+    isImage,
+    isVideo,
+    isAudio,
+    isDocx,
+    isPptx,
+    isPdf,
+    isCsv,
+    blobError,
+    blobLoading,
+    heicConverting,
+    pdfError,
+    pdfLoading,
+    csvLoading,
+  ]);
+
+  useEffect(() => {
+    if (ownStatus !== null) onStatusChange?.(ownStatus);
+  }, [ownStatus, onStatusChange]);
 
   // ═════════════════════════════════════════════════════════════════════════
   // Localhost URL → proxied iframe (caller provides the component)
@@ -538,6 +596,7 @@ export function ShowContentRenderer({
           showHeader={false}
           className="h-full"
           errorFallback={fileErrorFallback}
+          onStatusChange={onStatusChange}
         />
       </div>
     );

--- a/apps/web/src/features/file-viewer/file-content-renderer.tsx
+++ b/apps/web/src/features/file-viewer/file-content-renderer.tsx
@@ -299,6 +299,12 @@ export interface FileContentRendererProps {
    *  preview/source toggle into its own chrome. */
   markdownPreview?: boolean;
   onMarkdownPreviewChange?: (preview: boolean) => void;
+  /**
+   * Optional: report load status to the caller. Used by `show` tool cards to
+   * hide a dead/renamed file reference (→ 'error') instead of rendering the
+   * "file does not exist" state. No effect on the default viewer chrome.
+   */
+  onStatusChange?: (status: 'loading' | 'ready' | 'error') => void;
 }
 
 export function FileContentRenderer({
@@ -313,6 +319,7 @@ export function FileContentRenderer({
   readOnly = false,
   markdownPreview,
   onMarkdownPreviewChange,
+  onStatusChange,
 }: FileContentRendererProps) {
   const tI18nHardcoded = useTranslations('hardcodedUi');
   const tHardcodedUi = useTranslations('hardcodedUi');
@@ -638,6 +645,16 @@ export function FileContentRenderer({
     blobError,
     rawBlob,
   ]);
+
+  // Report load status up (used by `show` cards to hide dead references). Only
+  // fires when a caller opts in via `onStatusChange`; the default viewer is
+  // unaffected.
+  useEffect(() => {
+    if (!onStatusChange) return;
+    if (isNotFound) onStatusChange('error');
+    else if (showLoadingState) onStatusChange('loading');
+    else onStatusChange('ready');
+  }, [onStatusChange, isNotFound, showLoadingState]);
 
   // ---------------------------------------------------------------------------
   // Shared CodeEditor props — keeps edit & read-only paths DRY

--- a/apps/web/src/features/session/show-availability.test.ts
+++ b/apps/web/src/features/session/show-availability.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from 'bun:test';
+
+import { isShowContentUnavailable, type ShowAvailabilityInput } from './show-availability';
+
+const base: ShowAvailabilityInput = {
+  running: false,
+  isCarousel: false,
+  contentStatus: 'ready',
+  isWebsitePreview: false,
+  previewHasError: false,
+  previewIsLinkOnly: false,
+};
+
+describe('isShowContentUnavailable', () => {
+  test('hides a settled single-item show whose file 404d', () => {
+    expect(isShowContentUnavailable({ ...base, contentStatus: 'error' })).toBe(true);
+  });
+
+  test('keeps a show whose content loaded', () => {
+    expect(isShowContentUnavailable({ ...base, contentStatus: 'ready' })).toBe(false);
+  });
+
+  test('keeps a show whose content is still loading', () => {
+    expect(isShowContentUnavailable({ ...base, contentStatus: 'loading' })).toBe(false);
+  });
+
+  test('never hides while the tool is still running (artifact may be materializing)', () => {
+    expect(isShowContentUnavailable({ ...base, running: true, contentStatus: 'error' })).toBe(false);
+  });
+
+  test('never hides a carousel wholesale', () => {
+    expect(isShowContentUnavailable({ ...base, isCarousel: true, contentStatus: 'error' })).toBe(
+      false,
+    );
+  });
+
+  test('hides an errored website/iframe preview', () => {
+    expect(
+      isShowContentUnavailable({ ...base, isWebsitePreview: true, previewHasError: true }),
+    ).toBe(true);
+  });
+
+  test('keeps a healthy website preview', () => {
+    expect(
+      isShowContentUnavailable({ ...base, isWebsitePreview: true, previewHasError: false }),
+    ).toBe(false);
+  });
+
+  test('keeps an errored preview that is an intentional link-only fallback', () => {
+    expect(
+      isShowContentUnavailable({
+        ...base,
+        isWebsitePreview: true,
+        previewHasError: true,
+        previewIsLinkOnly: true,
+      }),
+    ).toBe(false);
+  });
+
+  test('a website preview ignores contentStatus (iframe health drives it)', () => {
+    expect(
+      isShowContentUnavailable({
+        ...base,
+        isWebsitePreview: true,
+        previewHasError: false,
+        contentStatus: 'error',
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/web/src/features/session/show-availability.ts
+++ b/apps/web/src/features/session/show-availability.ts
@@ -1,0 +1,60 @@
+/**
+ * Availability gating for `show` tool cards.
+ *
+ * A `show` tool call points at an artifact — a generated file, an image, a
+ * rendered iframe preview, etc. Artifacts get renamed, regenerated, or deleted
+ * as a session progresses, so a `show` from earlier in the run can end up
+ * pointing at something that no longer loads (a 404'd file, an unhealthy
+ * preview). Rather than render a broken "File not found" card for these dead
+ * references, the renderer hides them entirely and only keeps the `show` cards
+ * whose content actually loaded.
+ *
+ * This module holds the pure decision used by `ShowTool`, kept separate so it
+ * can be unit-tested without rendering the (async, data-fetching) tree.
+ */
+
+/** Load status reported up from a show's single-item content renderer. */
+export type ShowLoadStatus = 'loading' | 'ready' | 'error';
+
+export interface ShowAvailabilityInput {
+  /** The tool part is still streaming/producing — the artifact may not exist yet. */
+  running: boolean;
+  /** Multi-item carousel — manages its own per-item state, never hidden wholesale. */
+  isCarousel: boolean;
+  /** Status reported by the single-item file/media content renderer. */
+  contentStatus: ShowLoadStatus;
+  /** This show renders an embedded website/file iframe preview. */
+  isWebsitePreview: boolean;
+  /** The iframe preview failed to load (errored or timed out). */
+  previewHasError: boolean;
+  /** The preview is an intentional link-only fallback (a card, not a failure). */
+  previewIsLinkOnly: boolean;
+}
+
+/**
+ * Decide whether a single-item `show` card should be hidden because its
+ * underlying artifact failed to load.
+ *
+ * Rules:
+ *  - While the tool is still running, never hide — the file may still be
+ *    materializing, and a transient 404 shouldn't make the card flicker away.
+ *  - Carousels are never hidden wholesale (they navigate between items).
+ *  - A website/iframe preview is hidden only when it actually errored AND it
+ *    isn't a deliberate link-only fallback.
+ *  - Otherwise the card is hidden when its file/media content errored (e.g. the
+ *    file was renamed or deleted → 404).
+ */
+export function isShowContentUnavailable(input: ShowAvailabilityInput): boolean {
+  const {
+    running,
+    isCarousel,
+    contentStatus,
+    isWebsitePreview,
+    previewHasError,
+    previewIsLinkOnly,
+  } = input;
+
+  if (running || isCarousel) return false;
+  if (isWebsitePreview) return previewHasError && !previewIsLinkOnly;
+  return contentStatus === 'error';
+}

--- a/apps/web/src/features/session/tool-renderers.tsx
+++ b/apps/web/src/features/session/tool-renderers.tsx
@@ -13,6 +13,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { useFileContent } from '@/features/files/hooks/use-file-content';
 import { QuestionPrompt } from '@/features/session/question-prompt';
 import { prefersPreviewLink } from '@/features/session/preview-url-fallback';
+import { isShowContentUnavailable, type ShowLoadStatus } from './show-availability';
 import {
   SessionRetryDisplay,
   TurnErrorDisplay,
@@ -5051,6 +5052,10 @@ function ShowTool({ part, sessionId }: ToolProps) {
   const [carouselIndex, setCarouselIndex] = useState(0);
   const currentItem = isCarousel ? items![carouselIndex] || items![0] : null;
 
+  // Load status of a single-item show's content — drives whether we hide a dead
+  // reference (renamed/deleted file → 404) instead of rendering a broken card.
+  const [contentStatus, setContentStatus] = useState<ShowLoadStatus>('loading');
+
   // Derive the "active" item props — either the single item or the current carousel item
   const activeType = isCarousel ? currentItem?.type || '' : type;
   const activeUrl = isCarousel ? currentItem?.url || '' : url;
@@ -5122,6 +5127,23 @@ function ShowTool({ part, sessionId }: ToolProps) {
     : title || (type === 'error' ? 'Error' : type === 'url' ? showDomain(url) || 'Link' : 'Output');
 
   const headerIcon = isCarousel ? currentItem?.type || 'image' : isWebsitePreview ? 'url' : type;
+
+  // Hide a settled single-item show whose artifact failed to load — a renamed/
+  // deleted file (404) or an unhealthy iframe preview. Artifacts are updated
+  // throughout a run, so stale `show` references are expected; we surface only
+  // the ones that actually loaded rather than a broken "File not found" card.
+  if (
+    isShowContentUnavailable({
+      running,
+      isCarousel,
+      contentStatus,
+      isWebsitePreview,
+      previewHasError: preview.hasError,
+      previewIsLinkOnly: prefersPreviewLink(preview.previewUrl),
+    })
+  ) {
+    return null;
+  }
 
   return (
     <div
@@ -5251,6 +5273,7 @@ function ShowTool({ part, sessionId }: ToolProps) {
                 aspectRatio={aspectRatio}
                 LocalhostPreview={InlineServicePreview}
                 fill={fill}
+                onStatusChange={setContentStatus}
               />
             </div>
             {description && !title && (


### PR DESCRIPTION
## Problem

A `show` tool call points at an artifact — a generated file, image, or iframe preview. Artifacts get **renamed / regenerated / deleted** as a session runs, so a `show` from earlier in the run can end up pointing at a path that no longer exists.

Concrete case from prod ([session](https://kortix.com/projects/4320e248-9abf-4e43-92a6-c2cdb97237c0/sessions/59c54996-9aa1-423d-aab5-03ddf92cec35)): the deck was saved as `/workspace/output/spacex_ic_deck.pptx`, but an earlier `show` referenced `/workspace/output/spacex_ic_triage.pptx`. Opening it correctly 404s (the path genuinely doesn't exist) — but the viewer rendered a broken **"This file does not exist or may have been deleted"** card, which reads like a bug even though the real file renders fine from the Files panel.

## Fix

Only surface `show` cards whose content actually loaded. A **settled, single-item** show whose artifact fails to load is hidden entirely instead of rendering a broken card:

- **file/media** (`image/video/audio/pdf/csv/docx/pptx`) report load status up from `ShowContentRenderer`; the generic-file path forwards `FileContentRenderer`'s own not-found status.
- **website / file iframe previews** are hidden when the iframe errors — but kept when it's an intentional link-only fallback.
- **never hidden while the tool is still running** (the artifact may still be materializing) or for **multi-item carousels** (they navigate per item).

The hide decision is a pure, unit-tested helper (`isShowContentUnavailable`). The new `onStatusChange` props are opt-in — the default file viewer chrome (Files panel) is unaffected and still shows its not-found state.

## Test

- `apps/web/src/features/session/show-availability.test.ts` — 9 cases (404 → hide, loading/ready → keep, running → keep, carousel → keep, iframe error → hide, link-only → keep). All green.
- `tsc --noEmit` clean for all touched files.