### PR TITLE
fix(scim): actually contain the SCIM token dialog (grid-item min-w-0)

### DIFF
--- a/apps/web/src/components/iam/scim-card.tsx
+++ b/apps/web/src/components/iam/scim-card.tsx
@@ -322,10 +322,10 @@ function CreateScimTokenDialog({
         </DialogHeader>
 
         {created ? (
-          <div className="space-y-4">
+          <div className="min-w-0 space-y-4">
             <div>
               <Label className="text-xs">Token</Label>
-              <div className="mt-1 flex items-center gap-2">
+              <div className="mt-1 flex min-w-0 items-center gap-2">
                 <code className="min-w-0 flex-1 truncate rounded border border-border/60 bg-muted/30 px-3 py-2 font-mono text-xs">
                   {created.secret}
                 </code>
@@ -341,7 +341,7 @@ function CreateScimTokenDialog({
             </div>
             <div>
               <Label className="text-xs">{tHardcodedUi.raw('componentsIamScimCard.line301JsxTextSCIMBaseURL')}</Label>
-              <div className="mt-1 flex items-center gap-2">
+              <div className="mt-1 flex min-w-0 items-center gap-2">
                 <code className="min-w-0 flex-1 truncate rounded border border-border/60 bg-muted/30 px-3 py-2 font-mono text-xs">
                   {scimBaseUrl}
                 </code>
@@ -363,7 +363,7 @@ function CreateScimTokenDialog({
             </DialogFooter>
           </div>
         ) : (
-          <form onSubmit={handleSubmit} className="space-y-4">
+          <form onSubmit={handleSubmit} className="min-w-0 space-y-4">
             <div className="space-y-1.5">
               <Label htmlFor="scim-token-name">Name</Label>
               <Input


### PR DESCRIPTION
## The real fix (my #4239 attempt was at the wrong level)

`DialogContent` is a CSS **grid**. A grid item defaults to `min-width: auto`, which means it won't shrink below its content's intrinsic width — and for the nowrap token/URL that width is the full string, so the whole dialog stretched and the fields + copy buttons spilled outside it.

#4239 added `min-w-0` to the inner `<code>`, but the **grid item** wrapping it (`<div className="space-y-4">`) still had `min-width: auto`, so the dialog kept expanding and the inner `truncate` never engaged.

This puts `min-w-0` where it belongs — on the grid item (and the form + the flex rows), so the chain from `DialogContent` down can shrink and the value truncates within the dialog width.

Verify on the Vercel preview: open Settings → SCIM → New SCIM token; the dialog should stay put with the token/URL ellipsized (copy still copies the full value).

CSS-only → `no-tests-needed`.