### PR TITLE
feat(cli): answer session permission asks and questions from the CLI

### DIFF
--- a/apps/cli/src/__tests__/sessions-approvals.e2e.test.ts
+++ b/apps/cli/src/__tests__/sessions-approvals.e2e.test.ts
@@ -1,0 +1,274 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+
+import { runSessions } from '../commands/sessions';
+
+const PROJECT_ID = '00000000-0000-4000-a000-000000000111';
+const ACCOUNT_ID = '00000000-0000-4000-a000-000000000222';
+const SESSION_ID = '00000000-0000-4000-a000-000000000333';
+const PROXY_ID = 'external-approvals';
+
+const ENV_KEYS = [
+  'KORTIX_CONFIG_FILE',
+  'KORTIX_CLI_TOKEN',
+  'KORTIX_EXECUTOR_TOKEN',
+  'KORTIX_TOKEN',
+  'KORTIX_API_URL',
+  'KORTIX_PROJECT_ID',
+  'KORTIX_DISABLE_SANDBOX_ENV_FILE',
+] as const;
+
+let dir = '';
+let server: ReturnType<typeof Bun.serve> | null = null;
+let permissionReplies: Array<{ id: string; body: unknown }> = [];
+let questionReplies: Array<{ id: string; body: unknown; kind: 'reply' | 'reject' }> = [];
+let pendingPermissions: unknown[] = [];
+let pendingQuestions: unknown[] = [];
+let stdoutChunks: string[] = [];
+let stderrChunks: string[] = [];
+const savedEnv: Record<string, string | undefined> = {};
+const realStdoutWrite = process.stdout.write;
+const realStderrWrite = process.stderr.write;
+
+function sessionRow() {
+  return {
+    session_id: SESSION_ID,
+    account_id: ACCOUNT_ID,
+    project_id: PROJECT_ID,
+    branch_name: SESSION_ID,
+    sandbox_provider: 'daytona',
+    sandbox_id: 'sandbox-row-id',
+    sandbox_url: `http://127.0.0.1/v1/p/${PROXY_ID}/8000`,
+    opencode_session_id: 'ses_oc',
+    name: null,
+    agent_name: 'default',
+    status: 'running',
+    error: null,
+    metadata: {},
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+  };
+}
+
+describe('sessions pending/approve/answer', () => {
+  beforeEach(() => {
+    for (const k of ENV_KEYS) savedEnv[k] = process.env[k];
+    for (const k of ENV_KEYS) delete process.env[k];
+    process.env.KORTIX_DISABLE_SANDBOX_ENV_FILE = '1';
+    dir = mkdtempSync(join(tmpdir(), 'kortix-approvals-'));
+    permissionReplies = [];
+    questionReplies = [];
+    pendingPermissions = [];
+    pendingQuestions = [];
+    stdoutChunks = [];
+    stderrChunks = [];
+
+    server = Bun.serve({
+      port: 0,
+      fetch: async (req) => {
+        const url = new URL(req.url);
+        if (req.method === 'GET' && url.pathname === `/v1/projects/${PROJECT_ID}/sessions/${SESSION_ID}`) {
+          return Response.json(sessionRow());
+        }
+        if (req.method === 'GET' && url.pathname === `/v1/p/${PROXY_ID}/4096/permission`) {
+          return Response.json(pendingPermissions);
+        }
+        if (req.method === 'GET' && url.pathname === `/v1/p/${PROXY_ID}/4096/question`) {
+          return Response.json(pendingQuestions);
+        }
+        const permReply = url.pathname.match(
+          new RegExp(`^/v1/p/${PROXY_ID}/4096/permission/([^/]+)/reply$`),
+        );
+        if (req.method === 'POST' && permReply) {
+          permissionReplies.push({ id: permReply[1], body: await req.json() });
+          return Response.json(true);
+        }
+        const qReply = url.pathname.match(
+          new RegExp(`^/v1/p/${PROXY_ID}/4096/question/([^/]+)/(reply|reject)$`),
+        );
+        if (req.method === 'POST' && qReply) {
+          questionReplies.push({
+            id: qReply[1],
+            body: await req.json().catch(() => null),
+            kind: qReply[2] as 'reply' | 'reject',
+          });
+          return Response.json(true);
+        }
+        return Response.json({ error: `not found ${url.pathname}` }, { status: 404 });
+      },
+    });
+
+    const configPath = join(dir, 'config.json');
+    process.env.KORTIX_CONFIG_FILE = configPath;
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        active: 'default',
+        hosts: {
+          default: {
+            url: `http://127.0.0.1:${server.port}`,
+            token: 'kortix_pat_test',
+            user_id: 'user-1',
+            user_email: 'user@example.test',
+            account_id: ACCOUNT_ID,
+            logged_in_at: '2026-01-01T00:00:00.000Z',
+          },
+        },
+      }),
+    );
+
+    process.stdout.write = ((chunk: string | Uint8Array) => {
+      stdoutChunks.push(String(chunk));
+      return true;
+    }) as typeof process.stdout.write;
+    process.stderr.write = ((chunk: string | Uint8Array) => {
+      stderrChunks.push(String(chunk));
+      return true;
+    }) as typeof process.stderr.write;
+  });
+
+  afterEach(() => {
+    process.stdout.write = realStdoutWrite;
+    process.stderr.write = realStderrWrite;
+    server?.stop(true);
+    server = null;
+    for (const k of ENV_KEYS) {
+      if (savedEnv[k] === undefined) delete process.env[k];
+      else process.env[k] = savedEnv[k];
+    }
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function permission(id: string) {
+    return {
+      id,
+      sessionID: 'ses_oc',
+      permission: 'bash',
+      patterns: ['rm -rf *'],
+      metadata: {},
+      always: [],
+      tool: { messageID: 'msg_1', callID: 'call_1' },
+    };
+  }
+
+  function question(id: string) {
+    return {
+      id,
+      sessionID: 'ses_oc',
+      questions: [
+        {
+          question: 'Which environment should I deploy to?',
+          header: 'Environment',
+          options: [
+            { label: 'Staging', value: 'staging' },
+            { label: 'Production', value: 'production' },
+          ],
+        },
+      ],
+      tool: { messageID: 'msg_2', callID: 'call_2' },
+    };
+  }
+
+  test('pending --json emits permissions and questions', async () => {
+    pendingPermissions = [permission('perm_1')];
+    pendingQuestions = [question('q_1')];
+
+    const code = await runSessions(['pending', SESSION_ID, '--project', PROJECT_ID, '--json']);
+
+    expect(code).toBe(0);
+    const payload = JSON.parse(stdoutChunks.join(''));
+    expect(payload.permissions[0].id).toBe('perm_1');
+    expect(payload.questions[0].id).toBe('q_1');
+  });
+
+  test('pending human output lists the ask and the command to answer it', async () => {
+    pendingPermissions = [permission('perm_1')];
+
+    const code = await runSessions(['pending', SESSION_ID, '--project', PROJECT_ID]);
+
+    expect(code).toBe(0);
+    const out = stdoutChunks.join('');
+    expect(out).toContain('perm_1');
+    expect(out).toContain('bash');
+    expect(out).toContain(`kortix sessions approve ${SESSION_ID} perm_1`);
+  });
+
+  test('approve with an explicit request id replies once', async () => {
+    const code = await runSessions(['approve', SESSION_ID, 'perm_1', '--project', PROJECT_ID]);
+
+    expect(code).toBe(0);
+    expect(permissionReplies).toEqual([{ id: 'perm_1', body: { reply: 'once' } }]);
+  });
+
+  test('approve --always and --message pass through; bare approve resolves the single pending ask', async () => {
+    pendingPermissions = [permission('perm_solo')];
+
+    const code = await runSessions([
+      'approve', SESSION_ID, '--always', '--message', 'go ahead', '--project', PROJECT_ID,
+    ]);
+
+    expect(code).toBe(0);
+    expect(permissionReplies).toEqual([
+      { id: 'perm_solo', body: { reply: 'always', message: 'go ahead' } },
+    ]);
+  });
+
+  test('approve --reject sends a rejection', async () => {
+    const code = await runSessions(['approve', SESSION_ID, 'perm_x', '--reject', '--project', PROJECT_ID]);
+
+    expect(code).toBe(0);
+    expect(permissionReplies).toEqual([{ id: 'perm_x', body: { reply: 'reject' } }]);
+  });
+
+  test('bare approve with several pending permissions errors and lists ids', async () => {
+    pendingPermissions = [permission('perm_a'), permission('perm_b')];
+
+    const code = await runSessions(['approve', SESSION_ID, '--project', PROJECT_ID]);
+
+    expect(code).toBe(1);
+    expect(permissionReplies).toEqual([]);
+    const err = stderrChunks.join('');
+    expect(err).toContain('perm_a');
+    expect(err).toContain('perm_b');
+  });
+
+  test('answer maps option labels to canonical values', async () => {
+    pendingQuestions = [question('q_1')];
+
+    const code = await runSessions([
+      'answer', SESSION_ID, 'q_1', '--option', 'Staging', '--project', PROJECT_ID,
+    ]);
+
+    expect(code).toBe(0);
+    expect(questionReplies).toEqual([
+      { id: 'q_1', body: { answers: [['staging']] }, kind: 'reply' },
+    ]);
+  });
+
+  test('answer --text sends free text; --reject dismisses', async () => {
+    pendingQuestions = [question('q_1')];
+
+    let code = await runSessions([
+      'answer', SESSION_ID, 'q_1', '--text', 'use the blue one', '--project', PROJECT_ID,
+    ]);
+    expect(code).toBe(0);
+
+    pendingQuestions = [question('q_2')];
+    code = await runSessions(['answer', SESSION_ID, 'q_2', '--reject', '--project', PROJECT_ID]);
+    expect(code).toBe(0);
+
+    expect(questionReplies).toEqual([
+      { id: 'q_1', body: { answers: [['use the blue one']] }, kind: 'reply' },
+      { id: 'q_2', body: {}, kind: 'reject' },
+    ]);
+  });
+
+  test('answer without any answer flags errors before any network reply', async () => {
+    const code = await runSessions(['answer', SESSION_ID, 'q_1', '--project', PROJECT_ID]);
+
+    expect(code).toBe(2);
+    expect(questionReplies).toEqual([]);
+  });
+});

