### PR TITLE
fix(snapshots): unbreak Retry build / Fix with agent, and make quota GC able to fire

### DIFF
--- a/apps/api/src/__tests__/unit-build-slug.test.ts
+++ b/apps/api/src/__tests__/unit-build-slug.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  WARM_BUILD_SLUG_SUFFIX,
+  isWarmBuildSlug,
+  templateSlugFromBuildSlug,
+  warmBuildSlug,
+} from '../snapshots/ppwarm-names';
+
+describe('warm build slug ↔ template slug', () => {
+  it('round-trips a template slug through its warm build slug', () => {
+    expect(warmBuildSlug('default')).toBe('default-warm');
+    expect(templateSlugFromBuildSlug(warmBuildSlug('default'))).toBe('default');
+    expect(templateSlugFromBuildSlug(warmBuildSlug('custom-gpu'))).toBe('custom-gpu');
+  });
+
+  it('leaves a plain template slug untouched', () => {
+    expect(templateSlugFromBuildSlug('default')).toBe('default');
+    expect(isWarmBuildSlug('default')).toBe(false);
+  });
+
+  it('recognises the warm suffix', () => {
+    expect(isWarmBuildSlug(`anything${WARM_BUILD_SLUG_SUFFIX}`)).toBe(true);
+    expect(isWarmBuildSlug('warm')).toBe(false);
+    expect(isWarmBuildSlug('warm-ish')).toBe(false);
+  });
+
+  it('strips only the trailing suffix, not an internal one', () => {
+    expect(templateSlugFromBuildSlug('warm-build-warm')).toBe('warm-build');
+  });
+
+  // The regression this whole change exists for: `default-warm` reached the rebuild
+  // and fix-with-agent routes as if it were a template slug, resolved to nothing,
+  // and surfaced as 502 / 400 respectively.
+  it('maps the build slug that broke Retry build back to a real template', () => {
+    expect(templateSlugFromBuildSlug('default-warm')).toBe('default');
+  });
+});

--- a/apps/api/src/__tests__/unit-quota-gc-select.test.ts
+++ b/apps/api/src/__tests__/unit-quota-gc-select.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  DAYTONA_ORG_SNAPSHOT_LIMIT,
+  QUOTA_GC_KEEP_FRESHEST_DEFAULTS,
+  QUOTA_GC_MAX_PER_PASS,
+  QUOTA_GC_ORG_HIGH_WATER,
+  type SnapshotLike,
+  selectSnapshotsToReap,
+} from '../snapshots/quota-gc-select';
+
+const NOW = Date.parse('2026-07-08T00:00:00Z');
+const DAY = 86_400_000;
+const ago = (days: number) => new Date(NOW - days * DAY).toISOString();
+
+function snap(name: string, opts: Partial<SnapshotLike> = {}): SnapshotLike {
+  return {
+    id: opts.id ?? `id-${name}`,
+    name,
+    state: opts.state ?? 'active',
+    createdAt: opts.createdAt ?? ago(1),
+    lastUsedAt: opts.lastUsedAt ?? ago(1),
+  };
+}
+
+/** Pad the org up to `n` snapshots with untouchable stock images. */
+function padToOrgSize(items: SnapshotLike[], n: number): SnapshotLike[] {
+  const pad: SnapshotLike[] = [];
+  for (let i = items.length; i < n; i++) pad.push(snap(`daytonaio/sandbox:${i}`));
+  return [...items, ...pad];
+}
+
+const run = (all: SnapshotLike[], referenced: string[] = []) =>
+  selectSnapshotsToReap({ all, referenced: new Set(referenced), now: NOW });
+
+const names = (r: ReturnType<typeof run>) => r.doomed.map((d) => d.snapshot.name);
+
+describe('selectSnapshotsToReap — pressure gate', () => {
+  it('does nothing while the ORG total is under the high-water mark', () => {
+    const defaults = Array.from({ length: 40 }, (_, i) =>
+      snap(`kortix-default-${i}`, { lastUsedAt: ago(i + 1) }),
+    );
+    const res = run(padToOrgSize(defaults, QUOTA_GC_ORG_HIGH_WATER - 1));
+    expect(res.underPressure).toBe(false);
+    expect(res.doomed).toEqual([]);
+  });
+
+  // The bug: the old gate counted only our template namespace, so ppwarm + stock
+  // images could carry the org past 100 while the gate slept at 15/60.
+  it('fires on org total even when OUR namespace is tiny', () => {
+    const managed = [
+      ...Array.from({ length: 13 }, (_, i) => snap(`kortix-default-${i}`, { lastUsedAt: ago(i) })),
+      snap('kortix-tpl-a'),
+    ];
+    const stock = Array.from({ length: 70 }, (_, i) => snap(`daytonaio/sandbox:${i}`));
+    const res = run([...managed, ...stock]);
+
+    expect(res.orgTotal).toBe(84);
+    expect(res.managedCount).toBe(14);
+    expect(res.orgTotal).toBeGreaterThanOrEqual(QUOTA_GC_ORG_HIGH_WATER);
+    expect(res.underPressure).toBe(true);
+    expect(res.doomed.length).toBeGreaterThan(0);
+  });
+
+  it('high-water leaves headroom below the hard org limit', () => {
+    expect(QUOTA_GC_ORG_HIGH_WATER).toBeLessThan(DAYTONA_ORG_SNAPSHOT_LIMIT);
+  });
+});
+
+describe('selectSnapshotsToReap — defaults ranked by freshness, not idle', () => {
+  // A superseded default keeps a FRESH lastUsedAt (it was live minutes ago), so the
+  // old 7-day idle gate made zero defaults eligible while ~4.5/day accrued.
+  it('reaps superseded defaults that are not idle at all', () => {
+    const defaults = Array.from({ length: 20 }, (_, i) =>
+      snap(`kortix-default-${i}`, { lastUsedAt: new Date(NOW - i * 60_000).toISOString() }),
+    );
+    const res = run(padToOrgSize(defaults, 90));
+
+    expect(res.underPressure).toBe(true);
+    const reaped = names(res);
+    // Freshest N survive.
+    for (let i = 0; i < QUOTA_GC_KEEP_FRESHEST_DEFAULTS; i++) {
+      expect(reaped).not.toContain(`kortix-default-${i}`);
+    }
+    expect(reaped).toContain(`kortix-default-${QUOTA_GC_KEEP_FRESHEST_DEFAULTS}`);
+    expect(reaped).toContain('kortix-default-19');
+  });
+
+  it('never reaps a default a local template row still references', () => {
+    const defaults = Array.from({ length: 20 }, (_, i) =>
+      snap(`kortix-default-${i}`, { lastUsedAt: ago(i) }),
+    );
+    const res = run(padToOrgSize(defaults, 90), ['kortix-default-19']);
+    expect(names(res)).not.toContain('kortix-default-19');
+  });
+});
+
+describe('selectSnapshotsToReap — safety invariants', () => {
+  const base = () =>
+    padToOrgSize(
+      [
+        snap('kortix-tpl-user', { lastUsedAt: ago(30) }),
+        snap('kortix-ppwarm-aaaaaaaa-tip', { lastUsedAt: ago(1) }),
+        snap('daytona-small', { lastUsedAt: ago(400) }),
+        snap('bench-container-ubuntu2204', { lastUsedAt: ago(400) }),
+      ],
+      90,
+    );
+
+  it('never touches non-kortix stock/bench images, however stale', () => {
+    const reaped = names(run(base()));
+    expect(reaped).not.toContain('daytona-small');
+    expect(reaped).not.toContain('bench-container-ubuntu2204');
+  });
+
+  it('never deletes an in-flight build', () => {
+    const all = padToOrgSize(
+      [
+        snap('kortix-default-live', { lastUsedAt: ago(0), state: 'building' }),
+        ...Array.from({ length: 20 }, (_, i) =>
+          snap(`kortix-default-${i}`, { lastUsedAt: ago(i + 1) }),
+        ),
+      ],
+      90,
+    );
+    expect(names(run(all))).not.toContain('kortix-default-live');
+  });
+
+  it('reaps broken-state snapshots in our namespace', () => {
+    const all = padToOrgSize([snap('kortix-default-bad', { state: 'error' })], 90);
+    expect(names(run(all))).toContain('kortix-default-bad');
+  });
+
+  it('keeps the freshest ppwarm tip per project and reaps its stragglers', () => {
+    const all = padToOrgSize(
+      [
+        snap('kortix-ppwarm-0945686d-new', { lastUsedAt: ago(1) }),
+        snap('kortix-ppwarm-0945686d-old', { lastUsedAt: ago(2) }),
+        snap('kortix-ppwarm-0945686d-older', { lastUsedAt: ago(3) }),
+        snap('kortix-ppwarm-ffffffff-solo', { lastUsedAt: ago(5) }),
+      ],
+      90,
+    );
+    const reaped = names(run(all));
+    expect(reaped).not.toContain('kortix-ppwarm-0945686d-new');
+    expect(reaped).toContain('kortix-ppwarm-0945686d-old');
+    expect(reaped).toContain('kortix-ppwarm-0945686d-older');
+    // A project's only tip is live until proven idle.
+    expect(reaped).not.toContain('kortix-ppwarm-ffffffff-solo');
+  });
+
+  // One Daytona org, many databases: a ppwarm tip we can't attribute may belong to
+  // another environment. Idle time is the ONLY cross-env-safe liveness signal.
+  it('reaps a long-idle ppwarm tip but spares a recently used one', () => {
+    const all = padToOrgSize(
+      [
+        snap('kortix-ppwarm-aaaaaaaa-stale', { lastUsedAt: ago(20) }),
+        snap('kortix-ppwarm-bbbbbbbb-fresh', { lastUsedAt: ago(2) }),
+      ],
+      90,
+    );
+    const reaped = names(run(all));
+    expect(reaped).toContain('kortix-ppwarm-aaaaaaaa-stale');
+    expect(reaped).not.toContain('kortix-ppwarm-bbbbbbbb-fresh');
+  });
+
+  it('keeps anything with no usable timestamp — cannot prove it is idle', () => {
+    const all = padToOrgSize(
+      [snap('kortix-tpl-notime', { lastUsedAt: null, createdAt: null })],
+      90,
+    );
+    expect(names(run(all))).not.toContain('kortix-tpl-notime');
+  });
+
+  it('caps deletions per pass and reports the remainder instead of truncating silently', () => {
+    const defaults = Array.from({ length: 60 }, (_, i) =>
+      snap(`kortix-default-${i}`, { lastUsedAt: ago(i + 1) }),
+    );
+    const res = run(padToOrgSize(defaults, 90));
+    expect(res.doomed.length).toBe(QUOTA_GC_MAX_PER_PASS);
+    // 60 defaults, freshest 12 kept → 48 reapable, 15 this pass, 33 deferred.
+    expect(res.deferred).toBe(48 - QUOTA_GC_MAX_PER_PASS);
+  });
+});

