### PR TITLE
feat(cli): always-bound project UX — login binds a default project, unbound commands recover

### DIFF
--- a/apps/cli/src/__tests__/cli-blackbox.test.ts
+++ b/apps/cli/src/__tests__/cli-blackbox.test.ts
@@ -720,9 +720,16 @@ console.log(JSON.stringify({ cmd, args, body }));
     expect(noAuth.code).toBe(1);
     expect(noAuth.stderr).toContain('Not logged in');
 
+    // No project bound + logged in + exactly one project in the account →
+    // the always-bound invariant auto-binds it and the command proceeds
+    // instead of dead-ending with "No project linked".
     const noLink = await runCli(['marketplace', 'status', '--json'], tmp, { KORTIX_CONFIG_FILE: configFile });
-    expect(noLink.code).toBe(1);
-    expect(noLink.stderr).toContain('No project linked');
+    expect(noLink.code).toBe(0);
+    expect(noLink.stderr).toContain('Default project:');
+    const boundConfig = JSON.parse(readFileSync(configFile, 'utf8'));
+    expect(boundConfig.hosts.test.default_project.project_id).toBe('proj_e2e');
+    delete boundConfig.hosts.test.default_project;
+    writeFileSync(configFile, JSON.stringify(boundConfig));
 
     const init = await runCli(['init', 'edge-e2e', '--yes', '--no-git']);
     expect(init.code).toBe(0);
