### PR TITLE
Use the Kortix ASCII logo loader on main page loads

### DIFF
--- a/apps/web/src/app/(app)/checkout/page.tsx
+++ b/apps/web/src/app/(app)/checkout/page.tsx
@@ -5,7 +5,7 @@ import { useTranslations } from 'next-intl';
 import React, { useEffect, useState, Suspense } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { KortixLoader } from '@/components/ui/kortix-loader';
+import { KortixHyperLogo } from '@/components/ui/marketing/kortix-hyper-logo';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import Script from 'next/script';
 
@@ -136,7 +136,7 @@ function CheckoutContent() {
           </Card>
         ) : isLoading ? (
           <div className="flex flex-col items-center gap-4">
-            <KortixLoader size="xlarge" />
+            <KortixHyperLogo size={80} startOnView={false} loop className="text-foreground" />
             <p className="text-muted-foreground text-sm">{tHardcodedUi.raw('appCheckoutPage.line158JsxTextLoadingSecureCheckout')}</p>
           </div>
         ) : (
@@ -154,7 +154,7 @@ export default function CheckoutPage() {
   return (
     <Suspense fallback={
       <div className="min-h-screen bg-background flex items-center justify-center">
-        <KortixLoader size="large" forceTheme="light" />
+        <KortixHyperLogo size={72} startOnView={false} loop className="text-foreground" />
       </div>
     }>
       <CheckoutContent />

--- a/apps/web/src/app/(auth)/auth/github-connect/page.tsx
+++ b/apps/web/src/app/(auth)/auth/github-connect/page.tsx
@@ -4,7 +4,7 @@ import { useTranslations } from 'next-intl';
 
 import { useEffect, useState } from 'react';
 import { createClient } from '@/lib/supabase/client';
-import { KortixLoader } from '@/components/ui/kortix-loader';
+import { KortixHyperLogo } from '@/components/ui/marketing/kortix-hyper-logo';
 
 type ConnectMessage =
   | { type: 'github-connect-success'; provider_token: string; github_login?: string }
@@ -114,7 +114,9 @@ export default function GitHubConnectPopup() {
   return (
     <main className="flex min-h-screen flex-col items-center justify-center bg-background p-8">
       <div className="flex max-w-sm flex-col items-center gap-4 text-center">
-        {status !== 'error' && <KortixLoader size="large" />}
+        {status !== 'error' && (
+          <KortixHyperLogo size={64} startOnView={false} loop className="text-foreground" />
+        )}
         <div className="space-y-1">
           <h1 className="text-base font-medium">{tHardcodedUi.raw('appAuthGithubConnectPage.line116JsxTextConnectGithub')}</h1>
           <p className={status === 'error' ? 'text-sm text-destructive' : 'text-sm text-muted-foreground'}>

--- a/apps/web/src/app/(auth)/auth/github-popup/page.tsx
+++ b/apps/web/src/app/(auth)/auth/github-popup/page.tsx
@@ -5,7 +5,7 @@ import { useTranslations } from 'next-intl';
 import { cn } from '@/lib/utils';
 import { useEffect, useState } from 'react';
 import { createClient } from '@/lib/supabase/client';
-import { KortixLoader } from '@/components/ui/kortix-loader';
+import { KortixHyperLogo } from '@/components/ui/marketing/kortix-hyper-logo';
 import { Button } from '@/components/ui/button';
 
 interface AuthMessage {
@@ -199,7 +199,7 @@ export default function GitHubOAuthPopup() {
     <main className="flex flex-col items-center justify-center h-screen bg-background p-8">
       <div className="flex flex-col items-center gap-4 text-center max-w-sm">
         {status !== 'error' && (
-          <KortixLoader size="large" />
+          <KortixHyperLogo size={64} startOnView={false} loop className="text-foreground" />
         )}
 
         <div className="space-y-2">

--- a/apps/web/src/app/(public)/templates/[shareId]/page.tsx
+++ b/apps/web/src/app/(public)/templates/[shareId]/page.tsx
@@ -28,7 +28,7 @@ import {
   ChevronDown,
   ChevronUp
 } from 'lucide-react';
-import { KortixLoader } from '@/components/ui/kortix-loader';
+import { KortixHyperLogo } from '@/components/ui/marketing/kortix-hyper-logo';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -242,7 +242,7 @@ export default function TemplateSharePage() {
     return (
       <div className="min-h-screen">
         <div className="flex items-center justify-center h-screen">
-          <KortixLoader size="large" />
+          <KortixHyperLogo size={72} startOnView={false} loop className="text-foreground" />
         </div>
       </div>
     );

--- a/apps/web/src/app/admin/utils/page.tsx
+++ b/apps/web/src/app/admin/utils/page.tsx
@@ -5,7 +5,7 @@ import { useTranslations } from 'next-intl';
 import { useState, useEffect } from "react";
 import { Settings, Clock } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
-import { KortixLoader } from "@/components/ui/kortix-loader";
+import { KortixHyperLogo } from "@/components/ui/marketing/kortix-hyper-logo";
 import { toast } from "@/lib/toast";
 import {
   useMaintenanceAdmin,
@@ -108,7 +108,7 @@ export default function AdminUtilsPage() {
   if (isLoading) {
     return (
       <div className="flex items-center justify-center h-screen">
-        <KortixLoader size="large" />
+        <KortixHyperLogo size={72} startOnView={false} loop className="text-foreground" />
       </div>
     );
   }

--- a/apps/web/src/components/common/route-loading.tsx
+++ b/apps/web/src/components/common/route-loading.tsx
@@ -1,13 +1,13 @@
-import { KortixLoader } from '@/components/ui/kortix-loader';
+import { KortixHyperLogo } from '@/components/ui/marketing/kortix-hyper-logo';
 
 /**
- * Shared fallback for Next.js route-segment `loading.tsx` files — a centered
- * spinner shown during navigation/streaming instead of a blank frame.
+ * Shared fallback for Next.js route-segment `loading.tsx` files — the Kortix
+ * ASCII logo loader, shown during navigation/streaming instead of a blank frame.
  */
 export function RouteLoadingFallback() {
   return (
     <div className="flex min-h-[60vh] w-full items-center justify-center">
-      <KortixLoader size="large" />
+      <KortixHyperLogo size={72} startOnView={false} loop className="text-foreground" />
     </div>
   );
 }

--- a/apps/web/src/components/ui/marketing/kortix-hyper-logo.tsx
+++ b/apps/web/src/components/ui/marketing/kortix-hyper-logo.tsx
@@ -17,6 +17,8 @@ interface KortixHyperLogoProps extends Omit<MotionProps, 'children'> {
   delay?: number;
   startOnView?: boolean;
   animateOnHover?: boolean;
+  /** Replay the reveal continuously — use when this is a loading indicator. */
+  loop?: boolean;
 }
 
 export function KortixHyperLogo({
@@ -26,12 +28,14 @@ export function KortixHyperLogo({
   delay = 0,
   startOnView = true,
   animateOnHover = true,
+  loop = false,
   ...props
 }: KortixHyperLogoProps) {
   const clipId = useId();
   const [cells, setCells] = useState<Cell[]>(() => buildCells(false));
   const [progress, setProgress] = useState(1);
   const [isAnimating, setIsAnimating] = useState(false);
+  const [cycle, setCycle] = useState(0);
   const svgRef = useRef<SVGSVGElement | null>(null);
 
   const handleAnimationTrigger = () => {
@@ -72,6 +76,7 @@ export function KortixHyperLogo({
 
   useEffect(() => {
     let animationFrameId: number | null = null;
+    let restartTimer: ReturnType<typeof setTimeout> | null = null;
 
     if (isAnimating) {
       const startTime = performance.now();
@@ -84,7 +89,15 @@ export function KortixHyperLogo({
           animationFrameId = requestAnimationFrame(animate);
         } else {
           setProgress(1);
-          setIsAnimating(false);
+          if (loop) {
+            // hold the resolved logo briefly, then re-scramble and replay
+            restartTimer = setTimeout(() => {
+              setCells(buildCells(true));
+              setCycle((c) => c + 1);
+            }, 700);
+          } else {
+            setIsAnimating(false);
+          }
         }
       };
 
@@ -94,8 +107,9 @@ export function KortixHyperLogo({
 
     return () => {
       if (animationFrameId !== null) cancelAnimationFrame(animationFrameId);
+      if (restartTimer !== null) clearTimeout(restartTimer);
     };
-  }, [duration, isAnimating]);
+  }, [duration, isAnimating, loop, cycle]);
 
   const fillPhase = Math.min(progress / 0.6, 1);
   const solidOpacity = progress <= 0.6 ? 0 : (progress - 0.6) / 0.4;


### PR DESCRIPTION
## What

Swap the ring spinner (`KortixLoader`) for the **`KortixHyperLogo` ASCII-block reveal** on the **big / full-page loaders**, so a page load shows the branded Kortix loading effect instead of a generic spinner.

Changed loaders:
- **`RouteLoadingFallback`** — the shared Next.js route-segment `loading.tsx` fallback (app-wide page navigation/streaming).
- **Full-page auth** — `github-connect`, `github-popup`.
- **`checkout`** (the content loader + the Suspense fallback).
- **`templates/[shareId]`** (public share page).
- **`admin/utils`**.

**Inline button spinners are intentionally left as the small ring** (`KortixLoader size="small"` in sign-in, OTP, toolbars, agent cards, etc.) — an ASCII logo doesn't belong inside a button.

## How

Adds an **opt-in `loop` prop** to `KortixHyperLogo` so the ASCII reveal replays continuously as a loading indicator. Default is `false`, so the existing one-shot / hover usages (`error.tsx`, `cli-demo`, `project-access-boundary`) are unchanged. The page loaders use `<KortixHyperLogo startOnView={false} loop className="text-foreground" />`.

## Scope / notes

- No change to the BIOS boot-overlay or to any inline button spinner.
- `text-foreground` keeps it theme-aware (replaces the one `forceTheme="light"` usage on checkout).
- Typecheck clean for all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)