### PR TITLE
fix(iam): SCIM dialog overflow + SSO/SCIM settings-card polish

### DIFF
--- a/apps/web/src/components/iam/scim-card.tsx
+++ b/apps/web/src/components/iam/scim-card.tsx
@@ -11,7 +11,7 @@ import { useTranslations } from 'next-intl';
 
 import { FormEvent, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { Check, Copy, Loader2, Plus, Trash2, X } from 'lucide-react';
+import { Check, Copy, Loader2, Plus, RefreshCw, Trash2, X } from 'lucide-react';
 import { toast } from '@/lib/toast';
 import { getEnv } from '@/lib/env-config';
 import { buildScimBaseUrl, isAbsoluteHttpUrl } from '@/lib/scim-url';
@@ -100,7 +100,10 @@ export function ScimCard({ accountId, canManage }: ScimCardProps) {
   return (
     <section className="rounded-xl border border-border/70 bg-card">
       <header className="border-b border-border/60 px-6 py-4">
-        <h2 className="text-base font-semibold text-foreground">{tHardcodedUi.raw('componentsIamScimCard.line97JsxTextSCIMProvisioning')}</h2>
+        <h2 className="flex items-center gap-2 text-base font-semibold text-foreground">
+          <RefreshCw className="text-muted-foreground h-4 w-4" />
+          {tHardcodedUi.raw('componentsIamScimCard.line97JsxTextSCIMProvisioning')}
+        </h2>
         <p className="mt-0.5 text-xs text-muted-foreground">
           {tHardcodedUi.raw('componentsIamScimCard.line99JsxTextConnectOktaAzureADOrAnySCIM2')}</p>
       </header>
@@ -133,6 +136,27 @@ export function ScimCard({ accountId, canManage }: ScimCardProps) {
               </>
             )}
           </p>
+        </div>
+
+        {/* IdP setup hint — what to fill in on the Okta / Azure side, so admins
+            don't have to guess the identifier + auth from docs. */}
+        <div className="border-border/60 bg-muted/20 space-y-1.5 rounded-lg border px-3 py-2.5 text-[11px] text-muted-foreground">
+          <p className="text-foreground text-xs font-medium">Configure your IdP with</p>
+          <div className="flex gap-2">
+            <span className="w-24 shrink-0">Identifier</span>
+            <span className="text-foreground">
+              <code className="bg-muted/60 rounded px-1 py-0.5 font-mono">userName</code> — the user's
+              email
+            </span>
+          </div>
+          <div className="flex gap-2">
+            <span className="w-24 shrink-0">Auth</span>
+            <span className="text-foreground">Bearer token — Okta HTTP Header mode</span>
+          </div>
+          <div className="flex gap-2">
+            <span className="w-24 shrink-0">Actions</span>
+            <span className="text-foreground">Push users &amp; groups; deactivation deprovisions</span>
+          </div>
         </div>
 
         {/* Tokens header */}
@@ -173,12 +197,19 @@ export function ScimCard({ accountId, canManage }: ScimCardProps) {
                     <span className="truncate text-sm font-medium text-foreground">
                       {t.name}
                     </span>
-                    <Badge
-                      variant={t.status === 'active' ? 'outline' : 'destructive'}
-                      className="h-4 rounded-md px-1 text-[9px] font-normal capitalize"
-                    >
-                      {t.status}
-                    </Badge>
+                    {t.status === 'active' ? (
+                      <span className="inline-flex items-center gap-1 rounded-md bg-emerald-500/10 px-1.5 py-0.5 text-[9px] font-medium text-emerald-700 dark:text-emerald-300">
+                        <span className="h-1.5 w-1.5 rounded-full bg-emerald-500" />
+                        Active
+                      </span>
+                    ) : (
+                      <Badge
+                        variant="destructive"
+                        className="h-4 rounded-md px-1 text-[9px] font-normal capitalize"
+                      >
+                        {t.status}
+                      </Badge>
+                    )}
                   </div>
                   <div className="mt-0.5 flex items-center gap-3 text-[11px] text-muted-foreground">
                     <code className="font-mono">{t.public_prefix}</code>

--- a/apps/web/src/components/iam/scim-card.tsx
+++ b/apps/web/src/components/iam/scim-card.tsx
@@ -110,7 +110,7 @@ export function ScimCard({ accountId, canManage }: ScimCardProps) {
         <div className="space-y-1.5">
           <Label className="text-xs">{tHardcodedUi.raw('componentsIamScimCard.line107JsxTextSCIMBaseURL')}</Label>
           <div className="flex items-center gap-2">
-            <code className="flex-1 truncate rounded border border-border/60 bg-muted/30 px-3 py-2 font-mono text-xs">
+            <code className="min-w-0 flex-1 truncate rounded border border-border/60 bg-muted/30 px-3 py-2 font-mono text-xs">
               {scimBaseUrl}
             </code>
             <Button
@@ -295,7 +295,7 @@ function CreateScimTokenDialog({
             <div>
               <Label className="text-xs">Token</Label>
               <div className="mt-1 flex items-center gap-2">
-                <code className="flex-1 truncate rounded border border-border/60 bg-muted/30 px-3 py-2 font-mono text-xs">
+                <code className="min-w-0 flex-1 truncate rounded border border-border/60 bg-muted/30 px-3 py-2 font-mono text-xs">
                   {created.secret}
                 </code>
                 <Button
@@ -311,7 +311,7 @@ function CreateScimTokenDialog({
             <div>
               <Label className="text-xs">{tHardcodedUi.raw('componentsIamScimCard.line301JsxTextSCIMBaseURL')}</Label>
               <div className="mt-1 flex items-center gap-2">
-                <code className="flex-1 truncate rounded border border-border/60 bg-muted/30 px-3 py-2 font-mono text-xs">
+                <code className="min-w-0 flex-1 truncate rounded border border-border/60 bg-muted/30 px-3 py-2 font-mono text-xs">
                   {scimBaseUrl}
                 </code>
                 <Button

--- a/apps/web/src/components/iam/sso-card.tsx
+++ b/apps/web/src/components/iam/sso-card.tsx
@@ -9,7 +9,7 @@ import { useTranslations } from 'next-intl';
 
 import { toast } from '@/lib/toast';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { Loader2, Plus, ShieldCheck, Trash2, X } from 'lucide-react';
+import { ArrowRight, Check, Loader2, Plus, ShieldCheck, Trash2, X } from 'lucide-react';
 import { useMemo, useState } from 'react';
 
 import { Badge } from '@/components/ui/badge';
@@ -140,29 +140,67 @@ export function SsoCard({ accountId, canManage }: SsoCardProps) {
           {providerQuery.isLoading ? (
             <Skeleton className="h-16 w-full" />
           ) : (
-            <dl className="grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
-              <dt className="text-muted-foreground">Provider</dt>
-              <dd className="text-foreground font-medium">{provider.name}</dd>
-              <dt className="text-muted-foreground">
-                {tHardcodedUi.raw('componentsIamSsoCard.line135JsxTextPrimaryDomain')}
-              </dt>
-              <dd className="text-foreground font-mono text-xs">{provider.primary_domain}</dd>
-              <dt className="text-muted-foreground">
-                {tHardcodedUi.raw('componentsIamSsoCard.line137JsxTextGroupClaim')}
-              </dt>
-              <dd className="text-foreground font-mono text-xs">{provider.group_claim_name}</dd>
-              <dt className="text-muted-foreground">
-                {tHardcodedUi.raw('componentsIamSsoCard.line139JsxTextAutoCreateMembers')}
-              </dt>
-              <dd className="text-foreground">{provider.auto_create_members ? 'Yes' : 'No'}</dd>
-              <dt className="text-muted-foreground">Auto-provision groups</dt>
-              <dd className="text-foreground">{provider.auto_provision_groups ? 'Yes' : 'No'}</dd>
-              <dt className="text-muted-foreground">
-                {tHardcodedUi.raw('componentsIamSsoCard.line143JsxTextSupabaseProviderId')}
-              </dt>
-              <dd className="text-muted-foreground truncate font-mono text-[11px]">
-                {provider.supabase_sso_provider_id}
-              </dd>
+            <dl className="text-sm">
+              <div className="border-border/40 flex items-center justify-between gap-4 border-b py-2">
+                <dt className="text-muted-foreground shrink-0">Provider</dt>
+                <dd className="text-foreground min-w-0 truncate text-right font-medium">
+                  {provider.name}
+                </dd>
+              </div>
+              <div className="border-border/40 flex items-center justify-between gap-4 border-b py-2">
+                <dt className="text-muted-foreground shrink-0">
+                  {tHardcodedUi.raw('componentsIamSsoCard.line135JsxTextPrimaryDomain')}
+                </dt>
+                <dd className="text-foreground min-w-0 truncate text-right font-mono text-xs">
+                  {provider.primary_domain}
+                </dd>
+              </div>
+              <div className="border-border/40 flex items-center justify-between gap-4 border-b py-2">
+                <dt className="text-muted-foreground shrink-0">
+                  {tHardcodedUi.raw('componentsIamSsoCard.line137JsxTextGroupClaim')}
+                </dt>
+                <dd className="min-w-0 truncate text-right">
+                  <code className="bg-muted/60 text-foreground rounded px-1.5 py-0.5 font-mono text-[11px]">
+                    {provider.group_claim_name}
+                  </code>
+                </dd>
+              </div>
+              <div className="border-border/40 flex items-center justify-between gap-4 border-b py-2">
+                <dt className="text-muted-foreground shrink-0">
+                  {tHardcodedUi.raw('componentsIamSsoCard.line139JsxTextAutoCreateMembers')}
+                </dt>
+                <dd className="text-right">
+                  {provider.auto_create_members ? (
+                    <span className="inline-flex items-center gap-1 font-medium text-emerald-600 dark:text-emerald-400">
+                      <Check className="h-3.5 w-3.5" />
+                      Yes
+                    </span>
+                  ) : (
+                    <span className="text-muted-foreground">No</span>
+                  )}
+                </dd>
+              </div>
+              <div className="border-border/40 flex items-center justify-between gap-4 border-b py-2">
+                <dt className="text-muted-foreground shrink-0">Auto-provision groups</dt>
+                <dd className="text-right">
+                  {provider.auto_provision_groups ? (
+                    <span className="inline-flex items-center gap-1 font-medium text-emerald-600 dark:text-emerald-400">
+                      <Check className="h-3.5 w-3.5" />
+                      Yes
+                    </span>
+                  ) : (
+                    <span className="text-muted-foreground">No</span>
+                  )}
+                </dd>
+              </div>
+              <div className="flex items-center justify-between gap-4 py-2">
+                <dt className="text-muted-foreground shrink-0">
+                  {tHardcodedUi.raw('componentsIamSsoCard.line143JsxTextSupabaseProviderId')}
+                </dt>
+                <dd className="text-muted-foreground min-w-0 truncate text-right font-mono text-[11px]">
+                  {provider.supabase_sso_provider_id}
+                </dd>
+              </div>
             </dl>
           )}
         </div>
@@ -200,46 +238,39 @@ export function SsoCard({ accountId, canManage }: SsoCardProps) {
                 )}
               </p>
             ) : (
-              <table className="w-full text-sm">
-                <thead>
-                  <tr className="border-border/60 text-muted-foreground border-b text-left text-[10px] font-medium tracking-wider uppercase">
-                    <th className="py-2 font-medium">
-                      {tHardcodedUi.raw('componentsIamSsoCard.line180JsxTextClaimValue')}
-                    </th>
-                    <th className="py-2 font-medium">
-                      {tHardcodedUi.raw('componentsIamSsoCard.line181JsxTextIAMGroup')}
-                    </th>
-                    <th className="w-10 py-2" />
-                  </tr>
-                </thead>
-                <tbody className="divide-border divide-y">
-                  {mappings.map((m) => (
-                    <tr key={m.mapping_id} className="hover:bg-muted/20">
-                      <td className="text-foreground py-2 font-mono text-xs">{m.claim_value}</td>
-                      <td className="py-2">
-                        <Badge variant="outline" size="sm">
-                          {m.group_name}
-                        </Badge>
-                      </td>
-                      <td className="py-2 text-right">
-                        {canManage && (
-                          <Button
-                            size="icon"
-                            variant="ghost"
-                            className="text-muted-foreground hover:text-destructive h-7 w-7"
-                            onClick={() => setMapDeleteTarget(m)}
-                            aria-label={tHardcodedUi.raw(
-                              'componentsIamSsoCard.line201JsxAttrAriaLabelRemoveMapping',
-                            )}
-                          >
-                            <X className="h-3.5 w-3.5" />
-                          </Button>
+              <ul className="space-y-1.5">
+                {mappings.map((m) => (
+                  <li
+                    key={m.mapping_id}
+                    className="border-border/60 bg-muted/20 flex items-center gap-2.5 rounded-lg border px-3 py-2"
+                  >
+                    <code
+                      title={m.claim_value}
+                      className="text-foreground max-w-[42%] truncate font-mono text-xs"
+                    >
+                      {m.claim_value}
+                    </code>
+                    <ArrowRight className="text-muted-foreground/50 h-3.5 w-3.5 shrink-0" />
+                    <Badge variant="outline" size="sm" className="min-w-0 max-w-[42%] truncate">
+                      {m.group_name}
+                    </Badge>
+                    <span className="flex-1" />
+                    {canManage && (
+                      <Button
+                        size="icon"
+                        variant="ghost"
+                        className="text-muted-foreground hover:text-destructive h-7 w-7 shrink-0"
+                        onClick={() => setMapDeleteTarget(m)}
+                        aria-label={tHardcodedUi.raw(
+                          'componentsIamSsoCard.line201JsxAttrAriaLabelRemoveMapping',
                         )}
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
+                      >
+                        <X className="h-3.5 w-3.5" />
+                      </Button>
+                    )}
+                  </li>
+                ))}
+              </ul>
             )}
           </div>
         </>


### PR DESCRIPTION
Two IAM Settings improvements (same branch, per request).

## 1. SCIM dialog overflow (the original fix)
The token + base-URL fields overflowed the "SCIM token created" dialog once #4237 made the URL absolute. Cause: `flex-1 truncate` without `min-w-0` — a flex item won't shrink below its content width, so the long value blew past `max-w-md`. Added `min-w-0` to the three code boxes so `truncate` engages.

## 2. Polish the SSO + SCIM settings cards
Cohesive visual pass on both cards (presentational only — every handler, dialog, and i18n string is unchanged):

**SSO card**
- Detail list → clean divided rows with right-aligned values; `Auto-create members` / `Auto-provision groups` now render as emerald ✓ "Yes" pills instead of plain text; group-claim shown as a mono chip.
- Group mappings → from a flat table to visual `claim → group` rows (mono claim · arrow · group badge) in rounded cards, matching the token-list style.

**SCIM card**
- Header gets an icon, consistent with the SSO card.
- New compact **"Configure your IdP"** hint (identifier = `userName`/email, auth = Bearer/HTTP Header, actions) — so admins don't have to guess the IdP-side settings from docs.
- Active tokens get a green-dot status pill.

CSS/markup-only → labeled `no-tests-needed`. Left unmerged for you to merge.
