### PR TITLE
fix(qa-portal): supply gateway S3 creds via sidecar file (fix report 404s)

### DIFF
--- a/infra/k8s/charts/qa-portal/templates/deployment.yaml
+++ b/infra/k8s/charts/qa-portal/templates/deployment.yaml
@@ -40,6 +40,15 @@ spec:
         - name: landing
           emptyDir:
             sizeLimit: {{ .Values.landingVolumeSizeLimit }}
+        # The gateway's /tmp, shared with the sidecar. njs only reads its creds
+        # from the hardcoded /tmp/credentials.json (the AWS_CREDENTIALS_TEMP_FILE
+        # override isn't declared as an nginx `env`, so njs can't see it), and the
+        # gateway's own web-identity fetch is broken on EKS — so the sidecar drops
+        # fresh creds straight into the path the gateway natively reads. nginx
+        # recreates its own temp dirs + pid file in this volume at startup.
+        - name: gw-tmp
+          emptyDir:
+            sizeLimit: {{ .Values.gwTmpVolumeSizeLimit }}
         - name: landing-script
           configMap:
             name: {{ include "qa-portal.name" . }}-landing
@@ -105,33 +114,55 @@ spec:
               value: "true"
             - name: CORS_ENABLED
               value: "false"
-            # IRSA web-identity creds: AWS_ROLE_ARN + AWS_WEB_IDENTITY_TOKEN_FILE
-            # are auto-injected by EKS from the ServiceAccount role annotation.
-            # AWS_REGION + JS_TRUSTED_CERT_PATH are required for the gateway's njs
-            # STS subrequest to validate TLS when fetching those creds.
-            - name: AWS_REGION
-              value: {{ .Values.region | quote }}
-            - name: JS_TRUSTED_CERT_PATH
-              value: {{ .Values.s3Gateway.trustedCertPath | quote }}
           ports:
             - name: s3gw
               containerPort: {{ .Values.s3Gateway.port }}
               protocol: TCP
+          volumeMounts:
+            # Shared /tmp: nginx writes its temp dirs + pid here, and the sidecar
+            # drops /tmp/credentials.json (the file njs reads to sign requests).
+            - name: gw-tmp
+              mountPath: /tmp
           resources:
             {{- toYaml .Values.resources.gateway | nindent 12 }}
-        # Read-only landing-page generator: lists the reports/ lanes and rebuilds
-        # the small index.html so freshly published reports appear automatically.
-        - name: index-gen
+        # Sidecar (aws-cli): two jobs on the same interval —
+        #   1. refresh the gateway's S3 credentials file from IRSA (assume role
+        #      via web identity, write /aws-creds/credentials.json atomically).
+        #   2. rebuild the landing index.html by listing the reports/ lanes.
+        # aws-cli auth itself is IRSA web identity (AWS_ROLE_ARN +
+        # AWS_WEB_IDENTITY_TOKEN_FILE auto-injected by EKS); no static keys.
+        - name: s3-sidecar
           image: "{{ .Values.awsCli.repository }}:{{ .Values.awsCli.tag }}"
           imagePullPolicy: {{ .Values.awsCli.pullPolicy }}
           command: ["/bin/sh", "-c"]
           args:
             - |
-              # Generate once up front so / is populated within seconds, then
-              # refresh on the interval. Read-only: only `aws s3 ls`.
+              # Write fresh session creds for the gateway (it reads this file to
+              # sign S3 requests). Atomic via temp + mv so the gateway never reads
+              # a half-written file. The real STS creds are ~1h; this sidecar owns
+              # their lifecycle and refreshes every loop (well within that), so we
+              # stamp a far-future `expiration` in the file: the gateway must treat
+              # it as always-valid and NEVER run its own refresh — that refresh
+              # path is its broken njs STS fetch (TLS verify fails on EKS), which
+              # would 500 the request. 4070908800 = 2099-01-01.
+              refresh_creds() {
+                set -- $(aws sts assume-role-with-web-identity \
+                  --role-arn "$AWS_ROLE_ARN" --role-session-name qa-portal \
+                  --web-identity-token "$(cat "$AWS_WEB_IDENTITY_TOKEN_FILE")" \
+                  --query 'Credentials.[AccessKeyId,SecretAccessKey,SessionToken]' \
+                  --output text --region "$REGION" 2>/dev/null)
+                [ -n "$1" ] && [ -n "$2" ] && [ -n "$3" ] || return 1
+                printf '{"accessKeyId":"%s","secretAccessKey":"%s","sessionToken":"%s","expiration":4070908800}' \
+                  "$1" "$2" "$3" > /gw-tmp/.credentials.json.tmp \
+                  && mv /gw-tmp/.credentials.json.tmp /gw-tmp/credentials.json
+              }
+              # Prime both up front so the gateway can sign and / is populated
+              # within seconds, then refresh on the interval.
+              refresh_creds || true
               sh /scripts/gen-index.sh /landing || true
               while true; do
                 sleep {{ .Values.syncIntervalSeconds }}
