### PR TITLE
fix(sessions): close the delete-mid-provision resurrection race

### DIFF
--- a/apps/api/src/__tests__/e2e-stuck-session-reconcile.test.ts
+++ b/apps/api/src/__tests__/e2e-stuck-session-reconcile.test.ts
@@ -35,6 +35,7 @@ const ACCOUNT_ID = '00000000-0000-4000-a000-000000009301';
 const PROJECT_ID = '00000000-0000-4000-a000-000000009302';
 const SANDBOX_STOPPED = '00000000-0000-4000-a000-000000009303';
 const SANDBOX_ACTIVE = '00000000-0000-4000-a000-000000009304';
+const SANDBOX_ACTIVE_DELETED = '00000000-0000-4000-a000-000000009305';
 
 // Sessions covering the full decision matrix. *_STUCK should be reconciled to
 // 'stopped'; *_KEEP should be left exactly as seeded.
@@ -44,9 +45,17 @@ const S_ACTIVE_BOX_KEEP = 'keep-active-box';
 const S_RECENT_USAGE_KEEP = 'keep-recent-usage';
 const S_INFLIGHT_TURN_KEEP = 'keep-inflight-turn';
 const S_WITHIN_TTL_KEEP = 'keep-within-ttl';
+// Session-resurrection backstop: metadata.deletedAt is set (the user deleted
+// it) but it still has a LIVE session_sandboxes row behind it — e.g. the
+// provision-finish race resurrected it to 'running' before the row-level
+// guard in session-sandbox.ts landed, or any other path that leaves a
+// deleted session pointing at a live box. This must be reaped even though an
+// active box would normally exclude it (that's the provider reaper's job).
+const S_DELETED_ACTIVE_BOX_STUCK = 'stuck-deleted-active-box';
 const ALL_SESSIONS = [
   S_NO_BOX_STUCK, S_STOPPED_BOX_STUCK, S_ACTIVE_BOX_KEEP,
   S_RECENT_USAGE_KEEP, S_INFLIGHT_TURN_KEEP, S_WITHIN_TTL_KEEP,
+  S_DELETED_ACTIVE_BOX_STUCK,
 ];
 
 let testDb: Database | null = null;
@@ -62,7 +71,7 @@ async function cleanup() {
   const d = db();
   await d.delete(usageEvents).where(inArray(usageEvents.sessionId, ALL_SESSIONS));
   await d.delete(chatTurnStreams).where(inArray(chatTurnStreams.sessionId, ALL_SESSIONS));
-  await d.delete(sessionSandboxes).where(inArray(sessionSandboxes.sandboxId, [SANDBOX_STOPPED, SANDBOX_ACTIVE]));
+  await d.delete(sessionSandboxes).where(inArray(sessionSandboxes.sandboxId, [SANDBOX_STOPPED, SANDBOX_ACTIVE, SANDBOX_ACTIVE_DELETED]));
   await d.delete(projectSessions).where(inArray(projectSessions.sessionId, ALL_SESSIONS));
   await d.delete(projects).where(eq(projects.projectId, PROJECT_ID));
   await d.delete(accounts).where(eq(accounts.accountId, ACCOUNT_ID));
@@ -88,13 +97,20 @@ async function seed(now: Date) {
     sess(S_RECENT_USAGE_KEEP, 'running', old),
     sess(S_INFLIGHT_TURN_KEEP, 'running', old),
     sess(S_WITHIN_TTL_KEEP, 'provisioning', now), // fresh → within TTL
+    {
+      ...sess(S_DELETED_ACTIVE_BOX_STUCK, 'running', old),
+      metadata: { deletedAt: old.toISOString(), deletedBy: 'user-1' },
+    },
   ]);
 
   // A stopped box behind one stuck session (must NOT keep it alive); an ACTIVE
