### PR TITLE
revert: undo daytona→managed provider-identity rename (identity stays daytona)

### DIFF
--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -12,20 +12,7 @@ export const SANDBOX_VERSION = process.env.SANDBOX_VERSION || 'unknown';
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
-// 'managed' is the canonical name for the managed cloud backend; 'daytona' is a
-// permanent legacy alias for the SAME backend (kept so existing DB rows / any
-// external caller sending 'daytona' never break). New writes use 'managed'.
-export type SandboxProviderName = 'managed' | 'daytona' | 'platinum';
-
-/** True for either the canonical 'managed' name or its legacy 'daytona' alias. */
-export function isManagedProviderName(p: string | null | undefined): boolean {
-  return p === 'managed' || p === 'daytona';
-}
-
-/** Canonicalise a provider string: legacy 'daytona' → 'managed'; others pass through. */
-export function normalizeProviderName<T extends string>(p: T): T | 'managed' {
-  return p === 'daytona' ? 'managed' : p;
-}
+export type SandboxProviderName = 'daytona' | 'platinum';
 type InternalKortixEnv = 'dev' | 'staging' | 'prod' | 'preview';
 
 // ─── Zod Helpers ────────────────────────────────────────────────────────────
@@ -322,7 +309,7 @@ const envSchema = z.object({
   // ── Sandbox Platform ──────────────────────────────────────────────────────
   // Public API base URL, without a route suffix. Auto-derived from PORT in local mode.
   KORTIX_URL:                  optStr,
-  ALLOWED_SANDBOX_PROVIDERS:   optStrDefault('managed'),
+  ALLOWED_SANDBOX_PROVIDERS:   optStrDefault('daytona'),
   SANDBOX_IMAGE:               optStr,
   KORTIX_LOCAL_IMAGES:         optBoolFalse,
   SANDBOX_NETWORK:             optStr,
@@ -422,14 +409,12 @@ type EnvIssue = { var: string; message: string; level: 'error' | 'warn' };
 // Recognised provider names. Source-of-truth for what can legally appear in
 // ALLOWED_SANDBOX_PROVIDERS — adding a new provider is a one-place change
 // here plus a case in `getProvider()` in platform/providers/index.ts.
-// 'managed' is canonical; 'daytona' still parses (normalised to 'managed') so an
-// existing ALLOWED_SANDBOX_PROVIDERS=daytona env keeps working unchanged.
-const KNOWN_PROVIDERS: readonly SandboxProviderName[] = ['managed', 'platinum'] as const;
+const KNOWN_PROVIDERS: readonly SandboxProviderName[] = ['daytona', 'platinum'] as const;
 
-/** Parse comma-separated provider list (e.g. "managed,platinum"). */
+/** Parse comma-separated provider list (e.g. "daytona,platinum"). */
 function parseAllowedProviders(raw: string): SandboxProviderName[] {
-  if (!raw) return ['managed'];
-  const names = raw.split(',').map((s) => normalizeProviderName(s.trim().toLowerCase())).filter(Boolean);
+  if (!raw) return ['daytona'];
+  const names = raw.split(',').map((s) => s.trim().toLowerCase()).filter(Boolean);
   const valid: SandboxProviderName[] = [];
   for (const n of names) {
     if ((KNOWN_PROVIDERS as readonly string[]).includes(n)) {
@@ -439,7 +424,7 @@ function parseAllowedProviders(raw: string): SandboxProviderName[] {
       console.warn(`[config] Unknown sandbox provider "${n}" in ALLOWED_SANDBOX_PROVIDERS - ignored`);
     }
   }
-  return valid.length > 0 ? valid : ['managed'];
+  return valid.length > 0 ? valid : ['daytona'];
 }
 
 function validateEnv(): z.infer<typeof envSchema> {
@@ -460,7 +445,7 @@ function validateEnv(): z.infer<typeof envSchema> {
 
   // ── Conditional: Daytona provider enabled → need Daytona keys ──────────
   const providers = parseAllowedProviders((raw as any).ALLOWED_SANDBOX_PROVIDERS || '');
-  if (providers.includes('managed')) {
+  if (providers.includes('daytona')) {
     if (!raw.DAYTONA_API_KEY)    issues.push({ var: 'DAYTONA_API_KEY',    message: 'Required when ALLOWED_SANDBOX_PROVIDERS includes "daytona"', level: 'error' });
     if (!raw.DAYTONA_SERVER_URL) issues.push({ var: 'DAYTONA_SERVER_URL', message: 'Required when ALLOWED_SANDBOX_PROVIDERS includes "daytona"', level: 'error' });
     if (!raw.DAYTONA_TARGET)     issues.push({ var: 'DAYTONA_TARGET',     message: 'Required when ALLOWED_SANDBOX_PROVIDERS includes "daytona"', level: 'error' });
@@ -791,14 +776,12 @@ export const config = {
   // ─── Helper Methods ────────────────────────────────────────────────────────
 
   isProviderEnabled(name: SandboxProviderName): boolean {
-    const canonical = normalizeProviderName(name);
-    if (!this.ALLOWED_SANDBOX_PROVIDERS.includes(canonical)) return false;
-    switch (canonical) {
-      case 'managed':
+    if (!this.ALLOWED_SANDBOX_PROVIDERS.includes(name)) return false;
+    switch (name) {
       case 'daytona': return !!this.DAYTONA_API_KEY;
       case 'platinum': return !!this.PLATINUM_API_KEY;
       default: {
-        const exhaustive: never = canonical;
+        const exhaustive: never = name;
         return exhaustive;
       }
     }
@@ -806,23 +789,17 @@ export const config = {
 
   /**
    * Default sandbox provider for new sessions. First entry of
-   * ALLOWED_SANDBOX_PROVIDERS, with 'managed' as the safety belt for an
+   * ALLOWED_SANDBOX_PROVIDERS, with 'daytona' as the safety belt for an
    * empty list. The single-provider invariant means there's no resolution
    * order today, but the function is the contract callers depend on —
    * adding a new provider later just changes what the list can contain.
    */
   getDefaultProvider(): SandboxProviderName {
-    return this.ALLOWED_SANDBOX_PROVIDERS[0] ?? 'managed';
+    return this.ALLOWED_SANDBOX_PROVIDERS[0] ?? 'daytona';
   },
 
-  /** True when the managed cloud backend (canonical 'managed' / legacy 'daytona') is enabled. */
-  isManagedEnabled(): boolean {
-    return this.ALLOWED_SANDBOX_PROVIDERS.some(isManagedProviderName) && !!this.DAYTONA_API_KEY;
-  },
-
-  /** @deprecated use isManagedEnabled — kept for callers still on the old name. */
   isDaytonaEnabled(): boolean {
-    return this.isManagedEnabled();
+    return this.ALLOWED_SANDBOX_PROVIDERS.includes('daytona') && !!this.DAYTONA_API_KEY;
   },
 
   isPlatinumEnabled(): boolean {

--- a/apps/api/src/platform/providers/index.ts
+++ b/apps/api/src/platform/providers/index.ts
@@ -11,8 +11,10 @@ import { PlatinumProvider } from './platinum';
  *   - daytona — managed cloud (Daytona)
  *   - platinum — managed cloud (Platinum)
  */
-// 'managed' is canonical for the managed cloud backend; 'daytona' is its legacy alias.
-export type ProviderName = 'managed' | 'daytona' | 'platinum';
+// 'daytona' is the managed cloud backend's identity. 'managed' is kept only as a
+// defensive read alias so any row written during the daytona→managed rename window
+// still resolves to the Daytona adapter; new writes use 'daytona'.
+export type ProviderName = 'daytona' | 'managed' | 'platinum';
 
 /**
  * Thrown by the Daytona warm path when the experimental memory-snapshot restore
@@ -140,10 +142,10 @@ export function getProvider(name: ProviderName): SandboxProvider {
   let provider: SandboxProvider;
 
   switch (name) {
-    case 'managed':
     case 'daytona':
+    case 'managed':
       if (!config.DAYTONA_API_KEY) {
-        throw new Error('Managed provider requires DAYTONA_API_KEY to be set.');
+        throw new Error('Daytona provider requires DAYTONA_API_KEY to be set.');
       }
       provider = new DaytonaProvider();
       break;

--- a/apps/api/src/projects/legacy-migration-steps.ts
+++ b/apps/api/src/projects/legacy-migration-steps.ts
@@ -419,7 +419,7 @@ export async function dbStep(ctx: MigrationContext): Promise<void> {
         projectId: plan.project_id,
         branchName: spec.branchName,
         baseRef: defaultBranch,
-        sandboxProvider: 'managed',
+        sandboxProvider: 'daytona',
         sandboxId: null,
         sandboxUrl: null,
         opencodeSessionId: spec.opencodeSessionId,

--- a/apps/api/src/projects/lib/sessions.provider.test.ts
+++ b/apps/api/src/projects/lib/sessions.provider.test.ts
@@ -1,23 +1,17 @@
 import { test, expect, describe } from 'bun:test';
 import { resolveSessionProvider, warmPrebakeProviders } from './provider-precedence';
 
-// Mirrors config.normalizeProviderName (legacy 'daytona' → canonical 'managed').
-// Inlined so this stays a zero-dep pure test — importing config.ts would drag in
-// zod + full env validation and break the "no env/DB" isolation this file relies on.
-const norm = (p: string | null) => (p === 'daytona' ? 'managed' : p);
-
 // Per-project sandbox-provider override — precedence unit test. Deterministic:
 // `allowed` + `isEnabled` are injected (they model config.ALLOWED_SANDBOX_PROVIDERS
 // + config.isProviderEnabled), so no env/DB. Precedence under test:
 //   explicit request › per-project pin (if enabled) › fallback (weighted balancer).
-// Post-rename ALLOWED holds the canonical 'managed' (legacy 'daytona' → 'managed').
-const ALLOWED = ['managed', 'platinum'] as const;
+const ALLOWED = ['daytona', 'platinum'] as const;
 const bothEnabled = (_p: string) => true;
 
 describe('resolveSessionProvider (per-project provider override)', () => {
   test('explicit request wins over the pin + is used verbatim', () => {
     expect(
-      resolveSessionProvider({ requested: 'platinum', projectPin: 'managed', allowed: ALLOWED, isEnabled: bothEnabled }),
+      resolveSessionProvider({ requested: 'platinum', projectPin: 'daytona', allowed: ALLOWED, isEnabled: bothEnabled }),
     ).toEqual({ provider: 'platinum' });
   });
 
@@ -65,53 +59,16 @@ describe('resolveSessionProvider (per-project provider override)', () => {
   });
 });
 
-// Provider rename back-compat (regression for the missed session-create call site
-// from PR #4201). createProjectSession runs body.provider / the project pin through
-// normalizeProviderName() BEFORE resolveSessionProvider — so the legacy 'daytona'
-// alias resolves to canonical 'managed' against ALLOWED=['managed','platinum']
-// instead of 400 "Unknown or disabled sandbox provider: daytona".
-describe('legacy daytona→managed normalization at session-create', () => {
-  test("explicit provider:'daytona' → managed (no longer a 400)", () => {
-    expect(
-      resolveSessionProvider({ requested: norm('daytona'), projectPin: null, allowed: ALLOWED, isEnabled: bothEnabled }),
-    ).toEqual({ provider: 'managed' });
-  });
-
-  test("explicit provider:'managed' → managed (canonical unaffected)", () => {
-    expect(
-      resolveSessionProvider({ requested: norm('managed'), projectPin: null, allowed: ALLOWED, isEnabled: bothEnabled }),
-    ).toEqual({ provider: 'managed' });
-  });
-
-  test("explicit provider:'platinum' → platinum (other provider unaffected)", () => {
-    expect(
-      resolveSessionProvider({ requested: norm('platinum'), projectPin: null, allowed: ALLOWED, isEnabled: bothEnabled }),
-    ).toEqual({ provider: 'platinum' });
-  });
-
-  test("legacy 'daytona' project pin → managed (used when enabled)", () => {
-    expect(
-      resolveSessionProvider({ requested: null, projectPin: norm('daytona'), allowed: ALLOWED, isEnabled: bothEnabled }),
-    ).toEqual({ provider: 'managed' });
-  });
-
-  test('no request + no pin still falls through unaffected', () => {
-    expect(
-      resolveSessionProvider({ requested: norm(null), projectPin: norm(null), allowed: ALLOWED, isEnabled: bothEnabled }),
-    ).toEqual({ fallback: true });
-  });
-});
-
 // Build-on-push warm-prebake target selection. A git push carries no per-session
 // context, so it must warm the provider(s) a session on this project COULD land
 // on: an enabled pin ⇒ that one; no/stale pin ⇒ every enabled provider. This is
 // the parity fix — an unpinned project (or one that never used to warm Platinum)
 // now pre-warms BOTH backends, while a pinned project warms only what it uses.
 describe('warmPrebakeProviders (build-on-push provider parity)', () => {
-  test('no pin → EVERY enabled provider (managed + platinum) — full parity', () => {
+  test('no pin → EVERY enabled provider (daytona + platinum) — full parity', () => {
     expect(
       warmPrebakeProviders({ projectPin: null, allowed: ALLOWED, isEnabled: bothEnabled }),
-    ).toEqual(['managed', 'platinum']);
+    ).toEqual(['daytona', 'platinum']);
   });
 
   test('enabled pin → ONLY that provider (no wasted bake on the one it never uses)', () => {
@@ -119,27 +76,27 @@ describe('warmPrebakeProviders (build-on-push provider parity)', () => {
       warmPrebakeProviders({ projectPin: 'platinum', allowed: ALLOWED, isEnabled: bothEnabled }),
     ).toEqual(['platinum']);
     expect(
-      warmPrebakeProviders({ projectPin: 'managed', allowed: ALLOWED, isEnabled: bothEnabled }),
-    ).toEqual(['managed']);
+      warmPrebakeProviders({ projectPin: 'daytona', allowed: ALLOWED, isEnabled: bothEnabled }),
+    ).toEqual(['daytona']);
   });
 
-  test('Daytona pre-warm is NEVER dropped — managed is warmed with no pin and when pinned', () => {
-    // Regression guard for the task invariant: the working Daytona/managed
-    // pre-warm keeps firing. Both the no-pin (all-enabled) path and the
-    // managed-pinned path include 'managed'.
-    expect(warmPrebakeProviders({ projectPin: null, allowed: ALLOWED, isEnabled: bothEnabled })).toContain('managed');
-    expect(warmPrebakeProviders({ projectPin: 'managed', allowed: ALLOWED, isEnabled: bothEnabled })).toContain('managed');
+  test('Daytona pre-warm is NEVER dropped — daytona is warmed with no pin and when pinned', () => {
+    // Regression guard for the task invariant: the working Daytona pre-warm keeps
+    // firing. Both the no-pin (all-enabled) path and the daytona-pinned path
+    // include 'daytona'.
+    expect(warmPrebakeProviders({ projectPin: null, allowed: ALLOWED, isEnabled: bothEnabled })).toContain('daytona');
+    expect(warmPrebakeProviders({ projectPin: 'daytona', allowed: ALLOWED, isEnabled: bothEnabled })).toContain('daytona');
   });
 
   test('stale/disabled/absent pin degrades to all-enabled (never bakes a provider that cannot run)', () => {
-    // pin platinum but platinum is keyless → not [platinum]; warm only managed.
+    // pin platinum but platinum is keyless → not [platinum]; warm only daytona.
     expect(
-      warmPrebakeProviders({ projectPin: 'platinum', allowed: ALLOWED, isEnabled: (p) => p === 'managed' }),
-    ).toEqual(['managed']);
+      warmPrebakeProviders({ projectPin: 'platinum', allowed: ALLOWED, isEnabled: (p) => p === 'daytona' }),
+    ).toEqual(['daytona']);
     // pin a provider that has since left ALLOWED → all-enabled.
     expect(
       warmPrebakeProviders({ projectPin: 'gcp', allowed: ALLOWED, isEnabled: bothEnabled }),
-    ).toEqual(['managed', 'platinum']);
+    ).toEqual(['daytona', 'platinum']);
   });
 
   test('single-provider deploy → exactly that one (platinum-only)', () => {
@@ -150,7 +107,7 @@ describe('warmPrebakeProviders (build-on-push provider parity)', () => {
 
   test('only enabled providers are warmed — a listed-but-keyless provider is skipped', () => {
     expect(
-      warmPrebakeProviders({ projectPin: null, allowed: ALLOWED, isEnabled: (p) => p === 'managed' }),
-    ).toEqual(['managed']);
+      warmPrebakeProviders({ projectPin: null, allowed: ALLOWED, isEnabled: (p) => p === 'daytona' }),
+    ).toEqual(['daytona']);
   });
 });

--- a/apps/api/src/projects/lib/sessions.ts
+++ b/apps/api/src/projects/lib/sessions.ts
@@ -1,5 +1,5 @@
 import { checkBillingActive } from '../../billing/services/billing-gate';
-import { config, normalizeProviderName, type SandboxProviderName } from '../../config';
+import { config, type SandboxProviderName } from '../../config';
 import { resolveSessionProvider } from './provider-precedence';
 import { auth, json } from '../../openapi';
 import { resolveAccountSessionLimit } from '../../shared/account-limits';
@@ -446,16 +446,12 @@ export async function createProjectSession(input: {
   // Sandbox provider: explicit request › per-project pin (Customize → Settings) ›
   // weighted balancer. The pin lets you put ONE project on e.g. platinum regardless
   // of the global distribution weights — see resolveSessionProvider.
-  // Canonicalise the legacy 'daytona' alias → 'managed' BEFORE the allowed/enabled
-  // check (matches parseAllowedProviders/isProviderEnabled) so an explicit
-  // provider:'daytona' from any client (Kortix server, legacy SDK) keeps working.
-  const requestedProvider = normalizeString(body.provider);
-  const providerPin = normalizeString(
-    (project.metadata as Record<string, unknown> | null | undefined)?.default_sandbox_provider,
-  );
   const picked = resolveSessionProvider({
-    requested: requestedProvider ? normalizeProviderName(requestedProvider) : null,
-    projectPin: providerPin ? normalizeProviderName(providerPin) : null,
+    requested: normalizeString(body.provider) ?? null,
+    projectPin:
+      normalizeString(
+        (project.metadata as Record<string, unknown> | null | undefined)?.default_sandbox_provider,
+      ) ?? null,
     allowed: config.ALLOWED_SANDBOX_PROVIDERS,
     isEnabled: (p) => config.isProviderEnabled(p as SandboxProviderName),
   });

--- a/apps/api/src/projects/suna-migration/suna-migration-phases.ts
+++ b/apps/api/src/projects/suna-migration/suna-migration-phases.ts
@@ -188,7 +188,7 @@ export async function dbStep(ctx: SunaMigrationContext): Promise<void> {
     for (const s of specs) {
       await tx.insert(projectSessions).values({
         sessionId: crypto.randomUUID(), accountId: ctx.accountId, projectId,
-        branchName: s.slug, baseRef: defaultBranch, sandboxProvider: 'managed',
+        branchName: s.slug, baseRef: defaultBranch, sandboxProvider: 'daytona',
         sandboxId: null, sandboxUrl: null, opencodeSessionId: s.opencodeSessionId,
         agentName: 'default', status: 'stopped', createdBy: ctx.accountId, visibility: 'project',
         metadata: {

--- a/apps/api/src/setup/index.ts
+++ b/apps/api/src/setup/index.ts
@@ -209,12 +209,12 @@ setupApp.openapi(
 
   // Provider capabilities — tells the frontend how to handle provisioning UI
   const capabilities: Record<string, { async: boolean; events: boolean; polling: boolean }> = {
-    managed: { async: false, events: false, polling: false },
+    daytona: { async: false, events: false, polling: false },
   };
 
   return c.json({
     providers: available,
-    default: available.includes(config.getDefaultProvider()) ? config.getDefaultProvider() : (available[0] || 'managed'),
+    default: available.includes(config.getDefaultProvider()) ? config.getDefaultProvider() : (available[0] || 'daytona'),
     capabilities: Object.fromEntries(available.map((p) => [p, capabilities[p] || { async: false, events: false, polling: false }])),
   });
   },
@@ -371,7 +371,7 @@ setupApp.openapi(
   // DAYTONA_API_KEY. We don't ping Daytona here on purpose: that's a
   // latency-sensitive UI call and Daytona's auth-check endpoint is
   // their billing concern, not ours.
-  checks.managed = config.DAYTONA_API_KEY
+  checks.daytona = config.DAYTONA_API_KEY
     ? { ok: true }
     : { ok: false, error: 'DAYTONA_API_KEY not configured' };
   return c.json(checks);

--- a/apps/api/src/snapshots/builder.ts
+++ b/apps/api/src/snapshots/builder.ts
@@ -18,7 +18,7 @@ import { projectSnapshotBuilds } from '@kortix/db';
 import { db } from '../shared/db';
 import { resolveCommitSha, type GitBackedProject } from '../projects/git';
 import { getSandboxProvider, type ProviderState, type SandboxProviderAdapter } from './providers';
-import { config, normalizeProviderName, type SandboxProviderName } from '../config';
+import { config, type SandboxProviderName } from '../config';
 import { warmPrebakeProviders } from '../projects/lib/provider-precedence';
 import { perProjectWarmImageName, ppwarmReapTargets } from './ppwarm-names';
 import {
@@ -744,11 +744,10 @@ export async function kickProjectWarmPrebake(
   const providers = opts.provider
     ? [opts.provider]
     : warmPrebakeProviders({
-        // Canonicalise the stored pin (legacy 'daytona' → 'managed') so it matches
-        // ALLOWED_SANDBOX_PROVIDERS — exactly what session creation does before it
-        // routes on the pin. Without this a legacy-pinned project would fall through
-        // to the all-enabled branch (harmless, but not true parity).
-        projectPin: opts.projectPin ? normalizeProviderName(opts.projectPin) : null,
+        // Pre-warm the provider(s) a session on this project could land on —
+        // exactly what session creation resolves from the pin (an enabled pin ⇒
+        // that provider; no/stale pin ⇒ every enabled provider).
+        projectPin: opts.projectPin ?? null,
         allowed: config.ALLOWED_SANDBOX_PROVIDERS,
         isEnabled: (p) => config.isProviderEnabled(p as SandboxProviderName),
       });

--- a/apps/api/src/snapshots/providers/index.ts
+++ b/apps/api/src/snapshots/providers/index.ts
@@ -88,9 +88,10 @@ export interface SandboxProviderAdapter {
 }
 
 const ADAPTERS = new Map<string, SandboxProviderAdapter>();
-// The managed cloud backend is registered under BOTH its canonical name
-// ('managed') and its legacy alias ('daytona' = daytonaProvider.id), so template
-// rows / sessions holding either value resolve to the same adapter.
+// The managed cloud backend's identity is 'daytona' (daytonaProvider.id). It's
+// ALSO registered under 'managed' purely as a defensive read alias, so any row
+// written 'managed' during the daytona→managed rename window still resolves to
+// the same adapter. New writes use 'daytona'.
 ADAPTERS.set('managed', daytonaProvider);
 ADAPTERS.set(daytonaProvider.id, daytonaProvider);
 ADAPTERS.set(platinumProvider.id, platinumProvider);

--- a/apps/api/src/snapshots/templates.ts
+++ b/apps/api/src/snapshots/templates.ts
@@ -326,7 +326,7 @@ export async function createTemplate(input: CreateTemplateInput): Promise<DbSand
       name: input.name || input.slug,
       isShared: false,
       source: input.source ?? 'ui',
-      provider: 'managed',
+      provider: 'daytona',
       image: input.image ?? null,
       dockerfilePath: input.dockerfilePath ?? null,
       entrypoint: input.entrypoint ?? null,
@@ -537,7 +537,7 @@ export async function recordTemplateBuilt(
   // lazy, pressure-gated GC eventually notices.
   const oldName = prev?.providerSnapshotName ?? null;
   if (oldName && oldName !== args.snapshotName) {
-    await reapPredecessorSnapshot(templateId, oldName, args.provider ?? prev?.provider ?? 'managed');
+    await reapPredecessorSnapshot(templateId, oldName, args.provider ?? prev?.provider ?? 'daytona');
   }
 }
 
@@ -611,7 +611,7 @@ function synthesizedDefault(): ResolvedTemplate {
     name: tpl.name ?? 'Default',
     isShared: true,
     source: 'platform',
-    provider: 'managed',
+    provider: 'daytona',
     image: null,
     dockerfilePath: null,
     entrypoint: null,
@@ -634,7 +634,7 @@ function rowToResolved(row: DbSandboxTemplate): ResolvedTemplate {
     name: row.name,
     isShared: row.isShared,
     source: (row.source as ResolvedTemplate['source']) ?? 'toml',
-    provider: row.provider ?? 'managed',
+    provider: row.provider ?? 'daytona',
     image: row.image,
     dockerfilePath: row.dockerfilePath,
     entrypoint: row.entrypoint,
@@ -668,7 +668,7 @@ async function syncTomlTemplatesForProject(project: GitBackedProject): Promise<v
           name: tpl.name ?? tpl.slug,
           isShared: false,
           source: 'toml',
-          provider: 'managed',
+          provider: 'daytona',
           image: tpl.image ?? null,
           dockerfilePath: tpl.dockerfile ?? null,
           entrypoint: null,

--- a/apps/web/src/components/admin/admin-dashboard-sections.tsx
+++ b/apps/web/src/components/admin/admin-dashboard-sections.tsx
@@ -287,7 +287,7 @@ export function AdminInstancesSection({ embedded = false }: { embedded?: boolean
                 )}
               </SelectItem>
               <SelectItem value="justavps">JustAVPS</SelectItem>
-              <SelectItem value="managed">Managed</SelectItem>
+              <SelectItem value="daytona">Daytona</SelectItem>
             </SelectContent>
           </Select>
           <Button

--- a/packages/api-contract/src/index.ts
+++ b/packages/api-contract/src/index.ts
@@ -76,10 +76,8 @@ export const PROJECT_ROLES = ['manager', 'editor', 'member'] as const;
 export const ProjectRoleSchema = z.enum(PROJECT_ROLES);
 export type ProjectRole = z.infer<typeof ProjectRoleSchema>;
 
-/** Every provider that can appear on session/sandbox rows. 'managed' is the
- *  canonical name for the managed cloud backend; 'daytona' is its legacy alias,
- *  kept so existing rows / callers stay valid. */
-export const SANDBOX_PROVIDERS = ['managed', 'daytona', 'local_docker', 'justavps', 'platinum'] as const;
+/** Every provider that can appear on session/sandbox rows. */
+export const SANDBOX_PROVIDERS = ['daytona', 'local_docker', 'justavps', 'platinum'] as const;
 export const SandboxProviderSchema = z.enum(SANDBOX_PROVIDERS);
 export type SandboxProvider = z.infer<typeof SandboxProviderSchema>;
 

--- a/packages/api-contract/src/index.ts
+++ b/packages/api-contract/src/index.ts
@@ -76,8 +76,13 @@ export const PROJECT_ROLES = ['manager', 'editor', 'member'] as const;
 export const ProjectRoleSchema = z.enum(PROJECT_ROLES);
 export type ProjectRole = z.infer<typeof ProjectRoleSchema>;
 
-/** Every provider that can appear on session/sandbox rows. */
-export const SANDBOX_PROVIDERS = ['daytona', 'local_docker', 'justavps', 'platinum'] as const;
+/** Every provider that can appear on session/sandbox rows. 'daytona' is the
+ *  managed cloud backend's identity (default / first-class); 'managed' is kept as
+ *  an accepted value only because the DB sandbox_provider enum still carries it
+ *  (from the reverted daytona→managed rename) — a DB-derived provider can read
+ *  back 'managed', and the dual-accept guards resolve it to the Daytona adapter.
+ *  Nothing DEFAULTS to or normalizes toward 'managed'. */
+export const SANDBOX_PROVIDERS = ['daytona', 'managed', 'local_docker', 'justavps', 'platinum'] as const;
 export const SandboxProviderSchema = z.enum(SANDBOX_PROVIDERS);
 export type SandboxProvider = z.infer<typeof SandboxProviderSchema>;
 

--- a/packages/db/src/schema/kortix.test.ts
+++ b/packages/db/src/schema/kortix.test.ts
@@ -308,9 +308,9 @@ describe('sandboxes table', () => {
     expect(primaryColumn(sandboxes)).toBe('sandbox_id');
   });
 
-  test('provider defaults to managed', () => {
+  test('provider defaults to daytona', () => {
     const col = getTableConfig(sandboxes).columns.find((c) => c.name === 'provider');
-    expect(col?.default).toBe('managed');
+    expect(col?.default).toBe('daytona');
   });
 
   test('status defaults to provisioning', () => {

--- a/packages/db/src/schema/kortix.ts
+++ b/packages/db/src/schema/kortix.ts
@@ -27,10 +27,10 @@ export const sandboxStatusEnum = kortixSchema.enum('sandbox_status', [
 ]);
 
 export const sandboxProviderEnum = kortixSchema.enum('sandbox_provider', [
-  // 'managed' is the canonical name for the managed cloud backend. 'daytona' is
-  // the legacy alias for the SAME backend, kept valid forever so existing rows
-  // and any external caller still sending 'daytona' never break. New rows write
-  // 'managed'; read paths accept both (config.isManagedProviderName).
+  // 'daytona' is the managed cloud backend's identity — new rows write 'daytona'.
+  // 'managed' remains a valid enum value only because the ADD VALUE migration that
+  // introduced it can't be dropped in Postgres; it's a harmless defensive leftover
+  // from the reverted daytona→managed rename (read paths still accept it).
   'managed',
   'daytona',
   'local_docker',
@@ -539,7 +539,7 @@ export const projectSessions = kortixSchema.table(
       .references(() => projects.projectId, { onDelete: 'cascade' }),
     branchName: text('branch_name').notNull(),
     baseRef: text('base_ref').default('main').notNull(),
-    sandboxProvider: sandboxProviderEnum('sandbox_provider').default('managed').notNull(),
+    sandboxProvider: sandboxProviderEnum('sandbox_provider').default('daytona').notNull(),
     sandboxId: text('sandbox_id'),
     sandboxUrl: text('sandbox_url'),
     opencodeSessionId: text('opencode_session_id'),
@@ -986,7 +986,7 @@ export const sessionSandboxes = kortixSchema.table(
     sessionId: text('session_id').notNull().unique(),
     accountId: uuid('account_id').notNull(),
     projectId: uuid('project_id').notNull(),
-    provider: sandboxProviderEnum('provider').default('managed').notNull(),
+    provider: sandboxProviderEnum('provider').default('daytona').notNull(),
     externalId: text('external_id'),
     baseUrl: text('base_url'),
     status: sessionSandboxStatusEnum('status').default('provisioning').notNull(),
@@ -1081,7 +1081,7 @@ export const sandboxTemplates = kortixSchema.table(
     /** Where the template came from: 'platform' | 'toml' | 'ui'. */
     source: text('source').default('toml').notNull(),
     /** 'daytona' (others to follow). */
-    provider: text('provider').default('managed').notNull(),
+    provider: text('provider').default('daytona').notNull(),
 
     // ─── Image definition (exactly one of image / dockerfilePath) ──────────
     /** Public Docker image reference (e.g. python:3.12-slim). */
@@ -1178,7 +1178,7 @@ export const sandboxes = kortixSchema.table(
     sandboxId: uuid('sandbox_id').defaultRandom().primaryKey(),
     accountId: uuid('account_id').notNull(),
     name: varchar('name', { length: 255 }).notNull(),
-    provider: sandboxProviderEnum('provider').default('managed').notNull(),
+    provider: sandboxProviderEnum('provider').default('daytona').notNull(),
     externalId: text('external_id'),
     status: sandboxStatusEnum('status').default('provisioning').notNull(),
     baseUrl: text('base_url').notNull(),

--- a/packages/sdk/src/platform/platform-client/lifecycle.test.ts
+++ b/packages/sdk/src/platform/platform-client/lifecycle.test.ts
@@ -181,9 +181,9 @@ function wireNoProjects() {
 
 // ─── getProviders ────────────────────────────────────────────────────────────
 
-test('getProviders is pure — no network, always managed', async () => {
+test('getProviders is pure — no network, always daytona', async () => {
   const result = await getProviders();
-  expect(result).toEqual({ providers: ['managed'], default: 'managed' });
+  expect(result).toEqual({ providers: ['daytona'], default: 'daytona' });
   expect(calls.length).toBe(0);
 });
 

--- a/packages/sdk/src/platform/platform-client/lifecycle.ts
+++ b/packages/sdk/src/platform/platform-client/lifecycle.ts
@@ -32,7 +32,7 @@ import {
  * Get available sandbox providers from the platform service.
  */
 export async function getProviders(): Promise<ProvidersInfo> {
-  return { providers: ['managed'], default: 'managed' };
+  return { providers: ['daytona'], default: 'daytona' };
 }
 
 /**

--- a/packages/sdk/src/platform/platform-client/shared.ts
+++ b/packages/sdk/src/platform/platform-client/shared.ts
@@ -104,7 +104,7 @@ export function projectSessionToSandboxInfo(
     sandbox_id: runtime?.sandbox_id || session.sandbox_id || session.session_id,
     external_id: externalId,
     name: session.name || `${project.name} session`,
-    provider: (runtime?.provider as SandboxProviderName | null) || (session.sandbox_provider as SandboxProviderName | null) || 'managed',
+    provider: (runtime?.provider as SandboxProviderName | null) || (session.sandbox_provider as SandboxProviderName | null) || 'daytona',
     base_url: runtime?.base_url || session.sandbox_url || (runtime?.external_id ? `${getPlatformUrl()}/p/${runtime.external_id}/${SANDBOX_PORTS.KORTIX_MASTER}` : ''),
     status: normalizeSessionStatus(runtime?.status || session.status),
     metadata: {

--- a/packages/sdk/src/platform/platform-client/types.ts
+++ b/packages/sdk/src/platform/platform-client/types.ts
@@ -21,7 +21,7 @@ export const SANDBOX_PORTS = {
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
-export type SandboxProviderName = 'managed' | 'daytona' | 'justavps';
+export type SandboxProviderName = 'daytona' | 'justavps';
 export type ServerTypeOption = string;
 
 export interface SandboxCreateProgress {

--- a/packages/sdk/src/platform/projects-client/session-sandbox.ts
+++ b/packages/sdk/src/platform/projects-client/session-sandbox.ts
@@ -23,7 +23,7 @@ export interface ProjectSessionSandbox {
   session_id: string;
   project_id: string;
   account_id: string;
-  provider: 'managed' | 'daytona' | 'platinum' | 'local_docker' | 'justavps';
+  provider: 'daytona' | 'platinum' | 'local_docker' | 'justavps';
   external_id: string | null;
   base_url: string | null;
   status: ProjectSessionSandboxStatus;


### PR DESCRIPTION
Reverts the sandbox **provider-identity** rename that shipped in #4201 (rename), #4215 (sessions normalize), and #4242 (prebake normalize). The rename was made by mistake; the provider identity goes back to exactly how it was — **`daytona`**. The backend/adapter was never renamed and is untouched.

**Net effect:** new rows write `'daytona'`, the admin FE shows **"Daytona"**, the SDK reports `'daytona'` — and nothing 500s on a stray `'managed'` row written during the rename window (defensive read guards keep resolving it to the Daytona adapter).

## Reverted (identity → `daytona`)

- **`packages/db/src/schema/kortix.ts`** — the 4 column defaults `.default('managed')` → `.default('daytona')` (`projectSessions.sandboxProvider`, `sessionSandboxes.provider`, `sandboxTemplates.provider`, `sandboxes.provider`); `kortix.test.ts` default expectation back to `daytona`.
- **`apps/api/src/config.ts`** — `ALLOWED_SANDBOX_PROVIDERS` default `'managed'`→`'daytona'`; `KNOWN_PROVIDERS` / `parseAllowedProviders` empty-fallbacks / `getDefaultProvider` / `validateEnv` key-check back to `'daytona'`. **Dropped** `normalizeProviderName` + `isManagedProviderName` (they no longer rewrite `daytona`→`managed`) and `isManagedEnabled`; `isDaytonaEnabled` restored to its original body.
- **`apps/api/src/projects/lib/sessions.ts`** — session-create no longer normalizes the requested provider / project pin (the #4215 change); passes them through as-is.
- **`packages/api-contract/src/index.ts`** — `SANDBOX_PROVIDERS` back to `['daytona','local_docker','justavps','platinum']` (drop `'managed'` as first-class).
- **`packages/sdk`** (`types.ts`, `shared.ts`, `lifecycle.ts`, `session-sandbox.ts`) — `|| 'managed'` fallbacks → `'daytona'`; `getProviders()` back to `daytona`; `lifecycle.test` expectation fixed back to `daytona`.
- **`apps/api/src/setup/index.ts`** — capabilities key, default fallback, and health-check key back to `daytona`.
- **`apps/api/src/snapshots/templates.ts`** — 5 provider write/fallback sites → `'daytona'`.
- **`apps/api/src/projects/legacy-migration-steps.ts`** + **`suna-migration/suna-migration-phases.ts`** — new-session `sandboxProvider` write → `'daytona'`.
- **`apps/web` admin dropdown** (`admin-dashboard-sections.tsx`) — create-instance `SelectItem` back to `value="daytona">Daytona`.
- **provider registries** (`snapshots/providers/index.ts`, `platform/providers/index.ts`) — canonical case/comment order back to daytona-first; error message back to "Daytona provider requires...".
- **`sessions.provider.test.ts`** — `ALLOWED` back to `['daytona','platinum']`; dropped the `daytona→managed` normalization describe block; `warmPrebakeProviders` tests use the `daytona` identity.

## Kept (unrelated to the naming — intentionally NOT reverted)

- The **`ADD VALUE 'managed'` enum migration** (`20260706190000000_sandbox_provider_add_managed.sql`) — idempotent, and a Postgres enum value can't be dropped. The enum keeps `'managed'` as a harmless leftover value.
- **#4232** — the `runtime-fingerprint` churn fix (untouched).
- **#4242 core warm-prebake parity** — `kickProjectWarmPrebake` still pre-warms the provider(s) a session on the project could actually land on (per-provider loop, `warmPrebakeProviders` helper, git-proxy pin-passing). It now operates on the `daytona` identity with **no** managed-normalize.
- **Defensive dual-accept read guards** — code that resolves *either* `'daytona'` or `'managed'` to the Daytona adapter stays (session-sandbox `artifactType`, builder reap guard, `ADAPTERS.set('managed', …)`, `getProvider` `case 'managed'`), so any row written `'managed'` during the rename window still resolves and never 500s.

## Verification

- `apps/api` `bunx tsc --noEmit` — **no new errors** vs the `origin/main` baseline (only the pre-existing `@types/bun` env error, identical before/after).
- `provider-precedence` / session-provider unit tests: **13/13 pass**.
- SDK `lifecycle.test`: **23/23 pass**.
- `grep` confirms **no code path defaults to `'managed'`** (no `.default('managed')`, no `|| 'managed'` / `?? 'managed'` provider fallbacks, no `optStrDefault('managed')`); `getProviders()` resolves `daytona`.

Do not merge yet — will be driven manually after confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)