### PR TITLE
fix(platinum): create throws on terminal failed-start so provision retries

### DIFF
--- a/apps/api/src/platform/providers/platinum-create-terminal.test.ts
+++ b/apps/api/src/platform/providers/platinum-create-terminal.test.ts
@@ -1,0 +1,85 @@
+// PlatinumProvider.create() must THROW when the create wait returns a
+// terminal-fail state (failed-start / lost / deleted) and best-effort remove
+// the dead box — so retrySandboxProvisionCreate re-provisions instead of
+// silently handing back an unusable "running" session (proven 2026-07-07,
+// session c6fef0b5: Platinum state=failed-start while comp status=active).
+// Env is set before importing anything that reads config at module load.
+import { test, expect, mock, beforeEach } from 'bun:test';
+
+process.env.ALLOWED_SANDBOX_PROVIDERS = 'platinum';
+process.env.PLATINUM_API_KEY = 'pt_test_key';
+process.env.PLATINUM_API_URL = 'https://api.platinum.dev';
+process.env.PLATINUM_TEMPLATE = 'tpl_test';
+process.env.KORTIX_URL ??= 'https://api.example.com';
+process.env.DATABASE_URL ??= 'postgres://x';
+
+// Capture the paths platinumJson is called with so we can assert the dead box
+// gets a DELETE. `state` is driven per-test via the closure below.
+let createState = 'running';
+const calls: { path: string; method: string }[] = [];
+
+mock.module('../../shared/platinum', () => ({
+  isPlatinumConfigured: () => true,
+  platinumJson: async (path: string, init: RequestInit = {}) => {
+    calls.push({ path, method: String(init.method ?? 'GET') });
+    // POST /v1/sandboxes?wait_for_state=running — return a box in `createState`.
+    if (path.startsWith('/v1/sandboxes?')) {
+      return { id: 'sbx_dead', state: createState };
+    }
+    // expose / delete / anything else — succeed cheaply.
+    if (path.includes('/expose')) return { url: 'https://sbx.test/agent', port: 8000, public: true };
+    return {};
+  },
+}));
+
+// Keep service-key + frontend-url from touching real deps.
+mock.module('../service-key', () => ({ serviceKeyForExternalId: () => 'svc_key' }));
+mock.module('../sandbox-frontend-url', () => ({ sandboxFrontendBaseUrl: () => 'https://app.example.com' }));
+
+async function makeProvider() {
+  const { PlatinumProvider } = await import('./platinum');
+  return new PlatinumProvider();
+}
+
+const baseOpts = {
+  accountId: 'acc_1',
+  userId: 'usr_1',
+  name: 'test-box',
+  envVars: { KORTIX_SANDBOX_TOKEN: 'tok_test' },
+};
+
+beforeEach(() => {
+  calls.length = 0;
+});
+
+for (const state of ['failed-start', 'lost', 'deleted']) {
+  test(`create() throws and removes the box when create returns terminal state '${state}'`, async () => {
+    createState = state;
+    const p = await makeProvider();
+    await expect(p.create({ ...baseOpts })).rejects.toThrow(/did not reach running/);
+    // The dead box must be DELETE'd (best-effort remove) so it doesn't linger.
+    const deleted = calls.some((c) => c.method === 'DELETE' && c.path === '/v1/sandboxes/sbx_dead');
+    expect(deleted).toBe(true);
+  });
+}
+
+test('create() does NOT throw when the box is running', async () => {
+  createState = 'running';
+  const p = await makeProvider();
+  const res = await p.create({ ...baseOpts });
+  expect(res.externalId).toBe('sbx_dead');
+  // No DELETE for a healthy box.
+  const deleted = calls.some((c) => c.method === 'DELETE');
+  expect(deleted).toBe(false);
+});
+
+test("create() does NOT tear down a still-'provisioning' box (FE poll picks it up)", async () => {
+  createState = 'provisioning';
+  const p = await makeProvider();
+  // Should NOT throw on a non-terminal state — returns the id, FE readiness
+  // poll takes over.
+  const res = await p.create({ ...baseOpts });
+  expect(res.externalId).toBe('sbx_dead');
+  const deleted = calls.some((c) => c.method === 'DELETE');
+  expect(deleted).toBe(false);
+});

