### PR TITLE
fix(sessions): stuck-session restart bug + manual restart fallback

### DIFF
--- a/apps/api/src/projects/session-lifecycle/actions.ts
+++ b/apps/api/src/projects/session-lifecycle/actions.ts
@@ -272,6 +272,19 @@ export async function restartSession(input: {
     return { status: 202, body: { ok: true, session_id: sessionId, status: 'provisioning' } };
   }
 
+  if (existingSandbox) {
+    // Row exists but never reached a real provider sandbox (e.g. the original
+    // provision failed before an externalId was assigned) — there's nothing to
+    // stop/start, and leaving it in place would collide with the fresh insert
+    // provisionReplacementRuntime() is about to do on the same sandboxId PK.
+    await retireSessionSandboxRow(existingSandbox, 'restart_never_provisioned').catch((err) =>
+      console.warn(
+        `[projects] failed to retire never-provisioned sandbox row for session ${sessionId}:`,
+        err,
+      ),
+    );
+  }
+
   await provisionReplacementRuntime();
   return { status: 202, body: { ok: true, session_id: sessionId, status: 'provisioning' } };
 }

--- a/apps/web/src/app/(app)/projects/[id]/sessions/[sessionId]/page.tsx
+++ b/apps/web/src/app/(app)/projects/[id]/sessions/[sessionId]/page.tsx
@@ -233,7 +233,11 @@ export default function ProjectSessionPage() {
                 onSubmit={() => setShellSubmitted(true)}
               />
             ) : (
-              <SessionStartingLoader stage={authLoading || !user ? 'provisioning' : startStage} />
+              <SessionStartingLoader
+                stage={authLoading || !user ? 'provisioning' : startStage}
+                projectId={projectId}
+                sessionId={sessionId}
+              />
             )}
           </div>
         )}

