### PR TITLE
fix(api): name auto-provisioned accounts after the signup email

### DIFF
--- a/apps/api/src/shared/resolve-account.ts
+++ b/apps/api/src/shared/resolve-account.ts
@@ -5,6 +5,7 @@ import { HTTPException } from "hono/http-exception";
 import { bootstrapPersonalAccount } from "../accounts/core/bootstrap-personal-account";
 import { syncLegacyStripeSubscription } from "../billing/services/legacy-stripe-sync";
 import { db } from "./db";
+import { getSupabase } from "./supabase";
 import { ttlMemo } from "./ttl-memo";
 import { withTimeout } from "./with-timeout";
 
@@ -147,7 +148,20 @@ export async function resolveAccountId(userId: string): Promise<string> {
   // genuine new-user signup working while never minting a self-membership for an
   // account that already exists.
   try {
-    await bootstrapPersonalAccount(userId);
+    // Resolve the signup email so the account gets a real name
+    // ("<email>'s Account") instead of the bare "Account" placeholder. A
+    // token-authed caller reaches here with userId == an existing account_id,
+    // which is not an auth user — the lookup misses and the placeholder
+    // fallback inside bootstrapPersonalAccount still applies (the insert is a
+    // conflict no-op for those anyway).
+    let email: string | null = null;
+    try {
+      const { data } = await getSupabase().auth.admin.getUserById(userId);
+      email = data?.user?.email ?? null;
+    } catch {
+      /* name falls back to the placeholder */
+    }
+    await bootstrapPersonalAccount(userId, email);
   } catch (err) {
     console.warn("[resolve-account] Failed to initialize first account:", err);
   }


### PR DESCRIPTION
## Problem

`resolveAccountId`'s first-touch bootstrap called `bootstrapPersonalAccount(userId)` **without the email**, so any personal account provisioned through that path (a billing/token/resolve route touching a fresh user before `GET /v1/accounts` did) got the literal placeholder name **"Account"**. ~6,520 of ~36,300 prod accounts (18%) ended up named that way. The `GET /v1/accounts` bootstrap path already passed `userEmail` and produced proper names — which path won was a race.

## Fix

Resolve the user's email via Supabase admin in the (cold, first-touch-only) bootstrap branch and pass it through, so both paths produce `<email>'s Account`. Token-authed callers that reach this branch with `userId == an existing account_id` aren't auth users — the lookup misses and the placeholder fallback still applies (their insert is a conflict no-op anyway).

## Prod data

Existing rows were backfilled manually on prod (2026-07-06): 6,518 accounts renamed to `<email>'s Account`; 2 left as-is (one phantom account with no auth user, one user with a NULL email).