### PR TITLE
feat(iam): self-serve enterprise demo toggle

### DIFF
--- a/apps/api/src/__tests__/unit-entitlements-demo.test.ts
+++ b/apps/api/src/__tests__/unit-entitlements-demo.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, mock, test } from 'bun:test';
+
+// Stub the credit-account repo before loading the resolver, so we exercise the
+// demo-override branch without a database. `fakeRow` stands in for the row that
+// getCreditAccount() would return.
+let fakeRow: { tier?: string; demoEnterprise?: boolean } | null = null;
+mock.module('../billing/repositories/credit-accounts', () => ({
+  getCreditAccount: async () => fakeRow,
+}));
+
+const { accountHasEntitlement, getAccountEntitlements } = await import(
+  '../billing/services/entitlements'
+);
+
+// The self-serve enterprise-demo flag must unlock the ENTIRE enterprise surface
+// regardless of billing tier, stay fail-closed when off / unprovisioned, and
+// never suppress a genuine enterprise tier. These invariants ARE the demo's
+// access-control contract (the IAM guards call accountHasEntitlement).
+describe('enterprise-demo entitlement override', () => {
+  test('demo on → every entitlement unlocked even on the free tier', async () => {
+    fakeRow = { tier: 'free', demoEnterprise: true };
+    expect(await accountHasEntitlement('acct', 'sso')).toBe(true);
+    expect(await accountHasEntitlement('acct', 'scim')).toBe(true);
+    const ent = await getAccountEntitlements('acct');
+    expect(ent.sso).toBe(true);
+    expect(ent.scim).toBe(true);
+  });
+
+  test('demo off → falls back to tier gating (free is fully gated)', async () => {
+    fakeRow = { tier: 'free', demoEnterprise: false };
+    expect(await accountHasEntitlement('acct', 'sso')).toBe(false);
+    expect((await getAccountEntitlements('acct')).sso).toBe(false);
+  });
+
+  test('no billing row → fail closed', async () => {
+    fakeRow = null;
+    expect(await accountHasEntitlement('acct', 'sso')).toBe(false);
+    expect((await getAccountEntitlements('acct')).scim).toBe(false);
+  });
+
+  test('genuine enterprise tier still unlocks without the demo flag', async () => {
+    fakeRow = { tier: 'enterprise', demoEnterprise: false };
+    expect(await accountHasEntitlement('acct', 'sso')).toBe(true);
+    expect((await getAccountEntitlements('acct')).scim).toBe(true);
+  });
+});

--- a/apps/api/src/accounts/iam.ts
+++ b/apps/api/src/accounts/iam.ts
@@ -28,6 +28,7 @@ import './iam/members'; // super-admin, member groups / project-access / effecti
 import './iam/mfa'; // account-wide MFA enforcement
 import './iam/scim-tokens'; // SCIM provisioning tokens
 import './iam/sso'; // SAML SSO provider + group mappings
+import './iam/enterprise-demo'; // self-serve enterprise-preview toggle
 import './iam/policies'; // session policy, active sessions / revoke, PAT policy
 import './iam/service-accounts'; // service accounts (non-human IAM principals)
 import './iam/custom-roles'; // IAM v1: custom roles + action sets + principal→role policies