--- a/apps/api/src/platform/providers/platinum.ts
+++ b/apps/api/src/platform/providers/platinum.ts
@@ -131,6 +131,34 @@ export class PlatinumProvider implements SandboxProvider {
     const _vmMs = Date.now() - _t0;
 
     const externalId = sandbox.id;
+
+    // `?wait_for_state=running` returns 200 with the sandbox body even when the
+    // box reached a TERMINAL-FAIL state (failed-start / lost / deleted) — the
+    // wait helper on the Platinum side stops early on those but does NOT error
+    // (apps/api/src/api/sandboxes.ts maybeWait). So a create can hand back an id
+    // for a DEAD box. Before this guard we read `sandbox.id` and marched on, so
+    // an intermittent guest-boot stall surfaced as a "running" session that was
+    // actually failed-start (proven 2026-07-07, session c6fef0b5: Platinum
+    // state=failed-start, comp status=active). Throw on a non-running terminal
+    // state so retrySandboxProvisionCreate re-attempts (fresh box, possibly
+    // another host) instead of silently returning an unusable sandbox. The
+    // host-agent also relaunches the guest in-place once, so this retry is the
+    // outer backstop for the rare case both in-host attempts stall.
+    const createdState = String(sandbox.state ?? '').toLowerCase();
+    // Only a TERMINAL-fail state is a definite dead box (mirrors the Platinum
+    // maybeWait TERMINAL_FAIL_STATES set). 'provisioning' here means the wait
+    // timed out on a still-booting box — rare, and the FE readiness poll can
+    // still pick it up — so don't tear that down.
+    const TERMINAL_FAIL = new Set(['failed-start', 'lost', 'deleted']);
+    if (TERMINAL_FAIL.has(createdState)) {
+      // Best-effort remove the dead box so it doesn't linger/eat capacity; the
+      // retry provisions a fresh one.
+      await this.remove(externalId).catch(() => {});
+      throw new Error(
+        `[platinum] sandbox ${externalId} did not reach running (state=${createdState}) after ${_vmMs}ms`,
+      );
+    }
+
     const baseUrl = `${sandboxApiBase}/v1/p/${externalId}/${AGENT_PORT}`;
 
     // Eagerly expose the agent port so the *.sbx edge route is LIVE the moment


### PR DESCRIPTION
## Problem

Platinum's `POST /v1/sandboxes?wait_for_state=running` returns 200 with the sandbox body **even when the box reached a TERMINAL-FAIL state** (`failed-start` / `lost` / `deleted`) — its server-side wait helper (`maybeWait`) stops early on those but does NOT error. So `create()` could hand back an id for a DEAD box: we read `sandbox.id` and marched on, and an intermittent guest-boot stall surfaced as a "running"/active session that was actually `failed-start`.

Proven 2026-07-07 (session `c6fef0b5`): Platinum `state=failed-start` while comp `status=active`.

## Fix

Throw on a terminal-fail create state (best-effort `remove()` the dead box first) so `retrySandboxProvisionCreate` re-attempts on a fresh box — possibly another host. `provisioning` (wait-timeout on a still-booting box) is left alone; the FE readiness poll can still pick that up.

Pairs with the host-agent in-place guest-boot retry (kortix-ai/platinum#79); this is the outer backstop for the rare double-stall.

## Verification

- `apps/api` `tsc --noEmit` clean (0 errors).
- E2E on dev: forced-Platinum kortix sessions reach `ready` (not `failed-start`); fault-injected virtiofsd kill recovers via the host retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)