### PR TITLE
fix(triggers): real agent/model pickers for schedules + webhooks

### DIFF
--- a/apps/api/src/__tests__/e2e-project-triggers.test.ts
+++ b/apps/api/src/__tests__/e2e-project-triggers.test.ts
@@ -497,6 +497,7 @@ function cronEntry(opts: {
   cron: string;
   timezone?: string;
   agent?: string;
+  model?: string;
   enabled?: boolean;
   prompt: string;
 }): string {
@@ -504,6 +505,7 @@ function cronEntry(opts: {
   if (opts.name !== undefined) lines.push(`name = "${opts.name}"`);
   lines.push('type = "cron"');
   if (opts.agent !== undefined) lines.push(`agent = "${opts.agent}"`);
+  if (opts.model !== undefined) lines.push(`model = "${opts.model}"`);
   if (opts.enabled !== undefined) lines.push(`enabled = ${opts.enabled}`);
   lines.push(`cron = "${opts.cron}"`);
   if (opts.timezone !== undefined) lines.push(`timezone = "${opts.timezone}"`);
@@ -710,6 +712,58 @@ describe('git-backed triggers — CRUD', () => {
     expect(updated).toContain('old prompt');
   });
 
+  test('POST /triggers accepts and returns a pinned model', async () => {
+    const app = createApp();
+    const res = await app.request(`/v1/projects/${PROJECT_ID}/triggers`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: 'Pinned Model',
+        type: 'cron',
+        cron: '0 0 9 * * *',
+        timezone: 'UTC',
+        prompt_template: 'x',
+        model: 'anthropic/claude-sonnet-4-6',
+      }),
+    });
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.triggers[0]).toMatchObject({
+      slug: 'pinned-model',
+      model: 'anthropic/claude-sonnet-4-6',
+    });
+    expect(repoFiles.get(MANIFEST_PATH)).toContain('model = "anthropic/claude-sonnet-4-6"');
+  });
+
+  // Regression: a PATCH body containing ONLY `model` must still commit the
+  // manifest. TRIGGER_MANIFEST_KEYS previously omitted "model", so
+  // `touchesManifest` was false and the change was silently dropped (200 OK,
+  // nothing persisted, listing kept returning the stale model).
+  test('PATCH /triggers/:slug with only `model` persists it to the manifest', async () => {
+    seedManifest(cronEntry({
+      slug: 'one',
+      name: 'One',
+      agent: 'default',
+      cron: '0 0 9 * * *',
+      prompt: 'body',
+    }));
+
+    const app = createApp();
+    const res = await app.request(`/v1/projects/${PROJECT_ID}/triggers/one`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model: 'openai/gpt-5' }),
+    });
+    expect(res.status).toBe(200);
+    expect(commitCalls).toHaveLength(1);
+    expect(commitCalls[0]!.message).toBe('chore: update trigger one');
+    expect(repoFiles.get(MANIFEST_PATH)).toContain('model = "openai/gpt-5"');
+
+    const listing = await app.request(`/v1/projects/${PROJECT_ID}/triggers`);
+    const body = await listing.json();
+    expect(body.triggers[0].model).toBe('openai/gpt-5');
+  });
+
   test('PATCH /triggers/:slug returns 404 when the slug is not in the manifest', async () => {
     const app = createApp();
     const res = await app.request(`/v1/projects/${PROJECT_ID}/triggers/ghost`, {
@@ -784,6 +838,50 @@ describe('git-backed triggers — runtime fire paths', () => {
     expect(runtimeRows).toHaveLength(1);
     expect(runtimeRows[0]!.slug).toBe('daily');
     expect(runtimeRows[0]!.lastFiredAt).toBeTruthy();
+  });
+
+  test('manual fire applies the trigger-level model override to the session', async () => {
+    seedManifest(cronEntry({
+      slug: 'daily',
+      name: 'Daily',
+      cron: '* * * * * *',
+      model: 'anthropic/claude-sonnet-4-6',
+      prompt: 'Run at {{ fired_at }}',
+    }));
+
+    const app = createApp();
+    const res = await app.request(`/v1/projects/${PROJECT_ID}/triggers/daily/fire`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{}',
+    });
+    expect(res.status).toBe(202);
+    expect((await res.json()).status).toBe('fired');
+
+    await new Promise((r) => setTimeout(r, 0));
+    expect(sandboxProvisionCalls).toBe(1);
+    expect(lastProvisionEnv?.KORTIX_OPENCODE_MODEL).toBe('anthropic/claude-sonnet-4-6');
+  });
+
+  test('manual fire without a model leaves the default resolution chain untouched', async () => {
+    seedManifest(cronEntry({
+      slug: 'daily',
+      name: 'Daily',
+      cron: '* * * * * *',
+      prompt: 'Run at {{ fired_at }}',
+    }));
+
+    const app = createApp();
+    const res = await app.request(`/v1/projects/${PROJECT_ID}/triggers/daily/fire`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{}',
+    });
+    expect(res.status).toBe(202);
+
+    await new Promise((r) => setTimeout(r, 0));
+    expect(sandboxProvisionCalls).toBe(1);
+    expect(lastProvisionEnv?.KORTIX_OPENCODE_MODEL).toBeUndefined();
   });
 
   test('manual fire queues durably under backpressure', async () => {

--- a/apps/api/src/projects/lib/triggers.ts
+++ b/apps/api/src/projects/lib/triggers.ts
@@ -664,6 +664,10 @@ export async function fireGitTrigger(input: {
     body: {
       agent_name: spec.agent,
       initial_prompt: renderedPrompt,
+      // A trigger-level model pins this run's session to that model, taking
+      // precedence over the agent/account/platform default chain. Omitted
+      // (null) leaves resolution to that chain — see GitTriggerSpec.model.
+      ...(spec.model ? { opencode_model: spec.model } : {}),
       metadata: {
         trigger_source: source,
         trigger_kind: 'git',

--- a/apps/api/src/projects/routes/r4.ts
+++ b/apps/api/src/projects/routes/r4.ts
@@ -114,6 +114,7 @@ const TRIGGER_MANIFEST_KEYS = [
   "name",
   "type",
   "agent",
+  "model",
   "enabled",
   "prompt_template",
   "promptTemplate",

--- a/apps/mobile/components/pages/SchedulesPage.tsx
+++ b/apps/mobile/components/pages/SchedulesPage.tsx
@@ -39,6 +39,7 @@ import { PageHeader } from '@/components/ui/page-header';
 import { PageContent } from '@/components/ui/page-content';
 import { SearchListHeader } from '@/components/ui/search-list-header';
 import { useThemeColors, getSheetBg } from '@/lib/theme-colors';
+import { AgentPickerField, ModelPickerField } from './TriggerAgentModelFields';
 import {
   useProjectTriggers,
   useCreateProjectTrigger,
@@ -97,7 +98,8 @@ function ScheduleCreateSheet({
   const [tzOpen, setTzOpen] = useState(false);
   const [name, setName] = useState('');
   const [prompt, setPrompt] = useState('');
-  const [agent, setAgent] = useState('default');
+  const [agent, setAgent] = useState<string | null>(null);
+  const [model, setModel] = useState<string | null>(null);
   const [err, setErr] = useState<string | null>(null);
 
   const fg = isDark ? '#F8F8F8' : '#121215';
@@ -122,7 +124,8 @@ function ScheduleCreateSheet({
         name: name.trim(),
         type: 'cron',
         prompt_template: prompt,
-        agent: agent.trim() || 'default',
+        ...(agent ? { agent } : {}),
+        ...(model ? { model } : {}),
         enabled: true,
         ...(mode === 'recurring' ? { cron: cron.trim(), timezone } : { run_at: runAt!, timezone }),
       },
@@ -211,8 +214,8 @@ function ScheduleCreateSheet({
         <Text style={{ fontSize: 12, fontFamily: 'Roobert-Medium', color: muted, marginTop: 14, marginBottom: 6 }}>Prompt</Text>
         <BottomSheetTextInput value={prompt} onChangeText={setPrompt} placeholder="What should the agent do when this fires?" placeholderTextColor={muted} multiline style={[input, { height: 96, paddingTop: 10, textAlignVertical: 'top' }]} />
 
-        <Text style={{ fontSize: 12, fontFamily: 'Roobert-Medium', color: muted, marginTop: 14, marginBottom: 6 }}>Agent</Text>
-        <BottomSheetTextInput value={agent} onChangeText={setAgent} placeholder="default" placeholderTextColor={muted} autoCapitalize="none" autoCorrect={false} style={[input, { fontFamily: MONO }]} />
+        <AgentPickerField projectId={projectId} value={agent} onChange={setAgent} isDark={isDark} />
+        <ModelPickerField projectId={projectId} value={model} onChange={setModel} isDark={isDark} />
 
         {err && (
           <View style={{ marginTop: 14, padding: 12, borderRadius: 11, backgroundColor: 'rgba(239,68,68,0.08)', borderWidth: 1, borderColor: 'rgba(239,68,68,0.3)' }}>
@@ -282,6 +285,16 @@ function ScheduleDetailSheet({
     haptics.tap();
     update.mutate({ slug: trigger.slug, input: { prompt_template: prompt } }, {
       onError: (e: any) => Alert.alert('Failed', e?.message || 'Could not save prompt.'),
+    });
+  };
+  const handleAgentChange = (agent: string) => {
+    update.mutate({ slug: trigger.slug, input: { agent } }, {
+      onError: (e: any) => Alert.alert('Failed', e?.message || 'Could not update agent.'),
+    });
+  };
+  const handleModelChange = (model: string | null) => {
+    update.mutate({ slug: trigger.slug, input: { model } }, {
+      onError: (e: any) => Alert.alert('Failed', e?.message || 'Could not update model.'),
     });
   };
   const handleDelete = () => {
@@ -360,10 +373,12 @@ function ScheduleDetailSheet({
           </TouchableOpacity>
         )}
 
+        <AgentPickerField projectId={projectId} value={trigger.agent} onChange={handleAgentChange} isDark={isDark} />
+        <ModelPickerField projectId={projectId} value={trigger.model} onChange={handleModelChange} isDark={isDark} />
+
         {/* Metadata */}
         <View style={{ marginTop: 22, borderRadius: 12, borderWidth: 1, borderColor: border, paddingHorizontal: 14 }}>
           {[
-            { l: 'Agent', v: trigger.agent || 'default' },
             { l: 'Last fired', v: relativeTime(trigger.last_fired_at) },
             { l: 'Source', v: trigger.path },
           ].map((row, i) => (

--- a/apps/mobile/components/pages/TriggerAgentModelFields.tsx
+++ b/apps/mobile/components/pages/TriggerAgentModelFields.tsx
@@ -1,0 +1,192 @@
+/**
+ * Shared Agent + Model picker fields for the git-backed trigger (Schedules /
+ * Webhooks) create + detail sheets — mobile parity for
+ * apps/web/src/components/projects/schedule-view.tsx's AgentModelSection.
+ *
+ * Inline expand/collapse rows (matching this file family's existing Timezone
+ * picker pattern) rather than a nested bottom sheet — @gorhom/bottom-sheet
+ * doesn't stack modals here, so pickers expand in place instead.
+ */
+
+import React, { useState } from 'react';
+import { View, Text as RNText, TouchableOpacity, ActivityIndicator } from 'react-native';
+import { ChevronRight, Check } from 'lucide-react-native';
+import { Text } from '@/components/ui/text';
+import { useThemeColors } from '@/lib/theme-colors';
+import {
+  useProjectAgentsForTrigger,
+  useProjectModelCatalogForTrigger,
+} from '@/lib/projects/hooks';
+import { haptics } from '@/lib/haptics';
+
+const MONO = 'Menlo';
+
+function useFieldColors(isDark: boolean) {
+  return {
+    fg: isDark ? '#F8F8F8' : '#121215',
+    muted: isDark ? '#9b9b9b' : '#6e6e6e',
+    border: isDark ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.12)',
+    inputBg: isDark ? 'rgba(255,255,255,0.05)' : 'rgba(0,0,0,0.03)',
+  };
+}
+
+function FieldLabel({ children, muted }: { children: React.ReactNode; muted: string }) {
+  return (
+    <Text style={{ fontSize: 12, fontFamily: 'Roobert-Medium', color: muted, marginTop: 14, marginBottom: 6 }}>
+      {children}
+    </Text>
+  );
+}
+
+// ─── Agent ────────────────────────────────────────────────────────────────────
+
+export function AgentPickerField({
+  projectId,
+  value,
+  onChange,
+  isDark,
+}: {
+  projectId: string;
+  /** Selected agent name, or null to leave unset (server defaults to "default"). */
+  value: string | null;
+  onChange: (name: string) => void;
+  isDark: boolean;
+}) {
+  const theme = useThemeColors();
+  const { fg, muted, border, inputBg } = useFieldColors(isDark);
+  const [open, setOpen] = useState(false);
+  const { agents, isLoading } = useProjectAgentsForTrigger(projectId);
+
+  return (
+    <View>
+      <FieldLabel muted={muted}>Agent</FieldLabel>
+      <TouchableOpacity
+        onPress={() => { haptics.tap(); setOpen((v) => !v); }}
+        activeOpacity={0.7}
+        style={{ height: 44, borderRadius: 11, borderWidth: 1, borderColor: border, backgroundColor: inputBg, paddingHorizontal: 12, flexDirection: 'row', alignItems: 'center' }}
+      >
+        <RNText style={{ flex: 1, fontSize: 14, color: fg, fontFamily: MONO }} numberOfLines={1}>
+          {value || 'default'}
+        </RNText>
+        {isLoading ? (
+          <ActivityIndicator size="small" color={muted} />
+        ) : (
+          <ChevronRight size={16} color={muted} style={{ transform: [{ rotate: open ? '90deg' : '0deg' }] }} />
+        )}
+      </TouchableOpacity>
+      {open && (
+        <View style={{ marginTop: 8, borderRadius: 11, borderWidth: 1, borderColor: border, overflow: 'hidden' }}>
+          {agents.length === 0 && !isLoading && (
+            <View style={{ paddingHorizontal: 12, paddingVertical: 11 }}>
+              <Text style={{ fontSize: 13, color: muted }}>No agents found for this project.</Text>
+            </View>
+          )}
+          {agents.map((a, i) => {
+            const selected = value === a.name;
+            return (
+              <TouchableOpacity
+                key={a.name}
+                onPress={() => { haptics.selection(); onChange(a.name); setOpen(false); }}
+                activeOpacity={0.6}
+                style={{ flexDirection: 'row', alignItems: 'center', paddingHorizontal: 12, paddingVertical: 11, borderTopWidth: i === 0 ? 0 : 1, borderTopColor: border }}
+              >
+                <View style={{ flex: 1 }}>
+                  <RNText style={{ fontSize: 13.5, fontFamily: MONO, color: fg }}>{a.name}</RNText>
+                  {a.description ? (
+                    <RNText style={{ fontSize: 11.5, color: muted, marginTop: 2 }} numberOfLines={1}>{a.description}</RNText>
+                  ) : null}
+                </View>
+                {selected && <Check size={15} color={theme.primary} strokeWidth={3} />}
+              </TouchableOpacity>
+            );
+          })}
+        </View>
+      )}
+    </View>
+  );
+}
+
+// ─── Model ────────────────────────────────────────────────────────────────────
+
+export function ModelPickerField({
+  projectId,
+  value,
+  onChange,
+  isDark,
+}: {
+  projectId: string;
+  /** Selected wire model id, or null to resolve the agent/account/platform default at fire time. */
+  value: string | null;
+  onChange: (modelID: string | null) => void;
+  isDark: boolean;
+}) {
+  const theme = useThemeColors();
+  const { fg, muted, border, inputBg } = useFieldColors(isDark);
+  const [open, setOpen] = useState(false);
+  const { models, isLoading, gatewayDisabled } = useProjectModelCatalogForTrigger(projectId);
+  const current = models.find((m) => m.modelID === value);
+
+  if (gatewayDisabled) {
+    return (
+      <View>
+        <FieldLabel muted={muted}>Model</FieldLabel>
+        <Text style={{ fontSize: 12.5, color: muted, lineHeight: 18 }}>
+          Enable the LLM gateway for this project (Settings → LLM) to pin a model for this trigger.
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <View>
+      <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', marginTop: 14 }}>
+        <Text style={{ fontSize: 12, fontFamily: 'Roobert-Medium', color: muted }}>Model</Text>
+        {value && (
+          <TouchableOpacity onPress={() => { haptics.tap(); onChange(null); }} hitSlop={6}>
+            <Text style={{ fontSize: 12, fontFamily: 'Roobert-Medium', color: theme.primary }}>Use default</Text>
+          </TouchableOpacity>
+        )}
+      </View>
+      <TouchableOpacity
+        onPress={() => { haptics.tap(); setOpen((v) => !v); }}
+        activeOpacity={0.7}
+        style={{ height: 44, borderRadius: 11, borderWidth: 1, borderColor: border, backgroundColor: inputBg, paddingHorizontal: 12, flexDirection: 'row', alignItems: 'center', marginTop: 6 }}
+      >
+        <RNText style={{ flex: 1, fontSize: 14, color: fg }} numberOfLines={1}>
+          {current?.modelName ?? 'Default'}
+        </RNText>
+        {isLoading ? (
+          <ActivityIndicator size="small" color={muted} />
+        ) : (
+          <ChevronRight size={16} color={muted} style={{ transform: [{ rotate: open ? '90deg' : '0deg' }] }} />
+        )}
+      </TouchableOpacity>
+      {open && (
+        <View style={{ marginTop: 8, borderRadius: 11, borderWidth: 1, borderColor: border, overflow: 'hidden' }}>
+          <TouchableOpacity
+            onPress={() => { haptics.selection(); onChange(null); setOpen(false); }}
+            activeOpacity={0.6}
+            style={{ flexDirection: 'row', alignItems: 'center', paddingHorizontal: 12, paddingVertical: 11 }}
+          >
+            <RNText style={{ flex: 1, fontSize: 13.5, color: fg }}>Default</RNText>
+            {value == null && <Check size={15} color={theme.primary} strokeWidth={3} />}
+          </TouchableOpacity>
+          {models.map((m) => {
+            const selected = value === m.modelID;
+            return (
+              <TouchableOpacity
+                key={m.modelID}
+                onPress={() => { haptics.selection(); onChange(m.modelID); setOpen(false); }}
+                activeOpacity={0.6}
+                style={{ flexDirection: 'row', alignItems: 'center', paddingHorizontal: 12, paddingVertical: 11, borderTopWidth: 1, borderTopColor: border }}
+              >
+                <RNText style={{ flex: 1, fontSize: 13.5, color: fg }} numberOfLines={1}>{m.modelName}</RNText>
+                {selected && <Check size={15} color={theme.primary} strokeWidth={3} />}
+              </TouchableOpacity>
+            );
+          })}
+        </View>
+      )}
+    </View>
+  );
+}

--- a/apps/mobile/components/pages/WebhooksPage.tsx
+++ b/apps/mobile/components/pages/WebhooksPage.tsx
@@ -43,6 +43,7 @@ import { PageHeader } from '@/components/ui/page-header';
 import { PageContent } from '@/components/ui/page-content';
 import { SearchListHeader } from '@/components/ui/search-list-header';
 import { useThemeColors, getSheetBg } from '@/lib/theme-colors';
+import { AgentPickerField, ModelPickerField } from './TriggerAgentModelFields';
 import {
   useProjectTriggers,
   useCreateProjectTrigger,
@@ -112,7 +113,8 @@ function WebhookCreateSheet({
   const [name, setName] = useState('');
   const [secret, setSecret] = useState(genSecret);
   const [prompt, setPrompt] = useState('');
-  const [agent, setAgent] = useState('default');
+  const [agent, setAgent] = useState<string | null>(null);
+  const [model, setModel] = useState<string | null>(null);
   const [err, setErr] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
   const [saving, setSaving] = useState(false);
@@ -147,7 +149,8 @@ function WebhookCreateSheet({
         slug,
         type: 'webhook',
         prompt_template: prompt,
-        agent: agent.trim() || 'default',
+        ...(agent ? { agent } : {}),
+        ...(model ? { model } : {}),
         enabled: true,
         secret_env: env,
       });
@@ -191,8 +194,8 @@ function WebhookCreateSheet({
         <Text style={{ fontSize: 12, fontFamily: 'Roobert-Medium', color: muted, marginTop: 16, marginBottom: 6 }}>Prompt</Text>
         <BottomSheetTextInput value={prompt} onChangeText={setPrompt} placeholder="What should the agent do when a request arrives?" placeholderTextColor={muted} multiline style={[input, { height: 96, paddingTop: 10, textAlignVertical: 'top' }]} />
 
-        <Text style={{ fontSize: 12, fontFamily: 'Roobert-Medium', color: muted, marginTop: 14, marginBottom: 6 }}>Agent</Text>
-        <BottomSheetTextInput value={agent} onChangeText={setAgent} placeholder="default" placeholderTextColor={muted} autoCapitalize="none" autoCorrect={false} style={[input, { fontFamily: MONO }]} />
+        <AgentPickerField projectId={projectId} value={agent} onChange={setAgent} isDark={isDark} />
+        <ModelPickerField projectId={projectId} value={model} onChange={setModel} isDark={isDark} />
 
         {err && (
           <View style={{ marginTop: 14, padding: 12, borderRadius: 11, backgroundColor: 'rgba(239,68,68,0.08)', borderWidth: 1, borderColor: 'rgba(239,68,68,0.3)' }}>
@@ -301,6 +304,16 @@ function WebhookDetailSheet({
       onError: (e: any) => Alert.alert('Failed', e?.message || 'Could not save prompt.'),
     });
   };
+  const handleAgentChange = (agent: string) => {
+    update.mutate({ slug: trigger.slug, input: { agent } }, {
+      onError: (e: any) => Alert.alert('Failed', e?.message || 'Could not update agent.'),
+    });
+  };
+  const handleModelChange = (model: string | null) => {
+    update.mutate({ slug: trigger.slug, input: { model } }, {
+      onError: (e: any) => Alert.alert('Failed', e?.message || 'Could not update model.'),
+    });
+  };
   const handleDelete = () => {
     Alert.alert('Remove webhook', `Remove "${trigger.name || trigger.slug}"? Incoming requests will stop firing.`, [
       { text: 'Cancel', style: 'cancel' },
@@ -380,10 +393,12 @@ function WebhookDetailSheet({
           </TouchableOpacity>
         )}
 
+        <AgentPickerField projectId={projectId} value={trigger.agent} onChange={handleAgentChange} isDark={isDark} />
+        <ModelPickerField projectId={projectId} value={trigger.model} onChange={handleModelChange} isDark={isDark} />
+
         {/* Metadata */}
         <View style={{ marginTop: 22, borderRadius: 12, borderWidth: 1, borderColor: border, paddingHorizontal: 14 }}>
           {[
-            { l: 'Agent', v: trigger.agent || 'default' },
             { l: 'Last fired', v: relativeTime(trigger.last_fired_at) },
             { l: 'Source', v: trigger.path },
           ].map((row, i) => (

--- a/apps/mobile/lib/projects/hooks.ts
+++ b/apps/mobile/lib/projects/hooks.ts
@@ -3,6 +3,7 @@
  * Query keys mirror the web app: ['accounts'] and ['projects', accountId].
  */
 
+import { useMemo } from 'react';
 import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
   archiveProject,
@@ -32,6 +33,7 @@ import {
   getSlackMode,
   getProject,
   getProjectDetail,
+  getProjectLlmCatalog,
   getProjectCommitDiff,
   getProjectFileHistory,
   getVersionDiff,
@@ -90,12 +92,16 @@ import {
   type UpdateSandboxTemplateInput,
 } from './projects-client';
 import { invalidateAfterProjectCreation } from './project-mutation-cache';
+import { filterTriggerAgents, flattenTriggerModelCatalog } from './trigger-picker-options';
+
+export type { TriggerAgentOption, TriggerModelOption } from './trigger-picker-options';
 
 export const projectKeys = {
   accounts: ['accounts'] as const,
   projects: (accountId: string | null | undefined) => ['projects', accountId] as const,
   project: (projectId: string | null | undefined) => ['project', projectId] as const,
   projectDetail: (projectId: string | null | undefined) => ['project-detail', projectId] as const,
+  llmCatalog: (projectId: string | null | undefined) => ['project-llm-catalog', projectId] as const,
   projectFile: (projectId: string | null | undefined, path: string | null | undefined) =>
     ['project-file', projectId, path] as const,
   projectSessions: (projectId: string | null | undefined) =>
@@ -691,6 +697,34 @@ export function useFireProjectTrigger(projectId: string) {
     mutationFn: (slug: string) => fireProjectTrigger(projectId, slug),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: projectKeys.triggers(projectId) }),
   });
+}
+
+/** Server-side, sandbox-free agent list for a trigger's "Agent" picker — a
+ *  project may not have a live sandbox running when you're just configuring
+ *  a trigger, so this reads the repo config directly (web parity:
+ *  useVisibleAgents({ projectId })). */
+export function useProjectAgentsForTrigger(projectId: string | null) {
+  const { data, isLoading } = useProjectDetail(projectId);
+  const agents = useMemo(() => filterTriggerAgents(data?.config.agents), [data]);
+  return { agents, isLoading };
+}
+
+/** Gateway model catalog for a trigger's "Model" override picker (web parity:
+ *  useOpenCodeProviders() + flattenModels() in gateway mode). Sandbox-free —
+ *  reads the project's server-side catalog directly. `gatewayDisabled` is
+ *  true when the project hasn't turned the LLM gateway on; treat that as "no
+ *  override available" rather than an error. */
+export function useProjectModelCatalogForTrigger(projectId: string | null) {
+  const query = useQuery({
+    queryKey: projectKeys.llmCatalog(projectId),
+    queryFn: () => getProjectLlmCatalog(projectId!),
+    enabled: !!projectId,
+    staleTime: 60_000,
+    retry: false,
+  });
+  const gatewayDisabled = (query.error as { code?: string } | null)?.code === 'llm_gateway_disabled';
+  const models = useMemo(() => flattenTriggerModelCatalog(query.data?.models), [query.data]);
+  return { models, isLoading: query.isLoading, gatewayDisabled };
 }
 
 // ── Change requests (web parity) ──────────────────────────────────────────────

--- a/apps/mobile/lib/projects/projects-client.ts
+++ b/apps/mobile/lib/projects/projects-client.ts
@@ -409,6 +409,26 @@ export function getProjectDetail(projectId: string) {
   return apiFetch<ProjectDetail>(`/projects/${encodeURIComponent(projectId)}/detail`);
 }
 
+/** Server-side gateway model catalog (web parity). 404s with
+ *  `code: 'llm_gateway_disabled'` when the project hasn't turned the gateway
+ *  on — callers should treat that as "no model override available", not an
+ *  error to surface. */
+export interface ProjectLlmCatalogResponse {
+  models: Record<string, {
+    name: string;
+    free?: boolean;
+    reasoning?: boolean;
+    tool_call?: boolean;
+    attachment?: boolean;
+    temperature?: boolean;
+    limit?: { context?: number; output?: number };
+  }>;
+}
+
+export function getProjectLlmCatalog(projectId: string) {
+  return apiFetch<ProjectLlmCatalogResponse>(`/projects/${encodeURIComponent(projectId)}/llm-catalog`);
+}
+
 /** Read a repo file's content at the project's default ref (for config source views). */
 export function readProjectFile(projectId: string, path: string, ref?: string) {
   const params = new URLSearchParams({ path });
@@ -1030,6 +1050,10 @@ export interface ProjectTrigger {
   name: string;
   type: ProjectTriggerType;
   agent: string;
+  /** Wire-form model (`provider/model`) pinned to this trigger's runs, or
+   *  null to resolve the default chain (agent → project → account →
+   *  platform) at fire time. */
+  model: string | null;
   enabled: boolean;
   prompt_template: string;
   last_fired_at: string | null;
@@ -1059,6 +1083,9 @@ export interface CreateProjectTriggerInput {
   type: ProjectTriggerType;
   prompt_template: string;
   agent?: string;
+  /** Wire-form model (`provider/model`). Omit or pass null to resolve the
+   *  default chain (agent → project → account → platform) at fire time. */
+  model?: string | null;
   enabled?: boolean;
   cron?: string;
   run_at?: string;
@@ -1070,6 +1097,8 @@ export interface UpdateProjectTriggerInput {
   name?: string;
   prompt_template?: string;
   agent?: string;
+  /** Wire-form model (`provider/model`). null resets to the default chain. */
+  model?: string | null;
   enabled?: boolean;
   cron?: string;
   run_at?: string;

--- a/apps/mobile/lib/projects/trigger-picker-options.test.ts
+++ b/apps/mobile/lib/projects/trigger-picker-options.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from 'bun:test';
+
+import { filterTriggerAgents, flattenTriggerModelCatalog } from './trigger-picker-options';
+
+describe('filterTriggerAgents', () => {
+  test('drops subagents and keeps primary + unset-mode roles', () => {
+    const result = filterTriggerAgents([
+      { name: 'default', path: 'a', description: 'Default agent', mode: 'primary' },
+      { name: 'helper', path: 'b', description: null, mode: 'subagent' },
+      { name: 'legacy', path: 'c', description: null, mode: null },
+    ]);
+    expect(result).toEqual([
+      { name: 'default', description: 'Default agent' },
+      { name: 'legacy', description: null },
+    ]);
+  });
+
+  test('returns an empty list when no agents are given', () => {
+    expect(filterTriggerAgents(undefined)).toEqual([]);
+    expect(filterTriggerAgents([])).toEqual([]);
+  });
+});
+
+describe('flattenTriggerModelCatalog', () => {
+  test('flattens and sorts by display name', () => {
+    const result = flattenTriggerModelCatalog({
+      'anthropic/claude-sonnet-4-6': { name: 'Claude Sonnet 4.6' },
+      'openai/gpt-5': { name: 'GPT-5' },
+    });
+    expect(result).toEqual([
+      { modelID: 'anthropic/claude-sonnet-4-6', modelName: 'Claude Sonnet 4.6' },
+      { modelID: 'openai/gpt-5', modelName: 'GPT-5' },
+    ]);
+  });
+
+  test('falls back to the model id when name is empty', () => {
+    const result = flattenTriggerModelCatalog({ 'bare-model-id': { name: '' } });
+    expect(result).toEqual([{ modelID: 'bare-model-id', modelName: 'bare-model-id' }]);
+  });
+
+  test('returns an empty list when the catalog is undefined', () => {
+    expect(flattenTriggerModelCatalog(undefined)).toEqual([]);
+  });
+});

--- a/apps/mobile/lib/projects/trigger-picker-options.ts
+++ b/apps/mobile/lib/projects/trigger-picker-options.ts
@@ -1,0 +1,33 @@
+/**
+ * Pure transforms behind the Schedules/Webhooks Agent + Model pickers — split
+ * out of hooks.ts so they're testable without pulling in React Native/Expo
+ * (importing hooks.ts directly drags in the whole client + RN runtime).
+ */
+
+import type { ProjectAgentEntry, ProjectLlmCatalogResponse } from './projects-client';
+
+export interface TriggerAgentOption {
+  name: string;
+  description: string | null;
+}
+
+/** Non-subagent roles a trigger can run as. */
+export function filterTriggerAgents(agents: ProjectAgentEntry[] | undefined): TriggerAgentOption[] {
+  return (agents ?? [])
+    .filter((a) => a.mode !== 'subagent')
+    .map((a) => ({ name: a.name, description: a.description }));
+}
+
+export interface TriggerModelOption {
+  modelID: string;
+  modelName: string;
+}
+
+/** Flatten + sort the gateway catalog into picker options. */
+export function flattenTriggerModelCatalog(
+  models: ProjectLlmCatalogResponse['models'] | undefined,
+): TriggerModelOption[] {
+  return Object.entries(models ?? {})
+    .map(([modelID, model]) => ({ modelID, modelName: model.name || modelID }))
+    .sort((a, b) => a.modelName.localeCompare(b.modelName));
+}

--- a/apps/web/src/components/projects/schedule-view.tsx
+++ b/apps/web/src/components/projects/schedule-view.tsx
@@ -60,9 +60,15 @@ import { errorToast, successToast } from '@/components/ui/toast';
 import { Icon } from '@/features/icon/icon';
 import { EmptyState as EmptyStateBox } from '@/features/layout/section/empty-state';
 import { ErrorState } from '@/features/layout/section/error-state';
+import { ModelSelector } from '@/features/session/model-selector';
+import { AgentSelector, flattenModels } from '@/features/session/session-chat-input';
 import CustomizeSectionWrapper from '@/features/workspace/customize/sections/component/section-wrapper';
+import { type ModelKey, modelKeyToWire, wireToModelKey } from '@/hooks/opencode/use-model-store';
+import { useOpenCodeProviders, useVisibleAgents } from '@/hooks/opencode/use-opencode-sessions';
 import { getEnv } from '@/lib/env-config';
 import {
+  type ProjectAccessMember,
+  type ProjectTrigger,
   createProjectTrigger,
   deleteProjectTrigger,
   fireProjectTrigger,
@@ -70,8 +76,6 @@ import {
   listProjectTriggers,
   updateProjectTrigger,
   upsertProjectSecret,
-  type ProjectAccessMember,
-  type ProjectTrigger,
 } from '@/lib/projects-client';
 import { cn } from '@/lib/utils';
 import {
@@ -97,7 +101,7 @@ import {
   Webhook,
 } from 'lucide-react';
 import { useTranslations } from 'next-intl';
-import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react';
+import { type ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
 
 /* ─── Cron presets ──────────────────────────────────────────────────────── */
 
@@ -604,6 +608,7 @@ function TriggerDetailSheet({
           <div className="space-y-8">
             {isCron ? <CronSection trigger={trigger} /> : <WebhookSection trigger={trigger} />}
             <PromptTemplateSection projectId={projectId} trigger={trigger} onMutated={onMutated} />
+            <AgentModelSection projectId={projectId} trigger={trigger} onMutated={onMutated} />
             <OwnerSection projectId={projectId} trigger={trigger} onMutated={onMutated} />
             <MetaSection trigger={trigger} />
           </div>
@@ -665,6 +670,85 @@ function TriggerDetailToolbar({
         </DropdownMenuContent>
       </DropdownMenu>
     </div>
+  );
+}
+
+function AgentModelSection({
+  projectId,
+  trigger,
+  onMutated,
+}: {
+  projectId: string;
+  trigger: ProjectTrigger;
+  onMutated: () => void;
+}) {
+  const agents = useVisibleAgents({ projectId });
+  const { data: providers } = useOpenCodeProviders();
+  const models = useMemo(() => flattenModels(providers), [providers]);
+  const selectedModel = trigger.model ? wireToModelKey(trigger.model) : null;
+
+  const saveAgent = useMutation({
+    mutationFn: (agent: string) => updateProjectTrigger(projectId, trigger.slug, { agent }),
+    onSuccess: () => {
+      successToast('Agent updated');
+      onMutated();
+    },
+    onError: (e: Error) => errorToast(e.message || 'Failed to update agent'),
+  });
+  const saveModel = useMutation({
+    mutationFn: (model: ModelKey | null) =>
+      updateProjectTrigger(projectId, trigger.slug, {
+        model: model ? modelKeyToWire(model) : null,
+      }),
+    onSuccess: () => {
+      successToast('Model updated');
+      onMutated();
+    },
+    onError: (e: Error) => errorToast(e.message || 'Failed to update model'),
+  });
+
+  return (
+    <section className="space-y-4">
+      <div className="space-y-2">
+        <Label>Agent</Label>
+        <div className="bg-card rounded-2xl border px-2 py-1">
+          <AgentSelector
+            agents={agents}
+            selectedAgent={trigger.agent}
+            onSelect={(next) => next && saveAgent.mutate(next)}
+            disabled={saveAgent.isPending}
+          />
+        </div>
+      </div>
+      <div className="space-y-2">
+        <div className="flex items-center justify-between gap-2">
+          <Label>Model</Label>
+          {trigger.model && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-6 px-2 text-xs"
+              disabled={saveModel.isPending}
+              onClick={() => saveModel.mutate(null)}
+            >
+              Use default
+            </Button>
+          )}
+        </div>
+        <div className="bg-card rounded-2xl border px-2 py-1">
+          <ModelSelector
+            models={models}
+            providers={providers}
+            selectedModel={selectedModel}
+            onSelect={(next) => saveModel.mutate(next)}
+          />
+        </div>
+        <p className="text-muted-foreground/70 text-xs leading-relaxed text-pretty">
+          Overrides the agent's default model for this trigger's runs. Leave unset to resolve the
+          agent → account → platform default at fire time.
+        </p>
+      </div>
+    </section>
   );
 }
 
@@ -932,7 +1016,6 @@ function MetaSection({ trigger }: { trigger: ProjectTrigger }) {
       <PropertyTable
         rows={[
           { label: 'Slug', value: <span className="font-mono text-xs">{trigger.slug}</span> },
-          { label: 'Agent', value: <span className="font-mono text-xs">{trigger.agent}</span> },
           {
             label: 'Source file',
             value: <span className="font-mono text-xs">{trigger.path}</span>,
@@ -1056,10 +1139,15 @@ function CreateTriggerModal({
 
   const [name, setName] = useState('');
   const [prompt, setPrompt] = useState('');
-  const [agentName, setAgentName] = useState('default');
+  const [agentName, setAgentName] = useState<string | null>(null);
+  const [selectedModel, setSelectedModel] = useState<ModelKey | null>(null);
   const [ownerUserId, setOwnerUserId] = useState<string | null>(null);
 
   const [error, setError] = useState<string | null>(null);
+
+  const agents = useVisibleAgents({ projectId });
+  const { data: providers } = useOpenCodeProviders();
+  const models = useMemo(() => flattenModels(providers), [providers]);
 
   const access = useQuery({
     queryKey: ['project-access', projectId],
@@ -1083,7 +1171,8 @@ function CreateTriggerModal({
       setWebhookSecret('');
       setName('');
       setPrompt('');
-      setAgentName('default');
+      setAgentName(null);
+      setSelectedModel(null);
       setOwnerUserId(null);
       setError(null);
     }
@@ -1121,7 +1210,8 @@ function CreateTriggerModal({
         name: trimmedName,
         type: sourceType,
         prompt_template: trimmedPrompt,
-        agent: agentName.trim() || 'default',
+        ...(agentName ? { agent: agentName } : {}),
+        ...(selectedModel ? { model: modelKeyToWire(selectedModel) } : {}),
         ...(ownerUserId ? { owner_user_id: ownerUserId } : {}),
         ...(sourceType === 'cron'
           ? runAt
@@ -1390,14 +1480,27 @@ function CreateTriggerModal({
                 label="Agent"
                 description="Which agent profile handles each run."
               >
-                <Input
-                  id="trigger-agent"
-                  type="text"
-                  value={agentName}
-                  onChange={(e) => setAgentName(e.target.value)}
-                  placeholder="default"
-                  className="font-mono text-sm"
-                />
+                <div className="bg-card rounded-2xl border px-2 py-1">
+                  <AgentSelector
+                    agents={agents}
+                    selectedAgent={agentName}
+                    onSelect={setAgentName}
+                  />
+                </div>
+              </TriggerModalSection>
+
+              <TriggerModalSection
+                label="Model"
+                description="Overrides the agent's default model for this trigger's runs. Leave unset to use the agent's default."
+              >
+                <div className="bg-card rounded-2xl border px-2 py-1">
+                  <ModelSelector
+                    models={models}
+                    providers={providers}
+                    selectedModel={selectedModel}
+                    onSelect={setSelectedModel}
+                  />
+                </div>
               </TriggerModalSection>
 
               <TriggerModalSection

--- a/apps/web/src/lib/projects-client.ts
+++ b/apps/web/src/lib/projects-client.ts
@@ -2298,6 +2298,10 @@ export interface ProjectTrigger {
   name: string;
   type: ProjectTriggerType;
   agent: string;
+  /** Wire-form model (`provider/model`) pinned to this trigger's runs, or
+   *  null to resolve the default chain (agent → project → account →
+   *  platform) at fire time. */
+  model: string | null;
   enabled: boolean;
   cron: string | null;
   /** ISO-8601 instant for a one-off ("run once") schedule; null for recurring/webhook. */
@@ -2348,6 +2352,9 @@ export interface CreateProjectTriggerInput {
   prompt_template: string;
   /** Defaults to 'default'. */
   agent?: string;
+  /** Wire-form model (`provider/model`). Omit or pass null to resolve the
+   *  default chain (agent → project → account → platform) at fire time. */
+  model?: string | null;
   enabled?: boolean;
   /** For type='cron'. 6-field croner expression. Omit when using `run_at`. */
   cron?: string;
@@ -2366,6 +2373,8 @@ export interface UpdateProjectTriggerInput {
   name?: string;
   prompt_template?: string;
   agent?: string;
+  /** Wire-form model (`provider/model`). null resets to the default chain. */
+  model?: string | null;
   enabled?: boolean;
   cron?: string;
   timezone?: string;

--- a/packages/sdk/src/platform/projects-client/triggers.ts
+++ b/packages/sdk/src/platform/projects-client/triggers.ts
@@ -23,6 +23,10 @@ export interface ProjectTrigger {
   name: string;
   type: ProjectTriggerType;
   agent: string;
+  /** Wire-form model (`provider/model`) pinned to this trigger's runs, or
+   *  null to resolve the default chain (agent → project → account →
+   *  platform) at fire time. */
+  model: string | null;
   enabled: boolean;
   cron: string | null;
   /** ISO-8601 instant for a one-off ("run once") schedule; null for recurring/webhook. */
@@ -73,6 +77,9 @@ export interface CreateProjectTriggerInput {
   prompt_template: string;
   /** Defaults to 'default'. */
   agent?: string;
+  /** Wire-form model (`provider/model`). Omit or pass null to resolve the
+   *  default chain (agent → project → account → platform) at fire time. */
+  model?: string | null;
   enabled?: boolean;
   /** For type='cron'. 6-field croner expression. Omit when using `run_at`. */
   cron?: string;
@@ -91,6 +98,8 @@ export interface UpdateProjectTriggerInput {
   name?: string;
   prompt_template?: string;
   agent?: string;
+  /** Wire-form model (`provider/model`). null resets to the default chain. */
+  model?: string | null;
   enabled?: boolean;
   cron?: string;
   timezone?: string;

--- a/tests/src/flows/triggers.flow.ts
+++ b/tests/src/flows/triggers.flow.ts
@@ -17,13 +17,20 @@ flow(
   { domain: "triggers", routes: ["POST /v1/projects/:projectId/triggers"] },
   async (ctx) => {
     const p = await ctx.fixtures.project();
-    await ctx.step("create a cron trigger → 201", async () => {
+    await ctx.step("create a cron trigger with a pinned model → 201", async () => {
       const r = await ctx.client.as(ctx.P.OWNER).post(
         "/v1/projects/:projectId/triggers",
-        { name: "Nightly", type: "cron", cron: "0 0 3 * * *", timezone: "UTC", prompt_template: "do nightly work" },
+        {
+          name: "Nightly",
+          type: "cron",
+          cron: "0 0 3 * * *",
+          timezone: "UTC",
+          prompt_template: "do nightly work",
+          model: "anthropic/claude-sonnet-4-6",
+        },
         { params: { projectId: p.id } },
       );
-      r.status(201);
+      r.status(201).body().has("triggers[0].model", "anthropic/claude-sonnet-4-6");
     });
     await ctx.step("duplicate slug → 409", async () => {
       const r = await ctx.client.as(ctx.P.OWNER).post(
@@ -51,6 +58,18 @@ flow(
         .as(ctx.P.OWNER)
         .patch("/v1/projects/:projectId/triggers/:slug", { enabled: false }, { params: { projectId: p.id, slug: "toggle-me" } });
       r.status(200);
+    });
+    // Regression: a PATCH body with ONLY `model` must still persist — it was
+    // previously dropped silently (manifest-key allowlist omitted "model").
+    await ctx.step("patch model only → persists", async () => {
+      const r = await ctx.client
+        .as(ctx.P.OWNER)
+        .patch(
+          "/v1/projects/:projectId/triggers/:slug",
+          { model: "openai/gpt-5" },
+          { params: { projectId: p.id, slug: "toggle-me" } },
+        );
+      r.status(200).body().has("triggers[0].model", "openai/gpt-5");
     });
   },
 );


### PR DESCRIPTION
## Summary
- Schedule/webhook trigger create + edit had a free-text "Agent" input instead of the real agent selector used elsewhere (chat input), and no way to pin a model override for a trigger.
- The backend already had most of the plumbing (`GitTriggerSpec.model`) but two gaps kept it from working: a PATCH body containing only `model` was silently dropped (manifest-key allowlist omitted `"model"`), and `fireGitTrigger` never forwarded the pinned model into the session it creates.
- Fixes both backend gaps, adds `model` to the SDK/web/mobile client types, and wires the real `AgentSelector`/`ModelSelector` (same components as chat) into the web create dialog + detail sheet, and an equivalent picker into the mobile Schedules/Webhooks pages.

## Changes
- `apps/api/src/projects/routes/r4.ts`: add `"model"` to `TRIGGER_MANIFEST_KEYS` so a model-only PATCH persists.
- `apps/api/src/projects/lib/triggers.ts`: `fireGitTrigger` now forwards `spec.model` as `opencode_model` on the session it creates when set.
- `packages/sdk`, `apps/web/src/lib/projects-client.ts`, `apps/mobile/lib/projects/projects-client.ts`: add `model` to trigger create/update/read types.
- `apps/web/src/components/projects/schedule-view.tsx`: replace the free-text Agent `Input` with `AgentSelector`, add a `ModelSelector` field, in both the create modal and a new editable `AgentModelSection` in the trigger detail sheet.
- `apps/mobile`: new sandbox-free `useProjectAgentsForTrigger`/`useProjectModelCatalogForTrigger` hooks (a trigger can be configured before any session/sandbox exists) backing a new `AgentPickerField`/`ModelPickerField` shared component, wired into `SchedulesPage`/`WebhooksPage` create + detail sheets.
- Tests: new/extended `apps/api/src/__tests__/e2e-project-triggers.test.ts` cases (model create/PATCH persistence regression, fire-time model passthrough), extended `tests/src/flows/triggers.flow.ts` (TRG-2/TRG-3), new `apps/mobile/lib/projects/trigger-picker-options.test.ts` for the pure picker-option transforms.

## Test plan
- [x] `apps/api` typecheck + trigger test suite green (`e2e-project-triggers`, `unit-trigger-dsl`, `unit-trigger-owner`, `unit-trigger-pause`, `unit-trigger-activation-route`)
- [x] `packages/sdk` typecheck green
- [x] `apps/web` typecheck green (no new errors in touched files)
- [x] `apps/mobile` typecheck green (no new errors in touched files) + full `bun test` suite green
- [ ] Manual click-through of the web Schedules/Webhooks create + edit flow (not verified in a running browser this session)