### PR TITLE
fix(llm-gateway): fail over on empty-choices completions instead of forwarding them [staging hotfix]

### DIFF
--- a/packages/llm-gateway/src/pipeline/handler.test.ts
+++ b/packages/llm-gateway/src/pipeline/handler.test.ts
@@ -129,6 +129,7 @@ describe("gateway.chatCompletions", () => {
     const { hooks, usage, traces } = makeHooks();
     const fetchImpl = okFetch({
       model: "kortix/x",
+      choices: [{ message: { content: "ok" } }],
       usage: { prompt_tokens: 100, completion_tokens: 50, cost: 0.01 },
     });
     const res = await createGateway(
@@ -171,6 +172,7 @@ describe("gateway.chatCompletions", () => {
     const { hooks, usage } = makeHooks({ resolveUpstream: async () => [byok] });
     const fetchImpl = okFetch({
       model: "anthropic/x",
+      choices: [{ message: { content: "ok" } }],
       usage: { prompt_tokens: 100, completion_tokens: 50, cost: 0.5 },
     });
     await createGateway(
@@ -206,6 +208,7 @@ describe("gateway.chatCompletions", () => {
         : new Response(
             JSON.stringify({
               model: "m",
+              choices: [{ message: { content: "ok" } }],
               usage: { prompt_tokens: 1, completion_tokens: 1 },
             }),
             { status: 200 },
@@ -469,6 +472,7 @@ describe("gateway.chatCompletions — combined authorize hook", () => {
     });
     const fetchImpl = okFetch({
       model: "kortix/x",
+      choices: [{ message: { content: "ok" } }],
       usage: { prompt_tokens: 10, completion_tokens: 5 },
     });
     const res = await createGateway(
@@ -513,6 +517,7 @@ describe("gateway.chatCompletions — combined authorize hook", () => {
     });
     const fetchImpl = okFetch({
       model: "openrouter/fusion",
+      choices: [{ message: { content: "ok" } }],
       usage: { prompt_tokens: 1, completion_tokens: 1 },
     });
     const res = await createGateway(
@@ -541,6 +546,7 @@ describe("gateway.chatCompletions — combined authorize hook", () => {
       },
     });
     const fetchImpl = okFetch({
+      choices: [{ message: { content: "ok" } }],
       usage: { prompt_tokens: 1, completion_tokens: 1 },
     });
     await createGateway(
@@ -581,5 +587,119 @@ describe("gateway.chatCompletions — combined authorize hook", () => {
     expect(traces[0].ok).toBe(false);
     expect(traces[0].errorCode).toBe("budget_exceeded");
     expect(traces[0].accountId).toBe("a1"); // attributed even on denial
+  });
+});
+
+// Regression coverage for the empty-completion bug: an upstream 200 with
+// syntactically valid but empty choices/content (seen from OpenRouter/z-ai) must
+// be treated as a failed candidate — failed over to the next one, and only
+// surfaced to the caller once every candidate has come back empty.
+describe("gateway.chatCompletions — empty-completion failover", () => {
+  const emptyJson = JSON.stringify({
+    model: "m",
+    choices: [],
+    usage: { prompt_tokens: 0, completion_tokens: 0 },
+  });
+  const goodJson = JSON.stringify({
+    model: "m",
+    choices: [{ message: { content: "real answer" } }],
+    usage: { prompt_tokens: 5, completion_tokens: 3 },
+  });
+
+  function sseResponse(body: string): Response {
+    return new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode(body));
+          controller.close();
+        },
+      }),
+      { status: 200, headers: { "content-type": "text/event-stream" } },
+    );
+  }
+  const emptySse = 'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\ndata: [DONE]\n\n';
+  const goodSse =
+    'data: {"choices":[{"delta":{"content":"real answer"}}]}\n\n' +
+    'data: {"choices":[{"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":3}}\n\n' +
+    'data: [DONE]\n\n';
+
+  test("non-streaming: an empty completion from candidate A fails over to candidate B", async () => {
+    const a: UpstreamDescriptor = { ...managed, provider: "a", baseUrl: "https://a.test/v1" };
+    const b: UpstreamDescriptor = { ...managed, provider: "b", baseUrl: "https://b.test/v1" };
+    const { hooks, traces, usage } = makeHooks({ resolveUpstream: async () => [a, b] });
+    const fetchImpl: FetchImpl = async (url) =>
+      new Response(new URL(url).hostname === "a.test" ? emptyJson : goodJson, {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+
+    const res = await createGateway(hooks, { retry: fastRetry }, { fetchImpl }).chatCompletions({
+      authorization: "Bearer good",
+      rawBody: '{"model":"x"}',
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.choices[0].message.content).toBe("real answer");
+    await flush();
+    expect(usage).toHaveLength(1); // the empty candidate never billed
+    expect(traces[0].ok).toBe(true);
+    expect(traces[0].provider).toBe("b");
+    expect(traces[0].candidatesTried).toEqual(["a", "b"]);
+  });
+
+  test("non-streaming: every candidate empty → 502 empty_completion, nothing forwarded to the caller", async () => {
+    const { hooks, usage, traces } = makeHooks({ resolveUpstream: async () => [managed] });
+    const fetchImpl: FetchImpl = async () =>
+      new Response(emptyJson, { status: 200, headers: { "content-type": "application/json" } });
+
+    const res = await createGateway(hooks, { retry: fastRetry }, { fetchImpl }).chatCompletions({
+      authorization: "Bearer good",
+      rawBody: '{"model":"x"}',
+    });
+
+    expect(res.status).toBe(502);
+    expect((await res.json()).code).toBe("empty_completion");
+    await flush();
+    expect(usage).toHaveLength(0);
+    expect(traces[0].ok).toBe(false);
+    expect(traces[0].errorCode).toBe("empty_completion");
+  });
+
+  test("streaming: an empty stream from candidate A fails over to candidate B — A's bytes never reach the client", async () => {
+    const a: UpstreamDescriptor = { ...managed, provider: "a", baseUrl: "https://a.test/v1" };
+    const b: UpstreamDescriptor = { ...managed, provider: "b", baseUrl: "https://b.test/v1" };
+    const { hooks, traces } = makeHooks({ resolveUpstream: async () => [a, b] });
+    const fetchImpl: FetchImpl = async (url) =>
+      sseResponse(new URL(url).hostname === "a.test" ? emptySse : goodSse);
+
+    const res = await createGateway(hooks, { retry: fastRetry }, { fetchImpl }).chatCompletions({
+      authorization: "Bearer good",
+      rawBody: '{"model":"x","stream":true}',
+    });
+
+    expect(res.status).toBe(200);
+    const text = await new Response(res.body).text();
+    expect(text).toBe(goodSse);
+    expect(text).not.toContain('"finish_reason":"stop"}]}\n\ndata: [DONE]'); // candidate A's empty frame absent
+    await flush();
+    expect(traces.find((t) => t.ok)?.provider).toBe("b");
+  });
+
+  test("streaming: every candidate's stream is empty → 502 empty_completion, not a fabricated SSE response", async () => {
+    const { hooks, traces } = makeHooks({ resolveUpstream: async () => [managed] });
+    const fetchImpl: FetchImpl = async () => sseResponse(emptySse);
+
+    const res = await createGateway(hooks, { retry: fastRetry }, { fetchImpl }).chatCompletions({
+      authorization: "Bearer good",
+      rawBody: '{"model":"x","stream":true}',
+    });
+
+    expect(res.status).toBe(502);
+    expect(res.headers.get("content-type")).toContain("application/json");
+    expect((await res.json()).code).toBe("empty_completion");
+    await flush();
+    expect(traces[0].ok).toBe(false);
+    expect(traces[0].errorCode).toBe("empty_completion");
   });
 });

--- a/packages/llm-gateway/src/pipeline/handler.ts
+++ b/packages/llm-gateway/src/pipeline/handler.ts
@@ -5,13 +5,14 @@ import type {
   GatewayHooks,
   GatewayLogger,
   TokenCounts,
+  UpstreamDescriptor,
   UsageEvent,
 } from '../domain';
 import type { FetchImpl } from '../http';
 import type { CircuitBreaker } from '../resilience';
-import { type ExtractedUsage, calculateCost, extractUsageFromJson } from '../usage';
+import { type ExtractedUsage, calculateCost, extractUsageFromJson, jsonHasContent } from '../usage';
 import { runFailover } from './failover';
-import { relayStream } from './streaming';
+import { type StreamProbeResult, probeStream, relayStream } from './streaming';
 import { createTraceEmitter } from './trace';
 
 export interface ChatCompletionRequest {
@@ -260,30 +261,127 @@ export async function handleChatCompletions(
     : body;
 
   step('dispatch_upstream', { streaming, candidateCount: candidates.length });
-  const result = await runFailover({
-    candidates,
-    payload,
-    config,
-    fetchImpl,
-    breakerFor,
-    emit,
-    logger,
-    requestId,
-    trace: { ...id, requestedModel, streaming, metadata },
-    capturedRequest: capture(payload),
-  });
 
-  if (result.kind === 'response') {
-    step('upstream_failed', { ms: lap(), status: result.response.status });
-    return result.response;
+  // An upstream can return a syntactically valid 200 with empty `choices`/content
+  // (seen from OpenRouter/z-ai) — a real failure mode, not a legitimate zero-output
+  // turn. That never throws, so runFailover's transport-level retry/failover never
+  // sees it. This loop adds a second failover tier on top: each candidate that
+  // comes back HTTP-ok but empty is excluded and the remaining candidates are
+  // retried, exactly like a transport error would be — only once every candidate
+  // has produced nothing do we give up and tell the caller, instead of silently
+  // forwarding a blank "stop".
+  const emptyProviders = new Set<string>();
+  let upstream: Response | null = null;
+  let descriptor: UpstreamDescriptor | null = null;
+  let tried: string[] = [];
+  let attempts = 0;
+  let nonStreamBody: unknown;
+  let streamProbe: StreamProbeResult | null = null;
+
+  for (;;) {
+    const remaining = candidates.filter((c) => !emptyProviders.has(c.provider));
+    if (remaining.length === 0) {
+      step('all_candidates_empty', { ms: lap(), tried });
+      emit({
+        ...id,
+        requestedModel,
+        resolvedModel: routedModel,
+        streaming,
+        status: 502,
+        ok: false,
+        errorCode: 'empty_completion',
+        candidatesTried: tried,
+        request: capture(payload),
+        metadata,
+      });
+      return json(
+        { error: 'All upstream candidates returned an empty completion', code: 'empty_completion' },
+        502,
+      );
+    }
+
+    const result = await runFailover({
+      candidates: remaining,
+      payload,
+      config,
+      fetchImpl,
+      breakerFor,
+      emit,
+      logger,
+      requestId,
+      trace: { ...id, requestedModel, streaming, metadata },
+      capturedRequest: capture(payload),
+    });
+
+    if (result.kind === 'response') {
+      step('upstream_failed', { ms: lap(), status: result.response.status });
+      return result.response;
+    }
+
+    const {
+      upstream: candidateUpstream,
+      chosen,
+      tried: triedThisRound,
+      attempts: attemptsThisRound,
+    } = result.value;
+    tried = [...tried, ...triedThisRound];
+    attempts += attemptsThisRound;
+
+    if (!streaming) {
+      const data = await candidateUpstream.json();
+      step('non_stream_body', { ms: lap(), provider: chosen.provider });
+      if (jsonHasContent(data)) {
+        upstream = candidateUpstream;
+        descriptor = chosen;
+        nonStreamBody = data;
+        break;
+      }
+      logger.warn(
+        `[llm-gateway] empty completion from ${chosen.provider}, failing over ${requestId}`,
+      );
+      step('empty_completion_retry', { provider: chosen.provider, streaming: false });
+      emptyProviders.add(chosen.provider);
+      continue;
+    }
+
+    if (!candidateUpstream.body) {
+      logger.warn(
+        `[llm-gateway] empty stream body from ${chosen.provider}, failing over ${requestId}`,
+      );
+      step('empty_completion_retry', {
+        provider: chosen.provider,
+        streaming: true,
+        reason: 'no_body',
+      });
+      emptyProviders.add(chosen.provider);
+      continue;
+    }
+
+    const probe = await probeStream(candidateUpstream.body);
+    if (probe.hasContent) {
+      upstream = candidateUpstream;
+      descriptor = chosen;
+      streamProbe = probe;
+      break;
+    }
+    logger.warn(`[llm-gateway] empty stream from ${chosen.provider}, failing over ${requestId}`);
+    step('empty_completion_retry', { provider: chosen.provider, streaming: true });
+    emptyProviders.add(chosen.provider);
   }
 
-  const { upstream, chosen: descriptor, tried, attempts } = result.value;
+  // Every loop exit above either `return`s (transport failure / all-empty) or
+  // `break`s right after assigning both.
+  if (!descriptor || !upstream) {
+    throw new Error(`unreachable: dispatch loop exited without a chosen upstream (${requestId})`);
+  }
+  const finalDescriptor: UpstreamDescriptor = descriptor;
+  const finalUpstream: Response = upstream;
+
   step('upstream_ok', {
     ms: lap(),
-    provider: descriptor.provider,
-    resolvedModel: descriptor.resolvedModel,
-    upstreamStatus: upstream.status,
+    provider: finalDescriptor.provider,
+    resolvedModel: finalDescriptor.resolvedModel,
+    upstreamStatus: finalUpstream.status,
     attempts,
     tried,
   });
@@ -291,7 +389,7 @@ export async function handleChatCompletions(
   const settle = async (usage: ExtractedUsage | null, response: unknown): Promise<void> => {
     const usedModel = (
       usage?.model ??
-      descriptor.resolvedModel ??
+      finalDescriptor.resolvedModel ??
       requestedModel ??
       'unknown'
     ).toString();
@@ -300,20 +398,20 @@ export async function handleChatCompletions(
       completionTokens: usage?.completionTokens ?? 0,
       cachedTokens: usage?.cachedTokens ?? 0,
     };
-    const markup = descriptor.billingMode === 'none' ? 0 : descriptor.markup;
+    const markup = finalDescriptor.billingMode === 'none' ? 0 : finalDescriptor.markup;
     const { upstreamCost, finalCost } = calculateCost(
       usedModel,
       counts,
       markup,
       usage?.upstreamCostHint,
-      descriptor.pricing,
+      finalDescriptor.pricing,
     );
 
     // A billable request that priced to $0 means we have no pricing for the
     // resolved model (stale catalog) — surface it so it can't silently leak.
     if (markup > 0 && upstreamCost === 0 && counts.promptTokens + counts.completionTokens > 0) {
       logger.warn(
-        `[llm-gateway] billable request priced at $0 — missing pricing? ${requestId} model=${usedModel} provider=${descriptor.provider}`,
+        `[llm-gateway] billable request priced at $0 — missing pricing? ${requestId} model=${usedModel} provider=${finalDescriptor.provider}`,
       );
     }
 
@@ -324,11 +422,11 @@ export async function handleChatCompletions(
         actorUserId: principal.userId,
         projectId: principal.projectId,
         sessionId: principal.sessionId,
-        provider: descriptor.provider,
+        provider: finalDescriptor.provider,
         model: usedModel,
         upstreamCost,
         finalCost,
-        billingMode: descriptor.billingMode,
+        billingMode: finalDescriptor.billingMode,
         streaming,
         requestId,
       };
@@ -341,7 +439,7 @@ export async function handleChatCompletions(
 
     step('settled', {
       resolvedModel: usedModel,
-      provider: descriptor.provider,
+      provider: finalDescriptor.provider,
       promptTokens: counts.promptTokens,
       completionTokens: counts.completionTokens,
       cachedTokens: counts.cachedTokens,
@@ -354,8 +452,8 @@ export async function handleChatCompletions(
       ...id,
       requestedModel,
       resolvedModel: usedModel,
-      provider: descriptor.provider,
-      billingMode: descriptor.billingMode,
+      provider: finalDescriptor.provider,
+      billingMode: finalDescriptor.billingMode,
       streaming,
       status: 200,
       ok: true,
@@ -371,22 +469,19 @@ export async function handleChatCompletions(
   };
 
   if (!streaming) {
-    const data = await upstream.json();
-    step('non_stream_body', { ms: lap() });
-    void settle(extractUsageFromJson(data), data);
-    return json(data);
-  }
-
-  if (!upstream.body) {
-    step('empty_stream');
-    void settle(null, null);
-    return json({ error: 'Upstream returned an empty stream' }, 502);
+    void settle(extractUsageFromJson(nonStreamBody), nonStreamBody);
+    return json(nonStreamBody);
   }
 
   step('stream_begin');
 
+  // streamProbe is always set on this path — the streaming branch of the
+  // dispatch loop only `break`s after assigning it.
+  if (!streamProbe) {
+    throw new Error(`unreachable: streaming dispatch exited without a probe result (${requestId})`);
+  }
   const readable = relayStream({
-    upstreamBody: upstream.body,
+    primed: { reader: streamProbe.reader, chunks: streamProbe.chunks },
     captureBodies,
     requestId,
     logger,

--- a/packages/llm-gateway/src/pipeline/index.ts
+++ b/packages/llm-gateway/src/pipeline/index.ts
@@ -1,2 +1,5 @@
 export { handleChatCompletions } from './handler';
 export type { ChatCompletionRequest, GatewayDeps, HandlerRuntime } from './handler';
+
+export { probeStream, relayStream } from './streaming';
+export type { StreamProbeResult, StreamRelayOptions } from './streaming';

--- a/packages/llm-gateway/src/pipeline/streaming.test.ts
+++ b/packages/llm-gateway/src/pipeline/streaming.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { relayStream } from './streaming';
+import { probeStream, relayStream } from './streaming';
 
 const enc = new TextEncoder();
 const dec = new TextDecoder();
@@ -108,5 +108,87 @@ describe('relayStream', () => {
     expect(text).toContain('data: partial\n\n');
     // the partial frame is contiguous: nothing inserted between "par" and "tial"
     expect(text).not.toMatch(/par[^]*keep-alive[^]*tial/);
+  });
+});
+
+describe('probeStream', () => {
+  test('reports hasContent once a content delta arrives, without losing any bytes', async () => {
+    const up = controllableUpstream();
+    up.push('data: {"choices":[{"delta":{},"finish_reason":null}]}\n\n');
+    up.push('data: {"choices":[{"delta":{"content":"hi"}}]}\n\n');
+    const result = await probeStream(up.stream);
+    expect(result.hasContent).toBe(true);
+    expect(result.chunks.length).toBeGreaterThan(0);
+    // every byte read by the probe is preserved for replay — none dropped
+    const replayed = result.chunks.map((c) => dec.decode(c)).join('');
+    expect(replayed).toContain('"content":"hi"');
+  });
+
+  test('reports hasContent=false when the stream closes having produced nothing', async () => {
+    const up = controllableUpstream();
+    up.push('data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\n');
+    up.push('data: [DONE]\n\n');
+    up.close();
+    const result = await probeStream(up.stream);
+    expect(result.hasContent).toBe(false);
+  });
+
+  test('gives up and assumes content after the probe budget, never blocking a legitimately slow stream', async () => {
+    const up = controllableUpstream();
+    // Push far more empty-delta frames than the probe will buffer, without closing —
+    // the probe must bail out (assume ok) rather than hang or read forever.
+    for (let i = 0; i < 200; i++) up.push('data: {"choices":[{"delta":{}}]}\n\n');
+    const result = await probeStream(up.stream);
+    expect(result.hasContent).toBe(true);
+    expect(result.chunks.length).toBeLessThan(200); // bailed out before draining everything pushed
+  });
+
+  test('a read error mid-probe resolves on whatever content was seen so far', async () => {
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(enc.encode('data: {"choices":[{"delta":{}}]}\n\n'));
+      },
+      pull() {
+        throw new Error('upstream socket reset');
+      },
+    });
+    const result = await probeStream(stream);
+    expect(result.hasContent).toBe(false);
+  });
+});
+
+describe('relayStream with a primed reader', () => {
+  test('replays the probe-buffered prefix before continuing the live stream — no drops, no duplicates', async () => {
+    const up = controllableUpstream();
+    up.push('data: {"choices":[{"delta":{},"finish_reason":null}]}\n\n');
+    up.push('data: {"choices":[{"delta":{"content":"hi"}}]}\n\n');
+    const probe = await probeStream(up.stream);
+    expect(probe.hasContent).toBe(true);
+
+    let settledBuffer: unknown;
+    const out = relayStream({
+      primed: { reader: probe.reader, chunks: probe.chunks },
+      captureBodies: true,
+      requestId: 'primed-1',
+      logger: noop,
+      settle: async (_usage, response) => {
+        settledBuffer = response;
+      },
+      heartbeatMs: 10_000,
+    });
+    const collected = drain(out);
+    up.push('data: {"choices":[{"delta":{"content":" there"}}]}\n\n');
+    up.push('data: [DONE]\n\n');
+    up.close();
+    const text = await collected;
+
+    expect(text).toBe(
+      'data: {"choices":[{"delta":{},"finish_reason":null}]}\n\n' +
+        'data: {"choices":[{"delta":{"content":"hi"}}]}\n\n' +
+        'data: {"choices":[{"delta":{"content":" there"}}]}\n\n' +
+        'data: [DONE]\n\n',
+    );
+    await delay(10);
+    expect(settledBuffer).toBe(text);
   });
 });

--- a/packages/llm-gateway/src/pipeline/streaming.ts
+++ b/packages/llm-gateway/src/pipeline/streaming.ts
@@ -1,7 +1,10 @@
-import { type ExtractedUsage, extractUsageFromSseBuffer } from '../usage';
+import { type ExtractedUsage, extractUsageFromSseBuffer, sseHasContent } from '../usage';
 
 export interface StreamRelayOptions {
-  upstreamBody: ReadableStream<Uint8Array>;
+  /** Fresh upstream body — mutually exclusive with `primed`. */
+  upstreamBody?: ReadableStream<Uint8Array>;
+  /** A reader already advanced by `probeStream`, plus the chunks it consumed (must be replayed first). */
+  primed?: { reader: ReadableStreamDefaultReader<Uint8Array>; chunks: Uint8Array[] };
   captureBodies: boolean;
   requestId: string;
   logger: { warn: (...args: unknown[]) => void; debug?: (...args: unknown[]) => void };
@@ -19,8 +22,56 @@ const HEARTBEAT_MS = 10_000;
 // payload that just resets each hop's idle timer.
 const HEARTBEAT_FRAME = new TextEncoder().encode(': keep-alive\n\n');
 
+// A candidate that opens a stream, sends nothing usable, and closes cleanly (the
+// empty-completion bug) fails fast — real models produce their first token well
+// within this budget. Bounding the probe by chunk/byte count (not a wall-clock
+// timer racing the in-flight read) means we never abandon a pending read() and
+// risk silently dropping a chunk once real relaying resumes.
+const PROBE_MAX_CHUNKS = 64;
+const PROBE_MAX_BYTES = 64 * 1024;
+
+export interface StreamProbeResult {
+  hasContent: boolean;
+  reader: ReadableStreamDefaultReader<Uint8Array>;
+  chunks: Uint8Array[];
+}
+
+// Reads from the upstream body until either real content/tool-call/reasoning
+// output is seen, the stream ends, or the probe budget is exhausted — whichever
+// comes first. Every chunk consumed is captured in `chunks` so the caller can
+// replay them verbatim (via `primed`) without losing a single byte, regardless
+// of which outcome is reached.
+export async function probeStream(body: ReadableStream<Uint8Array>): Promise<StreamProbeResult> {
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  const decoder = new TextDecoder();
+  let buffer = '';
+  let bytes = 0;
+
+  for (;;) {
+    if (chunks.length >= PROBE_MAX_CHUNKS || bytes >= PROBE_MAX_BYTES) {
+      return { hasContent: true, reader, chunks };
+    }
+    let done: boolean;
+    let value: Uint8Array | undefined;
+    try {
+      ({ done, value } = await reader.read());
+    } catch {
+      // A read error mid-probe is not this function's concern to report — whatever
+      // content (if any) arrived before the error is all there is to judge on.
+      return { hasContent: sseHasContent(buffer), reader, chunks };
+    }
+    if (done) return { hasContent: sseHasContent(buffer), reader, chunks };
+    if (!value) continue;
+    chunks.push(value);
+    bytes += value.byteLength;
+    buffer += decoder.decode(value, { stream: true });
+    if (sseHasContent(buffer)) return { hasContent: true, reader, chunks };
+  }
+}
+
 export function relayStream(opts: StreamRelayOptions): ReadableStream<Uint8Array> {
-  const { upstreamBody, captureBodies, requestId, logger, settle } = opts;
+  const { captureBodies, requestId, logger, settle } = opts;
   const heartbeatMs = opts.heartbeatMs ?? HEARTBEAT_MS;
   const transform = new TransformStream<Uint8Array, Uint8Array>();
   const writer = transform.writable.getWriter();
@@ -32,17 +83,45 @@ export function relayStream(opts: StreamRelayOptions): ReadableStream<Uint8Array
     logger.debug?.(`[gateway] · ${requestId} ${event}`, { requestId, event, ...fields });
 
   void (async () => {
-    const reader = upstreamBody.getReader();
+    const reader = opts.primed?.reader ?? opts.upstreamBody?.getReader();
+    if (!reader) throw new Error('relayStream requires either `primed` or `upstreamBody`');
     let downstreamAlive = true;
     let firstByteAt = 0;
     let bytes = 0;
     let chunks = 0;
     let heartbeats = 0;
-    // Keep exactly one read in flight; race it against a heartbeat timer so a
-    // long token gap emits a keep-alive without ever issuing a second read.
-    let pending = reader.read();
-    debug('stream_open');
+
+    const writeChunk = async (value: Uint8Array): Promise<void> => {
+      if (!firstByteAt) {
+        firstByteAt = Date.now();
+        debug('stream_first_byte', { ttfbMs: firstByteAt - startMs });
+      }
+      chunks += 1;
+      bytes += value.byteLength;
+      sseBuffer += decoder.decode(value, { stream: true });
+      if (downstreamAlive) {
+        try {
+          await writer.write(value);
+        } catch {
+          downstreamAlive = false;
+        }
+      }
+    };
+
+    debug('stream_open', {
+      primed: Boolean(opts.primed),
+      primedChunks: opts.primed?.chunks.length ?? 0,
+    });
     try {
+      // Replay whatever probeStream already consumed before this relay took over —
+      // these bytes were never sent to the client, so order/content must be exact.
+      if (opts.primed) {
+        for (const value of opts.primed.chunks) await writeChunk(value);
+      }
+
+      // Keep exactly one read in flight; race it against a heartbeat timer so a
+      // long token gap emits a keep-alive without ever issuing a second read.
+      let pending = reader.read();
       while (true) {
         let timer: ReturnType<typeof setTimeout> | undefined;
         const beat = new Promise<'beat'>((resolve) => {
@@ -71,24 +150,15 @@ export function relayStream(opts: StreamRelayOptions): ReadableStream<Uint8Array
         if (done) break;
         pending = reader.read();
         if (!value) continue;
-        if (!firstByteAt) {
-          firstByteAt = Date.now();
-          debug('stream_first_byte', { ttfbMs: firstByteAt - startMs });
-        }
-        chunks += 1;
-        bytes += value.byteLength;
-        sseBuffer += decoder.decode(value, { stream: true });
-        if (downstreamAlive) {
-          try {
-            await writer.write(value);
-          } catch {
-            downstreamAlive = false;
-          }
-        }
+        await writeChunk(value);
       }
     } catch (err) {
       logger.warn(`[llm-gateway] stream read error ${requestId}:`, err);
-      debug('stream_error', { error: err instanceof Error ? err.message : String(err), bytes, chunks });
+      debug('stream_error', {
+        error: err instanceof Error ? err.message : String(err),
+        bytes,
+        chunks,
+      });
     } finally {
       try {
         await writer.close();

--- a/packages/llm-gateway/src/usage/completion-guard.test.ts
+++ b/packages/llm-gateway/src/usage/completion-guard.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from 'bun:test';
+import { jsonHasContent, sseHasContent } from './completion-guard';
+
+describe('jsonHasContent', () => {
+  test('true for a normal message completion', () => {
+    expect(jsonHasContent({ choices: [{ message: { content: 'hi' } }] })).toBe(true);
+  });
+
+  test('true for a tool-call-only completion (no text content)', () => {
+    expect(
+      jsonHasContent({
+        choices: [
+          { message: { content: null, tool_calls: [{ id: 't1', function: { name: 'x' } }] } },
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  test('true when reasoning-only content is present', () => {
+    expect(jsonHasContent({ choices: [{ message: { reasoning: 'thinking...' } }] })).toBe(true);
+  });
+
+  test('false for empty choices array — the observed production bug shape', () => {
+    expect(jsonHasContent({ choices: [], usage: { prompt_tokens: 0, completion_tokens: 0 } })).toBe(
+      false,
+    );
+  });
+
+  test('false when choices is missing entirely', () => {
+    expect(jsonHasContent({ usage: { prompt_tokens: 1, completion_tokens: 1 } })).toBe(false);
+  });
+
+  test('false for a choice with empty string content and no tool calls', () => {
+    expect(jsonHasContent({ choices: [{ message: { content: '' } }] })).toBe(false);
+  });
+
+  test('false for non-object input', () => {
+    expect(jsonHasContent(null)).toBe(false);
+    expect(jsonHasContent('nope')).toBe(false);
+    expect(jsonHasContent(undefined)).toBe(false);
+  });
+});
+
+describe('sseHasContent', () => {
+  test('true once a delta chunk carries content', () => {
+    const buf =
+      'data: {"choices":[{"delta":{}}]}\n\ndata: {"choices":[{"delta":{"content":"hi"}}]}\n\n';
+    expect(sseHasContent(buf)).toBe(true);
+  });
+
+  test('true for a tool_calls delta', () => {
+    const buf = 'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"t1"}]}}]}\n\n';
+    expect(sseHasContent(buf)).toBe(true);
+  });
+
+  test('false for a stream that only ever sent an empty stop event', () => {
+    const buf = 'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\ndata: [DONE]\n\n';
+    expect(sseHasContent(buf)).toBe(false);
+  });
+
+  test('false for an empty buffer', () => {
+    expect(sseHasContent('')).toBe(false);
+  });
+
+  test('ignores malformed JSON lines instead of throwing', () => {
+    expect(sseHasContent('data: {not json\n\n')).toBe(false);
+  });
+});

--- a/packages/llm-gateway/src/usage/completion-guard.ts
+++ b/packages/llm-gateway/src/usage/completion-guard.ts
@@ -1,0 +1,56 @@
+// A 200 OK with syntactically valid but empty `choices`/content is a real upstream
+// failure mode (seen from OpenRouter/z-ai), not a successful zero-output turn — the
+// gateway must detect it so failover can try the next candidate instead of handing
+// the caller a blank "stop" with no text or tool calls.
+
+interface ChoiceLike {
+  message?: { content?: unknown; tool_calls?: unknown };
+  delta?: {
+    content?: unknown;
+    tool_calls?: unknown;
+    reasoning?: unknown;
+    reasoning_content?: unknown;
+  };
+}
+
+function partHasContent(part: ChoiceLike['message'] | ChoiceLike['delta']): boolean {
+  if (!part) return false;
+  if (typeof part.content === 'string' && part.content.length > 0) return true;
+  if (Array.isArray(part.content) && part.content.length > 0) return true;
+  if (Array.isArray(part.tool_calls) && part.tool_calls.length > 0) return true;
+  const reasoning = 'reasoning' in part ? part.reasoning : undefined;
+  const reasoningContent = 'reasoning_content' in part ? part.reasoning_content : undefined;
+  if (typeof reasoning === 'string' && reasoning.length > 0) return true;
+  if (typeof reasoningContent === 'string' && reasoningContent.length > 0) return true;
+  return false;
+}
+
+function choiceHasContent(choice: unknown): boolean {
+  if (!choice || typeof choice !== 'object') return false;
+  const c = choice as ChoiceLike;
+  return partHasContent(c.message) || partHasContent(c.delta);
+}
+
+/** Non-streaming completion body: real output means at least one choice with content/tool_calls. */
+export function jsonHasContent(data: unknown): boolean {
+  if (!data || typeof data !== 'object') return false;
+  const choices = (data as { choices?: unknown }).choices;
+  if (!Array.isArray(choices) || choices.length === 0) return false;
+  return choices.some(choiceHasContent);
+}
+
+/** Streaming SSE buffer (one or more `data: {...}` frames): real output means any chunk carried content. */
+export function sseHasContent(buffer: string): boolean {
+  for (const line of buffer.split('\n')) {
+    if (!line.startsWith('data:')) continue;
+    const payload = line.slice(5).trim();
+    if (!payload || payload === '[DONE]') continue;
+    try {
+      const chunk = JSON.parse(payload) as { choices?: unknown };
+      if (Array.isArray(chunk.choices) && chunk.choices.some(choiceHasContent)) return true;
+    } catch {
+      // malformed SSE data line — not this function's concern, keep scanning
+    }
+  }
+  return false;
+}

--- a/packages/llm-gateway/src/usage/index.ts
+++ b/packages/llm-gateway/src/usage/index.ts
@@ -3,3 +3,5 @@ export type { ExtractedUsage } from './extract';
 
 export { calculateCost } from './pricing';
 export type { CostBreakdown, TokenUsage } from './pricing';
+
+export { jsonHasContent, sseHasContent } from './completion-guard';


### PR DESCRIPTION
## Summary
Staging cherry-pick of #4099 (targeting `main`) — same fix, fast-tracked directly onto `staging` since the affected files (`packages/llm-gateway/src/pipeline/{handler,streaming}.ts`, `usage/*`) are byte-identical between `main` and `staging`, so this is a clean, zero-conflict cherry-pick with no unrelated drift pulled in.

- Root cause: an upstream 200 with empty `choices`/content (seen from OpenRouter/z-ai) was forwarded straight through as a successful zero-token `stop` turn instead of being retried — this is what was producing the recurring "first prompt does nothing" reports.
- The dispatch loop now excludes any candidate that returns an empty completion and retries the rest, for both non-streaming and streaming requests, before giving up with `502 empty_completion`.

## Test plan
- [x] `bun test` in `packages/llm-gateway` on top of `staging` — 110 pass, 0 fail
- [x] `tsc --noEmit` clean
- [x] Clean cherry-pick of 8ad-free commit d6f912d2bd from #4099, no conflicts