### PR TITLE
feat(sdk+whitelabel): Kortix-as-a-Backend — wrapper-backend reference + server-grade SDK surface

### DIFF
--- a/apps/api/src/__tests__/unit-tier-model-entitlement.test.ts
+++ b/apps/api/src/__tests__/unit-tier-model-entitlement.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from 'bun:test';
+import { config } from '../config';
 import {
+  accountIsFreeTierForModels,
   CREDITS_PER_DOLLAR,
   getTier,
   isPaidTier,
@@ -53,5 +55,52 @@ describe('tierGrantsAllModels', () => {
 
   test('an unknown tier name falls back to the none tier (no gateway)', () => {
     expect(tierGrantsAllModels('totally-made-up-tier')).toBe(false);
+  });
+});
+
+// Regression covered here (2026-07-05): dev-api.kortix.com and the pr-4145
+// preview both 400 "No upstream configured for model glm-5.2" on every agent
+// turn — traced to gateway_request_logs showing a same-day 'free' tier signup
+// hitting the managed-model gate (`resolveCandidates` returns [] whenever
+// `accountIsFreeTierForModels` is true), while paid-tier dev accounts succeed
+// against the SAME openrouter/bedrock upstreams in the same window — i.e. the
+// upstream config was never the problem, only entitlement. Every fresh
+// dev/preview signup defaults to 'free', so without an exemption NO ONE could
+// exercise managed-model chat on those QA surfaces. `tierGrantsAllModels`
+// itself stays a pure function of tier config (see above) — the dev/preview
+// carve-out lives only in this wrapper, which every gateway/picker call site
+// now goes through instead of inlining `!tierGrantsAllModels`.
+describe('accountIsFreeTierForModels', () => {
+  // The no-arg form reads the AMBIENT config.INTERNAL_KORTIX_ENV, which varies
+  // by where the suite runs (provisioned dev box vs CI vs a bare worktree) —
+  // so assert only self-consistency with an explicit same-env call, never a
+  // specific ambient value.
+  test('no-arg form matches the explicit call for the ambient env', () => {
+    const ambient = config.INTERNAL_KORTIX_ENV;
+    for (const tier of ['free', 'none', 'totally-made-up-tier']) {
+      expect(accountIsFreeTierForModels(tier)).toBe(accountIsFreeTierForModels(tier, ambient));
+    }
+  });
+
+  test('dev/preview (explicit env arg): free and none tiers are NOT paywalled from managed models', () => {
+    for (const env of ['dev', 'preview']) {
+      expect(accountIsFreeTierForModels('free', env)).toBe(false);
+      expect(accountIsFreeTierForModels('none', env)).toBe(false);
+    }
+  });
+
+  test('prod/staging (explicit env arg): free and none tiers STAY paywalled', () => {
+    for (const env of ['prod', 'staging']) {
+      expect(accountIsFreeTierForModels('free', env)).toBe(true);
+      expect(accountIsFreeTierForModels('none', env)).toBe(true);
+    }
+  });
+
+  test('a paid tier is never blocked, in any environment', () => {
+    for (const env of ['prod', 'staging', 'dev', 'preview']) {
+      for (const name of PAID_TIER_NAMES) {
+        expect(accountIsFreeTierForModels(name, env)).toBe(false);
+      }
+    }
   });
 });

--- a/apps/api/src/billing/services/tiers.ts
+++ b/apps/api/src/billing/services/tiers.ts
@@ -586,9 +586,48 @@ export function isPaidTier(tierName: string): boolean {
  * off the resolved TIER, not `billing_model`: legacy paid customers are just as
  * entitled to premium models as per-seat teams (the gateway meters every account
  * the same way), and gating on `isPerSeatAccount` wrongly locked them out.
+ *
+ * Pure function of tier config only — deliberately environment-agnostic (see
+ * unit-tier-model-entitlement.test.ts, which locks this in as an invariant).
+ * Callers that need a dev/preview QA exemption from the paywall should go
+ * through `accountIsFreeTierForModels` below, not inline this.
  */
 export function tierGrantsAllModels(tierName: string): boolean {
   return getTier(tierName).models.includes('all');
+}
+
+/**
+ * Whether an account (given its resolved billing tier) should be treated as
+ * free-tier for MANAGED-MODEL access — i.e. blocked from every premium Kortix
+ * model and left with BYOK/Codex only. Same as `!tierGrantsAllModels(tier)`
+ * everywhere EXCEPT dev/preview, which never enforce this particular paywall.
+ *
+ * Why: every dev/preview signup — including every fresh PR-preview test/QA
+ * account — defaults to tier 'free' (`models: []`), so without this exemption
+ * it can never get a managed-model candidate. `auto` (the session default)
+ * resolves to `glm-5.2`, the gateway's resolveCandidates returns `[]`, and
+ * every agent turn 400s "No upstream configured for model glm-5.2" — confirmed
+ * against the dev DB on 2026-07-05: gateway_request_logs shows exactly this for
+ * a same-day free-tier signup, while OTHER dev accounts with a paid tier
+ * succeed against the SAME openrouter/bedrock upstreams in the same window.
+ * The upstream config is fine; only entitlement is missing. Prod keeps the
+ * real paywall; staging keeps it too (staging is where the free-tier paywall
+ * itself gets verified against Stripe test mode). dev + preview are internal
+ * engineering/QA surfaces, not customer-facing, so paywalling them only breaks
+ * testing, for no revenue-protection benefit.
+ *
+ * `env` defaults to the real deployed `INTERNAL_KORTIX_ENV` — it's a parameter
+ * (not a direct `config` read) purely so tests can exercise every environment
+ * branch deterministically in-process, without module-mocking `../config`
+ * (which risks leaking a stubbed config into unrelated test files sharing the
+ * same bun test process).
+ */
+export function accountIsFreeTierForModels(
+  tierName: string,
+  env: string = config.INTERNAL_KORTIX_ENV,
+): boolean {
+  if (env === 'dev' || env === 'preview') return false;
+  return !tierGrantsAllModels(tierName);
 }
 
 /** Full entitlement set for a tier (enterprise feature gates). */

--- a/apps/api/src/channels/slack/model-gate.ts
+++ b/apps/api/src/channels/slack/model-gate.ts
@@ -3,7 +3,7 @@ import { accountMembers, projects } from '@kortix/db';
 import { db } from '../../shared/db';
 import { config } from '../../config';
 import { getAccountTier } from '../../billing/services/entitlements';
-import { tierGrantsAllModels } from '../../billing/services/tiers';
+import { accountIsFreeTierForModels } from '../../billing/services/tiers';
 import { type ChannelCtx, currentChannelSelection } from './selection';
 
 // The account/tier context a channel's model setting resolves against. Kept out
@@ -40,7 +40,7 @@ export async function channelModelContext(ctx: ChannelCtx): Promise<ChannelModel
     .where(and(eq(accountMembers.accountId, project.accountId), eq(accountMembers.accountRole, 'owner')))
     .limit(1);
   const tier = await getAccountTier(project.accountId);
-  const freeManagedOnly = config.KORTIX_BILLING_INTERNAL_ENABLED && !tierGrantsAllModels(tier);
+  const freeManagedOnly = config.KORTIX_BILLING_INTERNAL_ENABLED && accountIsFreeTierForModels(tier);
   return {
     projectId: selection.projectId,
     accountId: project.accountId,

--- a/apps/api/src/llm-gateway/hooks.ts
+++ b/apps/api/src/llm-gateway/hooks.ts
@@ -8,7 +8,7 @@ import type {
 import { assertBillingActive } from '../billing/services/billing-gate';
 import { deductForLlmUsage } from '../billing/services/credits';
 import { getCachedAccountTier } from '../billing/services/entitlements';
-import { llmPriceMarkup, tierGrantsAllModels } from '../billing/services/tiers';
+import { accountIsFreeTierForModels, llmPriceMarkup } from '../billing/services/tiers';
 import { attributeYoloToken } from '../billing/services/yolo-tokens';
 import { config } from '../config';
 import { validateAccountToken } from '../repositories/account-tokens';
@@ -74,7 +74,7 @@ async function withResolvedTier(principal: AuthedPrincipal): Promise<AuthedPrinc
   const tiered: AuthedPrincipal = config.KORTIX_BILLING_INTERNAL_ENABLED
     ? await (async () => {
         const tier = await getCachedAccountTier(principal.accountId);
-        return { ...principal, tier, freeModelsOnly: !tierGrantsAllModels(tier) };
+        return { ...principal, tier, freeModelsOnly: accountIsFreeTierForModels(tier) };
       })()
     : { ...principal, freeModelsOnly: false };
   // Resolve the account/project/agent-configured default model once, here, so it

--- a/apps/api/src/llm-gateway/resolution/resolve-candidates.ts
+++ b/apps/api/src/llm-gateway/resolution/resolve-candidates.ts
@@ -5,7 +5,7 @@ import {
 } from '@kortix/llm-gateway';
 import { getManagedModel, pickAutoModel } from '@kortix/llm-catalog';
 import { getAccountTier } from '../../billing/services/entitlements';
-import { tierGrantsAllModels } from '../../billing/services/tiers';
+import { accountIsFreeTierForModels } from '../../billing/services/tiers';
 import { config } from '../../config';
 import { getProjectSecretValue } from '../../projects/secrets';
 import { resolveCodexCredential } from '../credentials/codex';
@@ -95,7 +95,7 @@ export async function resolveCandidates(
     if (principal.freeModelsOnly) return [];
     if (config.KORTIX_BILLING_INTERNAL_ENABLED) {
       const tier = await resolveCachedAccountTier(principal.accountId);
-      if (!tierGrantsAllModels(tier)) return [];
+      if (accountIsFreeTierForModels(tier)) return [];
     }
     return managedCandidates(managed);
   }

--- a/apps/api/src/projects/routes/r4.ts
+++ b/apps/api/src/projects/routes/r4.ts
@@ -19,7 +19,7 @@ import {
 } from "../../channels/agentmail-api";
 import { config } from "../../config";
 import { getCachedAccountTier } from "../../billing/services/entitlements";
-import { tierGrantsAllModels } from "../../billing/services/tiers";
+import { accountIsFreeTierForModels } from "../../billing/services/tiers";
 import {
   downloadSlackFile,
   uploadSlackFile,
@@ -1449,7 +1449,7 @@ projectsApp.openapi(
     // synthetic AUTO stay hidden from the picker.
     const freeManagedOnly =
       config.KORTIX_BILLING_INTERNAL_ENABLED && ownerAccountId
-        ? !tierGrantsAllModels(await getCachedAccountTier(ownerAccountId))
+        ? accountIsFreeTierForModels(await getCachedAccountTier(ownerAccountId))
         : false;
     const models = gatewayModelCatalog(projectId, { freeManagedOnly });
     return c.json({ models });
@@ -1490,7 +1490,7 @@ projectsApp.openapi(
     const defaults = await getAccountModelDefaults(ownerAccountId);
     const freeTier =
       config.KORTIX_BILLING_INTERNAL_ENABLED
-        ? !tierGrantsAllModels(await getCachedAccountTier(ownerAccountId))
+        ? accountIsFreeTierForModels(await getCachedAccountTier(ownerAccountId))
         : false;
     // Honest project-level resolution (project → account → platform) + where it
     // came from, so the UI can show "Sonnet 4.6 · project default". The
@@ -1560,7 +1560,7 @@ projectsApp.openapi(
     }
 
     const freeModelsOnly = config.KORTIX_BILLING_INTERNAL_ENABLED
-      ? !tierGrantsAllModels(await getCachedAccountTier(ownerAccountId))
+      ? accountIsFreeTierForModels(await getCachedAccountTier(ownerAccountId))
       : false;
     const servable = await isModelServableForAccount({
       userId,

--- a/apps/api/src/sandbox-proxy/routes/preview.ts
+++ b/apps/api/src/sandbox-proxy/routes/preview.ts
@@ -535,22 +535,44 @@ export async function forwardToSandbox(
         );
       }
 
-      const upstream = await fetch(targetUrl, {
-        method,
-        headers,
-        body,
-        redirect: 'manual',
-        // Bound a wedged first connection to a freshly-restored microVM (residual
-        // CH RX stall) so the attempt fails fast → retry on a fresh connection,
-        // instead of hanging the whole proxy. `body` is buffered (line ~576, not
-        // a stream) so aborting only kills the in-flight attempt, never truncates
-        // an upload mid-stream.
-        signal: AbortSignal.timeout(proxyAttemptTimeoutMs(budgetRemainingMs)),
-        // Bun extensions: no decompression (raw byte passthrough), duplex streaming —
-        // not in the lib RequestInit type.
-        decompress: false,
-        duplex: 'half',
-      } as RequestInit);
+      // Bound a wedged first connection to a freshly-restored microVM (residual
+      // CH RX stall) so the attempt fails fast → retry on a fresh connection,
+      // instead of hanging the whole proxy. `body` is buffered (line ~576, not
+      // a stream) so aborting only kills the in-flight attempt, never truncates
+      // an upload mid-stream.
+      //
+      // CRITICAL: the timeout bounds ONLY the connect/header phase — the timer
+      // is cleared the moment `fetch` resolves. The previous
+      // `AbortSignal.timeout(...)` bounded the ENTIRE fetch lifecycle, which
+      // severed every streaming response body at ~15s: the `/global/event` SSE
+      // stream (each open session tab then reconnected ~250ms later, forever —
+      // a fleet-wide reconnect storm, ~240 reconnects/hour/tab), long-polls,
+      // and any proxied download slower than 15s. The retry loop only ever
+      // needed to retry attempts whose CONNECTION wedged, which this still does.
+      const attemptController = new AbortController();
+      const connectTimer = setTimeout(
+        () =>
+          attemptController.abort(
+            new DOMException('proxy attempt connect timeout', 'TimeoutError'),
+          ),
+        proxyAttemptTimeoutMs(budgetRemainingMs),
+      );
+      let upstream: Response;
+      try {
+        upstream = await fetch(targetUrl, {
+          method,
+          headers,
+          body,
+          redirect: 'manual',
+          signal: attemptController.signal,
+          // Bun extensions: no decompression (raw byte passthrough), duplex streaming —
+          // not in the lib RequestInit type.
+          decompress: false,
+          duplex: 'half',
+        } as RequestInit);
+      } finally {
+        clearTimeout(connectTimer);
+      }
 
       if (upstream.status >= 300 && upstream.status < 400) {
         const respHeaders = clientResponseHeaders(upstream.headers, origin);

--- a/apps/api/src/shared/account-limits.ts
+++ b/apps/api/src/shared/account-limits.ts
@@ -1,6 +1,6 @@
 import { config } from '../config';
 import { getSubscriptionInfo } from '../billing/repositories/credit-accounts';
-import { getTier, isPaidTier, isPerSeatAccount, tierGrantsAllModels, MAX_PROJECTS_PER_ACCOUNT } from '../billing/services/tiers';
+import { accountIsFreeTierForModels, getTier, isPaidTier, isPerSeatAccount, MAX_PROJECTS_PER_ACCOUNT } from '../billing/services/tiers';
 import type { RateLimitPolicy } from './rate-limit';
 
 // Managed cloud is paid-only: new accounts resolve to tier 'none' and must
@@ -81,7 +81,7 @@ export async function resolveAccountTier(accountId: string): Promise<string | nu
 export async function accountEntitledToLlmGateway(accountId: string): Promise<boolean> {
   if (!config.KORTIX_BILLING_INTERNAL_ENABLED) return true;
   const tier = await resolveAccountTier(accountId);
-  return tierGrantsAllModels(tier ?? 'free');
+  return !accountIsFreeTierForModels(tier ?? 'free');
 }
 
 export function sessionLlmPolicyForTier(tier: string | null | undefined): RateLimitPolicy {

--- a/apps/web/src/components/pages/settings/api-keys/page.tsx
+++ b/apps/web/src/components/pages/settings/api-keys/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useTranslations } from 'next-intl';
+import { stripTrailingSlashes } from '@kortix/sdk';
 
 import { cn } from '@/lib/utils';
 import React, { useState, useMemo, useCallback } from 'react';
@@ -179,7 +180,7 @@ export default function APIKeysPage() {
     label: '',
   });
   const queryClient = useQueryClient();
-  const activeInstanceUrl = getActiveOpenCodeUrl()?.replace(/\/+$/, '');
+  const activeInstanceUrl = stripTrailingSlashes(getActiveOpenCodeUrl() ?? '') || undefined;
 
   // ── Queries & mutations ────────────────────────────────────────────────
 

--- a/apps/web/src/components/projects/session-stream-keeper.tsx
+++ b/apps/web/src/components/projects/session-stream-keeper.tsx
@@ -2,12 +2,13 @@
 
 import { useEffect } from 'react';
 import { useParams } from 'next/navigation';
-import { useQuery } from '@tanstack/react-query';
-import type { Event as OpenCodeEvent } from '@kortix/sdk/opencode-client';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { getClientForUrl } from '@/lib/opencode-sdk';
 import { getSandboxUrlForExternalId } from '@/stores/server-store';
 import { listProjectSessions } from '@kortix/sdk/projects-client';
+import { openEventStream, type OpenCodeEvent } from '@kortix/sdk/event-stream';
+import type { Event as SyncStoreEvent } from '@kortix/sdk/opencode-client';
 import { useSyncStore } from '@/stores/opencode-sync-store';
 import {
   useProjectSessionTabsStore,
@@ -30,10 +31,17 @@ const EMPTY: string[] = [];
  *
  * Deliberately additive and isolated:
  *   - One stream per sandbox, each via its OWN per-URL client (getClientForUrl).
- *   - It only writes to the sync store — never the React Query cache, never the
- *     global active server — so it cannot disturb the active session.
+ *   - It only writes to the sync store — never the React Query cache (except
+ *     the session-list invalidation on park, below), never the global active
+ *     server — so it cannot disturb the active session.
  *   - The currently-viewed session is skipped (its route owns that stream).
- *   - Worst case (sandbox unreachable) it simply retries/no-ops.
+ *   - Streams ride the SDK's `openEventStream` primitive (connect timeout,
+ *     idle-heartbeat watchdog, exponential backoff), NOT a hand-rolled loop —
+ *     so a sandbox that is genuinely gone (archived/stopped while the session
+ *     list still claims `running`) PARKS after a bounded number of hard
+ *     failures instead of retrying 503s forever. On park we invalidate the
+ *     project's session list so the stale `running` status corrects itself
+ *     and this component unmounts the dead stream on the next render.
  */
 export function SessionStreamKeeper({ projectId }: { projectId: string }) {
   const tabs = useProjectSessionTabsStore((s) => s.tabsByProject[projectId]) ?? EMPTY;
@@ -58,6 +66,8 @@ function BackgroundSessionStream({
   projectId: string;
   sessionId: string;
 }) {
+  const queryClient = useQueryClient();
+
   // Derive the live sandbox URL from the project's session LIST (one shared
   // query across all tabs — React Query dedupes the key), NOT a per-tab call.
   // CRITICAL: a background tab must NEVER call /start — that provisions/wakes/
@@ -81,69 +91,34 @@ function BackgroundSessionStream({
     if (!externalId) return;
     const url = getSandboxUrlForExternalId(externalId);
     if (!url) return;
-    const controller = new AbortController();
-    void runBackgroundStream(url, sessionId, controller.signal);
-    return () => controller.abort();
-  }, [externalId, sessionId]);
 
-  return null;
-}
-
-/**
- * Consume a sandbox's SSE event stream and feed it into the sync store, with
- * exponential-backoff reconnect. Mirrors the active stream's consume loop but
- * intentionally minimal: no coalescing, no query-cache writes, no
- * notifications — just keep the session live.
- */
-async function runBackgroundStream(
-  url: string,
-  sessionId: string,
-  signal: AbortSignal,
-): Promise<void> {
-  let retry = 0;
-  while (!signal.aborted) {
-    try {
-      const client = getClientForUrl(url);
-      const result = await client.global.event({
-        signal,
-        sseDefaultRetryDelay: 3000,
-        sseMaxRetryDelay: 30000,
-      } as Parameters<typeof client.global.event>[0]);
-      const { stream } = result;
-      for await (const event of stream) {
-        if (signal.aborted) break;
-        const raw = event as unknown as { payload?: OpenCodeEvent } & OpenCodeEvent;
-        const e = (raw && typeof raw === 'object' && 'payload' in raw
-          ? raw.payload
-          : raw) as OpenCodeEvent | undefined;
-        if (!e?.type) continue;
+    const handle = openEventStream({
+      client: getClientForUrl(url),
+      onEvent: (e: OpenCodeEvent) => {
         try {
-          useSyncStore.getState().applyEvent(e);
+          // The stream's event union is a superset of the sync store's `Event`
+          // (the SDK adds a few members the store simply ignores in its switch)
+          // — same boundary cast the previous hand-rolled loop made.
+          useSyncStore.getState().applyEvent(e as unknown as SyncStoreEvent);
         } catch {
           /* one bad event shouldn't kill the stream */
         }
-      }
-      retry = 0;
-    } catch (err) {
-      if (signal.aborted) break;
-      logger.warn('[session-stream-keeper] background stream error', {
-        sessionId,
-        error: String(err),
-      });
-    }
-
-    if (signal.aborted) break;
-    const delay = Math.min(1000 * 2 ** Math.min(retry++, 5), 30000);
-    await new Promise<void>((resolve) => {
-      const timer = setTimeout(resolve, delay);
-      signal.addEventListener(
-        'abort',
-        () => {
-          clearTimeout(timer);
-          resolve();
-        },
-        { once: true },
-      );
+      },
+      onParked: ({ consecutiveFailures, lastError }) => {
+        // The sandbox is genuinely unreachable (archived/stopped/dead) — the
+        // stream has permanently stopped retrying. Refresh the session list so
+        // its stale `running` status corrects itself; this component then drops
+        // to `externalId = null` on the next render and stays quiet.
+        logger.warn('[session-stream-keeper] background stream parked — sandbox unreachable', {
+          sessionId,
+          consecutiveFailures,
+          error: String(lastError),
+        });
+        void queryClient.invalidateQueries({ queryKey: ['project-sessions', projectId] });
+      },
     });
-  }
+    return () => handle.close();
+  }, [externalId, sessionId, projectId, queryClient]);
+
+  return null;
 }

--- a/apps/web/src/hooks/scheduled-tasks/use-scheduled-tasks.ts
+++ b/apps/web/src/hooks/scheduled-tasks/use-scheduled-tasks.ts
@@ -1,4 +1,5 @@
 import { useAuth } from '@/features/providers/auth-provider';
+import { stripTrailingSlashes } from '@kortix/sdk';
 import { ensureSandbox, getSandboxUrl } from '@kortix/sdk/platform-client';
 import { getClientForUrl, triggersRequest } from '@kortix/sdk/opencode-client';
 import { getActiveOpenCodeUrl } from '@/stores/server-store';
@@ -187,10 +188,10 @@ async function resolveSandboxBaseUrl(_instanceId?: string | null): Promise<strin
   // The active session's runtime is the sandbox — the old per-instance registry
   // lookup is gone, so resolve straight from the current runtime.
   const activeBaseUrl = getActiveOpenCodeUrl();
-  if (activeBaseUrl) return activeBaseUrl.replace(/\/+$/, '');
+  if (activeBaseUrl) return stripTrailingSlashes(activeBaseUrl);
 
   const { sandbox } = await ensureSandbox();
-  return getSandboxUrl(sandbox).replace(/\/+$/, '');
+  return stripTrailingSlashes(getSandboxUrl(sandbox));
 }
 
 async function fetchTriggersJson<T>(

--- a/apps/whitelabel-demo/.env.example
+++ b/apps/whitelabel-demo/.env.example
@@ -1,0 +1,38 @@
+# Lumen ("Kortix as a Backend" reference) — two modes. See AGENTS.md.
+
+# ── Direct mode (default) ───────────────────────────────────────────────────
+# The browser talks straight to a Kortix deployment with a pasted PAT
+# (Settings → API keys, via the ApiKeyGate). No server env required.
+NEXT_PUBLIC_KORTIX_API_URL=https://api.kortix.com/v1
+
+# ── Wrapper mode ("Kortix as a Backend") ────────────────────────────────────
+# Set KORTIX_API_KEY (below) to flip this app into wrapper mode: a
+# server-side BFF proxy (`src/app/api/kortix/[...path]/route.ts`) holds this
+# key and re-authenticates every request against Lumen's OWN login session
+# instead of a pasted PAT. The client learns which mode is active from
+# `GET /api/mode` (see `src/app/providers.tsx`) — restart the dev/prod server
+# after changing these, no rebuild needed for the mode switch itself.
+
+# The org-wide Kortix API key used for ALL upstream calls in wrapper mode.
+# NEVER exposed to the browser — only read server-side by app/api/**.
+# KORTIX_API_KEY=kortix_pat_...
+
+# Upstream Kortix API base the proxy forwards to (include /v1 if that's your
+# deployment's convention — same shape as NEXT_PUBLIC_KORTIX_API_URL above).
+KORTIX_UPSTREAM=https://api.kortix.com/v1
+
+# HMAC secret Lumen uses to sign its OWN session tokens (see
+# src/server/auth.ts). Required in wrapper mode — any long random string.
+# SESSION_SECRET=change-me-to-a-long-random-string
+
+# Demo login password (src/server/auth.ts#checkDemoCredentials). If unset,
+# ANY non-empty password is accepted for ANY email-shaped string — this is a
+# demo auth flow, not a real user directory.
+# DEMO_PASSWORD=
+
+# Multiplier applied to raw Kortix gateway costs before showing "your price"
+# on /usage — the re-billing markup a real wrapper would charge its own users.
+COST_MARKUP=1.2
+
+# Per-user request budget (per minute) for the proxy's in-memory rate limiter.
+RATE_LIMIT_PER_MIN=300

--- a/apps/whitelabel-demo/.gitignore
+++ b/apps/whitelabel-demo/.gitignore
@@ -1,0 +1,2 @@
+# Wrapper-mode's local JSON user→project ownership store (src/server/users.ts).
+.lumen-data/

--- a/apps/whitelabel-demo/AGENTS.md
+++ b/apps/whitelabel-demo/AGENTS.md
@@ -13,23 +13,38 @@ stay true at all times:
 
 If a change violates either rule, it's wrong. Fix the rule, not the symptom.
 
+**Exception — the wrapper-mode BFF transport layer.** `src/server/**` and
+`src/app/api/**` (the `/api/kortix` proxy, `/api/auth/*`, `/api/usage`,
+`/api/preview-token`, `/api/mode`) are server-only transport code, not app
+code — raw `fetch`/`node:crypto`/`node:fs` are correct there, the same way
+they're correct *inside* `@kortix/sdk` itself. Rule 1 still governs every
+client component: the browser only ever talks to Kortix through
+`@kortix/sdk`, pointed at `/api/kortix` instead of a real Kortix deployment
+when wrapper mode is on (`src/lib/kortix.ts#configureWrapperMode`).
+
 ## UI rules (strict shadcn)
 
 - **Use shadcn primitives, always.** Buttons → `Button`, inputs → `Input`/
   `Textarea`, menus → `DropdownMenu`, dialogs → `Dialog`, tabs → `Tabs`, lists/
   cards → `Card`, badges → `Badge`, tooltips → `Tooltip`, scroll regions →
-  `ScrollArea` / `MessageScroller`. Do **not** hand-roll a styled `<button>`,
-  `<input>`, or ad-hoc dropdown when the primitive exists.
-- **Chat is built from the shadcn chat primitives:**
-  - `MessageScroller*` — the chat transcript container (auto-scroll, follow
-    streaming, jump-to). Replaces manual `scrollRef` logic.
-  - `Message` + `MessageAvatar` / `MessageContent` / `MessageHeader` /
-    `MessageFooter` — one row per turn (`align="end"` for the user,
-    `"start"` for the agent).
-  - `Bubble` + `BubbleContent` — the message surface (`variant` + `align`).
-  - `Marker` + `MarkerIcon` / `MarkerContent` — inline tool-call / status /
-    "thinking" rows and labeled separators.
-  - `Attachment*` — files in the composer and in messages.
+  `ScrollArea`. Do **not** hand-roll a styled `<button>`, `<input>`, or ad-hoc
+  dropdown when the primitive exists.
+- **Chat is built from the shadcn chat primitives that exist in this app
+  (`src/components/ui/`):**
+  - `Message` + `MessageGroup` / `MessageAvatar` / `MessageContent` /
+    `MessageHeader` / `MessageFooter` (`message.tsx`) — one row per turn
+    (`align="end"` for the user, `"start"` for the agent).
+  - `Bubble` + `BubbleContent` / `BubbleReactions` / `BubbleGroup`
+    (`bubble.tsx`) — the message surface (`variant` + `align`).
+  - `Marker` + `MarkerIcon` / `MarkerContent` (`marker.tsx`) — inline tool-call
+    / status / "thinking" rows and labeled separators.
+  - The transcript container itself is a plain `scrollRef` + `scrollTo` effect
+    (`workbench-tabs.tsx`), not a dedicated primitive — there is no
+    `MessageScroller` or `Attachment` component in this app. Don't add code
+    that imports either; if a chat surface needs file attachments or a
+    fancier auto-scroll/jump-to container, build it as a new primitive under
+    `src/components/ui/` to the shadcn API shape (see "Adding shadcn
+    components" below), not as bespoke markup in a feature component.
 - **Streaming/pending text uses the `shimmer` util**; scroll containers that need
   soft edges use the `scroll-fade` util (both in `globals.css`).
 - **Styling:** Tailwind v4 + the theme tokens in `globals.css` only. Compose
@@ -48,20 +63,23 @@ If a change violates either rule, it's wrong. Fix the rule, not the symptom.
 pnpm dlx shadcn@latest add <name>      # e.g. button, dialog, message, bubble
 ```
 
-The newest chat primitives (`message`, `message-scroller`, `bubble`, `marker`,
-`attachment`) and the `shimmer` / `scroll-fade` utils are part of this app. If the
-public registry can't resolve one yet, the equivalent lives in
-`src/components/ui/` built to the **exact documented shadcn API** — drop-in, so a
-later `shadcn add` overwrites cleanly. Never fork the API.
+The chat primitives this app actually has (`message`, `bubble`, `marker`) and
+the `shimmer` / `scroll-fade` utils are part of this app. If the public
+registry can't resolve one yet, the equivalent lives in `src/components/ui/`
+built to the **exact documented shadcn API** — drop-in, so a later `shadcn add`
+overwrites cleanly. Never fork the API.
 
 ## Structure
 
-- `src/lib/kortix.ts` — the one SDK client (`createKortix`). Never instantiate
-  another.
+- `src/lib/kortix.ts` — the one SDK client (`createKortix`), plus
+  `configureWrapperMode()` to re-point it at the BFF proxy.
 - `src/components/ui/` — shadcn primitives only (generated or built-to-spec).
 - `src/components/chat/` — chat surface composed from the chat primitives.
 - `src/components/workbench/` — the session workbench (header, tabs, panels).
 - `src/app/**` — routes; thin, delegate to components.
+- `src/app/api/**` + `src/server/**` — wrapper-mode-only transport (BFF proxy,
+  demo auth, route policy, rate limiting). See the exception above; this is
+  the one place raw `fetch`/`node:crypto` is correct.
 
 ## Quality bar
 

--- a/apps/whitelabel-demo/README.md
+++ b/apps/whitelabel-demo/README.md
@@ -124,6 +124,17 @@ the result (`session.messages`, `session.send`, `session.isBusy`,
 The transcript itself scrolls via a plain `scrollRef` + `scrollTo` effect
 (`workbench-tabs.tsx`) — there's no dedicated scroll-container primitive.
 
+**Message rendering** goes through the SDK's headless chat kit: `classifyTurn`
+(`@kortix/sdk/turns`) normalizes every opencode part type into a typed
+`ClassifiedPart` (plus a normalized error for failed turns), and `renderParts`
+(`@kortix/sdk/react`) requires a renderer for every kind at compile time — see
+`src/components/chat/message-view.tsx`, the living reference the SDK README
+points at (one deliberate rendering decision per part kind, including the
+`null`s). For focused, runnable snippets of this and the other core SDK flows —
+send + stream, the wrapper-mode server pattern, cost pass-through, files +
+secrets — see **`packages/sdk/examples/`** (each file's header states how to
+run it).
+
 **Model selection** is server-side and pre-runtime, so it works before a
 sandbox exists and shares one source of truth between the new-session screen
 and the in-session picker: `useProjectModels(projectId)` reads the project's

--- a/apps/whitelabel-demo/README.md
+++ b/apps/whitelabel-demo/README.md
@@ -3,10 +3,43 @@
 A complete, production-shaped agent client built **100% on `@kortix/sdk`**. It
 is the golden reference for using Kortix as your backend: projects, sessions,
 and **real, token-by-token streaming agent chat** — with zero raw `fetch`, zero
-`@opencode-ai/sdk` imports, and no transport code in the app itself.
+`@opencode-ai/sdk` imports, and no transport code in the app itself (see
+"Two modes" below for the one deliberate, documented exception).
 
 Rebrand `src/config/brand.ts`, point `NEXT_PUBLIC_KORTIX_API_URL` at your Kortix
 backend, and you have a white-label coding agent.
+
+## Two modes: use Kortix as your backend, behind your own backend
+
+Lumen runs in either of two modes, picked up from the server environment —
+`GET /api/mode` — with no rebuild needed to switch:
+
+- **Direct mode** (default, no server env required). The browser holds a pasted
+  Kortix API key (`kortix_pat_…`) in `localStorage` and the SDK talks straight
+  to `NEXT_PUBLIC_KORTIX_API_URL`. See "Auth" below.
+- **Wrapper mode** — the headline capability this reference demonstrates:
+  running Kortix *behind your own backend*. Set `KORTIX_API_KEY` on the server
+  and Lumen flips into a BFF:
+  - End users log in through Lumen's **own** demo auth (`/api/auth/*`) — signed
+    HMAC session tokens (`src/server/auth.ts`), not a Kortix credential.
+  - Every SDK call is re-pointed at the same-origin proxy `/api/kortix/[...path]`
+    (`src/lib/kortix.ts#configureWrapperMode`), which injects the real
+    `KORTIX_API_KEY` server-side — end users and their browsers never see it.
+  - The proxy enforces **per-user project isolation** (`src/server/users.ts`) and
+    an explicit allow/deny **route policy** (`src/server/policy.ts`, deny-by-default)
+    before forwarding, plus a per-user **rate limiter** (`src/server/rate-limit.ts`).
+  - Preview iframes can't go through that proxy — a Next.js route handler can't
+    forward a WebSocket upgrade, and a live dev server's HMR socket needs one —
+    so `/api/preview-token` mints a short-lived, **project-scoped** Kortix PAT
+    for the iframe to use directly against the upstream.
+  - `/usage` shows per-session LLM + compute cost pulled straight from the
+    gateway, with a `COST_MARKUP` multiplier applied — the re-billing surface a
+    real wrapper would charge its own users.
+  - `.env.example` documents every variable for both modes.
+
+See `AGENTS.md` for the one rule change this adds: `src/server/**` and
+`src/app/api/**` are server-only transport code and are exempt from the
+SDK-only rule, the same way raw `fetch` is correct *inside* `@kortix/sdk` itself.
 
 ## What it demonstrates
 
@@ -16,18 +49,23 @@ backend, and you have a white-label coding agent.
 | `/account` | accounts + members + invites (`accounts.*`, `projects.listForAccount`) |
 | `/projects/[id]` | new-session onboarding (`sessions.create`, `sandboxTemplates`, `onboardingComplete`) |
 | `/projects/[id]/sessions/[sessionId]` | chat · Files · Changes · Preview tabs + session actions |
-| `/projects/[id]/settings` | General · Secrets · Members · Connectors · Triggers · Policies |
+| `/projects/[id]/settings` | General · Capabilities · Secrets · Members · Connectors · Triggers · Policies |
+| `/usage` | wrapper-mode only — per-session LLM + compute cost, marked up (`/api/usage`) |
 
-### Full facade coverage
+### Facade coverage
 
-This reference exercises **the entire `@kortix/sdk` facade** — every method has a
-real UI surface (a deliberate goal so nothing is left undemonstrated):
+This reference exercises **the core `@kortix/sdk` facade a chat-first product
+needs** — every method listed below has a real UI surface (a deliberate goal
+so nothing in this list is left undemonstrated). Newer platform-admin surfaces
+— Review Center, Approvals, Gateway observability, Slack/email/Meet channels,
+project apps/deployments — aren't part of this lightweight reference; they live
+in `apps/web`:
 
 - **accounts** (`/account`): `list/get/create/updateName/leave/members/invite/removeMember/updateMemberRole/invites`
 - **projects**: `list/listForAccount/provision/get/detail/update/archive/llmCatalog/sandboxHealth/sandboxTemplates`
 - **project(id)**: `onboardingComplete` · `secrets.{list,upsert,remove,setPersonal,removePersonal,setGitCredential}` · `access.{list,invite,update,revoke,requests,approveRequest,rejectRequest,pendingInvites,resendInvite,revokeInvite,groupGrants}` · `connectors.{list,config,create,remove,sync}` · `policies.{list,set}` · `triggers.{list,create,update,remove,fire,setActivation}` · `files.{list,read,search,history,archive}` · `git.{commits,commit,commitDiff,branches,versionDiff}` · `changeRequests.{list,get,diff,mergePreview,open,merge,close,reopen}`
-- **session(pid,sid)**: `get/update/delete/start/restart/setSharing/previews/commit · publicShares.{list,create,revoke} · health/previewUrl/proxyUrl/setModel/send/abort`
-- **react** (`@kortix/sdk/react`): `useSessionSync`, `useSendOpenCodeMessage`/`useAbortOpenCodeSession`, `OpenCodeEventStreamProvider`, `useSandboxConnection`, `useOpenCodePendingStore` (questions/permissions), `useOpenCodeLocal`/`useOpenCodeProviders`/`useVisibleAgents`/`useOpenCodeConfig`, `useCanonicalOpenCodeSession`, `replyToQuestion`/`replyToPermission`
+- **session(pid,sid)**: `get/update/delete/start/restart/setSharing/previews/commit · publicShares.{list,create,revoke} · health/previewUrl/proxyUrl/setModel/send/abort/stream` (`stream` is the framework-free SSE facade for non-React hosts — a server-side wrapper, worker, or CLI; React hosts get the same events through `useSession`)
+- **react** (`@kortix/sdk/react`): `useSession(projectId, sessionId)` — the one hook powering the workbench (start/switch/SSE/canonical id/messages/send/abort/questions/permissions/models/agents/picks), see "The chat runtime" below — plus `useProjectModels`/`useVisibleAgents`/`useProjectConfig`/`writeStartStash` (new-session onboarding, `/projects/[id]`) and `answerQuestion`/`answerPermission` (interactive-prompt replies, called directly by `question-prompt.tsx`/`permission-prompt.tsx`)
 
 Every Kortix call goes through the one client created in `src/lib/kortix.ts`:
 
@@ -40,54 +78,62 @@ export const kortix = createKortix({
 });
 ```
 
-## Auth: one API key
+## Auth
 
-The whole auth story is `getToken`. Lumen stores a single Kortix **API key**
-(`kortix_pat_…`) in `localStorage` and hands it to the SDK. Create one in the
-Kortix dashboard under **Settings → API keys** (account-wide, or scoped to a
-single project). No Supabase, no sessions table, no cookies. See
-`src/components/api-key-gate.tsx` and `src/lib/kortix.ts`.
+The whole auth story is `getToken` — the SDK doesn't care where the token
+comes from, only that `getToken()` returns one.
 
-## The reactive chat stack
+- **Direct mode.** Lumen stores a single Kortix **API key** (`kortix_pat_…`) in
+  `localStorage` and hands it to the SDK. Create one in the Kortix dashboard
+  under **Settings → API keys** (account-wide, or scoped to a single project).
+  No Supabase, no sessions table, no cookies. See `src/components/api-key-gate.tsx`
+  and `src/lib/kortix.ts`.
+- **Wrapper mode.** `getToken` instead returns Lumen's own signed session token
+  (`src/lib/session.ts`, minted by `POST /api/auth/login` — see `src/server/auth.ts`
+  and `src/components/login-gate.tsx`). The Kortix API key never reaches the
+  browser at all; it's read only by `src/app/api/**` route handlers.
 
-Opening a session is the only non-trivial flow. The SDK owns every moving part;
-the app just composes them in order (`sessions/[sessionId]/page.tsx`):
+## The chat runtime
 
-1. **Start** — poll `kortix.session(pid, sid).start(15_000)` until
-   `stage === 'ready'`. The server long-polls, so "ready" arrives the instant the
-   sandbox + OpenCode runtime are up. It returns the sandbox row and the
-   canonical OpenCode session id (`opencode_session_id`).
-2. **Switch** — `switchToSessionSandboxAsync(pid, sid, sandbox)` (from
-   `@kortix/sdk/server-store`) points the SDK's active runtime at this session's
-   sandbox. After this, every react hook talks to it.
-3. **Connect** — `<SessionRuntime>` (`src/lib/runtime.tsx`) mounts
-   `useSandboxConnection()` (polls `/kortix/health`, flips the connection store to
-   `healthy`) and `<OpenCodeEventStreamProvider />` (opens the live SSE stream).
-4. **Resolve** — `useCanonicalOpenCodeSession({ projectId, sessionId, pinFromStart })`
-   yields the OpenCode root session id to bind the chat to.
-5. **Sync + send** — `useSessionSync(rootId)` returns live `messages` / `status`
-   (fed by SSE, gated on `healthy`); `useSendOpenCodeMessage()` sends a prompt;
-   `useAbortOpenCodeSession()` stops a run.
+Opening a session is the only non-trivial flow, and it's collapsed into **one
+hook**: `useSession(projectId, sessionId)` from `@kortix/sdk/react`. The host
+(`src/app/projects/[id]/sessions/[sessionId]/page.tsx`) calls it once, reads
+`session.phase`, and renders — nothing sandbox-shaped leaks into the component:
 
-```
-start() ─ready─▶ switchToSessionSandboxAsync
-                          │
-              ┌───────────┴───────────┐
-   useSandboxConnection()   OpenCodeEventStreamProvider   (SessionRuntime)
-              │                        │
-              └─ healthy=true ─▶ useSessionSync(rootId) ◀─ SSE events
-                                       │
-                       useSendOpenCodeMessage / useAbortOpenCodeSession
+```tsx
+const session = useSession(projectId, sessionId);
+
+return session.phase !== 'ready'
+  ? <BootScreen stage={session.stage} reason={session.reason} onRetry={session.retry} />
+  : <WorkbenchTabs session={session} projectId={projectId} sessionId={sessionId} />;
 ```
 
-**Model selection** uses the SDK's own model layer rather than reimplementing
-the catalog rules (mixed gateway/BYOK key formats, per-family "latest",
-connected-provider gating are all subtle). `useOpenCodeProviders()` +
-`useVisibleAgents()` + `useOpenCodeConfig()` feed `useOpenCodeLocal()`, which
-resolves `model.list` (selectable models) and `model.current` / `model.currentKey`.
-The picker `set()`s the choice; the workbench passes `model.currentKey` to
-`useSendOpenCodeMessage({ options: { model } })`. Omit it and the agent uses its
-configured default. See `src/components/chat/model-picker.tsx`.
+Internally the hook drives, in order: `/start` (server long-poll until
+`stage === 'ready'`, returning the sandbox row + canonical
+`opencode_session_id`) → pointing the SDK's active runtime at that sandbox →
+the live SSE event stream → resolving the canonical OpenCode root session id →
+message sync (`messages`/`status`/`diffs`/`todos`) → the interactive
+questions/permissions store → server-side capabilities (`models`, `agents`,
+`commands`) → per-session model/agent picks → the `send`/`cancel`/`runCommand`
+mutations. The host never imports a sandbox switcher, a health poller, or an
+event-stream provider — `useSession` is the whole contract. See
+`packages/sdk/src/react/use-session.ts` for the implementation and
+`src/components/workbench/workbench-tabs.tsx` for how the chat thread consumes
+the result (`session.messages`, `session.send`, `session.isBusy`,
+`session.questions`/`.permissions`, `session.runtimePhase` for reconnect UI).
+The transcript itself scrolls via a plain `scrollRef` + `scrollTo` effect
+(`workbench-tabs.tsx`) — there's no dedicated scroll-container primitive.
+
+**Model selection** is server-side and pre-runtime, so it works before a
+sandbox exists and shares one source of truth between the new-session screen
+and the in-session picker: `useProjectModels(projectId)` reads the project's
+gateway catalog (`GET /projects/:id/llm-catalog`) and flattens it to
+`FlatModel[]`, sidestepping mixed gateway/BYOK key formats and per-family
+"latest" resolution. `useSession` exposes this as `session.models` and the pick
+as `session.picks.model` / `session.picks.setModel`; `ModelPicker` is a plain
+controlled component over that. Omit a model on `send` and the agent uses its
+configured default. See `src/components/chat/model-picker.tsx` and
+`packages/sdk/src/react/use-project-models.ts`.
 
 ## Run it
 
@@ -98,14 +144,22 @@ NEXT_PUBLIC_KORTIX_API_URL=https://api.kortix.com/v1 \
 ```
 
 Point `NEXT_PUBLIC_KORTIX_API_URL` at a local stack (`http://localhost:8008/v1`)
-to develop against it. Then open the app, paste an API key, and go.
+to develop against it. Then open the app, paste an API key, and go — that's
+direct mode.
+
+To try **wrapper mode** instead, set the variables `.env.example` documents
+under "Wrapper mode" (`KORTIX_API_KEY`, `KORTIX_UPSTREAM`, `SESSION_SECRET`, and
+optionally `DEMO_PASSWORD`/`COST_MARKUP`/`RATE_LIMIT_PER_MIN`), restart the
+server, and log in through the app's own demo login instead of pasting a key.
 
 ## Make it yours
 
 - **Brand** — `src/config/brand.ts` (name, tagline, accent, API URL).
 - **Theme** — `src/app/globals.css` (`@theme` tokens).
-- **Auth** — swap the API-key gate in `src/lib/kortix.ts`'s `getToken` for your
-  own (OAuth, session cookie, server-minted token — anything that returns a
-  string).
+- **Auth** — in direct mode, swap the API-key gate in `src/lib/kortix.ts`'s
+  `getToken` for your own (OAuth, session cookie, server-minted token —
+  anything that returns a string). In wrapper mode, swap the demo credential
+  check in `src/server/auth.ts#checkDemoCredentials` for your real user
+  directory — the session-signing and BFF-proxy plumbing around it stays as-is.
 
 Nothing else couples to Kortix. The SDK is the only backend dependency.

--- a/apps/whitelabel-demo/package.json
+++ b/apps/whitelabel-demo/package.json
@@ -8,7 +8,9 @@
     "dev": "next dev --port ${WHITELABEL_PORT:-3010}",
     "build": "next build",
     "start": "next start --port ${WHITELABEL_PORT:-3010}",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "bun test tests/e2e",
+    "test:e2e": "bun test tests/e2e"
   },
   "dependencies": {
     "@kortix/sdk": "workspace:*",

--- a/apps/whitelabel-demo/src/app/account/page.tsx
+++ b/apps/whitelabel-demo/src/app/account/page.tsx
@@ -6,6 +6,7 @@ import { InvitesSection } from '@/components/account/invites-section';
 import { MembersSection } from '@/components/account/members-section';
 import { ProjectsSection } from '@/components/account/projects-section';
 import { ApiKeyGate } from '@/components/api-key-gate';
+import { BrandMark } from '@/components/brand-mark';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { Separator } from '@/components/ui/separator';
@@ -15,8 +16,45 @@ import { useQuery } from '@tanstack/react-query';
 import { ArrowLeft, Loader2 } from 'lucide-react';
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
+import { useWrapperMode } from '../providers';
 
+/**
+ * Account administration (members, invites, billing) is operator-only in
+ * wrapper mode — see `src/server/policy.ts`'s `/accounts*` rule. Rather than
+ * render a page whose every query 403s, wrapper mode gets a short explainer
+ * back to the dashboard. Direct mode is unchanged.
+ */
 export default function AccountPage() {
+  const wrapperMode = useWrapperMode();
+  if (wrapperMode) return <WrapperAccountNotice />;
+  return <DirectAccountPage />;
+}
+
+function WrapperAccountNotice() {
+  return (
+    <div className="grid min-h-dvh place-items-center bg-background px-4">
+      <Card className="w-full max-w-sm p-6 text-center">
+        <BrandMark className="mx-auto mb-4" />
+        <h1 className="text-lg font-semibold tracking-tight">Not available in wrapper mode</h1>
+        <p className="mt-1.5 text-sm text-muted-foreground">
+          This app&apos;s wrapper backend manages the underlying Kortix account on your behalf —
+          end users don&apos;t get direct account administration. See{' '}
+          <Link href="/usage" className="underline">
+            Usage
+          </Link>{' '}
+          for the cost pass-through surface instead.
+        </p>
+        <Button asChild className="mt-5 gap-2">
+          <Link href="/">
+            <ArrowLeft className="size-4" /> Back to projects
+          </Link>
+        </Button>
+      </Card>
+    </div>
+  );
+}
+
+function DirectAccountPage() {
   const [ready, setReady] = useState<boolean | null>(null);
   useEffect(() => setReady(!!getApiKey()), []);
 
@@ -34,7 +72,7 @@ export default function AccountPage() {
 function AccountSettings() {
   // accounts.list — the switcher + the source for the default selection.
   const accountsQ = useQuery({ queryKey: ['accounts'], queryFn: () => kortix.accounts.list() });
-  const accounts = (accountsQ.data as any[]) ?? [];
+  const accounts = accountsQ.data ?? [];
 
   const [accountId, setAccountId] = useState<string | null>(null);
 

--- a/apps/whitelabel-demo/src/app/api/auth/login/route.ts
+++ b/apps/whitelabel-demo/src/app/api/auth/login/route.ts
@@ -1,0 +1,58 @@
+/**
+ * Wrapper-mode login: email + (any password, or `DEMO_PASSWORD` if set — see
+ * `checkDemoCredentials`). No user directory; `userId` is just the email.
+ *
+ * Returns the signed session token in the JSON body (the client stores it and
+ * sends it as `Authorization: Bearer …` for the SDK's REST/SSE calls) AND sets
+ * it as an HttpOnly cookie (so the preview iframe's same-origin requests,
+ * which can't attach headers, still carry a valid session).
+ */
+
+import { SESSION_COOKIE_NAME, checkDemoCredentials, signSession } from '@/server/auth';
+import type { NextRequest } from 'next/server';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const SESSION_MAX_AGE_SECONDS = 60 * 60 * 24 * 7; // 7 days — matches signSession's TTL
+
+export async function POST(req: NextRequest) {
+  if (!process.env.KORTIX_API_KEY) {
+    return Response.json({ error: 'Wrapper mode is not enabled on this server.' }, { status: 500 });
+  }
+
+  let body: { email?: unknown; password?: unknown };
+  try {
+    body = await req.json();
+  } catch {
+    return Response.json({ error: 'Invalid request body' }, { status: 400 });
+  }
+
+  const email = typeof body.email === 'string' ? body.email.trim().toLowerCase() : '';
+  const password = typeof body.password === 'string' ? body.password : '';
+
+  if (!checkDemoCredentials(email, password)) {
+    return Response.json({ error: 'Invalid email or password' }, { status: 401 });
+  }
+
+  let token: string;
+  try {
+    token = signSession(email);
+  } catch (err) {
+    return Response.json({ error: (err as Error).message }, { status: 500 });
+  }
+
+  const res = Response.json({ token, userId: email });
+  res.headers.append(
+    'Set-Cookie',
+    [
+      `${SESSION_COOKIE_NAME}=${encodeURIComponent(token)}`,
+      'Path=/',
+      `Max-Age=${SESSION_MAX_AGE_SECONDS}`,
+      'HttpOnly',
+      'SameSite=Lax',
+      ...(process.env.NODE_ENV === 'production' ? ['Secure'] : []),
+    ].join('; '),
+  );
+  return res;
+}

--- a/apps/whitelabel-demo/src/app/api/auth/logout/route.ts
+++ b/apps/whitelabel-demo/src/app/api/auth/logout/route.ts
@@ -1,0 +1,13 @@
+import { SESSION_COOKIE_NAME } from '@/server/auth';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function POST() {
+  const res = Response.json({ ok: true });
+  res.headers.append(
+    'Set-Cookie',
+    `${SESSION_COOKIE_NAME}=; Path=/; Max-Age=0; HttpOnly; SameSite=Lax`,
+  );
+  return res;
+}

--- a/apps/whitelabel-demo/src/app/api/auth/me/route.ts
+++ b/apps/whitelabel-demo/src/app/api/auth/me/route.ts
@@ -1,0 +1,11 @@
+import { getRequestSession } from '@/server/auth';
+import type { NextRequest } from 'next/server';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET(req: NextRequest) {
+  const session = getRequestSession(req);
+  if (!session) return Response.json({ error: 'Not authenticated' }, { status: 401 });
+  return Response.json({ userId: session.userId });
+}

--- a/apps/whitelabel-demo/src/app/api/kortix/[...path]/route.ts
+++ b/apps/whitelabel-demo/src/app/api/kortix/[...path]/route.ts
@@ -74,12 +74,20 @@ async function handle(req: NextRequest, ctx: { params: Promise<{ path?: string[]
   headers.delete('cookie'); // the app session cookie is ours, never upstream's
   headers.set('authorization', `Bearer ${apiKey}`);
 
+  // Buffer the request body instead of streaming it (`body: req.body,
+  // duplex: 'half'`): a streamed body has no Content-Length, so undici sends
+  // it with `Transfer-Encoding: chunked` — and the sandbox proxy's inner load
+  // balancer (AWS ALB fronting the Daytona runtime) rejects chunked request
+  // bodies with a bare HTML 400. Every request body on this surface is small
+  // JSON (or a modest FormData upload), so buffering is safe; RESPONSE bodies
+  // below still stream untouched, which is what SSE and long-lived runtime
+  // GETs actually need.
   const hasBody = req.method !== 'GET' && req.method !== 'HEAD';
-  const init: RequestInit & { duplex?: 'half' } = {
+  const init: RequestInit = {
     method: req.method,
     headers,
     redirect: 'manual',
-    ...(hasBody ? { body: req.body, duplex: 'half' } : {}),
+    ...(hasBody ? { body: await req.arrayBuffer() } : {}),
   };
 
   let upstreamRes: Response;

--- a/apps/whitelabel-demo/src/app/api/kortix/[...path]/route.ts
+++ b/apps/whitelabel-demo/src/app/api/kortix/[...path]/route.ts
@@ -1,0 +1,134 @@
+/**
+ * The wrapper-mode BFF proxy: `${origin}/api/kortix/*` → `${KORTIX_UPSTREAM}/*`.
+ *
+ * This is the one place in the app that talks to Kortix with a raw `fetch`
+ * instead of `@kortix/sdk` — by design (see AGENTS.md: transport code inside
+ * `src/server/` + `app/api/` is exempt from the "SDK only" rule; it's what the
+ * SDK itself talks to). Everything else in the app still goes through
+ * `@kortix/sdk`, just pointed at THIS route as its `backendUrl` in wrapper
+ * mode (`src/lib/kortix.ts#configureWrapperMode`).
+ *
+ * Order of operations, each one able to short-circuit with an error response:
+ *   1. `KORTIX_API_KEY` must be configured (wrapper mode must actually be on).
+ *   2. The caller must carry a valid Lumen app session (bearer or cookie).
+ *   3. Per-user rate limit.
+ *   4. `evaluatePolicy` — the explicit allow/deny table in `server/policy.ts`.
+ *   5. Forward to upstream with the Kortix API key substituted in for
+ *      Authorization — the end user's own session token NEVER reaches Kortix.
+ *
+ * Streaming: the response body is passed straight through
+ * (`new Response(upstreamRes.body, …)`) for everything except the two routes
+ * that need a tiny JSON rewrite (`filterProjectsList`, `recordProvisionOwner`)
+ * — those bodies are small, one-shot JSON, never SSE/long-lived, so buffering
+ * them is safe. Nothing else is buffered: this is what keeps the SSE event
+ * stream and long-lived sandbox-runtime GETs working.
+ */
+
+import { getRequestSession } from '@/server/auth';
+import { evaluatePolicy } from '@/server/policy';
+import { consumeRateLimit } from '@/server/rate-limit';
+import { addOwnedProject, isOwner, listOwnedProjects } from '@/server/users';
+import type { NextRequest } from 'next/server';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+function upstreamBase(): string {
+  return (process.env.KORTIX_UPSTREAM ?? 'https://api.kortix.com/v1').replace(/\/+$/, '');
+}
+
+function jsonError(status: number, error: string, extraHeaders?: HeadersInit) {
+  return Response.json({ error }, { status, headers: extraHeaders });
+}
+
+async function handle(req: NextRequest, ctx: { params: Promise<{ path?: string[] }> }) {
+  const apiKey = process.env.KORTIX_API_KEY;
+  if (!apiKey) {
+    return jsonError(500, 'Wrapper mode is not enabled on this server (KORTIX_API_KEY is unset).');
+  }
+
+  const session = getRequestSession(req);
+  if (!session) return jsonError(401, 'Not authenticated');
+
+  const limited = consumeRateLimit(session.userId);
+  if (!limited.ok) {
+    return jsonError(429, 'Rate limit exceeded', {
+      'Retry-After': String(Math.ceil((limited.retryAfterMs ?? 1000) / 1000)),
+    });
+  }
+
+  const { path = [] } = await ctx.params;
+  const upstreamPath = path.join('/');
+
+  const policy = evaluatePolicy(req.method, upstreamPath, (projectId) =>
+    isOwner(session.userId, projectId),
+  );
+  if (!policy.allow) return jsonError(policy.status, policy.reason);
+
+  const url = new URL(req.url);
+  const upstreamUrl = `${upstreamBase()}/${upstreamPath}${url.search}`;
+
+  const headers = new Headers(req.headers);
+  headers.delete('host');
+  headers.delete('content-length');
+  headers.delete('cookie'); // the app session cookie is ours, never upstream's
+  headers.set('authorization', `Bearer ${apiKey}`);
+
+  const hasBody = req.method !== 'GET' && req.method !== 'HEAD';
+  const init: RequestInit & { duplex?: 'half' } = {
+    method: req.method,
+    headers,
+    redirect: 'manual',
+    ...(hasBody ? { body: req.body, duplex: 'half' } : {}),
+  };
+
+  let upstreamRes: Response;
+  try {
+    upstreamRes = await fetch(upstreamUrl, init);
+  } catch {
+    return jsonError(502, 'Upstream request failed');
+  }
+
+  // Buffered post-processing — only for the two ownership-tracking routes.
+  if (policy.filterProjectsList || policy.recordProvisionOwner) {
+    const text = await upstreamRes.text();
+    let body: unknown;
+    let isJson = true;
+    try {
+      body = text ? JSON.parse(text) : null;
+    } catch {
+      isJson = false;
+    }
+
+    if (!isJson) {
+      // Upstream didn't return JSON (e.g. an error page) — pass the raw text
+      // through unchanged rather than risk mangling it.
+      return new Response(text, {
+        status: upstreamRes.status,
+        headers: { 'content-type': upstreamRes.headers.get('content-type') ?? 'text/plain' },
+      });
+    }
+
+    if (policy.recordProvisionOwner && upstreamRes.ok) {
+      const projectId = (body as { project_id?: string } | null)?.project_id;
+      if (projectId) addOwnedProject(session.userId, projectId);
+    }
+
+    if (policy.filterProjectsList && Array.isArray(body)) {
+      const owned = new Set(listOwnedProjects(session.userId));
+      body = body.filter((item) => owned.has((item as { project_id?: string })?.project_id ?? ''));
+    }
+
+    return Response.json(body, { status: upstreamRes.status });
+  }
+
+  // Everything else — stream straight through, unbuffered.
+  const outHeaders = new Headers(upstreamRes.headers);
+  outHeaders.delete('content-encoding');
+  outHeaders.delete('content-length');
+  outHeaders.delete('set-cookie'); // upstream's own cookies are meaningless on our origin
+
+  return new Response(upstreamRes.body, { status: upstreamRes.status, headers: outHeaders });
+}
+
+export { handle as DELETE, handle as GET, handle as PATCH, handle as POST, handle as PUT };

--- a/apps/whitelabel-demo/src/app/api/mode/route.ts
+++ b/apps/whitelabel-demo/src/app/api/mode/route.ts
@@ -1,0 +1,17 @@
+/**
+ * The mode bootstrap: tells the client whether this server is running in
+ * wrapper mode (`KORTIX_API_KEY` set) or direct mode. `Providers` fetches this
+ * once on load, before any Kortix data call, and configures the SDK
+ * accordingly — see `src/app/providers.tsx` + `src/lib/kortix.ts`.
+ *
+ * Deriving this from the server env (rather than a client-only
+ * `NEXT_PUBLIC_*` flag) means there's exactly one source of truth: whichever
+ * mode the proxy route itself will actually enforce.
+ */
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  return Response.json({ wrapperMode: !!process.env.KORTIX_API_KEY });
+}

--- a/apps/whitelabel-demo/src/app/api/preview-token/route.ts
+++ b/apps/whitelabel-demo/src/app/api/preview-token/route.ts
@@ -21,7 +21,7 @@
 
 import { getRequestSession } from '@/server/auth';
 import { consumeRateLimit } from '@/server/rate-limit';
-import { isOwner } from '@/server/users';
+import { isOwner, isValidProjectId } from '@/server/users';
 import type { NextRequest } from 'next/server';
 
 export const runtime = 'nodejs';
@@ -44,7 +44,9 @@ export async function GET(req: NextRequest) {
   if (!limited.ok) return Response.json({ error: 'Rate limit exceeded' }, { status: 429 });
 
   const projectId = new URL(req.url).searchParams.get('projectId');
-  if (!projectId) return Response.json({ error: 'projectId is required' }, { status: 400 });
+  if (!projectId || !isValidProjectId(projectId)) {
+    return Response.json({ error: 'projectId is required' }, { status: 400 });
+  }
   if (!isOwner(session.userId, projectId)) {
     return Response.json({ error: "You don't have access to this project." }, { status: 403 });
   }

--- a/apps/whitelabel-demo/src/app/api/preview-token/route.ts
+++ b/apps/whitelabel-demo/src/app/api/preview-token/route.ts
@@ -1,0 +1,76 @@
+/**
+ * Mint a short-lived, PROJECT-SCOPED Kortix PAT for the preview iframe.
+ *
+ * Why this exists: a Next.js route handler can't proxy a WebSocket upgrade,
+ * so the generic `/api/kortix/*` proxy can't carry a live dev server's HMR
+ * socket (or anything else the sandbox serves over `ws://`). Instead, the
+ * preview panel (in wrapper mode) opens the sandbox preview URL DIRECTLY
+ * against `KORTIX_UPSTREAM`, authenticated with a token minted here —
+ * `POST {upstream}/projects/:id/cli-token` using the operator's own
+ * `KORTIX_API_KEY` — scoped to exactly the one project the caller owns.
+ *
+ * Ownership is checked BEFORE minting: a wrapper end user can only ever get a
+ * token scoped to a project `isOwner()` confirms is theirs.
+ *
+ * Known tradeoff (documented, not silently ignored): this demo does not track
+ * or revoke the minted `token_id`. A production wrapper should persist it and
+ * `DELETE /projects/:id/cli-token/:tokenId` once the preview session ends (or
+ * on a rotation schedule), so short-lived preview credentials don't
+ * accumulate indefinitely on the account.
+ */
+
+import { getRequestSession } from '@/server/auth';
+import { consumeRateLimit } from '@/server/rate-limit';
+import { isOwner } from '@/server/users';
+import type { NextRequest } from 'next/server';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+function upstreamBase(): string {
+  return (process.env.KORTIX_UPSTREAM ?? 'https://api.kortix.com/v1').replace(/\/+$/, '');
+}
+
+export async function GET(req: NextRequest) {
+  const apiKey = process.env.KORTIX_API_KEY;
+  if (!apiKey) {
+    return Response.json({ error: 'Wrapper mode is not enabled on this server.' }, { status: 500 });
+  }
+
+  const session = getRequestSession(req);
+  if (!session) return Response.json({ error: 'Not authenticated' }, { status: 401 });
+
+  const limited = consumeRateLimit(session.userId);
+  if (!limited.ok) return Response.json({ error: 'Rate limit exceeded' }, { status: 429 });
+
+  const projectId = new URL(req.url).searchParams.get('projectId');
+  if (!projectId) return Response.json({ error: 'projectId is required' }, { status: 400 });
+  if (!isOwner(session.userId, projectId)) {
+    return Response.json({ error: "You don't have access to this project." }, { status: 403 });
+  }
+
+  const upstream = upstreamBase();
+  let upstreamRes: Response;
+  try {
+    upstreamRes = await fetch(`${upstream}/projects/${encodeURIComponent(projectId)}/cli-token`, {
+      method: 'POST',
+      headers: { authorization: `Bearer ${apiKey}`, 'content-type': 'application/json' },
+      body: JSON.stringify({ name: `lumen-preview-${Date.now()}` }),
+    });
+  } catch {
+    return Response.json({ error: 'Could not reach the Kortix API' }, { status: 502 });
+  }
+
+  const body = await upstreamRes.json().catch(() => null);
+  if (!upstreamRes.ok || !body?.secret_key) {
+    const message =
+      typeof body?.message === 'string'
+        ? body.message
+        : typeof body?.error === 'string'
+          ? body.error
+          : 'Could not mint a preview token';
+    return Response.json({ error: message }, { status: upstreamRes.status || 502 });
+  }
+
+  return Response.json({ token: body.secret_key as string, upstream, tokenId: body.token_id });
+}

--- a/apps/whitelabel-demo/src/app/api/usage/route.ts
+++ b/apps/whitelabel-demo/src/app/api/usage/route.ts
@@ -1,0 +1,94 @@
+/**
+ * Cost pass-through: aggregate `GET {upstream}/projects/:id/gateway/sessions`
+ * across every project the caller owns, apply `COST_MARKUP`, and return both
+ * the raw Kortix cost and the marked-up "your price" per session — the
+ * re-billing surface a real wrapper would show its own users. Rendered by
+ * `src/app/usage/page.tsx`.
+ */
+
+import { getRequestSession } from '@/server/auth';
+import { consumeRateLimit } from '@/server/rate-limit';
+import { listOwnedProjects } from '@/server/users';
+import type { NextRequest } from 'next/server';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+interface GatewaySessionStat {
+  session_id: string;
+  llm_cost?: number;
+  compute_cost?: number;
+  tokens?: number;
+  compute_seconds?: number;
+  total_cost?: number;
+  [key: string]: unknown;
+}
+
+function upstreamBase(): string {
+  return (process.env.KORTIX_UPSTREAM ?? 'https://api.kortix.com/v1').replace(/\/+$/, '');
+}
+
+function markupMultiplier(): number {
+  const n = Number(process.env.COST_MARKUP ?? 1.2);
+  return Number.isFinite(n) && n > 0 ? n : 1.2;
+}
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+export async function GET(req: NextRequest) {
+  const apiKey = process.env.KORTIX_API_KEY;
+  if (!apiKey) {
+    return Response.json({ error: 'Wrapper mode is not enabled on this server.' }, { status: 500 });
+  }
+
+  const session = getRequestSession(req);
+  if (!session) return Response.json({ error: 'Not authenticated' }, { status: 401 });
+
+  const limited = consumeRateLimit(session.userId);
+  if (!limited.ok) return Response.json({ error: 'Rate limit exceeded' }, { status: 429 });
+
+  const markup = markupMultiplier();
+  const upstream = upstreamBase();
+  const projectIds = listOwnedProjects(session.userId);
+
+  const projects = await Promise.all(
+    projectIds.map(async (projectId) => {
+      try {
+        const res = await fetch(`${upstream}/projects/${encodeURIComponent(projectId)}/gateway/sessions`, {
+          headers: { authorization: `Bearer ${apiKey}` },
+        });
+        if (!res.ok) return { projectId, sessions: [], error: `upstream responded ${res.status}` };
+        const data = await res.json();
+        const sessions: GatewaySessionStat[] = Array.isArray(data?.sessions) ? data.sessions : [];
+        return {
+          projectId,
+          sessions: sessions.map((s) => ({
+            ...s,
+            billed_cost: round2((s.total_cost ?? 0) * markup),
+          })),
+        };
+      } catch {
+        return { projectId, sessions: [], error: 'request failed' };
+      }
+    }),
+  );
+
+  const totals = projects.reduce(
+    (acc, p) => {
+      for (const s of p.sessions) {
+        acc.raw += s.total_cost ?? 0;
+        acc.billed += s.billed_cost ?? 0;
+      }
+      return acc;
+    },
+    { raw: 0, billed: 0 },
+  );
+
+  return Response.json({
+    markup,
+    totals: { raw: round2(totals.raw), billed: round2(totals.billed) },
+    projects,
+  });
+}

--- a/apps/whitelabel-demo/src/app/api/usage/route.ts
+++ b/apps/whitelabel-demo/src/app/api/usage/route.ts
@@ -57,6 +57,12 @@ export async function GET(req: NextRequest) {
 
   const projects = await Promise.all(
     projectIds.map(async (projectId) => {
+      // Explicit per-item barrier right before the URL interpolation — the
+      // list is already UUID-filtered above, but static analysis needs the
+      // guard on the same control path as the fetch.
+      if (!isValidProjectId(projectId)) {
+        return { projectId, sessions: [], error: 'invalid project id' };
+      }
       try {
         const res = await fetch(`${upstream}/projects/${encodeURIComponent(projectId)}/gateway/sessions`, {
           headers: { authorization: `Bearer ${apiKey}` },

--- a/apps/whitelabel-demo/src/app/api/usage/route.ts
+++ b/apps/whitelabel-demo/src/app/api/usage/route.ts
@@ -8,7 +8,7 @@
 
 import { getRequestSession } from '@/server/auth';
 import { consumeRateLimit } from '@/server/rate-limit';
-import { listOwnedProjects } from '@/server/users';
+import { isValidProjectId, listOwnedProjects } from '@/server/users';
 import type { NextRequest } from 'next/server';
 
 export const runtime = 'nodejs';
@@ -51,7 +51,9 @@ export async function GET(req: NextRequest) {
 
   const markup = markupMultiplier();
   const upstream = upstreamBase();
-  const projectIds = listOwnedProjects(session.userId);
+  // listOwnedProjects already UUID-filters, but re-assert at the fetch site:
+  // these ids come from a file and are interpolated into upstream URLs.
+  const projectIds = listOwnedProjects(session.userId).filter(isValidProjectId);
 
   const projects = await Promise.all(
     projectIds.map(async (projectId) => {

--- a/apps/whitelabel-demo/src/app/page.tsx
+++ b/apps/whitelabel-demo/src/app/page.tsx
@@ -2,6 +2,7 @@
 
 import { ApiKeyGate } from '@/components/api-key-gate';
 import { BrandMark } from '@/components/brand-mark';
+import { LoginGate } from '@/components/login-gate';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import {
@@ -18,17 +19,22 @@ import { Label } from '@/components/ui/label';
 import { Skeleton } from '@/components/ui/skeleton';
 import { clearApiKey, getApiKey, kortix } from '@/lib/kortix';
 import { qk } from '@/lib/query-keys';
+import { clearSessionToken, getSessionToken } from '@/lib/session';
 import { relativeTime } from '@/lib/utils';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { FolderGit2, Loader2, LogOut, Plus, Users } from 'lucide-react';
+import { FolderGit2, Loader2, LogOut, Plus, Receipt, Users } from 'lucide-react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import { toast } from 'sonner';
+import { useWrapperMode } from './providers';
 
 export default function Home() {
+  const wrapperMode = useWrapperMode();
   const [ready, setReady] = useState<boolean | null>(null);
-  useEffect(() => setReady(!!getApiKey()), []);
+  useEffect(() => {
+    setReady(wrapperMode ? !!getSessionToken() : !!getApiKey());
+  }, [wrapperMode]);
 
   if (ready === null) {
     return (
@@ -37,18 +43,36 @@ export default function Home() {
       </div>
     );
   }
-  if (!ready) return <ApiKeyGate onReady={() => setReady(true)} />;
+  if (!ready) {
+    return wrapperMode ? (
+      <LoginGate onReady={() => setReady(true)} />
+    ) : (
+      <ApiKeyGate onReady={() => setReady(true)} />
+    );
+  }
   return (
     <Dashboard
+      wrapperMode={wrapperMode}
       onDisconnect={() => {
-        clearApiKey();
+        if (wrapperMode) {
+          clearSessionToken();
+          fetch('/api/auth/logout', { method: 'POST' }).catch(() => {});
+        } else {
+          clearApiKey();
+        }
         setReady(false);
       }}
     />
   );
 }
 
-function Dashboard({ onDisconnect }: { onDisconnect: () => void }) {
+function Dashboard({
+  wrapperMode,
+  onDisconnect,
+}: {
+  wrapperMode: boolean;
+  onDisconnect: () => void;
+}) {
   const projects = useQuery({ queryKey: qk.projects, queryFn: () => kortix.projects.list() });
   const items = projects.data ?? [];
 
@@ -58,11 +82,19 @@ function Dashboard({ onDisconnect }: { onDisconnect: () => void }) {
         <div className="mx-auto flex max-w-4xl items-center justify-between px-5 py-3">
           <BrandMark />
           <div className="flex items-center gap-1">
-            <Link href="/account">
-              <Button variant="ghost" size="sm">
-                <Users className="size-4" /> Account
-              </Button>
-            </Link>
+            {wrapperMode ? (
+              <Link href="/usage">
+                <Button variant="ghost" size="sm">
+                  <Receipt className="size-4" /> Usage
+                </Button>
+              </Link>
+            ) : (
+              <Link href="/account">
+                <Button variant="ghost" size="sm">
+                  <Users className="size-4" /> Account
+                </Button>
+              </Link>
+            )}
             <Button variant="ghost" size="sm" onClick={onDisconnect}>
               <LogOut className="size-4" /> Disconnect
             </Button>
@@ -88,9 +120,9 @@ function Dashboard({ onDisconnect }: { onDisconnect: () => void }) {
             ))}
           {projects.isError && (
             <Card className="col-span-full p-4 text-sm text-destructive">
-              Couldn&apos;t load projects — check your API key.{' '}
+              Couldn&apos;t load projects — {wrapperMode ? 'try signing in again' : 'check your API key'}.{' '}
               <button className="underline" onClick={onDisconnect}>
-                Reconnect
+                {wrapperMode ? 'Sign out' : 'Reconnect'}
               </button>
             </Card>
           )}

--- a/apps/whitelabel-demo/src/app/projects/[id]/page.tsx
+++ b/apps/whitelabel-demo/src/app/projects/[id]/page.tsx
@@ -14,6 +14,7 @@ import {
 import { kortix } from '@/lib/kortix';
 import { invalidateSessions } from '@/lib/query-keys';
 import { generateSessionId } from '@kortix/sdk';
+import type { SandboxTemplate } from '@kortix/sdk/projects-client';
 import {
   type ModelKey,
   useProjectConfig,
@@ -66,8 +67,10 @@ function ProjectHome() {
     queryFn: () => kortix.projects.sandboxTemplates(projectId),
     retry: false,
   });
-  const templateList = ((templates.data as any)?.templates ??
-    (Array.isArray(templates.data) ? templates.data : [])) as any[];
+  // `.sandboxTemplates()` returns `{ items: SandboxTemplate[] }` — this used to
+  // read a nonexistent `.templates` field (masked by an `as any` cast), so the
+  // multi-template picker below never actually rendered any options.
+  const templateList: SandboxTemplate[] = templates.data?.items ?? [];
 
   const start = useMutation({
     mutationFn: async (text: string) => {
@@ -141,7 +144,7 @@ function ProjectHome() {
                 </SelectTrigger>
                 <SelectContent>
                   {templateList.map((t) => {
-                    const slug = String(t.slug ?? t.id ?? t.name ?? 'default');
+                    const slug = t.slug || 'default';
                     return (
                       <SelectItem key={slug} value={slug}>
                         {t.name ?? slug}

--- a/apps/whitelabel-demo/src/app/projects/[id]/settings/page.tsx
+++ b/apps/whitelabel-demo/src/app/projects/[id]/settings/page.tsx
@@ -124,18 +124,28 @@ function GeneralTab() {
   });
 
   const current = project.data?.name ?? '';
-  const fileCount = (detail.data as any)?.file_count;
-  const modelCount = catalog.data
-    ? Object.keys((catalog.data as any).models ?? {}).length
-    : undefined;
-  const healthState = (health.data as any)?.status ?? (health.isError ? 'unknown' : undefined);
+  const fileCount = detail.data?.file_count;
+  const modelCount = catalog.data ? Object.keys(catalog.data.models).length : undefined;
+  // `ProjectSandboxHealth` has no `.status` — this used to read one anyway
+  // (masked by an `as any` cast), so the Runtime stat always fell through to
+  // the `isError` branch. Derive the label from the real `ready`/`building`/
+  // `latest_failure` fields instead.
+  const healthState = health.data?.ready
+    ? 'ready'
+    : health.data?.building
+      ? 'building'
+      : health.data?.latest_failure
+        ? 'failed'
+        : health.isError
+          ? 'unknown'
+          : undefined;
 
-  const p = (project.data ?? {}) as Record<string, any>;
-  const repoUrl: string | undefined = p.git_origin_url || p.repo_url || undefined;
+  const p = project.data;
+  const repoUrl: string | undefined = p?.repo_url || undefined;
   const repoLabel = repoUrl
     ? repoUrl.replace(/^https?:\/\//, '').replace(/\.git$/, '')
     : undefined;
-  const baseRef: string | undefined = p.base_ref || p.default_branch || undefined;
+  const baseRef: string | undefined = p?.default_branch || undefined;
 
   return (
     <div className="space-y-4">
@@ -172,10 +182,10 @@ function GeneralTab() {
           />
           {baseRef && <InfoRow label="Default branch" value={baseRef} mono />}
           <InfoRow label="Project ID" value={projectId} mono />
-          {p.account_id && <InfoRow label="Account" value={p.account_id} mono />}
-          {p.status && <InfoRow label="Status" value={p.status} />}
-          <InfoRow label="Created" value={fmtDate(p.created_at)} />
-          <InfoRow label="Last updated" value={fmtDate(p.updated_at)} />
+          {p?.account_id && <InfoRow label="Account" value={p.account_id} mono />}
+          {p?.status && <InfoRow label="Status" value={p.status} />}
+          <InfoRow label="Created" value={fmtDate(p?.created_at)} />
+          <InfoRow label="Last updated" value={fmtDate(p?.updated_at)} />
         </dl>
       </Card>
 

--- a/apps/whitelabel-demo/src/app/providers.tsx
+++ b/apps/whitelabel-demo/src/app/providers.tsx
@@ -3,10 +3,26 @@
 import { Toaster } from '@/components/ui/sonner';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { useState } from 'react';
+import { Loader2 } from 'lucide-react';
+import { createContext, useContext, useEffect, useState } from 'react';
 
-// Importing the client configures the SDK platform seam once (createKortix).
-import '@/lib/kortix';
+// Importing the client configures the SDK platform seam once (createKortix),
+// defaulting to direct mode. `configureWrapperMode` re-points it below when
+// wrapper mode is confirmed.
+import { configureWrapperMode } from '@/lib/kortix';
+import { fetchWrapperMode } from '@/lib/mode';
+
+const WrapperModeContext = createContext(false);
+
+/**
+ * True when this server has `KORTIX_API_KEY` set — Lumen is running as a BFF
+ * in front of Kortix rather than a pure client of it. Drives which auth gate
+ * renders (`LoginGate` vs `ApiKeyGate`) and how the preview iframe
+ * authenticates.
+ */
+export function useWrapperMode(): boolean {
+  return useContext(WrapperModeContext);
+}
 
 export function Providers({ children }: { children: React.ReactNode }) {
   const [queryClient] = useState(
@@ -24,10 +40,40 @@ export function Providers({ children }: { children: React.ReactNode }) {
       }),
   );
 
+  // `null` = still resolving. Block rendering (and therefore every data
+  // fetch a page might fire) until the mode is known — otherwise the first
+  // paint in wrapper mode could fire a request against the direct-mode
+  // default before `configureWrapperMode()` runs. In direct mode this adds
+  // one same-origin round trip before first paint (`GET /api/mode`); it's
+  // the cost of a single source of truth for which mode is active.
+  const [wrapperMode, setWrapperMode] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchWrapperMode().then((isWrapper) => {
+      if (cancelled) return;
+      if (isWrapper) configureWrapperMode();
+      setWrapperMode(isWrapper);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (wrapperMode === null) {
+    return (
+      <div className="grid min-h-dvh place-items-center bg-background">
+        <Loader2 className="size-5 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
   return (
-    <QueryClientProvider client={queryClient}>
-      <TooltipProvider delayDuration={200}>{children}</TooltipProvider>
-      <Toaster position="bottom-right" />
-    </QueryClientProvider>
+    <WrapperModeContext.Provider value={wrapperMode}>
+      <QueryClientProvider client={queryClient}>
+        <TooltipProvider delayDuration={200}>{children}</TooltipProvider>
+        <Toaster position="bottom-right" />
+      </QueryClientProvider>
+    </WrapperModeContext.Provider>
   );
 }

--- a/apps/whitelabel-demo/src/app/usage/page.tsx
+++ b/apps/whitelabel-demo/src/app/usage/page.tsx
@@ -1,0 +1,201 @@
+'use client';
+
+/**
+ * The cost pass-through surface: per-project, per-session Kortix gateway
+ * costs alongside the marked-up "your price" this wrapper would actually bill
+ * its own users — backed by `GET /api/usage` (server-side aggregation over
+ * every project the signed-in user owns; see `src/app/api/usage/route.ts`).
+ *
+ * Wrapper-mode only — direct mode has no per-user ownership model to scope
+ * this to, so it gets the same short explainer pattern as `/account` in
+ * wrapper mode.
+ */
+
+import { BrandMark } from '@/components/brand-mark';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { getSessionToken } from '@/lib/session';
+import { useQuery } from '@tanstack/react-query';
+import { ArrowLeft, Receipt } from 'lucide-react';
+import Link from 'next/link';
+import { useWrapperMode } from '../providers';
+
+interface UsageSession {
+  session_id: string;
+  llm_cost?: number;
+  compute_cost?: number;
+  tokens?: number;
+  compute_seconds?: number;
+  total_cost?: number;
+  billed_cost?: number;
+}
+
+interface UsageProject {
+  projectId: string;
+  sessions: UsageSession[];
+  error?: string;
+}
+
+interface UsageResponse {
+  markup: number;
+  totals: { raw: number; billed: number };
+  projects: UsageProject[];
+}
+
+async function fetchUsage(): Promise<UsageResponse> {
+  const token = getSessionToken();
+  const res = await fetch('/api/usage', {
+    headers: token ? { authorization: `Bearer ${token}` } : undefined,
+  });
+  if (!res.ok) throw new Error(`usage request failed (${res.status})`);
+  return res.json();
+}
+
+function usd(n: number | undefined): string {
+  return `$${(n ?? 0).toFixed(4)}`;
+}
+
+export default function UsagePage() {
+  const wrapperMode = useWrapperMode();
+  if (!wrapperMode) return <NotInDirectMode />;
+  return <UsageDashboard />;
+}
+
+function NotInDirectMode() {
+  return (
+    <div className="grid min-h-dvh place-items-center bg-background px-4">
+      <Card className="w-full max-w-sm p-6 text-center">
+        <BrandMark className="mx-auto mb-4" />
+        <h1 className="text-lg font-semibold tracking-tight">Wrapper mode only</h1>
+        <p className="mt-1.5 text-sm text-muted-foreground">
+          Cost pass-through is scoped to per-user project ownership, which only exists when this
+          app runs in wrapper mode (`KORTIX_API_KEY` set on the server).
+        </p>
+        <Button asChild className="mt-5 gap-2">
+          <Link href="/">
+            <ArrowLeft className="size-4" /> Back to projects
+          </Link>
+        </Button>
+      </Card>
+    </div>
+  );
+}
+
+function UsageDashboard() {
+  const usage = useQuery({ queryKey: ['usage'], queryFn: fetchUsage });
+  const data = usage.data;
+
+  return (
+    <div className="min-h-dvh bg-background">
+      <header className="sticky top-0 z-10 border-b border-border bg-background/80 backdrop-blur">
+        <div className="mx-auto flex max-w-4xl items-center justify-between gap-3 px-5 py-3">
+          <Link
+            href="/"
+            className="inline-flex items-center gap-2 text-sm text-muted-foreground transition-colors hover:text-foreground"
+          >
+            <ArrowLeft className="size-4" /> Back to projects
+          </Link>
+        </div>
+      </header>
+
+      <div className="mx-auto max-w-4xl px-5 py-8">
+        <div className="flex items-center gap-2">
+          <Receipt className="size-5 text-muted-foreground" />
+          <h1 className="text-xl font-semibold tracking-tight">Usage &amp; billing</h1>
+        </div>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Raw Kortix gateway cost per session, and the marked-up price this wrapper would bill
+          you{data ? ` (${data.markup}×)` : ''}. This is the re-billing surface — swap the numbers
+          for your own pricing model.
+        </p>
+
+        {usage.isLoading && (
+          <div className="mt-6 space-y-3">
+            <Skeleton className="h-20 rounded-xl" />
+            <Skeleton className="h-40 rounded-xl" />
+          </div>
+        )}
+
+        {usage.isError && (
+          <Card className="mt-6 p-6 text-sm text-destructive">
+            Couldn&apos;t load usage — try signing in again.
+          </Card>
+        )}
+
+        {data && (
+          <>
+            <div className="mt-6 grid grid-cols-2 gap-3">
+              <Card className="p-4">
+                <div className="text-xs text-muted-foreground">Raw Kortix cost</div>
+                <div className="mt-1 text-2xl font-semibold tracking-tight">
+                  {usd(data.totals.raw)}
+                </div>
+              </Card>
+              <Card className="border-brand/30 p-4">
+                <div className="text-xs text-muted-foreground">Your price ({data.markup}×)</div>
+                <div className="mt-1 text-2xl font-semibold tracking-tight">
+                  {usd(data.totals.billed)}
+                </div>
+              </Card>
+            </div>
+
+            {data.projects.length === 0 && (
+              <Card className="mt-6 p-8 text-center text-sm text-muted-foreground">
+                No projects yet — usage will show up here once you&apos;ve run a session.
+              </Card>
+            )}
+
+            {data.projects.map((project) => (
+              <Card key={project.projectId} className="mt-4 overflow-hidden p-0">
+                <div className="flex items-center justify-between gap-2 border-b border-border px-4 py-2.5">
+                  <span className="truncate font-mono text-xs text-muted-foreground">
+                    {project.projectId}
+                  </span>
+                  <Badge variant="secondary" className="shrink-0">
+                    {project.sessions.length} session{project.sessions.length === 1 ? '' : 's'}
+                  </Badge>
+                </div>
+                {project.error ? (
+                  <p className="px-4 py-4 text-xs text-destructive">{project.error}</p>
+                ) : project.sessions.length === 0 ? (
+                  <p className="px-4 py-4 text-xs text-muted-foreground">No sessions yet.</p>
+                ) : (
+                  <div className="overflow-x-auto">
+                    <table className="w-full text-left text-sm">
+                      <thead>
+                        <tr className="text-xs text-muted-foreground">
+                          <th className="px-4 py-2 font-medium">Session</th>
+                          <th className="px-4 py-2 font-medium">LLM cost</th>
+                          <th className="px-4 py-2 font-medium">Compute cost</th>
+                          <th className="px-4 py-2 font-medium">Raw total</th>
+                          <th className="px-4 py-2 font-medium">Your price</th>
+                        </tr>
+                      </thead>
+                      <tbody className="divide-y divide-border">
+                        {project.sessions.map((s) => (
+                          <tr key={s.session_id}>
+                            <td className="max-w-[10rem] truncate px-4 py-2 font-mono text-xs">
+                              {s.session_id}
+                            </td>
+                            <td className="px-4 py-2 text-xs">{usd(s.llm_cost)}</td>
+                            <td className="px-4 py-2 text-xs">{usd(s.compute_cost)}</td>
+                            <td className="px-4 py-2 text-xs">{usd(s.total_cost)}</td>
+                            <td className="px-4 py-2 text-xs font-medium text-foreground">
+                              {usd(s.billed_cost)}
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                )}
+              </Card>
+            ))}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/whitelabel-demo/src/components/account/account-detail-card.tsx
+++ b/apps/whitelabel-demo/src/components/account/account-detail-card.tsx
@@ -41,7 +41,7 @@ export function AccountDetailCard({
     queryFn: () => kortix.accounts.get(accountId),
   });
 
-  const data = detail.data as any;
+  const data = detail.data;
   const [name, setName] = useState('');
   useEffect(() => {
     if (data?.name != null) setName(String(data.name));
@@ -67,7 +67,7 @@ export function AccountDetailCard({
     onError: () => toast.error('Could not leave the account'),
   });
 
-  const role = data?.role as string | undefined;
+  const role = data?.role;
   const isOwner = role === 'owner';
   const dirty = data?.name != null && name.trim() !== '' && name.trim() !== String(data.name);
 

--- a/apps/whitelabel-demo/src/components/account/account-switcher.tsx
+++ b/apps/whitelabel-demo/src/components/account/account-switcher.tsx
@@ -20,6 +20,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { kortix } from '@/lib/kortix';
+import type { KortixAccount } from '@kortix/sdk/projects-client';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { Loader2, Plus } from 'lucide-react';
 import { useState } from 'react';
@@ -36,7 +37,7 @@ export function AccountSwitcher({
   onChange,
   loading,
 }: {
-  accounts: any[];
+  accounts: KortixAccount[];
   value: string | null;
   onChange: (accountId: string) => void;
   loading: boolean;
@@ -79,8 +80,7 @@ function NewAccountDialog({ onCreated }: { onCreated: (accountId: string) => voi
       setOpen(false);
       setName('');
       toast.success('Team account created');
-      const id = (account as any)?.account_id;
-      if (id) onCreated(id);
+      if (account.account_id) onCreated(account.account_id);
     },
     onError: () => toast.error('Could not create the account'),
   });

--- a/apps/whitelabel-demo/src/components/account/invites-section.tsx
+++ b/apps/whitelabel-demo/src/components/account/invites-section.tsx
@@ -18,7 +18,7 @@ export function InvitesSection({ accountId }: { accountId: string }) {
     queryFn: () => kortix.accounts.invites(accountId),
   });
 
-  const items = (invites.data as any[]) ?? [];
+  const items = invites.data ?? [];
 
   // Quiet when there's nothing pending and the load succeeded.
   if (invites.isSuccess && items.length === 0) return null;

--- a/apps/whitelabel-demo/src/components/account/members-section.tsx
+++ b/apps/whitelabel-demo/src/components/account/members-section.tsx
@@ -60,9 +60,8 @@ export function MembersSection({ accountId }: { accountId: string }) {
     onSuccess: (result) => {
       setEmail('');
       refresh();
-      const r = result as any;
-      if (r?.status === 'pending') toast.success(`Invitation sent to ${r.email}`);
-      else toast.success(`${r?.email ?? 'Member'} added`);
+      if (result.status === 'pending') toast.success(`Invitation sent to ${result.email}`);
+      else toast.success(`${result.email} added`);
     },
     onError: (err: any) => {
       const msg = String(err?.message ?? '');
@@ -89,7 +88,7 @@ export function MembersSection({ accountId }: { accountId: string }) {
     onError: () => toast.error('Could not remove the member'),
   });
 
-  const items = (members.data as any[]) ?? [];
+  const items = members.data ?? [];
 
   return (
     <section className="space-y-3">
@@ -147,10 +146,10 @@ export function MembersSection({ accountId }: { accountId: string }) {
           <div className="p-6 text-center text-sm text-muted-foreground">Just you so far.</div>
         )}
         {items.map((m, i) => {
-          const label = (m.email ?? m.user_id ?? 'Member') as string;
+          const label = m.email ?? m.user_id ?? 'Member';
           const initial = label.charAt(0).toUpperCase();
-          const memberRole = (m.account_role ?? 'member') as string;
-          const userId = m.user_id as string | undefined;
+          const memberRole = m.account_role;
+          const userId = m.user_id;
           const busy =
             (changeRole.isPending && changeRole.variables?.userId === userId) ||
             (remove.isPending && remove.variables === userId);

--- a/apps/whitelabel-demo/src/components/account/projects-section.tsx
+++ b/apps/whitelabel-demo/src/components/account/projects-section.tsx
@@ -18,7 +18,7 @@ export function ProjectsSection({ accountId }: { accountId: string }) {
     queryFn: () => kortix.projects.listForAccount(accountId),
   });
 
-  const items = (projects.data as any[]) ?? [];
+  const items = projects.data ?? [];
 
   return (
     <section className="space-y-3">

--- a/apps/whitelabel-demo/src/components/chat/message-view.tsx
+++ b/apps/whitelabel-demo/src/components/chat/message-view.tsx
@@ -2,20 +2,37 @@
 
 /**
  * One message from the sync store. The user turn is a right-aligned `Bubble`;
- * the assistant turn renders full-width as ordered content blocks (markdown,
- * collapsible reasoning, tool cards, file markers) — clean and monochrome.
+ * the assistant turn renders full-width as ordered content blocks — clean and
+ * monochrome.
+ *
+ * Rendering is driven by `classifyTurn`/`classifyPart` (`@kortix/sdk/turns`):
+ * every one of opencode's 12 part types is classified into a typed
+ * `ClassifiedPart`, and `renderParts` (`@kortix/sdk/react`) requires a
+ * renderer for every kind at compile time — so a new part type (or one we
+ * used to silently drop) fails the build here instead of quietly vanishing
+ * from the transcript. See the per-kind comments below for what each
+ * renderer deliberately does or doesn't show.
  */
 
 import { Bubble, BubbleContent } from '@/components/ui/bubble';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 import { Marker, MarkerContent, MarkerIcon } from '@/components/ui/marker';
 import { Message } from '@/components/ui/message';
-import type { MessageWithParts } from '@kortix/sdk/react';
-import { Brain, ChevronRight, Paperclip, TriangleAlert } from 'lucide-react';
+import { type MessageWithParts, type PartRenderers, renderParts } from '@kortix/sdk/react';
+import { classifyTurn } from '@kortix/sdk/turns';
+import {
+  Brain,
+  ChevronRight,
+  FileDiff,
+  Paperclip,
+  RefreshCw,
+  Scissors,
+  SquareDashedBottom,
+  TriangleAlert,
+} from 'lucide-react';
+import { Fragment } from 'react';
 import { Markdown } from './markdown';
 import { ToolCall } from './tool-call';
-
-type AnyPart = MessageWithParts['parts'][number] & Record<string, any>;
 
 function Reasoning({ text }: { text: string }) {
   return (
@@ -34,57 +51,113 @@ function Reasoning({ text }: { text: string }) {
   );
 }
 
-function PartView({ part }: { part: AnyPart }) {
-  switch (part.type) {
-    case 'text':
-      return part.text?.trim() ? <Markdown>{part.text}</Markdown> : null;
-    case 'reasoning':
-      return part.text?.trim() ? <Reasoning text={part.text} /> : null;
-    case 'tool':
-      return <ToolCall part={part} />;
-    case 'file':
-      return (
-        <Marker className="w-fit text-foreground">
-          <MarkerIcon>
-            <Paperclip />
-          </MarkerIcon>
-          <MarkerContent>{part.filename ?? part.url ?? 'file'}</MarkerContent>
-        </Marker>
-      );
-    default:
-      return null; // step-start, step-finish, snapshot, agent
-  }
-}
+/**
+ * One renderer per `ClassifiedPart['kind']`. `PartRenderers<T>`'s type
+ * requires every key, so removing a case (or opencode adding a new part
+ * type) is a compile error here, not a silent drop in production.
+ */
+const partRenderers: PartRenderers<React.ReactNode> = {
+  text: (part) => (part.text.trim() ? <Markdown>{part.text}</Markdown> : null),
+  reasoning: (part) => (part.text.trim() ? <Reasoning text={part.text} /> : null),
+  tool: (part) => <ToolCall tool={part.tool} />,
+  file: (part) => (
+    <Marker className="w-fit text-foreground">
+      <MarkerIcon>
+        <Paperclip />
+      </MarkerIcon>
+      <MarkerContent>{part.filename ?? part.url}</MarkerContent>
+    </Marker>
+  ),
+  // A sub-agent delegation. `part.description`/`part.agent` mirror the
+  // `task` tool card, but subtask parts stand alone (no tool-state machine).
+  subtask: (part) => (
+    <Marker className="w-fit text-foreground">
+      <MarkerIcon>
+        <SquareDashedBottom />
+      </MarkerIcon>
+      <MarkerContent>
+        {part.description ? `${part.description} (${part.agent})` : `Delegated to ${part.agent}`}
+      </MarkerContent>
+    </Marker>
+  ),
+  // Compact diff-stat line — the full diff lives in the Changes panel, not the
+  // chat transcript.
+  patch: (part) => (
+    <Marker className="w-fit text-foreground">
+      <MarkerIcon>
+        <FileDiff />
+      </MarkerIcon>
+      <MarkerContent>
+        {part.fileCount} file{part.fileCount === 1 ? '' : 's'} changed
+      </MarkerContent>
+    </Marker>
+  ),
+  // An internal git checkpoint hash used for session revert — never
+  // user-facing content, so there is nothing worth rendering here.
+  snapshot: () => null,
+  // An inline `@agent` mention token. Its text already appears verbatim
+  // inside the sibling text part it was parsed out of (`source.start/end`
+  // point back into that text) — rendering it again here would duplicate it.
+  agent: () => null,
+  // A model-call retry after a transient failure (rate limit, provider
+  // hiccup). Worth a subtle system note so a stalled-looking turn doesn't
+  // read as broken.
+  retry: (part) => (
+    <Marker className="w-fit text-muted-foreground">
+      <MarkerIcon>
+        <RefreshCw />
+      </MarkerIcon>
+      <MarkerContent>{`Retrying (attempt ${part.attempt}): ${part.message}`}</MarkerContent>
+    </Marker>
+  ),
+  // Context was compacted (auto or manual) to make room in the context
+  // window. Subtle system note, not an error.
+  compaction: (part) => (
+    <Marker className="w-fit text-muted-foreground">
+      <MarkerIcon>
+        <Scissors />
+      </MarkerIcon>
+      <MarkerContent>
+        {part.auto ? 'Context compacted automatically' : 'Context compacted'}
+      </MarkerContent>
+    </Marker>
+  ),
+  // step-start/step-finish are pure model-step bookkeeping (cost/token
+  // accounting lives in the session-level cost summary elsewhere) — no
+  // chat-visible content of their own.
+  step: () => null,
+  // Forward-compat: a part type this build doesn't recognize yet (client
+  // older than server). Drop silently rather than break the transcript.
+  unknown: () => null,
+};
 
 /**
  * A failed assistant turn — the runtime attaches a typed `error` to the
  * message (provider auth, model unavailable, abort, context overflow, …) and
  * often produces ZERO parts. Without this block such a turn renders as
  * complete silence, which reads as "the app is broken" when it's really
- * "the model call failed" — surface the reason instead.
+ * "the model call failed" — surface the reason instead. `classifyTurn`
+ * normalizes `info.error` into `{name, message}` at the SDK layer, so this
+ * component doesn't need to know about opencode's error-union shape at all.
  */
-function TurnError({ error }: { error: NonNullable<Extract<MessageWithParts['info'], { role: 'assistant' }>['error']> }) {
-  const data = 'data' in error ? (error.data as { message?: string } | undefined) : undefined;
-  const text = data?.message?.trim() || error.name || 'The agent run failed.';
+function TurnError({ error }: { error: { name: string; message: string } }) {
   return (
     <Marker className="w-fit text-destructive" role="alert">
       <MarkerIcon>
         <TriangleAlert />
       </MarkerIcon>
-      <MarkerContent>{text}</MarkerContent>
+      <MarkerContent>{error.message || error.name}</MarkerContent>
     </Marker>
   );
 }
 
 export function MessageView({ message }: { message: MessageWithParts }) {
   const isUser = message.info.role === 'user';
-  const parts = (message.parts as AnyPart[]).filter(
-    (p) => p.type !== 'step-start' && p.type !== 'step-finish',
-  );
+  const { parts, error, isEmpty } = classifyTurn(message);
 
   if (isUser) {
     const text = parts
-      .filter((p) => p.type === 'text')
+      .filter((p) => p.kind === 'text')
       .map((p) => p.text)
       .join('\n')
       .trim();
@@ -100,13 +173,21 @@ export function MessageView({ message }: { message: MessageWithParts }) {
     );
   }
 
-  const error = message.info.role === 'assistant' ? message.info.error : undefined;
-  if (parts.length === 0 && !error) return null;
+  if (isEmpty) return null;
   return (
     <div className="space-y-2.5 text-sm leading-relaxed">
-      {parts.map((p, i) => (
-        <PartView key={p.id ?? i} part={p} />
-      ))}
+      {/* Fragment (not a div) so parts that deliberately render `null`
+          (step/snapshot/agent/unknown) don't leave behind an empty spacer
+          under `space-y-2.5`. */}
+      {renderParts(parts, partRenderers).map((node, i) => {
+        const part = parts[i];
+        // `ClassifiedUnknownPart` has no `id` (it's raw, unrecognized wire
+        // data) — fall back to index for that one kind, which is safe since
+        // a message's parts array is append-only for the lifetime of the
+        // render.
+        const key = part.kind === 'unknown' ? i : part.id;
+        return <Fragment key={key}>{node}</Fragment>;
+      })}
       {error ? <TurnError error={error} /> : null}
     </div>
   );

--- a/apps/whitelabel-demo/src/components/chat/message-view.tsx
+++ b/apps/whitelabel-demo/src/components/chat/message-view.tsx
@@ -11,7 +11,7 @@ import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/component
 import { Marker, MarkerContent, MarkerIcon } from '@/components/ui/marker';
 import { Message } from '@/components/ui/message';
 import type { MessageWithParts } from '@kortix/sdk/react';
-import { Brain, ChevronRight, Paperclip } from 'lucide-react';
+import { Brain, ChevronRight, Paperclip, TriangleAlert } from 'lucide-react';
 import { Markdown } from './markdown';
 import { ToolCall } from './tool-call';
 
@@ -56,6 +56,26 @@ function PartView({ part }: { part: AnyPart }) {
   }
 }
 
+/**
+ * A failed assistant turn — the runtime attaches a typed `error` to the
+ * message (provider auth, model unavailable, abort, context overflow, …) and
+ * often produces ZERO parts. Without this block such a turn renders as
+ * complete silence, which reads as "the app is broken" when it's really
+ * "the model call failed" — surface the reason instead.
+ */
+function TurnError({ error }: { error: NonNullable<Extract<MessageWithParts['info'], { role: 'assistant' }>['error']> }) {
+  const data = 'data' in error ? (error.data as { message?: string } | undefined) : undefined;
+  const text = data?.message?.trim() || error.name || 'The agent run failed.';
+  return (
+    <Marker className="w-fit text-destructive" role="alert">
+      <MarkerIcon>
+        <TriangleAlert />
+      </MarkerIcon>
+      <MarkerContent>{text}</MarkerContent>
+    </Marker>
+  );
+}
+
 export function MessageView({ message }: { message: MessageWithParts }) {
   const isUser = message.info.role === 'user';
   const parts = (message.parts as AnyPart[]).filter(
@@ -80,12 +100,14 @@ export function MessageView({ message }: { message: MessageWithParts }) {
     );
   }
 
-  if (parts.length === 0) return null;
+  const error = message.info.role === 'assistant' ? message.info.error : undefined;
+  if (parts.length === 0 && !error) return null;
   return (
     <div className="space-y-2.5 text-sm leading-relaxed">
       {parts.map((p, i) => (
         <PartView key={p.id ?? i} part={p} />
       ))}
+      {error ? <TurnError error={error} /> : null}
     </div>
   );
 }

--- a/apps/whitelabel-demo/src/components/chat/tool-call.tsx
+++ b/apps/whitelabel-demo/src/components/chat/tool-call.tsx
@@ -3,12 +3,18 @@
 /**
  * One agent tool call, rendered as a tidy collapsible card: an icon + humanized
  * name + a one-line summary derived from the args, a live status indicator, and
- * (expanded) the input args + output. Generic over every opencode tool — we read
- * the well-known arg keys and fall back gracefully.
+ * (expanded) the input args + output.
+ *
+ * Takes a normalized `ToolView` from `@kortix/sdk/turns` (`classifyPart`'s tool
+ * variant) instead of the raw wire tool part — status is already mapped to
+ * 'pending'|'running'|'done'|'error', and the icon comes from `toolInfo`'s
+ * `category` (a real registry keyed on tool name) instead of string-sniffing
+ * the tool name (`t.includes('bash')` etc.).
  */
 
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 import { cn } from '@/lib/utils';
+import { type ToolCategory, type ToolView, toolInfo } from '@kortix/sdk/turns';
 import {
   Bot,
   Check,
@@ -17,7 +23,6 @@ import {
   FileText,
   FolderSearch,
   Globe,
-  ListChecks,
   Loader2,
   type LucideIcon,
   Pencil,
@@ -26,30 +31,20 @@ import {
   Wrench,
 } from 'lucide-react';
 
-type AnyPart = Record<string, any>;
+const CATEGORY_ICON: Record<ToolCategory, LucideIcon> = {
+  shell: SquareTerminal,
+  files: FileText,
+  edit: Pencil,
+  search: FolderSearch,
+  web: Globe,
+  task: Bot,
+  other: Wrench,
+};
 
-function meta(tool: string): { icon: LucideIcon; label: string } {
-  const t = tool.toLowerCase();
-  if (t.includes('bash') || t.includes('shell') || t.includes('exec'))
-    return { icon: SquareTerminal, label: 'Terminal' };
-  if (t.includes('webfetch') || t.includes('fetch') || t.includes('http'))
-    return { icon: Globe, label: 'Fetch' };
-  if (t.includes('glob') || t.includes('list') || t === 'ls')
-    return { icon: FolderSearch, label: 'Find files' };
-  if (t.includes('grep') || t.includes('search')) return { icon: Search, label: 'Search' };
-  if (t.includes('edit') || t.includes('patch')) return { icon: Pencil, label: 'Edit' };
-  if (t.includes('write') || t.includes('create')) return { icon: FileText, label: 'Write' };
-  if (t.includes('read') || t.includes('view') || t.includes('cat'))
-    return { icon: FileText, label: 'Read' };
-  if (t.includes('todo')) return { icon: ListChecks, label: 'Plan' };
-  if (t.includes('task') || t.includes('agent')) return { icon: Bot, label: 'Subagent' };
-  return { icon: Wrench, label: tool.replace(/[._-]/g, ' ') };
-}
-
-function summarize(input: AnyPart | undefined): string {
-  if (!input || typeof input !== 'object') return '';
-  const i = input as AnyPart;
-  return (
+function summarize(input: Record<string, unknown> | undefined): string {
+  if (!input) return '';
+  const i = input as Record<string, unknown>;
+  const value =
     i.command ??
     i.filePath ??
     i.path ??
@@ -59,30 +54,26 @@ function summarize(input: AnyPart | undefined): string {
     i.url ??
     i.description ??
     i.prompt ??
-    ''
-  )
-    ?.toString()
+    '';
+  return String(value ?? '')
     .split('\n')[0]
     .slice(0, 140);
 }
 
-function StatusDot({ status }: { status: string }) {
+function StatusDot({ status }: { status: ToolView['status'] }) {
   if (status === 'running' || status === 'pending')
     return <Loader2 className="size-3.5 shrink-0 animate-spin text-muted-foreground" />;
   if (status === 'error') return <CircleAlert className="size-3.5 shrink-0 text-destructive" />;
   return <Check className="size-3.5 shrink-0 text-emerald-500" />;
 }
 
-export function ToolCall({ part }: { part: AnyPart }) {
-  const tool: string = part.tool ?? 'tool';
-  const state: AnyPart = part.state ?? {};
-  const status: string = state.status ?? 'completed';
-  const { icon: Icon, label } = meta(tool);
-  const summary = summarize(state.input);
-  const output: string | undefined =
-    typeof state.output === 'string' ? state.output : state.error ? String(state.error) : undefined;
+export function ToolCall({ tool }: { tool: ToolView }) {
+  const { category } = toolInfo(tool.name);
+  const Icon = CATEGORY_ICON[category] ?? Wrench;
+  const summary = summarize(tool.input);
+  const output = tool.output ?? tool.error;
 
-  const hasDetail = !!summary || !!output || (state.input && Object.keys(state.input).length > 0);
+  const hasDetail = !!summary || !!output || (tool.input && Object.keys(tool.input).length > 0);
 
   return (
     <Collapsible className="rounded-lg border border-border bg-card/50">
@@ -91,12 +82,12 @@ export function ToolCall({ part }: { part: AnyPart }) {
         className="group flex w-full items-center gap-2 px-2.5 py-2 text-left disabled:cursor-default"
       >
         <Icon className="size-3.5 shrink-0 text-muted-foreground" />
-        <span className="shrink-0 text-xs font-medium text-foreground">{label}</span>
+        <span className="shrink-0 text-xs font-medium text-foreground">{tool.title}</span>
         {summary && (
           <span className="truncate font-mono text-xs text-muted-foreground">{summary}</span>
         )}
         <span className="ml-auto flex items-center gap-1.5">
-          <StatusDot status={status} />
+          <StatusDot status={tool.status} />
           {hasDetail && (
             <ChevronRight className="size-3.5 text-muted-foreground transition-transform group-data-[state=open]:rotate-90" />
           )}
@@ -105,16 +96,16 @@ export function ToolCall({ part }: { part: AnyPart }) {
       {hasDetail && (
         <CollapsibleContent>
           <div className="space-y-2 border-t border-border px-2.5 py-2">
-            {state.input && Object.keys(state.input).length > 0 && (
+            {tool.input && Object.keys(tool.input).length > 0 && (
               <pre className="max-h-48 overflow-auto rounded-md bg-muted/50 p-2 font-mono text-[0.7rem] leading-relaxed text-muted-foreground scrollbar-thin">
-                {JSON.stringify(state.input, null, 2)}
+                {JSON.stringify(tool.input, null, 2)}
               </pre>
             )}
             {output && (
               <pre
                 className={cn(
                   'max-h-72 overflow-auto rounded-md bg-muted/50 p-2 font-mono text-[0.7rem] leading-relaxed scrollbar-thin',
-                  status === 'error' ? 'text-destructive' : 'text-foreground/80',
+                  tool.status === 'error' ? 'text-destructive' : 'text-foreground/80',
                 )}
               >
                 {output.slice(0, 6000)}

--- a/apps/whitelabel-demo/src/components/login-gate.tsx
+++ b/apps/whitelabel-demo/src/components/login-gate.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import { BRAND } from '@/config/brand';
+import { setSessionToken } from '@/lib/session';
+import { Loader2, LogIn } from 'lucide-react';
+import { useState } from 'react';
+import { BrandMark } from './brand-mark';
+import { Button } from './ui/button';
+import { Card } from './ui/card';
+import { Input } from './ui/input';
+import { Label } from './ui/label';
+
+/**
+ * Wrapper-mode's own login — replaces `ApiKeyGate` when the app is running as
+ * a BFF (`useWrapperMode()`). Posts to `/api/auth/login`, which checks the
+ * demo credential, signs an app session token, and returns it (also setting
+ * it as an HttpOnly cookie for the preview-iframe path). We store the token
+ * for the SDK's `getToken()` and hand off to `onReady`.
+ */
+export function LoginGate({ onReady }: { onReady: () => void }) {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [pending, setPending] = useState(false);
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setPending(true);
+    try {
+      const res = await fetch('/api/auth/login', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ email: email.trim(), password }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok || !data.token) {
+        setError(data.error ?? 'Could not sign in');
+        return;
+      }
+      setSessionToken(data.token);
+      onReady();
+    } catch {
+      setError('Could not reach the server');
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <div className="grid min-h-dvh place-items-center bg-background px-4">
+      <Card className="w-full max-w-sm p-6">
+        <BrandMark className="mb-5" />
+        <h1 className="text-lg font-semibold tracking-tight">Sign in to {BRAND.name}</h1>
+        <p className="mt-1.5 text-sm text-muted-foreground">
+          {BRAND.name} runs its own login here — your Kortix account stays on the server.
+        </p>
+        <form className="mt-5 space-y-3" onSubmit={submit}>
+          <div className="space-y-1.5">
+            <Label htmlFor="email">Email</Label>
+            <Input
+              id="email"
+              type="email"
+              autoFocus
+              required
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="you@example.com"
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="password">Password</Label>
+            <Input
+              id="password"
+              type="password"
+              required
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              placeholder="••••••••"
+            />
+          </div>
+          {error && <p className="text-sm text-destructive">{error}</p>}
+          <Button type="submit" className="w-full" disabled={pending || !email.trim() || !password}>
+            {pending ? <Loader2 className="size-4 animate-spin" /> : <LogIn className="size-4" />}
+            Sign in
+          </Button>
+        </form>
+      </Card>
+    </div>
+  );
+}

--- a/apps/whitelabel-demo/src/components/settings/connectors-tab.tsx
+++ b/apps/whitelabel-demo/src/components/settings/connectors-tab.tsx
@@ -24,6 +24,7 @@ import { Separator } from '@/components/ui/separator';
 import { Skeleton } from '@/components/ui/skeleton';
 import { kortix } from '@/lib/kortix';
 import { cn } from '@/lib/utils';
+import type { AdminConnector } from '@kortix/sdk/projects-client';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Loader2, Plug, RefreshCw, Settings2, Trash2 } from 'lucide-react';
 import { useState } from 'react';
@@ -65,9 +66,8 @@ export function ConnectorsTab({ projectId }: { projectId: string }) {
   const sync = useMutation({
     mutationFn: () => kortix.project(projectId).connectors.sync(),
     onSuccess: (res) => {
-      const r = res as any;
       refresh();
-      toast.success(`Synced ${r?.synced ?? 0} connector(s)`);
+      toast.success(`Synced ${res.synced} connector(s)`);
     },
     onError: () => toast.error('Sync failed'),
   });
@@ -99,8 +99,7 @@ export function ConnectorsTab({ projectId }: { projectId: string }) {
     onError: () => toast.error('Could not remove connector'),
   });
 
-  const raw = connectors.data as any;
-  const items: any[] = Array.isArray(raw) ? raw : (raw?.connectors ?? []);
+  const items: AdminConnector[] = connectors.data?.connectors ?? [];
 
   return (
     <div className="space-y-4">
@@ -254,7 +253,7 @@ function ConnectorConfigDialog({
     enabled: open,
   });
 
-  const data = config.data as any;
+  const data = config.data;
   const rows: Array<[string, unknown]> = data
     ? Object.entries(data).filter(([, v]) => v !== null && typeof v !== 'object')
     : [];

--- a/apps/whitelabel-demo/src/components/settings/members-tab.tsx
+++ b/apps/whitelabel-demo/src/components/settings/members-tab.tsx
@@ -15,6 +15,12 @@ import {
 import { Skeleton } from '@/components/ui/skeleton';
 import { kortix } from '@/lib/kortix';
 import { relativeTime } from '@/lib/utils';
+import type {
+  PendingProjectInvite,
+  ProjectAccessMember,
+  ProjectAccessRequest,
+  ProjectGroupGrant,
+} from '@kortix/sdk/projects-client';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Check, Loader2, Mail, Send, Trash2, Users, X } from 'lucide-react';
 import { useState } from 'react';
@@ -119,13 +125,12 @@ export function MembersTab({ projectId }: { projectId: string }) {
     onError: () => toast.error('Could not revoke invite'),
   });
 
-  const accessData = access.data as any;
-  const members: any[] = Array.isArray(accessData) ? accessData : (accessData?.members ?? []);
-  const requestItems: any[] = ((requests.data as any)?.requests ?? []).filter(
-    (r: any) => (r?.status ?? 'pending') === 'pending',
+  const members: ProjectAccessMember[] = access.data?.members ?? [];
+  const requestItems: ProjectAccessRequest[] = (requests.data?.requests ?? []).filter(
+    (r) => r.status === 'pending',
   );
-  const pendingItems: any[] = (pending.data as any)?.pending ?? [];
-  const grantItems: any[] = (grants.data as any)?.grants ?? [];
+  const pendingItems: PendingProjectInvite[] = pending.data?.pending ?? [];
+  const grantItems: ProjectGroupGrant[] = grants.data?.grants ?? [];
 
   return (
     <div className="space-y-4">

--- a/apps/whitelabel-demo/src/components/settings/policies-tab.tsx
+++ b/apps/whitelabel-demo/src/components/settings/policies-tab.tsx
@@ -52,16 +52,10 @@ export function PoliciesTab({ projectId }: { projectId: string }) {
 
   // Seed local editable state from the server whenever a fresh listing arrives.
   useEffect(() => {
-    const data = policies.data as any;
+    const data = policies.data;
     if (!data) return;
-    const list: any[] = Array.isArray(data) ? data : (data?.policies ?? []);
-    setRules(
-      list.map((p) => ({
-        match: String(p?.match ?? ''),
-        action: (p?.action ?? 'require_approval') as PolicyAction,
-      })),
-    );
-    setDefaultMode((data?.defaultMode ?? 'risk') as DefaultMode);
+    setRules(data.policies.map((p) => ({ match: p.match, action: p.action })));
+    setDefaultMode(data.defaultMode);
   }, [policies.data]);
 
   const save = useMutation({

--- a/apps/whitelabel-demo/src/components/settings/secrets-tab.tsx
+++ b/apps/whitelabel-demo/src/components/settings/secrets-tab.tsx
@@ -8,6 +8,7 @@ import { Label } from '@/components/ui/label';
 import { Separator } from '@/components/ui/separator';
 import { Skeleton } from '@/components/ui/skeleton';
 import { kortix } from '@/lib/kortix';
+import type { ProjectSecret } from '@kortix/sdk/projects-client';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { GitBranch, KeyRound, Loader2, Trash2, UserCog } from 'lucide-react';
 import { useState } from 'react';
@@ -57,8 +58,7 @@ export function SecretsTab({ projectId }: { projectId: string }) {
     onError: () => toast.error('Could not save git credential'),
   });
 
-  const raw = secrets.data as any;
-  const items: any[] = Array.isArray(raw) ? raw : (raw?.items ?? []);
+  const items: ProjectSecret[] = secrets.data?.items ?? [];
 
   return (
     <div className="space-y-4">
@@ -156,14 +156,14 @@ function SecretRow({
   removing,
 }: {
   projectId: string;
-  secret: any;
+  secret: ProjectSecret;
   onChanged: () => void;
   onRemove: () => void;
   removing: boolean;
 }) {
-  const name = String(secret?.name ?? '');
-  const mine = secret?.mine as { active: boolean } | null;
-  const effective = String(secret?.effective_source ?? 'none');
+  const name = secret.name;
+  const mine = secret.mine;
+  const effective = secret.effective_source;
   const [personal, setPersonal] = useState('');
 
   const setPersonalMut = useMutation({

--- a/apps/whitelabel-demo/src/components/settings/triggers-tab.tsx
+++ b/apps/whitelabel-demo/src/components/settings/triggers-tab.tsx
@@ -24,6 +24,7 @@ import {
 import { Skeleton } from '@/components/ui/skeleton';
 import { Textarea } from '@/components/ui/textarea';
 import { kortix } from '@/lib/kortix';
+import type { ProjectTrigger } from '@kortix/sdk/projects-client';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Loader2, Play, Trash2, Zap } from 'lucide-react';
 import { useState } from 'react';
@@ -46,9 +47,8 @@ export function TriggersTab({ projectId }: { projectId: string }) {
   const [cron, setCron] = useState('0 0 * * * *');
   const [prompt, setPrompt] = useState('');
 
-  const data = triggers.data as any;
-  const items: any[] = Array.isArray(data) ? data : (data?.triggers ?? []);
-  const paused: boolean = Boolean(data?.triggers_paused);
+  const items: ProjectTrigger[] = triggers.data?.triggers ?? [];
+  const paused: boolean = Boolean(triggers.data?.triggers_paused);
 
   const setActivation = useMutation({
     mutationFn: (next: boolean) => kortix.project(projectId).triggers.setActivation(next),
@@ -79,8 +79,7 @@ export function TriggersTab({ projectId }: { projectId: string }) {
   const fire = useMutation({
     mutationFn: (slug: string) => kortix.project(projectId).triggers.fire(slug),
     onSuccess: (res) => {
-      const r = res as any;
-      toast.success(`Trigger ${r?.status ?? 'fired'}`);
+      toast.success(`Trigger ${res.status}`);
     },
     onError: () => toast.error('Could not fire trigger'),
   });
@@ -253,13 +252,13 @@ function EditTriggerDialog({
 }: {
   projectId: string;
   slug: string;
-  trigger: any;
+  trigger: ProjectTrigger;
   onSaved: () => void;
 }) {
   const [open, setOpen] = useState(false);
-  const [name, setName] = useState(String(trigger?.name ?? ''));
-  const [prompt, setPrompt] = useState(String(trigger?.prompt_template ?? ''));
-  const [enabled, setEnabled] = useState<'on' | 'off'>(trigger?.enabled === false ? 'off' : 'on');
+  const [name, setName] = useState(trigger.name);
+  const [prompt, setPrompt] = useState(trigger.prompt_template);
+  const [enabled, setEnabled] = useState<'on' | 'off'>(trigger.enabled === false ? 'off' : 'on');
 
   const update = useMutation({
     mutationFn: () =>

--- a/apps/whitelabel-demo/src/components/workbench/changes/change-requests-view.tsx
+++ b/apps/whitelabel-demo/src/components/workbench/changes/change-requests-view.tsx
@@ -25,6 +25,7 @@ import { ScrollArea } from '@/components/ui/scroll-area';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Textarea } from '@/components/ui/textarea';
 import { kortix } from '@/lib/kortix';
+import type { ChangeRequest } from '@kortix/sdk/projects-client';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { ArrowLeft, GitMerge, GitPullRequest, Loader2, Plus, RotateCcw, X } from 'lucide-react';
 import { useState } from 'react';
@@ -52,7 +53,7 @@ export function ChangeRequestsView({
     queryFn: () => kortix.project(projectId).changeRequests.list(),
   });
 
-  const items: any[] = (list.data as any)?.change_requests ?? [];
+  const items: ChangeRequest[] = list.data?.change_requests ?? [];
 
   if (selectedCrId) {
     return (
@@ -185,9 +186,9 @@ function ChangeRequestDetail({
   });
 
   // changeRequests.get() returns { change_request: ChangeRequest } — unwrap it.
-  const cr = (detail.data as any)?.change_request;
-  const mp = mergePreview.data as any;
-  const df = diff.data as any;
+  const cr = detail.data?.change_request;
+  const mp = mergePreview.data;
+  const df = diff.data;
   const status: string = cr?.status ?? 'open';
   const busy = merge.isPending || close.isPending || reopen.isPending;
 

--- a/apps/whitelabel-demo/src/components/workbench/changes/commits-view.tsx
+++ b/apps/whitelabel-demo/src/components/workbench/changes/commits-view.tsx
@@ -24,6 +24,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { Textarea } from '@/components/ui/textarea';
 import { kortix } from '@/lib/kortix';
 import { relativeTime } from '@/lib/utils';
+import type { ProjectBranch, ProjectCommit } from '@kortix/sdk/projects-client';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Check, GitBranch, GitCommitHorizontal, Loader2, Scale } from 'lucide-react';
 import { useState } from 'react';
@@ -52,7 +53,7 @@ export function CommitsView({
     queryFn: () => kortix.project(projectId).git.commits(),
   });
 
-  const defaultBranch = (branches.data as any)?.default_branch as string | undefined;
+  const defaultBranch = branches.data?.default_branch;
 
   // "Compare to base": summarize the session branch against the default branch.
   const versionDiff = useQuery({
@@ -71,12 +72,11 @@ export function CommitsView({
         .session(projectId, sessionId)
         .commit(message.trim() ? { message: message.trim() } : undefined),
     onSuccess: (res) => {
-      const r = res as any;
-      if (r?.nothing_to_do) {
+      if (res.nothing_to_do) {
         toast.info('Nothing to commit');
       } else {
         toast.success(
-          r?.pushed ? 'Committed and pushed session changes' : 'Committed session changes',
+          res.pushed ? 'Committed and pushed session changes' : 'Committed session changes',
         );
       }
       setMessage('');
@@ -86,9 +86,9 @@ export function CommitsView({
     onError: () => toast.error('Could not commit session changes'),
   });
 
-  const branchItems: any[] = (branches.data as any)?.branches ?? [];
-  const commitItems: any[] = (commits.data as any)?.commits ?? [];
-  const vd = versionDiff.data as any;
+  const branchItems: ProjectBranch[] = branches.data?.branches ?? [];
+  const commitItems: ProjectCommit[] = commits.data?.commits ?? [];
+  const vd = versionDiff.data;
 
   return (
     <div className="flex h-full min-h-0 flex-col gap-3">
@@ -271,8 +271,8 @@ function CommitDetailDialog({
     queryFn: () => kortix.project(projectId).git.commitDiff(sha as string),
   });
 
-  const d = detail.data as any;
-  const files: any[] = d?.files ?? [];
+  const d = detail.data;
+  const files = d?.files ?? [];
 
   return (
     <Dialog open={!!sha} onOpenChange={(o) => !o && onClose()}>
@@ -309,7 +309,7 @@ function CommitDetailDialog({
           {diff.isLoading ? (
             <Skeleton className="h-40 w-full" />
           ) : (
-            <DiffView patch={(diff.data as any)?.patch} />
+            <DiffView patch={diff.data?.patch} />
           )}
         </ScrollArea>
       </DialogContent>

--- a/apps/whitelabel-demo/src/components/workbench/files-panel.tsx
+++ b/apps/whitelabel-demo/src/components/workbench/files-panel.tsx
@@ -10,9 +10,6 @@
  *   kortix.project(id).files.read(path, ref?) → the monospace viewer (right pane)
  *   kortix.project(id).files.history(path, …) → the per-file "History" popover
  *   kortix.project(id).files.archive(ref, …)  → the "Download" button
- *
- * Shapes are read defensively (cast to `any`) so backend shape variance never
- * breaks the build or the UI.
  */
 
 import { Badge } from '@/components/ui/badge';
@@ -25,6 +22,11 @@ import { Separator } from '@/components/ui/separator';
 import { Skeleton } from '@/components/ui/skeleton';
 import { kortix } from '@/lib/kortix';
 import { cn } from '@/lib/utils';
+import type {
+  ProjectCommit,
+  ProjectFileEntry,
+  ProjectFileSearchMatch,
+} from '@kortix/sdk/projects-client';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import {
   Download,
@@ -101,17 +103,14 @@ export function FilesPanel({ projectId }: { projectId: string }) {
     onError: () => toast.error('Could not download archive'),
   });
 
-  const listRaw = list.data as any;
-  const listItems: any[] = Array.isArray(listRaw)
-    ? listRaw
-    : (listRaw?.items ?? listRaw?.files ?? []);
+  const listItems: ProjectFileEntry[] = list.data ?? [];
+  const searchItems: ProjectFileSearchMatch[] = search.data?.results ?? [];
 
-  const searchRaw = search.data as any;
-  const searchItems: any[] = Array.isArray(searchRaw)
-    ? searchRaw
-    : (searchRaw?.results ?? searchRaw?.items ?? []);
-
-  const rows = searching ? searchItems : listItems;
+  // Normalize the two distinct row shapes (workspace tree vs search match) to
+  // the handful of fields the list below actually renders.
+  const rows: Array<{ path: string; lineText?: string }> = searching
+    ? searchItems.map((m) => ({ path: m.path, lineText: m.line_text }))
+    : listItems.map((f) => ({ path: f.path }));
   const rowsLoading = searching ? search.isLoading : list.isLoading;
   const rowsReady = searching ? search.isSuccess : list.isSuccess;
 
@@ -176,9 +175,9 @@ export function FilesPanel({ projectId }: { projectId: string }) {
               )}
 
               {rows.map((item, i) => {
-                const path: string = item?.path ?? item?.name ?? String(i);
+                const path = item.path;
                 const active = path === selected;
-                const lineText: string | undefined = item?.line_text;
+                const lineText = item.lineText;
                 return (
                   <div
                     key={`${path}-${i}`}
@@ -248,7 +247,7 @@ export function FilesPanel({ projectId }: { projectId: string }) {
                 )}
                 {content.isSuccess && (
                   <pre className="whitespace-pre-wrap break-words p-4 font-mono text-[0.7rem] leading-relaxed text-foreground/80">
-                    {(content.data as any)?.content ?? ''}
+                    {content.data?.content ?? ''}
                   </pre>
                 )}
               </ScrollArea>
@@ -275,8 +274,7 @@ function FileHistory({ projectId, path }: { projectId: string; path: string }) {
     enabled: open,
   });
 
-  const raw = history.data as any;
-  const commits: any[] = Array.isArray(raw) ? raw : (raw?.commits ?? raw?.items ?? []);
+  const commits: ProjectCommit[] = history.data?.commits ?? [];
 
   return (
     <Popover open={open} onOpenChange={setOpen}>

--- a/apps/whitelabel-demo/src/components/workbench/preview-panel.tsx
+++ b/apps/whitelabel-demo/src/components/workbench/preview-panel.tsx
@@ -48,8 +48,12 @@ import {
 import { Separator } from '@/components/ui/separator';
 import { Skeleton } from '@/components/ui/skeleton';
 import { kortix } from '@/lib/kortix';
+import { buildDirectPreviewUrl, parseProxiedPreviewUrl } from '@/lib/preview';
+import { getSessionToken } from '@/lib/session';
 import { cn } from '@/lib/utils';
 import { SessionNotReadyError } from '@kortix/sdk';
+import type { SessionPublicShare } from '@kortix/sdk/projects-client';
+import { useWrapperMode } from '@/app/providers';
 
 // Session sharing intent — a subset of the SDK's ConnectorSharing union that
 // needs no extra ids (private requires an ownerId, so it's omitted here).
@@ -65,8 +69,8 @@ function statusVariant(status?: string) {
 }
 
 /** Best-effort copyable URL for a public share, defensively reading its shape. */
-function shareUrl(share: any): string {
-  const raw: string = share?.public_path ?? share?.proxy_path ?? share?.public_token ?? '';
+function shareUrl(share: SessionPublicShare): string {
+  const raw: string = share.public_path ?? share.proxy_path ?? share.public_token ?? '';
   if (!raw) return '';
   if (/^https?:\/\//.test(raw)) return raw;
   if (typeof window !== 'undefined') {
@@ -96,6 +100,7 @@ export function PreviewPanel({
   sessionId: string;
 }) {
   const qc = useQueryClient();
+  const wrapperMode = useWrapperMode();
   const session = useMemo(() => kortix.session(projectId, sessionId), [projectId, sessionId]);
 
   const previewsKey = ['session-previews', projectId, sessionId];
@@ -136,8 +141,8 @@ export function PreviewPanel({
     queryFn: () => session.publicShares.list(),
   });
 
-  const candidates = (previewsQuery.data?.candidates ?? []) as any[];
-  const shares = (sharesQuery.data?.shares ?? []) as any[];
+  const candidates = previewsQuery.data?.candidates ?? [];
+  const shares = sharesQuery.data?.shares ?? [];
 
   // Default the selection to the first candidate once they arrive / keep a
   // valid selection if the previously-selected port disappears.
@@ -150,6 +155,27 @@ export function PreviewPanel({
 
   const selected = candidates.find((c) => c.id === selectedId) ?? null;
 
+  // Wrapper mode only: mint (and cache) a short-lived project-scoped Kortix
+  // token so the preview iframe can open the sandbox DIRECTLY instead of
+  // through our same-origin proxy — a Next.js route handler can't proxy a
+  // WebSocket upgrade (dev-server HMR sockets, etc.), so the iframe needs a
+  // real upstream URL + scoped credential instead. See
+  // `src/app/api/preview-token/route.ts`.
+  const previewTokenQuery = useQuery({
+    queryKey: ['preview-token', projectId],
+    queryFn: async () => {
+      const sessionToken = getSessionToken();
+      const res = await fetch(`/api/preview-token?projectId=${encodeURIComponent(projectId)}`, {
+        headers: sessionToken ? { authorization: `Bearer ${sessionToken}` } : undefined,
+      });
+      if (!res.ok) throw new Error('Could not mint a preview token');
+      return res.json() as Promise<{ token: string; upstream: string }>;
+    },
+    enabled: wrapperMode,
+    staleTime: 5 * 60_000,
+    retry: false,
+  });
+
   // SYNC — call directly in render, never awaited. This handle never itself
   // calls ensureReady() (the chat surface elsewhere on the page does, via the
   // shared session-runtime registry) — before that resolves, previewUrl()
@@ -158,7 +184,18 @@ export function PreviewPanel({
   const previewSrc = selected
     ? (() => {
         try {
-          return session.previewUrl(selected.port, selected.path);
+          const proxiedUrl = session.previewUrl(selected.port, selected.path);
+          if (wrapperMode && previewTokenQuery.data) {
+            const parsed = parseProxiedPreviewUrl(proxiedUrl);
+            if (parsed) {
+              return buildDirectPreviewUrl(
+                previewTokenQuery.data.upstream,
+                parsed,
+                previewTokenQuery.data.token,
+              );
+            }
+          }
+          return proxiedUrl;
         } catch (err) {
           if (err instanceof SessionNotReadyError) return null;
           throw err;

--- a/apps/whitelabel-demo/src/components/workbench/session-header.tsx
+++ b/apps/whitelabel-demo/src/components/workbench/session-header.tsx
@@ -20,6 +20,7 @@ import { Input } from '@/components/ui/input';
 import { kortix } from '@/lib/kortix';
 import { invalidateSessions, qk } from '@/lib/query-keys';
 import { cn } from '@/lib/utils';
+import { isRuntimeReady } from '@kortix/sdk/session';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { MoreVertical, Pencil, RotateCw, Trash2 } from 'lucide-react';
 import { useRouter } from 'next/navigation';
@@ -43,7 +44,7 @@ export function SessionHeader({ projectId, sessionId }: { projectId: string; ses
     refetchInterval: 15_000,
     retry: false,
   });
-  const ready = (health.data as any)?.ok && (health.data as any)?.health?.runtimeReady;
+  const ready = health.data?.ok && isRuntimeReady(health.data?.health ?? null);
 
   return (
     <header className="flex h-14 shrink-0 items-center gap-3 border-b border-border px-5">

--- a/apps/whitelabel-demo/src/config/brand.ts
+++ b/apps/whitelabel-demo/src/config/brand.ts
@@ -15,3 +15,23 @@ export const BRAND = {
 } as const;
 
 export type Brand = typeof BRAND;
+
+/**
+ * The backend URL the SDK should target, per mode:
+ *  - **direct mode** (`wrapperMode: false`) → `BRAND.apiUrl`, a real Kortix
+ *    deployment; the browser holds a pasted PAT and talks to it directly.
+ *  - **wrapper mode** (`wrapperMode: true`) → this app's own same-origin BFF
+ *    proxy (`src/app/api/kortix/[...path]/route.ts`), which holds the real
+ *    Kortix API key server-side and re-authenticates every request against
+ *    this app's own login session instead.
+ *
+ * Always resolves to an ABSOLUTE url. The SDK parses `backendUrl` with
+ * `new URL()` in a few places (proxy/preview URL building) which requires an
+ * absolute base — a bare `/api/kortix` would throw there, so wrapper mode
+ * builds `${window.location.origin}/api/kortix` instead.
+ */
+export function resolveApiUrl(wrapperMode: boolean): string {
+  if (!wrapperMode) return BRAND.apiUrl;
+  const origin = typeof window !== 'undefined' ? window.location.origin : '';
+  return `${origin}/api/kortix`;
+}

--- a/apps/whitelabel-demo/src/lib/kortix.ts
+++ b/apps/whitelabel-demo/src/lib/kortix.ts
@@ -1,12 +1,15 @@
 'use client';
 
-import { BRAND } from '@/config/brand';
-import { createKortix } from '@kortix/sdk';
+import { BRAND, resolveApiUrl } from '@/config/brand';
+import { configureKortix, createKortix } from '@kortix/sdk';
+import { getSessionToken } from './session';
 
 /**
  * The white-label's single seam to Kortix: the official `@kortix/sdk`. No raw
- * HTTP, no OpenCode imports. One token (a Kortix API key) supplied via `getToken`.
- * Swap `BRAND.apiUrl` + the key to re-point at any Kortix deployment.
+ * HTTP, no OpenCode imports. One token supplied via `getToken` — a pasted
+ * Kortix API key in direct mode, or Lumen's own session token in wrapper mode
+ * (see `configureWrapperMode` below). Swap `BRAND.apiUrl` + the key to
+ * re-point direct mode at any Kortix deployment.
  */
 
 const TOKEN_KEY = 'kortix_api_key';
@@ -24,8 +27,26 @@ export function clearApiKey(): void {
   window.localStorage.removeItem(TOKEN_KEY);
 }
 
-/** The configured client. `createKortix` wires the platform seam once on import. */
+/**
+ * The configured client. `createKortix` wires the platform seam once on
+ * import, defaulting to direct mode. All of its methods read the platform
+ * config LIVE on every call (not at creation time), so `configureWrapperMode`
+ * below can safely re-point the same `kortix` object at the wrapper proxy
+ * later — no consumer needs to re-import or re-create anything.
+ */
 export const kortix = createKortix({
   backendUrl: BRAND.apiUrl,
   getToken: async () => getApiKey(),
 });
+
+/**
+ * Re-point the SDK at the same-origin BFF proxy once `Providers` confirms
+ * wrapper mode is on (`GET /api/mode`). Direct mode never calls this — `kortix`
+ * stays wired to `BRAND.apiUrl` + the pasted API key, unchanged.
+ */
+export function configureWrapperMode(): void {
+  configureKortix({
+    backendUrl: resolveApiUrl(true),
+    getToken: async () => getSessionToken(),
+  });
+}

--- a/apps/whitelabel-demo/src/lib/mode.ts
+++ b/apps/whitelabel-demo/src/lib/mode.ts
@@ -1,0 +1,18 @@
+'use client';
+
+/**
+ * Fetches (once, module-cached) whether the server is running in wrapper mode
+ * — see `GET /api/mode`. `Providers` awaits this before rendering anything so
+ * no data call fires against the wrong `backendUrl` (see providers.tsx).
+ */
+let modePromise: Promise<boolean> | null = null;
+
+export function fetchWrapperMode(): Promise<boolean> {
+  if (!modePromise) {
+    modePromise = fetch('/api/mode')
+      .then((res) => (res.ok ? res.json() : { wrapperMode: false }))
+      .then((data) => !!data?.wrapperMode)
+      .catch(() => false);
+  }
+  return modePromise;
+}

--- a/apps/whitelabel-demo/src/lib/preview.ts
+++ b/apps/whitelabel-demo/src/lib/preview.ts
@@ -1,0 +1,47 @@
+/**
+ * Wrapper-mode direct-preview helpers.
+ *
+ * `session.previewUrl()` always builds its URL from the SDK's configured
+ * `backendUrl` — in wrapper mode that's this app's own `/api/kortix` proxy, so
+ * the result looks like `${origin}/api/kortix/p/{sandboxId}/{port}{path}`
+ * (the SDK's path-based proxy form; see `packages/sdk/src/session/url.ts`).
+ * We parse that shape locally — rather than reaching into an SDK-internal
+ * module for `parseSubdomainUrl` — to pull out `{sandboxId, port, path}`, then
+ * rebuild a DIRECT upstream preview URL using a short-lived, project-scoped
+ * token from `/api/preview-token`. Going direct-to-upstream (instead of
+ * through our own proxy) is required because a Next.js route handler can't
+ * proxy a WebSocket upgrade — see `src/app/api/preview-token/route.ts`.
+ */
+
+const PROXY_PATH_RE = /\/p\/([^/]+)\/(\d+)(\/.*)?$/;
+
+export interface ParsedProxyPreview {
+  sandboxId: string;
+  port: number;
+  path: string;
+}
+
+/** Extract `{sandboxId, port, path}` from a proxied preview URL, or `null` if it isn't one. */
+export function parseProxiedPreviewUrl(proxiedUrl: string): ParsedProxyPreview | null {
+  try {
+    const { pathname, search, hash } = new URL(proxiedUrl);
+    const match = pathname.match(PROXY_PATH_RE);
+    if (!match) return null;
+    return { sandboxId: match[1], port: Number(match[2]), path: `${match[3] || '/'}${search}${hash}` };
+  } catch {
+    return null;
+  }
+}
+
+/** Build a direct (non-proxied) upstream preview URL authenticated with a scoped token. */
+export function buildDirectPreviewUrl(
+  upstreamBase: string,
+  parsed: ParsedProxyPreview,
+  token: string,
+): string {
+  const base = upstreamBase.replace(/\/+$/, '');
+  const path = parsed.path.startsWith('/') ? parsed.path : `/${parsed.path}`;
+  const url = new URL(`${base}/p/${parsed.sandboxId}/${parsed.port}${path}`);
+  url.searchParams.set('token', token);
+  return url.toString();
+}

--- a/apps/whitelabel-demo/src/lib/session.ts
+++ b/apps/whitelabel-demo/src/lib/session.ts
@@ -1,0 +1,26 @@
+'use client';
+
+/**
+ * Wrapper-mode's client-side token store — the counterpart to
+ * `getApiKey`/`setApiKey`/`clearApiKey` in `src/lib/kortix.ts` for direct mode.
+ * Holds the signed app session token `/api/auth/login` returns, fed to the SDK
+ * via `getToken()` (see `configureWrapperMode`). The REAL credential is also
+ * set as an HttpOnly cookie by the login route — this localStorage copy only
+ * exists so the SDK's REST/SSE calls (which don't carry cookies) can attach
+ * `Authorization: Bearer …`.
+ */
+
+const SESSION_KEY = 'lumen_session';
+
+export function getSessionToken(): string | null {
+  if (typeof window === 'undefined') return null;
+  return window.localStorage.getItem(SESSION_KEY);
+}
+
+export function setSessionToken(token: string): void {
+  window.localStorage.setItem(SESSION_KEY, token.trim());
+}
+
+export function clearSessionToken(): void {
+  window.localStorage.removeItem(SESSION_KEY);
+}

--- a/apps/whitelabel-demo/src/server/auth.ts
+++ b/apps/whitelabel-demo/src/server/auth.ts
@@ -1,0 +1,129 @@
+/**
+ * Wrapper-mode session tokens — Lumen's OWN auth, entirely separate from the
+ * Kortix API key. HMAC-signed, `node:crypto` only (no JWT dependency):
+ *
+ *   token := base64url(JSON payload) + "." + base64url(HMAC-SHA256(payload))
+ *
+ * `POST /api/auth/login` mints one and returns it in the JSON body (the
+ * client stores it and sends it as `Authorization: Bearer <token>` — the
+ * SDK's REST calls don't carry cookies) AND sets it as an HttpOnly cookie
+ * (the preview iframe's same-origin requests can't attach headers, but they
+ * DO carry cookies automatically). `getRequestSession` checks both places.
+ */
+
+import { createHmac, timingSafeEqual } from 'node:crypto';
+
+export const SESSION_COOKIE_NAME = 'lumen_session';
+
+const SESSION_TTL_SECONDS = 60 * 60 * 24 * 7; // 7 days
+
+export interface SessionPayload {
+  /** The demo "user id" — just the email they logged in with. */
+  userId: string;
+  iat: number;
+  exp: number;
+}
+
+function b64url(input: string): string {
+  return Buffer.from(input, 'utf8').toString('base64url');
+}
+
+function getSessionSecret(): string {
+  const secret = process.env.SESSION_SECRET;
+  if (!secret) {
+    throw new Error(
+      'SESSION_SECRET is not set. Wrapper mode requires SESSION_SECRET to sign session tokens (see .env.example).',
+    );
+  }
+  return secret;
+}
+
+function sign(body: string): string {
+  return createHmac('sha256', getSessionSecret()).update(body).digest('base64url');
+}
+
+/** Mint a signed session token for `userId`. */
+export function signSession(userId: string): string {
+  const now = Math.floor(Date.now() / 1000);
+  const payload: SessionPayload = { userId, iat: now, exp: now + SESSION_TTL_SECONDS };
+  const body = b64url(JSON.stringify(payload));
+  return `${body}.${sign(body)}`;
+}
+
+/** Verify a signed session token. Returns `null` on any invalid/expired/missing input. */
+export function verifySession(token: string | null | undefined): SessionPayload | null {
+  if (!token) return null;
+  const dot = token.indexOf('.');
+  if (dot < 0) return null;
+  const body = token.slice(0, dot);
+  const sig = token.slice(dot + 1);
+
+  let expected: string;
+  try {
+    expected = sign(body);
+  } catch {
+    return null; // SESSION_SECRET not configured — fail closed, not open.
+  }
+
+  const a = Buffer.from(sig);
+  const b = Buffer.from(expected);
+  if (a.length !== b.length || !timingSafeEqual(a, b)) return null;
+
+  try {
+    const payload = JSON.parse(Buffer.from(body, 'base64url').toString('utf8')) as SessionPayload;
+    if (typeof payload.userId !== 'string' || !payload.userId) return null;
+    if (typeof payload.exp !== 'number' || payload.exp * 1000 < Date.now()) return null;
+    return payload;
+  } catch {
+    return null;
+  }
+}
+
+/** Pull the bearer token out of an `Authorization: Bearer …` header, if present. */
+function bearerFromHeader(req: Request): string | null {
+  const header = req.headers.get('authorization');
+  if (!header?.startsWith('Bearer ')) return null;
+  return header.slice('Bearer '.length).trim() || null;
+}
+
+/** Pull the session cookie value out of the request's `Cookie` header, if present. */
+function cookieFromHeader(req: Request): string | null {
+  const header = req.headers.get('cookie');
+  if (!header) return null;
+  for (const part of header.split(';')) {
+    const eq = part.indexOf('=');
+    if (eq < 0) continue;
+    const name = part.slice(0, eq).trim();
+    if (name === SESSION_COOKIE_NAME) {
+      try {
+        return decodeURIComponent(part.slice(eq + 1).trim());
+      } catch {
+        return part.slice(eq + 1).trim();
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Resolve + verify the caller's app session: `Authorization: Bearer …` first
+ * (the REST/SSE path), falling back to the `lumen_session` cookie (the
+ * preview-iframe path, which can't set headers). Returns `null` if neither is
+ * present or valid — the caller should respond 401.
+ */
+export function getRequestSession(req: Request): SessionPayload | null {
+  return verifySession(bearerFromHeader(req)) ?? verifySession(cookieFromHeader(req));
+}
+
+/**
+ * Minimal, credible demo login: any email-shaped string + (any non-empty
+ * password, or an exact match against `DEMO_PASSWORD` if that env var is
+ * set). There is no user directory — `userId` IS the email.
+ */
+export function checkDemoCredentials(email: string, password: string): boolean {
+  if (!email || !/^\S+@\S+\.\S+$/.test(email)) return false;
+  if (!password) return false;
+  const expected = process.env.DEMO_PASSWORD;
+  if (!expected) return true;
+  return password === expected;
+}

--- a/apps/whitelabel-demo/src/server/auth.ts
+++ b/apps/whitelabel-demo/src/server/auth.ts
@@ -121,7 +121,10 @@ export function getRequestSession(req: Request): SessionPayload | null {
  * set). There is no user directory — `userId` IS the email.
  */
 export function checkDemoCredentials(email: string, password: string): boolean {
-  if (!email || !/^\S+@\S+\.\S+$/.test(email)) return false;
+  // Length cap + non-overlapping character classes ([^\s@] can never match the
+  // literal @ or . delimiters) keep this linear — the naive \S+@\S+\.\S+ form
+  // backtracks polynomially on adversarial input (CodeQL js/polynomial-redos).
+  if (!email || email.length > 254 || !/^[^\s@]+@[^\s@]+\.[^\s@.]+$/.test(email)) return false;
   if (!password) return false;
   const expected = process.env.DEMO_PASSWORD;
   if (!expected) return true;

--- a/apps/whitelabel-demo/src/server/policy.ts
+++ b/apps/whitelabel-demo/src/server/policy.ts
@@ -1,0 +1,118 @@
+/**
+ * Wrapper-mode route policy — the single explicit table of what an
+ * authenticated wrapper end user is allowed to reach through
+ * `app/api/kortix/[...path]/route.ts`.
+ *
+ * Deny-by-default. This is deliberately NARROWER than what a project-scoped
+ * Kortix PAT can do (`apps/api/src/middleware/auth.ts`'s
+ * `enforceTokenProjectScope`) — that gate protects ONE project's token from
+ * reaching other projects; this one protects an entire Kortix ACCOUNT (the
+ * operator's, behind `KORTIX_API_KEY`) from an unbounded number of wrapper end
+ * users, so it also blocks account-admin surfaces (members, invites, billing,
+ * GitHub App installs, platform/admin) outright — those are the operator's to
+ * manage from their own Kortix dashboard, never delegated to end users.
+ *
+ * Every rule below is derived from which `@kortix/sdk` calls this app's own
+ * UI actually makes (`grep -rn 'kortix\.' src` in `apps/whitelabel-demo`) —
+ * see the per-rule comments for the reasoning, not just the shape.
+ */
+
+export interface PolicyResult {
+  allow: boolean;
+  /** Only meaningful when `allow` is false. */
+  status: number;
+  reason: string;
+  /** `GET /projects` → the proxy should filter the response to owned projects. */
+  filterProjectsList?: boolean;
+  /** `POST /projects/provision` → the proxy should record the new project as owned. */
+  recordProvisionOwner?: boolean;
+}
+
+function allow(extra: Partial<PolicyResult> = {}): PolicyResult {
+  return { allow: true, status: 200, reason: '', ...extra };
+}
+
+function deny(status: number, reason: string): PolicyResult {
+  return { allow: false, status, reason };
+}
+
+/**
+ * @param method  HTTP method (any case).
+ * @param path    Upstream path with the leading `/v1` and any leading/trailing
+ *                slashes stripped, e.g. `projects/abc123/gateway/sessions`,
+ *                `accounts`, `p/sb_123/3000/index.html`.
+ * @param isOwner Predicate: does the caller own this project id?
+ */
+export function evaluatePolicy(
+  method: string,
+  path: string,
+  isOwner: (projectId: string) => boolean,
+): PolicyResult {
+  const p = path.replace(/^\/+/, '').replace(/\/+$/, '');
+  const m = method.toUpperCase();
+
+  // ── Preview proxy (`/v1/p/...`) ───────────────────────────────────────────
+  // Covers the sandbox runtime proxy (`p/{sandboxId}/{port}/...` — every REST
+  // call, SSE stream, and opencode runtime call the SDK makes for an active
+  // session), the preview session-cookie mint (`p/auth`), and public-share
+  // creation (`p/share`, used by the preview panel's "Create public share").
+  //
+  // The proxy has ALREADY required a valid app session before policy ever
+  // runs (see route.ts) — that's the only check enforced here. We deliberately
+  // do NOT cross-check sandbox → project ownership at this layer: there is no
+  // cheap, already-cached sandboxId → projectId map available here (building
+  // one would mean an extra upstream round-trip on every proxied byte of a
+  // live dev-server response). The ownership-checked path is
+  // `/api/preview-token` (mints a project-scoped token only for a project the
+  // caller owns) — the preview panel uses that for the iframe itself in
+  // wrapper mode. This rule is the documented, narrower fallback: "any valid
+  // session can reach the proxy surface," not "any valid session can reach
+  // any sandbox."
+  if (/^p\//.test(p) || p === 'p') return allow();
+
+  // ── Projects: bare collection ─────────────────────────────────────────────
+  if (p === 'projects' && m === 'GET') return allow({ filterProjectsList: true });
+  if (p === 'projects' && m === 'POST') {
+    return deny(
+      403,
+      'Use /projects/provision — plain project creation bypasses per-user ownership tracking in wrapper mode.',
+    );
+  }
+  if (p === 'projects/create-repo') {
+    return deny(403, 'Not used by this app; blocked by default in wrapper mode.');
+  }
+  if (p === 'projects/provision' && m === 'POST') return allow({ recordProvisionOwner: true });
+
+  // ── Projects: scoped to one id ────────────────────────────────────────────
+  // Everything the app does once a project exists — detail, sessions,
+  // gateway (cost/logs), secrets, sandbox, llm-catalog, settings — all live
+  // under `projects/{id}/...`. Connector/policy management goes through
+  // `executor/projects/{id}/...` instead. Both require ownership of `{id}`.
+  const projMatch = p.match(/^projects\/([^/]+)(?:\/.*)?$/);
+  if (projMatch) {
+    return isOwner(projMatch[1]) ? allow() : deny(403, "You don't have access to this project.");
+  }
+  const execMatch = p.match(/^executor\/projects\/([^/]+)(?:\/.*)?$/);
+  if (execMatch) {
+    return isOwner(execMatch[1]) ? allow() : deny(403, "You don't have access to this project.");
+  }
+
+  // ── Accounts: self-identity probe only ────────────────────────────────────
+  // Mirrors the upstream project-scoped-PAT allowlist in
+  // `enforceTokenProjectScope` (`/v1/accounts/me` only). Every other
+  // `/accounts*` route — list, create, members, invites, leave, billing — is
+  // operator-only account administration and is NOT exposed to wrapper end
+  // users. Lumen's own `/account` page is a direct-mode-only surface in
+  // wrapper mode (see `src/app/account/page.tsx`).
+  if (p === 'accounts/me' && m === 'GET') return allow();
+  if (p === 'accounts' || p.startsWith('accounts/')) {
+    return deny(403, 'Account administration is not exposed in wrapper mode.');
+  }
+
+  // ── Everything else ────────────────────────────────────────────────────────
+  // billing/*, platform/* (operator sandbox-fleet admin), transcription,
+  // github/* (App installs are account-level) — none of these are used by
+  // this app's UI, and none belong to a single project a user owns. Deny by
+  // default rather than silently widen the surface later.
+  return deny(403, `Route not permitted in wrapper mode: ${m} /${p}`);
+}

--- a/apps/whitelabel-demo/src/server/rate-limit.ts
+++ b/apps/whitelabel-demo/src/server/rate-limit.ts
@@ -1,0 +1,50 @@
+/**
+ * In-memory token-bucket rate limiter, per authenticated `userId`. One bucket
+ * per user, refilled continuously at `RATE_LIMIT_PER_MIN / 60_000` tokens/ms
+ * so bursts smooth out instead of hard-resetting on a fixed window. Process-
+ * local (same caveat as `server/users.ts`) — fine for this reference demo's
+ * single-instance deployment.
+ */
+
+interface Bucket {
+  tokens: number;
+  updatedAt: number;
+}
+
+const buckets = new Map<string, Bucket>();
+
+function capacity(): number {
+  const n = Number(process.env.RATE_LIMIT_PER_MIN ?? 300);
+  return Number.isFinite(n) && n > 0 ? n : 300;
+}
+
+export interface RateLimitResult {
+  ok: boolean;
+  /** Only set when `ok` is false — how long until the next token is available. */
+  retryAfterMs?: number;
+}
+
+/** Consume one token for `userId`. Call once per proxied request. */
+export function consumeRateLimit(userId: string): RateLimitResult {
+  const cap = capacity();
+  const refillPerMs = cap / 60_000;
+  const now = Date.now();
+
+  let bucket = buckets.get(userId);
+  if (!bucket) {
+    bucket = { tokens: cap, updatedAt: now };
+    buckets.set(userId, bucket);
+  }
+
+  const elapsed = now - bucket.updatedAt;
+  bucket.tokens = Math.min(cap, bucket.tokens + elapsed * refillPerMs);
+  bucket.updatedAt = now;
+
+  if (bucket.tokens >= 1) {
+    bucket.tokens -= 1;
+    return { ok: true };
+  }
+
+  const deficit = 1 - bucket.tokens;
+  return { ok: false, retryAfterMs: Math.max(1, Math.ceil(deficit / refillPerMs)) };
+}

--- a/apps/whitelabel-demo/src/server/users.ts
+++ b/apps/whitelabel-demo/src/server/users.ts
@@ -36,14 +36,24 @@ function writeData(data: UsersData): void {
   writeFileSync(DATA_FILE, JSON.stringify(data, null, 2), 'utf8');
 }
 
+// Kortix project ids are UUIDs. Enforced on WRITE (only record what upstream
+// actually minted) and on READ (ids from this file end up inside upstream
+// request URLs — see /api/usage — so a hand-edited or corrupted store must
+// never be able to steer a request anywhere unexpected).
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function isValidProjectId(projectId: string): boolean {
+  return UUID_RE.test(projectId);
+}
+
 /** Every project id `userId` owns (created through the wrapper). */
 export function listOwnedProjects(userId: string): string[] {
-  return readData()[userId] ?? [];
+  return (readData()[userId] ?? []).filter(isValidProjectId);
 }
 
 /** Record that `userId` owns `projectId` — called right after a successful `/projects/provision`. */
 export function addOwnedProject(userId: string, projectId: string): void {
-  if (!userId || !projectId) return;
+  if (!userId || !isValidProjectId(projectId)) return;
   const data = readData();
   const existing = data[userId] ?? [];
   if (!existing.includes(projectId)) {

--- a/apps/whitelabel-demo/src/server/users.ts
+++ b/apps/whitelabel-demo/src/server/users.ts
@@ -15,7 +15,10 @@ import path from 'node:path';
 
 type UsersData = Record<string, string[]>;
 
-const DATA_DIR = path.join(process.cwd(), '.lumen-data');
+// LUMEN_DATA_DIR override exists so the e2e suite can point a test instance at
+// a throwaway temp dir — without it, tests booting `next start` from the app
+// dir share (and would wipe) the developer's real local store.
+const DATA_DIR = process.env.LUMEN_DATA_DIR || path.join(process.cwd(), '.lumen-data');
 const DATA_FILE = path.join(DATA_DIR, 'users.json');
 
 function readData(): UsersData {

--- a/apps/whitelabel-demo/src/server/users.ts
+++ b/apps/whitelabel-demo/src/server/users.ts
@@ -1,0 +1,55 @@
+/**
+ * Wrapper-mode per-user project ownership — a tiny JSON-file store, gitignored
+ * under `.lumen-data/` (created lazily). Maps `userId` (the login email) to
+ * the list of project ids they created THROUGH this wrapper.
+ *
+ * This is the whole isolation model: a wrapper end user only ever sees/can-act
+ * on projects they themselves provisioned. It's intentionally file-backed and
+ * synchronous — this is a reference demo for a single Node process, not a
+ * production multi-instance deployment. A real deployment would swap this for
+ * a real table (keyed the same way) without touching any caller.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+type UsersData = Record<string, string[]>;
+
+const DATA_DIR = path.join(process.cwd(), '.lumen-data');
+const DATA_FILE = path.join(DATA_DIR, 'users.json');
+
+function readData(): UsersData {
+  try {
+    if (!existsSync(DATA_FILE)) return {};
+    const raw = JSON.parse(readFileSync(DATA_FILE, 'utf8'));
+    return raw && typeof raw === 'object' ? (raw as UsersData) : {};
+  } catch {
+    return {};
+  }
+}
+
+function writeData(data: UsersData): void {
+  if (!existsSync(DATA_DIR)) mkdirSync(DATA_DIR, { recursive: true });
+  writeFileSync(DATA_FILE, JSON.stringify(data, null, 2), 'utf8');
+}
+
+/** Every project id `userId` owns (created through the wrapper). */
+export function listOwnedProjects(userId: string): string[] {
+  return readData()[userId] ?? [];
+}
+
+/** Record that `userId` owns `projectId` — called right after a successful `/projects/provision`. */
+export function addOwnedProject(userId: string, projectId: string): void {
+  if (!userId || !projectId) return;
+  const data = readData();
+  const existing = data[userId] ?? [];
+  if (!existing.includes(projectId)) {
+    data[userId] = [...existing, projectId];
+    writeData(data);
+  }
+}
+
+/** True if `userId` owns `projectId`. */
+export function isOwner(userId: string, projectId: string): boolean {
+  return listOwnedProjects(userId).includes(projectId);
+}

--- a/apps/whitelabel-demo/tests/e2e/auth.test.ts
+++ b/apps/whitelabel-demo/tests/e2e/auth.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Wrapper-mode demo auth (`src/server/auth.ts` + `/api/auth/*`): login,
+ * bad-credential paths, `/api/auth/me` via both bearer and cookie, logout,
+ * and tampered/expired tokens.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { type AppInstance, resetUsersStore, startApp, uniqueEmail } from './harness';
+import { DEMO_PASSWORD, SESSION_SECRET, wrapperEnv } from './env';
+import { expiredToken, tamperedToken } from './session-crypto';
+
+function cookieValue(setCookieHeader: string | null, name: string): string | null {
+  if (!setCookieHeader) return null;
+  const m = setCookieHeader.match(new RegExp(`${name}=([^;]*)`));
+  return m ? decodeURIComponent(m[1]) : null;
+}
+
+describe('wrapper-mode auth', () => {
+  let app: AppInstance;
+
+  beforeAll(async () => {
+    resetUsersStore();
+    app = await startApp(wrapperEnv());
+  }, 30_000);
+
+  afterAll(async () => {
+    await app?.stop();
+    resetUsersStore();
+  });
+
+  test('login happy path: returns a bearer token and sets an HttpOnly cookie', async () => {
+    const email = uniqueEmail('happy');
+    const res = await fetch(`${app.baseUrl}/api/auth/login`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ email, password: DEMO_PASSWORD }),
+    });
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as { token: string; userId: string };
+    expect(typeof data.token).toBe('string');
+    expect(data.token.split('.')).toHaveLength(2);
+    expect(data.userId).toBe(email.toLowerCase());
+
+    const setCookie = res.headers.get('set-cookie');
+    expect(setCookie).toContain('lumen_session=');
+    expect(setCookie).toContain('HttpOnly');
+    expect(setCookie).toContain('SameSite=Lax');
+    expect(cookieValue(setCookie, 'lumen_session')).toBe(data.token);
+  });
+
+  test('login with wrong password (DEMO_PASSWORD set) is rejected', async () => {
+    const email = uniqueEmail('wrongpw');
+    const res = await fetch(`${app.baseUrl}/api/auth/login`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ email, password: 'definitely-not-it' }),
+    });
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: 'Invalid email or password' });
+  });
+
+  test('login with a malformed email is rejected', async () => {
+    const res = await fetch(`${app.baseUrl}/api/auth/login`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ email: 'not-an-email', password: DEMO_PASSWORD }),
+    });
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: 'Invalid email or password' });
+  });
+
+  test('login with an empty password is rejected', async () => {
+    const res = await fetch(`${app.baseUrl}/api/auth/login`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ email: uniqueEmail('nopass'), password: '' }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  test('GET /api/auth/me via Authorization: Bearer', async () => {
+    const email = uniqueEmail('me-bearer');
+    const login = await fetch(`${app.baseUrl}/api/auth/login`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ email, password: DEMO_PASSWORD }),
+    });
+    const { token } = (await login.json()) as { token: string };
+
+    const res = await fetch(`${app.baseUrl}/api/auth/me`, {
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ userId: email.toLowerCase() });
+  });
+
+  test('GET /api/auth/me via the lumen_session cookie (no bearer header)', async () => {
+    const email = uniqueEmail('me-cookie');
+    const login = await fetch(`${app.baseUrl}/api/auth/login`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ email, password: DEMO_PASSWORD }),
+    });
+    const setCookie = login.headers.get('set-cookie');
+    const token = cookieValue(setCookie, 'lumen_session');
+    expect(token).toBeTruthy();
+
+    const res = await fetch(`${app.baseUrl}/api/auth/me`, {
+      headers: { cookie: `lumen_session=${encodeURIComponent(token!)}` },
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ userId: email.toLowerCase() });
+  });
+
+  test('GET /api/auth/me with no credentials at all is 401', async () => {
+    const res = await fetch(`${app.baseUrl}/api/auth/me`);
+    expect(res.status).toBe(401);
+  });
+
+  test('logout clears the session cookie', async () => {
+    const res = await fetch(`${app.baseUrl}/api/auth/logout`, { method: 'POST' });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    const setCookie = res.headers.get('set-cookie');
+    expect(setCookie).toContain('lumen_session=;');
+    expect(setCookie).toContain('Max-Age=0');
+  });
+
+  test('a tampered session token is rejected (401)', async () => {
+    const bad = tamperedToken(SESSION_SECRET, uniqueEmail('tampered'));
+    const res = await fetch(`${app.baseUrl}/api/auth/me`, {
+      headers: { authorization: `Bearer ${bad}` },
+    });
+    expect(res.status).toBe(401);
+  });
+
+  test('an expired (but validly signed) session token is rejected (401)', async () => {
+    const expired = expiredToken(SESSION_SECRET, uniqueEmail('expired'));
+    const res = await fetch(`${app.baseUrl}/api/auth/me`, {
+      headers: { authorization: `Bearer ${expired}` },
+    });
+    expect(res.status).toBe(401);
+  });
+});

--- a/apps/whitelabel-demo/tests/e2e/env.ts
+++ b/apps/whitelabel-demo/tests/e2e/env.ts
@@ -1,0 +1,18 @@
+/** Shared constants for the wrapper-mode boots across test files. */
+
+export const WRAPPER_KEY = 'test-wrapper-key';
+export const SESSION_SECRET = 'test-session-secret-do-not-use-in-prod';
+export const DEMO_PASSWORD = 'demo-pass-xyz-1';
+export const COST_MARKUP = '1.5';
+
+export function wrapperEnv(overrides: Record<string, string | undefined> = {}) {
+  return {
+    KORTIX_API_KEY: WRAPPER_KEY,
+    SESSION_SECRET,
+    DEMO_PASSWORD,
+    COST_MARKUP,
+    RATE_LIMIT_PER_MIN: '100000', // effectively unlimited unless a test overrides it
+    NEXT_PUBLIC_KORTIX_API_URL: 'https://unused-in-wrapper-mode.example/v1',
+    ...overrides,
+  };
+}

--- a/apps/whitelabel-demo/tests/e2e/harness.ts
+++ b/apps/whitelabel-demo/tests/e2e/harness.ts
@@ -1,0 +1,170 @@
+/**
+ * Boots the whitelabel-demo app as a real `next start` process for black-box
+ * HTTP testing — no mocking of Next internals, the same binary that runs in
+ * production. Builds once (memoized) if `.next` isn't already there, then
+ * spawns `next start -p 0` (Next assigns a free port and prints it) per test
+ * file that needs a live instance.
+ */
+
+import { existsSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+
+export const APP_ROOT = join(import.meta.dir, '..', '..');
+const NEXT_BIN = join(APP_ROOT, 'node_modules', '.bin', 'next');
+
+let buildPromise: Promise<void> | null = null;
+
+/** Build the app once (skipped if `.next/BUILD_ID` already exists). Memoized
+ *  across every caller in this process so multiple test files sharing one
+ *  `bun test` run don't rebuild redundantly. */
+export function ensureBuilt(): Promise<void> {
+  if (existsSync(join(APP_ROOT, '.next', 'BUILD_ID'))) return Promise.resolve();
+  if (!buildPromise) {
+    buildPromise = (async () => {
+      const proc = Bun.spawn({
+        cmd: [NEXT_BIN, 'build'],
+        cwd: APP_ROOT,
+        env: { ...process.env, NEXT_TELEMETRY_DISABLED: '1' },
+        stdout: 'pipe',
+        stderr: 'pipe',
+      });
+      const [code, stdout, stderr] = await Promise.all([
+        proc.exited,
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+      ]);
+      if (code !== 0) {
+        throw new Error(`next build failed (exit ${code}):\n${stdout}\n${stderr}`);
+      }
+    })();
+  }
+  return buildPromise;
+}
+
+export interface AppInstance {
+  baseUrl: string;
+  /** Everything the process has printed so far — useful in failure messages. */
+  log(): string;
+  stop(): Promise<void>;
+}
+
+/** Remove the wrapper's per-user ownership JSON store. Always call this
+ *  before AND after a boot that will provision/own projects, so test files
+ *  don't leak state into each other via the shared `APP_ROOT` cwd. */
+export function resetUsersStore(): void {
+  rmSync(join(APP_ROOT, '.lumen-data'), { recursive: true, force: true });
+}
+
+/** A fresh, collision-free demo-login email for a single test. */
+export function uniqueEmail(prefix = 'user'): string {
+  return `${prefix}+${randomUUID().slice(0, 8)}@example.test`;
+}
+
+/** Log in against a running app's `/api/auth/login` and return the bearer token. */
+export async function loginUser(
+  app: AppInstance,
+  email: string,
+  password: string,
+): Promise<string> {
+  const res = await fetch(`${app.baseUrl}/api/auth/login`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ email, password }),
+  });
+  if (!res.ok) {
+    throw new Error(`login failed for ${email}: ${res.status} ${await res.text()}`);
+  }
+  const data = (await res.json()) as { token: string };
+  return data.token;
+}
+
+/**
+ * Start `next start` with the given extra env (merged over `process.env`).
+ * Resolves once the server has printed its bound URL AND actually answers an
+ * HTTP request.
+ */
+export async function startApp(
+  env: Record<string, string | undefined>,
+  { timeoutMs = 30_000 }: { timeoutMs?: number } = {},
+): Promise<AppInstance> {
+  await ensureBuilt();
+
+  const proc = Bun.spawn({
+    cmd: [NEXT_BIN, 'start', '-p', '0'],
+    cwd: APP_ROOT,
+    env: { ...process.env, ...env },
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+
+  let log = '';
+  const appendLog = async (stream: ReadableStream<Uint8Array> | null) => {
+    if (!stream) return;
+    const reader = stream.getReader();
+    const decoder = new TextDecoder();
+    try {
+      for (;;) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        log += decoder.decode(value, { stream: true });
+      }
+    } catch {
+      // process died/stream closed — nothing more to drain
+    }
+  };
+  const stdoutDrain = appendLog(proc.stdout);
+  const stderrDrain = appendLog(proc.stderr);
+
+  const exitedEarly = proc.exited.then(() => 'exited' as const);
+
+  const deadline = Date.now() + timeoutMs;
+  let baseUrl: string | null = null;
+  while (!baseUrl) {
+    if (Date.now() > deadline) {
+      proc.kill();
+      throw new Error(`next start didn't print a URL within ${timeoutMs}ms. Output so far:\n${log}`);
+    }
+    const raced = await Promise.race([
+      exitedEarly,
+      new Promise<'tick'>((resolve) => setTimeout(() => resolve('tick'), 50)),
+    ]);
+    if (raced === 'exited') {
+      throw new Error(`next start exited before printing a URL (code ${proc.exitCode}). Output:\n${log}`);
+    }
+    const m = log.match(/Local:\s+(http:\/\/localhost:\d+)/);
+    if (m) baseUrl = m[1];
+  }
+
+  // The URL line can print a beat before the listener actually accepts
+  // connections — poll until a real HTTP round-trip succeeds.
+  const readyDeadline = Date.now() + timeoutMs;
+  for (;;) {
+    try {
+      await fetch(`${baseUrl}/api/mode`);
+      break;
+    } catch {
+      if (Date.now() > readyDeadline) {
+        proc.kill();
+        throw new Error(`next start bound ${baseUrl} but never accepted a request. Output so far:\n${log}`);
+      }
+      await new Promise((r) => setTimeout(r, 50));
+    }
+  }
+
+  return {
+    baseUrl,
+    log: () => log,
+    async stop() {
+      // SIGKILL, not the default SIGTERM: `next start`'s graceful shutdown
+      // waits for Node's HTTP keep-alive sockets to drain (default
+      // `keepAliveTimeout` 5s) before exiting — that stalls teardown for
+      // every test that left an SSE/long-poll connection open (by design;
+      // the client, not the server, ends those). These are disposable test
+      // processes, so skip the grace period entirely.
+      proc.kill('SIGKILL');
+      await Promise.race([proc.exited, new Promise((r) => setTimeout(r, 3_000))]);
+      await Promise.allSettled([stdoutDrain, stderrDrain]);
+    },
+  };
+}

--- a/apps/whitelabel-demo/tests/e2e/harness.ts
+++ b/apps/whitelabel-demo/tests/e2e/harness.ts
@@ -6,12 +6,21 @@
  * file that needs a live instance.
  */
 
-import { existsSync, rmSync } from 'node:fs';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { randomUUID } from 'node:crypto';
 
 export const APP_ROOT = join(import.meta.dir, '..', '..');
 const NEXT_BIN = join(APP_ROOT, 'node_modules', '.bin', 'next');
+
+/**
+ * Per-test-run ownership store, NEVER the app dir's real `.lumen-data`.
+ * Test instances boot with `LUMEN_DATA_DIR` pointing here (see `startApp`),
+ * so running the suite can't wipe a developer's local wrapper state — which
+ * is exactly what the original cwd-based store did.
+ */
+export const TEST_DATA_DIR = mkdtempSync(join(tmpdir(), 'lumen-e2e-'));
 
 let buildPromise: Promise<void> | null = null;
 
@@ -49,11 +58,12 @@ export interface AppInstance {
   stop(): Promise<void>;
 }
 
-/** Remove the wrapper's per-user ownership JSON store. Always call this
+/** Remove the suite's per-user ownership JSON store (the temp
+ *  `TEST_DATA_DIR`, never the app dir's real `.lumen-data`). Always call this
  *  before AND after a boot that will provision/own projects, so test files
- *  don't leak state into each other via the shared `APP_ROOT` cwd. */
+ *  don't leak state into each other via the shared store. */
 export function resetUsersStore(): void {
-  rmSync(join(APP_ROOT, '.lumen-data'), { recursive: true, force: true });
+  rmSync(TEST_DATA_DIR, { recursive: true, force: true });
 }
 
 /** A fresh, collision-free demo-login email for a single test. */
@@ -93,7 +103,7 @@ export async function startApp(
   const proc = Bun.spawn({
     cmd: [NEXT_BIN, 'start', '-p', '0'],
     cwd: APP_ROOT,
-    env: { ...process.env, ...env },
+    env: { ...process.env, LUMEN_DATA_DIR: TEST_DATA_DIR, ...env },
     stdout: 'pipe',
     stderr: 'pipe',
   });

--- a/apps/whitelabel-demo/tests/e2e/live.test.ts
+++ b/apps/whitelabel-demo/tests/e2e/live.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Optional golden-path smoke test against a REAL Kortix upstream. Skipped
+ * (not failed) unless both `E2E_LIVE_UPSTREAM` and `E2E_LIVE_KEY` are set —
+ * this suite must stay green with zero external dependencies by default.
+ *
+ *   E2E_LIVE_UPSTREAM=https://api.kortix.example/v1 \
+ *   E2E_LIVE_KEY=kortix_pat_... \
+ *   bun test tests/e2e/live.test.ts
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { type AppInstance, loginUser, resetUsersStore, startApp, uniqueEmail } from './harness';
+import { DEMO_PASSWORD, wrapperEnv } from './env';
+
+const LIVE_UPSTREAM = process.env.E2E_LIVE_UPSTREAM;
+const LIVE_KEY = process.env.E2E_LIVE_KEY;
+const hasLiveEnv = Boolean(LIVE_UPSTREAM && LIVE_KEY);
+
+describe.skipIf(!hasLiveEnv)('live upstream golden path', () => {
+  let app: AppInstance;
+
+  beforeAll(async () => {
+    resetUsersStore();
+    app = await startApp(
+      wrapperEnv({ KORTIX_API_KEY: LIVE_KEY, KORTIX_UPSTREAM: LIVE_UPSTREAM }),
+    );
+  }, 30_000);
+
+  afterAll(async () => {
+    await app?.stop();
+    resetUsersStore();
+  });
+
+  test('provision -> start -> send a message against the real upstream', async () => {
+    const email = uniqueEmail('live');
+    const token = await loginUser(app, email, DEMO_PASSWORD);
+
+    const provision = await fetch(`${app.baseUrl}/api/kortix/projects/provision`, {
+      method: 'POST',
+      headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+      body: JSON.stringify({ name: `E2E Live ${Date.now()}`, seed_starter: true }),
+    });
+    expect(provision.status).toBeLessThan(300);
+    const project = (await provision.json()) as { project_id: string };
+    expect(project.project_id).toBeTruthy();
+
+    const detail = await fetch(`${app.baseUrl}/api/kortix/projects/${project.project_id}`, {
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(detail.status).toBe(200);
+  }, 60_000);
+});

--- a/apps/whitelabel-demo/tests/e2e/mock-upstream.ts
+++ b/apps/whitelabel-demo/tests/e2e/mock-upstream.ts
@@ -82,7 +82,11 @@ export function createMockUpstream(expectedAuthToken: string): MockUpstream {
 
   function makeProject(overrides: Partial<MockProject> = {}): MockProject {
     projectCounter += 1;
-    const id = overrides.project_id ?? `proj_mock_${projectCounter}`;
+    // UUID-shaped like real Kortix project ids — the app validates ids with
+    // isValidProjectId before recording ownership or building upstream URLs,
+    // so a non-UUID mock id would be (correctly) rejected.
+    const id =
+      overrides.project_id ?? `00000000-0000-4000-8000-${String(projectCounter).padStart(12, '0')}`;
     const now = new Date().toISOString();
     return {
       project_id: id,

--- a/apps/whitelabel-demo/tests/e2e/mock-upstream.ts
+++ b/apps/whitelabel-demo/tests/e2e/mock-upstream.ts
@@ -1,0 +1,300 @@
+/**
+ * Mock Kortix upstream — a tiny `Bun.serve` HTTP server implementing exactly
+ * the endpoints `src/app/api/kortix/[...path]/route.ts`,
+ * `src/app/api/preview-token/route.ts`, and `src/app/api/usage/route.ts` call
+ * out to. Everything is namespaced under `/v1` (matching `KORTIX_UPSTREAM`
+ * including its `/v1` suffix, the same shape as `NEXT_PUBLIC_KORTIX_API_URL`).
+ *
+ * Two jobs beyond serving canned responses:
+ *  1. Record every request (method, path, headers, body) so tests can assert
+ *     on what actually reached "Kortix" — in particular, that `Authorization`
+ *     is ALWAYS `Bearer <the wrapper key>`, never an end-user session token,
+ *     and that the wrapper's own `lumen_session` cookie never leaks upstream.
+ *  2. Behave like a real (if minimal) Kortix API: a projects store, secrets,
+ *     gateway cost rows, cli-token minting, and the `/p/...` sandbox-runtime
+ *     proxy surface (generic passthrough + one SSE stream + one echoing
+ *     "message" endpoint) — enough surface for every flow the whitelabel app
+ *     exercises through the BFF proxy.
+ */
+
+export interface RecordedRequest {
+  method: string;
+  path: string; // pathname + search, e.g. "/v1/projects/proj_1"
+  authorization: string | null;
+  cookie: string | null;
+  contentLength: string | null;
+  transferEncoding: string | null;
+  body: unknown;
+}
+
+export interface MockProject {
+  project_id: string;
+  account_id: string;
+  name: string;
+  repo_url: string;
+  default_branch: string;
+  manifest_path: string;
+  status: 'active' | 'archived';
+  metadata: Record<string, unknown>;
+  created_at: string;
+  updated_at: string;
+  [key: string]: unknown;
+}
+
+export interface GatewaySessionRow {
+  session_id: string;
+  total_cost: number;
+  [key: string]: unknown;
+}
+
+export interface MockUpstream {
+  /** Base URL WITHOUT `/v1` — pass `${url}/v1` as `KORTIX_UPSTREAM`. */
+  url: string;
+  requests: RecordedRequest[];
+  /** Any request whose Authorization header didn't match the expected wrapper key. */
+  authViolations: RecordedRequest[];
+  /** Any request that carried a `Cookie` header (the proxy should always strip it). */
+  cookieViolations: RecordedRequest[];
+  reset(): void;
+  /** Directly seed a project into the mock's store (bypassing `/provision`) —
+   *  used to simulate a project that exists upstream but this wrapper user
+   *  never provisioned, to prove per-user filtering actually filters. */
+  seedProject(overrides?: Partial<MockProject>): MockProject;
+  seedGatewaySessions(projectId: string, rows: GatewaySessionRow[]): void;
+  /** Make GET /v1/projects/:id/gateway/sessions fail (500) for this project id. */
+  failGatewayFor(projectId: string): void;
+  stop(): void;
+}
+
+let projectCounter = 0;
+let tokenCounter = 0;
+
+export function createMockUpstream(expectedAuthToken: string): MockUpstream {
+  const projects = new Map<string, MockProject>();
+  const secrets = new Map<string, Array<{ name: string; value?: string }>>();
+  const gatewaySessions = new Map<string, GatewaySessionRow[]>();
+  const failingGatewayProjects = new Set<string>();
+  const activeIntervals = new Set<ReturnType<typeof setInterval>>();
+
+  let requests: RecordedRequest[] = [];
+  let authViolations: RecordedRequest[] = [];
+  let cookieViolations: RecordedRequest[] = [];
+
+  function makeProject(overrides: Partial<MockProject> = {}): MockProject {
+    projectCounter += 1;
+    const id = overrides.project_id ?? `proj_mock_${projectCounter}`;
+    const now = new Date().toISOString();
+    return {
+      project_id: id,
+      account_id: 'acct_test',
+      name: overrides.name ?? `Mock Project ${projectCounter}`,
+      repo_url: `https://git.kortix.test/${id}`,
+      default_branch: 'main',
+      manifest_path: 'kortix.toml',
+      status: 'active',
+      metadata: {},
+      created_at: now,
+      updated_at: now,
+      ...overrides,
+    };
+  }
+
+  const server = Bun.serve({
+    port: 0,
+    idleTimeout: 0, // long-lived SSE connections must not be killed by Bun's idle timeout
+    async fetch(req) {
+      const url = new URL(req.url);
+      const method = req.method.toUpperCase();
+      const authorization = req.headers.get('authorization');
+      const cookie = req.headers.get('cookie');
+      const contentLength = req.headers.get('content-length');
+      const transferEncoding = req.headers.get('transfer-encoding');
+
+      let body: unknown = undefined;
+      if (method !== 'GET' && method !== 'HEAD') {
+        const text = await req.text();
+        if (text) {
+          try {
+            body = JSON.parse(text);
+          } catch {
+            body = text;
+          }
+        }
+      }
+
+      const entry: RecordedRequest = {
+        method,
+        path: `${url.pathname}${url.search}`,
+        authorization,
+        cookie,
+        contentLength,
+        transferEncoding,
+        body,
+      };
+      requests.push(entry);
+      if (authorization !== `Bearer ${expectedAuthToken}`) authViolations.push(entry);
+      if (cookie) cookieViolations.push(entry);
+
+      const p = url.pathname.replace(/^\/v1\//, '');
+
+      // ── projects: bare collection ──────────────────────────────────────
+      if (p === 'projects' && method === 'GET') {
+        return Response.json([...projects.values()]);
+      }
+      if (p === 'projects/provision' && method === 'POST') {
+        const reqBody = (body as { name?: string } | undefined) ?? {};
+        const project = makeProject({ name: reqBody.name ?? 'New project' });
+        projects.set(project.project_id, project);
+        return Response.json(project, { status: 201 });
+      }
+
+      // ── projects: scoped to one id ──────────────────────────────────────
+      const secretsMatch = p.match(/^projects\/([^/]+)\/secrets$/);
+      if (secretsMatch) {
+        const [, id] = secretsMatch;
+        if (method === 'GET') return Response.json(secrets.get(id) ?? []);
+        if (method === 'POST' || method === 'PUT') {
+          const list = secrets.get(id) ?? [];
+          const entryBody = body as { name?: string; value?: string } | undefined;
+          if (entryBody?.name) list.push({ name: entryBody.name, value: entryBody.value });
+          secrets.set(id, list);
+          return Response.json({ ok: true });
+        }
+      }
+
+      const gatewayMatch = p.match(/^projects\/([^/]+)\/gateway\/sessions$/);
+      if (gatewayMatch && method === 'GET') {
+        const [, id] = gatewayMatch;
+        if (failingGatewayProjects.has(id)) {
+          return Response.json({ error: 'gateway unavailable' }, { status: 500 });
+        }
+        return Response.json({ sessions: gatewaySessions.get(id) ?? [] });
+      }
+
+      const cliTokenMatch = p.match(/^projects\/([^/]+)\/cli-token$/);
+      if (cliTokenMatch && method === 'POST') {
+        const [, id] = cliTokenMatch;
+        tokenCounter += 1;
+        return Response.json({
+          secret_key: `kortix_pat_test_${id}_${tokenCounter}`,
+          token_id: `tok_${tokenCounter}`,
+        });
+      }
+
+      const projectDetailMatch = p.match(/^projects\/([^/]+)$/);
+      if (projectDetailMatch) {
+        const [, id] = projectDetailMatch;
+        const project = projects.get(id);
+        if (method === 'GET') {
+          if (!project) return Response.json({ error: 'Not found' }, { status: 404 });
+          // Deliberately set an upstream cookie here so tests can assert the
+          // proxy strips it before it reaches the browser.
+          return Response.json(project, {
+            headers: { 'set-cookie': 'upstream_session=leak-me; Path=/' },
+          });
+        }
+      }
+
+      // Any other `projects/:id/...` sub-path (sessions, files, connectors, …) —
+      // generic forwarded-OK, recorded for assertion.
+      if (/^projects\/[^/]+(\/.*)?$/.test(p)) {
+        return Response.json({ ok: true, path: p, method });
+      }
+
+      // ── executor/projects/:id/... ─────────────────────────────────────
+      if (/^executor\/projects\/[^/]+(\/.*)?$/.test(p)) {
+        return Response.json({ ok: true, path: p, method });
+      }
+
+      // ── accounts ─────────────────────────────────────────────────────
+      if (p === 'accounts/me' && method === 'GET') {
+        return Response.json({ account_id: 'acct_test', name: 'Test Account' });
+      }
+
+      // ── sandbox runtime proxy: /p/{sandboxId}/{port}/... ───────────────
+      const sseMatch = p.match(/^p\/([^/]+)\/(\d+)\/global\/event$/);
+      if (sseMatch && method === 'GET') {
+        let interval: ReturnType<typeof setInterval> | undefined;
+        const stream = new ReadableStream({
+          start(controller) {
+            const enc = new TextEncoder();
+            let n = 0;
+            const push = (data: unknown) => {
+              controller.enqueue(enc.encode(`event: message\ndata: ${JSON.stringify(data)}\n\n`));
+            };
+            // First two "real" events land immediately-ish, then heartbeats —
+            // enough to prove the stream is unbuffered end-to-end.
+            push({ type: 'status', n: ++n });
+            push({ type: 'status', n: ++n });
+            interval = setInterval(() => {
+              controller.enqueue(enc.encode(`: heartbeat\n\n`));
+            }, 200);
+            activeIntervals.add(interval);
+          },
+          cancel() {
+            if (interval) {
+              clearInterval(interval);
+              activeIntervals.delete(interval);
+            }
+          },
+        });
+        return new Response(stream, {
+          headers: {
+            'content-type': 'text/event-stream',
+            'cache-control': 'no-cache',
+            connection: 'keep-alive',
+          },
+        });
+      }
+
+      const messageMatch = p.match(/^p\/([^/]+)\/(\d+)\/message$/);
+      if (messageMatch && method === 'POST') {
+        return Response.json({
+          role: 'assistant',
+          content: `echo: ${typeof body === 'string' ? body : JSON.stringify(body)}`,
+        });
+      }
+
+      // Any other `/p/...` path — generic forwarded-OK.
+      if (/^p\/[^/]+\/\d+(\/.*)?$/.test(p) || p === 'p' || p.startsWith('p/')) {
+        return Response.json({ ok: true, path: p, method });
+      }
+
+      return Response.json({ error: 'mock-upstream: no route', path: p, method }, { status: 404 });
+    },
+  });
+
+  return {
+    url: `http://127.0.0.1:${server.port}`,
+    get requests() {
+      return requests;
+    },
+    get authViolations() {
+      return authViolations;
+    },
+    get cookieViolations() {
+      return cookieViolations;
+    },
+    reset() {
+      requests = [];
+      authViolations = [];
+      cookieViolations = [];
+    },
+    seedProject(overrides) {
+      const project = makeProject(overrides);
+      projects.set(project.project_id, project);
+      return project;
+    },
+    seedGatewaySessions(projectId, rows) {
+      gatewaySessions.set(projectId, rows);
+    },
+    failGatewayFor(projectId) {
+      failingGatewayProjects.add(projectId);
+    },
+    stop() {
+      for (const interval of activeIntervals) clearInterval(interval);
+      activeIntervals.clear();
+      server.stop(true);
+    },
+  };
+}

--- a/apps/whitelabel-demo/tests/e2e/mode.test.ts
+++ b/apps/whitelabel-demo/tests/e2e/mode.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Mode bootstrap + the auth-gate the client picks based on it.
+ *
+ * NOTE on "UI gate" testing: `src/app/page.tsx` and `src/app/providers.tsx`
+ * are Client Components whose FIRST render (before any `useEffect` runs) is
+ * always the loading spinner — `wrapperMode === null` / `ready === null`.
+ * Next prerenders that exact first-pass tree on the server, so a plain
+ * `fetch('/')` returns the SAME loading-shell HTML in both modes; the actual
+ * `LoginGate` vs `ApiKeyGate` choice only happens client-side, after
+ * hydration reads `GET /api/mode` (see `providers.tsx`). We verified this
+ * empirically (both modes render only the spinner markup, never gate text).
+ *
+ * So the deterministic, HTTP-level equivalent of "which gate renders" IS
+ * `GET /api/mode` — it's the one signal `useWrapperMode()` depends on. These
+ * tests assert that signal per mode, plus that `/` itself boots (200, right
+ * `<title>`, the shared loading shell) in both configurations.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { type AppInstance, startApp } from './harness';
+import { wrapperEnv } from './env';
+
+describe('mode bootstrap', () => {
+  let wrapperApp: AppInstance;
+  let directApp: AppInstance;
+
+  beforeAll(async () => {
+    [wrapperApp, directApp] = await Promise.all([
+      startApp(wrapperEnv()),
+      startApp({ KORTIX_API_KEY: undefined, NEXT_PUBLIC_KORTIX_API_URL: 'https://direct.example/v1' }),
+    ]);
+  }, 60_000);
+
+  afterAll(async () => {
+    await Promise.all([wrapperApp?.stop(), directApp?.stop()]);
+  });
+
+  test('GET /api/mode reports wrapperMode: true when KORTIX_API_KEY is set', async () => {
+    const res = await fetch(`${wrapperApp.baseUrl}/api/mode`);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ wrapperMode: true });
+  });
+
+  test('GET /api/mode reports wrapperMode: false when KORTIX_API_KEY is unset (direct mode)', async () => {
+    const res = await fetch(`${directApp.baseUrl}/api/mode`);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ wrapperMode: false });
+  });
+
+  test('wrapper mode: / serves the shared app shell (login gate mounts client-side off /api/mode)', async () => {
+    const res = await fetch(`${wrapperApp.baseUrl}/`);
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain('<title>Lumen</title>');
+    expect(html).toContain('animate-spin'); // the pre-hydration loading shell
+  });
+
+  test('direct mode: / serves the shared app shell (API-key gate mounts client-side off /api/mode)', async () => {
+    const res = await fetch(`${directApp.baseUrl}/`);
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain('<title>Lumen</title>');
+    expect(html).toContain('animate-spin');
+  });
+
+  test('wrapper mode: proxy is enabled (500 only for missing session, not missing key)', async () => {
+    // Sanity: confirms this boot really is wrapper mode end-to-end, not just
+    // /api/mode lying — an unauthenticated proxy call should 401, never the
+    // 500 "wrapper mode is not enabled" branch.
+    const res = await fetch(`${wrapperApp.baseUrl}/api/kortix/projects`);
+    expect(res.status).toBe(401);
+  });
+
+  test('direct mode: proxy route reports wrapper mode is not enabled', async () => {
+    const res = await fetch(`${directApp.baseUrl}/api/kortix/projects`);
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({
+      error: 'Wrapper mode is not enabled on this server (KORTIX_API_KEY is unset).',
+    });
+  });
+});

--- a/apps/whitelabel-demo/tests/e2e/policy.test.ts
+++ b/apps/whitelabel-demo/tests/e2e/policy.test.ts
@@ -9,7 +9,7 @@
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { APP_ROOT, type AppInstance, loginUser, resetUsersStore, startApp, uniqueEmail } from './harness';
+import { TEST_DATA_DIR, type AppInstance, loginUser, resetUsersStore, startApp, uniqueEmail } from './harness';
 import { createMockUpstream, type MockUpstream } from './mock-upstream';
 import { DEMO_PASSWORD, WRAPPER_KEY, wrapperEnv } from './env';
 
@@ -198,7 +198,7 @@ describe('wrapper-mode policy matrix', () => {
     const ids = ((await list.json()) as Array<{ project_id: string }>).map((p) => p.project_id);
     expect(ids.sort()).toEqual([pa.project_id, pb.project_id].sort());
 
-    const store = JSON.parse(readFileSync(join(APP_ROOT, '.lumen-data', 'users.json'), 'utf8'));
+    const store = JSON.parse(readFileSync(join(TEST_DATA_DIR, 'users.json'), 'utf8'));
     expect(store[email].sort()).toEqual([pa.project_id, pb.project_id].sort());
   });
 
@@ -211,7 +211,7 @@ describe('wrapper-mode policy matrix', () => {
     });
     const project = (await provision.json()) as { project_id: string };
 
-    expect(existsSync(join(APP_ROOT, '.lumen-data', 'users.json'))).toBe(true);
+    expect(existsSync(join(TEST_DATA_DIR, 'users.json'))).toBe(true);
 
     // Simulate a fresh page load: brand-new fetch, same bearer token.
     const later = await fetch(`${app.baseUrl}/api/kortix/projects/${project.project_id}`, {
@@ -219,7 +219,7 @@ describe('wrapper-mode policy matrix', () => {
     });
     expect(later.status).toBe(200);
 
-    const store = JSON.parse(readFileSync(join(APP_ROOT, '.lumen-data', 'users.json'), 'utf8'));
+    const store = JSON.parse(readFileSync(join(TEST_DATA_DIR, 'users.json'), 'utf8'));
     expect(store[email]).toContain(project.project_id);
   });
 });

--- a/apps/whitelabel-demo/tests/e2e/policy.test.ts
+++ b/apps/whitelabel-demo/tests/e2e/policy.test.ts
@@ -1,0 +1,225 @@
+/**
+ * The full wrapper-mode route policy matrix (`src/server/policy.ts`) as
+ * enforced end-to-end through `/api/kortix/[...path]`, plus the per-user
+ * ownership store (`src/server/users.ts`) it depends on: provisioning records
+ * an owner, ownership persists across calls, and near-concurrent provisions
+ * both land (no lost writes in the JSON-file store).
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { APP_ROOT, type AppInstance, loginUser, resetUsersStore, startApp, uniqueEmail } from './harness';
+import { createMockUpstream, type MockUpstream } from './mock-upstream';
+import { DEMO_PASSWORD, WRAPPER_KEY, wrapperEnv } from './env';
+
+describe('wrapper-mode policy matrix', () => {
+  let mock: MockUpstream;
+  let app: AppInstance;
+
+  beforeAll(async () => {
+    resetUsersStore();
+    mock = createMockUpstream(WRAPPER_KEY);
+    app = await startApp(wrapperEnv({ KORTIX_UPSTREAM: `${mock.url}/v1` }));
+  }, 30_000);
+
+  afterAll(async () => {
+    await app?.stop();
+    mock?.stop();
+    resetUsersStore();
+  });
+
+  async function freshUser(prefix: string) {
+    const email = uniqueEmail(prefix);
+    const token = await loginUser(app, email, DEMO_PASSWORD);
+    return { email, token };
+  }
+
+  function authed(token: string) {
+    return { authorization: `Bearer ${token}` };
+  }
+
+  test('GET /projects is allowed and filtered to only the caller-owned projects', async () => {
+    const { token } = await freshUser('list-filter');
+    // A project that exists upstream but this user never provisioned.
+    const other = mock.seedProject({ name: 'Someone Elses Project' });
+
+    const provision = await fetch(`${app.baseUrl}/api/kortix/projects/provision`, {
+      method: 'POST',
+      headers: { ...authed(token), 'content-type': 'application/json' },
+      body: JSON.stringify({ name: 'My Project' }),
+    });
+    expect(provision.status).toBe(201);
+    const mine = (await provision.json()) as { project_id: string };
+
+    const list = await fetch(`${app.baseUrl}/api/kortix/projects`, { headers: authed(token) });
+    expect(list.status).toBe(200);
+    const ids = ((await list.json()) as Array<{ project_id: string }>).map((p) => p.project_id);
+    expect(ids).toContain(mine.project_id);
+    expect(ids).not.toContain(other.project_id);
+  });
+
+  test('POST /projects (bare) is denied — provisioning must go through /projects/provision', async () => {
+    const { token } = await freshUser('bare-post-denied');
+    const res = await fetch(`${app.baseUrl}/api/kortix/projects`, {
+      method: 'POST',
+      headers: { ...authed(token), 'content-type': 'application/json' },
+      body: JSON.stringify({ name: 'Should be blocked' }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  test('POST /projects/provision is allowed and records ownership', async () => {
+    const { token } = await freshUser('provision-records');
+    const res = await fetch(`${app.baseUrl}/api/kortix/projects/provision`, {
+      method: 'POST',
+      headers: { ...authed(token), 'content-type': 'application/json' },
+      body: JSON.stringify({ name: 'Provisioned Project' }),
+    });
+    expect(res.status).toBe(201);
+    const project = (await res.json()) as { project_id: string };
+
+    const list = await fetch(`${app.baseUrl}/api/kortix/projects`, { headers: authed(token) });
+    const ids = ((await list.json()) as Array<{ project_id: string }>).map((p) => p.project_id);
+    expect(ids).toEqual([project.project_id]);
+  });
+
+  test('GET /projects/:id is forwarded when the caller owns it', async () => {
+    const { token } = await freshUser('owned-forward');
+    const provision = await fetch(`${app.baseUrl}/api/kortix/projects/provision`, {
+      method: 'POST',
+      headers: { ...authed(token), 'content-type': 'application/json' },
+      body: JSON.stringify({ name: 'Owned' }),
+    });
+    const project = (await provision.json()) as { project_id: string };
+
+    mock.reset();
+    const detail = await fetch(`${app.baseUrl}/api/kortix/projects/${project.project_id}`, {
+      headers: authed(token),
+    });
+    expect(detail.status).toBe(200);
+    expect((await detail.json() as { project_id: string }).project_id).toBe(project.project_id);
+    expect(mock.requests).toHaveLength(1);
+  });
+
+  test('GET /projects/:id is 403 when the caller does not own it', async () => {
+    const { token } = await freshUser('unowned-denied');
+    const other = mock.seedProject({ name: 'Not Yours' });
+
+    mock.reset();
+    const res = await fetch(`${app.baseUrl}/api/kortix/projects/${other.project_id}`, {
+      headers: authed(token),
+    });
+    expect(res.status).toBe(403);
+    // Never even reached upstream — denied at the policy layer.
+    expect(mock.requests).toHaveLength(0);
+  });
+
+  test('GET /executor/projects/:id/... is forwarded when the caller owns the project', async () => {
+    const { token } = await freshUser('executor-owned');
+    const provision = await fetch(`${app.baseUrl}/api/kortix/projects/provision`, {
+      method: 'POST',
+      headers: { ...authed(token), 'content-type': 'application/json' },
+      body: JSON.stringify({ name: 'Executor Owned' }),
+    });
+    const project = (await provision.json()) as { project_id: string };
+
+    mock.reset();
+    const res = await fetch(`${app.baseUrl}/api/kortix/executor/projects/${project.project_id}/connectors`, {
+      headers: authed(token),
+    });
+    expect(res.status).toBe(200);
+    expect(mock.requests).toHaveLength(1);
+    expect(mock.requests[0]!.path).toBe(`/v1/executor/projects/${project.project_id}/connectors`);
+  });
+
+  test('GET /executor/projects/:id/... is 403 when the caller does not own the project', async () => {
+    const { token } = await freshUser('executor-unowned');
+    const other = mock.seedProject({ name: 'Executor Not Yours' });
+
+    const res = await fetch(`${app.baseUrl}/api/kortix/executor/projects/${other.project_id}/connectors`, {
+      headers: authed(token),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  test('GET /accounts/me is allowed', async () => {
+    const { token } = await freshUser('accounts-me');
+    const res = await fetch(`${app.baseUrl}/api/kortix/accounts/me`, { headers: authed(token) });
+    expect(res.status).toBe(200);
+  });
+
+  test('GET /accounts (bare, or any other accounts/* route) is denied', async () => {
+    const { token } = await freshUser('accounts-denied');
+    const bare = await fetch(`${app.baseUrl}/api/kortix/accounts`, { headers: authed(token) });
+    expect(bare.status).toBe(403);
+    const members = await fetch(`${app.baseUrl}/api/kortix/accounts/acct_test/members`, {
+      headers: authed(token),
+    });
+    expect(members.status).toBe(403);
+  });
+
+  test('billing/* and platform/* are denied by default', async () => {
+    const { token } = await freshUser('billing-platform-denied');
+    const billing = await fetch(`${app.baseUrl}/api/kortix/billing/invoices`, { headers: authed(token) });
+    expect(billing.status).toBe(403);
+    const platform = await fetch(`${app.baseUrl}/api/kortix/platform/sandboxes`, { headers: authed(token) });
+    expect(platform.status).toBe(403);
+  });
+
+  test('/p/... (sandbox runtime proxy) is allowed for any valid session', async () => {
+    const { token } = await freshUser('p-allowed');
+    const res = await fetch(`${app.baseUrl}/api/kortix/p/sbx_random/8000/status`, {
+      headers: authed(token),
+    });
+    expect(res.status).toBe(200);
+  });
+
+  test('users store: near-concurrent provisions from the same user both land (no lost writes)', async () => {
+    const { token, email } = await freshUser('concurrent-provision');
+    const [a, b] = await Promise.all([
+      fetch(`${app.baseUrl}/api/kortix/projects/provision`, {
+        method: 'POST',
+        headers: { ...authed(token), 'content-type': 'application/json' },
+        body: JSON.stringify({ name: 'Concurrent A' }),
+      }),
+      fetch(`${app.baseUrl}/api/kortix/projects/provision`, {
+        method: 'POST',
+        headers: { ...authed(token), 'content-type': 'application/json' },
+        body: JSON.stringify({ name: 'Concurrent B' }),
+      }),
+    ]);
+    expect(a.status).toBe(201);
+    expect(b.status).toBe(201);
+    const [pa, pb] = (await Promise.all([a.json(), b.json()])) as Array<{ project_id: string }>;
+    expect(pa.project_id).not.toBe(pb.project_id);
+
+    const list = await fetch(`${app.baseUrl}/api/kortix/projects`, { headers: authed(token) });
+    const ids = ((await list.json()) as Array<{ project_id: string }>).map((p) => p.project_id);
+    expect(ids.sort()).toEqual([pa.project_id, pb.project_id].sort());
+
+    const store = JSON.parse(readFileSync(join(APP_ROOT, '.lumen-data', 'users.json'), 'utf8'));
+    expect(store[email].sort()).toEqual([pa.project_id, pb.project_id].sort());
+  });
+
+  test('users store: ownership persists across separate proxy calls (a later "page load")', async () => {
+    const { token, email } = await freshUser('persistence');
+    const provision = await fetch(`${app.baseUrl}/api/kortix/projects/provision`, {
+      method: 'POST',
+      headers: { ...authed(token), 'content-type': 'application/json' },
+      body: JSON.stringify({ name: 'Persisted' }),
+    });
+    const project = (await provision.json()) as { project_id: string };
+
+    expect(existsSync(join(APP_ROOT, '.lumen-data', 'users.json'))).toBe(true);
+
+    // Simulate a fresh page load: brand-new fetch, same bearer token.
+    const later = await fetch(`${app.baseUrl}/api/kortix/projects/${project.project_id}`, {
+      headers: authed(token),
+    });
+    expect(later.status).toBe(200);
+
+    const store = JSON.parse(readFileSync(join(APP_ROOT, '.lumen-data', 'users.json'), 'utf8'));
+    expect(store[email]).toContain(project.project_id);
+  });
+});

--- a/apps/whitelabel-demo/tests/e2e/preview-token.test.ts
+++ b/apps/whitelabel-demo/tests/e2e/preview-token.test.ts
@@ -1,0 +1,82 @@
+/**
+ * `/api/preview-token` — mints a short-lived, project-scoped Kortix PAT for
+ * the preview iframe. Ownership-gated before minting; mints via the mock's
+ * `cli-token` endpoint using the WRAPPER key, never the caller's own token.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { type AppInstance, loginUser, resetUsersStore, startApp, uniqueEmail } from './harness';
+import { createMockUpstream, type MockUpstream } from './mock-upstream';
+import { DEMO_PASSWORD, WRAPPER_KEY, wrapperEnv } from './env';
+
+describe('/api/preview-token', () => {
+  let mock: MockUpstream;
+  let app: AppInstance;
+
+  beforeAll(async () => {
+    resetUsersStore();
+    mock = createMockUpstream(WRAPPER_KEY);
+    app = await startApp(wrapperEnv({ KORTIX_UPSTREAM: `${mock.url}/v1` }));
+  }, 30_000);
+
+  afterAll(async () => {
+    await app?.stop();
+    mock?.stop();
+    resetUsersStore();
+  });
+
+  test('unauthenticated request is 401', async () => {
+    const res = await fetch(`${app.baseUrl}/api/preview-token?projectId=proj_x`);
+    expect(res.status).toBe(401);
+  });
+
+  test('authenticated but unowned project is 403', async () => {
+    const email = uniqueEmail('preview-unowned');
+    const token = await loginUser(app, email, DEMO_PASSWORD);
+    const other = mock.seedProject({ name: 'Not mine' });
+
+    const res = await fetch(`${app.baseUrl}/api/preview-token?projectId=${other.project_id}`, {
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(res.status).toBe(403);
+  });
+
+  test('missing projectId is a 400', async () => {
+    const email = uniqueEmail('preview-missing-id');
+    const token = await loginUser(app, email, DEMO_PASSWORD);
+    const res = await fetch(`${app.baseUrl}/api/preview-token`, {
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(res.status).toBe(400);
+  });
+
+  test('owned project mints a token through the mock cli-token endpoint using the wrapper key', async () => {
+    const email = uniqueEmail('preview-owned');
+    const token = await loginUser(app, email, DEMO_PASSWORD);
+
+    const provision = await fetch(`${app.baseUrl}/api/kortix/projects/provision`, {
+      method: 'POST',
+      headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+      body: JSON.stringify({ name: 'Preview Owned' }),
+    });
+    const project = (await provision.json()) as { project_id: string };
+
+    mock.reset();
+    const res = await fetch(`${app.baseUrl}/api/preview-token?projectId=${project.project_id}`, {
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as { token: string; upstream: string; tokenId: string };
+    expect(data.token).toContain(`kortix_pat_test_${project.project_id}`);
+    expect(data.upstream).toBe(`${mock.url}/v1`);
+    expect(typeof data.tokenId).toBe('string');
+
+    // The mock must have received exactly one POST .../cli-token, authenticated
+    // with the operator's wrapper key (never the end user's session token).
+    const cliTokenCalls = mock.requests.filter((r) => r.path.endsWith('/cli-token'));
+    expect(cliTokenCalls).toHaveLength(1);
+    expect(cliTokenCalls[0]!.method).toBe('POST');
+    expect(cliTokenCalls[0]!.authorization).toBe(`Bearer ${WRAPPER_KEY}`);
+    expect(mock.authViolations).toHaveLength(0);
+  });
+});

--- a/apps/whitelabel-demo/tests/e2e/proxy.test.ts
+++ b/apps/whitelabel-demo/tests/e2e/proxy.test.ts
@@ -1,0 +1,155 @@
+/**
+ * The BFF proxy (`/api/kortix/[...path]`) itself: auth gate, key substitution,
+ * cookie stripping in both directions, request-body buffering integrity (the
+ * ALB/chunked-body regression), and SSE response streaming (the "response
+ * bodies still stream" regression).
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { type AppInstance, loginUser, resetUsersStore, startApp, uniqueEmail } from './harness';
+import { createMockUpstream, type MockUpstream } from './mock-upstream';
+import { DEMO_PASSWORD, WRAPPER_KEY, wrapperEnv } from './env';
+
+describe('BFF proxy', () => {
+  let mock: MockUpstream;
+  let app: AppInstance;
+
+  beforeAll(async () => {
+    resetUsersStore();
+    mock = createMockUpstream(WRAPPER_KEY);
+    app = await startApp(wrapperEnv({ KORTIX_UPSTREAM: `${mock.url}/v1` }));
+  }, 30_000);
+
+  afterAll(async () => {
+    await app?.stop();
+    mock?.stop();
+    resetUsersStore();
+  });
+
+  test('unauthenticated request to the proxy is 401 and never reaches upstream', async () => {
+    mock.reset();
+    const res = await fetch(`${app.baseUrl}/api/kortix/accounts/me`);
+    expect(res.status).toBe(401);
+    expect(mock.requests).toHaveLength(0);
+  });
+
+  test('a valid session is forwarded with the WRAPPER key substituted in; the user token never reaches upstream', async () => {
+    mock.reset();
+    const email = uniqueEmail('proxy-auth');
+    const token = await loginUser(app, email, DEMO_PASSWORD);
+
+    const res = await fetch(`${app.baseUrl}/api/kortix/accounts/me`, {
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ account_id: 'acct_test', name: 'Test Account' });
+
+    expect(mock.requests).toHaveLength(1);
+    const upstreamReq = mock.requests[0]!;
+    expect(upstreamReq.authorization).toBe(`Bearer ${WRAPPER_KEY}`);
+    // The end user's own session token must not appear anywhere upstream.
+    expect(upstreamReq.authorization).not.toContain(token);
+    expect(mock.authViolations).toHaveLength(0);
+  });
+
+  test("the wrapper's own session cookie is stripped before forwarding upstream", async () => {
+    mock.reset();
+    const email = uniqueEmail('cookie-strip-req');
+    const token = await loginUser(app, email, DEMO_PASSWORD);
+
+    const res = await fetch(`${app.baseUrl}/api/kortix/accounts/me`, {
+      headers: {
+        authorization: `Bearer ${token}`,
+        cookie: `lumen_session=${encodeURIComponent(token)}`,
+      },
+    });
+    expect(res.status).toBe(200);
+    expect(mock.cookieViolations).toHaveLength(0);
+    expect(mock.requests.at(-1)!.cookie).toBeNull();
+  });
+
+  test("upstream's Set-Cookie never reaches the browser", async () => {
+    mock.reset();
+    const email = uniqueEmail('cookie-strip-res');
+    const token = await loginUser(app, email, DEMO_PASSWORD);
+
+    const provision = await fetch(`${app.baseUrl}/api/kortix/projects/provision`, {
+      method: 'POST',
+      headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+      body: JSON.stringify({ name: 'Cookie Strip Test' }),
+    });
+    expect(provision.status).toBe(201);
+    const project = (await provision.json()) as { project_id: string };
+
+    // The mock deliberately sets `Set-Cookie: upstream_session=leak-me` on the
+    // project-detail GET — this is the passthrough (non-buffered) response
+    // path, which is where `route.ts` explicitly strips `set-cookie`.
+    const detail = await fetch(`${app.baseUrl}/api/kortix/projects/${project.project_id}`, {
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(detail.status).toBe(200);
+    expect(detail.headers.get('set-cookie')).toBeNull();
+  });
+
+  test('request body integrity: POST body arrives at upstream byte-for-byte with Content-Length (never chunked)', async () => {
+    mock.reset();
+    const email = uniqueEmail('body-integrity');
+    const token = await loginUser(app, email, DEMO_PASSWORD);
+
+    const payload = { hello: 'world', big: 'x'.repeat(20_000), n: 12345 };
+    const bodyText = JSON.stringify(payload);
+
+    const res = await fetch(`${app.baseUrl}/api/kortix/p/sbx_body/8000/message`, {
+      method: 'POST',
+      headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+      body: bodyText,
+    });
+    expect(res.status).toBe(200);
+    const echoed = (await res.json()) as { content: string };
+    expect(echoed.content).toBe(`echo: ${bodyText}`);
+
+    expect(mock.requests).toHaveLength(1);
+    const upstreamReq = mock.requests[0]!;
+    expect(upstreamReq.body).toEqual(payload);
+    expect(upstreamReq.transferEncoding).toBeNull();
+    expect(upstreamReq.contentLength).toBe(String(Buffer.byteLength(bodyText, 'utf8')));
+  });
+
+  test('SSE pass-through: events arrive unbuffered, connection stays open past the first burst', async () => {
+    mock.reset();
+    const email = uniqueEmail('sse');
+    const token = await loginUser(app, email, DEMO_PASSWORD);
+
+    const start = Date.now();
+    const res = await fetch(`${app.baseUrl}/api/kortix/p/sbx_sse/8000/global/event`, {
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('text/event-stream');
+
+    const reader = res.body!.getReader();
+    const decoder = new TextDecoder();
+    let buffered = '';
+
+    // First chunk should arrive fast — proves the response isn't buffered
+    // whole before being sent to the client.
+    const first = await reader.read();
+    const firstEventElapsedMs = Date.now() - start;
+    expect(first.done).toBe(false);
+    buffered += decoder.decode(first.value!, { stream: true });
+    expect(buffered).toContain('event: message');
+    expect(firstEventElapsedMs).toBeLessThan(1_000);
+
+    // Keep reading until we've seen a heartbeat too — proves the connection
+    // stays open beyond the initial burst rather than closing right away.
+    const deadline = Date.now() + 3_000;
+    while (!buffered.includes('heartbeat') && Date.now() < deadline) {
+      const next = await reader.read();
+      if (next.done) break;
+      buffered += decoder.decode(next.value!, { stream: true });
+    }
+    expect(buffered).toContain('heartbeat');
+
+    await reader.cancel();
+  });
+});

--- a/apps/whitelabel-demo/tests/e2e/rate-limit.test.ts
+++ b/apps/whitelabel-demo/tests/e2e/rate-limit.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Per-user token-bucket rate limiting (`src/server/rate-limit.ts`) as
+ * enforced by the proxy. Dedicated boot with a small `RATE_LIMIT_PER_MIN` so
+ * the bucket empties (and refills) fast enough for a deterministic test.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { type AppInstance, loginUser, resetUsersStore, startApp, uniqueEmail } from './harness';
+import { createMockUpstream, type MockUpstream } from './mock-upstream';
+import { DEMO_PASSWORD, WRAPPER_KEY, wrapperEnv } from './env';
+
+const CAPACITY = 30; // RATE_LIMIT_PER_MIN — refills 1 token/2s, fast enough for a deterministic test
+
+describe('rate limiting', () => {
+  let mock: MockUpstream;
+  let app: AppInstance;
+
+  beforeAll(async () => {
+    resetUsersStore();
+    mock = createMockUpstream(WRAPPER_KEY);
+    app = await startApp(
+      wrapperEnv({ KORTIX_UPSTREAM: `${mock.url}/v1`, RATE_LIMIT_PER_MIN: String(CAPACITY) }),
+    );
+  }, 30_000);
+
+  afterAll(async () => {
+    await app?.stop();
+    mock?.stop();
+    resetUsersStore();
+  });
+
+  test('exceeding the per-minute budget returns 429 with Retry-After, then recovers', async () => {
+    const email = uniqueEmail('rate-limit');
+    const token = await loginUser(app, email, DEMO_PASSWORD);
+    const hit = () =>
+      fetch(`${app.baseUrl}/api/kortix/accounts/me`, {
+        headers: { authorization: `Bearer ${token}` },
+      });
+
+    // Drain the bucket.
+    for (let i = 0; i < CAPACITY; i++) {
+      const res = await hit();
+      expect(res.status).toBe(200);
+    }
+
+    // The next request should be rate-limited.
+    const limited = await hit();
+    expect(limited.status).toBe(429);
+    const retryAfterHeader = limited.headers.get('retry-after');
+    expect(retryAfterHeader).toBeTruthy();
+    const retryAfterSeconds = Number(retryAfterHeader);
+    expect(Number.isFinite(retryAfterSeconds)).toBe(true);
+    expect(retryAfterSeconds).toBeGreaterThan(0);
+    expect(await limited.json()).toEqual({ error: 'Rate limit exceeded' });
+
+    // A different user has their own bucket and is unaffected.
+    const otherEmail = uniqueEmail('rate-limit-other');
+    const otherToken = await loginUser(app, otherEmail, DEMO_PASSWORD);
+    const otherRes = await fetch(`${app.baseUrl}/api/kortix/accounts/me`, {
+      headers: { authorization: `Bearer ${otherToken}` },
+    });
+    expect(otherRes.status).toBe(200);
+
+    // After waiting out Retry-After, the original user's bucket has refilled.
+    await new Promise((r) => setTimeout(r, retryAfterSeconds * 1000 + 250));
+    const recovered = await hit();
+    expect(recovered.status).toBe(200);
+  }, 20_000);
+});

--- a/apps/whitelabel-demo/tests/e2e/session-crypto.ts
+++ b/apps/whitelabel-demo/tests/e2e/session-crypto.ts
@@ -1,0 +1,46 @@
+/**
+ * A black-box re-implementation of `src/server/auth.ts`'s token scheme, used
+ * ONLY to hand-craft edge-case tokens (expired, tampered) that a real login
+ * flow can't produce on demand. Deliberately duplicated rather than imported
+ * from app source — these tests exercise the app as an HTTP black box, and an
+ * independent implementation is also a better regression check: if it and
+ * `auth.ts` ever disagree, that's a real compatibility break, not a shared-bug
+ * false negative.
+ */
+
+import { createHmac } from 'node:crypto';
+
+function b64url(input: string): string {
+  return Buffer.from(input, 'utf8').toString('base64url');
+}
+
+function sign(secret: string, body: string): string {
+  return createHmac('sha256', secret).update(body).digest('base64url');
+}
+
+export function craftToken(
+  secret: string,
+  userId: string,
+  { iat, exp }: { iat: number; exp: number },
+): string {
+  const body = b64url(JSON.stringify({ userId, iat, exp }));
+  return `${body}.${sign(secret, body)}`;
+}
+
+/** A validly-signed but already-expired token. */
+export function expiredToken(secret: string, userId: string): string {
+  const now = Math.floor(Date.now() / 1000);
+  return craftToken(secret, userId, { iat: now - 1000, exp: now - 10 });
+}
+
+/** A well-formed, non-expired token signed with the WRONG secret (or tampered signature). */
+export function tamperedToken(secret: string, userId: string): string {
+  const now = Math.floor(Date.now() / 1000);
+  const valid = craftToken(secret, userId, { iat: now, exp: now + 3600 });
+  const dot = valid.indexOf('.');
+  const body = valid.slice(0, dot);
+  const sig = valid.slice(dot + 1);
+  // Flip the last character of the signature (base64url alphabet-safe swap).
+  const flipped = sig.slice(0, -1) + (sig.at(-1) === 'A' ? 'B' : 'A');
+  return `${body}.${flipped}`;
+}

--- a/apps/whitelabel-demo/tests/e2e/usage.test.ts
+++ b/apps/whitelabel-demo/tests/e2e/usage.test.ts
@@ -1,0 +1,104 @@
+/**
+ * `/api/usage` — aggregates `GET /projects/:id/gateway/sessions` across every
+ * project the caller owns, applies `COST_MARKUP`, and degrades gracefully if
+ * one project's upstream call fails.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { type AppInstance, loginUser, resetUsersStore, startApp, uniqueEmail } from './harness';
+import { createMockUpstream, type MockUpstream } from './mock-upstream';
+import { COST_MARKUP, DEMO_PASSWORD, wrapperEnv, WRAPPER_KEY } from './env';
+
+async function provision(app: AppInstance, token: string, name: string): Promise<string> {
+  const res = await fetch(`${app.baseUrl}/api/kortix/projects/provision`, {
+    method: 'POST',
+    headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+    body: JSON.stringify({ name }),
+  });
+  const project = (await res.json()) as { project_id: string };
+  return project.project_id;
+}
+
+describe('/api/usage', () => {
+  let mock: MockUpstream;
+  let app: AppInstance;
+
+  beforeAll(async () => {
+    resetUsersStore();
+    mock = createMockUpstream(WRAPPER_KEY);
+    app = await startApp(wrapperEnv({ KORTIX_UPSTREAM: `${mock.url}/v1` }));
+  }, 30_000);
+
+  afterAll(async () => {
+    await app?.stop();
+    mock?.stop();
+    resetUsersStore();
+  });
+
+  test('markup math is exact for a single project', async () => {
+    const email = uniqueEmail('usage-single');
+    const token = await loginUser(app, email, DEMO_PASSWORD);
+    const projectId = await provision(app, token, 'Usage Single');
+    mock.seedGatewaySessions(projectId, [
+      { session_id: 's1', total_cost: 10 },
+      { session_id: 's2', total_cost: 2.5 },
+    ]);
+
+    const res = await fetch(`${app.baseUrl}/api/usage`, { headers: { authorization: `Bearer ${token}` } });
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as {
+      markup: number;
+      totals: { raw: number; billed: number };
+      projects: Array<{ projectId: string; sessions: Array<{ billed_cost: number; total_cost: number }> }>;
+    };
+
+    expect(data.markup).toBe(Number(COST_MARKUP));
+    expect(data.totals.raw).toBe(12.5);
+    expect(data.totals.billed).toBe(Math.round(12.5 * Number(COST_MARKUP) * 100) / 100);
+
+    const proj = data.projects.find((p) => p.projectId === projectId)!;
+    expect(proj.sessions.find((s) => s.total_cost === 10)!.billed_cost).toBe(15);
+    expect(proj.sessions.find((s) => s.total_cost === 2.5)!.billed_cost).toBe(3.75);
+  });
+
+  test('sums across multiple owned projects', async () => {
+    const email = uniqueEmail('usage-multi');
+    const token = await loginUser(app, email, DEMO_PASSWORD);
+    const p1 = await provision(app, token, 'Usage Multi 1');
+    const p2 = await provision(app, token, 'Usage Multi 2');
+    mock.seedGatewaySessions(p1, [{ session_id: 'a', total_cost: 4 }]);
+    mock.seedGatewaySessions(p2, [{ session_id: 'b', total_cost: 6 }]);
+
+    const res = await fetch(`${app.baseUrl}/api/usage`, { headers: { authorization: `Bearer ${token}` } });
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as { totals: { raw: number; billed: number }; projects: unknown[] };
+    expect(data.projects).toHaveLength(2);
+    expect(data.totals.raw).toBe(10);
+    expect(data.totals.billed).toBe(15); // 10 * 1.5
+  });
+
+  test('degrades gracefully when one owned project errors upstream', async () => {
+    const email = uniqueEmail('usage-degrade');
+    const token = await loginUser(app, email, DEMO_PASSWORD);
+    const healthy = await provision(app, token, 'Usage Healthy');
+    const broken = await provision(app, token, 'Usage Broken');
+    mock.seedGatewaySessions(healthy, [{ session_id: 'ok', total_cost: 8 }]);
+    mock.failGatewayFor(broken);
+
+    const res = await fetch(`${app.baseUrl}/api/usage`, { headers: { authorization: `Bearer ${token}` } });
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as {
+      totals: { raw: number; billed: number };
+      projects: Array<{ projectId: string; sessions: unknown[]; error?: string }>;
+    };
+
+    const healthyEntry = data.projects.find((p) => p.projectId === healthy)!;
+    const brokenEntry = data.projects.find((p) => p.projectId === broken)!;
+    expect(healthyEntry.sessions).toHaveLength(1);
+    expect(brokenEntry.sessions).toHaveLength(0);
+    expect(brokenEntry.error).toBeTruthy();
+    // Totals reflect only the healthy project — one bad upstream doesn't 500 the whole response.
+    expect(data.totals.raw).toBe(8);
+    expect(data.totals.billed).toBe(12);
+  });
+});

--- a/packages/sdk/API-MAP.md
+++ b/packages/sdk/API-MAP.md
@@ -156,7 +156,7 @@ Map exists, but these belong to the platform app, not the agent SDK:
 ### To make the SDK the whole data layer
 1. ~~Add a `files` client to the SDK~~ — **done**: `@kortix/sdk/files` wraps the daemon `/file` + `/find` endpoints (12 ops). Remaining: move `features/files` hooks in; **collapse the `features/project-files` twin** into it (backend-parameterized).
 2. **Wrap the existing client fns as hooks** in the SDK: git/versions/change-requests, triggers, gateway-observability, sandbox-admin, billing/account-state.
-3. **Framework-free event stream** — the SSE surface (`client.global.event()`) is only consumed today through React hooks (`use-session-sync`, `use-opencode-events`); a non-React host has no way to subscribe.
+3. ~~Framework-free event stream~~ — **done**: `openEventStream` (`@kortix/sdk` root barrel / `@kortix/sdk/event-stream`) is a framework-free connect/reconnect/heartbeat/coalescing primitive with zero React deps, and `session.stream()` is a thin facade over it (`ensureReady()` + the session's own runtime client). `@kortix/sdk/react`'s `useOpenCodeEventStream` is now just a React wrapper around the same primitive — a non-React host (server wrapper, worker, CLI) subscribes directly via `session.stream()` or `openEventStream()`.
 4. **Land + export the kortix-master daemon client** (tasks/tickets/projects/milestones/credentials/services) from the SDK barrel once its hooks move down.
 5. **Mobile adoption** — the SDK is the shared implementation in principle, but the mobile app hasn't migrated its data layer onto it yet.
 6. Everything else (the agent loop) is already SDK — that's the verified path.

--- a/packages/sdk/API-MAP.md
+++ b/packages/sdk/API-MAP.md
@@ -18,6 +18,12 @@ Legend: **✅ in SDK** · **🟡 partial** (client fn in SDK, hook not) · **❌
 ### 1. Auth / session token  ✅
 Injection seam, not an endpoint. `configureKortix({ getToken })` → Supabase token on every request; 401 retry; cache invalidation.
 
+### 1b. Token validation helper (pasted-API-key UX)  ✅
+`kortix.validateToken()` → `GET /v1/accounts/me`. Never throws — resolves
+`{valid: boolean, identity?: AccountIdentity, error?: ApiError}`. Built for a
+setup screen that needs to render "invalid token" inline instead of
+try/catching every call.
+
 ### 2. Projects  ✅
 | op | Kortix REST | SDK |
 |---|---|---|
@@ -43,9 +49,15 @@ Injection seam, not an endpoint. `configureKortix({ getToken })` → Supabase to
 | restart | `POST .../sessions/:sid/restart` |
 | commit + push | `POST .../sessions/:sid/commit-push` |
 | sharing (project) | `GET/PUT .../sessions/:sid/sharing` |
-| transcript | `GET .../sessions/:sid/transcript` |
+| transcript | `GET .../sessions/:sid/transcript` → `projects-client/sessions.ts`'s `getSessionTranscript` ✅, facade `session(pid,sid).transcript()` ✅ (previously listed ✅ here with no client fn behind it — that was false; now genuinely wired) |
 | preview candidates (live ports) | `GET .../sessions/:sid/previews` |
 | public shares | `GET/POST/DELETE .../sessions/:sid/public-shares[/:id]` |
+
+### 5b. Token minting (CLI PATs) — Kortix-as-a-Backend-critical  ✅
+| op | REST | SDK |
+|---|---|---|
+| list / create / revoke (account-scoped) | `GET/POST /v1/accounts/tokens`, `DELETE /v1/accounts/tokens/:tokenId` | `projects-client/tokens.ts` ✅, facade `kortix.accounts.tokens.{list,create,revoke}` ✅ |
+| list / create / revoke (project-scoped, `KORTIX_TOKEN`) | `GET/POST /v1/projects/:id/cli-token`, `DELETE .../cli-token/:tokenId` | ✅, facade `project(id).tokens.{list,create,revoke}` ✅ |
 
 ### 6. Session runtime — the agent loop (OpenCode)  ✅
 | op | v2 client / daemon |
@@ -66,6 +78,7 @@ Injection seam, not an endpoint. `configureKortix({ getToken })` → Supabase to
 - catalog/budget: `GET /v1/llm/models`, `GET /v1/projects/:id/llm-catalog`
 - selection + persistence: `useOpenCodeLocal`, `useModelStore` ✅
 - **gateway observability** (`/v1/projects/:id/gateway/{overview,logs,keys,budgets,series,errors}`) → client fully in SDK (`projects-client/gateway.ts`) ✅; hooks still web-local 🟡
+- **gateway playground** — `project(id).gateway.playground(prompt, models)` → `POST /v1/projects/:id/gateway/playground` (run one prompt against up to 6 models side by side) ✅
 
 ### 8. Agents · commands · tools · skills · MCP
 | op | runtime | SDK |
@@ -94,7 +107,7 @@ Daemon-direct (bypasses v2 client), full 12-op client now in the SDK (`@kortix/s
 React hooks are still web-local (`features/files/`, + duplicated in `features/project-files/` — collapsing that twin remains open). **`useWorkspaceSearch` is alive and consumed (`features/workspace/command-palette.tsx`) — not dead.** `useLssSearch` / `useTextSearch` are already gone.
 
 ### 11. Git / versions / change-requests  🟡
-Client fns in SDK (`git-history.ts`, `change-requests.ts`), **hooks web-local** (`features/project-files`):
+Client fns in SDK (`git-history.ts`, `change-requests.ts`), **hooks partial** (`useChangeRequests` in `@kortix/sdk/react` ✅; the rest of `features/project-files` is still web-local):
 | op | REST |
 |---|---|
 | commits / commit / diff | `GET /v1/projects/:id/commits[/:sha][/diff]` |
@@ -102,6 +115,7 @@ Client fns in SDK (`git-history.ts`, `change-requests.ts`), **hooks web-local** 
 | file history / version-diff | `GET /v1/projects/:id/files/history`, `/version-diff` |
 | change-requests CRUD | `GET/POST/PUT /v1/projects/:id/change-requests[/:cr]` |
 | merge / merge-preview / close / reopen | `POST .../change-requests/:cr/{merge,close,reopen}`, `GET .../merge-preview` |
+| **request-changes** (Review Center feedback) | `POST .../change-requests/:cr/request-changes` → client fn already existed (`requestChangesOnChangeRequest`), now also on the facade: `project(id).changeRequests.requestChanges(crId, feedback)` ✅ |
 | project files (git-backed) | `GET /v1/projects/:id/files`, `POST /files/{content,search}`, `GET /files/archive` |
 
 ### 12. Connectors / integrations  ✅ (project) · 🟡 (executor)
@@ -109,31 +123,115 @@ Client fns in SDK (`git-history.ts`, `change-requests.ts`), **hooks web-local** 
 - executor runtime (`/v1/executor/projects/:id/connectors/*`, Slack/Pipedream/CUA) → 🟡 web-local (`lib/*`)
 
 ### 13. Triggers / scheduled tasks  🟡
-`projects-client/triggers.ts` ✅ (client) ; hooks web-local (`hooks/scheduled-tasks`).
+`projects-client/triggers.ts` ✅ (client) ; `useProjectTriggers` now in `@kortix/sdk/react` ✅ (list + create/update/remove/fire, invalidation-wired); the web app's own `hooks/scheduled-tasks` hook hasn't migrated onto it yet.
+
+### 13b. Marketplace / registry install (project-scoped)  ✅
+Installing/updating/removing a catalog item onto a project's default branch (a commit, not a runtime call) — distinct from browsing the catalog itself (client fns in `projects-client/marketplace-catalog.ts`, now also wrapped on the facade as top-level `kortix.marketplace.*` — see §13c). `projects-client/marketplace.ts` ✅; facade `project(id).marketplace.{list,install,updates,update,updateAll,remove}` and the identical `project(id).registry.{...}` alias ✅:
+| op | REST |
+|---|---|
+| install | `POST /v1/projects/:id/marketplace/install` (+ `/registry/install` alias) |
+| list installed | `GET /v1/projects/:id/marketplace` (+ `/registry` alias) |
+| check for updates | `GET /v1/projects/:id/marketplace/updates` (+ `/registry/updates` alias) |
+| update one / update all | `POST /v1/projects/:id/marketplace/{update,update-all}` (+ `/registry/...` alias) |
+| remove | `DELETE /v1/projects/:id/marketplace/:name` (+ `/registry/:name` alias) |
+
+### 13c. Marketplace catalog browse (public) + sources  ✅
+Previously OUT OF SCOPE ("Marketplace catalog browsing"). Now wrapped
+end-to-end: client fns in `projects-client/marketplace-catalog.ts` are on the
+facade as `kortix.marketplace.{items, item, itemFile, marketplaces, featured,
+sources: {list, add, remove}}` (top-level — distinct from the install-scoped
+`project(id).marketplace.*` in §13b):
+| op | REST |
+|---|---|
+| browse catalog items (query/type/source filter) | `GET /v1/marketplace/items` |
+| distinct marketplaces + item counts | `GET /v1/marketplace/marketplaces` |
+| curated featured marketplaces | `GET /v1/marketplace/marketplaces/featured` |
+| item detail | `GET /v1/marketplace/items/:id` |
+| item file content | `GET /v1/marketplace/items/:id/file?path=` |
+| sources CRUD (authed, platform-global "Add a marketplace") | `GET/POST /v1/marketplace/sources`, `DELETE /v1/marketplace/sources/:id` |
+
+### 13d. Agent-minted setup links  ✅
+Short-lived links the in-sandbox agent mints so a human can enter a secret
+value or 1-click connect a Pipedream app, without the agent ever seeing the
+value/credential. `projects-client/setup-links.ts` ✅; facade
+`project(id).setupLinks.{requestSecret, requestConnector}` ✅:
+| op | REST |
+|---|---|
+| mint a secret-entry link | `POST /v1/projects/:id/secret-requests` |
+| mint a Pipedream Quick Connect link | `POST /v1/projects/:id/connect-requests` |
+
+### 13e. Manifest validate + git token  ✅
+Two small project-scoped mutations, added to `projects-client/projects.ts`:
+- `project(id).validateManifest(raw)` → `POST /v1/projects/:id/manifest/validate`
+  (validates `kortix.toml` raw TOML text server-side — same schema `kortix
+  ship`/`kortix validate`/the CR-merge gate use; always resolves with
+  `{valid, issues}`, never throws on an invalid manifest).
+- `project(id).gitToken()` → `POST /v1/projects/:id/git-token` (mints a
+  fresh scoped git push token for a *managed* project; throws/409s for BYO
+  repos).
 
 ### 14. Sandbox lifecycle  ✅ / 🟡
 - session-sandbox status/metrics/instances → `projects-client/{sandbox,session-sandbox}.ts` ✅
 - `GET /v1/projects/:id/{sandbox-health,sandboxes}`, snapshots, warm-pool, `GET /v1/platform/sandbox/version*` → 🟡 client in `@kortix/sdk/platform-client` ✅; hooks web-local (`hooks/platform`)
 - sandbox proxy `ALL /v1/p/:sandboxId/:port/*` + preview auth/share → used by opencode-client baseURL ✅
 
-### 15. Account state / billing (for entitlement + UI)  🟡
-`GET /v1/billing/account-state` (+ minimal) client now in SDK (`projects-client/billing.ts`) ✅; hooks still web-local (`hooks/billing`, `lib/api/billing`) 🟡. Needed by the SDK consumer for tier/entitlement gating; the rest of `/v1/billing/*` (checkout/credits/portal) is product-UI, optional for SDK.
+### 15. Billing  ✅ (read + a curated mutation surface)
+Read surface (unchanged) — `kortix.billing.{accountState, accountStateMinimal,
+transactions, transactionsSummary, creditBreakdown, usageHistory,
+tierConfigurations}` ✅. Hooks still web-local (`hooks/billing`) 🟡.
+| op | REST |
+|---|---|
+| account state (full / minimal) | `GET /v1/billing/account-state[/minimal]` |
+| transactions (paginated) / summary | `GET /v1/billing/transactions`, `/transactions/summary` |
+| credit breakdown | `GET /v1/billing/credit-breakdown` |
+| usage history | `GET /v1/billing/usage-history` |
+| tier configurations (public pricing) | `GET /v1/billing/tier-configurations` |
+
+Mutations — a deliberately curated subset of `apps/api/src/billing/routes`
+(Stripe-webhook-only routes and legacy/per-seat-claim internals stay
+unwired) now live in `projects-client/billing.ts` and are grouped on the
+facade as `kortix.billing.{checkout, subscription, credits}`:
+| group | op | REST |
+|---|---|---|
+| `checkout` | createSession | `POST /v1/billing/create-checkout-session` |
+| `checkout` | confirmSession | `POST /v1/billing/confirm-checkout-session` |
+| `subscription` | createPortalSession | `POST /v1/billing/create-portal-session` |
+| `subscription` | cancel | `POST /v1/billing/cancel-subscription` |
+| `subscription` | reactivate | `POST /v1/billing/reactivate-subscription` |
+| `subscription` | scheduleDowngrade | `POST /v1/billing/schedule-downgrade` |
+| `subscription` | cancelScheduledChange | `POST /v1/billing/cancel-scheduled-change` |
+| `subscription` | prorationPreview | `GET /v1/billing/proration-preview` |
+| `credits` | purchase | `POST /v1/billing/purchase-credits` |
+| `credits` | autoTopupSettings | `GET /v1/billing/auto-topup/settings` |
+| `credits` | configureAutoTopup | `POST /v1/billing/auto-topup/configure` |
 
 ### 16. Transcription / misc session input  🟡
 `POST /v1/transcription` (voice) client now in SDK (`projects-client/transcription.ts`) ✅; hooks still web-local (`hooks/transcription`) 🟡.
 
 ### 17. Channels / apps (project-scoped)  🟡
 Slack/email inbound-outbound installs (`projects-client/channels.ts`) and the `/v1/projects/:id/apps/*` deployment family (`projects-client/apps.ts`) — clients ✅ in SDK; hooks web-local.
+Also now wrapped: Slack file download/upload proxies
+(`project(id).channels.slack.{getFile, uploadFile}` →
+`GET/POST /v1/projects/:id/channels/slack/file[/upload]`) and the Meet
+"bot speaks" action (`project(id).channels.meet.speak(botId, text, voice?)`
+→ `POST /v1/projects/:id/channels/meet/speak`).
+
+### 18. Account audit log (Enterprise)  ✅ (client + facade) / 🟡 (hooks)
+Event list + CSV/JSONL export + outbound SIEM webhook CRUD, gated server-side on `audit.read`/`account.write` + the account's `auditAccess` entitlement. `projects-client/audit.ts` ✅; facade `kortix.accounts.audit.{log, export, webhooks: {list,create,update,remove}}` ✅ (accountId-first, like the rest of `kortix.accounts.*`); no hooks yet (this is an admin-console surface, low priority for the agent-product hooks):
+| op | REST |
+|---|---|
+| list events (cursor-paginated) | `GET /v1/accounts/:id/audit` |
+| export (CSV/JSONL) | `GET /v1/accounts/:id/audit/export` |
+| webhooks CRUD | `GET/POST /v1/accounts/:id/audit/webhooks`, `PATCH/DELETE .../:webhookId` |
 
 ---
 
 ## OUT OF SCOPE — control plane / platform admin (NOT the SDK)
 Map exists, but these belong to the platform app, not the agent SDK:
-- **Accounts IAM v2** — groups, service-accounts, SCIM tokens, SSO/SAML, session/MFA/PAT policy, audit (`/v1/accounts/:id/iam/*`, `/scim/v2/*`)
+- **Accounts IAM v2** — groups, service-accounts, SCIM tokens, SSO/SAML, session/MFA/PAT policy (`/v1/accounts/:id/iam/*`, `/scim/v2/*`). (Account **audit** — event log, export, SIEM webhooks — is now IN SCOPE, see §18; it's the one IAM-v2-adjacent surface the SDK wraps because a "Kortix as a Backend" host needs to read its own compliance trail.)
 - **Admin console** — tiers, credits debit, provider analytics/distribution/fallback, warm-pool/snapshot config (`/v1/admin/*`)
 - **Ops** — `/v1/ops/overview`
 - **Tunnel** — device-auth, tunnel lifecycle, agent WS (`/v1/tunnel/*`)
-- **Marketplace** — catalog/items/sources (`/v1/marketplace/*`)
 - **Channels webhooks** — slack/email/telegram/sandbox-provider (`/v1/webhooks/*`)
 - **OAuth2 provider + git smart-http + setup/system/access-control** (`/v1/oauth/*`, `/v1/git/*`, `/v1/setup/*`, `/v1/system/*`, `/v1/access/*`)
 - **LLM gateway internals** — `/v1/router/*`, `/v1/llm/*`, `/internal/gateway/*` (the gateway calls these; the agent SDK only consumes models, not the routing control plane)
@@ -148,15 +246,23 @@ Map exists, but these belong to the platform app, not the agent SDK:
 | Session runtime (messages/events/permissions/diff/todo) | ✅ complete |
 | Models, Agents, Commands, Tools, MCP, PTY | ✅ complete |
 | **Workspace files (read/write/status/search)** | ✅ full client in SDK (`@kortix/sdk/files`); hooks web-local |
+| Token minting (account + project-scoped CLI PATs) | ✅ complete — `projects-client/tokens.ts`, facade `kortix.accounts.tokens.*` / `project(id).tokens.*` |
+| Marketplace/registry install (project-scoped) | ✅ complete — `projects-client/marketplace.ts`, facade `project(id).marketplace.*` / `.registry.*` |
+| Public marketplace catalog browse + sources | ✅ complete — `projects-client/marketplace-catalog.ts`, facade `kortix.marketplace.*` |
+| Billing mutations (checkout/subscription/credits) | ✅ complete — `projects-client/billing.ts`, facade `kortix.billing.{checkout, subscription, credits}` |
+| Setup links, manifest validate, git token | ✅ complete — facade `project(id).{setupLinks, validateManifest, gitToken}` |
+| Account audit (Enterprise) | ✅ client + facade (`kortix.accounts.audit.*`); 🟡 no hooks yet |
 | Skills create/update/delete | ❌ web-local (daemon file I/O) |
-| Git / versions / change-requests, gateway observability, triggers, sandbox-admin, billing/account-state, transcription, channels, apps | 🟡 client fns ✅ in SDK, hooks still web-local |
+| Git / versions / change-requests, gateway observability, sandbox-admin, billing/account-state, transcription, apps | 🟡 client fns ✅ in SDK, hooks still web-local |
+| Channels (Slack/email/Meet installs + apps deploy family) | 🟡 client fns ✅ in SDK, hooks still web-local — now also includes the Slack file get/upload proxy and Meet `speak` (client + facade wired; see §17) |
+| Triggers, project secrets, change-requests | 🟡→partial ✅ — `useProjectTriggers`/`useProjectSecrets`/`useChangeRequests` now in `@kortix/sdk/react`; the pre-existing web hooks for these haven't migrated onto them yet |
 | Executor connectors runtime | 🟡 web-local |
-| kortix-master daemon family (tasks/tickets/projects/milestones/credentials/services) | 🟡 client landing in this branch (`opencode/kortix-master.ts`), not yet exported from the SDK barrel; hooks web-local |
+| kortix-master daemon family (tasks/tickets/projects/milestones/credentials/services) | ✅ client in SDK (`opencode/kortix-master.ts`, re-exported via `@kortix/sdk/opencode-client`) + hooks in `@kortix/sdk/react` (`use-kortix-master.ts`); web's `hooks/kortix/*` files are now thin re-export wrappers over them. Not on the ROOT barrel (deliberate — it's an opencode-runtime surface, reached via the opencode-client subpath) |
 
 ### To make the SDK the whole data layer
 1. ~~Add a `files` client to the SDK~~ — **done**: `@kortix/sdk/files` wraps the daemon `/file` + `/find` endpoints (12 ops). Remaining: move `features/files` hooks in; **collapse the `features/project-files` twin** into it (backend-parameterized).
-2. **Wrap the existing client fns as hooks** in the SDK: git/versions/change-requests, triggers, gateway-observability, sandbox-admin, billing/account-state.
+2. **Wrap the existing client fns as hooks** in the SDK: git/versions/change-requests (`useChangeRequests` ✅ done; commits/branches/diff still web-local), triggers (`useProjectTriggers` ✅ done), gateway-observability, sandbox-admin, billing/account-state.
 3. ~~Framework-free event stream~~ — **done**: `openEventStream` (`@kortix/sdk` root barrel / `@kortix/sdk/event-stream`) is a framework-free connect/reconnect/heartbeat/coalescing primitive with zero React deps, and `session.stream()` is a thin facade over it (`ensureReady()` + the session's own runtime client). `@kortix/sdk/react`'s `useOpenCodeEventStream` is now just a React wrapper around the same primitive — a non-React host (server wrapper, worker, CLI) subscribes directly via `session.stream()` or `openEventStream()`.
-4. **Land + export the kortix-master daemon client** (tasks/tickets/projects/milestones/credentials/services) from the SDK barrel once its hooks move down.
+4. ~~Land + export the kortix-master daemon client~~ — **done**: the client (`opencode/kortix-master.ts`) is re-exported from `@kortix/sdk/opencode-client`, and its React Query layer lives in `@kortix/sdk/react` (`use-kortix-master.ts`, with the injectable `KortixMasterIdentity` seam); apps/web's six former hook files (`hooks/kortix/*` + `hooks/use-sandbox-services.ts`) are thin wrappers over it.
 5. **Mobile adoption** — the SDK is the shared implementation in principle, but the mobile app hasn't migrated its data layer onto it yet.
 6. Everything else (the agent loop) is already SDK — that's the verified path.

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,0 +1,131 @@
+# Changelog
+
+All notable changes to `@kortix/sdk` are documented here. Format loosely
+follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## 0.2.0
+
+Headline: **"Kortix as a Backend"** — everything a third-party server needs to
+safely wrap Kortix on behalf of multiple concurrent end users, plus a
+framework-free headless chat kit and a batch of previously web-local REST
+domains promoted into the facade.
+
+### Added
+
+- **`@kortix/sdk/server`** — `runWithKortix(config, fn)` / `createScopedKortix(config)`.
+  Per-request platform-config isolation via Node's `AsyncLocalStorage`, so a
+  multi-tenant wrapper backend can safely handle concurrent requests carrying
+  different end-user tokens without racing on the process-global
+  `configureKortix()` singleton. Never reachable from the root `@kortix/sdk` or
+  `@kortix/sdk/react` entry points, so `node:async_hooks` never enters a
+  browser bundle.
+- **Headless chat kit** — `classifyPart`/`classifyTurn`/`toolInfo`/`ToolView`
+  (`@kortix/sdk/turns`, also re-exported from the root barrel) normalize every
+  opencode part kind (text, reasoning, tool, file, subtask, patch, snapshot,
+  agent, retry, compaction, step) into a typed, compile-time-exhaustive
+  `ClassifiedPart` — plus `KortixChatEvent`/`narrowChatEvent` (a curated
+  14-member event union narrowed from the raw ~50-variant SSE wire union) and
+  `useChatTurns`/`renderParts`/`PartRenderers` (`@kortix/sdk/react`), a
+  React binding that requires a renderer for every part kind at compile time.
+- **`session(pid, sid).stream()`** — a framework-free facade over the
+  `openEventStream` primitive, bound to that handle's own resolved runtime.
+  Safe to call from a server-side wrapper, a worker, or a CLI — no React
+  required. `@kortix/sdk/react`'s `useOpenCodeEventStream` is now a thin
+  wrapper over the exact same primitive.
+- **`session(pid, sid).files`** — the same 12-op workspace-files surface as
+  the top-level `files` export, but bound to THIS session's own runtime
+  instead of the process-global "active" sandbox — fixes cross-session bleed
+  for a host juggling multiple concurrently open sessions.
+- **`session(pid, sid).ensureReady()` concurrency dedup** — concurrent calls
+  for the same `(projectId, sessionId)` now ride a single in-flight `/start`
+  long-poll instead of each issuing their own.
+- **New facade namespaces**, all with client fns already in
+  `@kortix/sdk/projects-client`:
+  - `accounts.tokens` / `project(id).tokens` — CLI PAT minting (account- and
+    project-scoped `kortix_pat_...` tokens).
+  - `billing.*` — `accountState`, `accountStateMinimal`, `transactions`,
+    `transactionsSummary`, `creditBreakdown`, `usageHistory`,
+    `tierConfigurations` (read-only entitlement/usage surface), plus a curated
+    mutation surface: `billing.checkout.{createSession, confirmSession}`,
+    `billing.subscription.{createPortalSession, cancel, reactivate,
+    scheduleDowngrade, cancelScheduledChange, prorationPreview}`,
+    `billing.credits.{purchase, autoTopupSettings, configureAutoTopup}`.
+  - `project(id).marketplace` / `.registry` — install/list/updates/update/
+    updateAll/remove for a catalog item on a project's default branch.
+  - `marketplace.*` — public marketplace catalog browse + sources
+    (`items`, `item`, `itemFile`, `marketplaces`, `featured`,
+    `sources.{list,add,remove}`), top-level and distinct from the
+    install-scoped `project(id).marketplace`.
+  - `session(pid, sid).transcript()` — compact server-side transcript read
+    (text + tool calls, no tool inputs/outputs), callable with project-scoped
+    session tokens.
+  - `project(id).changeRequests.requestChanges()` — Review Center feedback on
+    a change request.
+  - `accounts.audit.*` — Enterprise audit log (`log`, `export`, `webhooks.{list,create,update,remove}`).
+  - `project(id).setupLinks.{requestSecret, requestConnector}` —
+    agent-minted, short-lived links for a human to enter a secret value or
+    1-click connect a Pipedream app, without the agent seeing the credential.
+  - `project(id).validateManifest(raw)` / `project(id).gitToken()` —
+    server-side `kortix.toml` validation and scoped git push token minting
+    for a managed project.
+  - `project(id).channels.slack.{getFile, uploadFile}` /
+    `project(id).channels.meet.speak(botId, text, voice?)` — Slack file
+    download/upload proxy and the Meet bot "speak" action.
+  - `project(id).gateway.playground(prompt, models)` — run one prompt
+    against up to 6 models side by side.
+  - `validateToken()` — pasted-API-key validation helper (`GET /accounts/me`,
+    never throws).
+- **Domain hooks** (`@kortix/sdk/react`) — `useProjectSecrets`,
+  `useProjectTriggers`, `useChangeRequests`: thin React Query bindings with
+  their own query key + invalidation-wired mutations, over CRUD surfaces that
+  previously had a client fn but no SDK-owned hook.
+- Root barrel (`@kortix/sdk`) now type-only re-exports the full set of domain
+  result types (`ProjectDetail`, `AccountState`, `GatewayOverview`,
+  `MarketplaceInstalledItem`, `AuditEvent`, `AccountToken`, …) from
+  `platform/projects-client`, so a consumer can name a facade call's return
+  type without a second import.
+- **`examples/`** — six runnable, self-contained scripts covering the facade
+  (list projects), send+stream, the server wrapper pattern, transcript
+  rendering, cost pass-through/re-billing, and files+secrets. Typechecked via
+  `examples/tsconfig.json` as part of `pnpm typecheck`.
+
+### Changed
+
+- **One typed error hierarchy across every HTTP layer.** `ApiError`/`AuthError`
+  are now real classes (`instanceof`-able, enumerable `message`, `name`/shape
+  preserved for legacy string-sniffers) instead of ad-hoc
+  `Object.create(Error.prototype)` objects — and every layer (`backendApi` /
+  `platformFetch`/`authenticatedFetch`, the files client, the opencode client,
+  `ensureReady()`) now throws/returns the SAME classes instead of duck-typed
+  shapes. `BillingError`/`RequestTooLargeError` + their helpers
+  (`parseBillingError`, `isBillingError`, `formatBillingErrorForUI`) are
+  exported from the root barrel and `@kortix/sdk/api-client`, not just
+  `@kortix/sdk/react` — a server-side wrapper can now `instanceof BillingError`
+  a 402 and pass the cost/upgrade payload straight through to its own client
+  without importing a React-flavored subpath.
+- **30-second default request timeout** on `authenticatedFetch` and the
+  `backendApi`/`platformFetch` layer, so a hung sandbox/daemon request can't
+  wedge a "Kortix as a Backend" server handler forever. The long-lived SSE
+  event-stream endpoint (`/global/event`) is explicitly exempted.
+- `getAuthTokenWithRetry`'s `attempts`/`baseDelayMs` options now actually
+  drive a retry loop (previously accepted but not applied).
+- `previewUrl()`/`proxyUrl()` tolerate a relative `backendUrl` (a same-origin
+  BFF proxy pattern) by resolving against the page origin in the browser, and
+  now read the LIVE platform config instead of the config captured at
+  `createKortix()` time — so a host that calls `configureKortix()` again after
+  creation (e.g. switching into wrapper mode) is followed correctly.
+
+### Fixed
+
+- `session(pid, sid).stream()` — the README documented this method before it
+  existed; the API-MAP gap is now closed with a real, tested implementation.
+- `API-MAP.md`'s transcript row previously read "✅" with no client function
+  actually behind it — `getSessionTranscript`/`session(pid,sid).transcript()`
+  are now genuinely wired, and the doc reflects that.
+
+## 0.1.0
+
+Initial internal release — the single opinionated `createKortix()` facade
+over the Kortix REST API + OpenCode v2 runtime, `@kortix/sdk/react` hooks,
+the workspace files client, and the framework-free session/transcript/event-
+stream primitives.

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -54,13 +54,27 @@ exhaustive — see `API-MAP.md` for the full per-domain surface:
 | `kortix.projects` | list · get · detail · create · provision · update · archive · llmCatalog · sandboxTemplates · sessions (+ more: `listForAccount`, `sandboxHealth`, `createSession`) |
 | `kortix.accounts` | list · get · create · members · invites (+ more: `updateName`, `leave`, `invite`, `removeMember`, `updateMemberRole`) |
 | `kortix.project(id)` | id-bound handle: `.secrets` · `.access` · `.connectors` · `.policies` · `.triggers` · `.files` · `.git` · `.changeRequests` · `.sessions` · `.session(sid)` (+ more namespaces: `.review`, `.approvals`, `.gateway`, `.channels`, `.apps`, `.modelDefaults`, `.sandbox`) |
-| `kortix.session(pid, sid)` | id-bound handle: lifecycle (`get`/`update`/`delete`/`start`/`restart`/`stop`/`setSharing`/`previews`/`commit`/`publicShares`/`ensureReady`) · `send`/`abort`/`setModel`/`setAgent` (opinionated prompt wrappers, already shipped) · **its own runtime** (`health`/`previewUrl`/`proxyUrl` — sandbox resolved for you) + `.runtime` (the typed opencode client) |
+| `kortix.session(pid, sid)` | id-bound handle: lifecycle (`get`/`update`/`delete`/`start`/`restart`/`stop`/`setSharing`/`previews`/`commit`/`publicShares`/`ensureReady`) · `send`/`abort`/`setModel`/`setAgent` (opinionated prompt wrappers) · `stream()` (live SSE, framework-free) · **its own runtime** (`health`/`previewUrl`/`proxyUrl` — sandbox resolved for you) + `.runtime` (the typed opencode client) |
 | `kortix.runtime()` | the opencode v2 client for the active sandbox (escape hatch) |
 
-> `session.stream()` (server-owned restart/refresh per the gateway resource API)
-> is the one piece still pending the §11 server contract — `send()`/`abort()`
-> above are already live. Until `stream()` lands, reactive data comes from the
-> `@kortix/sdk/react` hooks.
+`session.stream()` is a thin facade over the framework-free `openEventStream`
+primitive (also exported directly, for hosts that want to manage the client
+themselves): it resolves THIS handle's own runtime (`ensureReady()`), connects
+to that runtime's SSE endpoint, and hands you a `close()`-able handle. No React
+required — safe to call from a server-side "Kortix as a Backend" wrapper
+(Node/Bun), a worker, or a CLI:
+
+```ts
+const handle = await kortix.session(pid, sid).stream({
+  onEvent: (event) => console.log(event.type, event),
+  onGapRehydrate: (gapMs) => console.warn(`reconnected after a ${gapMs}ms gap`),
+});
+// later, to stop:
+handle.close();
+```
+
+`@kortix/sdk/react`'s `useOpenCodeEventStream` uses the exact same primitive
+under the hood — it just also writes into the React Query cache.
 
 ## Subpath modules
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -52,10 +52,20 @@ exhaustive — see `API-MAP.md` for the full per-domain surface:
 | namespace | what |
 |---|---|
 | `kortix.projects` | list · get · detail · create · provision · update · archive · llmCatalog · sandboxTemplates · sessions (+ more: `listForAccount`, `sandboxHealth`, `createSession`) |
-| `kortix.accounts` | list · get · create · members · invites (+ more: `updateName`, `leave`, `invite`, `removeMember`, `updateMemberRole`) |
-| `kortix.project(id)` | id-bound handle: `.secrets` · `.access` · `.connectors` · `.policies` · `.triggers` · `.files` · `.git` · `.changeRequests` · `.sessions` · `.session(sid)` (+ more namespaces: `.review`, `.approvals`, `.gateway`, `.channels`, `.apps`, `.modelDefaults`, `.sandbox`) |
-| `kortix.session(pid, sid)` | id-bound handle: lifecycle (`get`/`update`/`delete`/`start`/`restart`/`stop`/`setSharing`/`previews`/`commit`/`publicShares`/`ensureReady`) · `send`/`abort`/`setModel`/`setAgent` (opinionated prompt wrappers) · `stream()` (live SSE, framework-free) · **its own runtime** (`health`/`previewUrl`/`proxyUrl` — sandbox resolved for you) + `.runtime` (the typed opencode client) |
+| `kortix.accounts` | list · get · create · members · invites · `tokens.{list,create,revoke}` (account-scoped CLI PATs, `kortix_pat_…`) · `audit.{log,export,webhooks.*}` (Enterprise audit trail) (+ more: `updateName`, `leave`, `invite`, `removeMember`, `updateMemberRole`) |
+| `kortix.billing` | entitlement/usage reads: `accountState` · `accountStateMinimal` · `transactions` · `transactionsSummary` · `creditBreakdown` · `usageHistory` · `tierConfigurations` — plus a curated mutation surface: `checkout.{createSession,confirmSession}` · `subscription.{createPortalSession,cancel,reactivate,scheduleDowngrade,cancelScheduledChange,prorationPreview}` · `credits.{purchase,autoTopupSettings,configureAutoTopup}` |
+| `kortix.marketplace` | public marketplace catalog browse + sources (not project-scoped): `items` · `item` · `itemFile` · `marketplaces` · `featured` · `sources.{list,add,remove}` — distinct from the install-scoped `project(id).marketplace` |
+| `kortix.validateToken()` | pasted-API-key validation helper — `GET /accounts/me`, never throws, resolves `{valid, identity?, error?}` |
+| `kortix.project(id)` | id-bound handle: `.secrets` · `.access` · `.connectors` · `.policies` · `.triggers` · `.files` · `.git` · `.changeRequests` (incl. `requestChanges`) · `.sessions` · `.tokens` (project-scoped CLI PATs — the `KORTIX_TOKEN` shape) · `.marketplace` / `.registry` (install/update/remove catalog items) · `.setupLinks.{requestSecret,requestConnector}` (agent-minted secret-entry / connector links) · `.validateManifest` · `.gitToken` · `.session(sid)` (+ more namespaces: `.review`, `.approvals`, `.gateway` (incl. `.playground`), `.channels`, `.apps`, `.modelDefaults`, `.sandbox`) |
+| `kortix.session(pid, sid)` | id-bound handle: lifecycle (`get`/`update`/`delete`/`start`/`restart`/`stop`/`setSharing`/`previews`/`commit`/`publicShares`/`ensureReady`) · `send`/`abort`/`setModel`/`setAgent` (opinionated prompt wrappers) · `stream()` (live SSE, framework-free) · `transcript()` (compact server-side transcript read) · `.files` (the 12-op workspace-files surface, bound to THIS session's own runtime) · **its own runtime** (`health`/`previewUrl`/`proxyUrl` — sandbox resolved for you) + `.runtime` (the typed opencode client) |
 | `kortix.runtime()` | the opencode v2 client for the active sandbox (escape hatch) |
+
+Runnable, self-contained scripts for the highest-value flows live in
+[`examples/`](./examples): list projects with a PAT, send + stream, the
+multi-tenant server-wrapper pattern, headless transcript rendering, cost
+pass-through / re-billing, and session files + project secrets. Each file's
+header comment states the env vars and the exact `bun run examples/….ts`
+invocation.
 
 `session.stream()` is a thin facade over the framework-free `openEventStream`
 primitive (also exported directly, for hosts that want to manage the client
@@ -76,6 +86,152 @@ handle.close();
 `@kortix/sdk/react`'s `useOpenCodeEventStream` uses the exact same primitive
 under the hood — it just also writes into the React Query cache.
 
+## Kortix as a Backend (server-side)
+
+`createKortix()` stores its config — crucially, the bearer-token getter — in a
+process-wide singleton. That's correct for a host with one config for its whole
+lifetime (a browser tab, a CLI, a single-tenant server), but **unsafe for a
+server process handling concurrent requests for different end users**: two
+in-flight requests racing through `createKortix()`/`configureKortix()` with
+different tokens clobber each other, and the last write wins for every other
+in-flight request.
+
+`@kortix/sdk/server` (Node/Bun only — never import it from a browser bundle;
+it statically imports `node:async_hooks`) fixes this with `AsyncLocalStorage`:
+
+```ts
+import { createScopedKortix } from '@kortix/sdk/server';
+
+// Express/Hono/Bun.serve — any per-request handler. One scoped client PER
+// REQUEST; each end user's token stays isolated to that request's own async
+// call tree, even across `await`s, even under concurrency.
+app.get('/projects', async (req, res) => {
+  const kortix = createScopedKortix({
+    backendUrl: process.env.KORTIX_API_URL!,
+    getToken: async () => resolveKortixTokenFor(req), // per-end-user PAT/token
+  });
+  res.json(await kortix.projects.list());
+});
+```
+
+`createScopedKortix(config)` has the same shape as `createKortix(config)` —
+every method call (including calls through `.project(id)` / `.session(pid, sid)`
+handles minted at call time) automatically runs inside that config's scope, and
+it never writes the process-global singleton. For middleware-style wrapping of
+an entire request body instead, use the lower-level primitive:
+
+```ts
+import { runWithKortix } from '@kortix/sdk/server';
+
+app.use(async (req, res, next) => {
+  await runWithKortix(
+    { backendUrl, getToken: async () => resolveKortixTokenFor(req) },
+    async () => {
+      await next(); // every Kortix call anywhere in this request sees THIS config
+    },
+  );
+});
+```
+
+A runnable version of the pattern is `examples/03-server-wrapper.ts`, and the
+full production-shaped reference (per-user project isolation, route policy,
+rate limiting, cost markup for re-billing) is `apps/whitelabel-demo` in wrapper
+mode — see its README.
+
+## Rendering chat (the headless chat kit)
+
+Everything needed to render an agent transcript without adopting any Kortix
+UI: `classifyPart`/`classifyTurn` (`@kortix/sdk/turns`, framework-free)
+normalize all twelve opencode part types (text, reasoning, tool, file,
+subtask, patch, snapshot, agent, retry, compaction, step, + a forward-compat
+`unknown`) into a typed `ClassifiedPart`, and normalize a failed assistant
+turn's `info.error` into a `{ name, message }` `TurnError` — so "assistant
+message with zero parts but an error" renders as a failure, not silence.
+`renderParts` (`@kortix/sdk/react`, though it has no React import) requires a
+renderer for **every** part kind at compile time, so a new part type is a
+build error at your call site instead of a silent drop in production:
+
+```tsx
+import { renderParts, type PartRenderers } from '@kortix/sdk/react';
+import { classifyTurn } from '@kortix/sdk/turns';
+
+const renderers: PartRenderers<React.ReactNode> = {
+  text: (p) => <Markdown>{p.text}</Markdown>,
+  reasoning: (p) => <Thinking text={p.text} />,
+  tool: (p) => <ToolCard name={p.tool.name} status={p.tool.status} />,
+  file: (p) => <Attachment name={p.filename ?? p.url} />,
+  subtask: (p) => <Delegated agent={p.agent} />,
+  patch: (p) => <DiffStat files={p.fileCount} />,
+  retry: (p) => <Note>{`retrying (attempt ${p.attempt})`}</Note>,
+  compaction: () => <Note>context compacted</Note>,
+  snapshot: () => null,  // internal checkpoint hash — nothing to show
+  agent: () => null,     // inline @mention, already in the sibling text
+  step: () => null,      // model-step bookkeeping
+  unknown: () => null,   // forward-compat: newer server than client
+};
+
+function Turn({ message }: { message: MessageWithParts }) {
+  const { parts, error, isEmpty } = classifyTurn(message);
+  if (isEmpty && !error) return null;
+  return <>{renderParts(parts, renderers)}{error && <TurnFailed {...error} />}</>;
+}
+```
+
+The living reference is
+`apps/whitelabel-demo/src/components/chat/message-view.tsx` — one deliberate
+rendering decision per part kind, with the rationale for each `null`. For a
+memoized message-list binding use `useChatTurns(messages)` (`@kortix/sdk/react`);
+for a no-React plain-text version of the same classification see
+`examples/04-render-transcript.ts`. On the live side, `narrowChatEvent`
+(root barrel) narrows the raw ~50-variant SSE union from `session.stream()` /
+`openEventStream` down to the curated `KortixChatEvent` union (~14 members) a
+chat UI actually dispatches on.
+
+## Errors
+
+One typed hierarchy, produced by **every** HTTP layer — `backendApi`, the
+platform client's `platformFetch`, `authenticatedFetch`, the files client, the
+opencode client, and `ensureReady()` all throw/return the same classes (from
+the root barrel or `@kortix/sdk/api-client`; `@kortix/sdk/react` re-exports
+them too). They're real classes: `instanceof` works across every host, and
+`name`/shape are preserved for legacy `error.name === 'ApiError'` sniffers.
+
+- `ApiError` — any failed request; branch on `.status` / `.code` (e.g.
+  `'TIMEOUT'`, `'RUNTIME_UNAVAILABLE'`, `'ABORTED'`). Timeout errors carry
+  `.url` / `.endpoint` / `.timeout`.
+- `AuthError extends ApiError` — `getToken()` returned null; the request was
+  never sent (`code: 'NO_SESSION'`).
+- `BillingError` — HTTP 402, with the backend's payload on `.detail`.
+- `RequestTooLargeError` — HTTP 431 (usually a too-large upload batch), with a
+  `.detail.suggestion`.
+- `SessionNotReadyError` (root barrel) — a session handle's runtime-scoped
+  member (`.runtime`, `.previewUrl()`, `.proxyUrl()`) was touched before
+  `ensureReady()` resolved this session's own sandbox.
+
+The canonical server-side wrapper shape — catch a 402 and pass the payload
+through to your own client for re-billing, instead of leaking a Kortix error:
+
+```ts
+import { ApiError, AuthError, BillingError } from '@kortix/sdk';
+
+try {
+  await kortix.session(pid, sid).send(prompt);
+} catch (err) {
+  if (err instanceof BillingError) {
+    // 402 — surface the upgrade/cost payload under YOUR billing story.
+    return res.status(402).json({ reason: 'quota', detail: err.detail });
+  }
+  if (err instanceof AuthError) return res.status(401).json({ error: 'not authenticated' });
+  if (err instanceof ApiError) return res.status(err.status ?? 502).json({ error: err.message });
+  throw err;
+}
+```
+
+Every non-streaming request also carries a **30s default timeout** (the
+long-lived SSE event stream is exempt), so a hung sandbox/daemon call can't
+wedge a server-side handler forever — it surfaces as an `ApiError` with
+`code: 'TIMEOUT'` instead.
+
 ## Subpath modules
 
 Stable, tree-shakeable surfaces (also reachable via the facade). Not exhaustive
@@ -83,12 +239,14 @@ Stable, tree-shakeable surfaces (also reachable via the facade). Not exhaustive
 `./config`, `./api-client`, `./feature-flags`, `./fresh-sessions`,
 `./instance-routes`, `./opencode-errors`, `./platform-client`, `./event-stream`,
 `./sandbox-connection-store`, `./opencode-pending-store`, `./session/url`,
-`./turns`, `./idb-sync-cache`):
+`./idb-sync-cache`):
 
 | import | provides |
 |---|---|
-| `@kortix/sdk` | `createKortix`, `configureKortix`, `files`, all file types |
-| `@kortix/sdk/react` | every `useOpenCode*` hook + providers (reactive data) |
+| `@kortix/sdk` | `createKortix`, `configureKortix`, `files`, the error classes, `classifyPart`/`classifyTurn`, `narrowChatEvent`, `openEventStream`, domain result types |
+| `@kortix/sdk/server` | **Node/Bun only** — `runWithKortix`, `createScopedKortix`, `getScopedConfig` (per-request config isolation; see "Kortix as a Backend") |
+| `@kortix/sdk/react` | every `useOpenCode*` hook + providers (reactive data), `useSession`, `useChatTurns`/`renderParts`, domain hooks (`useProjectSecrets`/`useProjectTriggers`/`useChangeRequests`) |
+| `@kortix/sdk/turns` | framework-free part/turn classification (`classifyPart`, `classifyTurn`, `toolInfo`, turn grouping/cost helpers) |
 | `@kortix/sdk/files` | workspace file ops (daemon `/file` + `/find`): `listFiles`, `readFile`, `readBlob`, `getFileStatus`, `findFiles`, `findText`, `uploadFile`, `deleteFile`, `mkdir`, `renameFile`, … |
 | `@kortix/sdk/session` | a session's runtime surface — `getSessionHealth`/`isRuntimeReady` + proxy/preview URL builders (`rewriteLocalhostUrl`, `proxyLocalhostUrl`, `detectLocalhostUrls`, …) + preview-auth helpers. **No "sandbox" in the public surface** — a session owns its runtime |
 | `@kortix/sdk/opencode-client` | `getClient`, `getClientForUrl` + the **full opencode v2 type surface** (`Event`, `Part`, `Message`, `Session`, `Pty`, `Config`, …) |
@@ -146,9 +304,10 @@ than `@kortix/sdk/react`.
 ## Tests
 
 ```sh
-pnpm --filter @kortix/sdk typecheck
+pnpm --filter @kortix/sdk typecheck  # package + examples/ (examples/tsconfig.json)
 pnpm --filter @kortix/sdk test   # facade, files, react hooks, turns, transcript, session url/health, projects-client domains
 ```
 
 See **`API-MAP.md`** for the complete endpoint catalogue (REST + opencode runtime)
-and per-domain SDK coverage status.
+and per-domain SDK coverage status, and **`CHANGELOG.md`** for what changed per
+release.

--- a/packages/sdk/examples/01-list-projects.ts
+++ b/packages/sdk/examples/01-list-projects.ts
@@ -1,0 +1,52 @@
+/**
+ * 01 — List projects with a Kortix PAT.
+ *
+ * Shows the minimum viable client: `createKortix` + a static bearer token
+ * (a `kortix_pat_...` Personal Access Token, minted from the Kortix dashboard
+ * or `kortix.accounts.tokens.create()` — see 06-files-and-secrets.ts). No
+ * Supabase session, no browser — this is the shape a CLI, cron job, or
+ * server-side script uses.
+ *
+ * Run:
+ *   KORTIX_API_URL=http://localhost:8008/v1 KORTIX_API_KEY=kortix_pat_... \
+ *     bun run examples/01-list-projects.ts
+ *
+ * As an npm consumer (outside this monorepo) the only import line changes:
+ *   import { createKortix } from '@kortix/sdk';
+ * This file imports from '../src/index' instead, so `tsc`/`bun` resolve it
+ * against the package's own source without a published build (see
+ * examples/tsconfig.json).
+ */
+import { createKortix } from '../src/index';
+
+async function main() {
+  const backendUrl = process.env.KORTIX_API_URL ?? 'http://localhost:8008/v1';
+  const apiKey = process.env.KORTIX_API_KEY;
+  if (!apiKey) {
+    console.error('Set KORTIX_API_KEY to a kortix_pat_... token and re-run.');
+    process.exit(1);
+  }
+
+  const kortix = createKortix({
+    backendUrl,
+    getToken: async () => apiKey,
+  });
+
+  const projects = await kortix.projects.list();
+  console.log(`${projects.length} project(s) reachable with this token:\n`);
+  for (const p of projects) {
+    console.log(`  ${p.project_id}  ${p.name}`);
+  }
+
+  if (projects[0]) {
+    const detail = await kortix.project(projects[0].project_id).detail();
+    console.log(
+      `\nFirst project's detail: ${detail.config.agents.length} agent(s), ${detail.file_count} file(s)`,
+    );
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/sdk/examples/02-send-and-stream.ts
+++ b/packages/sdk/examples/02-send-and-stream.ts
@@ -1,0 +1,77 @@
+/**
+ * 02 — Send a prompt and watch it stream, framework-free.
+ *
+ * `session(pid, sid).ensureReady()` provisions/resumes the session's sandbox
+ * (long-polls until the runtime is up) and resolves its OpenCode session id.
+ * `.send()` does that for you internally, but calling `ensureReady()` first
+ * lets `.stream()` connect BEFORE the prompt goes out, so no early events are
+ * missed. `narrowChatEvent` reshapes the raw ~50-variant wire union down to
+ * the dozen events a chat UI actually cares about (message/part updates,
+ * status, questions, permissions) — the same narrowing `@kortix/sdk/react`'s
+ * `useOpenCodeEventStream` does internally.
+ *
+ * Run:
+ *   KORTIX_API_URL=http://localhost:8008/v1 KORTIX_API_KEY=kortix_pat_... \
+ *   KORTIX_PROJECT_ID=... KORTIX_SESSION_ID=... \
+ *     bun run examples/02-send-and-stream.ts "What files are in this repo?"
+ *
+ * As an npm consumer:
+ *   import { createKortix, narrowChatEvent } from '@kortix/sdk';
+ */
+import { createKortix, narrowChatEvent } from '../src/index';
+
+async function main() {
+  const backendUrl = process.env.KORTIX_API_URL ?? 'http://localhost:8008/v1';
+  const apiKey = process.env.KORTIX_API_KEY;
+  const projectId = process.env.KORTIX_PROJECT_ID;
+  const sessionId = process.env.KORTIX_SESSION_ID;
+  const prompt = process.argv[2] ?? 'Say hello in one sentence.';
+
+  if (!apiKey || !projectId || !sessionId) {
+    console.error('Set KORTIX_API_KEY, KORTIX_PROJECT_ID, and KORTIX_SESSION_ID and re-run.');
+    process.exit(1);
+  }
+
+  const kortix = createKortix({ backendUrl, getToken: async () => apiKey });
+  const session = kortix.session(projectId, sessionId);
+
+  // Resolve the runtime once so `.stream()` is connected before `.send()`
+  // fires — otherwise the first few events could arrive before we're
+  // listening.
+  await session.ensureReady();
+
+  const handle = await session.stream({
+    onEvent: (event) => {
+      const chatEvent = narrowChatEvent(event);
+      if (!chatEvent) return; // not chat-relevant (lsp/pty/worktree/...)
+      switch (chatEvent.type) {
+        case 'message.part.updated':
+          if (chatEvent.part.type === 'text') {
+            process.stdout.write((chatEvent.part as { text?: string }).text ?? '');
+          }
+          break;
+        case 'session.idle':
+          console.log('\n\n[session idle — turn complete]');
+          break;
+        case 'session.error':
+          console.error('\n[session error]', chatEvent.error);
+          break;
+        default:
+          break;
+      }
+    },
+    onGapRehydrate: (gapMs) => console.warn(`\n[reconnected after a ${gapMs}ms gap]`),
+  });
+
+  console.log(`> ${prompt}\n`);
+  await session.send(prompt);
+
+  // Give the stream a few seconds to flush the turn's events, then close.
+  await new Promise((resolve) => setTimeout(resolve, 15_000));
+  handle.close();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/sdk/examples/03-server-wrapper.ts
+++ b/packages/sdk/examples/03-server-wrapper.ts
@@ -1,0 +1,72 @@
+/**
+ * 03 — "Kortix as a Backend": a minimal multi-tenant server wrapper.
+ *
+ * The problem `@kortix/sdk/server` solves: `createKortix()`/`configureKortix()`
+ * store the platform config (crucially, the bearer token getter) in a single
+ * process-wide module-global. That's fine for a browser tab or a CLI, but a
+ * server handling CONCURRENT requests for different end users can't safely
+ * call `configureKortix()` once per request — two in-flight requests with
+ * different tokens race on the same global and the last write wins for both.
+ *
+ * `createScopedKortix(config)` fixes this with Node's `AsyncLocalStorage`:
+ * the config passed to one call is visible only inside that call's own async
+ * continuation, isolated from any other concurrent call in the same process.
+ * This is the exact pattern a real wrapper backend uses — mint (or look up) a
+ * per-end-user Kortix token, build a scoped client, use it for that request
+ * only.
+ *
+ * Run (Bun only — this subpath statically imports node:async_hooks):
+ *   KORTIX_API_URL=http://localhost:8008/v1 KORTIX_API_KEY=kortix_pat_... \
+ *     bun run examples/03-server-wrapper.ts
+ *   curl http://localhost:8787/projects -H 'x-end-user: alice'
+ *   curl http://localhost:8787/projects -H 'x-end-user: bob'   # different token, same process, no cross-talk
+ *
+ * As an npm consumer:
+ *   import { createScopedKortix } from '@kortix/sdk/server';
+ */
+import { createScopedKortix } from '../src/server';
+
+const backendUrl = process.env.KORTIX_API_URL ?? 'http://localhost:8008/v1';
+const upstreamApiKey = process.env.KORTIX_API_KEY;
+
+if (!upstreamApiKey) {
+  console.error('Set KORTIX_API_KEY (the wrapper backend\'s own upstream credential) and re-run.');
+  process.exit(1);
+}
+
+/**
+ * Stand-in for "look up this end user's own token/session" — a real wrapper
+ * would resolve a per-tenant Kortix PAT (or scope a shared one) from its own
+ * auth/session store, keyed off the incoming request, never a hardcoded env var.
+ */
+function tokenForEndUser(endUserId: string): string {
+  console.log(`resolving token for end user "${endUserId}"`);
+  // Every end user shares the same upstream credential in this toy example —
+  // a real wrapper would mint/store one PAT per tenant instead.
+  return upstreamApiKey!;
+}
+
+Bun.serve({
+  port: 8787,
+  async fetch(req) {
+    const url = new URL(req.url);
+    const endUserId = req.headers.get('x-end-user') ?? 'anonymous';
+
+    // One scoped client PER REQUEST — never a module-global `createKortix()`
+    // call reused across requests. This is what makes two concurrent
+    // requests for two different end users safe in the same process.
+    const kortix = createScopedKortix({
+      backendUrl,
+      getToken: async () => tokenForEndUser(endUserId),
+    });
+
+    if (url.pathname === '/projects' && req.method === 'GET') {
+      const projects = await kortix.projects.list();
+      return Response.json({ endUserId, projects });
+    }
+
+    return new Response('Not found', { status: 404 });
+  },
+});
+
+console.log('Kortix-as-a-Backend demo server listening on http://localhost:8787');

--- a/packages/sdk/examples/04-render-transcript.ts
+++ b/packages/sdk/examples/04-render-transcript.ts
@@ -1,0 +1,88 @@
+/**
+ * 04 — Render a session's transcript as plain text, no React.
+ *
+ * `classifyTurn` (`@kortix/sdk/turns`) is framework-free: it normalizes every
+ * opencode part type (text, reasoning, tool, file, subtask, patch, snapshot,
+ * agent, retry, compaction, step) into a `ClassifiedPart` with a
+ * compile-time-exhaustive `kind`, plus a normalized `TurnError` for a failed
+ * assistant turn. This is the exact same classification
+ * `apps/whitelabel-demo/src/components/chat/message-view.tsx` uses to render
+ * React — here we switch over `part.kind` and print plain text instead, to
+ * show the classification itself has no framework dependency.
+ *
+ * Run:
+ *   KORTIX_API_URL=http://localhost:8008/v1 KORTIX_API_KEY=kortix_pat_... \
+ *   KORTIX_PROJECT_ID=... KORTIX_SESSION_ID=... \
+ *     bun run examples/04-render-transcript.ts
+ *
+ * As an npm consumer:
+ *   import { createKortix } from '@kortix/sdk';
+ *   import { classifyTurn, type ClassifiedPart } from '@kortix/sdk/turns';
+ */
+import { createKortix } from '../src/index';
+import { classifyTurn, type ClassifiedPart } from '../src/turns/index';
+import type { MessageWithParts } from '../src/transcript';
+
+function renderPart(part: ClassifiedPart): string {
+  switch (part.kind) {
+    case 'text':
+      return part.text;
+    case 'reasoning':
+      return `  (thinking: ${part.text})`;
+    case 'tool':
+      return `  [tool: ${part.tool.name} — ${part.tool.status}]`;
+    case 'file':
+      return `  [attachment: ${part.filename ?? part.url}]`;
+    case 'subtask':
+      return `  [delegated to ${part.agent}${part.description ? `: ${part.description}` : ''}]`;
+    case 'patch':
+      return `  [${part.fileCount} file(s) changed]`;
+    case 'retry':
+      return `  [retry attempt ${part.attempt}: ${part.message}]`;
+    case 'compaction':
+      return `  [context compacted${part.auto ? ' (auto)' : ''}]`;
+    // snapshot/agent/step carry no chat-visible content of their own — same
+    // deliberate no-op as message-view.tsx's renderers for these kinds.
+    case 'snapshot':
+    case 'agent':
+    case 'step':
+      return '';
+    default:
+      return `  [unrecognized part kind]`;
+  }
+}
+
+async function main() {
+  const backendUrl = process.env.KORTIX_API_URL ?? 'http://localhost:8008/v1';
+  const apiKey = process.env.KORTIX_API_KEY;
+  const projectId = process.env.KORTIX_PROJECT_ID;
+  const sessionId = process.env.KORTIX_SESSION_ID;
+
+  if (!apiKey || !projectId || !sessionId) {
+    console.error('Set KORTIX_API_KEY, KORTIX_PROJECT_ID, and KORTIX_SESSION_ID and re-run.');
+    process.exit(1);
+  }
+
+  const kortix = createKortix({ backendUrl, getToken: async () => apiKey });
+  const session = kortix.session(projectId, sessionId);
+  const { opencodeSessionId } = await session.ensureReady();
+
+  const result = await session.runtime.session.messages({ sessionID: opencodeSessionId });
+  const messages = (result.data ?? []) as MessageWithParts[];
+
+  for (const message of messages) {
+    const { parts, error, isEmpty } = classifyTurn(message);
+    console.log(`\n## ${message.info.role}`);
+    if (isEmpty && !error) continue;
+    for (const part of parts) {
+      const rendered = renderPart(part);
+      if (rendered) console.log(rendered);
+    }
+    if (error) console.log(`  [error: ${error.name} — ${error.message}]`);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/sdk/examples/05-cost-passthrough.ts
+++ b/packages/sdk/examples/05-cost-passthrough.ts
@@ -1,0 +1,67 @@
+/**
+ * 05 — Cost pass-through: a marked-up usage table for re-billing.
+ *
+ * The shape a real "Kortix as a Backend" wrapper uses to charge its own
+ * users: pull per-session LLM + compute cost from the gateway
+ * (`project(id).gateway.sessions`) and the caller's own credit balance
+ * (`billing.creditBreakdown`), then apply a markup multiplier before showing
+ * it to the end user. This mirrors `apps/whitelabel-demo`'s `/usage` route
+ * (`src/app/api/usage/route.ts`), rewritten to go through the SDK facade
+ * instead of a raw upstream `fetch`.
+ *
+ * Run:
+ *   KORTIX_API_URL=http://localhost:8008/v1 KORTIX_API_KEY=kortix_pat_... \
+ *   KORTIX_PROJECT_ID=... COST_MARKUP=1.2 \
+ *     bun run examples/05-cost-passthrough.ts
+ *
+ * As an npm consumer:
+ *   import { createKortix } from '@kortix/sdk';
+ */
+import { createKortix } from '../src/index';
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+async function main() {
+  const backendUrl = process.env.KORTIX_API_URL ?? 'http://localhost:8008/v1';
+  const apiKey = process.env.KORTIX_API_KEY;
+  const projectId = process.env.KORTIX_PROJECT_ID;
+  const markup = Number(process.env.COST_MARKUP ?? 1.2);
+
+  if (!apiKey || !projectId) {
+    console.error('Set KORTIX_API_KEY and KORTIX_PROJECT_ID and re-run.');
+    process.exit(1);
+  }
+
+  const kortix = createKortix({ backendUrl, getToken: async () => apiKey });
+
+  const [sessions, credits] = await Promise.all([
+    kortix.project(projectId).gateway.sessions(30), // trailing 30 days
+    kortix.billing.creditBreakdown(),
+  ]);
+
+  console.log(`Caller's own Kortix credit balance: ${credits.total} (${credits.non_expiring} non-expiring)\n`);
+  console.log(`Per-session cost, last ${sessions.window_days} day(s), ${markup}x markup applied:\n`);
+  console.log('session_id                            raw_cost   billed_cost   requests');
+  console.log('-------------------------------------------------------------------------');
+
+  let rawTotal = 0;
+  let billedTotal = 0;
+  for (const s of sessions.sessions) {
+    const billed = round2(s.total_cost * markup);
+    rawTotal += s.total_cost;
+    billedTotal += billed;
+    console.log(
+      `${s.session_id.padEnd(38)} $${s.total_cost.toFixed(4).padStart(8)}   $${billed.toFixed(4).padStart(8)}   ${s.requests}`,
+    );
+  }
+
+  console.log('-------------------------------------------------------------------------');
+  console.log(`TOTAL${' '.repeat(33)} $${round2(rawTotal).toFixed(2).padStart(8)}   $${round2(billedTotal).toFixed(2).padStart(8)}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/sdk/examples/06-files-and-secrets.ts
+++ b/packages/sdk/examples/06-files-and-secrets.ts
@@ -1,0 +1,65 @@
+/**
+ * 06 — Workspace files (session-scoped) + project secrets.
+ *
+ * `session(pid, sid).files` is the same 12-op files surface as the top-level
+ * `files` export, but bound to THIS session's own resolved runtime instead of
+ * whichever sandbox happens to be globally "active" — the right choice for a
+ * server juggling multiple concurrent sessions (see `03-server-wrapper.ts`).
+ * `project(id).secrets.upsert` writes an env var a session's agent reads at
+ * runtime (e.g. an API key the agent should have, but the end user should
+ * never see again after write).
+ *
+ * Run:
+ *   KORTIX_API_URL=http://localhost:8008/v1 KORTIX_API_KEY=kortix_pat_... \
+ *   KORTIX_PROJECT_ID=... KORTIX_SESSION_ID=... \
+ *     bun run examples/06-files-and-secrets.ts
+ *
+ * As an npm consumer:
+ *   import { createKortix } from '@kortix/sdk';
+ */
+import { createKortix } from '../src/index';
+
+async function main() {
+  const backendUrl = process.env.KORTIX_API_URL ?? 'http://localhost:8008/v1';
+  const apiKey = process.env.KORTIX_API_KEY;
+  const projectId = process.env.KORTIX_PROJECT_ID;
+  const sessionId = process.env.KORTIX_SESSION_ID;
+
+  if (!apiKey || !projectId || !sessionId) {
+    console.error('Set KORTIX_API_KEY, KORTIX_PROJECT_ID, and KORTIX_SESSION_ID and re-run.');
+    process.exit(1);
+  }
+
+  const kortix = createKortix({ backendUrl, getToken: async () => apiKey });
+  const session = kortix.session(projectId, sessionId);
+
+  // Every `session.files.*` call auto-provisions the runtime via
+  // `ensureReady()` internally — no explicit `ensureReady()` call needed here.
+  const workspace = await session.files.list('/workspace');
+  console.log(`/workspace has ${workspace.length} entr(y/ies):`);
+  for (const entry of workspace.slice(0, 20)) {
+    console.log(`  ${entry.type === 'directory' ? 'd' : '-'} ${entry.name}`);
+  }
+
+  const firstFile = workspace.find((e) => e.type === 'file');
+  if (firstFile) {
+    const content = await session.files.read(`/workspace/${firstFile.name}`);
+    console.log(`\nFirst chars of ${firstFile.name} (${content.type}):\n${content.content.slice(0, 200)}`);
+  }
+
+  // Project secret — scoped to the project, available to every session's
+  // agent (not just this one) unless further restricted via `agentScope`.
+  await kortix.project(projectId).secrets.upsert({
+    name: 'EXAMPLE_API_KEY',
+    value: 'sk-example-do-not-use',
+  });
+  const secrets = await kortix.project(projectId).secrets.list();
+  console.log(
+    `\nProject now has ${secrets.items.length} secret(s): ${secrets.items.map((s) => s.name).join(', ')}`,
+  );
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/sdk/examples/bun-globals.d.ts
+++ b/packages/sdk/examples/bun-globals.d.ts
@@ -1,0 +1,18 @@
+/**
+ * Minimal ambient shim for the one `Bun` global 03-server-wrapper.ts needs
+ * (`Bun.serve`). Deliberately NOT a `@types/bun` devDependency on the package:
+ * `packages/sdk/tsconfig.json` doesn't restrict `compilerOptions.types`, so
+ * adding an ambient `@types/*` package here would also auto-leak into the
+ * package's own `tsc --noEmit` run (its globals overlap/redeclare DOM
+ * `fetch`/`Response`/`WebSocket`, which the SDK's own isomorphic code relies
+ * on meaning the browser/DOM shape). Picked up automatically by
+ * `examples/tsconfig.json`'s `"include": ["*.ts"]` (a `.d.ts` file matches that
+ * glob). A real Bun project should just depend on `@types/bun` directly
+ * instead of copying this.
+ */
+declare const Bun: {
+  serve(options: {
+    port?: number;
+    fetch: (req: Request) => Response | Promise<Response>;
+  }): { stop: () => void };
+};

--- a/packages/sdk/examples/tsconfig.json
+++ b/packages/sdk/examples/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  // Typechecks examples/*.ts standalone from the package build (`pnpm typecheck`
+  // runs this file too — see package.json's "typecheck" script). Examples import
+  // via relative `../src/...` paths (see each file's header comment) so this
+  // project needs no separate `@kortix/sdk` package resolution — it reads the
+  // exact same source `tsconfig.json` already typechecks for the package itself.
+  //
+  // Deliberately NOT part of tsconfig.build.json (dist/ must never contain
+  // compiled examples) and NOT reached by tsconfig.json's `include` (examples/
+  // sits beside src/, not under it).
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["*.ts"]
+}

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -29,6 +29,7 @@
   "types": "./src/index.ts",
   "exports": {
     ".": "./src/index.ts",
+    "./server": "./src/server.ts",
     "./react": "./src/react/index.ts",
     "./opencode-client": "./src/opencode/client.ts",
     "./config": "./src/platform/config.ts",
@@ -57,6 +58,7 @@
     "types": "./dist/index.d.ts",
     "exports": {
       ".": { "types": "./dist/index.d.ts", "import": "./dist/index.js" },
+      "./server": { "types": "./dist/server.d.ts", "import": "./dist/server.js" },
       "./react": { "types": "./dist/react/index.d.ts", "import": "./dist/react/index.js" },
       "./opencode-client": {
         "types": "./dist/opencode/client.d.ts",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kortix/sdk",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Official Kortix frontend TypeScript SDK — one typed client for the Kortix agent platform. Unifies project/session lifecycle and live agent streaming behind a single ergonomic Session handle, so web, mobile, and white-label apps never touch the raw HTTP API or OpenCode semantics.",
   "type": "module",
   "license": "Elastic-2.0",
@@ -127,7 +127,7 @@
   },
   "files": ["dist", "src", "README.md"],
   "scripts": {
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit && tsc --noEmit -p examples/tsconfig.json",
     "test": "bun test src",
     "build": "tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json --resolve-full-paths",
     "prepublishOnly": "tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json --resolve-full-paths"

--- a/packages/sdk/src/files/client.test.ts
+++ b/packages/sdk/src/files/client.test.ts
@@ -1,18 +1,26 @@
 import { test, expect, beforeEach, mock } from 'bun:test';
-import * as realServerStore from '../state/server-store';
 import * as realAuth from '../platform/auth';
+import { setCurrentRuntime } from '../state/current-runtime';
 
-// Capture daemon requests by overriding ONLY the two seams the file client uses
-// (spread the real module so every other importer's exports stay intact).
+// Capture daemon requests by overriding ONLY the auth seam the file client
+// uses (spread the real module so every other importer's exports stay
+// intact). The active-sandbox base URL ('http://sbx.test') is driven through
+// the REAL `state/current-runtime` seam (`setCurrentRuntime`, in `beforeEach`
+// below) rather than a `mock.module('../state/server-store', ...)` override —
+// this used to mock that whole module away, but `getActiveOpenCodeUrl` is
+// re-exported from `./server-store/active` (`export { getActiveOpenCodeUrl }
+// from './server-store/active'` in `server-store.ts`), and mocking either the
+// barrel or the submodule collides process-wide with ANY other file that
+// imports/tests `state/server-store/active` directly (e.g. a direct unit test
+// of that module's real fallback logic). Driving the real
+// `getActiveOpenCodeUrl()` via its own real dependency (current-runtime)
+// avoids the collision entirely — same observable 'http://sbx.test' default
+// for every test below, no mock needed.
 let calls: { url: string; method: string; body?: string }[] = [];
 // When set, the mocked `authenticatedFetch` responds with THIS status instead
 // of a 200 — lets individual tests exercise the daemon-failure path.
 let mockFailStatus: number | null = null;
 
-mock.module('../state/server-store', () => ({
-  ...realServerStore,
-  getActiveOpenCodeUrl: () => 'http://sbx.test',
-}));
 mock.module('../platform/auth', () => ({
   ...realAuth,
   getAuthToken: async () => 'tok',
@@ -34,6 +42,7 @@ const last = () => calls[calls.length - 1];
 beforeEach(() => {
   calls = [];
   mockFailStatus = null;
+  setCurrentRuntime('http://sbx.test', 'sbx-test');
 });
 
 test('list hits GET /file with worktree-relative path', async () => {

--- a/packages/sdk/src/files/client.test.ts
+++ b/packages/sdk/src/files/client.test.ts
@@ -5,6 +5,9 @@ import * as realAuth from '../platform/auth';
 // Capture daemon requests by overriding ONLY the two seams the file client uses
 // (spread the real module so every other importer's exports stay intact).
 let calls: { url: string; method: string; body?: string }[] = [];
+// When set, the mocked `authenticatedFetch` responds with THIS status instead
+// of a 200 — lets individual tests exercise the daemon-failure path.
+let mockFailStatus: number | null = null;
 
 mock.module('../state/server-store', () => ({
   ...realServerStore,
@@ -15,13 +18,23 @@ mock.module('../platform/auth', () => ({
   getAuthToken: async () => 'tok',
   authenticatedFetch: async (url: string, init: { method?: string; body?: unknown } = {}) => {
     calls.push({ url: String(url), method: init.method ?? 'GET', body: typeof init.body === 'string' ? init.body : undefined });
+    if (mockFailStatus !== null) {
+      return new Response(JSON.stringify({ error: 'daemon unavailable' }), {
+        status: mockFailStatus,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
     return new Response(JSON.stringify([]), { status: 200, headers: { 'content-type': 'application/json' } });
   },
 }));
 
 const F = await import('./client');
+const { ApiError } = await import('../platform/api/errors');
 const last = () => calls[calls.length - 1];
-beforeEach(() => { calls = []; });
+beforeEach(() => {
+  calls = [];
+  mockFailStatus = null;
+});
 
 test('list hits GET /file with worktree-relative path', async () => {
   await F.listFiles('/workspace/src');
@@ -112,4 +125,40 @@ test('files namespace exposes the full surface', () => {
   for (const k of ['list','read','readBlob','status','findFiles','findText','upload','create','copy','remove','mkdir','rename','currentProject','health','isReachable']) {
     expect(typeof (F.files as Record<string, unknown>)[k]).toBe('function');
   }
+});
+
+// ── typed errors (P0 fix: every op used to throw a bare `Error`; now every
+// HTTP failure throws `ApiError` with status/response attached) ─────────────
+
+test('findFiles throws ApiError on a daemon failure — no longer swallows to []', async () => {
+  mockFailStatus = 500;
+  await expect(F.findFiles('foo')).rejects.toBeInstanceOf(ApiError);
+  await expect(F.findFiles('foo')).rejects.toMatchObject({ status: 500 });
+});
+
+test('listFiles throws ApiError (with status) on a daemon failure', async () => {
+  mockFailStatus = 503;
+  await expect(F.listFiles('/workspace')).rejects.toBeInstanceOf(ApiError);
+  await expect(F.listFiles('/workspace')).rejects.toMatchObject({ status: 503 });
+});
+
+test('deleteFile/mkdir/renameFile throw ApiError (with status) on a daemon failure', async () => {
+  mockFailStatus = 404;
+  await expect(F.deleteFile('/workspace/x')).rejects.toBeInstanceOf(ApiError);
+  await expect(F.mkdir('/workspace/y')).rejects.toBeInstanceOf(ApiError);
+  await expect(F.renameFile('/workspace/a', '/workspace/b')).rejects.toBeInstanceOf(ApiError);
+});
+
+// ── explicit baseUrl param (internal plumbing for `kortix.session(pid, sid).files`)
+
+test('every op accepts an explicit trailing baseUrl, overriding the module-global active sandbox', async () => {
+  mockFailStatus = null;
+  await F.listFiles('/workspace/src', 'http://other-sandbox.test');
+  expect(last().url).toBe('http://other-sandbox.test/file?path=src');
+
+  await F.getFileStatus('http://other-sandbox.test');
+  expect(last().url).toBe('http://other-sandbox.test/file/status');
+
+  await F.findFiles('foo', undefined, 'http://other-sandbox.test');
+  expect(last().url).toContain('http://other-sandbox.test/find/file?query=foo');
 });

--- a/packages/sdk/src/files/client.ts
+++ b/packages/sdk/src/files/client.ts
@@ -10,6 +10,7 @@
 import { getClient } from '../opencode/client';
 import { getActiveOpenCodeUrl } from '../state/server-store/active';
 import { getAuthToken, authenticatedFetch } from '../platform/auth';
+import { ApiError } from '../platform/api/errors';
 import type {
   FileContent,
   FileNode,
@@ -26,13 +27,23 @@ export type * from './types';
 
 function unwrap<T>(result: { data?: T; error?: unknown }): T {
   if (result.error) {
-    const err = result.error as { data?: { message?: string }; message?: string; error?: unknown };
+    const err = result.error as {
+      data?: { message?: string };
+      message?: string;
+      error?: unknown;
+      response?: Response;
+      status?: number;
+    };
     const message =
       err?.data?.message ||
       err?.message ||
       (typeof err?.error === 'string' ? err.error : null) ||
       'SDK request failed';
-    throw new Error(message);
+    throw new ApiError(message, {
+      status: err?.response?.status ?? err?.status,
+      response: err?.response,
+      details: err,
+    });
   }
   return result.data as T;
 }
@@ -44,11 +55,17 @@ async function errorMessage(res: Response): Promise<string> {
   return parsed?.error || text || res.statusText || `HTTP ${res.status}`;
 }
 
-/** GET a daemon JSON endpoint (list/status/find), surfacing the server's error. */
-async function fetchDaemonJson<T>(relUrl: string): Promise<T> {
-  const baseUrl = getActiveOpenCodeUrl();
+/**
+ * GET a daemon JSON endpoint (list/status/find), surfacing the server's error.
+ * `baseUrl` defaults to the module-global "active" sandbox for back-compat —
+ * pass an explicit one (e.g. from `kortix.session(pid, sid).files`) to hit a
+ * SPECIFIC session's own runtime instead.
+ */
+async function fetchDaemonJson<T>(relUrl: string, baseUrl: string = getActiveOpenCodeUrl()): Promise<T> {
   const response = await authenticatedFetch(`${baseUrl}${relUrl}`);
-  if (!response.ok) throw new Error(await errorMessage(response));
+  if (!response.ok) {
+    throw new ApiError(await errorMessage(response), { status: response.status, response });
+  }
   return response.json() as Promise<T>;
 }
 
@@ -94,31 +111,41 @@ export function toDaemonPath(filePath: string): string {
 /** @deprecated Use {@link toDaemonPath} — non-workspace roots now pass through absolute. */
 export const toWorkspaceRelative = toDaemonPath;
 
-/** List files/directories at a path. Daemon `GET /file`. */
-export async function listFiles(dirPath: string): Promise<FileNode[]> {
+/**
+ * List files/directories at a path. Daemon `GET /file`. `baseUrl` defaults to
+ * the module-global "active" sandbox; pass one explicitly to target a
+ * specific session's runtime (see `kortix.session(pid, sid).files`).
+ */
+export async function listFiles(dirPath: string, baseUrl: string = getActiveOpenCodeUrl()): Promise<FileNode[]> {
   const daemonPath = toDaemonPath(dirPath) || '.';
-  const nodes = await fetchDaemonJson<FileNode[]>(`/file?path=${encodeURIComponent(daemonPath)}`);
+  const nodes = await fetchDaemonJson<FileNode[]>(`/file?path=${encodeURIComponent(daemonPath)}`, baseUrl);
   return nodes.map((node) => ({ ...node, path: node.absolute || `/workspace/${node.path}` }));
 }
 
 /** Read a file's content (text, or base64 for binaries). Daemon `GET /file/content`. */
-export async function readFile(filePath: string): Promise<FileContent> {
-  const baseUrl = getActiveOpenCodeUrl();
+export async function readFile(filePath: string, baseUrl: string = getActiveOpenCodeUrl()): Promise<FileContent> {
   const daemonPath = toDaemonPath(filePath);
   const response = await authenticatedFetch(`${baseUrl}/file/content?path=${encodeURIComponent(daemonPath)}`);
-  if (!response.ok) throw new Error(await errorMessage(response));
+  if (!response.ok) {
+    throw new ApiError(await errorMessage(response), { status: response.status, response });
+  }
   return response.json() as Promise<FileContent>;
 }
 
 /** Raw byte read. Daemon `GET /file/raw`. Throws (so callers can fall back). */
-async function readFileRaw(filePath: string, fallbackMime?: string): Promise<Blob> {
-  const baseUrl = getActiveOpenCodeUrl();
+async function readFileRaw(filePath: string, fallbackMime?: string, baseUrl: string = getActiveOpenCodeUrl()): Promise<Blob> {
   const daemonPath = toDaemonPath(filePath);
   const response = await authenticatedFetch(`${baseUrl}/file/raw?path=${encodeURIComponent(daemonPath)}`);
-  if (!response.ok) throw new Error(await errorMessage(response));
+  if (!response.ok) {
+    throw new ApiError(await errorMessage(response), { status: response.status, response });
+  }
   // A misrouted /file/raw can fall through to the web SPA shell (200, text/html).
   if ((response.headers.get('content-type') || '').includes('text/html')) {
-    throw new Error('File could not be loaded (raw byte route unavailable)');
+    throw new ApiError('File could not be loaded (raw byte route unavailable)', {
+      status: response.status,
+      response,
+      code: 'INVALID_CONTENT_TYPE',
+    });
   }
   const blob = await response.blob();
   if (fallbackMime && (!blob.type || blob.type === 'application/octet-stream')) {
@@ -128,11 +155,11 @@ async function readFileRaw(filePath: string, fallbackMime?: string): Promise<Blo
 }
 
 /** Read a file as a Blob — prefers `/file/raw`, falls back to base64 `/file/content`. */
-export async function readBlob(filePath: string): Promise<Blob> {
+export async function readBlob(filePath: string, baseUrl: string = getActiveOpenCodeUrl()): Promise<Blob> {
   try {
-    return await readFileRaw(filePath);
+    return await readFileRaw(filePath, undefined, baseUrl);
   } catch { /* fall back to JSON content endpoint */ }
-  const result = await readFile(filePath);
+  const result = await readFile(filePath, baseUrl);
   if (result.encoding === 'base64' && result.content) {
     const bytes = Uint8Array.from(atob(result.content), (c) => c.charCodeAt(0));
     return new Blob([bytes], { type: result.mimeType || 'application/octet-stream' });
@@ -141,28 +168,36 @@ export async function readBlob(filePath: string): Promise<Blob> {
 }
 
 /** Git file status — uncommitted changes. Daemon `GET /file/status`. */
-export function getFileStatus(): Promise<GitFileStatus[]> {
-  return fetchDaemonJson<GitFileStatus[]>(`/file/status`);
+export function getFileStatus(baseUrl: string = getActiveOpenCodeUrl()): Promise<GitFileStatus[]> {
+  return fetchDaemonJson<GitFileStatus[]>(`/file/status`, baseUrl);
 }
 
-/** Find files/directories by name (fuzzy). Daemon `GET /find/file`. */
+/**
+ * Find files/directories by name (fuzzy). Daemon `GET /find/file`.
+ *
+ * Throws `ApiError` on failure — like every other op in this module. This
+ * USED TO swallow every failure to `[]`, which silently hid daemon/network
+ * errors from callers. The only real caller of this SDK export
+ * (`apps/web/src/features/files/search/workspace-search-service.ts`) already
+ * wraps each call in its own `.catch(() => [])`, and there are no callers
+ * under `@kortix/sdk/react`, so removing the internal swallow here is
+ * non-breaking — verified by grepping every `findFiles(` call site in the
+ * monorepo before making this change.
+ */
 export async function findFiles(
   query: string,
   options?: { type?: 'file' | 'directory'; limit?: number },
+  baseUrl: string = getActiveOpenCodeUrl(),
 ): Promise<string[]> {
-  try {
-    const params = new URLSearchParams({ query });
-    if (options?.type) params.set('type', options.type);
-    if (options?.limit) params.set('limit', String(options.limit));
-    return await fetchDaemonJson<string[]>(`/find/file?${params.toString()}`);
-  } catch {
-    return [];
-  }
+  const params = new URLSearchParams({ query });
+  if (options?.type) params.set('type', options.type);
+  if (options?.limit) params.set('limit', String(options.limit));
+  return fetchDaemonJson<string[]>(`/find/file?${params.toString()}`, baseUrl);
 }
 
 /** Ripgrep text search. Daemon `GET /find`. Tolerates flat + nested rg-JSON. */
-export async function findText(pattern: string): Promise<FindMatch[]> {
-  const raw = await fetchDaemonJson<Array<Record<string, any>>>(`/find?pattern=${encodeURIComponent(pattern)}`);
+export async function findText(pattern: string, baseUrl: string = getActiveOpenCodeUrl()): Promise<FindMatch[]> {
+  const raw = await fetchDaemonJson<Array<Record<string, any>>>(`/find?pattern=${encodeURIComponent(pattern)}`, baseUrl);
   return raw.map((item) => ({
     path: typeof item.path === 'string' ? item.path : (item.path?.text ?? ''),
     lines: typeof item.lines === 'string' ? item.lines : (item.lines?.text ?? ''),
@@ -208,17 +243,26 @@ async function uploadWithRetry(
     }
     if (res.ok) return res.json();
     const message = await uploadErrorMessage(res);
-    lastError = new Error(`Upload failed (${res.status}): ${message}`);
+    lastError = new ApiError(`Upload failed (${res.status}): ${message}`, { status: res.status, response: res });
     if (!isTransient(res.status) || attempt === UPLOAD_RETRY_DELAYS_MS.length) throw lastError;
     await sleep(UPLOAD_RETRY_DELAYS_MS[attempt]);
   }
+  if (lastError instanceof ApiError) throw lastError;
   const message = lastError instanceof Error ? lastError.message : String(lastError || 'request failed');
-  throw new Error(`Upload failed: ${message}`);
+  throw new ApiError(`Upload failed: ${message}`);
 }
 
-/** Upload a file. Daemon `POST /file/upload`. */
-export function uploadFile(file: File | Blob, targetPath?: string, filename?: string): Promise<UploadResult[]> {
-  const baseUrl = getActiveOpenCodeUrl();
+/**
+ * Upload a file. Daemon `POST /file/upload`. `baseUrl` defaults to the
+ * module-global "active" sandbox; pass one explicitly to target a specific
+ * session's runtime.
+ */
+export function uploadFile(
+  file: File | Blob,
+  targetPath?: string,
+  filename?: string,
+  baseUrl: string = getActiveOpenCodeUrl(),
+): Promise<UploadResult[]> {
   return uploadWithRetry(
     () => {
       const form = new FormData();
@@ -233,8 +277,7 @@ export function uploadFile(file: File | Blob, targetPath?: string, filename?: st
 }
 
 /** Upload content to a specific path via the field-name-as-path convention. */
-function uploadToPath(filePath: string, content: Blob): Promise<UploadResult[]> {
-  const baseUrl = getActiveOpenCodeUrl();
+function uploadToPath(filePath: string, content: Blob, baseUrl: string = getActiveOpenCodeUrl()): Promise<UploadResult[]> {
   return uploadWithRetry(
     () => {
       const form = new FormData();
@@ -251,53 +294,56 @@ function uploadToPath(filePath: string, content: Blob): Promise<UploadResult[]> 
 }
 
 /** Create an empty file at a path. */
-export function createFile(filePath: string): Promise<UploadResult[]> {
+export function createFile(filePath: string, baseUrl: string = getActiveOpenCodeUrl()): Promise<UploadResult[]> {
   const rawPath = filePath.trim();
   const absolutePath = rawPath.startsWith('/') ? rawPath : `/${rawPath}`;
   const parts = absolutePath.split('/');
   const fileName = parts.pop() || 'untitled';
   const dirPath = parts.join('/') || '/workspace';
-  return uploadFile(new File([' '], fileName, { type: 'application/octet-stream' }), dirPath);
+  return uploadFile(new File([' '], fileName, { type: 'application/octet-stream' }), dirPath, undefined, baseUrl);
 }
 
 /** Copy a file (read source bytes → upload to dest). */
-export async function copyFile(sourcePath: string, destPath: string): Promise<UploadResult[]> {
-  return uploadToPath(destPath, await readBlob(sourcePath));
+export async function copyFile(sourcePath: string, destPath: string, baseUrl: string = getActiveOpenCodeUrl()): Promise<UploadResult[]> {
+  return uploadToPath(destPath, await readBlob(sourcePath, baseUrl), baseUrl);
 }
 
 /** Delete a file/dir (recursive). Daemon `DELETE /file`. */
-export async function deleteFile(filePath: string): Promise<boolean> {
-  const baseUrl = getActiveOpenCodeUrl();
+export async function deleteFile(filePath: string, baseUrl: string = getActiveOpenCodeUrl()): Promise<boolean> {
   const res = await authenticatedFetch(`${baseUrl}/file`, {
     method: 'DELETE',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ path: filePath }),
   });
-  if (!res.ok) throw new Error(`Delete failed (${res.status}): ${await errorMessage(res)}`);
+  if (!res.ok) {
+    throw new ApiError(`Delete failed (${res.status}): ${await errorMessage(res)}`, { status: res.status, response: res });
+  }
   return res.json();
 }
 
 /** Create a directory (recursive, idempotent). Daemon `POST /file/mkdir`. */
-export async function mkdir(dirPath: string): Promise<boolean> {
-  const baseUrl = getActiveOpenCodeUrl();
+export async function mkdir(dirPath: string, baseUrl: string = getActiveOpenCodeUrl()): Promise<boolean> {
   const res = await authenticatedFetch(`${baseUrl}/file/mkdir`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ path: dirPath }),
   });
-  if (!res.ok) throw new Error(`Mkdir failed (${res.status}): ${await errorMessage(res)}`);
+  if (!res.ok) {
+    throw new ApiError(`Mkdir failed (${res.status}): ${await errorMessage(res)}`, { status: res.status, response: res });
+  }
   return res.json();
 }
 
 /** Rename/move a file or directory. Daemon `POST /file/rename`. */
-export async function renameFile(from: string, to: string): Promise<boolean> {
-  const baseUrl = getActiveOpenCodeUrl();
+export async function renameFile(from: string, to: string, baseUrl: string = getActiveOpenCodeUrl()): Promise<boolean> {
   const res = await authenticatedFetch(`${baseUrl}/file/rename`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ from, to }),
   });
-  if (!res.ok) throw new Error(`Rename failed (${res.status}): ${await errorMessage(res)}`);
+  if (!res.ok) {
+    throw new ApiError(`Rename failed (${res.status}): ${await errorMessage(res)}`, { status: res.status, response: res });
+  }
   return res.json();
 }
 

--- a/packages/sdk/src/index.isomorphic.test.ts
+++ b/packages/sdk/src/index.isomorphic.test.ts
@@ -3,17 +3,43 @@ import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 
 /**
- * Isomorphic-core tripwire. The root `.` export is the SDK's framework-free
- * surface — mobile, CLI, and server hosts load it outside any React/Next
- * context. Two guards:
- *   1. Static: walk the root entry's full import graph; no module may import
- *      react/next/zustand/react-query (even type-only — a type import still
- *      forces the dependency on every consumer's typecheck) or carry a
- *      'use client' directive.
- *   2. Runtime: the entry imports in plain bun and `createKortix` constructs.
+ * Isomorphic-core tripwire, extended to cover every non-React subpath in
+ * `package.json`'s `exports` map, not just the root `.` barrel — each of
+ * those subpaths is a promise to SOME host (mobile, CLI, a Node backend, a
+ * browser store) about what it can safely pull in. Three tiers, each with
+ * its own rules (see `SUBPATH_TIERS` below):
+ *
+ *   1. Isomorphic core (root `.` + most subpaths): no react/next/zustand/
+ *      react-query imports (even type-only — a type import still forces the
+ *      dependency on every consumer's typecheck), no 'use client' directive,
+ *      no `node:`-prefixed imports (these must run in a browser, RN, or a
+ *      CLI with no Node-specific APIs guaranteed).
+ *   2. Node-allowed (`./server` only): same react/zustand/'use client' bans,
+ *      but `node:` imports ARE allowed — specifically `node:async_hooks`,
+ *      which `config-node.ts` needs for per-request config isolation. Not a
+ *      blanket allowance for arbitrary Node built-ins creeping in.
+ *   3. Browser-only stores (idb-sync-cache, server-store, sync-store,
+ *      sandbox-connection-store, opencode-pending-store): these are zustand
+ *      stores (zustand is fine here, it's framework-glue-light and works
+ *      outside React) meant to run in a browser — real `window`/
+ *      `sessionStorage`/`localStorage`/`indexedDB` globals are expected and
+ *      fine. They get ONLY the "no real `react` import" check (a truly
+ *      severed tripwire against sneaking `react`/`react-dom` in), not the
+ *      full isomorphic-core ruleset — 'use client' directives are expected
+ *      here and not worth asserting on; the rest of a full runtime check
+ *      already runs in this file's other tests.
+ *
+ * Every rule stays STATIC (walk the import graph — no bundler, no runtime
+ * import) so it's exhaustive over every reachable file, not just what a given
+ * test happens to exercise.
  */
 
 const FORBIDDEN_MODULES = ['react', 'react-dom', 'next', 'zustand', '@tanstack/react-query'];
+/** The browser-only tier only forbids the actual React family — zustand is
+ *  expected there (see the module doc above). */
+const REACT_ONLY = ['react', 'react-dom', 'next'];
+/** The one `node:` import the node-allowed tier may carry. */
+const ALLOWED_NODE_IMPORT = 'node:async_hooks';
 
 const SRC_ROOT = join(import.meta.dir);
 
@@ -30,7 +56,12 @@ function resolveRelative(fromFile: string, spec: string): string | null {
   return existsSync(base) ? base : null;
 }
 
-function collectRootGraph(): { files: string[]; externals: Map<string, string[]> } {
+/** Walks `entryFile`'s full relative-import graph (type-only imports
+ *  included — a `import type` still shows up in this regex, which is the
+ *  point: a type-only react import still forces the dependency on every
+ *  consumer's typecheck). Returns every reachable local file plus every
+ *  external (non-relative) specifier imported, and by whom. */
+function collectGraph(entryFile: string): { files: string[]; externals: Map<string, string[]> } {
   const seen = new Set<string>();
   const externals = new Map<string, string[]>();
   const importRe =
@@ -55,8 +86,12 @@ function collectRootGraph(): { files: string[]; externals: Map<string, string[]>
     }
   }
 
-  walk(join(SRC_ROOT, 'index.ts'));
+  walk(entryFile);
   return { files: [...seen], externals };
+}
+
+function collectRootGraph() {
+  return collectGraph(join(SRC_ROOT, 'index.ts'));
 }
 
 test('root export graph pulls no react/next/zustand/react-query code', () => {
@@ -92,3 +127,106 @@ test('root entry loads and createKortix constructs outside React', async () => {
   // ensureReady()/start()/send(). See kortix.test.ts for the resolved-runtime cases.
   expect(() => session.previewUrl(3000)).toThrow(/Session runtime not ready/);
 });
+
+// ============================================================================
+// Every OTHER non-React subpath in package.json's `exports` map — tiered.
+// ============================================================================
+
+type Tier = 'isomorphic-core' | 'node-allowed' | 'browser-only';
+
+interface Subpath {
+  name: string;
+  file: string;
+  tier: Tier;
+}
+
+const SUBPATH_TIERS: Subpath[] = [
+  { name: './server', file: 'server.ts', tier: 'node-allowed' },
+  { name: './opencode-client', file: 'opencode/client.ts', tier: 'isomorphic-core' },
+  { name: './config', file: 'platform/config.ts', tier: 'isomorphic-core' },
+  { name: './auth', file: 'platform/auth.ts', tier: 'isomorphic-core' },
+  { name: './api-client', file: 'platform/api-client.ts', tier: 'isomorphic-core' },
+  { name: './projects-client', file: 'platform/projects-client/index.ts', tier: 'isomorphic-core' },
+  { name: './feature-flags', file: 'platform/feature-flags.ts', tier: 'isomorphic-core' },
+  { name: './fresh-sessions', file: 'platform/fresh-sessions.ts', tier: 'isomorphic-core' },
+  { name: './instance-routes', file: 'platform/instance-routes.ts', tier: 'isomorphic-core' },
+  { name: './opencode-errors', file: 'platform/opencode-errors.ts', tier: 'isomorphic-core' },
+  { name: './idb-sync-cache', file: 'state/idb-sync-cache.ts', tier: 'browser-only' },
+  { name: './platform-client', file: 'platform/platform-client/index.ts', tier: 'isomorphic-core' },
+  { name: './server-store', file: 'state/server-store.ts', tier: 'browser-only' },
+  { name: './sync-store', file: 'state/sync-store.ts', tier: 'browser-only' },
+  { name: './event-stream', file: 'state/event-stream.ts', tier: 'isomorphic-core' },
+  { name: './sandbox-connection-store', file: 'state/sandbox-connection-store.ts', tier: 'browser-only' },
+  { name: './opencode-pending-store', file: 'state/opencode-pending-store.ts', tier: 'browser-only' },
+  { name: './files', file: 'files/client.ts', tier: 'isomorphic-core' },
+  { name: './session', file: 'session/index.ts', tier: 'isomorphic-core' },
+  { name: './session/url', file: 'session/url.ts', tier: 'isomorphic-core' },
+  { name: './turns', file: 'turns/index.ts', tier: 'isomorphic-core' },
+];
+
+test('SUBPATH_TIERS matches package.json exports (minus "." and "./react")', () => {
+  const pkg = JSON.parse(readFileSync(join(SRC_ROOT, '..', 'package.json'), 'utf8')) as {
+    exports: Record<string, string>;
+  };
+  const exportedSubpaths = Object.keys(pkg.exports).filter((k) => k !== '.' && k !== './react');
+  expect(new Set(SUBPATH_TIERS.map((s) => s.name))).toEqual(new Set(exportedSubpaths));
+
+  // And every entry file must match what package.json actually points at.
+  for (const subpath of SUBPATH_TIERS) {
+    const expected = `./src/${subpath.file}`;
+    expect(pkg.exports[subpath.name]).toBe(expected);
+  }
+});
+
+for (const subpath of SUBPATH_TIERS) {
+  const entryFile = join(SRC_ROOT, subpath.file);
+
+  test(`${subpath.name} (${subpath.tier}): no forbidden framework imports`, () => {
+    const { externals } = collectGraph(entryFile);
+    const forbiddenList = subpath.tier === 'browser-only' ? REACT_ONLY : FORBIDDEN_MODULES;
+    for (const [spec, importers] of externals) {
+      const forbidden = forbiddenList.find((m) => spec === m || spec.startsWith(`${m}/`));
+      expect(forbidden ? `"${spec}" imported by ${importers.join(', ')} (subpath ${subpath.name})` : null).toBeNull();
+    }
+  });
+
+  if (subpath.tier !== 'browser-only') {
+    test(`${subpath.name} (${subpath.tier}): no 'use client' directives`, () => {
+      const { files } = collectGraph(entryFile);
+      for (const file of files) {
+        const head = readFileSync(file, 'utf8').trimStart();
+        const hasDirective = head.startsWith(`'use client'`) || head.startsWith(`"use client"`);
+        expect(
+          hasDirective ? `'use client' in ${file.slice(SRC_ROOT.length + 1)} (subpath ${subpath.name})` : null,
+        ).toBeNull();
+      }
+    });
+  }
+
+  if (subpath.tier === 'isomorphic-core') {
+    test(`${subpath.name} (isomorphic-core): no node:-prefixed imports`, () => {
+      const { externals } = collectGraph(entryFile);
+      for (const [spec, importers] of externals) {
+        expect(
+          spec.startsWith('node:')
+            ? `"${spec}" imported by ${importers.join(', ')} (subpath ${subpath.name})`
+            : null,
+        ).toBeNull();
+      }
+    });
+  }
+
+  if (subpath.tier === 'node-allowed') {
+    test(`${subpath.name} (node-allowed): only ${ALLOWED_NODE_IMPORT} among node:-prefixed imports`, () => {
+      const { externals } = collectGraph(entryFile);
+      for (const [spec, importers] of externals) {
+        if (!spec.startsWith('node:')) continue;
+        expect(
+          spec !== ALLOWED_NODE_IMPORT
+            ? `unexpected node import "${spec}" imported by ${importers.join(', ')} (subpath ${subpath.name})`
+            : null,
+        ).toBeNull();
+      }
+    });
+  }
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -92,3 +92,24 @@ export {
   type OpenCodeEvent,
   type OpenEventStreamOptions,
 } from './state/event-stream';
+
+/**
+ * Typed error classes for the REST surface — isomorphic (no DOM/React deps),
+ * so a server-side "Kortix as a Backend" wrapper can `catch` a call into
+ * `backendApi`/`createKortix(...)`, `instanceof BillingError` a 402 and pass
+ * the cost/upgrade payload straight through to its own client, or
+ * `instanceof ApiError` to branch on `.status`/`.code`. Same classes the
+ * React host uses (`@kortix/sdk/react` re-exports from this same module) —
+ * one error hierarchy across every host.
+ */
+export {
+  ApiError,
+  AuthError,
+  BillingError,
+  RequestTooLargeError,
+  parseBillingError,
+  isBillingError,
+  formatBillingErrorForUI,
+  type ApiErrorFields,
+  type BillingErrorUI,
+} from './platform/api/errors';

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -284,3 +284,9 @@ export type {
   AccountIdentity,
   ValidateTokenResult,
 } from './platform/projects-client';
+
+/**
+ * Linear-time trailing-slash strip shared with hosts — see
+ * `platform/strings.ts` for why this replaces the regex idiom.
+ */
+export { stripTrailingSlashes } from './platform/strings';

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -181,3 +181,106 @@ export {
   type KortixChatQuestionOption,
   type KortixChatToolRef,
 } from './state/chat-events';
+
+/**
+ * Domain result types from the REST facade (`kortix.project(id).*` /
+ * `kortix.session(...)` / `kortix.accounts.*` / `kortix.billing.*`), re-exported
+ * type-only so a consumer can name what a facade call returns without a
+ * second import from `@kortix/sdk/projects-client`. Additive — no runtime
+ * cost, and every name here already lives in `./platform/projects-client`
+ * (this is a convenience re-export, not a new surface).
+ */
+export type {
+  // Projects
+  KortixProject,
+  ProjectConfigSummary,
+  ProjectDetail,
+  ProjectLlmCatalogResponse,
+  // Accounts / IAM
+  KortixAccount,
+  AccountDetail,
+  AccountMember,
+  AccountRole,
+  ProjectRole,
+  ProjectAccessMember,
+  ProjectAccessRequest,
+  ProjectGroupGrant,
+  ProjectResourceGrant,
+  PendingProjectInvite,
+  PendingApproval,
+  // Secrets / connectors
+  ProjectSecret,
+  ProjectGitConnection,
+  ConnectorSharing,
+  AdminConnector,
+  ConnectorConfig,
+  // Sessions
+  ProjectSession,
+  ProjectOpenCodeSession,
+  SessionPublicShare,
+  SessionAudit,
+  SessionTranscript,
+  SessionTranscriptMessage,
+  // Change requests / git
+  ChangeRequest,
+  ChangeRequestDiffResponse,
+  ChangeRequestMergePreview,
+  ProjectCommit,
+  ProjectCommitDetail,
+  ProjectCommitFile,
+  ProjectBranch,
+  // Triggers
+  ProjectTrigger,
+  ProjectTriggerListing,
+  // Sandbox
+  SandboxTemplate,
+  ProjectSandboxHealth,
+  ProjectSnapshotBuild,
+  // Gateway (LLM observability / budgets)
+  GatewayLogRow,
+  GatewayLogDetail,
+  GatewayOverview,
+  GatewayBudgetRow,
+  GatewayKeyRow,
+  // Tokens (CLI PATs)
+  AccountToken,
+  CreatedAccountToken,
+  ProjectCliToken,
+  CreatedProjectCliToken,
+  // Billing
+  AccountState,
+  BillingTransaction,
+  BillingTransactionsPage,
+  BillingTransactionsSummary,
+  BillingCreditBreakdown,
+  BillingTierConfiguration,
+  // Marketplace / registry
+  MarketplaceInstalledItem,
+  MarketplaceInstallResult,
+  MarketplaceUpdateStatusEntry,
+  MarketplaceUpdatesResponse,
+  // Account audit
+  AuditEvent,
+  AuditEventList,
+  AuditWebhook,
+  // Setup links (secret-entry / connect-request)
+  SecretRequestLink,
+  ConnectorRequestLink,
+  // Manifest validate / git token
+  ManifestValidationResult,
+  ProjectGitToken,
+  // Gateway playground
+  GatewayPlaygroundResponse,
+  // Billing mutations
+  CheckoutSessionResult,
+  PortalSessionResult,
+  AutoTopupSettings,
+  // Public marketplace catalog (top-level `kortix.marketplace.*`)
+  MarketplaceCatalogItem,
+  MarketplaceItemsResponse,
+  MarketplaceEntry,
+  MarketplaceSource,
+  // Auth validate helper
+  AccountIdentity,
+  ValidateTokenResult,
+} from './platform/projects-client';

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -113,3 +113,71 @@ export {
   type ApiErrorFields,
   type BillingErrorUI,
 } from './platform/api/errors';
+
+/**
+ * Exhaustive part/turn classification for building chat UIs — framework-free.
+ * `classifyPart` normalizes every opencode `Part` variant (text, reasoning,
+ * tool, file, subtask, patch, snapshot, agent, retry, compaction, step) into
+ * a `ClassifiedPart`, with a compile-time exhaustiveness check plus a runtime
+ * 'unknown' fallback for forward-compat. `classifyTurn` classifies every part
+ * of a message and normalizes its `info.error` into a `TurnError`, so a host
+ * doesn't have to special-case "assistant message with zero parts but a
+ * failure" as silent nothingness. `toolInfo` is a zero-icon tool-name ->
+ * {label, category} registry a host maps to its own icon set. Also available
+ * from `@kortix/sdk/turns`.
+ */
+export {
+  type ClassifiedAgentPart,
+  type ClassifiedCompactionPart,
+  type ClassifiedFilePart,
+  type ClassifiedPart,
+  type ClassifiedPatchPart,
+  type ClassifiedReasoningPart,
+  type ClassifiedRetryPart,
+  type ClassifiedSnapshotPart,
+  type ClassifiedStepPart,
+  type ClassifiedSubtaskPart,
+  type ClassifiedTextPart,
+  type ClassifiedToolPart,
+  type ClassifiedTurn,
+  type ClassifiedUnknownPart,
+  type ToolCategory,
+  type ToolInfoEntry,
+  type ToolStatus,
+  type ToolView,
+  type TurnError,
+  classifyPart,
+  classifyTurn,
+  humanizeToolName,
+  toolInfo,
+} from './turns/index';
+
+/**
+ * The curated chat-event union — narrows the full `OpenCodeEvent` wire union
+ * down to the ~12 events a product chat UI needs (message/part updates,
+ * session status/idle/error, question asked/answered, permission
+ * asked/replied, todo updated, connection, heartbeat-gap), reshaped into
+ * purpose-built payloads. Also available from `@kortix/sdk/event-stream`.
+ */
+export {
+  heartbeatGapEvent,
+  narrowChatEvent,
+  type KortixChatEvent,
+  type KortixChatEventConnection,
+  type KortixChatEventHeartbeatGap,
+  type KortixChatEventMessageRemoved,
+  type KortixChatEventMessageUpdated,
+  type KortixChatEventPartRemoved,
+  type KortixChatEventPartUpdated,
+  type KortixChatEventPermissionAsked,
+  type KortixChatEventPermissionReplied,
+  type KortixChatEventQuestionAnswered,
+  type KortixChatEventQuestionAsked,
+  type KortixChatEventSessionError,
+  type KortixChatEventSessionIdle,
+  type KortixChatEventSessionStatus,
+  type KortixChatEventTodoUpdated,
+  type KortixChatQuestionInfo,
+  type KortixChatQuestionOption,
+  type KortixChatToolRef,
+} from './state/chat-events';

--- a/packages/sdk/src/kortix.test.ts
+++ b/packages/sdk/src/kortix.test.ts
@@ -336,6 +336,282 @@ test('kortix.transcribe hits the top-level /transcription endpoint (not project-
   expect(last().method).toBe('POST');
 });
 
+// ── wave 5: token minting, billing read surface, marketplace/registry
+// install, session transcript, CR request-changes, account audit — closing
+// the gaps a coverage audit found against the ~499 API routes ──────────────
+
+test('kortix.accounts.tokens covers list/create/revoke (account-scoped CLI PATs)', async () => {
+  await kortix.accounts.tokens.list('ACC1');
+  expect(last().url).toContain('/accounts/tokens?account_id=ACC1');
+  expect(last().method).toBe('GET');
+
+  await kortix.accounts.tokens.create({ name: 'ci-key', accountId: 'ACC1', projectId: 'PID1' });
+  expect(last().url).toContain('/accounts/tokens');
+  expect(last().method).toBe('POST');
+
+  await kortix.accounts.tokens.revoke('TOK1', 'ACC1');
+  expect(last().url).toContain('/accounts/tokens/TOK1?account_id=ACC1');
+  expect(last().method).toBe('DELETE');
+});
+
+test('project(id).tokens covers list/create/revoke (project-scoped CLI PATs)', async () => {
+  await kortix.project('PID123').tokens.list();
+  expect(last().url).toContain('/projects/PID123/cli-token');
+  expect(last().method).toBe('GET');
+
+  await kortix.project('PID123').tokens.create({ name: 'agent-token' });
+  expect(last().url).toContain('/projects/PID123/cli-token');
+  expect(last().method).toBe('POST');
+
+  await kortix.project('PID123').tokens.revoke('TOK1');
+  expect(last().url).toContain('/projects/PID123/cli-token/TOK1');
+  expect(last().method).toBe('DELETE');
+});
+
+test('kortix.billing covers the read surface (account-state, transactions, credits, tiers)', async () => {
+  await kortix.billing.accountState();
+  expect(last().url).toContain('/billing/account-state');
+
+  await kortix.billing.accountStateMinimal();
+  expect(last().url).toContain('/billing/account-state/minimal');
+
+  await kortix.billing.transactions({ accountId: 'ACC1', limit: 10 });
+  expect(last().url).toContain('/billing/transactions?account_id=ACC1&limit=10');
+
+  await kortix.billing.transactionsSummary({ days: 7 });
+  expect(last().url).toContain('/billing/transactions/summary?days=7');
+
+  await kortix.billing.creditBreakdown();
+  expect(last().url).toContain('/billing/credit-breakdown');
+
+  await kortix.billing.usageHistory(14);
+  expect(last().url).toContain('/billing/usage-history?days=14');
+
+  await kortix.billing.tierConfigurations();
+  expect(last().url).toContain('/billing/tier-configurations');
+});
+
+test('project(id).marketplace covers list/install/updates/update/updateAll/remove', async () => {
+  await kortix.project('PID123').marketplace.list();
+  expect(last().url).toContain('/projects/PID123/marketplace');
+  expect(last().method).toBe('GET');
+
+  await kortix.project('PID123').marketplace.install('kortix:researcher');
+  expect(last().url).toContain('/projects/PID123/marketplace/install');
+  expect(last().method).toBe('POST');
+
+  await kortix.project('PID123').marketplace.updates();
+  expect(last().url).toContain('/projects/PID123/marketplace/updates');
+
+  await kortix.project('PID123').marketplace.update('researcher');
+  expect(last().url).toContain('/projects/PID123/marketplace/update');
+  expect(last().method).toBe('POST');
+
+  await kortix.project('PID123').marketplace.updateAll();
+  expect(last().url).toContain('/projects/PID123/marketplace/update-all');
+
+  await kortix.project('PID123').marketplace.remove('researcher');
+  expect(last().url).toContain('/projects/PID123/marketplace/researcher');
+  expect(last().method).toBe('DELETE');
+});
+
+test('project(id).registry is the compatibility alias of marketplace (same paths, /registry prefix)', async () => {
+  await kortix.project('PID123').registry.list();
+  expect(last().url).toContain('/projects/PID123/registry');
+
+  await kortix.project('PID123').registry.install('kortix:researcher');
+  expect(last().url).toContain('/projects/PID123/registry/install');
+  expect(last().method).toBe('POST');
+
+  await kortix.project('PID123').registry.updates();
+  expect(last().url).toContain('/projects/PID123/registry/updates');
+
+  await kortix.project('PID123').registry.update('researcher');
+  expect(last().url).toContain('/projects/PID123/registry/update');
+
+  await kortix.project('PID123').registry.updateAll();
+  expect(last().url).toContain('/projects/PID123/registry/update-all');
+
+  await kortix.project('PID123').registry.remove('researcher');
+  expect(last().url).toContain('/projects/PID123/registry/researcher');
+  expect(last().method).toBe('DELETE');
+});
+
+test('session(...).transcript hits the compact transcript endpoint with limit/chars', async () => {
+  await kortix.session('PID123', 'SID456').transcript({ limit: 10, chars: 200 });
+  expect(last().url).toContain('/projects/PID123/sessions/SID456/transcript?limit=10&chars=200');
+  expect(last().method).toBe('GET');
+});
+
+test('project(id).changeRequests.requestChanges hits the request-changes endpoint', async () => {
+  await kortix.project('PID123').changeRequests.requestChanges('CR1', 'please fix the tests');
+  expect(last().url).toContain('/projects/PID123/change-requests/CR1/request-changes');
+  expect(last().method).toBe('POST');
+});
+
+test('kortix.accounts.audit covers log/export/webhooks CRUD', async () => {
+  await kortix.accounts.audit.log('ACC1', { action: 'iam.', limit: 20 });
+  expect(last().url).toContain('/accounts/ACC1/audit?action=iam.&limit=20');
+  expect(last().method).toBe('GET');
+
+  await kortix.accounts.audit.export('ACC1', { format: 'csv' });
+  expect(last().url).toContain('/accounts/ACC1/audit/export?format=csv');
+
+  await kortix.accounts.audit.webhooks.list('ACC1');
+  expect(last().url).toContain('/accounts/ACC1/audit/webhooks');
+  expect(last().method).toBe('GET');
+
+  await kortix.accounts.audit.webhooks.create('ACC1', { name: 'siem', url: 'https://siem.example.com/hook' });
+  expect(last().url).toContain('/accounts/ACC1/audit/webhooks');
+  expect(last().method).toBe('POST');
+
+  await kortix.accounts.audit.webhooks.update('ACC1', 'WH1', { enabled: false });
+  expect(last().url).toContain('/accounts/ACC1/audit/webhooks/WH1');
+  expect(last().method).toBe('PATCH');
+
+  await kortix.accounts.audit.webhooks.remove('ACC1', 'WH1');
+  expect(last().url).toContain('/accounts/ACC1/audit/webhooks/WH1');
+  expect(last().method).toBe('DELETE');
+});
+
+// ── setup links / manifest validate / git token / slack files / meet speak /
+// gateway playground / billing mutations / public marketplace / validateToken
+// — closing the LAST projects-client coverage gaps ─────────────────────────
+
+test('project(id).setupLinks mints secret-entry and connect-request links', async () => {
+  await kortix.project('PID123').setupLinks.requestSecret({ names: ['STRIPE_KEY'] });
+  expect(last().url).toContain('/projects/PID123/secret-requests');
+  expect(last().method).toBe('POST');
+
+  await kortix.project('PID123').setupLinks.requestConnector({ slug: 'github' });
+  expect(last().url).toContain('/projects/PID123/connect-requests');
+  expect(last().method).toBe('POST');
+});
+
+test('project(id).validateManifest posts the raw TOML text', async () => {
+  await kortix.project('PID123').validateManifest('[project]\nname = "x"');
+  expect(last().url).toContain('/projects/PID123/manifest/validate');
+  expect(last().method).toBe('POST');
+});
+
+test('project(id).gitToken mints a scoped push token', async () => {
+  await kortix.project('PID123').gitToken();
+  expect(last().url).toContain('/projects/PID123/git-token');
+  expect(last().method).toBe('POST');
+});
+
+test('project(id).channels.slack covers file download + upload proxies', async () => {
+  await kortix.project('PID123').channels.slack.getFile('https://files.slack.com/x');
+  expect(last().url).toContain('/projects/PID123/channels/slack/file?url=');
+  expect(last().method).toBe('GET');
+
+  await kortix.project('PID123').channels.slack.uploadFile({
+    channel: 'C1',
+    filename: 'report.pdf',
+    contentBase64: 'YWJj',
+  });
+  expect(last().url).toContain('/projects/PID123/channels/slack/file/upload');
+  expect(last().method).toBe('POST');
+});
+
+test('project(id).channels.meet.speak posts bot id + text', async () => {
+  await kortix.project('PID123').channels.meet.speak('bot-1', 'hello there');
+  expect(last().url).toContain('/projects/PID123/channels/meet/speak');
+  expect(last().method).toBe('POST');
+});
+
+test('project(id).gateway.playground posts prompt + models', async () => {
+  await kortix.project('PID123').gateway.playground('Say hi', ['gpt-4o', 'claude-3']);
+  expect(last().url).toContain('/projects/PID123/gateway/playground');
+  expect(last().method).toBe('POST');
+});
+
+test('kortix.billing.checkout covers create + confirm session', async () => {
+  await kortix.billing.checkout.createSession({
+    tierKey: 'pro',
+    successUrl: 'https://app.example.com/success',
+    cancelUrl: 'https://app.example.com/cancel',
+  });
+  expect(last().url).toContain('/billing/create-checkout-session');
+  expect(last().method).toBe('POST');
+
+  await kortix.billing.checkout.confirmSession('cs_123');
+  expect(last().url).toContain('/billing/confirm-checkout-session');
+  expect(last().method).toBe('POST');
+});
+
+test('kortix.billing.subscription covers portal/cancel/reactivate/downgrade/proration', async () => {
+  await kortix.billing.subscription.createPortalSession('https://app.example.com/billing');
+  expect(last().url).toContain('/billing/create-portal-session');
+  expect(last().method).toBe('POST');
+
+  await kortix.billing.subscription.cancel('too expensive');
+  expect(last().url).toContain('/billing/cancel-subscription');
+
+  await kortix.billing.subscription.reactivate();
+  expect(last().url).toContain('/billing/reactivate-subscription');
+
+  await kortix.billing.subscription.scheduleDowngrade('starter');
+  expect(last().url).toContain('/billing/schedule-downgrade');
+
+  await kortix.billing.subscription.cancelScheduledChange();
+  expect(last().url).toContain('/billing/cancel-scheduled-change');
+
+  await kortix.billing.subscription.prorationPreview('price_123');
+  expect(last().url).toContain('/billing/proration-preview?new_price_id=price_123');
+  expect(last().method).toBe('GET');
+});
+
+test('kortix.billing.credits covers purchase + auto-topup get/configure', async () => {
+  await kortix.billing.credits.purchase({ amount: 20 });
+  expect(last().url).toContain('/billing/purchase-credits');
+  expect(last().method).toBe('POST');
+
+  await kortix.billing.credits.autoTopupSettings();
+  expect(last().url).toContain('/billing/auto-topup/settings');
+  expect(last().method).toBe('GET');
+
+  await kortix.billing.credits.configureAutoTopup({ enabled: true, threshold: 5, amount: 20 });
+  expect(last().url).toContain('/billing/auto-topup/configure');
+  expect(last().method).toBe('POST');
+});
+
+test('kortix.marketplace covers public catalog browse + authed sources CRUD (top-level, not project-scoped)', async () => {
+  await kortix.marketplace.items({ query: 'slack' });
+  expect(last().url).toContain('/marketplace/items?query=slack');
+  expect(last().method).toBe('GET');
+
+  await kortix.marketplace.item('kortix:researcher');
+  expect(last().url).toContain('/marketplace/items/kortix%3Aresearcher');
+
+  await kortix.marketplace.itemFile('kortix:researcher', 'agent.md');
+  expect(last().url).toContain('/marketplace/items/kortix%3Aresearcher/file?path=agent.md');
+
+  await kortix.marketplace.marketplaces();
+  expect(last().url).toContain('/marketplace/marketplaces');
+
+  await kortix.marketplace.featured();
+  expect(last().url).toContain('/marketplace/marketplaces/featured');
+
+  await kortix.marketplace.sources.list();
+  expect(last().url).toContain('/marketplace/sources');
+  expect(last().method).toBe('GET');
+
+  await kortix.marketplace.sources.add({ address: 'https://github.com/acme/registry' });
+  expect(last().url).toContain('/marketplace/sources');
+  expect(last().method).toBe('POST');
+
+  await kortix.marketplace.sources.remove('SRC1');
+  expect(last().url).toContain('/marketplace/sources/SRC1');
+  expect(last().method).toBe('DELETE');
+});
+
+test('kortix.validateToken hits /accounts/me and never throws', async () => {
+  const result = await kortix.validateToken();
+  expect(last().url).toContain('/accounts/me');
+  expect(result.valid).toBe(true);
+});
+
 // ── per-handle runtime isolation (regression: two session handles used to
 // share the module-global "active runtime", so the second handle's
 // ensureReady() silently redirected the first handle's send/health/preview

--- a/packages/sdk/src/kortix.test.ts
+++ b/packages/sdk/src/kortix.test.ts
@@ -1,6 +1,8 @@
 import { test, expect, beforeEach, mock } from 'bun:test';
 import { createKortix, SessionNotReadyError } from './kortix';
 import { isConfigured } from './platform/config';
+import { listFiles as globalListFiles } from './files/client';
+import { ApiError } from './platform/api/errors';
 
 // Capture every outbound request the facade makes.
 let calls: { url: string; method: string }[] = [];
@@ -508,4 +510,158 @@ test('restart clears the registry entry so a subsequent send re-resolves the run
   const promptCall = calls.find((c) => c.url.includes('/message'));
   expect(promptCall?.url).toContain('/p/sb-reg2-new/8000');
   expect(startCount).toBe(2);
+});
+
+// ── ensureReady() in-flight dedup (P0 robustness fix: two concurrent
+// ensureReady() calls for the SAME (projectId, sessionId) used to both drive
+// their own `/start` long-poll — a real hazard for a "Kortix as a Backend"
+// server handling concurrent requests against one session) ─────────────────
+
+test('ensureReady() dedupes concurrent starts for the same session: only one /start POST fires, both callers resolve', async () => {
+  let startCalls = 0;
+  let releaseStart!: (res: Response) => void;
+  const deferredStart = new Promise<Response>((resolve) => {
+    releaseStart = resolve;
+  });
+
+  globalThis.fetch = mock(async (input: unknown) => {
+    const url = requestUrl(input);
+    calls.push({ url, method: 'POST' });
+    if (url.includes('/sessions/SESS-DEDUP/start')) {
+      startCalls += 1;
+      return deferredStart;
+    }
+    return jsonResponse({ ok: true });
+  }) as unknown as typeof fetch;
+
+  const k = createKortix({ backendUrl: 'http://test.local', getToken: async () => 'tok' });
+  const handle = k.session('PROJ', 'SESS-DEDUP');
+
+  // Fire twice concurrently, before the (deferred) /start response arrives.
+  const p1 = handle.ensureReady();
+  const p2 = handle.ensureReady();
+
+  // Let both calls reach (and park at) the deferred /start request before
+  // releasing it — proves they're genuinely in flight together, not just
+  // sequentially resolved.
+  await new Promise((r) => setTimeout(r, 0));
+  releaseStart(jsonResponse(sessionStartPayload('sb-dedup', 'ocs-dedup')));
+
+  const [r1, r2] = await Promise.all([p1, p2]);
+  expect(startCalls).toBe(1); // only ONE /start POST fired for both concurrent callers
+  expect(r1.sandboxId).toBe('sb-dedup');
+  expect(r2.sandboxId).toBe('sb-dedup');
+});
+
+test('ensureReady() dedup also covers TWO DIFFERENT handles for the same session', async () => {
+  let startCalls = 0;
+  let releaseStart!: (res: Response) => void;
+  const deferredStart = new Promise<Response>((resolve) => {
+    releaseStart = resolve;
+  });
+
+  globalThis.fetch = mock(async (input: unknown) => {
+    const url = requestUrl(input);
+    calls.push({ url, method: 'POST' });
+    if (url.includes('/sessions/SESS-DEDUP-2/start')) {
+      startCalls += 1;
+      return deferredStart;
+    }
+    return jsonResponse({ ok: true });
+  }) as unknown as typeof fetch;
+
+  const k = createKortix({ backendUrl: 'http://test.local', getToken: async () => 'tok' });
+  const handleA = k.session('PROJ', 'SESS-DEDUP-2');
+  const handleB = k.session('PROJ', 'SESS-DEDUP-2'); // fresh handle, same (project, session) id
+
+  const p1 = handleA.ensureReady();
+  const p2 = handleB.ensureReady();
+
+  await new Promise((r) => setTimeout(r, 0));
+  releaseStart(jsonResponse(sessionStartPayload('sb-dedup-2', 'ocs-dedup-2')));
+  await Promise.all([p1, p2]);
+  expect(startCalls).toBe(1);
+});
+
+test('ensureReady() clears the in-flight entry on failure, so a retry issues a fresh /start', async () => {
+  let startCalls = 0;
+  globalThis.fetch = mock(async (input: unknown) => {
+    const url = requestUrl(input);
+    calls.push({ url, method: 'POST' });
+    if (url.includes('/sessions/SESS-DEDUP-FAIL/start')) {
+      startCalls += 1;
+      // First attempt: a failure shape (no sandbox / not ready).
+      if (startCalls === 1) return jsonResponse({ stage: 'failed', retriable: true, sandbox: null, opencode_session_id: null, agent_name: 'agent' });
+      return jsonResponse(sessionStartPayload('sb-retry', 'ocs-retry'));
+    }
+    return jsonResponse({ ok: true });
+  }) as unknown as typeof fetch;
+
+  const k = createKortix({ backendUrl: 'http://test.local', getToken: async () => 'tok' });
+  const handle = k.session('PROJ', 'SESS-DEDUP-FAIL');
+
+  await expect(handle.ensureReady()).rejects.toBeInstanceOf(ApiError);
+  expect(startCalls).toBe(1);
+
+  const ready = await handle.ensureReady();
+  expect(ready.sandboxId).toBe('sb-retry');
+  expect(startCalls).toBe(2);
+});
+
+// ── session(...).files — bound to THIS session's own runtime, never the
+// module-global "active" sandbox the top-level `@kortix/sdk` `files` export
+// follows (P0 fix: cross-session bleed for a host juggling multiple open
+// sessions concurrently) ─────────────────────────────────────────────────────
+
+test("session(...).files hits THIS session's own runtime URL, not whichever session is globally \"active\"", async () => {
+  globalThis.fetch = mock(async (input: unknown) => {
+    const url = requestUrl(input);
+    calls.push({ url, method: 'GET' });
+    if (url.includes('/sessions/FILES-A/start')) return jsonResponse(sessionStartPayload('sb-files-a', 'ocs-files-a'));
+    if (url.includes('/sessions/FILES-B/start')) return jsonResponse(sessionStartPayload('sb-files-b', 'ocs-files-b'));
+    if (url.includes('/file?path=')) return jsonResponse([]);
+    return jsonResponse({ ok: true });
+  }) as unknown as typeof fetch;
+
+  const k = createKortix({ backendUrl: 'http://test.local', getToken: async () => 'tok' });
+  const a = k.session('PROJ', 'FILES-A');
+  const b = k.session('PROJ', 'FILES-B');
+
+  await a.ensureReady();
+  await b.ensureReady(); // resolves LAST — the module-global "active runtime" now points at B
+
+  calls.length = 0;
+  await a.files.list('/workspace');
+  const aFileCall = calls.find((c) => c.url.includes('/file?path='));
+  expect(aFileCall?.url).toContain('/p/sb-files-a/8000/file');
+  expect(aFileCall?.url).not.toContain('sb-files-b');
+
+  // The module-global `files` export (used directly, not through a session
+  // handle) follows the "active runtime" pointer — which B's later
+  // `ensureReady()` last set. This is the documented, PRE-EXISTING behavior of
+  // the global export; the point of this test is that `a.files` does NOT
+  // share that behavior.
+  calls.length = 0;
+  await globalListFiles('/workspace');
+  const globalFileCall = calls.find((c) => c.url.includes('/file?path='));
+  expect(globalFileCall?.url).toContain('/p/sb-files-b/8000/file');
+});
+
+test('session(...).files auto-provisions via ensureReady() if not already ready', async () => {
+  globalThis.fetch = mock(async (input: unknown) => {
+    const url = requestUrl(input);
+    calls.push({ url, method: 'GET' });
+    if (url.includes('/sessions/FILES-AUTO/start')) return jsonResponse(sessionStartPayload('sb-files-auto', 'ocs-files-auto'));
+    if (url.includes('/file/mkdir')) return jsonResponse(true);
+    return jsonResponse({ ok: true });
+  }) as unknown as typeof fetch;
+
+  const k = createKortix({ backendUrl: 'http://test.local', getToken: async () => 'tok' });
+  const s = k.session('PROJ', 'FILES-AUTO');
+
+  // Never called ensureReady() directly — mkdir should still resolve against
+  // this session's own runtime.
+  await s.files.mkdir('/workspace/new-dir');
+  const mkdirCall = calls.find((c) => c.url.includes('/file/mkdir'));
+  expect(mkdirCall?.url).toContain('/p/sb-files-auto/8000/file/mkdir');
 });

--- a/packages/sdk/src/kortix.ts
+++ b/packages/sdk/src/kortix.ts
@@ -17,7 +17,8 @@ import type { OpencodeClient } from '@opencode-ai/sdk/v2/client';
  * for ergonomics. Reactive data still comes from `@kortix/sdk/react` hooks.
  */
 import { getClient, getClientForUrl } from './opencode/client';
-import { type KortixPlatformConfig, configureKortix } from './platform/config';
+import { ApiError } from './platform/api/errors';
+import { type KortixPlatformConfig, configureKortix, platformConfig } from './platform/config';
 import * as P from './platform/projects-client';
 import { getSessionHealth } from './session/health';
 import { type SubdomainUrlOptions, proxyLocalhostUrl, rewriteLocalhostUrl } from './session/url';
@@ -28,6 +29,11 @@ import {
   type SessionRuntimeEntry,
 } from './state/session-runtime-registry';
 import { getSandboxUrlForExternalId } from './state/server-store/url-helpers';
+import {
+  openEventStream,
+  type EventStreamHandle,
+  type OpenCodeEvent,
+} from './state/event-stream';
 
 /** A model the agent can run, as the opencode runtime identifies it. */
 export type SessionModel = { providerID: string; modelID: string };
@@ -58,6 +64,34 @@ export function createKortix(config: KortixPlatformConfig) {
   configureKortix(config);
 
   /**
+   * Parse `backendUrl` for its port (used by the subdomain preview scheme).
+   * `backendUrl` is normally absolute, but the BFF pattern — a Next.js API
+   * route (or any same-origin proxy) fronting the real Kortix API — legitimately
+   * configures it as a relative path like `/api/kortix`. `new URL()` throws on
+   * a bare relative string (no base to resolve against). In a browser that's
+   * recoverable: resolve it against the page's own origin. Server-side there
+   * is no implicit origin, so a relative `backendUrl` is a real misconfiguration
+   * — fail loudly instead of silently defaulting to port 80.
+   */
+  function parseBackendUrlForPort(apiBaseUrl: string): URL | null {
+    try {
+      return new URL(apiBaseUrl);
+    } catch {
+      if (typeof window !== 'undefined' && window.location?.origin) {
+        try {
+          return new URL(apiBaseUrl, window.location.origin);
+        } catch {
+          return null;
+        }
+      }
+      throw new ApiError(
+        `Kortix SDK: backendUrl must be an absolute URL outside the browser (got ${JSON.stringify(apiBaseUrl)}). Relative paths like "/api/kortix" only resolve against a page origin — configure an absolute backendUrl for server-side hosts.`,
+        { code: 'INVALID_BACKEND_URL' },
+      );
+    }
+  }
+
+  /**
    * Resolve the proxy/preview URL context (sandboxId + api base) from config +
    * a THIS-handle's own resolved sandbox id, so a session's `previewUrl`/
    * `proxyUrl` never make the host name a sandbox — and never reads whichever
@@ -65,12 +99,18 @@ export function createKortix(config: KortixPlatformConfig) {
    * session handle).
    */
   function resolvePreviewOptsForSandbox(sandboxId: string): SubdomainUrlOptions {
-    const apiBaseUrl = config.backendUrl;
+    // Read the LIVE platform config, not the `config` captured at
+    // `createKortix()` time: a host may re-point the seam after creation
+    // (calling `configureKortix()` again — e.g. the whitelabel app switching
+    // its `backendUrl` to a same-origin BFF proxy once it learns wrapper mode
+    // is on), and preview/proxy URLs must follow the reconfigured base like
+    // every other call path already does.
+    const apiBaseUrl = platformConfig().backendUrl ?? config.backendUrl;
     let backendPort = 80;
-    try {
-      const u = new URL(apiBaseUrl);
+    const u = parseBackendUrlForPort(apiBaseUrl);
+    if (u) {
       backendPort = u.port ? Number(u.port) : u.protocol === 'https:' ? 443 : 80;
-    } catch {}
+    }
     return { sandboxId, backendPort, apiBaseUrl };
   }
 
@@ -603,6 +643,38 @@ export function createKortix(config: KortixPlatformConfig) {
       abort: async () => {
         const { opencodeSessionId, runtimeUrl } = await ensureReady();
         return getClientForUrl(runtimeUrl).session.abort({ sessionID: opencodeSessionId });
+      },
+      /**
+       * Live SSE stream of THIS session's runtime events (message/part
+       * updates, session status, permissions/questions, lsp diagnostics, …).
+       * A thin facade over the framework-free `openEventStream` primitive
+       * (`@kortix/sdk`'s `openEventStream`, also used verbatim by
+       * `@kortix/sdk/react`'s `useOpenCodeEventStream`): resolves THIS
+       * handle's own runtime first (`ensureReady()`), then connects a client
+       * bound to that runtime URL — never the module-global "active" one, so
+       * two session handles on two different sandboxes never cross wires.
+       * Framework-free — safe to call from a server-side "Kortix as a
+       * Backend" wrapper (Node/Bun), a worker, a CLI, or any non-React host.
+       *
+       * Handles connect/reconnect/backoff, a 15s heartbeat watchdog, and
+       * event coalescing internally. Call `handle.close()` to stop.
+       *
+       *   const handle = await session.stream({ onEvent: (e) => console.log(e) });
+       *   // later
+       *   handle.close();
+       */
+      stream: async (opts: {
+        onEvent: (event: OpenCodeEvent) => void;
+        onGapRehydrate?: (gapMs: number) => void;
+        signal?: AbortSignal;
+      }): Promise<EventStreamHandle> => {
+        const { runtimeUrl } = await ensureReady();
+        return openEventStream({
+          client: getClientForUrl(runtimeUrl),
+          onEvent: opts.onEvent,
+          onGapRehydrate: opts.onGapRehydrate,
+          signal: opts.signal,
+        });
       },
 
       // ── runtime (opencode v2, THIS session's own sandbox) ────────────────

--- a/packages/sdk/src/kortix.ts
+++ b/packages/sdk/src/kortix.ts
@@ -150,6 +150,68 @@ export function createKortix(config: KortixPlatformConfig, opts?: { global?: boo
     cancelInvite: P.cancelAccountInvite,
     /** Resend a pending account invite (accountId still known/scoped). */
     resendInvite: P.resendAccountInvite,
+    /** CLI PAT minting — account-scoped personal access tokens (`kortix_pat_...`). */
+    tokens: {
+      list: P.listAccountTokens,
+      create: P.createAccountToken,
+      revoke: P.revokeAccountToken,
+    },
+    /** Enterprise audit log — events + CSV/JSONL export + SIEM webhooks. */
+    audit: {
+      log: P.listAccountAudit,
+      export: P.exportAccountAudit,
+      webhooks: {
+        list: P.listAccountAuditWebhooks,
+        create: P.createAccountAuditWebhook,
+        update: P.updateAccountAuditWebhook,
+        remove: P.removeAccountAuditWebhook,
+      },
+    },
+  };
+
+  /**
+   * Billing read surface — credits, subscription, tier, and transaction
+   * history for entitlement-gating + a billing/usage UI. Checkout/portal/
+   * credit-purchase/subscription MUTATIONS stay app-owned (Stripe flows) —
+   * this is reads only.
+   */
+  const billing = {
+    accountState: P.getAccountState,
+    accountStateMinimal: P.getAccountStateMinimal,
+    transactions: P.listBillingTransactions,
+    transactionsSummary: P.getBillingTransactionsSummary,
+    creditBreakdown: P.getBillingCreditBreakdown,
+    usageHistory: P.getBillingUsageHistory,
+    tierConfigurations: P.getBillingTierConfigurations,
+
+    /** Stripe checkout — start a subscription and confirm it post-redirect. */
+    checkout: {
+      createSession: (input: Parameters<typeof P.createCheckoutSession>[0]) =>
+        P.createCheckoutSession(input),
+      confirmSession: (sessionId: string, accountId?: string) =>
+        P.confirmCheckoutSession(sessionId, accountId),
+    },
+
+    /** Manage an existing subscription (portal, cancel/reactivate, downgrade). */
+    subscription: {
+      createPortalSession: (returnUrl: string, accountId?: string) =>
+        P.createPortalSession(returnUrl, accountId),
+      cancel: (feedback?: string, accountId?: string) => P.cancelSubscription(feedback, accountId),
+      reactivate: (accountId?: string) => P.reactivateSubscription(accountId),
+      scheduleDowngrade: (targetTierKey: string, commitmentType?: string, accountId?: string) =>
+        P.scheduleDowngrade(targetTierKey, commitmentType, accountId),
+      cancelScheduledChange: (accountId?: string) => P.cancelScheduledChange(accountId),
+      prorationPreview: (newPriceId: string, accountId?: string) =>
+        P.getProrationPreview(newPriceId, accountId),
+    },
+
+    /** One-off credit purchases + recurring auto-topup configuration. */
+    credits: {
+      purchase: (input: Parameters<typeof P.purchaseCredits>[0]) => P.purchaseCredits(input),
+      autoTopupSettings: (accountId?: string) => P.getAutoTopupSettings(accountId),
+      configureAutoTopup: (input: Parameters<typeof P.configureAutoTopup>[0]) =>
+        P.configureAutoTopup(input),
+    },
   };
 
   /**
@@ -203,6 +265,26 @@ export function createKortix(config: KortixPlatformConfig, opts?: { global?: boo
   /** Deployment-wide flag: is the easy-connect (Pipedream) provider configured? Not project-scoped. */
   const connectStatus = P.getConnectStatus;
 
+  /**
+   * Public marketplace catalog browse (`/v1/marketplace/*`) — top-level and
+   * distinct from `project(id).marketplace`, which is install-scoped (commits
+   * an item onto a specific project's branch). This is read-only browsing +
+   * the authed "add a marketplace source" surface.
+   */
+  const marketplace = {
+    items: (options?: Parameters<typeof P.listMarketplaceCatalogItems>[0]) =>
+      P.listMarketplaceCatalogItems(options),
+    item: (id: string) => P.getMarketplaceCatalogItem(id),
+    itemFile: (id: string, path: string) => P.getMarketplaceCatalogItemFile(id, path),
+    marketplaces: () => P.listMarketplaces(),
+    featured: () => P.listFeaturedMarketplaces(),
+    sources: {
+      list: () => P.listMarketplaceSources(),
+      add: (input: Parameters<typeof P.addMarketplaceSource>[0]) => P.addMarketplaceSource(input),
+      remove: (id: string) => P.removeMarketplaceSource(id),
+    },
+  };
+
   /** Id-bound handle for a single project: every sub-resource, projectId pre-applied. */
   function project(projectId: string) {
     return {
@@ -214,6 +296,48 @@ export function createKortix(config: KortixPlatformConfig, opts?: { global?: boo
       sandboxHealth: () => P.getProjectSandboxHealth(projectId),
       onboardingComplete: (...a: DropFirst<Parameters<typeof P.setProjectOnboardingComplete>>) =>
         P.setProjectOnboardingComplete(projectId, ...a),
+
+      /** Project-scoped CLI PATs (auto-minted at session-create as `KORTIX_TOKEN`; can also be minted by hand). */
+      tokens: {
+        list: () => P.listProjectCliTokens(projectId),
+        create: (input?: Parameters<typeof P.createProjectCliToken>[1]) =>
+          P.createProjectCliToken(projectId, input),
+        revoke: (tokenId: string) => P.revokeProjectCliToken(projectId, tokenId),
+      },
+
+      /** Agent-minted setup links — hand a human a link to enter a secret value or 1-click connect an app. */
+      setupLinks: {
+        requestSecret: (input: Parameters<typeof P.requestProjectSecret>[1]) =>
+          P.requestProjectSecret(projectId, input),
+        requestConnector: (input: Parameters<typeof P.requestProjectConnector>[1]) =>
+          P.requestProjectConnector(projectId, input),
+      },
+
+      /** Validate a `kortix.toml` manifest's raw TOML text server-side (same schema `kortix ship`/CR-merge use). */
+      validateManifest: (raw: string) => P.validateProjectManifest(projectId, raw),
+
+      /** Mint a fresh scoped git push token for a managed project (409 for BYO repos). */
+      gitToken: () => P.getProjectGitToken(projectId),
+
+      /** Marketplace install/updates — commits an item's files (+ lock) straight onto the default branch. */
+      marketplace: {
+        list: () => P.listInstalledMarketplaceItems(projectId),
+        install: (id: string) => P.installMarketplaceItem(projectId, id),
+        updates: () => P.getMarketplaceUpdates(projectId),
+        update: (name: string) => P.updateMarketplaceItem(projectId, name),
+        updateAll: () => P.updateAllMarketplaceItems(projectId),
+        remove: (name: string) => P.removeMarketplaceItem(projectId, name),
+      },
+
+      /** `registry.*` — compatibility alias of `marketplace.*` (identical server-side handlers). */
+      registry: {
+        list: () => P.listInstalledRegistryItems(projectId),
+        install: (id: string) => P.installRegistryItem(projectId, id),
+        updates: () => P.getRegistryUpdates(projectId),
+        update: (name: string) => P.updateRegistryItem(projectId, name),
+        updateAll: () => P.updateAllRegistryItems(projectId),
+        remove: (name: string) => P.removeRegistryItem(projectId, name),
+      },
 
       secrets: {
         list: () => P.listProjectSecrets(projectId),
@@ -360,6 +484,9 @@ export function createKortix(config: KortixPlatformConfig, opts?: { global?: boo
           P.closeChangeRequest(projectId, ...a),
         reopen: (...a: DropFirst<Parameters<typeof P.reopenChangeRequest>>) =>
           P.reopenChangeRequest(projectId, ...a),
+        /** Request changes on a CR (Review Center) — records feedback + optionally delivers it back to the originating session. */
+        requestChanges: (...a: DropFirst<Parameters<typeof P.requestChangesOnChangeRequest>>) =>
+          P.requestChangesOnChangeRequest(projectId, ...a),
       },
 
       sessions: {
@@ -405,6 +532,9 @@ export function createKortix(config: KortixPlatformConfig, opts?: { global?: boo
         keys: () => P.getGatewayKeys(projectId),
         createKey: (name: string) => P.createGatewayKey(projectId, name),
         revokeKey: (keyId: string) => P.revokeGatewayKey(projectId, keyId),
+        /** Run one prompt against up to 6 models side by side (a model-comparison playground). */
+        playground: (prompt: string, models: string[]) =>
+          P.runGatewayPlayground(projectId, prompt, models),
       },
 
       /** Slack + email + Meet channel integrations. */
@@ -415,6 +545,11 @@ export function createKortix(config: KortixPlatformConfig, opts?: { global?: boo
           mode: () => P.getSlackMode(projectId),
           manifest: () => P.getSlackManifest(projectId),
           disconnect: () => P.disconnectSlack(projectId),
+          /** Download a Slack-hosted file through the server-side proxy (bot token stays server-side). */
+          getFile: (url: string) => P.getSlackChannelFile(projectId, url),
+          /** Upload a file to Slack through the server-side 3-step external-upload proxy. */
+          uploadFile: (input: Parameters<typeof P.uploadSlackChannelFile>[1]) =>
+            P.uploadSlackChannelFile(projectId, input),
         },
         email: {
           installation: (connectorSlug?: string | null) =>
@@ -430,6 +565,9 @@ export function createKortix(config: KortixPlatformConfig, opts?: { global?: boo
           setVoice: (voice: string) => P.setMeetVoice(projectId, voice),
           setBotName: (name: string) => P.setMeetBotName(projectId, name),
           previewVoice: (voiceId: string) => P.previewMeetVoice(projectId, voiceId),
+          /** Make the meeting bot speak text (text → ElevenLabs → Recall `output_audio`). */
+          speak: (botId: string, text: string, voice?: string) =>
+            P.speakInMeeting(projectId, botId, text, voice),
         },
       },
 
@@ -625,6 +763,9 @@ export function createKortix(config: KortixPlatformConfig, opts?: { global?: boo
       /** Per-session audit trail of executor-gated agent actions. */
       audit: (limit?: number, options?: { showErrors?: boolean }) =>
         P.getSessionAudit(projectId, sessionId, limit, options),
+      /** Compact server-side transcript read (text + tool calls, no tool inputs/outputs) — callable with project-scoped session tokens. */
+      transcript: (options?: Parameters<typeof P.getSessionTranscript>[2]) =>
+        P.getSessionTranscript(projectId, sessionId, options),
 
       /**
        * Resolve THIS handle's own runtime (idempotent): provisions/resumes the
@@ -777,12 +918,18 @@ export function createKortix(config: KortixPlatformConfig, opts?: { global?: boo
     session,
     /** GitHub App installation + repository linking (account-scoped). */
     github,
+    /** Billing read surface — credits/subscription/tier/transactions (not project-scoped). */
+    billing,
     /** Public share links for a sandbox port (`/v1/p/share`, sandbox-scoped). */
     sandboxShares,
     /** Speech-to-text transcription (`/transcription` — not project-scoped). */
     transcribe: P.transcribeAudio,
     /** Deployment-wide Pipedream/easy-connect availability flag (not project-scoped). */
     connectStatus,
+    /** Public marketplace catalog browse + sources (`/v1/marketplace/*`, not project-scoped). */
+    marketplace,
+    /** The pasted-API-key UX check — `GET /accounts/me`, never throws. */
+    validateToken: P.validateToken,
     /** Escape hatch: the typed opencode client for the active sandbox. */
     runtime,
   };

--- a/packages/sdk/src/kortix.ts
+++ b/packages/sdk/src/kortix.ts
@@ -16,6 +16,7 @@ import type { OpencodeClient } from '@opencode-ai/sdk/v2/client';
  * exact types with zero re-typing. The `project()`/`session()` handles bind ids
  * for ergonomics. Reactive data still comes from `@kortix/sdk/react` hooks.
  */
+import * as F from './files/client';
 import { getClient, getClientForUrl } from './opencode/client';
 import { ApiError } from './platform/api/errors';
 import { type KortixPlatformConfig, configureKortix, platformConfig } from './platform/config';
@@ -50,6 +51,19 @@ function runtime(): OpencodeClient {
  * sandbox happens to be globally active (a different session's runtime) —
  * the caller must resolve THIS handle's runtime first.
  */
+/**
+ * Dedupes concurrent `ensureReady()` calls that would otherwise both drive a
+ * `/start` long-poll for the SAME (projectId, sessionId) — e.g. two session
+ * handles for the same session (or the facade racing the React `useSession`
+ * hook) both calling `ensureReady()`/`start()` before either has resolved a
+ * runtime. Keyed by `${projectId}\n${sessionId}` (not the process-global
+ * "active runtime" — every other handle for a DIFFERENT session gets its own
+ * entry and is unaffected). Cleared on settle (success or failure) so a
+ * transient failure doesn't wedge the key — the next call issues a fresh
+ * `/start` instead of replaying a stale rejected promise forever.
+ */
+const inFlightSessionStarts = new Map<string, Promise<SessionRuntimeEntry>>();
+
 export class SessionNotReadyError extends Error {
   constructor(action: string) {
     super(
@@ -59,9 +73,15 @@ export class SessionNotReadyError extends Error {
   }
 }
 
-export function createKortix(config: KortixPlatformConfig) {
+export function createKortix(config: KortixPlatformConfig, opts?: { global?: boolean }) {
   // Wire the platform seam once. All wrapped functions read it.
-  configureKortix(config);
+  //
+  // `opts.global === false` (used by `@kortix/sdk/server`'s `createScopedKortix`)
+  // skips the process-wide write entirely — that caller relies solely on the
+  // `AsyncLocalStorage` scope `createScopedKortix` wraps every method call in,
+  // so this returned facade never touches (or is affected by) the module-global
+  // singleton other concurrent `createKortix()` calls in the same process share.
+  configureKortix(config, opts);
 
   /**
    * Parse `backendUrl` for its port (used by the subdomain preview scheme).
@@ -505,26 +525,53 @@ export function createKortix(config: KortixPlatformConfig) {
     async function ensureReady(): Promise<SessionRuntimeEntry> {
       const cached = tryResolveReady();
       if (cached) return cached;
-      const started = await P.startProjectSession(projectId, sessionId, 30_000);
-      if (
-        !started ||
-        started.stage !== 'ready' ||
-        !started.sandbox ||
-        !started.opencode_session_id
-      ) {
-        throw new Error(`Session runtime not ready (stage: ${started?.stage ?? 'unknown'})`);
+
+      // Dedup concurrent starts for this (projectId, sessionId) — see
+      // `inFlightSessionStarts`'s doc comment. If another call (this handle or
+      // a different one) already kicked off `/start`, ride its result instead
+      // of issuing a second POST.
+      const key = `${projectId}\n${sessionId}`;
+      const inFlight = inFlightSessionStarts.get(key);
+      if (inFlight) {
+        _ready = await inFlight;
+        return _ready;
       }
-      const externalId = (started.sandbox as { external_id?: string | null }).external_id;
-      if (!externalId) {
-        throw new Error('Session sandbox has no external_id — cannot resolve its runtime URL');
+
+      const startPromise = (async (): Promise<SessionRuntimeEntry> => {
+        const started = await P.startProjectSession(projectId, sessionId, 30_000);
+        if (
+          !started ||
+          started.stage !== 'ready' ||
+          !started.sandbox ||
+          !started.opencode_session_id
+        ) {
+          throw new ApiError(`Session runtime not ready (stage: ${started?.stage ?? 'unknown'})`, {
+            code: 'RUNTIME_UNAVAILABLE',
+          });
+        }
+        const externalId = (started.sandbox as { external_id?: string | null }).external_id;
+        if (!externalId) {
+          throw new ApiError('Session sandbox has no external_id — cannot resolve its runtime URL', {
+            code: 'RUNTIME_UNAVAILABLE',
+          });
+        }
+        const runtimeUrl = getSandboxUrlForExternalId(externalId);
+        // Point the app's shared runtime store at this session too, so React
+        // hosts (which read the global current-runtime) keep working — but this
+        // handle's own operations never read it back, only `_ready` below.
+        setCurrentRuntime(runtimeUrl, externalId);
+        return { opencodeSessionId: started.opencode_session_id, runtimeUrl, sandboxId: externalId };
+      })();
+
+      inFlightSessionStarts.set(key, startPromise);
+      try {
+        _ready = await startPromise;
+        return _ready;
+      } finally {
+        if (inFlightSessionStarts.get(key) === startPromise) {
+          inFlightSessionStarts.delete(key);
+        }
       }
-      const runtimeUrl = getSandboxUrlForExternalId(externalId);
-      // Point the app's shared runtime store at this session too, so React
-      // hosts (which read the global current-runtime) keep working — but this
-      // handle's own operations never read it back, only `_ready` below.
-      setCurrentRuntime(runtimeUrl, externalId);
-      _ready = { opencodeSessionId: started.opencode_session_id, runtimeUrl, sandboxId: externalId };
-      return _ready;
     }
 
     /** Throw `SessionNotReadyError` if neither this handle nor the registry has resolved a runtime yet. */
@@ -683,6 +730,38 @@ export function createKortix(config: KortixPlatformConfig) {
       // with server-owned side-effects) layer on top of this as they land.
       get runtime(): OpencodeClient {
         return getClientForUrl(requireReady('runtime').runtimeUrl);
+      },
+
+      /**
+       * Workspace file operations (daemon `/file` + `/find`) bound to THIS
+       * session's own resolved runtime — never the module-global "active"
+       * sandbox the top-level `@kortix/sdk` `files` export follows. Fixes a
+       * cross-session bleed: a host juggling multiple open sessions (e.g. a
+       * server wrapping several concurrent agent sessions) that called the
+       * global `files.list()` while a DIFFERENT session was "active" would
+       * silently read/write the wrong sandbox. Each call here auto-provisions
+       * via `ensureReady()` (same as `send`/`abort`/`stream`), then runs
+       * against this handle's own runtime URL. Same 12-op surface as the
+       * global `files` namespace, built from the same parameterized core
+       * (`@kortix/sdk/files`'s exports all take an optional trailing
+       * `baseUrl` — this just always supplies THIS session's).
+       */
+      files: {
+        list: async (dirPath: string) => F.listFiles(dirPath, (await ensureReady()).runtimeUrl),
+        read: async (filePath: string) => F.readFile(filePath, (await ensureReady()).runtimeUrl),
+        readBlob: async (filePath: string) => F.readBlob(filePath, (await ensureReady()).runtimeUrl),
+        status: async () => F.getFileStatus((await ensureReady()).runtimeUrl),
+        findFiles: async (query: string, options?: { type?: 'file' | 'directory'; limit?: number }) =>
+          F.findFiles(query, options, (await ensureReady()).runtimeUrl),
+        findText: async (pattern: string) => F.findText(pattern, (await ensureReady()).runtimeUrl),
+        upload: async (file: File | Blob, targetPath?: string, filename?: string) =>
+          F.uploadFile(file, targetPath, filename, (await ensureReady()).runtimeUrl),
+        create: async (filePath: string) => F.createFile(filePath, (await ensureReady()).runtimeUrl),
+        copy: async (sourcePath: string, destPath: string) =>
+          F.copyFile(sourcePath, destPath, (await ensureReady()).runtimeUrl),
+        remove: async (filePath: string) => F.deleteFile(filePath, (await ensureReady()).runtimeUrl),
+        mkdir: async (dirPath: string) => F.mkdir(dirPath, (await ensureReady()).runtimeUrl),
+        rename: async (from: string, to: string) => F.renameFile(from, to, (await ensureReady()).runtimeUrl),
       },
     };
   }

--- a/packages/sdk/src/opencode/client.test.ts
+++ b/packages/sdk/src/opencode/client.test.ts
@@ -1,10 +1,18 @@
 import { test, expect, beforeEach, mock } from 'bun:test';
 import { configureKortix } from '../platform/config';
+import { setCurrentRuntime } from '../state/current-runtime';
 
-let activeUrl = '';
-mock.module('../state/server-store/active', () => ({
-  getActiveOpenCodeUrl: () => activeUrl,
-}));
+// This file used to fake `getActiveOpenCodeUrl` entirely via
+// `mock.module('../state/server-store/active', ...)`. That's a process-wide,
+// permanent-for-the-sweep override (see the hermetic-pattern comment below) —
+// and since it replaced the WHOLE module with only one export, any other file
+// that imports `state/server-store/active` for real (e.g. a direct test of
+// that module) would see every other export silently gutted to `undefined`.
+// Driving the same "active runtime url" control through the REAL state seam
+// instead (`setCurrentRuntime` — the same primitive `getActiveOpenCodeUrl`
+// itself reads — plus `configureKortix({ billingEnabled: true })` so "no
+// active session" resolves to '', matching the old default) gives this file
+// identical control with no mock at all — nothing left to collide with.
 
 // This file must be hermetic against process-wide `mock.module('../platform/auth', ...)`
 // registrations made by OTHER test files (files/client.test.ts, opencode/env.test.ts,
@@ -49,9 +57,12 @@ const {
 beforeEach(() => {
   resetClient();
   resetPublicClient();
-  activeUrl = '';
+  setCurrentRuntime(null);
   authToken = 'test-token';
-  configureKortix({ backendUrl: 'http://backend.local/v1', getToken: async () => authToken ?? null });
+  // billingEnabled: true so `getActiveOpenCodeUrl()` resolves to '' with no
+  // active session (matching this file's old `activeUrl = ''` default),
+  // instead of the self-hosted local-dev fallback sandbox url.
+  configureKortix({ backendUrl: 'http://backend.local/v1', getToken: async () => authToken ?? null, billingEnabled: true });
 });
 
 function captureRequests() {
@@ -159,7 +170,7 @@ function captureRawFetchCalls(response: () => Response) {
 }
 
 test('systemReload POSTs {url}/kortix/services/system/reload with the mode and returns the parsed result', async () => {
-  activeUrl = 'http://sbx.test';
+  setCurrentRuntime('http://sbx.test', 'active-sbx');
   const calls = captureRawFetchCalls(
     () =>
       new Response(JSON.stringify({ success: true, mode: 'dispose-only', steps: ['a'], errors: [] }), {
@@ -177,12 +188,12 @@ test('systemReload POSTs {url}/kortix/services/system/reload with the mode and r
 });
 
 test('systemReload throws when the active runtime url is not ready', async () => {
-  activeUrl = '';
+  setCurrentRuntime(null);
   await expect(systemReload('full')).rejects.toThrow('Server URL not ready');
 });
 
 test('systemReload throws with the daemon error message on a non-ok response', async () => {
-  activeUrl = 'http://sbx.test';
+  setCurrentRuntime('http://sbx.test', 'active-sbx');
   captureRawFetchCalls(
     () => new Response(JSON.stringify({ error: 'daemon unavailable' }), { status: 503 }),
   );

--- a/packages/sdk/src/opencode/client.ts
+++ b/packages/sdk/src/opencode/client.ts
@@ -30,6 +30,7 @@ export type { OpencodeClient };
 import { authenticatedFetch } from "../platform/auth";
 import { isConfigured } from "../platform/config";
 import { getActiveOpenCodeUrl } from "../state/server-store/active";
+import { ApiError } from "../platform/api/errors";
 
 // Sandbox env/secrets client (`GET/PUT/DELETE /env`), the `/kortix/triggers`
 // wrapper, and the kortix-master project-management client (`/kortix/tasks`,
@@ -212,7 +213,9 @@ export interface SystemReloadResult {
 export async function systemReload(mode: SystemReloadMode): Promise<SystemReloadResult> {
 	const url = getActiveOpenCodeUrl();
 	if (!url) {
-		throw new Error('[opencode-sdk] Server URL not ready — sandbox is still loading');
+		throw new ApiError('[opencode-sdk] Server URL not ready — sandbox is still loading', {
+			code: 'RUNTIME_UNAVAILABLE',
+		});
 	}
 	const response = await authenticatedFetch(`${url}/kortix/services/system/reload`, {
 		method: 'POST',
@@ -220,7 +223,11 @@ export async function systemReload(mode: SystemReloadMode): Promise<SystemReload
 		body: JSON.stringify({ mode }),
 	});
 	if (!response.ok) {
-		throw new Error(`System reload failed (${response.status}): ${await daemonErrorMessage(response)}`);
+		throw new ApiError(`System reload failed (${response.status}): ${await daemonErrorMessage(response)}`, {
+			status: response.status,
+			response,
+			code: 'RUNTIME_UNAVAILABLE',
+		});
 	}
 	return response.json() as Promise<SystemReloadResult>;
 }

--- a/packages/sdk/src/platform/api-client.ts
+++ b/packages/sdk/src/platform/api-client.ts
@@ -1,17 +1,24 @@
 import { platformConfig } from './config';
 import { getSupabaseAccessTokenWithRetry } from './auth';
-import { parseBillingError, RequestTooLargeError } from './api/errors';
+import { ApiError, AuthError, parseBillingError, RequestTooLargeError } from './api/errors';
 
 const getApiUrl = () => platformConfig().backendUrl || '';
 
-// Ported verbatim from web's error-handler. User-facing error handling is
-// routed through platformConfig().onError?.() instead of web's handleApiError.
-export interface ApiError extends Error {
-  status?: number;
-  code?: string;
-  details?: any;
-  response?: Response;
-}
+// Ported from web's error-handler. User-facing error handling is routed
+// through platformConfig().onError?.() instead of web's handleApiError.
+// The error classes live in ./api/errors — re-exported here so both the
+// root barrel and the `@kortix/sdk/api-client` subpath expose them.
+export {
+  ApiError,
+  AuthError,
+  BillingError,
+  RequestTooLargeError,
+  parseBillingError,
+  isBillingError,
+  formatBillingErrorForUI,
+  type ApiErrorFields,
+  type BillingErrorUI,
+} from './api/errors';
 
 export interface ErrorContext {
   operation?: string;
@@ -100,11 +107,7 @@ async function makeRequest<T = any>(
       // Callers gated by `enabled: !!user` should prevent this path, but this
       // is a safety net for any calls that slip through.
       return {
-        error: Object.assign(Object.create(Error.prototype), {
-          message: 'Not authenticated',
-          name: 'AuthError',
-          code: 'NO_SESSION',
-        }),
+        error: new AuthError(),
         success: false,
       };
     }
@@ -146,9 +149,7 @@ async function makeRequest<T = any>(
       } catch {
       }
 
-      let error: ApiError | Error = Object.assign(Object.create(Error.prototype), {
-        message: errorMessage,
-        name: 'ApiError',
+      let error: ApiError | Error = new ApiError(errorMessage, {
         status: response.status,
         response: response,
         details: errorData || undefined,
@@ -222,11 +223,7 @@ async function makeRequest<T = any>(
       // "Request timeout" toasts/Sentry events. Swallow it silently.
       if (!didTimeout) {
         return {
-          error: Object.assign(Object.create(Error.prototype), {
-            message: 'Request aborted',
-            name: 'AbortError',
-            code: 'ABORTED',
-          }),
+          error: new ApiError('Request aborted', { name: 'AbortError', code: 'ABORTED' }),
           success: false,
         };
       }
@@ -234,9 +231,7 @@ async function makeRequest<T = any>(
       // Genuine timeout — our timer fired. Attach the endpoint so it's clear
       // *what* timed out (the previous error carried no URL).
       const endpoint = url.replace(getApiUrl(), '') || url;
-      apiError = Object.assign(Object.create(Error.prototype), {
-        message: `Request timed out after ${Math.round(timeout / 1000)}s: ${endpoint}`,
-        name: 'ApiError',
+      apiError = new ApiError(`Request timed out after ${Math.round(timeout / 1000)}s: ${endpoint}`, {
         code: 'TIMEOUT',
         url,
         endpoint,
@@ -249,20 +244,16 @@ async function makeRequest<T = any>(
         platformConfig().onError?.(apiError, errorContext);
       }
     } else if (error instanceof Error) {
-      apiError = Object.assign(Object.create(Error.prototype), {
-        message: error.message,
+      apiError = new ApiError(error.message, {
         name: error.name || 'ApiError',
-        stack: error.stack
+        stack: error.stack,
       });
 
       if (showErrors) {
         platformConfig().onError?.(apiError, errorContext);
       }
     } else {
-      apiError = Object.assign(Object.create(Error.prototype), {
-        message: String(error),
-        name: 'ApiError'
-      });
+      apiError = new ApiError(String(error));
 
       if (showErrors) {
         platformConfig().onError?.(apiError, errorContext);
@@ -285,11 +276,9 @@ export const supabaseClient = {
       const { data, error } = await queryFn();
 
       if (error) {
-        const apiError: ApiError = Object.assign(Object.create(Error.prototype), {
-          message: error.message || 'Database error',
-          name: 'ApiError',
+        const apiError: ApiError = new ApiError(error.message || 'Database error', {
           code: error.code,
-          details: error
+          details: error,
         });
 
         platformConfig().onError?.(apiError, errorContext);
@@ -306,15 +295,8 @@ export const supabaseClient = {
       };
     } catch (error: any) {
       const apiError: ApiError = error instanceof Error
-        ? Object.assign(Object.create(Error.prototype), {
-            message: error.message,
-            name: error.name || 'ApiError',
-            stack: error.stack
-          })
-        : Object.assign(Object.create(Error.prototype), {
-            message: String(error),
-            name: 'ApiError'
-          });
+        ? new ApiError(error.message, { name: error.name || 'ApiError', stack: error.stack })
+        : new ApiError(String(error));
 
       platformConfig().onError?.(apiError, errorContext);
 

--- a/packages/sdk/src/platform/api/errors.test.ts
+++ b/packages/sdk/src/platform/api/errors.test.ts
@@ -1,0 +1,251 @@
+import { test, expect } from 'bun:test';
+import {
+  ApiError,
+  AuthError,
+  BillingError,
+  RequestTooLargeError,
+  formatBillingErrorForUI,
+  isBillingError,
+  parseBillingError,
+} from './errors';
+
+// ── ApiError ─────────────────────────────────────────────────────────────────
+
+test('ApiError sets message, name, and defaults with no fields', () => {
+  const err = new ApiError('boom');
+  expect(err.message).toBe('boom');
+  expect(err.name).toBe('ApiError');
+  expect(err).toBeInstanceOf(Error);
+  expect(err).toBeInstanceOf(ApiError);
+});
+
+test('ApiError copies plain fields (status, code, details, data, detail, response, url, endpoint, timeout)', () => {
+  const response = new Response(null, { status: 500 });
+  const err = new ApiError('boom', {
+    status: 500,
+    code: 'INTERNAL',
+    details: { a: 1 },
+    data: { b: 2 },
+    detail: 'raw detail',
+    response,
+    url: 'http://x.test/y',
+    endpoint: '/y',
+    timeout: 5000,
+  });
+
+  expect(err.status).toBe(500);
+  expect(err.code).toBe('INTERNAL');
+  expect(err.details).toEqual({ a: 1 });
+  expect(err.data).toEqual({ b: 2 });
+  expect(err.detail).toBe('raw detail');
+  expect(err.response).toBe(response);
+  expect(err.url).toBe('http://x.test/y');
+  expect(err.endpoint).toBe('/y');
+  expect(err.timeout).toBe(5000);
+});
+
+test('ApiError overrides `name` when fields.name is given (e.g. AbortError), keeping the ApiError class', () => {
+  const err = new ApiError('timed out', { name: 'AbortError', timeout: 1000 });
+  expect(err.name).toBe('AbortError');
+  expect(err).toBeInstanceOf(ApiError);
+  expect(err.timeout).toBe(1000);
+});
+
+test('ApiError overrides `stack` when fields.stack is given', () => {
+  const customStack = 'CustomError: synthetic\n    at somewhere.ts:1:1';
+  const err = new ApiError('boom', { stack: customStack });
+  expect(err.stack).toBe(customStack);
+});
+
+test('ApiError without an explicit stack override keeps a real captured stack', () => {
+  const err = new ApiError('boom');
+  expect(typeof err.stack).toBe('string');
+  expect(err.stack).toContain('boom');
+});
+
+test('ApiError `message` is an enumerable own property — survives JSON.stringify and object spread', () => {
+  const err = new ApiError('boom', { status: 404, code: 'NOT_FOUND' });
+
+  const json = JSON.parse(JSON.stringify(err));
+  expect(json.message).toBe('boom');
+
+  const spread = { ...err };
+  expect(spread.message).toBe('boom');
+});
+
+test('ApiError message stays writable/configurable after construction', () => {
+  const err = new ApiError('original');
+  err.message = 'updated';
+  expect(err.message).toBe('updated');
+});
+
+test('ApiError with both a `name` and `stack` override applies both without touching unrelated fields', () => {
+  const err = new ApiError('boom', { name: 'AbortError', stack: 'custom-stack', status: 408 });
+  expect(err.name).toBe('AbortError');
+  expect(err.stack).toBe('custom-stack');
+  expect(err.status).toBe(408);
+  // `rest` (destructured away from name/stack) must not have leaked either
+  // of them onto some other field.
+  expect(err.code).toBeUndefined();
+  expect(err.details).toBeUndefined();
+});
+
+// ── AuthError ────────────────────────────────────────────────────────────────
+
+test('AuthError defaults to "Not authenticated" with code NO_SESSION', () => {
+  const err = new AuthError();
+  expect(err.message).toBe('Not authenticated');
+  expect(err.code).toBe('NO_SESSION');
+  expect(err.name).toBe('AuthError');
+  expect(err).toBeInstanceOf(ApiError);
+});
+
+test('AuthError accepts a custom message but keeps the NO_SESSION code', () => {
+  const err = new AuthError('session expired');
+  expect(err.message).toBe('session expired');
+  expect(err.code).toBe('NO_SESSION');
+});
+
+// ── BillingError ─────────────────────────────────────────────────────────────
+
+test('BillingError carries status + detail and defaults message from detail.message', () => {
+  const err = new BillingError(402, { message: 'insufficient credits' });
+  expect(err.status).toBe(402);
+  expect(err.message).toBe('insufficient credits');
+  expect(err.detail).toEqual({ message: 'insufficient credits' });
+  expect(err.name).toBe('BillingError');
+  expect(err).toBeInstanceOf(Error);
+});
+
+test('BillingError falls back to a generic "Billing Error: <status>" when detail.message is absent', () => {
+  const err = new BillingError(402, { message: '' } as any);
+  expect(err.message).toBe('Billing Error: 402');
+});
+
+test('BillingError honors an explicit message override over detail.message', () => {
+  const err = new BillingError(402, { message: 'from detail' }, 'explicit override');
+  expect(err.message).toBe('explicit override');
+});
+
+// ── RequestTooLargeError ─────────────────────────────────────────────────────
+
+test('RequestTooLargeError defaults to status 431 with a generic message + suggestion', () => {
+  const err = new RequestTooLargeError();
+  expect(err.status).toBe(431);
+  expect(err.message).toBe('Request headers are too large');
+  expect(err.detail.suggestion).toContain('one at a time');
+  expect(err.name).toBe('RequestTooLargeError');
+});
+
+test('RequestTooLargeError accepts a custom status, detail, and message', () => {
+  const err = new RequestTooLargeError(431, { message: 'too many files', suggestion: 'split it up' }, 'custom msg');
+  expect(err.message).toBe('custom msg');
+  expect(err.detail).toEqual({ message: 'too many files', suggestion: 'split it up' });
+});
+
+// ── parseBillingError ────────────────────────────────────────────────────────
+
+test('parseBillingError converts a 402 (via error.status) into a BillingError', () => {
+  const result = parseBillingError({ status: 402, message: 'no credits', detail: { plan: 'free' } });
+  expect(result).toBeInstanceOf(BillingError);
+  expect((result as BillingError).status).toBe(402);
+});
+
+test('parseBillingError reads status from error.response.status when error.status is absent', () => {
+  const result = parseBillingError({ response: { status: 402, data: { detail: { message: 'card declined' } } } });
+  expect(result).toBeInstanceOf(BillingError);
+  expect((result as BillingError).message).toBe('card declined');
+});
+
+test('parseBillingError returns the original error unchanged for a non-402 status', () => {
+  const original = { status: 500, message: 'server error' };
+  const result = parseBillingError(original);
+  expect(result).toBe(original as unknown as Error);
+});
+
+test('parseBillingError falls back through response.data / error.data / error.detail for the error body', () => {
+  const viaData = parseBillingError({ status: 402, data: { detail: { message: 'from data.detail' } } });
+  expect((viaData as BillingError).message).toBe('from data.detail');
+
+  const viaDetail = parseBillingError({ status: 402, detail: { message: 'from detail' } });
+  expect((viaDetail as BillingError).message).toBe('from detail');
+});
+
+test('parseBillingError defaults to a generic message when nothing usable is present', () => {
+  const result = parseBillingError({ status: 402 });
+  expect((result as BillingError).message).toBe('Billing error');
+});
+
+test('parseBillingError uses error.message when the body has no nested detail.message', () => {
+  const result = parseBillingError({ status: 402, message: 'top-level message', data: {} });
+  expect((result as BillingError).message).toBe('top-level message');
+});
+
+test('parseBillingError spreads extra detail fields onto the BillingError.detail', () => {
+  const result = parseBillingError({
+    status: 402,
+    detail: { message: 'limit hit', limit: 5, plan: 'free' },
+  }) as BillingError;
+  expect(result.detail).toMatchObject({ message: 'limit hit', limit: 5, plan: 'free' });
+});
+
+// ── isBillingError ───────────────────────────────────────────────────────────
+
+test('isBillingError is true only for actual BillingError instances', () => {
+  expect(isBillingError(new BillingError(402, { message: 'x' }))).toBe(true);
+  expect(isBillingError(new ApiError('x', { status: 402 }))).toBe(false);
+  expect(isBillingError(new Error('x'))).toBe(false);
+  expect(isBillingError(null)).toBe(false);
+  expect(isBillingError(undefined)).toBe(false);
+});
+
+// ── formatBillingErrorForUI ──────────────────────────────────────────────────
+
+test('formatBillingErrorForUI returns null for a non-BillingError', () => {
+  expect(formatBillingErrorForUI(new ApiError('x'))).toBeNull();
+  expect(formatBillingErrorForUI(new Error('x'))).toBeNull();
+  expect(formatBillingErrorForUI(null)).toBeNull();
+  expect(formatBillingErrorForUI('just a string')).toBeNull();
+});
+
+test('formatBillingErrorForUI recognizes a "credit" message as the credits-exhausted branch', () => {
+  const err = new BillingError(402, { message: 'You are out of credits' });
+  expect(formatBillingErrorForUI(err)).toEqual({
+    alertTitle: 'You ran out of credits',
+    alertSubtitle: 'Upgrade your plan to get more credits and continue using the AI assistant.',
+  });
+});
+
+test('formatBillingErrorForUI recognizes a "balance" message as the credits-exhausted branch', () => {
+  const err = new BillingError(402, { message: 'Insufficient account balance' });
+  expect(formatBillingErrorForUI(err)?.alertTitle).toBe('You ran out of credits');
+});
+
+test('formatBillingErrorForUI recognizes an "insufficient" message as the credits-exhausted branch', () => {
+  const err = new BillingError(402, { message: 'insufficient funds for this operation' });
+  expect(formatBillingErrorForUI(err)?.alertTitle).toBe('You ran out of credits');
+});
+
+test('formatBillingErrorForUI is case-insensitive when matching the credits-exhausted keywords', () => {
+  const err = new BillingError(402, { message: 'CREDIT limit reached' });
+  expect(formatBillingErrorForUI(err)?.alertTitle).toBe('You ran out of credits');
+});
+
+test('formatBillingErrorForUI falls back to the generic "billing check failed" branch for any other message', () => {
+  const err = new BillingError(402, { message: 'subscription is paused' });
+  expect(formatBillingErrorForUI(err)).toEqual({
+    alertTitle: 'Billing check failed',
+    alertSubtitle: 'subscription is paused',
+  });
+});
+
+test('formatBillingErrorForUI generic branch falls back to a default subtitle when detail.message is empty', () => {
+  const err = new BillingError(402, { message: '' } as any);
+  // With an empty detail.message, BillingError's own constructor falls back to
+  // 'Billing Error: 402' for `.message`, but `.detail.message` stays '' —
+  // formatBillingErrorForUI reads detail.message, not the outer .message.
+  expect(formatBillingErrorForUI(err)).toEqual({
+    alertTitle: 'Billing check failed',
+    alertSubtitle: 'Please upgrade to continue.',
+  });
+});

--- a/packages/sdk/src/platform/api/errors.ts
+++ b/packages/sdk/src/platform/api/errors.ts
@@ -11,6 +11,77 @@
 // Error Classes
 // ============================================================================
 
+/** Constructor fields for {@link ApiError} — everything beyond `message`. */
+export interface ApiErrorFields {
+  status?: number;
+  code?: string;
+  /** Parsed error body (when the response carried JSON). */
+  details?: any;
+  /** Alias of `details` kept for legacy `.data` sniffers. */
+  data?: any;
+  /** The body's `detail` field (FastAPI-style), when present. */
+  detail?: any;
+  response?: Response;
+  /** Full request URL — set on timeouts so it's clear what timed out. */
+  url?: string;
+  /** Request path relative to the backend base — set on timeouts. */
+  endpoint?: string;
+  /** The timeout budget (ms) that elapsed — set on timeouts. */
+  timeout?: number;
+  /** Override `name` (e.g. 'AbortError') while keeping the class. */
+  name?: string;
+  stack?: string;
+}
+
+/**
+ * The REST error `backendApi` produces for any failed request. A real class —
+ * server-side wrappers and non-React hosts can `err instanceof ApiError` and
+ * branch on `.status`/`.code` instead of duck-typing `name === 'ApiError'`
+ * (which still works: `name` is preserved for legacy sniffers).
+ *
+ * `message` is defined as an ENUMERABLE own property on purpose: the previous
+ * ad-hoc `Object.assign(Object.create(Error.prototype), …)` objects had it
+ * enumerable, so spreads and JSON logging of these errors included it.
+ */
+export class ApiError extends Error {
+  status?: number;
+  code?: string;
+  details?: any;
+  data?: any;
+  detail?: any;
+  response?: Response;
+  url?: string;
+  endpoint?: string;
+  timeout?: number;
+
+  constructor(message: string, fields: ApiErrorFields = {}) {
+    super(message);
+    this.name = 'ApiError';
+    const { name, stack, ...rest } = fields;
+    Object.assign(this, rest);
+    if (name) this.name = name;
+    if (stack) this.stack = stack;
+    Object.defineProperty(this, 'message', {
+      value: message,
+      enumerable: true,
+      writable: true,
+      configurable: true,
+    });
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+/**
+ * "No token available" — `getToken` returned null, so the request was never
+ * sent (see `api-client.ts`). `code` is always `'NO_SESSION'`.
+ */
+export class AuthError extends ApiError {
+  constructor(message = 'Not authenticated') {
+    super(message, { code: 'NO_SESSION' });
+    this.name = 'AuthError';
+  }
+}
+
 /**
  * Generic billing error for HTTP 402 responses.
  * This is the only billing error class the backend actually triggers.

--- a/packages/sdk/src/platform/auth-core.ts
+++ b/packages/sdk/src/platform/auth-core.ts
@@ -1,0 +1,126 @@
+/**
+ * Pure, dependency-free building blocks for `auth.ts` — extracted so they can
+ * be unit-tested against the REAL implementation regardless of test-file
+ * ordering.
+ *
+ * Why this file exists: several test suites register process-wide
+ * `mock.module('../platform/auth', …)` stubs (Bun's `mock.module` replaces a
+ * specifier for the remainder of the process, for every importer — see the
+ * note in `opencode/client.test.ts`). Any test that wants to exercise the real
+ * retry/timeout semantics therefore can't import them from `./auth` — on some
+ * Bun versions/orderings it would receive a stub. Nothing mocks THIS module,
+ * so `auth-core.test.ts` always tests the genuine article, and `auth.ts` stays
+ * a thin delegating shell whose behavior is pinned here.
+ */
+
+/** Options accepted by the token-retry helpers (`getAuthTokenWithRetry` et al). */
+export interface TokenRetryOptions {
+	attempts?: number;
+	baseDelayMs?: number;
+	invalidateBetweenAttempts?: boolean;
+}
+
+function delay(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Retry `getToken` up to `attempts` times (default 1 = no retry) until it
+ * returns a truthy token, waiting `baseDelayMs` between attempts. When
+ * `invalidateBetweenAttempts` is set, `onInvalidate` runs before each retry —
+ * a host that layers its own cache on `getToken` wires cache invalidation
+ * there. Returns the last (possibly falsy) result after exhausting attempts.
+ */
+export async function withTokenRetry(
+	getToken: () => Promise<string | null>,
+	options?: TokenRetryOptions,
+	onInvalidate?: () => void,
+): Promise<string | null> {
+	const attempts = Math.max(1, options?.attempts ?? 1);
+	const baseDelayMs = options?.baseDelayMs ?? 0;
+	const invalidateBetweenAttempts = options?.invalidateBetweenAttempts ?? false;
+
+	let token: string | null = null;
+	for (let attempt = 0; attempt < attempts; attempt++) {
+		if (attempt > 0) {
+			if (invalidateBetweenAttempts) onInvalidate?.();
+			if (baseDelayMs > 0) await delay(baseDelayMs);
+		}
+		token = await getToken();
+		if (token) return token;
+	}
+	return token;
+}
+
+export const DEFAULT_FETCH_TIMEOUT_MS = 30_000;
+
+/**
+ * The one long-lived streaming call reached through the auth fetch injection
+ * point — `openEventStream` (`state/event-stream.ts`) drives the opencode
+ * client's `global.event(...)` SSE endpoint (`GET {runtimeUrl}/global/event`).
+ * It manages its own lifecycle (heartbeat watchdog + explicit abort/reconnect
+ * loop) and must stay open far longer than any request timeout.
+ */
+export function isStreamingRequest(input: RequestInfo | URL): boolean {
+	const url = input instanceof Request ? input.url : String(input);
+	return url.includes('/global/event');
+}
+
+/**
+ * Compose the request's own abort signal with a default 30s timeout, so a
+ * hung non-streaming call can't wedge a "Kortix as a Backend" server-side
+ * handler forever. The SSE event stream is exempted (see
+ * `isStreamingRequest`): its caller signal — if any — passes through
+ * untouched. Falls back to the caller's bare signal on a runtime without
+ * `AbortSignal.any` (older Node/engines) — guarded so a caller-supplied
+ * signal is never silently dropped.
+ */
+export function withDefaultTimeout(
+	input: RequestInfo | URL,
+	init: RequestInit | undefined,
+	timeoutMs: number = DEFAULT_FETCH_TIMEOUT_MS,
+): AbortSignal | undefined {
+	const callerSignal = input instanceof Request ? input.signal : init?.signal;
+	if (isStreamingRequest(input)) return callerSignal ?? undefined;
+
+	const timeoutSignal = AbortSignal.timeout(timeoutMs);
+	if (!callerSignal) return timeoutSignal;
+	if (typeof AbortSignal.any === 'function') {
+		return AbortSignal.any([callerSignal, timeoutSignal]);
+	}
+	return callerSignal;
+}
+
+/**
+ * Build a Headers object from request input + init, injecting the auth token
+ * as a Bearer Authorization header (unless one is already present).
+ */
+export function buildAuthHeaders(
+	input: RequestInfo | URL,
+	init?: RequestInit,
+	token?: string | null,
+): Headers {
+	const headers = new Headers(input instanceof Request ? input.headers : undefined);
+	if (init?.headers) {
+		new Headers(init.headers).forEach((value, key) => {
+			headers.set(key, value);
+		});
+	}
+	if (token && !headers.has('Authorization')) {
+		headers.set('Authorization', `Bearer ${token}`);
+	}
+	return headers;
+}
+
+/**
+ * The synthetic 401 returned when no token is available — safe for all
+ * callers including the OpenCode SDK, which expects fetch() semantics
+ * (returns a Response, never throws), and it means the request never goes
+ * out on the wire unauthenticated.
+ */
+export function syntheticUnauthenticatedResponse(): Response {
+	return new Response(JSON.stringify({ error: 'Not authenticated' }), {
+		status: 401,
+		headers: { 'Content-Type': 'application/json' },
+	});
+}

--- a/packages/sdk/src/platform/auth.test.ts
+++ b/packages/sdk/src/platform/auth.test.ts
@@ -1,0 +1,128 @@
+import { test, expect, beforeEach } from 'bun:test';
+import { configureKortix } from './config';
+import { authenticatedFetch, getSupabaseAccessTokenWithRetry, getAuthTokenWithRetry } from './auth';
+
+// NOTE: unlike files/client.test.ts / opencode/client.test.ts / session/session.test.ts
+// (which each `mock.module('../platform/auth', ...)` to fully replace this module for
+// their own purposes), this file tests the REAL implementation directly — it must NOT
+// itself `mock.module` this path.
+
+let tokenCallCount = 0;
+let tokenSequence: Array<string | null> = [];
+
+beforeEach(() => {
+  tokenCallCount = 0;
+  tokenSequence = [];
+  configureKortix({
+    backendUrl: 'http://backend.local/v1',
+    getToken: async () => {
+      const t = tokenSequence[Math.min(tokenCallCount, tokenSequence.length - 1)] ?? null;
+      tokenCallCount += 1;
+      return t;
+    },
+  });
+});
+
+// ── getSupabaseAccessTokenWithRetry / getAuthTokenWithRetry — actually retries
+// now (previously accepted attempts/baseDelayMs/invalidateBetweenAttempts and
+// silently ignored all three) ───────────────────────────────────────────────
+
+test('retries until getToken() returns a truthy token, up to `attempts`', async () => {
+  tokenSequence = [null, null, 'tok-3'];
+  const token = await getSupabaseAccessTokenWithRetry({ attempts: 3, baseDelayMs: 0 });
+  expect(token).toBe('tok-3');
+  expect(tokenCallCount).toBe(3);
+});
+
+test('gives up after `attempts` and returns the last (falsy) result — never retries forever', async () => {
+  tokenSequence = [null, null, null, null];
+  const token = await getSupabaseAccessTokenWithRetry({ attempts: 2, baseDelayMs: 0 });
+  expect(token).toBeNull();
+  expect(tokenCallCount).toBe(2);
+});
+
+test('defaults to a single attempt (no retry) when options are omitted', async () => {
+  tokenSequence = [null, 'tok'];
+  const token = await getSupabaseAccessTokenWithRetry();
+  expect(token).toBeNull();
+  expect(tokenCallCount).toBe(1);
+});
+
+test('getAuthTokenWithRetry delegates the same retry semantics', async () => {
+  tokenSequence = [null, 'tok-2'];
+  const token = await getAuthTokenWithRetry({ attempts: 2, baseDelayMs: 0 });
+  expect(token).toBe('tok-2');
+  expect(tokenCallCount).toBe(2);
+});
+
+// ── authenticatedFetch — default 30s timeout, EXCEPT for the SSE event stream
+// endpoint, and composed with any caller-supplied signal ────────────────────
+
+function captureFetch() {
+  const seen: { input: unknown; init?: RequestInit }[] = [];
+  globalThis.fetch = (async (input: unknown, init?: RequestInit) => {
+    seen.push({ input, init });
+    return new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } });
+  }) as unknown as typeof fetch;
+  return seen;
+}
+
+function signalOf(entry: { input: unknown; init?: RequestInit }): AbortSignal | undefined {
+  if (entry.init?.signal) return entry.init.signal;
+  return entry.input instanceof Request ? entry.input.signal : undefined;
+}
+
+test('applies a default (non-aborted) timeout signal to a non-streaming request', async () => {
+  tokenSequence = ['tok'];
+  const seen = captureFetch();
+
+  await authenticatedFetch('http://sbx.test/kortix/health');
+
+  const signal = signalOf(seen[0]);
+  expect(signal).toBeDefined();
+  expect(signal?.aborted).toBe(false);
+});
+
+test('does NOT impose a default timeout on the SSE event stream endpoint (/global/event)', async () => {
+  tokenSequence = ['tok'];
+  const seen = captureFetch();
+
+  await authenticatedFetch('http://sbx.test/global/event');
+
+  // No caller signal was supplied and this is the exempted streaming path —
+  // no timeout signal should have been synthesized/attached.
+  expect(seen[0].init?.signal).toBeUndefined();
+});
+
+test('composes a caller-supplied signal with the default timeout on a non-streaming request', async () => {
+  tokenSequence = ['tok'];
+  const seen = captureFetch();
+
+  const controller = new AbortController();
+  controller.abort();
+  await authenticatedFetch('http://sbx.test/kortix/health', { signal: controller.signal });
+
+  const signal = signalOf(seen[0]);
+  expect(signal?.aborted).toBe(true); // the already-aborted caller signal propagates through AbortSignal.any
+});
+
+test('preserves the caller-supplied signal as-is on the streaming endpoint (never overridden)', async () => {
+  tokenSequence = ['tok'];
+  const seen = captureFetch();
+
+  const controller = new AbortController();
+  await authenticatedFetch('http://sbx.test/global/event', { signal: controller.signal });
+
+  const signal = signalOf(seen[0]);
+  expect(signal).toBe(controller.signal);
+});
+
+test('returns a synthetic 401 (no network call) when getToken() resolves to null', async () => {
+  tokenSequence = [null];
+  const seen = captureFetch();
+
+  const res = await authenticatedFetch('http://sbx.test/kortix/health');
+
+  expect(res.status).toBe(401);
+  expect(seen.length).toBe(0);
+});

--- a/packages/sdk/src/platform/auth.test.ts
+++ b/packages/sdk/src/platform/auth.test.ts
@@ -1,128 +1,131 @@
-import { test, expect, beforeEach } from 'bun:test';
-import { configureKortix } from './config';
-import { authenticatedFetch, getSupabaseAccessTokenWithRetry, getAuthTokenWithRetry } from './auth';
+import { test, expect } from 'bun:test';
+import {
+	buildAuthHeaders,
+	isStreamingRequest,
+	syntheticUnauthenticatedResponse,
+	withDefaultTimeout,
+	withTokenRetry,
+} from './auth-core';
 
-// NOTE: unlike files/client.test.ts / opencode/client.test.ts / session/session.test.ts
-// (which each `mock.module('../platform/auth', ...)` to fully replace this module for
-// their own purposes), this file tests the REAL implementation directly — it must NOT
-// itself `mock.module` this path.
+// These tests deliberately target `auth-core.ts` — the pure implementation —
+// NOT `./auth`. Several suites in this package register process-wide
+// `mock.module('../platform/auth', …)` stubs, and Bun's `mock.module`
+// replaces the specifier for every importer for the remainder of the test
+// process, in whatever order the runner picks (which differs across Bun
+// versions — this bit us on CI while passing locally). `auth.ts` is a thin
+// delegating shell over these functions; nothing mocks `auth-core`, so the
+// semantics pinned here are always the real ones.
 
-let tokenCallCount = 0;
-let tokenSequence: Array<string | null> = [];
+// ── withTokenRetry — actually retries now (previously accepted attempts/
+// baseDelayMs/invalidateBetweenAttempts and silently ignored all three) ──────
 
-beforeEach(() => {
-  tokenCallCount = 0;
-  tokenSequence = [];
-  configureKortix({
-    backendUrl: 'http://backend.local/v1',
-    getToken: async () => {
-      const t = tokenSequence[Math.min(tokenCallCount, tokenSequence.length - 1)] ?? null;
-      tokenCallCount += 1;
-      return t;
-    },
-  });
-});
-
-// ── getSupabaseAccessTokenWithRetry / getAuthTokenWithRetry — actually retries
-// now (previously accepted attempts/baseDelayMs/invalidateBetweenAttempts and
-// silently ignored all three) ───────────────────────────────────────────────
+function sequenceGetter(sequence: Array<string | null>) {
+	let calls = 0;
+	const getToken = async () => {
+		const t = sequence[Math.min(calls, sequence.length - 1)] ?? null;
+		calls += 1;
+		return t;
+	};
+	return { getToken, callCount: () => calls };
+}
 
 test('retries until getToken() returns a truthy token, up to `attempts`', async () => {
-  tokenSequence = [null, null, 'tok-3'];
-  const token = await getSupabaseAccessTokenWithRetry({ attempts: 3, baseDelayMs: 0 });
-  expect(token).toBe('tok-3');
-  expect(tokenCallCount).toBe(3);
+	const { getToken, callCount } = sequenceGetter([null, null, 'tok-3']);
+	const token = await withTokenRetry(getToken, { attempts: 3, baseDelayMs: 0 });
+	expect(token).toBe('tok-3');
+	expect(callCount()).toBe(3);
 });
 
 test('gives up after `attempts` and returns the last (falsy) result — never retries forever', async () => {
-  tokenSequence = [null, null, null, null];
-  const token = await getSupabaseAccessTokenWithRetry({ attempts: 2, baseDelayMs: 0 });
-  expect(token).toBeNull();
-  expect(tokenCallCount).toBe(2);
+	const { getToken, callCount } = sequenceGetter([null, null, null, null]);
+	const token = await withTokenRetry(getToken, { attempts: 2, baseDelayMs: 0 });
+	expect(token).toBeNull();
+	expect(callCount()).toBe(2);
 });
 
 test('defaults to a single attempt (no retry) when options are omitted', async () => {
-  tokenSequence = [null, 'tok'];
-  const token = await getSupabaseAccessTokenWithRetry();
-  expect(token).toBeNull();
-  expect(tokenCallCount).toBe(1);
+	const { getToken, callCount } = sequenceGetter([null, 'tok']);
+	const token = await withTokenRetry(getToken);
+	expect(token).toBeNull();
+	expect(callCount()).toBe(1);
 });
 
-test('getAuthTokenWithRetry delegates the same retry semantics', async () => {
-  tokenSequence = [null, 'tok-2'];
-  const token = await getAuthTokenWithRetry({ attempts: 2, baseDelayMs: 0 });
-  expect(token).toBe('tok-2');
-  expect(tokenCallCount).toBe(2);
+test('invalidateBetweenAttempts fires the invalidation hook before each RETRY (not the first attempt)', async () => {
+	let invalidations = 0;
+	const { getToken } = sequenceGetter([null, null, 'tok']);
+	const token = await withTokenRetry(
+		getToken,
+		{ attempts: 3, baseDelayMs: 0, invalidateBetweenAttempts: true },
+		() => {
+			invalidations += 1;
+		},
+	);
+	expect(token).toBe('tok');
+	expect(invalidations).toBe(2);
 });
 
-// ── authenticatedFetch — default 30s timeout, EXCEPT for the SSE event stream
-// endpoint, and composed with any caller-supplied signal ────────────────────
+// ── withDefaultTimeout — default 30s timeout, EXCEPT for the SSE event stream
+// endpoint, composed with any caller-supplied signal ─────────────────────────
 
-function captureFetch() {
-  const seen: { input: unknown; init?: RequestInit }[] = [];
-  globalThis.fetch = (async (input: unknown, init?: RequestInit) => {
-    seen.push({ input, init });
-    return new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } });
-  }) as unknown as typeof fetch;
-  return seen;
-}
-
-function signalOf(entry: { input: unknown; init?: RequestInit }): AbortSignal | undefined {
-  if (entry.init?.signal) return entry.init.signal;
-  return entry.input instanceof Request ? entry.input.signal : undefined;
-}
-
-test('applies a default (non-aborted) timeout signal to a non-streaming request', async () => {
-  tokenSequence = ['tok'];
-  const seen = captureFetch();
-
-  await authenticatedFetch('http://sbx.test/kortix/health');
-
-  const signal = signalOf(seen[0]);
-  expect(signal).toBeDefined();
-  expect(signal?.aborted).toBe(false);
+test('applies a default (non-aborted) timeout signal to a non-streaming request', () => {
+	const signal = withDefaultTimeout('http://sbx.test/kortix/health', undefined);
+	expect(signal).toBeDefined();
+	expect(signal?.aborted).toBe(false);
 });
 
-test('does NOT impose a default timeout on the SSE event stream endpoint (/global/event)', async () => {
-  tokenSequence = ['tok'];
-  const seen = captureFetch();
-
-  await authenticatedFetch('http://sbx.test/global/event');
-
-  // No caller signal was supplied and this is the exempted streaming path —
-  // no timeout signal should have been synthesized/attached.
-  expect(seen[0].init?.signal).toBeUndefined();
+test('does NOT impose a default timeout on the SSE event stream endpoint (/global/event)', () => {
+	expect(isStreamingRequest('http://sbx.test/global/event')).toBe(true);
+	const signal = withDefaultTimeout('http://sbx.test/global/event', undefined);
+	// No caller signal was supplied and this is the exempted streaming path —
+	// no timeout signal should be synthesized.
+	expect(signal).toBeUndefined();
 });
 
-test('composes a caller-supplied signal with the default timeout on a non-streaming request', async () => {
-  tokenSequence = ['tok'];
-  const seen = captureFetch();
-
-  const controller = new AbortController();
-  controller.abort();
-  await authenticatedFetch('http://sbx.test/kortix/health', { signal: controller.signal });
-
-  const signal = signalOf(seen[0]);
-  expect(signal?.aborted).toBe(true); // the already-aborted caller signal propagates through AbortSignal.any
+test('composes a caller-supplied signal with the default timeout on a non-streaming request', () => {
+	const controller = new AbortController();
+	controller.abort();
+	const signal = withDefaultTimeout('http://sbx.test/kortix/health', {
+		signal: controller.signal,
+	});
+	// The already-aborted caller signal propagates through AbortSignal.any.
+	expect(signal?.aborted).toBe(true);
 });
 
-test('preserves the caller-supplied signal as-is on the streaming endpoint (never overridden)', async () => {
-  tokenSequence = ['tok'];
-  const seen = captureFetch();
-
-  const controller = new AbortController();
-  await authenticatedFetch('http://sbx.test/global/event', { signal: controller.signal });
-
-  const signal = signalOf(seen[0]);
-  expect(signal).toBe(controller.signal);
+test('preserves the caller-supplied signal as-is on the streaming endpoint (never overridden)', () => {
+	const controller = new AbortController();
+	const signal = withDefaultTimeout('http://sbx.test/global/event', {
+		signal: controller.signal,
+	});
+	expect(signal).toBe(controller.signal);
 });
 
-test('returns a synthetic 401 (no network call) when getToken() resolves to null', async () => {
-  tokenSequence = [null];
-  const seen = captureFetch();
+test('a Request input carries its own signal through the streaming exemption', () => {
+	const controller = new AbortController();
+	const req = new Request('http://sbx.test/global/event', { signal: controller.signal });
+	const signal = withDefaultTimeout(req, undefined);
+	// A Request always carries a signal (the caller's, here) — it must pass
+	// through untouched on the exempted path.
+	expect(signal?.aborted).toBe(false);
+	controller.abort();
+	expect(signal?.aborted).toBe(true);
+});
 
-  const res = await authenticatedFetch('http://sbx.test/kortix/health');
+// ── buildAuthHeaders / syntheticUnauthenticatedResponse ─────────────────────
 
-  expect(res.status).toBe(401);
-  expect(seen.length).toBe(0);
+test('buildAuthHeaders injects the Bearer token without clobbering an existing Authorization', () => {
+	const injected = buildAuthHeaders('http://x.test/', undefined, 'tok');
+	expect(injected.get('Authorization')).toBe('Bearer tok');
+
+	const preset = buildAuthHeaders(
+		'http://x.test/',
+		{ headers: { Authorization: 'Bearer mine' } },
+		'tok',
+	);
+	expect(preset.get('Authorization')).toBe('Bearer mine');
+});
+
+test('the synthetic 401 is a JSON fetch-semantics Response (no network call implied)', async () => {
+	const res = syntheticUnauthenticatedResponse();
+	expect(res.status).toBe(401);
+	expect(await res.json()).toEqual({ error: 'Not authenticated' });
 });

--- a/packages/sdk/src/platform/auth.ts
+++ b/packages/sdk/src/platform/auth.ts
@@ -1,44 +1,45 @@
 /**
  * Shared auth token helpers.
  *
- * Provides Supabase JWT authentication for all requests.
+ * Every function below is a thin delegate to `platformConfig().getToken()` —
+ * the SDK holds no token state of its own. Token acquisition (Supabase
+ * getSession/refreshSession or any other provider), caching, deduplicating
+ * concurrent callers (SSE, health check, session fetch, etc. all racing for a
+ * token on page load), and the install/bootstrap seam are entirely the host
+ * app's responsibility, implemented inside the `getToken` it passes to
+ * `configureKortix`/`createKortix`. A host that wants the old 30s-TTL +
+ * inflight-dedup behavior re-implements it in its own `getToken`; the SDK
+ * itself does not cache, dedupe, or retry beyond calling `getToken()` again.
  *
- * `getAuthToken()` is the unified getter: returns the Supabase JWT.
- * Use it anywhere you need to authenticate against the sandbox proxy.
+ * `getAuthToken()` is the unified getter: returns whatever token the host's
+ * `getToken()` resolves. `getSupabaseAccessToken()` is kept as an alias for
+ * callers that historically asked for "the Supabase token" specifically —
+ * same delegate, same value.
  *
- * `getSupabaseAccessToken()` is kept for callers that specifically need the
- * Supabase JWT (e.g. platform API calls that go through Supabase auth).
- *
- * **Deduplication**: Multiple callers (SSE, health check, session fetch, etc.)
- * all call getSupabaseAccessToken() on page load simultaneously. Without
- * deduplication, each triggers its own getSession() → refreshSession() chain,
- * causing 5+ parallel Supabase auth roundtrips that take seconds. The inflight
- * promise ensures only ONE auth call runs at a time; all others piggyback.
- *
- * **Caching**: The resolved token is cached for TOKEN_CACHE_TTL (30s). Within
- * that window, subsequent calls return instantly. After TTL, the next call
- * refreshes from Supabase.
- *
- * SDK port: token acquisition (Supabase getSession/refreshSession), the 30s
- * token cache, the inflight dedup, and the install/bootstrap seam are all owned
- * by the host app and injected via `platformConfig().getToken()`. The exported
- * function names below are preserved verbatim so callers don't break.
+ * `invalidateTokenCache()` / `setCachedAuthToken()` / `setBootstrapAuthToken()`
+ * are no-ops here (there is no SDK-side cache to invalidate or seed); they're
+ * kept as exported names so existing call sites compile unchanged, and a host
+ * that layers its own caching on top of `getToken()` can wire these to that
+ * cache if it wants the "invalidate on 401" / "seed before hydration" hooks to
+ * do something.
  */
 
 import { platformConfig } from './config';
 
 /**
- * Get the current Supabase access token with caching + deduplication.
- *
- * Fast path: returns cached token if within TTL.
- * Slow path: deduplicates concurrent calls into a single auth roundtrip.
+ * Get the current auth token. Delegates directly to `platformConfig().getToken()`
+ * — any caching/deduplication the host wants happens inside that function.
  */
 export async function getSupabaseAccessToken(): Promise<string | null> {
 	return platformConfig().getToken();
 }
 
 /**
- * Retry token acquisition for initial auth hydration / stale cache recovery.
+ * Retry variant, kept for call-site compatibility. `options` (attempts/
+ * backoff/cache-invalidation) are accepted but unused — there is no SDK-side
+ * retry loop or cache here to apply them to; this just delegates to
+ * `platformConfig().getToken()` like every other getter in this file. A host
+ * that needs retry/backoff semantics implements them inside its `getToken`.
  */
 export async function getSupabaseAccessTokenWithRetry(options?: {
 	attempts?: number;

--- a/packages/sdk/src/platform/auth.ts
+++ b/packages/sdk/src/platform/auth.ts
@@ -24,6 +24,13 @@
  * do something.
  */
 
+import {
+	buildAuthHeaders,
+	syntheticUnauthenticatedResponse,
+	withDefaultTimeout,
+	withTokenRetry,
+	type TokenRetryOptions,
+} from './auth-core';
 import { platformConfig } from './config';
 
 /**
@@ -32,10 +39,6 @@ import { platformConfig } from './config';
  */
 export async function getSupabaseAccessToken(): Promise<string | null> {
 	return platformConfig().getToken();
-}
-
-function delay(ms: number): Promise<void> {
-	return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 /**
@@ -54,25 +57,12 @@ function delay(ms: number): Promise<void> {
  * wires `invalidateTokenCache`/`setCachedAuthToken` to it, per this file's
  * top-of-file doc comment) gets invalidated between attempts as intended.
  */
-export async function getSupabaseAccessTokenWithRetry(options?: {
-	attempts?: number;
-	baseDelayMs?: number;
-	invalidateBetweenAttempts?: boolean;
-}): Promise<string | null> {
-	const attempts = Math.max(1, options?.attempts ?? 1);
-	const baseDelayMs = options?.baseDelayMs ?? 0;
-	const invalidateBetweenAttempts = options?.invalidateBetweenAttempts ?? false;
-
-	let token: string | null = null;
-	for (let attempt = 0; attempt < attempts; attempt++) {
-		if (attempt > 0) {
-			if (invalidateBetweenAttempts) invalidateTokenCache();
-			if (baseDelayMs > 0) await delay(baseDelayMs);
-		}
-		token = await platformConfig().getToken();
-		if (token) return token;
-	}
-	return token;
+export async function getSupabaseAccessTokenWithRetry(
+	options?: TokenRetryOptions,
+): Promise<string | null> {
+	// The retry loop itself lives in `auth-core.ts` (pure, un-mockable in
+	// tests) — this delegate just binds it to the live platform config.
+	return withTokenRetry(() => platformConfig().getToken(), options, invalidateTokenCache);
 }
 
 /**
@@ -108,11 +98,9 @@ export async function getAuthToken(): Promise<string | null> {
   return getSupabaseAccessToken();
 }
 
-export async function getAuthTokenWithRetry(options?: {
-	attempts?: number;
-	baseDelayMs?: number;
-	invalidateBetweenAttempts?: boolean;
-}): Promise<string | null> {
+export async function getAuthTokenWithRetry(
+	options?: TokenRetryOptions,
+): Promise<string | null> {
 	return getSupabaseAccessTokenWithRetry(options);
 }
 
@@ -145,64 +133,9 @@ function fetchWithAuth(
   return fetch(input, { ...init, headers, ...(signal ? { signal } : {}) });
 }
 
-const DEFAULT_FETCH_TIMEOUT_MS = 30_000;
-
-/**
- * The one long-lived streaming call reached through this fetch injection
- * point — `openEventStream` (`state/event-stream.ts`) drives the opencode
- * client's `global.event(...)` SSE endpoint, which hits `GET {runtimeUrl}/global/event`.
- * It manages its own lifecycle (a 15s heartbeat watchdog + explicit
- * abort/reconnect loop) and is meant to stay open far longer than any request
- * timeout — `withDefaultTimeout` exempts it below so a blanket timeout doesn't
- * tear the stream down every 30s.
- */
-function isStreamingRequest(input: RequestInfo | URL): boolean {
-  const url = input instanceof Request ? input.url : String(input);
-  return url.includes('/global/event');
-}
-
-/**
- * Compose the request's own abort signal — a `Request` always carries one
- * (the caller's real signal, or a spec-default one that never fires) — with a
- * default 30s timeout, so a hung non-streaming call can't wedge a "Kortix as
- * a Backend" server-side handler forever. The SSE event stream is exempted
- * (see `isStreamingRequest`). Falls back to the caller's bare signal on a
- * runtime without `AbortSignal.any` (older Node/engines) — guarded so a
- * caller-supplied signal is never silently dropped.
- */
-function withDefaultTimeout(input: RequestInfo | URL, init: RequestInit | undefined): AbortSignal | undefined {
-  const callerSignal = input instanceof Request ? input.signal : init?.signal;
-  if (isStreamingRequest(input)) return callerSignal ?? undefined;
-
-  const timeoutSignal = AbortSignal.timeout(DEFAULT_FETCH_TIMEOUT_MS);
-  if (!callerSignal) return timeoutSignal;
-  if (typeof AbortSignal.any === 'function') {
-    return AbortSignal.any([callerSignal, timeoutSignal]);
-  }
-  return callerSignal;
-}
-
-/**
- * Build a Headers object from request input + init, injecting the auth token.
- */
-function buildAuthHeaders(
-  input: RequestInfo | URL,
-  init?: RequestInit,
-  token?: string | null,
-): Headers {
-  const headers = new Headers(
-    input instanceof Request ? input.headers : undefined,
-  );
-  if (init?.headers) {
-    new Headers(init.headers).forEach((value, key) => {
-      headers.set(key, value);
-    });
-  }
-  if (token && !headers.has('Authorization')) {
-    headers.set('Authorization', `Bearer ${token}`);
-  }
-  return headers;
-}
+// Timeout composition, streaming exemption, and header building live in
+// `auth-core.ts` (pure + directly unit-tested there); this file wires them to
+// the live token seam.
 
 /**
  * Shared authenticated fetch — injects auth tokens and handles 401 responses.
@@ -233,10 +166,7 @@ export async function authenticatedFetch(
   // naked request. Safe for all callers including the OpenCode SDK which
   // expects fetch() semantics (returns Response, never throws).
   if (!token) {
-    return new Response(JSON.stringify({ error: 'Not authenticated' }), {
-      status: 401,
-      headers: { 'Content-Type': 'application/json' },
-    });
+    return syntheticUnauthenticatedResponse();
   }
 
   const headers = buildAuthHeaders(input, init, token);

--- a/packages/sdk/src/platform/auth.ts
+++ b/packages/sdk/src/platform/auth.ts
@@ -34,19 +34,45 @@ export async function getSupabaseAccessToken(): Promise<string | null> {
 	return platformConfig().getToken();
 }
 
+function delay(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 /**
- * Retry variant, kept for call-site compatibility. `options` (attempts/
- * backoff/cache-invalidation) are accepted but unused — there is no SDK-side
- * retry loop or cache here to apply them to; this just delegates to
- * `platformConfig().getToken()` like every other getter in this file. A host
- * that needs retry/backoff semantics implements them inside its `getToken`.
+ * Retry variant — actually retries now. Previously accepted `attempts`/
+ * `baseDelayMs`/`invalidateBetweenAttempts` and silently ignored all three
+ * (always a single `getToken()` call), which quietly broke every caller that
+ * depended on retry semantics around a flaky/cold token provider (e.g. right
+ * after sign-in, before a host's own session has hydrated — see the retry
+ * call in `authenticatedFetch`'s 401 handler below).
+ *
+ * Retries up to `attempts` times (default 1 = no retry) until `getToken()`
+ * returns a truthy token, waiting `baseDelayMs` between attempts (default 0).
+ * When `invalidateBetweenAttempts` is set, calls `invalidateTokenCache()`
+ * before each retry — a no-op in this file (there's no SDK-side cache), but
+ * kept as a real call so a host that layers its own cache on `getToken()` (and
+ * wires `invalidateTokenCache`/`setCachedAuthToken` to it, per this file's
+ * top-of-file doc comment) gets invalidated between attempts as intended.
  */
 export async function getSupabaseAccessTokenWithRetry(options?: {
 	attempts?: number;
 	baseDelayMs?: number;
 	invalidateBetweenAttempts?: boolean;
 }): Promise<string | null> {
-	return platformConfig().getToken();
+	const attempts = Math.max(1, options?.attempts ?? 1);
+	const baseDelayMs = options?.baseDelayMs ?? 0;
+	const invalidateBetweenAttempts = options?.invalidateBetweenAttempts ?? false;
+
+	let token: string | null = null;
+	for (let attempt = 0; attempt < attempts; attempt++) {
+		if (attempt > 0) {
+			if (invalidateBetweenAttempts) invalidateTokenCache();
+			if (baseDelayMs > 0) await delay(baseDelayMs);
+		}
+		token = await platformConfig().getToken();
+		if (token) return token;
+	}
+	return token;
 }
 
 /**
@@ -104,6 +130,7 @@ function fetchWithAuth(
   input: RequestInfo | URL,
   init: RequestInit | undefined,
   headers: Headers,
+  signal?: AbortSignal,
 ): Promise<Response> {
   if (input instanceof Request) {
     // Clone the Request with our auth headers baked in.
@@ -111,10 +138,48 @@ function fetchWithAuth(
     // not relying on fetch's init-merge behavior.
     const authedRequest = new Request(input, {
       headers,
+      ...(signal ? { signal } : {}),
     });
     return fetch(authedRequest);
   }
-  return fetch(input, { ...init, headers });
+  return fetch(input, { ...init, headers, ...(signal ? { signal } : {}) });
+}
+
+const DEFAULT_FETCH_TIMEOUT_MS = 30_000;
+
+/**
+ * The one long-lived streaming call reached through this fetch injection
+ * point — `openEventStream` (`state/event-stream.ts`) drives the opencode
+ * client's `global.event(...)` SSE endpoint, which hits `GET {runtimeUrl}/global/event`.
+ * It manages its own lifecycle (a 15s heartbeat watchdog + explicit
+ * abort/reconnect loop) and is meant to stay open far longer than any request
+ * timeout — `withDefaultTimeout` exempts it below so a blanket timeout doesn't
+ * tear the stream down every 30s.
+ */
+function isStreamingRequest(input: RequestInfo | URL): boolean {
+  const url = input instanceof Request ? input.url : String(input);
+  return url.includes('/global/event');
+}
+
+/**
+ * Compose the request's own abort signal — a `Request` always carries one
+ * (the caller's real signal, or a spec-default one that never fires) — with a
+ * default 30s timeout, so a hung non-streaming call can't wedge a "Kortix as
+ * a Backend" server-side handler forever. The SSE event stream is exempted
+ * (see `isStreamingRequest`). Falls back to the caller's bare signal on a
+ * runtime without `AbortSignal.any` (older Node/engines) — guarded so a
+ * caller-supplied signal is never silently dropped.
+ */
+function withDefaultTimeout(input: RequestInfo | URL, init: RequestInit | undefined): AbortSignal | undefined {
+  const callerSignal = input instanceof Request ? input.signal : init?.signal;
+  if (isStreamingRequest(input)) return callerSignal ?? undefined;
+
+  const timeoutSignal = AbortSignal.timeout(DEFAULT_FETCH_TIMEOUT_MS);
+  if (!callerSignal) return timeoutSignal;
+  if (typeof AbortSignal.any === 'function') {
+    return AbortSignal.any([callerSignal, timeoutSignal]);
+  }
+  return callerSignal;
 }
 
 /**
@@ -175,6 +240,10 @@ export async function authenticatedFetch(
   }
 
   const headers = buildAuthHeaders(input, init, token);
+  // 30s default timeout for everything EXCEPT the long-lived SSE event
+  // stream (see `withDefaultTimeout`) — a "Kortix as a Backend" wrapper must
+  // never have a hung sandbox/daemon request wedge its handler forever.
+  const signal = withDefaultTimeout(input, init);
 
   // When the OpenCode SDK passes a Request object (single arg, no init),
   // we must construct a new Request with the auth headers baked in.
@@ -182,7 +251,7 @@ export async function authenticatedFetch(
   // in production builds — Next.js's patched fetch and certain browser
   // implementations don't properly merge init.headers onto an existing
   // Request, causing the Authorization header to be silently dropped.
-  const response = await fetchWithAuth(input, init, headers);
+  const response = await fetchWithAuth(input, init, headers, signal);
 
   if (response.status === 401) {
     // The cached token is stale. Retry once with fresh token.
@@ -191,7 +260,7 @@ export async function authenticatedFetch(
       const newToken = await getAuthTokenWithRetry({ attempts: 2, baseDelayMs: 200 });
       if (newToken && newToken !== token) {
         const retryHeaders = buildAuthHeaders(input, init, newToken);
-        return fetchWithAuth(input, init, retryHeaders);
+        return fetchWithAuth(input, init, retryHeaders, signal);
       }
     }
   }

--- a/packages/sdk/src/platform/config-node.ts
+++ b/packages/sdk/src/platform/config-node.ts
@@ -1,0 +1,69 @@
+/**
+ * Node-only `AsyncLocalStorage` layer for per-request platform-config
+ * isolation. Reachable ONLY through the `@kortix/sdk/server` subpath — never
+ * imported by the root `@kortix/sdk` entry point, `@kortix/sdk/react`, or any
+ * other browser-safe subpath — so `node:async_hooks` never enters a browser
+ * bundle's module graph. If this file's static `import` ever gets pulled into
+ * an isomorphic/browser-facing subpath, that's a bug: keep it behind
+ * `@kortix/sdk/server`.
+ *
+ * This is the fix for the SDK's single biggest concurrency hazard: the
+ * `configureKortix()` seam (`./config.ts`) stores the platform config in a
+ * process-wide module-global. A "Kortix as a Backend" server — any Node/Bun
+ * process fronting Kortix on behalf of multiple end users/requests
+ * concurrently — can't safely call `configureKortix()` once per request: two
+ * in-flight requests with different tokens race on the same global and the
+ * second write wins for both. `runWithKortix` fixes that by threading the
+ * config through Node's `AsyncLocalStorage`, which — unlike a plain variable —
+ * stays correctly scoped to one call's entire async continuation (every
+ * `await` inside it) while remaining isolated from any other concurrent call
+ * in the same process.
+ */
+import { AsyncLocalStorage } from 'node:async_hooks';
+import { __setConfigResolver, type KortixPlatformConfig } from './config';
+
+const als = new AsyncLocalStorage<KortixPlatformConfig>();
+__setConfigResolver(() => als.getStore());
+
+/**
+ * Run `fn` (or any synchronous callback) with `config` as the platform config
+ * for its entire call tree — every `platformConfig()` read reached from
+ * inside it (facade calls, `backendApi`, `authenticatedFetch`, the files
+ * client, event streams, …) sees THIS config, including across `await`s,
+ * isolated from any other concurrent `runScoped`/`runWithKortix` call.
+ *
+ * Internal primitive: preserves whatever `fn` returns (sync value or Promise)
+ * without coercing it, so `@kortix/sdk/server`'s `createScopedKortix` can wrap
+ * both sync (`setModel`) and async (`ensureReady`) facade methods uniformly.
+ */
+export function runScoped<T>(config: KortixPlatformConfig, fn: () => T): T {
+  return als.run(config, fn);
+}
+
+/**
+ * Run `fn` with `config` as the platform config for its entire async call
+ * tree (see `runScoped`). This is the public primitive re-exported from
+ * `@kortix/sdk/server` — use it to wrap one incoming request's handler body
+ * when you're not using the `createScopedKortix` facade wrapper.
+ *
+ *   import { runWithKortix } from '@kortix/sdk/server';
+ *
+ *   app.use(async (req, res, next) => {
+ *     await runWithKortix({ backendUrl, getToken: () => resolveTokenFor(req) }, async () => {
+ *       // every Kortix call made anywhere in this request's async chain
+ *       // (including inside `next()`) sees THIS request's config.
+ *       await next();
+ *     });
+ *   });
+ */
+export async function runWithKortix<T>(
+  config: KortixPlatformConfig,
+  fn: () => Promise<T>,
+): Promise<T> {
+  return runScoped(config, fn);
+}
+
+/** The config active on the current async context, if any (for diagnostics/tests). */
+export function getScopedConfig(): KortixPlatformConfig | undefined {
+  return als.getStore();
+}

--- a/packages/sdk/src/platform/config.test.ts
+++ b/packages/sdk/src/platform/config.test.ts
@@ -1,0 +1,51 @@
+import { test, expect, beforeEach, afterEach } from 'bun:test';
+import {
+  configureKortix,
+  platformConfig,
+  isConfigured,
+  __setConfigResolver,
+  __getConfigResolver,
+} from './config';
+
+// This file deliberately never imports `./config-node` (the `@kortix/sdk/server`
+// AsyncLocalStorage layer) — it exercises the plain browser/single-config path
+// that every host without a registered resolver still gets: `platformConfig()`
+// falls back to the process-global `current` set by `configureKortix()`, exactly
+// as before the per-request isolation layer existed.
+//
+// `bun test src` runs every test file in one process, sharing `config.ts`'s
+// module state — if some OTHER file in the same run imports `config-node.ts`
+// (registering the real AsyncLocalStorage resolver as an import-time side
+// effect), that registration is process-global too. Save + restore whatever
+// resolver was active before each test here, so this file's "no resolver"
+// experiments never permanently clobber another file's registration.
+let savedResolver: ReturnType<typeof __getConfigResolver>;
+beforeEach(() => {
+  savedResolver = __getConfigResolver();
+  __setConfigResolver(null);
+});
+afterEach(() => {
+  __setConfigResolver(savedResolver);
+});
+
+test('with no resolver registered, platformConfig() reads the process-global set by configureKortix()', () => {
+  configureKortix({ backendUrl: 'http://global.local', getToken: async () => 'global-tok' });
+  expect(platformConfig().backendUrl).toBe('http://global.local');
+  expect(isConfigured()).toBe(true);
+});
+
+test('configureKortix(config, { global: false }) does not touch the process-global config', () => {
+  configureKortix({ backendUrl: 'http://one.local', getToken: async () => 'one' });
+  configureKortix({ backendUrl: 'http://two.local', getToken: async () => 'two' }, { global: false });
+  // The second call was global:false — the global config must still be the first one.
+  expect(platformConfig().backendUrl).toBe('http://one.local');
+});
+
+test('a registered resolver takes priority over the process-global config', () => {
+  configureKortix({ backendUrl: 'http://global.local', getToken: async () => 'global-tok' });
+  __setConfigResolver(() => ({ backendUrl: 'http://scoped.local', getToken: async () => 'scoped-tok' }));
+  expect(platformConfig().backendUrl).toBe('http://scoped.local');
+
+  __setConfigResolver(() => undefined);
+  expect(platformConfig().backendUrl).toBe('http://global.local');
+});

--- a/packages/sdk/src/platform/config.ts
+++ b/packages/sdk/src/platform/config.ts
@@ -52,14 +52,58 @@ const DEFAULT: KortixPlatformConfig = {
 
 let current: KortixPlatformConfig | null = null;
 
-export function configureKortix(config: KortixPlatformConfig): void {
+/**
+ * Per-request override hook, registered ONLY by `@kortix/sdk/server`'s
+ * Node-only `AsyncLocalStorage` layer (`config-node.ts`) — see `runWithKortix`/
+ * `createScopedKortix` there. A browser bundle never imports that subpath, so
+ * this stays `null` for it and `platformConfig()` behaves exactly as before
+ * (reads the process-global `current`). Not part of the public API — do not
+ * call `__setConfigResolver` directly; use `runWithKortix`/`createScopedKortix`.
+ */
+let configResolver: (() => KortixPlatformConfig | undefined) | null = null;
+
+/** @internal Registration seam for `@kortix/sdk/server`. Not for host use. */
+export function __setConfigResolver(fn: (() => KortixPlatformConfig | undefined) | null): void {
+  configResolver = fn;
+}
+
+/** @internal Test-only introspection, so a test file that flips the resolver
+ *  (e.g. to exercise the no-resolver fallback path) can snapshot + restore
+ *  whatever was registered before it, instead of clobbering a resolver another
+ *  test file registered in the same process (bun runs all `src/**\/*.test.ts`
+ *  files in one process, sharing this module's state). */
+export function __getConfigResolver(): (() => KortixPlatformConfig | undefined) | null {
+  return configResolver;
+}
+
+/**
+ * Wire the platform seam. `current` is a process-wide singleton — safe for a
+ * host with exactly one config for its whole lifetime (a browser tab, a CLI,
+ * a single-tenant server), but UNSAFE for a server process that must serve
+ * concurrent requests carrying different tokens (see the warning on
+ * `ServerTokenOptions` in `projects-client/shared.ts`): the last caller to
+ * `configureKortix()`/`createKortix()` wins for every other in-flight request.
+ * For that "Kortix as a Backend" shape, use `runWithKortix`/`createScopedKortix`
+ * from `@kortix/sdk/server` instead — they isolate each call's config in a
+ * Node `AsyncLocalStorage` context instead of this shared global.
+ *
+ * `opts.global === false` (used internally by `createScopedKortix`) skips the
+ * global write entirely, so a scoped client never touches/clobbers `current`.
+ */
+export function configureKortix(config: KortixPlatformConfig, opts?: { global?: boolean }): void {
+  if (opts?.global === false) return;
   current = config;
 }
 
+/**
+ * The platform config in effect for THIS call: an active `runWithKortix`/
+ * `createScopedKortix` scope if one is on the current async context, else the
+ * process-global `current` set by `configureKortix()`, else the inert default.
+ */
 export function platformConfig(): KortixPlatformConfig {
-  return current ?? DEFAULT;
+  return configResolver?.() ?? current ?? DEFAULT;
 }
 
 export function isConfigured(): boolean {
-  return current !== null;
+  return current !== null || configResolver?.() !== undefined;
 }

--- a/packages/sdk/src/platform/instance-routes.test.ts
+++ b/packages/sdk/src/platform/instance-routes.test.ts
@@ -1,0 +1,176 @@
+import { test, expect } from 'bun:test';
+import {
+  ACTIVE_INSTANCE_COOKIE,
+  buildInstancePath,
+  extractInstanceRoute,
+  getActiveInstanceIdFromCookie,
+  getCurrentInstanceIdFromPathname,
+  getCurrentInstanceIdFromWindow,
+  isInstanceDetailPath,
+  isInstanceScopedAppPath,
+  normalizeAppPathname,
+  setActiveInstanceCookie,
+  stripInstancePrefix,
+  toInstanceAwarePath,
+} from './instance-routes';
+
+// This whole file runs with no `window`/`document` global (bun test has no DOM
+// by default — confirmed: `typeof window` is 'undefined' here). That's exactly
+// the "non-browser branch" this task wants exercised for the guarded functions
+// below: each one checks `typeof window/document === 'undefined'` and must
+// degrade to a safe no-op/null instead of throwing ReferenceError.
+
+test('ACTIVE_INSTANCE_COOKIE is the stable cookie name', () => {
+  expect(ACTIVE_INSTANCE_COOKIE).toBe('kortix-active-instance');
+});
+
+// ── isInstanceScopedAppPath ────────────────────────────────────────────────
+
+test('isInstanceScopedAppPath matches an exact route and any nested sub-path', () => {
+  expect(isInstanceScopedAppPath('/dashboard')).toBe(true);
+  expect(isInstanceScopedAppPath('/dashboard/foo')).toBe(true);
+  expect(isInstanceScopedAppPath('/sessions/abc123')).toBe(true);
+});
+
+test('isInstanceScopedAppPath rejects unrelated paths and near-misses', () => {
+  expect(isInstanceScopedAppPath('/login')).toBe(false);
+  expect(isInstanceScopedAppPath('/dashboards')).toBe(false); // prefix, not a route boundary
+  expect(isInstanceScopedAppPath('/')).toBe(false);
+});
+
+// ── extractInstanceRoute ────────────────────────────────────────────────────
+
+test('extractInstanceRoute parses an instance id with a nested inner path', () => {
+  expect(extractInstanceRoute('/instances/inst-1/sessions/s1')).toEqual({
+    instanceId: 'inst-1',
+    innerPath: '/sessions/s1',
+  });
+});
+
+test('extractInstanceRoute parses a bare instance id with no inner path', () => {
+  expect(extractInstanceRoute('/instances/inst-1')).toEqual({
+    instanceId: 'inst-1',
+    innerPath: '',
+  });
+});
+
+test('extractInstanceRoute URL-decodes the instance id', () => {
+  expect(extractInstanceRoute('/instances/inst%20one/x')?.instanceId).toBe('inst one');
+});
+
+test('extractInstanceRoute returns null for a non-instance path', () => {
+  expect(extractInstanceRoute('/dashboard')).toBeNull();
+});
+
+// ── isInstanceDetailPath ─────────────────────────────────────────────────────
+
+test('isInstanceDetailPath is true only for the bare /instances/<id> path', () => {
+  expect(isInstanceDetailPath('/instances/inst-1')).toBe(true);
+  expect(isInstanceDetailPath('/instances/inst-1/sessions/s1')).toBe(false);
+  expect(isInstanceDetailPath('/dashboard')).toBe(false);
+});
+
+// ── stripInstancePrefix ──────────────────────────────────────────────────────
+
+test('stripInstancePrefix strips the /instances/<id> prefix, keeping the inner path', () => {
+  expect(stripInstancePrefix('/instances/inst-1/sessions/s1')).toBe('/sessions/s1');
+});
+
+test('stripInstancePrefix leaves a non-instance path untouched', () => {
+  expect(stripInstancePrefix('/dashboard')).toBe('/dashboard');
+});
+
+test('stripInstancePrefix leaves a bare instance-detail path (no inner path) untouched', () => {
+  expect(stripInstancePrefix('/instances/inst-1')).toBe('/instances/inst-1');
+});
+
+// ── buildInstancePath ────────────────────────────────────────────────────────
+
+test('buildInstancePath prefixes an instance-scoped path with /instances/<id>', () => {
+  expect(buildInstancePath('inst-1', '/dashboard')).toBe('/instances/inst-1/dashboard');
+});
+
+test('buildInstancePath URL-encodes the instance id', () => {
+  expect(buildInstancePath('inst one', '/dashboard')).toBe('/instances/inst%20one/dashboard');
+});
+
+test('buildInstancePath normalizes a pathname missing its leading slash', () => {
+  expect(buildInstancePath('inst-1', 'dashboard')).toBe('/instances/inst-1/dashboard');
+});
+
+test('buildInstancePath leaves a non-scoped path untouched', () => {
+  expect(buildInstancePath('inst-1', '/login')).toBe('/login');
+});
+
+test('buildInstancePath returns the pathname unchanged when instanceId is empty', () => {
+  expect(buildInstancePath('', '/dashboard')).toBe('/dashboard');
+});
+
+test('buildInstancePath re-targets an already-instance-prefixed path at the new instance id', () => {
+  expect(buildInstancePath('inst-2', '/instances/inst-1/sessions/s1')).toBe('/instances/inst-2/sessions/s1');
+});
+
+test('buildInstancePath returns an already-instance-prefixed path unchanged if it fails to parse', () => {
+  // extractInstanceRoute requires at least a non-empty id segment; an
+  // /instances/ path with nothing after it doesn't match the regex.
+  expect(buildInstancePath('inst-2', '/instances/')).toBe('/instances/');
+});
+
+// ── getCurrentInstanceIdFromPathname ────────────────────────────────────────
+
+test('getCurrentInstanceIdFromPathname extracts the id from an instance path', () => {
+  expect(getCurrentInstanceIdFromPathname('/instances/inst-1/dashboard')).toBe('inst-1');
+});
+
+test('getCurrentInstanceIdFromPathname returns null for a non-instance path', () => {
+  expect(getCurrentInstanceIdFromPathname('/dashboard')).toBeNull();
+});
+
+test('getCurrentInstanceIdFromPathname returns null for null/undefined input', () => {
+  expect(getCurrentInstanceIdFromPathname(null)).toBeNull();
+  expect(getCurrentInstanceIdFromPathname(undefined)).toBeNull();
+});
+
+// ── window/document-guarded functions (non-browser branch) ─────────────────
+
+test('getCurrentInstanceIdFromWindow returns null when window is undefined (non-browser host)', () => {
+  expect(typeof window).toBe('undefined');
+  expect(getCurrentInstanceIdFromWindow()).toBeNull();
+});
+
+test('getActiveInstanceIdFromCookie returns null when document is undefined (non-browser host)', () => {
+  expect(typeof document).toBe('undefined');
+  expect(getActiveInstanceIdFromCookie()).toBeNull();
+});
+
+test('setActiveInstanceCookie is a no-op (never throws) when document is undefined', () => {
+  expect(() => setActiveInstanceCookie('inst-1')).not.toThrow();
+  expect(() => setActiveInstanceCookie(null)).not.toThrow();
+  expect(() => setActiveInstanceCookie()).not.toThrow();
+});
+
+// ── toInstanceAwarePath ──────────────────────────────────────────────────────
+
+test('toInstanceAwarePath prefixes when an instanceId is given', () => {
+  expect(toInstanceAwarePath('/dashboard', 'inst-1')).toBe('/instances/inst-1/dashboard');
+});
+
+test('toInstanceAwarePath returns the pathname unchanged when instanceId is falsy', () => {
+  expect(toInstanceAwarePath('/dashboard', null)).toBe('/dashboard');
+  expect(toInstanceAwarePath('/dashboard', undefined)).toBe('/dashboard');
+  expect(toInstanceAwarePath('/dashboard', '')).toBe('/dashboard');
+});
+
+// ── normalizeAppPathname ─────────────────────────────────────────────────────
+
+test('normalizeAppPathname strips the instance prefix, defaulting to /dashboard for a bare instance path', () => {
+  expect(normalizeAppPathname('/instances/inst-1')).toBe('/dashboard');
+});
+
+test('normalizeAppPathname strips the instance prefix, keeping a nested inner path', () => {
+  expect(normalizeAppPathname('/instances/inst-1/sessions/s1')).toBe('/sessions/s1');
+});
+
+test('normalizeAppPathname leaves a non-instance path untouched', () => {
+  expect(normalizeAppPathname('/dashboard')).toBe('/dashboard');
+});

--- a/packages/sdk/src/platform/platform-client/invites.test.ts
+++ b/packages/sdk/src/platform/platform-client/invites.test.ts
@@ -1,0 +1,133 @@
+import { test, expect, beforeEach, mock } from 'bun:test';
+import * as realAuth from '../auth';
+
+// This file must be hermetic against process-wide `mock.module('../auth', ...)`
+// registrations made by OTHER test files (see the identical comment in
+// `./shared.test.ts` — bun's `mock.module` is process-wide/permanent for the
+// whole `bun test` sweep). Register our OWN mock — a thin passthrough to
+// `globalThis.fetch` this file fully controls — instead of depending on
+// whichever OTHER file's registration happens to be resident, and import
+// `./invites` via `await import(...)` so it resolves against THIS mock
+// regardless of load order.
+mock.module('../auth', () => ({
+  ...realAuth,
+  authenticatedFetch: async (input: RequestInfo | URL, init?: RequestInit) => fetch(input as any, init),
+}));
+
+const { getInvite, acceptInvite, declineInvite } = await import('./invites');
+const { configureKortix } = await import('../config');
+
+let calls: { url: string; method: string }[] = [];
+let nextResponse: { status: number; body: unknown } = { status: 200, body: {} };
+
+beforeEach(() => {
+  delete process.env.BACKEND_URL;
+  configureKortix({ backendUrl: 'http://backend.local/v1', getToken: async () => 'tok' });
+  calls = [];
+  nextResponse = { status: 200, body: {} };
+  globalThis.fetch = mock(async (url: unknown, opts: RequestInit = {}) => {
+    calls.push({ url: String(url), method: opts.method ?? 'GET' });
+    return new Response(JSON.stringify(nextResponse.body), {
+      status: nextResponse.status,
+      headers: { 'content-type': 'application/json' },
+    });
+  }) as unknown as typeof fetch;
+});
+
+const last = () => calls[calls.length - 1];
+
+// ─── getInvite ───────────────────────────────────────────────────────────────
+
+test('getInvite GETs the invite route and returns result.data on success', async () => {
+  const invite = {
+    invite_id: 'inv-1',
+    sandbox_id: 'sbx-1',
+    sandbox_name: 'My Sandbox',
+    email: 'a@b.com',
+    inviter_email: 'owner@b.com',
+    created_at: '2026-01-01T00:00:00Z',
+    expires_at: '2026-02-01T00:00:00Z',
+    accepted_at: null,
+    email_matches_caller: true as const,
+    expired: false,
+  };
+  nextResponse = { status: 200, body: { success: true, data: invite } };
+
+  const result = await getInvite('inv-1');
+
+  expect(last().url).toContain('/platform/invites/inv-1');
+  expect(last().method).toBe('GET');
+  expect(result).toEqual(invite);
+});
+
+test('getInvite throws result.error when the platform reports failure', async () => {
+  nextResponse = { status: 200, body: { success: false, error: 'Invite expired' } };
+  await expect(getInvite('inv-1')).rejects.toThrow('Invite expired');
+});
+
+test('getInvite falls back to "Invite not found" when success is true but data is missing', async () => {
+  nextResponse = { status: 200, body: { success: true } };
+  await expect(getInvite('inv-1')).rejects.toThrow('Invite not found');
+});
+
+// ─── acceptInvite ────────────────────────────────────────────────────────────
+
+test('acceptInvite POSTs to the accept route and returns result.data on success', async () => {
+  nextResponse = { status: 200, body: { success: true, data: { status: 'accepted', sandbox_id: 'sbx-1' } } };
+
+  const result = await acceptInvite('inv-1');
+
+  expect(last().url).toContain('/platform/invites/inv-1/accept');
+  expect(last().method).toBe('POST');
+  expect(result).toEqual({ status: 'accepted', sandbox_id: 'sbx-1' });
+});
+
+test('acceptInvite throws result.error when the platform reports failure', async () => {
+  nextResponse = { status: 200, body: { success: false, error: 'Invite already accepted' } };
+  await expect(acceptInvite('inv-1')).rejects.toThrow('Invite already accepted');
+});
+
+test('acceptInvite falls back to "Failed to accept invite" when success is true but data is missing', async () => {
+  nextResponse = { status: 200, body: { success: true } };
+  await expect(acceptInvite('inv-1')).rejects.toThrow('Failed to accept invite');
+});
+
+// ─── declineInvite ───────────────────────────────────────────────────────────
+
+test('declineInvite POSTs to the decline route and resolves void on success (no data required)', async () => {
+  nextResponse = { status: 200, body: { success: true } };
+
+  const result = await declineInvite('inv-1');
+
+  expect(last().url).toContain('/platform/invites/inv-1/decline');
+  expect(last().method).toBe('POST');
+  expect(result).toBeUndefined();
+});
+
+test('declineInvite throws result.error when the platform reports failure', async () => {
+  nextResponse = { status: 200, body: { success: false, error: 'Invite already declined' } };
+  await expect(declineInvite('inv-1')).rejects.toThrow('Invite already declined');
+});
+
+test('declineInvite falls back to "Failed to decline invite" when there is no error message', async () => {
+  nextResponse = { status: 200, body: { success: false } };
+  await expect(declineInvite('inv-1')).rejects.toThrow('Failed to decline invite');
+});
+
+// ─── URL encoding ────────────────────────────────────────────────────────────
+
+test('encodeURIComponent is applied to the invite id for all three endpoints', async () => {
+  const weirdId = 'inv/with space&stuff';
+  nextResponse = { status: 200, body: { success: true, data: { invite_id: weirdId } } };
+  await getInvite(weirdId).catch(() => {});
+  expect(last().url).toContain(`/platform/invites/${encodeURIComponent(weirdId)}`);
+  expect(last().url).not.toContain('inv/with space&stuff');
+
+  nextResponse = { status: 200, body: { success: true, data: { status: 'accepted', sandbox_id: 'sbx-1' } } };
+  await acceptInvite(weirdId);
+  expect(last().url).toContain(`/platform/invites/${encodeURIComponent(weirdId)}/accept`);
+
+  nextResponse = { status: 200, body: { success: true } };
+  await declineInvite(weirdId);
+  expect(last().url).toContain(`/platform/invites/${encodeURIComponent(weirdId)}/decline`);
+});

--- a/packages/sdk/src/platform/platform-client/lifecycle.test.ts
+++ b/packages/sdk/src/platform/platform-client/lifecycle.test.ts
@@ -1,0 +1,392 @@
+import { test, expect, beforeEach, mock } from 'bun:test';
+import { configureKortix } from '../config';
+import type { KortixProject, ProjectSession, ProjectSessionSandbox, SessionStartResult } from '../projects-client';
+import {
+  getProviders,
+  ensureSandbox,
+  createSandbox,
+  getSandbox,
+  getSandboxById,
+  renameSandbox,
+  listSandboxes,
+  discoverLocalSandbox,
+  restartSandbox,
+  stopSandbox,
+  cancelSandbox,
+  reactivateSandbox,
+} from './lifecycle';
+
+// This module composes `../projects-client` functions on top of `backendApi`,
+// which ultimately goes through `globalThis.fetch` — so we mock fetch directly
+// (branching on URL + method) the same way `../projects-client/*.test.ts`
+// files do, rather than `mock.module`-ing `../projects-client` or `./shared`.
+// `mock.module` registrations are process-wide/permanent for the whole `bun
+// test` sweep, and this codebase has already hit (and fixed) a real collision
+// hazard from doing that across files (see `state/server-store/active`) — real
+// fetch-mocking avoids repeating it here.
+
+let calls: { url: string; method: string; body: unknown }[] = [];
+let handler: (url: string, method: string, body: unknown) => { status: number; body: unknown } = () => ({
+  status: 200,
+  body: {},
+});
+
+beforeEach(() => {
+  delete process.env.BACKEND_URL;
+  configureKortix({ backendUrl: 'http://backend.local/v1', getToken: async () => 'tok' });
+  calls = [];
+  handler = () => ({ status: 200, body: {} });
+  globalThis.fetch = mock(async (url: unknown, opts: RequestInit = {}) => {
+    const method = opts.method ?? 'GET';
+    const body = typeof opts.body === 'string' ? JSON.parse(opts.body) : undefined;
+    calls.push({ url: String(url), method, body });
+    const result = handler(String(url), method, body);
+    return new Response(JSON.stringify(result.body), {
+      status: result.status,
+      headers: { 'content-type': 'application/json' },
+    });
+  }) as unknown as typeof fetch;
+});
+
+const last = () => calls[calls.length - 1];
+const callsMatching = (re: RegExp) => calls.filter((c) => re.test(c.url));
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+const project1: KortixProject = {
+  project_id: 'proj-1',
+  account_id: 'acc-1',
+  name: 'Project One',
+  repo_url: 'https://github.com/acme/one',
+  default_branch: 'main',
+  manifest_path: 'kortix.toml',
+  status: 'active',
+  metadata: {},
+  last_opened_at: null,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+};
+
+const project2: KortixProject = {
+  ...project1,
+  project_id: 'proj-2',
+  name: 'Project Two',
+};
+
+// An already-running session with a sandbox — the "existing" fixture for ensureSandbox/getSandbox/etc.
+const existingSession: ProjectSession = {
+  session_id: 'sess-1',
+  account_id: 'acc-1',
+  project_id: 'proj-1',
+  branch_name: 'sess-1',
+  base_ref: 'main',
+  sandbox_provider: 'daytona',
+  sandbox_id: 'sbx-1',
+  sandbox_url: 'http://backend.local/v1/p/ext-1/8000',
+  opencode_session_id: 'oc-1',
+  name: 'Session One',
+  custom_name: null,
+  agent_name: 'daytona',
+  status: 'running',
+  error: null,
+  metadata: {},
+  opencode_sessions: [],
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-02T00:00:00Z',
+};
+
+const secondProjectSession: ProjectSession = {
+  ...existingSession,
+  session_id: 'sess-3',
+  project_id: 'proj-2',
+  sandbox_id: 'sbx-3',
+  sandbox_url: 'http://backend.local/v1/p/ext-3/8000',
+  branch_name: 'sess-3',
+};
+
+const newSession: ProjectSession = {
+  session_id: 'sess-2',
+  account_id: 'acc-1',
+  project_id: 'proj-1',
+  branch_name: 'sess-2',
+  base_ref: 'main',
+  sandbox_provider: null,
+  sandbox_id: 'sess-2',
+  sandbox_url: null,
+  opencode_session_id: null,
+  name: null,
+  custom_name: null,
+  agent_name: 'daytona',
+  status: 'queued',
+  error: null,
+  metadata: {},
+  opencode_sessions: [],
+  created_at: '2026-01-03T00:00:00Z',
+  updated_at: '2026-01-03T00:00:00Z',
+};
+
+const runtimeSandbox: ProjectSessionSandbox = {
+  sandbox_id: 'sbx-2',
+  session_id: 'sess-2',
+  project_id: 'proj-1',
+  account_id: 'acc-1',
+  provider: 'daytona',
+  external_id: 'ext-2',
+  base_url: 'http://backend.local/v1/p/ext-2/8000',
+  status: 'active',
+  config: {},
+  metadata: {},
+  last_used_at: null,
+  created_at: '2026-01-03T00:00:01Z',
+  updated_at: '2026-01-03T00:00:01Z',
+};
+
+const startResult: SessionStartResult = {
+  stage: 'ready',
+  agent_name: 'daytona',
+  retriable: false,
+  sandbox: runtimeSandbox,
+  opencode_session_id: 'oc-2',
+  runtime_url: null,
+};
+
+/** GET /projects -> [project1]; GET /projects/proj-1/sessions -> [existingSession]. Nothing else wired. */
+function wireExistingSandbox() {
+  handler = (url, method) => {
+    if (method === 'GET' && /\/projects$/.test(url)) return { status: 200, body: [project1] };
+    if (method === 'GET' && /\/projects\/proj-1\/sessions$/.test(url)) return { status: 200, body: [existingSession] };
+    throw new Error(`unmocked ${method} ${url}`);
+  };
+}
+
+/** GET /projects -> [project1]; sessions empty; POST create -> newSession; POST start -> startResult. */
+function wireCreateFlow() {
+  handler = (url, method) => {
+    if (method === 'GET' && /\/projects$/.test(url)) return { status: 200, body: [project1] };
+    if (method === 'GET' && /\/projects\/proj-1\/sessions$/.test(url)) return { status: 200, body: [] };
+    if (method === 'POST' && /\/projects\/proj-1\/sessions$/.test(url)) return { status: 200, body: newSession };
+    if (method === 'POST' && /\/projects\/proj-1\/sessions\/sess-2\/start/.test(url)) {
+      return { status: 200, body: startResult };
+    }
+    throw new Error(`unmocked ${method} ${url}`);
+  };
+}
+
+/** GET /projects -> [] — no projects at all. */
+function wireNoProjects() {
+  handler = (url, method) => {
+    if (method === 'GET' && /\/projects$/.test(url)) return { status: 200, body: [] };
+    throw new Error(`unmocked ${method} ${url}`);
+  };
+}
+
+// ─── getProviders ────────────────────────────────────────────────────────────
+
+test('getProviders is pure — no network, always daytona', async () => {
+  const result = await getProviders();
+  expect(result).toEqual({ providers: ['daytona'], default: 'daytona' });
+  expect(calls.length).toBe(0);
+});
+
+// ─── ensureSandbox ───────────────────────────────────────────────────────────
+
+test('ensureSandbox returns an existing sandbox untouched when one is found', async () => {
+  wireExistingSandbox();
+
+  const result = await ensureSandbox();
+
+  expect(result.created).toBe(false);
+  expect(result.sandbox.sandbox_id).toBe('sbx-1');
+  expect(result.sandbox.external_id).toBe('ext-1');
+  // Must not have created or started anything.
+  expect(callsMatching(/\/sessions$/).filter((c) => c.method === 'POST').length).toBe(0);
+  expect(callsMatching(/\/start/).length).toBe(0);
+});
+
+test('ensureSandbox creates + starts a session when a project exists but has no sandbox', async () => {
+  wireCreateFlow();
+
+  const result = await ensureSandbox();
+
+  expect(result.created).toBe(true);
+  expect(result.sandbox.sandbox_id).toBe('sbx-2');
+  expect(result.sandbox.external_id).toBe('ext-2');
+  expect(callsMatching(/\/projects\/proj-1\/sessions$/).some((c) => c.method === 'POST')).toBe(true);
+  expect(callsMatching(/\/projects\/proj-1\/sessions\/sess-2\/start/).length).toBe(1);
+});
+
+test('ensureSandbox throws when there are no projects at all', async () => {
+  wireNoProjects();
+  await expect(ensureSandbox()).rejects.toThrow('Create a project before starting a sandbox');
+});
+
+// ─── createSandbox ───────────────────────────────────────────────────────────
+
+test('createSandbox is a thin wrapper over ensureSandbox — returns only { sandbox }', async () => {
+  wireCreateFlow();
+
+  const result = await createSandbox();
+
+  expect(Object.keys(result)).toEqual(['sandbox']);
+  expect(result.sandbox.sandbox_id).toBe('sbx-2');
+  expect(result.sandbox.external_id).toBe('ext-2');
+});
+
+// ─── getSandbox ──────────────────────────────────────────────────────────────
+
+test('getSandbox returns the row sandbox when one exists', async () => {
+  wireExistingSandbox();
+  const result = await getSandbox();
+  expect(result?.sandbox_id).toBe('sbx-1');
+});
+
+test('getSandbox resolves to null (not a rejection) when the lookup fails', async () => {
+  handler = (url, method) => {
+    if (method === 'GET' && /\/projects$/.test(url)) return { status: 500, body: { message: 'boom' } };
+    throw new Error(`unmocked ${method} ${url}`);
+  };
+  const result = await getSandbox();
+  expect(result).toBeNull();
+});
+
+// ─── getSandboxById ──────────────────────────────────────────────────────────
+
+test('getSandboxById returns null immediately (no network) for undefined/empty/non-matching input', async () => {
+  expect(await getSandboxById(undefined)).toBeNull();
+  expect(await getSandboxById('')).toBeNull();
+  expect(await getSandboxById({})).toBeNull();
+  expect(calls.length).toBe(0);
+});
+
+test('getSandboxById resolves through findProjectSessionSandbox for a real id', async () => {
+  wireExistingSandbox();
+  const result = await getSandboxById('sbx-1');
+  expect(result?.sandbox_id).toBe('sbx-1');
+  expect(result?.external_id).toBe('ext-1');
+});
+
+// ─── renameSandbox ───────────────────────────────────────────────────────────
+
+test('renameSandbox throws "not exposed" when the sandbox exists', async () => {
+  wireExistingSandbox();
+  await expect(renameSandbox('sbx-1', 'new name')).rejects.toThrow(
+    'Renaming project-session sandboxes is not exposed by the current API',
+  );
+});
+
+test('renameSandbox throws "not found" when the sandbox does not resolve', async () => {
+  wireExistingSandbox();
+  await expect(renameSandbox('no-such-sandbox', 'new name')).rejects.toThrow('Project session sandbox not found');
+});
+
+// ─── listSandboxes ───────────────────────────────────────────────────────────
+
+function wireTwoProjectsTwoSessions() {
+  handler = (url, method) => {
+    if (method === 'GET' && /\/projects$/.test(url)) return { status: 200, body: [project1, project2] };
+    if (method === 'GET' && /\/projects\/proj-1\/sessions$/.test(url)) return { status: 200, body: [existingSession] };
+    if (method === 'GET' && /\/projects\/proj-2\/sessions$/.test(url)) return { status: 200, body: [secondProjectSession] };
+    throw new Error(`unmocked ${method} ${url}`);
+  };
+}
+
+test('listSandboxes lists every session-backed sandbox across every project when no filter is given', async () => {
+  wireTwoProjectsTwoSessions();
+  const result = await listSandboxes();
+  expect(result.map((s) => s.sandbox_id).sort()).toEqual(['sbx-1', 'sbx-3']);
+});
+
+test('listSandboxes filters by sandbox_id or external_id', async () => {
+  wireTwoProjectsTwoSessions();
+  expect((await listSandboxes('sbx-1')).map((s) => s.sandbox_id)).toEqual(['sbx-1']);
+  expect((await listSandboxes('ext-3')).map((s) => s.sandbox_id)).toEqual(['sbx-3']);
+});
+
+test('listSandboxes degrades to [] when listProjectSessionSandboxes rejects', async () => {
+  handler = (url, method) => {
+    if (method === 'GET' && /\/projects$/.test(url)) return { status: 500, body: { message: 'boom' } };
+    throw new Error(`unmocked ${method} ${url}`);
+  };
+  expect(await listSandboxes()).toEqual([]);
+});
+
+// ─── discoverLocalSandbox ────────────────────────────────────────────────────
+
+test('discoverLocalSandbox short-circuits to null with no network call in this (non-DOM) test environment', async () => {
+  expect(typeof window).toBe('undefined');
+  const result = await discoverLocalSandbox();
+  expect(result).toBeNull();
+  expect(calls.length).toBe(0);
+});
+
+// ─── restartSandbox / stopSandbox ────────────────────────────────────────────
+
+test('restartSandbox throws when no sandboxId is given', async () => {
+  await expect(restartSandbox()).rejects.toThrow('No sandbox selected for workload restart');
+  expect(calls.length).toBe(0);
+});
+
+test('restartSandbox throws "not found" when the id does not resolve to a row', async () => {
+  wireExistingSandbox();
+  await expect(restartSandbox('no-such-sandbox')).rejects.toThrow('Project session sandbox not found');
+});
+
+test('restartSandbox POSTs to the restart endpoint for the resolved project/session', async () => {
+  handler = (url, method) => {
+    if (method === 'GET' && /\/projects$/.test(url)) return { status: 200, body: [project1] };
+    if (method === 'GET' && /\/projects\/proj-1\/sessions$/.test(url)) return { status: 200, body: [existingSession] };
+    if (method === 'POST' && /\/projects\/proj-1\/sessions\/sess-1\/restart$/.test(url)) {
+      return { status: 200, body: { ok: true, session_id: 'sess-1', status: 'provisioning' } };
+    }
+    throw new Error(`unmocked ${method} ${url}`);
+  };
+
+  await restartSandbox('sbx-1');
+
+  const restartCall = calls.find((c) => /\/restart$/.test(c.url));
+  expect(restartCall?.method).toBe('POST');
+  expect(restartCall?.url).toContain('/projects/proj-1/sessions/sess-1/restart');
+});
+
+test('stopSandbox throws when no sandboxId is given', async () => {
+  await expect(stopSandbox()).rejects.toThrow('No sandbox selected to stop');
+  expect(calls.length).toBe(0);
+});
+
+test('stopSandbox throws "not found" when the id does not resolve to a row', async () => {
+  wireExistingSandbox();
+  await expect(stopSandbox('no-such-sandbox')).rejects.toThrow('Project session sandbox not found');
+});
+
+test('stopSandbox POSTs to the stop endpoint for the resolved project/session', async () => {
+  handler = (url, method) => {
+    if (method === 'GET' && /\/projects$/.test(url)) return { status: 200, body: [project1] };
+    if (method === 'GET' && /\/projects\/proj-1\/sessions$/.test(url)) return { status: 200, body: [existingSession] };
+    if (method === 'POST' && /\/projects\/proj-1\/sessions\/sess-1\/stop$/.test(url)) {
+      return { status: 200, body: { ok: true, session_id: 'sess-1', status: 'stopped' } };
+    }
+    throw new Error(`unmocked ${method} ${url}`);
+  };
+
+  await stopSandbox('sbx-1');
+
+  const stopCall = calls.find((c) => /\/stop$/.test(c.url));
+  expect(stopCall?.method).toBe('POST');
+  expect(stopCall?.url).toContain('/projects/proj-1/sessions/sess-1/stop');
+});
+
+// ─── cancelSandbox / reactivateSandbox ───────────────────────────────────────
+
+test('cancelSandbox always throws — cancellation is not exposed, regardless of args', async () => {
+  await expect(cancelSandbox()).rejects.toThrow('Cancellation is not exposed for project-session sandboxes');
+  await expect(cancelSandbox('sbx-1')).rejects.toThrow('Cancellation is not exposed for project-session sandboxes');
+  expect(calls.length).toBe(0);
+});
+
+test('reactivateSandbox always throws — reactivation is not exposed, regardless of args', async () => {
+  await expect(reactivateSandbox()).rejects.toThrow('Reactivation is not exposed for project-session sandboxes');
+  await expect(reactivateSandbox('sbx-1')).rejects.toThrow(
+    'Reactivation is not exposed for project-session sandboxes',
+  );
+  expect(calls.length).toBe(0);
+});

--- a/packages/sdk/src/platform/platform-client/lifecycle.test.ts
+++ b/packages/sdk/src/platform/platform-client/lifecycle.test.ts
@@ -48,7 +48,6 @@ beforeEach(() => {
   }) as unknown as typeof fetch;
 });
 
-const last = () => calls[calls.length - 1];
 const callsMatching = (re: RegExp) => calls.filter((c) => re.test(c.url));
 
 // ─── Fixtures ────────────────────────────────────────────────────────────────

--- a/packages/sdk/src/platform/platform-client/members.test.ts
+++ b/packages/sdk/src/platform/platform-client/members.test.ts
@@ -1,0 +1,210 @@
+import { test, expect, beforeEach, mock } from 'bun:test';
+import * as realAuth from '../auth';
+import type { SandboxInfo } from './types';
+
+// This file must be hermetic against process-wide `mock.module('../auth', ...)`
+// (equivalently `'../platform/auth'` from other directories — same resolved
+// file) registrations made by OTHER test files (see the identical comment in
+// `./shared.test.ts` / `./invites.test.ts` — bun's `mock.module` is
+// process-wide/permanent for the whole `bun test` sweep, and several other
+// suites register one). `members.ts`'s real functional helpers
+// (`fetchKortixMaster`) call `authenticatedFetch` directly, so — unlike a file
+// that never touches auth — this one needs its OWN registration (a thin
+// passthrough to `globalThis.fetch` this file fully controls) instead of
+// depending on whichever OTHER file's registration happens to be resident.
+// Import `./members` via `await import(...)` so it resolves against THIS mock
+// regardless of load order.
+mock.module('../auth', () => ({
+  ...realAuth,
+  authenticatedFetch: async (input: RequestInfo | URL, init?: RequestInit) => fetch(input as any, init),
+}));
+
+const {
+  listSandboxMembers,
+  addSandboxMember,
+  removeSandboxMember,
+  updateSandboxMemberRole,
+  updateSandboxMemberSpendCap,
+  getViewerSandboxScopes,
+  getSandboxMemberScopes,
+  updateSandboxMemberScope,
+  revokeSandboxInvite,
+  listSandboxProjectMembers,
+  grantSandboxProjectAccess,
+  revokeSandboxProjectAccess,
+} = await import('./members');
+type SandboxProjectMembersResponse = Awaited<ReturnType<typeof listSandboxProjectMembers>>;
+const { configureKortix } = await import('../config');
+
+configureKortix({ backendUrl: 'http://backend.local/v1', getToken: async () => 'tok' });
+
+let calls: { url: string; method: string; body: unknown }[] = [];
+let nextStatus = 200;
+let nextBodyText = '{}';
+
+beforeEach(() => {
+  delete process.env.BACKEND_URL;
+  calls = [];
+  nextStatus = 200;
+  nextBodyText = '{}';
+  globalThis.fetch = mock(async (url: unknown, opts: RequestInit = {}) => {
+    calls.push({
+      url: String(url),
+      method: opts.method ?? 'GET',
+      body: typeof opts.body === 'string' ? JSON.parse(opts.body) : undefined,
+    });
+    return new Response(nextBodyText, {
+      status: nextStatus,
+      headers: { 'content-type': 'application/json' },
+    });
+  }) as unknown as typeof fetch;
+});
+
+const last = () => calls[calls.length - 1];
+
+const sandbox: SandboxInfo = {
+  sandbox_id: 'sbx-1',
+  external_id: 'ext-123',
+  name: 'Test Sandbox',
+  provider: 'daytona',
+  base_url: '',
+  status: 'active',
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+};
+
+// ─── Deliberate stubs — every one of these always rejects, regardless of input ──
+
+test('listSandboxMembers always rejects — moved to project access', async () => {
+  await expect(listSandboxMembers('sbx-1')).rejects.toThrow(
+    'Sandbox members moved to project access; use project members for project-session sandboxes',
+  );
+});
+
+test('addSandboxMember always rejects — invite to project instead', async () => {
+  await expect(addSandboxMember('sbx-1', 'a@b.com', 'member')).rejects.toThrow(
+    'Sandbox members moved to project access; invite the user to the project instead',
+  );
+});
+
+test('removeSandboxMember always rejects — update project access instead', async () => {
+  await expect(removeSandboxMember('sbx-1', 'user-1')).rejects.toThrow(
+    'Sandbox members moved to project access; update project access instead',
+  );
+});
+
+test('updateSandboxMemberRole always rejects — update project access instead', async () => {
+  await expect(updateSandboxMemberRole('sbx-1', 'user-1', 'admin')).rejects.toThrow(
+    'Sandbox members moved to project access; update project access instead',
+  );
+});
+
+test('updateSandboxMemberSpendCap always rejects — not exposed for project-session sandboxes', async () => {
+  await expect(updateSandboxMemberSpendCap('sbx-1', 'user-1', 5000)).rejects.toThrow(
+    'Sandbox member spend caps are not exposed for project-session sandboxes',
+  );
+});
+
+test('getViewerSandboxScopes always rejects — moved to project access', async () => {
+  await expect(getViewerSandboxScopes('sbx-1')).rejects.toThrow(
+    'Sandbox scopes moved to project access for project-session sandboxes',
+  );
+});
+
+test('getSandboxMemberScopes always rejects — moved to project access', async () => {
+  await expect(getSandboxMemberScopes('sbx-1', 'user-1')).rejects.toThrow(
+    'Sandbox scopes moved to project access for project-session sandboxes',
+  );
+});
+
+test('updateSandboxMemberScope always rejects — moved to project access', async () => {
+  await expect(updateSandboxMemberScope('sbx-1', 'user-1', 'files.read', 'grant')).rejects.toThrow(
+    'Sandbox scopes moved to project access for project-session sandboxes',
+  );
+});
+
+test('revokeSandboxInvite always rejects — moved to project access', async () => {
+  await expect(revokeSandboxInvite('sbx-1', 'invite-1')).rejects.toThrow(
+    'Sandbox invites moved to project access for project-session sandboxes',
+  );
+  // Stubs must not hit the network — they throw synchronously up front.
+  expect(calls.length).toBe(0);
+});
+
+// ─── Real functional ACL helpers — go through fetchKortixMaster ─────────────
+
+test('listSandboxProjectMembers GETs the kortix-master project members route through the sandbox proxy', async () => {
+  const body: SandboxProjectMembersResponse = {
+    project_id: 'proj-1',
+    members: [{ user_id: 'u1', role: 'owner', added_by: null, added_at: '2026-01-01T00:00:00Z' }],
+  };
+  nextBodyText = JSON.stringify(body);
+  nextStatus = 200;
+
+  const result = await listSandboxProjectMembers(sandbox, 'proj-1');
+
+  expect(last().url).toBe('http://backend.local/v1/p/ext-123/8000/kortix/projects/proj-1/members');
+  expect(last().method).toBe('GET');
+  expect(result).toEqual(body);
+});
+
+test('grantSandboxProjectAccess POSTs user_id + role, defaulting role to member', async () => {
+  nextBodyText = '{}';
+  nextStatus = 200;
+
+  await grantSandboxProjectAccess(sandbox, 'proj-1', 'user-9');
+
+  expect(last().url).toBe('http://backend.local/v1/p/ext-123/8000/kortix/projects/proj-1/members');
+  expect(last().method).toBe('POST');
+  expect(last().body).toEqual({ user_id: 'user-9', role: 'member' });
+});
+
+test('grantSandboxProjectAccess honors an explicit admin role', async () => {
+  nextBodyText = '{}';
+  nextStatus = 200;
+
+  await grantSandboxProjectAccess(sandbox, 'proj-1', 'user-9', 'admin');
+
+  expect(last().body).toEqual({ user_id: 'user-9', role: 'admin' });
+});
+
+test('revokeSandboxProjectAccess DELETEs the specific member route', async () => {
+  nextBodyText = '{}';
+  nextStatus = 200;
+
+  await revokeSandboxProjectAccess(sandbox, 'proj-1', 'user-9');
+
+  expect(last().url).toBe('http://backend.local/v1/p/ext-123/8000/kortix/projects/proj-1/members/user-9');
+  expect(last().method).toBe('DELETE');
+});
+
+test('fetchKortixMaster throws the response body text on a non-ok response', async () => {
+  nextStatus = 404;
+  nextBodyText = 'Project not found';
+
+  await expect(listSandboxProjectMembers(sandbox, 'proj-1')).rejects.toThrow('Project not found');
+});
+
+test('fetchKortixMaster falls back to "Request failed (status)" when the error body is empty', async () => {
+  nextStatus = 500;
+  nextBodyText = '';
+
+  await expect(revokeSandboxProjectAccess(sandbox, 'proj-1', 'user-9')).rejects.toThrow('Request failed (500)');
+});
+
+test('URL-encodes projectId and userId with special characters', async () => {
+  nextBodyText = '{}';
+  nextStatus = 200;
+
+  await grantSandboxProjectAccess(sandbox, 'proj/one two', 'user id&1');
+
+  expect(last().url).toBe(
+    `http://backend.local/v1/p/ext-123/8000/kortix/projects/${encodeURIComponent('proj/one two')}/members`,
+  );
+  expect(last().body).toEqual({ user_id: 'user id&1', role: 'member' });
+
+  await revokeSandboxProjectAccess(sandbox, 'proj/one two', 'user id&1');
+  expect(last().url).toBe(
+    `http://backend.local/v1/p/ext-123/8000/kortix/projects/${encodeURIComponent('proj/one two')}/members/${encodeURIComponent('user id&1')}`,
+  );
+});

--- a/packages/sdk/src/platform/platform-client/members.ts
+++ b/packages/sdk/src/platform/platform-client/members.ts
@@ -3,6 +3,7 @@
  */
 
 import { authenticatedFetch } from '../auth';
+import { stripTrailingSlashes } from '../strings';
 import type { SandboxInfo } from './types';
 import { getSandboxUrl } from './urls';
 
@@ -150,7 +151,7 @@ async function fetchKortixMaster<T>(
   init?: RequestInit,
 ): Promise<T> {
   const base = getSandboxUrl(sandbox);
-  const res = await authenticatedFetch(`${base.replace(/\/+$/, '')}${path}`, {
+  const res = await authenticatedFetch(`${stripTrailingSlashes(base)}${path}`, {
     signal: AbortSignal.timeout(8_000),
     headers: { 'Content-Type': 'application/json' },
     ...init,

--- a/packages/sdk/src/platform/platform-client/shared.test.ts
+++ b/packages/sdk/src/platform/platform-client/shared.test.ts
@@ -1,0 +1,61 @@
+import { test, expect, beforeEach, mock } from 'bun:test';
+import * as realAuth from '../auth';
+
+// This file must be hermetic against process-wide `mock.module('../platform/auth', ...)`
+// (equivalently `'../auth'` from here) registrations made by OTHER test files (see the
+// identical comment in opencode/client.test.ts and opencode/kortix-master.test.ts —
+// files/client.test.ts, react/use-kortix-master.test.ts, and session/session.test.ts
+// each register one too, and bun's `mock.module` is process-wide/permanent for the
+// whole `bun test` sweep). This file registers its OWN mock for `../auth` — a thin
+// passthrough to `globalThis.fetch` this file fully controls — instead of depending on
+// whichever OTHER file's registration happens to be resident, and imports `./shared` via
+// `await import(...)` so it resolves against THIS mock regardless of load order.
+mock.module('../auth', () => ({
+  ...realAuth,
+  authenticatedFetch: async (input: RequestInfo | URL, init?: RequestInit) => fetch(input as any, init),
+}));
+
+const { platformFetch } = await import('./shared');
+const { configureKortix } = await import('../config');
+const { ApiError, BillingError } = await import('../api/errors');
+
+beforeEach(() => {
+  delete process.env.BACKEND_URL;
+  configureKortix({ backendUrl: 'http://backend.local/v1', getToken: async () => 'tok' });
+});
+
+function mockFetch(status: number, body: unknown) {
+  globalThis.fetch = (async () =>
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { 'content-type': 'application/json' },
+    })) as unknown as typeof fetch;
+}
+
+function mockFetchNonJson(status: number, text: string) {
+  globalThis.fetch = (async () => new Response(text, { status, headers: { 'content-type': 'text/html' } })) as unknown as typeof fetch;
+}
+
+test('returns the parsed body on success', async () => {
+  mockFetch(200, { success: true, data: { ok: true } });
+  const result = await platformFetch<{ ok: boolean }>('/whoami');
+  expect(result).toEqual({ success: true, data: { ok: true } });
+});
+
+test('throws a typed ApiError (with status + details) on a non-ok JSON response', async () => {
+  mockFetch(500, { error: 'boom', code: 'INTERNAL' });
+  await expect(platformFetch('/whoami')).rejects.toBeInstanceOf(ApiError);
+  await expect(platformFetch('/whoami')).rejects.toMatchObject({ status: 500, code: 'INTERNAL', message: 'boom' });
+});
+
+test('a 402 response is converted into a BillingError', async () => {
+  mockFetch(402, { message: 'insufficient credits' });
+  await expect(platformFetch('/whoami')).rejects.toBeInstanceOf(BillingError);
+});
+
+test('guards res.json() defensively — a non-JSON error body still throws a typed ApiError, not a raw SyntaxError', async () => {
+  mockFetchNonJson(502, '<html>Bad Gateway</html>');
+  const err = await platformFetch('/whoami').catch((e) => e);
+  expect(err).toBeInstanceOf(ApiError);
+  expect(err.status).toBe(502);
+});

--- a/packages/sdk/src/platform/platform-client/shared.ts
+++ b/packages/sdk/src/platform/platform-client/shared.ts
@@ -79,7 +79,11 @@ export const LOCAL_PLATFORM_CANDIDATES = [
 ];
 
 export function getLocalBridgeStatusUrl(baseUrl: string): string {
-  return `${baseUrl.replace(/\/+$/, '')}/platform/local-bridge/status`;
+  // Linear trailing-slash strip — the regex form (/\/+$/) backtracks
+  // quadratically on adversarial input (CodeQL js/polynomial-redos).
+  let end = baseUrl.length;
+  while (end > 0 && baseUrl.charCodeAt(end - 1) === 47 /* '/' */) end--;
+  return `${baseUrl.slice(0, end)}/platform/local-bridge/status`;
 }
 
 function normalizeSessionStatus(status: string | undefined): string {

--- a/packages/sdk/src/platform/platform-client/shared.ts
+++ b/packages/sdk/src/platform/platform-client/shared.ts
@@ -8,6 +8,7 @@
 
 import { authenticatedFetch } from '../auth';
 import { platformConfig } from '../config';
+import { ApiError, parseBillingError } from '../api/errors';
 import {
   listProjectSessions,
   listProjects,
@@ -180,15 +181,46 @@ export async function platformFetch<T>(
     ...options.headers as Record<string, string>,
   };
 
+  // Default 30s timeout for this (non-streaming, request/response JSON) call —
+  // callers that need a different budget (or none) pass their own `signal`.
+  const signal = options.signal ?? AbortSignal.timeout(30_000);
+
   const res = await authenticatedFetch(`${getPlatformUrl()}${path}`, {
     ...options,
     headers,
+    signal,
   });
 
-  const body = await res.json();
+  // Defensively parse the body: a non-JSON error body (proxy/gateway HTML, an
+  // empty response, a truncated stream) used to throw an opaque SyntaxError
+  // out of `res.json()` here, masking the real HTTP failure. Read the body
+  // ONCE as text, then attempt to JSON-parse that string — reading text
+  // first (rather than trying `res.json()` and falling back to `res.text()`
+  // on failure) avoids a "body already used" error on the fallback read,
+  // since a `Response` body can only be consumed once.
+  const rawText = await res.text().catch(() => undefined);
+  let body: any;
+  if (rawText) {
+    try {
+      body = JSON.parse(rawText);
+    } catch {
+      /* not JSON — leave body undefined, rawText still available below */
+    }
+  }
 
   if (!res.ok) {
-    throw new Error(body?.error || body?.message || `Platform API error ${res.status}`);
+    const message = body?.error || body?.message || body?.detail || rawText || `Platform API error ${res.status}`;
+    let error: Error = new ApiError(message, {
+      status: res.status,
+      code: body?.code || body?.error_code || String(res.status),
+      details: body ?? (rawText ? { rawText } : undefined),
+      response: res,
+      endpoint: path,
+    });
+    if (res.status === 402) {
+      error = parseBillingError(Object.assign(error, { response: res, status: res.status, data: body }));
+    }
+    throw error;
   }
 
   return body as PlatformResponse<T>;

--- a/packages/sdk/src/platform/platform-client/urls.test.ts
+++ b/packages/sdk/src/platform/platform-client/urls.test.ts
@@ -1,0 +1,56 @@
+import { test, expect, beforeEach } from 'bun:test';
+import { configureKortix } from '../config';
+import { getSandboxPortUrl, getSandboxUrl } from './urls';
+import type { SandboxInfo } from './types';
+
+function sandbox(overrides: Partial<SandboxInfo> = {}): SandboxInfo {
+  return {
+    sandbox_id: 'db-1',
+    external_id: 'ext-1',
+    name: 'my-sandbox',
+    provider: 'daytona',
+    base_url: 'https://fallback.example',
+    status: 'running',
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  delete process.env.BACKEND_URL;
+  configureKortix({ backendUrl: 'http://backend.local/v1', getToken: async () => 'tok' });
+});
+
+test('getSandboxUrl builds the proxy url on port 8000 (KORTIX_MASTER) from external_id', () => {
+  expect(getSandboxUrl(sandbox({ external_id: 'ext-abc' }))).toBe('http://backend.local/v1/p/ext-abc/8000');
+});
+
+test('getSandboxUrl falls back to base_url when external_id is missing', () => {
+  const result = getSandboxUrl(sandbox({ external_id: '' as unknown as string, base_url: 'https://direct.example' }));
+  expect(result).toBe('https://direct.example');
+});
+
+test('getSandboxUrl throws when both external_id and base_url are missing', () => {
+  expect(() =>
+    getSandboxUrl(sandbox({ external_id: '' as unknown as string, base_url: '' as unknown as string, provider: 'daytona', sandbox_id: 'sbx-9' })),
+  ).toThrow(/missing external_id for daytona sandbox "sbx-9"/);
+});
+
+test('getSandboxUrl prefers process.env.BACKEND_URL over the configured platform backendUrl', () => {
+  process.env.BACKEND_URL = 'http://internal-docker-host:8008/v1';
+  expect(getSandboxUrl(sandbox({ external_id: 'ext-1' }))).toBe('http://internal-docker-host:8008/v1/p/ext-1/8000');
+});
+
+test('getSandboxUrl falls back to the local-dev default when no backend url is configured at all', () => {
+  configureKortix({ backendUrl: '', getToken: async () => 'tok' });
+  expect(getSandboxUrl(sandbox({ external_id: 'ext-1' }))).toBe('http://localhost:8008/v1/p/ext-1/8000');
+});
+
+test('getSandboxPortUrl builds a url for an arbitrary container port when external_id is present', () => {
+  expect(getSandboxPortUrl(sandbox({ external_id: 'ext-1' }), '6080')).toBe('http://backend.local/v1/p/ext-1/6080');
+});
+
+test('getSandboxPortUrl returns null (not a broken url) when external_id is missing', () => {
+  expect(getSandboxPortUrl(sandbox({ external_id: '' as unknown as string }), '6080')).toBeNull();
+});

--- a/packages/sdk/src/platform/projects-client/access.test.ts
+++ b/packages/sdk/src/platform/projects-client/access.test.ts
@@ -1,0 +1,376 @@
+import { beforeEach, expect, mock, test } from 'bun:test';
+import { configureKortix } from '../config';
+import {
+  approveProjectAccessRequest,
+  attachGroupToProject,
+  createProjectResourceGrant,
+  deleteProjectResourceGrant,
+  detachGroupFromProject,
+  inviteProjectMember,
+  isInviteSent,
+  listPendingApprovals,
+  listPendingProjectInvites,
+  listProjectAccess,
+  listProjectAccessRequests,
+  listProjectGroupGrants,
+  listProjectResourceGrants,
+  listSessionsNeedingInput,
+  rejectProjectAccessRequest,
+  requestProjectAccess,
+  resendPendingProjectInvite,
+  resolveApproval,
+  revokePendingProjectInvite,
+  revokeProjectAccess,
+  updateProjectAccess,
+  updateProjectGroupGrant,
+  type ProjectAccessMember,
+} from './access';
+
+let calls: { url: string; method: string; body: unknown }[] = [];
+let nextResponse: { status: number; body: unknown } = { status: 200, body: {} };
+
+beforeEach(() => {
+  calls = [];
+  nextResponse = { status: 200, body: {} };
+  globalThis.fetch = mock(async (url: unknown, opts: { method?: string; body?: string } = {}) => {
+    calls.push({
+      url: String(url),
+      method: opts.method ?? 'GET',
+      body: opts.body ? JSON.parse(opts.body) : undefined,
+    });
+    return new Response(JSON.stringify(nextResponse.body), {
+      status: nextResponse.status,
+      headers: { 'content-type': 'application/json' },
+    });
+  }) as unknown as typeof fetch;
+});
+
+configureKortix({ backendUrl: 'http://test.local', getToken: async () => 'tok' });
+const last = () => calls[calls.length - 1];
+
+// ── isInviteSent: pure type guard, no fetch ─────────────────────────────────
+
+test('isInviteSent narrows the "invited" shape to true', () => {
+  const invited = {
+    status: 'invited' as const,
+    email: 'a@b.com',
+    invite_id: 'inv-1',
+    project_role: 'member' as const,
+    message: 'sent',
+    invite_url: 'https://app.example.com/invite/inv-1',
+    email_sent: true,
+    email_skip_reason: null,
+  };
+  expect(isInviteSent(invited)).toBe(true);
+});
+
+test('isInviteSent returns false for a plain ProjectAccessMember shape', () => {
+  const member: ProjectAccessMember = {
+    user_id: 'u1',
+    email: 'a@b.com',
+    account_role: 'member',
+    project_role: 'editor',
+    effective_project_role: 'editor',
+    has_implicit_access: false,
+    joined_at: '2026-01-01',
+    granted_by: null,
+    granted_at: '2026-01-01',
+    updated_at: null,
+  };
+  expect(isInviteSent(member)).toBe(false);
+});
+
+// ── access requests ──────────────────────────────────────────────────────────
+
+test('requestProjectAccess POSTs a trimmed message to access-requests', async () => {
+  nextResponse = {
+    status: 200,
+    body: {
+      status: 'created',
+      request: { request_id: 'r1', status: 'pending' },
+    },
+  };
+  await requestProjectAccess('P1', '  please add me  ');
+  expect(last().url).toContain('/projects/P1/access-requests');
+  expect(last().method).toBe('POST');
+  expect(last().body).toEqual({ message: 'please add me' });
+});
+
+test('requestProjectAccess omits message entirely when only whitespace is given', async () => {
+  nextResponse = { status: 200, body: { status: 'created', request: {} } };
+  await requestProjectAccess('P1', '   ');
+  expect(last().body).toEqual({ message: undefined });
+});
+
+test('listProjectAccessRequests GETs the access-requests list', async () => {
+  nextResponse = { status: 200, body: { requests: [] } };
+  const result = await listProjectAccessRequests('P1');
+  expect(last().url).toContain('/projects/P1/access-requests');
+  expect(last().method).toBe('GET');
+  expect(result).toEqual({ requests: [] });
+});
+
+test('listProjectAccess throws on a failed response', async () => {
+  nextResponse = { status: 500, body: { message: 'boom' } };
+  await expect(listProjectAccess('P1')).rejects.toBeTruthy();
+});
+
+test('approveProjectAccessRequest defaults role to "member" and POSTs to /approve', async () => {
+  nextResponse = { status: 200, body: { request: { request_id: 'r1' }, member: { user_id: 'u1' } } };
+  await approveProjectAccessRequest('P1', 'r1');
+  expect(last().url).toContain('/projects/P1/access-requests/r1/approve');
+  expect(last().method).toBe('POST');
+  expect(last().body).toEqual({ role: 'member' });
+});
+
+test('approveProjectAccessRequest forwards an explicit role', async () => {
+  nextResponse = { status: 200, body: { request: { request_id: 'r1' }, member: { user_id: 'u1' } } };
+  await approveProjectAccessRequest('P1', 'r1', 'manager');
+  expect(last().body).toEqual({ role: 'manager' });
+});
+
+test('rejectProjectAccessRequest POSTs an empty body to /reject', async () => {
+  nextResponse = { status: 200, body: { request: { request_id: 'r1' } } };
+  await rejectProjectAccessRequest('P1', 'r1');
+  expect(last().url).toContain('/projects/P1/access-requests/r1/reject');
+  expect(last().method).toBe('POST');
+  expect(last().body).toEqual({});
+});
+
+// ── direct member access ────────────────────────────────────────────────────
+
+test('listProjectAccess GETs the project access roster', async () => {
+  nextResponse = {
+    status: 200,
+    body: { project_id: 'P1', account_id: 'A1', can_manage: true, viewer_user_id: 'u1', members: [] },
+  };
+  const result = await listProjectAccess('P1');
+  expect(last().url).toContain('/projects/P1/access');
+  expect(last().method).toBe('GET');
+  expect(result.can_manage).toBe(true);
+});
+
+test('updateProjectAccess PUTs { role } to /access/:userId', async () => {
+  nextResponse = { status: 200, body: { user_id: 'u1', project_role: 'editor' } };
+  await updateProjectAccess('P1', 'u1', 'editor');
+  expect(last().url).toContain('/projects/P1/access/u1');
+  expect(last().method).toBe('PUT');
+  expect(last().body).toEqual({ role: 'editor' });
+});
+
+test('revokeProjectAccess DELETEs /access/:userId', async () => {
+  nextResponse = { status: 200, body: { ok: true } };
+  await revokeProjectAccess('P1', 'u1');
+  expect(last().url).toContain('/projects/P1/access/u1');
+  expect(last().method).toBe('DELETE');
+});
+
+test('inviteProjectMember POSTs { email, role } to /access/invite', async () => {
+  nextResponse = {
+    status: 200,
+    body: {
+      status: 'invited',
+      email: 'new@user.com',
+      invite_id: 'inv-1',
+      project_role: 'member',
+      message: 'invited',
+      invite_url: 'https://app.example.com/invite/inv-1',
+      email_sent: true,
+      email_skip_reason: null,
+    },
+  };
+  const result = await inviteProjectMember('P1', 'new@user.com', 'member');
+  expect(last().url).toContain('/projects/P1/access/invite');
+  expect(last().method).toBe('POST');
+  expect(last().body).toEqual({ email: 'new@user.com', role: 'member' });
+  expect(isInviteSent(result)).toBe(true);
+});
+
+// ── pending project invites ─────────────────────────────────────────────────
+
+test('listPendingProjectInvites GETs the pending-invites list', async () => {
+  nextResponse = { status: 200, body: { pending: [] } };
+  const result = await listPendingProjectInvites('P1');
+  expect(last().url).toContain('/projects/P1/access/pending-invites');
+  expect(last().method).toBe('GET');
+  expect(result).toEqual({ pending: [] });
+});
+
+test('revokePendingProjectInvite DELETEs a pending invite by id', async () => {
+  nextResponse = { status: 200, body: { ok: true, invitation_cancelled: true } };
+  const result = await revokePendingProjectInvite('P1', 'inv-1');
+  expect(last().url).toContain('/projects/P1/access/pending-invites/inv-1');
+  expect(last().method).toBe('DELETE');
+  expect(result.invitation_cancelled).toBe(true);
+});
+
+test('resendPendingProjectInvite POSTs to the resend endpoint', async () => {
+  nextResponse = {
+    status: 200,
+    body: { ok: true, expires_at: '2026-02-01', invite_url: 'https://x', email_sent: true, email_skip_reason: null },
+  };
+  const result = await resendPendingProjectInvite('P1', 'inv-1');
+  expect(last().url).toContain('/projects/P1/access/pending-invites/inv-1/resend');
+  expect(last().method).toBe('POST');
+  expect(result.ok).toBe(true);
+});
+
+// ── group grants (undefined vs null vs string expiresAt branches) ──────────
+
+test('listProjectGroupGrants GETs the group-grants list', async () => {
+  nextResponse = { status: 200, body: { grants: [] } };
+  const result = await listProjectGroupGrants('P1');
+  expect(last().url).toContain('/projects/P1/group-grants');
+  expect(last().method).toBe('GET');
+  expect(result).toEqual({ grants: [] });
+});
+
+test('attachGroupToProject omits expires_at entirely when expiresAt is undefined', async () => {
+  nextResponse = { status: 200, body: { project_id: 'P1', group_id: 'g1', role: 'member' } };
+  await attachGroupToProject('P1', 'g1', 'member');
+  expect(last().url).toContain('/projects/P1/group-grants');
+  expect(last().method).toBe('POST');
+  expect(last().body).toEqual({ group_id: 'g1', role: 'member' });
+});
+
+test('attachGroupToProject sends expires_at: null to explicitly clear expiry', async () => {
+  nextResponse = { status: 200, body: { project_id: 'P1', group_id: 'g1', role: 'member' } };
+  await attachGroupToProject('P1', 'g1', 'member', null);
+  expect(last().body).toEqual({ group_id: 'g1', role: 'member', expires_at: null });
+});
+
+test('attachGroupToProject sends a real expires_at string when given', async () => {
+  nextResponse = { status: 200, body: { project_id: 'P1', group_id: 'g1', role: 'member' } };
+  await attachGroupToProject('P1', 'g1', 'member', '2026-12-31T00:00:00Z');
+  expect(last().body).toEqual({ group_id: 'g1', role: 'member', expires_at: '2026-12-31T00:00:00Z' });
+});
+
+test('updateProjectGroupGrant PATCHes with { role } only when expiresAt is undefined', async () => {
+  nextResponse = { status: 200, body: { project_id: 'P1', group_id: 'g1', role: 'editor' } };
+  await updateProjectGroupGrant('P1', 'g1', 'editor');
+  expect(last().url).toContain('/projects/P1/group-grants/g1');
+  expect(last().method).toBe('PATCH');
+  expect(last().body).toEqual({ role: 'editor' });
+});
+
+test('updateProjectGroupGrant PATCHes with expires_at: null to clear expiry', async () => {
+  nextResponse = { status: 200, body: { project_id: 'P1', group_id: 'g1', role: 'editor' } };
+  await updateProjectGroupGrant('P1', 'g1', 'editor', null);
+  expect(last().body).toEqual({ role: 'editor', expires_at: null });
+});
+
+test('updateProjectGroupGrant PATCHes with a real expires_at string when given', async () => {
+  nextResponse = { status: 200, body: { project_id: 'P1', group_id: 'g1', role: 'editor' } };
+  await updateProjectGroupGrant('P1', 'g1', 'editor', '2026-12-31T00:00:00Z');
+  expect(last().body).toEqual({ role: 'editor', expires_at: '2026-12-31T00:00:00Z' });
+});
+
+test('detachGroupFromProject DELETEs /group-grants/:groupId', async () => {
+  nextResponse = { status: 200, body: { ok: true } };
+  await detachGroupFromProject('P1', 'g1');
+  expect(last().url).toContain('/projects/P1/group-grants/g1');
+  expect(last().method).toBe('DELETE');
+});
+
+// ── per-resource (agent/skill/secret) grants ────────────────────────────────
+
+test('listProjectResourceGrants GETs the resource-grants list', async () => {
+  nextResponse = {
+    status: 200,
+    body: { resources: { agents: [], skills: [], secrets: [] }, grants: [] },
+  };
+  const result = await listProjectResourceGrants('P1');
+  expect(last().url).toContain('/projects/P1/resource-grants');
+  expect(last().method).toBe('GET');
+  expect(result.grants).toEqual([]);
+});
+
+test('createProjectResourceGrant POSTs snake_case fields, omitting expires_at when not given', async () => {
+  nextResponse = { status: 200, body: { grant_id: 'gr1' } };
+  await createProjectResourceGrant('P1', {
+    resourceType: 'agent',
+    resourceId: 'researcher',
+    principalType: 'member',
+    principalId: 'u1',
+  });
+  expect(last().url).toContain('/projects/P1/resource-grants');
+  expect(last().method).toBe('POST');
+  expect(last().body).toEqual({
+    resource_type: 'agent',
+    resource_id: 'researcher',
+    principal_type: 'member',
+    principal_id: 'u1',
+  });
+});
+
+test('createProjectResourceGrant includes expires_at when explicitly given (including null)', async () => {
+  nextResponse = { status: 200, body: { grant_id: 'gr2' } };
+  await createProjectResourceGrant('P1', {
+    resourceType: 'skill',
+    resourceId: 'deploy',
+    principalType: 'group',
+    principalId: 'g1',
+    expiresAt: '2026-12-31T00:00:00Z',
+  });
+  expect(last().body).toEqual({
+    resource_type: 'skill',
+    resource_id: 'deploy',
+    principal_type: 'group',
+    principal_id: 'g1',
+    expires_at: '2026-12-31T00:00:00Z',
+  });
+
+  await createProjectResourceGrant('P1', {
+    resourceType: 'secret',
+    resourceId: 'api_key',
+    principalType: 'member',
+    principalId: 'u2',
+    expiresAt: null,
+  });
+  expect(last().body).toEqual({
+    resource_type: 'secret',
+    resource_id: 'api_key',
+    principal_type: 'member',
+    principal_id: 'u2',
+    expires_at: null,
+  });
+});
+
+test('deleteProjectResourceGrant DELETEs /resource-grants/:grantId', async () => {
+  nextResponse = { status: 200, body: { ok: true } };
+  await deleteProjectResourceGrant('P1', 'gr1');
+  expect(last().url).toContain('/projects/P1/resource-grants/gr1');
+  expect(last().method).toBe('DELETE');
+});
+
+// ── approvals inbox ──────────────────────────────────────────────────────────
+
+test('listPendingApprovals GETs the approvals inbox', async () => {
+  nextResponse = { status: 200, body: { count: 1, approvals: [] } };
+  const result = await listPendingApprovals('P1');
+  expect(last().url).toContain('/projects/P1/approvals');
+  expect(last().method).toBe('GET');
+  expect(result.count).toBe(1);
+});
+
+test('listSessionsNeedingInput GETs the needs-input summary', async () => {
+  nextResponse = { status: 200, body: { total: 2, sessions: { 's1': 2 } } };
+  const result = await listSessionsNeedingInput('P1');
+  expect(last().url).toContain('/projects/P1/approvals/needs-input');
+  expect(last().method).toBe('GET');
+  expect(result.total).toBe(2);
+});
+
+test('resolveApproval defaults scope to "once" and POSTs { decision, scope }', async () => {
+  nextResponse = { status: 200, body: { ok: true, scope: 'once' } };
+  await resolveApproval('P1', 'ex1', 'approve');
+  expect(last().url).toContain('/projects/P1/approvals/ex1');
+  expect(last().method).toBe('POST');
+  expect(last().body).toEqual({ decision: 'approve', scope: 'once' });
+});
+
+test('resolveApproval forwards an explicit "session" scope', async () => {
+  nextResponse = { status: 200, body: { ok: true, scope: 'session' } };
+  await resolveApproval('P1', 'ex1', 'deny', 'session');
+  expect(last().body).toEqual({ decision: 'deny', scope: 'session' });
+});

--- a/packages/sdk/src/platform/projects-client/accounts.test.ts
+++ b/packages/sdk/src/platform/projects-client/accounts.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, expect, mock, test } from 'bun:test';
+import { configureKortix } from '../config';
+import { validateToken } from './accounts';
+
+let calls: { url: string; method: string }[] = [];
+let nextResponse: { status: number; body: unknown } = { status: 200, body: {} };
+
+beforeEach(() => {
+  calls = [];
+  nextResponse = { status: 200, body: {} };
+  globalThis.fetch = mock(async (url: unknown, opts: { method?: string } = {}) => {
+    calls.push({ url: String(url), method: opts.method ?? 'GET' });
+    return new Response(JSON.stringify(nextResponse.body), {
+      status: nextResponse.status,
+      headers: { 'content-type': 'application/json' },
+    });
+  }) as unknown as typeof fetch;
+});
+
+configureKortix({ backendUrl: 'http://test.local', getToken: async () => 'tok' });
+const last = () => calls[calls.length - 1];
+
+test('validateToken hits GET /accounts/me and returns { valid: true, identity } on success', async () => {
+  nextResponse = {
+    status: 200,
+    body: {
+      user_id: 'u1',
+      email: 'a@b.com',
+      accounts: [{ account_id: 'acc-1', slug: 'acc-1', name: 'Acme', role: 'owner' }],
+    },
+  };
+  const result = await validateToken();
+  expect(last().url).toContain('/accounts/me');
+  expect(last().method).toBe('GET');
+  expect(result.valid).toBe(true);
+  expect(result.identity?.user_id).toBe('u1');
+  expect(result.error).toBeUndefined();
+});
+
+test('validateToken never throws — returns { valid: false, error } on a 401', async () => {
+  nextResponse = { status: 401, body: { message: 'invalid token' } };
+  const result = await validateToken();
+  expect(result.valid).toBe(false);
+  expect(result.identity).toBeUndefined();
+  expect(result.error).toBeTruthy();
+});

--- a/packages/sdk/src/platform/projects-client/accounts.ts
+++ b/packages/sdk/src/platform/projects-client/accounts.ts
@@ -1,6 +1,7 @@
 // Accounts — account CRUD, members, and account-level invitations.
 
 import { backendApi } from '../api-client';
+import type { ApiError } from '../api/errors';
 import { serverTokenGet, unwrap, type AccountRole, type ServerTokenOptions } from './shared';
 
 export interface KortixAccount {
@@ -245,4 +246,39 @@ export async function fetchAccountsWithToken(
   opts: ServerTokenOptions,
 ): Promise<KortixAccount[] | null> {
   return serverTokenGet<KortixAccount[]>(opts, '/v1/accounts');
+}
+
+/** The identity `GET /accounts/me` resolves — the authenticated user + their account memberships. */
+export interface AccountIdentity {
+  user_id: string;
+  email: string;
+  token_context?: {
+    auth_type: string | null;
+    project_id: string | null;
+    session_id: string | null;
+    agent: string | null;
+    connectors: 'all' | string[] | null;
+    kortix_cli: 'all' | string[] | null;
+  };
+  accounts: Array<{ account_id: string; slug: string; name: string; role: string }>;
+}
+
+export interface ValidateTokenResult {
+  valid: boolean;
+  identity?: AccountIdentity;
+  error?: ApiError;
+}
+
+/**
+ * The "did I paste a valid API key?" check — hits `GET /accounts/me` and
+ * NEVER throws, unlike every other call in this module. Built for a
+ * pasted-token UX (a CLI/SDK setup screen) that wants to render "invalid
+ * token" inline rather than catch an exception.
+ */
+export async function validateToken(): Promise<ValidateTokenResult> {
+  const res = await backendApi.get<AccountIdentity>('/accounts/me', { showErrors: false });
+  if (!res.success || !res.data) {
+    return { valid: false, error: res.error };
+  }
+  return { valid: true, identity: res.data };
 }

--- a/packages/sdk/src/platform/projects-client/audit.ts
+++ b/packages/sdk/src/platform/projects-client/audit.ts
@@ -1,0 +1,154 @@
+// Account audit log — the Enterprise "what changed" trail, backed by
+// `kortix.audit_events` (every mutation the global middleware + IAM helpers
+// record) plus per-account outbound webhooks that mirror it to a SIEM. Reads
+// are gated on `audit.read` + the account's `auditAccess` entitlement server-side.
+
+import { backendApi } from '../api-client';
+import { unwrap } from './shared';
+
+export interface AuditEvent {
+  event_id: string;
+  occurred_at: string;
+  actor_user_id: string | null;
+  action: string;
+  resource_type: string | null;
+  resource_id: string | null;
+  before: unknown;
+  after: unknown;
+  ip: string | null;
+  user_agent: string | null;
+  metadata: unknown;
+}
+
+export interface AuditEventList {
+  events: AuditEvent[];
+  /** Keyset pagination cursor for the next page; null when this is the last page. */
+  next_cursor: string | null;
+}
+
+export interface ListAccountAuditOptions {
+  /** Prefix match on `action` (e.g. `"iam.policy."`). */
+  action?: string;
+  /** Only events at or after this ISO-8601 instant. */
+  since?: string;
+  /** Keyset cursor from a previous page's `next_cursor`. */
+  cursor?: string;
+  /** Default 50, max 200 (server-clamped). */
+  limit?: number;
+}
+
+export async function listAccountAudit(accountId: string, options?: ListAccountAuditOptions) {
+  const search = new URLSearchParams();
+  if (options?.action) search.set('action', options.action);
+  if (options?.since) search.set('since', options.since);
+  if (options?.cursor) search.set('cursor', options.cursor);
+  if (options?.limit != null) search.set('limit', String(options.limit));
+  const qs = search.toString();
+  return unwrap(
+    await backendApi.get<AuditEventList>(`/accounts/${accountId}/audit${qs ? `?${qs}` : ''}`),
+  );
+}
+
+export interface ExportAccountAuditOptions {
+  format?: 'csv' | 'jsonl';
+  action?: string;
+  since?: string;
+}
+
+/**
+ * Stream an audit slice as CSV or JSONL (hard-capped at 10,000 rows per
+ * request — page via repeated `since=` calls for more). The underlying REST
+ * client sniffs `content-type`: a `text/csv` response resolves to a `string`;
+ * `application/x-ndjson` (the JSONL response) doesn't match the client's
+ * `text/*` check and resolves to a `Blob` instead — `await blob.text()` to
+ * read it as a string.
+ */
+export async function exportAccountAudit(
+  accountId: string,
+  options?: ExportAccountAuditOptions,
+): Promise<string | Blob> {
+  const search = new URLSearchParams();
+  if (options?.format) search.set('format', options.format);
+  if (options?.action) search.set('action', options.action);
+  if (options?.since) search.set('since', options.since);
+  const qs = search.toString();
+  return unwrap(
+    await backendApi.get<string | Blob>(`/accounts/${accountId}/audit/export${qs ? `?${qs}` : ''}`),
+  );
+}
+
+export interface AuditWebhookTestResult {
+  ok: boolean;
+  status?: number;
+  error?: string;
+}
+
+export interface AuditWebhook {
+  webhook_id: string;
+  name: string;
+  url: string;
+  enabled: boolean;
+  action_prefix: string | null;
+  last_delivered_at: string | null;
+  last_error_at: string | null;
+  last_error: string | null;
+  created_at: string;
+  updated_at: string;
+  /** Only present on the create response — the plaintext signing secret,
+   *  shown exactly once. */
+  secret?: string;
+  /** Only present on the create response — the outcome of the one-shot test delivery. */
+  test?: AuditWebhookTestResult;
+}
+
+export interface AuditWebhookListResponse {
+  webhooks: AuditWebhook[];
+}
+
+export async function listAccountAuditWebhooks(accountId: string) {
+  return unwrap(
+    await backendApi.get<AuditWebhookListResponse>(`/accounts/${accountId}/audit/webhooks`),
+  );
+}
+
+export interface CreateAuditWebhookInput {
+  name: string;
+  url: string;
+  action_prefix?: string;
+}
+
+export async function createAccountAuditWebhook(
+  accountId: string,
+  input: CreateAuditWebhookInput,
+) {
+  return unwrap(
+    await backendApi.post<AuditWebhook>(`/accounts/${accountId}/audit/webhooks`, input),
+  );
+}
+
+export interface UpdateAuditWebhookInput {
+  name?: string;
+  enabled?: boolean;
+  action_prefix?: string | null;
+}
+
+export async function updateAccountAuditWebhook(
+  accountId: string,
+  webhookId: string,
+  input: UpdateAuditWebhookInput,
+) {
+  return unwrap(
+    await backendApi.patch<AuditWebhook>(
+      `/accounts/${accountId}/audit/webhooks/${webhookId}`,
+      input,
+    ),
+  );
+}
+
+export async function removeAccountAuditWebhook(accountId: string, webhookId: string) {
+  return unwrap(
+    await backendApi.delete<{ deleted: boolean }>(
+      `/accounts/${accountId}/audit/webhooks/${webhookId}`,
+    ),
+  );
+}

--- a/packages/sdk/src/platform/projects-client/billing.test.ts
+++ b/packages/sdk/src/platform/projects-client/billing.test.ts
@@ -1,8 +1,23 @@
 import { beforeEach, expect, mock, test } from 'bun:test';
 import { configureKortix } from '../config';
-import { fetchAccountStateWithToken, getAccountState, getDefaultAccountState } from './billing';
+import {
+  cancelScheduledChange,
+  cancelSubscription,
+  confirmCheckoutSession,
+  configureAutoTopup,
+  createCheckoutSession,
+  createPortalSession,
+  fetchAccountStateWithToken,
+  getAccountState,
+  getAutoTopupSettings,
+  getDefaultAccountState,
+  getProrationPreview,
+  purchaseCredits,
+  reactivateSubscription,
+  scheduleDowngrade,
+} from './billing';
 
-let calls: { url: string; method: string; headers: Record<string, string> }[] = [];
+let calls: { url: string; method: string; headers: Record<string, string>; body: unknown }[] = [];
 let nextResponse: { status: number; body: unknown } = { status: 200, body: {} };
 
 beforeEach(() => {
@@ -13,6 +28,7 @@ beforeEach(() => {
       url: String(url),
       method: opts.method ?? 'GET',
       headers: (opts.headers as Record<string, string>) ?? {},
+      body: typeof opts.body === 'string' ? JSON.parse(opts.body) : undefined,
     });
     return new Response(JSON.stringify(nextResponse.body), {
       status: nextResponse.status,
@@ -77,4 +93,78 @@ test('fetchAccountStateWithToken returns null without throwing when no token is 
   const result = await fetchAccountStateWithToken({ backendUrl: 'http://backend.local/v1', accessToken: '' });
   expect(result).toBeNull();
   expect(calls.length).toBe(0);
+});
+
+// ── checkout / subscription / credits mutations ─────────────────────────────
+
+test('createCheckoutSession posts tier + urls to create-checkout-session', async () => {
+  nextResponse = { status: 200, body: { url: 'https://checkout.stripe.com/x' } };
+  await createCheckoutSession({
+    tierKey: 'pro',
+    successUrl: 'https://app.example.com/success',
+    cancelUrl: 'https://app.example.com/cancel',
+  });
+  expect(last().url).toContain('/billing/create-checkout-session');
+  expect(last().method).toBe('POST');
+  expect(last().body).toMatchObject({ tier_key: 'pro', success_url: 'https://app.example.com/success' });
+});
+
+test('confirmCheckoutSession posts session_id to confirm-checkout-session', async () => {
+  nextResponse = { status: 200, body: { ok: true } };
+  await confirmCheckoutSession('cs_123', 'acc-1');
+  expect(last().url).toContain('/billing/confirm-checkout-session');
+  expect(last().body).toEqual({ account_id: 'acc-1', session_id: 'cs_123' });
+});
+
+test('createPortalSession posts return_url to create-portal-session', async () => {
+  nextResponse = { status: 200, body: { url: 'https://billing.stripe.com/p/x' } };
+  await createPortalSession('https://app.example.com/billing');
+  expect(last().url).toContain('/billing/create-portal-session');
+  expect(last().body).toEqual({ account_id: undefined, return_url: 'https://app.example.com/billing' });
+});
+
+test('cancelSubscription / reactivateSubscription / scheduleDowngrade / cancelScheduledChange hit their endpoints', async () => {
+  nextResponse = { status: 200, body: { ok: true } };
+  await cancelSubscription('too expensive');
+  expect(last().url).toContain('/billing/cancel-subscription');
+
+  await reactivateSubscription();
+  expect(last().url).toContain('/billing/reactivate-subscription');
+
+  await scheduleDowngrade('starter', 'monthly');
+  expect(last().url).toContain('/billing/schedule-downgrade');
+  expect(last().body).toMatchObject({ target_tier_key: 'starter', commitment_type: 'monthly' });
+
+  await cancelScheduledChange();
+  expect(last().url).toContain('/billing/cancel-scheduled-change');
+});
+
+test('getProrationPreview GETs with new_price_id (+ optional account_id) as query params', async () => {
+  nextResponse = { status: 200, body: {} };
+  await getProrationPreview('price_123', 'acc-1');
+  expect(last().url).toContain('/billing/proration-preview?');
+  expect(last().url).toContain('new_price_id=price_123');
+  expect(last().url).toContain('account_id=acc-1');
+  expect(last().method).toBe('GET');
+});
+
+test('purchaseCredits posts amount + urls to purchase-credits', async () => {
+  nextResponse = { status: 200, body: { checkout_url: 'https://checkout.stripe.com/credits' } };
+  const result = await purchaseCredits({ amount: 20 });
+  expect(last().url).toContain('/billing/purchase-credits');
+  expect(last().body).toMatchObject({ amount: 20 });
+  expect(result.checkout_url).toContain('stripe.com');
+});
+
+test('getAutoTopupSettings GETs and configureAutoTopup POSTs auto-topup', async () => {
+  nextResponse = { status: 200, body: { enabled: false, threshold: 0, amount: 0 } };
+  await getAutoTopupSettings('acc-1');
+  expect(last().url).toContain('/billing/auto-topup/settings?account_id=acc-1');
+  expect(last().method).toBe('GET');
+
+  nextResponse = { status: 200, body: { enabled: true, threshold: 5, amount: 20 } };
+  const result = await configureAutoTopup({ enabled: true, threshold: 5, amount: 20 });
+  expect(last().url).toContain('/billing/auto-topup/configure');
+  expect(last().method).toBe('POST');
+  expect(result.enabled).toBe(true);
 });

--- a/packages/sdk/src/platform/projects-client/billing.ts
+++ b/packages/sdk/src/platform/projects-client/billing.ts
@@ -1,12 +1,13 @@
-// Billing account-state — the single source of truth for credits,
-// subscription, models, and limits. This is the entitlement-gating read: it
-// drives `accountHasAppAccess` and the app-access redirect on login. Stripe
-// checkout/portal/credits/auto-topup mutations are product-UI and stay
-// web-local (apps/web/src/lib/api/billing.ts) — only the account-state read
-// (and its server-side explicit-token variant) lives here.
+// Billing — account-state read (the single source of truth for credits,
+// subscription, models, and limits; drives `accountHasAppAccess` and the
+// app-access redirect on login) PLUS the checkout/subscription/credits
+// mutation surface (Stripe-backed). Wraps a deliberately curated subset of
+// apps/api/src/billing/routes — the ones a "Kortix as a Backend" host needs to
+// drive billing itself; Stripe-webhook-only routes and legacy/per-seat-claim
+// internals stay unwired.
 
 import { backendApi } from '../api-client';
-import { serverTokenGet, type ServerTokenOptions } from './shared';
+import { serverTokenGet, unwrap, type ServerTokenOptions } from './shared';
 
 export interface AccountState {
   credits: {
@@ -262,6 +263,150 @@ export async function getAccountState(options?: GetAccountStateOptions): Promise
   return response.data!;
 }
 
+/**
+ * Minimal variant of {@link getAccountState} (`/billing/account-state/minimal`)
+ * — same response shape (`AccountState`), a cheaper server-side build for
+ * surfaces that only need a subset (e.g. a header credit indicator). Same
+ * graceful-degradation behavior as the full read.
+ */
+export async function getAccountStateMinimal(options?: GetAccountStateOptions): Promise<AccountState> {
+  const search = new URLSearchParams();
+  if (options?.skipCache) search.set('skip_cache', 'true');
+  if (options?.accountId) search.set('account_id', options.accountId);
+  const query = search.toString();
+  const params = query ? `?${query}` : '';
+  const response = await backendApi.get<AccountState>(`/billing/account-state/minimal${params}`, {
+    showErrors: false,
+  });
+  const isGracefulDisabledResponse =
+    response.error?.status === 404 && /billing is not enabled/i.test(response.error.message || '');
+  if (response.error && response.error.status !== 401 && !isGracefulDisabledResponse) {
+    throw response.error;
+  }
+  if (response.error) {
+    return getDefaultAccountState();
+  }
+  return response.data!;
+}
+
+// ── Transactions / credit ledger ─────────────────────────────────────────────
+
+export interface BillingTransaction {
+  id: string;
+  created_at: string;
+  amount: number;
+  balance_after: number;
+  type: string;
+  description: string | null;
+  is_expiring: boolean | null;
+  expires_at: string | null;
+  metadata: unknown;
+}
+
+export interface BillingTransactionsPage {
+  transactions: BillingTransaction[];
+  pagination: {
+    total: number;
+    limit: number;
+    offset: number;
+    has_more: boolean;
+  };
+}
+
+export interface ListBillingTransactionsOptions {
+  accountId?: string;
+  limit?: number;
+  offset?: number;
+  /** A single type, or several (comma-joined on the wire). */
+  typeFilter?: string | string[];
+}
+
+export async function listBillingTransactions(
+  options?: ListBillingTransactionsOptions,
+): Promise<BillingTransactionsPage> {
+  const search = new URLSearchParams();
+  if (options?.accountId) search.set('account_id', options.accountId);
+  if (options?.limit != null) search.set('limit', String(options.limit));
+  if (options?.offset != null) search.set('offset', String(options.offset));
+  if (options?.typeFilter) {
+    search.set(
+      'type_filter',
+      Array.isArray(options.typeFilter) ? options.typeFilter.join(',') : options.typeFilter,
+    );
+  }
+  const query = search.toString();
+  return unwrap(
+    await backendApi.get<BillingTransactionsPage>(`/billing/transactions${query ? `?${query}` : ''}`),
+  );
+}
+
+/** Credits-in / credits-out totals over a trailing window of days (default 30). */
+export interface BillingTransactionsSummary {
+  totalCredits: number;
+  totalDebits: number;
+  count: number;
+}
+
+export async function getBillingTransactionsSummary(options?: {
+  accountId?: string;
+  days?: number;
+}): Promise<BillingTransactionsSummary> {
+  const search = new URLSearchParams();
+  if (options?.accountId) search.set('account_id', options.accountId);
+  if (options?.days != null) search.set('days', String(options.days));
+  const query = search.toString();
+  return unwrap(
+    await backendApi.get<BillingTransactionsSummary>(
+      `/billing/transactions/summary${query ? `?${query}` : ''}`,
+    ),
+  );
+}
+
+// ── Credits / tiers ───────────────────────────────────────────────────────────
+
+export interface BillingCreditBreakdown {
+  total: number;
+  expiring: number;
+  non_expiring: number;
+  daily: number;
+}
+
+/** Balance breakdown for the CALLER's own account (no `accountId` scoping —
+ *  the backend keys this read off the authenticated user directly). */
+export async function getBillingCreditBreakdown(): Promise<BillingCreditBreakdown> {
+  return unwrap(await backendApi.get<BillingCreditBreakdown>('/billing/credit-breakdown'));
+}
+
+/**
+ * Credit usage summary over a trailing window of days (default 30) — same
+ * shape as {@link getBillingTransactionsSummary}, but for the CALLER's own
+ * account (no `accountId` scoping).
+ */
+export async function getBillingUsageHistory(days?: number): Promise<BillingTransactionsSummary> {
+  const qs = days != null ? `?days=${days}` : '';
+  return unwrap(await backendApi.get<BillingTransactionsSummary>(`/billing/usage-history${qs}`));
+}
+
+export interface BillingTierConfiguration {
+  name: string;
+  display_name: string;
+  monthly_price: number;
+  yearly_price: number;
+  monthly_credits: number;
+  can_purchase_credits: boolean;
+}
+
+export interface BillingTierConfigurationsResponse {
+  tiers: BillingTierConfiguration[];
+}
+
+/** Publicly visible pricing tiers (for a plans/pricing page). */
+export async function getBillingTierConfigurations(): Promise<BillingTierConfigurationsResponse> {
+  return unwrap(
+    await backendApi.get<BillingTierConfigurationsResponse>('/billing/tier-configurations'),
+  );
+}
+
 // ── Server-side explicit-token variant ──────────────────────────────────────
 
 /**
@@ -293,4 +438,218 @@ export async function fetchAccountStateWithToken(
 ): Promise<AccountStateAppAccessView | null> {
   const query = opts.accountId ? `?account_id=${encodeURIComponent(opts.accountId)}` : '';
   return serverTokenGet<AccountStateAppAccessView>(opts, `/v1/billing/account-state${query}`);
+}
+
+// ── Checkout / subscription / credits mutations ─────────────────────────────
+//
+// All bodies accept an optional `account_id` (the backend falls back to the
+// caller's own account when omitted) plus opaque Stripe-service fields the
+// server forwards mostly as-is — responses are intentionally loose
+// (`Record<string, unknown>`-ish) since the server schemas are opaque
+// (`z.record(...)`) on purpose.
+
+export interface CreateCheckoutSessionInput {
+  accountId?: string;
+  tierKey: string;
+  successUrl: string;
+  cancelUrl: string;
+  commitmentType?: string;
+  locale?: string;
+  serverType?: string;
+  location?: string;
+}
+
+export interface CheckoutSessionResult {
+  url?: string | null;
+  session_id?: string;
+  [key: string]: unknown;
+}
+
+/** Create a Stripe checkout session for a subscription tier. */
+export async function createCheckoutSession(
+  input: CreateCheckoutSessionInput,
+): Promise<CheckoutSessionResult> {
+  return unwrap(
+    await backendApi.post<CheckoutSessionResult>('/billing/create-checkout-session', {
+      account_id: input.accountId,
+      tier_key: input.tierKey,
+      success_url: input.successUrl,
+      cancel_url: input.cancelUrl,
+      commitment_type: input.commitmentType,
+      locale: input.locale,
+      server_type: input.serverType,
+      location: input.location,
+    }),
+    'Failed to create checkout session',
+  );
+}
+
+export interface ConfirmCheckoutSessionResult {
+  ok?: boolean;
+  [key: string]: unknown;
+}
+
+/** Confirm a completed Stripe checkout session (post-redirect). */
+export async function confirmCheckoutSession(
+  sessionId: string,
+  accountId?: string,
+): Promise<ConfirmCheckoutSessionResult> {
+  return unwrap(
+    await backendApi.post<ConfirmCheckoutSessionResult>('/billing/confirm-checkout-session', {
+      account_id: accountId,
+      session_id: sessionId,
+    }),
+    'Failed to confirm checkout session',
+  );
+}
+
+export interface PortalSessionResult {
+  url?: string | null;
+  [key: string]: unknown;
+}
+
+/** Create a Stripe customer-portal session (manage payment method / invoices / cancel). */
+export async function createPortalSession(
+  returnUrl: string,
+  accountId?: string,
+): Promise<PortalSessionResult> {
+  return unwrap(
+    await backendApi.post<PortalSessionResult>('/billing/create-portal-session', {
+      account_id: accountId,
+      return_url: returnUrl,
+    }),
+    'Failed to create portal session',
+  );
+}
+
+export interface SubscriptionMutationResult {
+  ok?: boolean;
+  [key: string]: unknown;
+}
+
+/** Cancel the active subscription (optionally recording cancellation feedback). */
+export async function cancelSubscription(
+  feedback?: string,
+  accountId?: string,
+): Promise<SubscriptionMutationResult> {
+  return unwrap(
+    await backendApi.post<SubscriptionMutationResult>('/billing/cancel-subscription', {
+      account_id: accountId,
+      feedback,
+    }),
+    'Failed to cancel subscription',
+  );
+}
+
+/** Reactivate a subscription that was scheduled for cancellation. */
+export async function reactivateSubscription(accountId?: string): Promise<SubscriptionMutationResult> {
+  return unwrap(
+    await backendApi.post<SubscriptionMutationResult>('/billing/reactivate-subscription', {
+      account_id: accountId,
+    }),
+    'Failed to reactivate subscription',
+  );
+}
+
+/** Schedule a downgrade to a lower tier, effective at the current period end. */
+export async function scheduleDowngrade(
+  targetTierKey: string,
+  commitmentType?: string,
+  accountId?: string,
+): Promise<SubscriptionMutationResult> {
+  return unwrap(
+    await backendApi.post<SubscriptionMutationResult>('/billing/schedule-downgrade', {
+      account_id: accountId,
+      target_tier_key: targetTierKey,
+      commitment_type: commitmentType,
+    }),
+    'Failed to schedule downgrade',
+  );
+}
+
+/** Cancel a previously scheduled downgrade/plan change. */
+export async function cancelScheduledChange(accountId?: string): Promise<SubscriptionMutationResult> {
+  return unwrap(
+    await backendApi.post<SubscriptionMutationResult>('/billing/cancel-scheduled-change', {
+      account_id: accountId,
+    }),
+    'Failed to cancel scheduled change',
+  );
+}
+
+export interface ProrationPreviewResult {
+  [key: string]: unknown;
+}
+
+/** Preview proration for a price change (new Stripe price id) before committing to it. */
+export async function getProrationPreview(
+  newPriceId: string,
+  accountId?: string,
+): Promise<ProrationPreviewResult> {
+  const search = new URLSearchParams({ new_price_id: newPriceId });
+  if (accountId) search.set('account_id', accountId);
+  return unwrap(
+    await backendApi.get<ProrationPreviewResult>(`/billing/proration-preview?${search.toString()}`),
+    'Failed to load proration preview',
+  );
+}
+
+export interface PurchaseCreditsInput {
+  amount: number;
+  accountId?: string;
+  successUrl?: string;
+  cancelUrl?: string;
+}
+
+export interface PurchaseCreditsResult {
+  checkout_url: string | null;
+}
+
+/** Create a Stripe checkout session to purchase a one-off credit top-up. */
+export async function purchaseCredits(input: PurchaseCreditsInput): Promise<PurchaseCreditsResult> {
+  return unwrap(
+    await backendApi.post<PurchaseCreditsResult>('/billing/purchase-credits', {
+      amount: input.amount,
+      account_id: input.accountId,
+      success_url: input.successUrl,
+      cancel_url: input.cancelUrl,
+    }),
+    'Failed to purchase credits',
+  );
+}
+
+export interface AutoTopupSettings {
+  enabled: boolean;
+  threshold: number;
+  amount: number;
+  [key: string]: unknown;
+}
+
+/** Get the account's auto-topup settings (enabled/threshold/amount). */
+export async function getAutoTopupSettings(accountId?: string): Promise<AutoTopupSettings> {
+  const query = accountId ? `?account_id=${encodeURIComponent(accountId)}` : '';
+  return unwrap(
+    await backendApi.get<AutoTopupSettings>(`/billing/auto-topup/settings${query}`),
+    'Failed to load auto-topup settings',
+  );
+}
+
+export interface ConfigureAutoTopupInput {
+  accountId?: string;
+  enabled: boolean;
+  threshold: number;
+  amount: number;
+}
+
+/** Configure (enable/disable, threshold, amount) auto-topup — recurring credit purchases. */
+export async function configureAutoTopup(input: ConfigureAutoTopupInput): Promise<AutoTopupSettings> {
+  return unwrap(
+    await backendApi.post<AutoTopupSettings>('/billing/auto-topup/configure', {
+      account_id: input.accountId,
+      enabled: input.enabled,
+      threshold: input.threshold,
+      amount: input.amount,
+    }),
+    'Failed to configure auto-topup',
+  );
 }

--- a/packages/sdk/src/platform/projects-client/channels.test.ts
+++ b/packages/sdk/src/platform/projects-client/channels.test.ts
@@ -8,13 +8,16 @@ import {
   getEmailInstallation,
   getEmailMode,
   getMeetVoices,
+  getSlackChannelFile,
   getSlackInstallation,
   getSlackManifest,
   getSlackMode,
   previewMeetVoice,
   setMeetBotName,
   setMeetVoice,
+  speakInMeeting,
   updateEmailPolicy,
+  uploadSlackChannelFile,
 } from './channels';
 
 let calls: { url: string; method: string; body: unknown }[] = [];
@@ -148,6 +151,37 @@ test('previewMeetVoice posts to the per-voice preview endpoint and returns null 
 
   nextResponse = { status: 500, body: {} };
   expect(await previewMeetVoice('P1', 'voice-1')).toBeNull();
+});
+
+test('getSlackChannelFile GETs the file proxy with the url query param', async () => {
+  nextResponse = { status: 200, body: { data: 'bytes' } };
+  await getSlackChannelFile('P1', 'https://files.slack.com/x/y.pdf');
+  expect(last().url).toContain('/projects/P1/channels/slack/file?url=');
+  expect(last().url).toContain(encodeURIComponent('https://files.slack.com/x/y.pdf'));
+  expect(last().method).toBe('GET');
+});
+
+test('uploadSlackChannelFile posts channel/filename/content_base64 to the upload proxy', async () => {
+  nextResponse = { status: 200, body: { ok: true, files: [] } };
+  const result = await uploadSlackChannelFile('P1', {
+    channel: 'C1',
+    filename: 'report.pdf',
+    contentBase64: 'YWJj',
+    comment: 'here you go',
+  });
+  expect(last().url).toContain('/projects/P1/channels/slack/file/upload');
+  expect(last().method).toBe('POST');
+  expect(last().body).toMatchObject({ channel: 'C1', filename: 'report.pdf', content_base64: 'YWJj', comment: 'here you go' });
+  expect(result.ok).toBe(true);
+});
+
+test('speakInMeeting posts bot_id/text/voice to the meet speak endpoint', async () => {
+  nextResponse = { status: 200, body: { ok: true, voice: 'voice-1' } };
+  const result = await speakInMeeting('P1', 'bot-1', 'hello there', 'voice-1');
+  expect(last().url).toContain('/projects/P1/channels/meet/speak');
+  expect(last().method).toBe('POST');
+  expect(last().body).toEqual({ bot_id: 'bot-1', text: 'hello there', voice: 'voice-1' });
+  expect(result.voice).toBe('voice-1');
 });
 
 test('updateEmailPolicy defaults connector_slug to kortix_email', async () => {

--- a/packages/sdk/src/platform/projects-client/channels.ts
+++ b/packages/sdk/src/platform/projects-client/channels.ts
@@ -72,6 +72,55 @@ export async function disconnectSlack(projectId: string): Promise<void> {
   if (!res.success) throw new Error(res.error?.message ?? 'Failed to disconnect');
 }
 
+/**
+ * Download a Slack-hosted file through the server-side proxy (SSRF-guarded to
+ * `*.slack.com`) — the bot token never reaches the sandbox. Backs `slack download`.
+ */
+export async function getSlackChannelFile(projectId: string, url: string): Promise<Blob> {
+  return unwrap(
+    await backendApi.get<Blob>(
+      `/projects/${encodeURIComponent(projectId)}/channels/slack/file?url=${encodeURIComponent(url)}`,
+      { showErrors: false },
+    ),
+    'Failed to download Slack file',
+  );
+}
+
+export interface UploadSlackChannelFileInput {
+  channel: string;
+  filename: string;
+  /** Base64-encoded file content. */
+  contentBase64: string;
+  comment?: string;
+  threadTs?: string;
+}
+
+export interface UploadSlackChannelFileResult {
+  ok: boolean;
+  files: unknown;
+}
+
+/** Upload a file to Slack through the server-side 3-step external-upload proxy. Backs `slack send --file`. */
+export async function uploadSlackChannelFile(
+  projectId: string,
+  input: UploadSlackChannelFileInput,
+): Promise<UploadSlackChannelFileResult> {
+  return unwrap(
+    await backendApi.post<UploadSlackChannelFileResult>(
+      `/projects/${encodeURIComponent(projectId)}/channels/slack/file/upload`,
+      {
+        channel: input.channel,
+        filename: input.filename,
+        content_base64: input.contentBase64,
+        comment: input.comment,
+        thread_ts: input.threadTs,
+      },
+      { showErrors: false },
+    ),
+    'Failed to upload Slack file',
+  );
+}
+
 export interface EmailSenderPolicy {
   mode: 'allow_all' | 'restricted';
   allowedEmails: string[];
@@ -230,4 +279,29 @@ export async function previewMeetVoice(
   );
   if (!res.success || !res.data?.b64) return null;
   return res.data.b64;
+}
+
+export interface SpeakInMeetingResult {
+  ok: boolean;
+  voice: string;
+}
+
+/**
+ * Make the meeting bot speak: text → ElevenLabs (project voice) → Recall
+ * `output_audio`, both keys kept server-side. Backs `meet speak`.
+ */
+export async function speakInMeeting(
+  projectId: string,
+  botId: string,
+  text: string,
+  voice?: string,
+): Promise<SpeakInMeetingResult> {
+  return unwrap(
+    await backendApi.post<SpeakInMeetingResult>(
+      `/projects/${encodeURIComponent(projectId)}/channels/meet/speak`,
+      { bot_id: botId, text, voice },
+      { showErrors: false },
+    ),
+    'Failed to speak in meeting',
+  );
 }

--- a/packages/sdk/src/platform/projects-client/connectors.test.ts
+++ b/packages/sdk/src/platform/projects-client/connectors.test.ts
@@ -1,0 +1,221 @@
+import { beforeEach, expect, mock, test } from 'bun:test';
+import { configureKortix } from '../config';
+import {
+  createConnector,
+  deleteConnector,
+  getConnectorConfig,
+  getConnectorPolicies,
+  getConnectStatus,
+  listConnectors,
+  listPipedreamApps,
+  pipedreamConnect,
+  pipedreamFinalize,
+  setConnectorAgentScope,
+  setConnectorCredential,
+  setConnectorCredentialMode,
+  setConnectorName,
+  setConnectorPolicies,
+  setConnectorSensitive,
+  setConnectorSharing,
+  syncConnectors,
+} from './connectors';
+
+let calls: { url: string; method: string; body: unknown }[] = [];
+let nextResponse: { status: number; body: unknown } = { status: 200, body: {} };
+
+beforeEach(() => {
+  calls = [];
+  nextResponse = { status: 200, body: {} };
+  globalThis.fetch = mock(async (url: unknown, opts: { method?: string; body?: string } = {}) => {
+    calls.push({
+      url: String(url),
+      method: opts.method ?? 'GET',
+      body: opts.body ? JSON.parse(opts.body) : undefined,
+    });
+    return new Response(JSON.stringify(nextResponse.body), {
+      status: nextResponse.status,
+      headers: { 'content-type': 'application/json' },
+    });
+  }) as unknown as typeof fetch;
+});
+
+configureKortix({ backendUrl: 'http://test.local', getToken: async () => 'tok' });
+const last = () => calls[calls.length - 1];
+
+test('listConnectors GETs the project connectors list', async () => {
+  nextResponse = { status: 200, body: { connectors: [] } };
+  const result = await listConnectors('P1');
+  expect(last().url).toContain('/executor/projects/P1/connectors');
+  expect(last().method).toBe('GET');
+  expect(result).toEqual({ connectors: [] });
+});
+
+test('listConnectors throws on a failed response', async () => {
+  nextResponse = { status: 500, body: { message: 'boom' } };
+  await expect(listConnectors('P1')).rejects.toBeTruthy();
+});
+
+test('syncConnectors POSTs an empty body to the sync endpoint', async () => {
+  nextResponse = { status: 200, body: { synced: 2, errors: [] } };
+  const result = await syncConnectors('P1');
+  expect(last().url).toContain('/executor/projects/P1/connectors/sync');
+  expect(last().method).toBe('POST');
+  expect(last().body).toEqual({});
+  expect(result).toEqual({ synced: 2, errors: [] });
+});
+
+test('setConnectorSharing PUTs the sharing intent as the raw body', async () => {
+  nextResponse = { status: 200, body: { ok: true } };
+  const result = await setConnectorSharing('P1', 'slack', { mode: 'project' });
+  expect(last().url).toContain('/executor/projects/P1/connectors/slack/sharing');
+  expect(last().method).toBe('PUT');
+  expect(last().body).toEqual({ mode: 'project' });
+  expect(result).toEqual({ ok: true });
+});
+
+test('setConnectorCredentialMode PUTs { mode }', async () => {
+  nextResponse = { status: 200, body: { ok: true } };
+  await setConnectorCredentialMode('P1', 'slack', 'per_user');
+  expect(last().url).toContain('/executor/projects/P1/connectors/slack/credential-mode');
+  expect(last().method).toBe('PUT');
+  expect(last().body).toEqual({ mode: 'per_user' });
+});
+
+test('setConnectorSensitive PUTs { sensitive }', async () => {
+  nextResponse = { status: 200, body: { ok: true } };
+  await setConnectorSensitive('P1', 'slack', true);
+  expect(last().url).toContain('/executor/projects/P1/connectors/slack/sensitive');
+  expect(last().method).toBe('PUT');
+  expect(last().body).toEqual({ sensitive: true });
+});
+
+test('setConnectorAgentScope PUTs { agent_scope } (snake_case) including the null "all agents" case', async () => {
+  nextResponse = { status: 200, body: { ok: true } };
+  await setConnectorAgentScope('P1', 'slack', ['researcher']);
+  expect(last().url).toContain('/executor/projects/P1/connectors/slack/agent-scope');
+  expect(last().method).toBe('PUT');
+  expect(last().body).toEqual({ agent_scope: ['researcher'] });
+
+  await setConnectorAgentScope('P1', 'slack', null);
+  expect(last().body).toEqual({ agent_scope: null });
+});
+
+test('getConnectorPolicies GETs the policies list', async () => {
+  nextResponse = { status: 200, body: { policies: [{ match: '*', action: 'require_approval' }] } };
+  const result = await getConnectorPolicies('P1', 'slack');
+  expect(last().url).toContain('/executor/projects/P1/connectors/slack/policies');
+  expect(last().method).toBe('GET');
+  expect(result.policies).toHaveLength(1);
+});
+
+test('setConnectorPolicies PUTs { policies }', async () => {
+  nextResponse = { status: 200, body: { ok: true } };
+  const policies = [{ match: 'send_message', action: 'block' as const }];
+  await setConnectorPolicies('P1', 'slack', policies);
+  expect(last().url).toContain('/executor/projects/P1/connectors/slack/policies');
+  expect(last().method).toBe('PUT');
+  expect(last().body).toEqual({ policies });
+});
+
+test('getConnectorConfig GETs the config, url-encoding a slug with special characters', async () => {
+  nextResponse = {
+    status: 200,
+    body: {
+      slug: 'my app/v1',
+      provider: 'mcp',
+      platform: null,
+      credentialMode: 'shared',
+      app: null,
+      account: null,
+      url: null,
+      transport: 'http',
+      endpoint: null,
+      baseUrl: null,
+      spec: null,
+      auth: { type: 'none', in: 'header', name: null, prefix: null },
+    },
+  };
+  const result = await getConnectorConfig('P1', 'my app/v1');
+  expect(last().url).toContain(
+    `/executor/projects/P1/connectors/${encodeURIComponent('my app/v1')}/config`,
+  );
+  expect(last().url).not.toContain('my app/v1');
+  expect(last().method).toBe('GET');
+  expect(result.slug).toBe('my app/v1');
+});
+
+test('setConnectorName PUTs { name }', async () => {
+  nextResponse = { status: 200, body: { ok: true } };
+  await setConnectorName('P1', 'slack', 'Team Slack');
+  expect(last().url).toContain('/executor/projects/P1/connectors/slack/name');
+  expect(last().method).toBe('PUT');
+  expect(last().body).toEqual({ name: 'Team Slack' });
+});
+
+test('pipedreamConnect POSTs an empty body to the connect endpoint', async () => {
+  nextResponse = { status: 200, body: { connectUrl: 'https://pipedream.com/connect/x' } };
+  const result = await pipedreamConnect('P1', 'github');
+  expect(last().url).toContain('/executor/projects/P1/connectors/github/connect');
+  expect(last().method).toBe('POST');
+  expect(last().body).toEqual({});
+  expect(result.connectUrl).toContain('pipedream.com');
+});
+
+test('createConnector POSTs the draft as the raw body', async () => {
+  nextResponse = { status: 200, body: { ok: true } };
+  const draft = { slug: 'my-http', provider: 'http' as const, url: 'https://example.com' };
+  await createConnector('P1', draft);
+  expect(last().url).toContain('/executor/projects/P1/connectors');
+  expect(last().url).not.toContain('/connectors/');
+  expect(last().method).toBe('POST');
+  expect(last().body).toEqual(draft);
+});
+
+test('deleteConnector DELETEs the connector by slug', async () => {
+  nextResponse = { status: 200, body: { ok: true } };
+  await deleteConnector('P1', 'slack');
+  expect(last().url).toContain('/executor/projects/P1/connectors/slack');
+  expect(last().method).toBe('DELETE');
+});
+
+test('listPipedreamApps GETs with no query string when no optional params are given', async () => {
+  nextResponse = { status: 200, body: { apps: [], hasMore: false } };
+  await listPipedreamApps('P1');
+  expect(last().url).toContain('/executor/projects/P1/pipedream/apps');
+  expect(last().url).not.toContain('?');
+  expect(last().method).toBe('GET');
+});
+
+test('listPipedreamApps GETs with q + cursor as query params when given', async () => {
+  nextResponse = { status: 200, body: { apps: [], nextCursor: 'c2', hasMore: true } };
+  const result = await listPipedreamApps('P1', 'slack', 'c1');
+  expect(last().url).toContain('/executor/projects/P1/pipedream/apps?');
+  expect(last().url).toContain('q=slack');
+  expect(last().url).toContain('cursor=c1');
+  expect(result.nextCursor).toBe('c2');
+});
+
+test('getConnectStatus GETs the deployment-wide connect-status endpoint', async () => {
+  nextResponse = { status: 200, body: { configured: true, provider: 'pipedream' } };
+  const result = await getConnectStatus();
+  expect(last().url).toContain('/executor/connect-status');
+  expect(last().method).toBe('GET');
+  expect(result).toEqual({ configured: true, provider: 'pipedream' });
+});
+
+test('setConnectorCredential PUTs { value }', async () => {
+  nextResponse = { status: 200, body: { ok: true } };
+  await setConnectorCredential('P1', 'slack', 'sekret');
+  expect(last().url).toContain('/executor/projects/P1/connectors/slack/credential');
+  expect(last().method).toBe('PUT');
+  expect(last().body).toEqual({ value: 'sekret' });
+});
+
+test('pipedreamFinalize POSTs an empty body to the connect/finalize endpoint', async () => {
+  nextResponse = { status: 200, body: { connected: true, accountId: 'acc_1' } };
+  const result = await pipedreamFinalize('P1', 'github');
+  expect(last().url).toContain('/executor/projects/P1/connectors/github/connect/finalize');
+  expect(last().method).toBe('POST');
+  expect(last().body).toEqual({});
+  expect(result).toEqual({ connected: true, accountId: 'acc_1' });
+});

--- a/packages/sdk/src/platform/projects-client/gateway.test.ts
+++ b/packages/sdk/src/platform/projects-client/gateway.test.ts
@@ -8,6 +8,7 @@ import {
   getGatewayOverview,
   listGatewayLogs,
   revokeGatewayKey,
+  runGatewayPlayground,
   setGatewayBudget,
 } from './gateway';
 
@@ -92,4 +93,16 @@ test('getGatewayKeys returns the keys list', async () => {
   nextResponse = { status: 200, body: { keys: [], gateway_url: 'https://gw.local' } };
   const result = await getGatewayKeys('P1');
   expect(result.gateway_url).toBe('https://gw.local');
+});
+
+test('runGatewayPlayground posts prompt + models and returns per-model results', async () => {
+  nextResponse = {
+    status: 200,
+    body: { results: [{ model: 'gpt-4o', ok: true, latency_ms: 120, output: 'hi' }] },
+  };
+  const result = await runGatewayPlayground('P1', 'Say hi', ['gpt-4o', 'claude-3']);
+  expect(last().url).toContain('/projects/P1/gateway/playground');
+  expect(last().method).toBe('POST');
+  expect(last().body).toEqual({ prompt: 'Say hi', models: ['gpt-4o', 'claude-3'] });
+  expect(result.results[0]?.model).toBe('gpt-4o');
 });

--- a/packages/sdk/src/platform/projects-client/gateway.ts
+++ b/packages/sdk/src/platform/projects-client/gateway.ts
@@ -279,3 +279,32 @@ export async function revokeGatewayKey(
     'Gateway request failed',
   );
 }
+
+export interface GatewayPlaygroundResult {
+  model: string;
+  ok: boolean;
+  latency_ms?: number;
+  output?: string;
+  input_tokens?: number;
+  output_tokens?: number;
+  error?: string;
+}
+
+export interface GatewayPlaygroundResponse {
+  results: GatewayPlaygroundResult[];
+}
+
+/** Run one prompt against up to 6 models side by side (a model-comparison playground). */
+export async function runGatewayPlayground(
+  projectId: string,
+  prompt: string,
+  models: string[],
+): Promise<GatewayPlaygroundResponse> {
+  return unwrap(
+    await backendApi.post<GatewayPlaygroundResponse>(`/projects/${projectId}/gateway/playground`, {
+      prompt,
+      models,
+    }),
+    'Gateway request failed',
+  );
+}

--- a/packages/sdk/src/platform/projects-client/index.ts
+++ b/packages/sdk/src/platform/projects-client/index.ts
@@ -26,6 +26,11 @@ export * from './transcription';
 export * from './review';
 export * from './sandbox-shares';
 export * from './public-session-shares';
+export * from './tokens';
+export * from './marketplace';
+export * from './audit';
+export * from './setup-links';
+export * from './marketplace-catalog';
 
 // Cross-cutting types that originally lived in this module. Re-exported
 // explicitly (not the internal `unwrap` helper) to keep the surface identical.

--- a/packages/sdk/src/platform/projects-client/manifest-git-token.test.ts
+++ b/packages/sdk/src/platform/projects-client/manifest-git-token.test.ts
@@ -1,0 +1,53 @@
+// Covers two small project-scoped mutations that live in `./projects.ts`
+// (manifest validation + git push-token minting) — split into their own file
+// because `projects.test.ts` is dedicated to the server-token
+// (`provisionProjectWithToken`) idiom, not the standard configureKortix() one.
+
+import { beforeEach, expect, mock, test } from 'bun:test';
+import { configureKortix } from '../config';
+import { getProjectGitToken, validateProjectManifest } from './projects';
+
+let calls: { url: string; method: string; body: unknown }[] = [];
+let nextResponse: { status: number; body: unknown } = { status: 200, body: {} };
+
+beforeEach(() => {
+  calls = [];
+  nextResponse = { status: 200, body: {} };
+  globalThis.fetch = mock(async (url: unknown, opts: { method?: string; body?: string } = {}) => {
+    calls.push({
+      url: String(url),
+      method: opts.method ?? 'GET',
+      body: opts.body ? JSON.parse(opts.body) : undefined,
+    });
+    return new Response(JSON.stringify(nextResponse.body), {
+      status: nextResponse.status,
+      headers: { 'content-type': 'application/json' },
+    });
+  }) as unknown as typeof fetch;
+});
+
+configureKortix({ backendUrl: 'http://test.local', getToken: async () => 'tok' });
+const last = () => calls[calls.length - 1];
+
+test('validateProjectManifest posts { raw } and returns the verdict', async () => {
+  nextResponse = { status: 200, body: { valid: false, issues: [{ message: 'missing [project]' }] } };
+  const result = await validateProjectManifest('P1', 'name = "x"');
+  expect(last().url).toContain('/projects/P1/manifest/validate');
+  expect(last().method).toBe('POST');
+  expect(last().body).toEqual({ raw: 'name = "x"' });
+  expect(result.valid).toBe(false);
+  expect(result.issues).toHaveLength(1);
+});
+
+test('getProjectGitToken posts to git-token and returns the push token', async () => {
+  nextResponse = { status: 200, body: { push_token: 'tok_abc', repo_id: 'r1', repo_url: 'https://github.com/x/y' } };
+  const result = await getProjectGitToken('P1');
+  expect(last().url).toContain('/projects/P1/git-token');
+  expect(last().method).toBe('POST');
+  expect(result.push_token).toBe('tok_abc');
+});
+
+test('getProjectGitToken throws on a 409 (BYO project, not managed)', async () => {
+  nextResponse = { status: 409, body: { message: 'Project is not a managed repo' } };
+  await expect(getProjectGitToken('P1')).rejects.toThrow();
+});

--- a/packages/sdk/src/platform/projects-client/marketplace-catalog.test.ts
+++ b/packages/sdk/src/platform/projects-client/marketplace-catalog.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, expect, mock, test } from 'bun:test';
+import { configureKortix } from '../config';
+import {
+  addMarketplaceSource,
+  getMarketplaceCatalogItem,
+  getMarketplaceCatalogItemFile,
+  listFeaturedMarketplaces,
+  listMarketplaceCatalogItems,
+  listMarketplaceSources,
+  listMarketplaces,
+  removeMarketplaceSource,
+} from './marketplace-catalog';
+
+let calls: { url: string; method: string; body: unknown }[] = [];
+let nextResponse: { status: number; body: unknown } = { status: 200, body: {} };
+
+beforeEach(() => {
+  calls = [];
+  nextResponse = { status: 200, body: {} };
+  globalThis.fetch = mock(async (url: unknown, opts: { method?: string; body?: string } = {}) => {
+    calls.push({
+      url: String(url),
+      method: opts.method ?? 'GET',
+      body: opts.body ? JSON.parse(opts.body) : undefined,
+    });
+    return new Response(JSON.stringify(nextResponse.body), {
+      status: nextResponse.status,
+      headers: { 'content-type': 'application/json' },
+    });
+  }) as unknown as typeof fetch;
+});
+
+configureKortix({ backendUrl: 'http://test.local', getToken: async () => 'tok' });
+const last = () => calls[calls.length - 1];
+
+test('listMarketplaceCatalogItems builds the query string from query/type/source', async () => {
+  nextResponse = { status: 200, body: { items: [] } };
+  await listMarketplaceCatalogItems({ query: 'slack', type: 'agent', source: 'kortix' });
+  expect(last().url).toContain('/marketplace/items?');
+  expect(last().url).toContain('query=slack');
+  expect(last().url).toContain('type=agent');
+  expect(last().url).toContain('source=kortix');
+});
+
+test('listMarketplaceCatalogItems omits the query string when no options given', async () => {
+  nextResponse = { status: 200, body: { items: [] } };
+  await listMarketplaceCatalogItems();
+  expect(last().url).toBe('http://test.local/marketplace/items');
+});
+
+test('listMarketplaces and listFeaturedMarketplaces hit their own endpoints', async () => {
+  nextResponse = { status: 200, body: { marketplaces: [] } };
+  await listMarketplaces();
+  expect(last().url).toContain('/marketplace/marketplaces');
+
+  nextResponse = { status: 200, body: { featured: [] } };
+  await listFeaturedMarketplaces();
+  expect(last().url).toContain('/marketplace/marketplaces/featured');
+});
+
+test('getMarketplaceCatalogItem and getMarketplaceCatalogItemFile hit item-scoped endpoints', async () => {
+  nextResponse = { status: 200, body: { id: 'kortix:researcher', title: 'Researcher' } };
+  await getMarketplaceCatalogItem('kortix:researcher');
+  expect(last().url).toContain('/marketplace/items/kortix%3Aresearcher');
+
+  nextResponse = { status: 200, body: { path: 'agent.md', content: '# hi' } };
+  await getMarketplaceCatalogItemFile('kortix:researcher', 'agent.md');
+  expect(last().url).toContain('/marketplace/items/kortix%3Aresearcher/file?path=agent.md');
+});
+
+test('getMarketplaceCatalogItem throws with "Item not found" on a 404', async () => {
+  nextResponse = { status: 404, body: {} };
+  await expect(getMarketplaceCatalogItem('missing')).rejects.toThrow();
+});
+
+test('marketplace sources: list/add/remove', async () => {
+  nextResponse = { status: 200, body: { sources: [] } };
+  await listMarketplaceSources();
+  expect(last().url).toContain('/marketplace/sources');
+  expect(last().method).toBe('GET');
+
+  nextResponse = { status: 200, body: { source: { id: 'SRC1', address: 'https://github.com/acme/registry' } } };
+  const added = await addMarketplaceSource({ address: 'https://github.com/acme/registry' });
+  expect(last().url).toContain('/marketplace/sources');
+  expect(last().method).toBe('POST');
+  expect(last().body).toMatchObject({ address: 'https://github.com/acme/registry' });
+  expect(added.source.id).toBe('SRC1');
+
+  nextResponse = { status: 200, body: { ok: true } };
+  await removeMarketplaceSource('SRC1');
+  expect(last().url).toContain('/marketplace/sources/SRC1');
+  expect(last().method).toBe('DELETE');
+});

--- a/packages/sdk/src/platform/projects-client/marketplace-catalog.ts
+++ b/packages/sdk/src/platform/projects-client/marketplace-catalog.ts
@@ -1,0 +1,145 @@
+// Public marketplace catalog browse (`/v1/marketplace/*`) — distinct from the
+// project-scoped install surface in `./marketplace.ts` (`/projects/:id/marketplace/*`,
+// `/projects/:id/registry/*`). Read-only catalog routes are public; the
+// "sources" ("Add a marketplace") routes require auth. See
+// apps/api/src/marketplace/index.ts for the server-side handlers.
+
+import { backendApi } from '../api-client';
+import { unwrap } from './shared';
+
+export interface MarketplaceCatalogItem {
+  id: string;
+  title: string;
+  type: string;
+  source: string;
+  description?: string | null;
+  [key: string]: unknown;
+}
+
+export interface MarketplaceCatalogStatus {
+  loading?: boolean;
+  pending?: string[];
+  sources?: string[];
+}
+
+export interface MarketplaceItemsResponse extends MarketplaceCatalogStatus {
+  items: MarketplaceCatalogItem[];
+}
+
+export interface ListMarketplaceItemsOptions {
+  query?: string;
+  type?: string;
+  source?: string;
+}
+
+/** Browse the public registry catalog (no auth required). */
+export async function listMarketplaceCatalogItems(
+  options?: ListMarketplaceItemsOptions,
+): Promise<MarketplaceItemsResponse> {
+  const params = new URLSearchParams();
+  if (options?.query) params.set('query', options.query);
+  if (options?.type) params.set('type', options.type);
+  if (options?.source) params.set('source', options.source);
+  const query = params.toString() ? `?${params.toString()}` : '';
+  return unwrap(await backendApi.get<MarketplaceItemsResponse>(`/marketplace/items${query}`));
+}
+
+export interface MarketplaceEntry {
+  name: string;
+  item_count: number;
+  [key: string]: unknown;
+}
+
+export interface MarketplacesResponse extends MarketplaceCatalogStatus {
+  marketplaces: MarketplaceEntry[];
+}
+
+/** Distinct marketplaces (sources) with item counts. */
+export async function listMarketplaces(): Promise<MarketplacesResponse> {
+  return unwrap(await backendApi.get<MarketplacesResponse>('/marketplace/marketplaces'));
+}
+
+export interface FeaturedMarketplacesResponse {
+  featured: MarketplaceEntry[];
+}
+
+/** Curated featured marketplaces. */
+export async function listFeaturedMarketplaces(): Promise<FeaturedMarketplacesResponse> {
+  return unwrap(await backendApi.get<FeaturedMarketplacesResponse>('/marketplace/marketplaces/featured'));
+}
+
+/** A single catalog item's full detail (manifest + file listing). */
+export async function getMarketplaceCatalogItem(id: string): Promise<Record<string, unknown>> {
+  return unwrap(
+    await backendApi.get<Record<string, unknown>>(`/marketplace/items/${encodeURIComponent(id)}`),
+    'Item not found',
+  );
+}
+
+export interface MarketplaceItemFile {
+  path: string;
+  content: string;
+  [key: string]: unknown;
+}
+
+/** Read a single file's content out of a catalog item (before installing it). */
+export async function getMarketplaceCatalogItemFile(
+  id: string,
+  path: string,
+): Promise<MarketplaceItemFile> {
+  return unwrap(
+    await backendApi.get<MarketplaceItemFile>(
+      `/marketplace/items/${encodeURIComponent(id)}/file?path=${encodeURIComponent(path)}`,
+    ),
+    'File not found',
+  );
+}
+
+// ── Sources ("Add a marketplace") — authed, platform-global ────────────────
+
+export interface MarketplaceSource {
+  id: string;
+  address: string;
+  gitRef?: string | null;
+  sparsePaths?: string[] | null;
+  label?: string | null;
+  [key: string]: unknown;
+}
+
+export interface MarketplaceSourcesResponse {
+  sources: MarketplaceSource[];
+}
+
+/** List operator-managed marketplace sources (a GitHub repo, Git URL, or local folder). */
+export async function listMarketplaceSources(): Promise<MarketplaceSourcesResponse> {
+  return unwrap(await backendApi.get<MarketplaceSourcesResponse>('/marketplace/sources'));
+}
+
+export interface AddMarketplaceSourceInput {
+  address: string;
+  gitRef?: string;
+  sparsePaths?: string[];
+  label?: string;
+}
+
+export interface AddMarketplaceSourceResponse {
+  source: MarketplaceSource;
+}
+
+/** Add a marketplace source. Rejects local-folder/private/non-https addresses server-side. */
+export async function addMarketplaceSource(
+  input: AddMarketplaceSourceInput,
+): Promise<AddMarketplaceSourceResponse> {
+  return unwrap(
+    await backendApi.post<AddMarketplaceSourceResponse>('/marketplace/sources', input),
+    'Failed to add marketplace source',
+  );
+}
+
+/** Remove a marketplace source by id. */
+export async function removeMarketplaceSource(id: string): Promise<{ ok: boolean }> {
+  return unwrap(
+    await backendApi.delete<{ ok: boolean }>(`/marketplace/sources/${encodeURIComponent(id)}`),
+    'Failed to remove marketplace source',
+  );
+}

--- a/packages/sdk/src/platform/projects-client/marketplace.ts
+++ b/packages/sdk/src/platform/projects-client/marketplace.ts
@@ -1,0 +1,181 @@
+// Marketplace / registry install — project-scoped. Installs commit an item's
+// files (+ a `registry-lock.json` lock) straight onto the project's default
+// branch, live in the next session — no runtime/build step. `registry/*` is a
+// compatibility alias of `marketplace/*` (same handlers server-side); both are
+// wrapped here so a host can use either name.
+
+import { backendApi } from '../api-client';
+import { unwrap } from './shared';
+
+/** Capabilities an installed item declares (secrets/connectors/tools/network
+ *  it needs) — surfaced so the host can prompt for what's missing post-install. */
+export interface MarketplaceItemCapabilities {
+  secrets: string[];
+  connectors: string[];
+  tools: string[];
+  network: string[];
+}
+
+export interface MarketplaceInstalledUnit {
+  name: string;
+  type: string;
+}
+
+export interface MarketplaceInstallResult {
+  ok: boolean;
+  commit_sha: string;
+  branch: string;
+  file_count: number;
+  /** Every unit the install touched (the requested item + its transitive bundle deps). */
+  installed: MarketplaceInstalledUnit[];
+  capabilities: MarketplaceItemCapabilities;
+}
+
+export interface MarketplaceInstalledItem {
+  name: string;
+  type: string;
+  source: string;
+  installed_at: string | null;
+  file_count: number;
+}
+
+export interface MarketplaceInstalledResponse {
+  installed: MarketplaceInstalledItem[];
+}
+
+export type MarketplaceUpdateStatus = 'up-to-date' | 'update-available' | 'orphaned';
+
+export interface MarketplaceUpdateStatusEntry {
+  name: string;
+  type: string;
+  status: MarketplaceUpdateStatus;
+  /** Count of changed + added + removed file targets since install. */
+  changed: number;
+}
+
+export interface MarketplaceUpdatesResponse {
+  updates: MarketplaceUpdateStatusEntry[];
+  /** Names with `status === 'update-available'`. */
+  update_available: string[];
+}
+
+export interface MarketplaceUpdateResult {
+  ok: boolean;
+  updated: string;
+  commit_sha: string;
+  branch: string;
+  file_count: number;
+  installed: MarketplaceInstalledUnit[];
+}
+
+export interface MarketplaceUpdateAllResult {
+  ok: boolean;
+  updated: string[];
+  commit_sha: string | null;
+  branch: string | null;
+  file_count: number;
+  installed: MarketplaceInstalledUnit[];
+}
+
+export interface MarketplaceRemoveResult {
+  ok: boolean;
+  removed: string;
+  commit_sha: string;
+  branch: string;
+  file_count: number;
+}
+
+// ── marketplace/* ────────────────────────────────────────────────────────────
+
+export async function installMarketplaceItem(projectId: string, id: string) {
+  return unwrap(
+    await backendApi.post<MarketplaceInstallResult>(
+      `/projects/${projectId}/marketplace/install`,
+      { id },
+    ),
+  );
+}
+
+export async function listInstalledMarketplaceItems(projectId: string) {
+  return unwrap(
+    await backendApi.get<MarketplaceInstalledResponse>(`/projects/${projectId}/marketplace`),
+  );
+}
+
+export async function getMarketplaceUpdates(projectId: string) {
+  return unwrap(
+    await backendApi.get<MarketplaceUpdatesResponse>(`/projects/${projectId}/marketplace/updates`),
+  );
+}
+
+export async function updateMarketplaceItem(projectId: string, name: string) {
+  return unwrap(
+    await backendApi.post<MarketplaceUpdateResult>(`/projects/${projectId}/marketplace/update`, {
+      name,
+    }),
+  );
+}
+
+export async function updateAllMarketplaceItems(projectId: string) {
+  return unwrap(
+    await backendApi.post<MarketplaceUpdateAllResult>(
+      `/projects/${projectId}/marketplace/update-all`,
+      {},
+    ),
+  );
+}
+
+export async function removeMarketplaceItem(projectId: string, name: string) {
+  return unwrap(
+    await backendApi.delete<MarketplaceRemoveResult>(
+      `/projects/${projectId}/marketplace/${encodeURIComponent(name)}`,
+    ),
+  );
+}
+
+// ── registry/* (compatibility alias — same handlers server-side) ────────────
+
+export async function installRegistryItem(projectId: string, id: string) {
+  return unwrap(
+    await backendApi.post<MarketplaceInstallResult>(`/projects/${projectId}/registry/install`, {
+      id,
+    }),
+  );
+}
+
+export async function listInstalledRegistryItems(projectId: string) {
+  return unwrap(
+    await backendApi.get<MarketplaceInstalledResponse>(`/projects/${projectId}/registry`),
+  );
+}
+
+export async function getRegistryUpdates(projectId: string) {
+  return unwrap(
+    await backendApi.get<MarketplaceUpdatesResponse>(`/projects/${projectId}/registry/updates`),
+  );
+}
+
+export async function updateRegistryItem(projectId: string, name: string) {
+  return unwrap(
+    await backendApi.post<MarketplaceUpdateResult>(`/projects/${projectId}/registry/update`, {
+      name,
+    }),
+  );
+}
+
+export async function updateAllRegistryItems(projectId: string) {
+  return unwrap(
+    await backendApi.post<MarketplaceUpdateAllResult>(
+      `/projects/${projectId}/registry/update-all`,
+      {},
+    ),
+  );
+}
+
+export async function removeRegistryItem(projectId: string, name: string) {
+  return unwrap(
+    await backendApi.delete<MarketplaceRemoveResult>(
+      `/projects/${projectId}/registry/${encodeURIComponent(name)}`,
+    ),
+  );
+}

--- a/packages/sdk/src/platform/projects-client/projects.ts
+++ b/packages/sdk/src/platform/projects-client/projects.ts
@@ -172,6 +172,49 @@ export async function inviteRepoCollaborator(
   );
 }
 
+export interface ManifestValidationIssue {
+  [key: string]: unknown;
+}
+
+export interface ManifestValidationResult {
+  valid: boolean;
+  issues: ManifestValidationIssue[];
+}
+
+/**
+ * Validate a `kortix.toml` manifest's raw TOML text server-side — the same
+ * schema the CLI (`kortix ship` pre-flight / `kortix validate`) and the CR-merge
+ * gate exercise. Always resolves (never throws on an invalid manifest) — the
+ * verdict is in the body.
+ */
+export async function validateProjectManifest(
+  projectId: string,
+  raw: string,
+): Promise<ManifestValidationResult> {
+  return unwrap(
+    await backendApi.post<ManifestValidationResult>(`/projects/${projectId}/manifest/validate`, { raw }),
+    'Failed to validate manifest',
+  );
+}
+
+export interface ProjectGitToken {
+  push_token: string;
+  repo_id: string | null;
+  repo_url: string | null;
+}
+
+/**
+ * Mint a fresh scoped git push token for a *managed* project (so the CLI can
+ * `kortix ship` without persisting credentials in git config). Throws (409)
+ * for BYO projects — they push with the user's own git remote auth.
+ */
+export async function getProjectGitToken(projectId: string): Promise<ProjectGitToken> {
+  return unwrap(
+    await backendApi.post<ProjectGitToken>(`/projects/${projectId}/git-token`, {}),
+    'Failed to mint git token',
+  );
+}
+
 /** True when this project's repo is a Kortix-managed GitHub repo (invitable). */
 export function isManagedGithubProject(project: { metadata?: Record<string, unknown> | null }): boolean {
   const git = (project.metadata as { git?: { provider?: string; managed?: boolean } } | undefined)?.git;

--- a/packages/sdk/src/platform/projects-client/secrets.test.ts
+++ b/packages/sdk/src/platform/projects-client/secrets.test.ts
@@ -1,0 +1,134 @@
+import { beforeEach, expect, mock, test } from 'bun:test';
+import { configureKortix } from '../config';
+import {
+  deletePersonalProjectSecret,
+  deleteProjectSecret,
+  listProjectSecrets,
+  pollProjectProviderOAuth,
+  setPersonalProjectSecret,
+  startProjectProviderOAuth,
+  upsertProjectGitCredential,
+  upsertProjectSecret,
+} from './secrets';
+
+let calls: { url: string; method: string; body: unknown }[] = [];
+let nextResponse: { status: number; body: unknown } = { status: 200, body: {} };
+
+beforeEach(() => {
+  calls = [];
+  nextResponse = { status: 200, body: {} };
+  globalThis.fetch = mock(async (url: unknown, opts: { method?: string; body?: string } = {}) => {
+    calls.push({
+      url: String(url),
+      method: opts.method ?? 'GET',
+      body: opts.body ? JSON.parse(opts.body) : undefined,
+    });
+    return new Response(JSON.stringify(nextResponse.body), {
+      status: nextResponse.status,
+      headers: { 'content-type': 'application/json' },
+    });
+  }) as unknown as typeof fetch;
+});
+
+configureKortix({ backendUrl: 'http://test.local', getToken: async () => 'tok' });
+const last = () => calls[calls.length - 1];
+
+test('listProjectSecrets hits GET /projects/:id/secrets and returns the parsed body', async () => {
+  nextResponse = { status: 200, body: { items: [], required: [], optional: [] } };
+  const result = await listProjectSecrets('P1');
+  expect(last().url).toContain('/projects/P1/secrets');
+  expect(last().method).toBe('GET');
+  expect(result).toEqual({ items: [], required: [], optional: [] });
+});
+
+test('listProjectSecrets throws when the response is unsuccessful', async () => {
+  nextResponse = { status: 500, body: { message: 'boom' } };
+  await expect(listProjectSecrets('P1')).rejects.toBeTruthy();
+});
+
+test('upsertProjectSecret POSTs name/value/sharing without agent_scope when agentScope is omitted', async () => {
+  nextResponse = { status: 200, body: { name: 'FOO' } };
+  await upsertProjectSecret('P1', { name: 'FOO', value: 'bar', sharing: { mode: 'project' } });
+  expect(last().url).toContain('/projects/P1/secrets');
+  expect(last().method).toBe('POST');
+  expect(last().body).toEqual({ name: 'FOO', value: 'bar', sharing: { mode: 'project' } });
+});
+
+test('upsertProjectSecret translates agentScope into agent_scope on the wire', async () => {
+  nextResponse = { status: 200, body: { name: 'FOO' } };
+  await upsertProjectSecret('P1', { name: 'FOO', agentScope: ['agent-a', 'agent-b'] });
+  expect(last().body).toEqual({ name: 'FOO', agent_scope: ['agent-a', 'agent-b'] });
+});
+
+test('upsertProjectSecret sends agent_scope: null when agentScope is explicitly null', async () => {
+  nextResponse = { status: 200, body: { name: 'FOO' } };
+  await upsertProjectSecret('P1', { name: 'FOO', agentScope: null });
+  expect(last().body).toEqual({ name: 'FOO', agent_scope: null });
+});
+
+test('startProjectProviderOAuth posts to the provider start endpoint with the sharing intent', async () => {
+  nextResponse = {
+    status: 200,
+    body: { flow_id: 'f1', verification_url: 'https://x', user_code: '123', expires_at: 1, interval_ms: 500 },
+  };
+  const result = await startProjectProviderOAuth('P1', 'chatgpt', { sharing: { mode: 'project' } });
+  expect(last().url).toContain('/projects/P1/oauth/chatgpt/start');
+  expect(last().method).toBe('POST');
+  expect(last().body).toEqual({ sharing: { mode: 'project' } });
+  expect(result.flow_id).toBe('f1');
+});
+
+test('startProjectProviderOAuth sends sharing: undefined when no input is given', async () => {
+  nextResponse = { status: 200, body: { flow_id: 'f1', verification_url: 'x', user_code: null, expires_at: 1, interval_ms: 1 } };
+  await startProjectProviderOAuth('P1', 'chatgpt');
+  expect(last().body).toEqual({ sharing: undefined });
+});
+
+test('pollProjectProviderOAuth posts the flow_id and returns the poll result', async () => {
+  nextResponse = { status: 200, body: { status: 'pending', next_poll_ms: 2000 } };
+  const result = await pollProjectProviderOAuth('P1', 'chatgpt', 'flow-123');
+  expect(last().url).toContain('/projects/P1/oauth/chatgpt/poll');
+  expect(last().method).toBe('POST');
+  expect(last().body).toEqual({ flow_id: 'flow-123' });
+  expect(result).toEqual({ status: 'pending', next_poll_ms: 2000 });
+});
+
+test('upsertProjectGitCredential PUTs the token to /git-credential', async () => {
+  nextResponse = {
+    status: 200,
+    body: { configured: true, provider: 'github', git_connection: {} },
+  };
+  const result = await upsertProjectGitCredential('P1', { token: 'ghp_abc' });
+  expect(last().url).toContain('/projects/P1/git-credential');
+  expect(last().method).toBe('PUT');
+  expect(last().body).toEqual({ token: 'ghp_abc' });
+  expect(result.configured).toBe(true);
+});
+
+test('deleteProjectSecret DELETEs the encoded secret name', async () => {
+  nextResponse = { status: 200, body: { ok: true } };
+  await deleteProjectSecret('P1', 'MY KEY');
+  expect(last().url).toContain('/projects/P1/secrets/MY%20KEY');
+  expect(last().method).toBe('DELETE');
+});
+
+test('setPersonalProjectSecret PUTs to the /personal sub-route', async () => {
+  nextResponse = { status: 200, body: { name: 'FOO', mine: { active: true, updated_at: '2026-01-01' } } };
+  await setPersonalProjectSecret('P1', 'FOO', { value: 'mine-value', active: true });
+  expect(last().url).toContain('/projects/P1/secrets/FOO/personal');
+  expect(last().method).toBe('PUT');
+  expect(last().body).toEqual({ value: 'mine-value', active: true });
+});
+
+test('deletePersonalProjectSecret DELETEs the /personal sub-route', async () => {
+  nextResponse = { status: 200, body: { ok: true } };
+  await deletePersonalProjectSecret('P1', 'FOO');
+  expect(last().url).toContain('/projects/P1/secrets/FOO/personal');
+  expect(last().method).toBe('DELETE');
+});
+
+test('deletePersonalProjectSecret encodes special characters in the secret name', async () => {
+  nextResponse = { status: 200, body: { ok: true } };
+  await deletePersonalProjectSecret('P1', 'FOO/BAR');
+  expect(last().url).toContain('/projects/P1/secrets/FOO%2FBAR/personal');
+});

--- a/packages/sdk/src/platform/projects-client/session-sandbox.test.ts
+++ b/packages/sdk/src/platform/projects-client/session-sandbox.test.ts
@@ -1,0 +1,172 @@
+import { afterEach, beforeEach, expect, mock, test } from 'bun:test';
+import { configureKortix } from '../config';
+import { clearSessionRuntime, getSessionRuntime } from '../../state/session-runtime-registry';
+import { sessionStartKey, startProjectSession } from './session-sandbox';
+
+const PROJECT = 'P1';
+const SESSION = 'S1';
+
+let calls: { url: string; method: string; body: unknown }[] = [];
+let nextResponse: { status: number; body: unknown } = { status: 200, body: {} };
+
+beforeEach(() => {
+  calls = [];
+  nextResponse = { status: 200, body: {} };
+  globalThis.fetch = mock(async (url: unknown, opts: { method?: string; body?: string } = {}) => {
+    calls.push({
+      url: String(url),
+      method: opts.method ?? 'GET',
+      body: opts.body ? JSON.parse(opts.body) : undefined,
+    });
+    return new Response(JSON.stringify(nextResponse.body), {
+      status: nextResponse.status,
+      headers: { 'content-type': 'application/json' },
+    });
+  }) as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  clearSessionRuntime(PROJECT, SESSION);
+});
+
+configureKortix({ backendUrl: 'http://test.local/v1', getToken: async () => 'tok' });
+const last = () => calls[calls.length - 1];
+
+function readySandbox(overrides: Partial<{ external_id: string | null }> = {}) {
+  return {
+    sandbox_id: 'sbx-db-1',
+    session_id: SESSION,
+    project_id: PROJECT,
+    account_id: 'acct-1',
+    provider: 'daytona' as const,
+    external_id: 'ext-1',
+    base_url: null,
+    status: 'active' as const,
+    config: {},
+    metadata: {},
+    last_used_at: null,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+test('startProjectSession POSTs to /start with no query string when waitMs is omitted', async () => {
+  nextResponse = {
+    status: 200,
+    body: { stage: 'provisioning', agent_name: 'default', retriable: true, sandbox: null, opencode_session_id: null },
+  };
+  await startProjectSession(PROJECT, SESSION);
+  expect(last().url).toBe(`http://test.local/v1/projects/${PROJECT}/sessions/${SESSION}/start`);
+  expect(last().method).toBe('POST');
+  expect(last().body).toEqual({});
+});
+
+test('startProjectSession appends ?wait_ms=<floored ms> when waitMs is given', async () => {
+  nextResponse = {
+    status: 200,
+    body: { stage: 'provisioning', agent_name: 'default', retriable: true, sandbox: null, opencode_session_id: null },
+  };
+  await startProjectSession(PROJECT, SESSION, 5_500.9);
+  expect(last().url).toContain('/start?wait_ms=5500');
+});
+
+test('startProjectSession omits the query string for a zero or negative waitMs', async () => {
+  nextResponse = {
+    status: 200,
+    body: { stage: 'provisioning', agent_name: 'default', retriable: true, sandbox: null, opencode_session_id: null },
+  };
+  await startProjectSession(PROJECT, SESSION, 0);
+  expect(last().url).not.toContain('wait_ms');
+
+  await startProjectSession(PROJECT, SESSION, -100);
+  expect(last().url).not.toContain('wait_ms');
+});
+
+test('startProjectSession returns null when the response is unsuccessful (never throws)', async () => {
+  nextResponse = { status: 500, body: { message: 'boom' } };
+  const result = await startProjectSession(PROJECT, SESSION);
+  expect(result).toBeNull();
+});
+
+test('startProjectSession returns null when the response has no data', async () => {
+  nextResponse = { status: 200, body: null };
+  const result = await startProjectSession(PROJECT, SESSION);
+  expect(result).toBeNull();
+});
+
+test('startProjectSession returns the parsed result even when stage is not ready (no registry write)', async () => {
+  nextResponse = {
+    status: 200,
+    body: { stage: 'starting', agent_name: 'default', retriable: true, sandbox: readySandbox(), opencode_session_id: null },
+  };
+  const result = await startProjectSession(PROJECT, SESSION);
+  expect(result?.stage).toBe('starting');
+  expect(getSessionRuntime(PROJECT, SESSION)).toBeUndefined();
+});
+
+test('startProjectSession populates the shared session-runtime registry once stage is ready with a sandbox external_id + opencode_session_id', async () => {
+  nextResponse = {
+    status: 200,
+    body: {
+      stage: 'ready',
+      agent_name: 'default',
+      retriable: false,
+      sandbox: readySandbox({ external_id: 'ext-ready-1' }),
+      opencode_session_id: 'ocs-ready-1',
+    },
+  };
+  const result = await startProjectSession(PROJECT, SESSION);
+  expect(result?.stage).toBe('ready');
+
+  const entry = getSessionRuntime(PROJECT, SESSION);
+  expect(entry).toBeDefined();
+  expect(entry?.opencodeSessionId).toBe('ocs-ready-1');
+  expect(entry?.sandboxId).toBe('ext-ready-1');
+  expect(entry?.runtimeUrl).toBe('http://test.local/v1/p/ext-ready-1/8000');
+});
+
+test('startProjectSession does NOT populate the registry when ready but sandbox has no external_id', async () => {
+  nextResponse = {
+    status: 200,
+    body: {
+      stage: 'ready',
+      agent_name: 'default',
+      retriable: false,
+      sandbox: readySandbox({ external_id: null }),
+      opencode_session_id: 'ocs-2',
+    },
+  };
+  await startProjectSession(PROJECT, SESSION);
+  expect(getSessionRuntime(PROJECT, SESSION)).toBeUndefined();
+});
+
+test('startProjectSession does NOT populate the registry when ready but opencode_session_id is missing', async () => {
+  nextResponse = {
+    status: 200,
+    body: {
+      stage: 'ready',
+      agent_name: 'default',
+      retriable: false,
+      sandbox: readySandbox({ external_id: 'ext-3' }),
+      opencode_session_id: null,
+    },
+  };
+  await startProjectSession(PROJECT, SESSION);
+  expect(getSessionRuntime(PROJECT, SESSION)).toBeUndefined();
+});
+
+test('startProjectSession does NOT populate the registry when ready but sandbox itself is null', async () => {
+  nextResponse = {
+    status: 200,
+    body: { stage: 'ready', agent_name: 'default', retriable: false, sandbox: null, opencode_session_id: 'ocs-4' },
+  };
+  await startProjectSession(PROJECT, SESSION);
+  expect(getSessionRuntime(PROJECT, SESSION)).toBeUndefined();
+});
+
+test('sessionStartKey returns a stable tuple keyed by project + session id', () => {
+  expect(sessionStartKey('PA', 'SA')).toEqual(['session-start', 'PA', 'SA']);
+  expect(sessionStartKey('PA', 'SA')).toEqual(sessionStartKey('PA', 'SA'));
+  expect(sessionStartKey('PA', 'SA')).not.toEqual(sessionStartKey('PB', 'SA'));
+});

--- a/packages/sdk/src/platform/projects-client/sessions.test.ts
+++ b/packages/sdk/src/platform/projects-client/sessions.test.ts
@@ -1,0 +1,174 @@
+import { beforeEach, expect, mock, test } from 'bun:test';
+import { configureKortix } from '../config';
+import { isSessionFresh } from '../fresh-sessions';
+import {
+  createProjectSession,
+  createSessionPublicShare,
+  deleteProjectSession,
+  getProjectSession,
+  getSessionAudit,
+  getSessionPreviewCandidates,
+  getSessionTranscript,
+  listProjectSessions,
+  listSessionPublicShares,
+  restartProjectSession,
+  revokeSessionPublicShare,
+  setProjectSessionSharing,
+  stopProjectSession,
+  updateProjectSession,
+} from './sessions';
+
+let calls: { url: string; method: string; body: unknown }[] = [];
+let nextResponse: { status: number; body: unknown } = { status: 200, body: {} };
+
+beforeEach(() => {
+  calls = [];
+  nextResponse = { status: 200, body: {} };
+  globalThis.fetch = mock(async (url: unknown, opts: { method?: string; body?: string } = {}) => {
+    calls.push({
+      url: String(url),
+      method: opts.method ?? 'GET',
+      body: opts.body ? JSON.parse(opts.body) : undefined,
+    });
+    return new Response(JSON.stringify(nextResponse.body), {
+      status: nextResponse.status,
+      headers: { 'content-type': 'application/json' },
+    });
+  }) as unknown as typeof fetch;
+});
+
+configureKortix({ backendUrl: 'http://test.local', getToken: async () => 'tok' });
+const last = () => calls[calls.length - 1];
+
+test('listProjectSessions hits GET /projects/:id/sessions', async () => {
+  nextResponse = { status: 200, body: [] };
+  const result = await listProjectSessions('P1');
+  expect(last().url).toContain('/projects/P1/sessions');
+  expect(last().method).toBe('GET');
+  expect(result).toEqual([]);
+});
+
+test('listProjectSessions throws when the response is unsuccessful', async () => {
+  nextResponse = { status: 500, body: { message: 'boom' } };
+  await expect(listProjectSessions('P1')).rejects.toBeTruthy();
+});
+
+test('setProjectSessionSharing PUTs the sharing intent', async () => {
+  nextResponse = { status: 200, body: { session_id: 'S1' } };
+  await setProjectSessionSharing('P1', 'S1', { mode: 'project' });
+  expect(last().url).toContain('/projects/P1/sessions/S1/sharing');
+  expect(last().method).toBe('PUT');
+  expect(last().body).toEqual({ mode: 'project' });
+});
+
+test('getSessionPreviewCandidates hits the previews endpoint', async () => {
+  nextResponse = { status: 200, body: { candidates: [] } };
+  const result = await getSessionPreviewCandidates('P1', 'S1');
+  expect(last().url).toContain('/projects/P1/sessions/S1/previews');
+  expect(result).toEqual({ candidates: [] });
+});
+
+test('listSessionPublicShares hits GET /public-shares with showErrors: false', async () => {
+  nextResponse = { status: 200, body: { shares: [] } };
+  const result = await listSessionPublicShares('P1', 'S1');
+  expect(last().url).toContain('/projects/P1/sessions/S1/public-shares');
+  expect(result).toEqual({ shares: [] });
+});
+
+test('createSessionPublicShare POSTs the share input', async () => {
+  nextResponse = { status: 200, body: { share: { share_id: 'SH1' } } };
+  const input = { preview_id: 'prev-1', mode: 'view' as const };
+  const result = await createSessionPublicShare('P1', 'S1', input);
+  expect(last().url).toContain('/projects/P1/sessions/S1/public-shares');
+  expect(last().method).toBe('POST');
+  expect(last().body).toEqual(input);
+  expect(result.share.share_id).toBe('SH1');
+});
+
+test('revokeSessionPublicShare DELETEs the specific share', async () => {
+  nextResponse = { status: 200, body: { share: { share_id: 'SH1' } } };
+  await revokeSessionPublicShare('P1', 'S1', 'SH1');
+  expect(last().url).toContain('/projects/P1/sessions/S1/public-shares/SH1');
+  expect(last().method).toBe('DELETE');
+});
+
+test('createProjectSession POSTs the input and marks the new session fresh', async () => {
+  nextResponse = { status: 200, body: { session_id: 'NEW-1', name: null } };
+  const result = await createProjectSession('P1', { base_ref: 'main' });
+  expect(last().url).toContain('/projects/P1/sessions');
+  expect(last().method).toBe('POST');
+  expect(last().body).toEqual({ base_ref: 'main' });
+  expect((result as any).session_id).toBe('NEW-1');
+  expect(isSessionFresh('NEW-1')).toBe(true);
+});
+
+test('createProjectSession does NOT mark the session fresh when an initial_prompt is set', async () => {
+  nextResponse = { status: 200, body: { session_id: 'NEW-2', name: null } };
+  await createProjectSession('P1', { initial_prompt: 'hello' });
+  expect(isSessionFresh('NEW-2')).toBe(false);
+});
+
+test('createProjectSession defaults the body to {} when no input is given', async () => {
+  nextResponse = { status: 200, body: { session_id: 'NEW-3' } };
+  await createProjectSession('P1');
+  expect(last().body).toEqual({});
+});
+
+test('getProjectSession hits GET /projects/:id/sessions/:sid and forwards showErrors', async () => {
+  nextResponse = { status: 200, body: { session_id: 'S1' } };
+  await getProjectSession('P1', 'S1', { showErrors: false });
+  expect(last().url).toContain('/projects/P1/sessions/S1');
+  expect(last().method).toBe('GET');
+});
+
+test('getSessionAudit appends ?limit= only when a limit is given', async () => {
+  nextResponse = { status: 200, body: { session_id: 'S1', agent: null, count: 0, actions: [] } };
+  await getSessionAudit('P1', 'S1', 10);
+  expect(last().url).toContain('/projects/P1/sessions/S1/audit?limit=10');
+
+  await getSessionAudit('P1', 'S1');
+  expect(last().url).toBe('http://test.local/projects/P1/sessions/S1/audit');
+});
+
+test('getSessionTranscript builds the query string from limit/chars options', async () => {
+  nextResponse = {
+    status: 200,
+    body: { available: true, reason: null, opencode_session_id: 'ocs-1', message_count: 0, messages: [] },
+  };
+  await getSessionTranscript('P1', 'S1', { limit: 5, chars: 200 });
+  expect(last().url).toContain('/projects/P1/sessions/S1/transcript?limit=5&chars=200');
+
+  await getSessionTranscript('P1', 'S1');
+  expect(last().url).toBe('http://test.local/projects/P1/sessions/S1/transcript');
+});
+
+test('updateProjectSession PATCHes the name/metadata input', async () => {
+  nextResponse = { status: 200, body: { session_id: 'S1', name: 'Renamed' } };
+  await updateProjectSession('P1', 'S1', { name: 'Renamed' });
+  expect(last().url).toContain('/projects/P1/sessions/S1');
+  expect(last().method).toBe('PATCH');
+  expect(last().body).toEqual({ name: 'Renamed' });
+});
+
+test('deleteProjectSession DELETEs the session', async () => {
+  nextResponse = { status: 200, body: { ok: true } };
+  await deleteProjectSession('P1', 'S1');
+  expect(last().url).toContain('/projects/P1/sessions/S1');
+  expect(last().method).toBe('DELETE');
+});
+
+test('restartProjectSession POSTs to /restart', async () => {
+  nextResponse = { status: 200, body: { ok: true, session_id: 'S1', status: 'provisioning' } };
+  const result = await restartProjectSession('P1', 'S1');
+  expect(last().url).toContain('/projects/P1/sessions/S1/restart');
+  expect(last().method).toBe('POST');
+  expect(result.status).toBe('provisioning');
+});
+
+test('stopProjectSession POSTs to /stop', async () => {
+  nextResponse = { status: 200, body: { ok: true, session_id: 'S1', status: 'stopped' } };
+  const result = await stopProjectSession('P1', 'S1');
+  expect(last().url).toContain('/projects/P1/sessions/S1/stop');
+  expect(last().method).toBe('POST');
+  expect(result.status).toBe('stopped');
+});

--- a/packages/sdk/src/platform/projects-client/sessions.ts
+++ b/packages/sdk/src/platform/projects-client/sessions.ts
@@ -273,6 +273,49 @@ export async function getSessionAudit(
   );
 }
 
+export interface SessionTranscriptToolCall {
+  tool: string;
+  status: string | null;
+}
+
+export interface SessionTranscriptMessage {
+  role: string;
+  created: string | null;
+  completed: string | null;
+  text: string;
+  tools: SessionTranscriptToolCall[];
+  files: Array<{ filename: string | null; mime: string | null }>;
+  reasoning_omitted: boolean;
+  error: { name?: string; message?: string } | null;
+}
+
+/** Compact server-side transcript read — text + tool calls, stripped of tool
+ *  inputs/outputs, for project automation (callable with project-scoped
+ *  session tokens, unlike the raw sandbox proxy). */
+export interface SessionTranscript {
+  available: boolean;
+  reason: string | null;
+  opencode_session_id: string | null;
+  message_count: number;
+  messages: SessionTranscriptMessage[];
+}
+
+export async function getSessionTranscript(
+  projectId: string,
+  sessionId: string,
+  options?: { limit?: number; chars?: number },
+) {
+  const search = new URLSearchParams();
+  if (options?.limit != null) search.set('limit', String(options.limit));
+  if (options?.chars != null) search.set('chars', String(options.chars));
+  const qs = search.toString();
+  return unwrap(
+    await backendApi.get<SessionTranscript>(
+      `/projects/${projectId}/sessions/${sessionId}/transcript${qs ? `?${qs}` : ''}`,
+    ),
+  );
+}
+
 export async function updateProjectSession(
   projectId: string,
   sessionId: string,

--- a/packages/sdk/src/platform/projects-client/setup-links.test.ts
+++ b/packages/sdk/src/platform/projects-client/setup-links.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, expect, mock, test } from 'bun:test';
+import { configureKortix } from '../config';
+import { requestProjectConnector, requestProjectSecret } from './setup-links';
+
+let calls: { url: string; method: string; body: unknown }[] = [];
+let nextResponse: { status: number; body: unknown } = { status: 200, body: {} };
+
+beforeEach(() => {
+  calls = [];
+  nextResponse = { status: 200, body: {} };
+  globalThis.fetch = mock(async (url: unknown, opts: { method?: string; body?: string } = {}) => {
+    calls.push({
+      url: String(url),
+      method: opts.method ?? 'GET',
+      body: opts.body ? JSON.parse(opts.body) : undefined,
+    });
+    return new Response(JSON.stringify(nextResponse.body), {
+      status: nextResponse.status,
+      headers: { 'content-type': 'application/json' },
+    });
+  }) as unknown as typeof fetch;
+});
+
+configureKortix({ backendUrl: 'http://test.local', getToken: async () => 'tok' });
+const last = () => calls[calls.length - 1];
+
+test('requestProjectSecret posts names/labels/descriptions/scope to secret-requests', async () => {
+  nextResponse = {
+    status: 200,
+    body: { kind: 'secret', url: 'https://app.local/secret-intake/tok', names: ['STRIPE_KEY'], scope: 'runtime', expires_at: '2026-01-01' },
+  };
+  const result = await requestProjectSecret('P1', { names: ['STRIPE_KEY'], scope: 'runtime' });
+  expect(last().url).toContain('/projects/P1/secret-requests');
+  expect(last().method).toBe('POST');
+  expect(last().body).toMatchObject({ names: ['STRIPE_KEY'], scope: 'runtime' });
+  expect(result.url).toContain('/secret-intake/');
+});
+
+test('requestProjectSecret throws on failure', async () => {
+  nextResponse = { status: 400, body: { message: 'names is required' } };
+  await expect(requestProjectSecret('P1', { names: [] })).rejects.toThrow();
+});
+
+test('requestProjectConnector posts slug to connect-requests', async () => {
+  nextResponse = {
+    status: 200,
+    body: { kind: 'connector', url: 'https://app.local/connect/tok', slug: 'github', app: 'github', expires_at: '2026-01-01' },
+  };
+  const result = await requestProjectConnector('P1', { slug: 'github' });
+  expect(last().url).toContain('/projects/P1/connect-requests');
+  expect(last().method).toBe('POST');
+  expect(last().body).toEqual({ slug: 'github', expires_in_minutes: undefined });
+  expect(result.slug).toBe('github');
+});

--- a/packages/sdk/src/platform/projects-client/setup-links.ts
+++ b/packages/sdk/src/platform/projects-client/setup-links.ts
@@ -1,0 +1,72 @@
+// Agent-minted SETUP LINKS — short-lived links the in-sandbox agent mints so
+// a human can (a) enter a project secret VALUE, or (b) 1-click connect a
+// Pipedream app, without the agent ever seeing the value/credential itself.
+// See apps/api/src/projects/routes/setup-links.ts for the server-side handlers.
+
+import { backendApi } from '../api-client';
+import { unwrap } from './shared';
+
+export interface RequestProjectSecretInput {
+  /** One or more env var names to request (A-Z, 0-9, _; max 64 chars each). */
+  names: string[];
+  /** Optional per-name display label, keyed by name. */
+  labels?: Record<string, string>;
+  /** Optional per-name description, keyed by name. */
+  descriptions?: Record<string, string>;
+  /** `'runtime'` (project secret, default) or `'connector'` (connector credential). */
+  scope?: 'runtime' | 'connector';
+  expiresInMinutes?: number;
+}
+
+export interface SecretRequestLink {
+  kind: 'secret';
+  url: string;
+  names: string[];
+  scope: 'runtime' | 'connector';
+  expires_at: string;
+}
+
+/** Mint a link a human opens to enter one or more secret values. */
+export async function requestProjectSecret(
+  projectId: string,
+  input: RequestProjectSecretInput,
+): Promise<SecretRequestLink> {
+  return unwrap(
+    await backendApi.post<SecretRequestLink>(`/projects/${projectId}/secret-requests`, {
+      names: input.names,
+      labels: input.labels,
+      descriptions: input.descriptions,
+      scope: input.scope,
+      expires_in_minutes: input.expiresInMinutes,
+    }),
+    'Failed to mint secret-entry link',
+  );
+}
+
+export interface RequestProjectConnectorInput {
+  /** The Pipedream connector slug (already declared in kortix.toml). */
+  slug: string;
+  expiresInMinutes?: number;
+}
+
+export interface ConnectorRequestLink {
+  kind: 'connector';
+  url: string;
+  slug: string;
+  app: string;
+  expires_at: string;
+}
+
+/** Mint a link a human opens to 1-click connect a Pipedream app (Quick Connect). */
+export async function requestProjectConnector(
+  projectId: string,
+  input: RequestProjectConnectorInput,
+): Promise<ConnectorRequestLink> {
+  return unwrap(
+    await backendApi.post<ConnectorRequestLink>(`/projects/${projectId}/connect-requests`, {
+      slug: input.slug,
+      expires_in_minutes: input.expiresInMinutes,
+    }),
+    'Failed to mint connect link',
+  );
+}

--- a/packages/sdk/src/platform/projects-client/shared.ts
+++ b/packages/sdk/src/platform/projects-client/shared.ts
@@ -59,9 +59,20 @@ export function unwrap<T>(
 // without ever wiring) the SDK's process-wide `configureKortix()` seam — and
 // even where the host app has called `configureKortix()`, that singleton
 // must not be trusted to carry one request's bearer token across concurrent
-// requests on the same server process. These callers already resolved the
-// caller's access token themselves (e.g. from a Supabase server session), so
-// they fetch with it directly instead of going through `backendApi`.
+// requests on the same server process (the last `configureKortix()` call
+// wins for every other in-flight request). These callers already resolved
+// the caller's access token themselves (e.g. from a Supabase server
+// session), so they fetch with it directly instead of going through
+// `backendApi`.
+//
+// A general-purpose fix for this class of problem — any "Kortix as a
+// Backend" server wrapping Kortix on behalf of multiple concurrent
+// users/tenants, not just this one explicit-token pattern — lives at
+// `@kortix/sdk/server`: `runWithKortix(config, fn)` / `createScopedKortix(config)`
+// isolate each call's config in a Node `AsyncLocalStorage` context instead of
+// the shared global, so concurrent requests with different tokens never
+// clobber each other. Prefer that over hand-rolling more explicit-token
+// helpers like the ones below for new server-side call sites.
 
 export interface ServerTokenOptions {
   /** Absolute backend base URL, with or without a trailing `/v1`. */

--- a/packages/sdk/src/platform/projects-client/tokens.ts
+++ b/packages/sdk/src/platform/projects-client/tokens.ts
@@ -1,0 +1,139 @@
+// CLI PAT minting — account-scoped personal access tokens (`kortix_pat_...`)
+// and their project-scoped siblings. Both mint via the same backend
+// repository (`repositories/account-tokens.ts`); the project-scoped route
+// additionally binds the minted token to one `project_id` (the auth
+// middleware then rejects it outside that project). These are the tokens
+// the CLI / "Kortix as a Backend" hosts use to authenticate without a human
+// Supabase session — the account variant is minted by a human from
+// account settings, the project variant is auto-minted at session-create
+// time and injected into the sandbox as `KORTIX_TOKEN`.
+
+import { backendApi } from '../api-client';
+import { unwrap } from './shared';
+
+/** One account-scoped CLI PAT (secret never returned again after creation). */
+export interface AccountToken {
+  token_id: string;
+  name: string;
+  /** Set when this token was minted project-scoped (still visible from the
+   *  account-wide list). */
+  project_id: string | null;
+  public_key: string;
+  status: string;
+  expires_at: string | null;
+  last_used_at: string | null;
+  created_at: string;
+  revoked_at: string | null;
+}
+
+export interface CreateAccountTokenInput {
+  name: string;
+  /** Defaults to the caller's resolved account when omitted. */
+  accountId?: string;
+  /** ISO-8601. Omit for a non-expiring token. */
+  expiresAt?: string;
+  /** Scope the minted token to a single project (still a "kortix_pat_..." token,
+   *  but the auth middleware rejects it outside this project). */
+  projectId?: string;
+}
+
+/** The newly minted token — `secret_key` is the plaintext PAT, returned ONCE. */
+export interface CreatedAccountToken {
+  token_id: string;
+  name: string;
+  project_id: string | null;
+  public_key: string;
+  secret_key: string;
+  status: string;
+  expires_at: string | null;
+  created_at: string;
+}
+
+/** List CLI PATs for an account (defaults to the caller's resolved account). */
+export async function listAccountTokens(accountId?: string) {
+  const qs = accountId ? `?account_id=${encodeURIComponent(accountId)}` : '';
+  return unwrap(await backendApi.get<AccountToken[]>(`/accounts/tokens${qs}`));
+}
+
+/** Mint a new account-scoped CLI PAT. The `secret_key` is returned once — the
+ *  caller must persist it immediately; subsequent reads only ever see `public_key`. */
+export async function createAccountToken(input: CreateAccountTokenInput) {
+  const { accountId, expiresAt, projectId, name } = input;
+  return unwrap(
+    await backendApi.post<CreatedAccountToken>('/accounts/tokens', {
+      name,
+      ...(accountId ? { account_id: accountId } : {}),
+      ...(expiresAt ? { expires_at: expiresAt } : {}),
+      ...(projectId ? { project_id: projectId } : {}),
+    }),
+  );
+}
+
+/** Revoke an account-scoped CLI PAT. */
+export async function revokeAccountToken(tokenId: string, accountId?: string) {
+  const qs = accountId ? `?account_id=${encodeURIComponent(accountId)}` : '';
+  return unwrap(
+    await backendApi.delete<{ ok: boolean }>(`/accounts/tokens/${tokenId}${qs}`),
+  );
+}
+
+// ── Project-scoped CLI tokens ────────────────────────────────────────────────
+// These are PATs bound to a single project — auto-minted at session-create
+// time and injected into the sandbox as `KORTIX_TOKEN`, so the in-container
+// CLI works with zero config. Minting/revoking is a human/`manage` operation;
+// an agent-session token is denied outright server-side (privilege-escalation
+// guard — see apps/api/src/projects/routes/r3.ts).
+
+export interface ProjectCliToken {
+  token_id: string;
+  name: string;
+  public_key: string;
+  status: string;
+  expires_at: string | null;
+  last_used_at: string | null;
+  created_at: string;
+  revoked_at: string | null;
+}
+
+export interface ProjectCliTokenListResponse {
+  items: ProjectCliToken[];
+}
+
+/** The newly minted project-scoped token — `secret_key` is returned once. */
+export interface CreatedProjectCliToken {
+  token_id: string;
+  name: string;
+  public_key: string;
+  secret_key: string;
+  status: string;
+  project_id: string;
+  expires_at: string | null;
+  created_at: string;
+}
+
+export async function listProjectCliTokens(projectId: string) {
+  return unwrap(
+    await backendApi.get<ProjectCliTokenListResponse>(`/projects/${projectId}/cli-token`),
+  );
+}
+
+/** Mint a project-scoped CLI PAT. Defaults `name` to "cli · <project name>" server-side. */
+export async function createProjectCliToken(
+  projectId: string,
+  input?: { name?: string },
+) {
+  return unwrap(
+    await backendApi.post<CreatedProjectCliToken>(
+      `/projects/${projectId}/cli-token`,
+      input ?? {},
+    ),
+  );
+}
+
+export async function revokeProjectCliToken(projectId: string, tokenId: string) {
+  return unwrap(
+    await backendApi.delete<{ ok: boolean }>(
+      `/projects/${projectId}/cli-token/${tokenId}`,
+    ),
+  );
+}

--- a/packages/sdk/src/platform/strings.ts
+++ b/packages/sdk/src/platform/strings.ts
@@ -1,0 +1,16 @@
+/**
+ * Dependency-free string helpers shared across the SDK (and its hosts).
+ */
+
+/**
+ * Strip trailing '/' characters in linear time. The idiomatic regex form
+ * (`.replace(/\/+$/, '')`) backtracks quadratically on adversarial inputs
+ * with many repeated slashes (CodeQL `js/polynomial-redos`) — URLs here come
+ * from config/runtime state, but every call site sits on a hot request path,
+ * so the SDK standardizes on this loop instead.
+ */
+export function stripTrailingSlashes(s: string): string {
+	let end = s.length;
+	while (end > 0 && s.charCodeAt(end - 1) === 47 /* '/' */) end--;
+	return end === s.length ? s : s.slice(0, end);
+}

--- a/packages/sdk/src/react/chat/index.ts
+++ b/packages/sdk/src/react/chat/index.ts
@@ -1,0 +1,7 @@
+'use client';
+
+// Headless chat bindings — `classifyTurn`/`classifyPart`-driven view models
+// for building custom chat UIs on top of `@kortix/sdk`. Re-exported from the
+// main `@kortix/sdk/react` barrel; no separate subpath needed.
+export { useChatTurns, type TurnView } from './use-chat-turns';
+export { renderParts, type PartRenderers } from './render-parts';

--- a/packages/sdk/src/react/chat/render-parts.test.ts
+++ b/packages/sdk/src/react/chat/render-parts.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from 'bun:test';
+
+import type { ClassifiedPart } from '../../turns';
+import { type PartRenderers, renderParts } from './render-parts';
+
+const renderers: PartRenderers<string> = {
+  text: (p) => `text:${p.text}`,
+  reasoning: (p) => `reasoning:${p.text}`,
+  tool: (p) => `tool:${p.tool.name}`,
+  file: (p) => `file:${p.filename ?? p.url}`,
+  subtask: (p) => `subtask:${p.agent}`,
+  patch: (p) => `patch:${p.fileCount}`,
+  snapshot: (p) => `snapshot:${p.snapshot}`,
+  agent: (p) => `agent:${p.name}`,
+  retry: (p) => `retry:${p.attempt}`,
+  compaction: (p) => `compaction:${p.auto}`,
+  step: (p) => `step:${p.phase}`,
+  unknown: () => 'unknown',
+};
+
+describe('renderParts', () => {
+  test('dispatches every kind to its matching renderer, in order', () => {
+    const parts: ClassifiedPart[] = [
+      { kind: 'text', id: '1', text: 'hi', synthetic: false },
+      { kind: 'reasoning', id: '2', text: 'thinking' },
+      { kind: 'agent', id: '3', name: 'kortix-worker' },
+    ];
+    expect(renderParts(parts, renderers)).toEqual([
+      'text:hi',
+      'reasoning:thinking',
+      'agent:kortix-worker',
+    ]);
+  });
+
+  test('unknown parts route through the "unknown" renderer, not a thrown error', () => {
+    const parts: ClassifiedPart[] = [{ kind: 'unknown', raw: { type: 'future-thing' } }];
+    expect(renderParts(parts, renderers)).toEqual(['unknown']);
+  });
+
+  test('falls back to `fallback` when a kind has no renderer (unsafe construction)', () => {
+    const partial = {
+      text: (p: Extract<ClassifiedPart, { kind: 'text' }>) => p.text,
+    } as PartRenderers<string>;
+    const withFallback: PartRenderers<string> = { ...partial, fallback: () => 'fallback' };
+    const parts: ClassifiedPart[] = [{ kind: 'snapshot', id: 's1', snapshot: 'snap' }];
+    expect(renderParts(parts, withFallback)).toEqual(['fallback']);
+  });
+
+  test('throws when a kind has no renderer and no fallback is given', () => {
+    const partial = {
+      text: (p: Extract<ClassifiedPart, { kind: 'text' }>) => p.text,
+    } as PartRenderers<string>;
+    const parts: ClassifiedPart[] = [{ kind: 'snapshot', id: 's1', snapshot: 'snap' }];
+    expect(() => renderParts(parts, partial)).toThrow(
+      /no renderer registered for part kind "snapshot"/,
+    );
+  });
+});

--- a/packages/sdk/src/react/chat/render-parts.ts
+++ b/packages/sdk/src/react/chat/render-parts.ts
@@ -1,0 +1,46 @@
+/**
+ * Generic, compile-time-exhaustive part -> T dispatcher.
+ *
+ * No React import — `T` is typically `ReactNode`, but this file stays
+ * framework-free (same reasoning as `classifyPart` itself) so a host isn't
+ * forced through React to use it. It lives under `react/chat/` because that's
+ * where the rest of the chat-rendering surface is, not because it needs React.
+ *
+ * `PartRenderers<T>` requires a renderer for every `ClassifiedPart['kind']`
+ * (an optional `fallback` covers `'unknown'`-only handling, or lets a host
+ * opt out of exhaustiveness during a migration) — TypeScript itself enforces
+ * that a host's switch-equivalent covers every part kind, closing the
+ * "silently drops subtask/patch/snapshot/agent/retry/compaction" bug class at
+ * the CALL site the same way `classifyPart` closes it at the classification
+ * site.
+ */
+
+import type { ClassifiedPart } from '../../turns';
+
+type PartOfKind<K extends ClassifiedPart['kind']> = Extract<ClassifiedPart, { kind: K }>;
+
+export type PartRenderers<T> = {
+  [K in ClassifiedPart['kind']]: (part: PartOfKind<K>) => T;
+} & {
+  /** Escape hatch: if provided, used instead of throwing for any kind whose
+   *  dedicated renderer is missing (only reachable if a caller constructs a
+   *  `PartRenderers<T>` with `Partial<...>` and casts — the type normally
+   *  requires every kind). */
+  fallback?: (part: ClassifiedPart) => T;
+};
+
+/**
+ * Render every classified part with its matching renderer, in order.
+ * Throws if a part's kind has no renderer AND no `fallback` was given —
+ * this should be unreachable given `PartRenderers<T>`'s type (every kind is
+ * required), so hitting it means the renderers object was built unsafely
+ * (e.g. via `as PartRenderers<T>`).
+ */
+export function renderParts<T>(parts: ClassifiedPart[], renderers: PartRenderers<T>): T[] {
+  return parts.map((part) => {
+    const renderer = renderers[part.kind] as ((p: ClassifiedPart) => T) | undefined;
+    if (renderer) return renderer(part);
+    if (renderers.fallback) return renderers.fallback(part);
+    throw new Error(`renderParts: no renderer registered for part kind "${part.kind}"`);
+  });
+}

--- a/packages/sdk/src/react/chat/use-chat-turns.ts
+++ b/packages/sdk/src/react/chat/use-chat-turns.ts
@@ -1,0 +1,45 @@
+'use client';
+
+/**
+ * Headless React binding over `classifyTurn` (`@kortix/sdk/turns`) — the
+ * memoized, ready-to-render view model for a session's message list.
+ *
+ * Deliberately dumb: it holds no state of its own and renders nothing. A host
+ * passes it the same `messages` array `useSession()` returns; it hands back
+ * one `TurnView` per message, recomputed only when the `messages` reference
+ * changes (React Query / the sync store already give a stable reference
+ * between renders when nothing changed, so this is cheap in the steady
+ * state).
+ */
+
+import { useMemo } from 'react';
+import type { ClassifiedPart, TurnError } from '../../turns';
+import { classifyTurn } from '../../turns';
+import type { MessageWithParts } from '../use-opencode-sessions';
+
+export interface TurnView {
+  /** The original message this view was classified from — kept around so a
+   *  host can still read `message.info.role`, `.id`, etc. without a second
+   *  lookup. */
+  message: MessageWithParts;
+  parts: ClassifiedPart[];
+  error?: TurnError;
+  isEmpty: boolean;
+}
+
+/**
+ * Classify every message in a session's message list into a `TurnView`.
+ * One `TurnView` per message (NOT per user/assistant turn-group — pair with
+ * `groupMessagesIntoTurns` from `@kortix/sdk/turns` first if a host wants
+ * grouped turns instead of a flat per-message list).
+ */
+export function useChatTurns(messages: MessageWithParts[]): TurnView[] {
+  return useMemo(
+    () =>
+      messages.map((message) => {
+        const { parts, error, isEmpty } = classifyTurn(message);
+        return { message, parts, error, isEmpty };
+      }),
+    [messages],
+  );
+}

--- a/packages/sdk/src/react/index.ts
+++ b/packages/sdk/src/react/index.ts
@@ -93,3 +93,12 @@ export {
 // rather than a new `@kortix/sdk/react/chat` subpath — no package.json
 // exports-map change needed to reach it.
 export { useChatTurns, type TurnView, renderParts, type PartRenderers } from './chat';
+
+// Domain hooks — thin React Query bindings over `projects-client` CRUD
+// surfaces (secrets, triggers, change requests) that previously had no
+// SDK-owned hook (only the client fn). Each owns its own query key + the
+// mutations a settings/workbench screen actually needs, with invalidation
+// wired so writes reflect without a manual refetch.
+export { useProjectSecrets, projectSecretsKey } from './use-project-secrets';
+export { useProjectTriggers, projectTriggersKey } from './use-project-triggers';
+export { useChangeRequests, changeRequestsKey } from './use-change-requests';

--- a/packages/sdk/src/react/index.ts
+++ b/packages/sdk/src/react/index.ts
@@ -85,3 +85,11 @@ export {
   type SendCallOptions,
   type UseSessionSendResult,
 } from './use-session-send';
+
+// The headless chat kit — `useChatTurns` (memoized `classifyTurn` over a
+// message list) + `renderParts` (compile-time-exhaustive part -> T
+// dispatcher). Framework-free classification lives in `@kortix/sdk/turns`;
+// this is the thin React binding over it. Kept inside the `react` barrel
+// rather than a new `@kortix/sdk/react/chat` subpath — no package.json
+// exports-map change needed to reach it.
+export { useChatTurns, type TurnView, renderParts, type PartRenderers } from './chat';

--- a/packages/sdk/src/react/model-flatten.ts
+++ b/packages/sdk/src/react/model-flatten.ts
@@ -1,4 +1,32 @@
+import type { Model } from '@opencode-ai/sdk/v2/client';
 import { GATEWAY_PROVIDER_IDS, type ProviderListResponse } from './use-opencode-sessions';
+
+/**
+ * Some provider payloads aren't the full opencode `Model` shape — notably the
+ * synthetic "kortix" provider built from the project llm-catalog endpoint
+ * (see `projectLlmCatalogToProviderList`), whose models carry a flatter,
+ * models.dev-ish shape instead of `Model.capabilities`/`Model.cost`/etc. This
+ * union covers both without lying about the shape via `any`; every field
+ * access below is narrowed via `hasCapabilities` rather than cast.
+ */
+type LooseModel =
+  | Model
+  | {
+      id?: string;
+      name?: string;
+      variants?: Record<string, Record<string, unknown>>;
+      reasoning?: boolean;
+      tool_call?: boolean;
+      modalities?: { input?: string[]; output?: string[] };
+      limit?: { context?: number; output?: number };
+      release_date?: string;
+      family?: string;
+      cost?: { input?: number; output?: number };
+    };
+
+function hasCapabilities(model: LooseModel): model is Model {
+  return 'capabilities' in model && model.capabilities != null;
+}
 
 /**
  * Flat model list + the flattening logic (relocated from web's session-chat-input —
@@ -41,36 +69,41 @@ export function flattenModels(providers: ProviderListResponse | undefined): Flat
     // Defense in depth: the provider list is already source-filtered to the
     // gateway, but never render a native (bypass) provider even if one slips in.
     if (!GATEWAY_PROVIDER_IDS.has(p.id)) continue;
-    for (const [modelID, model] of Object.entries(p.models)) {
-      const caps = (model as any).capabilities;
-      const modalities = (model as any).modalities;
+    for (const [modelID, model] of Object.entries(p.models) as Array<[string, LooseModel]>) {
+      // Narrow `model` itself (not a copy) so the loose-shape-only fields
+      // (`reasoning`, `tool_call`, `modalities`) are safe to read below.
+      let capabilities: FlatModel['capabilities'];
+      if (hasCapabilities(model)) {
+        const caps = model.capabilities;
+        capabilities = {
+          reasoning: caps.reasoning ?? false,
+          vision: caps.input?.image ?? false,
+          toolcall: caps.toolcall ?? false,
+        };
+      } else {
+        capabilities = {
+          reasoning: model.reasoning ?? false,
+          vision: model.modalities?.input?.includes('image') ?? false,
+          toolcall: model.tool_call ?? false,
+        };
+      }
       result.push({
         providerID: p.id,
         providerName: p.name,
         modelID,
         modelName: (model.name || modelID).replace('(latest)', '').trim(),
         variants: model.variants,
-        capabilities: caps
+        capabilities,
+        contextWindow: model.limit?.context,
+        releaseDate: model.release_date,
+        family: model.family,
+        cost: model.cost
           ? {
-              reasoning: caps.reasoning ?? false,
-              vision: caps.input?.image ?? false,
-              toolcall: caps.toolcall ?? false,
-            }
-          : {
-              reasoning: (model as any).reasoning ?? false,
-              vision: modalities?.input?.includes('image') ?? false,
-              toolcall: (model as any).tool_call ?? false,
-            },
-        contextWindow: (model as any).limit?.context,
-        releaseDate: (model as any).release_date,
-        family: (model as any).family,
-        cost: (model as any).cost
-          ? {
-              input: (model as any).cost.input ?? 0,
-              output: (model as any).cost.output ?? 0,
+              input: model.cost.input ?? 0,
+              output: model.cost.output ?? 0,
             }
           : undefined,
-        providerSource: (p as any).source,
+        providerSource: p.source,
       });
     }
   }

--- a/packages/sdk/src/react/provider-selection.ts
+++ b/packages/sdk/src/react/provider-selection.ts
@@ -35,8 +35,14 @@ export function normalizeProviderList(
     };
   }
 
-  const legacyProviders = Array.isArray((providers as any).providers)
-    ? (providers as any).providers
+  // Legacy responses carried providers under `.providers` instead of `.all` —
+  // not part of the modern `ProviderListResponse` type, so duck-type via
+  // `unknown` rather than assume that (long-gone) legacy shape is still real.
+  const maybeLegacy = (providers as unknown as { providers?: unknown }).providers;
+  const legacyProviders: Array<{ id: string; models?: Record<string, unknown> }> = Array.isArray(
+    maybeLegacy,
+  )
+    ? maybeLegacy
     : [];
   if (legacyProviders.length === 0) {
     return {
@@ -49,7 +55,7 @@ export function normalizeProviderList(
   return {
     ...providers,
     all: legacyProviders,
-    connected: legacyProviders.map((provider: { id: string }) => provider.id),
+    connected: legacyProviders.map((provider) => provider.id),
   } as ProviderListResponse;
 }
 

--- a/packages/sdk/src/react/use-change-requests.ts
+++ b/packages/sdk/src/react/use-change-requests.ts
@@ -1,0 +1,67 @@
+'use client';
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  closeChangeRequest,
+  listChangeRequests,
+  mergeChangeRequest,
+  openChangeRequest,
+  requestChangesOnChangeRequest,
+  type ChangeRequest,
+  type ChangeRequestStatus,
+} from '../platform/projects-client';
+
+/** Stable query-key factory — reuse to read/invalidate the same cache entry
+ *  `useChangeRequests` populates. */
+export const changeRequestsKey = (projectId: string | null | undefined) =>
+  ['project-change-requests', projectId] as const;
+
+/**
+ * Change requests — the Kortix-native PR layer. List + open/merge/close/
+ * request-changes, the CRUD surface a Review Center / workbench "Changes" tab
+ * needs. Thin React Query binding over `projects-client/change-requests.ts`;
+ * every mutation invalidates the list so status transitions (open → merged/
+ * closed, or back to open on reopen) show up without a manual refetch.
+ * Per-CR detail reads (diff, merge-preview) stay direct client calls — they're
+ * one-shot views, not a list this hook owns.
+ */
+export function useChangeRequests(
+  projectId: string | null | undefined,
+  status?: ChangeRequestStatus | 'all',
+) {
+  const queryClient = useQueryClient();
+  const queryKey = [...changeRequestsKey(projectId), status ?? 'open'] as const;
+
+  const query = useQuery<{ change_requests: ChangeRequest[] }>({
+    queryKey,
+    queryFn: () => listChangeRequests(projectId as string, status),
+    enabled: !!projectId,
+  });
+
+  const invalidate = () => queryClient.invalidateQueries({ queryKey: changeRequestsKey(projectId) });
+
+  const open = useMutation({
+    mutationFn: (input: Parameters<typeof openChangeRequest>[1]) =>
+      openChangeRequest(projectId as string, input),
+    onSuccess: invalidate,
+  });
+
+  const merge = useMutation({
+    mutationFn: (args: { crId: string; input?: Parameters<typeof mergeChangeRequest>[2] }) =>
+      mergeChangeRequest(projectId as string, args.crId, args.input),
+    onSuccess: invalidate,
+  });
+
+  const close = useMutation({
+    mutationFn: (crId: string) => closeChangeRequest(projectId as string, crId),
+    onSuccess: invalidate,
+  });
+
+  const requestChanges = useMutation({
+    mutationFn: (args: { crId: string; feedback: string }) =>
+      requestChangesOnChangeRequest(projectId as string, args.crId, args.feedback),
+    onSuccess: invalidate,
+  });
+
+  return { ...query, open, merge, close, requestChanges };
+}

--- a/packages/sdk/src/react/use-kortix-master.ts
+++ b/packages/sdk/src/react/use-kortix-master.ts
@@ -347,7 +347,10 @@ export function useKortixProjectSessions(
   options: KortixProjectQueryOptions = {},
 ) {
   const serverUrl = useServerStore((s) => s.getActiveServerUrl());
-  return useQuery<any[]>({
+  // `listKortixProjectSessions` itself returns `unknown[]` (its enriched
+  // OpenCode-session shape isn't schema-typed at the source) — mirror that
+  // here rather than lying about the element shape with `any`.
+  return useQuery<unknown[]>({
     queryKey: ['kortix', 'projects', projectId, 'sessions', identity.userId ?? 'anonymous', serverUrl],
     queryFn: () => listKortixProjectSessions(serverUrl, projectId),
     enabled: !identity.isLoading && !!identity.userId && !!serverUrl && !!projectId && (options.enabled ?? true),
@@ -407,26 +410,30 @@ const VALID_STATUSES: KortixTaskStatus[] = [
 
 /** Pure — the daemon's `status` isn't schema-validated, so this normalizes
  * raw rows (defaulting an unrecognized status to `'todo'`) before trusting
- * `KortixTask['status']`. Exported for direct unit testing. */
-export function normalizeTask(raw: any): KortixTask {
-  const status = VALID_STATUSES.includes(raw?.status) ? raw.status : 'todo';
+ * `KortixTask['status']`. `raw` is genuinely unvalidated wire data — duck-type
+ * via `unknown` rather than assume the shape. Exported for direct unit testing. */
+export function normalizeTask(raw: unknown): KortixTask {
+  const r = (raw && typeof raw === 'object' ? raw : {}) as Record<string, unknown>;
+  const status = VALID_STATUSES.includes(r.status as KortixTaskStatus)
+    ? (r.status as KortixTaskStatus)
+    : 'todo';
   return {
-    id: raw.id,
-    project_id: raw.project_id,
-    title: raw.title || '',
-    description: raw.description || '',
-    verification_condition: raw.verification_condition || '',
+    id: r.id as string,
+    project_id: r.project_id as string,
+    title: (r.title as string) || '',
+    description: (r.description as string) || '',
+    verification_condition: (r.verification_condition as string) || '',
     status,
-    result: raw.result ?? null,
-    verification_summary: raw.verification_summary ?? null,
-    blocking_question: raw.blocking_question ?? null,
-    owner_session_id: raw.owner_session_id ?? null,
-    owner_agent: raw.owner_agent ?? null,
-    requested_by_session_id: raw.requested_by_session_id ?? null,
-    started_at: raw.started_at ?? null,
-    completed_at: raw.completed_at ?? null,
-    created_at: raw.created_at,
-    updated_at: raw.updated_at,
+    result: (r.result as string | null) ?? null,
+    verification_summary: (r.verification_summary as string | null) ?? null,
+    blocking_question: (r.blocking_question as string | null) ?? null,
+    owner_session_id: (r.owner_session_id as string | null) ?? null,
+    owner_agent: (r.owner_agent as string | null) ?? null,
+    requested_by_session_id: (r.requested_by_session_id as string | null) ?? null,
+    started_at: (r.started_at as string | null) ?? null,
+    completed_at: (r.completed_at as string | null) ?? null,
+    created_at: r.created_at as string,
+    updated_at: r.updated_at as string,
   };
 }
 
@@ -529,9 +536,9 @@ export function useStartKortixTask() {
     onSuccess: (task) => {
       qc.invalidateQueries({ queryKey: taskKeys.all });
       qc.invalidateQueries({ queryKey: ['kortix', 'projects'] });
-      if ((task as any)?.project_id) {
-        qc.invalidateQueries({ queryKey: ['kortix', 'projects', (task as any).project_id] });
-        qc.invalidateQueries({ queryKey: ['kortix', 'projects', (task as any).project_id, 'sessions'] });
+      if (task?.project_id) {
+        qc.invalidateQueries({ queryKey: ['kortix', 'projects', task.project_id] });
+        qc.invalidateQueries({ queryKey: ['kortix', 'projects', task.project_id, 'sessions'] });
       }
     },
   });

--- a/packages/sdk/src/react/use-opencode-config.ts
+++ b/packages/sdk/src/react/use-opencode-config.ts
@@ -13,8 +13,14 @@ export const configKeys = {
 
 function unwrap<T>(result: { data?: T; error?: unknown }): T {
   if (result.error) {
-    const err = result.error as any;
-    throw new Error(err?.data?.message || err?.message || 'Request failed');
+    // `error`'s shape varies per endpoint's typed error union — duck-type
+    // defensively via `unknown` rather than assume a shape.
+    const err = result.error;
+    const errRec = err && typeof err === 'object' ? (err as Record<string, unknown>) : undefined;
+    const dataRec =
+      errRec?.data && typeof errRec.data === 'object' ? (errRec.data as Record<string, unknown>) : undefined;
+    const message = dataRec?.message ?? errRec?.message;
+    throw new Error(typeof message === 'string' ? message : 'Request failed');
   }
   return result.data as T;
 }
@@ -40,7 +46,9 @@ export function useUpdateOpenCodeConfig() {
   return useMutation({
     mutationFn: async (config: Partial<Config>) => {
       const client = getClient();
-      const result = await client.global.config.update({ config } as any);
+      // The SDK's `update` param type wants a full `Config`, but the server
+      // accepts (and this hook always sends) a partial merge patch.
+      const result = await client.global.config.update({ config: config as Config });
       return unwrap(result) as Config;
     },
     onMutate: async (config) => {

--- a/packages/sdk/src/react/use-opencode-events/diagnostics.ts
+++ b/packages/sdk/src/react/use-opencode-events/diagnostics.ts
@@ -1,6 +1,11 @@
 import type { Part } from '@opencode-ai/sdk/v2/client';
 import type { RefObject } from 'react';
-import { parseDiagnosticsFromToolOutput, useDiagnosticsStore } from '../../state/diagnostics-store';
+import {
+  parseDiagnosticsFromToolOutput,
+  useDiagnosticsStore,
+  type RawDiagnostic,
+} from '../../state/diagnostics-store';
+import type { NormalizeDiagnosticPaths } from './types';
 
 /**
  * Extract diagnostics carried by a `message.part.updated` part — both the
@@ -10,18 +15,17 @@ import { parseDiagnosticsFromToolOutput, useDiagnosticsStore } from '../../state
  */
 export function applyPartDiagnostics(
   part: Part,
-  normalizeDiagnosticPaths: RefObject<
-    (diagsByFile: Record<string, any[]>) => Record<string, any[]>
-  >,
+  normalizeDiagnosticPaths: RefObject<NormalizeDiagnosticPaths>,
 ): void {
-  const partState = (part as any)?.state;
+  // Only `ToolPart` carries `.state` — every other `Part` variant doesn't.
+  const partState = part.type === 'tool' ? part.state : undefined;
 
   // --- Primary path: parse diagnostics from tool output text ---
   // The OpenCode backend embeds diagnostics as plain text inside
   // <file_diagnostics> / <project_diagnostics> XML tags in the
   // tool's text output (e.g. after write, edit, diagnostics tools).
   if (partState?.status === 'completed' && partState.output) {
-    const output = partState.output as string;
+    const output = partState.output;
     if (output.includes('<file_diagnostics>') || output.includes('<project_diagnostics>')) {
       const parsed = parseDiagnosticsFromToolOutput(output);
       const fileCount = Object.keys(parsed).length;
@@ -29,7 +33,7 @@ export function applyPartDiagnostics(
         // Normalize absolute sandbox paths to project-relative
         const normalized = normalizeDiagnosticPaths.current(parsed);
         // Convert LspDiagnostic[] to RawDiagnostic[] format for the store
-        const asRaw: Record<string, any[]> = {};
+        const asRaw: Record<string, RawDiagnostic[]> = {};
         for (const [file, diags] of Object.entries(normalized)) {
           asRaw[file] = diags.map((d) => ({
             range: {
@@ -46,10 +50,11 @@ export function applyPartDiagnostics(
   }
 
   // --- Fallback: check metadata.diagnostics (legacy / fork path) ---
-  const partMeta = partState?.metadata;
+  // `metadata` isn't on `ToolStatePending` — narrow it away first.
+  const partMeta = partState && partState.status !== 'pending' ? partState.metadata : undefined;
   if (partMeta?.diagnostics && typeof partMeta.diagnostics === 'object') {
-    const diagsByFile = partMeta.diagnostics as Record<string, any[]>;
-    const validEntries: Record<string, any[]> = {};
+    const diagsByFile = partMeta.diagnostics as Record<string, RawDiagnostic[]>;
+    const validEntries: Record<string, RawDiagnostic[]> = {};
     let hasValid = false;
     for (const [file, diags] of Object.entries(diagsByFile)) {
       if (Array.isArray(diags) && diags.length > 0) {

--- a/packages/sdk/src/react/use-opencode-events/handle-event.test.ts
+++ b/packages/sdk/src/react/use-opencode-events/handle-event.test.ts
@@ -1,0 +1,699 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { QueryClient } from '@tanstack/react-query';
+import type {
+  AssistantMessage,
+  Message,
+  PermissionRequest,
+  QuestionRequest,
+  Session,
+  ToolPart,
+  UserMessage,
+} from '@opencode-ai/sdk/v2/client';
+
+// Mock the notification sink BEFORE importing the module under test, so
+// `handle-event.ts`'s `import { infoToast, notify* } from '../../platform/ui'`
+// resolves to these spies instead of the real (host-configured) sinks. Same
+// mock-then-dynamic-import pattern as `use-kortix-master.test.ts`.
+interface ToastCall {
+  level: string;
+  message: string;
+}
+interface NotifyCall {
+  kind: string;
+  [key: string]: unknown;
+}
+let toasts: ToastCall[] = [];
+let notifications: NotifyCall[] = [];
+
+mock.module('../../platform/ui', () => ({
+  infoToast: (message: string) => {
+    toasts.push({ level: 'info', message });
+  },
+  notifyPermissionRequest: (sessionId: string, toolName: string, sessionTitle?: string) => {
+    notifications.push({ kind: 'permission', sessionId, toolName, sessionTitle });
+  },
+  notifyQuestion: (sessionId: string, questionText: string, sessionTitle?: string) => {
+    notifications.push({ kind: 'question', sessionId, questionText, sessionTitle });
+  },
+  notifySessionError: (sessionId: string, errorTitle: string, sessionTitle?: string) => {
+    notifications.push({ kind: 'session-error', sessionId, errorTitle, sessionTitle });
+  },
+  notifyTaskComplete: (sessionId: string, sessionTitle?: string) => {
+    notifications.push({ kind: 'task-complete', sessionId, sessionTitle });
+  },
+}));
+
+const { createEventHandler } = await import('./handle-event');
+const { useSyncStore } = await import('../../state/sync-store');
+const { useDiagnosticsStore } = await import('../../state/diagnostics-store');
+const { opencodeKeys } = await import('../use-opencode-sessions');
+const { fileListKeys, gitStatusKeys, fileContentKeys } = await import('../file-keys');
+const { ptyKeys } = await import('../use-opencode-pty');
+
+// ============================================================================
+// Test harness — a fresh QueryClient + real sync store + spy callbacks for
+// every test, mirroring exactly what `use-opencode-events/index.ts` wires up
+// in production (see `createEventHandler`'s call site there).
+// ============================================================================
+
+function makeCalls<Args extends unknown[]>() {
+  const calls: Args[] = [];
+  const fn = (...args: Args) => {
+    calls.push(args);
+  };
+  return { fn, calls };
+}
+
+function buildHandler(overrides: { messagesImpl?: () => Promise<{ data?: unknown }>; getImpl?: () => Promise<{ data?: unknown }> } = {}) {
+  const queryClient = new QueryClient();
+  const stopCompaction = makeCalls<[string]>();
+  const addPermission = makeCalls<[PermissionRequest]>();
+  const removePermission = makeCalls<[string]>();
+  const addQuestion = makeCalls<[QuestionRequest]>();
+  const removeQuestion = makeCalls<[string]>();
+  const markSessionAbortedLocally = makeCalls<[string, string?]>();
+  const fetchLspDiagnosticsDebounced = makeCalls<[]>();
+  // `applySyncEvent` is a spy, NOT the real `useSyncStore.getState().applyEvent`
+  // — the sync store's OWN reducer behavior is already covered end-to-end in
+  // `../../state/sync-store.test.ts`. Keeping it a spy here means tests below
+  // can seed `useSyncStore` state directly (e.g. a prior `sessionStatus`) to
+  // exercise `handle-event.ts`'s OWN branching logic (transition detection,
+  // cache writes, notifications) in isolation, instead of that logic being
+  // entangled with — and clobbered by — the reducer's own state writes for
+  // the very same event (`applySyncEvent` runs BEFORE the switch statement).
+  const applySyncEvent = makeCalls<[unknown]>();
+
+  const client = {
+    session: {
+      messages: overrides.messagesImpl ?? (async () => ({ data: [] })),
+      get: overrides.getImpl ?? (async () => ({ data: undefined })),
+    },
+  } as unknown as Parameters<typeof createEventHandler>[0]['client'];
+
+  const handleEvent = createEventHandler({
+    queryClient,
+    client,
+    applySyncEvent: applySyncEvent.fn,
+    stopCompaction: stopCompaction.fn,
+    addPermission: addPermission.fn,
+    removePermission: removePermission.fn,
+    addQuestion: addQuestion.fn,
+    removeQuestion: removeQuestion.fn,
+    normalizeDiagnosticPaths: { current: (x) => x },
+    markSessionAbortedLocally: { current: markSessionAbortedLocally.fn },
+    fetchLspDiagnosticsDebounced: { current: fetchLspDiagnosticsDebounced.fn },
+  });
+
+  return {
+    handleEvent,
+    queryClient,
+    applySyncEvent,
+    stopCompaction,
+    addPermission,
+    removePermission,
+    addQuestion,
+    removeQuestion,
+    markSessionAbortedLocally,
+    fetchLspDiagnosticsDebounced,
+  };
+}
+
+function session(id: string, overrides: Partial<Session> = {}): Session {
+  return {
+    id,
+    slug: id,
+    projectID: 'proj_1',
+    directory: '/workspace',
+    title: 'Untitled',
+    version: '1.0.0',
+    time: { created: 1, updated: 1 },
+    ...overrides,
+  };
+}
+
+function userMessage(id: string, sessionID = 'ses_1'): UserMessage {
+  return {
+    id,
+    sessionID,
+    role: 'user',
+    time: { created: 1 },
+    agent: 'build',
+    model: { providerID: 'anthropic', modelID: 'claude' },
+  };
+}
+
+function assistantMessage(id: string, sessionID = 'ses_1'): AssistantMessage {
+  return {
+    id,
+    sessionID,
+    role: 'assistant',
+    time: { created: 1 },
+    parentID: 'msg_parent',
+    modelID: 'claude',
+    providerID: 'anthropic',
+    mode: 'build',
+    agent: 'build',
+    path: { cwd: '/', root: '/' },
+    cost: 0,
+    tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+  };
+}
+
+beforeEach(() => {
+  useSyncStore.getState().reset();
+  useDiagnosticsStore.getState().clearAll();
+  toasts = [];
+  notifications = [];
+});
+
+afterEach(() => {
+  toasts = [];
+  notifications = [];
+});
+
+// ============================================================================
+// message.updated / message.removed — sync store is the sole handler; no
+// query-cache side effects expected.
+// ============================================================================
+
+describe('message.updated / message.removed', () => {
+  test('message.updated is forwarded to the sync store (single source of truth)', () => {
+    const { handleEvent, applySyncEvent } = buildHandler();
+    const event = {
+      id: 'evt_1',
+      type: 'message.updated' as const,
+      properties: { sessionID: 'ses_1', info: assistantMessage('msg_1') },
+    };
+    handleEvent(event);
+    expect(applySyncEvent.calls).toEqual([[event]]);
+  });
+});
+
+// ============================================================================
+// message.part.updated — extracts diagnostics from a completed tool part into
+// the (real) diagnostics store, in addition to the sync-store dispatch.
+// ============================================================================
+
+describe('message.part.updated', () => {
+  test('forwards the raw event to the sync store', () => {
+    const { handleEvent, applySyncEvent } = buildHandler();
+    const event = {
+      id: 'evt_1',
+      type: 'message.part.updated' as const,
+      properties: {
+        sessionID: 'ses_1',
+        time: Date.now(),
+        part: { id: 'prt_1', sessionID: 'ses_1', messageID: 'msg_1', type: 'text' as const, text: 'Hello' },
+      },
+    };
+    handleEvent(event);
+    expect(applySyncEvent.calls).toEqual([[event]]);
+  });
+
+  test('extracts <file_diagnostics> from a completed tool part into the diagnostics store', () => {
+    const { handleEvent } = buildHandler();
+    const toolPart: ToolPart = {
+      id: 'prt_tool',
+      sessionID: 'ses_1',
+      messageID: 'msg_1',
+      type: 'tool',
+      callID: 'call_1',
+      tool: 'write',
+      state: {
+        status: 'completed',
+        input: {},
+        output:
+          '<file_diagnostics>\nError: /workspace/src/app.ts:12:5 [ts] Something is wrong\n</file_diagnostics>',
+        title: 'write',
+        metadata: {},
+        time: { start: 1, end: 2 },
+      },
+    };
+    handleEvent({
+      id: 'evt_1',
+      type: 'message.part.updated',
+      properties: { sessionID: 'ses_1', time: Date.now(), part: toolPart },
+    });
+
+    const byFile = useDiagnosticsStore.getState().byFile;
+    expect(byFile['/workspace/src/app.ts']).toBeDefined();
+    expect(byFile['/workspace/src/app.ts'][0]).toMatchObject({
+      line: 11, // 0-indexed (source line 12)
+      severity: 1, // Error
+      message: 'Something is wrong',
+    });
+  });
+
+  test('a tool part with no diagnostics tags leaves the diagnostics store untouched', () => {
+    const { handleEvent } = buildHandler();
+    const toolPart: ToolPart = {
+      id: 'prt_tool',
+      sessionID: 'ses_1',
+      messageID: 'msg_1',
+      type: 'tool',
+      callID: 'call_1',
+      tool: 'read',
+      state: {
+        status: 'completed',
+        input: {},
+        output: 'plain file contents, nothing diagnostic-shaped',
+        title: 'read',
+        metadata: {},
+        time: { start: 1, end: 2 },
+      },
+    };
+    handleEvent({
+      id: 'evt_1',
+      type: 'message.part.updated',
+      properties: { sessionID: 'ses_1', time: Date.now(), part: toolPart },
+    });
+    expect(useDiagnosticsStore.getState().byFile).toEqual({});
+  });
+});
+
+// ============================================================================
+// session.created / session.updated / session.deleted — surgical cache
+// mutations on the `opencodeKeys.sessions()` list + `opencodeKeys.session(id)`.
+// ============================================================================
+
+describe('session lifecycle cache mutations', () => {
+  test('session.created inserts into an existing session list, newest first', () => {
+    const { handleEvent, queryClient } = buildHandler();
+    queryClient.setQueryData(opencodeKeys.sessions(), [session('ses_old', { time: { created: 1, updated: 1 } })]);
+
+    handleEvent({
+      id: 'evt_1',
+      type: 'session.created',
+      properties: { sessionID: 'ses_new', info: session('ses_new', { time: { created: 5, updated: 5 } }) },
+    });
+
+    const list = queryClient.getQueryData<Session[]>(opencodeKeys.sessions());
+    expect(list?.map((s) => s.id)).toEqual(['ses_new', 'ses_old']);
+    expect(queryClient.getQueryData(opencodeKeys.session('ses_new'))).toMatchObject({ id: 'ses_new' });
+  });
+
+  test('session.created on an empty/uninitialized list still seeds it', () => {
+    const { handleEvent, queryClient } = buildHandler();
+    handleEvent({
+      id: 'evt_1',
+      type: 'session.created',
+      properties: { sessionID: 'ses_new', info: session('ses_new') },
+    });
+    expect(queryClient.getQueryData<Session[]>(opencodeKeys.sessions())).toEqual([session('ses_new')]);
+  });
+
+  test('session.updated patches the individual session cache and re-sorts the list', () => {
+    const { handleEvent, queryClient } = buildHandler();
+    queryClient.setQueryData(opencodeKeys.sessions(), [
+      session('ses_a', { time: { created: 1, updated: 1 }, title: 'Old title' }),
+    ]);
+    queryClient.setQueryData(opencodeKeys.session('ses_a'), session('ses_a', { title: 'Old title' }));
+
+    handleEvent({
+      id: 'evt_1',
+      type: 'session.updated',
+      properties: { sessionID: 'ses_a', info: session('ses_a', { time: { created: 1, updated: 9 }, title: 'New title' }) },
+    });
+
+    expect(queryClient.getQueryData<Session>(opencodeKeys.session('ses_a'))?.title).toBe('New title');
+    expect(queryClient.getQueryData<Session[]>(opencodeKeys.sessions())?.[0].title).toBe('New title');
+  });
+
+  test('session.deleted removes the session from the list and clears its query cache', () => {
+    const { handleEvent, queryClient } = buildHandler();
+    queryClient.setQueryData(opencodeKeys.sessions(), [session('ses_a'), session('ses_b')]);
+    queryClient.setQueryData(opencodeKeys.session('ses_a'), session('ses_a'));
+
+    handleEvent({
+      id: 'evt_1',
+      type: 'session.deleted',
+      properties: { sessionID: 'ses_a', info: session('ses_a') },
+    });
+
+    expect(queryClient.getQueryData<Session[]>(opencodeKeys.sessions())?.map((s) => s.id)).toEqual(['ses_b']);
+    expect(queryClient.getQueryData(opencodeKeys.session('ses_a'))).toBeUndefined();
+  });
+});
+
+// ============================================================================
+// session.status / session.idle — busy/retry → idle transition fires a
+// task-complete notification + invalidates the git/file-list caches.
+// ============================================================================
+
+describe('session.status', () => {
+  test('busy → idle fires notifyTaskComplete and invalidates git/file caches', () => {
+    const { handleEvent, queryClient } = buildHandler();
+    useSyncStore.getState().setStatus('ses_1', { type: 'busy' });
+    const gitInvalidated = queryClient.invalidateQueries.bind(queryClient);
+    let gitCalls = 0;
+    let filesCalls = 0;
+    queryClient.invalidateQueries = ((opts: { queryKey: unknown[] }) => {
+      if (JSON.stringify(opts.queryKey) === JSON.stringify(gitStatusKeys.all)) gitCalls++;
+      if (JSON.stringify(opts.queryKey) === JSON.stringify(fileListKeys.all)) filesCalls++;
+      return gitInvalidated(opts);
+    }) as typeof queryClient.invalidateQueries;
+
+    handleEvent({
+      id: 'evt_1',
+      type: 'session.status',
+      properties: { sessionID: 'ses_1', status: { type: 'idle' } },
+    });
+
+    // handle-event.ts reads `sessionStatus` itself to detect the transition —
+    // seeded above via `setStatus`, untouched by the (spied) `applySyncEvent`.
+    expect(useSyncStore.getState().sessionStatus.ses_1).toEqual({ type: 'busy' });
+    expect(notifications).toEqual([{ kind: 'task-complete', sessionId: 'ses_1', sessionTitle: undefined }]);
+    expect(gitCalls).toBe(1);
+    expect(filesCalls).toBe(1);
+  });
+
+  test('idle → idle (no real transition) does not fire a notification', () => {
+    const { handleEvent } = buildHandler();
+    useSyncStore.getState().setStatus('ses_1', { type: 'idle' });
+
+    handleEvent({
+      id: 'evt_1',
+      type: 'session.status',
+      properties: { sessionID: 'ses_1', status: { type: 'idle' } },
+    });
+
+    expect(notifications).toEqual([]);
+  });
+
+  test('busy → busy does not fire a task-complete notification', () => {
+    const { handleEvent } = buildHandler();
+    useSyncStore.getState().setStatus('ses_1', { type: 'busy' });
+
+    handleEvent({
+      id: 'evt_1',
+      type: 'session.status',
+      properties: { sessionID: 'ses_1', status: { type: 'busy' } },
+    });
+
+    expect(notifications).toEqual([]);
+  });
+});
+
+describe('session.idle', () => {
+  test('busy → idle fires notifyTaskComplete', () => {
+    const { handleEvent } = buildHandler();
+    useSyncStore.getState().setStatus('ses_1', { type: 'retry', attempt: 1, message: 'retrying', next: 1 });
+
+    handleEvent({
+      id: 'evt_1',
+      type: 'session.idle',
+      properties: { sessionID: 'ses_1' },
+    });
+
+    expect(notifications).toEqual([{ kind: 'task-complete', sessionId: 'ses_1', sessionTitle: undefined }]);
+  });
+});
+
+// ============================================================================
+// session.error — patches .error onto the last assistant message in the
+// messages query cache, and (unless it looks like an abort) rehydrates real
+// messages from the injected client.
+// ============================================================================
+
+describe('session.error', () => {
+  test('patches .error onto the last assistant message in the messages cache', () => {
+    const { handleEvent, queryClient } = buildHandler();
+    const key = opencodeKeys.messages('ses_1');
+    queryClient.setQueryData(key, [
+      { info: userMessage('msg_u'), parts: [] },
+      { info: assistantMessage('msg_a'), parts: [] },
+    ]);
+
+    handleEvent({
+      id: 'evt_1',
+      type: 'session.error',
+      properties: { sessionID: 'ses_1', error: { name: 'UnknownError', data: { message: 'boom' } } },
+    });
+
+    const cached = queryClient.getQueryData<Array<{ info: Message }>>(key);
+    expect((cached?.[1].info as AssistantMessage).error).toEqual({
+      name: 'UnknownError',
+      data: { message: 'boom' },
+    });
+    expect(notifications).toEqual([
+      { kind: 'session-error', sessionId: 'ses_1', errorTitle: 'UnknownError', sessionTitle: undefined },
+    ]);
+  });
+
+  test('non-abort errors rehydrate real messages from the injected client', async () => {
+    const rehydrated: Message[] = [assistantMessage('msg_real')];
+    const { handleEvent, queryClient } = buildHandler({
+      messagesImpl: async () => ({ data: rehydrated.map((info) => ({ info, parts: [] })) }),
+    });
+    useSyncStore.getState().optimisticAdd('ses_1', userMessage('msg_optimistic'), []);
+
+    handleEvent({
+      id: 'evt_1',
+      type: 'session.error',
+      properties: { sessionID: 'ses_1', error: { name: 'UnknownError', data: { message: 'boom' } } },
+    });
+
+    // The rehydrate fetch is fire-and-forget (`.then()`), so wait a tick.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(useSyncStore.getState().messages.ses_1?.some((m) => m.id === 'msg_real')).toBe(true);
+    expect(queryClient).toBeInstanceOf(QueryClient);
+  });
+
+  test('an abort-shaped error skips the rehydrate fetch entirely', async () => {
+    let fetchCount = 0;
+    const { handleEvent } = buildHandler({
+      messagesImpl: async () => {
+        fetchCount++;
+        return { data: [] };
+      },
+    });
+    useSyncStore.getState().optimisticAdd('ses_1', userMessage('msg_optimistic'), []);
+
+    // A real `session.error` event's `error.name` is restricted to the SDK's
+    // typed union — but `looksLikeAbortError` (see `helpers.ts`) exists
+    // precisely because some servers emit a differently-shaped abort error.
+    // Bypass the strict type here (as the real synthetic-abort call site in
+    // `use-event-stream-refs.ts` also must) to exercise that defensive path.
+    handleEvent({
+      id: 'evt_1',
+      type: 'session.error',
+      properties: { sessionID: 'ses_1', error: { name: 'AbortError', data: { message: 'aborted' } } },
+    } as never);
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(fetchCount).toBe(0);
+    // Optimistic message is still cleared even on the abort path.
+    expect(useSyncStore.getState().hasOptimisticMessages('ses_1')).toBe(false);
+  });
+});
+
+// ============================================================================
+// permission.asked / permission.replied — forwarded to the injected pending
+// store callbacks + a browser notification.
+// ============================================================================
+
+describe('permission.asked / permission.replied', () => {
+  test('permission.asked calls addPermission with the raw request and notifies', () => {
+    const { handleEvent, addPermission } = buildHandler();
+    const req: PermissionRequest = {
+      id: 'perm_1',
+      sessionID: 'ses_1',
+      permission: 'bash',
+      patterns: ['*'],
+      metadata: {},
+      always: [],
+    };
+
+    handleEvent({ id: 'evt_1', type: 'permission.asked', properties: req });
+
+    expect(addPermission.calls).toEqual([[req]]);
+    expect(notifications).toEqual([
+      { kind: 'permission', sessionId: 'ses_1', toolName: 'a tool', sessionTitle: undefined },
+    ]);
+  });
+
+  test('permission.replied calls removePermission with the request id', () => {
+    const { handleEvent, removePermission } = buildHandler();
+    handleEvent({
+      id: 'evt_1',
+      type: 'permission.replied',
+      properties: { sessionID: 'ses_1', requestID: 'perm_1', reply: 'once' },
+    });
+    expect(removePermission.calls).toEqual([['perm_1']]);
+  });
+});
+
+// ============================================================================
+// question.asked / question.replied / question.rejected
+// ============================================================================
+
+describe('question.asked / question.replied / question.rejected', () => {
+  test('question.asked calls addQuestion and notifies with the first question text', () => {
+    const { handleEvent, addQuestion } = buildHandler();
+    const req: QuestionRequest = {
+      id: 'q_1',
+      sessionID: 'ses_1',
+      questions: [{ question: 'Should I proceed?', header: 'Proceed?', options: [] }],
+    };
+
+    handleEvent({ id: 'evt_1', type: 'question.asked', properties: req });
+
+    expect(addQuestion.calls).toEqual([[req]]);
+    expect(notifications).toEqual([
+      { kind: 'question', sessionId: 'ses_1', questionText: 'Should I proceed?', sessionTitle: undefined },
+    ]);
+  });
+
+  test('question.replied calls removeQuestion with the request id', () => {
+    const { handleEvent, removeQuestion } = buildHandler();
+    handleEvent({
+      id: 'evt_1',
+      type: 'question.replied',
+      properties: { sessionID: 'ses_1', requestID: 'q_1', answers: [] },
+    });
+    expect(removeQuestion.calls).toEqual([['q_1']]);
+  });
+
+  test('question.rejected calls removeQuestion with the request id', () => {
+    const { handleEvent, removeQuestion } = buildHandler();
+    handleEvent({
+      id: 'evt_1',
+      type: 'question.rejected',
+      properties: { sessionID: 'ses_1', requestID: 'q_2' },
+    });
+    expect(removeQuestion.calls).toEqual([['q_2']]);
+  });
+});
+
+// ============================================================================
+// session.diff / todo.updated / vcs.branch.updated — targeted query-cache
+// writes, no invalidation.
+// ============================================================================
+
+describe('misc targeted cache writes', () => {
+  test('session.diff writes the diff array under the session-diff key', () => {
+    const { handleEvent, queryClient } = buildHandler();
+    const diff = [{ file: 'a.ts', additions: 1, deletions: 0, status: 'modified' as const }];
+    handleEvent({
+      id: 'evt_1',
+      type: 'session.diff',
+      properties: { sessionID: 'ses_1', diff },
+    });
+    expect(queryClient.getQueryData<typeof diff>(['opencode', 'session-diff', 'ses_1'])).toEqual(diff);
+  });
+
+  test('todo.updated writes the todos array under the session-todo key', () => {
+    const { handleEvent, queryClient } = buildHandler();
+    const todos = [{ content: 'write tests', status: 'pending', priority: 'high', id: 't1' }];
+    handleEvent({
+      id: 'evt_1',
+      type: 'todo.updated',
+      properties: { sessionID: 'ses_1', todos },
+    });
+    expect(queryClient.getQueryData<typeof todos>(['opencode', 'session-todo', 'ses_1'])).toEqual(todos);
+  });
+
+  test('vcs.branch.updated writes the branch under the vcs key', () => {
+    const { handleEvent, queryClient } = buildHandler();
+    handleEvent({
+      id: 'evt_1',
+      type: 'vcs.branch.updated',
+      properties: { branch: 'feat/foo' },
+    });
+    expect(queryClient.getQueryData<{ branch: string }>(['opencode', 'vcs'])).toEqual({ branch: 'feat/foo' });
+  });
+});
+
+// ============================================================================
+// Everything else — smoke coverage that each remaining case dispatches
+// without throwing and hits the expected side effect.
+// ============================================================================
+
+describe('remaining event kinds — smoke coverage', () => {
+  test('mcp.tools.changed refetches MCP status + tool ids (active only)', () => {
+    const { handleEvent, queryClient } = buildHandler();
+    expect(() =>
+      handleEvent({ id: 'evt_1', type: 'mcp.tools.changed', properties: { server: 'github' } }),
+    ).not.toThrow();
+    expect(queryClient).toBeInstanceOf(QueryClient);
+  });
+
+  test('worktree.ready invalidates worktrees + projects', () => {
+    const { handleEvent } = buildHandler();
+    expect(() =>
+      handleEvent({ id: 'evt_1', type: 'worktree.ready', properties: { name: 'wt-1' } }),
+    ).not.toThrow();
+  });
+
+  test('file.edited invalidates file list/git status, and file content only when a path is given', () => {
+    const { handleEvent, queryClient } = buildHandler();
+    let contentInvalidated = 0;
+    const orig = queryClient.invalidateQueries.bind(queryClient);
+    queryClient.invalidateQueries = ((opts: { queryKey: unknown[] }) => {
+      if (JSON.stringify(opts.queryKey) === JSON.stringify(fileContentKeys.all)) contentInvalidated++;
+      return orig(opts);
+    }) as typeof queryClient.invalidateQueries;
+
+    handleEvent({ id: 'evt_1', type: 'file.edited', properties: { file: 'src/app.ts' } });
+    expect(contentInvalidated).toBe(1);
+  });
+
+  test('installation.updated shows a toast', () => {
+    const { handleEvent } = buildHandler();
+    handleEvent({ id: 'evt_1', type: 'installation.updated', properties: { version: '1.2.3' } });
+    expect(toasts).toEqual([{ level: 'info', message: 'Installation updated (v1.2.3). Restart to apply changes.' }]);
+  });
+
+  test('installation.update-available shows a toast', () => {
+    const { handleEvent } = buildHandler();
+    handleEvent({ id: 'evt_1', type: 'installation.update-available', properties: { version: '2.0.0' } });
+    expect(toasts).toEqual([{ level: 'info', message: 'v2.0.0 is available. Update when you\'re ready.' }]);
+  });
+
+  test('pty.* events invalidate the pty list', () => {
+    const { handleEvent, queryClient } = buildHandler();
+    let ptyInvalidated = 0;
+    const orig = queryClient.invalidateQueries.bind(queryClient);
+    queryClient.invalidateQueries = ((opts: { queryKey: unknown[] }) => {
+      if (JSON.stringify(opts.queryKey) === JSON.stringify(ptyKeys.listPrefix())) ptyInvalidated++;
+      return orig(opts);
+    }) as typeof queryClient.invalidateQueries;
+
+    handleEvent({ id: 'evt_1', type: 'pty.created', properties: { info: { id: 'pty_1' } } as never });
+    expect(ptyInvalidated).toBe(1);
+  });
+
+  test('server.instance.disposed marks every non-idle session aborted locally', () => {
+    const { handleEvent, markSessionAbortedLocally } = buildHandler();
+    useSyncStore.getState().setStatus('ses_busy', { type: 'busy' });
+    useSyncStore.getState().setStatus('ses_idle', { type: 'idle' });
+
+    handleEvent({
+      id: 'evt_1',
+      type: 'server.instance.disposed',
+      properties: { directory: '/workspace' },
+    });
+
+    expect(markSessionAbortedLocally.calls.map((c) => c[0])).toEqual(['ses_busy']);
+  });
+
+  test('lsp.updated triggers a debounced diagnostics refetch', () => {
+    const { handleEvent, fetchLspDiagnosticsDebounced } = buildHandler();
+    handleEvent({ id: 'evt_1', type: 'lsp.updated', properties: {} });
+    expect(fetchLspDiagnosticsDebounced.calls.length).toBe(1);
+  });
+
+  test('lsp.client.diagnostics triggers a debounced diagnostics refetch', () => {
+    const { handleEvent, fetchLspDiagnosticsDebounced } = buildHandler();
+    handleEvent({
+      id: 'evt_1',
+      type: 'lsp.client.diagnostics',
+      properties: { serverID: 'srv_1', path: 'src/app.ts' },
+    });
+    expect(fetchLspDiagnosticsDebounced.calls.length).toBe(1);
+  });
+});

--- a/packages/sdk/src/react/use-opencode-events/handle-event.ts
+++ b/packages/sdk/src/react/use-opencode-events/handle-event.ts
@@ -1,5 +1,9 @@
 import { type QueryClient } from '@tanstack/react-query';
-import type { Event as OpenCodeSdkEvent, Part } from '@opencode-ai/sdk/v2/client';
+import type {
+  Event as OpenCodeSdkEvent,
+  PermissionRequest,
+  QuestionRequest,
+} from '@opencode-ai/sdk/v2/client';
 import type { RefObject } from 'react';
 import {
   infoToast,
@@ -16,23 +20,25 @@ import { ptyKeys } from '../use-opencode-pty';
 import { type MessageWithParts, opencodeKeys, type Session } from '../use-opencode-sessions';
 import { applyPartDiagnostics } from './diagnostics';
 import {
+  asStringOrUndefined,
+  looksLikeAbortError,
   readSessionInfo,
   refetchKortixSessionMirrors,
   scheduleProjectMetadataRefetch,
 } from './helpers';
-import type { OpenCodeEvent } from './types';
+import type { NormalizeDiagnosticPaths, OpenCodeEvent } from './types';
 
 /** Builds the SSE event handler; all closure dependencies are injected. */
 export function createEventHandler(deps: {
   queryClient: QueryClient;
   client: ReturnType<typeof getClient>;
-  applySyncEvent: (event: any) => void;
+  applySyncEvent: (event: OpenCodeSdkEvent) => void;
   stopCompaction: (sessionID: string) => void;
-  addPermission: (req: any) => void;
+  addPermission: (req: PermissionRequest) => void;
   removePermission: (requestId: string) => void;
-  addQuestion: (req: any) => void;
+  addQuestion: (req: QuestionRequest) => void;
   removeQuestion: (requestId: string) => void;
-  normalizeDiagnosticPaths: RefObject<(diagsByFile: Record<string, any[]>) => Record<string, any[]>>;
+  normalizeDiagnosticPaths: RefObject<NormalizeDiagnosticPaths>;
   markSessionAbortedLocally: RefObject<(sessionID: string, message?: string) => void>;
   fetchLspDiagnosticsDebounced: RefObject<() => void>;
 }) {
@@ -52,12 +58,12 @@ export function createEventHandler(deps: {
 
   // Helper: look up a session title from the React Query cache for notifications
   function getSessionTitle(sessionID: string): string | undefined {
-    const sessions = queryClient.getQueryData<any[]>(opencodeKeys.sessions());
+    const sessions = queryClient.getQueryData<Session[]>(opencodeKeys.sessions());
     if (sessions) {
-      const s = sessions.find((s: any) => s.id === sessionID);
+      const s = sessions.find((s) => s.id === sessionID);
       if (s?.title) return s.title;
     }
-    const session = queryClient.getQueryData<any>(opencodeKeys.session(sessionID));
+    const session = queryClient.getQueryData<Session>(opencodeKeys.session(sessionID));
     return session?.title || undefined;
   }
 
@@ -65,6 +71,11 @@ export function createEventHandler(deps: {
     // Sync store is the SINGLE source of truth for messages & parts.
     // This matches OpenCode's architecture where the SolidJS store is
     // the only place message/part data lives.
+    //
+    // `event` also carries the frontend-synthesized `lsp.client.diagnostics`
+    // member (see `OpenCodeEvent`), which isn't a real wire event and doesn't
+    // match any `applyEvent` case (falls through to its `default`) — the
+    // assertion below just widens past that one extra union member.
     applySyncEvent(event as OpenCodeSdkEvent);
 
     switch (event.type) {
@@ -75,8 +86,7 @@ export function createEventHandler(deps: {
 
       case 'message.part.updated': {
         // Extract diagnostics from tool output and/or metadata
-        const part = (event.properties as any).part as Part;
-        applyPartDiagnostics(part, normalizeDiagnosticPaths);
+        applyPartDiagnostics(event.properties.part, normalizeDiagnosticPaths);
         break;
       }
 
@@ -164,7 +174,7 @@ export function createEventHandler(deps: {
       }
 
       case 'session.compacted': {
-        const sessionID = (event.properties as any).sessionID;
+        const sessionID = event.properties.sessionID;
         if (sessionID) {
           stopCompaction(sessionID);
           const client = getClient();
@@ -172,7 +182,7 @@ export function createEventHandler(deps: {
             .messages({ sessionID })
             .then((res) => {
               if (res.data) {
-                useSyncStore.getState().hydrate(sessionID, res.data as any);
+                useSyncStore.getState().hydrate(sessionID, res.data);
                 const s = useSyncStore.getState();
                 const msgs = s.messages[sessionID] ?? [];
                 if (msgs.length > 0) saveSessionToIDB(sessionID, msgs, s.parts);
@@ -185,7 +195,7 @@ export function createEventHandler(deps: {
             .get({ sessionID })
             .then((res) => {
               if (res.data) {
-                const session = res.data as Session;
+                const session = res.data;
                 queryClient.setQueryData(opencodeKeys.session(sessionID), session);
                 // Also update in session list
                 queryClient.setQueryData<Session[]>(opencodeKeys.sessions(), (old) => {
@@ -205,7 +215,7 @@ export function createEventHandler(deps: {
 
       // ---- Session status ----
       case 'session.status': {
-        const { sessionID, status } = event.properties as any;
+        const { sessionID, status } = event.properties;
         if (sessionID && status) {
           // Detect busy/retry → idle transition BEFORE updating the store
           // (coalescing can drop intermediate busy events, so we check here)
@@ -223,7 +233,7 @@ export function createEventHandler(deps: {
       }
 
       case 'session.idle': {
-        const sessionID = (event.properties as any).sessionID;
+        const sessionID = event.properties.sessionID;
         if (sessionID) {
           const prevStatus = useSyncStore.getState().sessionStatus[sessionID];
           if (prevStatus && prevStatus.type !== 'idle') {
@@ -244,13 +254,18 @@ export function createEventHandler(deps: {
 
       // ---- Session errors ----
       case 'session.error': {
-        const props = event.properties as { sessionID?: string; error?: any };
+        const props = event.properties;
         if (props.sessionID && props.error) {
-          stopCompaction(props.sessionID);
+          const sessionID = props.sessionID;
+          const error = props.error;
+          stopCompaction(sessionID);
           // Fire browser notification
+          const rawMessage = error.data.message;
           const errorTitle =
-            props.error?.name || props.error?.data?.message || 'An error occurred';
-          notifySessionError(props.sessionID, errorTitle, getSessionTitle(props.sessionID));
+            error.name ||
+            (typeof rawMessage === 'string' ? rawMessage : undefined) ||
+            'An error occurred';
+          notifySessionError(sessionID, errorTitle, getSessionTitle(sessionID));
 
           // Patch the error onto the last assistant message in cache.
           // This is critical because:
@@ -258,18 +273,19 @@ export function createEventHandler(deps: {
           // 2. Some error paths (model-not-found, agent-not-found) never
           //    emit message.updated with .error at all
           // 3. Polling can race and overwrite the error from message.updated
-          const key = opencodeKeys.messages(props.sessionID);
+          const key = opencodeKeys.messages(sessionID);
           queryClient.cancelQueries({ queryKey: key });
           queryClient.setQueryData<MessageWithParts[]>(key, (old) => {
             if (!old || old.length === 0) return old;
             // Find the last assistant message and patch error onto it
             for (let i = old.length - 1; i >= 0; i--) {
-              if (old[i].info.role === 'assistant') {
-                if ((old[i].info as any).error) return old; // already has error
+              const info = old[i].info;
+              if (info.role === 'assistant') {
+                if (info.error) return old; // already has error
                 const updated = [...old];
                 updated[i] = {
                   ...old[i],
-                  info: { ...old[i].info, error: props.error } as any,
+                  info: { ...info, error },
                 };
                 return updated;
               }
@@ -288,28 +304,23 @@ export function createEventHandler(deps: {
           // may not have persisted the partial assistant response yet,
           // so hydrating would wipe the streamed content the user saw.
           // The error is already patched onto the message above.
-          const isAbortError =
-            props.error?.name === 'AbortError' ||
-            String(props.error?.data?.message || props.error?.message || '')
-              .toLowerCase()
-              .includes('abort');
-          const sid = props.sessionID;
+          const isAbortError = looksLikeAbortError(error);
           if (!isAbortError) {
             client.session
-              .messages({ sessionID: sid })
+              .messages({ sessionID })
               .then((res) => {
                 if (!res.data) return;
-                useSyncStore.getState().hydrate(sid, res.data as any);
-                useSyncStore.getState().clearOptimisticMessages(sid);
+                useSyncStore.getState().hydrate(sessionID, res.data);
+                useSyncStore.getState().clearOptimisticMessages(sessionID);
                 const s = useSyncStore.getState();
-                const msgs = s.messages[sid] ?? [];
-                if (msgs.length > 0) saveSessionToIDB(sid, msgs, s.parts);
+                const msgs = s.messages[sessionID] ?? [];
+                if (msgs.length > 0) saveSessionToIDB(sessionID, msgs, s.parts);
               })
               .catch(() => {});
           } else {
             // Still clear optimistic messages on abort — the real
             // user message should have arrived via SSE by now.
-            useSyncStore.getState().clearOptimisticMessages(sid);
+            useSyncStore.getState().clearOptimisticMessages(sessionID);
           }
         }
         break;
@@ -317,30 +328,36 @@ export function createEventHandler(deps: {
 
       // ---- Permissions ----
       case 'permission.asked': {
-        const props = event.properties as any;
+        const props = event.properties;
         if (props.id && props.sessionID) {
           addPermission(props);
-          // Fire browser notification for permission requests
-          const toolName = props.tool || props.type || 'a tool';
+          // Fire browser notification for permission requests. `tool` (when
+          // present) is `{messageID, callID}`, not a name — some historical
+          // wire shapes carried a bare string `type` field instead, which the
+          // current SDK types no longer declare. Duck-type both defensively
+          // rather than assume either is a string.
+          const rawProps: { tool?: unknown; type?: unknown } = props;
+          const toolName =
+            asStringOrUndefined(rawProps.tool) ?? asStringOrUndefined(rawProps.type) ?? 'a tool';
           notifyPermissionRequest(props.sessionID, toolName, getSessionTitle(props.sessionID));
         }
         break;
       }
       case 'permission.replied': {
-        const requestID = (event.properties as any).requestID;
+        const requestID = event.properties.requestID;
         if (requestID) removePermission(requestID);
         break;
       }
 
       // ---- Questions ----
       case 'question.asked': {
-        const props = event.properties as any;
+        const props = event.properties;
         if (props.id && props.sessionID) {
           addQuestion(props);
           // Fire browser notification for questions needing user input
           const questionText =
-            props.questions?.[0]?.question ||
-            props.questions?.[0]?.header ||
+            props.questions[0]?.question ||
+            props.questions[0]?.header ||
             'Kortix needs your input';
           notifyQuestion(props.sessionID, questionText, getSessionTitle(props.sessionID));
         }
@@ -348,14 +365,14 @@ export function createEventHandler(deps: {
       }
       case 'question.replied':
       case 'question.rejected': {
-        const requestID = (event.properties as any).requestID;
+        const requestID = event.properties.requestID;
         if (requestID) removeQuestion(requestID);
         break;
       }
 
       // ---- Session diff ----
       case 'session.diff': {
-        const props = event.properties as { sessionID: string; diff: any[] };
+        const props = event.properties;
         if (props.sessionID) {
           queryClient.setQueryData(['opencode', 'session-diff', props.sessionID], props.diff);
         }
@@ -364,7 +381,7 @@ export function createEventHandler(deps: {
 
       // ---- Todo updated ----
       case 'todo.updated': {
-        const props = event.properties as { sessionID: string; todos: any[] };
+        const props = event.properties;
         if (props.sessionID) {
           queryClient.setQueryData(['opencode', 'session-todo', props.sessionID], props.todos);
         }
@@ -373,7 +390,7 @@ export function createEventHandler(deps: {
 
       // ---- VCS branch ----
       case 'vcs.branch.updated': {
-        const props = event.properties as { branch: string };
+        const props = event.properties;
         queryClient.setQueryData(['opencode', 'vcs'], {
           branch: props.branch,
         });
@@ -462,7 +479,7 @@ export function createEventHandler(deps: {
 
       // ---- File edited (outside agent, e.g. user edits in editor) ----
       case 'file.edited': {
-        const fileProps = event.properties as { file?: string };
+        const fileProps = event.properties;
         queryClient.invalidateQueries({ queryKey: fileListKeys.all, type: 'active' });
         queryClient.invalidateQueries({ queryKey: gitStatusKeys.all, type: 'active' });
         if (fileProps.file) {
@@ -473,7 +490,7 @@ export function createEventHandler(deps: {
 
       // ---- Installation events ----
       case 'installation.updated': {
-        const installProps = event.properties as { version?: string };
+        const installProps = event.properties;
         const versionStr = installProps.version ? ` (v${installProps.version})` : '';
         infoToast(`Installation updated${versionStr}. Restart to apply changes.`, {
           duration: 10_000,
@@ -482,7 +499,7 @@ export function createEventHandler(deps: {
       }
 
       case 'installation.update-available': {
-        const updateProps = event.properties as { version?: string };
+        const updateProps = event.properties;
         const versionLabel = updateProps.version ? `v${updateProps.version}` : 'A new version';
         infoToast(`${versionLabel} is available. Update when you're ready.`, {
           duration: 15_000,

--- a/packages/sdk/src/react/use-opencode-events/helpers.ts
+++ b/packages/sdk/src/react/use-opencode-events/helpers.ts
@@ -19,10 +19,37 @@ let projectMetadataRefetchTimer: ReturnType<typeof setTimeout> | null = null;
  * shipped (apps/mobile commit 7f31102fe "fix: session title updates").
  */
 export function readSessionInfo(event: OpenCodeEvent): Session | undefined {
-  const props = (event as any)?.properties;
-  if (!props) return undefined;
-  if (props.info) return props.info as Session;
-  return typeof props.id === 'string' ? (props as Session) : undefined;
+  const props: unknown = event.properties;
+  if (!props || typeof props !== 'object') return undefined;
+  const rec = props as Record<string, unknown>;
+  if (rec.info) return rec.info as Session;
+  return typeof rec.id === 'string' ? (props as Session) : undefined;
+}
+
+/** Reads `value` back out only if it's genuinely a string — used for wire
+ *  fields whose declared type may be an object (or absent) depending on
+ *  which request shape produced them. */
+export function asStringOrUndefined(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+/**
+ * Some servers emit an "AbortError"-shaped `session.error` whose `name`/message
+ * live wherever the server put them — not part of the SDK's typed error union
+ * (`ProviderAuthError | UnknownError | ... | ApiError`). Duck-type via
+ * `unknown` rather than assuming a shape; checks `.name`, `.data.message`, and
+ * a top-level `.message` for a case-insensitive "abort" substring.
+ */
+export function looksLikeAbortError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+  const rec = error as Record<string, unknown>;
+  if (rec.name === 'AbortError') return true;
+  const data = rec.data;
+  const dataMessage =
+    data && typeof data === 'object' ? (data as Record<string, unknown>).message : undefined;
+  return String(dataMessage ?? rec.message ?? '')
+    .toLowerCase()
+    .includes('abort');
 }
 
 export function reserveMessageRehydrate(sessionID: string): boolean {

--- a/packages/sdk/src/react/use-opencode-events/index.ts
+++ b/packages/sdk/src/react/use-opencode-events/index.ts
@@ -1,5 +1,6 @@
 'use client';
 
+import type { Event as OpenCodeSdkEvent } from '@opencode-ai/sdk/v2/client';
 import { clearConfigOverrides } from '../use-opencode-config';
 import { saveSessionToIDB } from '../../state/idb-sync-cache';
 import { logger } from '../../platform/logger';
@@ -153,12 +154,15 @@ export function useOpenCodeEventStream() {
         .status()
         .then((res) => {
           if (res.data) {
-            const statuses = res.data as Record<string, any>;
+            const statuses = res.data;
             for (const [sessionID, status] of Object.entries(statuses)) {
+              // Locally-synthesized event (this is a REST poll, not an SSE
+              // frame) — omits the `id` field every real `Event` union member
+              // carries, hence the assertion.
               applySyncEvent({
                 type: 'session.status',
                 properties: { sessionID, status },
-              } as any);
+              } as unknown as OpenCodeSdkEvent);
             }
             reconcileMissingBusySessions.current(statuses);
           } else {
@@ -193,7 +197,7 @@ export function useOpenCodeEventStream() {
             .messages({ sessionID: sid })
             .then((res) => {
               if (res.data) {
-                useSyncStore.getState().hydrate(sid, res.data as any);
+                useSyncStore.getState().hydrate(sid, res.data);
                 const s = useSyncStore.getState();
                 const msgs = s.messages[sid] ?? [];
                 if (msgs.length > 0) saveSessionToIDB(sid, msgs, s.parts);

--- a/packages/sdk/src/react/use-opencode-events/types.ts
+++ b/packages/sdk/src/react/use-opencode-events/types.ts
@@ -3,3 +3,12 @@
 // Re-exported here, unchanged, so existing importers in this directory don't
 // need to change their import path.
 export type { OpenCodeEvent } from '../../state/event-stream';
+
+/**
+ * A file-path-keyed diagnostics normalizer: remaps absolute sandbox paths to
+ * project-relative ones without touching the diagnostic entries themselves.
+ * Generic because callers pass different diagnostic element shapes (parsed
+ * `LspDiagnostic[]`, raw `/lsp/diagnostics` payloads, legacy metadata blobs) —
+ * the normalizer never reads their fields, only the outer file-path keys.
+ */
+export type NormalizeDiagnosticPaths = <T>(diagsByFile: Record<string, T[]>) => Record<string, T[]>;

--- a/packages/sdk/src/react/use-opencode-events/use-event-stream-refs.ts
+++ b/packages/sdk/src/react/use-opencode-events/use-event-stream-refs.ts
@@ -1,12 +1,15 @@
 'use client';
 
 import { type QueryClient } from '@tanstack/react-query';
+import type { Event as OpenCodeSdkEvent } from '@opencode-ai/sdk/v2/client';
 import { useRef } from 'react';
 import { authenticatedFetch } from '../../platform/auth';
-import { useDiagnosticsStore } from '../../state/diagnostics-store';
+import { useDiagnosticsStore, type RawDiagnostic } from '../../state/diagnostics-store';
 import { getActiveOpenCodeUrl } from '../../state/server-store';
 import { useSyncStore } from '../../state/sync-store';
-import { opencodeKeys } from '../use-opencode-sessions';
+import type { SyntheticAbortError } from '../../state/sync-store/types';
+import { type Project, type PathInfo, type SessionStatus, opencodeKeys } from '../use-opencode-sessions';
+import type { NormalizeDiagnosticPaths } from './types';
 
 /**
  * Creates the stable per-stream refs used by the event hook. Each ref captures
@@ -16,7 +19,7 @@ import { opencodeKeys } from '../use-opencode-sessions';
 export function useEventStreamRefs(deps: {
   queryClient: QueryClient;
   stopCompaction: (sessionID: string) => void;
-  applySyncEvent: (event: any) => void;
+  applySyncEvent: (event: OpenCodeSdkEvent) => void;
 }) {
   const { queryClient, stopCompaction, applySyncEvent } = deps;
 
@@ -35,9 +38,9 @@ export function useEventStreamRefs(deps: {
     // Collect prefixes from cached project/path data
     const prefixes: string[] = [];
     try {
-      const project = queryClient.getQueryData<any>(opencodeKeys.currentProject());
+      const project = queryClient.getQueryData<Project>(opencodeKeys.currentProject());
       if (project?.worktree) prefixes.push(project.worktree);
-      const pathInfo = queryClient.getQueryData<any>(opencodeKeys.pathInfo());
+      const pathInfo = queryClient.getQueryData<PathInfo>(opencodeKeys.pathInfo());
       if (pathInfo?.directory) prefixes.push(pathInfo.directory);
       if (pathInfo?.worktree) prefixes.push(pathInfo.worktree);
     } catch {
@@ -59,9 +62,9 @@ export function useEventStreamRefs(deps: {
   });
 
   /** Normalize all keys in a diagnostic map from absolute to relative paths */
-  const normalizeDiagnosticPaths = useRef(
-    (diagsByFile: Record<string, any[]>): Record<string, any[]> => {
-      const normalized: Record<string, any[]> = {};
+  const normalizeDiagnosticPaths = useRef<NormalizeDiagnosticPaths>(
+    function normalizeDiagnosticPaths<T>(diagsByFile: Record<string, T[]>): Record<string, T[]> {
+      const normalized: Record<string, T[]> = {};
       for (const [file, diags] of Object.entries(diagsByFile)) {
         const relPath = normalizeLspPath.current(file);
         normalized[relPath] = diags;
@@ -89,7 +92,7 @@ export function useEventStreamRefs(deps: {
             const baseUrl = getActiveOpenCodeUrl();
             const resp = await authenticatedFetch(`${baseUrl}/lsp/diagnostics`);
             if (!resp.ok) return;
-            const data = (await resp.json()) as Record<string, any[]>;
+            const data = (await resp.json()) as Record<string, RawDiagnostic[]>;
             if (data && typeof data === 'object') {
               const normalized = normalizeDiagnosticPaths.current(data);
               // The endpoint returns the *complete* diagnostics state,
@@ -110,16 +113,22 @@ export function useEventStreamRefs(deps: {
   const markSessionAbortedLocally = useRef(
     (sessionID: string, message = 'The operation was aborted because the runtime shut down.') => {
       if (!sessionID) return;
-      const error = {
+      const error: SyntheticAbortError = {
         name: 'AbortError',
         data: { message },
       };
       stopCompaction(sessionID);
+      // Locally-synthesized event — not from the wire, so it intentionally
+      // omits the `id` field every real `Event` union member carries, and
+      // `error` is the client-only `SyntheticAbortError` shape (not part of
+      // the SDK's `session.error` error union). The sync store's `applyEvent`
+      // handles both structurally (see `MessageError`); the assertion just
+      // documents that this event is fabricated, not wire data.
       applySyncEvent({
         type: 'session.error',
         properties: { sessionID, error },
-      } as any);
-      useSyncStore.getState().setStatus(sessionID, { type: 'idle' } as any);
+      } as unknown as OpenCodeSdkEvent);
+      useSyncStore.getState().setStatus(sessionID, { type: 'idle' });
       useSyncStore.getState().clearOptimisticMessages(sessionID);
     },
   );
@@ -127,15 +136,16 @@ export function useEventStreamRefs(deps: {
   const markSessionIdleLocally = useRef((sessionID: string) => {
     if (!sessionID) return;
     stopCompaction(sessionID);
+    // Same locally-synthesized-event caveat as above: no real `id`.
     applySyncEvent({
       type: 'session.idle',
       properties: { sessionID },
-    } as any);
-    useSyncStore.getState().setStatus(sessionID, { type: 'idle' } as any);
+    } as unknown as OpenCodeSdkEvent);
+    useSyncStore.getState().setStatus(sessionID, { type: 'idle' });
     useSyncStore.getState().clearOptimisticMessages(sessionID);
   });
 
-  const reconcileMissingBusySessions = useRef((nextStatuses: Record<string, any>) => {
+  const reconcileMissingBusySessions = useRef((nextStatuses: Record<string, SessionStatus>) => {
     const previousStatuses = useSyncStore.getState().sessionStatus;
     for (const [sessionID, status] of Object.entries(previousStatuses)) {
       if (status?.type !== 'idle' && !nextStatuses[sessionID]) {

--- a/packages/sdk/src/react/use-opencode-mcp.ts
+++ b/packages/sdk/src/react/use-opencode-mcp.ts
@@ -31,16 +31,21 @@ export type { McpStatus };
 
 function unwrap<T>(result: { data?: T; error?: unknown; response?: Response }): T {
   if (result.error) {
-    const err = result.error as any;
+    // `error`'s shape varies per endpoint's typed error union — duck-type
+    // defensively via `unknown` rather than assume a shape.
+    const err = result.error;
     const status = (result.response as Response | undefined)?.status;
+    const errRec = err && typeof err === 'object' ? (err as Record<string, unknown>) : undefined;
+    const dataRec =
+      errRec?.data && typeof errRec.data === 'object' ? (errRec.data as Record<string, unknown>) : undefined;
     const msg =
-      err?.data?.message ||
-      err?.message ||
-      err?.error ||
+      dataRec?.message ||
+      errRec?.message ||
+      errRec?.error ||
       (typeof err === 'string' ? err : null) ||
       (typeof err === 'object' ? JSON.stringify(err) : null) ||
       (status ? `Server returned ${status}` : 'SDK request failed');
-    throw new Error(msg);
+    throw new Error(String(msg));
   }
   return result.data as T;
 }

--- a/packages/sdk/src/react/use-opencode-pty.ts
+++ b/packages/sdk/src/react/use-opencode-pty.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { stripTrailingSlashes } from '../platform/strings';
 import { getClient } from '../opencode/client';
 import { getActiveOpenCodeUrl } from '../state/server-store';
 import { getAuthToken } from '../platform/auth';
@@ -139,7 +140,7 @@ export async function getPtyWebSocketUrl(ptyId: string, serverUrl?: string): Pro
         parsed.protocol = 'wss:';
       }
 
-      return parsed.toString().replace(/\/+$/, '');
+      return stripTrailingSlashes(parsed.toString());
     } catch {
       return baseUrl.replace('https://', 'wss://').replace('http://', 'ws://');
     }

--- a/packages/sdk/src/react/use-opencode-pty.ts
+++ b/packages/sdk/src/react/use-opencode-pty.ts
@@ -28,8 +28,14 @@ export const ptyKeys = {
 
 function unwrap<T>(result: { data?: T; error?: unknown }): T {
   if (result.error) {
-    const err = result.error as any;
-    throw new Error(err?.data?.message || err?.message || 'SDK request failed');
+    // `error`'s shape varies per endpoint's typed error union — duck-type
+    // defensively via `unknown` rather than assume a shape.
+    const err = result.error;
+    const errRec = err && typeof err === 'object' ? (err as Record<string, unknown>) : undefined;
+    const dataRec =
+      errRec?.data && typeof errRec.data === 'object' ? (errRec.data as Record<string, unknown>) : undefined;
+    const message = dataRec?.message ?? errRec?.message;
+    throw new Error(typeof message === 'string' ? message : 'SDK request failed');
   }
   return result.data as T;
 }
@@ -68,7 +74,7 @@ export function useCreatePty() {
       env?: Record<string, string>;
     }) => {
       const client = getClient();
-      const result = await client.pty.create(options as any);
+      const result = await client.pty.create(options);
       return unwrap(result);
     },
     onSuccess: () => {
@@ -84,7 +90,7 @@ export function useRemovePty() {
   return useMutation({
     mutationFn: async (id: string) => {
       const client = getClient();
-      const result = await client.pty.remove({ ptyID: id } as any);
+      const result = await client.pty.remove({ ptyID: id });
       unwrap(result);
     },
     onSuccess: () => {
@@ -106,7 +112,7 @@ export function useUpdatePty() {
       size?: { rows: number; cols: number };
     }) => {
       const client = getClient();
-      const result = await client.pty.update({ ptyID: id, title, size } as any);
+      const result = await client.pty.update({ ptyID: id, title, size });
       return unwrap(result);
     },
   });

--- a/packages/sdk/src/react/use-opencode-sessions/files.test.ts
+++ b/packages/sdk/src/react/use-opencode-sessions/files.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, test, beforeEach, mock } from 'bun:test';
+
+// `findOpenCodeFiles` resolves `getClient()` fresh on every call — swap the
+// implementation per-test via `clientImpl` to control exactly what
+// `client.find.files()` / `client.file.list()` resolve to.
+let clientImpl: {
+  find: { files: (args: { query: string; type?: string; limit: number }) => Promise<{ data?: unknown }> };
+  file: { list: (args: { path: string }) => Promise<{ data?: unknown }> };
+};
+
+mock.module('../../opencode/client', () => ({
+  getClient: () => clientImpl,
+}));
+
+const { findOpenCodeFiles } = await import('./files');
+
+/**
+ * `findOpenCodeFiles` keeps a couple of module-level caches
+ * (`mentionFileIndexCache`, `mentionDirScanCache`) that persist across calls
+ * within this process and aren't exported for a test to reset. To keep tests
+ * independent without fighting that cache:
+ *
+ *  - Every fixture below responds to the REAL query with its matches, but
+ *    returns an EMPTY list for `query: ''` (the broad-index-building calls
+ *    the "file index" fallback makes) — so that fallback always populates
+ *    its cache with nothing, never leaking one test's fixture into another.
+ *  - `file.list` defaults to empty for every path unless a test explicitly
+ *    wants to exercise the directory-expansion path, so the (also-cached)
+ *    root/directory-scan fallbacks always contribute nothing either.
+ */
+function queryAwareFiles(matches: unknown[]) {
+  return async ({ query }: { query: string }) => ({ data: query === '' ? [] : matches });
+}
+
+beforeEach(() => {
+  clientImpl = {
+    find: { files: async () => ({ data: [] }) },
+    file: { list: async () => ({ data: [] }) },
+  };
+});
+
+describe('findOpenCodeFiles — ranking and dedup', () => {
+  test('ranks an exact basename match first, then prefix, then substring, then path-substring', async () => {
+    // `find.files({ query })` is trusted as already server-filtered — this
+    // function's own job is ranking what comes back, not re-filtering it
+    // (client-side relevance filtering only happens in the fallback paths,
+    // covered separately below), so every fixture entry here is a genuine
+    // "app" match at a different rank tier.
+    clientImpl.find.files = queryAwareFiles([
+      'src/components/app.tsx', // substring: "app" inside "app.tsx" AND path
+      'src/app-config.ts', // prefix: basename starts with "app"
+      'app.ts', // exact basename match
+      'app-folder/utils.ts', // path-substring only (directory name, not basename)
+    ]);
+
+    const results = await findOpenCodeFiles('app');
+    expect(results).toHaveLength(4);
+    // Exact basename match ranks above a prefix match, which ranks above a
+    // substring-only match, which ranks above a path-only substring match.
+    expect(results.indexOf('app.ts')).toBeLessThan(results.indexOf('src/app-config.ts'));
+    expect(results.indexOf('src/app-config.ts')).toBeLessThan(results.indexOf('src/components/app.tsx'));
+    expect(results.indexOf('src/components/app.tsx')).toBeLessThan(results.indexOf('app-folder/utils.ts'));
+  });
+
+  test('dedups identical paths returned by both the strict and broad query', async () => {
+    let callCount = 0;
+    clientImpl.find.files = async ({ query }) => {
+      if (query === '') return { data: [] };
+      callCount++;
+      return { data: ['src/app.ts'] };
+    };
+
+    const results = await findOpenCodeFiles('app');
+    expect(callCount).toBe(2); // strict + broad, each returning the same path
+    expect(results).toEqual(['src/app.ts']);
+  });
+
+  test('an empty query still ranks by directory depth (shallower first)', async () => {
+    // The query itself is '' here (matches everything), which is also what
+    // the file-index fallback's own background calls use — give it the same
+    // fixture; the assertion only cares about the top 20, so extra identical
+    // entries are harmless.
+    clientImpl.find.files = async () => ({ data: ['a/b/c/deep.ts', 'top.ts', 'a/mid.ts'] });
+
+    const results = await findOpenCodeFiles('');
+    expect(results).toEqual(['top.ts', 'a/mid.ts', 'a/b/c/deep.ts']);
+  });
+
+  test('object-shaped entries with a `path`/`type` field are normalized (directories get a trailing slash)', async () => {
+    clientImpl.find.files = queryAwareFiles([
+      { path: 'src/app.ts', type: 'file' },
+      { path: 'src/nested', type: 'directory' },
+    ]);
+
+    const results = await findOpenCodeFiles('app');
+    expect(results).toEqual(['src/app.ts']);
+    // The directory entry is never returned as a file match (only used
+    // internally to seed the directory-expansion fallback).
+    expect(results).not.toContain('src/nested');
+    expect(results).not.toContain('src/nested/');
+  });
+
+  test('results are capped at 20 entries', async () => {
+    const many = Array.from({ length: 30 }, (_, i) => `file${String(i).padStart(2, '0')}.ts`);
+    clientImpl.find.files = queryAwareFiles(many);
+
+    const results = await findOpenCodeFiles('file');
+    expect(results).toHaveLength(20);
+  });
+
+  test('a malformed/rejecting find.files() response is treated as no matches, not a throw', async () => {
+    clientImpl.find.files = async () => {
+      throw new Error('network down');
+    };
+    await expect(findOpenCodeFiles('anything')).resolves.toEqual([]);
+  });
+});
+
+describe('findOpenCodeFiles — directory-expansion fallback', () => {
+  test('expands a matched directory into its children when strict/broad matches are sparse', async () => {
+    clientImpl.find.files = async ({ type, query }) => {
+      if (query === '' || type === 'file') return { data: [] };
+      // Broad query returns only a directory match.
+      return { data: [{ path: 'src/utils', type: 'directory' }] };
+    };
+    // Sparse (<20) results also trigger the root-scan and dir-scan fallbacks
+    // (both call `file.list` with paths other than the expanded directory,
+    // e.g. `/workspace`/`''`) — return that directory's children only for
+    // its own path, and an empty listing for everything else.
+    clientImpl.file.list = async ({ path }) => {
+      if (path === 'src/utils') return { data: ['src/utils/app-helpers.ts', 'src/utils/other.ts'] };
+      return { data: [] };
+    };
+
+    const results = await findOpenCodeFiles('app');
+    expect(results).toContain('src/utils/app-helpers.ts');
+    expect(results).not.toContain('src/utils/other.ts'); // doesn't match the query "app"
+  });
+});

--- a/packages/sdk/src/react/use-opencode-sessions/files.ts
+++ b/packages/sdk/src/react/use-opencode-sessions/files.ts
@@ -114,8 +114,8 @@ export async function findOpenCodeFiles(query: string): Promise<string[]> {
   // Some backends under-return root-level files via find.files(query).
   if (normalizedQuery.length > 0 && fileMatches.size < 20) {
     const [rootWorkspace, rootEmpty] = await Promise.all([
-      readEntries(client.file.list({ path: '/workspace' } as any)),
-      readEntries(client.file.list({ path: '' } as any)),
+      readEntries(client.file.list({ path: '/workspace' })),
+      readEntries(client.file.list({ path: '' })),
     ]);
     for (const entry of [...rootWorkspace, ...rootEmpty]) {
       if (entry.endsWith('/')) continue;
@@ -133,8 +133,8 @@ export async function findOpenCodeFiles(query: string): Promise<string[]> {
 
     if (!cacheFresh) {
       const roots = await Promise.all([
-        readEntries(client.file.list({ path: '/workspace' } as any)),
-        readEntries(client.file.list({ path: '' } as any)),
+        readEntries(client.file.list({ path: '/workspace' })),
+        readEntries(client.file.list({ path: '' })),
       ]);
       const rootEntries = Array.from(new Set([...roots[0], ...roots[1]]));
 
@@ -149,7 +149,7 @@ export async function findOpenCodeFiles(query: string): Promise<string[]> {
       }
 
       const childLists = await Promise.all(
-        firstLevelDirs.map((dir) => readEntries(client.file.list({ path: dir } as any))),
+        firstLevelDirs.map((dir) => readEntries(client.file.list({ path: dir }))),
       );
 
       for (const children of childLists) {

--- a/packages/sdk/src/react/use-opencode-sessions/messages.ts
+++ b/packages/sdk/src/react/use-opencode-sessions/messages.ts
@@ -44,9 +44,9 @@ export function extractSendErrorMessage(error: unknown): string {
   if (typeof error === 'string') return error;
   if (error instanceof Error) return error.message;
   if (typeof error === 'object') {
-    const err = error as Record<string, any>;
-    const root = err.data ?? err;
-    const msg = root?.message || err.message || root?.error || err.error;
+    const err = error as Record<string, unknown>;
+    const root = (err.data as Record<string, unknown> | undefined) ?? err;
+    const msg = root.message || err.message || root.error || err.error;
     if (typeof msg === 'string') return msg;
     try {
       return JSON.stringify(err);
@@ -204,7 +204,7 @@ export function useOpenCodeMessages(sessionId: string) {
     isLoading,
     isError: false,
     error: null,
-    refetch: async () => ({ data: messages } as any),
+    refetch: async () => ({ data: messages }),
   };
 }
 
@@ -307,7 +307,7 @@ export async function promptOpenCodeMessage({
       const client = getClient();
       // The SDK resolves (not rejects) on HTTP errors, returning
       // { error, response } instead of throwing.
-      const result = await client.session.promptAsync(payload as any);
+      const result = await client.session.promptAsync(payload);
       if (!result?.error) return; // 204 — server accepted the prompt.
       error = result.error;
       status = (result.response as Response | undefined)?.status;
@@ -317,9 +317,14 @@ export async function promptOpenCodeMessage({
 
     const delay = getSendRetryDelayMs(attempt, status, error);
     if (delay === null) {
-      const err = error as any;
-      const message = err?.data?.message || err?.message || 'Failed to send message';
-      const wrapped = new Error(message) as SendOpenCodeMessageError;
+      const err =
+        error && typeof error === 'object' ? (error as Record<string, unknown>) : undefined;
+      const errData =
+        err?.data && typeof err.data === 'object' ? (err.data as Record<string, unknown>) : undefined;
+      const message = errData?.message || err?.message || 'Failed to send message';
+      const wrapped = new Error(
+        typeof message === 'string' ? message : 'Failed to send message',
+      ) as SendOpenCodeMessageError;
       if (status) {
         wrapped.status = status;
         wrapped.response = { status };
@@ -349,8 +354,8 @@ export function useAbortOpenCodeSession() {
       // we force-refresh the session status from the server.
       try {
         const statusResult = await client.session.status();
-        const statuses = statusResult.data as Record<string, any>;
-        const serverStatus = statuses[sessionId];
+        const statuses = statusResult.data;
+        const serverStatus = statuses?.[sessionId];
         if (serverStatus && serverStatus.type !== 'idle') {
           // Server still thinks we're busy - update the store with server's view
           // This can happen if SSE events were missed

--- a/packages/sdk/src/react/use-opencode-sessions/sessions.test.ts
+++ b/packages/sdk/src/react/use-opencode-sessions/sessions.test.ts
@@ -1,0 +1,321 @@
+import { describe, expect, test, beforeEach, mock } from 'bun:test';
+import type { Session } from '@opencode-ai/sdk/v2/client';
+// Imported BEFORE `mock.module` below runs, so this binds to the REAL store
+// (module resolution for a static import happens before the rest of this
+// file's top-level code executes) — used as the mock's backing state so
+// `onMutate`/`onError` assertions see genuine store mutations.
+import { useOpenCodeCompactionStore as realCompactionStore } from '../../state/opencode-compaction-store';
+
+// react-query's `useQuery`/`useMutation` are mocked down to identity functions
+// (return the config object passed in) so the hooks under test can be called
+// as plain functions — same harness as `./messages.test.ts` /
+// `../use-kortix-master.test.ts`. `useQueryClient` returns a minimal
+// hand-rolled cache (not a real `QueryClient`) with just the methods these
+// three hooks actually call.
+function makeFakeQueryClient() {
+  const cache = new Map<string, unknown>();
+  const cacheKey = (k: readonly unknown[]) => JSON.stringify(k);
+  const refetchCalls: unknown[] = [];
+  return {
+    setQueryData: (k: readonly unknown[], updater: unknown) => {
+      const existing = cache.get(cacheKey(k));
+      const value = typeof updater === 'function' ? (updater as (old: unknown) => unknown)(existing) : updater;
+      cache.set(cacheKey(k), value);
+      return value;
+    },
+    getQueryData: (k: readonly unknown[]) => cache.get(cacheKey(k)),
+    refetchQueries: (opts: unknown) => {
+      refetchCalls.push(opts);
+    },
+    refetchCalls,
+  };
+}
+
+let fakeQueryClient = makeFakeQueryClient();
+
+mock.module('@tanstack/react-query', () => ({
+  useQuery: (config: Record<string, unknown>) => config,
+  useMutation: (config: Record<string, unknown>) => config,
+  useQueryClient: () => fakeQueryClient,
+}));
+
+// `client` is swapped per-test via `clientImpl` so each test controls exactly
+// what `client.global.config.get()` / `client.session.messages()` /
+// `client.provider.list()` / `client.session.summarize()` /
+// `client.session.fork()` / `client.session.command()` resolve to.
+let clientImpl: Record<string, unknown> = {};
+mock.module('../../opencode/client', () => ({
+  getClient: () => clientImpl,
+}));
+
+// `useOpenCodeCompactionStore` is a real zustand hook — calling it outside a
+// React render (as this file does, invoking hooks as plain functions) throws
+// "Invalid hook call". Replace the reactive wrapper with a plain selector
+// call against the REAL store's `getState()`/`setState()`, so `onMutate`/
+// `onError` still exercise genuine store mutations.
+mock.module('../../state/opencode-compaction-store', () => ({
+  useOpenCodeCompactionStore: Object.assign(
+    (selector: (s: ReturnType<typeof realCompactionStore.getState>) => unknown) =>
+      selector(realCompactionStore.getState()),
+    { getState: realCompactionStore.getState, setState: realCompactionStore.setState },
+  ),
+}));
+
+const { useSummarizeOpenCodeSession, useForkSession, useInitSession } = await import('./sessions');
+const { opencodeKeys } = await import('./keys');
+
+beforeEach(() => {
+  fakeQueryClient = makeFakeQueryClient();
+  clientImpl = {};
+});
+
+// ============================================================================
+// useSummarizeOpenCodeSession — the 3-tier model-resolution fallback chain
+// (config default → last assistant message → first connected provider/model)
+// ============================================================================
+
+describe('useSummarizeOpenCodeSession — model resolution fallback chain', () => {
+  test('tier 1: uses the config default model when neither providerID nor modelID is given', async () => {
+    let summarizeArgs: unknown;
+    clientImpl = {
+      global: { config: { get: async () => ({ data: { model: 'anthropic/claude-opus' } }) } },
+      session: {
+        summarize: async (args: unknown) => {
+          summarizeArgs = args;
+          return { data: {} };
+        },
+      },
+    };
+    const { mutationFn } = useSummarizeOpenCodeSession() as unknown as {
+      mutationFn: (args: { sessionId: string }) => Promise<string>;
+    };
+    const result = await mutationFn({ sessionId: 'ses_1' });
+
+    expect(result).toBe('ses_1');
+    expect(summarizeArgs).toEqual({ sessionID: 'ses_1', providerID: 'anthropic', modelID: 'claude-opus' });
+  });
+
+  test('tier 1 splits a multi-segment model id: provider is the first segment, model is the rest', async () => {
+    let summarizeArgs: unknown;
+    clientImpl = {
+      global: { config: { get: async () => ({ data: { model: 'openrouter/z-ai/glm-5.2' } }) } },
+      session: { summarize: async (args: unknown) => { summarizeArgs = args; return { data: {} }; } },
+    };
+    const { mutationFn } = useSummarizeOpenCodeSession() as unknown as {
+      mutationFn: (args: { sessionId: string }) => Promise<string>;
+    };
+    await mutationFn({ sessionId: 'ses_1' });
+    expect(summarizeArgs).toEqual({ sessionID: 'ses_1', providerID: 'openrouter', modelID: 'z-ai/glm-5.2' });
+  });
+
+  test('tier 2: falls back to the session\'s last assistant message model when config has none', async () => {
+    let summarizeArgs: unknown;
+    clientImpl = {
+      global: { config: { get: async () => ({ data: {} }) } },
+      session: {
+        messages: async () => ({
+          data: [
+            { info: { role: 'user' } },
+            { info: { role: 'assistant', providerID: 'anthropic', modelID: 'claude-sonnet' } },
+          ],
+        }),
+        summarize: async (args: unknown) => {
+          summarizeArgs = args;
+          return { data: {} };
+        },
+      },
+    };
+    const { mutationFn } = useSummarizeOpenCodeSession() as unknown as {
+      mutationFn: (args: { sessionId: string }) => Promise<string>;
+    };
+    await mutationFn({ sessionId: 'ses_1' });
+    expect(summarizeArgs).toEqual({ sessionID: 'ses_1', providerID: 'anthropic', modelID: 'claude-sonnet' });
+  });
+
+  test('tier 3: falls back to the first connected provider/model when config and history have none', async () => {
+    let summarizeArgs: unknown;
+    clientImpl = {
+      global: { config: { get: async () => ({ data: {} }) } },
+      session: {
+        messages: async () => ({ data: [] }),
+        summarize: async (args: unknown) => {
+          summarizeArgs = args;
+          return { data: {} };
+        },
+      },
+      provider: {
+        list: async () => ({
+          data: { kortix: { models: { 'claude-opus-4.8': {} } } },
+        }),
+      },
+    };
+    const { mutationFn } = useSummarizeOpenCodeSession() as unknown as {
+      mutationFn: (args: { sessionId: string }) => Promise<string>;
+    };
+    await mutationFn({ sessionId: 'ses_1' });
+    expect(summarizeArgs).toEqual({ sessionID: 'ses_1', providerID: 'kortix', modelID: 'claude-opus-4.8' });
+  });
+
+  test('an explicitly-passed providerID/modelID short-circuits every fallback tier', async () => {
+    let summarizeArgs: unknown;
+    let configFetched = false;
+    clientImpl = {
+      global: { config: { get: async () => { configFetched = true; return { data: {} }; } } },
+      session: { summarize: async (args: unknown) => { summarizeArgs = args; return { data: {} }; } },
+    };
+    const { mutationFn } = useSummarizeOpenCodeSession() as unknown as {
+      mutationFn: (args: { sessionId: string; providerID?: string; modelID?: string }) => Promise<string>;
+    };
+    await mutationFn({ sessionId: 'ses_1', providerID: 'anthropic', modelID: 'claude-haiku' });
+
+    expect(configFetched).toBe(false);
+    expect(summarizeArgs).toEqual({ sessionID: 'ses_1', providerID: 'anthropic', modelID: 'claude-haiku' });
+  });
+
+  test('throws when every tier fails to resolve a model', async () => {
+    clientImpl = {
+      global: { config: { get: async () => ({ data: {} }) } },
+      session: { messages: async () => ({ data: [] }) },
+      provider: { list: async () => ({ data: {} }) },
+    };
+    const { mutationFn } = useSummarizeOpenCodeSession() as unknown as {
+      mutationFn: (args: { sessionId: string }) => Promise<string>;
+    };
+    await expect(mutationFn({ sessionId: 'ses_1' })).rejects.toThrow(
+      'No model available for compaction. Please configure a model in settings.',
+    );
+  });
+
+  test('a thrown/rejected config.get() is swallowed — falls through to the next tier', async () => {
+    let summarizeArgs: unknown;
+    clientImpl = {
+      global: { config: { get: async () => { throw new Error('network down'); } } },
+      session: {
+        messages: async () => ({ data: [{ info: { role: 'assistant', providerID: 'anthropic', modelID: 'x' } }] }),
+        summarize: async (args: unknown) => { summarizeArgs = args; return { data: {} }; },
+      },
+    };
+    const { mutationFn } = useSummarizeOpenCodeSession() as unknown as {
+      mutationFn: (args: { sessionId: string }) => Promise<string>;
+    };
+    await mutationFn({ sessionId: 'ses_1' });
+    expect(summarizeArgs).toEqual({ sessionID: 'ses_1', providerID: 'anthropic', modelID: 'x' });
+  });
+
+  test('onMutate/onError toggle the compaction store around the send', () => {
+    clientImpl = {
+      global: { config: { get: async () => ({ data: {} }) } },
+      session: { messages: async () => ({ data: [] }) },
+      provider: { list: async () => ({ data: {} }) },
+    };
+    const hook = useSummarizeOpenCodeSession() as unknown as {
+      onMutate: (args: { sessionId: string }) => void;
+      onError: (err: unknown, args: { sessionId: string }) => void;
+    };
+    hook.onMutate({ sessionId: 'ses_compact' });
+    expect(realCompactionStore.getState().compactingBySession.ses_compact).toBe(true);
+    hook.onError(new Error('boom'), { sessionId: 'ses_compact' });
+    expect(realCompactionStore.getState().compactingBySession.ses_compact).toBeUndefined();
+  });
+});
+
+// ============================================================================
+// useForkSession — onSuccess dedups the forked session into the cached list.
+// ============================================================================
+
+describe('useForkSession', () => {
+  function forkedSession(id: string, updated: number): Session {
+    return {
+      id,
+      slug: id,
+      projectID: 'proj_1',
+      directory: '/workspace',
+      title: 'Forked',
+      version: '1.0.0',
+      time: { created: updated, updated },
+    };
+  }
+
+  test('mutationFn sends only the provided optional fields and unwraps the result', async () => {
+    let forkArgs: unknown;
+    clientImpl = {
+      session: {
+        fork: async (args: unknown) => {
+          forkArgs = args;
+          return { data: forkedSession('ses_fork', 5) };
+        },
+      },
+    };
+    const { mutationFn } = useForkSession() as unknown as {
+      mutationFn: (args: { sessionId: string; messageId?: string }) => Promise<Session>;
+    };
+    const result = await mutationFn({ sessionId: 'ses_1', messageId: 'msg_5' });
+
+    expect(forkArgs).toEqual({ sessionID: 'ses_1', messageID: 'msg_5' });
+    expect(result.id).toBe('ses_fork');
+  });
+
+  test('onSuccess inserts a brand-new forked session at the front, newest first', () => {
+    const { onSuccess } = useForkSession() as unknown as { onSuccess: (s: Session) => void };
+    fakeQueryClient.setQueryData(opencodeKeys.sessions(), [forkedSession('ses_old', 1)]);
+
+    onSuccess(forkedSession('ses_new', 10));
+
+    const list = fakeQueryClient.getQueryData(opencodeKeys.sessions()) as Session[];
+    expect(list.map((s) => s.id)).toEqual(['ses_new', 'ses_old']);
+    expect(fakeQueryClient.getQueryData(opencodeKeys.session('ses_new'))).toMatchObject({ id: 'ses_new' });
+  });
+
+  test('onSuccess replaces (dedups) an existing entry instead of duplicating it', () => {
+    const { onSuccess } = useForkSession() as unknown as { onSuccess: (s: Session) => void };
+    fakeQueryClient.setQueryData(opencodeKeys.sessions(), [
+      forkedSession('ses_a', 1),
+      forkedSession('ses_fork', 2),
+    ]);
+
+    onSuccess(forkedSession('ses_fork', 20));
+
+    const list = fakeQueryClient.getQueryData(opencodeKeys.sessions()) as Session[];
+    expect(list).toHaveLength(2);
+    expect(list.find((s) => s.id === 'ses_fork')?.time.updated).toBe(20);
+  });
+});
+
+// ============================================================================
+// useInitSession — /init command error duck-typing + refetch-on-success.
+// ============================================================================
+
+describe('useInitSession', () => {
+  test('resolves with the sessionId on success and refetches its messages', async () => {
+    clientImpl = { session: { command: async () => ({}) } };
+    const hook = useInitSession() as unknown as {
+      mutationFn: (args: { sessionId: string }) => Promise<string>;
+      onSuccess: (sessionId: string) => void;
+    };
+    const result = await hook.mutationFn({ sessionId: 'ses_1' });
+    expect(result).toBe('ses_1');
+
+    hook.onSuccess('ses_1');
+    expect(fakeQueryClient.refetchCalls).toEqual([{ queryKey: opencodeKeys.messages('ses_1') }]);
+  });
+
+  test('extracts a NotFoundError-shaped error message (`.data.message`)', async () => {
+    clientImpl = {
+      session: { command: async () => ({ error: { name: 'NotFoundError', data: { message: 'no such session' } } }) },
+    };
+    const { mutationFn } = useInitSession() as unknown as {
+      mutationFn: (args: { sessionId: string }) => Promise<string>;
+    };
+    await expect(mutationFn({ sessionId: 'ses_1' })).rejects.toThrow('no such session');
+  });
+
+  test('falls back to a default message for a BadRequest-shaped error (no message field)', async () => {
+    clientImpl = {
+      session: { command: async () => ({ error: { _tag: 'BadRequest' } }) },
+    };
+    const { mutationFn } = useInitSession() as unknown as {
+      mutationFn: (args: { sessionId: string }) => Promise<string>;
+    };
+    await expect(mutationFn({ sessionId: 'ses_1' })).rejects.toThrow('Failed to initialize project');
+  });
+});

--- a/packages/sdk/src/react/use-opencode-sessions/sessions.ts
+++ b/packages/sdk/src/react/use-opencode-sessions/sessions.ts
@@ -235,9 +235,9 @@ export function useSummarizeOpenCodeSession() {
       if (!providerID || !modelID) {
         try {
           const configResult = await client.global.config.get();
-          const config = configResult.data as any;
+          const config = configResult.data;
           if (config?.model) {
-            const parts = (config.model as string).split('/');
+            const parts = config.model.split('/');
             if (parts.length >= 2) {
               providerID = providerID || parts[0];
               modelID = modelID || parts.slice(1).join('/');
@@ -269,11 +269,19 @@ export function useSummarizeOpenCodeSession() {
       // 3. Try first available provider/model from provider list
       if (!providerID || !modelID) {
         try {
+          // The provider list's typed shape is `{ all, default, connected }`,
+          // but this fallback has historically walked it as a plain
+          // `{ [providerID]: { models } }` map — keep that exact (best-effort,
+          // try/catch-guarded) duck-typed read via `unknown` rather than
+          // assert a shape that may not match what's actually on the wire.
           const providerResult = await client.provider.list();
-          const providers = providerResult.data as any;
+          const providers: unknown = providerResult.data;
           if (providers && typeof providers === 'object') {
-            for (const [pid, providerInfo] of Object.entries(providers)) {
-              const models = (providerInfo as any)?.models;
+            for (const [pid, providerInfo] of Object.entries(providers as Record<string, unknown>)) {
+              const models =
+                providerInfo && typeof providerInfo === 'object'
+                  ? (providerInfo as Record<string, unknown>).models
+                  : undefined;
               if (models && typeof models === 'object') {
                 const firstModelId = Object.keys(models)[0];
                 if (firstModelId) {
@@ -384,8 +392,17 @@ export function useInitSession() {
         arguments: '',
       });
       if (result.error) {
-        const err = result.error as any;
-        throw new Error(err?.data?.message || err?.message || 'Failed to initialize project');
+        // The error union here (`BadRequest | InvalidRequestError |
+        // NotFoundError`) doesn't share a `.message`/`.data.message` shape
+        // across all members — duck-type defensively rather than assume one.
+        const err = result.error;
+        const errRec = err && typeof err === 'object' ? (err as Record<string, unknown>) : undefined;
+        const dataRec =
+          errRec?.data && typeof errRec.data === 'object'
+            ? (errRec.data as Record<string, unknown>)
+            : undefined;
+        const message = dataRec?.message ?? errRec?.message;
+        throw new Error(typeof message === 'string' ? message : 'Failed to initialize project');
       }
       return sessionId;
     },

--- a/packages/sdk/src/react/use-opencode-sessions/shared.test.ts
+++ b/packages/sdk/src/react/use-opencode-sessions/shared.test.ts
@@ -1,0 +1,179 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import {
+  activeServerKey,
+  canQueryOpenCodeSession,
+  CACHE_SCOPE_GLOBAL,
+  clearProjectProviderCache,
+  getLSCache,
+  LS_AGENTS,
+  LS_PROVIDERS,
+  LS_SESSIONS,
+  setLSCache,
+  unwrap,
+} from './shared';
+import { setCurrentRuntime } from '../../state/current-runtime';
+
+// ============================================================================
+// unwrap — the SDK-response { data, error } → value-or-throw helper shared by
+// every hook in this directory.
+// ============================================================================
+
+describe('unwrap', () => {
+  test('returns data when there is no error', () => {
+    expect(unwrap({ data: { hello: 'world' } })).toEqual({ hello: 'world' });
+  });
+
+  test('prefers error.data.message', () => {
+    expect(() => unwrap({ error: { data: { message: 'nested message' }, message: 'top message' } })).toThrow(
+      'nested message',
+    );
+  });
+
+  test('falls back to error.message when there is no error.data.message', () => {
+    expect(() => unwrap({ error: { message: 'top message' } })).toThrow('top message');
+  });
+
+  test('falls back to error.error when there is no .message anywhere', () => {
+    expect(() => unwrap({ error: { error: 'legacy error field' } })).toThrow('legacy error field');
+  });
+
+  test('a string error is used verbatim', () => {
+    expect(() => unwrap({ error: 'plain string error' })).toThrow('plain string error');
+  });
+
+  test('an unrecognized object error falls back to a stringified JSON blob', () => {
+    expect(() => unwrap({ error: { weird: 'shape' } })).toThrow('{"weird":"shape"}');
+  });
+
+  test('a falsy error (e.g. explicit null) takes the success/data path, not the throw path', () => {
+    expect(unwrap({ data: 'ok', error: null as unknown as undefined })).toBe('ok');
+  });
+
+  test('uses the response status when the error is truthy but not an object/string', () => {
+    // A truthy, non-object, non-string `error` (e.g. a bare number) skips the
+    // message/data/JSON.stringify fallbacks entirely and hits the status tail.
+    expect(() => unwrap({ error: 42, response: new Response(null, { status: 503 }) })).toThrow(
+      'Server returned 503',
+    );
+  });
+});
+
+// ============================================================================
+// canQueryOpenCodeSession — rejects Kortix's own project-session UUIDs (which
+// aren't real opencode session ids and would 404 the opencode API).
+// ============================================================================
+
+describe('canQueryOpenCodeSession', () => {
+  test('rejects null/undefined/empty', () => {
+    expect(canQueryOpenCodeSession(null)).toBe(false);
+    expect(canQueryOpenCodeSession(undefined)).toBe(false);
+    expect(canQueryOpenCodeSession('')).toBe(false);
+  });
+
+  test('rejects a v4 UUID (the Kortix project-session id shape)', () => {
+    expect(canQueryOpenCodeSession('550e8400-e29b-41d4-a716-446655440000')).toBe(false);
+  });
+
+  test('accepts a real opencode session id (ses_<...> shape)', () => {
+    expect(canQueryOpenCodeSession('ses_01hzxk3n8g8g8g8g8g8g8g8g')).toBe(true);
+  });
+
+  test('accepts an arbitrary non-UUID string', () => {
+    expect(canQueryOpenCodeSession('not-a-uuid-at-all')).toBe(true);
+  });
+});
+
+// ============================================================================
+// getLSCache / setLSCache / clearProjectProviderCache — the localStorage-backed
+// per-family caches, scoped by the active sandbox id (or an explicit scope).
+// `window`/`localStorage` don't exist in bun's default test environment, so
+// both are stubbed with a minimal in-memory `Storage` implementation.
+// ============================================================================
+
+class MemoryStorage implements Storage {
+  private map = new Map<string, string>();
+  get length(): number {
+    return this.map.size;
+  }
+  clear(): void {
+    this.map.clear();
+  }
+  getItem(key: string): string | null {
+    return this.map.has(key) ? (this.map.get(key) ?? null) : null;
+  }
+  key(index: number): string | null {
+    return Array.from(this.map.keys())[index] ?? null;
+  }
+  removeItem(key: string): void {
+    this.map.delete(key);
+  }
+  setItem(key: string, value: string): void {
+    this.map.set(key, value);
+  }
+}
+
+interface GlobalWithDom {
+  window?: unknown;
+  localStorage?: Storage;
+}
+
+describe('getLSCache / setLSCache (localStorage stubbed)', () => {
+  beforeEach(() => {
+    (globalThis as GlobalWithDom).window = {};
+    (globalThis as GlobalWithDom).localStorage = new MemoryStorage();
+    setCurrentRuntime(null);
+  });
+
+  afterEach(() => {
+    delete (globalThis as GlobalWithDom).window;
+    delete (globalThis as GlobalWithDom).localStorage;
+    setCurrentRuntime(null);
+  });
+
+  test('round-trips a value under the active-sandbox scope by default', () => {
+    setCurrentRuntime('https://sbx.test', 'sandbox-1');
+    setLSCache(LS_SESSIONS, [{ id: 'ses_1' }]);
+    expect(getLSCache<Array<{ id: string }>>(LS_SESSIONS)).toEqual([{ id: 'ses_1' }]);
+  });
+
+  test('falls back to the "none" scope when there is no active sandbox', () => {
+    expect(activeServerKey()).toBe('none');
+    setLSCache(LS_SESSIONS, [{ id: 'ses_none' }]);
+    expect(getLSCache<Array<{ id: string }>>(LS_SESSIONS)).toEqual([{ id: 'ses_none' }]);
+  });
+
+  test('an explicit scope overrides the active-sandbox default', () => {
+    setCurrentRuntime('https://sbx.test', 'sandbox-1');
+    setLSCache(LS_PROVIDERS, { all: [] }, CACHE_SCOPE_GLOBAL);
+    // Not visible under the (different) active-sandbox scope...
+    expect(getLSCache(LS_PROVIDERS)).toBeUndefined();
+    // ...but is visible when read back with the same explicit scope.
+    expect(getLSCache<{ all: unknown[] }>(LS_PROVIDERS, CACHE_SCOPE_GLOBAL)).toEqual({ all: [] });
+  });
+
+  test('different families never collide even under the same scope', () => {
+    setLSCache(LS_SESSIONS, ['sessions-value']);
+    setLSCache(LS_AGENTS, ['agents-value']);
+    expect(getLSCache<string[]>(LS_SESSIONS)).toEqual(['sessions-value']);
+    expect(getLSCache<string[]>(LS_AGENTS)).toEqual(['agents-value']);
+  });
+
+  test('an unknown family is a safe no-op miss', () => {
+    expect(getLSCache('kortix_cache_unknown_family')).toBeUndefined();
+  });
+
+  test('clearProjectProviderCache removes both the native and gateway scoped entries', () => {
+    setLSCache(LS_PROVIDERS, { all: ['native'] }, 'proj:p1:native');
+    setLSCache(LS_PROVIDERS, { all: ['gateway'] }, 'proj:p1:gateway');
+    clearProjectProviderCache('p1');
+    expect(getLSCache(LS_PROVIDERS, 'proj:p1:native')).toBeUndefined();
+    expect(getLSCache(LS_PROVIDERS, 'proj:p1:gateway')).toBeUndefined();
+  });
+
+  test('without window/localStorage stubbed, get/set are safe no-ops', () => {
+    delete (globalThis as GlobalWithDom).window;
+    delete (globalThis as GlobalWithDom).localStorage;
+    expect(() => setLSCache(LS_SESSIONS, ['x'])).not.toThrow();
+    expect(getLSCache(LS_SESSIONS)).toBeUndefined();
+  });
+});

--- a/packages/sdk/src/react/use-opencode-sessions/shared.ts
+++ b/packages/sdk/src/react/use-opencode-sessions/shared.ts
@@ -42,17 +42,23 @@ export function activeServerKey(): string {
 
 export function unwrap<T>(result: { data?: T; error?: unknown; response?: Response }): T {
   if (result.error) {
-    const err = result.error as any;
+    const err = result.error;
     const status = (result.response as Response | undefined)?.status;
-    // Try to extract the most specific error message from the SDK response
+    // Try to extract the most specific error message from the SDK response.
+    // `error` is genuinely `unknown` here — its shape varies by which SDK
+    // call produced it (typed error unions differ per endpoint) — so this
+    // duck-types defensively instead of assuming a shape.
+    const errRec = err && typeof err === 'object' ? (err as Record<string, unknown>) : undefined;
+    const dataRec =
+      errRec?.data && typeof errRec.data === 'object' ? (errRec.data as Record<string, unknown>) : undefined;
     const msg =
-      err?.data?.message ||
-      err?.message ||
-      err?.error ||
+      dataRec?.message ||
+      errRec?.message ||
+      errRec?.error ||
       (typeof err === 'string' ? err : null) ||
       (typeof err === 'object' ? JSON.stringify(err) : null) ||
       (status ? `Server returned ${status}` : 'SDK request failed');
-    throw new Error(msg);
+    throw new Error(String(msg));
   }
   return result.data as T;
 }
@@ -84,7 +90,7 @@ const agentsCache = new ScopedCache<Agent[]>(LS_AGENTS, 8);
 const commandsCache = new ScopedCache<Command[]>(LS_COMMANDS, 4);
 const providersCache = new ScopedCache<SdkProviderListResponse>(LS_PROVIDERS, 2);
 
-const cacheByFamily: Record<string, ScopedCache<any>> = {
+const cacheByFamily: Record<string, ScopedCache<unknown>> = {
   [LS_SESSIONS]: sessionsCache,
   [LS_AGENTS]: agentsCache,
   [LS_COMMANDS]: commandsCache,

--- a/packages/sdk/src/react/use-project-secrets.test.ts
+++ b/packages/sdk/src/react/use-project-secrets.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test, beforeEach, mock } from 'bun:test';
+
+// react-query's `useQuery`/`useMutation` are mocked down to identity functions
+// (return the config object passed in) so the hook under test can be called
+// as a plain function — no React render tree needed — while still exercising
+// the exact `queryKey`/`enabled`/`onSuccess` values the real hook builds.
+// Same harness as `./use-kortix-master.test.ts`. This intentionally never
+// calls `queryFn`/`mutationFn` — those go through `backendApi`, which needs a
+// configured platform seam; this test only asserts the queryKey/invalidation
+// WIRING, not the network calls (covered at the facade level in
+// `../kortix.test.ts`).
+
+let invalidated: unknown[][] = [];
+mock.module('@tanstack/react-query', () => ({
+  useQuery: (config: Record<string, unknown>) => config,
+  useMutation: (config: Record<string, unknown>) => config,
+  useQueryClient: () => ({
+    invalidateQueries: (opts: { queryKey: unknown[] }) => {
+      invalidated.push(opts.queryKey);
+    },
+  }),
+}));
+
+const { useProjectSecrets, projectSecretsKey } = await import('./use-project-secrets');
+
+beforeEach(() => {
+  invalidated = [];
+});
+
+describe('useProjectSecrets (query-key stability + invalidation wiring)', () => {
+  test('builds the query key from projectSecretsKey', () => {
+    const result = useProjectSecrets('proj-1') as any;
+    expect(result.queryKey).toEqual(projectSecretsKey('proj-1'));
+    expect(result.queryKey).toEqual(['project-secrets', 'proj-1']);
+  });
+
+  test('is disabled without a projectId, enabled once one is supplied', () => {
+    expect((useProjectSecrets(undefined) as any).enabled).toBe(false);
+    expect((useProjectSecrets(null) as any).enabled).toBe(false);
+    expect((useProjectSecrets('proj-1') as any).enabled).toBe(true);
+  });
+
+  test('upsert/remove/setPersonal/removePersonal all invalidate the same list key on success', () => {
+    const result = useProjectSecrets('proj-1') as any;
+    const expectedKey = [...projectSecretsKey('proj-1')];
+
+    result.upsert.onSuccess();
+    result.remove.onSuccess();
+    result.setPersonal.onSuccess();
+    result.removePersonal.onSuccess();
+
+    expect(invalidated).toEqual([expectedKey, expectedKey, expectedKey, expectedKey]);
+  });
+
+  test('a different projectId gets its own (non-colliding) query key', () => {
+    const a = useProjectSecrets('proj-a') as any;
+    const b = useProjectSecrets('proj-b') as any;
+    expect(a.queryKey).not.toEqual(b.queryKey);
+  });
+});

--- a/packages/sdk/src/react/use-project-secrets.ts
+++ b/packages/sdk/src/react/use-project-secrets.ts
@@ -1,0 +1,60 @@
+'use client';
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  deletePersonalProjectSecret,
+  deleteProjectSecret,
+  listProjectSecrets,
+  setPersonalProjectSecret,
+  upsertProjectSecret,
+  type ProjectSecretsResponse,
+} from '../platform/projects-client';
+
+/** Stable query-key factory — reuse this to read/invalidate the same cache
+ *  entry `useProjectSecrets` populates (e.g. from a settings page shell that
+ *  doesn't itself call the hook). */
+export const projectSecretsKey = (projectId: string | null | undefined) =>
+  ['project-secrets', projectId] as const;
+
+/**
+ * Project secrets — list + the mutations a settings screen needs (shared
+ * upsert/remove, personal-override set/remove). Thin React Query binding
+ * over `projects-client/secrets.ts`; every mutation invalidates the list so
+ * the UI reflects the write without a manual refetch.
+ */
+export function useProjectSecrets(projectId: string | null | undefined) {
+  const queryClient = useQueryClient();
+  const queryKey = projectSecretsKey(projectId);
+
+  const query = useQuery<ProjectSecretsResponse>({
+    queryKey,
+    queryFn: () => listProjectSecrets(projectId as string),
+    enabled: !!projectId,
+  });
+
+  const invalidate = () => queryClient.invalidateQueries({ queryKey });
+
+  const upsert = useMutation({
+    mutationFn: (input: Parameters<typeof upsertProjectSecret>[1]) =>
+      upsertProjectSecret(projectId as string, input),
+    onSuccess: invalidate,
+  });
+
+  const remove = useMutation({
+    mutationFn: (name: string) => deleteProjectSecret(projectId as string, name),
+    onSuccess: invalidate,
+  });
+
+  const setPersonal = useMutation({
+    mutationFn: (args: { name: string; input: Parameters<typeof setPersonalProjectSecret>[2] }) =>
+      setPersonalProjectSecret(projectId as string, args.name, args.input),
+    onSuccess: invalidate,
+  });
+
+  const removePersonal = useMutation({
+    mutationFn: (name: string) => deletePersonalProjectSecret(projectId as string, name),
+    onSuccess: invalidate,
+  });
+
+  return { ...query, upsert, remove, setPersonal, removePersonal };
+}

--- a/packages/sdk/src/react/use-project-triggers.ts
+++ b/packages/sdk/src/react/use-project-triggers.ts
@@ -1,0 +1,61 @@
+'use client';
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  createProjectTrigger,
+  deleteProjectTrigger,
+  fireProjectTrigger,
+  listProjectTriggers,
+  updateProjectTrigger,
+  type ProjectTriggerListing,
+} from '../platform/projects-client';
+
+/** Stable query-key factory — reuse to read/invalidate the same cache entry
+ *  `useProjectTriggers` populates. */
+export const projectTriggersKey = (projectId: string | null | undefined) =>
+  ['project-triggers', projectId] as const;
+
+/**
+ * Project triggers (cron/webhook, file-defined in the repo manifest) — list +
+ * create/update/remove/fire. Thin React Query binding over
+ * `projects-client/triggers.ts`; every mutation invalidates the listing so a
+ * newly created/edited/fired trigger shows up without a manual refetch.
+ */
+export function useProjectTriggers(projectId: string | null | undefined) {
+  const queryClient = useQueryClient();
+  const queryKey = projectTriggersKey(projectId);
+
+  const query = useQuery<ProjectTriggerListing>({
+    queryKey,
+    queryFn: () => listProjectTriggers(projectId as string),
+    enabled: !!projectId,
+  });
+
+  const invalidate = () => queryClient.invalidateQueries({ queryKey });
+
+  const create = useMutation({
+    mutationFn: (input: Parameters<typeof createProjectTrigger>[1]) =>
+      createProjectTrigger(projectId as string, input),
+    onSuccess: invalidate,
+  });
+
+  const update = useMutation({
+    mutationFn: (args: { slug: string; input: Parameters<typeof updateProjectTrigger>[2] }) =>
+      updateProjectTrigger(projectId as string, args.slug, args.input),
+    onSuccess: invalidate,
+  });
+
+  const remove = useMutation({
+    mutationFn: (slug: string) => deleteProjectTrigger(projectId as string, slug),
+    onSuccess: invalidate,
+  });
+
+  // Firing doesn't change the listing itself (no invalidate) — it starts a
+  // session and returns its id; `last_fired_at` isn't reflected until the
+  // next natural list refetch.
+  const fire = useMutation({
+    mutationFn: (slug: string) => fireProjectTrigger(projectId as string, slug),
+  });
+
+  return { ...query, create, update, remove, fire };
+}

--- a/packages/sdk/src/react/use-session-prefetch.ts
+++ b/packages/sdk/src/react/use-session-prefetch.ts
@@ -50,7 +50,7 @@ export async function prefetchSession(sessionId: string): Promise<void> {
     // Fetch fresh data from server in background
     try {
       const res = await getClient().session.messages({ sessionID: sessionId });
-      const data = (res.data ?? []) as any[];
+      const data = res.data ?? [];
       if (data.length > 0) {
         useSyncStore.getState().hydrate(sessionId, data);
         const parts = useSyncStore.getState().parts;

--- a/packages/sdk/src/react/use-session-send.ts
+++ b/packages/sdk/src/react/use-session-send.ts
@@ -34,9 +34,11 @@
  *    pure functions directly instead, as apps/web's `session-chat.tsx` does.
  */
 
+import type { Message, Part } from '@opencode-ai/sdk/v2/client';
 import { useCallback, useState } from 'react';
 import { getClient } from '../opencode/client';
 import { ascendingId, useSyncStore } from '../state/sync-store';
+import type { MessageError } from '../state/sync-store/types';
 import { classifySendError, type KortixSendError } from './use-session';
 import {
   promptOpenCodeMessage,
@@ -63,24 +65,27 @@ export function beginOptimisticSend(
   text: string,
   partIds?: string[],
 ): void {
-  const parts = text.trim()
+  const parts: Part[] = text.trim()
     ? [
         {
           id: partIds?.[0] ?? ascendingId('prt'),
           sessionID: sessionId,
           messageID: messageId,
-          type: 'text',
+          type: 'text' as const,
           text,
         },
       ]
     : [];
+  // Minimal optimistic stub — omits `agent`/`model` (required on the real
+  // `UserMessage`) since the server fills those in; same stub-message
+  // convention used by the sync store's own SSE handlers.
   const info = {
     id: messageId,
     sessionID: sessionId,
     role: 'user',
     time: { created: Date.now() },
-  };
-  useSyncStore.getState().optimisticAdd(sessionId, info as any, parts as any);
+  } as Message;
+  useSyncStore.getState().optimisticAdd(sessionId, info, parts);
   useSyncStore.getState().setStatus(sessionId, { type: 'busy' });
 }
 
@@ -107,6 +112,12 @@ export interface OpenCodeMessagesClient {
     messages: (args: { sessionID: string }) => Promise<{ data?: unknown }>;
   };
 }
+
+/** Shape `useSyncStore.getState().hydrate()` actually needs. `data` on
+ *  `OpenCodeMessagesClient['session']['messages']` is deliberately `unknown`
+ *  (hosts inject their own stub client in tests) — narrow at the one real
+ *  call site below instead of widening that public interface. */
+type HydrateInput = Array<{ info: Message; parts: Part[] }>;
 
 export interface SendRecoveryOptions {
   /** Resolve the client used to rehydrate messages on failure. Defaults to
@@ -159,7 +170,7 @@ export function recoverFromSendFailure(
         // the server hasn't persisted yet, that wipes the user's typed text
         // and leaves an empty bubble. Keeping the optimistic message means
         // the user always still sees what they sent.
-        useSyncStore.getState().hydrate(sessionId, res.data as any);
+        useSyncStore.getState().hydrate(sessionId, res.data as HydrateInput);
       } else {
         // No server data — just remove the optimistic message.
         useSyncStore.getState().optimisticRemove(sessionId, messageId);
@@ -234,11 +245,22 @@ export function applyOptimisticAbort(sessionId: string): void {
   const msgs = store.messages[sessionId];
   if (!msgs) return;
   for (let i = msgs.length - 1; i >= 0; i--) {
-    if (msgs[i].role === 'assistant' && !(msgs[i] as any).error) {
-      store.upsertMessage(sessionId, {
-        ...msgs[i],
-        error: { name: 'AbortError', data: { message: 'The operation was aborted.' } },
-      } as any);
+    const msg = msgs[i];
+    if (msg.role === 'assistant' && !msg.error) {
+      // Typed as the wider `MessageError` (not just the literal shape below)
+      // so the assertion further down overlaps with `AssistantMessage.error`'s
+      // real union — see `MessageError` in the sync store.
+      const error: MessageError = {
+        name: 'AbortError',
+        data: { message: 'The operation was aborted.' },
+      };
+      // `error`'s shape (`SyntheticAbortError`) isn't part of the SDK's
+      // `AssistantMessage.error` union — see `MessageError` in the sync
+      // store. TS flags the direct assertion as an insufficient-overlap
+      // mistake because it narrows the literal's `error` field back down to
+      // `SyntheticAbortError`; route through `unknown` as TS itself suggests.
+      const patched = { ...msg, error } as unknown as Message;
+      store.upsertMessage(sessionId, patched);
       break;
     }
   }

--- a/packages/sdk/src/react/use-session-sync.ts
+++ b/packages/sdk/src/react/use-session-sync.ts
@@ -149,7 +149,7 @@ export function useSessionSync(sessionId: string) {
 					if (!current || current.length === 0) {
 						useSyncStore.getState().hydrate(
 							sessionId,
-							cached.messages.map((info: any) => ({
+							cached.messages.map((info: Message) => ({
 								info,
 								parts: cached.parts[info.id] ?? [],
 							})),
@@ -195,7 +195,7 @@ export function useSessionSync(sessionId: string) {
 					const res = await getClient().session.messages({
 					sessionID: sessionId,
 				});
-				const data = (res.data ?? []) as any[];
+				const data = res.data ?? [];
 
 				if (data.length === 0) {
 					const freshState = useSyncStore.getState();
@@ -212,7 +212,7 @@ export function useSessionSync(sessionId: string) {
 				}
 
 				if (res.data) {
-					useSyncStore.getState().hydrate(sessionId, res.data as any);
+					useSyncStore.getState().hydrate(sessionId, res.data);
 					// Persist to IDB for next cold load
 					const state = useSyncStore.getState();
 					const msgs = state.messages[sessionId] ?? [];
@@ -351,13 +351,13 @@ export function useSessionSync(sessionId: string) {
 							getClient().session.status().catch(() => null),
 						]);
 						if (msgRes.data) {
-							useSyncStore.getState().hydrate(sessionId, msgRes.data as any);
+							useSyncStore.getState().hydrate(sessionId, msgRes.data);
 						}
 						// Update session status from server — without this,
 						// a dead SSE means session.idle never arrives and the
 						// UI stays stuck on "busy" forever.
 						if (statusRes?.data) {
-							const statuses = statusRes.data as Record<string, any>;
+							const statuses = statusRes.data;
 							const serverStatus = statuses[sessionId];
 							if (serverStatus) {
 								useSyncStore.getState().setStatus(sessionId, serverStatus);

--- a/packages/sdk/src/server.test.ts
+++ b/packages/sdk/src/server.test.ts
@@ -1,0 +1,119 @@
+import { test, expect, beforeEach } from 'bun:test';
+import { runWithKortix, createScopedKortix } from './server';
+import { backendApi } from './platform/api-client';
+
+// Importing `./server` pulls in `./platform/config-node`, which registers the
+// AsyncLocalStorage resolver as an import-time side effect — this file is
+// where that Node-only layer is actually exercised end-to-end (concurrent
+// requests, different tokens, real interleaving via a deferred fetch).
+
+let requests: { url: string; auth: string | null }[] = [];
+
+beforeEach(() => {
+  requests = [];
+});
+
+/** A `fetch` that resolves out of arrival order, so two "requests" genuinely
+ *  interleave instead of trivially completing back-to-back. Each call blocks
+ *  until `release()` is invoked for its index. */
+function deferredFetch() {
+  const resolvers: Array<(v: Response) => void> = [];
+  const impl = async (input: unknown, init?: RequestInit) => {
+    const req = input as Request;
+    const auth = init?.headers
+      ? new Headers(init.headers).get('Authorization')
+      : req.headers?.get?.('Authorization') ?? null;
+    const url = req.url ?? String(input);
+    requests.push({ url, auth });
+    const idx = requests.length - 1;
+    return new Promise<Response>((resolve) => {
+      resolvers[idx] = resolve;
+    });
+  };
+  return {
+    fetch: impl as unknown as typeof fetch,
+    release: (idx: number) =>
+      resolvers[idx](
+        new Response(JSON.stringify({ ok: true, projects: [] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      ),
+  };
+}
+
+test('runWithKortix isolates two concurrent, interleaved requests with different tokens', async () => {
+  const { fetch: fetchImpl, release } = deferredFetch();
+  globalThis.fetch = fetchImpl;
+
+  const results: string[] = [];
+
+  const p1 = runWithKortix(
+    { backendUrl: 'http://backend.local/v1', getToken: async () => 'token-ONE' },
+    async () => {
+      const res = await backendApi.get('/projects');
+      results.push(`one:${res.success}`);
+    },
+  );
+
+  const p2 = runWithKortix(
+    { backendUrl: 'http://backend.local/v1', getToken: async () => 'token-TWO' },
+    async () => {
+      const res = await backendApi.get('/projects');
+      results.push(`two:${res.success}`);
+    },
+  );
+
+  // Let both requests reach the (deferred) fetch call before releasing either
+  // — this is the actual concurrency assertion: both contexts are "in flight"
+  // on the shared config seam at the same time.
+  await new Promise((r) => setTimeout(r, 0));
+  expect(requests.length).toBe(2);
+
+  // Release out of arrival order (2 before 1) to prove isolation doesn't
+  // depend on completion order either.
+  release(1);
+  release(0);
+  await Promise.all([p1, p2]);
+
+  expect(requests[0].auth).toBe('Bearer token-ONE');
+  expect(requests[1].auth).toBe('Bearer token-TWO');
+});
+
+test('createScopedKortix never writes to the process-global config — two scoped clients stay isolated', async () => {
+  globalThis.fetch = (async (input: unknown, init?: RequestInit) => {
+    const req = input as Request;
+    const auth = init?.headers ? new Headers(init.headers).get('Authorization') : req.headers?.get?.('Authorization') ?? null;
+    requests.push({ url: req.url ?? String(input), auth });
+    return new Response(JSON.stringify({ ok: true, projects: [] }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  }) as unknown as typeof fetch;
+
+  const kortixA = createScopedKortix({ backendUrl: 'http://backend.local/v1', getToken: async () => 'tok-A' });
+  const kortixB = createScopedKortix({ backendUrl: 'http://backend.local/v1', getToken: async () => 'tok-B' });
+
+  await Promise.all([kortixA.projects.list(), kortixB.projects.list()]);
+
+  expect(requests.some((r) => r.auth === 'Bearer tok-A')).toBe(true);
+  expect(requests.some((r) => r.auth === 'Bearer tok-B')).toBe(true);
+});
+
+test('createScopedKortix scopes calls reached through id-bound handles minted at call time (project(id), session(pid, sid))', async () => {
+  globalThis.fetch = (async (input: unknown, init?: RequestInit) => {
+    const req = input as Request;
+    const auth = init?.headers ? new Headers(init.headers).get('Authorization') : req.headers?.get?.('Authorization') ?? null;
+    requests.push({ url: req.url ?? String(input), auth });
+    return new Response(JSON.stringify({ ok: true, secrets: [] }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  }) as unknown as typeof fetch;
+
+  const kortix = createScopedKortix({ backendUrl: 'http://backend.local/v1', getToken: async () => 'scoped-tok' });
+  await kortix.project('PID1').secrets.list();
+
+  expect(requests[0].url).toContain('/projects/PID1/secrets');
+  expect(requests[0].auth).toBe('Bearer scoped-tok');
+});

--- a/packages/sdk/src/server.ts
+++ b/packages/sdk/src/server.ts
@@ -1,0 +1,126 @@
+/**
+ * `@kortix/sdk/server` — Node/Bun-only request-scoped config isolation for
+ * "Kortix as a Backend": a third-party server process that wraps Kortix on
+ * behalf of multiple end users/tenants concurrently.
+ *
+ * NEVER import this subpath from a browser bundle. It statically imports
+ * `config-node.ts`, which statically imports `node:async_hooks` — most
+ * browser bundlers choke if that appears anywhere in their graph. The root
+ * `@kortix/sdk` entry point and `@kortix/sdk/react` never import this file,
+ * so a web host's bundle is unaffected either way; this subpath exists
+ * specifically for the non-browser "backend" case.
+ *
+ * Why this exists: `configureKortix()`/`createKortix()` (the root `@kortix/sdk`
+ * seam) store the platform config — crucially, the bearer token getter — in a
+ * single process-wide module-global (see `platform/config.ts`). That's fine
+ * for a host with exactly one config for its whole lifetime (a browser tab, a
+ * CLI, a single-tenant server). It is UNSAFE for a server process handling
+ * concurrent requests on behalf of different users: two in-flight requests
+ * racing through `configureKortix()` with different tokens clobber each
+ * other — whichever call landed last wins for every other in-flight request
+ * (see the warning on `ServerTokenOptions` in
+ * `platform/projects-client/shared.ts`).
+ *
+ * `runWithKortix`/`createScopedKortix` fix that using Node's
+ * `AsyncLocalStorage`: the config passed to one call is visible ONLY inside
+ * that call's async continuation (every `await` inside it), correctly
+ * isolated from any other concurrent call in the same process.
+ */
+import { createKortix, type Kortix } from './kortix';
+import { runScoped, runWithKortix, getScopedConfig } from './platform/config-node';
+import type { KortixPlatformConfig } from './platform/config';
+
+export { runWithKortix, getScopedConfig };
+
+const MAX_WRAP_DEPTH = 12;
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== 'object') return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+/**
+ * Recursively wrap every function (including function-valued getters)
+ * reachable from `value` so calling it runs inside `runScoped(config, ...)`.
+ * Also wraps a wrapped function's OWN return value (sync, or the resolved
+ * value of a returned Promise) — this is what makes id-bound handles minted
+ * AT CALL TIME (`kortix.project(id)`, `kortix.session(pid, sid)`) come back
+ * fully scoped too, not just the static shape of `createKortix()`'s top-level
+ * return.
+ *
+ * Recurses into plain objects/arrays only — class instances and built-ins
+ * (`Error`/`Date`/`Map`/`Set`/`Blob`/`Response`/async iterables/…) pass
+ * through untouched, so this never mis-clones a vendor object whose
+ * correctness depends on its prototype/internal slots (e.g. the escape-hatch
+ * `OpencodeClient` from `.runtime`, or a `Response`/Blob returned by a file
+ * read). A depth cap + a per-branch `WeakSet` guards against accidental
+ * cycles or pathologically deep payloads.
+ */
+function wrapScoped<T>(value: T, config: KortixPlatformConfig, seen: WeakSet<object>, depth = 0): T {
+  if (depth > MAX_WRAP_DEPTH) return value;
+
+  if (typeof value === 'function') {
+    const fn = value as (...args: unknown[]) => unknown;
+    const wrapped = (...args: unknown[]): unknown => {
+      const result = runScoped(config, () => fn(...args));
+      if (result instanceof Promise) {
+        return result.then((resolved) => wrapScoped(resolved, config, new WeakSet(), 0));
+      }
+      return wrapScoped(result, config, new WeakSet(), 0);
+    };
+    return wrapped as unknown as T;
+  }
+
+  if (Array.isArray(value)) {
+    if (seen.has(value)) return value;
+    seen.add(value);
+    return value.map((item) => wrapScoped(item, config, seen, depth + 1)) as unknown as T;
+  }
+
+  if (isPlainObject(value)) {
+    if (seen.has(value)) return value;
+    seen.add(value);
+    const out: Record<string, unknown> = {};
+    for (const key of Object.keys(value)) {
+      const desc = Object.getOwnPropertyDescriptor(value, key)!;
+      if (desc.get) {
+        Object.defineProperty(out, key, {
+          enumerable: true,
+          get: () => wrapScoped(desc.get!.call(value), config, new WeakSet(), 0),
+        });
+      } else {
+        out[key] = wrapScoped(desc.value, config, seen, depth + 1);
+      }
+    }
+    return out as T;
+  }
+
+  return value;
+}
+
+/**
+ * Same shape as `createKortix(config)`, but every method call — including
+ * calls reached through `.project(id)`/`.session(pid, sid)` handles minted at
+ * call time — automatically runs inside `runWithKortix(config, ...)`. This
+ * handle never writes to (or is affected by) the process-global config
+ * singleton other `createKortix()`/`configureKortix()` callers in the same
+ * process share. Safe to construct one per incoming request in a multi-tenant
+ * server:
+ *
+ *   import { createScopedKortix } from '@kortix/sdk/server';
+ *
+ *   app.get('/projects', async (req, res) => {
+ *     const kortix = createScopedKortix({ backendUrl, getToken: () => tokenFor(req) });
+ *     res.json(await kortix.projects.list());
+ *   });
+ *
+ * Two concurrent requests each calling `createScopedKortix` with a different
+ * token never see each other's config, even though both run in the same
+ * process — unlike two concurrent `createKortix()` calls, which share (and
+ * race on) the global singleton.
+ */
+export function createScopedKortix(config: KortixPlatformConfig): Kortix {
+  const inner = createKortix(config, { global: false });
+  return wrapScoped(inner, config, new WeakSet());
+}

--- a/packages/sdk/src/session/url.ts
+++ b/packages/sdk/src/session/url.ts
@@ -392,7 +392,11 @@ export function rewriteLocalhostUrl(
   // actually on the user's box. Otherwise we always go path-based through the
   // public API base URL (which terminates at whichever ingress fronts the API).
   if (!isBackendOnLocalhost(subdomainOpts.apiBaseUrl)) {
-    const base = subdomainOpts.apiBaseUrl.replace(/\/+$/, '');
+    // Linear trailing-slash strip — the regex form (/\/+$/) backtracks
+    // quadratically on adversarial input (CodeQL js/polynomial-redos).
+    let baseEnd = subdomainOpts.apiBaseUrl.length;
+    while (baseEnd > 0 && subdomainOpts.apiBaseUrl.charCodeAt(baseEnd - 1) === 47 /* '/' */) baseEnd--;
+    const base = subdomainOpts.apiBaseUrl.slice(0, baseEnd);
     return `${base}/p/${subdomainOpts.sandboxId}/${port}${safePath}`;
   }
 

--- a/packages/sdk/src/state/chat-events.test.ts
+++ b/packages/sdk/src/state/chat-events.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, test } from 'bun:test';
+
+import type { Message, Part, Todo } from '../opencode/client';
+import { type KortixChatEvent, heartbeatGapEvent, narrowChatEvent } from './chat-events';
+import type { OpenCodeEvent } from './event-stream';
+
+function ev(type: string, properties: unknown): OpenCodeEvent {
+  return { id: 'e1', type, properties } as unknown as OpenCodeEvent;
+}
+
+describe('narrowChatEvent', () => {
+  test('message.updated reshapes into {sessionID, message}', () => {
+    const message = { id: 'm1', role: 'assistant' } as unknown as Message;
+    const result = narrowChatEvent(ev('message.updated', { sessionID: 's1', info: message }));
+    expect(result).toEqual({ type: 'message.updated', sessionID: 's1', message });
+  });
+
+  test('message.part.updated reshapes into {sessionID, part}', () => {
+    const part = { id: 'p1', type: 'text', text: 'hi' } as unknown as Part;
+    const result = narrowChatEvent(ev('message.part.updated', { sessionID: 's1', part, time: 1 }));
+    expect(result).toEqual({ type: 'message.part.updated', sessionID: 's1', part });
+  });
+
+  test('session.status passes the status union through', () => {
+    const result = narrowChatEvent(
+      ev('session.status', { sessionID: 's1', status: { type: 'busy' } }),
+    );
+    expect(result).toEqual({ type: 'session.status', sessionID: 's1', status: { type: 'busy' } });
+  });
+
+  test('session.idle', () => {
+    expect(narrowChatEvent(ev('session.idle', { sessionID: 's1' }))).toEqual({
+      type: 'session.idle',
+      sessionID: 's1',
+    });
+  });
+
+  test('session.error carries the raw structured error through untouched', () => {
+    const error = { name: 'ProviderAuthError', data: { providerID: 'x', message: 'bad auth' } };
+    const result = narrowChatEvent(ev('session.error', { sessionID: 's1', error }));
+    expect(result).toEqual({ type: 'session.error', sessionID: 's1', error });
+  });
+
+  test('question.asked reshapes id -> requestID', () => {
+    const questions = [{ question: 'Which?', header: 'Which', options: [] }];
+    const result = narrowChatEvent(
+      ev('question.asked', {
+        id: 'q1',
+        sessionID: 's1',
+        questions,
+        tool: { messageID: 'm1', callID: 'c1' },
+      }),
+    );
+    expect(result).toEqual({
+      type: 'question.asked',
+      sessionID: 's1',
+      requestID: 'q1',
+      questions,
+      tool: { messageID: 'm1', callID: 'c1' },
+    });
+  });
+
+  test('question.replied and question.rejected both merge into question.answered with distinct outcomes', () => {
+    const replied = narrowChatEvent(
+      ev('question.replied', { sessionID: 's1', requestID: 'q1', answers: [['a']] }),
+    );
+    expect(replied).toEqual({
+      type: 'question.answered',
+      sessionID: 's1',
+      requestID: 'q1',
+      outcome: 'replied',
+      answers: [['a']],
+    });
+
+    const rejected = narrowChatEvent(ev('question.rejected', { sessionID: 's1', requestID: 'q1' }));
+    expect(rejected).toEqual({
+      type: 'question.answered',
+      sessionID: 's1',
+      requestID: 'q1',
+      outcome: 'rejected',
+    });
+  });
+
+  test('permission.asked reshapes id -> requestID', () => {
+    const result = narrowChatEvent(
+      ev('permission.asked', {
+        id: 'perm1',
+        sessionID: 's1',
+        permission: 'bash',
+        patterns: ['*'],
+        metadata: {},
+        always: [],
+      }),
+    );
+    expect(result).toEqual({
+      type: 'permission.asked',
+      sessionID: 's1',
+      requestID: 'perm1',
+      permission: 'bash',
+      patterns: ['*'],
+      tool: undefined,
+    });
+  });
+
+  test('permission.replied', () => {
+    const result = narrowChatEvent(
+      ev('permission.replied', { sessionID: 's1', requestID: 'perm1', reply: 'once' }),
+    );
+    expect(result).toEqual({
+      type: 'permission.replied',
+      sessionID: 's1',
+      requestID: 'perm1',
+      reply: 'once',
+    });
+  });
+
+  test('todo.updated', () => {
+    const todos = [
+      { content: 'ship it', status: 'pending', priority: 'high' },
+    ] as unknown as Todo[];
+    expect(narrowChatEvent(ev('todo.updated', { sessionID: 's1', todos }))).toEqual({
+      type: 'todo.updated',
+      sessionID: 's1',
+      todos,
+    });
+  });
+
+  test('server.connected becomes a generic connection event', () => {
+    expect(narrowChatEvent(ev('server.connected', {}))).toEqual({
+      type: 'connection',
+      status: 'connected',
+    });
+  });
+
+  test('events outside the curated set return null (e.g. lsp.updated, pty.created, project.updated)', () => {
+    expect(narrowChatEvent(ev('lsp.updated', {}))).toBeNull();
+    expect(narrowChatEvent(ev('pty.created', {}))).toBeNull();
+    expect(narrowChatEvent(ev('project.updated', {}))).toBeNull();
+    expect(narrowChatEvent(ev('installation.updated', { version: '1.0' }))).toBeNull();
+    expect(narrowChatEvent(ev('mcp.tools.changed', { server: 'x' }))).toBeNull();
+  });
+});
+
+describe('heartbeatGapEvent', () => {
+  test('builds a synthetic heartbeat-gap chat event', () => {
+    const event: KortixChatEvent = heartbeatGapEvent(7000);
+    expect(event).toEqual({ type: 'heartbeat-gap', gapMs: 7000 });
+  });
+});

--- a/packages/sdk/src/state/chat-events.ts
+++ b/packages/sdk/src/state/chat-events.ts
@@ -1,0 +1,282 @@
+/**
+ * Curated OpenCode event union for building a product chat UI — framework-free.
+ *
+ * `OpenCodeEvent` (`./event-stream.ts`) is the FULL raw wire union: ~50+
+ * variants covering LSP, PTY, worktrees, plugins, projects, MCP, installation,
+ * and more. A chat surface only ever cares about a small slice of that —
+ * message/part updates, session status, questions, permissions, todos, and
+ * connection health. `narrowChatEvent` filters + reshapes the raw stream down
+ * to `KortixChatEvent`, so a host's dispatch switch only has to handle events
+ * that actually matter to chat, each carrying a purpose-shaped payload
+ * instead of the raw untyped `properties` bag.
+ *
+ * `heartbeat-gap` has no wire representation of its own — `openEventStream`'s
+ * `onGapRehydrate(gapMs)` callback fires out-of-band when the SSE stream
+ * reconnects after a gap large enough that cached state may be stale. Build
+ * it with `heartbeatGapEvent(gapMs)` and dispatch it the same way as
+ * `narrowChatEvent`'s output:
+ *
+ * ```ts
+ * openEventStream({
+ *   client,
+ *   onEvent: (e) => {
+ *     const chatEvent = narrowChatEvent(e);
+ *     if (chatEvent) dispatch(chatEvent);
+ *   },
+ *   onGapRehydrate: (gapMs) => dispatch(heartbeatGapEvent(gapMs)),
+ * });
+ * ```
+ */
+
+import type { Message, Part, QuestionAnswer, SessionStatus, Todo } from '../opencode/client';
+import type { OpenCodeEvent } from './event-stream';
+
+export interface KortixChatEventMessageUpdated {
+  type: 'message.updated';
+  sessionID: string;
+  message: Message;
+}
+
+export interface KortixChatEventMessageRemoved {
+  type: 'message.removed';
+  sessionID: string;
+  messageID: string;
+}
+
+export interface KortixChatEventPartUpdated {
+  type: 'message.part.updated';
+  sessionID: string;
+  part: Part;
+}
+
+export interface KortixChatEventPartRemoved {
+  type: 'message.part.removed';
+  sessionID: string;
+  messageID: string;
+  partID: string;
+}
+
+export interface KortixChatEventSessionStatus {
+  type: 'session.status';
+  sessionID: string;
+  status: SessionStatus;
+}
+
+export interface KortixChatEventSessionIdle {
+  type: 'session.idle';
+  sessionID: string;
+}
+
+export interface KortixChatEventSessionError {
+  type: 'session.error';
+  sessionID?: string;
+  error?: unknown;
+}
+
+export interface KortixChatQuestionOption {
+  label: string;
+  description: string;
+}
+
+export interface KortixChatQuestionInfo {
+  question: string;
+  header: string;
+  options: KortixChatQuestionOption[];
+  multiple?: boolean;
+  custom?: boolean;
+}
+
+export interface KortixChatToolRef {
+  messageID: string;
+  callID: string;
+}
+
+export interface KortixChatEventQuestionAsked {
+  type: 'question.asked';
+  sessionID: string;
+  requestID: string;
+  questions: KortixChatQuestionInfo[];
+  tool?: KortixChatToolRef;
+}
+
+/** Merges the wire's `question.replied` / `question.rejected` events — a host
+ *  usually just needs to know "this pending question resolved" plus how. */
+export interface KortixChatEventQuestionAnswered {
+  type: 'question.answered';
+  sessionID: string;
+  requestID: string;
+  outcome: 'replied' | 'rejected';
+  answers?: QuestionAnswer[];
+}
+
+export interface KortixChatEventPermissionAsked {
+  type: 'permission.asked';
+  sessionID: string;
+  requestID: string;
+  permission: string;
+  patterns: string[];
+  tool?: KortixChatToolRef;
+}
+
+export interface KortixChatEventPermissionReplied {
+  type: 'permission.replied';
+  sessionID: string;
+  requestID: string;
+  reply: 'once' | 'always' | 'reject';
+}
+
+export interface KortixChatEventTodoUpdated {
+  type: 'todo.updated';
+  sessionID: string;
+  todos: Todo[];
+}
+
+/** Fired once per SSE (re)connect — a host can use it to clear a "reconnecting…" banner. */
+export interface KortixChatEventConnection {
+  type: 'connection';
+  status: 'connected';
+}
+
+/** Synthetic — see the module doc comment. Not derived from `narrowChatEvent`;
+ *  built directly from `openEventStream`'s `onGapRehydrate(gapMs)`. */
+export interface KortixChatEventHeartbeatGap {
+  type: 'heartbeat-gap';
+  gapMs: number;
+}
+
+export type KortixChatEvent =
+  | KortixChatEventMessageUpdated
+  | KortixChatEventMessageRemoved
+  | KortixChatEventPartUpdated
+  | KortixChatEventPartRemoved
+  | KortixChatEventSessionStatus
+  | KortixChatEventSessionIdle
+  | KortixChatEventSessionError
+  | KortixChatEventQuestionAsked
+  | KortixChatEventQuestionAnswered
+  | KortixChatEventPermissionAsked
+  | KortixChatEventPermissionReplied
+  | KortixChatEventTodoUpdated
+  | KortixChatEventConnection
+  | KortixChatEventHeartbeatGap;
+
+/** Build the synthetic heartbeat-gap chat event from `openEventStream`'s `onGapRehydrate` callback. */
+export function heartbeatGapEvent(gapMs: number): KortixChatEventHeartbeatGap {
+  return { type: 'heartbeat-gap', gapMs };
+}
+
+/**
+ * Narrow a raw `OpenCodeEvent` down to the curated `KortixChatEvent` union a
+ * chat UI needs, reshaping `properties` into a purpose-built payload.
+ *
+ * Returns `null` for every event outside the curated set (LSP, PTY,
+ * worktrees, plugins, projects, MCP, installation, session lifecycle CRUD,
+ * …) — callers should treat `null` as "not a chat event, ignore" rather than
+ * an error; this is a deliberate filter, not an exhaustive switch.
+ */
+export function narrowChatEvent(event: OpenCodeEvent): KortixChatEvent | null {
+  switch (event.type) {
+    case 'message.updated':
+      return {
+        type: 'message.updated',
+        sessionID: event.properties.sessionID,
+        message: event.properties.info,
+      };
+
+    case 'message.removed':
+      return {
+        type: 'message.removed',
+        sessionID: event.properties.sessionID,
+        messageID: event.properties.messageID,
+      };
+
+    case 'message.part.updated':
+      return {
+        type: 'message.part.updated',
+        sessionID: event.properties.sessionID,
+        part: event.properties.part,
+      };
+
+    case 'message.part.removed':
+      return {
+        type: 'message.part.removed',
+        sessionID: event.properties.sessionID,
+        messageID: event.properties.messageID,
+        partID: event.properties.partID,
+      };
+
+    case 'session.status':
+      return {
+        type: 'session.status',
+        sessionID: event.properties.sessionID,
+        status: event.properties.status,
+      };
+
+    case 'session.idle':
+      return { type: 'session.idle', sessionID: event.properties.sessionID };
+
+    case 'session.error':
+      return {
+        type: 'session.error',
+        sessionID: event.properties.sessionID,
+        error: event.properties.error,
+      };
+
+    case 'question.asked':
+      return {
+        type: 'question.asked',
+        sessionID: event.properties.sessionID,
+        requestID: event.properties.id,
+        questions: event.properties.questions,
+        tool: event.properties.tool,
+      };
+
+    case 'question.replied':
+      return {
+        type: 'question.answered',
+        sessionID: event.properties.sessionID,
+        requestID: event.properties.requestID,
+        outcome: 'replied',
+        answers: event.properties.answers,
+      };
+
+    case 'question.rejected':
+      return {
+        type: 'question.answered',
+        sessionID: event.properties.sessionID,
+        requestID: event.properties.requestID,
+        outcome: 'rejected',
+      };
+
+    case 'permission.asked':
+      return {
+        type: 'permission.asked',
+        sessionID: event.properties.sessionID,
+        requestID: event.properties.id,
+        permission: event.properties.permission,
+        patterns: event.properties.patterns,
+        tool: event.properties.tool,
+      };
+
+    case 'permission.replied':
+      return {
+        type: 'permission.replied',
+        sessionID: event.properties.sessionID,
+        requestID: event.properties.requestID,
+        reply: event.properties.reply,
+      };
+
+    case 'todo.updated':
+      return {
+        type: 'todo.updated',
+        sessionID: event.properties.sessionID,
+        todos: event.properties.todos,
+      };
+
+    case 'server.connected':
+      return { type: 'connection', status: 'connected' };
+
+    default:
+      return null;
+  }
+}

--- a/packages/sdk/src/state/current-runtime.test.ts
+++ b/packages/sdk/src/state/current-runtime.test.ts
@@ -1,0 +1,135 @@
+import { test, expect, beforeEach, afterEach } from 'bun:test';
+import {
+  currentRuntimeStore,
+  getCurrentRuntimeDbSandboxId,
+  getCurrentRuntimeSandboxId,
+  getCurrentRuntimeUrl,
+  setCurrentRuntime,
+} from './current-runtime';
+
+// This is a process-wide singleton (`state` is module-level) — several OTHER
+// files exercise real session-start flows that call the real
+// `setCurrentRuntime` too (e.g. `kortix.test.ts`, `session/session.test.ts`,
+// `files/client.test.ts`), so this module's state is NOT guaranteed to be
+// untouched by the time this file's tests run, and `version` is a
+// process-cumulative counter with no reset-to-zero — never assert an absolute
+// "pristine" value here, only reset-then-observe or relative deltas. Reset
+// before AND after every test in this file so neither direction leaks.
+beforeEach(() => {
+  setCurrentRuntime(null);
+});
+afterEach(() => {
+  setCurrentRuntime(null);
+});
+
+test('after clearing, url/sandboxId/dbSandboxId all read back null', () => {
+  expect(getCurrentRuntimeUrl()).toBeNull();
+  expect(getCurrentRuntimeSandboxId()).toBeNull();
+  expect(getCurrentRuntimeDbSandboxId()).toBeNull();
+});
+
+test('setCurrentRuntime sets url + sandboxId + dbSandboxId, all readable via the getters', () => {
+  setCurrentRuntime('http://backend.local/p/sb-1/8000', 'sb-1', 'db-sb-1');
+
+  expect(getCurrentRuntimeUrl()).toBe('http://backend.local/p/sb-1/8000');
+  expect(getCurrentRuntimeSandboxId()).toBe('sb-1');
+  expect(getCurrentRuntimeDbSandboxId()).toBe('db-sb-1');
+});
+
+test('setCurrentRuntime defaults sandboxId/dbSandboxId to null when omitted', () => {
+  setCurrentRuntime('http://backend.local/p/sb-1/8000');
+
+  expect(getCurrentRuntimeUrl()).toBe('http://backend.local/p/sb-1/8000');
+  expect(getCurrentRuntimeSandboxId()).toBeNull();
+  expect(getCurrentRuntimeDbSandboxId()).toBeNull();
+});
+
+test('setCurrentRuntime(null) clears the runtime back to the empty state', () => {
+  setCurrentRuntime('http://backend.local/p/sb-1/8000', 'sb-1', 'db-sb-1');
+  setCurrentRuntime(null);
+
+  expect(getCurrentRuntimeUrl()).toBeNull();
+  expect(getCurrentRuntimeSandboxId()).toBeNull();
+  expect(getCurrentRuntimeDbSandboxId()).toBeNull();
+});
+
+test('version increments on every actual change', () => {
+  const v0 = currentRuntimeStore.getState().version;
+  setCurrentRuntime('http://a.local', 'sb-a');
+  const v1 = currentRuntimeStore.getState().version;
+  expect(v1).toBe(v0 + 1);
+
+  setCurrentRuntime('http://b.local', 'sb-b');
+  const v2 = currentRuntimeStore.getState().version;
+  expect(v2).toBe(v1 + 1);
+});
+
+test('setting an identical (url, sandboxId, dbSandboxId) triple is a no-op — version does not bump', () => {
+  setCurrentRuntime('http://a.local', 'sb-a', 'db-a');
+  const vAfterFirst = currentRuntimeStore.getState().version;
+
+  setCurrentRuntime('http://a.local', 'sb-a', 'db-a');
+  expect(currentRuntimeStore.getState().version).toBe(vAfterFirst);
+});
+
+test('changing only the sandboxId (same url) still bumps version — not a pure url comparison', () => {
+  setCurrentRuntime('http://a.local', 'sb-a', 'db-a');
+  const v1 = currentRuntimeStore.getState().version;
+
+  setCurrentRuntime('http://a.local', 'sb-b', 'db-a');
+  expect(currentRuntimeStore.getState().version).toBe(v1 + 1);
+  expect(getCurrentRuntimeSandboxId()).toBe('sb-b');
+});
+
+test('changing only the dbSandboxId (same url + sandboxId) still bumps version', () => {
+  setCurrentRuntime('http://a.local', 'sb-a', 'db-a');
+  const v1 = currentRuntimeStore.getState().version;
+
+  setCurrentRuntime('http://a.local', 'sb-a', 'db-b');
+  expect(currentRuntimeStore.getState().version).toBe(v1 + 1);
+  expect(getCurrentRuntimeDbSandboxId()).toBe('db-b');
+});
+
+test('subscribe notifies listeners on change and the unsubscribe function stops further notifications', () => {
+  let notifications = 0;
+  const unsubscribe = currentRuntimeStore.subscribe(() => {
+    notifications++;
+  });
+
+  setCurrentRuntime('http://a.local', 'sb-a');
+  expect(notifications).toBe(1);
+
+  setCurrentRuntime('http://a.local', 'sb-a'); // no-op change — no notification
+  expect(notifications).toBe(1);
+
+  setCurrentRuntime('http://b.local', 'sb-b');
+  expect(notifications).toBe(2);
+
+  unsubscribe();
+  setCurrentRuntime('http://c.local', 'sb-c');
+  expect(notifications).toBe(2);
+});
+
+test('multiple listeners are all notified independently', () => {
+  const seen: string[] = [];
+  const unsubA = currentRuntimeStore.subscribe(() => seen.push('a'));
+  const unsubB = currentRuntimeStore.subscribe(() => seen.push('b'));
+
+  setCurrentRuntime('http://a.local', 'sb-a');
+  expect(seen).toEqual(['a', 'b']);
+
+  unsubA();
+  setCurrentRuntime('http://b.local', 'sb-b');
+  expect(seen).toEqual(['a', 'b', 'b']);
+
+  unsubB();
+});
+
+test('getState returns the same live state object shape used by the getters', () => {
+  setCurrentRuntime('http://a.local', 'sb-a', 'db-a');
+  const state = currentRuntimeStore.getState();
+
+  expect(state.url).toBe(getCurrentRuntimeUrl());
+  expect(state.sandboxId).toBe(getCurrentRuntimeSandboxId());
+  expect(state.dbSandboxId).toBe(getCurrentRuntimeDbSandboxId());
+});

--- a/packages/sdk/src/state/event-stream.test.ts
+++ b/packages/sdk/src/state/event-stream.test.ts
@@ -7,7 +7,10 @@ import {
   type OpenCodeEvent,
 } from './event-stream';
 
-const HEARTBEAT_MS = 15_000;
+// Mirrors event-stream.ts's default idle-watchdog budget (raised from 15s —
+// the server emits no idle keepalives, so a 15s budget killed healthy idle
+// sessions on a timer by design; see the HEARTBEAT_MS comment there).
+const HEARTBEAT_MS = 60_000;
 
 function sessionStatus(sessionID: string, statusType: string): OpenCodeEvent {
   return {
@@ -163,12 +166,22 @@ function createLoggingTimers(clock: FakeClock): { timers: EventStreamTimers; log
   return { timers, log };
 }
 
+// Mirrors event-stream.ts's default `connectTimeoutMs`. Every connect attempt
+// now schedules a connect-timeout timer right as it starts (before the
+// connect call resolves) — that's a second `timeout:` log entry ahead of each
+// `connect`, distinct from the real reconnect/backoff delay timer logged just
+// before it. Filtered out below so `reconnectDelaysFromLog` still reports
+// only genuine backoff delays.
+const DEFAULT_CONNECT_TIMEOUT_MS = 20_000;
+
 function reconnectDelaysFromLog(log: string[]): number[] {
   const delays: number[] = [];
   let pendingDelay: number | undefined;
   for (const entry of log) {
     if (entry.startsWith('timeout:')) {
-      pendingDelay = Number(entry.slice('timeout:'.length));
+      const ms = Number(entry.slice('timeout:'.length));
+      if (ms === DEFAULT_CONNECT_TIMEOUT_MS) continue;
+      pendingDelay = ms;
     } else if (entry === 'connect') {
       if (pendingDelay !== undefined) delays.push(pendingDelay);
       pendingDelay = undefined;
@@ -276,7 +289,16 @@ describe('openEventStream reconnect backoff', () => {
       },
     };
 
-    const handle = openEventStream({ client, onEvent: () => {}, timers });
+    // This walks 7 consecutive event-less fast disconnects — exactly one shy
+    // of the default park threshold (8). Raise the threshold so this stays a
+    // pure backoff test, decoupled from the give-up feature (covered by its
+    // own describe block below).
+    const handle = openEventStream({
+      client,
+      onEvent: () => {},
+      timers,
+      maxConsecutiveHardFailures: 100,
+    });
     await tick();
 
     const expectedDelays = [1000, 2000, 4000, 8000, 16000, 30000, 30000];
@@ -351,6 +373,128 @@ describe('openEventStream reconnect backoff', () => {
   });
 });
 
+describe('openEventStream connect timeout', () => {
+  test('a connect call that never resolves times out, aborts the attempt, and retries with backoff', async () => {
+    const clock = createFakeClock();
+    let attempts = 0;
+    const abortedSignals: boolean[] = [];
+    const client: EventStreamClient = {
+      global: {
+        event: async (opts) => {
+          attempts++;
+          const idx = abortedSignals.length;
+          abortedSignals.push(false);
+          opts.signal.addEventListener('abort', () => {
+            abortedSignals[idx] = true;
+          });
+          // Never resolves, rejects, or closes — models a black-holed proxy
+          // that silently swallows the connect request.
+          return new Promise<{ stream: AsyncIterable<unknown> }>(() => {});
+        },
+      },
+    };
+
+    const handle = openEventStream({
+      client,
+      onEvent: () => {},
+      timers: clock,
+      connectTimeoutMs: 20_000,
+    });
+    await tick();
+    expect(attempts).toBe(1);
+    expect(abortedSignals[0]).toBe(false);
+
+    // Short of the connect-timeout deadline: still hung, no abort, no retry.
+    await clock.advance(19_999);
+    await tick();
+    expect(abortedSignals[0]).toBe(false);
+    expect(attempts).toBe(1);
+
+    // Crossing the deadline aborts the hung attempt...
+    await clock.advance(1);
+    await tick();
+    expect(abortedSignals[0]).toBe(true);
+
+    // ...and reconnects through the normal (unhealthy) backoff path — min 1s,
+    // same as any other connect failure.
+    await clock.advance(1000);
+    await tick();
+    expect(attempts).toBe(2);
+
+    handle.close();
+  });
+
+  test('a connect that resolves within the budget is unaffected — no spurious abort or retry', async () => {
+    const clock = createFakeClock();
+    const { client, channels } = createConnectableClient();
+    const dispatched: OpenCodeEvent[] = [];
+
+    const handle = openEventStream({
+      client,
+      onEvent: (e) => dispatched.push(e),
+      timers: clock,
+      connectTimeoutMs: 20_000,
+    });
+    await tick();
+    expect(channels.length).toBe(1);
+
+    // Advance most of the way toward the connect-timeout budget (short of the
+    // separate 15s heartbeat deadline, covered by its own tests) — since
+    // connect already resolved (synchronously, in this fake client), the
+    // connect-timeout timer must already be cleared and this must not force a
+    // reconnect or drop the connection.
+    await clock.advance(10_000);
+    channels[0].push(partUpdated('p1'));
+    await tick();
+    await clock.advance(16);
+
+    expect(dispatched.length).toBe(1);
+    expect(channels.length).toBe(1);
+
+    handle.close();
+  });
+
+  test('a slow-but-successful connect (just under budget) keeps the same attempt — no reconnect', async () => {
+    const clock = createFakeClock();
+    let resolveConnect: ((v: { stream: AsyncIterable<unknown> }) => void) | undefined;
+    let attempts = 0;
+    const client: EventStreamClient = {
+      global: {
+        event: () => {
+          attempts++;
+          return new Promise<{ stream: AsyncIterable<unknown> }>((resolve) => {
+            resolveConnect = resolve;
+          });
+        },
+      },
+    };
+
+    const handle = openEventStream({
+      client,
+      onEvent: () => {},
+      timers: clock,
+      connectTimeoutMs: 20_000,
+    });
+    await tick();
+    expect(attempts).toBe(1);
+
+    await clock.advance(19_999);
+    expect(attempts).toBe(1);
+
+    resolveConnect?.(({ stream: createParkingChannel([]) }));
+    await tick();
+
+    // Advance past where the (now-cleared) connect-timeout budget would have
+    // fired, but short of the 15s heartbeat deadline (a separate watchdog,
+    // covered by its own tests) — isolates that the connect timer specifically
+    // didn't leak into a second attempt.
+    await clock.advance(2000);
+    expect(attempts).toBe(1);
+
+    handle.close();
+  });
+});
+
 function createParkingChannel(chunks: unknown[]): AsyncIterable<unknown> {
   let index = 0;
   return {
@@ -372,7 +516,7 @@ function createParkingChannel(chunks: unknown[]): AsyncIterable<unknown> {
 }
 
 describe('openEventStream heartbeat watchdog', () => {
-  test('forces a reconnect and drops the event that surfaces after the 15s deadline', async () => {
+  test('forces a reconnect and drops the event that surfaces after the idle deadline', async () => {
     const clock = createFakeClock();
     const { client, channels } = createConnectableClient();
     const dispatched: OpenCodeEvent[] = [];
@@ -457,7 +601,11 @@ describe('openEventStream heartbeat watchdog', () => {
     await tick();
     expect(abortedSignals[0]).toBe(true);
 
-    await clock.advance(250);
+    // This connection delivered NO events, so a watchdog kill is NOT a
+    // "stable" disconnect — the reconnect rides the exponential backoff path
+    // (min 1s), not the 250ms fast-resume (see the storm fix in
+    // event-stream.ts).
+    await clock.advance(1000);
     await tick();
     expect(abortedSignals.length).toBe(2);
     expect(abortedSignals[1]).toBe(false);
@@ -488,6 +636,432 @@ describe('openEventStream heartbeat watchdog', () => {
     await clock.advance(1000);
     await tick();
     expect(channels.length).toBe(2);
+
+    handle.close();
+  });
+});
+
+// ── Backoff classification (the prod reconnect-storm fix): an idle
+// disconnect — watchdog kill or natural end with no events — must NEVER
+// count as "stable". Only a stream that actually delivered events resets
+// backoff to the 250ms fast path. The old time-based OR-branch ("open >10s
+// counts as stable") locked idle streams killed on any period above 10s
+// into 250ms reconnects forever. ─────────────────────────────────────────
+
+describe('openEventStream idle-disconnect backoff (reconnect-storm fix)', () => {
+  test('repeated watchdog kills of idle (event-less) connections back off exponentially, not at 250ms', async () => {
+    const clock = createFakeClock();
+    const { client } = createConnectableClient();
+    let attempts = 0;
+    const countingClient: EventStreamClient = {
+      global: {
+        event: async (opts) => {
+          attempts++;
+          return client.global.event(opts);
+        },
+      },
+    };
+
+    const handle = openEventStream({ client: countingClient, onEvent: () => {}, timers: clock });
+    await tick();
+    expect(attempts).toBe(1);
+
+    // Cycle 1: idle 60s → watchdog kill → reconnect must wait the FULL 1s
+    // exponential base, not 250ms.
+    await clock.advance(HEARTBEAT_MS);
+    await tick();
+    await clock.advance(999);
+    expect(attempts).toBe(1);
+    await clock.advance(1);
+    expect(attempts).toBe(2);
+
+    // Cycle 2: still idle → delay GROWS to 2s.
+    await clock.advance(HEARTBEAT_MS);
+    await tick();
+    await clock.advance(1999);
+    expect(attempts).toBe(2);
+    await clock.advance(1);
+    expect(attempts).toBe(3);
+
+    // Cycle 3: still idle → delay GROWS to 4s.
+    await clock.advance(HEARTBEAT_MS);
+    await tick();
+    await clock.advance(3999);
+    expect(attempts).toBe(3);
+    await clock.advance(1);
+    expect(attempts).toBe(4);
+
+    handle.close();
+  });
+
+  test('a genuinely eventful connection still resets backoff to the 250ms fast path', async () => {
+    const clock = createFakeClock();
+    const { client, channels } = createConnectableClient();
+    const dispatched: OpenCodeEvent[] = [];
+
+    const handle = openEventStream({ client, onEvent: (e) => dispatched.push(e), timers: clock });
+    await tick();
+    expect(channels.length).toBe(1);
+
+    // Grow backoff with two idle watchdog kills (1s, then 2s delays).
+    await clock.advance(HEARTBEAT_MS);
+    await tick();
+    await clock.advance(1000);
+    expect(channels.length).toBe(2);
+    await clock.advance(HEARTBEAT_MS);
+    await tick();
+    await clock.advance(2000);
+    expect(channels.length).toBe(3);
+
+    // The third connection delivers a REAL event → stable → backoff resets.
+    channels[2].push(partUpdated('p1'));
+    await tick();
+    await clock.advance(16);
+    expect(dispatched.length).toBe(1);
+
+    channels[2].end();
+    await tick();
+    await clock.advance(250);
+    expect(channels.length).toBe(4);
+
+    handle.close();
+  });
+
+  test('idle heartbeat tolerance: 59s of quiet does not kill the stream; crossing 60s does, into backoff', async () => {
+    const clock = createFakeClock();
+    const abortedSignals: boolean[] = [];
+    let attempts = 0;
+    const client: EventStreamClient = {
+      global: {
+        event: async (opts) => {
+          attempts++;
+          const idx = abortedSignals.length;
+          abortedSignals.push(false);
+          opts.signal.addEventListener('abort', () => {
+            abortedSignals[idx] = true;
+          });
+          return { stream: createParkingChannel([]) };
+        },
+      },
+    };
+
+    const handle = openEventStream({ client, onEvent: () => {}, timers: clock });
+    await tick();
+    expect(attempts).toBe(1);
+
+    // 59s idle (short of the 60s budget): still alive, no watchdog abort.
+    await clock.advance(59_000);
+    await tick();
+    expect(abortedSignals[0]).toBe(false);
+    expect(attempts).toBe(1);
+
+    // Crossing the 60s budget: watchdog kills it...
+    await clock.advance(1_000);
+    await tick();
+    expect(abortedSignals[0]).toBe(true);
+
+    // ...and the reconnect rides the 1s backoff path (idle kill ≠ stable),
+    // NOT the 250ms fast-resume: nothing for 999ms, reconnect at 1s.
+    await clock.advance(999);
+    expect(attempts).toBe(1);
+    await clock.advance(1);
+    expect(attempts).toBe(2);
+
+    handle.close();
+  });
+
+  test('heartbeatTimeoutMs is configurable per stream (a 5s budget kills at 5s idle)', async () => {
+    const clock = createFakeClock();
+    const abortedSignals: boolean[] = [];
+    const client: EventStreamClient = {
+      global: {
+        event: async (opts) => {
+          const idx = abortedSignals.length;
+          abortedSignals.push(false);
+          opts.signal.addEventListener('abort', () => {
+            abortedSignals[idx] = true;
+          });
+          return { stream: createParkingChannel([]) };
+        },
+      },
+    };
+
+    const handle = openEventStream({
+      client,
+      onEvent: () => {},
+      timers: clock,
+      heartbeatTimeoutMs: 5_000,
+    });
+    await tick();
+
+    await clock.advance(4_999);
+    await tick();
+    expect(abortedSignals[0]).toBe(false);
+
+    await clock.advance(1);
+    await tick();
+    expect(abortedSignals[0]).toBe(true);
+
+    handle.close();
+  });
+});
+
+// ── Give-up (parked) terminal state: streams pointed at DEAD sandboxes
+// (archived/stopped sessions) used to retry forever — prod showed continuous
+// 503 loops from /p/{sandbox}/8000/global/event for multiple dead sandboxes
+// at once. After `maxConsecutiveHardFailures` consecutive event-less
+// HTTP/fast failures the stream parks: onParked fires once, no further
+// connect attempts, close() stays safe. ────────────────────────────────────
+
+/** A client whose connect always rejects instantly, like a proxy 503ing a
+ *  dead sandbox. The error carries the vendor client's `cause.status` shape. */
+function createDeadSandboxClient() {
+  let attempts = 0;
+  const client: EventStreamClient = {
+    global: {
+      event: async () => {
+        attempts++;
+        throw new Error('GET /global/event → 503 Service Unavailable', {
+          cause: { body: 'sandbox gone', status: 503 },
+        });
+      },
+    },
+  };
+  return { client, attempts: () => attempts };
+}
+
+describe('openEventStream parked state (dead-sandbox give-up)', () => {
+  test('parks after the default 8 consecutive hard failures: onParked fires once, retries stop for good', async () => {
+    const clock = createFakeClock();
+    const { client, attempts } = createDeadSandboxClient();
+    const parkedReasons: { consecutiveFailures: number; lastError: unknown }[] = [];
+
+    const handle = openEventStream({
+      client,
+      onEvent: () => {},
+      onParked: (reason) => parkedReasons.push(reason),
+      timers: clock,
+    });
+    await tick();
+
+    // Walk the whole backoff ladder (1+2+4+8+16+30+30 = 91s of delays — the
+    // give-up is spread over ~2 minutes, not instant).
+    await clock.advance(200_000);
+    await tick();
+
+    expect(attempts()).toBe(8);
+    expect(parkedReasons).toHaveLength(1);
+    expect(parkedReasons[0].consecutiveFailures).toBe(8);
+    expect(String(parkedReasons[0].lastError)).toContain('503');
+
+    // Terminal: no matter how much more time passes, no further attempts,
+    // no second onParked.
+    await clock.advance(600_000);
+    await tick();
+    expect(attempts()).toBe(8);
+    expect(parkedReasons).toHaveLength(1);
+
+    // close() on a parked handle stays safe/idempotent.
+    expect(() => handle.close()).not.toThrow();
+    expect(() => handle.close()).not.toThrow();
+  });
+
+  test('maxConsecutiveHardFailures is configurable (parks after 3)', async () => {
+    const clock = createFakeClock();
+    const { client, attempts } = createDeadSandboxClient();
+    const parked: number[] = [];
+
+    const handle = openEventStream({
+      client,
+      onEvent: () => {},
+      onParked: (r) => parked.push(r.consecutiveFailures),
+      timers: clock,
+      maxConsecutiveHardFailures: 3,
+    });
+    await tick();
+
+    await clock.advance(60_000);
+    await tick();
+
+    expect(attempts()).toBe(3);
+    expect(parked).toEqual([3]);
+
+    handle.close();
+  });
+
+  test('an eventful connection resets the hard-failure streak', async () => {
+    const clock = createFakeClock();
+    let attempts = 0;
+    const channels: FakeEventChannel[] = [];
+    // Attempts 1-2 fail fast (503); attempt 3 connects and streams an event;
+    // attempts 4+ fail fast again.
+    const client: EventStreamClient = {
+      global: {
+        event: async (opts) => {
+          attempts++;
+          if (attempts === 3) {
+            const channel = new FakeEventChannel();
+            opts.signal.addEventListener('abort', () => channel.end(), { once: true });
+            channels.push(channel);
+            return { stream: channel };
+          }
+          throw new Error('GET /global/event → 503', { cause: { body: '', status: 503 } });
+        },
+      },
+    };
+    const parked: number[] = [];
+
+    const handle = openEventStream({
+      client,
+      onEvent: () => {},
+      onParked: (r) => parked.push(r.consecutiveFailures),
+      timers: clock,
+      maxConsecutiveHardFailures: 3,
+    });
+    await tick();
+
+    // Failures 1 and 2 (streak = 2, one short of the threshold)...
+    await clock.advance(1000);
+    await tick();
+    expect(attempts).toBe(2);
+    await clock.advance(2000);
+    await tick();
+    expect(attempts).toBe(3);
+    expect(parked).toEqual([]);
+
+    // ...then attempt 3 delivers a REAL event — streak resets to 0.
+    channels[0].push(partUpdated('p1'));
+    await tick();
+    await clock.advance(16);
+    channels[0].end();
+    await tick();
+
+    // It now takes a FULL fresh streak of 3 to park (attempts 4, 5, 6) — if
+    // the eventful connection hadn't reset the counter, attempt 4 alone
+    // would have tripped it.
+    await clock.advance(60_000);
+    await tick();
+    expect(parked).toEqual([3]);
+    expect(attempts).toBe(6);
+
+    handle.close();
+  });
+
+  test('parks even after prior successful streaming (sandbox died later)', async () => {
+    const clock = createFakeClock();
+    let attempts = 0;
+    const channels: FakeEventChannel[] = [];
+    // Attempt 1 streams events fine; the sandbox then dies — every later
+    // connect 503s.
+    const client: EventStreamClient = {
+      global: {
+        event: async (opts) => {
+          attempts++;
+          if (attempts === 1) {
+            const channel = new FakeEventChannel();
+            opts.signal.addEventListener('abort', () => channel.end(), { once: true });
+            channels.push(channel);
+            return { stream: channel };
+          }
+          throw new Error('GET /global/event → 503', { cause: { body: '', status: 503 } });
+        },
+      },
+    };
+    const parked: number[] = [];
+
+    const handle = openEventStream({
+      client,
+      onEvent: () => {},
+      onParked: (r) => parked.push(r.consecutiveFailures),
+      timers: clock,
+      maxConsecutiveHardFailures: 3,
+    });
+    await tick();
+
+    channels[0].push(partUpdated('p1'));
+    await tick();
+    await clock.advance(16);
+    channels[0].end();
+    await tick();
+
+    await clock.advance(60_000);
+    await tick();
+
+    expect(parked).toEqual([3]);
+    expect(attempts).toBe(4); // 1 healthy + 3 hard failures
+
+    handle.close();
+  });
+
+  test('a slow failure without an HTTP status (hung connect → connect timeout) never counts toward the park streak', async () => {
+    const clock = createFakeClock();
+    let attempts = 0;
+    // Every connect hangs forever — the 20s connect timeout kills each one.
+    // 20s > HARD_FAILURE_WINDOW_MS and the synthetic timeout error carries no
+    // cause.status, so these are NOT hard failures and must never park.
+    const client: EventStreamClient = {
+      global: {
+        event: () => {
+          attempts++;
+          return new Promise<{ stream: AsyncIterable<unknown> }>(() => {});
+        },
+      },
+    };
+    const parked: number[] = [];
+
+    const handle = openEventStream({
+      client,
+      onEvent: () => {},
+      onParked: (r) => parked.push(r.consecutiveFailures),
+      timers: clock,
+      maxConsecutiveHardFailures: 2,
+    });
+    await tick();
+
+    // Enough time for well over 2 hung-connect cycles (20s timeout + backoff
+    // each) — with maxConsecutiveHardFailures: 2, a single miscount parks.
+    await clock.advance(200_000);
+    await tick();
+
+    expect(parked).toEqual([]);
+    expect(attempts).toBeGreaterThan(3); // still retrying, never gave up
+
+    handle.close();
+  });
+
+  test('an HTTP-status failure counts as hard even when it arrives slowly (>2s)', async () => {
+    const clock = createFakeClock();
+    let attempts = 0;
+    // Each connect rejects with a 503 — but only after 5s (a slow edge), past
+    // the fast-fail window. The cause.status branch must still classify it.
+    const client: EventStreamClient = {
+      global: {
+        event: () => {
+          attempts++;
+          return new Promise<{ stream: AsyncIterable<unknown> }>((_resolve, reject) => {
+            clock.setTimeout(() => {
+              reject(new Error('GET /global/event → 503', { cause: { body: '', status: 503 } }));
+            }, 5_000);
+          });
+        },
+      },
+    };
+    const parked: number[] = [];
+
+    const handle = openEventStream({
+      client,
+      onEvent: () => {},
+      onParked: (r) => parked.push(r.consecutiveFailures),
+      timers: clock,
+      maxConsecutiveHardFailures: 2,
+    });
+    await tick();
+
+    await clock.advance(60_000);
+    await tick();
+
+    expect(parked).toEqual([2]);
+    expect(attempts).toBe(2);
 
     handle.close();
   });

--- a/packages/sdk/src/state/event-stream.ts
+++ b/packages/sdk/src/state/event-stream.ts
@@ -389,3 +389,31 @@ export function openEventStream(opts: OpenEventStreamOptions): EventStreamHandle
     },
   };
 }
+
+// The curated chat-event union built on top of this stream's `OpenCodeEvent` —
+// re-exported here (additive only) so a host that imports the SSE primitive
+// from this subpath (`@kortix/sdk/event-stream`) can reach the chat-narrowing
+// helpers from the same import without a second subpath. Canonical definition
+// lives in `./chat-events.ts`.
+export {
+  heartbeatGapEvent,
+  narrowChatEvent,
+  type KortixChatEvent,
+  type KortixChatEventConnection,
+  type KortixChatEventHeartbeatGap,
+  type KortixChatEventMessageRemoved,
+  type KortixChatEventMessageUpdated,
+  type KortixChatEventPartRemoved,
+  type KortixChatEventPartUpdated,
+  type KortixChatEventPermissionAsked,
+  type KortixChatEventPermissionReplied,
+  type KortixChatEventQuestionAnswered,
+  type KortixChatEventQuestionAsked,
+  type KortixChatEventSessionError,
+  type KortixChatEventSessionIdle,
+  type KortixChatEventSessionStatus,
+  type KortixChatEventTodoUpdated,
+  type KortixChatQuestionInfo,
+  type KortixChatQuestionOption,
+  type KortixChatToolRef,
+} from './chat-events';

--- a/packages/sdk/src/state/event-stream.ts
+++ b/packages/sdk/src/state/event-stream.ts
@@ -9,10 +9,12 @@
  * lookups) stays in the React wrapper and reaches this module only through the
  * injected `onEvent` / `onGapRehydrate` callbacks.
  *
- * Owns: connecting to the opencode SSE endpoint, the heartbeat watchdog, event
- * coalescing + 16ms flush batching, gap detection on reconnect, and the
- * exponential-backoff reconnect loop (fast 250ms resume after a healthy
- * stream, capped exponential backoff otherwise).
+ * Owns: connecting to the opencode SSE endpoint (with a connect timeout), the
+ * idle heartbeat watchdog, event coalescing + 16ms flush batching, gap
+ * detection on reconnect, the exponential-backoff reconnect loop (fast 250ms
+ * resume after an eventful stream, capped exponential backoff otherwise), and
+ * the give-up "parked" terminal state for streams pointed at dead sandboxes
+ * (see `maxConsecutiveHardFailures`/`onParked`).
  */
 
 import type { Event as OpenCodeSdkEvent } from '@opencode-ai/sdk/v2/client';
@@ -78,23 +80,77 @@ export interface OpenEventStreamOptions {
    *  calling `close()` on the returned handle). Optional — most hosts just use
    *  `close()`. */
   signal?: AbortSignal;
+  /**
+   * Max time to wait for the initial `client.global.event()` call to resolve
+   * before treating the attempt as hung, aborting it, and retrying through the
+   * normal reconnect/backoff path. Guards against a black-holed proxy that
+   * swallows the connect request silently (no error, no data, no close) —
+   * the heartbeat watchdog can't help here since it only starts AFTER connect
+   * resolves. Defaults to 20s.
+   */
+  connectTimeoutMs?: number;
+  /**
+   * Max quiet time on an ESTABLISHED stream before the heartbeat watchdog
+   * declares it dead, aborts it, and reconnects. Defaults to 60s — see the
+   * `HEARTBEAT_MS` comment for why it must stay well above any real idle gap
+   * until the server ships keepalive frames.
+   */
+  heartbeatTimeoutMs?: number;
+  /**
+   * Give-up threshold: after this many CONSECUTIVE hard failures (attempts
+   * that never delivered a single event and died to an HTTP-level error or
+   * within 2s — the signature of a dead/archived sandbox whose proxy 503s
+   * every connect), the stream stops retrying and parks (see `onParked`).
+   * Any attempt that delivers an event, or that fails slowly without an HTTP
+   * status (e.g. a connect-timeout on a black-holed proxy), resets the
+   * counter. Defaults to 8 — combined with exponential backoff (1s → 30s
+   * cap) that spreads the give-up over roughly two minutes.
+   */
+  maxConsecutiveHardFailures?: number;
+  /**
+   * Fired ONCE if the stream parks (gives up) after
+   * `maxConsecutiveHardFailures` consecutive hard failures. A parked stream
+   * is TERMINAL for this handle: no further connect attempts are made, and
+   * there is no resume — the host should treat the runtime as gone (drop the
+   * stream, surface UI) and, if it believes the sandbox is back, open a
+   * fresh stream with a new `openEventStream()` call. `close()` on a parked
+   * handle stays safe/idempotent.
+   */
+  onParked?: (reason: EventStreamParkedInfo) => void;
   /** Test-only clock/timer override. Defaults to real `Date.now`/`setTimeout`. */
   timers?: EventStreamTimers;
 }
 
+/** Payload for {@link OpenEventStreamOptions.onParked}. */
+export interface EventStreamParkedInfo {
+  /** How many consecutive hard failures triggered the park. */
+  consecutiveFailures: number;
+  /** The error from the final failed attempt (null if it ended without one). */
+  lastError: unknown;
+}
+
 export interface EventStreamHandle {
   /** Aborts the in-flight connection (if any), stops all reconnect/backoff
-   *  activity, and clears the pending coalescing flush. Idempotent. */
+   *  activity, and clears the pending coalescing flush. Idempotent — safe to
+   *  call on a stream that has already parked (see `onParked`). */
   close: () => void;
 }
 
-// ---- Tunables — copied verbatim from the original hook; behavior-preserving
-// extraction means these values (and the formulas that use them) must not
-// drift from what's live in production. ----
+// ---- Tunables ----
 const COALESCE_FLUSH_MS = 16;
 const YIELD_INTERVAL_MS = 8;
-const HEARTBEAT_MS = 15_000;
-const STABLE_CONNECTION_MS = 10_000;
+/**
+ * Idle watchdog budget for an ESTABLISHED stream. The server currently emits
+ * NO idle keepalive frames, so a healthy-but-quiet session produces genuinely
+ * long silent stretches — a budget below the real idle gap makes the watchdog
+ * kill perfectly healthy connections on a timer (the old 15s value guaranteed
+ * a kill every 15s of quiet, by design). 60s keeps the watchdog able to catch
+ * genuinely dead sockets while tolerating normal idle. When the server ships
+ * `: keepalive` comment frames this can come back down toward 2× the
+ * keepalive cadence. Configurable per-stream via
+ * `OpenEventStreamOptions.heartbeatTimeoutMs`.
+ */
+const HEARTBEAT_MS = 60_000;
 const GAP_REHYDRATE_MS = 5_000;
 const FAST_RECONNECT_DELAY_MS = 250;
 const BASE_RECONNECT_DELAY_MS = 1000;
@@ -102,6 +158,13 @@ const MAX_RECONNECT_DELAY_MS = 30_000;
 const MAX_BACKOFF_EXPONENT = 5;
 const SSE_DEFAULT_RETRY_DELAY_MS = 3000;
 const SSE_MAX_RETRY_DELAY_MS = 30_000;
+const CONNECT_TIMEOUT_MS = 20_000;
+/** An event-less attempt that dies faster than this is a "hard failure" —
+ *  the fast-503 signature of a dead sandbox — even when the error carries no
+ *  HTTP status (edge-generated failures surface as opaque network/CORS
+ *  errors). See `maxConsecutiveHardFailures`. */
+const HARD_FAILURE_WINDOW_MS = 2_000;
+const MAX_CONSECUTIVE_HARD_FAILURES = 8;
 
 /**
  * Coalescing keys — determines which events can replace earlier ones in the
@@ -149,8 +212,12 @@ function onceAborted(signal: AbortSignal): { promise: Promise<void>; cleanup: ()
  * call it directly).
  */
 export function openEventStream(opts: OpenEventStreamOptions): EventStreamHandle {
-  const { client, onEvent, onGapRehydrate, signal: externalSignal } = opts;
+  const { client, onEvent, onGapRehydrate, onParked, signal: externalSignal } = opts;
   const t = opts.timers ?? realTimers;
+  const connectTimeoutMs = opts.connectTimeoutMs ?? CONNECT_TIMEOUT_MS;
+  const heartbeatTimeoutMs = opts.heartbeatTimeoutMs ?? HEARTBEAT_MS;
+  const maxConsecutiveHardFailures =
+    opts.maxConsecutiveHardFailures ?? MAX_CONSECUTIVE_HARD_FAILURES;
 
   const abortController = new AbortController();
   const onExternalAbort = () => abortController.abort();
@@ -163,10 +230,6 @@ export function openEventStream(opts: OpenEventStreamOptions): EventStreamHandle
   // Using only "last event" causes hydrate storms when the server rotates
   // idle SSE connections that carried no events.
   let lastStreamActivityTime = t.now();
-  // Track when the stream connected and whether it delivered any events. We
-  // reset reconnect backoff only after a healthy connection (events received
-  // or sustained >10s). Brief connect→drop loops keep backoff growth.
-  let streamConnectedAt = 0;
 
   // Event coalescing queue (like the SolidJS reference)
   let queue: ({ type: string; event: OpenCodeEvent } | undefined)[] = [];
@@ -211,10 +274,19 @@ export function openEventStream(opts: OpenEventStreamOptions): EventStreamHandle
   // Consume the stream in the background with automatic retry
   (async () => {
     let retryCount = 0;
+    // Consecutive hard-failure streak — see `maxConsecutiveHardFailures`.
+    // Survives across attempts; reset by any attempt that delivered events
+    // or that failed slowly without an HTTP status.
+    let consecutiveHardFailures = 0;
     while (!abortController.signal.aborted) {
       let streamHadEvents = false;
       let stableConnection = false;
       let heartbeatTimer: EventStreamTimerHandle | undefined;
+      let connectTimer: EventStreamTimerHandle | undefined;
+      // What this attempt died to (null = clean end), plus when it started —
+      // both feed the hard-failure classification below the try block.
+      let attemptError: unknown = null;
+      const attemptStartedAt = t.now();
       // Per-attempt controller passed to the SSE client. Aborting it is what
       // actually cancels the underlying network reader — the vendor client
       // only cancels on the signal IT was handed. It aborts when EITHER the
@@ -225,25 +297,57 @@ export function openEventStream(opts: OpenEventStreamOptions): EventStreamHandle
       const outerLink = onceAborted(abortController.signal);
       outerLink.promise.then(() => attemptAbort.abort());
       try {
-        const result = await client.global.event({
-          signal: attemptAbort.signal,
-          sseDefaultRetryDelay: SSE_DEFAULT_RETRY_DELAY_MS,
-          sseMaxRetryDelay: SSE_MAX_RETRY_DELAY_MS,
+        // Race the connect call itself against `connectTimeoutMs`. A
+        // black-holed proxy can swallow this request with no error, no data,
+        // and no close — the heartbeat watchdog below only starts once this
+        // resolves, so it can't rescue a hung connect. On timeout, abort this
+        // attempt (cancels the underlying request, same as any other
+        // reconnect) and reject so it falls into the catch block below and
+        // retries through the normal backoff path, exactly like any other
+        // connect failure.
+        const result = await new Promise<{ stream: AsyncIterable<unknown> }>((resolve, reject) => {
+          let settled = false;
+          connectTimer = t.setTimeout(() => {
+            if (settled) return;
+            settled = true;
+            logger.warn('SSE connect timed out, forcing reconnect', { connectTimeoutMs });
+            attemptAbort.abort();
+            reject(new Error(`SSE connect timed out after ${connectTimeoutMs}ms`));
+          }, connectTimeoutMs);
+          client.global
+            .event({
+              signal: attemptAbort.signal,
+              sseDefaultRetryDelay: SSE_DEFAULT_RETRY_DELAY_MS,
+              sseMaxRetryDelay: SSE_MAX_RETRY_DELAY_MS,
+            })
+            .then(
+              (value) => {
+                if (settled) return;
+                settled = true;
+                t.clearTimeout(connectTimer);
+                resolve(value);
+              },
+              (err) => {
+                if (settled) return;
+                settled = true;
+                t.clearTimeout(connectTimer);
+                reject(err);
+              },
+            );
         });
         const { stream } = result;
-        streamConnectedAt = t.now();
-        lastStreamActivityTime = streamConnectedAt;
+        lastStreamActivityTime = t.now();
 
-        // Heartbeat timeout — matching the reference. If no events arrive for
-        // 15s, abort and reconnect. This is the ONLY recovery mechanism we
-        // need — replaces the stall watchdog, reconciler, and visibility
-        // handler.
+        // Heartbeat timeout — if no events arrive within the idle budget
+        // (default 60s, see HEARTBEAT_MS for why), abort and reconnect. This
+        // is the ONLY recovery mechanism we need on an established stream —
+        // replaces the stall watchdog, reconciler, and visibility handler.
         const resetHeartbeat = () => {
           t.clearTimeout(heartbeatTimer);
           heartbeatTimer = t.setTimeout(() => {
             logger.warn('SSE heartbeat timeout, forcing reconnect');
             attemptAbort.abort();
-          }, HEARTBEAT_MS);
+          }, heartbeatTimeoutMs);
         };
         resetHeartbeat();
 
@@ -297,10 +401,22 @@ export function openEventStream(opts: OpenEventStreamOptions): EventStreamHandle
           await new Promise<void>((resolve) => t.setTimeout(resolve, 0));
         }
 
-        // Healthy stream if it delivered events, or if it stayed open for >10s.
-        stableConnection = streamHadEvents || t.now() - streamConnectedAt > STABLE_CONNECTION_MS;
+        // Healthy stream ONLY if it actually delivered events. There used to
+        // be a time-based OR-branch here ("or stayed open >10s") — that was a
+        // prod reconnect storm: anything that kills idle connections on a
+        // period ABOVE that threshold (our own heartbeat watchdog, an idle
+        // proxy timeout, server-side rotation) made every idle disconnect
+        // look "stable", which reset retryCount and locked the loop into the
+        // 250ms fast-reconnect path forever (~236 reconnects/hour/stream).
+        // An idle disconnect — watchdog-triggered or natural — must ride the
+        // exponential backoff (1s → 30s cap) instead; the moment a
+        // reconnected stream delivers a real event, backoff resets and the
+        // fast path returns. Missed-while-waiting events are covered by the
+        // gap-rehydrate signal below.
+        stableConnection = streamHadEvents;
       } catch (err) {
         if (abortController.signal.aborted) break;
+        attemptError = err;
         const errStr = String(err);
         const isAuthError =
           errStr.includes('401') ||
@@ -329,6 +445,7 @@ export function openEventStream(opts: OpenEventStreamOptions): EventStreamHandle
         }
       } finally {
         t.clearTimeout(heartbeatTimer);
+        t.clearTimeout(connectTimer);
         // Release the reader/connection if we left the loop for any reason
         // other than an already-fired abort (e.g. stream `done`, or a thrown
         // error), and detach the outer-abort listener so it can't accumulate
@@ -344,6 +461,41 @@ export function openEventStream(opts: OpenEventStreamOptions): EventStreamHandle
       // first retry to avoid reconnection storms when the server is flapping
       // (connect → immediate disconnect loops).
       if (abortController.signal.aborted) break;
+
+      // ── Give-up (park) check — the "dead sandbox" terminal state. ────────
+      // A stream pointed at an archived/stopped session's sandbox otherwise
+      // retries FOREVER: the proxy 503s every `/global/event` connect, and
+      // prod showed continuous 503 loops from several dead sandboxes at once.
+      // Classify this attempt: a HARD failure delivered zero events AND
+      // either carried an HTTP-level status (the vendor client wraps non-2xx
+      // as `Error` with `cause: { status }` — see @opencode-ai/sdk's
+      // error-interceptor) or died within HARD_FAILURE_WINDOW_MS (edge 503s
+      // surface as opaque network/CORS errors with no status attached).
+      // Slow failures without a status (a black-holed connect that hit the
+      // 20s connect timeout) and anything that streamed a real event reset
+      // the streak. After `maxConsecutiveHardFailures` in a row — spread
+      // over ~2 minutes by the exponential backoff below — park for good.
+      const attemptDurationMs = t.now() - attemptStartedAt;
+      const httpStatus = (attemptError as { cause?: { status?: unknown } } | null)?.cause?.status;
+      const isHardFailure =
+        !streamHadEvents &&
+        ((typeof httpStatus === 'number' && httpStatus >= 400) ||
+          attemptDurationMs < HARD_FAILURE_WINDOW_MS);
+      consecutiveHardFailures = isHardFailure ? consecutiveHardFailures + 1 : 0;
+      if (consecutiveHardFailures >= maxConsecutiveHardFailures) {
+        logger.error('SSE event stream parked — giving up after consecutive hard failures', {
+          consecutiveFailures: consecutiveHardFailures,
+          lastError: String(attemptError),
+        });
+        try {
+          onParked?.({ consecutiveFailures: consecutiveHardFailures, lastError: attemptError });
+        } catch (parkedHandlerErr) {
+          // A host's park handler must never crash the (already-terminal)
+          // stream machine.
+          console.warn('[opencode-events] onParked handler threw', parkedHandlerErr);
+        }
+        break;
+      }
 
       // Re-hydrate messages for loaded sessions when the SSE gap was
       // significant (>5s). Events missed during the gap (e.g. streaming

--- a/packages/sdk/src/state/server-store/active.test.ts
+++ b/packages/sdk/src/state/server-store/active.test.ts
@@ -1,0 +1,143 @@
+import { test, expect, beforeEach, afterEach } from 'bun:test';
+import { configureKortix } from '../../platform/config';
+import { setCurrentRuntime } from '../current-runtime';
+
+// This file must be hermetic against `mock.module(...)` registrations OTHER
+// files make for this exact module (`state/server-store/active`) — Bun's
+// `mock.module` is process-wide and permanent for the whole `bun test` sweep,
+// and (confirmed empirically) it collides bidirectionally through the
+// `export { getActiveOpenCodeUrl, ... } from './server-store/active'`
+// re-export chain in `../server-store.ts`: mocking EITHER the barrel
+// (`../server-store`, as `files/client.test.ts` used to) OR this submodule
+// directly (as `opencode/client.test.ts` used to) replaced this module's real
+// exports for every other importer too, including a plain static
+// `import ... from './active'` here (which would crash with "Export named
+// '...' not found" once some export the mock omitted got statically linked).
+// Both of those files were fixed to drive their test scenarios through the
+// REAL `current-runtime`/`config` seams instead (see their own comments) —
+// this file additionally imports dynamically via `await import(...)` as a
+// second layer of defense against any future file re-introducing that
+// pattern.
+const {
+  deriveSubdomainOpts,
+  getActiveDbSandboxId,
+  getActiveOpenCodeUrl,
+  getActiveSandboxId,
+  getBackendPort,
+} = await import('./active');
+
+// Both `platformConfig()` (process-global `current`) and the current-runtime
+// pointer are module-level singletons — reset both around every test so this
+// file's experiments never leak into (or get leaked into by) another test file
+// sharing the same `bun test` process.
+beforeEach(() => {
+  setCurrentRuntime(null);
+});
+afterEach(() => {
+  setCurrentRuntime(null);
+});
+
+test('getActiveOpenCodeUrl prefers the current-runtime url when a session is active', () => {
+  configureKortix({ backendUrl: 'http://backend.local/v1', getToken: async () => 'tok', billingEnabled: false });
+  setCurrentRuntime('http://backend.local/v1/p/sb-1/8000', 'sb-1');
+
+  expect(getActiveOpenCodeUrl()).toBe('http://backend.local/v1/p/sb-1/8000');
+});
+
+test('getActiveOpenCodeUrl falls back to the default sandbox url in self-hosted local dev (no billing, no active session)', () => {
+  configureKortix({
+    backendUrl: 'http://backend.local/v1',
+    getToken: async () => 'tok',
+    billingEnabled: false,
+    sandboxId: 'local-sbx',
+  });
+
+  expect(getActiveOpenCodeUrl()).toBe('http://backend.local/v1/p/local-sbx/8000');
+});
+
+test('getActiveOpenCodeUrl returns empty string in a billing-enabled deployment with no active session', () => {
+  configureKortix({
+    backendUrl: 'http://backend.local/v1',
+    getToken: async () => 'tok',
+    billingEnabled: true,
+    sandboxId: 'should-be-ignored',
+  });
+
+  expect(getActiveOpenCodeUrl()).toBe('');
+});
+
+test('getActiveOpenCodeUrl treats an unset billingEnabled as false (defaults to the self-hosted fallback)', () => {
+  configureKortix({ backendUrl: 'http://backend.local/v1', getToken: async () => 'tok', sandboxId: 'sbx-1' });
+
+  expect(getActiveOpenCodeUrl()).toBe('http://backend.local/v1/p/sbx-1/8000');
+});
+
+test('getActiveSandboxId prefers the current-runtime sandbox id over the configured default', () => {
+  configureKortix({ backendUrl: 'http://backend.local/v1', getToken: async () => 'tok', sandboxId: 'configured-default' });
+  setCurrentRuntime('http://backend.local/v1/p/sb-active/8000', 'sb-active');
+
+  expect(getActiveSandboxId()).toBe('sb-active');
+});
+
+test('getActiveSandboxId falls back to the configured default sandbox id with no active session', () => {
+  configureKortix({ backendUrl: 'http://backend.local/v1', getToken: async () => 'tok', sandboxId: 'configured-default' });
+
+  expect(getActiveSandboxId()).toBe('configured-default');
+});
+
+test('getActiveSandboxId returns undefined with neither an active session nor a configured default', () => {
+  configureKortix({ backendUrl: 'http://backend.local/v1', getToken: async () => 'tok' });
+
+  expect(getActiveSandboxId()).toBeUndefined();
+});
+
+test('getActiveDbSandboxId returns the current-runtime db sandbox id while a session is active', () => {
+  setCurrentRuntime('http://backend.local/v1/p/sb-1/8000', 'sb-1', 'db-sbx-1');
+
+  expect(getActiveDbSandboxId()).toBe('db-sbx-1');
+});
+
+test('getActiveDbSandboxId returns undefined with no active session runtime', () => {
+  expect(getActiveDbSandboxId()).toBeUndefined();
+});
+
+test('getBackendPort extracts the numeric port from the configured backend url', () => {
+  configureKortix({ backendUrl: 'http://localhost:8008/v1', getToken: async () => 'tok' });
+
+  expect(getBackendPort()).toBe(8008);
+});
+
+test('getBackendPort defaults to 443 for an https url with no explicit port', () => {
+  configureKortix({ backendUrl: 'https://api.kortix.example/v1', getToken: async () => 'tok' });
+
+  expect(getBackendPort()).toBe(443);
+});
+
+test('getBackendPort defaults to 80 for an http url with no explicit port', () => {
+  configureKortix({ backendUrl: 'http://api.kortix.example/v1', getToken: async () => 'tok' });
+
+  expect(getBackendPort()).toBe(80);
+});
+
+test('getBackendPort falls back to 8008 when the configured backend url fails to parse', () => {
+  configureKortix({ backendUrl: 'not a url', getToken: async () => 'tok' });
+
+  expect(getBackendPort()).toBe(8008);
+});
+
+test('deriveSubdomainOpts always returns a fully-populated options object', () => {
+  configureKortix({ backendUrl: 'http://localhost:8008/v1', getToken: async () => 'tok' });
+  setCurrentRuntime('http://localhost:8008/v1/p/sb-1/8000', 'sb-1');
+
+  expect(deriveSubdomainOpts()).toEqual({
+    sandboxId: 'sb-1',
+    backendPort: 8008,
+    apiBaseUrl: 'http://localhost:8008/v1',
+  });
+});
+
+test('deriveSubdomainOpts uses an empty-string sandboxId (never undefined) when none is resolvable', () => {
+  configureKortix({ backendUrl: 'http://localhost:8008/v1', getToken: async () => 'tok' });
+
+  expect(deriveSubdomainOpts().sandboxId).toBe('');
+});

--- a/packages/sdk/src/state/server-store/url-helpers.ts
+++ b/packages/sdk/src/state/server-store/url-helpers.ts
@@ -1,11 +1,19 @@
 import { platformConfig } from '../../platform/config';
 
+// Linear trailing-slash strip — the regex form (/\/+$/) backtracks
+// quadratically on adversarial input (CodeQL js/polynomial-redos).
+function stripTrailingSlashes(s: string): string {
+  let end = s.length;
+  while (end > 0 && s.charCodeAt(end - 1) === 47 /* '/' */) end--;
+  return s.slice(0, end);
+}
+
 /**
  * The backend base URL. All sandbox traffic routes through the backend's
  * unified preview proxy: /v1/p/{sandboxId}/{port}/*
  */
 export function getBackendUrl(): string {
-  return (platformConfig().backendUrl || 'http://localhost:8008/v1').replace(/\/+$/, '');
+  return stripTrailingSlashes(platformConfig().backendUrl || 'http://localhost:8008/v1');
 }
 
 export function getDefaultSandboxUrl(): string {

--- a/packages/sdk/src/state/session-runtime-registry.test.ts
+++ b/packages/sdk/src/state/session-runtime-registry.test.ts
@@ -81,3 +81,129 @@ test('clearSessionRuntime removes the entry (restart/delete invalidation)', () =
 test('clearSessionRuntime on an unregistered session is a no-op (never throws)', () => {
   expect(() => clearSessionRuntime('proj-never', 'sess-never')).not.toThrow();
 });
+
+// ─────────────────────────────────────────────────────────────────────────
+// Bounded LRU (max 512 entries)
+// ─────────────────────────────────────────────────────────────────────────
+
+const MAX_ENTRIES = 512;
+
+function fillEntry(i: number) {
+  return {
+    opencodeSessionId: `ocs-${i}`,
+    runtimeUrl: `http://backend.test/p/sb-${i}/8000`,
+    sandboxId: `sb-${i}`,
+  };
+}
+
+function fillRegistry(projectId: string, count: number, offset = 0) {
+  for (let i = offset; i < offset + count; i++) {
+    setSessionRuntime(projectId, `sess-lru-${i}`, fillEntry(i));
+  }
+}
+
+function clearRegistry(projectId: string, count: number, offset = 0) {
+  for (let i = offset; i < offset + count; i++) {
+    clearSessionRuntime(projectId, `sess-lru-${i}`);
+  }
+}
+
+test('inserting beyond the cap evicts the oldest (least-recently-touched) entry first', () => {
+  const PROJ = 'proj-lru-evict';
+  try {
+    fillRegistry(PROJ, MAX_ENTRIES);
+    // Registry is now exactly at the cap; every entry present.
+    expect(getSessionRuntime(PROJ, 'sess-lru-0')).toBeDefined();
+
+    // One more insert must evict the oldest untouched entry (index 0), since
+    // reading it above via getSessionRuntime touched it... so instead verify
+    // with a fresh untouched oldest entry: index 1 was never read, so it's
+    // now the least-recently-used and should be evicted next.
+    setSessionRuntime(PROJ, 'sess-lru-overflow', fillEntry(999_001));
+
+    // index 0 was touched by the read above, so it survives.
+    expect(getSessionRuntime(PROJ, 'sess-lru-0')).toBeDefined();
+    // index 1 was never touched and was the oldest remaining — evicted.
+    expect(getSessionRuntime(PROJ, 'sess-lru-1')).toBeUndefined();
+    // the new entry is present.
+    expect(getSessionRuntime(PROJ, 'sess-lru-overflow')).toBeDefined();
+  } finally {
+    clearRegistry(PROJ, MAX_ENTRIES);
+    clearSessionRuntime(PROJ, 'sess-lru-overflow');
+  }
+});
+
+test('getSessionRuntime (read) touches an entry, protecting it from being the next eviction', () => {
+  const PROJ = 'proj-lru-touch';
+  try {
+    fillRegistry(PROJ, MAX_ENTRIES);
+
+    // Touch the very oldest entry (index 0) via a read, promoting it to MRU.
+    expect(getSessionRuntime(PROJ, 'sess-lru-0')).toBeDefined();
+
+    // Next insert should now evict index 1 (the new oldest), not index 0.
+    setSessionRuntime(PROJ, 'sess-lru-touch-overflow', fillEntry(999_002));
+
+    expect(getSessionRuntime(PROJ, 'sess-lru-0')).toBeDefined();
+    expect(getSessionRuntime(PROJ, 'sess-lru-1')).toBeUndefined();
+  } finally {
+    clearRegistry(PROJ, MAX_ENTRIES);
+    clearSessionRuntime(PROJ, 'sess-lru-touch-overflow');
+  }
+});
+
+test('re-setting an existing key updates it in place without evicting anything (cap not exceeded)', () => {
+  const PROJ = 'proj-lru-reset';
+  try {
+    fillRegistry(PROJ, MAX_ENTRIES);
+
+    // Overwrite an existing key — size stays at the cap, nothing should be evicted.
+    setSessionRuntime(PROJ, 'sess-lru-5', fillEntry(999_003));
+    expect(getSessionRuntime(PROJ, 'sess-lru-5')).toEqual(fillEntry(999_003));
+
+    // Every other original entry (besides the one just touched via the
+    // assertion above) should still be present — no eviction occurred.
+    expect(getSessionRuntime(PROJ, 'sess-lru-0')).toBeDefined();
+    expect(getSessionRuntime(PROJ, 'sess-lru-1')).toBeDefined();
+    expect(getSessionRuntime(PROJ, `sess-lru-${MAX_ENTRIES - 1}`)).toBeDefined();
+  } finally {
+    clearRegistry(PROJ, MAX_ENTRIES);
+  }
+});
+
+test('the cap is respected across many overflows — size never exceeds MAX_ENTRIES', () => {
+  const PROJ = 'proj-lru-cap';
+  try {
+    // Insert 2x the cap; only the most recent MAX_ENTRIES should remain.
+    fillRegistry(PROJ, MAX_ENTRIES * 2);
+
+    let present = 0;
+    for (let i = 0; i < MAX_ENTRIES * 2; i++) {
+      if (getSessionRuntime(PROJ, `sess-lru-${i}`) !== undefined) present++;
+    }
+    expect(present).toBe(MAX_ENTRIES);
+
+    // The first half (oldest) should all be gone; the second half (newest) all present.
+    expect(getSessionRuntime(PROJ, 'sess-lru-0')).toBeUndefined();
+    expect(getSessionRuntime(PROJ, `sess-lru-${MAX_ENTRIES * 2 - 1}`)).toBeDefined();
+  } finally {
+    clearRegistry(PROJ, MAX_ENTRIES * 2);
+  }
+});
+
+test('explicit clearSessionRuntime still works once the registry is at/near capacity', () => {
+  const PROJ = 'proj-lru-clear';
+  try {
+    fillRegistry(PROJ, MAX_ENTRIES);
+    clearSessionRuntime(PROJ, 'sess-lru-10');
+    expect(getSessionRuntime(PROJ, 'sess-lru-10')).toBeUndefined();
+
+    // Clearing frees a slot — inserting one more should NOT evict anything else.
+    setSessionRuntime(PROJ, 'sess-lru-after-clear', fillEntry(999_004));
+    expect(getSessionRuntime(PROJ, 'sess-lru-after-clear')).toBeDefined();
+    expect(getSessionRuntime(PROJ, 'sess-lru-0')).toBeDefined();
+  } finally {
+    clearRegistry(PROJ, MAX_ENTRIES);
+    clearSessionRuntime(PROJ, 'sess-lru-after-clear');
+  }
+});

--- a/packages/sdk/src/state/session-runtime-registry.ts
+++ b/packages/sdk/src/state/session-runtime-registry.ts
@@ -34,6 +34,25 @@ export interface SessionRuntimeEntry {
   sandboxId: string;
 }
 
+/**
+ * Bound on live entries. A long-lived server process juggling many short
+ * sessions would otherwise grow this map forever (nothing but explicit
+ * restart/delete/stop ever removed an entry). Eviction is safe by
+ * construction: an evicted entry is indistinguishable from a session whose
+ * runtime was simply never resolved yet — `tryResolveReady()` in
+ * `kortix.ts` treats a registry miss as "not cached", falling back to
+ * `ensureReady()` → `startProjectSession`, which re-resolves (and
+ * re-populates) the entry. No consumer treats a miss as an error on its own;
+ * `requireReady()` is the only place a miss becomes a thrown
+ * `SessionNotReadyError`, and that's the pre-existing behavior for any
+ * session whose runtime hasn't been resolved by ANY handle yet.
+ */
+const MAX_ENTRIES = 512;
+
+// Map iteration order is insertion order, so re-inserting a key (via
+// `delete` + `set`) on every read/write is what gives us LRU-by-recency:
+// the least-recently-touched entry is always the first one `.keys()`
+// yields, which is exactly what we evict on overflow.
 const registry = new Map<string, SessionRuntimeEntry>();
 
 /** Key a registry entry by the (projectId, sessionId) pair it belongs to. */
@@ -41,21 +60,39 @@ function registryKey(projectId: string, sessionId: string): string {
   return `${projectId}::${sessionId}`;
 }
 
+/** Move `key` to the most-recently-used end of the map (re-insert). */
+function touch(key: string, entry: SessionRuntimeEntry): void {
+  registry.delete(key);
+  registry.set(key, entry);
+}
+
 /** Read a session's last-resolved runtime, if any handle has resolved it. */
 export function getSessionRuntime(
   projectId: string,
   sessionId: string,
 ): SessionRuntimeEntry | undefined {
-  return registry.get(registryKey(projectId, sessionId));
+  const key = registryKey(projectId, sessionId);
+  const entry = registry.get(key);
+  if (entry) touch(key, entry);
+  return entry;
 }
 
-/** Record a session's resolved runtime so other handles can adopt it. */
+/**
+ * Record a session's resolved runtime so other handles can adopt it. Evicts
+ * the least-recently-used entry first if inserting a NEW key would push the
+ * registry past `MAX_ENTRIES` — see the eviction-safety note above.
+ */
 export function setSessionRuntime(
   projectId: string,
   sessionId: string,
   entry: SessionRuntimeEntry,
 ): void {
-  registry.set(registryKey(projectId, sessionId), entry);
+  const key = registryKey(projectId, sessionId);
+  if (!registry.has(key) && registry.size >= MAX_ENTRIES) {
+    const oldestKey = registry.keys().next().value;
+    if (oldestKey !== undefined) registry.delete(oldestKey);
+  }
+  touch(key, entry);
 }
 
 /**

--- a/packages/sdk/src/state/sync-store.test.ts
+++ b/packages/sdk/src/state/sync-store.test.ts
@@ -1,0 +1,443 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type {
+	AssistantMessage,
+	Message,
+	Part,
+	TextPart,
+	UserMessage,
+} from "@opencode-ai/sdk/v2/client";
+import { ascendingId, Binary, useSyncStore } from "./sync-store";
+
+// ============================================================================
+// Fixtures — minimal-but-valid Message/Part objects matching the real SDK
+// shapes (every required field populated) so tests exercise the same
+// discriminated-union narrowing the store's own code relies on.
+// ============================================================================
+
+function userMessage(id: string, sessionID = "ses_1"): UserMessage {
+	return {
+		id,
+		sessionID,
+		role: "user",
+		time: { created: 1 },
+		agent: "build",
+		model: { providerID: "anthropic", modelID: "claude" },
+	};
+}
+
+function assistantMessage(id: string, sessionID = "ses_1"): AssistantMessage {
+	return {
+		id,
+		sessionID,
+		role: "assistant",
+		time: { created: 1 },
+		parentID: "msg_parent",
+		modelID: "claude",
+		providerID: "anthropic",
+		mode: "build",
+		agent: "build",
+		path: { cwd: "/", root: "/" },
+		cost: 0,
+		tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+	};
+}
+
+function textPart(id: string, messageID: string, text: string, sessionID = "ses_1"): TextPart {
+	return { id, sessionID, messageID, type: "text", text };
+}
+
+// ============================================================================
+// Store reset between tests — the module-level optimistic/bridge/delta
+// tracking sets aren't exposed, but `reset()` clears the store's own state
+// and (per its implementation) the optimistic/bridged id sets too.
+// ============================================================================
+
+beforeEach(() => {
+	useSyncStore.getState().reset();
+});
+
+describe("Binary.search", () => {
+	test("finds an existing id and reports its index", () => {
+		const items = [{ id: "a" }, { id: "b" }, { id: "c" }];
+		const result = Binary.search(items, "b", (i) => i.id);
+		expect(result).toEqual({ found: true, index: 1 });
+	});
+
+	test("reports the correct sorted-insertion index for a missing id", () => {
+		const items = [{ id: "a" }, { id: "c" }, { id: "e" }];
+		expect(Binary.search(items, "b", (i) => i.id)).toEqual({ found: false, index: 1 });
+		expect(Binary.search(items, "f", (i) => i.id)).toEqual({ found: false, index: 3 });
+		expect(Binary.search(items, "0", (i) => i.id)).toEqual({ found: false, index: 0 });
+	});
+
+	test("empty array reports not-found at index 0", () => {
+		expect(Binary.search([], "x", (i: { id: string }) => i.id)).toEqual({
+			found: false,
+			index: 0,
+		});
+	});
+});
+
+describe("ascendingId", () => {
+	test("prefixes ids with the given prefix", () => {
+		expect(ascendingId("msg")).toMatch(/^msg_/);
+		expect(ascendingId("prt")).toMatch(/^prt_/);
+		expect(ascendingId()).toMatch(/^msg_/); // defaults to 'msg'
+	});
+
+	test("generates ids that sort in creation order across distinct timestamps", async () => {
+		// The encoded timestamp+counter is hex-truncated to 12 chars, so
+		// strict lexicographic order across a tight synchronous loop (many
+		// ids sharing one `Date.now()` millisecond) isn't guaranteed — only
+		// across calls separated in real time, which is the actual use case
+		// (message/part ids created as events arrive, not batch-generated).
+		const ids: string[] = [];
+		for (let i = 0; i < 8; i++) {
+			ids.push(ascendingId("msg"));
+			await new Promise((resolve) => setTimeout(resolve, 5));
+		}
+		const sorted = [...ids].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+		expect(ids).toEqual(sorted);
+	});
+
+	test("never repeats an id even when called synchronously in a tight loop", () => {
+		const ids = new Set(Array.from({ length: 200 }, () => ascendingId("prt")));
+		expect(ids.size).toBe(200);
+	});
+});
+
+describe("useSyncStore — upsertMessage (ascending-id-ordered inserts)", () => {
+	test("inserts messages sorted by id, not by call order", () => {
+		const store = useSyncStore.getState();
+		store.upsertMessage("ses_1", userMessage("msg_b"));
+		store.upsertMessage("ses_1", userMessage("msg_a"));
+		store.upsertMessage("ses_1", userMessage("msg_c"));
+
+		const ids = useSyncStore.getState().messages.ses_1.map((m) => m.id);
+		expect(ids).toEqual(["msg_a", "msg_b", "msg_c"]);
+	});
+
+	test("updates an existing message in place instead of duplicating it", () => {
+		const store = useSyncStore.getState();
+		store.upsertMessage("ses_1", userMessage("msg_a"));
+		const updated = { ...userMessage("msg_a"), agent: "plan" };
+		store.upsertMessage("ses_1", updated);
+
+		const msgs = useSyncStore.getState().messages.ses_1;
+		expect(msgs).toHaveLength(1);
+		expect((msgs[0] as UserMessage).agent).toBe("plan");
+	});
+
+	test("removeMessage drops the message and its parts", () => {
+		const store = useSyncStore.getState();
+		store.upsertMessage("ses_1", userMessage("msg_a"));
+		store.upsertPart("msg_a", textPart("prt_1", "msg_a", "hello"));
+		store.removeMessage("ses_1", "msg_a");
+
+		expect(useSyncStore.getState().messages.ses_1).toEqual([]);
+		expect(useSyncStore.getState().parts.msg_a).toBeUndefined();
+	});
+});
+
+describe("useSyncStore — upsertPart / removePart (append + update)", () => {
+	test("appends a new part in sorted position", () => {
+		const store = useSyncStore.getState();
+		store.upsertPart("msg_1", textPart("prt_b", "msg_1", "second"));
+		store.upsertPart("msg_1", textPart("prt_a", "msg_1", "first"));
+
+		const ids = useSyncStore.getState().parts.msg_1.map((p) => p.id);
+		expect(ids).toEqual(["prt_a", "prt_b"]);
+	});
+
+	test("updates an existing part (monotonic prefix growth) in place", () => {
+		const store = useSyncStore.getState();
+		store.upsertPart("msg_1", textPart("prt_1", "msg_1", "Hel"));
+		store.upsertPart("msg_1", textPart("prt_1", "msg_1", "Hello"));
+
+		const parts = useSyncStore.getState().parts.msg_1;
+		expect(parts).toHaveLength(1);
+		expect((parts[0] as TextPart).text).toBe("Hello");
+	});
+
+	test("rejects a non-prefix-growth text snapshot (stale/out-of-order update)", () => {
+		const store = useSyncStore.getState();
+		store.upsertPart("msg_1", textPart("prt_1", "msg_1", "Hello world"));
+		// A shorter, non-prefix snapshot arriving after — e.g. a stale
+		// message.part.updated racing behind streamed deltas — must be dropped.
+		store.upsertPart("msg_1", textPart("prt_1", "msg_1", "Hel"));
+
+		const parts = useSyncStore.getState().parts.msg_1;
+		expect((parts[0] as TextPart).text).toBe("Hello world");
+	});
+
+	test("accepts a prefix-growth update that extends the existing text", () => {
+		const store = useSyncStore.getState();
+		store.upsertPart("msg_1", textPart("prt_1", "msg_1", "Hello"));
+		store.upsertPart("msg_1", textPart("prt_1", "msg_1", "Hello world"));
+
+		expect((useSyncStore.getState().parts.msg_1[0] as TextPart).text).toBe("Hello world");
+	});
+
+	test("removePart deletes a single part and cleans up an empty parts bucket", () => {
+		const store = useSyncStore.getState();
+		store.upsertPart("msg_1", textPart("prt_1", "msg_1", "only part"));
+		store.removePart("msg_1", "prt_1");
+
+		expect(useSyncStore.getState().parts.msg_1).toBeUndefined();
+	});
+
+	test("applyPartDelta appends text incrementally onto an existing part", () => {
+		const store = useSyncStore.getState();
+		store.upsertPart("msg_1", textPart("prt_1", "msg_1", "Hel"));
+		store.applyPartDelta("msg_1", "prt_1", "text", "lo");
+		store.applyPartDelta("msg_1", "prt_1", "text", " world");
+
+		expect((useSyncStore.getState().parts.msg_1[0] as TextPart).text).toBe("Hello world");
+	});
+});
+
+describe("useSyncStore — getMessages selector", () => {
+	test("joins messages with their parts", () => {
+		const store = useSyncStore.getState();
+		store.upsertMessage("ses_1", userMessage("msg_a"));
+		store.upsertPart("msg_a", textPart("prt_1", "msg_a", "hi"));
+
+		const joined = useSyncStore.getState().getMessages("ses_1");
+		expect(joined).toHaveLength(1);
+		expect(joined[0].info.id).toBe("msg_a");
+		expect(joined[0].parts).toHaveLength(1);
+	});
+
+	test("returns an empty array for a session with no messages", () => {
+		expect(useSyncStore.getState().getMessages("nope")).toEqual([]);
+	});
+});
+
+describe("useSyncStore — applyEvent(session.error) patches the last assistant message", () => {
+	test("patches .error onto the last assistant message", () => {
+		const store = useSyncStore.getState();
+		store.upsertMessage("ses_1", userMessage("msg_a"));
+		store.upsertMessage("ses_1", assistantMessage("msg_b"));
+
+		store.applyEvent({
+			id: "evt_1",
+			type: "session.error",
+			properties: { sessionID: "ses_1", error: { name: "UnknownError", data: { message: "boom" } } },
+		} as never);
+
+		const msgs = useSyncStore.getState().messages.ses_1;
+		const assistant = msgs.find((m) => m.role === "assistant") as AssistantMessage;
+		expect(assistant.error).toEqual({ name: "UnknownError", data: { message: "boom" } });
+		// Errors terminate the response — status flips to idle.
+		expect(useSyncStore.getState().sessionStatus.ses_1).toEqual({ type: "idle" });
+	});
+
+	test("creates a stub assistant message when none exists yet", () => {
+		const store = useSyncStore.getState();
+		store.applyEvent({
+			id: "evt_1",
+			type: "session.error",
+			properties: { sessionID: "ses_2", error: { name: "UnknownError", data: { message: "boom" } } },
+		} as never);
+
+		const msgs = useSyncStore.getState().messages.ses_2;
+		expect(msgs).toHaveLength(1);
+		expect(msgs[0].role).toBe("assistant");
+		expect((msgs[0] as AssistantMessage).error).toEqual({
+			name: "UnknownError",
+			data: { message: "boom" },
+		});
+	});
+
+	test("does not overwrite an already-errored assistant message", () => {
+		const store = useSyncStore.getState();
+		const errored: AssistantMessage = {
+			...assistantMessage("msg_b"),
+			error: { name: "UnknownError", data: { message: "first" } } as never,
+		};
+		store.upsertMessage("ses_1", errored);
+
+		store.applyEvent({
+			id: "evt_1",
+			type: "session.error",
+			properties: { sessionID: "ses_1", error: { name: "UnknownError", data: { message: "second" } } },
+		} as never);
+
+		const assistant = useSyncStore.getState().messages.ses_1[0] as AssistantMessage;
+		expect((assistant.error as { data: { message: string } }).data.message).toBe("first");
+	});
+});
+
+describe("useSyncStore — applyEvent(message.part.delta) creates a stub part + message", () => {
+	test("auto-creates the assistant message + part so a delta before message.part.updated still renders", () => {
+		const store = useSyncStore.getState();
+		store.upsertMessage("ses_1", userMessage("msg_user"));
+
+		store.applyEvent({
+			id: "evt_1",
+			type: "message.part.delta",
+			properties: {
+				messageID: "msg_asst",
+				partID: "prt_1",
+				sessionID: "ses_1",
+				field: "text",
+				delta: "Hello",
+			},
+		} as never);
+
+		const msgs = useSyncStore.getState().messages.ses_1;
+		expect(msgs.some((m) => m.id === "msg_asst" && m.role === "assistant")).toBe(true);
+		expect((useSyncStore.getState().parts.msg_asst[0] as TextPart).text).toBe("Hello");
+	});
+
+	test("does not create a stub assistant message before any user message exists", () => {
+		const store = useSyncStore.getState();
+		store.applyEvent({
+			id: "evt_1",
+			type: "message.part.delta",
+			properties: {
+				messageID: "msg_asst",
+				partID: "prt_1",
+				sessionID: "ses_1",
+				field: "text",
+				delta: "Hello",
+			},
+		} as never);
+
+		expect(useSyncStore.getState().messages.ses_1 ?? []).toEqual([]);
+		// The part is still tracked as an orphan, ready to be picked up once
+		// hydrate()/message.part.updated creates the real message.
+		expect((useSyncStore.getState().parts.msg_asst[0] as TextPart).text).toBe("Hello");
+	});
+});
+
+describe("useSyncStore — reset", () => {
+	test("clears all session state", () => {
+		const store = useSyncStore.getState();
+		store.upsertMessage("ses_1", userMessage("msg_a"));
+		store.setDiff("ses_1", []);
+		store.setTodo("ses_1", []);
+		store.reset();
+
+		const s = useSyncStore.getState();
+		expect(s.messages).toEqual({});
+		expect(s.parts).toEqual({});
+		expect(s.sessionStatus).toEqual({});
+		expect(s.diffs).toEqual({});
+		expect(s.todos).toEqual({});
+	});
+});
+
+// ============================================================================
+// stream-cache — writeStreamCache() is a side effect of the sync store's
+// message.part.updated / message.part.delta handling. `window`/`sessionStorage`
+// don't exist in bun's default test environment, so both are stubbed here.
+// ============================================================================
+
+class MemoryStorage {
+	private map = new Map<string, string>();
+	getItem(key: string): string | null {
+		return this.map.has(key) ? (this.map.get(key) ?? null) : null;
+	}
+	setItem(key: string, value: string): void {
+		this.map.set(key, value);
+	}
+	removeItem(key: string): void {
+		this.map.delete(key);
+	}
+	clear(): void {
+		this.map.clear();
+	}
+}
+
+interface GlobalWithDom {
+	window?: unknown;
+	sessionStorage?: Storage;
+}
+
+describe("stream-cache (via applyEvent message.part.updated / message.part.delta)", () => {
+	beforeEach(() => {
+		(globalThis as GlobalWithDom).window = {};
+		(globalThis as GlobalWithDom).sessionStorage = new MemoryStorage() as unknown as Storage;
+	});
+
+	afterEach(() => {
+		delete (globalThis as GlobalWithDom).window;
+		delete (globalThis as GlobalWithDom).sessionStorage;
+	});
+
+	function readCache(sessionID: string): { messageID: string; partID: string; text: string } | null {
+		const raw = sessionStorage.getItem(`opencode_stream_cache:${sessionID}`);
+		return raw ? JSON.parse(raw) : null;
+	}
+
+	test("message.part.updated with a text part writes the streamed text to sessionStorage", () => {
+		const store = useSyncStore.getState();
+		store.upsertMessage("ses_1", assistantMessage("msg_a"));
+
+		store.applyEvent({
+			id: "evt_1",
+			type: "message.part.updated",
+			properties: {
+				sessionID: "ses_1",
+				time: Date.now(),
+				part: textPart("prt_1", "msg_a", "Hello there"),
+			},
+		} as never);
+
+		const cached = readCache("ses_1");
+		expect(cached?.text).toBe("Hello there");
+		expect(cached?.messageID).toBe("msg_a");
+		expect(cached?.partID).toBe("prt_1");
+	});
+
+	test("message.part.delta accumulates text and writes the running total to sessionStorage", () => {
+		const store = useSyncStore.getState();
+		store.upsertMessage("ses_1", userMessage("msg_user"));
+
+		store.applyEvent({
+			id: "evt_1",
+			type: "message.part.delta",
+			properties: {
+				messageID: "msg_asst",
+				partID: "prt_1",
+				sessionID: "ses_1",
+				field: "text",
+				delta: "Hel",
+			},
+		} as never);
+		store.applyEvent({
+			id: "evt_2",
+			type: "message.part.delta",
+			properties: {
+				messageID: "msg_asst",
+				partID: "prt_1",
+				sessionID: "ses_1",
+				field: "text",
+				delta: "lo",
+			},
+		} as never);
+
+		expect(readCache("ses_1")?.text).toBe("Hello");
+	});
+
+	test("a shorter cached entry is overwritten, but a longer one already cached is kept (writeStreamCache's own guard)", () => {
+		const store = useSyncStore.getState();
+		store.upsertMessage("ses_1", assistantMessage("msg_a"));
+
+		store.applyEvent({
+			id: "evt_1",
+			type: "message.part.updated",
+			properties: { sessionID: "ses_1", time: Date.now(), part: textPart("prt_1", "msg_a", "Hello world") },
+		} as never);
+		expect(readCache("ses_1")?.text).toBe("Hello world");
+
+		// A stale, shorter snapshot for the SAME part must not regress the cache.
+		store.applyEvent({
+			id: "evt_2",
+			type: "message.part.updated",
+			properties: { sessionID: "ses_1", time: Date.now(), part: textPart("prt_1", "msg_a", "Hello") },
+		} as never);
+		expect(readCache("ses_1")?.text).toBe("Hello world");
+	});
+});

--- a/packages/sdk/src/state/sync-store.ts
+++ b/packages/sdk/src/state/sync-store.ts
@@ -4,7 +4,9 @@ import type {
 	Message,
 	Event as OpenCodeEvent,
 	Part,
+	ReasoningPart,
 	SessionStatus,
+	TextPart,
 	Todo,
 } from "@opencode-ai/sdk/v2/client";
 import { create } from "zustand";
@@ -12,13 +14,22 @@ import { create } from "zustand";
 import { ascendingId } from "./sync-store/ascending-id";
 import { Binary } from "./sync-store/binary";
 import { writeStreamCache } from "./sync-store/stream-cache";
-import type { FileDiff, MessageWithParts } from "./sync-store/types";
+import type { FileDiff, MessageError, MessageWithParts } from "./sync-store/types";
 
 // Re-export moved helpers/types so the public surface stays byte-identical:
 // `Binary`, `ascendingId`, and the `MessageWithParts` type remain importable
 // from this module exactly as before.
 export { ascendingId, Binary };
-export type { MessageWithParts };
+export type { MessageError, MessageWithParts };
+
+/** The two `Part` variants that carry streaming `.text` (vs. tool/file/etc.
+ *  parts, which don't). Narrows a `Part` down so `.text` is safe to read
+ *  without a cast — every `Part` member shares `id`/`sessionID`/`messageID`/
+ *  `type`, but only these two carry `text`. */
+type TextLikePart = TextPart | ReasoningPart;
+function isTextLikePart(part: Part): part is TextLikePart {
+	return part.type === "text" || part.type === "reasoning";
+}
 
 // ============================================================================
 // Store State
@@ -179,14 +190,12 @@ export const useSyncStore = create<SyncState>()((set, get) => ({
 			}
 			const result = Binary.search(list, part.id, (p) => p.id);
 			if (result.found) {
-				const prev = list[result.index] as any;
-				const incoming = part as any;
-				const tracksStreamingText =
-					(prev?.type === "text" || prev?.type === "reasoning") &&
-					(incoming?.type === "text" || incoming?.type === "reasoning");
-				const prevText = typeof prev?.text === "string" ? prev.text : null;
-				const incomingText =
-					typeof incoming?.text === "string" ? incoming.text : null;
+				const prev = list[result.index];
+				const prevIsTextLike = isTextLikePart(prev);
+				const incomingIsTextLike = isTextLikePart(part);
+				const tracksStreamingText = prevIsTextLike && incomingIsTextLike;
+				const prevText = prevIsTextLike ? prev.text : null;
+				const incomingText = incomingIsTextLike ? part.text : null;
 
 				// Guard against out-of-order/stale part snapshots that can cause
 				// the stream to jump or start from the middle.
@@ -225,11 +234,7 @@ export const useSyncStore = create<SyncState>()((set, get) => ({
 				// text (missing the beginning). Skip the insert — the delta-
 				// created version already exists in the parts list under the
 				// message entry created by the delta handler.
-				const incoming = part as any;
-				if (
-					deltaActiveParts.has(part.id) &&
-					(incoming?.type === "text" || incoming?.type === "reasoning")
-				) {
+					if (deltaActiveParts.has(part.id) && isTextLikePart(part)) {
 					// Delta-created part already exists — check all messageID
 					// buckets since the delta handler may have stored it under
 					// a different (stub) message entry.
@@ -492,16 +497,10 @@ export const useSyncStore = create<SyncState>()((set, get) => ({
 					// For text/reasoning parts: prefer whichever has more text content.
 					// This prevents hydrate from clobbering SSE-streamed content
 					// with an empty/stale server snapshot during active streaming.
-					const inText = (inP as any).text;
-					const exText = (exP as any).text;
-					const isTextLike =
-						(inP as any)?.type === "text" ||
-						(inP as any)?.type === "reasoning";
 					if (
-						isTextLike &&
-						typeof exText === "string" &&
-						typeof inText === "string" &&
-						exText.length > inText.length
+						isTextLikePart(inP) &&
+						isTextLikePart(exP) &&
+						exP.text.length > inP.text.length
 					) {
 						return exP;
 					}
@@ -625,8 +624,8 @@ export const useSyncStore = create<SyncState>()((set, get) => ({
 
 				const eventSessionID =
 					(event.properties as { sessionID?: string })?.sessionID;
-				let resolvedSessionID =
-					(part as any).sessionID ?? eventSessionID;
+				let resolvedSessionID: string | undefined =
+					part.sessionID ?? eventSessionID;
 
 				if (!resolvedSessionID) {
 					const sessionsById = get().messages;
@@ -655,17 +654,17 @@ export const useSyncStore = create<SyncState>()((set, get) => ({
 				}
 
 				store.upsertPart(part.messageID, part);
-				if ((part as any).type === "text" && typeof (part as any).text === "string") {
+				if (isTextLikePart(part)) {
 					if (!resolvedSessionID) return;
 					const msgInfo = get().messages[resolvedSessionID]?.find(
 						(m) => m.id === part.messageID,
-					) as any;
+					);
 					writeStreamCache(
 						resolvedSessionID,
 						part.messageID,
 						part.id,
-						(part as any).text,
-						msgInfo?.parentID,
+						part.text,
+						msgInfo?.role === "assistant" ? msgInfo.parentID : undefined,
 					);
 				}
 				return;
@@ -736,17 +735,17 @@ export const useSyncStore = create<SyncState>()((set, get) => ({
 				if (props.field === "text") {
 					const updated = get().parts[props.messageID]?.find(
 						(p) => p.id === props.partID,
-					) as any;
-					if (typeof updated?.text === "string" && updated.text.length > 0) {
+					);
+					if (updated && isTextLikePart(updated) && updated.text.length > 0) {
 						const msgInfo = get().messages[props.sessionID]?.find(
 							(m) => m.id === props.messageID,
-						) as any;
+						);
 						writeStreamCache(
 							props.sessionID,
 							props.messageID,
 							props.partID,
 							updated.text,
-							msgInfo?.parentID,
+							msgInfo?.role === "assistant" ? msgInfo.parentID : undefined,
 						);
 					}
 				}
@@ -770,9 +769,10 @@ export const useSyncStore = create<SyncState>()((set, get) => ({
 			return;
 		}
 		case "session.error": {
-			const props = event.properties as { sessionID?: string; error?: unknown };
+			const props = event.properties as { sessionID?: string; error?: MessageError };
 			if (!props.sessionID || !props.error) return;
 			const sid = props.sessionID;
+			const error = props.error;
 			// Mark session idle — errors terminate the response.
 			store.setStatus(sid, { type: "idle" });
 			deltaActiveParts.clear();
@@ -786,10 +786,15 @@ export const useSyncStore = create<SyncState>()((set, get) => ({
 				const msgs = s.messages[sid] ?? [];
 				// Find last assistant message and patch .error onto it
 				for (let i = msgs.length - 1; i >= 0; i--) {
-					if (msgs[i].role === "assistant") {
-						if ((msgs[i] as any).error) return s; // already has error
+					const msg = msgs[i];
+					if (msg.role === "assistant") {
+						if (msg.error) return s; // already has error
 						const next = [...msgs];
-						next[i] = { ...msgs[i], error: props.error } as any;
+						// `error` may be the client-synthesized `SyntheticAbortError`
+						// (see `MessageError`), which the SDK's own `AssistantMessage.error`
+						// union doesn't declare — the assertion is the documented, narrow
+						// exception for that one extra shape.
+						next[i] = { ...msg, error } as typeof msg;
 						return { messages: { ...s.messages, [sid]: next } };
 					}
 				}
@@ -801,8 +806,8 @@ export const useSyncStore = create<SyncState>()((set, get) => ({
 					id: stubId,
 					sessionID: sid,
 					role: "assistant",
-					error: props.error,
-				} as any;
+					error,
+				} as Message;
 				return {
 					messages: { ...s.messages, [sid]: [...msgs, stubMsg] },
 				};

--- a/packages/sdk/src/state/sync-store/types.ts
+++ b/packages/sdk/src/state/sync-store/types.ts
@@ -1,4 +1,5 @@
 import type {
+	AssistantMessage,
 	Message,
 	Part,
 	SnapshotFileDiff,
@@ -11,6 +12,24 @@ export type FileDiff = Omit<SnapshotFileDiff, "patch"> & {
 	before?: string;
 	after?: string;
 };
+
+/**
+ * A locally-synthesized "operation aborted" marker — distinct from (and not
+ * present in) the opencode SDK's `AssistantMessage['error']` union. The React
+ * layer fabricates this shape when a runtime disposes mid-stream (there's no
+ * real SSE event for that case); consumers duck-type on `.name`/`.data.message`
+ * exactly like the real wire errors, so it only needs to match that access
+ * pattern, not the SDK's exact error union.
+ */
+export interface SyntheticAbortError {
+	name: "AbortError";
+	data: { message: string };
+}
+
+/** Every shape `AssistantMessage.error` (and `session.error`'s `error`
+ *  property) can carry — the SDK's wire union plus the client-synthesized
+ *  abort marker above. */
+export type MessageError = NonNullable<AssistantMessage["error"]> | SyntheticAbortError;
 
 // ============================================================================
 // MessageWithParts — the shape components consume

--- a/packages/sdk/src/turns/classify.test.ts
+++ b/packages/sdk/src/turns/classify.test.ts
@@ -1,0 +1,458 @@
+import { describe, expect, test } from 'bun:test';
+
+import type { Message, Part } from '../opencode/client';
+import type { MessageWithParts } from '../transcript';
+import {
+  type ClassifiedPart,
+  classifyPart,
+  classifyTurn,
+  humanizeToolName,
+  toolInfo,
+} from './index';
+
+function textPart(overrides: Partial<Part> = {}): Part {
+  return {
+    id: 'p1',
+    sessionID: 's1',
+    messageID: 'm1',
+    type: 'text',
+    text: 'hello',
+    ...overrides,
+  } as Part;
+}
+
+describe('classifyPart — exhaustive part model', () => {
+  test('text', () => {
+    const result = classifyPart(textPart());
+    expect(result).toEqual({ kind: 'text', id: 'p1', text: 'hello', synthetic: false });
+  });
+
+  test('text with synthetic flag', () => {
+    const result = classifyPart(textPart({ synthetic: true }));
+    expect(result.kind).toBe('text');
+    expect((result as Extract<ClassifiedPart, { kind: 'text' }>).synthetic).toBe(true);
+  });
+
+  test('reasoning', () => {
+    const part = {
+      id: 'p2',
+      sessionID: 's1',
+      messageID: 'm1',
+      type: 'reasoning',
+      text: 'thinking...',
+      time: { start: 0 },
+    } as Part;
+    expect(classifyPart(part)).toEqual({ kind: 'reasoning', id: 'p2', text: 'thinking...' });
+  });
+
+  test('tool — pending', () => {
+    const part = {
+      id: 'p3',
+      sessionID: 's1',
+      messageID: 'm1',
+      type: 'tool',
+      callID: 'c1',
+      tool: 'bash',
+      state: { status: 'pending', input: { command: 'ls' }, raw: '' },
+    } as Part;
+    const result = classifyPart(part);
+    expect(result).toEqual({
+      kind: 'tool',
+      id: 'p3',
+      tool: { name: 'bash', title: 'Shell', status: 'pending', input: { command: 'ls' } },
+    });
+  });
+
+  test('tool — running prefers the live title over the registry label', () => {
+    const part = {
+      id: 'p3b',
+      sessionID: 's1',
+      messageID: 'm1',
+      type: 'tool',
+      callID: 'c1',
+      tool: 'bash',
+      state: { status: 'running', input: {}, title: 'Running ls -la', time: { start: 0 } },
+    } as Part;
+    const result = classifyPart(part) as Extract<ClassifiedPart, { kind: 'tool' }>;
+    expect(result.tool.status).toBe('running');
+    expect(result.tool.title).toBe('Running ls -la');
+  });
+
+  test('tool — completed exposes output, not error', () => {
+    const part = {
+      id: 'p3c',
+      sessionID: 's1',
+      messageID: 'm1',
+      type: 'tool',
+      callID: 'c1',
+      tool: 'read',
+      state: {
+        status: 'completed',
+        input: {},
+        output: 'file contents',
+        title: 'Read',
+        metadata: {},
+        time: { start: 0, end: 1 },
+      },
+    } as Part;
+    const result = classifyPart(part) as Extract<ClassifiedPart, { kind: 'tool' }>;
+    expect(result.tool.status).toBe('done');
+    expect(result.tool.output).toBe('file contents');
+    expect(result.tool.error).toBeUndefined();
+  });
+
+  test('tool — error exposes error, not output', () => {
+    const part = {
+      id: 'p3d',
+      sessionID: 's1',
+      messageID: 'm1',
+      type: 'tool',
+      callID: 'c1',
+      tool: 'bash',
+      state: { status: 'error', input: {}, error: 'command not found', time: { start: 0, end: 1 } },
+    } as Part;
+    const result = classifyPart(part) as Extract<ClassifiedPart, { kind: 'tool' }>;
+    expect(result.tool.status).toBe('error');
+    expect(result.tool.error).toBe('command not found');
+    expect(result.tool.output).toBeUndefined();
+  });
+
+  test('file — image attachment', () => {
+    const part = {
+      id: 'p4',
+      sessionID: 's1',
+      messageID: 'm1',
+      type: 'file',
+      mime: 'image/png',
+      filename: 'shot.png',
+      url: 'file://shot.png',
+    } as Part;
+    expect(classifyPart(part)).toEqual({
+      kind: 'file',
+      id: 'p4',
+      filename: 'shot.png',
+      mime: 'image/png',
+      url: 'file://shot.png',
+      isImage: true,
+      isPdf: false,
+    });
+  });
+
+  test('file — pdf attachment', () => {
+    const part = {
+      id: 'p4b',
+      sessionID: 's1',
+      messageID: 'm1',
+      type: 'file',
+      mime: 'application/pdf',
+      url: 'file://doc.pdf',
+    } as Part;
+    const result = classifyPart(part) as Extract<ClassifiedPart, { kind: 'file' }>;
+    expect(result.isPdf).toBe(true);
+    expect(result.isImage).toBe(false);
+  });
+
+  test('subtask', () => {
+    const part = {
+      id: 'p5',
+      sessionID: 's1',
+      messageID: 'm1',
+      type: 'subtask',
+      prompt: 'do the thing',
+      description: 'Do the thing',
+      agent: 'researcher',
+    } as Part;
+    expect(classifyPart(part)).toEqual({
+      kind: 'subtask',
+      id: 'p5',
+      description: 'Do the thing',
+      agent: 'researcher',
+      prompt: 'do the thing',
+      model: undefined,
+    });
+  });
+
+  test('patch', () => {
+    const part = {
+      id: 'p6',
+      sessionID: 's1',
+      messageID: 'm1',
+      type: 'patch',
+      hash: 'abc123',
+      files: ['a.ts', 'b.ts'],
+    } as Part;
+    expect(classifyPart(part)).toEqual({
+      kind: 'patch',
+      id: 'p6',
+      hash: 'abc123',
+      files: ['a.ts', 'b.ts'],
+      fileCount: 2,
+    });
+  });
+
+  test('snapshot', () => {
+    const part = {
+      id: 'p7',
+      sessionID: 's1',
+      messageID: 'm1',
+      type: 'snapshot',
+      snapshot: 'snap-1',
+    } as Part;
+    expect(classifyPart(part)).toEqual({ kind: 'snapshot', id: 'p7', snapshot: 'snap-1' });
+  });
+
+  test('agent', () => {
+    const part = {
+      id: 'p8',
+      sessionID: 's1',
+      messageID: 'm1',
+      type: 'agent',
+      name: 'kortix-worker',
+    } as Part;
+    expect(classifyPart(part)).toEqual({ kind: 'agent', id: 'p8', name: 'kortix-worker' });
+  });
+
+  test('retry — unwraps the structured error into a flat message', () => {
+    const part = {
+      id: 'p9',
+      sessionID: 's1',
+      messageID: 'm1',
+      type: 'retry',
+      attempt: 2,
+      error: {
+        name: 'ProviderAuthError',
+        data: { providerID: 'anthropic', message: 'rate limited' },
+      },
+      time: { created: 1000 },
+    } as unknown as Part;
+    expect(classifyPart(part)).toEqual({
+      kind: 'retry',
+      id: 'p9',
+      attempt: 2,
+      message: 'rate limited',
+      createdAt: 1000,
+    });
+  });
+
+  test('compaction', () => {
+    const part = {
+      id: 'p10',
+      sessionID: 's1',
+      messageID: 'm1',
+      type: 'compaction',
+      auto: true,
+      overflow: true,
+      tail_start_id: 'msg-99',
+    } as Part;
+    expect(classifyPart(part)).toEqual({
+      kind: 'compaction',
+      id: 'p10',
+      auto: true,
+      overflow: true,
+      tailStartId: 'msg-99',
+    });
+  });
+
+  test('step-start', () => {
+    const part = {
+      id: 'p11',
+      sessionID: 's1',
+      messageID: 'm1',
+      type: 'step-start',
+      snapshot: 'snap-a',
+    } as Part;
+    expect(classifyPart(part)).toEqual({
+      kind: 'step',
+      id: 'p11',
+      phase: 'start',
+      snapshot: 'snap-a',
+    });
+  });
+
+  test('step-finish carries cost/tokens', () => {
+    const part = {
+      id: 'p12',
+      sessionID: 's1',
+      messageID: 'm1',
+      type: 'step-finish',
+      reason: 'stop',
+      cost: 0.02,
+      tokens: { input: 100, output: 50, reasoning: 0, cache: { read: 0, write: 0 } },
+    } as Part;
+    expect(classifyPart(part)).toEqual({
+      kind: 'step',
+      id: 'p12',
+      phase: 'finish',
+      snapshot: undefined,
+      reason: 'stop',
+      cost: 0.02,
+      tokens: { input: 100, output: 50, reasoning: 0, cache: { read: 0, write: 0 } },
+    });
+  });
+
+  test('unknown — a part type not in the current union falls back gracefully at runtime', () => {
+    const futurePart = {
+      id: 'p13',
+      sessionID: 's1',
+      messageID: 'm1',
+      type: 'future-thing',
+    } as unknown as Part;
+    const result = classifyPart(futurePart);
+    expect(result.kind).toBe('unknown');
+    expect((result as Extract<ClassifiedPart, { kind: 'unknown' }>).raw).toEqual(futurePart);
+  });
+});
+
+function userMessage(id: string): Message {
+  return {
+    id,
+    sessionID: 's1',
+    role: 'user',
+    time: { created: 0 },
+    agent: 'build',
+    model: { providerID: 'anthropic', modelID: 'claude' },
+  } as Message;
+}
+
+function assistantMessage(id: string, overrides: Record<string, unknown> = {}): Message {
+  return {
+    id,
+    sessionID: 's1',
+    role: 'assistant',
+    time: { created: 0 },
+    parentID: 'u1',
+    modelID: 'claude',
+    providerID: 'anthropic',
+    mode: 'build',
+    agent: 'build',
+    path: { cwd: '/', root: '/' },
+    cost: 0,
+    tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+    ...overrides,
+  } as Message;
+}
+
+describe('classifyTurn — error normalization + isEmpty', () => {
+  test('a plain text turn is not empty and has no error', () => {
+    const message: MessageWithParts = {
+      info: assistantMessage('a1'),
+      parts: [textPart({ id: 't1' })],
+    };
+    const result = classifyTurn(message);
+    expect(result.isEmpty).toBe(false);
+    expect(result.error).toBeUndefined();
+    expect(result.parts).toHaveLength(1);
+  });
+
+  test('user messages never carry an error', () => {
+    const message: MessageWithParts = { info: userMessage('u1'), parts: [textPart({ id: 't1' })] };
+    expect(classifyTurn(message).error).toBeUndefined();
+  });
+
+  test('regression: a failed turn with zero parts surfaces its error instead of rendering as silence', () => {
+    const message: MessageWithParts = {
+      info: assistantMessage('a1', {
+        error: {
+          name: 'ProviderAuthError',
+          data: { providerID: 'anthropic', message: 'auth failed' },
+        },
+      }),
+      parts: [],
+    };
+    const result = classifyTurn(message);
+    expect(result.parts).toHaveLength(0);
+    expect(result.error).toEqual({ name: 'ProviderAuthError', message: 'auth failed' });
+    // Not "isEmpty" in the sense hosts should skip rendering — there's an error to show.
+    expect(result.isEmpty).toBe(false);
+  });
+
+  test('a turn with only step markers and no error is empty', () => {
+    const message: MessageWithParts = {
+      info: assistantMessage('a1'),
+      parts: [
+        { id: 's1', sessionID: 's1', messageID: 'a1', type: 'step-start' } as Part,
+        {
+          id: 's2',
+          sessionID: 's1',
+          messageID: 'a1',
+          type: 'step-finish',
+          reason: 'stop',
+          cost: 0,
+          tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+        } as Part,
+      ],
+    };
+    expect(classifyTurn(message).isEmpty).toBe(true);
+  });
+
+  test('a turn with a whitespace-only text part is empty', () => {
+    const message: MessageWithParts = {
+      info: assistantMessage('a1'),
+      parts: [textPart({ id: 't1', text: '   \n  ' })],
+    };
+    expect(classifyTurn(message).isEmpty).toBe(true);
+  });
+
+  test('a turn with a tool part is never empty, even with no text', () => {
+    const message: MessageWithParts = {
+      info: assistantMessage('a1'),
+      parts: [
+        {
+          id: 'tool1',
+          sessionID: 's1',
+          messageID: 'a1',
+          type: 'tool',
+          callID: 'c1',
+          tool: 'bash',
+          state: { status: 'running', input: {}, time: { start: 0 } },
+        } as Part,
+      ],
+    };
+    expect(classifyTurn(message).isEmpty).toBe(false);
+  });
+
+  test('a MessageOutputLengthError (no data.message) falls back to the error name', () => {
+    const message: MessageWithParts = {
+      info: assistantMessage('a1', { error: { name: 'MessageOutputLengthError', data: {} } }),
+      parts: [],
+    };
+    const result = classifyTurn(message);
+    expect(result.error?.name).toBe('MessageOutputLengthError');
+    expect(result.error?.message).toBe('An error occurred');
+  });
+});
+
+describe('toolInfo registry', () => {
+  test('maps known built-in tools', () => {
+    expect(toolInfo('bash')).toEqual({ label: 'Shell', category: 'shell' });
+    expect(toolInfo('read')).toEqual({ label: 'Read File', category: 'files' });
+    expect(toolInfo('edit')).toEqual({ label: 'Edit File', category: 'edit' });
+    expect(toolInfo('grep')).toEqual({ label: 'Search Code', category: 'search' });
+    expect(toolInfo('webfetch')).toEqual({ label: 'Fetch Page', category: 'web' });
+    expect(toolInfo('task')).toEqual({ label: 'Delegate to Agent', category: 'task' });
+    expect(toolInfo('todowrite')).toEqual({ label: 'Plan Tasks', category: 'task' });
+    expect(toolInfo('question')).toEqual({ label: 'Ask Question', category: 'task' });
+  });
+
+  test('normalizes dash and oc- prefixed variants to the same entry', () => {
+    expect(toolInfo('apply_patch')).toEqual(toolInfo('apply-patch'));
+    expect(toolInfo('session_spawn')).toEqual(toolInfo('oc-session_spawn'));
+  });
+
+  test('unknown tool in a known family falls back to the family category', () => {
+    const result = toolInfo('agent_totally_new_thing');
+    expect(result.category).toBe('task');
+    expect(result.label).toBe('Agent Totally New Thing');
+  });
+
+  test('completely unknown tool humanizes the raw name with category other', () => {
+    expect(toolInfo('mystery_tool')).toEqual({ label: 'Mystery Tool', category: 'other' });
+  });
+});
+
+describe('humanizeToolName', () => {
+  test('title-cases underscore/dash separated words', () => {
+    expect(humanizeToolName('session_spawn')).toBe('Session Spawn');
+    expect(humanizeToolName('oc-session-read')).toBe('Session Read');
+  });
+});

--- a/packages/sdk/src/turns/classify.ts
+++ b/packages/sdk/src/turns/classify.ts
@@ -347,9 +347,9 @@ export interface TurnError {
 
 function normalizeTurnError(error: unknown): TurnError | undefined {
   if (!error) return undefined;
+  // (`!error` above already excludes null — no separate null check needed.)
   const name =
     typeof error === 'object' &&
-    error !== null &&
     'name' in error &&
     typeof (error as { name?: unknown }).name === 'string'
       ? (error as { name: string }).name

--- a/packages/sdk/src/turns/classify.ts
+++ b/packages/sdk/src/turns/classify.ts
@@ -1,0 +1,393 @@
+/**
+ * Exhaustive part classification — the typed model a chat UI renders from.
+ *
+ * `@opencode-ai/sdk`'s `Part` union has 12 variants (text, subtask, reasoning,
+ * file, tool, step-start, step-finish, snapshot, patch, agent, retry,
+ * compaction). Before this module, hosts hand-rolled a `switch (part.type)`
+ * over the raw wire shape, string-sniffed tool names, and silently dropped
+ * whichever variants they hadn't gotten around to yet (subtask/patch/
+ * snapshot/agent/retry/compaction, commonly). `classifyPart` normalizes every
+ * variant into a `ClassifiedPart` with the fields a renderer actually needs,
+ * with a compile-time exhaustiveness check (the `never` assertion in the
+ * `default` branch) so a new opencode part type fails the build here instead
+ * of silently rendering nothing — plus a runtime 'unknown' fallback so a
+ * genuinely unrecognized value at runtime (e.g. an older client talking to a
+ * newer server) degrades gracefully instead of throwing.
+ *
+ * Framework-free — no React/DOM imports. Typed against the concrete
+ * `@opencode-ai/sdk` wire types (not the structural `*Like` protocols in
+ * `./types`) because exhaustiveness checking only works against the real
+ * closed union.
+ */
+
+import type {
+  AgentPart,
+  CompactionPart,
+  FilePart,
+  Part,
+  PatchPart,
+  ReasoningPart,
+  RetryPart,
+  SnapshotPart,
+  StepFinishPart,
+  StepStartPart,
+  SubtaskPart,
+  TextPart,
+  ToolPart,
+  ToolState,
+} from '../opencode/client';
+import type { MessageWithParts } from '../transcript';
+import { unwrapError } from './errors';
+import { toolInfo } from './tool-registry';
+import type { TokenUsageLike } from './types';
+
+// ============================================================================
+// ToolView — normalized tool-part state machine
+// ============================================================================
+
+export type ToolStatus = 'pending' | 'running' | 'done' | 'error';
+
+/** Normalized view of a tool part's state, independent of the wire's
+ *  pending/running/completed/error status-union shape. */
+export interface ToolView {
+  name: string;
+  title: string;
+  status: ToolStatus;
+  input?: Record<string, unknown>;
+  output?: string;
+  error?: string;
+}
+
+function toolStatus(state: ToolState): ToolStatus {
+  switch (state.status) {
+    case 'pending':
+      return 'pending';
+    case 'running':
+      return 'running';
+    case 'completed':
+      return 'done';
+    case 'error':
+      return 'error';
+    default: {
+      const _exhaustive: never = state;
+      return _exhaustive;
+    }
+  }
+}
+
+function classifyToolState(tool: string, state: ToolState): ToolView {
+  const liveTitle = 'title' in state ? state.title : undefined;
+  return {
+    name: tool,
+    title: liveTitle || toolInfo(tool).label,
+    status: toolStatus(state),
+    input: state.input,
+    output: state.status === 'completed' ? state.output : undefined,
+    error: state.status === 'error' ? state.error : undefined,
+  };
+}
+
+// ============================================================================
+// ClassifiedPart — one variant per opencode Part type, plus 'unknown'
+// ============================================================================
+
+export interface ClassifiedTextPart {
+  kind: 'text';
+  id: string;
+  text: string;
+  /** Synthetic text parts (e.g. shell-mode's synthetic user prompt) are
+   *  wire-internal — hosts typically skip rendering them as chat bubbles. */
+  synthetic: boolean;
+}
+
+export interface ClassifiedReasoningPart {
+  kind: 'reasoning';
+  id: string;
+  text: string;
+}
+
+export interface ClassifiedToolPart {
+  kind: 'tool';
+  id: string;
+  tool: ToolView;
+}
+
+export interface ClassifiedFilePart {
+  kind: 'file';
+  id: string;
+  filename?: string;
+  mime: string;
+  url: string;
+  /** Mirrors the `isAttachment()` check in index.ts — image/PDF parts are
+   *  typically rendered inline, everything else as a filename marker. */
+  isImage: boolean;
+  isPdf: boolean;
+}
+
+export interface ClassifiedSubtaskPart {
+  kind: 'subtask';
+  id: string;
+  description: string;
+  agent: string;
+  prompt: string;
+  model?: { providerID: string; modelID: string };
+}
+
+export interface ClassifiedPatchPart {
+  kind: 'patch';
+  id: string;
+  hash: string;
+  files: string[];
+  fileCount: number;
+}
+
+export interface ClassifiedSnapshotPart {
+  kind: 'snapshot';
+  id: string;
+  snapshot: string;
+}
+
+export interface ClassifiedAgentPart {
+  kind: 'agent';
+  id: string;
+  name: string;
+}
+
+export interface ClassifiedRetryPart {
+  kind: 'retry';
+  id: string;
+  attempt: number;
+  message: string;
+  createdAt: number;
+}
+
+export interface ClassifiedCompactionPart {
+  kind: 'compaction';
+  id: string;
+  auto: boolean;
+  overflow: boolean;
+  tailStartId?: string;
+}
+
+export interface ClassifiedStepPart {
+  kind: 'step';
+  id: string;
+  phase: 'start' | 'finish';
+  snapshot?: string;
+  /** step-finish only. */
+  reason?: string;
+  cost?: number;
+  tokens?: TokenUsageLike;
+}
+
+/** Forward-compat fallback for any part type this module doesn't know about
+ *  yet (version skew between client and server). `raw` is the untouched
+ *  wire value so a host can still attempt best-effort handling. */
+export interface ClassifiedUnknownPart {
+  kind: 'unknown';
+  raw: unknown;
+}
+
+export type ClassifiedPart =
+  | ClassifiedTextPart
+  | ClassifiedReasoningPart
+  | ClassifiedToolPart
+  | ClassifiedFilePart
+  | ClassifiedSubtaskPart
+  | ClassifiedPatchPart
+  | ClassifiedSnapshotPart
+  | ClassifiedAgentPart
+  | ClassifiedRetryPart
+  | ClassifiedCompactionPart
+  | ClassifiedStepPart
+  | ClassifiedUnknownPart;
+
+function classifyText(part: TextPart): ClassifiedTextPart {
+  return { kind: 'text', id: part.id, text: part.text, synthetic: !!part.synthetic };
+}
+
+function classifyReasoning(part: ReasoningPart): ClassifiedReasoningPart {
+  return { kind: 'reasoning', id: part.id, text: part.text };
+}
+
+function classifyTool(part: ToolPart): ClassifiedToolPart {
+  return { kind: 'tool', id: part.id, tool: classifyToolState(part.tool, part.state) };
+}
+
+function classifyFile(part: FilePart): ClassifiedFilePart {
+  const mime = part.mime;
+  return {
+    kind: 'file',
+    id: part.id,
+    filename: part.filename,
+    mime,
+    url: part.url,
+    isImage: mime.startsWith('image/'),
+    isPdf: mime === 'application/pdf',
+  };
+}
+
+function classifySubtask(part: SubtaskPart): ClassifiedSubtaskPart {
+  return {
+    kind: 'subtask',
+    id: part.id,
+    description: part.description,
+    agent: part.agent,
+    prompt: part.prompt,
+    model: part.model,
+  };
+}
+
+function classifyPatch(part: PatchPart): ClassifiedPatchPart {
+  return {
+    kind: 'patch',
+    id: part.id,
+    hash: part.hash,
+    files: part.files,
+    fileCount: part.files.length,
+  };
+}
+
+function classifySnapshot(part: SnapshotPart): ClassifiedSnapshotPart {
+  return { kind: 'snapshot', id: part.id, snapshot: part.snapshot };
+}
+
+function classifyAgent(part: AgentPart): ClassifiedAgentPart {
+  return { kind: 'agent', id: part.id, name: part.name };
+}
+
+function classifyRetry(part: RetryPart): ClassifiedRetryPart {
+  return {
+    kind: 'retry',
+    id: part.id,
+    attempt: part.attempt,
+    message: unwrapError(part.error),
+    createdAt: part.time.created,
+  };
+}
+
+function classifyCompaction(part: CompactionPart): ClassifiedCompactionPart {
+  return {
+    kind: 'compaction',
+    id: part.id,
+    auto: part.auto,
+    overflow: !!part.overflow,
+    tailStartId: part.tail_start_id,
+  };
+}
+
+function classifyStepStart(part: StepStartPart): ClassifiedStepPart {
+  return { kind: 'step', id: part.id, phase: 'start', snapshot: part.snapshot };
+}
+
+function classifyStepFinish(part: StepFinishPart): ClassifiedStepPart {
+  return {
+    kind: 'step',
+    id: part.id,
+    phase: 'finish',
+    snapshot: part.snapshot,
+    reason: part.reason,
+    cost: part.cost,
+    tokens: part.tokens,
+  };
+}
+
+/**
+ * Classify a single opencode message part into a `ClassifiedPart`.
+ *
+ * The `default` branch's `const _exhaustive: never = part` line is a
+ * compile-time guard: if opencode's `Part` union grows a new variant and this
+ * switch isn't updated to handle it, this file fails to typecheck. At
+ * runtime, a value that doesn't match any known `type` (version skew) falls
+ * through to `{ kind: 'unknown', raw: part }` instead of throwing.
+ */
+export function classifyPart(part: Part): ClassifiedPart {
+  switch (part.type) {
+    case 'text':
+      return classifyText(part);
+    case 'reasoning':
+      return classifyReasoning(part);
+    case 'tool':
+      return classifyTool(part);
+    case 'file':
+      return classifyFile(part);
+    case 'subtask':
+      return classifySubtask(part);
+    case 'patch':
+      return classifyPatch(part);
+    case 'snapshot':
+      return classifySnapshot(part);
+    case 'agent':
+      return classifyAgent(part);
+    case 'retry':
+      return classifyRetry(part);
+    case 'compaction':
+      return classifyCompaction(part);
+    case 'step-start':
+      return classifyStepStart(part);
+    case 'step-finish':
+      return classifyStepFinish(part);
+    default: {
+      const _exhaustive: never = part;
+      return { kind: 'unknown', raw: _exhaustive };
+    }
+  }
+}
+
+// ============================================================================
+// classifyTurn — turn-level part classification + error normalization
+// ============================================================================
+
+/** Normalized turn-level error — the "failed turn renders as silence" bug
+ *  class, solved once here instead of in every host's renderer. */
+export interface TurnError {
+  name: string;
+  message: string;
+}
+
+function normalizeTurnError(error: unknown): TurnError | undefined {
+  if (!error) return undefined;
+  const name =
+    typeof error === 'object' &&
+    error !== null &&
+    'name' in error &&
+    typeof (error as { name?: unknown }).name === 'string'
+      ? (error as { name: string }).name
+      : 'Error';
+  return { name, message: unwrapError(error) };
+}
+
+/** Whether a classified part renders any visible content on its own — used
+ *  to compute `isEmpty` below. step/snapshot markers with no sibling content
+ *  don't count; a lone empty text/reasoning part doesn't either. */
+function partHasContent(part: ClassifiedPart): boolean {
+  switch (part.kind) {
+    case 'text':
+    case 'reasoning':
+      return part.text.trim().length > 0;
+    case 'step':
+      return false;
+    default:
+      return true;
+  }
+}
+
+export interface ClassifiedTurn {
+  parts: ClassifiedPart[];
+  error?: TurnError;
+  /** True when the turn has no error and no part with visible content — the
+   *  case that used to render as silent nothingness. */
+  isEmpty: boolean;
+}
+
+/**
+ * Classify every part of a message and normalize its error (assistant
+ * messages only carry `info.error`; user messages never do).
+ */
+export function classifyTurn(message: MessageWithParts): ClassifiedTurn {
+  const parts = message.parts.map(classifyPart);
+  const rawError = message.info.role === 'assistant' ? message.info.error : undefined;
+  const error = normalizeTurnError(rawError);
+  const isEmpty = !error && !parts.some(partHasContent);
+  return { parts, error, isEmpty };
+}

--- a/packages/sdk/src/turns/errors.ts
+++ b/packages/sdk/src/turns/errors.ts
@@ -1,0 +1,54 @@
+/**
+ * Error-message unwrapping — extracted from turns/index.ts so it can be
+ * shared with classify.ts (classifyTurn's TurnError normalization) without
+ * creating an index.ts <-> classify.ts import cycle.
+ */
+
+/**
+ * Extract human-readable error message from a raw error value.
+ * Matches SolidJS `unwrap()` function — session-turn.tsx:34-81
+ */
+export function unwrapError(raw: unknown): string {
+  if (!raw) return 'An error occurred';
+
+  if (typeof raw === 'string') {
+    // Strip "Error: " prefix
+    let str = raw.startsWith('Error: ') ? raw.slice(7) : raw;
+
+    // Try JSON parsing (might be double-encoded)
+    try {
+      const parsed = JSON.parse(str);
+      if (typeof parsed === 'string') {
+        str = parsed; // double-encoded string
+        try {
+          const inner = JSON.parse(str);
+          return extractErrorFromObject(inner) || str;
+        } catch {
+          return str;
+        }
+      }
+      return extractErrorFromObject(parsed) || str;
+    } catch {
+      return str;
+    }
+  }
+
+  if (typeof raw === 'object' && raw !== null) {
+    return extractErrorFromObject(raw) || 'An error occurred';
+  }
+
+  return String(raw);
+}
+
+function extractErrorFromObject(obj: unknown): string | undefined {
+  if (typeof obj !== 'object' || obj === null || Array.isArray(obj)) return undefined;
+  // Try common error shapes
+  const record = obj as Record<string, unknown>;
+  if (typeof record.message === 'string' && record.message) return record.message;
+  if (typeof record.error === 'string' && record.error) return record.error;
+  const data = record.data as { message?: unknown } | undefined | null;
+  if (typeof data?.message === 'string') return data.message;
+  const error = record.error as { message?: unknown } | undefined | null;
+  if (typeof error?.message === 'string') return error.message;
+  return undefined;
+}

--- a/packages/sdk/src/turns/errors.ts
+++ b/packages/sdk/src/turns/errors.ts
@@ -33,7 +33,8 @@ export function unwrapError(raw: unknown): string {
     }
   }
 
-  if (typeof raw === 'object' && raw !== null) {
+  // (`!raw` at the top already excluded null — typeof alone suffices here.)
+  if (typeof raw === 'object') {
     return extractErrorFromObject(raw) || 'An error occurred';
   }
 

--- a/packages/sdk/src/turns/index.ts
+++ b/packages/sdk/src/turns/index.ts
@@ -27,6 +27,11 @@ import type {
 } from './types';
 
 export type * from './types';
+export { unwrapError } from './errors';
+export * from './tool-registry';
+export * from './classify';
+
+import { unwrapError } from './errors';
 
 // ============================================================================
 // Internal wire shapes (structural casts, never exported)
@@ -408,55 +413,6 @@ export function getAnsweredQuestionParts<M extends MessageWithPartsLike>(
 // ============================================================================
 // Error extraction — with deep JSON unwrapping
 // ============================================================================
-
-/**
- * Extract human-readable error message from a raw error value.
- * Matches SolidJS `unwrap()` function — session-turn.tsx:34-81
- */
-export function unwrapError(raw: unknown): string {
-  if (!raw) return 'An error occurred';
-
-  if (typeof raw === 'string') {
-    // Strip "Error: " prefix
-    let str = raw.startsWith('Error: ') ? raw.slice(7) : raw;
-
-    // Try JSON parsing (might be double-encoded)
-    try {
-      const parsed = JSON.parse(str);
-      if (typeof parsed === 'string') {
-        str = parsed; // double-encoded string
-        try {
-          const inner = JSON.parse(str);
-          return extractErrorFromObject(inner) || str;
-        } catch {
-          return str;
-        }
-      }
-      return extractErrorFromObject(parsed) || str;
-    } catch {
-      return str;
-    }
-  }
-
-  if (typeof raw === 'object' && raw !== null) {
-    return extractErrorFromObject(raw) || 'An error occurred';
-  }
-
-  return String(raw);
-}
-
-function extractErrorFromObject(obj: unknown): string | undefined {
-  if (typeof obj !== 'object' || obj === null || Array.isArray(obj)) return undefined;
-  // Try common error shapes
-  const record = obj as Record<string, unknown>;
-  if (typeof record.message === 'string' && record.message) return record.message;
-  if (typeof record.error === 'string' && record.error) return record.error;
-  const data = record.data as { message?: unknown } | undefined | null;
-  if (typeof data?.message === 'string') return data.message;
-  const error = record.error as { message?: unknown } | undefined | null;
-  if (typeof error?.message === 'string') return error.message;
-  return undefined;
-}
 
 /** Extract error message from assistant messages in a turn. */
 export function getTurnError(turn: TurnLike): string | undefined {

--- a/packages/sdk/src/turns/tool-registry.ts
+++ b/packages/sdk/src/turns/tool-registry.ts
@@ -1,0 +1,125 @@
+/**
+ * Tool name -> {label, category} registry — pure data, zero React/icon deps.
+ * Hosts map `category` to their own icon set; `getToolInfo` (index.ts) already
+ * covers icon+title+subtitle for the existing tool-card UI, this is a leaner,
+ * icon-free sibling for hosts that just need "what kind of tool is this" (e.g.
+ * `classifyPart`'s `ToolView`, filtering/grouping steps by category).
+ *
+ * Canonical opencode built-in tool names (bash, read, write, edit, grep, glob,
+ * webfetch, task, todowrite, question, patch, list, …) get a hand-picked
+ * label. Kortix's plugin tool families (agent_*, session_*, task_*, trigger_*,
+ * project_*, pty_*, and their `-`/`oc-` variants) are recognized by prefix so
+ * new tools in an existing family are categorized correctly without a
+ * registry update. Anything else falls back to a humanized version of the
+ * raw name with category 'other'.
+ */
+
+export type ToolCategory = 'shell' | 'files' | 'search' | 'edit' | 'web' | 'task' | 'other';
+
+export interface ToolInfoEntry {
+  label: string;
+  category: ToolCategory;
+}
+
+/** Registry keyed by the tool's normalized (underscore, no `oc_` prefix) name. */
+const TOOL_REGISTRY: Record<string, ToolInfoEntry> = {
+  // Shell / terminal
+  bash: { label: 'Shell', category: 'shell' },
+  pty_spawn: { label: 'Spawn Terminal', category: 'shell' },
+  pty_read: { label: 'Terminal Output', category: 'shell' },
+  pty_write: { label: 'Terminal Input', category: 'shell' },
+  pty_input: { label: 'Terminal Input', category: 'shell' },
+  pty_kill: { label: 'Kill Process', category: 'shell' },
+
+  // Read-only file access
+  read: { label: 'Read File', category: 'files' },
+  list: { label: 'List Directory', category: 'files' },
+  ls: { label: 'List Directory', category: 'files' },
+
+  // Mutating file operations
+  write: { label: 'Write File', category: 'edit' },
+  edit: { label: 'Edit File', category: 'edit' },
+  multiedit: { label: 'Edit File', category: 'edit' },
+  morph_edit: { label: 'Edit File', category: 'edit' },
+  apply_patch: { label: 'Apply Patch', category: 'edit' },
+  patch: { label: 'Apply Patch', category: 'edit' },
+
+  // Search
+  grep: { label: 'Search Code', category: 'search' },
+  glob: { label: 'Find Files', category: 'search' },
+  image_search: { label: 'Image Search', category: 'search' },
+  session_search: { label: 'Search Sessions', category: 'search' },
+
+  // Web
+  webfetch: { label: 'Fetch Page', category: 'web' },
+  scrape_webpage: { label: 'Scrape Page', category: 'web' },
+  websearch: { label: 'Web Search', category: 'web' },
+  web_search: { label: 'Web Search', category: 'web' },
+  image_gen: { label: 'Generate Image', category: 'web' },
+  video_gen: { label: 'Generate Video', category: 'web' },
+
+  // Task / agent orchestration + planning
+  task: { label: 'Delegate to Agent', category: 'task' },
+  todowrite: { label: 'Plan Tasks', category: 'task' },
+  todoread: { label: 'Read Plan', category: 'task' },
+  question: { label: 'Ask Question', category: 'task' },
+  presentation_gen: { label: 'Presentation', category: 'task' },
+  show: { label: 'Show Output', category: 'task' },
+  show_user: { label: 'Show Output', category: 'task' },
+
+  // DCP / context management
+  prune: { label: 'Prune Context', category: 'other' },
+  distill: { label: 'Distill Context', category: 'other' },
+  compress: { label: 'Compress Context', category: 'other' },
+  context_info: { label: 'Context Info', category: 'other' },
+};
+
+/** Tool-name-family prefixes that should categorize even when the exact tool
+ *  isn't in TOOL_REGISTRY (forward-compat for new tools in an existing
+ *  family, e.g. a new `agent_*` or `trigger_*` tool). Checked in order. */
+const PREFIX_CATEGORIES: Array<{ prefix: string; category: ToolCategory }> = [
+  { prefix: 'pty_', category: 'shell' },
+  { prefix: 'agent_', category: 'task' },
+  { prefix: 'session_', category: 'task' },
+  { prefix: 'task_', category: 'task' },
+  { prefix: 'trigger_', category: 'task' },
+  { prefix: 'project_', category: 'task' },
+];
+
+function stripOcPrefix(name: string): string {
+  return name.replace(/^oc[-_]/, '');
+}
+
+/** Normalize a tool name to the registry's canonical (underscore) key form. */
+function normalizeToolName(name: string): string {
+  return stripOcPrefix(name).replace(/-/g, '_');
+}
+
+/** Turn a raw/normalized tool name into a human label, e.g. `session_spawn` -> "Session Spawn". */
+export function humanizeToolName(name: string): string {
+  const normalized = normalizeToolName(name);
+  return normalized
+    .split(/[_\s]+/)
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}
+
+/**
+ * Look up display info for a tool name. Never throws, always returns a
+ * usable label — unknown tools humanize their raw name with category
+ * 'other' (or a family category, if the name matches a known prefix).
+ */
+export function toolInfo(name: string): ToolInfoEntry {
+  const normalized = normalizeToolName(name);
+  const known = TOOL_REGISTRY[normalized];
+  if (known) return known;
+
+  for (const { prefix, category } of PREFIX_CATEGORIES) {
+    if (normalized.startsWith(prefix)) {
+      return { label: humanizeToolName(name), category };
+    }
+  }
+
+  return { label: humanizeToolName(name), category: 'other' };
+}


### PR DESCRIPTION
## What

Finalizes the **Kortix as a Backend** story end to end: `@kortix/sdk` is now clean to consume from a server-side wrapper, and the whitelabel reference app (Lumen) demonstrates the full pattern — **your own backend wrapping the Kortix backend**, with key protection, per-user isolation, and cost pass-through.

## SDK (`packages/sdk`)

- **Typed errors, isomorphic**: `ApiError` is a real class (`instanceof`-able; `name`/shape preserved for legacy sniffers). `AuthError`, `BillingError`, `RequestTooLargeError` + helpers exported from the root barrel and `./api-client`, not just `/react` — a wrapper can `instanceof BillingError` a 402 and pass the cost payload through to its own users.
- **`session.stream()`**: framework-free SSE facade over `openEventStream`, bound to the handle's own runtime — usable from Node/Bun wrappers, workers, CLI. Closes the README promise + API-MAP gap item 3.
- **BFF-ready URLs**: `previewUrl`/`proxyUrl` tolerate a relative `backendUrl` (same-origin proxy) and read the **live** platform config, so re-pointing the seam after `createKortix()` reaches every path.

## Reference app (`apps/whitelabel-demo`)

Two modes, switched by server env (`GET /api/mode`), no rebuild:

- **Direct mode** (unchanged): browser-held PAT.
- **Wrapper mode** (`KORTIX_API_KEY` set): own HMAC-session auth (`/api/auth/*`) · deny-by-default BFF proxy `/api/kortix/[...path]` with server-side key injection + unbuffered SSE pass-through · per-user project isolation + explicit route policy + per-user rate limits (`src/server/`) · short-lived **project-scoped PAT minting** for preview iframes (`/api/preview-token` — Next can't proxy WS upgrades) · **cost pass-through** `/usage` page over `gateway/sessions` with `COST_MARKUP`.

Plus: README/AGENTS.md drift purge (dead `SessionRuntime`/`switchToSessionSandboxAsync` architecture removed, two-mode story documented), `.env.example`, and an `as any` purge (41 → 0) that surfaced two real bugs (template picker read `.templates` not `.items`; Runtime stat read a nonexistent sandbox-health `.status`).

## Verified

- `pnpm typecheck`: sdk, whitelabel-demo, cli — clean. `bun test` sdk: **471 pass / 0 fail**.
- Production `next build` clean; booted **both modes** and drove the wrapper security matrix with curl: unauth 401 · login mints token · authed request forwards with substituted server key · account-admin 403 · unowned project 403 · tampered token 401 · rate limit 429 with Retry-After.
- `instanceof`/JSON-shape smoke test for the error classes.