### PR TITLE
fix(llm-gateway): auto-retry the same candidate on an empty completion before failing over

### DIFF
--- a/packages/llm-gateway/src/pipeline/handler.test.ts
+++ b/packages/llm-gateway/src/pipeline/handler.test.ts
@@ -623,7 +623,32 @@ describe("gateway.chatCompletions — empty-completion failover", () => {
     'data: {"choices":[{"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":3}}\n\n' +
     'data: [DONE]\n\n';
 
-  test("non-streaming: an empty completion from candidate A fails over to candidate B", async () => {
+  test("non-streaming: a candidate that recovers after retries never fails over — the common case (matches the observed ~19% transient rate)", async () => {
+    const { hooks, usage, traces } = makeHooks({ resolveUpstream: async () => [managed] });
+    let calls = 0;
+    const fetchImpl: FetchImpl = async () => {
+      calls += 1;
+      return new Response(calls < 2 ? emptyJson : goodJson, {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    };
+
+    const res = await createGateway(hooks, { retry: fastRetry }, { fetchImpl }).chatCompletions({
+      authorization: "Bearer good",
+      rawBody: '{"model":"x"}',
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.choices[0].message.content).toBe("real answer");
+    await flush();
+    expect(usage).toHaveLength(1);
+    expect(traces[0].ok).toBe(true);
+    expect(traces[0].candidatesTried).toEqual(["openrouter", "openrouter"]); // retried in place, no failover needed
+  });
+
+  test("non-streaming: a candidate empty on every attempt exhausts its retry budget, then fails over to candidate B", async () => {
     const a: UpstreamDescriptor = { ...managed, provider: "a", baseUrl: "https://a.test/v1" };
     const b: UpstreamDescriptor = { ...managed, provider: "b", baseUrl: "https://b.test/v1" };
     const { hooks, traces, usage } = makeHooks({ resolveUpstream: async () => [a, b] });
@@ -645,10 +670,11 @@ describe("gateway.chatCompletions — empty-completion failover", () => {
     expect(usage).toHaveLength(1); // the empty candidate never billed
     expect(traces[0].ok).toBe(true);
     expect(traces[0].provider).toBe("b");
-    expect(traces[0].candidatesTried).toEqual(["a", "b"]);
+    // "a" gets its full retry budget in place before failing over to "b"
+    expect(traces[0].candidatesTried).toEqual(["a", "a", "a", "b"]);
   });
 
-  test("non-streaming: every candidate empty → 502 empty_completion, nothing forwarded to the caller", async () => {
+  test("non-streaming: every candidate empty on every attempt → 502 empty_completion, nothing forwarded to the caller", async () => {
     const { hooks, usage, traces } = makeHooks({ resolveUpstream: async () => [managed] });
     const fetchImpl: FetchImpl = async () =>
       new Response(emptyJson, { status: 200, headers: { "content-type": "application/json" } });
@@ -664,6 +690,29 @@ describe("gateway.chatCompletions — empty-completion failover", () => {
     expect(usage).toHaveLength(0);
     expect(traces[0].ok).toBe(false);
     expect(traces[0].errorCode).toBe("empty_completion");
+    // the sole candidate was retried in place up to its full budget before giving up
+    expect(traces[0].candidatesTried).toEqual(["openrouter", "openrouter", "openrouter"]);
+  });
+
+  test("streaming: a candidate that recovers after retries never fails over", async () => {
+    const { hooks, traces } = makeHooks({ resolveUpstream: async () => [managed] });
+    let calls = 0;
+    const fetchImpl: FetchImpl = async () => {
+      calls += 1;
+      return sseResponse(calls < 2 ? emptySse : goodSse);
+    };
+
+    const res = await createGateway(hooks, { retry: fastRetry }, { fetchImpl }).chatCompletions({
+      authorization: "Bearer good",
+      rawBody: '{"model":"x","stream":true}',
+    });
+
+    expect(res.status).toBe(200);
+    const text = await new Response(res.body).text();
+    expect(text).toBe(goodSse);
+    await flush();
+    expect(traces[0].ok).toBe(true);
+    expect(traces[0].candidatesTried).toEqual(["openrouter", "openrouter"]);
   });
 
   test("streaming: an empty stream from candidate A fails over to candidate B — A's bytes never reach the client", async () => {

--- a/packages/llm-gateway/src/pipeline/handler.ts
+++ b/packages/llm-gateway/src/pipeline/handler.ts
@@ -9,7 +9,7 @@ import type {
   UsageEvent,
 } from '../domain';
 import type { FetchImpl } from '../http';
-import type { CircuitBreaker } from '../resilience';
+import { type CircuitBreaker, backoffDelay, realSleep } from '../resilience';
 import { type ExtractedUsage, calculateCost, extractUsageFromJson, jsonHasContent } from '../usage';
 import { runFailover } from './failover';
 import { type StreamProbeResult, probeStream, relayStream } from './streaming';
@@ -55,6 +55,15 @@ function newRequestId(): string {
 function errorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
+
+// An empty completion is often a transient upstream hiccup on one specific
+// backend (observed: OpenRouter intermittently routing a request to a backend
+// that returns an immediate empty `stop` with zero usage, while the very next
+// request to the SAME candidate succeeds normally). Retrying the same candidate
+// a few times — before falling over to a different candidate, and before ever
+// giving up — resolves the overwhelming majority of these transparently,
+// including the common case where there is only one candidate to begin with.
+const MAX_EMPTY_COMPLETION_ATTEMPTS_PER_CANDIDATE = 3;
 
 function idOf(principal: AuthedPrincipal) {
   return {
@@ -265,12 +274,41 @@ export async function handleChatCompletions(
   // An upstream can return a syntactically valid 200 with empty `choices`/content
   // (seen from OpenRouter/z-ai) — a real failure mode, not a legitimate zero-output
   // turn. That never throws, so runFailover's transport-level retry/failover never
-  // sees it. This loop adds a second failover tier on top: each candidate that
-  // comes back HTTP-ok but empty is excluded and the remaining candidates are
-  // retried, exactly like a transport error would be — only once every candidate
-  // has produced nothing do we give up and tell the caller, instead of silently
-  // forwarding a blank "stop".
+  // sees it. This loop adds a second failover tier on top: each candidate gets a
+  // few immediate retries in place (below), and only once it's exhausted its own
+  // retries is it excluded so the remaining candidates get a turn — only once
+  // every candidate has produced nothing do we give up and tell the caller,
+  // instead of silently forwarding a blank "stop".
   const emptyProviders = new Set<string>();
+  const emptyAttemptsByProvider = new Map<string, number>();
+  const sleep = config.retry?.sleep ?? realSleep;
+  const rand = config.retry?.rand ?? Math.random;
+  const baseDelayMs = config.retry?.baseDelayMs ?? 250;
+  const maxDelayMs = config.retry?.maxDelayMs ?? 8_000;
+  const jitter = config.retry?.jitter ?? true;
+
+  // Records an empty completion from `provider`. Retries the same candidate (via
+  // a short backoff, then `continue`) while it's under budget; once exhausted,
+  // excludes it from `remaining` so the loop moves on to the next candidate (or
+  // to the all-candidates-empty exit if there isn't one).
+  const registerEmptyCompletion = async (
+    provider: string,
+    fields: Record<string, unknown>,
+  ): Promise<void> => {
+    const attempt = (emptyAttemptsByProvider.get(provider) ?? 0) + 1;
+    emptyAttemptsByProvider.set(provider, attempt);
+    const exhausted = attempt >= MAX_EMPTY_COMPLETION_ATTEMPTS_PER_CANDIDATE;
+    logger.warn(
+      `[llm-gateway] empty completion from ${provider} (attempt ${attempt}/${MAX_EMPTY_COMPLETION_ATTEMPTS_PER_CANDIDATE}), ${exhausted ? 'failing over' : 'retrying same candidate'} ${requestId}`,
+    );
+    step('empty_completion_retry', { provider, attempt, exhausted, ...fields });
+    if (exhausted) {
+      emptyProviders.add(provider);
+      return;
+    }
+    await sleep(backoffDelay(attempt, baseDelayMs, maxDelayMs, jitter, rand));
+  };
+
   let upstream: Response | null = null;
   let descriptor: UpstreamDescriptor | null = null;
   let tried: string[] = [];
@@ -336,24 +374,12 @@ export async function handleChatCompletions(
         nonStreamBody = data;
         break;
       }
-      logger.warn(
-        `[llm-gateway] empty completion from ${chosen.provider}, failing over ${requestId}`,
-      );
-      step('empty_completion_retry', { provider: chosen.provider, streaming: false });
-      emptyProviders.add(chosen.provider);
+      await registerEmptyCompletion(chosen.provider, { streaming: false });
       continue;
     }
 
     if (!candidateUpstream.body) {
-      logger.warn(
-        `[llm-gateway] empty stream body from ${chosen.provider}, failing over ${requestId}`,
-      );
-      step('empty_completion_retry', {
-        provider: chosen.provider,
-        streaming: true,
-        reason: 'no_body',
-      });
-      emptyProviders.add(chosen.provider);
+      await registerEmptyCompletion(chosen.provider, { streaming: true, reason: 'no_body' });
       continue;
     }
 
@@ -364,9 +390,7 @@ export async function handleChatCompletions(
       streamProbe = probe;
       break;
     }
-    logger.warn(`[llm-gateway] empty stream from ${chosen.provider}, failing over ${requestId}`);
-    step('empty_completion_retry', { provider: chosen.provider, streaming: true });
-    emptyProviders.add(chosen.provider);
+    await registerEmptyCompletion(chosen.provider, { streaming: true });
   }
 
   // Every loop exit above either `return`s (transport failure / all-empty) or


### PR DESCRIPTION
## Summary
Follow-up to #4099. Investigated the original incident in depth (production `kortix.gateway_request_logs` + live gateway pod logs for the exact reported session `3d436119-75f5-47a2-9f3c-7982298d82e0`):

- 5 of 26 requests in that one session got an empty completion. In every case the account had **only one** upstream candidate resolved (`openrouter`/`glm-5.2`, no BYOK/fallback configured) — so #4099's candidate-to-candidate failover had nowhere to fail over to, and correctly but unhelpfully returned `502 empty_completion` every time.
- The captured raw response (`gateway_request_logs.response`) shows OpenRouter routing the request to its **"GMICloud"** backend and getting back a single SSE chunk with empty `content` and `finish_reason: "stop"` — a transient backend hiccup, not a hard failure: **21/26** requests to the exact same candidate in that session succeeded fine, including several that also landed on GMICloud.

Since most accounts only configure one managed candidate per model, candidate-level failover alone doesn't help the common case. This adds a bounded **same-candidate retry** (3 attempts, jittered backoff reusing the existing `config.retry` settings) before a candidate is excluded and failover moves on — so the overwhelming majority of empty completions now resolve transparently within the original request instead of ever reaching the client as an error.

## Test plan
- [x] `bun test` in `packages/llm-gateway` — 116 pass, 0 fail (updated the empty-completion suite: added "recovers after retry, no failover" cases for both streaming and non-streaming, and updated the failover/exhaustion cases to assert the new 3-attempt-per-candidate `candidatesTried` shape)
- [x] `tsc --noEmit` clean
- [x] `biome check` clean on `handler.ts`