### PR TITLE
chore(admin): remove the dead warm-fork sessions toggle (leftover from #4091)

### DIFF
--- a/apps/api/src/admin/index.ts
+++ b/apps/api/src/admin/index.ts
@@ -544,44 +544,6 @@ adminApp.openapi(
   },
 );
 
-// ── Warm-fork snapshots (per-project ~2s session start; DB-backed, not env) ──
-// GET the warm-snapshot toggle. Master switch for the per-project warm-fork
-// (Platinum + Daytona); per-provider sub-gates still apply (daytona warm target,
-// platinum host). Default ON — pure upside (a failed bake degrades to cold).
-adminApp.openapi(
-  createRoute({
-    method: 'get', path: '/api/warm-snapshot-config', tags: ['admin'],
-    summary: 'Get warm snapshot config', ...auth,
-    responses: { 200: json(z.record(z.string(), z.any()), 'config'), ...errors(401, 403) },
-  }),
-  async (c: any) => {
-    const { warmSnapshotSetting } = await import('../platform/services/runtime-settings');
-    return c.json(warmSnapshotSetting());
-  },
-);
-
-// PUT warm-snapshot toggle ({ enabled }). OFF = every session cold-clones its repo.
-adminApp.openapi(
-  createRoute({
-    method: 'put', path: '/api/warm-snapshot-config', tags: ['admin'],
-    summary: 'Set warm snapshot config', ...auth,
-    request: { body: { content: { 'application/json': { schema: z.object({ enabled: z.boolean() }) } } } },
-    responses: { 200: json(z.record(z.string(), z.any()), 'ok'), ...errors(401, 403) },
-  }),
-  async (c: any) => {
-    const body = await c.req.json().catch(() => ({}));
-    const value = { enabled: body?.enabled === true };
-    const { db } = await import('../shared/db');
-    const { platformSettings } = await import('@kortix/db');
-    const { WARM_SNAPSHOT_KEY, invalidateRuntimeSettings, refreshRuntimeSettings } = await import('../platform/services/runtime-settings');
-    await db.insert(platformSettings).values({ key: WARM_SNAPSHOT_KEY, value, updatedAt: new Date() })
-      .onConflictDoUpdate({ target: platformSettings.key, set: { value, updatedAt: new Date() } });
-    invalidateRuntimeSettings();
-    await refreshRuntimeSettings();
-    return c.json({ ok: true, ...value });
-  },
-);
-
 // ── Provider failover (one-shot, on session init; DB-backed, not env) ────────
 // GET current failover toggle. When ON, a provider that fails to provision a
 // session at birth hands off once to the next allowed provider. Default OFF.

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -354,7 +354,6 @@ const HealthSchema = z
     memory_mb: z.number(),
     timestamp: z.string(),
     billing_enabled: z.boolean(),
-    warm_snapshots: z.boolean(),
     tunnel: z.any(),
     leader: z.boolean(),
     trigger_scheduler: z.any(),
@@ -376,10 +375,6 @@ const healthHandler = (c: any) =>
     memory_mb: Math.round(process.memoryUsage().rss / 1024 / 1024),
     timestamp: new Date().toISOString(),
     billing_enabled: config.KORTIX_BILLING_INTERNAL_ENABLED,
-    // Warm/stateful-snapshot boots were removed — sessions are cold-only on
-    // every provider. Kept in the health contract (always false) for back-compat
-    // with any monitor that reads it.
-    warm_snapshots: false,
     tunnel: getTunnelServiceStatus(),
     leader: isLeader(),
     // The leader pod's trigger-sweep heartbeat: when it last ran, how long it

--- a/apps/api/src/platform/services/runtime-settings.ts
+++ b/apps/api/src/platform/services/runtime-settings.ts
@@ -4,60 +4,42 @@
  * mirroring provider_distribution (provider-balancer.ts).
  *
  * Read through a SYNC accessor backed by a 30s-TTL cache that refreshes in the
- * background, so hot paths (warmSnapshotEnabled, provider failover) never block
- * on the DB. The admin PUT awaits refreshRuntimeSettings()
- * after writing, so a toggle takes effect immediately for the writing process;
- * other processes pick it up within the TTL.
+ * background, so hot paths (provider failover) never block on the DB. The admin
+ * PUT awaits refreshRuntimeSettings() after writing, so a toggle takes effect
+ * immediately for the writing process; other processes pick it up within the TTL.
  *
  * The admin DB row is the ONLY control surface for these toggles — NOT env vars.
