### PR TITLE
fix(sandbox): ppwarm reap skips Platinum soft-delete tombstones

### DIFF
--- a/apps/api/src/__tests__/unit-ppwarm-reap.test.ts
+++ b/apps/api/src/__tests__/unit-ppwarm-reap.test.ts
@@ -54,4 +54,13 @@ describe('ppwarmReapTargets — on-bake reap selector', () => {
     // re-bake of the same tip: nothing to reap (live tip safe)
     expect(ppwarmReapTargets(PROJ_A, cur, [cur])).toEqual([]);
   });
+
+  test('never re-selects a Platinum soft-delete tombstone (…__deleted_<id>)', () => {
+    const names = [
+      'kortix-ppwarm-9ee8bc9c-aaaaaaaaaaaa', // current tip
+      'kortix-ppwarm-9ee8bc9c-bbbbbbbbbbbb__deleted_tpl_01ABC', // already-reaped tombstone
+      'kortix-ppwarm-9ee8bc9c-cccccccccccc__deleted__deleted', // double-tombstone (the observed regression)
+    ];
+    expect(ppwarmReapTargets(PROJ_A, CURRENT, names)).toEqual([]);
+  });
 });

--- a/apps/api/src/snapshots/ppwarm-names.ts
+++ b/apps/api/src/snapshots/ppwarm-names.ts
@@ -34,9 +34,13 @@ export function perProjectWarmImageName(projectId: string, tip: string, baseSnap
  * under the project's `kortix-ppwarm-<proj8>-` prefix that are NOT the current
  * tip. proj8-scoped so it can never match another project; the shared base
  * (`kortix-default-…`) never carries the ppwarm prefix so it's never a target;
- * returns [] when only the current tip exists (idempotent re-bake).
+ * returns [] when only the current tip exists (idempotent re-bake). Tombstones
+ * are excluded: Platinum's delete is a soft-delete that renames the row to
+ * `…__deleted_<id>` while KEEPING the ppwarm prefix, so an already-reaped tip
+ * would otherwise be re-selected (and re-DELETEd) on every later bake; those rows
+ * are already deprecated / not quota-counting, so there is nothing to reap.
  */
 export function ppwarmReapTargets(projectId: string, currentName: string, allNames: string[]): string[] {
   const prefix = `${PPWARM_PREFIX}${proj8(projectId)}-`;
-  return allNames.filter((n) => n.startsWith(prefix) && n !== currentName);
+  return allNames.filter((n) => n.startsWith(prefix) && n !== currentName && !n.includes('__deleted'));
 }


### PR DESCRIPTION
Follow-up to #4175. The reap surfaced a real wrinkle when tested on live data.

**Problem:** Platinum's template delete is a **soft-delete** — it renames the row to `…__deleted_<id>` but keeps the `kortix-ppwarm-<proj8>-` prefix. So `ppwarmReapTargets` re-selected the tombstone on every later bake and re-issued a DELETE (observed a `…__deleted__deleted` double-tombstone). Harmless (current tip always kept; deprecated rows don't count toward the Daytona quota the reap exists to protect; Daytona hard-deletes so it was already clean) — but a wasted DELETE per bake on Platinum.

**Fix:** one line — exclude names containing `__deleted` in the pure selector. +1 unit test covering single and double tombstones. `bun test` 6/6 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)