### PR TITLE
fix(sandbox): stop Platinum sessions hanging on 'llm proxy not ready' when the account has no gateway token

### DIFF
--- a/apps/kortix-sandbox-agent-server/src/__tests__/llm-proxy.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/llm-proxy.test.ts
@@ -15,6 +15,7 @@ import {
   executorProxyBaseUrl,
   stopExecutorProxy,
   EXECUTOR_PROXY_PLACEHOLDER_KEY,
+  shouldDisableProxyModeGateway,
 } from '../llm-proxy'
 import { buildOpencodeConfigContent } from '../opencode'
 
@@ -169,5 +170,45 @@ describe('buildOpencodeConfigContent — proxy mode vs direct mode', () => {
     expect(cfg.provider.kortix.options.baseURL).toBe('https://gateway.kortix.test/v1/llm')
     expect(cfg.provider.kortix.options.apiKey).toBe('real-session-llm-key')
     expect(cfg.mcp).toBeUndefined()
+  })
+
+  // The hazard the adoption fix compensates for: with proxy-mode baked but NO
+  // per-session gateway token (unentitled account), the config STILL mounts the
+  // kortix provider pointed at the proxy — so at runtime every call would hit the
+  // token-less proxy and 503 "llm proxy not ready". Locking this makes the reason
+  // the daemon must drop KORTIX_LLM_PROXY_URL for such sessions explicit.
+  test('PROXY mode still mounts the kortix provider even with NO session token (the failure the fix guards)', async () => {
+    const json = await buildOpencodeConfigContent({
+      KORTIX_LLM_PROXY_URL: 'http://127.0.0.1:4319',
+      KORTIX_LLM_CATALOG_FILE: catalog,
+      // no KORTIX_LLM_API_KEY / KORTIX_LLM_BASE_URL — account not entitled
+    } as NodeJS.ProcessEnv)
+    expect(json).toBeDefined()
+    const cfg = JSON.parse(json!)
+    expect(cfg.provider.kortix.options.baseURL).toBe('http://127.0.0.1:4319')
+    expect(cfg.provider.kortix.options.apiKey).toBe(LLM_PROXY_PLACEHOLDER_KEY)
+    expect(cfg.enabled_providers).toEqual(['kortix'])
+  })
+
+  // What the adoption fix produces for an unentitled account: it deletes
+  // KORTIX_LLM_PROXY_URL, so the rebuilt config has no gateway provider at all and
+  // opencode falls back to its native catalog (matching Daytona) — no dead proxy.
+  test('dropping the proxy URL with no session token yields native fallback (no kortix provider)', async () => {
+    expect(await buildOpencodeConfigContent({ KORTIX_LLM_CATALOG_FILE: catalog } as NodeJS.ProcessEnv)).toBeUndefined()
+  })
+})
+
+describe('shouldDisableProxyModeGateway — adoption decision', () => {
+  test('tears proxy-mode down only when it is baked but the proxy holds no token', () => {
+    // Unentitled account: seed baked proxy-mode, but no gateway token was injected
+    // → drop proxy-mode so opencode falls back to native models.
+    expect(shouldDisableProxyModeGateway({ hotswapBaked: true, proxyUrlSet: true, proxyReady: false })).toBe(true)
+    // Entitled: the proxy holds a usable token → keep proxy-mode (even if the fast
+    // hot-swap path was skipped for opencode-not-ok / repo-error reasons).
+    expect(shouldDisableProxyModeGateway({ hotswapBaked: true, proxyUrlSet: true, proxyReady: true })).toBe(false)
+    // Cold / Daytona: proxy-mode was never baked → nothing to tear down.
+    expect(shouldDisableProxyModeGateway({ hotswapBaked: false, proxyUrlSet: false, proxyReady: false })).toBe(false)
+    // Hot-swap flag on but the proxy never started (bind failure) → not our case.
+    expect(shouldDisableProxyModeGateway({ hotswapBaked: true, proxyUrlSet: false, proxyReady: false })).toBe(false)
   })
 })

