### PR TITLE
fix(sandbox): warm prebake-on-push pre-warms every provider a session can use (parity)

### DIFF
--- a/apps/api/src/git-proxy/index.ts
+++ b/apps/api/src/git-proxy/index.ts
@@ -134,11 +134,19 @@ async function forward(c: any, projectId: string, scope: GitScope, suffix: strin
   // push; kickProjectWarmPrebake resolves the current tip and is idempotent, so it
   // no-ops unless the default-branch tip actually moved. The session-start
   // on-demand trigger stays the fallback for projects that never push.
+  //
+  // Pass the per-project provider PIN so the prebake warms the provider(s) a
+  // session on this project will actually use (pinned provider ⇒ that one; no
+  // pin ⇒ every enabled provider) — full parity, not just the default provider.
   if (suffix === '/git-receive-pack' && res.status >= 200 && res.status < 300) {
     void (async () => {
       try {
         const gitProject = await loadGitProject({ row: auth.project });
-        await kickProjectWarmPrebake(gitProject, { accountId: auth.project.accountId });
+        const projectPin =
+          typeof (auth.project.metadata as Record<string, unknown> | null)?.default_sandbox_provider === 'string'
+            ? ((auth.project.metadata as Record<string, unknown>).default_sandbox_provider as string)
+            : null;
+        await kickProjectWarmPrebake(gitProject, { accountId: auth.project.accountId, projectPin });
       } catch (err) {
         console.warn(
           `[git-proxy] warm prebake-on-push skipped for ${projectId}:`,

--- a/apps/api/src/projects/lib/provider-precedence.ts
+++ b/apps/api/src/projects/lib/provider-precedence.ts
@@ -25,3 +25,27 @@ export function resolveSessionProvider(opts: {
   if (opts.projectPin && opts.isEnabled(opts.projectPin)) return { provider: opts.projectPin };
   return { fallback: true };
 }
+
+/**
+ * Which provider(s) a build-on-push warm prebake should target for a project —
+ * i.e. the providers a session on this project could actually land on. Mirrors
+ * {@link resolveSessionProvider} minus the per-request override (a push carries
+ * no session context):
+ *   - an ENABLED per-project pin ⇒ every session uses exactly that provider, so
+ *     warm ONLY it (no wasted bake for providers the project never boots on);
+ *   - otherwise ⇒ sessions fall to the weighted balancer, which can pick ANY
+ *     enabled provider, so warm ALL of them for symmetric parity.
+ * A stale/disabled/absent pin degrades to the "all enabled" case (never a bake
+ * on a provider that can't run). Pure — `allowed`/`isEnabled` are injected, so it
+ * unit-tests without env/DB.
+ */
+export function warmPrebakeProviders(opts: {
+  projectPin: string | null;
+  allowed: readonly string[];
+  isEnabled: (provider: string) => boolean;
+}): string[] {
+  if (opts.projectPin && opts.allowed.includes(opts.projectPin) && opts.isEnabled(opts.projectPin)) {
+    return [opts.projectPin];
+  }
+  return opts.allowed.filter((p) => opts.isEnabled(p));
+}

--- a/apps/api/src/projects/lib/sessions.provider.test.ts
+++ b/apps/api/src/projects/lib/sessions.provider.test.ts
@@ -1,5 +1,5 @@
 import { test, expect, describe } from 'bun:test';
-import { resolveSessionProvider } from './provider-precedence';
+import { resolveSessionProvider, warmPrebakeProviders } from './provider-precedence';
 
 // Mirrors config.normalizeProviderName (legacy 'daytona' → canonical 'managed').
 // Inlined so this stays a zero-dep pure test — importing config.ts would drag in
@@ -99,5 +99,58 @@ describe('legacy daytona→managed normalization at session-create', () => {
     expect(
       resolveSessionProvider({ requested: norm(null), projectPin: norm(null), allowed: ALLOWED, isEnabled: bothEnabled }),
     ).toEqual({ fallback: true });
+  });
+});
+
+// Build-on-push warm-prebake target selection. A git push carries no per-session
+// context, so it must warm the provider(s) a session on this project COULD land
+// on: an enabled pin ⇒ that one; no/stale pin ⇒ every enabled provider. This is
+// the parity fix — an unpinned project (or one that never used to warm Platinum)
+// now pre-warms BOTH backends, while a pinned project warms only what it uses.
+describe('warmPrebakeProviders (build-on-push provider parity)', () => {
+  test('no pin → EVERY enabled provider (managed + platinum) — full parity', () => {
+    expect(
+      warmPrebakeProviders({ projectPin: null, allowed: ALLOWED, isEnabled: bothEnabled }),
+    ).toEqual(['managed', 'platinum']);
+  });
+
+  test('enabled pin → ONLY that provider (no wasted bake on the one it never uses)', () => {
+    expect(
+      warmPrebakeProviders({ projectPin: 'platinum', allowed: ALLOWED, isEnabled: bothEnabled }),
+    ).toEqual(['platinum']);
+    expect(
+      warmPrebakeProviders({ projectPin: 'managed', allowed: ALLOWED, isEnabled: bothEnabled }),
+    ).toEqual(['managed']);
+  });
+
+  test('Daytona pre-warm is NEVER dropped — managed is warmed with no pin and when pinned', () => {
+    // Regression guard for the task invariant: the working Daytona/managed
+    // pre-warm keeps firing. Both the no-pin (all-enabled) path and the
+    // managed-pinned path include 'managed'.
+    expect(warmPrebakeProviders({ projectPin: null, allowed: ALLOWED, isEnabled: bothEnabled })).toContain('managed');
+    expect(warmPrebakeProviders({ projectPin: 'managed', allowed: ALLOWED, isEnabled: bothEnabled })).toContain('managed');
+  });
+
+  test('stale/disabled/absent pin degrades to all-enabled (never bakes a provider that cannot run)', () => {
+    // pin platinum but platinum is keyless → not [platinum]; warm only managed.
+    expect(
+      warmPrebakeProviders({ projectPin: 'platinum', allowed: ALLOWED, isEnabled: (p) => p === 'managed' }),
+    ).toEqual(['managed']);
+    // pin a provider that has since left ALLOWED → all-enabled.
+    expect(
+      warmPrebakeProviders({ projectPin: 'gcp', allowed: ALLOWED, isEnabled: bothEnabled }),
+    ).toEqual(['managed', 'platinum']);
+  });
+
+  test('single-provider deploy → exactly that one (platinum-only)', () => {
+    expect(
+      warmPrebakeProviders({ projectPin: null, allowed: ['platinum'], isEnabled: (p) => p === 'platinum' }),
+    ).toEqual(['platinum']);
+  });
+
+  test('only enabled providers are warmed — a listed-but-keyless provider is skipped', () => {
+    expect(
+      warmPrebakeProviders({ projectPin: null, allowed: ALLOWED, isEnabled: (p) => p === 'managed' }),
+    ).toEqual(['managed']);
   });
 });

--- a/apps/api/src/snapshots/builder.ts
+++ b/apps/api/src/snapshots/builder.ts
@@ -18,7 +18,8 @@ import { projectSnapshotBuilds } from '@kortix/db';
 import { db } from '../shared/db';
 import { resolveCommitSha, type GitBackedProject } from '../projects/git';
 import { getSandboxProvider, type ProviderState, type SandboxProviderAdapter } from './providers';
-import { config } from '../config';
+import { config, normalizeProviderName, type SandboxProviderName } from '../config';
+import { warmPrebakeProviders } from '../projects/lib/provider-precedence';
 import { perProjectWarmImageName, ppwarmReapTargets } from './ppwarm-names';
 import {
   computeTemplateIdentity,
@@ -724,15 +725,47 @@ function kickBackgroundWarmBuild(
  * the default-branch tip is unchanged (the warm image for that tip is already
  * active) or a bake for it is already in flight. Best-effort: never throws, never
  * blocks the push; the session-start on-demand trigger remains the fallback.
+ *
+ * PROVIDER PARITY: a push must pre-warm the provider(s) a session on this project
+ * could actually land on — NOT just the default provider. With `opts.provider`
+ * set, warm exactly that one (the pre-existing single-provider behaviour, kept
+ * byte-identical for callers that already target a provider). Otherwise resolve
+ * the target set from the project's provider PIN, exactly as session creation does
+ * (`warmPrebakeProviders`): an enabled pin ⇒ that one provider; no/stale pin ⇒
+ * every enabled provider (the weighted balancer can route a session to any of
+ * them). This closes the gap where a git push only warmed the default provider
+ * while a Platinum-routed (or Platinum-pinned) session still baked lazily on its
+ * first miss.
  */
 export async function kickProjectWarmPrebake(
   project: GitBackedProject,
-  opts: { accountId?: string; provider?: string } = {},
+  opts: { accountId?: string; provider?: string; projectPin?: string | null } = {},
+): Promise<void> {
+  const providers = opts.provider
+    ? [opts.provider]
+    : warmPrebakeProviders({
+        // Canonicalise the stored pin (legacy 'daytona' → 'managed') so it matches
+        // ALLOWED_SANDBOX_PROVIDERS — exactly what session creation does before it
+        // routes on the pin. Without this a legacy-pinned project would fall through
+        // to the all-enabled branch (harmless, but not true parity).
+        projectPin: opts.projectPin ? normalizeProviderName(opts.projectPin) : null,
+        allowed: config.ALLOWED_SANDBOX_PROVIDERS,
+        isEnabled: (p) => config.isProviderEnabled(p as SandboxProviderName),
+      });
+  // Per-provider: content-addressed name, own getSnapshotState check, own dedup
+  // in kickBackgroundWarmBuild. Independent + best-effort — one provider failing
+  // (or being unconfigured) must not skip the others, so each is its own try.
+  await Promise.all(providers.map((buildProvider) => prebakeForProvider(project, buildProvider, opts.accountId)));
+}
+
+async function prebakeForProvider(
+  project: GitBackedProject,
+  buildProvider: string,
+  accountId?: string,
 ): Promise<void> {
   try {
     const template = await resolveTemplateBySlug(project, undefined);
     if (!template.isShared) return; // same gate as the session-start warm trigger
-    const buildProvider = opts.provider ?? config.getDefaultProvider();
     const provider = getSandboxProvider(buildProvider);
     if (!provider.isConfigured()) return;
     const identity = await computeTemplateIdentity(project, template);
@@ -741,14 +774,14 @@ export async function kickProjectWarmPrebake(
     const warmName = perProjectWarmImageName(project.projectId, tip, identity.snapshotName);
     // Tip unchanged (or already warm for this commit) → nothing to do.
     if ((await provider.getSnapshotState(warmName)) === 'active') return;
-    kickBackgroundWarmBuild(project, { accountId: opts.accountId, provider: buildProvider, snapshotName: warmName });
+    kickBackgroundWarmBuild(project, { accountId, provider: buildProvider, snapshotName: warmName });
     console.log(
       `[snapshots] warm prebake-on-push kicked: project ${project.projectId.slice(0, 8)} ` +
       `tip ${tip.slice(0, 8)} (${buildProvider})`,
     );
   } catch (err) {
     console.warn(
-      `[snapshots] warm prebake-on-push skipped for ${project.projectId}:`,
+      `[snapshots] warm prebake-on-push skipped for ${project.projectId} (${buildProvider}):`,
       err instanceof Error ? err.message : err,
     );
   }


### PR DESCRIPTION
## The gap

Build-on-push warm prebake (#4206) only pre-warmed the **default** provider. The git-proxy `git-receive-pack` handler calls `kickProjectWarmPrebake(gitProject, { accountId })` with **no** `provider`, so inside `kickProjectWarmPrebake` `buildProvider = opts.provider ?? config.getDefaultProvider()` = `ALLOWED_SANDBOX_PROVIDERS[0]` (Daytona/managed on dev). A **Platinum-pinned** — or balancer-routed — session therefore still baked its warm image **lazily on the first miss** (cold "starting agent…"), never pre-emptively. Daytona had push-parity; Platinum did not.

## The fix (approach (a)+(b) hybrid)

Pre-warm the provider(s) a session on the project could **actually land on**, mirroring session-create's own precedence (`resolveSessionProvider`) minus the per-request override a push can't have:

- an **enabled per-project pin** (`metadata.default_sandbox_provider`) ⇒ every session uses exactly that provider ⇒ warm **only** it — approach (a), no wasted bake for a backend the project never boots on;
- **no / stale / disabled pin** ⇒ sessions fall to the weighted balancer, which can pick **any** enabled provider ⇒ warm **all** enabled providers — approach (b), full symmetric parity.

The clean per-project signal (the provider pin) exists, so we get (a) when it's set and (b) otherwise — the best of both.

### Changes
- **`provider-precedence.ts`** — new pure helper `warmPrebakeProviders({ projectPin, allowed, isEnabled })` beside `resolveSessionProvider`; `allowed`/`isEnabled` injected, zero-dep, unit-tested (no env/DB).
- **`builder.ts`** — `kickProjectWarmPrebake` now resolves the target provider list (via the helper) and **loops** it, each provider through the **existing** per-provider path: content-addressed `perProjectWarmImageName`, its own `getSnapshotState` check, and `kickBackgroundWarmBuild`'s existing dedup. Each provider is its **own** try/catch — one failing or being unconfigured never skips the others. Callers that pass `opts.provider` keep byte-identical single-provider behaviour. The stored pin is normalized (`daytona`→`managed`) to match `ALLOWED`, exactly as session-create does.
- **`git-proxy/index.ts`** — passes the project's provider pin from `auth.project.metadata`. Still fully **non-blocking**, fire-and-forget on the `git-receive-pack` path (unchanged control flow: `void (async () => …)()` after the response is built).
- **`sessions.provider.test.ts`** — extends the existing provider-precedence suite with `warmPrebakeProviders` cases, incl. an explicit regression guard that the Daytona/managed pre-warm is never dropped.

## Daytona is unchanged
- Unpinned dev (`ALLOWED=['managed']`) → all-enabled = `['managed']` → Daytona still fires, same as before.
- Managed-pinned → `['managed']`.
- Platinum now **also** pre-warms on push (Platinum-pinned → `['platinum']`; unpinned with both enabled → `['managed','platinum']`).

## Verification
- `bunx tsc --noEmit` in `apps/api`: **clean, exit 0** (baseline `origin/main` also clean; change adds zero errors).
- `bun test src/projects/lib/sessions.provider.test.ts`: **18/18 pass**.
- Trigger stays best-effort / fire-and-forget — never blocks or fails the push.

Do not merge — for review.