### PR TITLE
feat(web): Upgrades section (registry + one-off prompt runner) + v2 prompt baseline-refresh

### DIFF
--- a/apps/cli/src/commands/cr.ts
+++ b/apps/cli/src/commands/cr.ts
@@ -428,6 +428,26 @@ async function crOpen(argv: string[], opts: CtxOpts): Promise<number> {
   process.stdout.write(
     `  ${C.dim}${displayBranch(created.head_ref)} → ${displayBranch(created.base_ref)}${C.reset}\n\n`,
   );
+
+  // A CR whose head tip equals base shows "No changes detected" in the
+  // dashboard and can't be applied — by far the most common cause is a
+  // committed-but-never-pushed session branch. Catch it here, at open time,
+  // while the author (usually an agent) can still fix it in one command. The
+  // diff endpoint recomputes live, so pushing after this warning heals the
+  // SAME CR — no need to reopen. Best-effort: never fail the open over it.
+  try {
+    const diff = await ctx.client.get<ChangeRequestDiffResponse>(
+      `/projects/${ctx.projectId}/change-requests/${created.cr_id}/diff`,
+    );
+    if (diff.files_changed === 0) {
+      process.stderr.write(
+        `  ${C.yellow}⚠${C.reset} CR #${created.number} has NO changes — its head branch is identical to ${displayBranch(created.base_ref)}.\n    If you committed locally, push first: ${C.bold}git push origin HEAD${C.reset}\n    The CR updates automatically once the push lands.\n\n`,
+      );
+    }
+  } catch {
+    // Diff unavailable (e.g. transient mirror refresh) — the open succeeded,
+    // don't fail or confuse the caller over a advisory check.
+  }
   return 0;
 }
 

