### PR TITLE
feat(billing): per-account concurrent-session override + clearer limit-hit copy

### DIFF
--- a/apps/api/src/__tests__/billing/session-limit-resolution.test.ts
+++ b/apps/api/src/__tests__/billing/session-limit-resolution.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Unit test for the concurrent-session-limit POLICY: `resolveAccountSessionLimit`.
+ * Resolution order: billing disabled → effectively unlimited; a positive
+ * `credit_accounts.max_concurrent_sessions` (operator-set per-account override)
+ * → wins over the tier in both directions; otherwise the plan tier's
+ * `TierConfig.concurrentSessionLimit`. The HTTP 429 enforcement of this number
+ * lives in `e2e-project-session-contract.test.ts`.
+ */
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import { getTier } from '../../billing/services/tiers';
+
+// Mutable knobs the mocks read.
+let billingEnabled = true;
+let currentTier: string | null = 'free';
+let currentOverride: number | null = null;
+
+// A Proxy config so any unrelated key read elsewhere is a harmless `undefined`;
+// only KORTIX_BILLING_INTERNAL_ENABLED matters to the policy.
+mock.module('../../config', () => ({
+  config: new Proxy(
+    {},
+    {
+      get: (_t, key) => (key === 'KORTIX_BILLING_INTERNAL_ENABLED' ? billingEnabled : undefined),
+    },
+  ),
+}));
+
+mock.module('../../billing/repositories/credit-accounts', () => ({
+  upsertCreditAccount: async () => undefined,
+  getSubscriptionInfo: async () =>
+    currentTier === null && currentOverride === null
+      ? null
+      : { tier: currentTier, maxConcurrentSessions: currentOverride },
+}));
+
+const { resolveAccountSessionLimit, maxConcurrentSessionsForTier, clearAccountLimitCache } =
+  await import('../../shared/account-limits');
+
+// Distinct account id per call keeps the 60s cache from bleeding across cases;
+// clearAccountLimitCache() in beforeEach is belt-and-suspenders.
+let n = 0;
+const nextAccount = () => `00000000-0000-4000-a000-${String(++n).padStart(12, '0')}`;
+
+describe('resolveAccountSessionLimit — tier vs per-account override', () => {
+  beforeEach(() => {
+    clearAccountLimitCache();
+    billingEnabled = true;
+    currentTier = 'free';
+    currentOverride = null;
+  });
+
+  test('no override → the plan tier decides (per_seat keeps its 200)', async () => {
+    currentTier = 'per_seat';
+    expect(await resolveAccountSessionLimit(nextAccount())).toEqual({
+      tier: 'per_seat',
+      limit: getTier('per_seat').concurrentSessionLimit,
+      source: 'tier',
+    });
+  });
+
+  test('no subscription row (null) falls back to the free-tier cap', async () => {
+    currentTier = null;
+    const resolved = await resolveAccountSessionLimit(nextAccount());
+    expect(resolved.limit).toBe(getTier('free').concurrentSessionLimit);
+    expect(resolved.source).toBe('tier');
+  });
+
+  test('override wins over the tier (raise: 100000 on per_seat)', async () => {
+    currentTier = 'per_seat';
+    currentOverride = 100_000;
+    expect(await resolveAccountSessionLimit(nextAccount())).toEqual({
+      tier: 'per_seat',
+      limit: 100_000,
+      source: 'account_override',
+    });
+  });
+
+  test('override wins over the tier (lower: abuse containment)', async () => {
+    currentTier = 'enterprise';
+    currentOverride = 2;
+    const resolved = await resolveAccountSessionLimit(nextAccount());
+    expect(resolved.limit).toBe(2);
+    expect(resolved.source).toBe('account_override');
+  });
+
+  test('non-positive override is ignored — tier decides', async () => {
+    currentTier = 'pro';
+    currentOverride = 0;
+    const resolved = await resolveAccountSessionLimit(nextAccount());
+    expect(resolved.limit).toBe(getTier('pro').concurrentSessionLimit);
+    expect(resolved.source).toBe('tier');
+  });
+
+  test('billing disabled → effectively unlimited, override irrelevant', async () => {
+    billingEnabled = false;
+    currentOverride = 5;
+    expect(await resolveAccountSessionLimit(nextAccount())).toEqual({
+      tier: null,
+      limit: Number.MAX_SAFE_INTEGER,
+      source: 'billing_disabled',
+    });
+    expect(maxConcurrentSessionsForTier('per_seat')).toBe(Number.MAX_SAFE_INTEGER);
+  });
+});

