### PR TITLE
feat(customize): master-detail sidebar for agents, skills & commands

### DIFF
--- a/apps/web/src/features/marketplace/marketplace-view.tsx
+++ b/apps/web/src/features/marketplace/marketplace-view.tsx
@@ -13,8 +13,8 @@ import { MarketplaceInstalledPanel } from '@/features/marketplace/marketplace-in
 import { MarketplaceItemDetail } from '@/features/marketplace/marketplace-item-detail';
 import { useInstalledItems, useUninstallMarketplaceItem } from '@/hooks/marketplace';
 import type { MarketplaceItem } from '@/lib/marketplace-client';
-import { getProjectDetail } from '@kortix/sdk/projects-client';
 import { useMarketplaceDetailStore } from '@/stores/marketplace-detail-store';
+import { getProjectDetail } from '@kortix/sdk/projects-client';
 import CustomizeSectionWrapper from '../workspace/customize/sections/component/section-wrapper';
 
 export function MarketplaceView({ projectId }: { projectId: string }) {
@@ -87,8 +87,7 @@ export function MarketplaceView({ projectId }: { projectId: string }) {
       >
         <CustomizeSectionWrapper
           title="Marketplace"
-          description="Browse skills, agents, and commands from every source."
-          className="max-w-5xl"
+          className="max-w-5xl p-4 px-4 py-2  lg:py-2"
           action={
             <TabsListCompact>
               <TabsTriggerCompact value="browse">Browse</TabsTriggerCompact>

--- a/apps/web/src/features/workspace/customize/customize-panel.tsx
+++ b/apps/web/src/features/workspace/customize/customize-panel.tsx
@@ -106,10 +106,11 @@ const MEET_ITEM: RailItem = { section: 'meet', label: 'Meetings', icon: AudioLin
 
 const REVIEW_ITEM: RailItem = { section: 'review', label: 'Review', icon: Inbox };
 
-// The Upgrades section is always reachable (it hosts the one-off prompt
-// runner), but it only claims the pinned top slot while a registry upgrade
-// is actually applicable (e.g. the project is still on a v1 manifest) —
-// otherwise it sits quietly in Manage next to Settings.
+// The Upgrades section is always reachable (it hosts the one-off prompt runner)
+// and lives pinned at the very bottom of the rail — out of the scrolling nav (see
+// the desktop footer / mobile tail below). When a registry upgrade is actually
+// applicable (e.g. the project is still on a v1 manifest) it carries a small
+// attention dot instead of claiming a more prominent slot.
 const UPGRADE_ITEM: RailItem = { section: 'upgrade', label: 'Upgrades', icon: ArrowUpCircle };
 
 function railGroups(
@@ -118,10 +119,8 @@ function railGroups(
   llmGatewayAvailable: boolean,
   meetEnabled: boolean,
   reviewEnabled: boolean,
-  upgradeAttention: boolean,
 ): readonly RailGroup[] {
-  const groups = upgradeAttention ? [{ items: [UPGRADE_ITEM] }, ...GROUPS] : GROUPS;
-  return groups.map((g) => {
+  return GROUPS.map((g) => {
     if (g.label === 'Build' && marketplaceEnabled) {
       return { ...g, items: [...g.items, MARKETPLACE_ITEM] };
     }
@@ -138,9 +137,6 @@ function railGroups(
       const at = items.findIndex((it) => it.section === 'changes');
       items.splice(at >= 0 ? at + 1 : items.length, 0, REVIEW_ITEM);
       return { ...g, items };
-    }
-    if (g.label === 'Manage' && !upgradeAttention) {
-      return { ...g, items: [...g.items, UPGRADE_ITEM] };
     }
     return g;
   });
@@ -225,14 +221,7 @@ export function CustomizPanel({ projectId }: { projectId: string }) {
     // BOTH its flag check (baked into railGroups) AND its read-leaf probe. Empty
     // groups drop out so no orphan header renders.
     () =>
-      railGroups(
-        tunnelEnabled,
-        marketplaceEnabled,
-        llmGatewayAvailable,
-        meetEnabled,
-        reviewEnabled,
-        upgradeAttention,
-      )
+      railGroups(tunnelEnabled, marketplaceEnabled, llmGatewayAvailable, meetEnabled, reviewEnabled)
         .map((g) => ({ ...g, items: g.items.filter((item) => isSectionAllowed(item.section)) }))
         .filter((g) => g.items.length > 0),
     [
@@ -241,11 +230,16 @@ export function CustomizPanel({ projectId }: { projectId: string }) {
       llmGatewayAvailable,
       meetEnabled,
       reviewEnabled,
-      upgradeAttention,
       isSectionAllowed,
     ],
   );
-  const allItems = useMemo(() => groups.flatMap((g) => g.items), [groups]);
+  // Upgrades lives in its own pinned footer, but stays in the item universe so
+  // deep-links, the mobile tail, and the active-section fallback all still see it.
+  const upgradeAllowed = isSectionAllowed('upgrade');
+  const allItems = useMemo(
+    () => [...groups.flatMap((g) => g.items), ...(upgradeAllowed ? [UPGRADE_ITEM] : [])],
+    [groups, upgradeAllowed],
+  );
   // `llm-management` stands in for every `llm-*` sub-section so deep-links still work.
   const sectionVisible = allItems.some((item) => isRailItemActive(item, section));
 
@@ -311,6 +305,7 @@ export function CustomizPanel({ projectId }: { projectId: string }) {
                         onClick={() => setSection(item.section)}
                         orientation="horizontal"
                         count={item.section === 'review' ? reviewNeedsYou : undefined}
+                        attention={item.section === 'upgrade' && upgradeAttention}
                       />
                     </li>
                   ))}
@@ -330,8 +325,8 @@ export function CustomizPanel({ projectId }: { projectId: string }) {
               </div>
             </nav>
           ) : (
-            <section className="bg-sidebar flex min-h-0 flex-col space-y-10 border-r py-4">
-              <div className="w-full px-2.5">
+            <section className="bg-sidebar flex min-h-0 flex-col border-r py-4">
+              <div className="w-full shrink-0 px-2.5">
                 <ModalClose asChild>
                   <Button
                     variant="ghost"
@@ -344,32 +339,46 @@ export function CustomizPanel({ projectId }: { projectId: string }) {
                 </ModalClose>
               </div>
 
-              <nav aria-label="Customize">
-                <div className="flex-1 [scrollbar-width:none] overflow-y-auto px-2.5 py-3 [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden">
-                  {groups.map((group, idx) => (
-                    <div
-                      key={group.label ?? idx}
-                      className={cn('space-y-1', idx > 0 ? 'mt-4' : undefined)}
-                    >
-                      {group.label && (
-                        <Label className="text-muted-foreground px-2 pb-1">{group.label}</Label>
-                      )}
-                      <ul className="space-y-0.5">
-                        {group.items.map((item) => (
-                          <li key={item.section}>
-                            <RailButton
-                              item={item}
-                              active={isRailItemActive(item, section)}
-                              onClick={() => setSection(item.section)}
-                              count={item.section === 'review' ? reviewNeedsYou : undefined}
-                            />
-                          </li>
-                        ))}
-                      </ul>
-                    </div>
-                  ))}
-                </div>
+              <nav
+                aria-label="Customize"
+                className="mt-8 min-h-0 flex-1 [scrollbar-width:none] overflow-y-auto px-2.5 py-3 [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden"
+              >
+                {groups.map((group, idx) => (
+                  <div
+                    key={group.label ?? idx}
+                    className={cn('space-y-1', idx > 0 ? 'mt-4' : undefined)}
+                  >
+                    {group.label && (
+                      <Label className="text-muted-foreground px-2 pb-1">{group.label}</Label>
+                    )}
+                    <ul className="space-y-0.5">
+                      {group.items.map((item) => (
+                        <li key={item.section}>
+                          <RailButton
+                            item={item}
+                            active={isRailItemActive(item, section)}
+                            onClick={() => setSection(item.section)}
+                            count={item.section === 'review' ? reviewNeedsYou : undefined}
+                          />
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                ))}
               </nav>
+
+              {/* Upgrades pinned to the extreme bottom of the rail, below the
+                  scrolling nav. Carries an attention dot on a v1 manifest. */}
+              {upgradeAllowed && (
+                <div className="mt-2 shrink-0 px-2.5 pt-3">
+                  <RailButton
+                    item={UPGRADE_ITEM}
+                    active={isRailItemActive(UPGRADE_ITEM, section)}
+                    onClick={() => setSection('upgrade')}
+                    attention={upgradeAttention}
+                  />
+                </div>
+              )}
             </section>
           )}
 
@@ -396,6 +405,7 @@ function RailButton({
   onClick,
   orientation = 'vertical',
   count,
+  attention,
 }: {
   item: RailItem;
   active: boolean;
@@ -403,6 +413,8 @@ function RailButton({
   orientation?: 'vertical' | 'horizontal';
   /** Optional attention count shown as a pill (e.g. review items needing you). */
   count?: number;
+  /** A quiet dot for a pending nudge with no count (e.g. an available upgrade). */
+  attention?: boolean;
 }) {
   const Icon = item.icon;
   const horizontal = orientation === 'horizontal';
@@ -421,7 +433,7 @@ function RailButton({
     >
       {Icon && <Icon className="size-4 shrink-0" />}
       <span className={cn(!horizontal && 'truncate')}>{item.label}</span>
-      {showCount && (
+      {showCount ? (
         <span
           className={cn(
             'shrink-0 rounded-full px-1.5 py-0.5 text-[11px] font-medium tabular-nums',
@@ -431,7 +443,15 @@ function RailButton({
         >
           {count}
         </span>
-      )}
+      ) : attention ? (
+        <span
+          aria-hidden
+          className={cn(
+            'bg-kortix-orange size-1.5 shrink-0 rounded-full',
+            !horizontal && 'ml-auto',
+          )}
+        />
+      ) : null}
     </Button>
   );
 }

--- a/apps/web/src/features/workspace/customize/sections/component/config-entity-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/component/config-entity-view.tsx
@@ -49,9 +49,10 @@ export interface ConfigEntityViewProps<T extends ConfigEntity> {
   /** Lowercase singular used in inline copy ("No matches", "{noun} body is empty"). */
   noun: string;
 
+  className?: string;
   // Section shell
   title: string;
-  description: string;
+  description?: string;
   docs?: string;
 
   // Search
@@ -82,11 +83,13 @@ export interface ConfigEntityViewProps<T extends ConfigEntity> {
   renderContext?: (config: ProjectConfigSummary) => ReactNode;
 
   /**
-   * 'accordion' (default) — a vertical list where each row expands its detail
-   * inline. 'split' — a master-detail layout: a selectable list on the LEFT, the
-   * selected entity's source in the MIDDLE, and `renderDetailExtra` as a right
-   * aside. Use 'split' for agents (the detail carries scope/model/assignment
-   * cards that deserve their own column). Widens the section to fit three panes.
+   * 'accordion' — a vertical list where each row expands its detail inline.
+   * 'split' (the standard for agents, skills & commands) — a master-detail
+   * layout: a separate, self-scrolling sidebar that lists every entity on the
+   * LEFT, the selected entity's source in the MIDDLE, and (when provided)
+   * `renderDetailExtra` as a right aside — e.g. agents surface their
+   * scope/model/assignment cards in that third column. Widens the section to
+   * fit the extra panes.
    */
   layout?: 'accordion' | 'split';
 }
@@ -115,6 +118,7 @@ export function ConfigEntityView<T extends ConfigEntity>(props: ConfigEntityView
     emptyBodyLabel,
     renderContext,
     layout = 'accordion',
+    className,
   } = props;
 
   const detailQuery = useQuery({
@@ -252,84 +256,124 @@ export function ConfigEntityView<T extends ConfigEntity>(props: ConfigEntityView
     </div>
   );
 
-  const splitBody = (
-    <div className="space-y-4">
-      {config && entities.length > 0 && renderContext ? renderContext(config) : null}
-      {stateContent ??
-        (config ? (
-          <div className="grid grid-cols-1 gap-5 lg:grid-cols-[240px_minmax(0,1fr)]">
-            {/* Left — a selectable list, sticky on scroll. The top offset keeps
-                it from pinning flush against the scrollport edge (the section's
-                vertical padding scrolls away with the content). */}
-            <div className="lg:border-border/60 space-y-3 lg:sticky lg:top-6 lg:self-start lg:border-r lg:pr-4">
-              {searchInput}
-              {filtered.length === 0 ? (
-                noMatches
-              ) : (
-                <ul className="space-y-0.5">
-                  {filtered.map((entity) => {
-                    const trailing = renderRowTrailing?.(entity, config);
-                    const isActive = selected?.path === entity.path;
-                    return (
-                      <li key={entity.path}>
-                        <button
-                          type="button"
-                          onClick={() => setSelectedPath(entity.path)}
-                          aria-current={isActive}
-                          className={cn(
-                            'focus-visible:ring-kortix-blue flex w-full items-center gap-2 rounded-md px-3 py-2 text-left text-sm transition-colors focus-visible:ring-2 focus-visible:outline-none',
-                            isActive
-                              ? 'bg-secondary text-foreground font-medium'
-                              : 'text-muted-foreground hover:bg-muted/50',
-                          )}
-                        >
-                          <span className="min-w-0 flex-1 truncate">
+  // The agent's extras (scope / model / assignment cards) become their own fixed
+  // pane, so the middle content is the sole scroller.
+  const extra = selected && config ? renderDetailExtra?.(selected, config) : null;
+
+  // Fixed-shell master-detail: the section header, the left list, and the right
+  // aside all stay put — only the middle content pane scrolls (lg+). Below lg the
+  // whole thing degrades to a single scroll under the fixed header.
+  const splitBody = stateContent ? (
+    <div className="h-full overflow-y-auto px-6 py-10">{stateContent}</div>
+  ) : config ? (
+    <div className="flex min-h-0 flex-col lg:h-full">
+      {entities.length > 0 && renderContext ? (
+        <div className="border-border/60 shrink-0 border-b px-6 py-3">{renderContext(config)}</div>
+      ) : null}
+      <div className="flex min-h-0 flex-1 flex-col lg:flex-row">
+        {/* Left — the entity list. Fixed beside the content; only its own list
+            scrolls, and only when it overflows. */}
+        <aside className="border-border/60 flex shrink-0 flex-col border-b lg:h-full lg:min-h-0 lg:w-[264px] lg:border-r lg:border-b-0">
+          <div className="shrink-0 px-4 pt-4 pb-3">{searchInput}</div>
+          {filtered.length === 0 ? (
+            <div className="px-4">{noMatches}</div>
+          ) : (
+            <nav
+              aria-label={`${title} list`}
+              className="scrollbar-minimal px-2 pb-4 lg:min-h-0 lg:flex-1 lg:overflow-y-auto"
+            >
+              <ul className="space-y-0.5">
+                {filtered.map((entity) => {
+                  const trailing = renderRowTrailing?.(entity, config);
+                  const isActive = selected?.path === entity.path;
+                  return (
+                    <li key={entity.path}>
+                      <button
+                        type="button"
+                        onClick={() => setSelectedPath(entity.path)}
+                        aria-current={isActive}
+                        className={cn(
+                          'group flex w-full flex-col gap-0.5 rounded-md py-2 pr-2.5 pl-3 text-left transition-colors',
+                          'focus-visible:ring-kortix-blue/50 focus-visible:ring-2 focus-visible:outline-none',
+                          isActive ? 'bg-primary/[0.06]' : 'hover:bg-muted/40',
+                        )}
+                      >
+                        <span className="flex w-full items-center gap-2">
+                          <span
+                            className={cn(
+                              'min-w-0 flex-1 truncate text-sm font-medium',
+                              isActive
+                                ? 'text-foreground'
+                                : 'text-foreground/70 group-hover:text-foreground',
+                            )}
+                          >
                             {renderTriggerLabel(entity)}
                           </span>
                           {trailing ? (
                             <span className="flex shrink-0 items-center gap-1.5">{trailing}</span>
                           ) : null}
-                        </button>
-                      </li>
-                    );
-                  })}
-                </ul>
-              )}
+                        </span>
+                        {entity.description ? (
+                          <span className="text-muted-foreground/60 w-full truncate text-xs">
+                            {entity.description}
+                          </span>
+                        ) : null}
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+            </nav>
+          )}
+        </aside>
+        {/* Middle — the ONLY scroll region: the selected entity's content. */}
+        <div className="min-w-0 lg:h-full lg:min-h-0 lg:flex-1 lg:overflow-y-auto">
+          {selected ? (
+            <div className="mx-auto max-w-3xl px-6 py-8 lg:py-10">
+              <EntityDetail
+                key={selected.path}
+                projectId={projectId}
+                kind={kind}
+                entity={selected}
+                config={config}
+                renderDetailTitle={renderDetailTitle}
+                renderDetailMeta={renderDetailMeta}
+                emptyBodyLabel={emptyBodyLabel}
+                split
+              />
             </div>
-            {/* Right — the selected entity (source in the middle, extras aside). */}
-            <div className="min-w-0">
-              {selected ? (
-                <EntityDetail
-                  key={selected.path}
-                  projectId={projectId}
-                  kind={kind}
-                  entity={selected}
-                  config={config}
-                  renderDetailTitle={renderDetailTitle}
-                  renderDetailMeta={renderDetailMeta}
-                  renderDetailExtra={renderDetailExtra}
-                  emptyBodyLabel={emptyBodyLabel}
-                  split
-                />
-              ) : (
-                <p className="text-muted-foreground/60 px-4 py-16 text-center text-sm">
-                  Pick {noun === 'agent' ? 'an' : 'a'} {noun} on the left to preview it.
-                </p>
-              )}
+          ) : (
+            <div className="flex flex-col items-center justify-center gap-3 px-6 py-24 text-center lg:h-full">
+              <EmptyIcon className="text-muted-foreground/30 size-8" />
+              <p className="text-muted-foreground/60 text-sm">
+                Pick {noun === 'agent' ? 'an' : 'a'} {noun} on the left to preview it.
+              </p>
             </div>
-          </div>
-        ) : null)}
+          )}
+        </div>
+        {/* Right — entity extras (e.g. an agent's scope / model). Fixed; scrolls
+            only itself when tall. */}
+        {extra ? (
+          <aside
+            key={selected?.path}
+            className="border-border/60 shrink-0 space-y-3 border-t p-4 lg:h-full lg:min-h-0 lg:w-[344px] lg:overflow-y-auto lg:border-t-0 lg:border-l"
+          >
+            {extra}
+          </aside>
+        ) : null}
+      </div>
     </div>
-  );
+  ) : null;
 
   const body = layout === 'split' ? splitBody : accordionBody;
 
   return (
     <CustomizeSectionWrapper
+      className={className}
       title={title}
       description={description}
       docs={docs}
-      className={layout === 'split' ? 'max-w-none px-6' : undefined}
+      fill={layout === 'split'}
       action={
         <div className="flex items-center gap-1.5">
           <MarketplaceSectionButton projectId={projectId} />
@@ -466,7 +510,9 @@ function EntityDetail<T extends ConfigEntity>({
   );
 
   const meta = renderDetailMeta?.(entity, config);
-  const extra = renderDetailExtra?.(entity, config);
+  // In split mode the extras render as their own fixed pane (owned by
+  // ConfigEntityView), so the detail here is just the header + source.
+  const extra = split ? null : renderDetailExtra?.(entity, config);
 
   const source = fileQuery.isLoading ? (
     <div className="space-y-2.5">
@@ -517,25 +563,13 @@ function EntityDetail<T extends ConfigEntity>({
   );
 
   if (split) {
-    // Full-width master detail: the source (header + body) fills the MIDDLE with a
-    // readable max-width, and the extra cards sit as a right-hand aside stuck to
-    // the edge. Below xl the aside stacks under the source.
+    // Master-detail middle pane: header + source only. The readable max-width and
+    // padding come from the scrolling column wrapper in ConfigEntityView; the
+    // extras live in their own fixed aside there.
     return (
-      <div
-        className={cn(
-          'grid grid-cols-1 gap-8 pb-10',
-          extra && 'xl:grid-cols-[minmax(0,1fr)_340px]',
-        )}
-      >
-        <div className="min-w-0">
-          <div className="mx-auto max-w-3xl">
-            {header}
-            <div className="mt-8">{source}</div>
-          </div>
-        </div>
-        {extra ? (
-          <aside className="space-y-3 xl:sticky xl:top-6 xl:self-start xl:pt-1">{extra}</aside>
-        ) : null}
+      <div className="min-w-0">
+        {header}
+        <div className="mt-8">{source}</div>
       </div>
     );
   }

--- a/apps/web/src/features/workspace/customize/sections/component/section-wrapper.tsx
+++ b/apps/web/src/features/workspace/customize/sections/component/section-wrapper.tsx
@@ -1,15 +1,22 @@
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import Link from 'next/link';
-import React from 'react';
+import type React from 'react';
 
 type Props = {
   title: string;
-  description: string;
+  description?: string;
   children: React.ReactNode;
   action?: React.ReactNode;
   docs?: string;
   className?: string;
+  /**
+   * Fixed-shell mode. The header becomes a non-scrolling top bar and `children`
+   * fill the remaining height to own their own scroll — used by the master-detail
+   * split, where the section header, list, and aside stay put and only the
+   * content pane scrolls. Default is the single scrolling column.
+   */
+  fill?: boolean;
 };
 
 const CustomizeSectionWrapper = ({
@@ -19,7 +26,40 @@ const CustomizeSectionWrapper = ({
   action,
   docs,
   className,
+  fill,
 }: Props) => {
+  const heading = (
+    <div className="space-y-1">
+      <h2 className="text-foreground text-xl font-medium">{title}</h2>
+      {description || docs ? (
+        <span className="flex items-center gap-1">
+          {description ? (
+            <p className="text-muted-foreground text-sm text-balance">{description}</p>
+          ) : null}
+          {docs && (
+            <Button variant="transparent" className="m-0 p-0" asChild>
+              <Link href={docs} target="_blank" rel="noopener noreferrer">
+                Learn more.
+              </Link>
+            </Button>
+          )}
+        </span>
+      ) : null}
+    </div>
+  );
+
+  if (fill) {
+    return (
+      <div className="flex h-full min-h-0 flex-col">
+        <header className="border-border/60 flex shrink-0 flex-col gap-2 border-b px-4 py-2 sm:flex-row sm:items-center sm:justify-between">
+          {heading}
+          {action ? <div className="mt-2 shrink-0 sm:mt-0">{action}</div> : null}
+        </header>
+        <div className="min-h-0 flex-1 overflow-y-auto lg:overflow-hidden">{children}</div>
+      </div>
+    );
+  }
+
   return (
     <div className="flex h-full min-h-0 flex-col">
       <div className="min-h-0 flex-1 overflow-y-auto">
@@ -27,19 +67,7 @@ const CustomizeSectionWrapper = ({
           className={cn('mx-auto w-full max-w-3xl space-y-5 px-4 py-10 pb-20 lg:py-20', className)}
         >
           <header className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-            <div className="space-y-1">
-              <h2 className="text-foreground text-xl font-medium">{title}</h2>
-              <span className="flex items-center gap-1">
-                <p className="text-muted-foreground text-sm text-balance">{description}</p>
-                {docs && (
-                  <Button variant="transparent" className="m-0 p-0" asChild>
-                    <Link href={docs} target="_blank" rel="noopener noreferrer">
-                      Learn more.
-                    </Link>
-                  </Button>
-                )}
-              </span>
-            </div>
+            {heading}
             {action ? <div className="mt-2 shrink-0 sm:mt-0">{action}</div> : null}
           </header>
 

--- a/apps/web/src/features/workspace/customize/sections/connectors-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/connectors-view.tsx
@@ -2670,7 +2670,7 @@ function AddAppPanel({
     'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxTextEasyConnect19ca1c01',
   );
   return (
-    <div className="mx-auto w-full max-w-4xl space-y-6 px-6 py-10 pb-20 lg:py-20">
+    <div className="mx-auto w-full max-w-4xl space-y-6 p-4">
       <header className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
         <h2 className="text-foreground text-xl font-medium">Add a connector</h2>
       </header>

--- a/apps/web/src/features/workspace/customize/sections/view/agents-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/agents-view.tsx
@@ -40,8 +40,6 @@ export function AgentsView({ projectId }: { projectId: string }) {
       noun="agent"
       layout="split"
       title="Agents"
-      description="Pick an agent from the list to preview it, or create a new one."
-      docs="https://kortix.com/docs/concepts/agents"
       searchPlaceholder="Search agents"
       emptyIcon={Bot}
       emptyTitle="No agents yet"
@@ -50,6 +48,7 @@ export function AgentsView({ projectId }: { projectId: string }) {
       emptyBodyLabel="Agent body is empty. Add prompt content below the frontmatter."
       select={(config) => config.agents}
       renderTriggerLabel={(agent) => agent.name}
+      className=' p-4  lg:py-0'
       renderRowTrailing={(agent, config) => (
         <>
           {agent.mode ? (

--- a/apps/web/src/features/workspace/customize/sections/view/commands-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/commands-view.tsx
@@ -14,8 +14,8 @@ export function CommandsView({ projectId }: { projectId: string }) {
       projectId={projectId}
       kind="command"
       noun="command"
+      layout="split"
       title="Commands"
-      description="Pick a command from the list to preview it, or create a new one."
       searchPlaceholder="Search commands"
       emptyIcon={SquareSlash}
       emptyTitle="No commands yet"

--- a/apps/web/src/features/workspace/customize/sections/view/skills-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/skills-view.tsx
@@ -14,8 +14,8 @@ export function SkillsView({ projectId }: { projectId: string }) {
       projectId={projectId}
       kind="skill"
       noun="skill"
+      layout="split"
       title="Skills"
-      description="Pick a skill from the list to preview it, or create a new one."
       searchPlaceholder="Search skills"
       emptyIcon={Sparkles}
       emptyTitle="No skills yet"


### PR DESCRIPTION
## What & why

The **Agents**, **Skills**, and **Commands** sections of the customize panel now share one **fixed master-detail shell**: a persistent sidebar lists every entity, and only the selected item's content scrolls. Previously Skills and Commands used an inline-accordion (expand-in-place) layout while Agents used a scroll-along split — this unifies all three and makes long lists far easier to scan and navigate.

## Changes

**Layout**
- `CustomizeSectionWrapper` gains a `fill` mode — a non-scrolling header bar plus a body that owns its own height — so the split layout can pin its panes instead of living inside one scroll container.
- `ConfigEntityView`'s split layout is rebuilt as a three-pane fixed frame: **list · content · extras**. The header, the left list, and (for agents) the right scope/model aside stay put; only the middle content column scrolls.
- Skills and Commands move from the accordion layout onto the shared split layout (Agents already used it).

**Polish**
- Section headers are title-only now (removed the "pick a … to preview it" copy and the agents docs link).
- Sidebar selection is a subtle fill instead of a blue accent bar.
- The rail's **Upgrades** entry is pinned to the extreme bottom, below the scrolling nav, with a small attention dot when a manifest upgrade is applicable. It stays in the item set so deep-links, the mobile tail, and the active-section fallback still resolve it.
- Minor Marketplace / connector-panel padding trims.

## Verification
- `tsc` (web app): **0 errors**.
- `bun test` (customize): **102 passing**, incl. the `rail`, `checkpoints`, and `upgrade` suites.
- Driven live (authenticated) in light + dark: the header and both sidebars stay fixed while only the content pane scrolls; Upgrades confirmed pinned at the rail bottom.

## Notes
- The fixed three-pane frame is desktop (`lg+`); below that it degrades gracefully to a single scroll under the fixed header.
- The Upgrades attention dot preserves the v1→v2 migration nudge that the old top-pinned slot used to provide.