--- a/apps/api/src/accounts/iam/enterprise-demo.ts
+++ b/apps/api/src/accounts/iam/enterprise-demo.ts
@@ -1,0 +1,82 @@
+// IAM V2 route: the self-serve **enterprise demo** toggle.
+//
+// Enterprise features (SSO, SCIM, …) are normally gated behind the sales-
+// assigned `enterprise` tier (see requireEntitlement + tiers.ts). This toggle
+// lets any account member flip on an interactive PREVIEW of that surface for
+// their own account — no sales contact, no billing change — so prospects can
+// feel the enterprise features and we can dogfood them in development.
+//
+// Deliberately NOT behind requireEntitlement: unlocking the demo is the whole
+// point. It is fail-closed (default off) and clearly labelled a demo in the UI;
+// real production use still requires a signed Enterprise agreement.
+
+import { createRoute, z } from '@hono/zod-openapi';
+import { json, errors, auth } from '../../openapi';
+import { ACCOUNT_ACTIONS, assertAuthorized } from '../../iam';
+import { isDemoEnterprise, setDemoEnterprise } from '../../billing/repositories/credit-accounts';
+import { iamRouter, AccountIdParam } from './app';
+import { auditIam, readBody } from './helpers';
+
+const DemoStateSchema = z.object({ enabled: z.boolean() }).openapi('EnterpriseDemoState');
+
+iamRouter.openapi(
+  createRoute({
+    method: 'get',
+    path: '/{accountId}/iam/enterprise-demo',
+    tags: ['iam'],
+    summary: 'Get the enterprise-demo toggle state',
+    ...auth,
+    request: { params: AccountIdParam },
+    responses: {
+      200: json(DemoStateSchema, 'Whether the enterprise demo is enabled'),
+      ...errors(401, 403),
+    },
+  }),
+  async (c: any) => {
+    const userId = c.get('userId') as string;
+    const accountId = c.req.param('accountId');
+    await assertAuthorized(userId, accountId, ACCOUNT_ACTIONS.ACCOUNT_READ);
+    return c.json({ enabled: await isDemoEnterprise(accountId) });
+  },
+);
+
+iamRouter.openapi(
+  createRoute({
+    method: 'put',
+    path: '/{accountId}/iam/enterprise-demo',
+    tags: ['iam'],
+    summary: 'Enable or disable the enterprise demo for the account',
+    ...auth,
+    request: {
+      params: AccountIdParam,
+      body: { content: { 'application/json': { schema: DemoStateSchema } } },
+    },
+    responses: {
+      200: json(DemoStateSchema, 'The updated state'),
+      ...errors(400, 401, 403),
+    },
+  }),
+  async (c: any) => {
+    const userId = c.get('userId') as string;
+    const accountId = c.req.param('accountId');
+    await assertAuthorized(userId, accountId, ACCOUNT_ACTIONS.ACCOUNT_WRITE);
+
+    const body = await readBody(c);
+    if (typeof body.enabled !== 'boolean') {
+      return c.json({ error: 'enabled must be a boolean' }, 400);
+    }
+
+    const before = await isDemoEnterprise(accountId);
+    await setDemoEnterprise(accountId, body.enabled);
+    await auditIam(c, {
+      accountId,
+      action: body.enabled ? 'enterprise_demo.enable' : 'enterprise_demo.disable',
+      resourceType: 'account',
+      resourceId: accountId,
+      before: { enabled: before },
+      after: { enabled: body.enabled },
+    });
+
+    return c.json({ enabled: body.enabled });
+  },
+);

--- a/apps/api/src/billing/repositories/credit-accounts.ts
+++ b/apps/api/src/billing/repositories/credit-accounts.ts
@@ -12,6 +12,31 @@ export async function getCreditAccount(accountId: string) {
   return row ?? null;
 }
 