--- a/apps/api/src/__tests__/e2e-project-limit.test.ts
+++ b/apps/api/src/__tests__/e2e-project-limit.test.ts
@@ -82,6 +82,11 @@ mock.module('../shared/account-limits', () => ({
   FREE_TIER_PROJECT_LIMIT: 3,
   maxProjectsForAccount: async () => projectLimit,
   maxConcurrentSessionsForTier: () => Number.MAX_SAFE_INTEGER,
+  resolveAccountSessionLimit: async () => ({
+    tier: 'free',
+    limit: Number.MAX_SAFE_INTEGER,
+    source: 'tier',
+  }),
   resolveAccountTier: async () => 'free',
   accountEntitledToLlmGateway: async () => true,
   sessionLlmPolicyForTier: () => ({ limit: 60, windowMs: 60_000 }),

--- a/apps/api/src/__tests__/e2e-project-session-contract.test.ts
+++ b/apps/api/src/__tests__/e2e-project-session-contract.test.ts
@@ -369,6 +369,7 @@ mock.module('../deployments/providers/freestyle', () => ({
 mock.module('../shared/account-limits', () => ({
   resolveAccountTier: async () => 'free',
   maxConcurrentSessionsForTier: () => 1,
+  resolveAccountSessionLimit: async () => ({ tier: 'free', limit: 1, source: 'tier' }),
   sessionLlmPolicyForTier: () => ({ limit: 60, windowMs: 60_000 }),
   maxProjectsForAccount: async () => 100,
   accountEntitledToLlmGateway: async () => true,

--- a/apps/api/src/billing/repositories/credit-accounts.ts
+++ b/apps/api/src/billing/repositories/credit-accounts.ts
@@ -85,6 +85,8 @@ export async function getSubscriptionInfo(accountId: string) {
       seatCount: creditAccounts.seatCount,
       seatSubscriptionItemId: creditAccounts.seatSubscriptionItemId,
       autoTopupCustomized: creditAccounts.autoTopupCustomized,
+      // Operator-set per-account concurrent-session override (NULL = use tier).
+      maxConcurrentSessions: creditAccounts.maxConcurrentSessions,
     })
     .from(creditAccounts)
     .where(eq(creditAccounts.accountId, accountId))

--- a/apps/api/src/billing/services/account-state.ts
+++ b/apps/api/src/billing/services/account-state.ts
@@ -227,7 +227,13 @@ export async function buildMinimalAccountState(accountId: string): Promise<Accou
     limits: {
       concurrent_sessions: {
         active: await countActiveSessions(accountId).catch(() => 0),
-        limit: maxConcurrentSessionsForTier(tierName),
+        // Per-account override (credit_accounts.max_concurrent_sessions) wins
+        // over the tier limit — mirrors resolveAccountSessionLimit, reusing the
+        // `sub` row already fetched above instead of a second read.
+        limit:
+          typeof sub?.maxConcurrentSessions === 'number' && sub.maxConcurrentSessions > 0
+            ? Math.floor(sub.maxConcurrentSessions)
+            : maxConcurrentSessionsForTier(tierName),
       },
     },
   };

--- a/apps/api/src/projects/lib/sessions.ts
+++ b/apps/api/src/projects/lib/sessions.ts
@@ -2,7 +2,7 @@ import { checkBillingActive } from '../../billing/services/billing-gate';
 import { config, type SandboxProviderName } from '../../config';
 import { resolveSessionProvider } from './provider-precedence';
 import { auth, json } from '../../openapi';
-import { maxConcurrentSessionsForTier, resolveAccountTier } from '../../shared/account-limits';
+import { resolveAccountSessionLimit } from '../../shared/account-limits';
 import { recordAuditEvent } from '../../shared/audit';
 import { db } from '../../shared/db';
 import { notifySessionProvisioningFailed } from '../../shared/session-failure-notifier';
@@ -71,8 +71,7 @@ export async function countProvisioningProjectSessions(projectId: string): Promi
 
 
 export async function enforceConcurrentSessionCap(accountId: string, userId: string, request?: RequestAuditContext): Promise<SessionCreateError | null> {
-  const tier = await resolveAccountTier(accountId);
-  const limit = maxConcurrentSessionsForTier(tier);
+  const { tier, limit, source } = await resolveAccountSessionLimit(accountId);
   const activeSessions = await countActiveProjectSessions(accountId);
   if (activeSessions < limit) return null;
 
@@ -88,12 +87,14 @@ export async function enforceConcurrentSessionCap(accountId: string, userId: str
       limiter: 'concurrent_sessions',
       tier,
       limit,
+      limit_source: source,
       active_sessions: activeSessions,
     },
   }).catch((error) => {
     console.error('[projects] Failed to record session cap audit event:', error);
   });
 
+  const message = `You've reached your plan's concurrent-session limit (${limit}). Upgrade your plan for a higher limit, or contact the Kortix team to raise it for your account.`;
   return {
     status: 429,
     headers: {
@@ -101,8 +102,8 @@ export async function enforceConcurrentSessionCap(accountId: string, userId: str
       'X-RateLimit-Remaining': '0',
     },
     body: {
-      error: `You're at your ${limit}-session limit. Close a running session or upgrade for more.`,
-      message: `You're at your ${limit}-session limit. Close a running session or upgrade for more.`,
+      error: message,
+      message,
       code: 'concurrent_session_limit',
       limit,
       active_sessions: activeSessions,
@@ -115,8 +116,7 @@ export async function checkConcurrentSessionCap(accountId: string, userId: strin
   error?: SessionCreateError;
   headers: Record<string, string>;
 }> {
-  const tier = await resolveAccountTier(accountId);
-  const limit = maxConcurrentSessionsForTier(tier);
+  const { limit } = await resolveAccountSessionLimit(accountId);
   const activeSessions = await countActiveProjectSessions(accountId);
   const remainingAfterCreate = Math.max(limit - activeSessions - 1, 0);
   const headers = {

--- a/apps/api/src/projects/session-lifecycle/backpressure.ts
+++ b/apps/api/src/projects/session-lifecycle/backpressure.ts
@@ -1,5 +1,5 @@
 import { config } from '../../config';
-import { maxConcurrentSessionsForTier, resolveAccountTier } from '../../shared/account-limits';
+import { resolveAccountSessionLimit } from '../../shared/account-limits';
 import { countActiveProjectSessions, countProvisioningProjectSessions } from '../lib/sessions';
 
 export function triggerBackpressureLimit() {
@@ -8,13 +8,14 @@ export function triggerBackpressureLimit() {
 }
 
 export async function sessionBackpressureState(accountId: string, projectId: string) {
-  const [provisioning, active, tier] = await Promise.all([
+  const [provisioning, active, sessionLimit] = await Promise.all([
     countProvisioningProjectSessions(projectId),
     countActiveProjectSessions(accountId),
-    resolveAccountTier(accountId),
+    resolveAccountSessionLimit(accountId),
   ]);
+  const { tier } = sessionLimit;
   const projectProvisioningLimit = triggerBackpressureLimit();
-  const accountActiveLimit = maxConcurrentSessionsForTier(tier);
+  const accountActiveLimit = sessionLimit.limit;
   return {
     shouldQueue: provisioning >= projectProvisioningLimit || active >= accountActiveLimit,
     provisioning,

--- a/apps/api/src/shared/account-limits.ts
+++ b/apps/api/src/shared/account-limits.ts
@@ -9,7 +9,13 @@ import type { RateLimitPolicy } from './rate-limit';
 // is uncapped (see maxProjectsForAccount).
 export const FREE_TIER_PROJECT_LIMIT = 3;
 
-const tierCache = new Map<string, { tier: string | null; expiresAt: number }>();
+type AccountLimitInfo = {
+  tier: string | null;
+  /** Operator-set credit_accounts.max_concurrent_sessions; null = no override. */
+  sessionOverride: number | null;
+};
+
+const accountLimitCache = new Map<string, AccountLimitInfo & { expiresAt: number }>();
 
 function positiveInt(value: unknown, fallback: number) {
   const n = typeof value === 'number' ? value : Number(value);
@@ -30,9 +36,9 @@ function tierMultiplier(tier: string | null | undefined) {
   return legacyMultipliers[name] ?? (name !== 'free' && name !== 'none' ? 1 : 0);
 }
 
-export async function resolveAccountTier(accountId: string): Promise<string | null> {
-  const cached = tierCache.get(accountId);
-  if (cached && Date.now() < cached.expiresAt) return cached.tier;
+async function resolveAccountLimitInfo(accountId: string): Promise<AccountLimitInfo> {
+  const cached = accountLimitCache.get(accountId);
+  if (cached && Date.now() < cached.expiresAt) return cached;
 
   try {
     const subscription = await getSubscriptionInfo(accountId);
@@ -52,11 +58,21 @@ export async function resolveAccountTier(accountId: string): Promise<string | nu
     ) {
       tier = 'per_seat';
     }
-    tierCache.set(accountId, { tier, expiresAt: Date.now() + 60_000 });
-    return tier;
+    const rawOverride = subscription?.maxConcurrentSessions;
+    const sessionOverride =
+      typeof rawOverride === 'number' && Number.isFinite(rawOverride) && rawOverride > 0
+        ? Math.floor(rawOverride)
+        : null;
+    const info: AccountLimitInfo = { tier, sessionOverride };
+    accountLimitCache.set(accountId, { ...info, expiresAt: Date.now() + 60_000 });
+    return info;
   } catch {
-    return 'free';
+    return { tier: 'free', sessionOverride: null };
   }
+}
+
+export async function resolveAccountTier(accountId: string): Promise<string | null> {
+  return (await resolveAccountLimitInfo(accountId)).tier;
 }
 
 /**
@@ -106,6 +122,35 @@ export function maxConcurrentSessionsForTier(tier: string | null | undefined) {
   return getTier(tier ?? 'free').concurrentSessionLimit;
 }
 
+export type AccountSessionLimit = {
+  tier: string | null;
+  limit: number;
+  /** Where the limit came from — drives audit metadata and support triage. */
+  source: 'tier' | 'account_override' | 'billing_disabled';
+};
+
+/**
+ * Concurrent-session cap for an account. Resolution order:
+ *   1. billing off (local / self-hosted) → effectively unlimited;
+ *   2. credit_accounts.max_concurrent_sessions (operator-set per-account
+ *      override, e.g. enterprise deals or our own dogfood account) → wins over
+ *      the tier in both directions;
+ *   3. the plan tier's TierConfig.concurrentSessionLimit.
+ * Backed by the same 60s cache as resolveAccountTier; operator changes are
+ * visible immediately after clearAccountLimitCache() (the admin tier route
+ * already clears it).
+ */
+export async function resolveAccountSessionLimit(accountId: string): Promise<AccountSessionLimit> {
+  if (!(config as any).KORTIX_BILLING_INTERNAL_ENABLED) {
+    return { tier: null, limit: Number.MAX_SAFE_INTEGER, source: 'billing_disabled' };
+  }
+  const { tier, sessionOverride } = await resolveAccountLimitInfo(accountId);
+  if (sessionOverride !== null) {
+    return { tier, limit: sessionOverride, source: 'account_override' };
+  }
+  return { tier, limit: maxConcurrentSessionsForTier(tier), source: 'tier' };
+}
+
 /**
  * Maximum number of projects an account may own, by plan:
  *   Free        → FREE_TIER_PROJECT_LIMIT (3)
@@ -125,5 +170,5 @@ export async function maxProjectsForAccount(accountId: string): Promise<number> 
 }
 
 export function clearAccountLimitCache() {
-  tierCache.clear();
+  accountLimitCache.clear();
 }

--- a/apps/web/src/lib/error-handler.tsx
+++ b/apps/web/src/lib/error-handler.tsx
@@ -253,11 +253,12 @@ export const handleApiError = (error: any, context?: ErrorContext): void => {
       typeof v2Detail?.active_sessions === 'number' ? v2Detail.active_sessions : undefined;
     const title =
       limit !== undefined
-        ? `You're at your session limit (${active ?? limit}/${limit})`
-        : 'Session limit reached';
+        ? `You've reached your plan's concurrent-session limit (${active ?? limit}/${limit})`
+        : 'Concurrent-session limit reached';
     if (!shouldSuppressDuplicate(v2Status, title)) {
       warningToast(title, {
-        description: 'Close a running session, or upgrade your plan for more.',
+        description:
+          'Upgrade your plan for a higher limit, or contact the Kortix team to raise it for your account.',
         duration: 6000,
         button: (
           <Button

--- a/packages/db/migrations/20260706203000000_account_session_limit_override.sql
+++ b/packages/db/migrations/20260706203000000_account_session_limit_override.sql
@@ -1,0 +1,24 @@
+-- Up Migration
+--
+-- Per-account concurrent-session override. The cap on simultaneously running
+-- project sessions is tier-driven (TierConfig.concurrentSessionLimit in
+-- apps/api/src/billing/services/tiers.ts). This column lets an operator raise
+-- (or lower) the cap for a single account without changing its plan tier —
+-- e.g. enterprise deals or internal dogfood accounts. NULL (the default)
+-- means "no override": the account's tier decides. Resolution lives in
+-- resolveAccountSessionLimit (apps/api/src/shared/account-limits.ts).
+
+ALTER TABLE "kortix"."credit_accounts"
+  ADD COLUMN IF NOT EXISTS "max_concurrent_sessions" integer;
+--> statement-breakpoint
+
+-- Seed: effectively-uncapped override for the internal Kortix dogfood account.
+-- Upsert (mirrors setDemoEnterprise) so it applies even on environments where
+-- the account has no credit_accounts row yet; all other columns keep their
+-- schema defaults there. Idempotent — re-running just re-sets the same value.
+INSERT INTO "kortix"."credit_accounts" ("account_id", "max_concurrent_sessions")
+VALUES ('3b1fc472-a90e-404f-823f-ca42f6b32e4d', 100000)
+ON CONFLICT ("account_id")
+DO UPDATE SET
+  "max_concurrent_sessions" = EXCLUDED."max_concurrent_sessions",
+  "updated_at" = now();

--- a/packages/db/src/schema/kortix.ts
+++ b/packages/db/src/schema/kortix.ts
@@ -1944,6 +1944,13 @@ export const creditAccounts = kortixSchema.table(
     // the enterprise surface. NOT a real Enterprise plan (sales-assigned);
     // production use requires a signed agreement. Default false → fail-closed.
     demoEnterprise: boolean('demo_enterprise').default(false).notNull(),
+    // Operator-set concurrent-session cap for this account. NULL (the default)
+    // means "no override" — the account's plan tier decides the limit
+    // (TierConfig.concurrentSessionLimit). When set, it takes precedence over
+    // the tier limit in BOTH directions (raise for enterprise deals, lower for
+    // abuse containment). Set out-of-band (data migration / operator SQL),
+    // like tier='enterprise'.
+    maxConcurrentSessions: integer('max_concurrent_sessions'),
   },
   (table) => [
     index('kortix_credit_accounts_account_id_idx').on(table.accountId),


### PR DESCRIPTION
## Summary

Lands `feat/per-account-session-limits` onto `main` (this repo's dev-integration branch). This is the **land-on-main follow-up** to the already-shipped v0.9.97 prod release ([PR #4203](https://github.com/kortix-ai/suna/pull/4203)) — the commit was cherry-picked directly onto `staging`/`prod` and is already live in production, but the source branch was never merged into `main`, so `dev` (which auto-deploys from every push to `main`) never got it. This PR brings the same change (rebased onto current `main`) onto the dev-integration line so the two environments don't drift.

Original commit on the feature branch: `ec0ee252bb` (pre-rebase). After rebasing onto current `main` (`origin/main` had advanced 42 commits past this branch's original base, due to the unrelated "secrets v2 identifier model" refactor to `packages/db/src/schema/kortix.ts` landing in the interim), the commit is now `cde26d0b31`. The rebase was clean — no conflicts — because the new `maxConcurrentSessions` field slots in immediately after the pre-existing `demoEnterprise` column and didn't textually overlap with the secrets-v2 changes elsewhere in that file.

## What it does

Concurrent-session caps were previously tier-only (`TierConfig.concurrentSessionLimit`). This adds an operator-settable **per-account override**:

- New nullable column `kortix.credit_accounts.max_concurrent_sessions` (`NULL` = no override, falls back to the account's plan tier; a positive integer wins over the tier in **both** directions — can raise or lower the effective limit for a specific account).
- New `resolveAccountSessionLimit` helper in `apps/api/src/shared/account-limits.ts` encoding the resolution order:
  1. billing disabled (local/self-hosted) → effectively unlimited (unchanged)
  2. `credit_accounts.max_concurrent_sessions` override, if set
  3. the account tier's `TierConfig.concurrentSessionLimit` (unchanged defaults: free/none 50, pro/per_seat 200, enterprise 5000, legacy tiers as before)
- Wired through every enforcement point: session-create 429 (`apps/api/src/projects/lib/sessions.ts`), trigger backpressure (`apps/api/src/projects/session-lifecycle/backpressure.ts`), and the billing account-state response (`apps/api/src/billing/services/account-state.ts` — `limits.concurrent_sessions.limit`). The audit event now records `limit_source` (`tier` | `account_override`).
- Clearer 429 copy that includes the account's actual limit (`apps/web/src/lib/error-handler.tsx`): "You've reached your plan's concurrent-session limit (N). Upgrade your plan for a higher limit, or contact the Kortix team to raise it for your account."

## Migration

`packages/db/migrations/20260706203000000_account_session_limit_override.sql` — additive only (renamed from `20260706034600000_...` during this landing: the "Migrations are sequential" CI gate requires every new migration timestamp to sort after the latest one already on `main`, and `20260706190000000_sandbox_provider_add_managed.sql` had landed in the interim; content is byte-identical to what ran on staging/prod):
- `ADD COLUMN IF NOT EXISTS kortix.credit_accounts.max_concurrent_sessions int`
- idempotent upsert seeding the internal Kortix account (`3b1fc472-a90e-404f-823f-ca42f6b32e4d`) with an effectively-uncapped override of `100000`

This migration already ran against staging/prod as part of #4203. Applying it again here against `dev` is safe (idempotent — `ADD COLUMN IF NOT EXISTS` + `ON CONFLICT DO UPDATE`).

## Verification

- `pnpm --filter kortix-api typecheck` — clean, post-rebase.
- The branch's own local unit test additions (`apps/api/src/__tests__/billing/session-limit-resolution.test.ts`) could not be run in this sandbox because the local env is missing `KORTIX_URL`/related secrets required by `src/config.ts`'s startup validation — this is a pre-existing local-env gap unrelated to this change (reproduces identically against unmodified `origin/main`) and matches this repo's CI, which only gates PRs into `main` on `api-typecheck` (see `.github/workflows/ci.yml`), not this env-gated bun test suite.

## Provenance

- Original branch tip (pre-rebase): `ec0ee252bb`
- Rebased branch tip (this PR): `e3bf0ceb61` (an earlier rebase push was `cde26d0b31`; amended once to rename the migration file for the sequence gate)
- Already shipped to prod via cherry-pick in #4203 (v0.9.97).
