### PR TITLE
feat(sandbox-agent): auto-resume root turns killed by transient provider errors

### DIFF
--- a/apps/kortix-sandbox-agent-server/src/__tests__/turn-auto-resume.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/turn-auto-resume.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, test } from 'bun:test';
+import type { OpencodeTurnError } from '../opencode-events';
+import { createTurnAutoResumer, isTransientTurnError } from '../turn-auto-resume';
+
+describe('isTransientTurnError', () => {
+  test('the prod failure — OpenRouter mid-stream idle timeout (JSON-quoted message)', () => {
+    expect(
+      isTransientTurnError({ name: 'UnknownError', message: '"Upstream idle timeout exceeded"' }),
+    ).toBe(true);
+  });
+
+  test('opencode retryable flag wins', () => {
+    expect(isTransientTurnError({ name: 'APIError', isRetryable: true })).toBe(true);
+  });
+
+  test('rate limit and server errors are transient', () => {
+    expect(isTransientTurnError({ name: 'APIError', statusCode: 429 })).toBe(true);
+    expect(isTransientTurnError({ name: 'APIError', statusCode: 503 })).toBe(true);
+    expect(isTransientTurnError({ name: 'APIError', statusCode: 408 })).toBe(true);
+  });
+
+  test('user aborts and auth/credit failures are never resumed', () => {
+    expect(isTransientTurnError({ name: 'MessageAbortedError', message: 'aborted' })).toBe(false);
+    expect(isTransientTurnError({ name: 'ProviderAuthError', providerID: 'kortix' })).toBe(false);
+    expect(isTransientTurnError({ name: 'APIError', statusCode: 401 })).toBe(false);
+    expect(isTransientTurnError({ name: 'APIError', statusCode: 402, isRetryable: true })).toBe(
+      false,
+    );
+    expect(isTransientTurnError({ name: 'APIError', statusCode: 400 })).toBe(false);
+  });
+
+  test('connection failures match by message', () => {
+    expect(isTransientTurnError({ message: 'Connection reset by server' })).toBe(true);
+    expect(isTransientTurnError({ message: 'fetch failed' })).toBe(true);
+    expect(isTransientTurnError({ message: 'socket hang up' })).toBe(true);
+  });
+
+  test('unknown errors without a transient shape stay fatal', () => {
+    expect(isTransientTurnError(undefined)).toBe(false);
+    expect(isTransientTurnError({})).toBe(false);
+    expect(isTransientTurnError({ name: 'UnknownError', message: 'model not found' })).toBe(false);
+  });
+});
+
+// ── resumer harness ──────────────────────────────────────────────────────────
+
+const IDLE_TIMEOUT: OpencodeTurnError = {
+  name: 'UnknownError',
+  message: '"Upstream idle timeout exceeded"',
+};
+
+interface Harness {
+  resumer: ReturnType<typeof createTurnAutoResumer>;
+  prompts: Array<{ url: string; body: unknown }>;
+  setLastMessage: (m: { role: string; error?: boolean; completed?: boolean } | null) => void;
+  setIsRoot: (v: boolean) => void;
+  advance: (ms: number) => void;
+}
+
+function makeHarness(): Harness {
+  let lastMessage: { role: string; error?: boolean; completed?: boolean } | null = {
+    role: 'assistant',
+    error: true,
+    completed: true,
+  };
+  let isRoot = true;
+  let clock = 1_000_000;
+  const prompts: Array<{ url: string; body: unknown }> = [];
+
+  const fetchImpl = (async (input: string | URL | Request, init?: RequestInit) => {
+    const url = String(input);
+    if (url.includes('/prompt_async')) {
+      prompts.push({ url, body: JSON.parse(String(init?.body)) });
+      return new Response('{}', { status: 200 });
+    }
+    if (url.includes('/message')) {
+      const rows = lastMessage
+        ? [
+            {
+              info: {
+                role: lastMessage.role,
+                ...(lastMessage.error ? { error: { name: 'UnknownError' } } : {}),
+                time: lastMessage.completed ? { completed: clock } : {},
+              },
+            },
+          ]
+        : [];
+      return new Response(JSON.stringify(rows), { status: 200 });
+    }
+    return new Response('{}', { status: 200 });
+  }) as typeof fetch;
+
+  const resumer = createTurnAutoResumer({
+    opencode: { getInternalUrl: () => 'http://127.0.0.1:4096' },
+    cfg: { workspace: '/workspace' },
+    isRoot: async () => isRoot,
+    fetchImpl,
+    sleep: async () => {},
+    now: () => clock,
+  });
+
+  return {
+    resumer,
+    prompts,
+    setLastMessage: (m) => {
+      lastMessage = m;
+    },
+    setIsRoot: (v) => {
+      isRoot = v;
+    },
+    advance: (ms) => {
+      clock += ms;
+    },
+  };
+}
+
+describe('createTurnAutoResumer', () => {
+  test('delivers a resume prompt for a transient root-turn error', async () => {
+    const h = makeHarness();
+    const resumed = await h.resumer.maybeResume('ses_root', IDLE_TIMEOUT);
+    expect(resumed).toBe(true);
+    expect(h.prompts.length).toBe(1);
+    const prompt = h.prompts[0];
+    if (!prompt) throw new Error('expected a delivered prompt');
+    const body = prompt.body as { parts: Array<{ type: string; text: string }> };
+    const part = body.parts[0];
+    if (!part) throw new Error('expected a text part');
+    expect(part.type).toBe('text');
+    expect(part.text).toContain('Upstream idle timeout exceeded');
+    expect(part.text).toContain('Do not redo work that already succeeded');
+    // No model override — the session keeps its own model.
+    expect('model' in (prompt.body as Record<string, unknown>)).toBe(false);
+  });
+
+  test('never resumes a subagent session', async () => {
+    const h = makeHarness();
+    h.setIsRoot(false);
+    expect(await h.resumer.maybeResume('ses_child', IDLE_TIMEOUT)).toBe(false);
+    expect(h.prompts.length).toBe(0);
+  });
+
+  test('never resumes a permanent error', async () => {
+    const h = makeHarness();
+    expect(
+      await h.resumer.maybeResume('ses_root', { name: 'MessageAbortedError', message: 'aborted' }),
+    ).toBe(false);
+    expect(h.prompts.length).toBe(0);
+  });
+
+  test('budget: at most 3 resumes per window, then the error surfaces', async () => {
+    const h = makeHarness();
+    expect(await h.resumer.maybeResume('ses_root', IDLE_TIMEOUT)).toBe(true);
+    expect(await h.resumer.maybeResume('ses_root', IDLE_TIMEOUT)).toBe(true);
+    expect(await h.resumer.maybeResume('ses_root', IDLE_TIMEOUT)).toBe(true);
+    expect(await h.resumer.maybeResume('ses_root', IDLE_TIMEOUT)).toBe(false);
+    expect(h.prompts.length).toBe(3);
+    // Budget replenishes after the window passes.
+    h.advance(16 * 60_000);
+    expect(await h.resumer.maybeResume('ses_root', IDLE_TIMEOUT)).toBe(true);
+    expect(h.prompts.length).toBe(4);
+  });
+
+  test('budget is per-session', async () => {
+    const h = makeHarness();
+    for (let i = 0; i < 3; i++) await h.resumer.maybeResume('ses_a', IDLE_TIMEOUT);
+    expect(await h.resumer.maybeResume('ses_a', IDLE_TIMEOUT)).toBe(false);
+    expect(await h.resumer.maybeResume('ses_b', IDLE_TIMEOUT)).toBe(true);
+  });
+
+  test('skips (but suppresses the stale error) when the session moved on during backoff', async () => {
+    const h = makeHarness();
+    h.setLastMessage({ role: 'user' });
+    expect(await h.resumer.maybeResume('ses_root', IDLE_TIMEOUT)).toBe(true);
+    expect(h.prompts.length).toBe(0);
+  });
+
+  test('surfaces the error when the session cannot be inspected', async () => {
+    const h = makeHarness();
+    h.setLastMessage(null);
+    expect(await h.resumer.maybeResume('ses_root', IDLE_TIMEOUT)).toBe(false);
+    expect(h.prompts.length).toBe(0);
+  });
+
+  test('kill switch KORTIX_TURN_AUTO_RESUME=0 disables resumes', async () => {
+    const h = makeHarness();
+    process.env.KORTIX_TURN_AUTO_RESUME = '0';
+    try {
+      expect(await h.resumer.maybeResume('ses_root', IDLE_TIMEOUT)).toBe(false);
+      expect(h.prompts.length).toBe(0);
+    } finally {
+      delete process.env.KORTIX_TURN_AUTO_RESUME;
+    }
+  });
+});

