### PR TITLE
fix(web): create-first new-session flow — no silent bounce back to the project index

### DIFF
--- a/apps/web/src/app/(app)/projects/[id]/page.tsx
+++ b/apps/web/src/app/(app)/projects/[id]/page.tsx
@@ -17,7 +17,7 @@ import { usePendingFilesStore } from '@/stores/pending-files-store';
 import { useUpgradeDialogStore } from '@/stores/upgrade-dialog-store';
 import { useQuery } from '@tanstack/react-query';
 import { useParams } from 'next/navigation';
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 const FREE_ONBOARDING_UPGRADE_MODAL_KEY = 'kortix:free-onboarding-upgrade-modal-shown';
 
@@ -35,6 +35,9 @@ export default function ProjectIndexPage() {
   const openUpgradeDialog = useUpgradeDialogStore((s) => s.openUpgradeDialog);
 
   const newSession = useNewProjectSession(projectId);
+  // Composer sending state: spans Enter → create confirmed → navigation. Reset
+  // only on create failure (success navigates this page away).
+  const [sending, setSending] = useState(false);
 
   useEffect(() => {
     if (!isBillingEnabled() || !accountState || !projectAccountId) return;
@@ -70,16 +73,21 @@ export default function ProjectIndexPage() {
         return;
       }
 
-      // Identical optimistic path to every other new-session entry point: mint the
-      // id, paint the instant shell, and let the session page auto-send `text` once
-      // the box is ready. No server-side initial_prompt — the shell shows the
+      // Identical create-first path to every other new-session entry point: the
+      // composer shows a sending spinner for the create RTT (~one round trip),
+      // then navigates into the instant shell, which auto-sends `text` once the
+      // box is ready. No server-side initial_prompt — the shell shows the
       // message + inline boot status, matching the global dashboard composer.
       // Bind the chosen agent at session birth so it matches the `agent` the
       // composer sends on the first prompt — sessions are agent-immutable and the
       // API proxy 409s any prompt whose agent differs from the bound one, which
       // defaults to "default" when unset (see buildNewSessionCreateInput).
+      setSending(true);
       newSession({
         create: buildNewSessionCreateInput(options),
+        // Create failed (already surfaced by the hook) — we never left this
+        // page, so just unlock the composer with the text still in it.
+        onError: () => setSending(false),
         onNavigate: (sessionId) => {
           // `sessionId` here is the route/Kortix session id, not the OpenCode
           // pin the session page resolves later (`useCanonicalOpenCodeSession`
@@ -105,7 +113,7 @@ export default function ProjectIndexPage() {
 
   return (
     <ProjectShell projectId={projectId}>
-      <ProjectHome projectId={projectId} onSend={handleSend} busy={false} />
+      <ProjectHome projectId={projectId} onSend={handleSend} busy={sending} />
     </ProjectShell>
   );
 }

--- a/apps/web/src/features/session/composer-chat-input.tsx
+++ b/apps/web/src/features/session/composer-chat-input.tsx
@@ -34,6 +34,7 @@ export function ComposerChatInput({
   projectId,
   isBusy,
   stopDisabled,
+  isSending,
   disabled,
   autoFocus,
   placeholder,
@@ -51,6 +52,8 @@ export function ComposerChatInput({
   isBusy?: boolean;
   /** Show a disabled stop button while busy (e.g. the computer is still booting). */
   stopDisabled?: boolean;
+  /** Send in flight, not yet settled — spinner in the send slot (see SessionChatInput.isSending). */
+  isSending?: boolean;
   disabled?: boolean;
   /** Clear the composer optimistically on send. Set false on the project-home
    *  composer, whose send navigates it away (see SessionChatInput.clearOnSend). */
@@ -92,6 +95,7 @@ export function ComposerChatInput({
       clearOnSend={clearOnSend}
       isBusy={isBusy}
       stopDisabled={stopDisabled}
+      isSending={isSending}
       disabled={disabled}
       autoFocus={autoFocus}
       placeholder={placeholder}

--- a/apps/web/src/features/session/session-chat-input.tsx
+++ b/apps/web/src/features/session/session-chat-input.tsx
@@ -1105,6 +1105,13 @@ export interface SessionChatInputProps {
    * busy input shows a (non-clickable) stop button instead of nothing at all.
    */
   stopDisabled?: boolean;
+  /**
+   * The send is in flight but hasn't navigated/settled yet — swap the send
+   * button for a spinner (used by the project-home composer while the session
+   * create POST round-trips). Distinct from `isBusy`, which means "the agent is
+   * running" and shows a stop button instead.
+   */
+  isSending?: boolean;
   agents?: Agent[];
   selectedAgent?: string | null;
   onAgentChange?: (agentName: string | null | undefined) => void;
@@ -1217,6 +1224,7 @@ export function SessionChatInput({
   isBusy = false,
   onStop,
   stopDisabled = false,
+  isSending = false,
   agents = [],
   selectedAgent = null,
   onAgentChange,
@@ -2305,7 +2313,12 @@ export function SessionChatInput({
                 disabled={submitDisabled || isBusy}
               />
 
-              {isBusy && (onStop || stopDisabled) && !lockForQuestion && (
+              {isSending && !lockForQuestion && (
+                <Button size="sm" disabled className="h-8 w-8 flex-shrink-0 rounded-full p-0">
+                  <Loader2 className="size-4 animate-spin" />
+                </Button>
+              )}
+              {!isSending && isBusy && (onStop || stopDisabled) && !lockForQuestion && (
                 <div className="relative flex items-center">
                   {/* ESC hint — matches Kortix tooltip styling (bg-primary rounded-2xl) */}
                   {escCount > 0 && (
@@ -2345,7 +2358,7 @@ export function SessionChatInput({
                   </Tooltip>
                 </div>
               )}
-              {(!isBusy || lockForQuestion) && (
+              {!isSending && (!isBusy || lockForQuestion) && (
                 <div className="opacity-100">
                   {lockForQuestion && questionButtonLabel && !text.trim() ? (
                     <Button

--- a/apps/web/src/features/workspace/project-layout/project-home.tsx
+++ b/apps/web/src/features/workspace/project-layout/project-home.tsx
@@ -154,7 +154,10 @@ export function ProjectHome({
             onSend={handleSend}
             onCommand={handleCommand}
             projectId={projectId}
-            isBusy={busy}
+            // `busy` here means "create in flight" — spinner in the send slot,
+            // input locked. NOT isBusy (that renders agent-running stop-button
+            // semantics, which leave the composer with no button at all here).
+            isSending={busy}
             disabled={busy}
             // The home composer navigates to the new session on send — don't clear
             // it first (that only flashes an empty box before the route swaps, and

--- a/apps/web/src/hooks/projects/new-session-failure.test.ts
+++ b/apps/web/src/hooks/projects/new-session-failure.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from 'bun:test';
+
+import { resolveCreateFailure } from './new-session-failure';
+
+describe('resolveCreateFailure', () => {
+  test('billing rejections open the upgrade dialog and stay on the page', () => {
+    expect(resolveCreateFailure('subscription_required')).toBe('upgrade');
+    expect(resolveCreateFailure('no_account')).toBe('upgrade');
+  });
+
+  test('the concurrent-session cap stays silent (global 429 handler owns it)', () => {
+    expect(resolveCreateFailure('concurrent_session_limit')).toBe('silent');
+  });
+
+  test('everything else — including codeless network failures — surfaces a toast, never a redirect', () => {
+    expect(resolveCreateFailure(undefined)).toBe('toast');
+    expect(resolveCreateFailure('TIMEOUT')).toBe('toast');
+    expect(resolveCreateFailure('internal_error')).toBe('toast');
+  });
+});

--- a/apps/web/src/hooks/projects/new-session-failure.ts
+++ b/apps/web/src/hooks/projects/new-session-failure.ts
@@ -1,0 +1,19 @@
+/**
+ * How a failed session create resolves, keyed by the server's error code.
+ *
+ * - `upgrade`  → open the Team-plan dialog (billing said no); stay put.
+ * - `silent`   → the global 429 handler already surfaced it; stay put.
+ * - `toast`    → terminal failure the user must see; stay put.
+ *
+ * Every branch stays on the current page: `useNewProjectSession` only navigates
+ * AFTER a successful create, so there is no optimistic route to unwind. (The
+ * old navigate-first flow bounced `router.replace` back to the index on ANY
+ * rejection — including client-side timeouts where the server had actually
+ * committed the row, which read as "the session appeared in the sidebar but I
+ * never left the index page".)
+ */
+export function resolveCreateFailure(code: string | undefined): 'upgrade' | 'silent' | 'toast' {
+  if (code === 'subscription_required' || code === 'no_account') return 'upgrade';
+  if (code === 'concurrent_session_limit') return 'silent';
+  return 'toast';
+}

--- a/apps/web/src/hooks/projects/use-new-project-session.ts
+++ b/apps/web/src/hooks/projects/use-new-project-session.ts
@@ -4,6 +4,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import { useCallback, useRef } from 'react';
 
+import { resolveCreateFailure } from '@/hooks/projects/new-session-failure';
 import { useProjectCanRun } from '@/hooks/projects/use-project-can-run';
 import { isBillingEnabled } from '@/lib/config';
 import { toast } from '@/lib/toast';
@@ -13,21 +14,27 @@ import { createProjectSession } from '@kortix/sdk/projects-client';
 import { prefetchSessionStart } from '@kortix/sdk/react';
 
 /**
- * The fastest possible "new empty session" path, shared by every entry point
- * (project shell button, ⌘T/⌘J shortcuts, project sidebar, command palette).
+ * The ONE "new empty session" path, shared by every entry point (project shell
+ * button, ⌘T/⌘J shortcuts, project sidebar, command palette, home composer).
  *
- * OPTIMISTIC: mint the session id client-side and navigate IMMEDIATELY — the
- * instant shell paints before the create POST even returns. The backend honors a
- * client-provided UUID (`session_id` is client-authoritative), and the session page's `/start` poll tolerates the sub-second
- * create-vs-start race by retrying. Provisioning + the route bundle are warmed
- * during the navigation; the session is persisted in the background.
+ * CREATE-FIRST: mint the session id client-side, persist it, and navigate the
+ * moment the server confirms (create is a ~15ms insert, so this is still
+ * instant). The route bundle prefetch overlaps the create RTT, and `/start`
+ * is prefetched the moment the row exists — so provisioning still begins
+ * during the navigation, without ever racing the create POST.
  *
- * `onNavigate(sessionId)` runs synchronously right before the push — use it for
- * entry-point-specific side effects (open a tab, close a drawer, timing marks,
- * stashing a pending prompt so the shell auto-sends it once the box is ready).
+ * `onNavigate(sessionId)` runs synchronously right before the push — use it
+ * for entry-point-specific side effects (open a tab, close a drawer, timing
+ * marks, stashing a pending prompt so the shell auto-sends it once the box is
+ * ready).
  *
- * `create` carries create-time overrides (e.g. a chosen `sandbox_slug`) straight
- * to the persist POST without changing the optimistic timing.
+ * `onError()` fires when the create fails (after the failure is surfaced per
+ * `resolveCreateFailure`) — use it to reset an entry point's pending UI
+ * (e.g. the home composer's sending spinner). No navigation has happened at
+ * that point, so the user simply stays where they were.
+ *
+ * `create` carries create-time overrides (e.g. a chosen `sandbox_slug`)
+ * straight to the persist POST.
  */
 export function useNewProjectSession(projectId: string | undefined) {
   const router = useRouter();
@@ -39,18 +46,26 @@ export function useNewProjectSession(projectId: string | undefined) {
   return useCallback(
     (opts?: {
       onNavigate?: (sessionId: string) => void;
+      onError?: () => void;
       // `agent_name` binds the session's immutable boot agent at birth. It MUST
       // match the agent the composer sends on the first prompt — the API proxy
       // rejects any prompt whose `agent` differs from the session's bound agent
       // with 409 AGENT_SWITCH_REQUIRES_NEW_SESSION (sessions are agent-immutable).
       create?: { sandbox_slug?: string; agent_name?: string };
     }) => {
-      if (!projectId || creatingRef.current) return;
+      if (!projectId || creatingRef.current) {
+        opts?.onError?.();
+        return;
+      }
 
-      if (isBillingEnabled() && billingLoading) return;
+      if (isBillingEnabled() && billingLoading) {
+        opts?.onError?.();
+        return;
+      }
 
       if (isBillingEnabled() && !canRun) {
         openUpgradeDialog({ reason: 'subscription_required', accountId });
+        opts?.onError?.();
         return;
       }
 
@@ -60,30 +75,27 @@ export function useNewProjectSession(projectId: string | undefined) {
       // context this app runs (secure context: https + localhost).
       const sessionId = crypto.randomUUID();
       markSessionFresh(sessionId); // → instant shell, not the resume loader
-      prefetchSessionStart(queryClient, projectId, sessionId);
+      // Warm the route bundle while the create POST is in flight.
       router.prefetch(`/projects/${projectId}/sessions/${sessionId}`);
-      opts?.onNavigate?.(sessionId);
-      router.push(`/projects/${projectId}/sessions/${sessionId}`);
 
-      // Persist in the background — the page is already rendering the shell.
       createProjectSession(projectId, { session_id: sessionId, ...opts?.create })
         .then(() => {
+          // The row exists — kick provisioning so it overlaps the navigation.
+          prefetchSessionStart(queryClient, projectId, sessionId);
           queryClient.invalidateQueries({ queryKey: ['project-sessions', projectId] });
+          opts?.onNavigate?.(sessionId);
+          router.push(`/projects/${projectId}/sessions/${sessionId}`);
         })
         .catch((err) => {
           const code = (err as { code?: string })?.code;
-          // No-plan 402 → the session page itself shows the gated screen +
-          // upgrade modal (its billing gate knows this project's account), so
-          // stay put and let it handle the pitch.
-          if (code === 'subscription_required' || code === 'no_account') return;
-          // Any other terminal failure (concurrent-session limit, out-of-credits,
-          // validation, server error) means the session will never exist — we've
-          // already navigated optimistically, so bounce back off the dead shell.
-          // The 429 cap is surfaced by the global handler; others get a toast.
-          if (code !== 'concurrent_session_limit') {
+          const action = resolveCreateFailure(code);
+          if (action === 'upgrade') {
+            openUpgradeDialog({ reason: 'subscription_required', accountId });
+          } else if (action === 'toast') {
             toast.error(err instanceof Error ? err.message : 'Failed to start session');
           }
-          router.replace(`/projects/${projectId}`);
+          // 'silent': the global 429 handler already surfaced the session cap.
+          opts?.onError?.();
         })
         .finally(() => {
           creatingRef.current = false;


### PR DESCRIPTION
## Problem (reported on dev)

Hitting Enter on the project-home composer: the session appears in the left sidebar, but the page stays on the index — no redirect. No toast, no feedback; the typed text just sits there.

## Root cause

`useNewProjectSession` navigated optimistically (`router.push` before the create POST), then its `.catch` fired `router.replace` back to `/projects/[id]` on **any** rejection — including client-side timeouts/aborts/5xx where the server had actually committed the row. The sidebar's 5s live-session poll (and SSE `session.created` refetch) then surfaces the row anyway → "session created, but I never left the index page". #4241's `clearOnSend=false` removed the last visible signal, making the bounce read as a dead Enter.

## Fix — create first, then redirect (what was asked for)

- `useNewProjectSession` now awaits the create (a ~15ms insert; route bundle prefetch overlaps the RTT) and navigates the moment the server confirms. `/start` is prefetched right after the row exists, so provisioning still overlaps the navigation — and the create-vs-start 404 race is structurally gone for this flow.
- Failures **stay put** — there is no optimistic route to unwind. Resolution per new pure helper `resolveCreateFailure`: billing codes → upgrade dialog, `concurrent_session_limit` → silent (global 429 handler owns it), everything else → error toast. New `onError` callback lets entry points reset their pending UI.
- Home composer gets a real loading state: new `isSending` prop on `SessionChatInput` (spinner in the send slot, distinct from the agent-running `isBusy` stop button; previously `busy` left the composer with no button at all), forwarded via `ComposerChatInput`; the index page tracks sending state and passes `busy` into `ProjectHome`.

All 6 entry points (home composer, shell button, ⌘T/⌘J, sidebar, command palette, configure/upgrade threads) share the same create-first behavior.

## Tests

- `new-session-failure.test.ts`: upgrade/silent/toast mapping, incl. codeless network failures never redirecting.
- `bun test src/features/session src/hooks`: 119 pass. Web `tsc --noEmit` clean.