### PR TITLE
fix(infra): lock API + gateway origin ALBs to Cloudflare IP ranges

### DIFF
--- a/infra/k8s/envs/dev/gateway-values.yaml
+++ b/infra/k8s/envs/dev/gateway-values.yaml
@@ -30,3 +30,5 @@ ingress:
   # ACM cert for gateway-dev.kortix.com (dev-eks/cluster module.acm_gateway).
   certificateArn: "arn:aws:acm:us-west-2:935064898258:certificate/ee7b3729-26c7-4622-881d-028daa58d051"
   cloudflareProxied: true
+  # Lock the origin ALB to Cloudflare's edge ranges (no direct-to-origin bypass).
+  inboundCidrs: "173.245.48.0/20,103.21.244.0/22,103.22.200.0/22,103.31.4.0/22,141.101.64.0/18,108.162.192.0/18,190.93.240.0/20,188.114.96.0/20,197.234.240.0/22,198.41.128.0/17,162.158.0.0/15,104.16.0.0/13,104.24.0.0/14,172.64.0.0/13,131.0.72.0/22"

--- a/infra/k8s/envs/dev/values.yaml
+++ b/infra/k8s/envs/dev/values.yaml
@@ -78,6 +78,8 @@ ingress:
   host: dev-api-eks.kortix.com
   certificateArn: arn:aws:acm:us-west-2:935064898258:certificate/57eed8f4-cba4-4d6a-94ea-1b948708989b
   cloudflareProxied: true
+  # Lock the origin ALB to Cloudflare's edge ranges (no direct-to-origin bypass).
+  inboundCidrs: "173.245.48.0/20,103.21.244.0/22,103.22.200.0/22,103.31.4.0/22,141.101.64.0/18,108.162.192.0/18,190.93.240.0/20,188.114.96.0/20,197.234.240.0/22,198.41.128.0/17,162.158.0.0/15,104.16.0.0/13,104.24.0.0/14,172.64.0.0/13,131.0.72.0/22"
 # Plain rolling Deployment (no canary) — same delivery model as prod-eks:
 # probe-based auto-healing, HPA autoscaling, zero-downtime rolling deploys.
 rollout:

--- a/infra/k8s/envs/prod/gateway-values.yaml
+++ b/infra/k8s/envs/prod/gateway-values.yaml
@@ -31,3 +31,6 @@ ingress:
   # ACM cert for gateway.kortix.com in eu-west-2 (the prod-eks ALB region).
   certificateArn: "arn:aws:acm:eu-west-2:935064898258:certificate/89358fa4-c7a1-4ea8-82b6-310e9118b41a"
   cloudflareProxied: true
+  # Lock the origin ALB to Cloudflare's edge ranges so the LLM gateway can only be
+  # reached THROUGH Cloudflare — no direct-to-origin bypass of the edge.
+  inboundCidrs: "173.245.48.0/20,103.21.244.0/22,103.22.200.0/22,103.31.4.0/22,141.101.64.0/18,108.162.192.0/18,190.93.240.0/20,188.114.96.0/20,197.234.240.0/22,198.41.128.0/17,162.158.0.0/15,104.16.0.0/13,104.24.0.0/14,172.64.0.0/13,131.0.72.0/22"

--- a/infra/k8s/envs/prod/values.yaml
+++ b/infra/k8s/envs/prod/values.yaml
@@ -86,6 +86,10 @@ ingress:
   host: api-eks.kortix.com
   certificateArn: arn:aws:acm:eu-west-2:935064898258:certificate/27dd2310-c468-428c-b97a-ec46b1eed6fd
   cloudflareProxied: true
+  # Lock the origin ALB to Cloudflare's edge ranges so api.kortix.com can only be
+  # reached THROUGH Cloudflare — no direct-to-origin WAF/rate-limit bypass. Same
+  # allowlist as the devops/argocd ingress and qa-portal.
+  inboundCidrs: "173.245.48.0/20,103.21.244.0/22,103.22.200.0/22,103.31.4.0/22,141.101.64.0/18,108.162.192.0/18,190.93.240.0/20,188.114.96.0/20,197.234.240.0/22,198.41.128.0/17,162.158.0.0/15,104.16.0.0/13,104.24.0.0/14,172.64.0.0/13,131.0.72.0/22"
 
 serviceMonitor:
   enabled: true