@@ -749,6 +756,8 @@ console.log(JSON.stringify({ cmd, args, body }));
     expect(add.stderr).toContain('`add` is not a kortix subcommand');
 
     expect(requests.map((r) => [r.method, r.path, r.body ?? null])).toEqual([
+      ['GET', '/v1/projects?account_id=account_1', null],
+      ['GET', '/v1/projects/proj_e2e/marketplace', null],
       ['GET', '/v1/projects/missing', null],
       ['GET', '/v1/marketplace/items/does-not-exist', null],
       ['GET', '/v1/marketplace/items?query=does-not-exist', null],

--- a/apps/cli/src/__tests__/project-bind.test.ts
+++ b/apps/cli/src/__tests__/project-bind.test.ts
@@ -1,0 +1,166 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+
+import { ensureDefaultProjectBinding } from '../project-bind.ts';
+import type { Auth } from '../api/auth.ts';
+
+const AUTH: Auth = {
+  api_base: 'https://api.example.test/v1',
+  token: 'kortix_pat_test',
+  user_id: 'user_1',
+  user_email: 'user@example.test',
+  account_id: 'account_1',
+  logged_in_at: '2026-01-01T00:00:00.000Z',
+};
+
+const ENV_KEYS = [
+  'KORTIX_CONFIG_FILE',
+  'KORTIX_CLI_TOKEN',
+  'KORTIX_EXECUTOR_TOKEN',
+  'KORTIX_TOKEN',
+  'KORTIX_API_URL',
+  'KORTIX_PROJECT_ID',
+  'KORTIX_DISABLE_SANDBOX_ENV_FILE',
+] as const;
+
+function project(id: string, name: string) {
+  return {
+    project_id: id,
+    account_id: 'account_1',
+    name,
+    repo_url: 'https://git.example.test/r.git',
+    default_branch: 'main',
+    manifest_path: 'kortix.yaml',
+    status: 'active',
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+  };
+}
+
+describe('ensureDefaultProjectBinding', () => {
+  let dir: string;
+  let configFile: string;
+  let stderrChunks: string[];
+  const saved: Record<string, string | undefined> = {};
+  const realFetch = globalThis.fetch;
+  const realStderrWrite = process.stderr.write;
+
+  beforeEach(() => {
+    for (const k of ENV_KEYS) saved[k] = process.env[k];
+    for (const k of ENV_KEYS) delete process.env[k];
+    process.env.KORTIX_DISABLE_SANDBOX_ENV_FILE = '1';
+    dir = mkdtempSync(join(tmpdir(), 'kortix-bind-'));
+    configFile = join(dir, 'config.json');
+    process.env.KORTIX_CONFIG_FILE = configFile;
+    writeFileSync(
+      configFile,
+      JSON.stringify({
+        active: 'test',
+        hosts: {
+          test: {
+            url: AUTH.api_base,
+            token: AUTH.token,
+            user_id: AUTH.user_id,
+            user_email: AUTH.user_email,
+            account_id: AUTH.account_id,
+            logged_in_at: AUTH.logged_in_at,
+          },
+        },
+      }),
+    );
+    stderrChunks = [];
+    process.stderr.write = ((chunk: string | Uint8Array) => {
+      stderrChunks.push(String(chunk));
+      return true;
+    }) as typeof process.stderr.write;
+  });
+
+  afterEach(() => {
+    process.stderr.write = realStderrWrite;
+    globalThis.fetch = realFetch;
+    for (const k of ENV_KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function mockProjects(list: unknown[] | { status: number }) {
+    globalThis.fetch = (async (url: string | URL | Request) => {
+      const u = String(url instanceof Request ? url.url : url);
+      if (u.includes('/projects')) {
+        if (Array.isArray(list)) return Response.json(list);
+        return Response.json({ error: 'boom' }, { status: list.status });
+      }
+      return Response.json({ error: 'unexpected route' }, { status: 404 });
+    }) as typeof fetch;
+  }
+
+  function storedDefaultProject(): { project_id: string; name: string } | undefined {
+    const cfg = JSON.parse(readFileSync(configFile, 'utf8'));
+    return cfg.hosts?.test?.default_project;
+  }
+
+  it('is a no-op when a default project is already bound', async () => {
+    const cfg = JSON.parse(readFileSync(configFile, 'utf8'));
+    cfg.hosts.test.default_project = {
+      project_id: 'proj_existing',
+      account_id: 'account_1',
+      name: 'Existing',
+    };
+    writeFileSync(configFile, JSON.stringify(cfg));
+    globalThis.fetch = (async () => {
+      throw new Error('must not fetch when already bound');
+    }) as unknown as typeof fetch;
+
+    const outcome = await ensureDefaultProjectBinding(AUTH);
+
+    expect(outcome.bound).toBe(false);
+    expect(outcome.project?.project_id).toBe('proj_existing');
+  });
+
+  it('auto-binds when the account has exactly one project', async () => {
+    mockProjects([project('proj_only', 'Only One')]);
+
+    const outcome = await ensureDefaultProjectBinding(AUTH);
+
+    expect(outcome.bound).toBe(true);
+    expect(outcome.project?.project_id).toBe('proj_only');
+    expect(storedDefaultProject()?.project_id).toBe('proj_only');
+    expect(stderrChunks.join('')).toContain('Default project:');
+  });
+
+  it('hints at kortix init and binds nothing when the account has zero projects', async () => {
+    mockProjects([]);
+
+    const outcome = await ensureDefaultProjectBinding(AUTH);
+
+    expect(outcome.bound).toBe(false);
+    expect(outcome.project).toBeNull();
+    expect(storedDefaultProject()).toBeUndefined();
+    expect(stderrChunks.join('')).toContain('kortix init');
+  });
+
+  it('does not prompt or bind on a non-TTY when several projects exist', async () => {
+    mockProjects([project('proj_a', 'A'), project('proj_b', 'B')]);
+
+    const outcome = await ensureDefaultProjectBinding(AUTH);
+
+    expect(outcome.bound).toBe(false);
+    expect(outcome.project).toBeNull();
+    expect(storedDefaultProject()).toBeUndefined();
+    expect(stderrChunks.join('')).toContain('kortix projects use');
+  });
+
+  it('degrades to unbound with the reason on stderr when listing projects fails', async () => {
+    mockProjects({ status: 500 });
+
+    const outcome = await ensureDefaultProjectBinding(AUTH);
+
+    expect(outcome.bound).toBe(false);
+    expect(outcome.project).toBeNull();
+    expect(stderrChunks.join('')).toContain('Could not list projects');
+  });
+});

--- a/apps/cli/src/__tests__/sandbox-auth.test.ts
+++ b/apps/cli/src/__tests__/sandbox-auth.test.ts
@@ -147,10 +147,10 @@ describe('env token vs .kortix/link.json host', () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
-  it('resolveProjectContext uses the env token even when link.json names a host', () => {
+  it('resolveProjectContext uses the env token even when link.json names a host', async () => {
     process.env.KORTIX_CLI_TOKEN = 'kortix_pat_cli';
     process.env.KORTIX_API_URL = 'https://tunnel.example/v1';
-    const ctx = resolveProjectContext();
+    const ctx = await resolveProjectContext();
     expect(ctx).not.toBeNull();
     expect(ctx?.auth.token).toBe('kortix_pat_cli');
     expect(ctx?.auth.api_base).toBe('https://tunnel.example/v1');
@@ -158,18 +158,18 @@ describe('env token vs .kortix/link.json host', () => {
     expect(ctx?.projectId).toBe('proj-from-link');
   });
 
-  it('without an env token the link host is still honored (and fails logged-out)', () => {
+  it('without an env token the link host is still honored (and fails logged-out)', async () => {
     // Config file points at a nonexistent path → the named host has no token →
     // the pre-existing behavior (refuse with "not logged in") is preserved.
-    const ctx = resolveProjectContext();
+    const ctx = await resolveProjectContext();
     expect(ctx).toBeNull();
   });
 
-  it('an explicit --host override still wins over the env token', () => {
+  it('an explicit --host override still wins over the env token', async () => {
     process.env.KORTIX_CLI_TOKEN = 'kortix_pat_cli';
     // 'nonexistent-host' has no credentials → context resolution must fail
     // rather than silently falling back to the env token the caller did not ask for.
-    const ctx = resolveProjectContext({ hostArg: 'nonexistent-host' });
+    const ctx = await resolveProjectContext({ hostArg: 'nonexistent-host' });
     expect(ctx).toBeNull();
   });
 });

--- a/apps/cli/src/command-helpers.ts
+++ b/apps/cli/src/command-helpers.ts
@@ -2,6 +2,7 @@ import { loadAuth, loadAuthForHost, type Auth } from './api/auth.ts';
 import { hasEnvTokenHost } from './api/config.ts';
 import { ApiError, clientFromAuth, type ApiClient } from './api/client.ts';
 import { loadLink, resolveProjectId } from './project-link.ts';
+import { ensureDefaultProjectBinding } from './project-bind.ts';
 import { C, status } from './style.ts';
 
 interface ProjectContextOpts {
@@ -27,9 +28,9 @@ interface ProjectContextOpts {
  * Backward-compatible call shape: callers that pass a string get the
  * `(projectArg)` behavior; callers that need --host pass an object.
  */
-export function resolveProjectContext(
+export async function resolveProjectContext(
   optsOrProjectArg?: ProjectContextOpts | string,
-): { client: ApiClient; projectId: string; auth: Auth } | null {
+): Promise<{ client: ApiClient; projectId: string; auth: Auth } | null> {
   const opts: ProjectContextOpts =
     typeof optsOrProjectArg === 'string'
       ? { projectArg: optsOrProjectArg }
@@ -55,11 +56,21 @@ export function resolveProjectContext(
     }
     return null;
   }
-  const projectId = resolveProjectId(opts.projectArg);
+  let projectId = resolveProjectId(opts.projectArg);
+  if (!projectId) {
+    // The always-bound invariant: recover by binding a default project right
+    // here instead of dead-ending. (Inside a sandbox the env-token host
+    // always carries KORTIX_PROJECT_ID, so this never fires there; on a
+    // non-TTY it degrades to a hint and the error below.)
+    const outcome = await ensureDefaultProjectBinding(auth, {
+      promptTitle: 'No project bound — pick one for this command',
+    });
+    projectId = outcome.project?.project_id ?? null;
+  }
   if (!projectId) {
     process.stderr.write(
-      `${status.err('No project linked.')} Run \`kortix projects link\` ` +
-        `or pass ${C.cyan}--project <id>${C.reset}.\n`,
+      `${status.err('No project linked.')} Run \`kortix projects use\`, ` +
+        `\`kortix projects link\`, or pass ${C.cyan}--project <id>${C.reset}.\n`,
     );
     return null;
   }

--- a/apps/cli/src/commands/access.ts
+++ b/apps/cli/src/commands/access.ts
@@ -71,7 +71,7 @@ export async function runAccess(argv: string[]): Promise<number> {
     return 2;
   }
   const positional = rest.filter((a) => !a.startsWith('-'));
-  const ctx = resolveProjectContext({ projectArg: f.project, hostArg: f.host });
+  const ctx = await resolveProjectContext({ projectArg: f.project, hostArg: f.host });
   if (!ctx) return 1;
   const base = `/projects/${ctx.projectId}`;
   const role = f.role as ProjectRole | undefined;

--- a/apps/cli/src/commands/agents.ts
+++ b/apps/cli/src/commands/agents.ts
@@ -58,7 +58,7 @@ export async function runAgents(argv: string[]): Promise<number> {
   }
   const positional = rest.filter((a) => !a.startsWith('-'));
 
-  const ctx = resolveProjectContext({ projectArg: projectFlag, hostArg: hostFlag });
+  const ctx = await resolveProjectContext({ projectArg: projectFlag, hostArg: hostFlag });
   if (!ctx) return 1;
   const base = `/projects/${ctx.projectId}/model-defaults`;
 

--- a/apps/cli/src/commands/apps.ts
+++ b/apps/cli/src/commands/apps.ts
@@ -118,7 +118,7 @@ export async function runApps(argv: string[]): Promise<number> {
     return 2;
   }
   const positional = rest.filter((a) => !a.startsWith('-'));
-  const ctx = resolveProjectContext({ projectArg: f.project, hostArg: f.host });
+  const ctx = await resolveProjectContext({ projectArg: f.project, hostArg: f.host });
   if (!ctx) return 1;
   const base = `/projects/${ctx.projectId}/apps`;
 

--- a/apps/cli/src/commands/channels.ts
+++ b/apps/cli/src/commands/channels.ts
@@ -85,7 +85,7 @@ export async function runChannels(argv: string[]): Promise<number> {
 async function channelsStatus(
   ctxOpts: { projectArg?: string; hostArg?: string },
 ): Promise<number> {
-  const ctx = resolveProjectContext(ctxOpts);
+  const ctx = await resolveProjectContext(ctxOpts);
   if (!ctx) return 1;
   try {
     const install = await ctx.client.get<SlackInstallation | null>(
@@ -117,7 +117,7 @@ async function channelsConnect(
   botTokenFlag: string | undefined,
   signingSecretFlag: string | undefined,
 ): Promise<number> {
-  const ctx = resolveProjectContext(ctxOpts);
+  const ctx = await resolveProjectContext(ctxOpts);
   if (!ctx) return 1;
 
   const botToken = resolveSecret('bot token', botTokenFlag, 'SLACK_BOT_TOKEN');
@@ -156,7 +156,7 @@ async function channelsConnect(
 async function channelsDisconnect(
   ctxOpts: { projectArg?: string; hostArg?: string },
 ): Promise<number> {
-  const ctx = resolveProjectContext(ctxOpts);
+  const ctx = await resolveProjectContext(ctxOpts);
   if (!ctx) return 1;
   try {
     await ctx.client.delete(`/projects/${ctx.projectId}/channels/slack/installation`);
@@ -170,7 +170,7 @@ async function channelsDisconnect(
 async function channelsManifest(
   ctxOpts: { projectArg?: string; hostArg?: string },
 ): Promise<number> {
-  const ctx = resolveProjectContext(ctxOpts);
+  const ctx = await resolveProjectContext(ctxOpts);
   if (!ctx) return 1;
 
   const baseUrl = ctx.client.apiBase.replace(/\/$/, '');

--- a/apps/cli/src/commands/connectors.ts
+++ b/apps/cli/src/commands/connectors.ts
@@ -149,7 +149,7 @@ export async function runConnectors(argv: string[]): Promise<number> {
   if ((sub === 'rm' || sub === 'remove' || sub === 'delete') && !applyRemote) return connectorRmLocal(positional[0]);
   if ((sub === 'policy' || sub === 'policies') && positional[0] === 'set') return policySetLocal(f.default);
 
-  const ctx = resolveProjectContext({ projectArg: f.project, hostArg: f.host });
+  const ctx = await resolveProjectContext({ projectArg: f.project, hostArg: f.host });
   if (!ctx) return 1;
   const ex = `/executor/projects/${ctx.projectId}`;
 

--- a/apps/cli/src/commands/cr.ts
+++ b/apps/cli/src/commands/cr.ts
@@ -179,7 +179,7 @@ async function crLs(argv: string[], opts: CtxOpts, json = false): Promise<number
     return 2;
   }
 
-  const ctx = resolveProjectContext(opts);
+  const ctx = await resolveProjectContext(opts);
   if (!ctx) return 1;
 
   let resp: ChangeRequestsListResponse;
@@ -228,7 +228,7 @@ async function crLs(argv: string[], opts: CtxOpts, json = false): Promise<number
 }
 
 async function crShow(ref: string | undefined, opts: CtxOpts, json = false): Promise<number> {
-  const ctx = resolveProjectContext(opts);
+  const ctx = await resolveProjectContext(opts);
   if (!ctx) return 1;
   const cr = await resolveCr(ctx, ref);
   if (!cr) return 1;
@@ -301,7 +301,7 @@ async function crShow(ref: string | undefined, opts: CtxOpts, json = false): Pro
 
 async function crDiff(argv: string[], opts: CtxOpts, json = false): Promise<number> {
   const noColor = takeFlagBool(argv, ['--no-color']);
-  const ctx = resolveProjectContext(opts);
+  const ctx = await resolveProjectContext(opts);
   if (!ctx) return 1;
   const cr = await resolveCr(ctx, argv[0]);
   if (!cr) return 1;
@@ -401,7 +401,7 @@ async function crOpen(argv: string[], opts: CtxOpts): Promise<number> {
     return 2;
   }
 
-  const ctx = resolveProjectContext(opts);
+  const ctx = await resolveProjectContext(opts);
   if (!ctx) return 1;
 
   const body: Record<string, unknown> = {
@@ -459,7 +459,7 @@ async function crMerge(argv: string[], opts: CtxOpts): Promise<number> {
     process.stderr.write(`${status.err((err as Error).message)}\n`);
     return 2;
   }
-  const ctx = resolveProjectContext(opts);
+  const ctx = await resolveProjectContext(opts);
   if (!ctx) return 1;
   const cr = await resolveCr(ctx, argv[0]);
   if (!cr) return 1;
@@ -483,7 +483,7 @@ async function crMerge(argv: string[], opts: CtxOpts): Promise<number> {
 }
 
 async function crClose(ref: string | undefined, opts: CtxOpts): Promise<number> {
-  const ctx = resolveProjectContext(opts);
+  const ctx = await resolveProjectContext(opts);
   if (!ctx) return 1;
   const cr = await resolveCr(ctx, ref);
   if (!cr) return 1;
@@ -501,7 +501,7 @@ async function crClose(ref: string | undefined, opts: CtxOpts): Promise<number> 
 }
 
 async function crReopen(ref: string | undefined, opts: CtxOpts): Promise<number> {
-  const ctx = resolveProjectContext(opts);
+  const ctx = await resolveProjectContext(opts);
   if (!ctx) return 1;
   const cr = await resolveCr(ctx, ref);
   if (!cr) return 1;

--- a/apps/cli/src/commands/doctor.ts
+++ b/apps/cli/src/commands/doctor.ts
@@ -78,7 +78,7 @@ export async function runDoctor(argv: string[]): Promise<number> {
   );
 
   // ── 2. /accounts/me ─────────────────────────────────────────────────────
-  const ctx = resolveProjectContext({ projectArg: flags.project, hostArg: flags.host });
+  const ctx = await resolveProjectContext({ projectArg: flags.project, hostArg: flags.host });
   if (!ctx) return 1;
   try {
     const me = await ctx.client.get<MeResponse>('/accounts/me');

--- a/apps/cli/src/commands/env.ts
+++ b/apps/cli/src/commands/env.ts
@@ -71,7 +71,7 @@ export async function runEnv(argv: string[]): Promise<number> {
 type CtxOpts = { projectArg?: string; hostArg?: string };
 
 async function envPull(outArg: string | undefined, force: boolean, opts: CtxOpts): Promise<number> {
-  const ctx = resolveProjectContext(opts);
+  const ctx = await resolveProjectContext(opts);
   if (!ctx) return 1;
 
   let resp: ProjectSecretsResponse;
@@ -134,7 +134,7 @@ async function envPush(fromArg: string | undefined, opts: CtxOpts): Promise<numb
     process.stderr.write(`${status.err('Pass --from <dotenv-path>.')}\n`);
     return 2;
   }
-  const ctx = resolveProjectContext(opts);
+  const ctx = await resolveProjectContext(opts);
   if (!ctx) return 1;
 
   const srcPath = resolve(process.cwd(), fromArg);

--- a/apps/cli/src/commands/files.ts
+++ b/apps/cli/src/commands/files.ts
@@ -111,7 +111,7 @@ export async function runFiles(argv: string[]): Promise<number> {
     return 2;
   }
   const positional = rest.filter((a) => !a.startsWith('-'));
-  const ctx = resolveProjectContext({ projectArg: projectFlag, hostArg: hostFlag });
+  const ctx = await resolveProjectContext({ projectArg: projectFlag, hostArg: hostFlag });
   if (!ctx) return 1;
   const base = `/projects/${ctx.projectId}`;
   const refQ = ref ? `ref=${encodeURIComponent(ref)}` : '';

--- a/apps/cli/src/commands/grants.ts
+++ b/apps/cli/src/commands/grants.ts
@@ -128,7 +128,7 @@ export async function runGrants(argv: string[]): Promise<number> {
     return 2;
   }
   const positional = rest.filter((a) => !a.startsWith('-'));
-  const ctx = resolveProjectContext({ projectArg: f.project, hostArg: f.host });
+  const ctx = await resolveProjectContext({ projectArg: f.project, hostArg: f.host });
   if (!ctx) return 1;
   const base = `/projects/${ctx.projectId}`;
 

--- a/apps/cli/src/commands/login.ts
+++ b/apps/cli/src/commands/login.ts
@@ -11,6 +11,7 @@ import {
 } from '../api/config.ts';
 import { ApiError, createApiClient } from '../api/client.ts';
 import { startCallbackServer } from '../api/browser-auth.ts';
+import { ensureDefaultProjectBinding } from '../project-bind.ts';
 import { C, status } from '../style.ts';
 import { webDashboardUrl } from '../web-url.ts';
 import type { MeResponse } from '../api/types.ts';
@@ -29,6 +30,7 @@ Options:
                     host URL or ${DEFAULT_API_BASE}).
   --token <pat>     Skip the browser flow and authenticate directly
                     with a token. Useful for CI or headless boxes.
+  --no-project      Skip the default-project binding step at the end.
   -h, --help        Show this help.
 
 Examples:
@@ -41,14 +43,16 @@ interface LoginFlags {
   token?: string;
   api?: string;
   host?: string;
+  noProject: boolean;
   help: boolean;
 }
 
 function parseFlags(argv: string[]): LoginFlags {
-  const f: LoginFlags = { help: false };
+  const f: LoginFlags = { help: false, noProject: false };
   for (let i = 0; i < argv.length; i += 1) {
     const a = argv[i];
     if (a === '-h' || a === '--help') f.help = true;
+    else if (a === '--no-project') f.noProject = true;
     else if (a === '--token') {
       const next = argv[i + 1];
       if (!next) throw new Error('--token requires a value');
@@ -166,6 +170,18 @@ export async function runLogin(argv: string[]): Promise<number> {
     );
   }
   process.stdout.write(`${C.dim}  Stored at ${authFileLocation()}${C.reset}\n`);
+
+  // The always-bound invariant: a fresh login ends with a global default
+  // project so every later command Just Works from any directory.
+  if (!flags.noProject) {
+    const saved = loadAuthForHost(hostName);
+    if (saved?.token) {
+      process.stdout.write('\n');
+      await ensureDefaultProjectBinding(saved, {
+        promptTitle: 'Pick your default project (used anywhere no directory is linked)',
+      });
+    }
+  }
   return 0;
 }
 
@@ -236,6 +252,3 @@ function openInBrowser(url: string): void {
     /* user can copy-paste the URL from stdout */
   }
 }
-
-// Silence unused-import detection if loadAuthForHost ever becomes useful here.
-void loadAuthForHost;

--- a/apps/cli/src/commands/marketplace-install.ts
+++ b/apps/cli/src/commands/marketplace-install.ts
@@ -245,7 +245,7 @@ function printPlan(resolved: ResolvedItem, plan: InstallPlan, flags: Flags): voi
 
 /** Install a marketplace item straight into a linked cloud project's repo. */
 async function installToProject(address: string, flags: Flags): Promise<number> {
-  const ctx = resolveProjectContext({ projectArg: flags.project, hostArg: flags.host });
+  const ctx = await resolveProjectContext({ projectArg: flags.project, hostArg: flags.host });
   if (!ctx) return 1;
 
   let items: CatalogItem[];

--- a/apps/cli/src/commands/marketplace.ts
+++ b/apps/cli/src/commands/marketplace.ts
@@ -252,7 +252,7 @@ async function marketplaceInstall(argv: string[], flags: MarketplaceFlags): Prom
 }
 
 async function marketplaceStatus(flags: MarketplaceFlags): Promise<number> {
-  const ctx = resolveProjectContext({ projectArg: flags.project, hostArg: flags.host });
+  const ctx = await resolveProjectContext({ projectArg: flags.project, hostArg: flags.host });
   if (!ctx) return 1;
   let res: InstalledResponse;
   try {
@@ -282,7 +282,7 @@ async function marketplaceStatus(flags: MarketplaceFlags): Promise<number> {
 }
 
 async function marketplaceUpdates(flags: MarketplaceFlags): Promise<number> {
-  const ctx = resolveProjectContext({ projectArg: flags.project, hostArg: flags.host });
+  const ctx = await resolveProjectContext({ projectArg: flags.project, hostArg: flags.host });
   if (!ctx) return 1;
   let res: UpdatesResponse;
   try {
@@ -316,7 +316,7 @@ async function marketplaceUpdate(argv: string[], flags: MarketplaceFlags): Promi
     process.stderr.write(`${status.err('pass an item name or --all: kortix marketplace update pdf')}\n`);
     return 2;
   }
-  const ctx = resolveProjectContext({ projectArg: flags.project, hostArg: flags.host });
+  const ctx = await resolveProjectContext({ projectArg: flags.project, hostArg: flags.host });
   if (!ctx) return 1;
   let res: WriteResponse;
   try {
@@ -334,7 +334,7 @@ async function marketplaceUpdate(argv: string[], flags: MarketplaceFlags): Promi
 }
 
 async function marketplaceUpdateAll(flags: MarketplaceFlags): Promise<number> {
-  const ctx = resolveProjectContext({ projectArg: flags.project, hostArg: flags.host });
+  const ctx = await resolveProjectContext({ projectArg: flags.project, hostArg: flags.host });
   if (!ctx) return 1;
   let res: UpdateAllResponse;
   try {
@@ -363,7 +363,7 @@ async function marketplaceRemove(argv: string[], flags: MarketplaceFlags): Promi
     process.stderr.write(`${status.err('pass an item name: kortix marketplace remove pdf')}\n`);
     return 2;
   }
-  const ctx = resolveProjectContext({ projectArg: flags.project, hostArg: flags.host });
+  const ctx = await resolveProjectContext({ projectArg: flags.project, hostArg: flags.host });
   if (!ctx) return 1;
   let res: WriteResponse;
   try {

--- a/apps/cli/src/commands/providers.ts
+++ b/apps/cli/src/commands/providers.ts
@@ -118,7 +118,7 @@ export async function runProviders(argv: string[]): Promise<number> {
 }
 
 async function providersLs(opts: CtxOpts, json = false): Promise<number> {
-  const ctx = resolveProjectContext(opts);
+  const ctx = await resolveProjectContext(opts);
   if (!ctx) return 1;
 
   let oauthList: OauthListResponse;
@@ -201,7 +201,7 @@ async function providersLogin(
     );
     return 2;
   }
-  const ctx = resolveProjectContext(opts);
+  const ctx = await resolveProjectContext(opts);
   if (!ctx) return 1;
 
   // Kick off the device-code flow.
@@ -288,7 +288,7 @@ async function providersSet(
     );
     return 2;
   }
-  const ctx = resolveProjectContext(opts);
+  const ctx = await resolveProjectContext(opts);
   if (!ctx) return 1;
 
   let value = key;
@@ -320,7 +320,7 @@ async function providersRm(provider: string | undefined, opts: CtxOpts): Promise
     process.stderr.write(`${status.err('Pass a provider.')}\n`);
     return 2;
   }
-  const ctx = resolveProjectContext(opts);
+  const ctx = await resolveProjectContext(opts);
   if (!ctx) return 1;
 
   let removedOauth = false;

--- a/apps/cli/src/commands/proxy.ts
+++ b/apps/cli/src/commands/proxy.ts
@@ -76,7 +76,7 @@ export async function runProxy(argv: string[]): Promise<number> {
 
 async function resolveSandboxId(
   sessionId: string | undefined,
-  ctx: NonNullable<ReturnType<typeof resolveProjectContext>>,
+  ctx: NonNullable<Awaited<ReturnType<typeof resolveProjectContext>>>,
 ): Promise<string | null> {
   if (!sessionId) {
     process.stderr.write(`${status.err('Pass a session id.')}\n`);
@@ -115,7 +115,7 @@ async function proxyShare(
     return 2;
   }
 
-  const ctx = resolveProjectContext(opts);
+  const ctx = await resolveProjectContext(opts);
   if (!ctx) return 1;
   const sandboxId = await resolveSandboxId(sessionId, ctx);
   if (!sandboxId) return 1;
@@ -150,7 +150,7 @@ async function proxyShare(
 }
 
 async function proxyLs(sessionId: string | undefined, opts: CtxOpts, json = false): Promise<number> {
-  const ctx = resolveProjectContext(opts);
+  const ctx = await resolveProjectContext(opts);
   if (!ctx) return 1;
   const sandboxId = await resolveSandboxId(sessionId, ctx);
   if (!sandboxId) return 1;
@@ -207,7 +207,7 @@ async function proxyRm(
     process.stderr.write(`${status.err('Pass the share token.')}\n`);
     return 2;
   }
-  const ctx = resolveProjectContext(opts);
+  const ctx = await resolveProjectContext(opts);
   if (!ctx) return 1;
   const sandboxId = await resolveSandboxId(sessionId, ctx);
   if (!sandboxId) return 1;

--- a/apps/cli/src/commands/registry.ts
+++ b/apps/cli/src/commands/registry.ts
@@ -317,7 +317,7 @@ async function registryRemove(argv: string[], json: boolean): Promise<number> {
 
   // Cloud path: remove from a linked project's repo (commits the removal).
   if (project) {
-    const ctx = resolveProjectContext({ projectArg: project });
+    const ctx = await resolveProjectContext({ projectArg: project });
     if (!ctx) return 1;
     try {
       const res = await ctx.client.delete<{ removed: string; commit_sha?: string; branch?: string; file_count: number }>(

--- a/apps/cli/src/commands/sandboxes.ts
+++ b/apps/cli/src/commands/sandboxes.ts
@@ -112,7 +112,7 @@ export async function runSandboxes(argv: string[]): Promise<number> {
   if (sub === 'update' || sub === 'edit') return sandboxUpdateLocal(positional[0], f);
   if (sub === 'rm' || sub === 'remove' || sub === 'delete') return sandboxRmLocal(positional[0]);
 
-  const ctx = resolveProjectContext({ projectArg: f.project, hostArg: f.host });
+  const ctx = await resolveProjectContext({ projectArg: f.project, hostArg: f.host });
   if (!ctx) return 1;
   const base = `/projects/${ctx.projectId}`;
 

--- a/apps/cli/src/commands/secrets.ts
+++ b/apps/cli/src/commands/secrets.ts
@@ -82,7 +82,7 @@ export async function runSecrets(argv: string[]): Promise<number> {
 type CtxOpts = { projectArg?: string; hostArg?: string };
 
 async function secretsLs(opts: CtxOpts, json = false): Promise<number> {
-  const ctx = resolveProjectContext(opts);
+  const ctx = await resolveProjectContext(opts);
   if (!ctx) return 1;
 
   let resp: ProjectSecretsResponse;
@@ -201,7 +201,7 @@ async function secretsLs(opts: CtxOpts, json = false): Promise<number> {
 }
 
 async function secretsSet(args: string[], opts: CtxOpts): Promise<number> {
-  const ctx = resolveProjectContext(opts);
+  const ctx = await resolveProjectContext(opts);
   if (!ctx) return 1;
   if (args.length === 0) {
     process.stderr.write(`${status.err('Pass at least one NAME=VALUE pair.')}\n`);
@@ -263,7 +263,7 @@ async function secretsRequest(rest: string[], opts: CtxOpts, json = false): Prom
     return 2;
   }
 
-  const ctx = resolveProjectContext(opts);
+  const ctx = await resolveProjectContext(opts);
   if (!ctx) return 1;
 
   let resp: { url: string; names: string[]; scope: string; expires_at: string };
@@ -292,7 +292,7 @@ async function secretsRequest(rest: string[], opts: CtxOpts, json = false): Prom
 }
 
 async function secretsUnset(names: string[], opts: CtxOpts): Promise<number> {
-  const ctx = resolveProjectContext(opts);
+  const ctx = await resolveProjectContext(opts);
   if (!ctx) return 1;
   if (names.length === 0) {
     process.stderr.write(`${status.err('Pass at least one secret name to unset.')}\n`);

--- a/apps/cli/src/commands/sessions-chat.ts
+++ b/apps/cli/src/commands/sessions-chat.ts
@@ -32,7 +32,7 @@ interface ResolvedSession {
   /** The OpenCode session id INSIDE the sandbox. May need creating. */
   opencodeSessionId: string | null;
   /** Kortix-side API client (for PATCH/save-back). */
-  ctx: NonNullable<ReturnType<typeof resolveProjectContext>>;
+  ctx: NonNullable<Awaited<ReturnType<typeof resolveProjectContext>>>;
 }
 
 /**
@@ -46,7 +46,7 @@ export async function loadSessionForChat(
   sessionId: string,
   opts: CtxOpts,
 ): Promise<ResolvedSession | null> {
-  const ctx = resolveProjectContext(opts);
+  const ctx = await resolveProjectContext(opts);
   if (!ctx) return null;
 
   let session: ProjectSession;
@@ -348,7 +348,7 @@ async function resolveChatSessionId(
 ): Promise<string | null> {
   if (explicit) return explicit;
 
-  const ctx = resolveProjectContext(opts);
+  const ctx = await resolveProjectContext(opts);
   if (!ctx) return null;
 
   if (wantNew) {
@@ -400,7 +400,7 @@ async function resolveChatSessionId(
  * Returns the sentinel `'error'` (after printing the API error) on failure.
  */
 export async function chooseRunningSession(
-  ctx: NonNullable<ReturnType<typeof resolveProjectContext>>,
+  ctx: NonNullable<Awaited<ReturnType<typeof resolveProjectContext>>>,
   pickTitle: string,
 ): Promise<ProjectSession | null | 'error'> {
   let sessions: ProjectSession[];
@@ -432,7 +432,7 @@ export async function chooseRunningSession(
 
 /** Poll a freshly-created session until it's running (or fails / times out). */
 async function waitForRunning(
-  ctx: NonNullable<ReturnType<typeof resolveProjectContext>>,
+  ctx: NonNullable<Awaited<ReturnType<typeof resolveProjectContext>>>,
   sessionId: string,
 ): Promise<boolean> {
   for (let i = 0; i < 75; i += 1) {
@@ -511,7 +511,7 @@ export async function runSessionsLog(argv: string[]): Promise<number> {
   // Resolve which session: explicit id → most-recent running.
   let sessionId = positional[0];
   if (!sessionId) {
-    const ctx = resolveProjectContext(opts);
+    const ctx = await resolveProjectContext(opts);
     if (!ctx) return 1;
     const chosen = await chooseRunningSession(ctx, 'Pick a session to read');
     if (chosen === 'error') return 1;
@@ -680,7 +680,7 @@ export async function runSessionsStatus(argv: string[]): Promise<number> {
     return 2;
   }
   const opts: CtxOpts = { projectArg, hostArg };
-  const ctx = resolveProjectContext(opts);
+  const ctx = await resolveProjectContext(opts);
   if (!ctx) return 1;
 
   // Same auth the project context resolved with — needed for the OpenCode proxy.

--- a/apps/cli/src/commands/sessions-connect.ts
+++ b/apps/cli/src/commands/sessions-connect.ts
@@ -112,7 +112,7 @@ async function resolveConnectSessionId(
   opts: CtxOpts,
 ): Promise<string | null> {
   if (explicit) return explicit;
-  const ctx = resolveProjectContext(opts);
+  const ctx = await resolveProjectContext(opts);
   if (!ctx) return null;
   const chosen = await chooseRunningSession(ctx, 'Pick a session to connect to');
   if (chosen === 'error') return null;

--- a/apps/cli/src/commands/sessions-digest.ts
+++ b/apps/cli/src/commands/sessions-digest.ts
@@ -127,7 +127,7 @@ export async function runSessionsDigest(argv: string[]): Promise<number> {
   }
 
   const opts: CtxOpts = { projectArg, hostArg };
-  const ctx = resolveProjectContext(opts);
+  const ctx = await resolveProjectContext(opts);
   if (!ctx) return 1;
 
   let sessions: ProjectSession[];

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -136,7 +136,7 @@ export async function runSessions(argv: string[]): Promise<number> {
 type CtxOpts = { projectArg?: string; hostArg?: string };
 
 async function sessionsLs(opts: CtxOpts, json = false): Promise<number> {
-  const ctx = resolveProjectContext(opts);
+  const ctx = await resolveProjectContext(opts);
   if (!ctx) return 1;
 
   let sessions: ProjectSession[];
@@ -181,7 +181,7 @@ async function sessionsNew(
   json = false,
   wait = false,
 ): Promise<number> {
-  const ctx = resolveProjectContext(opts);
+  const ctx = await resolveProjectContext(opts);
   if (!ctx) return 1;
 
   const body: Record<string, unknown> = {};
@@ -313,7 +313,7 @@ async function sessionsInfo(
     process.stderr.write(`${status.err('Pass a session id.')}\n`);
     return 2;
   }
-  const ctx = resolveProjectContext(opts);
+  const ctx = await resolveProjectContext(opts);
   if (!ctx) return 1;
 
   let s: ProjectSession;
@@ -364,7 +364,7 @@ async function sessionsPreview(
     process.stderr.write(`${status.err(`Invalid port "${portArg}".`)}\n`);
     return 2;
   }
-  const ctx = resolveProjectContext(opts);
+  const ctx = await resolveProjectContext(opts);
   if (!ctx) return 1;
 
   let s: ProjectSession;
@@ -412,7 +412,7 @@ async function sessionsRestart(sessionId: string | undefined, opts: CtxOpts): Pr
     process.stderr.write(`${status.err('Pass a session id.')}\n`);
     return 2;
   }
-  const ctx = resolveProjectContext(opts);
+  const ctx = await resolveProjectContext(opts);
   if (!ctx) return 1;
 
   try {
@@ -439,7 +439,7 @@ async function sessionsRename(
     process.stderr.write(`${status.err('Pass a name (use "" to clear it).')}\n`);
     return 2;
   }
-  const ctx = resolveProjectContext(opts);
+  const ctx = await resolveProjectContext(opts);
   if (!ctx) return 1;
 
   let updated: ProjectSession;
@@ -465,7 +465,7 @@ async function sessionsRm(sessionId: string | undefined, opts: CtxOpts): Promise
     process.stderr.write(`${status.err('Pass a session id.')}\n`);
     return 2;
   }
-  const ctx = resolveProjectContext(opts);
+  const ctx = await resolveProjectContext(opts);
   if (!ctx) return 1;
 
   try {
@@ -482,7 +482,7 @@ async function sessionsOpen(sessionId: string | undefined, opts: CtxOpts): Promi
     process.stderr.write(`${status.err('Pass a session id.')}\n`);
     return 2;
   }
-  const ctx = resolveProjectContext(opts);
+  const ctx = await resolveProjectContext(opts);
   if (!ctx) return 1;
   const auth = loadAuth();
   if (!auth) return 1;

--- a/apps/cli/src/commands/triggers.ts
+++ b/apps/cli/src/commands/triggers.ts
@@ -122,7 +122,7 @@ export async function runTriggers(argv: string[]): Promise<number> {
 type CtxOpts = { projectArg?: string; hostArg?: string };
 
 async function triggersLs(opts: CtxOpts, json = false): Promise<number> {
-  const ctx = resolveProjectContext(opts);
+  const ctx = await resolveProjectContext(opts);
   if (!ctx) return 1;
 
   let resp: ProjectTriggersResponse;
@@ -183,7 +183,7 @@ async function triggersFire(slug: string | undefined, opts: CtxOpts): Promise<nu
     process.stderr.write(`${status.err('Pass a trigger slug.')}\n`);
     return 2;
   }
-  const ctx = resolveProjectContext(opts);
+  const ctx = await resolveProjectContext(opts);
   if (!ctx) return 1;
 
   let resp: TriggerFireResponse;
@@ -208,7 +208,7 @@ async function triggersFire(slug: string | undefined, opts: CtxOpts): Promise<nu
 // Server-side activation switch (cloud state in projects.metadata, NOT the
 // manifest). Pause = the platform stops auto-running this project's triggers.
 async function triggersActivation(opts: CtxOpts, paused: boolean): Promise<number> {
-  const ctx = resolveProjectContext(opts);
+  const ctx = await resolveProjectContext(opts);
   if (!ctx) return 1;
 
   try {
@@ -327,7 +327,7 @@ async function triggersInfo(slug: string | undefined, opts: CtxOpts, json = fals
     process.stderr.write(`${status.err('Pass a trigger slug.')}\n`);
     return 2;
   }
-  const ctx = resolveProjectContext(opts);
+  const ctx = await resolveProjectContext(opts);
   if (!ctx) return 1;
 
   let resp: ProjectTriggersResponse;

--- a/apps/cli/src/project-bind.ts
+++ b/apps/cli/src/project-bind.ts
@@ -1,0 +1,98 @@
+import type { Auth } from './api/auth.ts';
+import { clientFromAuth } from './api/client.ts';
+import {
+  activeAccount,
+  defaultProject,
+  setDefaultProject,
+  type DefaultProjectRef,
+} from './api/config.ts';
+import { selectFromList } from './tui-select.ts';
+import { C, status } from './style.ts';
+import type { ProjectSummary } from './api/types.ts';
+
+export interface BindOutcome {
+  project: DefaultProjectRef | null;
+  /** True when setDefaultProject was called during this invocation. */
+  bound: boolean;
+}
+
+function isInteractive(): boolean {
+  return process.stdin.isTTY === true && process.stdout.isTTY === true;
+}
+
+function bindableAccountId(auth: Auth): string | undefined {
+  return activeAccount()?.id ?? auth.account_id ?? undefined;
+}
+
+/**
+ * The always-bound invariant: make sure the active host has a global
+ * default project, creating the binding interactively when possible.
+ *
+ *   - already bound        → return it, do nothing
+ *   - zero projects        → hint at `kortix init`, return null
+ *   - exactly one project  → bind it automatically (no prompt)
+ *   - several + TTY        → picker (Esc skips)
+ *   - several + non-TTY    → hint, return null
+ *
+ * Never throws: any API failure degrades to "not bound" with the reason
+ * on stderr, so callers (login epilogue, unbound-command recovery) can
+ * fall back to their existing error paths.
+ */
+export async function ensureDefaultProjectBinding(
+  auth: Auth,
+  opts: { promptTitle?: string } = {},
+): Promise<BindOutcome> {
+  const existing = defaultProject();
+  if (existing) return { project: existing, bound: false };
+
+  let projects: ProjectSummary[];
+  try {
+    projects = await clientFromAuth(auth, { accountId: bindableAccountId(auth) }).get<
+      ProjectSummary[]
+    >('/projects');
+  } catch (err) {
+    process.stderr.write(
+      `${C.dim}Could not list projects to bind a default: ${(err as Error).message}${C.reset}\n`,
+    );
+    return { project: null, bound: false };
+  }
+
+  if (projects.length === 0) {
+    process.stderr.write(
+      `${C.dim}No projects in this account yet — create your first with ${C.reset}${C.cyan}kortix init <name>${C.reset}${C.dim} then ${C.reset}${C.cyan}kortix ship${C.reset}${C.dim}.${C.reset}\n`,
+    );
+    return { project: null, bound: false };
+  }
+
+  let picked: ProjectSummary | null = null;
+  if (projects.length === 1) {
+    picked = projects[0];
+  } else if (isInteractive()) {
+    picked = await selectFromList<ProjectSummary>({
+      title: opts.promptTitle ?? 'Pick your default project',
+      items: projects.map((p) => ({ value: p, label: p.name, sublabel: p.project_id })),
+    });
+    if (!picked) {
+      process.stderr.write(
+        `${C.dim}Skipped. Bind one any time with ${C.reset}${C.cyan}kortix projects use${C.reset}${C.dim}.${C.reset}\n`,
+      );
+      return { project: null, bound: false };
+    }
+  } else {
+    process.stderr.write(
+      `${C.dim}No default project bound. Run ${C.reset}${C.cyan}kortix projects use${C.reset}${C.dim} to pick one.${C.reset}\n`,
+    );
+    return { project: null, bound: false };
+  }
+
+  const ref: DefaultProjectRef = {
+    project_id: picked.project_id,
+    account_id: picked.account_id,
+    name: picked.name,
+  };
+  setDefaultProject(ref);
+  process.stderr.write(
+    `${status.ok(`Default project: ${C.bold}${picked.name}${C.reset}`)} ${C.dim}(change with \`kortix projects use\`)${C.reset}\n`,
+  );
+  return { project: ref, bound: true };
+}


### PR DESCRIPTION
Track B, Phase B0 of the one-token + CLI-centric plan (#4295).

## What changes

**`kortix login` ends with a bound project.** After auth verification it runs the new `ensureDefaultProjectBinding`: already bound → no-op; zero projects → hint at `kortix init`; exactly one → auto-bind; several + TTY → picker (Esc skips); several + non-TTY → hint. `--no-project` opts out.

**Unbound commands recover instead of dead-ending.** `resolveProjectContext` (now async; ~60 call sites awaited) runs the same binding flow before erroring, so `kortix sessions ls` with one project in the account just works and persists the binding. Inside sandboxes this never fires (`KORTIX_PROJECT_ID` is injected); non-TTY multi-project keeps the hard error for scripts.

All binding notices write to **stderr** so `--json` stdout stays machine-parseable.

## Tests

- New `project-bind.test.ts`: no-op when bound, auto-bind single, zero-project hint, non-TTY multi no-bind, API-failure degradation (5 tests).
- Blackbox edge-case test updated: the no-link case now asserts the auto-bind contract (exit 0, `Default project:` notice, config mutation) and the exact request sequence.
- Full CLI suite 150/150 green, typecheck clean, biome clean (two pre-existing hits at HEAD unchanged).