### PR TITLE
feat(scim): /ResourceTypes + /Schemas discovery for Azure AD

### DIFF
--- a/apps/api/src/scim/index.ts
+++ b/apps/api/src/scim/index.ts
@@ -4,14 +4,16 @@
 // so the IdP configures its base URL once. scimAuth middleware validates
 // the bearer token and ensures it belongs to the same account.
 //
-// What we implement (v1):
-//   - /ServiceProviderConfig (capabilities discovery)
-//   - /Users: GET (list + filter by userName), GET/:id, POST, PATCH, DELETE
+// What we implement:
+//   - /ServiceProviderConfig, /ResourceTypes, /Schemas (discovery — Azure AD
+//     probes ResourceTypes/Schemas during connector setup; Okta hardcodes them)
+//   - /Users: GET (list + filter by userName), GET/:id, POST, PATCH, PUT, DELETE
+//     (Okta's "Push Profile Updates" uses PUT; Azure uses PATCH — both work)
 //   - /Groups: GET (list), GET/:id, POST, PATCH, DELETE (member add/remove via PATCH)
+//   - Pending invitations are surfaced as ACTIVE Users so every IdP-pushed user
+//     resolves (an invited account is enabled; active:false made Okta loop)
 //
-// What we deliberately skip in v1:
-//   - PUT (most IdPs prefer PATCH; PATCH is sufficient for Okta + Azure AD)
-//   - /Schemas and /ResourceTypes (most IdPs hardcode knowledge of the spec)
+// What we deliberately skip:
 //   - Pagination beyond the default page (small directories fit; revisit if needed)
 //   - Full filter grammar — only `userName eq` / `id eq` / `displayName eq` are
 //     supported, which covers the request patterns Okta and Azure AD actually use.

--- a/apps/api/src/scim/service-provider.ts
+++ b/apps/api/src/scim/service-provider.ts
@@ -2,8 +2,9 @@
 // Registers onto the shared scimRouter via side effect.
 
 import { createRoute, z } from '@hono/zod-openapi';
-import { json, errors } from '../openapi';
-import { scimRouter, ScimResource } from './app';
+import { scimError } from '../middleware/scim-auth';
+import { errors, json } from '../openapi';
+import { ScimResource, listResponse, scimRouter } from './app';
 
 // ─── Discovery ────────────────────────────────────────────────────────────
 
@@ -38,5 +39,176 @@ scimRouter.openapi(
     ],
     meta: { resourceType: 'ServiceProviderConfig' },
   });