--- a/apps/kortix-sandbox-agent-server/src/main.ts
+++ b/apps/kortix-sandbox-agent-server/src/main.ts
@@ -32,6 +32,7 @@ import {
 import type { SandboxBootState } from './routes/health'
 import { installShutdownHandlers } from './shutdown'
 import { startStaticWebServer } from './static-web'
+import { createTurnAutoResumer } from './turn-auto-resume'
 
 // Pin file for the opencode session created from KORTIX_INITIAL_PROMPT.
 // Webhook follow-ups (e.g. Slack thread replies) read this to deliver new
@@ -335,8 +336,20 @@ async function startSessionRuntime(
       logger.warn('[opencode-events] turn-end relay failed', { err: (err as Error).message }),
     )
   }
+  // Transient provider/stream failures (a host stall killed mid-stream, a 5xx
+  // after opencode's own retries) get auto-resumed instead of ending the turn —
+  // the error only reaches the user when it's permanent, when the resume can't
+  // be delivered, or when the rolling retry budget is exhausted.
+  const autoResumer = createTurnAutoResumer({
+    opencode,
+    cfg,
+    isRoot: (sid) => isRootOpencodeSession(sid, opencode, cfg),
+  })
   const onSessionError = (opencodeSessionId: string, error?: OpencodeTurnError) => {
-    void relayTurnEndToApi(opencodeSessionId, 'error', opencode, cfg, error).catch((err) =>
+    void (async () => {
+      if (await autoResumer.maybeResume(opencodeSessionId, error)) return
+      await relayTurnEndToApi(opencodeSessionId, 'error', opencode, cfg, error)
+    })().catch((err) =>
       logger.warn('[opencode-events] turn-end relay failed', { err: (err as Error).message }),
     )
   }

--- a/apps/kortix-sandbox-agent-server/src/turn-auto-resume.ts
+++ b/apps/kortix-sandbox-agent-server/src/turn-auto-resume.ts
@@ -1,0 +1,223 @@
+import type { Config } from './config';
+import { logger } from './logger';
+import type { Opencode } from './opencode';
+import type { OpencodeTurnError } from './opencode-events';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Turn-level auto-resume: when a ROOT turn dies from a TRANSIENT provider/stream
+// failure (a stalled model host killed mid-stream — "Upstream idle timeout
+// exceeded" — a connection reset, a 5xx after opencode's own retries), the turn
+// is re-prompted to continue instead of surfacing a dead red turn to the user.
+//
+// WHY here and not lower in the stack: the gateway cannot replay a stream whose
+// bytes were already relayed (a fresh sample would splice two different
+// generations), and opencode (pinned npm) does not retry an error that arrives
+// mid-stream. The agent server is the platform-owned layer that already watches
+// `session.error` and owns the session lifecycle — the only place a turn can be
+// resumed with full context.
+//
+// LOOP SAFETY: a failed turn can end in `session.idle` as well as
+// `session.error`, so resetting a counter on idle would re-arm the budget on
+// every failure and retry forever. The budget is a rolling window instead:
+// at most MAX_ATTEMPTS resumes per session per WINDOW_MS, with growing backoff,
+// regardless of how the intervening turns ended. Exhausted budget → the error
+// relays/surfaces exactly as before this feature.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const MAX_ATTEMPTS_PER_WINDOW = 3;
+const WINDOW_MS = 15 * 60_000;
+// 5s, 15s, 45s — long enough for a wedged upstream host to be rotated out,
+// short enough that a demo/user barely notices the hiccup.
+const BACKOFF_MS = [5_000, 15_000, 45_000];
+
+/** Kill switch: KORTIX_TURN_AUTO_RESUME=0 restores the old fail-fast behavior. */
+function enabled(): boolean {
+  return (process.env.KORTIX_TURN_AUTO_RESUME ?? '1').trim() !== '0';
+}
+
+// Errors that must NEVER be auto-resumed: the user aborted on purpose, or the
+// failure needs a human/config fix (auth, credits, malformed request).
+const PERMANENT_ERROR_NAMES = new Set(['MessageAbortedError', 'ProviderAuthError']);
+
+// Message shapes of transient infrastructure failures seen from providers —
+// matched only after the permanent names/statuses above are excluded. Includes
+// OpenRouter's mid-stream "Upstream idle timeout exceeded" (the exact prod
+// failure this feature exists for), which arrives as an UnknownError whose
+// message is sometimes JSON-quoted.
+const TRANSIENT_MESSAGE =
+  /upstream idle timeout|connection (reset|closed|error)|econnreset|econnrefused|etimedout|socket hang ?up|fetch failed|premature close|network error|overloaded|empty completion|upstream_stream_error|internal server error|bad gateway|service unavailable|gateway.?time.?out|stream (closed|error|disconnected)|terminated/i;
+
+/** Is this turn failure a transient provider/stream error worth one more try? */
+export function isTransientTurnError(error?: OpencodeTurnError): boolean {
+  if (!error) return false;
+  if (error.name && PERMANENT_ERROR_NAMES.has(error.name)) return false;
+  const status = error.statusCode;
+  if (typeof status === 'number') {
+    if (status === 408 || status === 429 || status >= 500) return true;
+    // Remaining 4xx (auth, credits, bad request, not found) are the caller's to
+    // fix — a retry would fail identically and burn budget.
+    if (status >= 400) return false;
+  }
+  if (error.isRetryable === true) return true;
+  return typeof error.message === 'string' && TRANSIENT_MESSAGE.test(error.message);
+}
+
+/** Trim + de-JSON-quote an upstream error message for embedding in the resume prompt. */
+function describeError(error: OpencodeTurnError): string {
+  let msg = (error.message ?? error.name ?? 'unknown provider error').trim();
+  // OpenRouter error frames arrive with the message JSON-quoted ("\"...\"").
+  if (msg.startsWith('"') && msg.endsWith('"') && msg.length > 1) msg = msg.slice(1, -1);
+  return msg.length > 200 ? `${msg.slice(0, 200)}…` : msg;
+}
+
+function resumePrompt(error: OpencodeTurnError): string {
+  return (
+    `[auto-recovery] Your previous response was interrupted by a transient provider error (${describeError(error)}). ` +
+    'Resume the task from where it stopped: check which step or tool call was cut off, re-run it if it did not complete, ' +
+    'and continue to the original goal. Do not redo work that already succeeded.'
+  );
+}
+
+export interface TurnAutoResumerDeps {
+  opencode: Pick<Opencode, 'getInternalUrl'>;
+  cfg: Pick<Config, 'workspace'>;
+  /** Root check — subagent (Task tool) failures are the parent model's to handle. */
+  isRoot: (opencodeSessionId: string) => Promise<boolean>;
+  fetchImpl?: typeof fetch;
+  sleep?: (ms: number) => Promise<void>;
+  now?: () => number;
+}
+
+export interface TurnAutoResumer {
+  /**
+   * Try to auto-resume an errored turn. Resolves true when a resume prompt was
+   * delivered (or the session verifiably moved on by itself) — the caller must
+   * then NOT relay the error as the turn's final outcome. Resolves false when
+   * the error is not resumable (permanent error, subagent session, budget
+   * exhausted, resume delivery failed) — the caller relays it exactly as before.
+   */
+  maybeResume(opencodeSessionId: string, error?: OpencodeTurnError): Promise<boolean>;
+}
+
+interface LastMessageView {
+  role?: string;
+  hasError: boolean;
+  completed: boolean;
+}
+
+export function createTurnAutoResumer(deps: TurnAutoResumerDeps): TurnAutoResumer {
+  const fetchImpl = deps.fetchImpl ?? fetch;
+  const sleep = deps.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+  const now = deps.now ?? Date.now;
+  // Per-session resume timestamps within the rolling window.
+  const attempts = new Map<string, number[]>();
+
+  function takeBudget(sessionId: string): number | null {
+    const cutoff = now() - WINDOW_MS;
+    const stamps = (attempts.get(sessionId) ?? []).filter((t) => t >= cutoff);
+    if (stamps.length >= MAX_ATTEMPTS_PER_WINDOW) {
+      attempts.set(sessionId, stamps);
+      return null;
+    }
+    const attemptIndex = stamps.length;
+    stamps.push(now());
+    attempts.set(sessionId, stamps);
+    return attemptIndex;
+  }
+
+  async function readLastMessage(sessionId: string): Promise<LastMessageView | null> {
+    try {
+      const url = `${deps.opencode.getInternalUrl()}/session/${encodeURIComponent(sessionId)}/message?directory=${encodeURIComponent(deps.cfg.workspace)}`;
+      const res = await fetchImpl(url, { signal: AbortSignal.timeout(5_000) });
+      if (!res.ok) return null;
+      const rows = (await res.json()) as Array<{
+        info?: { role?: string; error?: unknown; time?: { completed?: number } };
+      }>;
+      if (!Array.isArray(rows) || rows.length === 0) return null;
+      const info = rows[rows.length - 1]?.info;
+      return {
+        role: info?.role,
+        hasError: Boolean(info?.error),
+        completed: Boolean(info?.time?.completed),
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  async function deliverResume(sessionId: string, error: OpencodeTurnError): Promise<boolean> {
+    try {
+      const url = `${deps.opencode.getInternalUrl()}/session/${encodeURIComponent(sessionId)}/prompt_async?directory=${encodeURIComponent(deps.cfg.workspace)}`;
+      // No `model` — the session continues on whatever model it was already using.
+      const res = await fetchImpl(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ parts: [{ type: 'text', text: resumePrompt(error) }] }),
+        signal: AbortSignal.timeout(15_000),
+      });
+      return res.ok;
+    } catch {
+      return false;
+    }
+  }
+
+  async function maybeResume(sessionId: string, error?: OpencodeTurnError): Promise<boolean> {
+    if (!enabled()) return false;
+    if (!error || !isTransientTurnError(error)) return false;
+    if (!(await deps.isRoot(sessionId))) return false;
+
+    const attemptIndex = takeBudget(sessionId);
+    if (attemptIndex === null) {
+      logger.warn('[turn-auto-resume] budget exhausted — surfacing error', {
+        sessionId,
+        maxAttempts: MAX_ATTEMPTS_PER_WINDOW,
+        windowMs: WINDOW_MS,
+        errorName: error.name,
+      });
+      return false;
+    }
+
+    const backoffMs = BACKOFF_MS[Math.min(attemptIndex, BACKOFF_MS.length - 1)] ?? 5_000;
+    logger.info('[turn-auto-resume] transient turn error — resuming after backoff', {
+      sessionId,
+      attempt: attemptIndex + 1,
+      backoffMs,
+      errorName: error.name,
+      errorMessage: describeError(error),
+    });
+    await sleep(backoffMs);
+
+    // Re-check the session AFTER the backoff: only deliver the resume prompt if
+    // the errored assistant message is still the latest thing that happened. If
+    // the user (or a parallel flow) already prompted again, or a new turn is
+    // running, the session moved on — deliver nothing, and report true so the
+    // stale error isn't relayed as the turn's final outcome.
+    const last = await readLastMessage(sessionId);
+    if (!last) {
+      logger.warn('[turn-auto-resume] could not inspect session — surfacing error', { sessionId });
+      return false;
+    }
+    if (!(last.role === 'assistant' && last.hasError)) {
+      logger.info('[turn-auto-resume] session moved on during backoff — skipping resume', {
+        sessionId,
+        lastRole: last.role,
+      });
+      return true;
+    }
+
+    const delivered = await deliverResume(sessionId, error);
+    if (!delivered) {
+      logger.warn('[turn-auto-resume] resume prompt delivery failed — surfacing error', {
+        sessionId,
+      });
+      return false;
+    }
+    logger.info('[turn-auto-resume] resume prompt delivered', {
+      sessionId,
+      attempt: attemptIndex + 1,
+    });
+    return true;
+  }
+
+  return { maybeResume };
+}


### PR DESCRIPTION
## Why

Completes the "Upstream idle timeout exceeded" fix (#4146 / v0.9.94). Host pinning makes the mid-stream stall rare; this PR makes the residual case (and any transient provider blip: connection reset, 5xx after retries, rate-limit exhaustion) **self-heal** instead of ending the turn with a red error.

## Why here

- The gateway cannot replay a stream whose bytes were already relayed (a fresh sample would splice two different generations).
- opencode (pinned npm 1.17.11) does not retry an error that arrives mid-stream.
- The agent server already watches `session.error` and owns the session lifecycle — the only platform-owned layer that can resume a turn with full context.

## Semantics

- **Transient-only**: never `MessageAbortedError` (user stop), `ProviderAuthError`, or non-retryable 4xx; yes for 408/429/5xx, opencode's `isRetryable`, and known transient message shapes (incl. the JSON-quoted OpenRouter frame).
- **Root sessions only** — subagent failures are the parent model's to handle.
- **Loop-safe budget**: max 3 resumes / 15 min / session, backoff 5s/15s/45s. Deliberately NOT reset on `session.idle` (failed turns can end idle → reset there would re-arm the budget on every failure and retry forever).
- **Post-backoff re-check**: resumes only if the errored assistant message is still the latest thing in the session — a user who already re-prompted wins, and their new turn isn't disturbed.
- **Graceful fallback**: delivery failure or exhausted budget → the error relays to Slack/UI exactly as before this PR.
- **Kill switch**: `KORTIX_TURN_AUTO_RESUME=0`.

## Delivery path

Agent server is baked into the API image; the snapshot hash's runtime fingerprint covers the `kortix-agent` binary bytes, so templates rebuild automatically on next use — new sessions pick this up with the normal promote, running sandboxes keep old behavior until restart.

## Testing

- 14 new tests (classifier + resumer: budget window, per-session isolation, superseded-session skip, delivery-failure fallback, kill switch); agent server suite 157 pass total
- tsc + biome clean