### PR TITLE
refactor(ui): rename "department" labels to "groups"

### DIFF
--- a/apps/cli/src/commands/grants.ts
+++ b/apps/cli/src/commands/grants.ts
@@ -8,7 +8,7 @@ import {
 import { C, pad, status } from '../style.ts';
 
 // Resource-access grants — the inheritance PYRAMID. Resources (secrets +
-// connectors) live on AGENTS; you assign an agent to a member or department and
+// connectors) live on AGENTS; you assign an agent to a member or group and
 // they inherit everything that agent declares. This wraps the same
 // /projects/:id/resource-grants routes the dashboard's "Members → Resource
 // access" panel uses. Grantable resource types: agent, skill, secret.
@@ -53,7 +53,7 @@ const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
 const HELP = `Usage: kortix grants <subcommand> [options]
 
 Assign project resources to people — the inheritance PYRAMID. Secrets and
-connectors live on AGENTS; assign an agent to a member (or department) and they
+connectors live on AGENTS; assign an agent to a member (or group) and they
 inherit everything that agent declares. Mirrors the dashboard's
 "Members → Resource access" panel. Authorization is centralized on the agent:
 \`assign\` only ever creates agent grants now (\`ls\` still lists any legacy
@@ -61,12 +61,12 @@ skill/secret rows for visibility — see Resource types: ${RESOURCE_TYPES.join('
 
 Subcommands:
   ls [--json]                          List grants + grantable agents/skills/secrets.
-  assign <agent-name> --to <who> [--group]   Assign an agent to a member (or --group department).
+  assign <agent-name> --to <who> [--group]   Assign an agent to a member (or a group with --group).
   revoke <grant-id>                    Remove a grant.
 
 Options:
-  --to <who>         Member email or user-id; department group-id with --group.
-  --group            Treat --to as a department (group) id, not a member.
+  --to <who>         Member email or user-id; group id with --group.
+  --group            Treat --to as a group id, not a member.
   --type <t>         agent (the only assignable type; default).
   --expires <iso>    Optional auto-revoke timestamp.
   --project <id>     Operate on this project id (default: linked).
@@ -183,7 +183,7 @@ export async function runGrants(argv: string[]): Promise<number> {
             .filter(Boolean)
             .join(' ');
           process.stdout.write(
-            `  ${pad(g.resource_type, 6)} ${C.bold}${pad(g.resource_id, 22)}${C.reset} → ${pad(`${g.principal_type === 'group' ? 'dept:' : ''}${g.principal_label}`, 26)} ${C.dim}${g.grant_id}${C.reset} ${flags}\n`,
+            `  ${pad(g.resource_type, 6)} ${C.bold}${pad(g.resource_id, 22)}${C.reset} → ${pad(`${g.principal_type === 'group' ? 'group:' : ''}${g.principal_label}`, 26)} ${C.dim}${g.grant_id}${C.reset} ${flags}\n`,
           );
         }
         process.stdout.write(
@@ -197,7 +197,7 @@ export async function runGrants(argv: string[]): Promise<number> {
         const resourceId = positional[0];
         if (!resourceId) return missing('an agent name');
         if (!f.to) return missing('--to <member-email|user-id|group-id>');
-        // Authorization is centralized on the AGENT: assigning a member/department
+        // Authorization is centralized on the AGENT: assigning a member/group
         // to an agent is the only grant this command creates. `ls` still shows
         // any legacy skill/secret rows for visibility, but they can't be created
         // here anymore.
@@ -218,7 +218,7 @@ export async function runGrants(argv: string[]): Promise<number> {
           principalId = resolved;
         } else if (!UUID_RE.test(f.to)) {
           process.stderr.write(
-            `${status.err('--group expects a department (group) id.')} Find it in the dashboard's Departments panel or via the API.\n`,
+            `${status.err('--group expects a group id.')} Find it in the dashboard's Groups panel or via the API.\n`,
           );
           return 2;
         }
@@ -233,7 +233,7 @@ export async function runGrants(argv: string[]): Promise<number> {
           emitJson(resp);
           return 0;
         }
