### PR TITLE
fix(api): strip oversized blobs from suna-migration repo push

### DIFF
--- a/apps/api/src/projects/suna-migration/suna-push.ts
+++ b/apps/api/src/projects/suna-migration/suna-push.ts
@@ -7,7 +7,7 @@
  * sandbox separately (rehydrate). We move it out of the tree before pushing.
  */
 import { dirname, join } from 'node:path';
-import { existsSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { existsSync, mkdirSync, writeFileSync, rmSync, readdirSync, statSync } from 'node:fs';
 import { getDefaultManagedBackend } from '../git-backends/registry';
 import type { GitConnectionRef } from '../git-backends/types';
 import { buildStarterFiles } from '../starter';
@@ -64,6 +64,31 @@ export async function pushBundleAsRepo(accountId: string, bundleDir: string): Pr
     if (existsSync(full)) continue; // never clobber his content
     mkdirSync(dirname(full), { recursive: true });
     writeFileSync(full, f.content);
+  }
+
+  // GitHub rejects oversized blobs (and LFS isn't wired up for managed repos),
+  // so a single big workspace artifact would fail the whole push. Strip anything
+  // over the limit and record what was dropped so it isn't lost silently.
+  const MAX_BLOB_BYTES = 50 * 1024 * 1024;
+  const dropped: string[] = [];
+  const strip = (dir: string): void => {
+    for (const e of readdirSync(dir, { withFileTypes: true })) {
+      if (e.name === '.git') continue;
+      const p = join(dir, e.name);
+      if (e.isDirectory()) { strip(p); continue; }
+      if (e.isFile()) {
+        const size = statSync(p).size;
+        if (size > MAX_BLOB_BYTES) {
+          dropped.push(`${p.slice(bundleDir.length + 1)} (${(size / 1048576).toFixed(1)}MB)`);
+          rmSync(p, { force: true });
+        }
+      }
+    }
+  };
+  strip(bundleDir);
+  if (dropped.length) {
+    writeFileSync(join(bundleDir, '.kortix-skipped-large-files.txt'),
+      `Omitted from this repo — exceeded GitHub's ${MAX_BLOB_BYTES / 1048576}MB file limit:\n\n${dropped.join('\n')}\n`);
   }
 
   rmSync(join(bundleDir, '.git'), { recursive: true, force: true });

--- a/apps/api/src/scripts/deliver-suna-files.ts
+++ b/apps/api/src/scripts/deliver-suna-files.ts
@@ -1,0 +1,43 @@
+/**
+ * Upload a customer's extracted /workspace archive to the private backup bucket
+ * and mint a time-limited signed download URL to hand back to them.
+ *
+ *   FREESTYLE_API_URL=... dotenvx run -f .env.prod --quiet -- \
+ *   bun run src/scripts/deliver-suna-files.ts --account-id <uuid> --file <path> [--days 7]
+ */
+import { readFileSync, statSync } from 'node:fs';
+import { config } from '../config';
+import { getSupabase } from '../shared/supabase';
+import { ensureBackupBucket } from '../projects/legacy-migration-storage';
+
+function arg(flag: string): string | undefined {
+  const i = Bun.argv.indexOf(flag);
+  return i >= 0 ? Bun.argv[i + 1] : Bun.argv.find((a) => a.startsWith(`${flag}=`))?.slice(flag.length + 1);
+}
+
+const accountId = arg('--account-id');
+const file = arg('--file');
+const days = Number(arg('--days') ?? 7);
+if (!accountId || !file) { console.error('--account-id and --file required'); process.exit(2); }
+
+async function main() {
+  const buf = readFileSync(file!);
+  console.log(`uploading ${file} (${(statSync(file!).size / 1048576).toFixed(1)}MB) …`);
+  await ensureBackupBucket();
+  const bucket = config.LEGACY_MIGRATION_BACKUP_BUCKET;
+  const path = `delivery/${accountId}/suna-files.tar.gz`;
+  const supabase = getSupabase();
+
+  const up = await supabase.storage.from(bucket).upload(path, buf, { upsert: true, contentType: 'application/gzip' });
+  if (up.error) throw up.error;
+
+  const expiresIn = days * 24 * 3600;
+  const signed = await supabase.storage.from(bucket).createSignedUrl(path, expiresIn, { download: 'suna-files.tar.gz' });
+  if (signed.error || !signed.data?.signedUrl) throw signed.error ?? new Error('failed to sign url');
+
+  console.log(`\n✓ uploaded to ${bucket}/${path}`);
+  console.log(`\nDownload link (valid ${days} days):\n${signed.data.signedUrl}\n`);
+}
+
+await main();
+process.exit(0);

