### PR TITLE
fix(auth): show 6-digit OTP code in magic-link sign-in email

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -41,6 +41,15 @@ enable_signup = true
 enable_signup = true
 enable_confirmations = false
 
+# Magic-link sign-in email. The template renders both the one-click link
+# ({{ .ConfirmationURL }}) and the 6-digit code ({{ .Token }}) so users can
+# either click or paste the code into /auth (see apps/web auth verifyOtp).
+# NOTE: this only styles the LOCAL (Inbucket) email. Production uses the
+# hosted Supabase dashboard template — mirror templates/magic_link.html there.
+[auth.email.template.magic_link]
+subject = "Your sign-in code"
+content_path = "./supabase/templates/magic_link.html"
+
 # GitHub OAuth — used by both /auth (sign-in) and the project import flow.
 # Requires a GitHub OAuth App with callback http://127.0.0.1:54321/auth/v1/callback.
 # Set SUPABASE_AUTH_EXTERNAL_GITHUB_CLIENT_ID and

--- a/supabase/templates/magic_link.html
+++ b/supabase/templates/magic_link.html
@@ -1,0 +1,71 @@
+<!--
+  Magic Link sign-in email.
+  Renders BOTH a one-click sign-in link ({{ .ConfirmationURL }}) and the
+  6-digit code ({{ .Token }}) that the /auth page can verify manually.
+  The frontend already accepts either method (see apps/web auth verifyOtp).
+-->
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="light dark" />
+    <title>Your sign-in link</title>
+  </head>
+  <body style="margin:0;padding:0;background-color:#f4f4f5;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:#f4f4f5;padding:40px 16px;">
+      <tr>
+        <td align="center">
+          <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="max-width:440px;background-color:#ffffff;border-radius:12px;border:1px solid #e4e4e7;overflow:hidden;">
+            <tr>
+              <td style="padding:40px 40px 8px 40px;">
+                <h1 style="margin:0 0 12px 0;font-size:20px;line-height:1.3;font-weight:600;color:#09090b;">
+                  Your sign-in link
+                </h1>
+                <p style="margin:0 0 28px 0;font-size:14px;line-height:1.6;color:#52525b;">
+                  Follow the link below to sign in. This link expires shortly and can only be used once.
+                </p>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:0 40px 28px 40px;">
+                <table role="presentation" cellpadding="0" cellspacing="0" width="100%">
+                  <tr>
+                    <td align="center" style="border-radius:8px;background-color:#09090b;">
+                      <a href="{{ .ConfirmationURL }}"
+                         style="display:block;padding:12px 24px;font-size:14px;font-weight:600;color:#ffffff;text-decoration:none;border-radius:8px;">
+                        Sign in
+                      </a>
+                    </td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:0 40px;">
+                <table role="presentation" cellpadding="0" cellspacing="0" width="100%">
+                  <tr>
+                    <td style="border-top:1px solid #e4e4e7;font-size:0;line-height:0;">&nbsp;</td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:28px 40px 40px 40px;">
+                <p style="margin:0 0 12px 0;font-size:14px;line-height:1.6;color:#52525b;">
+                  Or enter this 6-digit code on the sign-in page:
+                </p>
+                <div style="font-size:32px;font-weight:700;letter-spacing:8px;color:#09090b;font-family:'SFMono-Regular',ui-monospace,Menlo,Consolas,monospace;">
+                  {{ .Token }}
+                </div>
+              </td>
+            </tr>
+          </table>
+          <p style="max-width:440px;margin:24px auto 0 auto;font-size:12px;line-height:1.6;color:#a1a1aa;text-align:center;">
+            If you didn't request this email, you can safely ignore it.
+          </p>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>


### PR DESCRIPTION
## Problem
The sign-in email only rendered the magic **link** — users never saw a 6-digit code, even though the frontend (`apps/web` auth `verifyOtp`, `type: 'magiclink'`) already fully supports pasting a code.

## Root cause
The Supabase **Magic Link** email template only renders `{{ .ConfirmationURL }}`. An OTP code only appears if the template also renders `{{ .Token }}`. It didn't.

## Change
- Add `supabase/templates/magic_link.html` — branded email showing the **sign-in link (button) + the 6-digit `{{ .Token }}` code** below it (link + code both).
- Wire it into `supabase/config.toml` under `[auth.email.template.magic_link]` so local Inbucket emails show the code.

## ⚠️ Production follow-up (not code)
The live email is served by the **hosted Supabase dashboard**, not this repo. To fix production, paste the same HTML into **Supabase Dashboard → Authentication → Email Templates → Magic Link**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
