### PR TITLE
fix(scim): error-free Okta/Azure provisioning (invites active, PUT, dedup)

### DIFF
--- a/apps/api/src/__tests__/unit-scim-helpers.test.ts
+++ b/apps/api/src/__tests__/unit-scim-helpers.test.ts
@@ -1,6 +1,6 @@
 // Pure SCIM serializer/filter helpers — no DB, safe to run standalone.
 import { describe, expect, test } from 'bun:test';
-import { buildUser, isUnsupportedFilter, parseFilter } from '../scim/app';
+import { buildInviteUser, buildUser, isUnsupportedFilter, parseFilter } from '../scim/app';
 
 describe('parseFilter', () => {
   test('parses the supported `attr eq "value"` form (with whitespace)', () => {
@@ -55,5 +55,33 @@ describe('buildUser active flag', () => {
     expect(u.id).toBe('u-1');
     expect(u.userName).toBe('a@b.com');
     expect(u.externalId).toBe('ext-1');
+  });
+});
+
+describe('buildInviteUser', () => {
+  const invite = {
+    inviteId: 'inv-1',
+    email: 'new@b.com',
+    createdAt: new Date('2026-01-02T00:00:00Z'),
+    externalId: 'okta-99',
+  };
+
+  test('a pending invite is active:true — the key fix so Okta stops "reactivating"', () => {
+    const u = buildInviteUser('acc-1', invite);
+    expect(u.active).toBe(true);
+    expect(u.id).toBe('inv-1'); // SCIM id = invitation id
+    expect(u.userName).toBe('new@b.com');
+    expect(u.externalId).toBe('okta-99');
+    expect(u.emails[0]).toEqual({ value: 'new@b.com', primary: true });
+    expect(u.meta.location).toBe('/scim/v2/accounts/acc-1/Users/inv-1');
+  });
+
+  test('reports active:false when the invite is revoked (deprovision response)', () => {
+    expect(buildInviteUser('acc-1', invite, false).active).toBe(false);
+  });
+
+  test('tolerates a missing externalId (invites without one)', () => {
+    const u = buildInviteUser('acc-1', { ...invite, externalId: undefined });
+    expect(u.externalId).toBeNull();
   });
 });

--- a/apps/api/src/scim/app.ts
+++ b/apps/api/src/scim/app.ts
@@ -8,8 +8,8 @@
 // (the orchestrator) so the original ordering is preserved.
 
 import { z } from '@hono/zod-openapi';
-import { accountGroupMembers } from '@kortix/db';
-import { eq } from 'drizzle-orm';
+import { accountGroupMembers, accountMembers } from '@kortix/db';
+import { and, eq, inArray } from 'drizzle-orm';
 import type { Context } from 'hono';
 import { scimAuth } from '../middleware/scim-auth';
 import { makeOpenApiApp } from '../openapi';
@@ -98,7 +98,7 @@ export async function emailsByUserId(userIds: string[]): Promise<Map<string, str
   return map;
 }
 
-export async function userIdByEmail(email: string): Promise<string | null> {
+export async function userIdByEmail(email: string, accountId?: string): Promise<string | null> {
   const supabase = getSupabase();
   try {
     // Supabase admin doesn't expose a direct email-lookup; use the paginated
@@ -107,8 +107,22 @@ export async function userIdByEmail(email: string): Promise<string | null> {
     // local email→user_id table.
     const normalized = email.trim().toLowerCase();
     const { data } = await supabase.auth.admin.listUsers({ page: 1, perPage: 1000 });
-    const found = data?.users?.find((u) => (u.email ?? '').trim().toLowerCase() === normalized);
-    return found?.id ?? null;
+    const matches = (data?.users ?? []).filter(
+      (u) => (u.email ?? '').trim().toLowerCase() === normalized,
+    );
+    if (matches.length === 0) return null;
+    if (matches.length === 1 || !accountId) return matches[0]!.id;
+    // Duplicate auth users can exist for one email (e.g. the account was created
+    // both by an admin invite AND by SSO first-login). Prefer the id that is
+    // ALREADY a member of this account, so SCIM updates the real member row
+    // instead of forking a second membership onto the wrong auth user.
+    const ids = matches.map((m) => m.id);
+    const [memberRow] = await db
+      .select({ userId: accountMembers.userId })
+      .from(accountMembers)
+      .where(and(eq(accountMembers.accountId, accountId), inArray(accountMembers.userId, ids)))
+      .limit(1);
+    return memberRow?.userId ?? matches[0]!.id;
   } catch {
     return null;
   }
@@ -137,6 +151,36 @@ export function buildUser(
       created: iso,
       lastModified: iso,
       location: locationFor(accountId, 'Users', member.userId),
+    },
+  };
+}
+
+/**
+ * Serialize a PENDING INVITATION as a SCIM User. An invited-but-not-yet-joined
+ * person is a valid, ENABLED account from the IdP's point of view — so we return
+ * `active: true` (NOT false). Returning false made Okta treat the just-pushed
+ * user as deactivated and loop forever "reactivating" it. The SCIM id is the
+ * invitation id; once the person signs in via SSO they become a real member and
+ * are served by `buildUser` instead (the IdP re-correlates by userName/email).
+ */
+export function buildInviteUser(
+  accountId: string,
+  invite: { inviteId: string; email: string; createdAt: Date; externalId?: string | null },
+  active = true,
+): UserShape {
+  const iso = invite.createdAt.toISOString();
+  return {
+    schemas: ['urn:ietf:params:scim:schemas:core:2.0:User'],
+    id: invite.inviteId,
+    userName: invite.email,
+    active,
+    emails: [{ value: invite.email, primary: true }],
+    externalId: invite.externalId ?? null,
+    meta: {
+      resourceType: 'User',
+      created: iso,
+      lastModified: iso,
+      location: locationFor(accountId, 'Users', invite.inviteId),
     },
   };
 }

--- a/apps/api/src/scim/users.ts
+++ b/apps/api/src/scim/users.ts
@@ -3,7 +3,7 @@
 
 import { createRoute, z } from '@hono/zod-openapi';
 import { accountInvitations, accountMembers } from '@kortix/db';
-import { and, eq } from 'drizzle-orm';
+import { and, eq, gt, isNull } from 'drizzle-orm';
 import { invalidateIamCacheForUser } from '../iam/cache-invalidation';
 import { scimError } from '../middleware/scim-auth';
 import { errors, json } from '../openapi';
@@ -12,11 +12,11 @@ import { db } from '../shared/db';
 import {
   ScimResource,
   type UserShape,
+  buildInviteUser,
   buildUser,
   emailsByUserId,
   isUnsupportedFilter,
   listResponse,
-  locationFor,
   parseFilter,
   scimAudit,
   scimRouter,
@@ -24,6 +24,32 @@ import {
 } from './app';
 
 // ─── Users ────────────────────────────────────────────────────────────────
+
+/**
+ * Pending (unaccepted, unexpired) invitations for an account. SCIM presents
+ * account members AND pending invites uniformly, so the IdP sees every person
+ * it pushed — invited users included — as a resolvable, active account rather
+ * than a create that appears to have vanished.
+ */
+async function pendingInviteRows(
+  accountId: string,
+  onlyInviteId?: string,
+): Promise<Array<{ inviteId: string; email: string; createdAt: Date }>> {
+  const conds = [
+    eq(accountInvitations.accountId, accountId),
+    isNull(accountInvitations.acceptedAt),
+    gt(accountInvitations.expiresAt, new Date()),
+  ];
+  if (onlyInviteId) conds.push(eq(accountInvitations.inviteId, onlyInviteId));
+  return db
+    .select({
+      inviteId: accountInvitations.inviteId,
+      email: accountInvitations.email,
+      createdAt: accountInvitations.createdAt,
+    })
+    .from(accountInvitations)
+    .where(and(...conds));
+}
 
 scimRouter.openapi(
   createRoute({
@@ -63,9 +89,13 @@ scimRouter.openapi(
       .where(eq(accountMembers.accountId, accountId));
 
     const emails = await emailsByUserId(members.map((m) => m.userId));
-    const allResources: UserShape[] = members
-      .filter((m) => emails.has(m.userId))
-      .map((m) => buildUser(accountId, m, emails.get(m.userId)!));
+    const invites = await pendingInviteRows(accountId);
+    const allResources: UserShape[] = [
+      ...members
+        .filter((m) => emails.has(m.userId))
+        .map((m) => buildUser(accountId, m, emails.get(m.userId)!)),
+      ...invites.map((i) => buildInviteUser(accountId, i)),
+    ];
 
     if (!filter) return c.json(listResponse(allResources));
 
@@ -113,13 +143,17 @@ scimRouter.openapi(
       .from(accountMembers)
       .where(and(eq(accountMembers.accountId, accountId), eq(accountMembers.userId, userId)))
       .limit(1);
-    if (!member) return scimError(c, 404, 'User not found in this account');
+    if (member) {
+      const emails = await emailsByUserId([userId]);
+      const email = emails.get(userId);
+      if (email) return c.json(buildUser(accountId, member, email));
+    }
 
-    const emails = await emailsByUserId([userId]);
-    const email = emails.get(userId);
-    if (!email) return scimError(c, 404, 'User has no email on record');
+    // Not a live member — maybe a pending invitation (SCIM id = invitation id).
+    const [invite] = await pendingInviteRows(accountId, userId);
+    if (invite) return c.json(buildInviteUser(accountId, invite));
 
-    return c.json(buildUser(accountId, member, email));
+    return scimError(c, 404, 'User not found in this account');
   },
 );
 
@@ -157,7 +191,7 @@ scimRouter.openapi(
     // Look up an existing Supabase user by email. If none, send an invite —
     // we don't have permission to create a passwordless auth user without
     // additional infra (magic link), so an invite is the safe v1 default.
-    const existingUserId = await userIdByEmail(userName);
+    const existingUserId = await userIdByEmail(userName, accountId);
     if (!existingUserId) {
       // Create or refresh a pending invitation; the IdP retries on next sync
       // so the eventual sign-up gets reconciled.
@@ -185,24 +219,21 @@ scimRouter.openapi(
         after: { email: userName, external_id: externalId },
       });
 
-      // SCIM expects a User resource even when the human hasn't joined yet.
-      // We return a placeholder with id=invite.inviteId and active=false so
-      // the IdP can correlate without thinking the create failed.
+      // SCIM expects a User resource even when the human hasn't joined yet. We
+      // return it as active:true (an invited account IS enabled) with
+      // id=invite.inviteId, so the IdP records the push as successful instead of
+      // looping to "reactivate" a user it thinks we deactivated.
       return c.json(
-        {
-          schemas: ['urn:ietf:params:scim:schemas:core:2.0:User'],
-          id: invite.inviteId,
-          userName,
-          active: false,
-          emails: [{ value: userName, primary: true }],
-          externalId,
-          meta: {
-            resourceType: 'User',
-            created: invite.createdAt.toISOString(),
-            lastModified: invite.createdAt.toISOString(),
-            location: locationFor(accountId, 'Users', invite.inviteId),
+        buildInviteUser(
+          accountId,
+          {
+            inviteId: invite.inviteId,
+            email: userName.toLowerCase(),
+            createdAt: invite.createdAt,
+            externalId,
           },
-        },
+          true,
+        ),
         201,
       );
     }
@@ -311,23 +342,41 @@ scimRouter.openapi(
       for (const k of Object.keys(body)) changes.set(k, body[k]);
     }
 
-    const [member] = await db
-      .select({
-        userId: accountMembers.userId,
-        accountRole: accountMembers.accountRole,
-        scimExternalId: accountMembers.scimExternalId,
-        joinedAt: accountMembers.joinedAt,
-      })
-      .from(accountMembers)
-      .where(and(eq(accountMembers.accountId, accountId), eq(accountMembers.userId, userId)))
-      .limit(1);
+    return applyUserWrite(c, accountId, userId, changes);
+  },
+);
 
+/**
+ * Shared write path for PATCH and PUT. Resolves the SCIM id to a live member OR
+ * a pending invitation and applies the change:
+ *   - active:false  → deprovision (remove the member / revoke the invite)
+ *   - externalId    → stored on the member row
+ *   - anything else → accepted as a no-op, 200 with the current resource, so an
+ *     IdP "push profile update" doesn't error.
+ * Returns 404 only when the id matches neither a member nor a pending invite.
+ */
+async function applyUserWrite(
+  c: any,
+  accountId: string,
+  userId: string,
+  changes: Map<string, unknown>,
+) {
+  const [member] = await db
+    .select({
+      userId: accountMembers.userId,
+      accountRole: accountMembers.accountRole,
+      scimExternalId: accountMembers.scimExternalId,
+      joinedAt: accountMembers.joinedAt,
+    })
+    .from(accountMembers)
+    .where(and(eq(accountMembers.accountId, accountId), eq(accountMembers.userId, userId)))
+    .limit(1);
+
+  if (member) {
     // Deactivate
     if (changes.get('active') === false) {
-      if (!member) return c.body(null, 204); // idempotent
       // Refuse to deactivate the last owner — same invariant the human UI
-      // enforces. Without this an IdP misconfiguration could lock everyone
-      // out of an account.
+      // enforces, so an IdP misconfiguration can't lock everyone out.
       if (member.accountRole === 'owner') {
         const owners = await db
           .select({ userId: accountMembers.userId })
@@ -339,18 +388,15 @@ scimRouter.openapi(
           return scimError(c, 409, 'Cannot deactivate the last owner of this account');
         }
       }
-      // Capture the email before removing the row so the response can echo a
-      // complete (active:false) User resource for the IdP to confirm against.
       const emailsBefore = await emailsByUserId([userId]);
       await db
         .delete(accountMembers)
         .where(and(eq(accountMembers.accountId, accountId), eq(accountMembers.userId, userId)));
       invalidateIamCacheForUser(userId);
-      // IdP-driven offboarding: revoke the user's PATs + live sandbox session
-      // tokens so deactivation is immediate, not just membership-level. A failure
-      // here would leave a "deactivated" user with LIVE tokens — a silent
-      // offboarding hole — so surface it loudly and record it on the audit event
-      // (never swallow), while still completing the membership removal.
+      // IdP-driven offboarding: revoke PATs + live sandbox session tokens so
+      // deactivation is immediate. A failure would leave a "deactivated" user
+      // with LIVE tokens — a silent offboarding hole — so surface it loudly and
+      // record it on the audit event, while still removing the membership.
       const revocationError = await revokeAllAccountTokensForUser(userId, accountId).then(
         () => null,
         (err) => {
@@ -372,24 +418,77 @@ scimRouter.openapi(
           ? { metadata: { token_revocation_failed: true, token_revocation_error: revocationError } }
           : {}),
       });
-      // 200 + the deactivated resource (not a bare 204): Azure AD / Okta expect
+      // 200 + the deactivated resource (not a bare 204): Okta / Azure AD expect
       // the patched User back with active:false to confirm deprovisioning.
       return c.json(buildUser(accountId, member, emailsBefore.get(userId) ?? member.userId, false));
     }
 
-    // Reactivate or update — only meaningful when the user exists.
-    if (!member) return scimError(c, 404, 'User not found in this account');
-
     if (changes.has('externalId') && typeof changes.get('externalId') === 'string') {
+      const ext = changes.get('externalId') as string;
       await db
         .update(accountMembers)
-        .set({ scimExternalId: changes.get('externalId') as string })
+        .set({ scimExternalId: ext })
         .where(and(eq(accountMembers.accountId, accountId), eq(accountMembers.userId, userId)));
+      member.scimExternalId = ext;
     }
-
     const emails = await emailsByUserId([userId]);
-    const email = emails.get(userId);
-    return c.json(buildUser(accountId, member, email ?? ''));
+    return c.json(buildUser(accountId, member, emails.get(userId) ?? ''));
+  }
+
+  // Not a live member — maybe a pending invitation (SCIM id = invitation id).
+  const [invite] = await pendingInviteRows(accountId, userId);
+  if (invite) {
+    if (changes.get('active') === false) {
+      await db.delete(accountInvitations).where(eq(accountInvitations.inviteId, invite.inviteId));
+      await scimAudit(c, {
+        accountId,
+        action: 'scim.user.invite_revoke',
+        resourceType: 'account_invitation',
+        resourceId: invite.inviteId,
+        before: { email: invite.email },
+      });
+      return c.json(buildInviteUser(accountId, invite, false));
+    }
+    // No-op profile update on a pending invite — echo it back (200) so the IdP
+    // doesn't treat the update as a failure.
+    return c.json(buildInviteUser(accountId, invite));
+  }
+
+  // Neither a member nor a pending invite: a deactivate of an already-absent
+  // user is idempotent (204); anything else targets a missing resource (404).
+  if (changes.get('active') === false) return c.body(null, 204);
+  return scimError(c, 404, 'User not found in this account');
+}
+
+// PUT — Okta's "Push Profile Updates" replaces the whole resource via PUT
+// (Kortix previously implemented only PATCH, so these calls 404'd). Treat the
+// full body as the change set and run the shared write path.
+scimRouter.openapi(
+  createRoute({
+    method: 'put',
+    path: '/accounts/{accountId}/Users/{userId}',
+    tags: ['scim'],
+    summary: 'Replace a SCIM User (IdP profile push)',
+    request: {
+      params: z.object({ accountId: z.string(), userId: z.string() }),
+      body: { content: { 'application/json': { schema: ScimResource } } },
+    },
+    responses: {
+      200: json(ScimResource, 'SCIM User'),
+      ...errors(400, 401, 403, 404, 409),
+    },
+  }),
+  async (c: any) => {
+    const accountId = c.req.param('accountId');
+    const userId = c.req.param('userId');
+    let body: Record<string, unknown>;
+    try {
+      body = await c.req.json();
+    } catch {
+      return scimError(c, 400, 'Body must be JSON');
+    }
+    const changes = new Map<string, unknown>(Object.entries(body));
+    return applyUserWrite(c, accountId, userId, changes);
   },
 );
 
@@ -414,7 +513,24 @@ scimRouter.openapi(
       .from(accountMembers)
       .where(and(eq(accountMembers.accountId, accountId), eq(accountMembers.userId, userId)))
       .limit(1);
-    if (!member) return c.body(null, 204);
+    if (!member) {
+      // Not a live member — if the id is a pending invitation, revoke it
+      // (deprovision). Either way DELETE is idempotent → 204.
+      const [invite] = await pendingInviteRows(accountId, userId);
+      if (invite) {
+        await db
+          .delete(accountInvitations)
+          .where(eq(accountInvitations.inviteId, invite.inviteId));
+        await scimAudit(c, {
+          accountId,
+          action: 'scim.user.invite_revoke',
+          resourceType: 'account_invitation',
+          resourceId: invite.inviteId,
+          before: { email: invite.email },
+        });
+      }
+      return c.body(null, 204);
+    }
 
     // Same last-owner guard as PATCH active=false.
     if (member.accountRole === 'owner') {

--- a/tests/src/flows/scim.flow.ts
+++ b/tests/src/flows/scim.flow.ts
@@ -104,14 +104,16 @@ flow(
       r.status(400).body().exists("$.detail");
     });
 
-    await ctx.step("POST Users for an unknown email → 201 placeholder invite (active:false)", async () => {
+    await ctx.step("POST Users for an unknown email → 201 invite, active:true", async () => {
       const userName = `${ctx.fixtures.name("scim-user")}@ke2e.kortix.test`;
       const r = await scim.post(
         "/scim/v2/accounts/:accountId/Users",
         { userName, externalId: "ext-ke2e-1" },
         { params: { accountId: team.id } },
       );
-      r.status(201).body().has("$.active", false).has("$.userName", userName).exists("$.id");
+      // active:true — an invited account is enabled; returning false made Okta
+      // loop "reactivating" the user it had just pushed.
+      r.status(201).body().has("$.active", true).has("$.userName", userName).exists("$.id");
     });
 
     await ctx.step("GET unknown user → 404 SCIM error", async () => {
@@ -143,6 +145,22 @@ flow(
       const r = await scim.del("/scim/v2/accounts/:accountId/Users/:userId", {
         params: { accountId: team.id, userId: "00000000-0000-4000-8000-000000000000" },
       });
+      r.status(204);
+    });
+
+    await ctx.step("PUT is implemented (Okta profile push) — active:false → idempotent 204", async () => {
+      // Regression guard: PUT used to be unrouted, so Okta's "Push Profile
+      // Updates" (a PUT) got a bare 404 "Not Found". It now routes through the
+      // shared write path.
+      const r = await scim.put(
+        "/scim/v2/accounts/:accountId/Users/:userId",
+        {
+          schemas: ["urn:ietf:params:scim:schemas:core:2.0:User"],
+          userName: "x@ke2e.kortix.test",
+          active: false,
+        },
+        { params: { accountId: team.id, userId: "00000000-0000-4000-8000-000000000000" } },
+      );
       r.status(204);
     });
 


### PR DESCRIPTION
Makes Okta/Azure SCIM provisioning run without errors. Root causes were confirmed against the dev DB (audit trail + user/invite state), not guessed.

## The errors and their causes

1. **"delay in reactivating remote User. Rescheduling"** (users with no Kortix account) — Kortix creates a pending invite and returned it as `active: false`. Okta reads `active:false` on a user it just pushed as "deactivated" and loops trying to reactivate it.
2. **"push profile update … Not Found"** (existing members) — Okta's "Push Profile Updates" sends **`PUT`**, which Kortix never implemented (PUT was deliberately omitted). No route → 404.
3. **`manager@` had a duplicate `auth.users` row** — `userIdByEmail` matched by first email hit, so it could resolve to the non-member row and update/fork the wrong user.

## Fixes

- **Invites are active SCIM users.** `buildInviteUser` returns `active: true` (an invited account IS enabled), and pending invites are now first-class SCIM users — they appear in `GET /Users` (list + `userName`/`id`/`externalId` filters), resolve on `GET /Users/{id}`, and can be revoked via `PATCH active:false` / `DELETE`. So the IdP sees every user it pushed and stops the reactivation loop.
- **`PUT /Users/{id}`** implemented, sharing one `applyUserWrite` path with `PATCH` (deactivate / externalId / no-op profile push → 200). Okta's profile push no longer 404s.
- **Duplicate-safe `userIdByEmail(email, accountId?)`** — when an email maps to multiple auth users, prefer the one already a member of this account.
- **Idempotent deactivate**: `active:false` on an already-absent user → `204` (not 404).

## Tests

- Unit: `buildInviteUser` (invites are `active:true`; `active:false` on revoke; missing externalId). 10/10 pass; `tsc --noEmit` clean.
- e2e (`scim.flow.ts`): updated the invite assertion to `active:true`; added a PUT regression step (used to 404 as "no route").

## Not in this PR (Okta-side config, not a bug)

Groups (`Engineering`, `Test Users`) don't appear because SCIM group creation needs Okta's separate **"Push Groups"** tab configured; assigning groups under *Assignments* only pushes their users.

## Known limitation

When an invited user later signs in via SAML they become a member and their SCIM id changes (invite-id → user-id); Okta re-correlates by `userName` on its next sync. A future pass could hand out a stable id to avoid the transient re-match.