--- a/apps/web/src/features/workspace/customize/customize-panel.tsx
+++ b/apps/web/src/features/workspace/customize/customize-panel.tsx
@@ -48,7 +48,7 @@ import {
 import { useCallback, useEffect, useMemo } from 'react';
 import { LuSettings, LuUsersRound } from 'react-icons/lu';
 import { detectManifestVersion } from './migrate-to-v2/manifest-version';
-import { UpgradeView } from './migrate-to-v2/upgrade-view';
+import { UpgradesView } from './migrate-to-v2/upgrade-view';
 import { isRailItemActive } from './rail';
 import { FilesSection } from './sections/files-section';
 import { LlmManagementView } from './sections/gateway-view';
@@ -109,10 +109,11 @@ const MEET_ITEM: RailItem = { section: 'meet', label: 'Meetings', icon: AudioLin
 
 const REVIEW_ITEM: RailItem = { section: 'review', label: 'Review', icon: Inbox };
 
-// Pinned above every group while the project is still on a v1 (kortix.toml)
-// manifest — the one-time agent-led migration to kortix.yaml. Disappears for
-// good once the project is v2.
-const UPGRADE_ITEM: RailItem = { section: 'upgrade', label: 'Upgrade to v2', icon: ArrowUpCircle };
+// The Upgrades section is always reachable (it hosts the one-off prompt
+// runner), but it only claims the pinned top slot while a registry upgrade
+// is actually applicable (e.g. the project is still on a v1 manifest) —
+// otherwise it sits quietly in Manage next to Settings.
+const UPGRADE_ITEM: RailItem = { section: 'upgrade', label: 'Upgrades', icon: ArrowUpCircle };
 
 function railGroups(
   tunnelEnabled: boolean,
@@ -120,9 +121,9 @@ function railGroups(
   llmGatewayAvailable: boolean,
   meetEnabled: boolean,
   reviewEnabled: boolean,
-  upgradeAvailable: boolean,
+  upgradeAttention: boolean,
 ): readonly RailGroup[] {
-  const groups = upgradeAvailable ? [{ items: [UPGRADE_ITEM] }, ...GROUPS] : GROUPS;
+  const groups = upgradeAttention ? [{ items: [UPGRADE_ITEM] }, ...GROUPS] : GROUPS;
   return groups.map((g) => {
     if (g.label === 'Build' && marketplaceEnabled) {
       return { ...g, items: [...g.items, MARKETPLACE_ITEM] };
@@ -140,6 +141,9 @@ function railGroups(
       const at = items.findIndex((it) => it.section === 'changes');
       items.splice(at >= 0 ? at + 1 : items.length, 0, REVIEW_ITEM);
       return { ...g, items };
+    }
+    if (g.label === 'Manage' && !upgradeAttention) {
+      return { ...g, items: [...g.items, UPGRADE_ITEM] };
     }
     return g;
   });
@@ -198,10 +202,10 @@ export function CustomizPanel({ projectId }: { projectId: string }) {
   const llmGatewayAvailable = isLlmGatewayAvailable(detail.data?.project);
   const meetEnabled = detail.data?.project?.experimental?.meet ?? false;
   const reviewEnabled = detail.data?.project?.experimental?.review_center ?? false;
-  // Only offer the v2 upgrade once the manifest read resolved to v1 — while the
-  // detail query is in flight the item stays hidden (popping IN later is fine;
-  // rendering it for an already-v2 project is not).
-  const upgradeAvailable = detail.data
+  // Pin Upgrades to the top only once the manifest read resolved to v1 —
+  // while the detail query is in flight (or on v2 projects) the item sits in
+  // its calm Manage slot instead. Same detection the section rows use.
+  const upgradeAttention = detail.data
     ? detectManifestVersion(detail.data.config.manifest_raw) === 1
     : false;
 
@@ -230,7 +234,7 @@ export function CustomizPanel({ projectId }: { projectId: string }) {
         llmGatewayAvailable,
         meetEnabled,
         reviewEnabled,
-        upgradeAvailable,
+        upgradeAttention,
       )
         .map((g) => ({ ...g, items: g.items.filter((item) => isSectionAllowed(item.section)) }))
         .filter((g) => g.items.length > 0),
@@ -240,7 +244,7 @@ export function CustomizPanel({ projectId }: { projectId: string }) {
       llmGatewayAvailable,
       meetEnabled,
       reviewEnabled,
-      upgradeAvailable,
+      upgradeAttention,
       isSectionAllowed,
     ],
   );
@@ -490,7 +494,7 @@ function SectionContent({
     case 'settings':
       return <SettingsView projectId={projectId} />;
     case 'upgrade':
-      return <UpgradeView projectId={projectId} />;
+      return <UpgradesView projectId={projectId} />;
     default:
       return null;
   }

--- a/apps/web/src/features/workspace/customize/migrate-to-v2/index.ts
+++ b/apps/web/src/features/workspace/customize/migrate-to-v2/index.ts
@@ -6,5 +6,13 @@ export {
   type ProjectManifestVersionState,
 } from './manifest-version';
 export { useMigrateToV2, buildMigrateToV2Stash, type MigrateToV2 } from './use-migrate-to-v2';
+export { useRunUpgrade, buildUpgradeStash, type RunUpgrade } from './use-run-upgrade';
+export {
+  PROJECT_UPGRADES,
+  applicableUpgrades,
+  buildOneOffUpgradePrompt,
+  type ProjectUpgrade,
+  type ProjectUpgradeContext,
+} from './upgrade-defs';
 export { MigrateToV2Button, MigrateToV2ButtonView } from './migrate-to-v2-button';
-export { UpgradeView } from './upgrade-view';
+export { UpgradesView, UpgradesViewContent } from './upgrade-view';

--- a/apps/web/src/features/workspace/customize/migrate-to-v2/migration-prompt.test.ts
+++ b/apps/web/src/features/workspace/customize/migrate-to-v2/migration-prompt.test.ts
@@ -109,4 +109,35 @@ describe('MIGRATE_TO_V2_PROMPT — the core migration artifact', () => {
     expect(MIGRATE_TO_V2_PROMPT).toContain('kortix cr diff');
     expect(MIGRATE_TO_V2_PROMPT.toLowerCase()).toContain('do not open a second one');
   });
+
+  test('refreshes the marketplace baseline before touching the manifest', () => {
+    expect(MIGRATE_TO_V2_PROMPT).toContain('kortix marketplace updates');
+    expect(MIGRATE_TO_V2_PROMPT).toContain('kortix marketplace update --all');
+    const refresh = MIGRATE_TO_V2_PROMPT.indexOf('kortix marketplace update --all');
+    const shape = MIGRATE_TO_V2_PROMPT.indexOf('The v2 shape');
+    expect(refresh).toBeGreaterThan(-1);
+    expect(shape).toBeGreaterThan(refresh);
+  });
+
+  test('warns that marketplace update commits directly to main, outside the CR', () => {
+    expect(MIGRATE_TO_V2_PROMPT).toMatch(/commits directly to `main`/i);
+  });
+
+  test('scopes the baseline refresh to marketplace-tracked items only', () => {
+    expect(MIGRATE_TO_V2_PROMPT.toLowerCase()).toContain('orphaned');
+    expect(MIGRATE_TO_V2_PROMPT).toContain('leave every one of them untouched');
+  });
+
+  test('handles an advanced main: rebase, and redo the conversion on conflict rather than reverting', () => {
+    expect(MIGRATE_TO_V2_PROMPT).toContain('git fetch origin');
+    expect(MIGRATE_TO_V2_PROMPT).toContain('git rebase origin/main');
+    expect(MIGRATE_TO_V2_PROMPT).toContain('git rebase --abort');
+    expect(MIGRATE_TO_V2_PROMPT.toLowerCase()).toContain('redo the conversion');
+    expect(MIGRATE_TO_V2_PROMPT).toContain('--force-with-lease');
+  });
+
+  test('section numbering is unique and sequential', () => {
+    const numbers = [...MIGRATE_TO_V2_PROMPT.matchAll(/^## (\d+)\./gm)].map((m) => Number(m[1]));
+    expect(numbers).toEqual(Array.from({ length: numbers.length }, (_, i) => i + 1));
+  });
 });

--- a/apps/web/src/features/workspace/customize/migrate-to-v2/migration-prompt.test.ts
+++ b/apps/web/src/features/workspace/customize/migrate-to-v2/migration-prompt.test.ts
@@ -96,4 +96,17 @@ describe('MIGRATE_TO_V2_PROMPT — the core migration artifact', () => {
   test('instructs carrying over hand-written TOML comments', () => {
     expect(MIGRATE_TO_V2_PROMPT.toLowerCase()).toContain('comments');
   });
+
+  test('pushes the branch before opening the CR — an unpushed commit leaves the CR empty', () => {
+    expect(MIGRATE_TO_V2_PROMPT).toContain('git push origin HEAD');
+    const push = MIGRATE_TO_V2_PROMPT.indexOf('git push origin HEAD');
+    const open = MIGRATE_TO_V2_PROMPT.indexOf('kortix cr open');
+    expect(push).toBeGreaterThan(-1);
+    expect(open).toBeGreaterThan(push);
+  });
+
+  test('verifies the opened CR is non-empty instead of opening a duplicate', () => {
+    expect(MIGRATE_TO_V2_PROMPT).toContain('kortix cr diff');
+    expect(MIGRATE_TO_V2_PROMPT.toLowerCase()).toContain('do not open a second one');
+  });
 });

--- a/apps/web/src/features/workspace/customize/migrate-to-v2/migration-prompt.ts
+++ b/apps/web/src/features/workspace/customize/migrate-to-v2/migration-prompt.ts
@@ -197,10 +197,14 @@ Run \`kortix validate\` (it auto-detects \`kortix.yaml\`). Fix every error it re
 
 ## 9. Land it as a change request — never merge
 
-Commit the changes on your session's branch, then open a change request:
+Commit on your session's branch, **push the branch, then** open the change request. A commit that is never pushed leaves the CR empty ("No changes detected") and un-appliable — the push is not optional:
 
 \`\`\`
+git add -A && git commit -m "Migrate manifest to kortix_version 2 (kortix.yaml)"
+git push origin HEAD
 kortix cr open --head <your-branch> --title "Migrate manifest to kortix_version 2 (kortix.yaml)" --description "<what you converted, which agent you picked as default_agent and why, every legacy key you removed, and any grant you had to leave narrowed>"
 \`\`\`
 
-Do **not** run \`kortix cr merge\`. This is a human-reviewed change like any other — stop once the CR is open and tell the user its number so they can review the diff and merge it themselves.`;
+Then verify the CR actually carries your diff: run \`kortix cr diff <number>\` — if it reports no changes, your push didn't land; push again and re-check (the CR updates automatically, do not open a second one).
+
+Do **not** run \`kortix cr merge\`. This is a human-reviewed change like any other — stop once the CR is open and verified non-empty, and tell the user its number so they can review the diff and merge it themselves.`;

--- a/apps/web/src/features/workspace/customize/migrate-to-v2/migration-prompt.ts
+++ b/apps/web/src/features/workspace/customize/migrate-to-v2/migration-prompt.ts
@@ -32,7 +32,17 @@ export const MIGRATE_TO_V2_PROMPT = `Migrate this project's manifest from kortix
 - \`.kortix/opencode/opencode.jsonc\` — if it sets a top-level \`default_agent\`, that is the project's existing default; use it. If it doesn't, pick the agent whose \`.kortix/opencode/agents/*.md\` frontmatter has \`mode: primary\` and reads as the general/primary one (usually the first-created or the one with the broadest permissions). Record which you picked and why in the change request description — a human reviews this before it merges, so a defensible choice beats blocking on it.
 - **You do NOT need to read each agent's \`.md\` frontmatter to migrate it.** v1's frontmatter (mode/model/temperature/permission/prompt/…) is ALREADY valid v2 OpenCode behavior — it stays exactly where it is, unchanged. This migration is governance-only.
 
-## 2. The authoritative schema is one command away
+## 2. Bring the platform baseline up to date first
+
+A project still on a v1 manifest is usually also running stale platform skills. Refresh them BEFORE touching the manifest so the migration lands on a current baseline:
+
+1. \`kortix marketplace updates\` — a hash-diff report of every marketplace-tracked item (the kortix-managed skills like \`kortix-system\`/\`kortix-memory\`, plus any marketplace skills the user installed).
+2. If updates are listed, apply them: \`kortix marketplace update --all\`. **This commits directly to \`main\` through the platform's own hash-safe update path — it is intentionally NOT part of your change request.** It only rewrites files whose installed hash no longer matches the catalog, so untouched user files are never clobbered.
+3. Sync your session branch on top of the refreshed main: \`git fetch origin && git rebase origin/main\`.
+4. Items reported as \`orphaned\` (no longer in the catalog) are not updatable — leave them alone and mention them in the change request description.
+5. Marketplace-tracked items are the ONLY thing you refresh this way. Do NOT hand-update anything else "to latest": agents' \`.md\` files, \`.kortix/memory/\`, \`opencode.jsonc\`, the continuation plugin, \`tools/*.ts\`, and custom skills are user- or platform-owned files with no update tracking — leave every one of them untouched.
+
+## 3. The authoritative schema is one command away
 
 Whenever you are unsure about a field name, an allowed value, or whether a key survived into v2, consult the canonical JSON Schema instead of guessing:
 
@@ -41,7 +51,7 @@ Whenever you are unsure about a field name, an allowed value, or whether a key s
 
 The schema, this prompt, and \`kortix validate\` all enforce the same rules — if they ever appear to disagree, trust \`kortix validate\`'s output and say so in the change request description.
 
-## 3. The v2 shape you're producing
+## 4. The v2 shape you're producing
 
 v2's \`agents:\` map is GOVERNANCE ONLY — connectors/secrets/skills/kortix_cli/workspace/enabled. OpenCode behavior (mode/model/temperature/permission/the prompt itself) is NOT part of the manifest at all; it lives entirely in each agent's own native \`.kortix/opencode/agents/<name>.md\` frontmatter + body, exactly as it does today. The agent's NAME is the join between this map's keys and that \`.md\`'s filename.
 
@@ -72,7 +82,7 @@ Rules that the schema enforces (get these right or \`kortix validate\` fails):
 - Every other top-level section (\`project\`, \`env\` for required/optional documentation vars — NOT the per-agent grant, top-level \`opencode\` config-dir settings, \`sandbox\`, \`triggers\`, \`connectors\`, \`apps\`) keeps its v1 shape unchanged — translated to YAML, not restructured. If \`triggers[].agent\` names an agent, make sure that name still exists in the new \`agents\` map (rename references if you renamed an agent).
 - If an agent has no \`.md\` today (a bare \`[[agents]]\` entry with no matching OpenCode agent file), still declare it in \`agents:\` with its governance grants carried over — don't drop it. It will simply have no behavior until someone adds \`.kortix/opencode/agents/<name>.md\`.
 
-## 4. Legacy keys v2 refuses — drop these while you convert
+## 5. Legacy keys v2 refuses — drop these while you convert
 
 v1 tolerates several retired keys with a deprecation warning; v2 makes every one of them a hard error. Remove them as part of the conversion and note each removal in the change request description:
 
@@ -81,7 +91,7 @@ v1 tolerates several retired keys with a deprecation warning; v2 makes every one
 - **\`agent_scope\` on a \`[[connectors]]\` entry** — retired; the runtime no longer reads it. Per-agent connector access is expressed from the OTHER side now: each agent's \`connectors:\` grant in the \`agents:\` map. If a v1 connector had \`agent_scope = ["a", "b"]\`, make sure agents outside that list don't get that connector slug in their \`connectors\` grant (use an explicit slug list instead of \`all\` for the agents that should keep access), then delete the key.
 - **Legacy singular \`[sandbox]\` image keys** (\`image\`, \`dockerfile\`, \`cpu\`, \`memory\`, \`disk\`, …) — already an error in v1's validator; if \`kortix validate\` flags them, move the image definition under \`[[sandbox.templates]]\` → \`sandbox.templates:\` with a named slug.
 
-## 5. Worked example
+## 6. Worked example
 
 A representative v1 \`kortix.toml\`:
 
@@ -170,18 +180,18 @@ connectors:
 
 Note what happened: the \`[[channels]]\` block is gone (dashboard-owned now), \`env\` became \`secrets\`, the retired CLI action and connector keys were dropped, every omitted-in-v1 grant was written out explicitly, and the old \`agent_scope\` was honored by adjusting the AGENTS' \`connectors\` grants rather than copied over. Your project will differ — apply the rules, not this output verbatim.
 
-## 6. Leave every agent's \`.md\` alone
+## 7. Leave every agent's \`.md\` alone
 
 Do not open, edit, or reformat any \`.kortix/opencode/agents/*.md\` file as part of this migration. Its frontmatter (mode/model/permission/temperature/…) and body (the system prompt) are ALREADY the agent's v2 behavior — nothing about them needs to change. This is what makes this migration governance-only and comparatively small: you're translating one array-of-tables into one map of governance grants, full stop.
 
-## 7. Write the file, remove the old one
+## 8. Write the file, remove the old one
 
 - Write the fully assembled manifest to \`kortix.yaml\` at the repo root (same directory as the old \`kortix.toml\`).
 - Carry over meaningful TOML comments as YAML comments next to the same keys — hand-written context in a manifest is documentation someone chose to leave; don't strip it.
 - Delete the old \`kortix.toml\` in the same commit — don't leave both files (the platform always prefers \`kortix.yaml\` when both exist, but a stale v1 file next to it is confusing for the next person who edits by hand).
 - You do not need to touch any project setting outside git — the platform resolves \`kortix.yaml\` automatically once it exists, regardless of the configured manifest filename.
 
-## 8. Validate before you're done
+## 9. Validate before you're done
 
 Run \`kortix validate\` (it auto-detects \`kortix.yaml\`). Fix every error it reports — do not open the change request with a manifest that fails validation. Warnings are fine to leave if they're informational, but read them. If an error surprises you, cross-check the field against \`kortix schema --version 2\`.
 

--- a/apps/web/src/features/workspace/customize/migrate-to-v2/migration-prompt.ts
+++ b/apps/web/src/features/workspace/customize/migrate-to-v2/migration-prompt.ts
@@ -195,15 +195,19 @@ Do not open, edit, or reformat any \`.kortix/opencode/agents/*.md\` file as part
 
 Run \`kortix validate\` (it auto-detects \`kortix.yaml\`). Fix every error it reports — do not open the change request with a manifest that fails validation. Warnings are fine to leave if they're informational, but read them. If an error surprises you, cross-check the field against \`kortix schema --version 2\`.
 
-## 9. Land it as a change request — never merge
+## 10. Land it as a change request — never merge
 
-Commit on your session's branch, **push the branch, then** open the change request. A commit that is never pushed leaves the CR empty ("No changes detected") and un-appliable — the push is not optional:
+First, re-sync: \`git fetch origin\` and check whether \`origin/main\` advanced while you worked (\`git log HEAD..origin/main --oneline\`) — on active projects it will (connectors added from the dashboard, other sessions merging). If it moved, rebase; if the rebase conflicts on \`kortix.toml\` (main changed the manifest you deleted), don't fight it — \`git rebase --abort\`, \`git reset --hard origin/main\`, and redo the conversion against the CURRENT manifest, then continue. Never revert main's changes to win a conflict.
+
+Then commit, **push the branch**, and open the change request. A commit that is never pushed leaves the CR empty ("No changes detected") and un-appliable — the platform refuses such a CR outright (\`422 CR_HEAD_NOT_AHEAD\`):
 
 \`\`\`
 git add -A && git commit -m "Migrate manifest to kortix_version 2 (kortix.yaml)"
 git push origin HEAD
 kortix cr open --head <your-branch> --title "Migrate manifest to kortix_version 2 (kortix.yaml)" --description "<what you converted, which agent you picked as default_agent and why, every legacy key you removed, and any grant you had to leave narrowed>"
 \`\`\`
+
+If the push is rejected because the remote session branch moved, \`git fetch origin\` then \`git push --force-with-lease origin HEAD\` — your own session branch only, never any other branch.
 
 Then verify the CR actually carries your diff: run \`kortix cr diff <number>\` — if it reports no changes, your push didn't land; push again and re-check (the CR updates automatically, do not open a second one).
 

--- a/apps/web/src/features/workspace/customize/migrate-to-v2/upgrade-defs.test.ts
+++ b/apps/web/src/features/workspace/customize/migrate-to-v2/upgrade-defs.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from 'bun:test';
+
+import { MIGRATE_TO_V2_PROMPT } from './migration-prompt';
+import { PROJECT_UPGRADES, applicableUpgrades, buildOneOffUpgradePrompt } from './upgrade-defs';
+
+describe('PROJECT_UPGRADES registry', () => {
+  test('the v2 migration applies to v1 projects only', () => {
+    expect(applicableUpgrades({ manifestVersion: 1 }).map((u) => u.id)).toContain('manifest-v2');
+    expect(applicableUpgrades({ manifestVersion: 2 }).map((u) => u.id)).not.toContain(
+      'manifest-v2',
+    );
+  });
+
+  test('an unresolved manifest read applies nothing — no premature offers', () => {
+    expect(applicableUpgrades({ manifestVersion: null })).toHaveLength(0);
+  });
+
+  test('the v2 entry carries the real migration prompt, not a copy', () => {
+    const entry = PROJECT_UPGRADES.find((u) => u.id === 'manifest-v2');
+    expect(entry?.prompt).toBe(MIGRATE_TO_V2_PROMPT);
+  });
+
+  test('every registry entry is fully described', () => {
+    for (const u of PROJECT_UPGRADES) {
+      expect(u.id.length).toBeGreaterThan(0);
+      expect(u.title.length).toBeGreaterThan(0);
+      expect(u.description.length).toBeGreaterThan(0);
+      expect(u.prompt.length).toBeGreaterThan(100);
+    }
+  });
+});
+
+describe('buildOneOffUpgradePrompt — the freeform runner wrapper', () => {
+  const prompt = buildOneOffUpgradePrompt('Rename the release-bot agent to deploy-bot');
+
+  test('embeds the user request verbatim', () => {
+    expect(prompt).toContain('Rename the release-bot agent to deploy-bot');
+  });
+
+  test('enforces the full landing contract — push, open, verify, never merge', () => {
+    expect(prompt).toContain('git push origin HEAD');
+    expect(prompt).toContain('kortix cr open');
+    expect(prompt).toContain('kortix cr diff');
+    expect(prompt).toMatch(/do not run `kortix cr merge`/i);
+  });
+
+  test('syncs with an advanced base before landing', () => {
+    expect(prompt).toContain('git fetch origin');
+    expect(prompt.toLowerCase()).toContain('rebase');
+  });
+
+  test('forbids opening an empty CR when there is nothing to do', () => {
+    expect(prompt.toLowerCase()).toContain('do not open an empty change request');
+  });
+
+  test('validates manifest edits before landing', () => {
+    expect(prompt).toContain('kortix validate');
+  });
+});

--- a/apps/web/src/features/workspace/customize/migrate-to-v2/upgrade-defs.ts
+++ b/apps/web/src/features/workspace/customize/migrate-to-v2/upgrade-defs.ts
@@ -1,0 +1,61 @@
+/**
+ * The project-upgrade registry — every one-off, agent-run upgrade the
+ * Upgrades section can offer. An upgrade is nothing but a detection rule and
+ * a seed prompt: running one mints a fresh session, the project's default
+ * agent makes the change, and the result lands as a change request for human
+ * review (never merged by the agent). Adding a new upgrade = adding an entry
+ * here; the view renders whatever is applicable.
+ */
+
+import type { ManifestVersion } from './manifest-version';
+import { MIGRATE_TO_V2_PROMPT } from './migration-prompt';
+
+export interface ProjectUpgradeContext {
+  /** `null` while the manifest read hasn't resolved. */
+  manifestVersion: ManifestVersion | null;
+}
+
+export interface ProjectUpgrade {
+  id: string;
+  title: string;
+  description: string;
+  applicable: (ctx: ProjectUpgradeContext) => boolean;
+  prompt: string;
+}
+
+export const PROJECT_UPGRADES: readonly ProjectUpgrade[] = [
+  {
+    id: 'manifest-v2',
+    title: 'Migrate manifest to v2 (kortix.yaml)',
+    description:
+      'Converts the v1 kortix.toml into the governance-first kortix.yaml, refreshes platform-managed skills to the latest marketplace baseline, and opens a change request for review.',
+    applicable: (ctx) => ctx.manifestVersion === 1,
+    prompt: MIGRATE_TO_V2_PROMPT,
+  },
+];
+
+export function applicableUpgrades(ctx: ProjectUpgradeContext): readonly ProjectUpgrade[] {
+  return PROJECT_UPGRADES.filter((u) => u.applicable(ctx));
+}
+
+/**
+ * Wrap a freeform "just do this one thing to the project" request in the
+ * landing contract every upgrade session must follow. The wrapper is what
+ * makes a one-off prompt safe to fire-and-review: whatever the request says,
+ * the session still validates, pushes, opens a CR, verifies it's non-empty,
+ * and never merges.
+ */
+export function buildOneOffUpgradePrompt(request: string): string {
+  return `Run a one-off, self-contained upgrade of this project. The goal:
+
+${request.trim()}
+
+Ground rules — these override nothing above, they define how the change LANDS:
+
+1. Read the relevant files before writing anything; keep the change as small as the goal allows.
+2. Work on your session branch only.
+3. If you touched the manifest (kortix.yaml / kortix.toml), run \`kortix validate\` and fix every error before landing.
+4. Land it exactly per the kortix-system mandate: \`git fetch origin\` (rebase onto origin/main if it advanced) → commit → \`git push origin HEAD\` → \`kortix cr open --title "<short imperative summary>" --description "<what changed and why>"\` → verify with \`kortix cr diff <n>\` that the CR actually carries your diff. If the push is rejected because the remote session branch moved, fetch and \`git push --force-with-lease origin HEAD\` (your own session branch only).
+5. Do NOT run \`kortix cr merge\` — stop once the CR is open and verified non-empty, and tell the user its number.
+6. If the goal is already satisfied and there is nothing to change, say so and stop — do not open an empty change request.`;
+}

--- a/apps/web/src/features/workspace/customize/migrate-to-v2/upgrade-view.test.tsx
+++ b/apps/web/src/features/workspace/customize/migrate-to-v2/upgrade-view.test.tsx
@@ -1,34 +1,39 @@
 import { describe, expect, test } from 'bun:test';
 import { renderToStaticMarkup } from 'react-dom/server';
 
-import { UpgradeViewContent } from './upgrade-view';
+import { UpgradesViewContent } from './upgrade-view';
 
-describe('UpgradeViewContent — per-state rendering', () => {
-  test('v1 renders the migration explainer and the passed-in action', () => {
+describe('UpgradesViewContent — per-state rendering', () => {
+  test('v1 lists the manifest migration with a Run action, plus the one-off runner', () => {
     const html = renderToStaticMarkup(
-      <UpgradeViewContent version={1} action={<button type="button">Migrate to v2</button>} />,
+      <UpgradesViewContent version={1} onRun={() => {}} pending={false} />,
     );
-    expect(html).toContain('Upgrade to v2');
-    expect(html).toContain('What happens');
-    expect(html).toContain('An agent session does the conversion');
-    expect(html).toContain('Migrate to v2');
+    expect(html).toContain('Upgrades');
+    expect(html).toContain('Migrate manifest to v2');
+    expect(html).toContain('Run');
+    expect(html).toContain('One-off upgrade');
+    expect(html).not.toContain('up to date');
   });
 
-  test('v2 (stale deep-link) renders the already-migrated empty state, no action', () => {
+  test('v2 shows the up-to-date empty state but keeps the one-off runner available', () => {
     const html = renderToStaticMarkup(
-      <UpgradeViewContent version={2} action={<button type="button">Migrate to v2</button>} />,
+      <UpgradesViewContent version={2} onRun={() => {}} pending={false} />,
     );
-    expect(html).toContain('Already on v2');
-    expect(html).not.toContain('Migrate to v2');
-    expect(html).not.toContain('What happens');
+    expect(html).toContain('up to date');
+    expect(html).not.toContain('Migrate manifest to v2');
+    expect(html).toContain('One-off upgrade');
   });
 
-  test('unresolved manifest read renders placeholders only — no CTA, no premature claim', () => {
+  test('unresolved manifest read renders placeholders — no upgrade rows, no premature up-to-date claim', () => {
     const html = renderToStaticMarkup(
-      <UpgradeViewContent version={null} action={<button type="button">Migrate to v2</button>} />,
+      <UpgradesViewContent version={null} onRun={() => {}} pending={false} />,
     );
-    expect(html).not.toContain('Migrate to v2');
-    expect(html).not.toContain('Already on v2');
-    expect(html).not.toContain('What happens');
+    expect(html).not.toContain('Migrate manifest to v2');
+    expect(html).not.toContain('up to date');
+  });
+
+  test('run buttons disable while a session is being created', () => {
+    const html = renderToStaticMarkup(<UpgradesViewContent version={1} onRun={() => {}} pending />);
+    expect(html).toContain('disabled');
   });
 });

--- a/apps/web/src/features/workspace/customize/migrate-to-v2/upgrade-view.tsx
+++ b/apps/web/src/features/workspace/customize/migrate-to-v2/upgrade-view.tsx
@@ -1,108 +1,136 @@
 'use client';
 
 /**
- * The "Upgrade to v2" customize section — the dedicated home of the agent-led
- * kortix.toml → kortix.yaml migration. The rail only shows this section while
- * the project is still on a v1 manifest, but the section itself handles every
- * state (loading / already-v2 via deep-link / v1) so a stale link never
- * renders a broken page.
+ * The "Upgrades" customize section — one-off, agent-run project upgrades.
+ * Two halves:
  *
- * The action is deliberately a session, not a form: the only way config lands
- * is through an agent editing the repo on a branch and opening a change
- * request, so the button seeds a session with MIGRATE_TO_V2_PROMPT and drops
- * the user into the thread.
+ *  1. The registry (`upgrade-defs.ts`): known upgrades with a detection rule
+ *     (today: the v1→v2 manifest migration). Rows appear only while
+ *     applicable and disappear for good once done.
+ *  2. A freeform one-off runner: describe a single change ("bump X",
+ *     "restructure Y") and a session makes it and opens a change request —
+ *     the same mechanics, minus the registry entry.
+ *
+ * Every run is a session, not a form: the only way config lands is through
+ * an agent editing the repo on a branch and opening a CR the user reviews.
+ * Nothing here merges anything.
  */
 
+import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
+import Loading from '@/components/ui/loading';
 import { Skeleton } from '@/components/ui/skeleton';
+import { Textarea } from '@/components/ui/textarea';
 import { EmptyState } from '@/features/layout/section/empty-state';
-import { CircleCheckBig } from 'lucide-react';
-import type { ReactNode } from 'react';
+import { ArrowUpCircle, CircleCheckBig } from 'lucide-react';
+import { useState } from 'react';
 
 import CustomizeSectionWrapper from '../sections/component/section-wrapper';
 import type { ManifestVersion } from './manifest-version';
 import { useProjectManifestVersion } from './manifest-version';
-import { MigrateToV2Button } from './migrate-to-v2-button';
+import { applicableUpgrades, buildOneOffUpgradePrompt, type ProjectUpgrade } from './upgrade-defs';
+import { useRunUpgrade } from './use-run-upgrade';
 
-const STEPS: readonly { title: string; body: string }[] = [
-  {
-    title: 'An agent session does the conversion',
-    body: 'Your project’s default agent reads the current kortix.toml, translates the [[agents]] array into the v2 agents: map, and writes kortix.yaml against the canonical schema.',
-  },
-  {
-    title: 'Nothing narrows silently',
-    body: 'v2 is deny-by-default, so every grant an agent has today (connectors, secrets, CLI actions, skills) is written out explicitly — access stays exactly as it is.',
-  },
-  {
-    title: 'You review and merge',
-    body: 'The agent validates the result, commits on its branch, and opens a change request. Nothing changes on main until you approve the diff.',
-  },
-];
-
-/** Presentational only — no hooks, no data fetching. Kept separate from
- *  `UpgradeView` so every state (loading / v1 / already-v2) is testable
- *  without mocking react-query or the SDK. */
-export function UpgradeViewContent({
+/** Presentational only — no data fetching, so every state renders under
+ *  renderToStaticMarkup. Local textarea state is fine; the network side
+ *  lives in the `UpgradesView` wrapper below. */
+export function UpgradesViewContent({
   version,
-  action,
+  onRun,
+  pending,
 }: {
   /** `null` = the manifest read hasn't resolved yet. */
   version: ManifestVersion | null;
-  action?: ReactNode;
+  onRun: (prompt: string) => void;
+  pending: boolean;
 }) {
+  const [oneOff, setOneOff] = useState('');
+  const upgrades =
+    version === null ? null : applicableUpgrades({ manifestVersion: version });
+
   return (
     <CustomizeSectionWrapper
-      title="Upgrade to v2"
-      description="Move this project from the v1 kortix.toml manifest to kortix.yaml (v2)."
-      action={version === 1 ? action : undefined}
+      title="Upgrades"
+      description="One-off, agent-run changes — each run starts a session that makes the change and opens a change request for you to review."
     >
-      {version === null ? (
-        <div className="space-y-2">
-          {['a', 'b', 'c'].map((k) => (
-            <Skeleton key={k} className="h-16 w-full rounded-md" />
-          ))}
-        </div>
-      ) : version === 2 ? (
-        <EmptyState
-          icon={CircleCheckBig}
-          size="sm"
-          title="Already on v2"
-          description="This project uses the kortix.yaml (v2) manifest — there is nothing to migrate."
-        />
-      ) : (
-        <section className="space-y-4">
-          <Label>What happens</Label>
+      <section className="space-y-4">
+        <Label>Available upgrades</Label>
+        {upgrades === null ? (
+          <div className="space-y-2">
+            {['a', 'b'].map((k) => (
+              <Skeleton key={k} className="h-16 w-full rounded-md" />
+            ))}
+          </div>
+        ) : upgrades.length === 0 ? (
+          <EmptyState
+            icon={CircleCheckBig}
+            size="sm"
+            title="You're up to date"
+            description="No pending platform upgrades for this project."
+          />
+        ) : (
           <ul className="space-y-2">
-            {STEPS.map((step, i) => (
+            {upgrades.map((upgrade: ProjectUpgrade) => (
               <li
-                key={step.title}
-                className="bg-popover flex items-start gap-3 rounded-md border px-4 py-3"
+                key={upgrade.id}
+                className="bg-popover flex items-center gap-3 rounded-md border px-4 py-3"
               >
-                <span className="bg-kortix-base/15 text-kortix-base flex size-9 shrink-0 items-center justify-center rounded-sm text-sm font-medium tabular-nums">
-                  {i + 1}
+                <span className="bg-kortix-base/15 flex size-9 shrink-0 items-center justify-center rounded-sm">
+                  <ArrowUpCircle className="text-kortix-base size-5" />
                 </span>
-                <div className="min-w-0">
-                  <p className="text-foreground text-sm font-medium">{step.title}</p>
-                  <p className="text-muted-foreground mt-0.5 text-xs text-pretty">{step.body}</p>
+                <div className="min-w-0 flex-1">
+                  <p className="text-foreground text-sm font-medium">{upgrade.title}</p>
+                  <p className="text-muted-foreground mt-0.5 text-xs text-pretty">
+                    {upgrade.description}
+                  </p>
                 </div>
+                <Button
+                  size="sm"
+                  className="shrink-0"
+                  disabled={pending}
+                  onClick={() => onRun(upgrade.prompt)}
+                >
+                  {pending ? <Loading className="size-3.5 shrink-0" /> : null}
+                  Run
+                </Button>
               </li>
             ))}
           </ul>
+        )}
+      </section>
+
+      <section className="space-y-4">
+        <Label>One-off upgrade</Label>
+        <div className="bg-popover space-y-3 rounded-md border px-4 py-5">
           <p className="text-muted-foreground text-xs text-pretty">
-            v2 unifies per-agent governance in one place — explicit connector, secret, CLI, and
-            skill grants per agent, a required default agent, and YAML with schema-backed editor
-            support. Agent behavior files (
-            <span className="font-mono">.kortix/opencode/agents/*.md</span>) are left untouched.
+            Describe a single change to this project. An agent session makes it, validates,
+            and opens a change request — it never merges on its own.
           </p>
-        </section>
-      )}
+          <Textarea
+            value={oneOff}
+            onChange={(event) => setOneOff(event.target.value)}
+            placeholder="e.g. Rename the release-bot agent to deploy-bot everywhere it's referenced"
+            minHeight={72}
+          />
+          <div className="flex justify-end">
+            <Button
+              size="sm"
+              variant="secondary"
+              disabled={pending || !oneOff.trim()}
+              onClick={() => onRun(buildOneOffUpgradePrompt(oneOff))}
+            >
+              {pending ? <Loading className="size-3.5 shrink-0" /> : null}
+              Run upgrade
+            </Button>
+          </div>
+        </div>
+      </section>
     </CustomizeSectionWrapper>
   );
 }
 
-export function UpgradeView({ projectId }: { projectId: string }) {
+export function UpgradesView({ projectId }: { projectId: string }) {
   const { version } = useProjectManifestVersion(projectId);
-  return (
-    <UpgradeViewContent version={version} action={<MigrateToV2Button projectId={projectId} />} />
-  );
+  const run = useRunUpgrade(projectId);
+  return <UpgradesViewContent version={version} onRun={run.start} pending={run.pending} />;
 }

--- a/apps/web/src/features/workspace/customize/migrate-to-v2/upgrade-view.tsx
+++ b/apps/web/src/features/workspace/customize/migrate-to-v2/upgrade-view.tsx
@@ -28,7 +28,7 @@ import { useState } from 'react';
 import CustomizeSectionWrapper from '../sections/component/section-wrapper';
 import type { ManifestVersion } from './manifest-version';
 import { useProjectManifestVersion } from './manifest-version';
-import { applicableUpgrades, buildOneOffUpgradePrompt, type ProjectUpgrade } from './upgrade-defs';
+import { type ProjectUpgrade, applicableUpgrades, buildOneOffUpgradePrompt } from './upgrade-defs';
 import { useRunUpgrade } from './use-run-upgrade';
 
 /** Presentational only — no data fetching, so every state renders under
@@ -45,8 +45,7 @@ export function UpgradesViewContent({
   pending: boolean;
 }) {
   const [oneOff, setOneOff] = useState('');
-  const upgrades =
-    version === null ? null : applicableUpgrades({ manifestVersion: version });
+  const upgrades = version === null ? null : applicableUpgrades({ manifestVersion: version });
 
   return (
     <CustomizeSectionWrapper
@@ -103,8 +102,8 @@ export function UpgradesViewContent({
         <Label>One-off upgrade</Label>
         <div className="bg-popover space-y-3 rounded-md border px-4 py-5">
           <p className="text-muted-foreground text-xs text-pretty">
-            Describe a single change to this project. An agent session makes it, validates,
-            and opens a change request — it never merges on its own.
+            Describe a single change to this project. An agent session makes it, validates, and
+            opens a change request — it never merges on its own.
           </p>
           <Textarea
             value={oneOff}

--- a/apps/web/src/features/workspace/customize/migrate-to-v2/use-migrate-to-v2.ts
+++ b/apps/web/src/features/workspace/customize/migrate-to-v2/use-migrate-to-v2.ts
@@ -16,18 +16,17 @@
  * prompt expects to be run.
  */
 
-import { useCallback, useState } from 'react';
+import { useCallback } from 'react';
 
-import { useNewProjectSession } from '@/hooks/projects/use-new-project-session';
-import { useCustomizeStore } from '@/stores/customize-store';
-import { writeStartStash, type StartStash } from '@kortix/sdk/react';
+import type { StartStash } from '@kortix/sdk/react';
 
 import { MIGRATE_TO_V2_PROMPT } from './migration-prompt';
+import { buildUpgradeStash, useRunUpgrade } from './use-run-upgrade';
 
 /** Pure — the exact stash payload the migration session is seeded with.
  *  Split out from the hook so it's unit-testable without React. */
 export function buildMigrateToV2Stash(): StartStash {
-  return { prompt: MIGRATE_TO_V2_PROMPT, agent: null, model: null, variant: null };
+  return buildUpgradeStash(MIGRATE_TO_V2_PROMPT);
 }
 
 export interface MigrateToV2 {
@@ -40,20 +39,7 @@ export interface MigrateToV2 {
 }
 
 export function useMigrateToV2(projectId: string): MigrateToV2 {
-  const closeCustomize = useCustomizeStore((s) => s.close);
-  const [pending, setPending] = useState(false);
-  const newSession = useNewProjectSession(projectId);
-
-  const start = useCallback(() => {
-    if (pending) return;
-    setPending(true);
-    newSession({
-      onNavigate: (sessionId) => {
-        writeStartStash(sessionId, buildMigrateToV2Stash());
-        closeCustomize();
-      },
-    });
-  }, [pending, newSession, closeCustomize]);
-
-  return { start, pending };
+  const run = useRunUpgrade(projectId);
+  const start = useCallback(() => run.start(MIGRATE_TO_V2_PROMPT), [run]);
+  return { start, pending: run.pending };
 }

--- a/apps/web/src/features/workspace/customize/migrate-to-v2/use-run-upgrade.ts
+++ b/apps/web/src/features/workspace/customize/migrate-to-v2/use-run-upgrade.ts
@@ -15,7 +15,7 @@ import { useCallback, useState } from 'react';
 
 import { useNewProjectSession } from '@/hooks/projects/use-new-project-session';
 import { useCustomizeStore } from '@/stores/customize-store';
-import { writeStartStash, type StartStash } from '@kortix/sdk/react';
+import { type StartStash, writeStartStash } from '@kortix/sdk/react';
 
 /** Pure — the exact stash payload an upgrade session is seeded with. */
 export function buildUpgradeStash(prompt: string): StartStash {

--- a/apps/web/src/features/workspace/customize/migrate-to-v2/use-run-upgrade.ts
+++ b/apps/web/src/features/workspace/customize/migrate-to-v2/use-run-upgrade.ts
@@ -1,0 +1,52 @@
+'use client';
+
+/**
+ * useRunUpgrade — start any agent-led upgrade session from Customize: mint a
+ * fresh session, stash the given prompt as its first message, close the
+ * overlay, and drop the user into the thread. The generic engine behind both
+ * the registry entries in `upgrade-defs.ts` and the one-off prompt runner;
+ * `useMigrateToV2` is the v2-specific wrapper kept for its button.
+ *
+ * Deliberately does NOT pass `agent_name` — the session boots the project's
+ * default agent (the one with git/CR powers).
+ */
+
+import { useCallback, useState } from 'react';
+
+import { useNewProjectSession } from '@/hooks/projects/use-new-project-session';
+import { useCustomizeStore } from '@/stores/customize-store';
+import { writeStartStash, type StartStash } from '@kortix/sdk/react';
+
+/** Pure — the exact stash payload an upgrade session is seeded with. */
+export function buildUpgradeStash(prompt: string): StartStash {
+  return { prompt, agent: null, model: null, variant: null };
+}
+
+export interface RunUpgrade {
+  /** Mint + navigate to a session seeded with `prompt`. Ignored while a
+   *  session is already being created. */
+  start: (prompt: string) => void;
+  pending: boolean;
+}
+
+export function useRunUpgrade(projectId: string): RunUpgrade {
+  const closeCustomize = useCustomizeStore((s) => s.close);
+  const [pending, setPending] = useState(false);
+  const newSession = useNewProjectSession(projectId);
+
+  const start = useCallback(
+    (prompt: string) => {
+      if (pending || !prompt.trim()) return;
+      setPending(true);
+      newSession({
+        onNavigate: (sessionId) => {
+          writeStartStash(sessionId, buildUpgradeStash(prompt));
+          closeCustomize();
+        },
+      });
+    },
+    [pending, newSession, closeCustomize],
+  );
+
+  return { start, pending };
+}


### PR DESCRIPTION
## What

Generalizes the v2-migration surface into a permanent **Upgrades** customize section, and deepens the migration prompt per today's dev-testing learnings. Pairs with #4207 (server-side empty-CR guard).

### Upgrades section
- **Registry** (`upgrade-defs.ts`): one-off, agent-run upgrades with a detection rule — the v1→v2 manifest migration is the first entry. Adding a future upgrade = one registry entry; the view renders whatever is applicable, with an "You're up to date" state otherwise.
- **One-off runner**: a textarea for "just change this one thing" requests. The prompt is wrapped in the landing contract (read first → validate manifest edits → fetch/rebase → commit → push → `kortix cr open` → verify via `kortix cr diff` → never merge → don't open an empty CR when there's nothing to do), so any freeform request still lands as a reviewable CR.
- **Rail placement**: the item is always reachable (Manage, next to Settings) and jumps to a pinned top slot while a registry upgrade is applicable.
- `useRunUpgrade` generalizes `useMigrateToV2` (which now delegates).

### v2 migration prompt
- **New: refresh the platform baseline first** — `kortix marketplace updates` → `kortix marketplace update --all` (hash-safe, kortix-managed skills + installed marketplace skills), with an explicit caveat that this commits directly to `main` via the platform's own path (not part of the CR), then `git fetch && git rebase origin/main`. Orphaned items are reported, not touched; everything untracked (agents' `.md`, memory, `opencode.jsonc`, continuation plugin, tools, custom skills) is on a hard never-touch list.
- **Advanced-main handling** (straight from today's CR #2 transcript): fetch/rebase before landing; on a `kortix.toml` modify/delete conflict, abort + reset to `origin/main` and redo the conversion against the current manifest; `--force-with-lease` scoped to the session's own branch.
- **Includes the cherry-picked push-step fix** (`5df81d5238`) that landed on the #4202 branch *after* its merge and never reached main — which is why today's second test run still produced an empty CR.

## Tests
- New `upgrade-defs.test.ts` (registry applicability, one-off wrapper contract) and rewritten `upgrade-view.test.tsx` (v1 / v2 / unresolved / pending states)
- Prompt tests extended: baseline-refresh ordering, direct-to-main caveat, never-touch scoping, rebase/redo-on-conflict, unique sequential section numbering
- Module suite 48/48, `tsc --noEmit` clean, biome clean on touched files