--- a/apps/api/src/projects/lib/serializers.ts
+++ b/apps/api/src/projects/lib/serializers.ts
@@ -3,6 +3,12 @@ import type { Project, ProjectSession, Secret } from '@kortix/api-contract';
 import { type SecretGrant, visibilityToIntent } from '../../executor/share';
 import { db } from '../../shared/db';
 import { listSandboxTemplates, listSnapshotBuilds } from '../../snapshots/builder';
+import {
+  classifySnapshotError,
+  describeSnapshotError,
+  type SnapshotErrorCategory,
+} from '../../snapshots/error-classify';
+import { templateSlugFromBuildSlug } from '../../snapshots/ppwarm-names';
 import { type ProjectRole } from '../access';
 import { resolveAppsEnabled } from '../apps-config';
 import { resolveExperimentalFeatures, buildExperimentalCatalog } from '../../experimental/features';
@@ -449,14 +455,30 @@ export async function readBody(c: Context) {
 
 
 export function serializeBuildSummary(b: Awaited<ReturnType<typeof listSnapshotBuilds>>[number]) {
+  // errorCategory is a free-form column; older rows predate the classifier.
+  const category = (b.errorCategory ??
+    (b.error ? classifySnapshotError(b.error) : null)) as SnapshotErrorCategory | null;
   return {
     build_id: b.buildId,
     slug: b.slug,
+    /**
+     * The TEMPLATE this build was for. `slug` may be a build-log pseudo-slug
+     * (`default-warm`) that names no template; clients that want to act on a build
+     * — rebuild it, boot a session on it — must use this, never `slug`.
+     */
+    template_slug: templateSlugFromBuildSlug(b.slug),
     snapshot_name: b.snapshotName,
     content_hash: b.contentHash,
     status: b.status,
     error: b.error,
-    error_category: b.errorCategory,
+    error_category: category,
+    /**
+     * Whether an in-sandbox agent could plausibly fix this by editing the repo.
+     * Server-derived so the UI can't drift from what the API will accept: infra
+     * failures (quota, provider, timeout) are not repo-editable, and a fix session
+     * can't even boot when the snapshot it needs is the thing that failed.
+     */
+    fixable_by_agent: category ? describeSnapshotError(category).fixableByAgent : false,
     source: b.source,
     started_at: b.startedAt.toISOString(),
     finished_at: b.finishedAt?.toISOString() ?? null,

--- a/apps/api/src/projects/maintenance.test.ts
+++ b/apps/api/src/projects/maintenance.test.ts
@@ -27,7 +27,7 @@ mock.module('../shared/db', () => ({
 mock.module('./git', () => ({ deleteRemoteSessionBranch: async () => false }));
 mock.module('../billing/services/compute-metering', () => ({ tickRunningComputeCharges: async () => ({ settled: 0 }) }));
 mock.module('../snapshots/builder', () => ({ reconcileStaleBuilds: async () => ({ checked: 0, closedReady: 0, closedFailed: 0 }) }));
-mock.module('../snapshots/quota-gc', () => ({ reconcileSnapshotQuota: async () => ({ namespaceCount: 0, eligible: 0, deleted: 0, dryRun: false }) }));
+mock.module('../snapshots/quota-gc', () => ({ reconcileSnapshotQuota: async () => ({ orgTotal: 0, managedCount: 0, eligible: 0, deleted: 0, deferred: 0, dryRun: false }) }));
 // Controllable per-test: the first call can be made to hang forever (to
 // simulate the exact 2026-07-02 failure mode — an unbounded provider call
 // stuck inside reapAndReconcileSandboxes), later calls resolve normally.

--- a/apps/api/src/projects/maintenance.ts
+++ b/apps/api/src/projects/maintenance.ts
@@ -241,10 +241,10 @@ export async function runProjectMaintenance(): Promise<void> {
       }),
       // GC superseded template snapshots (content-addressed names orphaned by
       // every identity drift) before the 100/org Daytona quota fills up.
-      // Pressure-gated + bounded; no-op while the namespace is small.
+      // Pressure-gated + bounded; no-op while the ORG total is small.
       reconcileSnapshotQuota().catch((err) => {
         console.warn('[project-maintenance] snapshot quota GC failed:', err instanceof Error ? err.message : err);
-        return { namespaceCount: 0, eligible: 0, deleted: 0, dryRun: false };
+        return { orgTotal: 0, managedCount: 0, eligible: 0, deleted: 0, deferred: 0, dryRun: false };
       }),
     ]);
     const hadAction = Boolean(

--- a/apps/api/src/projects/routes/r2.ts
+++ b/apps/api/src/projects/routes/r2.ts
@@ -4,7 +4,8 @@ import { DEFAULT_SANDBOX_SLUG, deleteSandboxImage, kickPreBuild, kickProjectTemp
 import { classifySnapshotError, describeSnapshotError } from '../../snapshots/error-classify';
 import { getSandboxProvider } from '../../snapshots/providers';
 import { withTimeout } from '../../shared/with-timeout';
-import { createTemplate, deleteTemplate, getTemplateById, updateTemplate } from '../../snapshots/templates';
+import { templateSlugFromBuildSlug } from '../../snapshots/ppwarm-names';
+import { createTemplate, deleteTemplate, getTemplateById, TemplateNotFoundError, updateTemplate } from '../../snapshots/templates';
 import { commitFile, createRepo, getFileSha } from '../github';
 import { buildStarterFiles, normalizeStarterTemplateId } from '../starter';
 import { createRoute, z } from '@hono/zod-openapi';
@@ -591,6 +592,13 @@ projectsApp.openapi(
       202,
     );
   } catch (err) {
+    // A slug that names no template is the caller's mistake, not a provider
+    // outage — folding it into 502 hid the real bug (a build slug like
+    // `default-warm` being sent where a template slug was required) behind a
+    // status that reads as "Daytona is down".
+    if (err instanceof TemplateNotFoundError) {
+      return c.json({ error: err.message, code: 'TEMPLATE_NOT_FOUND' }, 404);
+    }
     const message = err instanceof Error ? err.message : String(err);
     return c.json({ error: message }, 502);
   }
@@ -633,6 +641,26 @@ projectsApp.openapi(
     return c.json({ error: 'No failed snapshot build to fix.' }, 409);
   }
 
+  const errorText = failed.error ?? 'Snapshot build failed';
+  const category = failed.errorCategory ?? classifySnapshotError(errorText);
+  const info = describeSnapshotError(category as ReturnType<typeof classifySnapshotError>);
+
+  // Infra failures (quota, provider blip, timeout) are not repo-editable. Spinning up
+  // a fix session for one is worse than useless: the session must boot a sandbox from
+  // a snapshot, which is exactly what the failure prevented — so it fails to start the
+  // very session meant to diagnose it. Refuse loudly rather than 400 from deep inside
+  // session creation.
+  if (!info.fixableByAgent) {
+    return c.json(
+      {
+        error: `${info.title}: ${info.hint}`,
+        code: 'NOT_AGENT_FIXABLE',
+        category,
+      },
+      409,
+    );
+  }
+
   const hostBuild = builds.find((b) => b.status === 'ready');
   if (!hostBuild) {
     return c.json(
@@ -644,10 +672,6 @@ projectsApp.openapi(
       409,
     );
   }
-
-  const errorText = failed.error ?? 'Snapshot build failed';
-  const category = failed.errorCategory ?? classifySnapshotError(errorText);
-  const info = describeSnapshotError(category as ReturnType<typeof classifySnapshotError>);
 
   const prompt = [
     `The sandbox image build for the "${failed.slug}" template is failing, so new sessions on it can't boot. Diagnose and fix the root cause, then open a change request.`,
@@ -676,7 +700,9 @@ projectsApp.openapi(
       initial_prompt: prompt,
       name: 'Fix sandbox build',
       metadata: { kind: 'sandbox-build-fix', failed_slug: failed.slug },
-      sandbox_slug: hostBuild.slug,
+      // hostBuild.slug is a BUILD slug — for a warm bake it reads `default-warm`,
+      // which names no template, so session creation rejected it with a 400.
+      sandbox_slug: templateSlugFromBuildSlug(hostBuild.slug),
     },
     request: requestAuditContext(c),
   });

--- a/apps/api/src/snapshots/builder.ts
+++ b/apps/api/src/snapshots/builder.ts
@@ -20,7 +20,7 @@ import { resolveCommitSha, type GitBackedProject } from '../projects/git';
 import { getSandboxProvider, type ProviderState, type SandboxProviderAdapter } from './providers';
 import { config, type SandboxProviderName } from '../config';
 import { warmPrebakeProviders } from '../projects/lib/provider-precedence';
-import { perProjectWarmImageName, ppwarmReapTargets } from './ppwarm-names';
+import { perProjectWarmImageName, ppwarmReapTargets, warmBuildSlug } from './ppwarm-names';
 import {
   computeTemplateIdentity,
   listTemplatesForProject,
@@ -28,6 +28,7 @@ import {
   recordTemplateFailed,
   refreshTemplateState,
   resolveTemplateBySlug,
+  resolveTemplateForBuildSlug,
   type ResolvedTemplate,
 } from './templates';
 import { DEFAULT_SANDBOX_SLUG } from './dockerfile-layer';
@@ -388,12 +389,17 @@ const inflightBuilds = new Map<string, Promise<EnsureSandboxImageResult>>();
 /**
  * Force the next session to rebuild by deleting the provider-side snapshot
  * for a given slug. No-op if nothing is there.
+ *
+ * Accepts a BUILD slug (`default-warm`) as well as a template slug: the retry
+ * surfaces hand us whatever `latest_failure.slug` held, and the warm bake's build
+ * row is never a template. Deleting the base template's snapshot is the correct
+ * response either way — the warm image is re-baked from it.
  */
 export async function deleteSandboxImage(
   project: GitBackedProject,
   opts: { slug?: string } = {},
 ): Promise<{ deleted: boolean; snapshotName: string; slug: string }> {
-  const template = await resolveTemplateBySlug(project, opts.slug);
+  const template = await resolveTemplateForBuildSlug(project, opts.slug);
   const provider = getSandboxProvider(template.provider);
   const identity = await computeTemplateIdentity(project, template);
   const before = await provider.getSnapshotState(identity.snapshotName);
@@ -979,7 +985,7 @@ export async function ensurePerProjectWarmImage(
     ? await openBuildLog({
         accountId: opts.accountId,
         projectId: project.projectId,
-        slug: `${DEFAULT_SANDBOX_SLUG}-warm`,
+        slug: warmBuildSlug(DEFAULT_SANDBOX_SLUG),
         snapshotName,
         contentHash: baseIdentity.contentHash,
         commitSha: tip,
@@ -1001,7 +1007,7 @@ export async function ensurePerProjectWarmImage(
       userDockerfile: baseIdentity.userDockerfile,
       entrypoint: template.entrypoint ? [template.entrypoint] : undefined,
       spec: { cpu: template.cpu, memoryGb: template.memoryGb, diskGb: template.diskGb },
-      slug: `${template.slug}-warm`,
+      slug: warmBuildSlug(template.slug),
       isShared: false,
       warmRepo,
     });

--- a/apps/api/src/snapshots/ppwarm-names.ts
+++ b/apps/api/src/snapshots/ppwarm-names.ts
@@ -10,6 +10,37 @@ import { createHash } from 'node:crypto';
 export const PPWARM_PREFIX = 'kortix-ppwarm-';
 
 /**
+ * Suffix that distinguishes the warm bake's BUILD-LOG row from the template it
+ * layers on top of. `project_snapshot_builds.metadata.slug` records
+ * `<template>-warm` for a warm bake, but no such template exists in
+ * `sandbox_templates` — the warm image is derived, never declared. Anything that
+ * feeds a build slug back into template resolution (rebuild, fix-with-agent)
+ * MUST map it back first via `templateSlugFromBuildSlug`, or it resolves nothing.
+ */
+export const WARM_BUILD_SLUG_SUFFIX = '-warm';
+
+/** The build-log slug recorded for `templateSlug`'s warm bake. */
+export function warmBuildSlug(templateSlug: string): string {
+  return `${templateSlug}${WARM_BUILD_SLUG_SUFFIX}`;
+}
+
+export function isWarmBuildSlug(slug: string): boolean {
+  return slug.endsWith(WARM_BUILD_SLUG_SUFFIX);
+}
+
+/**
+ * Map a build-log slug back to the template slug it was baked from. Note this is
+ * ambiguous by construction: a project MAY declare a real template literally named
+ * `foo-warm`. Callers must therefore try the slug verbatim FIRST and only fall
+ * back to this — see `resolveTemplateForBuildSlug`.
+ */
+export function templateSlugFromBuildSlug(buildSlug: string): string {
+  return isWarmBuildSlug(buildSlug)
+    ? buildSlug.slice(0, -WARM_BUILD_SLUG_SUFFIX.length)
+    : buildSlug;
+}
+
+/**
  * First 8 hex chars of the projectId with dashes stripped — the per-project scope
  * key in a ppwarm name. Matches warm-project.ts's `proj8` so the prefixes line up.
  */

--- a/apps/api/src/snapshots/quota-gc-select.ts
+++ b/apps/api/src/snapshots/quota-gc-select.ts
@@ -1,0 +1,225 @@
+/**
+ * Pure selection logic for the snapshot quota GC.
+ *
+ * Split out from quota-gc.ts (which owns the DB + provider IO) so the rules that
+ * decide what gets DELETED are unit-testable without a database, a Daytona org, or
+ * a clock. Nothing here imports config, db, or a provider.
+ *
+ * ── Why the old pressure gate could never fire ──────────────────────────────
+ * The Daytona quota (100) counts EVERY snapshot in the org: our templates, our
+ * per-project warm images, and Daytona's own stock/bench images. The old gate
+ * counted only `kortix-default-` / `kortix-tpl-` / `kortix-wproj-`. Measured live
+ * (2026-07-08): 120 snapshots tripped the cap while that namespace held 98 — and
+ * after a manual reclaim, 68 total against a GC-visible 15. With ~46 ppwarm + 22
+ * stock images uncounted, the namespace would have to reach 60 before GC woke up,
+ * i.e. an org total of ~128 — nearly 30 snapshots past the ceiling it defends.
+ * The gate is therefore on the ORG TOTAL, which is what the quota actually meters.
+ *
+ * ── Why defaults can't use an idle gate ─────────────────────────────────────
+ * The platform default is resolved dynamically from the runtime fingerprint; it is
+ * NOT stored in `sandbox_templates.provider_snapshot_name` (only custom `kortix-tpl-`
+ * rows and dev's default are). So "referenced" never protects it, and a *superseded*
+ * default keeps a fresh `lastUsedAt` — it was the live default until minutes ago.
+ * A 7-day idle rule makes zero defaults eligible while ~4.5/day accrue. Freshness
+ * rank, not idle time, is the only signal that separates live from superseded:
+ * every live environment boots its default constantly, so the live ones are always
+ * in the freshest few. Reaping a still-live default is self-healing — the next boot
+ * hits the snapshot-missing auto-heal and rebuilds (one slow boot, no data loss).
+ *
+ * ── Cross-environment safety ────────────────────────────────────────────────
+ * dev / staging / prod / laptops share ONE Daytona org but have SEPARATE databases.
+ * This process can only see its own DB. So "no project row for this proj8" does NOT
+ * mean the project is gone — it may be another environment's. `lastUsedAt` is the
+ * only cross-env liveness signal we have, and it is the sole basis on which a
+ * ppwarm tip belonging to nobody-we-know is reclaimed.
+ */
+
+/** The Daytona org-wide snapshot cap. Counts every snapshot, ours or not. */
+export const DAYTONA_ORG_SNAPSHOT_LIMIT = 100;
+
+/** Start reclaiming once the ORG total reaches this. Leaves room to act before builds fail. */
+export const QUOTA_GC_ORG_HIGH_WATER = 80;
+
+/** Live env defaults are booted constantly, so they're always in the freshest set. */
+export const QUOTA_GC_KEEP_FRESHEST_DEFAULTS = 12;
+
+/** Unreferenced user templates / legacy warm bases must be idle this long. */
+export const QUOTA_GC_MIN_IDLE_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * A ppwarm tip unused this long is reclaimed even though we can't see whose project
+ * it is. Cross-env safe: any environment still booting from it keeps lastUsedAt fresh.
+ */
+export const QUOTA_GC_PPWARM_MAX_IDLE_MS = 14 * 24 * 60 * 60 * 1000;
+
+/** Max deletions per sweep pass — keeps each pass cheap and observable. */
+export const QUOTA_GC_MAX_PER_PASS = 15;
+
+export const DEFAULT_PREFIX = 'kortix-default-';
+export const PPWARM_PREFIX = 'kortix-ppwarm-';
+/** Namespaces we own and may reap. Anything else (stock/bench images) is untouched. */
+export const MANAGED_PREFIXES = [
+  DEFAULT_PREFIX,
+  'kortix-tpl-',
+  'kortix-wproj-',
+  PPWARM_PREFIX,
+] as const;
+
+/** States that mean a build is IN FLIGHT — deleting these would break a live boot. */
+const IN_FLIGHT_STATES = new Set(['building', 'pulling']);
+/** States that mean the snapshot is pure waste. */
+const BROKEN_STATES = new Set(['error', 'build_failed']);
+
+export interface SnapshotLike {
+  id: string;
+  name: string;
+  state: string;
+  createdAt: string | null;
+  lastUsedAt: string | null;
+}
+
+export interface ReapCandidate {
+  snapshot: SnapshotLike;
+  reason: string;
+}
+
+export interface SelectInput {
+  /** EVERY snapshot in the org, including stock images. A partial list must never be passed. */
+  all: SnapshotLike[];
+  /** Names any local `sandbox_templates` row still points at. Never reaped. */
+  referenced: ReadonlySet<string>;
+  now: number;
+}
+
+export interface SelectResult {
+  /** Org-wide total — the number the Daytona quota actually meters. */
+  orgTotal: number;
+  /** Snapshots in namespaces we own. */
+  managedCount: number;
+  /** True when orgTotal has reached the high-water mark and reclaiming is warranted. */
+  underPressure: boolean;
+  /** Everything reapable, most-reclaimable first, already capped at MAX_PER_PASS. */
+  doomed: ReapCandidate[];
+  /** Reapable but dropped by the per-pass cap — logged so truncation is never silent. */
+  deferred: number;
+}
+
+export function isManaged(name: string): boolean {
+  return MANAGED_PREFIXES.some((p) => name.startsWith(p));
+}
+
+/** proj8 scope key of a ppwarm name: `kortix-ppwarm-<proj8>-<hash12>`. */
+export function ppwarmProj8(name: string): string | null {
+  if (!name.startsWith(PPWARM_PREFIX)) return null;
+  const rest = name.slice(PPWARM_PREFIX.length);
+  const proj8 = rest.split('-')[0];
+  return proj8 || null;
+}
+
+function lastTouch(s: SnapshotLike): number {
+  const t = s.lastUsedAt || s.createdAt;
+  return t ? new Date(t).getTime() : Number.NaN;
+}
+
+/** Freshest first; anything without a usable timestamp sorts last (and is kept). */
+function byFreshestFirst(a: SnapshotLike, b: SnapshotLike): number {
+  const ta = lastTouch(a);
+  const tb = lastTouch(b);
+  if (!Number.isFinite(ta) && !Number.isFinite(tb)) return 0;
+  if (!Number.isFinite(ta)) return 1;
+  if (!Number.isFinite(tb)) return -1;
+  return tb - ta;
+}
+
+/**
+ * Decide what to reap. Ordering of the returned list is deliberate: the cheapest,
+ * least-recoverable-value deletions come first, so the per-pass cap always spends
+ * itself on the safest wins before touching anything judgement-based.
+ */
+export function selectSnapshotsToReap(input: SelectInput): SelectResult {
+  const { all, referenced, now } = input;
+
+  const orgTotal = all.length;
+  const managed = all.filter((s) => isManaged(s.name));
+  const underPressure = orgTotal >= QUOTA_GC_ORG_HIGH_WATER;
+
+  const result: SelectResult = {
+    orgTotal,
+    managedCount: managed.length,
+    underPressure,
+    doomed: [],
+    deferred: 0,
+  };
+  if (!underPressure) return result;
+
+  // Reapable universe: ours, not referenced by a local template row, not mid-build.
+  const pool = managed.filter((s) => !referenced.has(s.name) && !IN_FLIGHT_STATES.has(s.state));
+
+  const candidates: ReapCandidate[] = [];
+  const claimed = new Set<string>();
+  const claim = (s: SnapshotLike, reason: string) => {
+    if (claimed.has(s.id)) return;
+    claimed.add(s.id);
+    candidates.push({ snapshot: s, reason });
+  };
+
+  // 1. Broken builds — pure waste, zero risk.
+  for (const s of pool
+    .filter((s) => BROKEN_STATES.has(s.state))
+    .sort(byFreshestFirst)
+    .reverse()) {
+    claim(s, `state=${s.state}`);
+  }
+
+  // 2. Superseded ppwarm tips: exactly one tip per project is live. The on-bake
+  //    reaper already does this, but it misses stragglers when a bake fails midway.
+  const byProj = new Map<string, SnapshotLike[]>();
+  for (const s of pool) {
+    if (s.name.includes('__deleted')) continue; // soft-delete tombstone; not quota-counting
+    const proj8 = ppwarmProj8(s.name);
+    if (!proj8) continue;
+    const group = byProj.get(proj8);
+    if (group) group.push(s);
+    else byProj.set(proj8, [s]);
+  }
+  for (const [proj8, group] of byProj) {
+    if (group.length < 2) continue;
+    const [, ...superseded] = [...group].sort(byFreshestFirst);
+    for (const s of superseded) claim(s, `superseded ppwarm tip for project ${proj8}`);
+  }
+
+  // 3. ppwarm tips nobody has booted in a long time. We cannot see other envs' DBs,
+  //    so idle time is the only safe liveness proof. Purely a cache — a wrongly
+  //    reaped tip re-bakes on the project's next background sync.
+  for (const s of pool) {
+    const t = lastTouch(s);
+    if (!ppwarmProj8(s.name)) continue;
+    if (!Number.isFinite(t)) continue; // can't prove idle → keep
+    if (now - t > QUOTA_GC_PPWARM_MAX_IDLE_MS) {
+      claim(s, `ppwarm idle ${Math.floor((now - t) / 86_400_000)}d`);
+    }
+  }
+
+  // 4. Superseded platform defaults — keep only the freshest N. Not idle-gated
+  //    (see the header): a superseded default's lastUsedAt is fresh by construction.
+  const defaults = pool.filter((s) => s.name.startsWith(DEFAULT_PREFIX)).sort(byFreshestFirst);
+  for (const s of defaults.slice(QUOTA_GC_KEEP_FRESHEST_DEFAULTS)) {
+    claim(s, 'superseded default (beyond freshest N)');
+  }
+
+  // 5. Everything else we own (user templates `kortix-tpl-`, legacy `kortix-wproj-`):
+  //    conservative idle gate. These can encode real user intent, so they get the
+  //    benefit of the doubt that a content-addressed default does not.
+  for (const s of pool) {
+    if (s.name.startsWith(DEFAULT_PREFIX) || ppwarmProj8(s.name)) continue;
+    const t = lastTouch(s);
+    if (!Number.isFinite(t)) continue;
+    if (now - t > QUOTA_GC_MIN_IDLE_MS) {
+      claim(s, `unreferenced + idle ${Math.floor((now - t) / 86_400_000)}d`);
+    }
+  }
+
+  result.deferred = Math.max(0, candidates.length - QUOTA_GC_MAX_PER_PASS);
+  result.doomed = candidates.slice(0, QUOTA_GC_MAX_PER_PASS);
+  return result;
+}

--- a/apps/api/src/snapshots/quota-gc.ts
+++ b/apps/api/src/snapshots/quota-gc.ts
@@ -1,31 +1,22 @@
 /**
- * Snapshot quota GC — reclaim superseded template snapshots.
+ * Snapshot quota GC — reclaim superseded snapshots before the org-wide cap bites.
  *
  * Template snapshots are content-addressed (`kortix-default-<hash>` /
  * `kortix-tpl-<hash>`), so every identity drift (each release bumps the runtime
  * fingerprint; every Dockerfile/spec edit) mints a NEW name and silently
  * orphans the old one. Nothing else deletes them: the only same-name deletes
  * run while that exact identity is being rebuilt. Measured live (2026-06-12):
- * ~4.5 new snapshots/day against the 100/org Daytona quota — exhaustion in
- * days, at which point every build org-wide starts failing.
+ * ~4.5 new snapshots/day against the 100/org Daytona quota — exhaustion in days,
+ * at which point every build org-wide starts failing.
  *
- * Deletion criteria (ALL must hold):
- *   1. Name is in our managed namespaces (`kortix-default-` / `kortix-tpl-` / `kortix-wproj-`).
- *      Warm bases have their own age-gated reaper; stock images are untouched.
- *   2. Not referenced by any local `sandbox_templates.provider_snapshot_name`
- *      (the row a session would boot from on the trust-the-row / graceful
- *      path — covers the platform default too, it has a shared row).
- *   3. Not USED for `QUOTA_GC_MIN_IDLE_MS` (lastUsedAt, falling back to
- *      createdAt). Several environments (laptops/dev/prod) share the org but
- *      have separate DBs — `lastUsedAt` is the cross-environment guard: any
- *      env still booting from a snapshot keeps it fresh. A cold-but-needed
- *      snapshot that does get deleted is self-healing: the next session hits
- *      the snapshot-missing auto-heal and rebuilds (one slow boot, no loss).
+ * This file owns the IO (DB reads, provider deletes). The RULES live in
+ * quota-gc-select.ts as a pure function — including the two hard-won invariants:
+ * the pressure gate must measure the ORG TOTAL (not just our namespace), and
+ * platform defaults must be ranked by freshness (not idle time). See that file's
+ * header for why each of those was wrong before, and for the cross-environment
+ * safety argument (one Daytona org, many databases).
  *
- * Pressure-gated: nothing is deleted while the org namespace is comfortably
- * under quota, so quiet orgs never see churn. Bounded per pass, oldest-first,
- * and skipped entirely when the org listing fails (never act on a partial
- * view).
+ * Never acts on a partial view: if the org listing fails, the pass does nothing.
  */
 
 import { isNotNull, sql } from 'drizzle-orm';
@@ -36,28 +27,26 @@ import {
   isDaytonaConfigured,
   listDaytonaSnapshots,
 } from '../shared/daytona';
+import {
+  QUOTA_GC_MAX_PER_PASS,
+  selectSnapshotsToReap,
+  type SnapshotLike,
+} from './quota-gc-select';
 
-const TEMPLATE_PREFIXES = ['kortix-default-', 'kortix-tpl-', 'kortix-wproj-'] as const;
-/** Start deleting only when our namespace holds this many snapshots. */
-const QUOTA_GC_PRESSURE_THRESHOLD = 60;
-/** A snapshot must be unused this long before it is eligible. */
-const QUOTA_GC_MIN_IDLE_MS = 7 * 24 * 60 * 60 * 1000;
-/** Max deletions per sweep pass — keeps each pass cheap and observable. */
-const QUOTA_GC_MAX_PER_PASS = 15;
-/** A project counts as ACTIVE (its warm snapshot is protected) when it has a
- * session or portal presence within this window. */
+/** A project counts as ACTIVE (its legacy warm pointer is protected) when it has a
+ * session within this window. */
 const QUOTA_GC_PROJECT_ACTIVE_MS = 14 * 24 * 60 * 60 * 1000;
 
 export interface QuotaGcResult {
-  /** Snapshots in our template namespaces (the pressure number). */
-  namespaceCount: number;
+  /** Org-wide snapshot count — the number the Daytona quota actually meters. */
+  orgTotal: number;
+  /** Snapshots in namespaces we own. */
+  managedCount: number;
   eligible: number;
   deleted: number;
+  /** Reapable but dropped by the per-pass cap. Never silently truncate. */
+  deferred: number;
   dryRun: boolean;
-}
-
-function isTemplateSnapshot(name: string): boolean {
-  return TEMPLATE_PREFIXES.some((p) => name.startsWith(p));
 }
 
 /**
@@ -68,20 +57,23 @@ export async function reconcileSnapshotQuota(
   opts: { dryRun?: boolean; now?: number } = {},
 ): Promise<QuotaGcResult> {
   const dryRun = opts.dryRun ?? false;
-  const result: QuotaGcResult = { namespaceCount: 0, eligible: 0, deleted: 0, dryRun };
+  const result: QuotaGcResult = {
+    orgTotal: 0,
+    managedCount: 0,
+    eligible: 0,
+    deleted: 0,
+    deferred: 0,
+    dryRun,
+  };
   if (!isDaytonaConfigured()) return result;
 
-  let all;
+  let all: SnapshotLike[];
   try {
     all = await listDaytonaSnapshots();
   } catch (err) {
     console.warn('[snapshot-gc] org listing failed — pass skipped:', err instanceof Error ? err.message : err);
     return result;
   }
-
-  const namespace = all.filter((s) => isTemplateSnapshot(s.name));
-  result.namespaceCount = namespace.length;
-  if (namespace.length < QUOTA_GC_PRESSURE_THRESHOLD) return result;
 
   const now = opts.now ?? Date.now();
 
@@ -120,33 +112,29 @@ export async function reconcileSnapshotQuota(
     if (r.name && r.active) referenced.add(r.name);
   }
 
-  const lastTouch = (s: { lastUsedAt?: string | null; createdAt: string | null }) => {
-    const t = s.lastUsedAt || s.createdAt;
-    return t ? new Date(t).getTime() : Number.NaN;
-  };
-  const eligible = namespace
-    .filter((s) => !referenced.has(s.name))
-    // No usable timestamp → can't prove it's idle → keep.
-    .filter((s) => Number.isFinite(lastTouch(s)) && now - lastTouch(s) > QUOTA_GC_MIN_IDLE_MS)
-    .sort((a, b) => lastTouch(a) - lastTouch(b));
-  result.eligible = eligible.length;
+  const plan = selectSnapshotsToReap({ all, referenced, now });
+  result.orgTotal = plan.orgTotal;
+  result.managedCount = plan.managedCount;
+  result.eligible = plan.doomed.length + plan.deferred;
+  result.deferred = plan.deferred;
 
-  for (const snap of eligible.slice(0, QUOTA_GC_MAX_PER_PASS)) {
+  if (!plan.underPressure) return result;
+
+  for (const { snapshot, reason } of plan.doomed) {
     if (dryRun) {
-      console.log(`[snapshot-gc] DRY RUN would delete ${snap.name} (last used ${snap.lastUsedAt ?? snap.createdAt})`);
+      console.log(`[snapshot-gc] DRY RUN would delete ${snapshot.name} (${reason})`);
       result.deleted++;
       continue;
     }
-    const ok = await deleteDaytonaSnapshotById(snap.id);
-    console.log(`[snapshot-gc] delete ${snap.name} (last used ${snap.lastUsedAt ?? snap.createdAt}): ${ok ? 'ok' : 'failed'}`);
-    if (ok) {
-      result.deleted++;
-    }
+    const ok = await deleteDaytonaSnapshotById(snapshot.id);
+    console.log(`[snapshot-gc] delete ${snapshot.name} (${reason}): ${ok ? 'ok' : 'failed'}`);
+    if (ok) result.deleted++;
   }
-  if (result.namespaceCount >= QUOTA_GC_PRESSURE_THRESHOLD) {
-    console.log(
-      `[snapshot-gc] namespace=${result.namespaceCount} eligible=${result.eligible} ${dryRun ? 'would-delete' : 'deleted'}=${result.deleted}`,
-    );
-  }
+
+  console.log(
+    `[snapshot-gc] org=${result.orgTotal} managed=${result.managedCount} ` +
+      `eligible=${result.eligible} ${dryRun ? 'would-delete' : 'deleted'}=${result.deleted}` +
+      (result.deferred > 0 ? ` deferred=${result.deferred} (cap ${QUOTA_GC_MAX_PER_PASS}/pass)` : ''),
+  );
   return result;
 }

--- a/apps/api/src/snapshots/templates.ts
+++ b/apps/api/src/snapshots/templates.ts
@@ -16,6 +16,7 @@ import { sandboxTemplates, projects } from '@kortix/db';
 import { AGENT_BROWSER_VERSION, OPENCODE_VERSION } from '@kortix/shared';
 type DbSandboxTemplate = typeof sandboxTemplates.$inferSelect;
 import { db } from '../shared/db';
+import { isWarmBuildSlug, templateSlugFromBuildSlug } from './ppwarm-names';
 import { readManifest } from '../projects/triggers';
 import { resolveCommitSha, readRepoFile, type GitBackedProject } from '../projects/git';
 import { SANDBOX_VERSION, config } from '../config';
@@ -231,7 +232,18 @@ export async function listTemplatesForProject(
   return value;
 }
 
-/** Resolve a slug → ResolvedTemplate. Throws if slug missing. */
+/**
+ * A slug that resolves to no template. Typed so callers can answer 404 instead of
+ * folding a client mistake into a generic 502 alongside real provider failures.
+ */
+export class TemplateNotFoundError extends Error {
+  constructor(readonly slug: string) {
+    super(`No sandbox template with slug "${slug}" in this project.`);
+    this.name = 'TemplateNotFoundError';
+  }
+}
+
+/** Resolve a slug → ResolvedTemplate. Throws TemplateNotFoundError if slug missing. */
 export async function resolveTemplateBySlug(
   project: GitBackedProject,
   slug: string | undefined,
@@ -254,7 +266,31 @@ export async function resolveTemplateBySlug(
   const items = await listTemplatesForProject(project);
   const match = items.find((t) => t.slug === target);
   if (match) return match;
-  throw new Error(`No sandbox template with slug "${target}" in this project.`);
+  throw new TemplateNotFoundError(target);
+}
+
+/**
+ * Resolve a slug that may have come from a BUILD LOG rather than a template.
+ *
+ * The warm bake records its build under `<template>-warm`, which is not a template
+ * (see WARM_BUILD_SLUG_SUFFIX). Every surface that hands a `latest_failure.slug` /
+ * `latest_build.slug` back to the API — Retry build, Fix with agent — lands here.
+ * Resolving the slug verbatim FIRST keeps a project that legitimately declares a
+ * template named `foo-warm` working; only when that misses do we treat the `-warm`
+ * as the derived-bake marker it usually is.
+ */
+export async function resolveTemplateForBuildSlug(
+  project: GitBackedProject,
+  slug: string | undefined,
+): Promise<ResolvedTemplate> {
+  try {
+    return await resolveTemplateBySlug(project, slug);
+  } catch (err) {
+    if (err instanceof TemplateNotFoundError && slug && isWarmBuildSlug(slug)) {
+      return resolveTemplateBySlug(project, templateSlugFromBuildSlug(slug));
+    }
+    throw err;
+  }
 }
 
 /**

--- a/apps/web/src/features/workspace/customize/sections/view/sandbox-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/sandbox-view.tsx
@@ -56,6 +56,7 @@ import { useState, type ReactNode } from 'react';
 const SNAPSHOTS_QUERY_KEY = (projectId: string) => ['project-snapshots', projectId];
 
 const CATEGORY_LABEL: Record<SnapshotErrorCategory, string> = {
+  quota: 'Snapshot quota reached',
   dockerfile: 'Dockerfile build failed',
   git: 'Repository access failed',
   tunnel: 'Sandbox callback unreachable',

--- a/apps/web/src/features/workspace/project-sidebar/footer/project-sandbox-alert.tsx
+++ b/apps/web/src/features/workspace/project-sidebar/footer/project-sandbox-alert.tsx
@@ -54,6 +54,7 @@ const SEVERITY_LABEL: Record<Severity, string> = {
 };
 
 const CATEGORY_LABEL: Record<string, string> = {
+  quota: 'Snapshot quota reached',
   dockerfile: 'Dockerfile build failed',
   git: 'Repository access failed',
   tunnel: 'Sandbox callback unreachable',
@@ -122,8 +123,16 @@ function SandboxAlertContent({
   const openCustomize = useCustomizeStore((s) => s.openCustomize);
   const { retry, fixWithAgent } = useSandboxRecovery(projectId);
   const failure = health.latest_failure;
+  // Only offer the agent for failures it can actually act on. Infra categories
+  // (quota, provider, timeout, runtime, tunnel) aren't repo-editable, and the fix
+  // session itself needs a bootable sandbox — the very thing the failure denied —
+  // so the button would fail to start the session meant to diagnose the failure.
+  // `fixable_by_agent` is server-derived; the API rejects the rest with 409.
   const canFixWithAgent =
-    !!failure && !!health.latest_build && health.latest_build.status === 'ready';
+    !!failure &&
+    failure.fixable_by_agent &&
+    !!health.latest_build &&
+    health.latest_build.status === 'ready';
 
   return (
     <div className="w-full overflow-hidden">
@@ -191,7 +200,7 @@ function SandboxAlertContent({
           variant="secondary"
           className="w-full border"
           disabled={retry.isPending}
-          onClick={() => retry.mutate(failure?.slug)}
+          onClick={() => retry.mutate(failure?.template_slug)}
         >
           {retry.isPending ? (
             <Loading className="text-foreground! size-3.5" />

--- a/packages/sdk/src/platform/projects-client/sandbox.ts
+++ b/packages/sdk/src/platform/projects-client/sandbox.ts
@@ -9,7 +9,10 @@ import { unwrap } from './shared';
 export type ProjectSnapshotStatus = 'building' | 'ready' | 'failed';
 
 /** Classified reason a snapshot build failed. */
+/** Mirrors apps/api/src/snapshots/error-classify.ts — keep in sync. */
 export type SnapshotErrorCategory =
+  /** Daytona org snapshot quota exhausted — infra, not repo-fixable. */
+  | 'quota'
   | 'dockerfile'
   | 'tunnel'
   | 'provider'
@@ -17,6 +20,7 @@ export type SnapshotErrorCategory =
   | 'runtime'
   | 'git'
   | 'unknown';
+
 
 /** A sandbox template: platform default + each `[[sandbox.templates]]` / UI-created entry. */
 export interface SandboxTemplate {
@@ -61,12 +65,21 @@ export interface SandboxTemplatesResponse {
 
 export interface ProjectSnapshotBuild {
   build_id: string;
+  /**
+   * The build-log slug. For a warm bake this is `<template>-warm`, which names NO
+   * template. Never feed this back to an API that expects a template slug — use
+   * `template_slug`.
+   */
   slug: string;
+  /** The template this build was for. Safe to pass to rebuild / session create. */
+  template_slug: string;
   snapshot_name: string;
   content_hash: string;
   status: ProjectSnapshotStatus;
   error: string | null;
   error_category: SnapshotErrorCategory | null;
+  /** Server-derived: can an in-sandbox agent plausibly fix this by editing the repo? */
+  fixable_by_agent: boolean;
   source: 'session-start' | 'project-create' | 'cr-merge' | 'manual' | 'background' | 'startup' | null;
   started_at: string;
   finished_at: string | null;


### PR DESCRIPTION
## What happened

Staging hit `Snapshot build failed: Snapshot quota exceeded. Maximum allowed: 100`. Reclaiming the quota by hand (120 → 68 snapshots) unblocked builds, but exposed that **every recovery affordance in the UI was broken**, and that the GC meant to prevent the incident could never have fired.

## Root cause: `default-warm` is a build-log slug, not a template

The warm bake records its build row as `` `${DEFAULT_SANDBOX_SLUG}-warm` `` (`builder.ts`). No such row exists in `sandbox_templates` — the warm image is *derived*, never declared. And since the warm bake layers on top of the base build, it always finishes **last**, so `latest_failure.slug` is essentially always `default-warm`.

Both recovery buttons fed that straight back into template resolution:

| Surface | Sends | Result |
|---|---|---|
| **Retry build** | `{slug:'default-warm'}` | `resolveTemplateBySlug` → no match → throw → **502** |
| **Fix with agent** | `sandbox_slug:'default-warm'` | session create rejects → **400** |

Confirmed in staging logs (`kortix-staging`, project `ce0f12cf`):
```
POST …/snapshots/rebuild          502   ×5
POST …/snapshots/fix-with-agent   400
```
Neither had ever worked for a base-build failure. The browser reported this as a CORS error, which is noise — CORS is configured correctly (preflight `204` + ACAO, `401` + ACAO, both verified with curl); Chrome just can't read a response it didn't get.

## Fixes

1. **One definition of the slug.** `warmBuildSlug()` / `templateSlugFromBuildSlug()`, replacing two hardcoded `` `${x}-warm` `` sites. `resolveTemplateForBuildSlug` tries the slug **verbatim first**, so a project that legitimately declares a template named `foo-warm` still resolves to it. Builds now serialize an explicit `template_slug` so clients never guess.

2. **Unknown slug → 404, not 502.** Folding a client error into "the provider is down" is what hid this. New `TemplateNotFoundError` → `404 TEMPLATE_NOT_FOUND`.

3. **Fix with agent no longer offered for infra failures.** `fixableByAgent: false` already existed for `quota`; nothing consulted it. Worse, the fix session must boot a sandbox from a snapshot — precisely what the quota denied — so the button *could not start the session meant to diagnose the failure*. Server rejects with `409 NOT_AGENT_FIXABLE`; the UI hides it via a server-derived `fixable_by_agent` (no client-side table to drift). Also adds the missing `quota` member to the SDK's `SnapshotErrorCategory` — its absence had let **two** `CATEGORY_LABEL` maps go stale, which is why the badge rendered a raw `quota`.

4. **`quota-gc` can now actually fire.** Its pressure gate counted only `kortix-default-`/`tpl-`/`wproj-`, but the Daytona quota counts **every** snapshot in the org.

   | | count | quota counts it | old GC counted it |
   |---|---|---|---|
   | `kortix-ppwarm-` | 46 | ✅ | ❌ |
   | non-kortix stock | 22 | ✅ | ❌ |
   | `default-` + `tpl-` | 15 | ✅ | ✅ |

   The gate waited for its namespace to hit 60 — an org total of ~128, nearly 30 past the 100 ceiling it defends. Now gated on the org total.

   Defaults also can't use an idle gate: a superseded default keeps a **fresh** `lastUsedAt` (it was live minutes ago) and is never `referenced` (the platform default resolves from the runtime fingerprint, not a DB row). Zero were ever eligible while ~4.5/day accrued. Ranked by **freshness** instead — keep the newest N. Reaping a live default is self-healing via the snapshot-missing rebuild path.

## Safety

Selection logic is extracted to a pure `quota-gc-select.ts` (no db/config/provider/clock) and unit-tested. It never touches stock images, in-flight builds (`building`/`pulling`), DB-referenced names, or anything without a usable timestamp. Truncation by the per-pass cap is reported (`deferred`), never silent.

The **cross-environment invariant** is encoded and tested: dev/staging/prod/laptops share one Daytona org but have separate databases, so "no project row for this proj8" **cannot** mean "dead" — it may be another env's project. `lastUsedAt` is the only safe liveness signal for a ppwarm tip we can't attribute. (My manual cleanup could use the stronger signal because I queried all three DBs; the in-process GC cannot.)

## Tests

- `unit-build-slug.test.ts` — round-trip + the exact `default-warm` regression.
- `unit-quota-gc-select.test.ts` — pressure gate fires on org total with a tiny namespace; superseded-but-not-idle defaults get reaped; freshest N survive; per-pass cap reports remainder; and the safety invariants above.

`bun test` 29/29 green. `tsc --noEmit` clean on `apps/api`, `packages/sdk`, `apps/web` (only pre-existing `@/.source` codegen error). `biome check` clean on touched files.

## Verification

Quota reclaimed to 68/100 by hand before this lands. After merge → dev, will verify on staging that `default` builds, Retry build returns `202`, and the warm bake succeeds.
