### PR TITLE
Promote main to staging: session-start race fixes + create-first flow + folder tiles

### DIFF
--- a/apps/web/src/app/(app)/projects/[id]/page.tsx
+++ b/apps/web/src/app/(app)/projects/[id]/page.tsx
@@ -17,7 +17,7 @@ import { usePendingFilesStore } from '@/stores/pending-files-store';
 import { useUpgradeDialogStore } from '@/stores/upgrade-dialog-store';
 import { useQuery } from '@tanstack/react-query';
 import { useParams } from 'next/navigation';
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 const FREE_ONBOARDING_UPGRADE_MODAL_KEY = 'kortix:free-onboarding-upgrade-modal-shown';
 
@@ -35,6 +35,9 @@ export default function ProjectIndexPage() {
   const openUpgradeDialog = useUpgradeDialogStore((s) => s.openUpgradeDialog);
 
   const newSession = useNewProjectSession(projectId);
+  // Composer sending state: spans Enter → create confirmed → navigation. Reset
+  // only on create failure (success navigates this page away).
+  const [sending, setSending] = useState(false);
 
   useEffect(() => {
     if (!isBillingEnabled() || !accountState || !projectAccountId) return;
@@ -70,16 +73,21 @@ export default function ProjectIndexPage() {
         return;
       }
 
-      // Identical optimistic path to every other new-session entry point: mint the
-      // id, paint the instant shell, and let the session page auto-send `text` once
-      // the box is ready. No server-side initial_prompt — the shell shows the
+      // Identical create-first path to every other new-session entry point: the
+      // composer shows a sending spinner for the create RTT (~one round trip),
+      // then navigates into the instant shell, which auto-sends `text` once the
+      // box is ready. No server-side initial_prompt — the shell shows the
       // message + inline boot status, matching the global dashboard composer.
       // Bind the chosen agent at session birth so it matches the `agent` the
       // composer sends on the first prompt — sessions are agent-immutable and the
       // API proxy 409s any prompt whose agent differs from the bound one, which
       // defaults to "default" when unset (see buildNewSessionCreateInput).
+      setSending(true);
       newSession({
         create: buildNewSessionCreateInput(options),
+        // Create failed (already surfaced by the hook) — we never left this
+        // page, so just unlock the composer with the text still in it.
+        onError: () => setSending(false),
         onNavigate: (sessionId) => {
           // `sessionId` here is the route/Kortix session id, not the OpenCode
           // pin the session page resolves later (`useCanonicalOpenCodeSession`
@@ -105,7 +113,7 @@ export default function ProjectIndexPage() {
 
   return (
     <ProjectShell projectId={projectId}>
-      <ProjectHome projectId={projectId} onSend={handleSend} busy={false} />
+      <ProjectHome projectId={projectId} onSend={handleSend} busy={sending} />
     </ProjectShell>
   );
 }

--- a/apps/web/src/app/(app)/projects/[id]/sessions/[sessionId]/page.tsx
+++ b/apps/web/src/app/(app)/projects/[id]/sessions/[sessionId]/page.tsx
@@ -4,6 +4,7 @@ import { useTranslations } from 'next-intl';
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Loader2, RotateCcw } from 'lucide-react';
+import { useReducedMotion } from 'motion/react';
 import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import { type ReactNode, useEffect, useRef, useState } from 'react';
 
@@ -13,6 +14,7 @@ import { InstantSessionShell } from '@/features/session/instant-session-shell';
 import { SandboxLoadingBoundary } from '@/features/session/sandbox-loading-boundary';
 import { SessionChat } from '@/features/session/session-chat';
 import { SessionLayout } from '@/features/session/session-layout';
+import { shouldShowStartError } from '@/features/session/session-start-gate';
 import { SessionStartingLoader } from '@/features/session/session-starting-loader';
 import { ProjectShell } from '@/features/workspace/project-layout/project-shell';
 import { useAccountState } from '@/hooks/billing';
@@ -115,6 +117,7 @@ export default function ProjectSessionPage() {
   // ── Crossfade: the instant shell fades out as the real chat fades in ──────
   // A fully-interactive shell (welcome wallpaper + live input) renders at a SINGLE
   // stable tree position for the whole pre-ready lifecycle, so it never remounts.
+  const prefersReducedMotion = useReducedMotion() ?? false;
   const [chatReady, setChatReady] = useState(false);
   const [loaderMounted, setLoaderMounted] = useState(true);
   const [shellSubmitted, setShellSubmitted] = useState(false);
@@ -143,6 +146,12 @@ export default function ProjectSessionPage() {
   useEffect(() => {
     if (chatReady) clearSessionFresh(sessionId);
   }, [chatReady, sessionId]);
+  // Reduced motion cuts instead of crossfading (motion-reduce:transition-none),
+  // so the loader layer's opacity change fires no transitionend — unmount it
+  // here instead of waiting for the handler below.
+  useEffect(() => {
+    if (chatReady && prefersReducedMotion) setLoaderMounted(false);
+  }, [chatReady, prefersReducedMotion]);
 
   // Terminal/gated states fully REPLACE the content (no chat to fade to).
   const gated = !authLoading && !!user && noPlan;
@@ -183,15 +192,15 @@ export default function ProjectSessionPage() {
       );
     }
 
-    if (session.startError) {
-      const sessionMissing = session.startError.status === 404;
+    if (shouldShowStartError(session.startError, isFresh)) {
+      const sessionMissing = session.startError!.status === 404;
       return (
         <InlineSessionError
           title="Couldn't start session"
           message={
             sessionMissing
               ? 'This session is no longer available, or you do not have access to it.'
-              : session.startError.message
+              : session.startError!.message
           }
         />
       );
@@ -225,7 +234,7 @@ export default function ProjectSessionPage() {
         {canMountChat && (
           <div
             className={cn(
-              'absolute inset-0 flex min-h-0 flex-1 flex-col overflow-hidden transition-opacity duration-300 ease-out',
+              'absolute inset-0 flex min-h-0 flex-1 flex-col overflow-hidden transition-opacity duration-300 ease-out motion-reduce:transition-none',
               chatReady ? 'opacity-100' : 'pointer-events-none opacity-0',
             )}
           >
@@ -248,7 +257,7 @@ export default function ProjectSessionPage() {
               if (chatReady) setLoaderMounted(false);
             }}
             className={cn(
-              'absolute inset-0 flex flex-col transition-opacity duration-300 ease-out',
+              'absolute inset-0 flex flex-col transition-opacity duration-300 ease-out motion-reduce:transition-none',
               chatReady ? 'pointer-events-none opacity-0' : 'opacity-100',
             )}
           >
@@ -260,11 +269,7 @@ export default function ProjectSessionPage() {
                 onSubmit={() => setShellSubmitted(true)}
               />
             ) : (
-              <SessionStartingLoader
-                stage={authLoading || !user ? 'provisioning' : startStage}
-                projectId={projectId}
-                sessionId={sessionId}
-              />
+              <SessionStartingLoader projectId={projectId} sessionId={sessionId} />
             )}
           </div>
         )}

--- a/apps/web/src/features/project-files/components/drive-folder-icon.tsx
+++ b/apps/web/src/features/project-files/components/drive-folder-icon.tsx
@@ -1,0 +1,36 @@
+import { chalkColors } from '@kortix/shared';
+
+interface DriveFolderIconProps {
+  /** Folder name — drives a stable per-folder color via chalkColors. */
+  label: string;
+  className?: string;
+}
+
+/**
+ * Google-Drive-style filled folder glyph. Two-tone: a darker back panel + tab
+ * and a lighter front pocket, tinted to a stable color derived from the folder
+ * name so each folder keeps the same hue across sessions.
+ */
+export function DriveFolderIcon({ label, className }: DriveFolderIconProps) {
+  const chalk = chalkColors(label);
+  const front = chalk.border;
+  const back = `color-mix(in srgb, ${chalk.border}, #000 16%)`;
+
+  return (
+    <svg
+      viewBox="0 0 48 40"
+      fill="none"
+      className={className}
+      aria-hidden="true"
+      focusable="false"
+    >
+      {/* Back panel + tab */}
+      <path
+        d="M4 12a4 4 0 0 1 4-4h9.5a3 3 0 0 1 2.4 1.2l1.8 2.4a3 3 0 0 0 2.4 1.2H40a4 4 0 0 1 4 4V32a4 4 0 0 1-4 4H8a4 4 0 0 1-4-4V12Z"
+        fill={back}
+      />
+      {/* Front pocket */}
+      <path d="M4 16h40v16a4 4 0 0 1-4 4H8a4 4 0 0 1-4-4V16Z" fill={front} />
+    </svg>
+  );
+}

--- a/apps/web/src/features/project-files/components/drive-grid-view.tsx
+++ b/apps/web/src/features/project-files/components/drive-grid-view.tsx
@@ -23,8 +23,6 @@ import {
   ClipboardCopy,
   Copy,
   Download,
-  Folder,
-  FolderCog,
   History,
   MoreVertical,
   Scissors,
@@ -32,6 +30,7 @@ import {
 import { useTranslations } from 'next-intl';
 import { useCallback, useRef, useState, type ComponentType, type ReactNode } from 'react';
 import type { FileNode } from '@/features/file-browser/types';
+import { DriveFolderIcon } from './drive-folder-icon';
 import { getFileIcon } from './file-icon';
 import { FileThumbnail } from './file-thumbnail';
 import type { GitStatusType } from '@/features/file-browser/components/file-tree-item';
@@ -351,14 +350,39 @@ function FolderCard({
           onDrop={handleDrop}
           onClick={isRenaming ? undefined : onClick}
           className={cn(
-            'group border-border bg-popover hover:bg-foreground/4 flex h-11 cursor-pointer items-center gap-2.5 rounded-md border px-3 transition-colors select-none',
+            'group border-border bg-popover hover:bg-foreground/4 relative flex cursor-pointer flex-col overflow-hidden rounded-md border transition-colors select-none',
             isCut && 'opacity-40',
             isDragging && 'opacity-30',
-            isDragOver && 'bg-primary/[0.08] border-primary/40',
+            isDragOver && 'border-primary/40 ring-primary/50 ring-2',
           )}
         >
-          <Folder className="text-muted-foreground size-4 shrink-0" />
-          <div className="flex h-full min-w-0 flex-1 items-center">
+          <div className="flex h-[120px] items-center justify-center">
+            <DriveFolderIcon label={node.name} className="w-[72px] drop-shadow-sm" />
+          </div>
+
+          {!isRenaming && (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  onClick={(e) => e.stopPropagation()}
+                  variant="secondary"
+                  size="icon-sm"
+                  className="absolute top-3 right-3 opacity-0 group-hover:opacity-100 data-[state=open]:opacity-100"
+                >
+                  <MoreVertical className="text-muted-foreground size-3.5" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-48">
+                <FolderDriveMenuItems
+                  Item={DropdownMenuItem}
+                  Separator={DropdownMenuSeparator}
+                  {...folderMenuProps}
+                />
+              </DropdownMenuContent>
+            </DropdownMenu>
+          )}
+
+          <div className="border-border/40 bg-background flex items-center border-t px-3 py-2.5">
             {isRenaming ? (
               <input
                 ref={renameInputRef}
@@ -374,30 +398,12 @@ function FolderCard({
                 className="border-primary/50 w-full border-b bg-transparent py-0.5 text-sm outline-none"
               />
             ) : (
-              <span className="text-foreground truncate text-sm font-medium">{node.name}</span>
+              <div className="flex w-full min-w-0 items-center gap-1.5">
+                <DriveFolderIcon label={node.name} className="size-4 shrink-0" />
+                <span className="text-foreground truncate text-sm font-medium">{node.name}</span>
+              </div>
             )}
           </div>
-          {!isRenaming && (
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  onClick={(e) => e.stopPropagation()}
-                  variant="ghost"
-                  size="icon-xs"
-                  className="shrink-0 opacity-0 group-hover:opacity-100"
-                >
-                  <MoreVertical className="text-muted-foreground size-3.5" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="w-48">
-                <FolderDriveMenuItems
-                  Item={DropdownMenuItem}
-                  Separator={DropdownMenuSeparator}
-                  {...folderMenuProps}
-                />
-              </DropdownMenuContent>
-            </DropdownMenu>
-          )}
         </div>
       </ContextMenuTrigger>
       <ContextMenuContent className="w-48">
@@ -564,9 +570,9 @@ function FileCard({
 // ─── Main Grid View ─────────────────────────────────────────────────────────
 
 /** Descriptions for elevated system directories */
-const ELEVATED_DIR_META: Record<string, { description: string; icon: typeof FolderCog }> = {
-  '.kortix': { description: 'Project config, tasks, context', icon: FolderCog },
-  '.opencode': { description: 'Agents, skills, commands', icon: FolderCog },
+const ELEVATED_DIR_META: Record<string, { description: string }> = {
+  '.kortix': { description: 'Project config, tasks, context' },
+  '.opencode': { description: 'Agents, skills, commands' },
 };
 
 interface DriveGridViewProps {
@@ -625,25 +631,29 @@ export function DriveGridView({
         <section className="space-y-2">
           <SectionHeader label="System" count={elevatedDirs.length} />
           <div
-            className="grid gap-2"
-            style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(180px, 1fr))' }}
+            className="grid gap-3"
+            style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(160px, 1fr))' }}
           >
             {elevatedDirs.map((node) => {
               const meta = ELEVATED_DIR_META[node.name];
-              const DirIcon = meta?.icon ?? FolderCog;
               return (
                 <div
                   key={node.path}
                   onClick={() => onNavigateToDir(node)}
                   title={meta?.description}
                   className={cn(
-                    'group border-border bg-popover hover:bg-foreground/4 flex h-11 cursor-pointer items-center gap-2.5 rounded-md border px-3 select-none',
+                    'group border-border bg-popover hover:bg-foreground/4 relative flex cursor-pointer flex-col overflow-hidden rounded-md border transition-colors select-none',
                   )}
                 >
-                  <DirIcon className="text-muted-foreground size-4 shrink-0" />
-                  <span className="text-foreground min-w-0 flex-1 truncate text-sm">
-                    {node.name}
-                  </span>
+                  <div className="flex h-[120px] items-center justify-center">
+                    <DriveFolderIcon label={node.name} className="w-[72px] drop-shadow-sm" />
+                  </div>
+                  <div className="border-border/40 bg-background flex items-center gap-1.5 border-t px-3 py-2.5">
+                    <DriveFolderIcon label={node.name} className="size-4 shrink-0" />
+                    <span className="text-foreground truncate text-sm font-medium">
+                      {node.name}
+                    </span>
+                  </div>
                 </div>
               );
             })}
@@ -655,8 +665,8 @@ export function DriveGridView({
         <section className="space-y-2">
           <SectionHeader label="Folders" count={dirs.length} />
           <div
-            className="grid gap-2"
-            style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(180px, 1fr))' }}
+            className="grid gap-3"
+            style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(160px, 1fr))' }}
           >
             {dirs.map((node) => (
               <FolderCard

--- a/apps/web/src/features/session/boot-status-line.test.ts
+++ b/apps/web/src/features/session/boot-status-line.test.ts
@@ -1,0 +1,9 @@
+import { expect, test } from 'bun:test';
+import { BOOT_STATUS_LABEL } from './boot-status-line';
+
+test('boot status is a single calm line, not a step checklist', () => {
+  expect(BOOT_STATUS_LABEL).toBe('Starting your computer…');
+  // Guard against regressing to the 4-step theater copy.
+  expect(BOOT_STATUS_LABEL).not.toContain('Allocating');
+  expect(BOOT_STATUS_LABEL).not.toContain('Provisioning your computer');
+});

--- a/apps/web/src/features/session/boot-status-line.tsx
+++ b/apps/web/src/features/session/boot-status-line.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { useReducedMotion } from 'motion/react';
+
+import { TextShimmer } from '@/components/ui/text-shimmer';
+import { cn } from '@/lib/utils';
+
+export const BOOT_STATUS_LABEL = 'Starting your computer…';
+
+/**
+ * The ONE boot indicator: a single quiet line with a soft kortix-green pulse and
+ * a slow shimmer sweeping the label. Replaces the old 4-step checklist theater
+ * everywhere the runtime is coming up (thread, side panel, resume loader).
+ * Honors prefers-reduced-motion: reduced-motion users get the steady label (no
+ * shimmer), and the pulse dot self-disables via `motion-reduce:animate-none`.
+ */
+export function BootStatusLine({
+  align = 'start',
+  className,
+}: {
+  align?: 'start' | 'center';
+  className?: string;
+}) {
+  const reduceMotion = useReducedMotion();
+  return (
+    <span
+      className={cn(
+        'text-muted-foreground/70 inline-flex items-center gap-2 text-[13px] tracking-tight',
+        align === 'center' && 'justify-center',
+        className,
+      )}
+      aria-live="polite"
+    >
+      <span
+        className="bg-kortix-green/70 h-1.5 w-1.5 shrink-0 animate-pulse rounded-full motion-reduce:animate-none"
+        aria-hidden
+      />
+      {reduceMotion ? (
+        <span>{BOOT_STATUS_LABEL}</span>
+      ) : (
+        <TextShimmer className="text-[13px] tracking-tight" duration={1.5}>
+          {BOOT_STATUS_LABEL}
+        </TextShimmer>
+      )}
+    </span>
+  );
+}

--- a/apps/web/src/features/session/composer-chat-input.tsx
+++ b/apps/web/src/features/session/composer-chat-input.tsx
@@ -34,6 +34,7 @@ export function ComposerChatInput({
   projectId,
   isBusy,
   stopDisabled,
+  isSending,
   disabled,
   autoFocus,
   placeholder,
@@ -51,6 +52,8 @@ export function ComposerChatInput({
   isBusy?: boolean;
   /** Show a disabled stop button while busy (e.g. the computer is still booting). */
   stopDisabled?: boolean;
+  /** Send in flight, not yet settled — spinner in the send slot (see SessionChatInput.isSending). */
+  isSending?: boolean;
   disabled?: boolean;
   /** Clear the composer optimistically on send. Set false on the project-home
    *  composer, whose send navigates it away (see SessionChatInput.clearOnSend). */
@@ -92,6 +95,7 @@ export function ComposerChatInput({
       clearOnSend={clearOnSend}
       isBusy={isBusy}
       stopDisabled={stopDisabled}
+      isSending={isSending}
       disabled={disabled}
       autoFocus={autoFocus}
       placeholder={placeholder}

--- a/apps/web/src/features/session/instant-session-shell.tsx
+++ b/apps/web/src/features/session/instant-session-shell.tsx
@@ -5,11 +5,11 @@ import { useCallback, useState } from 'react';
 import { createPortal } from 'react-dom';
 
 import { AssistantPendingRow } from '@/features/session/assistant-pending-row';
+import { BootStatusLine } from '@/features/session/boot-status-line';
 import { ComposerChatInput, type ComposerOptions } from '@/features/session/composer-chat-input';
 import { SessionSiteHeader } from '@/features/session/header/session-site-header';
 import type { AttachedFile } from '@/features/session/session-chat-input';
 import { SessionLayout } from '@/features/session/session-layout';
-import { SessionBootChecklistInline } from '@/features/session/session-starting-loader';
 import { useSessionWallpaperLayer } from '@/features/session/session-wallpaper-layer';
 import { SessionWelcome } from '@/features/session/session-welcome';
 import { optimisticUploadedFileRef } from '@/features/session/uploaded-file-refs';
@@ -35,9 +35,9 @@ import { GridFileCard } from './grid-file-card';
  * (keyed by the route session id; the session page migrates it onto the
  * OpenCode pin) so the real {@link SessionChat} auto-sends it the instant the
  * runtime is healthy — and the thread shows an inline "starting your computer"
- * status under the assistant logo until the real chat crossfades in. The boot
- * checklist also lives in the side panel, but only
- * if the user opens it (never auto-opened); once the runtime is ready the panel
+ * status under the assistant logo until the real chat crossfades in. The same
+ * calm boot status line also lives in the side panel, but only if the user
+ * opens it (never auto-opened); once the runtime is ready the panel
  * gracefully falls back to the real (empty) Actions view.
  */
 export function InstantSessionShell({
@@ -234,12 +234,12 @@ export function InstantSessionShell({
                     </div>
                   </div>
                   {/* While the computer is still coming up we show the SAME
-                      stepped boot checklist as the side panel, inline under the
+                      calm boot status line as the side panel, inline under the
                       logomark — so the progress is visible without opening the
                       panel. Once ready it falls back to the regular thinking text. */}
                   <AssistantPendingRow
                     className="mt-6"
-                    body={ready ? undefined : <SessionBootChecklistInline stage={stage} />}
+                    body={ready ? undefined : <BootStatusLine />}
                   />
                 </div>
               </div>
@@ -261,9 +261,9 @@ export function InstantSessionShell({
       projectId={projectId}
       projectSessionId={sessionId}
       transient
-      // Side-panel content: the boot checklist while still coming up, then the
-      // real (empty) Actions view once ready — so an open panel is never stuck on
-      // "Connecting". Visibility stays user-controlled (no auto-open).
+      // Side-panel content: the calm boot status line while still coming up,
+      // then the real (empty) Actions view once ready — so an open panel is
+      // never stuck on "Connecting". Visibility stays user-controlled (no auto-open).
       bootStage={ready ? null : stage}
     >
       {column}

--- a/apps/web/src/features/session/session-chat-input.tsx
+++ b/apps/web/src/features/session/session-chat-input.tsx
@@ -1105,6 +1105,13 @@ export interface SessionChatInputProps {
    * busy input shows a (non-clickable) stop button instead of nothing at all.
    */
   stopDisabled?: boolean;
+  /**
+   * The send is in flight but hasn't navigated/settled yet — swap the send
+   * button for a spinner (used by the project-home composer while the session
+   * create POST round-trips). Distinct from `isBusy`, which means "the agent is
+   * running" and shows a stop button instead.
+   */
+  isSending?: boolean;
   agents?: Agent[];
   selectedAgent?: string | null;
   onAgentChange?: (agentName: string | null | undefined) => void;
@@ -1217,6 +1224,7 @@ export function SessionChatInput({
   isBusy = false,
   onStop,
   stopDisabled = false,
+  isSending = false,
   agents = [],
   selectedAgent = null,
   onAgentChange,
@@ -2305,7 +2313,12 @@ export function SessionChatInput({
                 disabled={submitDisabled || isBusy}
               />
 
-              {isBusy && (onStop || stopDisabled) && !lockForQuestion && (
+              {isSending && !lockForQuestion && (
+                <Button size="sm" disabled className="h-8 w-8 flex-shrink-0 rounded-full p-0">
+                  <Loader2 className="size-4 animate-spin" />
+                </Button>
+              )}
+              {!isSending && isBusy && (onStop || stopDisabled) && !lockForQuestion && (
                 <div className="relative flex items-center">
                   {/* ESC hint — matches Kortix tooltip styling (bg-primary rounded-2xl) */}
                   {escCount > 0 && (
@@ -2345,7 +2358,7 @@ export function SessionChatInput({
                   </Tooltip>
                 </div>
               )}
-              {(!isBusy || lockForQuestion) && (
+              {!isSending && (!isBusy || lockForQuestion) && (
                 <div className="opacity-100">
                   {lockForQuestion && questionButtonLabel && !text.trim() ? (
                     <Button

--- a/apps/web/src/features/session/session-chat.tsx
+++ b/apps/web/src/features/session/session-chat.tsx
@@ -5252,7 +5252,7 @@ export function SessionChat({
   if (isDataLoading) {
     return (
       <div className="bg-background relative flex h-full flex-col" data-testid="session-chat">
-        <SessionStartingLoader stage="ready" />
+        <SessionStartingLoader />
       </div>
     );
   }

--- a/apps/web/src/features/session/session-layout.tsx
+++ b/apps/web/src/features/session/session-layout.tsx
@@ -340,19 +340,14 @@ export const SessionLayout = memo(function SessionLayout({
     </div>
   );
 
-  // While booting, the panel is JUST the dead-center "Kortix Computer is
-  // starting" loader — no header bar (the loader has its own heading, so a panel
-  // title would be redundant), filling the whole card so it's perfectly
-  // centered. The runtime-coupled views (Actions/Files/Terminal/Browser) need a
-  // live sandbox, so they only render once booted.
+  // While booting, the panel is JUST the dead-center resume loader — no header
+  // bar (the loader shows only the calm "Starting your computer…" status line,
+  // so a panel title would be redundant), filling the whole card so it's
+  // perfectly centered. The runtime-coupled views (Actions/Files/Terminal/
+  // Browser) need a live sandbox, so they only render once booted.
   const effectivePanelHeader = booting ? null : panelHeader;
   const effectivePanelBody = booting ? (
-    <SessionStartingLoader
-      stage={bootStage ?? 'provisioning'}
-      delayMs={0}
-      projectId={projectId}
-      sessionId={projectSessionId}
-    />
+    <SessionStartingLoader delayMs={0} projectId={projectId} sessionId={projectSessionId} />
   ) : (
     panelBody
   );

--- a/apps/web/src/features/session/session-start-gate.test.ts
+++ b/apps/web/src/features/session/session-start-gate.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from 'bun:test';
+import { shouldShowStartError } from './session-start-gate';
+
+test('hides a start error while the session is still fresh (boot noise)', () => {
+  expect(shouldShowStartError({ status: 404 }, true)).toBe(false);
+});
+
+test('shows a start error once the session is no longer fresh', () => {
+  expect(shouldShowStartError({ status: 404 }, false)).toBe(true);
+});
+
+test('no error → nothing to show', () => {
+  expect(shouldShowStartError(null, false)).toBe(false);
+  expect(shouldShowStartError(null, true)).toBe(false);
+});

--- a/apps/web/src/features/session/session-start-gate.ts
+++ b/apps/web/src/features/session/session-start-gate.ts
@@ -1,0 +1,13 @@
+/**
+ * Whether to render the terminal "Couldn't start session" card. While a session
+ * is FRESH (just minted client-side, create still settling) a /start error is the
+ * create-vs-start race — boot noise, not a failure — so the instant shell stays
+ * up. Once the fresh window has passed (see useSession's bounded grace), a real
+ * error surfaces normally.
+ */
+export function shouldShowStartError(
+  startError: { status?: number } | null,
+  isFresh: boolean,
+): boolean {
+  return !!startError && !isFresh;
+}

--- a/apps/web/src/features/session/session-starting-loader.tsx
+++ b/apps/web/src/features/session/session-starting-loader.tsx
@@ -1,32 +1,25 @@
 'use client';
 
-import { Check, Loader2, RotateCcw } from 'lucide-react';
-import { useTranslations } from 'next-intl';
+import { Loader2, RotateCcw } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { restartProjectSession, sessionStartKey, type SessionStartStage } from '@kortix/sdk/projects-client';
-import { formatDuration } from '@kortix/sdk/turns';
+import { restartProjectSession, sessionStartKey } from '@kortix/sdk/projects-client';
 import { Button } from '@/components/ui/button';
 import { errorToast } from '@/components/ui/toast';
 import { cn } from '@/lib/utils';
+import { BootStatusLine } from './boot-status-line';
 
 /**
  * The ONE loader shown while a session's Kortix Computer comes up — full-screen
  * for resumes, and dead-center in the side panel while a fresh session boots.
  * All the heavy lifting (provision / wake / OpenCode readiness + pin) is
- * server-side behind POST /sessions/:id/start; this just reports the real stage.
+ * server-side behind POST /sessions/:id/start; this just reports a calm status.
  *
- * Visual: super-minimal, perfectly centered. A single kortix-green pulse, the
- * heading, a clean stepped checklist (no connector rails), and one quiet hint.
+ * Visual: super-minimal, perfectly centered. A single calm boot status line
+ * (see {@link BootStatusLine}) and one quiet hint.
  */
 const LOADER_DELAY_MS = 700;
-/**
- * How long we sit in the backend `starting` stage before softly advancing from
- * "Preparing your workspace" to "Starting the agent". Both happen within that
- * one backend stage (clone → OpenCode boot), so the advance reflects real order.
- */
-const STARTING_SUBSTEP_MS = 5_000;
 /** After this long, swap the footer copy to set expectations for a cold start. */
 const SLOW_AFTER_MS = 15_000;
 /**
@@ -37,102 +30,17 @@ const SLOW_AFTER_MS = 15_000;
  */
 const STUCK_AFTER_MS = 45_000;
 
-interface Step {
-  label: string;
-  description: string;
-}
-
-const STEPS: Step[] = [
-  { label: 'Provisioning your computer', description: 'Allocating a secure sandbox' },
-  { label: 'Preparing your workspace', description: 'Cloning your project files' },
-  { label: 'Starting the agent', description: 'Booting the runtime and tools' },
-  { label: 'Connecting', description: 'Linking up your session' },
-];
-
-/**
- * Resolve which step is CURRENTLY active from the backend stage plus how long
- * we've been in it. The index is the floor we KNOW we're at — earlier steps are
- * genuinely complete, later ones haven't started.
- */
-function activeStep(stage: SessionStartStage, msInStage: number): number {
-  if (stage === 'provisioning') return 0;
-  if (stage === 'starting') return msInStage >= STARTING_SUBSTEP_MS ? 2 : 1;
-  return 3; // ready → the FE active-server switch + health poll ("connecting")
-}
-
-/**
- * The shared boot clock: a 1s tick that resolves the CURRENT active step from
- * the backend stage plus time-in-stage (so the `starting` soft-advance fires),
- * and exposes `now` for any caller-side elapsed/slow/stuck math. Both the side
- * panel loader and the inline thread checklist consume this, so the two always
- * report the same step.
- */
-function useBootProgress(stage: SessionStartStage): { active: number; now: number } {
+/** The shared boot clock: a 1s tick used for the `slow`/`stuck` footer math. */
+function useBootClock(): number {
   const [now, setNow] = useState(() => Date.now());
   useEffect(() => {
     const id = setInterval(() => setNow(Date.now()), 1_000);
     return () => clearInterval(id);
   }, []);
-
-  // Reset the per-stage clock whenever the backend stage changes, so the
-  // soft-advance measures time spent in the CURRENT stage (not since mount).
-  const stageEnteredAt = useRef(now);
-  const prevStage = useRef(stage);
-  if (prevStage.current !== stage) {
-    prevStage.current = stage;
-    stageEnteredAt.current = now;
-  }
-
-  return { active: activeStep(stage, now - stageEnteredAt.current), now };
-}
-
-/**
- * The stepped checklist itself — one render, shared by the centered panel loader
- * and the inline thread checklist so they can never visually drift. Pure: the
- * caller owns the clock (see {@link useBootProgress}) and passes the active index.
- */
-function BootStepList({ active }: { active: number }) {
-  return (
-    <ol className="flex flex-col gap-3.5" aria-live="polite">
-      {STEPS.map((step, i) => {
-        const done = i < active;
-        const current = i === active;
-        return (
-          <li
-            key={step.label}
-            className="flex items-center gap-2.5"
-            aria-current={current ? 'step' : undefined}
-          >
-            <span className="flex h-3.5 w-3.5 shrink-0 items-center justify-center">
-              {done ? (
-                <Check className="text-kortix-green h-3.5 w-3.5" strokeWidth={2.5} />
-              ) : current ? (
-                <Loader2 className="text-kortix-green h-3.5 w-3.5 animate-spin" />
-              ) : (
-                <span className="bg-muted-foreground/25 h-1 w-1 rounded-full" />
-              )}
-            </span>
-            <span
-              className={cn(
-                'text-[13px] leading-none tracking-tight transition-colors duration-500',
-                current
-                  ? 'text-foreground font-medium'
-                  : done
-                    ? 'text-muted-foreground'
-                    : 'text-muted-foreground/40',
-              )}
-            >
-              {step.label}
-            </span>
-          </li>
-        );
-      })}
-    </ol>
-  );
+  return now;
 }
 
 export function SessionStartingLoader({
-  stage = 'provisioning',
   /** Delay before the content fades in. The full-screen resume loader keeps the
    *  default so a warm open never flashes it; the side panel passes 0 because the
    *  user opened it deliberately and expects to see status immediately. */
@@ -143,12 +51,10 @@ export function SessionStartingLoader({
   projectId,
   sessionId,
 }: {
-  stage?: SessionStartStage;
   delayMs?: number;
   projectId?: string;
   sessionId?: string;
 }) {
-  const tI18nHardcoded = useTranslations('hardcodedUi');
   const queryClient = useQueryClient();
   const [show, setShow] = useState(delayMs <= 0);
   useEffect(() => {
@@ -160,9 +66,9 @@ export function SessionStartingLoader({
     return () => clearTimeout(t);
   }, [delayMs]);
 
-  // The shared boot clock owns the 1s tick + per-stage soft-advance; `now` also
-  // drives the footer copy below (and the inline checklist reuses the same hook).
-  const { active, now } = useBootProgress(stage);
+  // The shared boot clock owns the 1s tick that drives the `slow`/`stuck`
+  // footer math below.
+  const now = useBootClock();
   // A manual restart pushes the "stuck" clock back out so the button doesn't
   // reappear immediately while the fresh boot is still in progress.
   const clockStart = useRef(now);
@@ -188,30 +94,14 @@ export function SessionStartingLoader({
     <div className="flex h-full min-h-0 w-full flex-1 items-center justify-center px-8">
       <div
         className={cn(
-          'flex flex-col items-center gap-9 transition-opacity duration-500',
+          'flex flex-col items-center gap-5 transition-opacity duration-500 ease-out',
           show ? 'opacity-100' : 'opacity-0',
         )}
       >
-        {/* Brand heartbeat + heading, grouped. */}
-        <div className="flex flex-col items-center gap-4">
-          <span className="relative flex h-2.5 w-2.5" aria-hidden>
-            <span className="bg-kortix-green/40 absolute inline-flex h-full w-full animate-ping rounded-full" />
-            <span className="bg-kortix-green relative inline-flex h-2.5 w-2.5 rounded-full" />
-          </span>
-          <h2 className="text-foreground text-[13px] font-medium tracking-tight">
-            {tI18nHardcoded.raw(
-              'autoFeaturesSessionSessionStartingLoaderJsxTextKortixComputerIs7c42f59a',
-            )}
-          </h2>
-        </div>
-
-        {/* Auto-width so the checklist is a centered block under the heading. */}
-        <BootStepList active={active} />
-
+        <BootStatusLine align="center" />
         <p className="text-muted-foreground/40 text-center text-[11px] leading-relaxed">
           {slow ? 'A cold start can take a little longer.' : 'This usually takes a few seconds.'}
         </p>
-
         {stuck && canRestart ? (
           <Button
             type="button"
@@ -230,41 +120,6 @@ export function SessionStartingLoader({
           </Button>
         ) : null}
       </div>
-    </div>
-  );
-}
-
-/**
- * The boot checklist rendered INLINE in the thread (under the assistant
- * logomark) while a freshly-created session's Kortix Computer comes up — the
- * SAME stepped progress as the side panel's {@link SessionStartingLoader}, via
- * the shared {@link BootStepList} + {@link useBootProgress}, so a user who never
- * opens the computer panel still watches the real provisioning state advance
- * instead of one static "Provisioning…" line. Left-aligned to sit under the
- * Kortix logomark; carries its own elapsed timer to match the thread's regular
- * waiting indicator.
- */
-export function SessionBootChecklistInline({
-  stage = 'provisioning',
-  className,
-}: {
-  stage?: SessionStartStage;
-  className?: string;
-}) {
-  const { active, now } = useBootProgress(stage);
-  const startRef = useRef(now);
-  const elapsed = formatDuration(now - startRef.current);
-  return (
-    <div className={cn('flex flex-col items-start gap-2', className)}>
-      <div
-        className="bg-popover w-full rounded-2xl border px-4.5 py-4"
-        aria-label="Starting your Kortix Computer"
-      >
-        <BootStepList active={active} />
-      </div>
-      {elapsed ? (
-        <span className="text-muted-foreground/50 pl-1 text-xs tabular-nums">· {elapsed}</span>
-      ) : null}
     </div>
   );
 }

--- a/apps/web/src/features/workspace/project-layout/project-home.tsx
+++ b/apps/web/src/features/workspace/project-layout/project-home.tsx
@@ -154,7 +154,10 @@ export function ProjectHome({
             onSend={handleSend}
             onCommand={handleCommand}
             projectId={projectId}
-            isBusy={busy}
+            // `busy` here means "create in flight" — spinner in the send slot,
+            // input locked. NOT isBusy (that renders agent-running stop-button
+            // semantics, which leave the composer with no button at all here).
+            isSending={busy}
             disabled={busy}
             // The home composer navigates to the new session on send — don't clear
             // it first (that only flashes an empty box before the route swaps, and

--- a/apps/web/src/hooks/projects/new-session-failure.test.ts
+++ b/apps/web/src/hooks/projects/new-session-failure.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from 'bun:test';
+
+import { resolveCreateFailure } from './new-session-failure';
+
+describe('resolveCreateFailure', () => {
+  test('billing rejections open the upgrade dialog and stay on the page', () => {
+    expect(resolveCreateFailure('subscription_required')).toBe('upgrade');
+    expect(resolveCreateFailure('no_account')).toBe('upgrade');
+  });
+
+  test('the concurrent-session cap stays silent (global 429 handler owns it)', () => {
+    expect(resolveCreateFailure('concurrent_session_limit')).toBe('silent');
+  });
+
+  test('everything else — including codeless network failures — surfaces a toast, never a redirect', () => {
+    expect(resolveCreateFailure(undefined)).toBe('toast');
+    expect(resolveCreateFailure('TIMEOUT')).toBe('toast');
+    expect(resolveCreateFailure('internal_error')).toBe('toast');
+  });
+});

--- a/apps/web/src/hooks/projects/new-session-failure.ts
+++ b/apps/web/src/hooks/projects/new-session-failure.ts
@@ -1,0 +1,19 @@
+/**
+ * How a failed session create resolves, keyed by the server's error code.
+ *
+ * - `upgrade`  → open the Team-plan dialog (billing said no); stay put.
+ * - `silent`   → the global 429 handler already surfaced it; stay put.
+ * - `toast`    → terminal failure the user must see; stay put.
+ *
+ * Every branch stays on the current page: `useNewProjectSession` only navigates
+ * AFTER a successful create, so there is no optimistic route to unwind. (The
+ * old navigate-first flow bounced `router.replace` back to the index on ANY
+ * rejection — including client-side timeouts where the server had actually
+ * committed the row, which read as "the session appeared in the sidebar but I
+ * never left the index page".)
+ */
+export function resolveCreateFailure(code: string | undefined): 'upgrade' | 'silent' | 'toast' {
+  if (code === 'subscription_required' || code === 'no_account') return 'upgrade';
+  if (code === 'concurrent_session_limit') return 'silent';
+  return 'toast';
+}

--- a/apps/web/src/hooks/projects/use-new-project-session.ts
+++ b/apps/web/src/hooks/projects/use-new-project-session.ts
@@ -4,6 +4,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import { useCallback, useRef } from 'react';
 
+import { resolveCreateFailure } from '@/hooks/projects/new-session-failure';
 import { useProjectCanRun } from '@/hooks/projects/use-project-can-run';
 import { isBillingEnabled } from '@/lib/config';
 import { toast } from '@/lib/toast';
@@ -13,21 +14,27 @@ import { createProjectSession } from '@kortix/sdk/projects-client';
 import { prefetchSessionStart } from '@kortix/sdk/react';
 
 /**
- * The fastest possible "new empty session" path, shared by every entry point
- * (project shell button, ⌘T/⌘J shortcuts, project sidebar, command palette).
+ * The ONE "new empty session" path, shared by every entry point (project shell
+ * button, ⌘T/⌘J shortcuts, project sidebar, command palette, home composer).
  *
- * OPTIMISTIC: mint the session id client-side and navigate IMMEDIATELY — the
- * instant shell paints before the create POST even returns. The backend honors a
- * client-provided UUID (`session_id` is client-authoritative), and the session page's `/start` poll tolerates the sub-second
- * create-vs-start race by retrying. Provisioning + the route bundle are warmed
- * during the navigation; the session is persisted in the background.
+ * CREATE-FIRST: mint the session id client-side, persist it, and navigate the
+ * moment the server confirms (create is a ~15ms insert, so this is still
+ * instant). The route bundle prefetch overlaps the create RTT, and `/start`
+ * is prefetched the moment the row exists — so provisioning still begins
+ * during the navigation, without ever racing the create POST.
  *
- * `onNavigate(sessionId)` runs synchronously right before the push — use it for
- * entry-point-specific side effects (open a tab, close a drawer, timing marks,
- * stashing a pending prompt so the shell auto-sends it once the box is ready).
+ * `onNavigate(sessionId)` runs synchronously right before the push — use it
+ * for entry-point-specific side effects (open a tab, close a drawer, timing
+ * marks, stashing a pending prompt so the shell auto-sends it once the box is
+ * ready).
  *
- * `create` carries create-time overrides (e.g. a chosen `sandbox_slug`) straight
- * to the persist POST without changing the optimistic timing.
+ * `onError()` fires when the create fails (after the failure is surfaced per
+ * `resolveCreateFailure`) — use it to reset an entry point's pending UI
+ * (e.g. the home composer's sending spinner). No navigation has happened at
+ * that point, so the user simply stays where they were.
+ *
+ * `create` carries create-time overrides (e.g. a chosen `sandbox_slug`)
+ * straight to the persist POST.
  */
 export function useNewProjectSession(projectId: string | undefined) {
   const router = useRouter();
@@ -39,18 +46,26 @@ export function useNewProjectSession(projectId: string | undefined) {
   return useCallback(
     (opts?: {
       onNavigate?: (sessionId: string) => void;
+      onError?: () => void;
       // `agent_name` binds the session's immutable boot agent at birth. It MUST
       // match the agent the composer sends on the first prompt — the API proxy
       // rejects any prompt whose `agent` differs from the session's bound agent
       // with 409 AGENT_SWITCH_REQUIRES_NEW_SESSION (sessions are agent-immutable).
       create?: { sandbox_slug?: string; agent_name?: string };
     }) => {
-      if (!projectId || creatingRef.current) return;
+      if (!projectId || creatingRef.current) {
+        opts?.onError?.();
+        return;
+      }
 
-      if (isBillingEnabled() && billingLoading) return;
+      if (isBillingEnabled() && billingLoading) {
+        opts?.onError?.();
+        return;
+      }
 
       if (isBillingEnabled() && !canRun) {
         openUpgradeDialog({ reason: 'subscription_required', accountId });
+        opts?.onError?.();
         return;
       }
 
@@ -60,30 +75,27 @@ export function useNewProjectSession(projectId: string | undefined) {
       // context this app runs (secure context: https + localhost).
       const sessionId = crypto.randomUUID();
       markSessionFresh(sessionId); // → instant shell, not the resume loader
-      prefetchSessionStart(queryClient, projectId, sessionId);
+      // Warm the route bundle while the create POST is in flight.
       router.prefetch(`/projects/${projectId}/sessions/${sessionId}`);
-      opts?.onNavigate?.(sessionId);
-      router.push(`/projects/${projectId}/sessions/${sessionId}`);
 
-      // Persist in the background — the page is already rendering the shell.
       createProjectSession(projectId, { session_id: sessionId, ...opts?.create })
         .then(() => {
+          // The row exists — kick provisioning so it overlaps the navigation.
+          prefetchSessionStart(queryClient, projectId, sessionId);
           queryClient.invalidateQueries({ queryKey: ['project-sessions', projectId] });
+          opts?.onNavigate?.(sessionId);
+          router.push(`/projects/${projectId}/sessions/${sessionId}`);
         })
         .catch((err) => {
           const code = (err as { code?: string })?.code;
-          // No-plan 402 → the session page itself shows the gated screen +
-          // upgrade modal (its billing gate knows this project's account), so
-          // stay put and let it handle the pitch.
-          if (code === 'subscription_required' || code === 'no_account') return;
-          // Any other terminal failure (concurrent-session limit, out-of-credits,
-          // validation, server error) means the session will never exist — we've
-          // already navigated optimistically, so bounce back off the dead shell.
-          // The 429 cap is surfaced by the global handler; others get a toast.
-          if (code !== 'concurrent_session_limit') {
+          const action = resolveCreateFailure(code);
+          if (action === 'upgrade') {
+            openUpgradeDialog({ reason: 'subscription_required', accountId });
+          } else if (action === 'toast') {
             toast.error(err instanceof Error ? err.message : 'Failed to start session');
           }
-          router.replace(`/projects/${projectId}`);
+          // 'silent': the global 429 handler already surfaced the session cap.
+          opts?.onError?.();
         })
         .finally(() => {
           creatingRef.current = false;

--- a/apps/web/translations/de.json
+++ b/apps/web/translations/de.json
@@ -8014,7 +8014,6 @@
     "autoFeaturesSessionHeaderSessionChangesIndicatorJsxTextVersionYet922de6bd": "Version. Schlage die Änderungen vor, damit sie geprüft und übernommen werden.",
     "autoFeaturesSessionHeaderSessionSiteHeaderJsxTextRename41731a53": "Umbenennen…",
     "autoFeaturesSessionHeaderSessionSiteHeaderJsxTextShared7d34d4f": "Teilen…",
-    "autoFeaturesSessionSessionStartingLoaderJsxTextKortixComputerIs7c42f59a": "Kortix Computer startet",
     "autoFeaturesSessionSessionTerminalPanelJsxTextNewTerminaleeb6bbb9": "Neues Terminal",
     "autoFeaturesSessionSessionVersionHeaderJsxAttrAriaLabelFiles9fd01463": "Dateiansicht",
     "autoFeaturesSessionSessionVersionHeaderJsxAttrLabelAllFiles4f423738": "Alle Dateien",

--- a/apps/web/translations/en.json
+++ b/apps/web/translations/en.json
@@ -8074,7 +8074,6 @@
     "autoFeaturesSessionHeaderSessionSiteHeaderJsxTextRename41731a53": "Rename…",
     "autoFeaturesSessionHeaderSessionSiteHeaderJsxTextShared7d34d4f": "Share…",
     "autoFeaturesSessionInstantSessionShellJsxAttrSessionTitleNewSession6b8dfd00": "New session",
-    "autoFeaturesSessionSessionStartingLoaderJsxTextKortixComputerIs7c42f59a": "Kortix Computer is starting",
     "autoFeaturesSessionSessionTerminalPanelJsxTextConnecting80303e70": "Connecting…",
     "autoFeaturesSessionSessionTerminalPanelJsxTextNewTerminaleeb6bbb9": "New terminal",
     "autoFeaturesSessionSessionVersionHeaderJsxAttrAriaLabelFiles9fd01463": "Files view",

--- a/apps/web/translations/es.json
+++ b/apps/web/translations/es.json
@@ -8014,7 +8014,6 @@
     "autoFeaturesSessionHeaderSessionChangesIndicatorJsxTextVersionYet922de6bd": "versión. Propón los cambios para que se revisen y apliquen.",
     "autoFeaturesSessionHeaderSessionSiteHeaderJsxTextRename41731a53": "Cambiar nombre…",
     "autoFeaturesSessionHeaderSessionSiteHeaderJsxTextShared7d34d4f": "Comparte…",
-    "autoFeaturesSessionSessionStartingLoaderJsxTextKortixComputerIs7c42f59a": "La computadora Kortix se está iniciando",
     "autoFeaturesSessionSessionTerminalPanelJsxTextNewTerminaleeb6bbb9": "Nueva terminal",
     "autoFeaturesSessionSessionVersionHeaderJsxAttrAriaLabelFiles9fd01463": "Vista de archivos",
     "autoFeaturesSessionSessionVersionHeaderJsxAttrLabelAllFiles4f423738": "Todos los archivos",

--- a/apps/web/translations/fr.json
+++ b/apps/web/translations/fr.json
@@ -8014,7 +8014,6 @@
     "autoFeaturesSessionHeaderSessionChangesIndicatorJsxTextVersionYet922de6bd": "version. Proposez les modifications pour qu’elles soient relues et appliquées.",
     "autoFeaturesSessionHeaderSessionSiteHeaderJsxTextRename41731a53": "Renommer…",
     "autoFeaturesSessionHeaderSessionSiteHeaderJsxTextShared7d34d4f": "Partager…",
-    "autoFeaturesSessionSessionStartingLoaderJsxTextKortixComputerIs7c42f59a": "L'ordinateur Kortix démarre",
     "autoFeaturesSessionSessionTerminalPanelJsxTextNewTerminaleeb6bbb9": "Nouvelle borne",
     "autoFeaturesSessionSessionVersionHeaderJsxAttrAriaLabelFiles9fd01463": "Vue Fichiers",
     "autoFeaturesSessionSessionVersionHeaderJsxAttrLabelAllFiles4f423738": "Tous les fichiers",

--- a/apps/web/translations/it.json
+++ b/apps/web/translations/it.json
@@ -8014,7 +8014,6 @@
     "autoFeaturesSessionHeaderSessionChangesIndicatorJsxTextVersionYet922de6bd": "versione. Proponi le modifiche per farle revisionare e applicare.",
     "autoFeaturesSessionHeaderSessionSiteHeaderJsxTextRename41731a53": "Rinomina…",
     "autoFeaturesSessionHeaderSessionSiteHeaderJsxTextShared7d34d4f": "Condividi…",
-    "autoFeaturesSessionSessionStartingLoaderJsxTextKortixComputerIs7c42f59a": "Il computer Kortix è in fase di avvio",
     "autoFeaturesSessionSessionTerminalPanelJsxTextNewTerminaleeb6bbb9": "Nuovo terminale",
     "autoFeaturesSessionSessionVersionHeaderJsxAttrAriaLabelFiles9fd01463": "Visualizzazione dei file",
     "autoFeaturesSessionSessionVersionHeaderJsxAttrLabelAllFiles4f423738": "Tutti i file",

--- a/apps/web/translations/ja.json
+++ b/apps/web/translations/ja.json
@@ -8014,7 +8014,6 @@
     "autoFeaturesSessionHeaderSessionChangesIndicatorJsxTextVersionYet922de6bd": "バージョン。変更を提案してレビューと適用を受けてください。",
     "autoFeaturesSessionHeaderSessionSiteHeaderJsxTextRename41731a53": "名前を変更…",
     "autoFeaturesSessionHeaderSessionSiteHeaderJsxTextShared7d34d4f": "シェア…",
-    "autoFeaturesSessionSessionStartingLoaderJsxTextKortixComputerIs7c42f59a": "Kortix コンピューターが起動しています",
     "autoFeaturesSessionSessionTerminalPanelJsxTextNewTerminaleeb6bbb9": "新しいターミナル",
     "autoFeaturesSessionSessionVersionHeaderJsxAttrAriaLabelFiles9fd01463": "ファイルビュー",
     "autoFeaturesSessionSessionVersionHeaderJsxAttrLabelAllFiles4f423738": "すべてのファイル",

--- a/apps/web/translations/pt.json
+++ b/apps/web/translations/pt.json
@@ -8014,7 +8014,6 @@
     "autoFeaturesSessionHeaderSessionChangesIndicatorJsxTextVersionYet922de6bd": "versão. Proponha as alterações para que sejam revisadas e aplicadas.",
     "autoFeaturesSessionHeaderSessionSiteHeaderJsxTextRename41731a53": "Renomear…",
     "autoFeaturesSessionHeaderSessionSiteHeaderJsxTextShared7d34d4f": "Compartilhe…",
-    "autoFeaturesSessionSessionStartingLoaderJsxTextKortixComputerIs7c42f59a": "O computador Kortix está iniciando",
     "autoFeaturesSessionSessionTerminalPanelJsxTextNewTerminaleeb6bbb9": "Novo terminal",
     "autoFeaturesSessionSessionVersionHeaderJsxAttrAriaLabelFiles9fd01463": "Visualização de arquivos",
     "autoFeaturesSessionSessionVersionHeaderJsxAttrLabelAllFiles4f423738": "Todos os arquivos",

--- a/apps/web/translations/zh.json
+++ b/apps/web/translations/zh.json
@@ -8014,7 +8014,6 @@
     "autoFeaturesSessionHeaderSessionChangesIndicatorJsxTextVersionYet922de6bd": "版本中。提议这些更改以供审核和应用。",
     "autoFeaturesSessionHeaderSessionSiteHeaderJsxTextRename41731a53": "重命名...",
     "autoFeaturesSessionHeaderSessionSiteHeaderJsxTextShared7d34d4f": "分享...",
-    "autoFeaturesSessionSessionStartingLoaderJsxTextKortixComputerIs7c42f59a": "Kortix 计算机正在启动",
     "autoFeaturesSessionSessionTerminalPanelJsxTextNewTerminaleeb6bbb9": "新航站楼",
     "autoFeaturesSessionSessionVersionHeaderJsxAttrAriaLabelFiles9fd01463": "文件视图",
     "autoFeaturesSessionSessionVersionHeaderJsxAttrLabelAllFiles4f423738": "所有文件",

--- a/infra/k8s/envs/dev/values.yaml
+++ b/infra/k8s/envs/dev/values.yaml
@@ -6,7 +6,7 @@
 # Immutable dev tag (CI bumps to dev-<sha8> on each main push). Bootstrap value
 # is :dev-latest until the first deploy-dev-eks run pins an immutable sha.
 image:
-  tag: "dev-6c39b7c8"
+  tag: "dev-6f6a9307"
 kortixVersion: ""
 env:
   internalKortixEnv: dev

--- a/packages/sdk/src/react/use-session.test.ts
+++ b/packages/sdk/src/react/use-session.test.ts
@@ -42,7 +42,10 @@ import {
   classifySendError,
   sendStateOnStart,
   sendStateOnError,
+  shouldRetrySessionStart,
 } from './use-session';
+import { clearSessionFresh, markSessionFresh } from '../platform/fresh-sessions';
+import { SessionStartError } from '../platform/projects-client';
 
 function seedQuestion(id: string, sessionID = 'sess-1') {
   useOpenCodePendingStore.getState().addQuestion({
@@ -205,5 +208,41 @@ describe('send state transitions (sendStateOnStart / sendStateOnError)', () => {
     const restarted = sendStateOnStart('a new message');
     expect(restarted.sendError).toBeNull();
     expect(restarted.pending).toBe('a new message');
+  });
+});
+
+describe('shouldRetrySessionStart', () => {
+  const startError = (status: number) => new SessionStartError('nope', { status, terminal: true });
+
+  test('retries a 404 for a fresh session within the grace window, then gives up', () => {
+    markSessionFresh('fresh');
+    try {
+      expect(shouldRetrySessionStart(0, startError(404), 'fresh')).toBe(true);
+      expect(shouldRetrySessionStart(11, startError(404), 'fresh')).toBe(true);
+      expect(shouldRetrySessionStart(12, startError(404), 'fresh')).toBe(false);
+    } finally {
+      clearSessionFresh('fresh');
+    }
+  });
+
+  test('does NOT retry a 404 for a non-fresh session (genuinely missing / no access)', () => {
+    expect(shouldRetrySessionStart(0, startError(404), 'stale')).toBe(false);
+  });
+
+  test('does not retry other terminal start errors even when fresh', () => {
+    markSessionFresh('fresh');
+    try {
+      expect(shouldRetrySessionStart(0, startError(403), 'fresh')).toBe(false);
+      expect(shouldRetrySessionStart(0, startError(402), 'fresh')).toBe(false);
+    } finally {
+      clearSessionFresh('fresh');
+    }
+  });
+
+  test('retries a few times on transient (non-start) errors', () => {
+    const transient = new Error('network blip');
+    expect(shouldRetrySessionStart(0, transient, 'x')).toBe(true);
+    expect(shouldRetrySessionStart(2, transient, 'x')).toBe(true);
+    expect(shouldRetrySessionStart(3, transient, 'x')).toBe(false);
   });
 });

--- a/packages/sdk/src/react/use-session.ts
+++ b/packages/sdk/src/react/use-session.ts
@@ -36,6 +36,7 @@ import {
   sessionStartKey,
   startProjectSession,
 } from '../platform/projects-client';
+import { isSessionFresh } from '../platform/fresh-sessions';
 import { BillingError, parseBillingError } from '../platform/api/errors';
 import { formatOpenCodeRuntimeError } from '../platform/opencode-errors';
 import { useCanonicalOpenCodeSession } from './use-canonical-opencode-session';
@@ -60,6 +61,30 @@ import {
 
 /** Coarse session lifecycle for the host's top-level gating. */
 export type SessionPhase = 'starting' | 'ready' | 'error';
+
+// Grace window for the optimistic create-vs-start race: how long /start keeps
+// retrying a 404 for a freshly-minted session before treating it as terminal.
+// ~12 × 800ms ≈ 9.6s, comfortably past the sub-second create POST.
+const FRESH_START_404_RETRIES = 12;
+const FRESH_START_404_RETRY_DELAY_MS = 800;
+
+/**
+ * Whether the `/start` poll should retry. A 404 on a freshly-minted session is
+ * the optimistic create-vs-start race (the create POST hasn't landed yet), so
+ * retry it for the grace window; a 404 on any other (non-fresh) session is a
+ * genuinely-missing/no-access session and is terminal at once. Other terminal
+ * SessionStartErrors never retry; transient transport failures retry a few times.
+ */
+export function shouldRetrySessionStart(
+  failureCount: number,
+  error: unknown,
+  sessionId: string,
+): boolean {
+  if (isSessionStartError(error) && error.status === 404 && isSessionFresh(sessionId)) {
+    return failureCount < FRESH_START_404_RETRIES;
+  }
+  return !isSessionStartError(error) && failureCount < 3;
+}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Send-error classification. `send`/the reply actions below never throw for
@@ -253,7 +278,11 @@ export function useSession(
     queryKey: sessionStartKey(projectId, sessionId),
     queryFn: () => startProjectSession(projectId, sessionId, waitMs),
     enabled: enabled && !!projectId && !!sessionId,
-    retry: (failureCount, error) => !isSessionStartError(error) && failureCount < 3,
+    retry: (failureCount, error) => shouldRetrySessionStart(failureCount, error, sessionId),
+    retryDelay: (failureCount, error) =>
+      isSessionStartError(error) && error.status === 404
+        ? FRESH_START_404_RETRY_DELAY_MS
+        : Math.min(1000 * 2 ** failureCount, 5000),
     refetchInterval: (q) => {
       if (isSessionStartError(q.state.error)) return false;
       const stage = (q.state.data as SessionStartResult | null | undefined)?.stage;


### PR DESCRIPTION
Fifth sync of main into staging for the 0.9.98 candidate. Clean merge, no new migrations. Brings the create-vs-start race tolerance (#4256), instant session shell resilience (#4253), create-first new-session flow fix (#4259), and Google Drive-style colored folder tiles (#4254).