### PR TITLE
feat(inbox): automation inbox — awareness feed for background runs

### DIFF
--- a/apps/api/src/__tests__/unit-experimental-features.test.ts
+++ b/apps/api/src/__tests__/unit-experimental-features.test.ts
@@ -22,6 +22,7 @@ describe('isExperimentalFeatureKey', () => {
     expect(isExperimentalFeatureKey('agent_tunnel')).toBe(true);
     expect(isExperimentalFeatureKey('agentmail_email')).toBe(true);
     expect(isExperimentalFeatureKey('llm_gateway')).toBe(true);
+    expect(isExperimentalFeatureKey('inbox')).toBe(true);
     expect(isExperimentalFeatureKey('nope')).toBe(false);
     expect(isExperimentalFeatureKey(undefined)).toBe(false);
     expect(isExperimentalFeatureKey(42)).toBe(false);
@@ -105,6 +106,13 @@ describe('resolveExperimentalFeature — explicit override wins', () => {
       config.LLM_GATEWAY_ENABLED = previousEnabled;
       config.LLM_GATEWAY_DEFAULT_ENABLED = previousDefault;
     }
+  });
+
+  test('inbox is available and explicit opt-in (off by default)', () => {
+    expect(findCatalogFeature('inbox').available).toBe(true);
+    expect(resolveExperimentalFeature({}, 'inbox')).toBe(false);
+    expect(resolveExperimentalFeature({ experimental: { inbox: true } }, 'inbox')).toBe(true);
+    expect(resolveExperimentalFeature({ experimental: { inbox: false } }, 'inbox')).toBe(false);
   });
 
   test('null/empty metadata falls back to the operator default (no throw)', () => {

--- a/apps/api/src/experimental/features.ts
+++ b/apps/api/src/experimental/features.ts
@@ -137,6 +137,18 @@ const FEATURES: readonly ExperimentalFeatureDef[] = [
     // Explicit opt-in: hidden unless a project enables it in Settings.
     platformDefault: () => false,
   },
+  {
+    key: 'inbox',
+    name: 'Automation Inbox',
+    description:
+      "An awareness feed for what your automations do on their own — a triggered run (webhook, schedule, channel) finishing or failing becomes an unread item, with a sidebar bell and unread dots on the sessions. Distinct from Review Center: no verdicts, just what's new. Shape and signals are still moving.",
+    stability: 'experimental',
+    // Pure web/DB surface — the routes + table ship with the app, so no operator
+    // env gates it. Always available; a project opts in per Settings.
+    available: () => true,
+    // Explicit opt-in: hidden unless a project enables it in Settings.
+    platformDefault: () => false,
+  },
 ];
 
 const FEATURE_BY_KEY: Record<ExperimentalFeatureKey, ExperimentalFeatureDef> = Object.fromEntries(

--- a/apps/api/src/inbox/inbox-items.test.ts
+++ b/apps/api/src/inbox/inbox-items.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from 'bun:test';
+
+import { serializeInboxItem } from './inbox-items';
+
+type Row = Parameters<typeof serializeInboxItem>[0];
+
+function row(overrides: Partial<Row> = {}): Row {
+  return {
+    id: 'itm_1',
+    accountId: 'acc_1',
+    projectId: 'proj_1',
+    sessionId: 'sess_1',
+    userId: 'user_1',
+    kind: 'run_completed',
+    title: 'Nightly backup',
+    source: 'schedule',
+    metadata: { error: null },
+    dedupKey: 'run_completed:sess_1:1',
+    readAt: null,
+    createdAt: new Date('2026-07-06T09:00:00.000Z'),
+    ...overrides,
+  } as Row;
+}
+
+describe('serializeInboxItem', () => {
+  test('maps a row to the API shape and marks unread when read_at is null', () => {
+    expect(serializeInboxItem(row())).toEqual({
+      id: 'itm_1',
+      project_id: 'proj_1',
+      session_id: 'sess_1',
+      kind: 'run_completed',
+      title: 'Nightly backup',
+      source: 'schedule',
+      metadata: { error: null },
+      read: false,
+      read_at: null,
+      created_at: '2026-07-06T09:00:00.000Z',
+    });
+  });
+
+  test('reports read with an ISO read_at when set', () => {
+    const out = serializeInboxItem(row({ readAt: new Date('2026-07-06T10:00:00.000Z') }));
+    expect(out.read).toBe(true);
+    expect(out.read_at).toBe('2026-07-06T10:00:00.000Z');
+  });
+
+  test('defaults null metadata to an empty object', () => {
+    expect(serializeInboxItem(row({ metadata: null })).metadata).toEqual({});
+  });
+});

--- a/apps/api/src/inbox/inbox-items.ts
+++ b/apps/api/src/inbox/inbox-items.ts
@@ -1,0 +1,78 @@
+import { inboxItems } from '@kortix/db';
+import { and, desc, eq, inArray, isNull, sql } from 'drizzle-orm';
+import { db } from '../shared/db';
+
+type InboxItemRow = typeof inboxItems.$inferSelect;
+
+const DEFAULT_LIMIT = 100;
+const MAX_LIMIT = 200;
+
+export function serializeInboxItem(row: InboxItemRow) {
+  return {
+    id: row.id,
+    project_id: row.projectId,
+    session_id: row.sessionId,
+    kind: row.kind,
+    title: row.title,
+    source: row.source,
+    metadata: row.metadata ?? {},
+    read: row.readAt != null,
+    read_at: row.readAt ? row.readAt.toISOString() : null,
+    created_at: row.createdAt.toISOString(),
+  };
+}
+
+export async function listInboxForUser(
+  projectId: string,
+  userId: string,
+  opts: { unreadOnly?: boolean; limit?: number } = {},
+): Promise<InboxItemRow[]> {
+  const conds = [eq(inboxItems.projectId, projectId), eq(inboxItems.userId, userId)];
+  if (opts.unreadOnly) conds.push(isNull(inboxItems.readAt));
+  const limit = Math.min(Math.max(opts.limit ?? DEFAULT_LIMIT, 1), MAX_LIMIT);
+  return db
+    .select()
+    .from(inboxItems)
+    .where(and(...conds))
+    .orderBy(desc(inboxItems.createdAt))
+    .limit(limit);
+}
+
+export async function countUnreadForUser(projectId: string, userId: string): Promise<number> {
+  const [row] = await db
+    .select({ n: sql<number>`count(*)::int` })
+    .from(inboxItems)
+    .where(
+      and(
+        eq(inboxItems.projectId, projectId),
+        eq(inboxItems.userId, userId),
+        isNull(inboxItems.readAt),
+      ),
+    );
+  return row?.n ?? 0;
+}
+
+export async function markInboxRead(
+  projectId: string,
+  userId: string,
+  selection: { itemIds?: string[]; sessionId?: string; all?: boolean },
+): Promise<number> {
+  const conds = [
+    eq(inboxItems.projectId, projectId),
+    eq(inboxItems.userId, userId),
+    isNull(inboxItems.readAt),
+  ];
+  if (selection.itemIds && selection.itemIds.length > 0) {
+    conds.push(inArray(inboxItems.id, selection.itemIds));
+  } else if (selection.sessionId) {
+    conds.push(eq(inboxItems.sessionId, selection.sessionId));
+  } else if (!selection.all) {
+    return 0;
+  }
+  const updated = await db
+    .update(inboxItems)
+    .set({ readAt: new Date() })
+    .where(and(...conds))
+    .returning({ id: inboxItems.id });
+  return updated.length;
+}

--- a/apps/api/src/inbox/record-attention.test.ts
+++ b/apps/api/src/inbox/record-attention.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  attentionDedupKey,
+  inboxTitle,
+  isBackgroundSource,
+  sessionSourceKind,
+} from './record-attention';
+
+describe('isBackgroundSource', () => {
+  test('triggers and inbound channels are background automations', () => {
+    for (const s of [
+      'trigger:webhook',
+      'trigger:cron',
+      'trigger:manual',
+      'slack',
+      'email',
+      'telegram',
+      'meet',
+    ]) {
+      expect(isBackgroundSource(s)).toBe(true);
+    }
+  });
+
+  test('foreground and internal sources are not background', () => {
+    for (const s of ['ui', 'mobile', 'cli', 'admin', 'system:sandbox-build-fix']) {
+      expect(isBackgroundSource(s)).toBe(false);
+    }
+  });
+
+  test('non-strings are never background', () => {
+    expect(isBackgroundSource(undefined)).toBe(false);
+    expect(isBackgroundSource(null)).toBe(false);
+    expect(isBackgroundSource(42)).toBe(false);
+  });
+});
+
+describe('sessionSourceKind', () => {
+  test('maps cron to schedule and webhook/manual to webhook', () => {
+    expect(sessionSourceKind('trigger:cron')).toBe('schedule');
+    expect(sessionSourceKind('trigger:webhook')).toBe('webhook');
+    expect(sessionSourceKind('trigger:manual')).toBe('webhook');
+  });
+
+  test('passes channel kinds through', () => {
+    expect(sessionSourceKind('slack')).toBe('slack');
+    expect(sessionSourceKind('telegram')).toBe('telegram');
+    expect(sessionSourceKind('email')).toBe('email');
+    expect(sessionSourceKind('meet')).toBe('meet');
+  });
+
+  test('returns null for unmapped sources', () => {
+    expect(sessionSourceKind('ui')).toBeNull();
+    expect(sessionSourceKind(undefined)).toBeNull();
+  });
+});
+
+describe('inboxTitle', () => {
+  const base = { branchName: 'kortix/run-1', sessionId: 'sess_123' };
+
+  test('custom_name wins over auto name', () => {
+    expect(
+      inboxTitle({ ...base, metadata: { custom_name: 'Nightly backup', name: 'auto title' } }),
+    ).toBe('Nightly backup');
+  });
+
+  test('falls back to auto name, then branch, then id', () => {
+    expect(inboxTitle({ ...base, metadata: { name: 'Fix the flaky test' } })).toBe(
+      'Fix the flaky test',
+    );
+    expect(inboxTitle({ ...base, metadata: {} })).toBe('kortix/run-1');
+    expect(inboxTitle({ branchName: '', sessionId: 'sess_123', metadata: null })).toBe('sess_123');
+  });
+
+  test('ignores blank/whitespace names', () => {
+    expect(inboxTitle({ ...base, metadata: { custom_name: '   ', name: '' } })).toBe('kortix/run-1');
+  });
+
+  test('prefers the trigger slug over the auto name and branch', () => {
+    expect(
+      inboxTitle({ ...base, metadata: { trigger_slug: 'github-pr-review', name: 'auto' } }),
+    ).toBe('github-pr-review');
+    expect(
+      inboxTitle({ ...base, metadata: { custom_name: 'Mine', trigger_slug: 'nightly' } }),
+    ).toBe('Mine');
+  });
+});
+
+describe('attentionDedupKey', () => {
+  test('collapses within the same minute, differs across minutes', () => {
+    const t0 = 1_800_000_000_000;
+    expect(attentionDedupKey('run_completed', 'sess_1', t0)).toBe(
+      attentionDedupKey('run_completed', 'sess_1', t0 + 59_000),
+    );
+    expect(attentionDedupKey('run_completed', 'sess_1', t0)).not.toBe(
+      attentionDedupKey('run_completed', 'sess_1', t0 + 61_000),
+    );
+  });
+
+  test('kind and session are part of the key', () => {
+    const t0 = 1_800_000_000_000;
+    expect(attentionDedupKey('run_completed', 'sess_1', t0)).not.toBe(
+      attentionDedupKey('run_failed', 'sess_1', t0),
+    );
+    expect(attentionDedupKey('run_completed', 'sess_1', t0)).not.toBe(
+      attentionDedupKey('run_completed', 'sess_2', t0),
+    );
+  });
+});

--- a/apps/api/src/inbox/record-attention.ts
+++ b/apps/api/src/inbox/record-attention.ts
@@ -1,0 +1,138 @@
+import { accountMembers, inboxItems, projectSessions } from '@kortix/db';
+import { and, eq } from 'drizzle-orm';
+import { db } from '../shared/db';
+import type { SessionInvocationSource } from '../projects/session-lifecycle/types';
+
+export type InboxItemKind = (typeof inboxItems.$inferInsert)['kind'];
+
+const BACKGROUND_SOURCES: ReadonlySet<string> = new Set<SessionInvocationSource>([
+  'trigger:webhook',
+  'trigger:cron',
+  'trigger:manual',
+  'slack',
+  'email',
+  'telegram',
+  'meet',
+]);
+
+export function isBackgroundSource(source: unknown): boolean {
+  return typeof source === 'string' && BACKGROUND_SOURCES.has(source);
+}
+
+export function sessionSourceKind(source: unknown): string | null {
+  switch (source) {
+    case 'trigger:cron':
+      return 'schedule';
+    case 'trigger:webhook':
+    case 'trigger:manual':
+      return 'webhook';
+    case 'slack':
+      return 'slack';
+    case 'telegram':
+      return 'telegram';
+    case 'email':
+      return 'email';
+    case 'meet':
+      return 'meet';
+    default:
+      return null;
+  }
+}
+
+type SessionRow = typeof projectSessions.$inferSelect;
+
+export function inboxTitle(row: Pick<SessionRow, 'metadata' | 'branchName' | 'sessionId'>): string {
+  const meta = (row.metadata ?? {}) as Record<string, unknown>;
+  const customName = typeof meta.custom_name === 'string' ? meta.custom_name.trim() : '';
+  const autoName = typeof meta.name === 'string' ? meta.name.trim() : '';
+  const triggerSlug = typeof meta.trigger_slug === 'string' ? meta.trigger_slug.trim() : '';
+  return customName || triggerSlug || autoName || row.branchName || row.sessionId;
+}
+
+export function attentionDedupKey(kind: InboxItemKind, sessionId: string, at: number): string {
+  const minuteBucket = Math.floor(at / 60_000);
+  return `${kind}:${sessionId}:${minuteBucket}`;
+}
+
+export interface RecordAttentionInput {
+  accountId: string;
+  projectId: string;
+  userId: string;
+  kind: InboxItemKind;
+  title: string;
+  dedupKey: string;
+  sessionId?: string | null;
+  source?: string | null;
+  metadata?: Record<string, unknown>;
+}
+
+export async function recordAttention(input: RecordAttentionInput): Promise<void> {
+  try {
+    await db
+      .insert(inboxItems)
+      .values({
+        accountId: input.accountId,
+        projectId: input.projectId,
+        userId: input.userId,
+        kind: input.kind,
+        title: input.title,
+        dedupKey: input.dedupKey,
+        sessionId: input.sessionId ?? null,
+        source: input.source ?? null,
+        metadata: input.metadata ?? {},
+      })
+      .onConflictDoNothing({ target: [inboxItems.userId, inboxItems.dedupKey] });
+  } catch (err) {
+    console.warn(`[inbox] recordAttention failed (${input.kind}): ${String(err)}`);
+  }
+}
+
+async function resolveInboxRecipient(
+  accountId: string,
+  fallbackUserId: string | null,
+): Promise<string | null> {
+  const [owner] = await db
+    .select({ userId: accountMembers.userId })
+    .from(accountMembers)
+    .where(and(eq(accountMembers.accountId, accountId), eq(accountMembers.accountRole, 'owner')))
+    .limit(1);
+  return owner?.userId ?? fallbackUserId;
+}
+
+export async function recordSessionAttention(
+  sessionId: string,
+  kind: InboxItemKind,
+  opts: { dedupKey?: string; metadata?: Record<string, unknown>; now?: number } = {},
+): Promise<void> {
+  try {
+    const [row] = await db
+      .select()
+      .from(projectSessions)
+      .where(eq(projectSessions.sessionId, sessionId))
+      .limit(1);
+    if (!row) return;
+
+    const meta = (row.metadata ?? {}) as Record<string, unknown>;
+    const source = meta.source;
+    if (!isBackgroundSource(source)) return;
+
+    const userId = await resolveInboxRecipient(row.accountId, row.createdBy);
+    if (!userId) return;
+
+    const triggerSlug = typeof meta.trigger_slug === 'string' ? meta.trigger_slug : undefined;
+    const at = opts.now ?? Date.now();
+    await recordAttention({
+      accountId: row.accountId,
+      projectId: row.projectId,
+      userId,
+      kind,
+      title: inboxTitle(row),
+      dedupKey: opts.dedupKey ?? attentionDedupKey(kind, sessionId, at),
+      sessionId,
+      source: sessionSourceKind(source),
+      metadata: { ...opts.metadata, ...(triggerSlug ? { trigger_slug: triggerSlug } : {}) },
+    });
+  } catch (err) {
+    console.warn(`[inbox] recordSessionAttention failed (${sessionId}, ${kind}): ${String(err)}`);
+  }
+}

--- a/apps/api/src/platform/services/session-sandbox.ts
+++ b/apps/api/src/platform/services/session-sandbox.ts
@@ -16,6 +16,7 @@ import { eq } from 'drizzle-orm';
 import { projectSessions, sessionSandboxes } from '@kortix/db';
 import { db } from '../../shared/db';
 import { notifySessionProvisioningFailed } from '../../shared/session-failure-notifier';
+import { recordSessionAttention } from '../../inbox/record-attention';
 import { createApiKey } from '../../repositories/api-keys';
 import { createAccountToken } from '../../repositories/account-tokens';
 import { ensureAgentServiceAccount } from '../../repositories/service-accounts';
@@ -722,6 +723,9 @@ export async function provisionSessionSandbox(opts: {
           .set({ status: 'failed', error: userMessage, updatedAt: new Date() })
           .where(eq(projectSessions.sessionId, sandbox.sandboxId))
           .catch(() => {});
+        await recordSessionAttention(sandbox.sandboxId, 'run_failed', {
+          metadata: { error: { message: userMessage }, provisioning: true },
+        });
       } catch (markErr) {
         console.error(`[session-sandbox] Failed to mark sandbox ${sandbox.sandboxId} as error:`, markErr);
       }

--- a/apps/api/src/projects/index.ts
+++ b/apps/api/src/projects/index.ts
@@ -31,6 +31,7 @@ import './routes/r8';
 import './routes/r9';
 import './routes/r10';
 import './routes/r11';
+import './routes/inbox';
 import './routes/model-defaults';
 import './routes/agent-scope';
 import './routes/agent-config';

--- a/apps/api/src/projects/routes/inbox.ts
+++ b/apps/api/src/projects/routes/inbox.ts
@@ -1,0 +1,95 @@
+// ─── Automation Inbox ───────────────────────────────────────────────────────
+// Per-project, per-user awareness feed (gated by the `inbox` experimental flag).
+
+import { createRoute, z } from '@hono/zod-openapi';
+import { resolveExperimentalFeature } from '../../experimental/features';
+import {
+  countUnreadForUser,
+  listInboxForUser,
+  markInboxRead,
+  serializeInboxItem,
+} from '../../inbox/inbox-items';
+import { auth, errors, json } from '../../openapi';
+import { loadProjectForUser } from '../lib/access';
+import { AnyObject, projectsApp } from '../lib/app';
+import { readBody } from '../lib/serializers';
+
+projectsApp.openapi(
+  createRoute({
+    method: 'get',
+    path: '/{projectId}/inbox',
+    tags: ['inbox'],
+    summary: 'GET /:projectId/inbox',
+    ...auth,
+    request: {
+      params: z.object({ projectId: z.string() }),
+      query: z.object({}).passthrough(),
+    },
+    responses: {
+      200: json(
+        z.object({ items: z.array(AnyObject), unread_count: z.number() }),
+        'Inbox items for the caller',
+      ),
+      ...errors(400, 404),
+    },
+  }),
+  async (c: any) => {
+    const projectId = c.req.param('projectId');
+    const loaded = await loadProjectForUser(c, projectId, 'read');
+    if (!loaded) return c.json({ error: 'Not found' }, 404);
+    if (!resolveExperimentalFeature(loaded.row.metadata, 'inbox')) {
+      return c.json({ error: 'Not found' }, 404);
+    }
+
+    const filter = String(c.req.query('filter') ?? 'all').toLowerCase();
+    if (filter !== 'all' && filter !== 'unread') {
+      return c.json({ error: 'filter must be all or unread' }, 400);
+    }
+
+    const [rows, unreadCount] = await Promise.all([
+      listInboxForUser(projectId, loaded.userId, { unreadOnly: filter === 'unread' }),
+      countUnreadForUser(projectId, loaded.userId),
+    ]);
+    return c.json({ items: rows.map(serializeInboxItem), unread_count: unreadCount });
+  },
+);
+
+projectsApp.openapi(
+  createRoute({
+    method: 'post',
+    path: '/{projectId}/inbox/read',
+    tags: ['inbox'],
+    summary: 'POST /:projectId/inbox/read',
+    ...auth,
+    request: {
+      params: z.object({ projectId: z.string() }),
+      body: { content: { 'application/json': { schema: AnyObject } } },
+    },
+    responses: {
+      200: json(z.object({ updated: z.number(), unread_count: z.number() }), 'Marked read'),
+      ...errors(400, 404),
+    },
+  }),
+  async (c: any) => {
+    const projectId = c.req.param('projectId');
+    const loaded = await loadProjectForUser(c, projectId, 'read');
+    if (!loaded) return c.json({ error: 'Not found' }, 404);
+    if (!resolveExperimentalFeature(loaded.row.metadata, 'inbox')) {
+      return c.json({ error: 'Not found' }, 404);
+    }
+
+    const body = await readBody(c);
+    const itemIds = Array.isArray(body.item_ids)
+      ? body.item_ids.filter((v: unknown): v is string => typeof v === 'string')
+      : undefined;
+    const sessionId = typeof body.session_id === 'string' ? body.session_id : undefined;
+    const all = body.all === true;
+    if (!itemIds?.length && !sessionId && !all) {
+      return c.json({ error: 'Provide item_ids, session_id, or all: true' }, 400);
+    }
+
+    const updated = await markInboxRead(projectId, loaded.userId, { itemIds, sessionId, all });
+    const unreadCount = await countUnreadForUser(projectId, loaded.userId);
+    return c.json({ updated, unread_count: unreadCount });
+  },
+);

--- a/apps/api/src/projects/routes/r4.ts
+++ b/apps/api/src/projects/routes/r4.ts
@@ -44,6 +44,7 @@ import {
   type QuestionInfo,
 } from "../../channels/slack-webhook";
 import { PROJECT_ACTIONS } from "../../iam";
+import { recordSessionAttention } from "../../inbox/record-attention";
 import { auth, errors, json } from "../../openapi";
 import { projectLlmGatewayEnabled } from "../../llm-gateway/enablement";
 import { gatewayModelCatalog } from "../../llm-gateway/models/catalog-models";
@@ -1084,6 +1085,11 @@ projectsApp.openapi(
             }
           : undefined;
       const ok = await relayTurnEnd(sessionId, status, errorInfo);
+      await recordSessionAttention(
+        sessionId,
+        status === "error" ? "run_failed" : "run_completed",
+        errorInfo ? { metadata: { error: errorInfo } } : undefined,
+      );
       return c.json({ ok });
     }
 

--- a/apps/kortix-sandbox-agent-server/src/main.ts
+++ b/apps/kortix-sandbox-agent-server/src/main.ts
@@ -988,8 +988,10 @@ async function waitForInitialSessionCreate(baseUrl: string, workspace: string): 
 // the opencode event is handled natively. Shared by the question + turn-end
 // relays so BOTH gate on Slack identically — the question relay used to skip
 // this gate, which auto-answered the `question` tool in non-Slack sessions.
-function slackRelayContext(): { projectId: string; sessionId: string; token: string; apiRoot: string } | null {
-  if (!(process.env.SLACK_THREAD_TS || process.env.SLACK_CHANNEL_ID)) return null
+// Build the apps/api relay context from the KORTIX_* env every session carries.
+// Not Slack-gated — the turn-end relay uses this so run-end is reported for ALL
+// sessions (cron/webhook/channel/web), which is what drives the Automation Inbox.
+function relayContext(): { projectId: string; sessionId: string; token: string; apiRoot: string } | null {
   const projectId = process.env.KORTIX_PROJECT_ID?.trim()
   const sessionId = process.env.KORTIX_SESSION_ID?.trim()
   // /turn-stream accepts EITHER the session token or the sandbox credential
@@ -1010,6 +1012,13 @@ function slackRelayContext(): { projectId: string; sessionId: string; token: str
   }
   const apiRoot = apiUrl.endsWith('/v1') ? apiUrl : `${apiUrl}/v1`
   return { projectId, sessionId, token, apiRoot }
+}
+
+// The question relay STAYS Slack-gated: auto-answering opencode's `question`
+// tool outside Slack was a bug (the dashboard answers it interactively).
+function slackRelayContext(): { projectId: string; sessionId: string; token: string; apiRoot: string } | null {
+  if (!(process.env.SLACK_THREAD_TS || process.env.SLACK_CHANNEL_ID)) return null
+  return relayContext()
 }
 
 // Relay an opencode `question.asked` event for a SLACK session: post the
@@ -1097,11 +1106,11 @@ async function relayTurnEndToApi(
   cfg: Config,
   eventError?: OpencodeTurnError,
 ): Promise<void> {
-  const ctx = slackRelayContext()
+  const ctx = relayContext()
   if (!ctx) return
-  // Only the ROOT turn closes the Slack stream — a subagent going idle mid-task
-  // must NOT finalize the user-facing stream. Detected by parentID (objective),
-  // not pin-equality, so an orphaned-root re-pin can't filter out the real idle.
+  // Only the ROOT turn closes the stream — a subagent going idle mid-task must
+  // NOT finalize the user-facing turn. Detected by parentID (objective), not
+  // pin-equality, so an orphaned-root re-pin can't filter out the real idle.
   if (!(await isRootOpencodeSession(opencodeSessionId, opencode, cfg))) return
 
   // Resolve the turn's error. session.error already hands us one; an idle end

--- a/apps/web/src/features/workspace/project-sidebar/footer/project-inbox-nav.tsx
+++ b/apps/web/src/features/workspace/project-sidebar/footer/project-inbox-nav.tsx
@@ -1,0 +1,195 @@
+'use client';
+
+import { formatDistanceToNowStrict } from 'date-fns';
+import { Bell, CheckCheck, CheckCircle2, Inbox as InboxIcon, XCircle } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import { useCallback, useMemo, useState } from 'react';
+
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { SidebarMenuButton, SidebarMenuItem } from '@/components/ui/sidebar';
+import { useIsMobile } from '@/hooks/use-mobile';
+import {
+  useInboxEnabled,
+  useMarkInboxRead,
+  useProjectInbox,
+} from '@/hooks/projects/use-project-inbox';
+import type { InboxItem } from '@/lib/inbox-client';
+import { cn } from '@/lib/utils';
+
+type Filter = 'all' | 'unread' | 'failed';
+
+function relativeTime(iso: string): string {
+  try {
+    return formatDistanceToNowStrict(new Date(iso), { addSuffix: false });
+  } catch {
+    return '';
+  }
+}
+
+function InboxItemRow({ item, onOpen }: { item: InboxItem; onOpen: (item: InboxItem) => void }) {
+  const failed = item.kind === 'run_failed';
+  const Icon = failed ? XCircle : CheckCircle2;
+  return (
+    <button
+      type="button"
+      onClick={() => onOpen(item)}
+      className="group hover:bg-muted/50 focus-visible:bg-muted/50 flex w-full items-start gap-3 px-3.5 py-2.5 text-left transition-colors focus-visible:outline-none"
+    >
+      <Icon className={cn('mt-0.5 size-4 shrink-0', failed ? 'text-destructive' : 'text-kortix-green')} />
+      <div className="min-w-0 flex-1">
+        <span className="text-foreground block truncate text-sm leading-5 font-medium">
+          {item.title}
+        </span>
+        <div className="text-muted-foreground mt-0.5 flex items-center gap-1.5 text-xs">
+          <span>{failed ? 'Run failed' : 'Run finished'}</span>
+          {item.source && <span className="text-muted-foreground/60">· {item.source}</span>}
+          <span className="text-muted-foreground/60">· {relativeTime(item.created_at)}</span>
+        </div>
+      </div>
+      {!item.read && <span className="mt-1.5 size-1.5 shrink-0 rounded-full bg-red-500" />}
+    </button>
+  );
+}
+
+function FilterTab({
+  active,
+  count,
+  children,
+  onClick,
+}: {
+  active: boolean;
+  count?: number;
+  children: React.ReactNode;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        'flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium transition-colors',
+        active
+          ? 'bg-foreground/10 text-foreground'
+          : 'text-muted-foreground hover:text-foreground',
+      )}
+    >
+      {children}
+      {count != null && count > 0 && <span className="tabular-nums opacity-60">{count}</span>}
+    </button>
+  );
+}
+
+function NavItemInner({ projectId }: { projectId: string }) {
+  const enabled = useInboxEnabled(projectId);
+  const isMobile = useIsMobile();
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [filter, setFilter] = useState<Filter>('all');
+
+  const { data } = useProjectInbox(projectId, enabled);
+  const markRead = useMarkInboxRead(projectId);
+
+  const items = useMemo(() => data?.items ?? [], [data?.items]);
+  const unreadCount = data?.unread_count ?? 0;
+  const failedCount = useMemo(() => items.filter((i) => i.kind === 'run_failed').length, [items]);
+
+  const visible = useMemo(() => {
+    if (filter === 'unread') return items.filter((i) => !i.read);
+    if (filter === 'failed') return items.filter((i) => i.kind === 'run_failed');
+    return items;
+  }, [items, filter]);
+
+  const openItem = useCallback(
+    (item: InboxItem) => {
+      setOpen(false);
+      if (item.session_id) {
+        markRead.mutate({ session_id: item.session_id });
+        router.push(`/projects/${projectId}/sessions/${item.session_id}`);
+      } else {
+        markRead.mutate({ item_ids: [item.id] });
+      }
+    },
+    [markRead, projectId, router],
+  );
+
+  if (!enabled || unreadCount === 0) return null;
+
+  return (
+    <SidebarMenuItem>
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <SidebarMenuButton className="text-sm! font-medium [&_svg]:size-4!">
+            <Bell />
+            <span>Inbox</span>
+            <span className="ml-auto flex min-w-[1.125rem] items-center justify-center rounded-full bg-destructive/15 px-1.5 text-xs font-medium text-destructive tabular-nums">
+              {unreadCount}
+            </span>
+          </SidebarMenuButton>
+        </PopoverTrigger>
+        <PopoverContent
+          side={isMobile ? 'top' : 'right'}
+          align={isMobile ? 'start' : 'end'}
+          sideOffset={12}
+          className="w-[360px] overflow-hidden p-0"
+        >
+          <div className="border-border flex items-center justify-between gap-3 border-b px-3.5 py-2.5">
+            <div className="flex min-w-0 items-center gap-2.5">
+              <span className="bg-kortix-base/10 text-kortix-base grid size-8 shrink-0 place-items-center rounded-md">
+                <Bell className="size-4" />
+              </span>
+              <div className="min-w-0">
+                <h3 className="text-foreground truncate text-sm font-medium">Inbox</h3>
+                <p className="text-muted-foreground truncate text-xs">
+                  {unreadCount} unread from your automations
+                </p>
+              </div>
+            </div>
+            <button
+              type="button"
+              onClick={() => markRead.mutate({ all: true })}
+              className="text-muted-foreground hover:text-foreground flex shrink-0 items-center gap-1 text-xs transition-colors"
+            >
+              <CheckCheck className="size-3.5" />
+              Mark all
+            </button>
+          </div>
+
+          <div className="border-border flex items-center gap-1 border-b px-2.5 py-1.5">
+            <FilterTab active={filter === 'all'} count={items.length} onClick={() => setFilter('all')}>
+              All
+            </FilterTab>
+            <FilterTab
+              active={filter === 'unread'}
+              count={unreadCount}
+              onClick={() => setFilter('unread')}
+            >
+              Unread
+            </FilterTab>
+            <FilterTab
+              active={filter === 'failed'}
+              count={failedCount}
+              onClick={() => setFilter('failed')}
+            >
+              Failed
+            </FilterTab>
+          </div>
+
+          <div className="max-h-[50vh] overflow-y-auto py-1">
+            {visible.length === 0 ? (
+              <div className="text-muted-foreground/70 flex flex-col items-center gap-2 px-4 py-8 text-center">
+                <InboxIcon className="size-5 opacity-50" />
+                <span className="text-xs">Nothing here</span>
+              </div>
+            ) : (
+              visible.map((item) => <InboxItemRow key={item.id} item={item} onOpen={openItem} />)
+            )}
+          </div>
+        </PopoverContent>
+      </Popover>
+    </SidebarMenuItem>
+  );
+}
+
+export function ProjectInboxNavItem({ projectId }: { projectId: string }) {
+  return <NavItemInner projectId={projectId} />;
+}

--- a/apps/web/src/features/workspace/project-sidebar/project-session-list.tsx
+++ b/apps/web/src/features/workspace/project-sidebar/project-session-list.tsx
@@ -35,6 +35,7 @@ import {
 import { cn } from '@/lib/utils';
 import { Icon as IconMynauiType, Pencil, Share, TrashSolid } from '@mynaui/icons-react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useInboxEnabled, useUnreadSessionIds } from '@/hooks/projects/use-project-inbox';
 import { formatDistanceToNowStrict } from 'date-fns';
 import {
   CalendarClock,
@@ -106,6 +107,9 @@ export function ProjectSessionList({ projectId, filter = 'all' }: ProjectSession
   );
   const [sessionToShare, setSessionToShare] = useState<ProjectSession | null>(null);
   const [sessionToRename, setSessionToRename] = useState<{ id: string; name: string } | null>(null);
+
+  const inboxEnabled = useInboxEnabled(projectId);
+  const unreadSessionIds = useUnreadSessionIds(projectId, inboxEnabled);
 
   const { data, isLoading, error } = useQuery({
     queryKey: ['project-sessions', projectId],
@@ -191,6 +195,7 @@ export function ProjectSessionList({ projectId, filter = 'all' }: ProjectSession
                 isActive={!!isActive && !activeOpenCodeSessionId}
                 displayTitle={getSessionDisplayTitle(session)}
                 childCount={children.length}
+                isUnread={unreadSessionIds.has(session.session_id)}
                 onDelete={(id, label) => setSessionToDelete({ id, label })}
                 onShare={(s) => setSessionToShare(s)}
                 onRename={(id, name) => setSessionToRename({ id, name })}
@@ -265,6 +270,7 @@ interface ProjectSessionRowProps {
   onStop: (sessionId: string) => void;
   isStopping: boolean;
   childCount?: number;
+  isUnread?: boolean;
 }
 
 function ProjectSessionRow({
@@ -280,6 +286,7 @@ function ProjectSessionRow({
   onStop,
   isStopping,
   childCount = 0,
+  isUnread = false,
 }: ProjectSessionRowProps) {
   const tHardcodedUi = useTranslations('hardcodedUi');
   const [menuOpen, setMenuOpen] = useState(false);
@@ -313,9 +320,15 @@ function ProjectSessionRow({
         <Link href={href} className="flex min-w-0 flex-1 items-center gap-2 self-stretch">
           <SessionStatusDot status={session.status} />
 
-          <span className={cn('min-w-0 flex-1 truncate text-sm', isActive && 'font-medium')}>
+          <span
+            className={cn('min-w-0 flex-1 truncate text-sm', (isActive || isUnread) && 'font-medium')}
+          >
             {displayTitle}
           </span>
+
+          {isUnread && (
+            <span className="size-1.5 shrink-0 rounded-full bg-red-500" aria-label="Unread" />
+          )}
 
           {childCount > 0 && (
             <span className="bg-sidebar-accent/60 text-muted-foreground shrink-0 rounded-full px-1.5 py-0.5 text-xs tabular-nums">

--- a/apps/web/src/features/workspace/project-sidebar/project-sidebar.tsx
+++ b/apps/web/src/features/workspace/project-sidebar/project-sidebar.tsx
@@ -32,6 +32,7 @@ import { UserMenu } from '@/features/layout/user-menu';
 import { useAuth } from '@/features/providers/auth-provider';
 import { ProjectAppsNavItem } from '@/features/workspace/project-sidebar/footer/project-apps-nav';
 import { ProjectChangeRequestsNavItem } from '@/features/workspace/project-sidebar/footer/project-change-requests-nav';
+import { ProjectInboxNavItem } from '@/features/workspace/project-sidebar/footer/project-inbox-nav';
 import { ProjectChatGptConnectNavItem } from '@/features/workspace/project-sidebar/footer/project-chatgpt-connect-nav';
 import {
   ProjectCustomizeNavItem,
@@ -279,6 +280,7 @@ export function ProjectSidebar({ projectId }: { projectId: string }) {
           <SidebarGroup className="mt-auto py-0.5">
             <SidebarMenu>
               <ProjectSandboxAlert projectId={projectId} />
+              <ProjectInboxNavItem projectId={projectId} />
               <ProjectChangeRequestsNavItem projectId={projectId} />
               <ProjectAppsNavItem projectId={projectId} />
               {/* Files used to live on the collapsed icon rail; with the rail

--- a/apps/web/src/hooks/projects/use-project-inbox.ts
+++ b/apps/web/src/hooks/projects/use-project-inbox.ts
@@ -1,0 +1,57 @@
+'use client';
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useMemo } from 'react';
+
+import { getProjectDetail } from '@kortix/sdk/projects-client';
+
+import { getProjectInbox, markInboxRead, type InboxResponse } from '@/lib/inbox-client';
+
+export function projectInboxKey(projectId: string | undefined) {
+  return ['project-inbox', projectId] as const;
+}
+
+export function useInboxEnabled(projectId: string | undefined): boolean {
+  const { data } = useQuery({
+    queryKey: ['project-detail', projectId],
+    queryFn: () => getProjectDetail(projectId!),
+    enabled: !!projectId,
+    staleTime: 60_000,
+  });
+  return data?.project?.experimental?.inbox ?? false;
+}
+
+export function useUnreadSessionIds(projectId: string | undefined, enabled = true): Set<string> {
+  const { data } = useProjectInbox(projectId, enabled);
+  return useMemo(() => {
+    const ids = new Set<string>();
+    for (const item of data?.items ?? []) {
+      if (!item.read && item.session_id) ids.add(item.session_id);
+    }
+    return ids;
+  }, [data?.items]);
+}
+
+export function useProjectInbox(projectId: string | undefined, enabled = true) {
+  return useQuery({
+    queryKey: projectInboxKey(projectId),
+    queryFn: () => getProjectInbox(projectId!),
+    enabled: !!projectId && enabled,
+    refetchInterval: 20_000,
+    staleTime: 10_000,
+  });
+}
+
+export function useMarkInboxRead(projectId: string | undefined) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (selection: { item_ids?: string[]; session_id?: string; all?: boolean }) =>
+      markInboxRead(projectId!, selection),
+    onSuccess: (result) => {
+      queryClient.setQueryData<InboxResponse>(projectInboxKey(projectId), (prev) =>
+        prev ? { ...prev, unread_count: result.unread_count } : prev,
+      );
+      queryClient.invalidateQueries({ queryKey: projectInboxKey(projectId) });
+    },
+  });
+}

--- a/apps/web/src/lib/inbox-client.ts
+++ b/apps/web/src/lib/inbox-client.ts
@@ -1,0 +1,50 @@
+import { backendApi } from '@/lib/api-client';
+
+export type InboxItemKind = 'run_completed' | 'run_failed';
+
+export interface InboxItem {
+  id: string;
+  project_id: string;
+  session_id: string | null;
+  kind: InboxItemKind;
+  title: string;
+  source: string | null;
+  metadata: Record<string, unknown>;
+  read: boolean;
+  read_at: string | null;
+  created_at: string;
+}
+
+export interface InboxResponse {
+  items: InboxItem[];
+  unread_count: number;
+}
+
+export interface MarkReadResult {
+  updated: number;
+  unread_count: number;
+}
+
+function unwrap<T>(response: { data?: T; success: boolean; error?: Error }): T {
+  if (!response.success || response.data === undefined) {
+    throw response.error ?? new Error('Inbox request failed');
+  }
+  return response.data;
+}
+
+export async function getProjectInbox(
+  projectId: string,
+  opts?: { unreadOnly?: boolean },
+): Promise<InboxResponse> {
+  const suffix = opts?.unreadOnly ? '?filter=unread' : '';
+  return unwrap(await backendApi.get<InboxResponse>(`/projects/${projectId}/inbox${suffix}`));
+}
+
+export async function markInboxRead(
+  projectId: string,
+  selection: { item_ids?: string[]; session_id?: string; all?: boolean },
+): Promise<MarkReadResult> {
+  return unwrap(
+    await backendApi.post<MarkReadResult>(`/projects/${projectId}/inbox/read`, selection),
+  );
+}

--- a/packages/api-contract/src/__tests__/schemas.test.ts
+++ b/packages/api-contract/src/__tests__/schemas.test.ts
@@ -41,6 +41,7 @@ function projectFixture(overrides: Record<string, unknown> = {}) {
       meet: false,
       llm_gateway: true,
       review_center: false,
+      inbox: false,
     },
     experimental_features: [
       {
@@ -349,6 +350,7 @@ describe('envelopes', () => {
       'meet',
       'llm_gateway',
       'review_center',
+      'inbox',
     ]);
   });
 

--- a/packages/api-contract/src/index.ts
+++ b/packages/api-contract/src/index.ts
@@ -52,6 +52,7 @@ export const ExperimentalFeatureMapSchema = z.object({
   meet: z.boolean(),
   llm_gateway: z.boolean(),
   review_center: z.boolean(),
+  inbox: z.boolean(),
 });
 export type ExperimentalFeatureMap = z.infer<typeof ExperimentalFeatureMapSchema>;
 

--- a/packages/db/migrations/20260706120000001_add-inbox-items.sql
+++ b/packages/db/migrations/20260706120000001_add-inbox-items.sql
@@ -1,0 +1,66 @@
+-- Up Migration
+--
+-- Automation Inbox: the `inbox_items` table + its kind enum. An inbox_item is a
+-- per-user awareness signal that a background/triggered run did something the
+-- recipient may want to see — it completing or failing while nobody watched.
+-- This is an awareness feed (unread → read via `read_at`), NOT a verdict queue:
+-- approvals/decisions/change-requests live in `review_items`. Generic on
+-- purpose — any feature can emit here (see apps/api/src/inbox/record-attention.ts).
+-- Mirrors the Drizzle model in packages/db/src/schema/kortix.ts (inboxItems).
+-- Hand-written (node-pg-migrate) because the drizzle snapshot chain forked
+-- during the origin/main merge; node-pg-migrate applies migrations/*.sql
+-- independently of the drizzle snapshot (same as review_items).
+
+DO $$ BEGIN
+ CREATE TYPE "kortix"."inbox_item_kind" AS ENUM ('run_completed', 'run_failed');
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+
+CREATE TABLE IF NOT EXISTS "kortix"."inbox_items" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "account_id" uuid NOT NULL,
+  "project_id" uuid NOT NULL,
+  "session_id" text,
+  "user_id" uuid NOT NULL,
+  "kind" "kortix"."inbox_item_kind" NOT NULL,
+  "title" text NOT NULL,
+  "source" text,
+  "metadata" jsonb DEFAULT '{}'::jsonb,
+  "dedup_key" text NOT NULL,
+  "read_at" timestamp with time zone,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "inbox_items_account_id_accounts_account_id_fk"
+    FOREIGN KEY ("account_id") REFERENCES "kortix"."accounts"("account_id") ON DELETE cascade ON UPDATE no action,
+  CONSTRAINT "inbox_items_project_id_projects_project_id_fk"
+    FOREIGN KEY ("project_id") REFERENCES "kortix"."projects"("project_id") ON DELETE cascade ON UPDATE no action,
+  CONSTRAINT "inbox_items_session_id_project_sessions_session_id_fk"
+    FOREIGN KEY ("session_id") REFERENCES "kortix"."project_sessions"("session_id") ON DELETE cascade ON UPDATE no action
+);
+--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "idx_inbox_items_user_created"
+  ON "kortix"."inbox_items" USING btree ("user_id", "created_at");
+--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "idx_inbox_items_user_unread"
+  ON "kortix"."inbox_items" USING btree ("user_id", "read_at");
+--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "idx_inbox_items_project_user"
+  ON "kortix"."inbox_items" USING btree ("project_id", "user_id");
+--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "idx_inbox_items_session"
+  ON "kortix"."inbox_items" USING btree ("session_id");
+--> statement-breakpoint
+
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_inbox_items_dedup"
+  ON "kortix"."inbox_items" USING btree ("user_id", "dedup_key");
+
+-- Down Migration
+
+DROP TABLE IF EXISTS "kortix"."inbox_items";
+--> statement-breakpoint
+DROP TYPE IF EXISTS "kortix"."inbox_item_kind";

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -136,6 +136,9 @@ export {
   reviewItemSourceEnum,
   reviewItems,
   reviewItemsRelations,
+  // Automation Inbox
+  inboxItemKindEnum,
+  inboxItems,
   // IAM
   accountGroupSourceEnum,
   accountGroups,

--- a/packages/db/src/schema/kortix.test.ts
+++ b/packages/db/src/schema/kortix.test.ts
@@ -18,14 +18,17 @@ import {
   tunnelStatusEnum,
   platformRoleEnum,
   changeRequestStatusEnum,
+  inboxItemKindEnum,
   accounts,
   accountMembers,
   projects,
   projectMembers,
   projectGitConnections,
+  projectSessions,
   sandboxes,
   sandboxMembers,
   deployments,
+  inboxItems,
   kortixApiKeys,
 } from './kortix';
 
@@ -158,6 +161,64 @@ describe('kortix enums', () => {
   test('change_request_status enum is non-empty and named', () => {
     expect(changeRequestStatusEnum.enumName).toBe('change_request_status');
     expect(changeRequestStatusEnum.enumValues.length).toBeGreaterThan(0);
+  });
+
+  test('inbox_item_kind enum covers the awareness signals', () => {
+    expect(inboxItemKindEnum.enumName).toBe('inbox_item_kind');
+    expect(inboxItemKindEnum.enumValues).toEqual(['run_completed', 'run_failed']);
+  });
+});
+
+describe('inbox_items table', () => {
+  test('is named inbox_items in the kortix schema', () => {
+    expect(getTableConfig(inboxItems).name).toBe('inbox_items');
+    expect(getTableConfig(inboxItems).schema).toBe('kortix');
+  });
+
+  test('has the awareness-feed columns with id as primary key', () => {
+    expect(columnNames(inboxItems)).toEqual([
+      'id',
+      'account_id',
+      'project_id',
+      'session_id',
+      'user_id',
+      'kind',
+      'title',
+      'source',
+      'metadata',
+      'dedup_key',
+      'read_at',
+      'created_at',
+    ]);
+    expect(primaryColumn(inboxItems)).toBe('id');
+  });
+
+  test('read_at and session_id are nullable; user_id and dedup_key are required', () => {
+    const cols = getTableConfig(inboxItems).columns;
+    const byName = (n: string) => cols.find((c) => c.name === n);
+    expect(byName('read_at')?.notNull).toBe(false);
+    expect(byName('session_id')?.notNull).toBe(false);
+    expect(byName('source')?.notNull).toBe(false);
+    expect(byName('user_id')?.notNull).toBe(true);
+    expect(byName('dedup_key')?.notNull).toBe(true);
+  });
+
+  test('foreign-keys account, project, and session (session on delete cascade)', () => {
+    const fks = getTableConfig(inboxItems).foreignKeys;
+    const referenced = fks.map((f) => getTableConfig(f.reference().foreignTable).name).sort();
+    expect(referenced).toEqual(['accounts', 'project_sessions', 'projects']);
+  });
+
+  test('indexes the unread feed and a per-user dedup uniqueness', () => {
+    const names = indexNames(inboxItems);
+    expect(names).toContain('idx_inbox_items_user_created');
+    expect(names).toContain('idx_inbox_items_user_unread');
+    expect(names).toContain('idx_inbox_items_session');
+    const dedup = getTableConfig(inboxItems).indexes.find(
+      (i) => i.config.name === 'idx_inbox_items_dedup',
+    );
+    expect(dedup?.config.unique).toBe(true);
+    expect(dedup?.config.columns.map((c: any) => c.name)).toEqual(['user_id', 'dedup_key']);
   });
 });
 

--- a/packages/db/src/schema/kortix.ts
+++ b/packages/db/src/schema/kortix.ts
@@ -75,6 +75,11 @@ export const sessionLifecycleCommandStatusEnum = kortixSchema.enum(
   ],
 );
 
+export const inboxItemKindEnum = kortixSchema.enum('inbox_item_kind', [
+  'run_completed',
+  'run_failed',
+]);
+
 // `member` is the floor project role (renamed from `user`, see the
 // project_role_member_rename migration). `user` and the older `viewer` are
 // DEPRECATED — both fold into `member` via parseProjectRole/normalizeProjectRole
@@ -561,6 +566,37 @@ export const projectSessions = kortixSchema.table(
     // It is intentionally NOT declared here: re-adding it would make `db:generate`
     // emit a conflicting `CREATE INDEX` against the already-built index. Manage it
     // via that migration; its predicate mirrors ACTIVE_SESSION_STATUSES.
+  ],
+);
+
+export const inboxItems = kortixSchema.table(
+  'inbox_items',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    accountId: uuid('account_id')
+      .notNull()
+      .references(() => accounts.accountId, { onDelete: 'cascade' }),
+    projectId: uuid('project_id')
+      .notNull()
+      .references(() => projects.projectId, { onDelete: 'cascade' }),
+    sessionId: text('session_id').references(() => projectSessions.sessionId, {
+      onDelete: 'cascade',
+    }),
+    userId: uuid('user_id').notNull(),
+    kind: inboxItemKindEnum('kind').notNull(),
+    title: text('title').notNull(),
+    source: text('source'),
+    metadata: jsonb('metadata').default({}).$type<Record<string, unknown>>(),
+    dedupKey: text('dedup_key').notNull(),
+    readAt: timestamp('read_at', { withTimezone: true }),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => [
+    index('idx_inbox_items_user_created').on(table.userId, table.createdAt),
+    index('idx_inbox_items_user_unread').on(table.userId, table.readAt),
+    index('idx_inbox_items_project_user').on(table.projectId, table.userId),
+    index('idx_inbox_items_session').on(table.sessionId),
+    uniqueIndex('idx_inbox_items_dedup').on(table.userId, table.dedupKey),
   ],
 );
 

--- a/packages/sdk/src/platform/projects-client/projects.ts
+++ b/packages/sdk/src/platform/projects-client/projects.ts
@@ -12,7 +12,7 @@ import {
 } from './shared';
 
 /** Stable ids for experimental features (mirrors apps/api experimental/features). */
-export type ExperimentalFeatureKey = 'apps' | 'agent_tunnel' | 'marketplace' | 'agentmail_email' | 'meet' | 'llm_gateway' | 'review_center';
+export type ExperimentalFeatureKey = 'apps' | 'agent_tunnel' | 'marketplace' | 'agentmail_email' | 'meet' | 'llm_gateway' | 'review_center' | 'inbox';
 
 /** One experimental feature as described by the API catalog. */
 export interface ExperimentalFeatureView {


### PR DESCRIPTION
Flag-gated (experimental `inbox`), per-project, per-user awareness feed that records an item when a background/triggered run finishes or fails, surfaced as a sidebar bell (unread count + popover with All/Unread/Failed filters) and unread dots on session rows. Distinct from Review Center — no verdicts, just what's new.

- db: inbox_items table + inbox_item_kind enum (+ migration)
- api: record-attention emit seam (resolves the human owner as recipient), flag-gated /inbox routes, emit on turn-end and provisioning failure
- sandbox-agent: relay turn-end for ALL sessions (was Slack-only), so cron/ webhook/channel runs report completion
- web: bell nav + popover + filters, unread dots, client + query hooks
- contract/sdk: `inbox` experimental key

<!--
  Every change to a protected branch goes through this PR + review (SOC 2 CC8.1).
  Fill out each section. PRs cannot be merged without a passing CI check and an
  approving review from someone other than the author.
-->

## Summary

<!-- What does this change do, and why? Link the issue/ticket if there is one. -->

Closes #

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / chore
- [ ] Infrastructure / CI
- [ ] Security fix
- [ ] Breaking change

## How was this tested?

<!-- Commands run, manual steps, screenshots. State what you verified. -->

## Security & data review

- [ ] No secrets, keys, or credentials are committed (verified by secret scan / review)
- [ ] Authorization checks are in place for any new/changed endpoints (IAM / access control)
- [ ] User input is validated (e.g. Zod) and output is safe
- [ ] No sensitive data (tokens, PII, secrets) is written to logs
- [ ] DB schema / migration changes are reviewed and reversible
- [ ] Touches auth / IAM / crypto / billing / migrations → requested the relevant code owner

## Rollout / rollback

<!-- Migrations, feature flags, env vars, and how to revert if this misbehaves. -->

## Reviewer checklist

- [ ] Change is scoped and understandable
- [ ] Tests/CI pass and cover the change
- [ ] Security & data review above is satisfied
