### PR TITLE
feat(sandbox): per-project sandbox-provider override (Customize → Settings)

### DIFF
--- a/apps/api/src/projects/lib/provider-precedence.ts
+++ b/apps/api/src/projects/lib/provider-precedence.ts
@@ -1,0 +1,27 @@
+// Pure sandbox-provider precedence for new sessions. No deps — config/db are
+// injected as `allowed` + `isEnabled` — so it unit-tests without env/DB and stays
+// importable in isolation. Used by createProjectSession (projects/lib/sessions.ts).
+
+/**
+ * Resolve the sandbox provider for a new session. Precedence:
+ *   1. explicit request (`body.provider`) — validated against ALLOWED, 400 on miss;
+ *   2. the per-project pin (`metadata.default_sandbox_provider`) — used only if
+ *      still ENABLED (allowed + API key present). This intentionally bypasses the
+ *      distribution WEIGHTS, so a project can be pinned to e.g. platinum even when
+ *      platinum's weight is 0. A stale/disabled pin is silently ignored, never a
+ *      hard create failure;
+ *   3. `{ fallback: true }` → the caller runs the weighted balancer (selectProvider()).
+ */
+export function resolveSessionProvider(opts: {
+  requested: string | null;
+  projectPin: string | null;
+  allowed: readonly string[];
+  isEnabled: (provider: string) => boolean;
+}): { provider: string } | { badRequest: string } | { fallback: true } {
+  if (opts.requested) {
+    if (!opts.allowed.includes(opts.requested)) return { badRequest: opts.requested };
+    return { provider: opts.requested };
+  }
+  if (opts.projectPin && opts.isEnabled(opts.projectPin)) return { provider: opts.projectPin };
+  return { fallback: true };
+}

--- a/apps/api/src/projects/lib/serializers.ts
+++ b/apps/api/src/projects/lib/serializers.ts
@@ -1,4 +1,4 @@
-import { config } from '../../config';
+import { config, type SandboxProviderName } from '../../config';
 import { isSecretUsableBy, loadGrants, scopeToIntent, type SecretGrant, type ShareSubject, visibilityToIntent } from '../../executor/share';
 import { db } from '../../shared/db';
 import { listSandboxTemplates, listSnapshotBuilds } from '../../snapshots/builder';
@@ -143,6 +143,19 @@ export function serializeProject(row: ProjectRow, access?: { projectRole: Projec
     experimental: resolveExperimentalFeatures(row.metadata),
     experimental_features: buildExperimentalCatalog(row.metadata),
     apps_enabled: resolveAppsEnabled(row.metadata),
+    // Per-project sandbox-provider override (Customize → Settings). `default_sandbox_provider`
+    // is the current pin (null = follow the platform default/distribution);
+    // `available_sandbox_providers` is the enabled set the picker offers
+    // (ALLOWED ∩ has-API-key) — the web client renders + validates against the SAME
+    // set the backend enforces, without a separate (billing-gated) providers route.
+    // Surface the pin only when it's still USABLE (allowed + key) — mirrors the
+    // create path (which ignores a disabled/removed pin and falls back), so the
+    // picker never shows a value with no matching option.
+    default_sandbox_provider: ((): string | null => {
+      const pin = (row.metadata as Record<string, unknown> | null | undefined)?.default_sandbox_provider;
+      return typeof pin === 'string' && config.isProviderEnabled(pin as SandboxProviderName) ? pin : null;
+    })(),
+    available_sandbox_providers: config.ALLOWED_SANDBOX_PROVIDERS.filter((p) => config.isProviderEnabled(p)),
   };
 }
 

