### PR TITLE
fix(api): make suna-migration repo phase idempotent and pod-independent

### DIFF
--- a/apps/api/src/projects/suna-migration/suna-migration-phases.ts
+++ b/apps/api/src/projects/suna-migration/suna-migration-phases.ts
@@ -14,7 +14,7 @@
  * and the uploaded opencode archive + the DB rows. A crash before `repo`
  * re-extracts (idempotent: un-archive + tar again).
  */
-import { copyFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { copyFileSync, existsSync, mkdirSync, mkdtempSync, renameSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { sql } from 'drizzle-orm';
@@ -103,24 +103,41 @@ export async function extractStep(ctx: SunaMigrationContext): Promise<void> {
 export async function repoStep(ctx: SunaMigrationContext): Promise<void> {
   if (typeof ctx.progress.project_id === 'string') { ctx.log('repo: already done'); return; }
   const out = bundlePath(ctx.migrationId);
+  const dbAside = join(tmpdir(), `suna-mig-${ctx.migrationId}.opencode.db`);
+  const bundleDb = join(out, 'opencode.db');
+
+  // The bundle lives in this pod's /tmp. On EKS a retry can resume on a
+  // DIFFERENT pod (3–12 replicas, leader-only worker, no stickiness) where
+  // neither the bundle nor a prior aside exists — rebuild it from the live DB
+  // (extract is idempotent + self-contained) so repo is pod-independent.
+  if (!existsSync(bundleDb) && !existsSync(dbAside)) {
+    ctx.log('repo: bundle absent on this pod, re-extracting');
+    await extractStep(ctx);
+  }
+
+  // Move opencode.db out of the bundle BEFORE pushing (chat storage, not source)
+  // and key the aside to the stable migrationId — NOT the projectId, which
+  // pushBundleAsRepo mints fresh on every call. A retry that re-enters repoStep
+  // must still find the db an earlier attempt moved aside. Move once; idempotent.
+  if (existsSync(bundleDb)) renameSync(bundleDb, dbAside);
+  if (!existsSync(dbAside)) throw new Error('repo: opencode.db missing after re-extract');
+
   const repo = await pushBundleAsRepo(ctx.accountId, out);
 
-  // opencode.db was moved aside by pushBundleAsRepo. Tar it with the db named
-  // exactly `opencode.db` (same convention legacy archives use, which is what
-  // rehydrateSessionChat opens) and upload keyed by projectId for on-open ship.
-  const dbAside = join(tmpdir(), `${repo.projectId}.opencode.db`);
+  // Tar with the db named exactly `opencode.db` (the convention legacy archives
+  // use, which is what rehydrateSessionChat opens) and upload keyed by projectId.
   const stageDir = mkdtempSync(join(tmpdir(), `suna-oc-${repo.projectId}-`));
   copyFileSync(dbAside, join(stageDir, 'opencode.db'));
   const tar = Bun.spawnSync(['tar', 'czf', '-', '-C', stageDir, 'opencode.db']);
   if (tar.exitCode === 0) await uploadOpencodeArchive(repo.projectId, Buffer.from(tar.stdout));
   rmSync(stageDir, { recursive: true, force: true });
-  rmSync(dbAside, { force: true });
 
   await ctx.checkpoint({
     project_id: repo.projectId, repo_url: repo.upstreamUrl, repo_owner: repo.repoOwner,
     repo_name: repo.repoName, default_branch: repo.defaultBranch, provider: repo.provider,
     external_repo_id: repo.externalRepoId, installation_id: repo.installationId, credential_ref: repo.credentialRef,
   });
+  rmSync(dbAside, { force: true });
   ctx.log('repo: pushed + opencode archive uploaded', { repo: repo.upstreamUrl });
 }
 

--- a/apps/api/src/projects/suna-migration/suna-push.ts
+++ b/apps/api/src/projects/suna-migration/suna-push.ts
@@ -7,7 +7,7 @@
  * sandbox separately (rehydrate). We move it out of the tree before pushing.
  */
 import { dirname, join } from 'node:path';
-import { existsSync, mkdirSync, writeFileSync, renameSync, rmSync } from 'node:fs';
+import { existsSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { getDefaultManagedBackend } from '../git-backends/registry';
 import type { GitConnectionRef } from '../git-backends/types';
 import { buildStarterFiles } from '../starter';
@@ -51,9 +51,10 @@ export async function pushBundleAsRepo(accountId: string, bundleDir: string): Pr
   const pushUrl = await backend.authedPushUrl(ref);
 
   // Keep opencode.db + manifest OUT of the repo (chat storage, not source).
+  // repoStep already moved opencode.db aside (keyed by the stable migrationId);
+  // drop any stragglers so chat storage never lands in the commit.
   for (const f of ['opencode.db', 'migration-manifest.json']) {
-    const p = join(bundleDir, f);
-    if (existsSync(p)) renameSync(p, join(dirname(bundleDir), `${projectId}.${f}`));
+    rmSync(join(bundleDir, f), { force: true });
   }
 
   // One synthesized root config for the whole project.


### PR DESCRIPTION
## Problem

22 production Suna account-migrations are dead-lettered in **phase `repo`** with the same error:

```
phase repo failed (attempt 5): ENOENT: no such file or directory,
copyfile '/tmp/<projectId>.opencode.db' -> '/tmp/suna-oc-<projectId>-XXXX/opencode.db'
```

Root cause: `repoStep` keyed the `opencode.db` aside file to the **`projectId`**, but `pushBundleAsRepo` mints a **fresh `projectId` on every call** (`crypto.randomUUID()`), and the aside was deleted before the checkpoint. So after any mid-step failure (e.g. a flaky managed `git push`), the retry generated a new `projectId`, the source `opencode.db` had already been moved/deleted under the previous one, and `copyFileSync` `ENOENT`'d on every subsequent attempt through the 5-attempt cap — permanently stranding the migration (the user-facing "We hit a snag restoring your projects" with a Retry that can never succeed).

This is also fragile on EKS: the bundle lives in a pod's `/tmp`, but a retry is re-driven by the leader-only background worker, which can resume on a **different replica** (3–12 pods, no stickiness) where the bundle doesn't exist at all.

## Fix

- **`repoStep`**: key the `opencode.db` aside to the **stable `migrationId`** (not the per-call `projectId`) and move it **once** — within-pod retries stay idempotent.
- **`repoStep`**: delete the aside **only after** the checkpoint succeeds, so a mid-step failure no longer orphans the source.
- **`repoStep`**: **re-extract when the bundle is absent on the current pod** — `extract` is idempotent and rebuilds from the live DB, so `repo` is now pod-independent and a resume on a fresh replica self-heals (this is the behavior the runner's own header comment already promised but never implemented).
- **`pushBundleAsRepo`**: stop relocating `opencode.db` to a `projectId`-keyed path; it now only drops chat-storage files (`opencode.db`, `migration-manifest.json`) from the commit.

## Recovery for the 22 stranded rows (after deploy)

The background worker only re-drives `planned`/`running` rows, so the dead-lettered (`failed`, attempts=5) rows need a reset to be picked up again:

```sql
UPDATE kortix.suna_account_migrations
SET phase='extract', attempts=0, progress='{}'::jsonb, error=NULL,
    status='planned', heartbeat_at=NULL, updated_at=now()
WHERE status='failed' AND phase='repo' AND error LIKE '%ENOENT%opencode.db%';
```

The leader worker then drives each `extract -> repo -> push -> db -> done` on the new code. **Run only after this is deployed to prod.**

## Notes

- Typechecked (`tsc --noEmit`) clean on both files.
- No schema/migration changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)