### PR TITLE
fix(web): render footer copyright symbol

### DIFF
--- a/apps/web/translations/en.json
+++ b/apps/web/translations/en.json
@@ -7333,7 +7333,7 @@
     "autoComponentsHomeDevelopersRepoBrowserJsxTextYourCompanyAse8329445": "your company, as a git repo",
     "autoComponentsHomeDevelopersRepoBrowserJsxTextReadOnlyd13e142f": "read only",
     "autoComponentsHomeFooterJsxText4e1e5394": " ↗",
-    "autoComponentsHomeFooterJsxTextCopye99743e8": "&copy;",
+    "autoComponentsHomeFooterJsxTextCopye99743e8": "©",
     "autoComponentsHomeInteractiveDemoChatChatTurnJsxTextJust8e271ae4": "just now",
     "autoComponentsHomeInteractiveDemoChatComposerJsxTextClaudeOpusf5c492d2": "Claude Opus 4.8",
     "autoComponentsHomeInteractiveDemoChatScenariosJsxAttrMeta125fff632b": "12 slides · ready in 4 min",


### PR DESCRIPTION
## Summary
- Replace the English footer copyright translation from the HTML entity text to the literal © glyph.
- Keeps English consistent with the other locales so React renders the symbol instead of the raw HTML entity.

## Verification
- Node assertion: footer translation value is exactly ©.
- pnpm --filter Kortix-Computer-Frontend exec prettier --check translations/en.json src/components/home/footer.tsx
- pnpm --filter Kortix-Computer-Frontend exec eslint src/components/home/footer.tsx
- Local browser verification with agent-browser: #site-footer contains ©2026 Kortix and does not contain the raw HTML entity.