### PR TITLE
feat(provider): rename sandbox provider daytona → managed (backward-compatible)

### DIFF
--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -12,7 +12,20 @@ export const SANDBOX_VERSION = process.env.SANDBOX_VERSION || 'unknown';
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
-export type SandboxProviderName = 'daytona' | 'platinum';
+// 'managed' is the canonical name for the managed cloud backend; 'daytona' is a
+// permanent legacy alias for the SAME backend (kept so existing DB rows / any
+// external caller sending 'daytona' never break). New writes use 'managed'.
+export type SandboxProviderName = 'managed' | 'daytona' | 'platinum';
+
+/** True for either the canonical 'managed' name or its legacy 'daytona' alias. */
+export function isManagedProviderName(p: string | null | undefined): boolean {
+  return p === 'managed' || p === 'daytona';
+}
+
+/** Canonicalise a provider string: legacy 'daytona' → 'managed'; others pass through. */
+export function normalizeProviderName<T extends string>(p: T): T | 'managed' {
+  return p === 'daytona' ? 'managed' : p;
+}
 type InternalKortixEnv = 'dev' | 'staging' | 'prod' | 'preview';
 
 // ─── Zod Helpers ────────────────────────────────────────────────────────────
@@ -307,7 +320,7 @@ const envSchema = z.object({
   // ── Sandbox Platform ──────────────────────────────────────────────────────
   // Public API base URL, without a route suffix. Auto-derived from PORT in local mode.
   KORTIX_URL:                  optStr,
-  ALLOWED_SANDBOX_PROVIDERS:   optStrDefault('daytona'),
+  ALLOWED_SANDBOX_PROVIDERS:   optStrDefault('managed'),
   SANDBOX_IMAGE:               optStr,
   KORTIX_LOCAL_IMAGES:         optBoolFalse,
   SANDBOX_NETWORK:             optStr,
@@ -397,12 +410,14 @@ type EnvIssue = { var: string; message: string; level: 'error' | 'warn' };
 // Recognised provider names. Source-of-truth for what can legally appear in
 // ALLOWED_SANDBOX_PROVIDERS — adding a new provider is a one-place change
 // here plus a case in `getProvider()` in platform/providers/index.ts.
-const KNOWN_PROVIDERS: readonly SandboxProviderName[] = ['daytona', 'platinum'] as const;
+// 'managed' is canonical; 'daytona' still parses (normalised to 'managed') so an
+// existing ALLOWED_SANDBOX_PROVIDERS=daytona env keeps working unchanged.
+const KNOWN_PROVIDERS: readonly SandboxProviderName[] = ['managed', 'platinum'] as const;
 
-/** Parse comma-separated provider list (e.g. "daytona,platinum"). */
+/** Parse comma-separated provider list (e.g. "managed,platinum"). */
 function parseAllowedProviders(raw: string): SandboxProviderName[] {
-  if (!raw) return ['daytona'];
-  const names = raw.split(',').map((s) => s.trim().toLowerCase()).filter(Boolean);
+  if (!raw) return ['managed'];
+  const names = raw.split(',').map((s) => normalizeProviderName(s.trim().toLowerCase())).filter(Boolean);
   const valid: SandboxProviderName[] = [];
   for (const n of names) {
     if ((KNOWN_PROVIDERS as readonly string[]).includes(n)) {
@@ -412,7 +427,7 @@ function parseAllowedProviders(raw: string): SandboxProviderName[] {
       console.warn(`[config] Unknown sandbox provider "${n}" in ALLOWED_SANDBOX_PROVIDERS - ignored`);
     }
   }
-  return valid.length > 0 ? valid : ['daytona'];
+  return valid.length > 0 ? valid : ['managed'];
 }
 
 function validateEnv(): z.infer<typeof envSchema> {
@@ -433,7 +448,7 @@ function validateEnv(): z.infer<typeof envSchema> {
 
   // ── Conditional: Daytona provider enabled → need Daytona keys ──────────
   const providers = parseAllowedProviders((raw as any).ALLOWED_SANDBOX_PROVIDERS || '');
-  if (providers.includes('daytona')) {
+  if (providers.includes('managed')) {
     if (!raw.DAYTONA_API_KEY)    issues.push({ var: 'DAYTONA_API_KEY',    message: 'Required when ALLOWED_SANDBOX_PROVIDERS includes "daytona"', level: 'error' });
     if (!raw.DAYTONA_SERVER_URL) issues.push({ var: 'DAYTONA_SERVER_URL', message: 'Required when ALLOWED_SANDBOX_PROVIDERS includes "daytona"', level: 'error' });
     if (!raw.DAYTONA_TARGET)     issues.push({ var: 'DAYTONA_TARGET',     message: 'Required when ALLOWED_SANDBOX_PROVIDERS includes "daytona"', level: 'error' });
@@ -761,12 +776,14 @@ export const config = {
   // ─── Helper Methods ────────────────────────────────────────────────────────
 
   isProviderEnabled(name: SandboxProviderName): boolean {
-    if (!this.ALLOWED_SANDBOX_PROVIDERS.includes(name)) return false;
-    switch (name) {
+    const canonical = normalizeProviderName(name);
+    if (!this.ALLOWED_SANDBOX_PROVIDERS.includes(canonical)) return false;
+    switch (canonical) {
+      case 'managed':
       case 'daytona': return !!this.DAYTONA_API_KEY;
       case 'platinum': return !!this.PLATINUM_API_KEY;
       default: {
-        const exhaustive: never = name;
+        const exhaustive: never = canonical;
         return exhaustive;
       }
     }
@@ -774,17 +791,23 @@ export const config = {
 
   /**
    * Default sandbox provider for new sessions. First entry of
-   * ALLOWED_SANDBOX_PROVIDERS, with 'daytona' as the safety belt for an
+   * ALLOWED_SANDBOX_PROVIDERS, with 'managed' as the safety belt for an
    * empty list. The single-provider invariant means there's no resolution
    * order today, but the function is the contract callers depend on —
    * adding a new provider later just changes what the list can contain.
    */
   getDefaultProvider(): SandboxProviderName {
-    return this.ALLOWED_SANDBOX_PROVIDERS[0] ?? 'daytona';
+    return this.ALLOWED_SANDBOX_PROVIDERS[0] ?? 'managed';
   },
 
+  /** True when the managed cloud backend (canonical 'managed' / legacy 'daytona') is enabled. */
+  isManagedEnabled(): boolean {
+    return this.ALLOWED_SANDBOX_PROVIDERS.some(isManagedProviderName) && !!this.DAYTONA_API_KEY;
+  },
+
+  /** @deprecated use isManagedEnabled — kept for callers still on the old name. */
   isDaytonaEnabled(): boolean {
-    return this.ALLOWED_SANDBOX_PROVIDERS.includes('daytona') && !!this.DAYTONA_API_KEY;
+    return this.isManagedEnabled();
   },
 
   isPlatinumEnabled(): boolean {

--- a/apps/api/src/platform/providers/index.ts
+++ b/apps/api/src/platform/providers/index.ts
@@ -11,7 +11,8 @@ import { PlatinumProvider } from './platinum';
  *   - daytona — managed cloud (Daytona)
  *   - platinum — managed cloud (Platinum)
  */
-export type ProviderName = 'daytona' | 'platinum';
+// 'managed' is canonical for the managed cloud backend; 'daytona' is its legacy alias.
+export type ProviderName = 'managed' | 'daytona' | 'platinum';
 
 /**
  * Thrown by the Daytona warm path when the experimental memory-snapshot restore
@@ -124,9 +125,10 @@ export function getProvider(name: ProviderName): SandboxProvider {
   let provider: SandboxProvider;
 
   switch (name) {
+    case 'managed':
     case 'daytona':
       if (!config.DAYTONA_API_KEY) {
-        throw new Error('Daytona provider requires DAYTONA_API_KEY to be set.');
+        throw new Error('Managed provider requires DAYTONA_API_KEY to be set.');
       }
       provider = new DaytonaProvider();
       break;

--- a/apps/api/src/platform/services/session-sandbox.ts
+++ b/apps/api/src/platform/services/session-sandbox.ts
@@ -522,7 +522,7 @@ export async function provisionSessionSandbox(opts: {
             provisionTimeline: timeline,
             daytonaSandboxId: result.externalId,
             runtimeArtifact: {
-              artifactType: providerName === 'daytona' ? 'daytona_snapshot' : 'unknown',
+              artifactType: (providerName === 'daytona' || providerName === 'managed') ? 'daytona_snapshot' : 'unknown',
               providerArtifactRef: imageInfo!.snapshotName,
               contentHash: imageInfo!.contentHash,
               sandboxSlug: imageInfo!.slug,

--- a/apps/api/src/projects/legacy-migration-steps.ts
+++ b/apps/api/src/projects/legacy-migration-steps.ts
@@ -419,7 +419,7 @@ export async function dbStep(ctx: MigrationContext): Promise<void> {
         projectId: plan.project_id,
         branchName: spec.branchName,
         baseRef: defaultBranch,
-        sandboxProvider: 'daytona',
+        sandboxProvider: 'managed',
         sandboxId: null,
         sandboxUrl: null,
         opencodeSessionId: spec.opencodeSessionId,

--- a/apps/api/src/projects/suna-migration/suna-migration-phases.ts
+++ b/apps/api/src/projects/suna-migration/suna-migration-phases.ts
@@ -188,7 +188,7 @@ export async function dbStep(ctx: SunaMigrationContext): Promise<void> {
     for (const s of specs) {
       await tx.insert(projectSessions).values({
         sessionId: crypto.randomUUID(), accountId: ctx.accountId, projectId,
-        branchName: s.slug, baseRef: defaultBranch, sandboxProvider: 'daytona',
+        branchName: s.slug, baseRef: defaultBranch, sandboxProvider: 'managed',
         sandboxId: null, sandboxUrl: null, opencodeSessionId: s.opencodeSessionId,
         agentName: 'default', status: 'stopped', createdBy: ctx.accountId, visibility: 'project',
         metadata: {

--- a/apps/api/src/setup/index.ts
+++ b/apps/api/src/setup/index.ts
@@ -209,12 +209,12 @@ setupApp.openapi(
 
   // Provider capabilities — tells the frontend how to handle provisioning UI
   const capabilities: Record<string, { async: boolean; events: boolean; polling: boolean }> = {
-    daytona: { async: false, events: false, polling: false },
+    managed: { async: false, events: false, polling: false },
   };
 
   return c.json({
     providers: available,
-    default: available.includes(config.getDefaultProvider()) ? config.getDefaultProvider() : (available[0] || 'daytona'),
+    default: available.includes(config.getDefaultProvider()) ? config.getDefaultProvider() : (available[0] || 'managed'),
     capabilities: Object.fromEntries(available.map((p) => [p, capabilities[p] || { async: false, events: false, polling: false }])),
   });
   },
@@ -371,7 +371,7 @@ setupApp.openapi(
   // DAYTONA_API_KEY. We don't ping Daytona here on purpose: that's a
   // latency-sensitive UI call and Daytona's auth-check endpoint is
   // their billing concern, not ours.
-  checks.daytona = config.DAYTONA_API_KEY
+  checks.managed = config.DAYTONA_API_KEY
     ? { ok: true }
     : { ok: false, error: 'DAYTONA_API_KEY not configured' };
   return c.json(checks);

--- a/apps/api/src/snapshots/builder.ts
+++ b/apps/api/src/snapshots/builder.ts
@@ -981,7 +981,7 @@ async function resolveWarmRepoContext(project: GitBackedProject): Promise<WarmRe
  */
 async function reapOldPerProjectWarm(projectId: string, currentName: string, buildProvider: string): Promise<void> {
   try {
-    if (buildProvider === 'daytona') {
+    if (buildProvider === 'daytona' || buildProvider === 'managed') {
       const { listDaytonaSnapshots, deleteDaytonaSnapshotById } = await import('../shared/daytona');
       const snaps = await listDaytonaSnapshots();
       const targets = new Set(ppwarmReapTargets(projectId, currentName, snaps.map((s) => s.name)));

--- a/apps/api/src/snapshots/providers/index.ts
+++ b/apps/api/src/snapshots/providers/index.ts
@@ -88,6 +88,10 @@ export interface SandboxProviderAdapter {
 }
 
 const ADAPTERS = new Map<string, SandboxProviderAdapter>();
+// The managed cloud backend is registered under BOTH its canonical name
+// ('managed') and its legacy alias ('daytona' = daytonaProvider.id), so template
+// rows / sessions holding either value resolve to the same adapter.
+ADAPTERS.set('managed', daytonaProvider);
 ADAPTERS.set(daytonaProvider.id, daytonaProvider);
 ADAPTERS.set(platinumProvider.id, platinumProvider);
 

--- a/apps/api/src/snapshots/templates.ts
+++ b/apps/api/src/snapshots/templates.ts
@@ -300,7 +300,7 @@ export async function createTemplate(input: CreateTemplateInput): Promise<DbSand
       name: input.name || input.slug,
       isShared: false,
       source: input.source ?? 'ui',
-      provider: 'daytona',
+      provider: 'managed',
       image: input.image ?? null,
       dockerfilePath: input.dockerfilePath ?? null,
       entrypoint: input.entrypoint ?? null,
@@ -511,7 +511,7 @@ export async function recordTemplateBuilt(
   // lazy, pressure-gated GC eventually notices.
   const oldName = prev?.providerSnapshotName ?? null;
   if (oldName && oldName !== args.snapshotName) {
-    await reapPredecessorSnapshot(templateId, oldName, args.provider ?? prev?.provider ?? 'daytona');
+    await reapPredecessorSnapshot(templateId, oldName, args.provider ?? prev?.provider ?? 'managed');
   }
 }
 
@@ -585,7 +585,7 @@ function synthesizedDefault(): ResolvedTemplate {
     name: tpl.name ?? 'Default',
     isShared: true,
     source: 'platform',
-    provider: 'daytona',
+    provider: 'managed',
     image: null,
     dockerfilePath: null,
     entrypoint: null,
@@ -608,7 +608,7 @@ function rowToResolved(row: DbSandboxTemplate): ResolvedTemplate {
     name: row.name,
     isShared: row.isShared,
     source: (row.source as ResolvedTemplate['source']) ?? 'toml',
-    provider: row.provider ?? 'daytona',
+    provider: row.provider ?? 'managed',
     image: row.image,
     dockerfilePath: row.dockerfilePath,
     entrypoint: row.entrypoint,
@@ -642,7 +642,7 @@ async function syncTomlTemplatesForProject(project: GitBackedProject): Promise<v
           name: tpl.name ?? tpl.slug,
           isShared: false,
           source: 'toml',
-          provider: 'daytona',
+          provider: 'managed',
           image: tpl.image ?? null,
           dockerfilePath: tpl.dockerfile ?? null,
           entrypoint: null,

--- a/apps/web/src/components/admin/admin-dashboard-sections.tsx
+++ b/apps/web/src/components/admin/admin-dashboard-sections.tsx
@@ -287,7 +287,7 @@ export function AdminInstancesSection({ embedded = false }: { embedded?: boolean
                 )}
               </SelectItem>
               <SelectItem value="justavps">JustAVPS</SelectItem>
-              <SelectItem value="daytona">Daytona</SelectItem>
+              <SelectItem value="managed">Managed</SelectItem>
             </SelectContent>
           </Select>
           <Button

--- a/packages/api-contract/src/index.ts
+++ b/packages/api-contract/src/index.ts
@@ -76,8 +76,10 @@ export const PROJECT_ROLES = ['manager', 'editor', 'member'] as const;
 export const ProjectRoleSchema = z.enum(PROJECT_ROLES);
 export type ProjectRole = z.infer<typeof ProjectRoleSchema>;
 
-/** Every provider that can appear on session/sandbox rows. */
-export const SANDBOX_PROVIDERS = ['daytona', 'local_docker', 'justavps', 'platinum'] as const;
+/** Every provider that can appear on session/sandbox rows. 'managed' is the
+ *  canonical name for the managed cloud backend; 'daytona' is its legacy alias,
+ *  kept so existing rows / callers stay valid. */
+export const SANDBOX_PROVIDERS = ['managed', 'daytona', 'local_docker', 'justavps', 'platinum'] as const;
 export const SandboxProviderSchema = z.enum(SANDBOX_PROVIDERS);
 export type SandboxProvider = z.infer<typeof SandboxProviderSchema>;
 

--- a/packages/db/migrations/20260706190000000_sandbox_provider_add_managed.sql
+++ b/packages/db/migrations/20260706190000000_sandbox_provider_add_managed.sql
@@ -1,0 +1,11 @@
+-- Add 'managed' to the sandbox_provider enum — the canonical name for the managed
+-- cloud backend. 'daytona' (the legacy alias for the SAME backend) is kept as a
+-- valid enum member so existing rows and any external caller still sending
+-- 'daytona' never break. New rows are written as 'managed'; read paths accept
+-- both (config.isManagedProviderName / the adapter registry registers both keys).
+--
+-- ADD VALUE only (never USED in this txn) — matches the existing precedent for
+-- adding enum values (executor_connector_provider 'channel'/'computer'). MUST run
+-- before code that writes 'managed' deploys; the deploy pipeline applies pending
+-- migrations before the API rollout, so ordering holds. Non-destructive + idempotent.
+ALTER TYPE "kortix"."sandbox_provider" ADD VALUE IF NOT EXISTS 'managed';

--- a/packages/db/src/schema/kortix.test.ts
+++ b/packages/db/src/schema/kortix.test.ts
@@ -69,6 +69,7 @@ describe('kortix enums', () => {
   test('sandbox_provider enum lists supported providers', () => {
     expect(sandboxProviderEnum.enumName).toBe('sandbox_provider');
     expect(sandboxProviderEnum.enumValues).toEqual([
+      'managed',
       'daytona',
       'local_docker',
       'justavps',
@@ -307,9 +308,9 @@ describe('sandboxes table', () => {
     expect(primaryColumn(sandboxes)).toBe('sandbox_id');
   });
 
-  test('provider defaults to daytona', () => {
+  test('provider defaults to managed', () => {
     const col = getTableConfig(sandboxes).columns.find((c) => c.name === 'provider');
-    expect(col?.default).toBe('daytona');
+    expect(col?.default).toBe('managed');
   });
 
   test('status defaults to provisioning', () => {

--- a/packages/db/src/schema/kortix.ts
+++ b/packages/db/src/schema/kortix.ts
@@ -27,6 +27,11 @@ export const sandboxStatusEnum = kortixSchema.enum('sandbox_status', [
 ]);
 
 export const sandboxProviderEnum = kortixSchema.enum('sandbox_provider', [
+  // 'managed' is the canonical name for the managed cloud backend. 'daytona' is
+  // the legacy alias for the SAME backend, kept valid forever so existing rows
+  // and any external caller still sending 'daytona' never break. New rows write
+  // 'managed'; read paths accept both (config.isManagedProviderName).
+  'managed',
   'daytona',
   'local_docker',
   'justavps',
@@ -534,7 +539,7 @@ export const projectSessions = kortixSchema.table(
       .references(() => projects.projectId, { onDelete: 'cascade' }),
     branchName: text('branch_name').notNull(),
     baseRef: text('base_ref').default('main').notNull(),
-    sandboxProvider: sandboxProviderEnum('sandbox_provider').default('daytona').notNull(),
+    sandboxProvider: sandboxProviderEnum('sandbox_provider').default('managed').notNull(),
     sandboxId: text('sandbox_id'),
     sandboxUrl: text('sandbox_url'),
     opencodeSessionId: text('opencode_session_id'),
@@ -981,7 +986,7 @@ export const sessionSandboxes = kortixSchema.table(
     sessionId: text('session_id').notNull().unique(),
     accountId: uuid('account_id').notNull(),
     projectId: uuid('project_id').notNull(),
-    provider: sandboxProviderEnum('provider').default('daytona').notNull(),
+    provider: sandboxProviderEnum('provider').default('managed').notNull(),
     externalId: text('external_id'),
     baseUrl: text('base_url'),
     status: sessionSandboxStatusEnum('status').default('provisioning').notNull(),
@@ -1076,7 +1081,7 @@ export const sandboxTemplates = kortixSchema.table(
     /** Where the template came from: 'platform' | 'toml' | 'ui'. */
     source: text('source').default('toml').notNull(),
     /** 'daytona' (others to follow). */
-    provider: text('provider').default('daytona').notNull(),
+    provider: text('provider').default('managed').notNull(),
 
     // ─── Image definition (exactly one of image / dockerfilePath) ──────────
     /** Public Docker image reference (e.g. python:3.12-slim). */
@@ -1173,7 +1178,7 @@ export const sandboxes = kortixSchema.table(
     sandboxId: uuid('sandbox_id').defaultRandom().primaryKey(),
     accountId: uuid('account_id').notNull(),
     name: varchar('name', { length: 255 }).notNull(),
-    provider: sandboxProviderEnum('provider').default('daytona').notNull(),
+    provider: sandboxProviderEnum('provider').default('managed').notNull(),
     externalId: text('external_id'),
     status: sandboxStatusEnum('status').default('provisioning').notNull(),
     baseUrl: text('base_url').notNull(),

--- a/packages/sdk/src/platform/platform-client/lifecycle.test.ts
+++ b/packages/sdk/src/platform/platform-client/lifecycle.test.ts
@@ -181,9 +181,9 @@ function wireNoProjects() {
 
 // ─── getProviders ────────────────────────────────────────────────────────────
 
-test('getProviders is pure — no network, always daytona', async () => {
+test('getProviders is pure — no network, always managed', async () => {
   const result = await getProviders();
-  expect(result).toEqual({ providers: ['daytona'], default: 'daytona' });
+  expect(result).toEqual({ providers: ['managed'], default: 'managed' });
   expect(calls.length).toBe(0);
 });
 

--- a/packages/sdk/src/platform/platform-client/lifecycle.ts
+++ b/packages/sdk/src/platform/platform-client/lifecycle.ts
@@ -32,7 +32,7 @@ import {
  * Get available sandbox providers from the platform service.
  */
 export async function getProviders(): Promise<ProvidersInfo> {
-  return { providers: ['daytona'], default: 'daytona' };
+  return { providers: ['managed'], default: 'managed' };
 }
 
 /**

--- a/packages/sdk/src/platform/platform-client/shared.ts
+++ b/packages/sdk/src/platform/platform-client/shared.ts
@@ -104,7 +104,7 @@ export function projectSessionToSandboxInfo(
     sandbox_id: runtime?.sandbox_id || session.sandbox_id || session.session_id,
     external_id: externalId,
     name: session.name || `${project.name} session`,
-    provider: (runtime?.provider as SandboxProviderName | null) || (session.sandbox_provider as SandboxProviderName | null) || 'daytona',
+    provider: (runtime?.provider as SandboxProviderName | null) || (session.sandbox_provider as SandboxProviderName | null) || 'managed',
     base_url: runtime?.base_url || session.sandbox_url || (runtime?.external_id ? `${getPlatformUrl()}/p/${runtime.external_id}/${SANDBOX_PORTS.KORTIX_MASTER}` : ''),
     status: normalizeSessionStatus(runtime?.status || session.status),
     metadata: {

--- a/packages/sdk/src/platform/platform-client/types.ts
+++ b/packages/sdk/src/platform/platform-client/types.ts
@@ -21,7 +21,7 @@ export const SANDBOX_PORTS = {
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
-export type SandboxProviderName = 'daytona' | 'justavps';
+export type SandboxProviderName = 'managed' | 'daytona' | 'justavps';
 export type ServerTypeOption = string;
 
 export interface SandboxCreateProgress {

--- a/packages/sdk/src/platform/projects-client/session-sandbox.ts
+++ b/packages/sdk/src/platform/projects-client/session-sandbox.ts
@@ -22,7 +22,7 @@ export interface ProjectSessionSandbox {
   session_id: string;
   project_id: string;
   account_id: string;
-  provider: 'daytona' | 'platinum' | 'local_docker' | 'justavps';
+  provider: 'managed' | 'daytona' | 'platinum' | 'local_docker' | 'justavps';
   external_id: string | null;
   base_url: string | null;
   status: ProjectSessionSandboxStatus;


### PR DESCRIPTION
Renames the Kortix-facing sandbox provider **`daytona` → `managed`** (competitor name off our identifier). The backend is unchanged — still the same Daytona API under the hood; only the NAME changes. Prod runs on this, so it's built to survive a partial rollout.

### Backward-compat (why prod can't break)
- **Enum:** migration `ALTER TYPE kortix.sandbox_provider ADD VALUE IF NOT EXISTS 'managed'` (precedent-matched to how `platinum`/`channel` were added). `'daytona'` stays a **permanent valid alias** for the same backend. New rows write `'managed'`; existing `'daytona'` rows stay valid.
- **Dual-key reads:** `config.isManagedProviderName(p)` matches both; **both** provider registries (snapshots + platform `getProvider`) register/resolve **both** `'managed'` and `'daytona'` to the Daytona adapter; the 2 runtime comparisons (session-sandbox artifact type, builder reap branch) match both.
- **Input normalization:** `parseAllowedProviders` + `isProviderEnabled` map `'daytona'→'managed'`, so an external caller sending `provider:'daytona'` or `ALLOWED_SANDBOX_PROVIDERS=daytona` keeps working with **no env change**.
- **Migration is non-load-bearing for reads** (matcher handles old rows); no forced backfill. It must land before the code deploy (writes `'managed'`) — the pipeline applies migrations before API rollout, so ordering holds. Non-destructive + idempotent.
- **Env** `DAYTONA_*` unchanged and still required/used; internal config field names kept.
- Adapter self-identities (`daytonaProvider.id` / `DaytonaProvider.name`) **deliberately left `'daytona'`** — the legacy registry key that keeps old rows resolving.

### Scope: 17 files (+85/−39) — config, both registries, 4 write sites, 2 comparisons, SDK unions, admin dropdown label, enum + migration, tests updated.

### ⚠️ Verification note
Local `tsc` could **not** run in the worktree (broken `agent-tunnel@workspace` resolution → missing `@types/bun`, an env issue unrelated to the diff). The change is additive + type-checked by inspection (every exhaustive `switch` has a `'managed'` case; `'daytona'` kept in the type). **Please rely on CI's `API typecheck` + unit tests as the gate before merge.**

### Follow-ups (non-blocking)
`SET DEFAULT 'managed'` + backfill of existing `'daytona'` rows (both work via the matcher today); admin filter matching old `'daytona'` rows once backfilled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)