### PR TITLE
Promote main to staging: SDK create-vs-start race fix

### DIFF
--- a/packages/sdk/src/platform/projects-client/session-sandbox.test.ts
+++ b/packages/sdk/src/platform/projects-client/session-sandbox.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, expect, mock, test } from 'bun:test';
 import { configureKortix } from '../config';
+import { clearSessionFresh, markSessionFresh } from '../fresh-sessions';
 import { clearSessionRuntime, getSessionRuntime } from '../../state/session-runtime-registry';
 import { isSessionStartError, sessionStartKey, startProjectSession } from './session-sandbox';
 
@@ -27,6 +28,7 @@ beforeEach(() => {
 
 afterEach(() => {
   clearSessionRuntime(PROJECT, SESSION);
+  clearSessionFresh(SESSION);
 });
 
 configureKortix({ backendUrl: 'http://test.local/v1', getToken: async () => 'tok' });
@@ -96,6 +98,29 @@ test('startProjectSession throws a terminal SessionStartError for non-retryable 
   expect(isSessionStartError(caught)).toBe(true);
   expect((caught as Error & { status?: number; terminal?: boolean }).status).toBe(404);
   expect((caught as Error & { status?: number; terminal?: boolean }).terminal).toBe(true);
+});
+
+test('startProjectSession returns null on 404 for a fresh session (create-vs-start race) so the poll continues', async () => {
+  markSessionFresh(SESSION);
+  nextResponse = { status: 404, body: { error: 'Not found' } };
+
+  const result = await startProjectSession(PROJECT, SESSION);
+  expect(result).toBeNull();
+});
+
+test('startProjectSession still throws terminally on non-404 client errors for a fresh session', async () => {
+  markSessionFresh(SESSION);
+  nextResponse = { status: 403, body: { error: 'Forbidden' } };
+
+  let caught: unknown;
+  try {
+    await startProjectSession(PROJECT, SESSION);
+  } catch (error) {
+    caught = error;
+  }
+
+  expect(isSessionStartError(caught)).toBe(true);
+  expect((caught as Error & { status?: number }).status).toBe(403);
 });
 
 test('startProjectSession returns null for server failures so callers can retry', async () => {

--- a/packages/sdk/src/platform/projects-client/session-sandbox.ts
+++ b/packages/sdk/src/platform/projects-client/session-sandbox.ts
@@ -1,6 +1,7 @@
 // Session sandbox — runtime sandbox row + the session-open (/start) flow.
 
 import { backendApi } from '../api-client';
+import { isSessionFresh } from '../fresh-sessions';
 import { setSessionRuntime } from '../../state/session-runtime-registry';
 import { getSandboxUrlForExternalId } from '../../state/server-store/url-helpers';
 
@@ -111,7 +112,11 @@ export async function startProjectSession(
   );
   if (!response.success || !response.data) {
     const terminal = classifySessionStartFailure(response.error);
-    if (terminal) throw terminal;
+    // A 404 for a session minted in THIS tab is the optimistic create-vs-start
+    // race: `useNewProjectSession` fires this /start before its background
+    // create POST has landed, so the row doesn't exist yet. Yield null so the
+    // poll keeps going; a 404 for any other session stays terminal.
+    if (terminal && !(terminal.status === 404 && isSessionFresh(sessionId))) throw terminal;
     return null;
   }
   const result = response.data;


### PR DESCRIPTION
Fourth sync of main into staging for the 0.9.98 candidate. Clean merge, brings fix(sdk): tolerate /start 404 for freshly minted sessions (#4252).