### PR TITLE
Fix API transport hardening and runtime DB grants

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -90,13 +90,17 @@ jobs:
 
       - name: Resolve target
         id: target
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_BASE_URL: ${{ inputs.base_url }}
+          INPUT_ARGS: ${{ inputs.args }}
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
+          if [ "$EVENT_NAME" = "pull_request" ]; then
             echo "base=https://dev-api.kortix.com/v1" >> "$GITHUB_OUTPUT"
             echo "args=run --tag smoke" >> "$GITHUB_OUTPUT"
           else
-            echo "base=${{ inputs.base_url }}" >> "$GITHUB_OUTPUT"
-            echo "args=${{ inputs.args }}" >> "$GITHUB_OUTPUT"
+            echo "base=$INPUT_BASE_URL" >> "$GITHUB_OUTPUT"
+            echo "args=$INPUT_ARGS" >> "$GITHUB_OUTPUT"
           fi
 
       - name: GC leaked resources from prior runs
@@ -114,9 +118,13 @@ jobs:
           KE2E_DATABASE_URL: ${{ secrets.KE2E_DATABASE_URL }}
 
       - name: Run ke2e
-        run: bun bin/ke2e.ts ${{ steps.target.outputs.args }}
+        run: |
+          set -euo pipefail
+          read -r -a KE2E_ARGV <<< "$KE2E_ARGS"
+          bun bin/ke2e.ts "${KE2E_ARGV[@]}"
         working-directory: tests
         env:
+          KE2E_ARGS: ${{ steps.target.outputs.args }}
           KE2E_API_URL: ${{ steps.target.outputs.base }}
           KE2E_LIVE_CONFIRM: "ci"
           KE2E_OWNER_EMAIL: ${{ secrets.KE2E_OWNER_EMAIL }}

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -72,6 +72,9 @@ jobs:
 
       - name: Compute next version (from what's live on prod)
         id: ver
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_BUMP: ${{ inputs.bump }}
         run: |
           set -euo pipefail
           git fetch --no-tags origin prod >/dev/null 2>&1 || true
@@ -81,13 +84,13 @@ jobs:
           [ -n "$BASE" ] || BASE="$(tr -d '[:space:]' < VERSION)"
           echo "Currently live on prod: $BASE"
 
-          EXPLICIT="${{ inputs.version }}"
+          EXPLICIT="$INPUT_VERSION"
           if [ -n "$EXPLICIT" ]; then
             NEW="${EXPLICIT#v}"
           else
             IFS='.' read -r MAJOR MINOR PATCH <<< "$BASE"
             : "${MAJOR:=0}"; : "${MINOR:=0}"; : "${PATCH:=0}"
-            case "${{ inputs.bump }}" in
+            case "$INPUT_BUMP" in
               major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
               minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
               patch) PATCH=$((PATCH + 1)) ;;
@@ -110,6 +113,9 @@ jobs:
           # staging image-build checks to be green — deploy-prod retags those exact
           # images, so they must exist — but we DON'T wait on the slow QA/e2e lanes.
           FAST: ${{ (vars.RELEASE_FAST_TRACK == 'true' || inputs.skip_green) && 'true' || 'false' }}
+          INPUT_REF: ${{ inputs.ref }}
+          RUN_ID: ${{ github.run_id }}
+          REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
           if [ "$FAST" = "true" ]; then
@@ -117,7 +123,7 @@ jobs:
           fi
           TREE_SHA="$(git rev-parse HEAD)"
           IMAGE_SHA="$TREE_SHA"
-          if [ "${{ inputs.ref }}" = "staging" ] && [ -f infra/k8s/envs/staging/values.yaml ]; then
+          if [ "$INPUT_REF" = "staging" ] && [ -f infra/k8s/envs/staging/values.yaml ]; then
             staging_tag="$(yq -r '.image.tag // ""' infra/k8s/envs/staging/values.yaml)"
             if [[ "$staging_tag" =~ ^staging-([0-9a-f]{8})$ ]]; then
               candidate="$(git rev-parse "${BASH_REMATCH[1]}^{commit}" 2>/dev/null || true)"
