### PR TITLE
feat(contracts): @kortix/api-contract foundation, adopted for core project routes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
               - *pnpm
               - 'apps/api/**'
               - 'packages/agent-tunnel/**'
+              - 'packages/api-contract/**'
               - 'packages/db/**'
               - 'packages/manifest-schema/**'
               - 'packages/shared/**'

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -58,6 +58,7 @@ COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
 
 # Copy the target app and workspace packages it depends on
 COPY ${SERVICE} ./${SERVICE}
+COPY packages/api-contract ./packages/api-contract
 COPY packages/shared ./packages/shared
 COPY packages/llm-catalog ./packages/llm-catalog
 COPY packages/db ./packages/db
@@ -145,6 +146,9 @@ COPY --from=deps /app/packages/starter/templates ./packages/starter/templates
 COPY --from=deps /app/packages/manifest-schema/src ./packages/manifest-schema/src
 COPY --from=deps /app/packages/manifest-schema/package.json ./packages/manifest-schema/package.json
 COPY --from=deps /app/packages/manifest-schema/tsconfig.json ./packages/manifest-schema/tsconfig.json
+COPY --from=deps /app/packages/api-contract/src ./packages/api-contract/src
+COPY --from=deps /app/packages/api-contract/package.json ./packages/api-contract/package.json
+COPY --from=deps /app/packages/api-contract/tsconfig.json ./packages/api-contract/tsconfig.json
 COPY --from=deps /app/packages/registry/src ./packages/registry/src
 COPY --from=deps /app/packages/registry/package.json ./packages/registry/package.json
 COPY --from=deps /app/packages/registry/tsconfig.json ./packages/registry/tsconfig.json
@@ -188,7 +192,8 @@ RUN rm -rf \
     apps/kortix-sandbox-agent-server/src/__tests__ \
     apps/cli/src/__tests__ \
     packages/starter/src/__tests__ \
-    packages/manifest-schema/src/__tests__
+    packages/manifest-schema/src/__tests__ \
+    packages/api-contract/src/__tests__
 
 WORKDIR /app/${SERVICE}
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@daytonaio/sdk": "^0.184.0",
     "@hono/zod-openapi": "^0.19.10",
+    "@kortix/api-contract": "workspace:*",
     "@kortix/db": "workspace:*",
     "@kortix/llm-gateway": "workspace:*",
     "@kortix/manifest-schema": "workspace:*",

--- a/apps/api/src/__tests__/unit-api-contract-serializers.test.ts
+++ b/apps/api/src/__tests__/unit-api-contract-serializers.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  ProjectSchema,
+  ProjectSessionSandboxSchema,
+  ProjectSessionSchema,
+  SecretSchema,
+  SessionStartResultSchema,
+} from '@kortix/api-contract';
+import type { projectSecrets, projectSessions, projects, sessionSandboxes } from '@kortix/db';
+import { buildSecretView, serializeProject, serializeSession } from '../projects/lib/serializers';
+import { serializeSandboxRow } from '../projects/routes/shared';
+
+const NOW = new Date('2026-07-01T12:00:00.000Z');
+const PROJECT_ID = '11111111-2222-4333-8444-555555555555';
+const ACCOUNT_ID = '99999999-8888-4777-8666-555555555555';
+const USER_ID = '77777777-6666-4555-8444-333333333333';
+const SESSION_ID = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee';
+
+function projectRow(
+  overrides: Partial<typeof projects.$inferSelect> = {},
+): typeof projects.$inferSelect {
+  return {
+    projectId: PROJECT_ID,
+    accountId: ACCOUNT_ID,
+    name: 'Demo Project',
+    repoUrl: 'https://github.com/acme/demo',
+    defaultBranch: 'main',
+    manifestPath: 'kortix.toml',
+    status: 'active',
+    metadata: {},
+    lastOpenedAt: NOW,
+    createdAt: NOW,
+    updatedAt: NOW,
+    ...overrides,
+  };
+}
+
+function sessionRow(
+  overrides: Partial<typeof projectSessions.$inferSelect> = {},
+): typeof projectSessions.$inferSelect {
+  return {
+    sessionId: SESSION_ID,
+    accountId: ACCOUNT_ID,
+    projectId: PROJECT_ID,
+    branchName: 'kortix/session-1',
+    baseRef: 'main',
+    sandboxProvider: 'daytona',
+    sandboxId: null,
+    sandboxUrl: null,
+    opencodeSessionId: 'ses_abc',
+    agentName: 'default',
+    status: 'running',
+    error: null,
+    createdBy: USER_ID,
+    visibility: 'private',
+    metadata: { name: 'Fix the login bug' },
+    createdAt: NOW,
+    updatedAt: NOW,
+    ...overrides,
+  };
+}
+
+function sandboxRow(
+  overrides: Partial<typeof sessionSandboxes.$inferSelect> = {},
+): typeof sessionSandboxes.$inferSelect {
+  return {
+    sandboxId: SESSION_ID,
+    sessionId: SESSION_ID,
+    accountId: ACCOUNT_ID,
+    projectId: PROJECT_ID,
+    provider: 'platinum',
+    externalId: 'sbx-123',
+    baseUrl: 'https://sbx-123.proxy.kortix.com',
+    status: 'active',
+    config: { serviceKey: 'sensitive', region: 'eu' },
+    metadata: {},
+    lastUsedAt: NOW,
+    createdAt: NOW,
+    updatedAt: NOW,
+    ...overrides,
+  };
+}
+
+function secretRow(
+  overrides: Partial<typeof projectSecrets.$inferSelect> = {},
+): typeof projectSecrets.$inferSelect {
+  return {
+    secretId: 'bbbbbbbb-cccc-4ddd-8eee-ffffffffffff',
+    projectId: PROJECT_ID,
+    name: 'OPENAI_API_KEY',
+    valueEnc: 'enc:v1:abc',
+    scope: 'runtime',
+    shareScope: 'project',
+    ownerUserId: null,
+    active: true,
+    createdBy: USER_ID,
+    createdAt: NOW,
+    updatedAt: NOW,
+    ...overrides,
+  };
+}
+
+describe('serializeProject ⇄ ProjectSchema', () => {
+  test('output parses strictly and round-trips unchanged', () => {
+    const out = serializeProject(projectRow(), {
+      projectRole: 'manager',
+      effectiveRole: 'manager',
+    });
+    expect(ProjectSchema.strict().parse(out)).toEqual(out);
+  });
+
+  test('output without access context parses with null roles', () => {
+    const out = serializeProject(projectRow({ lastOpenedAt: null }));
+    const parsed = ProjectSchema.strict().parse(out);
+    expect(parsed.project_role).toBeNull();
+    expect(parsed.effective_project_role).toBeNull();
+    expect(parsed.last_opened_at).toBeNull();
+  });
+
+  test('experimental map carries every registered feature key', () => {
+    const out = serializeProject(projectRow());
+    expect(Object.keys(out.experimental).sort()).toEqual(
+      Object.keys(ProjectSchema.shape.experimental.shape).sort(),
+    );
+  });
+});
+
+describe('serializeSession ⇄ ProjectSessionSchema', () => {
+  test('owner view parses strictly and round-trips unchanged', () => {
+    const out = serializeSession(sessionRow(), {
+      viewerId: USER_ID,
+      canManageProject: false,
+    });
+    expect(ProjectSessionSchema.strict().parse(out)).toEqual(out);
+  });
+
+  test('restricted shared view with grants parses', () => {
+    const out = serializeSession(sessionRow({ visibility: 'restricted' }), {
+      grants: [{ principalType: 'member', principalId: USER_ID }],
+      viewerId: 'someone-else',
+      canManageProject: true,
+      ownerEmail: 'owner@acme.dev',
+    });
+    const parsed = ProjectSessionSchema.strict().parse(out);
+    expect(parsed.sharing).toEqual({ mode: 'members', memberIds: [USER_ID], groupIds: [] });
+    expect(parsed.owner_email).toBe('owner@acme.dev');
+    expect(parsed.is_owner).toBe(false);
+  });
+
+  test('custom_name override wins over the auto title', () => {
+    const out = serializeSession(sessionRow({ metadata: { name: 'auto', custom_name: 'Mine' } }));
+    const parsed = ProjectSessionSchema.strict().parse(out);
+    expect(parsed.name).toBe('Mine');
+    expect(parsed.custom_name).toBe('Mine');
+  });
+});
+
+describe('serializeSandboxRow ⇄ ProjectSessionSandboxSchema', () => {
+  test('output parses strictly and scrubs serviceKey from config', () => {
+    const out = serializeSandboxRow(sandboxRow());
+    const parsed = ProjectSessionSandboxSchema.strict().parse(out);
+    expect(parsed).toEqual(out);
+    expect(parsed.config).toEqual({ region: 'eu' });
+  });
+
+  test('start payload embedding the serialized row parses', () => {
+    const payload = {
+      stage: 'ready' as const,
+      agent_name: 'default',
+      retriable: false,
+      sandbox: serializeSandboxRow(sandboxRow()),
+      opencode_session_id: 'ses_abc',
+      runtime_url: '/p/sbx-123/8000',
+      reason: 'pinned',
+    };
+    expect(SessionStartResultSchema.strict().parse(payload)).toEqual(payload);
+  });
+});
+
+describe('buildSecretView ⇄ SecretSchema', () => {
+  test('shared project secret parses strictly and round-trips unchanged', () => {
+    const out = buildSecretView({
+      name: 'OPENAI_API_KEY',
+      shared: secretRow(),
+      sharedGrants: [],
+      subject: { userId: USER_ID, groupIds: [] },
+      canManageShared: true,
+    });
+    expect(SecretSchema.strict().parse(out)).toEqual(out);
+    expect(out.effective_source).toBe('shared');
+  });
+
+  test('personal override view parses', () => {
+    const out = buildSecretView({
+      name: 'OPENAI_API_KEY',
+      personal: secretRow({ ownerUserId: USER_ID }),
+      subject: { userId: USER_ID, groupIds: [] },
+      canManageShared: false,
+    });
+    const parsed = SecretSchema.strict().parse(out);
+    expect(parsed.configured).toBe(false);
+    expect(parsed.effective_source).toBe('mine');
+    expect(parsed.mine).toEqual({ active: true, updated_at: NOW.toISOString() });
+  });
+
+  test('system git-auth secret parses with restricted sharing', () => {
+    const out = buildSecretView({
+      name: 'KORTIX_GIT_AUTH_TOKEN',
+      shared: secretRow({ name: 'KORTIX_GIT_AUTH_TOKEN', shareScope: 'restricted' }),
+      sharedGrants: [{ principalType: 'member', principalId: USER_ID }],
+      subject: { userId: USER_ID, groupIds: [] },
+      canManageShared: true,
+    });
+    const parsed = SecretSchema.strict().parse(out);
+    expect(parsed.system).toBe(true);
+    expect(parsed.purpose).toBe('git_auth');
+    expect(parsed.can_manage_shared).toBe(false);
+  });
+});

