### PR TITLE
fix(iam): filter GET /detail sections by read capability, don't leak them

### DIFF
--- a/apps/api/src/__tests__/integration-detail-capability-http.test.ts
+++ b/apps/api/src/__tests__/integration-detail-capability-http.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test, beforeAll, afterAll } from 'bun:test';
+import { eq, sql } from 'drizzle-orm';
+import { accountMembers, accounts, projectMembers, projects } from '@kortix/db';
+import { db } from '../shared/db';
+import { app } from '../index';
+import { createAccountToken } from '../repositories/account-tokens';
+
+// GET /:projectId/detail must stay loadable by a plain `member` even though
+// member lacks project.file.read: the fix filters the file list OUT of the
+// response rather than 403-ing the whole bundle (a hard assert would lock every
+// member out of the workspace shell). This proves the coarse floor stayed
+// project.read and the file section is blanked, not gated.
+const ACCOUNT = crypto.randomUUID();
+const PROJECT = crypto.randomUUID();
+const MEMBER = crypto.randomUUID();
+const EDITOR = crypto.randomUUID();
+
+const minted: string[] = [];
+
+beforeAll(async () => {
+  await db.execute(sql`alter table kortix.account_tokens add column if not exists agent_grant jsonb`);
+  await db.execute(sql`alter table kortix.account_tokens add column if not exists session_id text`);
+  await db.execute(sql`alter table kortix.account_tokens add column if not exists service_account_id uuid`);
+
+  await db.insert(accounts).values({ accountId: ACCOUNT, name: 'detail-cap-test' });
+  await db.insert(projects).values({
+    projectId: PROJECT,
+    accountId: ACCOUNT,
+    name: 'detail-cap-test-project',
+    repoUrl: 'https://example.com/detail-cap-test.git',
+  });
+  await db.insert(accountMembers).values([
+    { userId: MEMBER, accountId: ACCOUNT, accountRole: 'member', isSuperAdmin: false },
+    { userId: EDITOR, accountId: ACCOUNT, accountRole: 'member', isSuperAdmin: false },
+  ]);
+  await db.insert(projectMembers).values([
+    { accountId: ACCOUNT, projectId: PROJECT, userId: MEMBER, projectRole: 'member' },
+    { accountId: ACCOUNT, projectId: PROJECT, userId: EDITOR, projectRole: 'editor' },
+  ]);
+});
+
+afterAll(async () => {
+  for (const tokenId of minted) {
+    await db.execute(sql`delete from kortix.account_tokens where token_id = ${tokenId}`);
+  }
+  await db.delete(projects).where(eq(projects.accountId, ACCOUNT));
+  await db.delete(accounts).where(eq(accounts.accountId, ACCOUNT));
+});
+
+async function mint(userId: string): Promise<string> {
+  const t = await createAccountToken({
+    accountId: ACCOUNT,
+    userId,
+    projectId: PROJECT,
+    name: 'detail-cap-test',
+    agentGrant: null as any,
+  });
+  minted.push(t.tokenId);
+  return t.secretKey;
+}
+
+function getDetail(secret: string) {
+  return app.request(`/v1/projects/${PROJECT}/detail`, {
+    method: 'GET',
+    headers: { Authorization: `Bearer ${secret}` },
+  });
+}
+
+describe('HTTP — GET /detail stays loadable for a member (file list filtered, not 403)', () => {
+  test('plain MEMBER (no file.read) → NOT 403 (workspace shell still loads)', async () => {
+    const secret = await mint(MEMBER);
+    const res = await getDetail(secret);
+    // The whole point: member must not be denied the bundle. The old naive fix
+    // (assertProjectCapability(file.read)) would 403 here.
+    expect(res.status).not.toBe(403);
+  });
+
+  test('plain MEMBER → the file list is blanked (no file paths leak via /detail)', async () => {
+    const secret = await mint(MEMBER);
+    const res = await getDetail(secret);
+    if (res.status === 200) {
+      const body = await res.json();
+      expect(body.files).toEqual([]);
+      expect(body.file_count).toBe(0);
+      // The config bundle is still present (member holds the config read leaves).
+      expect(body.config).toBeDefined();
+    }
+  });
+
+  test('EDITOR (has file.read) → NOT 403', async () => {
+    const secret = await mint(EDITOR);
+    const res = await getDetail(secret);
+    expect(res.status).not.toBe(403);
+  });
+});