--- a/infra/k8s/envs/staging/gateway-values.yaml
+++ b/infra/k8s/envs/staging/gateway-values.yaml
@@ -23,3 +23,5 @@ ingress:
   # us-west-2 wildcard cert for *.kortix.com.
   certificateArn: arn:aws:acm:us-west-2:935064898258:certificate/d70f1f49-d981-4add-abb6-971bad1f3755
   cloudflareProxied: true
+  # Lock the origin ALB to Cloudflare's edge ranges (no direct-to-origin bypass).
+  inboundCidrs: "173.245.48.0/20,103.21.244.0/22,103.22.200.0/22,103.31.4.0/22,141.101.64.0/18,108.162.192.0/18,190.93.240.0/20,188.114.96.0/20,197.234.240.0/22,198.41.128.0/17,162.158.0.0/15,104.16.0.0/13,104.24.0.0/14,172.64.0.0/13,131.0.72.0/22"

--- a/infra/k8s/envs/staging/values.yaml
+++ b/infra/k8s/envs/staging/values.yaml
@@ -53,5 +53,7 @@ ingress:
   # us-west-2 wildcard cert for *.kortix.com.
   certificateArn: arn:aws:acm:us-west-2:935064898258:certificate/d70f1f49-d981-4add-abb6-971bad1f3755
   cloudflareProxied: true
+  # Lock the origin ALB to Cloudflare's edge ranges (no direct-to-origin bypass).
+  inboundCidrs: "173.245.48.0/20,103.21.244.0/22,103.22.200.0/22,103.31.4.0/22,141.101.64.0/18,108.162.192.0/18,190.93.240.0/20,188.114.96.0/20,197.234.240.0/22,198.41.128.0/17,162.158.0.0/15,104.16.0.0/13,104.24.0.0/14,172.64.0.0/13,131.0.72.0/22"
 rollout:
   enabled: false

