### PR TITLE
fix(web): model picker updates instantly after connecting a provider

### DIFF
--- a/apps/web/src/components/projects/chatgpt-subscription-connect.tsx
+++ b/apps/web/src/components/projects/chatgpt-subscription-connect.tsx
@@ -161,7 +161,7 @@ export function ChatGptSubscriptionConnect({
           setPhase('done');
           toast.success('ChatGPT subscription connected to this project');
           queryClient.invalidateQueries({ queryKey: ['project-secrets', projectId] });
-          refreshProjectProviderState(queryClient, projectId);
+          refreshProjectProviderState(queryClient, projectId, { expectProviderId: 'codex' });
           onConnected?.();
           return;
         }

--- a/apps/web/src/features/workspace/customize/sections/llm-provider/api-key-connect-form.tsx
+++ b/apps/web/src/features/workspace/customize/sections/llm-provider/api-key-connect-form.tsx
@@ -52,7 +52,7 @@ export function ApiKeyConnectForm({
     onSuccess: () => {
       successToast(`${provider.label} connected`);
       queryClient.invalidateQueries({ queryKey: ['project-secrets', projectId] });
-      refreshProjectProviderState(queryClient, projectId);
+      refreshProjectProviderState(queryClient, projectId, { expectProviderId: provider.id });
       onConnected();
     },
     onError: (err) => setError(err instanceof Error ? err.message : 'Failed to save credentials'),

--- a/apps/web/src/features/workspace/customize/sections/llm-provider/chatgpt-subscription-connect.tsx
+++ b/apps/web/src/features/workspace/customize/sections/llm-provider/chatgpt-subscription-connect.tsx
@@ -75,7 +75,7 @@ export function ChatGptSubscriptionConnect({
           setPhase('done');
           successToast('ChatGPT subscription connected to this project');
           queryClient.invalidateQueries({ queryKey: ['project-secrets', projectId] });
-          refreshProjectProviderState(queryClient, projectId);
+          refreshProjectProviderState(queryClient, projectId, { expectProviderId: 'codex' });
           onConnected();
           return;
         }

--- a/packages/sdk/src/react/provider-refresh.test.ts
+++ b/packages/sdk/src/react/provider-refresh.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from 'bun:test';
+
+import { providerConnectedInSecrets } from './provider-refresh';
+
+describe('providerConnectedInSecrets', () => {
+  test('false for empty, null, or malformed responses', () => {
+    expect(providerConnectedInSecrets(undefined, 'anthropic')).toBe(false);
+    expect(providerConnectedInSecrets(null, 'anthropic')).toBe(false);
+    expect(providerConnectedInSecrets([], 'anthropic')).toBe(false);
+    expect(providerConnectedInSecrets({ items: [] }, 'anthropic')).toBe(false);
+    expect(providerConnectedInSecrets({ items: [{ notName: 1 }] }, 'anthropic')).toBe(false);
+  });
+
+  test('resolves a provider once its credential env var is present (array shape)', () => {
+    expect(providerConnectedInSecrets([{ name: 'ANTHROPIC_API_KEY' }], 'anthropic')).toBe(true);
+    expect(providerConnectedInSecrets([{ name: 'ANTHROPIC_API_KEY' }], 'openai')).toBe(false);
+  });
+
+  test('resolves a provider from the items envelope shape', () => {
+    const secrets = { items: [{ name: 'OPENAI_API_KEY' }, { name: 'UNRELATED' }] };
+    expect(providerConnectedInSecrets(secrets, 'openai')).toBe(true);
+  });
+
+  test('codex resolves from the subscription auth secret', () => {
+    expect(providerConnectedInSecrets([{ name: 'CODEX_AUTH_JSON' }], 'codex')).toBe(true);
+  });
+
+  test('an unrelated secret never resolves a provider', () => {
+    expect(providerConnectedInSecrets([{ name: 'STRIPE_API_KEY' }], 'anthropic')).toBe(false);
+  });
+});

--- a/packages/sdk/src/react/provider-refresh.ts
+++ b/packages/sdk/src/react/provider-refresh.ts
@@ -2,12 +2,57 @@
 
 import type { QueryClient } from '@tanstack/react-query';
 
+import { listProjectSecrets } from '../platform/projects-client';
+import { connectedGatewayProviderIdsFromSecretNames } from './provider-selection';
 import { configKeys } from './use-opencode-config';
 import { clearProjectProviderCache, opencodeKeys } from './use-opencode-sessions';
 
 type RefreshProjectProviderStateOptions = {
   removeProjectScopedCache?: boolean;
+  /**
+   * Provider id (e.g. 'anthropic', 'codex') whose credential was just saved.
+   * When set, the refresh keeps polling until the project's secrets actually
+   * resolve that provider as connected — instead of a fixed retry window that
+   * a slow save/opencode restart can outlive, leaving the picker stale until
+   * a hard page refresh.
+   */
+  expectProviderId?: string;
 };
+
+const CONVERGE_POLL_MS = 2_500;
+const CONVERGE_DEADLINE_MS = 45_000;
+
+/**
+ * Whether a raw secrets-list response resolves `expectedProviderId` as a
+ * connected gateway provider. Pure — the convergence signal for the
+ * poll-until-connected refresh below.
+ */
+export function providerConnectedInSecrets(
+  secrets: unknown,
+  expectedProviderId: string,
+): boolean {
+  const items = Array.isArray(secrets)
+    ? secrets
+    : ((secrets as { items?: Array<{ name?: unknown }> } | null | undefined)?.items ?? []);
+  const names = new Set<string>();
+  for (const item of items) {
+    if (item && typeof (item as { name?: unknown }).name === 'string') {
+      names.add((item as { name: string }).name);
+    }
+  }
+  return connectedGatewayProviderIdsFromSecretNames(names).has(expectedProviderId);
+}
+
+function invalidateProviderQueries(queryClient: QueryClient, projectId: string): void {
+  const projectProviderKey = ['project-providers', projectId];
+  clearProjectProviderCache(projectId);
+  void queryClient.invalidateQueries({ queryKey: projectProviderKey });
+  void queryClient.invalidateQueries({ queryKey: ['project-secrets', projectId] });
+  void queryClient.refetchQueries({ queryKey: ['project-secrets', projectId], type: 'all' });
+  void queryClient.refetchQueries({ queryKey: projectProviderKey, type: 'all' });
+  void queryClient.invalidateQueries({ queryKey: opencodeKeys.providers() });
+  void queryClient.invalidateQueries({ queryKey: configKeys.all });
+}
 
 export function refreshProjectProviderState(
   queryClient: QueryClient,
@@ -15,25 +60,48 @@ export function refreshProjectProviderState(
   opts: RefreshProjectProviderStateOptions = {},
 ): void {
   const projectProviderKey = ['project-providers', projectId];
-  clearProjectProviderCache(projectId);
   if (opts.removeProjectScopedCache) {
     queryClient.removeQueries({ queryKey: projectProviderKey });
   }
-  queryClient.invalidateQueries({ queryKey: projectProviderKey });
-  queryClient.invalidateQueries({ queryKey: ['project-secrets', projectId] });
-  queryClient.invalidateQueries({ queryKey: opencodeKeys.providers() });
-  queryClient.invalidateQueries({ queryKey: configKeys.all });
+  invalidateProviderQueries(queryClient, projectId);
+
+  if (typeof window === 'undefined') return;
 
   // Saving provider credentials hot-pushes env vars into active sandboxes and
-  // restarts OpenCode. A single immediate refetch can race that restart and
-  // accept the old native provider list as final, so follow up a few times.
-  if (typeof window === 'undefined') return;
-  for (const delay of [500, 1500, 3000, 6000]) {
-    window.setTimeout(() => {
-      void queryClient.invalidateQueries({ queryKey: projectProviderKey });
-      void queryClient.invalidateQueries({ queryKey: ['project-secrets', projectId] });
-      void queryClient.refetchQueries({ queryKey: ['project-secrets', projectId], type: 'all' });
-      void queryClient.refetchQueries({ queryKey: projectProviderKey, type: 'active' });
-    }, delay);
+  // restarts OpenCode; the secret write itself can also land after the save
+  // call returns. A refetch that races either one accepts the OLD state as
+  // final — and with staleTime:Infinity on the provider list nothing ever asks
+  // again, so the picker stays stale until a hard refresh. So: don't fire a
+  // fixed number of blind retries — poll until the connected state actually
+  // CONVERGES (the expected provider resolves from the project's secrets),
+  // then do one final refresh burst and stop.
+  const expected = opts.expectProviderId;
+  if (!expected) {
+    for (const delay of [500, 1500, 3000, 6000]) {
+      window.setTimeout(() => invalidateProviderQueries(queryClient, projectId), delay);
+    }
+    return;
   }
+
+  const startedAt = Date.now();
+  const poll = async (): Promise<void> => {
+    let connected = false;
+    try {
+      const secrets = await queryClient.fetchQuery({
+        queryKey: ['project-secrets', projectId],
+        queryFn: () => listProjectSecrets(projectId),
+        staleTime: 0,
+      });
+      connected = providerConnectedInSecrets(secrets, expected);
+    } catch {
+      // transient fetch failure — keep polling until the deadline
+    }
+    if (connected) {
+      invalidateProviderQueries(queryClient, projectId);
+      return;
+    }
+    if (Date.now() - startedAt >= CONVERGE_DEADLINE_MS) return;
+    window.setTimeout(() => void poll(), CONVERGE_POLL_MS);
+  };
+  window.setTimeout(() => void poll(), CONVERGE_POLL_MS);
 }


### PR DESCRIPTION
## What

After connecting an LLM provider, the model picker could stay stale until a hard page refresh (Marko hit this on staging during the v0.9.99 release test).

## Why

`refreshProjectProviderState` fired four blind retries over 6 seconds. A slow secret write — or the opencode restart that a credential save triggers — outlives that window, and with `staleTime: Infinity` on the provider-list query nothing ever asks again.

## How

- The refresh now **polls until the connected state converges**: it refetches project secrets every 2.5s (up to 45s) until the just-saved credential actually resolves the provider as connected, then fires a final refresh burst. No expectation → old behavior.
- Connect flows pass the provider they just saved (`expectProviderId`); the ChatGPT flows converge on `codex`.
- Extracted `providerConnectedInSecrets` as a pure, tested helper.

## Tests
- `bun test provider-refresh.test.ts` — 5 pass
- `tsc --noEmit` clean on packages/sdk and apps/web