--- a/apps/cli/src/api/sandbox-proxy.ts
+++ b/apps/cli/src/api/sandbox-proxy.ts
@@ -156,6 +156,31 @@ export function opencodeClient(opts: SandboxOpencodeOpts) {
         method: 'POST',
         body: {},
       }),
+    listPermissions: () =>
+      sandboxRequest<OpencodePermissionRequest[]>({ ...base, path: '/permission' }),
+    replyPermission: (requestId: string, reply: 'once' | 'always' | 'reject', message?: string) =>
+      sandboxRequest<boolean>({
+        ...base,
+        path: `/permission/${requestId}/reply`,
+        method: 'POST',
+        body: { reply, ...(message ? { message } : {}) },
+      }),
+    listQuestions: () =>
+      sandboxRequest<OpencodeQuestionRequest[]>({ ...base, path: '/question' }),
+    replyQuestion: (requestId: string, answers: string[][]) =>
+      sandboxRequest<boolean>({
+        ...base,
+        path: `/question/${requestId}/reply`,
+        method: 'POST',
+        body: { answers },
+      }),
+    rejectQuestion: (requestId: string) =>
+      sandboxRequest<boolean>({
+        ...base,
+        path: `/question/${requestId}/reject`,
+        method: 'POST',
+        body: {},
+      }),
   };
 }
 
