### PR TITLE
feat(web): hide legacy-machine migration; move to /legacy-machines archive

### DIFF
--- a/apps/web/src/app/(app)/legacy-machines/page.tsx
+++ b/apps/web/src/app/(app)/legacy-machines/page.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { Archive } from 'lucide-react';
+
+import { ConnectingScreen } from '@/components/dashboard/connecting-screen';
+import { LegacyMachineCard } from '@/components/projects/legacy-machine-card';
+import { SectionCard } from '@/components/ui/section-card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { AppHeader } from '@/features/layout/app-header';
+import { EmptyState } from '@/features/layout/section/empty-state';
+import { useAuth } from '@/features/providers/auth-provider';
+import { useLegacyMachines } from '@/hooks/legacy/use-legacy-machine-migration';
+import { listAccounts } from '@/lib/projects-client';
+import { useCurrentAccountStore } from '@/stores/current-account-store';
+
+/**
+ * Hidden archive of legacy (pre-migration) machines. Not linked from the main
+ * nav — reachable by direct URL or a discreet link on the Projects page.
+ * Automatic migration is retired; each machine offers a "request restore" that
+ * emails support. Scoped to the currently selected account, like Projects.
+ */
+export default function LegacyMachinesPage() {
+  const { user, isLoading: authLoading } = useAuth();
+  const { selectedAccountId } = useCurrentAccountStore();
+
+  const accountsQuery = useQuery({
+    queryKey: ['accounts'],
+    queryFn: listAccounts,
+    enabled: !!user,
+    staleTime: 60_000,
+  });
+  const activeAccountId =
+    accountsQuery.data?.find((a) => a.account_id === selectedAccountId)?.account_id ??
+    accountsQuery.data?.[0]?.account_id ??
+    null;
+
+  const machinesQuery = useLegacyMachines({
+    enabled: !!user && !!activeAccountId,
+    accountId: activeAccountId,
+  });
+  const machines = machinesQuery.data?.sandboxes ?? [];
+
+  if (authLoading || !user) {
+    return <ConnectingScreen forceConnecting overrideStage="auth" hideWorkspacePicker />;
+  }
+
+  const loading = accountsQuery.isLoading || machinesQuery.isLoading;
+
+  return (
+    <div className="bg-foreground/5 flex min-h-screen flex-col">
+      <AppHeader user={user} breadcrumb="Legacy machines" />
+      <main className="ring-input bg-background px-mobile flex-1 rounded-t-xl py-10 ring sm:py-12">
+        <div className="mx-auto w-full max-w-6xl space-y-8">
+          <div className="min-w-0 space-y-1">
+            <h1 className="text-foreground text-2xl font-semibold tracking-tight sm:text-3xl">
+              Legacy machines
+            </h1>
+            <p className="text-muted-foreground text-base">
+              Older machines from before the current platform. They&rsquo;re archived and can be
+              restored on request — contact support and we&rsquo;ll bring one back.
+            </p>
+          </div>
+
+          {loading && (
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {['a', 'b', 'c'].map((k) => (
+                <Skeleton key={k} className="h-[132px] rounded-2xl" />
+              ))}
+            </div>
+          )}
+
+          {!loading && machines.length === 0 && (
+            <SectionCard flush>
+              <EmptyState
+                icon={Archive}
+                title="No legacy machines"
+                description="You don't have any archived machines to restore."
+              />
+            </SectionCard>
+          )}
+
+          {!loading && machines.length > 0 && (
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {machines.map((machine) => (
+                <LegacyMachineCard key={machine.sandbox_id} machine={machine} />
+              ))}
+            </div>
+          )}
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/apps/web/src/app/(app)/projects/page.tsx
+++ b/apps/web/src/app/(app)/projects/page.tsx
@@ -2,12 +2,11 @@
 
 import { useTranslations } from 'next-intl';
 
+import Link from 'next/link';
+
 import { ConnectingScreen } from '@/components/dashboard/connecting-screen';
-import { LegacyMachineCard } from '@/components/projects/legacy-machine-card';
 import { PersonalOnboardingWelcome } from '@/components/projects/personal-onboarding-welcome';
-import { SunaMigrationBanner } from '@/components/projects/suna-migration-banner';
 import { Button } from '@/components/ui/button';
-import { EmptyState } from '@/features/layout/section/empty-state';
 import { EntityAvatar } from '@/components/ui/entity-avatar';
 import { Input } from '@/components/ui/input';
 import { SectionCard } from '@/components/ui/section-card';
@@ -18,16 +17,14 @@ import { GlobalUpgradeModal } from '@/features/billing/global-upgrade-modal';
 import { UpgradeButton } from '@/features/billing/upgrade-button';
 import { Icon } from '@/features/icon/icon';
 import { AppHeader } from '@/features/layout/app-header';
+import { EmptyState } from '@/features/layout/section/empty-state';
 import { ProjectCreateModal } from '@/features/projects/modal/project-create-modal';
 import { RenameProjectDialog } from '@/features/projects/modal/rename-project-modal';
 import NewProjectControl from '@/features/projects/new-project-control';
 import ProjectCard from '@/features/projects/project-card';
 import { useAuth } from '@/features/providers/auth-provider';
 import { invalidateAccountState, useAccountState } from '@/hooks/billing';
-import {
-  useLegacyMachines,
-  useStartLegacyMigration,
-} from '@/hooks/legacy/use-legacy-machine-migration';
+import { useLegacyMachines } from '@/hooks/legacy/use-legacy-machine-migration';
 import { billingApi } from '@/lib/api/billing';
 import { isBillingEnabled } from '@/lib/config';
 import {
@@ -190,7 +187,6 @@ export default function ProjectsPage() {
     enabled: !!user && !!activeAccountId,
     accountId: activeAccountId,
   });
-  const startMigration = useStartLegacyMigration(activeAccountId);
 
   // ── Onboarding: only explicit signup/subscription returns auto-bootstrap the
   // first project. A normal empty projects list can come from deleting the last
@@ -261,12 +257,6 @@ export default function ProjectsPage() {
     router,
   ]);
 
-  const handleMigrate = (sandboxId: string) =>
-    startMigration.mutate(sandboxId, {
-      onSuccess: () => successToast('Migration started — this runs in the background'),
-      onError: (e: Error) => errorToast(e.message || 'Failed to start migration'),
-    });
-
   const archiveMutation = useMutation({
     mutationFn: archiveProject,
     onMutate: (projectId) => setArchivingId(projectId),
@@ -285,23 +275,9 @@ export default function ProjectsPage() {
     [filterProjects, projectsQuery.data],
   );
 
-  const projectIds = useMemo(
-    () => new Set((projectsQuery.data ?? []).map((p) => p.project_id)),
-    [projectsQuery.data],
-  );
-
-  const legacyMachines = useMemo(() => {
-    const items = legacyMachinesQuery.data?.sandboxes ?? [];
-    const q = query.trim().toLowerCase();
-    return items.filter((machine) => {
-      const projectId = machine.migration?.project_id;
-      if (machine.migration?.status === 'completed' && projectId && projectIds.has(projectId)) {
-        return false;
-      }
-      if (!q) return true;
-      return machine.name.toLowerCase().includes(q) || machine.provider.toLowerCase().includes(q);
-    });
-  }, [legacyMachinesQuery.data, query, projectIds]);
+  // Legacy machines are no longer shown inline on Projects; the count only drives
+  // the discreet link to the hidden /legacy-machines archive.
+  const hasLegacyMachines = (legacyMachinesQuery.data?.sandboxes?.length ?? 0) > 0;
 
   if (authLoading || !user) {
     return <ConnectingScreen forceConnecting overrideStage="auth" hideWorkspacePicker />;
@@ -314,21 +290,15 @@ export default function ProjectsPage() {
   }
 
   const total = projectsQuery.data?.length ?? 0;
-  const totalLegacy = legacyMachinesQuery.data?.sandboxes?.length ?? 0;
   const showProjectsLoading = accountsQuery.isLoading || projectsQuery.isLoading;
   const showEmptyState =
-    !!activeAccountId &&
-    !showProjectsLoading &&
-    !projectsQuery.isError &&
-    total === 0 &&
-    totalLegacy === 0;
+    !!activeAccountId && !showProjectsLoading && !projectsQuery.isError && total === 0;
   const showNoResults =
     !!activeAccountId &&
     !showProjectsLoading &&
     !projectsQuery.isError &&
-    total + totalLegacy > 0 &&
-    filtered.length === 0 &&
-    legacyMachines.length === 0;
+    total > 0 &&
+    filtered.length === 0;
 
   const allRawTotal = viewAll
     ? accounts.reduce((n, _a, i) => n + (allAccountQueries[i]?.data?.length ?? 0), 0)
@@ -336,13 +306,8 @@ export default function ProjectsPage() {
   const allFilteredTotal = accountGroups.reduce((n, g) => n + g.projects.length, 0);
   const showAllLoading =
     viewAll && (accountsQuery.isLoading || allAccountQueries.some((q) => q.isLoading));
-  const showAllEmpty = viewAll && !showAllLoading && allRawTotal === 0 && totalLegacy === 0;
-  const showAllNoResults =
-    viewAll &&
-    !showAllLoading &&
-    allRawTotal + totalLegacy > 0 &&
-    allFilteredTotal === 0 &&
-    legacyMachines.length === 0;
+  const showAllEmpty = viewAll && !showAllLoading && allRawTotal === 0;
+  const showAllNoResults = viewAll && !showAllLoading && allRawTotal > 0 && allFilteredTotal === 0;
 
   const openCreateModal = (accountId: string | null) => {
     setCreateAccountId(accountId);
@@ -358,7 +323,6 @@ export default function ProjectsPage() {
       />
       <main className="ring-input bg-background px-mobile flex-1 rounded-t-xl py-10 ring sm:py-12">
         <div className="mx-auto w-full max-w-6xl space-y-8">
-          <SunaMigrationBanner accountId={activeAccountId} />
           <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
             <div className="min-w-0 space-y-1">
               <h1 className="text-foreground text-2xl font-semibold tracking-tight sm:text-3xl">
@@ -481,19 +445,8 @@ export default function ProjectsPage() {
                 </SectionCard>
               )}
 
-              {(filtered.length > 0 || legacyMachines.length > 0) && (
+              {filtered.length > 0 && (
                 <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-                  {legacyMachines.map((machine) => (
-                    <LegacyMachineCard
-                      key={machine.sandbox_id}
-                      machine={machine}
-                      starting={
-                        startMigration.isPending && startMigration.variables === machine.sandbox_id
-                      }
-                      onMigrate={() => handleMigrate(machine.sandbox_id)}
-                      onOpenProject={(projectId) => router.push(`/projects/${projectId}`)}
-                    />
-                  ))}
                   {filtered.map((project) => (
                     <ProjectCard
                       key={project.project_id}
@@ -558,22 +511,6 @@ export default function ProjectsPage() {
                 </SectionCard>
               )}
 
-              {!showAllLoading && legacyMachines.length > 0 && (
-                <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-                  {legacyMachines.map((machine) => (
-                    <LegacyMachineCard
-                      key={machine.sandbox_id}
-                      machine={machine}
-                      starting={
-                        startMigration.isPending && startMigration.variables === machine.sandbox_id
-                      }
-                      onMigrate={() => handleMigrate(machine.sandbox_id)}
-                      onOpenProject={(projectId) => router.push(`/projects/${projectId}`)}
-                    />
-                  ))}
-                </div>
-              )}
-
               {!showAllLoading &&
                 accountGroups.map((group) => (
                   <section key={group.account.account_id} className="space-y-4">
@@ -601,6 +538,16 @@ export default function ProjectsPage() {
                     </div>
                   </section>
                 ))}
+            </div>
+          )}
+          {hasLegacyMachines && (
+            <div className="pt-2 text-center">
+              <Link
+                href="/legacy-machines"
+                className="text-muted-foreground hover:text-foreground text-xs underline underline-offset-4 transition-colors"
+              >
+                Looking for older machines?
+              </Link>
             </div>
           )}
         </div>

--- a/apps/web/src/components/projects/legacy-machine-card.tsx
+++ b/apps/web/src/components/projects/legacy-machine-card.tsx
@@ -1,120 +1,57 @@
 'use client';
 
 import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { EntityAvatar } from '@/components/ui/entity-avatar';
 import { type LegacyMachine } from '@/hooks/legacy/use-legacy-machine-migration';
-import { cn } from '@/lib/utils';
-import { useTranslations } from 'next-intl';
-import Loading from '../ui/loading';
 
-const PHASE_LABEL: Record<string, string> = {
-  extract: 'Reading machine',
-  repo: 'Setting up project',
-  push: 'Bringing over files & agents',
-  db: 'Finishing up',
-  done: 'Finishing up',
-};
+const SUPPORT_EMAIL = 'support@kortix.com';
 
-export function LegacyMachineCard({
-  machine,
-  starting,
-  onMigrate,
-  onOpenProject,
-}: {
-  machine: LegacyMachine;
-  starting: boolean;
-  onMigrate: () => void;
-  onOpenProject: (projectId: string) => void;
-}) {
-  const tI18nHardcoded = useTranslations('hardcodedUi');
-  const migration = machine.migration;
-  const busy = starting || migration?.status === 'running' || migration?.status === 'planned';
-  const done = migration?.status === 'completed';
-  const failed = migration?.status === 'failed';
+/**
+ * Read-only card for an archived legacy machine. Automatic migration has been
+ * retired; instead we list the old machine and let the user email support to
+ * request a manual restore (subject/body prefilled with the sandbox id).
+ */
+export function LegacyMachineCard({ machine }: { machine: LegacyMachine }) {
   const providerLabel = machine.provider.charAt(0).toUpperCase() + machine.provider.slice(1);
+  const created = machine.created_at ? new Date(machine.created_at).toLocaleDateString() : null;
 
-  let onClick: (() => void) | null = null;
-  if (done && migration?.project_id) onClick = () => onOpenProject(migration.project_id!);
-  else if (!busy && machine.migratable) onClick = onMigrate;
-  const interactive = !!onClick;
-
-  const badge = busy ? (
-    <Badge variant="info" size="sm" className="gap-1">
-      <Loading className="size-3" />
-      Migrating
-    </Badge>
-  ) : done ? (
-    <Badge variant="success" size="sm">
-      Migrated
-    </Badge>
-  ) : failed ? (
-    <Badge variant="warning" size="sm">
-      {tI18nHardcoded.raw('autoComponentsProjectsLegacyMachineCardJsxTextMigrationFailed81a347fa')}
-    </Badge>
-  ) : machine.migratable ? (
-    <Badge variant="warning" size="sm">
-      {tI18nHardcoded.raw('autoComponentsProjectsLegacyMachineCardJsxTextMustBeMigrated0ff74c6e')}
-    </Badge>
-  ) : (
-    <Badge variant="muted" size="sm">
-      {tI18nHardcoded.raw('autoComponentsProjectsLegacyMachineCardJsxTextCanTMigratec1b5bcd9')}
-    </Badge>
+  const subject = encodeURIComponent(`Restore legacy machine: ${machine.name}`);
+  const body = encodeURIComponent(
+    `Hi Kortix support,\n\nI'd like to restore a legacy machine.\n\n` +
+      `Name: ${machine.name}\nSandbox ID: ${machine.sandbox_id}\nProvider: ${machine.provider}\n` +
+      (created ? `Created: ${created}\n` : ''),
   );
-
-  let subtitle: string;
-  if (busy && migration) {
-    subtitle = `${PHASE_LABEL[migration.phase ?? ''] ?? 'Migrating'}${
-      migration.step ? ` (${migration.step}/${migration.total_steps})` : ''
-    }`;
-  } else if (busy) {
-    subtitle = 'Starting migration';
-  } else if (failed && migration?.error) {
-    subtitle = migration.error;
-  } else if (done) {
-    subtitle = `${providerLabel} · open project`;
-  } else {
-    subtitle = providerLabel;
-  }
-
-  const body = (
-    <div className="flex w-full items-center gap-3">
-      <EntityAvatar label={machine.name} size="lg" className="bg-background" />
-      <div className="min-w-0 flex-1 space-y-1">
-        <h3 className="text-foreground truncate text-sm leading-tight font-semibold">
-          {machine.name}
-        </h3>
-        <p
-          className={cn(
-            'truncate text-xs',
-            failed ? 'text-destructive/80' : 'text-muted-foreground',
-          )}
-          title={failed && migration?.error ? migration.error : undefined}
-        >
-          {subtitle}
-        </p>
-      </div>
-    </div>
-  );
+  const mailto = `mailto:${SUPPORT_EMAIL}?subject=${subject}&body=${body}`;
 
   return (
-    <Card className="group bg-secondary/80 relative p-0">
-      {interactive ? (
-        <button type="button" onClick={onClick!} className="cursor-pointer px-5 py-4 text-left">
-          {body}
-        </button>
-      ) : (
-        <div
-          className="px-5 py-4 text-left"
-          title={
-            !machine.migratable ? 'Only your most recent machines can be migrated.' : undefined
-          }
-        >
-          {body}
+    <Card className="bg-secondary/80 relative flex flex-col gap-3 p-5">
+      <div className="flex w-full items-center gap-3">
+        <EntityAvatar label={machine.name} size="lg" className="bg-background" />
+        <div className="min-w-0 flex-1 space-y-1">
+          <h3 className="text-foreground truncate text-sm leading-tight font-semibold">
+            {machine.name}
+          </h3>
+          <p className="text-muted-foreground truncate text-xs">
+            {providerLabel}
+            {created ? ` · ${created}` : ''}
+          </p>
         </div>
-      )}
-
-      <div className="absolute top-3 right-3">{badge}</div>
+        <Badge variant="muted" size="sm">
+          Archived
+        </Badge>
+      </div>
+      <Button
+        variant="outline"
+        size="sm"
+        className="w-full"
+        onClick={() => {
+          window.location.href = mailto;
+        }}
+      >
+        Request restore
+      </Button>
     </Card>
   );
 }


### PR DESCRIPTION
## What
The legacy-machine auto-migration was failing for users (`toolbox error (401): Invalid proxy token`, "Can't migrate" / "Migration failed"). This retires it from the main **Projects** page and moves old machines to a hidden, read-only archive with a support-driven restore.

## Changes
- **Projects page**: removed the failing `LegacyMachineCard` migrate flow and the `SunaMigrationBanner`. Legacy machines no longer render inline or affect the empty-state gating. Added one discreet **"Looking for older machines?"** link at the bottom (shown only when the account has legacy machines).
- **New hidden page `/legacy-machines`**: read-only list of archived machines (name, provider, created date), scoped to the selected account. Not in the nav — reachable by direct URL or the discreet link.
- **`LegacyMachineCard`**: now read-only with a **"Request restore" → `mailto:support@kortix.com`** (subject/body prefilled with the sandbox id) instead of the retired migrate action.
- Kept `useLegacyMachines` (the onboarding auto-create gate depends on it); dropped the now-unused `startMigration` mutation and `handleMigrate`.

## Verify
- `tsc --noEmit` clean for the changed files; prettier passes.
- Users with only legacy machines (no projects) now see the normal empty state + the archive link, not a blank grid.
