### PR TITLE
fix(api): combinedAuth accepts service-account bearers, matching supabaseAuth

### DIFF
--- a/apps/api/src/__tests__/unit-combined-auth-sa.test.ts
+++ b/apps/api/src/__tests__/unit-combined-auth-sa.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import { Hono } from 'hono';
+
+let secretKeyValidations: string[] = [];
+
+mock.module('../shared/crypto', () => ({
+  isAccountToken: (t: string) => t.startsWith('kortix_pat_'),
+  isServiceAccountToken: (t: string) => t.startsWith('kortix_sa_'),
+  isKortixToken: (t: string) => t.startsWith('kortix_'),
+}));
+
+mock.module('../repositories/service-accounts', () => ({
+  validateServiceAccountToken: async (t: string) => {
+    if (t === 'kortix_sa_live') {
+      return { isValid: true, serviceAccountId: 'sa-1', accountId: 'acct-1' };
+    }
+    return { isValid: false, error: 'Invalid service account' };
+  },
+}));
+
+mock.module('../repositories/api-keys', () => ({
+  validateSecretKey: async (t: string) => {
+    secretKeyValidations.push(t);
+    return { isValid: false, error: 'Invalid Kortix token' };
+  },
+}));
+
+mock.module('../repositories/account-tokens', () => ({
+  validateAccountToken: async () => ({ isValid: false, error: 'invalid' }),
+}));
+
+mock.module('../shared/jwt-verify', () => ({
+  verifySupabaseJwt: async () => ({ ok: false }),
+}));
+
+mock.module('../shared/supabase', () => ({
+  getSupabase: () => ({
+    auth: {
+      getUser: async () => ({ data: { user: null }, error: { message: 'invalid' } }),
+    },
+  }),
+}));
+
+mock.module('../shared/preview-ownership', () => ({
+  canAccessPreviewSandbox: async ({ accountId }: { accountId?: string }) =>
+    accountId === 'acct-1',
+}));
+
+mock.module('../shared/auth-audit', () => ({
+  auditLoginSuccess: () => {},
+  auditLoginFail: () => {},
+}));
+
+mock.module('../lib/sentry', () => ({ setSentryUser: () => {} }));
+mock.module('../lib/request-context', () => ({ setContextField: () => {} }));
+mock.module('../iam/sso-sync', () => ({ syncSsoMembership: async () => {} }));
+
+const { combinedAuth, supabaseAuth } = await import('../middleware/auth');
+
+function appWith(middleware: typeof combinedAuth) {
+  const app = new Hono();
+  app.use('/*', middleware);
+  app.get('/probe', (c) =>
+    c.json({
+      userId: c.get('userId' as never),
+      accountId: c.get('accountId' as never),
+      authType: c.get('authType' as never),
+      iamTokenId: c.get('iamTokenId' as never),
+    }),
+  );
+  return app;
+}
+
+describe('combinedAuth accepts service-account bearers', () => {
+  beforeEach(() => {
+    secretKeyValidations = [];
+  });
+
+  test('a valid kortix_sa_ token resolves to a service-account principal', async () => {
+    const res = await appWith(combinedAuth).request('/probe', {
+      headers: { Authorization: 'Bearer kortix_sa_live' },
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.authType).toBe('service_account');
+    expect(body.userId).toBe('sa-1');
+    expect(body.accountId).toBe('acct-1');
+    expect(body.iamTokenId).toBe('sa-1');
+  });
+
+  test('kortix_sa_ never falls through to the generic Kortix-key validator', async () => {
+    await appWith(combinedAuth).request('/probe', {
+      headers: { Authorization: 'Bearer kortix_sa_live' },
+    });
+    await appWith(combinedAuth).request('/probe', {
+      headers: { Authorization: 'Bearer kortix_sa_bogus' },
+    });
+
+    expect(secretKeyValidations).toEqual([]);
+  });
+
+  test('an invalid kortix_sa_ token 401s with the service-account error, not the generic key error', async () => {
+    const res = await appWith(combinedAuth).request('/probe', {
+      headers: { Authorization: 'Bearer kortix_sa_bogus' },
+    });
+
+    expect(res.status).toBe(401);
+    expect(await res.text()).toContain('Invalid service account');
+  });
+
+  test('supabaseAuth and combinedAuth resolve the same SA token to the same principal', async () => {
+    const [a, b] = await Promise.all([
+      appWith(supabaseAuth).request('/probe', {
+        headers: { Authorization: 'Bearer kortix_sa_live' },
+      }),
+      appWith(combinedAuth).request('/probe', {
+        headers: { Authorization: 'Bearer kortix_sa_live' },
+      }),
+    ]);
+
+    expect(a.status).toBe(200);
+    expect(b.status).toBe(200);
+    expect(await a.json()).toEqual(await b.json());
+  });
+});

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -397,7 +397,54 @@ export async function combinedAuth(c: Context, next: Next) {
   // Determine if this is a preview proxy route (for cookie management)
   const isPreviewRoute = c.req.path.startsWith('/v1/p/') || c.req.path === '/v1/p';
 
-  // 0. CLI Personal Access Token — carries a real user_id.
+  // 0. Service-account bearer (non-human IAM principal) — mirrors the
+  // supabaseAuth branch. MUST run before the generic Kortix-token branch:
+  // `kortix_sa_` also matches the `kortix_` prefix, so without this check the
+  // token falls into validateSecretKey and every combinedAuth-mounted route
+  // (preview proxy, cron, secrets, providers, SSE) rejects service accounts
+  // that supabaseAuth-mounted routes accept.
+  if (isServiceAccountToken(token)) {
+    const sa = await validateServiceAccountToken(token);
+    if (!sa.isValid || !sa.serviceAccountId || !sa.accountId) {
+      auditLoginFail({
+        c,
+        reason: sa.error ?? 'invalid_service_account',
+        authType: 'service_account',
+      });
+      throw new HTTPException(401, { message: sa.error || 'Invalid service account' });
+    }
+    if (
+      previewSandboxId &&
+      !(await canAccessPreviewSandbox({ previewSandboxId, accountId: sa.accountId }))
+    ) {
+      auditLoginFail({
+        c,
+        reason: 'preview_sandbox_not_authorized',
+        authType: 'service_account',
+        accountId: sa.accountId,
+      });
+      throw new HTTPException(403, { message: 'Not authorized to access this sandbox' });
+    }
+    c.set('userId', sa.serviceAccountId);
+    c.set('userEmail', '');
+    c.set('authType', 'service_account');
+    c.set('accountId', sa.accountId);
+    c.set('iamTokenId', sa.serviceAccountId);
+    setSentryUser({ id: sa.serviceAccountId, accountId: sa.accountId });
+    setContextField('userId', sa.serviceAccountId);
+    setContextField('accountId', sa.accountId);
+    if (isPreviewRoute) setPreviewSessionCookie(c, token);
+    auditLoginSuccess({
+      c,
+      userId: sa.serviceAccountId,
+      accountId: sa.accountId,
+      authType: 'service_account',
+    });
+    await next();
+    return;
+  }
+
+  // 1. CLI Personal Access Token — carries a real user_id.
   if (isAccountToken(token)) {
     const patResult = await validateAccountToken(token);
     if (!patResult.isValid || !patResult.userId) {
@@ -433,7 +480,7 @@ export async function combinedAuth(c: Context, next: Next) {
     return;
   }
 
-  // 1. Try Kortix token (kortix_ or kortix_sb_) — used by agents inside the sandbox
+  // 2. Try Kortix token (kortix_ or kortix_sb_) — used by agents inside the sandbox
   if (isKortixToken(token)) {
     const result = await validateSecretKey(token);
     if (!result.isValid) {
@@ -478,7 +525,7 @@ export async function combinedAuth(c: Context, next: Next) {
     return;
   }
 
-  // 2. Try Supabase JWT — fast path: local verification (no network roundtrip)
+  // 3. Try Supabase JWT — fast path: local verification (no network roundtrip)
   const local = await verifySupabaseJwt(token);
   if (local.ok) {
     if (previewSandboxId && !(await canAccessPreviewSandbox({


### PR DESCRIPTION
Track A, Phase A0 of the one-token + CLI-centric plan (#4295) — defect 1 from the 2026-07-08 credential audit.

## Bug

`kortix_sa_` bearers are only wired into `supabaseAuth`. On `combinedAuth`-mounted routes (preview proxy `/v1/p/*`, cron, secrets, providers, SSE endpoints) the token matches the generic `kortix_` prefix, falls into `validateSecretKey`, and 401s with `Invalid Kortix token` — service accounts silently cannot use any of those surfaces, even with correct IAM policies. The non-Hono preview edge (`sandbox-proxy/preview-auth.ts`) already accepts SA tokens and its tests call out that credential matrix; `combinedAuth` was the one laggard.

## Fix

New branch 0 in `combinedAuth`, before the generic Kortix-key branch (order matters because of the shared prefix), mirroring the `supabaseAuth` SA principal exactly: `userId`/`iamTokenId` = the SA id so the IAM engine evaluates only the SA's own policies. Adds the `canAccessPreviewSandbox` ownership gate for parity with the PAT/key/JWT branches.

## Tests

New `unit-combined-auth-sa.test.ts` (4 tests): valid SA resolves to the service_account principal; `kortix_sa_` never reaches `validateSecretKey` (regression lock); invalid SA 401s with the SA-specific error; supabaseAuth and combinedAuth resolve the same token to the identical principal (drift guard). Adjacent auth unit suites pass in isolation; `auth-sso-sync.test.ts` env failure is pre-existing at HEAD (local encrypted-.env limitation). Typecheck clean.

Note: a ke2e flow exercising an SA bearer end-to-end needs SA fixtures in the live-suite bootstrap — tracked as Phase A0 follow-up in the spec rather than bundled here.