@@ -203,3 +228,37 @@ export type OpencodePart =
   | { type: 'tool'; tool: string; state?: { status?: string; output?: string } }
   | { type: 'file'; mime?: string; filename?: string; url?: string }
   | { type: string; [k: string]: unknown };
+
+/** A pending tool-permission ask (OpenCode holds the tool call open until
+ *  `/permission/{id}/reply`). */
+export interface OpencodePermissionRequest {
+  id: string;
+  sessionID: string;
+  permission: string;
+  patterns: string[];
+  metadata: Record<string, unknown>;
+  always: string[];
+  tool?: { messageID: string; callID: string };
+}
+
+export interface OpencodeQuestionOption {
+  label: string;
+  value?: string;
+  hint?: string;
+}
+
+export interface OpencodeQuestionInfo {
+  question: string;
+  header: string;
+  options: OpencodeQuestionOption[];
+  multiple?: boolean;
+  custom?: boolean;
+}
+
+/** A pending question the agent asked (blocks the turn until answered). */
+export interface OpencodeQuestionRequest {
+  id: string;
+  sessionID: string;
+  questions: OpencodeQuestionInfo[];
+  tool?: { messageID: string; callID: string };
+}

--- a/apps/cli/src/commands/sessions-approvals.ts
+++ b/apps/cli/src/commands/sessions-approvals.ts
@@ -1,0 +1,308 @@
+import type {
+  OpencodePermissionRequest,
+  OpencodeQuestionRequest,
+} from '../api/sandbox-proxy.ts';
+import { emitJson, surfaceApiError, takeFlagBool, takeFlagValue } from '../command-helpers.ts';
+import { C, status } from '../style.ts';
+import { loadSessionForChat, type ResolvedSession } from './sessions-chat.ts';
+
+type CtxOpts = { projectArg?: string; hostArg?: string };
+
+const PENDING_HELP = `Usage: kortix sessions pending <session-id> [options]
+
+List the session's open interactive prompts — tool-permission asks and
+questions the agent is blocked on. Answer them with
+\`kortix sessions approve\` / \`kortix sessions answer\`.
+
+Options:
+  --project <id>   Operate on this project id (default: linked/default).
+  --host <name>    Operate against a non-default Kortix host.
+  --json           Machine-readable output ({ permissions, questions }).
+  -h, --help       Show this help.
+`;
+
+const APPROVE_HELP = `Usage: kortix sessions approve <session-id> [<request-id>] [options]
+
+Answer a pending tool-permission ask. With no <request-id>, acts on the
+session's single pending permission (errors if there are several).
+
+Options:
+  --always           Allow this action pattern for the rest of the session.
+  --reject           Deny the request.
+  --message "<why>"  Note passed back to the agent with the reply.
+  --project <id>     Operate on this project id (default: linked/default).
+  --host <name>      Operate against a non-default Kortix host.
+  -h, --help         Show this help.
+`;
+
+const ANSWER_HELP = `Usage: kortix sessions answer <session-id> [<request-id>] [options]
+
+Answer a pending question the agent asked. With no <request-id>, acts on
+the session's single pending question (errors if there are several).
+
+Options:
+  --option <value>   Pick this option (label or value; repeat for
+                     multi-select questions).
+  --text "<answer>"  Free-text answer (for questions that accept custom
+                     input; combinable with --option).
+  --reject           Dismiss the question without answering.
+  --answers <json>   Raw answers payload (string[][]) for requests carrying
+                     several questions — overrides --option/--text.
+  --project <id>     Operate on this project id (default: linked/default).
+  --host <name>      Operate against a non-default Kortix host.
+  -h, --help         Show this help.
+`;
+
+interface ParsedTarget {
+  sessionId: string;
+  requestId?: string;
+  opts: CtxOpts;
+  rest: string[];
+}
+
+function parseTarget(argv: string[], help: string): ParsedTarget | null {
+  const rest = [...argv];
+  let projectArg: string | undefined;
+  let hostArg: string | undefined;
+  try {
+    projectArg = takeFlagValue(rest, ['--project']);
+    hostArg = takeFlagValue(rest, ['--host']);
+  } catch (err) {
+    process.stderr.write(`${status.err((err as Error).message)}\n\n${help}`);
+    return null;
+  }
+  const positional = rest.filter((a) => !a.startsWith('-'));
+  if (!positional[0]) {
+    process.stderr.write(`${status.err('Pass a session id.')}\n\n${help}`);
+    return null;
+  }
+  return { sessionId: positional[0], requestId: positional[1], opts: { projectArg, hostArg }, rest };
+}
+
+async function pendingFor(resolved: ResolvedSession): Promise<{
+  permissions: OpencodePermissionRequest[];
+  questions: OpencodeQuestionRequest[];
+} | null> {
+  try {
+    const [permissions, questions] = await Promise.all([
+      resolved.oc.listPermissions(),
+      resolved.oc.listQuestions(),
+    ]);
+    return { permissions: permissions ?? [], questions: questions ?? [] };
+  } catch (err) {
+    surfaceApiError(err);
+    return null;
+  }
+}
+
+export async function runSessionsPending(argv: string[]): Promise<number> {
+  if (argv.includes('-h') || argv.includes('--help')) {
+    process.stdout.write(PENDING_HELP);
+    return 0;
+  }
+  const rest = [...argv];
+  const json = takeFlagBool(rest, ['--json']);
+  const target = parseTarget(rest, PENDING_HELP);
+  if (!target) return 2;
+
+  const resolved = await loadSessionForChat(target.sessionId, target.opts);
+  if (!resolved) return 1;
+  const pending = await pendingFor(resolved);
+  if (!pending) return 1;
+
+  if (json) {
+    emitJson(pending);
+    return 0;
+  }
+
+  const { permissions, questions } = pending;
+  if (permissions.length === 0 && questions.length === 0) {
+    process.stdout.write(`${C.dim}Nothing pending — the agent isn't blocked on you.${C.reset}\n`);
+    return 0;
+  }
+  if (permissions.length > 0) {
+    process.stdout.write(`\n  ${C.white}${C.bold}Permissions${C.reset}\n`);
+    for (const p of permissions) {
+      process.stdout.write(
+        `  ${C.cyan}${p.id}${C.reset}  ${C.bold}${p.permission}${C.reset}` +
+          `${p.patterns.length ? ` ${C.dim}${p.patterns.join(', ')}${C.reset}` : ''}\n` +
+          `    ${C.dim}approve: kortix sessions approve ${resolved.session.session_id} ${p.id}${C.reset}\n`,
+      );
+    }
+  }
+  if (questions.length > 0) {
+    process.stdout.write(`\n  ${C.white}${C.bold}Questions${C.reset}\n`);
+    for (const q of questions) {
+      for (const info of q.questions) {
+        process.stdout.write(`  ${C.cyan}${q.id}${C.reset}  ${info.question}\n`);
+        for (const o of info.options) {
+          process.stdout.write(
+            `    ${C.dim}- ${o.label}${o.hint ? ` (${o.hint})` : ''}${C.reset}\n`,
+          );
+        }
+      }
+      process.stdout.write(
+        `    ${C.dim}answer: kortix sessions answer ${resolved.session.session_id} ${q.id} --option "<label>"${C.reset}\n`,
+      );
+    }
+  }
+  process.stdout.write('\n');
+  return 0;
+}
+
+export async function runSessionsApprove(argv: string[]): Promise<number> {
+  if (argv.includes('-h') || argv.includes('--help')) {
+    process.stdout.write(APPROVE_HELP);
+    return 0;
+  }
+  const rest = [...argv];
+  const always = takeFlagBool(rest, ['--always']);
+  const reject = takeFlagBool(rest, ['--reject']);
+  let message: string | undefined;
+  try {
+    message = takeFlagValue(rest, ['--message', '-m']);
+  } catch (err) {
+    process.stderr.write(`${status.err((err as Error).message)}\n\n${APPROVE_HELP}`);
+    return 2;
+  }
+  if (always && reject) {
+    process.stderr.write(`${status.err('--always and --reject are mutually exclusive.')}\n`);
+    return 2;
+  }
+  const target = parseTarget(rest, APPROVE_HELP);
+  if (!target) return 2;
+
+  const resolved = await loadSessionForChat(target.sessionId, target.opts);
+  if (!resolved) return 1;
+
+  let requestId = target.requestId;
+  if (!requestId) {
+    const pending = await pendingFor(resolved);
+    if (!pending) return 1;
+    if (pending.permissions.length === 0) {
+      process.stderr.write(`${status.err('No pending permission on this session.')}\n`);
+      return 1;
+    }
+    if (pending.permissions.length > 1) {
+      const listing = pending.permissions.map((p) => `  ${p.id}  ${p.permission}`).join('\n');
+      process.stderr.write(
+        `${status.err('Several permissions are pending — pass a request id:')}\n${listing}\n`,
+      );
+      return 1;
+    }
+    requestId = pending.permissions[0].id;
+  }
+
+  const reply = reject ? 'reject' : always ? 'always' : 'once';
+  try {
+    await resolved.oc.replyPermission(requestId, reply, message);
+  } catch (err) {
+    return surfaceApiError(err);
+  }
+  process.stdout.write(
+    `${status.ok(`${reply === 'reject' ? 'Rejected' : 'Approved'} ${C.bold}${requestId}${C.reset}`)}` +
+      `${reply === 'always' ? ` ${C.dim}(and future matches this session)${C.reset}` : ''}\n`,
+  );
+  return 0;
+}
+
+export async function runSessionsAnswer(argv: string[]): Promise<number> {
+  if (argv.includes('-h') || argv.includes('--help')) {
+    process.stdout.write(ANSWER_HELP);
+    return 0;
+  }
+  const rest = [...argv];
+  const reject = takeFlagBool(rest, ['--reject']);
+  const options: string[] = [];
+  let text: string | undefined;
+  let answersJson: string | undefined;
+  try {
+    for (;;) {
+      const o = takeFlagValue(rest, ['--option', '-o']);
+      if (o === undefined) break;
+      options.push(o);
+    }
+    text = takeFlagValue(rest, ['--text']);
+    answersJson = takeFlagValue(rest, ['--answers']);
+  } catch (err) {
+    process.stderr.write(`${status.err((err as Error).message)}\n\n${ANSWER_HELP}`);
+    return 2;
+  }
+  const target = parseTarget(rest, ANSWER_HELP);
+  if (!target) return 2;
+  if (!reject && !answersJson && options.length === 0 && text === undefined) {
+    process.stderr.write(
+      `${status.err('Pass an answer: --option/--text (or --reject).')}\n\n${ANSWER_HELP}`,
+    );
+    return 2;
+  }
+
+  const resolved = await loadSessionForChat(target.sessionId, target.opts);
+  if (!resolved) return 1;
+
+  let request: OpencodeQuestionRequest | undefined;
+  if (target.requestId) {
+    const pending = await pendingFor(resolved);
+    if (!pending) return 1;
+    request = pending.questions.find((q) => q.id === target.requestId);
+    if (!request && !reject) {
+      process.stderr.write(`${status.err(`No pending question ${target.requestId}.`)}\n`);
+      return 1;
+    }
+  } else {
+    const pending = await pendingFor(resolved);
+    if (!pending) return 1;
+    if (pending.questions.length === 0) {
+      process.stderr.write(`${status.err('No pending question on this session.')}\n`);
+      return 1;
+    }
+    if (pending.questions.length > 1) {
+      const listing = pending.questions
+        .map((q) => `  ${q.id}  ${q.questions[0]?.header ?? ''}`)
+        .join('\n');
+      process.stderr.write(
+        `${status.err('Several questions are pending — pass a request id:')}\n${listing}\n`,
+      );
+      return 1;
+    }
+    request = pending.questions[0];
+  }
+  const requestId = target.requestId ?? request?.id;
+  if (!requestId) {
+    process.stderr.write(`${status.err('Could not resolve a question request id.')}\n`);
+    return 1;
+  }
+
+  try {
+    if (reject) {
+      await resolved.oc.rejectQuestion(requestId);
+      process.stdout.write(`${status.ok(`Dismissed ${C.bold}${requestId}${C.reset}`)}\n`);
+      return 0;
+    }
+    let answers: string[][];
+    if (answersJson) {
+      answers = JSON.parse(answersJson);
+    } else {
+      if (request && request.questions.length > 1) {
+        process.stderr.write(
+          `${status.err('This request carries several questions — pass --answers with a string[][] payload.')}\n`,
+        );
+        return 2;
+      }
+      // Map option labels to canonical values where the question defines them.
+      const info = request?.questions[0];
+      const mapped = options.map((o) => {
+        const match = info?.options.find(
+          (opt) => opt.label === o || opt.value === o,
+        );
+        return match?.value ?? match?.label ?? o;
+      });
+      answers = [[...mapped, ...(text !== undefined ? [text] : [])]];
+    }
+    await resolved.oc.replyQuestion(requestId, answers);
+  } catch (err) {
+    return surfaceApiError(err);
+  }
+  process.stdout.write(`${status.ok(`Answered ${C.bold}${requestId}${C.reset}`)}\n`);
+  return 0;
+}

