### PR TITLE
feat(executor): oauth1 auth type for openapi/http connectors

### DIFF
--- a/apps/api/src/__tests__/unit-executor-execute.test.ts
+++ b/apps/api/src/__tests__/unit-executor-execute.test.ts
@@ -6,6 +6,8 @@
 import { describe, expect, test } from 'bun:test';
 import {
   executeCall,
+  oauth1Header,
+  oauth1Signature,
   paramHintsFromSchema,
   parseResponseBody,
   type ExecutorAuth,
@@ -261,5 +263,97 @@ describe('executeCall dispatch', () => {
     await expect(
       executeCall({ binding: { kind: 'graphql', operation: 'query', field: 'user' }, fetchImpl }),
     ).rejects.toThrow('endpoint');
+  });
+});
+
+describe('oauth1 signing', () => {
+  // Test vector from the X OAuth 1.0a docs ("Creating a signature").
+  const VECTOR = {
+    method: 'POST',
+    url: 'https://api.x.com/1.1/statuses/update.json',
+    params: [
+      ['status', 'Hello Ladies + Gentlemen, a signed OAuth request!'],
+      ['include_entities', 'true'],
+      ['oauth_consumer_key', 'xvz1evFS4wEEPTGEFPHBog'],
+      ['oauth_nonce', 'kYjzVBB8Y0ZFabxSWbWovY3uYSQ2pTgmZeNu2VS4cg'],
+      ['oauth_signature_method', 'HMAC-SHA1'],
+      ['oauth_timestamp', '1318622958'],
+      ['oauth_token', '370773112-GmHxMAgYyLbNEtIKZeRNFsMKPR9EyMZeS9weJAEb'],
+      ['oauth_version', '1.0'],
+    ] as Array<[string, string]>,
+    consumerSecret: 'kAcSOqF21Fu85e7zjz7ZN2U4ZRhfV3WpwPAoE3Z7kBw',
+    tokenSecret: 'LswwdoUaIvS8ltyTt5jkRh4J50vUPVVHtR2YPi5kE',
+    signature: 'Ls93hJiZbQ3akF3HF3x1Bz8/zU4=',
+  };
+
+  test('oauth1Signature matches the published X docs test vector', () => {
+    expect(
+      oauth1Signature({
+        method: VECTOR.method,
+        url: VECTOR.url,
+        params: VECTOR.params,
+        consumerSecret: VECTOR.consumerSecret,
+        tokenSecret: VECTOR.tokenSecret,
+      }),
+    ).toBe(VECTOR.signature);
+  });
+
+  test('oauth1Header signs the final query and emits an OAuth header', () => {
+    const query = new URLSearchParams();
+    query.set('status', 'Hello Ladies + Gentlemen, a signed OAuth request!');
+    query.set('include_entities', 'true');
+    const header = oauth1Header({
+      method: 'POST',
+      url: 'https://api.x.com/1.1/statuses/update.json',
+      query,
+      creds: {
+        consumer_key: 'xvz1evFS4wEEPTGEFPHBog',
+        consumer_secret: VECTOR.consumerSecret,
+        token: '370773112-GmHxMAgYyLbNEtIKZeRNFsMKPR9EyMZeS9weJAEb',
+        token_secret: VECTOR.tokenSecret,
+      },
+      nonce: 'kYjzVBB8Y0ZFabxSWbWovY3uYSQ2pTgmZeNu2VS4cg',
+      timestamp: '1318622958',
+    });
+    expect(header).toContain(`oauth_signature="${encodeURIComponent(VECTOR.signature)}"`);
+    expect(header).toContain('oauth_consumer_key="xvz1evFS4wEEPTGEFPHBog"');
+    expect(header.startsWith('OAuth ')).toBe(true);
+  });
+
+  test('executeCall with oauth1 attaches a signed Authorization header, creds never in URL', async () => {
+    const { fetchImpl, calls } = recordingFetch();
+    await executeCall({
+      binding: { kind: 'openapi', method: 'GET', path: '/accounts', server: 'https://ads-api.x.com/12' },
+      auth: { type: 'oauth1', in: 'header', name: null, prefix: null },
+      secret: JSON.stringify({
+        consumer_key: 'ck',
+        consumer_secret: 'cs',
+        token: 'tk',
+        token_secret: 'ts',
+      }),
+      args: { count: 5 },
+      paramHints: { count: 'query' },
+      fetchImpl,
+    });
+    const call = calls[0]!;
+    expect(call.headers.Authorization).toMatch(/^OAuth /);
+    expect(call.headers.Authorization).toContain('oauth_consumer_key="ck"');
+    expect(call.headers.Authorization).toContain('oauth_signature="');
+    expect(call.url).toBe('https://ads-api.x.com/12/accounts?count=5');
+    expect(call.url).not.toContain('ck');
+    expect(call.url).not.toContain('cs');
+  });
+
+  test('executeCall with oauth1 rejects a malformed credential', async () => {
+    const { fetchImpl } = recordingFetch();
+    await expect(
+      executeCall({
+        binding: { kind: 'http', method: 'GET', path: '/x' },
+        baseUrl: 'https://api.example.com',
+        auth: { type: 'oauth1', in: 'header', name: null, prefix: null },
+        secret: 'not-json',
+        fetchImpl,
+      }),
+    ).rejects.toThrow('oauth1 credential');
   });
 });

