### PR TITLE
fix(meet): materialize kortix_meet connector when the Meetings flag is toggled on

### DIFF
--- a/apps/api/src/projects/routes/r6.ts
+++ b/apps/api/src/projects/routes/r6.ts
@@ -14,7 +14,7 @@ import { AccessMemberSchema, AnyObject, projectsApp } from '../lib/app';
 import { getAccountMembership } from '../lib/git';
 import { readBody, serializeProject } from '../lib/serializers';
 import { applyExperimentalOverride, isExperimentalFeatureKey } from '../../experimental/features';
-import { reconcileComputerConnectors } from '../../executor/sync';
+import { reconcileChannelConnectors, reconcileComputerConnectors } from '../../executor/sync';
 import { propagateLlmGatewayModeToActiveSandboxes } from '../lib/sandbox-env-sync';
 import { projectLlmGatewayEnabled } from '../../llm-gateway/enablement';
 
@@ -1115,6 +1115,9 @@ projectsApp.openapi(
     if (!row || row.status === 'archived') return c.json({ error: 'Not found' }, 404);
     if (feature === 'agent_tunnel') {
       void reconcileComputerConnectors(row.accountId);
+    }
+    if (feature === 'meet') {
+      void reconcileChannelConnectors(projectId);
     }
     if (feature === 'llm_gateway') {
       void propagateLlmGatewayModeToActiveSandboxes(projectId, projectLlmGatewayEnabled(row.metadata));

--- a/tests/src/flows/experimental.flow.ts
+++ b/tests/src/flows/experimental.flow.ts
@@ -46,6 +46,31 @@ flow(
       r.status(200);
     });
 
+    // meet uses the same write path + reconciles the kortix_meet channel connector.
+    // Assert structure (not the effective value — that depends on MEET_ENABLED on the
+    // target), then clear it.
+    await ctx.step("OWNER enables meet → 200 + catalog in body", async () => {
+      const r = await ctx.client
+        .as(ctx.P.OWNER)
+        .patch(
+          "/v1/projects/:projectId/experimental",
+          { feature: "meet", enabled: true },
+          { params: { projectId: p.id } },
+        );
+      r.status(200).body().exists("$.experimental_features").exists("$.experimental");
+    });
+
+    await ctx.step("OWNER clears the meet override (enabled: null) → 200", async () => {
+      const r = await ctx.client
+        .as(ctx.P.OWNER)
+        .patch(
+          "/v1/projects/:projectId/experimental",
+          { feature: "meet", enabled: null },
+          { params: { projectId: p.id } },
+        );
+      r.status(200);
+    });
+
     await ctx.step("unknown feature → 400", async () => {
       const r = await ctx.client
         .as(ctx.P.OWNER)


### PR DESCRIPTION
Follow-up to #3980.

Enabling the **Meetings** experimental flag wrote `metadata.experimental.meet = true` but never reconciled connectors, so the `kortix_meet` connector was never materialized — `meet join` returned `connector_not_found` even with the flag on and a Recall key configured.

The `PATCH /:projectId/experimental` handler already reconciles for `agent_tunnel` (computer connectors) and `llm_gateway` (sandbox propagation), but did nothing for `meet`. This adds `reconcileChannelConnectors(projectId)` on the `meet` toggle, mirroring them — so the connector materializes immediately (via `channel-materialize.ts`, when `MEET_ENABLED` + a Recall key are present), instead of waiting for the next periodic sync.

Note: deployed envs still need `MEET_ENABLED` + `RECALL_API_KEY` live in the running pods (set in the env secret; picked up on rollout) for the connector to materialize.