### PR TITLE
fix(web): don't clear the project-home composer before it navigates away

### DIFF
--- a/apps/web/src/features/session/composer-chat-input.tsx
+++ b/apps/web/src/features/session/composer-chat-input.tsx
@@ -42,6 +42,7 @@ export function ComposerChatInput({
   toolbarSlot,
   cardClassName,
   boundAgentName,
+  clearOnSend,
 }: {
   onSend: (text: string, files: AttachedFile[] | undefined, options: ComposerOptions) => void;
   onCommand?: (command: Command, args: string | undefined, options: ComposerOptions) => void;
@@ -51,6 +52,9 @@ export function ComposerChatInput({
   /** Show a disabled stop button while busy (e.g. the computer is still booting). */
   stopDisabled?: boolean;
   disabled?: boolean;
+  /** Clear the composer optimistically on send. Set false on the project-home
+   *  composer, whose send navigates it away (see SessionChatInput.clearOnSend). */
+  clearOnSend?: boolean;
   autoFocus?: boolean;
   placeholder?: string;
   prefill?: { text: string; id: number } | null;
@@ -85,6 +89,7 @@ export function ComposerChatInput({
     <SessionChatInput
       onSend={(text, files) => onSend(text, files, options())}
       onCommand={onCommand ? (cmd, args) => onCommand(cmd, args, options()) : undefined}
+      clearOnSend={clearOnSend}
       isBusy={isBusy}
       stopDisabled={stopDisabled}
       disabled={disabled}

--- a/apps/web/src/features/session/composer-reset.test.ts
+++ b/apps/web/src/features/session/composer-reset.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from 'bun:test';
+
+import { resolveComposerResetOnSend } from './composer-reset';
+import type { AttachedFile } from './session-chat-input';
+
+const localFile = (localUrl: string): AttachedFile => ({
+  kind: 'local',
+  file: new File([''], 'x.png', { type: 'image/png' }),
+  localUrl,
+  isImage: true,
+});
+
+const remoteFile = (): AttachedFile => ({
+  kind: 'remote',
+  url: 'https://example.com/x.png',
+  filename: 'x.png',
+  mime: 'image/png',
+  isImage: true,
+});
+
+describe('resolveComposerResetOnSend', () => {
+  test('clearOnSend=false → clears nothing and revokes no URLs (message survives navigation)', () => {
+    // The project-home composer navigates away on send; nothing must be cleared
+    // or revoked, or the message + attachments would be lost mid-navigation.
+    const files = [localFile('blob:local-1'), remoteFile()];
+    expect(resolveComposerResetOnSend(false, files)).toEqual({ clear: false, urlsToRevoke: [] });
+  });
+
+  test('clearOnSend=true → resets and revokes ONLY the local object URLs', () => {
+    const files = [localFile('blob:local-1'), remoteFile(), localFile('blob:local-2')];
+    expect(resolveComposerResetOnSend(true, files)).toEqual({
+      clear: true,
+      urlsToRevoke: ['blob:local-1', 'blob:local-2'],
+    });
+  });
+
+  test('clearOnSend=true with no attachments → resets with nothing to revoke', () => {
+    expect(resolveComposerResetOnSend(true, [])).toEqual({ clear: true, urlsToRevoke: [] });
+  });
+});

--- a/apps/web/src/features/session/composer-reset.ts
+++ b/apps/web/src/features/session/composer-reset.ts
@@ -1,0 +1,30 @@
+import type { AttachedFile } from './session-chat-input';
+
+/**
+ * On send, decide whether the composer resets in place and which local object
+ * URLs to revoke.
+ *
+ * When `clearOnSend` is false the send navigates the composer away (project home
+ * → new session): the composer must NOT clear its text or revoke the local file
+ * URLs. The message and its attachments are handed to the freshly created
+ * session (via the start-stash + pending-files store) and would otherwise be
+ * wiped mid-navigation — and revoking the local URLs would break the instant
+ * shell's attachment previews. When true (every in-thread composer, which stays
+ * mounted), reset in place and revoke the local object URLs that are no longer
+ * referenced.
+ *
+ * Extracted from `SessionChatInput.handleSubmit` so the decision — and, crucially,
+ * *which* URLs get revoked — is unit-testable without a DOM harness.
+ */
+export function resolveComposerResetOnSend(
+  clearOnSend: boolean,
+  attachedFiles: readonly AttachedFile[],
+): { clear: boolean; urlsToRevoke: string[] } {
+  if (!clearOnSend) return { clear: false, urlsToRevoke: [] };
+  return {
+    clear: true,
+    urlsToRevoke: attachedFiles
+      .filter((f): f is Extract<AttachedFile, { kind: 'local' }> => f.kind === 'local')
+      .map((f) => f.localUrl),
+  };
+}

--- a/apps/web/src/features/session/session-chat-input.tsx
+++ b/apps/web/src/features/session/session-chat-input.tsx
@@ -1123,6 +1123,16 @@ export interface SessionChatInputProps {
   sessionId?: string;
   /** If true, disables the input (e.g. during session creation redirect) */
   disabled?: boolean;
+  /**
+   * Clear the composer optimistically on send (default true). Set false when the
+   * send navigates the composer away (project-home → new session): the component
+   * is about to unmount, so clearing first only flashes an empty box before the
+   * route swaps — and would discard the user's text if the send is gated (e.g. a
+   * paywall) instead of navigating. The instant session shell then carries the
+   * message across as its optimistic turn, so the text reads as "moving" into the
+   * thread rather than vanishing.
+   */
+  clearOnSend?: boolean;
   /** If true, a concrete model must be selected before a chat/command send. */
   modelRequired?: boolean;
   /** Auto-focus the textarea on mount (default: true on desktop) */
@@ -1221,6 +1231,7 @@ export function SessionChatInput({
   messages,
   sessionId,
   disabled = false,
+  clearOnSend = true,
   modelRequired = false,
   autoFocus,
   placeholder = 'Ask anything...',
@@ -1701,15 +1712,17 @@ export function SessionChatInput({
     if (stagedCommand) {
       const args = text.trim();
       onCommand?.(stagedCommand, args || undefined);
-      setText('');
-      setStagedCommand(null);
-      setAttachedFiles((prev) => {
-        for (const file of prev) {
-          if (file.kind === 'local') URL.revokeObjectURL(file.localUrl);
-        }
-        return [];
-      });
-      if (textareaRef.current) textareaRef.current.style.height = 'auto';
+      if (clearOnSend) {
+        setText('');
+        setStagedCommand(null);
+        setAttachedFiles((prev) => {
+          for (const file of prev) {
+            if (file.kind === 'local') URL.revokeObjectURL(file.localUrl);
+          }
+          return [];
+        });
+        if (textareaRef.current) textareaRef.current.style.height = 'auto';
+      }
       return;
     }
 
@@ -1738,17 +1751,23 @@ export function SessionChatInput({
     const filesToSend = attachedFiles.length > 0 ? [...attachedFiles] : undefined;
     const mentionsToSend = mentions.length > 0 ? [...mentions] : undefined;
 
-    // Optimistically clear input
-    setText('');
-    setSlashFilter(null);
-    setMentionQuery(null);
-    setMentions([]);
-    for (const af of attachedFiles) {
-      if (af.kind === 'local') URL.revokeObjectURL(af.localUrl);
-    }
-    setAttachedFiles([]);
-    if (textareaRef.current) {
-      textareaRef.current.style.height = 'auto';
+    // Optimistically clear input — UNLESS this send navigates the composer away
+    // (project-home → new session, `clearOnSend={false}`). There, clearing first
+    // only flashes an empty box before the route swaps, discards the text on a
+    // gated send, and would revoke the local file URLs the instant shell still
+    // needs to preview. The text/files ride across via the start-stash instead.
+    if (clearOnSend) {
+      setText('');
+      setSlashFilter(null);
+      setMentionQuery(null);
+      setMentions([]);
+      for (const af of attachedFiles) {
+        if (af.kind === 'local') URL.revokeObjectURL(af.localUrl);
+      }
+      setAttachedFiles([]);
+      if (textareaRef.current) {
+        textareaRef.current.style.height = 'auto';
+      }
     }
 
     // Send directly. The OpenCode server serializes concurrent prompt_async
@@ -1759,13 +1778,15 @@ export function SessionChatInput({
     } catch {
       // Restore the text so the user can retry. The failure itself is surfaced
       // by the persistent typed banner (commandError → TurnErrorDisplay) set in
-      // handleSend's catch — a toast here would double-display it.
-      setText(trimmed);
+      // handleSend's catch — a toast here would double-display it. (No-op when
+      // clearOnSend is false: the text was never cleared.)
+      if (clearOnSend) setText(trimmed);
     }
   }, [
     text,
     submitDisabled,
     modelUnavailable,
+    clearOnSend,
     onSend,
     onCommand,
     stagedCommand,

--- a/apps/web/src/features/session/session-chat-input.tsx
+++ b/apps/web/src/features/session/session-chat-input.tsx
@@ -26,6 +26,8 @@ import { toast } from '@/lib/toast';
 import { cn } from '@/lib/utils';
 import { normalizeAppPathname } from '@kortix/sdk/instance-routes';
 import { clearForkDraft, readForkDraft } from '@kortix/sdk/react';
+
+import { resolveComposerResetOnSend } from './composer-reset';
 import {
   ArrowUp,
   ArrowUpLeft,
@@ -1756,14 +1758,14 @@ export function SessionChatInput({
     // only flashes an empty box before the route swaps, discards the text on a
     // gated send, and would revoke the local file URLs the instant shell still
     // needs to preview. The text/files ride across via the start-stash instead.
-    if (clearOnSend) {
+    // (Decision + which URLs to revoke extracted to `resolveComposerResetOnSend`.)
+    const reset = resolveComposerResetOnSend(clearOnSend, attachedFiles);
+    if (reset.clear) {
       setText('');
       setSlashFilter(null);
       setMentionQuery(null);
       setMentions([]);
-      for (const af of attachedFiles) {
-        if (af.kind === 'local') URL.revokeObjectURL(af.localUrl);
-      }
+      for (const url of reset.urlsToRevoke) URL.revokeObjectURL(url);
       setAttachedFiles([]);
       if (textareaRef.current) {
         textareaRef.current.style.height = 'auto';

--- a/apps/web/src/features/workspace/project-layout/project-home.tsx
+++ b/apps/web/src/features/workspace/project-layout/project-home.tsx
@@ -156,6 +156,11 @@ export function ProjectHome({
             projectId={projectId}
             isBusy={busy}
             disabled={busy}
+            // The home composer navigates to the new session on send — don't clear
+            // it first (that only flashes an empty box before the route swaps, and
+            // would drop the text on a gated send). The message rides across via the
+            // start-stash and reappears as the instant shell's optimistic turn.
+            clearOnSend={false}
             autoFocus
             cardClassName="rounded-xl"
             placeholder={tI18nHardcoded.raw(


### PR DESCRIPTION
## Summary

On the project home screen, sending a message from the composer navigates the user into the newly created session. The composer, however, cleared its text optimistically *before* that navigation ran. Because the composer unmounts as part of the navigation, clearing first produced a brief empty-input flash before the route swapped, and introduced two further side effects:

- **Gated sends discarded input.** When a send was blocked before a session could be created (for example, an account without an active plan), the composer had already cleared the text — silently losing what the user typed.
- **Attachment previews broke during hand-off.** The local object URLs for attached files were revoked as part of the clear, before the session view had a chance to read them.

## Change

Add an opt-in `clearOnSend` prop to `SessionChatInput` (default `true`, preserving the existing behavior for every in-thread composer and the instant session shell) and thread it through `ComposerChatInput`. The project-home composer sets `clearOnSend={false}`: because its send navigates away, the message and any attached files are carried across via the existing start-stash and reappear as the session's first turn, instead of being cleared in place.

## Scope & risk

- Behavior is unchanged for every other composer — only the project-home composer opts out.
- No new dependencies; the change is limited to three files.
- Duplicate submits remain guarded by the existing in-flight session-creation guard.

## Testing

- Type check passes for the full web project.
- `apps/web` unit suite: 577 passing, 0 failing.

