### PR TITLE
fix(accounts): name unnamed accounts after their owner, not the caller

### DIFF
--- a/apps/api/src/__tests__/unit-account-display-names.test.ts
+++ b/apps/api/src/__tests__/unit-account-display-names.test.ts
@@ -1,0 +1,167 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+// Account display names must fall back to the account OWNER's email, not the
+// caller's — otherwise every unnamed account a user is invited into renders
+// as "<caller>'s Account" and shared projects look like they live in the
+// caller's personal account.
+
+let dbResults: unknown[][] = [];
+function makeChain(): any {
+  const chain: any = {};
+  for (const m of ['from', 'where', 'limit', 'orderBy', 'set', 'values', 'returning']) {
+    chain[m] = () => chain;
+  }
+  chain.then = (resolve: (rows: unknown[]) => unknown) => Promise.resolve(resolve(dbResults.shift() ?? []));
+  return chain;
+}
+mock.module('../shared/db', () => ({
+  db: { select: () => makeChain(), update: () => makeChain(), insert: () => makeChain(), execute: async () => [] },
+  hasDatabase: () => true,
+}));
+
+// Emails looked up via the Supabase admin API (owner ids → emails).
+let emailsById: Record<string, string> = {};
+mock.module('../shared/supabase', () => ({
+  getSupabase: () => ({
+    auth: {
+      admin: {
+        getUserById: async (uid: string) => ({ data: { user: emailsById[uid] ? { email: emailsById[uid] } : null } }),
+      },
+    },
+  }),
+}));
+
+mock.module('../shared/resolve-account', () => ({
+  resolveAccountId: async () => 'acc-x',
+}));
+
+const {
+  accountDisplayName,
+  properAccountName,
+  resolveAccountDisplayNames,
+  resolveLegacyAccountDisplayNames,
+} = await import('../accounts/core/app');
+
+const CALLER = { userId: 'u-caller', email: 'marko@kortix.ai' };
+
+beforeEach(() => {
+  dbResults = [];
+  emailsById = {};
+});
+
+describe('properAccountName / accountDisplayName', () => {
+  test('placeholder names are not proper names', () => {
+    expect(properAccountName('Personal')).toBeNull();
+    expect(properAccountName('User')).toBeNull();
+    expect(properAccountName('  ')).toBeNull();
+    expect(properAccountName(null)).toBeNull();
+    expect(properAccountName('Acme Corp')).toBe('Acme Corp');
+  });
+
+  test('accountDisplayName falls back to email-derived name', () => {
+    expect(accountDisplayName('Personal', 'a@b.com')).toBe("a@b.com's Account");
+    expect(accountDisplayName('Acme', 'a@b.com')).toBe('Acme');
+    expect(accountDisplayName(null, null)).toBe('Account');
+  });
+});
+
+describe('resolveAccountDisplayNames', () => {
+  test('keeps proper names without touching owners', async () => {
+    const names = await resolveAccountDisplayNames(
+      [{ accountId: 'a1', name: 'Acme Corp' }],
+      CALLER,
+    );
+    expect(names.get('a1')).toBe('Acme Corp');
+  });
+
+  test("unnamed account owned by the caller → caller's email", async () => {
+    dbResults = [[{ accountId: 'a1', userId: 'u-caller' }]];
+    const names = await resolveAccountDisplayNames(
+      [{ accountId: 'a1', name: 'Personal' }],
+      CALLER,
+    );
+    expect(names.get('a1')).toBe("marko@kortix.ai's Account");
+  });
+
+  test("unnamed account owned by someone else → OWNER's email, not the caller's", async () => {
+    dbResults = [[{ accountId: 'a1', userId: 'u-owner' }]];
+    emailsById = { 'u-owner': 'bob@example.com' };
+    const names = await resolveAccountDisplayNames(
+      [{ accountId: 'a1', name: 'Personal' }],
+      CALLER,
+    );
+    expect(names.get('a1')).toBe("bob@example.com's Account");
+  });
+
+  test('multiple owners → earliest-joined owner wins (first row)', async () => {
+    dbResults = [[
+      { accountId: 'a1', userId: 'u-first' },
+      { accountId: 'a1', userId: 'u-second' },
+    ]];
+    emailsById = { 'u-first': 'first@example.com', 'u-second': 'second@example.com' };
+    const names = await resolveAccountDisplayNames(
+      [{ accountId: 'a1', name: '' }],
+      CALLER,
+    );
+    expect(names.get('a1')).toBe("first@example.com's Account");
+  });
+
+  test("no owner rows → caller's email as last resort", async () => {
+    dbResults = [[]];
+    const names = await resolveAccountDisplayNames(
+      [{ accountId: 'a1', name: 'User' }],
+      CALLER,
+    );
+    expect(names.get('a1')).toBe("marko@kortix.ai's Account");
+  });
+
+  test('owner whose email cannot be resolved → caller email fallback', async () => {
+    dbResults = [[{ accountId: 'a1', userId: 'u-ghost' }]];
+    const names = await resolveAccountDisplayNames(
+      [{ accountId: 'a1', name: 'Personal' }],
+      CALLER,
+    );
+    expect(names.get('a1')).toBe("marko@kortix.ai's Account");
+  });
+
+  test('mixed batch resolves each account independently', async () => {
+    dbResults = [[
+      { accountId: 'a2', userId: 'u-owner' },
+    ]];
+    emailsById = { 'u-owner': 'owner@example.com' };
+    const names = await resolveAccountDisplayNames(
+      [
+        { accountId: 'a1', name: 'Acme Corp' },
+        { accountId: 'a2', name: 'Personal' },
+      ],
+      CALLER,
+    );
+    expect(names.get('a1')).toBe('Acme Corp');
+    expect(names.get('a2')).toBe("owner@example.com's Account");
+  });
+});
+
+describe('resolveLegacyAccountDisplayNames', () => {
+  test("basejump account owned by someone else → OWNER's email", async () => {
+    dbResults = [[{ accountId: 'a1', userId: 'u-owner' }]];
+    emailsById = { 'u-owner': 'legacy-owner@example.com' };
+    const names = await resolveLegacyAccountDisplayNames(['a1'], CALLER);
+    expect(names.get('a1')).toBe("legacy-owner@example.com's Account");
+  });
+
+  test('personal-account convention (account_id == user_id) is preferred over other owners', async () => {
+    dbResults = [[
+      { accountId: 'a-personal', userId: 'u-other' },
+      { accountId: 'a-personal', userId: 'a-personal' },
+    ]];
+    emailsById = { 'a-personal': 'real-owner@example.com', 'u-other': 'other@example.com' };
+    const names = await resolveLegacyAccountDisplayNames(['a-personal'], CALLER);
+    expect(names.get('a-personal')).toBe("real-owner@example.com's Account");
+  });
+
+  test("caller's own legacy account → caller's email", async () => {
+    dbResults = [[{ accountId: 'a1', userId: 'u-caller' }]];
+    const names = await resolveLegacyAccountDisplayNames(['a1'], CALLER);
+    expect(names.get('a1')).toBe("marko@kortix.ai's Account");
+  });
+});