- * provider_fallback AND warm_snapshot default OFF and are opt-in
- * via the panel (the panel writes { enabled: true }). A cold cache / DB hiccup /
- * missing row resolves to OFF, so a fresh pod (e.g. right after a deploy) is
- * never warm on against the admin's setting before the first DB read completes —
- * boot awaits refreshRuntimeSettings() so the row is loaded before serving.
- * (Previously warm_snapshot hardcoded ON on the theory "a failed bake just
- * cold-clones"; the 2026-06-26 opencode wedge disproved it — a STALE warm seed
- * can hang a session — so off-until-explicitly-enabled is the safe direction.)
+ * provider_fallback defaults OFF and is opt-in via the panel (the panel writes
+ * { enabled: true }). A cold cache / DB hiccup / missing row resolves to OFF, so
+ * a fresh pod (e.g. right after a deploy) is never on against the admin's setting
+ * before the first DB read completes — boot awaits refreshRuntimeSettings() so
+ * the row is loaded before serving.
  */
 
 export const PROVIDER_FALLBACK_KEY = 'provider_fallback';
-export const WARM_SNAPSHOT_KEY = 'warm_snapshot';
 
 export interface ProviderFallbackSetting {
   /** When ON, a provider that fails to provision a session AT BIRTH hands off
    *  once to the next allowed provider before the session is marked failed. */
   enabled: boolean;
 }
-export interface WarmSnapshotSetting {
-  /** Master gate for per-project warm-fork snapshots (the ~2s session start).
-   *  ON by default — pure upside (a failed bake degrades to a cold clone). The
-   *  per-provider sub-gates still apply: daytona also needs a warm target,
-   *  platinum also needs a configured host (see shared/daytona warmSnapshots*). */
-  enabled: boolean;
-}
 
 const TTL_MS = 30_000;
 
 /** Fallback defaults used until the DB rows load and whenever the DB can't be
- *  read. ALL default OFF (fail-safe): warm_snapshot is now admin-OPT-IN — the
- *  admin Providers panel turns it on/off and that DB row is the ONLY control
- *  surface (no env knob). A cold cache / DB hiccup / no row therefore resolves to
- *  OFF, so a fresh pod (e.g. right after a deploy) never warm-forks against the
- *  admin's "off" — the 2026-06-26 stale-seed opencode wedge. The old "default ON,
- *  a failed bake just cold-clones" premise was wrong: a stale warm seed can hang. */
+ *  read. Default OFF (fail-safe): the admin Providers panel turns provider
+ *  failover on/off and that DB row is the ONLY control surface (no env knob). A
+ *  cold cache / DB hiccup / no row therefore resolves to OFF. */
 function envDefaults(): {
   fallback: ProviderFallbackSetting;
-  warmSnapshot: WarmSnapshotSetting;
 } {
   return {
     fallback: { enabled: false },
-    warmSnapshot: { enabled: false },
   };
 }
 
 let cache: {
   fallback: ProviderFallbackSetting;
-  warmSnapshot: WarmSnapshotSetting;
   at: number;
 } | null = null;
 let inflight: Promise<void> | null = null;