--- a/apps/api/src/experimental/features.ts
+++ b/apps/api/src/experimental/features.ts
@@ -22,15 +22,10 @@
  * {@link buildExperimentalCatalog}, so a new entry lights up everywhere.
  */
 import { config } from '../config';
+import type { ExperimentalFeatureKey } from '@kortix/api-contract';
 
-/** Stable identifiers for experimental features. */
-export type ExperimentalFeatureKey =
-  | 'apps'
-  | 'agent_tunnel'
-  | 'marketplace'
-  | 'agentmail_email'
-  | 'meet'
-  | 'llm_gateway';
+/** Stable identifiers for experimental features — wire contract is the SoT. */
+export type { ExperimentalFeatureKey } from '@kortix/api-contract';
 
 /** How settled a feature is — surfaced as a badge so users know what to expect. */
 type ExperimentalStability = 'experimental' | 'beta';

--- a/apps/api/src/openapi/index.ts
+++ b/apps/api/src/openapi/index.ts
@@ -7,18 +7,12 @@
  * served at /v1/openapi.json and rendered by Scalar at /v1/docs.
  */
 import { OpenAPIHono, z, type RouteConfig } from "@hono/zod-openapi";
+import { ErrorEnvelopeSchema } from "@kortix/api-contract";
 import type { Env } from "hono";
 import { Scalar } from "@scalar/hono-api-reference";
 
 /** Permissive error envelope — matches the platform's `{error,message,status}` 404 shape. */