+  },
+);
+
+// ─── ResourceTypes + Schemas ────────────────────────────────────────────────
+// Azure AD (and other strict SCIM clients) probe /ResourceTypes and /Schemas
+// during connector setup to discover the User/Group endpoints and their
+// attributes. Okta hardcodes this knowledge and never asked, so v1 skipped
+// them — but Azure needs them, so we serve minimal, valid definitions.
+
+const RESOURCE_TYPE_DEFS = [
+  {
+    name: 'User' as const,
+    endpoint: '/Users',
+    schema: 'urn:ietf:params:scim:schemas:core:2.0:User',
+  },
+  {
+    name: 'Group' as const,
+    endpoint: '/Groups',
+    schema: 'urn:ietf:params:scim:schemas:core:2.0:Group',
+  },
+];
+
+function resourceTypeFor(accountId: string, def: (typeof RESOURCE_TYPE_DEFS)[number]) {
+  return {
+    schemas: ['urn:ietf:params:scim:schemas:core:2.0:ResourceType'],
+    id: def.name,
+    name: def.name,
+    endpoint: def.endpoint,
+    description: `${def.name} resource`,
+    schema: def.schema,
+    meta: {
+      resourceType: 'ResourceType',
+      location: `/scim/v2/accounts/${accountId}/ResourceTypes/${def.name}`,
+    },
+  };
+}
+
+interface ScimAttr {
+  name: string;
+  type: string;
+  multiValued: boolean;
+  required: boolean;
+  caseExact: boolean;
+  mutability: string;
+  returned: string;
+  uniqueness: string;
+  subAttributes?: ScimAttr[];
+}
+
+function attr(name: string, type: string, opts: Partial<ScimAttr> = {}): ScimAttr {
+  return {
+    name,
+    type,
+    multiValued: opts.multiValued ?? false,
+    required: opts.required ?? false,
+    caseExact: opts.caseExact ?? false,
+    mutability: opts.mutability ?? 'readWrite',
+    returned: 'default',
+    uniqueness: opts.uniqueness ?? 'none',
+    ...(opts.subAttributes ? { subAttributes: opts.subAttributes } : {}),
+  };
+}
+
+const SCHEMA_DEFS = [
+  {
+    schemas: ['urn:ietf:params:scim:schemas:core:2.0:Schema'],
+    id: 'urn:ietf:params:scim:schemas:core:2.0:User',
+    name: 'User',
+    description: 'User Account',
+    attributes: [
+      attr('userName', 'string', { required: true, uniqueness: 'server' }),
+      attr('active', 'boolean'),
+      attr('externalId', 'string'),
+      attr('emails', 'complex', {
+        multiValued: true,
+        subAttributes: [attr('value', 'string'), attr('primary', 'boolean')],
+      }),
+      attr('name', 'complex', {
+        subAttributes: [attr('givenName', 'string'), attr('familyName', 'string')],
+      }),
+    ],
+  },
+  {
+    schemas: ['urn:ietf:params:scim:schemas:core:2.0:Schema'],
+    id: 'urn:ietf:params:scim:schemas:core:2.0:Group',
+    name: 'Group',
+    description: 'Group',
+    attributes: [
+      attr('displayName', 'string', { required: true }),
+      attr('externalId', 'string'),
+      attr('members', 'complex', {
+        multiValued: true,
+        subAttributes: [attr('value', 'string'), attr('display', 'string')],
+      }),
+    ],
+  },
+];
+
+function schemaWithLocation(accountId: string, schema: (typeof SCHEMA_DEFS)[number]) {
+  return {
+    ...schema,
+    meta: {
+      resourceType: 'Schema',
+      location: `/scim/v2/accounts/${accountId}/Schemas/${schema.id}`,
+    },
+  };
+}
+
+scimRouter.openapi(
+  createRoute({
+    method: 'get',
+    path: '/accounts/{accountId}/ResourceTypes',
+    tags: ['scim'],
+    summary: 'SCIM ResourceTypes (User + Group discovery)',
+    request: { params: z.object({ accountId: z.string() }) },
+    responses: { 200: json(ScimResource, 'ResourceTypes ListResponse'), ...errors(401, 403) },
+  }),
+  async (c: any) => {
+    const accountId = c.req.param('accountId');
+    return c.json(listResponse(RESOURCE_TYPE_DEFS.map((d) => resourceTypeFor(accountId, d))));
+  },
+);
+
+scimRouter.openapi(
+  createRoute({
+    method: 'get',
+    path: '/accounts/{accountId}/ResourceTypes/{id}',
+    tags: ['scim'],
+    summary: 'SCIM ResourceType by id',
+    request: { params: z.object({ accountId: z.string(), id: z.string() }) },
+    responses: { 200: json(ScimResource, 'ResourceType'), ...errors(401, 403, 404) },
+  }),
+  async (c: any) => {
+    const accountId = c.req.param('accountId');
+    const id = c.req.param('id');
+    const def = RESOURCE_TYPE_DEFS.find((d) => d.name === id);
+    if (!def) return scimError(c, 404, `Unknown ResourceType "${id}"`);
+    return c.json(resourceTypeFor(accountId, def));
+  },
+);
+
+scimRouter.openapi(
+  createRoute({
+    method: 'get',
+    path: '/accounts/{accountId}/Schemas',
+    tags: ['scim'],
+    summary: 'SCIM Schemas (User + Group attribute definitions)',
+    request: { params: z.object({ accountId: z.string() }) },
+    responses: { 200: json(ScimResource, 'Schemas ListResponse'), ...errors(401, 403) },
+  }),
+  async (c: any) => {
+    const accountId = c.req.param('accountId');
+    return c.json(listResponse(SCHEMA_DEFS.map((s) => schemaWithLocation(accountId, s))));
+  },
+);
+
+scimRouter.openapi(
+  createRoute({
+    method: 'get',
+    path: '/accounts/{accountId}/Schemas/{id}',
+    tags: ['scim'],
+    summary: 'SCIM Schema by urn',
+    request: { params: z.object({ accountId: z.string(), id: z.string() }) },
+    responses: { 200: json(ScimResource, 'Schema'), ...errors(401, 403, 404) },
+  }),
+  async (c: any) => {
+    const accountId = c.req.param('accountId');
+    const id = c.req.param('id');
+    const schema = SCHEMA_DEFS.find((s) => s.id === id);
+    if (!schema) return scimError(c, 404, `Unknown Schema "${id}"`);
+    return c.json(schemaWithLocation(accountId, schema));
   },
 );

--- a/tests/src/flows/scim.flow.ts
+++ b/tests/src/flows/scim.flow.ts
@@ -50,6 +50,23 @@ flow(
       r.status(200).body().exists("$.schemas").exists("$.patch.supported").exists("$.authenticationSchemes");
     });
 
+    await ctx.step("ResourceTypes → 200 with User + Group (Azure AD probes this)", async () => {
+      const r = await scim.get("/scim/v2/accounts/:accountId/ResourceTypes", { params: { accountId: team.id } });
+      r.status(200)
+        .body()
+        .has("$.totalResults", 2)
+        .has("$.Resources[0].id", "User")
+        .has("$.Resources[1].id", "Group");
+    });
+
+    await ctx.step("Schemas → 200 with the core User schema + its attributes", async () => {
+      const r = await scim.get("/scim/v2/accounts/:accountId/Schemas", { params: { accountId: team.id } });
+      r.status(200)
+        .body()
+        .has("$.Resources[0].id", "urn:ietf:params:scim:schemas:core:2.0:User")
+        .exists("$.Resources[0].attributes");
+    });
+
     await ctx.step("OWNER JWT (not a SCIM token) → 401", async () => {
       const r = await ctx.client
         .as(ctx.P.OWNER)


### PR DESCRIPTION
Splits the Azure-discovery work out of #4244 into its own PR (per request).

## What
Azure AD probes `/ResourceTypes` and `/Schemas` during connector setup to discover the User/Group endpoints and their attributes. Okta hardcodes the spec and never asks, so v1 skipped them — an Azure connector could fail at setup. This serves both:
- `GET /ResourceTypes` (+ `/{id}`) → User + Group resource types.
- `GET /Schemas` (+ `/{id}`) → core User + Group schemas with attribute definitions (userName, active, emails, name, externalId; displayName, members).

Both auth-gated like `ServiceProviderConfig`. e2e steps added (ResourceTypes → User+Group; Schemas → User schema + attributes). `tsc --noEmit` clean.

Complements #4244 (the Okta provisioning fixes). No overlap — this only adds discovery routes.