### PR TITLE
fix(api): wait for opencode ready after first-prompt env restart

### DIFF
--- a/apps/api/src/__tests__/unit-sandbox-daemon-ready.test.ts
+++ b/apps/api/src/__tests__/unit-sandbox-daemon-ready.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from 'bun:test';
+
+import { waitForDaemonOpencodeReady } from '../projects/lib/sandbox-daemon-ready';
+
+type HealthBody = { opencode?: string; status?: string };
+
+// A fake fetch that walks a fixed sequence of /kortix/health responses. 'fail'
+// models an unreachable probe (non-2xx); the last entry repeats once exhausted.
+function fakeHealthFetch(sequence: Array<HealthBody | 'fail'>): typeof fetch {
+  let i = 0;
+  return (async () => {
+    const step = sequence[Math.min(i, sequence.length - 1)];
+    i += 1;
+    if (step === 'fail') return new Response('unreachable', { status: 503 });
+    return new Response(JSON.stringify(step), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  }) as unknown as typeof fetch;
+}
+
+// Virtual clock so polling advances without real timers.
+function fakeClock() {
+  let t = 0;
+  return {
+    now: () => t,
+    sleep: async (ms: number) => {
+      t += ms;
+    },
+  };
+}
+
+describe('waitForDaemonOpencodeReady', () => {
+  test('resolves true once opencode reports ok (the post-restart window clears)', async () => {
+    const clock = fakeClock();
+    const ready = await waitForDaemonOpencodeReady({
+      previewUrl: 'http://127.0.0.1:1/',
+      previewToken: null,
+      deps: {
+        fetchImpl: fakeHealthFetch([
+          { opencode: 'starting' },
+          { opencode: 'starting' },
+          { opencode: 'ok', status: 'ok' },
+        ]),
+        sleep: clock.sleep,
+        now: clock.now,
+      },
+    });
+    expect(ready).toBe(true);
+  });
+
+  test('keeps polling through a transient unreachable probe, then succeeds', async () => {
+    const clock = fakeClock();
+    const ready = await waitForDaemonOpencodeReady({
+      previewUrl: 'http://127.0.0.1:1/',
+      previewToken: 'tok',
+      deps: {
+        fetchImpl: fakeHealthFetch(['fail', { opencode: 'starting' }, { opencode: 'ok' }]),
+        sleep: clock.sleep,
+        now: clock.now,
+      },
+    });
+    expect(ready).toBe(true);
+  });
+
+  test('short-circuits false on a boot error — waiting cannot fix repo/init failures', async () => {
+    const clock = fakeClock();
+    const ready = await waitForDaemonOpencodeReady({
+      previewUrl: 'http://127.0.0.1:1/',
+      previewToken: null,
+      deps: {
+        fetchImpl: fakeHealthFetch([{ opencode: 'down', status: 'error' }]),
+        sleep: clock.sleep,
+        now: clock.now,
+      },
+    });
+    expect(ready).toBe(false);
+  });
+
+  test('gives up false when the budget is exhausted (cold boot overruns)', async () => {
+    const clock = fakeClock();
+    const ready = await waitForDaemonOpencodeReady({
+      previewUrl: 'http://127.0.0.1:1/',
+      previewToken: null,
+      budgetMs: 1_000,
+      deps: {
+        fetchImpl: fakeHealthFetch([{ opencode: 'starting' }]),
+        sleep: clock.sleep,
+        now: clock.now,
+      },
+    });
+    expect(ready).toBe(false);
+  });
+});

--- a/apps/api/src/projects/lib/sandbox-daemon-ready.ts
+++ b/apps/api/src/projects/lib/sandbox-daemon-ready.ts
@@ -1,0 +1,88 @@
+// Daemon-readiness polling, factored out of sandbox-env-sync so it can be unit
+// tested without pulling in db/config. No heavy imports here on purpose.
+
+// When a prompt's env sync changes model-affecting env, the daemon RESTARTS
+// opencode and returns 200 the instant the new process is spawned — while it
+// reports `opencode: 'starting'`, not yet able to serve `/session/.../prompt`.
+// If we forwarded the prompt right then, the daemon's own proxy 503s
+// "opencode not ready" and the preview proxy bounces that straight to the
+// client (no retry) — so the FIRST prompt of every new session was silently
+// dropped and the user had to resend. Block the sync until opencode is serving
+// again, bounded well under the 50s proxy budget, so the forward always lands
+// on a ready runtime. A genuinely cold boot that misses the budget just falls
+// back to today's behaviour (forward → 503 → client retry), never worse.
+const OPENCODE_READY_WAIT_BUDGET_MS = 18_000;
+const OPENCODE_READY_POLL_INTERVAL_MS = 300;
+const HEALTH_FETCH_TIMEOUT_MS = 2_000;
+
+export interface DaemonReadyDeps {
+  fetchImpl?: typeof fetch;
+  sleep?: (ms: number) => Promise<void>;
+  now?: () => number;
+}
+
+export function daytonaPreviewHeaders(previewToken: string | null): Record<string, string> {
+  const headers: Record<string, string> = {
+    'X-Daytona-Skip-Preview-Warning': 'true',
+    'X-Daytona-Disable-CORS': 'true',
+  };
+  if (previewToken) headers['X-Daytona-Preview-Token'] = previewToken;
+  return headers;
+}
+
+/**
+ * Read the daemon's `/kortix/health` once. Returns the opencode/runtime state,
+ * or null when the probe itself failed (transient — the caller keeps polling).
+ * Health is unauthenticated at the daemon and always answers 200, so a null
+ * here means the preview link couldn't be reached, not "opencode down".
+ */
+async function fetchDaemonOpencodeState(
+  previewUrl: string,
+  previewToken: string | null,
+  fetchImpl: typeof fetch,
+): Promise<{ opencode: string | null; status: string | null } | null> {
+  try {
+    const res = await fetchImpl(`${previewUrl.replace(/\/$/, '')}/kortix/health`, {
+      method: 'GET',
+      headers: daytonaPreviewHeaders(previewToken),
+      signal: AbortSignal.timeout(HEALTH_FETCH_TIMEOUT_MS),
+    });
+    if (!res.ok) return null;
+    const body = (await res.json().catch(() => null)) as
+      | { opencode?: unknown; status?: unknown }
+      | null;
+    if (!body) return null;
+    return {
+      opencode: typeof body.opencode === 'string' ? body.opencode : null,
+      status: typeof body.status === 'string' ? body.status : null,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Poll `/kortix/health` until opencode is serving again after a restart.
+ * Returns true once `opencode === 'ok'`, false if a boot error is reported
+ * (waiting can't fix it) or the budget is exhausted.
+ */
+export async function waitForDaemonOpencodeReady(args: {
+  previewUrl: string;
+  previewToken: string | null;
+  budgetMs?: number;
+  deps?: DaemonReadyDeps;
+}): Promise<boolean> {
+  const fetchImpl = args.deps?.fetchImpl ?? fetch;
+  const sleep = args.deps?.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+  const now = args.deps?.now ?? Date.now;
+  const deadline = now() + (args.budgetMs ?? OPENCODE_READY_WAIT_BUDGET_MS);
+  for (;;) {
+    const state = await fetchDaemonOpencodeState(args.previewUrl, args.previewToken, fetchImpl);
+    if (state?.opencode === 'ok') return true;
+    // A repo/initial-session boot error won't clear by waiting — bail and let the
+    // forward surface the real failure instead of burning the whole budget.
+    if (state?.status === 'error') return false;
+    if (now() >= deadline) return false;
+    await sleep(OPENCODE_READY_POLL_INTERVAL_MS);
+  }
+}

--- a/apps/api/src/projects/lib/sandbox-env-sync.ts
+++ b/apps/api/src/projects/lib/sandbox-env-sync.ts
@@ -11,6 +11,7 @@ import {
   projectSecretsRevision,
 } from '../secrets';
 import { sanitizeSandboxEnv } from './sandbox-env-names';
+import { daytonaPreviewHeaders, waitForDaemonOpencodeReady } from './sandbox-daemon-ready';
 
 const SANDBOX_SERVICE_PORT = 8000;
 const FANOUT_CONCURRENCY = 6;
@@ -79,17 +80,15 @@ async function postEnvToDaemon(args: {
   llmGatewayEnabled?: boolean;
   llmGatewayBaseUrl?: string;
   llmGatewayDenyEnv?: string;
-}): Promise<void> {
+}): Promise<{ opencodeState: string | null }> {
   if (!isSecureOrPrivateTarget(args.previewUrl)) {
     throw new Error('refusing to push secrets over insecure transport (non-TLS public host)');
   }
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
     'Authorization': `Bearer ${args.serviceKey}`,
-    'X-Daytona-Skip-Preview-Warning': 'true',
-    'X-Daytona-Disable-CORS': 'true',
+    ...daytonaPreviewHeaders(args.previewToken),
   };
-  if (args.previewToken) headers['X-Daytona-Preview-Token'] = args.previewToken;
 
   const res = await fetch(`${args.previewUrl.replace(/\/$/, '')}/kortix/env`, {
     method: 'POST',
@@ -112,6 +111,11 @@ async function postEnvToDaemon(args: {
     const body = await res.text().catch(() => '');
     throw new Error(`env sync failed: ${res.status}${body ? ` ${body.slice(0, 500)}` : ''}`);
   }
+  // The daemon echoes opencode's post-sync state. After a model-affecting change
+  // it restarts opencode and reports `starting` here — the signal we use to wait
+  // for readiness before the prompt is forwarded.
+  const body = (await res.json().catch(() => null)) as { opencode?: unknown } | null;
+  return { opencodeState: typeof body?.opencode === 'string' ? body.opencode : null };
 }
 
 export async function syncSandboxEnvForPrompt(args: {
@@ -125,7 +129,7 @@ export async function syncSandboxEnvForPrompt(args: {
   const snapshot = await resolveSandboxEnvSnapshot(args.projectId, args.sessionId);
   if (!snapshot) return;
   const llmGatewayEnabled = await resolveProjectLlmGatewayEnabled(args.projectId);
-  await postEnvToDaemon({
+  const { opencodeState } = await postEnvToDaemon({
     previewUrl: args.previewUrl,
     previewToken: args.previewToken,
     serviceKey: args.serviceKey,
@@ -135,6 +139,22 @@ export async function syncSandboxEnvForPrompt(args: {
     llmGatewayBaseUrl: llmGatewayEnabled ? resolveLlmGatewayBaseUrl() : undefined,
     llmGatewayDenyEnv: llmGatewayEnabled ? nativeProviderEnvNames().join(',') : '',
   });
+  // A model-affecting change just restarted opencode (state !== 'ok'). The prompt
+  // is forwarded the instant this returns, so block until opencode is serving —
+  // otherwise the forward hits the restart window and 503s "opencode not ready",
+  // dropping the session's first prompt (the user then has to resend).
+  if (opencodeState && opencodeState !== 'ok') {
+    const waitStartedAt = Date.now();
+    const ready = await waitForDaemonOpencodeReady({
+      previewUrl: args.previewUrl,
+      previewToken: args.previewToken,
+    });
+    console.log(
+      `[env-sync] opencode restarted by prompt env-sync (state=${opencodeState}); ` +
+        `waited ${Date.now() - waitStartedAt}ms for readiness before forwarding ` +
+        `(ready=${ready}) session=${args.sessionId}`,
+    );
+  }
   await markSandboxLlmGatewayMode(args.sessionId, llmGatewayEnabled);
 }
 


### PR DESCRIPTION
## Problem
Every new project session's **first prompt was silently dropped** — the user had to resend, and the second prompt worked. Live on dev/staging/prod.

## Root cause
The preview proxy pre-syncs project env before forwarding each prompt (`syncSandboxEnvForPrompt` → `/kortix/env` with `refreshModels: true`). On a session's first prompt the model-affecting env changes for the first time, so the sandbox daemon **restarts opencode** and returns `200` the instant the new process is *spawned* (`opencode.restart()` resolves at spawn, not readiness → state `starting`). The proxy then forwards the prompt straight into the restart window; the daemon's own proxy returns `503 "opencode not ready"`, and the preview proxy passes that to the client **with no retry** (`preview.ts`). So the very request that triggered the restart is the one guaranteed to be dropped. The second prompt changes no env → no restart → it runs.

## Fix
`syncSandboxEnvForPrompt` now, when the daemon reports opencode restarted (`opencode !== 'ok'`), polls `/kortix/health` until opencode is serving again **before** the prompt is forwarded. Bounded 18s (proxy budget is 50s), bails early on a boot error, and degrades to today's behaviour on a cold-boot overrun (never worse). Only a session's first prompt ever waits — later prompts make no env change, so zero added latency.

API-only (not the baked daemon), so it ships with a normal API rollout — no Daytona-snapshot rebuild — and is exercised by local `pnpm dev`.

## Tests
- New deterministic unit test (`unit-sandbox-daemon-ready.test.ts`, injected fetch/clock): ready-after-restart, transient-probe retry, boot-error short-circuit, budget-exhaustion.
- `apps/api` typecheck clean.