-  // box behind the keep session (the provider reaper owns that one).
+  // box behind the keep session (the provider reaper owns that one); an ACTIVE
+  // box behind the deleted-but-resurrected session (must NOT keep it alive —
+  // metadata.deletedAt overrides the active-sandbox-row exclusion).
   await d.insert(sessionSandboxes).values([
     { sandboxId: SANDBOX_STOPPED, sessionId: S_STOPPED_BOX_STUCK, accountId: ACCOUNT_ID, projectId: PROJECT_ID, status: 'stopped', externalId: 'ext-stopped' },
     { sandboxId: SANDBOX_ACTIVE, sessionId: S_ACTIVE_BOX_KEEP, accountId: ACCOUNT_ID, projectId: PROJECT_ID, status: 'active', externalId: 'ext-active' },
+    { sandboxId: SANDBOX_ACTIVE_DELETED, sessionId: S_DELETED_ACTIVE_BOX_STUCK, accountId: ACCOUNT_ID, projectId: PROJECT_ID, status: 'active', externalId: 'ext-active-deleted' },
   ]);
 
   // Recent LLM usage → meaningful activity within the TTL window.
@@ -127,6 +143,9 @@ describeWithDb('reconcileStuckActiveSessions (real DB)', () => {
     // Both genuinely-stuck sessions reconciled to 'stopped'.
     expect(await statusOf(S_NO_BOX_STUCK)).toBe('stopped');
     expect(await statusOf(S_STOPPED_BOX_STUCK)).toBe('stopped');
+    // Deleted-but-resurrected session: metadata.deletedAt bypasses the
+    // active-sandbox-row exclusion, so it's reaped too.
+    expect(await statusOf(S_DELETED_ACTIVE_BOX_STUCK)).toBe('stopped');
 
     // Everything with a live box / recent activity / in-flight turn / within TTL
     // is untouched.
@@ -135,8 +154,8 @@ describeWithDb('reconcileStuckActiveSessions (real DB)', () => {
     expect(await statusOf(S_INFLIGHT_TURN_KEEP)).toBe('running');
     expect(await statusOf(S_WITHIN_TTL_KEEP)).toBe('provisioning');
 
-    // Reported exactly the two it changed.
-    expect(result.reconciled).toBe(2);
+    // Reported exactly the three it changed.
+    expect(result.reconciled).toBe(3);
     expect(result.errors).toBe(0);
   });
 

--- a/apps/api/src/platform/services/session-sandbox.test.ts
+++ b/apps/api/src/platform/services/session-sandbox.test.ts
@@ -1,0 +1,305 @@
+// Unit test for the session-resurrection race fix in provisionSessionSandbox.
+//
+// Background: provisioning runs in a detached (fire-and-forget) IIFE. Before
+// this fix, the finish-of-provisioning writes were unconditional: if a user
+// deleted the session while the box was still being created, deleteSession()
+// would flip session_sandboxes to 'archived' and project_sessions to
+// 'stopped' — but the still-running provisioning IIFE would later land its
+// "success" writes anyway, flipping project_sessions BACK to 'running' and
+// opening a compute-metering row for a session the user just deleted.
+//
+// The fix makes both finish-of-provisioning writes conditional:
+//   1. session_sandboxes finish update: WHERE status != 'archived' RETURNING.
+//      No row back → the session was deleted mid-provision: remove the
+//      just-created provider box and stop (no flip, no metering).
+//   2. project_sessions status flip: WHERE status IN (queued, branching,
+//      provisioning) — never clobbers a 'stopped' (deleted, or explicitly
+//      stopped) or already-'running' (won by the separate stopped→running
+//      resume path in routes/shared.ts) session.
+//
+// This test drives the REAL provisionSessionSandbox with every external
+// dependency mocked (provider, snapshot builder, token minting, billing,
+// LLM-gateway entitlement) so it can run fully offline, deterministic, and
+// fast. The DB is a lightweight fake that records every update() call and
+// compiles its WHERE condition to real SQL text via drizzle's PgDialect (no
+// live Postgres needed) so the test asserts on the actual guard clauses, not
+// just on the mock's own bookkeeping.
+//
+// Run this file in its own `bun test <file>` invocation (as CI does per
+// file). `provisionSessionSandbox` and its dependencies (providers, billing,
+// snapshot builder) are heavily mocked here; other suites mock the SAME
+// resolved modules with different shapes (or exercise the real ones), and
+// `bun:test`'s `mock.module` + ES module cache are process-global rather than
+// file-scoped — batching many files into one `bun test a b c...` invocation
+// can leak mocks/cached module instances across files. See the same caveat
+// documented in ../../projects/sandbox-reaper.test.ts.
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import { projectSessions, sessionSandboxes } from '@kortix/db';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import { PROVISIONING_SESSION_STATUSES } from '../../projects/lib/session-status';
+
+const dialect = new PgDialect();
+
+const SANDBOX_ID = '00000000-0000-4000-a000-00000000a001';
+const ACCOUNT_ID = '00000000-0000-4000-a000-00000000a002';
+const PROJECT_ID = '00000000-0000-4000-a000-00000000a003';
+const USER_ID = '00000000-0000-4000-a000-00000000a004';
+const EXTERNAL_ID = 'ext-daytona-1';
+
+// ── mutable test state, reset in beforeEach ─────────────────────────────────
+let updateCalls: Array<{
+  table: unknown;
+  updates: Record<string, unknown>;
+  sql: string;
+  params: unknown[];
+}> = [];
+let scenario: { archiveBeforeFinish: boolean; projectSessionStatusAtCheck: string } = {
+  archiveBeforeFinish: false,
+  projectSessionStatusAtCheck: 'provisioning',
+};
+let removedIds: string[] = [];
+let onRemoved: (() => void) | null = null;
+let computeSessionsOpened: Array<{ sandboxId: string; accountId: string }> = [];
+let onComputeOpened: (() => void) | null = null;
+let recordedEvents: Array<{ outcome: string }> = [];
+
+function compile(condition: unknown): { sql: string; params: unknown[] } {
+  try {
+    return dialect.sqlToQuery(condition as Parameters<typeof dialect.sqlToQuery>[0]);
+  } catch {
+    return { sql: '', params: [] };
+  }
+}
+
+// A resolved Promise with `.returning()` bolted on so it satisfies both the
+// plain-await + `.catch()` call sites and the `.returning()` call sites drizzle
+// query builders support.
+function updateResult(rows: unknown[]) {
+  const p = Promise.resolve(undefined) as Promise<undefined> & {
+    returning: () => Promise<unknown[]>;
+  };
+  p.returning = async () => rows;
+  return p;
+}
+
+mock.module('../../config', () => ({
+  config: {
+    ALLOWED_SANDBOX_PROVIDERS: ['daytona'],
+    KORTIX_URL: 'http://localhost:8008',
+    LLM_GATEWAY_PROXY_PORT: undefined,
+    LLM_GATEWAY_PROXY_TARGET: undefined,
+    LLM_GATEWAY_BASE_URL: undefined,
+  },
+}));
+
+mock.module('../../shared/db', () => ({
+  db: {
+    insert: (table: unknown) => ({
+      values: (v: Record<string, unknown>) => ({
+        returning: async () => [{ ...v }],
+      }),
+    }),
+    select: (_proj: unknown) => ({
+      from: (table: unknown) => ({
+        where: (_cond: unknown) => ({
+          limit: async (_n: number) => {
+            if (table === projectSessions) {
+              return [{ status: scenario.projectSessionStatusAtCheck }];
+            }
+            return [];
+          },
+        }),
+      }),
+    }),
+    update: (table: unknown) => ({
+      set: (updates: Record<string, unknown>) => ({
+        where: (condition: unknown) => {
+          const { sql, params } = compile(condition);
+          updateCalls.push({ table, updates, sql, params });
+          const isSessionSandboxesFinish =
+            table === sessionSandboxes && 'externalId' in updates && 'config' in updates;
+          if (isSessionSandboxesFinish) {
+            return updateResult(scenario.archiveBeforeFinish ? [] : [{ sandboxId: SANDBOX_ID }]);
+          }
+          return updateResult([{ ok: true }]);
+        },
+      }),
+    }),
+  },
+}));
+
+mock.module('../providers', () => ({
+  getProvider: (_name: string) => ({
+    provisioning: { async: true, stages: [{ id: 'boot', progress: 50, message: 'Booting…' }] },
+    create: async (_opts: unknown) => ({
+      externalId: EXTERNAL_ID,
+      baseUrl: 'https://sandbox.test',
+      metadata: {},
+    }),
+    remove: async (externalId: string) => {
+      removedIds.push(externalId);
+      onRemoved?.();
+    },
+    start: async () => {},
+    stop: async () => {},
+    getStatus: async () => 'running',
+    resolveEndpoint: async () => ({ url: '', headers: {} }),
+    resolveProxyEndpoint: async () => ({ url: '', headers: {} }),
+  }),
+  WarmRuntimeUnavailableError: class WarmRuntimeUnavailableError extends Error {},
+}));
+
+mock.module('../../snapshots/builder', () => ({
+  DEFAULT_SANDBOX_SLUG: 'default',
+  ensureSandboxImage: async (_gitProject: unknown, _opts: unknown) => ({
+    snapshotName: 'snap-test-1',
+    slug: 'default',
+    contentHash: 'hash-1',
+    isDefault: true,
+    built: false,
+  }),
+  deleteSandboxImage: async () => {},
+  resolveTemplate: async (_project: unknown, _slug: unknown) => ({}),
+}));
+
+let onProviderEvent: (() => void) | null = null;
+mock.module('./provider-events', () => ({
+  recordProviderEvent: (e: { outcome: string }) => {
+    recordedEvents.push(e);
+    onProviderEvent?.();
+  },
+}));
+
+mock.module('../../billing/services/compute-metering', () => ({
+  startComputeSession: async (input: { sandboxId: string; accountId: string }) => {
+    computeSessionsOpened.push(input);
+    onComputeOpened?.();
+  },
+}));
+
+mock.module('../../repositories/api-keys', () => ({
+  createApiKey: async (_opts: unknown) => ({ secretKey: 'sbx-key-1' }),
+}));
+
+mock.module('../../repositories/account-tokens', () => ({
+  createAccountToken: async (_opts: unknown) => ({ secretKey: 'exec-tok-1' }),
+}));
+
+mock.module('../../repositories/service-accounts', () => ({
+  ensureAgentServiceAccount: async (_opts: unknown) => null,
+}));
+
+mock.module('../../shared/account-limits', () => ({
+  accountEntitledToLlmGateway: async (_accountId: string) => false,
+}));
+
+mock.module('../../projects/triggers', () => ({
+  readManifest: async () => null,
+}));
+
+mock.module('../../projects/agents', () => ({
+  resolveAgentGrant: async (_agentName: string, _gitProject: unknown) => null,
+}));
+
+mock.module('../../llm-gateway/enablement', () => ({
+  projectLlmGatewayEnabled: (_metadata: unknown) => false,
+}));
+
+const { provisionSessionSandbox } = await import('./session-sandbox');
+
+function waitFor(setResolver: (resolve: () => void) => void, timeoutMs = 2000): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('waitFor timed out')), timeoutMs);
+    setResolver(() => {
+      clearTimeout(timer);
+      resolve();
+    });
+  });
+}
+
+beforeEach(() => {
+  updateCalls = [];
+  scenario = { archiveBeforeFinish: false, projectSessionStatusAtCheck: 'provisioning' };
+  removedIds = [];
+  onRemoved = null;
+  computeSessionsOpened = [];
+  onComputeOpened = null;
+  recordedEvents = [];
+  onProviderEvent = null;
+});
+
+function baseOpts() {
+  return {
+    sandboxId: SANDBOX_ID,
+    accountId: ACCOUNT_ID,
+    projectId: PROJECT_ID,
+    userId: USER_ID,
+    provider: 'daytona' as const,
+    gitProject: { defaultBranch: 'main' } as unknown as Parameters<
+      typeof provisionSessionSandbox
+    >[0]['gitProject'],
+    metadata: {},
+  };
+}
+
+describe('provisionSessionSandbox — mid-provision delete race', () => {
+  test('nothing raced it: flips to running, guarded WHERE clauses are the expected shape, opens compute metering', async () => {
+    const opened = waitFor((resolve) => {
+      onComputeOpened = resolve;
+    });
+    await provisionSessionSandbox(baseOpts());
+    await opened;
+
+    expect(removedIds).toEqual([]);
+    expect(computeSessionsOpened).toHaveLength(1);
+    expect(computeSessionsOpened[0].sandboxId).toBe(SANDBOX_ID);
+    expect(computeSessionsOpened[0].accountId).toBe(ACCOUNT_ID);
+
+    // The session_sandboxes finish update is guarded by `status != 'archived'`.
+    const finishCall = updateCalls.find(
+      (c) => c.table === sessionSandboxes && 'externalId' in c.updates && 'config' in c.updates,
+    );
+    expect(finishCall).toBeTruthy();
+    expect(finishCall?.sql).toContain('<>');
+    expect(finishCall?.params).toContain('archived');
+
+    // The project_sessions running-flip is guarded by `status IN (queued, branching, provisioning)`.
+    const flipCall = updateCalls.find(
+      (c) => c.table === projectSessions && c.updates.status === 'running',
+    );
+    expect(flipCall).toBeTruthy();
+    expect(flipCall?.sql).toContain('in (');
+    expect(flipCall?.params).toEqual([SANDBOX_ID, ...PROVISIONING_SESSION_STATUSES]);
+  });
+
+  test('deleted mid-provision: session_sandboxes row is already archived when the finish write lands — removes the box, never flips to running, never opens metering', async () => {
+    scenario.archiveBeforeFinish = true;
+    // Still 'provisioning' at the early stopped-check (line ~463): the delete
+    // happens in the gap AFTER that check and BEFORE the finish write — the
+    // exact race window this fix closes.
+    scenario.projectSessionStatusAtCheck = 'provisioning';
+
+    const eventRecorded = waitFor((resolve) => {
+      onProviderEvent = resolve;
+    });
+    await provisionSessionSandbox(baseOpts());
+    await eventRecorded;
+
+    expect(removedIds).toEqual([EXTERNAL_ID]);
+    expect(computeSessionsOpened).toEqual([]);
+
+    // The guarded finish update was attempted (and, per the mock, returned no
+    // rows because the row was already 'archived') — but no project_sessions
+    // running-flip was ever attempted off the back of it.
+    const finishCall = updateCalls.find(
+      (c) => c.table === sessionSandboxes && 'externalId' in c.updates && 'config' in c.updates,
+    );
+    expect(finishCall).toBeTruthy();
+    const flipCall = updateCalls.find(
+      (c) => c.table === projectSessions && c.updates.status === 'running',
+    );
+    expect(flipCall).toBeUndefined();
+
+    expect(recordedEvents.some((e) => e.outcome === 'stopped')).toBe(true);
+  });
+});