--- a/apps/api/src/accounts/core/accounts.ts
+++ b/apps/api/src/accounts/core/accounts.ts
@@ -9,6 +9,8 @@ import {
   accountsRouter,
   accountDisplayName,
   defaultAccountName,
+  resolveAccountDisplayNames,
+  resolveLegacyAccountDisplayNames,
   AccountSummarySchema,
   AccountDetailSchema,
   AccountIdParam,
@@ -58,10 +60,14 @@ export function registerAccountRoutes(): void {
           .where(eq(accountMembers.userId, userId));
 
         if (memberships.length > 0) {
+          const displayNames = await resolveAccountDisplayNames(memberships, {
+            userId,
+            email: userEmail,
+          });
           return c.json(
             memberships.map((m) => ({
               account_id: m.accountId,
-              name: accountDisplayName(m.name, userEmail),
+              name: displayNames.get(m.accountId) ?? accountDisplayName(m.name, userEmail),
               slug: m.accountId.slice(0, 8),
               created_at:
                 m.createdAt?.toISOString() ?? new Date().toISOString(),
@@ -86,10 +92,14 @@ export function registerAccountRoutes(): void {
           .where(eq(accountUser.userId, userId));
 
         if (legacyMemberships.length > 0) {
+          const displayNames = await resolveLegacyAccountDisplayNames(
+            legacyMemberships.map((m) => m.accountId),
+            { userId, email: userEmail },
+          );
           return c.json(
             legacyMemberships.map((m) => ({
               account_id: m.accountId,
-              name: defaultAccountName(userEmail),
+              name: displayNames.get(m.accountId) ?? defaultAccountName(userEmail),
               slug: m.accountId.slice(0, 8),
               created_at: new Date().toISOString(),
               updated_at: new Date().toISOString(),
@@ -245,9 +255,14 @@ export function registerAccountRoutes(): void {
           and(eq(projects.accountId, accountId), eq(projects.status, "active")),
         );
 
+      const displayNames = await resolveAccountDisplayNames(
+        [{ accountId: row.accountId, name: row.name }],
+        { userId, email: c.get("userEmail") as string },
+      );
+
       return c.json({
         account_id: row.accountId,
-        name: row.name,
+        name: displayNames.get(row.accountId) ?? row.name,
         member_count: memberCount,
         project_count: Number(projectCountRow?.n ?? 0),
         role: membership.accountRole,

--- a/apps/api/src/accounts/core/app.ts
+++ b/apps/api/src/accounts/core/app.ts
@@ -1,8 +1,8 @@
 import { Context } from 'hono';
 import { z } from '@hono/zod-openapi';
-import { and, count, eq, gt, isNull, sql } from 'drizzle-orm';
+import { and, asc, count, eq, gt, inArray, isNull, sql } from 'drizzle-orm';
 import { makeOpenApiApp } from '../../openapi';
-import { accountInvitations, accountMembers, accounts } from '@kortix/db';
+import { accountInvitations, accountMembers, accountUser, accounts } from '@kortix/db';
 import type { AppEnv } from '../../types';
 import { db } from '../../shared/db';
 import { getSupabase } from '../../shared/supabase';
@@ -16,15 +16,20 @@ export function defaultAccountName(email: string | null | undefined): string {
   return normalized ? `${normalized}'s Account` : 'Account';
 }
 
+// A stored name counts as "proper" only when it isn't one of the placeholder
+// values migrations left behind ('Personal', 'User'). Placeholder accounts
+// fall back to an email-derived name.
+export function properAccountName(name: string | null | undefined): string | null {
+  const normalized = name?.trim();
+  if (!normalized || normalized === 'Personal' || normalized === 'User') return null;
+  return normalized;
+}
+
 export function accountDisplayName(
   name: string | null | undefined,
   email: string | null | undefined,
 ): string {
-  const normalized = name?.trim();
-  if (!normalized || normalized === 'Personal' || normalized === 'User') {
-    return defaultAccountName(email);
-  }
-  return normalized;
+  return properAccountName(name) ?? defaultAccountName(email);
 }
 
 // ─── Shared response/request schemas (power the Scalar docs) ────────────────
@@ -209,6 +214,101 @@ export async function lookupEmailsByUserIds(userIds: string[]): Promise<Map<stri
     }),
   );
   return result;
+}
+
+// Display names for a batch of accounts, deriving the fallback for unnamed
+// (placeholder-named) accounts from the account OWNER's email — not the
+// caller's. Deriving from the caller made every unnamed account a user was
+// invited into render as "<caller>'s Account", so shared projects looked like
+// they lived in the caller's own personal account.
+export async function resolveAccountDisplayNames(
+  rows: Array<{ accountId: string; name: string | null }>,
+  caller: { userId: string; email: string | null | undefined },
+): Promise<Map<string, string>> {
+  const names = new Map<string, string>();
+  const unnamed: string[] = [];
+  for (const row of rows) {
+    const proper = properAccountName(row.name);
+    if (proper) names.set(row.accountId, proper);
+    else unnamed.push(row.accountId);
+  }
+  if (unnamed.length === 0) return names;
+
+  // Primary owner per unnamed account = earliest-joined 'owner' row.
+  const ownerByAccount = new Map<string, string>();
+  try {
+    const owners = await db
+      .select({ accountId: accountMembers.accountId, userId: accountMembers.userId })
+      .from(accountMembers)
+      .where(and(
+        inArray(accountMembers.accountId, unnamed),
+        eq(accountMembers.accountRole, 'owner'),
+      ))
+      .orderBy(asc(accountMembers.joinedAt));
+    for (const o of owners) {
+      if (!ownerByAccount.has(o.accountId)) ownerByAccount.set(o.accountId, o.userId);
+    }
+  } catch {
+    // account_members may not exist yet — fall through to caller email below.
+  }
+
+  const foreignOwnerIds = [...new Set(ownerByAccount.values())].filter(
+    (id) => id !== caller.userId,
+  );
+  const ownerEmails = await lookupEmailsByUserIds(foreignOwnerIds);
+
+  for (const accountId of unnamed) {
+    const ownerId = ownerByAccount.get(accountId);
+    const email = !ownerId || ownerId === caller.userId
+      ? caller.email // ownerless account: caller email beats a bare 'Account'
+      : ownerEmails.get(ownerId) ?? caller.email;
+    names.set(accountId, defaultAccountName(email));
+  }
+  return names;
+}
+
+// Same idea for legacy basejump memberships (no kortix.accounts row to carry a
+// name at all): resolve each account's basejump owner and name it after them.
+export async function resolveLegacyAccountDisplayNames(
+  accountIds: string[],
+  caller: { userId: string; email: string | null | undefined },
+): Promise<Map<string, string>> {
+  const names = new Map<string, string>();
+  if (accountIds.length === 0) return names;
+
+  const ownerByAccount = new Map<string, string>();
+  try {
+    const owners = await db
+      .select({ accountId: accountUser.accountId, userId: accountUser.userId })
+      .from(accountUser)
+      .where(and(
+        inArray(accountUser.accountId, accountIds),
+        eq(accountUser.accountRole, 'owner'),
+      ));
+    for (const o of owners) {
+      // Basejump personal accounts use account_id == user_id; prefer that
+      // owner, otherwise first one wins (no join timestamp to order by).
+      if (o.accountId === o.userId || !ownerByAccount.has(o.accountId)) {
+        ownerByAccount.set(o.accountId, o.userId);
+      }
+    }
+  } catch {
+    // basejump may not exist — fall through to caller email below.
+  }
+
+  const foreignOwnerIds = [...new Set(ownerByAccount.values())].filter(
+    (id) => id !== caller.userId,
+  );
+  const ownerEmails = await lookupEmailsByUserIds(foreignOwnerIds);
+
+  for (const accountId of accountIds) {
+    const ownerId = ownerByAccount.get(accountId);
+    const email = !ownerId || ownerId === caller.userId
+      ? caller.email
+      : ownerEmails.get(ownerId) ?? caller.email;
+    names.set(accountId, defaultAccountName(email));
+  }
+  return names;
 }
 
 export function serializeAccount(row: typeof accounts.$inferSelect) {

--- a/apps/api/src/accounts/core/tokens.ts
+++ b/apps/api/src/accounts/core/tokens.ts
@@ -20,6 +20,7 @@ import {
   autoClaimPendingInvites,
   readBodyTokens,
   resolveAccountForUser,
+  resolveAccountDisplayNames,
   lookupEmailsByUserIds,
 } from './app';
 
@@ -81,6 +82,11 @@ accountsRouter.openapi(
     memberships = await loadMemberships();
   }
 
+  const displayNames = await resolveAccountDisplayNames(memberships, {
+    userId,
+    email: userEmail,
+  });
+
   return c.json({
     user_id: userId,
     email: userEmail,
@@ -95,7 +101,7 @@ accountsRouter.openapi(
     accounts: memberships.map((m) => ({
       account_id: m.accountId,
       slug: m.accountId.slice(0, 8),
-      name: accountDisplayName(m.name, userEmail),
+      name: displayNames.get(m.accountId) ?? accountDisplayName(m.name, userEmail),
       role: m.accountRole,
     })),
   });


### PR DESCRIPTION
## Problem

Projects you were **invited to** appear to sit under "**\<your-email\>'s Account**" in the sidebar / project list, instead of under the account that actually owns them.

The grouping itself was never wrong — the bug is in account **display naming**: `GET /accounts`, `GET /accounts/:id` and `/accounts/me` derived the fallback name for unnamed accounts (empty / `'Personal'` / `'User'` placeholder names left by migrations) from the **caller's** email, for *every* membership. So each unnamed account you were invited into rendered as "\<caller\>'s Account", making several distinct accounts masquerade as your personal one — and their projects looked like they'd been dumped into yours.

## Fix

- New `resolveAccountDisplayNames()` in `accounts/core/app.ts`: for unnamed accounts, resolve the **primary owner** (earliest-joined `owner` row in `kortix.account_members`) and derive the fallback `\<owner-email\>'s Account` from *their* email. The caller's email is used only when the caller is the owner or no owner/email can be resolved.
- `resolveLegacyAccountDisplayNames()` does the same for legacy basejump memberships (via `basejump.account_user`, preferring the `account_id == user_id` personal-account convention), which previously *always* used the caller's email.
- Applied at all three read sites: `GET /accounts` (both kortix + legacy paths), `GET /accounts/:id`, and `/accounts/me`.
- Zero UI changes needed — the web app groups by account already; it was just fed wrong labels.

Properly named accounts (real team names) are untouched; your own personal account still shows as "\<your-email\>'s Account".

## Verification

- `pnpm typecheck` (apps/api) clean.
- New unit suite `unit-account-display-names.test.ts` (12 tests): placeholder-name detection, owner-derived fallback, caller-owned accounts, multi-owner tie-break, ownerless/ghost-owner fallbacks, legacy basejump paths.