### PR TITLE
refactor(sdk): isomorphic core — remove use-client/next coupling from root entry

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,9 +1,9 @@
 import { BrowserNoiseGuard } from '@/components/browser-noise-guard';
-import { KortixProjectScope } from '@/components/kortix-project-scope';
 import { DesktopChrome } from '@/components/desktop/desktop-chrome';
 import { DesktopUrlPrompt } from '@/components/desktop/desktop-url-prompt';
 import { ThemeProvider } from '@/components/home/theme-provider';
 import { I18nProvider } from '@/components/i18n-provider';
+import { KortixProjectScope } from '@/components/kortix-project-scope';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import { AuthProvider } from '@/features/providers/auth-provider';
 import { DESKTOP_INIT_SCRIPT, DESKTOP_UA_TOKEN } from '@/lib/desktop';

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import { BrowserNoiseGuard } from '@/components/browser-noise-guard';
+import { KortixProjectScope } from '@/components/kortix-project-scope';
 import { DesktopChrome } from '@/components/desktop/desktop-chrome';
 import { DesktopUrlPrompt } from '@/components/desktop/desktop-url-prompt';
 import { ThemeProvider } from '@/components/home/theme-provider';
@@ -376,7 +377,7 @@ export default async function RootLayout({ children }: Readonly<{ children: Reac
                 <DesktopUrlPrompt />
                 <ReactQueryProvider>
                   <Toaster />
-                  {children}
+                  <KortixProjectScope>{children}</KortixProjectScope>
                   {/* Global maintenance/incident banner (info/warning/critical).
                       Needs the query client, so it mounts inside ReactQueryProvider. */}
                   <Suspense fallback={null}>

--- a/apps/web/src/components/kortix-project-scope.tsx
+++ b/apps/web/src/components/kortix-project-scope.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import { KortixProjectProvider } from '@kortix/sdk/react';
+import { useParams } from 'next/navigation';
+
+/**
+ * Bridges Next's router into the router-agnostic SDK: derives the route's
+ * project id the same way the hooks did when they read `useParams()` themselves
+ * (any `[id]` segment), and injects it once for the whole app.
+ */
+export function KortixProjectScope({ children }: { children: React.ReactNode }) {
+  const params = useParams();
+  const projectId = typeof params?.id === 'string' ? params.id : null;
+  return <KortixProjectProvider projectId={projectId}>{children}</KortixProjectProvider>;
+}

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -19,12 +19,10 @@
   },
   "peerDependencies": {
     "@tanstack/react-query": "^5.75.2",
-    "next": ">=15",
     "react": ">=18"
   },
   "peerDependenciesMeta": {
     "@tanstack/react-query": { "optional": true },
-    "next": { "optional": true },
     "react": { "optional": true }
   },
   "main": "./src/index.ts",

--- a/packages/sdk/src/files/client.ts
+++ b/packages/sdk/src/files/client.ts
@@ -8,7 +8,7 @@
  * consume `readBlob`/`list` from here.
  */
 import { getClient } from '../opencode/client';
-import { getActiveOpenCodeUrl } from '../state/server-store';
+import { getActiveOpenCodeUrl } from '../state/server-store/active';
 import { getAuthToken, authenticatedFetch } from '../platform/auth';
 import type {
   FileContent,

--- a/packages/sdk/src/index.isomorphic.test.ts
+++ b/packages/sdk/src/index.isomorphic.test.ts
@@ -1,0 +1,88 @@
+import { expect, test } from 'bun:test';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+
+/**
+ * Isomorphic-core tripwire. The root `.` export is the SDK's framework-free
+ * surface — mobile, CLI, and server hosts load it outside any React/Next
+ * context. Two guards:
+ *   1. Static: walk the root entry's full import graph; no module may import
+ *      react/next/zustand/react-query (even type-only — a type import still
+ *      forces the dependency on every consumer's typecheck) or carry a
+ *      'use client' directive.
+ *   2. Runtime: the entry imports in plain bun and `createKortix` constructs.
+ */
+
+const FORBIDDEN_MODULES = ['react', 'react-dom', 'next', 'zustand', '@tanstack/react-query'];
+
+const SRC_ROOT = join(import.meta.dir);
+
+function resolveRelative(fromFile: string, spec: string): string | null {
+  const base = resolve(dirname(fromFile), spec);
+  for (const candidate of [base + '.ts', base + '.tsx', join(base, 'index.ts'), join(base, 'index.tsx')]) {
+    if (existsSync(candidate)) return candidate;
+  }
+  return existsSync(base) ? base : null;
+}
+
+function collectRootGraph(): { files: string[]; externals: Map<string, string[]> } {
+  const seen = new Set<string>();
+  const externals = new Map<string, string[]>();
+  const importRe =
+    /(?:import|export)\s[^'"]*?from\s*['"]([^'"]+)['"]|import\s*\(\s*['"]([^'"]+)['"]\s*\)|require\(\s*['"]([^'"]+)['"]\s*\)/g;
+
+  function walk(file: string) {
+    if (seen.has(file)) return;
+    seen.add(file);
+    const source = readFileSync(file, 'utf8');
+    for (const match of source.matchAll(importRe)) {
+      const spec = match[1] ?? match[2] ?? match[3];
+      if (!spec) continue;
+      if (spec.startsWith('.')) {
+        const resolved = resolveRelative(file, spec);
+        expect(resolved).not.toBeNull();
+        if (resolved) walk(resolved);
+      } else {
+        const importers = externals.get(spec) ?? [];
+        importers.push(file.slice(SRC_ROOT.length + 1));
+        externals.set(spec, importers);
+      }
+    }
+  }
+
+  walk(join(SRC_ROOT, 'index.ts'));
+  return { files: [...seen], externals };
+}
+
+test('root export graph pulls no react/next/zustand/react-query code', () => {
+  const { externals } = collectRootGraph();
+  for (const [spec, importers] of externals) {
+    const forbidden = FORBIDDEN_MODULES.find((m) => spec === m || spec.startsWith(`${m}/`));
+    expect(
+      forbidden ? `"${spec}" imported by ${importers.join(', ')}` : null,
+    ).toBeNull();
+  }
+});
+
+test("root export graph has no 'use client' directives", () => {
+  const { files } = collectRootGraph();
+  for (const file of files) {
+    const head = readFileSync(file, 'utf8').trimStart();
+    const hasDirective = head.startsWith(`'use client'`) || head.startsWith(`"use client"`);
+    expect(hasDirective ? `'use client' in ${file.slice(SRC_ROOT.length + 1)}` : null).toBeNull();
+  }
+});
+
+test('root entry loads and createKortix constructs outside React', async () => {
+  const sdk = await import('./index');
+  const kortix = sdk.createKortix({
+    backendUrl: 'http://isomorphic.test/v1',
+    getToken: async () => null,
+  });
+  expect(typeof kortix.projects.list).toBe('function');
+  expect(typeof kortix.project('p').secrets.upsert).toBe('function');
+  const session = kortix.session('p', 's');
+  expect(typeof session.send).toBe('function');
+  expect(typeof session.health).toBe('function');
+  expect(session.previewUrl(3000)).toContain('3000');
+});

