### PR TITLE
fix(iam): run SAML JIT sync on all Supabase-auth paths (network + combinedAuth)

### DIFF
--- a/apps/api/src/middleware/auth-sso-sync.test.ts
+++ b/apps/api/src/middleware/auth-sso-sync.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+let verifyResult: unknown;
+let networkUser: unknown;
+
+mock.module('../shared/jwt-verify', () => ({
+  verifySupabaseJwt: async () => verifyResult,
+}));
+
+mock.module('../shared/supabase', () => ({
+  getSupabase: () => ({
+    auth: { getUser: async () => ({ data: { user: networkUser }, error: networkUser ? null : { message: 'x' } }) },
+  }),
+}));
+
+const syncCalls: Array<{ userId: string; email: string; jwtPayload: unknown }> = [];
+mock.module('../iam/sso-sync', () => ({
+  syncSsoMembership: async (args: { userId: string; email: string; jwtPayload: unknown }) => {
+    syncCalls.push(args);
+    return { skipped: false, memberCreated: true };
+  },
+}));
+
+mock.module('../shared/auth-audit', () => ({ auditLoginSuccess: () => {}, auditLoginFail: () => {} }));
+mock.module('../lib/sentry', () => ({ setSentryUser: () => {} }));
+mock.module('../lib/request-context', () => ({ setContextField: () => {} }));
+
+const { supabaseAuth, combinedAuth } = await import('./auth');
+
+const SSO_PAYLOAD = { app_metadata: { provider: 'sso:prov-123', providers: ['sso:prov-123'] } };
+
+function ctx(token: string, path = '/v1/accounts') {
+  const store = new Map<string, unknown>();
+  return {
+    ctx: {
+      req: {
+        header: (h: string) => (h === 'Authorization' ? `Bearer ${token}` : undefined),
+        path,
+        method: 'GET',
+      },
+      set: (k: string, v: unknown) => store.set(k, v),
+      get: (k: string) => store.get(k),
+    } as never,
+    store,
+  };
+}
+
+const JWT = 'eyJhbGciOiJSUzI1NiJ9.body.sig';
+
+describe('auth middleware runs SAML JIT sync on every Supabase-JWT path', () => {
+  beforeEach(() => {
+    syncCalls.length = 0;
+    verifyResult = undefined;
+    networkUser = undefined;
+  });
+
+  test('supabaseAuth LOCAL path syncs', async () => {
+    verifyResult = { ok: true, userId: 'u1', email: 'u1@corp.com', payload: SSO_PAYLOAD };
+    const { ctx: c } = ctx(JWT);
+    await supabaseAuth(c, async () => {});
+    expect(syncCalls).toHaveLength(1);
+    expect(syncCalls[0].userId).toBe('u1');
+    expect((syncCalls[0].jwtPayload as typeof SSO_PAYLOAD).app_metadata.provider).toBe('sso:prov-123');
+  });
+
+  test('supabaseAuth NETWORK-fallback path syncs (the regression: kid not in cached JWKS)', async () => {
+    verifyResult = { ok: false, reason: 'no-key-for-kid' };
+    networkUser = { id: 'u2', email: 'u2@corp.com', ...SSO_PAYLOAD };
+    const { ctx: c } = ctx(JWT);
+    await supabaseAuth(c, async () => {});
+    expect(syncCalls).toHaveLength(1);
+    expect(syncCalls[0].userId).toBe('u2');
+    expect((syncCalls[0].jwtPayload as typeof SSO_PAYLOAD).app_metadata.provider).toBe('sso:prov-123');
+  });
+
+  test('combinedAuth LOCAL path syncs', async () => {
+    verifyResult = { ok: true, userId: 'u3', email: 'u3@corp.com', payload: SSO_PAYLOAD };
+    const { ctx: c } = ctx(JWT);
+    await combinedAuth(c, async () => {});
+    expect(syncCalls).toHaveLength(1);
+    expect(syncCalls[0].userId).toBe('u3');
+  });
+
+  test('combinedAuth NETWORK-fallback path syncs', async () => {
+    verifyResult = { ok: false, reason: 'no-key-for-kid' };
+    networkUser = { id: 'u4', email: 'u4@corp.com', ...SSO_PAYLOAD };
+    const { ctx: c } = ctx(JWT);
+    await combinedAuth(c, async () => {});
+    expect(syncCalls).toHaveLength(1);
+    expect(syncCalls[0].userId).toBe('u4');
+  });
+});

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -14,6 +14,30 @@ import { auditLoginFail, auditLoginSuccess } from '../shared/auth-audit';
 
 const PREVIEW_SESSION_COOKIE = '__preview_session';
 