--- a/apps/api/src/projects/lib/sessions.provider.test.ts
+++ b/apps/api/src/projects/lib/sessions.provider.test.ts
@@ -1,0 +1,60 @@
+import { test, expect, describe } from 'bun:test';
+import { resolveSessionProvider } from './provider-precedence';
+
+// Per-project sandbox-provider override — precedence unit test. Deterministic:
+// `allowed` + `isEnabled` are injected (they model config.ALLOWED_SANDBOX_PROVIDERS
+// + config.isProviderEnabled), so no env/DB. Precedence under test:
+//   explicit request › per-project pin (if enabled) › fallback (weighted balancer).
+const ALLOWED = ['daytona', 'platinum'] as const;
+const bothEnabled = (_p: string) => true;
+
+describe('resolveSessionProvider (per-project provider override)', () => {
+  test('explicit request wins over the pin + is used verbatim', () => {
+    expect(
+      resolveSessionProvider({ requested: 'platinum', projectPin: 'daytona', allowed: ALLOWED, isEnabled: bothEnabled }),
+    ).toEqual({ provider: 'platinum' });
+  });
+
+  test('explicit request not in ALLOWED → badRequest (becomes 400 upstream)', () => {
+    expect(
+      resolveSessionProvider({ requested: 'gcp', projectPin: null, allowed: ALLOWED, isEnabled: bothEnabled }),
+    ).toEqual({ badRequest: 'gcp' });
+  });
+
+  test('per-project pin is used when set + enabled + no explicit request', () => {
+    expect(
+      resolveSessionProvider({ requested: null, projectPin: 'platinum', allowed: ALLOWED, isEnabled: bothEnabled }),
+    ).toEqual({ provider: 'platinum' });
+  });
+
+  test('pin BYPASSES distribution weights — the gate is enabled(allowed+key), NOT weight', () => {
+    // platinum allowed+enabled but (hypothetically) weight-0 in the distribution;
+    // the pin still wins. The helper never consults weights — that is the feature.
+    expect(
+      resolveSessionProvider({
+        requested: null,
+        projectPin: 'platinum',
+        allowed: ALLOWED,
+        isEnabled: (p) => p === 'daytona' || p === 'platinum',
+      }),
+    ).toEqual({ provider: 'platinum' });
+  });
+
+  test('stale pin (provider since removed from ALLOWED) is ignored → fallback', () => {
+    expect(
+      resolveSessionProvider({ requested: null, projectPin: 'platinum', allowed: ['daytona'], isEnabled: (p) => p === 'daytona' }),
+    ).toEqual({ fallback: true });
+  });
+
+  test('pin allowed but keyless (isEnabled=false) → fallback, never a hard create failure', () => {
+    expect(
+      resolveSessionProvider({ requested: null, projectPin: 'platinum', allowed: ALLOWED, isEnabled: (p) => p === 'daytona' }),
+    ).toEqual({ fallback: true });
+  });
+
+  test('no request + no pin → fallback (weighted balancer runs)', () => {
+    expect(
+      resolveSessionProvider({ requested: null, projectPin: null, allowed: ALLOWED, isEnabled: bothEnabled }),
+    ).toEqual({ fallback: true });
+  });
+});

--- a/apps/api/src/projects/lib/sessions.ts
+++ b/apps/api/src/projects/lib/sessions.ts
@@ -1,5 +1,6 @@
 import { checkBillingActive } from '../../billing/services/billing-gate';
 import { config, type SandboxProviderName } from '../../config';
+import { resolveSessionProvider } from './provider-precedence';
 import { resolveShareSubject } from '../../executor/share';
 import { auth, json } from '../../openapi';
 import { maxConcurrentSessionsForTier, resolveAccountTier } from '../../shared/account-limits';