+/** Whether the account has the self-serve enterprise demo toggled on. */
+export async function isDemoEnterprise(accountId: string): Promise<boolean> {
+  const [row] = await db
+    .select({ demoEnterprise: creditAccounts.demoEnterprise })
+    .from(creditAccounts)
+    .where(eq(creditAccounts.accountId, accountId))
+    .limit(1);
+  return row?.demoEnterprise ?? false;
+}
+
+/**
+ * Flip the enterprise-demo flag. Upserts the credit row so a brand-new account
+ * (no billing row yet) can still preview the enterprise surface — all other
+ * columns fall back to their schema defaults (tier 'free', legacy billing, …).
+ */
+export async function setDemoEnterprise(accountId: string, enabled: boolean): Promise<void> {
+  await db
+    .insert(creditAccounts)
+    .values({ accountId, demoEnterprise: enabled })
+    .onConflictDoUpdate({
+      target: creditAccounts.accountId,
+      set: { demoEnterprise: enabled, updatedAt: new Date().toISOString() },
+    });
+}
+
 export async function getCreditBalance(accountId: string) {
   const [row] = await db
     .select({

--- a/apps/api/src/billing/services/entitlements.ts
+++ b/apps/api/src/billing/services/entitlements.ts
@@ -37,7 +37,14 @@ export async function getCachedAccountTier(accountId: string): Promise<string> {
 
 /** The full enterprise entitlement set for an account. */
 export async function getAccountEntitlements(accountId: string): Promise<TierEntitlements> {
-  return getTierEntitlements(await getAccountTier(accountId));
+  const acct = await getCreditAccount(accountId);
+  // Demo/dogfood override: an account can self-enable an interactive demo of the
+  // enterprise surface from account settings. When on, it unlocks EVERY
+  // enterprise entitlement — whatever the `enterprise` tier grants — regardless
+  // of billing tier, so gates added later are covered automatically. This is a
+  // preview, NOT a real Enterprise plan (which is sales-assigned).
+  if (acct?.demoEnterprise) return getTierEntitlements('enterprise');
+  return getTierEntitlements(acct?.tier ?? 'none');
 }
 
 /** Whether an account's plan unlocks a specific enterprise feature. */
@@ -45,5 +52,7 @@ export async function accountHasEntitlement(
   accountId: string,
   key: keyof TierEntitlements,
 ): Promise<boolean> {
-  return tierHasEntitlement(await getAccountTier(accountId), key);
+  const acct = await getCreditAccount(accountId);
+  if (acct?.demoEnterprise) return true;
+  return tierHasEntitlement(acct?.tier ?? 'none', key);
 }

--- a/apps/web/src/app/(app)/accounts/[id]/page.tsx
+++ b/apps/web/src/app/(app)/accounts/[id]/page.tsx
@@ -33,6 +33,7 @@ import { MfaRequiredCard } from '@/components/iam/mfa-required-card';
 import { PatPolicyCard } from '@/components/iam/pat-policy-card';
 import { PermissionsHelpPopover } from '@/components/iam/permissions-help-popover';
 import { RolesTab } from '@/components/iam/roles-tab';
+import { EnterpriseDemoCard } from '@/components/iam/enterprise-demo-card';
 import { ScimCard } from '@/components/iam/scim-card';
 import { ServiceAccountsCard } from '@/components/iam/service-accounts-card';
 import { SessionControlsCard } from '@/components/iam/session-controls-card';
@@ -450,6 +451,10 @@ export default function AccountSettingsPage() {
                       'autoAppAppAccountsIdPageJsxAttrDescriptionBringMembersa0baf40c',
                     )}
                   >
+                    <EnterpriseDemoCard
+                      accountId={account.account_id}
+                      canManage={canWriteAccount}
+                    />
                     <SsoCard accountId={account.account_id} canManage={canWriteAccount} />
                     <ScimCard accountId={account.account_id} canManage={canWriteAccount} />
                   </SettingsGroup>

--- a/apps/web/src/components/iam/enterprise-demo-card.tsx
+++ b/apps/web/src/components/iam/enterprise-demo-card.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+// Self-serve "enterprise demo" toggle. Enterprise features (SSO, SCIM, …) are
+// normally sales-assigned via the enterprise tier; this switch lets any account
+// admin flip on an interactive PREVIEW of the whole surface — no sales contact,
+// no billing change — so prospects can evaluate it and we can dogfood in dev.
+// It is explicitly a demo: real production use still requires a signed
+// Enterprise agreement (the "Request access" link below).
+
+import { toast } from '@/lib/toast';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { FlaskConical } from 'lucide-react';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Switch } from '@/components/ui/switch';
+import { getEnterpriseDemo, setEnterpriseDemo } from '@/lib/iam-client';
+
+const REQUEST_ACCESS_HREF =
+  'mailto:marko@kortix.ai?subject=Kortix%20Enterprise%20—%20access%20request';
+
+interface EnterpriseDemoCardProps {
+  accountId: string;
+  canManage: boolean;
+}
+
+export function EnterpriseDemoCard({ accountId, canManage }: EnterpriseDemoCardProps) {
+  const queryClient = useQueryClient();
+
+  const stateQuery = useQuery({
+    queryKey: ['iam-enterprise-demo', accountId],
+    queryFn: () => getEnterpriseDemo(accountId),
+    staleTime: 30_000,
+  });
+
+  const toggleMutation = useMutation({
+    mutationFn: (enabled: boolean) => setEnterpriseDemo(accountId, enabled),
+    onSuccess: (enabled) => {
+      toast.success(enabled ? 'Enterprise demo enabled' : 'Enterprise demo disabled');
+      // Entitlements changed — refresh the enterprise cards that gate on them.
+      queryClient.invalidateQueries({ queryKey: ['iam-enterprise-demo', accountId] });
+      queryClient.invalidateQueries({ queryKey: ['iam-sso-provider', accountId] });
+      queryClient.invalidateQueries({ queryKey: ['iam-scim', accountId] });
+    },
+    onError: (err: Error) => toast.error(err.message || 'Failed to update the demo'),
+  });
+
+  const enabled = stateQuery.data ?? false;
+
+  return (
+    <section className="border-border/70 bg-card rounded-xl border">
+      <header className="px-6 py-4">
+        <div className="flex items-center justify-between gap-3">
+          <div className="min-w-0">
+            <h2 className="text-foreground flex items-center gap-2 text-base font-semibold">
+              <FlaskConical className="text-muted-foreground h-4 w-4" />
+              Enterprise features
+              <Badge
+                variant="outline"
+                size="sm"
+                className="border-amber-500/40 bg-amber-500/10 text-[10px] font-normal text-amber-700 dark:text-amber-300"
+              >
+                demo
+              </Badge>
+            </h2>
+            <p className="text-muted-foreground mt-0.5 max-w-prose text-xs">
+              Turn on an interactive preview of the enterprise surface — SSO, SCIM, advanced RBAC,
+              and audit logs — for this account. This is an evaluation demo, not a production plan.
+            </p>
+          </div>
+          {stateQuery.isLoading ? (
+            <Skeleton className="h-6 w-11 shrink-0 rounded-full" />
+          ) : (
+            <Switch
+              checked={enabled}
+              disabled={!canManage || toggleMutation.isPending}
+              onCheckedChange={(next) => toggleMutation.mutate(next)}
+              aria-label="Toggle enterprise features demo"
+              className="shrink-0"
+            />
+          )}
+        </div>
+
+        <div className="border-border/60 mt-4 border-t pt-3">
+          <p className="text-muted-foreground text-xs">
+            For real enterprise use — production SLA, DPA, and support — you must talk to us to
+            upgrade to the Enterprise plan.
+          </p>
+          <Button asChild variant="outline" size="sm" className="mt-3">
+            <a href={REQUEST_ACCESS_HREF}>Request enterprise access</a>
+          </Button>
+        </div>
+      </header>
+    </section>
+  );
+}

--- a/apps/web/src/lib/iam-client.ts
+++ b/apps/web/src/lib/iam-client.ts
@@ -1481,3 +1481,22 @@ export async function probeEffectivePermissions(
     ),
   ).results;
 }
