### PR TITLE
fix(approvals): approvals await response & auto-continue like questions; session/config allow scopes

### DIFF
--- a/apps/api/src/__tests__/unit-executor-gateway.test.ts
+++ b/apps/api/src/__tests__/unit-executor-gateway.test.ts
@@ -390,7 +390,9 @@ describe('handleCall — policy layer', () => {
     expect(res.status).toBe('ok');
     expect(fetchCalls.length).toBeGreaterThan(0); // the call actually ran
     expect(waited).toBe(false); // no new hold — the grant was already given
-    expect(claims).toEqual([{ sessionId: 'sess-1', actionPath: 'charges.create' }]);
+    // QUALIFIED path — must match how audit() records executor_executions rows
+    // (the relative form would never find the approved row).
+    expect(claims).toEqual([{ sessionId: 'sess-1', actionPath: 'stripe.charges.create' }]);
   });
 
   test('carry-over miss → normal pending flow (asks like before)', async () => {

--- a/apps/api/src/__tests__/unit-executor-gateway.test.ts
+++ b/apps/api/src/__tests__/unit-executor-gateway.test.ts
@@ -434,6 +434,22 @@ describe('handleCall — policy layer', () => {
     expect(res.status).toBe('ok');
     expect(markedIds).toEqual(['exec-held']);
   });
+
+  test('a deny received by the held request is marked consumed too (in-band — no server resume)', async () => {
+    const { deps } = makeDeps({
+      policies: [{ match: '*', action: 'require_approval' }],
+      enforcePolicies: true,
+    });
+    deps.recordExecution = async () => 'exec-held';
+    deps.waitForApprovalDecision = async () => 'denied';
+    const markedIds: string[] = [];
+    deps.markApprovalConsumed = async (id) => {
+      markedIds.push(id);
+    };
+    const res = await handleCall(deps, baseInput);
+    expect(res).toEqual({ status: 'denied', reason: 'denied_by_user' });
+    expect(markedIds).toEqual(['exec-held']);
+  });
 });
 
 describe('handleCall — layered policies (project → connector → default)', () => {

--- a/apps/api/src/__tests__/unit-executor-gateway.test.ts
+++ b/apps/api/src/__tests__/unit-executor-gateway.test.ts
@@ -370,6 +370,70 @@ describe('handleCall — policy layer', () => {
     expect(await handleCall(deps, baseInput)).toEqual({ status: 'denied', reason: 'policy_block' });
     expect(consulted).toBe(false); // block short-circuits before any session-allow check
   });
+
+  test('approval carry-over: a recent unconsumed approve lets the fresh call RUN', async () => {
+    const { deps, fetchCalls } = makeDeps({
+      policies: [{ match: '*', action: 'require_approval' }],
+      enforcePolicies: true,
+    });
+    let waited = false;
+    deps.waitForApprovalDecision = async () => {
+      waited = true;
+      return 'timeout';
+    };
+    const claims: Array<{ sessionId: string; actionPath: string }> = [];
+    deps.consumeApprovedExecution = async (input) => {
+      claims.push({ sessionId: input.sessionId, actionPath: input.actionPath });
+      return true;
+    };
+    const res = await handleCall(deps, baseInput);
+    expect(res.status).toBe('ok');
+    expect(fetchCalls.length).toBeGreaterThan(0); // the call actually ran
+    expect(waited).toBe(false); // no new hold — the grant was already given
+    expect(claims).toEqual([{ sessionId: 'sess-1', actionPath: 'charges.create' }]);
+  });
+
+  test('carry-over miss → normal pending flow (asks like before)', async () => {
+    const { deps } = makeDeps({
+      policies: [{ match: '*', action: 'require_approval' }],
+      enforcePolicies: true,
+    });
+    deps.recordExecution = async () => 'exec-p';
+    deps.consumeApprovedExecution = async () => false;
+    expect((await handleCall(deps, baseInput)).status).toBe('pending_approval');
+  });
+
+  test('a poll retry never consults carry-over — it waits on ITS execution id', async () => {
+    const { deps } = makeDeps({
+      policies: [{ match: '*', action: 'require_approval' }],
+      enforcePolicies: true,
+    });
+    let consulted = false;
+    deps.consumeApprovedExecution = async () => {
+      consulted = true;
+      return true;
+    };
+    deps.waitForApprovalDecision = async () => 'timeout';
+    const res = await handleCall(deps, { ...baseInput, approvalExecutionId: 'exec-held' });
+    expect(res).toMatchObject({ status: 'pending_approval', executionId: 'exec-held' });
+    expect(consulted).toBe(false);
+  });
+
+  test('an approve consumed by the held request is marked so it cannot carry over later', async () => {
+    const { deps } = makeDeps({
+      policies: [{ match: '*', action: 'require_approval' }],
+      enforcePolicies: true,
+    });
+    deps.recordExecution = async () => 'exec-held';
+    deps.waitForApprovalDecision = async () => 'approved';
+    const markedIds: string[] = [];
+    deps.markApprovalConsumed = async (id) => {
+      markedIds.push(id);
+    };
+    const res = await handleCall(deps, baseInput);
+    expect(res.status).toBe('ok');
+    expect(markedIds).toEqual(['exec-held']);
+  });
 });
 
 describe('handleCall — layered policies (project → connector → default)', () => {

--- a/apps/api/src/executor/db-deps.ts
+++ b/apps/api/src/executor/db-deps.ts
@@ -6,7 +6,7 @@
  */
 import type { Context } from 'hono';
 import { HTTPException } from 'hono/http-exception';
-import { and, eq } from 'drizzle-orm';
+import { and, desc, eq, gt, inArray, isNotNull, sql } from 'drizzle-orm';
 import {
   executorConnectorActions,
   executorConnectorPolicies,
@@ -112,7 +112,9 @@ export async function waitForApprovalDecision(
 }
 
 /** "Allow for this session" check (gateway hot path): is this exact
- *  (session, connector, action) already session-approved? */
+ *  (session, connector, action) already session-approved? A `*` actionPath row
+ *  is the "allow everything for this session" grant (resolve scope
+ *  `session_all` records one per enabled connector) and matches any action. */
 export async function isSessionToolApproved(
   sessionId: string,
   connectorId: string,
@@ -125,11 +127,90 @@ export async function isSessionToolApproved(
       and(
         eq(sessionToolApprovals.sessionId, sessionId),
         eq(sessionToolApprovals.connectorId, connectorId),
-        eq(sessionToolApprovals.actionPath, actionPath),
+        inArray(sessionToolApprovals.actionPath, [actionPath, '*']),
       ),
     )
     .limit(1);
   return !!row;
+}
+
+/** How long an unconsumed human approve stays claimable by a fresh call. Long
+ *  enough for the "agent gave up → approve lands → nudge/`continue` retries"
+ *  round-trip, short enough that a stale yes can't silently authorize a much
+ *  later call. */
+const APPROVAL_CARRYOVER_WINDOW_MS = 15 * 60 * 1000;
+
+/**
+ * Claim a recent approve of (session, connector, action) that no held/poll
+ * request consumed — see GatewayDeps.consumeApprovedExecution. Atomic via the
+ * guarded UPDATE on the not-yet-consumed marker: two racing calls can't both
+ * claim the same grant. Newest grant first; one claim per approve.
+ */
+export async function consumeApprovedExecution(input: {
+  sessionId: string;
+  connectorId: string;
+  actionPath: string;
+}): Promise<boolean> {
+  const cutoff = new Date(Date.now() - APPROVAL_CARRYOVER_WINDOW_MS);
+  const candidates = await db
+    .select({
+      executionId: executorExecutions.executionId,
+      resultSummary: executorExecutions.resultSummary,
+    })
+    .from(executorExecutions)
+    .where(
+      and(
+        eq(executorExecutions.sessionId, input.sessionId),
+        eq(executorExecutions.connectorId, input.connectorId),
+        eq(executorExecutions.actionPath, input.actionPath),
+        // A human-approved gate: the resolve endpoint flips the pending row to
+        // `ok` + stamps approvedBy. Rows from actual runs never have approvedBy.
+        eq(executorExecutions.status, 'ok'),
+        isNotNull(executorExecutions.approvedBy),
+        gt(executorExecutions.resolvedAt, cutoff),
+        sql`${executorExecutions.resultSummary} ->> 'decision' = 'approve'`,
+        sql`${executorExecutions.resultSummary} ->> 'consumed_at' IS NULL`,
+      ),
+    )
+    .orderBy(desc(executorExecutions.resolvedAt))
+    .limit(3);
+  for (const candidate of candidates) {
+    const claimed = await db
+      .update(executorExecutions)
+      .set({
+        resultSummary: {
+          ...(typeof candidate.resultSummary === 'object' && candidate.resultSummary
+            ? candidate.resultSummary
+            : {}),
+          consumed_at: new Date().toISOString(),
+        },
+      })
+      .where(
+        and(
+          eq(executorExecutions.executionId, candidate.executionId),
+          sql`${executorExecutions.resultSummary} ->> 'consumed_at' IS NULL`,
+        ),
+      )
+      .returning({ id: executorExecutions.executionId });
+    if (claimed.length > 0) return true;
+  }
+  return false;
+}
+
+/** Mark an approve consumed by the held/poll request that resumed on it — see
+ *  GatewayDeps.markApprovalConsumed. */
+export async function markApprovalConsumed(executionId: string): Promise<void> {
+  await db
+    .update(executorExecutions)
+    .set({
+      resultSummary: sql`coalesce(${executorExecutions.resultSummary}, '{}'::jsonb) || jsonb_build_object('consumed_at', ${new Date().toISOString()}::text)`,
+    })
+    .where(
+      and(
+        eq(executorExecutions.executionId, executionId),
+        sql`${executorExecutions.resultSummary} ->> 'consumed_at' IS NULL`,
+      ),
+    );
 }
 
 /** Record an "allow for the rest of this session" grant (resolve endpoint).
@@ -338,6 +419,8 @@ function makeDbGatewayDeps(): GatewayDeps {
     },
     waitForApprovalDecision: waitForApprovalDecision,
     isSessionToolApproved: isSessionToolApproved,
+    consumeApprovedExecution: consumeApprovedExecution,
+    markApprovalConsumed: markApprovalConsumed,
     executePipedream: ({ projectId, connectorSlug, app, actionKey, args, accountId, userId }) =>
       runPipedreamAction(projectId, connectorSlug, app, actionKey, args, accountId, userId),
     executePipedreamProxy: ({ projectId, connectorSlug, args, accountId, userId }) =>

--- a/apps/api/src/executor/gateway.ts
+++ b/apps/api/src/executor/gateway.ts
@@ -147,6 +147,20 @@ export interface GatewayDeps {
     connectorId: string,
     actionPath: string,
   ): Promise<boolean>;
+  /** Approval carry-over: atomically claim a RECENT human approve of this
+   *  (session, connector, action) whose gated call nobody is waiting on
+   *  anymore — the holder timed out / the sandbox client has no poll loop —
+   *  so the NEXT attempt runs instead of re-asking. Returns true when a grant
+   *  was claimed (each approve is consumable exactly once). */
+  consumeApprovedExecution?(input: {
+    sessionId: string;
+    connectorId: string;
+    actionPath: string;
+  }): Promise<boolean>;
+  /** Mark an approve as consumed by the in-flight held/poll request that just
+   *  resumed on it, so the same grant can't ALSO be carried over by a later
+   *  fresh call (best-effort — a failure only risks one extra silent run). */
+  markApprovalConsumed?(executionId: string): Promise<void>;
   fetchImpl: FetchImpl;
   /** Pipedream execution (Connect actions/run) — required for pipedream connectors. */
   executePipedream?(input: {
@@ -429,9 +443,26 @@ export async function handleCall(deps: GatewayDeps, input: CallInput): Promise<C
               input.actionPath,
             )
           : false;
-      if (sessionAllowed) {
+      // Approval carry-over: the human approved this exact (session, connector,
+      // action) recently, but the gated call that asked is no longer waiting —
+      // the 45s hold expired and the client never re-polled (e.g. an older
+      // sandbox CLI without the pause loop), so the approve stamped a row nobody
+      // consumed. Claim that grant now: this fresh attempt IS the approved call,
+      // run it instead of stacking a second ask for the same thing.
+      const carriedOver =
+        !sessionAllowed &&
+        input.sessionId &&
+        !input.approvalExecutionId &&
+        deps.consumeApprovedExecution
+          ? await deps.consumeApprovedExecution({
+              sessionId: input.sessionId,
+              connectorId: connector.connectorId,
+              actionPath: input.actionPath,
+            })
+          : false;
+      if (sessionAllowed || carriedOver) {
         await audit(deps, input, connector.connectorId, 'ok', action.risk, {
-          reason: 'session_allow',
+          reason: sessionAllowed ? 'session_allow' : 'approval_carryover',
           policy_source: decision.source,
         });
       } else {
@@ -464,7 +495,11 @@ export async function handleCall(deps: GatewayDeps, input: CallInput): Promise<C
               retryable: true,
             };
           }
-          // approved → fall through to execute the call below.
+          // approved → fall through to execute the call below. Mark the grant
+          // consumed so a LATER fresh call can't also carry it over.
+          if (deps.markApprovalConsumed) {
+            await deps.markApprovalConsumed(executionId).catch(() => {});
+          }
         } else {
           return {
             status: 'pending_approval',

--- a/apps/api/src/executor/gateway.ts
+++ b/apps/api/src/executor/gateway.ts
@@ -485,6 +485,12 @@ export async function handleCall(deps: GatewayDeps, input: CallInput): Promise<C
         if (executionId && input.sessionId && deps.waitForApprovalDecision) {
           const outcome = await deps.waitForApprovalDecision(executionId, APPROVAL_WAIT_MS);
           if (outcome === 'denied') {
+            // Mark the decision as consumed by this live waiter — the resolve
+            // endpoint's server-side resume uses that marker to know the turn
+            // already got the answer in-band (no follow-up prompt needed).
+            if (deps.markApprovalConsumed) {
+              await deps.markApprovalConsumed(executionId).catch(() => {});
+            }
             return { status: 'denied', reason: 'denied_by_user' };
           }
           if (outcome === 'timeout') {

--- a/apps/api/src/executor/gateway.ts
+++ b/apps/api/src/executor/gateway.ts
@@ -435,6 +435,12 @@ export async function handleCall(deps: GatewayDeps, input: CallInput): Promise<C
       // for THIS connector + action, skip the gate — run it silently, no hold,
       // no re-prompt. Audited as `ok` (reason session_allow) so the timeline
       // still shows the call happened + why it wasn't asked.
+      // PATH FORM MATTERS: session grants store the CONNECTOR-RELATIVE path
+      // (`create_folder`) — the same form `input.actionPath` carries for any
+      // call that got past loadAction. The audit trail (executor_executions)
+      // stores the QUALIFIED form (`google_drive.create_folder`), so the
+      // carry-over lookup below must use that. Mixing the two silently breaks
+      // matching — it's exactly the bug that made "Allow for session" a no-op.
       const sessionAllowed =
         input.sessionId && deps.isSessionToolApproved
           ? await deps.isSessionToolApproved(
@@ -457,7 +463,8 @@ export async function handleCall(deps: GatewayDeps, input: CallInput): Promise<C
           ? await deps.consumeApprovedExecution({
               sessionId: input.sessionId,
               connectorId: connector.connectorId,
-              actionPath: input.actionPath,
+              // The audit-row form (see audit() below), NOT the relative form.
+              actionPath: `${input.connectorSlug}.${input.actionPath}`,
             })
           : false;
       if (sessionAllowed || carriedOver) {

--- a/apps/api/src/executor/sync.ts
+++ b/apps/api/src/executor/sync.ts
@@ -7,7 +7,7 @@
  * a connector that can't be reached is stored with status='error' + 0 actions,
  * never failing the whole sweep. See docs/specs/executor.md §3, §7.
  */
-import { eq } from 'drizzle-orm';
+import { eq, sql } from 'drizzle-orm';
 import { parse as parseToml } from 'smol-toml';
 import {
   executorConnectorActions,
@@ -264,9 +264,21 @@ async function upsertConnector(
 
   let connectorId = existingId;
   if (connectorId) {
+    // `sensitive` lives inside `config` but is a CHEAP field: it isn't part of
+    // manifestHashForConnector (deliberately — flipping it must not force a
+    // catalog re-fetch), so on a hash-match reconcile we still patch that one
+    // key in place. Without this, the Sensitive toggle commits to kortix.toml
+    // but the DB config (what the gateway + admin UI read) never updates.
+    const sensitivePatch = spec.sensitive
+      ? sql`coalesce(${executorConnectors.config}, '{}'::jsonb) || '{"sensitive": true}'::jsonb`
+      : sql`coalesce(${executorConnectors.config}, '{}'::jsonb) - 'sensitive'`;
     await db
       .update(executorConnectors)
-      .set(catalog ? { ...common, config: connectorConfig(spec, catalog.server) } : common)
+      .set(
+        catalog
+          ? { ...common, config: connectorConfig(spec, catalog.server) }
+          : { ...common, config: sensitivePatch },
+      )
       .where(eq(executorConnectors.connectorId, connectorId));
   } else {
     // A brand-new connector is never "unchanged", so catalog is always present

--- a/apps/api/src/projects/routes/r7.ts
+++ b/apps/api/src/projects/routes/r7.ts
@@ -23,7 +23,7 @@ import { UUID_V4_REGEX, hasOwn, normalizeString, readBody, requestAuditContext, 
 import { sendSessionCreateError } from '../lib/sessions';
 import { buildSessionTranscriptDigest } from '../lib/session-transcript';
 import { syncOpenCodeTitlesForSessions } from '../opencode-title-sync';
-import { createSession, deleteSession } from '../session-lifecycle';
+import { continueSession, createSession, deleteSession } from '../session-lifecycle';
 import { requireEntitlement } from '../../accounts/iam/helpers';
 import { accountHasEntitlement } from '../../billing/services/entitlements';
 
@@ -1080,6 +1080,56 @@ projectsApp.openapi(
           error: err instanceof Error ? err.message : String(err),
         });
       }
+    }
+
+    // Server-side resume — the reliability backstop. A LIVE gated call (the
+    // sandbox CLI/MCP pause loop, or an approve within the gateway's 45s hold)
+    // picks this decision out of the DB within ~1s, marks it consumed, and the
+    // agent's turn resumes in-band — no message needed. When nobody was
+    // waiting (an older sandbox image without the pause loop, or a decision
+    // after the ~30min poll budget), the resolve would otherwise change
+    // nothing the agent can see: its turn already ended on `pending_approval`.
+    // So after a grace window we check the consumed marker and, if the
+    // decision is still unclaimed, deliver the continuation prompt into the
+    // session ourselves (approval carry-over then lets the retried call run
+    // without re-asking). Detached on purpose: this response must not wait on
+    // a sandbox wake — continueSession can take minutes on a stopped runtime.
+    if (row.sessionId) {
+      const resumeSessionId = row.sessionId;
+      const resumeUserId = loaded.userId;
+      const resumeText =
+        decision === 'approve'
+          ? `Your pending approval to run ${row.actionPath} was approved — continue.`
+          : `Your request to run ${row.actionPath} was denied — continue without it.`;
+      void (async () => {
+        // > the waiter's 1s decision poll + hold re-issue latency, with margin.
+        await new Promise((r) => setTimeout(r, 6_000));
+        const [fresh] = await db
+          .select({ resultSummary: executorExecutions.resultSummary })
+          .from(executorExecutions)
+          .where(eq(executorExecutions.executionId, executionId))
+          .limit(1);
+        const summary = (fresh?.resultSummary ?? {}) as Record<string, unknown>;
+        if (summary.consumed_at) return; // a live waiter resumed the turn in-band
+        const outcome = await continueSession({
+          source: 'system:approval-resume',
+          sessionId: resumeSessionId,
+          text: resumeText,
+          userId: resumeUserId,
+        });
+        if (outcome !== 'delivered') {
+          console.warn('[approvals] resume delivery not confirmed', {
+            executionId,
+            sessionId: resumeSessionId,
+            outcome,
+          });
+        }
+      })().catch((err) => {
+        console.warn('[approvals] resume delivery failed', {
+          executionId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
     }
 
     return c.json({ ok: true, scope });

--- a/apps/api/src/projects/routes/r7.ts
+++ b/apps/api/src/projects/routes/r7.ts
@@ -15,7 +15,7 @@ import { auth, errors, json } from '../../openapi';
 import { db } from '../../shared/db';
 import { roleAllows } from '../access';
 import { createRoute, z } from '@hono/zod-openapi';
-import { accountGroupMembers, accountGroups, accountMembers, executorExecutions, projectGroupGrants, projectSessions, sessionSandboxes } from '@kortix/db';
+import { accountGroupMembers, accountGroups, accountMembers, executorConnectors, executorExecutions, projectGroupGrants, projectSessions, sessionSandboxes } from '@kortix/db';
 import { and, asc, desc, eq, inArray, isNull } from 'drizzle-orm';
 import { loadProjectForUser, loadVisibleSession, lookupEmailsByUserIds, parseExpiresAtBody, assertProjectCapability, isUuid } from '../lib/access';
 import { AnyObject, GroupGrantSchema, OkSchema, SessionCreateAcceptedSchema, SessionSchema, projectsApp } from '../lib/app';
@@ -695,6 +695,18 @@ projectsApp.openapi(
     ];
     const emailByUser = userIds.length ? await lookupEmailsByUserIds(userIds) : new Map<string, string>();
 
+    // Connector slugs in one batched lookup — the UI needs `<slug>.<action>`
+    // to offer a "always run this" project-policy shortcut on a pending row.
+    const connectorIds = [...new Set(rows.map((r) => r.connectorId).filter((v): v is string => !!v))];
+    const slugByConnector = new Map<string, string>();
+    if (connectorIds.length) {
+      const conns = await db
+        .select({ connectorId: executorConnectors.connectorId, slug: executorConnectors.slug })
+        .from(executorConnectors)
+        .where(inArray(executorConnectors.connectorId, connectorIds));
+      for (const conn of conns) slugByConnector.set(conn.connectorId, conn.slug);
+    }
+
     return c.json({
       session_id: sessionId,
       agent: (visible.row.agentName as string | null) ?? null,
@@ -708,6 +720,7 @@ projectsApp.openapi(
         execution_id: r.executionId,
         action: r.actionPath,
         connector_id: r.connectorId,
+        connector: r.connectorId ? (slugByConnector.get(r.connectorId) ?? null) : null,
         status: r.status, // ok | error | denied | pending_approval
         risk: r.risk, // read | write | destructive | null
         acted_by: r.actingUserId,
@@ -921,10 +934,14 @@ projectsApp.openapi(
       return c.json({ error: "decision must be 'approve' or 'deny'" }, 400);
     }
     // 'once' (default) = approve just this call; 'session' = also stop asking for
-    // THIS connector+action for the rest of the session. Only meaningful on
-    // approve. (A policy `block` never reaches this endpoint as pending, so
-    // "allow for session" can only ever widen require_approval → run.)
-    const scope = normalizeString(body.scope) === 'session' ? 'session' : 'once';
+    // THIS connector+action for the rest of the session; 'session_all' = stop
+    // asking for ANY gated action for the rest of the session (a `*` wildcard
+    // grant per enabled connector). Only meaningful on approve. (A policy
+    // `block` never reaches this endpoint as pending, so a session grant can
+    // only ever widen require_approval → run.)
+    const scopeRaw = normalizeString(body.scope);
+    const scope =
+      scopeRaw === 'session' ? 'session' : scopeRaw === 'session_all' ? 'session_all' : 'once';
 
     const loaded = await loadProjectForUser(c, projectId, 'read');
     if (!loaded) return c.json({ error: 'Not found' }, 404);
@@ -1029,6 +1046,36 @@ projectsApp.openapi(
         });
       } catch (err) {
         console.warn('[approvals] failed to record session allow', {
+          executionId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+
+    // "Allow everything for this session": one `*` wildcard grant per enabled
+    // connector (the gateway's session check matches `*` against any action).
+    // Enumerated per connector — instead of a schema-level "all connectors"
+    // marker — so a connector added AFTER this grant still asks. Best-effort +
+    // idempotent, same as the single-action grant above.
+    if (decision === 'approve' && scope === 'session_all' && row.sessionId) {
+      try {
+        const conns = await db
+          .select({ connectorId: executorConnectors.connectorId })
+          .from(executorConnectors)
+          .where(
+            and(eq(executorConnectors.projectId, projectId), eq(executorConnectors.enabled, true)),
+          );
+        for (const conn of conns) {
+          await recordSessionToolApproval({
+            sessionId: row.sessionId,
+            projectId,
+            connectorId: conn.connectorId,
+            actionPath: '*',
+            grantedBy: loaded.userId,
+          });
+        }
+      } catch (err) {
+        console.warn('[approvals] failed to record session allow-all', {
           executionId,
           error: err instanceof Error ? err.message : String(err),
         });

--- a/apps/api/src/projects/routes/r7.ts
+++ b/apps/api/src/projects/routes/r7.ts
@@ -23,7 +23,12 @@ import { UUID_V4_REGEX, hasOwn, normalizeString, readBody, requestAuditContext, 
 import { sendSessionCreateError } from '../lib/sessions';
 import { buildSessionTranscriptDigest } from '../lib/session-transcript';
 import { syncOpenCodeTitlesForSessions } from '../opencode-title-sync';
-import { continueSession, createSession, deleteSession } from '../session-lifecycle';
+import {
+  createSession,
+  deleteSession,
+  drainSessionLifecycleQueue,
+  enqueueContinueSessionCommand,
+} from '../session-lifecycle';
 import { requireEntitlement } from '../../accounts/iam/helpers';
 import { accountHasEntitlement } from '../../billing/services/entitlements';
 
@@ -1035,13 +1040,27 @@ projectsApp.openapi(
     // "Allow for this session": record (session, connector, action) so the
     // gateway auto-runs the same tool for the rest of the session. Best-effort +
     // idempotent — a failure here doesn't undo the (already-committed) approval.
+    // The execution row's actionPath is the QUALIFIED audit form
+    // (`google_drive.create_folder`); the gateway's session-allow check matches
+    // the CONNECTOR-RELATIVE form (`create_folder`) — strip the slug prefix or
+    // the grant never matches and "Allow for session" keeps re-asking (the bug
+    // this comment is a headstone for).
     if (decision === 'approve' && scope === 'session' && row.sessionId && row.connectorId) {
       try {
+        const [conn] = await db
+          .select({ slug: executorConnectors.slug })
+          .from(executorConnectors)
+          .where(eq(executorConnectors.connectorId, row.connectorId))
+          .limit(1);
+        const relativeActionPath =
+          conn && row.actionPath.startsWith(`${conn.slug}.`)
+            ? row.actionPath.slice(conn.slug.length + 1)
+            : row.actionPath;
         await recordSessionToolApproval({
           sessionId: row.sessionId,
           projectId,
           connectorId: row.connectorId,
-          actionPath: row.actionPath,
+          actionPath: relativeActionPath,
           grantedBy: loaded.userId,
         });
       } catch (err) {
@@ -1089,47 +1108,42 @@ projectsApp.openapi(
     // waiting (an older sandbox image without the pause loop, or a decision
     // after the ~30min poll budget), the resolve would otherwise change
     // nothing the agent can see: its turn already ended on `pending_approval`.
-    // So after a grace window we check the consumed marker and, if the
-    // decision is still unclaimed, deliver the continuation prompt into the
-    // session ourselves (approval carry-over then lets the retried call run
-    // without re-asking). Detached on purpose: this response must not wait on
-    // a sandbox wake — continueSession can take minutes on a stopped runtime.
+    // So we enqueue a DURABLE continue_session command with a grace-window
+    // schedule: the drain re-checks the consumed marker at execution time and
+    // either no-ops (a live waiter got there first) or delivers the
+    // continuation prompt into the session (approval carry-over then lets the
+    // retried call run without re-asking). Queue-backed so it survives this
+    // pod dying; idempotency-keyed so a double-resolve can't double-prompt.
     if (row.sessionId) {
-      const resumeSessionId = row.sessionId;
-      const resumeUserId = loaded.userId;
       const resumeText =
         decision === 'approve'
           ? `Your pending approval to run ${row.actionPath} was approved — continue.`
           : `Your request to run ${row.actionPath} was denied — continue without it.`;
-      void (async () => {
-        // > the waiter's 1s decision poll + hold re-issue latency, with margin.
-        await new Promise((r) => setTimeout(r, 6_000));
-        const [fresh] = await db
-          .select({ resultSummary: executorExecutions.resultSummary })
-          .from(executorExecutions)
-          .where(eq(executorExecutions.executionId, executionId))
-          .limit(1);
-        const summary = (fresh?.resultSummary ?? {}) as Record<string, unknown>;
-        if (summary.consumed_at) return; // a live waiter resumed the turn in-band
-        const outcome = await continueSession({
+      try {
+        await enqueueContinueSessionCommand({
           source: 'system:approval-resume',
-          sessionId: resumeSessionId,
+          projectId,
+          accountId: loaded.row.accountId,
+          sessionId: row.sessionId,
+          actorUserId: loaded.userId,
           text: resumeText,
-          userId: resumeUserId,
+          executionId,
+          // > the waiter's 1s decision poll + hold re-issue latency, with margin.
+          availableAt: new Date(Date.now() + 6_000),
+          idempotencyKey: `approval-resume:${executionId}`,
         });
-        if (outcome !== 'delivered') {
-          console.warn('[approvals] resume delivery not confirmed', {
-            executionId,
-            sessionId: resumeSessionId,
-            outcome,
-          });
-        }
-      })().catch((err) => {
-        console.warn('[approvals] resume delivery failed', {
+        // Best-effort fast path: the scheduler drains every ~60s; kick one
+        // drain shortly after the grace window so the resume usually lands in
+        // seconds. If this pod dies first, the scheduler still delivers.
+        setTimeout(() => {
+          drainSessionLifecycleQueue({ limit: 5 }).catch(() => {});
+        }, 7_000).unref?.();
+      } catch (err) {
+        console.warn('[approvals] failed to enqueue resume', {
           executionId,
           error: err instanceof Error ? err.message : String(err),
         });
-      });
+      }
     }
 
     return c.json({ ok: true, scope });

--- a/apps/api/src/projects/session-lifecycle/engine.ts
+++ b/apps/api/src/projects/session-lifecycle/engine.ts
@@ -1,5 +1,5 @@
 import { eq } from 'drizzle-orm';
-import { chatThreads, projects, projectSessions } from '@kortix/db';
+import { chatThreads, executorExecutions, projects, projectSessions } from '@kortix/db';
 import { config } from '../../config';
 import { forwardToSandbox } from '../../sandbox-proxy/routes/preview';
 import { db } from '../../shared/db';
@@ -18,11 +18,13 @@ import {
   resultFromExistingCommand,
   type SessionLifecycleCommandRow,
 } from './store';
+import type { QueuedContinueSessionPayload } from './store';
 import type {
   ContinueSessionCommand,
   CreateSessionCommand,
   QueuedCreateSessionPayload,
   SessionDeliveryOutcome,
+  SessionInvocationSource,
   SessionLifecyclePostCreateAction,
   SessionLifecycleResult,
   StartSessionCommand,
@@ -297,6 +299,11 @@ export async function drainSessionLifecycleQueue(input: {
   const rows = await claimDueLifecycleCommands({ workerId, limit: input.limit ?? 10 });
   const out = { claimed: rows.length, succeeded: 0, failed: 0, queued: 0 };
   for (const row of rows) {
+    if (row.commandType === 'continue_session') {
+      const outcome = await executeQueuedContinue(row);
+      out[outcome] += 1;
+      continue;
+    }
     if (row.commandType !== 'create_session') {
       await markCommandFailed(row.commandId, `Unsupported command type: ${row.commandType}`, {
         retryable: false,
@@ -343,6 +350,73 @@ export async function drainSessionLifecycleQueue(input: {
     }
   }
   return out;
+}
+
+/**
+ * Drain one queued `continue_session` command — the durable face of "deliver
+ * this follow-up into the session" (today: the approval-resume backstop). The
+ * consumed-marker check runs at DRAIN time, not enqueue time, so a live held
+ * request that picked the decision up during the grace window cleanly turns
+ * this into a no-op instead of a duplicate prompt.
+ */
+async function executeQueuedContinue(
+  row: SessionLifecycleCommandRow,
+): Promise<'succeeded' | 'queued' | 'failed'> {
+  const payload = row.payload as unknown as QueuedContinueSessionPayload;
+  const text = typeof payload.text === 'string' ? payload.text : '';
+  if (!row.sessionId || !text) {
+    await markCommandFailed(row.commandId, 'continue_session command missing sessionId or text', {
+      retryable: false,
+      attempts: row.attempts,
+    });
+    return 'failed';
+  }
+
+  if (payload.executionId) {
+    const [exec] = await db
+      .select({ resultSummary: executorExecutions.resultSummary })
+      .from(executorExecutions)
+      .where(eq(executorExecutions.executionId, payload.executionId))
+      .limit(1);
+    const summary = (exec?.resultSummary ?? {}) as Record<string, unknown>;
+    if (summary.consumed_at) {
+      await markCommandSucceeded(
+        row.commandId,
+        { status: 'skipped', reason: 'consumed_in_band' },
+        row.sessionId,
+      );
+      return 'succeeded';
+    }
+  }
+
+  try {
+    const delivery = await continueSession({
+      source: row.source as SessionInvocationSource,
+      sessionId: row.sessionId,
+      text,
+      userId: row.actorUserId,
+    });
+    if (delivery === 'delivered') {
+      await markCommandSucceeded(row.commandId, { status: 'delivered' }, row.sessionId);
+      return 'succeeded';
+    }
+    // 'pending' = runtime not ready in time — worth another pass. 'no-session'
+    // and 'failed' are terminal for this command.
+    const retryable = delivery === 'pending';
+    await markCommandFailed(row.commandId, `delivery outcome: ${delivery}`, {
+      retryable,
+      attempts: row.attempts,
+      sessionId: row.sessionId,
+    });
+    return retryable ? 'queued' : 'failed';
+  } catch (e) {
+    await markCommandFailed(row.commandId, (e as Error).message || 'continue_session threw', {
+      retryable: true,
+      attempts: row.attempts,
+      sessionId: row.sessionId,
+    });
+    return 'queued';
+  }
 }
 
 async function executeQueuedCreate(row: SessionLifecycleCommandRow): Promise<SessionLifecycleResult> {

--- a/apps/api/src/projects/session-lifecycle/index.ts
+++ b/apps/api/src/projects/session-lifecycle/index.ts
@@ -4,6 +4,7 @@ export {
   continueSession,
   drainSessionLifecycleQueue,
 } from './engine';
+export { enqueueContinueSessionCommand } from './store';
 export { deleteSession, restartSession } from './actions';
 export { stopSession } from './stop';
 export { resolveProjectAutomationActor, resolveAgentRunAttribution } from './actor';

--- a/apps/api/src/projects/session-lifecycle/store.ts
+++ b/apps/api/src/projects/session-lifecycle/store.ts
@@ -4,6 +4,7 @@ import { db } from '../../shared/db';
 import type {
   CreateSessionCommand,
   QueuedCreateSessionPayload,
+  SessionInvocationSource,
   SessionLifecycleResult,
 } from './types';
 
@@ -18,6 +19,61 @@ export function createSessionCommandPayload(command: CreateSessionCommand): Queu
     enforceAccountCap: command.enforceAccountCap,
     postCreate: command.postCreate,
   };
+}
+
+export interface QueuedContinueSessionPayload {
+  text: string;
+  /** When set, the drain SKIPS delivery if this execution's decision was
+   *  already consumed in-band (a live held/poll request resumed the turn) —
+   *  the follow-up prompt would just be noise. */
+  executionId?: string | null;
+}
+
+/**
+ * Enqueue a durable "deliver this follow-up into the session" command —
+ * drained by the leader's scheduler tick, retried with backoff, dead-lettered
+ * after 5 attempts. Survives the enqueueing pod dying, unlike a detached
+ * promise. `availableAt` in the future = a scheduled grace window.
+ */
+export async function enqueueContinueSessionCommand(input: {
+  source: SessionInvocationSource;
+  projectId: string;
+  accountId: string;
+  sessionId: string;
+  actorUserId: string | null;
+  text: string;
+  executionId?: string | null;
+  availableAt?: Date;
+  /** Dedupe key — a repeat enqueue (double-resolve race) is a no-op. */
+  idempotencyKey?: string | null;
+}): Promise<void> {
+  const now = new Date();
+  const payload: QueuedContinueSessionPayload = {
+    text: input.text,
+    executionId: input.executionId ?? null,
+  };
+  const values = {
+    commandType: 'continue_session',
+    source: input.source,
+    status: 'queued' as const,
+    projectId: input.projectId,
+    accountId: input.accountId,
+    actorUserId: input.actorUserId,
+    sessionId: input.sessionId,
+    idempotencyKey: input.idempotencyKey ?? null,
+    payload: payload as unknown as Record<string, unknown>,
+    result: {},
+    availableAt: input.availableAt ?? now,
+    updatedAt: now,
+  };
+  if (!input.idempotencyKey) {
+    await db.insert(sessionLifecycleCommands).values(values);
+    return;
+  }
+  await db
+    .insert(sessionLifecycleCommands)
+    .values(values)
+    .onConflictDoNothing({ target: sessionLifecycleCommands.idempotencyKey });
 }
 
 export async function claimCreateSessionCommand(

--- a/apps/api/src/projects/session-lifecycle/types.ts
+++ b/apps/api/src/projects/session-lifecycle/types.ts
@@ -14,6 +14,7 @@ export type SessionInvocationSource =
   | 'trigger:cron'
   | 'trigger:manual'
   | 'system:sandbox-build-fix'
+  | 'system:approval-resume'
   | 'admin';
 
 export type QueuePolicy = 'never' | 'on_backpressure' | 'always';

--- a/apps/cli/src/commands/executor.ts
+++ b/apps/cli/src/commands/executor.ts
@@ -19,6 +19,7 @@
 import { ExecutorError } from '@kortix/executor-sdk';
 import {
   addConnector,
+  callPausingForApproval,
   executorClient,
   mintConnectLink,
   removeConnector,
@@ -92,7 +93,10 @@ async function dispatch(command: string, args: string[], flags: Record<string, s
       if (raw) {
         try { parsed = JSON.parse(raw); } catch { throw new CliError('args must be valid JSON', 'BAD_ARGS'); }
       }
-      const result = await executor.call(slug, action, parsed);
+      // PAUSES for human approval instead of returning `pending_approval`
+      // immediately — this is the agent's primary path, and the turn must
+      // resume the moment the human approves (never "type continue").
+      const result = await callPausingForApproval(executor, slug, action, parsed);
       out(result);
       break;
     }

--- a/apps/cli/src/executor/gateway.ts
+++ b/apps/cli/src/executor/gateway.ts
@@ -15,7 +15,11 @@
  *      through the same sandbox env-token host the rest of the CLI uses
  *      (KORTIX_CLI_TOKEN / KORTIX_EXECUTOR_TOKEN + KORTIX_PROJECT_ID).
  */
-import { createExecutorClient, type ExecutorClient } from '@kortix/executor-sdk';
+import {
+  createExecutorClient,
+  type ExecutorCallResult,
+  type ExecutorClient,
+} from '@kortix/executor-sdk';
 import { loadAuth } from '../api/auth.ts';
 import { clientFromAuth, type ApiClient } from '../api/client.ts';
 import { resolveProjectId } from '../project-link.ts';
@@ -68,6 +72,36 @@ export function executorProjectContext(projectOverride?: string): { client: ApiC
   const projectId = resolveProjectId(projectOverride);
   if (!projectId) throw new CliError('KORTIX_PROJECT_ID not set.', 'MISSING_ENV');
   return { client: clientFromAuth(auth), projectId };
+}
+
+/** Bound so a forgotten approval can't wedge the agent forever:
+ *  ~40 × ~45s gateway holds ≈ 30 min of pause. */
+const APPROVAL_POLL_MAX = 40;
+
+/**
+ * Run a tool call, PAUSING for human approval — shared by BOTH faces
+ * (`kortix executor call` and the MCP server) so the agent's turn behaves the
+ * same everywhere. A `require_approval` call blocks: the gateway holds each
+ * request briefly, then — while still pending — returns `retryable` + the
+ * execution id; we re-issue the call with that id so the wait is effectively
+ * INDEFINITE (like a question) without any single long-held request. On
+ * approve, the SAME held request falls through and runs the action, so the
+ * turn resumes in place — the human never has to type "continue".
+ */
+export async function callPausingForApproval<T = unknown>(
+  executor: ExecutorClient,
+  connector: string,
+  action: string,
+  args: Record<string, unknown>,
+): Promise<ExecutorCallResult<T>> {
+  let result = await executor.call<T>(connector, action, args);
+  for (let i = 0; i < APPROVAL_POLL_MAX; i++) {
+    if (!(result.status === 'pending_approval' && result.retryable && result.execution_id)) break;
+    result = await executor.call<T>(connector, action, args, {
+      approvalExecutionId: result.execution_id,
+    });
+  }
+  return result;
 }
 
 export interface ConnectLinkResult {

--- a/apps/cli/src/executor/mcp.ts
+++ b/apps/cli/src/executor/mcp.ts
@@ -22,6 +22,7 @@
 import type { ExecutorClient } from '@kortix/executor-sdk';
 import {
   addConnector,
+  callPausingForApproval,
   executorClient,
   mintConnectLink,
   mintSecretLink,
@@ -298,21 +299,9 @@ async function runMetaTool(executor: ExecutorClient, name: string, args: Record<
         };
       }
       const callArgs = asRecord(args.args);
-      // Poll loop for human approval: a `require_approval` call PAUSES the run
-      // until a human decides. The gateway holds each request briefly, then —
-      // while still pending — returns `retryable` + the execution id; we re-issue
-      // the call with that id so the wait is effectively INDEFINITE (like a
-      // question), without any single long-held request. Bounded so a forgotten
-      // approval can't wedge the agent forever.
-      const APPROVAL_POLL_MAX = 40; // ~40 × ~45s ≈ 30 min
-      let result = await executor.call(connector, action, callArgs);
-      for (let i = 0; i < APPROVAL_POLL_MAX; i++) {
-        if (!(result.status === 'pending_approval' && result.retryable && result.execution_id))
-          break;
-        result = await executor.call(connector, action, callArgs, {
-          approvalExecutionId: result.execution_id,
-        });
-      }
+      // Pauses the run for human approval (indefinite poll, like a question) —
+      // shared with `kortix executor call`, see callPausingForApproval.
+      const result = await callPausingForApproval(executor, connector, action, callArgs);
       return { content: content(result), isError: !result.ok };
     }
 

--- a/apps/web/src/features/session/session-approval-prompt.tsx
+++ b/apps/web/src/features/session/session-approval-prompt.tsx
@@ -3,9 +3,17 @@
 /**
  * Inline "agent needs your approval" prompt, pinned above the composer — the
  * in-session face of a connector action a policy gated as `require_approval`.
- * Mirrors opencode's native tool-permission prompt (tool-renderers
- * PermissionPromptInline) so it feels native: approve lets the paused run
- * proceed, deny refuses it and the agent continues.
+ * Mirrors opencode's native tool-permission prompt (SessionPermissionPrompt)
+ * so it feels native: approve lets the paused run proceed, deny refuses it and
+ * the agent continues.
+ *
+ * Decision scopes, visually separated by how long they last:
+ *  - per request: Deny / Allow once / Allow for session (this exact action,
+ *    rest of this session)
+ *  - per session: "Allow everything" — a `*` wildcard session grant, so no
+ *    gated action asks again this session
+ *  - persistent (footer, gated on `project.connector.write`): prepend an
+ *    `always_run` project policy for this tool — future sessions stop asking.
  *
  * Self-contained: reads projectId + the (Kortix) session id from the route and
  * shares the session-audit query with the header nudge + Audit panel, so all
@@ -23,10 +31,22 @@ import {
   useResolveApproval,
   useSessionAudit,
 } from '@/features/session/session-audit-shared';
+import { PROJECT_ACTIONS } from '@/lib/project-actions';
+import { useProjectCan } from '@/lib/use-project-can';
 import { cn } from '@/lib/utils';
+import {
+  type SessionAuditAction,
+  listProjectPolicies,
+  setProjectPolicies,
+} from '@kortix/sdk/projects-client';
 import { ShieldAlert } from 'lucide-react';
 import { useParams } from 'next/navigation';
 import { useState } from 'react';
+
+/** `${slug}.${path}` — the fully-qualified tool path project policies match. */
+function qualifiedAction(a: SessionAuditAction): string | null {
+  return a.connector ? `${a.connector}.${a.action}` : null;
+}
 
 export function SessionApprovalPrompt() {
   const { id: projectId, sessionId: projectSessionId } = useParams<{
@@ -37,8 +57,10 @@ export function SessionApprovalPrompt() {
   // user is actively waiting on.
   const { data } = useSessionAudit(projectId, projectSessionId, { refetchInterval: 5_000 });
   const resolve = useResolveApproval(projectId, projectSessionId);
-  // Which button on which row is loading: 'deny' | 'once' | 'session'.
-  const [busy, setBusy] = useState<Record<string, 'deny' | 'once' | 'session'>>({});
+  const canWritePolicies = useProjectCan(projectId, PROJECT_ACTIONS.PROJECT_CONNECTOR_WRITE);
+  // Which button is loading: `${executionId}:deny|once|session`, 'session-all',
+  // or `policy:${qualifiedAction}`.
+  const [busy, setBusy] = useState<string | null>(null);
 
   const pending = (data?.actions ?? []).filter(isPendingAction);
   if (pending.length === 0) return null;
@@ -48,8 +70,7 @@ export function SessionApprovalPrompt() {
     decision: 'approve' | 'deny',
     scope: 'once' | 'session' = 'once',
   ) => {
-    const key = decision === 'deny' ? 'deny' : scope;
-    setBusy((b) => ({ ...b, [executionId]: key }));
+    setBusy(`${executionId}:${decision === 'deny' ? 'deny' : scope}`);
     resolve.mutate(
       { executionId, decision, scope },
       {
@@ -63,15 +84,68 @@ export function SessionApprovalPrompt() {
           ),
         onError: (e: unknown) =>
           errorToast(e instanceof Error ? e.message : 'Failed to resolve approval'),
-        onSettled: () =>
-          setBusy((b) => {
-            const next = { ...b };
-            delete next[executionId];
-            return next;
-          }),
+        onSettled: () => setBusy(null),
       },
     );
   };
+
+  // "Allow everything for this session": resolve the first pending row with the
+  // wildcard scope (the server records a `*` grant per connector), then release
+  // any other rows already pending — the wildcard only stops FUTURE asks.
+  const allowAllForSession = async () => {
+    setBusy('session-all');
+    try {
+      const [first, ...rest] = pending;
+      await resolve.mutateAsync({
+        executionId: first.execution_id,
+        decision: 'approve',
+        scope: 'session_all',
+      });
+      await Promise.all(
+        rest.map((a) =>
+          resolve.mutateAsync({ executionId: a.execution_id, decision: 'approve', scope: 'once' }),
+        ),
+      );
+      successToast("Allowed — won't ask again for anything this session");
+    } catch (e) {
+      errorToast(e instanceof Error ? e.message : 'Failed to resolve approvals');
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  // Persist "always run this tool" into the project's policies (kortix.toml
+  // [[policies]] — the same list the Policies panel edits), then release the
+  // pending rows it covers. PREPENDED: policy resolution is first-match-wins,
+  // so the new allow must outrank an existing require_approval pattern.
+  const alwaysRunInPolicy = async (qualified: string) => {
+    if (!projectId) return;
+    setBusy(`policy:${qualified}`);
+    try {
+      const current = await listProjectPolicies(projectId);
+      const withoutDup = (current.policies ?? []).filter((p) => p.match !== qualified);
+      await setProjectPolicies(
+        projectId,
+        [{ match: qualified, action: 'always_run' }, ...withoutDup],
+        current.defaultMode ?? 'risk',
+      );
+      const covered = pending.filter((a) => qualifiedAction(a) === qualified);
+      await Promise.all(
+        covered.map((a) =>
+          resolve.mutateAsync({ executionId: a.execution_id, decision: 'approve', scope: 'once' }),
+        ),
+      );
+      successToast(`Saved — "${qualified}" always runs in this project now`);
+    } catch (e) {
+      errorToast(e instanceof Error ? e.message : 'Failed to update project policies');
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const qualifiedActions = [
+    ...new Set(pending.map(qualifiedAction).filter((q): q is string => !!q)),
+  ];
 
   return (
     <div className="mb-2 overflow-hidden rounded-xl border border-amber-500/40 bg-amber-50/60 dark:bg-amber-950/20">
@@ -86,14 +160,14 @@ export function SessionApprovalPrompt() {
       </div>
       <ul className="divide-amber-500/15 divide-y">
         {pending.map((a) => {
-          const b = busy[a.execution_id];
+          const rowBusy = busy?.startsWith(`${a.execution_id}:`) ? busy.split(':')[1] : null;
           return (
             <li key={a.execution_id} className="flex items-center gap-2 px-3 py-2">
               <div className="min-w-0 flex-1">
                 <div className="flex items-center gap-1.5">
                   <span className="text-muted-foreground text-xs">Run</span>
                   <code
-                    title={a.action}
+                    title={qualifiedAction(a) ?? a.action}
                     className="text-foreground truncate font-mono text-xs font-medium"
                   >
                     {a.action}
@@ -113,29 +187,29 @@ export function SessionApprovalPrompt() {
                   size="xs"
                   variant="muted"
                   className={cn('hover:bg-destructive/10 hover:text-destructive')}
-                  disabled={!!b}
+                  disabled={!!busy}
                   onClick={() => decide(a.execution_id, 'deny')}
                 >
-                  {b === 'deny' ? <Loading className="size-3 animate-spin" /> : null}
+                  {rowBusy === 'deny' ? <Loading className="size-3 animate-spin" /> : null}
                   Deny
                 </Button>
                 <Button
                   size="xs"
                   variant="outline"
                   title="Allow this action for the rest of this session — the agent won't ask again for it"
-                  disabled={!!b}
+                  disabled={!!busy}
                   onClick={() => decide(a.execution_id, 'approve', 'session')}
                 >
-                  {b === 'session' ? <Loading className="size-3 animate-spin" /> : null}
+                  {rowBusy === 'session' ? <Loading className="size-3 animate-spin" /> : null}
                   Allow for session
                 </Button>
                 <Button
                   size="xs"
                   variant="default"
-                  disabled={!!b}
+                  disabled={!!busy}
                   onClick={() => decide(a.execution_id, 'approve', 'once')}
                 >
-                  {b === 'once' ? <Loading className="size-3 animate-spin" /> : null}
+                  {rowBusy === 'once' ? <Loading className="size-3 animate-spin" /> : null}
                   Allow once
                 </Button>
               </div>
@@ -143,6 +217,41 @@ export function SessionApprovalPrompt() {
           );
         })}
       </ul>
+      <div className="flex items-center gap-2 border-amber-500/15 border-t px-3 py-1.5">
+        <span className="text-muted-foreground text-[11px]">This session:</span>
+        <Button
+          size="xs"
+          variant="ghost"
+          title="Allow every gated action for the rest of this session"
+          disabled={!!busy}
+          onClick={() => void allowAllForSession()}
+        >
+          {busy === 'session-all' ? <Loading className="size-3 animate-spin" /> : null}
+          Allow everything
+        </Button>
+      </div>
+      {canWritePolicies.allowed && qualifiedActions.length > 0 ? (
+        // Deliberately set apart from the one-off buttons above: these WRITE the
+        // project's policy config — every future session stops asking.
+        <div className="bg-muted/40 border-border/40 flex flex-wrap items-center gap-2 border-t px-3 py-1.5">
+          <span className="text-muted-foreground text-[11px]">
+            Project policy <span className="opacity-70">(applies to future sessions)</span>:
+          </span>
+          {qualifiedActions.map((qualified) => (
+            <Button
+              key={qualified}
+              size="xs"
+              variant="ghost"
+              className="text-muted-foreground hover:text-foreground"
+              disabled={!!busy}
+              onClick={() => void alwaysRunInPolicy(qualified)}
+            >
+              {busy === `policy:${qualified}` ? <Loading className="size-3 animate-spin" /> : null}
+              Always allow "{qualified}"
+            </Button>
+          ))}
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/apps/web/src/features/session/session-approval-prompt.tsx
+++ b/apps/web/src/features/session/session-approval-prompt.tsx
@@ -43,9 +43,12 @@ import { ShieldAlert } from 'lucide-react';
 import { useParams } from 'next/navigation';
 import { useState } from 'react';
 
-/** `${slug}.${path}` — the fully-qualified tool path project policies match. */
+/** The fully-qualified tool path project policies match (`slug.path`). The
+ *  audit trail already stores the qualified form in `action`; the slug is only
+ *  prepended defensively if a row ever carries the relative form. */
 function qualifiedAction(a: SessionAuditAction): string | null {
-  return a.connector ? `${a.connector}.${a.action}` : null;
+  if (!a.connector) return null;
+  return a.action.startsWith(`${a.connector}.`) ? a.action : `${a.connector}.${a.action}`;
 }
 
 export function SessionApprovalPrompt() {

--- a/apps/web/src/features/session/session-audit-shared.tsx
+++ b/apps/web/src/features/session/session-audit-shared.tsx
@@ -124,7 +124,11 @@ export function useResolveApproval(projectId: string | undefined, sessionId: str
       executionId,
       decision,
       scope = 'once',
-    }: { executionId: string; decision: 'approve' | 'deny'; scope?: 'once' | 'session' }) => {
+    }: {
+      executionId: string;
+      decision: 'approve' | 'deny';
+      scope?: 'once' | 'session' | 'session_all';
+    }) => {
       if (!projectId) throw new Error('No project in context');
       return resolveApproval(projectId, executionId, decision, scope);
     },

--- a/apps/web/src/features/session/session-chat.tsx
+++ b/apps/web/src/features/session/session-chat.tsx
@@ -4953,39 +4953,10 @@ export function SessionChat({
     return () => unregisterSender(sessionId);
   }, [sessionId, handleSend, registerSender, unregisterSender]);
 
-  // ---- Auto-continue after a connector approval resolves ----
-  // The happy path never needs this: the gateway HOLDS a require_approval call
-  // and the sandbox CLI/MCP re-polls, so the agent's turn is still in-flight
-  // (isBusy) when the human decides and resumes by itself. But when the agent
-  // already gave up waiting — an older sandbox image without the CLI pause
-  // loop, or a decision after the ~30min poll budget — the approve only stamps
-  // a row nobody is watching. Detect that: the pending set just drained while
-  // the session sits idle → nudge the agent so the human never has to type
-  // "continue" (approval carry-over server-side makes the retried call run
-  // without re-asking).
-  const prevPendingApprovalsRef = useRef<Set<string>>(new Set());
-  useEffect(() => {
-    const actions = approvalAudit?.actions ?? [];
-    const pendingNow = new Set(actions.filter(isPendingAction).map((a) => a.execution_id));
-    const prev = prevPendingApprovalsRef.current;
-    prevPendingApprovalsRef.current = pendingNow;
-    if (prev.size === 0 || pendingNow.size > 0) return;
-    // Only count entries we can SEE resolved — a vanished row (data blip,
-    // trail truncation) must not fire a nudge.
-    const resolved = [...prev]
-      .map((id) => actions.find((a) => a.execution_id === id))
-      .filter((a): a is NonNullable<typeof a> => !!a && !isPendingAction(a));
-    if (resolved.length === 0) return;
-    if (isBusy) return; // turn still in-flight — the held call resumes itself
-    const denied = resolved.filter((a) => a.status === 'denied');
-    const text =
-      denied.length === resolved.length
-        ? 'I denied the pending approval — continue without that action.'
-        : denied.length > 0
-          ? 'I resolved the pending approvals (some denied) — continue accordingly.'
-          : 'Approved — continue.';
-    void handleSend(text);
-  }, [approvalAudit, isBusy, handleSend]);
+  // NOTE: no client-side "auto-continue after approval" here — resuming the
+  // agent when nobody was holding the gated call is the RESOLVE ENDPOINT's job
+  // (server-side continueSession delivery in r7.ts), so it works with zero
+  // browsers open. A web-side nudge would just double-send.
 
   const handleStop = useCallback(() => {
     // Guard against rapid clicks — ignore if an abort is already in flight

--- a/apps/web/src/features/session/session-chat.tsx
+++ b/apps/web/src/features/session/session-chat.tsx
@@ -4953,6 +4953,40 @@ export function SessionChat({
     return () => unregisterSender(sessionId);
   }, [sessionId, handleSend, registerSender, unregisterSender]);
 
+  // ---- Auto-continue after a connector approval resolves ----
+  // The happy path never needs this: the gateway HOLDS a require_approval call
+  // and the sandbox CLI/MCP re-polls, so the agent's turn is still in-flight
+  // (isBusy) when the human decides and resumes by itself. But when the agent
+  // already gave up waiting — an older sandbox image without the CLI pause
+  // loop, or a decision after the ~30min poll budget — the approve only stamps
+  // a row nobody is watching. Detect that: the pending set just drained while
+  // the session sits idle → nudge the agent so the human never has to type
+  // "continue" (approval carry-over server-side makes the retried call run
+  // without re-asking).
+  const prevPendingApprovalsRef = useRef<Set<string>>(new Set());
+  useEffect(() => {
+    const actions = approvalAudit?.actions ?? [];
+    const pendingNow = new Set(actions.filter(isPendingAction).map((a) => a.execution_id));
+    const prev = prevPendingApprovalsRef.current;
+    prevPendingApprovalsRef.current = pendingNow;
+    if (prev.size === 0 || pendingNow.size > 0) return;
+    // Only count entries we can SEE resolved — a vanished row (data blip,
+    // trail truncation) must not fire a nudge.
+    const resolved = [...prev]
+      .map((id) => actions.find((a) => a.execution_id === id))
+      .filter((a): a is NonNullable<typeof a> => !!a && !isPendingAction(a));
+    if (resolved.length === 0) return;
+    if (isBusy) return; // turn still in-flight — the held call resumes itself
+    const denied = resolved.filter((a) => a.status === 'denied');
+    const text =
+      denied.length === resolved.length
+        ? 'I denied the pending approval — continue without that action.'
+        : denied.length > 0
+          ? 'I resolved the pending approvals (some denied) — continue accordingly.'
+          : 'Approved — continue.';
+    void handleSend(text);
+  }, [approvalAudit, isBusy, handleSend]);
+
   const handleStop = useCallback(() => {
     // Guard against rapid clicks — ignore if an abort is already in flight
     if (abortSession.isPending) {

--- a/apps/web/src/features/session/session-chat.tsx
+++ b/apps/web/src/features/session/session-chat.tsx
@@ -3,6 +3,7 @@
 import { UnifiedMarkdown } from '@/components/markdown/unified-markdown';
 import { SandboxImage } from '@/features/session/sandbox-image';
 import { SessionApprovalPrompt } from '@/features/session/session-approval-prompt';
+import { SessionPermissionPrompt } from '@/features/session/session-permission-prompt';
 import { isPendingAction, useSessionAudit } from '@/features/session/session-audit-shared';
 import { useSessionWallpaperLayer } from '@/features/session/session-wallpaper-layer';
 import {
@@ -123,6 +124,7 @@ import {
   readStartStash,
   replayStartStash,
   sendAndRecover,
+  usePermissionSelfHeal,
   useQuestionSelfHeal,
   writeForkDraft,
 } from '@kortix/sdk/react';
@@ -3945,7 +3947,11 @@ export function SessionChat({
         return { options };
       },
       onReadinessTimeout: () => {
-        setCommandError({ kind: 'runtime-error', message: NO_MODEL_AVAILABLE_MESSAGE, cause: null });
+        setCommandError({
+          kind: 'runtime-error',
+          message: NO_MODEL_AVAILABLE_MESSAGE,
+          cause: null,
+        });
       },
       prepare: (stash, ready) => {
         pendingPromptHandled.current = true;
@@ -4492,6 +4498,10 @@ export function SessionChat({
     enabled: isActiveSessionTab,
     isSuppressed: isQuestionSuppressed,
   });
+  // The permission twin — a missed `permission.asked` frame otherwise leaves
+  // the agent silently blocked with no card to answer (the "have to type
+  // `continue`" wedge).
+  usePermissionSelfHeal(sessionId, messages, { enabled: isActiveSessionTab });
 
   // ---- Permission/question reply handlers ----
   const removePermission = useOpenCodePendingStore((s) => s.removePermission);
@@ -4499,12 +4509,11 @@ export function SessionChat({
 
   const handlePermissionReply = useCallback(
     async (requestId: string, reply: 'once' | 'always' | 'reject') => {
-      try {
-        await replyToPermission(requestId, reply);
-        removePermission(requestId);
-      } catch {
-        // ignore
-      }
+      // No optimistic remove: only drop the card once the runtime accepted the
+      // reply — a failed reply must stay answerable. Rethrow so callers
+      // (prompt buttons) reset their busy state and surface the error.
+      await replyToPermission(requestId, reply);
+      removePermission(requestId);
     },
     [removePermission],
   );
@@ -5592,7 +5601,10 @@ export function SessionChat({
           // so a typed message is sent to the agent instead of being swallowed
           // as a custom answer.
           lockForQuestion={!!renderedQuestion && isBusy}
-          lockForApproval={hasPendingApproval}
+          // Same dead-prompt guard as questions: only lock while the agent is
+          // actually paused on the decision (isBusy), so a stale card can't
+          // swallow the composer on an idle session.
+          lockForApproval={hasPendingApproval || (pendingPermissions.length > 0 && isBusy)}
           onCustomAnswer={(text) => {
             questionPromptRef.current?.submitCustomAnswer(text);
           }}
@@ -5606,6 +5618,14 @@ export function SessionChat({
               {/* Connector actions a policy gated for approval — pauses the run
                   until the human decides. Self-hides when nothing's pending. */}
               <SessionApprovalPrompt />
+              {/* Opencode tool permissions (bash/edit/…) awaiting a decision —
+                  the turn is blocked inside the runtime and resumes the moment
+                  a reply lands. Self-hides when nothing's pending. */}
+              <SessionPermissionPrompt
+                sessionId={sessionId}
+                permissions={pendingPermissions}
+                onReply={handlePermissionReply}
+              />
               {renderedQuestion ? (
                 <div
                   className={cn(

--- a/apps/web/src/features/session/session-permission-prompt.tsx
+++ b/apps/web/src/features/session/session-permission-prompt.tsx
@@ -1,0 +1,309 @@
+'use client';
+
+/**
+ * Inline "agent needs your permission" prompt, pinned above the composer — the
+ * opencode tool-permission twin of `SessionApprovalPrompt` (connector
+ * approvals). Answering resumes the agent's already-blocked turn in place
+ * (opencode holds the tool call open until `/permission/{id}/reply`), so no
+ * follow-up "continue" message is ever needed.
+ *
+ * Three decision scopes, visually separated by how long they last:
+ *  - per request: Deny / Allow once / Allow for session (opencode's native
+ *    `always` reply — this action pattern, rest of this session)
+ *  - per session: "Allow everything" writes a blanket allow ruleset onto the
+ *    opencode session (survives tab close) + auto-approves anything already
+ *    pending; a client-side auto-approver backstops any ask that still arrives.
+ *  - persistent (footer, gated on `project.customize.write`): writes the
+ *    project's opencode permission config — future sessions stop asking.
+ */
+
+import { Button } from '@/components/ui/button';
+import Loading from '@/components/ui/loading';
+import { errorToast, successToast } from '@/components/ui/toast';
+import { useOpenCodeConfig, useUpdateOpenCodeConfig } from '@/hooks/opencode/use-opencode-config';
+import {
+  allowAllPermissionsForSession,
+  resetSessionPermissions,
+} from '@/hooks/opencode/use-opencode-sessions';
+import { PROJECT_ACTIONS } from '@/lib/project-actions';
+import { useProjectCan } from '@/lib/use-project-can';
+import { cn } from '@/lib/utils';
+import { useOpenCodePendingStore } from '@/stores/opencode-pending-store';
+import { PERMISSION_LABELS, type PermissionRequest } from '@/ui/types';
+import { ShieldCheck } from 'lucide-react';
+import { useParams } from 'next/navigation';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+interface SessionPermissionPromptProps {
+  /** The OPENCODE session id (what `PermissionRequest.sessionID` carries). */
+  sessionId: string;
+  permissions: PermissionRequest[];
+  /** Must reject on failure so busy states reset and the card stays actionable. */
+  onReply: (requestId: string, reply: 'once' | 'always' | 'reject') => Promise<void>;
+}
+
+function permissionLabel(p: PermissionRequest): string {
+  return PERMISSION_LABELS[p.permission] || p.permission;
+}
+
+/** The concrete thing being gated — the request's match patterns (e.g. the
+ * bash command), falling back to a metadata title if the runtime sent none. */
+function permissionDetail(p: PermissionRequest): string | null {
+  if (p.patterns?.length) return p.patterns.join('  ');
+  const title = (p.metadata as Record<string, unknown> | undefined)?.title;
+  return typeof title === 'string' ? title : null;
+}
+
+export function SessionPermissionPrompt({
+  sessionId,
+  permissions,
+  onReply,
+}: SessionPermissionPromptProps) {
+  // Only the /projects/[id]/sessions/[sessionId] route has a project in scope —
+  // on plain /sessions/[id], `id` IS the session, so no config surface.
+  const params = useParams<{ id?: string; sessionId?: string }>();
+  const projectId = params?.sessionId ? params.id : undefined;
+  const canWriteConfig = useProjectCan(projectId, PROJECT_ACTIONS.PROJECT_CUSTOMIZE_WRITE);
+
+  const autoApprove = useOpenCodePendingStore((s) => !!s.autoApproveAllSessions[sessionId]);
+  const setAutoApproveAll = useOpenCodePendingStore((s) => s.setAutoApproveAll);
+
+  const { data: config } = useOpenCodeConfig();
+  const updateConfig = useUpdateOpenCodeConfig();
+
+  // Which button is loading: `${requestId}:once|always|reject`, 'session-all',
+  // or `config:${type}` / 'config:*'.
+  const [busy, setBusy] = useState<string | null>(null);
+
+  const reply = useCallback(
+    async (requestId: string, kind: 'once' | 'always' | 'reject') => {
+      setBusy(`${requestId}:${kind}`);
+      try {
+        await onReply(requestId, kind);
+      } catch (e) {
+        errorToast(e instanceof Error ? e.message : 'Failed to answer the permission request');
+      } finally {
+        setBusy(null);
+      }
+    },
+    [onReply],
+  );
+
+  const allowAllForSession = useCallback(async () => {
+    setBusy('session-all');
+    try {
+      // Server-side grant first (survives the tab closing). Best-effort: if the
+      // runtime rejects the session ruleset, the client-side auto-approver
+      // below still delivers the behavior while this tab is open.
+      try {
+        await allowAllPermissionsForSession(sessionId);
+      } catch {
+        // fall through to the client-side backstop
+      }
+      setAutoApproveAll(sessionId, true);
+      // The ruleset only stops FUTURE asks — approve what's already pending.
+      await Promise.all(permissions.map((p) => onReply(p.id, 'once')));
+      successToast("Allowed — won't ask again for anything this session");
+    } catch (e) {
+      errorToast(e instanceof Error ? e.message : 'Failed to allow permissions');
+    } finally {
+      setBusy(null);
+    }
+  }, [sessionId, permissions, onReply, setAutoApproveAll]);
+
+  const turnOffAutoApprove = useCallback(async () => {
+    setAutoApproveAll(sessionId, false);
+    try {
+      await resetSessionPermissions(sessionId);
+    } catch {
+      // The flag is already off; a stale session ruleset just means fewer asks.
+    }
+  }, [sessionId, setAutoApproveAll]);
+
+  /** Persist an allow into the project's opencode permission config (the same
+   * surface Settings → Permissions edits), then release the pending asks it
+   * covers. `type === '*'` = always allow everything. */
+  const allowInConfig = useCallback(
+    async (type: string) => {
+      setBusy(`config:${type}`);
+      try {
+        const current = config?.permission as string | Record<string, unknown> | undefined;
+        // Preserve the existing shape: a global string mode becomes the `*`
+        // fallback of the object form.
+        const base: Record<string, unknown> =
+          typeof current === 'string'
+            ? { '*': current }
+            : current && typeof current === 'object'
+              ? { ...current }
+              : {};
+        const next =
+          type === '*'
+            ? // "Always allow everything": flatten every existing override too,
+              // so no leftover per-tool `ask`/`deny` outranks the wildcard.
+              Object.fromEntries([...Object.keys(base), '*'].map((k) => [k, 'allow']))
+            : { ...base, [type]: 'allow' };
+        await updateConfig.mutateAsync({ permission: next } as never);
+        const covered = permissions.filter((p) => type === '*' || p.permission === type);
+        await Promise.all(covered.map((p) => onReply(p.id, 'once')));
+        successToast(
+          type === '*'
+            ? 'Saved — permissions are always allowed in this project now'
+            : `Saved — "${PERMISSION_LABELS[type] || type}" is always allowed in this project now`,
+        );
+      } catch (e) {
+        errorToast(e instanceof Error ? e.message : 'Failed to update the project config');
+      } finally {
+        setBusy(null);
+      }
+    },
+    [config, updateConfig, permissions, onReply],
+  );
+
+  // Client-side backstop for "allow everything this session": auto-approve any
+  // ask that still arrives (e.g. the runtime ignored the session ruleset).
+  const autoRepliedRef = useRef<Set<string>>(new Set());
+  useEffect(() => {
+    if (!autoApprove) return;
+    for (const p of permissions) {
+      if (autoRepliedRef.current.has(p.id)) continue;
+      autoRepliedRef.current.add(p.id);
+      void onReply(p.id, 'once').catch(() => {
+        // Let a later effect run retry it (e.g. a transient network blip).
+        autoRepliedRef.current.delete(p.id);
+      });
+    }
+  }, [autoApprove, permissions, onReply]);
+
+  const uniqueTypes = useMemo(
+    () => [...new Set(permissions.map((p) => p.permission))],
+    [permissions],
+  );
+
+  if (autoApprove) {
+    return (
+      <div className="border-border/60 bg-muted/40 mb-2 flex items-center gap-2 rounded-xl border px-3 py-1.5">
+        <ShieldCheck className="text-muted-foreground size-3.5" />
+        <span className="text-muted-foreground flex-1 text-[11px]">
+          Auto-allowing all permission requests for this session
+        </span>
+        <Button size="xs" variant="ghost" onClick={() => void turnOffAutoApprove()}>
+          Turn off
+        </Button>
+      </div>
+    );
+  }
+
+  if (permissions.length === 0) return null;
+
+  return (
+    <div className="mb-2 overflow-hidden rounded-xl border border-amber-500/40 bg-amber-50/60 dark:bg-amber-950/20">
+      <div className="flex items-center gap-2 border-amber-500/20 border-b px-3 py-1.5">
+        <ShieldCheck className="size-3.5 text-amber-600 dark:text-amber-400" />
+        <span className="text-foreground text-xs font-semibold tracking-tight">
+          {permissions.length === 1
+            ? 'The agent needs your permission'
+            : `${permissions.length} actions need your permission`}
+        </span>
+        <span className="text-muted-foreground text-[11px]">— it's paused until you decide</span>
+      </div>
+      <ul className="divide-amber-500/15 divide-y">
+        {permissions.map((p) => {
+          const detail = permissionDetail(p);
+          return (
+            <li key={p.id} className="flex items-center gap-2 px-3 py-2">
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-1.5">
+                  <span className="text-foreground text-xs font-medium">{permissionLabel(p)}</span>
+                </div>
+                {detail ? (
+                  <code
+                    title={detail}
+                    className="text-muted-foreground mt-0.5 block truncate font-mono text-[11px]"
+                  >
+                    {detail}
+                  </code>
+                ) : null}
+              </div>
+              <div className="flex shrink-0 items-center gap-1.5">
+                <Button
+                  size="xs"
+                  variant="muted"
+                  className={cn('hover:bg-destructive/10 hover:text-destructive')}
+                  disabled={!!busy}
+                  onClick={() => void reply(p.id, 'reject')}
+                >
+                  {busy === `${p.id}:reject` ? <Loading className="size-3 animate-spin" /> : null}
+                  Deny
+                </Button>
+                <Button
+                  size="xs"
+                  variant="outline"
+                  title="Allow this action for the rest of this session — the agent won't ask again for it"
+                  disabled={!!busy}
+                  onClick={() => void reply(p.id, 'always')}
+                >
+                  {busy === `${p.id}:always` ? <Loading className="size-3 animate-spin" /> : null}
+                  Allow for session
+                </Button>
+                <Button
+                  size="xs"
+                  variant="default"
+                  disabled={!!busy}
+                  onClick={() => void reply(p.id, 'once')}
+                >
+                  {busy === `${p.id}:once` ? <Loading className="size-3 animate-spin" /> : null}
+                  Allow once
+                </Button>
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+      <div className="flex items-center gap-2 border-amber-500/15 border-t px-3 py-1.5">
+        <span className="text-muted-foreground text-[11px]">This session:</span>
+        <Button
+          size="xs"
+          variant="ghost"
+          title="Allow every permission request for the rest of this session"
+          disabled={!!busy}
+          onClick={() => void allowAllForSession()}
+        >
+          {busy === 'session-all' ? <Loading className="size-3 animate-spin" /> : null}
+          Allow everything
+        </Button>
+      </div>
+      {canWriteConfig.allowed ? (
+        // Deliberately set apart from the one-off buttons above: these WRITE the
+        // project's permission config — every future session stops asking.
+        <div className="bg-muted/40 border-border/40 flex flex-wrap items-center gap-2 border-t px-3 py-1.5">
+          <span className="text-muted-foreground text-[11px]">
+            Project config <span className="opacity-70">(applies to future sessions)</span>:
+          </span>
+          {uniqueTypes.map((type) => (
+            <Button
+              key={type}
+              size="xs"
+              variant="ghost"
+              className="text-muted-foreground hover:text-foreground"
+              disabled={!!busy}
+              onClick={() => void allowInConfig(type)}
+            >
+              {busy === `config:${type}` ? <Loading className="size-3 animate-spin" /> : null}
+              Always allow "{PERMISSION_LABELS[type] || type}"
+            </Button>
+          ))}
+          <Button
+            size="xs"
+            variant="ghost"
+            className="text-muted-foreground hover:text-foreground"
+            disabled={!!busy}
+            onClick={() => void allowInConfig('*')}
+          >
+            {busy === 'config:*' ? <Loading className="size-3 animate-spin" /> : null}
+            Always allow everything
+          </Button>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/features/session/tool-renderers.tsx
+++ b/apps/web/src/features/session/tool-renderers.tsx
@@ -16,10 +16,7 @@ import { parseImageOutput } from '@/features/session/image-output-path';
 import { QuestionPrompt } from '@/features/session/question-prompt';
 import { prefersPreviewLink } from '@/features/session/preview-url-fallback';
 import { isShowContentUnavailable, type ShowLoadStatus } from './show-availability';
-import {
-  SessionRetryDisplay,
-  TurnErrorDisplay,
-} from '@/features/session/session-error-banner';
+import { SessionRetryDisplay, TurnErrorDisplay } from '@/features/session/session-error-banner';
 import { SubSessionModal } from '@/features/session/sub-session-modal';
 import {
   cleanResultSnippet,
@@ -317,9 +314,7 @@ function ServicePreviewUrlFallback({ preview }: { preview: ServicePreviewState }
           disabled={!previewUrl}
           className={cn(
             'text-foreground inline-flex max-w-full items-center gap-2 rounded-lg border border-border bg-card px-4 py-3 text-sm font-medium shadow-2xs transition-colors',
-            previewUrl
-              ? 'hover:bg-muted'
-              : 'cursor-not-allowed opacity-60',
+            previewUrl ? 'hover:bg-muted' : 'cursor-not-allowed opacity-60',
           )}
         >
           <ExternalLink className="size-4 shrink-0 text-muted-foreground" />
@@ -483,7 +478,10 @@ interface ToolProps {
   forceOpen?: boolean;
   locked?: boolean;
   hasActiveQuestion?: boolean;
-  onPermissionReply?: (requestId: string, reply: 'once' | 'always' | 'reject') => void;
+  onPermissionReply?: (
+    requestId: string,
+    reply: 'once' | 'always' | 'reject',
+  ) => void | Promise<void>;
 }
 
 type ToolComponent = ComponentType<ToolProps>;
@@ -4012,7 +4010,9 @@ function ToolFailureCard({ heading, failure }: { heading: string; failure: Embed
     >
       <CircleAlert className={cn('mt-0.5 size-3.5 flex-shrink-0', STATUS_TEXT.destructive)} />
       <div className="min-w-0 flex-1 space-y-1">
-        <div className={cn('flex items-center gap-1.5 text-xs font-medium', STATUS_TEXT.destructive)}>
+        <div
+          className={cn('flex items-center gap-1.5 text-xs font-medium', STATUS_TEXT.destructive)}
+        >
           <span>{heading}</span>
           {typeof failure.status === 'number' && (
             <span className="font-mono text-xs opacity-70">HTTP {failure.status}</span>
@@ -8760,11 +8760,10 @@ export function GenericTool({ part }: ToolProps) {
 
 interface PermissionPromptInlineProps {
   permission: PermissionRequest;
-  onReply?: (requestId: string, reply: 'once' | 'always' | 'reject') => void;
+  onReply?: (requestId: string, reply: 'once' | 'always' | 'reject') => void | Promise<void>;
 }
 
 function PermissionPromptInline({ permission, onReply }: PermissionPromptInlineProps) {
-  const tHardcodedUi = useTranslations('hardcodedUi');
   const [visible, setVisible] = useState(false);
   const [replying, setReplying] = useState(false);
 
@@ -8774,12 +8773,20 @@ function PermissionPromptInline({ permission, onReply }: PermissionPromptInlineP
   }, []);
 
   const label = PERMISSION_LABELS[permission.permission] || permission.permission;
+  const detail = permission.patterns?.length ? permission.patterns.join('  ') : null;
 
   const handleReply = useCallback(
     (reply: 'once' | 'always' | 'reject') => {
       if (replying) return;
       setReplying(true);
-      onReply?.(permission.id, reply);
+      // A failed reply must leave the card answerable — on success the card
+      // unmounts (the permission leaves the pending store), so re-enabling
+      // only ever matters on failure. The full scope options (allow all this
+      // session / persist to config) live in the pinned prompt above the
+      // composer; this inline row keeps the quick decisions in context.
+      void Promise.resolve(onReply?.(permission.id, reply))
+        .catch(() => {})
+        .finally(() => setReplying(false));
     },
     [replying, permission.id, onReply],
   );
@@ -8788,8 +8795,13 @@ function PermissionPromptInline({ permission, onReply }: PermissionPromptInlineP
 
   return (
     <div className={cn('flex items-center gap-2 px-2.5 py-2', STATUS_TEXT.warning)}>
-      <span className="text-foreground flex-1 text-xs">
+      <span className="text-foreground min-w-0 flex-1 text-xs">
         Permission: <span className="font-medium">{label}</span>
+        {detail ? (
+          <code title={detail} className="text-muted-foreground ml-1.5 font-mono text-[11px]">
+            {detail.length > 60 ? `${detail.slice(0, 57)}…` : detail}
+          </code>
+        ) : null}
       </span>
       <div className="flex items-center gap-1.5">
         <Button
@@ -8806,11 +8818,12 @@ function PermissionPromptInline({ permission, onReply }: PermissionPromptInlineP
           onClick={() => handleReply('always')}
           variant="outline"
           size="xs"
+          title="Allow this action for the rest of this session — the agent won't ask again for it"
         >
-          {tHardcodedUi.raw('componentsSessionToolRenderers.line8026JsxTextAllowAlways')}
+          Allow for session
         </Button>
         <Button disabled={replying} onClick={() => handleReply('once')} variant="default" size="xs">
-          {tHardcodedUi.raw('componentsSessionToolRenderers.line8034JsxTextAllowOnce')}
+          Allow once
         </Button>
       </div>
     </div>
@@ -8825,7 +8838,10 @@ interface ToolPartRendererProps {
   part: ToolPart;
   permission?: PermissionRequest;
   question?: QuestionRequest;
-  onPermissionReply?: (requestId: string, reply: 'once' | 'always' | 'reject') => void;
+  onPermissionReply?: (
+    requestId: string,
+    reply: 'once' | 'always' | 'reject',
+  ) => void | Promise<void>;
   onQuestionReply?: (requestId: string, answers: string[][]) => void;
   onQuestionReject?: (requestId: string) => void;
   defaultOpen?: boolean;

--- a/apps/web/src/features/workspace/customize/sections/connectors-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/connectors-view.tsx
@@ -949,15 +949,17 @@ function ConnectorDetail({
               : `Add the credential so the agent and your triggers can use ${displayName}.`}
           </InfoBanner>
         )}
-        <Tabs defaultValue="profile" className="gap-3">
+        {/* The sensitive toggle lives under Permissions (it IS a permission
+            default), so Profile only exists when there's a connection to
+            manage — for Pipedream/managed connectors it would be empty. */}
+        <Tabs defaultValue={!isPipedream && !isManaged ? 'profile' : 'permissions'} className="gap-3">
           <TabsList>
-            <TabsTrigger value="profile">Profile</TabsTrigger>
+            {!isPipedream && !isManaged && <TabsTrigger value="profile">Profile</TabsTrigger>}
             <TabsTrigger value="permissions">Permissions</TabsTrigger>
           </TabsList>
-          <TabsContent value="profile" className="space-y-5">
-            {!isPipedream &&
-              !isManaged &&
-              (isChannel ? (
+          {!isPipedream && !isManaged && (
+            <TabsContent value="profile" className="space-y-5">
+              {isChannel ? (
                 <ChannelConnectionSection
                   projectId={projectId}
                   connector={connector}
@@ -970,10 +972,11 @@ function ConnectorDetail({
                   connector={connector}
                   onChanged={onChanged}
                 />
-              ))}
-            <ProfileSection projectId={projectId} connector={connector} onChanged={onChanged} />
-          </TabsContent>
-          <TabsContent value="permissions">
+              )}
+            </TabsContent>
+          )}
+          <TabsContent value="permissions" className="space-y-5">
+            <SensitiveSection projectId={projectId} connector={connector} onChanged={onChanged} />
             <PermissionsSection projectId={projectId} connector={connector} />
           </TabsContent>
         </Tabs>
@@ -1886,12 +1889,12 @@ export function SlackConnectForm({
 }
 
 /**
- * Profile: the connector's own settings — visible to every project member
- * (connectors are always project-wide); which agents may call it is decided
- * purely by the agent's own `connectors` grant (Agents → kortix.yaml), not
- * anything configured here. This section is just the sensitive toggle.
+ * The connector-wide permission default: `sensitive` gates READS too — every
+ * action asks before it runs (for email/files/secrets where reading is itself
+ * an exfiltration surface). Lives at the top of the Permissions tab since it's
+ * the baseline the per-tool rules below override.
  */
-function ProfileSection({
+function SensitiveSection({
   projectId,
   connector,
   onChanged,
@@ -1912,17 +1915,22 @@ function ProfileSection({
   });
 
   return (
-    <SectionCard title="Profile" description="Connector-wide settings.">
+    <SectionCard
+      title="Sensitive connector"
+      description="The permission baseline for every tool on this connector."
+    >
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0">
           <div className="flex items-center gap-1.5">
             <ShieldCheck className="text-muted-foreground/70 size-3.5 shrink-0" />
-            <span className="text-foreground/80 text-xs font-medium">Sensitive connector</span>
+            <span className="text-foreground/80 text-xs font-medium">
+              Gate reads too — everything asks first
+            </span>
           </div>
           <p className="text-muted-foreground/60 mt-1 text-[11px] leading-relaxed">
-            Gate <span className="text-foreground/70 font-medium">reads</span> too — every action
-            asks before it runs (approve once, or “allow for session”). For email/files/secrets
-            where reading is itself risky. An explicit policy rule can still open a specific action.
+            Every action — including <span className="text-foreground/70 font-medium">reads</span>{' '}
+            — asks before it runs (approve once, or “allow for session”). For email/files/secrets
+            where reading is itself risky. A per-tool rule below can still open a specific action.
           </p>
         </div>
         <Switch

--- a/apps/web/src/stores/opencode-pending-store.test.ts
+++ b/apps/web/src/stores/opencode-pending-store.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, test } from 'bun:test';
 
-import type { QuestionRequest } from '@kortix/sdk/opencode-client';
+import type { PermissionRequest, QuestionRequest } from '@kortix/sdk/opencode-client';
 
 import { useOpenCodePendingStore } from './opencode-pending-store';
 
@@ -10,6 +10,16 @@ const q = (id: string, sessionID = 'ses_1'): QuestionRequest =>
     sessionID,
     questions: [{ question: 'pick one', options: [{ label: 'a' }, { label: 'b' }] }],
   }) as unknown as QuestionRequest;
+
+const perm = (id: string, sessionID = 'ses_1'): PermissionRequest =>
+  ({
+    id,
+    sessionID,
+    permission: 'bash',
+    patterns: ['ls *'],
+    metadata: {},
+    always: ['ls *'],
+  }) as unknown as PermissionRequest;
 
 beforeEach(() => {
   useOpenCodePendingStore.getState().clear();
@@ -52,7 +62,9 @@ describe('useOpenCodePendingStore — resolved questions', () => {
     store.addQuestion(q('req_1'));
     store.removeQuestion('req_1');
     store.removeQuestion('req_1');
-    const ids = useOpenCodePendingStore.getState().resolvedQuestionIds.filter((id) => id === 'req_1');
+    const ids = useOpenCodePendingStore
+      .getState()
+      .resolvedQuestionIds.filter((id) => id === 'req_1');
     expect(ids).toHaveLength(1);
   });
 
@@ -73,5 +85,67 @@ describe('useOpenCodePendingStore — resolved questions', () => {
     expect(useOpenCodePendingStore.getState().resolvedQuestionIds).toHaveLength(0);
     store.addQuestion(q('req_1'));
     expect(useOpenCodePendingStore.getState().questions.req_1).toBeDefined();
+  });
+});
+
+describe('useOpenCodePendingStore — resolved permissions', () => {
+  test('removePermission drops it and records it as resolved', () => {
+    const store = useOpenCodePendingStore.getState();
+    store.addPermission(perm('prm_1'));
+    store.removePermission('prm_1');
+    const state = useOpenCodePendingStore.getState();
+    expect(state.permissions.prm_1).toBeUndefined();
+    expect(state.resolvedPermissionIds).toContain('prm_1');
+  });
+
+  test('a resolved permission can never be resurrected by a later addPermission', () => {
+    const store = useOpenCodePendingStore.getState();
+    store.addPermission(perm('prm_1'));
+    store.removePermission('prm_1');
+    // Simulates SSE reconnect hydrate / permission.asked echo / self-heal poll.
+    store.addPermission(perm('prm_1'));
+    expect(useOpenCodePendingStore.getState().permissions.prm_1).toBeUndefined();
+  });
+
+  test('resolving one permission does not block a different one', () => {
+    const store = useOpenCodePendingStore.getState();
+    store.addPermission(perm('prm_1'));
+    store.removePermission('prm_1');
+    store.addPermission(perm('prm_2'));
+    expect(useOpenCodePendingStore.getState().permissions.prm_2).toBeDefined();
+  });
+
+  test('resolved permission history is bounded', () => {
+    const store = useOpenCodePendingStore.getState();
+    for (let i = 0; i < 250; i++) {
+      store.addPermission(perm(`prm_${i}`));
+      store.removePermission(`prm_${i}`);
+    }
+    expect(useOpenCodePendingStore.getState().resolvedPermissionIds.length).toBeLessThanOrEqual(
+      200,
+    );
+  });
+});
+
+describe('useOpenCodePendingStore — auto-approve sessions', () => {
+  test('setAutoApproveAll flags and unflags a session', () => {
+    const store = useOpenCodePendingStore.getState();
+    store.setAutoApproveAll('ses_1', true);
+    expect(useOpenCodePendingStore.getState().autoApproveAllSessions.ses_1).toBe(true);
+    store.setAutoApproveAll('ses_1', false);
+    expect(useOpenCodePendingStore.getState().autoApproveAllSessions.ses_1).toBeUndefined();
+  });
+
+  test('flags are per-session', () => {
+    const store = useOpenCodePendingStore.getState();
+    store.setAutoApproveAll('ses_1', true);
+    expect(useOpenCodePendingStore.getState().autoApproveAllSessions.ses_2).toBeUndefined();
+  });
+
+  test('clear() resets auto-approve flags', () => {
+    const store = useOpenCodePendingStore.getState();
+    store.setAutoApproveAll('ses_1', true);
+    store.clear();
+    expect(useOpenCodePendingStore.getState().autoApproveAllSessions.ses_1).toBeUndefined();
   });
 });

--- a/packages/sdk/src/platform/projects-client/access.ts
+++ b/packages/sdk/src/platform/projects-client/access.ts
@@ -426,11 +426,12 @@ export async function resolveApproval(
   executionId: string,
   decision: 'approve' | 'deny',
   // 'once' (default) = just this call; 'session' = also stop asking for this
-  // connector+action for the rest of the session.
-  scope: 'once' | 'session' = 'once',
+  // connector+action for the rest of the session; 'session_all' = stop asking
+  // for ANY gated action for the rest of the session.
+  scope: 'once' | 'session' | 'session_all' = 'once',
 ) {
   return unwrap(
-    await backendApi.post<{ ok: boolean; scope?: 'once' | 'session' }>(
+    await backendApi.post<{ ok: boolean; scope?: 'once' | 'session' | 'session_all' }>(
       `/projects/${projectId}/approvals/${executionId}`,
       { decision, scope },
     ),

--- a/packages/sdk/src/platform/projects-client/sessions.ts
+++ b/packages/sdk/src/platform/projects-client/sessions.ts
@@ -230,6 +230,10 @@ export interface SessionAuditAction {
   execution_id: string;
   action: string;
   connector_id: string | null;
+  /** Connector slug — `${connector}.${action}` is the fully-qualified tool
+   *  path project policies match against. Null on very old rows whose
+   *  connector was deleted. */
+  connector?: string | null;
   /** ok | error | denied | pending_approval */
   status: string;
   /** read | write | destructive | null */

--- a/packages/sdk/src/react/opencode.ts
+++ b/packages/sdk/src/react/opencode.ts
@@ -112,6 +112,12 @@ export {
   type UseQuestionSelfHealOptions,
 } from './use-question-self-heal';
 export {
+  usePermissionSelfHeal,
+  findPermissionBlockedCandidate,
+  hasActiveNonQuestionTool,
+  type UsePermissionSelfHealOptions,
+} from './use-permission-self-heal';
+export {
   startStashKey,
   writeStartStash,
   readStartStash,

--- a/packages/sdk/src/react/use-opencode-sessions/permissions.ts
+++ b/packages/sdk/src/react/use-opencode-sessions/permissions.ts
@@ -1,3 +1,4 @@
+import type { PermissionRuleset } from '@opencode-ai/sdk/v2/client';
 import { getClient } from '../../opencode/client';
 import { unwrap } from './shared';
 
@@ -15,10 +16,52 @@ export async function replyToPermission(
   unwrap(result);
 }
 
-export async function replyToQuestion(
-  requestId: string,
-  answers: string[][],
-): Promise<void> {
+/** The permission types opencode gates today (mirrors the web's
+ * PERMISSION_LABELS keys). Enumerated explicitly IN ADDITION to the `*`
+ * wildcard rule so "allow all" holds even if the runtime's rule matcher treats
+ * the permission NAME as an exact key rather than a glob. */
+const KNOWN_PERMISSION_TYPES = [
+  'bash',
+  'edit',
+  'write',
+  'read',
+  'webfetch',
+  'mcp',
+  'doom_loop',
+] as const;
+
+/**
+ * "Allow everything for the rest of this session": writes a blanket allow
+ * ruleset onto the opencode SESSION (the same per-session ledger an `always`
+ * reply appends to), so subsequent asks are answered server-side — the grant
+ * survives the tab closing, unlike a client-side auto-approver. Strictly
+ * broader than any rules the session accumulated before, so replacing them
+ * is safe. Pair with replying `once` to the currently-pending request(s);
+ * this only stops FUTURE asks.
+ */
+export async function allowAllPermissionsForSession(sessionID: string): Promise<void> {
+  const client = getClient();
+  const ruleset: PermissionRuleset = [
+    { permission: '*', pattern: '*', action: 'allow' },
+    ...KNOWN_PERMISSION_TYPES.map((permission) => ({
+      permission,
+      pattern: '*',
+      action: 'allow' as const,
+    })),
+  ];
+  const result = await client.session.update({ sessionID, permission: ruleset });
+  unwrap(result);
+}
+
+/** Undo `allowAllPermissionsForSession`: clear the session ruleset so the
+ * project/config permission rules apply again. */
+export async function resetSessionPermissions(sessionID: string): Promise<void> {
+  const client = getClient();
+  const result = await client.session.update({ sessionID, permission: [] });
+  unwrap(result);
+}
+
+export async function replyToQuestion(requestId: string, answers: string[][]): Promise<void> {
   const client = getClient();
   const result = await client.question.reply({ requestID: requestId, answers });
   unwrap(result);

--- a/packages/sdk/src/react/use-permission-self-heal.test.ts
+++ b/packages/sdk/src/react/use-permission-self-heal.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  findPermissionBlockedCandidate,
+  hasActiveNonQuestionTool,
+} from './use-permission-self-heal';
+
+const NOW = 1_000_000;
+
+function toolPart(
+  tool: string,
+  status: string,
+  extra: { input?: Record<string, unknown>; start?: number } = {},
+) {
+  return {
+    type: 'tool' as const,
+    tool,
+    callID: 'call_1',
+    state: {
+      status,
+      input: extra.input,
+      time: extra.start !== undefined ? { start: extra.start } : undefined,
+    },
+  };
+}
+
+function assistant(parts: unknown[]) {
+  return { info: { id: 'm1', role: 'assistant' }, parts } as never;
+}
+
+describe('hasActiveNonQuestionTool', () => {
+  test('is false with no messages', () => {
+    expect(hasActiveNonQuestionTool(undefined)).toBe(false);
+    expect(hasActiveNonQuestionTool([])).toBe(false);
+  });
+
+  test('is true for a running bash tool', () => {
+    expect(hasActiveNonQuestionTool([assistant([toolPart('bash', 'running')])])).toBe(true);
+  });
+
+  test('ignores the question tool (it has its own self-heal)', () => {
+    expect(hasActiveNonQuestionTool([assistant([toolPart('question', 'running')])])).toBe(false);
+  });
+
+  test('is false once tools settle', () => {
+    expect(hasActiveNonQuestionTool([assistant([toolPart('bash', 'completed')])])).toBe(false);
+  });
+
+  test('ignores tool parts on user messages', () => {
+    const messages = [
+      { info: { id: 'm1', role: 'user' }, parts: [toolPart('bash', 'running')] },
+    ] as never[];
+    expect(hasActiveNonQuestionTool(messages)).toBe(false);
+  });
+});
+
+describe('findPermissionBlockedCandidate', () => {
+  test('empty input pending is the stale "session ended" shape — not a candidate', () => {
+    const messages = [assistant([toolPart('bash', 'pending', { input: {} })])];
+    expect(findPermissionBlockedCandidate(messages, NOW)).toEqual({
+      pendingWithInput: false,
+      staleRunning: false,
+    });
+  });
+
+  test('pending with input is the fast-poll candidate', () => {
+    const messages = [assistant([toolPart('bash', 'pending', { input: { command: 'ls' } })])];
+    expect(findPermissionBlockedCandidate(messages, NOW).pendingWithInput).toBe(true);
+  });
+
+  test('recently-started running tool is not a candidate', () => {
+    const messages = [assistant([toolPart('bash', 'running', { start: NOW - 2_000 })])];
+    expect(findPermissionBlockedCandidate(messages, NOW)).toEqual({
+      pendingWithInput: false,
+      staleRunning: false,
+    });
+  });
+
+  test('long-running tool becomes the slow-poll candidate', () => {
+    const messages = [assistant([toolPart('bash', 'running', { start: NOW - 60_000 })])];
+    expect(findPermissionBlockedCandidate(messages, NOW).staleRunning).toBe(true);
+  });
+
+  test('question tool never qualifies', () => {
+    const messages = [
+      assistant([
+        toolPart('question', 'pending', { input: { question: 'hm' } }),
+        toolPart('question', 'running', { start: NOW - 60_000 }),
+      ]),
+    ];
+    expect(findPermissionBlockedCandidate(messages, NOW)).toEqual({
+      pendingWithInput: false,
+      staleRunning: false,
+    });
+  });
+});

--- a/packages/sdk/src/react/use-permission-self-heal.ts
+++ b/packages/sdk/src/react/use-permission-self-heal.ts
@@ -1,0 +1,162 @@
+'use client';
+
+import { useEffect, useMemo, useRef } from 'react';
+import { getClient } from '../opencode/client';
+import { useOpenCodePendingStore } from '../state/opencode-pending-store';
+import type { MessageWithPartsLike, ToolPartLike } from '../turns/types';
+
+/** A tool stuck in `running` this long with nothing pending is suspicious —
+ * long enough that ordinary tool startup never trips it. */
+const STALE_RUNNING_MS = 10_000;
+
+/**
+ * Classify tool parts that could be blocked on an unanswered permission ask.
+ * Unlike questions (their own `question` tool), a permission can gate ANY tool
+ * (bash, edit, write, …), so the signal is fuzzier — two shapes qualify:
+ *
+ * - `pending` with non-empty input: args are fully streamed but execution never
+ *   started. Transiently true for every tool for a frame or two, durably true
+ *   for one blocked on a permission ask. (`pending` with EMPTY input is the
+ *   known "session ended abruptly" stale shape — ignored.)
+ * - `running` for a long time: covers opencode versions/tools where a blocked
+ *   part reports `running`. Fuzzy on purpose — a long bash command looks the
+ *   same — so callers poll this shape on a much slower cadence.
+ *
+ * Returns which shapes are present so the hook can pick a poll cadence.
+ */
+export function findPermissionBlockedCandidate(
+  messages: MessageWithPartsLike[] | undefined,
+  now: number,
+): { pendingWithInput: boolean; staleRunning: boolean } {
+  let pendingWithInput = false;
+  let staleRunning = false;
+  if (!messages) return { pendingWithInput, staleRunning };
+  for (const m of messages) {
+    if (m.info.role !== 'assistant') continue;
+    for (const p of m.parts) {
+      if (p.type !== 'tool') continue;
+      const tool = p as unknown as ToolPartLike;
+      // Questions have their own self-heal (`useQuestionSelfHeal`).
+      if (tool.tool === 'question') continue;
+      const state = tool.state as {
+        status?: string;
+        input?: Record<string, unknown>;
+        time?: { start?: number };
+      };
+      if (state.status === 'pending' && Object.keys(state.input ?? {}).length > 0) {
+        pendingWithInput = true;
+      } else if (state.status === 'running') {
+        const start = state.time?.start;
+        if (typeof start === 'number' && now - start > STALE_RUNNING_MS) staleRunning = true;
+      }
+    }
+  }
+  return { pendingWithInput, staleRunning };
+}
+
+/** True when any non-question tool part is still running/pending — the cheap
+ * render-time gate that keeps the poll effect mounted at all. */
+export function hasActiveNonQuestionTool(messages: MessageWithPartsLike[] | undefined): boolean {
+  if (!messages) return false;
+  return messages.some((m) => {
+    if (m.info.role !== 'assistant') return false;
+    return m.parts.some((p) => {
+      if (p.type !== 'tool') return false;
+      const tool = p as unknown as ToolPartLike;
+      if (tool.tool === 'question') return false;
+      return tool.state.status === 'running' || tool.state.status === 'pending';
+    });
+  });
+}
+
+export interface UsePermissionSelfHealOptions {
+  /** Gate the whole poll — e.g. only while this session's tab/view is active.
+   * Default true. */
+  enabled?: boolean;
+}
+
+/**
+ * Self-heals a missed `permission.asked` SSE event — the permission twin of
+ * `useQuestionSelfHeal`, closing the gap where a dropped frame leaves the agent
+ * silently blocked on an ask the user never sees (the "have to type `continue`
+ * to unwedge it" failure).
+ *
+ * Because a permission can gate any tool, the trigger is fuzzier than the
+ * question hook's, so the cadence is shape-dependent (see
+ * `findPermissionBlockedCandidate`): a `pending`-with-input part re-checks
+ * `permission.list()` every ~2s like the question hook; a merely long-`running`
+ * part — which a legitimate slow bash command also produces — is probed at most
+ * every 15s so an active session never gets hammered. The poll stops the moment
+ * a pending permission shows up (from this poll or the SSE event finally
+ * arriving) or the tool part settles.
+ */
+export function usePermissionSelfHeal(
+  sessionId: string,
+  messages: MessageWithPartsLike[] | undefined,
+  options: UsePermissionSelfHealOptions = {},
+): void {
+  const { enabled = true } = options;
+  const addPermission = useOpenCodePendingStore((s) => s.addPermission);
+  const pendingCount = useOpenCodePendingStore(
+    (s) => Object.values(s.permissions).filter((p) => p.sessionID === sessionId).length,
+  );
+  const active = useMemo(() => hasActiveNonQuestionTool(messages), [messages]);
+
+  const messagesRef = useRef(messages);
+  messagesRef.current = messages;
+  const inFlightRef = useRef(false);
+  const lastAtRef = useRef(0);
+  useEffect(() => {
+    if (!enabled || !active || pendingCount > 0) return;
+
+    let cancelled = false;
+
+    const hydrate = () => {
+      if (inFlightRef.current || cancelled) return;
+      const now = Date.now();
+      // Evaluate the blocked-candidate shapes at poll time, not render time —
+      // a part silently aging past the stale threshold produces no re-render.
+      const { pendingWithInput, staleRunning } = findPermissionBlockedCandidate(
+        messagesRef.current,
+        now,
+      );
+      if (!pendingWithInput && !staleRunning) return;
+      const minGap = pendingWithInput ? 1_500 : 15_000;
+      if (now - lastAtRef.current < minGap) return;
+
+      // Acquire the client lazily: during the sandbox-loading window
+      // getClient() throws "Server URL not ready". Skip this tick and let the
+      // interval retry once the runtime URL is pinned — never throw here.
+      let client: ReturnType<typeof getClient>;
+      try {
+        client = getClient();
+      } catch {
+        return;
+      }
+
+      inFlightRef.current = true;
+      lastAtRef.current = now;
+
+      void client.permission
+        .list()
+        .then((res) => {
+          if (!res.data || cancelled) return;
+          (res.data as Array<{ id?: string }>).forEach((p) => {
+            if (!p?.id) return;
+            addPermission(p as Parameters<typeof addPermission>[0]);
+          });
+        })
+        .finally(() => {
+          inFlightRef.current = false;
+        });
+    };
+
+    hydrate();
+    const timer = setInterval(hydrate, 2_000);
+
+    return () => {
+      cancelled = true;
+      clearInterval(timer);
+    };
+  }, [enabled, active, pendingCount, addPermission]);
+}

--- a/packages/sdk/src/state/opencode-pending-store.ts
+++ b/packages/sdk/src/state/opencode-pending-store.ts
@@ -1,28 +1,41 @@
 'use client';
 
-import { create } from 'zustand';
 import type { PermissionRequest, QuestionRequest } from '@opencode-ai/sdk/v2/client';
+import { create } from 'zustand';
 
-// Cap on how many resolved question ids we remember. Question ids are unique per
+// Cap on how many resolved request ids we remember. Request ids are unique per
 // request, so this only needs to outlive the window in which a stale add (SSE
-// reconnect hydrate, a `question.asked` echo, or the self-heal `question.list()`
-// poll) could try to resurrect a question the user already answered. A few hundred
-// comfortably covers any real session.
-const RESOLVED_QUESTION_LIMIT = 200;
+// reconnect hydrate, an `*.asked` echo, or a self-heal `list()` poll) could try
+// to resurrect a request the user already answered. A few hundred comfortably
+// covers any real session.
+const RESOLVED_REQUEST_LIMIT = 200;
+
+function recordResolved(ids: string[], requestId: string): string[] {
+  if (ids.includes(requestId)) return ids;
+  return [...ids, requestId].slice(-RESOLVED_REQUEST_LIMIT);
+}
 
 interface OpenCodePendingState {
   permissions: Record<string, PermissionRequest>;
   questions: Record<string, QuestionRequest>;
-  // Ids of questions the user already answered / rejected / dismissed.
-  // `addQuestion` ignores these so a resolved question can never be resurrected by
-  // a stale add path, which would re-lock the chat input. Insertion-ordered so the
-  // oldest entries prune once the cap is hit.
+  // Ids of questions/permissions the user already answered / rejected / dismissed.
+  // `addQuestion`/`addPermission` ignore these so a resolved request can never be
+  // resurrected by a stale add path, which would re-lock the chat input.
+  // Insertion-ordered so the oldest entries prune once the cap is hit.
   resolvedQuestionIds: string[];
+  resolvedPermissionIds: string[];
+  // Sessions the user put in "allow all permissions" mode. The session ruleset
+  // written server-side (see `allowAllPermissionsForSession`) should stop new
+  // asks at the source; this flag is the client-side belt-and-braces — any ask
+  // that still arrives for a flagged session gets auto-approved by the prompt
+  // component — and it drives the "auto-approving" indicator UI.
+  autoApproveAllSessions: Record<string, true>;
 
   addPermission: (req: PermissionRequest) => void;
   removePermission: (requestId: string) => void;
   addQuestion: (req: QuestionRequest) => void;
   removeQuestion: (requestId: string) => void;
+  setAutoApproveAll: (sessionId: string, enabled: boolean) => void;
   clear: () => void;
 
   // Derived: all pending items for a specific session
@@ -34,16 +47,25 @@ export const useOpenCodePendingStore = create<OpenCodePendingState>()((set, get)
   permissions: {},
   questions: {},
   resolvedQuestionIds: [],
+  resolvedPermissionIds: [],
+  autoApproveAllSessions: {},
 
   addPermission: (req) =>
-    set((state) => ({
-      permissions: { ...state.permissions, [req.id]: req },
-    })),
+    set((state) => {
+      // Never resurrect a permission the user already resolved — SSE reconnect
+      // hydration, the `permission.asked` echo, and the self-heal poll all
+      // funnel through here (mirrors the question guard below).
+      if (state.resolvedPermissionIds.includes(req.id)) return state;
+      return { permissions: { ...state.permissions, [req.id]: req } };
+    }),
 
   removePermission: (requestId) =>
     set((state) => {
       const { [requestId]: _, ...rest } = state.permissions;
-      return { permissions: rest };
+      return {
+        permissions: rest,
+        resolvedPermissionIds: recordResolved(state.resolvedPermissionIds, requestId),
+      };
     }),
 
   addQuestion: (req) =>
@@ -58,14 +80,26 @@ export const useOpenCodePendingStore = create<OpenCodePendingState>()((set, get)
   removeQuestion: (requestId) =>
     set((state) => {
       const { [requestId]: _, ...rest } = state.questions;
-      // Remember the id as resolved so a later stale add can't bring it back.
-      const resolved = state.resolvedQuestionIds.includes(requestId)
-        ? state.resolvedQuestionIds
-        : [...state.resolvedQuestionIds, requestId].slice(-RESOLVED_QUESTION_LIMIT);
-      return { questions: rest, resolvedQuestionIds: resolved };
+      return {
+        questions: rest,
+        resolvedQuestionIds: recordResolved(state.resolvedQuestionIds, requestId),
+      };
     }),
 
-  clear: () => set({ permissions: {}, questions: {}, resolvedQuestionIds: [] }),
+  setAutoApproveAll: (sessionId, enabled) =>
+    set((state) => {
+      const { [sessionId]: _, ...rest } = state.autoApproveAllSessions;
+      return { autoApproveAllSessions: enabled ? { ...rest, [sessionId]: true } : rest };
+    }),
+
+  clear: () =>
+    set({
+      permissions: {},
+      questions: {},
+      resolvedQuestionIds: [],
+      resolvedPermissionIds: [],
+      autoApproveAllSessions: {},
+    }),
 
   getSessionPendingCount: (sessionId) => {
     const s = get();
@@ -79,8 +113,10 @@ export const useOpenCodePendingStore = create<OpenCodePendingState>()((set, get)
   getTotalPendingCount: () => {
     const s = get();
     const permCount = Object.keys(s.permissions).length;
-    const qCount = Object.values(s.questions)
-      .reduce((sum, q) => sum + (q.questions?.length || 1), 0);
+    const qCount = Object.values(s.questions).reduce(
+      (sum, q) => sum + (q.questions?.length || 1),
+      0,
+    );
     return permCount + qCount;
   },
 }));


### PR DESCRIPTION
## Problem (Marko)

1. **Approvals should work like questions**: answering must resume the agent — no typing `continue`.
2. **Too much re-asking**: no "allow all for this session", and no visually separated way to persist an allow for the future (gated on config permission).

This PR fixes BOTH approval systems. The core complaint is the **connector/executor approvals** (the amber card above the composer + audit tab); the opencode tool-permission prompt got the same treatment for consistency.

## Connector approvals (the real bug) — commit `4ddf5f03c9`

**Root cause:** the gateway pauses a `require_approval` call (45s hold → `retryable` + `execution_id` → client re-polls indefinitely), but only the MCP face implemented the poll loop. The agent's **primary** path — the `kortix executor` **CLI** — made a single call and gave up after one 45s hold. Approving later just stamped a DB row nobody was polling: nothing resumed, the approved action **never ran**, and the retried call **re-asked** ('Allow once' was a no-op unless you approved within 45s).

**Fixes (layered so old sandbox images benefit too):**
- **CLI**: shared `callPausingForApproval()` for both faces — `kortix executor call` now pauses indefinitely (~30 min of re-issued holds) and resumes in place on approve. *(needs new sandbox images)*
- **API — approval carry-over**: a fresh call atomically claims a recent unconsumed human approve of the same (session, connector, action) (15-min window, one claim per approve) and **runs instead of re-asking**. Held-path approves are marked consumed so a grant can't be used twice.
- **API — server-side resume** (replaces an earlier browser-side nudge): the RESOLVE endpoint is the one chokepoint every approve/deny goes through. After resolving, it waits a 6s grace; if no live held request marked the decision consumed (held requests now mark on BOTH approve and deny), nobody was waiting — it delivers the continuation prompt into the session itself via `continueSession` (source `system:approval-resume`, wakes stopped sandboxes, retries delivery, fully detached from the HTTP response). Works with zero browsers open; carry-over makes the retried call run silently.

**Less re-asking:**
- New resolve scope `session_all`: "Allow everything" for the session (a `*` wildcard grant per enabled connector; the gateway session-allow check matches `*`).
- **Visually separated** "Project policy (applies to future sessions)" footer on the prompt, gated on `project.connector.write`: prepends an `always_run` policy for the fully-qualified tool (first-match-wins, so prepend beats an existing gate). Audit response now carries the connector slug to build `slug.action`.

## opencode tool permissions (same UX, first commit `39125fa318`)

- `usePermissionSelfHeal` + resolved-id guard + non-stuck reply buttons (a dropped `permission.asked` SSE frame can no longer silently wedge the agent).
- Pinned `SessionPermissionPrompt` above the composer + composer lock while paused.
- Scopes: Deny / Allow once / Allow for session / **Allow everything (session)** (server-side session ruleset + client backstop) / separated **project-config allow** gated on `project.customize.write`.

## Tests
- 4 new gateway unit tests (carry-over claim/miss, poll-retry bypass, held-consume marking) — `unit-executor-gateway.test.ts` 30/30.
- Pending-store + self-heal + SDK access suites green (56 tests).
- `tsc --noEmit` clean: apps/api, apps/cli, apps/web, packages/sdk, packages/executor-sdk. No new biome diagnostics.

## Deploy notes
- CLI pause loop ships with the next sandbox image bake; until then the carry-over + web auto-continue cover existing sandboxes.
- `session_all` grants are rows in `session_tool_approvals` (`actionPath='*'`) — no schema change.