### PR TITLE
fix(sandbox): kill idle dead-time — 15m autostop, 5m trigger TTL, pre-stop busy probe, resume grace

### DIFF
--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -334,6 +334,13 @@ const envSchema = z.object({
   //   autostop   → idle box stops, compute billing ends. CLAMPED to >=1 at the
   //                use site so a box is NEVER created persistent.
   //                This is what actually stops the money burn.
+  //                Was 120 until 2026-07-07: prod never set the env var, so every
+  //                box idled a full 2h after its last real activity — 78% of all
+  //                billed sandbox-hours (Jul 1-7 audit) were idle tail charged to
+  //                users. 15 matches dev and the reaper's own default.
+  //                Trigger-fired sessions (source 'trigger:*') have no human
+  //                waiting on the box, so the reaper stops them after the much
+  //                shorter TRIGGER_AUTOSTOP window instead.
   //   autoarchive→ stopped box moves to cold storage after half a day (cheap,
   //                still resumable; kept warm-resumable in the meantime).
   //                Was 3 days (4320) until 2026-07-02: the org-wide (shared
@@ -347,7 +354,8 @@ const envSchema = z.object({
   //   autodelete → NEVER (-1). A sandbox is only ever removed when a user
   //                explicitly deletes the session — auto-stop + cold archive
   //                make an idle box nearly free, so we never destroy disk.
-  KORTIX_SANDBOX_AUTOSTOP_MINUTES:    optInt(120),
+  KORTIX_SANDBOX_AUTOSTOP_MINUTES:    optInt(15),
+  KORTIX_SANDBOX_TRIGGER_AUTOSTOP_MINUTES: optInt(5),
   KORTIX_SANDBOX_AUTOARCHIVE_MINUTES: optInt(720),    // 12 hours
   KORTIX_SANDBOX_AUTODELETE_MINUTES:  optInt(-1),     // never auto-delete
 
@@ -679,6 +687,7 @@ export const config = {
 
   // Sandbox lifecycle intervals (minutes) — see schema comment above.
   KORTIX_SANDBOX_AUTOSTOP_MINUTES: env.KORTIX_SANDBOX_AUTOSTOP_MINUTES,
+  KORTIX_SANDBOX_TRIGGER_AUTOSTOP_MINUTES: env.KORTIX_SANDBOX_TRIGGER_AUTOSTOP_MINUTES,
   KORTIX_SANDBOX_AUTOARCHIVE_MINUTES: env.KORTIX_SANDBOX_AUTOARCHIVE_MINUTES,
   KORTIX_SANDBOX_AUTODELETE_MINUTES: env.KORTIX_SANDBOX_AUTODELETE_MINUTES,
 

--- a/apps/api/src/platform/providers/daytona.test.ts
+++ b/apps/api/src/platform/providers/daytona.test.ts
@@ -84,3 +84,13 @@ test('getStatus() reports missing Daytona sandboxes as removed', async () => {
 
   await expect(provider.getStatus('sbx_missing')).resolves.toBe('removed');
 });
+
+test('native auto-stop is a backstop clamped well above the reaper TTL', async () => {
+  const { daytonaLifecycle } = await import('./daytona');
+  const { providerAutoStopBackstopMinutes } = await import('./index');
+
+  expect(providerAutoStopBackstopMinutes()).toBe(60);
+  expect(daytonaLifecycle().autoStopInterval).toBe(60);
+  expect(daytonaLifecycle(5).autoStopInterval).toBe(5);
+  expect(daytonaLifecycle(0).autoStopInterval).toBe(1);
+});

--- a/apps/api/src/platform/providers/daytona.ts
+++ b/apps/api/src/platform/providers/daytona.ts
@@ -16,6 +16,7 @@ import {
 } from '../../shared/daytona';
 import { serviceKeyForExternalId } from '../service-key';
 import { sandboxFrontendBaseUrl } from '../sandbox-frontend-url';
+import { providerAutoStopBackstopMinutes } from './index';
 import { withTimeout, configuredTimeoutMs } from '../../shared/with-timeout';
 
 // The Daytona SDK's axios client is created with a 24-HOUR timeout (see
@@ -126,8 +127,10 @@ function isMissingSandboxError(error: unknown): boolean {
  * idle sweep can't see boxes it has no DB row for.
  *
  *  - autoStopInterval: idle → stop (compute billing ends). CLAMPED to >= 1 so a
- *    box is NEVER created persistent. This is the setting that actually stops
- *    the money burn.
+ *    box is NEVER created persistent. BACKSTOP only: Daytona's idle signal is
+ *    "no inbound requests", blind to local tool runs, so it must sit well above
+ *    the reaper's activity-aware TTL (providerAutoStopBackstopMinutes) or it
+ *    kills working boxes.
  *  - autoArchiveInterval: stopped → archived to cold storage after a few days
  *    (cheap, still resumable). Until then the stopped box stays warm-resumable.
  *  - autoDeleteInterval: -1 by default → NEVER auto-delete. An idle box is
@@ -139,9 +142,9 @@ export function daytonaLifecycle(autoStopOverride?: number): {
   autoArchiveInterval: number;
   autoDeleteInterval: number;
 } {
-  const stop = autoStopOverride ?? config.KORTIX_SANDBOX_AUTOSTOP_MINUTES;
+  const stop = autoStopOverride ?? providerAutoStopBackstopMinutes();
   return {
-    autoStopInterval: Math.max(1, stop || config.KORTIX_SANDBOX_AUTOSTOP_MINUTES || 15),
+    autoStopInterval: Math.max(1, stop),
     autoArchiveInterval: config.KORTIX_SANDBOX_AUTOARCHIVE_MINUTES,
     autoDeleteInterval: config.KORTIX_SANDBOX_AUTODELETE_MINUTES,
   };

--- a/apps/api/src/platform/providers/index.ts
+++ b/apps/api/src/platform/providers/index.ts
@@ -116,6 +116,21 @@ export interface SandboxProvider {
   listManagedRunningSandboxes?(): Promise<Array<{ externalId: string; createdAt: Date | null }>>;
 }
 
+/**
+ * Provider-native auto-stop is a BACKSTOP, not the primary stop mechanism.
+ * The reaper (projects/sandbox-reaper.ts) is the primary: it asks the box's
+ * own opencode whether a turn is running before stopping, so it never kills
+ * mid-work. The provider's native timer only sees inbound traffic — blind to
+ * local tool runs — so at the reaper's TTL it WOULD kill working boxes (the
+ * 2026-06-24 "stopped too quickly mid-session" class). Its sole job is to
+ * stop boxes when this API is dead or the box has no DB row, so it sits well
+ * above the reaper's window.
+ */
+export function providerAutoStopBackstopMinutes(): number {
+  const ttl = Math.max(1, config.KORTIX_SANDBOX_AUTOSTOP_MINUTES || 15);
+  return Math.max(60, ttl * 2);
+}
+
 const providers = new Map<ProviderName, SandboxProvider>();
 
 export function getProvider(name: ProviderName): SandboxProvider {

--- a/apps/api/src/platform/providers/platinum.ts
+++ b/apps/api/src/platform/providers/platinum.ts
@@ -26,6 +26,7 @@ import type {
   ProvisioningTraits,
   ProvisioningStatus,
 } from './index';
+import { providerAutoStopBackstopMinutes } from './index';
 
 const AGENT_PORT = 8000;
 
@@ -101,14 +102,13 @@ export class PlatinumProvider implements SandboxProvider {
     // autoStopInterval maps to Platinum's auto_stop_minutes. 0 → persistent
     // (never auto-stops); >0 → ephemeral with that idle timeout.
     //
-    // Platinum now AUTO-STOPS idle boxes natively (idle timeout) and resumes them
-    // CoW on reopen. The old reason for forcing persistent (the CH UFFD demand-paged
-    // device-resume bug, isolated 2026-06-06, which wedged net+vsock on resume) is
-    // FIXED — the CH v52 UFFD patch landed; verified stop→resume ~2.3s with the guest
-    // alive. Relying on Platinum's own timer makes idle-stop robust (no dependency on
-    // the Kortix maintenance reaper, which when down let boxes run 24/7 and flood the
-    // host). A normal session gets KORTIX_SANDBOX_AUTOSTOP_MINUTES.
-    const autoStop = opts.autoStopInterval ?? config.KORTIX_SANDBOX_AUTOSTOP_MINUTES;
+    // Platinum AUTO-STOPS idle boxes natively and resumes them CoW on reopen
+    // (the CH UFFD resume bug that once forced persistent is fixed; verified
+    // stop→resume ~2.3s). Its native timer is the BACKSTOP for when this API
+    // is dead — the activity-aware reaper (sandbox-reaper.ts) is the primary
+    // stop, so the native interval sits well above the reaper's TTL to never
+    // kill a box mid-work (providerAutoStopBackstopMinutes).
+    const autoStop = opts.autoStopInterval ?? providerAutoStopBackstopMinutes();
 
     const _t0 = Date.now();
     // This asks Platinum to long-poll server-side for up to 60s

--- a/apps/api/src/projects/routes/shared.ts
+++ b/apps/api/src/projects/routes/shared.ts
@@ -68,8 +68,11 @@ export async function resumeStoppedSandbox(row: {
       updatedAt: now,
       // Explicit resume clears the reaper's idle-quiesce marker so the resumed
       // box is treated normally again (passive traffic can keep it warm until
-      // the next idle window).
-      metadata: sql`coalesce(${sessionSandboxes.metadata}, '{}'::jsonb) - 'idleQuiesced' - 'idleQuiescedAt'`,
+      // the next idle window) — and stamps lastTurnAt so the resume opens a
+      // FRESH idle window. Without the stamp the reaper's idle clock still
+      // reads the pre-stop last activity, already past the TTL, and the box
+      // gets re-reaped on the next pass before the user's first turn.
+      metadata: sql`(coalesce(${sessionSandboxes.metadata}, '{}'::jsonb) - 'idleQuiesced' - 'idleQuiescedAt') || ${JSON.stringify({ lastTurnAt: now.toISOString() })}::jsonb`,
     })
     .where(
       and(

--- a/apps/api/src/projects/routes/shared.ts
+++ b/apps/api/src/projects/routes/shared.ts
@@ -66,13 +66,11 @@ export async function resumeStoppedSandbox(row: {
     .set({
       status: 'active',
       updatedAt: now,
-      // Explicit resume clears the reaper's idle-quiesce marker so the resumed
-      // box is treated normally again (passive traffic can keep it warm until
-      // the next idle window) — and stamps lastTurnAt so the resume opens a
-      // FRESH idle window. Without the stamp the reaper's idle clock still
-      // reads the pre-stop last activity, already past the TTL, and the box
-      // gets re-reaped on the next pass before the user's first turn.
-      metadata: sql`(coalesce(${sessionSandboxes.metadata}, '{}'::jsonb) - 'idleQuiesced' - 'idleQuiescedAt') || ${JSON.stringify({ lastTurnAt: now.toISOString() })}::jsonb`,
+      // Explicit resume clears the reaper's idle-quiesce marker AND its idle
+      // countdown (idleObservedAt — a stale pre-stop stamp would shut the box
+      // down on the very next pass), and stamps lastTurnAt so the resume opens
+      // a FRESH idle window for the unreachable-box fallback clock too.
+      metadata: sql`(coalesce(${sessionSandboxes.metadata}, '{}'::jsonb) - 'idleQuiesced' - 'idleQuiescedAt' - 'idleObservedAt') || ${JSON.stringify({ lastTurnAt: now.toISOString() })}::jsonb`,
     })
     .where(
       and(

--- a/apps/api/src/projects/sandbox-busy-probe.test.ts
+++ b/apps/api/src/projects/sandbox-busy-probe.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+let previewLink: { url: string; token: string | null } = { url: 'https://box.example', token: 'ptoken' };
+let serviceKey: string | null = 'svc-key';
+let previewLinkError: Error | null = null;
+
+mock.module('../sandbox-proxy/backend', () => ({
+  resolvePreviewLink: async () => {
+    if (previewLinkError) throw previewLinkError;
+    return previewLink;
+  },
+  resolveServiceKey: async () => serviceKey,
+}));
+
+const { classifySessionStatusBody, probeSandboxBusy } = await import('./sandbox-busy-probe');
+
+const realFetch = globalThis.fetch;
+let fetchResponse: (() => Response | Promise<Response>) | null = null;
+let lastRequest: { url: string; headers: Record<string, string> } | null = null;
+
+beforeEach(() => {
+  previewLink = { url: 'https://box.example', token: 'ptoken' };
+  serviceKey = 'svc-key';
+  previewLinkError = null;
+  fetchResponse = null;
+  lastRequest = null;
+  globalThis.fetch = (async (url: any, init: any) => {
+    lastRequest = { url: String(url), headers: (init?.headers ?? {}) as Record<string, string> };
+    if (!fetchResponse) throw new Error('no fetch stub');
+    return fetchResponse();
+  }) as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+describe('classifySessionStatusBody', () => {
+  test('any busy session marks the box busy', () => {
+    expect(classifySessionStatusBody({ a: { type: 'idle' }, b: { type: 'busy' } })).toBe('busy');
+  });
+  test('a retrying turn counts as busy', () => {
+    expect(classifySessionStatusBody({ a: { type: 'retry', attempt: 2 } })).toBe('busy');
+  });
+  test('all idle → idle', () => {
+    expect(classifySessionStatusBody({ a: { type: 'idle' }, b: { type: 'idle' } })).toBe('idle');
+  });
+  test('no sessions → idle', () => {
+    expect(classifySessionStatusBody({})).toBe('idle');
+  });
+  test('non-object bodies → unknown', () => {
+    expect(classifySessionStatusBody(null)).toBe('unknown');
+    expect(classifySessionStatusBody('nope')).toBe('unknown');
+    expect(classifySessionStatusBody([1, 2])).toBe('unknown');
+  });
+});
+
+describe('probeSandboxBusy', () => {
+  const row = { sandboxId: 'sb-1', externalId: 'ext-1' };
+
+  test('busy body → busy, with auth + preview headers sent', async () => {
+    fetchResponse = () => new Response(JSON.stringify({ s1: { type: 'busy' } }), { status: 200 });
+    expect(await probeSandboxBusy(row)).toBe('busy');
+    expect(lastRequest?.url).toBe('https://box.example/session/status');
+    expect(lastRequest?.headers['Authorization']).toBe('Bearer svc-key');
+    expect(lastRequest?.headers['X-Daytona-Preview-Token']).toBe('ptoken');
+    expect(lastRequest?.headers['X-Kortix-User-Context']).toContain('.');
+  });
+
+  test('all-idle body → idle', async () => {
+    fetchResponse = () => new Response(JSON.stringify({ s1: { type: 'idle' } }), { status: 200 });
+    expect(await probeSandboxBusy(row)).toBe('idle');
+  });
+
+  test('non-200 (legacy opencode without the endpoint) → unknown', async () => {
+    fetchResponse = () => new Response('nope', { status: 404 });
+    expect(await probeSandboxBusy(row)).toBe('unknown');
+  });
+
+  test('fetch failure → unknown', async () => {
+    fetchResponse = () => {
+      throw new Error('timeout');
+    };
+    expect(await probeSandboxBusy(row)).toBe('unknown');
+  });
+
+  test('missing service key → unknown without calling the box', async () => {
+    serviceKey = null;
+    expect(await probeSandboxBusy(row)).toBe('unknown');
+    expect(lastRequest).toBeNull();
+  });
+
+  test('preview-link resolution failure → unknown', async () => {
+    previewLinkError = new Error('no sandbox row');
+    expect(await probeSandboxBusy(row)).toBe('unknown');
+  });
+});

--- a/apps/api/src/projects/sandbox-busy-probe.ts
+++ b/apps/api/src/projects/sandbox-busy-probe.ts
@@ -1,0 +1,74 @@
+/**
+ * Pre-stop busy probe — the reaper's "is a process still running?" check.
+ *
+ * The idle heuristic (last LLM call / lastTurnAt) goes blind during long tool
+ * executions, upstream retries, and subagent work: none of those leave a
+ * usage_events trail while they run. That blindness is what forced the
+ * autostop TTL to 120m on 2026-06-24 ("idle sandboxes were stopping too
+ * quickly mid-session") — and the 2h TTL then billed every box ~2h of idle
+ * tail. Instead of a huge TTL, ask the box directly before stopping it:
+ * opencode's `GET /session/status` returns `{ [sessionId]: { type } }` with
+ * type 'busy' | 'retry' | 'idle' for every session in the box (root and
+ * subagents). Reached through the daemon's catch-all proxy, so it works on
+ * every already-provisioned sandbox — no image change required.
+ *
+ * Fail direction: 'unknown' (unreachable box, legacy opencode without the
+ * endpoint, timeout) falls through to the stop — identical to pre-probe
+ * behavior. A wedged daemon must never hold compute billing open forever;
+ * the probe is a veto for provably-busy boxes, not a requirement.
+ */
+
+import { resolvePreviewLink, resolveServiceKey } from '../sandbox-proxy/backend';
+import { encodeKortixUserContext, KORTIX_USER_CONTEXT_HEADER } from '../shared/kortix-user-context';
+
+export type SandboxBusyState = 'busy' | 'idle' | 'unknown';
+
+const PROBE_TIMEOUT_MS = 3_000;
+const SANDBOX_SERVICE_PORT = 8000;
+
+/** Pure classifier for opencode's /session/status body. Exported for tests. */
+export function classifySessionStatusBody(body: unknown): SandboxBusyState {
+  if (!body || typeof body !== 'object' || Array.isArray(body)) return 'unknown';
+  const statuses = Object.values(body as Record<string, unknown>);
+  for (const s of statuses) {
+    const type = (s as { type?: unknown } | null)?.type;
+    if (type === 'busy' || type === 'retry') return 'busy';
+  }
+  return 'idle';
+}
+
+export async function probeSandboxBusy(row: {
+  sandboxId: string;
+  externalId: string;
+}): Promise<SandboxBusyState> {
+  try {
+    const [link, serviceKey] = await Promise.all([
+      resolvePreviewLink(row.externalId, SANDBOX_SERVICE_PORT),
+      resolveServiceKey(row.sandboxId),
+    ]);
+    if (!serviceKey) return 'unknown';
+    const headers: Record<string, string> = {
+      'X-Daytona-Skip-Preview-Warning': 'true',
+      'X-Daytona-Disable-CORS': 'true',
+      Authorization: `Bearer ${serviceKey}`,
+      [KORTIX_USER_CONTEXT_HEADER]: encodeKortixUserContext(
+        {
+          userId: 'system:sandbox-reaper',
+          sandboxId: row.sandboxId,
+          sandboxRole: 'platform_admin',
+          scopes: [],
+        },
+        serviceKey,
+      ),
+    };
+    if (link.token) headers['X-Daytona-Preview-Token'] = link.token;
+    const res = await fetch(`${link.url}/session/status`, {
+      headers,
+      signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+    });
+    if (!res.ok) return 'unknown';
+    return classifySessionStatusBody(await res.json());
+  } catch {
+    return 'unknown';
+  }
+}

--- a/apps/api/src/projects/sandbox-reaper.test.ts
+++ b/apps/api/src/projects/sandbox-reaper.test.ts
@@ -1,9 +1,8 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
-import { projectSessions, sessionSandboxes, chatTurnStreams, usageEvents } from '@kortix/db';
+import { projectSessions, sessionSandboxes, usageEvents } from '@kortix/db';
 
 // ── mock state ──────────────────────────────────────────────────────────────
 let candidates: any[] = [];
-let activeTurns: Array<{ sessionId: string }> = [];
 let usageRows: Array<{ sessionId: string; last: string }> = [];
 let throwOnUsageLookup = false;
 let statusByExternal: Record<string, 'running' | 'stopped' | 'removed' | 'unknown'> = {};
@@ -47,13 +46,11 @@ mock.module('../shared/db', () => ({
           hybrid(
             table === sessionSandboxes
               ? candidates
-              : table === chatTurnStreams
-                ? activeTurns
-                : table === usageEvents
-                  ? usageRows
-                  : table === projectSessions
-                    ? stuckSessions
-                    : [],
+              : table === usageEvents
+                ? usageRows
+                : table === projectSessions
+                  ? stuckSessions
+                  : [],
             table === usageEvents && throwOnUsageLookup,
           ),
       }),
@@ -113,7 +110,6 @@ const TTL = 15 * 60_000;
 
 beforeEach(() => {
   candidates = [];
-  activeTurns = [];
   usageRows = [];
   throwOnUsageLookup = false;
   statusByExternal = {};
@@ -398,17 +394,6 @@ describe('reapAndReconcileSandboxes', () => {
     expect(stops).toEqual([]);
   });
 
-  test('never reaps a box with a turn in flight', async () => {
-    candidates = [candidate()]; // idle by timestamp
-    statusByExternal['ext-1'] = 'running';
-    activeTurns = [{ sessionId: 'sess-1' }];
-
-    const r = await reapAndReconcileSandboxes(NOW);
-
-    expect(r.skipped).toBe(1);
-    expect(stops).toEqual([]);
-  });
-
   test('does not act on transient unknown provider state', async () => {
     candidates = [candidate()];
     statusByExternal['ext-1'] = 'unknown';
@@ -452,8 +437,8 @@ describe('reapAndReconcileSandboxes', () => {
     expect(stops).toEqual([]); // never poke a removed box
   });
 
-  test('FAIL-SAFE: when the activity lookup fails, never stop a running box', async () => {
-    candidates = [candidate()]; // idle by timestamp (created 2h ago)
+  test('FAIL-SAFE: unreachable box + failed usage lookup → never stop', async () => {
+    candidates = [candidate()]; // idle by timestamp (created 2h ago), probe defaults to unknown
     statusByExternal['ext-1'] = 'running';
     throwOnUsageLookup = true; // simulate a DB/transient failure
 
@@ -462,6 +447,18 @@ describe('reapAndReconcileSandboxes', () => {
     expect(stops).toEqual([]); // uncertain → do not stop
     expect(pausedCompute).toEqual([]);
     expect(r.stopped).toBe(0);
+  });
+
+  test('probe-confirmed idle still counts down even when the usage lookup fails', async () => {
+    candidates = [candidate({ metadata: { idleObservedAt: new Date(NOW.getTime() - TTL).toISOString() } })];
+    statusByExternal['ext-1'] = 'running';
+    busyByExternal['ext-1'] = 'idle';
+    throwOnUsageLookup = true;
+
+    const r = await reapAndReconcileSandboxes(NOW);
+
+    expect(r.stopped).toBe(1);
+    expect(stops).toEqual(['ext-1']);
   });
 });
 

--- a/apps/api/src/projects/sandbox-reaper.test.ts
+++ b/apps/api/src/projects/sandbox-reaper.test.ts
@@ -107,7 +107,7 @@ mock.module('../billing/services/compute-metering', () => ({
   },
 }));
 
-const { decideReap, lastMeaningfulAt, reapAndReconcileSandboxes, buildIdleStopMetadata, reapOrphanProviderBoxes, reconcileStuckActiveSessions, isTriggerSession, triggerAutoStopTtlMs } = await import('./sandbox-reaper');
+const { decideReconcile, decideIdleConfirm, idleObservedAtOf, lastMeaningfulAt, reapAndReconcileSandboxes, buildIdleStopMetadata, reapOrphanProviderBoxes, reconcileStuckActiveSessions, isTriggerSession, triggerAutoStopTtlMs } = await import('./sandbox-reaper');
 
 const TTL = 15 * 60_000;
 
@@ -128,37 +128,47 @@ beforeEach(() => {
   busyByExternal = {};
 });
 
-// ── pure decision matrix (the money + UX correctness lives here) ─────────────
-describe('decideReap', () => {
+// ── pure decision functions (the money + UX correctness lives here) ──────────
+describe('decideReconcile', () => {
   test('never acts on unknown provider state', () => {
-    expect(decideReap({ providerStatus: 'unknown', meaningfulIdleMs: 10 * TTL, hasActiveTurn: false, ttlMs: TTL, provider: 'daytona' }).action).toBe('none');
+    expect(decideReconcile('unknown')).toBe('none');
   });
-
-  test('removed → reconcile-removed + reprovision', () => {
-    const d = decideReap({ providerStatus: 'removed', meaningfulIdleMs: 0, hasActiveTurn: false, ttlMs: TTL, provider: 'platinum' });
-    expect(d.action).toBe('reconcile-removed');
-    expect(d.reprovisionOnResume).toBe(true);
+  test('removed → reconcile-removed', () => {
+    expect(decideReconcile('removed')).toBe('reconcile-removed');
   });
-
   test('provider already stopped → reconcile-stopped', () => {
-    expect(decideReap({ providerStatus: 'stopped', meaningfulIdleMs: 0, hasActiveTurn: false, ttlMs: TTL, provider: 'daytona' }).action).toBe('reconcile-stopped');
+    expect(decideReconcile('stopped')).toBe('reconcile-stopped');
   });
-
-  test('running + idle past TTL → stop-idle', () => {
-    expect(decideReap({ providerStatus: 'running', meaningfulIdleMs: TTL + 1, hasActiveTurn: false, ttlMs: TTL, provider: 'daytona' }).action).toBe('stop-idle');
+  test('running is not a reconcile concern', () => {
+    expect(decideReconcile('running')).toBe('none');
   });
+});
 
-  test('running + idle but a turn is in flight → none', () => {
-    expect(decideReap({ providerStatus: 'running', meaningfulIdleMs: 10 * TTL, hasActiveTurn: true, ttlMs: TTL, provider: 'daytona' }).action).toBe('none');
+describe('decideIdleConfirm', () => {
+  const now = new Date('2026-07-07T12:00:00Z');
+  test('no prior observation → arm the countdown', () => {
+    expect(decideIdleConfirm({ idleObservedAt: null, now, ttlMs: TTL })).toBe('arm');
   });
-
-  test('running + within TTL → none', () => {
-    expect(decideReap({ providerStatus: 'running', meaningfulIdleMs: TTL - 1, hasActiveTurn: false, ttlMs: TTL, provider: 'daytona' }).action).toBe('none');
+  test('observed idle but countdown not elapsed → wait', () => {
+    expect(decideIdleConfirm({ idleObservedAt: new Date(now.getTime() - TTL + 1), now, ttlMs: TTL })).toBe('wait');
   });
+  test('observed idle for the full TTL → stop', () => {
+    expect(decideIdleConfirm({ idleObservedAt: new Date(now.getTime() - TTL), now, ttlMs: TTL })).toBe('stop');
+  });
+  test('future stamp (clock skew) → re-arm', () => {
+    expect(decideIdleConfirm({ idleObservedAt: new Date(now.getTime() + 60_000), now, ttlMs: TTL })).toBe('arm');
+  });
+});
 
-  test('Daytona idle stop resumes in place; Platinum must reprovision', () => {
-    expect(decideReap({ providerStatus: 'running', meaningfulIdleMs: TTL + 1, hasActiveTurn: false, ttlMs: TTL, provider: 'daytona' }).reprovisionOnResume).toBe(false);
-    expect(decideReap({ providerStatus: 'running', meaningfulIdleMs: TTL + 1, hasActiveTurn: false, ttlMs: TTL, provider: 'platinum' }).reprovisionOnResume).toBe(true);
+describe('idleObservedAtOf', () => {
+  test('reads a valid stamp', () => {
+    expect(idleObservedAtOf({ idleObservedAt: '2026-07-07T11:00:00.000Z' })?.toISOString()).toBe('2026-07-07T11:00:00.000Z');
+  });
+  test('null / missing / cleared / garbage → null', () => {
+    expect(idleObservedAtOf(null)).toBeNull();
+    expect(idleObservedAtOf({})).toBeNull();
+    expect(idleObservedAtOf({ idleObservedAt: null })).toBeNull();
+    expect(idleObservedAtOf({ idleObservedAt: 'not-a-date' })).toBeNull();
   });
 });
 
@@ -282,8 +292,35 @@ describe('reapAndReconcileSandboxes', () => {
     expect(sbUpdate?.updates.status).toBeUndefined();
   });
 
-  test('probe-confirmed idle box still stops', async () => {
+  test('first idle observation arms the countdown instead of stopping', async () => {
     candidates = [candidate()];
+    statusByExternal['ext-1'] = 'running';
+    busyByExternal['ext-1'] = 'idle';
+
+    const r = await reapAndReconcileSandboxes(NOW);
+
+    expect(r.idleArmed).toBe(1);
+    expect(r.stopped).toBe(0);
+    expect(stops).toEqual([]);
+    const sbUpdate = updateCalls.find((c) => c.table === sessionSandboxes);
+    expect(sbUpdate?.updates.metadata).toBeDefined();
+    expect(sbUpdate?.updates.status).toBeUndefined();
+  });
+
+  test('observed idle for less than the TTL → wait, no writes', async () => {
+    candidates = [candidate({ metadata: { idleObservedAt: new Date(NOW.getTime() - TTL + 60_000).toISOString() } })];
+    statusByExternal['ext-1'] = 'running';
+    busyByExternal['ext-1'] = 'idle';
+
+    const r = await reapAndReconcileSandboxes(NOW);
+
+    expect(r.skipped).toBe(1);
+    expect(r.stopped).toBe(0);
+    expect(updateCalls).toEqual([]);
+  });
+
+  test('observed idle for the full TTL → shut down', async () => {
+    candidates = [candidate({ metadata: { idleObservedAt: new Date(NOW.getTime() - TTL).toISOString() } })];
     statusByExternal['ext-1'] = 'running';
     busyByExternal['ext-1'] = 'idle';
 
@@ -291,6 +328,25 @@ describe('reapAndReconcileSandboxes', () => {
 
     expect(r.stopped).toBe(1);
     expect(stops).toEqual(['ext-1']);
+    expect(pausedCompute).toEqual(['sb-1']);
+  });
+
+  test('trigger boxes confirm idle on the shorter TTL', async () => {
+    const sixMinAgo = new Date(NOW.getTime() - 6 * 60_000).toISOString();
+    candidates = [
+      candidate({ sandboxId: 'sb-t', sessionId: 'sess-t', externalId: 'ext-t', metadata: { source: 'trigger:webhook', idleObservedAt: sixMinAgo } }),
+      candidate({ sandboxId: 'sb-u', sessionId: 'sess-u', externalId: 'ext-u', metadata: { source: 'ui', idleObservedAt: sixMinAgo } }),
+    ];
+    statusByExternal['ext-t'] = 'running';
+    statusByExternal['ext-u'] = 'running';
+    busyByExternal['ext-t'] = 'idle';
+    busyByExternal['ext-u'] = 'idle';
+
+    const r = await reapAndReconcileSandboxes(NOW);
+
+    expect(stops).toEqual(['ext-t']);
+    expect(r.stopped).toBe(1);
+    expect(r.skipped).toBe(1);
   });
 
   test('Platinum idle stop flags reprovision (resume is broken)', async () => {

--- a/apps/api/src/projects/sandbox-reaper.test.ts
+++ b/apps/api/src/projects/sandbox-reaper.test.ts
@@ -32,7 +32,12 @@ function hybrid(rows: any[], throwOnGroupBy = false) {
 // test doesn't import the real config, which calls process.exit on incomplete
 // local env. Run this file in its own `bun test <file>` invocation (as CI does)
 // so the mock never leaks into a sibling file that uses the real config.
-mock.module('../config', () => ({ config: { KORTIX_SANDBOX_AUTOSTOP_MINUTES: 15, DAYTONA_API_KEY: 'test-key' } }));
+mock.module('../config', () => ({ config: { KORTIX_SANDBOX_AUTOSTOP_MINUTES: 15, KORTIX_SANDBOX_TRIGGER_AUTOSTOP_MINUTES: 5, DAYTONA_API_KEY: 'test-key' } }));
+
+let busyByExternal: Record<string, 'busy' | 'idle' | 'unknown'> = {};
+mock.module('./sandbox-busy-probe', () => ({
+  probeSandboxBusy: async ({ externalId }: { externalId: string }) => busyByExternal[externalId] ?? 'unknown',
+}));
 
 mock.module('../shared/db', () => ({
   db: {
@@ -102,7 +107,7 @@ mock.module('../billing/services/compute-metering', () => ({
   },
 }));
 
-const { decideReap, lastMeaningfulAt, reapAndReconcileSandboxes, buildIdleStopMetadata, reapOrphanProviderBoxes, reconcileStuckActiveSessions } = await import('./sandbox-reaper');
+const { decideReap, lastMeaningfulAt, reapAndReconcileSandboxes, buildIdleStopMetadata, reapOrphanProviderBoxes, reconcileStuckActiveSessions, isTriggerSession, triggerAutoStopTtlMs } = await import('./sandbox-reaper');
 
 const TTL = 15 * 60_000;
 
@@ -120,6 +125,7 @@ beforeEach(() => {
   endedCompute = [];
   updateCalls = [];
   stuckSessions = [];
+  busyByExternal = {};
 });
 
 // ── pure decision matrix (the money + UX correctness lives here) ─────────────
@@ -172,6 +178,27 @@ describe('lastMeaningfulAt', () => {
   });
 });
 
+describe('isTriggerSession', () => {
+  test('trigger:* sources are unattended', () => {
+    expect(isTriggerSession({ source: 'trigger:webhook' })).toBe(true);
+    expect(isTriggerSession({ source: 'trigger:cron' })).toBe(true);
+    expect(isTriggerSession({ source: 'trigger:manual' })).toBe(true);
+  });
+  test('interactive and unknown sources are not', () => {
+    expect(isTriggerSession({ source: 'ui' })).toBe(false);
+    expect(isTriggerSession({ source: 'slack' })).toBe(false);
+    expect(isTriggerSession({})).toBe(false);
+    expect(isTriggerSession(null)).toBe(false);
+    expect(isTriggerSession({ source: 42 })).toBe(false);
+  });
+});
+
+describe('triggerAutoStopTtlMs', () => {
+  test('reads the trigger-specific knob', () => {
+    expect(triggerAutoStopTtlMs()).toBe(5 * 60_000);
+  });
+});
+
 describe('buildIdleStopMetadata', () => {
   const nowIso = '2026-06-21T12:00:00.000Z';
   test('idle stop quiesces so passive traffic cannot resurrect', () => {
@@ -221,6 +248,49 @@ describe('reapAndReconcileSandboxes', () => {
     expect(sbUpdate?.updates.status).toBe('stopped');
     expect(sbUpdate?.updates.metadata).toBeDefined(); // quiesce flag merged
     expect(updateCalls.some((c) => c.table === projectSessions && c.updates.status === 'stopped')).toBe(true);
+  });
+
+  test('trigger box idles out on the short TTL while an interactive twin survives', async () => {
+    const sixMinAgo = new Date(NOW.getTime() - 6 * 60_000);
+    candidates = [
+      candidate({ sandboxId: 'sb-t', sessionId: 'sess-t', externalId: 'ext-t', metadata: { source: 'trigger:webhook' }, createdAt: sixMinAgo }),
+      candidate({ sandboxId: 'sb-u', sessionId: 'sess-u', externalId: 'ext-u', metadata: { source: 'ui' }, createdAt: sixMinAgo }),
+    ];
+    statusByExternal['ext-t'] = 'running';
+    statusByExternal['ext-u'] = 'running';
+
+    const r = await reapAndReconcileSandboxes(NOW);
+
+    expect(stops).toEqual(['ext-t']);
+    expect(r.stopped).toBe(1);
+    expect(r.skipped).toBe(1);
+  });
+
+  test('busy probe vetoes the stop and resets the idle clock', async () => {
+    candidates = [candidate()];
+    statusByExternal['ext-1'] = 'running';
+    busyByExternal['ext-1'] = 'busy';
+
+    const r = await reapAndReconcileSandboxes(NOW);
+
+    expect(r.busyVetoed).toBe(1);
+    expect(r.stopped).toBe(0);
+    expect(stops).toEqual([]);
+    expect(pausedCompute).toEqual([]);
+    const sbUpdate = updateCalls.find((c) => c.table === sessionSandboxes);
+    expect(sbUpdate?.updates.metadata).toBeDefined();
+    expect(sbUpdate?.updates.status).toBeUndefined();
+  });
+
+  test('probe-confirmed idle box still stops', async () => {
+    candidates = [candidate()];
+    statusByExternal['ext-1'] = 'running';
+    busyByExternal['ext-1'] = 'idle';
+
+    const r = await reapAndReconcileSandboxes(NOW);
+
+    expect(r.stopped).toBe(1);
+    expect(stops).toEqual(['ext-1']);
   });
 
   test('Platinum idle stop flags reprovision (resume is broken)', async () => {

--- a/apps/api/src/projects/sandbox-reaper.ts
+++ b/apps/api/src/projects/sandbox-reaper.ts
@@ -64,57 +64,53 @@ export function isTriggerSession(metadata: Record<string, unknown> | null): bool
   return typeof source === 'string' && source.startsWith('trigger:');
 }
 
-export type ReapAction = 'none' | 'stop-idle' | 'reconcile-stopped' | 'reconcile-removed';
-
-export interface ReapDecision {
-  action: ReapAction;
-  /** Platinum stop→resume is broken (CH resume-freeze) → the next open must
-   *  REPROVISION a fresh box rather than start() the stopped one. */
-  reprovisionOnResume: boolean;
-  reason: string;
+/** When the reaper first OBSERVED the box idle (probe-confirmed). Null when
+ *  never observed / cleared by a busy observation or an explicit resume. */
+export function idleObservedAtOf(metadata: Record<string, unknown> | null): Date | null {
+  const raw = metadata?.idleObservedAt;
+  if (typeof raw !== 'string') return null;
+  const d = new Date(raw);
+  return Number.isNaN(d.getTime()) ? null : d;
 }
 
-/**
- * Pure, deterministic decision from the provider's REAL state + meaningful idle.
- * Kept side-effect-free so it is exhaustively unit-tested (the money + UX
- * correctness lives here).
- */
-export function decideReap(input: {
-  providerStatus: SandboxStatus;
-  meaningfulIdleMs: number;
-  hasActiveTurn: boolean;
-  ttlMs: number;
-  provider: ProviderName;
-}): ReapDecision {
-  const { providerStatus, meaningfulIdleMs, hasActiveTurn, ttlMs, provider } = input;
+export type IdleConfirmAction = 'arm' | 'wait' | 'stop';
 
-  // NEVER act on uncertainty. getStatus() returns 'unknown' on a transient
-  // provider error or a transitional state (starting/resuming/migrating);
-  // stopping or reconciling on that could kill a healthy box or fight a wake.
-  if (providerStatus === 'unknown') {
-    return { action: 'none', reprovisionOnResume: false, reason: 'provider-unknown' };
-  }
+/**
+ * The idle TTL counts from OBSERVED idleness, not from the last LLM call —
+ * the last usage_event can predate the real turn end by however long the
+ * final tool run takes, and stopping "TTL after last LLM call" could kill a
+ * box seconds after its turn actually finished. So the first probe-confirmed
+ * idle observation only ARMS the timer; the stop fires once the box has
+ * stayed observably idle for the full TTL, and any busy observation disarms.
+ * Pure so the money semantics are exhaustively unit-tested.
+ */
+export function decideIdleConfirm(input: {
+  idleObservedAt: Date | null;
+  now: Date;
+  ttlMs: number;
+}): IdleConfirmAction {
+  const { idleObservedAt, now, ttlMs } = input;
+  if (!idleObservedAt || idleObservedAt.getTime() > now.getTime()) return 'arm';
+  return now.getTime() - idleObservedAt.getTime() >= ttlMs ? 'stop' : 'wait';
+}
+
+export type ReconcileAction = 'none' | 'reconcile-stopped' | 'reconcile-removed';
+
+/**
+ * Pure reconcile decision for a box the provider says is NOT running.
+ * (Running boxes take the probe path: busy → alive, observed idle for the
+ * TTL → stop.) 'unknown' is a transient provider error or a transitional
+ * state (starting/resuming/migrating) — NEVER act on uncertainty; acting
+ * could kill a healthy box or fight a wake.
+ */
+export function decideReconcile(providerStatus: SandboxStatus): ReconcileAction {
   // The external box is gone — finalize billing and mark our row so the next
   // open reprovisions instead of trying to resume a box that no longer exists.
-  if (providerStatus === 'removed') {
-    return { action: 'reconcile-removed', reprovisionOnResume: true, reason: 'provider-removed' };
-  }
+  if (providerStatus === 'removed') return 'reconcile-removed';
   // Provider already stopped/archived it (its own auto-stop, an admin, or a
   // webhook we missed) but our row still says active — reconcile + close billing.
-  if (providerStatus === 'stopped') {
-    return { action: 'reconcile-stopped', reprovisionOnResume: false, reason: 'provider-stopped' };
-  }
-
-  // providerStatus === 'running'
-  // A turn in flight (long agent run / streaming) is meaningful even if the last
-  // stamped lastTurnAt is older than the TTL — never reap an in-progress turn.
-  if (hasActiveTurn) {
-    return { action: 'none', reprovisionOnResume: false, reason: 'active-turn' };
-  }
-  if (meaningfulIdleMs > ttlMs) {
-    return { action: 'stop-idle', reprovisionOnResume: provider === 'platinum', reason: 'meaningful-idle' };
-  }
-  return { action: 'none', reprovisionOnResume: false, reason: 'within-ttl' };
+  if (providerStatus === 'stopped') return 'reconcile-stopped';
+  return 'none';
 }
 
 /**
@@ -211,7 +207,8 @@ export interface ReapResult {
   reconciled: number;   // provider already not-running; we synced our row
   billingClosed: number;
   skipped: number;
-  busyVetoed: number;   // idle-by-TTL but the box itself reported a running turn
+  busyVetoed: number;   // idle-by-clock but the box itself reported a running turn
+  idleArmed: number;    // first probe-confirmed idle observation — TTL countdown started
   errors: number;
 }
 
@@ -243,7 +240,7 @@ export async function reapAndReconcileSandboxes(now = new Date()): Promise<ReapR
     ))
     .limit(REAP_BATCH_SIZE)) as ReapCandidate[];
 
-  const result: ReapResult = { candidates: rows.length, stopped: 0, reconciled: 0, billingClosed: 0, skipped: 0, busyVetoed: 0, errors: 0 };
+  const result: ReapResult = { candidates: rows.length, stopped: 0, reconciled: 0, billingClosed: 0, skipped: 0, busyVetoed: 0, idleArmed: 0, errors: 0 };
   if (rows.length === 0) return result;
 
   const sessionIds = rows.map((r) => r.sessionId);
@@ -271,25 +268,81 @@ export async function reapAndReconcileSandboxes(now = new Date()): Promise<ReapR
       try {
         const provider = getProvider(row.provider);
         const providerStatus: SandboxStatus = await provider.getStatus(row.externalId);
-        // Meaningful = latest of (stamped lastTurnAt | row creation) and the last
-        // LLM call for the session. Passive traffic (proxy/opencode/presence) is
-        // deliberately NOT considered.
-        const base = lastMeaningfulAt(row);
-        const usage = lastUsageBySession.get(row.sessionId);
-        const lastMeaningful = usage && usage.getTime() > base.getTime() ? usage : base;
-        const meaningfulIdleMs = now.getTime() - lastMeaningful.getTime();
-        const decision = decideReap({
-          providerStatus,
-          meaningfulIdleMs,
-          // When the activity signal is unreliable this cycle, treat the box as
-          // if a turn is in flight so a running box is never stopped on uncertain
-          // data (provider-confirmed stopped/removed still reconciles).
-          hasActiveTurn: !activitySignalReliable || activeTurnSessions.has(row.sessionId),
-          ttlMs: isTriggerSession(row.metadata) ? triggerTtlMs : ttlMs,
-          provider: row.provider,
-        });
+        const rowTtl = isTriggerSession(row.metadata) ? triggerTtlMs : ttlMs;
 
-        switch (decision.action) {
+        // ── Running boxes: the simple rule — busy → alive; observed idle for
+        // the TTL → shut down. The box's own opencode session status is the
+        // primary signal (it sees tool runs / retries / subagents that leave no
+        // LLM-usage trail); the activity clock survives only as the fallback
+        // for boxes we can't reach, so a wedged daemon still gets stopped.
+        if (providerStatus === 'running') {
+          // Fail-safe first: a Slack turn in flight or an unreliable activity
+          // lookup this cycle → never touch the box.
+          if (!activitySignalReliable || activeTurnSessions.has(row.sessionId)) {
+            result.skipped += 1;
+            continue;
+          }
+          const busyState = await probeSandboxBusy({ sandboxId: row.sandboxId, externalId: row.externalId });
+          if (busyState === 'busy') {
+            // A running process — disarm the countdown, stamp the activity.
+            await db
+              .update(sessionSandboxes)
+              .set({ updatedAt: now, metadata: mergeMetadata({ lastTurnAt: now.toISOString(), idleObservedAt: null }) })
+              .where(eq(sessionSandboxes.sandboxId, row.sandboxId));
+            result.busyVetoed += 1;
+            continue;
+          }
+          if (busyState === 'idle') {
+            const confirm = decideIdleConfirm({ idleObservedAt: idleObservedAtOf(row.metadata), now, ttlMs: rowTtl });
+            if (confirm === 'arm') {
+              await db
+                .update(sessionSandboxes)
+                .set({ updatedAt: now, metadata: mergeMetadata({ idleObservedAt: now.toISOString() }) })
+                .where(eq(sessionSandboxes.sandboxId, row.sandboxId));
+              result.idleArmed += 1;
+              continue;
+            }
+            if (confirm === 'wait') {
+              result.skipped += 1;
+              continue;
+            }
+            // 'stop' — observed idle for the full TTL → fall through.
+          } else {
+            // 'unknown' — box unreachable / legacy image. Fall back to the
+            // activity clock (latest of stamped lastTurnAt | row creation |
+            // last LLM call; passive proxy traffic deliberately NOT counted).
+            const base = lastMeaningfulAt(row);
+            const usage = lastUsageBySession.get(row.sessionId);
+            const lastMeaningful = usage && usage.getTime() > base.getTime() ? usage : base;
+            if (now.getTime() - lastMeaningful.getTime() <= rowTtl) {
+              result.skipped += 1;
+              continue;
+            }
+          }
+          try {
+            await provider.stop(row.externalId);
+          } catch (err) {
+            if (isLifecycleTransitionInProgress(err)) {
+              result.skipped += 1;
+              continue;
+            }
+            if (!isAlreadyNotRunning(err)) {
+              result.errors += 1;
+              console.error(
+                `[reaper] provider.stop failed for sandbox ${row.sandboxId}: ${(err as Error)?.message ?? err}`,
+              );
+              continue;
+            }
+            // Already stopped/gone on the provider side is success — reconcile.
+          }
+          await reconcileRowToStopped(row, now, /* quiesce */ true, /* reprovision */ row.provider === 'platinum');
+          result.stopped += 1;
+          result.billingClosed += 1;
+          continue;
+        }
+
+        // ── Not running: reconcile our row to the provider's real state.
+        switch (decideReconcile(providerStatus)) {
           case 'none':
             result.skipped += 1;
             break;
@@ -323,43 +376,6 @@ export async function reapAndReconcileSandboxes(now = new Date()): Promise<ReapR
             result.reconciled += 1;
             result.billingClosed += 1;
             break;
-          case 'stop-idle': {
-            // The idle heuristic can't see long tool runs / retries / subagent
-            // work (no usage_events trail while they execute) — ask the box
-            // itself before pulling the plug. 'busy' resets the idle clock;
-            // 'unknown' (unreachable/legacy box) proceeds to stop, exactly the
-            // pre-probe behavior, so a wedged daemon can't hold billing open.
-            const busyState = await probeSandboxBusy({ sandboxId: row.sandboxId, externalId: row.externalId });
-            if (busyState === 'busy') {
-              await db
-                .update(sessionSandboxes)
-                .set({ updatedAt: now, metadata: mergeMetadata({ lastTurnAt: now.toISOString() }) })
-                .where(eq(sessionSandboxes.sandboxId, row.sandboxId));
-              result.busyVetoed += 1;
-              break;
-            }
-            try {
-              await provider.stop(row.externalId);
-            } catch (err) {
-              if (isLifecycleTransitionInProgress(err)) {
-                result.skipped += 1;
-                break;
-              }
-              if (!isAlreadyNotRunning(err)) {
-                result.errors += 1;
-                console.error(
-                  `[reaper] provider.stop failed for sandbox ${row.sandboxId}: ${(err as Error)?.message ?? err}`,
-                );
-                break;
-              }
-              // Already stopped/gone on the provider side is success — reconcile
-              // our row + close billing.
-            }
-            await reconcileRowToStopped(row, now, /* quiesce */ true, decision.reprovisionOnResume);
-            result.stopped += 1;
-            result.billingClosed += 1;
-            break;
-          }
         }
       } catch (err) {
         result.errors += 1;

--- a/apps/api/src/projects/sandbox-reaper.ts
+++ b/apps/api/src/projects/sandbox-reaper.ts
@@ -1,31 +1,34 @@
 /**
  * Provider-agnostic sandbox reaper + state/billing reconciler.
  *
- * THE problem this fixes (verified live 2026-06-21): session sandboxes stayed
- * running for hours/days after work finished, and the compute meter kept billing
- * them — 1,597 phantom-active compute rows across 23 accounts.
+ * ONE RULE for running boxes: ask the box itself. Each pass probes the box's
+ * own opencode session status (sandbox-busy-probe.ts):
  *
- * Root cause was twofold:
- *   1. Daytona's provider-side auto-stop ("stop after N min of no REQUEST to the
- *      box") never fired because passive traffic — an open tab streaming opencode
- *      events, repeated /start, the server-side opencode-pin hit — touched each
- *      box < auto-stop apart. So "15 min idle" never elapsed.
- *   2. Kortix's own idle GC keyed off `session_sandboxes.last_used_at`, which is
- *      bumped ONLY by /v1/p proxy traffic — a partial signal that real turn/
- *      session traffic never touches — and its stops didn't stick (auto-wake).
+ *   busy/retry → alive. Disarm the idle countdown, stamp lastTurnAt.
+ *   idle       → the first observation ARMS `metadata.idleObservedAt`; the
+ *                stop fires only once the box has stayed OBSERVABLY idle for
+ *                the full TTL. The TTL counts from real idleness — never from
+ *                a heuristic like "last LLM call", which can predate the turn
+ *                end by a whole tool run (the 2026-06-24 mid-session kills).
+ *   unknown    → unreachable / legacy box. Fall back to the activity clock
+ *                (lastTurnAt | row creation | last LLM usage_event + TTL) so a
+ *                wedged daemon can't hold compute billing open forever.
  *
- * The fix is to stop trusting "any request" as activity. We define MEANINGFUL
- * activity = a real turn (a prompt / Slack message / agent run), stamped as
- * `metadata.lastTurnAt` at the turn boundary, and we make the PROVIDER's real
- * state (getStatus) the source of truth. A box with no meaningful activity for
- * the TTL is stopped regardless of how much passive traffic it sees, and billing
- * is closed the moment the provider reports it is no longer running.
+ * Trigger-fired boxes (metadata.source 'trigger:*') confirm idle on a shorter
+ * TTL — nobody is waiting on a webhook/cron box.
  *
- * Webhooks (see channels/providers webhook ingress) are the fast path that
- * closes billing the instant a box stops; this reaper is the deterministic
- * backstop that runs even if an event is dropped — together they make
- * "15 min of no real activity → stopped, and never billed while stopped" an
- * invariant rather than a best-effort.
+ * Passive traffic (an open tab streaming events, /v1/p proxy hits, repeated
+ * /start polls) is deliberately NEVER treated as activity — trusting it is
+ * what once kept idle boxes alive for days (verified live 2026-06-21: 1,597
+ * phantom-active compute rows). The provider's own auto-stop timer survives
+ * only as the orphan backstop (providerAutoStopBackstopMinutes): its "no
+ * inbound requests" signal is blind to local tool runs, so it sits well above
+ * the reaper's TTL and matters only when this API is dead.
+ *
+ * Provider webhooks are the fast path that closes billing the instant a box
+ * stops; this reaper is the deterministic backstop that runs even if an event
+ * is dropped — together they make "idle for the TTL → stopped, and never
+ * billed while stopped" an invariant rather than a best-effort.
  */
 
 import { and, eq, gt, inArray, isNotNull, lt, or, sql } from 'drizzle-orm';
@@ -212,11 +215,67 @@ export interface ReapResult {
   errors: number;
 }
 
+type RunningBoxOutcome = 'stopped' | 'busyVetoed' | 'idleArmed' | 'skipped' | 'errors';
+
+/**
+ * The rule for one running box: busy → alive; observed idle for the TTL →
+ * shut down; unreachable → activity-clock fallback so a wedged daemon still
+ * stops. `fallbackLastMeaningful` is null when this pass's usage lookup
+ * failed — then an unreachable box cannot be judged at all and is skipped
+ * (never act on uncertainty).
+ */
+async function reapRunningBox(
+  row: ReapCandidate,
+  opts: { now: Date; ttlMs: number; fallbackLastMeaningful: Date | null },
+): Promise<RunningBoxOutcome> {
+  const { now, ttlMs, fallbackLastMeaningful } = opts;
+  const busyState = await probeSandboxBusy({ sandboxId: row.sandboxId, externalId: row.externalId });
+
+  if (busyState === 'busy') {
+    // A running process — disarm the countdown, stamp the activity.
+    await db
+      .update(sessionSandboxes)
+      .set({ updatedAt: now, metadata: mergeMetadata({ lastTurnAt: now.toISOString(), idleObservedAt: null }) })
+      .where(eq(sessionSandboxes.sandboxId, row.sandboxId));
+    return 'busyVetoed';
+  }
+
+  if (busyState === 'idle') {
+    const confirm = decideIdleConfirm({ idleObservedAt: idleObservedAtOf(row.metadata), now, ttlMs });
+    if (confirm === 'arm') {
+      await db
+        .update(sessionSandboxes)
+        .set({ updatedAt: now, metadata: mergeMetadata({ idleObservedAt: now.toISOString() }) })
+        .where(eq(sessionSandboxes.sandboxId, row.sandboxId));
+      return 'idleArmed';
+    }
+    if (confirm === 'wait') return 'skipped';
+    // 'stop' — observed idle for the full TTL → fall through to the stop.
+  } else {
+    // 'unknown' — box unreachable / legacy image: activity-clock fallback.
+    if (!fallbackLastMeaningful) return 'skipped';
+    if (now.getTime() - fallbackLastMeaningful.getTime() <= ttlMs) return 'skipped';
+  }
+
+  try {
+    await getProvider(row.provider).stop(row.externalId);
+  } catch (err) {
+    if (isLifecycleTransitionInProgress(err)) return 'skipped';
+    if (!isAlreadyNotRunning(err)) {
+      console.error(`[reaper] provider.stop failed for sandbox ${row.sandboxId}: ${(err as Error)?.message ?? err}`);
+      return 'errors';
+    }
+    // Already stopped/gone on the provider side is success — reconcile.
+  }
+  await reconcileRowToStopped(row, now, /* quiesce */ true, /* reprovision */ row.provider === 'platinum');
+  return 'stopped';
+}
+
 /**
  * One reaper pass over active session sandboxes. For each:
  *   - ask the provider its REAL state,
  *   - reconcile our row + close billing if it is not running,
- *   - stop it (and close billing) if it has had no meaningful activity for the TTL.
+ *   - otherwise apply the running-box rule (probe → busy alive / idle countdown).
  * Bounded concurrency so a batch of provider round-trips doesn't serialize.
  */
 export async function reapAndReconcileSandboxes(now = new Date()): Promise<ReapResult> {
@@ -243,101 +302,32 @@ export async function reapAndReconcileSandboxes(now = new Date()): Promise<ReapR
   const result: ReapResult = { candidates: rows.length, stopped: 0, reconciled: 0, billingClosed: 0, skipped: 0, busyVetoed: 0, idleArmed: 0, errors: 0 };
   if (rows.length === 0) return result;
 
-  const sessionIds = rows.map((r) => r.sessionId);
-  // The real activity signals, batched (both lookups are indexed):
-  //  - last LLM call per session (the truest "a real turn happened" signal,
-  //    covering web / Slack / trigger uniformly — the gateway stamps session_id
-  //    on usage_events), and
-  //  - which sessions have a turn IN FLIGHT (unfinalized stream) — never reap those.
-  const [usageResult, activeTurnResult] = await Promise.all([
-    loadLastUsageBySession(sessionIds),
-    loadActiveTurnSessions(sessionIds),
-  ]);
-  // FAIL-SAFE: a null result means the lookup itself FAILED (DB/transient). We
-  // then cannot prove a box is idle, so we must NOT stop it on uncertain data —
-  // same "never act on uncertainty" rule the provider-status path follows.
-  // Provider-confirmed stopped/removed reconciliation still proceeds below.
-  const activitySignalReliable = usageResult !== null && activeTurnResult !== null;
-  const lastUsageBySession = usageResult ?? new Map<string, Date>();
-  const activeTurnSessions = activeTurnResult ?? new Set<string>();
+  // Batched fallback signal: last LLM call per session (indexed usage_events).
+  // Only consulted for boxes the probe can't reach; null = the lookup itself
+  // failed this pass, and unreachable boxes are then skipped (fail safe).
+  const lastUsageBySession = await loadLastUsageBySession(rows.map((r) => r.sessionId));
 
   let cursor = 0;
   const worker = async () => {
     while (cursor < rows.length) {
       const row = rows[cursor++];
       try {
-        const provider = getProvider(row.provider);
-        const providerStatus: SandboxStatus = await provider.getStatus(row.externalId);
-        const rowTtl = isTriggerSession(row.metadata) ? triggerTtlMs : ttlMs;
+        const providerStatus: SandboxStatus = await getProvider(row.provider).getStatus(row.externalId);
 
-        // ── Running boxes: the simple rule — busy → alive; observed idle for
-        // the TTL → shut down. The box's own opencode session status is the
-        // primary signal (it sees tool runs / retries / subagents that leave no
-        // LLM-usage trail); the activity clock survives only as the fallback
-        // for boxes we can't reach, so a wedged daemon still gets stopped.
         if (providerStatus === 'running') {
-          // Fail-safe first: a Slack turn in flight or an unreliable activity
-          // lookup this cycle → never touch the box.
-          if (!activitySignalReliable || activeTurnSessions.has(row.sessionId)) {
-            result.skipped += 1;
-            continue;
-          }
-          const busyState = await probeSandboxBusy({ sandboxId: row.sandboxId, externalId: row.externalId });
-          if (busyState === 'busy') {
-            // A running process — disarm the countdown, stamp the activity.
-            await db
-              .update(sessionSandboxes)
-              .set({ updatedAt: now, metadata: mergeMetadata({ lastTurnAt: now.toISOString(), idleObservedAt: null }) })
-              .where(eq(sessionSandboxes.sandboxId, row.sandboxId));
-            result.busyVetoed += 1;
-            continue;
-          }
-          if (busyState === 'idle') {
-            const confirm = decideIdleConfirm({ idleObservedAt: idleObservedAtOf(row.metadata), now, ttlMs: rowTtl });
-            if (confirm === 'arm') {
-              await db
-                .update(sessionSandboxes)
-                .set({ updatedAt: now, metadata: mergeMetadata({ idleObservedAt: now.toISOString() }) })
-                .where(eq(sessionSandboxes.sandboxId, row.sandboxId));
-              result.idleArmed += 1;
-              continue;
-            }
-            if (confirm === 'wait') {
-              result.skipped += 1;
-              continue;
-            }
-            // 'stop' — observed idle for the full TTL → fall through.
-          } else {
-            // 'unknown' — box unreachable / legacy image. Fall back to the
-            // activity clock (latest of stamped lastTurnAt | row creation |
-            // last LLM call; passive proxy traffic deliberately NOT counted).
+          let fallbackLastMeaningful: Date | null = null;
+          if (lastUsageBySession !== null) {
             const base = lastMeaningfulAt(row);
             const usage = lastUsageBySession.get(row.sessionId);
-            const lastMeaningful = usage && usage.getTime() > base.getTime() ? usage : base;
-            if (now.getTime() - lastMeaningful.getTime() <= rowTtl) {
-              result.skipped += 1;
-              continue;
-            }
+            fallbackLastMeaningful = usage && usage.getTime() > base.getTime() ? usage : base;
           }
-          try {
-            await provider.stop(row.externalId);
-          } catch (err) {
-            if (isLifecycleTransitionInProgress(err)) {
-              result.skipped += 1;
-              continue;
-            }
-            if (!isAlreadyNotRunning(err)) {
-              result.errors += 1;
-              console.error(
-                `[reaper] provider.stop failed for sandbox ${row.sandboxId}: ${(err as Error)?.message ?? err}`,
-              );
-              continue;
-            }
-            // Already stopped/gone on the provider side is success — reconcile.
-          }
-          await reconcileRowToStopped(row, now, /* quiesce */ true, /* reprovision */ row.provider === 'platinum');
-          result.stopped += 1;
-          result.billingClosed += 1;
+          const outcome = await reapRunningBox(row, {
+            now,
+            ttlMs: isTriggerSession(row.metadata) ? triggerTtlMs : ttlMs,
+            fallbackLastMeaningful,
+          });
+          result[outcome] += 1;
+          if (outcome === 'stopped') result.billingClosed += 1;
           continue;
         }
 
@@ -413,26 +403,6 @@ async function loadLastUsageBySession(sessionIds: string[]): Promise<Map<string,
     return out;
   } catch (err) {
     console.warn('[reaper] usage-activity lookup failed — failing safe (no stops this cycle):', err instanceof Error ? err.message : err);
-    return null;
-  }
-}
-
-/**
- * Session ids that currently have an unfinalized turn stream (a turn in flight).
- * Returns `null` on a lookup FAILURE so the caller fails safe (never reap when
- * we can't tell if a turn is running). Empty set = looked up fine, none active.
- */
-async function loadActiveTurnSessions(sessionIds: string[]): Promise<Set<string> | null> {
-  if (sessionIds.length === 0) return new Set();
-  try {
-    const { chatTurnStreams } = await import('@kortix/db');
-    const rows = await db
-      .select({ sessionId: chatTurnStreams.sessionId })
-      .from(chatTurnStreams)
-      .where(and(inArray(chatTurnStreams.sessionId, sessionIds), eq(chatTurnStreams.finalized, false)));
-    return new Set(rows.map((r) => r.sessionId));
-  } catch (err) {
-    console.warn('[reaper] active-turn lookup failed — failing safe (no stops this cycle):', err instanceof Error ? err.message : err);
     return null;
   }
 }

--- a/apps/api/src/projects/sandbox-reaper.ts
+++ b/apps/api/src/projects/sandbox-reaper.ts
@@ -34,17 +34,34 @@ import { db } from '../shared/db';
 import { getProvider, type ProviderName, type SandboxStatus } from '../platform/providers';
 import { invalidateProviderCache } from '../sandbox-proxy';
 import { pauseComputeSession, endComputeSession } from '../billing/services/compute-metering';
+import { probeSandboxBusy } from './sandbox-busy-probe';
 import { ACTIVE_SESSION_STATUSES } from './lib/session-status';
 import { config } from '../config';
 
 export const REAP_BATCH_SIZE = 100;
 const REAP_CONCURRENCY = 6;
 const DEFAULT_AUTOSTOP_MINUTES = 15;
+const DEFAULT_TRIGGER_AUTOSTOP_MINUTES = 5;
 
 /** The single knob for "how long with no real turn before we stop a box". */
 export function autoStopTtlMs(): number {
   const min = Math.max(1, config.KORTIX_SANDBOX_AUTOSTOP_MINUTES || DEFAULT_AUTOSTOP_MINUTES);
   return min * 60_000;
+}
+
+/** Shorter idle window for trigger-fired boxes — no human is waiting on them,
+ *  so every idle minute past turn end is pure billed dead time. */
+export function triggerAutoStopTtlMs(): number {
+  const min = Math.max(1, config.KORTIX_SANDBOX_TRIGGER_AUTOSTOP_MINUTES || DEFAULT_TRIGGER_AUTOSTOP_MINUTES);
+  return min * 60_000;
+}
+
+/** Sandbox rows carry the session's invocation source in `metadata.source`
+ *  (stamped at provisioning). 'trigger:*' boxes are unattended; anything else
+ *  (ui/slack/cli/missing) is treated as interactive — the safe direction. */
+export function isTriggerSession(metadata: Record<string, unknown> | null): boolean {
+  const source = metadata?.source;
+  return typeof source === 'string' && source.startsWith('trigger:');
 }
 
 export type ReapAction = 'none' | 'stop-idle' | 'reconcile-stopped' | 'reconcile-removed';
@@ -194,6 +211,7 @@ export interface ReapResult {
   reconciled: number;   // provider already not-running; we synced our row
   billingClosed: number;
   skipped: number;
+  busyVetoed: number;   // idle-by-TTL but the box itself reported a running turn
   errors: number;
 }
 
@@ -206,6 +224,7 @@ export interface ReapResult {
  */
 export async function reapAndReconcileSandboxes(now = new Date()): Promise<ReapResult> {
   const ttlMs = autoStopTtlMs();
+  const triggerTtlMs = triggerAutoStopTtlMs();
 
   const rows = (await db
     .select({
@@ -224,7 +243,7 @@ export async function reapAndReconcileSandboxes(now = new Date()): Promise<ReapR
     ))
     .limit(REAP_BATCH_SIZE)) as ReapCandidate[];
 
-  const result: ReapResult = { candidates: rows.length, stopped: 0, reconciled: 0, billingClosed: 0, skipped: 0, errors: 0 };
+  const result: ReapResult = { candidates: rows.length, stopped: 0, reconciled: 0, billingClosed: 0, skipped: 0, busyVetoed: 0, errors: 0 };
   if (rows.length === 0) return result;
 
   const sessionIds = rows.map((r) => r.sessionId);
@@ -266,7 +285,7 @@ export async function reapAndReconcileSandboxes(now = new Date()): Promise<ReapR
           // if a turn is in flight so a running box is never stopped on uncertain
           // data (provider-confirmed stopped/removed still reconciles).
           hasActiveTurn: !activitySignalReliable || activeTurnSessions.has(row.sessionId),
-          ttlMs,
+          ttlMs: isTriggerSession(row.metadata) ? triggerTtlMs : ttlMs,
           provider: row.provider,
         });
 
@@ -304,7 +323,21 @@ export async function reapAndReconcileSandboxes(now = new Date()): Promise<ReapR
             result.reconciled += 1;
             result.billingClosed += 1;
             break;
-          case 'stop-idle':
+          case 'stop-idle': {
+            // The idle heuristic can't see long tool runs / retries / subagent
+            // work (no usage_events trail while they execute) — ask the box
+            // itself before pulling the plug. 'busy' resets the idle clock;
+            // 'unknown' (unreachable/legacy box) proceeds to stop, exactly the
+            // pre-probe behavior, so a wedged daemon can't hold billing open.
+            const busyState = await probeSandboxBusy({ sandboxId: row.sandboxId, externalId: row.externalId });
+            if (busyState === 'busy') {
+              await db
+                .update(sessionSandboxes)
+                .set({ updatedAt: now, metadata: mergeMetadata({ lastTurnAt: now.toISOString() }) })
+                .where(eq(sessionSandboxes.sandboxId, row.sandboxId));
+              result.busyVetoed += 1;
+              break;
+            }
             try {
               await provider.stop(row.externalId);
             } catch (err) {
@@ -326,6 +359,7 @@ export async function reapAndReconcileSandboxes(now = new Date()): Promise<ReapR
             result.stopped += 1;
             result.billingClosed += 1;
             break;
+          }
         }
       } catch (err) {
         result.errors += 1;


### PR DESCRIPTION
## Problem

Since 2026-06-24 (9356a5ab58 raised autostop 15m → 120m), every prod sandbox billed ~2h of idle tail after its last real activity. Audit of Jul 1–7: **78% of all billed sandbox-hours (~3,400h, ~$614 of ~$788 in user charges) were dead time.** Affected users have been reimbursed ($161.92 across 40 accounts, ledger keys `reimbursement:idle-tail-autostop-2026-07-07:*`).

The 120m bump papered over the real defect: the reaper couldn't see a running turn outside Slack (its only signals were Slack turn-streams + the last LLM usage_event), so long tool runs / retries looked idle and got killed mid-session. Raising the TTL 8× was the workaround.

## The model (simple by design)

Every reaper pass (5 min), for each running box, ask the box itself — opencode `GET /session/status` via the daemon catch-all proxy (works on every existing sandbox, no image change):

- **busy / retry** → alive; disarm the countdown, stamp `lastTurnAt`.
- **idle** → first observation **arms** `metadata.idleObservedAt`; the stop fires only once the box has stayed observably idle for the full TTL. The TTL counts from *actual observed idleness*, never from a heuristic.
- **unreachable / legacy** → fall back to the old activity clock (last LLM call / lastTurnAt / createdAt + TTL) so a wedged daemon can't hold billing open forever.

A box can never be stopped mid-work (probe veto) and can never be stopped before it has been idle for the full TTL (armed countdown). `decideReap`'s running-state matrix became dead code under this model and was collapsed to `decideReconcile` (provider stopped/removed reconciliation); the money semantics live in the pure `decideIdleConfirm`.

## Changes

1. `KORTIX_SANDBOX_AUTOSTOP_MINUTES` default 120 → 15 (dev parity; prod env never set it, so the code default WAS prod behavior). Already applied to prod Secrets Manager ahead of this deploy — the backlog sweep stopped 58 idle boxes within 10 minutes.
2. Trigger-fired boxes (`metadata.source` = `trigger:*`) confirm idle on `KORTIX_SANDBOX_TRIGGER_AUTOSTOP_MINUTES` (default 5m) — nobody is waiting on a webhook/cron box.
3. `sandbox-busy-probe.ts` — Bearer service key + self-signed system `X-Kortix-User-Context`; 3s timeout; `unknown` on any failure.
4. Resume clears `idleQuiesced`/`idleObservedAt` and stamps `lastTurnAt` — a resumed box gets a fresh idle window instead of being re-reaped on the next pass.

## Tests
- `decideIdleConfirm` arm/wait/stop matrix + clock-skew re-arm; `idleObservedAtOf` parsing; `decideReconcile`.
- Orchestration: busy veto (no stop, no billing close, countdown disarmed), arm-on-first-idle, wait-under-TTL (no writes), stop-after-TTL, trigger-vs-interactive TTL split, unreachable-box clock fallback, fail-safes untouched. 41 + 11 pass.

## Follow-ups (not this PR)
- Daemon `session.status` SSE handler → push-based busy state (needs image rollout).
- Generalize turn-end relay beyond Slack so `lastTurnAt` stamps at every turn boundary.