### PR TITLE
fix(web): confirm dialog before secret delete and gateway key revoke

### DIFF
--- a/.claude/skills/kortix-design-system/SKILL.md
+++ b/.claude/skills/kortix-design-system/SKILL.md
@@ -59,7 +59,7 @@ These are **mandatory** for their job. Import from the paths below; never reimpl
 | Search fields | `apps/web/src/components/ui/input-group.tsx` | `InputGroupSearch` + `InputGroupSearchInput variant="popover"` |
 | Forms in panels | `apps/web/src/components/ui/field.tsx` | `Field`, `FieldLabel`, `FieldGroup`, `FieldDescription` |
 | Empty / error states | `apps/web/src/features/layout/section/empty-state.tsx`, `error-state.tsx` | `size="sm"` in customize sections |
-| Confirm destructive | `apps/web/src/components/ui/confirm-dialog.tsx` | Final confirm only — not routine buttons |
+| Confirm destructive | `apps/web/src/components/ui/confirm-dialog.tsx` | **Mandatory before any destructive mutation** — including `DropdownMenuItem variant="destructive"` items (see `secrets-view.tsx` delete, `gateway-keys.tsx` revoke). Only accepted alternative: the inline Cancel/confirm button swap used for channel disconnects (`channels-view.tsx`). Never mutate from a single click |
 | Loading / pending spinners | `apps/web/src/components/ui/loading.tsx` | `import Loading from '@/components/ui/loading'` — default `size-4`; use `className="size-4 shrink-0"` in dense buttons. **Never** `Loader2` or other icons |
 
 Also reach for: `Button`, `ButtonGroup`, `Input`, `Select`, `Switch`, `Skeleton`, `Tabs` / `TabsListCompact`, `Table`, `InlineMeta`, `UserAvatar`, `EntityAvatar`.
@@ -360,6 +360,7 @@ Standard content block (`agents-view.tsx` pattern):
 - ✅ Lists → `<ul className="space-y-2">` + entity row classes. ❌ `List` / `ListRow`, ❌ `divide-y` Card lists.
 - ✅ Expandable config → `Disclosure` + `Button variant="popover"`. ❌ custom accordion, ❌ nested `rounded-md` inside rounded parent.
 - ✅ Modals → `Modal` from `modal.tsx`. ❌ `Dialog`/`DialogContent` in features.
+- ✅ Destructive actions → `ConfirmDialog` (or the inline two-step Cancel/confirm swap, `channels-view.tsx`). ❌ firing a delete/revoke mutation directly from a `variant="destructive"` click.
 - ✅ Tooltips → `Hint`. ❌ `Tooltip` primitives in features.
 - ✅ Toasts → `@/components/ui/toast` helpers. ❌ `@/lib/toast`, raw sonner.
 - ✅ Badges → `<Badge size="sm" variant="…">`. ❌ hand-rolled chip spans.

--- a/apps/web/src/features/workspace/customize/sections/view/gateway/gateway-keys.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/gateway/gateway-keys.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import { useState } from 'react';
 import { Check, Copy, KeyRound, MoreHorizontal, Trash2 } from 'lucide-react';
