### PR TITLE
fix(meet): half-duplex guard against the bot's own speech echoing back

### DIFF
--- a/apps/api/src/__tests__/unit-meet-echo.test.ts
+++ b/apps/api/src/__tests__/unit-meet-echo.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { isBotEcho, recordBotSpeech } from '../channels/meet-echo';
+import { isBotEcho, isBotSpeaking, recordBotSpeech } from '../channels/meet-echo';
 import { isSelfEcho } from '../channels/meet-webhook';
 
 describe('meet self-echo suppression (the bot hearing itself)', () => {
@@ -38,12 +38,31 @@ describe('meet self-echo suppression (the bot hearing itself)', () => {
 
 describe('isSelfEcho', () => {
   test("drops the bot's own chat message by sender name", () => {
-    expect(isSelfEcho('botX', 'Kortix Notetaker', { speaker: 'Kortix Notetaker', text: 'hi' })).toBe(true);
-    expect(isSelfEcho('botX', 'Kortix Notetaker', { speaker: 'Saumya', text: 'hi' })).toBe(false);
+    expect(isSelfEcho('botX', 'Kortix Notetaker', { speaker: 'Kortix Notetaker', text: 'hi', spoken: false })).toBe(
+      true,
+    );
+    expect(isSelfEcho('botX', 'Kortix Notetaker', { speaker: 'Saumya', text: 'hi', spoken: false })).toBe(false);
   });
 
   test('drops the bot transcribed speaking itself (content echo)', () => {
     recordBotSpeech('botY', 'Welcome everyone, glad to be here.');
-    expect(isSelfEcho('botY', 'Kortix', { speaker: 'Unknown', text: 'Welcome everyone glad to be here' })).toBe(true);
+    expect(
+      isSelfEcho('botY', 'Kortix', { speaker: 'Unknown', text: 'Welcome everyone glad to be here', spoken: true }),
+    ).toBe(true);
+  });
+
+  test('half-duplex: drops ALL inbound speech while the bot is speaking (immune to caption mangling)', () => {
+    recordBotSpeech('botSpk', 'Let me tell you all about what the project is and everything it can do today');
+    // even a fragment that would NOT content-match (heavy mis-hearing) is dropped during the window
+    expect(isBotSpeaking('botSpk')).toBe(true);
+    expect(isSelfEcho('botSpk', 'Kortix', { speaker: 'Unknown', text: 'so kortix is all about', spoken: true })).toBe(
+      true,
+    );
+    // chat is exempt from the speaking window — a real typed message still gets through
+    expect(isSelfEcho('botSpk', 'Kortix', { speaker: 'Saumya', text: 'unrelated typed note', spoken: false })).toBe(
+      false,
+    );
+    // a bot that hasn't spoken is not gated
+    expect(isBotSpeaking('botQuiet')).toBe(false);
   });
 });

--- a/apps/api/src/channels/meet-echo.ts
+++ b/apps/api/src/channels/meet-echo.ts
@@ -1,7 +1,18 @@
 const ECHO_TTL_MS = 25_000;
 const MAX_TRACKED_BOTS = 512;
 
+// Half-duplex window: meeting captions transcribe the bot's OWN output audio and
+// stream it back as "Unknown" speech, which would re-wake the agent. While the bot
+// is speaking — for the estimated duration of its utterance plus a caption-lag
+// buffer — we drop inbound spoken transcripts entirely. Unlike content matching this
+// scales with utterance length (long monologues don't outrun a fixed TTL) and is
+// immune to caption mis-hearings ("Kortix" → "cortex").
+const MS_PER_WORD = 450;
+const CAPTION_LAG_MS = 12_000;
+const MIN_SPEAK_MS = 3_000;
+
 const recent = new Map<string, Array<{ text: string; at: number }>>();
+const speakingUntil = new Map<string, number>();
 
 function normalize(text: string): string {
   return text
@@ -9,6 +20,10 @@ function normalize(text: string): string {
     .replace(/[^a-z0-9\s]/g, '')
     .replace(/\s+/g, ' ')
     .trim();
+}
+
+function wordCount(text: string): number {
+  return text.trim().split(/\s+/).filter(Boolean).length;
 }
 
 export function recordBotSpeech(botId: string, text: string): void {
@@ -19,6 +34,21 @@ export function recordBotSpeech(botId: string, text: string): void {
   list.push({ text: norm, at: now });
   recent.set(botId, list);
   if (recent.size > MAX_TRACKED_BOTS) prune(now);
+
+  const windowMs = Math.max(MIN_SPEAK_MS, wordCount(text) * MS_PER_WORD) + CAPTION_LAG_MS;
+  speakingUntil.set(botId, Math.max(speakingUntil.get(botId) ?? 0, now + windowMs));
+}
+
+/** True while the bot is (estimated to be) speaking + captions are still catching up. */
+export function isBotSpeaking(botId: string): boolean {
+  if (!botId) return false;
+  const until = speakingUntil.get(botId);
+  if (until == null) return false;
+  if (Date.now() >= until) {
+    speakingUntil.delete(botId);
+    return false;
+  }
+  return true;
 }
 
 export function isBotEcho(botId: string, text: string): boolean {

--- a/apps/api/src/channels/meet-webhook.ts
+++ b/apps/api/src/channels/meet-webhook.ts
@@ -3,7 +3,7 @@ import { continueSession } from '../projects/session-lifecycle';
 import { makeOpenApiApp, json, errors } from '../openapi';
 import { MEET_DEFAULT_WAKE, verifyMeetSessionToken } from './meet-realtime';
 import { type MeetTurn, meetConversation } from './meet-conversation';
-import { isBotEcho } from './meet-echo';
+import { isBotEcho, isBotSpeaking } from './meet-echo';
 import { playAcknowledgement } from './meet-tts';
 
 export const meetWebhookApp = makeOpenApiApp();
@@ -148,8 +148,14 @@ function deliverTurn(args: { projectId: string; sessionId: string; botId: string
 export function isSelfEcho(
   botId: string,
   botName: string,
-  turn: { speaker: string; text: string },
+  turn: { speaker: string; text: string; spoken: boolean },
 ): boolean {
+  // Primary guard: while the bot is speaking, captions stream its own output audio
+  // back as "Unknown" speech — drop all inbound speech for that window. Chat is
+  // never echoed this way, so it's exempt.
+  if (turn.spoken && isBotSpeaking(botId)) return true;
+  // Fallbacks for stragglers past the window: content match, and the bot's own
+  // chat message (attributed to its name).
   if (isBotEcho(botId, turn.text)) return true;
   if (botName && turn.speaker && turn.speaker.toLowerCase() === botName.toLowerCase()) return true;
   return false;


### PR DESCRIPTION
## Problem
Meeting captions transcribe the bot's **own output audio** and stream it back as `Unknown` speech, which re-wakes the agent. The existing content-based echo suppression is too fragile in practice:
- a **long monologue**'s later caption fragments arrive **past the 25s record TTL**, so they're no longer matched;
- captions mis-hear the bot's name (`Kortix` → `cortex`), dropping the content match.

Result: the agent gets woken repeatedly by its own voice (it correctly says "no reply needed" each time, but it's wasted turns/tokens and looks broken).

Recall has **no native guard** for this — no `is_bot` flag, no setting to exclude the bot's output from transcription, and the bot's audio comes through as a null/"Unknown" participant, so participant-filtering can't catch it.

## Fix
A **half-duplex window**: when the bot speaks, mark it as speaking for *estimated utterance duration* (word count × 450ms, min 3s) **+ a 12s caption-lag buffer*. While that window is open, drop **all inbound SPOKEN transcripts** before they reach the wake logic.

- **Scales with utterance length** — long monologues don't outrun a fixed TTL.
- **Immune to caption mangling** — it doesn't rely on matching text.
- Content-match + bot-name match stay as fallbacks for stragglers past the window.
- **Chat is exempt** (the bot's chat is never echoed back through captions), so typed messages still wake the agent normally.

Trade-off: a participant who talks *over* the bot won't wake it until the window closes — acceptable for a notetaker (the full recording/transcript is unaffected; only the wake relay is gated), and real replies are short (≈5–10s windows).

Tests: extended `unit-meet-echo` to cover the speaking window (incl. that it drops even a non-content-matching fragment, and that chat is exempt).