### PR TITLE
feat(web): account picker in the New Project modal

### DIFF
--- a/apps/web/scripts/e2e/project-create-modal-starter-smoke.ts
+++ b/apps/web/scripts/e2e/project-create-modal-starter-smoke.ts
@@ -11,8 +11,42 @@ type ProvisionPayload = {
 
 const baseUrl = process.env.E2E_BASE_URL || 'http://localhost:3300';
 
+const DEFAULT_ACCOUNT_ID = '00000000-0000-4000-a000-000000000101';
+const TEAM_ACCOUNT_ID = '00000000-0000-4000-a000-000000000202';
+
+const ACCOUNTS = [
+  {
+    account_id: DEFAULT_ACCOUNT_ID,
+    name: 'Personal',
+    slug: 'personal',
+    account_role: 'owner',
+    is_primary_owner: true,
+  },
+  {
+    account_id: TEAM_ACCOUNT_ID,
+    name: 'Acme Team',
+    slug: 'acme-team',
+    account_role: 'admin',
+    is_primary_owner: false,
+  },
+];
+
 function assert(condition: unknown, message: string): asserts condition {
   if (!condition) throw new Error(message);
+}
+
+async function mockAccounts(page: Page) {
+  await page.route(/\/accounts$/, async (route) => {
+    assert(
+      route.request().headers().authorization === 'Bearer debug-project-create-token',
+      'accounts request should include the debug bootstrap auth token',
+    );
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(ACCOUNTS),
+    });
+  });
 }
 
 async function openHarness(page: Page) {
@@ -156,7 +190,34 @@ async function main() {
     assert(optOutPayload.starter_template === 'minimal', 'opt-out payload should still use minimal starter_template');
     assert(JSON.stringify(optOutPayload.marketplace_items) === JSON.stringify([]), 'opt-out payload should omit starter pack skills');
 
-    console.log('[project-create-modal] ok: starter template and marketplace item payloads verified');
+    await mockAccounts(page);
+    await openHarness(page);
+    const accountField = page.getByTestId('project-create-account');
+    await accountField.waitFor({ state: 'visible', timeout: 30_000 });
+    assert(
+      (await accountField.textContent())?.includes('Personal'),
+      'account field should show the default account before switching',
+    );
+    const defaultAccountPayload = await submitProjectCreate(page, 'default-account-visible', false);
+    assert(
+      defaultAccountPayload.account_id === DEFAULT_ACCOUNT_ID,
+      'payload should target the displayed default account',
+    );
+
+    await openHarness(page);
+    await page.getByRole('button', { name: /personal/i }).click();
+    await page.getByRole('menuitem', { name: /acme team/i }).click();
+    assert(
+      (await page.getByTestId('project-create-account').textContent())?.includes('Acme Team'),
+      'account field should show the switched account',
+    );
+    const switchedPayload = await submitProjectCreate(page, 'switched-account', false);
+    assert(
+      switchedPayload.account_id === TEAM_ACCOUNT_ID,
+      'payload should target the account picked in the modal',
+    );
+
+    console.log('[project-create-modal] ok: starter template, marketplace item, and account picker payloads verified');
   } finally {
     await browser.close();
   }

--- a/apps/web/src/features/projects/modal/create-account-selection.test.ts
+++ b/apps/web/src/features/projects/modal/create-account-selection.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from 'bun:test';
+
+import type { KortixAccount } from '@kortix/sdk/projects-client';
+
+import { resolveCreateAccountSelection } from './create-account-selection';
+
+function account(overrides: Partial<KortixAccount> & { account_id: string }): KortixAccount {
+  return {
+    name: `Account ${overrides.account_id}`,
+    account_role: 'owner',
+    ...overrides,
+  };
+}
+
+const personal = account({ account_id: 'acc-personal', name: 'Personal' });
+const team = account({ account_id: 'acc-team', name: 'Acme Team', account_role: 'admin' });
+const readonly = account({ account_id: 'acc-readonly', name: 'Readonly', account_role: 'member' });
+
+describe('resolveCreateAccountSelection', () => {
+  test('defaults to the opener-provided account when nothing is picked', () => {
+    const selection = resolveCreateAccountSelection([personal, team], 'acc-personal', null);
+
+    expect(selection.effectiveAccountId).toBe('acc-personal');
+    expect(selection.currentAccount).toEqual(personal);
+    expect(selection.canSwitch).toBe(true);
+  });
+
+  test('an in-modal pick overrides the default account', () => {
+    const selection = resolveCreateAccountSelection([personal, team], 'acc-personal', 'acc-team');
+
+    expect(selection.effectiveAccountId).toBe('acc-team');
+    expect(selection.currentAccount).toEqual(team);
+  });
+
+  test('only owner and admin accounts are offered, sorted by name', () => {
+    const selection = resolveCreateAccountSelection(
+      [readonly, personal, team],
+      'acc-personal',
+      null,
+    );
+
+    expect(selection.options.map((item) => item.account_id)).toEqual(['acc-team', 'acc-personal']);
+  });
+
+  test('a pick that is no longer creatable falls back to the default', () => {
+    const selection = resolveCreateAccountSelection(
+      [personal, readonly],
+      'acc-personal',
+      'acc-readonly',
+    );
+
+    expect(selection.effectiveAccountId).toBe('acc-personal');
+    expect(selection.currentAccount).toEqual(personal);
+  });
+
+  test('degrades to the default id when the accounts list is unavailable', () => {
+    const selection = resolveCreateAccountSelection(undefined, 'acc-personal', 'acc-team');
+
+    expect(selection.effectiveAccountId).toBe('acc-personal');
+    expect(selection.currentAccount).toBeNull();
+    expect(selection.options).toEqual([]);
+    expect(selection.canSwitch).toBe(false);
+  });
+
+  test('a single creatable account shows the target without offering a switch', () => {
+    const selection = resolveCreateAccountSelection([personal, readonly], 'acc-personal', null);
+
+    expect(selection.currentAccount).toEqual(personal);
+    expect(selection.canSwitch).toBe(false);
+  });
+
+  test('a member-role default still resolves for display and allows switching away', () => {
+    const selection = resolveCreateAccountSelection([readonly, team], 'acc-readonly', null);
+
+    expect(selection.currentAccount).toEqual(readonly);
+    expect(selection.canSwitch).toBe(true);
+    expect(selection.options).toEqual([team]);
+  });
+});

--- a/apps/web/src/features/projects/modal/create-account-selection.ts
+++ b/apps/web/src/features/projects/modal/create-account-selection.ts
@@ -1,0 +1,38 @@
+import type { KortixAccount } from '@kortix/sdk/projects-client';
+
+export interface CreateAccountSelection {
+  /** Accounts the user may create projects in (owner/admin), sorted by name. */
+  options: KortixAccount[];
+  /** The account id the create/link mutations should target. */
+  effectiveAccountId: string | null;
+  /** The account to display as the creation target, when resolvable. */
+  currentAccount: KortixAccount | null;
+  /** True when there is at least one other account to switch to. */
+  canSwitch: boolean;
+}
+
+/** Resolves which account a new project will be created under: an explicit
+ *  in-modal pick wins (only while it remains a creatable account), otherwise
+ *  the account handed in by the opener. Degrades to the plain default id when
+ *  the accounts list is unavailable so the modal keeps working without it. */
+export function resolveCreateAccountSelection(
+  accounts: KortixAccount[] | undefined,
+  defaultAccountId: string | null,
+  pickedAccountId: string | null,
+): CreateAccountSelection {
+  const list = accounts ?? [];
+  const options = list
+    .filter((account) => account.account_role === 'owner' || account.account_role === 'admin')
+    .sort((a, b) => (a.name || '').localeCompare(b.name || ''));
+
+  const picked =
+    pickedAccountId && options.some((account) => account.account_id === pickedAccountId)
+      ? pickedAccountId
+      : null;
+  const effectiveAccountId = picked ?? defaultAccountId;
+  const currentAccount = list.find((account) => account.account_id === effectiveAccountId) ?? null;
+  const canSwitch =
+    currentAccount !== null && options.some((account) => account.account_id !== effectiveAccountId);
+
+  return { options, effectiveAccountId, currentAccount, canSwitch };
+}

--- a/apps/web/src/features/projects/modal/project-create-modal.tsx
+++ b/apps/web/src/features/projects/modal/project-create-modal.tsx
@@ -8,6 +8,14 @@ import { z } from 'zod';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { EntityAvatar } from '@/components/ui/entity-avatar';
 import { EmptyState } from '@/features/layout/section/empty-state';
 import {
   Form,
@@ -19,6 +27,7 @@ import {
 } from '@/components/ui/form';
 import { InlineMeta } from '@/components/ui/inline-meta';
 import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 import {
   Item,
   ItemActions,
@@ -49,18 +58,23 @@ import {
 } from '@/lib/marketplace-client';
 import {
   linkRepository,
+  listAccounts,
   listGitHubInstallations,
   listGitHubRepositories,
   listProjectsForAccount,
   provisionProject,
   type GitHubRepository,
+  type KortixAccount,
   type KortixProject,
 } from '@kortix/sdk/projects-client';
 import { cn } from '@/lib/utils';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { CheckCircleSolid } from '@mynaui/icons-react';
 import { Boxes, ChevronsUpDown, ExternalLink, Github } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { useEffect, useMemo, useState, type ReactNode } from 'react';
+
+import { resolveCreateAccountSelection } from './create-account-selection';
 
 const sanitizeProjectName = (value: string) => value.replace(/[^a-zA-Z0-9._ -]+/g, '').trim();
 
@@ -115,6 +129,19 @@ export const ProjectCreateModal = ({ open, onOpenChange, accountId }: ProjectCre
   const [mode, setMode] = useState<'managed' | 'github'>('managed');
   const [isConnectingGitHub, setIsConnectingGitHub] = useState(false);
   const [marketplaceDefaultsApplied, setMarketplaceDefaultsApplied] = useState(false);
+  const [pickedAccountId, setPickedAccountId] = useState<string | null>(null);
+
+  const accountsQuery = useQuery({
+    queryKey: ['accounts'],
+    queryFn: listAccounts,
+    staleTime: 60_000,
+    enabled: open,
+  });
+  const accountSelection = useMemo(
+    () => resolveCreateAccountSelection(accountsQuery.data, accountId, pickedAccountId),
+    [accountsQuery.data, accountId, pickedAccountId],
+  );
+  const effectiveAccountId = accountSelection.effectiveAccountId;
 
   const managedForm = useForm<ManagedProjectFormValues>({
     resolver: zodResolver(managedProjectSchema),
@@ -140,6 +167,7 @@ export const ProjectCreateModal = ({ open, onOpenChange, accountId }: ProjectCre
   function resetAndClose() {
     setMode('managed');
     setMarketplaceDefaultsApplied(false);
+    setPickedAccountId(null);
     managedForm.reset();
     githubForm.reset();
     onOpenChange(false);
@@ -173,9 +201,9 @@ export const ProjectCreateModal = ({ open, onOpenChange, accountId }: ProjectCre
       router.replace(`/projects/${project.project_id}`);
     },
     onError: async (error: Error) => {
-      if (accountId && isProjectLimitError(error)) {
+      if (effectiveAccountId && isProjectLimitError(error)) {
         try {
-          const existing = await listProjectsForAccount(accountId);
+          const existing = await listProjectsForAccount(effectiveAccountId);
           const project = existing[0];
           if (project) {
             resetAndClose();
@@ -191,9 +219,9 @@ export const ProjectCreateModal = ({ open, onOpenChange, accountId }: ProjectCre
   });
 
   const githubInstallationsQuery = useQuery({
-    queryKey: ['github-installations', accountId],
-    queryFn: () => listGitHubInstallations(accountId!),
-    enabled: open && mode === 'github' && !!accountId,
+    queryKey: ['github-installations', effectiveAccountId],
+    queryFn: () => listGitHubInstallations(effectiveAccountId!),
+    enabled: open && mode === 'github' && !!effectiveAccountId,
     staleTime: 0,
   });
 
@@ -230,9 +258,9 @@ export const ProjectCreateModal = ({ open, onOpenChange, accountId }: ProjectCre
     ) ?? null;
 
   const githubReposQuery = useQuery({
-    queryKey: ['github-repositories', accountId, selectedInstallationId],
-    queryFn: () => listGitHubRepositories(accountId!, selectedInstallationId),
-    enabled: open && mode === 'github' && !!accountId && !!selectedInstallationId,
+    queryKey: ['github-repositories', effectiveAccountId, selectedInstallationId],
+    queryFn: () => listGitHubRepositories(effectiveAccountId!, selectedInstallationId),
+    enabled: open && mode === 'github' && !!effectiveAccountId && !!selectedInstallationId,
     staleTime: 30_000,
   });
 
@@ -280,10 +308,10 @@ export const ProjectCreateModal = ({ open, onOpenChange, accountId }: ProjectCre
   });
 
   function handleCreate(values: ManagedProjectFormValues) {
-    if (!accountId) return errorToast('Select an account first');
+    if (!effectiveAccountId) return errorToast('Select an account first');
     const defaultMarketplaceItems = marketplaceItems.map((item) => item.id);
     createMutation.mutate({
-      account_id: accountId,
+      account_id: effectiveAccountId,
       name: values.name,
       starter_template: 'minimal',
       marketplace_items: values.includeGeneralKnowledgeSkills ? defaultMarketplaceItems : [],
@@ -291,10 +319,10 @@ export const ProjectCreateModal = ({ open, onOpenChange, accountId }: ProjectCre
   }
 
   function handleLinkGitHub(values: GitHubLinkFormValues) {
-    if (!accountId) return errorToast('Select an account first');
+    if (!effectiveAccountId) return errorToast('Select an account first');
     const trimmedName = values.name.trim();
     linkMutation.mutate({
-      account_id: accountId,
+      account_id: effectiveAccountId,
       installation_id: values.installationId,
       repo_full_name: values.repo,
       ...(trimmedName ? { name: trimmedName } : {}),
@@ -302,7 +330,7 @@ export const ProjectCreateModal = ({ open, onOpenChange, accountId }: ProjectCre
   }
 
   async function handleConnectGitHub() {
-    if (!accountId) {
+    if (!effectiveAccountId) {
       errorToast('Select an account first');
       return;
     }
@@ -349,6 +377,16 @@ export const ProjectCreateModal = ({ open, onOpenChange, accountId }: ProjectCre
             )}
           </ModalDescription> */}
         </ModalHeader>
+
+        {accountSelection.currentAccount ? (
+          <CreateAccountField
+            current={accountSelection.currentAccount}
+            options={accountSelection.options}
+            canSwitch={accountSelection.canSwitch}
+            disabled={submitting}
+            onSelect={setPickedAccountId}
+          />
+        ) : null}
 
         {mode === 'managed' ? (
           <Form {...managedForm}>
@@ -436,7 +474,7 @@ export const ProjectCreateModal = ({ open, onOpenChange, accountId }: ProjectCre
                   className="w-full sm:w-auto"
                   disabled={
                     submitting ||
-                    !accountId ||
+                    !effectiveAccountId ||
                     (includeGeneralKnowledgeSkills && marketplaceDefaultsQuery.isLoading)
                   }
                 >
@@ -675,7 +713,9 @@ export const ProjectCreateModal = ({ open, onOpenChange, accountId }: ProjectCre
                 </Button>
                 <Button
                   type="submit"
-                  disabled={submitting || !accountId || !selectedInstallationId || !selectedRepo}
+                  disabled={
+                    submitting || !effectiveAccountId || !selectedInstallationId || !selectedRepo
+                  }
                   className="w-full sm:w-auto"
                 >
                   {submitting ? <Loading /> : <Icon.Github />}
@@ -691,6 +731,80 @@ export const ProjectCreateModal = ({ open, onOpenChange, accountId }: ProjectCre
     </Modal>
   );
 };
+
+/** Shows which account the new project will be created under. Becomes a
+ *  dropdown when the user can create projects in more than one account;
+ *  otherwise it's a static read-only field so the target is still visible. */
+function CreateAccountField({
+  current,
+  options,
+  canSwitch,
+  disabled,
+  onSelect,
+}: {
+  current: KortixAccount;
+  options: KortixAccount[];
+  canSwitch: boolean;
+  disabled?: boolean;
+  onSelect: (accountId: string) => void;
+}) {
+  const label = current.name || 'Account';
+  const summary = (
+    <span className="flex min-w-0 items-center gap-2">
+      <EntityAvatar label={label} size="xs" />
+      <span className="text-foreground min-w-0 truncate text-sm font-medium">{label}</span>
+    </span>
+  );
+
+  return (
+    <div className="space-y-1.5" data-testid="project-create-account">
+      <Label>Account</Label>
+      {canSwitch ? (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              type="button"
+              variant="secondary-outline"
+              disabled={disabled}
+              className="w-full justify-between px-3"
+            >
+              {summary}
+              <ChevronsUpDown className="text-muted-foreground size-3.5 shrink-0" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent
+            align="start"
+            className="w-[var(--radix-dropdown-menu-trigger-width)]"
+          >
+            <DropdownMenuLabel className="text-muted-foreground">Create in</DropdownMenuLabel>
+            <div className="max-h-[280px] [scrollbar-width:none] overflow-y-auto [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden">
+              {options.map((account) => {
+                const itemLabel = account.name || 'Account';
+                const active = account.account_id === current.account_id;
+                return (
+                  <DropdownMenuItem
+                    key={account.account_id}
+                    onSelect={() => onSelect(account.account_id)}
+                  >
+                    <EntityAvatar label={itemLabel} size="xs" />
+                    <span className="min-w-0 flex-1 truncate text-sm leading-tight font-medium">
+                      {itemLabel}
+                    </span>
+                    {active && <CheckCircleSolid className="text-kortix-green size-3.5 shrink-0" />}
+                  </DropdownMenuItem>
+                );
+              })}
+            </div>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      ) : (
+        <div className="border-border bg-secondary flex h-9 w-full items-center rounded-md border px-3">
+          {summary}
+        </div>
+      )}
+    </div>
+  );
+}
 
 /** One selectable row in the New Project "Starter skills" surface — the whole
  *  row is a label wrapping a real checkbox, so a click anywhere toggles it and


### PR DESCRIPTION
## What

The New Project modal now shows which account the project will be created under, with an inline dropdown to switch it — previously the target account was invisible and fixed by the opener.

- New shared **Account** field above both modes (managed + GitHub import): EntityAvatar + name, dropdown listing owner/admin accounts (account-switcher pattern, active row checked). When only one creatable account exists it renders as a static read-only field so the target stays visible.
- The picked account drives everything account-scoped in the modal: `provisionProject` payload, GitHub installation/repository queries (re-keyed so switching mid-modal refetches), `linkRepository`, and the project-limit fallback lookup.
- Selection resolution extracted to a pure helper `create-account-selection.ts`; degrades gracefully to the opener-provided `accountId` when the accounts list is unavailable (keeps the debug harness and any accounts-fetch failure working exactly as before).
- Pick resets on close; a pick that stops being creatable (role change on refetch) falls back to the default.

## Tests

- `create-account-selection.test.ts` — 7 unit tests (default/pick/override, owner+admin filtering & sort, stale-pick fallback, missing-list degradation, single-account no-switch, member-role default display).
- Extended `project-create-modal-starter-smoke.ts` with mocked `/accounts`: asserts the field shows the default account, and that switching to another account changes the `account_id` sent to `/projects/provision`. Ran green locally against the worktree web app; existing no-accounts scenarios still pass (picker hidden, old payload assertions unchanged).
- `tsc` clean (only the pre-existing generated `@/.source` error); new files biome-clean; remaining lint findings in touched files pre-exist on main.

Server-side `resolveProjectAccount` membership validation remains the trust boundary — the picker is UX only.