### PR TITLE
fix(sandbox): reap superseded per-project warm images on bake (Daytona quota)

### DIFF
--- a/apps/api/src/__tests__/unit-ppwarm-reap.test.ts
+++ b/apps/api/src/__tests__/unit-ppwarm-reap.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from 'bun:test';
+import { ppwarmReapTargets, perProjectWarmImageName } from '../snapshots/ppwarm-names';
+
+// proj8 = first 8 hex chars of the projectId with dashes stripped.
+const PROJ_A = '9ee8bc9c-5108-437f-a01f-6c5e26f2062c'; // proj8 = 9ee8bc9c
+const CURRENT = 'kortix-ppwarm-9ee8bc9c-aaaaaaaaaaaa';
+
+describe('ppwarmReapTargets — on-bake reap selector', () => {
+  test('reaps superseded tips of the same project, keeps the current', () => {
+    const names = [
+      'kortix-ppwarm-9ee8bc9c-aaaaaaaaaaaa', // current
+      'kortix-ppwarm-9ee8bc9c-bbbbbbbbbbbb', // superseded
+      'kortix-ppwarm-9ee8bc9c-cccccccccccc', // superseded
+    ];
+    expect(ppwarmReapTargets(PROJ_A, CURRENT, names).sort()).toEqual([
+      'kortix-ppwarm-9ee8bc9c-bbbbbbbbbbbb',
+      'kortix-ppwarm-9ee8bc9c-cccccccccccc',
+    ]);
+  });
+
+  test('never touches another project (proj8-scoped)', () => {
+    const names = [
+      'kortix-ppwarm-9ee8bc9c-aaaaaaaaaaaa', // current, project A
+      'kortix-ppwarm-dc42fe89-bbbbbbbbbbbb', // project B — off-limits
+      'kortix-ppwarm-dc42fe89-cccccccccccc', // project B — off-limits
+    ];
+    expect(ppwarmReapTargets(PROJ_A, CURRENT, names)).toEqual([]);
+  });
+
+  test('never targets the shared base/default, custom tpls, or prod stateful warm', () => {
+    const names = [
+      'kortix-ppwarm-9ee8bc9c-aaaaaaaaaaaa', // current
+      'kortix-default-e881f000eae5', // shared base
+      'kortix-tpl-9ee8bc9c-deadbeef1234', // custom template
+      'kortix-wproj-9ee8bc9c-cafebabe5678', // prod stateful warm (daytona)
+      'kortix-wprojpt-9ee8bc9c-0badc0de9999', // prod stateful warm (platinum)
+    ];
+    expect(ppwarmReapTargets(PROJ_A, CURRENT, names)).toEqual([]);
+  });
+
+  test('idempotent — only the current tip (or nothing) present → nothing reaped', () => {
+    expect(ppwarmReapTargets(PROJ_A, CURRENT, [CURRENT])).toEqual([]);
+    expect(ppwarmReapTargets(PROJ_A, CURRENT, [])).toEqual([]);
+  });
+
+  test('integrates with perProjectWarmImageName: a moved tip makes the old image a target, a re-bake does not', () => {
+    const base = 'kortix-default-e881f000eae5';
+    const cur = perProjectWarmImageName(PROJ_A, 'tipB', base);
+    const old = perProjectWarmImageName(PROJ_A, 'tipA', base);
+    expect(cur.startsWith('kortix-ppwarm-9ee8bc9c-')).toBe(true);
+    expect(old).not.toBe(cur);
+    // moved tip: the old image is a reap target, the current is kept
+    expect(ppwarmReapTargets(PROJ_A, cur, [cur, old])).toEqual([old]);
+    // re-bake of the same tip: nothing to reap (live tip safe)
+    expect(ppwarmReapTargets(PROJ_A, cur, [cur])).toEqual([]);
+  });
+});

--- a/apps/api/src/snapshots/builder.ts
+++ b/apps/api/src/snapshots/builder.ts
@@ -19,6 +19,7 @@ import { db } from '../shared/db';
 import { resolveCommitSha, type GitBackedProject } from '../projects/git';
 import { getSandboxProvider, type ProviderState, type SandboxProviderAdapter } from './providers';
 import { config } from '../config';