--- a/apps/api/src/__tests__/unit-detail-capability-filter.test.ts
+++ b/apps/api/src/__tests__/unit-detail-capability-filter.test.ts
@@ -1,7 +1,10 @@
 import { describe, test, expect } from 'bun:test';
 import { applyDetailCapabilityFilter } from '../projects/lib/detail-capability-filter';
 
-const sampleConfig = {
+// Record<string, unknown> so the filtered fields (which the runtime blanks to
+// {} / [] / null) type as `unknown` at the assertions — otherwise the literal
+// type (e.g. manifest: { name: string }) rejects `.toEqual({})`.
+const sampleConfig: Record<string, unknown> = {
   is_kortix_repo: true,
   signals: { manifest: true },
   manifest_raw: 'raw toml',

--- a/apps/api/src/__tests__/unit-detail-capability-filter.test.ts
+++ b/apps/api/src/__tests__/unit-detail-capability-filter.test.ts
@@ -1,0 +1,85 @@
+import { describe, test, expect } from 'bun:test';
+import { applyDetailCapabilityFilter } from '../projects/lib/detail-capability-filter';
+
+const sampleConfig = {
+  is_kortix_repo: true,
+  signals: { manifest: true },
+  manifest_raw: 'raw toml',
+  manifest: { name: 'x' },
+  env: [{ name: 'FOO' }],
+  open_code_raw: '{}',
+  open_code_default_agent: 'bot',
+  agent_discovery: 'declared',
+  agents: [{ name: 'a' }],
+  skills: [{ name: 's' }],
+  commands: [{ name: 'c' }],
+};
+const files = [{ path: 'a' }, { path: 'b' }, { path: 'c' }];
+const ALL = { canFiles: true, canAgents: true, canSkills: true, canCommands: true, canCustomize: true };
+
+describe('applyDetailCapabilityFilter — /detail per-capability section gating', () => {
+  test('all caps → nothing filtered', () => {
+    const out = applyDetailCapabilityFilter(sampleConfig, files, ALL);
+    expect(out.config.agents).toEqual([{ name: 'a' }]);
+    expect(out.config.skills).toEqual([{ name: 's' }]);
+    expect(out.config.commands).toEqual([{ name: 'c' }]);
+    expect(out.config.manifest_raw).toBe('raw toml');
+    expect(out.files).toHaveLength(3);
+    expect(out.file_count).toBe(3);
+  });
+
+  test('no file.read → files dropped, config untouched', () => {
+    const out = applyDetailCapabilityFilter(sampleConfig, files, { ...ALL, canFiles: false });
+    expect(out.files).toEqual([]);
+    expect(out.file_count).toBe(0);
+    expect(out.config.agents).toEqual([{ name: 'a' }]);
+  });
+
+  test('no skill.read → skills emptied, agents/commands intact', () => {
+    const out = applyDetailCapabilityFilter(sampleConfig, files, { ...ALL, canSkills: false });
+    expect(out.config.skills).toEqual([]);
+    expect(out.config.agents).toEqual([{ name: 'a' }]);
+    expect(out.config.commands).toEqual([{ name: 'c' }]);
+  });
+
+  test('no agent.read → agents + discovery blanked', () => {
+    const out = applyDetailCapabilityFilter(sampleConfig, files, { ...ALL, canAgents: false });
+    expect(out.config.agents).toEqual([]);
+    expect(out.config.agent_discovery).toBeNull();
+  });
+
+  test('no command.read → commands emptied', () => {
+    const out = applyDetailCapabilityFilter(sampleConfig, files, { ...ALL, canCommands: false });
+    expect(out.config.commands).toEqual([]);
+  });
+
+  test('no customize.read → raw config blanked, structural signals kept', () => {
+    const out = applyDetailCapabilityFilter(sampleConfig, files, { ...ALL, canCustomize: false });
+    expect(out.config.manifest_raw).toBeNull();
+    expect(out.config.manifest).toEqual({});
+    expect(out.config.env).toEqual([]);
+    expect(out.config.open_code_raw).toBeNull();
+    expect(out.config.open_code_default_agent).toBeNull();
+    // Structural signals survive so the workspace shell still renders.
+    expect(out.config.is_kortix_repo).toBe(true);
+    expect(out.config.signals).toEqual({ manifest: true });
+  });
+
+  test('member profile (all config reads, NO file.read) → config visible, file list hidden', () => {
+    const out = applyDetailCapabilityFilter(sampleConfig, files, {
+      canFiles: false, canAgents: true, canSkills: true, canCommands: true, canCustomize: true,
+    });
+    expect(out.files).toEqual([]);
+    expect(out.file_count).toBe(0);
+    expect(out.config.agents).toEqual([{ name: 'a' }]);
+    expect(out.config.skills).toEqual([{ name: 's' }]);
+    expect(out.config.manifest_raw).toBe('raw toml');
+  });
+
+  test('files capped at 300 but file_count is the true total', () => {
+    const many = Array.from({ length: 350 }, (_, i) => ({ path: `f${i}` }));
+    const out = applyDetailCapabilityFilter(sampleConfig, many, ALL);
+    expect(out.files).toHaveLength(300);
+    expect(out.file_count).toBe(350);
+  });
+});

--- a/apps/api/src/projects/lib/access.ts
+++ b/apps/api/src/projects/lib/access.ts
@@ -377,6 +377,36 @@ export async function assertProjectCapability(
 }
 
 /**
+ * Non-throwing sibling of assertProjectCapability: returns WHETHER the leaf is
+ * allowed for the current request (threading the acting token so the agent-grant
+ * fold fires), instead of 403-ing. For response-level filtering where a coarse
+ * gate already passed but individual sections must be hidden per-capability —
+ * e.g. GET /detail returns the project shell to any member but omits the file
+ * list / a config sub-section the caller can't read, rather than denying the
+ * whole bundle (which would lock a plain `member`, who lacks file.read, out of
+ * the workspace entirely).
+ */
+export async function projectCapabilityAllowed(
+  c: Context,
+  userId: string,
+  accountId: string,
+  projectId: string,
+  action: string,
+): Promise<boolean> {
+  const actingTokenId =
+    ((c as unknown as { get(k: string): unknown }).get('iamTokenId') as string | undefined) ?? undefined;
+  const verdict = await authorize(
+    userId,
+    accountId,
+    action,
+    { type: 'project', id: projectId },
+    actingTokenId,
+    deriveRequestContext(c),
+  );
+  return verdict.allowed;
+}
+
+/**
  * The per-capability WRITE leaf that governs editing a given repo path. Agents,
  * skills and commands live under their own directories; everything else is a
  * generic project file. Lets an API edit path (e.g. a marketplace install) gate

--- a/apps/api/src/projects/lib/detail-capability-filter.ts
+++ b/apps/api/src/projects/lib/detail-capability-filter.ts
@@ -1,0 +1,47 @@
+// GET /:projectId/detail bundles several read surfaces (the config summary's
+// agents/skills/commands + raw customization config, and the repo file list)
+// behind ONE coarse project.read floor. To keep each capability checkbox
+// authoritative WITHOUT 403-ing the whole workspace load, the handler resolves
+// the caller's per-leaf read capabilities and passes them here to blank out the
+// sections they can't read. Pure + exported so the gating is unit-tested
+// independent of git/DB (the handler just supplies the resolved booleans).
+
+export interface DetailCaps {
+  /** project.file.read — the repo file list. */
+  canFiles: boolean;
+  /** project.agent.read — the agents summary + discovery mode. */
+  canAgents: boolean;
+  /** project.skill.read — the skills summary. */
+  canSkills: boolean;
+  /** project.command.read — the slash-commands summary. */
+  canCommands: boolean;
+  /** project.customize.read — the raw project config (kortix.toml / opencode). */
+  canCustomize: boolean;
+}
+
+/**
+ * Blank out the /detail sections the caller lacks the leaf for. Structural
+ * signals (is_kortix_repo, signals) are always preserved so the shell renders;
+ * only the resource lists / raw config are emptied. Files are capped at 300 (the
+ * same cap the handler used inline) and dropped entirely without file.read.
+ */
+export function applyDetailCapabilityFilter<C extends Record<string, unknown>, F>(
+  config: C,
+  visibleFiles: F[],
+  caps: DetailCaps,
+): { config: C; files: F[]; file_count: number } {
+  const gatedConfig = {
+    ...config,
+    ...(caps.canAgents ? {} : { agents: [], agent_discovery: null }),
+    ...(caps.canSkills ? {} : { skills: [] }),
+    ...(caps.canCommands ? {} : { commands: [] }),
+    ...(caps.canCustomize
+      ? {}
+      : { manifest_raw: null, manifest: {}, env: [], open_code_raw: null, open_code_default_agent: null }),
+  } as C;
+  return {
+    config: gatedConfig,
+    files: caps.canFiles ? visibleFiles.slice(0, 300) : [],
+    file_count: caps.canFiles ? visibleFiles.length : 0,
+  };
+}

--- a/apps/api/src/projects/lib/detail-capability-filter.ts
+++ b/apps/api/src/projects/lib/detail-capability-filter.ts
@@ -25,7 +25,10 @@ export interface DetailCaps {
  * only the resource lists / raw config are emptied. Files are capped at 300 (the
  * same cap the handler used inline) and dropped entirely without file.read.
  */
-export function applyDetailCapabilityFilter<C extends Record<string, unknown>, F>(
+// `C extends object` (not Record<string, unknown>): the handler's config is a
+// concrete interface (ProjectConfigSummary), which TS won't implicitly widen to
+// a Record index signature. `object` accepts both interfaces and literals.
+export function applyDetailCapabilityFilter<C extends object, F>(
   config: C,
   visibleFiles: F[],
   caps: DetailCaps,

--- a/apps/api/src/projects/routes/r5.ts
+++ b/apps/api/src/projects/routes/r5.ts
@@ -8,7 +8,8 @@ import { archiveRepoSubtree, getBranchDiff, getCommit, getCommitDiff, getFileHis
 import { createRoute, z } from '@hono/zod-openapi';
 import { deployments, projects } from '@kortix/db';
 import { eq } from 'drizzle-orm';
-import { loadProjectForUser, assertProjectCapability } from '../lib/access';
+import { loadProjectForUser, assertProjectCapability, projectCapabilityAllowed } from '../lib/access';
+import { applyDetailCapabilityFilter } from '../lib/detail-capability-filter';
 import { filterConfigResourcesForUser, denierFromConfig, resourceDenierForRequest } from '../lib/project-resources';
 import { AnyObject, CommitSchema, ProjectSchema, projectsApp } from '../lib/app';
 import { getProjectGitConnection, withProjectGitAuth } from '../lib/git';
@@ -233,15 +234,36 @@ projectsApp.openapi(
   // isolation). Reuses the config already loaded — no extra git round-trip.
   const denier = await denierFromConfig(rawConfig, denierCtx);
   const visibleFiles = denier ? files.filter((f) => !denier.isDenied(f.path)) : files;
+  // Per-CAPABILITY filtering (distinct from the per-resource grants above): the
+  // /detail bundle serves several read surfaces behind ONE project.read floor, so
+  // gate each section on its own leaf. A plain `member` keeps the config sections
+  // it can read but NOT the file list (member lacks project.file.read), and a
+  // custom role that unchecks e.g. project.skill.read gets an empty skills
+  // section — all WITHOUT 403-ing the whole workspace load (which loadProjectForUser
+  // deliberately gates only on project.read so the shell renders for every member).
+  const [canFiles, canAgents, canSkills, canCommands, canCustomize] = await Promise.all([
+    projectCapabilityAllowed(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_FILE_READ),
+    projectCapabilityAllowed(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_AGENT_READ),
+    projectCapabilityAllowed(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_SKILL_READ),
+    projectCapabilityAllowed(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_COMMAND_READ),
+    projectCapabilityAllowed(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_CUSTOMIZE_READ),
+  ]);
+  const gated = applyDetailCapabilityFilter(config, visibleFiles, {
+    canFiles,
+    canAgents,
+    canSkills,
+    canCommands,
+    canCustomize,
+  });
   return c.json({
     project: serializeProject(loaded.row, {
       projectRole: loaded.projectRole,
       effectiveRole: loaded.effectiveRole,
     }),
     git_connection: serializeProjectGitConnection(await getProjectGitConnection(projectId)),
-    config,
-    file_count: visibleFiles.length,
-    files: visibleFiles.slice(0, 300),
+    config: gated.config,
+    file_count: gated.file_count,
+    files: gated.files,
   });
 },
 );


### PR DESCRIPTION
## What

Part 3 (final) of making the granular RBAC checkboxes authoritative for custom roles (enterprise pilot). PR #4275 fixed over-gated members-governance routes; #4279 closed the write/lifecycle enforcement holes; this PR closes the **`GET /:projectId/detail` read leak**.

`/detail` bundles several read surfaces behind ONE `project.read` floor:
- the repo **file list** (up to 300 paths) → should need `project.file.read`
- the config summary: **agents** (`agent.read`), **skills** (`skill.read`), **commands** (`command.read`), and the raw **kortix.toml / opencode config** (`customize.read`)

So a plain **member** (who deliberately lacks `file.read` after #4268) still saw the file list here, and unchecking any config read leaf in a custom role did nothing — the exact "the checkbox is dead" case.

## Approach — filter, don't 403

A naive `assertProjectCapability(file.read)` on `/detail` would **403 every member** out of the workspace shell (member lacks `file.read` by design). Instead the coarse floor stays `project.read` (so the shell always loads) and each **section is blanked** when the caller lacks its leaf:

- `files` / `file_count` dropped without `file.read`
- `agents` (+`agent_discovery`) / `skills` / `commands` emptied per their read leaf
- raw config (`manifest_raw`, `manifest`, `env`, `open_code_raw`, `open_code_default_agent`) blanked without `customize.read`; structural `is_kortix_repo` / `signals` kept so the shell renders

Net effect on built-in roles: only the intended member→no-files change; editor/manager see everything (they hold all the leaves). Only custom roles that uncheck a specific read leaf lose that section.

## Changes

- **`projectCapabilityAllowed()`** (access.ts) — non-throwing sibling of `assertProjectCapability`, threading the acting token so the agent-grant fold still applies. For response-level filtering.
- **`applyDetailCapabilityFilter()`** (new `lib/detail-capability-filter.ts`) — pure, so the gating is unit-tested independent of git/DB; the handler just supplies the resolved booleans.
- r5.ts `/detail` resolves the 5 read leaves in parallel and applies the filter.

## Test

- `unit-detail-capability-filter.test.ts` — 8 cases over every leaf combo (files dropped, each section emptied per its leaf, structural signals kept, member profile = config-yes/files-no, 300-cap with true count).
- `integration-detail-capability-http.test.ts` — a plain **member still loads `/detail` (not 403)** with the file list blanked — the regression the naive fix would have caused.

109/109 green with the read-leaf + role-perms suites.

## Follow-ups (not in this PR)
- The `/detail` git round-trip still runs even when `!file.read` (files are listed then dropped) — a later optimization could skip it.