+
+// ─── Enterprise demo toggle ───────────────────────────────────────────────
+// Self-serve preview of the enterprise surface (SSO, SCIM, …). Backed by
+// GET/PUT /accounts/:id/iam/enterprise-demo. Off by default; flipping it on
+// unlocks the enterprise features for evaluation — NOT a real Enterprise plan.
+
+export async function getEnterpriseDemo(accountId: string): Promise<boolean> {
+  return unwrap(
+    await backendApi.get<{ enabled: boolean }>(`/accounts/${accountId}/iam/enterprise-demo`),
+  ).enabled;
+}
+
+export async function setEnterpriseDemo(accountId: string, enabled: boolean): Promise<boolean> {
+  return unwrap(
+    await backendApi.put<{ enabled: boolean }>(`/accounts/${accountId}/iam/enterprise-demo`, {
+      enabled,
+    }),
+  ).enabled;
+}

--- a/packages/db/migrations/20260701201651600_demo-enterprise-flag.sql
+++ b/packages/db/migrations/20260701201651600_demo-enterprise-flag.sql
@@ -1,0 +1,16 @@
+-- Up Migration
+--
+-- Self-serve "enterprise demo" flag on credit_accounts. When true, the account
+-- resolves ALL enterprise entitlements (SSO, SCIM, …) regardless of billing
+-- tier — an interactive preview of the enterprise surface, toggled by any
+-- account member from settings (PUT /v1/accounts/:id/iam/enterprise-demo).
+-- Default false → existing accounts are unaffected and it fails closed. NOT a
+-- real Enterprise plan (that stays sales-assigned via credit_accounts.tier).
+
+ALTER TABLE "kortix"."credit_accounts"
+  ADD COLUMN "demo_enterprise" boolean NOT NULL DEFAULT false;
+
+-- Down Migration
+
+ALTER TABLE "kortix"."credit_accounts"
+  DROP COLUMN "demo_enterprise";

