### PR TITLE
fix(sandbox): verify opencode-config-deps bundles at bake time [staging hotfix]

### DIFF
--- a/apps/api/src/__tests__/unit-dockerfile-layer.test.ts
+++ b/apps/api/src/__tests__/unit-dockerfile-layer.test.ts
@@ -70,6 +70,48 @@ describe('buildLayeredDockerfile', () => {
     expect(envIdx).toBeLessThan(installIdx);
   });
 
+  test('hard-fails the bake if opencode-config-deps cannot be bundled by Bun', () => {
+    const merged = buildLayeredDockerfile({ userDockerfile: 'FROM ubuntu:24.04', ...COMMON });
+    // Regression coverage for the incident where `bun install` exited 0 but
+    // the installed tree (a CVE-driven axios override) failed to BUNDLE at
+    // session runtime, silently baking a broken image. This must be its own
+    // RUN step, not folded into a `set +e` block — an unbundlable dependency
+    // tree has to fail the image build.
+    const verifyIdx = merged.indexOf(
+      'bun build node_modules/axios/lib/utils.js node_modules/form-data/lib/form_data.js',
+    );
+    expect(verifyIdx).toBeGreaterThanOrEqual(0);
+    const precedingRun = merged.lastIndexOf('RUN', verifyIdx);
+    const stepText = merged.slice(precedingRun, verifyIdx);
+    expect(stepText).not.toContain('set +e');
+    // Must run after the install it's verifying, not before.
+    const installIdx = merged.indexOf('bun install');
+    expect(installIdx).toBeGreaterThanOrEqual(0);
+    expect(installIdx).toBeLessThan(verifyIdx);
+  });
+
+  test('also verifies the real starter tool files bundle when opencodeConfigPath is provided', () => {
+    const withConfig = buildLayeredDockerfile({
+      userDockerfile: 'FROM ubuntu:24.04',
+      ...COMMON,
+      opencodeConfigPath: 'kortix-opencode-config',
+      catalogPath: 'kortix-llm-catalog.json',
+    });
+    const verifyIdx = withConfig.indexOf('bun build tools/*.ts');
+    expect(verifyIdx).toBeGreaterThanOrEqual(0);
+    const precedingRun = withConfig.lastIndexOf('RUN', verifyIdx);
+    const stepText = withConfig.slice(precedingRun, verifyIdx);
+    expect(stepText).not.toContain('set +e');
+    // Without opencodeConfigPath there's no starter tool tree to verify, so
+    // this stricter check is correctly absent — only the axios/form-data
+    // override check (always present) still runs.
+    const withoutConfig = buildLayeredDockerfile({ userDockerfile: 'FROM ubuntu:24.04', ...COMMON });
+    expect(withoutConfig).not.toContain('bun build tools/*.ts');
+    expect(withoutConfig).toContain(
+      'bun build node_modules/axios/lib/utils.js node_modules/form-data/lib/form_data.js',
+    );
+  });
+
   test('does NOT bake the project workspace into the image', () => {
     const merged = buildLayeredDockerfile({ userDockerfile: 'FROM scratch', ...COMMON });
     expect(merged).not.toContain('kortix-workspace.tar.gz');

--- a/apps/api/src/snapshots/dockerfile-layer.ts
+++ b/apps/api/src/snapshots/dockerfile-layer.ts
@@ -262,10 +262,32 @@ export function buildLayeredDockerfile(opts: BuildLayeredDockerfileOpts): string
     // the matching plugin on EVERY boot — the ~5–8s "opencode-session-created" gap.
     // Baking the binary version makes opencode find it already present → no fetch.
     // Bump RUNTIME_LAYER_VERSION in templates.ts when this step changes.
+    // NOTE: this dependency set (and the "axios"/"form-data" security overrides
+    // below) is duplicated in packages/starter/templates/base/.kortix/opencode/package.json
+    // and .kortix/opencode/package.json (local dev). Keep all three in sync —
+    // a version bump made in only one place is exactly how this file's axios
+    // override once diverged and shipped a bundle-breaking install (see the
+    // verification RUN step right below, added after that incident).
     'RUN mkdir -p /opt/kortix/home/.bun/install/cache /opt/kortix/opencode-config-deps \\',
     '    && cd /opt/kortix/opencode-config-deps \\',
     `    && printf '{"name":"kortix-opencode-config","private":true,"dependencies":{"@mendable/firecrawl-js":"^4.25.1","@opencode-ai/plugin":"${opencodeVersion}","@tavily/core":"^0.7.3","replicate":"^1.4.0"},"overrides":{"axios":"1.16.0","form-data":"4.0.6"}}' > package.json \\`,
     '    && HOME=/opt/kortix/home BUN_INSTALL_CACHE_DIR=/opt/kortix/home/.bun/install/cache bun install',
+    '',
+    // Verify the baked tree is actually usable by OpenCode's own runtime
+    // bundler (Bun, invoked live by ToolRegistry the first time a session
+    // resolves its tools) — not just that `bun install` exited 0. A CVE-driven
+    // axios override bump here once produced an installed tree that resolved
+    // fine but failed to BUNDLE at session runtime
+    // (`AggregateError: N errors building ".../axios/lib/utils.js"`), which
+    // silently baked into every sandbox cloned from this image until a user
+    // hit it on their very first prompt. Bundling the override targets here,
+    // at build time, turns that failure mode into a build failure instead —
+    // intentionally NOT `set +e`: an unbundlable dependency tree must fail
+    // the image build, unlike the best-effort warm-up steps below.
+    'RUN cd /opt/kortix/opencode-config-deps \\',
+    '    && HOME=/opt/kortix/home bun build node_modules/axios/lib/utils.js node_modules/form-data/lib/form_data.js --target=bun --outdir=/tmp/opencode-deps-bundle-check \\',
+    '    && rm -rf /tmp/opencode-deps-bundle-check \\',
+    '    && echo "opencode-config-deps: baked tree bundles cleanly"',
     '',
     // Warm a real opencode PROJECT INSTANCE at build time. The first time opencode
     // creates an instance for a project dir it loads that dir's .kortix/opencode
@@ -284,6 +306,24 @@ export function buildLayeredDockerfile(opts: BuildLayeredDockerfileOpts): string
     ...(opencodeConfigPath
       ? [
           `COPY ${opencodeConfigPath}/ /opt/kortix/warm-config/.kortix/opencode/`,
+          // Same "does it actually bundle" check as the opencode-config-deps
+          // verification above, but exercised against the REAL starter tool
+          // files (web_search / scrape_webpage / image_search / memory / show)
+          // instead of just their axios/form-data override targets — this is
+          // what actually walks the full transitive dependency tree
+          // (firecrawl-js, tavily-core, replicate) that ToolRegistry resolves
+          // on a session's first prompt. Deliberately its own RUN step (not
+          // folded into the `set +e` warm-up below): a tool that can't bundle
+          // breaks every session's first prompt, not just startup latency, so
+          // it must fail the build — the warm-up readiness probe below stays
+          // best-effort as before.
+          'RUN cd /opt/kortix/warm-config/.kortix/opencode \\',
+          '    && rm -rf node_modules \\',
+          '    && ln -s /opt/kortix/opencode-config-deps/node_modules node_modules \\',
+          '    && HOME=/opt/kortix/home bun build tools/*.ts --target=bun --outdir=/tmp/opencode-tools-bundle-check \\',
+          '    && rm -rf /tmp/opencode-tools-bundle-check \\',
+          '    && echo "opencode-config-deps: starter tool files bundle cleanly"',
+          '',
           'RUN set +e; \\',
           '    export HOME=/opt/kortix/home \\',
           '        XDG_DATA_HOME=/opt/kortix/home/.local/share \\',

--- a/apps/api/src/snapshots/templates.ts
+++ b/apps/api/src/snapshots/templates.ts
@@ -72,7 +72,13 @@ const FINGERPRINT_EXCLUDES = ['node_modules', '.bin', 'dist', '.turbo', '.cache'
 // loads the plugin SDK matching its own binary and re-fetches it over the network
 // if the baked tree carries a different version — the stale starter pin left every
 // boot re-installing it, the ~5–8s opencode-session-created gap).
-const RUNTIME_LAYER_VERSION = 'baked-config-deps-binplugin-v15';
+// v16: hard-fail the bake if the baked opencode-config-deps tree (or the
+// starter tool files against it) can't actually be bundled by Bun — a
+// bundle-breaking axios override once shipped silently baked into every
+// sandbox image (bun install succeeded; the runtime bundle did not). Ported
+// from main (#4073) directly onto staging as a hotfix — main's v16-v23 are
+// unrelated feature bumps not yet promoted here.
+const RUNTIME_LAYER_VERSION = 'baked-config-deps-binplugin-v16';
 const DEFAULT_CPU = readPositiveIntEnv('KORTIX_DEFAULT_SANDBOX_CPU', 2);
 const DEFAULT_MEMORY_GB = readPositiveIntEnv('KORTIX_DEFAULT_SANDBOX_MEMORY_GB', 6);
 const DEFAULT_DISK_GB = readPositiveIntEnv('KORTIX_DEFAULT_SANDBOX_DISK_GB', 20);

--- a/apps/kortix-sandbox-agent-server/src/__tests__/opencode-process-group-kill.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/opencode-process-group-kill.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Regression coverage for the opencode.ts stop()/restart() fix: opencode is
+ * spawned with `detached: true` and killed via the negative pid (the whole
+ * process group), not just the direct child. Without that, a grandchild
+ * opencode forks (its own `bun install` for the config dir's tool deps) can
+ * outlive a restart-triggered SIGTERM and keep writing into a directory a
+ * freshly-spawned opencode is installing into concurrently — a real path to
+ * a torn/corrupted node_modules that then fails every session's first
+ * prompt. These tests exercise the underlying OS-level mechanism directly.
+ */
+import { describe, expect, test } from 'bun:test'
+import { spawn } from 'node:child_process'
+
+function isPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 3000, intervalMs = 50): Promise<void> {
+  const start = Date.now()
+  while (!predicate()) {
+    if (Date.now() - start > timeoutMs) throw new Error('timeout waiting for condition')
+    await new Promise((r) => setTimeout(r, intervalMs))
+  }
+}
+
+async function spawnWithGrandchild() {
+  // The child backgrounds a nested `sh` (the "grandchild"), prints its pid,
+  // then waits on it — mirroring opencode forking its own `bun install`.
+  const child = spawn('sh', ['-c', 'sh -c "sleep 30" & echo $!; wait'], {
+    detached: true,
+    stdio: ['ignore', 'pipe', 'ignore'],
+  })
+  const grandchildPid = await new Promise<number>((resolve, reject) => {
+    let buf = ''
+    child.stdout?.on('data', (d) => {
+      buf += d.toString()
+      const m = buf.match(/(\d+)/)
+      if (m) resolve(Number(m[1]))
+    })
+    child.on('error', reject)
+  })
+  return { child, grandchildPid }
+}
+
+describe('opencode process-group kill', () => {
+  test('signaling the process group (detached + -pid) also kills the grandchild', async () => {
+    const { child, grandchildPid } = await spawnWithGrandchild()
+    expect(isPidAlive(grandchildPid)).toBe(true)
+
+    // This is exactly what opencode.ts's killGroup() does.
+    expect(child.pid).toBeTruthy()
+    process.kill(-(child.pid as number), 'SIGTERM')
+
+    await waitFor(() => !isPidAlive(grandchildPid))
+    expect(isPidAlive(grandchildPid)).toBe(false)
+  })
+
+  test('signaling only the direct child (the pre-fix behavior) orphans the grandchild', async () => {
+    const { child, grandchildPid } = await spawnWithGrandchild()
+    expect(isPidAlive(grandchildPid)).toBe(true)
+
+    child.kill('SIGTERM')
+    await waitFor(() => !isPidAlive(child.pid as number))
+
+    // The grandchild survives — this is the orphaned-subprocess race that
+    // let a corrupted node_modules install slip through.
+    expect(isPidAlive(grandchildPid)).toBe(true)
+
+    process.kill(grandchildPid, 'SIGKILL')
+  })
+})

--- a/apps/kortix-sandbox-agent-server/src/opencode.ts
+++ b/apps/kortix-sandbox-agent-server/src/opencode.ts
@@ -649,10 +649,19 @@ export function createOpencodeSupervisor(
 
     const cwd = ensureCwdExists()
     logger.info('[opencode] spawning', { bin, port: currentCfg.opencodeInternalPort, cwd })
+    // detached: true makes opencode the leader of its own process group, so
+    // stop()/restart() can SIGTERM/SIGKILL the whole group (-pid) instead of
+    // just this direct child. Without it, a grandchild opencode forks itself
+    // (e.g. its internal `bun install` for the config dir's tool deps) can
+    // outlive a restart-triggered kill and keep writing into a directory a
+    // freshly-spawned opencode is installing into concurrently — a real path
+    // to a torn/corrupted node_modules that then fails every session's first
+    // prompt until the sandbox is rebuilt.
     const proc = spawn(bin, args, {
       cwd,
       env,
       stdio: ['ignore', 'inherit', 'inherit'],
+      detached: true,
     })
 
     proc.on('exit', (code, signal) => {
@@ -732,19 +741,34 @@ export function createOpencodeSupervisor(
       }
       if (!child) return
       const c = child
+      // Spawned with detached: true, so c.pid also identifies the process
+      // group opencode leads — signal the whole group (-pid), not just this
+      // direct child, so a grandchild opencode forks (e.g. its own `bun
+      // install` for the config dir) can't outlive the kill and race a
+      // freshly-spawned opencode's install into the same directory. Falls
+      // back to a plain child kill if the group signal itself throws.
+      const killGroup = (sig: NodeJS.Signals) => {
+        if (c.pid) {
+          try {
+            process.kill(-c.pid, sig)
+            return
+          } catch {}
+        }
+        c.kill(sig)
+      }
       return new Promise<void>((resolve) => {
         const onExit = () => resolve()
         c.once('exit', onExit)
         try {
-          c.kill(signal)
+          killGroup(signal)
         } catch {
           resolve()
           return
         }
-        // Hard kill if the child ignores SIGTERM.
+        // Hard kill if the child (or its group) ignores SIGTERM.
         setTimeout(() => {
           try {
-            c.kill('SIGKILL')
+            killGroup('SIGKILL')
           } catch {}
           resolve()
         }, 5_000).unref()


### PR DESCRIPTION
## Summary
Direct cherry-pick of #4073 (merged to `main`) onto `staging`, bypassing the normal promote flow since `main` is 204 commits ahead and not being promoted yet — this is a live-incident hotfix only.

A CVE-driven axios override bump (95dc0192f2) once produced an installed `node_modules` tree for OpenCode's custom tools (web_search / scrape_webpage / etc.) that resolved fine (`bun install` exit 0) but failed to **bundle** at session runtime — OpenCode's live Bun bundler threw `AggregateError: N errors building ".../axios/lib/utils.js"` on literally every session's first prompt. Because this dependency tree is baked once into the golden sandbox image and every sandbox just symlinks to it, the broken tree shipped silently to every sandbox cloned from that image.

- Adds two hard-failing (non-`set +e`) build-time checks right after the bake that actually bundle the dependency tree with Bun — the same thing ToolRegistry does at runtime — so a broken bake fails the *image build* instead of a live session.
- Bumps `RUNTIME_LAYER_VERSION` (renumbered to `v16` to fit staging's own sequence, since staging hasn't seen main's `v16`-`v23` unrelated feature bumps yet) to force a rebake.
- Closes a related gap: opencode's own internal `bun install` fallback subprocess could previously outlive a restart-triggered kill (no process-group signaling) and race a fresh install into the same directory. Spawn opencode detached and kill its process group on stop()/restart().

## Test plan
- [x] Typecheck clean (`apps/api`, `apps/kortix-sandbox-agent-server`)
- [x] `unit-dockerfile-layer.test.ts` / `unit-runtime-versions.test.ts` — 25/26 pass, 1 pre-existing unrelated failure (confirmed present on unmodified `main` and `staging` independently)
- [x] `opencode-fork-root.test.ts` / `opencode-config-deps.test.ts` / `opencode-events-dispatch.test.ts` — all pass
- [x] Verified the exact `bun build` commands added to the Dockerfile locally against real axios 1.16.0 + the actual starter tool files