### PR TITLE
fix(web): repoint legacy-machines page at the moved projects-client SDK export

### DIFF
--- a/apps/web/src/app/(app)/legacy-machines/page.tsx
+++ b/apps/web/src/app/(app)/legacy-machines/page.tsx
@@ -11,7 +11,7 @@ import { AppHeader } from '@/features/layout/app-header';
 import { EmptyState } from '@/features/layout/section/empty-state';
 import { useAuth } from '@/features/providers/auth-provider';
 import { useLegacyMachines } from '@/hooks/legacy/use-legacy-machine-migration';
-import { listAccounts } from '@/lib/projects-client';
+import { listAccounts } from '@kortix/sdk/projects-client';
 import { useCurrentAccountStore } from '@/stores/current-account-store';
 
 /**


### PR DESCRIPTION
## Summary
`refactor/sdk-web-projects-client` deleted `apps/web/src/lib/projects-client.ts` in favor of `@kortix/sdk/projects-client` but missed this one importer. Currently breaks `next build` on main:

```
./src/app/(app)/legacy-machines/page.tsx
Module not found: Can't resolve '@/lib/projects-client'
```

This is red right now on `main` and blocks the "Frontend build" CI gate + Vercel preview on every open PR (found while landing #4075).

## Test plan
- [x] `tsc --noEmit` on `apps/web` — the two `legacy-machines/page.tsx` errors are gone (only the pre-existing, unrelated `@/.source` codegen artifact remains, present with or without this fix)
- [ ] CI Frontend build / Vercel preview green