### PR TITLE
feat(web): highlight available upgrades — accent card + Recommended badge

### DIFF
--- a/apps/web/src/features/workspace/customize/migrate-to-v2/upgrade-view.test.tsx
+++ b/apps/web/src/features/workspace/customize/migrate-to-v2/upgrade-view.test.tsx
@@ -11,6 +11,8 @@ describe('UpgradesViewContent — per-state rendering', () => {
     expect(html).toContain('Upgrades');
     expect(html).toContain('Migrate manifest to v2');
     expect(html).toContain('Run');
+    // Applicable upgrades are surfaced as a highlighted, recommended action.
+    expect(html).toContain('Recommended');
     expect(html).toContain('One-off upgrade');
     expect(html).not.toContain('up to date');
   });
@@ -21,6 +23,8 @@ describe('UpgradesViewContent — per-state rendering', () => {
     );
     expect(html).toContain('up to date');
     expect(html).not.toContain('Migrate manifest to v2');
+    // No applicable upgrade ⇒ no recommended-action highlight.
+    expect(html).not.toContain('Recommended');
     expect(html).toContain('One-off upgrade');
   });
 

--- a/apps/web/src/features/workspace/customize/migrate-to-v2/upgrade-view.tsx
+++ b/apps/web/src/features/workspace/customize/migrate-to-v2/upgrade-view.tsx
@@ -16,6 +16,7 @@
  * Nothing here merges anything.
  */
 
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import Loading from '@/components/ui/loading';
@@ -72,13 +73,20 @@ export function UpgradesViewContent({
             {upgrades.map((upgrade: ProjectUpgrade) => (
               <li
                 key={upgrade.id}
-                className="bg-popover flex items-center gap-3 rounded-md border px-4 py-3"
+                className="border-kortix-base/30 bg-kortix-base/[0.06] shadow-kortix-base/20 flex items-center gap-3 rounded-md border px-4 py-3 shadow-md transition-colors hover:border-kortix-base/45 hover:bg-kortix-base/[0.09]"
               >
-                <span className="bg-kortix-base/15 flex size-9 shrink-0 items-center justify-center rounded-sm">
+                <span className="bg-kortix-base/15 ring-kortix-base/25 flex size-9 shrink-0 items-center justify-center rounded-sm ring-1 ring-inset">
                   <ArrowUpCircle className="text-kortix-base size-5" />
                 </span>
                 <div className="min-w-0 flex-1">
-                  <p className="text-foreground text-sm font-medium">{upgrade.title}</p>
+                  <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+                    <p className="text-foreground text-sm font-medium text-balance">
+                      {upgrade.title}
+                    </p>
+                    <Badge variant="kortix" size="xs" className="shrink-0">
+                      Recommended
+                    </Badge>
+                  </div>
                   <p className="text-muted-foreground mt-0.5 text-xs text-pretty">
                     {upgrade.description}
                   </p>


### PR DESCRIPTION
Brings visual prominence to the **Available upgrades** card in Project → Customize → **Upgrades** (e.g. "Migrate manifest to v2"). It previously rendered as a plain neutral `bg-popover` row that blended into the page, so the one thing we want people to act on didn't stand out.

### What changed (`upgrade-view.tsx`)
- **Brand-accent surface** — accent border (`border-kortix-base/30`), a faint brand tint (`bg-kortix-base/[0.06]`), and a soft brand glow (`shadow-md shadow-kortix-base/20`); hover deepens the accent.
- **Inset-ring icon tile** — the `ArrowUpCircle` tile gains `ring-1 ring-inset ring-kortix-base/25` for crisper definition.
- **"Recommended" badge** — a `Badge variant="kortix"` next to the title. This is the attention signal that does **not** rely on color alone (accessible), and it renders only for genuinely-applicable upgrades.

### Robustness
- 100% token/alpha based → correct in **light + dark**; no raw palette colors, no hex.
- **SSR-safe** (renders under `renderToStaticMarkup`) — no hooks, no motion, no client APIs.
- Uses the design-system `Badge` primitive + the sanctioned tinted-tile pattern (mirrors `changes-view.tsx`); concentric radii preserved (`rounded-md` card → `rounded-sm` tile → `rounded-full` badge).
- Every Tailwind class family used already has precedent in `apps/web` (e.g. `shadow-primary/24`, `ring-kortix-blue/40`).
- Generic across the upgrade registry — any applicable upgrade gets the treatment, not just the v2 migration.

### Tests
`upgrade-view.test.tsx` asserts the **Recommended** highlight renders for an applicable (v1) upgrade and is absent in the up-to-date (v2) empty state.

> Not merging — leaving that to you once checks are green (the PR gets a Vercel preview to eyeball the card live).