### PR TITLE
feat(accounts): member directory visible to all members

### DIFF
--- a/apps/api/src/__tests__/unit-members-visibility.test.ts
+++ b/apps/api/src/__tests__/unit-members-visibility.test.ts
@@ -1,42 +1,19 @@
 import { describe, expect, test } from 'bun:test';
-import { visibleMemberRows } from '../accounts/core/member-visibility';
+import { canSeeSensitiveMemberColumns } from '../accounts/core/member-visibility';
 
-// The roster is deliberately filtered for plain members so an account that
-// hosts unrelated invitees doesn't leak the rest of the roster. These lock in
-// that cut — the same cut the members list AND its header count rely on.
-const rows = [
-  { userId: 'owner-1', accountRole: 'owner' },
-  { userId: 'admin-1', accountRole: 'admin' },
-  { userId: 'member-me', accountRole: 'member' },
-  { userId: 'member-other', accountRole: 'member' },
-];
-
-describe('visibleMemberRows', () => {
-  test('managers see every member', () => {
-    expect(visibleMemberRows(rows, 'member-me', true)).toHaveLength(4);
+// The member DIRECTORY is visible to everyone in the account (all rows are
+// returned). This gate is ONLY about the sensitive per-member columns — PAT
+// count, MFA, groups, project grants — which stay manager-only + own-row.
+describe('canSeeSensitiveMemberColumns', () => {
+  test('member-managers (owner/admin/member.invite) see sensitive columns on every row', () => {
+    expect(canSeeSensitiveMemberColumns('mgr', 'someone-else', true)).toBe(true);
+    expect(canSeeSensitiveMemberColumns('mgr', 'mgr', true)).toBe(true);
   });
 
-  test('a plain member sees owners/admins + themselves, never other bare members', () => {
-    const seen = visibleMemberRows(rows, 'member-me', false).map((r) => r.userId);
-    expect(seen).toContain('owner-1');
-    expect(seen).toContain('admin-1');
-    expect(seen).toContain('member-me');
-    // The roster-leak guard: another plain member is NOT visible, so neither
-    // the list nor the count (members.length) exposes them or the true size.
-    expect(seen).not.toContain('member-other');
-    expect(seen).toHaveLength(3);
-  });
-
-  test('a plain member who is not themselves a member still sees only owners/admins', () => {
-    // e.g. a viewer who was just removed; they never see other bare members.
-    const seen = visibleMemberRows(rows, 'ghost', false).map((r) => r.userId);
-    expect(seen).toEqual(['owner-1', 'admin-1']);
-  });
-
-  test('does not mutate the input rows', () => {
-    const snapshot = JSON.parse(JSON.stringify(rows));
-    visibleMemberRows(rows, 'member-me', false);
-    visibleMemberRows(rows, 'anyone', true);
-    expect(rows).toEqual(snapshot);
+  test('a plain member sees sensitive columns only on their OWN row', () => {
+    expect(canSeeSensitiveMemberColumns('me', 'me', false)).toBe(true);
+    // Another member's PAT count / MFA / groups stay hidden from a plain member,
+    // even though that member IS visible in the directory.
+    expect(canSeeSensitiveMemberColumns('me', 'someone-else', false)).toBe(false);
   });
 });

--- a/apps/api/src/accounts/core/member-visibility.ts
+++ b/apps/api/src/accounts/core/member-visibility.ts
@@ -1,21 +1,20 @@
 /**
- * Which account-member rows a given viewer is allowed to see.
+ * The member DIRECTORY (who is in the account — email, role, group names) is
+ * visible to EVERY member of the account, the way Slack / GitHub / Notion show
+ * teammates within one company. But one member's SECURITY POSTURE is not
+ * something every teammate should see.
  *
- * Full-roster visibility is a member-management capability. Managers (owners,
- * admins, or anyone granted `member.invite`) see every member. A plain member
- * sees only who runs the account — owners/admins — and themselves; it must
- * NOT enumerate the other bare members, because one account can host unrelated
- * invitees (e.g. a demo account with several prospect orgs) and a bare
- * membership must not leak the rest of the roster (identities OR its size).
+ * `canSeeSensitiveMemberColumns` decides who may see the sensitive per-member
+ * columns — active PAT count, verified-MFA flag, group memberships, and explicit
+ * project grants: only member-managers (owners/admins, or anyone granted
+ * `member.invite`) and the viewer's OWN row.
  *
- * Pure and dependency-free so it can be unit-tested in isolation and reused by
- * anything that needs the "what can this viewer see" cut (list rows AND count).
+ * Pure and dependency-free so it can be unit-tested in isolation.
  */
-export function visibleMemberRows<T extends { userId: string; accountRole: string }>(
-  rows: readonly T[],
+export function canSeeSensitiveMemberColumns(
   viewerUserId: string,
+  rowUserId: string,
   canManageMembers: boolean,
-): T[] {
-  if (canManageMembers) return [...rows];
-  return rows.filter((r) => r.userId === viewerUserId || r.accountRole !== 'member');
+): boolean {
+  return canManageMembers || viewerUserId === rowUserId;
 }

--- a/apps/api/src/accounts/core/members.ts
+++ b/apps/api/src/accounts/core/members.ts
@@ -16,7 +16,7 @@ import { revokeAllAccountTokensForUser } from '../../repositories/account-tokens
 import { db } from '../../shared/db';
 import { lookupUserIdByEmail } from '../../shared/users';
 import { buildInviteUrl, sendAccountInviteEmail } from '../email';
-import { visibleMemberRows } from './member-visibility';
+import { canSeeSensitiveMemberColumns } from './member-visibility';
 import {
   AccountIdParam,
   AccountInviteSchema,
@@ -56,13 +56,12 @@ export function registerMemberRoutes(): void {
       const membership = await getMembership(userId, accountId);
       if (!membership) return c.json({ error: 'Forbidden' }, 403);
 
-      // Full-roster visibility is a member-management capability. Owners,
-      // admins, and anyone granted member.invite by a custom policy see every
-      // member plus the sensitive columns (PATs, MFA, groups, project grants).
-      // Plain members only see who runs the account — owners/admins — and
-      // themselves: an account can host unrelated invitees (e.g. one demo
-      // account with several prospect orgs), and a bare membership must not
-      // enumerate the other invitees' emails or security posture.
+      // The member directory is visible to EVERY member of the account (the way
+      // Slack / GitHub show teammates within one company), so all rows are
+      // returned. What stays gated is the SENSITIVE per-member data (PAT count,
+      // MFA, group memberships, project grants): member-managers (owner / admin /
+      // member.invite) see it on every row, everyone else only on their own —
+      // enforced by canSeeSensitiveMemberColumns in the map below.
       const canManageMembers = (await authorize(userId, accountId, ACCOUNT_ACTIONS.MEMBER_INVITE))
         .allowed;
 
@@ -76,7 +75,9 @@ export function registerMemberRoutes(): void {
         .from(accountMembers)
         .where(eq(accountMembers.accountId, accountId));
 
-      const visibleRows = visibleMemberRows(rows, userId, canManageMembers);
+      // Everyone in the account sees the full directory; sensitive columns are
+      // gated per-row below.
+      const visibleRows = rows;
 
       const emails = await lookupEmailsByUserIds(rows.map((r) => r.userId));
       const projectGrantRows = await db
@@ -170,7 +171,7 @@ export function registerMemberRoutes(): void {
             // Sensitive columns (PATs, MFA, groups, grants) are visible on a
             // member's own row and to member-managers — never across rows for
             // plain members.
-            const showSensitive = canManageMembers || r.userId === userId;
+            const showSensitive = canSeeSensitiveMemberColumns(userId, r.userId, canManageMembers);
             return {
               user_id: r.userId,
               email: emails.get(r.userId) ?? null,

--- a/apps/web/src/app/(app)/accounts/[id]/page.tsx
+++ b/apps/web/src/app/(app)/accounts/[id]/page.tsx
@@ -1318,7 +1318,8 @@ function MembersCard({
                   <InlineMeta>
                     <span>Joined {formatDate(member.joined_at)}</span>
                     {member.account_role === 'member' &&
-                    typeof member.explicit_project_count === 'number' ? (
+                    typeof member.explicit_project_count === 'number' &&
+                    member.explicit_project_count > 0 ? (
                       <span>
                         {member.explicit_project_count} project
                         {member.explicit_project_count === 1 ? '' : 's'}


### PR DESCRIPTION
## Why
A plain member could see **all groups** but only a **filtered member list** (owners/admins + self) — inconsistent, and confusing ("why can't I see my teammates?"). The member-hiding rule was written for one account hosting *unrelated* prospect orgs — a demo edge case, not how real customers use it. Every real account is one company, where seeing coworkers is the norm (Slack / GitHub / Notion).

## What
- The member **directory** is now returned to every member of the account (all rows).
- **Sensitive per-member columns stay gated** — active PAT count, verified-MFA flag, group memberships, project grants are visible only to member-managers (owner / admin / `member.invite`) and on a member's own row. So you see *who's* in the org, not everyone's security posture. (Slack/GitHub norm.)
- Refactor: the old `visibleMemberRows` row-filter helper → `canSeeSensitiveMemberColumns` (the column gate that remains), with its unit test rewritten.
- Frontend tidy: hide the "0 projects" meta when the count is 0 (matches how PATs/MFA/groups already hide when empty).

Groups were already visible to all — so this makes members consistent with groups, in the direction users expect. A locked-down directory can be an explicit account setting later if a customer needs it.

Verified: `tsc --noEmit` clean, unit test passes.