### PR TITLE
fix(sessions): tolerate the create-vs-start race on fresh sessions

### DIFF
--- a/packages/sdk/src/react/use-session.test.ts
+++ b/packages/sdk/src/react/use-session.test.ts
@@ -42,7 +42,10 @@ import {
   classifySendError,
   sendStateOnStart,
   sendStateOnError,
+  shouldRetrySessionStart,
 } from './use-session';
+import { clearSessionFresh, markSessionFresh } from '../platform/fresh-sessions';
+import { SessionStartError } from '../platform/projects-client';
 
 function seedQuestion(id: string, sessionID = 'sess-1') {
   useOpenCodePendingStore.getState().addQuestion({
@@ -205,5 +208,41 @@ describe('send state transitions (sendStateOnStart / sendStateOnError)', () => {
     const restarted = sendStateOnStart('a new message');
     expect(restarted.sendError).toBeNull();
     expect(restarted.pending).toBe('a new message');
+  });
+});
+
+describe('shouldRetrySessionStart', () => {
+  const startError = (status: number) => new SessionStartError('nope', { status, terminal: true });
+
+  test('retries a 404 for a fresh session within the grace window, then gives up', () => {
+    markSessionFresh('fresh');
+    try {
+      expect(shouldRetrySessionStart(0, startError(404), 'fresh')).toBe(true);
+      expect(shouldRetrySessionStart(11, startError(404), 'fresh')).toBe(true);
+      expect(shouldRetrySessionStart(12, startError(404), 'fresh')).toBe(false);
+    } finally {
+      clearSessionFresh('fresh');
+    }
+  });
+
+  test('does NOT retry a 404 for a non-fresh session (genuinely missing / no access)', () => {
+    expect(shouldRetrySessionStart(0, startError(404), 'stale')).toBe(false);
+  });
+
+  test('does not retry other terminal start errors even when fresh', () => {
+    markSessionFresh('fresh');
+    try {
+      expect(shouldRetrySessionStart(0, startError(403), 'fresh')).toBe(false);
+      expect(shouldRetrySessionStart(0, startError(402), 'fresh')).toBe(false);
+    } finally {
+      clearSessionFresh('fresh');
+    }
+  });
+
+  test('retries a few times on transient (non-start) errors', () => {
+    const transient = new Error('network blip');
+    expect(shouldRetrySessionStart(0, transient, 'x')).toBe(true);
+    expect(shouldRetrySessionStart(2, transient, 'x')).toBe(true);
+    expect(shouldRetrySessionStart(3, transient, 'x')).toBe(false);
   });
 });

--- a/packages/sdk/src/react/use-session.ts
+++ b/packages/sdk/src/react/use-session.ts
@@ -36,6 +36,7 @@ import {
   sessionStartKey,
   startProjectSession,
 } from '../platform/projects-client';
+import { isSessionFresh } from '../platform/fresh-sessions';
 import { BillingError, parseBillingError } from '../platform/api/errors';
 import { formatOpenCodeRuntimeError } from '../platform/opencode-errors';
 import { useCanonicalOpenCodeSession } from './use-canonical-opencode-session';
@@ -60,6 +61,30 @@ import {
 
 /** Coarse session lifecycle for the host's top-level gating. */
 export type SessionPhase = 'starting' | 'ready' | 'error';
+
+// Grace window for the optimistic create-vs-start race: how long /start keeps
+// retrying a 404 for a freshly-minted session before treating it as terminal.
+// ~12 × 800ms ≈ 9.6s, comfortably past the sub-second create POST.
+const FRESH_START_404_RETRIES = 12;
+const FRESH_START_404_RETRY_DELAY_MS = 800;
+
+/**
+ * Whether the `/start` poll should retry. A 404 on a freshly-minted session is
+ * the optimistic create-vs-start race (the create POST hasn't landed yet), so
+ * retry it for the grace window; a 404 on any other (non-fresh) session is a
+ * genuinely-missing/no-access session and is terminal at once. Other terminal
+ * SessionStartErrors never retry; transient transport failures retry a few times.
+ */
+export function shouldRetrySessionStart(
+  failureCount: number,
+  error: unknown,
+  sessionId: string,
+): boolean {
+  if (isSessionStartError(error) && error.status === 404 && isSessionFresh(sessionId)) {
+    return failureCount < FRESH_START_404_RETRIES;
+  }
+  return !isSessionStartError(error) && failureCount < 3;
+}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Send-error classification. `send`/the reply actions below never throw for
@@ -253,7 +278,11 @@ export function useSession(
     queryKey: sessionStartKey(projectId, sessionId),
     queryFn: () => startProjectSession(projectId, sessionId, waitMs),
     enabled: enabled && !!projectId && !!sessionId,
-    retry: (failureCount, error) => !isSessionStartError(error) && failureCount < 3,
+    retry: (failureCount, error) => shouldRetrySessionStart(failureCount, error, sessionId),
+    retryDelay: (failureCount, error) =>
+      isSessionStartError(error) && error.status === 404
+        ? FRESH_START_404_RETRY_DELAY_MS
+        : Math.min(1000 * 2 ** failureCount, 5000),
     refetchInterval: (q) => {
       if (isSessionStartError(q.state.error)) return false;
       const stage = (q.state.data as SessionStartResult | null | undefined)?.stage;


### PR DESCRIPTION
## Problem (P0)
Brand-new sessions intermittently show **"Couldn't start session — This session is no longer available, or you do not have access to it."** right after opening.

## Root cause — create-vs-start race
`useNewProjectSession` is optimistic: it mints a client-side session UUID, **navigates immediately**, then persists via `createProjectSession` in the background. The session page fires `POST /sessions/:id/start` right away — but for the sub-second window before the create lands, the row doesn't exist yet, so `/start` returns **404**.

The FE then treated that transient 404 as terminal:
- `classifySessionStartFailure` marks any 4xx (incl. 404) as `terminal` → a `SessionStartError`.
- `use-session.ts` retry was `!isSessionStartError(error) && failureCount < 3` → a 404 was **never retried**.
- → the race-404 surfaced instantly as the "no longer available" screen on fresh sessions.

(The `useNewProjectSession` comment even claims `/start` "tolerates the race by retrying" — but the retry excluded exactly this error.)

## Fix
For a **fresh** session (`isSessionFresh` — set at optimistic create, cleared only when the chat is ready), a 404 is retried for a grace window (~12 × 800ms ≈ 9.6s) while the create lands. A **non-fresh** session (genuinely deleted / no access) still 404s **terminally at once**, so real errors aren't masked. During retries no error is shown — the page stays on its "starting" shell.

- `packages/sdk/src/react/use-session.ts` — retry delegates to the extracted pure `shouldRetrySessionStart()`, plus a short 800ms `retryDelay` for race-404s.
- `use-session.test.ts` — regression tests: fresh-404 retries then gives up; non-fresh-404 terminal; other 4xx terminal; transient errors retry.

## Testing
- `use-session` suite green (16), SDK typecheck clean.