### PR TITLE
fix(gateway): strip NUL bytes before persisting gateway request logs (prod 22P05)

### DIFF
--- a/apps/api/src/llm-gateway/internal-routes.ts
+++ b/apps/api/src/llm-gateway/internal-routes.ts
@@ -11,6 +11,7 @@ import {
 import { matchesInternalToken } from './internal-auth';
 import { gatewayModelCatalog } from './models/catalog-models';
 import { resolveCandidates } from './resolution/resolve-candidates';
+import { logger } from '../lib/logger';
 
 // HTTP control plane for the OUT-OF-PROCESS gateway pod. Every handler is a thin
 // wrapper over the shared in-process hooks in ./hooks — the standalone service
@@ -95,7 +96,16 @@ export function createInternalGatewayRoutes() {
   app.post('/trace', async (c) => {
     const { trace } = await c.req.json();
     if (!trace || typeof trace.requestId !== 'string') return c.json({ ok: false }, 400);
-    await persistGatewayTrace(trace as GatewayTrace);
+    // Trace persistence is best-effort observability — never 500 the gateway's
+    // fire-and-forget trace post if the write fails.
+    try {
+      await persistGatewayTrace(trace as GatewayTrace);
+    } catch (err) {
+      logger.warn(`[gateway] persistGatewayTrace failed for ${trace.requestId}`, {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return c.json({ ok: false }, 200);
+    }
     return c.json({ ok: true });
   });
 

--- a/apps/api/src/shared/gateway-logs.ts
+++ b/apps/api/src/shared/gateway-logs.ts
@@ -1,75 +1,12 @@
 import { gatewayRequestLogs } from '@kortix/db';
 import { db } from './db';
+import { buildGatewayTraceRow, type GatewayTraceInput } from './gateway-trace-row';
 
-export interface GatewayTraceInput {
-  requestId: string;
-  accountId: string;
-  projectId?: string | null;
-  sessionId?: string | null;
-  actorUserId?: string | null;
-  keyId?: string | null;
-  requestedModel: string;
-  resolvedModel: string;
-  provider: string;
-  status: number;
-  ok: boolean;
-  errorCode?: string | null;
-  errorMessage?: string | null;
-  latencyMs?: number;
-  attempts?: number;
-  candidatesTried?: string[];
-  promptTokens?: number;
-  completionTokens?: number;
-  cachedTokens?: number;
-  upstreamCost?: number;
-  finalCost?: number;
-  streaming?: boolean;
-  billingMode?: string | null;
-  request?: unknown;
-  response?: unknown;
-  metadata?: Record<string, unknown>;
-}
-
-function nonNegInt(value: number | undefined) {
-  return Number.isFinite(value) && value && value > 0 ? Math.floor(value) : 0;
-}
-
-function asJson(value: unknown): Record<string, unknown> | null {
-  if (value && typeof value === 'object') return value as Record<string, unknown>;
-  if (value === undefined || value === null) return null;
-  return { value };
-}
+export type { GatewayTraceInput };
 
 export async function recordGatewayTrace(input: GatewayTraceInput): Promise<void> {
   await db
     .insert(gatewayRequestLogs)
-    .values({
-      requestId: input.requestId,
-      accountId: input.accountId,
-      projectId: input.projectId || null,
-      sessionId: input.sessionId || null,
-      actorUserId: input.actorUserId || null,
-      keyId: input.keyId || null,
-      requestedModel: input.requestedModel,
-      resolvedModel: input.resolvedModel,
-      provider: input.provider,
-      status: input.status,
-      ok: input.ok,
-      errorCode: input.errorCode || null,
-      errorMessage: input.errorMessage || null,
-      latencyMs: nonNegInt(input.latencyMs),
-      attempts: nonNegInt(input.attempts),
-      candidatesTried: input.candidatesTried ?? [],
-      inputTokens: nonNegInt(input.promptTokens),
-      outputTokens: nonNegInt(input.completionTokens),
-      cachedTokens: nonNegInt(input.cachedTokens),
-      upstreamCost: String(input.upstreamCost ?? 0),
-      finalCost: String(input.finalCost ?? 0),
-      streaming: input.streaming ?? false,
-      billingMode: input.billingMode || null,
-      request: asJson(input.request),
-      response: asJson(input.response),
-      metadata: input.metadata ?? {},
-    })
+    .values(buildGatewayTraceRow(input))
     .onConflictDoNothing({ target: gatewayRequestLogs.requestId });
 }

--- a/apps/api/src/shared/gateway-trace-row.test.ts
+++ b/apps/api/src/shared/gateway-trace-row.test.ts
@@ -1,0 +1,71 @@
+import { describe, test, expect } from 'bun:test';
+import { buildGatewayTraceRow, type GatewayTraceInput } from './gateway-trace-row';
+
+// Built via fromCharCode so this test file stays pure ASCII: a literal NUL byte
+// in source would make it a binary file.
+const NUL = String.fromCharCode(0);
+const NUL_JSON_ESCAPE = String.fromCharCode(92) + 'u0000';
+
+function baseInput(overrides: Partial<GatewayTraceInput> = {}): GatewayTraceInput {
+  return {
+    requestId: 'req_1',
+    accountId: 'acc_1',
+    requestedModel: 'claude',
+    resolvedModel: 'claude',
+    provider: 'bedrock',
+    status: 200,
+    ok: true,
+    ...overrides,
+  };
+}
+
+describe('buildGatewayTraceRow', () => {
+  test('strips NUL bytes from the request body (the column Postgres rejected)', () => {
+    const row = buildGatewayTraceRow(
+      baseInput({
+        request: {
+          messages: [{ role: 'system', content: `How you work${NUL} step 1` }],
+        },
+      }),
+    );
+    expect(JSON.stringify(row.request).includes(NUL_JSON_ESCAPE)).toBe(false);
+    expect((row.request as any).messages[0].content).toBe('How you work step 1');
+  });
+
+  test('strips NUL bytes from response, metadata, candidatesTried, and errorMessage', () => {
+    const row = buildGatewayTraceRow(
+      baseInput({
+        ok: false,
+        errorMessage: `boom${NUL}`,
+        candidatesTried: [`model${NUL}a`, 'model-b'],
+        response: { output: `text${NUL}` },
+        metadata: { note: `meta${NUL}data` },
+      }),
+    );
+    const serialized = JSON.stringify(row);
+    expect(serialized.includes(NUL_JSON_ESCAPE)).toBe(false);
+    expect(row.errorMessage).toBe('boom');
+    expect(row.candidatesTried).toEqual(['modela', 'model-b']);
+    expect((row.response as any).output).toBe('text');
+    expect((row.metadata as any).note).toBe('metadata');
+  });
+
+  test('wraps a non-object request payload under `value` and still scrubs it', () => {
+    const row = buildGatewayTraceRow(baseInput({ request: `raw${NUL}body` }));
+    expect(row.request).toEqual({ value: 'rawbody' });
+  });
+
+  test('null request/response become null; metadata defaults to {}', () => {
+    const row = buildGatewayTraceRow(baseInput());
+    expect(row.request).toBeNull();
+    expect(row.response).toBeNull();
+    expect(row.metadata).toEqual({});
+    expect(row.candidatesTried).toEqual([]);
+  });
+
+  test('clean payloads pass through unchanged', () => {
+    const request = { messages: [{ role: 'user', content: 'hi' }] };
+    const row = buildGatewayTraceRow(baseInput({ request }));
+    expect(row.request).toEqual(request);
+  });
+});

--- a/apps/api/src/shared/gateway-trace-row.ts
+++ b/apps/api/src/shared/gateway-trace-row.ts
@@ -1,0 +1,87 @@
+import { stripNullBytes, stripNullBytesDeep } from '@kortix/shared';
+
+export interface GatewayTraceInput {
+  requestId: string;
+  accountId: string;
+  projectId?: string | null;
+  sessionId?: string | null;
+  actorUserId?: string | null;
+  keyId?: string | null;
+  requestedModel: string;
+  resolvedModel: string;
+  provider: string;
+  status: number;
+  ok: boolean;
+  errorCode?: string | null;
+  errorMessage?: string | null;
+  latencyMs?: number;
+  attempts?: number;
+  candidatesTried?: string[];
+  promptTokens?: number;
+  completionTokens?: number;
+  cachedTokens?: number;
+  upstreamCost?: number;
+  finalCost?: number;
+  streaming?: boolean;
+  billingMode?: string | null;
+  request?: unknown;
+  response?: unknown;
+  metadata?: Record<string, unknown>;
+}
+
+function nonNegInt(value: number | undefined) {
+  return Number.isFinite(value) && value && value > 0 ? Math.floor(value) : 0;
+}
+
+function asJson(value: unknown): Record<string, unknown> | null {
+  if (value && typeof value === 'object') return value as Record<string, unknown>;
+  if (value === undefined || value === null) return null;
+  return { value };
+}
+
+/**
+ * Build the gateway_request_logs row, scrubbing NUL characters (U+0000) from
+ * every free-form payload first.
+ *
+ * The request/response bodies (and occasionally `metadata` or the upstream
+ * `errorMessage`) carry raw LLM conversation content that can contain U+0000 —
+ * from binary file reads, raw terminal output, or truncated tool results.
+ * Postgres rejects U+0000 in both `jsonb` and `text` columns: a jsonb value
+ * whose JSON text holds the U+0000 escape fails at parse time with
+ * `22P05 unsupported Unicode escape sequence`. Because the trace write is
+ * best-effort (fire-and-forget in the pipeline), an unscrubbed NUL doesn't fail
+ * the LLM call — it silently drops the trace and spams the error logs on every
+ * affected request. Stripping here keeps the write from ever throwing.
+ *
+ * Pure (no DB import) so the sanitization is unit-testable in isolation.
+ */
+export function buildGatewayTraceRow(input: GatewayTraceInput) {
+  return {
+    requestId: input.requestId,
+    accountId: input.accountId,
+    projectId: input.projectId || null,
+    sessionId: input.sessionId || null,
+    actorUserId: input.actorUserId || null,
+    keyId: input.keyId || null,
+    requestedModel: input.requestedModel,
+    resolvedModel: input.resolvedModel,
+    provider: input.provider,
+    status: input.status,
+    ok: input.ok,
+    errorCode: input.errorCode || null,
+    errorMessage: input.errorMessage ? stripNullBytes(input.errorMessage) : null,
+    latencyMs: nonNegInt(input.latencyMs),
+    attempts: nonNegInt(input.attempts),
+    candidatesTried: stripNullBytesDeep(input.candidatesTried ?? []),
+    inputTokens: nonNegInt(input.promptTokens),
+    outputTokens: nonNegInt(input.completionTokens),
+    cachedTokens: nonNegInt(input.cachedTokens),
+    upstreamCost: String(input.upstreamCost ?? 0),
+    finalCost: String(input.finalCost ?? 0),
+    streaming: input.streaming ?? false,
+    billingMode: input.billingMode || null,
+    request: stripNullBytesDeep(asJson(input.request)),
+    response: stripNullBytesDeep(asJson(input.response)),
+    metadata: stripNullBytesDeep(input.metadata ?? {}),
+  };
+}

--- a/packages/llm-gateway/src/pipeline/trace.ts
+++ b/packages/llm-gateway/src/pipeline/trace.ts
@@ -63,8 +63,14 @@ export function createTraceEmitter(
     logTrace(logger, trace);
 
     if (hooks.recordTrace) {
+      // Log only the error MESSAGE, never the raw error: a DB driver error
+      // (e.g. postgres-js) carries `.query` and `.parameters` — the entire LLM
+      // request body — which we must not ship to the log transport on every
+      // failed trace write.
       void hooks.recordTrace(trace).catch((err) =>
-        logger.warn(`[gateway] recordTrace failed for ${requestId}:`, err),
+        logger.warn(
+          `[gateway] recordTrace failed for ${requestId}: ${err instanceof Error ? err.message : String(err)}`,
+        ),
       );
     }
   };

--- a/packages/shared/src/utils/unicode.test.ts
+++ b/packages/shared/src/utils/unicode.test.ts
@@ -1,5 +1,10 @@
 import { describe, test, expect } from 'bun:test';
-import { normalizeFilenameToNFC, normalizePathToNFC } from './unicode';
+import {
+  normalizeFilenameToNFC,
+  normalizePathToNFC,
+  stripNullBytes,
+  stripNullBytesDeep,
+} from './unicode';
 
 const UNICODE_SPACE_CODE_POINTS = [
   0x00a0, 0x2000, 0x2001, 0x2002, 0x2003, 0x2004, 0x2005, 0x2006, 0x2007,
@@ -79,5 +84,81 @@ describe('normalizePathToNFC', () => {
   test('is idempotent for already-normalized input', () => {
     const normalized = normalizePathToNFC(`/users/${CAFE_DECOMPOSED}`);
     expect(normalizePathToNFC(normalized)).toBe(normalized);
+  });
+});
+
+// Built via fromCharCode so this test file stays pure ASCII: a literal NUL byte
+// in source would make it a binary file.
+const NUL = String.fromCharCode(0);
+
+describe('stripNullBytes', () => {
+  test('returns a string with no NUL bytes unchanged (same reference)', () => {
+    const input = 'hello world';
+    expect(stripNullBytes(input)).toBe(input);
+  });
+
+  test('returns an empty string unchanged', () => {
+    expect(stripNullBytes('')).toBe('');
+  });
+
+  test('removes a single embedded NUL byte', () => {
+    expect(stripNullBytes(`a${NUL}b`)).toBe('ab');
+  });
+
+  test('removes multiple and consecutive NUL bytes', () => {
+    expect(stripNullBytes(`${NUL}a${NUL}${NUL}b${NUL}`)).toBe('ab');
+  });
+
+  test('preserves other control characters and whitespace', () => {
+    expect(stripNullBytes(`a\tb\nc ${NUL}d`)).toBe('a\tb\nc d');
+  });
+
+  test('result never contains a NUL byte', () => {
+    expect(stripNullBytes(`x${NUL}y`).includes(NUL)).toBe(false);
+  });
+});
+
+describe('stripNullBytesDeep', () => {
+  test('passes through non-string primitives untouched', () => {
+    expect(stripNullBytesDeep(42)).toBe(42);
+    expect(stripNullBytesDeep(true)).toBe(true);
+    expect(stripNullBytesDeep(null)).toBe(null);
+    expect(stripNullBytesDeep(undefined)).toBe(undefined);
+  });
+
+  test('strips NUL from a bare string', () => {
+    expect(stripNullBytesDeep(`a${NUL}b`)).toBe('ab');
+  });
+
+  test('strips NUL from strings nested in objects, arrays, and keys', () => {
+    const dirty = {
+      [`key${NUL}1`]: `val${NUL}ue`,
+      nested: { messages: [`hi${NUL}`, { text: `to${NUL}ol` }] },
+      clean: 7,
+    };
+    expect(stripNullBytesDeep(dirty)).toEqual({
+      key1: 'value',
+      nested: { messages: ['hi', { text: 'tool' }] },
+      clean: 7,
+    });
+  });
+
+  test('produces a value whose JSON serialization is free of the NUL escape', () => {
+    const cleaned = stripNullBytesDeep({ body: `sys${NUL}prompt`, arr: [`a${NUL}`] });
+    // JSON.stringify renders a NUL byte as the six-character token backslash-u-
+    // 0000 — the exact escape Postgres jsonb rejects with 22P05. Build that token
+    // escape-free (char 92 is backslash) and assert the serialization omits it.
+    const NUL_JSON_ESCAPE = String.fromCharCode(92) + 'u0000';
+    expect(JSON.stringify(cleaned).includes(NUL_JSON_ESCAPE)).toBe(false);
+  });
+
+  test('does not recurse into non-plain objects (e.g. Date) but keeps them', () => {
+    const d = new Date(0);
+    expect(stripNullBytesDeep({ when: d }).when).toBe(d);
+  });
+
+  test('leaves a fully clean object structurally equal', () => {
+    const clean = { a: 1, b: ['x', 'y'], c: { d: 'z' } };
+    expect(stripNullBytesDeep(clean)).toEqual(clean);
   });
 });

--- a/packages/shared/src/utils/unicode.ts
+++ b/packages/shared/src/utils/unicode.ts
@@ -59,3 +59,48 @@ export const normalizePathToNFC = (path: string): string => {
     return path;
   }
 };
+
+// The NUL control character (U+0000). Built via fromCharCode so this source
+// file stays pure ASCII: a literal NUL byte would make the file binary.
+const NUL_CHAR = String.fromCharCode(0);
+
+/**
+ * Strip NUL characters (U+0000) from a string.
+ *
+ * Postgres cannot store U+0000 in either a `text` or a `jsonb` column. A jsonb
+ * value whose JSON text carries the U+0000 escape is rejected at parse time
+ * with `22P05 unsupported Unicode escape sequence` (the NUL "cannot be
+ * converted to text"). LLM request/response bodies routinely smuggle NUL bytes
+ * in (binary file reads, raw terminal output, truncated tool results), so any
+ * free-form string headed for Postgres must be scrubbed first. U+0000 carries
+ * no meaning in our text payloads, so we drop it rather than substitute.
+ */
+export const stripNullBytes = (value: string): string =>
+  value.includes(NUL_CHAR) ? value.split(NUL_CHAR).join('') : value;
+
+/**
+ * Recursively strip NUL characters from every string in a JSON-like value —
+ * object values, object keys, and array elements alike — returning a
+ * structurally identical value safe to persist into a Postgres `jsonb`/`text`
+ * column.
+ *
+ * Non-string primitives pass through untouched. Only arrays and plain objects
+ * (those with `Object.prototype` or a null prototype, i.e. the shapes
+ * `JSON.parse` produces) are recursed into; anything else (Date, Map, class
+ * instances) is returned as-is, since JSON payloads never contain them.
+ */
+export const stripNullBytesDeep = <T>(value: T): T => {
+  if (typeof value === 'string') return stripNullBytes(value) as unknown as T;
+  if (Array.isArray(value)) return value.map((item) => stripNullBytesDeep(item)) as unknown as T;
+  if (value !== null && typeof value === 'object') {
+    const proto = Object.getPrototypeOf(value);
+    if (proto === Object.prototype || proto === null) {
+      const out: Record<string, unknown> = {};
+      for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
+        out[stripNullBytes(key)] = stripNullBytesDeep(val);
+      }
+      return out as unknown as T;
+    }
+  }
+  return value;
+};


### PR DESCRIPTION
## Prod incident

Recurring Better Stack alert from **Kortix API (prod)**, ~1/min:

> `PostgresError: unsupported Unicode escape sequence` (SQLSTATE **22P05**)

The alert "Location" payload was a chunk of the **kortix agent system prompt**, which is what made it look mysterious.

## Root cause

Every LLM call is traced into `gateway_request_logs` via `recordGatewayTrace`. Its `request` / `response` **jsonb** columns store the full LLM request/response bodies — system prompt + entire message history + tool results.

Postgres **cannot store `U+0000` in `text` or `jsonb`**. When any string in that body contains a NUL character (binary file reads, raw terminal output, truncated tool results), postgres-js serializes it to JSON text carrying the `U+0000` escape, and Postgres rejects it at parse time with `22P05`.

The trace write is **fire-and-forget** (`void recordTrace(...).catch(logger.warn)` in `packages/llm-gateway/src/pipeline/trace.ts`), so:
- the LLM call itself still succeeded (no user-facing failure), but
- every affected request logged the **full `PostgresError`** — including `.query` + `.parameters`, i.e. the entire request body — to Better Stack. That serialized request body (with the agent prompt) is exactly the "Location" content in the alerts.

So: a real data bug (unsanitized NUL) + a noisy log path = the alert storm.

## Fix

- **`@kortix/shared`**: add `stripNullBytes` / `stripNullBytesDeep`. `U+0000` is unstorable in Postgres text/jsonb, so we drop it (no meaningful substitute).
- **`gateway-trace-row.ts`** (new, pure, db-free): `buildGatewayTraceRow` scrubs `request`, `response`, `metadata`, `candidatesTried`, and `errorMessage` before insert. Extracted from `gateway-logs.ts` so the sanitization is unit-testable without a DB.
- **`/trace` internal route**: wrapped so a failed write can't 500 the out-of-process gateway pod.
- **`trace.ts`**: on `recordTrace` failure, log only the error **message**, never the raw driver error — so a future DB error can't ship the whole request body to the log transport again.

## Tests

- `packages/shared/.../unicode.test.ts`: sanitizer cases (nested objects/arrays/keys, consecutive NULs, JSON-serialization has no `U+0000` escape, non-plain objects preserved).
- `apps/api/src/shared/gateway-trace-row.test.ts`: every free-form field scrubbed; clean payloads pass through unchanged.
- `@kortix/shared` 229 pass, `@kortix/llm-gateway` 89 pass, new suites 31 pass. `tsc --noEmit` clean for all three packages.

## Notes

Isolated hotfix branched off `main` (not the in-flight executor branch). Resolves the prod incident once merged + released; no migration needed.
