### PR TITLE
chore(security): gitleaks-ignore the published X OAuth1 doc test vectors

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,16 @@
+# gitleaks false positives — reviewed and intentionally ignored.
+#
+# apps/api/src/__tests__/unit-executor-execute.test.ts contains the PUBLISHED
+# X (Twitter) OAuth 1.0a example test vectors — the exact sample values from
+# X's own developer docs (consumer key "xvz1evFS4wEEPTGEFPHBog", token
+# "370773112-GmHxMAgYyLbNEtIKZeRNFsMKPR9EyMZeS9weJAEb", etc.). They are public
+# documentation constants used to assert oauth1Signature/oauth1Header against
+# the known-good vector; none are live credentials.
+e1f0bcd84ccd4685211bfa3b47ae6b07d9e3437c:apps/api/src/__tests__/unit-executor-execute.test.ts:generic-api-key:277
+e1f0bcd84ccd4685211bfa3b47ae6b07d9e3437c:apps/api/src/__tests__/unit-executor-execute.test.ts:generic-api-key:278
+e1f0bcd84ccd4685211bfa3b47ae6b07d9e3437c:apps/api/src/__tests__/unit-executor-execute.test.ts:generic-api-key:281
+e1f0bcd84ccd4685211bfa3b47ae6b07d9e3437c:apps/api/src/__tests__/unit-executor-execute.test.ts:generic-api-key:284
+e1f0bcd84ccd4685211bfa3b47ae6b07d9e3437c:apps/api/src/__tests__/unit-executor-execute.test.ts:generic-api-key:285
+e1f0bcd84ccd4685211bfa3b47ae6b07d9e3437c:apps/api/src/__tests__/unit-executor-execute.test.ts:generic-api-key:310
+e1f0bcd84ccd4685211bfa3b47ae6b07d9e3437c:apps/api/src/__tests__/unit-executor-execute.test.ts:generic-api-key:312
+e1f0bcd84ccd4685211bfa3b47ae6b07d9e3437c:apps/api/src/__tests__/unit-executor-execute.test.ts:generic-api-key:319


### PR DESCRIPTION
The secret-scan on the main→staging release PR (#4312) fails on 8 `generic-api-key` findings in `apps/api/src/__tests__/unit-executor-execute.test.ts`. These are the **published X (Twitter) OAuth 1.0a example test vectors** (consumer key `xvz1evFS4wEEPTGEFPHBog`, token `370773112-…`, nonce `kYjz…`) — public documentation constants the test uses to assert `oauth1Signature`/`oauth1Header` against the known-good vector. None are live credentials.

Adds a root `.gitleaksignore` allowlisting the 8 fingerprints (gitleaks auto-loads it). Verified locally with gitleaks 8.21.2: `no leaks found` on `staging..HEAD`.

Unblocks the 0.9.100 promotion secret-scan without touching the test.