--- a/apps/api/src/executor/execute.ts
+++ b/apps/api/src/executor/execute.ts
@@ -8,10 +8,11 @@
  * string from the field + selection — is a follow-up; normalization already
  * works.) See docs/specs/executor.md §7.
  */
+import { createHmac, randomBytes } from 'node:crypto';
 import type { ActionBinding } from './types';
 
 export interface ExecutorAuth {
-  type: 'bearer' | 'basic' | 'custom' | 'none';
+  type: 'bearer' | 'basic' | 'custom' | 'oauth1' | 'none';
   in: 'header' | 'query';
   name: string | null;
   prefix: string | null;
@@ -34,14 +35,19 @@ export interface ExecResult {
 
 const NO_AUTH: ExecutorAuth = { type: 'none', in: 'header', name: null, prefix: null };
 
-/** Attach a credential to a request per the connector's auth method. */
+/**
+ * Attach a credential to a request per the connector's auth method.
+ * `oauth1` is not handled here — it needs the method + final URL + query to
+ * sign, so buildHttpRequest applies it (manifest validation restricts oauth1
+ * to openapi/http connectors, the only bindings that route through there).
+ */
 function applyAuth(
   headers: Record<string, string>,
   query: URLSearchParams,
   auth: ExecutorAuth,
   secret: string | null,
 ): void {
-  if (auth.type === 'none' || !secret) return;
+  if (auth.type === 'none' || auth.type === 'oauth1' || !secret) return;
   if (auth.type === 'bearer') {
     const prefix = auth.prefix ?? 'Bearer';
     headers['Authorization'] = `${prefix} ${secret}`.trim();
@@ -57,6 +63,102 @@ function applyAuth(
   const name = auth.name ?? 'Authorization';
   if (auth.in === 'query') query.set(name, value);
   else headers[name] = value;
+}
+
+/* ─── OAuth 1.0a (RFC 5849) — HMAC-SHA1 request signing ─────────────────── */
+
+/**
+ * The oauth1 credential is ONE stored secret whose value is a JSON object with
+ * all four values (same pack-into-one convention as basic's "user:pass"):
+ * `{"consumer_key":"…","consumer_secret":"…","token":"…","token_secret":"…"}`.
+ */
+interface Oauth1Creds {
+  consumer_key: string;
+  consumer_secret: string;
+  token: string;
+  token_secret: string;
+}
+
+function parseOauth1Secret(secret: string | null): Oauth1Creds | null {
+  if (!secret) return null;
+  try {
+    const o = JSON.parse(secret) as Record<string, unknown>;
+    if (
+      typeof o?.consumer_key === 'string' &&
+      typeof o?.consumer_secret === 'string' &&
+      typeof o?.token === 'string' &&
+      typeof o?.token_secret === 'string'
+    ) {
+      return o as unknown as Oauth1Creds;
+    }
+  } catch {
+    /* not JSON */
+  }
+  return null;
+}
+
+/** RFC 3986 percent-encoding — stricter than encodeURIComponent. */
+function rfc3986(s: string): string {
+  return encodeURIComponent(s).replace(/[!'()*]/g, (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`);
+}
+
+/**
+ * Compute the OAuth 1.0a HMAC-SHA1 signature (RFC 5849 §3.4). Pure — exported
+ * for unit tests against the spec's published test vector. `params` are the
+ * decoded oauth_* + query pairs; JSON bodies are excluded per §3.4.1.3.1.
+ */
+export function oauth1Signature(opts: {
+  method: string;
+  /** Base string URI — scheme://host/path, no query. */
+  url: string;
+  params: Array<[string, string]>;
+  consumerSecret: string;
+  tokenSecret: string;
+}): string {
+  const normalized = opts.params
+    .map(([k, v]) => [rfc3986(k), rfc3986(v)] as const)
+    .sort(([ak, av], [bk, bv]) => (ak === bk ? (av < bv ? -1 : av > bv ? 1 : 0) : ak < bk ? -1 : 1))
+    .map(([k, v]) => `${k}=${v}`)
+    .join('&');
+  const base = `${opts.method.toUpperCase()}&${rfc3986(opts.url)}&${rfc3986(normalized)}`;
+  const key = `${rfc3986(opts.consumerSecret)}&${rfc3986(opts.tokenSecret)}`;
+  return createHmac('sha1', key).update(base).digest('base64');
+}
+
+/** Build the `Authorization: OAuth …` header for a request. */
+export function oauth1Header(opts: {
+  method: string;
+  /** Request URL without the query string. */
+  url: string;
+  query: URLSearchParams;
+  creds: Oauth1Creds;
+  /** Test seams — real calls omit these. */
+  nonce?: string;
+  timestamp?: string;
+}): string {
+  const oauth: Record<string, string> = {
+    oauth_consumer_key: opts.creds.consumer_key,
+    oauth_nonce: opts.nonce ?? randomBytes(16).toString('hex'),
+    oauth_signature_method: 'HMAC-SHA1',
+    oauth_timestamp: opts.timestamp ?? Math.floor(Date.now() / 1000).toString(),
+    oauth_token: opts.creds.token,
+    oauth_version: '1.0',
+  };
+  const params: Array<[string, string]> = [
+    ...Object.entries(oauth),
+    ...[...opts.query.entries()],
+  ];
+  oauth.oauth_signature = oauth1Signature({
+    method: opts.method,
+    url: opts.url,
+    params,
+    consumerSecret: opts.creds.consumer_secret,
+    tokenSecret: opts.creds.token_secret,
+  });
+  return `OAuth ${Object.keys(oauth)
+    .sort()
+    .map((k) => `${rfc3986(k)}="${rfc3986(oauth[k]!)}"`)
+    .join(', ')}`;
 }
 
 /** Derive where each input property goes from its `x-in` hint (from normalization). */
@@ -131,7 +233,25 @@ function buildHttpRequest(opts: {
     else appendQuery(query, key, value);
   }
 
-  applyAuth(headers, query, opts.auth ?? NO_AUTH, opts.secret ?? null);
+  const auth = opts.auth ?? NO_AUTH;
+  if (auth.type === 'oauth1') {
+    // Signed over method + URL + query (JSON bodies are excluded per RFC 5849
+    // §3.4.1.3.1) — must run after the query is final, so not in applyAuth.
+    const creds = parseOauth1Secret(opts.secret ?? null);
+    if (!creds) {
+      throw new Error(
+        'oauth1 credential must be a JSON object {"consumer_key","consumer_secret","token","token_secret"}',
+      );
+    }
+    headers['Authorization'] = oauth1Header({
+      method: opts.method,
+      url: joinUrl(opts.baseUrl, path),
+      query,
+      creds,
+    });
+  } else {
+    applyAuth(headers, query, auth, opts.secret ?? null);
+  }
 
   let url = joinUrl(opts.baseUrl, path);
   const qs = query.toString();

--- a/apps/api/src/executor/manifest-crud.ts
+++ b/apps/api/src/executor/manifest-crud.ts
@@ -41,7 +41,7 @@ export interface ConnectorDraft {
    *  removed 2026-07-05) — accepted for back-compat callers but never emitted
    *  into the manifest, since `shared` is already the implicit default. */
   credential?: 'shared';
-  auth?: { type?: 'none' | 'bearer' | 'basic' | 'custom'; in?: 'header' | 'query'; name?: string; prefix?: string };
+  auth?: { type?: 'none' | 'bearer' | 'basic' | 'custom' | 'oauth1'; in?: 'header' | 'query'; name?: string; prefix?: string };
 }
 
 export type CrudResult =
@@ -335,7 +335,7 @@ export interface ConnectorConfigView {
   endpoint: string | null;
   baseUrl: string | null;
   spec: string | null;
-  auth: { type: 'none' | 'bearer' | 'basic' | 'custom'; in: 'header' | 'query'; name: string | null; prefix: string | null };
+  auth: { type: 'none' | 'bearer' | 'basic' | 'custom' | 'oauth1'; in: 'header' | 'query'; name: string | null; prefix: string | null };
 }
 
 /**

--- a/apps/api/src/executor/router.ts
+++ b/apps/api/src/executor/router.ts
@@ -221,7 +221,7 @@ export interface ExecutorRouterDeps {
     baseUrl: string | null;
     spec: string | null;
     auth: {
-      type: 'none' | 'bearer' | 'basic' | 'custom';
+      type: 'none' | 'bearer' | 'basic' | 'custom' | 'oauth1';
       in: 'header' | 'query';
       name: string | null;
       prefix: string | null;

--- a/apps/api/src/projects/connectors.ts
+++ b/apps/api/src/projects/connectors.ts
@@ -75,8 +75,8 @@ export const RESERVED_CONNECTOR_SLUGS = new Set<string>([
 /** Chat platforms a `channel` connector can target. */
 export type ChannelPlatform = 'slack' | 'email' | 'meet';
 
-type ConnectorAuthType = 'bearer' | 'basic' | 'custom' | 'none';
-const AUTH_TYPES: readonly ConnectorAuthType[] = ['bearer', 'basic', 'custom', 'none'];
+type ConnectorAuthType = 'bearer' | 'basic' | 'custom' | 'oauth1' | 'none';
+const AUTH_TYPES: readonly ConnectorAuthType[] = ['bearer', 'basic', 'custom', 'oauth1', 'none'];
 
 interface ConnectorAuthSpec {
   /** How the credential is attached to outbound calls. */
@@ -439,6 +439,9 @@ function parseAuth(
   }
   if (provider === 'channel' && type !== 'none') {
     return err(slug, 'provider="channel" authenticates via its platform install token — omit [connectors.auth]');
+  }
+  if (type === 'oauth1' && provider !== 'openapi' && provider !== 'http') {
+    return err(slug, '[connectors.auth] type="oauth1" is only supported for openapi/http connectors');
   }
 
   if (type === 'none') return { ok: true, value: { ...NO_AUTH } };

--- a/apps/web/public/schema/kortix.schema.json
+++ b/apps/web/public/schema/kortix.schema.json
@@ -416,6 +416,7 @@
                         "bearer",
                         "basic",
                         "custom",
+                        "oauth1",
                         "none"
                       ]
                     },
@@ -1415,6 +1416,7 @@
                         "bearer",
                         "basic",
                         "custom",
+                        "oauth1",
                         "none"
                       ]
                     },

--- a/apps/web/public/schema/kortix.v1.schema.json
+++ b/apps/web/public/schema/kortix.v1.schema.json
@@ -393,6 +393,7 @@
                   "bearer",
                   "basic",
                   "custom",
+                  "oauth1",
                   "none"
                 ]
               },

--- a/apps/web/public/schema/kortix.v2.schema.json
+++ b/apps/web/public/schema/kortix.v2.schema.json
@@ -549,6 +549,7 @@
                   "bearer",
                   "basic",
                   "custom",
+                  "oauth1",
                   "none"
                 ]
               },