+import { useState } from 'react';
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -58,6 +59,7 @@ export function GatewayKeys({
   const [creating, setCreating] = useState(false);
   const [name, setName] = useState('');
   const [created, setCreated] = useState<CreatedGatewayKey | null>(null);
+  const [revokeTarget, setRevokeTarget] = useState<{ key_id: string; name: string } | null>(null);
 
   const keys = data?.keys ?? [];
 
@@ -94,7 +96,7 @@ export function GatewayKeys({
                 API keys
                 <span className="text-muted-foreground font-normal"> ({keys.length})</span>
               </Label>
-              <p className="text-muted-foreground mt-0.5 text-xs text-pretty">
+              <p className="text-muted-foreground mt-0.5 text-pretty text-xs">
                 Project-scoped keys for calling the gateway from external apps — every request is
                 logged and billed here.
               </p>
@@ -128,7 +130,7 @@ export function GatewayKeys({
                 return (
                   <li
                     key={k.key_id}
-                    className="group bg-popover flex items-center gap-3 rounded-md border px-4 py-2.5 transition-colors"
+                    className="bg-popover group flex items-center gap-3 rounded-md border px-4 py-2.5 transition-colors"
                   >
                     <EntityAvatar icon={KeyRound} size="sm" />
                     <div className="min-w-0 flex-1">
@@ -169,13 +171,7 @@ export function GatewayKeys({
                         <DropdownMenuContent align="end" className="w-44">
                           <DropdownMenuItem
                             variant="destructive"
-                            onClick={() =>
-                              revokeKey.mutate(k.key_id, {
-                                onSuccess: () => successToast('Key revoked'),
-                                onError: (e) =>
-                                  errorToast(e instanceof Error ? e.message : 'Could not revoke'),
-                              })
-                            }
+                            onClick={() => setRevokeTarget({ key_id: k.key_id, name: k.name })}
                           >
                             <Trash2 className="size-3.5 shrink-0" />
                             Revoke key
@@ -230,6 +226,32 @@ export function GatewayKeys({
           onClose={() => setCreated(null)}
         />
       )}
+
+      <ConfirmDialog
+        open={revokeTarget !== null}
+        onOpenChange={(open) => {
+          if (!open) setRevokeTarget(null);
+        }}
+        title="Revoke key"
+        description={
+          revokeTarget
+            ? `Revoke ${revokeTarget.name}? Apps calling the gateway with it stop working immediately.`
+            : ''
+        }
+        confirmLabel="Revoke"
+        confirmVariant="destructive"
+        onConfirm={() => {
+          if (!revokeTarget) return;
+          revokeKey.mutate(revokeTarget.key_id, {
+            onSuccess: () => {
+              setRevokeTarget(null);
+              successToast('Key revoked');
+            },
+            onError: (e) => errorToast(e instanceof Error ? e.message : 'Could not revoke'),
+          });
+        }}
+        isPending={revokeKey.isPending}
+      />
     </div>
   );
 }

--- a/apps/web/src/features/workspace/customize/sections/view/secrets-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/secrets-view.tsx
@@ -8,6 +8,7 @@ import { type FormEvent, useCallback, useEffect, useMemo, useState } from 'react
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -113,6 +114,7 @@ export function SecretsView({ projectId }: { projectId: string }) {
   const [providerModalOpen, setProviderModalOpen] = useState(false);
   const [dialogOpen, setDialogOpen] = useState(false);
   const [dialogRow, setDialogRow] = useState<SecretRow | null>(null);
+  const [deleteRow, setDeleteRow] = useState<SecretRow | null>(null);
 
   const refreshSecretsAndProviders = useCallback(() => {
     queryClient.invalidateQueries({ queryKey });
@@ -262,7 +264,7 @@ export function SecretsView({ projectId }: { projectId: string }) {
                         canManage={canManage}
                         busy={removeShared.isPending && removeShared.variables === row.identifier}
                         onEdit={() => openEdit(row)}
-                        onDelete={() => removeShared.mutate(row.identifier)}
+                        onDelete={() => setDeleteRow(row)}
                       />
                     ))}
                   </TableBody>
@@ -285,6 +287,29 @@ export function SecretsView({ projectId }: { projectId: string }) {
         open={providerModalOpen}
         onOpenChange={setProviderModalOpen}
         canWrite={canManage}
+      />
+      <ConfirmDialog
+        open={deleteRow !== null}
+        onOpenChange={(open) => {
+          if (!open) setDeleteRow(null);
+        }}
+        title="Delete secret"
+        description={
+          deleteRow ? `Delete ${deleteRow.identifier}? The stored value can't be recovered.` : ''
+        }
+        confirmLabel="Delete"
+        confirmVariant="destructive"
+        onConfirm={() => {
+          if (!deleteRow) return;
+          removeShared.mutate(deleteRow.identifier, {
+            onSuccess: () => {
+              setDeleteRow(null);
+              successToast('Secret deleted');
+            },
+            onError: (e) => errorToast(e instanceof Error ? e.message : 'Could not delete secret'),
+          });
+        }}
+        isPending={removeShared.isPending}
       />
     </>
   );
@@ -356,8 +381,12 @@ function buildRows(raw: ProjectSecretsResponse | ProjectSecret[] | null | undefi
     });
   }
 
-  const rank = (r: SecretRow) => (r.requirement === 'required' ? 0 : r.requirement === 'optional' ? 1 : 2);
-  rows.sort((a, b) => rank(a) - rank(b) || a.key.localeCompare(b.key) || a.identifier.localeCompare(b.identifier));
+  const rank = (r: SecretRow) =>
+    r.requirement === 'required' ? 0 : r.requirement === 'optional' ? 1 : 2;
+  rows.sort(
+    (a, b) =>
+      rank(a) - rank(b) || a.key.localeCompare(b.key) || a.identifier.localeCompare(b.identifier),
+  );
   return rows;
 }
 
@@ -412,7 +441,7 @@ function SecretTableRow({
           </div>
         </div>
       </TableCell>
-      <TableCell className="text-muted-foreground max-w-[200px] text-xs font-medium whitespace-normal">
+      <TableCell className="text-muted-foreground max-w-[200px] whitespace-normal text-xs font-medium">
         {statusLabel(row)}
       </TableCell>
       <TableCell>
@@ -504,7 +533,9 @@ function SecretDialog({
       });
     },
     onSuccess: () => {
-      successToast(`Saved ${(row?.identifier ?? identifier).trim() || (row?.key ?? key).trim().toUpperCase()}`);
+      successToast(
+        `Saved ${(row?.identifier ?? identifier).trim() || (row?.key ?? key).trim().toUpperCase()}`,
+      );
       onSaved();
       onOpenChange(false);
     },
@@ -518,7 +549,11 @@ function SecretDialog({
     save.mutate();
   }
 
-  const title = !row ? 'Add secret' : row.configured ? `Edit ${row.identifier}` : `Set ${row.identifier}`;
+  const title = !row
+    ? 'Add secret'
+    : row.configured
+      ? `Edit ${row.identifier}`
+      : `Set ${row.identifier}`;
 
   return (
     <Modal
@@ -541,7 +576,10 @@ function SecretDialog({
           <ModalBody className="max-h-[60vh] space-y-4 overflow-y-auto">
             <div className="border-border bg-sidebar flex flex-col overflow-hidden rounded-md border">
               <div className="flex flex-col gap-1 border-b px-3 py-2">
-                <label className="text-muted-foreground text-xs font-medium" htmlFor="secret-dialog-identifier">
+                <label
+                  className="text-muted-foreground text-xs font-medium"
+                  htmlFor="secret-dialog-identifier"
+                >
                   Identifier
                 </label>
                 <Input
@@ -592,8 +630,8 @@ function SecretDialog({
 
             {!isEdit && (
               <p className="text-muted-foreground text-xs">
-                Leave the identifier blank to use the key as its own identifier — the common case. Set
-                it explicitly to keep a second value under the same key (e.g. a backup key).
+                Leave the identifier blank to use the key as its own identifier — the common case.
+                Set it explicitly to keep a second value under the same key (e.g. a backup key).
               </p>
             )}
             {row?.configured && (
@@ -618,7 +656,9 @@ function SecretDialog({
               type="submit"
               size="sm"
               className="w-full sm:w-auto"
-              disabled={(!isEdit && !key.trim()) || (requiresValue && !value.trim()) || save.isPending}
+              disabled={
+                (!isEdit && !key.trim()) || (requiresValue && !value.trim()) || save.isPending
+              }
             >
               {save.isPending && <Loading className="size-4 shrink-0 animate-spin" />}
               Save


### PR DESCRIPTION
Lands the output of the background audit session ("Audit destructive DropdownMenuItem deletes for ConfirmDialog") — it finished its work at ~09:05 and committed, but sat idle without opening a PR. Cherry-picked onto current main, rebased over #4328/#4330/#4331, re-verified (tsc clean, 104 web tests pass).

## What it fixes
The two destructive actions that fired with **zero confirmation** (deliberately left as follow-up from the UX batch, since both files are design-system reference implementations):
- **Secrets → Delete secret** — now goes through `ConfirmDialog` naming the secret and the consequence.
- **LLM gateway → Revoke key** — same treatment.
- Codifies the rule in the design-system skill: destructive actions always confirm via `ConfirmDialog`.

Work authored in the audit session (as Ivan), integrated + verified here. Merging after checks pass per standing rule.