### PR TITLE
feat(web): UX & functionality improvements — marketplace, review center, customize, projects/sessions

### DIFF
--- a/apps/web/src/app/(app)/projects/page.tsx
+++ b/apps/web/src/app/(app)/projects/page.tsx
@@ -6,9 +6,10 @@ import Link from 'next/link';
 
 import { PersonalOnboardingWelcome } from '@/components/projects/personal-onboarding-welcome';
 import { Button } from '@/components/ui/button';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { EntityAvatar } from '@/components/ui/entity-avatar';
+import { InfoBanner } from '@/components/ui/info-banner';
 import { Input } from '@/components/ui/input';
-import { SectionCard } from '@/components/ui/section-card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { errorToast, successToast } from '@/components/ui/toast';
@@ -17,6 +18,7 @@ import { UpgradeButton } from '@/features/billing/upgrade-button';
 import { Icon } from '@/features/icon/icon';
 import { AppHeader } from '@/features/layout/app-header';
 import { EmptyState } from '@/features/layout/section/empty-state';
+import { ErrorState } from '@/features/layout/section/error-state';
 import { ProjectCreateModal } from '@/features/projects/modal/project-create-modal';
 import { RenameProjectDialog } from '@/features/projects/modal/rename-project-modal';
 import NewProjectControl from '@/features/projects/new-project-control';
@@ -41,7 +43,7 @@ import {
 } from '@kortix/sdk/projects-client';
 import { Search } from '@mynaui/icons-react';
 import { useMutation, useQueries, useQuery, useQueryClient } from '@tanstack/react-query';
-import { AlertCircle, FolderPlus } from 'lucide-react';
+import { FolderPlus } from 'lucide-react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
@@ -89,6 +91,7 @@ export default function ProjectsPage() {
   const [query, setQuery] = useState('');
   const [archivingId, setArchivingId] = useState<string | null>(null);
   const [renameTarget, setRenameTarget] = useState<KortixProject | null>(null);
+  const [archiveTarget, setArchiveTarget] = useState<KortixProject | null>(null);
   const [modalOpen, setModalOpen] = useState(false);
   const [createAccountId, setCreateAccountId] = useState<string | null>(null);
   const searchParams = useSearchParams();
@@ -291,14 +294,21 @@ export default function ProjectsPage() {
     mutationFn: archiveProject,
     onMutate: (projectId) => setArchivingId(projectId),
     onSettled: () => setArchivingId(null),
-    onSuccess: () => {
+    onSuccess: (_data, projectId) => {
       queryClient.invalidateQueries({ queryKey: ['projects'] });
-      successToast('Project archived');
+      const name = projectId === archiveTarget?.project_id ? archiveTarget?.name : undefined;
+      successToast(name ? `"${name}" archived` : 'Project archived');
+      setArchiveTarget(null);
     },
     onError: (error: Error) => {
       errorToast(error.message || 'Failed to archive project');
     },
   });
+
+  const confirmArchive = () => {
+    if (!archiveTarget || archiveMutation.isPending) return;
+    archiveMutation.mutate(archiveTarget.project_id);
+  };
 
   const filtered = useMemo(
     () => filterProjects(projectsQuery.data ?? []),
@@ -336,8 +346,11 @@ export default function ProjectsPage() {
   const allFilteredTotal = accountGroups.reduce((n, g) => n + g.projects.length, 0);
   const showAllLoading =
     viewAll && (accountsQuery.isLoading || allAccountQueries.some((q) => q.isLoading));
-  const showAllEmpty = viewAll && !showAllLoading && allRawTotal === 0;
-  const showAllNoResults = viewAll && !showAllLoading && allRawTotal > 0 && allFilteredTotal === 0;
+  const failedAllAccountQueries = viewAll ? allAccountQueries.filter((q) => q.isError) : [];
+  const showAllError = viewAll && !showAllLoading && failedAllAccountQueries.length > 0;
+  const showAllEmpty = viewAll && !showAllLoading && !showAllError && allRawTotal === 0;
+  const showAllNoResults =
+    viewAll && !showAllLoading && !showAllError && allRawTotal > 0 && allFilteredTotal === 0;
 
   const openCreateModal = (accountId: string | null) => {
     setCreateAccountId(accountId);
@@ -423,58 +436,51 @@ export default function ProjectsPage() {
               )}
 
               {projectsQuery.isError && (
-                <SectionCard flush>
-                  <EmptyState
-                    icon={AlertCircle}
-                    title={tHardcodedUi.raw(
-                      'appProjectsPage.line252JsxAttrTitleFailedToLoadProjects',
-                    )}
-                    description={(projectsQuery.error as Error).message}
-                    action={
-                      <Button variant="outline" size="sm" onClick={() => projectsQuery.refetch()}>
-                        Retry
-                      </Button>
-                    }
-                  />
-                </SectionCard>
+                <ErrorState
+                  title={tHardcodedUi.raw(
+                    'appProjectsPage.line252JsxAttrTitleFailedToLoadProjects',
+                  )}
+                  description={(projectsQuery.error as Error).message}
+                  action={
+                    <Button variant="outline" size="sm" onClick={() => projectsQuery.refetch()}>
+                      Retry
+                    </Button>
+                  }
+                />
               )}
 
               {showEmptyState && (
-                <SectionCard flush>
-                  <EmptyState
-                    icon={FolderPlus}
-                    title={tI18nHardcoded.raw(
-                      'autoAppAppProjectsPageJsxAttrTitleNoProjectsYet85527dd3',
-                    )}
-                    description={tI18nHardcoded.raw(
-                      'autoAppAppProjectsPageJsxAttrDescriptionAProjectIsa4dc84d2',
-                    )}
-                    action={
-                      <Button
-                        onClick={() => openCreateModal(activeAccountId)}
-                        disabled={!canCreateProjects}
-                      >
-                        <Icon.Plus />
-                        {tI18nHardcoded.raw(
-                          'autoAppAppProjectsPageJsxTextCreateYourFirstProject061cafdb',
-                        )}
-                      </Button>
-                    }
-                  />
-                </SectionCard>
+                <EmptyState
+                  icon={FolderPlus}
+                  title={tI18nHardcoded.raw(
+                    'autoAppAppProjectsPageJsxAttrTitleNoProjectsYet85527dd3',
+                  )}
+                  description={tI18nHardcoded.raw(
+                    'autoAppAppProjectsPageJsxAttrDescriptionAProjectIsa4dc84d2',
+                  )}
+                  action={
+                    <Button
+                      onClick={() => openCreateModal(activeAccountId)}
+                      disabled={!canCreateProjects}
+                    >
+                      <Icon.Plus />
+                      {tI18nHardcoded.raw(
+                        'autoAppAppProjectsPageJsxTextCreateYourFirstProject061cafdb',
+                      )}
+                    </Button>
+                  }
+                />
               )}
 
               {showNoResults && (
-                <SectionCard flush>
-                  <EmptyState
-                    icon={Search}
-                    size="sm"
-                    title={`No matches for "${query}"`}
-                    description={tHardcodedUi.raw(
-                      'appProjectsPage.line288JsxAttrDescriptionTryADifferentSearchTerm',
-                    )}
-                  />
-                </SectionCard>
+                <EmptyState
+                  icon={Search}
+                  size="sm"
+                  title={`No matches for "${query}"`}
+                  description={tHardcodedUi.raw(
+                    'appProjectsPage.line288JsxAttrDescriptionTryADifferentSearchTerm',
+                  )}
+                />
               )}
 
               {filtered.length > 0 && (
@@ -485,7 +491,7 @@ export default function ProjectsPage() {
                       project={project}
                       onOpen={() => router.push(`/projects/${project.project_id}`)}
                       onRename={() => setRenameTarget(project)}
-                      onArchive={() => archiveMutation.mutate(project.project_id)}
+                      onArchive={() => setArchiveTarget(project)}
                       archiving={archivingId === project.project_id}
                     />
                   ))}
@@ -504,43 +510,59 @@ export default function ProjectsPage() {
                 </div>
               )}
 
+              {showAllError && (
+                <InfoBanner
+                  tone="destructive"
+                  title={`Failed to load projects for ${failedAllAccountQueries.length} account${failedAllAccountQueries.length === 1 ? '' : 's'}`}
+                  action={
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => {
+                        for (const q of allAccountQueries) {
+                          if (q.isError) void q.refetch();
+                        }
+                      }}
+                    >
+                      Retry
+                    </Button>
+                  }
+                />
+              )}
+
               {showAllEmpty && (
-                <SectionCard flush>
-                  <EmptyState
-                    icon={FolderPlus}
-                    title={tI18nHardcoded.raw(
-                      'autoAppAppProjectsPageJsxAttrTitleNoProjectsYet85527dd3',
-                    )}
-                    description={tI18nHardcoded.raw(
-                      'autoAppAppProjectsPageJsxAttrDescriptionAProjectIsa4dc84d2',
-                    )}
-                    action={
-                      <NewProjectControl
-                        viewAll
-                        creatableAccounts={creatableAccounts}
-                        activeAccountId={activeAccountId}
-                        canCreateActive={canCreateProjects}
-                        onPick={openCreateModal}
-                        label={tI18nHardcoded.raw(
-                          'autoAppAppProjectsPageJsxAttrLabelCreateYourFirst301a83a6',
-                        )}
-                      />
-                    }
-                  />
-                </SectionCard>
+                <EmptyState
+                  icon={FolderPlus}
+                  title={tI18nHardcoded.raw(
+                    'autoAppAppProjectsPageJsxAttrTitleNoProjectsYet85527dd3',
+                  )}
+                  description={tI18nHardcoded.raw(
+                    'autoAppAppProjectsPageJsxAttrDescriptionAProjectIsa4dc84d2',
+                  )}
+                  action={
+                    <NewProjectControl
+                      viewAll
+                      creatableAccounts={creatableAccounts}
+                      activeAccountId={activeAccountId}
+                      canCreateActive={canCreateProjects}
+                      onPick={openCreateModal}
+                      label={tI18nHardcoded.raw(
+                        'autoAppAppProjectsPageJsxAttrLabelCreateYourFirst301a83a6',
+                      )}
+                    />
+                  }
+                />
               )}
 
               {showAllNoResults && (
-                <SectionCard flush>
-                  <EmptyState
-                    icon={Search}
-                    size="sm"
-                    title={`No matches for "${query}"`}
-                    description={tHardcodedUi.raw(
-                      'appProjectsPage.line288JsxAttrDescriptionTryADifferentSearchTerm',
-                    )}
-                  />
-                </SectionCard>
+                <EmptyState
+                  icon={Search}
+                  size="sm"
+                  title={`No matches for "${query}"`}
+                  description={tHardcodedUi.raw(
+                    'appProjectsPage.line288JsxAttrDescriptionTryADifferentSearchTerm',
+                  )}
+                />
               )}
 
               {!showAllLoading &&
@@ -563,7 +585,7 @@ export default function ProjectsPage() {
                             router.push(`/projects/${project.project_id}`);
                           }}
                           onRename={() => setRenameTarget(project)}
-                          onArchive={() => archiveMutation.mutate(project.project_id)}
+                          onArchive={() => setArchiveTarget(project)}
                           archiving={archivingId === project.project_id}
                         />
                       ))}