--- a/packages/manifest-schema/src/__tests__/json-schema.conformance.test.ts
+++ b/packages/manifest-schema/src/__tests__/json-schema.conformance.test.ts
@@ -304,6 +304,13 @@ apps:
       'kortix_version = 1\n[[connectors]]\nslug = "x"\nprovider = "openapi"\nspec = "https://x/y.json"\n[connectors.auth]\ntype = "oauth2"\n',
   },
   {
+    name: 'connectors.auth.type oauth1 is a known enum value (openapi connector)',
+    format: 'toml',
+    valid: true,
+    input:
+      'kortix_version = 1\n[[connectors]]\nslug = "x"\nprovider = "openapi"\nspec = "https://x/y.json"\n[connectors.auth]\ntype = "oauth1"\n',
+  },
+  {
     name: 'channel connectors must not declare a non-"none" auth.type',
     format: 'toml',
     valid: false,
@@ -744,6 +751,13 @@ describe('Known divergence: cross-field rules only the imperative validator enfo
 
   test('kortix_version 2 in a .toml file: imperative rejects (format-aware), schema accepts (format-blind)', () => {
     const toml = 'kortix_version = 2\ndefault_agent = "w"\n[agents.w]\n';
+    expect(validateManifest(toml, 'toml').valid).toBe(false);
+    expect(validateCombined(parseToml(toml))).toBe(true);
+  });
+
+  test('auth.type oauth1 on a non-openapi/http connector: imperative rejects, schema accepts', () => {
+    const toml =
+      'kortix_version = 1\n[[connectors]]\nslug = "g"\nprovider = "graphql"\nendpoint = "https://x/graphql"\n[connectors.auth]\ntype = "oauth1"\n';
     expect(validateManifest(toml, 'toml').valid).toBe(false);
     expect(validateCombined(parseToml(toml))).toBe(true);
   });

--- a/packages/manifest-schema/src/constants.ts
+++ b/packages/manifest-schema/src/constants.ts
@@ -26,7 +26,7 @@ export const TRIGGER_TYPES = ['cron', 'webhook'] as const;
 // by apps/api/src/__tests__/unit-connectors-parse.test.ts. `computer` is
 // deliberately absent: it is synth-only and never written to a manifest.
 export const CONNECTOR_PROVIDERS = ['pipedream', 'mcp', 'openapi', 'graphql', 'http', 'channel'] as const;
-export const CONNECTOR_AUTH_TYPES = ['bearer', 'basic', 'custom', 'none'] as const;
+export const CONNECTOR_AUTH_TYPES = ['bearer', 'basic', 'custom', 'oauth1', 'none'] as const;
 /** Platforms a `channel` connector can target — mirrors connectors.ts CHANNEL_PLATFORMS. */
 export const CHANNEL_PLATFORMS = ['slack', 'email', 'meet'] as const;
 /**

--- a/packages/manifest-schema/src/index.ts
+++ b/packages/manifest-schema/src/index.ts
@@ -1053,6 +1053,13 @@ function validateConnectors(node: unknown, path: string, issues: ManifestIssue[]
             severity: 'error',
           });
         }
+        if (t === 'oauth1' && provider !== 'openapi' && provider !== 'http') {
+          issues.push({
+            path: `${where}.auth.type`,
+            message: 'auth.type "oauth1" is only supported for openapi/http connectors.',
+            severity: 'error',
+          });
+        }
         if (auth.secret !== undefined) {
           issues.push({
             path: `${where}.auth.secret`,

--- a/packages/sdk/src/platform/projects-client/connectors.ts
+++ b/packages/sdk/src/platform/projects-client/connectors.ts
@@ -116,7 +116,7 @@ export interface ConnectorConfig {
   endpoint: string | null;
   baseUrl: string | null;
   spec: string | null;
-  auth: { type: 'none' | 'bearer' | 'basic' | 'custom'; in: 'header' | 'query'; name: string | null; prefix: string | null };
+  auth: { type: 'none' | 'bearer' | 'basic' | 'custom' | 'oauth1'; in: 'header' | 'query'; name: string | null; prefix: string | null };
 }
 
 export async function getConnectorConfig(projectId: string, slug: string) {

--- a/packages/sdk/src/platform/projects-client/connectors.ts
+++ b/packages/sdk/src/platform/projects-client/connectors.ts
@@ -116,7 +116,7 @@ export interface ConnectorConfig {
   endpoint: string | null;
   baseUrl: string | null;
   spec: string | null;
-  auth: { type: 'none' | 'bearer' | 'basic' | 'custom' | 'oauth1'; in: 'header' | 'query'; name: string | null; prefix: string | null };
+  auth: { type: 'none' | 'bearer' | 'basic' | 'custom' | 'oauth1' | 'oauth1'; in: 'header' | 'query'; name: string | null; prefix: string | null };
 }
 
 export async function getConnectorConfig(projectId: string, slug: string) {
@@ -161,7 +161,7 @@ export interface ConnectorDraftInput {
    *  removed 2026-07-05). */
   credential?: 'shared';
   auth?: {
-    type?: 'none' | 'bearer' | 'basic' | 'custom';
+    type?: 'none' | 'bearer' | 'basic' | 'custom' | 'oauth1';
     in?: 'header' | 'query';
     name?: string;
     prefix?: string;


### PR DESCRIPTION
## Why

The X Ads API (ads-api.x.com) — and any other OAuth 1.0a API — requires per-request HMAC-SHA1 signing over method + URL + query params. The gateway's existing auth types (bearer/basic/custom) can only attach a static credential, so these APIs couldn't be first-class connectors. First consumer: the company project's `x_ads` connector (staged behind a comment in its kortix.yaml, activates when this ships).

## What

- `oauth1` added to `CONNECTOR_AUTH_TYPES` (manifest-schema), the API parse path, executor types, and the SDK unions; published `apps/web/public/schema/*.json` regenerated.
- Gateway signing in `execute.ts`: `buildHttpRequest` signs after the query is final (RFC 5849 §3.4); JSON bodies excluded per §3.4.1.3.1. `applyAuth` explicitly skips oauth1 (it can't sign — no method/URL there).
- Credential shape: ONE stored secret whose value is JSON `{consumer_key, consumer_secret, token, token_secret}` — same pack-into-one convention as basic's `user:pass`, so the credential pipeline is untouched.
- Validation restricts oauth1 to `openapi`/`http` connectors on both the manifest-schema and API parse paths (graphql/mcp can't route through the signing point).

## Tests

- `oauth1Signature` verified against the published X docs test vector (`Ls93hJiZbQ3akF3HF3x1Bz8/zU4=`).
- `executeCall` wiring: signed Authorization header, creds never leak into the URL, malformed credential rejected.
- Conformance cases: oauth1 accepted on openapi (schema + imperative agree); oauth1 on graphql rejected imperatively (documented cross-field divergence).
- `packages/manifest-schema` 325 pass · api execute suite 20 pass · tsc clean on api/sdk/manifest-schema.