### PR TITLE
fix(web): keep the instant session shell up on transient start errors and calm the session-start UI

### DIFF
--- a/apps/web/src/app/(app)/projects/[id]/sessions/[sessionId]/page.tsx
+++ b/apps/web/src/app/(app)/projects/[id]/sessions/[sessionId]/page.tsx
@@ -13,6 +13,7 @@ import { InstantSessionShell } from '@/features/session/instant-session-shell';
 import { SandboxLoadingBoundary } from '@/features/session/sandbox-loading-boundary';
 import { SessionChat } from '@/features/session/session-chat';
 import { SessionLayout } from '@/features/session/session-layout';
+import { shouldShowStartError } from '@/features/session/session-start-gate';
 import { SessionStartingLoader } from '@/features/session/session-starting-loader';
 import { ProjectShell } from '@/features/workspace/project-layout/project-shell';
 import { useAccountState } from '@/hooks/billing';
@@ -183,15 +184,15 @@ export default function ProjectSessionPage() {
       );
     }
 
-    if (session.startError) {
-      const sessionMissing = session.startError.status === 404;
+    if (shouldShowStartError(session.startError, isFresh)) {
+      const sessionMissing = session.startError!.status === 404;
       return (
         <InlineSessionError
           title="Couldn't start session"
           message={
             sessionMissing
               ? 'This session is no longer available, or you do not have access to it.'
-              : session.startError.message
+              : session.startError!.message
           }
         />
       );

--- a/apps/web/src/app/(app)/projects/[id]/sessions/[sessionId]/page.tsx
+++ b/apps/web/src/app/(app)/projects/[id]/sessions/[sessionId]/page.tsx
@@ -4,6 +4,7 @@ import { useTranslations } from 'next-intl';
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Loader2, RotateCcw } from 'lucide-react';
+import { useReducedMotion } from 'motion/react';
 import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import { type ReactNode, useEffect, useRef, useState } from 'react';
 
@@ -116,6 +117,7 @@ export default function ProjectSessionPage() {
   // ── Crossfade: the instant shell fades out as the real chat fades in ──────
   // A fully-interactive shell (welcome wallpaper + live input) renders at a SINGLE
   // stable tree position for the whole pre-ready lifecycle, so it never remounts.
+  const prefersReducedMotion = useReducedMotion() ?? false;
   const [chatReady, setChatReady] = useState(false);
   const [loaderMounted, setLoaderMounted] = useState(true);
   const [shellSubmitted, setShellSubmitted] = useState(false);
@@ -144,6 +146,12 @@ export default function ProjectSessionPage() {
   useEffect(() => {
     if (chatReady) clearSessionFresh(sessionId);
   }, [chatReady, sessionId]);
+  // Reduced motion cuts instead of crossfading (motion-reduce:transition-none),
+  // so the loader layer's opacity change fires no transitionend — unmount it
+  // here instead of waiting for the handler below.
+  useEffect(() => {
+    if (chatReady && prefersReducedMotion) setLoaderMounted(false);
+  }, [chatReady, prefersReducedMotion]);
 
   // Terminal/gated states fully REPLACE the content (no chat to fade to).
   const gated = !authLoading && !!user && noPlan;
@@ -226,7 +234,7 @@ export default function ProjectSessionPage() {
         {canMountChat && (
           <div
             className={cn(
-              'absolute inset-0 flex min-h-0 flex-1 flex-col overflow-hidden transition-opacity duration-300 ease-out',
+              'absolute inset-0 flex min-h-0 flex-1 flex-col overflow-hidden transition-opacity duration-300 ease-out motion-reduce:transition-none',
               chatReady ? 'opacity-100' : 'pointer-events-none opacity-0',
             )}
           >
@@ -249,7 +257,7 @@ export default function ProjectSessionPage() {
               if (chatReady) setLoaderMounted(false);
             }}
             className={cn(
-              'absolute inset-0 flex flex-col transition-opacity duration-300 ease-out',
+              'absolute inset-0 flex flex-col transition-opacity duration-300 ease-out motion-reduce:transition-none',
               chatReady ? 'pointer-events-none opacity-0' : 'opacity-100',
             )}
           >
@@ -261,11 +269,7 @@ export default function ProjectSessionPage() {
                 onSubmit={() => setShellSubmitted(true)}
               />
             ) : (
-              <SessionStartingLoader
-                stage={authLoading || !user ? 'provisioning' : startStage}
-                projectId={projectId}
-                sessionId={sessionId}
-              />
+              <SessionStartingLoader projectId={projectId} sessionId={sessionId} />
             )}
           </div>
         )}

--- a/apps/web/src/features/session/boot-status-line.test.ts
+++ b/apps/web/src/features/session/boot-status-line.test.ts
@@ -1,0 +1,9 @@
+import { expect, test } from 'bun:test';
+import { BOOT_STATUS_LABEL } from './boot-status-line';
+
+test('boot status is a single calm line, not a step checklist', () => {
+  expect(BOOT_STATUS_LABEL).toBe('Starting your computer…');
+  // Guard against regressing to the 4-step theater copy.
+  expect(BOOT_STATUS_LABEL).not.toContain('Allocating');
+  expect(BOOT_STATUS_LABEL).not.toContain('Provisioning your computer');
+});

--- a/apps/web/src/features/session/boot-status-line.tsx
+++ b/apps/web/src/features/session/boot-status-line.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { cn } from '@/lib/utils';
+
+export const BOOT_STATUS_LABEL = 'Starting your computer…';
+
+/**
+ * The ONE boot indicator: a single quiet line with a soft kortix-green pulse.
+ * Replaces the old 4-step checklist theater everywhere the runtime is coming up
+ * (thread, side panel, resume loader). Honors prefers-reduced-motion.
+ */
+export function BootStatusLine({
+  align = 'start',
+  className,
+}: {
+  align?: 'start' | 'center';
+  className?: string;
+}) {
+  return (
+    <span
+      className={cn(
+        'text-muted-foreground/70 inline-flex items-center gap-2 text-[13px] tracking-tight',
+        align === 'center' && 'justify-center',
+        className,
+      )}
+      aria-live="polite"
+    >
+      <span
+        className="bg-kortix-green/70 h-1.5 w-1.5 shrink-0 animate-pulse rounded-full motion-reduce:animate-none"
+        aria-hidden
+      />
+      <span>{BOOT_STATUS_LABEL}</span>
+    </span>
+  );
+}

--- a/apps/web/src/features/session/boot-status-line.tsx
+++ b/apps/web/src/features/session/boot-status-line.tsx
@@ -1,13 +1,18 @@
 'use client';
 
+import { useReducedMotion } from 'motion/react';
+
+import { TextShimmer } from '@/components/ui/text-shimmer';
 import { cn } from '@/lib/utils';
 
 export const BOOT_STATUS_LABEL = 'Starting your computer…';
 
 /**
- * The ONE boot indicator: a single quiet line with a soft kortix-green pulse.
- * Replaces the old 4-step checklist theater everywhere the runtime is coming up
- * (thread, side panel, resume loader). Honors prefers-reduced-motion.
+ * The ONE boot indicator: a single quiet line with a soft kortix-green pulse and
+ * a slow shimmer sweeping the label. Replaces the old 4-step checklist theater
+ * everywhere the runtime is coming up (thread, side panel, resume loader).
+ * Honors prefers-reduced-motion: reduced-motion users get the steady label (no
+ * shimmer), and the pulse dot self-disables via `motion-reduce:animate-none`.
  */
 export function BootStatusLine({
   align = 'start',
@@ -16,6 +21,7 @@ export function BootStatusLine({
   align?: 'start' | 'center';
   className?: string;
 }) {
+  const reduceMotion = useReducedMotion();
   return (
     <span
       className={cn(
@@ -29,7 +35,13 @@ export function BootStatusLine({
         className="bg-kortix-green/70 h-1.5 w-1.5 shrink-0 animate-pulse rounded-full motion-reduce:animate-none"
         aria-hidden
       />
-      <span>{BOOT_STATUS_LABEL}</span>
+      {reduceMotion ? (
+        <span>{BOOT_STATUS_LABEL}</span>
+      ) : (
+        <TextShimmer className="text-[13px] tracking-tight" duration={1.5}>
+          {BOOT_STATUS_LABEL}
+        </TextShimmer>
+      )}
     </span>
   );
 }

--- a/apps/web/src/features/session/instant-session-shell.tsx
+++ b/apps/web/src/features/session/instant-session-shell.tsx
@@ -5,11 +5,11 @@ import { useCallback, useState } from 'react';
 import { createPortal } from 'react-dom';
 
 import { AssistantPendingRow } from '@/features/session/assistant-pending-row';
+import { BootStatusLine } from '@/features/session/boot-status-line';
 import { ComposerChatInput, type ComposerOptions } from '@/features/session/composer-chat-input';
 import { SessionSiteHeader } from '@/features/session/header/session-site-header';
 import type { AttachedFile } from '@/features/session/session-chat-input';
 import { SessionLayout } from '@/features/session/session-layout';
-import { SessionBootChecklistInline } from '@/features/session/session-starting-loader';
 import { useSessionWallpaperLayer } from '@/features/session/session-wallpaper-layer';
 import { SessionWelcome } from '@/features/session/session-welcome';
 import { optimisticUploadedFileRef } from '@/features/session/uploaded-file-refs';
@@ -35,9 +35,9 @@ import { GridFileCard } from './grid-file-card';
  * (keyed by the route session id; the session page migrates it onto the
  * OpenCode pin) so the real {@link SessionChat} auto-sends it the instant the
  * runtime is healthy — and the thread shows an inline "starting your computer"
- * status under the assistant logo until the real chat crossfades in. The boot
- * checklist also lives in the side panel, but only
- * if the user opens it (never auto-opened); once the runtime is ready the panel
+ * status under the assistant logo until the real chat crossfades in. The same
+ * calm boot status line also lives in the side panel, but only if the user
+ * opens it (never auto-opened); once the runtime is ready the panel
  * gracefully falls back to the real (empty) Actions view.
  */
 export function InstantSessionShell({
@@ -234,12 +234,12 @@ export function InstantSessionShell({
                     </div>
                   </div>
                   {/* While the computer is still coming up we show the SAME
-                      stepped boot checklist as the side panel, inline under the
+                      calm boot status line as the side panel, inline under the
                       logomark — so the progress is visible without opening the
                       panel. Once ready it falls back to the regular thinking text. */}
                   <AssistantPendingRow
                     className="mt-6"
-                    body={ready ? undefined : <SessionBootChecklistInline stage={stage} />}
+                    body={ready ? undefined : <BootStatusLine />}
                   />
                 </div>
               </div>
@@ -261,9 +261,9 @@ export function InstantSessionShell({
       projectId={projectId}
       projectSessionId={sessionId}
       transient
-      // Side-panel content: the boot checklist while still coming up, then the
-      // real (empty) Actions view once ready — so an open panel is never stuck on
-      // "Connecting". Visibility stays user-controlled (no auto-open).
+      // Side-panel content: the calm boot status line while still coming up,
+      // then the real (empty) Actions view once ready — so an open panel is
+      // never stuck on "Connecting". Visibility stays user-controlled (no auto-open).
       bootStage={ready ? null : stage}
     >
       {column}

--- a/apps/web/src/features/session/session-chat.tsx
+++ b/apps/web/src/features/session/session-chat.tsx
@@ -5252,7 +5252,7 @@ export function SessionChat({
   if (isDataLoading) {
     return (
       <div className="bg-background relative flex h-full flex-col" data-testid="session-chat">
-        <SessionStartingLoader stage="ready" />
+        <SessionStartingLoader />
       </div>
     );
   }

--- a/apps/web/src/features/session/session-layout.tsx
+++ b/apps/web/src/features/session/session-layout.tsx
@@ -340,19 +340,14 @@ export const SessionLayout = memo(function SessionLayout({
     </div>
   );
 
-  // While booting, the panel is JUST the dead-center "Kortix Computer is
-  // starting" loader — no header bar (the loader has its own heading, so a panel
-  // title would be redundant), filling the whole card so it's perfectly
-  // centered. The runtime-coupled views (Actions/Files/Terminal/Browser) need a
-  // live sandbox, so they only render once booted.
+  // While booting, the panel is JUST the dead-center resume loader — no header
+  // bar (the loader shows only the calm "Starting your computer…" status line,
+  // so a panel title would be redundant), filling the whole card so it's
+  // perfectly centered. The runtime-coupled views (Actions/Files/Terminal/
+  // Browser) need a live sandbox, so they only render once booted.
   const effectivePanelHeader = booting ? null : panelHeader;
   const effectivePanelBody = booting ? (
-    <SessionStartingLoader
-      stage={bootStage ?? 'provisioning'}
-      delayMs={0}
-      projectId={projectId}
-      sessionId={projectSessionId}
-    />
+    <SessionStartingLoader delayMs={0} projectId={projectId} sessionId={projectSessionId} />
   ) : (
     panelBody
   );

--- a/apps/web/src/features/session/session-start-gate.test.ts
+++ b/apps/web/src/features/session/session-start-gate.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from 'bun:test';
+import { shouldShowStartError } from './session-start-gate';
+
+test('hides a start error while the session is still fresh (boot noise)', () => {
+  expect(shouldShowStartError({ status: 404 }, true)).toBe(false);
+});
+
+test('shows a start error once the session is no longer fresh', () => {
+  expect(shouldShowStartError({ status: 404 }, false)).toBe(true);
+});
+
+test('no error → nothing to show', () => {
+  expect(shouldShowStartError(null, false)).toBe(false);
+  expect(shouldShowStartError(null, true)).toBe(false);
+});

--- a/apps/web/src/features/session/session-start-gate.ts
+++ b/apps/web/src/features/session/session-start-gate.ts
@@ -1,0 +1,13 @@
+/**
+ * Whether to render the terminal "Couldn't start session" card. While a session
+ * is FRESH (just minted client-side, create still settling) a /start error is the
+ * create-vs-start race — boot noise, not a failure — so the instant shell stays
+ * up. Once the fresh window has passed (see useSession's bounded grace), a real
+ * error surfaces normally.
+ */
+export function shouldShowStartError(
+  startError: { status?: number } | null,
+  isFresh: boolean,
+): boolean {
+  return !!startError && !isFresh;
+}

--- a/apps/web/src/features/session/session-starting-loader.tsx
+++ b/apps/web/src/features/session/session-starting-loader.tsx
@@ -4,7 +4,7 @@ import { Loader2, RotateCcw } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { restartProjectSession, sessionStartKey, type SessionStartStage } from '@kortix/sdk/projects-client';
+import { restartProjectSession, sessionStartKey } from '@kortix/sdk/projects-client';
 import { Button } from '@/components/ui/button';
 import { errorToast } from '@/components/ui/toast';
 import { cn } from '@/lib/utils';
@@ -41,7 +41,6 @@ function useBootClock(): number {
 }
 
 export function SessionStartingLoader({
-  stage = 'provisioning',
   /** Delay before the content fades in. The full-screen resume loader keeps the
    *  default so a warm open never flashes it; the side panel passes 0 because the
    *  user opened it deliberately and expects to see status immediately. */
@@ -52,7 +51,6 @@ export function SessionStartingLoader({
   projectId,
   sessionId,
 }: {
-  stage?: SessionStartStage;
   delayMs?: number;
   projectId?: string;
   sessionId?: string;
@@ -96,7 +94,7 @@ export function SessionStartingLoader({
     <div className="flex h-full min-h-0 w-full flex-1 items-center justify-center px-8">
       <div
         className={cn(
-          'flex flex-col items-center gap-5 transition-opacity duration-500',
+          'flex flex-col items-center gap-5 transition-opacity duration-500 ease-out',
           show ? 'opacity-100' : 'opacity-0',
         )}
       >

--- a/apps/web/src/features/session/session-starting-loader.tsx
+++ b/apps/web/src/features/session/session-starting-loader.tsx
@@ -1,32 +1,25 @@
 'use client';
 
-import { Check, Loader2, RotateCcw } from 'lucide-react';
-import { useTranslations } from 'next-intl';
+import { Loader2, RotateCcw } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { restartProjectSession, sessionStartKey, type SessionStartStage } from '@kortix/sdk/projects-client';
-import { formatDuration } from '@kortix/sdk/turns';
 import { Button } from '@/components/ui/button';
 import { errorToast } from '@/components/ui/toast';
 import { cn } from '@/lib/utils';
+import { BootStatusLine } from './boot-status-line';
 
 /**
  * The ONE loader shown while a session's Kortix Computer comes up — full-screen
  * for resumes, and dead-center in the side panel while a fresh session boots.
  * All the heavy lifting (provision / wake / OpenCode readiness + pin) is
- * server-side behind POST /sessions/:id/start; this just reports the real stage.
+ * server-side behind POST /sessions/:id/start; this just reports a calm status.
  *
- * Visual: super-minimal, perfectly centered. A single kortix-green pulse, the
- * heading, a clean stepped checklist (no connector rails), and one quiet hint.
+ * Visual: super-minimal, perfectly centered. A single calm boot status line
+ * (see {@link BootStatusLine}) and one quiet hint.
  */
 const LOADER_DELAY_MS = 700;
-/**
- * How long we sit in the backend `starting` stage before softly advancing from
- * "Preparing your workspace" to "Starting the agent". Both happen within that
- * one backend stage (clone → OpenCode boot), so the advance reflects real order.
- */
-const STARTING_SUBSTEP_MS = 5_000;
 /** After this long, swap the footer copy to set expectations for a cold start. */
 const SLOW_AFTER_MS = 15_000;
 /**
@@ -37,98 +30,14 @@ const SLOW_AFTER_MS = 15_000;
  */
 const STUCK_AFTER_MS = 45_000;
 
-interface Step {
-  label: string;
-  description: string;
-}
-
-const STEPS: Step[] = [
-  { label: 'Provisioning your computer', description: 'Allocating a secure sandbox' },
-  { label: 'Preparing your workspace', description: 'Cloning your project files' },
-  { label: 'Starting the agent', description: 'Booting the runtime and tools' },
-  { label: 'Connecting', description: 'Linking up your session' },
-];
-
-/**
- * Resolve which step is CURRENTLY active from the backend stage plus how long
- * we've been in it. The index is the floor we KNOW we're at — earlier steps are
- * genuinely complete, later ones haven't started.
- */
-function activeStep(stage: SessionStartStage, msInStage: number): number {
-  if (stage === 'provisioning') return 0;
-  if (stage === 'starting') return msInStage >= STARTING_SUBSTEP_MS ? 2 : 1;
-  return 3; // ready → the FE active-server switch + health poll ("connecting")
-}
-
-/**
- * The shared boot clock: a 1s tick that resolves the CURRENT active step from
- * the backend stage plus time-in-stage (so the `starting` soft-advance fires),
- * and exposes `now` for any caller-side elapsed/slow/stuck math. Both the side
- * panel loader and the inline thread checklist consume this, so the two always
- * report the same step.
- */
-function useBootProgress(stage: SessionStartStage): { active: number; now: number } {
+/** The shared boot clock: a 1s tick used for the `slow`/`stuck` footer math. */
+function useBootClock(): number {
   const [now, setNow] = useState(() => Date.now());
   useEffect(() => {
     const id = setInterval(() => setNow(Date.now()), 1_000);
     return () => clearInterval(id);
   }, []);
-
-  // Reset the per-stage clock whenever the backend stage changes, so the
-  // soft-advance measures time spent in the CURRENT stage (not since mount).
-  const stageEnteredAt = useRef(now);
-  const prevStage = useRef(stage);
-  if (prevStage.current !== stage) {
-    prevStage.current = stage;
-    stageEnteredAt.current = now;
-  }
-
-  return { active: activeStep(stage, now - stageEnteredAt.current), now };
-}
-
-/**
- * The stepped checklist itself — one render, shared by the centered panel loader
- * and the inline thread checklist so they can never visually drift. Pure: the
- * caller owns the clock (see {@link useBootProgress}) and passes the active index.
- */
-function BootStepList({ active }: { active: number }) {
-  return (
-    <ol className="flex flex-col gap-3.5" aria-live="polite">
-      {STEPS.map((step, i) => {
-        const done = i < active;
-        const current = i === active;
-        return (
-          <li
-            key={step.label}
-            className="flex items-center gap-2.5"
-            aria-current={current ? 'step' : undefined}
-          >
-            <span className="flex h-3.5 w-3.5 shrink-0 items-center justify-center">
-              {done ? (
-                <Check className="text-kortix-green h-3.5 w-3.5" strokeWidth={2.5} />
-              ) : current ? (
-                <Loader2 className="text-kortix-green h-3.5 w-3.5 animate-spin" />
-              ) : (
-                <span className="bg-muted-foreground/25 h-1 w-1 rounded-full" />
-              )}
-            </span>
-            <span
-              className={cn(
-                'text-[13px] leading-none tracking-tight transition-colors duration-500',
-                current
-                  ? 'text-foreground font-medium'
-                  : done
-                    ? 'text-muted-foreground'
-                    : 'text-muted-foreground/40',
-              )}
-            >
-              {step.label}
-            </span>
-          </li>
-        );
-      })}
-    </ol>
-  );
+  return now;
 }
 
 export function SessionStartingLoader({
@@ -148,7 +57,6 @@ export function SessionStartingLoader({
   projectId?: string;
   sessionId?: string;
 }) {
-  const tI18nHardcoded = useTranslations('hardcodedUi');
   const queryClient = useQueryClient();
   const [show, setShow] = useState(delayMs <= 0);
   useEffect(() => {
@@ -160,9 +68,9 @@ export function SessionStartingLoader({
     return () => clearTimeout(t);
   }, [delayMs]);
 
-  // The shared boot clock owns the 1s tick + per-stage soft-advance; `now` also
-  // drives the footer copy below (and the inline checklist reuses the same hook).
-  const { active, now } = useBootProgress(stage);
+  // The shared boot clock owns the 1s tick that drives the `slow`/`stuck`
+  // footer math below.
+  const now = useBootClock();
   // A manual restart pushes the "stuck" clock back out so the button doesn't
   // reappear immediately while the fresh boot is still in progress.
   const clockStart = useRef(now);
@@ -188,30 +96,14 @@ export function SessionStartingLoader({
     <div className="flex h-full min-h-0 w-full flex-1 items-center justify-center px-8">
       <div
         className={cn(
-          'flex flex-col items-center gap-9 transition-opacity duration-500',
+          'flex flex-col items-center gap-5 transition-opacity duration-500',
           show ? 'opacity-100' : 'opacity-0',
         )}
       >
-        {/* Brand heartbeat + heading, grouped. */}
-        <div className="flex flex-col items-center gap-4">
-          <span className="relative flex h-2.5 w-2.5" aria-hidden>
-            <span className="bg-kortix-green/40 absolute inline-flex h-full w-full animate-ping rounded-full" />
-            <span className="bg-kortix-green relative inline-flex h-2.5 w-2.5 rounded-full" />
-          </span>
-          <h2 className="text-foreground text-[13px] font-medium tracking-tight">
-            {tI18nHardcoded.raw(
-              'autoFeaturesSessionSessionStartingLoaderJsxTextKortixComputerIs7c42f59a',
-            )}
-          </h2>
-        </div>
-
-        {/* Auto-width so the checklist is a centered block under the heading. */}
-        <BootStepList active={active} />
-
+        <BootStatusLine align="center" />
         <p className="text-muted-foreground/40 text-center text-[11px] leading-relaxed">
           {slow ? 'A cold start can take a little longer.' : 'This usually takes a few seconds.'}
         </p>
-
         {stuck && canRestart ? (
           <Button
             type="button"
@@ -230,41 +122,6 @@ export function SessionStartingLoader({
           </Button>
         ) : null}
       </div>
-    </div>
-  );
-}
-
-/**
- * The boot checklist rendered INLINE in the thread (under the assistant
- * logomark) while a freshly-created session's Kortix Computer comes up — the
- * SAME stepped progress as the side panel's {@link SessionStartingLoader}, via
- * the shared {@link BootStepList} + {@link useBootProgress}, so a user who never
- * opens the computer panel still watches the real provisioning state advance
- * instead of one static "Provisioning…" line. Left-aligned to sit under the
- * Kortix logomark; carries its own elapsed timer to match the thread's regular
- * waiting indicator.
- */
-export function SessionBootChecklistInline({
-  stage = 'provisioning',
-  className,
-}: {
-  stage?: SessionStartStage;
-  className?: string;
-}) {
-  const { active, now } = useBootProgress(stage);
-  const startRef = useRef(now);
-  const elapsed = formatDuration(now - startRef.current);
-  return (
-    <div className={cn('flex flex-col items-start gap-2', className)}>
-      <div
-        className="bg-popover w-full rounded-2xl border px-4.5 py-4"
-        aria-label="Starting your Kortix Computer"
-      >
-        <BootStepList active={active} />
-      </div>
-      {elapsed ? (
-        <span className="text-muted-foreground/50 pl-1 text-xs tabular-nums">· {elapsed}</span>
-      ) : null}
     </div>
   );
 }

--- a/apps/web/translations/de.json
+++ b/apps/web/translations/de.json
@@ -8014,7 +8014,6 @@
     "autoFeaturesSessionHeaderSessionChangesIndicatorJsxTextVersionYet922de6bd": "Version. Schlage die Änderungen vor, damit sie geprüft und übernommen werden.",
     "autoFeaturesSessionHeaderSessionSiteHeaderJsxTextRename41731a53": "Umbenennen…",
     "autoFeaturesSessionHeaderSessionSiteHeaderJsxTextShared7d34d4f": "Teilen…",
-    "autoFeaturesSessionSessionStartingLoaderJsxTextKortixComputerIs7c42f59a": "Kortix Computer startet",
     "autoFeaturesSessionSessionTerminalPanelJsxTextNewTerminaleeb6bbb9": "Neues Terminal",
     "autoFeaturesSessionSessionVersionHeaderJsxAttrAriaLabelFiles9fd01463": "Dateiansicht",
     "autoFeaturesSessionSessionVersionHeaderJsxAttrLabelAllFiles4f423738": "Alle Dateien",

--- a/apps/web/translations/en.json
+++ b/apps/web/translations/en.json
@@ -8074,7 +8074,6 @@
     "autoFeaturesSessionHeaderSessionSiteHeaderJsxTextRename41731a53": "Rename…",
     "autoFeaturesSessionHeaderSessionSiteHeaderJsxTextShared7d34d4f": "Share…",
     "autoFeaturesSessionInstantSessionShellJsxAttrSessionTitleNewSession6b8dfd00": "New session",
-    "autoFeaturesSessionSessionStartingLoaderJsxTextKortixComputerIs7c42f59a": "Kortix Computer is starting",
     "autoFeaturesSessionSessionTerminalPanelJsxTextConnecting80303e70": "Connecting…",
     "autoFeaturesSessionSessionTerminalPanelJsxTextNewTerminaleeb6bbb9": "New terminal",
     "autoFeaturesSessionSessionVersionHeaderJsxAttrAriaLabelFiles9fd01463": "Files view",

--- a/apps/web/translations/es.json
+++ b/apps/web/translations/es.json
@@ -8014,7 +8014,6 @@
     "autoFeaturesSessionHeaderSessionChangesIndicatorJsxTextVersionYet922de6bd": "versión. Propón los cambios para que se revisen y apliquen.",
     "autoFeaturesSessionHeaderSessionSiteHeaderJsxTextRename41731a53": "Cambiar nombre…",
     "autoFeaturesSessionHeaderSessionSiteHeaderJsxTextShared7d34d4f": "Comparte…",
-    "autoFeaturesSessionSessionStartingLoaderJsxTextKortixComputerIs7c42f59a": "La computadora Kortix se está iniciando",
     "autoFeaturesSessionSessionTerminalPanelJsxTextNewTerminaleeb6bbb9": "Nueva terminal",
     "autoFeaturesSessionSessionVersionHeaderJsxAttrAriaLabelFiles9fd01463": "Vista de archivos",
     "autoFeaturesSessionSessionVersionHeaderJsxAttrLabelAllFiles4f423738": "Todos los archivos",

--- a/apps/web/translations/fr.json
+++ b/apps/web/translations/fr.json
@@ -8014,7 +8014,6 @@
     "autoFeaturesSessionHeaderSessionChangesIndicatorJsxTextVersionYet922de6bd": "version. Proposez les modifications pour qu’elles soient relues et appliquées.",
     "autoFeaturesSessionHeaderSessionSiteHeaderJsxTextRename41731a53": "Renommer…",
     "autoFeaturesSessionHeaderSessionSiteHeaderJsxTextShared7d34d4f": "Partager…",
-    "autoFeaturesSessionSessionStartingLoaderJsxTextKortixComputerIs7c42f59a": "L'ordinateur Kortix démarre",
     "autoFeaturesSessionSessionTerminalPanelJsxTextNewTerminaleeb6bbb9": "Nouvelle borne",
     "autoFeaturesSessionSessionVersionHeaderJsxAttrAriaLabelFiles9fd01463": "Vue Fichiers",
     "autoFeaturesSessionSessionVersionHeaderJsxAttrLabelAllFiles4f423738": "Tous les fichiers",

--- a/apps/web/translations/it.json
+++ b/apps/web/translations/it.json
@@ -8014,7 +8014,6 @@
     "autoFeaturesSessionHeaderSessionChangesIndicatorJsxTextVersionYet922de6bd": "versione. Proponi le modifiche per farle revisionare e applicare.",
     "autoFeaturesSessionHeaderSessionSiteHeaderJsxTextRename41731a53": "Rinomina…",
     "autoFeaturesSessionHeaderSessionSiteHeaderJsxTextShared7d34d4f": "Condividi…",
-    "autoFeaturesSessionSessionStartingLoaderJsxTextKortixComputerIs7c42f59a": "Il computer Kortix è in fase di avvio",
     "autoFeaturesSessionSessionTerminalPanelJsxTextNewTerminaleeb6bbb9": "Nuovo terminale",
     "autoFeaturesSessionSessionVersionHeaderJsxAttrAriaLabelFiles9fd01463": "Visualizzazione dei file",
     "autoFeaturesSessionSessionVersionHeaderJsxAttrLabelAllFiles4f423738": "Tutti i file",

--- a/apps/web/translations/ja.json
+++ b/apps/web/translations/ja.json
@@ -8014,7 +8014,6 @@
     "autoFeaturesSessionHeaderSessionChangesIndicatorJsxTextVersionYet922de6bd": "バージョン。変更を提案してレビューと適用を受けてください。",
     "autoFeaturesSessionHeaderSessionSiteHeaderJsxTextRename41731a53": "名前を変更…",
     "autoFeaturesSessionHeaderSessionSiteHeaderJsxTextShared7d34d4f": "シェア…",
-    "autoFeaturesSessionSessionStartingLoaderJsxTextKortixComputerIs7c42f59a": "Kortix コンピューターが起動しています",
     "autoFeaturesSessionSessionTerminalPanelJsxTextNewTerminaleeb6bbb9": "新しいターミナル",
     "autoFeaturesSessionSessionVersionHeaderJsxAttrAriaLabelFiles9fd01463": "ファイルビュー",
     "autoFeaturesSessionSessionVersionHeaderJsxAttrLabelAllFiles4f423738": "すべてのファイル",

--- a/apps/web/translations/pt.json
+++ b/apps/web/translations/pt.json
@@ -8014,7 +8014,6 @@
     "autoFeaturesSessionHeaderSessionChangesIndicatorJsxTextVersionYet922de6bd": "versão. Proponha as alterações para que sejam revisadas e aplicadas.",
     "autoFeaturesSessionHeaderSessionSiteHeaderJsxTextRename41731a53": "Renomear…",
     "autoFeaturesSessionHeaderSessionSiteHeaderJsxTextShared7d34d4f": "Compartilhe…",
-    "autoFeaturesSessionSessionStartingLoaderJsxTextKortixComputerIs7c42f59a": "O computador Kortix está iniciando",
     "autoFeaturesSessionSessionTerminalPanelJsxTextNewTerminaleeb6bbb9": "Novo terminal",
     "autoFeaturesSessionSessionVersionHeaderJsxAttrAriaLabelFiles9fd01463": "Visualização de arquivos",
     "autoFeaturesSessionSessionVersionHeaderJsxAttrLabelAllFiles4f423738": "Todos os arquivos",

--- a/apps/web/translations/zh.json
+++ b/apps/web/translations/zh.json
@@ -8014,7 +8014,6 @@
     "autoFeaturesSessionHeaderSessionChangesIndicatorJsxTextVersionYet922de6bd": "版本中。提议这些更改以供审核和应用。",
     "autoFeaturesSessionHeaderSessionSiteHeaderJsxTextRename41731a53": "重命名...",
     "autoFeaturesSessionHeaderSessionSiteHeaderJsxTextShared7d34d4f": "分享...",
-    "autoFeaturesSessionSessionStartingLoaderJsxTextKortixComputerIs7c42f59a": "Kortix 计算机正在启动",
     "autoFeaturesSessionSessionTerminalPanelJsxTextNewTerminaleeb6bbb9": "新航站楼",
     "autoFeaturesSessionSessionVersionHeaderJsxAttrAriaLabelFiles9fd01463": "文件视图",
     "autoFeaturesSessionSessionVersionHeaderJsxAttrLabelAllFiles4f423738": "所有文件",


### PR DESCRIPTION
## Summary

Fixes a race-condition symptom in the new-session flow: creating a fresh session could briefly surface a **"Couldn't start session"** error card — and, before it, a noisy boot-checklist animation — even though the session was provisioning normally. This PR keeps the instant session shell up through that transient window and replaces the busy loader with a single calm status line.

**Frontend only** — no SDK or API changes.

## What changed

- **Suppress premature start errors while a session is still "fresh."** A new pure gate, `shouldShowStartError(startError, isFresh)`, hides the terminal error card during the brief window right after a session is optimistically created — the create-vs-start timing gap is boot noise, not a failure. Once the fresh window passes, genuine errors surface exactly as before.
- **Replace the boot-checklist with one calm status line.** The multi-step checklist loader is removed in favor of a single `BootStatusLine`, cutting ~165 lines from the loader.
- **Calmer session-start motion, reduced-motion safe.** Softer transitions that honor `prefers-reduced-motion`, and removal of a vestigial `stage` prop that no longer served a purpose.
- **Subtle shimmer on the status line** while starting, also gated behind reduced-motion (plain static text when motion is reduced).

## Why

The "Couldn't start session" flash on a brand-new session was a false negative: the session was starting fine, but the UI rendered the error before the backend had answered. Keeping the shell up removes the false alarm, and the calmer loader removes the visual churn shown on every new session.

## Behavior

- New session → instant shell stays up with a calm status line; no error flash, no checklist animation.
- A genuine, non-transient start error still shows the "Couldn't start session" card once the session is no longer fresh.
- Reduced-motion users get static text with no shimmer or animation.

## Testing

- `session-start-gate.test.ts` — fresh vs. non-fresh error-gating logic.
- `boot-status-line.test.ts` — status-line rendering.
- `tsc --noEmit` clean; existing session suite green.

## Scope

Frontend only. The deeper server-side create-vs-start timing work (SDK polling grace and the API provisioning response) is intentionally **not** part of this PR and is being handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tae66HrhUksh7UQctbf1ie
