### PR TITLE
fix(web): give auto-created "My First Project" the full starter pack

### DIFF
--- a/apps/web/src/lib/auth/bootstrap-first-project.ts
+++ b/apps/web/src/lib/auth/bootstrap-first-project.ts
@@ -34,7 +34,12 @@ export async function resolveFirstProjectPathForNewUser(opts: {
 
   const result = await provisionProjectWithToken(
     { ...tokenOpts, timeoutMs: PROVISION_TIMEOUT_MS },
-    { account_id: accountId, name: 'My First Project', seed_starter: true },
+    {
+      account_id: accountId,
+      name: 'My First Project',
+      seed_starter: true,
+      starter_template: 'general-knowledge-worker',
+    },
   );
 
   if (result.ok) {

--- a/apps/web/src/lib/onboarding/ensure-first-project.provision.test.ts
+++ b/apps/web/src/lib/onboarding/ensure-first-project.provision.test.ts
@@ -33,7 +33,7 @@ describe('ensureFirstProject provisioning', () => {
       {
         account_id: 'acct_1',
         name: 'My First Project',
-        starter_template: 'minimal',
+        starter_template: 'general-knowledge-worker',
         marketplace_items: ['kortix-starter:agent-browser'],
       },
     ]);

--- a/apps/web/src/lib/onboarding/ensure-first-project.ts
+++ b/apps/web/src/lib/onboarding/ensure-first-project.ts
@@ -49,7 +49,7 @@ export async function ensureFirstProject(accountId: string): Promise<KortixProje
     return await provisionProject({
       account_id: accountId,
       name: 'My First Project',
-      starter_template: 'minimal',
+      starter_template: 'general-knowledge-worker',
       marketplace_items: marketplaceItems.map((item) => item.id),
     });
   } catch (err) {


### PR DESCRIPTION
## Summary
- Both new-user bootstrap paths for the auto-created "My First Project" (`apps/web/src/lib/onboarding/ensure-first-project.ts` and `apps/web/src/lib/auth/bootstrap-first-project.ts`) provisioned without an explicit `starter_template`.
- `normalizeStarterTemplateId` defaults to `'minimal'` when unset (`packages/starter/src/index.ts`), so every brand-new account's first project silently shipped without the general-knowledge-worker skill pack — one path set `'minimal'` explicitly, the other omitted the field and got the same default.
- Both now explicitly request `starter_template: 'general-knowledge-worker'`.

## Test plan
- [x] `bun test` on the touched files + related SDK provision tests (16/16 pass)
- [x] Updated the one test asserting the old `'minimal'` value