### PR TITLE
fix(config): YAML (v2) manifest parity — agent-scope, trigger paths, format-aware errors

### DIFF
--- a/apps/api/src/__tests__/unit-agent-scope-v2.test.ts
+++ b/apps/api/src/__tests__/unit-agent-scope-v2.test.ts
@@ -1,0 +1,98 @@
+import { describe, test, expect } from 'bun:test';
+import { parseManifestString, serializeManifest } from '../projects/triggers';
+import { applyAgentScopeV2 } from '../projects/lib/agent-config-v2';
+import { extractAgents } from '../projects/agents';
+
+// Regression for the v2-YAML agent-scope bug: the /scope route used
+// applyAgentScope (v1 `[[agents]]` array only), which treated a v2 `agents:` map
+// as an empty array → every scope edit on a YAML project 404'd. applyAgentScopeV2
+// merges into the map correctly: v1 wire `env` ↦ v2 `secrets`, deny-by-default
+// omit, and every other governance field preserved.
+
+const YAML = `kortix_version: 2
+default_agent: kortix
+agents:
+  kortix:
+    connectors: all
+    secrets: all
+    kortix_cli: all
+    skills: all
+  scout:
+    kortix_cli: [project.cr.open]
+    connectors: [github]
+    skills: [research]
+`;
+
+function manifest() {
+  return parseManifestString(YAML, 'yaml', 'kortix.yaml');
+}
+
+describe('applyAgentScopeV2 — v2 agents map scope edit', () => {
+  test('set connectors to a list — updates the map, preserves other governance', () => {
+    const m = manifest();
+    const r = applyAgentScopeV2(m, 'scout', { connectors: ['github', 'linear'] });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    const scout = (r.raw.agents as Record<string, any>).scout;
+    expect(scout.connectors).toEqual(['github', 'linear']);
+    // kortix_cli + skills untouched.
+    expect(scout.kortix_cli).toEqual(['project.cr.open']);
+    expect(scout.skills).toEqual(['research']);
+  });
+
+  test('wire `env` maps to v2 `secrets` (NOT `env`)', () => {
+    const m = manifest();
+    const r = applyAgentScopeV2(m, 'scout', { env: ['API_KEY'] });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    const scout = (r.raw.agents as Record<string, any>).scout;
+    expect(scout.secrets).toEqual(['API_KEY']);
+    expect(scout.env).toBeUndefined(); // never writes the v1 key into a v2 block
+  });
+
+  test("'all' is written explicitly (v2 default is none, not all)", () => {
+    const m = manifest();
+    const r = applyAgentScopeV2(m, 'scout', { env: 'all', connectors: 'all' });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    const scout = (r.raw.agents as Record<string, any>).scout;
+    expect(scout.secrets).toBe('all');
+    expect(scout.connectors).toBe('all');
+  });
+
+  test('empty selection ([] = none) OMITS the key (deny-by-default idiom)', () => {
+    const m = manifest();
+    const r = applyAgentScopeV2(m, 'scout', { env: [], connectors: [] });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    const scout = (r.raw.agents as Record<string, any>).scout;
+    expect(scout).not.toHaveProperty('secrets');
+    expect(scout).not.toHaveProperty('connectors');
+    // Non-scope fields still preserved.
+    expect(scout.kortix_cli).toEqual(['project.cr.open']);
+  });
+
+  test('undeclared agent → notFound (route maps to 404)', () => {
+    const m = manifest();
+    const r = applyAgentScopeV2(m, 'ghost', { connectors: ['x'] });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.notFound).toBe(true);
+  });
+
+  test('round-trips: serialize stays YAML, re-parse reflects the edit via extractAgents', () => {
+    const m = manifest();
+    const r = applyAgentScopeV2(m, 'scout', { connectors: ['github', 'linear'], env: ['API_KEY'] });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    m.raw = r.raw;
+    const out = serializeManifest(m);
+    expect(out).toContain('agents:');
+    expect(out).not.toContain('[[agents]]');
+    const m2 = parseManifestString(out, 'yaml', 'kortix.yaml');
+    const scout = extractAgents(m2).specs.find((s) => s.name === 'scout')!;
+    expect(scout.connectors).toEqual(['github', 'linear']);
+    // extractAgentsV2 surfaces v2 `secrets` as the unified spec.env field.
+    expect(scout.env).toEqual(['API_KEY']);
+  });
+});