--- a/packages/sdk/src/index.isomorphic.test.ts
+++ b/packages/sdk/src/index.isomorphic.test.ts
@@ -19,7 +19,12 @@ const SRC_ROOT = join(import.meta.dir);
 
 function resolveRelative(fromFile: string, spec: string): string | null {
   const base = resolve(dirname(fromFile), spec);
-  for (const candidate of [base + '.ts', base + '.tsx', join(base, 'index.ts'), join(base, 'index.tsx')]) {
+  for (const candidate of [
+    `${base}.ts`,
+    `${base}.tsx`,
+    join(base, 'index.ts'),
+    join(base, 'index.tsx'),
+  ]) {
     if (existsSync(candidate)) return candidate;
   }
   return existsSync(base) ? base : null;
@@ -58,9 +63,7 @@ test('root export graph pulls no react/next/zustand/react-query code', () => {
   const { externals } = collectRootGraph();
   for (const [spec, importers] of externals) {
     const forbidden = FORBIDDEN_MODULES.find((m) => spec === m || spec.startsWith(`${m}/`));
-    expect(
-      forbidden ? `"${spec}" imported by ${importers.join(', ')}` : null,
-    ).toBeNull();
+    expect(forbidden ? `"${spec}" imported by ${importers.join(', ')}` : null).toBeNull();
   }
 });
 

--- a/packages/sdk/src/kortix.ts
+++ b/packages/sdk/src/kortix.ts
@@ -1,4 +1,3 @@
-'use client';
 import type { OpencodeClient } from '@opencode-ai/sdk/v2/client';
 import { getClient } from './opencode/client';
 /**
@@ -22,7 +21,8 @@ import { type KortixPlatformConfig, configureKortix } from './platform/config';
 import * as P from './platform/projects-client';
 import { getSessionHealth } from './session/health';
 import { type SubdomainUrlOptions, proxyLocalhostUrl, rewriteLocalhostUrl } from './session/url';
-import { getActiveSandboxId, getSandboxUrlForExternalId } from './state/server-store';
+import { getActiveSandboxId } from './state/server-store/active';
+import { getSandboxUrlForExternalId } from './state/server-store/url-helpers';
 import { setCurrentRuntime } from './state/current-runtime';
 
 /** A model the agent can run, as the opencode runtime identifies it. */

--- a/packages/sdk/src/kortix.ts
+++ b/packages/sdk/src/kortix.ts
@@ -21,9 +21,9 @@ import { type KortixPlatformConfig, configureKortix } from './platform/config';
 import * as P from './platform/projects-client';
 import { getSessionHealth } from './session/health';
 import { type SubdomainUrlOptions, proxyLocalhostUrl, rewriteLocalhostUrl } from './session/url';
+import { setCurrentRuntime } from './state/current-runtime';
 import { getActiveSandboxId } from './state/server-store/active';
 import { getSandboxUrlForExternalId } from './state/server-store/url-helpers';
-import { setCurrentRuntime } from './state/current-runtime';
 
 /** A model the agent can run, as the opencode runtime identifies it. */
 export type SessionModel = { providerID: string; modelID: string };

--- a/packages/sdk/src/opencode/client.ts
+++ b/packages/sdk/src/opencode/client.ts
@@ -24,7 +24,7 @@ export type { OpencodeClient };
 
 import { authenticatedFetch } from "../platform/auth";
 import { platformConfig } from "../platform/config";
-import { getActiveOpenCodeUrl } from "../state/server-store";
+import { getActiveOpenCodeUrl } from "../state/server-store/active";
 
 
 /**

--- a/packages/sdk/src/platform/projects-client/session-sandbox.ts
+++ b/packages/sdk/src/platform/projects-client/session-sandbox.ts
@@ -1,7 +1,5 @@
 // Session sandbox — runtime sandbox row + the session-open (/start) flow.
 
-import type { QueryClient } from '@tanstack/react-query';
-
 import { backendApi } from '../api-client';
 
 // ---------------------------------------------------------------------------
@@ -86,23 +84,4 @@ export async function startProjectSession(
  */
 export function sessionStartKey(projectId: string, sessionId: string) {
   return ['session-start', projectId, sessionId] as const;
-}
-
-/**
- * Begin the session runtime boot DURING the route transition (before the session
- * page mounts), so provisioning overlaps navigation instead of starting after the
- * page paints. Idempotent + fire-and-forget: React Query dedupes against the
- * session page's own query (same key), and `/start` is idempotent server-side.
- * Also warms the route bundle. Use at every createProjectSession→navigate site.
- */
-export function prefetchSessionStart(
-  queryClient: QueryClient,
-  projectId: string,
-  sessionId: string,
-): void {
-  void queryClient.prefetchQuery({
-    queryKey: sessionStartKey(projectId, sessionId),
-    queryFn: () => startProjectSession(projectId, sessionId),
-    staleTime: 0,
-  });
 }

--- a/packages/sdk/src/react/opencode.ts
+++ b/packages/sdk/src/react/opencode.ts
@@ -81,7 +81,12 @@ export type { ProjectConfigSummary } from '../platform/projects-client';
 // host never touches the sandbox. The primitives below are what it composes —
 // also exported standalone for hosts that want the pieces (a model picker, a boot
 // pill, the new-session hand-off) without a full session.
-export { useSession, type SessionPhase, type UseSessionResult, type UseSessionOptions } from './use-session';
+export {
+  useSession,
+  type SessionPhase,
+  type UseSessionResult,
+  type UseSessionOptions,
+} from './use-session';
 export { useSessionPicks, type SessionPicks } from './use-session-picks';
 export { useRuntimePhase, type RuntimePhase } from './use-runtime-phase';
 export {

--- a/packages/sdk/src/react/opencode.ts
+++ b/packages/sdk/src/react/opencode.ts
@@ -31,6 +31,10 @@
 // migration lands they come out of the public surface. New hosts: do not import
 // them — use `useSession`.
 // ─────────────────────────────────────────────────────────────────────────────
+// Router-agnostic route scope: the host injects "the project the user is
+// looking at" here (Next hosts derive it from useParams once, near the root);
+// `useOpenCodeProviders`/`useOpenCodeLocal` resolve it via this context.
+export { KortixProjectProvider, useKortixRouteProjectId } from './route-project';
 export * from './use-opencode-sessions';
 export * from './use-opencode-events';
 export * from './use-opencode-local';
@@ -54,6 +58,9 @@ export {
   type SandboxConnectionStatus,
 } from '../state/sandbox-connection-store';
 export * from './use-session-prefetch';
+// Relocated from `platform/projects-client/session-sandbox` — it types against
+// react-query's QueryClient, which the framework-free REST layer must not.
+export { prefetchSessionStart } from './prefetch-session-start';
 export * from './use-canonical-opencode-session';
 export * from './use-gateway-catalog-sync';
 export * from './use-visible-agents';

--- a/packages/sdk/src/react/prefetch-session-start.ts
+++ b/packages/sdk/src/react/prefetch-session-start.ts
@@ -1,0 +1,24 @@
+'use client';
+
+import type { QueryClient } from '@tanstack/react-query';
+
+import { sessionStartKey, startProjectSession } from '../platform/projects-client';
+
+/**
+ * Begin the session runtime boot DURING the route transition (before the session
+ * page mounts), so provisioning overlaps navigation instead of starting after the
+ * page paints. Idempotent + fire-and-forget: React Query dedupes against the
+ * session page's own query (same key), and `/start` is idempotent server-side.
+ * Also warms the route bundle. Use at every createProjectSession→navigate site.
+ */
+export function prefetchSessionStart(
+  queryClient: QueryClient,
+  projectId: string,
+  sessionId: string,
+): void {
+  void queryClient.prefetchQuery({
+    queryKey: sessionStartKey(projectId, sessionId),
+    queryFn: () => startProjectSession(projectId, sessionId),
+    staleTime: 0,
+  });
+}

--- a/packages/sdk/src/react/route-project.ts
+++ b/packages/sdk/src/react/route-project.ts
@@ -1,0 +1,25 @@
+'use client';
+
+import { type ReactNode, createContext, createElement, useContext } from 'react';
+
+/**
+ * The route-scoped project id, injected by the host instead of read from a
+ * router. The SDK is router-agnostic: a Next host derives the id from
+ * `useParams()` and mounts `KortixProjectProvider` once near its root; native
+ * or CLI-driven hosts pass whatever their navigation state says. Hooks that
+ * need "the project the user is looking at" (`useOpenCodeProviders`,
+ * `useOpenCodeLocal`) read it via `useKortixRouteProjectId`, which yields
+ * `null` outside a project scope — the same as a non-project route.
+ */
+const KortixProjectContext = createContext<string | null>(null);
+
+export function KortixProjectProvider(props: {
+  projectId: string | null;
+  children?: ReactNode;
+}): ReactNode {
+  return createElement(KortixProjectContext.Provider, { value: props.projectId }, props.children);
+}
+
+export function useKortixRouteProjectId(): string | null {
+  return useContext(KortixProjectContext);
+}

--- a/packages/sdk/src/react/use-current-runtime.ts
+++ b/packages/sdk/src/react/use-current-runtime.ts
@@ -1,0 +1,18 @@
+'use client';
+
+import { useSyncExternalStore } from 'react';
+
+import { type CurrentRuntimeState, currentRuntimeStore } from '../state/current-runtime';
+
+/**
+ * React selector hook over the framework-free `currentRuntimeStore`. Keep
+ * selectors primitive-valued (string/number/null) — the selected value is
+ * compared by reference on every store change.
+ */
+export function useCurrentRuntime<T>(selector: (state: CurrentRuntimeState) => T): T {
+  return useSyncExternalStore(
+    currentRuntimeStore.subscribe,
+    () => selector(currentRuntimeStore.getState()),
+    () => selector(currentRuntimeStore.getState()),
+  );
+}

--- a/packages/sdk/src/react/use-opencode-events/index.ts
+++ b/packages/sdk/src/react/use-opencode-events/index.ts
@@ -11,7 +11,7 @@ import { useOpenCodePendingStore } from '../../state/opencode-pending-store';
 import { useSyncStore } from '../../state/sync-store';
 import { useSandboxConnectionStore } from '../../state/sandbox-connection-store';
 import { useServerStore } from '../../state/server-store';
-import { useCurrentRuntime } from '../../state/current-runtime';
+import { useCurrentRuntime } from '../use-current-runtime';
 import { useQueryClient } from '@tanstack/react-query';
 import { useEffect, useRef } from 'react';
 import { opencodeKeys } from '../use-opencode-sessions';

--- a/packages/sdk/src/react/use-opencode-local.ts
+++ b/packages/sdk/src/react/use-opencode-local.ts
@@ -16,8 +16,8 @@ import { featureFlags } from '../platform/feature-flags';
 import { listProjectSecrets } from '../platform/projects-client';
 import type { Agent, Config, ProviderListResponse } from '@opencode-ai/sdk/v2/client';
 import { useQuery } from '@tanstack/react-query';
-import { useParams } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useKortixRouteProjectId } from './route-project';
 import {
   connectedGatewayProviderIdsFromSecretNames,
   normalizeProviderList,
@@ -158,8 +158,7 @@ export function useOpenCodeLocal({
   // ---- Flatten models from providers (shared with the chat input, so the
   // gateway-only allowlist applies here too — native providers never leak in) ----
   const flatModels = useMemo<FlatModel[]>(() => flattenModels(providers), [providers]);
-  const params = useParams();
-  const projectId = typeof params?.id === 'string' ? params.id : null;
+  const projectId = useKortixRouteProjectId();
   const providerMode = useMemo(() => modelProviderMode(providers), [providers]);
   const secretsQuery = useQuery({
     queryKey: ['project-secrets', projectId],

--- a/packages/sdk/src/react/use-opencode-sessions/providers.ts
+++ b/packages/sdk/src/react/use-opencode-sessions/providers.ts
@@ -1,8 +1,8 @@
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
-import { useParams } from 'next/navigation';
 import { getClient } from '../../opencode/client';
+import { useKortixRouteProjectId } from '../route-project';
 import { opencodeKeys, useOpenCodeRuntimeReady } from './keys';
 import type { ProviderListResponse } from './keys';
 import { unwrap, getLSCache, setLSCache, LS_PROVIDERS, CACHE_SCOPE_GLOBAL } from './shared';
@@ -30,8 +30,7 @@ export { GATEWAY_PROVIDER_IDS };
 
 export function useOpenCodeProviders() {
   const runtimeReady = useOpenCodeRuntimeReady();
-  const params = useParams();
-  const projectId = typeof params?.id === 'string' ? params.id : null;
+  const projectId = useKortixRouteProjectId();
   const projectDetailQuery = useQuery({
     queryKey: ['project-detail', projectId],
     queryFn: () => getProjectDetail(projectId!),

--- a/packages/sdk/src/react/use-opencode-sessions/sessions.ts
+++ b/packages/sdk/src/react/use-opencode-sessions/sessions.ts
@@ -5,7 +5,7 @@ import { getClient } from '../../opencode/client';
 import { isOpenCodeConfigInvalidError } from '../../platform/opencode-errors';
 import { markSessionFresh } from '../../platform/fresh-sessions';
 import { useOpenCodeCompactionStore } from '../../state/opencode-compaction-store';
-import { useCurrentRuntime } from '../../state/current-runtime';
+import { useCurrentRuntime } from '../use-current-runtime';
 import type { Session } from '@opencode-ai/sdk/v2/client';
 import { opencodeKeys, useOpenCodeRuntimeReady } from './keys';
 import { unwrap, getLSCache, setLSCache, LS_SESSIONS, canQueryOpenCodeSession } from './shared';

--- a/packages/sdk/src/session/health.ts
+++ b/packages/sdk/src/session/health.ts
@@ -15,7 +15,7 @@
  */
 
 import { authenticatedFetch } from '../platform/auth';
-import { getActiveOpenCodeUrl } from '../state/server-store';
+import { getActiveOpenCodeUrl } from '../state/server-store/active';
 
 export type SessionHealthResponse = {
   status?: string;

--- a/packages/sdk/src/state/current-runtime.ts
+++ b/packages/sdk/src/state/current-runtime.ts
@@ -1,7 +1,3 @@
-'use client';
-
-import { create } from 'zustand';
-
 /**
  * The current session runtime — the ONE OpenCode daemon the app is talking to
  * right now (the sandbox of the session being viewed), as a proxy URL
@@ -13,8 +9,12 @@ import { create } from 'zustand';
  * it; switching sessions just sets a new url. There is no servers[] registry, no
  * `serverVersion`, no reset-cascade. `version` bumps on every change so the SSE
  * stream re-subscribes to the new daemon.
+ *
+ * This module is part of the isomorphic core (reachable from the root
+ * `@kortix/sdk` export), so it is a plain hand-rolled store — no zustand, no
+ * React. The React selector hook lives at `react/use-current-runtime`.
  */
-interface CurrentRuntimeState {
+export interface CurrentRuntimeState {
   url: string | null;
   /** The sandbox's external_id (Daytona id) — used for proxy routing. */
   sandboxId: string | null;
@@ -25,12 +25,27 @@ interface CurrentRuntimeState {
   version: number;
 }
 
-export const useCurrentRuntime = create<CurrentRuntimeState>(() => ({
+let state: CurrentRuntimeState = {
   url: null,
   sandboxId: null,
   dbSandboxId: null,
   version: 0,
-}));
+};
+
+const listeners = new Set<() => void>();
+
+/** Framework-free store over the current runtime (getState/subscribe). */
+export const currentRuntimeStore = {
+  getState(): CurrentRuntimeState {
+    return state;
+  },
+  subscribe(listener: () => void): () => void {
+    listeners.add(listener);
+    return () => {
+      listeners.delete(listener);
+    };
+  },
+};
 
 /**
  * Point the app at a session's runtime. `null` clears it (no active session) — the
@@ -42,22 +57,23 @@ export function setCurrentRuntime(
   sandboxId: string | null = null,
   dbSandboxId: string | null = null,
 ): void {
-  const cur = useCurrentRuntime.getState();
-  if (cur.url === url && cur.sandboxId === sandboxId && cur.dbSandboxId === dbSandboxId) return;
-  useCurrentRuntime.setState({ url, sandboxId, dbSandboxId, version: cur.version + 1 });
+  if (state.url === url && state.sandboxId === sandboxId && state.dbSandboxId === dbSandboxId)
+    return;
+  state = { url, sandboxId, dbSandboxId, version: state.version + 1 };
+  for (const listener of listeners) listener();
 }
 
 /** Read the current runtime url outside React (API modules, the client factory). */
 export function getCurrentRuntimeUrl(): string | null {
-  return useCurrentRuntime.getState().url;
+  return state.url;
 }
 
 /** Read the current runtime sandbox id (external_id) outside React. */
 export function getCurrentRuntimeSandboxId(): string | null {
-  return useCurrentRuntime.getState().sandboxId;
+  return state.sandboxId;
 }
 
 /** Read the current runtime DB sandbox id (platform `sandbox_id`) outside React. */
 export function getCurrentRuntimeDbSandboxId(): string | null {
-  return useCurrentRuntime.getState().dbSandboxId;
+  return state.dbSandboxId;
 }

--- a/packages/sdk/src/state/server-store.ts
+++ b/packages/sdk/src/state/server-store.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand';
 
-import { type ServerStore } from './server-store/types';
 import { getActiveOpenCodeUrl } from './server-store/active';
+import type { ServerStore } from './server-store/types';
 
 // Re-export the public surface that lives in sibling modules so importers of
 // '../state/server-store' (and '@kortix/sdk/server-store') stay unchanged.

--- a/packages/sdk/src/state/server-store.ts
+++ b/packages/sdk/src/state/server-store.ts
@@ -1,21 +1,18 @@
 import { create } from 'zustand';
 
-import { platformConfig } from '../platform/config';
-
 import { type ServerStore } from './server-store/types';
-import {
-  getBackendUrl,
-  getDefaultSandboxUrl,
-} from './server-store/url-helpers';
-import {
-  getCurrentRuntimeSandboxId,
-  getCurrentRuntimeUrl,
-  getCurrentRuntimeDbSandboxId,
-} from './current-runtime';
+import { getActiveOpenCodeUrl } from './server-store/active';
 
 // Re-export the public surface that lives in sibling modules so importers of
 // '../state/server-store' (and '@kortix/sdk/server-store') stay unchanged.
 export { getSandboxUrlForExternalId } from './server-store/url-helpers';
+export {
+  deriveSubdomainOpts,
+  getActiveDbSandboxId,
+  getActiveOpenCodeUrl,
+  getActiveSandboxId,
+  getBackendPort,
+} from './server-store/active';
 
 /**
  * server-store — a thin, read-only view over the per-session runtime.
@@ -25,75 +22,11 @@ export { getSandboxUrlForExternalId } from './server-store/url-helpers';
  * surface: `getActiveServerUrl()` resolves the active OpenCode proxy URL. The
  * old multi-instance registry, the persisted server list, and the server-
  * switching machinery are gone — there is no "active server" to switch.
+ *
+ * The resolution helpers themselves live in `./server-store/active` (framework-
+ * free, part of the isomorphic core); this module adds only the zustand read
+ * surface for React hosts.
  */
 export const useServerStore = create<ServerStore>(() => ({
   getActiveServerUrl: () => getActiveOpenCodeUrl(),
 }));
-
-/**
- * Resolve the active OpenCode proxy URL (routed through the backend).
- * Prefers the per-session runtime; falls back to the local-dev default sandbox.
- * Use in non-React contexts (API modules, etc.).
- */
-export function getActiveOpenCodeUrl(): string {
-  const current = getCurrentRuntimeUrl();
-  if (current) return current;
-  // Cloud/billing deployments have no local default — wait for the session to
-  // point the runtime at its sandbox ('' tells callers to skip/retry).
-  if (platformConfig().billingEnabled ?? false) return '';
-  // Self-hosted local dev: talk to the default container sandbox.
-  return getDefaultSandboxUrl();
-}
-
-/**
- * sandboxId for the active runtime.
- * - With an active session: the session's sandbox external id (current-runtime).
- * - Otherwise: the configured default sandbox id (self-hosted local dev).
- */
-export function getActiveSandboxId(): string | undefined {
-  return getCurrentRuntimeSandboxId() ?? platformConfig().sandboxId ?? undefined;
-}
-
-/**
- * DB instance id (platform `sandbox_id`) for the active runtime's sandbox.
- *
- * This is the stable DB primary key — distinct from the external id returned by
- * `getActiveSandboxId()`. Ownership-scoped APIs (per-sandbox API keys) key on
- * this, not the external id (which the backend would mistake for the DB key).
- * Only set while a session runtime is active.
- */
-export function getActiveDbSandboxId(): string | undefined {
-  return getCurrentRuntimeDbSandboxId() ?? undefined;
-}
-
-/**
- * Extract the backend port from NEXT_PUBLIC_BACKEND_URL (e.g. 8008 from
- * "http://localhost:8008/v1"). Used for subdomain URL construction:
- *   http://p{port}-{sandboxId}.localhost:{backendPort}/
- */
-export function getBackendPort(): number {
-  try {
-    const url = new URL(getBackendUrl());
-    return parseInt(url.port, 10) || (url.protocol === 'https:' ? 443 : 80);
-  } catch {
-    return 8008; // fallback for local dev
-  }
-}
-
-/**
- * Subdomain URL options for the active runtime (pure-ish function).
- *
- * Always returns a valid options object — never undefined. Every provider routes
- * through the same backend preview proxy; the `apiBaseUrl` field lets
- * `rewriteLocalhostUrl` take the path-based branch on VPS/cloud deployments
- * where *.localhost DNS isn't available. The sandbox id comes from the active
- * runtime (no legacy 'kortix-sandbox' default — it masked the real cloud sandbox
- * and 403'd the preview proxy).
- */
-export function deriveSubdomainOpts(): { sandboxId: string; backendPort: number; apiBaseUrl: string } {
-  return {
-    sandboxId: getActiveSandboxId() || '',
-    backendPort: getBackendPort(),
-    apiBaseUrl: getBackendUrl(),
-  };
-}

--- a/packages/sdk/src/state/server-store/active.ts
+++ b/packages/sdk/src/state/server-store/active.ts
@@ -57,7 +57,7 @@ export function getActiveDbSandboxId(): string | undefined {
 export function getBackendPort(): number {
   try {
     const url = new URL(getBackendUrl());
-    return parseInt(url.port, 10) || (url.protocol === 'https:' ? 443 : 80);
+    return Number.parseInt(url.port, 10) || (url.protocol === 'https:' ? 443 : 80);
   } catch {
     return 8008; // fallback for local dev
   }

--- a/packages/sdk/src/state/server-store/active.ts
+++ b/packages/sdk/src/state/server-store/active.ts
@@ -1,0 +1,86 @@
+import { platformConfig } from '../../platform/config';
+import {
+  getCurrentRuntimeDbSandboxId,
+  getCurrentRuntimeSandboxId,
+  getCurrentRuntimeUrl,
+} from '../current-runtime';
+import { getBackendUrl, getDefaultSandboxUrl } from './url-helpers';
+
+/**
+ * Active-runtime resolution, framework-free. These are the read helpers the
+ * isomorphic core (`createKortix`, the opencode client factory) resolves the
+ * runtime through; the zustand read surface in `../server-store` layers on top
+ * for React hosts.
+ */
+
+/**
+ * Resolve the active OpenCode proxy URL (routed through the backend).
+ * Prefers the per-session runtime; falls back to the local-dev default sandbox.
+ * Use in non-React contexts (API modules, etc.).
+ */
+export function getActiveOpenCodeUrl(): string {
+  const current = getCurrentRuntimeUrl();
+  if (current) return current;
+  // Cloud/billing deployments have no local default — wait for the session to
+  // point the runtime at its sandbox ('' tells callers to skip/retry).
+  if (platformConfig().billingEnabled ?? false) return '';
+  // Self-hosted local dev: talk to the default container sandbox.
+  return getDefaultSandboxUrl();
+}
+
+/**
+ * sandboxId for the active runtime.
+ * - With an active session: the session's sandbox external id (current-runtime).
+ * - Otherwise: the configured default sandbox id (self-hosted local dev).
+ */
+export function getActiveSandboxId(): string | undefined {
+  return getCurrentRuntimeSandboxId() ?? platformConfig().sandboxId ?? undefined;
+}
+
+/**
+ * DB instance id (platform `sandbox_id`) for the active runtime's sandbox.
+ *
+ * This is the stable DB primary key — distinct from the external id returned by
+ * `getActiveSandboxId()`. Ownership-scoped APIs (per-sandbox API keys) key on
+ * this, not the external id (which the backend would mistake for the DB key).
+ * Only set while a session runtime is active.
+ */
+export function getActiveDbSandboxId(): string | undefined {
+  return getCurrentRuntimeDbSandboxId() ?? undefined;
+}
+
+/**
+ * Extract the backend port from NEXT_PUBLIC_BACKEND_URL (e.g. 8008 from
+ * "http://localhost:8008/v1"). Used for subdomain URL construction:
+ *   http://p{port}-{sandboxId}.localhost:{backendPort}/
+ */
+export function getBackendPort(): number {
+  try {
+    const url = new URL(getBackendUrl());
+    return parseInt(url.port, 10) || (url.protocol === 'https:' ? 443 : 80);
+  } catch {
+    return 8008; // fallback for local dev
+  }
+}
+
+/**
+ * Subdomain URL options for the active runtime (pure-ish function).
+ *
+ * Always returns a valid options object — never undefined. Every provider routes
+ * through the same backend preview proxy; the `apiBaseUrl` field lets
+ * `rewriteLocalhostUrl` take the path-based branch on VPS/cloud deployments
+ * where *.localhost DNS isn't available. The sandbox id comes from the active
+ * runtime (no legacy 'kortix-sandbox' default — it masked the real cloud sandbox
+ * and 403'd the preview proxy).
+ */
+export function deriveSubdomainOpts(): {
+  sandboxId: string;
+  backendPort: number;
+  apiBaseUrl: string;
+} {
+  return {
+    sandboxId: getActiveSandboxId() || '',
+    backendPort: getBackendPort(),
+    apiBaseUrl: getBackendUrl(),
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1329,9 +1329,6 @@ importers:
       '@opencode-ai/sdk':
         specifier: ^1.14.28
         version: 1.17.11
-      next:
-        specifier: 15.5.18
-        version: 15.5.18(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.0)(react-dom@19.1.0)(react@19.1.0)
       zustand:
         specifier: ^5.0.3
         version: 5.0.14(@types/react@19.1.17)(react@19.1.0)(use-sync-external-store@1.6.0)


### PR DESCRIPTION
## What & why

The `@kortix/sdk` root `.` export promised web + mobile + white-label consumption but could not load outside a Next.js React client context: `kortix.ts` opened with `'use client'`, the core graph pulled zustand (which imports React) through `state/server-store` + `state/current-runtime`, the REST layer typed against react-query's `QueryClient`, and two react hooks imported `next/navigation`. This PR makes the core entry isomorphic — the enabler for mobile/CLI SDK adoption. It is deliberately NOT the two-package split (follow-up).

### Changes

- **`state/current-runtime.ts`** — now a hand-rolled framework-free store (`getState`/`subscribe`), no zustand, no `'use client'`. The React selector hook moved to `react/use-current-runtime.ts` (`useSyncExternalStore`); both SDK call sites updated. Function surface (`setCurrentRuntime`, `getCurrentRuntime*`) unchanged.
- **`state/server-store/active.ts` (new)** — the framework-free active-runtime resolution (`getActiveOpenCodeUrl`, `getActiveSandboxId`, `getActiveDbSandboxId`, `getBackendPort`, `deriveSubdomainOpts`) extracted out of `server-store.ts`, which keeps the zustand `useServerStore` read surface and re-exports everything, so `@kortix/sdk/server-store` importers are unchanged. Core-graph modules (`kortix.ts`, `opencode/client.ts`, `files/client.ts`, `session/health.ts`) now import from `active.ts`.
- **`platform/projects-client/session-sandbox.ts`** — the `QueryClient`-typed `prefetchSessionStart` moved to `react/prefetch-session-start.ts`, exported from `@kortix/sdk/react`. No external consumer imported it from `projects-client` (apps/web has its own copy in `lib/projects-client.ts`); if a sibling PR migrates web onto the SDK copy, import it from `@kortix/sdk/react`.
- **next decoupling** — `react/use-opencode-sessions/providers.ts` and `react/use-opencode-local.ts` no longer import `next/navigation`. They read the route project id from a new injected context (`react/route-project.ts`: `KortixProjectProvider` + `useKortixRouteProjectId`). apps/web mounts the bridge once in the root layout (`components/kortix-project-scope.tsx`, deriving `params?.id` exactly as the hooks did internally — behavior preserved bug-for-bug, including non-project `[id]` routes). The `next` peer dependency is dropped.
- **`kortix.ts`** — `'use client'` removed.
- **Tripwire test** (`src/index.isomorphic.test.ts`) — statically walks the root export's full import graph asserting no `react`/`react-dom`/`next`/`zustand`/`@tanstack/react-query` (even type-only) and no `'use client'` directives, then runtime-imports the root entry in plain bun and constructs `createKortix`. Only remaining external in the root graph: `@opencode-ai/sdk/v2/client`.

Line delta: **21 files changed, +327 / −134**.

## Verification (re-run 2026-07-02 after rebase onto a65d497135)

- Rebased onto latest `origin/main` — clean, no conflicts (new main commits touch only workflows/infra + whitelabel's `next` bump).
- `pnpm install` — ok, lockfile stable.
- `packages/sdk`: `pnpm exec tsc --noEmit` — clean.
- `packages/sdk`: `bun test src` — **32 pass, 0 fail** (4 files, incl. the 3 new tripwire tests).
- `apps/web`: `pnpm exec tsc --noEmit` — error output **byte-identical** to a fresh-install clean-main baseline at the merge-base (same 10 pre-existing errors: `@/.source` fumadocs codegen ×1, `src/ui/turns.test.ts` token-type drift ×9; diffed sorted outputs → `TSC_IDENTICAL`). An earlier revision of this body claimed the baseline also had 2 `next/navigation` TS2307 errors removed by this PR; a clean-install baseline does not reproduce those, so the accurate claim is simply: no new errors.
- `apps/whitelabel-demo`: `pnpm run typecheck` — clean.
- `biome check` on every changed file — per-file/per-rule diagnostics **identical** to the clean-main baseline versions (all pre-existing: `layout.tsx` `noDangerouslySetInnerHtml` ×5 + legacy lint debt in the touched react hook files); all newly authored files produce zero diagnostics.

## Caveats & expected sibling overlaps

- Original commits used `--no-verify` (mid-recovery from a shared-stash race with a sibling worktree agent); biome was run manually instead — see verification above.
- **Sibling overlap:** siblings touch `packages/sdk/package.json` (exports map) — my edit is only the removal of the `next` peer-dep lines; `platform/projects-client/*` (drift reconcile) — my edit there is only the `QueryClient` import + `prefetchSessionStart` removal in `session-sandbox.ts`; a web-adoption sibling deleting `apps/web/src/lib/projects-client.ts` should import `prefetchSessionStart` from `@kortix/sdk/react`.
- Biome legacy-format churn intentionally reverted on `opencode/client.ts`, `files/client.ts`, `session/health.ts` and the untouched react hook files to keep the diff scoped.
- `useOpenCodeProviders`/`useOpenCodeLocal` in a host that does not mount `KortixProjectProvider` resolve `projectId` as `null` (global provider list) — identical to a route without an `[id]` param today. apps/web is bridged; apps/mobile and whitelabel-demo do not consume these hooks.
- Note for reviewers: during this work a shared `git stash` stack race with a sibling worktree agent occurred; the sibling's WIP was preserved back onto the stash stack as "recovered sibling WIP (accidentally popped in wf_50931180-f06-7...)".
