### PR TITLE
fix(llm-gateway): pin managed GLM to Z.AI host + surface in-stream upstream error frames

### DIFF
--- a/apps/api/src/llm-gateway/resolution/descriptors.ts
+++ b/apps/api/src/llm-gateway/resolution/descriptors.ts
@@ -40,6 +40,7 @@ function openRouterManagedDescriptor(managed: ManagedModel): UpstreamDescriptor 
     appReferer: config.KORTIX_URL,
     resolvedModel: managed.upstreamModelId,
     pricing: managedPricing(managed),
+    ...(managed.openrouterProvider ? { bodyExtras: { provider: managed.openrouterProvider } } : {}),
   };
 }
 

--- a/packages/llm-gateway/src/domain/descriptor.ts
+++ b/packages/llm-gateway/src/domain/descriptor.ts
@@ -26,4 +26,8 @@ export interface UpstreamDescriptor {
   headers?: Record<string, string>;
   omitAuthorization?: boolean;
   pricing?: UpstreamPricing;
+  // Upstream-specific fields merged into the outgoing request body, overriding
+  // any same-named client fields (e.g. OpenRouter's `provider` routing
+  // preferences pinning managed models to reliable hosts). openai-compat only.
+  bodyExtras?: Record<string, unknown>;
 }

--- a/packages/llm-gateway/src/pipeline/handler.ts
+++ b/packages/llm-gateway/src/pipeline/handler.ts
@@ -10,7 +10,13 @@ import type {
 } from '../domain';
 import type { FetchImpl } from '../http';
 import { type CircuitBreaker, backoffDelay, realSleep } from '../resilience';
-import { type ExtractedUsage, calculateCost, extractUsageFromJson, jsonHasContent } from '../usage';
+import {
+  type ExtractedUsage,
+  type SseErrorFrame,
+  calculateCost,
+  extractUsageFromJson,
+  jsonHasContent,
+} from '../usage';
 import { runFailover } from './failover';
 import { type StreamProbeResult, probeStream, relayStream } from './streaming';
 import { createTraceEmitter } from './trace';
@@ -410,7 +416,11 @@ export async function handleChatCompletions(
     tried,
   });
 
