### PR TITLE
feat(marketplace): surface agents, commands & bundles as 1-click imports

### DIFF
--- a/apps/api/src/__tests__/e2e-marketplace-http.test.ts
+++ b/apps/api/src/__tests__/e2e-marketplace-http.test.ts
@@ -65,13 +65,12 @@ describe('marketplace HTTP contract', () => {
     expect(body.items.find((item) => item.name === 'memory-reflector')).toBeUndefined();
   });
 
-  test('GET /marketplace/items is public read-only and skill-only', async () => {
+  test('GET /marketplace/items is public read-only', async () => {
     authCalls = 0;
     const res = await fetch(`${baseUrl}/marketplace/items?query=agent-browser&source=kortix`);
     expect(res.status).toBe(200);
     const body = await res.json() as { items: Array<{ name: string; type: string }> };
     expect(body.items).toContainEqual(expect.objectContaining({ name: 'agent-browser', type: 'registry:skill' }));
-    expect(body.items.every((item) => item.type === 'registry:skill')).toBe(true);
     expect(authCalls).toBe(0);
   });
 

--- a/apps/api/src/__tests__/unit-marketplace.test.ts
+++ b/apps/api/src/__tests__/unit-marketplace.test.ts
@@ -26,16 +26,16 @@ describe('marketplace catalog', () => {
     expect(DEFAULT_MARKETPLACES).not.toContain('NousResearch/hermes-agent');
   });
 
-  test('lists the starter skill pack; non-skill items are hidden from browse', async () => {
+  test('surfaces skills + bundles through browse; support types stay internal', async () => {
     const all = await listCatalogItems();
     expect(all.length).toBeGreaterThan(50);
 
-    // Launch scope: marketplace browsing is the skill library. Non-skill
-    // registry entries remain internal for compatibility/dependency handling.
-    expect(all.some((i) => i.type === 'registry:bundle')).toBe(false);
-    expect(all.some((i) => i.type === 'registry:agent')).toBe(false);
+    // The marketplace surfaces the one-click importables (skills, agents,
+    // commands, bundles). Tools/files stay internal for dependency handling.
+    expect(all.some((i) => i.type === 'registry:bundle')).toBe(true);
     expect(all.some((i) => i.type === 'registry:tool')).toBe(false);
-    expect(all.find((i) => i.id === 'kortix:research-pack')).toBeUndefined();
+    expect(all.some((i) => i.type === 'registry:file')).toBe(false);
+    expect(all.find((i) => i.id === 'kortix:research-pack')).toBeTruthy();
 
     expect(all.find((i) => i.name === 'pdf')).toBeTruthy();
   });
@@ -89,7 +89,9 @@ describe('marketplace catalog', () => {
   });
 
   test('filters by type and query', async () => {
-    expect((await listCatalogItems({ type: 'bundle' })).length).toBe(0); // bundles hidden
+    const bundles = await listCatalogItems({ type: 'bundle' });
+    expect(bundles.length).toBeGreaterThan(0); // bundles are browseable one-click starters
+    expect(bundles.every((i) => i.type === 'registry:bundle')).toBe(true);
     expect((await listCatalogItems({ query: 'pdf' })).some((i) => i.name === 'pdf')).toBe(true);
     expect((await listCatalogItems({ query: 'zzzznotathing' })).length).toBe(0);
   });

--- a/apps/api/src/marketplace/catalog.test.ts
+++ b/apps/api/src/marketplace/catalog.test.ts
@@ -81,12 +81,29 @@ describe('pageCatalogItems', () => {
     const items = [
       ...synthetic(3, (i) => ({ name: `alpha-${i}`, title: `Alpha ${i}`, type: 'registry:skill', registry: 'kortix-starter' })),
       ...synthetic(3, (i) => ({ name: `beta-${i}`, title: `Beta ${i}`, type: 'registry:skill', registry: 'other-registry' })),
-      item({ id: 'hidden-agent', name: 'hidden-agent', title: 'Hidden Agent', type: 'registry:agent', registry: 'kortix-starter' }),
+      item({ id: 'hidden-tool', name: 'hidden-tool', title: 'Hidden Tool', type: 'registry:tool', registry: 'kortix-starter' }),
     ];
     const result = pageCatalogItems(items, { query: 'alpha', source: 'kortix', limit: 2, offset: 0 });
     expect(result.total).toBe(3);
     expect(result.items.length).toBe(2);
     expect(result.items.every((it) => it.name.startsWith('alpha'))).toBe(true);
+  });
+
+  test('surfaces skills, agents, commands, and bundles as browseable; hides support types', () => {
+    const items = [
+      item({ id: 'k:skill', name: 'a-skill', type: 'registry:skill' }),
+      item({ id: 'k:agent', name: 'a-agent', type: 'registry:agent' }),
+      item({ id: 'k:command', name: 'a-command', type: 'registry:command' }),
+      item({ id: 'k:bundle', name: 'a-bundle', type: 'registry:bundle' }),
+      item({ id: 'k:tool', name: 'a-tool', type: 'registry:tool' }),
+      item({ id: 'k:rules', name: 'a-rules', type: 'registry:rules' }),
+    ];
+    const result = pageCatalogItems(items, {});
+    const visible = new Set(result.items.map((it) => it.type));
+    expect(visible).toEqual(
+      new Set(['registry:skill', 'registry:agent', 'registry:command', 'registry:bundle']),
+    );
+    expect(result.total).toBe(4);
   });
 
   test('offset past the end returns empty items, hasMore false, and a correct total', () => {

--- a/apps/api/src/marketplace/catalog.ts
+++ b/apps/api/src/marketplace/catalog.ts
@@ -1428,10 +1428,18 @@ export async function listFeaturedMarketplaces(): Promise<
 // ── public read API ────────────────────────────────────────────────────────
 type ItemQuery = { query?: string; type?: string; source?: string };
 
-// Launch scope: the marketplace is the skill library. Agents, commands, tools,
-// bundles, and support files may still exist in registries for compatibility
-// and dependency resolution, but they are not browse/install choices.
-const MARKETPLACE_VISIBLE_TYPES = new Set<string>(["registry:skill"]);
+// The one-click importables the marketplace surfaces to users: skills, agents,
+// commands, and bundles (curated starters / use-cases). Tools, rules, and other
+// support files still exist in registries for dependency resolution but aren't
+// browse/install choices on their own. Install is capability-gated per committed
+// file path (see projects/routes/r10 assertCommitCapabilities), so widening this
+// set never bypasses authz.
+const MARKETPLACE_VISIBLE_TYPES = new Set<string>([
+  "registry:skill",
+  "registry:agent",
+  "registry:command",
+  "registry:bundle",
+]);
 
 function isBrowseableCatalogItem(it: CatalogItem): boolean {
   return MARKETPLACE_VISIBLE_TYPES.has(it.type) && !it.hidden;

--- a/apps/web/src/features/marketplace/marketplace-grid.test.ts
+++ b/apps/web/src/features/marketplace/marketplace-grid.test.ts
@@ -46,6 +46,23 @@ describe('buildMarketplaceGridRows', () => {
     ]);
   });
 
+  test('groups skills, agents, commands, and bundles into their own sections in taxonomy order', () => {
+    // Interleaved + out of section order on input; grouping must sort into the
+    // TYPE_SECTIONS order regardless.
+    const rows = buildMarketplaceGridRows({
+      items: [
+        ...makeItems('registry:command', ['c1']),
+        ...makeItems('registry:bundle', ['b1']),
+        ...makeItems('registry:skill', ['s1', 's2']),
+        ...makeItems('registry:agent', ['a1']),
+      ],
+      grouped: true,
+    });
+
+    const headers = rows.flatMap((r) => (r.kind === 'header' ? [r.label] : []));
+    expect(headers).toEqual(['Skills', 'Agents', 'Commands', 'Bundles']);
+  });
+
   test('for a large dataset, row count is far smaller than item count', () => {
     const items = makeItems(
       'registry:skill',

--- a/apps/web/src/features/marketplace/marketplace-item-avatar.tsx
+++ b/apps/web/src/features/marketplace/marketplace-item-avatar.tsx
@@ -72,7 +72,8 @@ export type MarketplaceItemAvatarItem = Pick<
 >;
 
 /**
- * Identity tile for a single marketplace ITEM (a skill). Picks a deterministic
+ * Identity tile for a single marketplace ITEM (skill, agent, command, or
+ * bundle). Picks a deterministic
  * icon from the item's name and pins the source avatar as a corner badge for
  * provenance. All deterministic — no flash, no layout shift.
  */

--- a/apps/web/src/features/marketplace/marketplace-meta.tsx
+++ b/apps/web/src/features/marketplace/marketplace-meta.tsx
@@ -59,14 +59,22 @@ export function TypeTile({
   );
 }
 
-// Launch scope: marketplace browsing is the skill library. Keep the visual type
-// taxonomy above for detail/legacy data, but only expose skill filters here.
+// The one-click importables users browse + install. Filters and grouped
+// sections auto-hide any type with no items (marketplace-browser derives
+// `typeOptions` from live typeCounts; marketplace-grid only emits a section for
+// present items), so listing a type here is safe even before content exists.
 export const TYPE_FILTERS: Array<{ value: string; label: string }> = [
   { value: 'all', label: 'All' },
   { value: 'skill', label: 'Skills' },
+  { value: 'agent', label: 'Agents' },
+  { value: 'command', label: 'Commands' },
+  { value: 'bundle', label: 'Bundles' },
 ];
 
 /** Section order + labels for the grouped (filter=All) gallery view. */
 export const TYPE_SECTIONS: Array<{ type: string; label: string }> = [
   { type: 'registry:skill', label: 'Skills' },
+  { type: 'registry:agent', label: 'Agents' },
+  { type: 'registry:command', label: 'Commands' },
+  { type: 'registry:bundle', label: 'Bundles' },
 ];


### PR DESCRIPTION
## What & why
The marketplace already had a full **1-click import** pipeline — registry install, transitive dependency resolution, per-path capability authz, and the item **card / detail / add-to-project** UI — but the browse catalog was gated to **skills only** by a launch-scope allowlist. This widens it to the primitives the task asks for: **skills, agents, commands, and bundles** (curated starters / use-cases).

This also matches copy already shipped on the public marketplace page: _"Browse skills, agents, and commands from every source. Add them to a Kortix project in one click."_

## The change (5 files, +59/-8)
- **`apps/api/src/marketplace/catalog.ts`** — `MARKETPLACE_VISIBLE_TYPES` now includes `registry:{skill,agent,command,bundle}`. This single allowlist drives browse (`filterCatalogItems`), the grouped gallery, the detail endpoint (`getCatalogItemDetail` 404-gates on it), **and** the per-source type-count facets that make the web filters appear.
- **`apps/web/.../marketplace-meta.tsx`** — `TYPE_FILTERS` + `TYPE_SECTIONS` gain Agents / Commands / Bundles (visual `TYPE_META` for these already existed).
- **`marketplace-item-avatar.tsx`** — doc comment accuracy.
- **Tests** — `catalog.test.ts` asserts the four types are browseable and support types (tool/rules) stay hidden; `marketplace-grid.test.ts` asserts items group into their sections in taxonomy order.

## Why it is safe / robust
- **Authz unchanged & enforced.** Install commits are gated by `assertCommitCapabilities`, which maps every committed file path to a capability (`agents/*`→`project.agent.write`, `commands/*`→`project.command.write`, `skills/*`→`project.skill.write`, else `project.file.write`) and asserts **each** one — including every **bundle member**. No default-allow, no privilege escalation; a skill-only role still cannot install an agent. _(Adversarially verified.)_
- **No empty/broken UI.** The browser derives type filters from live `typeCounts` and the grid only emits a section for present items, so Agents/Commands/Bundles surface **only when content exists**. The card/detail/add-flow already render any type generically via `typeMeta` (the card even has a bundle-specific "N items" label).
- **Goes live now:** the 3 seeded bundles become browseable immediately; **agents/commands appear as soon as a registry source provides them.**

> Not merging — leaving that to you since this opens marketplace install to new item types. CI + the Vercel preview will let you see the Agents/Commands/Bundles filters live.