### PR TITLE
fix(billing): correct per-seat grant on checkout and seat-aware renewal

### DIFF
--- a/apps/api/src/billing/services/webhooks.ts
+++ b/apps/api/src/billing/services/webhooks.ts
@@ -15,6 +15,7 @@ import {
   getTier,
   getTierByPriceId,
   getMonthlyCredits,
+  grantForSeats,
   isUpgrade,
   mapRevenueCatProductToTier,
   getRevenueCatPeriodType,
@@ -138,6 +139,9 @@ async function handleSubscriptionCheckout(session: Stripe.Checkout.Session, acco
     : session.subscription?.id;
   if (!subscriptionId) return;
 
+  const stripe = getStripe();
+  const subscription = await stripe.subscriptions.retrieve(subscriptionId);
+
   const tier = getTier(tierKey);
   const commitmentType = session.metadata?.commitment_type;
   const isYearly = commitmentType === 'yearly' || commitmentType === 'yearly_commitment';
@@ -151,6 +155,28 @@ async function handleSubscriptionCheckout(session: Stripe.Checkout.Session, acco
         : null
     );
 
+  // For per-seat plans, seat count drives the grant size and the
+  // auto-topup defaults. Resolve from the subscription line item if available.
+  const perSeatPriceId = resolvePerSeatPriceId();
+  const perSeatItem = subscription.items.data.find(
+    (item) => (perSeatPriceId && item.price?.id === perSeatPriceId) ||
+      subscription.metadata?.billing_model === 'per_seat',
+  );
+  const seatCount = perSeatItem ? Math.max(1, Math.floor(perSeatItem.quantity ?? 1)) : 1;
+  const isPerSeat = tierKey === 'per_seat' || !!perSeatItem;
+
+  // For monthly plans, set next_credit_grant to the period-end so the
+  // renewal loop knows when the next grant is due. Previously this was only
+  // set for yearly plans, leaving monthly accounts with next_credit_grant=NULL
+  // and no way for the cron to know they needed a grant.
+  const nextCreditGrantTs = isYearly
+    ? calculateNextCreditGrant(new Date()).toISOString()
+    : new Date(subscription.current_period_end * 1000).toISOString();
+
+  const perSeatAutoTopupDefaults = isPerSeat && !existingAccount?.autoTopupCustomized
+    ? defaultAutoTopupForSeats(seatCount)
+    : null;
+
   await upsertCreditAccount(accountId, {
     tier: tierKey,
     provider: 'stripe',
@@ -158,18 +184,34 @@ async function handleSubscriptionCheckout(session: Stripe.Checkout.Session, acco
     stripeSubscriptionStatus: 'active',
     planType: isYearly ? 'yearly' : 'monthly',
     commitmentType: commitmentType === 'yearly_commitment' ? commitmentType : null,
-    ...(isYearly ? { nextCreditGrant: calculateNextCreditGrant(new Date()).toISOString() } : {}),
+    nextCreditGrant: nextCreditGrantTs,
+    lastRenewalPeriodStart: subscription.current_period_start,
+    ...(isPerSeat ? {
+      billingModel: 'per_seat',
+      seatCount,
+      ...(perSeatAutoTopupDefaults ? {
+        autoTopupThreshold: String(perSeatAutoTopupDefaults.threshold),
+        autoTopupAmount: String(perSeatAutoTopupDefaults.amount),
+      } : {}),
+    } : {}),
     autoTopupEnabled: true,
-    autoTopupThreshold: String(AUTO_TOPUP_DEFAULT_THRESHOLD),
-    autoTopupAmount: String(AUTO_TOPUP_DEFAULT_AMOUNT),
+    autoTopupThreshold: String(perSeatAutoTopupDefaults?.threshold ?? AUTO_TOPUP_DEFAULT_THRESHOLD),
+    autoTopupAmount: String(perSeatAutoTopupDefaults?.amount ?? AUTO_TOPUP_DEFAULT_AMOUNT),
   });
 
-  if (tier.monthlyCredits > 0) {
+  // For per-seat: grant grantForSeats(seatCount) so 1 seat → $25, 3 seats → $75, etc.
+  // For legacy tiers: grant tier.monthlyCredits (unchanged behaviour).
+  const creditAmount = isPerSeat ? grantForSeats(seatCount) : tier.monthlyCredits;
+  const creditDesc = isPerSeat
+    ? `${tier.displayName} subscription activated: ${creditAmount} credits (${seatCount} ${seatCount === 1 ? 'seat' : 'seats'})`
+    : `${tier.displayName} subscription activated: ${creditAmount} credits`;
+
+  if (creditAmount > 0) {
     await grantCredits(
       accountId,
-      tier.monthlyCredits,
+      creditAmount,
       'tier_grant',
-      `${tier.displayName} subscription activated: ${tier.monthlyCredits} credits`,
+      creditDesc,
       true,
       session.id,
     );
@@ -419,10 +461,18 @@ async function handleInvoicePaid(invoice: Stripe.Invoice) {
   }
 
   const tierName = account.scheduledTierChange ?? account.tier ?? 'free';
-  const credits = getMonthlyCredits(tierName);
+
+  // Per-seat accounts: credit grant scales with seat count.
+  // Legacy tiers: grant the flat tier credit.
+  const isPerSeatTier = tierName === 'per_seat' || account.billingModel === 'per_seat';
+  const seatCount = isPerSeatTier ? Math.max(1, account.seatCount ?? 1) : 1;
+  const credits = isPerSeatTier ? grantForSeats(seatCount) : getMonthlyCredits(tierName);
+  const renewalDesc = isPerSeatTier
+    ? `Monthly renewal: ${credits} credits (${seatCount} ${seatCount === 1 ? 'seat' : 'seats'})`
+    : `Monthly renewal: ${credits} credits`;
 
   if (credits > 0) {
-    await resetExpiringCredits(accountId, credits, `Monthly renewal: ${credits} credits`, invoice.id);
+    await resetExpiringCredits(accountId, credits, renewalDesc, invoice.id);
   }
 
   const planType = account.planType ?? 'monthly';


### PR DESCRIPTION
## What

Three related bugs in the Stripe webhook billing path that caused per-seat accounts to start with missing or wrong credits and no next_credit_grant.

**Bug 1: Monthly subscriptions never get next_credit_grant set on first subscribe**

handleSubscriptionCheckout only set nextCreditGrant for yearly plans. Monthly per-seat accounts came away from checkout with next_credit_grant = NULL. The renewal handler (handleInvoicePaid) skips billing_reason !== 'subscription_cycle', so the subscription_create invoice never sets it either.

Fix: read subscription.current_period_end from Stripe in handleSubscriptionCheckout and always set next_credit_grant + last_renewal_period_start.

**Bug 2: Checkout grants flat tier.monthlyCredits instead of grantForSeats(seatCount)**

For per_seat checkouts, the seat count is visible on the subscription line item. The old code used tier.monthlyCredits (always 25 = single seat), so a 3-seat checkout gave the same grant as a 1-seat checkout.

Fix: resolve the per-seat item quantity and call grantForSeats(seatCount).

**Bug 3: Renewal handler also uses flat getMonthlyCredits instead of seat-aware grant**

handleInvoicePaid called getMonthlyCredits(tierName) which returns the single-seat value regardless of seat count.

Fix: use grantForSeats(account.seatCount) for per-seat accounts on renewal.

## Impact

Accounts that signed up when INCLUDED_CREDITS_PER_SEAT_USD was 20 (before d431bc9) got 20 credits at checkout instead of 25. next_credit_grant remained NULL for all monthly accounts that activated via checkout without an intervening subscription_cycle invoice.

Three production accounts were manually remediated in the support sweep.

Going forward all new checkouts and renewals are correct.

## Tests

- All 80 directly-related billing tests pass (webhooks, e2e-per-seat-webhooks, per-seat-pricing)
- 27 pre-existing failures unchanged (confirmed same count before this change)
- pnpm --filter kortix-api typecheck clean