### PR TITLE
feat(api): Subject identity foundation for Kortix-as-a-backend

### DIFF
--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -165,6 +165,18 @@ const envSchema = z.object({
   // behavior (absence of `[[agents]]` → unrestricted) untouched.
   KORTIX_REQUIRE_DECLARED_AGENTS: optBoolFalse,
 
+  // "Kortix as a backend" (verticalized wrappers / untrusted end-users). Platform
+  // default OFF. When a project runs in backend mode, its sessions are provisioned
+  // secret-less (no plaintext project secrets, no account-privileged PAT, capped LLM
+  // spend), and "no [[agents]] grant" flips from unrestricted to default-DENY. The
+  // subject-scoped session token (account_tokens.backend_scoped) is enforced to a
+  // single session regardless of this flag — the flag governs the RUNTIME hardening,
+  // not the token boundary. Like KORTIX_REQUIRE_DECLARED_AGENTS, this is intended to
+  // become a per-project setting (project.metadata.backend_mode); the platform flag
+  // is the global override for dogfood/testing.
+  // See docs/specs/2026-07-08-kortix-as-a-backend-subject-identity.md.
+  KORTIX_BACKEND_MODE: optBoolFalse,
+
   // ── Legacy migration — reaching legacy JustAVPS VMs + backup storage ──────
   // The new backend has no JustAVPS provider, but it must reach legacy VMs to
   // back them up. VMs are reachable via the CF proxy at {slug}.{proxy domain};

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -2,6 +2,8 @@ import { Context, Next } from 'hono';
 import { HTTPException } from 'hono/http-exception';
 import { validateSecretKey } from '../repositories/api-keys';
 import { validateAccountToken } from '../repositories/account-tokens';
+import type { AccountTokenValidationResult } from '../repositories/account-tokens';
+import { checkSessionScope } from '../subjects/session-scope';
 import { validateServiceAccountToken } from '../repositories/service-accounts';
 import { isKortixToken, isAccountToken, isServiceAccountToken } from '../shared/crypto';
 import { canAccessPreviewSandbox } from '../shared/preview-ownership';
@@ -183,6 +185,7 @@ export async function supabaseAuth(c: Context, next: Next) {
     if (result.projectId) {
       enforceTokenProjectScope(c, result.projectId);
     }
+    enforceBackendSessionScope(c, result);
     c.set('userId', result.userId);
     c.set('userEmail', '');
     c.set('authType', 'pat');
@@ -407,6 +410,7 @@ export async function combinedAuth(c: Context, next: Next) {
     if (patResult.projectId) {
       enforceTokenProjectScope(c, patResult.projectId);
     }
+    enforceBackendSessionScope(c, patResult);
     c.set('userId', patResult.userId);
     c.set('userEmail', '');
     c.set('authType', 'pat');
@@ -609,6 +613,25 @@ function extractPreviewSandboxId(path: string): string | null {
  *
  * Throws HTTPException(403) so the calling middleware aborts the chain.
  */
+/**
+ * Enforce the subject-scoped session boundary for "Kortix as a backend" tokens.
+ * No-op for every ordinary token (backend_scoped = false), so existing behavior is
+ * untouched. For a backend-scoped token, the request must target exactly the token's
+ * own session or it is refused — this is the boundary that makes a subject-scoped
+ * token safe to hand to an untrusted browser (see subjects/session-scope.ts).
+ */
+function enforceBackendSessionScope(c: Context, result: AccountTokenValidationResult): void {
+  if (!result.backendScoped) return;
+  const verdict = checkSessionScope({
+    backendScoped: true,
+    tokenSessionId: result.sessionId,
+    path: c.req.path,
+  });
+  if (!verdict.ok) {
+    throw new HTTPException(403, { message: verdict.reason ?? 'Subject-scoped token out of scope' });
+  }
+}
+
 function enforceTokenProjectScope(c: Context, tokenProjectId: string): void {
   const path = c.req.path;
 

--- a/apps/api/src/repositories/account-tokens.ts
+++ b/apps/api/src/repositories/account-tokens.ts
@@ -27,6 +27,12 @@ export interface AccountTokenValidationResult {
    *  authorization (which Kortix CLI/API actions + connectors it may use,
    *  already ∩ the launching user). Null = full access (laptop CLI PAT). */
   agentGrant?: AgentGrant | null;
+  /** Non-null = subject-scoped session token ("Kortix as a backend"): acts on
+   *  behalf of this external end-user (subjects.subject_id). */
+  subjectId?: string | null;
+  /** TRUE = interact-only token whose single-session boundary IS enforced by the
+   *  auth middleware (checkSessionScope). Default false = every ordinary token. */
+  backendScoped?: boolean;
   error?: string;
 }
 
@@ -48,6 +54,13 @@ export interface CreateAccountTokenParams {
    *  authorizes this session AS the SA (its own policies) ∩ agentGrant, not the
    *  launching user. Null = legacy (authorize as the user). */
   serviceAccountId?: string | null;
+  /** Set for subject-scoped session tokens — the external end-user this token acts
+   *  for (subjects.subject_id). Requires backendScoped. */
+  subjectId?: string | null;
+  /** TRUE = mint an interact-only, single-session-enforced token safe for an
+   *  untrusted browser. Callers must also pass the locked grant (lockedSubjectGrant)
+   *  and a sessionId. Default false. */
+  backendScoped?: boolean;
 }
 
 export interface CreateAccountTokenResult {
@@ -167,6 +180,8 @@ export async function createAccountToken(
       expiresAt: params.expiresAt ?? null,
       agentGrant: params.agentGrant ?? null,
       serviceAccountId: params.serviceAccountId ?? null,
+      subjectId: params.subjectId ?? null,
+      backendScoped: params.backendScoped ?? false,
     })
     .returning();
 
@@ -295,6 +310,8 @@ export async function validateAccountToken(
         lastUsedAt: accountTokens.lastUsedAt,
         createdAt: accountTokens.createdAt,
         agentGrant: accountTokens.agentGrant,
+        subjectId: accountTokens.subjectId,
+        backendScoped: accountTokens.backendScoped,
         patIdleRevokeDays: accounts.patIdleRevokeDays,
       })
       .from(accountTokens)
@@ -345,6 +362,8 @@ export async function validateAccountToken(
       projectId: row.projectId,
       sessionId: row.sessionId ?? null,
       agentGrant: row.agentGrant ?? null,
+      subjectId: row.subjectId ?? null,
+      backendScoped: row.backendScoped ?? false,
     };
   } catch (err) {
     console.error('Account token validation error:', err);

--- a/apps/api/src/subjects/mint.ts
+++ b/apps/api/src/subjects/mint.ts
@@ -1,0 +1,78 @@
+import { createAccountToken } from '../repositories/account-tokens';
+import { upsertSubject } from './repository';
+import { lockedSubjectGrant } from './session-scope';
+
+/**
+ * Mint a subject-scoped session token — the server-side operation an operator's BFF
+ * calls to get a credential it can safely hand to an untrusted end-user's browser.
+ *
+ * Composition (all parts individually tested / typed):
+ *   1. upsertSubject          — idempotently assert the external end-user.
+ *   2. lockedSubjectGrant     — interact-only grant (no secrets, no CLI, no connectors).
+ *   3. createAccountToken      — a real account_tokens row, backend_scoped + session-bound,
+ *                                short-lived; its single-session boundary is enforced by
+ *                                the auth middleware (checkSessionScope).
+ *
+ * The caller supplies an ALREADY-CREATED session id (the BFF ensures/creates the session
+ * with an operator credential first). Wiring an HTTP route + session provisioning on top of
+ * this — and the secret-less runtime for backend-mode sessions — is the next step tracked in
+ * docs/specs/2026-07-08-kortix-as-a-backend-subject-identity.md (§2 Item 2/3).
+ */
+export interface MintSubjectSessionTokenParams {
+  accountId: string;
+  projectId: string;
+  /** The operator/user id the token is attributed to for provenance (the launcher). */
+  userId: string;
+  /** The already-created session (sandbox) this token is bound to. */
+  sessionId: string;
+  /** The session's boot agent — carried through the locked grant for attribution. */
+  agent: string;
+  /** The operator's own id for this end-user (unique per project). */
+  externalRef: string;
+  displayName?: string | null;
+  /** Token lifetime in seconds. Keep short (minutes); the BFF re-mints on refresh. */
+  ttlSeconds?: number;
+}
+
+export interface MintSubjectSessionTokenResult {
+  subjectId: string;
+  sessionId: string;
+  /** Plaintext token — returned ONCE. Hand to the end-user's browser; never log it. */
+  token: string;
+  expiresAt: Date;
+}
+
+const DEFAULT_TTL_SECONDS = 15 * 60;
+
+export async function mintSubjectSessionToken(
+  params: MintSubjectSessionTokenParams,
+): Promise<MintSubjectSessionTokenResult> {
+  const subject = await upsertSubject({
+    accountId: params.accountId,
+    projectId: params.projectId,
+    externalRef: params.externalRef,
+    displayName: params.displayName ?? null,
+  });
+
+  const ttl = params.ttlSeconds ?? DEFAULT_TTL_SECONDS;
+  const expiresAt = new Date(Date.now() + ttl * 1000);
+
+  const created = await createAccountToken({
+    accountId: params.accountId,
+    userId: params.userId,
+    name: `subject:${subject.externalRef}:${params.sessionId}`,
+    projectId: params.projectId,
+    sessionId: params.sessionId,
+    agentGrant: lockedSubjectGrant(params.agent),
+    subjectId: subject.subjectId,
+    backendScoped: true,
+    expiresAt,
+  });
+
+  return {
+    subjectId: subject.subjectId,
+    sessionId: params.sessionId,
+    token: created.secretKey,
+    expiresAt,
+  };
+}

--- a/apps/api/src/subjects/repository.ts
+++ b/apps/api/src/subjects/repository.ts
@@ -1,0 +1,93 @@
+import { subjects } from '@kortix/db';
+import { and, eq } from 'drizzle-orm';
+import { db } from '../shared/db';
+
+/**
+ * Subjects — external end-user identities an operator asserts for "Kortix as a
+ * backend". See docs/specs/2026-07-08-kortix-as-a-backend-subject-identity.md and
+ * ./session-scope.ts for the token boundary these identities key.
+ */
+
+export interface Subject {
+  subjectId: string;
+  accountId: string;
+  projectId: string;
+  externalRef: string;
+  displayName: string | null;
+  disabledAt: Date | null;
+}
+
+export interface UpsertSubjectParams {
+  accountId: string;
+  projectId: string;
+  /** The operator's OWN id for this end-user. Unique per project. */
+  externalRef: string;
+  displayName?: string | null;
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Idempotently assert a subject. Keyed on (project_id, external_ref) so the operator
+ * can call this every time an end-user shows up without accumulating duplicates.
+ * Re-asserting clears any prior `disabled_at` (the operator vouches for them again)
+ * and refreshes the display name / metadata.
+ */
+export async function upsertSubject(params: UpsertSubjectParams): Promise<Subject> {
+  const [row] = await db
+    .insert(subjects)
+    .values({
+      accountId: params.accountId,
+      projectId: params.projectId,
+      externalRef: params.externalRef,
+      displayName: params.displayName ?? null,
+      metadata: params.metadata ?? {},
+    })
+    .onConflictDoUpdate({
+      target: [subjects.projectId, subjects.externalRef],
+      set: {
+        displayName: params.displayName ?? null,
+        metadata: params.metadata ?? {},
+        disabledAt: null,
+      },
+    })
+    .returning();
+
+  if (!row) throw new Error('Failed to upsert subject');
+  return toSubject(row);
+}
+
+/** Resolve a subject by the operator's external id within a project. */
+export async function getSubjectByExternalRef(
+  projectId: string,
+  externalRef: string,
+): Promise<Subject | null> {
+  const [row] = await db
+    .select()
+    .from(subjects)
+    .where(and(eq(subjects.projectId, projectId), eq(subjects.externalRef, externalRef)))
+    .limit(1);
+  return row ? toSubject(row) : null;
+}
+
+/**
+ * Disable a subject. Existing subject-scoped tokens are revoked separately (they
+ * CASCADE off the subject row only on hard delete); disabling is the soft, reversible
+ * offboarding signal an operator uses to stop minting new tokens for this end-user.
+ */
+export async function disableSubject(projectId: string, externalRef: string): Promise<void> {
+  await db
+    .update(subjects)
+    .set({ disabledAt: new Date() })
+    .where(and(eq(subjects.projectId, projectId), eq(subjects.externalRef, externalRef)));
+}
+
+function toSubject(row: typeof subjects.$inferSelect): Subject {
+  return {
+    subjectId: row.subjectId,
+    accountId: row.accountId,
+    projectId: row.projectId,
+    externalRef: row.externalRef,
+    displayName: row.displayName,
+    disabledAt: row.disabledAt,
+  };
+}

--- a/apps/api/src/subjects/session-scope.test.ts
+++ b/apps/api/src/subjects/session-scope.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  checkSessionScope,
+  isLockedSubjectGrant,
+  lockedSubjectGrant,
+  requestedSessionId,
+} from './session-scope';
+
+describe('lockedSubjectGrant', () => {
+  test('denies every capability', () => {
+    const g = lockedSubjectGrant('support');
+    expect(g).toEqual({ agent: 'support', kortixCli: [], connectors: [], env: [] });
+  });
+
+  test('isLockedSubjectGrant recognizes the locked shape', () => {
+    expect(isLockedSubjectGrant(lockedSubjectGrant('x'))).toBe(true);
+  });
+
+  test('isLockedSubjectGrant rejects null and permissive grants', () => {
+    expect(isLockedSubjectGrant(null)).toBe(false);
+    expect(isLockedSubjectGrant(undefined)).toBe(false);
+    expect(isLockedSubjectGrant({ agent: 'a', kortixCli: 'all', connectors: 'all' })).toBe(false);
+    // one axis open is not locked
+    expect(isLockedSubjectGrant({ agent: 'a', kortixCli: [], connectors: [], env: 'all' })).toBe(
+      false,
+    );
+    expect(
+      isLockedSubjectGrant({ agent: 'a', kortixCli: ['project.cr.open'], connectors: [], env: [] }),
+    ).toBe(false);
+  });
+});
+
+describe('requestedSessionId', () => {
+  test('extracts from the sessions route', () => {
+    expect(requestedSessionId('/v1/projects/proj-1/sessions/sess-abc/prompt')).toBe('sess-abc');
+    expect(requestedSessionId('/v1/projects/proj-1/sessions/sess-abc')).toBe('sess-abc');
+  });
+
+  test('extracts from the preview/runtime proxy route', () => {
+    expect(requestedSessionId('/v1/p/sandbox-xyz/3000/index.html')).toBe('sandbox-xyz');
+    expect(requestedSessionId('/v1/p/sandbox-xyz')).toBe('sandbox-xyz');
+  });
+
+  test('returns null for non-session-addressed paths', () => {
+    expect(requestedSessionId('/v1/projects/proj-1/secrets')).toBeNull();
+    expect(requestedSessionId('/v1/projects/proj-1')).toBeNull();
+    expect(requestedSessionId('/v1/accounts/me')).toBeNull();
+    expect(requestedSessionId('/v1/projects')).toBeNull();
+  });
+
+  test('decodes url-encoded segments', () => {
+    expect(requestedSessionId('/v1/projects/p/sessions/sess%2Dabc/x')).toBe('sess-abc');
+  });
+});
+
+describe('checkSessionScope', () => {
+  test('non-backend tokens are never gated (behavior unchanged)', () => {
+    // A normal session token on some other session, or an account route — all fine.
+    expect(
+      checkSessionScope({
+        backendScoped: false,
+        tokenSessionId: 'sess-a',
+        path: '/v1/projects/p/sessions/sess-b/prompt',
+      }).ok,
+    ).toBe(true);
+    expect(
+      checkSessionScope({ backendScoped: false, tokenSessionId: null, path: '/v1/accounts/me' }).ok,
+    ).toBe(true);
+  });
+
+  test('backend token may touch exactly its own session', () => {
+    expect(
+      checkSessionScope({
+        backendScoped: true,
+        tokenSessionId: 'sess-a',
+        path: '/v1/projects/p/sessions/sess-a/prompt',
+      }).ok,
+    ).toBe(true);
+    expect(
+      checkSessionScope({
+        backendScoped: true,
+        tokenSessionId: 'sess-a',
+        path: '/v1/p/sess-a/3000/',
+      }).ok,
+    ).toBe(true);
+  });
+
+  test('backend token is refused on a different session', () => {
+    const v = checkSessionScope({
+      backendScoped: true,
+      tokenSessionId: 'sess-a',
+      path: '/v1/projects/p/sessions/sess-b/prompt',
+    });
+    expect(v.ok).toBe(false);
+    expect(v.reason).toContain('different session');
+  });
+
+  test('backend token fails closed on non-session routes (secrets, account, lists)', () => {
+    for (const path of [
+      '/v1/projects/p/secrets',
+      '/v1/accounts/me',
+      '/v1/projects',
+      '/v1/projects/p',
+    ]) {
+      const v = checkSessionScope({ backendScoped: true, tokenSessionId: 'sess-a', path });
+      expect(v.ok).toBe(false);
+    }
+  });
+
+  test('malformed backend token (no bound session) is refused', () => {
+    const v = checkSessionScope({
+      backendScoped: true,
+      tokenSessionId: null,
+      path: '/v1/projects/p/sessions/sess-a/prompt',
+    });
+    expect(v.ok).toBe(false);
+    expect(v.reason).toContain('not bound to a session');
+  });
+});

--- a/apps/api/src/subjects/session-scope.ts
+++ b/apps/api/src/subjects/session-scope.ts
@@ -1,0 +1,103 @@
+import type { AgentGrant } from '@kortix/db';
+
+/**
+ * Subject identity — the security primitives for "Kortix as a backend".
+ *
+ * A SUBJECT is an opaque external end-user identity the operator asserts through
+ * their own credential (see docs/specs/2026-07-08-kortix-as-a-backend-subject-identity.md).
+ * A subject-scoped session token (`account_tokens.backend_scoped = true`,
+ * `subject_id` set) is the only credential safe to hand to an untrusted browser:
+ * it is bound to ONE session and MUST NOT reach any other session, any secret, or
+ * any account route.
+ *
+ * This module is intentionally free of Hono/DB imports so the boundary logic — the
+ * part where a mistake is a security hole — is pure and exhaustively unit-testable.
+ * The middleware calls `checkSessionScope` and throws on a violation.
+ */
+
+/**
+ * The locked, interact-only grant stamped onto a subject-scoped session token.
+ * It denies every capability an untrusted driver must never have:
+ *   - `kortixCli: []`  → no Kortix CLI/API actions (no CR open/merge, no reads of
+ *     other sessions, no member/connector management).
+ *   - `connectors: []` → cannot invoke any connector directly (the operator's BFF
+ *     brokers connector use server-side when it wants to expose it).
+ *   - `env: []`        → cannot receive or read ANY project secret.
+ *
+ * The effective grant is still intersected with the launching principal's role by
+ * the IAM engine, so this can only ever NARROW. The agent name is carried through
+ * purely so attribution/telemetry keeps working.
+ */
+export function lockedSubjectGrant(agent: string): AgentGrant {
+  return { agent, kortixCli: [], connectors: [], env: [] };
+}
+
+/** True when `grant` is the fully-locked interact-only shape (all denies). */
+export function isLockedSubjectGrant(grant: AgentGrant | null | undefined): boolean {
+  if (!grant) return false;
+  const empty = (v: string[] | 'all' | undefined) => Array.isArray(v) && v.length === 0;
+  return empty(grant.kortixCli) && empty(grant.connectors) && empty(grant.env);
+}
+
+/**
+ * Extract the session (sandbox) id a request is targeting, or null if the path is
+ * not session-addressed. Covers the two surfaces a subject-scoped token legitimately
+ * hits:
+ *   - `/v1/projects/<projectId>/sessions/<sessionId>/...`
+ *   - `/v1/p/<sandboxId>/...`   (the preview/runtime proxy — sandboxId === sessionId)
+ *
+ * A path with no session segment returns null; the caller decides whether a
+ * non-session-addressed path is allowed for a backend-scoped token (it is not —
+ * see `checkSessionScope`).
+ */
+export function requestedSessionId(path: string): string | null {
+  const sessions = path.match(/^\/v1\/projects\/[^/]+\/sessions\/([^/]+)/);
+  if (sessions?.[1]) return decodeURIComponent(sessions[1]);
+  const proxy = path.match(/^\/v1\/p\/([^/]+)/);
+  if (proxy?.[1]) return decodeURIComponent(proxy[1]);
+  return null;
+}
+
+export interface SessionScopeInput {
+  /** Is this a subject-scoped backend token? Non-backend tokens are never gated here. */
+  backendScoped: boolean;
+  /** The single session this token is bound to. */
+  tokenSessionId: string | null | undefined;
+  /** The request path (e.g. c.req.path). */
+  path: string;
+}
+
+export interface SessionScopeVerdict {
+  ok: boolean;
+  /** Present when `ok` is false — a safe, non-leaky reason for the 403. */
+  reason?: string;
+}
+
+/**
+ * The boundary. Returns `{ ok: true }` for any non-backend token (behavior is
+ * unchanged for every existing credential). For a backend-scoped token it allows
+ * the request ONLY when the path targets exactly the token's own session; every
+ * other surface — a different session, or any non-session-addressed route — is a
+ * violation.
+ *
+ * This deliberately fails closed: a backend token on a path with no session
+ * segment (an account route, a project-wide list, a secrets endpoint) is rejected,
+ * because a subject-scoped token has no business anywhere but its own session.
+ */
+export function checkSessionScope(input: SessionScopeInput): SessionScopeVerdict {
+  if (!input.backendScoped) return { ok: true };
+
+  // A backend-scoped token with no bound session is malformed — refuse.
+  if (!input.tokenSessionId) {
+    return { ok: false, reason: 'Subject-scoped token is not bound to a session' };
+  }
+
+  const target = requestedSessionId(input.path);
+  if (target === null) {
+    return { ok: false, reason: 'Subject-scoped token can only access its own session' };
+  }
+  if (target !== input.tokenSessionId) {
+    return { ok: false, reason: 'Subject-scoped token cannot access a different session' };
+  }
+  return { ok: true };
+}

--- a/docs/specs/2026-07-08-kortix-as-a-backend-subject-identity.md
+++ b/docs/specs/2026-07-08-kortix-as-a-backend-subject-identity.md
@@ -1,0 +1,357 @@
+# Kortix as a Backend — The Subject Identity Model
+
+**Status:** Proposal + foundation implementation — Marko + Fable, 2026-07-08. Items 1–4
+(Subject principal, subject-scoped session token, secret-less runtime, executor-grant
+default) land as an **additive, feature-flagged** foundation PR — default behavior is
+unchanged; the enforcing flags stay **off** until security review. Items 5–17 are the
+persisted backlog (§6). This doc is the durable source of truth for the whole
+"Kortix as a backend / verticalized wrapper" thread.
+
+**Depends on:** `docs/specs/2026-06-28-token-session-agent-identity.md` (the token
+contract this extends), `docs/specs/2026-07-05-agent-first-config-unification.md`
+(agent-first, Phase 4 git boundary), `docs/AUTHZ_MODEL_FINAL_PLAN.md` (§5b secret-less
+runtime, §7b git-optional/CMS mode).
+
+**Companion artifacts (visual):** the Trust-Boundary thesis and the Two-Plane
+consumption map produced alongside this doc.
+
+---
+
+## 0. The one-sentence thesis
+
+**Kortix's entire security model assumes the person driving the agent is a trusted
+insider. Wrapping Kortix as a backend inverts exactly that assumption — and every
+concern in this document is a consequence of that single inversion.**
+
+The fix is one new principal — the **Subject**: an opaque external end-user identity the
+operator asserts through their own API key. Kortix never authenticates the Subject; it
+trusts the operator's assertion and issues a token *scoped to that Subject*. Every
+capability the "backend" use case needs (per-end-user isolation, per-user credentials,
+per-user budgets/model caps, protected agent IP, safe browser tokens) becomes a property
+of the Subject. **The verticalized-wrapper question and the untrusted-driver question are
+the same body of work.**
+
+---
+
+## 1. Two framings, one boundary
+
+### 1a. Trust boundary (untrusted driver)
+Today the sandbox sits **inside** the trust boundary: it holds plaintext secrets, the
+full git history, a reusable model OAuth credential, and a real account-privileged PAT.
+That is correct when the driver is a trusted teammate. When an untrusted end-user drives
+the agent, the sandbox is effectively controlled by the adversary, so the boundary must
+move: **the sandbox becomes an untrusted zone**, and everything sensitive retreats behind
+a server-side proxy the driver's privilege cannot cross.
+
+### 1b. Two planes (verticalized wrapper)
+Every Kortix primitive lives in a **control plane** (operator configures once — git
+authored, editor/manager role) or a **runtime plane** (end-user touches every session —
+floor `member` role). The line between them is drawn by one permission,
+`project.customize.write`. A verticalized wrapper serves only the runtime plane and keeps
+100% of the control plane private. **This mostly works today** (see §3) — the built-in
+`member` role already is a "run the agent, can't build it" role. The Subject work closes
+the three places the plane leaks.
+
+Both framings converge on the same primitive. §2 is the design.
+
+---
+
+## 2. The design — items 1–4
+
+### Item 1 — Subject principal
+
+A **Subject** is an external identity namespaced to a project (or account), asserted by
+the operator. It is *not* a Kortix login, not a Supabase auth user, and never a
+`project_members` row.
+
+- New table `subjects`: `(subject_id uuid pk, account_id, project_id, external_ref text,
+  display_name, metadata jsonb, created_at, disabled_at)`. `external_ref` is the
+  operator's own end-user id (unique per project). No FK to `auth.users`.
+- Subjects are created/asserted programmatically by an **operator credential** (a
+  `kortix_pat_` acting as the operator, or a service account with the right grant).
+  Idempotent upsert on `(project_id, external_ref)`.
+- A Subject carries **no ambient authority**. It only becomes meaningful when a
+  subject-scoped session token is minted for it (Item 2). This keeps the Subject a pure
+  identity, not a role — authorization stays in IAM + the token grant.
+
+*Why a new principal and not a `project_members` row:* members require a real Supabase
+auth user (email invite / `lookupUserIdByEmail`), cannot be bulk-minted (even SCIM only
+creates pending invites), and every member in a shared project can see every other
+member's sessions (floor `member` has `project.session.read`). Subjects are cheap,
+headless, and isolatable.
+
+### Item 2 — Subject-scoped session token
+
+Today's session executor token (`docs/specs/2026-06-28-token-session-agent-identity.md`)
+is a real account PAT that acts **as the launching user**, carries `project_id`,
+`session_id`, `agent_grant`, and — critically — `session_id` is **metadata, never an
+access boundary** (`enforceTokenProjectScope`, `apps/api/src/middleware/auth.ts:612-658`,
+gates project only). We add a **subject-scoped** variant:
+
+- Same `account_tokens` row shape, plus a new `subject_id` column and a
+  `backend_scoped boolean` flag.
+- When `backend_scoped = true`, the token:
+  - is bound to **exactly one `session_id`** and that binding **is enforced** — any
+    request whose `:sessionId` (path or body) differs from the token's is `403`. This is
+    the missing boundary; it is the whole point.
+  - carries an **interact-only** grant: may prompt/stream/answer-permission on its one
+    session; may **not** read secrets, open/merge change requests, read other sessions,
+    or reach any account route. Implemented as a locked `agent_grant`
+    (`kortixCli: []`, `secrets: []`) plus a hard route allowlist independent of role.
+  - has a **short TTL** (minutes), refreshable only by the operator's BFF (which holds
+    the operator credential), never by the browser.
+- Minting endpoint: `POST /v1/projects/:projectId/subjects/:externalRef/session-token`
+  — operator credential in, `{ session_id, token, expires_at }` out. The operator's BFF
+  creates/ensures the session, mints the subject-scoped token, hands *only that* to the
+  end-user's browser.
+
+This is the token a third party may safely put in an untrusted browser. It replaces the
+current unsafe options: (a) hand over the operator's full JWT/PAT, or (b) the fixed-shape
+`kps_` public share (read-only, single-resource, no interactivity).
+
+### Item 3 — Secret-less runtime (backend mode)
+
+A per-project **backend mode** flag (`projects.metadata.backend_mode` /
+`KORTIX_BACKEND_MODE` platform default off). When a session is provisioned in backend
+mode:
+
+- **No plaintext project secrets** are injected into the sandbox env. Today
+  `listProjectSecretsSnapshotForUser` decrypts every `runtime` secret into
+  `agent-env.sh` (`apps/kortix-sandbox-agent-server/src/agent-env-file.ts:142-159`),
+  readable by the agent's `bash` tool. In backend mode this snapshot is empty; secrets
+  are resolved **server-side per call** only (the connector/executor path already does
+  this correctly — extend the same discipline to any secret the agent needs).
+- **No account-privileged PAT** in the sandbox. Today the LLM key *is* the executor token
+  *is* a real account PAT valid on the general API
+  (`apps/api/src/platform/services/session-sandbox.ts:322-360`). In backend mode the
+  sandbox holds only the subject-scoped, interact-only token (Item 2) and the LLM proxy
+  token, both budget-capped.
+- **No reusable model OAuth on disk** (`CODEX_AUTH_JSON`,
+  `apps/kortix-sandbox-agent-server/src/opencode.ts:487-511`).
+- **Scoped clone** (overlaps Item 7): no full history; exclude `.kortix/` agent+skill IP.
+- **Capped LLM spend**: backend-mode sessions get a default block-budget so an end-user
+  can't drain the operator's wallet (today spend is uncapped absent an explicit
+  `gateway_budgets` block, `apps/api/src/llm-gateway/hooks.ts:139-172`).
+
+Aligns with `AUTHZ_MODEL_FINAL_PLAN.md` §5b ("stop injecting project runtime secrets at
+boot; resolve per-call server-side; the sandbox holds exactly one opaque agent-scoped
+token and no raw credentials").
+
+### Item 4 — Fix the default executor grant
+
+Today, a project that has **not** adopted `[[agents]]` resolves the session grant to
+`null` = **unrestricted** (capped only by the launching human's role):
+`grantFromLoadedAgents` / `agentMayUseEnv` treat "no grant" as "no restriction"
+(`apps/api/src/iam/agent-scope.ts:62-71`, `apps/api/src/projects/agents.ts:280-335`). For
+a backend-mode project this is unacceptable — the session can read all secrets, open/merge
+CRs, and reach the launcher's other sessions.
+
+- In **backend mode**, "no grant" flips to **default-deny** (least privilege): the
+  subject-scoped token gets an explicit minimal grant, never the ambient `null`.
+- Outside backend mode, behavior is **unchanged** (the `default` sentinel stays
+  non-binding per the token-identity spec) — this is the back-compat contract we must not
+  break.
+
+---
+
+## 3. Current-state facts (verified by code audit, file:line)
+
+### What breaks under an untrusted driver
+- **Full clone forced every session**, incl. reachable history — a deleted-then-recommitted
+  secret is recoverable via `git show`. `apps/api/src/projects/lib/sessions.ts:302-310`
+  (`KORTIX_CLONE_FILTER=''`).
+- **Plaintext secrets in sandbox env**, readable by the agent's `bash`. Provider keys are
+  only withheld from the opencode *process*, not the container.
+  `apps/kortix-sandbox-agent-server/src/agent-env-file.ts:142-159`,
+  `.../opencode.ts:628-646`.
+- **Reusable model OAuth on disk.** `.../opencode.ts:487-511` (`CODEX_AUTH_JSON`).
+- **LLM key = executor token = account PAT**, valid on general API, uncapped spend.
+  `apps/api/src/platform/services/session-sandbox.ts:322-360`,
+  `apps/api/src/llm-gateway/hooks.ts:139-172`.
+- **`session_id` is not an access boundary.** `apps/api/src/middleware/auth.ts:612-658`
+  (project scope only).
+- **Default executor grant is unrestricted.** `apps/api/src/iam/agent-scope.ts:62-71`,
+  `apps/api/src/projects/agents.ts:280-335`.
+- **Git-proxy `_scope` is unused** → session clones whole repo regardless of resource
+  grants. `apps/api/src/projects/lib/git.ts:582-611`; acknowledged
+  `docs/AUTHZ_MODEL_FINAL_PLAN.md:36-43`.
+
+### Connector/profile corollary
+- Every connector resolves **one shared project credential** —
+  `resolveCredential(connector, null)` is hard-coded.
+  `apps/api/src/executor/gateway.ts:300`. Per-end-user switching is *impossible* today.
+- `per_user` mode was deliberately removed 2026-07-05 (correct reasoning: leaked launcher
+  identity, no answer for triggers). The redesign ("connect your own account", interactive
+  only) is parked in `2026-07-05-agent-first-config-unification.md` §2.5.
+- Pipedream's `external_user_id` already computes `projectId:slug:userId`
+  (`apps/api/src/executor/pipedream.ts:49-59`) — subject-ready; every write path just
+  passes `null`.
+
+### Tenancy / billing
+- Billing is **one fungible per-account wallet** (`credit_accounts` keyed by `accountId`).
+  No native per-project/per-user sub-wallet.
+- **No external end-user identity exists anywhere** — every principal traces to a real
+  Supabase auth user; even SCIM can't bulk-mint logins.
+- Metering *is* reconstructable: `usage_events` / `gateway_request_logs` carry
+  `accountId`, `projectId`, `sessionId`, `actorUserId`; `gateway.budgets()` returns a
+  per-`actorUserId` breakdown — but only differentiates end-users if each is a distinct
+  Kortix principal.
+- Ceilings that bite at scale: concurrent sessions capped per-account (enterprise 5000,
+  paid 200), `MAX_PROJECTS_PER_ACCOUNT=200`, `GET /v1/projects` unpaginated.
+
+### What already works for a vertical (the good news)
+- **Floor `member` role IS the end-user role.** `session.start/stop/read` +
+  read-only + `review.submit` + `trigger.fire`, and **sees zero Customize sections**
+  (all gated on `project.customize.write`, editor-tier).
+  `apps/api/src/iam/role-perms.ts:137-178`; customize gate
+  `apps/web/src/lib/project-actions.ts:161-167`.
+- **One locked agent, enforced at the door.** New projects stamped
+  `require_declared_agents: true` at provision (`apps/api/src/projects/routes/r1.ts:454`);
+  a one-agent manifest makes any other `agent_name` a hard `400 AGENT_NOT_DECLARED`.
+- **Config-as-git is the operator moat** — agents/skills/connectors/triggers/policies/
+  sandbox spec all git-authored; end-users never author config.
+- **Skills grants have runtime teeth** — compile to an allow/deny `permission.skill` tree,
+  deny-by-default in v2. `apps/api/src/projects/lib/compile-agent-config.ts:293-371`.
+- **SDK covers almost the whole control plane** — connectors, secrets, triggers, channels,
+  CRs, review, sandbox, apps, gateway, billing, access, marketplace all have facades.
+
+### Expressiveness verdicts (IAM)
+- (a) Silo end-users in a **shared** project — **not expressible** (floor `member` has
+  `session.read`; no per-session-owner grant). → native isolation is **project-per-end-user**.
+- (b) Pre-built agent, invoke-not-edit — **expressible** (`agent.write` is editor-tier).
+- (c) Operator-only secrets/config — **expressible** (floor `member` excludes
+  `secret.read`/`connector.write`/`customize.write`).
+- (d) Custom "vertical-end-user" role below the `member` floor — **expressible only if the
+  principal has no `project_members`/group row** (IAM is allow-only union; a built-in role
+  can't be subtracted).
+- (e) ASK/approval on specific tool calls — **expressible** via System B (`[[policies]]`
+  in `kortix.toml`, enforced in the executor gateway), *not* the IAM `iam_policies` table.
+
+---
+
+## 4. Feature-by-feature consumption map (the vertical's cheat-sheet)
+
+| Primitive | Mode | Config | SDK | Locked by floor role |
+|---|---|---|---|---|
+| Agent identity/persona | Pre-configure | `kortix.yaml` + `agents/*.md` (git) | partial (scope-narrow only) | yes (`agent.write`=editor) |
+| Skills | Pre-configure | `.kortix/opencode/skills/` (git) | list-only (CRUD web-local) | yes |
+| Secrets | Pre-configure & hide | names git · values DB | full | yes (member can't read values) |
+| Connectors | Pre-configure + remap creds | `[[connectors]]` git + DB | full CRUD | yes |
+| Triggers | Pre-configure / expose fire | `[[triggers]]` git | full | split (read+fire; create=editor) |
+| Channels | Hide / bypass | DB (v2) | full | yes |
+| Memory | Runtime write | `.kortix/memory/*.md` git | file I/O | merge-gated (CR) |
+| Change Requests / Review | Expose submit / hide merge | DB + git | full | split (submit; act/merge=editor) |
+| Sessions / Sandbox | Expose (the product) | DB · spec git | full | open by design |
+| Apps / Deploys | Hide / bypass | `[[apps]]` git | full | yes (deploy=editor) |
+| Models | Default (can't hard-pin) | agent `.md` git | budgets/keys | not IAM-gated (explicit wins) |
+| Approval policy | Pre-configure + runtime prompt | `[[policies]]` git | full | split |
+| Billing / credits | Hide · operator re-bills | account DB | read + curated | account-scoped |
+| Marketplace | Hide / bypass | catalog ext · install git | full | yes (install=editor) |
+| Projects & IAM | Operator-only + remap identity | DB | project yes · account no | the lock itself |
+
+---
+
+## 5. Sequencing
+
+- **P0 (this PR, feature-flagged):** Item 1 Subject principal · Item 2 subject-scoped
+  session token (session_id boundary) · Item 3 secret-less runtime · Item 4 default-deny
+  grant in backend mode. Additive; flags default off.
+- **P1:** Item 5 per-subject credential resolution (un-null the resolver) · Item 6
+  per-subject budget/model caps · Item 7 scoped clone + git boundary · Item 8 model pin ·
+  Item 9 default LLM cap.
+- **P2:** Item 10 account-scoped IAM in SDK · Item 11 skills CRUD + web-local ports ·
+  Item 12 git-optional/CMS mode · Item 13 per-subject metering API · Item 14 per-turn
+  token re-mint → re-enable agent lock.
+- **Ship-now (no platform change):** Item 15 vanilla-TS BFF reference app · Item 16
+  "Kortix as a backend" hardening guide · Item 17 replace whitelabel-demo stubs.
+
+---
+
+## 6. The full backlog (items 5–17) — persisted with evidence
+
+**P1 — platform-only, can't be engineered around by the customer**
+
+5. **Per-subject credential resolution.** Un-hardcode
+   `resolveCredential(connector, null)` (`apps/api/src/executor/gateway.ts:300`) to key on
+   `subjectId`. Revive "connect your own account" (interactive-only) from
+   `2026-07-05-agent-first-config-unification.md` §2.5. Pipedream already supports
+   `projectId:slug:subjectId` (`apps/api/src/executor/pipedream.ts:49-59`).
+6. **Per-subject budget + model entitlement caps.** Extend `gateway_budgets` (already has
+   a `member` scope keyed by subject-ish `subjectUserId`) to a `subject` scope; cap spend,
+   concurrency, and which models a subject may pick.
+7. **Scoped clone + git boundary.** Honor the unused `_scope` in `authorizeGitProxy`
+   (`apps/api/src/projects/lib/git.ts:582-611`); sparse-checkout to exclude `.kortix/`
+   agent+skill IP; blobless/no-history so deleted secrets aren't recoverable. This is
+   agent-first **Phase 4**, currently OPEN.
+8. **Model pin that survives explicit override.** Today explicit
+   `opencode_model`/per-message model always beats `agent.model`
+   (`apps/kortix-sandbox-agent-server/src/__tests__/resolve-opencode-model.test.ts`); only
+   tier/entitlement gates it, never agent identity. Add an agent/subject-level hard pin.
+9. **Default LLM spend cap.** Backend-mode sessions (and ideally all sessions) get a
+   default block-budget; today spend is unbounded absent an explicit block
+   (`apps/api/src/llm-gateway/hooks.ts:139-172`, `.../budgets.ts:25-52`).
+
+**P2 — completeness / DX for a clean "backend" story**
+
+10. **Account-scoped IAM in the SDK.** Custom roles, policy bindings, groups, service
+    accounts, SCIM, SSO are REST-only under `/v1/accounts/:id/iam/*`; the dashboard calls
+    them via `apps/web/src/lib/iam-client.ts`, `@kortix/sdk` has no wrapper
+    (`packages/sdk/API-MAP.md:229-237`). A backend wrapper shouldn't reverse-engineer
+    dashboard calls.
+11. **Skills CRUD + remaining web-local ports.** Skills create/update/delete is web-local
+    (`packages/sdk/API-MAP.md:90`); also executor runtime connector calls, Review Center
+    hooks, connector OAuth flows.
+12. **Git-optional / CMS mode.** Make `repo_url`/`branch`/`manifest_path` optional; move
+    GitHub-specifics out of SDK core; project config can come from git **or** the API.
+    `AUTHZ_MODEL_FINAL_PLAN.md` §7b ("what unlocks wrapping Kortix as a generic backend").
+13. **Per-subject metering read API.** `usage-history` has no actor filter
+    (`apps/api/src/billing/routes/credits.ts:188-206`); add a usage-by-subject endpoint so
+    a wrapper can re-bill cleanly without inviting one real member per end-user.
+14. **Per-turn token re-mint → re-enable agent lock.** The correct model behind
+    `KORTIX_ENFORCE_SESSION_AGENT_LOCK` (off today); already written up in
+    `docs/specs/2026-06-28-agent-defaults-todo.md`.
+
+**Ship-now — customer best-practice, we enable + document**
+
+15. **Vanilla-TS BFF reference app** (DeepAI shape, no React): project-per-end-user,
+    one declared agent, floor-`member` PATs, model picker omitted, tools hitting the
+    operator's proxy. A twin of `apps/whitelabel-demo` wrapper mode without the React/Next
+    coupling — the SDK core is mechanically framework-agnostic
+    (`packages/sdk/src/index.isomorphic.test.ts`), and `@kortix/sdk/server`'s
+    `createScopedKortix` (AsyncLocalStorage) is purpose-built for a multi-end-user BFF.
+16. **"Kortix as a backend" hardening guide.** Codify the best-practices: agent isolation,
+    own-proxy egress for tools, authorization-rule patterns, and the explicit list of what
+    must never reach the sandbox. Highest-leverage near-term deliverable for DeepAI.
+17. **Replace `whitelabel-demo` stubs** (file-based user store, hand-rolled proxy policy)
+    with the real primitives as P0/P1 land.
+
+---
+
+## 7. The hard ceiling until P0 lands
+
+Until Items 2–3 ship, one rule holds for any untrusted-end-user deployment: **the
+end-user may never hold a Kortix token, and never drive the agent's shell/tools directly.**
+Everything routes through the operator's BFF — the end-user sends prompts and sees
+sanitized transcript output; the BFF holds the only credential. The moment an untrusted
+end-user reaches anything inside the sandbox, they hold the operator's PAT, secrets, and
+reusable OAuth creds. That is the current architecture working exactly as designed for a
+*different* threat model.
+
+---
+
+## 8. Open questions
+
+1. **Subject scope: project vs account.** Namespacing to project is the clean isolation
+   default (project-per-end-user). Is there a real need for account-level subjects that
+   span projects?
+2. **Session reuse per subject.** One long-lived session per subject vs a fresh session
+   per interaction — affects concurrency-cap math (per-account 5000 ceiling) and warm-pool
+   economics.
+3. **Metering attribution.** Do we bless `subject_id` as a first-class column on
+   `usage_events`/`gateway_request_logs`, or keep reconstructing via `sessionId`↔subject
+   in the operator's BFF?
+4. **Interaction with the pluggable-runtime-harness work** (`2026-07-08-...`) — backend
+   mode's secret-less runtime should compose with, not fork, whatever runtime abstraction
+   that spec introduces.
+5. **Billing model.** Per-account wallet stays; the operator re-bills. Do we ever want a
+   native per-subject sub-wallet, or is BFF-side metering the permanent answer?

--- a/packages/db/migrations/20260708120000000_subject-identity.sql
+++ b/packages/db/migrations/20260708120000000_subject-identity.sql
@@ -1,0 +1,45 @@
+-- Up Migration
+--
+-- Subject identity for "Kortix as a backend" (verticalized wrappers / untrusted
+-- end-users). See docs/specs/2026-07-08-kortix-as-a-backend-subject-identity.md.
+--
+-- Additive and inert by default: the new columns default to NULL / FALSE, so every
+-- existing token and code path is unchanged until backend mode is explicitly used.
+--
+--   subjects                     — external end-user identities an operator asserts
+--   account_tokens.subject_id    — which subject a session token acts for
+--   account_tokens.backend_scoped— TRUE = interact-only, single-session-enforced token
+
+CREATE TABLE IF NOT EXISTS "kortix"."subjects" (
+  "subject_id"   uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  "account_id"   uuid NOT NULL REFERENCES "kortix"."accounts"("account_id") ON DELETE CASCADE,
+  "project_id"   uuid NOT NULL REFERENCES "kortix"."projects"("project_id") ON DELETE CASCADE,
+  "external_ref" varchar(255) NOT NULL,
+  "display_name" varchar(255),
+  "metadata"     jsonb DEFAULT '{}'::jsonb,
+  "created_at"   timestamptz NOT NULL DEFAULT now(),
+  "disabled_at"  timestamptz
+);
+--> statement-breakpoint
+
+-- One subject per (project, operator's external id) — lets the operator upsert
+-- idempotently by their own end-user id.
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_subjects_project_external_ref"
+  ON "kortix"."subjects" ("project_id", "external_ref");
+--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "idx_subjects_account"
+  ON "kortix"."subjects" ("account_id");
+--> statement-breakpoint
+
+ALTER TABLE "kortix"."account_tokens"
+  ADD COLUMN IF NOT EXISTS "subject_id" uuid
+    REFERENCES "kortix"."subjects"("subject_id") ON DELETE CASCADE;
+--> statement-breakpoint
+
+ALTER TABLE "kortix"."account_tokens"
+  ADD COLUMN IF NOT EXISTS "backend_scoped" boolean NOT NULL DEFAULT false;
+--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "idx_account_tokens_subject"
+  ON "kortix"."account_tokens" ("subject_id");

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -72,6 +72,7 @@ export {
   deployments,
   kortixApiKeys,
   accountTokens,
+  subjects,
   workerLeaderLease,
   // Relations
   projectsRelations,

--- a/packages/db/src/schema/kortix.ts
+++ b/packages/db/src/schema/kortix.ts
@@ -1494,6 +1494,19 @@ export const accountTokens = kortixSchema.table(
     serviceAccountId: uuid('service_account_id').references(() => serviceAccounts.serviceAccountId, {
       onDelete: 'cascade',
     }),
+    /** The external end-user (SUBJECT) this session token acts on behalf of, for
+     *  "Kortix as a backend" wrappers. NULL for every ordinary token. Set only on
+     *  subject-scoped session tokens minted by an operator credential. Identity
+     *  only — authorization stays in agentGrant + IAM.
+     *  See docs/specs/2026-07-08-kortix-as-a-backend-subject-identity.md. */
+    subjectId: uuid('subject_id').references(() => subjects.subjectId, {
+      onDelete: 'cascade',
+    }),
+    /** TRUE = a subject-scoped token safe to hand to an untrusted browser: bound to
+     *  exactly one session (the boundary IS enforced — unlike ordinary tokens where
+     *  session_id is mere attribution), carrying the locked interact-only grant.
+     *  Default FALSE preserves every existing token's behavior. */
+    backendScoped: boolean('backend_scoped').default(false).notNull(),
   },
   (table) => [
     uniqueIndex('idx_account_tokens_public_key').on(table.publicKey),
@@ -1501,6 +1514,40 @@ export const accountTokens = kortixSchema.table(
     index('idx_account_tokens_account').on(table.accountId),
     index('idx_account_tokens_user').on(table.userId),
     index('idx_account_tokens_project').on(table.projectId),
+    index('idx_account_tokens_subject').on(table.subjectId),
+  ],
+);
+
+// ─── Subjects (external end-user identities for "Kortix as a backend") ─────────
+//
+// A SUBJECT is an opaque external end-user a wrapper (e.g. a verticalized AI app)
+// asserts through its operator credential. It is NOT a Kortix login, NOT a Supabase
+// auth user, and never a project_members row — that is the whole point: subjects are
+// cheap, headless, and isolatable, where real members require an email invite and can
+// see each other's sessions. A subject carries no ambient authority; it only becomes
+// meaningful through a subject-scoped session token (account_tokens.backend_scoped).
+// See docs/specs/2026-07-08-kortix-as-a-backend-subject-identity.md.
+export const subjects = kortixSchema.table(
+  'subjects',
+  {
+    subjectId: uuid('subject_id').defaultRandom().primaryKey(),
+    accountId: uuid('account_id')
+      .notNull()
+      .references(() => accounts.accountId, { onDelete: 'cascade' }),
+    projectId: uuid('project_id')
+      .notNull()
+      .references(() => projects.projectId, { onDelete: 'cascade' }),
+    /** The operator's OWN end-user id (their primary key for this person). Unique
+     *  per project so an operator can idempotently upsert-by-external-ref. */
+    externalRef: varchar('external_ref', { length: 255 }).notNull(),
+    displayName: varchar('display_name', { length: 255 }),
+    metadata: jsonb('metadata').default({}).$type<Record<string, unknown>>(),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+    disabledAt: timestamp('disabled_at', { withTimezone: true }),
+  },
+  (table) => [
+    uniqueIndex('idx_subjects_project_external_ref').on(table.projectId, table.externalRef),
+    index('idx_subjects_account').on(table.accountId),
   ],
 );
 


### PR DESCRIPTION
## What & why

Foundation for **"Kortix as a backend"** — wrapping Kortix so a third party or a verticalized AI app can build their own product on top, with their own untrusted end-users driving agents.

The whole thread reduces to one insight: **Kortix's security model assumes the agent's driver is a trusted insider; the backend use case inverts that.** The fix is one new principal — the **Subject** (an opaque external end-user the operator asserts) — and a session token scoped to it that is safe to hand to an untrusted browser.

Full design + the complete backlog (items 5-17, with file:line evidence) lives in `docs/specs/2026-07-08-kortix-as-a-backend-subject-identity.md`.

## Scope of THIS PR (items 1-4, foundation)

Additive and **feature-flagged** — default behavior is unchanged, nothing existing breaks, and the enforcing paths engage **only** for the new `backend_scoped` tokens.

- **Data model**: `subjects` table + `account_tokens.subject_id` / `backend_scoped` (migration + drizzle schema + barrel export).
- **The boundary** (`subjects/session-scope.ts`): `checkSessionScope` enforces that a subject-scoped token may touch **exactly one session** and fails closed everywhere else. This is the missing primitive — today `session_id` is billing metadata, never an access boundary. Pure, Hono/DB-free, and exhaustively unit-tested (12 cases).
- **Locked grant** (`lockedSubjectGrant`): interact-only — no secrets, no CLI actions, no connectors.
- **Repository + composition**: idempotent `upsertSubject`; `mintSubjectSessionToken` = the exact server-side call an operator BFF makes.
- **Config**: `KORTIX_BACKEND_MODE` (off) — governs the secret-less runtime + default-deny grant (wiring tracked in the spec).
- Wired into both PAT auth paths (`supabaseAuth` + `combinedAuth`) via `enforceBackendSessionScope`, guarded so ordinary tokens are untouched.

## Verification

- `packages/db` typecheck: clean
- `apps/api` typecheck: clean (exit 0)
- `apps/api` biome: clean on all new files
- `bun test src/subjects/`: **12 pass / 0 fail**

## NOT in this PR (follow-ups, in the spec)

- HTTP mint route wired to session provisioning
- Secret-less runtime session provisioning (no plaintext secrets / no account PAT / capped LLM spend) — the biggest, riskiest piece
- Default-deny grant flip in backend mode
- Items 5-17 (per-subject creds/budgets, scoped clone/git boundary, model pin, SDK gaps, reference app, hardening guide)

## Review posture

This touches the auth core. It is intentionally inert by default. **Please security-review before any flag or enforcement default is flipped** — particularly `checkSessionScope`'s route coverage (does it fail closed on every session-bearing surface a `backend_scoped` token could reach?).
