### PR TITLE
fix(web): customize sections visible per read leaf + read-only-safe for all roles

### DIFF
--- a/apps/web/src/components/projects/schedule-view.tsx
+++ b/apps/web/src/components/projects/schedule-view.tsx
@@ -66,6 +66,8 @@ import CustomizeSectionWrapper from '@/features/workspace/customize/sections/com
 import { type ModelKey, modelKeyToWire, wireToModelKey } from '@/hooks/opencode/use-model-store';
 import { useOpenCodeProviders, useVisibleAgents } from '@/hooks/opencode/use-opencode-sessions';
 import { getEnv } from '@/lib/env-config';
+import { PROJECT_ACTIONS } from '@/lib/project-actions';
+import { useProjectCan } from '@/lib/use-project-can';
 import { cn } from '@/lib/utils';
 import {
   type ProjectTrigger,
@@ -271,6 +273,8 @@ export function ScheduleView({ projectId, type }: { projectId: string; type: Tri
 
   const tHardcodedUi = useTranslations('hardcodedUi');
   const queryClient = useQueryClient();
+  const canWrite =
+    useProjectCan(projectId, PROJECT_ACTIONS.PROJECT_TRIGGER_CREATE).allowed === true;
   const queryKey = useMemo(() => ['project-triggers', projectId], [projectId]);
 
   const triggersQuery = useQuery({
@@ -331,7 +335,7 @@ export function ScheduleView({ projectId, type }: { projectId: string; type: Tri
               )
         }
         action={
-          showContent ? (
+          showContent && canWrite ? (
             <Button
               size="sm"
               variant="secondary"
@@ -402,15 +406,17 @@ export function ScheduleView({ projectId, type }: { projectId: string; type: Tri
               size="sm"
               title={meta.empty.title}
               action={
-                <Button
-                  variant="secondary"
-                  size="sm"
-                  onClick={() => setCreateOpen(true)}
-                  className="gap-1.5"
-                >
-                  <Icon.Plus className="size-3.5 shrink-0" />
-                  {meta.createButtonLabel}
-                </Button>
+                canWrite ? (
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    onClick={() => setCreateOpen(true)}
+                    className="gap-1.5"
+                  >
+                    <Icon.Plus className="size-3.5 shrink-0" />
+                    {meta.createButtonLabel}
+                  </Button>
+                ) : null
               }
             />
           ) : filtered.length === 0 ? (
@@ -513,6 +519,7 @@ export function ScheduleView({ projectId, type }: { projectId: string; type: Tri
       <TriggerDetailSheet
         projectId={projectId}
         trigger={selectedTrigger}
+        canWrite={canWrite}
         open={!!selectedTrigger}
         onOpenChange={(open) => {
           if (!open) setSelectedId(null);
@@ -538,6 +545,7 @@ export function ScheduleView({ projectId, type }: { projectId: string; type: Tri
 function TriggerDetailSheet({
   projectId,
   trigger,
+  canWrite,
   open,
   onOpenChange,
   onDelete,
@@ -545,6 +553,7 @@ function TriggerDetailSheet({
 }: {
   projectId: string;
   trigger: ProjectTrigger | null;
+  canWrite: boolean;
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onDelete: () => void;
@@ -592,21 +601,33 @@ function TriggerDetailSheet({
             <h1 className="text-foreground text-xl font-semibold tracking-tight text-balance">
               {getTriggerName(trigger)}
             </h1>
-            <TriggerDetailToolbar
-              enabled={trigger.enabled}
-              firePending={fire.isPending}
-              togglePending={toggle.isPending}
-              fireLabel={tHardcodedUi.raw('componentsProjectsTriggersView.line623JsxTextFireNow')}
-              onFire={() => fire.mutate()}
-              onToggle={() => toggle.mutate(!trigger.enabled)}
-              onDelete={onDelete}
-            />
+            {canWrite ? (
+              <TriggerDetailToolbar
+                enabled={trigger.enabled}
+                firePending={fire.isPending}
+                togglePending={toggle.isPending}
+                fireLabel={tHardcodedUi.raw('componentsProjectsTriggersView.line623JsxTextFireNow')}
+                onFire={() => fire.mutate()}
+                onToggle={() => toggle.mutate(!trigger.enabled)}
+                onDelete={onDelete}
+              />
+            ) : null}
           </header>
 
           <div className="space-y-8">
             {isCron ? <CronSection trigger={trigger} /> : <WebhookSection trigger={trigger} />}
-            <PromptTemplateSection projectId={projectId} trigger={trigger} onMutated={onMutated} />
-            <AgentModelSection projectId={projectId} trigger={trigger} onMutated={onMutated} />
+            <PromptTemplateSection
+              projectId={projectId}
+              trigger={trigger}
+              canWrite={canWrite}
+              onMutated={onMutated}
+            />
+            <AgentModelSection
+              projectId={projectId}
+              trigger={trigger}
+              canWrite={canWrite}
+              onMutated={onMutated}
+            />
             <MetaSection trigger={trigger} />
           </div>
         </SheetBody>
@@ -673,10 +694,12 @@ function TriggerDetailToolbar({
 function AgentModelSection({
   projectId,
   trigger,
+  canWrite,
   onMutated,
 }: {
   projectId: string;
   trigger: ProjectTrigger;
+  canWrite: boolean;
   onMutated: () => void;
 }) {
   const agents = useVisibleAgents({ projectId });
@@ -703,6 +726,28 @@ function AgentModelSection({
     },
     onError: (e: Error) => errorToast(e.message || 'Failed to update model'),
   });
+
+  if (!canWrite) {
+    return (
+      <section className="space-y-2">
+        <Label>Agent &amp; model</Label>
+        <PropertyTable
+          rows={[
+            {
+              label: 'Agent',
+              value: <span className="text-xs tracking-wide uppercase">{trigger.agent}</span>,
+            },
+            {
+              label: 'Model',
+              value: (
+                <span className="font-mono text-xs">{trigger.model ?? 'Agent default'}</span>
+              ),
+            },
+          ]}
+        />
+      </section>
+    );
+  }
 
   return (
     <section className="space-y-4">
@@ -887,10 +932,12 @@ function WebhookSection({ trigger }: { trigger: ProjectTrigger }) {
 function PromptTemplateSection({
   projectId,
   trigger,
+  canWrite,
   onMutated,
 }: {
   projectId: string;
   trigger: ProjectTrigger;
+  canWrite: boolean;
   onMutated: () => void;
 }) {
   const tHardcodedUi = useTranslations('hardcodedUi');
@@ -917,7 +964,7 @@ function PromptTemplateSection({
         <Label>
           {tHardcodedUi.raw('componentsProjectsTriggersView.line817JsxAttrTitlePromptTemplate')}
         </Label>
-        {editing ? (
+        {!canWrite ? null : editing ? (
           <ButtonGroup>
             <Button
               variant="outline"
@@ -946,7 +993,7 @@ function PromptTemplateSection({
         )}
       </div>
 
-      {editing ? (
+      {canWrite && editing ? (
         <Textarea
           value={draft}
           onChange={(e) => setDraft(e.target.value)}

--- a/apps/web/src/features/review-center/review-center-connected.tsx
+++ b/apps/web/src/features/review-center/review-center-connected.tsx
@@ -31,7 +31,16 @@ import { ReviewCenter } from './review-center';
 const CR_PREFIX = 'cr:';
 const EXEC_PREFIX = 'exec:';
 
-export function ReviewCenterConnected({ projectName }: { projectName: string }) {
+export function ReviewCenterConnected({
+  projectName,
+  canAct = true,
+}: {
+  projectName: string;
+  // When false (a review.read-only role), withhold the act handlers so the
+  // ReviewCenter renders its inbox read-only — no mutation UI that would 403.
+  // Defaults to true to preserve behavior for callers that don't gate.
+  canAct?: boolean;
+}) {
   const ctx = useProjectContext();
   const projectId = ctx?.projectId ?? '';
   const qc = useQueryClient();
@@ -130,9 +139,12 @@ export function ReviewCenterConnected({ projectName }: { projectName: string }) 
       isLoading={isLoading}
       isFetching={isFetching}
       sessionLabels={sessionLabels}
-      onAct={handleAct}
-      onBulkAct={(ids, verdict) =>
-        bulk.mutate({ ids, verdict }, { onError: (e) => errorToast(e.message) })
+      onAct={canAct ? handleAct : undefined}
+      onBulkAct={
+        canAct
+          ? (ids, verdict) =>
+              bulk.mutate({ ids, verdict }, { onError: (e) => errorToast(e.message) })
+          : undefined
       }
       onOpenSession={(sessionId) => {
         // "See progress" only VIEWS the session — feedback delivery goes through

--- a/apps/web/src/features/session/model-selector.tsx
+++ b/apps/web/src/features/session/model-selector.tsx
@@ -40,6 +40,8 @@ import { useModelStore } from '@/hooks/opencode/use-model-store';
 import type { ProviderListResponse } from '@/hooks/opencode/use-opencode-sessions';
 import { featureFlags } from '@kortix/sdk/feature-flags';
 import { isLlmGatewayEnabled } from '@/lib/llm-gateway';
+import { PROJECT_ACTIONS } from '@/lib/project-actions';
+import { useProjectCan } from '@/lib/use-project-can';
 import { getProjectDetail, listProjectSecrets } from '@kortix/sdk/projects-client';
 import { useCustomizeStore } from '@/stores/customize-store';
 import type { ProviderModalTab } from '@/stores/provider-modal-store';
@@ -158,6 +160,13 @@ export function ModelSelector({
     staleTime: 30_000,
   });
   const llmGatewayEnabled = isLlmGatewayEnabled(projectDetailQuery.data?.project);
+  // The legacy (non-gateway) provider modal lets you connect/disconnect
+  // providers — all writes. Gate them so a read-only member sees the catalog
+  // but no mutating controls (fails safe to read-only until the probe resolves).
+  const canWriteProviders =
+    useProjectCan(projectId ?? undefined, PROJECT_ACTIONS.PROJECT_WRITE, {
+      accountId: projectDetailQuery.data?.project.account_id,
+    }).allowed === true;
   const baseModels = useMemo(() => {
     return llmGatewayEnabled ? models : models.filter((m) => m.providerID !== 'kortix');
   }, [models, llmGatewayEnabled]);
@@ -344,6 +353,7 @@ export function ModelSelector({
           open={projectModalOpen}
           onOpenChange={setProjectModalOpen}
           defaultTab={projectModalTab}
+          canWrite={canWriteProviders}
         />
       )}
       <CommandPopover open={open} onOpenChange={setOpen}>

--- a/apps/web/src/features/tunnel/tunnel-overview.tsx
+++ b/apps/web/src/features/tunnel/tunnel-overview.tsx
@@ -115,7 +115,7 @@ function LoadingSkeleton() {
   );
 }
 
-export function TunnelOverview() {
+export function TunnelOverview({ canWrite = false }: { canWrite?: boolean }) {
   const tHardcodedUi = useTranslations('hardcodedUi');
   const { data: connections = [], isLoading } = useTunnelConnections();
   const deleteMutation = useDeleteTunnelConnection();
@@ -163,7 +163,7 @@ export function TunnelOverview() {
         title="Computers"
         description="Connect local machines and grant agents permissioned access over a reverse tunnel."
       >
-        {hasConnections && (
+        {hasConnections && canWrite && (
           <div className="flex items-center justify-between gap-3">
             <ConnectCommandPanel />
           </div>
@@ -206,9 +206,11 @@ export function TunnelOverview() {
                   )}
                 </EmptyDescription>
               </EmptyHeader>
-              <EmptyContent className="max-w-md">
-                <ConnectCommandPanel />
-              </EmptyContent>
+              {canWrite && (
+                <EmptyContent className="max-w-md">
+                  <ConnectCommandPanel />
+                </EmptyContent>
+              )}
             </Empty>
           ) : filtered.length === 0 && searchQuery ? (
             <p className="text-muted-foreground px-3 py-6 text-center text-xs">
@@ -293,7 +295,8 @@ export function TunnelOverview() {
           setSettingsOpen(open);
           if (!open) setSelectedTunnel(null);
         }}
-        onDelete={() => selectedTunnel && setDeleteTarget(selectedTunnel)}
+        canWrite={canWrite}
+        onDelete={canWrite ? () => selectedTunnel && setDeleteTarget(selectedTunnel) : undefined}
       />
 
       <DeleteConnectionDialog

--- a/apps/web/src/features/tunnel/tunnel-scope-toggles.tsx
+++ b/apps/web/src/features/tunnel/tunnel-scope-toggles.tsx
@@ -25,6 +25,9 @@ import type { TunnelPermission } from '@/hooks/tunnel/use-tunnel';
 
 interface TunnelScopeTogglesProps {
   tunnelId: string;
+  /** When false, the toggles and expiry select are shown but disabled — the
+   *  active scopes remain visible as read-only data. */
+  canWrite?: boolean;
 }
 
 function groupBy<T>(arr: T[], fn: (item: T) => string): Record<string, T[]> {
@@ -57,7 +60,7 @@ export function buildActiveScopeMap(permissions: TunnelPermission[] | undefined)
   return map;
 }
 
-export function TunnelScopeToggles({ tunnelId }: TunnelScopeTogglesProps) {
+export function TunnelScopeToggles({ tunnelId, canWrite = false }: TunnelScopeTogglesProps) {
   const tHardcodedUi = useTranslations('hardcodedUi');
   const { data: permissions, isLoading } = useTunnelPermissions(tunnelId);
   const grantMutation = useGrantTunnelPermission();
@@ -104,7 +107,7 @@ export function TunnelScopeToggles({ tunnelId }: TunnelScopeTogglesProps) {
         <span className="text-muted-foreground">
           {tHardcodedUi.raw('componentsTunnelTunnelScopeToggles.line79JsxTextNewGrantsExpireIn')}
         </span>
-        <Select value={expiryValue} onValueChange={setExpiryValue}>
+        <Select value={expiryValue} onValueChange={setExpiryValue} disabled={!canWrite}>
           <SelectTrigger variant="popover">
             <SelectValue />
           </SelectTrigger>
@@ -135,7 +138,7 @@ export function TunnelScopeToggles({ tunnelId }: TunnelScopeTogglesProps) {
                     key={scope.key}
                     scope={scope}
                     isActive={isActive}
-                    isPending={grantMutation.isPending || revokeMutation.isPending}
+                    disabled={!canWrite || grantMutation.isPending || revokeMutation.isPending}
                     onToggle={() => handleToggle(scope, isActive)}
                   />
                 );
@@ -151,17 +154,20 @@ export function TunnelScopeToggles({ tunnelId }: TunnelScopeTogglesProps) {
 function ScopeToggleRow({
   scope,
   isActive,
-  isPending,
+  disabled,
   onToggle,
 }: {
   scope: ScopeInfo;
   isActive: boolean;
-  isPending: boolean;
+  disabled: boolean;
   onToggle: () => void;
 }) {
   return (
     <label
-      className={cn('flex cursor-pointer items-center gap-3 rounded-md py-2 transition-colors')}
+      className={cn(
+        'flex items-center gap-3 rounded-md py-2 transition-colors',
+        disabled ? 'cursor-default' : 'cursor-pointer',
+      )}
     >
       <div className="flex min-w-0 flex-1 items-center gap-2">
         <code className="text-foreground font-mono text-xs">{scope.key}</code>
@@ -170,7 +176,7 @@ function ScopeToggleRow({
       <Switch
         checked={isActive}
         onCheckedChange={onToggle}
-        disabled={isPending}
+        disabled={disabled}
         className="shrink-0"
       />
     </label>

--- a/apps/web/src/features/tunnel/tunnel-settings-dialog.tsx
+++ b/apps/web/src/features/tunnel/tunnel-settings-dialog.tsx
@@ -26,6 +26,9 @@ interface TunnelSettingsDialogProps {
   tunnel: TunnelConnection | null;
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  /** When false, the permissions toggles and delete action are hidden — the
+   *  dialog stays open as a read-only view of the connection's data. */
+  canWrite?: boolean;
   onDelete?: () => void;
 }
 
@@ -35,6 +38,7 @@ export function TunnelSettingsDialog({
   tunnel,
   open,
   onOpenChange,
+  canWrite = false,
   onDelete,
 }: TunnelSettingsDialogProps) {
   const tHardcodedUi = useTranslations('hardcodedUi');
@@ -120,7 +124,7 @@ export function TunnelSettingsDialog({
             <div className="min-h-0 flex-1 overflow-y-auto">
               <TabsContent value="permissions">
                 {activeTab === 'permissions' && tunnelId ? (
-                  <TunnelScopeToggles tunnelId={tunnelId || ''} />
+                  <TunnelScopeToggles tunnelId={tunnelId || ''} canWrite={canWrite} />
                 ) : null}
               </TabsContent>
 

--- a/apps/web/src/features/workspace/customize/customize-panel.tsx
+++ b/apps/web/src/features/workspace/customize/customize-panel.tsx
@@ -177,10 +177,12 @@ export function CustomizPanel({ projectId }: { projectId: string }) {
       ),
     [caps],
   );
-  // A section is permitted when its GATE leaf resolved to allowed:true. Every
-  // customize section gates on WRITE (editor+) — a plain `member` sees none of
-  // them (Files lives on its own /projects/[id]/files page, not in here). Until
-  // the probe resolves (or if it errored) we permit everything (optimistic).
+  // A section is permitted when its READ leaf resolved to allowed:true — a role
+  // that can read a section SEES it (read-only unless it also holds the write
+  // leaf; edit controls inside each view gate on can_manage separately). A role
+  // that omits a read leaf hides just that section. (Files lives on its own
+  // /projects/[id]/files page, not in here.) Until the probe resolves (or if it
+  // errored) we permit everything (optimistic) — visibility, not security.
   const isSectionAllowed = useCallback(
     (s: CustomizeSection) => {
       if (!capsResolved) return true;

--- a/apps/web/src/features/workspace/customize/migrate-to-v2/upgrade-view.test.tsx
+++ b/apps/web/src/features/workspace/customize/migrate-to-v2/upgrade-view.test.tsx
@@ -6,7 +6,7 @@ import { UpgradesViewContent } from './upgrade-view';
 describe('UpgradesViewContent — per-state rendering', () => {
   test('v1 lists the manifest migration with a Run action, plus the one-off runner', () => {
     const html = renderToStaticMarkup(
-      <UpgradesViewContent version={1} onRun={() => {}} pending={false} />,
+      <UpgradesViewContent version={1} onRun={() => {}} pending={false} canWrite />,
     );
     expect(html).toContain('Upgrades');
     expect(html).toContain('Migrate manifest to v2');
@@ -17,7 +17,7 @@ describe('UpgradesViewContent — per-state rendering', () => {
 
   test('v2 shows the up-to-date empty state but keeps the one-off runner available', () => {
     const html = renderToStaticMarkup(
-      <UpgradesViewContent version={2} onRun={() => {}} pending={false} />,
+      <UpgradesViewContent version={2} onRun={() => {}} pending={false} canWrite />,
     );
     expect(html).toContain('up to date');
     expect(html).not.toContain('Migrate manifest to v2');
@@ -26,14 +26,28 @@ describe('UpgradesViewContent — per-state rendering', () => {
 
   test('unresolved manifest read renders placeholders — no upgrade rows, no premature up-to-date claim', () => {
     const html = renderToStaticMarkup(
-      <UpgradesViewContent version={null} onRun={() => {}} pending={false} />,
+      <UpgradesViewContent version={null} onRun={() => {}} pending={false} canWrite />,
     );
     expect(html).not.toContain('Migrate manifest to v2');
     expect(html).not.toContain('up to date');
   });
 
   test('run buttons disable while a session is being created', () => {
-    const html = renderToStaticMarkup(<UpgradesViewContent version={1} onRun={() => {}} pending />);
+    const html = renderToStaticMarkup(
+      <UpgradesViewContent version={1} onRun={() => {}} pending canWrite />,
+    );
     expect(html).toContain('disabled');
+  });
+
+  test('read-only (no write) hides the Run action and the one-off runner but keeps the explanation', () => {
+    const html = renderToStaticMarkup(
+      <UpgradesViewContent version={1} onRun={() => {}} pending={false} canWrite={false} />,
+    );
+    // Section + upgrade row still render (data stays visible)…
+    expect(html).toContain('Upgrades');
+    expect(html).toContain('Migrate manifest to v2');
+    expect(html).toContain('One-off upgrade');
+    // …but the mutating "Run upgrade" control is gone.
+    expect(html).not.toContain('Run upgrade');
   });
 });

--- a/apps/web/src/features/workspace/customize/migrate-to-v2/upgrade-view.tsx
+++ b/apps/web/src/features/workspace/customize/migrate-to-v2/upgrade-view.tsx
@@ -22,6 +22,8 @@ import Loading from '@/components/ui/loading';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Textarea } from '@/components/ui/textarea';
 import { EmptyState } from '@/features/layout/section/empty-state';
+import { PROJECT_ACTIONS } from '@/lib/project-actions';
+import { useProjectCan } from '@/lib/use-project-can';
 import { ArrowUpCircle, CircleCheckBig } from 'lucide-react';
 import { useState } from 'react';
 
@@ -38,11 +40,15 @@ export function UpgradesViewContent({
   version,
   onRun,
   pending,
+  canWrite = false,
 }: {
   /** `null` = the manifest read hasn't resolved yet. */
   version: ManifestVersion | null;
   onRun: (prompt: string) => void;
   pending: boolean;
+  /** When false, the Run action buttons are hidden — the upgrade explanation
+   *  and one-off description stay visible as a read-only view. */
+  canWrite?: boolean;
 }) {
   const [oneOff, setOneOff] = useState('');
   const upgrades = version === null ? null : applicableUpgrades({ manifestVersion: version });
@@ -83,15 +89,17 @@ export function UpgradesViewContent({
                     {upgrade.description}
                   </p>
                 </div>
-                <Button
-                  size="sm"
-                  className="shrink-0"
-                  disabled={pending}
-                  onClick={() => onRun(upgrade.prompt)}
-                >
-                  {pending ? <Loading className="size-3.5 shrink-0" /> : null}
-                  Run
-                </Button>
+                {canWrite ? (
+                  <Button
+                    size="sm"
+                    className="shrink-0"
+                    disabled={pending}
+                    onClick={() => onRun(upgrade.prompt)}
+                  >
+                    {pending ? <Loading className="size-3.5 shrink-0" /> : null}
+                    Run
+                  </Button>
+                ) : null}
               </li>
             ))}
           </ul>
@@ -105,23 +113,27 @@ export function UpgradesViewContent({
             Describe a single change to this project. An agent session makes it, validates, and
             opens a change request — it never merges on its own.
           </p>
-          <Textarea
-            value={oneOff}
-            onChange={(event) => setOneOff(event.target.value)}
-            placeholder="e.g. Rename the release-bot agent to deploy-bot everywhere it's referenced"
-            minHeight={72}
-          />
-          <div className="flex justify-end">
-            <Button
-              size="sm"
-              variant="secondary"
-              disabled={pending || !oneOff.trim()}
-              onClick={() => onRun(buildOneOffUpgradePrompt(oneOff))}
-            >
-              {pending ? <Loading className="size-3.5 shrink-0" /> : null}
-              Run upgrade
-            </Button>
-          </div>
+          {canWrite ? (
+            <>
+              <Textarea
+                value={oneOff}
+                onChange={(event) => setOneOff(event.target.value)}
+                placeholder="e.g. Rename the release-bot agent to deploy-bot everywhere it's referenced"
+                minHeight={72}
+              />
+              <div className="flex justify-end">
+                <Button
+                  size="sm"
+                  variant="secondary"
+                  disabled={pending || !oneOff.trim()}
+                  onClick={() => onRun(buildOneOffUpgradePrompt(oneOff))}
+                >
+                  {pending ? <Loading className="size-3.5 shrink-0" /> : null}
+                  Run upgrade
+                </Button>
+              </div>
+            </>
+          ) : null}
         </div>
       </section>
     </CustomizeSectionWrapper>
@@ -131,5 +143,13 @@ export function UpgradesViewContent({
 export function UpgradesView({ projectId }: { projectId: string }) {
   const { version } = useProjectManifestVersion(projectId);
   const run = useRunUpgrade(projectId);
-  return <UpgradesViewContent version={version} onRun={run.start} pending={run.pending} />;
+  const canWrite = useProjectCan(projectId, PROJECT_ACTIONS.PROJECT_WRITE).allowed === true;
+  return (
+    <UpgradesViewContent
+      version={version}
+      onRun={run.start}
+      pending={run.pending}
+      canWrite={canWrite}
+    />
+  );
 }

--- a/apps/web/src/features/workspace/customize/sections/component/config-entity-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/component/config-entity-view.tsx
@@ -49,6 +49,14 @@ export interface ConfigEntityViewProps<T extends ConfigEntity> {
   /** Lowercase singular used in inline copy ("No matches", "{noun} body is empty"). */
   noun: string;
 
+  /**
+   * Whether the viewer may create/edit entities. Defaults to `true` so any
+   * caller that doesn't gate stays unchanged. When `false` the section renders
+   * READ-ONLY — the "New" and "Edit" mutating controls are hidden — so a role
+   * holding only the READ leaf sees the list + detail without buttons that 403.
+   */
+  canWrite?: boolean;
+
   className?: string;
   // Section shell
   title: string;
@@ -118,6 +126,7 @@ export function ConfigEntityView<T extends ConfigEntity>(props: ConfigEntityView
     emptyBodyLabel,
     renderContext,
     layout = 'accordion',
+    canWrite = true,
     className,
   } = props;
 
@@ -193,20 +202,22 @@ export function ConfigEntityView<T extends ConfigEntity>(props: ConfigEntityView
       title={emptyTitle}
       action={
         <div className="flex flex-col items-center gap-2">
-          <Button
-            variant="outline"
-            size="sm"
-            className="gap-1.5"
-            onClick={() => configure.start(newConfigPrompt(kind))}
-            disabled={configure.pending}
-          >
-            {configure.pending ? (
-              <Loading className="size-3.5 shrink-0" />
-            ) : (
-              <Plus className="size-3.5 shrink-0" />
-            )}
-            Create {noun}
-          </Button>
+          {canWrite ? (
+            <Button
+              variant="outline"
+              size="sm"
+              className="gap-1.5"
+              onClick={() => configure.start(newConfigPrompt(kind))}
+              disabled={configure.pending}
+            >
+              {configure.pending ? (
+                <Loading className="size-3.5 shrink-0" />
+              ) : (
+                <Plus className="size-3.5 shrink-0" />
+              )}
+              Create {noun}
+            </Button>
+          ) : null}
           {emptyDocsHref ? (
             <Button asChild variant="ghost" size="sm" className="gap-1.5">
               <a href={emptyDocsHref} target="_blank" rel="noopener noreferrer">
@@ -248,6 +259,7 @@ export function ConfigEntityView<T extends ConfigEntity>(props: ConfigEntityView
                   renderDetailMeta={renderDetailMeta}
                   renderDetailExtra={renderDetailExtra}
                   emptyBodyLabel={emptyBodyLabel}
+                  canWrite={canWrite}
                 />
               </li>
             ))}
@@ -339,6 +351,7 @@ export function ConfigEntityView<T extends ConfigEntity>(props: ConfigEntityView
                 renderDetailTitle={renderDetailTitle}
                 renderDetailMeta={renderDetailMeta}
                 emptyBodyLabel={emptyBodyLabel}
+                canWrite={canWrite}
                 split
               />
             </div>
@@ -377,19 +390,21 @@ export function ConfigEntityView<T extends ConfigEntity>(props: ConfigEntityView
       action={
         <div className="flex items-center gap-1.5">
           <MarketplaceSectionButton projectId={projectId} />
-          <Button
-            size="sm"
-            variant="secondary"
-            onClick={() => configure.start(newConfigPrompt(kind))}
-            disabled={configure.pending}
-          >
-            {configure.pending ? (
-              <Loading className="size-4 shrink-0" />
-            ) : (
-              <Plus className="size-4" />
-            )}
-            New
-          </Button>
+          {canWrite ? (
+            <Button
+              size="sm"
+              variant="secondary"
+              onClick={() => configure.start(newConfigPrompt(kind))}
+              disabled={configure.pending}
+            >
+              {configure.pending ? (
+                <Loading className="size-4 shrink-0" />
+              ) : (
+                <Plus className="size-4" />
+              )}
+              New
+            </Button>
+          ) : null}
         </div>
       }
     >
@@ -417,6 +432,7 @@ interface EntityDisclosureProps<T extends ConfigEntity> {
   renderDetailMeta?: (entity: T, config: ProjectConfigSummary) => ReactNode;
   renderDetailExtra?: (entity: T, config: ProjectConfigSummary) => ReactNode;
   emptyBodyLabel: string;
+  canWrite: boolean;
 }
 
 function EntityDisclosure<T extends ConfigEntity>({
@@ -431,6 +447,7 @@ function EntityDisclosure<T extends ConfigEntity>({
   renderDetailMeta,
   renderDetailExtra,
   emptyBodyLabel,
+  canWrite,
 }: EntityDisclosureProps<T>) {
   const [open, setOpen] = useState(false);
   const trailing = renderRowTrailing?.(entity, config);
@@ -456,6 +473,7 @@ function EntityDisclosure<T extends ConfigEntity>({
           renderDetailMeta={renderDetailMeta}
           renderDetailExtra={renderDetailExtra}
           emptyBodyLabel={emptyBodyLabel}
+          canWrite={canWrite}
         />
       </DisclosureContent>
     </Disclosure>
@@ -471,6 +489,8 @@ interface EntityDetailProps<T extends ConfigEntity> {
   renderDetailMeta?: (entity: T, config: ProjectConfigSummary) => ReactNode;
   renderDetailExtra?: (entity: T, config: ProjectConfigSummary) => ReactNode;
   emptyBodyLabel: string;
+  /** Read-only viewers (READ leaf, no WRITE) hide the "Edit" control. */
+  canWrite: boolean;
   /** Master-detail mode: render the source in the middle and `renderDetailExtra`
    *  as a right-hand aside, instead of stacking the extra above the source. */
   split?: boolean;
@@ -485,6 +505,7 @@ function EntityDetail<T extends ConfigEntity>({
   renderDetailMeta,
   renderDetailExtra,
   emptyBodyLabel,
+  canWrite,
   split,
 }: EntityDetailProps<T>) {
   const configure = useConfigureThread(projectId);
@@ -558,6 +579,7 @@ function EntityDetail<T extends ConfigEntity>({
         onEdit={() => configure.start(editConfigPrompt(kind, entity.name, entity.path))}
         editing={configure.pending}
         copyDisabled={!fileQuery.data?.content}
+        canWrite={canWrite}
       />
     </div>
   );
@@ -588,24 +610,28 @@ function DetailToolbarActions({
   onEdit,
   editing,
   copyDisabled,
+  canWrite,
 }: {
   onCopy: () => void;
   onEdit: () => void;
   editing: boolean;
   copyDisabled: boolean;
+  canWrite: boolean;
 }) {
   return (
     <ButtonGroup className="shrink-0">
-      <Hint label="Edit">
-        <Button variant="outline" size="sm" onClick={onEdit} disabled={editing}>
-          {editing ? (
-            <Loading className="size-3.5 shrink-0" />
-          ) : (
-            <Pencil className="size-3.5 shrink-0" />
-          )}
-          Edit
-        </Button>
-      </Hint>
+      {canWrite ? (
+        <Hint label="Edit">
+          <Button variant="outline" size="sm" onClick={onEdit} disabled={editing}>
+            {editing ? (
+              <Loading className="size-3.5 shrink-0" />
+            ) : (
+              <Pencil className="size-3.5 shrink-0" />
+            )}
+            Edit
+          </Button>
+        </Hint>
+      ) : null}
       <Hint label="Copy source">
         <Button variant="outline" size="icon" onClick={onCopy} disabled={copyDisabled}>
           <Copy className="size-3.5 shrink-0" />

--- a/apps/web/src/features/workspace/customize/sections/connectors-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/connectors-view.tsx
@@ -98,6 +98,8 @@ import {
   useSlackMode,
   useUpdateEmailPolicy,
 } from '@/hooks/channels/use-channels-installations';
+import { PROJECT_ACTIONS } from '@/lib/project-actions';
+import { useProjectCan } from '@/lib/use-project-can';
 import { cn } from '@/lib/utils';
 import {
   type AdminConnector,
@@ -254,6 +256,11 @@ function ConnectorsMasterDetail({ projectId }: { projectId: string }) {
     staleTime: 10_000,
   });
   const connectors = useMemo(() => query.data?.connectors ?? [], [query.data]);
+  // Section shows to any role holding the connector READ leaf; the mutating
+  // controls below gate on WRITE. Defaults false until the probe resolves →
+  // fails safe (read-only) rather than flashing editable controls that 403.
+  const canWrite =
+    useProjectCan(projectId, PROJECT_ACTIONS.PROJECT_CONNECTOR_WRITE).allowed === true;
   const emailChannelEnabled = projectQuery.data?.experimental?.agentmail_email === true;
   const isForbidden = query.isError && /403|forbidden/i.test((query.error as Error)?.message ?? '');
 
@@ -360,6 +367,7 @@ function ConnectorsMasterDetail({ projectId }: { projectId: string }) {
             key={active.slug}
             projectId={projectId}
             connector={active}
+            canWrite={canWrite}
             onChanged={invalidate}
             onRemoved={() => {
               invalidate();
@@ -737,11 +745,13 @@ function RailItem({
 function ConnectorDetail({
   projectId,
   connector,
+  canWrite,
   onChanged,
   onRemoved,
 }: {
   projectId: string;
   connector: AdminConnector;
+  canWrite: boolean;
   onChanged: () => void;
   onRemoved: () => void;
 }) {
@@ -793,7 +803,9 @@ function ConnectorDetail({
       <div className="flex items-start gap-3.5">
         <ConnectorAppIcon projectId={projectId} connector={connector} size="lg" />
         <div className="min-w-0 flex-1">
-          {editingName ? (
+          {!canWrite ? (
+            <h2 className="text-foreground truncate text-lg font-semibold">{displayName}</h2>
+          ) : editingName ? (
             <form
               className="flex items-center gap-1.5"
               onSubmit={(e) => {
@@ -870,7 +882,8 @@ function ConnectorDetail({
             When NOT connected, the connect action is a big CTA below — not a
             small header button buried next to the title. (Channel connectors
             are managed from the Channels tab, so neither shows.) */}
-        {connector.authSecret &&
+        {canWrite &&
+          connector.authSecret &&
           connected &&
           !isChannel &&
           (isPipedream ? (
@@ -927,7 +940,7 @@ function ConnectorDetail({
           </InfoBanner>
         )}
         {/* Prominent connect CTA — the first thing you see on an unconnected connector. */}
-        {connector.authSecret && !connected && !isChannel && (
+        {canWrite && connector.authSecret && !connected && !isChannel && (
           <InfoBanner
             tone="info"
             icon={KeyRound}
@@ -952,7 +965,10 @@ function ConnectorDetail({
         {/* The sensitive toggle lives under Permissions (it IS a permission
             default), so Profile only exists when there's a connection to
             manage — for Pipedream/managed connectors it would be empty. */}
-        <Tabs defaultValue={!isPipedream && !isManaged ? 'profile' : 'permissions'} className="gap-3">
+        <Tabs
+          defaultValue={!isPipedream && !isManaged ? 'profile' : 'permissions'}
+          className="gap-3"
+        >
           <TabsList>
             {!isPipedream && !isManaged && <TabsTrigger value="profile">Profile</TabsTrigger>}
             <TabsTrigger value="permissions">Permissions</TabsTrigger>
@@ -963,6 +979,7 @@ function ConnectorDetail({
                 <ChannelConnectionSection
                   projectId={projectId}
                   connector={connector}
+                  canWrite={canWrite}
                   onChanged={onChanged}
                   onRemoved={onRemoved}
                 />
@@ -970,6 +987,7 @@ function ConnectorDetail({
                 <ConnectionSection
                   projectId={projectId}
                   connector={connector}
+                  canWrite={canWrite}
                   onChanged={onChanged}
                 />
               )}
@@ -979,12 +997,13 @@ function ConnectorDetail({
             <PermissionsSection
               projectId={projectId}
               connector={connector}
+              canWrite={canWrite}
               onChanged={onChanged}
             />
           </TabsContent>
         </Tabs>
 
-        {!isManaged && !isChannel && (
+        {canWrite && !isManaged && !isChannel && (
           <SectionCard
             tone="destructive"
             title={tI18nHardcoded.raw(
@@ -1057,11 +1076,13 @@ function connectorPlatform(connector: AdminConnector): ChannelPlatform | null {
 function ChannelConnectionSection({
   projectId,
   connector,
+  canWrite,
   onChanged,
   onRemoved,
 }: {
   projectId: string;
   connector: AdminConnector;
+  canWrite: boolean;
   onChanged: () => void;
   onRemoved: () => void;
 }) {
@@ -1071,6 +1092,7 @@ function ChannelConnectionSection({
       <EmailChannelProfile
         projectId={projectId}
         connector={connector}
+        canWrite={canWrite}
         onChanged={onChanged}
         onRemoved={onRemoved}
       />
@@ -1078,7 +1100,12 @@ function ChannelConnectionSection({
   }
   if (platform === 'slack') {
     return (
-      <SlackChannelProfile projectId={projectId} onChanged={onChanged} onRemoved={onRemoved} />
+      <SlackChannelProfile
+        projectId={projectId}
+        canWrite={canWrite}
+        onChanged={onChanged}
+        onRemoved={onRemoved}
+      />
     );
   }
   return (
@@ -1091,11 +1118,13 @@ function ChannelConnectionSection({
 function EmailChannelProfile({
   projectId,
   connector,
+  canWrite,
   onChanged,
   onRemoved,
 }: {
   projectId: string;
   connector: AdminConnector;
+  canWrite: boolean;
   onChanged: () => void;
   onRemoved: () => void;
 }) {
@@ -1113,14 +1142,19 @@ function EmailChannelProfile({
           projectId={projectId}
           connectorSlug={connector.slug}
           installation={install.data}
+          canWrite={canWrite}
           onRemoved={onRemoved}
         />
-      ) : (
+      ) : canWrite ? (
         <EmailConnectForm
           projectId={projectId}
           connectorSlug={connector.slug}
           onConnected={onChanged}
         />
+      ) : (
+        <InfoBanner tone="neutral" icon={Mail} title="No email inbox connected">
+          You have read-only access to connectors. Ask a workspace admin to connect an inbox.
+        </InfoBanner>
       )}
     </SectionCard>
   );
@@ -1130,11 +1164,13 @@ function ConnectedEmailProfile({
   projectId,
   connectorSlug,
   installation,
+  canWrite,
   onRemoved,
 }: {
   projectId: string;
   connectorSlug: string;
   installation: EmailInstallation;
+  canWrite: boolean;
   onRemoved: () => void;
 }) {
   const disconnect = useDisconnectEmail();
@@ -1155,42 +1191,47 @@ function ConnectedEmailProfile({
         projectId={projectId}
         connectorSlug={connectorSlug}
         policy={installation.senderPolicy}
+        canWrite={canWrite}
       />
-      <div className="flex items-center justify-end gap-2">
-        {confirming ? (
-          <>
-            <span className="text-muted-foreground mr-auto text-xs">
-              Removes the Email channel profile from this project.
-            </span>
-            <Button variant="ghost" size="sm" onClick={() => setConfirming(false)}>
-              Cancel
-            </Button>
-            <Button
-              variant="destructive"
-              size="sm"
-              disabled={disconnect.isPending}
-              onClick={() =>
-                disconnect.mutate(
-                  { projectId, connectorSlug },
-                  {
-                    onSuccess: () => {
-                      setConfirming(false);
-                      onRemoved();
+      {canWrite && (
+        <div className="flex items-center justify-end gap-2">
+          {confirming ? (
+            <>
+              <span className="text-muted-foreground mr-auto text-xs">
+                Removes the Email channel profile from this project.
+              </span>
+              <Button variant="ghost" size="sm" onClick={() => setConfirming(false)}>
+                Cancel
+              </Button>
+              <Button
+                variant="destructive"
+                size="sm"
+                disabled={disconnect.isPending}
+                onClick={() =>
+                  disconnect.mutate(
+                    { projectId, connectorSlug },
+                    {
+                      onSuccess: () => {
+                        setConfirming(false);
+                        onRemoved();
+                      },
                     },
-                  },
-                )
-              }
-            >
-              {disconnect.isPending ? <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" /> : null}
+                  )
+                }
+              >
+                {disconnect.isPending ? (
+                  <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" />
+                ) : null}
+                Disconnect
+              </Button>
+            </>
+          ) : (
+            <Button variant="outline" size="sm" onClick={() => setConfirming(true)}>
               Disconnect
             </Button>
-          </>
-        ) : (
-          <Button variant="outline" size="sm" onClick={() => setConfirming(true)}>
-            Disconnect
-          </Button>
-        )}
-      </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }
@@ -1221,10 +1262,12 @@ function EmailSenderPolicyEditor({
   projectId,
   connectorSlug,
   policy,
+  canWrite,
 }: {
   projectId: string;
   connectorSlug: string;
   policy: EmailSenderPolicy | null | undefined;
+  canWrite: boolean;
 }) {
   const update = useUpdateEmailPolicy();
   const initial = normalizeEmailSenderPolicy(policy);
@@ -1280,6 +1323,7 @@ function EmailSenderPolicyEditor({
           id="email-sender-restricted"
           checked={restricted}
           onCheckedChange={(checked) => setRestricted(Boolean(checked))}
+          disabled={!canWrite}
           className="mt-0.5"
         />
         <div className="min-w-0 flex-1 space-y-3">
@@ -1297,6 +1341,7 @@ function EmailSenderPolicyEditor({
                   value={emails}
                   onChange={(e) => setEmails(e.target.value)}
                   placeholder="person@example.com"
+                  disabled={!canWrite}
                 />
               </Field>
               <Field>
@@ -1304,6 +1349,7 @@ function EmailSenderPolicyEditor({
                   value={domains}
                   onChange={(e) => setDomains(e.target.value)}
                   placeholder="example.com"
+                  disabled={!canWrite}
                 />
               </Field>
               <div className="sm:col-span-2">
@@ -1313,24 +1359,27 @@ function EmailSenderPolicyEditor({
                     onChange={(e) => setRegex(e.target.value)}
                     placeholder=".*@customer-[0-9]+\\.com$"
                     spellCheck={false}
+                    disabled={!canWrite}
                   />
                 </Field>
               </div>
             </div>
           ) : null}
           {error ? <InfoBanner tone="destructive">{error}</InfoBanner> : null}
-          <SaveBar
-            dirty={dirty}
-            saving={update.isPending}
-            onSave={save}
-            onReset={() => {
-              setRestricted(initial.mode === 'restricted');
-              setEmails(initial.allowedEmails.join('\n'));
-              setDomains(initial.allowedDomains.join('\n'));
-              setRegex(initial.allowedRegex ?? '');
-            }}
-            label="Save policy"
-          />
+          {canWrite && (
+            <SaveBar
+              dirty={dirty}
+              saving={update.isPending}
+              onSave={save}
+              onReset={() => {
+                setRestricted(initial.mode === 'restricted');
+                setEmails(initial.allowedEmails.join('\n'));
+                setDomains(initial.allowedDomains.join('\n'));
+                setRegex(initial.allowedRegex ?? '');
+              }}
+              label="Save policy"
+            />
+          )}
         </div>
       </div>
     </div>
@@ -1601,10 +1650,12 @@ export function EmailConnectForm({
 
 function SlackChannelProfile({
   projectId,
+  canWrite,
   onChanged,
   onRemoved,
 }: {
   projectId: string;
+  canWrite: boolean;
   onChanged: () => void;
   onRemoved: () => void;
 }) {
@@ -1620,10 +1671,15 @@ function SlackChannelProfile({
         <ConnectedSlackProfile
           projectId={projectId}
           installation={install.data}
+          canWrite={canWrite}
           onRemoved={onRemoved}
         />
-      ) : (
+      ) : canWrite ? (
         <SlackConnectForm projectId={projectId} onConnected={onChanged} />
+      ) : (
+        <InfoBanner tone="neutral" icon={<SlackLogo />} title="No Slack workspace connected">
+          You have read-only access to connectors. Ask a workspace admin to connect Slack.
+        </InfoBanner>
       )}
     </SectionCard>
   );
@@ -1632,10 +1688,12 @@ function SlackChannelProfile({
 function ConnectedSlackProfile({
   projectId,
   installation,
+  canWrite,
   onRemoved,
 }: {
   projectId: string;
   installation: SlackInstallation;
+  canWrite: boolean;
   onRemoved: () => void;
 }) {
   const disconnect = useDisconnectSlack();
@@ -1646,38 +1704,42 @@ function ConnectedSlackProfile({
         Workspace{' '}
         <code className="font-mono">{installation.workspaceName || installation.workspaceId}</code>
       </InfoBanner>
-      <div className="flex items-center justify-end gap-2">
-        {confirming ? (
-          <>
-            <span className="text-muted-foreground mr-auto text-xs">
-              Removes the Slack channel profile from this project.
-            </span>
-            <Button variant="ghost" size="sm" onClick={() => setConfirming(false)}>
-              Cancel
-            </Button>
-            <Button
-              variant="destructive"
-              size="sm"
-              disabled={disconnect.isPending}
-              onClick={() =>
-                disconnect.mutate(projectId, {
-                  onSuccess: () => {
-                    setConfirming(false);
-                    onRemoved();
-                  },
-                })
-              }
-            >
-              {disconnect.isPending ? <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" /> : null}
+      {canWrite && (
+        <div className="flex items-center justify-end gap-2">
+          {confirming ? (
+            <>
+              <span className="text-muted-foreground mr-auto text-xs">
+                Removes the Slack channel profile from this project.
+              </span>
+              <Button variant="ghost" size="sm" onClick={() => setConfirming(false)}>
+                Cancel
+              </Button>
+              <Button
+                variant="destructive"
+                size="sm"
+                disabled={disconnect.isPending}
+                onClick={() =>
+                  disconnect.mutate(projectId, {
+                    onSuccess: () => {
+                      setConfirming(false);
+                      onRemoved();
+                    },
+                  })
+                }
+              >
+                {disconnect.isPending ? (
+                  <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" />
+                ) : null}
+                Disconnect
+              </Button>
+            </>
+          ) : (
+            <Button variant="outline" size="sm" onClick={() => setConfirming(true)}>
               Disconnect
             </Button>
-          </>
-        ) : (
-          <Button variant="outline" size="sm" onClick={() => setConfirming(true)}>
-            Disconnect
-          </Button>
-        )}
-      </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }
@@ -1931,10 +1993,12 @@ function connectionSig(d: ConnectorDraftInput): string {
 function ConnectionSection({
   projectId,
   connector,
+  canWrite,
   onChanged,
 }: {
   projectId: string;
   connector: AdminConnector;
+  canWrite: boolean;
   onChanged: () => void;
 }) {
   const tI18nHardcoded = useTranslations('hardcodedUi');
@@ -2003,17 +2067,19 @@ function ConnectionSection({
         </div>
       ) : (
         <div className="space-y-4">
-          <ConnectorConfigFields draft={draft} onChange={setDraft} />
-          <SaveBar
-            dirty={dirty}
-            saving={save.isPending}
-            disabled={!connectionValid(draft)}
-            onSave={() => save.mutate()}
-            onReset={reset}
-            label={tI18nHardcoded.raw(
-              'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrLabelSave8c6f945f',
-            )}
-          />
+          <ConnectorConfigFields draft={draft} onChange={setDraft} readOnly={!canWrite} />
+          {canWrite && (
+            <SaveBar
+              dirty={dirty}
+              saving={save.isPending}
+              disabled={!connectionValid(draft)}
+              onSave={() => save.mutate()}
+              onReset={reset}
+              label={tI18nHardcoded.raw(
+                'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrLabelSave8c6f945f',
+              )}
+            />
+          )}
         </div>
       )}
     </SectionCard>
@@ -2128,10 +2194,12 @@ function tsSignature(slug: string, action: ConnectorAction): string {
 function PermissionsSection({
   projectId,
   connector,
+  canWrite,
   onChanged,
 }: {
   projectId: string;
   connector: AdminConnector;
+  canWrite: boolean;
   onChanged: () => void;
 }) {
   const tI18nHardcoded = useTranslations('hardcodedUi');
@@ -2298,7 +2366,7 @@ function PermissionsSection({
               description="Reads run automatically; writes and destructive actions still ask, per the rules below."
               size="lg"
               variant="outline"
-              disabled={sensitiveMut.isPending}
+              disabled={!canWrite || sensitiveMut.isPending}
             />
             <RadioGroupItem
               value="ask_first"
@@ -2315,7 +2383,7 @@ function PermissionsSection({
               }
               size="lg"
               variant="outline"
-              disabled={sensitiveMut.isPending}
+              disabled={!canWrite || sensitiveMut.isPending}
             />
           </RadioGroup>
         </div>
@@ -2335,17 +2403,19 @@ function PermissionsSection({
           <div className="border-border/60 overflow-hidden rounded-2xl border">
             {/* Select-all + bulk apply */}
             <div className="border-border/60 bg-muted/30 flex h-9 items-center gap-2 border-b px-3">
-              <Checkbox
-                checked={
-                  allFilteredSelected ? true : someFilteredSelected ? 'indeterminate' : false
-                }
-                onCheckedChange={toggleAllFiltered}
-                aria-label={tI18nHardcoded.raw(
-                  'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrAriaLabel924a321f',
-                )}
-                className="size-3.5"
-              />
-              {selected.size > 0 ? (
+              {canWrite && (
+                <Checkbox
+                  checked={
+                    allFilteredSelected ? true : someFilteredSelected ? 'indeterminate' : false
+                  }
+                  onCheckedChange={toggleAllFiltered}
+                  aria-label={tI18nHardcoded.raw(
+                    'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrAriaLabel924a321f',
+                  )}
+                  className="size-3.5"
+                />
+              )}
+              {canWrite && selected.size > 0 ? (
                 <>
                   <span className="text-foreground text-xs font-medium">
                     {selected.size} selected
@@ -2402,17 +2472,19 @@ function PermissionsSection({
                         isSel ? 'bg-primary/[0.05]' : 'hover:bg-muted/30',
                       )}
                     >
-                      <Checkbox
-                        checked={isSel}
-                        onCheckedChange={() => toggleSel(t.path)}
-                        aria-label={`Select ${t.path}`}
-                        className={cn(
-                          'size-3.5 shrink-0 transition-opacity',
-                          isSel
-                            ? ''
-                            : 'opacity-0 group-hover:opacity-100 focus-visible:opacity-100',
-                        )}
-                      />
+                      {canWrite && (
+                        <Checkbox
+                          checked={isSel}
+                          onCheckedChange={() => toggleSel(t.path)}
+                          aria-label={`Select ${t.path}`}
+                          className={cn(
+                            'size-3.5 shrink-0 transition-opacity',
+                            isSel
+                              ? ''
+                              : 'opacity-0 group-hover:opacity-100 focus-visible:opacity-100',
+                          )}
+                        />
+                      )}
                       <button
                         type="button"
                         onClick={() => setExpanded(isOpen ? null : t.path)}
@@ -2447,10 +2519,21 @@ function PermissionsSection({
                             : 'text-muted-foreground/40 opacity-0 group-hover:opacity-100',
                         )}
                       />
-                      <PermissionPicker
-                        value={explicit ?? 'default'}
-                        onChange={(c) => setChoice(t.path, c)}
-                      />
+                      {canWrite ? (
+                        <PermissionPicker
+                          value={explicit ?? 'default'}
+                          onChange={(c) => setChoice(t.path, c)}
+                        />
+                      ) : (
+                        <span
+                          className={cn(
+                            'shrink-0 px-2 py-0.5 text-xs font-medium',
+                            explicit ? POLICY_LABEL[explicit].tint : 'text-muted-foreground',
+                          )}
+                        >
+                          {explicit ? POLICY_LABEL[explicit].label : 'Default'}
+                        </span>
+                      )}
                     </div>
                     {isOpen && (
                       <div className="bg-muted/20 space-y-3 px-4 pt-1 pb-3">
@@ -2553,9 +2636,11 @@ function PermissionsSection({
                         'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrPlaceholderSend3b0a4ee1',
                       )}
                       className="h-8 flex-1 font-mono text-xs"
+                      disabled={!canWrite}
                     />
                     <Select
                       value={r.action}
+                      disabled={!canWrite}
                       onValueChange={(v) =>
                         setRules((rs) =>
                           rs.map((x) =>
@@ -2577,50 +2662,58 @@ function PermissionsSection({
                         ))}
                       </SelectContent>
                     </Select>
-                    <Button
-                      size="icon"
-                      variant="ghost"
-                      className="hover:text-destructive h-8 w-8 shrink-0"
-                      onClick={() => setRules((rs) => rs.filter((x) => x.id !== r.id))}
-                      aria-label={tI18nHardcoded.raw(
-                        'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrAriaLabeld2296c34',
-                      )}
-                    >
-                      <Trash2 className="h-3.5 w-3.5" />
-                    </Button>
+                    {canWrite && (
+                      <Button
+                        size="icon"
+                        variant="ghost"
+                        className="hover:text-destructive h-8 w-8 shrink-0"
+                        onClick={() => setRules((rs) => rs.filter((x) => x.id !== r.id))}
+                        aria-label={tI18nHardcoded.raw(
+                          'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrAriaLabeld2296c34',
+                        )}
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
+                      </Button>
+                    )}
                   </div>
                 ))}
-                <Button
-                  size="sm"
-                  variant="outline"
-                  className="h-8 gap-1.5 text-xs"
-                  onClick={() =>
-                    setRules((rs) => [
-                      ...rs,
-                      { id: ruleId(), match: '', action: 'require_approval' },
-                    ])
-                  }
-                >
-                  <Plus className="h-3.5 w-3.5" />
-                  {tI18nHardcoded.raw(
-                    'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxTextAddRule873a093f',
-                  )}
-                </Button>
+                {canWrite ? (
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="h-8 gap-1.5 text-xs"
+                    onClick={() =>
+                      setRules((rs) => [
+                        ...rs,
+                        { id: ruleId(), match: '', action: 'require_approval' },
+                      ])
+                    }
+                  >
+                    <Plus className="h-3.5 w-3.5" />
+                    {tI18nHardcoded.raw(
+                      'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxTextAddRule873a093f',
+                    )}
+                  </Button>
+                ) : rules.length === 0 ? (
+                  <p className="text-muted-foreground text-xs">No pattern rules.</p>
+                ) : null}
               </div>
             )}
           </div>
         )}
       </div>
 
-      <SaveBar
-        dirty={dirty}
-        saving={save.isPending}
-        onSave={() => save.mutate()}
-        onReset={reset}
-        label={tI18nHardcoded.raw(
-          'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrLabelSave783950c7',
-        )}
-      />
+      {canWrite && (
+        <SaveBar
+          dirty={dirty}
+          saving={save.isPending}
+          onSave={() => save.mutate()}
+          onReset={reset}
+          label={tI18nHardcoded.raw(
+            'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrLabelSave783950c7',
+          )}
+        />
+      )}
     </SectionCard>
   );
 }
@@ -2648,7 +2741,6 @@ function GlobalRulesPanel({ projectId }: { projectId: string }) {
     </div>
   );
 }
-
 
 function AddAppPanel({
   projectId,
@@ -3069,11 +3161,13 @@ function ConnectorConfigFields({
   draft,
   onChange,
   slugEditable,
+  readOnly = false,
   emailChannelEnabled = true,
 }: {
   draft: ConnectorDraftInput;
   onChange: (d: ConnectorDraftInput) => void;
   slugEditable?: boolean;
+  readOnly?: boolean;
   emailChannelEnabled?: boolean;
 }) {
   const tI18nHardcoded = useTranslations('hardcodedUi');
@@ -3097,7 +3191,7 @@ function ConnectorConfigFields({
             placeholder="my-api"
             className="font-mono text-xs"
             variant="popover"
-            disabled={!slugEditable}
+            disabled={!slugEditable || readOnly}
             required
           />
         </Field>
@@ -3105,6 +3199,7 @@ function ConnectorConfigFields({
           <FieldLabel htmlFor="connector-provider">Provider</FieldLabel>
           <Select
             value={p}
+            disabled={readOnly}
             onValueChange={(v) => {
               const provider = v as ConnectorDraftInput['provider'];
               set({
@@ -3141,6 +3236,7 @@ function ConnectorConfigFields({
                 ? 'slack'
                 : (draft.platform ?? (emailChannelEnabled ? 'email' : 'slack'))
             }
+            disabled={readOnly}
             onValueChange={(v) => set({ platform: v as ChannelPlatform, auth: { type: 'none' } })}
           >
             <SelectTrigger>
@@ -3166,6 +3262,7 @@ function ConnectorConfigFields({
             onChange={(e) => set({ spec: e.target.value })}
             placeholder="https://…/openapi.json"
             variant="popover"
+            disabled={readOnly}
             required
           />
         </Field>
@@ -3180,6 +3277,7 @@ function ConnectorConfigFields({
               onChange={(e) => set({ endpoint: e.target.value })}
               placeholder="https://api/graphql"
               variant="popover"
+              disabled={readOnly}
               required
             />
           </Field>
@@ -3195,6 +3293,7 @@ function ConnectorConfigFields({
               onChange={(e) => set({ spec: e.target.value })}
               placeholder=".kortix/executor/schema.graphql"
               variant="popover"
+              disabled={readOnly}
             />
           </Field>
         </>
@@ -3209,6 +3308,7 @@ function ConnectorConfigFields({
               onChange={(e) => set({ url: e.target.value })}
               placeholder="https://mcp…/mcp"
               variant="popover"
+              disabled={readOnly}
               required
             />
           </Field>
@@ -3216,6 +3316,7 @@ function ConnectorConfigFields({
             <FieldLabel htmlFor="connector-transport">Transport</FieldLabel>
             <Select
               value={draft.transport ?? 'http'}
+              disabled={readOnly}
               onValueChange={(v) => set({ transport: v as 'http' | 'sse' })}
             >
               <SelectTrigger id="connector-transport" className="w-full" variant="popover">
@@ -3243,6 +3344,7 @@ function ConnectorConfigFields({
               onChange={(e) => set({ baseUrl: e.target.value })}
               placeholder="https://api.internal"
               variant="popover"
+              disabled={readOnly}
               required
             />
           </Field>
@@ -3258,6 +3360,7 @@ function ConnectorConfigFields({
               onChange={(e) => set({ spec: e.target.value })}
               placeholder=".kortix/executor/routes.toml"
               variant="popover"
+              disabled={readOnly}
             />
           </Field>
         </>
@@ -3268,6 +3371,7 @@ function ConnectorConfigFields({
             <FieldLabel htmlFor="connector-auth">Auth</FieldLabel>
             <Select
               value={draft.auth?.type ?? 'none'}
+              disabled={readOnly}
               onValueChange={(v) => setAuth({ type: v as 'none' | 'bearer' | 'basic' | 'custom' })}
             >
               <SelectTrigger id="connector-auth" className="w-full" variant="popover">
@@ -3298,6 +3402,7 @@ function ConnectorConfigFields({
                 onChange={(e) => setAuth({ name: e.target.value })}
                 placeholder="X-API-Key"
                 variant="popover"
+                disabled={readOnly}
                 required
               />
             </Field>
@@ -3377,7 +3482,9 @@ export function CustomConnectorForm({
             <Button
               type="submit"
               size="sm"
-              disabled={!draft.slug || save.isPending || !connectionValid(draft, emailChannelEnabled)}
+              disabled={
+                !draft.slug || save.isPending || !connectionValid(draft, emailChannelEnabled)
+              }
               className="gap-1.5"
             >
               {save.isPending && <Loader2 className="h-4 w-4 animate-spin" />}

--- a/apps/web/src/features/workspace/customize/sections/gateway-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/gateway-view.tsx
@@ -29,6 +29,8 @@ import { GatewayOverview } from '@/features/workspace/customize/sections/view/ga
 import { useModelDefaults } from '@/hooks/opencode/use-model-defaults';
 import { useOpenCodeProviders } from '@/hooks/opencode/use-opencode-sessions';
 import type { CustomizeSection } from '@/lib/customize-sections';
+import { PROJECT_ACTIONS } from '@/lib/project-actions';
+import { useProjectCan } from '@/lib/use-project-can';
 import { useCustomizeStore } from '@/stores/customize-store';
 
 type LlmTab = 'providers' | 'overview' | 'logs' | 'budgets' | 'keys';
@@ -63,6 +65,11 @@ export function LlmManagementView({ projectId }: { projectId: string }) {
   const models = useMemo(() => flattenModels(providers), [providers]);
   const modelDefaults = useModelDefaults(projectId);
   const effectiveDefault = modelDefaults.accountDefault ?? modelDefaults.platformDefault ?? null;
+  // A role with the LLM section's READ leaf (project.read) but not project.write
+  // sees the gateway read-only: logs/overview/spend stay visible, but the
+  // account-default model picker — the one mutating control in this bar, which
+  // POSTs setAccountDefault — is hidden so a read-only user can't 403.
+  const canWrite = useProjectCan(projectId, PROJECT_ACTIONS.PROJECT_WRITE).allowed === true;
 
   // Follow an external deep-link (e.g. openCustomize('llm-providers')) to its
   // tab. Plain in-view tab clicks stay local and never move the main rail.
@@ -88,14 +95,16 @@ export function LlmManagementView({ projectId }: { projectId: string }) {
             </TabsTrigger>
           ))}
         </TabsList>
-        <ModelSelector
-          models={models}
-          providers={providers}
-          selectedModel={effectiveDefault}
-          onSelect={(m) => {
-            if (m) void modelDefaults.setAccountDefault(m);
-          }}
-        />
+        {canWrite ? (
+          <ModelSelector
+            models={models}
+            providers={providers}
+            selectedModel={effectiveDefault}
+            onSelect={(m) => {
+              if (m) void modelDefaults.setAccountDefault(m);
+            }}
+          />
+        ) : null}
       </div>
 
       {/* min-h-0 lets each panel actually shrink inside the flex column so
@@ -107,6 +116,7 @@ export function LlmManagementView({ projectId }: { projectId: string }) {
           open={open}
           onOpenChange={() => {}}
           defaultTab={llmProvidersTab}
+          canWrite={canWrite}
         />
       </TabsContent>
       <TabsContent value="overview" className="min-h-0 overflow-y-auto">
@@ -116,10 +126,10 @@ export function LlmManagementView({ projectId }: { projectId: string }) {
         <GatewayLogs projectId={projectId} />
       </TabsContent>
       <TabsContent value="budgets" className="min-h-0 overflow-y-auto">
-        <GatewayBudgets projectId={projectId} />
+        <GatewayBudgets projectId={projectId} canWrite={canWrite} />
       </TabsContent>
       <TabsContent value="keys" className="min-h-0 overflow-y-auto">
-        <GatewayKeys projectId={projectId} />
+        <GatewayKeys projectId={projectId} canWrite={canWrite} />
       </TabsContent>
     </Tabs>
   );

--- a/apps/web/src/features/workspace/customize/sections/llm-provider/catalog-tab.tsx
+++ b/apps/web/src/features/workspace/customize/sections/llm-provider/catalog-tab.tsx
@@ -24,12 +24,14 @@ export function CatalogTab({
   search,
   subview,
   setSubview,
+  canWrite = false,
 }: {
   projectId: string;
   connectedIds: Set<string>;
   search: string;
   subview: CatalogSubview;
   setSubview: (next: CatalogSubview) => void;
+  canWrite?: boolean;
 }) {
   const tHardcodedUi = useTranslations('hardcodedUi');
   const filtered = useMemo(() => {
@@ -43,6 +45,13 @@ export function CatalogTab({
     );
   }, [search]);
 
+  // Read-only members can browse the list/detail but can't reach the write
+  // flows; fold connect/custom back to the list so a POST is never attempted.
+  if (!canWrite && (subview.kind === 'connect' || subview.kind === 'custom')) {
+    setSubview({ kind: 'list' });
+    return null;
+  }
+
   if (subview.kind === 'detail') {
     const provider = LLM_PROVIDER_BY_ID.get(subview.providerId);
     if (!provider) {
@@ -53,6 +62,7 @@ export function CatalogTab({
       <ProviderDetail
         provider={provider}
         isConnected={connectedIds.has(provider.id)}
+        canWrite={canWrite}
         onBack={() => setSubview({ kind: 'list' })}
         onConnect={() => setSubview({ kind: 'connect', providerId: provider.id })}
       />
@@ -87,22 +97,24 @@ export function CatalogTab({
 
   return (
     <div className="space-y-3 px-5 pt-3 pb-4">
-      <button type="button" className={`${ROW} border-dashed`} onClick={() => setSubview({ kind: 'custom' })}>
-        <span className="border-border/60 text-muted-foreground/70 flex size-9 shrink-0 items-center justify-center rounded-sm border border-dashed">
-          <Plus className="size-4 shrink-0" />
-        </span>
-        <div className="min-w-0 flex-1">
-          <div className="text-foreground truncate text-sm font-medium">
-            {tHardcodedUi.raw('componentsProjectsProjectProviderModal.line492JsxTextCustomProvider')}
+      {canWrite && (
+        <button type="button" className={`${ROW} border-dashed`} onClick={() => setSubview({ kind: 'custom' })}>
+          <span className="border-border/60 text-muted-foreground/70 flex size-9 shrink-0 items-center justify-center rounded-sm border border-dashed">
+            <Plus className="size-4 shrink-0" />
+          </span>
+          <div className="min-w-0 flex-1">
+            <div className="text-foreground truncate text-sm font-medium">
+              {tHardcodedUi.raw('componentsProjectsProjectProviderModal.line492JsxTextCustomProvider')}
+            </div>
+            <p className="text-muted-foreground mt-0.5 truncate text-xs">
+              {tHardcodedUi.raw(
+                'componentsProjectsProjectProviderModal.line495JsxTextConnectAnyOpenaiCompatibleEndpointWithYourOwn',
+              )}
+            </p>
           </div>
-          <p className="text-muted-foreground mt-0.5 truncate text-xs">
-            {tHardcodedUi.raw(
-              'componentsProjectsProjectProviderModal.line495JsxTextConnectAnyOpenaiCompatibleEndpointWithYourOwn',
-            )}
-          </p>
-        </div>
-        <ChevronRight className="text-muted-foreground/40 size-4 shrink-0 transition-transform group-hover:translate-x-0.5" />
-      </button>
+          <ChevronRight className="text-muted-foreground/40 size-4 shrink-0 transition-transform group-hover:translate-x-0.5" />
+        </button>
+      )}
 
       {filtered.length === 0 ? (
         <EmptyState size="sm" title={search ? `No providers match "${search}"` : 'No providers'} />
@@ -145,11 +157,13 @@ export function CatalogTab({
 function ProviderDetail({
   provider,
   isConnected,
+  canWrite,
   onBack,
   onConnect,
 }: {
   provider: LlmProviderEntry;
   isConnected: boolean;
+  canWrite: boolean;
   onBack: () => void;
   onConnect: () => void;
 }) {
@@ -188,9 +202,11 @@ function ProviderDetail({
             {models.length === 1 ? '' : 's'}
           </p>
         </div>
-        <Button size="sm" className="shrink-0" onClick={onConnect}>
-          {isConnected ? 'Reconnect' : 'Connect'}
-        </Button>
+        {canWrite && (
+          <Button size="sm" className="shrink-0" onClick={onConnect}>
+            {isConnected ? 'Reconnect' : 'Connect'}
+          </Button>
+        )}
       </div>
 
       {helpHostname && provider.helpUrl && (

--- a/apps/web/src/features/workspace/customize/sections/llm-provider/connected-tab.tsx
+++ b/apps/web/src/features/workspace/customize/sections/llm-provider/connected-tab.tsx
@@ -23,11 +23,13 @@ export function ConnectedTab({
   connectedProviders,
   search,
   onAddProvider,
+  canWrite = false,
 }: {
   projectId: string;
   connectedProviders: LlmProviderEntry[];
   search: string;
   onAddProvider: () => void;
+  canWrite?: boolean;
 }) {
   const tHardcodedUi = useTranslations('hardcodedUi');
   const queryClient = useQueryClient();
@@ -78,9 +80,13 @@ export function ConnectedTab({
             'componentsProjectsProjectProviderModal.line300JsxTextNoProvidersConnectedYet',
           )}
           action={
-            <Button variant="outline" size="sm" onClick={onAddProvider}>
-              {tHardcodedUi.raw('componentsProjectsProjectProviderModal.line302JsxTextAddProvider')}
-            </Button>
+            canWrite ? (
+              <Button variant="outline" size="sm" onClick={onAddProvider}>
+                {tHardcodedUi.raw(
+                  'componentsProjectsProjectProviderModal.line302JsxTextAddProvider',
+                )}
+              </Button>
+            ) : undefined
           }
         />
       </div>
@@ -130,7 +136,7 @@ export function ConnectedTab({
                     : `${providerCredentialSummary(provider)} · ${provider.models.length} model${provider.models.length === 1 ? '' : 's'}`}
                 </p>
               </div>
-              {!provider.managed && (
+              {canWrite && !provider.managed && (
                 <Hint label="Disconnect">
                   <Button
                     type="button"

--- a/apps/web/src/features/workspace/customize/sections/llm-provider/llm-provider-modal.tsx
+++ b/apps/web/src/features/workspace/customize/sections/llm-provider/llm-provider-modal.tsx
@@ -36,6 +36,7 @@ export function ProjectProviderModal({
   initialProviderId,
   asPanel = false,
   allowedTabs,
+  canWrite = false,
 }: ProjectProviderModalProps) {
   const tHardcodedUi = useTranslations('hardcodedUi');
   const { secretsQuery, connectedProviders, llmGatewayEnabled } = useConnectedProviders(
@@ -44,9 +45,14 @@ export function ProjectProviderModal({
   );
   const hasConnections = connectedProviders.length > 0;
 
+  // Read-only members never reach the catalog (its detail → connect forms POST
+  // secrets and would 403); fold any attempt to land there back to Connected.
   const clampTab = useCallback(
-    (t: ActiveTab): ActiveTab => (allowedTabs && !allowedTabs.includes(t) ? allowedTabs[0] : t),
-    [allowedTabs],
+    (t: ActiveTab): ActiveTab => {
+      const resolved = allowedTabs && !allowedTabs.includes(t) ? allowedTabs[0] : t;
+      return !canWrite && resolved === 'catalog' ? 'connected' : resolved;
+    },
+    [allowedTabs, canWrite],
   );
 
   const [activeTab, setActiveTab] = useState<ActiveTab>(() =>
@@ -57,7 +63,7 @@ export function ProjectProviderModal({
 
   useEffect(() => {
     if (open) {
-      if (initialProviderId) {
+      if (initialProviderId && canWrite) {
         setActiveTab(clampTab('catalog'));
         setSubview({ kind: 'connect', providerId: initialProviderId });
       } else {
@@ -84,7 +90,8 @@ export function ProjectProviderModal({
         ? 'Search models...'
         : 'Search providers...';
 
-  const showTab = (t: ActiveTab) => !allowedTabs || allowedTabs.includes(t);
+  const showTab = (t: ActiveTab) =>
+    (!allowedTabs || allowedTabs.includes(t)) && (canWrite || t !== 'catalog');
   const showTabBar = !allowedTabs || allowedTabs.length > 1;
 
   const body = (
@@ -152,6 +159,7 @@ export function ProjectProviderModal({
                 projectId={projectId}
                 connectedProviders={connectedProviders}
                 search={search}
+                canWrite={canWrite}
                 onAddProvider={() => switchTab('catalog')}
               />
             </TabsContent>
@@ -163,6 +171,7 @@ export function ProjectProviderModal({
                 search={search}
                 subview={subview}
                 setSubview={setSubview}
+                canWrite={canWrite}
               />
             </TabsContent>
 

--- a/apps/web/src/features/workspace/customize/sections/llm-provider/types.ts
+++ b/apps/web/src/features/workspace/customize/sections/llm-provider/types.ts
@@ -14,6 +14,12 @@ export interface ProjectProviderModalProps {
   initialProviderId?: string;
   asPanel?: boolean;
   allowedTabs?: ActiveTab[];
+  /**
+   * Read-only members see connected providers + catalog but not the
+   * add/connect/remove controls (which POST and would 403). Fails safe: a
+   * missing value is treated as read-only.
+   */
+  canWrite?: boolean;
 }
 
 export interface CustomFormState {

--- a/apps/web/src/features/workspace/customize/sections/view/agents-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/agents-view.tsx
@@ -14,7 +14,9 @@ import {
 import { formatMode } from '@/features/workspace/customize/shared/utils';
 import { useModelDefaults } from '@/hooks/opencode/use-model-defaults';
 import { useOpenCodeProviders } from '@/hooks/opencode/use-opencode-sessions';
+import { PROJECT_ACTIONS } from '@/lib/project-actions';
 import { toast } from '@/lib/toast';
+import { useProjectCan } from '@/lib/use-project-can';
 import { cn } from '@/lib/utils';
 import {
   type AgentGrantSet,
@@ -33,12 +35,14 @@ import { useEffect, useMemo, useState } from 'react';
 type Agent = ProjectConfigSummary['agents'][number];
 
 export function AgentsView({ projectId }: { projectId: string }) {
+  const canWrite = useProjectCan(projectId, PROJECT_ACTIONS.PROJECT_AGENT_WRITE).allowed === true;
   return (
     <ConfigEntityView<Agent>
       projectId={projectId}
       kind="agent"
       noun="agent"
       layout="split"
+      canWrite={canWrite}
       title="Agents"
       searchPlaceholder="Search agents"
       emptyIcon={Bot}

--- a/apps/web/src/features/workspace/customize/sections/view/changes-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/changes-view.tsx
@@ -22,6 +22,8 @@ import {
 } from '@/features/project-files/hooks/use-change-requests';
 import { useCommits } from '@/features/project-files/hooks/use-commits';
 import { getProject, type ProjectCommit } from '@kortix/sdk/projects-client';
+import { PROJECT_ACTIONS } from '@/lib/project-actions';
+import { useProjectCan } from '@/lib/use-project-can';
 import { cn } from '@/lib/utils';
 import {
   Check,
@@ -127,7 +129,15 @@ function CheckpointRow({
   );
 }
 
-function ChangeRequestRow({ cr, onOpen }: { cr: ChangeRequest; onOpen: (crId: string) => void }) {
+function ChangeRequestRow({
+  cr,
+  onOpen,
+  canAct,
+}: {
+  cr: ChangeRequest;
+  onOpen: (crId: string) => void;
+  canAct: boolean;
+}) {
   const merge = useMergeChangeRequest();
   const close = useCloseChangeRequest();
   const reopen = useReopenChangeRequest();
@@ -189,7 +199,7 @@ function ChangeRequestRow({ cr, onOpen }: { cr: ChangeRequest; onOpen: (crId: st
         </span>
       </button>
 
-      {cr.status === 'open' && (
+      {canAct && cr.status === 'open' && (
         <div className="flex shrink-0 items-center gap-2">
           <Button variant="ghost" size="sm" onClick={onClose} disabled={busy}>
             Dismiss
@@ -200,7 +210,7 @@ function ChangeRequestRow({ cr, onOpen }: { cr: ChangeRequest; onOpen: (crId: st
           </Button>
         </div>
       )}
-      {cr.status === 'closed' && (
+      {canAct && cr.status === 'closed' && (
         <Button variant="secondary" size="sm" onClick={onReopen} disabled={busy}>
           Reopen
         </Button>
@@ -214,16 +224,18 @@ function TimelineRow({
   index,
   onOpenCheckpoint,
   onOpenCr,
+  canAct,
 }: {
   item: TimelineItem;
   index: number;
   onOpenCheckpoint: (sha: string) => void;
   onOpenCr: (crId: string) => void;
+  canAct: boolean;
 }) {
   if (item.kind === 'checkpoint') {
     return <CheckpointRow commit={item.commit} index={index} onOpen={onOpenCheckpoint} />;
   }
-  return <ChangeRequestRow cr={item.cr} onOpen={onOpenCr} />;
+  return <ChangeRequestRow cr={item.cr} onOpen={onOpenCr} canAct={canAct} />;
 }
 
 function ListSkeleton({ rows = 6 }: { rows?: number }) {
@@ -253,10 +265,18 @@ export function ChangesView({ projectId }: { projectId: string }) {
     staleTime: 60_000,
   });
   const defaultBranch = projectQuery.data?.default_branch ?? '';
+  // Apply/Dismiss/Reopen assert project.gitops.push server-side; a read-only role
+  // (gitops.read but not gitops.push) still SEES the change list + diffs, just no
+  // action buttons that would 403. Fails safe: false until the probe resolves.
+  const canAct = useProjectCan(projectId, PROJECT_ACTIONS.PROJECT_GITOPS_PUSH).allowed === true;
 
   return (
     <ProjectFilesProvider value={{ projectId, ref: defaultBranch, defaultBranch }}>
-      <ChangesTimeline defaultBranch={defaultBranch} projectLoading={projectQuery.isLoading} />
+      <ChangesTimeline
+        defaultBranch={defaultBranch}
+        projectLoading={projectQuery.isLoading}
+        canAct={canAct}
+      />
     </ProjectFilesProvider>
   );
 }
@@ -264,9 +284,11 @@ export function ChangesView({ projectId }: { projectId: string }) {
 function ChangesTimeline({
   defaultBranch,
   projectLoading,
+  canAct,
 }: {
   defaultBranch: string;
   projectLoading: boolean;
+  canAct: boolean;
 }) {
   const [selectedSha, setSelectedSha] = useState<string | null>(null);
   const [detailCrId, setDetailCrId] = useState<string | null>(null);
@@ -381,6 +403,7 @@ function ChangesTimeline({
                     index={i}
                     onOpenCheckpoint={setSelectedSha}
                     onOpenCr={setDetailCrId}
+                    canAct={canAct}
                   />
                 ))}
               </ul>

--- a/apps/web/src/features/workspace/customize/sections/view/channels-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/channels-view.tsx
@@ -65,6 +65,8 @@ import {
   listProjectAccess,
   type ProjectConfigSummary,
 } from '@kortix/sdk/projects-client';
+import { PROJECT_ACTIONS } from '@/lib/project-actions';
+import { useProjectCan } from '@/lib/use-project-can';
 import { cn } from '@/lib/utils';
 import { Check, CheckCircleSolid, ExternalLinkSolid } from '@mynaui/icons-react';
 import { Copy, Mail, MessageSquare, X } from 'lucide-react';
@@ -93,6 +95,8 @@ export function ChannelsView({ projectId }: { projectId: string | null }) {
   const loading =
     loadingInstall || loadingMode || projectQuery.isLoading || (emailChannelEnabled && loadingEmail);
   const oauthInstallUrl = mode?.oauth_available ? mode.install_url : null;
+  const canWrite =
+    useProjectCan(projectId ?? undefined, PROJECT_ACTIONS.PROJECT_CONNECTOR_WRITE).allowed === true;
 
   return (
     <CustomizeSectionWrapper
@@ -101,7 +105,7 @@ export function ChannelsView({ projectId }: { projectId: string | null }) {
         'autoComponentsProjectsCustomizeSectionsChannelsViewJsxTextRunThisb83f74db',
       )}
       action={
-        projectId && !loading && !install && oauthInstallUrl ? (
+        canWrite && projectId && !loading && !install && oauthInstallUrl ? (
           <Button size="sm" variant="secondary" asChild>
             <Link href={oauthInstallUrl} target="_blank" rel="noopener noreferrer">
               {tI18nHardcoded.raw(
@@ -168,11 +172,13 @@ export function ChannelsView({ projectId }: { projectId: string | null }) {
                   projectId={projectId}
                   installation={install ?? null}
                   oauthInstallUrl={oauthInstallUrl}
+                  canWrite={canWrite}
                 />
                 {emailChannelEnabled ? (
                   <EmailChannelRow
                     projectId={projectId}
                     installation={emailInstall ?? null}
+                    canWrite={canWrite}
                   />
                 ) : null}
               </TableBody>
@@ -199,7 +205,9 @@ export function ChannelsView({ projectId }: { projectId: string | null }) {
               <BringYourOwnPanel projectId={projectId} />
             ) : null}
 
-            {install ? <ChannelBindingsSection projectId={projectId} /> : null}
+            {install ? (
+              <ChannelBindingsSection projectId={projectId} canWrite={canWrite} />
+            ) : null}
           </>
         )}
       </div>
@@ -213,7 +221,13 @@ export function ChannelsView({ projectId }: { projectId: string | null }) {
  * the only other way to change these is the in-Slack `/kortix agent|model|policy`
  * commands; this edits the same row through `PATCH …/channels/bindings/:id`.
  */
-function ChannelBindingsSection({ projectId }: { projectId: string }) {
+function ChannelBindingsSection({
+  projectId,
+  canWrite,
+}: {
+  projectId: string;
+  canWrite: boolean;
+}) {
   const bindingsQuery = useChannelBindings(projectId);
   const bindings = bindingsQuery.data?.bindings ?? [];
 
@@ -250,6 +264,7 @@ function ChannelBindingsSection({ projectId }: { projectId: string }) {
               projectId={projectId}
               binding={b}
               projectDefaultAgent={bindingsQuery.data?.projectDefaultAgent ?? null}
+              canWrite={canWrite}
             />
           ))}
         </TableBody>
@@ -271,17 +286,22 @@ function ChannelBindingTableRow({
   projectId,
   binding,
   projectDefaultAgent,
+  canWrite,
 }: {
   projectId: string;
   binding: ChannelBinding;
   projectDefaultAgent: string | null;
+  canWrite: boolean;
 }) {
   const accessQuery = useQuery({
     queryKey: ['project-access', projectId],
     queryFn: () => listProjectAccess(projectId),
     staleTime: 20_000,
   });
-  const canManage = Boolean(accessQuery.data?.can_manage);
+  // `can_manage` is the coarse project-manage flag; AND it with the real
+  // connector write leaf so a READ-only connector role can't edit bindings
+  // (the PATCH route asserts project.connector.write and would 403).
+  const canManage = Boolean(accessQuery.data?.can_manage) && canWrite;
 
   const detailQuery = useQuery({
     queryKey: ['project-detail', projectId],
@@ -415,10 +435,12 @@ function SlackChannelRow({
   projectId,
   installation,
   oauthInstallUrl,
+  canWrite,
 }: {
   projectId: string;
   installation: SlackInstallation | null;
   oauthInstallUrl: string | null;
+  canWrite: boolean;
 }) {
   const tI18nHardcoded = useTranslations('hardcodedUi');
   const disconnect = useDisconnectSlack();
@@ -449,7 +471,7 @@ function SlackChannelRow({
         {connected ? (installation?.workspaceName ?? installation?.workspaceId ?? '—') : '—'}
       </TableCell>
       <TableCell>
-        {connected ? (
+        {!canWrite ? null : connected ? (
           confirming ? (
             <div className="flex items-center justify-end gap-1">
               <Button variant="ghost" size="sm" onClick={() => setConfirming(false)}>
@@ -497,9 +519,11 @@ function SlackChannelRow({
 function EmailChannelRow({
   projectId,
   installation,
+  canWrite,
 }: {
   projectId: string;
   installation: EmailInstallation | null;
+  canWrite: boolean;
 }) {
   const disconnect = useDisconnectEmail();
   const [connectOpen, setConnectOpen] = useState(false);
@@ -535,7 +559,7 @@ function EmailChannelRow({
           )}
         </TableCell>
         <TableCell>
-          {connected ? (
+          {!canWrite ? null : connected ? (
             confirming ? (
               <div className="flex items-center justify-end gap-1">
                 <Button variant="ghost" size="sm" onClick={() => setConfirming(false)}>

--- a/apps/web/src/features/workspace/customize/sections/view/commands-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/commands-view.tsx
@@ -4,17 +4,21 @@ import {
   type ConfigEntity,
   ConfigEntityView,
 } from '@/features/workspace/customize/sections/component/config-entity-view';
+import { PROJECT_ACTIONS } from '@/lib/project-actions';
+import { useProjectCan } from '@/lib/use-project-can';
 import { SquareSlash } from 'lucide-react';
 
 type Command = ConfigEntity;
 
 export function CommandsView({ projectId }: { projectId: string }) {
+  const canWrite = useProjectCan(projectId, PROJECT_ACTIONS.PROJECT_COMMAND_WRITE).allowed === true;
   return (
     <ConfigEntityView<Command>
       projectId={projectId}
       kind="command"
       noun="command"
       layout="split"
+      canWrite={canWrite}
       title="Commands"
       searchPlaceholder="Search commands"
       emptyIcon={SquareSlash}

--- a/apps/web/src/features/workspace/customize/sections/view/computers-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/computers-view.tsx
@@ -1,7 +1,11 @@
 'use client';
 
 import { TunnelOverview } from '@/features/tunnel/tunnel-overview';
+import { PROJECT_ACTIONS } from '@/lib/project-actions';
+import { useProjectCan } from '@/lib/use-project-can';
 
-export function ComputersView({ projectId: _projectId }: { projectId: string }) {
-  return <TunnelOverview />;
+export function ComputersView({ projectId }: { projectId: string }) {
+  const canWrite =
+    useProjectCan(projectId, PROJECT_ACTIONS.PROJECT_CONNECTOR_WRITE).allowed === true;
+  return <TunnelOverview canWrite={canWrite} />;
 }

--- a/apps/web/src/features/workspace/customize/sections/view/dev-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/dev-view.tsx
@@ -24,6 +24,8 @@ import { Icon } from '@/features/icon/icon';
 import { ErrorState } from '@/features/layout/section/error-state';
 import { useCopy } from '@/hooks/use-copy';
 import { getProject, inviteRepoCollaborator, isManagedGithubProject } from '@kortix/sdk/projects-client';
+import { PROJECT_ACTIONS } from '@/lib/project-actions';
+import { useProjectCan } from '@/lib/use-project-can';
 import { cn } from '@/lib/utils';
 import CustomizeSectionWrapper from '../component/section-wrapper';
 
@@ -36,6 +38,11 @@ export function DevView({ projectId }: { projectId: string }) {
   });
 
   const project = projectQuery.data;
+  // The GitHub-invite form calls inviteRepoCollaborator, which asserts
+  // project.write server-side. A read-only role (project.read only) still sees the
+  // whole dev walkthrough — just not the invite control that would 403. Fails safe:
+  // false until the probe resolves.
+  const canWrite = useProjectCan(projectId, PROJECT_ACTIONS.PROJECT_WRITE).allowed === true;
 
   return (
     <CustomizeSectionWrapper
@@ -68,7 +75,7 @@ export function DevView({ projectId }: { projectId: string }) {
         />
       )}
 
-      {project && <DevSteps project={project} />}
+      {project && <DevSteps project={project} canWrite={canWrite} />}
     </CustomizeSectionWrapper>
   );
 }
@@ -79,7 +86,13 @@ type DevStep = {
   content: ReactNode;
 };
 
-function DevSteps({ project }: { project: Awaited<ReturnType<typeof getProject>> }) {
+function DevSteps({
+  project,
+  canWrite,
+}: {
+  project: Awaited<ReturnType<typeof getProject>>;
+  canWrite: boolean;
+}) {
   const tI18nHardcoded = useTranslations('hardcodedUi');
   const cloneUrl = cloneUrlFor(project.repo_url);
   const repoDir = repoDirFor(project.repo_url) || 'my-project';
@@ -88,7 +101,9 @@ function DevSteps({ project }: { project: Awaited<ReturnType<typeof getProject>>
 
   const steps: DevStep[] = [];
 
-  if (managed) {
+  // The invite step is the only WRITE surface in this walkthrough; hide it for
+  // read-only roles so they don't hit a 403 on submit. The rest stays visible.
+  if (managed && canWrite) {
     steps.push({
       title: tI18nHardcoded.raw(
         'autoComponentsProjectsCustomizeSectionsDevViewJsxAttrTitleGetd1e11afa',

--- a/apps/web/src/features/workspace/customize/sections/view/gateway/gateway-budgets.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/gateway/gateway-budgets.tsx
@@ -72,7 +72,13 @@ type EditTarget =
   | { scope: 'project' }
   | { scope: 'member'; subjectUserId: string; email: string | null };
 
-export function GatewayBudgets({ projectId }: { projectId: string }) {
+export function GatewayBudgets({
+  projectId,
+  canWrite = false,
+}: {
+  projectId: string;
+  canWrite?: boolean;
+}) {
   const { data } = useGatewayBudgets(projectId);
   const setBudget = useSetGatewayBudget(projectId);
   const delBudget = useDeleteGatewayBudget(projectId);
@@ -123,9 +129,11 @@ export function GatewayBudgets({ projectId }: { projectId: string }) {
           title="Project budget"
           description="Cap total spend across everyone in this project's gateway"
           action={
-            <Button size="sm" variant="outline" onClick={() => setEditing({ scope: 'project' })}>
-              {projectBudget ? 'Edit' : 'Set budget'}
-            </Button>
+            canWrite ? (
+              <Button size="sm" variant="outline" onClick={() => setEditing({ scope: 'project' })}>
+                {projectBudget ? 'Edit' : 'Set budget'}
+              </Button>
+            ) : undefined
           }
         >
           {projectBudget ? (
@@ -154,15 +162,17 @@ export function GatewayBudgets({ projectId }: { projectId: string }) {
                     </span>
                   </div>
                   <Meter spent={projectSpend} limit={projectBudget.limit_usd} />
-                  <div className="flex justify-end">
-                    <button
-                      type="button"
-                      onClick={() => remove(projectBudget.budget_id)}
-                      className="text-xs text-muted-foreground transition-colors hover:text-foreground"
-                    >
-                      Remove budget
-                    </button>
-                  </div>
+                  {canWrite && (
+                    <div className="flex justify-end">
+                      <button
+                        type="button"
+                        onClick={() => remove(projectBudget.budget_id)}
+                        className="text-xs text-muted-foreground transition-colors hover:text-foreground"
+                      >
+                        Remove budget
+                      </button>
+                    </div>
+                  )}
                 </div>
               );
             })()
@@ -191,6 +201,7 @@ export function GatewayBudgets({ projectId }: { projectId: string }) {
                   member={m}
                   maxCost={Math.max(1e-9, ...members.map((x) => x.cost))}
                   budget={memberBudget(m.user_id)}
+                  canWrite={canWrite}
                   onSetCap={() =>
                     m.user_id &&
                     setEditing({ scope: 'member', subjectUserId: m.user_id, email: m.email })
@@ -238,12 +249,14 @@ function MemberRow({
   member,
   maxCost,
   budget,
+  canWrite,
   onSetCap,
   onRemove,
 }: {
   member: GatewayMemberSpend;
   maxCost: number;
   budget: GatewayBudgetRow | null;
+  canWrite: boolean;
   onSetCap: () => void;
   onRemove: (id: string) => void;
 }) {
@@ -271,19 +284,20 @@ function MemberRow({
           </div>
         )}
       </div>
-      {budget ? (
-        <button
-          type="button"
-          onClick={() => onRemove(budget.budget_id)}
-          className="shrink-0 text-xs text-muted-foreground transition-colors hover:text-foreground"
-        >
-          Remove
-        </button>
-      ) : (
-        <Button size="sm" variant="ghost" className="shrink-0" onClick={onSetCap}>
-          Set cap
-        </Button>
-      )}
+      {canWrite &&
+        (budget ? (
+          <button
+            type="button"
+            onClick={() => onRemove(budget.budget_id)}
+            className="shrink-0 text-xs text-muted-foreground transition-colors hover:text-foreground"
+          >
+            Remove
+          </button>
+        ) : (
+          <Button size="sm" variant="ghost" className="shrink-0" onClick={onSetCap}>
+            Set cap
+          </Button>
+        ))}
     </div>
   );
 }

--- a/apps/web/src/features/workspace/customize/sections/view/gateway/gateway-keys.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/gateway/gateway-keys.tsx
@@ -45,7 +45,13 @@ function fmtDate(s: string | null): string {
   });
 }
 
-export function GatewayKeys({ projectId }: { projectId: string }) {
+export function GatewayKeys({
+  projectId,
+  canWrite = false,
+}: {
+  projectId: string;
+  canWrite?: boolean;
+}) {
   const { data, isError } = useGatewayKeys(projectId);
   const createKey = useCreateGatewayKey(projectId);
   const revokeKey = useRevokeGatewayKey(projectId);
@@ -93,9 +99,11 @@ export function GatewayKeys({ projectId }: { projectId: string }) {
                 logged and billed here.
               </p>
             </div>
-            <Button size="sm" className="shrink-0" onClick={() => setCreating(true)}>
-              Create key
-            </Button>
+            {canWrite && (
+              <Button size="sm" className="shrink-0" onClick={() => setCreating(true)}>
+                Create key
+              </Button>
+            )}
           </div>
 
           {keys.length === 0 ? (
@@ -105,9 +113,11 @@ export function GatewayKeys({ projectId }: { projectId: string }) {
               title="No keys yet"
               description="Create a project-scoped key to call the gateway from outside a Kortix session."
               action={
-                <Button variant="outline" size="sm" onClick={() => setCreating(true)}>
-                  Create key
-                </Button>
+                canWrite ? (
+                  <Button variant="outline" size="sm" onClick={() => setCreating(true)}>
+                    Create key
+                  </Button>
+                ) : undefined
               }
             />
           ) : (
@@ -139,7 +149,7 @@ export function GatewayKeys({ projectId }: { projectId: string }) {
                         <span>last used {fmtDate(k.last_used_at)}</span>
                       </InlineMeta>
                     </div>
-                    {active && (
+                    {active && canWrite && (
                       <DropdownMenu>
                         <DropdownMenuTrigger asChild>
                           <Button

--- a/apps/web/src/features/workspace/customize/sections/view/meet-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/meet-view.tsx
@@ -23,11 +23,15 @@ import {
   useSetMeetBotName,
   useSetMeetVoice,
 } from '@/hooks/channels/use-meet-voices';
+import { PROJECT_ACTIONS } from '@/lib/project-actions';
+import { useProjectCan } from '@/lib/use-project-can';
 
 export function MeetView({ projectId }: { projectId: string }) {
   const voicesQuery = useMeetVoices(projectId);
   const setVoice = useSetMeetVoice();
   const setBotName = useSetMeetBotName();
+  const canWrite =
+    useProjectCan(projectId, PROJECT_ACTIONS.PROJECT_CONNECTOR_WRITE).allowed === true;
   const [previewing, setPreviewing] = useState<string | null>(null);
   const [draftName, setDraftName] = useState<string | null>(null);
 
@@ -98,6 +102,10 @@ export function MeetView({ projectId }: { projectId: string }) {
         >
           {voicesQuery.isLoading ? (
             <Skeleton className="h-10 w-full rounded-lg" />
+          ) : !canWrite ? (
+            <p className="text-foreground text-sm font-medium">
+              {(data?.bot_name ?? '').trim() || defaultBotName}
+            </p>
           ) : (
             <div className="flex items-center gap-2">
               <Input
@@ -131,6 +139,17 @@ export function MeetView({ projectId }: { projectId: string }) {
             <Skeleton className="h-11 w-full rounded-lg" />
           ) : voices.length === 0 ? (
             <p className="text-muted-foreground text-sm">No voices available.</p>
+          ) : !canWrite ? (
+            <p className="text-muted-foreground text-sm">
+              {selectedVoice ? (
+                <>
+                  <span className="text-foreground font-medium">{selectedVoice.name}</span> —{' '}
+                  {selectedVoice.desc}
+                </>
+              ) : (
+                'No voice selected.'
+              )}
+            </p>
           ) : (
             <div className="space-y-3">
               <div className="flex items-center gap-2">

--- a/apps/web/src/features/workspace/customize/sections/view/review-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/review-view.tsx
@@ -2,6 +2,8 @@
 
 import { ProjectFilesProvider } from '@/features/project-files';
 import { ReviewCenterConnected } from '@/features/review-center/review-center-connected';
+import { PROJECT_ACTIONS } from '@/lib/project-actions';
+import { useProjectCan } from '@/lib/use-project-can';
 import { getProject } from '@kortix/sdk/projects-client';
 import { useQuery } from '@tanstack/react-query';
 
@@ -17,11 +19,17 @@ export function ReviewView({ projectId }: { projectId: string }) {
     staleTime: 60_000,
   });
   const projectName = projectQuery.data?.name ?? '';
+  // Acting on a review item (approve/reject/request-changes, and the bulk act)
+  // asserts project.review.act server-side. A read-only role (review.read only)
+  // still SEES the inbox — ReviewCenterConnected withholds the act handlers so the
+  // ReviewCenter's mutation UI disables itself. Fails safe: false until resolved.
+  const canActReview =
+    useProjectCan(projectId, PROJECT_ACTIONS.PROJECT_REVIEW_ACT).allowed === true;
 
   return (
     <div className="bg-background flex h-full min-h-0 flex-col">
       <ProjectFilesProvider value={{ projectId, ref: '', defaultBranch: '' }}>
-        <ReviewCenterConnected projectName={projectName} />
+        <ReviewCenterConnected projectName={projectName} canAct={canActReview} />
       </ProjectFilesProvider>
     </div>
   );

--- a/apps/web/src/features/workspace/customize/sections/view/secrets-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/secrets-view.tsx
@@ -284,6 +284,7 @@ export function SecretsView({ projectId }: { projectId: string }) {
         projectId={projectId}
         open={providerModalOpen}
         onOpenChange={setProviderModalOpen}
+        canWrite={canManage}
       />
     </>
   );

--- a/apps/web/src/features/workspace/customize/sections/view/settings-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/settings-view.tsx
@@ -50,6 +50,8 @@ import {
   type ProjectDetail,
 } from '@kortix/sdk/projects-client';
 import { refreshProjectProviderState } from '@/hooks/opencode/provider-refresh';
+import { PROJECT_ACTIONS } from '@/lib/project-actions';
+import { useProjectCan } from '@/lib/use-project-can';
 import { TrashSolid } from '@mynaui/icons-react';
 import CustomizeSectionWrapper from '../component/section-wrapper';
 
@@ -66,6 +68,12 @@ export function SettingsView({ projectId }: { projectId: string }) {
 
   const project = projectQuery.data;
   const canManage = project?.effective_project_role === 'manager';
+  // Real per-leaf write cap: a custom role granted project.write edits the
+  // general controls (name/repo/experimental) without being a full manager.
+  // The mutating routes assert project.write, so a READ-only role sees the
+  // section read-only. Archive/danger-zone stays manager-only below.
+  const canWrite = useProjectCan(projectId, PROJECT_ACTIONS.PROJECT_WRITE).allowed === true;
+  const canEdit = canManage || canWrite;
 
   const archiveMutation = useMutation({
     mutationFn: () => archiveProject(projectId),
@@ -103,15 +111,15 @@ export function SettingsView({ projectId }: { projectId: string }) {
 
       {project && (
         <div className="space-y-8">
-          <GeneralProjectCard project={project} canManage={!!canManage} />
-          <RepositoryCard project={project} canManage={!!canManage} />
+          <GeneralProjectCard project={project} canManage={canEdit} />
+          <RepositoryCard project={project} canManage={canEdit} />
           {canManage && (
             <section className="space-y-4">
               <Label>Automation</Label>
-              <TriggersActivationCard projectId={projectId} canManage={!!canManage} />
+              <TriggersActivationCard projectId={projectId} canManage={canEdit} />
             </section>
           )}
-          <ExperimentalCard project={project} canManage={!!canManage} />
+          <ExperimentalCard project={project} canManage={canEdit} />
           {canManage && (
             <section className="space-y-4">
               <Label>
@@ -269,7 +277,7 @@ function RepositoryCard({ project, canManage }: { project: KortixProject; canMan
 
         {managed ? (
           <div className="border-border/60 border-t pt-5">
-            <RepoCollaboratorInvite projectId={project.project_id} />
+            <RepoCollaboratorInvite projectId={project.project_id} canManage={canManage} />
           </div>
         ) : null}
       </div>
@@ -492,7 +500,13 @@ function TriggersActivationCard({
   );
 }
 
-function RepoCollaboratorInvite({ projectId }: { projectId: string }) {
+function RepoCollaboratorInvite({
+  projectId,
+  canManage,
+}: {
+  projectId: string;
+  canManage: boolean;
+}) {
   const tI18nHardcoded = useTranslations('hardcodedUi');
   const [username, setUsername] = useState('');
   const [permission, setPermission] = useState<'read' | 'write'>('write');
@@ -512,6 +526,7 @@ function RepoCollaboratorInvite({ projectId }: { projectId: string }) {
 
   const submit = (e: FormEvent) => {
     e.preventDefault();
+    if (!canManage) return;
     if (username.trim() && !inviteMutation.isPending) inviteMutation.mutate();
   };
 
@@ -528,6 +543,7 @@ function RepoCollaboratorInvite({ projectId }: { projectId: string }) {
         </p>
       </div>
 
+      {canManage ? (
       <form onSubmit={submit}>
         <FieldGroup className="gap-3">
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-[minmax(0,1fr)_8.5rem_auto] sm:items-end sm:gap-x-3">
@@ -581,7 +597,7 @@ function RepoCollaboratorInvite({ projectId }: { projectId: string }) {
               <Button
                 type="submit"
                 className="w-full shrink-0 sm:w-auto"
-                disabled={!username.trim() || inviteMutation.isPending}
+                disabled={!canManage || !username.trim() || inviteMutation.isPending}
               >
                 {inviteMutation.isPending ? <Loading className="size-3.5 animate-spin" /> : null}
                 Add
@@ -590,6 +606,7 @@ function RepoCollaboratorInvite({ projectId }: { projectId: string }) {
           </div>
         </FieldGroup>
       </form>
+      ) : null}
     </div>
   );
 }

--- a/apps/web/src/features/workspace/customize/sections/view/skills-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/skills-view.tsx
@@ -4,17 +4,21 @@ import {
   type ConfigEntity,
   ConfigEntityView,
 } from '@/features/workspace/customize/sections/component/config-entity-view';
+import { PROJECT_ACTIONS } from '@/lib/project-actions';
+import { useProjectCan } from '@/lib/use-project-can';
 import { Sparkles } from 'lucide-react';
 
 type Skill = ConfigEntity;
 
 export function SkillsView({ projectId }: { projectId: string }) {
+  const canWrite = useProjectCan(projectId, PROJECT_ACTIONS.PROJECT_SKILL_WRITE).allowed === true;
   return (
     <ConfigEntityView<Skill>
       projectId={projectId}
       kind="skill"
       noun="skill"
       layout="split"
+      canWrite={canWrite}
       title="Skills"
       searchPlaceholder="Search skills"
       emptyIcon={Sparkles}

--- a/apps/web/src/lib/project-actions.test.ts
+++ b/apps/web/src/lib/project-actions.test.ts
@@ -8,9 +8,8 @@ import {
 // A `can(action)` that returns true for the given allow-list.
 const canFrom = (allowed: string[]) => (action: string) => allowed.includes(action);
 
-// The read leaves a plain `member` (read-only floor) holds — everything READ,
-// nothing WRITE. (Mirrors PROJECT_ROLE_PERMS.member in the backend.)
-const MEMBER_READS = [
+// A generic set of section READ leaves (agents/skills/commands/connectors/etc.).
+const READS = [
   PROJECT_ACTIONS.PROJECT_READ,
   PROJECT_ACTIONS.PROJECT_AGENT_READ,
   PROJECT_ACTIONS.PROJECT_SKILL_READ,
@@ -19,44 +18,48 @@ const MEMBER_READS = [
   PROJECT_ACTIONS.PROJECT_SECRET_READ,
   PROJECT_ACTIONS.PROJECT_TRIGGER_READ,
   PROJECT_ACTIONS.PROJECT_GITOPS_READ,
-  PROJECT_ACTIONS.PROJECT_FILE_READ,
   PROJECT_ACTIONS.PROJECT_MEMBERS_READ,
 ];
 
-describe('isCustomizeSectionVisible — member vs editor+', () => {
-  test('a member (reads only, no customize.write) sees no customize sections', () => {
-    const can = canFrom(MEMBER_READS);
-    expect(isCustomizeSectionVisible('agents', can)).toBe(false);
-    expect(isCustomizeSectionVisible('connectors', can)).toBe(false);
-    expect(isCustomizeSectionVisible('secrets', can)).toBe(false);
-    expect(isCustomizeSectionVisible('schedules', can)).toBe(false);
-    expect(isCustomizeSectionVisible('members', can)).toBe(false);
-    expect(isCustomizeSectionVisible('settings', can)).toBe(false);
-  });
-
-  test('an editor (has customize.write + the read leaves) sees the customization sections', () => {
-    const can = canFrom([...MEMBER_READS, PROJECT_ACTIONS.PROJECT_CUSTOMIZE_WRITE]);
+describe('isCustomizeSectionVisible — gates on the READ leaf, not write', () => {
+  test('a read-only role (read leaves, NO customize.write) STILL SEES the sections (the bug fix)', () => {
+    // The old rule required project.customize.write for every section → a
+    // read-only / granular role saw a blank panel. Now the read leaf is enough.
+    const can = canFrom(READS); // deliberately no customize.write
     expect(isCustomizeSectionVisible('agents', can)).toBe(true);
     expect(isCustomizeSectionVisible('connectors', can)).toBe(true);
     expect(isCustomizeSectionVisible('secrets', can)).toBe(true);
     expect(isCustomizeSectionVisible('schedules', can)).toBe(true);
-    expect(isCustomizeSectionVisible('webhooks', can)).toBe(true);
     expect(isCustomizeSectionVisible('members', can)).toBe(true);
     expect(isCustomizeSectionVisible('settings', can)).toBe(true);
   });
 
-  test('a custom role omitting a specific read leaf still hides just that section (editor+)', () => {
-    const can = canFrom(
-      [...MEMBER_READS, PROJECT_ACTIONS.PROJECT_CUSTOMIZE_WRITE].filter(
-        (a) => a !== PROJECT_ACTIONS.PROJECT_SECRET_READ,
-      ),
-    );
+  test("the reported role (customize.read + secret.read) sees the sections it can read", () => {
+    const can = canFrom([
+      PROJECT_ACTIONS.PROJECT_READ,
+      PROJECT_ACTIONS.PROJECT_CUSTOMIZE_READ,
+      PROJECT_ACTIONS.PROJECT_SECRET_READ,
+    ]);
+    expect(isCustomizeSectionVisible('secrets', can)).toBe(true); // has secret.read
+    expect(isCustomizeSectionVisible('settings', can)).toBe(true); // gates on project.read
+    expect(isCustomizeSectionVisible('agents', can)).toBe(false); // lacks agent.read
+  });
+
+  test('a role omitting a specific read leaf hides just that section', () => {
+    const can = canFrom(READS.filter((a) => a !== PROJECT_ACTIONS.PROJECT_SECRET_READ));
     expect(isCustomizeSectionVisible('agents', can)).toBe(true);
     expect(isCustomizeSectionVisible('secrets', can)).toBe(false); // read leaf omitted
   });
 
-  test('the probe list includes customize.write + is deduped', () => {
-    expect(CUSTOMIZE_SECTION_GATE_ACTIONS).toContain(PROJECT_ACTIONS.PROJECT_CUSTOMIZE_WRITE);
+  test('a role with NO read leaves sees nothing (empty panel, correctly)', () => {
+    const can = canFrom([]);
+    expect(isCustomizeSectionVisible('agents', can)).toBe(false);
+    expect(isCustomizeSectionVisible('secrets', can)).toBe(false);
+    expect(isCustomizeSectionVisible('settings', can)).toBe(false);
+  });
+
+  test('the probe list is READ leaves only (no customize.write) + deduped', () => {
+    expect(CUSTOMIZE_SECTION_GATE_ACTIONS).not.toContain(PROJECT_ACTIONS.PROJECT_CUSTOMIZE_WRITE);
     expect(new Set(CUSTOMIZE_SECTION_GATE_ACTIONS).size).toBe(CUSTOMIZE_SECTION_GATE_ACTIONS.length);
   });
 });

--- a/apps/web/src/lib/project-actions.ts
+++ b/apps/web/src/lib/project-actions.ts
@@ -150,27 +150,28 @@ export const CUSTOMIZE_SECTION_READ_ACTIONS: readonly ProjectAction[] = Array.fr
 
 /**
  * Whether a section is visible in the rail, given the current user's resolved
- * capabilities (`caps[action].allowed`). Customization is an editor+
- * capability, so a section shows only when the user can customize
- * (`project.customize.write`, i.e. editor or manager) AND still holds that
- * section's own read leaf (so a custom role that omits a read leaf keeps
- * hiding just that section). A plain `member` (read-only floor) lacks
- * customize.write → sees none of them. Files is NOT here — it's the
- * standalone /projects/[id]/files page, reachable by any member.
+ * capabilities (`caps[action].allowed`). Visibility gates on the section's own
+ * READ leaf: a role that can READ a section SEES it — read-only if it lacks the
+ * section's WRITE leaf (the mutating controls inside each view gate on
+ * write / can_manage SEPARATELY). This mirrors the read/write split declared in
+ * CUSTOMIZE_SECTION_ACCESS above and the backend's granular capability model —
+ * so a custom role granted e.g. `secret.read` sees the Secrets section
+ * read-only, and a role that omits a read leaf hides just that one section.
+ * (Previously this ALSO required `project.customize.write`, which blanked the
+ * whole panel for every read-only / granular role — the bug this fixes.) This
+ * is a VISIBILITY layer only; the API re-checks every mutation. Files is NOT
+ * here — it's the standalone /projects/[id]/files page, gated on project.file.read.
  */
 export function isCustomizeSectionVisible(
   s: CustomizeSection,
   can: (action: ProjectAction) => boolean,
 ): boolean {
-  const a = CUSTOMIZE_SECTION_ACCESS[s];
-  return can(PROJECT_ACTIONS.PROJECT_CUSTOMIZE_WRITE) && can(a.read);
+  return can(CUSTOMIZE_SECTION_ACCESS[s].read);
 }
 
-/** Distinct actions to probe for section visibility — every read leaf plus the
- *  editor+ `customize.write` gate — in one batched capability call. */
+/** Distinct READ leaves to probe for section visibility — one batched capability
+ *  call over every section the rail might show. (Edit controls inside each
+ *  section gate separately on can_manage / the section's own write leaf.) */
 export const CUSTOMIZE_SECTION_GATE_ACTIONS: readonly ProjectAction[] = Array.from(
-  new Set<ProjectAction>([
-    ...Object.values(CUSTOMIZE_SECTION_ACCESS).map((a) => a.read),
-    PROJECT_ACTIONS.PROJECT_CUSTOMIZE_WRITE,
-  ]),
+  new Set<ProjectAction>(Object.values(CUSTOMIZE_SECTION_ACCESS).map((a) => a.read)),
 );


### PR DESCRIPTION
## The bug

A custom role granted `customize.read` + `secret.read` (and any read-only / granular role) saw a **blank customization page** — empty nav, no content. Root cause: `isCustomizeSectionVisible` gated section visibility on `project.customize.write` (editor+), so a role with READ capabilities but no write failed the gate on **every** section. This directly contradicted the file's own documented design (`read` → visible, `write` → the controls inside).

## The fix

**Visibility now gates on each section's READ leaf** (`project-actions.ts`) — a role sees exactly the sections it can read (Secrets via `secret.read`, Agents via `agent.read`, …). This mirrors the read/write split already declared in `CUSTOMIZE_SECTION_ACCESS` and the backend's granular capability model.

Because sections now render for read-only roles, every section view had to **degrade to a clean read-only view** instead of showing edit buttons that 403. An audit found only 3 of 18 views (Secrets/Members/Sandbox) already did this — the other 15 leaked their controls. Each now gates its mutating controls on the section's **write** capability (`useProjectCan(<write leaf>)`, fail-closed while the probe resolves):

| Area | Gated controls |
|---|---|
| agents / skills / commands | shared `ConfigEntityView` New/Create/Edit |
| connectors | rename/delete, the whole permissions editor, channel connect/disconnect, custom-connector fields |
| channels | Add-to-Slack, connect/disconnect, binding selects |
| settings | edit inputs, experimental/trigger switches, repo-collaborator invite (danger-zone stays manager-only) |
| changes | CR Apply/Dismiss/Reopen |
| review | act / bulk-act handlers |
| dev | repo-access invite form |
| gateway / LLM | budgets (set/cap/remove), keys (create/revoke), providers (add/connect/disconnect) |
| meet, schedules/webhooks, computers/tunnel, upgrade | connect/edit/run controls |

Read-only users still **see all the data** — just without the affordances that would 403. Visibility is a UI layer only; the API re-checks every mutation (this rides on the capability-gate hardening in #4275/#4279/#4282).

## Verification
- `tsc --noEmit` on `apps/web` clean (the real gate — the build ignores type errors).
- `project-actions` (rewritten for the read-leaf model), `customize-sections`, `rail`, `upgrade-view` suites pass (17).
- Regression guard: `ProjectProviderModal`'s two non-gateway callers (`secrets-view`, `model-selector`) get an explicit write value so those admin modals aren't accidentally made read-only.

## ⚠️ Needs your eyes before merge
This is a 31-file UI change I can't run here. Please **verify on dev with the actual role** (customize.read + secret.read): the panel should show the sections that role can read, read-only, with no broken edit buttons — and an editor/manager should still see full controls. I'll merge once you confirm.