### PR TITLE
fix(security): resolve CodeQL high-severity alerts (ReDoS, temp-file, TOCTOU, CLI opener)

### DIFF
--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -709,21 +709,27 @@ export const config = {
       console.log('[config] Auto-generated INTERNAL_SERVICE_KEY for sandbox auth');
       // Persist to .env so the key survives process restarts (avoids re-sync on every restart)
       try {
-        const { appendFileSync, readFileSync, existsSync } = require('fs');
+        const { appendFileSync, readFileSync } = require('fs');
         const { resolve } = require('path');
         const candidates = [
           resolve(__dirname, '../../.env'),       // from src/config.ts -> ../../.env
           resolve(process.cwd(), '.env'),          // cwd/.env
         ];
         for (const envPath of candidates) {
-          if (existsSync(envPath)) {
-            const content = readFileSync(envPath, 'utf-8');
-            if (!content.includes('INTERNAL_SERVICE_KEY=')) {
-              appendFileSync(envPath, `\n# Auto-generated service key for sandbox auth (do not remove)\nINTERNAL_SERVICE_KEY=${generated}\n`);
-              console.log(`[config] Persisted INTERNAL_SERVICE_KEY to ${envPath}`);
-            }
-            break;
+          // No existsSync-then-write: check-then-act on a path is a TOCTOU race.
+          // The read IS the existence test — a missing/unreadable file throws us
+          // to the next candidate, leaving no gap between check and use.
+          let content: string;
+          try {
+            content = readFileSync(envPath, 'utf-8');
+          } catch {
+            continue;
           }
+          if (!content.includes('INTERNAL_SERVICE_KEY=')) {
+            appendFileSync(envPath, `\n# Auto-generated service key for sandbox auth (do not remove)\nINTERNAL_SERVICE_KEY=${generated}\n`);
+            console.log(`[config] Persisted INTERNAL_SERVICE_KEY to ${envPath}`);
+          }
+          break;
         }
       } catch (err: any) {
         // Non-fatal -- key still works in-memory for this process lifetime

--- a/apps/api/src/projects/suna-migration/suna-push.ts
+++ b/apps/api/src/projects/suna-migration/suna-push.ts
@@ -7,7 +7,7 @@
  * sandbox separately (rehydrate). We move it out of the tree before pushing.
  */
 import { dirname, join } from 'node:path';
-import { existsSync, mkdirSync, writeFileSync, rmSync, readdirSync, statSync } from 'node:fs';
+import { mkdirSync, writeFileSync, rmSync, readdirSync, statSync } from 'node:fs';
 import { getDefaultManagedBackend } from '../git-backends/registry';
 import type { GitConnectionRef } from '../git-backends/types';
 import { buildStarterFiles } from '../starter';
@@ -61,9 +61,17 @@ export async function pushBundleAsRepo(accountId: string, bundleDir: string): Pr
   const repoFullName = repo.repoOwner && repo.repoName ? `${repo.repoOwner}/${repo.repoName}` : undefined;
   for (const f of buildStarterFiles({ projectName: 'Legacy (Suna) projects', repoFullName, template: STARTER_TEMPLATE })) {
     const full = join(bundleDir, f.path);
-    if (existsSync(full)) continue; // never clobber his content
     mkdirSync(dirname(full), { recursive: true });
-    writeFileSync(full, f.content);
+    // Exclusive create (O_EXCL via 'wx', mode 0600): the bundle dir is a
+    // predictable /tmp path, so a plain write could clobber his content or
+    // follow a pre-planted symlink. Exclusive creation both preserves the
+    // "never clobber his content" rule (EEXIST → skip) and closes the
+    // existsSync-then-write race in one step.
+    try {
+      writeFileSync(full, f.content, { flag: 'wx', mode: 0o600 });
+    } catch (e: any) {
+      if (e?.code !== 'EEXIST') throw e; // his file already present — leave it
+    }
   }
 
   // GitHub rejects oversized blobs (and LFS isn't wired up for managed repos),
@@ -87,8 +95,16 @@ export async function pushBundleAsRepo(accountId: string, bundleDir: string): Pr
   };
   strip(bundleDir);
   if (dropped.length) {
-    writeFileSync(join(bundleDir, '.kortix-skipped-large-files.txt'),
-      `Omitted from this repo — exceeded GitHub's ${MAX_BLOB_BYTES / 1048576}MB file limit:\n\n${dropped.join('\n')}\n`);
+    const reportPath = join(bundleDir, '.kortix-skipped-large-files.txt');
+    // Exclusive create (O_EXCL, 0600) into the predictable /tmp bundle dir; a
+    // retry that re-enters this step just re-uses the existing report (EEXIST).
+    try {
+      writeFileSync(reportPath,
+        `Omitted from this repo — exceeded GitHub's ${MAX_BLOB_BYTES / 1048576}MB file limit:\n\n${dropped.join('\n')}\n`,
+        { flag: 'wx', mode: 0o600 });
+    } catch (e: any) {
+      if (e?.code !== 'EEXIST') throw e;
+    }
   }
 
   rmSync(join(bundleDir, '.git'), { recursive: true, force: true });

--- a/apps/cli/src/commands/login.ts
+++ b/apps/cli/src/commands/login.ts
@@ -232,6 +232,10 @@ function safeHostname(): string {
 }
 
 function openInBrowser(url: string): void {
+  // Only hand a real web URL to the OS opener — a value starting with '-' would
+  // be read as a flag by open/xdg-open, and Windows `start` parses its argument,
+  // so an unvalidated URL is a command-injection vector.
+  if (!/^https?:\/\//i.test(url)) return;
   const platform = process.platform;
   let cmd: string;
   let args: string[];

--- a/apps/cli/src/commands/projects.ts
+++ b/apps/cli/src/commands/projects.ts
@@ -569,6 +569,10 @@ function formatRelative(iso: string): string {
 
 
 function openInBrowser(url: string): void {
+  // Only hand a real web URL to the OS opener — a value starting with '-' would
+  // be read as a flag by open/xdg-open, and Windows `start` parses its argument,
+  // so an unvalidated URL is a command-injection vector.
+  if (!/^https?:\/\//i.test(url)) return;
   const cmd =
     process.platform === 'darwin'
       ? 'open'

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -599,6 +599,10 @@ function formatRelative(iso: string): string {
 }
 
 function openInBrowser(url: string): void {
+  // Only hand a real web URL to the OS opener — a value starting with '-' would
+  // be read as a flag by open/xdg-open, and Windows `start` parses its argument,
+  // so an unvalidated URL is a command-injection vector.
+  if (!/^https?:\/\//i.test(url)) return;
   const cmd =
     process.platform === 'darwin'
       ? 'open'

--- a/packages/shared/src/utils/url-autolink.test.ts
+++ b/packages/shared/src/utils/url-autolink.test.ts
@@ -115,4 +115,25 @@ describe('autoLinkUrls', () => {
   test('inline math spanning a url keeps it unlinked', () => {
     expect(autoLinkUrls('math $x = example.com$ end')).toBe('math $x = example.com$ end');
   });
+
+  test('adversarial (ReDoS-shaped) input stays fast and correct', () => {
+    // Before the quantifiers were bounded, these repetitive strings drove the
+    // email / markdown-link / angle-link regexes into polynomial backtracking
+    // (seconds+) on user-controlled chat content. Bounded quantifiers keep every
+    // match attempt constant-work, so the whole scan stays linear. A generous
+    // time budget still fails hard if the super-linear behaviour ever returns.
+    const cases = [
+      '%'.repeat(50_000), // email local-part run that never reaches '@'
+      'a.'.repeat(30_000), // dotted run with no '@' and no TLD
+      '['.repeat(50_000), // markdown-link opens that never reach ']('
+      '[]('.repeat(15_000), // link prefixes that never close
+      '<http://'.repeat(15_000), // angle links that never close '>'
+    ];
+    for (const input of cases) {
+      const start = Date.now();
+      const out = autoLinkUrls(input);
+      expect(typeof out).toBe('string');
+      expect(Date.now() - start).toBeLessThan(2_000);
+    }
+  });
 });

--- a/packages/shared/src/utils/url-autolink.ts
+++ b/packages/shared/src/utils/url-autolink.ts
@@ -16,14 +16,18 @@
  * - LaTeX block math: $$...$$
  */
 
-const EMAIL_PATTERN = /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g;
+// Bounded quantifiers everywhere: unbounded `+`/`*` runs on user-controlled chat
+// content are polynomial-ReDoS bait (long runs that never reach `@`/TLD backtrack
+// across every start index). RFC caps — local-part ≤64, domain ≤255, TLD ≤24 —
+// keep every match attempt constant-work, so the whole scan stays linear.
+const EMAIL_PATTERN = /[a-zA-Z0-9._%+-]{1,64}@[a-zA-Z0-9.-]{1,255}\.[a-zA-Z]{2,24}/g;
 
 // No lookbehind anywhere in this file: a regex literal with (?<!…) is a
 // parse-time SyntaxError on Safari <16.4 and kills every chunk importing this
 // module (chat, public share page). The old (?<![/@]) guard on the bare-domain
 // alternative is enforced imperatively in autoLinkUrls via a prev-char check.
 const URL_PATTERN =
-  /(?:https?:\/\/(?:www\.)?|www\.)[-a-zA-Z0-9@:%._+~#=]{1,256}(?:\.[a-zA-Z0-9()]{1,6})+\b(?:[-a-zA-Z0-9()@:%_+.~#?&/=]*)|(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+(?:com|org|net|io|dev|app|ai|co|uk|de|fr|it|es|jp|cn|in|br|au|ca|us|gov|edu|xyz|info|tech|online|site|me|cc|ws|name|mobi|tv|biz|us|eu|academy|agency|blog|chat|cloud|digital|email|finance|global|health|legal|media|money|news|page|shop|store|studio|ventures|vc|world)\b(?:\/[-a-zA-Z0-9()@:%_+.~#?&/=]*)?/g;
+  /(?:https?:\/\/(?:www\.)?|www\.)[-a-zA-Z0-9@:%._+~#=]{1,256}(?:\.[a-zA-Z0-9()]{1,6}){1,64}\b(?:[-a-zA-Z0-9()@:%_+.~#?&/=]*)|(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.){1,64}(?:com|org|net|io|dev|app|ai|co|uk|de|fr|it|es|jp|cn|in|br|au|ca|us|gov|edu|xyz|info|tech|online|site|me|cc|ws|name|mobi|tv|biz|us|eu|academy|agency|blog|chat|cloud|digital|email|finance|global|health|legal|media|money|news|page|shop|store|studio|ventures|vc|world)\b(?:\/[-a-zA-Z0-9()@:%_+.~#?&/=]*)?/g;
 
 /**
  * Character scan for unescaped `$…$` inline-math spans (interior non-empty,
@@ -83,13 +87,13 @@ function buildProtectedRanges(text: string): Array<[number, number]> {
 
   // ── Markdown links  [text](url) ─────────────────────────────────────────
   // Protect BOTH the link-text part AND the url part so we never re-process them.
-  const linkRe = /\[([^\]]*)\]\(([^)]*)\)/g;
+  const linkRe = /\[([^\]]{0,4096})\]\(([^)]{0,8192})\)/g;
   while ((m = linkRe.exec(text)) !== null) {
     ranges.push([m.index, m.index + m[0].length - 1]);
   }
 
   // ── Bare markdown link references  <url> ────────────────────────────────
-  const angleRe = /<(?:https?:\/\/|mailto:)[^>]+>/g;
+  const angleRe = /<(?:https?:\/\/|mailto:)[^>\n]{1,8192}>/g;
   while ((m = angleRe.exec(text)) !== null) {
     ranges.push([m.index, m.index + m[0].length - 1]);
   }

--- a/packages/starter/src/__tests__/opencode-tool-env.test.ts
+++ b/packages/starter/src/__tests__/opencode-tool-env.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -33,8 +33,8 @@ async function importFreshHelper() {
 
 describe("opencode tool env helper", () => {
   test("reads Kortix router env from the live agent env file", async () => {
-    tempDir = join(tmpdir(), `kortix-tool-env-${Date.now()}`);
-    mkdirSync(tempDir, { recursive: true });
+    // mkdtemp gives an unpredictable, race-free dir (vs a guessable /tmp path).
+    tempDir = mkdtempSync(join(tmpdir(), "kortix-tool-env-"));
     const envFile = join(tempDir, "agent-env.sh");
     writeFileSync(
       envFile,


### PR DESCRIPTION
Resolves the high-severity CodeQL alerts flagged on the 0.9.100 candidate so the release is clean.

## Fixes
| Alert | File | Fix |
|---|---|---|
| Polynomial ReDoS ×3 (+1 unflagged) | `packages/shared/.../url-autolink.ts` | Bound every quantifier (email/URL/markdown-link/angle). A plain `'a.'×30k` hung `autoLinkUrls` ~15s — caught by a new adversarial regression test. |
| Insecure temp file + file-race ×3 | `apps/api/.../suna-migration/suna-push.ts` | Exclusive `O_EXCL` (`wx`, 0600) writes into the predictable /tmp bundle dir; drops the existsSync-then-write TOCTOU. |
| File-system race | `apps/api/src/config.ts` | Drop existsSync check-then-append; the read is the existence test. |
| Command injection ×3 | `apps/cli/.../login|projects|sessions.ts` | `openInBrowser` only hands http(s) URLs to the OS opener. |
| Insecure temp file | `packages/starter/.../opencode-tool-env.test.ts` | `mkdtemp` instead of a guessable /tmp path. |

## Verified
- `bun test url-autolink` 23/23 (adversarial ReDoS cases now <2s; suite 15s → <1s)
- `bun test opencode-tool-env` 1/1
- `tsc --noEmit` clean: shared, starter, cli, api

## Not in scope (flagged separately)
- `apps/api/scripts/bake-warm-snapshot.ts` `call-to-non-callable`: a **pre-existing dead dev script** importing removed modules (`../src/snapshots/warm-bake`, `getDaytonaWarm`/`warmSnapshotsEnabled` — none exist). Not shipped in any runtime; needs its own cleanup.
- npm base-image CVEs (sigstore/picomatch/tar/ip-address under `usr/local/lib/node_modules/npm`): dependency/base-image, not source-fixable here.