--- a/apps/web/src/features/session/session-layout.tsx
+++ b/apps/web/src/features/session/session-layout.tsx
@@ -347,7 +347,12 @@ export const SessionLayout = memo(function SessionLayout({
   // live sandbox, so they only render once booted.
   const effectivePanelHeader = booting ? null : panelHeader;
   const effectivePanelBody = booting ? (
-    <SessionStartingLoader stage={bootStage ?? 'provisioning'} delayMs={0} />
+    <SessionStartingLoader
+      stage={bootStage ?? 'provisioning'}
+      delayMs={0}
+      projectId={projectId}
+      sessionId={projectSessionId}
+    />
   ) : (
     panelBody
   );

--- a/apps/web/src/features/session/session-starting-loader.tsx
+++ b/apps/web/src/features/session/session-starting-loader.tsx
@@ -1,10 +1,13 @@
 'use client';
 
-import { Check, Loader2 } from 'lucide-react';
+import { Check, Loader2, RotateCcw } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { useEffect, useRef, useState } from 'react';
 
-import type { SessionStartStage } from '@kortix/sdk/projects-client';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { restartProjectSession, sessionStartKey, type SessionStartStage } from '@kortix/sdk/projects-client';
+import { Button } from '@/components/ui/button';
+import { errorToast } from '@/components/ui/toast';
 import { cn } from '@/lib/utils';
 
 /**
@@ -25,6 +28,13 @@ const LOADER_DELAY_MS = 700;
 const STARTING_SUBSTEP_MS = 5_000;
 /** After this long, swap the footer copy to set expectations for a cold start. */
 const SLOW_AFTER_MS = 15_000;
+/**
+ * After this long, offer a manual restart. Sandboxes occasionally wedge (e.g. a
+ * stuck provider-side proxy) with no server-side signal that anything is wrong —
+ * a stop/start of the sandbox is the known fix, so surface it as a fallback
+ * instead of leaving the user staring at "Connecting" indefinitely.
+ */
+const STUCK_AFTER_MS = 45_000;
 
 interface Step {
   label: string;
@@ -55,11 +65,19 @@ export function SessionStartingLoader({
    *  default so a warm open never flashes it; the side panel passes 0 because the
    *  user opened it deliberately and expects to see status immediately. */
   delayMs = LOADER_DELAY_MS,
+  /** When both are given, a "Restart session" fallback appears once the boot
+   *  has clearly stalled (see STUCK_AFTER_MS). Omit either to hide it — some
+   *  embeddings of this loader don't have a project session id in scope. */
+  projectId,
+  sessionId,
 }: {
   stage?: SessionStartStage;
   delayMs?: number;
+  projectId?: string;
+  sessionId?: string;
 }) {
   const tI18nHardcoded = useTranslations('hardcodedUi');
+  const queryClient = useQueryClient();
   const [show, setShow] = useState(delayMs <= 0);
   useEffect(() => {
     if (delayMs <= 0) {
@@ -88,7 +106,26 @@ export function SessionStartingLoader({
   }
 
   const active = activeStep(stage, now - stageEnteredAt.current);
-  const slow = now - mountedAt.current >= SLOW_AFTER_MS;
+  // A manual restart pushes the "stuck" clock back out so the button doesn't
+  // reappear immediately while the fresh boot is still in progress.
+  const clockStart = useRef(mountedAt.current);
+  const slow = now - clockStart.current >= SLOW_AFTER_MS;
+  const stuck = now - clockStart.current >= STUCK_AFTER_MS;
+  const canRestart = !!projectId && !!sessionId;
+
+  const restartMutation = useMutation({
+    mutationFn: () => restartProjectSession(projectId!, sessionId!),
+    onSuccess: () => {
+      clockStart.current = Date.now();
+      queryClient.invalidateQueries({ queryKey: sessionStartKey(projectId!, sessionId!) });
+      queryClient.invalidateQueries({
+        queryKey: ['project', 'session-sandbox', projectId, sessionId],
+      });
+    },
+    onError: (err) => {
+      errorToast(err instanceof Error ? err.message : 'Failed to restart session');
+    },
+  });
 
   return (
     <div className="flex h-full min-h-0 w-full flex-1 items-center justify-center px-8">
@@ -151,6 +188,24 @@ export function SessionStartingLoader({
         <p className="text-muted-foreground/40 text-center text-[11px] leading-relaxed">
           {slow ? 'A cold start can take a little longer.' : 'This usually takes a few seconds.'}
         </p>
+
+        {stuck && canRestart ? (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="h-7 gap-1.5 rounded-full px-3 text-[11px]"
+            disabled={restartMutation.isPending}
+            onClick={() => restartMutation.mutate()}
+          >
+            {restartMutation.isPending ? (
+              <Loader2 className="h-3 w-3 animate-spin" />
+            ) : (
+              <RotateCcw className="h-3 w-3" />
+            )}
+            {restartMutation.isPending ? 'Restarting…' : 'Taking too long? Restart session'}
+          </Button>
+        ) : null}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- `restartSession()` only retires the existing `session_sandboxes` row when it has a provider `externalId` and the provider reports it `removed`. A session whose original provision failed *before* ever getting an `externalId` (e.g. hit a Daytona-side error) leaves an orphaned row — every subsequent restart attempt then crashes on a duplicate-key insert instead of recovering. Found live while investigating a session stuck on "Provisioning failed via daytona" (root cause: the 2026-07-02 org-wide Daytona disk-quota incident, already fixed by #4072 — but the orphaned-row bug independently blocks restart of any session caught in that window, or any other provision failure before externalId assignment).
- Adds a "Restart session" fallback button to `SessionStartingLoader` (the "Kortix Computer is starting…" boot screen) that appears if boot is still stuck 45s after the cold-start notice — lets users self-recover from a wedged sandbox (e.g. the known Daytona `toolbox_server` reverse-proxy stuck-connection bug) without waiting indefinitely on "Connecting".

## Test plan
- [x] `tsc --noEmit` clean on both changed packages (api, web)
- [x] Reproduced the orphan-row restart crash live against a real stuck prod session before writing the fix
- [ ] Manual: trigger a session restart from the UI on a session with no externalId yet, confirm it reprovisions instead of erroring
- [ ] Manual: leave a session on the boot loader past 45s, confirm the restart button appears and works