@@ -128,7 +134,7 @@ jobs:
           fi
           echo "tree_sha=$TREE_SHA" >> "$GITHUB_OUTPUT"
           echo "image_sha=$IMAGE_SHA" >> "$GITHUB_OUTPUT"
-          echo "Promote tree ${{ inputs.ref }} @ $TREE_SHA"
+          echo "Promote tree $INPUT_REF @ $TREE_SHA"
           echo "Release image source @ $IMAGE_SHA"
           # The staging branch tip can be a GitOps pin commit created by
           # deploy-staging.yml after the build. In that normal case the deploy
@@ -159,7 +165,7 @@ jobs:
           check_green() {
             local sha="$1" label="$2"
             local not_green
-            not_green="$(RID="${{ github.run_id }}" gh api "repos/${{ github.repository }}/commits/${sha}/check-runs?per_page=100" --paginate \
+            not_green="$(RID="$RUN_ID" gh api "repos/${REPOSITORY}/commits/${sha}/check-runs?per_page=100" --paginate \
               --jq '[ .check_runs[]
                       | select((.details_url // "") | contains("/runs/" + env.RID + "/") | not)
                       | select(((.name | ascii_downcase | startswith("dependabot")) or (.name | ascii_downcase | startswith("analyze")) or (.name == "compliance-as-code-action") or (.name == "Open review-gated release PR")) | not)
@@ -171,7 +177,7 @@ jobs:
             if [ -n "$not_green" ]; then
               echo "::error::Refusing to promote — ${label} ${sha} is not all-green:"
               echo "$not_green"
-              echo "Wait for these to finish/pass on '${{ inputs.ref }}', then re-run promote." >&2
+              echo "Wait for these to finish/pass on '$INPUT_REF', then re-run promote." >&2
               exit 1
             fi
             echo "✓ ${label} ${sha} is green."
@@ -187,15 +193,18 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           IN_TITLE: ${{ inputs.title }}
           IN_NOTES: ${{ inputs.notes }}
+          RELEASE_NEW: ${{ steps.ver.outputs.new }}
+          RELEASE_TAG: ${{ steps.ver.outputs.tag }}
+          RELEASE_SOURCE_SHA: ${{ steps.preflight.outputs.image_sha }}
         run: |
           set -euo pipefail
-          NEW="${{ steps.ver.outputs.new }}"
-          TAG="${{ steps.ver.outputs.tag }}"
+          NEW="$RELEASE_NEW"
+          TAG="$RELEASE_TAG"
           RELBR="release/$TAG"
           # The image source is normally the staged source commit. When staging
           # HEAD is a GitOps pin commit, this is the commit named by the pinned
           # `staging-<sha8>` image tag, not the pin commit itself.
-          SRC_SHA="${{ steps.preflight.outputs.image_sha }}"
+          SRC_SHA="$RELEASE_SOURCE_SHA"
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -241,13 +250,18 @@ jobs:
           fi
 
       - name: Summary
+        env:
+          RELEASE_TAG: ${{ steps.ver.outputs.tag }}
+          RELEASE_BASE: ${{ steps.ver.outputs.base }}
+          RELEASE_NEW: ${{ steps.ver.outputs.new }}
+          INPUT_REF: ${{ inputs.ref }}
         run: |
           {
-            echo "### Release PR opened — \`${{ steps.ver.outputs.tag }}\`"
+            echo "### Release PR opened — \`$RELEASE_TAG\`"
             echo ""
-            echo "- Live on prod: \`${{ steps.ver.outputs.base }}\`"
-            echo "- Proposed version: \`${{ steps.ver.outputs.new }}\`"
-            echo "- \`${{ inputs.ref }}\` → \`release/${{ steps.ver.outputs.tag }}\` → PR into \`prod\`"
+            echo "- Live on prod: \`$RELEASE_BASE\`"
+            echo "- Proposed version: \`$RELEASE_NEW\`"
+            echo "- \`$INPUT_REF\` → \`release/$RELEASE_TAG\` → PR into \`prod\`"
             echo ""
             echo "_Nothing is published yet. A reviewer approves + merges the PR; the **merge** publishes the version (tag + GitHub Release + image retag + EKS roll + frontend)._"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/apps/api/src/projects/secrets.ts
+++ b/apps/api/src/projects/secrets.ts
@@ -13,6 +13,7 @@ import { isSecretUsableBy, loadGrants, type ShareSubject } from '../executor/sha
 
 const SECRET_NAME_REGEX = /^[A-Z_][A-Z0-9_]{0,63}$/;
 const ENVELOPE_VERSION = 'v1';
+const GCM_AUTH_TAG_LENGTH = 16;
 
 function b64url(input: Buffer): string {
   return input.toString('base64url');
@@ -42,7 +43,9 @@ function projectSecretKey(projectId: string): Buffer {
 
 export function encryptProjectSecret(projectId: string, value: string): string {
   const iv = randomBytes(12);
-  const cipher = createCipheriv('aes-256-gcm', projectSecretKey(projectId), iv);
+  const cipher = createCipheriv('aes-256-gcm', projectSecretKey(projectId), iv, {
+    authTagLength: GCM_AUTH_TAG_LENGTH,
+  });
   const ciphertext = Buffer.concat([
     cipher.update(value, 'utf8'),
     cipher.final(),
@@ -56,8 +59,14 @@ export function decryptProjectSecret(projectId: string, valueEnc: string): strin
   if (version !== ENVELOPE_VERSION || !ivB64 || !tagB64 || !ciphertextB64) {
     throw new Error('Unsupported project secret envelope');
   }
-  const decipher = createDecipheriv('aes-256-gcm', projectSecretKey(projectId), fromB64url(ivB64));
-  decipher.setAuthTag(fromB64url(tagB64));
+  const tag = fromB64url(tagB64);
+  if (tag.length !== GCM_AUTH_TAG_LENGTH) {
+    throw new Error('Unsupported project secret auth tag length');
+  }
+  const decipher = createDecipheriv('aes-256-gcm', projectSecretKey(projectId), fromB64url(ivB64), {
+    authTagLength: GCM_AUTH_TAG_LENGTH,
+  });
+  decipher.setAuthTag(tag);
   return Buffer.concat([
     decipher.update(fromB64url(ciphertextB64)),
     decipher.final(),

--- a/apps/api/src/setup/index.ts
+++ b/apps/api/src/setup/index.ts
@@ -12,7 +12,7 @@ import { makeOpenApiApp, json, errors, auth } from '../openapi';
 import type { AppEnv } from '../types';
 import { existsSync } from 'fs';
 import { resolve } from 'path';
-import { execSync } from 'child_process';
+import { spawnSync } from 'child_process';
 import { config } from '../config';
 import { supabaseAuth } from '../middleware/auth';
 import { eq, sql } from 'drizzle-orm';
@@ -328,8 +328,8 @@ setupApp.openapi(
 
   let dockerRunning = false;
   try {
-    execSync('docker info', { stdio: 'pipe', timeout: 10000 });
-    dockerRunning = true;
+    const result = spawnSync('docker', ['info'], { stdio: 'pipe', timeout: 10000 });
+    dockerRunning = result.status === 0;
   } catch {}
 
   return c.json({

--- a/infra/cloudflare/workers/api-router/worker.mjs
+++ b/infra/cloudflare/workers/api-router/worker.mjs
@@ -10,6 +10,14 @@
 // failover with no DNS change. Both backends run the same image against the same
 // DB, so a flip is safe (background-worker leadership is a single global DB lease
 // — see apps/api/src/shared/leader-election.ts — so only one side ever runs cron).
+const STRICT_TRANSPORT_SECURITY = 'max-age=31536000';
+
+function addSecurityHeaders(response) {
+  response.headers.set('Strict-Transport-Security', STRICT_TRANSPORT_SECURITY);
+  response.headers.set('X-Content-Type-Options', 'nosniff');
+  return response;
+}
+
 export default {
   async fetch(request, env) {
     const active = env.ACTIVE_BACKEND || 'eks';
@@ -25,6 +33,16 @@ export default {
     }
 
     const url = new URL(request.url);
+    if (url.protocol !== 'https:') {
+      url.protocol = 'https:';
+      return new Response(null, {
+        status: 308,
+        headers: {
+          Location: url.toString(),
+        },
+      });
+    }
+
     const targetUrl = new URL(url.pathname + url.search, backendUrl);
 
     // `manual` so backend 3xx responses are passed straight through to the
@@ -43,6 +61,6 @@ export default {
     const response = await fetch(modifiedRequest);
     const newResponse = new Response(response.body, response);
     newResponse.headers.set('X-Backend', active);
-    return newResponse;
+    return addSecurityHeaders(newResponse);
   },
 };

--- a/infra/cloudflare/workers/api-router/worker.test.mjs
+++ b/infra/cloudflare/workers/api-router/worker.test.mjs
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import worker from './worker.mjs';
+
+const env = {
+  ACTIVE_BACKEND: 'eks',
+  BACKEND_EKS: 'https://api-eks.kortix.com',
+  BACKEND_ECS_FARGATE: 'https://api-fargate.kortix.com',
+};
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe('api-router worker', () => {
+  test('redirects plaintext API requests to HTTPS before proxying', async () => {
+    let fetched = false;
+    globalThis.fetch = async () => {
+      fetched = true;
+      return new Response('unexpected');
+    };
+
+    const response = await worker.fetch(
+      new Request('http://api.kortix.com/v1/health/live?x=1'),
+      env,
+    );
+
+    expect(response.status).toBe(308);
+    expect(response.headers.get('Location')).toBe('https://api.kortix.com/v1/health/live?x=1');
+    expect(fetched).toBe(false);
+  });
+
+  test('adds API security headers to proxied HTTPS responses', async () => {
+    let proxiedUrl = '';
+    globalThis.fetch = async (request) => {
+      proxiedUrl = request.url;
+      return new Response(JSON.stringify({ status: 'ok' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    };
+
+    const response = await worker.fetch(
+      new Request('https://api.kortix.com/v1/health/live'),
+      env,
+    );
+
+    expect(proxiedUrl).toBe('https://api-eks.kortix.com/v1/health/live');
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Strict-Transport-Security')).toBe('max-age=31536000');
+    expect(response.headers.get('X-Content-Type-Options')).toBe('nosniff');
+    expect(response.headers.get('X-Backend')).toBe('eks');
+  });
+});

--- a/packages/db/migrations/20260704160000000_reassert_kortix_runtime_grants.sql
+++ b/packages/db/migrations/20260704160000000_reassert_kortix_runtime_grants.sql
@@ -1,0 +1,37 @@
+-- Reassert runtime grants for the direct API DATABASE_URL role plus the
+-- Supabase JWT roles. Prod drift showed the API connecting as postgres but
+-- failing with 42501 on kortix.oauth_clients and credit RPC fallback paths.
+
+DO $$
+DECLARE
+  role_name text;
+BEGIN
+  FOREACH role_name IN ARRAY ARRAY['postgres', 'service_role'] LOOP
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = role_name) THEN
+      EXECUTE format('GRANT USAGE ON SCHEMA kortix TO %I', role_name);
+      EXECUTE format('GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA kortix TO %I', role_name);
+      EXECUTE format('GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA kortix TO %I', role_name);
+      EXECUTE format('GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA public TO %I', role_name);
+      EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA kortix GRANT ALL PRIVILEGES ON TABLES TO %I', role_name);
+      EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA kortix GRANT ALL PRIVILEGES ON SEQUENCES TO %I', role_name);
+    END IF;
+  END LOOP;
+
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'authenticated') THEN
+    GRANT USAGE ON SCHEMA kortix TO authenticated;
+    GRANT SELECT, INSERT, UPDATE ON ALL TABLES IN SCHEMA kortix TO authenticated;
+    GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA kortix TO authenticated;
+    GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA public TO authenticated;
+    ALTER DEFAULT PRIVILEGES IN SCHEMA kortix GRANT SELECT, INSERT, UPDATE ON TABLES TO authenticated;
+    ALTER DEFAULT PRIVILEGES IN SCHEMA kortix GRANT USAGE, SELECT ON SEQUENCES TO authenticated;
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'anon') THEN
+    GRANT USAGE ON SCHEMA kortix TO anon;
+    GRANT SELECT ON ALL TABLES IN SCHEMA kortix TO anon;
+    GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA kortix TO anon;
+    ALTER DEFAULT PRIVILEGES IN SCHEMA kortix GRANT SELECT ON TABLES TO anon;
+    ALTER DEFAULT PRIVILEGES IN SCHEMA kortix GRANT USAGE, SELECT ON SEQUENCES TO anon;
+  END IF;
+END
+$$;

--- a/tests/src/fixtures/gc.ts
+++ b/tests/src/fixtures/gc.ts
@@ -51,7 +51,7 @@ async function listTestUsersViaDb(env: Env): Promise<SupaUser[]> {
   const conn = env.databaseUrl!;
   const local = conn.includes("localhost") || conn.includes("127.0.0.1");
   const { Client } = await import("pg");
-  const client = new Client({ connectionString: conn, ssl: local ? false : { rejectUnauthorized: false } });
+  const client = new Client({ connectionString: conn, ssl: local ? false : true });
   await client.connect();
   try {
     const r = await client.query(


### PR DESCRIPTION
## Summary
- Redirect plaintext API Worker requests to HTTPS before proxying and add API HSTS/nosniff headers on HTTPS responses.
- Add focused Worker tests for HTTP redirect, proxy target preservation, HSTS, nosniff, and X-Backend.
- Add an idempotent DB migration that reasserts `kortix` schema/table/sequence grants for the direct runtime `postgres` role and Supabase JWT roles after live 42501 drift.
- Remove direct GitHub Actions expression interpolation from release/e2e shell bodies.
- Tighten adjacent SAST findings: explicit AES-GCM auth tag length, `spawnSync` args for docker status, and verified TLS in the ke2e DB fallback.

## Live evidence behind this PR
- `http://api.kortix.com/v1/health/live`, `http://dev-api.kortix.com/v1/health/live`, and `http://staging-api.kortix.com/v1/health/live` returned `200 OK` through the API Worker instead of redirecting.
- `https://api.kortix.com/v1/oauth/authorize?...client_id=notreal` and `POST /v1/oauth/token` returned `500`; prod pod logs showed `DrizzleQueryError` selecting `kortix.oauth_clients` plus `42501 permission denied for schema kortix`.
- The running prod API `DATABASE_URL` username is `postgres`, which was not covered by the existing checked-in `kortix` grants.

## Verification
- `bun test infra/cloudflare/workers/api-router/worker.test.mjs`
- `pnpm --filter @kortix/db migrate:lint`
- `pnpm --filter @kortix/db test`
- `pnpm --filter kortix-api typecheck`
- `KORTIX_URL=http://localhost:8008 dotenvx run -- bun test src/__tests__/unit-setup-links.test.ts` from `apps/api`
- `psql postgres://postgres:postgres@127.0.0.1:54322/postgres -v ON_ERROR_STOP=1 -f packages/db/migrations/20260704160000000_reassert_kortix_runtime_grants.sql`
- Local privilege readback returned true for `postgres` and `service_role` `kortix` schema usage plus `kortix.oauth_clients` select.
- `git diff --check`

## Security scan notes
- `bash tests/security/run.sh --sast` still fails on 17 existing baseline findings, but the fixed classes are gone: GitHub Actions shell interpolation, AES-GCM tag length, `execSync('docker info')`, and disabled TLS verification.
- `bash tests/security/run.sh --secrets` still fails on known existing baseline findings outside this PR: mobile Podfile checksum, Terraform IAM user-name inventory, and a negative-test curl password.

## Post-deploy checks
- `curl -I http://api.kortix.com/v1/health/live` should return `308` with `Location: https://api.kortix.com/v1/health/live`.
- `curl -I https://api.kortix.com/v1/health/live` should include `Strict-Transport-Security: max-age=31536000`.
- OAuth unknown-client probes should return `400 invalid_client` for authorize and `401 invalid_client` for token, not `500`.
- Prod API logs should stop showing `42501 permission denied for schema kortix` for OAuth and credit fallback paths.