### PR TITLE
fix(iam): gate ungated project endpoints on their capability leaves

### DIFF
--- a/apps/api/src/__tests__/integration-project-write-leaf-gates-http.test.ts
+++ b/apps/api/src/__tests__/integration-project-write-leaf-gates-http.test.ts
@@ -135,6 +135,16 @@ const CASES: WCase[] = [
     path: () => `/v1/projects/${PROJECT}/review/items`, body: {},
     tier: 'member', denyGrant: [A.PROJECT_TRIGGER_FIRE], allowGrant: [A.PROJECT_REVIEW_SUBMIT],
   },
+  // ── Triggers ─────────────────────────────────────────────────────────────
+  {
+    // Floor was 'manage' (project.write) — which the floor `member` role lacks
+    // though it HOLDS trigger.fire, so a plain member could never fire. Floor is
+    // now 'read', so the trigger.fire leaf is the gate and member can fire.
+    name: 'trigger fire (trigger.fire — member floor role must be able to fire)',
+    leaf: A.PROJECT_TRIGGER_FIRE, method: 'POST',
+    path: () => `/v1/projects/${PROJECT}/triggers/some-slug/fire`, body: {},
+    tier: 'member', denyGrant: [A.PROJECT_SESSION_START], allowGrant: [A.PROJECT_TRIGGER_FIRE],
+  },
   // ── Connectors (write) ───────────────────────────────────────────────────
   {
     name: 'email connect (connector.write)',

--- a/apps/api/src/__tests__/integration-project-write-leaf-gates-http.test.ts
+++ b/apps/api/src/__tests__/integration-project-write-leaf-gates-http.test.ts
@@ -1,0 +1,266 @@
+import { describe, expect, test, beforeAll, afterAll } from 'bun:test';
+import { eq, sql } from 'drizzle-orm';
+import { accountMembers, accounts, projectMembers, projects } from '@kortix/db';
+import { db } from '../shared/db';
+import { app } from '../index';
+import { createAccountToken } from '../repositories/account-tokens';
+import { PROJECT_ACTIONS } from '../iam';
+
+// Every capability checkbox must be authoritative: unchecking a leaf must DENY
+// its endpoint. These endpoints previously gated on a coarse floor only (or an
+// agent-scope check that is a no-op for humans), so unchecking the leaf did
+// nothing. This suite proves each newly-added leaf gate fires, using the
+// agent-grant fold: a scoped agent token restricts the launching user to the
+// leaves in its kortix_cli grant (project.read/project.write are exempt — see
+// AGENT_GRANT_EXEMPT_ACTIONS — so the coarse floor always passes and only the
+// specific leaf gate is under test).
+const ACCOUNT = crypto.randomUUID();
+const PROJECT = crypto.randomUUID();
+const MEMBER = crypto.randomUUID();
+const EDITOR = crypto.randomUUID();
+
+const minted: string[] = [];
+
+beforeAll(async () => {
+  await db.execute(sql`alter table kortix.account_tokens add column if not exists agent_grant jsonb`);
+  await db.execute(sql`alter table kortix.account_tokens add column if not exists session_id text`);
+  await db.execute(sql`alter table kortix.account_tokens add column if not exists service_account_id uuid`);
+
+  await db.insert(accounts).values({ accountId: ACCOUNT, name: 'write-leaf-gate-test' });
+  await db.insert(projects).values({
+    projectId: PROJECT,
+    accountId: ACCOUNT,
+    name: 'write-leaf-gate-test-project',
+    repoUrl: 'https://example.com/write-leaf-gate-test.git',
+  });
+  await db.insert(accountMembers).values([
+    { userId: MEMBER, accountId: ACCOUNT, accountRole: 'member', isSuperAdmin: false },
+    { userId: EDITOR, accountId: ACCOUNT, accountRole: 'member', isSuperAdmin: false },
+  ]);
+  await db.insert(projectMembers).values([
+    { accountId: ACCOUNT, projectId: PROJECT, userId: MEMBER, projectRole: 'member' },
+    { accountId: ACCOUNT, projectId: PROJECT, userId: EDITOR, projectRole: 'editor' },
+  ]);
+});
+
+afterAll(async () => {
+  for (const tokenId of minted) {
+    await db.execute(sql`delete from kortix.account_tokens where token_id = ${tokenId}`);
+  }
+  await db.delete(projects).where(eq(projects.accountId, ACCOUNT));
+  await db.delete(accounts).where(eq(accounts.accountId, ACCOUNT));
+});
+
+async function mint(userId: string, kortixCli: string[] | null): Promise<string> {
+  const t = await createAccountToken({
+    accountId: ACCOUNT,
+    userId,
+    projectId: PROJECT,
+    name: 'write-leaf-gate-test',
+    agentGrant: (kortixCli ? { agent: 'scoped-bot', kortixCli, connectors: [] } : null) as any,
+  });
+  minted.push(t.tokenId);
+  return t.secretKey;
+}
+
+function req(method: string, path: string, secret: string, body?: unknown) {
+  return app.request(path, {
+    method,
+    headers: {
+      Authorization: `Bearer ${secret}`,
+      ...(body !== undefined ? { 'content-type': 'application/json' } : {}),
+    },
+    ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+  });
+}
+
+// An IAM denial (403) from either loadProjectForUser (floor) or
+// assertProjectCapability (leaf). Both phrase it distinctively; a non-IAM 403
+// (e.g. the "email is experimental" gate) matches none of these, so the ALLOW
+// cases can still 403 for an unrelated reason without being counted as a leaf
+// denial.
+async function iamDenied(res: Response): Promise<boolean> {
+  if (res.status !== 403) return false;
+  const text = JSON.stringify(await res.json().catch(() => ({})));
+  return /permission|do not have access|doesn't let you/i.test(text);
+}
+
+interface WCase {
+  name: string;
+  leaf: string;
+  method: string;
+  path: () => string;
+  body?: unknown;
+  // 'member' = the floor role holds this leaf (so a plain member passes);
+  // 'editor' = editor-tier (a plain member is denied, an editor passes).
+  tier: 'member' | 'editor';
+  // kortix_cli grants for the agent-grant fold. deny = a grant that should be
+  // rejected by the leaf gate; allow = the exact grant that should pass it.
+  denyGrant: string[];
+  allowGrant: string[];
+}
+
+const A = PROJECT_ACTIONS;
+const sid = () => crypto.randomUUID();
+
+const CASES: WCase[] = [
+  // ── Session lifecycle ────────────────────────────────────────────────────
+  {
+    name: 'session start (floor session.start)',
+    leaf: A.PROJECT_SESSION_START, method: 'POST',
+    path: () => `/v1/projects/${PROJECT}/sessions/${sid()}/start`,
+    tier: 'member', denyGrant: [A.PROJECT_TRIGGER_FIRE], allowGrant: [A.PROJECT_SESSION_START],
+  },
+  {
+    name: 'session stop (leaf session.stop)',
+    leaf: A.PROJECT_SESSION_STOP, method: 'POST',
+    path: () => `/v1/projects/${PROJECT}/sessions/${sid()}/stop`,
+    tier: 'member',
+    // floor is session.start, so the deny grant must hold start (to reach the
+    // stop assert) but not stop.
+    denyGrant: [A.PROJECT_SESSION_START], allowGrant: [A.PROJECT_SESSION_START, A.PROJECT_SESSION_STOP],
+  },
+  // ── Review ───────────────────────────────────────────────────────────────
+  {
+    name: 'CR request-changes (review.act, not gitops.push)',
+    leaf: A.PROJECT_REVIEW_ACT, method: 'POST',
+    path: () => `/v1/projects/${PROJECT}/change-requests/${sid()}/request-changes`, body: {},
+    tier: 'editor',
+    // deny with gitops.push (the OLD leaf) to prove the gate is now review.act.
+    denyGrant: [A.PROJECT_GITOPS_PUSH], allowGrant: [A.PROJECT_REVIEW_ACT],
+  },
+  {
+    name: 'review item submit (review.submit)',
+    leaf: A.PROJECT_REVIEW_SUBMIT, method: 'POST',
+    path: () => `/v1/projects/${PROJECT}/review/items`, body: {},
+    tier: 'member', denyGrant: [A.PROJECT_TRIGGER_FIRE], allowGrant: [A.PROJECT_REVIEW_SUBMIT],
+  },
+  // ── Connectors (write) ───────────────────────────────────────────────────
+  {
+    name: 'email connect (connector.write)',
+    leaf: A.PROJECT_CONNECTOR_WRITE, method: 'POST',
+    path: () => `/v1/projects/${PROJECT}/channels/email/connect`, body: {},
+    tier: 'editor', denyGrant: [A.PROJECT_TRIGGER_FIRE], allowGrant: [A.PROJECT_CONNECTOR_WRITE],
+  },
+  {
+    name: 'email installation PATCH (connector.write)',
+    leaf: A.PROJECT_CONNECTOR_WRITE, method: 'PATCH',
+    path: () => `/v1/projects/${PROJECT}/channels/email/installation`, body: {},
+    tier: 'editor', denyGrant: [A.PROJECT_TRIGGER_FIRE], allowGrant: [A.PROJECT_CONNECTOR_WRITE],
+  },
+  {
+    name: 'email installation DELETE (connector.write)',
+    leaf: A.PROJECT_CONNECTOR_WRITE, method: 'DELETE',
+    path: () => `/v1/projects/${PROJECT}/channels/email/installation`,
+    tier: 'editor', denyGrant: [A.PROJECT_TRIGGER_FIRE], allowGrant: [A.PROJECT_CONNECTOR_WRITE],
+  },
+  {
+    name: 'channel binding PATCH (connector.write)',
+    leaf: A.PROJECT_CONNECTOR_WRITE, method: 'PATCH',
+    path: () => `/v1/projects/${PROJECT}/channels/bindings/${sid()}`, body: {},
+    tier: 'editor', denyGrant: [A.PROJECT_TRIGGER_FIRE], allowGrant: [A.PROJECT_CONNECTOR_WRITE],
+  },
+  {
+    name: 'connect-requests (connector.write)',
+    leaf: A.PROJECT_CONNECTOR_WRITE, method: 'POST',
+    path: () => `/v1/projects/${PROJECT}/connect-requests`, body: {},
+    tier: 'editor', denyGrant: [A.PROJECT_TRIGGER_FIRE], allowGrant: [A.PROJECT_CONNECTOR_WRITE],
+  },
+  // ── Connectors (read) ────────────────────────────────────────────────────
+  {
+    name: 'channel bindings list (connector.read)',
+    leaf: A.PROJECT_CONNECTOR_READ, method: 'GET',
+    path: () => `/v1/projects/${PROJECT}/channels/bindings`,
+    tier: 'member', denyGrant: [A.PROJECT_TRIGGER_FIRE], allowGrant: [A.PROJECT_CONNECTOR_READ],
+  },
+  // ── Customize (write) ────────────────────────────────────────────────────
+  {
+    name: 'meet bot name (customize.write)',
+    leaf: A.PROJECT_CUSTOMIZE_WRITE, method: 'PUT',
+    path: () => `/v1/projects/${PROJECT}/channels/meet/name`, body: {},
+    tier: 'editor', denyGrant: [A.PROJECT_TRIGGER_FIRE], allowGrant: [A.PROJECT_CUSTOMIZE_WRITE],
+  },
+  {
+    name: 'meet voice (customize.write)',
+    leaf: A.PROJECT_CUSTOMIZE_WRITE, method: 'PUT',
+    path: () => `/v1/projects/${PROJECT}/channels/meet/voice`, body: {},
+    tier: 'editor', denyGrant: [A.PROJECT_TRIGGER_FIRE], allowGrant: [A.PROJECT_CUSTOMIZE_WRITE],
+  },
+  {
+    // Strict body (ModelDefaultBody) is validated at the OpenAPI layer BEFORE the
+    // handler, so send a schema-valid body — otherwise a 400 pre-empts the gate.
+    name: 'model-defaults PUT (customize.write)',
+    leaf: A.PROJECT_CUSTOMIZE_WRITE, method: 'PUT',
+    path: () => `/v1/projects/${PROJECT}/model-defaults`, body: { scope: 'project', model: 'openai/gpt-4o' },
+    tier: 'editor', denyGrant: [A.PROJECT_TRIGGER_FIRE], allowGrant: [A.PROJECT_CUSTOMIZE_WRITE],
+  },
+  {
+    name: 'model-defaults DELETE (customize.write)',
+    leaf: A.PROJECT_CUSTOMIZE_WRITE, method: 'DELETE',
+    path: () => `/v1/projects/${PROJECT}/model-defaults?scope=project`,
+    tier: 'editor', denyGrant: [A.PROJECT_TRIGGER_FIRE], allowGrant: [A.PROJECT_CUSTOMIZE_WRITE],
+  },
+  {
+    name: 'experimental toggle (customize.write)',
+    leaf: A.PROJECT_CUSTOMIZE_WRITE, method: 'PATCH',
+    path: () => `/v1/projects/${PROJECT}/experimental`, body: {},
+    tier: 'editor', denyGrant: [A.PROJECT_TRIGGER_FIRE], allowGrant: [A.PROJECT_CUSTOMIZE_WRITE],
+  },
+  {
+    name: 'sandbox-provider (customize.write)',
+    leaf: A.PROJECT_CUSTOMIZE_WRITE, method: 'PATCH',
+    path: () => `/v1/projects/${PROJECT}/sandbox-provider`, body: {},
+    tier: 'editor', denyGrant: [A.PROJECT_TRIGGER_FIRE], allowGrant: [A.PROJECT_CUSTOMIZE_WRITE],
+  },
+  // ── Agent scope (agent.write) ────────────────────────────────────────────
+  {
+    name: 'agent scope PUT (agent.write)',
+    leaf: A.PROJECT_AGENT_WRITE, method: 'PUT',
+    path: () => `/v1/projects/${PROJECT}/agents/scoped-bot/scope`, body: {},
+    tier: 'editor', denyGrant: [A.PROJECT_TRIGGER_FIRE], allowGrant: [A.PROJECT_AGENT_WRITE],
+  },
+  // ── Secrets (write) ──────────────────────────────────────────────────────
+  {
+    name: 'secret-requests (secret.write)',
+    leaf: A.PROJECT_SECRET_WRITE, method: 'POST',
+    path: () => `/v1/projects/${PROJECT}/secret-requests`, body: {},
+    tier: 'editor', denyGrant: [A.PROJECT_TRIGGER_FIRE], allowGrant: [A.PROJECT_SECRET_WRITE],
+  },
+];
+
+describe('HTTP enforcement — project write/lifecycle leaf gates (every checkbox authoritative)', () => {
+  for (const c of CASES) {
+    describe(c.name, () => {
+      test('scoped agent with an UNRELATED grant → denied by the leaf gate', async () => {
+        const secret = await mint(EDITOR, c.denyGrant);
+        const res = await req(c.method, c.path(), secret, c.body);
+        expect(await iamDenied(res)).toBe(true);
+      });
+
+      test('scoped agent granted the exact leaf → NOT denied by the leaf gate', async () => {
+        const secret = await mint(EDITOR, c.allowGrant);
+        const res = await req(c.method, c.path(), secret, c.body);
+        expect(await iamDenied(res)).toBe(false);
+      });
+
+      if (c.tier === 'editor') {
+        test('plain MEMBER (lacks the editor-tier leaf) → denied', async () => {
+          const secret = await mint(MEMBER, null);
+          const res = await req(c.method, c.path(), secret, c.body);
+          expect(await iamDenied(res)).toBe(true);
+        });
+        test('plain EDITOR (holds the leaf) → NOT denied', async () => {
+          const secret = await mint(EDITOR, null);
+          const res = await req(c.method, c.path(), secret, c.body);
+          expect(await iamDenied(res)).toBe(false);
+        });
+      } else {
+        test('plain MEMBER (floor role holds the leaf) → NOT denied', async () => {
+          const secret = await mint(MEMBER, null);
+          const res = await req(c.method, c.path(), secret, c.body);
+          expect(await iamDenied(res)).toBe(false);
+        });
+      }
+    });
+  }
+});

--- a/apps/api/src/projects/routes/agent-scope.ts
+++ b/apps/api/src/projects/routes/agent-scope.ts
@@ -14,8 +14,9 @@
 import { createRoute, z } from '@hono/zod-openapi';
 import { auth, errors, json } from '../../openapi';
 import { applyAgentScope, extractAgents } from '../agents';
-import { loadProjectForUser } from '../lib/access';
+import { assertProjectCapability, loadProjectForUser } from '../lib/access';
 import { projectsApp } from '../lib/app';
+import { PROJECT_ACTIONS } from '../../iam';
 import { commitManifest, loadManifestForEdit } from '../lib/triggers';
 
 // `'all'` = every item the launcher can see; a list = an explicit allowlist;
@@ -43,8 +44,14 @@ projectsApp.openapi(
   async (c: any) => {
     const projectId = c.req.param('projectId');
     const agentName = c.req.param('agentName');
-    const loaded = await loadProjectForUser(c, projectId, 'manage');
+    // Floor 'read' (membership); the real gate is project.agent.write below.
+    // Scoping an agent edits its `[[agents]]` manifest entry (binding its
+    // connectors AND secrets), so it's an agent-config edit — agent.write is the
+    // precise leaf (a single connector/secret leaf wouldn't cover both). Was
+    // 'manage' → project.write, so unchecking agent.write did nothing here.
+    const loaded = await loadProjectForUser(c, projectId, 'read');
     if (!loaded) return c.json({ error: 'Not found' }, 404);
+    await assertProjectCapability(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_AGENT_WRITE);
 
     const parsed = AgentScopeBody.safeParse(await c.req.json().catch(() => null));
     if (!parsed.success) return c.json({ error: 'Invalid body', code: 'invalid_body' }, 400);

--- a/apps/api/src/projects/routes/channel-bindings.ts
+++ b/apps/api/src/projects/routes/channel-bindings.ts
@@ -77,6 +77,10 @@ projectsApp.openapi(
     const projectId = c.req.param("projectId");
     const loaded = await loadProjectForUser(c, projectId, "read");
     if (!loaded) return c.json({ error: "Not found" }, 404);
+    // Listing channel↔agent bindings exposes which connectors the project's
+    // channels talk through — connector-read info. Gate on connector.read so
+    // unchecking it in a custom role is denied. Every built-in role holds it.
+    await assertProjectCapability(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_CONNECTOR_READ);
 
     const projectDefaultAgent = projectDefaultAgentOf(loaded.row.metadata);
     const bindings = await listChannelBindingsForProject(projectId);
@@ -111,7 +115,9 @@ projectsApp.openapi(
   async (c: any) => {
     const projectId = c.req.param("projectId");
     const bindingId = c.req.param("bindingId");
-    const loaded = await loadProjectForUser(c, projectId, "manage");
+    // Floor 'read'; project.connector.write below is the real gate (was 'manage'
+    // → project.write, which over-gated a custom connector.write-only role).
+    const loaded = await loadProjectForUser(c, projectId, "read");
     if (!loaded) return c.json({ error: "Not found" }, 404);
     // No dedicated "channel binding write" leaf exists yet (the channel.* actions
     // in iam/actions.ts are scoped to resource_type='channel' and aren't wired

--- a/apps/api/src/projects/routes/model-defaults.ts
+++ b/apps/api/src/projects/routes/model-defaults.ts
@@ -16,8 +16,9 @@ import {
   getAccountModelDefaults,
   upsertAccountModelPreference,
 } from "../../repositories/model-preferences";
-import { loadProjectForUser } from "../lib/access";
+import { assertProjectCapability, loadProjectForUser } from "../lib/access";
 import { projectsApp } from "../lib/app";
+import { PROJECT_ACTIONS } from "../../iam";
 
 /** A storable default must be a concrete model — a managed id (bare or
  *  kortix/-prefixed), or a `provider/model` BYOK/direct wire — never the
@@ -81,8 +82,11 @@ projectsApp.openapi(
   }),
   async (c: any) => {
     const projectId = c.req.param("projectId");
-    const loaded = await loadProjectForUser(c, projectId, "manage");
+    // Floor 'read'; project.customize.write is the real gate (model defaults are
+    // project customization). Built-in editor/manager hold the leaf.
+    const loaded = await loadProjectForUser(c, projectId, "read");
     if (!loaded) return c.json({ error: "Not found" }, 404);
+    await assertProjectCapability(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_CUSTOMIZE_WRITE);
     const accountId = loaded.row.accountId as string;
     const userId = c.get("userId") as string;
 
@@ -121,8 +125,10 @@ projectsApp.openapi(
   }),
   async (c: any) => {
     const projectId = c.req.param("projectId");
-    const loaded = await loadProjectForUser(c, projectId, "manage");
+    // Floor 'read'; project.customize.write is the real gate (see PUT above).
+    const loaded = await loadProjectForUser(c, projectId, "read");
     if (!loaded) return c.json({ error: "Not found" }, 404);
+    await assertProjectCapability(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_CUSTOMIZE_WRITE);
     const accountId = loaded.row.accountId as string;
     const scope = c.req.query("scope");
     const agentName = c.req.query("agentName");

--- a/apps/api/src/projects/routes/r11.ts
+++ b/apps/api/src/projects/routes/r11.ts
@@ -122,6 +122,9 @@ projectsApp.openapi(
     const body = await readBody(c);
     const loaded = await loadProjectForUser(c, projectId, 'read');
     if (!loaded) return c.json({ error: 'Not found' }, 404);
+    // Human gate: submitting a reviewable needs project.review.submit. Every
+    // built-in role holds it; a custom role that unchecks it is denied here.
+    await assertProjectCapability(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_REVIEW_SUBMIT);
     // Agent-side gate: submitting a reviewable is the agent's intended path.
     assertAgentScope(c, 'project.review.submit');
 

--- a/apps/api/src/projects/routes/r4.ts
+++ b/apps/api/src/projects/routes/r4.ts
@@ -662,8 +662,12 @@ projectsApp.openapi(
   }),
   async (c: any) => {
     const projectId = c.req.param("projectId");
-    const loaded = await loadProjectForUser(c, projectId, "manage");
+    // Floor 'read' (membership); the connector.write leaf below is the real gate,
+    // so a custom role that unchecks connector.write is denied even if it holds
+    // project.write. Built-in editor/manager hold the leaf.
+    const loaded = await loadProjectForUser(c, projectId, "read");
     if (!loaded) return c.json({ error: "Not found" }, 404);
+    await assertProjectCapability(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_CONNECTOR_WRITE);
     if (!emailChannelEnabled(loaded.row.metadata)) {
       return c.json(
         {
@@ -815,8 +819,10 @@ projectsApp.openapi(
   }),
   async (c: any) => {
     const projectId = c.req.param("projectId");
-    const loaded = await loadProjectForUser(c, projectId, "manage");
+    // Floor 'read'; project.connector.write is the real gate (see /email/connect).
+    const loaded = await loadProjectForUser(c, projectId, "read");
     if (!loaded) return c.json({ error: "Not found" }, 404);
+    await assertProjectCapability(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_CONNECTOR_WRITE);
     if (!emailChannelEnabled(loaded.row.metadata)) {
       return c.json(
         {
@@ -873,8 +879,10 @@ projectsApp.openapi(
   }),
   async (c: any) => {
     const projectId = c.req.param("projectId");
-    const loaded = await loadProjectForUser(c, projectId, "manage");
+    // Floor 'read'; project.connector.write is the real gate (see /email/connect).
+    const loaded = await loadProjectForUser(c, projectId, "read");
     if (!loaded) return c.json({ error: "Not found" }, 404);
+    await assertProjectCapability(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_CONNECTOR_WRITE);
     const connectorSlug =
       c.req.query("connector_slug") ||
       c.req.query("profile_slug") ||
@@ -1285,8 +1293,11 @@ projectsApp.openapi(
   }),
   async (c: any) => {
     const projectId = c.req.param("projectId");
-    const loaded = await loadProjectForUser(c, projectId, "manage");
+    // Floor 'read'; project.customize.write is the real gate (setting the bot
+    // name is project customization). Built-in editor/manager hold the leaf.
+    const loaded = await loadProjectForUser(c, projectId, "read");
     if (!loaded) return c.json({ error: "Not found" }, 404);
+    await assertProjectCapability(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_CUSTOMIZE_WRITE);
     const body = await readBody(c);
     const name = String(body.name ?? body.bot_name ?? "");
     const saved = await setProjectBotName(projectId, name);
@@ -1313,8 +1324,11 @@ projectsApp.openapi(
   }),
   async (c: any) => {
     const projectId = c.req.param("projectId");
-    const loaded = await loadProjectForUser(c, projectId, "manage");
+    // Floor 'read'; project.customize.write is the real gate (choosing the voice
+    // is project customization). Built-in editor/manager hold the leaf.
+    const loaded = await loadProjectForUser(c, projectId, "read");
     if (!loaded) return c.json({ error: "Not found" }, 404);
+    await assertProjectCapability(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_CUSTOMIZE_WRITE);
     const body = await readBody(c);
     const voiceId = String(body.voice ?? "");
     if (!isMeetVoice(voiceId)) return c.json({ error: "unknown voice" }, 400);
@@ -1559,8 +1573,13 @@ projectsApp.openapi(
   }),
   async (c: any) => {
     const projectId = c.req.param("projectId");
-    const loaded = await loadProjectForUser(c, projectId, "manage");
+    // Floor 'read'; project.customize.write is the real gate (model defaults are
+    // project customization). NOTE: /{projectId}/model-defaults is ALSO defined in
+    // routes/model-defaults.ts (registered later in projects/index.ts) — both are
+    // gated here to be safe against route-registration order; dedupe is follow-up.
+    const loaded = await loadProjectForUser(c, projectId, "read");
     if (!loaded) return c.json({ error: "Not found" }, 404);
+    await assertProjectCapability(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_CUSTOMIZE_WRITE);
     const ownerAccountId = loaded.row.accountId as string;
     const userId = c.get("userId") as string;
 
@@ -1639,8 +1658,11 @@ projectsApp.openapi(
   }),
   async (c: any) => {
     const projectId = c.req.param("projectId");
-    const loaded = await loadProjectForUser(c, projectId, "manage");
+    // Floor 'read'; project.customize.write is the real gate (see PUT above; also
+    // mirrored in routes/model-defaults.ts).
+    const loaded = await loadProjectForUser(c, projectId, "read");
     if (!loaded) return c.json({ error: "Not found" }, 404);
+    await assertProjectCapability(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_CUSTOMIZE_WRITE);
     const ownerAccountId = loaded.row.accountId as string;
     const scope = c.req.query("scope");
     const agentName = c.req.query("agentName");

--- a/apps/api/src/projects/routes/r4.ts
+++ b/apps/api/src/projects/routes/r4.ts
@@ -1829,7 +1829,12 @@ projectsApp.openapi(
   async (c: any) => {
     const projectId = c.req.param("projectId");
     const slug = c.req.param("slug");
-    const loaded = await loadProjectForUser(c, projectId, "manage");
+    // Floor 'read' (membership); project.trigger.fire is the real gate. The floor
+    // was 'manage' (= project.write) — which the floor `member` role LACKS even
+    // though it HOLDS trigger.fire, so a plain member could never fire a trigger
+    // (its designed fire grant was dead behind the floor). Now member/editor/
+    // manager all fire (all hold the leaf); a custom role without it is denied.
+    const loaded = await loadProjectForUser(c, projectId, "read");
     if (!loaded) return c.json({ error: "Not found" }, 404);
     await assertProjectCapability(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_TRIGGER_FIRE);
 

--- a/apps/api/src/projects/routes/r6.ts
+++ b/apps/api/src/projects/routes/r6.ts
@@ -1121,8 +1121,11 @@ projectsApp.openapi(
     const body = await readBody(c);
     const feature = body.feature;
     const enabled = body.enabled;
-    const loaded = await loadProjectForUser(c, projectId, 'manage');
+    // Floor 'read' (membership); project.customize.write is the human gate below
+    // (was 'manage' → project.write, so unchecking customize.write did nothing).
+    const loaded = await loadProjectForUser(c, projectId, 'read');
     if (!loaded) return c.json({ error: 'Not found' }, 404);
+    await assertProjectCapability(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_CUSTOMIZE_WRITE);
     // Per-agent gate: toggling experimental features is project config. A scoped
     // agent token must hold project.customize.write (no-op for humans/PATs).
     assertAgentScope(c, PROJECT_ACTIONS.PROJECT_CUSTOMIZE_WRITE);
@@ -1179,8 +1182,11 @@ projectsApp.openapi(
     const body = await readBody(c);
     const raw = body.provider ?? body.sandbox_provider;
     const provider = raw === null || raw === undefined || raw === '' ? null : String(raw);
-    const loaded = await loadProjectForUser(c, projectId, 'manage');
+    // Floor 'read'; project.customize.write is the human gate below (was
+    // 'manage' → project.write, so unchecking customize.write did nothing here).
+    const loaded = await loadProjectForUser(c, projectId, 'read');
     if (!loaded) return c.json({ error: 'Not found' }, 404);
+    await assertProjectCapability(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_CUSTOMIZE_WRITE);
     assertAgentScope(c, PROJECT_ACTIONS.PROJECT_CUSTOMIZE_WRITE);
     if (provider !== null && !config.isProviderEnabled(provider as SandboxProviderName)) {
       return c.json({ error: `Unknown or disabled sandbox provider: ${provider}` }, 400);

--- a/apps/api/src/projects/routes/r8.ts
+++ b/apps/api/src/projects/routes/r8.ts
@@ -57,7 +57,10 @@ projectsApp.openapi(
     if (!UUID_V4_REGEX.test(sessionId))
       return c.json({ error: 'Invalid session id' }, 400);
 
-    const loaded = await loadProjectForUser(c, projectId, 'read');
+    // Floor 'session' (= project.session.start) so the human gate matches
+    // restart/stop and a custom role that withholds session.start is denied here
+    // (was 'read', which let any project-reader start sessions).
+    const loaded = await loadProjectForUser(c, projectId, 'session');
     if (!loaded) return c.json({ error: 'Not found' }, 404);
     // Per-agent gate: resuming a session provisions compute. A scoped agent
     // token must hold project.session.start (no-op for human/PAT tokens).
@@ -174,6 +177,10 @@ projectsApp.openapi(
     // Per-agent gate: same capability as start/restart — stopping is part of
     // the agent's session-lifecycle surface.
     assertAgentScope(c, PROJECT_ACTIONS.PROJECT_SESSION_START);
+    // Human gate: stopping has its own leaf (project.session.stop), distinct from
+    // start, so a custom role can allow one and withhold the other. Every
+    // built-in role holds it, so member/editor/manager are unaffected.
+    await assertProjectCapability(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_SESSION_STOP);
 
     // Stop is reserved for the session owner or an account owner/admin, same policy
     // as restart.
@@ -650,12 +657,16 @@ projectsApp.openapi(
     const body = await readBody(c);
     const loaded = await loadProjectForUser(c, projectId, 'write');
     if (!loaded) return c.json({ error: 'Not found' }, 404);
+    // request-changes is a human review decision on a CR, not a code push —
+    // gate it on project.review.act (the same leaf as /review/items/{id}/act),
+    // not gitops.push. Editor/manager hold both; a custom reviewer role with
+    // review.act but no gitops.push can now request changes.
     await assertProjectCapability(
       c,
       loaded.userId,
       loaded.row.accountId,
       projectId,
-      PROJECT_ACTIONS.PROJECT_GITOPS_PUSH,
+      PROJECT_ACTIONS.PROJECT_REVIEW_ACT,
     );
 
     const feedback = normalizeString(body.feedback ?? body.text);

--- a/apps/api/src/projects/routes/setup-links.ts
+++ b/apps/api/src/projects/routes/setup-links.ts
@@ -18,8 +18,9 @@ import { loadPipedreamConnector } from '../../executor/db-deps';
 import { pipedreamConfigured } from '../../executor/pipedream';
 import { mintSetupLink, type SecretFieldSpec } from '../../setup-links/token';
 import { isValidSecretName } from '../secrets';
-import { loadProjectForUser } from '../lib/access';
+import { assertProjectCapability, loadProjectForUser } from '../lib/access';
 import { AnyObject, projectsApp } from '../lib/app';
+import { PROJECT_ACTIONS } from '../../iam';
 import { CODEX_AUTH_JSON_SECRET_NAME, normalizeString, readBody } from '../lib/serializers';
 
 function frontendBase(): string {
@@ -49,8 +50,12 @@ projectsApp.openapi(
   async (c: any) => {
     const projectId = c.req.param('projectId');
     const body = await readBody(c);
-    const loaded = await loadProjectForUser(c, projectId, 'manage');
+    // Floor 'read'; project.secret.write is the real gate — the same leaf as
+    // POST /secrets. Was 'manage' → project.write, so unchecking secret.write
+    // did nothing here.
+    const loaded = await loadProjectForUser(c, projectId, 'read');
     if (!loaded) return c.json({ error: 'Not found' }, 404);
+    await assertProjectCapability(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_SECRET_WRITE);
 
     // Accept `names: [...]` or a single `name`.
     const rawNames: unknown[] = Array.isArray(body.names)
@@ -128,8 +133,11 @@ projectsApp.openapi(
   async (c: any) => {
     const projectId = c.req.param('projectId');
     const body = await readBody(c);
-    const loaded = await loadProjectForUser(c, projectId, 'manage');
+    // Floor 'read'; project.connector.write is the real gate (minting a Pipedream
+    // Quick Connect link is a connector operation). Was 'manage' → project.write.
+    const loaded = await loadProjectForUser(c, projectId, 'read');
     if (!loaded) return c.json({ error: 'Not found' }, 404);
+    await assertProjectCapability(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_CONNECTOR_WRITE);
 
     if (!pipedreamConfigured()) return c.json({ error: 'Pipedream is not configured on this deployment' }, 501);
 


### PR DESCRIPTION
## What

Part 2 of making the granular RBAC checkboxes authoritative for custom roles (enterprise pilot). PR #4275 fixed the *over-gated* members-governance routes; this PR closes the **enforcement HOLES** the capability-enforcement audit found — endpoints that gated on a coarse floor only (or an `assertAgentScope` check that is a no-op for humans), so **unchecking the matching leaf in a custom role did nothing**.

Every fix: assert the granular leaf, and drop the floor to `'read'` so the leaf is the *sole* capability gate (no over-gating a granular custom role). Built-in member/editor/manager are unaffected — they already hold these leaves.

## Holes closed

| Route | Leaf now enforced |
|---|---|
| POST `/sessions/{id}/start` | `session.start` (floor was `read`; now matches stop/restart) |
| POST `/sessions/{id}/stop` | `session.stop` (distinct human leaf) |
| POST `/change-requests/{id}/request-changes` | `review.act` (was the **wrong** `gitops.push`) |
| POST `/review/items` | `review.submit` |
| POST `/channels/email/connect`, PATCH/DELETE `/channels/email/installation` | `connector.write` |
| PATCH `/channels/bindings/{id}`, POST `/connect-requests` | `connector.write` |
| GET `/channels/bindings` | `connector.read` |
| PUT `/agents/{name}/scope` | `agent.write` (edits the agent's manifest entry — binds its connectors **and** secrets, so `agent.write` is the precise umbrella; audit suggested `connector.write`) |
| PUT `/channels/meet/name`, `/channels/meet/voice`, PUT/DELETE `/model-defaults`, PATCH `/experimental`, `/sandbox-provider` | `customize.write` |
| POST `/secret-requests` | `secret.write` (same leaf as POST `/secrets`) |

## Notes for review

- **Dropped 2 audit findings** as false positives: adding a *human* `project.cr.open` gate to CR close/reopen would 403 built-in editors — `cr.open`/`cr.merge` are **agent-scope-only** leaves (not in any built-in role); those routes are correctly gated by the `write` floor + `assertAgentScope`.
- **`/model-defaults` is defined twice** (routes/r4.ts *and* routes/model-defaults.ts, both registered in projects/index.ts). Both copies are gated here to be safe against route-registration order — the duplication itself is flagged for a follow-up dedupe.
- **`agent-scope` uses `agent.write`, not the audit's `connector.write`** — see table note.

## Test

`integration-project-write-leaf-gates-http.test.ts` drives every gate via the agent-grant fold (`AGENT_GRANT_EXEMPT_ACTIONS` = `project.read`/`project.write` only, so the coarse floor always passes and only the specific leaf is under test): unrelated grant → 403, exact leaf → pass, plus member/editor tier checks. `request-changes` is proven to gate `review.act` by denying a `gitops.push` grant. **68/68 green**; read-leaf + members-manage + role-perms suites still green (98/98).
