### PR TITLE
feat(sdk+web): perfect tool-call handling — embedded failures surfaced everywhere + dev credit-gate exemption

### DIFF
--- a/apps/api/src/__tests__/unit-router-credit-gate.test.ts
+++ b/apps/api/src/__tests__/unit-router-credit-gate.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from 'bun:test';
+import { creditGateExemptEnv } from '../router/services/credit-gate-env';
+
+// dev/preview QA exemption from the router credit gate — mirrors
+// accountIsFreeTierForModels' env carve-out (see unit-tier-model-entitlement).
+// Regression: web_search 402'd "Insufficient credits" for every fresh dev
+// account because billing internal is intentionally enabled on dev.
+describe('creditGateExemptEnv', () => {
+  test('dev and preview are exempt from the internal credit gate', () => {
+    expect(creditGateExemptEnv('dev')).toBe(true);
+    expect(creditGateExemptEnv('preview')).toBe(true);
+  });
+
+  test('prod and staging keep the real credit gate', () => {
+    expect(creditGateExemptEnv('prod')).toBe(false);
+    expect(creditGateExemptEnv('staging')).toBe(false);
+  });
+
+  test('no-arg form matches the explicit call for the ambient env', () => {
+    const ambient = process.env.INTERNAL_KORTIX_ENV || 'dev';
+    expect(creditGateExemptEnv()).toBe(creditGateExemptEnv(ambient));
+  });
+});

--- a/apps/api/src/router/services/billing.ts
+++ b/apps/api/src/router/services/billing.ts
@@ -1,4 +1,7 @@
 import { config, getToolCost } from '../../config';