+import { perProjectWarmImageName, ppwarmReapTargets } from './ppwarm-names';
 import {
   computeTemplateIdentity,
   listTemplatesForProject,
@@ -852,24 +853,6 @@ export function kickProjectTemplatePrebuilds(
 /** Managed name prefix for per-project COLD warm images. Reapable, disjoint
  *  from the shared-default (`kortix-default-`) and custom (`kortix-tpl-`) names.
  *  Provider-agnostic: the SAME cold image builds on Daytona and Platinum. */
-const PPWARM_PREFIX = 'kortix-ppwarm-';
-
-function proj8(projectId: string): string {
-  return projectId.replace(/-/g, '').slice(0, 8);
-}
-
-/**
- * Content-addressed name for a project's COLD warm image, keyed on
- * (project, tip, base runtime identity). A new tip OR a runtime-fingerprint bump
- * moves the name → a fresh bake; a stale name is never served for a moved tip.
- * Mirrors warm-project.ts's `kortix-wproj-<proj8>-<hash12>` naming (that module
- * is stateful/prod-only; this is the cold, provider-agnostic equivalent).
- */
-export function perProjectWarmImageName(projectId: string, tip: string, baseSnapshotName: string): string {
-  const hash = createHash('sha256').update(`${projectId}|${tip}|${baseSnapshotName}`).digest('hex').slice(0, 12);
-  return `${PPWARM_PREFIX}${proj8(projectId)}-${hash}`;
-}
-
 export interface PerProjectWarmResult {
   snapshotName: string;
   tip: string;
@@ -910,7 +893,10 @@ export async function ensurePerProjectWarmImage(
   const snapshotName = perProjectWarmImageName(project.projectId, tip, baseIdentity.snapshotName);
 
   // Idempotency: active image under this (project, tip, runtime) → reuse it.
+  // Still reap here — this path also runs when a prior bake's reap failed or a
+  // moved-then-restored tip races to active, so it cleans lingering old tips.
   if ((await provider.getSnapshotState(snapshotName)) === 'active') {
+    await reapOldPerProjectWarm(project.projectId, snapshotName, buildProvider);
     return { snapshotName, tip, built: false, provider: buildProvider };
   }
 
@@ -947,6 +933,7 @@ export async function ensurePerProjectWarmImage(
       warmRepo,
     });
     if (buildId) await closeBuildLogReady(buildId);
+    await reapOldPerProjectWarm(project.projectId, snapshotName, buildProvider);
     return { snapshotName, tip, built: true, provider: buildProvider };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
@@ -979,4 +966,43 @@ async function resolveWarmRepoContext(project: GitBackedProject): Promise<WarmRe
     branch: project.defaultBranch,
     originUrl: proxyGitUrl(project.projectId),
   };
+}
+
+/**
+ * On-bake reap of a project's SUPERSEDED per-project warm images — the aggressive
+ * cleanup prod does (warm-project.ts `reapOldProjectWarm` / `…Platinum`). A moved
+ * tip orphans the old content-addressed image; `REAPABLE_SNAPSHOT_PREFIXES` lets
+ * the *general* reaper sweep it eventually, but on Daytona (which has a
+ * snapshot-COUNT quota) that lag piles up, so we delete superseded tips the moment
+ * the new one is active — keeping ~1 image per active project, exactly like prod.
+ * Best-effort: a reap failure (list/delete error, provider hiccup) NEVER fails the
+ * bake. Provider-branched like prod (Daytona lists+deletes by id; Platinum by
+ * name); other providers have no per-project snapshot store to reap here.
+ */
+async function reapOldPerProjectWarm(projectId: string, currentName: string, buildProvider: string): Promise<void> {
+  try {
+    if (buildProvider === 'daytona') {
+      const { listDaytonaSnapshots, deleteDaytonaSnapshotById } = await import('../shared/daytona');
+      const snaps = await listDaytonaSnapshots();
+      const targets = new Set(ppwarmReapTargets(projectId, currentName, snaps.map((s) => s.name)));
+      for (const snap of snaps) {
+        if (!targets.has(snap.name)) continue;
+        const ok = await deleteDaytonaSnapshotById(snap.id);
+        console.log(`[snapshots] per-project warm: reaped superseded ${snap.name}: ${ok ? 'ok' : 'failed'}`);
+      }
+    } else if (buildProvider === 'platinum') {
+      const { platinumJson } = await import('../shared/platinum');
+      const { platinumProvider } = await import('./providers/platinum');
+      const list = await platinumJson<Array<{ name?: string }>>('/v1/templates');
+      const names = list.map((t) => t.name ?? '').filter((n): n is string => n.length > 0);
+      for (const name of ppwarmReapTargets(projectId, currentName, names)) {
+        await platinumProvider.deleteSnapshot(name);
+        console.log(`[snapshots] per-project warm: reaped superseded ${name}`);
+      }
+    }
+  } catch (err) {
+    console.warn(
+      `[snapshots] per-project warm: supersession reap skipped: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
 }

--- a/apps/api/src/snapshots/ppwarm-names.ts
+++ b/apps/api/src/snapshots/ppwarm-names.ts
@@ -1,0 +1,42 @@
+import { createHash } from 'node:crypto';
+
+/**
+ * Naming + reap-selection for per-project COLD warm images (`kortix-ppwarm-…`),
+ * the cold, provider-agnostic analogue of prod's stateful `kortix-wproj-`
+ * snapshots. Pure — NO config/env/provider imports — so the selection logic is
+ * unit-testable without booting the server.
+ */
+
+export const PPWARM_PREFIX = 'kortix-ppwarm-';
+
+/**
+ * First 8 hex chars of the projectId with dashes stripped — the per-project scope
+ * key in a ppwarm name. Matches warm-project.ts's `proj8` so the prefixes line up.
+ */
+export function proj8(projectId: string): string {
+  return projectId.replace(/-/g, '').slice(0, 8);
+}
+
+/**
+ * Content-addressed name for a project's COLD warm image, keyed on
+ * (project, tip, base runtime identity). A new tip OR a runtime-fingerprint bump
+ * moves the name → a fresh bake; a stale name is never served for a moved tip.
+ * Mirrors warm-project.ts's `kortix-wproj-<proj8>-<hash12>` naming.
+ */
+export function perProjectWarmImageName(projectId: string, tip: string, baseSnapshotName: string): string {
+  const hash = createHash('sha256').update(`${projectId}|${tip}|${baseSnapshotName}`).digest('hex').slice(0, 12);
+  return `${PPWARM_PREFIX}${proj8(projectId)}-${hash}`;
+}
+
+/**
+ * Pure selector for the on-bake reap: given every snapshot/template name the
+ * provider knows, return this project's SUPERSEDED per-project warm names — those
+ * under the project's `kortix-ppwarm-<proj8>-` prefix that are NOT the current
+ * tip. proj8-scoped so it can never match another project; the shared base
+ * (`kortix-default-…`) never carries the ppwarm prefix so it's never a target;
+ * returns [] when only the current tip exists (idempotent re-bake).
+ */
+export function ppwarmReapTargets(projectId: string, currentName: string, allNames: string[]): string[] {
+  const prefix = `${PPWARM_PREFIX}${proj8(projectId)}-`;
+  return allNames.filter((n) => n.startsWith(prefix) && n !== currentName);
+}


### PR DESCRIPTION
## The gap

`ensurePerProjectWarmImage` builds `kortix-ppwarm-<proj8>-<hash>` images content-addressed per `(project, tip)`, but never deletes a project's **superseded** tips on a new bake. `REAPABLE_SNAPSHOT_PREFIXES` includes `kortix-ppwarm-` so the *general* reaper sweeps them eventually — but not on-bake, so on **Daytona (snapshot-count quota)** old tips pile up. Prod avoids exactly this with an aggressive on-bake reap (`warm-project.ts` `reapOldProjectWarm` / `reapOldProjectWarmPlatinum`) for the stateful `kortix-wproj-` snapshots; this ports the same behavior to the cold `kortix-ppwarm-` images.

**Live proof the gap is real:** Platinum currently holds accumulated pairs (two tips each) for projects `2b9e1445` and `0f0af36e` — exactly the pileup this reap prevents.

## The fix (mirrors prod 1:1)

- Extract `PPWARM_PREFIX` / `proj8` / `perProjectWarmImageName` + a new pure **`ppwarmReapTargets`** selector into a config-free `ppwarm-names.ts`, so the selection logic is unit-testable without booting the server (importing `builder.ts` pulls the whole env-validating config).
- **`reapOldPerProjectWarm(projectId, currentName, buildProvider)`** — called after each successful bake (both the fresh-build path and the idempotent short-circuit): lists the provider's ppwarm names, deletes this project's superseded tips (proj8-scoped, skips the current tip). **Best-effort — a reap failure never fails the bake** (wrapped in try/catch, exactly like prod). Provider-branched like prod: Daytona `listDaytonaSnapshots` + `deleteDaytonaSnapshotById`; Platinum `GET /v1/templates` + `platinumProvider.deleteSnapshot`.

## Tests

**Unit (`unit-ppwarm-reap.test.ts`, 5 cases, passing):** reaps superseded tips of the same project, keeps the current tip, never touches another project (proj8-scoped), never targets the shared base / custom tpls / prod stateful warm, is idempotent (only-current → nothing), and integrates with `perProjectWarmImageName`.

**Live integration (Platinum):** built a real throwaway `kortix-ppwarm-e2e00001-…` and ran the reap against live Platinum template data:
- reap with it as the **current** tip → **kept** (current-safe, no delete).
- reap with a **different** current → the reap **selected and issued the delete on exactly that superseded tip** (`reaped superseded kortix-ppwarm-e2e00001-…`) and left all **10 other-project ppwarm images untouched** (proj8 scoping verified against live data).

**Honest caveat:** the throwaway got orphaned in `building` state (a known stuck-build case), and the provider won't remove a mid-build template, so the *final removal* couldn't be observed on that specific image. `deleteSnapshot` is the same primitive prod's reap uses on **active** templates in production, so the removal path is prod-proven; what this PR proves live is the selection / skip-current / proj8-scoping. A full live **Daytona** delete-cycle was not completed in this pass (the test build orphaned before the Daytona leg ran); the Daytona selector was verified against live Daytona snapshot data and the delete path is the identical `deleteDaytonaSnapshotById` prod runs.

## Edge cases covered

Never deletes the current tip; proj8-scoped (never another project); never the shared base/default or custom templates or prod stateful warm; idempotent (re-baking the same tip deletes nothing); tolerant of list/delete failures so the bake never fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
