### PR TITLE
fix(web): setup links render as clean CTA chips, never raw token URLs

### DIFF
--- a/apps/web/src/components/markdown/unified-markdown.tsx
+++ b/apps/web/src/components/markdown/unified-markdown.tsx
@@ -855,7 +855,10 @@ export const UnifiedMarkdown = React.memo<UnifiedMarkdownProps>(({
       const linkClassName = cn(
         "font-medium text-foreground",
         "underline decoration-foreground/30 underline-offset-[3px] decoration-[1px]",
-        "hover:decoration-foreground/60 transition-colors duration-150"
+        "hover:decoration-foreground/60 transition-colors duration-150",
+        // Bare-URL link text (autolinks, tokens) has no break opportunities —
+        // without this a long URL forces the whole message to scroll sideways.
+        "[overflow-wrap:anywhere]"
       );
 
       if (isHashLink) {
@@ -938,6 +941,14 @@ export const UnifiedMarkdown = React.memo<UnifiedMarkdownProps>(({
             </HighlightedCode>
           </CodeBlock>
         );
+      }
+
+      // Agents sometimes wrap a setup link in backticks instead of a markdown
+      // link — same interception as `a` above, so the human still gets the
+      // in-chat form chip instead of a wall of token characters.
+      const inlineSetupLink = parseSetupLinkHref(code.trim());
+      if (inlineSetupLink) {
+        return <SetupLinkButton kind={inlineSetupLink.kind} token={inlineSetupLink.token} />;
       }
 
       // Inline code - subtle pill style, clickable if it looks like a file path

--- a/apps/web/src/components/setup-links/setup-link-button.tsx
+++ b/apps/web/src/components/setup-links/setup-link-button.tsx
@@ -3,16 +3,27 @@
 import React, { useState } from 'react';
 import { KeyRound, Plug } from 'lucide-react';
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog';
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalDescription,
+  ModalHeader,
+  ModalTitle,
+} from '@/components/ui/modal';
 import { cn } from '@/lib/utils';
 import { SecretIntakeForm } from './secret-intake-form';
 import { ConnectorIntake } from './connector-intake';
-import type { SetupLinkKind } from './util';
+import { setupLinkChipLabel, type SetupLinkKind } from './util';
+
+function textOf(node: React.ReactNode): string {
+  if (node == null || typeof node === 'boolean') return '';
+  if (typeof node === 'string' || typeof node === 'number') return String(node);
+  if (Array.isArray(node)) return node.map(textOf).join('');
+  if (React.isValidElement(node)) {
+    return textOf((node.props as { children?: React.ReactNode }).children);
+  }
+  return '';
+}
 
 /**
  * In-chat renderer for an agent-minted setup link. Instead of navigating away,
@@ -30,7 +41,11 @@ export function SetupLinkButton({
 }) {
   const [open, setOpen] = useState(false);
   const Icon = kind === 'secret' ? KeyRound : Plug;
-  const fallbackLabel = kind === 'secret' ? 'Add secret' : 'Connect';
+  const label = setupLinkChipLabel(
+    textOf(children),
+    token,
+    kind === 'secret' ? 'Enter credentials' : 'Connect app',
+  );
 
   return (
     <>
@@ -38,34 +53,39 @@ export function SetupLinkButton({
         type="button"
         onClick={() => setOpen(true)}
         className={cn(
-          'inline-flex items-center gap-1.5 rounded-md border border-border bg-muted/40 px-2 py-0.5',
-          'align-baseline text-sm font-medium text-foreground',
-          'hover:bg-muted transition-colors duration-150',
+          'inline-flex max-w-full items-center gap-1.5 rounded-full border bg-popover py-1 pr-3 pl-2',
+          'align-middle text-sm font-medium text-foreground',
+          'hover:bg-muted active:scale-[0.96]',
+          'transition-[background-color,scale] duration-150',
         )}
       >
-        <Icon className="h-3.5 w-3.5 text-muted-foreground" />
-        {children || fallbackLabel}
+        <span className="bg-primary/[0.06] flex size-5 shrink-0 items-center justify-center rounded-full">
+          <Icon className="size-3 text-muted-foreground" />
+        </span>
+        <span className="truncate">{label}</span>
       </button>
 
-      <Dialog open={open} onOpenChange={setOpen}>
-        <DialogContent className="sm:max-w-md">
-          <DialogHeader>
-            <DialogTitle>
+      <Modal open={open} onOpenChange={setOpen}>
+        <ModalContent className="lg:max-w-md">
+          <ModalHeader>
+            <ModalTitle>
               {kind === 'secret' ? 'Add a project secret' : 'Connect an app'}
-            </DialogTitle>
-            <DialogDescription>
+            </ModalTitle>
+            <ModalDescription>
               {kind === 'secret'
                 ? 'Enter the value below. It’s encrypted and the agent never sees it.'
                 : 'Authorize the app in one click — no keys touch the chat or the repo.'}
-            </DialogDescription>
-          </DialogHeader>
-          {kind === 'secret' ? (
-            <SecretIntakeForm token={token} compact />
-          ) : (
-            <ConnectorIntake token={token} compact />
-          )}
-        </DialogContent>
-      </Dialog>
+            </ModalDescription>
+          </ModalHeader>
+          <ModalBody className="max-h-[60vh] overflow-y-auto">
+            {kind === 'secret' ? (
+              <SecretIntakeForm token={token} compact />
+            ) : (
+              <ConnectorIntake token={token} compact />
+            )}
+          </ModalBody>
+        </ModalContent>
+      </Modal>
     </>
   );
 }

--- a/apps/web/src/components/setup-links/util.test.ts
+++ b/apps/web/src/components/setup-links/util.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+
+import { parseSetupLinkHref, setupLinkChipLabel } from './util';
+
+const TOKEN = `ksl_${'A'.repeat(400)}`;
+
+function withWindowOrigin(origin: string) {
+  (globalThis as any).window = { location: { origin } };
+}
+
+afterEach(() => {
+  delete (globalThis as any).window;
+});
+
+describe('parseSetupLinkHref', () => {
+  test('parses a same-origin secret-intake URL', () => {
+    withWindowOrigin('https://kortix.com');
+    expect(parseSetupLinkHref(`https://kortix.com/secret-intake/${TOKEN}`)).toEqual({
+      kind: 'secret',
+      token: TOKEN,
+    });
+  });
+
+  test('parses a relative connect path', () => {
+    expect(parseSetupLinkHref(`/connect/${TOKEN}`)).toEqual({
+      kind: 'connector',
+      token: TOKEN,
+    });
+  });
+
+  test('cross-origin ksl_ links are still intercepted (FRONTEND_URL ≠ app origin)', () => {
+    withWindowOrigin('https://staging.kortix.com');
+    expect(parseSetupLinkHref(`https://kortix.com/secret-intake/${TOKEN}`)).toEqual({
+      kind: 'secret',
+      token: TOKEN,
+    });
+  });
+
+  test('cross-origin non-ksl paths stay plain links', () => {
+    withWindowOrigin('https://kortix.com');
+    expect(parseSetupLinkHref('https://example.com/connect/some-other-token')).toBeNull();
+  });
+
+  test('unrelated URLs are ignored', () => {
+    expect(parseSetupLinkHref('https://kortix.com/docs')).toBeNull();
+    expect(parseSetupLinkHref('/projects/p1')).toBeNull();
+    expect(parseSetupLinkHref(undefined)).toBeNull();
+  });
+});
+
+describe('setupLinkChipLabel', () => {
+  test('a raw URL as link text falls back to the friendly label', () => {
+    expect(
+      setupLinkChipLabel(`https://kortix.com/secret-intake/${TOKEN}`, TOKEN, 'Enter credentials'),
+    ).toBe('Enter credentials');
+  });
+
+  test('link text containing the token falls back', () => {
+    expect(setupLinkChipLabel(`secret-intake/${TOKEN}`, TOKEN, 'Enter credentials')).toBe(
+      'Enter credentials',
+    );
+  });
+
+  test('a long unbroken string falls back', () => {
+    expect(setupLinkChipLabel('x'.repeat(80), TOKEN, 'Connect app')).toBe('Connect app');
+  });
+
+  test('empty text falls back', () => {
+    expect(setupLinkChipLabel('  ', TOKEN, 'Connect app')).toBe('Connect app');
+  });
+
+  test('a human-authored label is kept', () => {
+    expect(setupLinkChipLabel('Enter your Slack credentials', TOKEN, 'Enter credentials')).toBe(
+      'Enter your Slack credentials',
+    );
+  });
+});

--- a/apps/web/src/components/setup-links/util.ts
+++ b/apps/web/src/components/setup-links/util.ts
@@ -18,10 +18,12 @@ export function parseSetupLinkHref(
 ): { kind: SetupLinkKind; token: string } | null {
   if (!href) return null;
   let pathname = href;
+  let sameOrigin = true;
   if (/^https?:\/\//i.test(href)) {
     try {
       const u = new URL(href);
-      if (typeof window !== 'undefined' && u.origin !== window.location.origin) return null;
+      sameOrigin =
+        typeof window === 'undefined' || u.origin === window.location.origin;
       pathname = u.pathname;
     } catch {
       return null;
@@ -29,5 +31,29 @@ export function parseSetupLinkHref(
   }
   const m = pathname.match(/^\/(secret-intake|connect)\/([^/?#]+)/);
   if (!m) return null;
-  return { kind: m[1] === 'secret-intake' ? 'secret' : 'connector', token: decodeURIComponent(m[2]) };
+  const token = decodeURIComponent(m[2]);
+  // Links are minted against FRONTEND_URL, which can differ from the origin the
+  // app is being viewed on (staging, preview deploys, self-host behind another
+  // domain). A cross-origin URL is still ours when it carries the `ksl_` wire
+  // prefix — the token is HMAC-verified server-side, so intercepting can never
+  // hand a foreign form our data. Anything else stays a plain link.
+  if (!sameOrigin && !token.startsWith('ksl_')) return null;
+  return { kind: m[1] === 'secret-intake' ? 'secret' : 'connector', token };
+}
+
+/**
+ * Agents usually emit the setup link as a bare URL, so the markdown link text
+ * IS the URL — a few hundred opaque token characters. That never belongs on
+ * the chip. Only keep the author's text when it reads like a human label.
+ */
+export function setupLinkChipLabel(raw: string, token: string, fallback: string): string {
+  const text = raw.trim();
+  if (!text) return fallback;
+  const looksLikeUrl =
+    /^https?:\/\//i.test(text) ||
+    text.includes(token) ||
+    text.includes('/secret-intake/') ||
+    text.includes('/connect/') ||
+    (text.length > 48 && !text.includes(' '));
+  return looksLikeUrl ? fallback : text;
 }


### PR DESCRIPTION
## Why

When an agent surfaces a secret-intake / connect link in chat, the link text is usually the bare URL — a few hundred opaque `ksl_…` token characters. The chat renderer put that whole string on the setup-link chip, producing a giant horizontally-overflowing pill (screenshot below from a real session). Related: cross-origin minted links (FRONTEND_URL ≠ viewing origin) escaped interception entirely and rendered as a monster underlined link.

| Before | After |
| --- | --- |
| chip label = full raw URL, overflows the message column | `🔑 Enter credentials` / `🔌 Connect app` pill; human-authored labels kept |

## What

- **`SetupLinkButton`**: label logic — keep the author's link text only when it reads like a human label; fall back to a friendly default when it's a URL, contains the token, or is a long unbroken string. Restyled as a pill chip (tinted icon dot, truncation, `active:scale-[0.96]`), and migrated the deprecated `Dialog` → `Modal` (width capped at `lg:` only, so the <1024px bottom-sheet keeps full width).
- **`parseSetupLinkHref`**: also intercept cross-origin links when the token carries the `ksl_` wire prefix — staging/preview/self-host origins differ from FRONTEND_URL; safe because the token is HMAC-verified server-side.
- **`unified-markdown`**: intercept backtick-wrapped setup links (agents sometimes emit them as inline code), and add `[overflow-wrap:anywhere]` to link text so any long bare URL wraps instead of forcing the message to scroll sideways.

## Verification

Rendered a preview page through `UnifiedMarkdown` with all four emission shapes (bold bare URL, labeled link, connect link, backtick-wrapped) plus a long plain URL — all render as chips / wrap correctly in light+dark; modal opens centered on desktop and as a full-width sheet on mobile widths.

- `util.test.ts`: 10 cases (same-origin/relative/cross-origin ksl/cross-origin foreign/unrelated URLs; label fallback matrix).
- Web `tsc --noEmit` clean (except the pre-existing `@/.source` fumadocs codegen artifact in fresh checkouts).

Pairs with #4302 (CLI one-click Slack connect) — together: the agent runs one command, the chat shows one clean chip.