@@ -421,14 +422,23 @@ export async function createProjectSession(input: {
   );
   const sandboxSlug =
     normalizeString(body.sandbox_slug ?? body.sandboxSlug) ?? projectDefaultSandboxSlug ?? undefined;
-  const requestedProvider = normalizeString(body.provider);
-  let providerName: SandboxProviderName = await selectProvider();
-  if (requestedProvider) {
-    if (!(config.ALLOWED_SANDBOX_PROVIDERS as readonly string[]).includes(requestedProvider)) {
-      return { error: { status: 400, body: { error: `Unknown or disabled sandbox provider: ${requestedProvider}` } } };
-    }
-    providerName = requestedProvider as SandboxProviderName;
+  // Sandbox provider: explicit request › per-project pin (Customize → Settings) ›
+  // weighted balancer. The pin lets you put ONE project on e.g. platinum regardless
+  // of the global distribution weights — see resolveSessionProvider.
+  const picked = resolveSessionProvider({
+    requested: normalizeString(body.provider) ?? null,
+    projectPin:
+      normalizeString(
+        (project.metadata as Record<string, unknown> | null | undefined)?.default_sandbox_provider,
+      ) ?? null,
+    allowed: config.ALLOWED_SANDBOX_PROVIDERS,
+    isEnabled: (p) => config.isProviderEnabled(p as SandboxProviderName),
+  });
+  if ('badRequest' in picked) {
+    return { error: { status: 400, body: { error: `Unknown or disabled sandbox provider: ${picked.badRequest}` } } };
   }
+  const providerName: SandboxProviderName =
+    'provider' in picked ? (picked.provider as SandboxProviderName) : await selectProvider();
 
   const callbackUnreachable = sandboxCallbackUnreachableReason();
   if (callbackUnreachable) {

--- a/apps/api/src/projects/routes/r6.ts
+++ b/apps/api/src/projects/routes/r6.ts
@@ -19,6 +19,7 @@ import { applyExperimentalOverride, isExperimentalFeatureKey } from '../../exper
 import { reconcileChannelConnectors, reconcileComputerConnectors } from '../../executor/sync';
 import { propagateLlmGatewayModeToActiveSandboxes } from '../lib/sandbox-env-sync';
 import { projectLlmGatewayEnabled } from '../../llm-gateway/enablement';
+import { config, type SandboxProviderName } from '../../config';
 
 function serializeProjectAccessRequest(row: typeof projectAccessRequests.$inferSelect) {
   return {
@@ -1145,6 +1146,52 @@ projectsApp.openapi(
     if (feature === 'llm_gateway') {
       void propagateLlmGatewayModeToActiveSandboxes(projectId, projectLlmGatewayEnabled(row.metadata));
     }
+    return c.json(serializeProject(row, { projectRole: loaded.projectRole, effectiveRole: loaded.effectiveRole }));
+  },
+);
+
+// PATCH /:projectId/sandbox-provider — set or clear the per-project sandbox-provider
+// pin (Customize → Settings). The value must be an ENABLED provider
+// (in ALLOWED_SANDBOX_PROVIDERS and with its API key configured), or null/'' to clear
+// (follow the platform default/distribution). Bypasses the distribution weights by
+// design — pin a project to platinum even when platinum's weight is 0. Same auth as
+// the experimental toggle (project 'manage' + project.customize.write for agents).
+projectsApp.openapi(
+  createRoute({
+    method: 'patch',
+    path: '/{projectId}/sandbox-provider',
+    tags: ['projects'],
+    summary: 'Set or clear the per-project sandbox provider override',
+    ...auth,
+    request: {
+      params: z.object({ projectId: z.string() }),
+      body: { content: { 'application/json': { schema: AnyObject } } },
+    },
+    responses: {
+      200: json(AnyObject, 'Updated project'),
+      ...errors(400, 401, 403, 404),
+    },
+  }),
+  async (c: any) => {
+    const projectId = c.req.param('projectId');
+    const body = await readBody(c);
+    const raw = body.provider ?? body.sandbox_provider;
+    const provider = raw === null || raw === undefined || raw === '' ? null : String(raw);
+    const loaded = await loadProjectForUser(c, projectId, 'manage');
+    if (!loaded) return c.json({ error: 'Not found' }, 404);
+    assertAgentScope(c, PROJECT_ACTIONS.PROJECT_CUSTOMIZE_WRITE);
+    if (provider !== null && !config.isProviderEnabled(provider as SandboxProviderName)) {
+      return c.json({ error: `Unknown or disabled sandbox provider: ${provider}` }, 400);
+    }
+    const meta: Record<string, unknown> = { ...((loaded.row.metadata as Record<string, unknown> | null) ?? {}) };
+    if (provider === null) delete meta.default_sandbox_provider;
+    else meta.default_sandbox_provider = provider;
+    const [row] = await db
+      .update(projects)
+      .set({ metadata: meta, updatedAt: new Date() })
+      .where(eq(projects.projectId, projectId))
+      .returning();
+    if (!row || row.status === 'archived') return c.json({ error: 'Not found' }, 404);
     return c.json(serializeProject(row, { projectRole: loaded.projectRole, effectiveRole: loaded.effectiveRole }));
   },
 );

--- a/apps/web/src/features/workspace/customize/sections/view/settings-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/settings-view.tsx
@@ -44,6 +44,7 @@ import {
   setProjectTriggersActivation,
   updateExperimentalFeature,
   updateProject,
+  updateProjectSandboxProvider,
   type ExperimentalFeatureView,
   type KortixProject,
   type ProjectDetail,
@@ -111,6 +112,7 @@ export function SettingsView({ projectId }: { projectId: string }) {
             </section>
           )}
           <ExperimentalCard project={project} canManage={!!canManage} />
+          <SandboxProviderCard project={project} canManage={!!canManage} />
           {canManage && (
             <section className="space-y-4">
               <Label>
@@ -368,6 +370,80 @@ function ExperimentalFeatureRow({
         onCheckedChange={(v) => mutation.mutate(v)}
       />
     </div>
+  );
+}
+
+// Per-project sandbox-provider pin. Overrides the platform's weighted distribution
+// for THIS project only — e.g. put one project on Platinum even when the fleet is
+// mostly Daytona. Options come from the project payload (`available_sandbox_providers`
+// = the enabled set), so the backend + UI agree without a separate providers call.
+// Self-hides when the platform exposes a single provider (nothing to choose).
+const AUTO_PROVIDER = '__auto__';
+function SandboxProviderCard({
+  project,
+  canManage,
+}: {
+  project: KortixProject;
+  canManage: boolean;
+}) {
+  const queryClient = useQueryClient();
+  const available = project.available_sandbox_providers ?? [];
+  const current = project.default_sandbox_provider ?? null;
+
+  const mutation = useMutation({
+    mutationFn: (next: string | null) => updateProjectSandboxProvider(project.project_id, next),
+    onSuccess: (updated) => {
+      queryClient.setQueryData(['project', project.project_id], updated);
+      queryClient.setQueryData<ProjectDetail | undefined>(
+        ['project-detail', project.project_id],
+        (c) => (c ? { ...c, project: updated } : c),
+      );
+      queryClient.invalidateQueries({ queryKey: ['project-detail', project.project_id] });
+      queryClient.invalidateQueries({ queryKey: ['projects'] });
+    },
+    onError: (error: Error) => errorToast(error.message || 'Failed to update sandbox provider'),
+  });
+
+  if (available.length < 2) return null;
+
+  const label = (p: string) => p.charAt(0).toUpperCase() + p.slice(1);
+
+  return (
+    <section className="space-y-4">
+      <Label>Sandbox provider</Label>
+      <div className="bg-popover flex items-center justify-between gap-4 rounded-md border px-4 py-3">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <p className="text-foreground text-sm font-medium">Provider</p>
+            <Badge variant="highlight" size="sm">
+              Experimental
+            </Badge>
+          </div>
+          <p className="text-muted-foreground mt-0.5 text-xs text-pretty">
+            Pin this project to a specific sandbox provider, overriding the platform
+            default. New sessions here run on the chosen provider — “Automatic”
+            follows the platform default.
+          </p>
+        </div>
+        <Select
+          value={current ?? AUTO_PROVIDER}
+          onValueChange={(v) => mutation.mutate(v === AUTO_PROVIDER ? null : v)}
+          disabled={!canManage || mutation.isPending}
+        >
+          <SelectTrigger className="w-40 shrink-0" variant="popover">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={AUTO_PROVIDER}>Automatic</SelectItem>
+            {available.map((p) => (
+              <SelectItem key={p} value={p}>
+                {label(p)}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+    </section>
   );
 }
 

--- a/apps/web/src/lib/projects-client.ts
+++ b/apps/web/src/lib/projects-client.ts
@@ -43,6 +43,11 @@ export interface KortixProject {
   experimental_features?: ExperimentalFeatureView[];
   /** Back-compat alias for `experimental.apps`. */
   apps_enabled?: boolean;
+  /** Per-project sandbox-provider pin (Customize → Settings).
+   *  null = follow the platform default/distribution. */
+  default_sandbox_provider?: string | null;
+  /** Enabled sandbox providers the picker offers (ALLOWED ∩ has-API-key). */
+  available_sandbox_providers?: string[];
 }
 
 export interface KortixAccount {
@@ -2661,6 +2666,20 @@ export async function updateExperimentalFeature(
     await backendApi.patch<KortixProject>(`/projects/${projectId}/experimental`, {
       feature,
       enabled,
+    }),
+  );
+}
+
+/** Set or clear the per-project sandbox-provider pin (Customize → Settings).
+ *  Pass `null` to clear (follow the platform default/distribution). The value must
+ *  be one of the project's `available_sandbox_providers`. */
+export async function updateProjectSandboxProvider(
+  projectId: string,
+  provider: string | null,
+) {
+  return unwrap(
+    await backendApi.patch<KortixProject>(`/projects/${projectId}/sandbox-provider`, {
+      provider,
     }),
   );
 }

--- a/packages/sdk/src/platform/projects-client/projects.ts
+++ b/packages/sdk/src/platform/projects-client/projects.ts
@@ -50,6 +50,11 @@ export interface KortixProject {
   warm_pool?: { enabled: boolean; size: number };
   /** Whether the warm pool feature is enabled platform-wide (gates the UI). */
   warm_pool_available?: boolean;
+  /** Per-project sandbox-provider pin (Customize → Settings). null = follow the
+   *  platform default/distribution. */
+  default_sandbox_provider?: string | null;
+  /** Enabled sandbox providers the picker offers (ALLOWED ∩ has-API-key). */
+  available_sandbox_providers?: string[];
 }
 
 export interface ProjectConfigSummary {
@@ -222,6 +227,20 @@ export async function updateExperimentalFeature(
     await backendApi.patch<KortixProject>(`/projects/${projectId}/experimental`, {
       feature,
       enabled,
+    }),
+  );
+}
+
+/** Set or clear the per-project sandbox-provider pin (Customize → Settings).
+ *  Pass `null` to clear (follow the platform default/distribution). The value must
+ *  be one of the project's `available_sandbox_providers`. */
+export async function updateProjectSandboxProvider(
+  projectId: string,
+  provider: string | null,
+) {
+  return unwrap(
+    await backendApi.patch<KortixProject>(`/projects/${projectId}/sandbox-provider`, {
+      provider,
     }),
   );
 }


### PR DESCRIPTION
## Per-project sandbox-provider override

Pin **one project** to a specific sandbox provider (e.g. Platinum) from **Customize → Settings**, overriding the platform's weighted provider distribution for that project only. Honored as long as the provider is **enabled** (in `ALLOWED_SANDBOX_PROVIDERS` with its API key) — so you can put a project on Platinum even when the fleet default is Daytona, or Platinum is weight-0 in the distribution. Greenfield — no per-project provider control existed before.

### How it works
Precedence at session create (`createProjectSession`): **explicit `body.provider` › per-project pin › weighted balancer** (`selectProvider()`). A stale/disabled pin is silently ignored — never a hard create failure. It gates on *allowed + enabled*, **not** weight, which is what bypasses the distribution.

Storage: a new key on the existing `projects.metadata` jsonb (`default_sandbox_provider`) — **no migration**.

### Changes
**Backend** (`apps/api`)
- `provider-precedence.ts` *(new)* — pure, dependency-injected `resolveSessionProvider()`.
- `sessions.ts` — wired into the single create funnel.
- `r6.ts` — `PATCH /projects/:id/sandbox-provider` (set/clear; `isProviderEnabled` → 400; `manage` + `customize.write` auth, mirroring `/experimental`).
- `serializers.ts` — `default_sandbox_provider` (gated on `isProviderEnabled` so a disabled pin shows as Automatic) + `available_sandbox_providers` on the project payload — the picker's options without a separate (billing-gated) providers route.
- `sessions.provider.test.ts` *(new)* — **7/7** precedence tests.

**Frontend + SDK**
- `apps/web` — `projects-client.ts` types + mutation; `settings-view.tsx` `SandboxProviderCard` picker (self-hides when < 2 providers are usable).
- `packages/sdk` — `KortixProject` fields + `updateProjectSandboxProvider()` (parity with the `/experimental` route).

Mobile client intentionally omitted — no per-project provider UI there.

### Testing
- Precedence unit test: **7/7**.
- Backend + SDK `tsc`: clean for all touched files.
- Adversarial multi-dimension audit (backend integration, frontend, no-slop, edge/security, completeness), each finding independently verified: **0 logic bugs**; the confirmed polish/parity items are fixed in this branch.
- The web `tsc` couldn't run in the throwaway worktree (path-alias resolution gap that also errors untouched code) — CI is the typecheck gate there; the UI is a faithful copy of the existing experimental-toggle + repo-collaborator `<Select>` patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)