--- a/apps/api/src/scripts/fix-suna-migration-direct.ts
+++ b/apps/api/src/scripts/fix-suna-migration-direct.ts
@@ -1,0 +1,77 @@
+/**
+ * Drive ONE stuck Suna migration to completion locally, OUT of band — without
+ * the lease/worker. The prod migration worker only ever grabs rows whose status
+ * is 'planned'|'running' (acquireLease), so by keeping the row 'failed' until the
+ * very end and never calling driveSunaMigration, the worker never races us.
+ *
+ * Reuses the committed, FIXED phase functions (extract → repo → push → db) with a
+ * tiny in-memory context: checkpoint is in-memory, heartbeat is a no-op, and we
+ * stamp the row 'completed' atomically only once the project + sessions exist.
+ *
+ * Usage:
+ *   FREESTYLE_API_URL="$(dotenvx get FREESTYLE_API_URL -f .env)" \
+ *   dotenvx run -f .env.prod --quiet -- \
+ *   bun run src/scripts/fix-suna-migration-direct.ts --account-id <uuid> [--limit 25]
+ */
+import { statSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { eq } from 'drizzle-orm';
+import { sunaAccountMigrations } from '@kortix/db';
+import { db } from '../shared/db';
+import { extractStep, repoStep, pushStep, dbStep } from '../projects/suna-migration/suna-migration-phases';
+import { latestSunaMigration, type SunaMigrationContext } from '../projects/suna-migration/suna-migration-runner';
+
+function arg(flag: string): string | undefined {
+  const i = Bun.argv.indexOf(flag);
+  return i >= 0 ? Bun.argv[i + 1] : Bun.argv.find((a) => a.startsWith(`${flag}=`))?.slice(flag.length + 1);
+}
+
+const accountId = arg('--account-id');
+const limit = Number(arg('--limit') ?? 25);
+if (!accountId) { console.error('--account-id <uuid> required'); process.exit(2); }
+
+async function main() {
+  const row = await latestSunaMigration(db, accountId!);
+  if (!row) { console.error(`no migration row for account ${accountId}`); process.exit(1); }
+  console.log(`\n▸ direct-drive migration ${row.migrationId} (account ${accountId}) — current: ${row.status}/${row.phase}\n`);
+
+  const progress: Record<string, unknown> = {};
+  const ctx: SunaMigrationContext = {
+    database: db,
+    migrationId: row.migrationId,
+    runId: row.runId,
+    accountId: accountId!,
+    plan: { limit, offset: 0 },
+    progress,
+    checkpoint: async (patch) => { Object.assign(progress, patch); },
+    heartbeat: async () => {},
+    log: (m, e) => console.log(`  [${new Date().toISOString()}] ${m}`, e ? JSON.stringify(e) : ''),
+  };
+
+  console.log('— extract —'); await extractStep(ctx);
+
+  // Capture his COMPLETE /workspace (every file, including >50MB artifacts the
+  // repo push will strip) so he can be handed the full set separately.
+  const bundleDir = join(tmpdir(), `suna-mig-${row.migrationId}`);
+  const archive = arg('--archive') ?? join(tmpdir(), `suna-files-${accountId}.tar.gz`);
+  const t = Bun.spawnSync(['tar', 'czf', archive, '-C', bundleDir, 'legacy']);
+  if (t.exitCode === 0) console.log(`  ✓ full files archive: ${archive} (${(statSync(archive).size / 1048576).toFixed(1)}MB)`);
+  else console.error('  ✗ archive failed:', new TextDecoder().decode(t.stderr).slice(0, 200));
+
+  console.log('— repo —');    await repoStep(ctx);
+  console.log('— push —');    await pushStep(ctx);
+  console.log('— db —');      await dbStep(ctx);
+
+  await db.update(sunaAccountMigrations).set({
+    status: 'completed', phase: 'done', error: null, attempts: 0,
+    projectId: (progress.project_id as string) ?? null,
+    progress, heartbeatAt: null,
+    appliedAt: row.appliedAt ?? new Date(), verifiedAt: new Date(), updatedAt: new Date(),
+  }).where(eq(sunaAccountMigrations.migrationId, row.migrationId));
+
+  console.log(`\n✓ completed — project_id ${progress.project_id}, ${(progress.sessions as unknown[])?.length ?? 0} sessions.\n`);
+}
+
+await main();
+process.exit(0);


### PR DESCRIPTION
Follow-up to #4020. While recovering the first stranded prod migration, the repo push failed on a real customer's content:

```
remote: error: File legacy/kortix-bot-setup/CodeMigrator_Pro_macOS_Lite.tar.gz is 77.38 MB ... See gh.io/lfs
git push failed
```

GitHub rejects oversized blobs and LFS isn't wired up for managed repos, so a single big workspace artifact fails the **entire** migration at the repo phase — independent of the retry bug #4020 fixed.

## Fix
- `pushBundleAsRepo` strips files over 50MB from the bundle before the commit, and records them in `.kortix-skipped-large-files.txt` so nothing is dropped silently.
- The full `/workspace` (including stripped files) is still recoverable separately — see `deliver-suna-files.ts`.

## Recovery tooling (used to fix the first affected account live)
- `fix-suna-migration-direct.ts` — drives ONE stuck migration to completion **out of band**: it reuses the fixed `extract→repo→push→db` phases but never sets the row to `running`, so the prod worker (which only leases `planned`/`running`) can't race it; the row is stamped `completed` atomically at the end. Recovered account `9b7ef1f9` → project `5b08accc`, 10 sessions.
- `deliver-suna-files.ts` — uploads a customer's extracted `/workspace` archive to the backup bucket and mints a signed download URL.

Typechecked clean; no schema changes.