-export const ErrorSchema = z
-  .object({
-    error: z.union([z.boolean(), z.string()]).optional(),
-    message: z.string().optional(),
-    code: z.string().optional(),
-    status: z.number().optional(),
-  })
-  .openapi("Error");
+export const ErrorSchema = ErrorEnvelopeSchema.openapi("Error");
 
 const STATUS_TEXT: Record<number, string> = {
   400: "Bad request",

--- a/apps/api/src/projects/lib/app.ts
+++ b/apps/api/src/projects/lib/app.ts
@@ -1,5 +1,14 @@
 import { makeOpenApiApp } from '../../openapi';
 import { type AppEnv } from '../../types';
+import {
+  OkResponseSchema as ContractOkResponseSchema,
+  ProjectSchema as ContractProjectSchema,
+  ProjectSessionSchema as ContractProjectSessionSchema,
+  SecretSchema as ContractSecretSchema,
+  SessionCreateAcceptedSchema as ContractSessionCreateAcceptedSchema,
+  SessionStartResultSchema as ContractSessionStartResultSchema,
+  TriggerSchema as ContractTriggerSchema,
+} from '@kortix/api-contract';
 import { z } from '@hono/zod-openapi';
 import { Hono } from 'hono';
 
@@ -7,19 +16,26 @@ export const projectsApp = makeOpenApiApp<AppEnv>();
 
 export const projectWebhooksApp = new Hono<AppEnv>();
 
-// ─── Reusable OpenAPI schemas (permissive — these power the docs, not runtime
-// response validation). Many handlers return large/dynamic shapes, so common
-// surfaces are modeled loosely and a permissive fallback is used elsewhere. ───
+// ─── Reusable OpenAPI schemas (these power the docs, not runtime response
+// validation). Core project-domain surfaces come from @kortix/api-contract —
+// the shared wire contract — while large/dynamic shapes are still modeled
+// loosely with a permissive fallback. ───
 
-export const ProjectSchema = z.object({}).passthrough().openapi('Project');
+export const ProjectSchema = ContractProjectSchema.openapi('Project');
 
-export const SessionSchema = z.object({}).passthrough().openapi('Session');
+export const SessionSchema = ContractProjectSessionSchema.openapi('Session');
+
+export const SessionStartResultSchema = ContractSessionStartResultSchema.openapi('SessionStartResult');
+
+export const SessionCreateAcceptedSchema = ContractSessionCreateAcceptedSchema.openapi('SessionCreateAccepted');
+
+export const OkSchema = ContractOkResponseSchema.openapi('Ok');
 
 export const ChangeRequestSchema = z.object({}).passthrough().openapi('ChangeRequest');
 
-export const SecretSchema = z.object({}).passthrough().openapi('Secret');
+export const SecretSchema = ContractSecretSchema.openapi('Secret');
 
-export const TriggerSchema = z.object({}).passthrough().openapi('Trigger');
+export const TriggerSchema = ContractTriggerSchema.openapi('Trigger');
 
 export const AppSchema = z.object({}).passthrough().openapi('App');
 

--- a/apps/api/src/projects/lib/serializers.ts
+++ b/apps/api/src/projects/lib/serializers.ts
@@ -1,4 +1,5 @@
 import { config, type SandboxProviderName } from '../../config';
+import type { Project, ProjectSession, Secret } from '@kortix/api-contract';
 import { isSecretUsableBy, loadGrants, scopeToIntent, type SecretGrant, type ShareSubject, visibilityToIntent } from '../../executor/share';
 import { db } from '../../shared/db';
 import { listSandboxTemplates, listSnapshotBuilds } from '../../snapshots/builder';
@@ -51,7 +52,7 @@ export function serializeSession(
     /** Resolved email of the session owner, for "shared by X" display. */
     ownerEmail?: string | null;
   },
-) {
+): ProjectSession {
   const opencodeSessions = Array.isArray(row.metadata?.opencode_sessions)
     ? row.metadata.opencode_sessions
     : [];
@@ -112,7 +113,7 @@ export function isRepoNameTakenError(error: unknown): boolean {
 }
 
 
-export function serializeProject(row: ProjectRow, access?: { projectRole: ProjectRole | null; effectiveRole: ProjectRole }) {
+export function serializeProject(row: ProjectRow, access?: { projectRole: ProjectRole | null; effectiveRole: ProjectRole }): Project {
   return {
     project_id: row.projectId,
     account_id: row.accountId,
@@ -237,7 +238,7 @@ export function buildSecretView(input: {
   personal?: SecretRow;
   subject: ShareSubject;
   canManageShared: boolean;
-}) {
+}): Secret {
   const { name, shared, sharedGrants = [], personal, subject, canManageShared } = input;
   const system = isSystemProjectSecretName(name);
   const isGitAuth = name === PROJECT_GIT_AUTH_SECRET_NAME;

--- a/apps/api/src/projects/lib/triggers.ts
+++ b/apps/api/src/projects/lib/triggers.ts
@@ -1,4 +1,5 @@
 import { config } from '../../config';
+import type { TriggerList } from '@kortix/api-contract';
 import { auth, errors } from '../../openapi';
 import { db } from '../../shared/db';
 import { isLeader } from '../../shared/leader-election';
@@ -919,7 +920,7 @@ export function buildPublicWebhookUrl(projectId: string, slug: string): string {
 
 /** Builds the GET-listing response shape (specs + runtime + errors). */
 
-export async function loadTriggersForResponse(projectId: string, project: ProjectRow) {
+export async function loadTriggersForResponse(projectId: string, project: ProjectRow): Promise<TriggerList> {
   const { specs, errors } = await loadProjectTriggers(await withProjectGitAuth(project));
   const runtimeRows = specs.length === 0
     ? []

--- a/apps/api/src/projects/routes/r1.ts
+++ b/apps/api/src/projects/routes/r1.ts
@@ -154,7 +154,7 @@ projectsApp.openapi(
         200: json(z.array(ProjectSchema), 'Projects the caller can read'),
     },
   }),
-  async (c: any) => {
+  async (c) => {
   const scope = await resolveProjectAccount(c);
   // Reach through `any` for non-typed context keys set by the auth
   // middleware (the AppEnv only types userId/userEmail).

--- a/apps/api/src/projects/routes/r5.ts
+++ b/apps/api/src/projects/routes/r5.ts
@@ -168,7 +168,7 @@ projectsApp.openapi(
         ...errors(404),
     },
   }),
-  async (c: any) => {
+  async (c) => {
   const projectId = c.req.param('projectId');
 
   const loaded = await loadProjectForUser(c, projectId, 'read');

--- a/apps/api/src/projects/routes/r7.ts
+++ b/apps/api/src/projects/routes/r7.ts
@@ -16,7 +16,7 @@ import { createRoute, z } from '@hono/zod-openapi';
 import { accountGroupMembers, accountGroups, accountMembers, projectGroupGrants, projectSecrets, projectSessions, sessionSandboxes } from '@kortix/db';
 import { and, asc, desc, eq, inArray, isNull } from 'drizzle-orm';
 import { loadProjectForUser, loadVisibleSession, lookupEmailsByUserIds, parseExpiresAtBody, assertProjectCapability, isUuid } from '../lib/access';
-import { AnyObject, GroupGrantSchema, SessionSchema, projectsApp } from '../lib/app';
+import { AnyObject, GroupGrantSchema, OkSchema, SessionCreateAcceptedSchema, SessionSchema, projectsApp } from '../lib/app';
 import { UUID_V4_REGEX, hasOwn, normalizeString, readBody, requestAuditContext, serializeSession } from '../lib/serializers';
 import { sendSessionCreateError } from '../lib/sessions';
 import { buildSessionTranscriptDigest } from '../lib/session-transcript';
@@ -335,6 +335,7 @@ projectsApp.openapi(
       },
     responses: {
         201: json(SessionSchema, 'The created session'),
+        202: json(SessionCreateAcceptedSchema, 'Create accepted; poll the session'),
         ...errors(404),
     },
   }),
@@ -410,7 +411,7 @@ projectsApp.openapi(
         ...errors(404),
     },
   }),
-  async (c: any) => {
+  async (c) => {
   const projectId = c.req.param('projectId');
 
   const loaded = await loadProjectForUser(c, projectId, 'read');
@@ -504,7 +505,7 @@ projectsApp.openapi(
         ...errors(400, 404),
     },
   }),
-  async (c: any) => {
+  async (c) => {
   const projectId = c.req.param('projectId');
   const sessionId = c.req.param('sessionId');
   if (!UUID_V4_REGEX.test(sessionId)) return c.json({ error: 'Invalid session id' }, 400);
@@ -650,11 +651,11 @@ projectsApp.openapi(
         body: { content: { 'application/json': { schema: AnyObject } } },
       },
     responses: {
-        200: json(z.any(), 'OK'),
+        200: json(SessionSchema, 'The updated session'),
         ...errors(400, 404),
     },
   }),
-  async (c: any) => {
+  async (c) => {
   const projectId = c.req.param('projectId');
   const sessionId = c.req.param('sessionId');
   if (!UUID_V4_REGEX.test(sessionId)) return c.json({ error: 'Invalid session id' }, 400);
@@ -746,11 +747,11 @@ projectsApp.openapi(
         params: z.object({ projectId: z.string(), sessionId: z.string() }),
       },
     responses: {
-        200: json(z.any(), 'OK'),
+        200: json(OkSchema, 'Session stopped'),
         ...errors(400, 403, 404),
     },
   }),
-  async (c: any) => {
+  async (c) => {
   const projectId = c.req.param('projectId');
   const sessionId = c.req.param('sessionId');
   if (!UUID_V4_REGEX.test(sessionId)) return c.json({ error: 'Invalid session id' }, 400);

--- a/apps/api/src/projects/routes/r8.ts
+++ b/apps/api/src/projects/routes/r8.ts
@@ -21,7 +21,7 @@ import { and, desc, eq } from 'drizzle-orm';
 import { loadProjectForUser, loadVisibleSession, assertProjectCapability } from '../lib/access';
 import { assertAgentScope } from '../../iam/agent-scope';
 import { PROJECT_ACTIONS } from '../../iam';
-import { AnyObject, ChangeRequestSchema, projectsApp } from '../lib/app';
+import { AnyObject, ChangeRequestSchema, SessionStartResultSchema, projectsApp } from '../lib/app';
 import { withProjectGitAuth } from '../lib/git';
 import { UUID_V4_REGEX, normalizeString, readBody } from '../lib/serializers';
 import { restartSession, startSession } from '../session-lifecycle';
@@ -45,9 +45,12 @@ projectsApp.openapi(
     request: {
       params: z.object({ projectId: z.string(), sessionId: z.string() }),
     },
-    responses: { 200: json(z.any(), 'OK'), ...errors(400, 402, 404) },
+    responses: {
+      200: json(SessionStartResultSchema, 'Session readiness payload'),
+      ...errors(400, 402, 404),
+    },
   }),
-  async (c: any) => {
+  async (c) => {
     const projectId = c.req.param('projectId');
     const sessionId = c.req.param('sessionId');
     if (!UUID_V4_REGEX.test(sessionId))

--- a/apps/api/src/projects/routes/shared.ts
+++ b/apps/api/src/projects/routes/shared.ts
@@ -3,6 +3,7 @@ import {
   reopenComputeForSandbox,
 } from '../../billing/services/compute-metering';
 import { config, type SandboxProviderName } from '../../config';
+import type { ProjectSessionSandbox, SessionStartResult } from '@kortix/api-contract';
 import { auth, json } from '../../openapi';
 import { getProvider, type SandboxStatus } from '../../platform/providers';
 import { db } from '../../shared/db';
@@ -277,35 +278,10 @@ export async function allocateRuntimeOnOpen(
 }
 
 // ── Unified session-open orchestration ──────────────────────────────────────
+// The stage/result wire types live in @kortix/api-contract (the shared wire
+// contract); re-exported here for the existing import sites.
 
-export type SessionStartStage =
-  | 'provisioning'
-  | 'starting'
-  | 'ready'
-  | 'stopped'
-  | 'failed';
-
-export interface SessionStartResult {
-  /** Coarse lifecycle stage the client renders + polls on. */
-  stage: SessionStartStage;
-  /** Immutable project-session agent bound at session creation. */
-  agent_name: string;
-  /** Whether polling /start again can make progress (false = terminal). */
-  retriable: boolean;
-  /** Serialized session_sandboxes row (same shape as GET /sandbox), or null. */
-  sandbox: Record<string, unknown> | null;
-  /** Canonical OpenCode root pin (resolved client-side once the box is ready). */
-  opencode_session_id: string | null;
-  /**
-   * Relative proxy path for this session's OpenCode runtime (port 8000), composed
-   * by the client against the SDK's configured backendUrl. The server owns the
-   * proxy scheme so the client never builds `/p/<id>/<port>` itself — it treats
-   * this as an opaque per-session runtime base. Absent until the box has an
-   * external_id. See `sessionRuntimeUrlPath`.
-   */
-  runtime_url?: string | null;
-  reason?: string;
-}
+export type { SessionStartResult, SessionStartStage } from '@kortix/api-contract';
 
 /**
  * The relative proxy path a client uses for all OpenCode (port 8000) traffic for
@@ -374,9 +350,9 @@ export async function retireSessionSandboxRow(
     .where(eq(sessionSandboxes.sandboxId, row.sandboxId));
 }
 
-function serializeSandboxRow(
+export function serializeSandboxRow(
   row: typeof sessionSandboxes.$inferSelect,
-): Record<string, unknown> {
+): ProjectSessionSandbox {
   return {
     sandbox_id: row.sandboxId,
     session_id: row.sessionId,

--- a/packages/api-contract/package.json
+++ b/packages/api-contract/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@kortix/api-contract",
+  "version": "1.0.0",
+  "description": "Shared wire-type contract for the Kortix platform API. Zod schemas + inferred TS types describing exactly what apps/api serializes onto the wire — the single source of truth for clients (SDK, web, mobile) and the OpenAPI docs.",
+  "private": true,
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "zod": "^3.23.0"
+  },
+  "devDependencies": {
+    "@types/bun": "^1.1.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/packages/api-contract/src/__tests__/schemas.test.ts
+++ b/packages/api-contract/src/__tests__/schemas.test.ts
@@ -1,0 +1,359 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  EXPERIMENTAL_FEATURE_KEYS,
+  ErrorEnvelopeSchema,
+  OkResponseSchema,
+  ProjectSchema,
+  ProjectSessionSandboxSchema,
+  ProjectSessionSchema,
+  SecretSchema,
+  SessionCreateAcceptedSchema,
+  SessionStartResultSchema,
+  SharingIntentSchema,
+  TriggerListSchema,
+  TriggerSchema,
+} from '../index';
+
+const NOW = '2026-07-01T12:00:00.000Z';
+
+function projectFixture(overrides: Record<string, unknown> = {}) {
+  return {
+    project_id: '11111111-2222-4333-8444-555555555555',
+    account_id: '99999999-8888-4777-8666-555555555555',
+    name: 'Demo Project',
+    repo_url: 'https://github.com/acme/demo',
+    git_origin_url: 'https://github.com/acme/demo',
+    default_branch: 'main',
+    manifest_path: 'kortix.toml',
+    status: 'active',
+    metadata: { onboarding_completed_at: NOW },
+    last_opened_at: NOW,
+    created_at: NOW,
+    updated_at: NOW,
+    project_role: 'manager',
+    effective_project_role: 'manager',
+    dashboard_url: 'https://kortix.com/projects/11111111-2222-4333-8444-555555555555',
+    experimental: {
+      apps: false,
+      agent_tunnel: false,
+      marketplace: false,
+      agentmail_email: false,
+      meet: false,
+      llm_gateway: true,
+    },
+    experimental_features: [
+      {
+        key: 'apps',
+        name: 'Apps',
+        description: 'Deploy apps.',
+        stability: 'experimental',
+        available: true,
+        enabled: false,
+        overridden: false,
+      },
+    ],
+    apps_enabled: false,
+    default_sandbox_provider: null,
+    available_sandbox_providers: ['daytona', 'platinum'],
+    ...overrides,
+  };
+}
+
+function sessionFixture(overrides: Record<string, unknown> = {}) {
+  return {
+    session_id: 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee',
+    account_id: '99999999-8888-4777-8666-555555555555',
+    project_id: '11111111-2222-4333-8444-555555555555',
+    branch_name: 'kortix/session-1',
+    base_ref: 'main',
+    sandbox_provider: 'daytona',
+    sandbox_id: null,
+    sandbox_url: null,
+    opencode_session_id: 'ses_abc',
+    name: 'Fix the login bug',
+    custom_name: null,
+    agent_name: 'default',
+    status: 'running',
+    error: null,
+    metadata: { name: 'Fix the login bug' },
+    opencode_sessions: [],
+    created_by: '99999999-8888-4777-8666-555555555555',
+    owner_email: null,
+    visibility: 'private',
+    sharing: { mode: 'private', ownerId: '' },
+    is_owner: true,
+    can_manage_sharing: true,
+    created_at: NOW,
+    updated_at: NOW,
+    ...overrides,
+  };
+}
+
+function sandboxFixture(overrides: Record<string, unknown> = {}) {
+  return {
+    sandbox_id: 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee',
+    session_id: 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee',
+    project_id: '11111111-2222-4333-8444-555555555555',
+    account_id: '99999999-8888-4777-8666-555555555555',
+    provider: 'platinum',
+    external_id: 'sbx-123',
+    base_url: 'https://sbx-123.proxy.kortix.com',
+    status: 'active',
+    config: {},
+    metadata: {},
+    last_used_at: NOW,
+    created_at: NOW,
+    updated_at: NOW,
+    ...overrides,
+  };
+}
+
+function triggerFixture(overrides: Record<string, unknown> = {}) {
+  return {
+    slug: 'nightly-report',
+    path: 'kortix.toml#triggers.nightly-report',
+    name: 'Nightly report',
+    type: 'cron',
+    agent: 'default',
+    model: null,
+    enabled: true,
+    cron: '0 0 3 * * *',
+    run_at: null,
+    timezone: 'UTC',
+    secret_env: null,
+    prompt_template: 'Summarize yesterday.',
+    session_mode: 'fresh',
+    owner_user_id: null,
+    last_fired_at: NOW,
+    last_status: 'queued',
+    last_error: null,
+    last_attempt_at: NOW,
+    webhook_url: null,
+    ...overrides,
+  };
+}
+
+function secretFixture(overrides: Record<string, unknown> = {}) {
+  return {
+    name: 'OPENAI_API_KEY',
+    project_id: '11111111-2222-4333-8444-555555555555',
+    secret_id: 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee',
+    created_by: '99999999-8888-4777-8666-555555555555',
+    created_at: NOW,
+    updated_at: NOW,
+    system: false,
+    readonly: false,
+    purpose: null,
+    can_rotate: false,
+    managed_by: null,
+    configured: true,
+    share_scope: 'project',
+    sharing: { mode: 'project' },
+    usable_by_me: true,
+    mine: null,
+    effective_source: 'shared',
+    can_manage_shared: true,
+    ...overrides,
+  };
+}
+
+describe('ProjectSchema', () => {
+  test('accepts a full serialized project', () => {
+    expect(() => ProjectSchema.strict().parse(projectFixture())).not.toThrow();
+  });
+
+  test('accepts null roles for inherited access', () => {
+    const parsed = ProjectSchema.parse(
+      projectFixture({ project_role: null, effective_project_role: 'user' }),
+    );
+    expect(parsed.project_role).toBeNull();
+  });
+
+  test('rejects an unknown status', () => {
+    expect(() => ProjectSchema.parse(projectFixture({ status: 'deleted' }))).toThrow();
+  });
+
+  test('rejects an experimental map missing a registered key', () => {
+    const { llm_gateway: _dropped, ...partial } = projectFixture().experimental as Record<
+      string,
+      boolean
+    >;
+    expect(() => ProjectSchema.parse(projectFixture({ experimental: partial }))).toThrow();
+  });
+});
+
+describe('ProjectSessionSchema', () => {
+  test('accepts a full serialized session', () => {
+    expect(() => ProjectSessionSchema.strict().parse(sessionFixture())).not.toThrow();
+  });
+
+  test.each([
+    { mode: 'project' },
+    { mode: 'private', ownerId: 'u1' },
+    { mode: 'members', memberIds: ['u1'], groupIds: [] },
+  ])('accepts sharing intent %#', (sharing) => {
+    expect(() => ProjectSessionSchema.parse(sessionFixture({ sharing }))).not.toThrow();
+  });
+
+  test('rejects a sharing intent with an unknown mode', () => {
+    expect(() =>
+      ProjectSessionSchema.parse(sessionFixture({ sharing: { mode: 'everyone' } })),
+    ).toThrow();
+  });
+
+  test('rejects a Date where an ISO string is expected', () => {
+    expect(() =>
+      ProjectSessionSchema.parse(sessionFixture({ created_at: new Date(NOW) })),
+    ).toThrow();
+  });
+});
+
+describe('SessionStartResultSchema', () => {
+  test('accepts the provisioning payload without sandbox or runtime_url', () => {
+    const parsed = SessionStartResultSchema.strict().parse({
+      stage: 'provisioning',
+      agent_name: 'default',
+      retriable: true,
+      sandbox: null,
+      opencode_session_id: null,
+    });
+    expect(parsed.runtime_url).toBeUndefined();
+  });
+
+  test('accepts the ready payload with a serialized sandbox', () => {
+    const parsed = SessionStartResultSchema.parse({
+      stage: 'ready',
+      agent_name: 'default',
+      retriable: false,
+      sandbox: sandboxFixture(),
+      opencode_session_id: 'ses_abc',
+      runtime_url: '/p/sbx-123/8000',
+      reason: 'pinned',
+    });
+    expect(parsed.sandbox?.provider).toBe('platinum');
+  });
+
+  test('rejects an unknown stage', () => {
+    expect(() =>
+      SessionStartResultSchema.parse({
+        stage: 'booting',
+        agent_name: 'default',
+        retriable: true,
+        sandbox: null,
+        opencode_session_id: null,
+      }),
+    ).toThrow();
+  });
+});
+
+describe('ProjectSessionSandboxSchema', () => {
+  test('accepts every provider the platform can emit', () => {
+    for (const provider of ['daytona', 'local_docker', 'justavps', 'platinum']) {
+      expect(() =>
+        ProjectSessionSandboxSchema.strict().parse(sandboxFixture({ provider })),
+      ).not.toThrow();
+    }
+  });
+});
+
+describe('TriggerSchema', () => {
+  test('accepts a cron trigger and a webhook trigger', () => {
+    expect(() => TriggerSchema.strict().parse(triggerFixture())).not.toThrow();
+    expect(() =>
+      TriggerSchema.strict().parse(
+        triggerFixture({
+          type: 'webhook',
+          cron: null,
+          secret_env: 'HOOK_SECRET',
+          webhook_url: 'https://api.kortix.com/v1/webhooks/projects/p/hook',
+        }),
+      ),
+    ).not.toThrow();
+  });
+
+  test('list response is an envelope, not a bare array', () => {
+    expect(() =>
+      TriggerListSchema.strict().parse({
+        triggers: [triggerFixture()],
+        triggers_paused: false,
+        errors: [{ slug: 'bad', path: 'kortix.toml#triggers.bad', error: 'invalid cron' }],
+      }),
+    ).not.toThrow();
+    expect(TriggerListSchema.safeParse([triggerFixture()]).success).toBe(false);
+  });
+});
+
+describe('SecretSchema', () => {
+  test('accepts the shared view and the personal-override view', () => {
+    expect(() => SecretSchema.strict().parse(secretFixture())).not.toThrow();
+    expect(() =>
+      SecretSchema.strict().parse(
+        secretFixture({
+          configured: false,
+          secret_id: null,
+          created_by: null,
+          sharing: null,
+          usable_by_me: false,
+          mine: { active: true, updated_at: NOW },
+          effective_source: 'mine',
+        }),
+      ),
+    ).not.toThrow();
+  });
+
+  test('accepts the system git-auth secret shape', () => {
+    expect(() =>
+      SecretSchema.parse(
+        secretFixture({
+          name: 'KORTIX_GIT_AUTH_TOKEN',
+          system: true,
+          readonly: true,
+          purpose: 'git_auth',
+          can_rotate: true,
+          managed_by: 'project_secret',
+        }),
+      ),
+    ).not.toThrow();
+  });
+});
+
+describe('envelopes', () => {
+  test('error envelope tolerates both string and boolean error fields', () => {
+    expect(() => ErrorEnvelopeSchema.parse({ error: 'Not found' })).not.toThrow();
+    expect(() =>
+      ErrorEnvelopeSchema.parse({ error: true, message: 'Validation failed', status: 400 }),
+    ).not.toThrow();
+  });
+
+  test('ok response requires literal true', () => {
+    expect(() => OkResponseSchema.parse({ ok: true })).not.toThrow();
+    expect(OkResponseSchema.safeParse({ ok: false }).success).toBe(false);
+  });
+
+  test('session-create 202 envelope parses', () => {
+    expect(() =>
+      SessionCreateAcceptedSchema.strict().parse({
+        status: 'queued',
+        command_id: 'cmd_1',
+        session_id: null,
+        reason: null,
+      }),
+    ).not.toThrow();
+  });
+
+  test('experimental keys stay in sync with the map schema', () => {
+    expect(EXPERIMENTAL_FEATURE_KEYS).toEqual([
+      'apps',
+      'agent_tunnel',
+      'marketplace',
+      'agentmail_email',
+      'meet',
+      'llm_gateway',
+    ]);
+  });
+
+  test('sharing intent normalizes readonly member lists', () => {
+    const parsed = SharingIntentSchema.parse({ mode: 'members', memberIds: ['u1'] });
+    expect(parsed).toEqual({ mode: 'members', memberIds: ['u1'] });
+  });
+});

--- a/packages/api-contract/src/index.ts
+++ b/packages/api-contract/src/index.ts
@@ -1,0 +1,314 @@
+/**
+ * @kortix/api-contract — the shared wire contract for the Kortix platform API.
+ *
+ * Zod schemas + inferred TS types describing EXACTLY what apps/api serializes
+ * onto the wire today. The API serializers
+ * (apps/api/src/projects/lib/serializers.ts et al) are the behavioral source
+ * of truth; these schemas are purely descriptive — nothing here validates
+ * requests or reshapes responses.
+ *
+ * The contract is enforced two ways:
+ *   1. compile time — serializer return types in apps/api are annotated with
+ *      the inferred types below, so any added/renamed/retyped field fails
+ *      typecheck (object-literal excess-property checks catch additions);
+ *   2. runtime — apps/api's unit suite parses real serializer output against
+ *      these schemas (see apps/api/src/__tests__/unit-api-contract.test.ts).
+ */
+import { z } from 'zod';
+
+/** Loose JSON object — jsonb metadata/config columns surfaced as-is. */
+export const JsonObjectSchema = z.record(z.string(), z.unknown());
+export type JsonObject = z.infer<typeof JsonObjectSchema>;
+
+/**
+ * Standard error envelope. Matches the platform-wide shape
+ * (`{ error, message, code, status }`) — permissive because handlers attach
+ * route-specific extras (e.g. `balance` on 402, `issues` on validation 400).
+ */
+export const ErrorEnvelopeSchema = z.object({
+  error: z.union([z.boolean(), z.string()]).optional(),
+  message: z.string().optional(),
+  code: z.string().optional(),
+  status: z.number().optional(),
+});
+export type ErrorEnvelope = z.infer<typeof ErrorEnvelopeSchema>;
+
+/** Bare success acknowledgement returned by delete/detach-style routes. */
+export const OkResponseSchema = z.object({ ok: z.literal(true) });
+export type OkResponse = z.infer<typeof OkResponseSchema>;
+
+/**
+ * Effective on/off map for every experimental feature. Keys mirror the
+ * registry in apps/api/src/experimental/features.ts, which imports
+ * `ExperimentalFeatureKey` from here — adding a feature there without
+ * updating this map fails typecheck.
+ */
+export const ExperimentalFeatureMapSchema = z.object({
+  apps: z.boolean(),
+  agent_tunnel: z.boolean(),
+  marketplace: z.boolean(),
+  agentmail_email: z.boolean(),
+  meet: z.boolean(),
+  llm_gateway: z.boolean(),
+});
+export type ExperimentalFeatureMap = z.infer<typeof ExperimentalFeatureMapSchema>;
+
+export const ExperimentalFeatureKeySchema = ExperimentalFeatureMapSchema.keyof();
+export type ExperimentalFeatureKey = z.infer<typeof ExperimentalFeatureKeySchema>;
+export const EXPERIMENTAL_FEATURE_KEYS = ExperimentalFeatureKeySchema.options;
+
+/** One catalog entry of the self-describing experimental-features UI list. */
+export const ExperimentalFeatureViewSchema = z.object({
+  key: ExperimentalFeatureKeySchema,
+  name: z.string(),
+  description: z.string(),
+  stability: z.enum(['experimental', 'beta']),
+  available: z.boolean(),
+  enabled: z.boolean(),
+  overridden: z.boolean(),
+});
+export type ExperimentalFeatureView = z.infer<typeof ExperimentalFeatureViewSchema>;
+
+/** Assignable project roles (`viewer` is deprecated and no longer emitted). */
+export const PROJECT_ROLES = ['manager', 'editor', 'user'] as const;
+export const ProjectRoleSchema = z.enum(PROJECT_ROLES);
+export type ProjectRole = z.infer<typeof ProjectRoleSchema>;
+
+/** Every provider that can appear on session/sandbox rows. */
+export const SANDBOX_PROVIDERS = ['daytona', 'local_docker', 'justavps', 'platinum'] as const;
+export const SandboxProviderSchema = z.enum(SANDBOX_PROVIDERS);
+export type SandboxProvider = z.infer<typeof SandboxProviderSchema>;
+
+/**
+ * The dashboard's three sharing options, as emitted on sessions
+ * (`visibilityToIntent`) and secrets (`scopeToIntent`).
+ */
+export const SharingIntentSchema = z.discriminatedUnion('mode', [
+  z.object({ mode: z.literal('project') }),
+  z.object({ mode: z.literal('private'), ownerId: z.string() }),
+  z.object({
+    mode: z.literal('members'),
+    memberIds: z.array(z.string()).readonly().optional(),
+    groupIds: z.array(z.string()).readonly().optional(),
+  }),
+]);
+export type SharingIntent = z.infer<typeof SharingIntentSchema>;
+
+/** A project as serialized by `serializeProject`. */
+export const ProjectSchema = z.object({
+  project_id: z.string(),
+  account_id: z.string(),
+  name: z.string(),
+  repo_url: z.string(),
+  /** Universal client-facing git origin (proxy URL when enabled, else repo_url). */
+  git_origin_url: z.string(),
+  default_branch: z.string(),
+  manifest_path: z.string(),
+  status: z.enum(['active', 'archived']),
+  metadata: JsonObjectSchema,
+  last_opened_at: z.string().nullable(),
+  created_at: z.string(),
+  updated_at: z.string(),
+  /** Explicit project_members role, or null when access is inherited. */
+  project_role: ProjectRoleSchema.nullable(),
+  /** UI label for the caller's effective role (not an auth decision). */
+  effective_project_role: ProjectRoleSchema.nullable(),
+  dashboard_url: z.string(),
+  experimental: ExperimentalFeatureMapSchema,
+  experimental_features: z.array(ExperimentalFeatureViewSchema),
+  /** Back-compat alias for `experimental.apps`. */
+  apps_enabled: z.boolean(),
+  /** Per-project provider pin, surfaced only while still usable. */
+  default_sandbox_provider: z.string().nullable(),
+  available_sandbox_providers: z.array(SandboxProviderSchema),
+});
+export type Project = z.infer<typeof ProjectSchema>;
+
+export const SESSION_STATUSES = [
+  'queued',
+  'branching',
+  'provisioning',
+  'running',
+  'stopped',
+  'failed',
+  'completed',
+] as const;
+export const SessionStatusSchema = z.enum(SESSION_STATUSES);
+export type SessionStatus = z.infer<typeof SessionStatusSchema>;
+
+export const SESSION_VISIBILITIES = ['private', 'project', 'restricted'] as const;
+export const SessionVisibilitySchema = z.enum(SESSION_VISIBILITIES);
+export type SessionVisibility = z.infer<typeof SessionVisibilitySchema>;
+
+/** A project session as serialized by `serializeSession`. */
+export const ProjectSessionSchema = z.object({
+  session_id: z.string(),
+  account_id: z.string(),
+  project_id: z.string(),
+  branch_name: z.string(),
+  base_ref: z.string(),
+  sandbox_provider: SandboxProviderSchema,
+  sandbox_id: z.string().nullable(),
+  sandbox_url: z.string().nullable(),
+  opencode_session_id: z.string().nullable(),
+  /** Resolved display name: the user-set override, else the auto title. */
+  name: z.string().nullable(),
+  /** The user-set override alone, so clients can tell it apart from the auto title. */
+  custom_name: z.string().nullable(),
+  agent_name: z.string(),
+  status: SessionStatusSchema,
+  error: z.string().nullable(),
+  metadata: JsonObjectSchema,
+  opencode_sessions: z.array(z.unknown()),
+  created_by: z.string().nullable(),
+  owner_email: z.string().nullable(),
+  visibility: SessionVisibilitySchema,
+  sharing: SharingIntentSchema,
+  is_owner: z.boolean(),
+  can_manage_sharing: z.boolean(),
+  created_at: z.string(),
+  updated_at: z.string(),
+});
+export type ProjectSession = z.infer<typeof ProjectSessionSchema>;
+
+export const SESSION_SANDBOX_STATUSES = [
+  'provisioning',
+  'active',
+  'stopped',
+  'error',
+  'archived',
+] as const;
+export const SessionSandboxStatusSchema = z.enum(SESSION_SANDBOX_STATUSES);
+export type SessionSandboxStatus = z.infer<typeof SessionSandboxStatusSchema>;
+
+/** A session_sandboxes row as serialized onto `SessionStartResult.sandbox`. */
+export const ProjectSessionSandboxSchema = z.object({
+  sandbox_id: z.string(),
+  session_id: z.string(),
+  project_id: z.string(),
+  account_id: z.string(),
+  provider: SandboxProviderSchema,
+  external_id: z.string().nullable(),
+  base_url: z.string().nullable(),
+  status: SessionSandboxStatusSchema,
+  config: JsonObjectSchema,
+  metadata: JsonObjectSchema,
+  last_used_at: z.string().nullable(),
+  created_at: z.string(),
+  updated_at: z.string(),
+});
+export type ProjectSessionSandbox = z.infer<typeof ProjectSessionSandboxSchema>;
+
+export const SESSION_START_STAGES = [
+  'provisioning',
+  'starting',
+  'ready',
+  'stopped',
+  'failed',
+] as const;
+export const SessionStartStageSchema = z.enum(SESSION_START_STAGES);
+export type SessionStartStage = z.infer<typeof SessionStartStageSchema>;
+
+/**
+ * The readiness payload of POST /v1/projects/:id/sessions/:id/start — the one
+ * object clients poll until `stage === 'ready'`.
+ */
+export const SessionStartResultSchema = z.object({
+  /** Coarse lifecycle stage the client renders + polls on. */
+  stage: SessionStartStageSchema,
+  /** Immutable project-session agent bound at session creation. */
+  agent_name: z.string(),
+  /** Whether polling /start again can make progress (false = terminal). */
+  retriable: z.boolean(),
+  /** Serialized session_sandboxes row, or null while none is usable. */
+  sandbox: ProjectSessionSandboxSchema.nullable(),
+  /** Canonical OpenCode root pin, resolved server-side once the box is up. */
+  opencode_session_id: z.string().nullable(),
+  /**
+   * Relative proxy path for this session's OpenCode runtime (port 8000),
+   * composed by the client against its configured backend URL. The server owns
+   * the proxy scheme; absent until the box has an external_id.
+   */
+  runtime_url: z.string().nullable().optional(),
+  reason: z.string().optional(),
+});
+export type SessionStartResult = z.infer<typeof SessionStartResultSchema>;
+
+/**
+ * The 202 envelope of POST /v1/projects/:id/sessions when the create is
+ * accepted asynchronously instead of returning a session row.
+ */
+export const SessionCreateAcceptedSchema = z.object({
+  status: z.string(),
+  command_id: z.string().nullable(),
+  session_id: z.string().nullable(),
+  reason: z.string().nullable(),
+});
+export type SessionCreateAccepted = z.infer<typeof SessionCreateAcceptedSchema>;
+
+/** One trigger entry as emitted by `loadTriggersForResponse`. */
+export const TriggerSchema = z.object({
+  slug: z.string(),
+  path: z.string(),
+  name: z.string(),
+  type: z.enum(['cron', 'webhook']),
+  agent: z.string(),
+  /** Wire-form model (`provider/model`) or null for "Default". */
+  model: z.string().nullable(),
+  enabled: z.boolean(),
+  cron: z.string().nullable(),
+  run_at: z.string().nullable(),
+  timezone: z.string(),
+  secret_env: z.string().nullable(),
+  prompt_template: z.string(),
+  session_mode: z.enum(['fresh', 'reuse']),
+  /** The member this trigger's automated runs act as (null = account owner). */
+  owner_user_id: z.string().nullable(),
+  last_fired_at: z.string().nullable(),
+  last_status: z.string().nullable(),
+  last_error: z.string().nullable(),
+  last_attempt_at: z.string().nullable(),
+  webhook_url: z.string().nullable(),
+});
+export type Trigger = z.infer<typeof TriggerSchema>;
+
+/**
+ * The actual GET /v1/projects/:id/triggers response: an envelope, not a bare
+ * array (specs + per-project pause switch + manifest parse errors).
+ */
+export const TriggerListSchema = z.object({
+  triggers: z.array(TriggerSchema),
+  triggers_paused: z.boolean(),
+  errors: z.array(z.object({ slug: z.string(), path: z.string(), error: z.string() })),
+});
+export type TriggerList = z.infer<typeof TriggerListSchema>;
+
+/**
+ * The per-user view of one secret KEY as built by `buildSecretView`: the
+ * shared/project row merged with the member's own override. Values are never
+ * serialized.
+ */
+export const SecretSchema = z.object({
+  name: z.string(),
+  project_id: z.string(),
+  secret_id: z.string().nullable(),
+  created_by: z.string().nullable(),
+  created_at: z.string().nullable(),
+  updated_at: z.string().nullable(),
+  system: z.boolean(),
+  readonly: z.boolean(),
+  purpose: z.literal('git_auth').nullable(),
+  can_rotate: z.boolean(),
+  managed_by: z.literal('project_secret').nullable(),
+  /** Is a shared project value set at all. */
+  configured: z.boolean(),
+  share_scope: z.enum(['project', 'restricted']),
+  sharing: SharingIntentSchema.nullable(),
+  usable_by_me: z.boolean(),
+  /** The caller's private override (value omitted), or null. */
+  mine: z.object({ active: z.boolean(), updated_at: z.string() }).nullable(),
+  /** Which value actually gets injected into the caller's sessions. */
+  effective_source: z.enum(['mine', 'shared', 'none']),
+  can_manage_shared: z.boolean(),
+});
+export type Secret = z.infer<typeof SecretSchema>;

--- a/packages/api-contract/src/index.ts
+++ b/packages/api-contract/src/index.ts
@@ -12,7 +12,8 @@
  *      the inferred types below, so any added/renamed/retyped field fails
  *      typecheck (object-literal excess-property checks catch additions);
  *   2. runtime — apps/api's unit suite parses real serializer output against
- *      these schemas (see apps/api/src/__tests__/unit-api-contract.test.ts).
+ *      these schemas (see
+ *      apps/api/src/__tests__/unit-api-contract-serializers.test.ts).
  */
 import { z } from 'zod';
 

--- a/packages/api-contract/tsconfig.json
+++ b/packages/api-contract/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "lib": ["ES2022"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,6 +93,9 @@ importers:
       '@hono/zod-openapi':
         specifier: ^0.19.10
         version: 0.19.10(hono@4.12.25)(zod@3.25.76)
+      '@kortix/api-contract':
+        specifier: workspace:*
+        version: link:../../packages/api-contract
       '@kortix/db':
         specifier: workspace:*
         version: link:../../packages/db
@@ -1244,6 +1247,19 @@ importers:
         version: 1.3.14
       typescript:
         specifier: ^5.4.0
+        version: 5.9.3
+
+  packages/api-contract:
+    dependencies:
+      zod:
+        specifier: ^3.23.0
+        version: 3.25.76
+    devDependencies:
+      '@types/bun':
+        specifier: ^1.1.0
+        version: 1.3.14
+      typescript:
+        specifier: ^5.0.0
         version: 5.9.3
 
   packages/db:


### PR DESCRIPTION
## What

Creates **`packages/api-contract`** (`@kortix/api-contract`) — the shared type-contract foundation for the platform API — and adopts it in `apps/api` for the core project domain. This PR **changes zero wire behavior**: it only *describes* the shapes the API already emits. No route path, status code, or response shape changes (the only route-declaration addition is documenting the *already-existing* 202 branch of `POST /sessions`).

### The package (zod + inferred TS types, structured like `packages/manifest-schema`)

Schemas derived from what the serializers actually emit (`apps/api/src/projects/lib/serializers.ts`, `routes/shared.ts`, `lib/triggers.ts` are the source of truth):

- `Project`, `ProjectSession`, `ProjectSessionSandbox`
- `SessionStartStage` / `SessionStartResult` (+ the `SessionCreateAccepted` 202 envelope)
- `Trigger` + `TriggerList` (the real list envelope — see docs-bug note below)
- `Secret` (the per-user secret view), `SharingIntent`
- `ExperimentalFeatureKey` / map / catalog view (canonical 6-key set incl. `meet`)
- `ErrorEnvelope`, `OkResponse`

### Adoption in `apps/api`

- `projects/lib/app.ts`: `ProjectSchema`, `SessionSchema`, `SecretSchema`, `TriggerSchema` are no longer `z.object({}).passthrough()` — they're the contract schemas (plus new `SessionStartResultSchema`, `SessionCreateAcceptedSchema`, `OkSchema`). `openapi/index.ts` `ErrorSchema` now comes from the contract.
- Routes: `GET /v1/projects`, `GET /v1/projects/:id`, sessions CRUD (`POST/GET/GET one/PATCH/DELETE`), and `POST …/sessions/:id/start` now declare the real response schemas; the contained handlers are **really typed** (dropped `(c: any)` on 6 of them — zod-openapi now type-checks their `c.json()` returns against the contract). `POST /sessions` keeps `(c: any)` because `sendSessionCreateError` returns dynamic statuses (noted follow-up).
- Serializer return types annotated against the contract: `serializeProject`, `serializeSession`, `serializeSandboxRow` (now exported), `buildSecretView`, `loadTriggersForResponse`. Object-literal excess-property checks make any field add/rename/retype a **compile error**.
- `experimental/features.ts` imports/re-exports `ExperimentalFeatureKey` from the contract, so a new registry entry that isn't in the contract fails typecheck.

### Drift alarms (tests)

- `packages/api-contract/src/__tests__/schemas.test.ts` — 23 pure fixture tests (round-trips, negative cases).
- `apps/api/src/__tests__/unit-api-contract-serializers.test.ts` — 11 tests feeding representative Drizzle rows through the **real serializers** and strict-parsing the output against the contract (incl. `serviceKey` scrub, sharing-intent grants, custom_name precedence, system git-auth secret). *Placed in apps/api rather than the contract package deliberately:* importing the serializers loads `config.ts` (env-validated at import) and would create a reverse workspace dependency; apps/api's test lane already has the env.

## Line delta

+1,002 / −69 across 17 files (the package itself is ~314 lines of schema + ~330 lines of tests; apps/api adoption is +292/−69).

## Verification

- `pnpm install` — clean
- `pnpm --filter @kortix/api-contract exec tsc --noEmit` — clean
- `pnpm --filter kortix-api exec tsc --noEmit` — clean (this is the real check: the 6 newly typed handlers + 5 serializer annotations all compile against the contract)
- `cd packages/api-contract && bun test` — 23 pass / 0 fail
- `cd apps/api && KORTIX_URL=… dotenvx run -- bun test src/__tests__/unit-api-contract-serializers.test.ts src/projects/session-lifecycle/__tests__/ src/__tests__/unit-trigger-activation-route.test.ts src/__tests__/unit-projects-policies.test.ts` — 38 pass / 0 fail (`KORTIX_URL` supplied because the local decrypted `.env` lacks it; CI env has it — known local false-failure pattern)
- OpenAPI smoke: mounted r1/r5/r7/r8 + `mountOpenApiDocs` in a scratch harness and rendered `/v1/openapi.json` — the `Project`/`Session`/`SessionStartResult`/`SessionCreateAccepted`/`Ok`/`Error` components now emit full property schemas (previously empty passthrough objects); no zod-to-openapi errors on `discriminatedUnion`/`.readonly()`.
- ke2e: read `tests/spec/end-to-end.md` + `tests/spec/routes.generated.json` — **no route added/removed/renamed, no status/shape change**, so no manifest regen or spec edit needed (suite is WIP/not enforced per the ke2e skill).
- Docker: `docker build --target deps --build-arg SERVICE=apps/api -f apps/api/Dockerfile .` — green after the fix below (this was the one red CI check on the first push).

## Follow-up fix (second push): carry the package in the API image

The first push failed **Self-host schema bootstrap**: `apps/api/Dockerfile` copies an explicit list of workspace packages into the image, so the deps stage's `pnpm install` couldn't resolve `@kortix/api-contract@workspace:*` (`ERR_PNPM_WORKSPACE_PKG_NOT_FOUND`). Fixed by adding `packages/api-contract` to the Dockerfile (deps-stage COPY + runner-stage src/package.json/tsconfig.json copies + `__tests__` prune), mirroring the `manifest-schema` pattern, and adding `packages/api-contract/**` to the `api` paths-filter in `ci.yml` so contract changes trigger API typecheck/tests. Verified locally by building the Dockerfile's `deps` stage to completion.

## Client-declaration discrepancies found (cross-check, NOT changed here)

The API is the source of truth; these client copies have drifted and should be fixed by adopting the contract (follow-up):

- `packages/sdk/src/platform/projects-client/session-sandbox.ts`: `SessionStartResult` is **missing `agent_name`**; sandbox `provider` union is missing `local_docker`/`platinum`.
- `apps/web/src/lib/projects-client.ts`: `SessionStartResult` is **missing `runtime_url`**; sandbox `provider` union missing `platinum`.
- `apps/mobile/lib/projects/projects-client.ts`: `SessionStartResult` missing **both `agent_name` and `runtime_url`**.
- `packages/sdk/…/projects.ts` `KortixProject`: missing `git_origin_url` + `dashboard_url`; declares optional `warm_pool`/`warm_pool_available` that `serializeProject` never emits.

## Pre-existing docs bugs surfaced (documented, not fixed — behavior-preserving scope)

- `GET/POST /:projectId/triggers` declare `z.array(TriggerSchema)` / `TriggerSchema` but actually return the `TriggerList` **envelope** (`{triggers, triggers_paused, errors}`). The contract ships `TriggerListSchema`; swapping the route declarations is a follow-up docs fix.
- `GET /:projectId/secrets` similarly returns `{items, required, optional, can_manage, manifest_status, manifest_path}` rather than a bare array.

## Caveats / sibling-PR overlap

- Six sibling blitz PRs are churning `packages/sdk`, `apps/web`, `apps/mobile` — per plan this PR does **not** touch them; adopting the contract there is the follow-up (kill the 4x `SessionStartResult` / 3x `KortixProject` duplicates).
- Likely merge-touch overlap with siblings on: `apps/api/package.json` (dep list), `pnpm-lock.yaml`, and possibly `apps/api/src/projects/lib/serializers.ts` if any sibling types serializers.
- `pnpm exec biome check --write` was run; it wanted to mass-reformat ~2,000 pre-existing non-conformant lines in `r1/r5/r7/shared/triggers` — I reverted that churn to keep the diff scoped and formatted only the new files (which pass clean).
- `ProjectRole` is modeled as `manager|editor|user` (matching `projects/access.ts`); the DB enum still contains the deprecated, migrated-away `viewer`.
