### PR TITLE
fix(api): suna-migration repo phase idempotent + pod-independent (prod hotfix)

### DIFF
--- a/apps/api/src/projects/suna-migration/suna-migration-phases.ts
+++ b/apps/api/src/projects/suna-migration/suna-migration-phases.ts
@@ -14,7 +14,7 @@
  * and the uploaded opencode archive + the DB rows. A crash before `repo`
  * re-extracts (idempotent: un-archive + tar again).
  */
-import { copyFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { copyFileSync, existsSync, mkdirSync, mkdtempSync, renameSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { sql } from 'drizzle-orm';
@@ -103,24 +103,41 @@ export async function extractStep(ctx: SunaMigrationContext): Promise<void> {
 export async function repoStep(ctx: SunaMigrationContext): Promise<void> {
   if (typeof ctx.progress.project_id === 'string') { ctx.log('repo: already done'); return; }
   const out = bundlePath(ctx.migrationId);
+  const dbAside = join(tmpdir(), `suna-mig-${ctx.migrationId}.opencode.db`);
+  const bundleDb = join(out, 'opencode.db');
+
+  // The bundle lives in this pod's /tmp. On EKS a retry can resume on a
+  // DIFFERENT pod (3–12 replicas, leader-only worker, no stickiness) where
+  // neither the bundle nor a prior aside exists — rebuild it from the live DB
+  // (extract is idempotent + self-contained) so repo is pod-independent.
+  if (!existsSync(bundleDb) && !existsSync(dbAside)) {
+    ctx.log('repo: bundle absent on this pod, re-extracting');
+    await extractStep(ctx);
+  }
+
+  // Move opencode.db out of the bundle BEFORE pushing (chat storage, not source)
+  // and key the aside to the stable migrationId — NOT the projectId, which
+  // pushBundleAsRepo mints fresh on every call. A retry that re-enters repoStep
+  // must still find the db an earlier attempt moved aside. Move once; idempotent.
+  if (existsSync(bundleDb)) renameSync(bundleDb, dbAside);
+  if (!existsSync(dbAside)) throw new Error('repo: opencode.db missing after re-extract');
+
   const repo = await pushBundleAsRepo(ctx.accountId, out);
 
-  // opencode.db was moved aside by pushBundleAsRepo. Tar it with the db named
-  // exactly `opencode.db` (same convention legacy archives use, which is what
-  // rehydrateSessionChat opens) and upload keyed by projectId for on-open ship.
-  const dbAside = join(tmpdir(), `${repo.projectId}.opencode.db`);
+  // Tar with the db named exactly `opencode.db` (the convention legacy archives
+  // use, which is what rehydrateSessionChat opens) and upload keyed by projectId.
   const stageDir = mkdtempSync(join(tmpdir(), `suna-oc-${repo.projectId}-`));
   copyFileSync(dbAside, join(stageDir, 'opencode.db'));
   const tar = Bun.spawnSync(['tar', 'czf', '-', '-C', stageDir, 'opencode.db']);
   if (tar.exitCode === 0) await uploadOpencodeArchive(repo.projectId, Buffer.from(tar.stdout));
   rmSync(stageDir, { recursive: true, force: true });
-  rmSync(dbAside, { force: true });
 
   await ctx.checkpoint({
     project_id: repo.projectId, repo_url: repo.upstreamUrl, repo_owner: repo.repoOwner,
     repo_name: repo.repoName, default_branch: repo.defaultBranch, provider: repo.provider,
     external_repo_id: repo.externalRepoId, installation_id: repo.installationId, credential_ref: repo.credentialRef,
   });
+  rmSync(dbAside, { force: true });
   ctx.log('repo: pushed + opencode archive uploaded', { repo: repo.upstreamUrl });
 }
 

--- a/apps/api/src/projects/suna-migration/suna-push.ts
+++ b/apps/api/src/projects/suna-migration/suna-push.ts
@@ -7,7 +7,7 @@
  * sandbox separately (rehydrate). We move it out of the tree before pushing.
  */
 import { dirname, join } from 'node:path';
-import { existsSync, mkdirSync, writeFileSync, renameSync, rmSync } from 'node:fs';
+import { existsSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { getDefaultManagedBackend } from '../git-backends/registry';
 import type { GitConnectionRef } from '../git-backends/types';
 import { buildStarterFiles } from '../starter';
@@ -51,9 +51,10 @@ export async function pushBundleAsRepo(accountId: string, bundleDir: string): Pr
   const pushUrl = await backend.authedPushUrl(ref);
 
   // Keep opencode.db + manifest OUT of the repo (chat storage, not source).
+  // repoStep already moved opencode.db aside (keyed by the stable migrationId);
+  // drop any stragglers so chat storage never lands in the commit.
   for (const f of ['opencode.db', 'migration-manifest.json']) {
-    const p = join(bundleDir, f);
-    if (existsSync(p)) renameSync(p, join(dirname(bundleDir), `${projectId}.${f}`));
+    rmSync(join(bundleDir, f), { force: true });
   }
 
   // One synthesized root config for the whole project.


### PR DESCRIPTION
Targeted hotfix onto **staging** to ship the suna-migration `repo`-phase fix to prod (patch release) — cherry-pick of the `main` fix (#4020), **only** the migration change, none of main's other unreleased commits.

## Why
22 production Suna migrations are dead-lettered in phase `repo` with `ENOENT ... copyfile '/tmp/<projectId>.opencode.db'`. Root cause: the `opencode.db` aside was keyed to a `projectId` that `pushBundleAsRepo` re-mints every call and deleted before checkpoint, so every retry ENOENT'd through the 5-attempt cap. The buggy code is already live on staging+prod.

## Fix (cherry-pick of 5033b2385)
- key the `opencode.db` aside to the stable `migrationId`, move once → within-pod retries idempotent
- delete the aside only after the checkpoint succeeds
- re-extract when the bundle is absent on the current pod → pod-independent on EKS (leader-only worker, 3–12 replicas, no stickiness)
- `pushBundleAsRepo` no longer relocates `opencode.db`; it only drops chat-storage files from the commit

## After merge
build-staging → deploy-staging → qa-staging green, then `promote.yml ref=staging` (patch → v0.9.92) opens the review-gated prod release PR. Post-deploy, the 22 stranded rows get reset (`phase='extract', status='planned'`) so the leader worker re-drives them.

Typechecked clean; no schema/migration changes.