--- a/apps/api/src/__tests__/unit-apps-parse.test.ts
+++ b/apps/api/src/__tests__/unit-apps-parse.test.ts
@@ -315,7 +315,8 @@ apps:
 `);
     expect(specs).toEqual([]);
     expect(errors).toHaveLength(1);
-    expect(errors[0]!.error).toMatch(/must be an array of tables/);
+    // YAML manifest → the hint names the YAML shape (a list), not TOML `[[apps]]`.
+    expect(errors[0]!.error).toMatch(/must be a list/);
   });
 
   test('missing slug', () => {

--- a/apps/api/src/__tests__/unit-yaml-config-roundtrip.test.ts
+++ b/apps/api/src/__tests__/unit-yaml-config-roundtrip.test.ts
@@ -1,0 +1,158 @@
+import { describe, test, expect } from 'bun:test';
+import { parseManifestString, serializeManifest, extractTriggers } from '../projects/triggers';
+import { draftToSpec } from '../projects/lib/triggers';
+import { extractAgents } from '../projects/agents';
+import { extractApps } from '../projects/apps';
+import { extractConnectors } from '../projects/connectors';
+
+// Empirical ground truth for the dual-format (TOML v1 + YAML v2) manifest core:
+// parse → extract each resource → serialize → re-parse, for BOTH formats, and
+// prove the write path preserves the file's own format (a .yaml project must
+// never serialize back as TOML).
+
+const YAML_V2 = `kortix_version: 2
+default_agent: kortix
+project:
+  name: probe
+  description: A probe project.
+env:
+  required: []
+  optional: [STRIPE_API_KEY]
+opencode:
+  config_dir: .kortix/opencode
+agents:
+  kortix:
+    connectors: all
+    secrets: all
+    kortix_cli: all
+    skills: all
+  scout:
+    kortix_cli: [project.cr.open]
+    connectors: [github]
+triggers:
+  - slug: nightly
+    name: Nightly
+    type: cron
+    agent: scout
+    enabled: true
+    cron: "0 0 3 * * *"
+    timezone: UTC
+    prompt: do the nightly thing
+`;
+
+const TOML_V1 = `kortix_version = 1
+default_agent = "kortix"
+
+[[agents]]
+name = "kortix"
+env = "all"
+connectors = "all"
+
+[[agents]]
+name = "scout"
+connectors = ["github"]
+
+[[triggers]]
+slug = "nightly"
+name = "Nightly"
+type = "cron"
+agent = "kortix"
+enabled = true
+cron = "0 0 3 * * *"
+prompt = "do the nightly thing"
+`;
+
+describe('YAML v2 manifest — parse + extract', () => {
+  const m = parseManifestString(YAML_V2, 'yaml', 'kortix.yaml');
+
+  test('parses as yaml, schema v2, format/path threaded', () => {
+    expect(m.format).toBe('yaml');
+    expect(m.path).toBe('kortix.yaml');
+    expect(m.schemaVersion).toBe(2);
+  });
+
+  test('extractAgents reads the v2 agents MAP', () => {
+    const { specs, errors } = extractAgents(m);
+    expect(errors).toEqual([]);
+    const names = specs.map((s) => s.name).sort();
+    expect(names).toEqual(['kortix', 'scout']);
+    const scout = specs.find((s) => s.name === 'scout')!;
+    expect(scout.kortixCli).toEqual(['project.cr.open']);
+    expect(scout.connectors).toEqual(['github']);
+    const kortix = specs.find((s) => s.name === 'kortix')!;
+    expect(kortix.connectors).toBe('all');
+  });
+
+  test('extractTriggers reads the yaml triggers list', () => {
+    const { specs, errors } = extractTriggers(m);
+    expect(errors).toEqual([]);
+    expect(specs.map((s) => s.slug)).toEqual(['nightly']);
+    expect(specs[0].agent).toBe('scout');
+  });
+
+  test('extractApps / extractConnectors never throw on a yaml manifest', () => {
+    expect(() => extractApps(m)).not.toThrow();
+    expect(() => extractConnectors(m)).not.toThrow();
+  });
+});
+
+describe('TOML v1 manifest — parse + extract (parity)', () => {
+  const m = parseManifestString(TOML_V1, 'toml', 'kortix.toml');
+
+  test('parses as toml, schema v1', () => {
+    expect(m.format).toBe('toml');
+    expect(m.schemaVersion).toBe(1);
+  });
+
+  test('extractAgents reads the v1 [[agents]] ARRAY', () => {
+    const { specs, errors } = extractAgents(m);
+    expect(errors).toEqual([]);
+    expect(specs.map((s) => s.name).sort()).toEqual(['kortix', 'scout']);
+    expect(specs.find((s) => s.name === 'scout')!.connectors).toEqual(['github']);
+  });
+
+  test('extractTriggers reads the toml [[triggers]] array', () => {
+    const { specs, errors } = extractTriggers(m);
+    expect(errors).toEqual([]);
+    expect(specs.map((s) => s.slug)).toEqual(['nightly']);
+  });
+});
+
+describe('round-trip serialize preserves the file format', () => {
+  test('yaml manifest → serialize stays YAML (agents map, not [[agents]]) + re-parses equal', () => {
+    const m = parseManifestString(YAML_V2, 'yaml', 'kortix.yaml');
+    const out = serializeManifest(m);
+    expect(out).toMatch(/^kortix_version: 2/m); // yaml scalar, not `kortix_version = 2`
+    expect(out).toContain('agents:');
+    expect(out).not.toContain('[[agents]]');
+    // Re-parse and confirm no data loss on the round-trip.
+    const m2 = parseManifestString(out, 'yaml', 'kortix.yaml');
+    expect(extractAgents(m2).specs.map((s) => s.name).sort()).toEqual(['kortix', 'scout']);
+    expect(extractTriggers(m2).specs.map((s) => s.slug)).toEqual(['nightly']);
+  });
+
+  test('toml manifest → serialize stays TOML ([[agents]], not agents:)', () => {
+    const m = parseManifestString(TOML_V1, 'toml', 'kortix.toml');
+    const out = serializeManifest(m);
+    expect(out).toMatch(/kortix_version = 1/);
+    expect(out).toContain('[[agents]]');
+    const m2 = parseManifestString(out, 'toml', 'kortix.toml');
+    expect(extractAgents(m2).specs.map((s) => s.name).sort()).toEqual(['kortix', 'scout']);
+  });
+});
+
+describe('draftToSpec — new trigger spec path uses the real manifest file', () => {
+  const draft = {
+    slug: 'nightly', name: 'Nightly', type: 'cron' as const, agent: 'kortix', model: null,
+    enabled: true, promptTemplate: 'do it', cron: '0 0 3 * * *', runAt: null,
+    timezone: 'UTC', secretEnv: null, sessionMode: 'fresh' as const,
+  };
+
+  test('YAML project → path is kortix.yaml#triggers.<slug> (not hardcoded toml)', () => {
+    expect(draftToSpec(draft, 'kortix.yaml').path).toBe('kortix.yaml#triggers.nightly');
+  });
+
+  test('TOML default preserved when no path passed', () => {
+    expect(draftToSpec(draft).path).toBe('kortix.toml#triggers.nightly');
+  });
+});

--- a/apps/api/src/projects/agents.ts
+++ b/apps/api/src/projects/agents.ts
@@ -152,7 +152,10 @@ export function extractAgents(manifest: ParsedManifest): LoadedAgents {
       errors: [{
         name: '(top-level)',
         path: filename,
-        error: '`agents` must be an array of tables — use [[agents]], not [agents]',
+        error:
+          manifest.format === 'yaml'
+            ? '`agents` must be a list — write it as a YAML `agents:` list (or a name→block map in v2), not a scalar.'
+            : '`agents` must be an array of tables — use [[agents]], not [agents]',
       }],
       defaultAgent: null,
     };

--- a/apps/api/src/projects/apps.ts
+++ b/apps/api/src/projects/apps.ts
@@ -88,7 +88,10 @@ export function extractApps(manifest: ParsedManifest): LoadedApps {
       errors: [{
         slug: '(top-level)',
         path: filename,
-        error: '`apps` must be an array of tables — use [[apps]], not [apps]',
+        error:
+          manifest.format === 'yaml'
+            ? '`apps` must be a list — write it as a YAML `apps:` list, not a map or scalar.'
+            : '`apps` must be an array of tables — use [[apps]], not [apps]',
       }],
     };
   }

--- a/apps/api/src/projects/connectors.ts
+++ b/apps/api/src/projects/connectors.ts
@@ -167,7 +167,10 @@ export function extractConnectors(manifest: ParsedManifest): LoadedConnectors {
       errors: [{
         slug: '(top-level)',
         path: filename,
-        error: '`connectors` must be an array of tables — use [[connectors]], not [connectors]',
+        error:
+          manifest.format === 'yaml'
+            ? '`connectors` must be a list — write it as a YAML `connectors:` list, not a map or scalar.'
+            : '`connectors` must be an array of tables — use [[connectors]], not [connectors]',
       }],
     };
   }

--- a/apps/api/src/projects/lib/agent-config-v2.ts
+++ b/apps/api/src/projects/lib/agent-config-v2.ts
@@ -126,3 +126,52 @@ export function applyAgentBlockV2(
   }
   return { ok: true, raw: nextRaw };
 }
+
+/**
+ * Apply a secrets/connectors SCOPE edit to a v2 `agents:` MAP manifest — the v2
+ * counterpart of `applyAgentScope` in `../agents.ts` (which only handles the v1
+ * `[[agents]]` array and would treat a v2 map as an empty array → "agent not
+ * found"). Reads the agent's existing governance block, merges in JUST the two
+ * scope grants, and reuses `applyAgentBlockV2` for the upsert + `validateManifest`
+ * gate (so every other governance field on the block is preserved verbatim).
+ *
+ * Two v2 semantics the v1 path gets wrong: (1) v1's wire `env` is v2's `secrets`
+ * key; (2) v2 is deny-by-default, so a none/`[]` selection is written by OMITTING
+ * the key (matching hand-authored kortix.yaml), NOT by v1's env-default-is-'all'
+ * omit rule. `notFound` distinguishes "agent not declared" (route → 404) from a
+ * validation failure (route → 400) — this path scopes an existing agent, it
+ * never creates one.
+ */
+export function applyAgentScopeV2(
+  manifest: ParsedManifest,
+  agentName: string,
+  scope: { env?: string[] | 'all'; connectors?: string[] | 'all' },
+): ApplyAgentBlockResult & { notFound?: boolean } {
+  const rawAgents = manifest.raw.agents;
+  const existing =
+    rawAgents && typeof rawAgents === 'object' && !Array.isArray(rawAgents)
+      ? (rawAgents as Record<string, unknown>)[agentName]
+      : undefined;
+  if (existing === undefined || existing === null) {
+    return {
+      ok: false,
+      notFound: true,
+      error: `No agent "${agentName}" declared in ${manifest.path || 'kortix.yaml'}`,
+    };
+  }
+  if (typeof existing !== 'object' || Array.isArray(existing)) {
+    return { ok: false, error: `agents.${agentName} is malformed (expected a table/object).` };
+  }
+  const merged: Record<string, unknown> = { ...(existing as Record<string, unknown>) };
+  if (scope.env !== undefined) {
+    if (scope.env === 'all') merged.secrets = 'all';
+    else if (scope.env.length === 0) delete merged.secrets;
+    else merged.secrets = scope.env;
+  }
+  if (scope.connectors !== undefined) {
+    if (scope.connectors === 'all') merged.connectors = 'all';
+    else if (scope.connectors.length === 0) delete merged.connectors;
+    else merged.connectors = scope.connectors;
+  }
+  return applyAgentBlockV2(manifest, agentName, merged as AgentBlockV2);
+}

--- a/apps/api/src/projects/lib/triggers.ts
+++ b/apps/api/src/projects/lib/triggers.ts
@@ -1223,10 +1223,12 @@ export function slugify(input: string): string {
   );
 }
 
-export function draftToSpec(draft: TriggerDraft): GitTriggerSpec {
+export function draftToSpec(draft: TriggerDraft, manifestPath: string = MANIFEST_FILENAME): GitTriggerSpec {
   return {
     slug: draft.slug,
-    path: `${MANIFEST_FILENAME}#triggers.${draft.slug}`,
+    // Use the ACTUAL manifest path so a YAML project's trigger spec reports
+    // `kortix.yaml#triggers.<slug>`, not a hardcoded `kortix.toml#…`.
+    path: `${manifestPath}#triggers.${draft.slug}`,
     name: draft.name,
     type: draft.type,
     agent: draft.agent,

