### PR TITLE
fix(sandbox): default LLM catalog to baked image file on cold boot (~2s off spawn)

### DIFF
--- a/apps/kortix-sandbox-agent-server/src/opencode.ts
+++ b/apps/kortix-sandbox-agent-server/src/opencode.ts
@@ -129,10 +129,14 @@ export async function buildOpencodeConfigContent(env: NodeJS.ProcessEnv): Promis
         // mode (cold/Daytona) it's the real gateway base + key, as before.
         baseURL: proxyMode ? llmProxyUrl! : llmBaseUrl!,
         apiKey: proxyMode ? LLM_PROXY_PLACEHOLDER_KEY : llmApiKey!,
-        // Catalog is org-stable: prefer a baked file (lets the warm seed bake the
-        // full catalog with no per-session token), else fetch from the real
-        // gateway (needs a real base+key — only available in direct mode).
-        catalogFile: env.KORTIX_LLM_CATALOG_FILE,
+        // Catalog is org-stable, so prefer the baked file — the full model catalog
+        // ships in every image at BAKED_LLM_CATALOG_PATH. Defaulting to it means a
+        // COLD boot (Daytona + Platinum) reads the file and SKIPS the ~2.2s gateway
+        // /models fetch that otherwise gates opencode's port bind on the critical
+        // path — matching how the warm seed (KORTIX_LLM_CATALOG_FILE) already
+        // behaves. Missing/empty file → readCatalogFile returns null → the fetch
+        // (step 2) still runs as the fallback, so this only ever removes latency.
+        catalogFile: env.KORTIX_LLM_CATALOG_FILE ?? BAKED_LLM_CATALOG_PATH,
         fetchBaseURL: llmBaseUrl,
         fetchApiKey: llmApiKey,
       }),


### PR DESCRIPTION
## What
Default `catalogFile` to `BAKED_LLM_CATALOG_PATH` in the sandbox daemon so a **cold boot reads the baked model catalog instead of fetching the gateway**.

## Why
Cold Daytona + Platinum boots log `fetching gateway models from …/v1/llm/models` and block opencode's port bind for ~2s — even though the full ~4491-model catalog **already ships baked** at `/opt/kortix/llm-catalog.json`. The strip that removed the warm-seed `captureEnv` dropped the `KORTIX_LLM_CATALOG_FILE` pointer with it, so the daemon skipped the file and hit the network. This restores the baked-file read on the cold path (what the warm seed already did) — **no env var, no snapshot**.

A missing/empty file still falls through to the gateway fetch (step 2), so this **only ever removes latency**.

## Measured (local, real spawns)
- catalog load: **1997ms (fetch) → 47ms (baked)** — ~2s off every cold spawn
- verified on real boxes: `[opencode] loaded 4491 gateway models from baked catalog /opt/kortix/llm-catalog.json`
- start→ready, unified cold path, same daemon: Platinum ~9.1s avg, Daytona ~9.2s avg — identical path, only `body.provider` differs

## Deploy
Nothing to configure — the file already ships in every image. Takes effect as templates rebuild with the new daemon (dist content-hash changes → image rebuilds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)