### PR TITLE
fix(web): keep sidebar flyout open while an anchored menu is open

### DIFF
--- a/apps/web/src/components/ui/sidebar-peek.test.ts
+++ b/apps/web/src/components/ui/sidebar-peek.test.ts
@@ -91,4 +91,74 @@ describe('createPeekController', () => {
     flush();
     expect(calls).toEqual([true]);
   });
+
+  test('hold keeps the panel open when the pointer leaves onto portaled menu content', () => {
+    const { controller, calls, pending, flush } = createHarness();
+    controller.enter();
+    flush();
+    controller.hold(true); // menu opens
+    controller.leave(); // pointer travels onto the portaled menu
+    expect(pending.size).toBe(0);
+    flush();
+    expect(calls).toEqual([true]);
+  });
+
+  test('hold cancels a close already armed by the leave-to-portal', () => {
+    const { controller, calls, flush } = createHarness();
+    controller.enter();
+    flush();
+    controller.leave(); // arms close
+    controller.hold(true); // menu opens right after
+    flush();
+    expect(calls).toEqual([true]);
+  });
+
+  test('releasing the last hold re-arms close when the pointer is away', () => {
+    const { controller, calls, pending, flush } = createHarness();
+    controller.enter();
+    flush();
+    controller.hold(true);
+    controller.leave();
+    controller.hold(false, () => false); // menu closes, pointer off panel
+    expect([...pending.values()][0]?.ms).toBe(SIDEBAR_PEEK_CLOSE_DELAY_MS);
+    flush();
+    expect(calls).toEqual([true, false]);
+  });
+
+  test('releasing the last hold keeps the panel open when the pointer is back on it', () => {
+    const { controller, calls, pending, flush } = createHarness();
+    controller.enter();
+    flush();
+    controller.hold(true);
+    controller.hold(false, () => true); // menu closes, pointer over panel
+    expect(pending.size).toBe(0);
+    flush();
+    expect(calls).toEqual([true]);
+  });
+
+  test('nested holds only re-arm close after the final release', () => {
+    const { controller, calls, flush } = createHarness();
+    controller.enter();
+    flush();
+    controller.hold(true);
+    controller.hold(true);
+    controller.hold(false, () => false);
+    expect(calls).toEqual([true]); // still one hold outstanding
+    controller.hold(false, () => false);
+    flush();
+    expect(calls).toEqual([true, false]);
+  });
+
+  test('cancel clears outstanding holds', () => {
+    const { controller, calls, flush } = createHarness();
+    controller.enter();
+    flush();
+    controller.hold(true);
+    controller.cancel();
+    expect(calls).toEqual([true, false]);
+    // A stale leave after cancel must not resurrect a close via the old hold.
+    controller.leave();
+    flush();
+    expect(calls).toEqual([true, false]);
+  });
 });

--- a/apps/web/src/components/ui/sidebar-peek.ts
+++ b/apps/web/src/components/ui/sidebar-peek.ts
@@ -7,6 +7,15 @@ export interface PeekController {
   enter: () => void;
   leave: () => void;
   cancel: () => void;
+  /**
+   * Hold the flyout open across pointer-leaves — used while a menu/popover
+   * anchored in the panel is open. Its content portals outside the panel, so
+   * moving the pointer onto it fires the panel's `leave` and would otherwise
+   * arm the close timer. Calls must be balanced: `hold(true)` on open,
+   * `hold(false)` on close. On the final release the close timer is armed
+   * unless `isPointerOver()` reports the pointer is back on the panel.
+   */
+  hold: (held: boolean, isPointerOver?: () => boolean) => void;
 }
 
 /**
@@ -24,12 +33,25 @@ export function createPeekController(
 ): PeekController {
   let timer: TimerId | null = null;
   let peeked = false;
+  // Number of menus/popovers currently pinning the flyout open. While > 0 a
+  // `leave` cannot close the panel; the last release re-arms the close timer.
+  let holds = 0;
 
   const clear = () => {
     if (timer !== null) {
       unschedule(timer);
       timer = null;
     }
+  };
+
+  const armClose = () => {
+    clear();
+    if (!peeked) return;
+    timer = schedule(() => {
+      timer = null;
+      peeked = false;
+      setPeek(false);
+    }, SIDEBAR_PEEK_CLOSE_DELAY_MS);
   };
 
   return {
@@ -43,19 +65,26 @@ export function createPeekController(
       }, SIDEBAR_PEEK_OPEN_DELAY_MS);
     },
     leave: () => {
-      clear();
-      if (!peeked) return;
-      timer = schedule(() => {
-        timer = null;
-        peeked = false;
-        setPeek(false);
-      }, SIDEBAR_PEEK_CLOSE_DELAY_MS);
+      if (holds > 0) return;
+      armClose();
     },
     cancel: () => {
       clear();
+      holds = 0;
       if (!peeked) return;
       peeked = false;
       setPeek(false);
+    },
+    hold: (held, isPointerOver) => {
+      if (held) {
+        holds += 1;
+        // Cancel any close armed by the leave that fired as the pointer
+        // travelled from the panel onto the portaled menu content.
+        clear();
+        return;
+      }
+      holds = Math.max(0, holds - 1);
+      if (holds === 0 && !isPointerOver?.()) armClose();
     },
   };
 }

--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -42,6 +42,10 @@ type SidebarContextProps = {
   peek: boolean;
   peekEnter: () => void;
   peekLeave: () => void;
+  /** Pin the flyout open while a menu/popover anchored in the panel is open —
+   *  its content portals outside the panel, so hovering it would otherwise
+   *  collapse the flyout. Balanced: `holdPeek(true)` on open, `false` on close. */
+  holdPeek: (held: boolean) => void;
 };
 
 export const SidebarContext = React.createContext<SidebarContextProps | null>(null);