--- a/packages/db/src/schema/kortix.ts
+++ b/packages/db/src/schema/kortix.ts
@@ -1931,6 +1931,11 @@ export const creditAccounts = kortixSchema.table(
     autoTopupCustomized: boolean('auto_topup_customized').default(false).notNull(),
     autoTopupConsecutiveFailures: integer('auto_topup_consecutive_failures').default(0).notNull(),
     autoTopupDisabledReason: text('auto_topup_disabled_reason'),
+    // Demo/dogfood flag: when true the account gets ALL enterprise entitlements
+    // (SSO, SCIM, …) regardless of tier — a self-serve, interactive preview of
+    // the enterprise surface. NOT a real Enterprise plan (sales-assigned);
+    // production use requires a signed agreement. Default false → fail-closed.
+    demoEnterprise: boolean('demo_enterprise').default(false).notNull(),
   },
   (table) => [
     index('kortix_credit_accounts_account_id_idx').on(table.accountId),


### PR DESCRIPTION
## What

Adds a per-account **enterprise demo** toggle. Enterprise features (SSO, SCIM, and RBAC/audit as they land) are normally sales-assigned via the `enterprise` tier; this lets any account admin flip on an **interactive preview** of the whole surface from **account settings → IAM** — no sales contact, no billing change.

Purpose: let prospects *feel* the enterprise features before a sales call, and make dogfooding easier in dev.

## How

- **DB:** `credit_accounts.demo_enterprise boolean default false` + migration. Additive, fail-closed — existing accounts unaffected.
- **Resolver:** `accountHasEntitlement()` / `getAccountEntitlements()` return true / the full enterprise set when the flag is on, regardless of tier. Single chokepoint, so any entitlement added later is covered automatically.
- **Route:** self-serve `GET` / `PUT /v1/accounts/:id/iam/enterprise-demo` — audited, deliberately **not** behind `requireEntitlement` (unlocking the demo is the point).
- **Web:** `EnterpriseDemoCard` on the account IAM page (Switch + `demo` badge + "Request enterprise access" → sales).

## Not a real plan

The card states production use (SLA, DPA, support) requires talking to sales; the genuine Enterprise plan stays sales-assigned via `credit_accounts.tier`.

## Tests / verification

- Unit: `unit-entitlements-demo.test.ts` — 4/4 (on unlocks all; off & no-row fail closed; real enterprise tier unaffected).
- `tsc` clean across `@kortix/db`, `apps/api`, `apps/web`.
- Migration SQL validated against the live schema (BEGIN…ROLLBACK).

## Note

Local `pnpm migrate` couldn't apply against the shared dev DB due to **pre-existing** migration-order drift unrelated to this change; the migration is the latest timestamp and applies cleanly on an ordered ledger (CI / fresh DB).
