### PR TITLE
fix(iam): read SSO group claim from user_metadata.custom_claims

### DIFF
--- a/apps/api/src/__tests__/unit-iam-sso.test.ts
+++ b/apps/api/src/__tests__/unit-iam-sso.test.ts
@@ -80,6 +80,15 @@ describe('extractGroupClaims', () => {
     expect(out).toEqual(['Engineers', 'Admins']);
   });
 
+  test('reads the real Supabase SSO location: user_metadata.custom_claims.groups', () => {
+    expect(
+      extractGroupClaims(
+        { user_metadata: { custom_claims: { groups: ['Everyone', 'Managers'] } } },
+        'groups',
+      ),
+    ).toEqual(['Everyone', 'Managers']);
+  });
+
   test('reads string claim and wraps as array', () => {
     expect(
       extractGroupClaims({ app_metadata: { groups: 'Engineers' } }, 'groups'),

--- a/apps/api/src/iam/sso-sync.ts
+++ b/apps/api/src/iam/sso-sync.ts
@@ -88,11 +88,19 @@ export function extractGroupClaims(
   claimName: string,
 ): string[] {
   if (!payload) return [];
-  // Try app_metadata first (Supabase wraps SAML attributes there), then
-  // the top level for IdPs that don't.
+  const asObj = (v: unknown): Record<string, unknown> | undefined =>
+    v && typeof v === 'object' ? (v as Record<string, unknown>) : undefined;
+  const app = asObj(payload.app_metadata);
+  const user = asObj(payload.user_metadata);
+  // Supabase SSO nests the mapped SAML attributes under
+  // `user_metadata.custom_claims` (e.g. `custom_claims.groups`) — NOT at the top
+  // of user_metadata — so check custom_claims FIRST, then fall back to the flat
+  // locations other IdPs / non-SSO tokens use.
   const sources: Array<Record<string, unknown> | undefined> = [
-    payload.app_metadata as Record<string, unknown> | undefined,
-    payload.user_metadata as Record<string, unknown> | undefined,
+    asObj(user?.custom_claims),
+    asObj(app?.custom_claims),
+    app,
+    user,
     payload,
   ];
   for (const src of sources) {


### PR DESCRIPTION
Supabase SSO nests mapped SAML attributes under `user_metadata.custom_claims` (verified on the live dev token: `custom_claims.groups: ["Everyone","Managers"]`), but `extractGroupClaims` only looked at `app_metadata`/`user_metadata`/top-level — so Okta group claims were never read and no group ever synced. Now checks `custom_claims` first, with the flat locations as fallback for other IdPs. Unit test added. 🤖 Generated with [Claude Code](https://claude.com/claude-code)