@@ -65,7 +47,6 @@ let inflight: Promise<void> | null = null;
 export async function refreshRuntimeSettings(): Promise<void> {
   const def = envDefaults();
   let fallback = def.fallback;
-  let warmSnapshot = def.warmSnapshot;
   try {
     const { hasDatabase, db } = await import('../../shared/db');
     if (hasDatabase) {
@@ -74,23 +55,19 @@ export async function refreshRuntimeSettings(): Promise<void> {
       const rows = await db
         .select({ key: platformSettings.key, value: platformSettings.value })
         .from(platformSettings)
-        .where(inArray(platformSettings.key, [PROVIDER_FALLBACK_KEY, WARM_SNAPSHOT_KEY]));
+        .where(inArray(platformSettings.key, [PROVIDER_FALLBACK_KEY]));
       for (const r of rows) {
         const v = r.value as Record<string, unknown> | null;
         if (!v || typeof v !== 'object') continue;
         if (r.key === PROVIDER_FALLBACK_KEY) {
           fallback = { enabled: v.enabled === true };
-        } else if (r.key === WARM_SNAPSHOT_KEY) {
-          // The admin row is the ONLY control. With NO row warm-fork stays OFF
-          // (envDefaults) — it is opt-in; the admin panel writes { enabled: true }.
-          warmSnapshot = { enabled: v.enabled === true };
         }
       }
     }
   } catch {
-    /* DB hiccup -> fail-safe defaults: fallback/warm_snapshot OFF */
+    /* DB hiccup -> fail-safe defaults: fallback OFF */
   }
-  cache = { fallback, warmSnapshot, at: Date.now() };
+  cache = { fallback, at: Date.now() };
 }
 
 function ensureFresh(): void {
@@ -101,11 +78,6 @@ function ensureFresh(): void {
 export function providerFallbackSetting(): ProviderFallbackSetting {
   ensureFresh();
   return cache?.fallback ?? envDefaults().fallback;
-}
-
-export function warmSnapshotSetting(): WarmSnapshotSetting {
-  ensureFresh();
-  return cache?.warmSnapshot ?? envDefaults().warmSnapshot;
 }
 
 export function invalidateRuntimeSettings(): void {

--- a/apps/web/src/app/admin/providers/page.tsx
+++ b/apps/web/src/app/admin/providers/page.tsx
@@ -294,32 +294,6 @@ export default function ProvidersPage() {
     onError: (e: any) => toast.error(e?.message ?? 'Save failed'),
   });
 
-  // ── Warm-fork snapshots (per-project ~2s session start; master gate) ──────
-  const wsQ = useQuery({
-    queryKey: ['admin', 'warm-snapshot-config'],
-    queryFn: async () => {
-      const r = await backendApi.get<{ enabled: boolean }>('/admin/api/warm-snapshot-config');
-      if (r.error) throw new Error(r.error.message);
-      return r.data!;
-    },
-  });
-  const [wsEnabled, setWsEnabled] = useState(true);
-  useEffect(() => {
-    if (wsQ.data) setWsEnabled(!!wsQ.data.enabled);
-  }, [wsQ.data]);
-  const saveWs = useMutation({
-    mutationFn: async () => {
-      const r = await backendApi.put('/admin/api/warm-snapshot-config', { enabled: wsEnabled });
-      if (r.error) throw new Error(r.error.message);
-      return r.data;
-    },
-    onSuccess: () => {
-      toast.success('Warm-fork saved');
-      qc.invalidateQueries({ queryKey: ['admin', 'warm-snapshot-config'] });
-    },
-    onError: (e: any) => toast.error(e?.message ?? 'Save failed'),
-  });
-
   const dist = distQ.data;
   const allowed = dist?.allowed ?? [];
   const totalW = allowed.reduce((s, p) => s + (Number(weights[p]) || 0), 0);
@@ -492,43 +466,6 @@ export default function ProvidersPage() {
               </>
             )}
           </div>
-
-          {/* ── Warm-fork sessions (Platinum only — Daytona has no warm/stateful snapshots) ── */}
-          {allowed.includes('platinum') && (
-          <div className="border-border/60 bg-card space-y-4 rounded-2xl border p-5">
-            <div className="flex items-start justify-between gap-4">
-              <div className="space-y-1">
-                <h2 className="flex items-center gap-2 text-sm font-semibold tracking-tight">
-                  {tI18nHardcoded.raw('autoAppAdminProvidersPageJsxTextWarmForkSessionsf726dcdc')}
-                  <Badge variant="outline" size="sm" className="text-[10px] capitalize">
-                    platinum
-                  </Badge>
-                </h2>
-                <p className="text-muted-foreground max-w-2xl text-xs leading-relaxed">
-                  {tI18nHardcoded.raw('autoAppAdminProvidersPageJsxTextPerProjectWarmbd60f907')}
-                </p>
-              </div>
-              {wsQ.isLoading ? (
-                <Skeleton className="h-6 w-10 rounded-full" />
-              ) : (
-                <Switch
-                  checked={wsEnabled}
-                  onCheckedChange={setWsEnabled}
-                  aria-label={tI18nHardcoded.raw('autoAppAdminProvidersPageJsxAttrAriaLabelEnableWarmForkb78de78a')}
-                />
-              )}
-            </div>
-            <Button
-              size="sm"
-              onClick={() => saveWs.mutate()}
-              disabled={saveWs.isPending}
-              className="gap-1.5"
-            >
-              {saveWs.isPending && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
-              {tI18nHardcoded.raw('autoAppAdminProvidersPageJsxTextSaveWarmFork8eeda5df')}
-            </Button>
-          </div>
-          )}
 
           {/* ── Provider failover ──────────────────────────────────────────── */}
           <div className="border-border/60 bg-card space-y-4 rounded-2xl border p-5">


### PR DESCRIPTION
Follow-up to #4091 (the Kortix cold-only strip). The stateful/warm-fork **backend** was removed and merged in #4091, but the **admin toggle** removal missed that PR's squash (an auto-merge race), so it's still on main describing a feature that no longer exists.

Removes the leftover:
- web Providers-panel **"Warm-fork sessions"** switch (`apps/web/src/app/admin/providers/page.tsx`)
- `GET`/`PUT /api/warm-snapshot-config` routes (`apps/api/src/admin/index.ts`)
- the `warm_snapshot` runtime-setting (`runtime-settings.ts`)
- the `warm_snapshots` health field (`index.ts`)

`provider_fallback` untouched. −148 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)