### PR TITLE
fix(snapshots): stop dev-only CLI/test churn from re-minting every project's sandbox runtime identity

### DIFF
--- a/apps/api/src/snapshots/__tests__/cli-executor-closure.test.ts
+++ b/apps/api/src/snapshots/__tests__/cli-executor-closure.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from 'bun:test';
+import { existsSync, readFileSync, statSync } from 'node:fs';
+import { dirname, isAbsolute, join, normalize, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Scope guard for the in-sandbox `kortix executor` fingerprint (templates.ts
+// CLI_EXECUTOR_CLOSURE).
+//
+// The snapshot runtime fingerprint used to hash ALL of apps/cli/src, so every
+// developer-only CLI edit (`ship`, `cr`, `tunnel`, `self-host`, the scaffold
+// surface, …) re-minted every project's runtime identity and moved the non-agent
+// `swapKey`, disabling the cheap agent-swap and forcing a full rebuild. A sandbox
+// session only ever runs `kortix executor` / `kortix executor mcp`, so the
+// fingerprint now hashes just that command's import closure.
+//
+// This test re-derives the closure from the real import graph and asserts it is a
+// SUBSET of the hashed set. If a future refactor makes the executor path import a
+// file that isn't fingerprinted, this fails — so scoping can never silently ship a
+// stale in-sandbox executor under an unchanged snapshot identity. When it fails,
+// add the newly-imported file (or its dir) to CLI_EXECUTOR_CLOSURE in templates.ts.
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '../../../../..');
+const CLI_SRC = resolve(REPO_ROOT, 'apps/cli/src');
+
+// Must mirror CLI_EXECUTOR_CLOSURE in apps/api/src/snapshots/templates.ts.
+const HASHED_CLOSURE = [
+  'executor',
+  'commands/executor.ts',
+  'api/auth.ts',
+  'api/client.ts',
+  'api/config.ts',
+  'api/sandbox-env.ts',
+  'project-link.ts',
+] as const;
+
+// Entrypoints the sandbox actually invokes (`kortix executor …`). The `index.ts`
+// dispatcher is deliberately NOT an entrypoint here: it imports EVERY subcommand
+// for arg routing, so seeding from it would pull the whole (monolithic) CLI in.
+// Its executor branch is just `argv[0] === 'executor' → runExecutor()`, whose
+// behavior lives entirely in commands/executor.ts + executor/*.
+const ENTRYPOINTS = [
+  'commands/executor.ts',
+  'executor/gateway.ts',
+  'executor/io.ts',
+  'executor/mcp.ts',
+];
+
+/** Resolve a relative import specifier (from `fromFile`) to a real .ts file, or null. */
+function resolveImport(fromFile: string, spec: string): string | null {
+  const base = resolve(dirname(fromFile), spec);
+  for (const cand of [base, `${base}.ts`, `${base}.tsx`, join(base, 'index.ts')]) {
+    if (existsSync(cand) && statSync(cand).isFile()) return cand;
+  }
+  return null;
+}
+
+/** BFS the transitive relative-import closure (absolute file paths) under CLI_SRC. */
+function importClosure(entrypoints: string[]): Set<string> {
+  const seen = new Set<string>();
+  const stack = entrypoints.map((e) => resolve(CLI_SRC, e));
+  const importRe = /from\s+['"](\.[^'"]+)['"]/g;
+  while (stack.length) {
+    const file = stack.pop()!;
+    if (seen.has(file) || !existsSync(file)) continue;
+    seen.add(file);
+    const src = readFileSync(file, 'utf8');
+    for (const m of src.matchAll(importRe)) {
+      const target = resolveImport(file, m[1]);
+      if (target) stack.push(target);
+    }
+  }
+  return seen;
+}
+
+/** True iff `abs` is covered by a hashed closure entry (a file, or a dir prefix). */
+function isHashed(abs: string): boolean {
+  const rel = relative(CLI_SRC, abs);
+  return HASHED_CLOSURE.some((entry) => {
+    const norm = normalize(entry);
+    return rel === norm || rel.startsWith(`${norm}/`);
+  });
+}
+
+describe('kortix executor fingerprint closure', () => {
+  test('every file the in-sandbox executor imports is in the hashed CLI closure', () => {
+    const closure = [...importClosure(ENTRYPOINTS)];
+    // All entrypoints must resolve — a typo here would make the guard vacuous.
+    for (const e of ENTRYPOINTS) {
+      expect(existsSync(resolve(CLI_SRC, e))).toBe(true);
+    }
+    const uncovered = closure
+      .filter((f) => !isHashed(f))
+      .map((f) => relative(CLI_SRC, f))
+      .sort();
+    // If this fails, the executor now depends on a file that isn't fingerprinted:
+    // a change to it would ship a stale binary under an unchanged snapshot name.
+    // Add the file (or its directory) to CLI_EXECUTOR_CLOSURE in templates.ts.
+    expect(uncovered).toEqual([]);
+  });
+
+  test('every hashed closure entry exists (no dead fingerprint inputs)', () => {
+    for (const entry of HASHED_CLOSURE) {
+      const abs = resolve(CLI_SRC, entry);
+      expect(isAbsolute(abs)).toBe(true);
+      expect(existsSync(abs)).toBe(true);
+    }
+  });
+});

--- a/apps/api/src/snapshots/runtime-fingerprint.ts
+++ b/apps/api/src/snapshots/runtime-fingerprint.ts
@@ -21,6 +21,18 @@ interface RuntimeArtifactFingerprintInput {
   artifacts: RuntimeArtifact[];
 }
 
+/**
+ * True for a directory entry that holds test sources only. `__tests__` dirs and
+ * `*.test.ts` / `*.spec.ts` files are excluded from the runtime fingerprint: they
+ * are never copied into a sandbox image nor compiled into the CLI/agent binary, so
+ * editing them can't change what a session runs — but hashing them re-minted every
+ * template's identity on every test change, defeating the warm cache. Matches by
+ * entry name so it works both for `__tests__` subdirs and loose colocated tests.
+ */
+function isTestEntry(name: string): boolean {
+  return name === '__tests__' || /\.(test|spec)\.[cm]?tsx?$/.test(name);
+}
+
 export async function buildRuntimeArtifactFingerprint(
   input: RuntimeArtifactFingerprintInput,
 ): Promise<string> {
@@ -50,6 +62,12 @@ async function hashPath(
     entries.sort((a, b) => a.name.localeCompare(b.name));
     for (const entry of entries) {
       if (excludeNames && excludeNames.includes(entry.name)) continue;
+      // Test sources never ship into a sandbox image (nothing COPYs `__tests__`
+      // or `*.test.ts`, and `bun build` doesn't compile them into the CLI/agent
+      // binary), so they can't change what a session runs — yet hashing them made
+      // every test edit re-mint every project's runtime identity, forcing a mass
+      // cache miss. Skip them so the fingerprint moves only on real runtime code.
+      if (isTestEntry(entry.name)) continue;
       await hashPath(hash, join(path, entry.name), `${logicalPath}/${entry.name}`, excludeNames);
     }
     return;

--- a/apps/api/src/snapshots/templates.ts
+++ b/apps/api/src/snapshots/templates.ts
@@ -31,7 +31,7 @@ import {
 import { computeSnapshotHash } from './hash';
 import { buildRuntimeArtifactFingerprint } from './runtime-fingerprint';
 import { getSandboxProvider, type SandboxProviderAdapter } from './providers';
-import { dirname, resolve } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -47,12 +47,38 @@ const EXECUTOR_SDK_SRC_PATH = process.env.KORTIX_SNAPSHOT_EXECUTOR_SDK_PATH
 // Source of the `kortix` CLI binary baked into every sandbox. We fingerprint
 // the SOURCE (not the compiled binary, which `bun build --compile` produces
 // non-deterministically) so a CLI code change rebuilds snapshots while a
-// rebuild of the identical source does not. packages/starter is deliberately
-// excluded: it only feeds `kortix init` scaffolding, which is never run inside
-// a sandbox, so its churn shouldn't invalidate every project's image.
+// rebuild of the identical source does not.
+//
+// Scope: only the files whose change can alter what the CLI does INSIDE a
+// sandbox. The single compiled `kortix` binary bakes ALL of apps/cli/src, but a
+// session only ever invokes `kortix executor` / `kortix executor mcp` — the rest
+// (`ship`, `cr`, `tunnel`, `self-host`, `accounts`, the whole `init`/scaffold
+// surface, …) is developer-facing and runs on a laptop, never in the sandbox.
+// Hashing the WHOLE tree meant every dev-only CLI edit re-minted every project's
+// runtime identity AND moved the non-agent `swapKey`, which DISABLES the cheap
+// agent-swap fast path and forces a full O(all-projects) rebuild (measured: ~4 of
+// 11 forced mass-rebuilds over 2 weeks were pure dev-CLI churn). So we hash the
+// in-sandbox executor import-closure instead of `apps/cli/src` wholesale.
+//
+// This closure is asserted complete by snapshots/__tests__/cli-executor-closure
+// .test.ts, which re-derives it from the `kortix executor` entrypoints and fails
+// if a new import escapes the hashed set — so scoping can never silently ship a
+// stale in-sandbox executor. packages/starter (scaffolding) and packages/
+// manifest-schema (only reached by laptop-side `ship`/`validate`) are likewise
+// never in the sandbox and are deliberately not fingerprinted.
 const CLI_SRC_DIR = resolve(REPO_ROOT, 'apps/cli/src');
+// The in-sandbox `kortix executor` closure (see comment above). Relative to
+// CLI_SRC_DIR; the guard test keeps this in sync with the real import graph.
+const CLI_EXECUTOR_CLOSURE = [
+  'executor',
+  'commands/executor.ts',
+  'api/auth.ts',
+  'api/client.ts',
+  'api/config.ts',
+  'api/sandbox-env.ts',
+  'project-link.ts',
+] as const;
 const CLI_PKG_JSON = resolve(REPO_ROOT, 'apps/cli/package.json');
-const MANIFEST_SCHEMA_SRC_DIR = resolve(REPO_ROOT, 'packages/manifest-schema/src');
 const FINGERPRINT_EXCLUDES = ['node_modules', '.bin', 'dist', '.turbo', '.cache'] as const;
 
 // Bump when the rendered Kortix Dockerfile layer changes (the Dockerfile text
@@ -720,9 +746,9 @@ function validateTemplateMutation(args: { image?: unknown; dockerfilePath?: unkn
 }
 
 // The runtime layer bakes source artifacts into every template's rootfs. Exactly
-// TWO are the kortix-agent binary; the rest (entrypoint, CLI, slack-cli,
-// executor-sdk, manifest-schema) are the non-agent runtime. The agent-swap fast
-// path replaces ONLY the agent, so the builder must prove the NON-agent runtime is
+// TWO are the kortix-agent binary; the rest (entrypoint, in-sandbox CLI surface,
+// slack-cli, executor-sdk) are the non-agent runtime. The agent-swap fast path
+// replaces ONLY the agent, so the builder must prove the NON-agent runtime is
 // byte-identical before swapping — hence the split into two artifact sets.
 const AGENT_RUNTIME_ARTIFACTS = [
   { label: 'kortix-agent-src', path: AGENT_SRC_DIR, excludeNames: FINGERPRINT_EXCLUDES },
@@ -732,9 +758,15 @@ const NON_AGENT_RUNTIME_ARTIFACTS = [
   { label: 'kortix-entrypoint', path: ENTRYPOINT_PATH },
   { label: 'kortix-slack-cli', path: SLACK_CLI_SRC_PATH, excludeNames: FINGERPRINT_EXCLUDES },
   { label: 'kortix-executor-sdk', path: EXECUTOR_SDK_SRC_PATH, excludeNames: FINGERPRINT_EXCLUDES },
-  { label: 'kortix-cli-src', path: CLI_SRC_DIR, excludeNames: FINGERPRINT_EXCLUDES },
+  // Only the in-sandbox `kortix executor` closure (NOT the whole apps/cli/src) —
+  // see CLI_EXECUTOR_CLOSURE. Labels carry the relative path so two files can't
+  // collide, and the set is sorted by label in buildRuntimeArtifactFingerprint.
+  ...CLI_EXECUTOR_CLOSURE.map((rel) => ({
+    label: `kortix-cli-${rel}`,
+    path: join(CLI_SRC_DIR, rel),
+    excludeNames: FINGERPRINT_EXCLUDES,
+  })),
   { label: 'kortix-cli-pkg', path: CLI_PKG_JSON },
-  { label: 'kortix-manifest-schema-src', path: MANIFEST_SCHEMA_SRC_DIR, excludeNames: FINGERPRINT_EXCLUDES },
 ];
 // Both version strings fold in the layer/opencode/browser/sandbox constants — all
 // NON-agent inputs (bumped when the layer/opencode/browser change, not the agent


### PR DESCRIPTION
## Problem (isolated, git-proven)

The sandbox **runtime fingerprint** (`currentRuntimeArtifactFingerprint`) keys every project's snapshot identity (`kortix-default-<hash>` / `kortix-tpl-<hash>`), the warm-base name, AND the agent-swap `swapKey`. It is derived by hashing whole **source trees**: `apps/kortix-sandbox-agent-server/src`, `apps/cli/src`, `packages/executor-sdk`, `packages/manifest-schema/src`, `apps/sandbox/{entrypoint.sh,slack-cli}` — including `__tests__` and the entire developer-facing `kortix` CLI.

But a sandbox session only ever runs the **agent daemon** and **`kortix executor` / `kortix executor mcp`**. The rest of the CLI (`ship`, `cr`, `tunnel`, `self-host`, `accounts`, `init`/scaffold, `connectors`, …) runs on a developer's laptop and **never inside a sandbox**; `packages/manifest-schema` is reached only by laptop-side `ship`/`validate` and is not baked into the image nor imported by the agent/executor/executor-sdk.

So **every dev-only CLI edit or test change re-minted every project's runtime identity and moved the non-agent `swapKey`** — which disables the cheap agent-swap fast path and forces a full O(all-projects) rebuild. That is the churn that tanked the dev warm-hit rate.

### Proof (2026-07-06 dev deploys)
The base identity took **5 distinct values in one day** (each new value invalidates every project's warm image). Diffing the exact deployed source SHAs of the 4 churning transitions:

| transition | hashed files that changed | in sandbox? |
|---|---|---|
| `e5b910cb→46ee7395` | `commands/{accounts,self-host,ship}.ts`, `api/types.ts`, `accounts.test.ts` | ❌ dev-only |
| `46ee7395→68aef1c6` | ~25 CLI/manifest-schema **test** files + dev commands + `opencode.ts` (daemon) + `executor/mcp.ts` | mixed (mostly ❌) |
| `6a1f1e00→eb23048a` | `commands/executor.ts`, `executor/{gateway,mcp}.ts` | ✅ genuine |
| `499ebd32→31e33006` | `commands/cr.ts` | ❌ dev-only |

Over 2 weeks of `main` (301 commits), **63% of hashed-path file changes were spurious** (test files 25, dev-CLI commands 24, manifest-schema non-test 3) vs 37% genuine (daemon 28, executor 1, executor-sdk/entrypoint/slack-cli 1). The fingerprint hashing itself is deterministic (`SANDBOX_VERSION` is the constant `'unknown'` on dev; no timestamps/build-ids) — so this is **not** nondeterministic build output; it is genuinely-changed but sandbox-irrelevant source.

## Fix — hash only what runs in the sandbox

1. **Exclude test sources** (`__tests__` dirs, `*.test.ts`/`*.spec.ts`) from the fingerprint walk — they never ship into an image nor compile into a binary. (`runtime-fingerprint.ts`)
2. **Scope the CLI** to the in-sandbox `kortix executor` **import-closure** (`CLI_EXECUTOR_CLOSURE`) instead of all of `apps/cli/src`. (`templates.ts`)
3. **Drop `packages/manifest-schema/src`** from the fingerprint — nothing that runs in a sandbox imports it. (`templates.ts`)

### Safety net
A new guard test (`cli-executor-closure.test.ts`) re-derives the `kortix executor` import graph from source and **fails if it ever imports a file outside the hashed set** — so scoping can never silently ship a stale in-sandbox executor under an unchanged snapshot name.

## Verification

1. **STABLE across a no-op / dev-CLI-only deploy** — the `cr.ts`-only and `accounts/self-host/ship`-only deploys now produce the **same** hash (previously each churned). ✅
2. **Still bumps on a real runtime change** — the `executor/*` change and the `opencode.ts` daemon change still **change** the hash. ✅
3. **Existing warm HITs still resolve** — HIT resolution (`getSnapshotState(name)==='active'`) is unchanged; the one-time re-mint is absorbed by the builder's graceful last-known-good + background-rebuild path and the warm-base's non-blocking fallback (no session blocks). ✅
4. **Builds still work** — fingerprint computes end-to-end with the scoped artifacts (all paths resolve), is stable across calls, and the full fingerprint still differs from the non-agent one (agent folded in → agent changes still bump). Snapshot/fingerprint unit tests pass (11/11); typecheck clean. ✅

### Estimated impact
Over 2 weeks of `main`: **forced full rebuilds 11 → 7 (36% fewer)**; full-identity re-mints 29 → 25. On the dev branch the benefit is larger — the many dev-CLI-only deploys that previously re-minted every identity now cause **zero** churn.

> Note: this changes the fingerprint inputs, so it re-mints current identities **once** on rollout (absorbed by the graceful rebuild path), then the identity is stable against dev-only churn going forward.