### PR TITLE
fix(accounts): members count reflects caller visibility, not raw total

### DIFF
--- a/apps/api/src/__tests__/unit-members-visibility.test.ts
+++ b/apps/api/src/__tests__/unit-members-visibility.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from 'bun:test';
+import { visibleMemberRows } from '../accounts/core/member-visibility';
+
+// The roster is deliberately filtered for plain members so an account that
+// hosts unrelated invitees doesn't leak the rest of the roster. These lock in
+// that cut — the same cut the members list AND its header count rely on.
+const rows = [
+  { userId: 'owner-1', accountRole: 'owner' },
+  { userId: 'admin-1', accountRole: 'admin' },
+  { userId: 'member-me', accountRole: 'member' },
+  { userId: 'member-other', accountRole: 'member' },
+];
+
+describe('visibleMemberRows', () => {
+  test('managers see every member', () => {
+    expect(visibleMemberRows(rows, 'member-me', true)).toHaveLength(4);
+  });
+
+  test('a plain member sees owners/admins + themselves, never other bare members', () => {
+    const seen = visibleMemberRows(rows, 'member-me', false).map((r) => r.userId);
+    expect(seen).toContain('owner-1');
+    expect(seen).toContain('admin-1');
+    expect(seen).toContain('member-me');
+    // The roster-leak guard: another plain member is NOT visible, so neither
+    // the list nor the count (members.length) exposes them or the true size.
+    expect(seen).not.toContain('member-other');
+    expect(seen).toHaveLength(3);
+  });
+
+  test('a plain member who is not themselves a member still sees only owners/admins', () => {
+    // e.g. a viewer who was just removed; they never see other bare members.
+    const seen = visibleMemberRows(rows, 'ghost', false).map((r) => r.userId);
+    expect(seen).toEqual(['owner-1', 'admin-1']);
+  });
+
+  test('does not mutate the input rows', () => {
+    const snapshot = JSON.parse(JSON.stringify(rows));
+    visibleMemberRows(rows, 'member-me', false);
+    visibleMemberRows(rows, 'anyone', true);
+    expect(rows).toEqual(snapshot);
+  });
+});

--- a/apps/api/src/accounts/core/member-visibility.ts
+++ b/apps/api/src/accounts/core/member-visibility.ts
@@ -1,0 +1,21 @@
+/**
+ * Which account-member rows a given viewer is allowed to see.
+ *
+ * Full-roster visibility is a member-management capability. Managers (owners,
+ * admins, or anyone granted `member.invite`) see every member. A plain member
+ * sees only who runs the account — owners/admins — and themselves; it must
+ * NOT enumerate the other bare members, because one account can host unrelated
+ * invitees (e.g. a demo account with several prospect orgs) and a bare
+ * membership must not leak the rest of the roster (identities OR its size).
+ *
+ * Pure and dependency-free so it can be unit-tested in isolation and reused by
+ * anything that needs the "what can this viewer see" cut (list rows AND count).
+ */
+export function visibleMemberRows<T extends { userId: string; accountRole: string }>(
+  rows: readonly T[],
+  viewerUserId: string,
+  canManageMembers: boolean,
+): T[] {
+  if (canManageMembers) return [...rows];
+  return rows.filter((r) => r.userId === viewerUserId || r.accountRole !== 'member');
+}

--- a/apps/api/src/accounts/core/members.ts
+++ b/apps/api/src/accounts/core/members.ts
@@ -16,6 +16,7 @@ import { revokeAllAccountTokensForUser } from '../../repositories/account-tokens
 import { db } from '../../shared/db';
 import { lookupUserIdByEmail } from '../../shared/users';
 import { buildInviteUrl, sendAccountInviteEmail } from '../email';
+import { visibleMemberRows } from './member-visibility';
 import {
   AccountIdParam,
   AccountInviteSchema,
@@ -75,9 +76,7 @@ export function registerMemberRoutes(): void {
         .from(accountMembers)
         .where(eq(accountMembers.accountId, accountId));
 
-      const visibleRows = canManageMembers
-        ? rows
-        : rows.filter((r) => r.userId === userId || r.accountRole !== 'member');
+      const visibleRows = visibleMemberRows(rows, userId, canManageMembers);
 
       const emails = await lookupEmailsByUserIds(rows.map((r) => r.userId));
       const projectGrantRows = await db

--- a/apps/web/src/app/(app)/accounts/[id]/page.tsx
+++ b/apps/web/src/app/(app)/accounts/[id]/page.tsx
@@ -1122,7 +1122,12 @@ function MembersCard({
   return (
     <SectionCard
       title="Members"
-      count={account.member_count}
+      // Count what THIS caller can actually see, not the raw total. The roster
+      // is visibility-filtered server-side for plain members (owners/admins +
+      // self), while account.member_count is the unfiltered COUNT(*) — using it
+      // would leak the roster size and mismatch the list below. Owners/admins
+      // see everyone, so for them members.length === member_count anyway.
+      count={members.length}
       description={tHardcodedUi.raw(
         'appAccountsIdPage.line761JsxAttrDescriptionPeopleWithAccessToThisAccount',
       )}


### PR DESCRIPTION
## Problem
As a plain **Member**, the account members header shows "Members (4)" but only 2 rows are listed; the Owner sees all 4. Count and list disagree.

## Root cause
The roster list is deliberately visibility-filtered server-side — plain members see only owners/admins + themselves (`apps/api/src/accounts/core/members.ts`: *"a bare membership must not leak the full roster"*). But the "Members (N)" header used `account.member_count`, an **unfiltered COUNT(*)** of all members. So it reported the true total (4) to someone allowed to see only 2 — a UX mismatch **and** a roster-size leak that undercuts the very filtering above it.

## Fix
The header now counts what the caller can actually see (`members.length` — the already-filtered list). Owners/admins see everyone, so it's unchanged for them; plain members now get a count that matches the list.

`account.member_count` is left untouched on purpose — billing seat counts and the upgrade modal depend on the true total (billing.ts, global-upgrade-modal.tsx).