--- a/apps/api/src/platform/services/session-sandbox.ts
+++ b/apps/api/src/platform/services/session-sandbox.ts
@@ -12,9 +12,10 @@
  * path in sandbox-cloud.ts.
  */
 
-import { eq } from 'drizzle-orm';
+import { and, eq, inArray, ne } from 'drizzle-orm';
 import { projectSessions, sessionSandboxes } from '@kortix/db';
 import { db } from '../../shared/db';
+import { PROVISIONING_SESSION_STATUSES } from '../../projects/lib/session-status';
 import { notifySessionProvisioningFailed } from '../../shared/session-failure-notifier';
 import { createApiKey } from '../../repositories/api-keys';
 import { createAccountToken } from '../../repositories/account-tokens';
@@ -546,14 +547,52 @@ export async function provisionSessionSandbox(opts: {
         finishUpdate.status = 'active';
       }
 
-      await db
+      // Conditional finish: `deleteSession()` is the ONLY place that sets a
+      // session_sandboxes row to 'archived', and it does so as soon as the
+      // user deletes the session — even while this provisioning IIFE is still
+      // in flight. Guard the write so a late-finishing provision can never
+      // resurrect a tombstoned row. If no row comes back, the session was
+      // deleted mid-provision: remove the box we just created and stop —
+      // no 'running' flip, no compute metering.
+      const [finished] = await db
         .update(sessionSandboxes)
         .set(finishUpdate)
-        .where(eq(sessionSandboxes.sandboxId, sandbox.sandboxId));
+        .where(
+          and(
+            eq(sessionSandboxes.sandboxId, sandbox.sandboxId),
+            ne(sessionSandboxes.status, 'archived'),
+          ),
+        )
+        .returning();
+
+      if (!finished) {
+        console.warn(
+          `[session-sandbox] session ${sandbox.sandboxId} was deleted mid-provision — removing box ${result.externalId} instead of finishing provisioning`,
+        );
+        await provider.remove(result.externalId).catch((err) =>
+          console.warn(
+            `[session-sandbox] cleanup of ${result.externalId} after mid-provision delete failed:`,
+            err,
+          ),
+        );
+        tl.mark('row-deleted-mid-provision');
+        tl.log({ provider: providerName, attempts, deletedMidProvision: true });
+        const delTl = tl.summary();
+        recordProviderEvent({
+          provider: providerName, kind: 'provision', outcome: 'stopped',
+          totalMs: delTl.totalMs, marks: delTl.marks, attempts,
+          sessionId: sandbox.sandboxId, accountId,
+        });
+        return;
+      }
 
       // Mirror sandbox readiness onto the project_sessions row so the
       // sidebar's status dot stops spinning. session_id == sandbox_id by
-      // construction, so the lookup is direct.
+      // construction, so the lookup is direct. Only flip sessions that are
+      // still genuinely mid-provision (queued/branching/provisioning) —
+      // 'stopped' (deleted, or an explicit stop) and 'running' (won by the
+      // separate stopped→running resume path in routes/shared.ts) must not be
+      // clobbered back to 'running' by a provisioning attempt finishing late.
       await db
         .update(projectSessions)
         .set({
@@ -561,7 +600,12 @@ export async function provisionSessionSandbox(opts: {
           sandboxUrl: result.baseUrl || null,
           updatedAt: new Date(),
         })
-        .where(eq(projectSessions.sessionId, sandbox.sandboxId))
+        .where(
+          and(
+            eq(projectSessions.sessionId, sandbox.sandboxId),
+            inArray(projectSessions.status, [...PROVISIONING_SESSION_STATUSES]),
+          ),
+        )
         .catch(() => {});
 
       tl.mark('row-active');

--- a/apps/api/src/projects/sandbox-reaper.ts
+++ b/apps/api/src/projects/sandbox-reaper.ts
@@ -461,7 +461,13 @@ const STUCK_SESSION_BATCH = 200;
  * reaper, and it acts ONLY on sessions that are provably idle:
  *   - status ∈ ACTIVE_SESSION_STATUSES and untouched for longer than the auto-
  *     stop TTL (so a healthy in-flight provision/branch is never touched),
- *   - NO `active` session_sandboxes row (a live box is the provider reaper's job),
+ *   - NO `active` session_sandboxes row (a live box is the provider reaper's
+ *     job) — UNLESS `metadata.deletedAt` is set. A session the user deleted
+ *     is tombstoned regardless of what its sandbox row says; this is the
+ *     backstop for the provision-finish race (a provisioning attempt that
+ *     resurrected a deleted session to 'running' before the row-level guard
+ *     landed, or any other path that leaves a deleted session pointing at a
+ *     live box) — it must not hide behind the active-sandbox exclusion,
  *   - NO in-flight turn (unfinalized chat_turn_stream), and
  *   - NO LLM usage within the TTL window.
  * For each it settles + closes any lingering billing window (DB-only) and flips
@@ -481,7 +487,10 @@ export async function reconcileStuckActiveSessions(
       and(
         inArray(projectSessions.status, [...ACTIVE_SESSION_STATUSES]),
         lt(projectSessions.updatedAt, cutoff),
-        sql`not exists (select 1 from ${sessionSandboxes} sb where sb.session_id = ${projectSessions.sessionId} and sb.status = 'active')`,
+        or(
+          sql`not exists (select 1 from ${sessionSandboxes} sb where sb.session_id = ${projectSessions.sessionId} and sb.status = 'active')`,
+          sql`(${projectSessions.metadata}->>'deletedAt') is not null`,
+        ),
         sql`not exists (select 1 from ${chatTurnStreams} t where t.session_id = ${projectSessions.sessionId} and t.finalized = false)`,
         sql`not exists (select 1 from ${usageEvents} u where u.session_id = ${projectSessions.sessionId} and u.created_at > ${cutoff.toISOString()})`,
       ),

--- a/apps/api/src/projects/session-lifecycle/__tests__/continue-session-deleted-guard.test.ts
+++ b/apps/api/src/projects/session-lifecycle/__tests__/continue-session-deleted-guard.test.ts
@@ -1,0 +1,143 @@
+// continueSession() must not revive a session the user explicitly deleted.
+//
+// deleteSession() (../actions.ts) stamps metadata.deletedAt and leaves
+// project_sessions.status = 'stopped' — the SAME status a normal hibernate
+// uses. Before this guard, a queued follow-up delivery (a Slack reply, a
+// scheduled trigger firing late, a retried webhook, …) landing after the
+// delete would see status === 'stopped' and revive the session by flipping
+// it back to 'running' and driving openSession(). This test asserts the
+// metadata.deletedAt check short-circuits to 'no-session' before any of that
+// happens, and — as a regression guard for the check itself — that a normal
+// (non-deleted) stopped session still takes the revival path.
+//
+// This file mocks the heavier engine.ts dependencies to a throwing stub —
+// never actually exercised by either test below (both return before those
+// call sites would be reached), they only need to exist so engine.ts's
+// top-level imports resolve. `./deliver` and `./await-stage` are deliberately
+// NOT mocked here: both are pure (type-only imports, no db/config), their own
+// dedicated test files (deliver.test.ts, await-terminal-stage.test.ts) import
+// them for real, and `bun:test`'s `mock.module` is process-global rather than
+// file-scoped — stubbing them here would leak into those files if bun ever
+// runs test files in the same process/order. See the same caveat documented
+// in ../../sandbox-reaper.test.ts.
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import { projectSessions, projects } from '@kortix/db';
+
+const SESSION_ID = 'sess-deleted-guard-1';
+const ACCOUNT_ID = 'acct-1';
+const PROJECT_ID = 'proj-1';
+
+let sessionRow: Record<string, unknown> | null = null;
+let updateCalls: Array<{ table: unknown; updates: Record<string, unknown> }> = [];
+
+mock.module('../../../config', () => ({ config: {} }));
+
+mock.module('../../../shared/db', () => ({
+  db: {
+    select: (_proj: unknown) => ({
+      from: (table: unknown) => ({
+        where: () => ({
+          limit: async () => {
+            if (table === projectSessions) return sessionRow ? [sessionRow] : [];
+            if (table === projects) return [{ projectId: PROJECT_ID, accountId: ACCOUNT_ID }];
+            return [];
+          },
+        }),
+      }),
+    }),
+    update: (table: unknown) => ({
+      set: (updates: Record<string, unknown>) => ({
+        where: async () => {
+          updateCalls.push({ table, updates });
+        },
+      }),
+    }),
+  },
+}));
+
+mock.module('../../../sandbox-proxy/routes/preview', () => ({
+  forwardToSandbox: async () => {
+    throw new Error('forwardToSandbox: not expected in this test');
+  },
+}));
+mock.module('../../lib/sessions', () => ({
+  createProjectSession: async () => {
+    throw new Error('createProjectSession: not expected in this test');
+  },
+}));
+mock.module('../../routes/shared', () => ({
+  openSession: async () => {
+    throw new Error('openSession: not reached when the deletedAt guard trips');
+  },
+}));
+mock.module('../actor', () => ({
+  resolveProjectAutomationActor: async () => 'automation-user-1',
+}));
+mock.module('../backpressure', () => ({
+  sessionBackpressureState: async () => ({ shouldQueue: false, reason: null }),
+}));
+mock.module('../store', () => ({
+  claimCreateSessionCommand: async () => {
+    throw new Error('not expected in this test');
+  },
+  claimDueLifecycleCommands: async () => {
+    throw new Error('not expected in this test');
+  },
+  markCommandFailed: async () => {
+    throw new Error('not expected in this test');
+  },
+  markCommandQueued: async () => {
+    throw new Error('not expected in this test');
+  },
+  markCommandSucceeded: async () => {
+    throw new Error('not expected in this test');
+  },
+  resultFromExistingCommand: () => {
+    throw new Error('not expected in this test');
+  },
+}));
+
+const { continueSession } = await import('../engine');
+
+beforeEach(() => {
+  sessionRow = null;
+  updateCalls = [];
+});
+
+describe('continueSession — deleted-mid-flight guard', () => {
+  test('a stopped session with metadata.deletedAt is never revived', async () => {
+    sessionRow = {
+      accountId: ACCOUNT_ID,
+      projectId: PROJECT_ID,
+      status: 'stopped',
+      metadata: { deletedAt: new Date().toISOString(), deletedBy: 'user-1' },
+    };
+
+    const result = await continueSession({ sessionId: SESSION_ID, text: 'follow-up' } as never);
+
+    expect(result).toBe('no-session');
+    // No project_sessions revival update was attempted — the guard trips
+    // before the function ever reaches the stopped/completed revival branch.
+    expect(updateCalls).toEqual([]);
+  });
+
+  test('regression guard: a normal stopped session (no deletedAt) still takes the revival path', async () => {
+    sessionRow = {
+      accountId: ACCOUNT_ID,
+      projectId: PROJECT_ID,
+      status: 'stopped',
+      metadata: {},
+    };
+
+    // openSession is mocked to throw, so the revival path surfaces as a
+    // rejection once it reaches openOnce() — proving the code got past the
+    // deletedAt guard and attempted the flip first.
+    await expect(
+      continueSession({ sessionId: SESSION_ID, text: 'follow-up' } as never),
+    ).rejects.toThrow(/openSession/);
+
+    expect(updateCalls).toHaveLength(1);
+    expect(updateCalls[0].table).toBe(projectSessions);
+    expect(updateCalls[0].updates.status).toBe('running');
+  });
+});

--- a/apps/api/src/projects/session-lifecycle/engine.ts
+++ b/apps/api/src/projects/session-lifecycle/engine.ts
@@ -197,6 +197,7 @@ export async function continueSession(
       accountId: projectSessions.accountId,
       projectId: projectSessions.projectId,
       status: projectSessions.status,
+      metadata: projectSessions.metadata,
     })
     .from(projectSessions)
     .where(eq(projectSessions.sessionId, sessionId))
@@ -204,6 +205,12 @@ export async function continueSession(
 
   if (!session) return 'no-session';
   if (session.status === 'failed') return 'failed';
+  // deleteSession() stamps metadata.deletedAt and leaves the row 'stopped' —
+  // the same status a normal hibernate uses. Without this check a queued
+  // follow-up (Slack reply, scheduled trigger, etc.) would revive a session
+  // the user explicitly deleted.
+  const sessionMeta = (session.metadata ?? {}) as Record<string, unknown>;
+  if (typeof sessionMeta.deletedAt === 'string') return 'no-session';
 
   const userId = command.userId ?? await resolveProjectAutomationActor(session.accountId);
   if (!userId) {


### PR DESCRIPTION
## Summary

Lands `fix/session-delete-provision-race` onto `main` (this repo's dev-integration branch). This is the **land-on-main follow-up** to the already-shipped v0.9.97 prod release ([PR #4203](https://github.com/kortix-ai/suna/pull/4203)) — the commit was cherry-picked directly onto `staging`/`prod` and is already live in production, but the source branch was never merged into `main`, so `dev` (which auto-deploys from every push to `main`) never got it. This PR brings the same change (rebased onto current `main`) onto the dev-integration line so the two environments don't drift.

Original commit on the feature branch: `6b234345ae` (pre-rebase). At the time of the original cherry-pick, this branch's base was already even with `main`; `main` has since advanced 7 more commits, so this PR rebases onto current `origin/main`. The rebase was clean — no conflicts. Rebased commit: `17e1fa3e03`.

## What it does

Closes a race where a session deleted while its sandbox was still provisioning could be resurrected: `deleteSession()` flips `session_sandboxes` to `archived` and `project_sessions` to `stopped`, but the still-running fire-and-forget provisioner had no status guards on its finish-of-provisioning writes, so it could later flip the session back to `active`/`running` anyway — including opening a compute-metering row for a session the user just deleted.

- `apps/api/.../session-sandbox.ts` (`provisionSessionSandbox`): the `session_sandboxes` finish-update is now conditional on `status != 'archived'` (via `.returning()`); if no row comes back, the session was deleted mid-provision, so the just-created provider sandbox is torn down and no `running` flip / compute metering occurs.
- The `project_sessions` running-flip is now conditional on `status IN (queued, branching, provisioning)`, so it can never clobber a `stopped` (deleted or explicitly stopped) or already-`running` session. (The intentional stopped→running resume path in `routes/shared.ts` is a separate function/condition and is unaffected.)
- `engine.ts` (`continueSession`): a queued follow-up delivery (Slack reply, late trigger, retried webhook) no longer revives a session whose `metadata.deletedAt` is set, even though `deleteSession()` leaves it at the same `stopped` status a normal hibernate uses.
- `sandbox-reaper.ts` (`reconcileStuckActiveSessions`): the stuck-session sweep hardened against the same class of resurrection.

## Verification

- `pnpm --filter kortix-api typecheck` — clean, post-rebase.
- No migration involved in this change (guard-clause/logic fix only).

## Provenance

- Original branch tip (pre-rebase): `6b234345ae`
- Rebased branch tip (this PR): `17e1fa3e03`
- Already shipped to prod via cherry-pick in #4203 (v0.9.97).
