### PR TITLE
feat(review-center): render markdown change descriptions properly

### DIFF
--- a/apps/web/src/features/review-center/map.ts
+++ b/apps/web/src/features/review-center/map.ts
@@ -6,6 +6,7 @@
  */
 
 import type { ApiReviewItem, ReviewVerdict } from '@kortix/sdk/projects-client';
+import { looksLikeMarkdown } from './review-markdown';
 import type {
   ApprovalAction,
   ApprovalActionIcon,
@@ -92,12 +93,22 @@ const lines = (s: string): string[] =>
 
 function changeDetail(d: AnyRec, row: ApiReviewItem): ChangeDetail {
   const adv = rec(d.advanced);
+  // A free-form description that's real markdown (agent-written CR bodies
+  // often are) is carried whole and rendered as markdown in the modal —
+  // line-splitting it into checkmark rows would show raw `##`/`**` noise.
+  // Plain text keeps the designed per-line treatment; a native structured
+  // `whatChanged` array always wins.
+  const description = str(d.description);
+  const native = arrOf<string>(d.whatChanged);
+  const descriptionMarkdown =
+    !native && description && looksLikeMarkdown(description) ? description : undefined;
   const whatChanged =
-    arrOf<string>(d.whatChanged) ??
-    (str(d.description) ? lines(str(d.description) as string) : row.summary ? [row.summary] : []);
+    native ??
+    (descriptionMarkdown ? [] : description ? lines(description) : row.summary ? [row.summary] : []);
   return {
     crId: str(d.cr_id),
     whatChanged,
+    descriptionMarkdown,
     impact: str(d.impact) ?? '',
     verification: arrOf<ChangeDetail['verification'][number]>(d.verification) ?? [],
     previewUrl: str(d.previewUrl) ?? str(d.preview_url),

--- a/apps/web/src/features/review-center/review-detail-modal.tsx
+++ b/apps/web/src/features/review-center/review-detail-modal.tsx
@@ -34,6 +34,8 @@ import {
   SparklesSolid,
 } from '@mynaui/icons-react';
 import { useEffect, useRef, useState } from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
 import { ChangeFilesModal } from './change-files';
 import { formatItemAgeLong } from './review-actions';
 import {
@@ -98,6 +100,72 @@ function SectionLabel({ children }: { children: React.ReactNode }) {
   );
 }
 
+/**
+ * Compact markdown for agent-written descriptions (no Shiki/KaTeX/Mermaid —
+ * same lightweight approach as the session QuestionMarkdown). Styled to the
+ * modal's scale: sm body, small semibold headings, muted code chips.
+ */
+function ReviewMarkdown({ content }: { content: string }) {
+  return (
+    <div className="min-w-0 text-sm">
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        components={{
+          h1: ({ children }) => (
+            <h4 className="text-foreground mt-4 mb-1.5 text-sm font-semibold first:mt-0">
+              {children}
+            </h4>
+          ),
+          h2: ({ children }) => (
+            <h4 className="text-foreground mt-4 mb-1.5 text-sm font-semibold first:mt-0">
+              {children}
+            </h4>
+          ),
+          h3: ({ children }) => (
+            <h5 className="text-foreground mt-3 mb-1 text-sm font-medium first:mt-0">{children}</h5>
+          ),
+          p: ({ children }) => (
+            <p className="text-foreground/90 my-1.5 leading-relaxed text-pretty">{children}</p>
+          ),
+          strong: ({ children }) => (
+            <strong className="text-foreground font-semibold">{children}</strong>
+          ),
+          em: ({ children }) => <em>{children}</em>,
+          ul: ({ children }) => <ul className="my-1.5 list-disc space-y-1 pl-5">{children}</ul>,
+          ol: ({ children }) => <ol className="my-1.5 list-decimal space-y-1 pl-5">{children}</ol>,
+          li: ({ children }) => <li className="text-foreground/90 text-pretty">{children}</li>,
+          code: ({ children }) => (
+            <code className="bg-muted rounded px-1 py-0.5 font-mono text-xs">{children}</code>
+          ),
+          pre: ({ children }) => (
+            <pre className="bg-muted my-2 overflow-x-auto rounded-md p-3 font-mono text-xs">
+              {children}
+            </pre>
+          ),
+          a: ({ children, href }) => (
+            <a
+              href={href}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-foreground underline underline-offset-2"
+            >
+              {children}
+            </a>
+          ),
+          blockquote: ({ children }) => (
+            <blockquote className="border-border text-muted-foreground my-2 border-l-2 pl-3">
+              {children}
+            </blockquote>
+          ),
+          hr: () => <hr className="border-border my-3" />,
+        }}
+      >
+        {content}
+      </ReactMarkdown>
+    </div>
+  );
+}
+
 // ── change ────────────────────────────────────────────────────────────────
 function ChangeBody({
   item,
@@ -148,18 +216,24 @@ function ChangeBody({
         </div>
       )}
 
-      {(whatChanged.length > 0 || d.impact) && (
+      {(whatChanged.length > 0 || d.descriptionMarkdown || d.impact) && (
         <div>
           <SectionLabel>What changed</SectionLabel>
-          {whatChanged.length > 0 && (
-            <ul className="space-y-1.5">
-              {whatChanged.map((line) => (
-                <li key={line} className="text-foreground flex items-start gap-2 text-sm">
-                  <Check className="text-kortix-green mt-0.5 size-4 shrink-0" />
-                  <span className="text-pretty">{line}</span>
-                </li>
-              ))}
-            </ul>
+          {/* An agent-written markdown description renders as real markdown;
+              structured/plain-line payloads keep the checkmark treatment. */}
+          {d.descriptionMarkdown ? (
+            <ReviewMarkdown content={d.descriptionMarkdown} />
+          ) : (
+            whatChanged.length > 0 && (
+              <ul className="space-y-1.5">
+                {whatChanged.map((line) => (
+                  <li key={line} className="text-foreground flex items-start gap-2 text-sm">
+                    <Check className="text-kortix-green mt-0.5 size-4 shrink-0" />
+                    <span className="text-pretty">{line}</span>
+                  </li>
+                ))}
+              </ul>
+            )
           )}
           {d.impact && (
             <div className="text-muted-foreground mt-2 text-sm text-pretty">{d.impact}</div>

--- a/apps/web/src/features/review-center/review-markdown.test.ts
+++ b/apps/web/src/features/review-center/review-markdown.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from 'bun:test';
+import type { ApiReviewItem } from '@kortix/sdk/projects-client';
+
+import { mapApiReviewItem } from './map';
+import { looksLikeMarkdown } from './review-markdown';
+import type { ChangeDetail } from './types';
+
+describe('looksLikeMarkdown', () => {
+  test('detects the clear markdown signals', () => {
+    expect(looksLikeMarkdown('## What this changes\nMigrates the manifest.')).toBe(true);
+    expect(looksLikeMarkdown('This has **bold emphasis** in it.')).toBe(true);
+    expect(looksLikeMarkdown('Run `kortix validate` before landing.')).toBe(true);
+    expect(looksLikeMarkdown('```yaml\nagents: {}\n```')).toBe(true);
+    expect(looksLikeMarkdown('See [the docs](https://kortix.com/docs).')).toBe(true);
+    expect(looksLikeMarkdown('1. fetch\n2. rebase\n3. push')).toBe(true);
+  });
+
+  test('plain prose stays plain — the designed checkmark treatment must survive', () => {
+    expect(looksLikeMarkdown('Fixed the header alignment on mobile.')).toBe(false);
+    expect(looksLikeMarkdown('Updated dependencies.\nFixed two flaky tests.')).toBe(false);
+    // Simple dash bullets are common in plain agent output — not enough signal
+    // on their own to switch away from the per-line checkmarks.
+    expect(looksLikeMarkdown('- updated the schema\n- fixed the tests')).toBe(false);
+  });
+
+  test('is not fooled by lookalikes', () => {
+    expect(looksLikeMarkdown('The #4135 PR shipped yesterday.')).toBe(false); // not an ATX heading
+    expect(looksLikeMarkdown('rated 5* by users')).toBe(false);
+    expect(looksLikeMarkdown('')).toBe(false);
+  });
+});
+
+describe('mapApiReviewItem — markdown change descriptions', () => {
+  const changeRow = (description: string): ApiReviewItem =>
+    ({
+      review_item_id: 'rv-1',
+      kind: 'change',
+      title: 'Migrate manifest to v2',
+      summary: 'CR #12',
+      status: 'pending',
+      risk: 'medium',
+      agent: 'Agent',
+      created_at: '2026-07-08T10:00:00.000Z',
+      detail: { cr_id: 'cr-12', base_ref: 'main', head_ref: 'session/x', description },
+    }) as unknown as ApiReviewItem;
+
+  test('a markdown description is carried whole, not line-split into checkmark rows', () => {
+    const md = '## What this changes\nMigrates `kortix.toml` to **kortix.yaml**.';
+    const item = mapApiReviewItem(changeRow(md), 'proj');
+    const d = item.detail as ChangeDetail;
+    expect(d.descriptionMarkdown).toBe(md);
+    expect(d.whatChanged).toEqual([]);
+  });
+
+  test('a plain description keeps the per-line treatment', () => {
+    const item = mapApiReviewItem(changeRow('Updated the schema.\nFixed the tests.'), 'proj');
+    const d = item.detail as ChangeDetail;
+    expect(d.descriptionMarkdown).toBeUndefined();
+    expect(d.whatChanged).toEqual(['Updated the schema.', 'Fixed the tests.']);
+  });
+
+  test('a native structured whatChanged array always wins over markdown detection', () => {
+    const row = changeRow('## ignored');
+    (row.detail as Record<string, unknown>).whatChanged = ['Did the thing'];
+    const d = mapApiReviewItem(row, 'proj').detail as ChangeDetail;
+    expect(d.descriptionMarkdown).toBeUndefined();
+    expect(d.whatChanged).toEqual(['Did the thing']);
+  });
+});

--- a/apps/web/src/features/review-center/review-markdown.ts
+++ b/apps/web/src/features/review-center/review-markdown.ts
@@ -1,0 +1,21 @@
+/**
+ * Markdown detection for free-form review-item descriptions (the thin
+ * Change-Request adapter payload carries whatever prose the agent wrote).
+ * Pure + conservative: plain multi-line text — including simple `-` bullet
+ * lists — must NOT match, so those keep the designed per-line checkmark
+ * treatment; only clear markdown syntax switches the modal to a real
+ * markdown render.
+ */
+
+const MD_SIGNALS: RegExp[] = [
+  /^#{1,6}\s+\S/m, // ATX heading: "## What this changes"
+  /```/, // fenced code block
+  /\*\*[^*\n]+\*\*/, // bold
+  /(^|[^`])`[^`\n]+`([^`]|$)/, // inline code span (not a fence)
+  /\[[^\]\n]+\]\([^)\n]+\)/, // [link](url)
+  /^\s*\d+\.\s+\S/m, // ordered list: "1. step"
+];
+
+export function looksLikeMarkdown(text: string): boolean {
+  return MD_SIGNALS.some((re) => re.test(text));
+}

--- a/apps/web/src/features/review-center/types.ts
+++ b/apps/web/src/features/review-center/types.ts
@@ -59,6 +59,9 @@ export interface RequestedChange {
 export interface ChangeDetail {
   crId?: string; // the underlying Change Request id (connected mode) — enables the live diff
   whatChanged: string[];
+  /** The agent's free-form description when it's real markdown — rendered as
+   *  such in the modal instead of being line-split into `whatChanged` rows. */
+  descriptionMarkdown?: string;
   impact: string;
   verification: { label: string; tone: 'success' | 'warning' | 'neutral' | 'info' }[];
   previewUrl?: string;


### PR DESCRIPTION
Rescues the markdown-rendering commit that landed on the #4325 branch **minutes after you merged it** — it missed the merge, so re-landing it cleanly off current main (verified: cherry-pick applied with zero conflicts, 70/70 review-center tests, `tsc --noEmit` clean on the merged base).

## What it does
Agent-written CR descriptions (like the "Migrate manifest to kortix_version 2" item) were line-split into checkmark rows, showing raw `##` / `**` / backtick noise in the Review Center detail modal.

- **`looksLikeMarkdown`** (new pure helper, conservative): detects real markdown — ATX headings, fenced code, bold, inline code, links, ordered lists. Plain prose and simple `-` dash bullets keep the designed green-checkmark treatment.
- Markdown descriptions are carried whole (`ChangeDetail.descriptionMarkdown`) and rendered compactly in the modal via the app's existing `react-markdown` + `remark-gfm` pattern (same approach as the session QuestionMarkdown — **no new dependencies**): small semibold headings, real lists, muted code chips/blocks, safe links.
- Native structured `whatChanged` payloads always win; inbox row summaries were already clean (`#N → main`).

## Tests
6 new cases in `review-markdown.test.ts`: detector positives (headings/bold/code/fence/link/ordered list), negatives (plain prose, dash bullets, mid-sentence `#4135`, empty), and the full `mapApiReviewItem` round-trip (markdown → carried whole + empty checklist; plain → line-split; native array wins).

Merging after checks pass per standing rule (content was part of the reviewed UX batch — this is the same commit, re-landed).