### PR TITLE
fix(sandbox-agent): fail fast when opencode is wedged instead of hanging forever

### DIFF
--- a/apps/kortix-sandbox-agent-server/src/__tests__/proxy-auth.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/proxy-auth.test.ts
@@ -52,13 +52,13 @@ function baseConfig(over: Partial<Config> = {}): Config {
 
 function fakeOpencode(
   state: 'ok' | 'starting' | 'down' = 'starting',
-  hooks: { restart?: () => void } = {},
+  hooks: { restart?: () => void; internalUrl?: string } = {},
 ): Opencode {
   // Loose cast — buildOpencodeApp only touches these three methods.
   return {
     getState: () => state,
     getPid: () => null,
-    getInternalUrl: () => 'http://127.0.0.1:1', // unreachable on purpose
+    getInternalUrl: () => hooks.internalUrl ?? 'http://127.0.0.1:1', // unreachable by default
     restart: async () => hooks.restart?.(),
   } as unknown as Opencode
 }
@@ -493,6 +493,43 @@ describe('daemon proxy auth gate', () => {
     const body = (await res.json()) as { error: string }
     expect(body.error).toBe('upstream unreachable')
   })
+
+  it(
+    'fails fast with 502 instead of hanging forever when opencode accepts the connection but never responds',
+    async () => {
+      // Simulates a wedged opencode: the TCP connection is accepted (unlike the
+      // "connect refused" case above) but the handler never resolves — the
+      // failure mode that left real sessions stuck at "Starting the agent" with
+      // no error surfaced until this fix.
+      const hungUpstream = Bun.serve({
+        port: 0,
+        fetch: () => new Promise<Response>(() => {}),
+      })
+      try {
+        const app = buildOpencodeApp(
+          baseConfig(),
+          fakeOpencode('ok', { internalUrl: `http://127.0.0.1:${hungUpstream.port}` }),
+          Date.now(),
+        )
+        const signed = signCtx({ userId: 'u', sandboxId: 's', sandboxRole: 'owner' }, TEST_TOKEN)
+        const startedAt = Date.now()
+        const res = await app.request('/global/event', {
+          headers: { [KORTIX_USER_CONTEXT_HEADER]: signed },
+        })
+        const elapsedMs = Date.now() - startedAt
+
+        expect(res.status).toBe(502)
+        // Well under the old unbounded hang (and under the ALB's 60s idle cap) —
+        // proves the internal fetch actually aborts instead of waiting forever.
+        expect(elapsedMs).toBeLessThan(15_000)
+        const body = (await res.json()) as { error: string }
+        expect(body.error).toBe('upstream unreachable')
+      } finally {
+        hungUpstream.stop(true)
+      }
+    },
+    20_000,
+  )
 
   it('rejects /kortix/refresh without a signed user context', async () => {
     const app = buildOpencodeApp(baseConfig(), fakeOpencode('ok'), Date.now())

--- a/apps/kortix-sandbox-agent-server/src/proxy.ts
+++ b/apps/kortix-sandbox-agent-server/src/proxy.ts
@@ -34,6 +34,20 @@ const STRIP_RESPONSE_HEADERS = new Set(['transfer-encoding', 'connection'])
 const PTY_WS_PATH_RE = /^\/pty\/[^/]+\/connect\/?$/
 const KORTIX_USER_CONTEXT_QUERY_PARAM = '__kortix_user_context'
 
+// Bound on waiting for opencode to respond to a proxied request. Applied only
+// to the wait for the response to arrive (headers), never to a streaming body
+// already in flight — an SSE stream like /global/event legitimately stays open
+// for the life of the session, so aborting on a fixed wall clock would sever
+// healthy long-lived connections. A wedged opencode process (hung event loop,
+// deadlock) otherwise leaves this `fetch` unresolved forever: the daemon's own
+// `/kortix/health` stays green throughout (it never touches opencode), so
+// nothing else catches it, and the browser just sees the request hang until
+// something upstream (ALB/ingress) eventually resets the connection — which
+// surfaces as a confusing "blocked by CORS" error with no real diagnostic
+// value. Failing fast here instead gives a clean 502 that apps/api's own
+// retry+auto-wake loop can act on immediately.
+const UPSTREAM_RESPONSE_TIMEOUT_MS = 10_000
+
 type OpencodeWsData = {
   type: 'opencode-pty'
   url: string
@@ -158,6 +172,7 @@ async function prepareOpencodePtyWsUpgrade(
         ...headers,
         'x-opencode-ticket': '1',
       },
+      signal: AbortSignal.timeout(UPSTREAM_RESPONSE_TIMEOUT_MS),
     })
     if (tokenRes.ok) {
       const body = await tokenRes.json().catch(() => null) as { ticket?: unknown } | null
@@ -351,6 +366,13 @@ export function buildOpencodeApp(
     const method = c.req.method.toUpperCase()
     const hasBody = method !== 'GET' && method !== 'HEAD'
 
+    // Bound only the wait for opencode's response (headers) — not the abort
+    // controller's whole lifetime — so we can free-run a stream once it starts.
+    // Clearing the timer right after `fetch` resolves means the controller can
+    // never fire again, so a long-lived SSE body already in flight (e.g.
+    // /global/event) is never cut off mid-stream.
+    const controller = new AbortController()
+    const responseTimer = setTimeout(() => controller.abort(), UPSTREAM_RESPONSE_TIMEOUT_MS)
     try {
       const fetchInit: RequestInit & { duplex?: 'half' } = {
         method,
@@ -359,8 +381,10 @@ export function buildOpencodeApp(
         // duplex: 'half' is required by undici when piping a ReadableStream body;
         // Bun accepts the extra key too. Not in lib.dom RequestInit yet.
         duplex: 'half',
+        signal: controller.signal,
       }
       const upstream = await fetch(upstreamUrl, fetchInit)
+      clearTimeout(responseTimer)
 
       const respHeaders = new Headers()
       upstream.headers.forEach((value, key) => {
@@ -373,7 +397,16 @@ export function buildOpencodeApp(
         headers: respHeaders,
       })
     } catch (err) {
-      logger.error('[proxy] upstream fetch failed', err)
+      clearTimeout(responseTimer)
+      const timedOut = err instanceof Error && (err.name === 'AbortError' || err.name === 'TimeoutError')
+      if (timedOut) {
+        logger.error('[proxy] upstream fetch timed out — opencode unresponsive', {
+          path: url.pathname,
+          timeoutMs: UPSTREAM_RESPONSE_TIMEOUT_MS,
+        })
+      } else {
+        logger.error('[proxy] upstream fetch failed', err)
+      }
       return c.json({ error: 'upstream unreachable', details: (err as Error).message }, 502)
     }
   })


### PR DESCRIPTION
## Summary
- The sandbox daemon's reverse proxy to opencode's internal port (4096) had no timeout on its internal fetch. When opencode itself wedges (hung event loop / deadlock), every proxied request -- /global/event, /pty/* -- hung indefinitely, while /kortix/health stayed green the whole time since it's served directly by the daemon and never touches opencode.
- Live symptom (dev, 2026-07-02): two Platinum sandboxes stuck at "Starting the agent" forever. /kortix/health returned 200 fast; /global/event and /pty/* timed out on every retry (~50s each, matching apps/api's own retry budget) before eventually 502ing. Because the daemon-side request never resolved, the browser reported a misleading "blocked by CORS" error instead of a real failure.
- Fix: bound the wait for opencode's response (not the whole streaming body) to 10s via an AbortController that's cleared as soon as headers arrive -- so a long-lived SSE stream already in flight (/global/event) is never cut off mid-stream, but a wedged opencode now fails fast with a clean 502 instead of hanging past the ALB's idle window. Same fix applied to the PTY ticket-mint fetch (short exchange, plain AbortSignal.timeout).
- This doesn't recover an already-wedged opencode process (that needs a restart) -- it converts a silent, indefinite, confusingly-labeled hang into an immediate, correctly-classified failure that apps/api's existing retry+auto-wake loop can act on.

## Test plan
- [x] New unit test in proxy-auth.test.ts -- spins up a real Bun.serve upstream whose handler never resolves (simulating wedged opencode), asserts the proxy returns 502 within 15s instead of hanging.
- [x] bun test -- 149/149 pass in apps/kortix-sandbox-agent-server.
- [x] bun tsc --noEmit -- clean.