--- a/apps/cli/src/commands/sessions-chat.ts
+++ b/apps/cli/src/commands/sessions-chat.ts
@@ -22,7 +22,7 @@ import { C, pad, status } from '../style.ts';
 
 type CtxOpts = { projectArg?: string; hostArg?: string };
 
-interface ResolvedSession {
+export interface ResolvedSession {
   /** Kortix session row. */
   session: ProjectSession;
   /** Auth used (so opencodeClient builds with the right base URL). */

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -8,6 +8,7 @@ import {
   takeFlagBool,
   takeFlagValue,
 } from '../command-helpers.ts';
+import { runSessionsAnswer, runSessionsApprove, runSessionsPending } from './sessions-approvals.ts';
 import { runSessionsChat, runSessionsLog, runSessionsStatus } from './sessions-chat.ts';
 import { runSessionsConnect } from './sessions-connect.ts';
 import { runSessionsDigest } from './sessions-digest.ts';
@@ -37,6 +38,14 @@ Subcommands:
                                     (read-only) — peek at what an agent is
                                     doing without sending it anything.
                                     --limit <N>, --json. Aliases: messages.
+  pending <session-id>              List open interactive prompts the agent
+                                    is blocked on: tool-permission asks +
+                                    questions. --json. Aliases: prompts.
+  approve <session-id> [<req-id>]   Answer a pending tool-permission ask.
+                                    --always, --reject, --message "<why>".
+  answer <session-id> [<req-id>]    Answer a pending question.
+                                    --option <value> (repeatable),
+                                    --text "<answer>", --reject.
   digest                            Compact review of recent sessions for
                                     reflection: metadata + compressed
                                     transcript snippets with tool outputs
@@ -86,6 +95,17 @@ export async function runSessions(argv: string[]): Promise<number> {
   // `digest` owns its own time-window + compaction flags.
   if (sub === 'digest' || sub === 'review' || sub === 'summary') {
     return runSessionsDigest(argv.slice(1));
+  }
+  // Interactive-prompt commands own their own flag parsing (repeatable
+  // --option, --message, positional request ids).
+  if (sub === 'pending' || sub === 'prompts') {
+    return runSessionsPending(argv.slice(1));
+  }
+  if (sub === 'approve') {
+    return runSessionsApprove(argv.slice(1));
+  }
+  if (sub === 'answer') {
+    return runSessionsAnswer(argv.slice(1));
   }
   const rest = argv.slice(1);
   const json = takeFlagBool(rest, ['--json']);


### PR DESCRIPTION
Re-opened #4299 (GitHub closed it when its stacked base branch `cli-bind` was deleted on merge of #4297; the branch is now rebased onto main — identical single commit).

The **#1 ranked agent blocker** from the parity audit (#4295): a CLI-driven session that pauses on a tool-permission ask or agent question was unanswerable from the CLI; the run just hung.

## New commands

- **`kortix sessions pending <session-id> [--json]`** — list open interactive prompts (permission asks + questions), each with the exact command to answer it.
- **`kortix sessions approve <session-id> [<request-id>] [--always | --reject] [--message]`** — reply to a tool-permission ask; bare form resolves the single pending request.
- **`kortix sessions answer <session-id> [<request-id>] [--option <v>]… [--text] [--reject] [--answers <json>]`** — answer an agent question; labels map to canonical values.

Same wire surface the dashboard uses (opencode `/permission` + `/question` via the `/v1/p/<sandbox>/4096` proxy). 9 new in-process e2e tests; suite was 159/159 + typecheck + biome clean pre-rebase (rebase had no conflicts; CI re-verifies).