+
+import { creditGateExemptEnv } from './credit-gate-env';
+
 import {
   checkCredits as checkCreditsDb,
   deductCredits as deductCreditsDb,
@@ -17,7 +20,7 @@ export async function checkCredits(
 ): Promise<BillingCheckResult> {
   // When billing is disabled (self-host/dev), all checks pass — no Stripe, no
   // real subscriptions, and gating on a $0 balance just stalls everything.
-  if (!config.KORTIX_BILLING_INTERNAL_ENABLED) {
+  if (!config.KORTIX_BILLING_INTERNAL_ENABLED || creditGateExemptEnv()) {
     return { hasCredits: true, balance: 0, message: 'Credits check skipped (billing disabled)' };
   }
 
@@ -51,7 +54,7 @@ export async function deductToolCredits(
   // Skip deduction when billing is disabled (self-host/dev) — no Stripe, no
   // real subscriptions, billing on a $0 balance would just stall everything
   // with InsufficientCreditsError.
-  if (!config.KORTIX_BILLING_INTERNAL_ENABLED) {
+  if (!config.KORTIX_BILLING_INTERNAL_ENABLED || creditGateExemptEnv()) {
     return { success: true, cost: 0, newBalance: 0 };
   }
 
@@ -96,7 +99,7 @@ export async function deductLLMCredits(
   }
 
   // Skip deduction when billing is disabled (see deductToolCredits for rationale).
-  if (!config.KORTIX_BILLING_INTERNAL_ENABLED) {
+  if (!config.KORTIX_BILLING_INTERNAL_ENABLED || creditGateExemptEnv()) {
     return { success: true, cost: 0, newBalance: 0 };
   }
 

--- a/apps/api/src/router/services/credit-gate-env.ts
+++ b/apps/api/src/router/services/credit-gate-env.ts
@@ -1,0 +1,17 @@
+import { config } from '../../config';
+
+/**
+ * dev/preview QA exemption from the internal credit gate — the same policy
+ * carve-out as `accountIsFreeTierForModels` (billing/services/tiers.ts): every
+ * fresh dev/preview signup has a $0 credit account, so with billing internal
+ * enabled (intentional on dev, to exercise Stripe test mode elsewhere) NO QA
+ * account could ever use billed router tools (web_search 402'd with
+ * "Insufficient credits" on every call). prod and staging keep the real gate —
+ * staging is where the credit gate itself gets verified.
+ *
+ * `env` is a parameter (defaulting to the deployed value) purely so tests can
+ * exercise every branch deterministically without module-mocking config.
+ */
+export function creditGateExemptEnv(env: string = config.INTERNAL_KORTIX_ENV): boolean {
+  return env === 'dev' || env === 'preview';
+}

--- a/apps/web/src/features/session/tool-output-format.test.ts
+++ b/apps/web/src/features/session/tool-output-format.test.ts
@@ -4,6 +4,7 @@ import {
   cleanResultSnippet,
   formatRawOutput,
   looksLikeJsonPayload,
+  parseEmbeddedFailure,
   recoverLinkResults,
 } from './tool-output-format';
 
@@ -91,5 +92,52 @@ describe('tool output formatting', () => {
   test('recovers nothing from plain prose', () => {
     expect(recoverLinkResults('just some text, no json here')).toEqual([]);
     expect(recoverLinkResults(undefined)).toEqual([]);
+  });
+});
+
+describe('parseEmbeddedFailure', () => {
+  test('unwraps the real web_search 402 transcript to the innermost message', () => {
+    const output = JSON.stringify({
+      query: 'best financial benchmarks',
+      success: false,
+      error:
+        'Error: 402 Error: {"error":true,"message":"Insufficient credits","status":402}',
+    });
+    expect(parseEmbeddedFailure(output)).toEqual({
+      message: 'Insufficient credits',
+      status: 402,
+    });
+  });
+
+  test('keeps a flat error message as-is when there is no nested JSON', () => {
+    const output = JSON.stringify({ success: false, error: 'Search provider timed out' });
+    expect(parseEmbeddedFailure(output)).toEqual({
+      message: 'Search provider timed out',
+      status: undefined,
+    });
+  });
+
+  test('handles a double-encoded (stringified) failure payload', () => {
+    const inner = JSON.stringify({ success: false, error: 'Rate limited' });
+    expect(parseEmbeddedFailure(JSON.stringify(inner))).toEqual({
+      message: 'Rate limited',
+      status: undefined,
+    });
+  });
+
+  test('returns null for a successful payload', () => {
+    const output = JSON.stringify({ query: 'x', results: [{ title: 'a', url: 'http://a.com' }] });
+    expect(parseEmbeddedFailure(output)).toBeNull();
+  });
+
+  test('returns null for success:false without a string error', () => {
+    expect(parseEmbeddedFailure(JSON.stringify({ success: false }))).toBeNull();
+    expect(parseEmbeddedFailure(JSON.stringify({ success: false, error: 123 }))).toBeNull();
+  });
+
+  test('returns null for non-JSON, empty, or undefined input', () => {
+    expect(parseEmbeddedFailure('not json')).toBeNull();
+    expect(parseEmbeddedFailure('')).toBeNull();
+    expect(parseEmbeddedFailure(undefined)).toBeNull();
   });
 });

--- a/apps/web/src/features/session/tool-output-format.ts
+++ b/apps/web/src/features/session/tool-output-format.ts
@@ -62,6 +62,79 @@ export function cleanResultSnippet(content: string | undefined, maxChars = 200):
   return s.length > maxChars ? s.slice(0, maxChars).trimEnd() + '…' : s;
 }
 
+export interface EmbeddedFailure {
+  /** Fully-unwrapped, human-readable error message. */
+  message: string;
+  /** HTTP status code recovered from a nested error payload, if any. */
+  status?: number;
+}
+
+/**
+ * Detect the "well-known" embedded-failure shape some tools return even when
+ * the outer part state is `completed`: a JSON object with `success: false`
+ * and a string `error` field — e.g. a `web_search` call that hit a 402 from
+ * the search provider still reports `state.status: "completed"` because the
+ * *tool call* completed, only the underlying request failed.
+ *
+ * The `error` string is frequently itself a wrapper around a nested JSON
+ * error object (proxy error → upstream error), e.g.
+ * `"Error: 402 Error: {\"message\":\"Insufficient credits\",\"status\":402}"`.
+ * This unwraps up to a few levels of that nesting so callers can show the
+ * innermost human message ("Insufficient credits") instead of the raw blob.
+ *
+ * Deliberately conservative: only matches this exact `{success:false,
+ * error:string}` shape so it never misfires on legitimate tool payloads that
+ * happen to contain the words "success" or "error".
+ */
+export function parseEmbeddedFailure(output: string | undefined): EmbeddedFailure | null {
+  const trimmed = (output ?? '').trim();
+  if (!trimmed) return null;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+    if (typeof parsed === 'string') {
+      try {
+        parsed = JSON.parse(parsed);
+      } catch {
+        return null;
+      }
+    }
+  } catch {
+    return null;
+  }
+
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+  const obj = parsed as Record<string, unknown>;
+  if (obj.success !== false || typeof obj.error !== 'string' || !obj.error.trim()) return null;
+
+  let message = obj.error.trim();
+  let status: number | undefined;
+
+  // Unwrap `... : {json}` tails: proxy errors often wrap an upstream error
+  // object. Walk a few levels deep so a doubly-wrapped message still resolves.
+  for (let i = 0; i < 3; i++) {
+    const nestedMatch = message.match(/:\s*(\{[\s\S]*\})\s*$/);
+    if (!nestedMatch) break;
+    let nested: Record<string, unknown>;
+    try {
+      nested = JSON.parse(nestedMatch[1]);
+    } catch {
+      break;
+    }
+    if (typeof nested.status === 'number') status = nested.status;
+    if (typeof nested.message === 'string' && nested.message.trim()) {
+      message = nested.message.trim();
+    } else if (typeof nested.error === 'string' && nested.error.trim()) {
+      message = nested.error.trim();
+    } else {
+      break;
+    }
+  }
+
+  return { message, status };
+}
+
 export interface RecoveredResult {
   title: string;
   url: string;

--- a/apps/web/src/features/session/tool-renderers.tsx
+++ b/apps/web/src/features/session/tool-renderers.tsx
@@ -23,8 +23,10 @@ import {
 import { SubSessionModal } from '@/features/session/sub-session-modal';
 import {
   cleanResultSnippet,
+  type EmbeddedFailure,
   formatRawOutput,
   looksLikeJsonPayload,
+  parseEmbeddedFailure,
   recoverLinkResults,
 } from '@/features/session/tool-output-format';
 import {
@@ -3819,6 +3821,13 @@ function parseWebSearchOutput(output: string | any): WebSearchQueryResult[] {
   }
 
   if (parsed) {
+    // Embedded failure: { query, success:false, error } — the tool call
+    // itself completed, but the underlying search request failed (e.g. a 402
+    // from the provider). This is NOT a valid (if empty) result set — treat
+    // it as "no results" so the caller falls through to the failure UI
+    // instead of silently rendering a blank, success-looking query.
+    if (parsed.success === false) return [];
+
     // Batch mode: { results: [{ query, answer, results: [...] }] }
     if (parsed.results && Array.isArray(parsed.results) && parsed.results.length > 0) {
       const firstItem = parsed.results[0];
@@ -3972,6 +3981,49 @@ function wsFavicon(url: string): string | null {
   }
 }
 
+/**
+ * Small destructive "Failed" chip for a tool row's trigger — the inline
+ * equivalent of the `isError` badge used elsewhere in this file (e.g. the
+ * agent-task row), reused for tools whose output embeds a `success:false`
+ * failure even though the part status itself reports `completed`.
+ */
+function EmbeddedFailureBadge() {
+  return (
+    <span className="text-destructive bg-destructive/10 flex-shrink-0 rounded px-1.5 py-0.5 text-xs font-medium whitespace-nowrap">
+      Failed
+    </span>
+  );
+}
+
+/**
+ * Clear failure body for a tool whose call `completed` but whose parsed
+ * output embeds `{success:false, error}` — used so a provider-side failure
+ * (e.g. "402 Insufficient credits") never renders as blank, success-looking
+ * output. `heading` should name the action that failed ("Web search failed").
+ */
+function ToolFailureCard({ heading, failure }: { heading: string; failure: EmbeddedFailure }) {
+  return (
+    <div
+      className={cn(
+        'mx-3 mb-2.5 flex items-start gap-2 rounded-2xl border px-3 py-2.5',
+        STATUS_BORDER.destructive,
+        STATUS_BG.destructive,
+      )}
+    >
+      <CircleAlert className={cn('mt-0.5 size-3.5 flex-shrink-0', STATUS_TEXT.destructive)} />
+      <div className="min-w-0 flex-1 space-y-1">
+        <div className={cn('flex items-center gap-1.5 text-xs font-medium', STATUS_TEXT.destructive)}>
+          <span>{heading}</span>
+          {typeof failure.status === 'number' && (
+            <span className="font-mono text-xs opacity-70">HTTP {failure.status}</span>
+          )}
+        </div>
+        <p className="text-foreground/80 text-xs leading-relaxed break-words">{failure.message}</p>
+      </div>
+    </div>
+  );
+}
+
 function WebSearchTool({ part, defaultOpen, forceOpen, locked }: ToolProps) {
   const tHardcodedUi = useTranslations('hardcodedUi');
   const input = partInput(part);
@@ -3981,6 +4033,7 @@ function WebSearchTool({ part, defaultOpen, forceOpen, locked }: ToolProps) {
 
   // Access raw state output to handle both string and object types
   const rawOutput = part.state.status === 'completed' ? (part.state as any).output : undefined;
+  const rawOutputStr = typeof rawOutput === 'string' ? rawOutput : output;
   const queryResults = useMemo(
     () => parseWebSearchOutput(rawOutput ?? output),
     [rawOutput, output],
@@ -3989,11 +4042,19 @@ function WebSearchTool({ part, defaultOpen, forceOpen, locked }: ToolProps) {
     () => queryResults.reduce((n, q) => n + q.sources.length, 0),
     [queryResults],
   );
+  // The tool call itself completed, but the parsed output may still embed a
+  // provider-side failure (`{success:false, error}`, e.g. a 402 from the
+  // search API) — parseWebSearchOutput already returns no results for that
+  // shape, so surface it explicitly instead of rendering a blank success.
+  const failure = useMemo(
+    () => (status === 'completed' ? parseEmbeddedFailure(rawOutputStr) : null),
+    [status, rawOutputStr],
+  );
   const [expandedQuery, setExpandedQuery] = useState<number | null>(null);
 
   // Compact trigger badge
   const triggerBadge =
-    status === 'completed' && queryResults.length > 0
+    status === 'completed' && !failure && queryResults.length > 0
       ? queryResults.length > 1
         ? `${queryResults.length} queries`
         : totalSources > 0
@@ -4003,17 +4064,29 @@ function WebSearchTool({ part, defaultOpen, forceOpen, locked }: ToolProps) {
 
   return (
     <BasicTool
-      icon={<Search className="size-3.5 flex-shrink-0" />}
+      icon={
+        failure ? (
+          <CircleAlert className={cn('size-3.5 flex-shrink-0', STATUS_TEXT.destructive)} />
+        ) : (
+          <Search className="size-3.5 flex-shrink-0" />
+        )
+      }
       trigger={
         <div className="flex min-w-0 flex-1 items-center gap-1.5">
           <span className="text-foreground text-xs font-medium whitespace-nowrap">
             {tHardcodedUi.raw('componentsSessionToolRenderers.line3806JsxTextWebSearch')}
           </span>
           <span className="text-muted-foreground truncate font-mono text-xs">{query}</span>
-          {triggerBadge && (
-            <span className="text-primary/70 ml-auto flex-shrink-0 text-xs font-medium whitespace-nowrap">
-              {triggerBadge}
-            </span>
+          {failure ? (
+            <div className="ml-auto flex-shrink-0">
+              <EmbeddedFailureBadge />
+            </div>
+          ) : (
+            triggerBadge && (
+              <span className="text-primary/70 ml-auto flex-shrink-0 text-xs font-medium whitespace-nowrap">
+                {triggerBadge}
+              </span>
+            )
           )}
         </div>
       }
@@ -4133,6 +4206,8 @@ function WebSearchTool({ part, defaultOpen, forceOpen, locked }: ToolProps) {
             );
           })}
         </div>
+      ) : failure ? (
+        <ToolFailureCard heading="Web search failed" failure={failure} />
       ) : output ? (
         <ToolOutputFallback
           output={output}
@@ -4421,20 +4496,39 @@ function ImageSearchTool({ part, defaultOpen, forceOpen, locked }: ToolProps) {
     };
   }, [output, query]);
 
+  // Same embedded-failure shape as web_search: a completed call whose parsed
+  // output is `{success:false, error}` (e.g. a 402 from the search provider).
+  const failure = useMemo(
+    () => (status === 'completed' ? parseEmbeddedFailure(output) : null),
+    [status, output],
+  );
+
   return (
     <BasicTool
-      icon={<ImageIcon className="size-3.5 flex-shrink-0" />}
+      icon={
+        failure ? (
+          <CircleAlert className={cn('size-3.5 flex-shrink-0', STATUS_TEXT.destructive)} />
+        ) : (
+          <ImageIcon className="size-3.5 flex-shrink-0" />
+        )
+      }
       trigger={
         <div className="flex min-w-0 flex-1 items-center gap-1.5">
           <span className="text-foreground text-xs font-medium whitespace-nowrap">
             {tHardcodedUi.raw('componentsSessionToolRenderers.line4240JsxTextImageSearch')}
           </span>
           <span className="text-muted-foreground truncate font-mono text-xs">{displayQuery}</span>
-          {imageResults.length > 0 && (
-            <span className="text-muted-foreground/60 ml-auto flex-shrink-0 font-mono text-xs whitespace-nowrap">
-              {isBatch ? `${batchCount}q, ` : ''}
-              {imageResults.length} images
-            </span>
+          {failure ? (
+            <div className="ml-auto flex-shrink-0">
+              <EmbeddedFailureBadge />
+            </div>
+          ) : (
+            imageResults.length > 0 && (
+              <span className="text-muted-foreground/60 ml-auto flex-shrink-0 font-mono text-xs whitespace-nowrap">
+                {isBatch ? `${batchCount}q, ` : ''}
+                {imageResults.length} images
+              </span>
+            )
           )}
         </div>
       }
@@ -4475,6 +4569,8 @@ function ImageSearchTool({ part, defaultOpen, forceOpen, locked }: ToolProps) {
             })}
           </div>
         </div>
+      ) : failure ? (
+        <ToolFailureCard heading="Image search failed" failure={failure} />
       ) : output ? (
         <ToolOutputFallback
           output={output.slice(0, 3000)}
@@ -8581,7 +8677,18 @@ function parseToolName(tool: string): {
 export function GenericTool({ part }: ToolProps) {
   const output = partOutput(part);
   const input = partInput(part);
+  const status = partStatus(part);
   const { server, display } = useMemo(() => parseToolName(part.tool), [part.tool]);
+
+  // Generic hardening: a tool call can report `state.status: "completed"`
+  // while its own output embeds `{success:false, error}` (e.g. an
+  // integration proxy returning a 402/500 body as a "successful" tool
+  // result). Conservative on purpose — only this well-known shape flips the
+  // row from a completed look to a failed one.
+  const failure = useMemo(
+    () => (status === 'completed' ? parseEmbeddedFailure(output) : null),
+    [status, output],
+  );
 
   // Primary arg: first meaningful input value (matches reference's label() helper)
   const subtitle = useMemo(() => {
@@ -8628,12 +8735,19 @@ export function GenericTool({ part }: ToolProps) {
 
   return (
     <BasicTool
-      icon={<Cpu />}
+      icon={
+        failure ? (
+          <CircleAlert className={cn('size-3.5 flex-shrink-0', STATUS_TEXT.destructive)} />
+        ) : (
+          <Cpu />
+        )
+      }
       trigger={{
         title: display,
         subtitle,
         args: server ? [server, ...args] : args.length > 0 ? args : undefined,
       }}
+      badge={failure ? <EmbeddedFailureBadge /> : undefined}
     >
       {output ? <ToolOutputFallback output={output} toolName={part.tool} /> : null}
     </BasicTool>

--- a/apps/whitelabel-demo/src/components/chat/tool-call.tsx
+++ b/apps/whitelabel-demo/src/components/chat/tool-call.tsx
@@ -2,22 +2,35 @@
 
 /**
  * One agent tool call, rendered as a tidy collapsible card: an icon + humanized
- * name + a one-line summary derived from the args, a live status indicator, and
- * (expanded) the input args + output.
+ * name + a one-line summary, a live status indicator, and (expanded) a
+ * per-tool body built from `toolViewModel` — typed shapes for web/image
+ * search, shell, file read/write/edit, grep/glob search, task, todowrite,
+ * and question, with a pretty-JSON `generic` fallback for everything else.
  *
- * Takes a normalized `ToolView` from `@kortix/sdk/turns` (`classifyPart`'s tool
- * variant) instead of the raw wire tool part — status is already mapped to
- * 'pending'|'running'|'done'|'error', and the icon comes from `toolInfo`'s
+ * Takes a normalized `ToolView` from `@kortix/sdk/turns` (`classifyPart`'s
+ * tool variant) instead of the raw wire tool part — status is already mapped
+ * to 'pending'|'running'|'done'|'error' (including router/executor tools like
+ * `web_search` that report `state.status: "completed"` but wrap a failure in
+ * their JSON output body — `ToolView` reclassifies those as `'error'` so they
+ * never render as a quiet success), and the icon comes from `toolInfo`'s
  * `category` (a real registry keyed on tool name) instead of string-sniffing
  * the tool name (`t.includes('bash')` etc.).
  */
 
+import { Badge } from '@/components/ui/badge';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 import { cn } from '@/lib/utils';
-import { type ToolCategory, type ToolView, toolInfo } from '@kortix/sdk/turns';
+import {
+  type ToolCategory,
+  type ToolView,
+  type ToolViewModel,
+  toolInfo,
+  toolViewModel,
+} from '@kortix/sdk/turns';
 import {
   Bot,
   Check,
+  CheckSquare,
   ChevronRight,
   CircleAlert,
   FileText,
@@ -41,25 +54,6 @@ const CATEGORY_ICON: Record<ToolCategory, LucideIcon> = {
   other: Wrench,
 };
 
-function summarize(input: Record<string, unknown> | undefined): string {
-  if (!input) return '';
-  const i = input as Record<string, unknown>;
-  const value =
-    i.command ??
-    i.filePath ??
-    i.path ??
-    i.file ??
-    i.pattern ??
-    i.query ??
-    i.url ??
-    i.description ??
-    i.prompt ??
-    '';
-  return String(value ?? '')
-    .split('\n')[0]
-    .slice(0, 140);
-}
-
 function StatusDot({ status }: { status: ToolView['status'] }) {
   if (status === 'running' || status === 'pending')
     return <Loader2 className="size-3.5 shrink-0 animate-spin text-muted-foreground" />;
@@ -67,22 +61,290 @@ function StatusDot({ status }: { status: ToolView['status'] }) {
   return <Check className="size-3.5 shrink-0 text-emerald-500" />;
 }
 
+/** One-line summary shown next to the tool title, collapsed. */
+function summaryFor(vm: ToolViewModel): string {
+  switch (vm.kind) {
+    case 'web-search':
+      return vm.query;
+    case 'shell':
+      return vm.command;
+    case 'file-read':
+    case 'file-write':
+    case 'file-edit':
+      return vm.path;
+    case 'search':
+      return vm.pattern;
+    case 'task':
+      return vm.description;
+    case 'todo':
+      return vm.items.length > 0 ? `${vm.items.length} item${vm.items.length === 1 ? '' : 's'}` : '';
+    case 'question':
+      return vm.questions[0]?.question ?? '';
+    case 'generic':
+      return '';
+  }
+}
+
+function OutputBlock({ text, isError }: { text: string; isError?: boolean }) {
+  return (
+    <pre
+      className={cn(
+        'max-h-72 overflow-auto rounded-md bg-muted/50 p-2 font-mono text-[0.7rem] leading-relaxed scrollbar-thin',
+        isError ? 'text-destructive' : 'text-foreground/80',
+      )}
+    >
+      {text.slice(0, 6000)}
+    </pre>
+  );
+}
+
+function WebSearchBody({ vm }: { vm: Extract<ToolViewModel, { kind: 'web-search' }> }) {
+  if (vm.error) {
+    return (
+      <div className="flex items-start gap-2 rounded-md border border-destructive/20 bg-destructive/5 p-2 text-xs text-destructive">
+        <CircleAlert className="mt-0.5 size-3.5 shrink-0" />
+        <span>Web search failed: {vm.error}</span>
+      </div>
+    );
+  }
+  if (!vm.results || vm.results.length === 0) {
+    return <p className="text-xs text-muted-foreground">No results.</p>;
+  }
+  return (
+    <div className="space-y-2">
+      {vm.answer && <p className="text-xs text-foreground/80">{vm.answer}</p>}
+      <ul className="space-y-1.5">
+        {vm.results.map((r, i) => (
+          <li key={`${r.url}-${i}`} className="min-w-0">
+            <a
+              href={r.url}
+              target="_blank"
+              rel="noreferrer noopener"
+              className="block truncate text-xs font-medium text-primary hover:underline"
+            >
+              {r.title || r.url}
+            </a>
+            <div className="truncate text-[0.7rem] text-muted-foreground">{r.url}</div>
+            {r.snippet && (
+              <p className="mt-0.5 line-clamp-2 text-xs text-foreground/70">{r.snippet}</p>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function ShellBody({ vm }: { vm: Extract<ToolViewModel, { kind: 'shell' }>; isError: boolean }) {
+  return (
+    <div className="space-y-2">
+      {vm.command && (
+        <pre className="overflow-auto rounded-md bg-muted/50 p-2 font-mono text-[0.7rem] leading-relaxed text-foreground/80 scrollbar-thin">
+          $ {vm.command}
+        </pre>
+      )}
+      {typeof vm.exitCode === 'number' && vm.exitCode !== 0 && (
+        <Badge variant="destructive" className="text-[0.65rem]">
+          exit {vm.exitCode}
+        </Badge>
+      )}
+      {vm.stdout && <OutputBlock text={vm.stdout} />}
+    </div>
+  );
+}
+
+function FilePreviewBody({ path, preview }: { path: string; preview?: string }) {
+  return (
+    <div className="space-y-1.5">
+      {path && <div className="truncate font-mono text-[0.7rem] text-muted-foreground">{path}</div>}
+      {preview && <OutputBlock text={preview} />}
+    </div>
+  );
+}
+
+function FileEditBody({ vm }: { vm: Extract<ToolViewModel, { kind: 'file-edit' }> }) {
+  return (
+    <div className="space-y-1.5">
+      {vm.path && (
+        <div className="truncate font-mono text-[0.7rem] text-muted-foreground">{vm.path}</div>
+      )}
+      {vm.diff && vm.diff.length > 0 ? (
+        <pre className="max-h-72 overflow-auto rounded-md bg-muted/50 p-2 font-mono text-[0.7rem] leading-relaxed scrollbar-thin">
+          {vm.diff.slice(0, 400).map((line, i) => (
+            <div
+              key={i}
+              className={cn(
+                'whitespace-pre-wrap',
+                line.type === 'added' && 'bg-emerald-500/10 text-emerald-500',
+                line.type === 'removed' && 'bg-destructive/10 text-destructive',
+                line.type === 'unchanged' && 'text-foreground/60',
+              )}
+            >
+              {line.type === 'added' ? '+ ' : line.type === 'removed' ? '- ' : '  '}
+              {line.text}
+            </div>
+          ))}
+        </pre>
+      ) : null}
+    </div>
+  );
+}
+
+function SearchBody({ vm }: { vm: Extract<ToolViewModel, { kind: 'search' }> }) {
+  if (!vm.matches || vm.matches.length === 0) {
+    return <p className="text-xs text-muted-foreground">No matches.</p>;
+  }
+  return (
+    <ul className="max-h-72 space-y-1 overflow-auto font-mono text-[0.7rem] text-foreground/80 scrollbar-thin">
+      {vm.matches.map((m, i) => (
+        <li key={i} className="truncate">
+          <span className="text-muted-foreground">{m.path}</span>
+          {typeof m.line === 'number' && <span className="text-muted-foreground">:{m.line}</span>}
+          {m.content && <span className="ml-1.5">{m.content}</span>}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function TaskBody({ vm }: { vm: Extract<ToolViewModel, { kind: 'task' }> }) {
+  return (
+    <div className="flex flex-wrap items-center gap-1.5 text-xs text-foreground/80">
+      <span>{vm.description}</span>
+      {vm.agent && (
+        <Badge variant="secondary" className="text-[0.65rem]">
+          {vm.agent}
+        </Badge>
+      )}
+    </div>
+  );
+}
+
+function TodoBody({ vm }: { vm: Extract<ToolViewModel, { kind: 'todo' }> }) {
+  if (vm.items.length === 0) return null;
+  return (
+    <ul className="space-y-1">
+      {vm.items.map((item, i) => (
+        <li key={i} className="flex items-start gap-2 text-xs">
+          <CheckSquare
+            className={cn(
+              'mt-0.5 size-3.5 shrink-0',
+              item.status === 'completed' ? 'text-emerald-500' : 'text-muted-foreground',
+            )}
+          />
+          <span
+            className={cn(
+              item.status === 'completed' && 'text-muted-foreground line-through',
+              item.status !== 'completed' && 'text-foreground/80',
+            )}
+          >
+            {item.content}
+          </span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function QuestionBody({ vm }: { vm: Extract<ToolViewModel, { kind: 'question' }> }) {
+  if (vm.questions.length === 0) return null;
+  return (
+    <div className="space-y-2">
+      {vm.questions.map((q, i) => (
+        <div key={i} className="space-y-1">
+          <p className="text-xs font-medium text-foreground/80">{q.question}</p>
+          {q.options.length > 0 && (
+            <ul className="space-y-0.5 pl-3 text-xs text-muted-foreground">
+              {q.options.map((o, oi) => (
+                <li key={oi}>• {o.label}</li>
+              ))}
+            </ul>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function GenericBody({ vm }: { vm: Extract<ToolViewModel, { kind: 'generic' }>; isError: boolean }) {
+  return (
+    <div className="space-y-2">
+      {vm.inputPretty && (
+        <pre className="max-h-48 overflow-auto rounded-md bg-muted/50 p-2 font-mono text-[0.7rem] leading-relaxed text-muted-foreground scrollbar-thin">
+          {vm.inputPretty}
+        </pre>
+      )}
+      {vm.outputPretty && <OutputBlock text={vm.outputPretty} />}
+    </div>
+  );
+}
+
+/** Renders the expanded body for a `ToolViewModel`, one branch per kind —
+ *  the switch is exhaustive so a new kind fails typecheck here instead of
+ *  silently falling through to nothing. */
+function ToolBody({ vm, isError }: { vm: ToolViewModel; isError: boolean }) {
+  switch (vm.kind) {
+    case 'web-search':
+      return <WebSearchBody vm={vm} />;
+    case 'shell':
+      return <ShellBody vm={vm} isError={isError} />;
+    case 'file-read':
+    case 'file-write':
+      return <FilePreviewBody path={vm.path} preview={vm.preview} />;
+    case 'file-edit':
+      return <FileEditBody vm={vm} />;
+    case 'search':
+      return <SearchBody vm={vm} />;
+    case 'task':
+      return <TaskBody vm={vm} />;
+    case 'todo':
+      return <TodoBody vm={vm} />;
+    case 'question':
+      return <QuestionBody vm={vm} />;
+    case 'generic':
+      return <GenericBody vm={vm} isError={isError} />;
+    default: {
+      const _exhaustive: never = vm;
+      return _exhaustive;
+    }
+  }
+}
+
 export function ToolCall({ tool }: { tool: ToolView }) {
   const { category } = toolInfo(tool.name);
   const Icon = CATEGORY_ICON[category] ?? Wrench;
-  const summary = summarize(tool.input);
-  const output = tool.output ?? tool.error;
+  const vm = toolViewModel(tool);
+  const summary = summaryFor(vm);
+  const isError = tool.status === 'error';
 
-  const hasDetail = !!summary || !!output || (tool.input && Object.keys(tool.input).length > 0);
+  const hasDetail =
+    vm.kind !== 'generic' ||
+    !!vm.inputPretty ||
+    !!vm.outputPretty ||
+    !!summary;
 
   return (
-    <Collapsible className="rounded-lg border border-border bg-card/50">
+    <Collapsible
+      className={cn(
+        'rounded-lg border bg-card/50',
+        isError ? 'border-destructive/30 bg-destructive/[0.03]' : 'border-border',
+      )}
+    >
       <CollapsibleTrigger
         disabled={!hasDetail}
         className="group flex w-full items-center gap-2 px-2.5 py-2 text-left disabled:cursor-default"
       >
-        <Icon className="size-3.5 shrink-0 text-muted-foreground" />
-        <span className="shrink-0 text-xs font-medium text-foreground">{tool.title}</span>
+        <Icon
+          className={cn('size-3.5 shrink-0', isError ? 'text-destructive' : 'text-muted-foreground')}
+        />
+        <span
+          className={cn(
+            'shrink-0 text-xs font-medium',
+            isError ? 'text-destructive' : 'text-foreground',
+          )}
+        >
+          {tool.title}
+        </span>
         {summary && (
           <span className="truncate font-mono text-xs text-muted-foreground">{summary}</span>
         )}
@@ -95,22 +357,8 @@ export function ToolCall({ tool }: { tool: ToolView }) {
       </CollapsibleTrigger>
       {hasDetail && (
         <CollapsibleContent>
-          <div className="space-y-2 border-t border-border px-2.5 py-2">
-            {tool.input && Object.keys(tool.input).length > 0 && (
-              <pre className="max-h-48 overflow-auto rounded-md bg-muted/50 p-2 font-mono text-[0.7rem] leading-relaxed text-muted-foreground scrollbar-thin">
-                {JSON.stringify(tool.input, null, 2)}
-              </pre>
-            )}
-            {output && (
-              <pre
-                className={cn(
-                  'max-h-72 overflow-auto rounded-md bg-muted/50 p-2 font-mono text-[0.7rem] leading-relaxed scrollbar-thin',
-                  tool.status === 'error' ? 'text-destructive' : 'text-foreground/80',
-                )}
-              >
-                {output.slice(0, 6000)}
-              </pre>
-            )}
+          <div className="border-t border-border px-2.5 py-2">
+            <ToolBody vm={vm} isError={isError} />
           </div>
         </CollapsibleContent>
       )}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -290,3 +290,27 @@ export type {
  * `platform/strings.ts` for why this replaces the regex idiom.
  */
 export { stripTrailingSlashes } from './platform/strings';
+
+/**
+ * Per-tool view models for `ToolView` — a discriminated union with a typed
+ * shape for each tool family a product chat UI renders specially (web/image
+ * search, shell, file read/write/edit, grep/glob search, task, todowrite,
+ * question), plus a `generic` fallback for everything else. Pairs with
+ * `ToolView`'s new `outputParsed`/`outputText` fields and its embedded-
+ * failure detection (a `state.status: "completed"` tool part whose JSON
+ * output body carries `success: false` or a top-level `error` — the shape
+ * router/executor tools like `web_search` commonly return on failure — now
+ * classifies as `status: 'error'` instead of rendering as a success with raw
+ * JSON inside). Also available from `@kortix/sdk/turns`.
+ */
+export {
+  type DiffLine,
+  type DiffLineType,
+  type QuestionItem,
+  type QuestionOption,
+  type SearchMatch,
+  type TodoItem,
+  type ToolViewModel,
+  type WebSearchResultItem,
+  toolViewModel,
+} from './turns/view-model';

--- a/packages/sdk/src/turns/classify.test.ts
+++ b/packages/sdk/src/turns/classify.test.ts
@@ -117,6 +117,163 @@ describe('classifyPart — exhaustive part model', () => {
     expect(result.tool.output).toBeUndefined();
   });
 
+  test('tool — completed web_search wrapping a 402 as JSON reclassifies as error with the innermost message', () => {
+    // Real prod transcript: web_search's router call failed with a 402, but
+    // the tool itself catches the error and returns `state.status:
+    // "completed"` with the failure serialized as its JSON *output* —
+    // `{"query":"...","success":false,"error":"Error: 402 Error:
+    // {\"error\":true,\"message\":\"Insufficient credits\",\"status\":402}"}`.
+    // Before this fix, ToolView trusted `state.status` and rendered this as
+    // a successful 'done' tool call with raw JSON garbage inside.
+    const output = JSON.stringify({
+      query: 'anthropic claude opus pricing',
+      success: false,
+      error:
+        'Error: 402 Error: {"error":true,"message":"Insufficient credits","status":402}',
+    });
+    const part = {
+      id: 'p20',
+      sessionID: 's1',
+      messageID: 'm1',
+      type: 'tool',
+      callID: 'c20',
+      tool: 'web_search',
+      state: {
+        status: 'completed',
+        input: { query: 'anthropic claude opus pricing' },
+        output,
+        title: 'Web Search',
+        metadata: {},
+        time: { start: 0, end: 1 },
+      },
+    } as Part;
+    const result = classifyPart(part) as Extract<ClassifiedPart, { kind: 'tool' }>;
+    expect(result.tool.status).toBe('error');
+    expect(result.tool.error).toBe('Insufficient credits');
+    // The raw output stays available even once reclassified as an error.
+    expect(result.tool.output).toBe(output);
+    expect(result.tool.outputText).toBe(output);
+    expect(result.tool.outputParsed).toEqual({
+      query: 'anthropic claude opus pricing',
+      success: false,
+      error: 'Error: 402 Error: {"error":true,"message":"Insufficient credits","status":402}',
+    });
+  });
+
+  test('tool — completed web_search with a top-level error object (no success flag) also reclassifies', () => {
+    const output = JSON.stringify({ query: 'q', error: { message: 'Rate limited' } });
+    const part = {
+      id: 'p21',
+      sessionID: 's1',
+      messageID: 'm1',
+      type: 'tool',
+      callID: 'c21',
+      tool: 'web_search',
+      state: { status: 'completed', input: {}, output, title: 'Web Search', metadata: {}, time: { start: 0, end: 1 } },
+    } as Part;
+    const result = classifyPart(part) as Extract<ClassifiedPart, { kind: 'tool' }>;
+    expect(result.tool.status).toBe('error');
+    expect(result.tool.error).toBe('Rate limited');
+  });
+
+  test('tool — completed web_search with real results stays done, exposes outputParsed', () => {
+    const output = JSON.stringify({
+      query: 'kortix ai',
+      success: true,
+      answer: 'Kortix is an open AI command center.',
+      results: [
+        { title: 'Kortix', url: 'https://kortix.ai', snippet: 'The open AI command center.' },
+      ],
+    });
+    const part = {
+      id: 'p22',
+      sessionID: 's1',
+      messageID: 'm1',
+      type: 'tool',
+      callID: 'c22',
+      tool: 'web_search',
+      state: { status: 'completed', input: { query: 'kortix ai' }, output, title: 'Web Search', metadata: {}, time: { start: 0, end: 1 } },
+    } as Part;
+    const result = classifyPart(part) as Extract<ClassifiedPart, { kind: 'tool' }>;
+    expect(result.tool.status).toBe('done');
+    expect(result.tool.error).toBeUndefined();
+    expect((result.tool.outputParsed as { success: boolean }).success).toBe(true);
+  });
+
+  test('tool — completed bash output parses to outputText but no outputParsed (plain text isn\'t JSON)', () => {
+    const part = {
+      id: 'p23',
+      sessionID: 's1',
+      messageID: 'm1',
+      type: 'tool',
+      callID: 'c23',
+      tool: 'bash',
+      state: {
+        status: 'completed',
+        input: { command: 'ls -la' },
+        output: 'total 0\ndrwxr-xr-x  2 me me 64 Jan 1 00:00 .',
+        title: 'Shell',
+        metadata: {},
+        time: { start: 0, end: 1 },
+      },
+    } as Part;
+    const result = classifyPart(part) as Extract<ClassifiedPart, { kind: 'tool' }>;
+    expect(result.tool.status).toBe('done');
+    expect(result.tool.outputText).toBe('total 0\ndrwxr-xr-x  2 me me 64 Jan 1 00:00 .');
+    expect(result.tool.outputParsed).toBeUndefined();
+  });
+
+  test('tool — an unparseable string output never throws and stays generic/done', () => {
+    const part = {
+      id: 'p24',
+      sessionID: 's1',
+      messageID: 'm1',
+      type: 'tool',
+      callID: 'c24',
+      tool: 'read',
+      state: {
+        status: 'completed',
+        input: {},
+        output: '{not valid json at all',
+        title: 'Read',
+        metadata: {},
+        time: { start: 0, end: 1 },
+      },
+    } as Part;
+    expect(() => classifyPart(part)).not.toThrow();
+    const result = classifyPart(part) as Extract<ClassifiedPart, { kind: 'tool' }>;
+    expect(result.tool.status).toBe('done');
+    expect(result.tool.outputParsed).toBeUndefined();
+    expect(result.tool.outputText).toBe('{not valid json at all');
+  });
+
+  test('tool — output over the parse-size cap is never JSON.parsed, even if it would parse', () => {
+    // A huge but technically-valid JSON array — still must not be parsed;
+    // the cap is a size circuit breaker, not a validity check.
+    const hugeArray = `[${Array(80_000).fill('"x"').join(',')}]`; // > 256KB
+    expect(hugeArray.length).toBeGreaterThan(256 * 1024);
+    const part = {
+      id: 'p25',
+      sessionID: 's1',
+      messageID: 'm1',
+      type: 'tool',
+      callID: 'c25',
+      tool: 'web_search',
+      state: {
+        status: 'completed',
+        input: {},
+        output: hugeArray,
+        title: 'Web Search',
+        metadata: {},
+        time: { start: 0, end: 1 },
+      },
+    } as Part;
+    const result = classifyPart(part) as Extract<ClassifiedPart, { kind: 'tool' }>;
+    expect(result.tool.status).toBe('done');
+    expect(result.tool.outputParsed).toBeUndefined();
+    expect(result.tool.outputText).toBe(hugeArray);
+  });
+
   test('file — image attachment', () => {
     const part = {
       id: 'p4',

--- a/packages/sdk/src/turns/classify.ts
+++ b/packages/sdk/src/turns/classify.ts
@@ -56,7 +56,24 @@ export interface ToolView {
   input?: Record<string, unknown>;
   output?: string;
   error?: string;
+  /**
+   * `JSON.parse` of a string `output` when it parses as JSON; a non-string
+   * output value passes through unchanged (defensive — the wire type is
+   * always `string`, but nothing stops a future/plugin tool from handing
+   * back a structured value directly). `undefined` when parsing fails or
+   * there's no output. Bounded — strings over ~256KB are never parsed (a
+   * huge blob is never meaningfully "structured" for view-model purposes,
+   * and JSON.parse on it would be wasted work on every render).
+   */
+  outputParsed?: unknown;
+  /** The raw output text, unconditionally — same value as `output` (kept as
+   *  its own field so `outputParsed`/`outputText` read as a matched pair). */
+  outputText?: string;
 }
+
+/** Never parse (or diff/pretty-print) an output blob larger than this — a
+ *  cheap circuit breaker against pathological huge tool outputs. */
+const MAX_PARSEABLE_OUTPUT_LENGTH = 256 * 1024;
 
 function toolStatus(state: ToolState): ToolStatus {
   switch (state.status) {
@@ -75,15 +92,69 @@ function toolStatus(state: ToolState): ToolStatus {
   }
 }
 
+function parseToolOutput(rawOutput: string | undefined): {
+  outputParsed?: unknown;
+  outputText?: string;
+} {
+  if (rawOutput === undefined) return {};
+  if (rawOutput.length > MAX_PARSEABLE_OUTPUT_LENGTH) return { outputText: rawOutput };
+  try {
+    return { outputParsed: JSON.parse(rawOutput), outputText: rawOutput };
+  } catch {
+    return { outputText: rawOutput };
+  }
+}
+
+/**
+ * Detect the "completed but actually failed" shape router/executor tools
+ * (web_search, image_search, connector calls) commonly return: the wire's
+ * `state.status` says `completed`, but the JSON output body itself carries
+ * `success: false` or a top-level `error`. Without this, a real prod failure
+ * (e.g. a 402 "Insufficient credits" from the search router) renders as a
+ * successful tool call with raw JSON garbage inside.
+ */
+function detectEmbeddedFailure(outputParsed: unknown): string | undefined {
+  if (typeof outputParsed !== 'object' || outputParsed === null || Array.isArray(outputParsed)) {
+    return undefined;
+  }
+  const obj = outputParsed as Record<string, unknown>;
+  const failedFlag = obj.success === false;
+  const errorField = obj.error;
+  const hasErrorField =
+    (typeof errorField === 'string' && errorField.length > 0) ||
+    (typeof errorField === 'object' && errorField !== null);
+  if (!failedFlag && !hasErrorField) return undefined;
+
+  if (hasErrorField) return unwrapError(errorField);
+  if (typeof obj.message === 'string' && obj.message) return obj.message;
+  return 'Tool reported failure';
+}
+
 function classifyToolState(tool: string, state: ToolState): ToolView {
   const liveTitle = 'title' in state ? state.title : undefined;
+  const rawOutput = state.status === 'completed' ? state.output : undefined;
+  const { outputParsed, outputText } = parseToolOutput(rawOutput);
+
+  let status = toolStatus(state);
+  let error = state.status === 'error' ? state.error : undefined;
+
+  if (status === 'done') {
+    const embeddedError = detectEmbeddedFailure(outputParsed);
+    if (embeddedError) {
+      status = 'error';
+      error = embeddedError;
+    }
+  }
+
   return {
     name: tool,
     title: liveTitle || toolInfo(tool).label,
-    status: toolStatus(state),
+    status,
     input: state.input,
-    output: state.status === 'completed' ? state.output : undefined,
-    error: state.status === 'error' ? state.error : undefined,
+    output: rawOutput,
+    outputParsed,
+    outputText,
+    error,
   };
 }
 

--- a/packages/sdk/src/turns/errors.ts
+++ b/packages/sdk/src/turns/errors.ts
@@ -29,7 +29,13 @@ export function unwrapError(raw: unknown): string {
       }
       return extractErrorFromObject(parsed) || str;
     } catch {
-      return str;
+      // Not directly parseable as JSON — router/executor errors commonly wrap
+      // a JSON body inside a plain-text prefix, e.g. router tool credit
+      // failures: `Error: 402 Error: {"error":true,"message":"Insufficient
+      // credits","status":402}`. Extract the outermost {...} substring (if
+      // any) and try that instead of surfacing the raw prefixed string.
+      const embedded = extractEmbeddedJsonMessage(str);
+      return embedded ?? str;
     }
   }
 
@@ -39,6 +45,26 @@ export function unwrapError(raw: unknown): string {
   }
 
   return String(raw);
+}
+
+/**
+ * Best-effort extraction of a human message from a JSON object embedded
+ * somewhere inside a larger non-JSON string. Takes the substring spanning
+ * the first `{` to the last `}` — correct for the common single-object case
+ * (nested double-wrapped errors don't nest braces inside the outer text) and
+ * cheap; falls back to `undefined` (never throws) if that substring isn't
+ * valid JSON or has no recognizable error shape.
+ */
+function extractEmbeddedJsonMessage(str: string): string | undefined {
+  const start = str.indexOf('{');
+  const end = str.lastIndexOf('}');
+  if (start === -1 || end === -1 || end <= start) return undefined;
+  try {
+    const parsed = JSON.parse(str.slice(start, end + 1));
+    return extractErrorFromObject(parsed);
+  } catch {
+    return undefined;
+  }
 }
 
 function extractErrorFromObject(obj: unknown): string | undefined {

--- a/packages/sdk/src/turns/index.ts
+++ b/packages/sdk/src/turns/index.ts
@@ -30,6 +30,7 @@ export type * from './types';
 export { unwrapError } from './errors';
 export * from './tool-registry';
 export * from './classify';
+export * from './view-model';
 
 import { unwrapError } from './errors';
 

--- a/packages/sdk/src/turns/tool-registry.ts
+++ b/packages/sdk/src/turns/tool-registry.ts
@@ -90,8 +90,10 @@ function stripOcPrefix(name: string): string {
   return name.replace(/^oc[-_]/, '');
 }
 
-/** Normalize a tool name to the registry's canonical (underscore) key form. */
-function normalizeToolName(name: string): string {
+/** Normalize a tool name to the registry's canonical (underscore) key form.
+ *  Exported for other turns/ modules (e.g. `view-model.ts`'s per-tool
+ *  dispatch) that need the same `oc-`/dash normalization `toolInfo` uses. */
+export function normalizeToolName(name: string): string {
   return stripOcPrefix(name).replace(/-/g, '_');
 }
 

--- a/packages/sdk/src/turns/view-model.test.ts
+++ b/packages/sdk/src/turns/view-model.test.ts
@@ -1,0 +1,378 @@
+import { describe, expect, test } from 'bun:test';
+
+import type { Part } from '../opencode/client';
+import { classifyPart, type ClassifiedPart } from './classify';
+import type { ToolView } from './classify';
+import { toolViewModel } from './view-model';
+
+/** Build a minimal ToolView directly — most tests here exercise `toolViewModel`
+ *  in isolation rather than going through the full `classifyPart` pipeline. */
+function toolView(overrides: Partial<ToolView> = {}): ToolView {
+  return {
+    name: 'unknown_tool',
+    title: 'Unknown Tool',
+    status: 'done',
+    ...overrides,
+  };
+}
+
+function classifyToolPart(tool: string, state: Record<string, unknown>): ToolView {
+  const part = {
+    id: 'p1',
+    sessionID: 's1',
+    messageID: 'm1',
+    type: 'tool',
+    callID: 'c1',
+    tool,
+    state,
+  } as Part;
+  const result = classifyPart(part) as Extract<ClassifiedPart, { kind: 'tool' }>;
+  return result.tool;
+}
+
+describe('toolViewModel — web-search / image-search', () => {
+  test('successful web_search maps results with title/url/snippet', () => {
+    const tool = classifyToolPart('web_search', {
+      status: 'completed',
+      input: { query: 'kortix ai' },
+      output: JSON.stringify({
+        query: 'kortix ai',
+        success: true,
+        answer: 'Kortix is an open AI command center.',
+        results: [
+          { title: 'Kortix', url: 'https://kortix.ai', snippet: 'The open AI command center.' },
+        ],
+      }),
+      title: 'Web Search',
+      metadata: {},
+      time: { start: 0, end: 1 },
+    });
+    const vm = toolViewModel(tool);
+    expect(vm).toEqual({
+      kind: 'web-search',
+      query: 'kortix ai',
+      results: [
+        { title: 'Kortix', url: 'https://kortix.ai', snippet: 'The open AI command center.' },
+      ],
+      answer: 'Kortix is an open AI command center.',
+    });
+  });
+
+  test('the real prod 402-in-completed-output transcript reclassifies to a destructive web-search error', () => {
+    const tool = classifyToolPart('web_search', {
+      status: 'completed',
+      input: { query: 'anthropic claude opus pricing' },
+      output: JSON.stringify({
+        query: 'anthropic claude opus pricing',
+        success: false,
+        error: 'Error: 402 Error: {"error":true,"message":"Insufficient credits","status":402}',
+      }),
+      title: 'Web Search',
+      metadata: {},
+      time: { start: 0, end: 1 },
+    });
+    expect(tool.status).toBe('error');
+    const vm = toolViewModel(tool);
+    expect(vm).toEqual({
+      kind: 'web-search',
+      query: 'anthropic claude opus pricing',
+      error: 'Insufficient credits',
+    });
+  });
+
+  test('image_search results map images (url/title/description) into the same result shape', () => {
+    const tool = classifyToolPart('image_search', {
+      status: 'completed',
+      input: { query: 'golden retriever' },
+      output: JSON.stringify({
+        query: 'golden retriever',
+        total: 1,
+        images: [
+          {
+            url: 'https://example.com/dog.jpg',
+            title: 'Golden Retriever',
+            source: 'https://example.com',
+            width: 800,
+            height: 600,
+            description: 'A golden retriever sitting in a field.',
+          },
+        ],
+      }),
+      title: 'Image Search',
+      metadata: {},
+      time: { start: 0, end: 1 },
+    });
+    const vm = toolViewModel(tool);
+    expect(vm.kind).toBe('web-search');
+    if (vm.kind !== 'web-search') throw new Error('unreachable');
+    expect(vm.results).toEqual([
+      {
+        title: 'Golden Retriever',
+        url: 'https://example.com/dog.jpg',
+        snippet: 'A golden retriever sitting in a field.',
+      },
+    ]);
+  });
+});
+
+describe('toolViewModel — shell (bash)', () => {
+  test('strips bash_metadata/system_info/exit_code tags and extracts exitCode', () => {
+    const tool = classifyToolPart('bash', {
+      status: 'completed',
+      input: { command: 'ls -la' },
+      output:
+        'total 0\ndrwxr-xr-x 2 me me 64 Jan 1 00:00 .\n<bash_metadata>{"cwd":"/"}</bash_metadata><exit_code>0</exit_code>',
+      title: 'Shell',
+      metadata: {},
+      time: { start: 0, end: 1 },
+    });
+    const vm = toolViewModel(tool);
+    expect(vm).toEqual({
+      kind: 'shell',
+      command: 'ls -la',
+      stdout: 'total 0\ndrwxr-xr-x 2 me me 64 Jan 1 00:00 .',
+      exitCode: 0,
+    });
+  });
+
+  test('a failed bash call falls back to the error text as stdout when output is empty', () => {
+    const tool = classifyToolPart('bash', {
+      status: 'error',
+      input: { command: 'exit 1' },
+      error: 'command failed with exit code 1',
+      time: { start: 0, end: 1 },
+    });
+    const vm = toolViewModel(tool);
+    expect(vm).toEqual({ kind: 'shell', command: 'exit 1', stdout: 'command failed with exit code 1', exitCode: undefined });
+  });
+});
+
+describe('toolViewModel — file read/write/edit', () => {
+  test('file-read exposes a preview of the output', () => {
+    const tool = classifyToolPart('read', {
+      status: 'completed',
+      input: { filePath: '/repo/README.md' },
+      output: '# Hello\n',
+      title: 'Read',
+      metadata: {},
+      time: { start: 0, end: 1 },
+    });
+    expect(toolViewModel(tool)).toEqual({
+      kind: 'file-read',
+      path: '/repo/README.md',
+      preview: '# Hello\n',
+    });
+  });
+
+  test('file-write exposes a preview of the written content', () => {
+    const tool = classifyToolPart('write', {
+      status: 'completed',
+      input: { filePath: '/repo/a.txt', content: 'hello world' },
+      output: 'File written',
+      title: 'Write',
+      metadata: {},
+      time: { start: 0, end: 1 },
+    });
+    expect(toolViewModel(tool)).toEqual({
+      kind: 'file-write',
+      path: '/repo/a.txt',
+      preview: 'hello world',
+    });
+  });
+
+  test('file-edit computes a prefix/suffix-trimmed line diff from oldString/newString', () => {
+    const tool = classifyToolPart('edit', {
+      status: 'completed',
+      input: {
+        filePath: '/repo/a.ts',
+        oldString: 'line1\nline2\nline3',
+        newString: 'line1\nCHANGED\nline3',
+      },
+      output: 'ok',
+      title: 'Edit',
+      metadata: {},
+      time: { start: 0, end: 1 },
+    });
+    expect(toolViewModel(tool)).toEqual({
+      kind: 'file-edit',
+      path: '/repo/a.ts',
+      diff: [
+        { type: 'unchanged', text: 'line1' },
+        { type: 'removed', text: 'line2' },
+        { type: 'added', text: 'CHANGED' },
+        { type: 'unchanged', text: 'line3' },
+      ],
+    });
+  });
+});
+
+describe('toolViewModel — search (grep/glob)', () => {
+  test('grep output parses into path/line/content matches', () => {
+    const tool = classifyToolPart('grep', {
+      status: 'completed',
+      input: { pattern: 'TODO' },
+      output: 'Found 2 matches\n\n/repo/a.ts: \nLine 3: // TODO fix this\nLine 9: // TODO cleanup',
+      title: 'Grep',
+      metadata: {},
+      time: { start: 0, end: 1 },
+    });
+    const vm = toolViewModel(tool);
+    expect(vm).toEqual({
+      kind: 'search',
+      pattern: 'TODO',
+      matches: [
+        { path: '/repo/a.ts', line: 3, content: '// TODO fix this' },
+        { path: '/repo/a.ts', line: 9, content: '// TODO cleanup' },
+      ],
+    });
+  });
+
+  test('glob output parses into a flat path list', () => {
+    const tool = classifyToolPart('glob', {
+      status: 'completed',
+      input: { pattern: '**/*.ts' },
+      output: '/repo/a.ts\n/repo/b.ts',
+      title: 'Glob',
+      metadata: {},
+      time: { start: 0, end: 1 },
+    });
+    expect(toolViewModel(tool)).toEqual({
+      kind: 'search',
+      pattern: '**/*.ts',
+      matches: [{ path: '/repo/a.ts' }, { path: '/repo/b.ts' }],
+    });
+  });
+});
+
+describe('toolViewModel — task / todo / question', () => {
+  test('task pulls description + subagent_type', () => {
+    const tool = toolView({
+      name: 'task',
+      title: 'Delegate to Agent',
+      input: { description: 'Fix the flaky test', subagent_type: 'general-purpose' },
+    });
+    expect(toolViewModel(tool)).toEqual({
+      kind: 'task',
+      description: 'Fix the flaky test',
+      agent: 'general-purpose',
+    });
+  });
+
+  test('todowrite normalizes todos from input', () => {
+    const tool = toolView({
+      name: 'todowrite',
+      title: 'Plan Tasks',
+      input: {
+        todos: [
+          { content: 'Write tests', status: 'in_progress', priority: 'high' },
+          { content: 'Ship it', status: 'pending' },
+        ],
+      },
+    });
+    expect(toolViewModel(tool)).toEqual({
+      kind: 'todo',
+      items: [
+        { content: 'Write tests', status: 'in_progress', priority: 'high' },
+        { content: 'Ship it', status: 'pending' },
+      ],
+    });
+  });
+
+  test('question normalizes questions + options', () => {
+    const tool = toolView({
+      name: 'question',
+      title: 'Ask Question',
+      input: {
+        questions: [
+          {
+            question: 'Which environment?',
+            options: [{ label: 'staging' }, { label: 'prod', description: 'Careful!' }],
+          },
+        ],
+      },
+    });
+    expect(toolViewModel(tool)).toEqual({
+      kind: 'question',
+      questions: [
+        {
+          question: 'Which environment?',
+          header: undefined,
+          options: [
+            { label: 'staging', description: undefined },
+            { label: 'prod', description: 'Careful!' },
+          ],
+        },
+      ],
+    });
+  });
+});
+
+describe('toolViewModel — generic fallback', () => {
+  test('an unrecognized tool falls back to generic with pretty input/output', () => {
+    const tool = classifyToolPart('webfetch', {
+      status: 'completed',
+      input: { url: 'https://example.com' },
+      output: JSON.stringify({ title: 'Example', content: 'hi' }),
+      title: 'Fetch Page',
+      metadata: {},
+      time: { start: 0, end: 1 },
+    });
+    const vm = toolViewModel(tool);
+    expect(vm.kind).toBe('generic');
+    if (vm.kind !== 'generic') throw new Error('unreachable');
+    expect(vm.label).toBe('Fetch Page');
+    expect(vm.inputPretty).toContain('"url": "https://example.com"');
+    expect(vm.outputPretty).toContain('"title": "Example"');
+  });
+
+  test('unparseable string output never throws and falls back to raw text, capped', () => {
+    const tool = classifyToolPart('mystery_tool', {
+      status: 'completed',
+      input: {},
+      output: 'not json at all, just plain text',
+      title: 'Mystery Tool',
+      metadata: {},
+      time: { start: 0, end: 1 },
+    });
+    expect(() => toolViewModel(tool)).not.toThrow();
+    const vm = toolViewModel(tool);
+    expect(vm).toEqual({
+      kind: 'generic',
+      label: 'Mystery Tool',
+      inputPretty: undefined,
+      outputPretty: 'not json at all, just plain text',
+    });
+  });
+
+  test('a huge output is capped, never blows up rendering', () => {
+    const huge = 'x'.repeat(300_000);
+    const tool = classifyToolPart('mystery_tool', {
+      status: 'completed',
+      input: {},
+      output: huge,
+      title: 'Mystery Tool',
+      metadata: {},
+      time: { start: 0, end: 1 },
+    });
+    expect(() => toolViewModel(tool)).not.toThrow();
+    const vm = toolViewModel(tool);
+    expect(vm.kind).toBe('generic');
+    if (vm.kind !== 'generic') throw new Error('unreachable');
+    expect(vm.outputPretty!.length).toBeLessThan(huge.length);
+  });
+
+  test('an error-status tool with no output surfaces the error as outputPretty', () => {
+    const tool = classifyToolPart('mystery_tool', {
+      status: 'error',
+      input: {},
+      error: 'boom',
+      time: { start: 0, end: 1 },
+    });
+    expect(toolViewModel(tool)).toEqual({
+      kind: 'generic',
+      label: 'Mystery Tool',
+      inputPretty: undefined,
+      outputPretty: 'boom',
+    });
+  });
+});

--- a/packages/sdk/src/turns/view-model.ts
+++ b/packages/sdk/src/turns/view-model.ts
@@ -177,9 +177,48 @@ function webSearchViewModel(tool: ToolView): Extract<ToolViewModel, { kind: 'web
 // shell (bash)
 // ============================================================================
 
-const BASH_METADATA_TAG_RE = /<bash_metadata>[\s\S]*?<\/bash_metadata>/g;
-const INTERNAL_TAG_TAIL_RE = /<\/?(?:system_info|exit_code|stderr_note)>[\s\S]*?(?:<\/\w+>)?$/g;
 const EXIT_CODE_RE = /<exit_code>\s*(-?\d+)\s*<\/exit_code>/;
+
+// Linear (indexOf-based) tag strippers — the regex forms
+// (`/<bash_metadata>[\s\S]*?<\/bash_metadata>/g` and a lazy tail matcher)
+// backtrack polynomially on adversarial output (CodeQL js/polynomial-redos),
+// and shell output is arbitrary user/tool-controlled text.
+
+/** Remove every `<open>…</close>` block; an unterminated block is left as-is
+ *  (matching the old lazy-regex behavior, which required the closing tag). */
+function stripTagBlocks(s: string, open: string, close: string): string {
+  let out = '';
+  let i = 0;
+  for (;;) {
+    const start = s.indexOf(open, i);
+    if (start === -1) return out + s.slice(i);
+    const end = s.indexOf(close, start + open.length);
+    if (end === -1) return out + s.slice(i);
+    out += s.slice(i, start);
+    i = end + close.length;
+  }
+}
+
+const INTERNAL_TAG_MARKERS = [
+  '<system_info>',
+  '</system_info>',
+  '<exit_code>',
+  '</exit_code>',
+  '<stderr_note>',
+  '</stderr_note>',
+];
+
+/** Cut the trailing internal-protocol tag block: everything from the FIRST
+ *  internal tag marker onward. These tags are appended by the bash tool AFTER
+ *  the real output, so first-marker-to-end is the whole machine tail. */
+function stripInternalTagTail(s: string): string {
+  let cut = -1;
+  for (const marker of INTERNAL_TAG_MARKERS) {
+    const idx = s.indexOf(marker);
+    if (idx !== -1 && (cut === -1 || idx < cut)) cut = idx;
+  }
+  return cut === -1 ? s : s.slice(0, cut);
+}
 
 // Minimal local ANSI stripper mirroring `stripAnsi` in turns/index.ts —
 // duplicated (rather than imported) to avoid a circular import between this
@@ -198,7 +237,7 @@ function shellViewModel(tool: ToolView): Extract<ToolViewModel, { kind: 'shell' 
   const exitMatch = raw.match(EXIT_CODE_RE);
   const exitCode = exitMatch ? Number(exitMatch[1]) : undefined;
   const cleaned = stripAnsiLocal(
-    raw.replace(BASH_METADATA_TAG_RE, '').replace(INTERNAL_TAG_TAIL_RE, ''),
+    stripInternalTagTail(stripTagBlocks(raw, '<bash_metadata>', '</bash_metadata>')),
   ).trim();
   const stdout = cleaned || (tool.status === 'error' ? tool.error : undefined);
   return { kind: 'shell', command, stdout: stdout || undefined, exitCode };
@@ -283,7 +322,11 @@ function fileEditViewModel(tool: ToolView): Extract<ToolViewModel, { kind: 'file
 
 const GREP_HEADER_RE = /^Found\s+(\d+)\s+match/i;
 const GREP_FILE_HEADER_RE = /^(\/[^:]+?):\s*/;
-const GREP_LINE_RE = /Line\s+(\d+):\s*([\s\S]*?)(?=\s*(?:Line\s+\d+:|$))/g;
+// Header-only matcher — content between consecutive headers is sliced out
+// positionally below. The previous single-regex form captured content with a
+// lazy `[\s\S]*?` + lookahead-alternation, which backtracks polynomially on
+// adversarial output like repeated "Line\t0:" (CodeQL js/polynomial-redos).
+const GREP_LINE_HEADER_RE = /Line\s+(\d+):/g;
 
 function parseGrepMatches(output: string): SearchMatch[] {
   const text = output.trim();
@@ -299,10 +342,22 @@ function parseGrepMatches(output: string): SearchMatch[] {
     if (!fileMatch) continue;
     const path = fileMatch[1];
     const rest = trimmed.slice(fileMatch[0].length);
+    // Scan headers linearly, then slice each entry's content as the span up
+    // to the next header (or end) — no backtracking-prone content capture.
+    const headers: { line: number; contentStart: number; headerStart: number }[] = [];
     let m: RegExpExecArray | null;
-    GREP_LINE_RE.lastIndex = 0;
-    while ((m = GREP_LINE_RE.exec(rest)) !== null) {
-      matches.push({ path, line: Number(m[1]), content: m[2].trim().replace(/;$/, '') });
+    GREP_LINE_HEADER_RE.lastIndex = 0;
+    while ((m = GREP_LINE_HEADER_RE.exec(rest)) !== null) {
+      headers.push({ line: Number(m[1]), contentStart: m.index + m[0].length, headerStart: m.index });
+    }
+    for (let i = 0; i < headers.length; i++) {
+      const end = i + 1 < headers.length ? headers[i + 1].headerStart : rest.length;
+      const content = rest.slice(headers[i].contentStart, end).trim();
+      matches.push({
+        path,
+        line: headers[i].line,
+        content: content.endsWith(';') ? content.slice(0, -1) : content,
+      });
     }
   }
   return matches;

--- a/packages/sdk/src/turns/view-model.ts
+++ b/packages/sdk/src/turns/view-model.ts
@@ -1,0 +1,449 @@
+/**
+ * Per-tool view models — the "what should a product UI actually show for
+ * this tool call" layer on top of `ToolView`.
+ *
+ * `ToolView` (classify.ts) normalizes the wire's pending/running/completed/
+ * error state machine and now detects embedded (completed-but-actually-
+ * failed) failures — but it still leaves `input`/`output` as loosely-typed
+ * bags. Rendering a web search, a shell command, and a file edit all the
+ * same way (a JSON blob in a `<pre>`) is what produced the original bug:
+ * a real failure LOOKED like a success because nothing gave it special
+ * shape. `toolViewModel` maps a `ToolView` to a small discriminated union
+ * with one variant per tool family a product UI is expected to render
+ * specially, plus a `generic` fallback for everything else.
+ *
+ * Field shapes below are grounded in the real wire data, not guessed:
+ *  - web_search / image_search: `.kortix/opencode/tools/web_search.ts` +
+ *    `image_search.ts` (this repo) — success shape
+ *    `{query, success, answer, results:[{title,url,snippet,...}], images}`,
+ *    failure shape `{query, success:false, error}`; image_search's images
+ *    carry `{url,title,source,description}` instead of `results`.
+ *  - shell (bash): `apps/web/src/features/session/tool-renderers.tsx`
+ *    (`partOutput`) and `apps/mobile/components/session/SessionTurn.tsx`
+ *    (`ShellExpandedContent`) — `input.command`, raw text output with
+ *    `<bash_metadata>`/`<exit_code>`/`<system_info>`/`<stderr_note>` tags to
+ *    strip.
+ *  - file read/write/edit: `apps/mobile/.../SessionTurn.tsx`
+ *    (`WriteEditExpandedContent`) — `input.filePath`, `input.oldString`/
+ *    `input.newString` for edit, `input.content` for write.
+ *  - search (grep/glob): `apps/web/.../tool-renderers.tsx`
+ *    (`parseFilePaths`, `parseGrepOutput`) — glob output is a newline list of
+ *    paths; grep output is `Found N matches\n\n/path:\nLine N: content...`.
+ *  - task: `toolInfo`'s `task` entry + `getAgentCardLabel` (index.ts) —
+ *    `input.description`/`input.subagent_type`/`input.prompt`.
+ *  - todo (todowrite): `apps/mobile/.../SessionTurn.tsx`
+ *    (`TodosExpandedContent`) — `input.todos: {content,status,priority?}[]`.
+ *  - question: `apps/web/.../tool-renderers.tsx` (`QuestionTool`) —
+ *    `input.questions: {question,header?,options:{label,description?}[]}[]`.
+ *
+ * `permission` isn't included: it's a request keyed by `{messageID,callID}`
+ * pointing AT a tool call (see `RequestWithToolLike` in types.ts), not a
+ * tool call itself — there's no tool named `permission` on the wire.
+ */
+
+import { normalizeToolName } from './tool-registry';
+import type { ToolView } from './classify';
+
+// ============================================================================
+// Shared shapes
+// ============================================================================
+
+export interface WebSearchResultItem {
+  title: string;
+  url: string;
+  snippet?: string;
+}
+
+export interface SearchMatch {
+  path: string;
+  line?: number;
+  content?: string;
+}
+
+export type DiffLineType = 'added' | 'removed' | 'unchanged';
+
+export interface DiffLine {
+  type: DiffLineType;
+  text: string;
+}
+
+export interface TodoItem {
+  content: string;
+  status: string;
+  priority?: string;
+}
+
+export interface QuestionOption {
+  label: string;
+  description?: string;
+}
+
+export interface QuestionItem {
+  question: string;
+  header?: string;
+  options: QuestionOption[];
+}
+
+// ============================================================================
+// ToolViewModel — the discriminated union
+// ============================================================================
+
+export type ToolViewModel =
+  | {
+      kind: 'web-search';
+      query: string;
+      results?: WebSearchResultItem[];
+      answer?: string;
+      error?: string;
+    }
+  | { kind: 'shell'; command: string; stdout?: string; exitCode?: number }
+  | { kind: 'file-read'; path: string; preview?: string }
+  | { kind: 'file-write'; path: string; preview?: string }
+  | { kind: 'file-edit'; path: string; diff?: DiffLine[] }
+  | { kind: 'search'; pattern: string; matches?: SearchMatch[] }
+  | { kind: 'task'; description: string; agent?: string }
+  | { kind: 'todo'; items: TodoItem[] }
+  | { kind: 'question'; questions: QuestionItem[]; answers?: string[][] }
+  | { kind: 'generic'; label: string; inputPretty?: string; outputPretty?: string };
+
+const PRETTY_CAP = 4000;
+
+function capText(text: string, max = PRETTY_CAP): string {
+  return text.length > max ? `${text.slice(0, max)}\n…` : text;
+}
+
+function prettyJson(value: unknown): string | undefined {
+  if (value === undefined) return undefined;
+  try {
+    return capText(JSON.stringify(value, null, 2));
+  } catch {
+    return undefined;
+  }
+}
+
+/** First non-empty string among candidates — tool inputs use inconsistent
+ *  key names across tool families (`filePath` vs `file_path` vs `path`). */
+function firstString(...candidates: unknown[]): string | undefined {
+  for (const c of candidates) {
+    if (typeof c === 'string' && c.length > 0) return c;
+  }
+  return undefined;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+// ============================================================================
+// web-search / image-search
+// ============================================================================
+
+function webSearchViewModel(tool: ToolView): Extract<ToolViewModel, { kind: 'web-search' }> {
+  const inputQuery = firstString(tool.input?.query) ?? '';
+
+  if (tool.status === 'error') {
+    return { kind: 'web-search', query: inputQuery, error: tool.error ?? 'Search failed' };
+  }
+
+  const obj = asRecord(tool.outputParsed);
+  if (!obj) return { kind: 'web-search', query: inputQuery };
+
+  const rawItems = Array.isArray(obj.results)
+    ? (obj.results as unknown[])
+    : Array.isArray(obj.images)
+      ? (obj.images as unknown[])
+      : [];
+
+  const results: WebSearchResultItem[] = rawItems.slice(0, 50).map((raw) => {
+    const r = asRecord(raw) ?? {};
+    return {
+      title: firstString(r.title) ?? '',
+      url: firstString(r.url, r.link) ?? '',
+      snippet: firstString(r.snippet, r.description, r.source),
+    };
+  });
+
+  return {
+    kind: 'web-search',
+    query: firstString(obj.query) ?? inputQuery,
+    results: results.length > 0 ? results : undefined,
+    answer: firstString(obj.answer),
+  };
+}
+
+// ============================================================================
+// shell (bash)
+// ============================================================================
+
+const BASH_METADATA_TAG_RE = /<bash_metadata>[\s\S]*?<\/bash_metadata>/g;
+const INTERNAL_TAG_TAIL_RE = /<\/?(?:system_info|exit_code|stderr_note)>[\s\S]*?(?:<\/\w+>)?$/g;
+const EXIT_CODE_RE = /<exit_code>\s*(-?\d+)\s*<\/exit_code>/;
+
+// Minimal local ANSI stripper mirroring `stripAnsi` in turns/index.ts —
+// duplicated (rather than imported) to avoid a circular import between this
+// module and the barrel file that re-exports it.
+const ANSI_RE =
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: matching terminal escape sequences requires literal ESC/BEL control characters
+  /\x1B\[[\d;]*[A-Za-z]|\x1B\][^\x07]{0,512}\x07|\x1B[()#][A-Z0-9]|\x1B\[?[\d;]*[hl]|\x1B[>=<]|\x1B\[[?]?\d*[A-Z]|\x1B\[\d*[JKHG]|\x1B\[\d*;\d*[Hf]|\x1b\[[0-9;]*m/g;
+
+function stripAnsiLocal(str: string): string {
+  return str.replace(ANSI_RE, '');
+}
+
+function shellViewModel(tool: ToolView): Extract<ToolViewModel, { kind: 'shell' }> {
+  const command = firstString(tool.input?.command) ?? '';
+  const raw = tool.output ?? '';
+  const exitMatch = raw.match(EXIT_CODE_RE);
+  const exitCode = exitMatch ? Number(exitMatch[1]) : undefined;
+  const cleaned = stripAnsiLocal(
+    raw.replace(BASH_METADATA_TAG_RE, '').replace(INTERNAL_TAG_TAIL_RE, ''),
+  ).trim();
+  const stdout = cleaned || (tool.status === 'error' ? tool.error : undefined);
+  return { kind: 'shell', command, stdout: stdout || undefined, exitCode };
+}
+
+// ============================================================================
+// file read / write / edit
+// ============================================================================
+
+function filePath(tool: ToolView): string {
+  return firstString(tool.input?.filePath, tool.input?.file_path, tool.input?.path) ?? '';
+}
+
+function fileReadViewModel(tool: ToolView): Extract<ToolViewModel, { kind: 'file-read' }> {
+  const preview =
+    tool.status === 'error' ? tool.error : (tool.output && capText(tool.output)) || undefined;
+  return { kind: 'file-read', path: filePath(tool), preview };
+}
+
+function fileWriteViewModel(tool: ToolView): Extract<ToolViewModel, { kind: 'file-write' }> {
+  const content = firstString(tool.input?.content);
+  const preview =
+    tool.status === 'error'
+      ? tool.error
+      : capText(content ?? tool.output ?? '') || undefined;
+  return { kind: 'file-write', path: filePath(tool), preview };
+}
+
+/** Cap total input size before diffing — the naive O(n) prefix/suffix trim
+ *  below is cheap, but there's no reason to diff a multi-hundred-KB blob for
+ *  a chat UI card. */
+const MAX_DIFF_INPUT_LENGTH = 256 * 1024;
+
+/**
+ * Line diff between an edit tool's `oldString`/`newString`. Not a general
+ * LCS diff — `edit`/`morph_edit` operate on one contiguous replaced block,
+ * so trimming the common prefix/suffix and marking the differing middle as
+ * removed/added is both correct for that shape and O(n) instead of O(n²).
+ */
+function computeLineDiff(oldStr: string, newStr: string): DiffLine[] | undefined {
+  if (oldStr.length + newStr.length > MAX_DIFF_INPUT_LENGTH) return undefined;
+  const oldLines = oldStr.split('\n');
+  const newLines = newStr.split('\n');
+
+  let start = 0;
+  while (
+    start < oldLines.length &&
+    start < newLines.length &&
+    oldLines[start] === newLines[start]
+  ) {
+    start++;
+  }
+
+  let oldEnd = oldLines.length;
+  let newEnd = newLines.length;
+  while (oldEnd > start && newEnd > start && oldLines[oldEnd - 1] === newLines[newEnd - 1]) {
+    oldEnd--;
+    newEnd--;
+  }
+
+  const lines: DiffLine[] = [];
+  for (let i = 0; i < start; i++) lines.push({ type: 'unchanged', text: oldLines[i] });
+  for (let i = start; i < oldEnd; i++) lines.push({ type: 'removed', text: oldLines[i] });
+  for (let i = start; i < newEnd; i++) lines.push({ type: 'added', text: newLines[i] });
+  for (let i = oldEnd; i < oldLines.length; i++) lines.push({ type: 'unchanged', text: oldLines[i] });
+  return lines;
+}
+
+function fileEditViewModel(tool: ToolView): Extract<ToolViewModel, { kind: 'file-edit' }> {
+  const oldString = firstString(tool.input?.oldString);
+  const newString = firstString(tool.input?.newString);
+  const diff =
+    oldString !== undefined && newString !== undefined
+      ? computeLineDiff(oldString, newString)
+      : undefined;
+  return { kind: 'file-edit', path: filePath(tool), diff };
+}
+
+// ============================================================================
+// search (grep / glob)
+// ============================================================================
+
+const GREP_HEADER_RE = /^Found\s+(\d+)\s+match/i;
+const GREP_FILE_HEADER_RE = /^(\/[^:]+?):\s*/;
+const GREP_LINE_RE = /Line\s+(\d+):\s*([\s\S]*?)(?=\s*(?:Line\s+\d+:|$))/g;
+
+function parseGrepMatches(output: string): SearchMatch[] {
+  const text = output.trim();
+  const headerMatch = text.match(GREP_HEADER_RE);
+  const body = headerMatch ? text.slice(headerMatch[0].length).trim() : text;
+  if (!body) return [];
+
+  const matches: SearchMatch[] = [];
+  for (const block of body.split(/\n\n+/)) {
+    const trimmed = block.trim();
+    if (!trimmed) continue;
+    const fileMatch = trimmed.match(GREP_FILE_HEADER_RE);
+    if (!fileMatch) continue;
+    const path = fileMatch[1];
+    const rest = trimmed.slice(fileMatch[0].length);
+    let m: RegExpExecArray | null;
+    GREP_LINE_RE.lastIndex = 0;
+    while ((m = GREP_LINE_RE.exec(rest)) !== null) {
+      matches.push({ path, line: Number(m[1]), content: m[2].trim().replace(/;$/, '') });
+    }
+  }
+  return matches;
+}
+
+function parseGlobMatches(output: string): SearchMatch[] {
+  return output
+    .trim()
+    .split('\n')
+    .map((l) => l.trim())
+    .filter((l) => l.startsWith('/') || l.startsWith('./') || l.startsWith('~'))
+    .map((path) => ({ path }));
+}
+
+function searchViewModel(tool: ToolView): Extract<ToolViewModel, { kind: 'search' }> {
+  const pattern = firstString(tool.input?.pattern, tool.input?.query) ?? '';
+  if (tool.status === 'error' || !tool.output) return { kind: 'search', pattern };
+  const matches = GREP_HEADER_RE.test(tool.output.trim())
+    ? parseGrepMatches(tool.output)
+    : parseGlobMatches(tool.output);
+  return { kind: 'search', pattern, matches: matches.length > 0 ? matches.slice(0, 200) : undefined };
+}
+
+// ============================================================================
+// task
+// ============================================================================
+
+function taskViewModel(tool: ToolView): Extract<ToolViewModel, { kind: 'task' }> {
+  const description =
+    firstString(tool.input?.description, tool.input?.title, tool.input?.prompt) ?? tool.title;
+  const agent = firstString(tool.input?.subagent_type, tool.input?.agent);
+  return { kind: 'task', description, agent };
+}
+
+// ============================================================================
+// todo (todowrite)
+// ============================================================================
+
+function normalizeTodo(raw: unknown): TodoItem {
+  const t = asRecord(raw) ?? {};
+  return {
+    content: firstString(t.content) ?? '',
+    status: firstString(t.status) ?? 'pending',
+    priority: firstString(t.priority),
+  };
+}
+
+function todoViewModel(tool: ToolView): Extract<ToolViewModel, { kind: 'todo' }> {
+  const inputTodos = tool.input?.todos;
+  if (Array.isArray(inputTodos)) return { kind: 'todo', items: inputTodos.map(normalizeTodo) };
+
+  if (Array.isArray(tool.outputParsed)) {
+    return { kind: 'todo', items: tool.outputParsed.map(normalizeTodo) };
+  }
+  const outObj = asRecord(tool.outputParsed);
+  if (outObj && Array.isArray(outObj.todos)) {
+    return { kind: 'todo', items: (outObj.todos as unknown[]).map(normalizeTodo) };
+  }
+  return { kind: 'todo', items: [] };
+}
+
+// ============================================================================
+// question
+// ============================================================================
+
+function questionViewModel(tool: ToolView): Extract<ToolViewModel, { kind: 'question' }> {
+  const rawQuestions = Array.isArray(tool.input?.questions) ? tool.input.questions : [];
+  const questions: QuestionItem[] = rawQuestions.map((rawQuestion) => {
+    const q = asRecord(rawQuestion) ?? {};
+    const rawOptions = Array.isArray(q.options) ? q.options : [];
+    const options: QuestionOption[] = rawOptions.flatMap((rawOption) => {
+      const o = asRecord(rawOption);
+      const label = o && firstString(o.label);
+      return label ? [{ label, description: o ? firstString(o.description) : undefined }] : [];
+    });
+    return { question: firstString(q.question) ?? '', header: firstString(q.header), options };
+  });
+  return { kind: 'question', questions };
+}
+
+// ============================================================================
+// generic fallback
+// ============================================================================
+
+function genericViewModel(tool: ToolView): Extract<ToolViewModel, { kind: 'generic' }> {
+  const hasInput = tool.input && Object.keys(tool.input).length > 0;
+  const inputPretty = hasInput ? prettyJson(tool.input) : undefined;
+
+  let outputPretty: string | undefined;
+  if (tool.outputParsed !== undefined) {
+    outputPretty =
+      typeof tool.outputParsed === 'string' ? capText(tool.outputParsed) : prettyJson(tool.outputParsed);
+  } else if (tool.outputText !== undefined) {
+    outputPretty = capText(tool.outputText);
+  } else {
+    outputPretty = tool.error;
+  }
+
+  return { kind: 'generic', label: tool.title, inputPretty, outputPretty };
+}
+
+// ============================================================================
+// toolViewModel — the dispatcher
+// ============================================================================
+
+/**
+ * Map a normalized `ToolView` to its typed `ToolViewModel`. Known tool
+ * families (web/image search, shell, file read/write/edit, grep/glob,
+ * task, todowrite, question) get a shape a product UI can render specially;
+ * anything else (webfetch, scrape_webpage, image_gen, presentation_gen,
+ * session_, agent_, project_, trigger_ prefixed plugin tools, pty_*, …) falls back
+ * to `generic`, which is always safe to render (pretty-printed input/output,
+ * capped).
+ */
+export function toolViewModel(tool: ToolView): ToolViewModel {
+  const name = normalizeToolName(tool.name);
+  switch (name) {
+    case 'web_search':
+    case 'websearch':
+    case 'image_search':
+      return webSearchViewModel(tool);
+    case 'bash':
+      return shellViewModel(tool);
+    case 'read':
+      return fileReadViewModel(tool);
+    case 'write':
+      return fileWriteViewModel(tool);
+    case 'edit':
+    case 'morph_edit':
+      return fileEditViewModel(tool);
+    case 'grep':
+    case 'glob':
+      return searchViewModel(tool);
+    case 'task':
+      return taskViewModel(tool);
+    case 'todowrite':
+      return todoViewModel(tool);
+    case 'question':
+    case 'ask':
+      return questionViewModel(tool);
+    default:
+      return genericViewModel(tool);
+  }
+}


### PR DESCRIPTION
## What

A prod transcript showed a `web_search` tool that failed with 402 'Insufficient credits' rendering as a **successful** tool call with raw JSON inside — in the chat, the action side panel, and any SDK consumer. Three layers fixed:

**SDK (`@kortix/sdk/turns`)** — `ToolView` now parses string outputs, detects the router/executor `{success:false | error}` embedded-failure shape even when opencode says `completed`, and unwraps nested `Error: 402 Error: {json}` strings to the human message. New `toolViewModel()` discriminated union (web-search / shell / file-read / file-write / file-edit / search / task / todo / question / generic) gives every frontend typed access to tool calls — grounded in the real wire formats. 1022 SDK tests (the exact prod transcript is a fixture).

**Web app** — `web_search`/`image_search` failures now render destructive icon + red Failed chip + a failure card ('Web search failed · HTTP 402 · Insufficient credits') in BOTH the inline chat row and the action side panel; generic fallback hardened the same way for all tools. Root cause was `parseWebSearchOutput` treating the failure shape as a valid empty result.

**API** — the 402 itself: dev/preview QA accounts have $0 credit accounts with billing internal enabled, so every billed router tool failed. `creditGateExemptEnv` skips the credit gate on dev/preview (same pattern as the model-entitlement carve-out, #4145); prod/staging keep the real gate.

## Verified
- SDK: 1022 pass / 0 fail, typecheck + build clean
- apps/web: 65/65 session-feature tests, `next build` clean (TS2308 in src/ui is pre-existing on main)
- whitelabel: typecheck + build + 43 e2e green
- apps/api: typecheck clean; credit-gate unit test runs in CI (local run blocked by encrypted .env)