--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -48,6 +48,14 @@ provider "cloudflare" {
 locals {
   name   = "kortix-dev"
   domain = "dev-api-ecs-fargate.kortix.com" # the ECS fallback name; dev-api itself is the Worker's custom domain
+  # Cloudflare's published IPv4 edge ranges — lock the ALB so the origin is only
+  # reachable THROUGH Cloudflare. Mirrors the EKS chart inboundCidrs / prod.
+  cloudflare_ip_ranges = [
+    "173.245.48.0/20", "103.21.244.0/22", "103.22.200.0/22", "103.31.4.0/22",
+    "141.101.64.0/18", "108.162.192.0/18", "190.93.240.0/20", "188.114.96.0/20",
+    "197.234.240.0/22", "198.41.128.0/17", "162.158.0.0/15", "104.16.0.0/13",
+    "104.24.0.0/14", "172.64.0.0/13", "131.0.72.0/22",
+  ]
   tags = {
     Environment = "dev"
     Service     = "kortix-api"
@@ -94,6 +102,9 @@ module "api" {
   certificate_arn = var.enable_https ? one(module.acm[*].certificate_arn) : ""
   environment     = var.api_environment
   secrets         = var.api_secrets
+
+  # Only Cloudflare's edge may reach the ALB (no direct-to-origin WAF bypass).
+  alb_ingress_cidrs = local.cloudflare_ip_ranges
 
   # dev sizing: small + spot, floor of 1
   task_cpu         = 512

--- a/infra/terraform/environments/prod/main.tf
+++ b/infra/terraform/environments/prod/main.tf
@@ -43,6 +43,16 @@ locals {
   # "new-api.kortix.com" → "new-api"; for "api.kortix.com" → "api". (Single-label
   # subdomain on the kortix.com zone, which is all we use here.)
   dns_record_name = replace(var.api_domain, ".kortix.com", "")
+  # Cloudflare's published IPv4 edge ranges. Lock the public ALB to these so the
+  # origin can only be reached THROUGH Cloudflare — no direct-to-origin bypass of
+  # the WAF / rate limiting. Mirrors the EKS chart inboundCidrs and the
+  # devops/argocd ingress allowlist. Refresh from https://www.cloudflare.com/ips-v4.
+  cloudflare_ip_ranges = [
+    "173.245.48.0/20", "103.21.244.0/22", "103.22.200.0/22", "103.31.4.0/22",
+    "141.101.64.0/18", "108.162.192.0/18", "190.93.240.0/20", "188.114.96.0/20",
+    "197.234.240.0/22", "198.41.128.0/17", "162.158.0.0/15", "104.16.0.0/13",
+    "104.24.0.0/14", "172.64.0.0/13", "131.0.72.0/22",
+  ]
   tags = {
     Environment = "prod"
     Service     = "kortix-api"
@@ -86,6 +96,9 @@ module "api" {
   certificate_arn = module.acm.certificate_arn
   environment     = var.api_environment
   secrets         = var.api_secrets
+
+  # Only Cloudflare's edge may reach the ALB (no direct-to-origin WAF bypass).
+  alb_ingress_cidrs = local.cloudflare_ip_ranges
 
   # prod sizing: bigger tasks, HA floor of 2, no spot, insights on
   task_cpu           = 1024


### PR DESCRIPTION
## What

Lock the customer-facing **API** and **LLM-gateway** origin ALBs to Cloudflare's published IPv4 edge ranges, in `prod`/`dev`/`staging`, for both backends:

- **EKS** (primary): `ingress.inboundCidrs` in `infra/k8s/envs/{prod,dev,staging}/values.yaml` + `.../gateway-values.yaml`
- **ECS-Fargate** (standby): `alb_ingress_cidrs = local.cloudflare_ip_ranges` in `infra/terraform/environments/{prod,dev}/main.tf`

The allowlist is identical to the one already used by the `devops`/`argocd` ingress (`infra/k8s/platform/gateway/argocd-ingress.yaml`) and `qa-portal`.

## Why

Today the origin ALBs accept `0.0.0.0/0`. The comment in `charts/kortix-api/values.yaml` literally says *"Lock ALB ingress to Cloudflare IP ranges in prod (recommended). Empty = open."* — it was applied to the internal/admin surfaces but never to the customer-facing API/gateway.

Because the origin ALB terminates TLS with the same ACM cert that covers the public hostname, anyone who discovers the origin ALB hostname (trivial via Certificate Transparency logs + historical DNS — and our DNS is hand-managed since external-dns is wedged) can connect directly with `Host: api.kortix.com` and route straight through, **bypassing Cloudflare's WAF, rate limiting, and bot/DDoS mitigation.** This is what an external researcher flagged as "your cloudflare is accessible to the internet" (i.e. the origin behind it).

## Severity: Medium (not critical)

Assessed against the app-layer controls:

- **Auth bypass — none.** Every route authenticates itself (Supabase JWT / API key / PAT / service-account); no sensitive route trusts network position. Public routes are HMAC/Svix-signed or capability-token gated.
- **LLM-credit theft — none.** The gateway requires a valid bearer token *and* an active billing balance; origin-bypass grants no new capability vs. hitting it through Cloudflare.
- **Rate-limit / DDoS — Medium (the real teeth).** App-level rate limiting is narrow and IP-spoofable, so losing Cloudflare's volumetric/bot mitigation genuinely raises resource-exhaustion + brute-force risk. This is what the change closes.
- **/metrics scrape — Low.** Unauthenticated but exposes only operational telemetry (request counts/latency by route, memory/uptime) — no secrets/PII.

## Safety of this change

- The Cloudflare Worker's origin fetches and normal orange-cloud proxying both egress from these same Cloudflare ranges → the live request path is unaffected.
- ALB→target health checks are intra-VPC (separate SG path), not gated by `inbound-cidrs`.
- Proven pattern: `argocd`/`devops`/`qa` ALBs already run with this exact allowlist.
- **Rollout caution:** this changes prod ALB security-group inbound rules. If the Cloudflare range list is stale it could drop legitimate edge traffic — verify against https://www.cloudflare.com/ips-v4 at deploy and watch 5xx/health after the EKS sync + `terraform apply`.

## Validation

- `helm template` for `kortix-api` and `kortix-gateway` with prod values renders the `alb.ingress.kubernetes.io/inbound-cidrs` annotation correctly.
- `terraform fmt -check` clean on both `prod` and `dev`.

## Not in this PR (follow-ups)

- **Authenticated Origin Pulls (mTLS)** or a shared-secret origin header — the IP allowlist stops drive-by scanners but another Cloudflare tenant could still proxy to the origin; mTLS/secret-header is full closure.
- Restrict `/metrics` at the edge or behind a bearer token (already tracked in `docs/WHATS_MISSING.md`).
- Add Cloudflare **IPv6** ranges if the origin ALBs go dual-stack.
- Lock the `preview` (ephemeral PR) shared ALB too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
