### PR TITLE
feat(slack): turn moonshot asks into shippable work

### DIFF
--- a/apps/api/src/__tests__/unit-slack-dispatch-session.test.ts
+++ b/apps/api/src/__tests__/unit-slack-dispatch-session.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import type { SlackEvent } from '../channels/slack/types';
 import type { ProjectSessionRow } from '../projects/lib/serializers';
-import type { SessionDeliveryOutcome } from '../projects/session-lifecycle';
+import type { ContinueSessionCommand, CreateSessionCommand, SessionDeliveryOutcome } from '../projects/session-lifecycle';
 
 // Persist the headline invariant of the Slack channel refactor: a known thread
 // maps PERMANENTLY to exactly one session. A follow-up routes into that session
@@ -56,15 +57,19 @@ let deliverOutcome: SessionDeliveryOutcome = 'delivered';
 let deliverCalls = 0;
 
 // ─── lifecycle seam: spy on createSession (the "second session") ─────────────
+type RecordedCreateSessionInput = CreateSessionCommand & {
+  body: { initial_prompt?: string };
+  metadata?: { slack?: { conversation_policy?: string } };
+};
 let createSessionCalls = 0;
-let createSessionInputs: any[] = [];
+let createSessionInputs: RecordedCreateSessionInput[] = [];
 mock.module('../projects/session-lifecycle', () => ({
   continueSession: async () => {
     deliverCalls++;
     return deliverOutcome;
   },
-  createSession: async (input: any) => {
-    createSessionInputs.push(input);
+  createSession: async (input: CreateSessionCommand) => {
+    createSessionInputs.push(input as RecordedCreateSessionInput);
     createSessionCalls++;
     return { status: 'created', sessionId: 'replacement-sess', row: fakeSessionRow('replacement-sess') };
   },
@@ -167,8 +172,8 @@ beforeEach(() => {
       deliverCalls++;
       return deliverOutcome;
     },
-    createSession: async (input: any) => {
-      createSessionInputs.push(input);
+    createSession: async (input: CreateSessionCommand) => {
+      createSessionInputs.push(input as RecordedCreateSessionInput);
       createSessionCalls++;
       return { status: 'created', sessionId: 'replacement-sess', row: fakeSessionRow('replacement-sess') };
     },
@@ -191,7 +196,7 @@ describe('Slack authorization matrix — project access and session visibility',
       ts: '110.1',
       user: 'Uoutsider',
       text: '<@B1> show me secrets',
-    } as any);
+    } satisfies SlackEvent);
 
     expect(createSessionCalls).toBe(0);
     expect(deliverCalls).toBe(0);
@@ -425,6 +430,31 @@ describe('createOrJoinThreadSession — atomic claim arbitrates a brand-new thre
     expect(deliverCalls).toBe(0); // the winner creates with the initial prompt; no follow-up
   });
 
+  test('initial prompt pushes vague ambitious asks into a shippable slice', async () => {
+    dbResults = [
+      [project], // spawnAgentTurn project lookup
+      [], // chat_threads lookup → brand-new thread
+      [project], // projects lookup
+      [{ eventId: 'claim' }], // claimThreadCreate → WON
+      [], // re-check chat_threads → still none
+      [], // channel selection → defaults
+      [], // remember owner participant
+    ];
+    await spawnAgentTurn('proj-1', envelope, {
+      ...event,
+      thread_ts: undefined,
+      ts: '150.1',
+      text: '<@B1> build agi. like fr try.',
+    } satisfies SlackEvent);
+
+    const prompt = createSessionInputs[0]?.body?.initial_prompt;
+    expect(prompt).toContain('load the `engineering` skill');
+    expect(prompt).toContain('For ambitious or vague asks like "build AGI"');
+    expect(prompt).toContain('Pick the smallest concrete');
+    expect(prompt).toContain('valuable slice you can actually ship');
+    expect(prompt).toContain('implement and verify it');
+  });
+
   test('claim LOST → joins the winner’s session as a follow-up, NEVER creates a second', async () => {
     dbResults = [
       [project], // spawnAgentTurn project lookup
@@ -436,6 +466,29 @@ describe('createOrJoinThreadSession — atomic claim arbitrates a brand-new thre
     await spawnAgentTurn('proj-1', envelope, event);
     expect(createSessionCalls).toBe(0); // never a shadow session
     expect(deliverCalls).toBe(1); // delivered into the winner's session as a follow-up
+  });
+
+  test('follow-up prompt keeps the same shippable-slice behavior', async () => {
+    let followUpText = '';
+    setSlackSessionLifecycleForTest({
+      continueSession: async (input: ContinueSessionCommand) => {
+        followUpText = input.text;
+        deliverCalls++;
+        return deliverOutcome;
+      },
+    });
+    deliverOutcome = 'delivered';
+    dbResults = [[project], [{ sessionId: 'sess-1', createdBy: 'user-1', metadata: {} }], []];
+
+    await spawnAgentTurn('proj-1', envelope, {
+      ...event,
+      text: '<@B1> actually build agi now',
+    } satisfies SlackEvent);
+
+    expect(followUpText).toContain('For ambitious or vague asks like "build AGI"');
+    expect(followUpText).toContain('Pick the smallest concrete');
+    expect(followUpText).toContain('valuable slice you can actually ship');
+    expect(followUpText).toContain('implement and verify it');
   });
 });
 

--- a/apps/api/src/channels/slack/session.ts
+++ b/apps/api/src/channels/slack/session.ts
@@ -1,11 +1,11 @@
-import { and, eq } from 'drizzle-orm';
 import { chatEventDedup, chatThreads, projects } from '@kortix/db';
-import { db } from '../../shared/db';
+import { and, eq } from 'drizzle-orm';
 import {
   continueSession as continueLifecycleSession,
   createSession as createLifecycleSession,
   resolveProjectAutomationActor as resolveLifecycleAutomationActor,
 } from '../../projects/session-lifecycle';
+import { db } from '../../shared/db';
 import { EVENT_DEDUPE_TTL_MS } from './app';
 import { currentChannelSelection } from './selection';
 import {
@@ -287,6 +287,14 @@ const TURN_INSTRUCTIONS = [
   '  The `blocks` JSON follows the Block Kit schema (header, section with mrkdwn,',
   '  divider, context, image, actions). Plain text via `slack send "..."` is fine',
   '  for one-liners, but prefer blocks when there\'s real structure to convey.',
+  '- If the task implies code changes, load the `engineering` skill, work in the repo',
+  '  that owns the code, verify with real tests/app behavior, then open a PR with the',
+  '  required preview/checks before calling it done.',
+  '- For ambitious or vague asks like "build AGI", "fix growth", or "make this 10x",',
+  '  do not only debate semantics or ask for clarification. Pick the smallest concrete,',
+  '  valuable slice you can actually ship in the current repo/context, announce that',
+  '  slice with a `slack step`, then implement and verify it. Be honest about scope,',
+  '  but leave the system measurably better than you found it.',
   '- One `slack send` per turn. It finalizes the live stream and can\'t be undone.',
 ].join('\n');
 


### PR DESCRIPTION
## Summary
- add Slack turn guidance that code-changing tasks should use the engineering workflow and PR/preview gate
- tell Slack agents to convert ambitious/vague asks like "build AGI" into the smallest concrete shippable slice instead of only debating scope
- add regression coverage for initial and follow-up Slack prompts

## Verification
- KORTIX_BILLING_INTERNAL_ENABLED=false KORTIX_URL=http://localhost:8008 pnpm exec dotenvx run -f .env.keys -f apps/api/.env -- bun test apps/api/src/__tests__/unit-slack-dispatch-session.test.ts
- pnpm --filter kortix-api typecheck