### PR TITLE
Extend entitlement gating to custom RBAC and audit access

### DIFF
--- a/apps/api/src/__tests__/unit-tier-entitlements.test.ts
+++ b/apps/api/src/__tests__/unit-tier-entitlements.test.ts
@@ -6,15 +6,17 @@ import {
   tierHasEntitlement,
 } from '../billing/services/tiers';
 
-// Locks in the plan-gating contract for the enterprise identity surfaces
-// (SAML SSO + SCIM). Only the sales-assigned `enterprise` tier unlocks them;
-// every self-serve / legacy tier is fully gated. The IAM route guard
-// (requireEntitlement) and the /scim/v2 data-plane middleware both key off
-// tierHasEntitlement, so these invariants ARE the access-control policy.
+// Locks in the plan-gating contract for the enterprise surfaces (SAML SSO,
+// SCIM, custom RBAC, audit access). Only the sales-assigned `enterprise` tier
+// unlocks them; every self-serve / legacy tier is fully gated. The IAM route
+// guard (requireEntitlement) and the /scim/v2 data-plane middleware both key
+// off tierHasEntitlement, so these invariants ARE the access-control policy.
 describe('tier entitlements (enterprise gating)', () => {
-  test('enterprise tier unlocks SSO + SCIM', () => {
+  test('enterprise tier unlocks SSO + SCIM + RBAC + audit access', () => {
     expect(tierHasEntitlement('enterprise', 'sso')).toBe(true);
     expect(tierHasEntitlement('enterprise', 'scim')).toBe(true);
+    expect(tierHasEntitlement('enterprise', 'rbac')).toBe(true);
+    expect(tierHasEntitlement('enterprise', 'auditAccess')).toBe(true);
   });
 
   test('every non-enterprise tier is fully gated', () => {
@@ -34,13 +36,20 @@ describe('tier entitlements (enterprise gating)', () => {
     ]) {
       expect(tierHasEntitlement(t, 'sso')).toBe(false);
       expect(tierHasEntitlement(t, 'scim')).toBe(false);
+      expect(tierHasEntitlement(t, 'rbac')).toBe(false);
+      expect(tierHasEntitlement(t, 'auditAccess')).toBe(false);
     }
   });
 
   test('unknown tier names fail closed (default tier = none, no entitlements)', () => {
     expect(tierHasEntitlement('does-not-exist', 'sso')).toBe(false);
     expect(tierHasEntitlement('does-not-exist', 'scim')).toBe(false);
-    expect(getTierEntitlements('does-not-exist')).toEqual({ sso: false, scim: false });
+    expect(getTierEntitlements('does-not-exist')).toEqual({
+      sso: false,
+      scim: false,
+      rbac: false,
+      auditAccess: false,
+    });
   });
 
   test('the Team (per_seat) plan kept its $40 anchor — gating did not touch price', () => {

--- a/apps/api/src/accounts/audit.ts
+++ b/apps/api/src/accounts/audit.ts
@@ -21,6 +21,7 @@ import { recordAuditEvent } from '../shared/audit';
 import type { AppEnv } from '../types';
 import { ACCOUNT_ACTIONS, assertAuthorized } from '../iam';
 import { makeOpenApiApp, json, errors, auth, ErrorSchema } from '../openapi';
+import { requireEntitlement } from './iam/helpers';
 
 export const auditRouter = makeOpenApiApp<AppEnv>();
 
@@ -141,6 +142,8 @@ auditRouter.openapi(
   const userId = c.get('userId') as string;
   const accountId = c.req.param('accountId');
   await assertAuthorized(userId, accountId, ACCOUNT_ACTIONS.AUDIT_READ);
+  const denied = await requireEntitlement(c, accountId, 'auditAccess');
+  if (denied) return denied;
 
   const actionPrefix = c.req.query('action')?.trim() || null;
   const sinceRaw = c.req.query('since')?.trim() || null;
@@ -261,6 +264,8 @@ auditRouter.openapi(
   const userId = c.get('userId') as string;
   const accountId = c.req.param('accountId');
   await assertAuthorized(userId, accountId, ACCOUNT_ACTIONS.AUDIT_READ);
+  const denied = await requireEntitlement(c, accountId, 'auditAccess');
+  if (denied) return denied;
 
   const format = (c.req.query('format') || 'csv').toLowerCase();
   if (format !== 'csv' && format !== 'jsonl') {
@@ -393,6 +398,8 @@ auditRouter.openapi(
   const userId = c.get('userId') as string;
   const accountId = c.req.param('accountId');
   await assertAuthorized(userId, accountId, ACCOUNT_ACTIONS.ACCOUNT_WRITE);
+  const denied = await requireEntitlement(c, accountId, 'auditAccess');
+  if (denied) return denied;
 
   const rows = await db
     .select()
@@ -424,6 +431,8 @@ auditRouter.openapi(
   const userId = c.get('userId') as string;
   const accountId = c.req.param('accountId');
   await assertAuthorized(userId, accountId, ACCOUNT_ACTIONS.ACCOUNT_WRITE);
+  const denied = await requireEntitlement(c, accountId, 'auditAccess');
+  if (denied) return denied;
 
   const body = await readBody(c);
 
@@ -508,6 +517,8 @@ auditRouter.openapi(
   const accountId = c.req.param('accountId');
   const webhookId = c.req.param('webhookId');
   await assertAuthorized(userId, accountId, ACCOUNT_ACTIONS.ACCOUNT_WRITE);
+  const denied = await requireEntitlement(c, accountId, 'auditAccess');
+  if (denied) return denied;
 
   const [before] = await db
     .select()
@@ -582,6 +593,8 @@ auditRouter.openapi(
   const accountId = c.req.param('accountId');
   const webhookId = c.req.param('webhookId');
   await assertAuthorized(userId, accountId, ACCOUNT_ACTIONS.ACCOUNT_WRITE);
+  const denied = await requireEntitlement(c, accountId, 'auditAccess');
+  if (denied) return denied;
 
   const rows = await db
     .delete(auditWebhooks)

--- a/apps/api/src/accounts/audit.ts
+++ b/apps/api/src/accounts/audit.ts
@@ -398,8 +398,8 @@ auditRouter.openapi(
   const userId = c.get('userId') as string;
   const accountId = c.req.param('accountId');
   await assertAuthorized(userId, accountId, ACCOUNT_ACTIONS.ACCOUNT_WRITE);
-  const denied = await requireEntitlement(c, accountId, 'auditAccess');
-  if (denied) return denied;
+  // No entitlement gate on listing: a downgraded admin must be able to see
+  // leftover webhooks to delete them. Creation/update stay gated below.
 
   const rows = await db
     .select()
@@ -593,8 +593,9 @@ auditRouter.openapi(
   const accountId = c.req.param('accountId');
   const webhookId = c.req.param('webhookId');
   await assertAuthorized(userId, accountId, ACCOUNT_ACTIONS.ACCOUNT_WRITE);
-  const denied = await requireEntitlement(c, accountId, 'auditAccess');
-  if (denied) return denied;
+  // No entitlement gate: deleting a webhook is cleanup, always allowed — and
+  // delivery itself is entitlement-gated in shared/audit-webhooks.ts, so a
+  // leftover row on a downgraded account streams nothing either way.
 
   const rows = await db
     .delete(auditWebhooks)

--- a/apps/api/src/accounts/iam/custom-roles.ts
+++ b/apps/api/src/accounts/iam/custom-roles.ts
@@ -17,7 +17,7 @@ import {
   invalidateIamCacheForRole,
 } from '../../iam/cache-invalidation';
 import { iamRouter, AccountIdParam } from './app';
-import { auditIam, isUniqueViolation, readBody } from './helpers';
+import { auditIam, isUniqueViolation, readBody, requireEntitlement } from './helpers';
 import { listAgentServiceAccounts, ensureAgentServiceAccount } from '../../repositories/service-accounts';
 import { loadConfigWithFiles } from '../../projects/lib/project-resources';
 import {
@@ -143,6 +143,8 @@ iamRouter.openapi(
     const userId = c.get('userId') as string;
     const accountId = c.req.param('accountId');
     await assertAuthorized(userId, accountId, ACCOUNT_ACTIONS.ROLE_CREATE);
+    const denied = await requireEntitlement(c, accountId, 'rbac');
+    if (denied) return denied;
 
     const body = await readBody(c);
     const key = typeof body.key === 'string' ? body.key.trim() : '';
@@ -200,6 +202,8 @@ iamRouter.openapi(
     const accountId = c.req.param('accountId');
     const roleId = c.req.param('roleId');
     await assertAuthorized(userId, accountId, ACCOUNT_ACTIONS.ROLE_UPDATE);
+    const denied = await requireEntitlement(c, accountId, 'rbac');
+    if (denied) return denied;
     if (BUILTIN_BY_ID.has(roleId)) return c.json({ error: 'built-in roles cannot be edited' }, 400);
     const role = await loadCustomRole(accountId, roleId);
     if (!role) return c.json({ error: 'role not found' }, 404);
@@ -237,6 +241,8 @@ iamRouter.openapi(
     const accountId = c.req.param('accountId');
     const roleId = c.req.param('roleId');
     await assertAuthorized(userId, accountId, ACCOUNT_ACTIONS.ROLE_DELETE);
+    const denied = await requireEntitlement(c, accountId, 'rbac');
+    if (denied) return denied;
     if (BUILTIN_BY_ID.has(roleId)) return c.json({ error: 'built-in roles cannot be deleted' }, 400);
     const role = await loadCustomRole(accountId, roleId);
     if (!role) return c.json({ error: 'role not found' }, 404);
@@ -297,6 +303,8 @@ iamRouter.openapi(
     const accountId = c.req.param('accountId');
     const roleId = c.req.param('roleId');
     await assertAuthorized(userId, accountId, ACCOUNT_ACTIONS.ROLE_UPDATE);
+    const denied = await requireEntitlement(c, accountId, 'rbac');
+    if (denied) return denied;
     if (BUILTIN_BY_ID.has(roleId)) return c.json({ error: 'built-in role permissions are fixed' }, 400);
     const role = await loadCustomRole(accountId, roleId);
     if (!role) return c.json({ error: 'role not found' }, 404);
@@ -472,6 +480,8 @@ iamRouter.openapi(
     const userId = c.get('userId') as string;
     const accountId = c.req.param('accountId');
     await assertAuthorized(userId, accountId, ACCOUNT_ACTIONS.POLICY_CREATE);
+    const denied = await requireEntitlement(c, accountId, 'rbac');
+    if (denied) return denied;
 
     const body = await readBody(c);
     const parsed = await parsePolicyInput(accountId, body);
@@ -523,6 +533,8 @@ iamRouter.openapi(
     const accountId = c.req.param('accountId');
     const policyId = c.req.param('policyId');
     await assertAuthorized(userId, accountId, ACCOUNT_ACTIONS.POLICY_DELETE);
+    const denied = await requireEntitlement(c, accountId, 'rbac');
+    if (denied) return denied;
 
     const [row] = await db
       .delete(iamPolicies)
@@ -555,6 +567,8 @@ iamRouter.openapi(
     const userId = c.get('userId') as string;
     const accountId = c.req.param('accountId');
     await assertAuthorized(userId, accountId, ACCOUNT_ACTIONS.POLICY_DELETE);
+    const denied = await requireEntitlement(c, accountId, 'rbac');
+    if (denied) return denied;
     const body = await readBody(c);
     const ids = Array.isArray(body.policy_ids) ? body.policy_ids.filter((x: unknown): x is string => typeof x === 'string') : [];
     if (ids.length === 0) return c.json({ deleted: 0 });
@@ -583,6 +597,8 @@ iamRouter.openapi(
     const policyId = c.req.param('policyId');
     // Editing an assignment is a create-class action — gate on POLICY_CREATE.
     await assertAuthorized(userId, accountId, ACCOUNT_ACTIONS.POLICY_CREATE);
+    const denied = await requireEntitlement(c, accountId, 'rbac');
+    if (denied) return denied;
 
     const [existing] = await db
       .select()
@@ -645,6 +661,8 @@ iamRouter.openapi(
     const userId = c.get('userId') as string;
     const accountId = c.req.param('accountId');
     await assertAuthorized(userId, accountId, ACCOUNT_ACTIONS.POLICY_CREATE);
+    const denied = await requireEntitlement(c, accountId, 'rbac');
+    if (denied) return denied;
 
     const body = await readBody(c);
     const entries = Array.isArray(body.policies) ? (body.policies as Array<Record<string, unknown>>) : [];

--- a/apps/api/src/accounts/iam/custom-roles.ts
+++ b/apps/api/src/accounts/iam/custom-roles.ts
@@ -241,8 +241,8 @@ iamRouter.openapi(
     const accountId = c.req.param('accountId');
     const roleId = c.req.param('roleId');
     await assertAuthorized(userId, accountId, ACCOUNT_ACTIONS.ROLE_DELETE);
-    const denied = await requireEntitlement(c, accountId, 'rbac');
-    if (denied) return denied;
+    // No entitlement gate: deleting a role is cleanup — a downgraded account
+    // must always be able to remove custom roles it can no longer manage.
     if (BUILTIN_BY_ID.has(roleId)) return c.json({ error: 'built-in roles cannot be deleted' }, 400);
     const role = await loadCustomRole(accountId, roleId);
     if (!role) return c.json({ error: 'role not found' }, 404);
@@ -533,8 +533,7 @@ iamRouter.openapi(
     const accountId = c.req.param('accountId');
     const policyId = c.req.param('policyId');
     await assertAuthorized(userId, accountId, ACCOUNT_ACTIONS.POLICY_DELETE);
-    const denied = await requireEntitlement(c, accountId, 'rbac');
-    if (denied) return denied;
+    // No entitlement gate: revoking a policy binding is cleanup, always allowed.
 
     const [row] = await db
       .delete(iamPolicies)
@@ -567,8 +566,7 @@ iamRouter.openapi(
     const userId = c.get('userId') as string;
     const accountId = c.req.param('accountId');
     await assertAuthorized(userId, accountId, ACCOUNT_ACTIONS.POLICY_DELETE);
-    const denied = await requireEntitlement(c, accountId, 'rbac');
-    if (denied) return denied;
+    // No entitlement gate: bulk policy revocation is cleanup, always allowed.
     const body = await readBody(c);
     const ids = Array.isArray(body.policy_ids) ? body.policy_ids.filter((x: unknown): x is string => typeof x === 'string') : [];
     if (ids.length === 0) return c.json({ deleted: 0 });

--- a/apps/api/src/accounts/iam/groups.ts
+++ b/apps/api/src/accounts/iam/groups.ts
@@ -34,9 +34,11 @@ import {
 } from './app';
 import { auditIam, isUniqueViolation, readBody, requireEntitlement } from './helpers';
 
-// Groups are an Enterprise-only construct (no free-tier group concept) — every
-// route in this file gates on `rbac`, reads included, unlike custom-roles.ts
-// where read routes stay open. See TierEntitlements in ../../types.
+// Groups are an Enterprise-only construct (no free-tier group concept). The
+// `rbac` entitlement gates every route that CREATES or GROWS group state
+// (create group, rename, add members); reads and deletions stay open so a
+// downgraded account can still see and clean up leftover groups — revoking
+// access is never paywalled. See TierEntitlements in ../../types.
 
 // ─── Groups ────────────────────────────────────────────────────────────────
 
@@ -57,8 +59,6 @@ iamRouter.openapi(
   const userId = c.get('userId') as string;
   const accountId = c.req.param('accountId');
   await assertAuthorized(userId, accountId, ACCOUNT_ACTIONS.GROUP_READ);
-  const denied = await requireEntitlement(c, accountId, 'rbac');
-  if (denied) return denied;
 
   const rows = await listGroups(accountId);
   return c.json({
@@ -153,8 +153,6 @@ iamRouter.openapi(
   const accountId = c.req.param('accountId');
   const groupId = c.req.param('groupId');
   await assertAuthorized(userId, accountId, ACCOUNT_ACTIONS.GROUP_READ);
-  const denied = await requireEntitlement(c, accountId, 'rbac');
-  if (denied) return denied;
 
   const group = await getGroup(accountId, groupId);
   if (!group) return c.json({ error: 'group not found' }, 404);
@@ -252,8 +250,7 @@ iamRouter.openapi(
     type: 'group',
     id: groupId,
   });
-  const denied = await requireEntitlement(c, accountId, 'rbac');
-  if (denied) return denied;
+  // No entitlement gate: deletion is cleanup, always allowed (see file header).
 
   const beforeGroup = await getGroup(accountId, groupId);
 
@@ -300,8 +297,6 @@ iamRouter.openapi(
   const accountId = c.req.param('accountId');
   const groupId = c.req.param('groupId');
   await assertAuthorized(userId, accountId, ACCOUNT_ACTIONS.GROUP_READ);
-  const denied = await requireEntitlement(c, accountId, 'rbac');
-  if (denied) return denied;
 
   const members = await listGroupMembers(accountId, groupId);
   return c.json({
@@ -391,8 +386,7 @@ iamRouter.openapi(
     type: 'group',
     id: groupId,
   });
-  const denied = await requireEntitlement(c, accountId, 'rbac');
-  if (denied) return denied;
+  // No entitlement gate: removing a member is cleanup, always allowed.
 
   const group = await getGroup(accountId, groupId);
   if (!group) return c.json({ error: 'group not found' }, 404);
@@ -443,8 +437,6 @@ iamRouter.openapi(
   const accountId = c.req.param('accountId');
   const groupId = c.req.param('groupId');
   await assertAuthorized(userId, accountId, ACCOUNT_ACTIONS.GROUP_READ);
-  const denied = await requireEntitlement(c, accountId, 'rbac');
-  if (denied) return denied;
 
   const group = await getGroup(accountId, groupId);
   if (!group) return c.json({ error: 'group not found' }, 404);

--- a/apps/api/src/accounts/iam/groups.ts
+++ b/apps/api/src/accounts/iam/groups.ts
@@ -32,7 +32,11 @@ import {
   GroupMemberSchema,
   ProjectGrantSchema,
 } from './app';
-import { auditIam, isUniqueViolation, readBody } from './helpers';
+import { auditIam, isUniqueViolation, readBody, requireEntitlement } from './helpers';
+
+// Groups are an Enterprise-only construct (no free-tier group concept) — every
+// route in this file gates on `rbac`, reads included, unlike custom-roles.ts
+// where read routes stay open. See TierEntitlements in ../../types.
 
 // ─── Groups ────────────────────────────────────────────────────────────────
 
@@ -53,6 +57,8 @@ iamRouter.openapi(
   const userId = c.get('userId') as string;
   const accountId = c.req.param('accountId');
   await assertAuthorized(userId, accountId, ACCOUNT_ACTIONS.GROUP_READ);
+  const denied = await requireEntitlement(c, accountId, 'rbac');
+  if (denied) return denied;
 
   const rows = await listGroups(accountId);
   return c.json({
@@ -88,6 +94,8 @@ iamRouter.openapi(
   const userId = c.get('userId') as string;
   const accountId = c.req.param('accountId');
   await assertAuthorized(userId, accountId, ACCOUNT_ACTIONS.GROUP_CREATE);
+  const denied = await requireEntitlement(c, accountId, 'rbac');
+  if (denied) return denied;
 
   const body = await readBody(c);
   const name = typeof body.name === 'string' ? body.name.trim() : '';
@@ -145,6 +153,8 @@ iamRouter.openapi(
   const accountId = c.req.param('accountId');
   const groupId = c.req.param('groupId');
   await assertAuthorized(userId, accountId, ACCOUNT_ACTIONS.GROUP_READ);
+  const denied = await requireEntitlement(c, accountId, 'rbac');
+  if (denied) return denied;
 
   const group = await getGroup(accountId, groupId);
   if (!group) return c.json({ error: 'group not found' }, 404);
@@ -182,6 +192,8 @@ iamRouter.openapi(
     type: 'group',
     id: groupId,
   });
+  const denied = await requireEntitlement(c, accountId, 'rbac');
+  if (denied) return denied;
 
   const body = await readBody(c);
   const patch: { name?: string; description?: string | null } = {};
@@ -240,6 +252,8 @@ iamRouter.openapi(
     type: 'group',
     id: groupId,
   });
+  const denied = await requireEntitlement(c, accountId, 'rbac');
+  if (denied) return denied;
 
   const beforeGroup = await getGroup(accountId, groupId);
 
@@ -286,6 +300,8 @@ iamRouter.openapi(
   const accountId = c.req.param('accountId');
   const groupId = c.req.param('groupId');
   await assertAuthorized(userId, accountId, ACCOUNT_ACTIONS.GROUP_READ);
+  const denied = await requireEntitlement(c, accountId, 'rbac');
+  if (denied) return denied;
 
   const members = await listGroupMembers(accountId, groupId);
   return c.json({
@@ -319,6 +335,8 @@ iamRouter.openapi(
     type: 'group',
     id: groupId,
   });
+  const denied = await requireEntitlement(c, accountId, 'rbac');
+  if (denied) return denied;
 
   const group = await getGroup(accountId, groupId);
   if (!group) return c.json({ error: 'group not found' }, 404);
@@ -373,6 +391,8 @@ iamRouter.openapi(
     type: 'group',
     id: groupId,
   });
+  const denied = await requireEntitlement(c, accountId, 'rbac');
+  if (denied) return denied;
 
   const group = await getGroup(accountId, groupId);
   if (!group) return c.json({ error: 'group not found' }, 404);
@@ -423,6 +443,8 @@ iamRouter.openapi(
   const accountId = c.req.param('accountId');
   const groupId = c.req.param('groupId');
   await assertAuthorized(userId, accountId, ACCOUNT_ACTIONS.GROUP_READ);
+  const denied = await requireEntitlement(c, accountId, 'rbac');
+  if (denied) return denied;
 
   const group = await getGroup(accountId, groupId);
   if (!group) return c.json({ error: 'group not found' }, 404);

--- a/apps/api/src/accounts/iam/helpers.ts
+++ b/apps/api/src/accounts/iam/helpers.ts
@@ -11,6 +11,8 @@ import type { TierEntitlements } from '../../types';
 const ENTITLEMENT_LABEL: Record<keyof TierEntitlements, string> = {
   sso: 'SAML single sign-on',
   scim: 'SCIM directory provisioning',
+  rbac: 'Custom roles, policies, and groups',
+  auditAccess: 'Audit log access and export',
 };
 
 /**

--- a/apps/api/src/billing/services/tiers.ts
+++ b/apps/api/src/billing/services/tiers.ts
@@ -154,8 +154,8 @@ export function getComputeDescription(serverType: string): string {
 // Enterprise feature gates. Every self-serve tier (Free / Team) gets NONE;
 // the sales-assigned `enterprise` tier gets ALL. See TierEntitlements in
 // ../../types and the requireEntitlement() guard in the IAM routes.
-const NO_ENTERPRISE: TierEntitlements = { sso: false, scim: false };
-const ALL_ENTERPRISE: TierEntitlements = { sso: true, scim: true };
+const NO_ENTERPRISE: TierEntitlements = { sso: false, scim: false, rbac: false, auditAccess: false };
+const ALL_ENTERPRISE: TierEntitlements = { sso: true, scim: true, rbac: true, auditAccess: true };
 
 const TIERS: Record<string, TierConfig> = {
   none: {

--- a/apps/api/src/projects/routes/r7.ts
+++ b/apps/api/src/projects/routes/r7.ts
@@ -23,6 +23,7 @@ import { addSecretResourceGrant, listSecretResourceGrants, removeSecretResourceG
 import { buildSessionTranscriptDigest } from '../lib/session-transcript';
 import { syncOpenCodeTitlesForSessions } from '../opencode-title-sync';
 import { createSession, deleteSession } from '../session-lifecycle';
+import { requireEntitlement } from '../../accounts/iam/helpers';
 
 function parseBoundedPositiveInt(
   raw: string | undefined,
@@ -625,6 +626,8 @@ projectsApp.openapi(
     if (!loaded) return c.json({ error: 'Not found' }, 404);
     const visible = await loadVisibleSession(loaded, sessionId);
     if (!visible) return c.json({ error: 'Not found' }, 404);
+    const denied = await requireEntitlement(c, loaded.row.accountId, 'auditAccess');
+    if (denied) return denied;
 
     const rows = await db
       .select({

--- a/apps/api/src/projects/routes/r7.ts
+++ b/apps/api/src/projects/routes/r7.ts
@@ -167,6 +167,13 @@ projectsApp.openapi(
   // threaded and the agent-grant fold fires: an agent-session token must also
   // hold project.members.manage to mutate group grants, not just its user.
   await assertProjectCapability(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_MEMBERS_MANAGE);
+  // Group→project grants are part of the Enterprise RBAC surface (groups are
+  // gated in accounts/iam/groups.ts); gate the mutation here too so grants
+  // can't be minted through the project-scoped path.
+  {
+    const denied = await requireEntitlement(c, loaded.row.accountId, 'rbac');
+    if (denied) return denied;
+  }
 
   const body = await readBody(c);
   const groupId = normalizeString(body.group_id ?? body.groupId);
@@ -247,6 +254,13 @@ projectsApp.openapi(
   // threaded and the agent-grant fold fires: an agent-session token must also
   // hold project.members.manage to mutate group grants, not just its user.
   await assertProjectCapability(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_MEMBERS_MANAGE);
+  // Enterprise RBAC gate — same reasoning as the POST above. DELETE below is
+  // deliberately ungated: revoking access is never paywalled, so a downgraded
+  // account can always detach grants it can no longer manage.
+  {
+    const denied = await requireEntitlement(c, loaded.row.accountId, 'rbac');
+    if (denied) return denied;
+  }
 
   const body = await readBody(c);
   const role = parseProjectRole(body.role);

--- a/apps/api/src/shared/audit-webhooks.ts
+++ b/apps/api/src/shared/audit-webhooks.ts
@@ -7,6 +7,7 @@ import { createHmac, randomBytes } from 'node:crypto';
 import { and, eq } from 'drizzle-orm';
 import { auditWebhooks } from '@kortix/db';
 import { db } from './db';
+import { accountHasEntitlement } from '../billing/services/entitlements';
 
 /** Payload shape sent to the customer's webhook. Stable contract — bump
  *  schema_version if ever changing the shape. */
@@ -70,6 +71,17 @@ async function deliverAll(payload: AuditWebhookPayload): Promise<void> {
     throw err;
   }
   if (hooks.length === 0) return;
+
+  // Entitlement gate on the DATA PLANE, not just the management routes: a
+  // downgraded account's leftover webhook rows must stop streaming the audit
+  // feed. Checked only when the account actually has enabled hooks, so the
+  // common no-webhook case pays nothing. Fail closed on lookup errors —
+  // a webhook missing one event beats leaking audit data.
+  try {
+    if (!(await accountHasEntitlement(accountId, 'auditAccess'))) return;
+  } catch {
+    return;
+  }
 
   // Filter by action prefix if the hook is restricted.
   const matches = hooks.filter(

--- a/apps/api/src/types.ts
+++ b/apps/api/src/types.ts
@@ -118,6 +118,20 @@ export interface TierEntitlements {
   sso: boolean;
   /** SCIM 2.0 directory provisioning (token mint/revoke + /scim/v2 endpoints). */
   scim: boolean;
+  /**
+   * Custom RBAC: user-defined roles, fine-grained policy bindings, and groups
+   * (IAM v1 — custom-roles.ts + groups.ts). Built-in preset roles (owner/admin/
+   * member/manager/editor/user) stay free on every tier — this only gates the
+   * ability to define custom roles/policies/groups beyond those presets.
+   */
+  rbac: boolean;
+  /**
+   * Read/export access to the audit trail (account audit log + per-session
+   * agent-action audit) and audit-webhook streaming. Recording is NEVER gated —
+   * every tier's actions are always captured; this only gates who can read,
+   * export, or stream them out.
+   */
+  auditAccess: boolean;
 }
 
 export interface TierConfig {

--- a/docs/ENTERPRISE_EDITION.md
+++ b/docs/ENTERPRISE_EDITION.md
@@ -1,0 +1,69 @@
+# Enterprise Edition — what's gated, and how
+
+Kortix is source-available under the [Elastic License 2.0](../LICENSE): free to
+self-host, modify, and run in production. ELv2 also explicitly permits gating
+specific functionality behind a license key ("you may not move, change, disable,
+or circumvent the license key functionality"). This doc is the single source of
+truth for exactly what that gate covers today — so sales copy, docs, and code
+can't drift apart.
+
+**The mechanism:** every account resolves to a billing `tier` (`none` / `free`
+/ `pro` / `per_seat` / … / `enterprise`). Each tier carries a static
+`TierEntitlements` object (`apps/api/src/types.ts`); only the sales-assigned
+`enterprise` tier has every flag on. Routes call
+`requireEntitlement(c, accountId, '<key>')` (`apps/api/src/accounts/iam/helpers.ts`)
+to fail closed with a `402 entitlement_required` when the account's tier lacks
+the flag. An account with no billing row resolves to `none` — no entitlements,
+ever, unprovisioned-safe by default.
+
+## Community (every self-serve and self-hosted tier)
+
+Everything not listed under Enterprise below — the full agent/skill/connector/
+session/memory product, hardware-isolated sandboxes, change-request workflow,
+unlimited self-hosted use per the ELv2 terms. Specifically, on the identity/
+governance surface:
+
+- **Preset roles** — Owner / Admin / Member (account) and Manager / Editor /
+  User (project). Assignable to any member, free on every tier
+  (`role-presets.ts`; assignment lives outside the entitlement-gated IAM v1
+  surface entirely).
+- **Audit recording** — every governed action (IAM changes, agent tool/connector
+  calls with their risk verdict, etc.) is captured always, on every tier.
+  Community never loses the underlying trail.
+
+## Enterprise (sales-assigned `enterprise` tier only)
+
+| Entitlement key | Gates | Why it's Enterprise |
+|---|---|---|
+| `sso` | SAML SSO config, JIT provisioning, group-claim mapping (`accounts/iam/sso.ts`) | Identity federation is the standard enterprise trigger across this category (Documenso, n8n, GitLab, Onyx, Cal.com all gate SAML the same way) |
+| `scim` | SCIM 2.0 directory provisioning — token mint/revoke + `/scim/v2/*` (`accounts/iam/scim-tokens.ts`, `middleware/scim-auth.ts`) | Pairs with SSO; automated user lifecycle is an IT/security-team need, not an individual one |
+| `rbac` | **Custom** roles, fine-grained policy bindings, and groups — `accounts/iam/custom-roles.ts` (all writes) + `accounts/iam/groups.ts` (every route, reads included) | Preset roles cover the common cases for free; defining your own roles/policies and grouping members is the governance layer regulated orgs actually need |
+| `auditAccess` | **Reading, exporting, and streaming** the audit trail — account audit log + export (`accounts/audit.ts`), audit webhooks (`accounts/audit.ts`), and the per-session agent-action audit (`projects/routes/r7.ts`) | Recording is universal (see above); *who gets to look at it* — and pipe it into a SIEM — is the compliance feature |
+
+Nothing else in the product is currently entitlement-gated. Categories common
+elsewhere in this space (HA/clustering, dedicated single-tenant infra,
+white-labeling, LDAP, tiered data retention, air-gap-specific code) aren't yet
+built as Kortix features at all, so there's nothing to gate — self-hosting the
+whole product already *is* your air-gapped, dedicated, single-tenant
+deployment. If/when any of those become real product surfaces, they get a new
+`TierEntitlements` key here, not a separate mechanism.
+
+## Adding a new gate
+
+1. Add the key + a one-line doc comment to `TierEntitlements` in
+   `apps/api/src/types.ts`.
+2. Set it in `NO_ENTERPRISE` / `ALL_ENTERPRISE` in
+   `apps/api/src/billing/services/tiers.ts`.
+3. Add a human label to `ENTITLEMENT_LABEL` in
+   `apps/api/src/accounts/iam/helpers.ts` (the compiler enforces this — it's a
+   `Record<keyof TierEntitlements, string>`).
+4. Guard the route(s): `const denied = await requireEntitlement(c, accountId, '<key>'); if (denied) return denied;`
+5. Update the table above.
+
+## Previewing the gate without a contract
+
+Any account can flip `PUT /{accountId}/iam/enterprise-demo` to unlock every
+entitlement for itself — a self-serve, clearly-labeled preview so prospects
+(and we, dogfooding) can see the real surface before signing. It is **not**
+behind `requireEntitlement` by design; production use of the resulting access
+still requires a signed Enterprise agreement, same as always.

--- a/docs/ENTERPRISE_EDITION.md
+++ b/docs/ENTERPRISE_EDITION.md
@@ -37,8 +37,21 @@ governance surface:
 |---|---|---|
 | `sso` | SAML SSO config, JIT provisioning, group-claim mapping (`accounts/iam/sso.ts`) | Identity federation is the standard enterprise trigger across this category (Documenso, n8n, GitLab, Onyx, Cal.com all gate SAML the same way) |
 | `scim` | SCIM 2.0 directory provisioning — token mint/revoke + `/scim/v2/*` (`accounts/iam/scim-tokens.ts`, `middleware/scim-auth.ts`) | Pairs with SSO; automated user lifecycle is an IT/security-team need, not an individual one |
-| `rbac` | **Custom** roles, fine-grained policy bindings, and groups — `accounts/iam/custom-roles.ts` (all writes) + `accounts/iam/groups.ts` (every route, reads included) | Preset roles cover the common cases for free; defining your own roles/policies and grouping members is the governance layer regulated orgs actually need |
-| `auditAccess` | **Reading, exporting, and streaming** the audit trail — account audit log + export (`accounts/audit.ts`), audit webhooks (`accounts/audit.ts`), and the per-session agent-action audit (`projects/routes/r7.ts`) | Recording is universal (see above); *who gets to look at it* — and pipe it into a SIEM — is the compliance feature |
+| `rbac` | **Creating/growing** custom RBAC state: custom roles + their permission sets, policy bindings (`accounts/iam/custom-roles.ts`), groups + membership adds (`accounts/iam/groups.ts`), and group→project grant create/re-role (`projects/routes/r7.ts`) | Preset roles cover the common cases for free; defining your own roles/policies and grouping members is the governance layer regulated orgs actually need |
+| `auditAccess` | **Reading, exporting, and streaming** the audit trail — account audit log + export, webhook create/update (`accounts/audit.ts`), webhook **delivery** (`shared/audit-webhooks.ts`, the data plane), and the per-session agent-action audit (`projects/routes/r7.ts`) | Recording is universal (see above); *who gets to look at it* — and pipe it into a SIEM — is the compliance feature |
+
+**Revocation is never paywalled.** Deleting a custom role, revoking a policy,
+deleting a group, removing a group member, detaching a group grant, or deleting
+an audit webhook all work on every tier — a downgraded account must always be
+able to see and clean up state it can no longer manage. Reads stay open for the
+same reason (they return empty for accounts that never had Enterprise).
+
+**Existing grants keep enforcing after a downgrade** (standard open-core
+practice — gate management, not evaluation). The IAM engine honors whatever
+custom policies/groups exist until an admin removes them; what a downgraded
+account can't do is mint new ones. The one deliberate exception is audit
+webhook delivery, which checks the live entitlement per event — leftover
+webhook rows stop streaming immediately.
 
 Nothing else in the product is currently entitlement-gated. Categories common
 elsewhere in this space (HA/clustering, dedicated single-tenant infra,


### PR DESCRIPTION
## Summary
- `TierEntitlements` only covered `sso`/`scim`. Custom roles/policies/groups and audit read/export/webhooks had no entitlement check — extends the existing plan-gating pattern to cover them too, consistent with what's already listed on the pricing page (SSO, SCIM, RBAC, audit logs).
- Preset roles and audit *recording* stay free on every tier — only creating custom RBAC state and reading/exporting/streaming the audit trail require the entitlement.
- Revocation is never gated: deleting/removing/detaching stays open on every tier so a downgraded account can always clean up its own state.
- Adds `docs/ENTERPRISE_EDITION.md` as the canonical reference for what's gated and why.

## Test plan
- [x] `tsc --noEmit` clean
- [x] Updated `unit-tier-entitlements.test.ts` for the new keys
- [x] Manual code audit for bypasses (project-scoped group-grants route, audit webhook delivery data-plane) — both found ungated in first pass, now fixed
- [ ] End-to-end verification on the PR preview (401/402 responses for un-entitled accounts on the new gates)