### PR TITLE
fix(desktop): tighten /projects header + polish project sidebar

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1114,13 +1114,22 @@ html[data-desktop-platform='macos'] {
 }
 
 /* AppHeader (the breadcrumb bar on standalone pages like /projects, /accounts):
-   clear the OS window controls on desktop by reserving space ABOVE the header
-   (a blank strip that holds the macOS traffic lights / Win-Linux control
-   cluster), instead of indenting the header sideways. Keeps the breadcrumb
-   left-aligned and the page content at full width. `py-4` (1rem) is preserved
-   on top of the title-bar inset. */
+   clear the OS window controls on desktop by reserving just enough space ABOVE
+   the header for them, so the breadcrumb row sits in a tight, even band right
+   below the macOS traffic lights / Win-Linux control cluster instead of
+   floating far under them. Keeps the breadcrumb left-aligned and the page
+   content at full width (no sideways indent). */
 html[data-desktop='true'] .kx-app-header {
-  padding-top: calc(var(--kx-titlebar-inset) + 1rem);
+  /* Win/Linux: controls live in a 32px top-right strip — clear it with a small
+     even gap (28px inset + 0.5rem = 36px). */
+  padding-top: calc(var(--kx-titlebar-inset) + 0.5rem);
+  padding-bottom: 0.75rem;
+}
+/* macOS: traffic lights sit at y≈18–30; drop the header just below them
+   (40px inset − 0.25rem = 36px) so the row reads as aligned with the lights
+   rather than pushed down. */
+html[data-desktop-platform='macos'] .kx-app-header {
+  padding-top: calc(var(--kx-titlebar-inset) - 0.25rem);
 }
 
 /* Reusable title-bar spacer: a blank, draggable strip the height of the OS

--- a/apps/web/src/features/workspace/project-sidebar/project-sidebar.tsx
+++ b/apps/web/src/features/workspace/project-sidebar/project-sidebar.tsx
@@ -279,11 +279,14 @@ export function ProjectSidebar({ projectId }: { projectId: string }) {
                 <SidebarMenuButton
                   onClick={handleNewSession}
                   size="md"
-                  className="group/menu-button text-sidebar-foreground border-border dark:bg-background dark:hover:bg-background/90 bg-background hover:bg-background/90 flex items-center justify-center border-[1.2px] text-center !text-sm [&_svg]:!size-5"
+                  className="group/menu-button text-sidebar-foreground border-border dark:bg-background dark:hover:bg-background/90 bg-background hover:bg-background/90 relative flex items-center justify-start gap-2 border-[1.2px] font-medium !text-sm [&_svg]:!size-4"
                 >
-                  {tI18nHardcoded.raw(
-                    'autoFeaturesCoWorkerProjectSidebarProjectSidebarJsxTextNew55d0b491',
-                  )}
+                  <Plus className="text-muted-foreground" />
+                  <span>
+                    {tI18nHardcoded.raw(
+                      'autoFeaturesCoWorkerProjectSidebarProjectSidebarJsxTextNew55d0b491',
+                    )}
+                  </span>
                   <KbdGroup className="absolute top-1/2 right-2 -translate-y-1/2 opacity-0 transition-opacity duration-200 group-hover/menu-button:opacity-100">
                     <Kbd>{modSymbol}</Kbd>
                     <Kbd>J</Kbd>
@@ -298,9 +301,9 @@ export function ProjectSidebar({ projectId }: { projectId: string }) {
                 label only carries the active filter; the ⋯ button opens the
                 filter menu. */}
             <div className="flex min-h-0 flex-1 flex-col space-y-2">
-              <SidebarGroupLabel className="text-muted-foreground/60 mt-1 flex h-6 items-center px-0 text-xs font-medium tracking-wider uppercase">
+              <SidebarGroupLabel className="text-muted-foreground/60 mt-1 flex h-6 items-center px-0 text-[11px] font-medium tracking-wider uppercase">
                 <div className="flex w-full flex-row items-center gap-0.5">
-                  <div className="flex min-w-0 flex-1 flex-row items-center gap-0.5 px-2 text-[13px] font-normal">
+                  <div className="flex min-w-0 flex-1 flex-row items-center gap-1.5 px-2">
                     <span>Sessions</span>
                     {sessionFilter !== 'all' && (
                       <span className="text-muted-foreground/90 truncate tracking-normal normal-case">


### PR DESCRIPTION
## What & why

Two desktop-only UI fixes on the `/projects` page and the project/session sidebar, reported as looking loose/unpolished.

### 1. `/projects` header top padding
The standalone `AppHeader` reserved `titlebar-inset + 1rem` above itself, floating the breadcrumb row far below the OS window controls (**56px** on macOS, **44px** on Win/Linux). Now the row sits in a tight, even band right below the controls:

- **macOS**: `inset − 0.25rem` = **36px** → ~6px below the traffic lights (which sit at y≈18–30), so the row reads as aligned with them.
- **Win/Linux**: `inset + 0.5rem` = **36px** → clears the 32px top-right control strip with a 4px gap.
- Trimmed header bottom padding to `0.75rem` for a balanced bar.

Left alignment / full-width page content is unchanged (no sideways indent).

### 2. Project sidebar polish
- **"New session"**: was centered bare text — now a left-aligned action with a leading `+` icon (matches the collapsed rail's `+` and the standard new-session pattern). Keyboard hint (`⌘J`) preserved.
- **"Sessions" label**: dropped the `text-[13px] font-normal` that was fighting the uppercase micro-label styling; now a crisp 11px uppercase section label.

## Verification
- Reasoned against exact geometry: traffic lights `{x:10, y:18}` (`main.js`), 40px macOS / 28px Win-Linux titlebar inset, 32px Win/Linux control strip.
- Biome: no new diagnostics introduced.
- Not run in the Electron shell to avoid disrupting the live dev server on :3000 — worth a quick visual pass on macOS + Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)