+/**
+ * Run SAML JIT provisioning for a Supabase-authenticated request. Cheap no-op
+ * when the JWT isn't from a SAML provider (returns before any DB work).
+ *
+ * MUST be called on EVERY Supabase-JWT success path — local AND network
+ * verification, in BOTH supabaseAuth and combinedAuth. A token that fails local
+ * (JWKS) verification falls back to the network `getUser()` path, and the
+ * dashboard also hits combinedAuth routes; if the sync lives on only one of
+ * those paths, SSO users whose requests take a different path are never
+ * provisioned into their org. Never fails the request — the user already
+ * authenticated; sync errors are logged for ops review.
+ */
+async function jitSyncSso(
+  userId: string,
+  email: string,
+  jwtPayload: Record<string, unknown> | undefined,
+): Promise<void> {
+  try {
+    await syncSsoMembership({ userId, email, jwtPayload });
+  } catch (err) {
+    console.warn('[auth] SAML JIT sync failed', err);
+  }
+}
+
 // ═══════════════════════════════════════════════════════════════════════════════
 // Auth Middleware (3 middlewares — one per auth strategy)
 //
@@ -232,23 +256,14 @@ export async function supabaseAuth(c: Context, next: Next) {
     if (typeof (local.payload as { iat?: number }).iat === 'number') {
       c.set('sessionIat', (local.payload as { iat: number }).iat);
     }
-    // SAML JIT — no-ops when the JWT isn't from a SAML provider. AWAITED so the
-    // org membership is committed BEFORE any downstream handler resolves this
-    // user's account: resolveAccountId / GET /v1/accounts bootstrap a personal
-    // owner+super account for a user with zero memberships, and a fire-and-forget
-    // sync raced (and lost) that bootstrap — stranding SSO users on a standalone
-    // personal account instead of their org. A non-SAML token returns before any
-    // DB work, so this adds no latency to normal logins. We still don't fail the
-    // request on a sync error — the user already authenticated.
-    try {
-      await syncSsoMembership({
-        userId: local.userId,
-        email: local.email,
-        jwtPayload: local.payload as unknown as Record<string, unknown>,
-      });
-    } catch (err) {
-      console.warn('[auth] SAML JIT sync failed', err);
-    }
+    // SAML JIT — provision the SSO user into their org before the request
+    // proceeds (see jitSyncSso). Awaited so the org membership is committed
+    // before any handler bootstraps a personal account for a member-less user.
+    await jitSyncSso(
+      local.userId,
+      local.email,
+      local.payload as unknown as Record<string, unknown>,
+    );
     setSentryUser({ id: local.userId, email: local.email });
     setContextField('userId', local.userId);
     setContextField('userEmail', local.email);
@@ -300,6 +315,10 @@ export async function supabaseAuth(c: Context, next: Next) {
       authType: 'supabase',
       metadata: { verify_path: 'network' },
     });
+    // SAML JIT on the network-verify path too (a token whose kid isn't in the
+    // cached JWKS lands here, NOT the local path) — `user.app_metadata` is the
+    // authoritative record straight from Supabase.
+    await jitSyncSso(user.id, user.email || '', user as unknown as Record<string, unknown>);
     await next();
   } catch (err) {
     if (err instanceof HTTPException) throw err;
@@ -487,6 +506,13 @@ export async function combinedAuth(c: Context, next: Next) {
       authType: 'supabase',
       metadata: { verify_path: 'local' },
     });
+    // SAML JIT — combinedAuth guards user-facing routes too, so SSO users must
+    // provision here as well, not only in supabaseAuth.
+    await jitSyncSso(
+      local.userId,
+      local.email,
+      local.payload as unknown as Record<string, unknown>,
+    );
     await next();
     return;
   }
@@ -537,6 +563,8 @@ export async function combinedAuth(c: Context, next: Next) {
       authType: 'supabase',
       metadata: { verify_path: 'network' },
     });
+    // SAML JIT — combinedAuth network-verify path.
+    await jitSyncSso(user.id, user.email || '', user as unknown as Record<string, unknown>);
     await next();
   } catch (err) {
     if (err instanceof HTTPException) throw err;


### PR DESCRIPTION
## Why manager@ still wasn't provisioned after #4177

Confirmed on dev via direct DB inspection: `manager@kortixssotest.com` stayed on a personal owner/super account even after 3 clean re-logins on the fixed build. Root cause:

`syncSsoMembership` was only ever called in **`supabaseAuth`'s local (JWKS) verification path** — one of **four** Supabase-JWT success paths. The other three never called it:
- `supabaseAuth` **network** fallback (taken when the token's `kid` isn't in the cached JWKS)
- `combinedAuth` **local**
- `combinedAuth` **network**

So #4177's parse + await fixes were correct but **never executed** for manager, because their requests took a sync-less path. This is also why *no* SSO user had ever been provisioned.

## Fix

Extract `jitSyncSso()` and call it on **all four** paths. Network paths pass `user.app_metadata` — the authoritative record straight from Supabase's `getUser()` (I verified it's `{ "provider": "sso:464651b7…" }`), so the provider id is always resolvable there.

## Test

New `auth-sso-sync.test.ts` mocks each verification outcome and asserts `syncSsoMembership` fires on **every** path — including the network fallback that was the regression. 4/4 pass locally; tsc clean.

## After merge + deploy

`manager@` re-logs in → provisioned as **member** of the org. I'll verify live against the dev DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)