### PR TITLE
fix(iam): SSO users land in their org — parse real Supabase SAML JWT + await JIT sync

### DIFF
--- a/apps/api/src/__tests__/integration-iam-sso-sync.test.ts
+++ b/apps/api/src/__tests__/integration-iam-sso-sync.test.ts
@@ -33,10 +33,16 @@ const SUPA_SSO = crypto.randomUUID(); // stands in for the Supabase auth.sso_pro
 const MKT_GROUP = crypto.randomUUID();
 const AAD_CLAIM = 'Marketing-AAD'; // what Entra ships in the memberOf claim
 
-// An Azure/Entra-shaped Supabase JWT: SAML attrs live under app_metadata, the
-// provider id under app_metadata.provider_id.
+// A real-shape Supabase SAML JWT: the auth sso_providers id rides in
+// `app_metadata.provider` as "sso:<uuid>" (NOT a bare provider_id — no real
+// Supabase token sets that), and the SAML group attribute (Entra `memberOf`)
+// is wrapped under app_metadata.
 const jwt = (memberOf: string[]) => ({
-  app_metadata: { provider_id: SUPA_SSO, memberOf },
+  app_metadata: {
+    provider: `sso:${SUPA_SSO}`,
+    providers: [`sso:${SUPA_SSO}`],
+    memberOf,
+  },
 });
 
 const canWrite = async (userId: string) =>

--- a/apps/api/src/__tests__/unit-iam-sso.test.ts
+++ b/apps/api/src/__tests__/unit-iam-sso.test.ts
@@ -21,6 +21,43 @@ describe('extractSsoProviderId', () => {
     ).toBe('bbb');
   });
 