--- a/apps/api/src/projects/policies.ts
+++ b/apps/api/src/projects/policies.ts
@@ -52,20 +52,23 @@ const DEFAULT_SETTINGS: ProjectPolicySettings = { defaultMode: 'allow_all' };
  */
 export function extractProjectPolicies(manifest: ParsedManifest): LoadedProjectPolicies {
   const errors: ProjectPolicyParseError[] = [];
+  // Use the ACTUAL manifest file in error paths so a YAML project reports
+  // `kortix.yaml#policy`, not a hardcoded `kortix.toml#…`.
+  const filename = manifest.path || MANIFEST_FILENAME;
 
   // ── policy block (default_mode) ────────────────────────────────────────────
   let settings: ProjectPolicySettings = { ...DEFAULT_SETTINGS };
   const policyBlock = manifest.raw.policy;
   if (policyBlock !== undefined && policyBlock !== null) {
     if (typeof policyBlock !== 'object' || Array.isArray(policyBlock)) {
-      errors.push({ path: `${MANIFEST_FILENAME}#policy`, error: '`policy` must be an object' });
+      errors.push({ path: `${filename}#policy`, error: '`policy` must be an object' });
     } else {
       const row = policyBlock as Record<string, unknown>;
       if (row.default_mode !== undefined) {
         const mode = typeof row.default_mode === 'string' ? row.default_mode.trim().toLowerCase() : '';
         if (!DEFAULT_MODES.includes(mode as DefaultMode)) {
           errors.push({
-            path: `${MANIFEST_FILENAME}#policy.default_mode`,
+            path: `${filename}#policy.default_mode`,
             error: `policy.default_mode must be one of ${DEFAULT_MODES.join(', ')} (got "${mode || 'unset'}")`,
           });
         } else {
@@ -81,12 +84,12 @@ export function extractProjectPolicies(manifest: ParsedManifest): LoadedProjectP
   if (raw !== undefined && raw !== null) {
     if (!Array.isArray(raw)) {
       errors.push({
-        path: MANIFEST_FILENAME,
+        path: filename,
         error: '`policies` must be an array of tables — a YAML list (or a legacy TOML [[policies]]), not a single mapping',
       });
     } else {
       raw.forEach((entry, i) => {
-        const path = `${MANIFEST_FILENAME}#policies[${i}]`;
+        const path = `${filename}#policies[${i}]`;
         if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
           errors.push({ path, error: `policies entry #${i + 1} is not an object` });
           return;

--- a/apps/api/src/projects/routes/agent-scope.ts
+++ b/apps/api/src/projects/routes/agent-scope.ts
@@ -19,6 +19,7 @@
 import { createRoute, z } from '@hono/zod-openapi';
 import { auth, errors, json } from '../../openapi';
 import { applyAgentScope, extractAgents } from '../agents';
+import { applyAgentScopeV2 } from '../lib/agent-config-v2';
 import { assertProjectCapability, loadProjectForUser } from '../lib/access';
 import { projectsApp } from '../lib/app';
 import { PROJECT_ACTIONS } from '../../iam';
@@ -75,14 +76,27 @@ projectsApp.openapi(
       );
     }
 
-    // The agent must already be declared — this route scopes an existing
-    // `[[agents]]`, it doesn't create the roster entry (that's a fuller edit).
-    const current = Array.isArray(manifest.raw.agents)
-      ? (manifest.raw.agents as Record<string, unknown>[])
-      : [];
-    const applied = applyAgentScope(current, agentName, { env, connectors }, manifest.path);
-    if (!applied.ok) return c.json({ error: applied.error, code: 'agent_not_found' }, 404);
-    manifest.raw.agents = applied.agents;
+    // The agent must already be declared — this route SCOPES an existing agent,
+    // it doesn't create the roster entry (that's the fuller /config editor). v1
+    // stores agents as a `[[agents]]` array; v2 (kortix.yaml) as an `agents:`
+    // map. The v1-only path treated a v2 map as an empty array, so EVERY scope
+    // edit on a YAML project 404'd "agent not found" — branch on the schema.
+    if (manifest.schemaVersion >= 2) {
+      const applied = applyAgentScopeV2(manifest, agentName, { env, connectors });
+      if (!applied.ok) {
+        return applied.notFound
+          ? c.json({ error: applied.error, code: 'agent_not_found' }, 404)
+          : c.json({ error: applied.error, code: 'invalid_scope', issues: applied.issues }, 400);
+      }
+      manifest.raw = applied.raw;
+    } else {
+      const current = Array.isArray(manifest.raw.agents)
+        ? (manifest.raw.agents as Record<string, unknown>[])
+        : [];
+      const applied = applyAgentScope(current, agentName, { env, connectors }, manifest.path);
+      if (!applied.ok) return c.json({ error: applied.error, code: 'agent_not_found' }, 404);
+      manifest.raw.agents = applied.agents;
+    }
 
     // Shape-validate through the real parser before committing — a malformed
     // grant set is a clean 400, never a broken manifest.

--- a/apps/api/src/projects/routes/r4.ts
+++ b/apps/api/src/projects/routes/r4.ts
@@ -202,7 +202,7 @@ projectsApp.openapi(
       );
     }
 
-    const next = upsertTriggerInManifest(manifest, draftToSpec(draft));
+    const next = upsertTriggerInManifest(manifest, draftToSpec(draft, manifest.path));
     const result = await commitManifest(
       loaded.row,
       next,
@@ -322,7 +322,7 @@ projectsApp.openapi(
       );
       if ("error" in draft) return c.json({ error: draft.error }, 400);
 
-      const next = upsertTriggerInManifest(manifest, draftToSpec(draft));
+      const next = upsertTriggerInManifest(manifest, draftToSpec(draft, manifest.path));
       const result = await commitManifest(
         loaded.row,
         next,

--- a/apps/api/src/projects/triggers.ts
+++ b/apps/api/src/projects/triggers.ts
@@ -258,7 +258,10 @@ export function extractTriggers(manifest: ParsedManifest): LoadedTriggers {
         {
           slug: '(top-level)',
           path: filename,
-          error: '`triggers` must be an array of tables — use [[triggers]], not [triggers]',
+          error:
+            manifest.format === 'yaml'
+              ? '`triggers` must be a list — write it as a YAML `triggers:` list, not a map or scalar.'
+              : '`triggers` must be an array of tables — use [[triggers]], not [triggers]',
         },
       ],
     };

--- a/packages/manifest-schema/src/__tests__/format_error_message_bug.test.ts
+++ b/packages/manifest-schema/src/__tests__/format_error_message_bug.test.ts
@@ -1,0 +1,55 @@
+import { describe, test, expect } from 'bun:test';
+import { validateManifest } from '../index';
+
+// Regression: a manifest section-SHAPE error must reference the syntax that fits
+// the FILE'S format. A YAML author who writes `triggers:` as a map/scalar must
+// be told to use a YAML list — never "use `[[triggers]]`" (TOML table-array),
+// and vice-versa. Each `*Bad` input below malforms exactly one section (a
+// single table/map where a list is required) so the list-shape validator fires.
+describe('manifest error messages are format-aware (YAML vs TOML)', () => {
+  const cases = [
+    {
+      name: 'agents',
+      toml: '[[agents]]',
+      yamlBad: `kortix_version: 1\nagents:\n  name: test`,
+      tomlBad: `kortix_version = 1\n[agents]\nname = "test"`,
+    },
+    {
+      name: 'connectors',
+      toml: '[[connectors]]',
+      yamlBad: `kortix_version: 1\nconnectors:\n  name: test`,
+      tomlBad: `kortix_version = 1\n[connectors]\nname = "test"`,
+    },
+    {
+      name: 'triggers',
+      toml: '[[triggers]]',
+      yamlBad: `kortix_version: 1\ntriggers:\n  slug: test`,
+      tomlBad: `kortix_version = 1\n[triggers]\nslug = "test"`,
+    },
+    {
+      name: 'sandbox.templates',
+      toml: '[[sandbox.templates]]',
+      yamlBad: `kortix_version: 1\nsandbox:\n  templates:\n    slug: test`,
+      tomlBad: `kortix_version = 1\n[sandbox.templates]\nslug = "test"`,
+    },
+  ];
+
+  const errText = (input: string, fmt: 'yaml' | 'toml') =>
+    validateManifest(input, fmt)
+      .issues.filter((i) => i.severity === 'error')
+      .map((i) => i.message)
+      .join(' | ');
+
+  for (const c of cases) {
+    test(`${c.name} — YAML shape error says "list", never the TOML ${c.toml}`, () => {
+      const e = errText(c.yamlBad, 'yaml');
+      expect(e).toContain('must be a list');
+      expect(e).not.toContain(c.toml);
+    });
+
+    test(`${c.name} — TOML shape error references ${c.toml}`, () => {
+      const e = errText(c.tomlBad, 'toml');
+      expect(e).toContain(c.toml);
+    });
+  }
+});

--- a/packages/manifest-schema/src/index.ts
+++ b/packages/manifest-schema/src/index.ts
@@ -202,9 +202,9 @@ export function validateManifest(
   const version = validateRoot(parsed, format, issues);
 
   if (version === 2) {
-    validateManifestBodyV2(parsed, issues);
+    validateManifestBodyV2(parsed, format, issues);
   } else {
-    validateManifestBodyV1(parsed, issues);
+    validateManifestBodyV1(parsed, format, issues);
   }
 
   return {
@@ -219,17 +219,21 @@ export function validateManifest(
  * Byte-for-byte the same calls as always; v1 manifests must keep validating
  * identically no matter what v2 support is added alongside it.
  */
-function validateManifestBodyV1(parsed: Record<string, unknown>, issues: ManifestIssue[]): void {
+function validateManifestBodyV1(
+  parsed: Record<string, unknown>,
+  format: ManifestFormat,
+  issues: ManifestIssue[],
+): void {
   validateProject(parsed.project, 'project', issues);
   validateEnv(parsed.env, 'env', issues);
   validateOpenCode(parsed.opencode, 'opencode', issues);
-  validateSandbox(parsed.sandbox, 'sandbox', issues);
+  validateSandbox(parsed.sandbox, 'sandbox', issues, format);
   rejectLegacySandboxes(parsed.sandboxes, 'sandboxes', issues);
-  validateTriggers(parsed.triggers, 'triggers', issues);
-  validateConnectors(parsed.connectors, 'connectors', issues, 1);
-  validateAgents(parsed.agents, 'agents', issues);
-  validateChannels(parsed.channels, 'channels', issues);
-  validateApps(parsed.apps, 'apps', issues);
+  validateTriggers(parsed.triggers, 'triggers', issues, format);
+  validateConnectors(parsed.connectors, 'connectors', issues, 1, format);
+  validateAgents(parsed.agents, 'agents', issues, format);
+  validateChannels(parsed.channels, 'channels', issues, format);
+  validateApps(parsed.apps, 'apps', issues, format);
 }
 
 /**
@@ -239,15 +243,19 @@ function validateManifestBodyV1(parsed: Record<string, unknown>, issues: Manifes
  * is removed (§2.5), and `default_agent` + `runtime` are new top-level keys
  * (§2.1/§2.3).
  */
-function validateManifestBodyV2(parsed: Record<string, unknown>, issues: ManifestIssue[]): void {
+function validateManifestBodyV2(
+  parsed: Record<string, unknown>,
+  format: ManifestFormat,
+  issues: ManifestIssue[],
+): void {
   validateProject(parsed.project, 'project', issues);
   validateEnv(parsed.env, 'env', issues);
   validateOpenCode(parsed.opencode, 'opencode', issues);
-  validateSandbox(parsed.sandbox, 'sandbox', issues);
+  validateSandbox(parsed.sandbox, 'sandbox', issues, format);
   rejectLegacySandboxes(parsed.sandboxes, 'sandboxes', issues);
-  validateTriggers(parsed.triggers, 'triggers', issues);
-  validateConnectors(parsed.connectors, 'connectors', issues, 2);
-  validateApps(parsed.apps, 'apps', issues);
+  validateTriggers(parsed.triggers, 'triggers', issues, format);
+  validateConnectors(parsed.connectors, 'connectors', issues, 2, format);
+  validateApps(parsed.apps, 'apps', issues, format);
   rejectChannelsV2(parsed.channels, 'channels', issues);
   validateRuntimeV2(parsed.runtime, 'runtime', issues);
   const { names: agentNames, disabledNames } = validateAgentsV2(parsed.agents, 'agents', issues);
@@ -268,6 +276,19 @@ export function formatIssues(issues: ManifestIssue[], opts: { color?: boolean } 
       return `  ${tag} ${dim(i.path)}: ${i.message}${where}`;
     })
     .join('\n');
+}
+
+/**
+ * A format-appropriate "this section must be a list" hint. Legacy TOML uses
+ * `[[key]]` table-arrays; YAML (every v2 manifest, and any v1 YAML) uses a
+ * plain `key:` list — so a YAML author who malforms a section should never be
+ * told to "use `[[triggers]]`". Defaults to TOML so v1 TOML messages stay
+ * byte-for-byte identical.
+ */
+function listSectionHint(key: string, format: ManifestFormat = 'toml'): string {
+  return format === 'yaml'
+    ? `\`${key}\` must be a list of entries — write it as a YAML \`${key}:\` list, not a map or scalar.`
+    : `\`${key}\` must be an array of tables — use \`[[${key}]]\`.`;
 }
 
 // ─── Section validators ───────────────────────────────────────────────────
@@ -348,12 +369,12 @@ export function validateGrantList(
 }
 
 /** `[[agents]]` — the per-agent scoping overlay (name + connectors + kortix_cli). */
-function validateAgents(node: unknown, path: string, issues: ManifestIssue[]): void {
+function validateAgents(node: unknown, path: string, issues: ManifestIssue[], format: ManifestFormat = 'toml'): void {
   if (node == null) return;
   if (!Array.isArray(node)) {
     issues.push({
       path,
-      message: '`agents` must be an array of tables — use `[[agents]]`.',
+      message: listSectionHint('agents', format),
       severity: 'error',
     });
     return;
@@ -516,7 +537,7 @@ function validateOpenCode(node: unknown, path: string, issues: ManifestIssue[]):
  * carries no direct image keys — those belonged to the removed singular
  * `[sandbox]` table, so any that linger are flagged as legacy.
  */
-function validateSandbox(node: unknown, path: string, issues: ManifestIssue[]): void {
+function validateSandbox(node: unknown, path: string, issues: ManifestIssue[], format: ManifestFormat = 'toml'): void {
   if (node == null) return;
   if (!isTable(node)) {
     issues.push({
@@ -538,7 +559,7 @@ function validateSandbox(node: unknown, path: string, issues: ManifestIssue[]): 
       severity: 'error',
     });
   }
-  validateSandboxTemplates(node.templates, `${path}.templates`, issues);
+  validateSandboxTemplates(node.templates, `${path}.templates`, issues, format);
 
   // `default` selects which template EVERY session in the project boots
   // (UI, triggers, channels) without passing `sandbox_slug`. It must name a
@@ -573,13 +594,13 @@ function validateSandbox(node: unknown, path: string, issues: ManifestIssue[]): 
   }
 }
 
-function validateSandboxTemplates(node: unknown, path: string, issues: ManifestIssue[]): void {
+function validateSandboxTemplates(node: unknown, path: string, issues: ManifestIssue[], format: ManifestFormat = 'toml'): void {
   if (node == null) return;
   if (!Array.isArray(node)) {
     issues.push({
       path,
       message:
-        '`sandbox.templates` must be an array of tables — use `[[sandbox.templates]]`, not `[sandbox.templates]`.',
+        listSectionHint('sandbox.templates', format),
       severity: 'error',
     });
     return;
@@ -685,12 +706,12 @@ function rejectLegacySandboxes(node: unknown, path: string, issues: ManifestIssu
   });
 }
 
-function validateTriggers(node: unknown, path: string, issues: ManifestIssue[]): void {
+function validateTriggers(node: unknown, path: string, issues: ManifestIssue[], format: ManifestFormat = 'toml'): void {
   if (node == null) return;
   if (!Array.isArray(node)) {
     issues.push({
       path,
-      message: '`triggers` must be an array of tables — use `[[triggers]]`.',
+      message: listSectionHint('triggers', format),
       severity: 'error',
     });
     return;
@@ -841,12 +862,12 @@ function validateTriggers(node: unknown, path: string, issues: ManifestIssue[]):
   });
 }
 
-function validateConnectors(node: unknown, path: string, issues: ManifestIssue[], version: 1 | 2 = 1): void {
+function validateConnectors(node: unknown, path: string, issues: ManifestIssue[], version: 1 | 2 = 1, format: ManifestFormat = 'toml'): void {
   if (node == null) return;
   if (!Array.isArray(node)) {
     issues.push({
       path,
-      message: '`connectors` must be an array of tables — use `[[connectors]]`.',
+      message: listSectionHint('connectors', format),
       severity: 'error',
     });
     return;
@@ -1107,12 +1128,12 @@ function validateConnectors(node: unknown, path: string, issues: ManifestIssue[]
   });
 }
 
-function validateChannels(node: unknown, path: string, issues: ManifestIssue[]): void {
+function validateChannels(node: unknown, path: string, issues: ManifestIssue[], format: ManifestFormat = 'toml'): void {
   if (node == null) return;
   if (!Array.isArray(node)) {
     issues.push({
       path,
-      message: '`channels` must be an array of tables — use `[[channels]]`.',
+      message: listSectionHint('channels', format),
       severity: 'error',
     });
     return;
@@ -1169,12 +1190,12 @@ function validateChannels(node: unknown, path: string, issues: ManifestIssue[]):
   });
 }
 
-function validateApps(node: unknown, path: string, issues: ManifestIssue[]): void {
+function validateApps(node: unknown, path: string, issues: ManifestIssue[], format: ManifestFormat = 'toml'): void {
   if (node == null) return;
   if (!Array.isArray(node)) {
     issues.push({
       path,
-      message: '`apps` must be an array of tables — use `[[apps]]`.',
+      message: listSectionHint('apps', format),
       severity: 'error',
     });
     return;


### PR DESCRIPTION
## What

You asked me to test the whole dual-format config system (legacy **TOML v1** + **YAML v2**) and fix what's broken. I audited every manifest consumer + write path (parallel audit workflow, 22 candidates → 19 confirmed after adversarial verify) and empirically round-trip-probed both formats. The core (parse/serialize/extract) is solid; these are the real gaps.

## Functional bugs — v2 YAML was actually broken

- **Agent scope editor 404'd on every YAML project.** `PUT /agents/:name/scope` used `applyAgentScope`, which only understands the v1 `[[agents]]` **array** — a v2 `agents:` **map** got coerced to `[]`, so the "Access scope" editor (Customize → Agents) always returned *"agent not found."* New `applyAgentScopeV2` merges into the map correctly: v1 wire `env` ↦ v2 `secrets`, deny-by-default omit, every other governance field preserved, reusing `applyAgentBlockV2`'s validation. The route branches on `schemaVersion`.
  - (The audit's suggested fix — array↔map roundtrip — was itself buggy: it would write the v1 `env` key into a v2 block instead of `secrets`. Used the correct rename instead.)
- **New/edited triggers reported the wrong file.** `draftToSpec` hardcoded `kortix.toml` in the spec path; a YAML project's trigger spec said `kortix.toml#triggers.<slug>`. Now threads the real `manifest.path` (both r4 call sites).

## Polish — format-aware error messages

A YAML author who malformed a section was told to *"use `[[triggers]]`"* (TOML). Fixed on both paths:
- **manifest-schema validators** (save path: triggers/connectors/apps/sandbox/agents/channels) now take `format` and emit *"must be a list"* for YAML vs the `[[…]]` hint for TOML. Threaded from `validateManifest`; **default `'toml'` keeps every v1 TOML message byte-for-byte identical**.
- **apps/api extractors** (read path: agents/apps/connectors/triggers) + policies error paths use the file's actual format/path, not a hardcoded `kortix.toml`.

## Deliberately NOT changed (verified non-bugs)
- `snapshots/templates.ts` `source: 'toml'` — a typed `'platform'|'toml'|'ui'` **provenance** enum meaning "from the committed manifest", not a format flag; `'yaml'` isn't a valid value and changing it would break the union + consumers.
- `legacy-migration.ts` `manifestPath: 'kortix.toml'` and a couple of `MANIFEST_FILENAME` fallbacks — verified intentional / unreachable.

## Tests
- `unit-agent-scope-v2` — map edit, `env`→`secrets`, deny-by-default omit, field preservation, not-found, YAML round-trip.
- `unit-yaml-config-roundtrip` — parse/extract/serialize for both formats + format preservation + `draftToSpec` path.
- Rewrote `format_error_message_bug.test.ts` (was a no-op `console.log` placeholder) into a real regression test asserting YAML→"list" / TOML→"[[…]]" across sections; updated the `apps-parse` assertion.

All manifest/agents/triggers/apps/policies suites green (500+ assertions). The lone `manifest-schema` failure is a **pre-existing** missing `ajv` dev-dep on `main` (`Cannot find module 'ajv/dist/2020'`), unrelated to this change.

## Note
There's a stray **untracked** `packages/manifest-schema/src/__tests__/test_agents_yaml_bug.test.ts` (a bug-demo with `console.log` assertions) in the working tree — superseded by the rewritten regression test; safe to delete.