### PR TITLE
test(sandbox): backfill coverage for the opencode-config-deps bake fix

### DIFF
--- a/apps/api/src/__tests__/unit-dockerfile-layer.test.ts
+++ b/apps/api/src/__tests__/unit-dockerfile-layer.test.ts
@@ -70,6 +70,48 @@ describe('buildLayeredDockerfile', () => {
     expect(envIdx).toBeLessThan(installIdx);
   });
 
+  test('hard-fails the bake if opencode-config-deps cannot be bundled by Bun', () => {
+    const merged = buildLayeredDockerfile({ userDockerfile: 'FROM ubuntu:24.04', ...COMMON });
+    // Regression coverage for the incident where `bun install` exited 0 but
+    // the installed tree (a CVE-driven axios override) failed to BUNDLE at
+    // session runtime, silently baking a broken image. This must be its own
+    // RUN step, not folded into a `set +e` block — an unbundlable dependency
+    // tree has to fail the image build.
+    const verifyIdx = merged.indexOf(
+      'bun build node_modules/axios/lib/utils.js node_modules/form-data/lib/form_data.js',
+    );
+    expect(verifyIdx).toBeGreaterThanOrEqual(0);
+    const precedingRun = merged.lastIndexOf('RUN', verifyIdx);
+    const stepText = merged.slice(precedingRun, verifyIdx);
+    expect(stepText).not.toContain('set +e');
+    // Must run after the install it's verifying, not before.
+    const installIdx = merged.indexOf('bun install');
+    expect(installIdx).toBeGreaterThanOrEqual(0);
+    expect(installIdx).toBeLessThan(verifyIdx);
+  });
+
+  test('also verifies the real starter tool files bundle when opencodeConfigPath is provided', () => {
+    const withConfig = buildLayeredDockerfile({
+      userDockerfile: 'FROM ubuntu:24.04',
+      ...COMMON,
+      opencodeConfigPath: 'kortix-opencode-config',
+      catalogPath: 'kortix-llm-catalog.json',
+    });
+    const verifyIdx = withConfig.indexOf('bun build tools/*.ts');
+    expect(verifyIdx).toBeGreaterThanOrEqual(0);
+    const precedingRun = withConfig.lastIndexOf('RUN', verifyIdx);
+    const stepText = withConfig.slice(precedingRun, verifyIdx);
+    expect(stepText).not.toContain('set +e');
+    // Without opencodeConfigPath there's no starter tool tree to verify, so
+    // this stricter check is correctly absent — only the axios/form-data
+    // override check (always present) still runs.
+    const withoutConfig = buildLayeredDockerfile({ userDockerfile: 'FROM ubuntu:24.04', ...COMMON });
+    expect(withoutConfig).not.toContain('bun build tools/*.ts');
+    expect(withoutConfig).toContain(
+      'bun build node_modules/axios/lib/utils.js node_modules/form-data/lib/form_data.js',
+    );
+  });
+
   test('does NOT bake the project workspace into the image', () => {
     const merged = buildLayeredDockerfile({ userDockerfile: 'FROM scratch', ...COMMON });
     expect(merged).not.toContain('kortix-workspace.tar.gz');

--- a/apps/kortix-sandbox-agent-server/src/__tests__/opencode-process-group-kill.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/opencode-process-group-kill.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Regression coverage for the opencode.ts stop()/restart() fix: opencode is
+ * spawned with `detached: true` and killed via the negative pid (the whole
+ * process group), not just the direct child. Without that, a grandchild
+ * opencode forks (its own `bun install` for the config dir's tool deps) can
+ * outlive a restart-triggered SIGTERM and keep writing into a directory a
+ * freshly-spawned opencode is installing into concurrently — a real path to
+ * a torn/corrupted node_modules that then fails every session's first
+ * prompt. These tests exercise the underlying OS-level mechanism directly.
+ */
+import { describe, expect, test } from 'bun:test'
+import { spawn } from 'node:child_process'
+
+function isPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 3000, intervalMs = 50): Promise<void> {
+  const start = Date.now()
+  while (!predicate()) {
+    if (Date.now() - start > timeoutMs) throw new Error('timeout waiting for condition')
+    await new Promise((r) => setTimeout(r, intervalMs))
+  }
+}
+
+async function spawnWithGrandchild() {
+  // The child backgrounds a nested `sh` (the "grandchild"), prints its pid,
+  // then waits on it — mirroring opencode forking its own `bun install`.
+  const child = spawn('sh', ['-c', 'sh -c "sleep 30" & echo $!; wait'], {
+    detached: true,
+    stdio: ['ignore', 'pipe', 'ignore'],
+  })
+  const grandchildPid = await new Promise<number>((resolve, reject) => {
+    let buf = ''
+    child.stdout?.on('data', (d) => {
+      buf += d.toString()
+      const m = buf.match(/(\d+)/)
+      if (m) resolve(Number(m[1]))
+    })
+    child.on('error', reject)
+  })
+  return { child, grandchildPid }
+}
+
+describe('opencode process-group kill', () => {
+  test('signaling the process group (detached + -pid) also kills the grandchild', async () => {
+    const { child, grandchildPid } = await spawnWithGrandchild()
+    expect(isPidAlive(grandchildPid)).toBe(true)
+
+    // This is exactly what opencode.ts's killGroup() does.
+    expect(child.pid).toBeTruthy()
+    process.kill(-(child.pid as number), 'SIGTERM')
+
+    await waitFor(() => !isPidAlive(grandchildPid))
+    expect(isPidAlive(grandchildPid)).toBe(false)
+  })
+
+  test('signaling only the direct child (the pre-fix behavior) orphans the grandchild', async () => {
+    const { child, grandchildPid } = await spawnWithGrandchild()
+    expect(isPidAlive(grandchildPid)).toBe(true)
+
+    child.kill('SIGTERM')
+    await waitFor(() => !isPidAlive(child.pid as number))
+
+    // The grandchild survives — this is the orphaned-subprocess race that
+    // let a corrupted node_modules install slip through.
+    expect(isPidAlive(grandchildPid)).toBe(true)
+
+    process.kill(grandchildPid, 'SIGKILL')
+  })
+})


### PR DESCRIPTION
## Summary
Test-only backfill for #4073, which merged to `main` without an accompanying test change — the coverage gate's diff was computed against a stale base commit and didn't catch it (confirmed while landing the staging cherry-pick, #4076, where the gate correctly fired).

Adds the same two regression tests now on `staging`:
- `unit-dockerfile-layer.test.ts`: asserts the bake-verification RUN steps exist, run after `bun install`, and are NOT wrapped in `set +e` (so a broken bake fails the image build).
- `opencode-process-group-kill.test.ts`: demonstrates the detached-spawn + process-group kill actually terminates a grandchild process, vs. the old plain `child.kill()` which orphans it.

No production code changes — test-only.

## Test plan
- [x] `unit-dockerfile-layer.test.ts` — 23/24 pass (1 pre-existing unrelated failure, same on unmodified `main`)
- [x] `opencode-process-group-kill.test.ts` — 2/2 pass