+  test('reads the real Supabase shape: app_metadata.provider = "sso:<uuid>"', () => {
+    expect(
+      extractSsoProviderId({
+        app_metadata: {
+          provider: 'sso:464651b7-6157-46b1-afaa-5bbd7fa37599',
+          providers: ['sso:464651b7-6157-46b1-afaa-5bbd7fa37599'],
+        },
+      }),
+    ).toBe('464651b7-6157-46b1-afaa-5bbd7fa37599');
+  });
+
+  test('reads the id out of the providers[] array when provider is absent', () => {
+    expect(
+      extractSsoProviderId({ app_metadata: { providers: ['sso:abc-123'] } }),
+    ).toBe('abc-123');
+  });
+
+  test('prefers an explicit sso_provider_id over the provider tag', () => {
+    expect(
+      extractSsoProviderId({
+        app_metadata: { sso_provider_id: 'explicit', provider: 'sso:tagged' },
+      }),
+    ).toBe('explicit');
+  });
+
+  test('non-SSO providers resolve to null', () => {
+    expect(
+      extractSsoProviderId({ app_metadata: { provider: 'email', providers: ['email'] } }),
+    ).toBeNull();
+    expect(extractSsoProviderId({ app_metadata: { provider: 'google' } })).toBeNull();
+  });
+
+  test('an empty "sso:" tag resolves to null', () => {
+    expect(extractSsoProviderId({ app_metadata: { provider: 'sso:' } })).toBeNull();
+    expect(extractSsoProviderId({ app_metadata: { provider: 'sso:   ' } })).toBeNull();
+  });
+
   test('returns null when missing', () => {
     expect(extractSsoProviderId({})).toBeNull();
     expect(extractSsoProviderId(undefined)).toBeNull();

--- a/apps/api/src/iam/sso-sync.ts
+++ b/apps/api/src/iam/sso-sync.ts
@@ -33,9 +33,28 @@ interface SsoSyncOutcome {
   groupsRemoved?: string[];
 }
 
+/** Pull the auth `sso_providers` id out of a Supabase `"sso:<uuid>"` tag. */
+function ssoIdFromProviderTag(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const prefix = 'sso:';
+  if (!value.startsWith(prefix)) return null;
+  const id = value.slice(prefix.length).trim();
+  return id.length > 0 ? id : null;
+}
+
 /**
- * Extract the supabase sso_provider id from a JWT payload. Supabase puts
- * it in `app_metadata.provider_id` when the user signed in via SAML.
+ * Extract the Supabase `sso_providers` id from a JWT payload, or null when the
+ * token isn't a SAML login.
+ *
+ * Real Supabase SAML tokens carry the id INSIDE `app_metadata.provider` (and
+ * `app_metadata.providers[]`) as the string `"sso:<uuid>"`, e.g.
+ * `provider: "sso:464651b7-6157-46b1-afaa-5bbd7fa37599"`. We also accept a bare
+ * `sso_provider_id`/`provider_id` for forward-compat and simpler test fixtures.
+ *
+ * The previous implementation read ONLY the bare fields, which no real Supabase
+ * SAML token sets — so `extractSsoProviderId` always returned null and NO SSO
+ * user was ever JIT-provisioned into their org (they fell through to a personal
+ * account instead). Parsing the `"sso:<uuid>"` tag is the actual fix.
  */
 export function extractSsoProviderId(
   payload: Record<string, unknown> | undefined,
@@ -43,10 +62,21 @@ export function extractSsoProviderId(
   if (!payload) return null;
   const meta = payload.app_metadata as Record<string, unknown> | undefined;
   if (!meta) return null;
-  // Supabase historically used `provider_id`; newer versions also set
-  // `sso_provider_id`. Accept either so we're forward-compat.
-  const id = meta.sso_provider_id ?? meta.provider_id;
-  return typeof id === 'string' && id.length > 0 ? id : null;
+
+  // Explicit fields first (forward-compat / fixtures).
+  const explicit = meta.sso_provider_id ?? meta.provider_id;
+  if (typeof explicit === 'string' && explicit.length > 0) return explicit;
+
+  // Real shape: provider = "sso:<uuid>", providers = ["sso:<uuid>"].
+  const fromProvider = ssoIdFromProviderTag(meta.provider);
+  if (fromProvider) return fromProvider;
+  if (Array.isArray(meta.providers)) {
+    for (const p of meta.providers) {
+      const id = ssoIdFromProviderTag(p);
+      if (id) return id;
+    }
+  }
+  return null;
 }
 
 /**

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -232,16 +232,23 @@ export async function supabaseAuth(c: Context, next: Next) {
     if (typeof (local.payload as { iat?: number }).iat === 'number') {
       c.set('sessionIat', (local.payload as { iat: number }).iat);
     }
-    // SAML JIT — no-ops when the JWT isn't from a SAML provider. We
-    // don't block the request on sync failures since the user already
-    // authenticated; failures are logged for ops review.
-    syncSsoMembership({
-      userId: local.userId,
-      email: local.email,
-      jwtPayload: local.payload as unknown as Record<string, unknown>,
-    }).catch((err) => {
+    // SAML JIT — no-ops when the JWT isn't from a SAML provider. AWAITED so the
+    // org membership is committed BEFORE any downstream handler resolves this
+    // user's account: resolveAccountId / GET /v1/accounts bootstrap a personal
+    // owner+super account for a user with zero memberships, and a fire-and-forget
+    // sync raced (and lost) that bootstrap — stranding SSO users on a standalone
+    // personal account instead of their org. A non-SAML token returns before any
+    // DB work, so this adds no latency to normal logins. We still don't fail the
+    // request on a sync error — the user already authenticated.
+    try {
+      await syncSsoMembership({
+        userId: local.userId,
+        email: local.email,
+        jwtPayload: local.payload as unknown as Record<string, unknown>,
+      });
+    } catch (err) {
       console.warn('[auth] SAML JIT sync failed', err);
-    });
+    }
     setSentryUser({ id: local.userId, email: local.email });
     setContextField('userId', local.userId);
     setContextField('userEmail', local.email);


### PR DESCRIPTION
## Problem

A SAML SSO user (test: `manager@kortixssotest.com`) signs in successfully but is stranded on a **personal `owner` + `super`** account instead of joining the SSO provider's org. Confirmed on dev: the user does **not** appear in the org's member list even though the provider is connected with *Auto-create members: Yes*.

## Root causes (two, both required for the fix)

**1. The JIT sync never identified the provider.** `extractSsoProviderId` read `app_metadata.sso_provider_id` / `provider_id`, but a **real Supabase SAML token** carries the id in `app_metadata.provider` as `"sso:<uuid>"`. Verified against the live dev user:
```json
"app_metadata": { "provider": "sso:464651b7-6157-46b1-afaa-5bbd7fa37599", "providers": ["sso:464651b7-…"] }
```
So it always returned `null` → `syncSsoMembership` skipped → **no SSO user was ever JIT-provisioned**. This path had never been exercised end-to-end until the sign-in flow was wired up.

**2. A race stranded them on a personal account.** `syncSsoMembership` ran **fire-and-forget** in the auth middleware, racing (and losing to) `bootstrapPersonalAccount` — which `#4171` (retire basejump) made the sole first-login path, minting `accountRole:'owner'` + `is_super_admin:true`.

## Fix

- Parse the `"sso:<uuid>"` tag (and `providers[]`), keeping the bare `sso_provider_id`/`provider_id` for forward-compat + fixtures.
- **`await`** the JIT sync in the middleware so the org membership commits **before** any personal-account bootstrap. Non-SAML tokens return before any DB work → normal logins unaffected.

## Tests

- Unit: every JWT shape (`sso:<uuid>`, `providers[]`, bare fields, non-SSO `email`/`google`, empty `sso:` tag).
- Integration: fixture updated to the **real** Supabase shape as a regression lock (the full Entra `memberOf` → group → project-role → `authorizeV2` chain).

## Manual verification after deploy

1. As `manager@kortixssotest.com`, sign out + back in via SSO → should now appear as a **member** of ino's org.
2. Note: the existing `manager@` user has a stray personal account from *before* this fix — one-off cleanup (delete it); brand-new SSO users won't get one.

Then groups are testable (map an Okta group → IAM group → project role).

🤖 Generated with [Claude Code](https://claude.com/claude-code)