--- a/apps/kortix-sandbox-agent-server/src/__tests__/provider-llm-parity.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/provider-llm-parity.test.ts
@@ -1,0 +1,123 @@
+import { describe, test, expect } from 'bun:test'
+import { writeFileSync, mkdtempSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+import { buildOpencodeConfigContent } from '../opencode'
+import { resolveLlmRuntime, shouldDisableProxyModeGateway } from '../llm-proxy'
+
+// The integrator (session-sandbox.ts) calls provider.create(envVars) through ONE
+// SandboxProvider interface and never branches on Daytona vs Platinum. This suite
+// enforces the matching promise one layer down: the in-sandbox daemon must resolve
+// the SAME OBSERVABLE LLM runtime for the same logical input, whichever provider's
+// boot model produced the env. Daytona (cold: real gateway creds in env) and
+// Platinum (warm: gateway via the localhost hot-swap proxy) use different transports
+// — that is an internal detail the caller must not see. A per-provider difference in
+// the OBSERVABLE outcome (gateway available? which providers enabled?) is a bug, and
+// fails here.
+
+// Small baked catalog so config materialization is deterministic (no /models fetch)
+// for BOTH the direct and proxy transports.
+const catalog = join(mkdtempSync(join(tmpdir(), 'parity-cat-')), 'catalog.json')
+writeFileSync(catalog, JSON.stringify({ models: { 'kortix/auto': { id: 'kortix/auto', name: 'Auto' } } }))
+
+// Provider-shaped envs for the SAME logical input. These mirror what each provider
+// hands the daemon: Daytona bakes the real gateway creds into opencode's env; a
+// Platinum warm template bakes KORTIX_LLM_HOTSWAP + routes through KORTIX_LLM_PROXY_URL
+// and injects the real token into the proxy at adoption (modelled by proxyHasToken).
+const daytonaEntitled: NodeJS.ProcessEnv = {
+  KORTIX_LLM_API_KEY: 'real-session-key',
+  KORTIX_LLM_BASE_URL: 'https://gateway.kortix.test/v1/llm',
+  KORTIX_LLM_CATALOG_FILE: catalog,
+}
+const platinumEntitled: NodeJS.ProcessEnv = {
+  KORTIX_LLM_HOTSWAP: '1',
+  KORTIX_LLM_PROXY_URL: 'http://127.0.0.1:4319',
+  KORTIX_LLM_CATALOG_FILE: catalog,
+}
+const daytonaUnentitled: NodeJS.ProcessEnv = {}
+const platinumUnentitled: NodeJS.ProcessEnv = {
+  KORTIX_LLM_HOTSWAP: '1',
+  KORTIX_LLM_PROXY_URL: 'http://127.0.0.1:4319',
+  KORTIX_LLM_CATALOG_FILE: catalog,
+}
+
+// Model the daemon's fork-adoption reconciliation then materialize opencode's config,
+// and reduce it to what the agent/integrator actually observes — deliberately
+// ignoring internal transport (proxy baseURL vs direct baseURL).
+async function observableRuntime(env: NodeJS.ProcessEnv, proxyHasToken: boolean) {
+  const e = { ...env }
+  const hotswapBaked = e.KORTIX_LLM_HOTSWAP === '1'
+  const proxyUrlSet = !!e.KORTIX_LLM_PROXY_URL
+  // Adoption reconciliation (what main.ts does): drop the warm proxy transport if it
+  // will never serve, so the config downgrades to the same outcome a cold box gets.
+  if (
+    shouldDisableProxyModeGateway({
+      hotswapBaked,
+      proxyUrlSet,
+      proxyReady: proxyHasToken,
+      directGatewayCredsPresent: !!e.KORTIX_LLM_API_KEY && !!e.KORTIX_LLM_BASE_URL,
+    })
+  ) {
+    delete e.KORTIX_LLM_PROXY_URL
+  }
+  const raw = await buildOpencodeConfigContent(e)
+  const cfg = raw ? JSON.parse(raw) : null
+  return {
+    gatewayAvailable: !!cfg?.provider?.kortix,
+    enabledProviders: (cfg?.enabled_providers as string[] | undefined) ?? null,
+  }
+}
+
+describe('provider parity — Daytona and Platinum yield identical OBSERVABLE LLM runtime', () => {
+  test('entitled account: both expose the gateway (transport differs internally, capability identical)', async () => {
+    const daytona = await observableRuntime(daytonaEntitled, /* proxyHasToken */ false)
+    const platinum = await observableRuntime(platinumEntitled, /* proxyHasToken */ true)
+
+    expect(daytona.gatewayAvailable).toBe(true)
+    expect(platinum.gatewayAvailable).toBe(true)
+    // The whole point: same observable result on both providers.
+    expect(platinum.gatewayAvailable).toBe(daytona.gatewayAvailable)
+    expect(platinum.enabledProviders).toEqual(daytona.enabledProviders) // ['kortix'] on both
+  })
+
+  test('unentitled account: both fall back to native — no dead gateway left on Platinum', async () => {
+    const daytona = await observableRuntime(daytonaUnentitled, false)
+    const platinum = await observableRuntime(platinumUnentitled, /* proxyHasToken */ false)
+
+    expect(daytona.gatewayAvailable).toBe(false)
+    expect(platinum.gatewayAvailable).toBe(false)
+    expect(platinum.gatewayAvailable).toBe(daytona.gatewayAvailable)
+    expect(platinum.enabledProviders).toEqual(daytona.enabledProviders) // null (native) on both
+  })
+
+  test('the pure oracle agrees for both provider shapes (same kind regardless of transport)', () => {
+    // Entitled: Daytona resolves via direct creds, Platinum via a tokened proxy —
+    // different transport, SAME kind.
+    const dEnt = resolveLlmRuntime({ proxyTransportAvailable: false, proxyHasToken: false, directGatewayCredsPresent: true })
+    const pEnt = resolveLlmRuntime({ proxyTransportAvailable: true, proxyHasToken: true, directGatewayCredsPresent: false })
+    expect(dEnt.kind).toBe('gateway')
+    expect(pEnt.kind).toBe('gateway')
+    expect(pEnt.kind).toBe(dEnt.kind)
+
+    // Unentitled: neither has a usable gateway → both native.
+    const dUn = resolveLlmRuntime({ proxyTransportAvailable: false, proxyHasToken: false, directGatewayCredsPresent: false })
+    const pUn = resolveLlmRuntime({ proxyTransportAvailable: true, proxyHasToken: false, directGatewayCredsPresent: false })
+    expect(dUn.kind).toBe('native')
+    expect(pUn.kind).toBe('native')
+    expect(pUn.kind).toBe(dUn.kind)
+  })
+
+  // Guardrail: prove the reconciliation is LOAD-BEARING. Without it, Platinum's raw
+  // unentitled seed config mounts a token-less (dead) `kortix` provider while Daytona
+  // is native — the exact divergence this contract forbids. If someone deletes the
+  // adoption teardown, the parity tests above still need this to stay meaningful.
+  test('regression proof: raw Platinum seed config DIVERGES from Daytona for unentitled (why reconciliation exists)', async () => {
+    const rawPlatinum = JSON.parse((await buildOpencodeConfigContent(platinumUnentitled))!)
+    const rawDaytona = await buildOpencodeConfigContent(daytonaUnentitled)
+
+    expect(rawPlatinum.provider.kortix).toBeDefined() // token-less dead gateway mounted
+    expect(rawDaytona).toBeUndefined() // native
+    // They differ WITHOUT reconciliation → observableRuntime()'s convergence above is real work.
+  })
+})

--- a/apps/kortix-sandbox-agent-server/src/llm-proxy.ts
+++ b/apps/kortix-sandbox-agent-server/src/llm-proxy.ts
@@ -189,26 +189,69 @@ export const executorProxyReady = () => executor.ready()
 export const executorProxyBaseUrl = () => executor.baseUrl()
 export const stopExecutorProxy = () => executor.stop()
 
-// ── Adoption-time decision ─────────────────────────────────────────────────────
+// ── Provider-agnostic LLM runtime resolution ───────────────────────────────────
+// THE single source of truth for what LLM runtime a session ends up with. Daytona
+// (cold: real gateway creds live in opencode's env) and Platinum (warm: gateway
+// reached through the localhost hot-swap proxy) are DIFFERENT transports, but the
+// integrator must not care — the same logical input has to yield the same OBSERVABLE
+// outcome on every provider: a working gateway when a token exists, native fallback
+// when it doesn't. Both boot paths funnel through resolveLlmRuntime so no provider
+// can silently produce a divergent outcome (e.g. Platinum's old "gateway provider
+// mounted but token-less → 503 forever" state, which had no Daytona equivalent).
+// The provider-parity contract test (__tests__/provider-llm-parity.test.ts) enforces
+// this: same logical input → identical observable runtime across providers.
+
+export type LlmRuntimeMode =
+  | { kind: 'gateway'; transport: 'direct' | 'proxy' }
+  | { kind: 'native' }
+
+export interface LlmRuntimeInputs {
+  /** KORTIX_LLM_PROXY_URL is set → the localhost credential-proxy transport exists
+   *  (warm-fork / Platinum). It is only a WORKING gateway once it holds a token. */
+  proxyTransportAvailable: boolean
+  /** The proxy actually holds a usable per-session token (llmProxyReady()). */
+  proxyHasToken: boolean
+  /** Direct gateway creds baked into opencode's env (cold / Daytona):
+   *  KORTIX_LLM_API_KEY + KORTIX_LLM_BASE_URL. */
+  directGatewayCredsPresent: boolean
+}
+
 /**
- * A warm seed bakes proxy-mode opencode (KORTIX_LLM_HOTSWAP=1 — Platinum only): the
- * `kortix` provider points at THIS localhost proxy with a placeholder key, and the
- * real per-session gateway token is injected into the proxy at fork adoption. But
- * an account that is not entitled to the LLM gateway never gets a token injected, so
- * a session that keeps routing through the token-less proxy 503s "llm proxy not
- * ready" on EVERY model call forever (and the frontend retries it indefinitely).
- *
- * Returns true when proxy-mode must be TORN DOWN at adoption so the rebuilt opencode
- * config drops the `kortix` provider and opencode falls back to its native catalog —
- * matching Daytona, which never bakes proxy-mode and already degrades this way. The
- * decision keys off `proxyReady` (proxy is listening AND holds a usable token), so
- * an entitled account whose token WAS injected keeps proxy-mode even when the fast
- * hot-swap path is skipped (opencode not yet `ok`, repo error, …).
+ * Resolve the FINAL, adopted-session LLM runtime. Deliberately has no fourth
+ * "gateway mounted but dead" state: a gateway is reported ONLY when it can serve,
+ * so `native` is the identical fallback on every provider. Transport (direct vs
+ * proxy) is an INTERNAL detail the integrator never observes.
+ */
+export function resolveLlmRuntime(i: LlmRuntimeInputs): LlmRuntimeMode {
+  // Warm/proxy transport counts as a gateway ONLY once the token is in the proxy.
+  if (i.proxyTransportAvailable && i.proxyHasToken) return { kind: 'gateway', transport: 'proxy' }
+  // Cold/direct transport: real key + base baked straight into opencode's env.
+  if (i.directGatewayCredsPresent) return { kind: 'gateway', transport: 'direct' }
+  // No usable gateway on either transport → native catalog (identical everywhere).
+  return { kind: 'native' }
+}
+
+/**
+ * Adoption action derived from the shared oracle: a warm seed bakes proxy-mode
+ * opencode (KORTIX_LLM_HOTSWAP=1, Platinum), but if the resolved runtime is NOT the
+ * proxy gateway (no token arrived → unentitled account), the proxy must be TORN DOWN
+ * at adoption so the rebuilt config drops the token-less `kortix` provider and
+ * opencode falls back to whatever a cold/Daytona box would use (native, or direct if
+ * creds exist). Left as-is it would 503 "llm proxy not ready" on every call forever.
+ * Keying off the resolver (not a bespoke boolean) is what keeps the two providers'
+ * observable behavior identical.
  */
 export function shouldDisableProxyModeGateway(opts: {
   hotswapBaked: boolean
   proxyUrlSet: boolean
   proxyReady: boolean
+  directGatewayCredsPresent?: boolean
 }): boolean {
-  return opts.hotswapBaked && opts.proxyUrlSet && !opts.proxyReady
+  if (!opts.hotswapBaked || !opts.proxyUrlSet) return false
+  const mode = resolveLlmRuntime({
+    proxyTransportAvailable: opts.proxyUrlSet,
+    proxyHasToken: opts.proxyReady,
+    directGatewayCredsPresent: !!opts.directGatewayCredsPresent,
+  })
+  return !(mode.kind === 'gateway' && mode.transport === 'proxy')
 }

--- a/apps/kortix-sandbox-agent-server/src/llm-proxy.ts
+++ b/apps/kortix-sandbox-agent-server/src/llm-proxy.ts
@@ -188,3 +188,27 @@ export const setExecutorProxyToken = (token: string | undefined, upstreamBase?: 
 export const executorProxyReady = () => executor.ready()
 export const executorProxyBaseUrl = () => executor.baseUrl()
 export const stopExecutorProxy = () => executor.stop()
+
+// ── Adoption-time decision ─────────────────────────────────────────────────────
+/**
+ * A warm seed bakes proxy-mode opencode (KORTIX_LLM_HOTSWAP=1 — Platinum only): the
+ * `kortix` provider points at THIS localhost proxy with a placeholder key, and the
+ * real per-session gateway token is injected into the proxy at fork adoption. But
+ * an account that is not entitled to the LLM gateway never gets a token injected, so
+ * a session that keeps routing through the token-less proxy 503s "llm proxy not
+ * ready" on EVERY model call forever (and the frontend retries it indefinitely).
+ *
+ * Returns true when proxy-mode must be TORN DOWN at adoption so the rebuilt opencode
+ * config drops the `kortix` provider and opencode falls back to its native catalog —
+ * matching Daytona, which never bakes proxy-mode and already degrades this way. The
+ * decision keys off `proxyReady` (proxy is listening AND holds a usable token), so
+ * an entitled account whose token WAS injected keeps proxy-mode even when the fast
+ * hot-swap path is skipped (opencode not yet `ok`, repo error, …).
+ */
+export function shouldDisableProxyModeGateway(opts: {
+  hotswapBaked: boolean
+  proxyUrlSet: boolean
+  proxyReady: boolean
+}): boolean {
+  return opts.hotswapBaked && opts.proxyUrlSet && !opts.proxyReady
+}

--- a/apps/kortix-sandbox-agent-server/src/main.ts
+++ b/apps/kortix-sandbox-agent-server/src/main.ts
@@ -634,6 +634,8 @@ async function runWarmSeedMode(
             hotswapBaked: llmHotswap,
             proxyUrlSet: !!process.env.KORTIX_LLM_PROXY_URL,
             proxyReady: llmProxyReady(),
+            directGatewayCredsPresent:
+              !!process.env.KORTIX_LLM_API_KEY && !!process.env.KORTIX_LLM_BASE_URL,
           })
         ) {
           logger.warn(

--- a/apps/kortix-sandbox-agent-server/src/main.ts
+++ b/apps/kortix-sandbox-agent-server/src/main.ts
@@ -24,6 +24,8 @@ import {
   setLlmProxyToken,
   llmProxyReady,
   llmProxyBaseUrl,
+  stopLlmProxy,
+  shouldDisableProxyModeGateway,
   startExecutorProxy,
   setExecutorProxyToken,
   executorProxyReady,
@@ -573,22 +575,16 @@ async function runWarmSeedMode(
       await ensureOpencodeConfigDeps(adoptedOpencodeConfigDir).catch((err) =>
         logger.warn('[seed] adoption config deps failed', { err: (err as Error).message }),
       )
-      // NO-RESTART fast path (opt-in, stateful warm-fork only): the seed baked a
-      // session-independent opencode config routed through the localhost LLM +
-      // executor proxies, so inject the per-session tokens LIVE and reuse the
-      // already-warm opencode — skipping the ~8s restart. Engages only when
-      // hot-swap is on, the LLM proxy is up + the seed baked the proxied provider
-      // (KORTIX_LLM_PROXY_URL set), opencode is currently healthy, and the repo
-      // materialized cleanly. Anything missing falls through to restart.
-      let hotSwapped = false
-      if (
-        llmHotswap &&
-        !!process.env.KORTIX_LLM_PROXY_URL &&
-        llmProxyBaseUrl() != null &&
-        opencode.getState() === 'ok' &&
-        !bootState.repoMaterializationError
-      ) {
-        // LLM gateway: required for the session to function.
+      // Inject the per-session tokens into the localhost proxies whenever the warm
+      // seed baked proxy-mode opencode. This MUST run before the no-restart decision
+      // below: the baked opencode config always routes the `kortix` provider through
+      // the proxy, so the proxy has to hold the token for BOTH the fast hot-swap path
+      // AND any subsequent restart path (repo error, or opencode not yet `ok`).
+      // Injecting only inside the fast path left the restart path routed through a
+      // token-less proxy → permanent 503 "llm proxy not ready" even for entitled
+      // accounts. A no-op when this account has no gateway token (unentitled): the
+      // set is guarded on a non-empty token, so llmProxyReady() stays false.
+      if (llmHotswap && !!process.env.KORTIX_LLM_PROXY_URL && llmProxyBaseUrl() != null) {
         setLlmProxyToken(process.env.KORTIX_LLM_API_KEY, process.env.KORTIX_LLM_BASE_URL)
         // Optional Executor MCP compatibility: if the seed enabled that face,
         // the running MCP points at this proxy. The CLI path does not need this;
@@ -596,18 +592,56 @@ async function runWarmSeedMode(
         if (process.env.KORTIX_EXECUTOR_PROXY_URL && executorProxyBaseUrl() != null) {
           setExecutorProxyToken(process.env.KORTIX_EXECUTOR_TOKEN, process.env.KORTIX_API_URL)
         }
-        if (llmProxyReady()) {
-          hotSwapped = true
-          bootMark('adopt-opencode-hotswapped')
-          // Observability only: this confirms the optional executor proxy has a
-          // live token. It does not assert that OpenCode registered MCP tools.
-          if (executorProxyReady()) bootMark('adopt-executor-proxy-ready')
-          logger.info('[seed] fork adoption hot-swap: per-session tokens injected via proxies, opencode not restarted', {
-            executorReady: executorProxyReady(),
-          })
-        }
+      }
+
+      // NO-RESTART fast path (opt-in, stateful warm-fork only): the seed baked a
+      // session-independent opencode config routed through the localhost LLM +
+      // executor proxies, so reuse the already-warm opencode — skipping the ~8s
+      // restart. Engages only when hot-swap is on, the seed baked the proxied
+      // provider (KORTIX_LLM_PROXY_URL set), the LLM proxy now holds a usable token
+      // (llmProxyReady), opencode is currently healthy, and the repo materialized
+      // cleanly. Anything missing falls through to restart.
+      let hotSwapped = false
+      if (
+        llmHotswap &&
+        !!process.env.KORTIX_LLM_PROXY_URL &&
+        llmProxyBaseUrl() != null &&
+        llmProxyReady() &&
+        opencode.getState() === 'ok' &&
+        !bootState.repoMaterializationError
+      ) {
+        hotSwapped = true
+        bootMark('adopt-opencode-hotswapped')
+        // Observability only: this confirms the optional executor proxy has a
+        // live token. It does not assert that OpenCode registered MCP tools.
+        if (executorProxyReady()) bootMark('adopt-executor-proxy-ready')
+        logger.info('[seed] fork adoption hot-swap: per-session tokens injected via proxies, opencode not restarted', {
+          executorReady: executorProxyReady(),
+        })
       }
       if (!hotSwapped) {
+        // If the seed baked proxy-mode opencode but the LLM proxy has no token to
+        // serve (account not entitled to the gateway → no KORTIX_LLM_API_KEY was
+        // injected), tear proxy-mode down so the rebuilt config drops the `kortix`
+        // provider and opencode falls back to its native catalog. Left as-is, every
+        // model call would route through the token-less proxy and 503 "llm proxy not
+        // ready" forever. Daytona never bakes proxy-mode, so this makes Platinum match
+        // it. buildOpencodeConfigContent reads KORTIX_LLM_PROXY_URL from process.env
+        // (never the session env file), so deleting it here is sufficient to drop the
+        // provider on the reconfigure+restart below.
+        if (
+          shouldDisableProxyModeGateway({
+            hotswapBaked: llmHotswap,
+            proxyUrlSet: !!process.env.KORTIX_LLM_PROXY_URL,
+            proxyReady: llmProxyReady(),
+          })
+        ) {
+          logger.warn(
+            '[seed] no per-session LLM gateway token (account not entitled?); disabling proxy-mode gateway provider so opencode falls back to native models instead of 503 "llm proxy not ready"',
+          )
+          delete process.env.KORTIX_LLM_PROXY_URL
+          stopLlmProxy()
+        }
         opencode.reconfigure(cfg2, adoptedOpencodeConfigDir, projectEnv)
         await opencode.restart().catch((err) =>
           logger.warn('[seed] adoption opencode restart failed', { err: (err as Error).message }),


### PR DESCRIPTION
## Symptom
Live dev sessions stuck showing **`Service Unavailable: llm proxy not ready` / Retrying…** forever (e.g. projects `27bb9190…` and `2b9e1445…`). Infra is healthy — `sandbox-health`, `change-requests`, even `turn-stream` all `200`. Only the model call dies.

## Root cause (Platinum-specific)
Inside a Platinum sandbox, opencode's `kortix` provider is routed through a **localhost credential proxy** (`llm-proxy.ts`) that fails closed with `503 "llm proxy not ready"` until a per-session gateway token is injected at fork adoption. `KORTIX_LLM_HOTSWAP='1'` (which turns this proxy on) is baked **only** into Platinum templates (`builder.ts:320`, `warm-project.ts:388`) — Daytona never sets it and simply falls back to the native catalog.

Two paths left the proxy token-less forever, both surfacing as the infinite retry (the frontend treats `/not ready/i` as a transient boot signal):

1. **Unentitled account.** Dev runs `KORTIX_BILLING_INTERNAL_ENABLED=true`, so `accountEntitledToLlmGateway()` returns false for a free tier → no `KORTIX_LLM_API_KEY` injected (`session-sandbox.ts:382`) → proxy never gets a token. Because proxy-mode is baked, `buildOpencodeConfigContent` mounts *only* the `kortix` provider through the dead proxy (`enabled_providers=['kortix']`) — defeating the intended "no key → native fallback" behavior that Daytona still gets.
2. **Latent robustness bug.** The adoption **restart** fallback never called `setLlmProxyToken` at all, so even an *entitled* account got a dead proxy whenever adoption missed the hot-swap fast path (opencode not `ok`, repo error, timing).

## Fix (`apps/kortix-sandbox-agent-server`)
- Inject the proxy token **before** the fast/restart branch, so the restart path also serves a tokened proxy; gate the no-restart fast path on `llmProxyReady()`.
- When proxy-mode was baked but no token exists, **tear it down** (`delete KORTIX_LLM_PROXY_URL` + `stopLlmProxy()`) so opencode rebuilds without the `kortix` provider and falls back to native models — Platinum now matches Daytona.
- New pure helper `shouldDisableProxyModeGateway()` + tests (decision matrix, the no-token hazard, native fallback).

## Scope / non-goal
This stops the permanent hang and restores graceful degradation. It does **not** change entitlement semantics — an unentitled account still won't get managed models; **entitling the account is the separate lever** that gives it working models. Worth a follow-up decision on whether free tier should get free managed models (the gateway supports them) vs. a clean upsell surface.

## Tests
- `bun test` (daemon pkg): **144 pass / 0 fail**
- `bun tsc --noEmit`: clean