-        const whoLabel = group ? `dept ${principalId}` : f.to;
+        const whoLabel = group ? `group ${principalId}` : f.to;
         process.stdout.write(
           `${status.ok(`Assigned ${resourceType} ${C.bold}${resourceId}${C.reset} → ${C.bold}${whoLabel}${C.reset}`)}\n`,
         );

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -167,7 +167,7 @@ const SECTIONS: readonly CommandSection[] = [
       {
         name: 'grants',
         args: '<subcommand>',
-        blurb: "Assign agents to members or departments (they inherit the agent's skills/connectors/secrets)",
+        blurb: "Assign agents to members or groups (they inherit the agent's skills/connectors/secrets)",
       },
     ],
   },

--- a/apps/web/src/features/workspace/customize/sections/view/agents-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/agents-view.tsx
@@ -112,7 +112,7 @@ export function AgentsView({ projectId }: { projectId: string }) {
 }
 
 /**
- * Who inherits this agent — the members/departments assigned to it (Members →
+ * Who inherits this agent — the members/groups assigned to it (Members →
  * Resource access). Each inherits the agent's declared secrets & connectors as
  * their own. Manager-only data: gated on a LIVE can_manage capability so it never
  * fires the manager-only grants endpoint (no 403 / error toast) and never renders
@@ -157,12 +157,12 @@ function AgentAssignments({ projectId, agentName }: { projectId: string; agentNa
               <User className="size-3 shrink-0" />
             )}
             {g.principal_label}
-            {g.principal_type === 'group' ? ' · dept' : ''}
+            {g.principal_type === 'group' ? ' · group' : ''}
           </Badge>
         ))}
       </div>
       <p className="text-muted-foreground/50 text-[11px] leading-relaxed">
-        These members &amp; departments inherit this agent's declared secrets &amp; connectors
+        These members &amp; groups inherit this agent's declared secrets &amp; connectors
         (below) as their own — usable in Secrets, sessions, and connector calls.
       </p>
     </div>

--- a/apps/web/src/features/workspace/customize/sections/view/members-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/members-view.tsx
@@ -1623,7 +1623,7 @@ function ProjectGroupGrantsCard({
   );
 }
 
-// ─── Per-resource scoping (agents/skills → member/department) ──────────────
+// ─── Per-resource scoping (agents/skills → member/group) ──────────────
 
 /**
  * A row of filter pills shown above a long list (resource grants, role
@@ -1887,7 +1887,7 @@ function ResourceAccessCard({
     <SectionCard
       flush
       title="Resource access"
-      description="Assign agents to a member or department to control who can USE them. An agent with no assignment is open to everyone with project access; assigning one restricts it to the people or departments you choose — they inherit that agent's declared skills, connectors, and secrets to use in its sessions. This only ever grants USE, never edit: changing the agent, a skill, a connector, or a secret still requires the editor role."
+      description="Assign agents to a member or group to control who can USE them. An agent with no assignment is open to everyone with project access; assigning one restricts it to the people or groups you choose — they inherit that agent's declared skills, connectors, and secrets to use in its sessions. This only ever grants USE, never edit: changing the agent, a skill, a connector, or a secret still requires the editor role."
       count={grants.length}
       action={
         canManage && hasResources ? (
@@ -1902,7 +1902,7 @@ function ResourceAccessCard({
               <DialogHeader>
                 <DialogTitle>Assign an agent</DialogTitle>
                 <DialogDescription>
-                  Assign an agent to a member or department — they inherit everything that agent
+                  Assign an agent to a member or group — they inherit everything that agent
                   uses (its secrets, connectors, and skills) to USE, not edit. Resources reach
                   people through agents, not by a direct grant; agents you don't assign stay open
                   to everyone with project access. Editing the agent or any resource it uses still
@@ -1949,7 +1949,7 @@ function ResourceAccessCard({
                     disabled={createMutation.isPending}
                   >
                     <SelectTrigger className="w-full">
-                      <SelectValue placeholder="Member or department" />
+                      <SelectValue placeholder="Member or group" />
                     </SelectTrigger>
                     <SelectContent>
                       {members.map((m) => (
@@ -1959,7 +1959,7 @@ function ResourceAccessCard({
                       ))}
                       {groups.map((g) => (
                         <SelectItem key={`group:${g.group_id}`} value={`group:${g.group_id}`}>
-                          {g.name} · dept
+                          {g.name} · group
                         </SelectItem>
                       ))}
                     </SelectContent>
@@ -2035,7 +2035,7 @@ function ResourceAccessCard({
                 subtitle={
                   <InlineMeta>
                     <span>
-                      {g.principal_type === 'group' ? 'Dept' : 'Member'}: {g.principal_label}
+                      {g.principal_type === 'group' ? 'Group' : 'Member'}: {g.principal_label}
                     </span>
                     <span>Granted {formatDate(g.created_at)}</span>
                   </InlineMeta>
@@ -2071,7 +2071,7 @@ function ResourceAccessCard({
 /**
  * Custom-role assignments for THIS project — the project-level view of the
  * account Roles page's bindings. Custom roles are DEFINED on the account Roles
- * page; here a manager grants one (to a member / department / agent) scoped to
+ * page; here a manager grants one (to a member / group / agent) scoped to
  * this project, so a project's full access picture lives in one place.
  */
 function ProjectRoleAssignmentsCard({
@@ -2138,7 +2138,7 @@ function ProjectRoleAssignmentsCard({
 
   function principalLabel(p: IamPolicy): { kind: string; label: string; missing: boolean } {
     if (p.principal_type === 'group') {
-      return { kind: 'Dept', label: groupNameById.get(p.principal_id) ?? p.principal_id, missing: false };
+      return { kind: 'Group', label: groupNameById.get(p.principal_id) ?? p.principal_id, missing: false };
     }
     if (p.principal_type === 'token') {
       // Agent SAs resolve from the account-wide identity list; a miss means the
@@ -2175,7 +2175,7 @@ function ProjectRoleAssignmentsCard({
       (
         [
           { type: 'member', label: 'Member', Icon: User, items: members.map((m) => ({ id: m.user_id, name: userLabel(m) })) },
-          { type: 'group', label: 'Dept', Icon: Users, items: groups.map((g) => ({ id: g.group_id, name: g.name })) },
+          { type: 'group', label: 'Group', Icon: Users, items: groups.map((g) => ({ id: g.group_id, name: g.name })) },
           {
             type: 'token',
             label: 'Agent',
@@ -2248,7 +2248,7 @@ function ProjectRoleAssignmentsCard({
       { value: 'all', label: 'All', count: policies.length },
     ];
     if (policyCounts.member) opts.push({ value: 'member', label: 'Members', count: policyCounts.member });
-    if (policyCounts.group) opts.push({ value: 'group', label: 'Depts', count: policyCounts.group });
+    if (policyCounts.group) opts.push({ value: 'group', label: 'Groups', count: policyCounts.group });
     if (policyCounts.token) opts.push({ value: 'token', label: 'Agents', count: policyCounts.token });
     return opts;
   }, [policies.length, policyCounts]);
@@ -2263,7 +2263,7 @@ function ProjectRoleAssignmentsCard({
     <SectionCard
       flush
       title="Custom roles"
-      description="Grant a custom role to a member, department, or agent on this project. Custom roles are defined on the account Roles page; here you bind them for this project only."
+      description="Grant a custom role to a member, group, or agent on this project. Custom roles are defined on the account Roles page; here you bind them for this project only."
       count={policies.length}
       action={
         canManage && customRoles.length > 0 ? (
@@ -2278,7 +2278,7 @@ function ProjectRoleAssignmentsCard({
               <DialogHeader>
                 <DialogTitle>Assign a custom role</DialogTitle>
                 <DialogDescription>
-                  Bind a custom role to a member, department, or agent on this project only.
+                  Bind a custom role to a member, group, or agent on this project only.
                 </DialogDescription>
               </DialogHeader>
 
@@ -2312,7 +2312,7 @@ function ProjectRoleAssignmentsCard({
 
                 <div className="space-y-1.5">
                   <span className="text-muted-foreground text-xs font-medium">
-                    2. {subjectType === 'group' ? 'Department' : subjectType === 'token' ? 'Agent' : 'Member'}
+                    2. {subjectType === 'group' ? 'Group' : subjectType === 'token' ? 'Agent' : 'Member'}
                   </span>
                   <Select
                     value={subjectId}
@@ -2381,7 +2381,7 @@ function ProjectRoleAssignmentsCard({
               , then bind it here for this project.
             </>
           ) : (
-            'No custom-role assignments on this project yet. Bind one above to grant a member, department, or agent a custom role here.'
+            'No custom-role assignments on this project yet. Bind one above to grant a member, group, or agent a custom role here.'
           )}
         </div>
       )}

--- a/apps/web/src/features/workspace/shared/sharing-intent.test.ts
+++ b/apps/web/src/features/workspace/shared/sharing-intent.test.ts
@@ -7,7 +7,7 @@ import {
 } from './sharing-intent';
 
 describe('selectionToIntent', () => {
-  test('members carries both memberIds and groupIds (departments reach the wire)', () => {
+  test('members carries both memberIds and groupIds (groups reach the wire)', () => {
     const sel: SharingSelection = { mode: 'members', memberIds: ['u1'], groupIds: ['g1', 'g2'] };
     expect(selectionToIntent(sel)).toEqual({
       mode: 'members',
@@ -16,7 +16,7 @@ describe('selectionToIntent', () => {
     });
   });
 
-  test('department-only selection still emits a members intent (not project-wide)', () => {
+  test('group-only selection still emits a members intent (not project-wide)', () => {
     const sel: SharingSelection = { mode: 'members', memberIds: [], groupIds: ['g1'] };
     expect(selectionToIntent(sel)).toEqual({ mode: 'members', memberIds: [], groupIds: ['g1'] });
   });
@@ -33,7 +33,7 @@ describe('selectionToIntent', () => {
 });
 
 describe('intentToSelection', () => {
-  test('reads groupIds back so a saved department selection round-trips', () => {
+  test('reads groupIds back so a saved group selection round-trips', () => {
     const sel = intentToSelection({ mode: 'members', memberIds: ['u1'], groupIds: ['g1'] });
     expect(sel).toEqual({ mode: 'members', memberIds: ['u1'], groupIds: ['g1'] });
   });
@@ -61,11 +61,11 @@ describe('intentToSelection', () => {
 });
 
 describe('isSharingComplete', () => {
-  test('members is complete with ONLY departments selected (the footgun guard)', () => {
+  test('members is complete with ONLY groups selected (the footgun guard)', () => {
     expect(isSharingComplete({ mode: 'members', memberIds: [], groupIds: ['g1'] })).toBe(true);
   });
 
-  test('members is incomplete when neither members nor departments are picked', () => {
+  test('members is incomplete when neither members nor groups are picked', () => {
     // An empty allow-list would silently collapse to project-wide on save.
     expect(isSharingComplete({ mode: 'members', memberIds: [], groupIds: [] })).toBe(false);
   });

--- a/apps/web/src/features/workspace/shared/sharing-intent.ts
+++ b/apps/web/src/features/workspace/shared/sharing-intent.ts
@@ -4,7 +4,7 @@ import type { ConnectorSharing } from '@kortix/sdk/projects-client';
  * Pure sharing-selection logic, shared by the <SharingPicker> component and its
  * callers (secrets, connectors, session sharing). Kept framework-free so it can
  * be unit-tested without pulling in React. The selection carries BOTH members
- * and departments (account groups) — aligned with the IAM member+department
+ * and groups (account groups) — aligned with the IAM member+group
  * model; the share-scope backend already evaluates group grants.
  */
 export type SharingMode = 'project' | 'private' | 'members';
@@ -12,7 +12,7 @@ export type SharingMode = 'project' | 'private' | 'members';
 export interface SharingSelection {
   mode: SharingMode;
   memberIds: string[];
-  /** Departments (account groups) allowed to use this. */
+  /** Groups (account groups) allowed to use this. */
   groupIds: string[];
 }
 
@@ -33,12 +33,12 @@ export const DEFAULT_COPY: SharingCopy = {
   project: { label: 'Project-wide', desc: 'Every member of this project' },
   private: { label: 'Only me', desc: 'Just you' },
   members: {
-    label: 'Specific members or departments',
-    desc: 'A chosen list of members and departments',
+    label: 'Specific members or groups',
+    desc: 'A chosen list of members and groups',
   },
 };
 
-/** A "Specific members or departments" selection must name at least one subject,
+/** A "Specific members or groups" selection must name at least one subject,
  *  else the empty allow-list silently collapses to project-wide on save. */
 export function isSharingComplete(s: SharingSelection): boolean {
   return s.mode !== 'members' || s.memberIds.length + s.groupIds.length > 0;

--- a/apps/web/src/features/workspace/shared/sharing-picker.tsx
+++ b/apps/web/src/features/workspace/shared/sharing-picker.tsx
@@ -71,7 +71,7 @@ export function SharingPicker({
   showHeading?: boolean;
   /**
    * Pure-pyramid mode (secrets + connectors): drop the direct "specific
-   * members/departments" option — targeted access comes ONLY through agent
+   * members/groups" option — targeted access comes ONLY through agent
    * assignment (declare the resource on an agent, assign people to that agent,
    * they inherit it). Keeps one mental model: resources live on agents.
    */
@@ -112,7 +112,7 @@ export function SharingPicker({
       )}
       {hideMembers && !legacyMembers && (
         <p className="text-muted-foreground text-xs leading-relaxed">
-          To give specific people access, assign them (or a department) to an{' '}
+          To give specific people access, assign them (or a group) to an{' '}
           <span className="text-foreground/80 font-medium">agent</span> that uses this — they
           inherit it automatically. Manage that in the project's Members tab.
         </p>
@@ -128,9 +128,9 @@ export function SharingPicker({
 }
 
 /**
- * Searchable, multi-select allow-list of MEMBERS and DEPARTMENTS — the same
- * member+department subject model the IAM Resource-access dialog uses. Members
- * come from the project's access list; departments (account groups) from
+ * Searchable, multi-select allow-list of MEMBERS and GROUPS — the same
+ * member+group subject model the IAM Resource-access dialog uses. Members
+ * come from the project's access list; groups (account groups) from
  * listGroups, keyed off the account the project belongs to (derived from the
  * access response, so no extra prop plumbing).
  */
@@ -244,7 +244,7 @@ function SubjectPicker({
           </div>
         ) : nothing ? (
           <p className="text-muted-foreground px-3 py-6 text-center text-xs">
-            No members or departments in this project yet.
+            No members or groups in this project yet.
           </p>
         ) : filteredGroups.length === 0 && filteredMembers.length === 0 ? (
           <p className="text-muted-foreground px-3 py-6 text-center text-xs">
@@ -255,7 +255,7 @@ function SubjectPicker({
             {filteredGroups.length > 0 && (
               <>
                 <p className="text-muted-foreground/70 px-2 pt-1.5 pb-1 text-[11px] font-medium tracking-wide uppercase">
-                  Departments
+                  Groups
                 </p>
                 {filteredGroups.map((g) => {
                   const isSelected = groupSet.has(g.group_id);
@@ -275,7 +275,7 @@ function SubjectPicker({
                       </span>
                       <span className="text-foreground min-w-0 flex-1 truncate text-sm">
                         {g.name}
-                        <span className="text-muted-foreground ml-1 text-xs">· dept</span>
+                        <span className="text-muted-foreground ml-1 text-xs">· group</span>
                       </span>
                       {isSelected && (
                         <span className="shrink-0 px-1">

--- a/apps/web/src/lib/project-actions.ts
+++ b/apps/web/src/lib/project-actions.ts
@@ -8,7 +8,7 @@
  * — `VALID_ACTIONS` rejects anything else, so a typo here means the IAM probe
  * 400s. Keep this list in sync when actions.ts changes.
  *
- * Gating rule (IAM v1): a capability is DEACTIVATED for a department by giving
+ * Gating rule (IAM v1): a capability is DEACTIVATED for a group by giving
  * its custom role a permission set that OMITS the capability's leaf. The UI
  * reflects that by hiding/disabling the section whose `read`/`write` leaf the
  * role no longer grants. Therefore every `read` leaf used below MUST be one the


### PR DESCRIPTION
Renames the user-facing **"department" labels to "groups"** for the account-groups feature, so the project-level UI matches the account-level UI (which already says **Groups** — the `accounts/[id]` Groups tab, "No groups attached", etc.).

### What changed (display copy + comments only)
- **Project → Customization → Members** (`members-view.tsx`): Resource-access & Custom-roles card copy, the "Member or group" picker, and the `Group`/`Groups` badges & filters.
- **Project → Customization → Agents** (`agents-view.tsx`): the `· group` badge and inheritance blurb.
- **Sharing picker** (`sharing-picker.tsx`, `sharing-intent.ts` + test): "Groups" section header, "· group", "Specific members or groups".
- **CLI** (`grants.ts`, `index.ts`): `kortix grants` help & output (`group:`, "Groups panel", …).

### Deliberately left unchanged
- The **data model** — `group_id`, `groupIds`, `principal_type === 'group'`, object keys/wire values (already "group").\n- **Marketing prose** using "departments" as a general business term (`marketing/**`, `blog-posts.ts`, translation catalogs).\n- The mobile onboarding **mock revenue table** ("Dept" column) and backend/DB code comments.\n\nPure UI-copy rename — no behavioural change. `sharing-intent.test.ts` descriptions updated to match; assertions on the unchanged `groupIds` wire field are intact.