### PR TITLE
fix(scim): show the absolute SCIM base URL so it's paste-ready for the IdP

### DIFF
--- a/apps/web/src/components/iam/scim-card.tsx
+++ b/apps/web/src/components/iam/scim-card.tsx
@@ -13,6 +13,8 @@ import { FormEvent, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Check, Copy, Loader2, Plus, Trash2, X } from 'lucide-react';
 import { toast } from '@/lib/toast';
+import { getEnv } from '@/lib/env-config';
+import { buildScimBaseUrl, isAbsoluteHttpUrl } from '@/lib/scim-url';
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -88,10 +90,12 @@ export function ScimCard({ accountId, canManage }: ScimCardProps) {
   });
 
   const tokens = tokensQuery.data ?? [];
-  // SCIM base URL is documented per-account. We can't know the full host
-  // from this component (the API may sit on a different domain) so we show
-  // a relative path and let the admin prepend their API origin.
-  const scimBaseUrl = `/scim/v2/accounts/${accountId}`;
+  // The SCIM base URL is what the admin pastes into their IdP (Okta/Azure),
+  // which calls it directly — so show the absolute API origin when we know it.
+  // Falls back to a relative path (+ the "prepend your origin" hint below) when
+  // the backend is configured as a same-origin proxy path.
+  const scimBaseUrl = buildScimBaseUrl(accountId, getEnv().BACKEND_URL);
+  const scimBaseIsAbsolute = isAbsoluteHttpUrl(scimBaseUrl);
 
   return (
     <section className="rounded-xl border border-border/70 bg-card">
@@ -119,7 +123,15 @@ export function ScimCard({ accountId, canManage }: ScimCardProps) {
             </Button>
           </div>
           <p className="text-[11px] text-muted-foreground">
-            {tHardcodedUi.raw('componentsIamScimCard.line122JsxTextPrependYourAPIOriginEG')}<code>https://api.kortix.com</code>{tHardcodedUi.raw('componentsIamScimCard.line122JsxTextTheIdPAppends')}<code>/Users</code> and <code>/Groups</code>.
+            {scimBaseIsAbsolute ? (
+              <>
+                Your IdP appends <code>/Users</code> and <code>/Groups</code>.
+              </>
+            ) : (
+              <>
+                {tHardcodedUi.raw('componentsIamScimCard.line122JsxTextPrependYourAPIOriginEG')}<code>https://api.kortix.com</code>{tHardcodedUi.raw('componentsIamScimCard.line122JsxTextTheIdPAppends')}<code>/Users</code> and <code>/Groups</code>.
+              </>
+            )}
           </p>
         </div>
 
@@ -236,6 +248,9 @@ function CreateScimTokenDialog({
   const queryClient = useQueryClient();
   const [name, setName] = useState('');
   const [created, setCreated] = useState<CreatedScimToken | null>(null);
+  // Same absolute-when-known base URL the card shows, so the post-mint view
+  // matches (the API returns a relative path in created.scim_base_url).
+  const scimBaseUrl = buildScimBaseUrl(accountId, getEnv().BACKEND_URL);
 
   const mutation = useMutation({
     mutationFn: () => createScimToken(accountId, { name: name.trim() }),
@@ -297,13 +312,13 @@ function CreateScimTokenDialog({
               <Label className="text-xs">{tHardcodedUi.raw('componentsIamScimCard.line301JsxTextSCIMBaseURL')}</Label>
               <div className="mt-1 flex items-center gap-2">
                 <code className="flex-1 truncate rounded border border-border/60 bg-muted/30 px-3 py-2 font-mono text-xs">
-                  {created.scim_base_url}
+                  {scimBaseUrl}
                 </code>
                 <Button
                   variant="outline"
                   size="icon"
                   aria-label={tHardcodedUi.raw('componentsIamScimCard.line309JsxAttrAriaLabelCopyURL')}
-                  onClick={() => copyToClipboard(created.scim_base_url, 'URL copied')}
+                  onClick={() => copyToClipboard(scimBaseUrl, 'URL copied')}
                 >
                   <Copy className="h-3.5 w-3.5" />
                 </Button>

--- a/apps/web/src/lib/scim-url.test.ts
+++ b/apps/web/src/lib/scim-url.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from 'bun:test';
+import { buildScimBaseUrl, isAbsoluteHttpUrl } from './scim-url';
+
+describe('buildScimBaseUrl', () => {
+  test('prepends the API origin when the backend URL is absolute', () => {
+    expect(buildScimBaseUrl('acc-1', 'https://api.kortix.com')).toBe(
+      'https://api.kortix.com/scim/v2/accounts/acc-1',
+    );
+  });
+
+  test('uses only the ORIGIN, dropping any API path prefix like /v1', () => {
+    expect(buildScimBaseUrl('acc-1', 'https://api.kortix.com/v1')).toBe(
+      'https://api.kortix.com/scim/v2/accounts/acc-1',
+    );
+  });
+
+  test('falls back to a relative path for a root-relative proxy backend', () => {
+    expect(buildScimBaseUrl('acc-1', '/v1')).toBe('/scim/v2/accounts/acc-1');
+  });
+
+  test('falls back to a relative path when the backend URL is missing', () => {
+    expect(buildScimBaseUrl('acc-1', undefined)).toBe('/scim/v2/accounts/acc-1');
+    expect(buildScimBaseUrl('acc-1', null)).toBe('/scim/v2/accounts/acc-1');
+  });
+
+  test('falls back to a relative path when the backend URL is malformed', () => {
+    expect(buildScimBaseUrl('acc-1', 'http://[not-a-url')).toBe('/scim/v2/accounts/acc-1');
+  });
+});
+
+describe('isAbsoluteHttpUrl', () => {
+  test('true for http(s) URLs, false for relative paths', () => {
+    expect(isAbsoluteHttpUrl('https://api.kortix.com/scim/v2/accounts/x')).toBe(true);
+    expect(isAbsoluteHttpUrl('/scim/v2/accounts/x')).toBe(false);
+  });
+});

--- a/apps/web/src/lib/scim-url.ts
+++ b/apps/web/src/lib/scim-url.ts
@@ -1,0 +1,33 @@
+/**
+ * Build the SCIM 2.0 base URL an IdP (Okta / Azure AD / JumpCloud) is pointed
+ * at. The IdP calls this URL directly — server-to-server, never through the web
+ * app — so it MUST be an absolute, publicly-reachable origin.
+ *
+ * We take only the ORIGIN of the app's configured backend URL and append the
+ * SCIM path: SCIM is mounted at the API root (`/scim/v2`), NOT under the `/v1`
+ * API prefix, so a backend like `https://api.kortix.com/v1` still yields
+ * `https://api.kortix.com/scim/v2/...`.
+ *
+ * `backendUrl` may legitimately be a root-relative proxy path (e.g. `/v1`) in
+ * same-origin deployments — there we can't derive a public origin, so we return
+ * the relative path and the caller keeps its "prepend your API origin" hint.
+ */
+export function buildScimBaseUrl(accountId: string, backendUrl: string | null | undefined): string {
+  const path = `/scim/v2/accounts/${accountId}`;
+  if (backendUrl && /^https?:\/\//i.test(backendUrl)) {
+    try {
+      return new URL(backendUrl).origin + path;
+    } catch {
+      /* malformed URL — fall through to the relative path */
+    }
+  }
+  return path;
+}
+
+/**
+ * Whether a value is an absolute http(s) URL. Lets the UI drop the
+ * "prepend your API origin" hint once the base URL is already absolute.
+ */
+export function isAbsoluteHttpUrl(value: string): boolean {
+  return /^https?:\/\//i.test(value);
+}


### PR DESCRIPTION
## Problem
The SCIM provisioning card showed a **relative** base URL (`/scim/v2/accounts/…`) and asked the admin to hand-prepend their API origin. But that URL gets pasted into Okta/Azure, which call it directly — a relative path isn't usable without editing.

## Fix
Show the **absolute** URL — `https://api.kortix.com/scim/v2/accounts/…` — by prepending the API origin derived from the app's configured backend URL (`getEnv().BACKEND_URL`, the same source the app uses for API calls).

- Uses only the **origin** of the backend URL, so a backend like `…/v1` still yields `…/scim/v2/…` (SCIM is mounted at the API root, not under `/v1`).
- **Graceful fallback:** if the backend is a root-relative proxy path (e.g. `/v1`), the public origin is unknowable, so it keeps the relative path + the "prepend your API origin" hint — no regression.
- Applied to **both** the standing card and the post-mint dialog so they match (the API returns a relative `scim_base_url`).

Logic lives in a pure `buildScimBaseUrl` helper with unit tests (absolute, `/v1`-prefix stripping, and relative/missing/malformed fallbacks).