### PR TITLE
feat(iam): groups + custom roles available on every tier

### DIFF
--- a/apps/api/src/__tests__/unit-tier-entitlements.test.ts
+++ b/apps/api/src/__tests__/unit-tier-entitlements.test.ts
@@ -7,10 +7,13 @@ import {
 } from '../billing/services/tiers';
 
 // Locks in the plan-gating contract for the enterprise surfaces (SAML SSO,
-// SCIM, custom RBAC, audit access). Only the sales-assigned `enterprise` tier
-// unlocks them; every self-serve / legacy tier is fully gated. The IAM route
-// guard (requireEntitlement) and the /scim/v2 data-plane middleware both key
-// off tierHasEntitlement, so these invariants ARE the access-control policy.
+// SCIM, audit access). Only the sales-assigned `enterprise` tier unlocks
+// those; every self-serve / legacy tier is gated. Groups + custom roles
+// (`rbac`) are deliberately EXEMPT — they're the platform's core
+// collaboration model and available on every tier (un-gated 2026-07-08).
+// The IAM route guard (requireEntitlement) and the /scim/v2 data-plane
+// middleware both key off tierHasEntitlement, so these invariants ARE the
+// access-control policy.
 describe('tier entitlements (enterprise gating)', () => {
   test('enterprise tier unlocks SSO + SCIM + RBAC + audit access', () => {
     expect(tierHasEntitlement('enterprise', 'sso')).toBe(true);
@@ -19,7 +22,7 @@ describe('tier entitlements (enterprise gating)', () => {
     expect(tierHasEntitlement('enterprise', 'auditAccess')).toBe(true);
   });
 
-  test('every non-enterprise tier is fully gated', () => {
+  test('every non-enterprise tier: identity + audit gated, groups/roles (rbac) open', () => {
     for (const t of [
       'none',
       'free',
@@ -36,18 +39,18 @@ describe('tier entitlements (enterprise gating)', () => {
     ]) {
       expect(tierHasEntitlement(t, 'sso')).toBe(false);
       expect(tierHasEntitlement(t, 'scim')).toBe(false);
-      expect(tierHasEntitlement(t, 'rbac')).toBe(false);
+      expect(tierHasEntitlement(t, 'rbac')).toBe(true);
       expect(tierHasEntitlement(t, 'auditAccess')).toBe(false);
     }
   });
 
-  test('unknown tier names fail closed (default tier = none, no entitlements)', () => {
+  test('unknown tier names fail closed on identity/audit; rbac stays universally open', () => {
     expect(tierHasEntitlement('does-not-exist', 'sso')).toBe(false);
     expect(tierHasEntitlement('does-not-exist', 'scim')).toBe(false);
     expect(getTierEntitlements('does-not-exist')).toEqual({
       sso: false,
       scim: false,
-      rbac: false,
+      rbac: true,
       auditAccess: false,
     });
   });

--- a/apps/api/src/accounts/iam.ts
+++ b/apps/api/src/accounts/iam.ts
@@ -12,7 +12,8 @@
 // Custom roles + policies were REBUILT from scratch in Phase 3 of
 // feat/iam-rbac-v1 (June 2026, ./iam/custom-roles.ts): DB-backed custom
 // roles (iam_roles / iam_role_actions) and role bindings (iam_policies) are
-// live, Enterprise-entitlement-gated ('rbac'), and read by the V2 engine
+// live, available on every tier (the 'rbac' entitlement is granted to all
+// plans since 2026-07-08), and read by the V2 engine
 // (../iam/engine-v2.ts), which unions their granted actions additively on
 // top of the fixed built-in preset roles. These tables are NOT dead.
 //

--- a/apps/api/src/billing/services/tiers.ts
+++ b/apps/api/src/billing/services/tiers.ts
@@ -151,10 +151,14 @@ export function getComputeDescription(serverType: string): string {
 
 // ─── Tiers ──────────────────────────────────────────────────────────────────
 
-// Enterprise feature gates. Every self-serve tier (Free / Team) gets NONE;
-// the sales-assigned `enterprise` tier gets ALL. See TierEntitlements in
-// ../../types and the requireEntitlement() guard in the IAM routes.
-const NO_ENTERPRISE: TierEntitlements = { sso: false, scim: false, rbac: false, auditAccess: false };
+// Enterprise feature gates. Groups + custom roles/policies (`rbac`) are
+// available on EVERY tier — they're the platform's core collaboration and
+// access model, not an upsell (un-gated 2026-07-08; they were briefly
+// enterprise-gated by #4135). The enterprise identity surface (SAML SSO +
+// SCIM) and audit access remain exclusive to the sales-assigned `enterprise`
+// tier. See TierEntitlements in ../../types and the requireEntitlement()
+// guard in the IAM routes, which keys off this matrix.
+const SELF_SERVE: TierEntitlements = { sso: false, scim: false, rbac: true, auditAccess: false };
 const ALL_ENTERPRISE: TierEntitlements = { sso: true, scim: true, rbac: true, auditAccess: true };
 
 const TIERS: Record<string, TierConfig> = {
@@ -169,7 +173,7 @@ const TIERS: Record<string, TierConfig> = {
     dailyCreditConfig: null,
     hidden: true,
     concurrentSessionLimit: 50,
-    entitlements: NO_ENTERPRISE,
+    entitlements: SELF_SERVE,
   },
 
   free: {
@@ -183,7 +187,7 @@ const TIERS: Record<string, TierConfig> = {
     dailyCreditConfig: null,
     hidden: false,
     concurrentSessionLimit: 50,
-    entitlements: NO_ENTERPRISE,
+    entitlements: SELF_SERVE,
   },
 
   pro: {
@@ -197,7 +201,7 @@ const TIERS: Record<string, TierConfig> = {
     dailyCreditConfig: null,
     hidden: false,
     concurrentSessionLimit: 200,
-    entitlements: NO_ENTERPRISE,
+    entitlements: SELF_SERVE,
   },
 
   // Billing v2 — per-member seat plan. $25 × seat_count / month.
@@ -214,7 +218,7 @@ const TIERS: Record<string, TierConfig> = {
     dailyCreditConfig: null,
     hidden: false,
     concurrentSessionLimit: 200,
-    entitlements: NO_ENTERPRISE,
+    entitlements: SELF_SERVE,
   },
 
   // ── Enterprise (sales-assigned, not self-serve) ──────────────────────────
@@ -252,7 +256,7 @@ const TIERS: Record<string, TierConfig> = {
     dailyCreditConfig: null,
     hidden: true,
     concurrentSessionLimit: 200,
-    entitlements: NO_ENTERPRISE,
+    entitlements: SELF_SERVE,
   },
   tier_6_50: {
     name: 'tier_6_50',
@@ -265,7 +269,7 @@ const TIERS: Record<string, TierConfig> = {
     dailyCreditConfig: null,
     hidden: true,
     concurrentSessionLimit: 300,
-    entitlements: NO_ENTERPRISE,
+    entitlements: SELF_SERVE,
   },
   tier_12_100: {
     name: 'tier_12_100',
@@ -278,7 +282,7 @@ const TIERS: Record<string, TierConfig> = {
     dailyCreditConfig: null,
     hidden: true,
     concurrentSessionLimit: 400,
-    entitlements: NO_ENTERPRISE,
+    entitlements: SELF_SERVE,
   },
   tier_25_200: {
     name: 'tier_25_200',
@@ -291,7 +295,7 @@ const TIERS: Record<string, TierConfig> = {
     dailyCreditConfig: null,
     hidden: true,
     concurrentSessionLimit: 500,
-    entitlements: NO_ENTERPRISE,
+    entitlements: SELF_SERVE,
   },
   tier_50_400: {
     name: 'tier_50_400',
@@ -304,7 +308,7 @@ const TIERS: Record<string, TierConfig> = {
     dailyCreditConfig: null,
     hidden: true,
     concurrentSessionLimit: 750,
-    entitlements: NO_ENTERPRISE,
+    entitlements: SELF_SERVE,
   },
   tier_125_800: {
     name: 'tier_125_800',
@@ -317,7 +321,7 @@ const TIERS: Record<string, TierConfig> = {
     dailyCreditConfig: null,
     hidden: true,
     concurrentSessionLimit: 1000,
-    entitlements: NO_ENTERPRISE,
+    entitlements: SELF_SERVE,
   },
   tier_200_1000: {
     name: 'tier_200_1000',
@@ -330,7 +334,7 @@ const TIERS: Record<string, TierConfig> = {
     dailyCreditConfig: null,
     hidden: true,
     concurrentSessionLimit: 1500,
-    entitlements: NO_ENTERPRISE,
+    entitlements: SELF_SERVE,
   },
   tier_150_1200: {
     name: 'tier_150_1200',
@@ -343,7 +347,7 @@ const TIERS: Record<string, TierConfig> = {
     dailyCreditConfig: null,
     hidden: true,
     concurrentSessionLimit: 2000,
-    entitlements: NO_ENTERPRISE,
+    entitlements: SELF_SERVE,
   },
 };
 

--- a/apps/api/src/projects/routes/r7.ts
+++ b/apps/api/src/projects/routes/r7.ts
@@ -174,9 +174,11 @@ projectsApp.openapi(
   // threaded and the agent-grant fold fires: an agent-session token must also
   // hold project.members.manage to mutate group grants, not just its user.
   await assertProjectCapability(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_MEMBERS_MANAGE);
-  // Group→project grants are part of the Enterprise RBAC surface (groups are
-  // gated in accounts/iam/groups.ts); gate the mutation here too so grants
-  // can't be minted through the project-scoped path.
+  // Entitlement mirror of accounts/iam/groups.ts so grants can't be minted
+  // through the project-scoped path when the account-scoped one is gated.
+  // Dormant since 2026-07-08: `rbac` is granted on every tier (groups + roles
+  // are core collaboration, not an upsell) — it only bites again if the
+  // packaging in tiers.ts changes.
   {
     const denied = await requireEntitlement(c, loaded.row.accountId, 'rbac');
     if (denied) return denied;
@@ -261,9 +263,9 @@ projectsApp.openapi(
   // threaded and the agent-grant fold fires: an agent-session token must also
   // hold project.members.manage to mutate group grants, not just its user.
   await assertProjectCapability(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_MEMBERS_MANAGE);
-  // Enterprise RBAC gate — same reasoning as the POST above. DELETE below is
-  // deliberately ungated: revoking access is never paywalled, so a downgraded
-  // account can always detach grants it can no longer manage.
+  // Same dormant entitlement mirror as the POST above (rbac is on every
+  // tier). DELETE below carries no gate at all: revoking access is never
+  // paywalled, so an account can always detach grants it can't manage.
   {
     const denied = await requireEntitlement(c, loaded.row.accountId, 'rbac');
     if (denied) return denied;


### PR DESCRIPTION
Un-gates **Groups and custom Roles/Policies** from the Enterprise plan — they're available on **every tier** now. **SAML SSO, SCIM, and audit access stay Enterprise-only.**

## Why
PR #4135 (IAM/RBAC v1 finalization, 2026-07-05) bundled Groups/Roles/Policies into the Enterprise plan alongside SSO/SCIM. But groups and roles are the platform's core collaboration + access model — the sharing picker ("Specific members or groups"), agent resource-access assignment, and project role bindings all route through them. Gating their creation left those surfaces functionally empty for self-serve users. SSO/SCIM (+ audit) remain the enterprise anchor — and SCIM is what auto-syncs groups from an IdP, which stays a natural upsell.

## How (one semantic change, centralized)
- `tiers.ts`: the self-serve entitlement set (`NO_ENTERPRISE` → renamed `SELF_SERVE`) now carries **`rbac: true`** for every tier. That single matrix drives all 11 `requireEntitlement('rbac')` route gates (account groups create/rename/add-member, custom-roles CRUD + policy bindings, project-scoped group grants) — they stay in place but are **dormant**, so a future packaging change is again a one-line edit.
- The account-page Groups/Roles UI unlocks **automatically** — `rbacEnabled` reads the entitlement from account-state, so the "Enterprise feature" banner + disabled Create buttons disappear with zero frontend changes.
- Comments updated where they claimed rbac was enterprise-gated (tiers.ts, r7.ts ×2, accounts/iam.ts).

## Verified
- `unit-tier-entitlements.test.ts` updated to pin the new contract: **rbac open on every tier (incl. unknown-tier fallback), SSO/SCIM/audit still fail-closed** — 11/11 pass locally with `unit-iam-entitlement-gates.test.ts` (SCIM 402s intact).
- API `tsc --noEmit` clean.
- ke2e iam flows only used the enterprise-demo toggle as a *setup step* for group creation — they pass with the gate open (toggle now unnecessary, harmless); the only 402-asserting flow targets `sso`, untouched.