### PR TITLE
fix(llm-providers): provider API keys are always project-wide

### DIFF
--- a/apps/api/src/projects/routes/r3.ts
+++ b/apps/api/src/projects/routes/r3.ts
@@ -1011,6 +1011,19 @@ projectsApp.openapi(
   if (name === CODEX_AUTH_JSON_SECRET_NAME) {
     return c.json({ error: `${CODEX_AUTH_JSON_SECRET_NAME} is managed by ChatGPT subscription onboarding` }, 400);
   }
+  // LLM provider credentials are always project-wide. The gateway resolves
+  // BYOK keys from the SHARED row only (getProjectSecretValue), so a personal
+  // override would show the provider as connected in the UI while every model
+  // turn 400s with "No upstream configured" (2026-07-07 prod incident).
+  if (isGatewayManagedEnv(name)) {
+    return c.json(
+      {
+        error: `${name} is an LLM provider credential — provider keys are always project-wide, update the shared value instead`,
+        code: 'llm_credentials_project_wide',
+      },
+      400,
+    );
+  }
 
   const value = typeof body.value === 'string' ? body.value : null;
   const active = typeof body.active === 'boolean' ? body.active : undefined;

--- a/apps/web/src/features/workspace/customize/sections/llm-provider/api-key-connect-form.tsx
+++ b/apps/web/src/features/workspace/customize/sections/llm-provider/api-key-connect-form.tsx
@@ -4,22 +4,29 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { successToast } from '@/components/ui/toast';
 import { ProviderLogo } from '@/features/providers/provider-branding';
-import {
-  SharingPicker,
-  isSharingComplete,
-  type SharingSelection,
-} from '@/features/workspace/shared/sharing-picker';
+import type { SharingSelection } from '@/features/workspace/shared/sharing-picker';
 import { refreshProjectProviderState } from '@/hooks/opencode/provider-refresh';
 import type { LlmProviderEntry } from '@/lib/llm-providers';
-import { setPersonalProjectSecret, upsertProjectSecret } from '@kortix/sdk/projects-client';
 import { cn } from '@/lib/utils';
+import { upsertProjectSecret } from '@kortix/sdk/projects-client';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { AlertCircle, ChevronLeft, ExternalLink, Info, Loader2 } from 'lucide-react';
 import { useTranslations } from 'next-intl';
-import { FormEvent, useMemo, useState } from 'react';
+import { type FormEvent, useMemo, useState } from 'react';
 
 import { ChatGptSubscriptionConnect } from './chatgpt-subscription-connect';
 import { envVarPlaceholder, helpHostnameFromUrl, prettyFieldLabel } from './utils';
+
+// LLM provider credentials are ALWAYS project-wide. A per-user "Only me" key is
+// invisible to the LLM gateway's shared-row resolution, so every model turn
+// dies with "No upstream configured" while the picker still shows the provider
+// as connected (2026-07-07 prod incident). The server rejects personal
+// overrides for provider env vars; this form never offers the choice.
+const PROJECT_WIDE_SHARING: SharingSelection = {
+  mode: 'project',
+  memberIds: [],
+  groupIds: [],
+};
 
 export function ApiKeyConnectForm({
   projectId,
@@ -37,29 +44,15 @@ export function ApiKeyConnectForm({
   const [values, setValues] = useState<Record<string, string>>(() =>
     Object.fromEntries(provider.envVars.map((v) => [v, ''])),
   );
-  const [sharing, setSharing] = useState<SharingSelection>({
-    mode: 'project',
-    memberIds: [],
-    groupIds: [],
-  });
   const [error, setError] = useState<string | null>(null);
 
   const upsert = useMutation({
     mutationFn: async () => {
       for (const envVar of provider.envVars) {
-        if (sharing.mode === 'private') {
-          await setPersonalProjectSecret(projectId, envVar, {
-            value: values[envVar] ?? '',
-            active: true,
-          });
-        } else {
-          // Project-wide is the only shared option now — secret sharing
-          // (restricting a shared value to specific members) was retired.
-          await upsertProjectSecret(projectId, {
-            name: envVar,
-            value: values[envVar] ?? '',
-          });
-        }
+        await upsertProjectSecret(projectId, {
+          name: envVar,
+          value: values[envVar] ?? '',
+        });
       }
     },
     onSuccess: () => {
@@ -83,10 +76,6 @@ export function ApiKeyConnectForm({
           ? 'API key is required'
           : `All ${provider.envVars.length} fields are required`,
       );
-      return;
-    }
-    if (!isSharingComplete(sharing)) {
-      setError('Pick at least one member, or choose another access option.');
       return;
     }
     upsert.mutate();
@@ -124,7 +113,7 @@ export function ApiKeyConnectForm({
       {provider.id === 'openai' && (
         <ChatGptSubscriptionConnect
           projectId={projectId}
-          sharing={sharing}
+          sharing={PROJECT_WIDE_SHARING}
           onConnected={onConnected}
         />
       )}
@@ -154,7 +143,9 @@ export function ApiKeyConnectForm({
           </div>
         ))}
 
-        <SharingPicker projectId={projectId} value={sharing} onChange={setSharing} showHeading hideMembers />
+        <p className="text-muted-foreground text-xs">
+          Project-wide — every member of this project can use this provider.
+        </p>
 
         {provider.helpUrl && helpHostname && (
           <a
@@ -187,12 +178,7 @@ export function ApiKeyConnectForm({
           </p>
         </div>
 
-        <Button
-          type="submit"
-          size="sm"
-          className="px-4"
-          disabled={upsert.isPending || !allFilled || !isSharingComplete(sharing)}
-        >
+        <Button type="submit" size="sm" className="px-4" disabled={upsert.isPending || !allFilled}>
           {upsert.isPending ? (
             <>
               <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />

--- a/apps/web/src/features/workspace/customize/sections/llm-provider/api-key-connect-form.tsx
+++ b/apps/web/src/features/workspace/customize/sections/llm-provider/api-key-connect-form.tsx
@@ -4,7 +4,6 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { successToast } from '@/components/ui/toast';
 import { ProviderLogo } from '@/features/providers/provider-branding';
-import type { SharingSelection } from '@/features/workspace/shared/sharing-picker';
 import { refreshProjectProviderState } from '@/hooks/opencode/provider-refresh';
 import type { LlmProviderEntry } from '@/lib/llm-providers';
 import { cn } from '@/lib/utils';
@@ -22,11 +21,6 @@ import { envVarPlaceholder, helpHostnameFromUrl, prettyFieldLabel } from './util
 // dies with "No upstream configured" while the picker still shows the provider
 // as connected (2026-07-07 prod incident). The server rejects personal
 // overrides for provider env vars; this form never offers the choice.
-const PROJECT_WIDE_SHARING: SharingSelection = {
-  mode: 'project',
-  memberIds: [],
-  groupIds: [],
-};
 
 export function ApiKeyConnectForm({
   projectId,
@@ -111,11 +105,7 @@ export function ApiKeyConnectForm({
       </div>
 
       {provider.id === 'openai' && (
-        <ChatGptSubscriptionConnect
-          projectId={projectId}
-          sharing={PROJECT_WIDE_SHARING}
-          onConnected={onConnected}
-        />
+        <ChatGptSubscriptionConnect projectId={projectId} onConnected={onConnected} />
       )}
 
       <form

--- a/apps/web/src/features/workspace/customize/sections/llm-provider/chatgpt-subscription-connect.tsx
+++ b/apps/web/src/features/workspace/customize/sections/llm-provider/chatgpt-subscription-connect.tsx
@@ -3,11 +3,6 @@
 import { Button } from '@/components/ui/button';
 import { successToast } from '@/components/ui/toast';
 import { ProviderLogo } from '@/features/providers/provider-branding';
-import {
-  isSharingComplete,
-  selectionToIntent,
-  type SharingSelection,
-} from '@/features/workspace/shared/sharing-picker';
 import { refreshProjectProviderState } from '@/hooks/opencode/provider-refresh';
 import {
   pollProjectProviderOAuth,
@@ -21,13 +16,14 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import type { ChatGptChallenge, ChatGptPhase } from './types';
 import { sleep } from './utils';
 
+// ChatGPT subscription logins connect project-wide, like every other LLM
+// provider credential (kortix policy: no per-user access choice at the LLM
+// level). The server's default sharing intent is project-wide.
 export function ChatGptSubscriptionConnect({
   projectId,
-  sharing,
   onConnected,
 }: {
   projectId: string;
-  sharing: SharingSelection;
   onConnected: () => void;
 }) {
   const tHardcodedUi = useTranslations('hardcodedUi');
@@ -51,18 +47,12 @@ export function ChatGptSubscriptionConnect({
   }, []);
 
   const handleConnect = useCallback(async () => {
-    if (!isSharingComplete(sharing)) {
-      setError('Pick at least one member, or choose another access option.');
-      return;
-    }
     cancelledRef.current = false;
     setError(null);
     setChallenge(null);
     setPhase('waiting');
     try {
-      const start = await startProjectProviderOAuth(projectId, 'openai', {
-        sharing: selectionToIntent(sharing),
-      });
+      const start = await startProjectProviderOAuth(projectId, 'openai', {});
       if (cancelledRef.current) return;
       setChallenge({ url: start.verification_url, code: start.user_code });
       if (start.verification_url) {
@@ -113,7 +103,7 @@ export function ChatGptSubscriptionConnect({
       setPhase('idle');
       setError(err instanceof Error ? err.message : 'Failed to connect ChatGPT subscription');
     }
-  }, [projectId, sharing, queryClient, onConnected]);
+  }, [projectId, queryClient, onConnected]);
 
   const waiting = phase === 'waiting';
 

--- a/apps/web/src/features/workspace/customize/sections/llm-provider/connected-tab.tsx
+++ b/apps/web/src/features/workspace/customize/sections/llm-provider/connected-tab.tsx
@@ -10,7 +10,7 @@ import { EmptyState } from '@/features/layout/section/empty-state';
 import { PROVIDER_LABELS, ProviderLogo } from '@/features/providers/provider-branding';
 import { refreshProjectProviderState } from '@/hooks/opencode/provider-refresh';
 import { LLM_PROVIDER_BY_ID, type LlmProviderEntry } from '@/lib/llm-providers';
-import { deletePersonalProjectSecret, deleteProjectSecret } from '@kortix/sdk/projects-client';
+import { deleteProjectSecret } from '@kortix/sdk/projects-client';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { Plug, Unplug } from 'lucide-react';
 import { useTranslations } from 'next-intl';
@@ -44,10 +44,7 @@ export function ConnectedTab({
             ]
           : provider.envVars;
       await Promise.all(
-        names.flatMap((envVar) => [
-          deleteProjectSecret(projectId, envVar).catch(() => undefined),
-          deletePersonalProjectSecret(projectId, envVar).catch(() => undefined),
-        ]),
+        names.map((envVar) => deleteProjectSecret(projectId, envVar).catch(() => undefined)),
       );
       return provider;
     },

--- a/apps/web/src/features/workspace/customize/sections/llm-provider/custom-provider-form.tsx
+++ b/apps/web/src/features/workspace/customize/sections/llm-provider/custom-provider-form.tsx
@@ -3,20 +3,12 @@
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { errorToast, successToast } from '@/components/ui/toast';
-import {
-  SharingPicker,
-  isSharingComplete,
-  type SharingSelection,
-} from '@/features/workspace/shared/sharing-picker';
 import { refreshProjectProviderState } from '@/hooks/opencode/provider-refresh';
-import {
-  setPersonalProjectSecret,
-  upsertProjectSecret,
-} from '@kortix/sdk/projects-client';
+import { upsertProjectSecret } from '@kortix/sdk/projects-client';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { AlertCircle, ChevronLeft, Copy, Loader2 } from 'lucide-react';
 import { useTranslations } from 'next-intl';
-import { FormEvent, useState } from 'react';
+import { type FormEvent, useState } from 'react';
 
 import type { CustomFormState } from './types';
 import { buildCustomProviderSnippet } from './utils';
@@ -39,11 +31,6 @@ export function CustomProviderForm({
     apiKey: '',
     modelId: '',
     modelName: '',
-  });
-  const [sharing, setSharing] = useState<SharingSelection>({
-    mode: 'project',
-    memberIds: [],
-    groupIds: [],
   });
   const [error, setError] = useState<string | null>(null);
   const [savedSnippet, setSavedSnippet] = useState<{
@@ -79,22 +66,13 @@ export function CustomProviderForm({
         ? `CUSTOM_${trimmed.providerId.toUpperCase().replace(/-/g, '_')}_API_KEY`
         : null;
       if (secretName) {
-        if (!isSharingComplete(sharing)) {
-          throw new Error('Pick at least one member, or choose another access option.');
-        }
-        if (sharing.mode === 'private') {
-          await setPersonalProjectSecret(projectId, secretName, {
-            value: trimmed.apiKey,
-            active: true,
-          });
-        } else {
-          // Project-wide is the only shared option now — secret sharing
-          // (restricting a shared value to specific members) was retired.
-          await upsertProjectSecret(projectId, {
-            name: secretName,
-            value: trimmed.apiKey,
-          });
-        }
+        // LLM provider credentials are always project-wide (see
+        // api-key-connect-form.tsx) — a per-user key is invisible to the
+        // gateway's shared-row resolution and breaks every model turn.
+        await upsertProjectSecret(projectId, {
+          name: secretName,
+          value: trimmed.apiKey,
+        });
       }
 
       const snippet = buildCustomProviderSnippet({
@@ -204,7 +182,9 @@ export function CustomProviderForm({
         </div>
 
         {form.apiKey.trim() && (
-          <SharingPicker projectId={projectId} value={sharing} onChange={setSharing} showHeading hideMembers />
+          <p className="text-muted-foreground text-xs">
+            Project-wide — every member of this project can use this provider.
+          </p>
         )}
         <div>
           <label className="text-muted-foreground mb-1.5 block text-xs font-medium">
@@ -269,12 +249,7 @@ export function CustomProviderForm({
           </div>
         )}
 
-        <Button
-          type="submit"
-          size="sm"
-          className="px-4"
-          disabled={save.isPending || (Boolean(form.apiKey.trim()) && !isSharingComplete(sharing))}
-        >
+        <Button type="submit" size="sm" className="px-4" disabled={save.isPending}>
           {save.isPending ? (
             <>
               <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />

--- a/tests/src/flows/remaining.flow.ts
+++ b/tests/src/flows/remaining.flow.ts
@@ -71,6 +71,12 @@ flow(
         .del("/v1/projects/:projectId/secrets/:name/personal", { params: { projectId: p.id, name: "PERSONAL_KEY" } });
       r.status([200, 204, 404]);
     });
+    await ctx.step("personal override of an LLM provider key → 400 (always project-wide)", async () => {
+      const r = await ctx.client
+        .as(ctx.P.OWNER)
+        .put("/v1/projects/:projectId/secrets/:name/personal", { value: "sk-mine" }, { params: { projectId: p.id, name: "ANTHROPIC_API_KEY" } });
+      r.status(400);
+    });
   },
 );
 


### PR DESCRIPTION
## What

Removes the project-wide vs. 'Only me' sharing choice when connecting an LLM provider (API-key and custom-provider forms). Provider keys are now always saved as the shared project secret, with an info line replacing the picker. The API additionally rejects personal overrides of gateway-managed provider env vars (`400 llm_credentials_project_wide`).

## Why (prod incident, 2026-07-07)

A free-tier signup (alex@blaise.new) connected an Anthropic key with 'Only me'. That writes a personal (`owner_user_id`-scoped) `project_secrets` row — but the LLM gateway's BYOK resolution (`resolveCandidates` → `getProjectSecretValue`) reads **shared rows only**. Result: the UI showed Anthropic as connected and Claude selectable, while every model turn died with `Bad Request: No upstream configured for model "anthropic/claude-opus-4-8"`. The user retried across two sessions for 47s and churned.

Worse, flipping an **existing** shared key to 'Only me' was a silent no-op revocation: the personal route never touches the shared row, so the 'restricted' key stayed live for every member and every sandbox.

Prod data was already remediated by hand (the one affected personal row promoted to shared; redundant test rows removed).

## How

- `api-key-connect-form.tsx` / `custom-provider-form.tsx`: drop `SharingPicker` + the `setPersonalProjectSecret` branch; always `upsertProjectSecret`. ChatGPT subscription connect keeps its existing default (project-wide).
- `r3.ts` `PUT /secrets/:name/personal`: reject `isGatewayManagedEnv` names with a clear error, so CLI/API callers can't recreate the broken state.
- ke2e `SEC-5`: new step asserting the 400.

## Tests
- `tsc --noEmit` clean on apps/web and apps/api; biome clean on changed lines
- ke2e secrets flow covers the new guard