-  const settle = async (usage: ExtractedUsage | null, response: unknown): Promise<void> => {
+  const settle = async (
+    usage: ExtractedUsage | null,
+    response: unknown,
+    streamError?: SseErrorFrame | null,
+  ): Promise<void> => {
     const usedModel = (
       usage?.model ??
       finalDescriptor.resolvedModel ??
@@ -470,8 +480,12 @@ export async function handleChatCompletions(
       upstreamCost,
       finalCost,
       streaming,
+      ...(streamError ? { streamError: streamError.message } : {}),
     });
 
+    // A stream that carried an upstream error frame delivered a failed turn to
+    // the caller, whatever the HTTP status said — trace it as such (tokens are
+    // still billed above: the upstream consumed them before it died).
     emit({
       ...id,
       requestedModel,
@@ -480,7 +494,10 @@ export async function handleChatCompletions(
       billingMode: finalDescriptor.billingMode,
       streaming,
       status: 200,
-      ok: true,
+      ok: !streamError,
+      ...(streamError
+        ? { errorCode: 'upstream_stream_error', errorMessage: streamError.message }
+        : {}),
       attempts,
       candidatesTried: tried,
       usage: counts,

--- a/packages/llm-gateway/src/pipeline/streaming.test.ts
+++ b/packages/llm-gateway/src/pipeline/streaming.test.ts
@@ -192,3 +192,60 @@ describe('relayStream with a primed reader', () => {
     expect(settledBuffer).toBe(text);
   });
 });
+
+describe('relayStream upstream error frames', () => {
+  test('passes the in-stream error frame to settle and warns', async () => {
+    const up = controllableUpstream();
+    const warnings: unknown[][] = [];
+    let settledError: unknown = 'unset';
+    const out = relayStream({
+      upstreamBody: up.stream,
+      captureBodies: false,
+      requestId: 'r-err',
+      logger: { warn: (...args: unknown[]) => warnings.push(args) },
+      settle: async (_usage, _response, streamError) => {
+        settledError = streamError;
+      },
+      heartbeatMs: 10_000,
+    });
+    up.push('data: {"choices":[{"delta":{"content":"partial"}}]}\n\n');
+    up.push('data: {"error":{"message":"Upstream idle timeout exceeded","code":502}}\n\n');
+    up.close();
+    const text = await drain(out);
+    // The frame is still relayed verbatim — the caller must see the failure too.
+    expect(text).toContain('Upstream idle timeout exceeded');
+    await delay(10); // let the detached finally run settle()
+    expect(settledError).toEqual({ message: 'Upstream idle timeout exceeded', code: 502 });
+    expect(warnings.some((w) => String(w[0]).includes('upstream error frame'))).toBe(true);
+  });
+
+  test('settles with a null error frame on a clean stream', async () => {
+    const up = controllableUpstream();
+    let settledError: unknown = 'unset';
+    const out = relayStream({
+      upstreamBody: up.stream,
+      captureBodies: false,
+      requestId: 'r-clean',
+      logger: noop,
+      settle: async (_usage, _response, streamError) => {
+        settledError = streamError;
+      },
+      heartbeatMs: 10_000,
+    });
+    up.push('data: {"choices":[{"delta":{"content":"hi"}}]}\n\ndata: [DONE]\n\n');
+    up.close();
+    await drain(out);
+    await delay(10);
+    expect(settledError).toBeNull();
+  });
+});
+
+describe('probeStream error frames', () => {
+  test('an error-frame-only stream probes as no-content (so the handler retries it)', async () => {
+    const up = controllableUpstream();
+    up.push('data: {"error":{"message":"Upstream idle timeout exceeded","code":502}}\n\n');
+    up.close();
+    const probe = await probeStream(up.stream);
+    expect(probe.hasContent).toBe(false);
+  });
+});

--- a/packages/llm-gateway/src/pipeline/streaming.ts
+++ b/packages/llm-gateway/src/pipeline/streaming.ts
@@ -1,4 +1,10 @@
-import { type ExtractedUsage, extractUsageFromSseBuffer, sseHasContent } from '../usage';
+import {
+  type ExtractedUsage,
+  type SseErrorFrame,
+  extractUsageFromSseBuffer,
+  sseErrorFrame,
+  sseHasContent,
+} from '../usage';
 
 export interface StreamRelayOptions {
   /** Fresh upstream body — mutually exclusive with `primed`. */
@@ -8,7 +14,11 @@ export interface StreamRelayOptions {
   captureBodies: boolean;
   requestId: string;
   logger: { warn: (...args: unknown[]) => void; debug?: (...args: unknown[]) => void };
-  settle: (usage: ExtractedUsage | null, response: unknown) => Promise<void>;
+  settle: (
+    usage: ExtractedUsage | null,
+    response: unknown,
+    streamError?: SseErrorFrame | null,
+  ) => Promise<void>;
   /** Keep-alive interval in ms (overridable for tests). */
   heartbeatMs?: number;
 }
@@ -165,6 +175,16 @@ export function relayStream(opts: StreamRelayOptions): ReadableStream<Uint8Array
       } catch {
         // writer already closed / downstream gone — nothing to do here.
       }
+      // An upstream that dies mid-generation (a stalled model host behind
+      // OpenRouter, e.g. "Upstream idle timeout exceeded") reports it as an
+      // in-stream error frame on an otherwise clean 200 stream. Surface it so
+      // the trace records a failed turn instead of a silent success.
+      const streamError = sseErrorFrame(sseBuffer);
+      if (streamError) {
+        logger.warn(
+          `[llm-gateway] upstream error frame in stream ${requestId}: "${streamError.message}"${streamError.code !== undefined ? ` (code ${streamError.code})` : ''}`,
+        );
+      }
       debug('stream_end', {
         totalMs: Date.now() - startMs,
         ttfbMs: firstByteAt ? firstByteAt - startMs : null,
@@ -172,12 +192,17 @@ export function relayStream(opts: StreamRelayOptions): ReadableStream<Uint8Array
         chunks,
         heartbeats,
         downstreamAlive,
+        ...(streamError ? { streamError: streamError.message } : {}),
       });
       // Settlement (usage extraction + recordUsage + trace) must never throw out
       // of this detached async task — a failure here would otherwise be an
       // unhandled rejection and silently lose billing/trace for the stream.
       try {
-        await settle(extractUsageFromSseBuffer(sseBuffer), captureBodies ? sseBuffer : null);
+        await settle(
+          extractUsageFromSseBuffer(sseBuffer),
+          captureBodies ? sseBuffer : null,
+          streamError,
+        );
       } catch (err) {
         logger.warn(`[llm-gateway] stream settle failed ${requestId}:`, err);
       }

--- a/packages/llm-gateway/src/transports/openai-compat/index.ts
+++ b/packages/llm-gateway/src/transports/openai-compat/index.ts
@@ -24,9 +24,13 @@ export function buildUpstreamRequest(
   if (descriptor.appReferer) headers['http-referer'] = descriptor.appReferer;
   if (descriptor.headers) Object.assign(headers, descriptor.headers);
 
+  let payload = body;
+  if (descriptor.bodyExtras) payload = { ...payload, ...descriptor.bodyExtras };
+  if (descriptor.resolvedModel) payload = { ...payload, model: descriptor.resolvedModel };
+
   return {
     url: `${trimTrailingSlash(descriptor.baseUrl)}/chat/completions`,
     headers,
-    payload: descriptor.resolvedModel ? { ...body, model: descriptor.resolvedModel } : body,
+    payload,
   };
 }

--- a/packages/llm-gateway/src/transports/openai-compat/openai-compat.test.ts
+++ b/packages/llm-gateway/src/transports/openai-compat/openai-compat.test.ts
@@ -42,3 +42,33 @@ describe('openai-compat transport', () => {
     expect(req.headers.authorization).toBeUndefined();
   });
 });
+
+describe('openai-compat bodyExtras', () => {
+  test('merges descriptor bodyExtras into the payload, overriding client fields', () => {
+    const req = buildUpstreamRequest(
+      { model: 'kortix/glm-5.2', messages: [], provider: { order: ['evil'] } },
+      {
+        ...descriptor,
+        provider: 'openrouter',
+        baseUrl: 'https://openrouter.ai/api/v1',
+        resolvedModel: 'z-ai/glm-5.2',
+        bodyExtras: { provider: { order: ['z-ai'], allow_fallbacks: true } },
+      },
+    );
+    expect(req.payload.provider).toEqual({ order: ['z-ai'], allow_fallbacks: true });
+    expect(req.payload.model).toBe('z-ai/glm-5.2');
+  });
+
+  test('bodyExtras cannot clobber the resolved model', () => {
+    const req = buildUpstreamRequest(
+      { model: 'kortix/glm-5.2', messages: [] },
+      { ...descriptor, resolvedModel: 'z-ai/glm-5.2', bodyExtras: { model: 'other' } },
+    );
+    expect(req.payload.model).toBe('z-ai/glm-5.2');
+  });
+
+  test('payload untouched without bodyExtras', () => {
+    const req = buildUpstreamRequest({ model: 'xai/grok-4.3', messages: [] }, descriptor);
+    expect('provider' in req.payload).toBe(false);
+  });
+});

--- a/packages/llm-gateway/src/usage/completion-guard.test.ts
+++ b/packages/llm-gateway/src/usage/completion-guard.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { jsonHasContent, sseHasContent } from './completion-guard';
+import { jsonHasContent, sseErrorFrame, sseHasContent } from './completion-guard';
 
 describe('jsonHasContent', () => {
   test('true for a normal message completion', () => {
@@ -64,5 +64,34 @@ describe('sseHasContent', () => {
 
   test('ignores malformed JSON lines instead of throwing', () => {
     expect(sseHasContent('data: {not json\n\n')).toBe(false);
+  });
+});
+
+describe('sseErrorFrame', () => {
+  test('extracts an OpenRouter mid-stream error frame', () => {
+    const buf =
+      'data: {"choices":[{"delta":{"content":"hi"}}]}\n\n' +
+      'data: {"error":{"message":"Upstream idle timeout exceeded","code":502}}\n\n';
+    expect(sseErrorFrame(buf)).toEqual({ message: 'Upstream idle timeout exceeded', code: 502 });
+  });
+
+  test('extracts an error frame without a code', () => {
+    const buf = 'data: {"error":{"message":"boom"}}\n\n';
+    expect(sseErrorFrame(buf)).toEqual({ message: 'boom' });
+  });
+
+  test('null for a clean stream', () => {
+    const buf =
+      'data: {"choices":[{"delta":{"content":"hi"},"finish_reason":"stop"}]}\n\ndata: [DONE]\n\n';
+    expect(sseErrorFrame(buf)).toBeNull();
+  });
+
+  test('null for an empty buffer and for malformed lines', () => {
+    expect(sseErrorFrame('')).toBeNull();
+    expect(sseErrorFrame('data: {not json\n\n')).toBeNull();
+  });
+
+  test('ignores a non-object error field', () => {
+    expect(sseErrorFrame('data: {"error":"nope"}\n\n')).toBeNull();
   });
 });

--- a/packages/llm-gateway/src/usage/completion-guard.ts
+++ b/packages/llm-gateway/src/usage/completion-guard.ts
@@ -39,6 +39,39 @@ export function jsonHasContent(data: unknown): boolean {
   return choices.some(choiceHasContent);
 }
 
+export interface SseErrorFrame {
+  message: string;
+  code?: string | number;
+}
+
+/** First in-stream error frame in an SSE buffer, if any. OpenRouter (and other
+ *  openai-compat upstreams) report a mid-stream upstream failure as a 200 stream
+ *  carrying `data: {"error":{"message":"Upstream idle timeout exceeded",...}}` —
+ *  the HTTP layer never sees a failure, so without parsing for this the gateway
+ *  books a dead turn as a success. */
+export function sseErrorFrame(buffer: string): SseErrorFrame | null {
+  for (const line of buffer.split('\n')) {
+    if (!line.startsWith('data:')) continue;
+    const payload = line.slice(5).trim();
+    if (!payload || payload === '[DONE]') continue;
+    try {
+      const chunk = JSON.parse(payload) as { error?: unknown };
+      const error = chunk.error;
+      if (!error || typeof error !== 'object') continue;
+      const { message, code } = error as { message?: unknown; code?: unknown };
+      if (typeof message === 'string' && message.length > 0) {
+        return {
+          message,
+          ...(typeof code === 'string' || typeof code === 'number' ? { code } : {}),
+        };
+      }
+    } catch {
+      // malformed SSE data line — not this function's concern, keep scanning
+    }
+  }
+  return null;
+}
+
 /** Streaming SSE buffer (one or more `data: {...}` frames): real output means any chunk carried content. */
 export function sseHasContent(buffer: string): boolean {
   for (const line of buffer.split('\n')) {

--- a/packages/llm-gateway/src/usage/index.ts
+++ b/packages/llm-gateway/src/usage/index.ts
@@ -4,4 +4,5 @@ export type { ExtractedUsage } from './extract';
 export { calculateCost } from './pricing';
 export type { CostBreakdown, TokenUsage } from './pricing';
 
-export { jsonHasContent, sseHasContent } from './completion-guard';
+export { jsonHasContent, sseErrorFrame, sseHasContent } from './completion-guard';
+export type { SseErrorFrame } from './completion-guard';

--- a/packages/shared/src/llm-catalog/index.ts
+++ b/packages/shared/src/llm-catalog/index.ts
@@ -57,6 +57,12 @@ export interface ManagedModel {
   // size the conversation and fire auto-compaction. This is the CANONICAL home —
   // it used to be backfilled from a hardcoded table in the sandbox agent server.
   limit: { context: number; output: number };
+  // OpenRouter request-level provider routing preferences (their `provider`
+  // body field), for 'openrouter'-transport models only. Without this,
+  // OpenRouter load-balances across every host serving the slug — including
+  // low-uptime fp4 requantizations that stall mid-generation until OpenRouter
+  // kills the stream with "Upstream idle timeout exceeded".
+  openrouterProvider?: Record<string, unknown>;
 }
 
 // Managed model ids are single-segment (no `provider/` prefix). They are served
@@ -100,6 +106,9 @@ export const MANAGED_MODELS: ManagedModel[] = [
     tier: "balanced",
     vision: false,
     limit: { context: 1_000_000, output: 131_072 },
+    // Prefer Z.AI's first-party endpoint (99.9%+ uptime, native fp8). Fallbacks
+    // stay enabled so an actual Z.AI outage still routes rather than failing.
+    openrouterProvider: { order: ["z-ai"], allow_fallbacks: true },
   },
   {
     id: "qwen3.7-max",


### PR DESCRIPTION
## Problem — prod "Upstream idle timeout exceeded" turn failures

Veyris demo session `a7c68404` (and recurring elsewhere): a turn on `glm-5.2` dies mid-`write`-tool with **"Upstream idle timeout exceeded"**.

**Root cause (traced end-to-end via prod logs + the sandbox's opencode session):**
- Gateway request `req_mr891ourn7koy8tf` (20:34:18Z, matches the failing opencode message to the ms): OpenRouter stream ran 122.7s and delivered only **115 completion tokens** — the GLM host had stalled mid-generation.
- **None of our timeouts fired**: `heartbeats: 0`, `downstreamAlive: true`, ALB 300s / Bun 255s / api proxy untouched. The timeout is **OpenRouter's own upstream idle timer** against the model host.
- OpenRouter load-balances `z-ai/glm-5.2` across ~20 hosts, incl. fp4 requants and hosts at 89–97% uptime (DigitalOcean currently in outage status). Managed traffic gets whatever is cheapest.
- Bonus bug: the error arrives as an **in-stream error frame on a clean 200**, so the gateway logged and traced this dead turn as ✓ success (and Langfuse/api traces say ok). Zero observability.

## Fix
1. **`ManagedModel.openrouterProvider`** → OpenRouter request-level `provider` routing prefs. `glm-5.2` pins `order: ["z-ai"]` (first-party host, 99.94% uptime, native fp8) with `allow_fallbacks: true`.
2. **`UpstreamDescriptor.bodyExtras`** merged into the openai-compat payload (wins over client fields; resolved model still wins over extras). The api's managed OpenRouter descriptor carries `{provider: ...}` through it.
3. **`sseErrorFrame()`** — relayStream parses the settled SSE buffer; an in-stream error frame now warn-logs and settles the trace as `ok:false, errorCode: upstream_stream_error` (✗ log line) instead of silent ✓. Frames still relayed verbatim to opencode; tokens still billed.
4. Locked in a test that pre-content error frames keep falling into the existing empty-completion retry path (#4104).

## Retry semantics after this PR
- connect/5xx: 3 attempts per candidate w/ backoff + breaker, then failover (unchanged)
- empty completion or error-frame-before-content: up to 3 attempts per candidate, then failover (unchanged, now tested)
- error frame mid-stream after content: cannot be replayed by the gateway (content already relayed) — now **visible/alertable**; probability cut by host pinning. True turn-level auto-resume = follow-up in opencode/agent-server.

## Testing
- `packages/llm-gateway`: 123 tests pass (12 new)
- `packages/shared` llm-catalog: 24 pass; `apps/api` llm-gateway: 69 pass
- tsc clean on llm-gateway, shared, api; biome clean on all touched files

Urgent: intended for staging → immediate prod promote.