### PR TITLE
fix(sessions): normalize legacy 'daytona' provider at session-create (rename back-compat)

### DIFF
--- a/apps/api/src/projects/lib/sessions.provider.test.ts
+++ b/apps/api/src/projects/lib/sessions.provider.test.ts
@@ -1,17 +1,23 @@
 import { test, expect, describe } from 'bun:test';
 import { resolveSessionProvider } from './provider-precedence';
 
+// Mirrors config.normalizeProviderName (legacy 'daytona' → canonical 'managed').
+// Inlined so this stays a zero-dep pure test — importing config.ts would drag in
+// zod + full env validation and break the "no env/DB" isolation this file relies on.
+const norm = (p: string | null) => (p === 'daytona' ? 'managed' : p);
+
 // Per-project sandbox-provider override — precedence unit test. Deterministic:
 // `allowed` + `isEnabled` are injected (they model config.ALLOWED_SANDBOX_PROVIDERS
 // + config.isProviderEnabled), so no env/DB. Precedence under test:
 //   explicit request › per-project pin (if enabled) › fallback (weighted balancer).
-const ALLOWED = ['daytona', 'platinum'] as const;
+// Post-rename ALLOWED holds the canonical 'managed' (legacy 'daytona' → 'managed').
+const ALLOWED = ['managed', 'platinum'] as const;
 const bothEnabled = (_p: string) => true;
 
 describe('resolveSessionProvider (per-project provider override)', () => {
   test('explicit request wins over the pin + is used verbatim', () => {
     expect(
-      resolveSessionProvider({ requested: 'platinum', projectPin: 'daytona', allowed: ALLOWED, isEnabled: bothEnabled }),
+      resolveSessionProvider({ requested: 'platinum', projectPin: 'managed', allowed: ALLOWED, isEnabled: bothEnabled }),
     ).toEqual({ provider: 'platinum' });
   });
 
@@ -55,6 +61,43 @@ describe('resolveSessionProvider (per-project provider override)', () => {
   test('no request + no pin → fallback (weighted balancer runs)', () => {
     expect(
       resolveSessionProvider({ requested: null, projectPin: null, allowed: ALLOWED, isEnabled: bothEnabled }),
+    ).toEqual({ fallback: true });
+  });
+});
+
+// Provider rename back-compat (regression for the missed session-create call site
+// from PR #4201). createProjectSession runs body.provider / the project pin through
+// normalizeProviderName() BEFORE resolveSessionProvider — so the legacy 'daytona'
+// alias resolves to canonical 'managed' against ALLOWED=['managed','platinum']
+// instead of 400 "Unknown or disabled sandbox provider: daytona".
+describe('legacy daytona→managed normalization at session-create', () => {
+  test("explicit provider:'daytona' → managed (no longer a 400)", () => {
+    expect(
+      resolveSessionProvider({ requested: norm('daytona'), projectPin: null, allowed: ALLOWED, isEnabled: bothEnabled }),
+    ).toEqual({ provider: 'managed' });
+  });
+
+  test("explicit provider:'managed' → managed (canonical unaffected)", () => {
+    expect(
+      resolveSessionProvider({ requested: norm('managed'), projectPin: null, allowed: ALLOWED, isEnabled: bothEnabled }),
+    ).toEqual({ provider: 'managed' });
+  });
+
+  test("explicit provider:'platinum' → platinum (other provider unaffected)", () => {
+    expect(
+      resolveSessionProvider({ requested: norm('platinum'), projectPin: null, allowed: ALLOWED, isEnabled: bothEnabled }),
+    ).toEqual({ provider: 'platinum' });
+  });
+
+  test("legacy 'daytona' project pin → managed (used when enabled)", () => {
+    expect(
+      resolveSessionProvider({ requested: null, projectPin: norm('daytona'), allowed: ALLOWED, isEnabled: bothEnabled }),
+    ).toEqual({ provider: 'managed' });
+  });
+
+  test('no request + no pin still falls through unaffected', () => {
+    expect(
+      resolveSessionProvider({ requested: norm(null), projectPin: norm(null), allowed: ALLOWED, isEnabled: bothEnabled }),
     ).toEqual({ fallback: true });
   });
 });

--- a/apps/api/src/projects/lib/sessions.ts
+++ b/apps/api/src/projects/lib/sessions.ts
@@ -1,5 +1,5 @@
 import { checkBillingActive } from '../../billing/services/billing-gate';
-import { config, type SandboxProviderName } from '../../config';
+import { config, normalizeProviderName, type SandboxProviderName } from '../../config';
 import { resolveSessionProvider } from './provider-precedence';
 import { auth, json } from '../../openapi';
 import { resolveAccountSessionLimit } from '../../shared/account-limits';
@@ -446,12 +446,16 @@ export async function createProjectSession(input: {
   // Sandbox provider: explicit request › per-project pin (Customize → Settings) ›
   // weighted balancer. The pin lets you put ONE project on e.g. platinum regardless
   // of the global distribution weights — see resolveSessionProvider.
+  // Canonicalise the legacy 'daytona' alias → 'managed' BEFORE the allowed/enabled
+  // check (matches parseAllowedProviders/isProviderEnabled) so an explicit
+  // provider:'daytona' from any client (Kortix server, legacy SDK) keeps working.
+  const requestedProvider = normalizeString(body.provider);
+  const providerPin = normalizeString(
+    (project.metadata as Record<string, unknown> | null | undefined)?.default_sandbox_provider,
+  );
   const picked = resolveSessionProvider({
-    requested: normalizeString(body.provider) ?? null,
-    projectPin:
-      normalizeString(
-        (project.metadata as Record<string, unknown> | null | undefined)?.default_sandbox_provider,
-      ) ?? null,
+    requested: requestedProvider ? normalizeProviderName(requestedProvider) : null,
+    projectPin: providerPin ? normalizeProviderName(providerPin) : null,
     allowed: config.ALLOWED_SANDBOX_PROVIDERS,
     isEnabled: (p) => config.isProviderEnabled(p as SandboxProviderName),
   });


### PR DESCRIPTION
## The bug

PR #4201 renamed the sandbox provider `'daytona'` → `'managed'` and added a `normalizeProviderName()` helper (`apps/api/src/config.ts`) that maps the legacy alias `'daytona'` → `'managed'`. It applied that helper in `parseAllowedProviders` and `isProviderEnabled` — **but missed the session-create call site.**

`createProjectSession` (`apps/api/src/projects/lib/sessions.ts`) fed the raw `body.provider` (and the per-project pin `metadata.default_sandbox_provider`) straight into `resolveSessionProvider`'s allowed-check **without** normalizing first. Post-rename `ALLOWED_SANDBOX_PROVIDERS` is `['managed','platinum']`, so an explicit `provider: 'daytona'` from any client (the Kortix server, the SDK's legacy value) now returns:

```
400 Unknown or disabled sandbox provider: daytona
```

## The fix

One-line-per-value normalization at the call site — run the requested provider and the project pin through `normalizeProviderName()` **before** the allowed/enabled check, exactly like the other #4201 call sites:

```ts
requested: requestedProvider ? normalizeProviderName(requestedProvider) : null,
projectPin: providerPin   ? normalizeProviderName(providerPin)   : null,
```

- `'daytona'` → `'managed'` (back-compat restored — no more 400)
- `'managed'` and `'platinum'` pass through verbatim (canonical + other provider unaffected)
- default sessions (no `provider`, no pin) are **unaffected** — still fall through to the weighted balancer

## Verification

- `bunx tsc --noEmit` in `apps/api` → **0 errors**
- Extended the existing `sessions.provider.test.ts` with the legacy-alias cases (daytona→managed for both explicit request and pin; managed/platinum verbatim; no-request/no-pin fallback). **12/12 pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)