@@ -104,6 +108,22 @@ function SidebarProvider({
     if (open || isMobile) peekController.cancel();
   }, [open, isMobile, peekController]);
 
+  // Tracks whether the pointer is currently over the panel/edge zone so a
+  // menu closing can decide whether to re-arm the flyout's close timer.
+  const pointerOverRef = React.useRef(false);
+  const peekEnter = React.useCallback(() => {
+    pointerOverRef.current = true;
+    peekController.enter();
+  }, [peekController]);
+  const peekLeave = React.useCallback(() => {
+    pointerOverRef.current = false;
+    peekController.leave();
+  }, [peekController]);
+  const holdPeek = React.useCallback(
+    (held: boolean) => peekController.hold(held, () => pointerOverRef.current),
+    [peekController],
+  );
+
   // Adds a keyboard shortcut to toggle the sidebar.
   React.useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -131,8 +151,9 @@ function SidebarProvider({
       setOpenMobile,
       toggleSidebar,
       peek,
-      peekEnter: peekController.enter,
-      peekLeave: peekController.leave,
+      peekEnter,
+      peekLeave,
+      holdPeek,
     }),
     [
       state,
@@ -143,7 +164,9 @@ function SidebarProvider({
       setOpenMobile,
       toggleSidebar,
       peek,
-      peekController,
+      peekEnter,
+      peekLeave,
+      holdPeek,
     ],
   );
 

--- a/apps/web/src/features/layout/user-menu.tsx
+++ b/apps/web/src/features/layout/user-menu.tsx
@@ -92,6 +92,15 @@ export function UserMenu({
     }
   }, [accountsQuery.data, selectedAccountId, setSelectedAccountId]);
 
+  // In the collapsed sidebar's hover flyout, the menu content portals outside
+  // the panel — hovering it fires the panel's pointer-leave and would collapse
+  // the flyout out from under the open menu. Pin the flyout open while it's up.
+  useEffect(() => {
+    if (variant !== 'sidebar' || !menuOpen) return;
+    sidebar?.holdPeek(true);
+    return () => sidebar?.holdPeek(false);
+  }, [menuOpen, variant, sidebar]);
+
   const currentAccount =
     accountsQuery.data?.find((a) => a.account_id === selectedAccountId) ?? null;
 

--- a/apps/web/src/features/workspace/project-sidebar/project-sidebar.tsx
+++ b/apps/web/src/features/workspace/project-sidebar/project-sidebar.tsx
@@ -81,7 +81,7 @@ const SESSION_FILTER_ICONS: Record<SessionFilterValue, LucideIcon | IconMynauiTy
 
 export function ProjectSidebar({ projectId }: { projectId: string }) {
   const tI18nHardcoded = useTranslations('hardcodedUi');
-  const { state, setOpenMobile, toggleSidebar, peek } = useSidebar();
+  const { state, setOpenMobile, toggleSidebar, peek, holdPeek } = useSidebar();
   const isExpanded = state === 'expanded';
   const isMobile = useIsMobile();
   const sessionsGroupRef = useRef<HTMLDivElement>(null);
@@ -235,7 +235,7 @@ export function ProjectSidebar({ projectId }: { projectId: string }) {
                       </span>
                     )}
                   </div>
-                  <DropdownMenu>
+                  <DropdownMenu onOpenChange={holdPeek}>
                     <DropdownMenuContent align="start" className="w-44 p-1">
                       {SESSION_FILTER_OPTIONS.map((option) => {
                         const OptionIcon = SESSION_FILTER_ICONS[option.value];


### PR DESCRIPTION
## Problem

The collapsed sidebar's hover **flyout** closed out from under its dropdowns. Opening the **UserMenu** (or the session-filter `⋯` menu) and moving the pointer onto it slid the whole panel away, breaking the flow.

**Root cause:** the flyout stays open only while the pointer is over the panel — `onPointerLeave` arms a close timer. Radix dropdowns render their content in a **portal outside** the panel's DOM, so moving onto the open menu fires the panel's `leave` and collapses the flyout while the menu is still open.

## Fix

- **`sidebar-peek.ts`** — new `hold(held, isPointerOver?)` on the peek controller. While ≥1 hold is active, `leave` can't close the panel, and opening a hold cancels any close already armed by the leave-to-portal. The final release re-arms close **only if the pointer isn't back on the panel**.
- **`sidebar.tsx`** — provider tracks pointer-over via wrapped `peekEnter`/`peekLeave` and exposes `holdPeek(held)` on the context.
- **`user-menu.tsx`** — holds peek while the sidebar-variant menu is open (released on close/unmount).
- **`project-sidebar.tsx`** — session-filter dropdown (same flyout, same bug) now `onOpenChange={holdPeek}`.

## Testing

- Extended `sidebar-peek.test.ts` with 6 new cases (hold-through-leave, cancel-armed-close, release re-arms/keeps-open by pointer position, nested holds, cancel clears holds). **12/12 pass.**
- `tsc --noEmit` clean on all touched files.

