### PR TITLE
feat(iam): restrictable files/secrets (reads→editor) + least-privilege group defaults

### DIFF
--- a/apps/api/src/__tests__/integration-project-read-leaf-gates-http.test.ts
+++ b/apps/api/src/__tests__/integration-project-read-leaf-gates-http.test.ts
@@ -10,9 +10,9 @@ const ACCOUNT = crypto.randomUUID();
 const PROJECT = crypto.randomUUID();
 const MEMBER = crypto.randomUUID();
 // A second principal on the SAME project with the 'editor' role — the floor
-// `member` role has every READ leaf but NOT project.connector.write (that's
-// editor+), so the "human/legacy token with no agent grant still passes"
-// cases for connector-write-gated routes need an editor, not the floor member.
+// `member` role has most READ leaves but NOT file.read / secret.read / any write
+// (those are editor+), so the "human/legacy token with no agent grant still
+// passes" cases for those routes need an editor, not the floor member.
 const EDITOR = crypto.randomUUID();
 
 const minted: string[] = [];
@@ -112,12 +112,20 @@ const CASES: Case[] = [
   { name: 'commit detail', leaf: PROJECT_ACTIONS.PROJECT_GITOPS_READ, path: () => `/v1/projects/${PROJECT}/commits/deadbeef` },
   { name: 'commit diff', leaf: PROJECT_ACTIONS.PROJECT_GITOPS_READ, path: () => `/v1/projects/${PROJECT}/commits/deadbeef/diff` },
   { name: 'version diff', leaf: PROJECT_ACTIONS.PROJECT_GITOPS_READ, path: () => `/v1/projects/${PROJECT}/version-diff?from=a&into=b` },
+  { name: 'triggers list', leaf: PROJECT_ACTIONS.PROJECT_TRIGGER_READ, path: () => `/v1/projects/${PROJECT}/triggers` },
+];
+
+// EDITOR-TIER reads: project.file.read + project.secret.read were moved OUT of
+// the floor `member` role into editor, so a bare member is 403 here (they can
+// run the agent/chat but not browse the file tree or view secret values); an
+// editor passes. Same agent-grant fold as the member-tier CASES above.
+const EDITOR_TIER_READ_CASES: Case[] = [
   { name: 'files list', leaf: PROJECT_ACTIONS.PROJECT_FILE_READ, path: () => `/v1/projects/${PROJECT}/files` },
   { name: 'files archive', leaf: PROJECT_ACTIONS.PROJECT_FILE_READ, path: () => `/v1/projects/${PROJECT}/files/archive` },
   { name: 'files search', leaf: PROJECT_ACTIONS.PROJECT_FILE_READ, path: () => `/v1/projects/${PROJECT}/files/search?q=x` },
   { name: 'files content', leaf: PROJECT_ACTIONS.PROJECT_FILE_READ, path: () => `/v1/projects/${PROJECT}/files/content?path=README.md` },
   { name: 'files history', leaf: PROJECT_ACTIONS.PROJECT_FILE_READ, path: () => `/v1/projects/${PROJECT}/files/history?path=README.md` },
-  { name: 'triggers list', leaf: PROJECT_ACTIONS.PROJECT_TRIGGER_READ, path: () => `/v1/projects/${PROJECT}/triggers` },
+  { name: 'secrets list', leaf: PROJECT_ACTIONS.PROJECT_SECRET_READ, path: () => `/v1/projects/${PROJECT}/secrets` },
 ];
 
 describe('HTTP enforcement — project read-leaf gates (agent-grant fold now reachable)', () => {
@@ -139,6 +147,32 @@ describe('HTTP enforcement — project read-leaf gates (agent-grant fold now rea
 
       test('full-role member token with NO grant (human/legacy) → passes the gate (not 403)', async () => {
         const secret = await mintToken(null);
+        const res = await getReq(c.path(), secret);
+        expect(res.status).not.toBe(403);
+      });
+    });
+  }
+});
+
+describe('HTTP enforcement — editor-tier read gates (file.read / secret.read moved off member)', () => {
+  for (const c of EDITOR_TIER_READ_CASES) {
+    describe(c.name, () => {
+      test('floor MEMBER (no file/secret read) → 403', async () => {
+        const secret = await mintToken(null);
+        const res = await getReq(c.path(), secret);
+        expect(res.status).toBe(403);
+        const body = await res.json().catch(() => ({}));
+        expect(JSON.stringify(body)).toContain(c.leaf);
+      });
+
+      test('EDITOR (has the read leaf) → passes the gate (not 403)', async () => {
+        const secret = await mintEditorToken(null);
+        const res = await getReq(c.path(), secret);
+        expect(res.status).not.toBe(403);
+      });
+
+      test('agent (editor) granted the exact leaf → passes the gate (not 403)', async () => {
+        const secret = await mintEditorToken({ agent: 'scoped-bot', kortixCli: [c.leaf], connectors: [] });
         const res = await getReq(c.path(), secret);
         expect(res.status).not.toBe(403);
       });

--- a/apps/api/src/__tests__/unit-iam-v2-role-perms.test.ts
+++ b/apps/api/src/__tests__/unit-iam-v2-role-perms.test.ts
@@ -118,9 +118,10 @@ describe('IAM V2 — role helpers', () => {
 
 describe('IAM V2 — no unknown actions', () => {
   // IAM v1 per-capability leaves: backward-compat invariant. Editor must hold
-  // every write leaf (it had all of these via project.write before) and the
-  // Member floor role every read leaf (via project.read). Member must NOT gain any
-  // write leaf.
+  // every write leaf (it had all of these via project.write before). The floor
+  // Member role keeps MOST read leaves — EXCEPT file.read + secret.read, which
+  // moved to editor-tier (a member can run the agent/chat but can't browse the
+  // file tree or view secret values). Member must NOT gain any write leaf.
   test('per-capability leaves preserve the editor/member capability surface', () => {
     const writeLeaves = [
       PROJECT_ACTIONS.PROJECT_AGENT_WRITE,
@@ -133,24 +134,33 @@ describe('IAM V2 — no unknown actions', () => {
       PROJECT_ACTIONS.PROJECT_SECRET_WRITE,
       PROJECT_ACTIONS.PROJECT_CONNECTOR_WRITE,
     ];
-    const readLeaves = [
+    // Reads the floor member role keeps.
+    const memberReadLeaves = [
       PROJECT_ACTIONS.PROJECT_AGENT_READ,
       PROJECT_ACTIONS.PROJECT_SKILL_READ,
       PROJECT_ACTIONS.PROJECT_COMMAND_READ,
-      PROJECT_ACTIONS.PROJECT_FILE_READ,
       PROJECT_ACTIONS.PROJECT_CUSTOMIZE_READ,
       PROJECT_ACTIONS.PROJECT_GITOPS_READ,
-      PROJECT_ACTIONS.PROJECT_SECRET_READ,
       PROJECT_ACTIONS.PROJECT_CONNECTOR_READ,
+    ];
+    // Sensitive reads that are now editor-tier (member is denied).
+    const editorReadLeaves = [
+      PROJECT_ACTIONS.PROJECT_FILE_READ,
+      PROJECT_ACTIONS.PROJECT_SECRET_READ,
     ];
     for (const a of writeLeaves) {
       expect(projectRoleAllows('editor', a)).toBe(true);
       expect(projectRoleAllows('manager', a)).toBe(true);
       expect(projectRoleAllows('member', a)).toBe(false);
     }
-    for (const a of readLeaves) {
+    for (const a of memberReadLeaves) {
       expect(projectRoleAllows('member', a)).toBe(true);
       expect(projectRoleAllows('editor', a)).toBe(true);
+    }
+    for (const a of editorReadLeaves) {
+      expect(projectRoleAllows('member', a)).toBe(false);
+      expect(projectRoleAllows('editor', a)).toBe(true);
+      expect(projectRoleAllows('manager', a)).toBe(true);
     }
   });
 

--- a/apps/api/src/iam/role-perms.ts
+++ b/apps/api/src/iam/role-perms.ts
@@ -113,19 +113,27 @@ const EDITOR_EXTRAS: readonly string[] = [
   PROJECT_ACTIONS.PROJECT_SECRET_WRITE,
   PROJECT_ACTIONS.PROJECT_CONNECTOR_WRITE,
 
+  // Sensitive READS — moved out of the floor `member` role. A plain member can
+  // use the project (run the agent/chat) but can't browse the file tree via the
+  // files page or view secret values; editor+ retains both. Makes "project
+  // access without files/secrets" expressible as the built-in `member` role.
+  PROJECT_ACTIONS.PROJECT_FILE_READ,
+  PROJECT_ACTIONS.PROJECT_SECRET_READ,
+
   // Acting on a review item (approve / reject / answer) is a decision on agent
   // work — editor-tier, alongside gitops.
   PROJECT_ACTIONS.PROJECT_REVIEW_ACT,
 ];
 
 /** Baseline for the floor project role. `member` is the base *usable* role:
- *  it can read everything AND start / run / stop sessions — i.e. actually use
- *  the agent and the chat. A role that can't open a session is useless, and
- *  this is the role new members get by default, so it has to be able to drive
- *  Kortix. What it CANNOT do is customize the project: edit settings, deploy,
- *  manage members, or create/delete triggers — those live in EDITOR_EXTRAS /
- *  MANAGER_ONLY above. Named PROJECT_MEMBER_* to avoid colliding with the
- *  account-role MEMBER_BASELINE above. */
+ *  it can read the project and start / run / stop sessions — i.e. actually use
+ *  the agent and the chat — but NOT view secret values or browse the file tree
+ *  (those moved to editor-tier). A role that can't open a session is useless,
+ *  and this is the role new members get by default, so it has to be able to
+ *  drive Kortix. What it CANNOT do is customize the project (edit settings,
+ *  deploy, manage members, create/delete triggers) OR read files/secrets —
+ *  those live in EDITOR_EXTRAS / MANAGER_ONLY above. Named PROJECT_MEMBER_* to
+ *  avoid colliding with the account-role MEMBER_BASELINE above. */
 const PROJECT_MEMBER_BASELINE: readonly string[] = [
   PROJECT_ACTIONS.PROJECT_READ,
   PROJECT_ACTIONS.PROJECT_SESSION_READ,
@@ -138,15 +146,16 @@ const PROJECT_MEMBER_BASELINE: readonly string[] = [
   PROJECT_ACTIONS.PROJECT_GATEWAY_LOGS_READ,
   PROJECT_ACTIONS.PROJECT_GATEWAY_SPEND_READ,
 
-  // Per-capability read leaves (IAM v1). The floor role keeps everything it
-  // can read today (these previously collapsed to project.read).
+  // Per-capability read leaves (IAM v1). NOTE: project.file.read and
+  // project.secret.read are DELIBERATELY NOT here — they moved to EDITOR_EXTRAS
+  // so a floor `member` can run the agent/chat but can't browse the file tree or
+  // view secret values (the sensitive reads are an editor concern). This is the
+  // one place `member ⊂ editor` is a real capability difference on reads.
   PROJECT_ACTIONS.PROJECT_AGENT_READ,
   PROJECT_ACTIONS.PROJECT_SKILL_READ,
   PROJECT_ACTIONS.PROJECT_COMMAND_READ,
-  PROJECT_ACTIONS.PROJECT_FILE_READ,
   PROJECT_ACTIONS.PROJECT_CUSTOMIZE_READ,
   PROJECT_ACTIONS.PROJECT_GITOPS_READ,
-  PROJECT_ACTIONS.PROJECT_SECRET_READ,
   PROJECT_ACTIONS.PROJECT_CONNECTOR_READ,
 
   // Review Center: the floor role can see the inbox and (via its agent) submit

--- a/apps/web/src/app/(app)/accounts/[id]/groups/[groupId]/page.tsx
+++ b/apps/web/src/app/(app)/accounts/[id]/groups/[groupId]/page.tsx
@@ -901,7 +901,7 @@ function AttachToProjectDialog({
 }) {
   const tI18nHardcoded = useTranslations('hardcodedUi');
   const [selectedProjectId, setSelectedProjectId] = useState<string | undefined>(undefined);
-  const [selectedRole, setSelectedRole] = useState<ProjectRole>('editor');
+  const [selectedRole, setSelectedRole] = useState<ProjectRole>('member');
   // Optional auto-revoke timestamp. Empty string = permanent (default).
   // Stored as the raw <input type="datetime-local"> value; we convert
   // to ISO on submit so the server can parse it.

--- a/apps/web/src/app/(app)/accounts/[id]/groups/[groupId]/page.tsx
+++ b/apps/web/src/app/(app)/accounts/[id]/groups/[groupId]/page.tsx
@@ -852,12 +852,9 @@ function GroupProjectGrantsCard({
         description={
           detachTarget ? (
             <span>
-              <strong>{groupName}</strong>{' '}
-              {tI18nHardcoded.raw('autoAppAppAccountsIdGroupsGroupIdPageJsxTextWilldd678991')}{' '}
-              <strong>{detachTarget.project_name}</strong>
-              {tI18nHardcoded.raw('autoAppAppAccountsIdGroupsGroupIdPageJsxTextEvery76958122')}
-              <strong>{detachTarget.role}</strong>{' '}
-              {tI18nHardcoded.raw('autoAppAppAccountsIdGroupsGroupIdPageJsxTextAccessf385fd87')}
+              <strong>{groupName}</strong> will no longer be attached to{' '}
+              <strong>{detachTarget.project_name}</strong>. Every group member will lose their
+              inherited <strong className="capitalize">{detachTarget.role}</strong> access.
             </span>
           ) : null
         }

--- a/apps/web/src/features/workspace/customize/sections/view/members-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/members-view.tsx
@@ -257,7 +257,7 @@ function InviteMemberCard({ projectId }: { projectId: string }) {
   const queryClient = useQueryClient();
   const [emails, setEmails] = useState<string[]>([]);
   const [inputValue, setInputValue] = useState('');
-  const [role, setRole] = useState<ProjectRole>('editor');
+  const [role, setRole] = useState<ProjectRole>('member');
   const [inlineError, setInlineError] = useState<string | null>(null);
 
   const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
@@ -1363,7 +1363,7 @@ function ProjectGroupGrantsCard({
   );
 
   const [pickerGroupId, setPickerGroupId] = useState<string>('');
-  const [pickerRole, setPickerRole] = useState<ProjectRole>('editor');
+  const [pickerRole, setPickerRole] = useState<ProjectRole>('member');
   const [pendingGroupIds, setPendingGroupIds] = useState<Set<string>>(() => new Set());
   const markPending = (id: string) => setPendingGroupIds((prev) => new Set(prev).add(id));
   const clearPending = (id: string) =>

--- a/apps/web/src/features/workspace/customize/sections/view/members-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/members-view.tsx
@@ -1325,6 +1325,28 @@ function ProjectGroupGrantsCard({
     enabled: canManage,
     staleTime: 60_000,
   });
+  // Custom-role policies bound to a GROUP on this project. A group that has BOTH
+  // a built-in grant (this list) AND a custom-role policy hits the union trap:
+  // allow-only/highest-wins means the built-in role WINS and silently overrides
+  // the custom role's restrictions. We flag those rows so it isn't a silent gotcha.
+  const policiesQuery = useQuery({
+    queryKey: ['project-policies', projectId],
+    queryFn: () => listPolicies(accountId, { scopeId: projectId }),
+    enabled: canManage,
+    staleTime: 20_000,
+  });
+  const groupsWithCustomRole = useMemo(
+    () =>
+      new Set(
+        (policiesQuery.data ?? [])
+          .filter(
+            (p) =>
+              p.principal_type === 'group' && p.scope_type === 'project' && p.scope_id === projectId,
+          )
+          .map((p) => p.principal_id),
+      ),
+    [policiesQuery.data, projectId],
+  );
 
   const grants = useMemo(() => {
     const raw = grantsQuery.data?.grants ?? [];
@@ -1540,6 +1562,14 @@ function ProjectGroupGrantsCard({
                             {tHardcodedUi.raw(
                               'autoComponentsProjectsCustomizeSectionsMembersViewJsxTextGetManagera88e6fc4',
                             )}
+                          </span>
+                        )}
+                        {groupsWithCustomRole.has(g.group_id) && (
+                          <span
+                            className="text-kortix-orange font-medium"
+                            title="This group also has a custom role assigned on this project. Built-in role grants WIN over custom roles (allow-only / highest-wins), so this grant overrides the custom role's limits. Detach it to let the custom role apply."
+                          >
+                            ⚠ overrides an assigned custom role
                           </span>
                         )}
                       </InlineMeta>


### PR DESCRIPTION
IAM: make "project access without files/secrets" actually expressible, plus two guardrails.

## 1. Move `file.read` + `secret.read` off the floor `member` role → editor-tier
Previously the floor `member` project role granted **every** read leaf (files, secrets, …), and IAM is allow-only/union — so you could never grant project access *without* file+secret read, and a custom role couldn't subtract them. Now:
- **`member`** = use the project (read the shell, run the agent/chat, fire triggers) but **cannot browse the file tree or view secret values**.
- **`editor`/`manager`** = retain both (unchanged for them).

So "let this group use the project but not see files/secrets" = grant them **`member`**.

⚠️ **Blast radius:** existing project **`member`-role** users lose file-read + secret-read (they'd need `editor`). Deliberate least-privilege tightening. On the dev account this affects nobody (all groups are `editor`).

Tests: `unit-iam-v2-role-perms` split into member-reads vs editor-tier-reads; `integration-project-read-leaf-gates-http` moves the files cases (and adds a secrets case) into an editor-tier group asserting **member → 403, editor → 200**.

## 2. Default group→project grant is now `member`, not `editor`
Attaching a group (or inviting a member) defaults to `member` — least-privilege by default, instead of handing out full editor.

## 3. Guardrails (from earlier in this PR)
- Warn on any Group-access row that **also** has a custom-role policy ("⚠ overrides an assigned custom role").
- Fixed the Detach dialog's leaking raw i18n key + missing space.