+                refresh_creds || true
                 sh /scripts/gen-index.sh /landing || true
               done
           env:
@@ -151,6 +182,8 @@ spec:
             - name: REGION
               value: {{ .Values.region | quote }}
           volumeMounts:
+            - name: gw-tmp
+              mountPath: /gw-tmp
             - name: landing
               mountPath: /landing
             - name: landing-script

--- a/infra/k8s/charts/qa-portal/values.yaml
+++ b/infra/k8s/charts/qa-portal/values.yaml
@@ -27,9 +27,6 @@ s3Gateway:
   # The unprivileged gateway listens on 8080; the front nginx proxies here. Kept
   # distinct from the web containerPort so the two share the pod netns cleanly.
   port: 8080
-  # CA bundle the gateway's njs uses to validate TLS when fetching IRSA web
-  # identity credentials from STS. Path inside the gateway image.
-  trustedCertPath: /etc/ssl/certs/ca-certificates.crt
 
 # aws-cli image for the read-only index-gen sidecar (lists reports/ lanes and
 # regenerates the landing index.html — never downloads report bodies).
@@ -54,6 +51,11 @@ replicas: 1
 # emptyDir for the generated landing index.html ONLY — kilobytes, never holds
 # report bytes, so it can never fill and evict the pod (the old failure mode).
 landingVolumeSizeLimit: 16Mi
+
+# The gateway's /tmp (shared with the sidecar): nginx temp/pid files + the
+# credentials.json the sidecar drops. nginx proxy temp files are transient and
+# self-cleaning, so unlike the old report sync this can't accumulate and evict.
+gwTmpVolumeSizeLimit: 512Mi
 
 resources:
   web:


### PR DESCRIPTION
Follow-up to #3990 (the stateless redesign). With the pod proxying reports straight from private S3, every signed request **404'd** because the gateway never had credentials.

## Root cause
The `nginx-s3-gateway`'s own njs **web-identity fetch does not work on EKS** — its STS subrequest fails TLS verification, so it never writes a credentials file. With no creds, signing throws and returns 404 (and 500 once it tries to refresh). Notably, the `AWS_CREDENTIALS_TEMP_FILE` override is useless here because njs only sees env vars that nginx.conf declares with `env` — and that one isn't declared — so njs always reads the hardcoded `/tmp/credentials.json`.

## Fix
Bypass the broken fetch and hand the gateway creds through the file it natively reads:
- the `s3-sidecar` assumes the role via web identity using **aws-cli** (which works) and writes session creds to **`/tmp/credentials.json`**.
- `/tmp` is a shared `emptyDir`; nginx recreates its own temp dirs there at startup.
- the file stamps a **far-future `expiration`** so the gateway treats it as always-valid and never runs its broken refresh; the sidecar keeps the real ~1h creds fresh every interval.

## Verification (live on dev-eks)
- `/` (landing) → 200 with real generated lane/run links
- `/reports/latest/index.html`, `/reports/latest/summary.json`, `/reports/release/<id>/index.html` → 200 (streamed from S3)
- 25/25 rapid report fetches clean — no intermittent refresh 500s
- `helm template` clean

## Deploy
`helm upgrade qa-portal -n kortix-qa -f infra/k8s/envs/qa/values.yaml` (already applied to dev-eks for verification).