### PR TITLE
fix(api): never 402 the per-session audit endpoint — it is the approval control plane

### DIFF
--- a/apps/api/src/__tests__/integration-approvals.test.ts
+++ b/apps/api/src/__tests__/integration-approvals.test.ts
@@ -15,17 +15,22 @@ import { db } from '../shared/db';
 import { app } from '../index';
 import { waitForApprovalDecision } from '../executor/db-deps';
 import { createAccountToken } from '../repositories/account-tokens';
+import { getCreditAccount, setDemoEnterprise } from '../billing/repositories/credit-accounts';
 
 const minted: string[] = [];
 const execIds: string[] = [];
 const SESSION = crypto.randomUUID();
 let ctx: { projectId: string; accountId: string; userId: string } | null = null;
 let secret = '';
+let priorDemoEnterprise = false;
 
 beforeAll(async () => {
   await db.execute(sql`alter table kortix.account_tokens add column if not exists agent_grant jsonb`);
   await db.execute(sql`alter table kortix.account_tokens add column if not exists session_id text`);
   await db.execute(sql`alter table kortix.account_tokens add column if not exists service_account_id uuid`);
+  await db.execute(
+    sql`alter table kortix.credit_accounts add column if not exists demo_enterprise boolean not null default false`,
+  );
   const rows = (await db.execute(sql`
     select p.project_id, p.account_id, m.user_id
     from kortix.projects p
@@ -45,12 +50,18 @@ beforeAll(async () => {
     createdBy: ctx.userId,
     visibility: 'private',
   });
+  // The full-trail assertions below need the auditAccess entitlement; flip the
+  // enterprise demo on for the suite (restored in afterAll). The unentitled
+  // contract has its own dedicated test that toggles it off.
+  priorDemoEnterprise = (await getCreditAccount(ctx.accountId))?.demoEnterprise ?? false;
+  await setDemoEnterprise(ctx.accountId, true);
 });
 
 afterAll(async () => {
   for (const id of execIds) await db.delete(executorExecutions).where(eq(executorExecutions.executionId, id));
   await db.delete(projectSessions).where(eq(projectSessions.sessionId, SESSION));
   for (const id of minted) await db.execute(sql`delete from kortix.account_tokens where token_id = ${id}`);
+  if (ctx) await setDemoEnterprise(ctx.accountId, priorDemoEnterprise);
 });
 
 async function seedPending(): Promise<string> {
@@ -106,8 +117,32 @@ describe('approvals inbox + resolution', () => {
 
     const audit = await authGet(`/v1/projects/${ctx.projectId}/sessions/${SESSION}/audit`);
     expect(audit.status).toBe(200);
-    const entry = (await audit.json()).actions.find((a: any) => a.execution_id === execId);
+    const auditBody = await audit.json();
+    expect(auditBody.audit_access).toBe(true);
+    const entry = auditBody.actions.find((a: any) => a.execution_id === execId);
     expect(entry?.resolved_by).toBe(ctx.userId);
+  });
+
+  test('unentitled account: audit degrades to pending-only (never a 402 — the approval control plane)', async () => {
+    if (!ctx) return;
+    // A resolved action (history) + a still-pending one.
+    const resolvedId = await seedPending();
+    await authPost(`/v1/projects/${ctx.projectId}/approvals/${resolvedId}`, { decision: 'approve' });
+    const pendingId = await seedPending();
+
+    await setDemoEnterprise(ctx.accountId, false);
+    try {
+      const res = await authGet(`/v1/projects/${ctx.projectId}/sessions/${SESSION}/audit`);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.audit_access).toBe(false);
+      const ids = body.actions.map((a: any) => a.execution_id);
+      expect(ids).toContain(pendingId);
+      expect(ids).not.toContain(resolvedId);
+      expect(body.actions.every((a: any) => a.status === 'pending_approval')).toBe(true);
+    } finally {
+      await setDemoEnterprise(ctx.accountId, true);
+    }
   });
 
   test('deny flips the action to denied + records the denier', async () => {

--- a/apps/api/src/projects/routes/r7.ts
+++ b/apps/api/src/projects/routes/r7.ts
@@ -24,6 +24,7 @@ import { buildSessionTranscriptDigest } from '../lib/session-transcript';
 import { syncOpenCodeTitlesForSessions } from '../opencode-title-sync';
 import { createSession, deleteSession } from '../session-lifecycle';
 import { requireEntitlement } from '../../accounts/iam/helpers';
+import { accountHasEntitlement } from '../../billing/services/entitlements';
 
 function parseBoundedPositiveInt(
   raw: string | undefined,
@@ -610,7 +611,8 @@ projectsApp.openapi(
 // verdict, who acted, and (for approvals) who resolved it. This is the enterprise
 // "what did the agent actually do" trail, read straight from executor_executions.
 // Same visibility gate as the session detail/transcript (project read + the
-// session must be visible to the caller).
+// session must be visible to the caller). Non-Enterprise accounts get only the
+// unresolved pending approvals (never a 402 — see the entitlement note below).
 
 projectsApp.openapi(
   createRoute({
@@ -640,8 +642,15 @@ projectsApp.openapi(
     if (!loaded) return c.json({ error: 'Not found' }, 404);
     const visible = await loadVisibleSession(loaded, sessionId);
     if (!visible) return c.json({ error: 'Not found' }, 404);
-    const denied = await requireEntitlement(c, loaded.row.accountId, 'auditAccess');
-    if (denied) return denied;
+    // The historical trail is Enterprise (`auditAccess`), but this endpoint is
+    // also the approval CONTROL PLANE: write/destructive connector actions
+    // default to require_approval on every tier (executor/policy.ts), the web
+    // app polls this route from every open session to render the approval
+    // prompt, and it is the launcher's only view of what's blocking the run.
+    // A 402 here breaks approvals for every non-Enterprise account (and toasts
+    // the upsell on each poll) — so unentitled accounts degrade to unresolved
+    // pending approvals only instead of being denied.
+    const audited = await accountHasEntitlement(loaded.row.accountId, 'auditAccess');
 
     const rows = await db
       .select({
@@ -657,7 +666,19 @@ projectsApp.openapi(
         resolvedAt: executorExecutions.resolvedAt,
       })
       .from(executorExecutions)
-      .where(and(eq(executorExecutions.projectId, projectId), eq(executorExecutions.sessionId, sessionId)))
+      .where(
+        and(
+          eq(executorExecutions.projectId, projectId),
+          eq(executorExecutions.sessionId, sessionId),
+          ...(audited
+            ? []
+            : [
+                eq(executorExecutions.status, 'pending_approval'),
+                isNull(executorExecutions.approvedBy),
+                isNull(executorExecutions.resolvedAt),
+              ]),
+        ),
+      )
       // Most-recent-first: when a busy session exceeds `limit`, keep the RECENT
       // actions (truncating oldest), not the other way round.
       .orderBy(desc(executorExecutions.createdAt))
@@ -672,6 +693,10 @@ projectsApp.openapi(
     return c.json({
       session_id: sessionId,
       agent: (visible.row.agentName as string | null) ?? null,
+      // False when the account lacks the Enterprise `auditAccess` entitlement:
+      // `actions` then contains only unresolved pending approvals, and the UI
+      // shows the upgrade path for the full trail.
+      audit_access: audited,
       count: rows.length,
       // Most-recent-first trail of every executor-gated action this session took.
       actions: rows.map((r) => ({

--- a/apps/web/src/features/session/session-audit-panel.tsx
+++ b/apps/web/src/features/session/session-audit-panel.tsx
@@ -41,6 +41,9 @@ export function SessionAuditPanel({
   const actions = data?.actions ?? [];
   const pending = actions.filter(isPendingAction);
   const history = actions.filter((a) => !isPendingAction(a));
+  // Non-Enterprise accounts get pending approvals only — the historical trail
+  // is gated on the `auditAccess` entitlement (absent field = entitled backend).
+  const historyGated = data?.audit_access === false;
 
   const decide = (executionId: string, decision: 'approve' | 'deny') => {
     setBusy((b) => ({ ...b, [executionId]: decision }));
@@ -86,9 +89,13 @@ export function SessionAuditPanel({
         ) : actions.length === 0 ? (
           <div className="flex flex-col items-center gap-2 px-6 py-16 text-center">
             <ShieldCheck className="text-muted-foreground/60 size-6" />
-            <p className="text-foreground text-sm font-medium">No governed actions yet</p>
+            <p className="text-foreground text-sm font-medium">
+              {historyGated ? 'Nothing awaiting approval' : 'No governed actions yet'}
+            </p>
             <p className="text-muted-foreground text-xs">
-              When the agent runs a tool or connector a policy gates, it shows up here.
+              {historyGated
+                ? 'Actions the agent needs approval for show up here. The full audit trail is available on the Enterprise plan.'
+                : 'When the agent runs a tool or connector a policy gates, it shows up here.'}
             </p>
           </div>
         ) : (
@@ -202,6 +209,13 @@ export function SessionAuditPanel({
                   ))}
                 </List>
               </section>
+            )}
+
+            {historyGated && (
+              <p className="text-muted-foreground px-6 py-4 text-xs">
+                The full audit trail of allowed and denied actions is available on the Enterprise
+                plan.
+              </p>
             )}
           </>
         )}

--- a/docs/ENTERPRISE_EDITION.md
+++ b/docs/ENTERPRISE_EDITION.md
@@ -38,7 +38,14 @@ governance surface:
 | `sso` | SAML SSO config, JIT provisioning, group-claim mapping (`accounts/iam/sso.ts`) | Identity federation is the standard enterprise trigger across this category (Documenso, n8n, GitLab, Onyx, Cal.com all gate SAML the same way) |
 | `scim` | SCIM 2.0 directory provisioning — token mint/revoke + `/scim/v2/*` (`accounts/iam/scim-tokens.ts`, `middleware/scim-auth.ts`) | Pairs with SSO; automated user lifecycle is an IT/security-team need, not an individual one |
 | `rbac` | **Creating/growing** custom RBAC state: custom roles + their permission sets, policy bindings (`accounts/iam/custom-roles.ts`), groups + membership adds (`accounts/iam/groups.ts`), and group→project grant create/re-role (`projects/routes/r7.ts`) | Preset roles cover the common cases for free; defining your own roles/policies and grouping members is the governance layer regulated orgs actually need |
-| `auditAccess` | **Reading, exporting, and streaming** the audit trail — account audit log + export, webhook create/update (`accounts/audit.ts`), webhook **delivery** (`shared/audit-webhooks.ts`, the data plane), and the per-session agent-action audit (`projects/routes/r7.ts`) | Recording is universal (see above); *who gets to look at it* — and pipe it into a SIEM — is the compliance feature |
+| `auditAccess` | **Reading, exporting, and streaming** the audit trail — account audit log + export, webhook create/update (`accounts/audit.ts`), webhook **delivery** (`shared/audit-webhooks.ts`, the data plane), and the per-session agent-action **history** (`projects/routes/r7.ts`) | Recording is universal (see above); *who gets to look at it* — and pipe it into a SIEM — is the compliance feature |
+
+**The approval control plane is never paywalled.** Write/destructive connector
+actions default to `require_approval` on every tier (`executor/policy.ts`), so
+`GET /sessions/:id/audit` never returns a 402 — for unentitled accounts it
+degrades to *unresolved pending approvals only* (`audit_access: false` in the
+response) so the launcher can always see and resolve what's blocking the run.
+Only the historical allowed/denied trail is Enterprise.
 
 **Revocation is never paywalled.** Deleting a custom role, revoking a policy,
 deleting a group, removing a group member, detaching a group grant, or deleting

--- a/packages/sdk/src/platform/projects-client/sessions.ts
+++ b/packages/sdk/src/platform/projects-client/sessions.ts
@@ -248,6 +248,10 @@ export interface SessionAuditAction {
 export interface SessionAudit {
   session_id: string;
   agent: string | null;
+  /** False when the account lacks the Enterprise `auditAccess` entitlement —
+   *  `actions` then contains only unresolved pending approvals, not the full
+   *  historical trail. Absent on older backends (treat as true). */
+  audit_access?: boolean;
   count: number;
   actions: SessionAuditAction[];
 }


### PR DESCRIPTION
## Problem

Since #4107 (deployed to dev this morning), every non-Enterprise account sees the toast **"Audit log access and export is available on the Enterprise plan. Contact sales to enable it."** popping up repeatedly during regular usage — and, worse, the connector-approval flow is silently broken.

Root cause: #4107 gated `GET /projects/:id/sessions/:id/audit` behind the `auditAccess` entitlement, but that endpoint is not just the Enterprise audit trail — it is the **approval control plane**:

- The web app polls it from every open session (5–15s cadence): `SessionApprovalPrompt`, the composer lock in `session-chat.tsx`, the header nudge, the Audit-tab badge (`session-audit-shared.tsx`).
- Two of those pollers surface errors via the global toast → the recurring upsell toast.
- Write/destructive connector actions default to `require_approval` on **every** tier (`executor/policy.ts:96`), and this endpoint is the launcher's only view of pending items → with a 402, pending approvals never render, the prompt never shows, and gated agent actions can never be approved from the UI.

## Fix

- `r7.ts`: unentitled accounts get **unresolved pending approvals only** (plus `audit_access: false`) instead of a 402. The full allowed/denied history stays Enterprise-gated. Entitled accounts are unchanged.
- SDK: `SessionAudit.audit_access?: boolean` (absent on older backends = entitled).
- Audit panel: shows the Enterprise upgrade note in place of history when gated; approvals keep working.
- `docs/ENTERPRISE_EDITION.md`: documents the new "approval control plane is never paywalled" rule next to the existing revocation rule.

## Tests

`integration-approvals.test.ts` (9/9 pass against local DB):
- suite now runs with the enterprise demo flag on (restored after), so the existing full-trail assertions exercise the entitled contract, now also asserting `audit_access: true` — note these assertions were already broken by #4107's 402 on any non-enterprise test account
- new test: unentitled account → 200, `audit_access: false`, pending item present, resolved item absent
- self-heals the `credit_accounts.demo_enterprise` column (same drift exists in prod per earlier investigation), following the file's existing pattern

Typecheck clean for api + sdk; web's only error is the pre-existing `@/.source` fumadocs artifact.