@@ -601,6 +623,24 @@ export default function ProjectsPage() {
         onOpenChange={(o) => {
           if (!o) setRenameTarget(null);
         }}
+      />
+
+      <ConfirmDialog
+        open={!!archiveTarget}
+        onOpenChange={(o) => {
+          if (!o && !archiveMutation.isPending) setArchiveTarget(null);
+        }}
+        title="Archive project"
+        description={
+          <>
+            <span className="text-foreground font-medium">{archiveTarget?.name}</span> will be
+            archived and removed from your projects list.
+          </>
+        }
+        confirmLabel="Archive"
+        confirmVariant="destructive"
+        isPending={archiveMutation.isPending}
+        onConfirm={confirmArchive}
       />
 
       <PersonalOnboardingWelcome />

--- a/apps/web/src/features/marketplace/add-to-project-modal.tsx
+++ b/apps/web/src/features/marketplace/add-to-project-modal.tsx
@@ -3,8 +3,10 @@
 import { useQuery } from '@tanstack/react-query';
 import { KeyRound, Plug, Wrench } from 'lucide-react';
 import { useTranslations } from 'next-intl';
-import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { type FormEvent, useEffect, useState } from 'react';
 
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
   Field,
@@ -14,6 +16,7 @@ import {
   FieldLabel,
   FieldTitle,
 } from '@/components/ui/field';
+import Loading from '@/components/ui/loading';
 import {
   Modal,
   ModalBody,
@@ -32,9 +35,16 @@ import {
 } from '@/components/ui/select';
 import { errorToast, successToast } from '@/components/ui/toast';
 import { useAuth } from '@/features/providers/auth-provider';
-import { useInstallMarketplaceItem } from '@/hooks/marketplace';
+import { useInstallMarketplaceItem, useInstalledItems } from '@/hooks/marketplace';
 import type { MarketplaceItem } from '@/lib/marketplace-client';
 import { listProjectsForAccount } from '@kortix/sdk/projects-client';
+import {
+  buildInstallSuccessSummary,
+  capabilityCount,
+  hasCapabilities,
+  isInstallDisabled,
+  projectMarketplaceHref,
+} from './marketplace-install';
 import { typeMeta } from './marketplace-meta';
 
 export function AddToProjectModal({
@@ -52,6 +62,7 @@ export function AddToProjectModal({
   fixedProjectName?: string;
 }) {
   const tI18nHardcoded = useTranslations('hardcodedUi');
+  const router = useRouter();
   const { user } = useAuth();
   const usePicker = !fixedProjectId;
   const [pickedProjectId, setPickedProjectId] = useState('');
@@ -71,16 +82,47 @@ export function AddToProjectModal({
     }
   }, [open, usePicker, projects, pickedProjectId]);
 
+  // Reset any stale pending/close-guard state when a fresh item is opened.
+  useEffect(() => {
+    if (!open) return;
+    install.reset();
+  }, [open, item?.id]);
+
   const targetProjectId = fixedProjectId ?? pickedProjectId;
   const caps = item?.capabilities;
-  const hasCaps = !!caps && caps.secrets.length + caps.connectors.length + caps.tools.length > 0;
+  const showCaps = hasCapabilities(caps);
+  const capCount = capabilityCount(caps);
+
+  const installedQuery = useInstalledItems(targetProjectId || null);
+  const alreadyInstalled = !!(
+    item && installedQuery.data?.some((installed) => installed.name === item.name)
+  );
+
+  const disabled = isInstallDisabled({
+    hasItem: !!item,
+    targetProjectId,
+    pending: install.isPending,
+  });
+
+  const guardedOpenChange = (next: boolean) => {
+    // Block the modal from closing mid-flight — losing the pending/error
+    // feedback would leave the user unsure whether the install landed.
+    if (install.isPending) return;
+    onOpenChange(next);
+  };
 
   const onInstall = async () => {
-    if (!item || !targetProjectId) return;
+    if (!item || disabled) return;
     try {
       const res = await install.mutateAsync({ projectId: targetProjectId, id: item.id });
-      successToast(`Added ${item.title}`, {
-        description: `Committed ${res.file_count} file${res.file_count === 1 ? '' : 's'} — live in the next session.`,
+      const summary = buildInstallSuccessSummary(item.title, res);
+      successToast(summary.title, {
+        description: summary.description,
+        button: (
+          <Button size="sm" onClick={() => router.push(projectMarketplaceHref(targetProjectId))}>
+            View in project
+          </Button>
+        ),
       });
       onOpenChange(false);
     } catch (e) {
@@ -88,9 +130,14 @@ export function AddToProjectModal({
     }
   };
 
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    onInstall();
+  };
+
   return (
-    <Modal open={open} onOpenChange={onOpenChange}>
-      <ModalContent className="lg:max-w-md">
+    <Modal open={open} onOpenChange={guardedOpenChange}>
+      <ModalContent className="lg:max-w-md" closeOnOutsideClick={!install.isPending}>
         <ModalHeader>
           <ModalTitle>
             Add {item?.title}
@@ -105,92 +152,138 @@ export function AddToProjectModal({
           </ModalDescription>
         </ModalHeader>
 
-        <ModalBody>
-          <FieldGroup className="gap-4">
-            {usePicker && (
-              <Field className="gap-1.5">
-                <FieldLabel htmlFor="mp-project">Project</FieldLabel>
-                <Select value={pickedProjectId} onValueChange={setPickedProjectId}>
-                  <SelectTrigger id="mp-project">
-                    <SelectValue
-                      placeholder={projectsQuery.isLoading ? 'Loading…' : 'Choose a project'}
-                    />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {projects.map((p) => (
-                      <SelectItem key={p.project_id} value={p.project_id}>
-                        {p.name}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-                {!projectsQuery.isLoading && projects.length === 0 && (
-                  <FieldDescription>
-                    {tI18nHardcoded.raw(
-                      'autoComponentsMarketplaceAddToProjectModalJsxTextYouHavec6bfb213',
-                    )}
-                  </FieldDescription>
-                )}
-              </Field>
-            )}
+        <form onSubmit={handleSubmit}>
+          <ModalBody>
+            <FieldGroup className="gap-4">
+              {usePicker && (
+                <Field className="gap-1.5">
+                  <FieldLabel htmlFor="mp-project">Project</FieldLabel>
+                  <Select value={pickedProjectId} onValueChange={setPickedProjectId}>
+                    <SelectTrigger id="mp-project">
+                      <SelectValue
+                        placeholder={projectsQuery.isLoading ? 'Loading…' : 'Choose a project'}
+                      />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {projects.map((p) => (
+                        <SelectItem key={p.project_id} value={p.project_id}>
+                          {p.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  {!projectsQuery.isLoading && projects.length === 0 && (
+                    <FieldDescription>
+                      {tI18nHardcoded.raw(
+                        'autoComponentsMarketplaceAddToProjectModalJsxTextYouHavec6bfb213',
+                      )}
+                    </FieldDescription>
+                  )}
+                </Field>
+              )}
 
-            {item && item.dependencies.length > 0 && (
-              <FieldDescription>
-                {tI18nHardcoded.raw(
-                  'autoComponentsMarketplaceAddToProjectModalJsxTextAlsoInstallsac6dcc9a',
-                )}
-                <span className="text-foreground">{item.dependencies.join(', ')}</span>
-              </FieldDescription>
-            )}
+              {alreadyInstalled && (
+                <div className="bg-popover flex items-center gap-2 rounded-md border px-4 py-2.5">
+                  <Badge variant="success" size="sm">
+                    Already installed
+                  </Badge>
+                  <span className="text-muted-foreground text-xs">
+                    Adding again reinstalls it from source.
+                  </span>
+                </div>
+              )}
 
-            {hasCaps ? (
-              <Field variant="outline">
-                <FieldContent>
-                  <FieldTitle>
-                    {tI18nHardcoded.raw(
-                      'autoComponentsMarketplaceAddToProjectModalJsxTextThisItem2bb697bd',
-                    )}
-                  </FieldTitle>
-                  <ul className="text-muted-foreground mt-2 space-y-1.5 text-sm">
-                    {caps!.secrets.map((s) => (
-                      <li key={s} className="flex items-center gap-2">
-                        <KeyRound className="size-3.5 shrink-0" />
-                        <span className="font-mono text-xs">{s}</span>
-                      </li>
-                    ))}
-                    {caps!.connectors.map((c) => (
-                      <li key={c} className="flex items-center gap-2">
-                        <Plug className="size-3.5 shrink-0" />
-                        {c}
-                      </li>
-                    ))}
-                    {caps!.tools.map((t) => (
-                      <li key={t} className="flex items-center gap-2">
-                        <Wrench className="size-3.5 shrink-0" />
-                        {t}
-                      </li>
-                    ))}
-                  </ul>
-                </FieldContent>
-              </Field>
-            ) : (
-              <FieldDescription>
-                {tI18nHardcoded.raw(
-                  'autoComponentsMarketplaceAddToProjectModalJsxTextNoSpecial521751ba',
-                )}
-              </FieldDescription>
-            )}
-          </FieldGroup>
-        </ModalBody>
+              {item && item.dependencies.length > 0 && (
+                <FieldDescription>
+                  {tI18nHardcoded.raw(
+                    'autoComponentsMarketplaceAddToProjectModalJsxTextAlsoInstallsac6dcc9a',
+                  )}
+                  <span className="text-foreground">{item.dependencies.join(', ')}</span>
+                </FieldDescription>
+              )}
 
-        <ModalFooter className="sm:justify-between">
-          <Button variant="outline-ghost" size="sm" onClick={() => onOpenChange(false)}>
-            Cancel
-          </Button>
-          <Button size="sm" onClick={onInstall} disabled={!targetProjectId || install.isPending}>
-            {install.isPending ? 'Adding…' : 'Add'}
-          </Button>
-        </ModalFooter>
+              {showCaps ? (
+                <Field variant="outline">
+                  <FieldContent>
+                    <div className="flex items-center gap-2">
+                      <FieldTitle>
+                        {tI18nHardcoded.raw(
+                          'autoComponentsMarketplaceAddToProjectModalJsxTextThisItem2bb697bd',
+                        )}
+                      </FieldTitle>
+                      <Badge variant="outline" size="sm">
+                        {capCount}
+                      </Badge>
+                    </div>
+                    <ul className="mt-2 space-y-1.5">
+                      {caps!.secrets.map((s) => (
+                        <li key={s} className="flex items-center gap-2.5">
+                          <span className="bg-kortix-yellow/15 text-kortix-yellow flex size-6 shrink-0 items-center justify-center rounded-sm">
+                            <KeyRound className="size-3.5" />
+                          </span>
+                          <span className="text-foreground min-w-0 flex-1 truncate font-mono text-xs">
+                            {s}
+                          </span>
+                          <Badge variant="outline" size="sm">
+                            Secret
+                          </Badge>
+                        </li>
+                      ))}
+                      {caps!.connectors.map((c) => (
+                        <li key={c} className="flex items-center gap-2.5">
+                          <span className="bg-kortix-blue/15 text-kortix-blue flex size-6 shrink-0 items-center justify-center rounded-sm">
+                            <Plug className="size-3.5" />
+                          </span>
+                          <span className="text-foreground min-w-0 flex-1 truncate text-sm">
+                            {c}
+                          </span>
+                          <Badge variant="outline" size="sm">
+                            Connector
+                          </Badge>
+                        </li>
+                      ))}
+                      {caps!.tools.map((t) => (
+                        <li key={t} className="flex items-center gap-2.5">
+                          <span className="bg-kortix-orange/15 text-kortix-orange flex size-6 shrink-0 items-center justify-center rounded-sm">
+                            <Wrench className="size-3.5" />
+                          </span>
+                          <span className="text-foreground min-w-0 flex-1 truncate text-sm">
+                            {t}
+                          </span>
+                          <Badge variant="outline" size="sm">
+                            Tool
+                          </Badge>
+                        </li>
+                      ))}
+                    </ul>
+                  </FieldContent>
+                </Field>
+              ) : (
+                <FieldDescription>
+                  {tI18nHardcoded.raw(
+                    'autoComponentsMarketplaceAddToProjectModalJsxTextNoSpecial521751ba',
+                  )}
+                </FieldDescription>
+              )}
+            </FieldGroup>
+          </ModalBody>
+
+          <ModalFooter className="sm:justify-between">
+            <Button
+              type="button"
+              variant="outline-ghost"
+              size="sm"
+              disabled={install.isPending}
+              onClick={() => onOpenChange(false)}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" size="sm" disabled={disabled}>
+              {install.isPending ? <Loading className="size-3.5 shrink-0" /> : null}
+              {install.isPending ? 'Adding…' : alreadyInstalled ? 'Reinstall' : 'Add'}
+            </Button>
+          </ModalFooter>
+        </form>
       </ModalContent>
     </Modal>
   );

--- a/apps/web/src/features/marketplace/add-to-project-modal.tsx
+++ b/apps/web/src/features/marketplace/add-to-project-modal.tsx
@@ -82,12 +82,6 @@ export function AddToProjectModal({
     }
   }, [open, usePicker, projects, pickedProjectId]);
 
-  // Reset any stale pending/close-guard state when a fresh item is opened.
-  useEffect(() => {
-    if (!open) return;
-    install.reset();
-  }, [open, item?.id]);
-
   const targetProjectId = fixedProjectId ?? pickedProjectId;
   const caps = item?.capabilities;
   const showCaps = hasCapabilities(caps);
@@ -216,7 +210,7 @@ export function AddToProjectModal({
                       </Badge>
                     </div>
                     <ul className="mt-2 space-y-1.5">
-                      {caps!.secrets.map((s) => (
+                      {caps?.secrets.map((s) => (
                         <li key={s} className="flex items-center gap-2.5">
                           <span className="bg-kortix-yellow/15 text-kortix-yellow flex size-6 shrink-0 items-center justify-center rounded-sm">
                             <KeyRound className="size-3.5" />
@@ -229,7 +223,7 @@ export function AddToProjectModal({
                           </Badge>
                         </li>
                       ))}
-                      {caps!.connectors.map((c) => (
+                      {caps?.connectors.map((c) => (
                         <li key={c} className="flex items-center gap-2.5">
                           <span className="bg-kortix-blue/15 text-kortix-blue flex size-6 shrink-0 items-center justify-center rounded-sm">
                             <Plug className="size-3.5" />
@@ -242,7 +236,7 @@ export function AddToProjectModal({
                           </Badge>
                         </li>
                       ))}
-                      {caps!.tools.map((t) => (
+                      {caps?.tools.map((t) => (
                         <li key={t} className="flex items-center gap-2.5">
                           <span className="bg-kortix-orange/15 text-kortix-orange flex size-6 shrink-0 items-center justify-center rounded-sm">
                             <Wrench className="size-3.5" />

--- a/apps/web/src/features/marketplace/installed-client.test.ts
+++ b/apps/web/src/features/marketplace/installed-client.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, test } from 'bun:test';
+
+import type { InstalledItem, MarketplaceItem, RegistryItemStatus } from '@/lib/marketplace-client';
+import {
+  buildCatalogByName,
+  deriveInstalledItemStatus,
+  describeRemoveConsequence,
+  filterInstalledItems,
+  matchesInstalledItemQuery,
+  updatableInstalledItemNames,
+} from './installed-client';
+
+function makeItem(overrides: Partial<InstalledItem> = {}): InstalledItem {
+  return {
+    name: 'pdf-toolkit',
+    type: 'registry:skill',
+    source: 'kortix/marketplace',
+    installed_at: '2026-07-01T00:00:00.000Z',
+    file_count: 3,
+    ...overrides,
+  };
+}
+
+describe('deriveInstalledItemStatus', () => {
+  test('reports the status from the updates map when present', () => {
+    const map = new Map<string, RegistryItemStatus>([['pdf-toolkit', 'update-available']]);
+
+    expect(deriveInstalledItemStatus('pdf-toolkit', map)).toBe('update-available');
+  });
+
+  test('reports orphaned when the map says orphaned', () => {
+    const map = new Map<string, RegistryItemStatus>([['pdf-toolkit', 'orphaned']]);
+
+    expect(deriveInstalledItemStatus('pdf-toolkit', map)).toBe('orphaned');
+  });
+
+  test('falls back to up-to-date when absent from the map (server only lists attention items)', () => {
+    const map = new Map<string, RegistryItemStatus>();
+
+    expect(deriveInstalledItemStatus('pdf-toolkit', map)).toBe('up-to-date');
+  });
+});
+
+describe('matchesInstalledItemQuery', () => {
+  test('an empty query matches everything', () => {
+    expect(matchesInstalledItemQuery(makeItem(), '')).toBe(true);
+    expect(matchesInstalledItemQuery(makeItem(), '   ')).toBe(true);
+  });
+
+  test('matches on the raw registry name, case-insensitively', () => {
+    expect(matchesInstalledItemQuery(makeItem({ name: 'PDF-Toolkit' }), 'pdf')).toBe(true);
+  });
+
+  test('matches on the resolved catalog title even when the name differs', () => {
+    const item = makeItem({ name: 'internal-slug-42' });
+
+    expect(matchesInstalledItemQuery(item, 'notion', { catalogTitle: 'Notion Sync' })).toBe(true);
+  });
+
+  test('matches on the source', () => {
+    expect(matchesInstalledItemQuery(makeItem({ source: 'acme/tools' }), 'acme')).toBe(true);
+  });
+
+  test('matches on the type label', () => {
+    expect(matchesInstalledItemQuery(makeItem(), 'skill', { typeLabel: 'Skill' })).toBe(true);
+  });
+
+  test('does not match unrelated text', () => {
+    expect(matchesInstalledItemQuery(makeItem(), 'zzz-nope')).toBe(false);
+  });
+});
+
+describe('filterInstalledItems', () => {
+  const items = [
+    makeItem({ name: 'pdf-toolkit' }),
+    makeItem({ name: 'notion-sync', source: 'acme/tools' }),
+  ];
+  const resolve = () => ({});
+
+  test('an empty query returns every item unfiltered', () => {
+    expect(filterInstalledItems(items, '', resolve)).toEqual(items);
+  });
+
+  test('filters down to items matching the query', () => {
+    const result = filterInstalledItems(items, 'notion', resolve);
+
+    expect(result.map((i) => i.name)).toEqual(['notion-sync']);
+  });
+
+  test('resolves catalog title per item so titles (not just names) are searchable', () => {
+    const resolveByName = (item: InstalledItem) =>
+      item.name === 'pdf-toolkit' ? { catalogTitle: 'PDF Toolkit Pro' } : {};
+
+    const result = filterInstalledItems(items, 'toolkit pro', resolveByName);
+
+    expect(result.map((i) => i.name)).toEqual(['pdf-toolkit']);
+  });
+
+  test('no matches returns an empty list', () => {
+    expect(filterInstalledItems(items, 'nothing-matches-this', resolve)).toEqual([]);
+  });
+});
+
+describe('describeRemoveConsequence', () => {
+  test('names the file count and that it commits the removal', () => {
+    const sentence = describeRemoveConsequence(makeItem({ file_count: 3, name: 'pdf-toolkit' }));
+
+    expect(sentence).toContain('3 files');
+    expect(sentence).toContain('"pdf-toolkit"');
+    expect(sentence).toContain('commits the removal');
+  });
+
+  test('uses singular "file" for a single-file item', () => {
+    const sentence = describeRemoveConsequence(makeItem({ file_count: 1 }));
+
+    expect(sentence).toContain('1 file');
+    expect(sentence).not.toContain('1 files');
+  });
+
+  test('prefers the catalog title over the raw name when available', () => {
+    const sentence = describeRemoveConsequence(
+      makeItem({ name: 'internal-slug-42' }),
+      'Notion Sync',
+    );
+
+    expect(sentence).toContain('"Notion Sync"');
+    expect(sentence).not.toContain('internal-slug-42');
+  });
+});
+
+describe('updatableInstalledItemNames', () => {
+  test('keeps only update-available entries', () => {
+    const updates: { name: string; status: RegistryItemStatus }[] = [
+      { name: 'a', status: 'update-available' },
+      { name: 'b', status: 'up-to-date' },
+      { name: 'c', status: 'orphaned' },
+      { name: 'd', status: 'update-available' },
+    ];
+
+    expect(updatableInstalledItemNames(updates)).toEqual(['a', 'd']);
+  });
+
+  test('an empty updates list yields no updatable names', () => {
+    expect(updatableInstalledItemNames([])).toEqual([]);
+  });
+});
+
+describe('buildCatalogByName', () => {
+  test('indexes catalog items by name', () => {
+    const items = [{ name: 'pdf-toolkit' }, { name: 'notion-sync' }] as MarketplaceItem[];
+
+    const map = buildCatalogByName(items);
+
+    expect(map.get('pdf-toolkit')).toBe(items[0]);
+    expect(map.get('notion-sync')).toBe(items[1]);
+    expect(map.get('missing')).toBeUndefined();
+  });
+
+  test('an empty catalog produces an empty map', () => {
+    expect(buildCatalogByName([]).size).toBe(0);
+  });
+});

--- a/apps/web/src/features/marketplace/installed-client.ts
+++ b/apps/web/src/features/marketplace/installed-client.ts
@@ -1,0 +1,72 @@
+import type { InstalledItem, MarketplaceItem, RegistryItemStatus } from '@/lib/marketplace-client';
+
+/** Display-facing status for an installed item, derived from the registry
+ *  updates check. Absent from the updates map (or the check hasn't loaded
+ *  yet) reads as `'up-to-date'` — the server only lists items that need
+ *  attention (`update-available` / `orphaned`), so silence means "fine". */
+export type InstalledItemStatus = RegistryItemStatus;
+
+/** Resolves an installed item's status badge state from the (possibly still
+ *  loading) `/registry/updates` map. Extracted so the up-to-date/update/
+ *  orphaned decision is unit-testable without mounting the panel. */
+export function deriveInstalledItemStatus(
+  name: string,
+  statusByName: Map<string, RegistryItemStatus>,
+): InstalledItemStatus {
+  return statusByName.get(name) ?? 'up-to-date';
+}
+
+/** Case-insensitive match over the fields a user would recognize an installed
+ *  item by: its catalog title (when resolved), its raw registry name, its
+ *  type label, and its source. Extracted so the search box's predicate is
+ *  testable without react state. */
+export function matchesInstalledItemQuery(
+  item: InstalledItem,
+  query: string,
+  extra?: { catalogTitle?: string; typeLabel?: string },
+): boolean {
+  const q = query.trim().toLowerCase();
+  if (!q) return true;
+  const haystack = [item.name, item.source, extra?.catalogTitle, extra?.typeLabel]
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase();
+  return haystack.includes(q);
+}
+
+/** Filters an installed list against a search query, resolving each item's
+ *  catalog title/type label via the supplied lookup so matches work on the
+ *  friendly title, not just the raw registry name. */
+export function filterInstalledItems(
+  items: InstalledItem[],
+  query: string,
+  resolve: (item: InstalledItem) => { catalogTitle?: string; typeLabel?: string },
+): InstalledItem[] {
+  const q = query.trim();
+  if (!q) return items;
+  return items.filter((item) => matchesInstalledItemQuery(item, q, resolve(item)));
+}
+
+/** Precise consequence sentence for the remove confirm dialog — names the
+ *  exact file count and that removal lands as a new commit, so the user
+ *  knows what "Remove" actually does before confirming. */
+export function describeRemoveConsequence(item: InstalledItem, catalogTitle?: string): string {
+  const label = catalogTitle ?? item.name;
+  const fileWord = item.file_count === 1 ? 'file' : 'files';
+  return `This deletes ${item.file_count} ${fileWord} installed by "${label}" from the repo and commits the removal. This can't be undone from here.`;
+}
+
+/** Names of installed items eligible for a batch "Update all" — anything the
+ *  updates check actually reports as `update-available`. Orphaned items are
+ *  excluded (there's nothing to update them against). */
+export function updatableInstalledItemNames(
+  updates: { name: string; status: RegistryItemStatus }[],
+): string[] {
+  return updates.filter((u) => u.status === 'update-available').map((u) => u.name);
+}
+
+/** Builds the `Map<name, MarketplaceItem>` used to resolve an installed
+ *  item's catalog title/description/capabilities, from a catalog page. */
+export function buildCatalogByName(items: MarketplaceItem[]): Map<string, MarketplaceItem> {
+  return new Map(items.map((item) => [item.name, item]));
+}

--- a/apps/web/src/features/marketplace/marketplace-install.test.ts
+++ b/apps/web/src/features/marketplace/marketplace-install.test.ts
@@ -72,7 +72,12 @@ describe('capabilityCount', () => {
 
   test('sums across all three kinds', () => {
     expect(
-      capabilityCount({ secrets: ['A', 'B'], connectors: ['c'], tools: ['t1', 't2', 't3'], network: [] }),
+      capabilityCount({
+        secrets: ['A', 'B'],
+        connectors: ['c'],
+        tools: ['t1', 't2', 't3'],
+        network: [],
+      }),
     ).toBe(6);
   });
 });

--- a/apps/web/src/features/marketplace/marketplace-install.test.ts
+++ b/apps/web/src/features/marketplace/marketplace-install.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  buildInstallSuccessSummary,
+  capabilityCount,
+  hasCapabilities,
+  isInstallDisabled,
+  projectMarketplaceHref,
+} from './marketplace-install';
+
+describe('buildInstallSuccessSummary', () => {
+  test('singularizes "file" for a single-file install', () => {
+    const summary = buildInstallSuccessSummary('Code Review', { file_count: 1 });
+
+    expect(summary.title).toBe('Added Code Review');
+    expect(summary.description).toBe('Committed 1 file — live in the next session.');
+  });
+
+  test('pluralizes "files" for multi-file installs', () => {
+    const summary = buildInstallSuccessSummary('Bundle', { file_count: 4 });
+
+    expect(summary.description).toBe('Committed 4 files — live in the next session.');
+  });
+
+  test('pluralizes for a zero-file install', () => {
+    const summary = buildInstallSuccessSummary('Empty', { file_count: 0 });
+
+    expect(summary.description).toBe('Committed 0 files — live in the next session.');
+  });
+});
+
+describe('projectMarketplaceHref', () => {
+  test('builds the customize marketplace deep link for a project', () => {
+    expect(projectMarketplaceHref('proj_123')).toBe('/projects/proj_123/customize/marketplace');
+  });
+
+  test('URL-encodes project ids with special characters', () => {
+    expect(projectMarketplaceHref('proj/weird id')).toBe(
+      '/projects/proj%2Fweird%20id/customize/marketplace',
+    );
+  });
+});
+
+describe('hasCapabilities', () => {
+  test('false for null/undefined', () => {
+    expect(hasCapabilities(null)).toBe(false);
+    expect(hasCapabilities(undefined)).toBe(false);
+  });
+
+  test('false when every list is empty', () => {
+    expect(hasCapabilities({ secrets: [], connectors: [], tools: [], network: [] })).toBe(false);
+  });
+
+  test('true when any list is non-empty', () => {
+    expect(hasCapabilities({ secrets: ['API_KEY'], connectors: [], tools: [], network: [] })).toBe(
+      true,
+    );
+    expect(hasCapabilities({ secrets: [], connectors: ['slack'], tools: [], network: [] })).toBe(
+      true,
+    );
+    expect(hasCapabilities({ secrets: [], connectors: [], tools: ['browser'], network: [] })).toBe(
+      true,
+    );
+  });
+});
+
+describe('capabilityCount', () => {
+  test('0 for null/undefined', () => {
+    expect(capabilityCount(null)).toBe(0);
+    expect(capabilityCount(undefined)).toBe(0);
+  });
+
+  test('sums across all three kinds', () => {
+    expect(
+      capabilityCount({ secrets: ['A', 'B'], connectors: ['c'], tools: ['t1', 't2', 't3'], network: [] }),
+    ).toBe(6);
+  });
+});
+
+describe('isInstallDisabled', () => {
+  test('disabled when no item is resolved', () => {
+    expect(isInstallDisabled({ hasItem: false, targetProjectId: 'p1', pending: false })).toBe(true);
+  });
+
+  test('disabled when no target project is chosen', () => {
+    expect(isInstallDisabled({ hasItem: true, targetProjectId: '', pending: false })).toBe(true);
+  });
+
+  test('disabled while a request is pending', () => {
+    expect(isInstallDisabled({ hasItem: true, targetProjectId: 'p1', pending: true })).toBe(true);
+  });
+
+  test('enabled once an item, project, and idle state all line up', () => {
+    expect(isInstallDisabled({ hasItem: true, targetProjectId: 'p1', pending: false })).toBe(false);
+  });
+});

--- a/apps/web/src/features/marketplace/marketplace-install.ts
+++ b/apps/web/src/features/marketplace/marketplace-install.ts
@@ -1,0 +1,55 @@
+import type { InstallResult, ItemCapabilities } from '@/lib/marketplace-client';
+
+/** Everything the install success toast needs, decoupled from the mutation's
+ *  raw response shape so it's independently testable. */
+export interface InstallSuccessSummary {
+  title: string;
+  description: string;
+}
+
+/** Builds the "what landed" toast copy from the install response — the item
+ *  title plus a plain-English file count, singular/plural handled inline. */
+export function buildInstallSuccessSummary(
+  itemTitle: string,
+  result: Pick<InstallResult, 'file_count'>,
+): InstallSuccessSummary {
+  const { file_count } = result;
+  return {
+    title: `Added ${itemTitle}`,
+    description: `Committed ${file_count} file${file_count === 1 ? '' : 's'} — live in the next session.`,
+  };
+}
+
+/** Deep-link destination for "View in project" — the customize overlay's
+ *  Marketplace section (installed tab lives there), scoped to the project the
+ *  item just landed in. Kept as a plain path builder (no router dependency)
+ *  so it's testable and reusable from both in-app navigation and a toast
+ *  action that has to work from any page, including the public marketplace. */
+export function projectMarketplaceHref(projectId: string): string {
+  return `/projects/${encodeURIComponent(projectId)}/customize/marketplace`;
+}
+
+/** True when an item exposes any secrets/connectors/tools it needs — used to
+ *  decide whether the modal renders the capabilities panel at all. */
+export function hasCapabilities(caps: ItemCapabilities | null | undefined): boolean {
+  return !!caps && caps.secrets.length + caps.connectors.length + caps.tools.length > 0;
+}
+
+/** Total capability count across all three kinds, for the section's count
+ *  badge. */
+export function capabilityCount(caps: ItemCapabilities | null | undefined): number {
+  if (!caps) return 0;
+  return caps.secrets.length + caps.connectors.length + caps.tools.length;
+}
+
+/** Whether the install control should be disabled: no item resolved yet, no
+ *  destination project chosen (picker mode), or a request already in flight —
+ *  the single source of truth so the button and the Enter-to-submit handler
+ *  can't disagree about when a submit is valid. */
+export function isInstallDisabled(params: {
+  hasItem: boolean;
+  targetProjectId: string;
+  pending: boolean;
+}): boolean {
+  return !params.hasItem || !params.targetProjectId || params.pending;
+}

--- a/apps/web/src/features/marketplace/marketplace-installed-panel.tsx
+++ b/apps/web/src/features/marketplace/marketplace-installed-panel.tsx
@@ -215,7 +215,12 @@ export function MarketplaceInstalledPanel({
               <InstalledItemCard
                 item={it}
                 catalogItem={catalogByName.get(it.name)}
-                status={deriveInstalledItemStatus(it.name, statusByName)}
+                // Only assert a status once the updates check has resolved —
+                // before that (loading/failed) the map is empty and every item
+                // would false-claim "Up to date".
+                status={
+                  updates.isSuccess ? deriveInstalledItemStatus(it.name, statusByName) : undefined
+                }
                 busy={busy}
                 onUpdate={() => onUpdate(it)}
                 onRemove={() => onRemove(it)}
@@ -238,7 +243,9 @@ function InstalledItemCard({
 }: {
   item: InstalledItem;
   catalogItem?: MarketplaceItem;
-  status: RegistryItemStatus;
+  /** Absent while the registry-updates check is loading or failed — render no
+   *  freshness claim rather than a false "Up to date". */
+  status: RegistryItemStatus | undefined;
   busy: boolean;
   onUpdate: () => void;
   onRemove: () => void;

--- a/apps/web/src/features/marketplace/marketplace-installed-panel.tsx
+++ b/apps/web/src/features/marketplace/marketplace-installed-panel.tsx
@@ -2,28 +2,47 @@
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { Disclosure, DisclosureContent, DisclosureTrigger } from '@/components/ui/disclosure';
 import { InlineMeta } from '@/components/ui/inline-meta';
+import {
+  InputGroupSearch,
+  InputGroupSearchClear,
+  InputGroupSearchIcon,
+  InputGroupSearchInput,
+} from '@/components/ui/input-group';
+import Loading from '@/components/ui/loading';
 import { Skeleton } from '@/components/ui/skeleton';
 import { errorToast, successToast } from '@/components/ui/toast';
 import { EmptyState } from '@/features/layout/section/empty-state';
+import { ErrorState } from '@/features/layout/section/error-state';
+import {
+  buildCatalogByName,
+  deriveInstalledItemStatus,
+  describeRemoveConsequence,
+  filterInstalledItems,
+} from '@/features/marketplace/installed-client';
 import {
   useInstalledItems,
   useMarketplaceItems,
   useRegistryUpdates,
   useUninstallMarketplaceItem,
+  useUpdateAllMarketplaceItems,
   useUpdateMarketplaceItem,
 } from '@/hooks/marketplace';
-import type { InstalledItem, MarketplaceItem } from '@/lib/marketplace-client';
+import type { InstalledItem, MarketplaceItem, RegistryItemStatus } from '@/lib/marketplace-client';
 import { cn } from '@/lib/utils';
 import { formatRelative } from '@kortix/shared';
-import { TrashSolid } from '@mynaui/icons-react';
+import { Search, TrashSolid } from '@mynaui/icons-react';
 import { ExternalLink, KeyRound, PackageOpen, Plug, RefreshCw, Wrench } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { useState } from 'react';
 import { MarketplaceAvatar } from './marketplace-avatar';
 import { MarketplaceItemAvatar } from './marketplace-item-avatar';
 import { TypeTile, typeMeta } from './marketplace-meta';
+
+// Stable keys for the initial-load skeleton rows (fixed count, never reordered).
+const SKELETON_ROW_IDS = ['s1', 's2', 's3', 's4', 's5', 's6'];
 
 export function MarketplaceInstalledPanel({
   projectId,
@@ -33,17 +52,26 @@ export function MarketplaceInstalledPanel({
   onBrowse: () => void;
 }) {
   const tI18nHardcoded = useTranslations('hardcodedUi');
+  const [query, setQuery] = useState('');
   const installed = useInstalledItems(projectId);
   const updates = useRegistryUpdates(projectId);
   const catalog = useMarketplaceItems({});
   const updateMut = useUpdateMarketplaceItem();
+  const updateAllMut = useUpdateAllMarketplaceItems();
   const uninstallMut = useUninstallMarketplaceItem();
 
   const items = installed.data ?? [];
-  const statusByName = new Map((updates.data?.updates ?? []).map((u) => [u.name, u.status]));
-  const catalogByName = new Map((catalog.data?.items ?? []).map((i) => [i.name, i]));
+  const statusByName = new Map<string, RegistryItemStatus>(
+    (updates.data?.updates ?? []).map((u) => [u.name, u.status]),
+  );
+  const catalogByName = buildCatalogByName(catalog.data?.items ?? []);
   const updateCount = updates.data?.update_available.length ?? 0;
-  const busy = updateMut.isPending || uninstallMut.isPending;
+  const busy = updateMut.isPending || updateAllMut.isPending || uninstallMut.isPending;
+
+  const filteredItems = filterInstalledItems(items, query, (it) => ({
+    catalogTitle: catalogByName.get(it.name)?.title,
+    typeLabel: typeMeta(it.type).label,
+  }));
 
   const onUpdate = async (it: InstalledItem) => {
     try {
@@ -53,6 +81,21 @@ export function MarketplaceInstalledPanel({
       });
     } catch (e) {
       errorToast('Update failed', { description: (e as Error).message });
+    }
+  };
+
+  const onUpdateAll = async () => {
+    try {
+      const res = await updateAllMut.mutateAsync({ projectId });
+      const count = res.updated.length;
+      successToast(count === 1 ? `Updated ${res.updated[0]}` : `Updated ${count} items`, {
+        description:
+          count > 0
+            ? `Re-committed ${res.file_count} file${res.file_count === 1 ? '' : 's'} — live next session.`
+            : 'Nothing needed an update.',
+      });
+    } catch (e) {
+      errorToast('Update all failed', { description: (e as Error).message });
     }
   };
 
@@ -70,10 +113,25 @@ export function MarketplaceInstalledPanel({
   if (installed.isLoading) {
     return (
       <div className="columns-1 gap-2 md:columns-2">
-        {Array.from({ length: 6 }).map((_, i) => (
-          <Skeleton key={i} className="mb-2 h-14 break-inside-avoid rounded-md" />
+        {SKELETON_ROW_IDS.map((id) => (
+          <Skeleton key={id} className="mb-2 h-14 break-inside-avoid rounded-md" />
         ))}
       </div>
+    );
+  }
+
+  if (installed.isError) {
+    return (
+      <ErrorState
+        size="sm"
+        title="Failed to load installed items"
+        description={(installed.error as Error)?.message}
+        action={
+          <Button variant="outline" size="sm" onClick={() => installed.refetch()}>
+            Retry
+          </Button>
+        }
+      />
     );
   }
 
@@ -99,34 +157,73 @@ export function MarketplaceInstalledPanel({
   }
 
   return (
-    <div className="space-y-5">
-      <InlineMeta className="text-sm">
-        <span className="tabular-nums">{items.length} installed</span>
-        {updateCount > 0 && (
-          <span className="text-foreground font-medium tabular-nums">
-            {updateCount} update{updateCount === 1 ? '' : 's'} available
-          </span>
-        )}
-        {updates.isLoading &&
-          tI18nHardcoded.raw(
-            'autoComponentsMarketplaceMarketplaceInstalledPanelJsxTextCheckingForUpdatese5306763',
+    <div className="space-y-4">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <InlineMeta className="text-sm">
+          <span className="tabular-nums">{items.length} installed</span>
+          {updateCount > 0 && (
+            <span className="text-foreground font-medium tabular-nums">
+              {updateCount} update{updateCount === 1 ? '' : 's'} available
+            </span>
           )}
-      </InlineMeta>
-
-      <div className="columns-1 gap-2 md:columns-2">
-        {items.map((it) => (
-          <div key={it.name} className="mb-2 break-inside-avoid">
-            <InstalledItemCard
-              item={it}
-              catalogItem={catalogByName.get(it.name)}
-              status={statusByName.get(it.name)}
-              busy={busy}
-              onUpdate={() => onUpdate(it)}
-              onRemove={() => onRemove(it)}
-            />
-          </div>
-        ))}
+          {updates.isLoading &&
+            tI18nHardcoded.raw(
+              'autoComponentsMarketplaceMarketplaceInstalledPanelJsxTextCheckingForUpdatese5306763',
+            )}
+        </InlineMeta>
+        {updateCount > 1 && (
+          <Button
+            size="sm"
+            variant="secondary"
+            disabled={busy}
+            className="shrink-0 gap-1.5 transition-transform active:scale-[0.96]"
+            onClick={onUpdateAll}
+          >
+            {updateAllMut.isPending ? (
+              <Loading className="size-3.5 shrink-0" />
+            ) : (
+              <RefreshCw className="size-3.5 shrink-0" />
+            )}
+            Update all
+          </Button>
+        )}
       </div>
+
+      {items.length > 5 && (
+        <InputGroupSearch>
+          <InputGroupSearchIcon>
+            <Search />
+          </InputGroupSearchIcon>
+          <InputGroupSearchInput
+            placeholder="Search installed"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            variant="popover"
+          />
+          <InputGroupSearchClear onClick={() => setQuery('')} />
+        </InputGroupSearch>
+      )}
+
+      {filteredItems.length === 0 ? (
+        <p className="text-muted-foreground px-1 py-6 text-center text-xs">
+          No installed items match &ldquo;{query}&rdquo;.
+        </p>
+      ) : (
+        <div className="columns-1 gap-2 md:columns-2">
+          {filteredItems.map((it) => (
+            <div key={it.name} className="mb-2 break-inside-avoid">
+              <InstalledItemCard
+                item={it}
+                catalogItem={catalogByName.get(it.name)}
+                status={deriveInstalledItemStatus(it.name, statusByName)}
+                busy={busy}
+                onUpdate={() => onUpdate(it)}
+                onRemove={() => onRemove(it)}
+              />
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   );
 }
@@ -141,212 +238,234 @@ function InstalledItemCard({
 }: {
   item: InstalledItem;
   catalogItem?: MarketplaceItem;
-  status?: string;
+  status: RegistryItemStatus;
   busy: boolean;
   onUpdate: () => void;
   onRemove: () => void;
 }) {
   const tI18nHardcoded = useTranslations('hardcodedUi');
   const [open, setOpen] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
   const meta = typeMeta(item.type);
   const TypeIcon = meta.Icon;
 
   return (
-    <Disclosure
-      variant="outline"
-      open={open}
-      onOpenChange={setOpen}
-      className="group/card overflow-hidden"
-      transition={{ duration: 0.18, ease: [0.23, 1, 0.32, 1] }}
-    >
-      <DisclosureTrigger variant="outline">
-        <div
-          className={cn(
-            'hover:bg-muted/40 flex w-full cursor-pointer items-center gap-3 px-4 py-3 text-left transition-colors',
-            'focus-visible:bg-muted/40 focus-visible:outline-none',
-          )}
-        >
-          <div className="shrink-0">
-            {catalogItem ? (
-              <MarketplaceItemAvatar item={catalogItem} size="sm" showSource={false} />
-            ) : (
-              <TypeTile type={item.type} size="sm" />
+    <>
+      <Disclosure
+        variant="outline"
+        open={open}
+        onOpenChange={setOpen}
+        className="group/card overflow-hidden"
+        transition={{ duration: 0.18, ease: [0.23, 1, 0.32, 1] }}
+      >
+        <DisclosureTrigger variant="outline">
+          <div
+            className={cn(
+              'hover:bg-muted/40 flex w-full cursor-pointer items-center gap-3 px-4 py-3 text-left transition-colors',
+              'focus-visible:bg-muted/40 focus-visible:outline-none',
             )}
-          </div>
-          <div className="min-w-0 flex-1">
-            <div className="flex items-center gap-2">
-              <span className="text-foreground truncate text-sm font-medium">
-                {catalogItem?.title ?? item.name}
-              </span>
-              {status === 'update-available' && (
-                <Badge variant="update" size="sm">
-                  {tI18nHardcoded.raw(
-                    'autoComponentsMarketplaceMarketplaceInstalledPanelJsxTextUpdateAvailable9830d327',
-                  )}
-                </Badge>
-              )}
-              {status === 'orphaned' && (
-                <Badge variant="muted" size="sm">
-                  {tI18nHardcoded.raw(
-                    'autoComponentsMarketplaceMarketplaceInstalledPanelJsxTextSourceRemoved1896940e',
-                  )}
-                </Badge>
+          >
+            <div className="shrink-0">
+              {catalogItem ? (
+                <MarketplaceItemAvatar item={catalogItem} size="sm" showSource={false} />
+              ) : (
+                <TypeTile type={item.type} size="sm" />
               )}
             </div>
-            <div className="mt-0.5">
-              <InlineMeta>
-                {meta.label}
-                {catalogItem?.marketplaceLabel ?? item.source}
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-2">
+                <span className="text-foreground truncate text-sm font-medium">
+                  {catalogItem?.title ?? item.name}
+                </span>
+                {status === 'update-available' && (
+                  <Badge variant="update" size="sm">
+                    {tI18nHardcoded.raw(
+                      'autoComponentsMarketplaceMarketplaceInstalledPanelJsxTextUpdateAvailable9830d327',
+                    )}
+                  </Badge>
+                )}
+                {status === 'orphaned' && (
+                  <Badge variant="muted" size="sm">
+                    {tI18nHardcoded.raw(
+                      'autoComponentsMarketplaceMarketplaceInstalledPanelJsxTextSourceRemoved1896940e',
+                    )}
+                  </Badge>
+                )}
+                {status === 'up-to-date' && (
+                  <Badge variant="success" size="sm">
+                    Up to date
+                  </Badge>
+                )}
+              </div>
+              <div className="mt-0.5">
+                <InlineMeta>
+                  {meta.label}
+                  {catalogItem?.marketplaceLabel ?? item.source}
+                  <span className="tabular-nums">
+                    {item.file_count} file{item.file_count === 1 ? '' : 's'}
+                  </span>
+                </InlineMeta>
+              </div>
+            </div>
+            <div className="flex shrink-0 items-center gap-1">
+              {status === 'update-available' && (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  disabled={busy}
+                  className="transition-transform active:scale-[0.96]"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onUpdate();
+                  }}
+                >
+                  <RefreshCw className="size-3.5" />
+                  Update
+                </Button>
+              )}
+              <Button
+                size="icon-sm"
+                variant="ghost"
+                disabled={busy}
+                aria-label={`Remove ${item.name}`}
+                className={cn(
+                  'text-muted-foreground/40 hover:text-foreground transition-opacity transition-transform active:scale-[0.96]',
+                  'opacity-0 group-hover/card:opacity-100 focus-visible:opacity-100',
+                )}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setConfirmOpen(true);
+                }}
+              >
+                <TrashSolid className="size-3.5" />
+              </Button>
+            </div>
+          </div>
+        </DisclosureTrigger>
+        <DisclosureContent variant="outline" contentClassName="border-border border-t">
+          <div className="space-y-4 px-4 py-4">
+            {catalogItem?.description ? (
+              <p className="text-muted-foreground text-sm leading-relaxed text-pretty">
+                {catalogItem.description}
+              </p>
+            ) : null}
+
+            <div className="space-y-2">
+              <p className="text-muted-foreground text-xs font-medium">Install</p>
+              <InlineMeta className="text-xs">
+                <span className="inline-flex items-center gap-1">
+                  <TypeIcon className="size-3 shrink-0" />
+                  {meta.label}
+                </span>
+                {item.installed_at ? `added ${formatRelative(item.installed_at) ?? ''}` : null}
+                <span className="font-mono tabular-nums">{item.name}</span>
                 <span className="tabular-nums">
-                  {item.file_count} file{item.file_count === 1 ? '' : 's'}
+                  {item.file_count} file{item.file_count === 1 ? '' : 's'} in repo
                 </span>
               </InlineMeta>
             </div>
-          </div>
-          <div className="flex shrink-0 items-center gap-1">
-            {status === 'update-available' && (
-              <Button
-                size="sm"
-                variant="outline"
-                disabled={busy}
-                className="transition-transform active:scale-[0.96]"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onUpdate();
-                }}
-              >
-                <RefreshCw className="size-3.5" />
-                Update
-              </Button>
+
+            {catalogItem ? (
+              <div className="space-y-2">
+                <p className="text-muted-foreground text-xs font-medium">Source</p>
+                <div className="flex min-w-0 items-center gap-2">
+                  <MarketplaceAvatar
+                    id={catalogItem.marketplaceId}
+                    owner={catalogItem.owner}
+                    sourceUrl={catalogItem.sourceUrl}
+                    label={catalogItem.marketplaceLabel}
+                    size="xs"
+                  />
+                  {catalogItem.sourceUrl ? (
+                    <a
+                      href={catalogItem.sourceUrl}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="text-foreground hover:text-foreground/80 inline-flex min-w-0 items-center gap-1 text-sm transition-colors"
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      <span className="truncate">{catalogItem.marketplaceLabel}</span>
+                      <ExternalLink className="size-3 shrink-0" />
+                    </a>
+                  ) : (
+                    <span className="text-foreground truncate text-sm">
+                      {catalogItem.marketplaceLabel}
+                    </span>
+                  )}
+                </div>
+              </div>
+            ) : (
+              <div className="space-y-2">
+                <p className="text-muted-foreground text-xs font-medium">Source</p>
+                <p className="text-foreground truncate font-mono text-sm">{item.source}</p>
+              </div>
             )}
-            <Button
-              size="icon-sm"
-              variant="ghost"
-              disabled={busy}
-              aria-label={`Remove ${item.name}`}
-              className={cn(
-                'text-muted-foreground/40 hover:text-foreground transition-opacity transition-transform active:scale-[0.96]',
-                'opacity-0 group-hover/card:opacity-100 focus-visible:opacity-100',
-              )}
-              onClick={(e) => {
-                e.stopPropagation();
-                onRemove();
-              }}
-            >
-              <TrashSolid className="size-3.5" />
-            </Button>
+
+            {catalogItem && catalogItem.categories.length > 0 ? (
+              <div className="space-y-2">
+                <p className="text-muted-foreground text-xs font-medium">Categories</p>
+                <div className="flex flex-wrap gap-1">
+                  {catalogItem.categories.map((cat) => (
+                    <Badge key={cat} variant="muted" size="sm">
+                      {cat}
+                    </Badge>
+                  ))}
+                </div>
+              </div>
+            ) : null}
+
+            {catalogItem && hasCapabilities(catalogItem) ? (
+              <div className="space-y-2">
+                <p className="text-muted-foreground text-xs font-medium">Permissions</p>
+                <div className="flex flex-wrap gap-1">
+                  {catalogItem.capabilities.secrets.map((s) => (
+                    <Badge key={s} variant="muted" size="xs" className="font-mono">
+                      <KeyRound />
+                      {s}
+                    </Badge>
+                  ))}
+                  {catalogItem.capabilities.tools.map((tool) => (
+                    <Badge key={tool} variant="muted" size="xs">
+                      <Wrench />
+                      {tool}
+                    </Badge>
+                  ))}
+                  {catalogItem.capabilities.connectors.map((cn) => (
+                    <Badge key={cn} variant="muted" size="xs">
+                      <Plug />
+                      {cn}
+                    </Badge>
+                  ))}
+                </div>
+              </div>
+            ) : null}
+
+            {catalogItem && catalogItem.dependencies.length > 0 ? (
+              <InlineMeta className="text-xs">
+                <span className="tabular-nums">
+                  {catalogItem.dependencies.length} dependenc
+                  {catalogItem.dependencies.length === 1 ? 'y' : 'ies'}
+                </span>
+              </InlineMeta>
+            ) : null}
           </div>
-        </div>
-      </DisclosureTrigger>
-      <DisclosureContent variant="outline" contentClassName="border-border border-t">
-        <div className="space-y-4 px-4 py-4">
-          {catalogItem?.description ? (
-            <p className="text-muted-foreground text-sm leading-relaxed text-pretty">
-              {catalogItem.description}
-            </p>
-          ) : null}
+        </DisclosureContent>
+      </Disclosure>
 
-          <div className="space-y-2">
-            <p className="text-muted-foreground text-xs font-medium">Install</p>
-            <InlineMeta className="text-xs">
-              <span className="inline-flex items-center gap-1">
-                <TypeIcon className="size-3 shrink-0" />
-                {meta.label}
-              </span>
-              {item.installed_at ? `added ${formatRelative(item.installed_at) ?? ''}` : null}
-              <span className="font-mono tabular-nums">{item.name}</span>
-              <span className="tabular-nums">
-                {item.file_count} file{item.file_count === 1 ? '' : 's'} in repo
-              </span>
-            </InlineMeta>
-          </div>
-
-          {catalogItem ? (
-            <div className="space-y-2">
-              <p className="text-muted-foreground text-xs font-medium">Source</p>
-              <div className="flex min-w-0 items-center gap-2">
-                <MarketplaceAvatar
-                  id={catalogItem.marketplaceId}
-                  owner={catalogItem.owner}
-                  sourceUrl={catalogItem.sourceUrl}
-                  label={catalogItem.marketplaceLabel}
-                  size="xs"
-                />
-                {catalogItem.sourceUrl ? (
-                  <a
-                    href={catalogItem.sourceUrl}
-                    target="_blank"
-                    rel="noreferrer"
-                    className="text-foreground hover:text-foreground/80 inline-flex min-w-0 items-center gap-1 text-sm transition-colors"
-                    onClick={(e) => e.stopPropagation()}
-                  >
-                    <span className="truncate">{catalogItem.marketplaceLabel}</span>
-                    <ExternalLink className="size-3 shrink-0" />
-                  </a>
-                ) : (
-                  <span className="text-foreground truncate text-sm">
-                    {catalogItem.marketplaceLabel}
-                  </span>
-                )}
-              </div>
-            </div>
-          ) : (
-            <div className="space-y-2">
-              <p className="text-muted-foreground text-xs font-medium">Source</p>
-              <p className="text-foreground truncate font-mono text-sm">{item.source}</p>
-            </div>
-          )}
-
-          {catalogItem && catalogItem.categories.length > 0 ? (
-            <div className="space-y-2">
-              <p className="text-muted-foreground text-xs font-medium">Categories</p>
-              <div className="flex flex-wrap gap-1">
-                {catalogItem.categories.map((cat) => (
-                  <Badge key={cat} variant="muted" size="sm">
-                    {cat}
-                  </Badge>
-                ))}
-              </div>
-            </div>
-          ) : null}
-
-          {catalogItem && hasCapabilities(catalogItem) ? (
-            <div className="space-y-2">
-              <p className="text-muted-foreground text-xs font-medium">Permissions</p>
-              <div className="flex flex-wrap gap-1">
-                {catalogItem.capabilities.secrets.map((s) => (
-                  <Badge key={s} variant="muted" size="xs" className="font-mono">
-                    <KeyRound />
-                    {s}
-                  </Badge>
-                ))}
-                {catalogItem.capabilities.tools.map((tool) => (
-                  <Badge key={tool} variant="muted" size="xs">
-                    <Wrench />
-                    {tool}
-                  </Badge>
-                ))}
-                {catalogItem.capabilities.connectors.map((cn) => (
-                  <Badge key={cn} variant="muted" size="xs">
-                    <Plug />
-                    {cn}
-                  </Badge>
-                ))}
-              </div>
-            </div>
-          ) : null}
-
-          {catalogItem && catalogItem.dependencies.length > 0 ? (
-            <InlineMeta className="text-xs">
-              <span className="tabular-nums">
-                {catalogItem.dependencies.length} dependenc
-                {catalogItem.dependencies.length === 1 ? 'y' : 'ies'}
-              </span>
-            </InlineMeta>
-          ) : null}
-        </div>
-      </DisclosureContent>
-    </Disclosure>
+      <ConfirmDialog
+        open={confirmOpen}
+        onOpenChange={setConfirmOpen}
+        title={`Remove ${catalogItem?.title ?? item.name}?`}
+        description={describeRemoveConsequence(item, catalogItem?.title)}
+        confirmLabel="Remove"
+        confirmVariant="destructive"
+        isPending={busy}
+        onConfirm={() => {
+          onRemove();
+          setConfirmOpen(false);
+        }}
+      />
+    </>
   );
 }
 

--- a/apps/web/src/features/marketplace/marketplace-item-card.tsx
+++ b/apps/web/src/features/marketplace/marketplace-item-card.tsx
@@ -61,13 +61,13 @@ export function MarketplaceItemCard({
         <div className="text-muted-foreground/70 mt-1.5 flex items-center gap-1.5 text-xs">
           <span>{label}</span>
           <span aria-hidden>·</span>
-          <span>
+          <span className="tabular-nums">
             {count} {unit}
           </span>
           {secretCount > 0 && (
             <>
               <span aria-hidden>·</span>
-              <span className="inline-flex items-center gap-0.5">
+              <span className="inline-flex items-center gap-0.5 tabular-nums">
                 <KeyRound className="size-3" />
                 {secretCount}
               </span>

--- a/apps/web/src/features/marketplace/marketplace-item-card.tsx
+++ b/apps/web/src/features/marketplace/marketplace-item-card.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import type { MarketplaceItem } from '@/lib/marketplace-client';
 import { MarketplaceItemAvatar } from './marketplace-item-avatar';
+import { emptyDescriptionCopy, itemCountLabel } from './marketplace-item-view';
 import { typeMeta } from './marketplace-meta';
 
 export function MarketplaceItemCard({
@@ -24,8 +25,7 @@ export function MarketplaceItemCard({
 }) {
   const { label } = typeMeta(item.type);
   const secretCount = item.capabilities?.secrets?.length ?? 0;
-  const count = item.type === 'registry:bundle' ? item.dependencies.length : item.fileCount;
-  const countLabel = item.type === 'registry:bundle' ? 'items' : 'files';
+  const { count, unit } = itemCountLabel(item);
 
   return (
     <div
@@ -45,7 +45,9 @@ export function MarketplaceItemCard({
       <MarketplaceItemAvatar item={item} size="md" showSource={showSource} />
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-2">
-          <span className="text-foreground truncate text-sm font-medium">{item.title}</span>
+          <span className="text-foreground truncate text-sm font-medium" title={item.title}>
+            {item.title}
+          </span>
           {installed && (
             <Badge variant="new" size="sm" className="shrink-0 gap-0.5">
               <Check className="size-3" />
@@ -53,14 +55,14 @@ export function MarketplaceItemCard({
             </Badge>
           )}
         </div>
-        {item.description && (
-          <p className="text-muted-foreground mt-0.5 line-clamp-2 text-xs leading-relaxed">{item.description}</p>
-        )}
+        <p className="text-muted-foreground mt-0.5 line-clamp-2 text-xs leading-relaxed text-pretty">
+          {item.description || emptyDescriptionCopy(item.type)}
+        </p>
         <div className="text-muted-foreground/70 mt-1.5 flex items-center gap-1.5 text-xs">
           <span>{label}</span>
           <span aria-hidden>·</span>
           <span>
-            {count} {countLabel}
+            {count} {unit}
           </span>
           {secretCount > 0 && (
             <>
@@ -88,7 +90,7 @@ export function MarketplaceItemCard({
             e.stopPropagation();
             onAdd(item);
           }}
-          aria-label="Add"
+          aria-label={`Add ${item.title}`}
         >
           <Plus className="size-4" />
         </Button>

--- a/apps/web/src/features/marketplace/marketplace-item-detail.tsx
+++ b/apps/web/src/features/marketplace/marketplace-item-detail.tsx
@@ -181,7 +181,9 @@ export function MarketplaceItemDetail({
 
               {isBundle && bundleMembers.length > 0 && (
                 <section>
-                  <SectionLabel>What&rsquo;s inside {bundleMembers.length}</SectionLabel>
+                  <SectionLabel>
+                    What&rsquo;s inside <span className="tabular-nums">{bundleMembers.length}</span>
+                  </SectionLabel>
                   <ul className="space-y-2">
                     {bundleMembers.map((member) => (
                       <li key={member.key}>
@@ -217,7 +219,9 @@ export function MarketplaceItemDetail({
 
               {capCount > 0 && (
                 <section>
-                  <SectionLabel>Requires {capCount}</SectionLabel>
+                  <SectionLabel>
+                    Requires <span className="tabular-nums">{capCount}</span>
+                  </SectionLabel>
                   <div className="space-y-3">
                     {capGroups.map((group) => (
                       <div key={group.kind}>
@@ -242,7 +246,9 @@ export function MarketplaceItemDetail({
 
               {data.files.length > 0 && (
                 <section>
-                  <SectionLabel>Files {data.files.length}</SectionLabel>
+                  <SectionLabel>
+                    Files <span className="tabular-nums">{data.files.length}</span>
+                  </SectionLabel>
                   <div className="bg-popover max-h-72 overflow-y-auto rounded-md border">
                     <ul className="divide-border divide-y">
                       {data.files.map((file) => (

--- a/apps/web/src/features/marketplace/marketplace-item-detail.tsx
+++ b/apps/web/src/features/marketplace/marketplace-item-detail.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { ExternalLink, FileText, KeyRound, Plug, Wrench } from 'lucide-react';
-import { useTranslations } from 'next-intl';
+import { ExternalLink, FileText } from 'lucide-react';
 
 import { UnifiedMarkdown } from '@/components/markdown';
+import { Badge } from '@/components/ui/badge';
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -23,7 +23,14 @@ import { TrashSolid } from '@mynaui/icons-react';
 import { Icon } from '../icon/icon';
 import { MarketplaceAvatar } from './marketplace-avatar';
 import { MarketplaceItemAvatar } from './marketplace-item-avatar';
-import { typeMeta } from './marketplace-meta';
+import { TypeTile, typeMeta } from './marketplace-meta';
+import {
+  emptyDescriptionCopy,
+  emptyReadmeCopy,
+  groupCapabilities,
+  resolveBundleMembers,
+  totalCapabilityCount,
+} from './marketplace-item-view';
 
 function SectionLabel({ children }: { children: React.ReactNode }) {
   return <div className="text-muted-foreground/60 mb-3 text-xs font-medium">{children}</div>;
@@ -40,26 +47,6 @@ function stripFrontmatter(md: string): string {
   return md;
 }
 
-function CapabilityCard({
-  icon: IconComponent,
-  title,
-  subtitle,
-}: {
-  icon: React.ComponentType<{ className?: string }>;
-  title: string;
-  subtitle: string;
-}) {
-  return (
-    <div className="bg-muted/40 flex items-start gap-3 rounded-lg px-4 py-3">
-      <IconComponent className="text-muted-foreground mt-0.5 size-4 shrink-0" />
-      <div className="min-w-0">
-        <div className="text-foreground truncate text-sm font-medium">{title}</div>
-        <div className="text-muted-foreground text-xs">{subtitle}</div>
-      </div>
-    </div>
-  );
-}
-
 export function MarketplaceItemDetail({
   onBack,
   onAdd,
@@ -73,20 +60,23 @@ export function MarketplaceItemDetail({
   addLabel?: string;
   installedNames?: Set<string>;
 }) {
-  const tI18nHardcoded = useTranslations('hardcodedUi');
   const openId = useMarketplaceDetailStore((s) => s.openId);
+  const openItem = useMarketplaceDetailStore((s) => s.openItem);
   const { data, isLoading } = useMarketplaceItem(openId);
   const tm = data ? typeMeta(data.type) : null;
-  const caps = data?.capabilities;
-  const capItems = caps
-    ? [
-        ...caps.secrets.map((s) => ({ kind: 'secret' as const, id: s })),
-        ...caps.connectors.map((c) => ({ kind: 'connector' as const, id: c })),
-        ...caps.tools.map((t) => ({ kind: 'tool' as const, id: t })),
-      ]
-    : [];
+  const capGroups = groupCapabilities(data?.capabilities);
+  const capCount = totalCapabilityCount(data?.capabilities);
   const readme = data?.readme ? stripFrontmatter(data.readme) : '';
   const isInstalled = !!(data && installedNames?.has(data.name));
+  const isBundle = data?.type === 'registry:bundle';
+  const bundleMembers =
+    data && isBundle
+      ? resolveBundleMembers({
+          dependencies: data.dependencies,
+          dependencyItems: data.dependencyItems,
+          hrefForId: (id) => id,
+        })
+      : [];
 
   const actions = !data ? null : isInstalled ? (
     <ButtonGroup>
@@ -155,11 +145,9 @@ export function MarketplaceItemDetail({
                   {actions}
                 </div>
 
-                {data.description && (
-                  <p className="text-muted-foreground max-w-prose text-sm leading-relaxed">
-                    {data.description}
-                  </p>
-                )}
+                <p className="text-muted-foreground max-w-prose text-sm leading-relaxed text-pretty">
+                  {data.description || emptyDescriptionCopy(data.type)}
+                </p>
 
                 <div className="text-muted-foreground flex flex-wrap items-center gap-x-4 gap-y-2 text-xs">
                   <span className="inline-flex min-w-0 items-center gap-1.5">
@@ -191,40 +179,82 @@ export function MarketplaceItemDetail({
                 </div>
               </header>
 
-              {capItems.length > 0 && (
+              {isBundle && bundleMembers.length > 0 && (
                 <section>
-                  <SectionLabel>Permissions {capItems.length}</SectionLabel>
-                  <div className="space-y-2">
-                    {capItems.map((item) => {
-                      if (item.kind === 'secret') {
-                        return (
-                          <CapabilityCard
-                            key={`secret:${item.id}`}
-                            icon={KeyRound}
-                            title={item.id}
-                            subtitle="Secret"
-                          />
-                        );
-                      }
-                      if (item.kind === 'connector') {
-                        return (
-                          <CapabilityCard
-                            key={`connector:${item.id}`}
-                            icon={Plug}
-                            title={item.id}
-                            subtitle="Connector"
-                          />
-                        );
-                      }
-                      return (
-                        <CapabilityCard
-                          key={`tool:${item.id}`}
-                          icon={Wrench}
-                          title={item.id}
-                          subtitle="Tool"
-                        />
-                      );
-                    })}
+                  <SectionLabel>What&rsquo;s inside {bundleMembers.length}</SectionLabel>
+                  <ul className="space-y-2">
+                    {bundleMembers.map((member) => (
+                      <li key={member.key}>
+                        <button
+                          type="button"
+                          disabled={!member.href}
+                          onClick={() => member.href && openItem(member.href)}
+                          className="group bg-popover hover:bg-muted/70 disabled:hover:bg-popover flex w-full items-center gap-3 rounded-md border px-3 py-2 text-left transition-colors disabled:cursor-default"
+                        >
+                          {member.type ? (
+                            <TypeTile type={member.type} size="sm" />
+                          ) : (
+                            <span className="bg-foreground/5 text-muted-foreground flex size-8 shrink-0 items-center justify-center rounded-lg">
+                              <FileText className="size-4" />
+                            </span>
+                          )}
+                          <span className="min-w-0 flex-1">
+                            <span className="text-foreground block truncate text-sm font-medium">
+                              {member.title}
+                            </span>
+                            {member.type && (
+                              <span className="text-muted-foreground block text-xs">
+                                {typeMeta(member.type).label}
+                              </span>
+                            )}
+                          </span>
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                </section>
+              )}
+
+              {capCount > 0 && (
+                <section>
+                  <SectionLabel>Requires {capCount}</SectionLabel>
+                  <div className="space-y-3">
+                    {capGroups.map((group) => (
+                      <div key={group.kind}>
+                        <div className="text-muted-foreground mb-1.5 text-xs">{group.label}</div>
+                        <div className="flex flex-wrap gap-1.5">
+                          {group.items.map((value) => (
+                            <Badge
+                              key={`${group.kind}:${value}`}
+                              variant="outline"
+                              size="sm"
+                              className="font-mono"
+                            >
+                              {value}
+                            </Badge>
+                          ))}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </section>
+              )}
+
+              {data.files.length > 0 && (
+                <section>
+                  <SectionLabel>Files {data.files.length}</SectionLabel>
+                  <div className="bg-popover max-h-72 overflow-y-auto rounded-md border">
+                    <ul className="divide-border divide-y">
+                      {data.files.map((file) => (
+                        <li
+                          key={file.target}
+                          className="text-foreground/90 truncate px-4 py-2 font-mono text-xs"
+                          title={file.target}
+                        >
+                          {file.target}
+                        </li>
+                      ))}
+                    </ul>
                   </div>
                 </section>
               )}
@@ -237,12 +267,8 @@ export function MarketplaceItemDetail({
                 ) : (
                   <EmptyState
                     icon={FileText}
-                    title={tI18nHardcoded.raw(
-                      'autoComponentsMarketplaceMarketplaceItemDetailJsxAttrTitleNoREADME4966916b',
-                    )}
-                    description={tI18nHardcoded.raw(
-                      'autoComponentsMarketplaceMarketplaceItemDetailJsxAttrDescriptionThisSkill2316ce31',
-                    )}
+                    title="No README"
+                    description={emptyReadmeCopy(data.type)}
                   />
                 )}
               </section>

--- a/apps/web/src/features/marketplace/marketplace-item-view.test.ts
+++ b/apps/web/src/features/marketplace/marketplace-item-view.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, test } from 'bun:test';
+
+import type { DependencyItem, ItemCapabilities } from '@/lib/marketplace-client';
+import {
+  emptyDescriptionCopy,
+  emptyReadmeCopy,
+  groupCapabilities,
+  itemCountLabel,
+  resolveBundleMembers,
+  totalCapabilityCount,
+} from './marketplace-item-view';
+
+describe('emptyDescriptionCopy', () => {
+  test('derives type-aware wording for a skill', () => {
+    expect(emptyDescriptionCopy('registry:skill')).toBe(
+      "This skill doesn't have a description yet.",
+    );
+  });
+
+  test('derives type-aware wording for an agent', () => {
+    expect(emptyDescriptionCopy('registry:agent')).toBe(
+      "This agent doesn't have a description yet.",
+    );
+  });
+
+  test('derives type-aware wording for a bundle', () => {
+    expect(emptyDescriptionCopy('registry:bundle')).toBe(
+      "This bundle doesn't have a description yet.",
+    );
+  });
+
+  test('falls back to the raw type label for an unknown type', () => {
+    expect(emptyDescriptionCopy('registry:widget')).toBe(
+      "This widget doesn't have a description yet.",
+    );
+  });
+});
+
+describe('emptyReadmeCopy', () => {
+  test('derives type-aware wording for a command', () => {
+    expect(emptyReadmeCopy('registry:command')).toBe("This command doesn't ship a README yet.");
+  });
+
+  test('derives type-aware wording for a skill', () => {
+    expect(emptyReadmeCopy('registry:skill')).toBe("This skill doesn't ship a README yet.");
+  });
+});
+
+describe('itemCountLabel', () => {
+  test('a bundle counts its member dependencies as items', () => {
+    const result = itemCountLabel({
+      type: 'registry:bundle',
+      dependencies: ['a', 'b', 'c'],
+      fileCount: 0,
+    });
+
+    expect(result).toEqual({ count: 3, unit: 'items' });
+  });
+
+  test('a bundle with exactly one member uses the singular unit', () => {
+    const result = itemCountLabel({ type: 'registry:bundle', dependencies: ['a'], fileCount: 0 });
+
+    expect(result).toEqual({ count: 1, unit: 'item' });
+  });
+
+  test('a non-bundle type counts files, ignoring dependencies', () => {
+    const result = itemCountLabel({ type: 'registry:skill', dependencies: ['a', 'b'], fileCount: 5 });
+
+    expect(result).toEqual({ count: 5, unit: 'files' });
+  });
+
+  test('a single file uses the singular unit', () => {
+    const result = itemCountLabel({ type: 'registry:agent', dependencies: [], fileCount: 1 });
+
+    expect(result).toEqual({ count: 1, unit: 'file' });
+  });
+});
+
+describe('resolveBundleMembers', () => {
+  const hrefForId = (id: string) => `/marketplace/${id}`;
+
+  test('joins each dependency name against its resolved metadata', () => {
+    const dependencyItems: DependencyItem[] = [
+      { id: 'kortix:review', name: 'review', type: 'registry:skill', title: 'Review', description: null },
+    ];
+
+    const members = resolveBundleMembers({
+      dependencies: ['review'],
+      dependencyItems,
+      hrefForId,
+    });
+
+    expect(members).toEqual([
+      { key: 'kortix:review', title: 'Review', type: 'registry:skill', href: '/marketplace/kortix:review' },
+    ]);
+  });
+
+  test('preserves dependency order even when resolved metadata arrives in a different order', () => {
+    const dependencyItems: DependencyItem[] = [
+      { id: 'kortix:b', name: 'b', type: 'registry:skill', title: 'B', description: null },
+      { id: 'kortix:a', name: 'a', type: 'registry:skill', title: 'A', description: null },
+    ];
+
+    const members = resolveBundleMembers({
+      dependencies: ['a', 'b'],
+      dependencyItems,
+      hrefForId,
+    });
+
+    expect(members.map((m) => m.key)).toEqual(['kortix:a', 'kortix:b']);
+  });
+
+  test('falls back to the bare name when a dependency has no resolved metadata', () => {
+    const members = resolveBundleMembers({
+      dependencies: ['unresolved-item'],
+      dependencyItems: [],
+      hrefForId,
+    });
+
+    expect(members).toEqual([{ key: 'unresolved-item', title: 'unresolved-item', type: null, href: null }]);
+  });
+
+  test('an empty dependency list produces no members', () => {
+    expect(resolveBundleMembers({ dependencies: [], dependencyItems: [], hrefForId })).toEqual([]);
+  });
+});
+
+describe('groupCapabilities', () => {
+  function caps(overrides: Partial<ItemCapabilities>): ItemCapabilities {
+    return { secrets: [], connectors: [], tools: [], network: [], ...overrides };
+  }
+
+  test('includes network alongside secrets, connectors, and tools', () => {
+    const groups = groupCapabilities(
+      caps({ secrets: ['API_KEY'], connectors: ['slack'], tools: ['search'], network: ['api.example.com'] }),
+    );
+
+    expect(groups).toEqual([
+      { kind: 'secret', label: 'Secrets', items: ['API_KEY'] },
+      { kind: 'connector', label: 'Connectors', items: ['slack'] },
+      { kind: 'tool', label: 'Tools', items: ['search'] },
+      { kind: 'network', label: 'Network', items: ['api.example.com'] },
+    ]);
+  });
+
+  test('drops groups with no items', () => {
+    const groups = groupCapabilities(caps({ secrets: ['API_KEY'] }));
+
+    expect(groups).toEqual([{ kind: 'secret', label: 'Secrets', items: ['API_KEY'] }]);
+  });
+
+  test('an item with no capabilities produces no groups', () => {
+    expect(groupCapabilities(caps({}))).toEqual([]);
+  });
+
+  test('null/undefined capabilities produce no groups', () => {
+    expect(groupCapabilities(null)).toEqual([]);
+    expect(groupCapabilities(undefined)).toEqual([]);
+  });
+});
+
+describe('totalCapabilityCount', () => {
+  test('sums every capability kind, including network', () => {
+    const count = totalCapabilityCount({
+      secrets: ['A', 'B'],
+      connectors: ['c'],
+      tools: [],
+      network: ['n1', 'n2', 'n3'],
+    });
+
+    expect(count).toBe(6);
+  });
+
+  test('null/undefined capabilities count as zero', () => {
+    expect(totalCapabilityCount(null)).toBe(0);
+    expect(totalCapabilityCount(undefined)).toBe(0);
+  });
+});

--- a/apps/web/src/features/marketplace/marketplace-item-view.ts
+++ b/apps/web/src/features/marketplace/marketplace-item-view.ts
@@ -1,0 +1,92 @@
+import type { DependencyItem, ItemCapabilities, MarketplaceItem } from '@/lib/marketplace-client';
+import { typeMeta } from './marketplace-meta';
+
+/** Type-aware copy for the "no description" state. Every item type reads as
+ *  itself instead of silently assuming "skill". */
+export function emptyDescriptionCopy(type: string): string {
+  return `This ${typeMeta(type).label.toLowerCase()} doesn't have a description yet.`;
+}
+
+/** Type-aware copy for the "no README" empty state. */
+export function emptyReadmeCopy(type: string): string {
+  return `This ${typeMeta(type).label.toLowerCase()} doesn't ship a README yet.`;
+}
+
+/** Type-aware meta-line count label for a card/detail (e.g. "3 items" for a
+ *  bundle's member count, "12 files" for everything else). */
+export function itemCountLabel(item: Pick<MarketplaceItem, 'type' | 'dependencies' | 'fileCount'>): {
+  count: number;
+  unit: string;
+} {
+  if (item.type === 'registry:bundle') {
+    const count = item.dependencies.length;
+    return { count, unit: count === 1 ? 'item' : 'items' };
+  }
+  const count = item.fileCount;
+  return { count, unit: count === 1 ? 'file' : 'files' };
+}
+
+/** A single "what's inside" row for a bundle's member items. Prefers the
+ *  resolved `DependencyItem` (title/type known) and falls back to the bare
+ *  dependency name when the server hasn't resolved it (e.g. an external ref
+ *  the catalog couldn't join). */
+export interface BundleMember {
+  key: string;
+  title: string;
+  type: string | null;
+  href: string | null;
+}
+
+/** Derives the ordered member list for a bundle's "What's inside" section,
+ *  joining `dependencies` (names, always present) against `dependencyItems`
+ *  (resolved metadata, best-effort) by name. Extracted so the join/fallback
+ *  logic is unit-testable without mounting the detail view. */
+export function resolveBundleMembers(params: {
+  dependencies: string[];
+  dependencyItems: DependencyItem[];
+  hrefForId: (id: string) => string;
+}): BundleMember[] {
+  const byName = new Map(params.dependencyItems.map((d) => [d.name, d]));
+  return params.dependencies.map((name) => {
+    const resolved = byName.get(name);
+    if (resolved) {
+      return {
+        key: resolved.id,
+        title: resolved.title,
+        type: resolved.type,
+        href: params.hrefForId(resolved.id),
+      };
+    }
+    return { key: name, title: name, type: null, href: null };
+  });
+}
+
+/** One row in the grouped capability-badge display. */
+export type CapabilityKind = 'secret' | 'connector' | 'tool' | 'network';
+
+export interface CapabilityGroup {
+  kind: CapabilityKind;
+  label: string;
+  items: string[];
+}
+
+/** Groups an item's `capabilities` into labeled sections for the detail
+ *  view's scannable badge rows, dropping empty groups. Includes `network`,
+ *  which existing detail views silently omitted. */
+export function groupCapabilities(caps: ItemCapabilities | undefined | null): CapabilityGroup[] {
+  if (!caps) return [];
+  const groups: CapabilityGroup[] = [
+    { kind: 'secret', label: 'Secrets', items: caps.secrets },
+    { kind: 'connector', label: 'Connectors', items: caps.connectors },
+    { kind: 'tool', label: 'Tools', items: caps.tools },
+    { kind: 'network', label: 'Network', items: caps.network },
+  ];
+  return groups.filter((g) => g.items.length > 0);
+}
+
+/** Total capability count across all groups — used for section-header counts
+ *  and to decide whether the capabilities section renders at all. */
+export function totalCapabilityCount(caps: ItemCapabilities | undefined | null): number {
+  if (!caps) return 0;
+  return caps.secrets.length + caps.connectors.length + caps.tools.length + caps.network.length;
+}

--- a/apps/web/src/features/marketplace/marketplace-public-detail.tsx
+++ b/apps/web/src/features/marketplace/marketplace-public-detail.tsx
@@ -1,12 +1,14 @@
 'use client';
 
-import { FileText, KeyRound, Layers, Plug, Wrench } from 'lucide-react';
+import { FileText } from 'lucide-react';
 import Link from 'next/link';
+import { usePathname } from 'next/navigation';
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 
 import { cn } from '@/lib/utils';
 
 import { UnifiedMarkdown } from '@/components/markdown';
+import { Badge } from '@/components/ui/badge';
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -18,13 +20,21 @@ import {
 import { Button } from '@/components/ui/button';
 import { FadedScrollArea } from '@/components/ui/faded-scroll-area';
 import { EmptyState } from '@/features/layout/section/empty-state';
+import { useAuth } from '@/features/providers/auth-provider';
 import type { MarketplaceItemDetail, MarketplaceSummary } from '@/lib/marketplace-client';
 import { marketplaceCompanyHref, marketplaceItemHref } from '@/lib/marketplace-slug';
 import { MarketplaceAddButton } from './marketplace-add-button';
 import { MarketplaceAvatar } from './marketplace-avatar';
 import { displayCompanyLabel } from './marketplace-company-filter';
 import { MarketplaceItemAvatar } from './marketplace-item-avatar';
-import { typeMeta } from './marketplace-meta';
+import {
+  emptyDescriptionCopy,
+  emptyReadmeCopy,
+  groupCapabilities,
+  resolveBundleMembers,
+  totalCapabilityCount,
+} from './marketplace-item-view';
+import { TypeTile, typeMeta } from './marketplace-meta';
 
 function stripFrontmatter(md: string): string {
   if (md.startsWith('---')) {
@@ -106,24 +116,30 @@ function CompanyAside({
   );
 }
 
-function MetaRow({
-  icon: IconComponent,
+function BundleMemberRow({
   title,
-  subtitle,
+  type,
   href,
 }: {
-  icon: React.ComponentType<{ className?: string }>;
   title: string;
-  subtitle?: string;
-  href?: string;
+  type: string | null;
+  href: string | null;
 }) {
   const body = (
     <>
-      <IconComponent className="text-muted-foreground size-4 shrink-0" />
-      <span className="text-foreground min-w-0 flex-1 truncate text-sm">{title}</span>
-      {subtitle ? (
-        <span className="text-muted-foreground/70 shrink-0 text-xs">{subtitle}</span>
-      ) : null}
+      {type ? (
+        <TypeTile type={type} size="sm" />
+      ) : (
+        <span className="bg-foreground/5 text-muted-foreground flex size-8 shrink-0 items-center justify-center rounded-lg">
+          <FileText className="size-4" />
+        </span>
+      )}
+      <span className="min-w-0 flex-1">
+        <span className="text-foreground block truncate text-sm">{title}</span>
+        {type ? (
+          <span className="text-muted-foreground/70 block text-xs">{typeMeta(type).label}</span>
+        ) : null}
+      </span>
     </>
   );
   if (href) {
@@ -207,12 +223,18 @@ export function MarketplacePublicDetail({
   company?: MarketplaceSummary;
 }) {
   const tm = typeMeta(data.type);
-  const caps = data.capabilities;
-  const capItems = [
-    ...caps.secrets.map((s) => ({ kind: 'secret' as const, id: s })),
-    ...caps.connectors.map((c) => ({ kind: 'connector' as const, id: c })),
-    ...caps.tools.map((t) => ({ kind: 'tool' as const, id: t })),
-  ];
+  const { user, isLoading: authLoading } = useAuth();
+  const pathname = usePathname();
+  const capGroups = groupCapabilities(data.capabilities);
+  const capCount = totalCapabilityCount(data.capabilities);
+  const isBundle = data.type === 'registry:bundle';
+  const bundleMembers = isBundle
+    ? resolveBundleMembers({
+        dependencies: data.dependencies,
+        dependencyItems: data.dependencyItems,
+        hrefForId: marketplaceItemHref,
+      })
+    : [];
   const readme = data.readme ? stripFrontmatter(data.readme) : '';
   const itemTitle = data.title.replaceAll('-', ' ');
   const companyLabel = displayCompanyLabel(data.marketplaceId, data.marketplaceLabel);
@@ -259,65 +281,90 @@ export function MarketplacePublicDetail({
             <div className="flex items-start justify-between gap-4">
               <div className="flex min-w-0 items-center gap-4">
                 <MarketplaceItemAvatar item={data} size="md" showSource={false} />
-                <h1 className="text-foreground text-2xl font-semibold tracking-tight text-balance capitalize sm:text-3xl">
-                  {itemTitle}
-                </h1>
+                <div className="min-w-0 space-y-1">
+                  <h1 className="text-foreground text-2xl font-semibold tracking-tight text-balance capitalize sm:text-3xl">
+                    {itemTitle}
+                  </h1>
+                  <span className="text-muted-foreground inline-flex items-center gap-1.5 text-xs">
+                    <tm.Icon className="size-3.5 shrink-0" />
+                    {tm.label}
+                  </span>
+                </div>
               </div>
-              <MarketplaceAddButton item={data} />
+              <div className="flex shrink-0 flex-col items-end gap-2">
+                <MarketplaceAddButton item={data} />
+                {!authLoading && !user ? (
+                  <Link
+                    href={`/auth?redirect=${encodeURIComponent(pathname)}`}
+                    className="text-muted-foreground hover:text-foreground text-xs transition-colors"
+                  >
+                    Sign in to add to a project
+                  </Link>
+                ) : null}
+              </div>
             </div>
-            {data.description ? (
-              <p className="text-foreground text-base leading-relaxed text-pretty">
-                {data.description}
-              </p>
-            ) : null}
+            <p className="text-foreground text-base leading-relaxed text-pretty">
+              {data.description || emptyDescriptionCopy(data.type)}
+            </p>
           </header>
 
-          {capItems.length > 0 ? (
+          {isBundle && bundleMembers.length > 0 ? (
             <section>
-              <SectionLabel count={capItems.length}>Permissions</SectionLabel>
+              <SectionLabel count={bundleMembers.length}>What&rsquo;s inside</SectionLabel>
               <RowPanel>
-                {capItems.map((item) =>
-                  item.kind === 'secret' ? (
-                    <MetaRow
-                      key={`secret:${item.id}`}
-                      icon={KeyRound}
-                      title={item.id}
-                      subtitle="Secret"
-                    />
-                  ) : item.kind === 'connector' ? (
-                    <MetaRow
-                      key={`connector:${item.id}`}
-                      icon={Plug}
-                      title={item.id}
-                      subtitle="Connector"
-                    />
-                  ) : (
-                    <MetaRow
-                      key={`tool:${item.id}`}
-                      icon={Wrench}
-                      title={item.id}
-                      subtitle="Tool"
-                    />
-                  ),
-                )}
+                {bundleMembers.map((member) => (
+                  <BundleMemberRow
+                    key={member.key}
+                    title={member.title}
+                    type={member.type}
+                    href={member.href}
+                  />
+                ))}
               </RowPanel>
             </section>
           ) : null}
 
-          {data.dependencyItems.length > 0 ? (
+          {capCount > 0 ? (
             <section>
-              <SectionLabel count={data.dependencyItems.length}>Includes</SectionLabel>
-              <RowPanel>
-                {data.dependencyItems.map((dep) => (
-                  <MetaRow
-                    key={dep.id}
-                    icon={Layers}
-                    title={dep.title}
-                    subtitle={typeMeta(dep.type).label}
-                    href={marketplaceItemHref(dep.id)}
-                  />
+              <SectionLabel count={capCount}>Requires</SectionLabel>
+              <div className="bg-popover space-y-3 rounded-md border px-4 py-4">
+                {capGroups.map((group) => (
+                  <div key={group.kind}>
+                    <div className="text-muted-foreground mb-1.5 text-xs">{group.label}</div>
+                    <div className="flex flex-wrap gap-1.5">
+                      {group.items.map((value) => (
+                        <Badge
+                          key={`${group.kind}:${value}`}
+                          variant="outline"
+                          size="sm"
+                          className="font-mono"
+                        >
+                          {value}
+                        </Badge>
+                      ))}
+                    </div>
+                  </div>
                 ))}
-              </RowPanel>
+              </div>
+            </section>
+          ) : null}
+
+          {data.files.length > 0 ? (
+            <section>
+              <SectionLabel count={data.files.length}>Files</SectionLabel>
+              <div className="bg-popover max-h-72 overflow-y-auto rounded-md border">
+                <ul className="divide-border divide-y">
+                  {data.files.map((file) => (
+                    <li
+                      key={file.target}
+                      className="text-foreground/90 truncate px-4 py-2 font-mono text-xs"
+                      title={file.target}
+                    >
+                      {file.target}
+                    </li>
+                  ))}
+                </ul>
+              </div>
             </section>
           ) : null}
 
@@ -329,7 +376,7 @@ export function MarketplacePublicDetail({
                 icon={FileText}
                 size="sm"
                 title="No README"
-                description="This item doesn't ship a README yet."
+                description={emptyReadmeCopy(data.type)}
               />
             )}
           </section>

--- a/apps/web/src/features/projects/modal/rename-project-modal.tsx
+++ b/apps/web/src/features/projects/modal/rename-project-modal.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState } from 'react';
 
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import Loading from '@/components/ui/loading';
 import {
   Modal,
   ModalBody,
@@ -53,7 +54,7 @@ export const RenameProjectDialog = ({
         queryClient.setQueryData(['project', projectId], updated);
       }
       queryClient.invalidateQueries({ queryKey: ['projects'] });
-      successToast('Project renamed');
+      successToast(updated?.name ? `Renamed to "${updated.name}"` : 'Project renamed');
       onSaved?.();
       onOpenChange(false);
     },
@@ -72,7 +73,12 @@ export const RenameProjectDialog = ({
   };
 
   return (
-    <Modal open={open} onOpenChange={onOpenChange}>
+    <Modal
+      open={open}
+      onOpenChange={(o) => {
+        if (!renameMutation.isPending) onOpenChange(o);
+      }}
+    >
       <ModalContent className="lg:max-w-md">
         <ModalHeader>
           <ModalTitle>
@@ -104,11 +110,16 @@ export const RenameProjectDialog = ({
           />
         </ModalBody>
         <ModalFooter className="sm:justify-between">
-          <Button variant="outline-ghost" onClick={() => onOpenChange(false)}>
+          <Button
+            variant="outline-ghost"
+            onClick={() => onOpenChange(false)}
+            disabled={renameMutation.isPending}
+          >
             Cancel
           </Button>
           <Button onClick={submit} disabled={renameMutation.isPending || isUnchanged || isEmpty}>
-            {renameMutation.isPending ? 'Saving…' : 'Save'}
+            {renameMutation.isPending ? <Loading className="size-4 shrink-0" /> : null}
+            Save
           </Button>
         </ModalFooter>
       </ModalContent>

--- a/apps/web/src/features/projects/project-card.tsx
+++ b/apps/web/src/features/projects/project-card.tsx
@@ -46,10 +46,15 @@ const ProjectCard = ({
         <div className="flex w-full items-center gap-3">
           <EntityAvatar label={project.name} size="lg" className="bg-background" />
           <div className="min-w-0 flex-1 space-y-1">
-            <h3 className="text-foreground truncate text-sm leading-tight font-semibold">
+            <h3
+              title={project.name}
+              className="text-foreground truncate text-sm leading-tight font-semibold"
+            >
               {project.name}
             </h3>
-            <p className="text-muted-foreground truncate text-xs">Updated {updatedLabel}</p>
+            <p className="text-muted-foreground truncate text-xs tabular-nums">
+              Updated {updatedLabel}
+            </p>
           </div>
         </div>
       </button>
@@ -81,7 +86,7 @@ const ProjectCard = ({
               onSelect={onArchive}
               disabled={archiving || !canManageProject}
             >
-              {archiving ? <Loading /> : <TrashSolid className="size-4" />}
+              {archiving ? <Loading className="size-4 shrink-0" /> : <TrashSolid className="size-4" />}
               Archive
             </DropdownMenuItem>
           </DropdownMenuContent>

--- a/apps/web/src/features/review-center/hooks/use-review-items.ts
+++ b/apps/web/src/features/review-center/hooks/use-review-items.ts
@@ -7,6 +7,7 @@ import {
   actReviewItem,
   bulkActReviewItems,
   listReviewItems,
+  resolveApproval,
   submitReviewItem,
 } from '@kortix/sdk/projects-client';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
@@ -69,6 +70,30 @@ export function useSubmitReviewItem() {
   const invalidate = useInvalidate(projectId);
   return useMutation<ApiReviewItem, Error, Parameters<typeof submitReviewItem>[1]>({
     mutationFn: (input) => submitReviewItem(projectId, input),
+    onSuccess: invalidate,
+  });
+}
+
+/**
+ * Resolve an executor approval (`exec:` adapted review item) directly from the
+ * inbox — the SAME call + payload the in-session approval prompt uses
+ * (`resolveApproval`, via `SessionApprovalPrompt` → `useResolveApproval` in
+ * session-audit-shared.tsx). Scope is always `'once'` here: the inbox acts on
+ * one specific pending call, not "for the rest of this session" — that
+ * broader scope stays a session-view-only affordance since it needs the
+ * session's other pending rows in view to make sense.
+ */
+export function useResolveReviewApproval() {
+  const ctx = useProjectContext();
+  const projectId = ctx?.projectId ?? '';
+  const invalidate = useInvalidate(projectId);
+  return useMutation<
+    { ok: boolean; scope?: 'once' | 'session' | 'session_all' },
+    Error,
+    { executionId: string; decision: 'approve' | 'deny' }
+  >({
+    mutationFn: ({ executionId, decision }) =>
+      resolveApproval(projectId, executionId, decision, 'once'),
     onSuccess: invalidate,
   });
 }

--- a/apps/web/src/features/review-center/review-actions.test.ts
+++ b/apps/web/src/features/review-center/review-actions.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import {
+  bulkSkipMessage,
   crChangeRequestId,
   execExecutionId,
   formatItemAge,
@@ -7,7 +8,9 @@ import {
   isQuickDecidableApproval,
   itemDeepLink,
   planBulkAction,
+  resolveBulkOutcome,
 } from './review-actions';
+import type { ReviewRisk } from './types';
 
 describe('execExecutionId', () => {
   test('strips the exec: prefix', () => {
@@ -111,5 +114,66 @@ describe('formatItemAgeLong', () => {
     expect(formatItemAgeLong(new Date(base - 7 * 60_000).toISOString(), base)).toBe('7m ago');
     expect(formatItemAgeLong(new Date(base - 3 * 3_600_000).toISOString(), base)).toBe('3h ago');
     expect(formatItemAgeLong(new Date(base - 50 * 3_600_000).toISOString(), base)).toBe('2d ago');
+  });
+});
+
+describe('resolveBulkOutcome', () => {
+  const risk =
+    (m: Record<string, ReviewRisk>) =>
+    (id: string): ReviewRisk | undefined =>
+      m[id];
+
+  test('dismiss NEVER answers an executor approval — exec ids are kept, not denied', () => {
+    const out = resolveBulkOutcome(['exec:e1', 'rv-1'], 'dismiss', risk({ 'exec:e1': 'none' }));
+    expect(out.act).toEqual(['rv-1']);
+    expect(out.skippedApprovals).toEqual(['exec:e1']);
+    expect(out.skippedRisky).toEqual([]);
+  });
+
+  test('approve sweeps only safe exec approvals; risky ones are skipped', () => {
+    const out = resolveBulkOutcome(
+      ['exec:safe', 'exec:risky', 'rv-1'],
+      'approve',
+      risk({ 'exec:safe': 'low', 'exec:risky': 'high' }),
+    );
+    expect(out.act).toEqual(['exec:safe', 'rv-1']);
+    expect(out.skippedRisky).toEqual(['exec:risky']);
+    expect(out.skippedApprovals).toEqual([]);
+  });
+
+  test('an exec approval with unknown risk is treated as risky on approve', () => {
+    const out = resolveBulkOutcome(['exec:mystery'], 'approve', risk({}));
+    expect(out.act).toEqual([]);
+    expect(out.skippedRisky).toEqual(['exec:mystery']);
+  });
+
+  test('Change Requests are skipped under any verdict', () => {
+    expect(resolveBulkOutcome(['cr:1'], 'approve', risk({})).skippedChanges).toEqual(['cr:1']);
+    expect(resolveBulkOutcome(['cr:1'], 'dismiss', risk({})).skippedChanges).toEqual(['cr:1']);
+  });
+
+  test('native ids act under both verdicts', () => {
+    expect(resolveBulkOutcome(['rv-1', 'rv-2'], 'dismiss', risk({})).act).toEqual(['rv-1', 'rv-2']);
+    expect(resolveBulkOutcome(['rv-1'], 'approve', risk({})).act).toEqual(['rv-1']);
+  });
+});
+
+describe('bulkSkipMessage', () => {
+  test('empty when nothing was skipped', () => {
+    expect(
+      bulkSkipMessage({ act: ['a'], skippedRisky: [], skippedApprovals: [], skippedChanges: [] }),
+    ).toBe('');
+  });
+
+  test('names every skip bucket with counts', () => {
+    const msg = bulkSkipMessage({
+      act: [],
+      skippedRisky: ['exec:r'],
+      skippedApprovals: ['exec:a', 'exec:b'],
+      skippedChanges: ['cr:1'],
+    });
+    expect(msg).toContain('2 approvals kept');
+    expect(msg).toContain('1 risky approval skipped');
+    expect(msg).toContain('1 change skipped');
   });
 });

--- a/apps/web/src/features/review-center/review-actions.test.ts
+++ b/apps/web/src/features/review-center/review-actions.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  crChangeRequestId,
+  execExecutionId,
+  formatItemAge,
+  formatItemAgeLong,
+  isQuickDecidableApproval,
+  itemDeepLink,
+  planBulkAction,
+} from './review-actions';
+
+describe('execExecutionId', () => {
+  test('strips the exec: prefix', () => {
+    expect(execExecutionId('exec:abc-123')).toBe('abc-123');
+  });
+  test('returns null for a non-exec id', () => {
+    expect(execExecutionId('cr:abc-123')).toBeNull();
+    expect(execExecutionId('rv-native-1')).toBeNull();
+    expect(execExecutionId('')).toBeNull();
+  });
+});
+
+describe('crChangeRequestId', () => {
+  test('strips the cr: prefix', () => {
+    expect(crChangeRequestId('cr:xyz-9')).toBe('xyz-9');
+  });
+  test('returns null for a non-cr id', () => {
+    expect(crChangeRequestId('exec:xyz-9')).toBeNull();
+    expect(crChangeRequestId('rv-native-1')).toBeNull();
+  });
+});
+
+describe('itemDeepLink', () => {
+  test('builds the session route when both ids are present', () => {
+    expect(itemDeepLink('proj-1', 'sess-1')).toBe('/projects/proj-1/sessions/sess-1');
+  });
+  test('is null without a session id (nothing to deep-link into)', () => {
+    expect(itemDeepLink('proj-1', undefined)).toBeNull();
+    expect(itemDeepLink('proj-1', null)).toBeNull();
+    expect(itemDeepLink('proj-1', '')).toBeNull();
+  });
+  test('is null without a project id', () => {
+    expect(itemDeepLink('', 'sess-1')).toBeNull();
+  });
+});
+
+describe('planBulkAction', () => {
+  test('buckets ids by how the inbox can act on them', () => {
+    const plan = planBulkAction(['rv-1', 'exec:e1', 'cr:c1', 'rv-2', 'exec:e2']);
+    expect(plan.native).toEqual(['rv-1', 'rv-2']);
+    expect(plan.resolvable).toEqual(['exec:e1', 'exec:e2']);
+    expect(plan.unsupported).toEqual(['cr:c1']);
+  });
+  test('accepts a Set and handles an all-native selection', () => {
+    const plan = planBulkAction(new Set(['rv-1', 'rv-2']));
+    expect(plan).toEqual({ native: ['rv-1', 'rv-2'], resolvable: [], unsupported: [] });
+  });
+  test('empty selection yields empty buckets', () => {
+    expect(planBulkAction([])).toEqual({ native: [], resolvable: [], unsupported: [] });
+  });
+});
+
+describe('formatItemAge', () => {
+  const base = new Date('2026-07-08T12:00:00.000Z').getTime();
+  test('minutes under an hour', () => {
+    expect(formatItemAge(new Date(base - 7 * 60_000).toISOString(), base)).toBe('7m');
+  });
+  test('floors at 1 minute for sub-minute / future timestamps', () => {
+    expect(formatItemAge(new Date(base).toISOString(), base)).toBe('1m');
+    expect(formatItemAge(new Date(base + 60_000).toISOString(), base)).toBe('1m');
+  });
+  test('hours under a day', () => {
+    expect(formatItemAge(new Date(base - 3 * 3_600_000).toISOString(), base)).toBe('3h');
+  });
+  test('days at or beyond 24 hours', () => {
+    expect(formatItemAge(new Date(base - 50 * 3_600_000).toISOString(), base)).toBe('2d');
+  });
+});
+
+describe('isQuickDecidableApproval', () => {
+  test('a single-action executor approval is quick-decidable', () => {
+    expect(
+      isQuickDecidableApproval({ kind: 'approval', id: 'exec:e1', detail: { actions: [{}] } }),
+    ).toBe(true);
+  });
+  test('an approval with no detail (defensive) is quick-decidable', () => {
+    expect(isQuickDecidableApproval({ kind: 'approval', id: 'exec:e1' })).toBe(true);
+  });
+  test('a multi-action approval needs the modal', () => {
+    expect(
+      isQuickDecidableApproval({
+        kind: 'approval',
+        id: 'exec:e1',
+        detail: { actions: [{}, {}] },
+      }),
+    ).toBe(false);
+  });
+  test('a Change Request approval-kind lookalike is not quick-decidable (not an exec id)', () => {
+    expect(
+      isQuickDecidableApproval({ kind: 'approval', id: 'rv-native-1', detail: { actions: [{}] } }),
+    ).toBe(false);
+  });
+  test('non-approval kinds are never quick-decidable', () => {
+    expect(isQuickDecidableApproval({ kind: 'change', id: 'exec:e1' })).toBe(false);
+  });
+});
+
+describe('formatItemAgeLong', () => {
+  const base = new Date('2026-07-08T12:00:00.000Z').getTime();
+  test('appends "ago" at every scale', () => {
+    expect(formatItemAgeLong(new Date(base - 7 * 60_000).toISOString(), base)).toBe('7m ago');
+    expect(formatItemAgeLong(new Date(base - 3 * 3_600_000).toISOString(), base)).toBe('3h ago');
+    expect(formatItemAgeLong(new Date(base - 50 * 3_600_000).toISOString(), base)).toBe('2d ago');
+  });
+});

--- a/apps/web/src/features/review-center/review-actions.ts
+++ b/apps/web/src/features/review-center/review-actions.ts
@@ -8,7 +8,7 @@
  * endpoint, which 409s on them by design (see review-center-connected.tsx).
  */
 
-import type { ReviewItem } from './types';
+import { type ReviewItem, type ReviewRisk, isSafeRisk } from './types';
 
 export const CR_ID_PREFIX = 'cr:';
 export const EXEC_ID_PREFIX = 'exec:';
@@ -34,11 +34,15 @@ export function crChangeRequestId(id: string): string | null {
  * several independent decisions.
  */
 export function isQuickDecidableApproval(
-  item: Pick<ReviewItem, 'kind' | 'id'> & { detail?: { actions?: unknown[] } },
+  // `detail` is `unknown` (not `{ actions?: ... }`) so every ReviewItem union
+  // member is assignable — ChangeDetail/OutputDetail have no `actions` and a
+  // weak object type would reject them at the call sites.
+  item: Pick<ReviewItem, 'kind' | 'id'> & { detail?: unknown },
 ): boolean {
   if (item.kind !== 'approval') return false;
   if (execExecutionId(item.id) === null) return false;
-  const count = item.detail?.actions?.length ?? 0;
+  const detail = item.detail as { actions?: readonly unknown[] } | undefined;
+  const count = detail?.actions?.length ?? 0;
   return count <= 1;
 }
 
@@ -77,6 +81,69 @@ export function planBulkAction(ids: Iterable<string>): BulkActionPlan {
     else native.push(id);
   }
   return { native, resolvable, unsupported };
+}
+
+/**
+ * What a bulk verdict on a connected selection will REALLY do, decided before
+ * any optimistic UI update so the toast/removal can never claim more than the
+ * server was asked. The rules the buckets encode:
+ *  - Executor approvals are a live question to the agent: "dismiss" doesn't
+ *    answer it, so they're KEPT (never mapped to a deny) under any non-approve
+ *    verdict, and an approve sweep still respects the safe-risk floor.
+ *  - Change Requests have no bulk path at all (merging needs the diff in view).
+ */
+export interface BulkOutcome {
+  /** Ids the verdict genuinely acts on — safe to optimistically update. */
+  act: string[];
+  /** Exec approvals blocked by the approve safe-risk floor. */
+  skippedRisky: string[];
+  /** Exec approvals kept under a non-approve verdict (dismiss ≠ deny). */
+  skippedApprovals: string[];
+  /** Change Requests — each needs its own review. */
+  skippedChanges: string[];
+}
+
+export function resolveBulkOutcome(
+  ids: Iterable<string>,
+  verdict: 'approve' | 'dismiss',
+  riskOf: (id: string) => ReviewRisk | undefined,
+): BulkOutcome {
+  const act: string[] = [];
+  const skippedRisky: string[] = [];
+  const skippedApprovals: string[] = [];
+  const skippedChanges: string[] = [];
+  for (const id of ids) {
+    if (crChangeRequestId(id) !== null) {
+      skippedChanges.push(id);
+    } else if (execExecutionId(id) !== null) {
+      if (verdict !== 'approve') skippedApprovals.push(id);
+      else if (!isSafeRisk(riskOf(id) ?? 'high')) skippedRisky.push(id);
+      else act.push(id);
+    } else {
+      act.push(id);
+    }
+  }
+  return { act, skippedRisky, skippedApprovals, skippedChanges };
+}
+
+/** One compact sentence describing what a bulk verdict skipped (empty string
+ *  when nothing was). Kept pure so the copy is unit-testable. */
+export function bulkSkipMessage(outcome: BulkOutcome): string {
+  const parts: string[] = [];
+  const plural = (n: number, s: string, p: string) => (n === 1 ? s : p);
+  if (outcome.skippedApprovals.length > 0)
+    parts.push(
+      `${outcome.skippedApprovals.length} ${plural(outcome.skippedApprovals.length, 'approval', 'approvals')} kept — dismissing doesn't answer the agent; approve or deny ${plural(outcome.skippedApprovals.length, 'it', 'them')}`,
+    );
+  if (outcome.skippedRisky.length > 0)
+    parts.push(
+      `${outcome.skippedRisky.length} risky ${plural(outcome.skippedRisky.length, 'approval', 'approvals')} skipped — review ${plural(outcome.skippedRisky.length, 'it', 'them')} individually`,
+    );
+  if (outcome.skippedChanges.length > 0)
+    parts.push(
+      `${outcome.skippedChanges.length} ${plural(outcome.skippedChanges.length, 'change', 'changes')} skipped — open ${plural(outcome.skippedChanges.length, 'it', 'each')} to review`,
+    );
+  return parts.join('. ');
 }
 
 /** Relative age like "7m", "3h", "2d" — the compact inbox-row idiom (see

--- a/apps/web/src/features/review-center/review-actions.ts
+++ b/apps/web/src/features/review-center/review-actions.ts
@@ -1,0 +1,101 @@
+/**
+ * Pure helpers for acting on adapted review items (Change Requests + executor
+ * approvals) from the inbox. Kept free of React/query so the id-parsing and
+ * URL-building logic — the part worth getting right — is unit-testable.
+ *
+ * Adapted items carry a namespaced id (`cr:<id>` / `exec:<id>`) so the inbox
+ * can route a verdict to the right source instead of the native `/act`
+ * endpoint, which 409s on them by design (see review-center-connected.tsx).
+ */
+
+import type { ReviewItem } from './types';
+
+export const CR_ID_PREFIX = 'cr:';
+export const EXEC_ID_PREFIX = 'exec:';
+
+/** Strip the `exec:` namespace prefix, returning the underlying
+ *  `executorExecutions.executionId` that `resolveApproval` expects — or
+ *  `null` if `id` isn't an adapted executor-approval id. */
+export function execExecutionId(id: string): string | null {
+  return id.startsWith(EXEC_ID_PREFIX) ? id.slice(EXEC_ID_PREFIX.length) : null;
+}
+
+/** Strip the `cr:` namespace prefix, returning the underlying Change Request
+ *  id — or `null` if `id` isn't an adapted CR id. */
+export function crChangeRequestId(id: string): string | null {
+  return id.startsWith(CR_ID_PREFIX) ? id.slice(CR_ID_PREFIX.length) : null;
+}
+
+/**
+ * True when the row can show Approve/Deny buttons directly — no modal hop —
+ * because the item resolves to exactly one clear decision: a single-action
+ * executor approval. Multi-action approvals (the prototype's bulk-approval
+ * shape) still need the detail modal, since one button pair can't represent
+ * several independent decisions.
+ */
+export function isQuickDecidableApproval(
+  item: Pick<ReviewItem, 'kind' | 'id'> & { detail?: { actions?: unknown[] } },
+): boolean {
+  if (item.kind !== 'approval') return false;
+  if (execExecutionId(item.id) === null) return false;
+  const count = item.detail?.actions?.length ?? 0;
+  return count <= 1;
+}
+
+/** Build the deep link that lands the user exactly where they can act on an
+ *  item whose source view isn't reachable inline from the inbox — the
+ *  item's originating session. Returns `null` when the item has no
+ *  originating session to link to (nothing to deep-link into). */
+export function itemDeepLink(
+  projectId: string,
+  sessionId: string | undefined | null,
+): string | null {
+  if (!projectId || !sessionId) return null;
+  return `/projects/${projectId}/sessions/${sessionId}`;
+}
+
+/**
+ * Split a set of selected ids into the ones a bulk verdict can cover
+ * natively (`/review/bulk`) vs. ones that need their own per-item resolve
+ * call (executor approvals) vs. ones with no bulk path at all (Change
+ * Requests — merging in bulk needs full diff context per item, so they're
+ * excluded rather than silently no-op'd).
+ */
+export interface BulkActionPlan {
+  native: string[];
+  resolvable: string[];
+  unsupported: string[];
+}
+
+export function planBulkAction(ids: Iterable<string>): BulkActionPlan {
+  const native: string[] = [];
+  const resolvable: string[] = [];
+  const unsupported: string[] = [];
+  for (const id of ids) {
+    if (execExecutionId(id) !== null) resolvable.push(id);
+    else if (crChangeRequestId(id) !== null) unsupported.push(id);
+    else native.push(id);
+  }
+  return { native, resolvable, unsupported };
+}
+
+/** Relative age like "7m", "3h", "2d" — the compact inbox-row idiom (see
+ *  `TimeAgo` in review-center.tsx, which renders this client-only to avoid
+ *  an SSR/hydration mismatch on `Date.now()`). */
+export function formatItemAge(iso: string, now = Date.now()): string {
+  const mins = Math.max(1, Math.round((now - new Date(iso).getTime()) / 60_000));
+  if (mins < 60) return `${mins}m`;
+  const hrs = Math.round(mins / 60);
+  if (hrs < 24) return `${hrs}h`;
+  return `${Math.round(hrs / 24)}d`;
+}
+
+/** Longer relative age with a trailing "ago" — the detail-modal idiom (see
+ *  `rel` in review-detail-modal.tsx). */
+export function formatItemAgeLong(iso: string, now = Date.now()): string {
+  const mins = Math.max(1, Math.round((now - new Date(iso).getTime()) / 60_000));
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.round(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  return `${Math.round(hrs / 24)}d ago`;
+}

--- a/apps/web/src/features/review-center/review-center-connected.tsx
+++ b/apps/web/src/features/review-center/review-center-connected.tsx
@@ -7,7 +7,10 @@
  * items act through THEIR OWN source flow — a Change Request ships via merge,
  * is dismissed via close, and "request changes" persists the feedback + delivers
  * it to the change's agent (the review `/act` endpoint 409s on adapted ids by
- * design). The presentational inbox (review-center.tsx) is shared with the mock
+ * design). Executor approvals (`exec:`) resolve directly via `resolveApproval` —
+ * the same client call the in-session approval prompt uses
+ * (session-approval-prompt.tsx) — so Approve/Deny work inline in the inbox too.
+ * The presentational inbox (review-center.tsx) is shared with the mock
  * prototype. See docs/REVIEW_CENTER_DESIGN.md.
  */
 
@@ -24,12 +27,16 @@ import { clearStartStash } from '@kortix/sdk/react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import { useMemo } from 'react';
-import { useActReviewItem, useBulkActReviewItems, useReviewItems } from './hooks/use-review-items';
+import {
+  useActReviewItem,
+  useBulkActReviewItems,
+  useResolveReviewApproval,
+  useReviewItems,
+} from './hooks/use-review-items';
 import { mapApiReviewItem } from './map';
+import { crChangeRequestId, execExecutionId, itemDeepLink, planBulkAction } from './review-actions';
 import { ReviewCenter } from './review-center';
-
-const CR_PREFIX = 'cr:';
-const EXEC_PREFIX = 'exec:';
+import { isSafeRisk } from './types';
 
 export function ReviewCenterConnected({ projectName }: { projectName: string }) {
   const ctx = useProjectContext();
@@ -37,9 +44,10 @@ export function ReviewCenterConnected({ projectName }: { projectName: string }) 
   const qc = useQueryClient();
   const router = useRouter();
   const closeCustomize = useCustomizeStore((s) => s.close);
-  const { data, isLoading, isFetching } = useReviewItems();
+  const { data, isLoading, isFetching, isError, refetch } = useReviewItems();
   const act = useActReviewItem();
   const bulk = useBulkActReviewItems();
+  const resolve = useResolveReviewApproval();
   const merge = useMergeChangeRequest();
   const close = useCloseChangeRequest();
   const requestChanges = useRequestChangesOnChangeRequest();
@@ -69,10 +77,28 @@ export function ReviewCenterConnected({ projectName }: { projectName: string }) 
   const refreshInbox = () => qc.invalidateQueries({ queryKey: ['review-center', projectId] });
 
   function handleAct(id: string, verdict: ReviewVerdict, feedback?: string) {
+    // Executor approvals resolve directly — the same call + payload the
+    // in-session approval prompt uses (resolveApproval, 'once' scope: this
+    // acts on the one call the row represents, not "for the rest of the
+    // session" — that broader grant stays a session-view affordance).
+    const executionId = execExecutionId(id);
+    if (executionId) {
+      resolve.mutate(
+        { executionId, decision: verdict === 'approve' ? 'approve' : 'deny' },
+        {
+          onSuccess: () =>
+            verdict === 'approve'
+              ? successToast('Approved — the agent will continue')
+              : infoToast('Denied'),
+          onError: (e) => errorToast(e.message),
+        },
+      );
+      return;
+    }
     // Change Requests ship/close through their own flow — the review `/act`
     // endpoint 409s on `cr:` ids ("act on this item from its source view").
-    if (id.startsWith(CR_PREFIX)) {
-      const crId = id.slice(CR_PREFIX.length);
+    const crId = crChangeRequestId(id);
+    if (crId) {
       if (verdict === 'approve') {
         merge.mutate(crId, {
           onSuccess: () => {
@@ -115,13 +141,38 @@ export function ReviewCenterConnected({ projectName }: { projectName: string }) 
       }
       return;
     }
-    // Executor approvals resume through the connector flow (KORTIX-207); not yet
-    // actionable from the inbox, so guide rather than throw a 409.
-    if (id.startsWith(EXEC_PREFIX)) {
-      infoToast('Approve tool actions from the connector’s policy view for now.');
-      return;
-    }
     act.mutate({ id, verdict, feedback }, { onError: (e) => errorToast(e.message) });
+  }
+
+  // Bulk (multi-select) verdicts: split the selection by how each id can
+  // actually be acted on. Native ids go through the batch endpoint; executor
+  // approvals resolve one call each (no bulk endpoint for them, but each is
+  // a real approve/deny — not a no-op); Change Requests have no bulk path
+  // (merging needs full diff context per item) so they're skipped with a
+  // toast rather than silently ignored. Bulk APPROVE of executor approvals
+  // additionally respects "approve all safe" — the same none/low-risk-only
+  // rule the single-item bulk bar already applies (never silently sweep a
+  // risky action through a multi-select); bulk DENY has no such risk floor.
+  function handleBulkAct(ids: string[], verdict: ReviewVerdict) {
+    const { native, resolvable, unsupported } = planBulkAction(ids);
+    if (native.length > 0) {
+      bulk.mutate({ ids: native, verdict }, { onError: (e) => errorToast(e.message) });
+    }
+    if (resolvable.length > 0) {
+      const decision = verdict === 'approve' ? 'approve' : 'deny';
+      const riskById = new Map(items.map((i) => [i.id, i.risk]));
+      for (const id of resolvable) {
+        if (decision === 'approve' && !isSafeRisk(riskById.get(id) ?? 'high')) continue;
+        const executionId = execExecutionId(id);
+        if (executionId)
+          resolve.mutate({ executionId, decision }, { onError: (e) => errorToast(e.message) });
+      }
+    }
+    if (unsupported.length > 0) {
+      infoToast(
+        `${unsupported.length} ${unsupported.length === 1 ? 'change needs' : 'changes need'} its own review — open ${unsupported.length === 1 ? 'it' : 'them'} to ship.`,
+      );
+    }
   }
 
   return (
@@ -129,18 +180,20 @@ export function ReviewCenterConnected({ projectName }: { projectName: string }) 
       initialItems={items}
       isLoading={isLoading}
       isFetching={isFetching}
+      isError={isError}
       sessionLabels={sessionLabels}
       onAct={handleAct}
-      onBulkAct={(ids, verdict) =>
-        bulk.mutate({ ids, verdict }, { onError: (e) => errorToast(e.message) })
-      }
+      onBulkAct={handleBulkAct}
+      onRefresh={() => void refetch()}
       onOpenSession={(sessionId) => {
         // "See progress" only VIEWS the session — feedback delivery goes through
         // the backend now. Clear any stale queued prompt so navigating can't
         // auto-send a leftover message (e.g. from an earlier client-side attempt).
+        const href = itemDeepLink(projectId, sessionId);
+        if (!href) return;
         clearStartStash(sessionId);
         closeCustomize();
-        router.push(`/projects/${projectId}/sessions/${sessionId}`);
+        router.push(href);
       }}
     />
   );

--- a/apps/web/src/features/review-center/review-center-connected.tsx
+++ b/apps/web/src/features/review-center/review-center-connected.tsx
@@ -144,28 +144,31 @@ export function ReviewCenterConnected({ projectName }: { projectName: string }) 
     act.mutate({ id, verdict, feedback }, { onError: (e) => errorToast(e.message) });
   }
 
-  // Bulk (multi-select) verdicts: split the selection by how each id can
-  // actually be acted on. Native ids go through the batch endpoint; executor
-  // approvals resolve one call each (no bulk endpoint for them, but each is
-  // a real approve/deny — not a no-op); Change Requests have no bulk path
-  // (merging needs full diff context per item) so they're skipped with a
-  // toast rather than silently ignored. Bulk APPROVE of executor approvals
-  // additionally respects "approve all safe" — the same none/low-risk-only
-  // rule the single-item bulk bar already applies (never silently sweep a
-  // risky action through a multi-select); bulk DENY has no such risk floor.
+  // Bulk (multi-select) verdicts: the presentational layer pre-filters the
+  // selection through `resolveBulkOutcome` (same pure helper), so what
+  // arrives here is already actionable — native ids for any verdict, exec
+  // approvals only under an APPROVE that passed the safe-risk floor. The
+  // guards below are defense in depth, not the primary filter:
+  //  - an executor approval is a live question to the agent; a bulk
+  //    "dismiss" must NEVER answer it with a deny, so exec ids resolve only
+  //    on an explicit approve (single-item Deny goes through handleAct).
+  //  - the safe-risk floor is re-checked before each resolve.
+  //  - Change Requests have no bulk path (merging needs the diff in view).
   function handleBulkAct(ids: string[], verdict: ReviewVerdict) {
     const { native, resolvable, unsupported } = planBulkAction(ids);
     if (native.length > 0) {
       bulk.mutate({ ids: native, verdict }, { onError: (e) => errorToast(e.message) });
     }
-    if (resolvable.length > 0) {
-      const decision = verdict === 'approve' ? 'approve' : 'deny';
+    if (resolvable.length > 0 && verdict === 'approve') {
       const riskById = new Map(items.map((i) => [i.id, i.risk]));
       for (const id of resolvable) {
-        if (decision === 'approve' && !isSafeRisk(riskById.get(id) ?? 'high')) continue;
+        if (!isSafeRisk(riskById.get(id) ?? 'high')) continue;
         const executionId = execExecutionId(id);
         if (executionId)
-          resolve.mutate({ executionId, decision }, { onError: (e) => errorToast(e.message) });
+          resolve.mutate(
+            { executionId, decision: 'approve' },
+            { onError: (e) => errorToast(e.message) },
+          );
       }
     }
     if (unsupported.length > 0) {

--- a/apps/web/src/features/review-center/review-center.tsx
+++ b/apps/web/src/features/review-center/review-center.tsx
@@ -19,8 +19,10 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import Hint from '@/components/ui/hint';
 import { Input } from '@/components/ui/input';
 import { Kbd } from '@/components/ui/kbd';
+import Loading from '@/components/ui/loading';
 import { Modal, ModalBody, ModalContent, ModalHeader, ModalTitle } from '@/components/ui/modal';
 import { Skeleton } from '@/components/ui/skeleton';
 import { StatusBadge } from '@/components/ui/status';
@@ -33,6 +35,7 @@ import {
 } from '@/components/ui/tabs';
 import { infoToast, successToast } from '@/components/ui/toast';
 import { EmptyState } from '@/features/layout/section/empty-state';
+import { ErrorState } from '@/features/layout/section/error-state';
 import { cn } from '@/lib/utils';
 import type { ReviewVerdict } from '@kortix/sdk/projects-client';
 import { CheckCircleSolid, InboxSolid, ShieldCheckSolid, X } from '@mynaui/icons-react';
@@ -41,6 +44,7 @@ import { AnimatePresence, motion, useReducedMotion } from 'motion/react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { statusToVerdict } from './map';
 import { MOCK_ITEMS } from './mock-data';
+import { formatItemAge, isQuickDecidableApproval } from './review-actions';
 import { type ReviewActions, ReviewDetailModal } from './review-detail-modal';
 import { KIND_META, RISK_BAR, RISK_META, SOURCE_META, STATUS_META } from './review-meta';
 import {
@@ -59,14 +63,6 @@ import { type ReviewItem, type ReviewKind, type ReviewSegment, segmentForStatus 
 /** Calm, premium easing for the inbox's enter/exit/layout motion. */
 const EASE = [0.2, 0, 0, 1] as const;
 
-function rel(iso: string): string {
-  const mins = Math.max(1, Math.round((Date.now() - new Date(iso).getTime()) / 60_000));
-  if (mins < 60) return `${mins}m`;
-  const hrs = Math.round(mins / 60);
-  if (hrs < 24) return `${hrs}h`;
-  return `${Math.round(hrs / 24)}d`;
-}
-
 /**
  * Relative time is client-only: it depends on `Date.now()`, which differs between
  * the server render and hydration. Render nothing until mounted so SSR and the
@@ -75,7 +71,7 @@ function rel(iso: string): string {
 function TimeAgo({ iso }: { iso: string }) {
   const [mounted, setMounted] = useState(false);
   useEffect(() => setMounted(true), []);
-  return <span className="tabular-nums">{mounted ? rel(iso) : ''}</span>;
+  return <span className="tabular-nums">{mounted ? formatItemAge(iso) : ''}</span>;
 }
 
 /** A count that rolls when it changes — the satisfying tick as you clear the inbox. */
@@ -134,8 +130,13 @@ function ItemRow({
   showCheck,
   fresh,
   reduce,
+  quickDecidable,
+  pendingDecision,
+  sessionLabel,
   onOpen,
   onToggleSelect,
+  onQuickApprove,
+  onQuickDeny,
 }: {
   item: ReviewItem;
   idx: number;
@@ -146,13 +147,25 @@ function ItemRow({
   fresh: boolean;
   /** prefers-reduced-motion: collapse enter/stagger to instant. */
   reduce: boolean;
+  /** A single-action approval with a real client-side resolve path (an
+   *  executor approval) — show Approve/Deny right on the row, no modal hop. */
+  quickDecidable: boolean;
+  /** 'approve' | 'deny' while this row's own resolve mutation is in flight. */
+  pendingDecision?: 'approve' | 'deny' | null;
+  /** The item's originating session name, when known — shown inline so a
+   *  Change Request or approval's origin is legible without opening it.
+   *  Omitted in the grouped view (the session already names the group). */
+  sessionLabel?: string;
   onOpen: () => void;
   onToggleSelect: () => void;
+  onQuickApprove?: () => void;
+  onQuickDeny?: () => void;
 }) {
   const kind = KIND_META[item.kind];
   const Source = SOURCE_META[item.source];
   const segment = segmentForStatus(item.status);
   const risk = RISK_META[item.risk];
+  const busy = !!pendingDecision;
   // Left accent bar: kind tone by default; in Needs-you it escalates to the
   // risk tone for medium/high so risky work glows at the row's edge.
   const barClass =
@@ -228,14 +241,32 @@ function ItemRow({
           <span className="text-muted-foreground/70 font-medium">{kind.label}</span>
           {item.summary ? <span className="text-muted-foreground/40"> · </span> : null}
           {item.summary}
+          {sessionLabel ? <span className="text-muted-foreground/40"> · </span> : null}
+          {sessionLabel}
         </div>
       </button>
 
-      <div className="flex shrink-0 items-center gap-2">
+      <div className="flex shrink-0 items-center gap-1.5">
         {segment === 'needs_you' ? (
-          <Button size="sm" variant="secondary" onClick={onOpen}>
-            {item.primaryAction}
-          </Button>
+          quickDecidable ? (
+            <>
+              <Button size="sm" variant="ghost" disabled={busy} onClick={onQuickDeny}>
+                {pendingDecision === 'deny' ? <Loading className="size-3.5 shrink-0" /> : null}
+                Deny
+              </Button>
+              <Button size="sm" variant="secondary" disabled={busy} onClick={onQuickApprove}>
+                {pendingDecision === 'approve' ? <Loading className="size-3.5 shrink-0" /> : null}
+                Approve
+              </Button>
+            </>
+          ) : (
+            <Button size="sm" variant="secondary" onClick={onOpen}>
+              {/* "Ship it" reads as instant-merge, but this only opens the
+                  detail (the modal's own button ships) — label the row
+                  action for what it does: open the full diff to decide. */}
+              {item.kind === 'change' ? 'Review' : item.primaryAction}
+            </Button>
+          )
         ) : (
           <Badge variant={STATUS_META[item.status].badge} size="sm">
             {STATUS_META[item.status].label}
@@ -277,8 +308,10 @@ export function ReviewCenter({
   onAct,
   onBulkAct,
   onOpenSession,
+  onRefresh,
   isLoading,
   isFetching,
+  isError,
   sessionLabels,
 }: {
   /** When provided, the inbox renders real data instead of the mock fixtures. */
@@ -289,9 +322,15 @@ export function ReviewCenter({
   onBulkAct?: (ids: string[], verdict: ReviewVerdict) => void;
   /** Connected mode: open a session (e.g. to watch the agent revise a change). */
   onOpenSession?: (sessionId: string) => void;
+  /** Connected mode: force an immediate poll instead of waiting for the
+   *  interval — the "Live" indicator doubles as this refresh affordance. */
+  onRefresh?: () => void;
   isLoading?: boolean;
   /** A background poll is in flight — drives the "Live" refreshing affordance. */
   isFetching?: boolean;
+  /** The initial/only load failed — show a retry state instead of an empty
+   *  inbox (an empty list and a failed fetch must never look the same). */
+  isError?: boolean;
   /** sessionId → human name, for the per-session filter + group headers. */
   sessionLabels?: Record<string, string>;
 } = {}) {
@@ -317,6 +356,12 @@ export function ReviewCenter({
   const knownIdsRef = useRef<Set<string> | null>(null);
   const [freshIds, setFreshIds] = useState<Set<string>>(new Set());
   const markSeen = () => setFreshIds((prev) => (prev.size ? new Set() : prev));
+  // The single item id currently mid-mutation (row quick-decide or the detail
+  // modal's approve/deny) + which verdict, so the row/modal button that fired
+  // it — and only that one — shows `Loading` while connected. Cleared on the
+  // next `initialItems` reconciliation (the refetch that follows a mutation).
+  const [pendingId, setPendingId] = useState<string | null>(null);
+  const [pendingDecision, setPendingDecision] = useState<'approve' | 'deny' | null>(null);
 
   const undoRef = useRef<ReviewItem[] | null>(null);
   // Query root for scroll-into-view — a container of the [data-idx] rows. It wraps
@@ -377,9 +422,15 @@ export function ReviewCenter({
       ?.scrollIntoView({ block: 'nearest' });
   }, [focusedIdx]);
 
-  // Connected mode: reconcile with the server list as it (re)loads.
+  // Connected mode: reconcile with the server list as it (re)loads. Each
+  // reconciliation is also the "settled" signal for a row/modal quick-decide
+  // mutation (there's no per-call settle callback threaded through `apply`),
+  // so clear the pending marker here rather than leave a button spinning
+  // forever if the item already left the list (e.g. a stale poll raced it).
   useEffect(() => {
     if (initialItems) setItems(initialItems);
+    setPendingId(null);
+    setPendingDecision(null);
   }, [initialItems]);
 
   // Detect items that arrived since the user last looked → flag them "fresh".
@@ -450,6 +501,10 @@ export function ReviewCenter({
   const actions: ReviewActions = {
     resolve: (id, status, message, feedback) => {
       const verdict = statusToVerdict(status);
+      if (connected && (status === 'approved' || status === 'rejected')) {
+        setPendingId(id);
+        setPendingDecision(status === 'approved' ? 'approve' : 'deny');
+      }
       apply(
         setStatus(items, id, status),
         message ?? 'Updated',
@@ -462,11 +517,30 @@ export function ReviewCenter({
     approveAllSafe: (itemId) => setItems(approveAllSafe(items, itemId)),
     openSession: onOpenSession,
     connected,
+    pendingId,
+    pendingDecision,
+  };
+
+  /** Row-level Approve/Deny for a single-action executor approval — resolves
+   *  it directly via `actions.resolve`, no modal hop. */
+  const quickDecide = (item: ReviewItem, decision: 'approve' | 'deny') => {
+    actions.resolve(
+      item.id,
+      decision === 'approve' ? 'approved' : 'rejected',
+      decision === 'approve' ? 'Approved — the agent will continue' : 'Denied',
+    );
   };
 
   const quickPrimary = (item: ReviewItem) => {
-    if (item.kind === 'approval' || item.kind === 'decision') {
-      setSelectedId(item.id); // needs a choice — open the detail
+    if (connected && isQuickDecidableApproval(item)) {
+      quickDecide(item, 'approve');
+      return;
+    }
+    // Change Requests never one-click-ship from the inbox, even via the `a`
+    // shortcut — merging needs the full diff in view, so this always opens
+    // the detail (its "Ship it" button is the real merge action).
+    if (item.kind === 'approval' || item.kind === 'decision' || item.kind === 'change') {
+      setSelectedId(item.id); // needs a choice / full context — open the detail
       return;
     }
     apply(
@@ -478,6 +552,10 @@ export function ReviewCenter({
   };
 
   const quickAskChanges = (item: ReviewItem) => {
+    if (connected && isQuickDecidableApproval(item)) {
+      quickDecide(item, 'deny');
+      return;
+    }
     if (item.kind === 'change' || item.kind === 'output') {
       apply(
         setStatus(items, item.id, 'changes_requested'),
@@ -674,18 +752,22 @@ export function ReviewCenter({
                 </TabsList>
               </Tabs>
               {connected && (
-                <span
-                  className="text-muted-foreground/70 hidden shrink-0 items-center gap-1.5 text-xs sm:flex"
-                  title={isFetching ? 'Refreshing…' : 'Live — auto-updating as agents work'}
-                >
-                  <span
-                    className={cn(
-                      'bg-kortix-green size-1.5 rounded-full',
-                      isFetching && !reduce && 'animate-pulse',
-                    )}
-                  />
-                  Live
-                </span>
+                <Hint label={isFetching ? 'Refreshing…' : 'Auto-updating — click to refresh now'}>
+                  <button
+                    type="button"
+                    onClick={onRefresh}
+                    disabled={!onRefresh || isFetching}
+                    className="text-muted-foreground/70 hover:text-foreground disabled:hover:text-muted-foreground/70 hidden shrink-0 items-center gap-1.5 text-xs transition-colors sm:flex"
+                  >
+                    <span
+                      className={cn(
+                        'bg-kortix-green size-1.5 rounded-full',
+                        isFetching && !reduce && 'animate-pulse',
+                      )}
+                    />
+                    Live
+                  </button>
+                </Hint>
               )}
             </div>
 
@@ -781,9 +863,10 @@ export function ReviewCenter({
             )}
 
             {/* Bulk bar (safe approvals across the current view). Prototype-only:
-                connected-mode approvals are executor-adapted (exec:) and resume
-                via the session's connector prompt, so there's no inbox bulk path
-                to approve them yet (KORTIX-207) — hide rather than fake it. */}
+                connected mode already surfaces "approve all safe" per-item via
+                each approval's own inline Approve/Deny + the floating
+                multi-select bar below, so this global banner would be a
+                second, redundant safe-approve entry point there. */}
             <AnimatePresence initial={false}>
               {!connected &&
                 segment === 'needs_you' &&
@@ -812,7 +895,21 @@ export function ReviewCenter({
           </div>
 
           {/* List */}
-          {isLoading && items.length === 0 ? (
+          {isError && items.length === 0 ? (
+            <div className="pt-6">
+              <ErrorState
+                size="sm"
+                title="Couldn't load the review inbox"
+                description="Check your connection and try again."
+                action={
+                  <Button variant="outline" size="sm" onClick={onRefresh} disabled={isFetching}>
+                    {isFetching ? <Loading className="size-3.5 shrink-0" /> : null}
+                    Retry
+                  </Button>
+                }
+              />
+            </div>
+          ) : isLoading && items.length === 0 ? (
             <ul className="space-y-2">
               {['a', 'b', 'c', 'd'].map((k) => (
                 <li key={k}>
@@ -892,8 +989,12 @@ export function ReviewCenter({
                           showCheck={selectionCount > 0}
                           fresh={freshIds.has(item.id)}
                           reduce={reduce}
+                          quickDecidable={connected && isQuickDecidableApproval(item)}
+                          pendingDecision={pendingId === item.id ? pendingDecision : null}
                           onOpen={() => setSelectedId(item.id)}
                           onToggleSelect={() => toggleSelect(item.id)}
+                          onQuickApprove={() => quickDecide(item, 'approve')}
+                          onQuickDeny={() => quickDecide(item, 'deny')}
                         />
                       );
                     })}
@@ -922,8 +1023,13 @@ export function ReviewCenter({
                   showCheck={selectionCount > 0}
                   fresh={freshIds.has(item.id)}
                   reduce={reduce}
+                  quickDecidable={connected && isQuickDecidableApproval(item)}
+                  pendingDecision={pendingId === item.id ? pendingDecision : null}
+                  sessionLabel={item.sessionId ? labelFor(item.sessionId) : undefined}
                   onOpen={() => setSelectedId(item.id)}
                   onToggleSelect={() => toggleSelect(item.id)}
+                  onQuickApprove={() => quickDecide(item, 'approve')}
+                  onQuickDeny={() => quickDecide(item, 'deny')}
                 />
               ))}
             </ul>

--- a/apps/web/src/features/review-center/review-center.tsx
+++ b/apps/web/src/features/review-center/review-center.tsx
@@ -44,7 +44,12 @@ import { AnimatePresence, motion, useReducedMotion } from 'motion/react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { statusToVerdict } from './map';
 import { MOCK_ITEMS } from './mock-data';
-import { formatItemAge, isQuickDecidableApproval } from './review-actions';
+import {
+  bulkSkipMessage,
+  formatItemAge,
+  isQuickDecidableApproval,
+  resolveBulkOutcome,
+} from './review-actions';
 import { type ReviewActions, ReviewDetailModal } from './review-detail-modal';
 import { KIND_META, RISK_BAR, RISK_META, SOURCE_META, STATUS_META } from './review-meta';
 import {
@@ -568,8 +573,32 @@ export function ReviewCenter({
     }
   };
 
+  /** Connected mode: decide up-front what the verdict will really act on so
+   *  the optimistic removal + toast never claim more than the server was
+   *  asked (exec approvals are never denied by a dismiss; risky approvals
+   *  survive an approve sweep; CRs each need their own review). */
+  const connectedBulkOutcome = (ids: string[], verdict: 'approve' | 'dismiss') => {
+    const riskById = new Map(items.map((i) => [i.id, i.risk]));
+    return resolveBulkOutcome(ids, verdict, (id) => riskById.get(id));
+  };
+
   const dismissIds = (ids: string[]) => {
     if (ids.length === 0) return;
+    if (connected && onBulkAct) {
+      const outcome = connectedBulkOutcome(ids, 'dismiss');
+      const skipped = bulkSkipMessage(outcome);
+      if (skipped) infoToast(skipped);
+      if (outcome.act.length > 0) {
+        apply(
+          bulkSetStatus(items, outcome.act, 'dismissed'),
+          `Dismissed ${outcome.act.length}`,
+          'info',
+          () => onBulkAct(outcome.act, 'dismiss'),
+        );
+      }
+      setSelectedIds(new Set());
+      return;
+    }
     apply(
       bulkSetStatus(items, ids, 'dismissed'),
       `Dismissed ${ids.length}`,
@@ -581,6 +610,21 @@ export function ReviewCenter({
 
   const approveIds = (ids: string[]) => {
     if (ids.length === 0) return;
+    if (connected && onBulkAct) {
+      const outcome = connectedBulkOutcome(ids, 'approve');
+      const skipped = bulkSkipMessage(outcome);
+      if (skipped) infoToast(skipped);
+      if (outcome.act.length > 0) {
+        apply(
+          bulkSetStatus(items, outcome.act, 'approved'),
+          `Approved ${outcome.act.length}`,
+          'success',
+          () => onBulkAct(outcome.act, 'approve'),
+        );
+      }
+      setSelectedIds(new Set());
+      return;
+    }
     let next = items;
     for (const id of ids) {
       const it = items.find((x) => x.id === id);

--- a/apps/web/src/features/review-center/review-detail-modal.tsx
+++ b/apps/web/src/features/review-center/review-detail-modal.tsx
@@ -13,6 +13,7 @@ import { Button } from '@/components/ui/button';
 import { Disclosure, DisclosureContent, DisclosureTrigger } from '@/components/ui/disclosure';
 import { InfoBanner } from '@/components/ui/info-banner';
 import { Kbd } from '@/components/ui/kbd';
+import Loading from '@/components/ui/loading';
 import {
   Modal,
   ModalBody,
@@ -34,6 +35,7 @@ import {
 } from '@mynaui/icons-react';
 import { useEffect, useRef, useState } from 'react';
 import { ChangeFilesModal } from './change-files';
+import { formatItemAgeLong } from './review-actions';
 import {
   APPROVAL_ACTION_ICON,
   KIND_META,
@@ -49,17 +51,16 @@ export interface ReviewActions {
   approveAllSafe: (itemId: string) => void;
   /** Open the item's originating session (e.g. to watch the agent revise). */
   openSession?: (sessionId: string) => void;
-  /** Live-data mode. Executor approvals are resolved in-session (KORTIX-207), so
-   *  the inbox guides to the session rather than faking an inline decision. */
+  /** Live-data mode: executor approvals resolve inline via `resolve()` too
+   *  (the same `resolveApproval` call the in-session prompt uses), not just
+   *  native/CR items. */
   connected?: boolean;
-}
-
-function rel(iso: string): string {
-  const mins = Math.max(1, Math.round((Date.now() - new Date(iso).getTime()) / 60_000));
-  if (mins < 60) return `${mins}m ago`;
-  const hrs = Math.round(mins / 60);
-  if (hrs < 24) return `${hrs}h ago`;
-  return `${Math.round(hrs / 24)}d ago`;
+  /** The review item id currently mid-mutation, if any — drives the
+   *  per-item `Loading` state on Approve/Deny while connected. */
+  pendingId?: string | null;
+  /** Which verdict `pendingId`'s in-flight mutation is — so Approve and Deny
+   *  don't both show `Loading` at once. */
+  pendingDecision?: 'approve' | 'deny' | null;
 }
 
 /** A muted bordered panel — the friendly content surface. */
@@ -241,14 +242,16 @@ function ChangeBody({
 function ApprovalActionRow({
   action,
   connected,
+  pending,
   onApprove,
   onDeny,
   onAlwaysAllow,
   onOpenSession,
 }: {
   action: ApprovalAction;
-  /** Live mode: resolve in-session (KORTIX-207), so hide the fake inline verdict. */
   connected?: boolean;
+  /** 'approve' | 'deny' while this row's own mutation is in flight. */
+  pending?: 'approve' | 'deny' | null;
   onApprove: () => void;
   onDeny: () => void;
   onAlwaysAllow: () => void;
@@ -257,6 +260,7 @@ function ApprovalActionRow({
   const Icon = APPROVAL_ACTION_ICON[action.icon];
   const safe = isSafeRisk(action.risk);
   const args = action.argsPreview ?? [];
+  const busy = !!pending;
   return (
     <div className="bg-popover rounded-md border px-4 py-3">
       <div className="flex items-start gap-3">
@@ -305,30 +309,40 @@ function ApprovalActionRow({
             <Badge variant={action.decided === 'approved' ? 'success' : 'destructive'} size="sm">
               {action.decided === 'approved' ? 'Approved' : 'Denied'}
             </Badge>
-          ) : connected ? (
-            // Executor approvals resume in the session's own approval prompt.
-            <Button variant="secondary" size="sm" onClick={onOpenSession} disabled={!onOpenSession}>
-              Approve in session
-              <ArrowUpRight className="size-3.5" />
-            </Button>
           ) : (
             <div className="flex flex-col items-end gap-1.5">
               <div className="flex items-center gap-1.5">
-                <Button variant="ghost" size="sm" onClick={onDeny}>
+                <Button variant="ghost" size="sm" disabled={busy} onClick={onDeny}>
+                  {pending === 'deny' ? <Loading className="size-3.5 shrink-0" /> : null}
                   Deny
                 </Button>
-                <Button size="sm" onClick={onApprove}>
-                  <Check className="size-3.5" />
+                <Button size="sm" disabled={busy} onClick={onApprove}>
+                  {pending === 'approve' ? (
+                    <Loading className="size-3.5 shrink-0" />
+                  ) : (
+                    <Check className="size-3.5" />
+                  )}
                   Approve
                 </Button>
               </div>
-              <button
-                type="button"
-                onClick={onAlwaysAllow}
-                className="text-muted-foreground hover:text-foreground text-xs underline-offset-2 hover:underline"
-              >
-                Always allow this
-              </button>
+              {connected && onOpenSession ? (
+                <button
+                  type="button"
+                  onClick={onOpenSession}
+                  className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1 text-xs underline-offset-2 hover:underline"
+                >
+                  See it in the session
+                  <ArrowUpRight className="size-3" />
+                </button>
+              ) : !connected ? (
+                <button
+                  type="button"
+                  onClick={onAlwaysAllow}
+                  className="text-muted-foreground hover:text-foreground text-xs underline-offset-2 hover:underline"
+                >
+                  Always allow this
+                </button>
+              ) : null}
             </div>
           )}
         </div>
@@ -350,68 +364,65 @@ function ApprovalBody({
     actions.openSession && item.sessionId
       ? () => actions.openSession?.(item.sessionId as string)
       : undefined;
+  // Connected mode resolves each action for real via `resolve()` (routes to
+  // `resolveApproval` — the same call the in-session prompt uses), so the row
+  // pending state is keyed off the shared `pendingId` rather than local proto
+  // state. Prototype mode keeps the instant local `decideAction` + "Always
+  // allow this" full-allow affordance.
   return (
     <>
-      {actions.connected ? (
-        // Live mode: executor approvals are resolved in the session's connector
-        // prompt, not the inbox (KORTIX-207) — guide there rather than fake it.
+      {!actions.connected && safePending.length > 0 && (
         <InfoBanner
-          tone="info"
-          title="Approve these from the session"
+          tone="success"
+          title={`${safePending.length} ${safePending.length === 1 ? 'action is' : 'actions are'} safe to approve together`}
           action={
-            openSession && (
-              <Button size="sm" variant="secondary" onClick={openSession}>
-                Open session
-                <ArrowUpRight className="size-3.5" />
-              </Button>
-            )
+            <Button
+              size="sm"
+              onClick={() => {
+                actions.approveAllSafe(item.id);
+                successToast(`Approved ${safePending.length} safe actions`);
+              }}
+            >
+              Approve all safe
+            </Button>
           }
         >
-          Tool approvals resume in the agent&apos;s own conversation, where you can approve or deny
-          with full context. This is the read-only preview.
+          Reads and low-risk writes. Risky actions stay below for you to decide one by one.
         </InfoBanner>
-      ) : (
-        safePending.length > 0 && (
-          <InfoBanner
-            tone="success"
-            title={`${safePending.length} ${safePending.length === 1 ? 'action is' : 'actions are'} safe to approve together`}
-            action={
-              <Button
-                size="sm"
-                onClick={() => {
-                  actions.approveAllSafe(item.id);
-                  successToast(`Approved ${safePending.length} safe actions`);
-                }}
-              >
-                Approve all safe
-              </Button>
-            }
-          >
-            Reads and low-risk writes. Risky actions stay below for you to decide one by one.
-          </InfoBanner>
-        )
       )}
       <div className="space-y-2">
-        {list.map((a) => (
-          <ApprovalActionRow
-            key={a.id}
-            action={a}
-            connected={actions.connected}
-            onOpenSession={openSession}
-            onApprove={() => {
-              actions.decideAction(item.id, a.id, 'approved');
-              successToast(`Approved · ${a.title}`);
-            }}
-            onDeny={() => {
-              actions.decideAction(item.id, a.id, 'denied');
-              infoToast(`Denied · ${a.title}`);
-            }}
-            onAlwaysAllow={() => {
-              actions.decideAction(item.id, a.id, 'approved');
-              infoToast(`Saved — ${a.connector} ${a.action} won’t ask again`);
-            }}
-          />
-        ))}
+        {list.map((a) => {
+          const busy = actions.connected && actions.pendingId === item.id;
+          return (
+            <ApprovalActionRow
+              key={a.id}
+              action={a}
+              connected={actions.connected}
+              pending={busy ? (actions.pendingDecision ?? 'approve') : null}
+              onOpenSession={openSession}
+              onApprove={() => {
+                if (actions.connected) {
+                  actions.resolve(item.id, 'approved', `Approved · ${a.title}`);
+                  return;
+                }
+                actions.decideAction(item.id, a.id, 'approved');
+                successToast(`Approved · ${a.title}`);
+              }}
+              onDeny={() => {
+                if (actions.connected) {
+                  actions.resolve(item.id, 'rejected', `Denied · ${a.title}`);
+                  return;
+                }
+                actions.decideAction(item.id, a.id, 'denied');
+                infoToast(`Denied · ${a.title}`);
+              }}
+              onAlwaysAllow={() => {
+                actions.decideAction(item.id, a.id, 'approved');
+                infoToast(`Saved — ${a.connector} ${a.action} won’t ask again`);
+              }}
+            />
+          );
+        })}
       </div>
     </>
   );
@@ -617,7 +628,7 @@ function Footer({
     return (
       <ModalFooter className="border-border/60 border-t pt-4">
         <span className="text-muted-foreground mr-auto text-xs">
-          {STATUS_META[item.status].label} · {rel(item.createdAt)}
+          {STATUS_META[item.status].label} · {formatItemAgeLong(item.createdAt)}
         </span>
         <Button variant="outline-ghost" onClick={onClose}>
           Close
@@ -754,7 +765,7 @@ export function ReviewDetailModal({
 
         <ModalBody className="space-y-3">
           <div className="text-muted-foreground text-xs">
-            {item.agent} · {rel(item.createdAt)}
+            {item.agent} · {formatItemAgeLong(item.createdAt)}
           </div>
 
           {item.kind === 'change' && <ChangeBody item={item} actions={actions} onClose={onClose} />}

--- a/apps/web/src/features/review-center/review-detail-modal.tsx
+++ b/apps/web/src/features/review-center/review-detail-modal.tsx
@@ -243,6 +243,7 @@ function ApprovalActionRow({
   action,
   connected,
   pending,
+  readOnly,
   onApprove,
   onDeny,
   onAlwaysAllow,
@@ -252,6 +253,9 @@ function ApprovalActionRow({
   connected?: boolean;
   /** 'approve' | 'deny' while this row's own mutation is in flight. */
   pending?: 'approve' | 'deny' | null;
+  /** Display-only row — the decision lives elsewhere (the whole-item bar for
+   *  connected multi-action approvals, where one verdict covers every row). */
+  readOnly?: boolean;
   onApprove: () => void;
   onDeny: () => void;
   onAlwaysAllow: () => void;
@@ -309,7 +313,7 @@ function ApprovalActionRow({
             <Badge variant={action.decided === 'approved' ? 'success' : 'destructive'} size="sm">
               {action.decided === 'approved' ? 'Approved' : 'Denied'}
             </Badge>
-          ) : (
+          ) : readOnly ? null : (
             <div className="flex flex-col items-end gap-1.5">
               <div className="flex items-center gap-1.5">
                 <Button variant="ghost" size="sm" disabled={busy} onClick={onDeny}>
@@ -390,40 +394,87 @@ function ApprovalBody({
           Reads and low-risk writes. Risky actions stay below for you to decide one by one.
         </InfoBanner>
       )}
-      <div className="space-y-2">
-        {list.map((a) => {
-          const busy = actions.connected && actions.pendingId === item.id;
-          return (
-            <ApprovalActionRow
-              key={a.id}
-              action={a}
-              connected={actions.connected}
-              pending={busy ? (actions.pendingDecision ?? 'approve') : null}
-              onOpenSession={openSession}
-              onApprove={() => {
-                if (actions.connected) {
-                  actions.resolve(item.id, 'approved', `Approved · ${a.title}`);
-                  return;
-                }
-                actions.decideAction(item.id, a.id, 'approved');
-                successToast(`Approved · ${a.title}`);
-              }}
-              onDeny={() => {
-                if (actions.connected) {
-                  actions.resolve(item.id, 'rejected', `Denied · ${a.title}`);
-                  return;
-                }
-                actions.decideAction(item.id, a.id, 'denied');
-                infoToast(`Denied · ${a.title}`);
-              }}
-              onAlwaysAllow={() => {
-                actions.decideAction(item.id, a.id, 'approved');
-                infoToast(`Saved — ${a.connector} ${a.action} won’t ask again`);
-              }}
-            />
-          );
-        })}
-      </div>
+      {/* A connected item resolves as ONE unit (`/act` and `resolveApproval`
+          take a single verdict for the whole item), so with several pending
+          actions the per-row button pairs would misrepresent their granularity
+          — clicking Approve on one row would green-light all of them. Rows go
+          display-only and one clearly-labeled decision bar carries the verdict. */}
+      {(() => {
+        const wholeItem = !!actions.connected && list.filter((a) => !a.decided).length > 1;
+        const busy = actions.connected && actions.pendingId === item.id;
+        return (
+          <>
+            <div className="space-y-2">
+              {list.map((a) => (
+                <ApprovalActionRow
+                  key={a.id}
+                  action={a}
+                  connected={actions.connected}
+                  readOnly={wholeItem}
+                  pending={busy && !wholeItem ? (actions.pendingDecision ?? 'approve') : null}
+                  onOpenSession={openSession}
+                  onApprove={() => {
+                    if (actions.connected) {
+                      actions.resolve(item.id, 'approved', `Approved · ${a.title}`);
+                      return;
+                    }
+                    actions.decideAction(item.id, a.id, 'approved');
+                    successToast(`Approved · ${a.title}`);
+                  }}
+                  onDeny={() => {
+                    if (actions.connected) {
+                      actions.resolve(item.id, 'rejected', `Denied · ${a.title}`);
+                      return;
+                    }
+                    actions.decideAction(item.id, a.id, 'denied');
+                    infoToast(`Denied · ${a.title}`);
+                  }}
+                  onAlwaysAllow={() => {
+                    actions.decideAction(item.id, a.id, 'approved');
+                    infoToast(`Saved — ${a.connector} ${a.action} won’t ask again`);
+                  }}
+                />
+              ))}
+            </div>
+            {wholeItem && (
+              <div className="bg-popover flex items-center justify-between gap-3 rounded-md border px-4 py-3">
+                <p className="text-muted-foreground min-w-0 text-sm text-pretty">
+                  These {list.length} actions resolve together — one decision covers all of them.
+                </p>
+                <div className="flex shrink-0 items-center gap-1.5">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    disabled={busy}
+                    onClick={() =>
+                      actions.resolve(item.id, 'rejected', `Denied all ${list.length} actions`)
+                    }
+                  >
+                    {busy && actions.pendingDecision === 'deny' ? (
+                      <Loading className="size-3.5 shrink-0" />
+                    ) : null}
+                    Deny all
+                  </Button>
+                  <Button
+                    size="sm"
+                    disabled={busy}
+                    onClick={() =>
+                      actions.resolve(item.id, 'approved', `Approved all ${list.length} actions`)
+                    }
+                  >
+                    {busy && actions.pendingDecision === 'approve' ? (
+                      <Loading className="size-3.5 shrink-0" />
+                    ) : (
+                      <Check className="size-3.5" />
+                    )}
+                    Approve all
+                  </Button>
+                </div>
+              </div>
+            )}
+          </>
+        );
+      })()}
     </>
   );
 }

--- a/apps/web/src/features/workspace/customize/sections/connectors-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/connectors-view.tsx
@@ -12,7 +12,6 @@ import {
   ExternalLink,
   Globe,
   KeyRound,
-  Loader2,
   type LucideIcon,
   Mail,
   MessageSquare,
@@ -39,14 +38,6 @@ import { Checkbox } from '@/components/ui/checkbox';
 import { CodeBlockCode } from '@/components/ui/code-block';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog';
-import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -70,7 +61,6 @@ import {
   ModalTitle,
 } from '@/components/ui/modal';
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
-import { SectionCard } from '@/components/ui/section-card';
 import {
   Select,
   SelectContent,
@@ -81,7 +71,6 @@ import {
 import { Skeleton } from '@/components/ui/skeleton';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { errorToast, successToast, warningToast } from '@/components/ui/toast';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { EmptyState } from '@/features/layout/section/empty-state';
 import {
   type EmailInstallation,
@@ -452,7 +441,7 @@ function SaveBar({
         </Button>
       )}
       <Button size="sm" onClick={onSave} disabled={saving || disabled} className="gap-1.5">
-        {saving && <Loader2 className="h-4 w-4 animate-spin" />}
+        {saving && <Loading className="size-4 shrink-0" />}
         {label}
       </Button>
     </div>
@@ -587,7 +576,7 @@ function ConnectorRail({
           disabled={syncing}
         >
           {syncing ? (
-            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            <Loading className="size-3.5 shrink-0" />
           ) : (
             <RefreshCw className="h-3.5 w-3.5" />
           )}
@@ -819,7 +808,7 @@ function ConnectorDetail({
                 )}
               >
                 {rename.isPending ? (
-                  <Loader2 className="h-4 w-4 animate-spin" />
+                  <Loading className="size-4 shrink-0" />
                 ) : (
                   <Check className="h-4 w-4" />
                 )}
@@ -840,19 +829,16 @@ function ConnectorDetail({
           ) : (
             <div className="group flex items-center gap-2">
               <h2 className="text-foreground truncate text-lg font-semibold">{displayName}</h2>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <button
-                    type="button"
-                    onClick={() => setEditingName(true)}
-                    aria-label="Rename"
-                    className="text-muted-foreground hover:text-foreground opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100"
-                  >
-                    <Pencil className="h-3.5 w-3.5" />
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent>Rename</TooltipContent>
-              </Tooltip>
+              <Hint label="Rename">
+                <button
+                  type="button"
+                  onClick={() => setEditingName(true)}
+                  aria-label="Rename"
+                  className="text-muted-foreground hover:text-foreground opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100"
+                >
+                  <Pencil className="h-3.5 w-3.5" />
+                </button>
+              </Hint>
             </div>
           )}
           <div className="mt-1.5 flex items-center gap-2">
@@ -882,7 +868,7 @@ function ConnectorDetail({
               disabled={reconnect.isPending}
             >
               {reconnect.isPending ? (
-                <Loader2 className="h-4 w-4 animate-spin" />
+                <Loading className="size-4 shrink-0" />
               ) : (
                 <KeyRound className="h-4 w-4" />
               )}
@@ -939,7 +925,7 @@ function ConnectorDetail({
                 onClick={() => (isPipedream ? reconnect.mutate() : setCredOpen(true))}
                 disabled={isPipedream && reconnect.isPending}
               >
-                {isPipedream && reconnect.isPending && <Loader2 className="h-4 w-4 animate-spin" />}
+                {isPipedream && reconnect.isPending && <Loading className="size-4 shrink-0" />}
                 {isPipedream ? `Connect ${displayName}` : 'Set credential'}
               </Button>
             }
@@ -985,26 +971,31 @@ function ConnectorDetail({
         </Tabs>
 
         {!isManaged && !isChannel && (
-          <SectionCard
-            tone="destructive"
-            title={tI18nHardcoded.raw(
-              'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrTitleRemove74be1411',
-            )}
-            description={tI18nHardcoded.raw(
-              'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrDescriptionDeletes0a130396',
-            )}
-            action={
+          <div className="bg-popover rounded-md border px-4 py-3">
+            <div className="flex items-center justify-between gap-4">
+              <div className="min-w-0">
+                <p className="text-foreground text-sm font-medium">
+                  {tI18nHardcoded.raw(
+                    'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrTitleRemove74be1411',
+                  )}
+                </p>
+                <p className="text-muted-foreground mt-0.5 text-xs text-pretty">
+                  {tI18nHardcoded.raw(
+                    'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrDescriptionDeletes0a130396',
+                  )}
+                </p>
+              </div>
               <Button
                 size="sm"
                 variant="outline"
-                className="gap-1.5"
+                className="shrink-0 gap-1.5"
                 onClick={() => setConfirmDelete(true)}
               >
                 <Trash2 className="h-3.5 w-3.5" />
                 Remove
               </Button>
-            }
-          />
+            </div>
+          </div>
         )}
       </div>
 
@@ -1082,9 +1073,12 @@ function ChannelConnectionSection({
     );
   }
   return (
-    <SectionCard title="Connection">
-      <InfoBanner tone="warning">This channel profile is missing its platform setting.</InfoBanner>
-    </SectionCard>
+    <section className="space-y-4">
+      <Label>Connection</Label>
+      <div className="bg-popover rounded-md border px-4 py-5">
+        <InfoBanner tone="warning">This channel profile is missing its platform setting.</InfoBanner>
+      </div>
+    </section>
   );
 }
 
@@ -1102,27 +1096,30 @@ function EmailChannelProfile({
   const install = useEmailInstall(projectId, connector.slug);
 
   return (
-    <SectionCard
-      title="Email connection"
-      description="AgentMail inbox assigned to this connector profile."
-    >
-      {install.isLoading ? (
-        <Skeleton className="h-24 w-full rounded-2xl" />
-      ) : install.data ? (
-        <ConnectedEmailProfile
-          projectId={projectId}
-          connectorSlug={connector.slug}
-          installation={install.data}
-          onRemoved={onRemoved}
-        />
-      ) : (
-        <EmailConnectForm
-          projectId={projectId}
-          connectorSlug={connector.slug}
-          onConnected={onChanged}
-        />
-      )}
-    </SectionCard>
+    <section className="space-y-4">
+      <Label>Email connection</Label>
+      <p className="text-muted-foreground -mt-2 text-xs">
+        AgentMail inbox assigned to this connector profile.
+      </p>
+      <div className="bg-popover rounded-md border px-4 py-5">
+        {install.isLoading ? (
+          <Skeleton className="h-24 w-full rounded-2xl" />
+        ) : install.data ? (
+          <ConnectedEmailProfile
+            projectId={projectId}
+            connectorSlug={connector.slug}
+            installation={install.data}
+            onRemoved={onRemoved}
+          />
+        ) : (
+          <EmailConnectForm
+            projectId={projectId}
+            connectorSlug={connector.slug}
+            onConnected={onChanged}
+          />
+        )}
+      </div>
+    </section>
   );
 }
 
@@ -1181,7 +1178,7 @@ function ConnectedEmailProfile({
                 )
               }
             >
-              {disconnect.isPending ? <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" /> : null}
+              {disconnect.isPending ? <Loading className="mr-2 size-3.5 shrink-0" /> : null}
               Disconnect
             </Button>
           </>
@@ -1591,7 +1588,7 @@ export function EmailConnectForm({
       {error ? <InfoBanner tone="destructive">{error}</InfoBanner> : null}
       <div className="flex justify-end">
         <Button size="sm" onClick={submit} disabled={connect.isPending || mode.isLoading}>
-          {connect.isPending ? <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" /> : null}
+          {connect.isPending ? <Loading className="mr-2 size-3.5 shrink-0" /> : null}
           Create inbox
         </Button>
       </div>
@@ -1610,22 +1607,25 @@ function SlackChannelProfile({
 }) {
   const install = useSlackInstall(projectId);
   return (
-    <SectionCard
-      title="Slack connection"
-      description="Slack workspace assigned to this connector profile."
-    >
-      {install.isLoading ? (
-        <Skeleton className="h-24 w-full rounded-2xl" />
-      ) : install.data ? (
-        <ConnectedSlackProfile
-          projectId={projectId}
-          installation={install.data}
-          onRemoved={onRemoved}
-        />
-      ) : (
-        <SlackConnectForm projectId={projectId} onConnected={onChanged} />
-      )}
-    </SectionCard>
+    <section className="space-y-4">
+      <Label>Slack connection</Label>
+      <p className="text-muted-foreground -mt-2 text-xs">
+        Slack workspace assigned to this connector profile.
+      </p>
+      <div className="bg-popover rounded-md border px-4 py-5">
+        {install.isLoading ? (
+          <Skeleton className="h-24 w-full rounded-2xl" />
+        ) : install.data ? (
+          <ConnectedSlackProfile
+            projectId={projectId}
+            installation={install.data}
+            onRemoved={onRemoved}
+          />
+        ) : (
+          <SlackConnectForm projectId={projectId} onConnected={onChanged} />
+        )}
+      </div>
+    </section>
   );
 }
 
@@ -1668,7 +1668,7 @@ function ConnectedSlackProfile({
                 })
               }
             >
-              {disconnect.isPending ? <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" /> : null}
+              {disconnect.isPending ? <Loading className="mr-2 size-3.5 shrink-0" /> : null}
               Disconnect
             </Button>
           </>
@@ -1879,7 +1879,7 @@ export function SlackConnectForm({
                   onClick={submit}
                   disabled={connect.isPending || !botToken.trim() || !signingSecret.trim()}
                 >
-                  {connect.isPending ? <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" /> : null}
+                  {connect.isPending ? <Loading className="mr-2 size-3.5 shrink-0" /> : null}
                   Connect custom Slack app
                 </Button>
               </div>
@@ -1975,48 +1975,51 @@ function ConnectionSection({
   });
 
   return (
-    <SectionCard
-      title="Connection"
-      description={tI18nHardcoded.raw(
-        'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrDescriptionHowa31daf50',
-      )}
-    >
-      {configQuery.isError ? (
-        <InfoBanner
-          tone="destructive"
-          title={tI18nHardcoded.raw(
-            'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrTitleCouldn277b73a0',
-          )}
-          action={
-            <Button size="sm" variant="outline" onClick={() => configQuery.refetch()}>
-              Retry
-            </Button>
-          }
-        >
-          {(configQuery.error as Error)?.message ?? 'Unknown error'}
-        </InfoBanner>
-      ) : configQuery.isLoading || !draft ? (
-        <div className="space-y-3">
-          <Skeleton className="h-9 w-full rounded-2xl" />
-          <Skeleton className="h-9 w-2/3 rounded-2xl" />
-          <Skeleton className="h-9 w-full rounded-2xl" />
-        </div>
-      ) : (
-        <div className="space-y-4">
-          <ConnectorConfigFields draft={draft} onChange={setDraft} />
-          <SaveBar
-            dirty={dirty}
-            saving={save.isPending}
-            disabled={!connectionValid(draft)}
-            onSave={() => save.mutate()}
-            onReset={reset}
-            label={tI18nHardcoded.raw(
-              'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrLabelSave8c6f945f',
+    <section className="space-y-4">
+      <Label>Connection</Label>
+      <p className="text-muted-foreground -mt-2 text-xs">
+        {tI18nHardcoded.raw(
+          'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrDescriptionHowa31daf50',
+        )}
+      </p>
+      <div className="bg-popover rounded-md border px-4 py-5">
+        {configQuery.isError ? (
+          <InfoBanner
+            tone="destructive"
+            title={tI18nHardcoded.raw(
+              'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrTitleCouldn277b73a0',
             )}
-          />
-        </div>
-      )}
-    </SectionCard>
+            action={
+              <Button size="sm" variant="outline" onClick={() => configQuery.refetch()}>
+                Retry
+              </Button>
+            }
+          >
+            {(configQuery.error as Error)?.message ?? 'Unknown error'}
+          </InfoBanner>
+        ) : configQuery.isLoading || !draft ? (
+          <div className="space-y-3">
+            <Skeleton className="h-9 w-full rounded-2xl" />
+            <Skeleton className="h-9 w-2/3 rounded-2xl" />
+            <Skeleton className="h-9 w-full rounded-2xl" />
+          </div>
+        ) : (
+          <div className="space-y-4">
+            <ConnectorConfigFields draft={draft} onChange={setDraft} />
+            <SaveBar
+              dirty={dirty}
+              saving={save.isPending}
+              disabled={!connectionValid(draft)}
+              onSave={() => save.mutate()}
+              onReset={reset}
+              label={tI18nHardcoded.raw(
+                'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrLabelSave8c6f945f',
+              )}
+            />
+          </div>
+        )}
+      </div>
+    </section>
   );
 }
 
@@ -2262,14 +2265,18 @@ function PermissionsSection({
   };
 
   return (
-    <SectionCard
-      title="Permissions"
-      description={tI18nHardcoded.raw(
-        'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrDescriptionWhat4e375237',
-      )}
-      action={
-        tools.length > 6 ? (
-          <div className="relative w-48">
+    <section className="space-y-4">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h3 className="text-sm font-medium">Permissions</h3>
+          <p className="text-muted-foreground mt-1 text-xs">
+            {tI18nHardcoded.raw(
+              'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrDescriptionWhat4e375237',
+            )}
+          </p>
+        </div>
+        {tools.length > 6 ? (
+          <div className="relative w-48 shrink-0">
             <Search className="text-muted-foreground pointer-events-none absolute top-1/2 left-2.5 h-3.5 w-3.5 -translate-y-1/2" />
             <Input
               value={search}
@@ -2280,10 +2287,10 @@ function PermissionsSection({
               className="h-8 pl-8 text-sm"
             />
           </div>
-        ) : undefined
-      }
-    >
-      <div className="space-y-4">
+        ) : null}
+      </div>
+      <div className="bg-popover rounded-md border px-4 py-5">
+        <div className="space-y-4">
         <div className="space-y-2">
           <Label>Default</Label>
           <RadioGroup
@@ -2610,18 +2617,19 @@ function PermissionsSection({
             )}
           </div>
         )}
-      </div>
+        </div>
 
-      <SaveBar
-        dirty={dirty}
-        saving={save.isPending}
-        onSave={() => save.mutate()}
-        onReset={reset}
-        label={tI18nHardcoded.raw(
-          'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrLabelSave783950c7',
-        )}
-      />
-    </SectionCard>
+        <SaveBar
+          dirty={dirty}
+          saving={save.isPending}
+          onSave={() => save.mutate()}
+          onReset={reset}
+          label={tI18nHardcoded.raw(
+            'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrLabelSave783950c7',
+          )}
+        />
+      </div>
+    </section>
   );
 }
 
@@ -2821,16 +2829,16 @@ function AddEmailProfileCard({
           agent should run.
         </p>
       </button>
-      <Dialog open={open} onOpenChange={(next) => !add.isPending && setOpen(next)}>
-        <DialogContent className="gap-0 overflow-hidden p-0 sm:max-w-md">
-          <DialogHeader className="border-border/60 border-b px-6 pt-6 pb-4">
-            <DialogTitle>Add Email inbox</DialogTitle>
-            <DialogDescription>
+      <Modal open={open} onOpenChange={(next) => !add.isPending && setOpen(next)}>
+        <ModalContent className="lg:max-w-md">
+          <ModalHeader>
+            <ModalTitle>Add Email inbox</ModalTitle>
+            <ModalDescription>
               Create a separate connector profile. You choose the AgentMail address when connecting
               it.
-            </DialogDescription>
-          </DialogHeader>
-          <div className="space-y-4 px-6 py-5">
+            </ModalDescription>
+          </ModalHeader>
+          <ModalBody className="max-h-[60vh] space-y-4 overflow-y-auto">
             <Field>
               <Input
                 id="email-profile-name"
@@ -2856,18 +2864,18 @@ function AddEmailProfileCard({
                 Used as the first choice for the AgentMail address, for example support@agentmail.
               </p>
             </Field>
-          </div>
-          <DialogFooter className="border-border/60 bg-muted/30 flex items-center justify-end gap-2 border-t px-6 py-3">
-            <Button variant="ghost" onClick={() => setOpen(false)} disabled={add.isPending}>
+          </ModalBody>
+          <ModalFooter className="sm:justify-between">
+            <Button variant="outline-ghost" onClick={() => setOpen(false)} disabled={add.isPending}>
               Cancel
             </Button>
             <Button onClick={() => add.mutate()} disabled={add.isPending} className="gap-1.5">
-              {add.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+              {add.isPending ? <Loading className="size-4 shrink-0" /> : null}
               Add inbox
             </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
     </>
   );
 }
@@ -2900,20 +2908,20 @@ function AddSlackProfileCard({
           Add Kortix to Slack so mentions and threaded replies route into Kortix agent sessions.
         </p>
       </button>
-      <Dialog open={open} onOpenChange={setOpen}>
-        <DialogContent className="gap-0 overflow-hidden p-0 sm:max-w-2xl">
-          <DialogHeader className="border-border/60 border-b px-6 pt-6 pb-4">
-            <DialogTitle>Add Kortix to Slack</DialogTitle>
-            <DialogDescription>
+      <Modal open={open} onOpenChange={setOpen}>
+        <ModalContent className="lg:max-w-2xl">
+          <ModalHeader>
+            <ModalTitle>Add Kortix to Slack</ModalTitle>
+            <ModalDescription>
               Connect the built-in Slack channel. The connector profile appears automatically after
               installation.
-            </DialogDescription>
-          </DialogHeader>
-          <div className="max-h-[75vh] overflow-y-auto px-6 py-5">
+            </ModalDescription>
+          </ModalHeader>
+          <ModalBody className="max-h-[60vh] overflow-y-auto">
             <SlackConnectForm projectId={projectId} onConnected={handleConnected} />
-          </div>
-        </DialogContent>
-      </Dialog>
+          </ModalBody>
+        </ModalContent>
+      </Modal>
     </>
   );
 }
@@ -3047,7 +3055,7 @@ function AppCatalogue({
                 >
                   {appsQuery.isFetchingNextPage ? (
                     <>
-                      <Loading className="size-4 animate-spin" />
+                      <Loading className="size-4 shrink-0" />
                       {tI18nHardcoded.raw(
                         'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxTextLoading7131cc18',
                       )}
@@ -3380,7 +3388,7 @@ export function CustomConnectorForm({
               disabled={!draft.slug || save.isPending || !connectionValid(draft, emailChannelEnabled)}
               className="gap-1.5"
             >
-              {save.isPending && <Loader2 className="h-4 w-4 animate-spin" />}
+              {save.isPending && <Loading className="size-4 shrink-0" />}
               {tI18nHardcoded.raw(
                 'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxTextAddConnectore01e22fc',
               )}
@@ -3472,7 +3480,7 @@ function SetCredentialModal({
               Cancel
             </Button>
             <Button type="submit" size="sm" disabled={!value || save.isPending} className="gap-1.5">
-              {save.isPending && <Loader2 className="h-4 w-4 animate-spin" />}Save
+              {save.isPending && <Loading className="size-4 shrink-0" />}Save
             </Button>
           </ModalFooter>
         </form>

--- a/apps/web/src/features/workspace/customize/sections/llm-provider/api-key-connect-form.tsx
+++ b/apps/web/src/features/workspace/customize/sections/llm-provider/api-key-connect-form.tsx
@@ -1,7 +1,9 @@
 'use client';
 
 import { Button } from '@/components/ui/button';
+import { InfoBanner } from '@/components/ui/info-banner';
 import { Input } from '@/components/ui/input';
+import Loading from '@/components/ui/loading';
 import { successToast } from '@/components/ui/toast';
 import { ProviderLogo } from '@/features/providers/provider-branding';
 import { refreshProjectProviderState } from '@/hooks/opencode/provider-refresh';
@@ -9,7 +11,7 @@ import type { LlmProviderEntry } from '@/lib/llm-providers';
 import { cn } from '@/lib/utils';
 import { upsertProjectSecret } from '@kortix/sdk/projects-client';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { AlertCircle, ChevronLeft, ExternalLink, Info, Loader2 } from 'lucide-react';
+import { AlertCircle, ChevronLeft, ExternalLink, Info } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { type FormEvent, useMemo, useState } from 'react';
 
@@ -159,19 +161,16 @@ export function ApiKeyConnectForm({
           </div>
         )}
 
-        <div className="flex items-start gap-2.5 rounded-2xl border border-amber-500/20 bg-amber-500/[0.06] px-3 py-2.5">
-          <Info className="mt-0.5 size-4 shrink-0 text-amber-600 dark:text-amber-500" />
-          <p className="text-foreground/80 text-xs leading-relaxed">
-            {tHardcodedUi.raw(
-              'autoComponentsProjectsProjectProviderModalJsxTextASandboxPicks96cfb428',
-            )}
-          </p>
-        </div>
+        <InfoBanner tone="warning" icon={Info} className="rounded-2xl">
+          {tHardcodedUi.raw(
+            'autoComponentsProjectsProjectProviderModalJsxTextASandboxPicks96cfb428',
+          )}
+        </InfoBanner>
 
         <Button type="submit" size="sm" className="px-4" disabled={upsert.isPending || !allFilled}>
           {upsert.isPending ? (
             <>
-              <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+              <Loading className="mr-1.5 size-3.5 shrink-0" />
               {tHardcodedUi.raw('componentsProjectsProjectProviderModal.line847JsxTextConnecting')}
             </>
           ) : (

--- a/apps/web/src/features/workspace/customize/sections/llm-provider/chatgpt-subscription-connect.tsx
+++ b/apps/web/src/features/workspace/customize/sections/llm-provider/chatgpt-subscription-connect.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Button } from '@/components/ui/button';
+import Loading from '@/components/ui/loading';
 import { successToast } from '@/components/ui/toast';
 import { ProviderLogo } from '@/features/providers/provider-branding';
 import { refreshProjectProviderState } from '@/hooks/opencode/provider-refresh';
@@ -9,7 +10,7 @@ import {
   startProjectProviderOAuth,
 } from '@kortix/sdk/projects-client';
 import { useQueryClient } from '@tanstack/react-query';
-import { AlertCircle, ExternalLink, Loader2 } from 'lucide-react';
+import { AlertCircle, ExternalLink } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
@@ -169,14 +170,14 @@ export function ChatGptSubscriptionConnect({
             </div>
           )}
           <div className="text-muted-foreground mt-3 flex items-center gap-2 text-xs">
-            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            <Loading className="size-3.5 shrink-0" />
             {challenge ? 'Waiting for you to finish in the browser…' : 'Connecting to OpenAI…'}
           </div>
         </div>
       )}
 
       {phase === 'done' && (
-        <div className="text-foreground/80 mt-3 flex items-start gap-2 rounded-2xl border border-emerald-500/20 bg-emerald-500/[0.06] px-3 py-2.5 text-xs">
+        <div className="text-foreground/80 border-kortix-green/20 bg-kortix-green/[0.06] mt-3 flex items-start gap-2 rounded-2xl border px-3 py-2.5 text-xs">
           {tHardcodedUi.raw(
             'autoComponentsProjectsProjectProviderModalJsxTextChatGPTSubscriptionConnectedcf12bc87',
           )}

--- a/apps/web/src/features/workspace/customize/sections/llm-provider/custom-provider-form.tsx
+++ b/apps/web/src/features/workspace/customize/sections/llm-provider/custom-provider-form.tsx
@@ -2,11 +2,12 @@
 
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import Loading from '@/components/ui/loading';
 import { errorToast, successToast } from '@/components/ui/toast';
 import { refreshProjectProviderState } from '@/hooks/opencode/provider-refresh';
 import { upsertProjectSecret } from '@kortix/sdk/projects-client';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { AlertCircle, ChevronLeft, Copy, Loader2 } from 'lucide-react';
+import { AlertCircle, ChevronLeft, Copy } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { type FormEvent, useState } from 'react';
 
@@ -252,7 +253,7 @@ export function CustomProviderForm({
         <Button type="submit" size="sm" className="px-4" disabled={save.isPending}>
           {save.isPending ? (
             <>
-              <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+              <Loading className="mr-1.5 size-3.5 shrink-0" />
               {tHardcodedUi.raw('componentsProjectsProjectProviderModal.line1094JsxTextGenerating')}
             </>
           ) : (
@@ -289,7 +290,7 @@ function CustomProviderSnippetView({
 
   return (
     <div className="space-y-3 px-5 pt-3 pb-5">
-      <div className="rounded-2xl border border-emerald-500/30 bg-emerald-500/[0.04] px-3.5 py-3">
+      <div className="border-kortix-green/30 bg-kortix-green/[0.04] rounded-2xl border px-3.5 py-3">
         <div className="text-foreground text-sm font-medium">
           {secretName ? 'API key saved' : 'Snippet ready'}
         </div>

--- a/apps/web/src/features/workspace/customize/sections/llm-provider/llm-provider-modal.tsx
+++ b/apps/web/src/features/workspace/customize/sections/llm-provider/llm-provider-modal.tsx
@@ -141,7 +141,7 @@ export function ProjectProviderModal({
       <div className="min-h-0 flex-1 overflow-y-auto">
         {secretsQuery.isLoading && (
           <div className="flex min-h-[200px] items-center justify-center">
-            <Loading className="text-muted-foreground h-4 w-4 animate-spin" />
+            <Loading className="text-muted-foreground size-4 shrink-0" />
           </div>
         )}
 

--- a/apps/web/src/features/workspace/customize/sections/view/agents-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/agents-view.tsx
@@ -2,6 +2,8 @@
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import Loading from '@/components/ui/loading';
+import { errorToast, successToast } from '@/components/ui/toast';
 import { ModelSelector } from '@/features/session/model-selector';
 import { flattenModels } from '@/features/session/session-chat-input';
 import { AgentConfigEditor } from '@/features/workspace/customize/sections/view/agent-editor';
@@ -14,7 +16,6 @@ import {
 import { formatMode } from '@/features/workspace/customize/shared/utils';
 import { useModelDefaults } from '@/hooks/opencode/use-model-defaults';
 import { useOpenCodeProviders } from '@/hooks/opencode/use-opencode-sessions';
-import { toast } from '@/lib/toast';
 import { cn } from '@/lib/utils';
 import {
   type AgentGrantSet,
@@ -27,7 +28,7 @@ import {
 } from '@kortix/sdk/projects-client';
 import { StarSolid } from '@mynaui/icons-react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { Bot, Check, Loader2, ShieldCheck, Sparkles, User, Users } from 'lucide-react';
+import { Bot, Check, ShieldCheck, Sparkles, User, Users } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 
 type Agent = ProjectConfigSummary['agents'][number];
@@ -216,7 +217,7 @@ function AgentModel({ projectId, agentName }: { projectId: string; agentName: st
             onSelect={(m) => {
               if (m) {
                 void defaults.setAgentDefault(agentName, m);
-                toast.success(`${agentName} → ${nameOf(m)}`);
+                successToast(`${agentName} → ${nameOf(m)}`);
               } else {
                 void defaults.clearAgentDefault(agentName);
               }
@@ -229,7 +230,7 @@ function AgentModel({ projectId, agentName }: { projectId: string; agentName: st
               className="h-7 px-2 text-xs"
               onClick={() => {
                 void defaults.clearAgentDefault(agentName);
-                toast.success(`${agentName} follows the default model again`);
+                successToast(`${agentName} follows the default model again`);
               }}
             >
               Reset to default
@@ -350,11 +351,11 @@ function AgentScopeCard({
   const save = useMutation({
     mutationFn: () => setAgentScope(projectId, agentName, { env, connectors }),
     onSuccess: () => {
-      toast.success(`Scope updated for ${agentName}`);
+      successToast(`Scope updated for ${agentName}`);
       // Refetch the project config so the committed scope (this card's source) updates.
       queryClient.invalidateQueries({ queryKey: ['project-detail', projectId] });
     },
-    onError: (e: Error) => toast.error(e.message || 'Failed to update scope'),
+    onError: (e: Error) => errorToast(e.message || 'Failed to update scope'),
   });
 
   // Non-managers get the read-only mirror (the old presentation).
@@ -423,7 +424,7 @@ function AgentScopeCard({
             disabled={!dirty || save.isPending}
             onClick={() => save.mutate()}
           >
-            {save.isPending && <Loader2 className="size-3.5 animate-spin" />}
+            {save.isPending && <Loading className="size-3.5 shrink-0" />}
             Save scope
           </Button>
         </div>
@@ -561,7 +562,7 @@ function ScopeEditor({
                     {isSel && <Check className="size-3" />}
                   </span>
                   <span className="min-w-0 flex-1 truncate font-mono">{o.label}</span>
-                  {isOrphan && <span className="text-amber-600 dark:text-amber-400">missing</span>}
+                  {isOrphan && <span className="text-kortix-orange">missing</span>}
                 </button>
               );
             })}

--- a/apps/web/src/features/workspace/customize/sections/view/gateway/gateway-logs.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/gateway/gateway-logs.tsx
@@ -16,6 +16,7 @@ import { forwardRef, type ReactNode, useEffect, useRef, useState } from 'react';
 import { EmptyState } from '@/features/layout/section/empty-state';
 import { FilterBar, FilterBarItem } from '@/components/ui/tabs';
 import Hint from '@/components/ui/hint';
+import { Skeleton } from '@/components/ui/skeleton';
 import { useGatewayLog, useGatewayLogs } from '@/hooks/projects/use-project-gateway';
 import type { GatewayLogRow } from '@/lib/projects-gateway-client';
 import { cn } from '@/lib/utils';
@@ -222,8 +223,8 @@ function GatewayLogDetail({
       </div>
       {isLoading || !data ? (
         <div className="space-y-3 p-5">
-          <div className="h-24 animate-pulse rounded-2xl bg-muted" />
-          <div className="h-40 animate-pulse rounded-2xl bg-muted" />
+          <Skeleton className="h-24 rounded-2xl" />
+          <Skeleton className="h-40 rounded-2xl" />
         </div>
       ) : (
         <div className="flex w-full animate-in fade-in-0 flex-col gap-4 p-5">
@@ -422,12 +423,12 @@ export function GatewayLogs({ projectId }: { projectId: string }) {
           <div className="divide-y divide-border/40">
             {Array.from({ length: 8 }).map((_, i) => (
               <div key={i} className="flex items-center gap-3 px-4 py-3">
-                <span className="size-2 animate-pulse rounded-full bg-muted" />
+                <Skeleton className="size-2 shrink-0 rounded-full" />
                 <div className="flex-1 space-y-1.5">
-                  <div className="h-3 w-40 animate-pulse rounded-full bg-muted" />
-                  <div className="h-2.5 w-24 animate-pulse rounded-full bg-muted" />
+                  <Skeleton className="h-3 w-40 rounded-full" />
+                  <Skeleton className="h-2.5 w-24 rounded-full" />
                 </div>
-                <div className="h-4 w-14 animate-pulse rounded-full bg-muted" />
+                <Skeleton className="h-4 w-14 rounded-full" />
               </div>
             ))}
           </div>

--- a/apps/web/src/features/workspace/customize/sections/view/meet-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/meet-view.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import { Loader2, Play } from 'lucide-react';
+import { Play } from 'lucide-react';
 import { useState } from 'react';
 
 import { Button } from '@/components/ui/button';
 import { InfoBanner } from '@/components/ui/info-banner';
 import { Input } from '@/components/ui/input';
-import { SectionCard } from '@/components/ui/section-card';
+import { Label } from '@/components/ui/label';
+import Loading from '@/components/ui/loading';
 import {
   Select,
   SelectContent,
@@ -92,84 +93,91 @@ export function MeetView({ projectId }: { projectId: string }) {
           </InfoBanner>
         ) : null}
 
-        <SectionCard
-          title="Bot name"
-          description="The display name the notetaker joins under. People wake it in the call by saying its first name."
-        >
-          {voicesQuery.isLoading ? (
-            <Skeleton className="h-10 w-full rounded-lg" />
-          ) : (
-            <div className="flex items-center gap-2">
-              <Input
-                size="lg"
-                value={botName}
-                onChange={(e) => setDraftName(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter') onSaveName();
-                }}
-                placeholder={defaultBotName}
-                maxLength={80}
-                className="flex-1"
-              />
-              <Button
-                size="lg"
-                className="shrink-0"
-                disabled={setBotName.isPending || !nameDirty}
-                onClick={onSaveName}
-              >
-                Save
-              </Button>
-            </div>
-          )}
-        </SectionCard>
-
-        <SectionCard
-          title="Default voice"
-          description="Used for the bot's spoken replies in calls. Preview a voice before you set it."
-        >
-          {voicesQuery.isLoading ? (
-            <Skeleton className="h-11 w-full rounded-lg" />
-          ) : voices.length === 0 ? (
-            <p className="text-muted-foreground text-sm">No voices available.</p>
-          ) : (
-            <div className="space-y-3">
+        <section className="space-y-4">
+          <Label>Bot name</Label>
+          <p className="text-muted-foreground -mt-2 text-xs">
+            The display name the notetaker joins under. People wake it in the call by saying its
+            first name.
+          </p>
+          <div className="bg-popover rounded-md border px-4 py-5">
+            {voicesQuery.isLoading ? (
+              <Skeleton className="h-10 w-full rounded-lg" />
+            ) : (
               <div className="flex items-center gap-2">
-                <Select value={selected} onValueChange={onSelect} disabled={setVoice.isPending}>
-                  <SelectTrigger size="lg" className="flex-1">
-                    <SelectValue placeholder="Select a voice" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {voices.map((v) => (
-                      <SelectItem key={v.id} value={v.id}>
-                        <span className="font-medium">{v.name}</span>
-                        <span className="text-muted-foreground ml-2">{v.desc}</span>
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-                <Button
-                  variant="outline"
+                <Input
                   size="lg"
-                  className="shrink-0 gap-1.5"
-                  disabled={!selected || previewing !== null}
-                  onClick={() => selected && onPreview(selected)}
+                  value={botName}
+                  onChange={(e) => setDraftName(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') onSaveName();
+                  }}
+                  placeholder={defaultBotName}
+                  maxLength={80}
+                  className="flex-1"
+                />
+                <Button
+                  size="lg"
+                  className="shrink-0"
+                  disabled={setBotName.isPending || !nameDirty}
+                  onClick={onSaveName}
                 >
-                  {previewing === selected ? (
-                    <Loader2 className="size-4 animate-spin" />
-                  ) : (
-                    <Play className="size-4" />
-                  )}
-                  Preview
+                  Save
                 </Button>
               </div>
-              {selectedVoice ? (
-                <p className="text-muted-foreground text-xs">
-                  Current: {selectedVoice.name} — {selectedVoice.desc}
-                </p>
-              ) : null}
-            </div>
-          )}
-        </SectionCard>
+            )}
+          </div>
+        </section>
+
+        <section className="space-y-4">
+          <Label>Default voice</Label>
+          <p className="text-muted-foreground -mt-2 text-xs">
+            Used for the bot's spoken replies in calls. Preview a voice before you set it.
+          </p>
+          <div className="bg-popover rounded-md border px-4 py-5">
+            {voicesQuery.isLoading ? (
+              <Skeleton className="h-11 w-full rounded-lg" />
+            ) : voices.length === 0 ? (
+              <p className="text-muted-foreground text-sm">No voices available.</p>
+            ) : (
+              <div className="space-y-3">
+                <div className="flex items-center gap-2">
+                  <Select value={selected} onValueChange={onSelect} disabled={setVoice.isPending}>
+                    <SelectTrigger size="lg" className="flex-1">
+                      <SelectValue placeholder="Select a voice" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {voices.map((v) => (
+                        <SelectItem key={v.id} value={v.id}>
+                          <span className="font-medium">{v.name}</span>
+                          <span className="text-muted-foreground ml-2">{v.desc}</span>
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <Button
+                    variant="outline"
+                    size="lg"
+                    className="shrink-0 gap-1.5"
+                    disabled={!selected || previewing !== null}
+                    onClick={() => selected && onPreview(selected)}
+                  >
+                    {previewing === selected ? (
+                      <Loading className="size-4 shrink-0" />
+                    ) : (
+                      <Play className="size-4 shrink-0" />
+                    )}
+                    Preview
+                  </Button>
+                </div>
+                {selectedVoice ? (
+                  <p className="text-muted-foreground text-xs">
+                    Current: {selectedVoice.name} — {selectedVoice.desc}
+                  </p>
+                ) : null}
+              </div>
+            )}
+          </div>
+        </section>
       </div>
     </CustomizeSectionWrapper>
   );

--- a/apps/web/src/features/workspace/customize/sections/view/members-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/members-view.tsx
@@ -4,7 +4,7 @@ import { useTranslations } from 'next-intl';
 
 import { errorToast, successToast, warningToast } from '@/components/ui/toast';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { Bot, Check, Clock, CornerDownRight, KeyRound, Loader2, Mail, MessageSquare, Plug, Plus, RefreshCw, Shield, Sparkles, User, Users, X } from 'lucide-react';
+import { Bot, Check, Clock, CornerDownRight, KeyRound, Mail, MessageSquare, Plug, Plus, RefreshCw, Shield, Sparkles, User, Users, X } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { FormEvent, useEffect, useMemo, useState } from 'react';
 
@@ -18,16 +18,6 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import {
-  Dialog,
-  DialogClose,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from '@/components/ui/dialog';
-import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -37,9 +27,16 @@ import { EntityAvatar } from '@/components/ui/entity-avatar';
 import { Field, FieldDescription, FieldError, FieldGroup, FieldLabel } from '@/components/ui/field';
 import { InlineMeta } from '@/components/ui/inline-meta';
 import { InputGroup, InputGroupAddon, InputGroupInput } from '@/components/ui/input-group';
-import { List, ListRow } from '@/components/ui/list';
 import Loading from '@/components/ui/loading';
-import { SectionCard } from '@/components/ui/section-card';
+import {
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalDescription,
+  ModalFooter,
+  ModalHeader,
+  ModalTitle,
+} from '@/components/ui/modal';
 import {
   Select,
   SelectContent,
@@ -1914,187 +1911,208 @@ function ResourceAccessCard({
   const canSubmit = !!pickerType && !!pickerResourceId && !!principalValue && !createMutation.isPending;
 
   return (
-    <SectionCard
-      flush
-      title="Resource access"
-      description="Assign agents to a member or group to control who can USE them. An agent with no assignment is open to everyone with project access; assigning one restricts it to the people or groups you choose — they inherit that agent's declared skills, connectors, and secrets to use in its sessions. This only ever grants USE, never edit: changing the agent, a skill, a connector, or a secret still requires the editor role."
-      count={grants.length}
-      action={
-        canManage && hasResources ? (
-          <Dialog open={dialogOpen} onOpenChange={onDialogOpenChange}>
-            <DialogTrigger asChild>
-              <Button size="sm" variant="outline" className="gap-1.5">
-                <Plus className="h-3.5 w-3.5" />
-                Grant access
-              </Button>
-            </DialogTrigger>
-            <DialogContent className="sm:max-w-md">
-              <DialogHeader>
-                <DialogTitle>Assign an agent</DialogTitle>
-                <DialogDescription>
-                  Assign an agent to a member or group — they inherit everything that agent
-                  uses (its secrets, connectors, and skills) to USE, not edit. Resources reach
-                  people through agents, not by a direct grant; agents you don't assign stay open
-                  to everyone with project access. Editing the agent or any resource it uses still
-                  requires the editor role.
-                </DialogDescription>
-              </DialogHeader>
+    <>
+      <section className="space-y-4">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h3 className="text-sm font-medium">
+              Resource access
+              {grants.length > 0 ? (
+                <span className="text-muted-foreground ml-1.5 font-normal">({grants.length})</span>
+              ) : null}
+            </h3>
+            <p className="text-muted-foreground mt-1 text-xs">
+              Assign agents to a member or group to control who can USE them. An agent with no
+              assignment is open to everyone with project access; assigning one restricts it to
+              the people or groups you choose — they inherit that agent's declared skills,
+              connectors, and secrets to use in its sessions. This only ever grants USE, never
+              edit: changing the agent, a skill, a connector, or a secret still requires the
+              editor role.
+            </p>
+          </div>
 
-              <form
-                id="grant-resource-form"
-                className="space-y-4 py-1"
-                onSubmit={(e) => {
-                  e.preventDefault();
-                  if (!canSubmit) return;
-                  createMutation.mutate();
-                }}
-              >
-                <div className="space-y-1.5">
-                  <span className="text-muted-foreground text-xs font-medium">1. Agent</span>
-                  <Select
-                    value={pickerResourceId}
-                    onValueChange={setPickerResourceId}
-                    disabled={createMutation.isPending}
-                  >
-                    <SelectTrigger className="w-full">
-                      <SelectValue placeholder="Select an agent" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {activeItems.map((r) => (
-                        <SelectItem key={r.id} value={r.id}>
-                          {r.name}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-
-                {selectedAgentDeclares && <BlastRadiusPreview declares={selectedAgentDeclares} />}
-
-                <div className="space-y-1.5">
-                  <span className="text-muted-foreground text-xs font-medium">2. Grant to</span>
-                  <Select
-                    value={principalValue}
-                    onValueChange={setPrincipalValue}
-                    disabled={createMutation.isPending}
-                  >
-                    <SelectTrigger className="w-full">
-                      <SelectValue placeholder="Member or group" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {members.map((m) => (
-                        <SelectItem key={`member:${m.user_id}`} value={`member:${m.user_id}`}>
-                          {userLabel(m)}
-                        </SelectItem>
-                      ))}
-                      {groups.map((g) => (
-                        <SelectItem key={`group:${g.group_id}`} value={`group:${g.group_id}`}>
-                          {g.name} · group
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-              </form>
-
-              <DialogFooter>
-                <DialogClose asChild>
-                  <Button type="button" variant="ghost" size="sm">
-                    Cancel
-                  </Button>
-                </DialogClose>
-                <Button type="submit" form="grant-resource-form" size="sm" disabled={!canSubmit}>
-                  {createMutation.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : 'Grant access'}
-                </Button>
-              </DialogFooter>
-            </DialogContent>
-          </Dialog>
-        ) : null
-      }
-    >
-      {grantsQuery.isLoading && (
-        <div className="px-6 py-5">
-          <Skeleton className="h-8 w-full" />
+          {canManage && hasResources ? (
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              className="shrink-0 gap-1.5"
+              onClick={() => onDialogOpenChange(true)}
+            >
+              <Plus className="size-3.5 shrink-0" />
+              Grant access
+            </Button>
+          ) : null}
         </div>
-      )}
 
-      {!grantsQuery.isLoading && grants.length === 0 && (
-        <div className="text-muted-foreground px-6 py-5 text-xs">
-          {hasResources
-            ? 'Nothing is scoped yet — every agent is open to everyone with project access to use. Grant one above to restrict who can use it. Skills, connectors, and secrets aren’t assigned directly here — they’re governed by the editor role (to edit) and inherited through the agents you assign (to use).'
-            : 'This project has no agents to scope yet. Add one first, then come back here to limit who can use it.'}
-        </div>
-      )}
+        {grantsQuery.isLoading && (
+          <div className="space-y-2">
+            <Skeleton className="h-14 w-full rounded-md" />
+          </div>
+        )}
 
-      {!grantsQuery.isLoading && grants.length > 0 && (
-        <>
-          {grantFilterOptions.length > 2 && (
-            <FilterChips value={resourceFilter} onChange={setResourceFilter} options={grantFilterOptions} />
-          )}
-          <List>
-            {visibleGrants.map((g: ProjectResourceGrant) => {
-              const busy = pendingIds.has(g.grant_id);
-              const displayName = resourceName.get(`${g.resource_type}:${g.resource_id}`) ?? g.resource_id;
-            const ResourceIcon = g.resource_type === 'agent' ? Bot : g.resource_type === 'secret' ? KeyRound : Sparkles;
-            return (
-              <ListRow
-                key={g.grant_id}
-                leading={
-                  <span className="bg-muted/60 flex h-8 w-8 items-center justify-center rounded-full">
-                    <ResourceIcon className="text-muted-foreground h-4 w-4" />
-                  </span>
-                }
-                title={
-                  <span className="flex items-center gap-2">
-                    {displayName}
-                    <Badge variant="outline" size="sm" className="capitalize">
-                      {g.resource_type}
-                    </Badge>
-                    {g.orphaned && (
-                      <Badge
-                        variant="outline"
+        {!grantsQuery.isLoading && grants.length === 0 && (
+          <p className="text-muted-foreground text-xs">
+            {hasResources
+              ? 'Nothing is scoped yet — every agent is open to everyone with project access to use. Grant one above to restrict who can use it. Skills, connectors, and secrets aren’t assigned directly here — they’re governed by the editor role (to edit) and inherited through the agents you assign (to use).'
+              : 'This project has no agents to scope yet. Add one first, then come back here to limit who can use it.'}
+          </p>
+        )}
+
+        {!grantsQuery.isLoading && grants.length > 0 && (
+          <div className="space-y-3">
+            {grantFilterOptions.length > 2 && (
+              <FilterChips value={resourceFilter} onChange={setResourceFilter} options={grantFilterOptions} />
+            )}
+            <ul className="space-y-2">
+              {visibleGrants.map((g: ProjectResourceGrant) => {
+                const busy = pendingIds.has(g.grant_id);
+                const displayName = resourceName.get(`${g.resource_type}:${g.resource_id}`) ?? g.resource_id;
+                const ResourceIcon = g.resource_type === 'agent' ? Bot : g.resource_type === 'secret' ? KeyRound : Sparkles;
+                return (
+                  <li key={g.grant_id} className={MEMBER_ROW}>
+                    <span className="bg-muted/60 flex size-8 shrink-0 items-center justify-center rounded-full">
+                      <ResourceIcon className="text-muted-foreground size-4" />
+                    </span>
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2">
+                        <span className="text-foreground truncate text-sm font-medium">
+                          {displayName}
+                        </span>
+                        <Badge variant="outline" size="sm" className="capitalize">
+                          {g.resource_type}
+                        </Badge>
+                        {g.orphaned && (
+                          <Badge
+                            variant="outline"
+                            size="sm"
+                            className="border-kortix-orange/30 text-kortix-orange"
+                            title={`This ${g.resource_type} no longer exists (renamed or deleted). The grant is inert — the restriction has lapsed. Remove it or re-grant the current ${g.resource_type}.`}
+                          >
+                            renamed / removed
+                          </Badge>
+                        )}
+                      </div>
+                      <span className="text-muted-foreground text-xs">
+                        <InlineMeta>
+                          <span>
+                            {g.principal_type === 'group' ? 'Group' : 'Member'}: {g.principal_label}
+                          </span>
+                          <span>Granted {formatDate(g.created_at)}</span>
+                        </InlineMeta>
+                      </span>
+                    </div>
+                    {busy ? (
+                      <Loading className="text-muted-foreground shrink-0" />
+                    ) : canManage ? (
+                      <Button
+                        type="button"
                         size="sm"
-                        className="border-amber-300 text-amber-700 dark:border-amber-500/40 dark:text-amber-400"
-                        title={`This ${g.resource_type} no longer exists (renamed or deleted). The grant is inert — the restriction has lapsed. Remove it or re-grant the current ${g.resource_type}.`}
+                        variant="ghost"
+                        onClick={() => removeMutation.mutate(g.grant_id)}
                       >
-                        renamed / removed
+                        Remove
+                      </Button>
+                    ) : (
+                      <Badge variant="outline" size="sm" className="capitalize">
+                        {g.principal_type}
                       </Badge>
                     )}
-                  </span>
-                }
-                subtitle={
-                  <InlineMeta>
-                    <span>
-                      {g.principal_type === 'group' ? 'Group' : 'Member'}: {g.principal_label}
-                    </span>
-                    <span>Granted {formatDate(g.created_at)}</span>
-                  </InlineMeta>
-                }
-                trailing={
-                  busy ? (
-                    <Loader2 className="text-muted-foreground h-4 w-4 animate-spin" />
-                  ) : canManage ? (
-                    <Button
-                      type="button"
-                      size="sm"
-                      variant="ghost"
-                      onClick={() => removeMutation.mutate(g.grant_id)}
-                    >
-                      Remove
-                    </Button>
-                  ) : (
-                    <Badge variant="outline" size="sm" className="capitalize">
-                      {g.principal_type}
-                    </Badge>
-                  )
-                }
-              />
-            );
-          })}
-          </List>
-        </>
-      )}
-    </SectionCard>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        )}
+      </section>
+
+      <Modal open={dialogOpen} onOpenChange={onDialogOpenChange}>
+        <ModalContent className="sm:max-w-md">
+          <ModalHeader>
+            <ModalTitle>Assign an agent</ModalTitle>
+            <ModalDescription>
+              Assign an agent to a member or group — they inherit everything that agent
+              uses (its secrets, connectors, and skills) to USE, not edit. Resources reach
+              people through agents, not by a direct grant; agents you don't assign stay open
+              to everyone with project access. Editing the agent or any resource it uses still
+              requires the editor role.
+            </ModalDescription>
+          </ModalHeader>
+
+          <form
+            onSubmit={(e) => {
+              e.preventDefault();
+              if (!canSubmit) return;
+              createMutation.mutate();
+            }}
+          >
+            <ModalBody className="space-y-4">
+              <div className="space-y-1.5">
+                <span className="text-muted-foreground text-xs font-medium">1. Agent</span>
+                <Select
+                  value={pickerResourceId}
+                  onValueChange={setPickerResourceId}
+                  disabled={createMutation.isPending}
+                >
+                  <SelectTrigger className="w-full">
+                    <SelectValue placeholder="Select an agent" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {activeItems.map((r) => (
+                      <SelectItem key={r.id} value={r.id}>
+                        {r.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              {selectedAgentDeclares && <BlastRadiusPreview declares={selectedAgentDeclares} />}
+
+              <div className="space-y-1.5">
+                <span className="text-muted-foreground text-xs font-medium">2. Grant to</span>
+                <Select
+                  value={principalValue}
+                  onValueChange={setPrincipalValue}
+                  disabled={createMutation.isPending}
+                >
+                  <SelectTrigger className="w-full">
+                    <SelectValue placeholder="Member or group" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {members.map((m) => (
+                      <SelectItem key={`member:${m.user_id}`} value={`member:${m.user_id}`}>
+                        {userLabel(m)}
+                      </SelectItem>
+                    ))}
+                    {groups.map((g) => (
+                      <SelectItem key={`group:${g.group_id}`} value={`group:${g.group_id}`}>
+                        {g.name} · group
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </ModalBody>
+
+            <ModalFooter className="sm:justify-between">
+              <Button
+                type="button"
+                variant="outline-ghost"
+                size="sm"
+                onClick={() => onDialogOpenChange(false)}
+              >
+                Cancel
+              </Button>
+              <Button type="submit" size="sm" disabled={!canSubmit}>
+                {createMutation.isPending ? <Loading className="size-4 shrink-0" /> : null}
+                Grant access
+              </Button>
+            </ModalFooter>
+          </form>
+        </ModalContent>
+      </Modal>
+    </>
   );
 }
 
@@ -2290,194 +2308,211 @@ function ProjectRoleAssignmentsCard({
   const canSubmit = !!subjectType && !!subjectId && !!roleId && !createMutation.isPending;
 
   return (
-    <SectionCard
-      flush
-      title="Custom roles"
-      description="Grant a custom role to a member, group, or agent on this project. Custom roles are defined on the account Roles page; here you bind them for this project only."
-      count={policies.length}
-      action={
-        canManage && customRoles.length > 0 ? (
-          <Dialog open={dialogOpen} onOpenChange={onDialogOpenChange}>
-            <DialogTrigger asChild>
-              <Button size="sm" variant="outline" className="gap-1.5">
-                <Plus className="h-3.5 w-3.5" />
+    <>
+      <section className="space-y-4">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h3 className="text-sm font-medium">
+              Custom roles
+              {policies.length > 0 ? (
+                <span className="text-muted-foreground ml-1.5 font-normal">({policies.length})</span>
+              ) : null}
+            </h3>
+            <p className="text-muted-foreground mt-1 text-xs">
+              Grant a custom role to a member, group, or agent on this project. Custom roles are
+              defined on the account Roles page; here you bind them for this project only.
+            </p>
+          </div>
+
+          {canManage && customRoles.length > 0 ? (
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              className="shrink-0 gap-1.5"
+              onClick={() => onDialogOpenChange(true)}
+            >
+              <Plus className="size-3.5 shrink-0" />
+              Assign role
+            </Button>
+          ) : null}
+        </div>
+
+        {policiesQuery.isLoading && (
+          <div className="space-y-2">
+            <Skeleton className="h-14 w-full rounded-md" />
+          </div>
+        )}
+
+        {!policiesQuery.isLoading && policies.length === 0 && (
+          <p className="text-muted-foreground text-xs">
+            {customRoles.length === 0 ? (
+              <>
+                No custom roles exist yet. Create one on the{' '}
+                <a href={`/accounts/${accountId}?tab=roles`} className="underline">
+                  account Roles page
+                </a>
+                , then bind it here for this project.
+              </>
+            ) : (
+              'No custom-role assignments on this project yet. Bind one above to grant a member, group, or agent a custom role here.'
+            )}
+          </p>
+        )}
+
+        {!policiesQuery.isLoading && policies.length > 0 && (
+          <div className="space-y-3">
+            {policyFilterOptions.length > 2 && (
+              <FilterChips value={policyFilter} onChange={setPolicyFilter} options={policyFilterOptions} />
+            )}
+            <ul className="space-y-2">
+              {visiblePolicies.map((p) => {
+                const busy = pendingIds.has(p.policy_id);
+                const { kind, label, missing } = principalLabel(p);
+                return (
+                  <li key={p.policy_id} className={MEMBER_ROW}>
+                    <span className="bg-muted/60 flex size-8 shrink-0 items-center justify-center rounded-full">
+                      <Shield className="text-muted-foreground size-4" />
+                    </span>
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2">
+                        <span className="text-foreground truncate text-sm font-medium">
+                          {roleNameById.get(p.role_id) ?? p.role_id}
+                        </span>
+                        <Badge variant="outline" size="sm">
+                          Custom
+                        </Badge>
+                      </div>
+                      <span className="text-muted-foreground text-xs">
+                        <InlineMeta>
+                          <span className="flex items-center gap-1.5">
+                            {kind}: {label}
+                            {missing && (
+                              <Badge
+                                variant="outline"
+                                size="sm"
+                                className="border-kortix-orange/30 text-kortix-orange"
+                                title="This agent no longer exists (deleted or renamed). The binding is stale — remove it or re-assign the current agent."
+                              >
+                                removed
+                              </Badge>
+                            )}
+                          </span>
+                          {p.expires_at ? <span>Expires {formatDate(p.expires_at)}</span> : null}
+                        </InlineMeta>
+                      </span>
+                    </div>
+                    {busy ? (
+                      <Loading className="text-muted-foreground shrink-0" />
+                    ) : canManage ? (
+                      <Button type="button" size="sm" variant="ghost" onClick={() => removeMutation.mutate(p.policy_id)}>
+                        Remove
+                      </Button>
+                    ) : (
+                      <Badge variant="outline" size="sm" className="capitalize">
+                        {kind}
+                      </Badge>
+                    )}
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        )}
+      </section>
+
+      <Modal open={dialogOpen} onOpenChange={onDialogOpenChange}>
+        <ModalContent className="sm:max-w-md">
+          <ModalHeader>
+            <ModalTitle>Assign a custom role</ModalTitle>
+            <ModalDescription>
+              Bind a custom role to a member, group, or agent on this project only.
+            </ModalDescription>
+          </ModalHeader>
+
+          <form
+            onSubmit={(e) => {
+              e.preventDefault();
+              if (!canSubmit) return;
+              createMutation.mutate();
+            }}
+          >
+            <ModalBody className="space-y-4">
+              <div className="space-y-1.5">
+                <span className="text-muted-foreground text-xs font-medium">1. Assign to</span>
+                <div className="flex gap-1.5">
+                  {subjectOptions.map(({ type, label, Icon }) => (
+                    <Button
+                      key={type}
+                      type="button"
+                      size="sm"
+                      variant={subjectType === type ? 'default' : 'outline'}
+                      className="flex-1 gap-1.5"
+                      onClick={() => onSubjectTypeChange(type)}
+                    >
+                      <Icon className="size-3.5 shrink-0" />
+                      {label}
+                    </Button>
+                  ))}
+                </div>
+              </div>
+
+              <div className="space-y-1.5">
+                <span className="text-muted-foreground text-xs font-medium">
+                  2. {subjectType === 'group' ? 'Group' : subjectType === 'token' ? 'Agent' : 'Member'}
+                </span>
+                <Select
+                  value={subjectId}
+                  onValueChange={setSubjectId}
+                  disabled={!subjectType || createMutation.isPending}
+                >
+                  <SelectTrigger className="w-full">
+                    <SelectValue placeholder={subjectType ? 'Select one' : 'Pick a type first'} />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {activeSubjects.map((s) => (
+                      <SelectItem key={s.id} value={s.id}>
+                        {s.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="space-y-1.5">
+                <span className="text-muted-foreground text-xs font-medium">3. Custom role</span>
+                <Select value={roleId} onValueChange={setRoleId} disabled={createMutation.isPending}>
+                  <SelectTrigger className="w-full">
+                    <SelectValue placeholder="Select a role" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {customRoles.map((r) => (
+                      <SelectItem key={r.role_id} value={r.role_id}>
+                        {r.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </ModalBody>
+
+            <ModalFooter className="sm:justify-between">
+              <Button
+                type="button"
+                variant="outline-ghost"
+                size="sm"
+                onClick={() => onDialogOpenChange(false)}
+              >
+                Cancel
+              </Button>
+              <Button type="submit" size="sm" disabled={!canSubmit}>
+                {createMutation.isPending ? <Loading className="size-4 shrink-0" /> : null}
                 Assign role
               </Button>
-            </DialogTrigger>
-            <DialogContent className="sm:max-w-md">
-              <DialogHeader>
-                <DialogTitle>Assign a custom role</DialogTitle>
-                <DialogDescription>
-                  Bind a custom role to a member, group, or agent on this project only.
-                </DialogDescription>
-              </DialogHeader>
-
-              <form
-                id="assign-role-form"
-                className="space-y-4 py-1"
-                onSubmit={(e) => {
-                  e.preventDefault();
-                  if (!canSubmit) return;
-                  createMutation.mutate();
-                }}
-              >
-                <div className="space-y-1.5">
-                  <span className="text-muted-foreground text-xs font-medium">1. Assign to</span>
-                  <div className="flex gap-1.5">
-                    {subjectOptions.map(({ type, label, Icon }) => (
-                      <Button
-                        key={type}
-                        type="button"
-                        size="sm"
-                        variant={subjectType === type ? 'default' : 'outline'}
-                        className="flex-1 gap-1.5"
-                        onClick={() => onSubjectTypeChange(type)}
-                      >
-                        <Icon className="h-3.5 w-3.5" />
-                        {label}
-                      </Button>
-                    ))}
-                  </div>
-                </div>
-
-                <div className="space-y-1.5">
-                  <span className="text-muted-foreground text-xs font-medium">
-                    2. {subjectType === 'group' ? 'Group' : subjectType === 'token' ? 'Agent' : 'Member'}
-                  </span>
-                  <Select
-                    value={subjectId}
-                    onValueChange={setSubjectId}
-                    disabled={!subjectType || createMutation.isPending}
-                  >
-                    <SelectTrigger className="w-full">
-                      <SelectValue placeholder={subjectType ? 'Select one' : 'Pick a type first'} />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {activeSubjects.map((s) => (
-                        <SelectItem key={s.id} value={s.id}>
-                          {s.name}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-
-                <div className="space-y-1.5">
-                  <span className="text-muted-foreground text-xs font-medium">3. Custom role</span>
-                  <Select value={roleId} onValueChange={setRoleId} disabled={createMutation.isPending}>
-                    <SelectTrigger className="w-full">
-                      <SelectValue placeholder="Select a role" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {customRoles.map((r) => (
-                        <SelectItem key={r.role_id} value={r.role_id}>
-                          {r.name}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-              </form>
-
-              <DialogFooter>
-                <DialogClose asChild>
-                  <Button type="button" variant="ghost" size="sm">
-                    Cancel
-                  </Button>
-                </DialogClose>
-                <Button type="submit" form="assign-role-form" size="sm" disabled={!canSubmit}>
-                  {createMutation.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : 'Assign role'}
-                </Button>
-              </DialogFooter>
-            </DialogContent>
-          </Dialog>
-        ) : null
-      }
-    >
-      {policiesQuery.isLoading && (
-        <div className="px-6 py-5">
-          <Skeleton className="h-8 w-full" />
-        </div>
-      )}
-
-      {!policiesQuery.isLoading && policies.length === 0 && (
-        <div className="text-muted-foreground px-6 py-5 text-xs">
-          {customRoles.length === 0 ? (
-            <>
-              No custom roles exist yet. Create one on the{' '}
-              <a href={`/accounts/${accountId}?tab=roles`} className="underline">
-                account Roles page
-              </a>
-              , then bind it here for this project.
-            </>
-          ) : (
-            'No custom-role assignments on this project yet. Bind one above to grant a member, group, or agent a custom role here.'
-          )}
-        </div>
-      )}
-
-      {!policiesQuery.isLoading && policies.length > 0 && (
-        <>
-          {policyFilterOptions.length > 2 && (
-            <FilterChips value={policyFilter} onChange={setPolicyFilter} options={policyFilterOptions} />
-          )}
-          <List>
-            {visiblePolicies.map((p) => {
-            const busy = pendingIds.has(p.policy_id);
-            const { kind, label, missing } = principalLabel(p);
-            return (
-              <ListRow
-                key={p.policy_id}
-                leading={
-                  <span className="bg-muted/60 flex h-8 w-8 items-center justify-center rounded-full">
-                    <Shield className="text-muted-foreground h-4 w-4" />
-                  </span>
-                }
-                title={
-                  <span className="flex items-center gap-2">
-                    {roleNameById.get(p.role_id) ?? p.role_id}
-                    <Badge variant="outline" size="sm">
-                      Custom
-                    </Badge>
-                  </span>
-                }
-                subtitle={
-                  <InlineMeta>
-                    <span className="flex items-center gap-1.5">
-                      {kind}: {label}
-                      {missing && (
-                        <Badge
-                          variant="outline"
-                          size="sm"
-                          className="border-amber-300 text-amber-700 dark:border-amber-500/40 dark:text-amber-400"
-                          title="This agent no longer exists (deleted or renamed). The binding is stale — remove it or re-assign the current agent."
-                        >
-                          removed
-                        </Badge>
-                      )}
-                    </span>
-                    {p.expires_at ? <span>Expires {formatDate(p.expires_at)}</span> : null}
-                  </InlineMeta>
-                }
-                trailing={
-                  busy ? (
-                    <Loader2 className="text-muted-foreground h-4 w-4 animate-spin" />
-                  ) : canManage ? (
-                    <Button type="button" size="sm" variant="ghost" onClick={() => removeMutation.mutate(p.policy_id)}>
-                      Remove
-                    </Button>
-                  ) : (
-                    <Badge variant="outline" size="sm" className="capitalize">
-                      {kind}
-                    </Badge>
-                  )
-                }
-              />
-            );
-          })}
-          </List>
-        </>
-      )}
-    </SectionCard>
+            </ModalFooter>
+          </form>
+        </ModalContent>
+      </Modal>
+    </>
   );
 }

--- a/apps/web/src/features/workspace/customize/sections/view/sandbox-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/sandbox-view.tsx
@@ -3,6 +3,7 @@
 import { SandboxTemplateForm } from '@/components/projects/sandbox-template-form';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import {
   Disclosure,
   DisclosureBody,
@@ -347,6 +348,7 @@ function TemplateRow({
   const tI18nHardcoded = useTranslations('hardcodedUi');
   const queryClient = useQueryClient();
   const { version: manifestVersion } = useProjectManifestVersion(projectId);
+  const [confirmDelete, setConfirmDelete] = useState(false);
   const buildMut = useMutation({
     mutationFn: () => buildSandboxTemplate(projectId, template.template_id!),
     onSuccess: () => {
@@ -361,6 +363,7 @@ function TemplateRow({
       successToast(`Deleted "${template.name}"`);
       queryClient.invalidateQueries({ queryKey: SNAPSHOTS_QUERY_KEY(projectId) });
       queryClient.invalidateQueries({ queryKey: ['project-sandboxes', projectId] });
+      setConfirmDelete(false);
     },
     onError: (err: Error) => errorToast(err.message || 'Failed to delete template'),
   });
@@ -391,97 +394,105 @@ function TemplateRow({
           : AlarmClockSolid;
 
   return (
-    <li className="bg-popover flex flex-wrap items-center gap-4 overflow-hidden px-4 py-3 text-sm">
-      <div
-        className={cn(
-          'inline-flex size-11 shrink-0 items-center justify-center rounded-sm border',
-          DAYTONA_TONE_ICON_TILE[stateInfo.tone],
-        )}
-      >
-        <Icon className="size-6 shrink-0" />
-      </div>
-      <div className="min-w-0 flex-1 space-y-0.5">
-        <div className="flex items-center gap-2">
-          <span className="font-medium">{template.name}</span>
-          <Badge variant="secondary" size="sm">
-            {template.slug}
-          </Badge>
-          <span className="text-muted-foreground/70 text-[10px] tracking-wide uppercase">
-            {sourceTag}
-          </span>
+    <>
+      <li className="bg-popover flex flex-wrap items-center gap-4 overflow-hidden px-4 py-3 text-sm">
+        <div
+          className={cn(
+            'inline-flex size-11 shrink-0 items-center justify-center rounded-sm border',
+            DAYTONA_TONE_ICON_TILE[stateInfo.tone],
+          )}
+        >
+          <Icon className="size-6 shrink-0" />
         </div>
-        <div className="text-muted-foreground gap-1 truncate text-[13px]">
-          {sub} &bull; {template.cpu} &bull;{' '}
-          {tI18nHardcoded.raw('autoComponentsProjectsSandboxSnapshotCardJsxTextVCPU15535b27')}
-          &bull; {template.memory_gb}{' '}
-          {tI18nHardcoded.raw('autoComponentsProjectsSandboxSnapshotCardJsxTextGiB9d1e488f')}
-          &bull; {template.disk_gb}{' '}
-          {tI18nHardcoded.raw('autoComponentsProjectsSandboxSnapshotCardJsxTextGiBDiskd395296d')}
+        <div className="min-w-0 flex-1 space-y-0.5">
+          <div className="flex items-center gap-2">
+            <span className="font-medium">{template.name}</span>
+            <Badge variant="secondary" size="sm">
+              {template.slug}
+            </Badge>
+            <span className="text-muted-foreground/70 text-[10px] tracking-wide uppercase">
+              {sourceTag}
+            </span>
+          </div>
+          <div className="text-muted-foreground gap-1 truncate text-[13px]">
+            {sub} &bull; {template.cpu} &bull;{' '}
+            {tI18nHardcoded.raw('autoComponentsProjectsSandboxSnapshotCardJsxTextVCPU15535b27')}
+            &bull; {template.memory_gb}{' '}
+            {tI18nHardcoded.raw('autoComponentsProjectsSandboxSnapshotCardJsxTextGiB9d1e488f')}
+            &bull; {template.disk_gb}{' '}
+            {tI18nHardcoded.raw('autoComponentsProjectsSandboxSnapshotCardJsxTextGiBDiskd395296d')}
+          </div>
         </div>
-      </div>
-      <Badge
-        variant={stateBadge.variant}
-        color={'color' in stateBadge ? stateBadge.color : undefined}
-      >
-        <StateIcon className="size-4 shrink-0" />
-        {stateInfo.label}
-      </Badge>
-      {canManage && (
-        <div className="flex items-center gap-1">
-          {template.template_id && !template.is_default && (
-            <>
+        <Badge
+          variant={stateBadge.variant}
+          color={'color' in stateBadge ? stateBadge.color : undefined}
+        >
+          <StateIcon className="size-4 shrink-0" />
+          {stateInfo.label}
+        </Badge>
+        {canManage && (
+          <div className="flex items-center gap-1">
+            {template.template_id && !template.is_default && (
+              <>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="size-7 p-0"
+                  onClick={() => onEdit(template)}
+                  aria-label={tI18nHardcoded.raw(
+                    'autoComponentsProjectsSandboxSnapshotCardJsxAttrAriaLabelEditdc9d24c2',
+                  )}
+                >
+                  <Edit3 className="size-3.5" />
+                </Button>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="text-destructive hover:text-destructive size-7 p-0"
+                  disabled={deleteMut.isPending}
+                  onClick={() => setConfirmDelete(true)}
+                  aria-label={tI18nHardcoded.raw(
+                    'autoComponentsProjectsSandboxSnapshotCardJsxAttrAriaLabelDeleteda0507cf',
+                  )}
+                >
+                  {deleteMut.isPending ? (
+                    <Loading className="size-3.5 shrink-0" />
+                  ) : (
+                    <Trash2 className="size-3.5 shrink-0" />
+                  )}
+                </Button>
+              </>
+            )}
+            {template.template_id && (
               <Button
                 size="sm"
-                variant="ghost"
-                className="size-7 p-0"
-                onClick={() => onEdit(template)}
-                aria-label={tI18nHardcoded.raw(
-                  'autoComponentsProjectsSandboxSnapshotCardJsxAttrAriaLabelEditdc9d24c2',
-                )}
+                variant="outline"
+                className="gap-1.5"
+                disabled={buildMut.isPending}
+                onClick={() => buildMut.mutate()}
               >
-                <Edit3 className="size-3.5" />
-              </Button>
-              <Button
-                size="sm"
-                variant="ghost"
-                className="text-destructive hover:text-destructive size-7 p-0"
-                disabled={deleteMut.isPending}
-                onClick={() => {
-                  if (window.confirm(`Delete sandbox template "${template.name}"?`)) {
-                    deleteMut.mutate();
-                  }
-                }}
-                aria-label={tI18nHardcoded.raw(
-                  'autoComponentsProjectsSandboxSnapshotCardJsxAttrAriaLabelDeleteda0507cf',
-                )}
-              >
-                {deleteMut.isPending ? (
+                {buildMut.isPending ? (
                   <Loading className="size-3.5 shrink-0" />
                 ) : (
-                  <Trash2 className="size-3.5 shrink-0" />
+                  <RefreshCw className="size-3.5 shrink-0" />
                 )}
+                Rebuild
               </Button>
-            </>
-          )}
-          {template.template_id && (
-            <Button
-              size="sm"
-              variant="outline"
-              className="gap-1.5"
-              disabled={buildMut.isPending}
-              onClick={() => buildMut.mutate()}
-            >
-              {buildMut.isPending ? (
-                <Loading className="size-3.5 shrink-0" />
-              ) : (
-                <RefreshCw className="size-3.5 shrink-0" />
-              )}
-              Rebuild
-            </Button>
-          )}
-        </div>
-      )}
-    </li>
+            )}
+          </div>
+        )}
+      </li>
+      <ConfirmDialog
+        open={confirmDelete}
+        onOpenChange={setConfirmDelete}
+        title={`Delete sandbox template "${template.name}"?`}
+        description="This removes the template from the project. Sessions already using it are unaffected."
+        confirmLabel="Delete"
+        confirmVariant="destructive"
+        isPending={deleteMut.isPending}
+        onConfirm={() => deleteMut.mutate()}
+      />
+    </>
   );
 }
 

--- a/apps/web/src/features/workspace/customize/sections/view/sandbox-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/sandbox-view.tsx
@@ -14,6 +14,7 @@ import { InlineMeta } from '@/components/ui/inline-meta';
 import { Label } from '@/components/ui/label';
 import Loading from '@/components/ui/loading';
 import { Skeleton } from '@/components/ui/skeleton';
+import { errorToast, successToast } from '@/components/ui/toast';
 import { Icon } from '@/features/icon/icon';
 import { EmptyState } from '@/features/layout/section/empty-state';
 import { ErrorState } from '@/features/layout/section/error-state';
@@ -30,7 +31,6 @@ import {
   type SandboxTemplate,
   type SnapshotErrorCategory,
 } from '@kortix/sdk/projects-client';
-import { toast } from '@/lib/toast';
 import { cn } from '@/lib/utils';
 import {
   AlarmClockSolid,
@@ -44,7 +44,6 @@ import {
   Container,
   Edit3,
   FileCode,
-  Loader2,
   Package,
   Plus,
   RefreshCw,
@@ -83,7 +82,6 @@ const BUILD_STATUS_TILE: Record<
     tileBg: string;
     iconColor: string;
     Icon: typeof CheckCircleSolid;
-    spin?: boolean;
   }
 > = {
   ready: {
@@ -99,7 +97,6 @@ const BUILD_STATUS_TILE: Record<
     tileBg: 'bg-kortix-yellow/15',
     iconColor: 'text-kortix-yellow',
     Icon: Loading,
-    spin: true,
   },
   failed: {
     label: 'failed',
@@ -166,7 +163,7 @@ function BuildRow({ build }: { build: ProjectSnapshotBuild }) {
       <span
         className={cn('flex size-9 shrink-0 items-center justify-center rounded-sm', status.tileBg)}
       >
-        <Icon className={cn('size-5', status.iconColor, status.spin && 'animate-spin')} />
+        <Icon className={cn('size-5 shrink-0', status.iconColor)} />
       </span>
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-1.5">
@@ -298,7 +295,7 @@ function LatestFailureBanner({
                     onClick={onFix}
                   >
                     {isFixPending ? (
-                      <Loading className="size-3.5 shrink-0 animate-spin" />
+                      <Loading className="size-3.5 shrink-0" />
                     ) : (
                       <SparklesSolid className="size-3.5 shrink-0" />
                     )}
@@ -353,19 +350,19 @@ function TemplateRow({
   const buildMut = useMutation({
     mutationFn: () => buildSandboxTemplate(projectId, template.template_id!),
     onSuccess: () => {
-      toast.success(`Rebuild started for "${template.name}"`);
+      successToast(`Rebuild started for "${template.name}"`);
       queryClient.invalidateQueries({ queryKey: SNAPSHOTS_QUERY_KEY(projectId) });
     },
-    onError: (err: Error) => toast.error(err.message || 'Failed to start build'),
+    onError: (err: Error) => errorToast(err.message || 'Failed to start build'),
   });
   const deleteMut = useMutation({
     mutationFn: () => deleteSandboxTemplate(projectId, template.template_id!),
     onSuccess: () => {
-      toast.success(`Deleted "${template.name}"`);
+      successToast(`Deleted "${template.name}"`);
       queryClient.invalidateQueries({ queryKey: SNAPSHOTS_QUERY_KEY(projectId) });
       queryClient.invalidateQueries({ queryKey: ['project-sandboxes', projectId] });
     },
-    onError: (err: Error) => toast.error(err.message || 'Failed to delete template'),
+    onError: (err: Error) => errorToast(err.message || 'Failed to delete template'),
   });
 
   const Icon = template.is_default ? Container : template.has_image ? Package : FileCode;
@@ -426,7 +423,7 @@ function TemplateRow({
         variant={stateBadge.variant}
         color={'color' in stateBadge ? stateBadge.color : undefined}
       >
-        <StateIcon className={cn(stateInfo.tone === 'busy' && 'animate-spin', 'size-4')} />
+        <StateIcon className="size-4 shrink-0" />
         {stateInfo.label}
       </Badge>
       {canManage && (
@@ -459,9 +456,9 @@ function TemplateRow({
                 )}
               >
                 {deleteMut.isPending ? (
-                  <Loader2 className="size-3.5 animate-spin" />
+                  <Loading className="size-3.5 shrink-0" />
                 ) : (
-                  <Trash2 className="size-3.5" />
+                  <Trash2 className="size-3.5 shrink-0" />
                 )}
               </Button>
             </>
@@ -475,9 +472,9 @@ function TemplateRow({
               onClick={() => buildMut.mutate()}
             >
               {buildMut.isPending ? (
-                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                <Loading className="size-3.5 shrink-0" />
               ) : (
-                <RefreshCw className="h-3.5 w-3.5" />
+                <RefreshCw className="size-3.5 shrink-0" />
               )}
               Rebuild
             </Button>

--- a/apps/web/src/features/workspace/project-sidebar/modal/rename-session-modal.tsx
+++ b/apps/web/src/features/workspace/project-sidebar/modal/rename-session-modal.tsx
@@ -2,6 +2,7 @@
 
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import Loading from '@/components/ui/loading';
 import {
   Modal,
   ModalBody,
@@ -49,9 +50,9 @@ export function RenameSessionModal({
       if (!sessionId) throw new Error('No session selected');
       return updateProjectSession(projectId, sessionId, { name });
     },
-    onSuccess: () => {
+    onSuccess: (_updated, name) => {
       queryClient.invalidateQueries({ queryKey: ['project-sessions', projectId] });
-      successToast('Session renamed');
+      successToast(name ? `Renamed to "${name}"` : 'Session renamed');
       onSaved?.();
       onOpenChange(false);
     },
@@ -69,7 +70,12 @@ export function RenameSessionModal({
   };
 
   return (
-    <Modal open={open} onOpenChange={onOpenChange}>
+    <Modal
+      open={open}
+      onOpenChange={(o) => {
+        if (!renameMutation.isPending) onOpenChange(o);
+      }}
+    >
       <ModalContent className="lg:max-w-md">
         <ModalHeader>
           <ModalTitle>
@@ -106,6 +112,7 @@ export function RenameSessionModal({
             size="sm"
             className="w-full sm:w-auto"
             onClick={() => onOpenChange(false)}
+            disabled={renameMutation.isPending}
           >
             Cancel
           </Button>
@@ -115,7 +122,8 @@ export function RenameSessionModal({
             onClick={submit}
             disabled={renameMutation.isPending || isUnchanged}
           >
-            {renameMutation.isPending ? 'Saving…' : 'Save'}
+            {renameMutation.isPending ? <Loading className="size-4 shrink-0" /> : null}
+            Save
           </Button>
         </ModalFooter>
       </ModalContent>

--- a/apps/web/src/features/workspace/project-sidebar/modal/session-delete-modal.tsx
+++ b/apps/web/src/features/workspace/project-sidebar/modal/session-delete-modal.tsx
@@ -1,15 +1,6 @@
 'use client';
 
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from '@/components/ui/alert-dialog';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { errorToast, successToast } from '@/components/ui/toast';
 import { deleteProjectSession } from '@kortix/sdk/projects-client';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
@@ -38,7 +29,7 @@ export function SessionDeleteModal({
   const deleteMutation = useMutation({
     mutationFn: (id: string) => deleteProjectSession(projectId, id),
     onSuccess: () => {
-      successToast('Session deleted');
+      successToast(sessionLabel ? `"${sessionLabel}" deleted` : 'Session deleted');
       queryClient.invalidateQueries({ queryKey: ['project-sessions', projectId] });
       onDeleted?.();
       onOpenChange(false);
@@ -54,33 +45,27 @@ export function SessionDeleteModal({
   };
 
   return (
-    <AlertDialog open={open} onOpenChange={onOpenChange}>
-      <AlertDialogContent>
-        <AlertDialogHeader>
-          <AlertDialogTitle>
-            {tHardcodedUi.raw('componentsProjectsProjectSessionList.line189JsxTextDeleteSession')}
-          </AlertDialogTitle>
-          <AlertDialogDescription>
-            {tHardcodedUi.raw(
-              'componentsProjectsProjectSessionList.line191JsxTextThisWillPermanentlyDestroyTheBranchAndSandbox',
-            )}{' '}
-            <span className="text-foreground font-medium">{sessionLabel}</span>
-            {tHardcodedUi.raw(
-              'componentsProjectsProjectSessionList.line193JsxTextThisActionCannotBeUndone',
-            )}
-          </AlertDialogDescription>
-        </AlertDialogHeader>
-        <AlertDialogFooter>
-          <AlertDialogCancel>Cancel</AlertDialogCancel>
-          <AlertDialogAction
-            variant="destructive"
-            onClick={confirmDelete}
-            disabled={deleteMutation.isPending}
-          >
-            Delete
-          </AlertDialogAction>
-        </AlertDialogFooter>
-      </AlertDialogContent>
-    </AlertDialog>
+    <ConfirmDialog
+      open={open}
+      onOpenChange={(o) => {
+        if (!deleteMutation.isPending) onOpenChange(o);
+      }}
+      title={tHardcodedUi.raw('componentsProjectsProjectSessionList.line189JsxTextDeleteSession')}
+      description={
+        <>
+          {tHardcodedUi.raw(
+            'componentsProjectsProjectSessionList.line191JsxTextThisWillPermanentlyDestroyTheBranchAndSandbox',
+          )}{' '}
+          <span className="text-foreground font-medium">{sessionLabel}</span>
+          {tHardcodedUi.raw(
+            'componentsProjectsProjectSessionList.line193JsxTextThisActionCannotBeUndone',
+          )}
+        </>
+      }
+      confirmLabel="Delete"
+      confirmVariant="destructive"
+      isPending={deleteMutation.isPending}
+      onConfirm={confirmDelete}
+    />
   );
 }

--- a/apps/web/src/features/workspace/project-sidebar/project-session-list-helpers.test.ts
+++ b/apps/web/src/features/workspace/project-sidebar/project-session-list-helpers.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  getSessionDisplayTitle,
+  resolveSessionListViewState,
+  shortRelative,
+  shouldPollProjectSessions,
+  sortSessionsByCreatedAt,
+} from './project-session-list-helpers';
+import type { ProjectSession } from '@kortix/sdk/projects-client';
+
+function makeSession(overrides: Partial<ProjectSession> = {}): ProjectSession {
+  return {
+    session_id: 's1',
+    project_id: 'p1',
+    status: 'running',
+    created_at: '2026-01-01T00:00:00.000Z',
+    custom_name: null,
+    name: null,
+    branch_name: null,
+    metadata: null,
+    ...overrides,
+  } as unknown as ProjectSession;
+}
+
+describe('shouldPollProjectSessions', () => {
+  test('polls when a session is queued', () => {
+    expect(shouldPollProjectSessions([makeSession({ status: 'queued' })])).toBe(true);
+  });
+
+  test('polls when a session is branching', () => {
+    expect(shouldPollProjectSessions([makeSession({ status: 'branching' })])).toBe(true);
+  });
+
+  test('polls when a session is provisioning', () => {
+    expect(shouldPollProjectSessions([makeSession({ status: 'provisioning' })])).toBe(true);
+  });
+
+  test('does not poll when every session has settled', () => {
+    const sessions = [
+      makeSession({ status: 'running' }),
+      makeSession({ status: 'stopped' }),
+      makeSession({ status: 'completed' }),
+    ];
+    expect(shouldPollProjectSessions(sessions)).toBe(false);
+  });
+
+  test('does not poll an empty or undefined list', () => {
+    expect(shouldPollProjectSessions([])).toBe(false);
+    expect(shouldPollProjectSessions(undefined)).toBe(false);
+  });
+});
+
+describe('sortSessionsByCreatedAt', () => {
+  test('orders sessions newest-first', () => {
+    const oldest = makeSession({ session_id: 'a', created_at: '2026-01-01T00:00:00.000Z' });
+    const middle = makeSession({ session_id: 'b', created_at: '2026-01-02T00:00:00.000Z' });
+    const newest = makeSession({ session_id: 'c', created_at: '2026-01-03T00:00:00.000Z' });
+
+    const result = sortSessionsByCreatedAt([oldest, newest, middle]);
+
+    expect(result.map((s) => s.session_id)).toEqual(['c', 'b', 'a']);
+  });
+
+  test('does not mutate the input array', () => {
+    const input = [
+      makeSession({ session_id: 'a', created_at: '2026-01-01T00:00:00.000Z' }),
+      makeSession({ session_id: 'b', created_at: '2026-01-02T00:00:00.000Z' }),
+    ];
+    const inputCopy = [...input];
+
+    sortSessionsByCreatedAt(input);
+
+    expect(input).toEqual(inputCopy);
+  });
+
+  test('an empty list sorts to an empty list', () => {
+    expect(sortSessionsByCreatedAt([])).toEqual([]);
+  });
+});
+
+describe('getSessionDisplayTitle', () => {
+  test('a user rename (custom_name) wins over everything else', () => {
+    const session = makeSession({
+      custom_name: 'My renamed session',
+      name: 'server-name',
+      branch_name: 'feature/branch-name',
+    });
+    expect(getSessionDisplayTitle(session)).toBe('My renamed session');
+  });
+
+  test('falls back to the server name when there is no custom name', () => {
+    const session = makeSession({ name: 'server-name', branch_name: 'feature/branch-name' });
+    expect(getSessionDisplayTitle(session)).toBe('server-name');
+  });
+
+  test('falls back to legacy metadata.session_name next', () => {
+    const session = makeSession({
+      metadata: { session_name: 'legacy-name' },
+      branch_name: 'feature/branch-name',
+    });
+    expect(getSessionDisplayTitle(session)).toBe('legacy-name');
+  });
+
+  test('falls back to a 14-char slice of the branch name', () => {
+    const session = makeSession({ branch_name: 'feature/a-very-long-branch-name' });
+    expect(getSessionDisplayTitle(session)).toBe('feature/a-very');
+  });
+
+  test('falls back to the literal "session" when nothing is available', () => {
+    expect(getSessionDisplayTitle(makeSession())).toBe('session');
+  });
+
+  test('blank/whitespace-only names are treated as absent', () => {
+    const session = makeSession({ custom_name: '   ', name: 'server-name' });
+    expect(getSessionDisplayTitle(session)).toBe('server-name');
+  });
+});
+
+describe('shortRelative', () => {
+  test('collapses "less than a minute" to "now"', () => {
+    expect(shortRelative('less than a minute')).toBe('now');
+  });
+
+  test('collapses "0 seconds" to "now"', () => {
+    expect(shortRelative('0 seconds')).toBe('now');
+  });
+
+  test('compresses each unit to its single-letter suffix', () => {
+    expect(shortRelative('5 seconds')).toBe('5s');
+    expect(shortRelative('5 minutes')).toBe('5m');
+    expect(shortRelative('5 hours')).toBe('5h');
+    expect(shortRelative('5 days')).toBe('5d');
+    expect(shortRelative('5 months')).toBe('5mo');
+    expect(shortRelative('5 years')).toBe('5y');
+  });
+
+  test('handles the singular form (no trailing "s")', () => {
+    expect(shortRelative('1 minute')).toBe('1m');
+  });
+
+  test('passes unrecognized input through unchanged', () => {
+    expect(shortRelative('a while ago')).toBe('a while ago');
+  });
+});
+
+describe('resolveSessionListViewState', () => {
+  test('loading wins regardless of error or counts', () => {
+    const state = resolveSessionListViewState({
+      isLoading: true,
+      isError: true,
+      totalCount: 5,
+      visibleCount: 5,
+    });
+    expect(state).toBe('loading');
+  });
+
+  test('error wins over empty/no-matches once loading has settled', () => {
+    const state = resolveSessionListViewState({
+      isLoading: false,
+      isError: true,
+      totalCount: 0,
+      visibleCount: 0,
+    });
+    expect(state).toBe('error');
+  });
+
+  test('no sessions at all is "empty"', () => {
+    const state = resolveSessionListViewState({
+      isLoading: false,
+      isError: false,
+      totalCount: 0,
+      visibleCount: 0,
+    });
+    expect(state).toBe('empty');
+  });
+
+  test('sessions exist but the active filter matches none: "no-matches"', () => {
+    const state = resolveSessionListViewState({
+      isLoading: false,
+      isError: false,
+      totalCount: 3,
+      visibleCount: 0,
+    });
+    expect(state).toBe('no-matches');
+  });
+
+  test('sessions exist and the filter matches some: "content"', () => {
+    const state = resolveSessionListViewState({
+      isLoading: false,
+      isError: false,
+      totalCount: 3,
+      visibleCount: 2,
+    });
+    expect(state).toBe('content');
+  });
+});

--- a/apps/web/src/features/workspace/project-sidebar/project-session-list-helpers.ts
+++ b/apps/web/src/features/workspace/project-sidebar/project-session-list-helpers.ts
@@ -1,0 +1,90 @@
+import type { ProjectSession, ProjectSessionStatus } from '@kortix/sdk/projects-client';
+
+/**
+ * Pure helpers extracted from `project-session-list.tsx` so the sidebar's
+ * sort/poll/label/time-formatting decisions and its loading/error/empty/
+ * content state selection are unit-testable without mounting react-query or
+ * the row components.
+ */
+
+export const LIVE_SESSION_STATUSES: ProjectSessionStatus[] = [
+  'queued',
+  'branching',
+  'provisioning',
+];
+
+/** Whether the session list should keep polling — true while any session is
+ *  still mid-provisioning (queued/branching/provisioning). */
+export function shouldPollProjectSessions(sessions: ProjectSession[] | undefined): boolean {
+  return (sessions ?? []).some((session) => LIVE_SESSION_STATUSES.includes(session.status));
+}
+
+/** Newest-first sort by `created_at`. Extracted so the ordering rule (and its
+ *  stability for equal timestamps) is independently testable. */
+export function sortSessionsByCreatedAt(sessions: ProjectSession[]): ProjectSession[] {
+  return sessions
+    .slice()
+    .sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime());
+}
+
+/**
+ * Display title for a session row. Precedence: user rename (custom_name) →
+ * server name → legacy metadata.session_name → a slice of the branch name →
+ * the literal "session" fallback when nothing else is available.
+ */
+export function getSessionDisplayTitle(session: ProjectSession): string {
+  const legacyMetadataName =
+    typeof session.metadata?.session_name === 'string'
+      ? (session.metadata.session_name as string)
+      : null;
+  const titleCandidate =
+    session.custom_name?.trim() || session.name?.trim() || legacyMetadataName?.trim();
+
+  if (titleCandidate) return titleCandidate;
+  return session.branch_name ? session.branch_name.slice(0, 14) : 'session';
+}
+
+/** Compresses date-fns' `formatDistanceToNowStrict` output ("5 minutes") down
+ *  to the sidebar's fixed-width form ("5m") so the relative-time column never
+ *  reflows the row. "0 seconds" and "less than a minute" both collapse to
+ *  "now". Unrecognized input (a future date-fns phrasing change, or a locale
+ *  string) is passed through unchanged rather than dropped. */
+export function shortRelative(input: string): string {
+  if (input === 'less than a minute') return 'now';
+  const match = input.match(/^(\d+)\s+(second|minute|hour|day|month|year)s?$/);
+  if (!match) return input;
+  if (match[1] === '0' && match[2] === 'second') return 'now';
+  const [, n, unit] = match;
+  const suffix =
+    unit === 'second'
+      ? 's'
+      : unit === 'minute'
+        ? 'm'
+        : unit === 'hour'
+          ? 'h'
+          : unit === 'day'
+            ? 'd'
+            : unit === 'month'
+              ? 'mo'
+              : 'y';
+  return `${n}${suffix}`;
+}
+
+/** Which of the sidebar's mutually-exclusive render states applies. Mirrors
+ *  the early-return ladder in `ProjectSessionList`: loading and error both
+ *  win outright (independent of data), then "no sessions at all" wins over
+ *  "sessions exist but none match the active filter". */
+export type SessionListViewState = 'loading' | 'error' | 'empty' | 'no-matches' | 'content';
+
+export function resolveSessionListViewState(params: {
+  isLoading: boolean;
+  isError: boolean;
+  totalCount: number;
+  visibleCount: number;
+}): SessionListViewState {
+  if (params.isLoading) return 'loading';
+  if (params.isError) return 'error';
+  if (params.totalCount === 0) return 'empty';
+  if (params.visibleCount === 0) return 'no-matches';
+  return 'content';
+}

--- a/apps/web/src/features/workspace/project-sidebar/project-session-list.tsx
+++ b/apps/web/src/features/workspace/project-sidebar/project-session-list.tsx
@@ -24,6 +24,13 @@ import { errorToast, successToast } from '@/components/ui/toast';
 import { RenameSessionModal } from '@/features/workspace/project-sidebar/modal/rename-session-modal';
 import { SessionDeleteModal } from '@/features/workspace/project-sidebar/modal/session-delete-modal';
 import { ShareSessionModal } from '@/features/workspace/project-sidebar/modal/share-session-modal';
+import {
+  getSessionDisplayTitle,
+  resolveSessionListViewState,
+  shortRelative,
+  shouldPollProjectSessions,
+  sortSessionsByCreatedAt,
+} from '@/features/workspace/project-sidebar/project-session-list-helpers';
 import { Icon } from '@/features/icon/icon';
 import {
   listProjectSessions,
@@ -55,8 +62,6 @@ interface ProjectSessionListProps {
   filter?: SessionFilterValue;
 }
 
-const LIVE_SESSION_STATUSES: ProjectSessionStatus[] = ['queued', 'branching', 'provisioning'];
-
 const SESSION_RELATIVE_TIME_CLASS =
   'text-muted-foreground/60 block w-10 min-w-10 max-w-10 shrink-0 truncate text-right text-xs tabular-nums';
 
@@ -70,10 +75,6 @@ const SOURCE_ICONS: Record<
   schedule: CalendarClock,
   webhook: Webhook,
 };
-
-function shouldPollProjectSessions(sessions: ProjectSession[] | undefined): boolean {
-  return (sessions ?? []).some((session) => LIVE_SESSION_STATUSES.includes(session.status));
-}
 
 // Staggered (unique) widths so the loading state reads as a list of rows, not a
 // block; the width doubles as a stable key.
@@ -107,7 +108,7 @@ export function ProjectSessionList({ projectId, filter = 'all' }: ProjectSession
   const [sessionToShare, setSessionToShare] = useState<ProjectSession | null>(null);
   const [sessionToRename, setSessionToRename] = useState<{ id: string; name: string } | null>(null);
 
-  const { data, isLoading, error } = useQuery({
+  const { data, isLoading, isError, error, refetch } = useQuery({
     queryKey: ['project-sessions', projectId],
     queryFn: () => listProjectSessions(projectId),
     staleTime: 10_000,
@@ -117,9 +118,10 @@ export function ProjectSessionList({ projectId, filter = 'all' }: ProjectSession
   });
 
   const restartMutation = useMutation({
-    mutationFn: (sessionId: string) => restartProjectSession(projectId, sessionId),
-    onSuccess: () => {
-      successToast('Restarting session…');
+    mutationFn: ({ sessionId }: { sessionId: string; label: string }) =>
+      restartProjectSession(projectId, sessionId),
+    onSuccess: (_data, { label }) => {
+      successToast(`Restarting "${label}"…`);
       queryClient.invalidateQueries({ queryKey: ['project-sessions', projectId] });
     },
     onError: (err) => {
@@ -128,9 +130,10 @@ export function ProjectSessionList({ projectId, filter = 'all' }: ProjectSession
   });
 
   const stopMutation = useMutation({
-    mutationFn: (sessionId: string) => stopProjectSession(projectId, sessionId),
-    onSuccess: () => {
-      successToast('Session stopped');
+    mutationFn: ({ sessionId }: { sessionId: string; label: string }) =>
+      stopProjectSession(projectId, sessionId),
+    onSuccess: (_data, { label }) => {
+      successToast(`"${label}" stopped`);
       queryClient.invalidateQueries({ queryKey: ['project-sessions', projectId] });
     },
     onError: (err) => {
@@ -138,25 +141,44 @@ export function ProjectSessionList({ projectId, filter = 'all' }: ProjectSession
     },
   });
 
-  if (isLoading) {
+  const sessions = sortSessionsByCreatedAt(data ?? []);
+  // Filtering itself lives in the SESSIONS header dropdown (project-sidebar);
+  // this list only applies the chosen filter.
+  const visibleSessions = sessions.filter((session) => matchesSessionFilter(session, filter));
+
+  const viewState = resolveSessionListViewState({
+    isLoading,
+    isError,
+    totalCount: sessions.length,
+    visibleCount: visibleSessions.length,
+  });
+
+  if (viewState === 'loading') {
     return <ProjectSessionListSkeleton />;
   }
 
-  if (error) {
+  if (viewState === 'error') {
+    const message = error instanceof Error ? error.message : undefined;
     return (
-      <div className="text-destructive/80 px-2 py-2 text-xs">
-        {tHardcodedUi.raw(
-          'componentsProjectsProjectSessionList.line120JsxTextFailedToLoadSessions',
+      <div className="space-y-1.5 px-2 py-2">
+        <p className="text-destructive/80 text-xs">
+          {tHardcodedUi.raw(
+            'componentsProjectsProjectSessionList.line120JsxTextFailedToLoadSessions',
+          )}
+        </p>
+        {message && (
+          <p className="text-muted-foreground/70 truncate text-xs" title={message}>
+            {message}
+          </p>
         )}
+        <Button variant="outline" size="sm" className="h-6 px-2 text-xs" onClick={() => refetch()}>
+          Retry
+        </Button>
       </div>
     );
   }
 
-  const sessions = (data ?? [])
-    .slice()
-    .sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime());
-
-  if (sessions.length === 0) {
+  if (viewState === 'empty') {
     return (
       <div className="text-muted-foreground/60 px-2 pt-1 pb-2 text-xs">
         {tHardcodedUi.raw('componentsProjectsProjectSessionList.line132JsxTextNoSessionsYet')}
@@ -164,11 +186,7 @@ export function ProjectSessionList({ projectId, filter = 'all' }: ProjectSession
     );
   }
 
-  // Filtering itself lives in the SESSIONS header dropdown (project-sidebar);
-  // this list only applies the chosen filter.
-  const visibleSessions = sessions.filter((session) => matchesSessionFilter(session, filter));
-
-  if (visibleSessions.length === 0) {
+  if (viewState === 'no-matches') {
     return (
       <div className="text-muted-foreground/60 px-2 pt-1 pb-2 text-xs">
         {tI18nHardcoded.raw('autoFeaturesCoWorkerProjectSidebarProjectSessionListJsxText1fba7ca0')}
@@ -194,13 +212,14 @@ export function ProjectSessionList({ projectId, filter = 'all' }: ProjectSession
                 onDelete={(id, label) => setSessionToDelete({ id, label })}
                 onShare={(s) => setSessionToShare(s)}
                 onRename={(id, name) => setSessionToRename({ id, name })}
-                onRestart={(id) => restartMutation.mutate(id)}
+                onRestart={(id, label) => restartMutation.mutate({ sessionId: id, label })}
                 isRestarting={
-                  restartMutation.isPending && restartMutation.variables === session.session_id
+                  restartMutation.isPending &&
+                  restartMutation.variables?.sessionId === session.session_id
                 }
-                onStop={(id) => stopMutation.mutate(id)}
+                onStop={(id, label) => stopMutation.mutate({ sessionId: id, label })}
                 isStopping={
-                  stopMutation.isPending && stopMutation.variables === session.session_id
+                  stopMutation.isPending && stopMutation.variables?.sessionId === session.session_id
                 }
               />
               {children.length > 0 && isActive && (
@@ -260,9 +279,9 @@ interface ProjectSessionRowProps {
   onDelete: (sessionId: string, label: string) => void;
   onShare: (session: ProjectSession) => void;
   onRename: (sessionId: string, currentName: string) => void;
-  onRestart: (sessionId: string) => void;
+  onRestart: (sessionId: string, label: string) => void;
   isRestarting: boolean;
-  onStop: (sessionId: string) => void;
+  onStop: (sessionId: string, label: string) => void;
   isStopping: boolean;
   childCount?: number;
 }
@@ -313,7 +332,10 @@ function ProjectSessionRow({
         <Link href={href} className="flex min-w-0 flex-1 items-center gap-2 self-stretch">
           <SessionStatusDot status={session.status} />
 
-          <span className={cn('min-w-0 flex-1 truncate text-sm', isActive && 'font-medium')}>
+          <span
+            title={displayTitle}
+            className={cn('min-w-0 flex-1 truncate text-sm', isActive && 'font-medium')}
+          >
             {displayTitle}
           </span>
 
@@ -400,18 +422,18 @@ function ProjectSessionRow({
                 <DropdownMenuItem
                   className="cursor-pointer"
                   disabled={isRestarting}
-                  onSelect={() => deferAfterClose(() => onRestart(session.session_id))}
+                  onSelect={() => deferAfterClose(() => onRestart(session.session_id, displayTitle))}
                 >
-                  {isRestarting ? <Loading /> : <RotateCcw />}
+                  {isRestarting ? <Loading className="size-4 shrink-0" /> : <RotateCcw />}
                   Restart
                 </DropdownMenuItem>
                 {session.status === 'running' && session.can_manage_sharing !== false && (
                   <DropdownMenuItem
                     className="cursor-pointer"
                     disabled={isStopping}
-                    onSelect={() => deferAfterClose(() => onStop(session.session_id))}
+                    onSelect={() => deferAfterClose(() => onStop(session.session_id, displayTitle))}
                   >
-                    {isStopping ? <Loading /> : <Square />}
+                    {isStopping ? <Loading className="size-4 shrink-0" /> : <Square />}
                     Stop
                   </DropdownMenuItem>
                 )}
@@ -456,7 +478,9 @@ function ProjectSubsessionRow({
         )}
       >
         <span className="bg-muted-foreground/40 h-1 w-1 shrink-0 rounded-full" />
-        <span className={cn('flex-1 truncate', isActive && 'font-medium')}>{title}</span>
+        <span title={title} className={cn('flex-1 truncate', isActive && 'font-medium')}>
+          {title}
+        </span>
         {relative && <span className={SESSION_RELATIVE_TIME_CLASS}>{relative}</span>}
       </div>
     </Link>
@@ -506,37 +530,4 @@ function SessionStatusDot({ status }: { status: ProjectSessionStatus }) {
       </div>
     </Hint>
   );
-}
-
-function getSessionDisplayTitle(session: ProjectSession): string {
-  const legacyMetadataName =
-    typeof session.metadata?.session_name === 'string'
-      ? (session.metadata.session_name as string)
-      : null;
-  const titleCandidate =
-    session.custom_name?.trim() || session.name?.trim() || legacyMetadataName?.trim();
-
-  if (titleCandidate) return titleCandidate;
-  return session.branch_name ? session.branch_name.slice(0, 14) : 'session';
-}
-
-function shortRelative(input: string): string {
-  if (input === 'less than a minute') return 'now';
-  const match = input.match(/^(\d+)\s+(second|minute|hour|day|month|year)s?$/);
-  if (!match) return input;
-  if (match[1] === '0' && match[2] === 'second') return 'now';
-  const [, n, unit] = match;
-  const suffix =
-    unit === 'second'
-      ? 's'
-      : unit === 'minute'
-        ? 'm'
-        : unit === 'hour'
-          ? 'h'
-          : unit === 'day'
-            ? 'd'
-            : unit === 'month'
-              ? 'mo'
-              : 'y';
-  return `${n}${suffix}`;
 }


### PR DESCRIPTION
Six parallel workstreams of UX + functionality improvements across the app, integrated into one branch (24 commits, 35 files, all `apps/web/src`). Each stream kept a disjoint file set — zero merge conflicts — and every stream ships its logic as tested pure helpers.

## 1. Marketplace — install flow (`add-to-project-modal`, new `marketplace-install.ts`)
- Install button: `Loading` pending state, double-submit impossible, Enter submits, modal can't be dismissed mid-install.
- Success toast now says what landed (title + file count) with a **"View in project"** action deep-linking to Customize → Marketplace; errors surface the real server message.
- Capabilities preview (secrets/connectors/tools) as tinted tiles + badges; **"Already installed"** detection with Reinstall relabel (reuses the existing installed-items query cache).

## 2. Marketplace — item detail & cards (new `marketplace-item-view.ts`)
- Type-aware copy everywhere (an agent/command/bundle no longer reads as a "skill").
- Bundles get a **"What's inside"** member list (public + in-app detail); capabilities as labeled Badge rows — including `network`, which existed in the data model but was silently dropped in every view.
- File list on detail (monospace, capped height); public detail gets a type meta line + **sign-in CTA** (`/auth?redirect=…`, same contract as CLI/Slack flows); card a11y/polish (`title` attrs, specific aria-labels, `tabular-nums`).

## 3. Marketplace — installed panel (new `installed-client.ts`)
- Full status story: Up to date / Update available / Source removed badges.
- **Update all** — activates the previously-unused `useUpdateAllMarketplaceItems` hook; remove is now gated by `ConfirmDialog` with exact file-count consequences (was a bare click); error state with retry; search filter appears past 5 items.

## 4. Review Center — approvals are now actionable (new `review-actions.ts`)
- **Approve/Deny work directly from the inbox** — wired to the same `resolveApproval` SDK call the session view uses (`exec:`-id contract verified), inline on rows and in the detail modal, with per-item pending state and list refresh. Bulk select routes `exec:` ids individually (the native bulk endpoint no-ops on them) and respects the "safe-only" risk floor for approve.
- Removed the one-click CR **ship** from the inbox/keyboard — merging now always goes through the detail modal where the diff lives ("Review" label on CR rows).
- Error state with retry (an error was previously indistinguishable from an empty inbox), manual refresh affordance, session names on ungrouped rows.

## 5. Customize panel — design-system compliance sweep (10 files)
- Migrated every banned primitive in the panel: `Dialog`→`Modal` (members-view, connectors-view), `SectionCard`→hand-composed panels, `@/lib/toast`→canonical toast helpers, `Loader2`/hand-rolled spinners→`Loading`, `Tooltip`→`Hint`, raw amber/emerald palette→`kortix-*` tokens, `window.confirm`→`ConfirmDialog` (sandbox template delete), `animate-pulse` placeholders→`Skeleton` (gateway logs).
- Behavior-preserving: zero banned references remain in any touched file (grep-verified); all migrated files parse clean.

## 6. Projects & sessions — state matrix + destructive-action safety (new `project-session-list-helpers.ts`)
- **Project Archive and session Delete are now confirm-gated** (`ConfirmDialog` with the entity named; Archive previously fired on a single dropdown click with no confirmation at all).
- Projects page: canonical `ErrorState`, removed banned `SectionCard` wrappers, "all accounts" view no longer swallows fetch errors (banner + retry).
- Session sidebar: dead-end error line → retry-able error state; action toasts name the session; rename modals get `Loading` + close-guard while pending.

## Verification
- **115 runnable pure-logic tests pass** across 5 new test files + the existing review-center suite (57/57). One test file (`marketplace-item-view.test.ts`) only fails locally for the known environmental reason (no `node_modules` → `react/jsx-dev-runtime`); it runs in CI.
- Every stream's riskiest claims were independently re-verified against the code (SDK exports, route shapes, id contracts, component APIs, banned-primitive greps, parse checks).
- No changes to `apps/api`, packages, dependencies, or the files owned by open PRs #4318/#4322.

> Left unmerged for your review + testing. CI (Frontend build = the real typecheck, unit tests) runs on this PR; Vercel preview available for click-through.