### PR TITLE
feat(sandbox): build-on-push warm prebake (warm on commit, not just session-start)

### DIFF
--- a/apps/api/src/git-proxy/index.ts
+++ b/apps/api/src/git-proxy/index.ts
@@ -32,6 +32,8 @@ import {
   scopeForService,
 } from './parse';
 import { makeOpenApiApp } from '../openapi';
+import { loadGitProject } from '../projects/lib/git';
+import { kickProjectWarmPrebake } from '../snapshots/builder';
 
 export const gitProxyApp = makeOpenApiApp();
 
@@ -124,6 +126,27 @@ async function forward(c: any, projectId: string, scope: GitScope, suffix: strin
   res.headers.forEach((value, key) => {
     if (!STRIP_RESPONSE_HEADERS.has(key.toLowerCase())) respHeaders.set(key, value);
   });
+
+  // Build-on-push warm prebake: a successful push (git-receive-pack) to the
+  // managed git may have advanced the project's default-branch tip. Kick a
+  // fire-and-forget per-project warm bake so the FIRST session on the new commit
+  // boots warm instead of cold ("starting agent…"). Never blocks or fails the
+  // push; kickProjectWarmPrebake resolves the current tip and is idempotent, so it
+  // no-ops unless the default-branch tip actually moved. The session-start
+  // on-demand trigger stays the fallback for projects that never push.
+  if (suffix === '/git-receive-pack' && res.status >= 200 && res.status < 300) {
+    void (async () => {
+      try {
+        const gitProject = await loadGitProject({ row: auth.project });
+        await kickProjectWarmPrebake(gitProject, { accountId: auth.project.accountId });
+      } catch (err) {
+        console.warn(
+          `[git-proxy] warm prebake-on-push skipped for ${projectId}:`,
+          err instanceof Error ? err.message : err,
+        );
+      }
+    })();
+  }
 
   return new Response(res.body, { status: res.status, headers: respHeaders });
 }

--- a/apps/api/src/snapshots/builder.ts
+++ b/apps/api/src/snapshots/builder.ts
@@ -714,6 +714,47 @@ function kickBackgroundWarmBuild(
 }
 
 /**
+ * Build-on-push warm prebake. Fire-and-forget: when a commit lands on a project's
+ * default branch (a successful push to the managed git), kick the per-project warm
+ * bake for the CURRENT tip so the FIRST session on the new commit boots warm —
+ * instead of waiting for a session to MISS and trigger the bake on demand (which
+ * leaves that first session cold). Reuses the exact resolve-tip + dedup path the
+ * session-start trigger uses: gated to the shared default, keyed on the
+ * default-branch tip, deduped by the target warm name. Idempotent — it no-ops when
+ * the default-branch tip is unchanged (the warm image for that tip is already
+ * active) or a bake for it is already in flight. Best-effort: never throws, never
+ * blocks the push; the session-start on-demand trigger remains the fallback.
+ */
+export async function kickProjectWarmPrebake(
+  project: GitBackedProject,
+  opts: { accountId?: string; provider?: string } = {},
+): Promise<void> {
+  try {
+    const template = await resolveTemplateBySlug(project, undefined);
+    if (!template.isShared) return; // same gate as the session-start warm trigger
+    const buildProvider = opts.provider ?? config.getDefaultProvider();
+    const provider = getSandboxProvider(buildProvider);
+    if (!provider.isConfigured()) return;
+    const identity = await computeTemplateIdentity(project, template);
+    const tip = await resolveCommitSha(project, project.defaultBranch);
+    if (!tip) return;
+    const warmName = perProjectWarmImageName(project.projectId, tip, identity.snapshotName);
+    // Tip unchanged (or already warm for this commit) → nothing to do.
+    if ((await provider.getSnapshotState(warmName)) === 'active') return;
+    kickBackgroundWarmBuild(project, { accountId: opts.accountId, provider: buildProvider, snapshotName: warmName });
+    console.log(
+      `[snapshots] warm prebake-on-push kicked: project ${project.projectId.slice(0, 8)} ` +
+      `tip ${tip.slice(0, 8)} (${buildProvider})`,
+    );
+  } catch (err) {
+    console.warn(
+      `[snapshots] warm prebake-on-push skipped for ${project.projectId}:`,
+      err instanceof Error ? err.message : err,
+    );
+  }
+}
+
+/**
  * Fire-and-forget pre-build. Used at project-create and CR-merge time so the
  * first session for a new commit can boot off a cache hit.
  */


### PR DESCRIPTION
Follow-up to the warm-bake work — mostly eliminates the "first session after a new commit is cold" problem (the slow "starting agent…").

**Problem:** the per-project warm image (`kortix-ppwarm-<proj8>-<tip>`) is baked ON DEMAND at session-start — a warm-MISS in `ensureSandboxImage` fires the background bake. So the FIRST session on a new commit boots cold (clone + agent init) while the image builds; only the *next* session gets it warm.

**Fix:** fire the same bake the moment a commit lands. On a successful push (`git-receive-pack`, 2xx) in `apps/api/src/git-proxy/index.ts`, kick a fire-and-forget `kickProjectWarmPrebake` (new, in `apps/api/src/snapshots/builder.ts`). It:
- resolves the CURRENT default-branch tip and reuses the exact resolve-tip + dedup path the session-start trigger uses (gated to the shared default, keyed on the tip, deduped by the warm name);
- is **idempotent** — no-ops when the tip is unchanged / already warm / a bake is already in flight;
- is **best-effort** — try/catch, never throws, never blocks or slows the push;
- prebakes on the project's default provider (`config.getDefaultProvider()`).

The session-start on-demand trigger stays the fallback for projects that never push.

**Caveat (honest):** shrinks the cold window, doesn't 100% eliminate it — a session opened within the ~1 min build window right after a commit is still cold once. Changes "every first session after a commit is cold" → "only if you open within the build window".

`tsc --noEmit` clean. The "tip advanced → build / tip unchanged → skip" decision reduces to `perProjectWarmImageName`'s content-addressing (already covered by `unit-ppwarm-reap.test.ts`) + `getSnapshotState` idempotency; the rest is best-effort glue, so no dedicated test (recommend the `no-tests-needed` label).

🤖 Generated with [Claude Code](https://claude.com/claude-code)