### PR TITLE
feat(web): make Dither the default wallpaper

### DIFF
--- a/apps/web/src/lib/wallpapers.ts
+++ b/apps/web/src/lib/wallpapers.ts
@@ -20,7 +20,7 @@ export interface Wallpaper {
   thumbs?: { dark: string; light: string };
 }
 
-export const DEFAULT_WALLPAPER_ID = 'brandmark';
+export const DEFAULT_WALLPAPER_ID = 'dither';
 
 function shaderThumbs(id: Wallpaper['id']): Wallpaper['thumbs'] {
   return {
@@ -30,6 +30,12 @@ function shaderThumbs(id: Wallpaper['id']): Wallpaper['thumbs'] {
 }
 
 export const WALLPAPERS: Wallpaper[] = [
+  {
+    id: 'dither',
+    name: 'Dither',
+    type: 'shader',
+    thumbs: shaderThumbs('dither'),
+  },
   {
     id: 'brandmark',
     name: 'Brandmark',
@@ -48,12 +54,6 @@ export const WALLPAPERS: Wallpaper[] = [
     name: 'Silk',
     type: 'shader',
     thumbs: shaderThumbs('silk'),
-  },
-  {
-    id: 'dither',
-    name: 'Dither',
-    type: 'shader',
-    thumbs: shaderThumbs('dither'),
   },
   {
     id: 'grain',


### PR DESCRIPTION
## What

Makes the **Dither** shader the default workspace wallpaper and moves it to the top of the picker.

## Why

Dither is the look we want new users to land on. This is an order-only change — Dither was already a selectable option; it just wasn't the default and sat mid-list.

## Changes

`apps/web/src/lib/wallpapers.ts`:
- `DEFAULT_WALLPAPER_ID`: `'brandmark'` → `'dither'` — anyone without a saved preference now renders the `DitherShader` background.
- Reordered `WALLPAPERS` so `dither` is first → it leads the appearance-tab picker grid and carries the **Default** badge.

No component edits needed: `WallpaperBackground` and `appearance-tab` both derive the default and ordering from `lib/wallpapers.ts`. Users who already picked a wallpaper are unaffected (stored preference wins).

## Test plan

- [ ] Fresh session (no saved preference) shows the Dither background
- [ ] Appearance settings lists Dither first with the "Default" badge
- [ ] Switching to another wallpaper and back still works

https://claude.ai/code/session_01YGJkVAQSEGYfDTEkREc1Fr
