### PR TITLE
promote: snapshot quota fix + IAM capability gating → staging

### DIFF
--- a/.claude/skills/kortix-design-system/SKILL.md
+++ b/.claude/skills/kortix-design-system/SKILL.md
@@ -59,7 +59,7 @@ These are **mandatory** for their job. Import from the paths below; never reimpl
 | Search fields | `apps/web/src/components/ui/input-group.tsx` | `InputGroupSearch` + `InputGroupSearchInput variant="popover"` |
 | Forms in panels | `apps/web/src/components/ui/field.tsx` | `Field`, `FieldLabel`, `FieldGroup`, `FieldDescription` |
 | Empty / error states | `apps/web/src/features/layout/section/empty-state.tsx`, `error-state.tsx` | `size="sm"` in customize sections |
-| Confirm destructive | `apps/web/src/components/ui/confirm-dialog.tsx` | Final confirm only — not routine buttons |
+| Confirm destructive | `apps/web/src/components/ui/confirm-dialog.tsx` | **Mandatory before any destructive mutation** — including `DropdownMenuItem variant="destructive"` items (see `secrets-view.tsx` delete, `gateway-keys.tsx` revoke). Only accepted alternative: the inline Cancel/confirm button swap used for channel disconnects (`channels-view.tsx`). Never mutate from a single click |
 | Loading / pending spinners | `apps/web/src/components/ui/loading.tsx` | `import Loading from '@/components/ui/loading'` — default `size-4`; use `className="size-4 shrink-0"` in dense buttons. **Never** `Loader2` or other icons |
 
 Also reach for: `Button`, `ButtonGroup`, `Input`, `Select`, `Switch`, `Skeleton`, `Tabs` / `TabsListCompact`, `Table`, `InlineMeta`, `UserAvatar`, `EntityAvatar`.
@@ -360,6 +360,7 @@ Standard content block (`agents-view.tsx` pattern):
 - ✅ Lists → `<ul className="space-y-2">` + entity row classes. ❌ `List` / `ListRow`, ❌ `divide-y` Card lists.
 - ✅ Expandable config → `Disclosure` + `Button variant="popover"`. ❌ custom accordion, ❌ nested `rounded-md` inside rounded parent.
 - ✅ Modals → `Modal` from `modal.tsx`. ❌ `Dialog`/`DialogContent` in features.
+- ✅ Destructive actions → `ConfirmDialog` (or the inline two-step Cancel/confirm swap, `channels-view.tsx`). ❌ firing a delete/revoke mutation directly from a `variant="destructive"` click.
 - ✅ Tooltips → `Hint`. ❌ `Tooltip` primitives in features.
 - ✅ Toasts → `@/components/ui/toast` helpers. ❌ `@/lib/toast`, raw sonner.
 - ✅ Badges → `<Badge size="sm" variant="…">`. ❌ hand-rolled chip spans.

--- a/apps/api/src/__tests__/e2e-marketplace-http.test.ts
+++ b/apps/api/src/__tests__/e2e-marketplace-http.test.ts
@@ -65,13 +65,12 @@ describe('marketplace HTTP contract', () => {
     expect(body.items.find((item) => item.name === 'memory-reflector')).toBeUndefined();
   });
 
-  test('GET /marketplace/items is public read-only and skill-only', async () => {
+  test('GET /marketplace/items is public read-only', async () => {
     authCalls = 0;
     const res = await fetch(`${baseUrl}/marketplace/items?query=agent-browser&source=kortix`);
     expect(res.status).toBe(200);
     const body = await res.json() as { items: Array<{ name: string; type: string }> };
     expect(body.items).toContainEqual(expect.objectContaining({ name: 'agent-browser', type: 'registry:skill' }));
-    expect(body.items.every((item) => item.type === 'registry:skill')).toBe(true);
     expect(authCalls).toBe(0);
   });
 

--- a/apps/api/src/__tests__/integration-detail-capability-http.test.ts
+++ b/apps/api/src/__tests__/integration-detail-capability-http.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test, beforeAll, afterAll } from 'bun:test';
+import { eq, sql } from 'drizzle-orm';
+import { accountMembers, accounts, projectMembers, projects } from '@kortix/db';
+import { db } from '../shared/db';
+import { app } from '../index';
+import { createAccountToken } from '../repositories/account-tokens';
+
+// GET /:projectId/detail must stay loadable by a plain `member` even though
+// member lacks project.file.read: the fix filters the file list OUT of the
+// response rather than 403-ing the whole bundle (a hard assert would lock every
+// member out of the workspace shell). This proves the coarse floor stayed
+// project.read and the file section is blanked, not gated.
+const ACCOUNT = crypto.randomUUID();
+const PROJECT = crypto.randomUUID();
+const MEMBER = crypto.randomUUID();
+const EDITOR = crypto.randomUUID();
+
+const minted: string[] = [];
+
+beforeAll(async () => {
+  await db.execute(sql`alter table kortix.account_tokens add column if not exists agent_grant jsonb`);
+  await db.execute(sql`alter table kortix.account_tokens add column if not exists session_id text`);
+  await db.execute(sql`alter table kortix.account_tokens add column if not exists service_account_id uuid`);
+
+  await db.insert(accounts).values({ accountId: ACCOUNT, name: 'detail-cap-test' });
+  await db.insert(projects).values({
+    projectId: PROJECT,
+    accountId: ACCOUNT,
+    name: 'detail-cap-test-project',
+    repoUrl: 'https://example.com/detail-cap-test.git',
+  });
+  await db.insert(accountMembers).values([
+    { userId: MEMBER, accountId: ACCOUNT, accountRole: 'member', isSuperAdmin: false },
+    { userId: EDITOR, accountId: ACCOUNT, accountRole: 'member', isSuperAdmin: false },
+  ]);
+  await db.insert(projectMembers).values([
+    { accountId: ACCOUNT, projectId: PROJECT, userId: MEMBER, projectRole: 'member' },
+    { accountId: ACCOUNT, projectId: PROJECT, userId: EDITOR, projectRole: 'editor' },
+  ]);
+});
+
+afterAll(async () => {
+  for (const tokenId of minted) {
+    await db.execute(sql`delete from kortix.account_tokens where token_id = ${tokenId}`);
+  }
+  await db.delete(projects).where(eq(projects.accountId, ACCOUNT));
+  await db.delete(accounts).where(eq(accounts.accountId, ACCOUNT));
+});
+
+async function mint(userId: string): Promise<string> {
+  const t = await createAccountToken({
+    accountId: ACCOUNT,
+    userId,
+    projectId: PROJECT,
+    name: 'detail-cap-test',
+    agentGrant: null as any,
+  });
+  minted.push(t.tokenId);
+  return t.secretKey;
+}
+
+function getDetail(secret: string) {
+  return app.request(`/v1/projects/${PROJECT}/detail`, {
+    method: 'GET',
+    headers: { Authorization: `Bearer ${secret}` },
+  });
+}
+
+describe('HTTP — GET /detail stays loadable for a member (file list filtered, not 403)', () => {
+  test('plain MEMBER (no file.read) → NOT 403 (workspace shell still loads)', async () => {
+    const secret = await mint(MEMBER);
+    const res = await getDetail(secret);
+    // The whole point: member must not be denied the bundle. The old naive fix
+    // (assertProjectCapability(file.read)) would 403 here.
+    expect(res.status).not.toBe(403);
+  });
+
+  test('plain MEMBER → the file list is blanked (no file paths leak via /detail)', async () => {
+    const secret = await mint(MEMBER);
+    const res = await getDetail(secret);
+    if (res.status === 200) {
+      const body = await res.json();
+      expect(body.files).toEqual([]);
+      expect(body.file_count).toBe(0);
+      // The config bundle is still present (member holds the config read leaves).
+      expect(body.config).toBeDefined();
+    }
+  });
+
+  test('EDITOR (has file.read) → NOT 403', async () => {
+    const secret = await mint(EDITOR);
+    const res = await getDetail(secret);
+    expect(res.status).not.toBe(403);
+  });
+});

--- a/apps/api/src/__tests__/integration-members-manage-gates-http.test.ts
+++ b/apps/api/src/__tests__/integration-members-manage-gates-http.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, test, beforeAll, afterAll } from 'bun:test';
+import { eq, sql } from 'drizzle-orm';
+import {
+  accountMembers,
+  accounts,
+  iamPolicies,
+  iamRoleActions,
+  iamRoles,
+  projectMembers,
+  projects,
+} from '@kortix/db';
+import { db } from '../shared/db';
+import { app } from '../index';
+import { createAccountToken } from '../repositories/account-tokens';
+import { PROJECT_ACTIONS } from '../iam';
+
+// These endpoints are the project-scoped members-governance surface (group
+// grants, resource grants, approvals, access requests). Each already asserts
+// the project.members.manage leaf — but the coarse floor was
+// loadProjectForUser(..,'manage'), which maps to project.write. That OVER-GATED
+// them: a custom "member manager" role (project.read + members.manage, but NOT
+// project.write) was wrongly denied at the floor before its members.manage
+// grant was ever consulted. The fix lowers the floor to 'read' so the
+// members.manage leaf is the sole capability gate. (GET /access-requests also
+// GAINED the leaf assert — it previously ran on the floor alone, so a plain
+// editor could list pending requests; now it's manager-only like its siblings.)
+const ACCOUNT = crypto.randomUUID();
+const PROJECT = crypto.randomUUID();
+const MANAGER = crypto.randomUUID();
+const EDITOR = crypto.randomUUID();
+const MEMBER = crypto.randomUUID();
+// The custom-role principal: no built-in project role at all — access is purely
+// an iam_policies grant of [project.read, project.members.manage] at project
+// scope. This is the exact role the granular RBAC model must support, and the
+// exact case the old 'manage' floor broke.
+const CUSTOM = crypto.randomUUID();
+const CUSTOM_ROLE = crypto.randomUUID();
+
+const minted: string[] = [];
+
+beforeAll(async () => {
+  await db.execute(sql`alter table kortix.account_tokens add column if not exists agent_grant jsonb`);
+  await db.execute(sql`alter table kortix.account_tokens add column if not exists session_id text`);
+  await db.execute(sql`alter table kortix.account_tokens add column if not exists service_account_id uuid`);
+
+  await db.insert(accounts).values({ accountId: ACCOUNT, name: 'members-manage-gate-test' });
+  await db.insert(projects).values({
+    projectId: PROJECT,
+    accountId: ACCOUNT,
+    name: 'members-manage-gate-test-project',
+    repoUrl: 'https://example.com/members-manage-gate-test.git',
+  });
+  await db.insert(accountMembers).values([
+    { userId: MANAGER, accountId: ACCOUNT, accountRole: 'member', isSuperAdmin: false },
+    { userId: EDITOR, accountId: ACCOUNT, accountRole: 'member', isSuperAdmin: false },
+    { userId: MEMBER, accountId: ACCOUNT, accountRole: 'member', isSuperAdmin: false },
+    { userId: CUSTOM, accountId: ACCOUNT, accountRole: 'member', isSuperAdmin: false },
+  ]);
+  await db.insert(projectMembers).values([
+    { accountId: ACCOUNT, projectId: PROJECT, userId: MANAGER, projectRole: 'manager' },
+    { accountId: ACCOUNT, projectId: PROJECT, userId: EDITOR, projectRole: 'editor' },
+    { accountId: ACCOUNT, projectId: PROJECT, userId: MEMBER, projectRole: 'member' },
+  ]);
+  // Custom "member manager" role — members.manage WITHOUT project.write.
+  await db.insert(iamRoles).values({
+    roleId: CUSTOM_ROLE,
+    accountId: ACCOUNT,
+    key: `mm-${CUSTOM_ROLE.slice(0, 6)}`,
+    name: 'Member Manager',
+    scopeType: 'project',
+  });
+  await db.insert(iamRoleActions).values([
+    { roleId: CUSTOM_ROLE, action: PROJECT_ACTIONS.PROJECT_READ },
+    { roleId: CUSTOM_ROLE, action: PROJECT_ACTIONS.PROJECT_MEMBERS_MANAGE },
+  ]);
+  await db.insert(iamPolicies).values({
+    accountId: ACCOUNT,
+    principalType: 'member',
+    principalId: CUSTOM,
+    roleId: CUSTOM_ROLE,
+    scopeType: 'project',
+    scopeId: PROJECT,
+  });
+});
+
+afterAll(async () => {
+  for (const tokenId of minted) {
+    await db.execute(sql`delete from kortix.account_tokens where token_id = ${tokenId}`);
+  }
+  await db.delete(iamPolicies).where(eq(iamPolicies.accountId, ACCOUNT));
+  await db.delete(iamRoleActions).where(eq(iamRoleActions.roleId, CUSTOM_ROLE));
+  await db.delete(iamRoles).where(eq(iamRoles.accountId, ACCOUNT));
+  await db.delete(projects).where(eq(projects.accountId, ACCOUNT));
+  await db.delete(accounts).where(eq(accounts.accountId, ACCOUNT));
+});
+
+async function mint(userId: string): Promise<string> {
+  const t = await createAccountToken({
+    accountId: ACCOUNT,
+    userId,
+    projectId: PROJECT,
+    name: 'members-manage-gate-test',
+    agentGrant: null as any,
+  });
+  minted.push(t.tokenId);
+  return t.secretKey;
+}
+
+function req(method: string, path: string, secret: string, body?: unknown) {
+  return app.request(path, {
+    method,
+    headers: {
+      Authorization: `Bearer ${secret}`,
+      ...(body !== undefined ? { 'content-type': 'application/json' } : {}),
+    },
+    ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+  });
+}
+
+// Was the request denied by the RBAC capability gate? Every IAM denial throws a
+// "You don't have permission …" 403 (see humanizePermissionDenial in
+// iam/dispatcher.ts — members.manage renders the friendly verb, not the raw
+// leaf). Because the floor is now 'read' (which ALL four principals hold), the
+// only 403 an editor/member can hit on these routes is the members.manage
+// assert, and none of these routes entitlement-403 the free test account — so a
+// "permission" 403 here is unambiguously the members.manage gate. 400/404 (bad
+// body / missing resource) come only AFTER the gate passes.
+async function deniedByLeaf(res: Response): Promise<boolean> {
+  if (res.status !== 403) return false;
+  const body = await res.json().catch(() => ({}));
+  return JSON.stringify(body).toLowerCase().includes('permission');
+}
+
+interface EP {
+  name: string;
+  method: string;
+  path: () => string;
+  body?: unknown;
+}
+
+const ENDPOINTS: EP[] = [
+  { name: 'POST /group-grants', method: 'POST', path: () => `/v1/projects/${PROJECT}/group-grants`, body: {} },
+  { name: 'PATCH /group-grants/{id}', method: 'PATCH', path: () => `/v1/projects/${PROJECT}/group-grants/${crypto.randomUUID()}`, body: {} },
+  { name: 'DELETE /group-grants/{id}', method: 'DELETE', path: () => `/v1/projects/${PROJECT}/group-grants/${crypto.randomUUID()}` },
+  { name: 'GET /approvals', method: 'GET', path: () => `/v1/projects/${PROJECT}/approvals` },
+  { name: 'GET /resource-grants', method: 'GET', path: () => `/v1/projects/${PROJECT}/resource-grants` },
+  { name: 'POST /resource-grants', method: 'POST', path: () => `/v1/projects/${PROJECT}/resource-grants`, body: {} },
+  { name: 'DELETE /resource-grants/{id}', method: 'DELETE', path: () => `/v1/projects/${PROJECT}/resource-grants/${crypto.randomUUID()}` },
+  { name: 'GET /access-requests', method: 'GET', path: () => `/v1/projects/${PROJECT}/access-requests` },
+];
+
+describe('HTTP enforcement — project members.manage gates (floor lowered read; leaf is the gate)', () => {
+  for (const ep of ENDPOINTS) {
+    describe(ep.name, () => {
+      test('EDITOR (project.write but NOT members.manage) → 403 on the members.manage leaf', async () => {
+        const secret = await mint(EDITOR);
+        const res = await req(ep.method, ep.path(), secret, ep.body);
+        expect(await deniedByLeaf(res)).toBe(true);
+      });
+
+      test('MEMBER (floor role) → 403 on the members.manage leaf', async () => {
+        const secret = await mint(MEMBER);
+        const res = await req(ep.method, ep.path(), secret, ep.body);
+        expect(await deniedByLeaf(res)).toBe(true);
+      });
+
+      test('MANAGER (has members.manage) → NOT denied by the leaf gate', async () => {
+        const secret = await mint(MANAGER);
+        const res = await req(ep.method, ep.path(), secret, ep.body);
+        expect(await deniedByLeaf(res)).toBe(false);
+      });
+
+      test('custom role [project.read + members.manage], NO project.write → NOT denied (over-gating fixed)', async () => {
+        const secret = await mint(CUSTOM);
+        const res = await req(ep.method, ep.path(), secret, ep.body);
+        expect(await deniedByLeaf(res)).toBe(false);
+      });
+    });
+  }
+});

--- a/apps/api/src/__tests__/integration-project-write-leaf-gates-http.test.ts
+++ b/apps/api/src/__tests__/integration-project-write-leaf-gates-http.test.ts
@@ -135,6 +135,16 @@ const CASES: WCase[] = [
     path: () => `/v1/projects/${PROJECT}/review/items`, body: {},
     tier: 'member', denyGrant: [A.PROJECT_TRIGGER_FIRE], allowGrant: [A.PROJECT_REVIEW_SUBMIT],
   },
+  // ── Triggers ─────────────────────────────────────────────────────────────
+  {
+    // Floor was 'manage' (project.write) — which the floor `member` role lacks
+    // though it HOLDS trigger.fire, so a plain member could never fire. Floor is
+    // now 'read', so the trigger.fire leaf is the gate and member can fire.
+    name: 'trigger fire (trigger.fire — member floor role must be able to fire)',
+    leaf: A.PROJECT_TRIGGER_FIRE, method: 'POST',
+    path: () => `/v1/projects/${PROJECT}/triggers/some-slug/fire`, body: {},
+    tier: 'member', denyGrant: [A.PROJECT_SESSION_START], allowGrant: [A.PROJECT_TRIGGER_FIRE],
+  },
   // ── Connectors (write) ───────────────────────────────────────────────────
   {
     name: 'email connect (connector.write)',

--- a/apps/api/src/__tests__/integration-project-write-leaf-gates-http.test.ts
+++ b/apps/api/src/__tests__/integration-project-write-leaf-gates-http.test.ts
@@ -1,0 +1,276 @@
+import { describe, expect, test, beforeAll, afterAll } from 'bun:test';
+import { eq, sql } from 'drizzle-orm';
+import { accountMembers, accounts, projectMembers, projects } from '@kortix/db';
+import { db } from '../shared/db';
+import { app } from '../index';
+import { createAccountToken } from '../repositories/account-tokens';
+import { PROJECT_ACTIONS } from '../iam';
+
+// Every capability checkbox must be authoritative: unchecking a leaf must DENY
+// its endpoint. These endpoints previously gated on a coarse floor only (or an
+// agent-scope check that is a no-op for humans), so unchecking the leaf did
+// nothing. This suite proves each newly-added leaf gate fires, using the
+// agent-grant fold: a scoped agent token restricts the launching user to the
+// leaves in its kortix_cli grant (project.read/project.write are exempt — see
+// AGENT_GRANT_EXEMPT_ACTIONS — so the coarse floor always passes and only the
+// specific leaf gate is under test).
+const ACCOUNT = crypto.randomUUID();
+const PROJECT = crypto.randomUUID();
+const MEMBER = crypto.randomUUID();
+const EDITOR = crypto.randomUUID();
+
+const minted: string[] = [];
+
+beforeAll(async () => {
+  await db.execute(sql`alter table kortix.account_tokens add column if not exists agent_grant jsonb`);
+  await db.execute(sql`alter table kortix.account_tokens add column if not exists session_id text`);
+  await db.execute(sql`alter table kortix.account_tokens add column if not exists service_account_id uuid`);
+
+  await db.insert(accounts).values({ accountId: ACCOUNT, name: 'write-leaf-gate-test' });
+  await db.insert(projects).values({
+    projectId: PROJECT,
+    accountId: ACCOUNT,
+    name: 'write-leaf-gate-test-project',
+    repoUrl: 'https://example.com/write-leaf-gate-test.git',
+  });
+  await db.insert(accountMembers).values([
+    { userId: MEMBER, accountId: ACCOUNT, accountRole: 'member', isSuperAdmin: false },
+    { userId: EDITOR, accountId: ACCOUNT, accountRole: 'member', isSuperAdmin: false },
+  ]);
+  await db.insert(projectMembers).values([
+    { accountId: ACCOUNT, projectId: PROJECT, userId: MEMBER, projectRole: 'member' },
+    { accountId: ACCOUNT, projectId: PROJECT, userId: EDITOR, projectRole: 'editor' },
+  ]);
+});
+
+afterAll(async () => {
+  for (const tokenId of minted) {
+    await db.execute(sql`delete from kortix.account_tokens where token_id = ${tokenId}`);
+  }
+  await db.delete(projects).where(eq(projects.accountId, ACCOUNT));
+  await db.delete(accounts).where(eq(accounts.accountId, ACCOUNT));
+});
+
+async function mint(userId: string, kortixCli: string[] | null): Promise<string> {
+  const t = await createAccountToken({
+    accountId: ACCOUNT,
+    userId,
+    projectId: PROJECT,
+    name: 'write-leaf-gate-test',
+    agentGrant: (kortixCli ? { agent: 'scoped-bot', kortixCli, connectors: [] } : null) as any,
+  });
+  minted.push(t.tokenId);
+  return t.secretKey;
+}
+
+function req(method: string, path: string, secret: string, body?: unknown) {
+  return app.request(path, {
+    method,
+    headers: {
+      Authorization: `Bearer ${secret}`,
+      ...(body !== undefined ? { 'content-type': 'application/json' } : {}),
+    },
+    ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+  });
+}
+
+// An IAM denial (403) from either loadProjectForUser (floor) or
+// assertProjectCapability (leaf). Both phrase it distinctively; a non-IAM 403
+// (e.g. the "email is experimental" gate) matches none of these, so the ALLOW
+// cases can still 403 for an unrelated reason without being counted as a leaf
+// denial.
+async function iamDenied(res: Response): Promise<boolean> {
+  if (res.status !== 403) return false;
+  const text = JSON.stringify(await res.json().catch(() => ({})));
+  return /permission|do not have access|doesn't let you/i.test(text);
+}
+
+interface WCase {
+  name: string;
+  leaf: string;
+  method: string;
+  path: () => string;
+  body?: unknown;
+  // 'member' = the floor role holds this leaf (so a plain member passes);
+  // 'editor' = editor-tier (a plain member is denied, an editor passes).
+  tier: 'member' | 'editor';
+  // kortix_cli grants for the agent-grant fold. deny = a grant that should be
+  // rejected by the leaf gate; allow = the exact grant that should pass it.
+  denyGrant: string[];
+  allowGrant: string[];
+}
+
+const A = PROJECT_ACTIONS;
+const sid = () => crypto.randomUUID();
+
+const CASES: WCase[] = [
+  // ── Session lifecycle ────────────────────────────────────────────────────
+  {
+    name: 'session start (floor session.start)',
+    leaf: A.PROJECT_SESSION_START, method: 'POST',
+    path: () => `/v1/projects/${PROJECT}/sessions/${sid()}/start`,
+    tier: 'member', denyGrant: [A.PROJECT_TRIGGER_FIRE], allowGrant: [A.PROJECT_SESSION_START],
+  },
+  {
+    name: 'session stop (leaf session.stop)',
+    leaf: A.PROJECT_SESSION_STOP, method: 'POST',
+    path: () => `/v1/projects/${PROJECT}/sessions/${sid()}/stop`,
+    tier: 'member',
+    // floor is session.start, so the deny grant must hold start (to reach the
+    // stop assert) but not stop.
+    denyGrant: [A.PROJECT_SESSION_START], allowGrant: [A.PROJECT_SESSION_START, A.PROJECT_SESSION_STOP],
+  },
+  // ── Review ───────────────────────────────────────────────────────────────
+  {
+    name: 'CR request-changes (review.act, not gitops.push)',
+    leaf: A.PROJECT_REVIEW_ACT, method: 'POST',
+    path: () => `/v1/projects/${PROJECT}/change-requests/${sid()}/request-changes`, body: {},
+    tier: 'editor',
+    // deny with gitops.push (the OLD leaf) to prove the gate is now review.act.
+    denyGrant: [A.PROJECT_GITOPS_PUSH], allowGrant: [A.PROJECT_REVIEW_ACT],
+  },
+  {
+    name: 'review item submit (review.submit)',
+    leaf: A.PROJECT_REVIEW_SUBMIT, method: 'POST',
+    path: () => `/v1/projects/${PROJECT}/review/items`, body: {},
+    tier: 'member', denyGrant: [A.PROJECT_TRIGGER_FIRE], allowGrant: [A.PROJECT_REVIEW_SUBMIT],
+  },
+  // ── Triggers ─────────────────────────────────────────────────────────────
+  {
+    // Floor was 'manage' (project.write) — which the floor `member` role lacks
+    // though it HOLDS trigger.fire, so a plain member could never fire. Floor is
+    // now 'read', so the trigger.fire leaf is the gate and member can fire.
+    name: 'trigger fire (trigger.fire — member floor role must be able to fire)',
+    leaf: A.PROJECT_TRIGGER_FIRE, method: 'POST',
+    path: () => `/v1/projects/${PROJECT}/triggers/some-slug/fire`, body: {},
+    tier: 'member', denyGrant: [A.PROJECT_SESSION_START], allowGrant: [A.PROJECT_TRIGGER_FIRE],
+  },
+  // ── Connectors (write) ───────────────────────────────────────────────────
+  {
+    name: 'email connect (connector.write)',
+    leaf: A.PROJECT_CONNECTOR_WRITE, method: 'POST',
+    path: () => `/v1/projects/${PROJECT}/channels/email/connect`, body: {},
+    tier: 'editor', denyGrant: [A.PROJECT_TRIGGER_FIRE], allowGrant: [A.PROJECT_CONNECTOR_WRITE],
+  },
+  {
+    name: 'email installation PATCH (connector.write)',
+    leaf: A.PROJECT_CONNECTOR_WRITE, method: 'PATCH',
+    path: () => `/v1/projects/${PROJECT}/channels/email/installation`, body: {},
+    tier: 'editor', denyGrant: [A.PROJECT_TRIGGER_FIRE], allowGrant: [A.PROJECT_CONNECTOR_WRITE],
+  },
+  {
+    name: 'email installation DELETE (connector.write)',
+    leaf: A.PROJECT_CONNECTOR_WRITE, method: 'DELETE',
+    path: () => `/v1/projects/${PROJECT}/channels/email/installation`,
+    tier: 'editor', denyGrant: [A.PROJECT_TRIGGER_FIRE], allowGrant: [A.PROJECT_CONNECTOR_WRITE],
+  },
+  {
+    name: 'channel binding PATCH (connector.write)',
+    leaf: A.PROJECT_CONNECTOR_WRITE, method: 'PATCH',
+    path: () => `/v1/projects/${PROJECT}/channels/bindings/${sid()}`, body: {},
+    tier: 'editor', denyGrant: [A.PROJECT_TRIGGER_FIRE], allowGrant: [A.PROJECT_CONNECTOR_WRITE],
+  },
+  {
+    name: 'connect-requests (connector.write)',
+    leaf: A.PROJECT_CONNECTOR_WRITE, method: 'POST',
+    path: () => `/v1/projects/${PROJECT}/connect-requests`, body: {},
+    tier: 'editor', denyGrant: [A.PROJECT_TRIGGER_FIRE], allowGrant: [A.PROJECT_CONNECTOR_WRITE],
+  },
+  // ── Connectors (read) ────────────────────────────────────────────────────
+  {
+    name: 'channel bindings list (connector.read)',
+    leaf: A.PROJECT_CONNECTOR_READ, method: 'GET',
+    path: () => `/v1/projects/${PROJECT}/channels/bindings`,
+    tier: 'member', denyGrant: [A.PROJECT_TRIGGER_FIRE], allowGrant: [A.PROJECT_CONNECTOR_READ],
+  },
+  // ── Customize (write) ────────────────────────────────────────────────────
+  {
+    name: 'meet bot name (customize.write)',
+    leaf: A.PROJECT_CUSTOMIZE_WRITE, method: 'PUT',
+    path: () => `/v1/projects/${PROJECT}/channels/meet/name`, body: {},
+    tier: 'editor', denyGrant: [A.PROJECT_TRIGGER_FIRE], allowGrant: [A.PROJECT_CUSTOMIZE_WRITE],
+  },
+  {
+    name: 'meet voice (customize.write)',
+    leaf: A.PROJECT_CUSTOMIZE_WRITE, method: 'PUT',
+    path: () => `/v1/projects/${PROJECT}/channels/meet/voice`, body: {},
+    tier: 'editor', denyGrant: [A.PROJECT_TRIGGER_FIRE], allowGrant: [A.PROJECT_CUSTOMIZE_WRITE],
+  },
+  {
+    // Strict body (ModelDefaultBody) is validated at the OpenAPI layer BEFORE the
+    // handler, so send a schema-valid body — otherwise a 400 pre-empts the gate.
+    name: 'model-defaults PUT (customize.write)',
+    leaf: A.PROJECT_CUSTOMIZE_WRITE, method: 'PUT',
+    path: () => `/v1/projects/${PROJECT}/model-defaults`, body: { scope: 'project', model: 'openai/gpt-4o' },
+    tier: 'editor', denyGrant: [A.PROJECT_TRIGGER_FIRE], allowGrant: [A.PROJECT_CUSTOMIZE_WRITE],
+  },
+  {
+    name: 'model-defaults DELETE (customize.write)',
+    leaf: A.PROJECT_CUSTOMIZE_WRITE, method: 'DELETE',
+    path: () => `/v1/projects/${PROJECT}/model-defaults?scope=project`,
+    tier: 'editor', denyGrant: [A.PROJECT_TRIGGER_FIRE], allowGrant: [A.PROJECT_CUSTOMIZE_WRITE],
+  },
+  {
+    name: 'experimental toggle (customize.write)',
+    leaf: A.PROJECT_CUSTOMIZE_WRITE, method: 'PATCH',
+    path: () => `/v1/projects/${PROJECT}/experimental`, body: {},
+    tier: 'editor', denyGrant: [A.PROJECT_TRIGGER_FIRE], allowGrant: [A.PROJECT_CUSTOMIZE_WRITE],
+  },
+  {
+    name: 'sandbox-provider (customize.write)',
+    leaf: A.PROJECT_CUSTOMIZE_WRITE, method: 'PATCH',
+    path: () => `/v1/projects/${PROJECT}/sandbox-provider`, body: {},
+    tier: 'editor', denyGrant: [A.PROJECT_TRIGGER_FIRE], allowGrant: [A.PROJECT_CUSTOMIZE_WRITE],
+  },
+  // ── Agent scope (agent.write) ────────────────────────────────────────────
+  {
+    name: 'agent scope PUT (agent.write)',
+    leaf: A.PROJECT_AGENT_WRITE, method: 'PUT',
+    path: () => `/v1/projects/${PROJECT}/agents/scoped-bot/scope`, body: {},
+    tier: 'editor', denyGrant: [A.PROJECT_TRIGGER_FIRE], allowGrant: [A.PROJECT_AGENT_WRITE],
+  },
+  // ── Secrets (write) ──────────────────────────────────────────────────────
+  {
+    name: 'secret-requests (secret.write)',
+    leaf: A.PROJECT_SECRET_WRITE, method: 'POST',
+    path: () => `/v1/projects/${PROJECT}/secret-requests`, body: {},
+    tier: 'editor', denyGrant: [A.PROJECT_TRIGGER_FIRE], allowGrant: [A.PROJECT_SECRET_WRITE],
+  },
+];
+
+describe('HTTP enforcement — project write/lifecycle leaf gates (every checkbox authoritative)', () => {
+  for (const c of CASES) {
+    describe(c.name, () => {
+      test('scoped agent with an UNRELATED grant → denied by the leaf gate', async () => {
+        const secret = await mint(EDITOR, c.denyGrant);
+        const res = await req(c.method, c.path(), secret, c.body);
+        expect(await iamDenied(res)).toBe(true);
+      });
+
+      test('scoped agent granted the exact leaf → NOT denied by the leaf gate', async () => {
+        const secret = await mint(EDITOR, c.allowGrant);
+        const res = await req(c.method, c.path(), secret, c.body);
+        expect(await iamDenied(res)).toBe(false);
+      });
+
+      if (c.tier === 'editor') {
+        test('plain MEMBER (lacks the editor-tier leaf) → denied', async () => {
+          const secret = await mint(MEMBER, null);
+          const res = await req(c.method, c.path(), secret, c.body);
+          expect(await iamDenied(res)).toBe(true);
+        });
+        test('plain EDITOR (holds the leaf) → NOT denied', async () => {
+          const secret = await mint(EDITOR, null);
+          const res = await req(c.method, c.path(), secret, c.body);
+          expect(await iamDenied(res)).toBe(false);
+        });
+      } else {
+        test('plain MEMBER (floor role holds the leaf) → NOT denied', async () => {
+          const secret = await mint(MEMBER, null);
+          const res = await req(c.method, c.path(), secret, c.body);
+          expect(await iamDenied(res)).toBe(false);
+        });
+      }
+    });
+  }
+});

--- a/apps/api/src/__tests__/integration-project-write-leaf-gates-http.test.ts
+++ b/apps/api/src/__tests__/integration-project-write-leaf-gates-http.test.ts
@@ -1,0 +1,266 @@
+import { describe, expect, test, beforeAll, afterAll } from 'bun:test';
+import { eq, sql } from 'drizzle-orm';
+import { accountMembers, accounts, projectMembers, projects } from '@kortix/db';
+import { db } from '../shared/db';
+import { app } from '../index';
+import { createAccountToken } from '../repositories/account-tokens';
+import { PROJECT_ACTIONS } from '../iam';
+
+// Every capability checkbox must be authoritative: unchecking a leaf must DENY
+// its endpoint. These endpoints previously gated on a coarse floor only (or an
+// agent-scope check that is a no-op for humans), so unchecking the leaf did
+// nothing. This suite proves each newly-added leaf gate fires, using the
+// agent-grant fold: a scoped agent token restricts the launching user to the
+// leaves in its kortix_cli grant (project.read/project.write are exempt — see
+// AGENT_GRANT_EXEMPT_ACTIONS — so the coarse floor always passes and only the
+// specific leaf gate is under test).
+const ACCOUNT = crypto.randomUUID();
+const PROJECT = crypto.randomUUID();
+const MEMBER = crypto.randomUUID();
+const EDITOR = crypto.randomUUID();
+
+const minted: string[] = [];
+
+beforeAll(async () => {
+  await db.execute(sql`alter table kortix.account_tokens add column if not exists agent_grant jsonb`);
+  await db.execute(sql`alter table kortix.account_tokens add column if not exists session_id text`);
+  await db.execute(sql`alter table kortix.account_tokens add column if not exists service_account_id uuid`);
+
+  await db.insert(accounts).values({ accountId: ACCOUNT, name: 'write-leaf-gate-test' });
+  await db.insert(projects).values({
+    projectId: PROJECT,
+    accountId: ACCOUNT,
+    name: 'write-leaf-gate-test-project',
+    repoUrl: 'https://example.com/write-leaf-gate-test.git',
+  });
+  await db.insert(accountMembers).values([
+    { userId: MEMBER, accountId: ACCOUNT, accountRole: 'member', isSuperAdmin: false },
+    { userId: EDITOR, accountId: ACCOUNT, accountRole: 'member', isSuperAdmin: false },
+  ]);
+  await db.insert(projectMembers).values([
+    { accountId: ACCOUNT, projectId: PROJECT, userId: MEMBER, projectRole: 'member' },
+    { accountId: ACCOUNT, projectId: PROJECT, userId: EDITOR, projectRole: 'editor' },
+  ]);
+});
+
+afterAll(async () => {
+  for (const tokenId of minted) {
+    await db.execute(sql`delete from kortix.account_tokens where token_id = ${tokenId}`);
+  }
+  await db.delete(projects).where(eq(projects.accountId, ACCOUNT));
+  await db.delete(accounts).where(eq(accounts.accountId, ACCOUNT));
+});
+
+async function mint(userId: string, kortixCli: string[] | null): Promise<string> {
+  const t = await createAccountToken({
+    accountId: ACCOUNT,
+    userId,
+    projectId: PROJECT,
+    name: 'write-leaf-gate-test',
+    agentGrant: (kortixCli ? { agent: 'scoped-bot', kortixCli, connectors: [] } : null) as any,
+  });
+  minted.push(t.tokenId);
+  return t.secretKey;
+}
+
+function req(method: string, path: string, secret: string, body?: unknown) {
+  return app.request(path, {
+    method,
+    headers: {
+      Authorization: `Bearer ${secret}`,
+      ...(body !== undefined ? { 'content-type': 'application/json' } : {}),
+    },
+    ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+  });
+}
+
+// An IAM denial (403) from either loadProjectForUser (floor) or
+// assertProjectCapability (leaf). Both phrase it distinctively; a non-IAM 403
+// (e.g. the "email is experimental" gate) matches none of these, so the ALLOW
+// cases can still 403 for an unrelated reason without being counted as a leaf
+// denial.
+async function iamDenied(res: Response): Promise<boolean> {
+  if (res.status !== 403) return false;
+  const text = JSON.stringify(await res.json().catch(() => ({})));
+  return /permission|do not have access|doesn't let you/i.test(text);
+}
+
+interface WCase {
+  name: string;
+  leaf: string;
+  method: string;
+  path: () => string;
+  body?: unknown;
+  // 'member' = the floor role holds this leaf (so a plain member passes);
+  // 'editor' = editor-tier (a plain member is denied, an editor passes).
+  tier: 'member' | 'editor';
+  // kortix_cli grants for the agent-grant fold. deny = a grant that should be
+  // rejected by the leaf gate; allow = the exact grant that should pass it.
+  denyGrant: string[];
+  allowGrant: string[];
+}
+
+const A = PROJECT_ACTIONS;
+const sid = () => crypto.randomUUID();
+
+const CASES: WCase[] = [
+  // ── Session lifecycle ────────────────────────────────────────────────────
+  {
+    name: 'session start (floor session.start)',
+    leaf: A.PROJECT_SESSION_START, method: 'POST',
+    path: () => `/v1/projects/${PROJECT}/sessions/${sid()}/start`,
+    tier: 'member', denyGrant: [A.PROJECT_TRIGGER_FIRE], allowGrant: [A.PROJECT_SESSION_START],
+  },
+  {
+    name: 'session stop (leaf session.stop)',
+    leaf: A.PROJECT_SESSION_STOP, method: 'POST',
+    path: () => `/v1/projects/${PROJECT}/sessions/${sid()}/stop`,
+    tier: 'member',
+    // floor is session.start, so the deny grant must hold start (to reach the
+    // stop assert) but not stop.
+    denyGrant: [A.PROJECT_SESSION_START], allowGrant: [A.PROJECT_SESSION_START, A.PROJECT_SESSION_STOP],
+  },
+  // ── Review ───────────────────────────────────────────────────────────────
+  {
+    name: 'CR request-changes (review.act, not gitops.push)',
+    leaf: A.PROJECT_REVIEW_ACT, method: 'POST',
+    path: () => `/v1/projects/${PROJECT}/change-requests/${sid()}/request-changes`, body: {},
+    tier: 'editor',
+    // deny with gitops.push (the OLD leaf) to prove the gate is now review.act.
+    denyGrant: [A.PROJECT_GITOPS_PUSH], allowGrant: [A.PROJECT_REVIEW_ACT],
+  },
+  {
+    name: 'review item submit (review.submit)',
+    leaf: A.PROJECT_REVIEW_SUBMIT, method: 'POST',
+    path: () => `/v1/projects/${PROJECT}/review/items`, body: {},
+    tier: 'member', denyGrant: [A.PROJECT_TRIGGER_FIRE], allowGrant: [A.PROJECT_REVIEW_SUBMIT],
+  },
+  // ── Connectors (write) ───────────────────────────────────────────────────
+  {
+    name: 'email connect (connector.write)',
+    leaf: A.PROJECT_CONNECTOR_WRITE, method: 'POST',
+    path: () => `/v1/projects/${PROJECT}/channels/email/connect`, body: {},
+    tier: 'editor', denyGrant: [A.PROJECT_TRIGGER_FIRE], allowGrant: [A.PROJECT_CONNECTOR_WRITE],
+  },
+  {
+    name: 'email installation PATCH (connector.write)',
+    leaf: A.PROJECT_CONNECTOR_WRITE, method: 'PATCH',
+    path: () => `/v1/projects/${PROJECT}/channels/email/installation`, body: {},
+    tier: 'editor', denyGrant: [A.PROJECT_TRIGGER_FIRE], allowGrant: [A.PROJECT_CONNECTOR_WRITE],
+  },
+  {
+    name: 'email installation DELETE (connector.write)',
+    leaf: A.PROJECT_CONNECTOR_WRITE, method: 'DELETE',
+    path: () => `/v1/projects/${PROJECT}/channels/email/installation`,
+    tier: 'editor', denyGrant: [A.PROJECT_TRIGGER_FIRE], allowGrant: [A.PROJECT_CONNECTOR_WRITE],
+  },
+  {
+    name: 'channel binding PATCH (connector.write)',
+    leaf: A.PROJECT_CONNECTOR_WRITE, method: 'PATCH',
+    path: () => `/v1/projects/${PROJECT}/channels/bindings/${sid()}`, body: {},
+    tier: 'editor', denyGrant: [A.PROJECT_TRIGGER_FIRE], allowGrant: [A.PROJECT_CONNECTOR_WRITE],
+  },
+  {
+    name: 'connect-requests (connector.write)',
+    leaf: A.PROJECT_CONNECTOR_WRITE, method: 'POST',
+    path: () => `/v1/projects/${PROJECT}/connect-requests`, body: {},
+    tier: 'editor', denyGrant: [A.PROJECT_TRIGGER_FIRE], allowGrant: [A.PROJECT_CONNECTOR_WRITE],
+  },
+  // ── Connectors (read) ────────────────────────────────────────────────────
+  {
+    name: 'channel bindings list (connector.read)',
+    leaf: A.PROJECT_CONNECTOR_READ, method: 'GET',
+    path: () => `/v1/projects/${PROJECT}/channels/bindings`,
+    tier: 'member', denyGrant: [A.PROJECT_TRIGGER_FIRE], allowGrant: [A.PROJECT_CONNECTOR_READ],
+  },
+  // ── Customize (write) ────────────────────────────────────────────────────
+  {
+    name: 'meet bot name (customize.write)',
+    leaf: A.PROJECT_CUSTOMIZE_WRITE, method: 'PUT',
+    path: () => `/v1/projects/${PROJECT}/channels/meet/name`, body: {},
+    tier: 'editor', denyGrant: [A.PROJECT_TRIGGER_FIRE], allowGrant: [A.PROJECT_CUSTOMIZE_WRITE],
+  },
+  {
+    name: 'meet voice (customize.write)',
+    leaf: A.PROJECT_CUSTOMIZE_WRITE, method: 'PUT',
+    path: () => `/v1/projects/${PROJECT}/channels/meet/voice`, body: {},
+    tier: 'editor', denyGrant: [A.PROJECT_TRIGGER_FIRE], allowGrant: [A.PROJECT_CUSTOMIZE_WRITE],
+  },
+  {
+    // Strict body (ModelDefaultBody) is validated at the OpenAPI layer BEFORE the
+    // handler, so send a schema-valid body — otherwise a 400 pre-empts the gate.
+    name: 'model-defaults PUT (customize.write)',
+    leaf: A.PROJECT_CUSTOMIZE_WRITE, method: 'PUT',
+    path: () => `/v1/projects/${PROJECT}/model-defaults`, body: { scope: 'project', model: 'openai/gpt-4o' },
+    tier: 'editor', denyGrant: [A.PROJECT_TRIGGER_FIRE], allowGrant: [A.PROJECT_CUSTOMIZE_WRITE],
+  },
+  {
+    name: 'model-defaults DELETE (customize.write)',
+    leaf: A.PROJECT_CUSTOMIZE_WRITE, method: 'DELETE',
+    path: () => `/v1/projects/${PROJECT}/model-defaults?scope=project`,
+    tier: 'editor', denyGrant: [A.PROJECT_TRIGGER_FIRE], allowGrant: [A.PROJECT_CUSTOMIZE_WRITE],
+  },
+  {
+    name: 'experimental toggle (customize.write)',
+    leaf: A.PROJECT_CUSTOMIZE_WRITE, method: 'PATCH',
+    path: () => `/v1/projects/${PROJECT}/experimental`, body: {},
+    tier: 'editor', denyGrant: [A.PROJECT_TRIGGER_FIRE], allowGrant: [A.PROJECT_CUSTOMIZE_WRITE],
+  },
+  {
+    name: 'sandbox-provider (customize.write)',
+    leaf: A.PROJECT_CUSTOMIZE_WRITE, method: 'PATCH',
+    path: () => `/v1/projects/${PROJECT}/sandbox-provider`, body: {},
+    tier: 'editor', denyGrant: [A.PROJECT_TRIGGER_FIRE], allowGrant: [A.PROJECT_CUSTOMIZE_WRITE],
+  },
+  // ── Agent scope (agent.write) ────────────────────────────────────────────
+  {
+    name: 'agent scope PUT (agent.write)',
+    leaf: A.PROJECT_AGENT_WRITE, method: 'PUT',
+    path: () => `/v1/projects/${PROJECT}/agents/scoped-bot/scope`, body: {},
+    tier: 'editor', denyGrant: [A.PROJECT_TRIGGER_FIRE], allowGrant: [A.PROJECT_AGENT_WRITE],
+  },
+  // ── Secrets (write) ──────────────────────────────────────────────────────
+  {
+    name: 'secret-requests (secret.write)',
+    leaf: A.PROJECT_SECRET_WRITE, method: 'POST',
+    path: () => `/v1/projects/${PROJECT}/secret-requests`, body: {},
+    tier: 'editor', denyGrant: [A.PROJECT_TRIGGER_FIRE], allowGrant: [A.PROJECT_SECRET_WRITE],
+  },
+];
+
+describe('HTTP enforcement — project write/lifecycle leaf gates (every checkbox authoritative)', () => {
+  for (const c of CASES) {
+    describe(c.name, () => {
+      test('scoped agent with an UNRELATED grant → denied by the leaf gate', async () => {
+        const secret = await mint(EDITOR, c.denyGrant);
+        const res = await req(c.method, c.path(), secret, c.body);
+        expect(await iamDenied(res)).toBe(true);
+      });
+
+      test('scoped agent granted the exact leaf → NOT denied by the leaf gate', async () => {
+        const secret = await mint(EDITOR, c.allowGrant);
+        const res = await req(c.method, c.path(), secret, c.body);
+        expect(await iamDenied(res)).toBe(false);
+      });
+
+      if (c.tier === 'editor') {
+        test('plain MEMBER (lacks the editor-tier leaf) → denied', async () => {
+          const secret = await mint(MEMBER, null);
+          const res = await req(c.method, c.path(), secret, c.body);
+          expect(await iamDenied(res)).toBe(true);
+        });
+        test('plain EDITOR (holds the leaf) → NOT denied', async () => {
+          const secret = await mint(EDITOR, null);
+          const res = await req(c.method, c.path(), secret, c.body);
+          expect(await iamDenied(res)).toBe(false);
+        });
+      } else {
+        test('plain MEMBER (floor role holds the leaf) → NOT denied', async () => {
+          const secret = await mint(MEMBER, null);
+          const res = await req(c.method, c.path(), secret, c.body);
+          expect(await iamDenied(res)).toBe(false);
+        });
+      }
+    });
+  }
+});

--- a/apps/api/src/__tests__/unit-agent-scope-v2.test.ts
+++ b/apps/api/src/__tests__/unit-agent-scope-v2.test.ts
@@ -1,0 +1,98 @@
+import { describe, test, expect } from 'bun:test';
+import { parseManifestString, serializeManifest } from '../projects/triggers';
+import { applyAgentScopeV2 } from '../projects/lib/agent-config-v2';
+import { extractAgents } from '../projects/agents';
+
+// Regression for the v2-YAML agent-scope bug: the /scope route used
+// applyAgentScope (v1 `[[agents]]` array only), which treated a v2 `agents:` map
+// as an empty array → every scope edit on a YAML project 404'd. applyAgentScopeV2
+// merges into the map correctly: v1 wire `env` ↦ v2 `secrets`, deny-by-default
+// omit, and every other governance field preserved.
+
+const YAML = `kortix_version: 2
+default_agent: kortix
+agents:
+  kortix:
+    connectors: all
+    secrets: all
+    kortix_cli: all
+    skills: all
+  scout:
+    kortix_cli: [project.cr.open]
+    connectors: [github]
+    skills: [research]
+`;
+
+function manifest() {
+  return parseManifestString(YAML, 'yaml', 'kortix.yaml');
+}
+
+describe('applyAgentScopeV2 — v2 agents map scope edit', () => {
+  test('set connectors to a list — updates the map, preserves other governance', () => {
+    const m = manifest();
+    const r = applyAgentScopeV2(m, 'scout', { connectors: ['github', 'linear'] });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    const scout = (r.raw.agents as Record<string, any>).scout;
+    expect(scout.connectors).toEqual(['github', 'linear']);
+    // kortix_cli + skills untouched.
+    expect(scout.kortix_cli).toEqual(['project.cr.open']);
+    expect(scout.skills).toEqual(['research']);
+  });
+
+  test('wire `env` maps to v2 `secrets` (NOT `env`)', () => {
+    const m = manifest();
+    const r = applyAgentScopeV2(m, 'scout', { env: ['API_KEY'] });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    const scout = (r.raw.agents as Record<string, any>).scout;
+    expect(scout.secrets).toEqual(['API_KEY']);
+    expect(scout.env).toBeUndefined(); // never writes the v1 key into a v2 block
+  });
+
+  test("'all' is written explicitly (v2 default is none, not all)", () => {
+    const m = manifest();
+    const r = applyAgentScopeV2(m, 'scout', { env: 'all', connectors: 'all' });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    const scout = (r.raw.agents as Record<string, any>).scout;
+    expect(scout.secrets).toBe('all');
+    expect(scout.connectors).toBe('all');
+  });
+
+  test('empty selection ([] = none) OMITS the key (deny-by-default idiom)', () => {
+    const m = manifest();
+    const r = applyAgentScopeV2(m, 'scout', { env: [], connectors: [] });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    const scout = (r.raw.agents as Record<string, any>).scout;
+    expect(scout).not.toHaveProperty('secrets');
+    expect(scout).not.toHaveProperty('connectors');
+    // Non-scope fields still preserved.
+    expect(scout.kortix_cli).toEqual(['project.cr.open']);
+  });
+
+  test('undeclared agent → notFound (route maps to 404)', () => {
+    const m = manifest();
+    const r = applyAgentScopeV2(m, 'ghost', { connectors: ['x'] });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.notFound).toBe(true);
+  });
+
+  test('round-trips: serialize stays YAML, re-parse reflects the edit via extractAgents', () => {
+    const m = manifest();
+    const r = applyAgentScopeV2(m, 'scout', { connectors: ['github', 'linear'], env: ['API_KEY'] });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    m.raw = r.raw;
+    const out = serializeManifest(m);
+    expect(out).toContain('agents:');
+    expect(out).not.toContain('[[agents]]');
+    const m2 = parseManifestString(out, 'yaml', 'kortix.yaml');
+    const scout = extractAgents(m2).specs.find((s) => s.name === 'scout')!;
+    expect(scout.connectors).toEqual(['github', 'linear']);
+    // extractAgentsV2 surfaces v2 `secrets` as the unified spec.env field.
+    expect(scout.env).toEqual(['API_KEY']);
+  });
+});

--- a/apps/api/src/__tests__/unit-apps-parse.test.ts
+++ b/apps/api/src/__tests__/unit-apps-parse.test.ts
@@ -315,7 +315,8 @@ apps:
 `);
     expect(specs).toEqual([]);
     expect(errors).toHaveLength(1);
-    expect(errors[0]!.error).toMatch(/must be an array of tables/);
+    // YAML manifest → the hint names the YAML shape (a list), not TOML `[[apps]]`.
+    expect(errors[0]!.error).toMatch(/must be a list/);
   });
 
   test('missing slug', () => {

--- a/apps/api/src/__tests__/unit-build-slug.test.ts
+++ b/apps/api/src/__tests__/unit-build-slug.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  WARM_BUILD_SLUG_SUFFIX,
+  isWarmBuildSlug,
+  templateSlugFromBuildSlug,
+  warmBuildSlug,
+} from '../snapshots/ppwarm-names';
+
+describe('warm build slug ↔ template slug', () => {
+  it('round-trips a template slug through its warm build slug', () => {
+    expect(warmBuildSlug('default')).toBe('default-warm');
+    expect(templateSlugFromBuildSlug(warmBuildSlug('default'))).toBe('default');
+    expect(templateSlugFromBuildSlug(warmBuildSlug('custom-gpu'))).toBe('custom-gpu');
+  });
+
+  it('leaves a plain template slug untouched', () => {
+    expect(templateSlugFromBuildSlug('default')).toBe('default');
+    expect(isWarmBuildSlug('default')).toBe(false);
+  });
+
+  it('recognises the warm suffix', () => {
+    expect(isWarmBuildSlug(`anything${WARM_BUILD_SLUG_SUFFIX}`)).toBe(true);
+    expect(isWarmBuildSlug('warm')).toBe(false);
+    expect(isWarmBuildSlug('warm-ish')).toBe(false);
+  });
+
+  it('strips only the trailing suffix, not an internal one', () => {
+    expect(templateSlugFromBuildSlug('warm-build-warm')).toBe('warm-build');
+  });
+
+  // The regression this whole change exists for: `default-warm` reached the rebuild
+  // and fix-with-agent routes as if it were a template slug, resolved to nothing,
+  // and surfaced as 502 / 400 respectively.
+  it('maps the build slug that broke Retry build back to a real template', () => {
+    expect(templateSlugFromBuildSlug('default-warm')).toBe('default');
+  });
+});

--- a/apps/api/src/__tests__/unit-detail-capability-filter.test.ts
+++ b/apps/api/src/__tests__/unit-detail-capability-filter.test.ts
@@ -1,0 +1,88 @@
+import { describe, test, expect } from 'bun:test';
+import { applyDetailCapabilityFilter } from '../projects/lib/detail-capability-filter';
+
+// Record<string, unknown> so the filtered fields (which the runtime blanks to
+// {} / [] / null) type as `unknown` at the assertions — otherwise the literal
+// type (e.g. manifest: { name: string }) rejects `.toEqual({})`.
+const sampleConfig: Record<string, unknown> = {
+  is_kortix_repo: true,
+  signals: { manifest: true },
+  manifest_raw: 'raw toml',
+  manifest: { name: 'x' },
+  env: [{ name: 'FOO' }],
+  open_code_raw: '{}',
+  open_code_default_agent: 'bot',
+  agent_discovery: 'declared',
+  agents: [{ name: 'a' }],
+  skills: [{ name: 's' }],
+  commands: [{ name: 'c' }],
+};
+const files = [{ path: 'a' }, { path: 'b' }, { path: 'c' }];
+const ALL = { canFiles: true, canAgents: true, canSkills: true, canCommands: true, canCustomize: true };
+
+describe('applyDetailCapabilityFilter — /detail per-capability section gating', () => {
+  test('all caps → nothing filtered', () => {
+    const out = applyDetailCapabilityFilter(sampleConfig, files, ALL);
+    expect(out.config.agents).toEqual([{ name: 'a' }]);
+    expect(out.config.skills).toEqual([{ name: 's' }]);
+    expect(out.config.commands).toEqual([{ name: 'c' }]);
+    expect(out.config.manifest_raw).toBe('raw toml');
+    expect(out.files).toHaveLength(3);
+    expect(out.file_count).toBe(3);
+  });
+
+  test('no file.read → files dropped, config untouched', () => {
+    const out = applyDetailCapabilityFilter(sampleConfig, files, { ...ALL, canFiles: false });
+    expect(out.files).toEqual([]);
+    expect(out.file_count).toBe(0);
+    expect(out.config.agents).toEqual([{ name: 'a' }]);
+  });
+
+  test('no skill.read → skills emptied, agents/commands intact', () => {
+    const out = applyDetailCapabilityFilter(sampleConfig, files, { ...ALL, canSkills: false });
+    expect(out.config.skills).toEqual([]);
+    expect(out.config.agents).toEqual([{ name: 'a' }]);
+    expect(out.config.commands).toEqual([{ name: 'c' }]);
+  });
+
+  test('no agent.read → agents + discovery blanked', () => {
+    const out = applyDetailCapabilityFilter(sampleConfig, files, { ...ALL, canAgents: false });
+    expect(out.config.agents).toEqual([]);
+    expect(out.config.agent_discovery).toBeNull();
+  });
+
+  test('no command.read → commands emptied', () => {
+    const out = applyDetailCapabilityFilter(sampleConfig, files, { ...ALL, canCommands: false });
+    expect(out.config.commands).toEqual([]);
+  });
+
+  test('no customize.read → raw config blanked, structural signals kept', () => {
+    const out = applyDetailCapabilityFilter(sampleConfig, files, { ...ALL, canCustomize: false });
+    expect(out.config.manifest_raw).toBeNull();
+    expect(out.config.manifest).toEqual({});
+    expect(out.config.env).toEqual([]);
+    expect(out.config.open_code_raw).toBeNull();
+    expect(out.config.open_code_default_agent).toBeNull();
+    // Structural signals survive so the workspace shell still renders.
+    expect(out.config.is_kortix_repo).toBe(true);
+    expect(out.config.signals).toEqual({ manifest: true });
+  });
+
+  test('member profile (all config reads, NO file.read) → config visible, file list hidden', () => {
+    const out = applyDetailCapabilityFilter(sampleConfig, files, {
+      canFiles: false, canAgents: true, canSkills: true, canCommands: true, canCustomize: true,
+    });
+    expect(out.files).toEqual([]);
+    expect(out.file_count).toBe(0);
+    expect(out.config.agents).toEqual([{ name: 'a' }]);
+    expect(out.config.skills).toEqual([{ name: 's' }]);
+    expect(out.config.manifest_raw).toBe('raw toml');
+  });
+
+  test('files capped at 300 but file_count is the true total', () => {
+    const many = Array.from({ length: 350 }, (_, i) => ({ path: `f${i}` }));
+    const out = applyDetailCapabilityFilter(sampleConfig, many, ALL);
+    expect(out.files).toHaveLength(300);
+    expect(out.file_count).toBe(350);
+  });
+});

--- a/apps/api/src/__tests__/unit-marketplace.test.ts
+++ b/apps/api/src/__tests__/unit-marketplace.test.ts
@@ -26,16 +26,16 @@ describe('marketplace catalog', () => {
     expect(DEFAULT_MARKETPLACES).not.toContain('NousResearch/hermes-agent');
   });
 
-  test('lists the starter skill pack; non-skill items are hidden from browse', async () => {
+  test('surfaces skills + bundles through browse; support types stay internal', async () => {
     const all = await listCatalogItems();
     expect(all.length).toBeGreaterThan(50);
 
-    // Launch scope: marketplace browsing is the skill library. Non-skill
-    // registry entries remain internal for compatibility/dependency handling.
-    expect(all.some((i) => i.type === 'registry:bundle')).toBe(false);
-    expect(all.some((i) => i.type === 'registry:agent')).toBe(false);
+    // The marketplace surfaces the one-click importables (skills, agents,
+    // commands, bundles). Tools/files stay internal for dependency handling.
+    expect(all.some((i) => i.type === 'registry:bundle')).toBe(true);
     expect(all.some((i) => i.type === 'registry:tool')).toBe(false);
-    expect(all.find((i) => i.id === 'kortix:research-pack')).toBeUndefined();
+    expect(all.some((i) => i.type === 'registry:file')).toBe(false);
+    expect(all.find((i) => i.id === 'kortix:research-pack')).toBeTruthy();
 
     expect(all.find((i) => i.name === 'pdf')).toBeTruthy();
   });
@@ -89,7 +89,9 @@ describe('marketplace catalog', () => {
   });
 
   test('filters by type and query', async () => {
-    expect((await listCatalogItems({ type: 'bundle' })).length).toBe(0); // bundles hidden
+    const bundles = await listCatalogItems({ type: 'bundle' });
+    expect(bundles.length).toBeGreaterThan(0); // bundles are browseable one-click starters
+    expect(bundles.every((i) => i.type === 'registry:bundle')).toBe(true);
     expect((await listCatalogItems({ query: 'pdf' })).some((i) => i.name === 'pdf')).toBe(true);
     expect((await listCatalogItems({ query: 'zzzznotathing' })).length).toBe(0);
   });

--- a/apps/api/src/__tests__/unit-quota-gc-select.test.ts
+++ b/apps/api/src/__tests__/unit-quota-gc-select.test.ts
@@ -4,6 +4,7 @@ import {
   QUOTA_GC_KEEP_FRESHEST_DEFAULTS,
   QUOTA_GC_MAX_PER_PASS,
   QUOTA_GC_ORG_HIGH_WATER,
+  QUOTA_GC_ORG_TARGET,
   type SnapshotLike,
   selectSnapshotsToReap,
 } from '../snapshots/quota-gc-select';
@@ -130,6 +131,11 @@ describe('selectSnapshotsToReap — safety invariants', () => {
     expect(names(run(all))).toContain('kortix-default-bad');
   });
 
+  // These two isolate the LIVENESS rules, so the org sits under QUOTA_GC_ORG_TARGET
+  // (still over the high-water mark). Above target the budget stage legitimately
+  // evicts idle ppwarm tips these cases expect to survive — covered separately below.
+  const UNDER_TARGET = QUOTA_GC_ORG_TARGET - 1;
+
   it('keeps the freshest ppwarm tip per project and reaps its stragglers', () => {
     const all = padToOrgSize(
       [
@@ -138,7 +144,7 @@ describe('selectSnapshotsToReap — safety invariants', () => {
         snap('kortix-ppwarm-0945686d-older', { lastUsedAt: ago(3) }),
         snap('kortix-ppwarm-ffffffff-solo', { lastUsedAt: ago(5) }),
       ],
-      90,
+      UNDER_TARGET,
     );
     const reaped = names(run(all));
     expect(reaped).not.toContain('kortix-ppwarm-0945686d-new');
@@ -156,7 +162,7 @@ describe('selectSnapshotsToReap — safety invariants', () => {
         snap('kortix-ppwarm-aaaaaaaa-stale', { lastUsedAt: ago(20) }),
         snap('kortix-ppwarm-bbbbbbbb-fresh', { lastUsedAt: ago(2) }),
       ],
-      90,
+      UNDER_TARGET,
     );
     const reaped = names(run(all));
     expect(reaped).toContain('kortix-ppwarm-aaaaaaaa-stale');
@@ -179,5 +185,76 @@ describe('selectSnapshotsToReap — safety invariants', () => {
     expect(res.doomed.length).toBe(QUOTA_GC_MAX_PER_PASS);
     // 60 defaults, freshest 12 kept → 48 reapable, 15 this pass, 33 deferred.
     expect(res.deferred).toBe(48 - QUOTA_GC_MAX_PER_PASS);
+  });
+});
+
+/**
+ * The live shape on 2026-07-08: 69 ppwarm tips for 69 distinct, non-archived
+ * projects + 22 stock images + 13 defaults + 3 templates = 107, over the 100 cap.
+ * Every liveness rule reclaims nothing (each tip is a live project's only tip), so
+ * a purely liveness-based GC sat at 100% pressure doing nothing. ppwarm is a pure
+ * cache, so it must absorb budget pressure — or say it cannot.
+ */
+describe('selectSnapshotsToReap — ppwarm LRU budget', () => {
+  const liveOrg = (ppwarmCount: number, idleHours: number) =>
+    padToOrgSize(
+      [
+        ...Array.from({ length: ppwarmCount }, (_, i) =>
+          // distinct proj8 per tip → no "superseded tip" rule can fire
+          snap(`kortix-ppwarm-${i.toString(16).padStart(8, '0')}-tip`, {
+            lastUsedAt: new Date(NOW - idleHours * 3_600_000).toISOString(),
+          }),
+        ),
+        ...Array.from({ length: 12 }, (_, i) =>
+          snap(`kortix-default-${i}`, { lastUsedAt: ago(0) }),
+        ),
+      ],
+      107,
+    );
+
+  it('evicts LRU ppwarm to reach target when no liveness rule can free anything', () => {
+    const res = run(liveOrg(69, 30));
+    expect(res.orgTotal).toBe(107);
+    expect(res.underPressure).toBe(true);
+    expect(res.doomed.length).toBeGreaterThan(0);
+    expect(res.doomed.every((d) => d.snapshot.name.startsWith('kortix-ppwarm-'))).toBe(true);
+    expect(res.doomed.some((d) => d.reason.includes('LRU eviction'))).toBe(true);
+    expect(res.budgetUnresolved).toBe(false);
+  });
+
+  it('evicts oldest-first', () => {
+    const all = padToOrgSize(
+      [
+        snap('kortix-ppwarm-aaaaaaaa-tip', {
+          lastUsedAt: new Date(NOW - 50 * 3_600_000).toISOString(),
+        }),
+        snap('kortix-ppwarm-bbbbbbbb-tip', {
+          lastUsedAt: new Date(NOW - 10 * 3_600_000).toISOString(),
+        }),
+      ],
+      QUOTA_GC_ORG_TARGET + 1,
+    );
+    const reaped = names(run(all));
+    expect(reaped).toContain('kortix-ppwarm-aaaaaaaa-tip');
+    expect(reaped).not.toContain('kortix-ppwarm-bbbbbbbb-tip');
+  });
+
+  // Evicting a hot project's tip frees a slot it reclaims on its next session:
+  // churn, not reclamation.
+  it('never evicts a recently-used ppwarm tip, even under pressure', () => {
+    const res = run(liveOrg(69, 1)); // every tip used an hour ago
+    expect(res.underPressure).toBe(true);
+    expect(res.doomed.every((d) => !d.reason.includes('LRU eviction'))).toBe(true);
+  });
+
+  // The alarm that would have caught the original outage: GC out of road.
+  it('flags budgetUnresolved when the cache floor exceeds the quota', () => {
+    const res = run(liveOrg(69, 1)); // nothing evictable, still 107 > target
+    expect(res.budgetUnresolved).toBe(true);
+  });
+
+  it('does not flag budgetUnresolved once target is reachable', () => {
+    const res = run(liveOrg(69, 30));
+    expect(res.budgetUnresolved).toBe(false);
   });
 });

--- a/apps/api/src/__tests__/unit-quota-gc-select.test.ts
+++ b/apps/api/src/__tests__/unit-quota-gc-select.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  DAYTONA_ORG_SNAPSHOT_LIMIT,
+  QUOTA_GC_KEEP_FRESHEST_DEFAULTS,
+  QUOTA_GC_MAX_PER_PASS,
+  QUOTA_GC_ORG_HIGH_WATER,
+  type SnapshotLike,
+  selectSnapshotsToReap,
+} from '../snapshots/quota-gc-select';
+
+const NOW = Date.parse('2026-07-08T00:00:00Z');
+const DAY = 86_400_000;
+const ago = (days: number) => new Date(NOW - days * DAY).toISOString();
+
+function snap(name: string, opts: Partial<SnapshotLike> = {}): SnapshotLike {
+  return {
+    id: opts.id ?? `id-${name}`,
+    name,
+    state: opts.state ?? 'active',
+    createdAt: opts.createdAt ?? ago(1),
+    lastUsedAt: opts.lastUsedAt ?? ago(1),
+  };
+}
+
+/** Pad the org up to `n` snapshots with untouchable stock images. */
+function padToOrgSize(items: SnapshotLike[], n: number): SnapshotLike[] {
+  const pad: SnapshotLike[] = [];
+  for (let i = items.length; i < n; i++) pad.push(snap(`daytonaio/sandbox:${i}`));
+  return [...items, ...pad];
+}
+
+const run = (all: SnapshotLike[], referenced: string[] = []) =>
+  selectSnapshotsToReap({ all, referenced: new Set(referenced), now: NOW });
+
+const names = (r: ReturnType<typeof run>) => r.doomed.map((d) => d.snapshot.name);
+
+describe('selectSnapshotsToReap — pressure gate', () => {
+  it('does nothing while the ORG total is under the high-water mark', () => {
+    const defaults = Array.from({ length: 40 }, (_, i) =>
+      snap(`kortix-default-${i}`, { lastUsedAt: ago(i + 1) }),
+    );
+    const res = run(padToOrgSize(defaults, QUOTA_GC_ORG_HIGH_WATER - 1));
+    expect(res.underPressure).toBe(false);
+    expect(res.doomed).toEqual([]);
+  });
+
+  // The bug: the old gate counted only our template namespace, so ppwarm + stock
+  // images could carry the org past 100 while the gate slept at 15/60.
+  it('fires on org total even when OUR namespace is tiny', () => {
+    const managed = [
+      ...Array.from({ length: 13 }, (_, i) => snap(`kortix-default-${i}`, { lastUsedAt: ago(i) })),
+      snap('kortix-tpl-a'),
+    ];
+    const stock = Array.from({ length: 70 }, (_, i) => snap(`daytonaio/sandbox:${i}`));
+    const res = run([...managed, ...stock]);
+
+    expect(res.orgTotal).toBe(84);
+    expect(res.managedCount).toBe(14);
+    expect(res.orgTotal).toBeGreaterThanOrEqual(QUOTA_GC_ORG_HIGH_WATER);
+    expect(res.underPressure).toBe(true);
+    expect(res.doomed.length).toBeGreaterThan(0);
+  });
+
+  it('high-water leaves headroom below the hard org limit', () => {
+    expect(QUOTA_GC_ORG_HIGH_WATER).toBeLessThan(DAYTONA_ORG_SNAPSHOT_LIMIT);
+  });
+});
+
+describe('selectSnapshotsToReap — defaults ranked by freshness, not idle', () => {
+  // A superseded default keeps a FRESH lastUsedAt (it was live minutes ago), so the
+  // old 7-day idle gate made zero defaults eligible while ~4.5/day accrued.
+  it('reaps superseded defaults that are not idle at all', () => {
+    const defaults = Array.from({ length: 20 }, (_, i) =>
+      snap(`kortix-default-${i}`, { lastUsedAt: new Date(NOW - i * 60_000).toISOString() }),
+    );
+    const res = run(padToOrgSize(defaults, 90));
+
+    expect(res.underPressure).toBe(true);
+    const reaped = names(res);
+    // Freshest N survive.
+    for (let i = 0; i < QUOTA_GC_KEEP_FRESHEST_DEFAULTS; i++) {
+      expect(reaped).not.toContain(`kortix-default-${i}`);
+    }
+    expect(reaped).toContain(`kortix-default-${QUOTA_GC_KEEP_FRESHEST_DEFAULTS}`);
+    expect(reaped).toContain('kortix-default-19');
+  });
+
+  it('never reaps a default a local template row still references', () => {
+    const defaults = Array.from({ length: 20 }, (_, i) =>
+      snap(`kortix-default-${i}`, { lastUsedAt: ago(i) }),
+    );
+    const res = run(padToOrgSize(defaults, 90), ['kortix-default-19']);
+    expect(names(res)).not.toContain('kortix-default-19');
+  });
+});
+
+describe('selectSnapshotsToReap — safety invariants', () => {
+  const base = () =>
+    padToOrgSize(
+      [
+        snap('kortix-tpl-user', { lastUsedAt: ago(30) }),
+        snap('kortix-ppwarm-aaaaaaaa-tip', { lastUsedAt: ago(1) }),
+        snap('daytona-small', { lastUsedAt: ago(400) }),
+        snap('bench-container-ubuntu2204', { lastUsedAt: ago(400) }),
+      ],
+      90,
+    );
+
+  it('never touches non-kortix stock/bench images, however stale', () => {
+    const reaped = names(run(base()));
+    expect(reaped).not.toContain('daytona-small');
+    expect(reaped).not.toContain('bench-container-ubuntu2204');
+  });
+
+  it('never deletes an in-flight build', () => {
+    const all = padToOrgSize(
+      [
+        snap('kortix-default-live', { lastUsedAt: ago(0), state: 'building' }),
+        ...Array.from({ length: 20 }, (_, i) =>
+          snap(`kortix-default-${i}`, { lastUsedAt: ago(i + 1) }),
+        ),
+      ],
+      90,
+    );
+    expect(names(run(all))).not.toContain('kortix-default-live');
+  });
+
+  it('reaps broken-state snapshots in our namespace', () => {
+    const all = padToOrgSize([snap('kortix-default-bad', { state: 'error' })], 90);
+    expect(names(run(all))).toContain('kortix-default-bad');
+  });
+
+  it('keeps the freshest ppwarm tip per project and reaps its stragglers', () => {
+    const all = padToOrgSize(
+      [
+        snap('kortix-ppwarm-0945686d-new', { lastUsedAt: ago(1) }),
+        snap('kortix-ppwarm-0945686d-old', { lastUsedAt: ago(2) }),
+        snap('kortix-ppwarm-0945686d-older', { lastUsedAt: ago(3) }),
+        snap('kortix-ppwarm-ffffffff-solo', { lastUsedAt: ago(5) }),
+      ],
+      90,
+    );
+    const reaped = names(run(all));
+    expect(reaped).not.toContain('kortix-ppwarm-0945686d-new');
+    expect(reaped).toContain('kortix-ppwarm-0945686d-old');
+    expect(reaped).toContain('kortix-ppwarm-0945686d-older');
+    // A project's only tip is live until proven idle.
+    expect(reaped).not.toContain('kortix-ppwarm-ffffffff-solo');
+  });
+
+  // One Daytona org, many databases: a ppwarm tip we can't attribute may belong to
+  // another environment. Idle time is the ONLY cross-env-safe liveness signal.
+  it('reaps a long-idle ppwarm tip but spares a recently used one', () => {
+    const all = padToOrgSize(
+      [
+        snap('kortix-ppwarm-aaaaaaaa-stale', { lastUsedAt: ago(20) }),
+        snap('kortix-ppwarm-bbbbbbbb-fresh', { lastUsedAt: ago(2) }),
+      ],
+      90,
+    );
+    const reaped = names(run(all));
+    expect(reaped).toContain('kortix-ppwarm-aaaaaaaa-stale');
+    expect(reaped).not.toContain('kortix-ppwarm-bbbbbbbb-fresh');
+  });
+
+  it('keeps anything with no usable timestamp — cannot prove it is idle', () => {
+    const all = padToOrgSize(
+      [snap('kortix-tpl-notime', { lastUsedAt: null, createdAt: null })],
+      90,
+    );
+    expect(names(run(all))).not.toContain('kortix-tpl-notime');
+  });
+
+  it('caps deletions per pass and reports the remainder instead of truncating silently', () => {
+    const defaults = Array.from({ length: 60 }, (_, i) =>
+      snap(`kortix-default-${i}`, { lastUsedAt: ago(i + 1) }),
+    );
+    const res = run(padToOrgSize(defaults, 90));
+    expect(res.doomed.length).toBe(QUOTA_GC_MAX_PER_PASS);
+    // 60 defaults, freshest 12 kept → 48 reapable, 15 this pass, 33 deferred.
+    expect(res.deferred).toBe(48 - QUOTA_GC_MAX_PER_PASS);
+  });
+});

--- a/apps/api/src/__tests__/unit-tier-entitlements.test.ts
+++ b/apps/api/src/__tests__/unit-tier-entitlements.test.ts
@@ -7,10 +7,13 @@ import {
 } from '../billing/services/tiers';
 
 // Locks in the plan-gating contract for the enterprise surfaces (SAML SSO,
-// SCIM, custom RBAC, audit access). Only the sales-assigned `enterprise` tier
-// unlocks them; every self-serve / legacy tier is fully gated. The IAM route
-// guard (requireEntitlement) and the /scim/v2 data-plane middleware both key
-// off tierHasEntitlement, so these invariants ARE the access-control policy.
+// SCIM, audit access). Only the sales-assigned `enterprise` tier unlocks
+// those; every self-serve / legacy tier is gated. Groups + custom roles
+// (`rbac`) are deliberately EXEMPT — they're the platform's core
+// collaboration model and available on every tier (un-gated 2026-07-08).
+// The IAM route guard (requireEntitlement) and the /scim/v2 data-plane
+// middleware both key off tierHasEntitlement, so these invariants ARE the
+// access-control policy.
 describe('tier entitlements (enterprise gating)', () => {
   test('enterprise tier unlocks SSO + SCIM + RBAC + audit access', () => {
     expect(tierHasEntitlement('enterprise', 'sso')).toBe(true);
@@ -19,7 +22,7 @@ describe('tier entitlements (enterprise gating)', () => {
     expect(tierHasEntitlement('enterprise', 'auditAccess')).toBe(true);
   });
 
-  test('every non-enterprise tier is fully gated', () => {
+  test('every non-enterprise tier: identity + audit gated, groups/roles (rbac) open', () => {
     for (const t of [
       'none',
       'free',
@@ -36,18 +39,18 @@ describe('tier entitlements (enterprise gating)', () => {
     ]) {
       expect(tierHasEntitlement(t, 'sso')).toBe(false);
       expect(tierHasEntitlement(t, 'scim')).toBe(false);
-      expect(tierHasEntitlement(t, 'rbac')).toBe(false);
+      expect(tierHasEntitlement(t, 'rbac')).toBe(true);
       expect(tierHasEntitlement(t, 'auditAccess')).toBe(false);
     }
   });
 
-  test('unknown tier names fail closed (default tier = none, no entitlements)', () => {
+  test('unknown tier names fail closed on identity/audit; rbac stays universally open', () => {
     expect(tierHasEntitlement('does-not-exist', 'sso')).toBe(false);
     expect(tierHasEntitlement('does-not-exist', 'scim')).toBe(false);
     expect(getTierEntitlements('does-not-exist')).toEqual({
       sso: false,
       scim: false,
-      rbac: false,
+      rbac: true,
       auditAccess: false,
     });
   });

--- a/apps/api/src/__tests__/unit-yaml-config-roundtrip.test.ts
+++ b/apps/api/src/__tests__/unit-yaml-config-roundtrip.test.ts
@@ -1,0 +1,158 @@
+import { describe, test, expect } from 'bun:test';
+import { parseManifestString, serializeManifest, extractTriggers } from '../projects/triggers';
+import { draftToSpec } from '../projects/lib/triggers';
+import { extractAgents } from '../projects/agents';
+import { extractApps } from '../projects/apps';
+import { extractConnectors } from '../projects/connectors';
+
+// Empirical ground truth for the dual-format (TOML v1 + YAML v2) manifest core:
+// parse → extract each resource → serialize → re-parse, for BOTH formats, and
+// prove the write path preserves the file's own format (a .yaml project must
+// never serialize back as TOML).
+
+const YAML_V2 = `kortix_version: 2
+default_agent: kortix
+project:
+  name: probe
+  description: A probe project.
+env:
+  required: []
+  optional: [STRIPE_API_KEY]
+opencode:
+  config_dir: .kortix/opencode
+agents:
+  kortix:
+    connectors: all
+    secrets: all
+    kortix_cli: all
+    skills: all
+  scout:
+    kortix_cli: [project.cr.open]
+    connectors: [github]
+triggers:
+  - slug: nightly
+    name: Nightly
+    type: cron
+    agent: scout
+    enabled: true
+    cron: "0 0 3 * * *"
+    timezone: UTC
+    prompt: do the nightly thing
+`;
+
+const TOML_V1 = `kortix_version = 1
+default_agent = "kortix"
+
+[[agents]]
+name = "kortix"
+env = "all"
+connectors = "all"
+
+[[agents]]
+name = "scout"
+connectors = ["github"]
+
+[[triggers]]
+slug = "nightly"
+name = "Nightly"
+type = "cron"
+agent = "kortix"
+enabled = true
+cron = "0 0 3 * * *"
+prompt = "do the nightly thing"
+`;
+
+describe('YAML v2 manifest — parse + extract', () => {
+  const m = parseManifestString(YAML_V2, 'yaml', 'kortix.yaml');
+
+  test('parses as yaml, schema v2, format/path threaded', () => {
+    expect(m.format).toBe('yaml');
+    expect(m.path).toBe('kortix.yaml');
+    expect(m.schemaVersion).toBe(2);
+  });
+
+  test('extractAgents reads the v2 agents MAP', () => {
+    const { specs, errors } = extractAgents(m);
+    expect(errors).toEqual([]);
+    const names = specs.map((s) => s.name).sort();
+    expect(names).toEqual(['kortix', 'scout']);
+    const scout = specs.find((s) => s.name === 'scout')!;
+    expect(scout.kortixCli).toEqual(['project.cr.open']);
+    expect(scout.connectors).toEqual(['github']);
+    const kortix = specs.find((s) => s.name === 'kortix')!;
+    expect(kortix.connectors).toBe('all');
+  });
+
+  test('extractTriggers reads the yaml triggers list', () => {
+    const { specs, errors } = extractTriggers(m);
+    expect(errors).toEqual([]);
+    expect(specs.map((s) => s.slug)).toEqual(['nightly']);
+    expect(specs[0].agent).toBe('scout');
+  });
+
+  test('extractApps / extractConnectors never throw on a yaml manifest', () => {
+    expect(() => extractApps(m)).not.toThrow();
+    expect(() => extractConnectors(m)).not.toThrow();
+  });
+});
+
+describe('TOML v1 manifest — parse + extract (parity)', () => {
+  const m = parseManifestString(TOML_V1, 'toml', 'kortix.toml');
+
+  test('parses as toml, schema v1', () => {
+    expect(m.format).toBe('toml');
+    expect(m.schemaVersion).toBe(1);
+  });
+
+  test('extractAgents reads the v1 [[agents]] ARRAY', () => {
+    const { specs, errors } = extractAgents(m);
+    expect(errors).toEqual([]);
+    expect(specs.map((s) => s.name).sort()).toEqual(['kortix', 'scout']);
+    expect(specs.find((s) => s.name === 'scout')!.connectors).toEqual(['github']);
+  });
+
+  test('extractTriggers reads the toml [[triggers]] array', () => {
+    const { specs, errors } = extractTriggers(m);
+    expect(errors).toEqual([]);
+    expect(specs.map((s) => s.slug)).toEqual(['nightly']);
+  });
+});
+
+describe('round-trip serialize preserves the file format', () => {
+  test('yaml manifest → serialize stays YAML (agents map, not [[agents]]) + re-parses equal', () => {
+    const m = parseManifestString(YAML_V2, 'yaml', 'kortix.yaml');
+    const out = serializeManifest(m);
+    expect(out).toMatch(/^kortix_version: 2/m); // yaml scalar, not `kortix_version = 2`
+    expect(out).toContain('agents:');
+    expect(out).not.toContain('[[agents]]');
+    // Re-parse and confirm no data loss on the round-trip.
+    const m2 = parseManifestString(out, 'yaml', 'kortix.yaml');
+    expect(extractAgents(m2).specs.map((s) => s.name).sort()).toEqual(['kortix', 'scout']);
+    expect(extractTriggers(m2).specs.map((s) => s.slug)).toEqual(['nightly']);
+  });
+
+  test('toml manifest → serialize stays TOML ([[agents]], not agents:)', () => {
+    const m = parseManifestString(TOML_V1, 'toml', 'kortix.toml');
+    const out = serializeManifest(m);
+    expect(out).toMatch(/kortix_version = 1/);
+    expect(out).toContain('[[agents]]');
+    const m2 = parseManifestString(out, 'toml', 'kortix.toml');
+    expect(extractAgents(m2).specs.map((s) => s.name).sort()).toEqual(['kortix', 'scout']);
+  });
+});
+
+describe('draftToSpec — new trigger spec path uses the real manifest file', () => {
+  const draft = {
+    slug: 'nightly', name: 'Nightly', type: 'cron' as const, agent: 'kortix', model: null,
+    enabled: true, promptTemplate: 'do it', cron: '0 0 3 * * *', runAt: null,
+    timezone: 'UTC', secretEnv: null, sessionMode: 'fresh' as const,
+  };
+
+  test('YAML project → path is kortix.yaml#triggers.<slug> (not hardcoded toml)', () => {
+    expect(draftToSpec(draft, 'kortix.yaml').path).toBe('kortix.yaml#triggers.nightly');
+  });
+
+  test('TOML default preserved when no path passed', () => {
+    expect(draftToSpec(draft).path).toBe('kortix.toml#triggers.nightly');
+  });
+});

--- a/apps/api/src/accounts/iam.ts
+++ b/apps/api/src/accounts/iam.ts
@@ -12,7 +12,8 @@
 // Custom roles + policies were REBUILT from scratch in Phase 3 of
 // feat/iam-rbac-v1 (June 2026, ./iam/custom-roles.ts): DB-backed custom
 // roles (iam_roles / iam_role_actions) and role bindings (iam_policies) are
-// live, Enterprise-entitlement-gated ('rbac'), and read by the V2 engine
+// live, available on every tier (the 'rbac' entitlement is granted to all
+// plans since 2026-07-08), and read by the V2 engine
 // (../iam/engine-v2.ts), which unions their granted actions additively on
 // top of the fixed built-in preset roles. These tables are NOT dead.
 //

--- a/apps/api/src/billing/services/tiers.ts
+++ b/apps/api/src/billing/services/tiers.ts
@@ -151,10 +151,14 @@ export function getComputeDescription(serverType: string): string {
 
 // ─── Tiers ──────────────────────────────────────────────────────────────────
 
-// Enterprise feature gates. Every self-serve tier (Free / Team) gets NONE;
-// the sales-assigned `enterprise` tier gets ALL. See TierEntitlements in
-// ../../types and the requireEntitlement() guard in the IAM routes.
-const NO_ENTERPRISE: TierEntitlements = { sso: false, scim: false, rbac: false, auditAccess: false };
+// Enterprise feature gates. Groups + custom roles/policies (`rbac`) are
+// available on EVERY tier — they're the platform's core collaboration and
+// access model, not an upsell (un-gated 2026-07-08; they were briefly
+// enterprise-gated by #4135). The enterprise identity surface (SAML SSO +
+// SCIM) and audit access remain exclusive to the sales-assigned `enterprise`
+// tier. See TierEntitlements in ../../types and the requireEntitlement()
+// guard in the IAM routes, which keys off this matrix.
+const SELF_SERVE: TierEntitlements = { sso: false, scim: false, rbac: true, auditAccess: false };
 const ALL_ENTERPRISE: TierEntitlements = { sso: true, scim: true, rbac: true, auditAccess: true };
 
 const TIERS: Record<string, TierConfig> = {
@@ -169,7 +173,7 @@ const TIERS: Record<string, TierConfig> = {
     dailyCreditConfig: null,
     hidden: true,
     concurrentSessionLimit: 50,
-    entitlements: NO_ENTERPRISE,
+    entitlements: SELF_SERVE,
   },
 
   free: {
@@ -183,7 +187,7 @@ const TIERS: Record<string, TierConfig> = {
     dailyCreditConfig: null,
     hidden: false,
     concurrentSessionLimit: 50,
-    entitlements: NO_ENTERPRISE,
+    entitlements: SELF_SERVE,
   },
 
   pro: {
@@ -197,7 +201,7 @@ const TIERS: Record<string, TierConfig> = {
     dailyCreditConfig: null,
     hidden: false,
     concurrentSessionLimit: 200,
-    entitlements: NO_ENTERPRISE,
+    entitlements: SELF_SERVE,
   },
 
   // Billing v2 — per-member seat plan. $25 × seat_count / month.
@@ -214,7 +218,7 @@ const TIERS: Record<string, TierConfig> = {
     dailyCreditConfig: null,
     hidden: false,
     concurrentSessionLimit: 200,
-    entitlements: NO_ENTERPRISE,
+    entitlements: SELF_SERVE,
   },
 
   // ── Enterprise (sales-assigned, not self-serve) ──────────────────────────
@@ -252,7 +256,7 @@ const TIERS: Record<string, TierConfig> = {
     dailyCreditConfig: null,
     hidden: true,
     concurrentSessionLimit: 200,
-    entitlements: NO_ENTERPRISE,
+    entitlements: SELF_SERVE,
   },
   tier_6_50: {
     name: 'tier_6_50',
@@ -265,7 +269,7 @@ const TIERS: Record<string, TierConfig> = {
     dailyCreditConfig: null,
     hidden: true,
     concurrentSessionLimit: 300,
-    entitlements: NO_ENTERPRISE,
+    entitlements: SELF_SERVE,
   },
   tier_12_100: {
     name: 'tier_12_100',
@@ -278,7 +282,7 @@ const TIERS: Record<string, TierConfig> = {
     dailyCreditConfig: null,
     hidden: true,
     concurrentSessionLimit: 400,
-    entitlements: NO_ENTERPRISE,
+    entitlements: SELF_SERVE,
   },
   tier_25_200: {
     name: 'tier_25_200',
@@ -291,7 +295,7 @@ const TIERS: Record<string, TierConfig> = {
     dailyCreditConfig: null,
     hidden: true,
     concurrentSessionLimit: 500,
-    entitlements: NO_ENTERPRISE,
+    entitlements: SELF_SERVE,
   },
   tier_50_400: {
     name: 'tier_50_400',
@@ -304,7 +308,7 @@ const TIERS: Record<string, TierConfig> = {
     dailyCreditConfig: null,
     hidden: true,
     concurrentSessionLimit: 750,
-    entitlements: NO_ENTERPRISE,
+    entitlements: SELF_SERVE,
   },
   tier_125_800: {
     name: 'tier_125_800',
@@ -317,7 +321,7 @@ const TIERS: Record<string, TierConfig> = {
     dailyCreditConfig: null,
     hidden: true,
     concurrentSessionLimit: 1000,
-    entitlements: NO_ENTERPRISE,
+    entitlements: SELF_SERVE,
   },
   tier_200_1000: {
     name: 'tier_200_1000',
@@ -330,7 +334,7 @@ const TIERS: Record<string, TierConfig> = {
     dailyCreditConfig: null,
     hidden: true,
     concurrentSessionLimit: 1500,
-    entitlements: NO_ENTERPRISE,
+    entitlements: SELF_SERVE,
   },
   tier_150_1200: {
     name: 'tier_150_1200',
@@ -343,7 +347,7 @@ const TIERS: Record<string, TierConfig> = {
     dailyCreditConfig: null,
     hidden: true,
     concurrentSessionLimit: 2000,
-    entitlements: NO_ENTERPRISE,
+    entitlements: SELF_SERVE,
   },
 };
 

--- a/apps/api/src/marketplace/catalog.test.ts
+++ b/apps/api/src/marketplace/catalog.test.ts
@@ -81,12 +81,29 @@ describe('pageCatalogItems', () => {
     const items = [
       ...synthetic(3, (i) => ({ name: `alpha-${i}`, title: `Alpha ${i}`, type: 'registry:skill', registry: 'kortix-starter' })),
       ...synthetic(3, (i) => ({ name: `beta-${i}`, title: `Beta ${i}`, type: 'registry:skill', registry: 'other-registry' })),
-      item({ id: 'hidden-agent', name: 'hidden-agent', title: 'Hidden Agent', type: 'registry:agent', registry: 'kortix-starter' }),
+      item({ id: 'hidden-tool', name: 'hidden-tool', title: 'Hidden Tool', type: 'registry:tool', registry: 'kortix-starter' }),
     ];
     const result = pageCatalogItems(items, { query: 'alpha', source: 'kortix', limit: 2, offset: 0 });
     expect(result.total).toBe(3);
     expect(result.items.length).toBe(2);
     expect(result.items.every((it) => it.name.startsWith('alpha'))).toBe(true);
+  });
+
+  test('surfaces skills, agents, commands, and bundles as browseable; hides support types', () => {
+    const items = [
+      item({ id: 'k:skill', name: 'a-skill', type: 'registry:skill' }),
+      item({ id: 'k:agent', name: 'a-agent', type: 'registry:agent' }),
+      item({ id: 'k:command', name: 'a-command', type: 'registry:command' }),
+      item({ id: 'k:bundle', name: 'a-bundle', type: 'registry:bundle' }),
+      item({ id: 'k:tool', name: 'a-tool', type: 'registry:tool' }),
+      item({ id: 'k:rules', name: 'a-rules', type: 'registry:rules' }),
+    ];
+    const result = pageCatalogItems(items, {});
+    const visible = new Set(result.items.map((it) => it.type));
+    expect(visible).toEqual(
+      new Set(['registry:skill', 'registry:agent', 'registry:command', 'registry:bundle']),
+    );
+    expect(result.total).toBe(4);
   });
 
   test('offset past the end returns empty items, hasMore false, and a correct total', () => {

--- a/apps/api/src/marketplace/catalog.ts
+++ b/apps/api/src/marketplace/catalog.ts
@@ -1428,10 +1428,18 @@ export async function listFeaturedMarketplaces(): Promise<
 // ── public read API ────────────────────────────────────────────────────────
 type ItemQuery = { query?: string; type?: string; source?: string };
 
-// Launch scope: the marketplace is the skill library. Agents, commands, tools,
-// bundles, and support files may still exist in registries for compatibility
-// and dependency resolution, but they are not browse/install choices.
-const MARKETPLACE_VISIBLE_TYPES = new Set<string>(["registry:skill"]);
+// The one-click importables the marketplace surfaces to users: skills, agents,
+// commands, and bundles (curated starters / use-cases). Tools, rules, and other
+// support files still exist in registries for dependency resolution but aren't
+// browse/install choices on their own. Install is capability-gated per committed
+// file path (see projects/routes/r10 assertCommitCapabilities), so widening this
+// set never bypasses authz.
+const MARKETPLACE_VISIBLE_TYPES = new Set<string>([
+  "registry:skill",
+  "registry:agent",
+  "registry:command",
+  "registry:bundle",
+]);
 
 function isBrowseableCatalogItem(it: CatalogItem): boolean {
   return MARKETPLACE_VISIBLE_TYPES.has(it.type) && !it.hidden;

--- a/apps/api/src/projects/agents.ts
+++ b/apps/api/src/projects/agents.ts
@@ -152,7 +152,10 @@ export function extractAgents(manifest: ParsedManifest): LoadedAgents {
       errors: [{
         name: '(top-level)',
         path: filename,
-        error: '`agents` must be an array of tables — use [[agents]], not [agents]',
+        error:
+          manifest.format === 'yaml'
+            ? '`agents` must be a list — write it as a YAML `agents:` list (or a name→block map in v2), not a scalar.'
+            : '`agents` must be an array of tables — use [[agents]], not [agents]',
       }],
       defaultAgent: null,
     };

--- a/apps/api/src/projects/apps.ts
+++ b/apps/api/src/projects/apps.ts
@@ -88,7 +88,10 @@ export function extractApps(manifest: ParsedManifest): LoadedApps {
       errors: [{
         slug: '(top-level)',
         path: filename,
-        error: '`apps` must be an array of tables — use [[apps]], not [apps]',
+        error:
+          manifest.format === 'yaml'
+            ? '`apps` must be a list — write it as a YAML `apps:` list, not a map or scalar.'
+            : '`apps` must be an array of tables — use [[apps]], not [apps]',
       }],
     };
   }

--- a/apps/api/src/projects/connectors.ts
+++ b/apps/api/src/projects/connectors.ts
@@ -167,7 +167,10 @@ export function extractConnectors(manifest: ParsedManifest): LoadedConnectors {
       errors: [{
         slug: '(top-level)',
         path: filename,
-        error: '`connectors` must be an array of tables — use [[connectors]], not [connectors]',
+        error:
+          manifest.format === 'yaml'
+            ? '`connectors` must be a list — write it as a YAML `connectors:` list, not a map or scalar.'
+            : '`connectors` must be an array of tables — use [[connectors]], not [connectors]',
       }],
     };
   }

--- a/apps/api/src/projects/lib/access.ts
+++ b/apps/api/src/projects/lib/access.ts
@@ -377,6 +377,36 @@ export async function assertProjectCapability(
 }
 
 /**
+ * Non-throwing sibling of assertProjectCapability: returns WHETHER the leaf is
+ * allowed for the current request (threading the acting token so the agent-grant
+ * fold fires), instead of 403-ing. For response-level filtering where a coarse
+ * gate already passed but individual sections must be hidden per-capability —
+ * e.g. GET /detail returns the project shell to any member but omits the file
+ * list / a config sub-section the caller can't read, rather than denying the
+ * whole bundle (which would lock a plain `member`, who lacks file.read, out of
+ * the workspace entirely).
+ */
+export async function projectCapabilityAllowed(
+  c: Context,
+  userId: string,
+  accountId: string,
+  projectId: string,
+  action: string,
+): Promise<boolean> {
+  const actingTokenId =
+    ((c as unknown as { get(k: string): unknown }).get('iamTokenId') as string | undefined) ?? undefined;
+  const verdict = await authorize(
+    userId,
+    accountId,
+    action,
+    { type: 'project', id: projectId },
+    actingTokenId,
+    deriveRequestContext(c),
+  );
+  return verdict.allowed;
+}
+
+/**
  * The per-capability WRITE leaf that governs editing a given repo path. Agents,
  * skills and commands live under their own directories; everything else is a
  * generic project file. Lets an API edit path (e.g. a marketplace install) gate

--- a/apps/api/src/projects/lib/agent-config-v2.ts
+++ b/apps/api/src/projects/lib/agent-config-v2.ts
@@ -126,3 +126,52 @@ export function applyAgentBlockV2(
   }
   return { ok: true, raw: nextRaw };
 }
+
+/**
+ * Apply a secrets/connectors SCOPE edit to a v2 `agents:` MAP manifest — the v2
+ * counterpart of `applyAgentScope` in `../agents.ts` (which only handles the v1
+ * `[[agents]]` array and would treat a v2 map as an empty array → "agent not
+ * found"). Reads the agent's existing governance block, merges in JUST the two
+ * scope grants, and reuses `applyAgentBlockV2` for the upsert + `validateManifest`
+ * gate (so every other governance field on the block is preserved verbatim).
+ *
+ * Two v2 semantics the v1 path gets wrong: (1) v1's wire `env` is v2's `secrets`
+ * key; (2) v2 is deny-by-default, so a none/`[]` selection is written by OMITTING
+ * the key (matching hand-authored kortix.yaml), NOT by v1's env-default-is-'all'
+ * omit rule. `notFound` distinguishes "agent not declared" (route → 404) from a
+ * validation failure (route → 400) — this path scopes an existing agent, it
+ * never creates one.
+ */
+export function applyAgentScopeV2(
+  manifest: ParsedManifest,
+  agentName: string,
+  scope: { env?: string[] | 'all'; connectors?: string[] | 'all' },
+): ApplyAgentBlockResult & { notFound?: boolean } {
+  const rawAgents = manifest.raw.agents;
+  const existing =
+    rawAgents && typeof rawAgents === 'object' && !Array.isArray(rawAgents)
+      ? (rawAgents as Record<string, unknown>)[agentName]
+      : undefined;
+  if (existing === undefined || existing === null) {
+    return {
+      ok: false,
+      notFound: true,
+      error: `No agent "${agentName}" declared in ${manifest.path || 'kortix.yaml'}`,
+    };
+  }
+  if (typeof existing !== 'object' || Array.isArray(existing)) {
+    return { ok: false, error: `agents.${agentName} is malformed (expected a table/object).` };
+  }
+  const merged: Record<string, unknown> = { ...(existing as Record<string, unknown>) };
+  if (scope.env !== undefined) {
+    if (scope.env === 'all') merged.secrets = 'all';
+    else if (scope.env.length === 0) delete merged.secrets;
+    else merged.secrets = scope.env;
+  }
+  if (scope.connectors !== undefined) {
+    if (scope.connectors === 'all') merged.connectors = 'all';
+    else if (scope.connectors.length === 0) delete merged.connectors;
+    else merged.connectors = scope.connectors;
+  }
+  return applyAgentBlockV2(manifest, agentName, merged as AgentBlockV2);
+}

--- a/apps/api/src/projects/lib/detail-capability-filter.ts
+++ b/apps/api/src/projects/lib/detail-capability-filter.ts
@@ -1,0 +1,50 @@
+// GET /:projectId/detail bundles several read surfaces (the config summary's
+// agents/skills/commands + raw customization config, and the repo file list)
+// behind ONE coarse project.read floor. To keep each capability checkbox
+// authoritative WITHOUT 403-ing the whole workspace load, the handler resolves
+// the caller's per-leaf read capabilities and passes them here to blank out the
+// sections they can't read. Pure + exported so the gating is unit-tested
+// independent of git/DB (the handler just supplies the resolved booleans).
+
+export interface DetailCaps {
+  /** project.file.read — the repo file list. */
+  canFiles: boolean;
+  /** project.agent.read — the agents summary + discovery mode. */
+  canAgents: boolean;
+  /** project.skill.read — the skills summary. */
+  canSkills: boolean;
+  /** project.command.read — the slash-commands summary. */
+  canCommands: boolean;
+  /** project.customize.read — the raw project config (kortix.toml / opencode). */
+  canCustomize: boolean;
+}
+
+/**
+ * Blank out the /detail sections the caller lacks the leaf for. Structural
+ * signals (is_kortix_repo, signals) are always preserved so the shell renders;
+ * only the resource lists / raw config are emptied. Files are capped at 300 (the
+ * same cap the handler used inline) and dropped entirely without file.read.
+ */
+// `C extends object` (not Record<string, unknown>): the handler's config is a
+// concrete interface (ProjectConfigSummary), which TS won't implicitly widen to
+// a Record index signature. `object` accepts both interfaces and literals.
+export function applyDetailCapabilityFilter<C extends object, F>(
+  config: C,
+  visibleFiles: F[],
+  caps: DetailCaps,
+): { config: C; files: F[]; file_count: number } {
+  const gatedConfig = {
+    ...config,
+    ...(caps.canAgents ? {} : { agents: [], agent_discovery: null }),
+    ...(caps.canSkills ? {} : { skills: [] }),
+    ...(caps.canCommands ? {} : { commands: [] }),
+    ...(caps.canCustomize
+      ? {}
+      : { manifest_raw: null, manifest: {}, env: [], open_code_raw: null, open_code_default_agent: null }),
+  } as C;
+  return {
+    config: gatedConfig,
+    files: caps.canFiles ? visibleFiles.slice(0, 300) : [],
+    file_count: caps.canFiles ? visibleFiles.length : 0,
+  };
+}

--- a/apps/api/src/projects/lib/serializers.ts
+++ b/apps/api/src/projects/lib/serializers.ts
@@ -3,6 +3,12 @@ import type { Project, ProjectSession, Secret } from '@kortix/api-contract';
 import { type SecretGrant, visibilityToIntent } from '../../executor/share';
 import { db } from '../../shared/db';
 import { listSandboxTemplates, listSnapshotBuilds } from '../../snapshots/builder';
+import {
+  classifySnapshotError,
+  describeSnapshotError,
+  type SnapshotErrorCategory,
+} from '../../snapshots/error-classify';
+import { templateSlugFromBuildSlug } from '../../snapshots/ppwarm-names';
 import { type ProjectRole } from '../access';
 import { resolveAppsEnabled } from '../apps-config';
 import { resolveExperimentalFeatures, buildExperimentalCatalog } from '../../experimental/features';
@@ -449,14 +455,30 @@ export async function readBody(c: Context) {
 
 
 export function serializeBuildSummary(b: Awaited<ReturnType<typeof listSnapshotBuilds>>[number]) {
+  // errorCategory is a free-form column; older rows predate the classifier.
+  const category = (b.errorCategory ??
+    (b.error ? classifySnapshotError(b.error) : null)) as SnapshotErrorCategory | null;
   return {
     build_id: b.buildId,
     slug: b.slug,
+    /**
+     * The TEMPLATE this build was for. `slug` may be a build-log pseudo-slug
+     * (`default-warm`) that names no template; clients that want to act on a build
+     * — rebuild it, boot a session on it — must use this, never `slug`.
+     */
+    template_slug: templateSlugFromBuildSlug(b.slug),
     snapshot_name: b.snapshotName,
     content_hash: b.contentHash,
     status: b.status,
     error: b.error,
-    error_category: b.errorCategory,
+    error_category: category,
+    /**
+     * Whether an in-sandbox agent could plausibly fix this by editing the repo.
+     * Server-derived so the UI can't drift from what the API will accept: infra
+     * failures (quota, provider, timeout) are not repo-editable, and a fix session
+     * can't even boot when the snapshot it needs is the thing that failed.
+     */
+    fixable_by_agent: category ? describeSnapshotError(category).fixableByAgent : false,
     source: b.source,
     started_at: b.startedAt.toISOString(),
     finished_at: b.finishedAt?.toISOString() ?? null,

--- a/apps/api/src/projects/lib/triggers.ts
+++ b/apps/api/src/projects/lib/triggers.ts
@@ -1223,10 +1223,12 @@ export function slugify(input: string): string {
   );
 }
 
-export function draftToSpec(draft: TriggerDraft): GitTriggerSpec {
+export function draftToSpec(draft: TriggerDraft, manifestPath: string = MANIFEST_FILENAME): GitTriggerSpec {
   return {
     slug: draft.slug,
-    path: `${MANIFEST_FILENAME}#triggers.${draft.slug}`,
+    // Use the ACTUAL manifest path so a YAML project's trigger spec reports
+    // `kortix.yaml#triggers.<slug>`, not a hardcoded `kortix.toml#…`.
+    path: `${manifestPath}#triggers.${draft.slug}`,
     name: draft.name,
     type: draft.type,
     agent: draft.agent,

--- a/apps/api/src/projects/maintenance.test.ts
+++ b/apps/api/src/projects/maintenance.test.ts
@@ -27,7 +27,7 @@ mock.module('../shared/db', () => ({
 mock.module('./git', () => ({ deleteRemoteSessionBranch: async () => false }));
 mock.module('../billing/services/compute-metering', () => ({ tickRunningComputeCharges: async () => ({ settled: 0 }) }));
 mock.module('../snapshots/builder', () => ({ reconcileStaleBuilds: async () => ({ checked: 0, closedReady: 0, closedFailed: 0 }) }));
-mock.module('../snapshots/quota-gc', () => ({ reconcileSnapshotQuota: async () => ({ namespaceCount: 0, eligible: 0, deleted: 0, dryRun: false }) }));
+mock.module('../snapshots/quota-gc', () => ({ reconcileSnapshotQuota: async () => ({ orgTotal: 0, managedCount: 0, eligible: 0, deleted: 0, deferred: 0, dryRun: false }) }));
 // Controllable per-test: the first call can be made to hang forever (to
 // simulate the exact 2026-07-02 failure mode — an unbounded provider call
 // stuck inside reapAndReconcileSandboxes), later calls resolve normally.

--- a/apps/api/src/projects/maintenance.test.ts
+++ b/apps/api/src/projects/maintenance.test.ts
@@ -25,23 +25,50 @@ mock.module('../shared/db', () => ({
   },
 }));
 mock.module('./git', () => ({ deleteRemoteSessionBranch: async () => false }));
-mock.module('../billing/services/compute-metering', () => ({ tickRunningComputeCharges: async () => ({ settled: 0 }) }));
-mock.module('../snapshots/builder', () => ({ reconcileStaleBuilds: async () => ({ checked: 0, closedReady: 0, closedFailed: 0 }) }));
-mock.module('../snapshots/quota-gc', () => ({ reconcileSnapshotQuota: async () => ({ orgTotal: 0, managedCount: 0, eligible: 0, deleted: 0, deferred: 0, dryRun: false }) }));
+mock.module('../billing/services/compute-metering', () => ({
+  tickRunningComputeCharges: async () => ({ settled: 0 }),
+}));
+mock.module('../snapshots/builder', () => ({
+  reconcileStaleBuilds: async () => ({ checked: 0, closedReady: 0, closedFailed: 0 }),
+}));
+mock.module('../snapshots/quota-gc', () => ({
+  reconcileSnapshotQuota: async () => ({
+    orgTotal: 0,
+    managedCount: 0,
+    eligible: 0,
+    deleted: 0,
+    deferred: 0,
+    budgetUnresolved: false,
+    dryRun: false,
+  }),
+}));
 // Controllable per-test: the first call can be made to hang forever (to
 // simulate the exact 2026-07-02 failure mode — an unbounded provider call
 // stuck inside reapAndReconcileSandboxes), later calls resolve normally.
-let reapAndReconcileSandboxesImpl = async () => ({ candidates: 0, stopped: 0, reconciled: 0, billingClosed: 0, skipped: 0, errors: 0 });
+let reapAndReconcileSandboxesImpl = async () => ({
+  candidates: 0,
+  stopped: 0,
+  reconciled: 0,
+  billingClosed: 0,
+  skipped: 0,
+  errors: 0,
+});
 
 mock.module('./sandbox-reaper', () => ({
   reapAndReconcileSandboxes: () => reapAndReconcileSandboxesImpl(),
   reconcileOrphanComputeSessions: async () => ({ checked: 0, closed: 0, errors: 0 }),
-  reconcileStuckActiveSessions: async () => ({ candidates: 0, reconciled: 0, billingClosed: 0, errors: 0 }),
+  reconcileStuckActiveSessions: async () => ({
+    candidates: 0,
+    reconciled: 0,
+    billingClosed: 0,
+    errors: 0,
+  }),
   reapOrphanProviderBoxes: async () => ({ listed: 0, orphans: 0, stopped: 0, errors: 0 }),
   countBillingInvariantViolations: async () => 0,
 }));
 
-const { shouldForceResetStaleLock, runProjectMaintenance, __isMaintenanceRunningForTest } = await import('./maintenance');
+const { shouldForceResetStaleLock, runProjectMaintenance, __isMaintenanceRunningForTest } =
+  await import('./maintenance');
 
 // Regression coverage for the 2026-07-02 incident: an unbounded Daytona SDK
 // call inside a maintenance cycle left `maintenanceRunning` stuck `true`
@@ -85,7 +112,7 @@ describe('shouldForceResetStaleLock', () => {
 // THIRD cycle start concurrently. The fix gates the `finally` release on a
 // generation counter so only the run that's still current can release it.
 describe('runProjectMaintenance stale-lock generation guard', () => {
-  test('an abandoned run settling late does not release a newer run\'s lock', async () => {
+  test("an abandoned run settling late does not release a newer run's lock", async () => {
     process.env.KORTIX_PROJECT_MAINTENANCE_STALL_MS = '20';
 
     let releaseHungRun: () => void = () => {};
@@ -95,7 +122,14 @@ describe('runProjectMaintenance stale-lock generation guard', () => {
 
     // Run A: hangs until we explicitly release it.
     reapAndReconcileSandboxesImpl = () =>
-      hungRunSettled.then(() => ({ candidates: 0, stopped: 0, reconciled: 0, billingClosed: 0, skipped: 0, errors: 0 }));
+      hungRunSettled.then(() => ({
+        candidates: 0,
+        stopped: 0,
+        reconciled: 0,
+        billingClosed: 0,
+        skipped: 0,
+        errors: 0,
+      }));
     const runA = runProjectMaintenance();
 
     // Let run A acquire the lock before we try to stall past the threshold.
@@ -105,7 +139,14 @@ describe('runProjectMaintenance stale-lock generation guard', () => {
     // Wait past the (tiny, test-only) stall threshold, then start run B —
     // this is the watchdog force-reset path.
     await new Promise((r) => setTimeout(r, 30));
-    reapAndReconcileSandboxesImpl = async () => ({ candidates: 0, stopped: 0, reconciled: 0, billingClosed: 0, skipped: 0, errors: 0 });
+    reapAndReconcileSandboxesImpl = async () => ({
+      candidates: 0,
+      stopped: 0,
+      reconciled: 0,
+      billingClosed: 0,
+      skipped: 0,
+      errors: 0,
+    });
     const errorSpy = mock((..._args: unknown[]) => {});
     const originalError = console.error;
     console.error = errorSpy;

--- a/apps/api/src/projects/maintenance.ts
+++ b/apps/api/src/projects/maintenance.ts
@@ -1,16 +1,16 @@
-import { and, eq, inArray, lt, ne } from 'drizzle-orm';
 import { projectSessions, projects } from '@kortix/db';
-import { db } from '../shared/db';
-import { deleteRemoteSessionBranch, type GitBackedProject } from './git';
+import { and, eq, inArray, lt, ne } from 'drizzle-orm';
 import { tickRunningComputeCharges } from '../billing/services/compute-metering';
+import { db } from '../shared/db';
 import { reconcileStaleBuilds } from '../snapshots/builder';
 import { reconcileSnapshotQuota } from '../snapshots/quota-gc';
+import { type GitBackedProject, deleteRemoteSessionBranch } from './git';
 import {
+  countBillingInvariantViolations,
   reapAndReconcileSandboxes,
+  reapOrphanProviderBoxes,
   reconcileOrphanComputeSessions,
   reconcileStuckActiveSessions,
-  reapOrphanProviderBoxes,
-  countBillingInvariantViolations,
 } from './sandbox-reaper';
 
 const DEFAULT_BRANCH_RETENTION_DAYS = 90;
@@ -50,7 +50,10 @@ function branchRetentionDays(): number {
 }
 
 function maintenanceIntervalMs(): number {
-  return positiveInt(process.env.KORTIX_PROJECT_MAINTENANCE_INTERVAL_MS, DEFAULT_MAINTENANCE_INTERVAL_MS);
+  return positiveInt(
+    process.env.KORTIX_PROJECT_MAINTENANCE_INTERVAL_MS,
+    DEFAULT_MAINTENANCE_INTERVAL_MS,
+  );
 }
 
 // STALL WATCHDOG — the second, independent line of defense against this exact
@@ -74,7 +77,9 @@ export function shouldForceResetStaleLock(heldForMs: number, thresholdMs: number
   return heldForMs >= thresholdMs;
 }
 
-export function hasOpenPullRequestMarker(metadata: Record<string, unknown> | null | undefined): boolean {
+export function hasOpenPullRequestMarker(
+  metadata: Record<string, unknown> | null | undefined,
+): boolean {
   if (!metadata) return false;
   if (metadata.open_pr === true || metadata.has_open_pr === true) return true;
   for (const key of ['pull_request', 'github_pull_request', 'pr']) {
@@ -117,11 +122,13 @@ export async function sweepExpiredSessionBranches(now = new Date()): Promise<{
     })
     .from(projectSessions)
     .innerJoin(projects, eq(projectSessions.projectId, projects.projectId))
-    .where(and(
-      inArray(projectSessions.status, [...TERMINAL_SESSION_STATUSES]),
-      lt(projectSessions.updatedAt, cutoff),
-      ne(projectSessions.branchName, projects.defaultBranch),
-    ))
+    .where(
+      and(
+        inArray(projectSessions.status, [...TERMINAL_SESSION_STATUSES]),
+        lt(projectSessions.updatedAt, cutoff),
+        ne(projectSessions.branchName, projects.defaultBranch),
+      ),
+    )
     .limit(GC_BATCH_SIZE);
 
   let deleted = 0;
@@ -190,24 +197,46 @@ export async function runProjectMaintenance(): Promise<void> {
     // below so it can no longer clobber this (or a later) run's lock.
     console.error(
       `[project-maintenance] STALLED — lock held for ${heldForMs}ms (threshold ${stallThresholdMs()}ms), forcing reset. ` +
-      'This means a prior cycle hung on an unbounded call — file a bug, this should not happen with all provider calls timeout-bounded.',
+        'This means a prior cycle hung on an unbounded call — file a bug, this should not happen with all provider calls timeout-bounded.',
     );
   }
   const myGeneration = ++maintenanceGeneration;
   maintenanceRunning = true;
   maintenanceStartedAt = Date.now();
   try {
-    const [idle, orphanCompute, stuckSessions, orphanBoxes, branches, computeTick, staleBuilds, snapshotGc] = await Promise.all([
+    const [
+      idle,
+      orphanCompute,
+      stuckSessions,
+      orphanBoxes,
+      branches,
+      computeTick,
+      staleBuilds,
+      snapshotGc,
+    ] = await Promise.all([
       // Provider-authoritative idle reaper + state/billing reconcile (the fix for
       // boxes that never auto-stopped and kept billing). Backstops the webhooks.
       reapAndReconcileSandboxes().catch((err) => {
-        console.warn('[project-maintenance] reaper failed:', err instanceof Error ? err.message : err);
-        return { candidates: 0, stopped: 0, reconciled: 0, billingClosed: 0, skipped: 0, errors: 0 };
+        console.warn(
+          '[project-maintenance] reaper failed:',
+          err instanceof Error ? err.message : err,
+        );
+        return {
+          candidates: 0,
+          stopped: 0,
+          reconciled: 0,
+          billingClosed: 0,
+          skipped: 0,
+          errors: 0,
+        };
       }),
       // Billing safety net: close metering for any active compute row whose box
       // is not actually running (catches orphans / missed webhooks).
       reconcileOrphanComputeSessions().catch((err) => {
-        console.warn('[project-maintenance] orphan-compute reconcile failed:', err instanceof Error ? err.message : err);
+        console.warn(
+          '[project-maintenance] orphan-compute reconcile failed:',
+          err instanceof Error ? err.message : err,
+        );
         return { checked: 0, closed: 0, errors: 0 };
       }),
       // Session-side leak fix: reconcile project_sessions stuck in an ACTIVE
@@ -216,47 +245,88 @@ export async function runProjectMaintenance(): Promise<void> {
       // account's concurrent-session cap fills up and wedges Slack. DB-only, so
       // it drains the cap even while Daytona is throttling the box reaper.
       reconcileStuckActiveSessions().catch((err) => {
-        console.warn('[project-maintenance] stuck-session reconcile failed:', err instanceof Error ? err.message : err);
+        console.warn(
+          '[project-maintenance] stuck-session reconcile failed:',
+          err instanceof Error ? err.message : err,
+        );
         return { candidates: 0, reconciled: 0, billingClosed: 0, errors: 0 };
       }),
       // Provider-authoritative orphan-BOX reaper: stops boxes still running on
       // the provider (this env) with no live DB row — the leak the DB-driven
       // reaper above structurally can't see. STOP-only, label-scoped, age-gated.
       reapOrphanProviderBoxes().catch((err) => {
-        console.warn('[project-maintenance] orphan-box reaper failed:', err instanceof Error ? err.message : err);
+        console.warn(
+          '[project-maintenance] orphan-box reaper failed:',
+          err instanceof Error ? err.message : err,
+        );
         return { listed: 0, orphans: 0, stopped: 0, errors: 0 };
       }),
       sweepExpiredSessionBranches(),
       // Billing v2 — partial-bill any active compute sessions that haven't
       // settled in > 1h, so a missed stop hook can't accrue uncharged compute.
       tickRunningComputeCharges().catch((err) => {
-        console.warn('[project-maintenance] compute tick failed:', err instanceof Error ? err.message : err);
+        console.warn(
+          '[project-maintenance] compute tick failed:',
+          err instanceof Error ? err.message : err,
+        );
         return { settled: 0 };
       }),
       // Heal snapshot build-log rows orphaned at "building" by a process
       // restart/crash, globally across all projects.
       reconcileStaleBuilds().catch((err) => {
-        console.warn('[project-maintenance] stale-build reconcile failed:', err instanceof Error ? err.message : err);
+        console.warn(
+          '[project-maintenance] stale-build reconcile failed:',
+          err instanceof Error ? err.message : err,
+        );
         return { checked: 0, closedReady: 0, closedFailed: 0 };
       }),
       // GC superseded template snapshots (content-addressed names orphaned by
       // every identity drift) before the 100/org Daytona quota fills up.
       // Pressure-gated + bounded; no-op while the ORG total is small.
       reconcileSnapshotQuota().catch((err) => {
-        console.warn('[project-maintenance] snapshot quota GC failed:', err instanceof Error ? err.message : err);
-        return { orgTotal: 0, managedCount: 0, eligible: 0, deleted: 0, deferred: 0, dryRun: false };
+        console.warn(
+          '[project-maintenance] snapshot quota GC failed:',
+          err instanceof Error ? err.message : err,
+        );
+        return {
+          orgTotal: 0,
+          managedCount: 0,
+          eligible: 0,
+          deleted: 0,
+          deferred: 0,
+          budgetUnresolved: false,
+          dryRun: false,
+        };
       }),
     ]);
     const hadAction = Boolean(
-      idle.stopped || idle.reconciled || idle.errors || orphanCompute.closed || orphanCompute.errors ||
-      stuckSessions.reconciled || stuckSessions.errors ||
-      orphanBoxes.stopped || orphanBoxes.errors ||
-      branches.deleted || branches.errors ||
-      computeTick.settled || staleBuilds.closedReady || staleBuilds.closedFailed ||
-      snapshotGc.deleted,
+      idle.stopped ||
+        idle.reconciled ||
+        idle.errors ||
+        orphanCompute.closed ||
+        orphanCompute.errors ||
+        stuckSessions.reconciled ||
+        stuckSessions.errors ||
+        orphanBoxes.stopped ||
+        orphanBoxes.errors ||
+        branches.deleted ||
+        branches.errors ||
+        computeTick.settled ||
+        staleBuilds.closedReady ||
+        staleBuilds.closedFailed ||
+        snapshotGc.deleted,
     );
     if (hadAction) {
-      console.log('[project-maintenance] completed', { idle, orphanCompute, stuckSessions, orphanBoxes, branches, computeTick, staleBuilds, snapshotGc });
+      console.log('[project-maintenance] completed', {
+        idle,
+        orphanCompute,
+        stuckSessions,
+        orphanBoxes,
+        branches,
+        computeTick,
+        staleBuilds,
+        snapshotGc,
+      });
     }
     // Unconditional heartbeat — proof-of-life independent of whether any
     // action happened. A stuck lock (see the watchdog above) produces total
@@ -266,7 +336,9 @@ export async function runProjectMaintenance(): Promise<void> {
     // the 2026-07-02 incident went undetected for hours. This line is cheap
     // (one per cycle, ~every 5min) and makes "the loop is alive" observable —
     // wire an alert on its absence for N cycles instead of trusting silence.
-    console.log(`[project-maintenance] heartbeat idle_candidates=${idle.candidates} action=${hadAction}`);
+    console.log(
+      `[project-maintenance] heartbeat idle_candidates=${idle.candidates} action=${hadAction}`,
+    );
 
     // Invariant monitor: in steady state, every `active` compute session has a
     // running box. A non-zero count means billing is leaking — make it loud so a
@@ -274,10 +346,15 @@ export async function runProjectMaintenance(): Promise<void> {
     try {
       const billingLeak = await countBillingInvariantViolations();
       if (billingLeak > 0) {
-        console.warn(`[project-maintenance] BILLING INVARIANT VIOLATED: ${billingLeak} active compute session(s) with a non-running box`);
+        console.warn(
+          `[project-maintenance] BILLING INVARIANT VIOLATED: ${billingLeak} active compute session(s) with a non-running box`,
+        );
       }
     } catch (err) {
-      console.warn('[project-maintenance] billing invariant check failed:', err instanceof Error ? err.message : err);
+      console.warn(
+        '[project-maintenance] billing invariant check failed:',
+        err instanceof Error ? err.message : err,
+      );
     }
   } finally {
     // Only the run that's still current may release the lock — see

--- a/apps/api/src/projects/maintenance.ts
+++ b/apps/api/src/projects/maintenance.ts
@@ -241,10 +241,10 @@ export async function runProjectMaintenance(): Promise<void> {
       }),
       // GC superseded template snapshots (content-addressed names orphaned by
       // every identity drift) before the 100/org Daytona quota fills up.
-      // Pressure-gated + bounded; no-op while the namespace is small.
+      // Pressure-gated + bounded; no-op while the ORG total is small.
       reconcileSnapshotQuota().catch((err) => {
         console.warn('[project-maintenance] snapshot quota GC failed:', err instanceof Error ? err.message : err);
-        return { namespaceCount: 0, eligible: 0, deleted: 0, dryRun: false };
+        return { orgTotal: 0, managedCount: 0, eligible: 0, deleted: 0, deferred: 0, dryRun: false };
       }),
     ]);
     const hadAction = Boolean(

--- a/apps/api/src/projects/policies.ts
+++ b/apps/api/src/projects/policies.ts
@@ -52,20 +52,23 @@ const DEFAULT_SETTINGS: ProjectPolicySettings = { defaultMode: 'allow_all' };
  */
 export function extractProjectPolicies(manifest: ParsedManifest): LoadedProjectPolicies {
   const errors: ProjectPolicyParseError[] = [];
+  // Use the ACTUAL manifest file in error paths so a YAML project reports
+  // `kortix.yaml#policy`, not a hardcoded `kortix.toml#…`.
+  const filename = manifest.path || MANIFEST_FILENAME;
 
   // ── policy block (default_mode) ────────────────────────────────────────────
   let settings: ProjectPolicySettings = { ...DEFAULT_SETTINGS };
   const policyBlock = manifest.raw.policy;
   if (policyBlock !== undefined && policyBlock !== null) {
     if (typeof policyBlock !== 'object' || Array.isArray(policyBlock)) {
-      errors.push({ path: `${MANIFEST_FILENAME}#policy`, error: '`policy` must be an object' });
+      errors.push({ path: `${filename}#policy`, error: '`policy` must be an object' });
     } else {
       const row = policyBlock as Record<string, unknown>;
       if (row.default_mode !== undefined) {
         const mode = typeof row.default_mode === 'string' ? row.default_mode.trim().toLowerCase() : '';
         if (!DEFAULT_MODES.includes(mode as DefaultMode)) {
           errors.push({
-            path: `${MANIFEST_FILENAME}#policy.default_mode`,
+            path: `${filename}#policy.default_mode`,
             error: `policy.default_mode must be one of ${DEFAULT_MODES.join(', ')} (got "${mode || 'unset'}")`,
           });
         } else {
@@ -81,12 +84,12 @@ export function extractProjectPolicies(manifest: ParsedManifest): LoadedProjectP
   if (raw !== undefined && raw !== null) {
     if (!Array.isArray(raw)) {
       errors.push({
-        path: MANIFEST_FILENAME,
+        path: filename,
         error: '`policies` must be an array of tables — a YAML list (or a legacy TOML [[policies]]), not a single mapping',
       });
     } else {
       raw.forEach((entry, i) => {
-        const path = `${MANIFEST_FILENAME}#policies[${i}]`;
+        const path = `${filename}#policies[${i}]`;
         if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
           errors.push({ path, error: `policies entry #${i + 1} is not an object` });
           return;

--- a/apps/api/src/projects/routes/agent-scope.ts
+++ b/apps/api/src/projects/routes/agent-scope.ts
@@ -14,8 +14,9 @@
 import { createRoute, z } from '@hono/zod-openapi';
 import { auth, errors, json } from '../../openapi';
 import { applyAgentScope, extractAgents } from '../agents';
-import { loadProjectForUser } from '../lib/access';
+import { assertProjectCapability, loadProjectForUser } from '../lib/access';
 import { projectsApp } from '../lib/app';
+import { PROJECT_ACTIONS } from '../../iam';
 import { commitManifest, loadManifestForEdit } from '../lib/triggers';
 
 // `'all'` = every item the launcher can see; a list = an explicit allowlist;
@@ -43,8 +44,14 @@ projectsApp.openapi(
   async (c: any) => {
     const projectId = c.req.param('projectId');
     const agentName = c.req.param('agentName');
-    const loaded = await loadProjectForUser(c, projectId, 'manage');
+    // Floor 'read' (membership); the real gate is project.agent.write below.
+    // Scoping an agent edits its `[[agents]]` manifest entry (binding its
+    // connectors AND secrets), so it's an agent-config edit — agent.write is the
+    // precise leaf (a single connector/secret leaf wouldn't cover both). Was
+    // 'manage' → project.write, so unchecking agent.write did nothing here.
+    const loaded = await loadProjectForUser(c, projectId, 'read');
     if (!loaded) return c.json({ error: 'Not found' }, 404);
+    await assertProjectCapability(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_AGENT_WRITE);
 
     const parsed = AgentScopeBody.safeParse(await c.req.json().catch(() => null));
     if (!parsed.success) return c.json({ error: 'Invalid body', code: 'invalid_body' }, 400);

--- a/apps/api/src/projects/routes/agent-scope.ts
+++ b/apps/api/src/projects/routes/agent-scope.ts
@@ -19,6 +19,7 @@
 import { createRoute, z } from '@hono/zod-openapi';
 import { auth, errors, json } from '../../openapi';
 import { applyAgentScope, extractAgents } from '../agents';
+import { applyAgentScopeV2 } from '../lib/agent-config-v2';
 import { assertProjectCapability, loadProjectForUser } from '../lib/access';
 import { projectsApp } from '../lib/app';
 import { PROJECT_ACTIONS } from '../../iam';
@@ -75,14 +76,27 @@ projectsApp.openapi(
       );
     }
 
-    // The agent must already be declared — this route scopes an existing
-    // `[[agents]]`, it doesn't create the roster entry (that's a fuller edit).
-    const current = Array.isArray(manifest.raw.agents)
-      ? (manifest.raw.agents as Record<string, unknown>[])
-      : [];
-    const applied = applyAgentScope(current, agentName, { env, connectors }, manifest.path);
-    if (!applied.ok) return c.json({ error: applied.error, code: 'agent_not_found' }, 404);
-    manifest.raw.agents = applied.agents;
+    // The agent must already be declared — this route SCOPES an existing agent,
+    // it doesn't create the roster entry (that's the fuller /config editor). v1
+    // stores agents as a `[[agents]]` array; v2 (kortix.yaml) as an `agents:`
+    // map. The v1-only path treated a v2 map as an empty array, so EVERY scope
+    // edit on a YAML project 404'd "agent not found" — branch on the schema.
+    if (manifest.schemaVersion >= 2) {
+      const applied = applyAgentScopeV2(manifest, agentName, { env, connectors });
+      if (!applied.ok) {
+        return applied.notFound
+          ? c.json({ error: applied.error, code: 'agent_not_found' }, 404)
+          : c.json({ error: applied.error, code: 'invalid_scope', issues: applied.issues }, 400);
+      }
+      manifest.raw = applied.raw;
+    } else {
+      const current = Array.isArray(manifest.raw.agents)
+        ? (manifest.raw.agents as Record<string, unknown>[])
+        : [];
+      const applied = applyAgentScope(current, agentName, { env, connectors }, manifest.path);
+      if (!applied.ok) return c.json({ error: applied.error, code: 'agent_not_found' }, 404);
+      manifest.raw.agents = applied.agents;
+    }
 
     // Shape-validate through the real parser before committing — a malformed
     // grant set is a clean 400, never a broken manifest.

--- a/apps/api/src/projects/routes/agent-scope.ts
+++ b/apps/api/src/projects/routes/agent-scope.ts
@@ -19,8 +19,9 @@
 import { createRoute, z } from '@hono/zod-openapi';
 import { auth, errors, json } from '../../openapi';
 import { applyAgentScope, extractAgents } from '../agents';
-import { loadProjectForUser } from '../lib/access';
+import { assertProjectCapability, loadProjectForUser } from '../lib/access';
 import { projectsApp } from '../lib/app';
+import { PROJECT_ACTIONS } from '../../iam';
 import { commitManifest, loadManifestForEdit } from '../lib/triggers';
 
 // `'all'` = every item the launcher can see; a list = an explicit allowlist;
@@ -48,8 +49,14 @@ projectsApp.openapi(
   async (c: any) => {
     const projectId = c.req.param('projectId');
     const agentName = c.req.param('agentName');
-    const loaded = await loadProjectForUser(c, projectId, 'manage');
+    // Floor 'read' (membership); the real gate is project.agent.write below.
+    // Scoping an agent edits its `[[agents]]` manifest entry (binding its
+    // connectors AND secrets), so it's an agent-config edit — agent.write is the
+    // precise leaf (a single connector/secret leaf wouldn't cover both). Was
+    // 'manage' → project.write, so unchecking agent.write did nothing here.
+    const loaded = await loadProjectForUser(c, projectId, 'read');
     if (!loaded) return c.json({ error: 'Not found' }, 404);
+    await assertProjectCapability(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_AGENT_WRITE);
 
     const parsed = AgentScopeBody.safeParse(await c.req.json().catch(() => null));
     if (!parsed.success) return c.json({ error: 'Invalid body', code: 'invalid_body' }, 400);

--- a/apps/api/src/projects/routes/channel-bindings.ts
+++ b/apps/api/src/projects/routes/channel-bindings.ts
@@ -77,6 +77,10 @@ projectsApp.openapi(
     const projectId = c.req.param("projectId");
     const loaded = await loadProjectForUser(c, projectId, "read");
     if (!loaded) return c.json({ error: "Not found" }, 404);
+    // Listing channel↔agent bindings exposes which connectors the project's
+    // channels talk through — connector-read info. Gate on connector.read so
+    // unchecking it in a custom role is denied. Every built-in role holds it.
+    await assertProjectCapability(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_CONNECTOR_READ);
 
     const projectDefaultAgent = projectDefaultAgentOf(loaded.row.metadata);
     const bindings = await listChannelBindingsForProject(projectId);
@@ -111,7 +115,9 @@ projectsApp.openapi(
   async (c: any) => {
     const projectId = c.req.param("projectId");
     const bindingId = c.req.param("bindingId");
-    const loaded = await loadProjectForUser(c, projectId, "manage");
+    // Floor 'read'; project.connector.write below is the real gate (was 'manage'
+    // → project.write, which over-gated a custom connector.write-only role).
+    const loaded = await loadProjectForUser(c, projectId, "read");
     if (!loaded) return c.json({ error: "Not found" }, 404);
     // No dedicated "channel binding write" leaf exists yet (the channel.* actions
     // in iam/actions.ts are scoped to resource_type='channel' and aren't wired

--- a/apps/api/src/projects/routes/model-defaults.ts
+++ b/apps/api/src/projects/routes/model-defaults.ts
@@ -16,8 +16,9 @@ import {
   getAccountModelDefaults,
   upsertAccountModelPreference,
 } from "../../repositories/model-preferences";
-import { loadProjectForUser } from "../lib/access";
+import { assertProjectCapability, loadProjectForUser } from "../lib/access";
 import { projectsApp } from "../lib/app";
+import { PROJECT_ACTIONS } from "../../iam";
 
 /** A storable default must be a concrete model — a managed id (bare or
  *  kortix/-prefixed), or a `provider/model` BYOK/direct wire — never the
@@ -81,8 +82,11 @@ projectsApp.openapi(
   }),
   async (c: any) => {
     const projectId = c.req.param("projectId");
-    const loaded = await loadProjectForUser(c, projectId, "manage");
+    // Floor 'read'; project.customize.write is the real gate (model defaults are
+    // project customization). Built-in editor/manager hold the leaf.
+    const loaded = await loadProjectForUser(c, projectId, "read");
     if (!loaded) return c.json({ error: "Not found" }, 404);
+    await assertProjectCapability(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_CUSTOMIZE_WRITE);
     const accountId = loaded.row.accountId as string;
     const userId = c.get("userId") as string;
 
@@ -121,8 +125,10 @@ projectsApp.openapi(
   }),
   async (c: any) => {
     const projectId = c.req.param("projectId");
-    const loaded = await loadProjectForUser(c, projectId, "manage");
+    // Floor 'read'; project.customize.write is the real gate (see PUT above).
+    const loaded = await loadProjectForUser(c, projectId, "read");
     if (!loaded) return c.json({ error: "Not found" }, 404);
+    await assertProjectCapability(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_CUSTOMIZE_WRITE);
     const accountId = loaded.row.accountId as string;
     const scope = c.req.query("scope");
     const agentName = c.req.query("agentName");

--- a/apps/api/src/projects/routes/r11.ts
+++ b/apps/api/src/projects/routes/r11.ts
@@ -122,6 +122,9 @@ projectsApp.openapi(
     const body = await readBody(c);
     const loaded = await loadProjectForUser(c, projectId, 'read');
     if (!loaded) return c.json({ error: 'Not found' }, 404);
+    // Human gate: submitting a reviewable needs project.review.submit. Every
+    // built-in role holds it; a custom role that unchecks it is denied here.
+    await assertProjectCapability(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_REVIEW_SUBMIT);
     // Agent-side gate: submitting a reviewable is the agent's intended path.
     assertAgentScope(c, 'project.review.submit');
 

--- a/apps/api/src/projects/routes/r2.ts
+++ b/apps/api/src/projects/routes/r2.ts
@@ -4,7 +4,8 @@ import { DEFAULT_SANDBOX_SLUG, deleteSandboxImage, kickPreBuild, kickProjectTemp
 import { classifySnapshotError, describeSnapshotError } from '../../snapshots/error-classify';
 import { getSandboxProvider } from '../../snapshots/providers';
 import { withTimeout } from '../../shared/with-timeout';
-import { createTemplate, deleteTemplate, getTemplateById, updateTemplate } from '../../snapshots/templates';
+import { templateSlugFromBuildSlug } from '../../snapshots/ppwarm-names';
+import { createTemplate, deleteTemplate, getTemplateById, TemplateNotFoundError, updateTemplate } from '../../snapshots/templates';
 import { commitFile, createRepo, getFileSha } from '../github';
 import { buildStarterFiles, normalizeStarterTemplateId } from '../starter';
 import { createRoute, z } from '@hono/zod-openapi';
@@ -591,6 +592,13 @@ projectsApp.openapi(
       202,
     );
   } catch (err) {
+    // A slug that names no template is the caller's mistake, not a provider
+    // outage — folding it into 502 hid the real bug (a build slug like
+    // `default-warm` being sent where a template slug was required) behind a
+    // status that reads as "Daytona is down".
+    if (err instanceof TemplateNotFoundError) {
+      return c.json({ error: err.message, code: 'TEMPLATE_NOT_FOUND' }, 404);
+    }
     const message = err instanceof Error ? err.message : String(err);
     return c.json({ error: message }, 502);
   }
@@ -633,6 +641,26 @@ projectsApp.openapi(
     return c.json({ error: 'No failed snapshot build to fix.' }, 409);
   }
 
+  const errorText = failed.error ?? 'Snapshot build failed';
+  const category = failed.errorCategory ?? classifySnapshotError(errorText);
+  const info = describeSnapshotError(category as ReturnType<typeof classifySnapshotError>);
+
+  // Infra failures (quota, provider blip, timeout) are not repo-editable. Spinning up
+  // a fix session for one is worse than useless: the session must boot a sandbox from
+  // a snapshot, which is exactly what the failure prevented — so it fails to start the
+  // very session meant to diagnose it. Refuse loudly rather than 400 from deep inside
+  // session creation.
+  if (!info.fixableByAgent) {
+    return c.json(
+      {
+        error: `${info.title}: ${info.hint}`,
+        code: 'NOT_AGENT_FIXABLE',
+        category,
+      },
+      409,
+    );
+  }
+
   const hostBuild = builds.find((b) => b.status === 'ready');
   if (!hostBuild) {
     return c.json(
@@ -644,10 +672,6 @@ projectsApp.openapi(
       409,
     );
   }
-
-  const errorText = failed.error ?? 'Snapshot build failed';
-  const category = failed.errorCategory ?? classifySnapshotError(errorText);
-  const info = describeSnapshotError(category as ReturnType<typeof classifySnapshotError>);
 
   const prompt = [
     `The sandbox image build for the "${failed.slug}" template is failing, so new sessions on it can't boot. Diagnose and fix the root cause, then open a change request.`,
@@ -676,7 +700,9 @@ projectsApp.openapi(
       initial_prompt: prompt,
       name: 'Fix sandbox build',
       metadata: { kind: 'sandbox-build-fix', failed_slug: failed.slug },
-      sandbox_slug: hostBuild.slug,
+      // hostBuild.slug is a BUILD slug — for a warm bake it reads `default-warm`,
+      // which names no template, so session creation rejected it with a 400.
+      sandbox_slug: templateSlugFromBuildSlug(hostBuild.slug),
     },
     request: requestAuditContext(c),
   });

--- a/apps/api/src/projects/routes/r4.ts
+++ b/apps/api/src/projects/routes/r4.ts
@@ -202,7 +202,7 @@ projectsApp.openapi(
       );
     }
 
-    const next = upsertTriggerInManifest(manifest, draftToSpec(draft));
+    const next = upsertTriggerInManifest(manifest, draftToSpec(draft, manifest.path));
     const result = await commitManifest(
       loaded.row,
       next,
@@ -322,7 +322,7 @@ projectsApp.openapi(
       );
       if ("error" in draft) return c.json({ error: draft.error }, 400);
 
-      const next = upsertTriggerInManifest(manifest, draftToSpec(draft));
+      const next = upsertTriggerInManifest(manifest, draftToSpec(draft, manifest.path));
       const result = await commitManifest(
         loaded.row,
         next,

--- a/apps/api/src/projects/routes/r4.ts
+++ b/apps/api/src/projects/routes/r4.ts
@@ -662,8 +662,12 @@ projectsApp.openapi(
   }),
   async (c: any) => {
     const projectId = c.req.param("projectId");
-    const loaded = await loadProjectForUser(c, projectId, "manage");
+    // Floor 'read' (membership); the connector.write leaf below is the real gate,
+    // so a custom role that unchecks connector.write is denied even if it holds
+    // project.write. Built-in editor/manager hold the leaf.
+    const loaded = await loadProjectForUser(c, projectId, "read");
     if (!loaded) return c.json({ error: "Not found" }, 404);
+    await assertProjectCapability(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_CONNECTOR_WRITE);
     if (!emailChannelEnabled(loaded.row.metadata)) {
       return c.json(
         {
@@ -815,8 +819,10 @@ projectsApp.openapi(
   }),
   async (c: any) => {
     const projectId = c.req.param("projectId");
-    const loaded = await loadProjectForUser(c, projectId, "manage");
+    // Floor 'read'; project.connector.write is the real gate (see /email/connect).
+    const loaded = await loadProjectForUser(c, projectId, "read");
     if (!loaded) return c.json({ error: "Not found" }, 404);
+    await assertProjectCapability(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_CONNECTOR_WRITE);
     if (!emailChannelEnabled(loaded.row.metadata)) {
       return c.json(
         {
@@ -873,8 +879,10 @@ projectsApp.openapi(
   }),
   async (c: any) => {
     const projectId = c.req.param("projectId");
-    const loaded = await loadProjectForUser(c, projectId, "manage");
+    // Floor 'read'; project.connector.write is the real gate (see /email/connect).
+    const loaded = await loadProjectForUser(c, projectId, "read");
     if (!loaded) return c.json({ error: "Not found" }, 404);
+    await assertProjectCapability(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_CONNECTOR_WRITE);
     const connectorSlug =
       c.req.query("connector_slug") ||
       c.req.query("profile_slug") ||
@@ -1285,8 +1293,11 @@ projectsApp.openapi(
   }),
   async (c: any) => {
     const projectId = c.req.param("projectId");
-    const loaded = await loadProjectForUser(c, projectId, "manage");
+    // Floor 'read'; project.customize.write is the real gate (setting the bot
+    // name is project customization). Built-in editor/manager hold the leaf.
+    const loaded = await loadProjectForUser(c, projectId, "read");
     if (!loaded) return c.json({ error: "Not found" }, 404);
+    await assertProjectCapability(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_CUSTOMIZE_WRITE);
     const body = await readBody(c);
     const name = String(body.name ?? body.bot_name ?? "");
     const saved = await setProjectBotName(projectId, name);
@@ -1313,8 +1324,11 @@ projectsApp.openapi(
   }),
   async (c: any) => {
     const projectId = c.req.param("projectId");
-    const loaded = await loadProjectForUser(c, projectId, "manage");
+    // Floor 'read'; project.customize.write is the real gate (choosing the voice
+    // is project customization). Built-in editor/manager hold the leaf.
+    const loaded = await loadProjectForUser(c, projectId, "read");
     if (!loaded) return c.json({ error: "Not found" }, 404);
+    await assertProjectCapability(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_CUSTOMIZE_WRITE);
     const body = await readBody(c);
     const voiceId = String(body.voice ?? "");
     if (!isMeetVoice(voiceId)) return c.json({ error: "unknown voice" }, 400);
@@ -1559,8 +1573,13 @@ projectsApp.openapi(
   }),
   async (c: any) => {
     const projectId = c.req.param("projectId");
-    const loaded = await loadProjectForUser(c, projectId, "manage");
+    // Floor 'read'; project.customize.write is the real gate (model defaults are
+    // project customization). NOTE: /{projectId}/model-defaults is ALSO defined in
+    // routes/model-defaults.ts (registered later in projects/index.ts) — both are
+    // gated here to be safe against route-registration order; dedupe is follow-up.
+    const loaded = await loadProjectForUser(c, projectId, "read");
     if (!loaded) return c.json({ error: "Not found" }, 404);
+    await assertProjectCapability(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_CUSTOMIZE_WRITE);
     const ownerAccountId = loaded.row.accountId as string;
     const userId = c.get("userId") as string;
 
@@ -1639,8 +1658,11 @@ projectsApp.openapi(
   }),
   async (c: any) => {
     const projectId = c.req.param("projectId");
-    const loaded = await loadProjectForUser(c, projectId, "manage");
+    // Floor 'read'; project.customize.write is the real gate (see PUT above; also
+    // mirrored in routes/model-defaults.ts).
+    const loaded = await loadProjectForUser(c, projectId, "read");
     if (!loaded) return c.json({ error: "Not found" }, 404);
+    await assertProjectCapability(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_CUSTOMIZE_WRITE);
     const ownerAccountId = loaded.row.accountId as string;
     const scope = c.req.query("scope");
     const agentName = c.req.query("agentName");

--- a/apps/api/src/projects/routes/r4.ts
+++ b/apps/api/src/projects/routes/r4.ts
@@ -662,8 +662,12 @@ projectsApp.openapi(
   }),
   async (c: any) => {
     const projectId = c.req.param("projectId");
-    const loaded = await loadProjectForUser(c, projectId, "manage");
+    // Floor 'read' (membership); the connector.write leaf below is the real gate,
+    // so a custom role that unchecks connector.write is denied even if it holds
+    // project.write. Built-in editor/manager hold the leaf.
+    const loaded = await loadProjectForUser(c, projectId, "read");
     if (!loaded) return c.json({ error: "Not found" }, 404);
+    await assertProjectCapability(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_CONNECTOR_WRITE);
     if (!emailChannelEnabled(loaded.row.metadata)) {
       return c.json(
         {
@@ -815,8 +819,10 @@ projectsApp.openapi(
   }),
   async (c: any) => {
     const projectId = c.req.param("projectId");
-    const loaded = await loadProjectForUser(c, projectId, "manage");
+    // Floor 'read'; project.connector.write is the real gate (see /email/connect).
+    const loaded = await loadProjectForUser(c, projectId, "read");
     if (!loaded) return c.json({ error: "Not found" }, 404);
+    await assertProjectCapability(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_CONNECTOR_WRITE);
     if (!emailChannelEnabled(loaded.row.metadata)) {
       return c.json(
         {
@@ -873,8 +879,10 @@ projectsApp.openapi(
   }),
   async (c: any) => {
     const projectId = c.req.param("projectId");
-    const loaded = await loadProjectForUser(c, projectId, "manage");
+    // Floor 'read'; project.connector.write is the real gate (see /email/connect).
+    const loaded = await loadProjectForUser(c, projectId, "read");
     if (!loaded) return c.json({ error: "Not found" }, 404);
+    await assertProjectCapability(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_CONNECTOR_WRITE);
     const connectorSlug =
       c.req.query("connector_slug") ||
       c.req.query("profile_slug") ||
@@ -1285,8 +1293,11 @@ projectsApp.openapi(
   }),
   async (c: any) => {
     const projectId = c.req.param("projectId");
-    const loaded = await loadProjectForUser(c, projectId, "manage");
+    // Floor 'read'; project.customize.write is the real gate (setting the bot
+    // name is project customization). Built-in editor/manager hold the leaf.
+    const loaded = await loadProjectForUser(c, projectId, "read");
     if (!loaded) return c.json({ error: "Not found" }, 404);
+    await assertProjectCapability(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_CUSTOMIZE_WRITE);
     const body = await readBody(c);
     const name = String(body.name ?? body.bot_name ?? "");
     const saved = await setProjectBotName(projectId, name);
@@ -1313,8 +1324,11 @@ projectsApp.openapi(
   }),
   async (c: any) => {
     const projectId = c.req.param("projectId");
-    const loaded = await loadProjectForUser(c, projectId, "manage");
+    // Floor 'read'; project.customize.write is the real gate (choosing the voice
+    // is project customization). Built-in editor/manager hold the leaf.
+    const loaded = await loadProjectForUser(c, projectId, "read");
     if (!loaded) return c.json({ error: "Not found" }, 404);
+    await assertProjectCapability(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_CUSTOMIZE_WRITE);
     const body = await readBody(c);
     const voiceId = String(body.voice ?? "");
     if (!isMeetVoice(voiceId)) return c.json({ error: "unknown voice" }, 400);
@@ -1559,8 +1573,13 @@ projectsApp.openapi(
   }),
   async (c: any) => {
     const projectId = c.req.param("projectId");
-    const loaded = await loadProjectForUser(c, projectId, "manage");
+    // Floor 'read'; project.customize.write is the real gate (model defaults are
+    // project customization). NOTE: /{projectId}/model-defaults is ALSO defined in
+    // routes/model-defaults.ts (registered later in projects/index.ts) — both are
+    // gated here to be safe against route-registration order; dedupe is follow-up.
+    const loaded = await loadProjectForUser(c, projectId, "read");
     if (!loaded) return c.json({ error: "Not found" }, 404);
+    await assertProjectCapability(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_CUSTOMIZE_WRITE);
     const ownerAccountId = loaded.row.accountId as string;
     const userId = c.get("userId") as string;
 
@@ -1639,8 +1658,11 @@ projectsApp.openapi(
   }),
   async (c: any) => {
     const projectId = c.req.param("projectId");
-    const loaded = await loadProjectForUser(c, projectId, "manage");
+    // Floor 'read'; project.customize.write is the real gate (see PUT above; also
+    // mirrored in routes/model-defaults.ts).
+    const loaded = await loadProjectForUser(c, projectId, "read");
     if (!loaded) return c.json({ error: "Not found" }, 404);
+    await assertProjectCapability(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_CUSTOMIZE_WRITE);
     const ownerAccountId = loaded.row.accountId as string;
     const scope = c.req.query("scope");
     const agentName = c.req.query("agentName");
@@ -1807,7 +1829,12 @@ projectsApp.openapi(
   async (c: any) => {
     const projectId = c.req.param("projectId");
     const slug = c.req.param("slug");
-    const loaded = await loadProjectForUser(c, projectId, "manage");
+    // Floor 'read' (membership); project.trigger.fire is the real gate. The floor
+    // was 'manage' (= project.write) — which the floor `member` role LACKS even
+    // though it HOLDS trigger.fire, so a plain member could never fire a trigger
+    // (its designed fire grant was dead behind the floor). Now member/editor/
+    // manager all fire (all hold the leaf); a custom role without it is denied.
+    const loaded = await loadProjectForUser(c, projectId, "read");
     if (!loaded) return c.json({ error: "Not found" }, 404);
     await assertProjectCapability(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_TRIGGER_FIRE);
 

--- a/apps/api/src/projects/routes/r4.ts
+++ b/apps/api/src/projects/routes/r4.ts
@@ -1829,7 +1829,12 @@ projectsApp.openapi(
   async (c: any) => {
     const projectId = c.req.param("projectId");
     const slug = c.req.param("slug");
-    const loaded = await loadProjectForUser(c, projectId, "manage");
+    // Floor 'read' (membership); project.trigger.fire is the real gate. The floor
+    // was 'manage' (= project.write) — which the floor `member` role LACKS even
+    // though it HOLDS trigger.fire, so a plain member could never fire a trigger
+    // (its designed fire grant was dead behind the floor). Now member/editor/
+    // manager all fire (all hold the leaf); a custom role without it is denied.
+    const loaded = await loadProjectForUser(c, projectId, "read");
     if (!loaded) return c.json({ error: "Not found" }, 404);
     await assertProjectCapability(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_TRIGGER_FIRE);
 

--- a/apps/api/src/projects/routes/r5.ts
+++ b/apps/api/src/projects/routes/r5.ts
@@ -8,7 +8,8 @@ import { archiveRepoSubtree, getBranchDiff, getCommit, getCommitDiff, getFileHis
 import { createRoute, z } from '@hono/zod-openapi';
 import { deployments, projects } from '@kortix/db';
 import { eq } from 'drizzle-orm';
-import { loadProjectForUser, assertProjectCapability } from '../lib/access';
+import { loadProjectForUser, assertProjectCapability, projectCapabilityAllowed } from '../lib/access';
+import { applyDetailCapabilityFilter } from '../lib/detail-capability-filter';
 import { filterConfigResourcesForUser, denierFromConfig, resourceDenierForRequest } from '../lib/project-resources';
 import { AnyObject, CommitSchema, ProjectSchema, projectsApp } from '../lib/app';
 import { getProjectGitConnection, withProjectGitAuth } from '../lib/git';
@@ -233,15 +234,36 @@ projectsApp.openapi(
   // isolation). Reuses the config already loaded — no extra git round-trip.
   const denier = await denierFromConfig(rawConfig, denierCtx);
   const visibleFiles = denier ? files.filter((f) => !denier.isDenied(f.path)) : files;
+  // Per-CAPABILITY filtering (distinct from the per-resource grants above): the
+  // /detail bundle serves several read surfaces behind ONE project.read floor, so
+  // gate each section on its own leaf. A plain `member` keeps the config sections
+  // it can read but NOT the file list (member lacks project.file.read), and a
+  // custom role that unchecks e.g. project.skill.read gets an empty skills
+  // section — all WITHOUT 403-ing the whole workspace load (which loadProjectForUser
+  // deliberately gates only on project.read so the shell renders for every member).
+  const [canFiles, canAgents, canSkills, canCommands, canCustomize] = await Promise.all([
+    projectCapabilityAllowed(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_FILE_READ),
+    projectCapabilityAllowed(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_AGENT_READ),
+    projectCapabilityAllowed(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_SKILL_READ),
+    projectCapabilityAllowed(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_COMMAND_READ),
+    projectCapabilityAllowed(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_CUSTOMIZE_READ),
+  ]);
+  const gated = applyDetailCapabilityFilter(config, visibleFiles, {
+    canFiles,
+    canAgents,
+    canSkills,
+    canCommands,
+    canCustomize,
+  });
   return c.json({
     project: serializeProject(loaded.row, {
       projectRole: loaded.projectRole,
       effectiveRole: loaded.effectiveRole,
     }),
     git_connection: serializeProjectGitConnection(await getProjectGitConnection(projectId)),
-    config,
-    file_count: visibleFiles.length,
-    files: visibleFiles.slice(0, 300),
+    config: gated.config,
+    file_count: gated.file_count,
+    files: gated.files,
   });
 },
 );

--- a/apps/api/src/projects/routes/r6.ts
+++ b/apps/api/src/projects/routes/r6.ts
@@ -391,8 +391,13 @@ projectsApp.openapi(
   }),
   async (c: any) => {
   const projectId = c.req.param('projectId');
-  const loaded = await loadProjectForUser(c, projectId, 'manage');
+  // Floor is 'read' (project membership); the real gate is the members.manage
+  // leaf below, so a custom role granting ONLY members.manage (no project.write)
+  // works, and — matching the sibling approve/reject routes — a plain editor
+  // (project.write but not members.manage) can't list pending access requests.
+  const loaded = await loadProjectForUser(c, projectId, 'read');
   if (!loaded) return c.json({ error: 'Not found' }, 404);
+  await assertProjectCapability(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_MEMBERS_MANAGE);
 
   const rows = await db
     .select()

--- a/apps/api/src/projects/routes/r6.ts
+++ b/apps/api/src/projects/routes/r6.ts
@@ -1121,8 +1121,11 @@ projectsApp.openapi(
     const body = await readBody(c);
     const feature = body.feature;
     const enabled = body.enabled;
-    const loaded = await loadProjectForUser(c, projectId, 'manage');
+    // Floor 'read' (membership); project.customize.write is the human gate below
+    // (was 'manage' → project.write, so unchecking customize.write did nothing).
+    const loaded = await loadProjectForUser(c, projectId, 'read');
     if (!loaded) return c.json({ error: 'Not found' }, 404);
+    await assertProjectCapability(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_CUSTOMIZE_WRITE);
     // Per-agent gate: toggling experimental features is project config. A scoped
     // agent token must hold project.customize.write (no-op for humans/PATs).
     assertAgentScope(c, PROJECT_ACTIONS.PROJECT_CUSTOMIZE_WRITE);
@@ -1179,8 +1182,11 @@ projectsApp.openapi(
     const body = await readBody(c);
     const raw = body.provider ?? body.sandbox_provider;
     const provider = raw === null || raw === undefined || raw === '' ? null : String(raw);
-    const loaded = await loadProjectForUser(c, projectId, 'manage');
+    // Floor 'read'; project.customize.write is the human gate below (was
+    // 'manage' → project.write, so unchecking customize.write did nothing here).
+    const loaded = await loadProjectForUser(c, projectId, 'read');
     if (!loaded) return c.json({ error: 'Not found' }, 404);
+    await assertProjectCapability(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_CUSTOMIZE_WRITE);
     assertAgentScope(c, PROJECT_ACTIONS.PROJECT_CUSTOMIZE_WRITE);
     if (provider !== null && !config.isProviderEnabled(provider as SandboxProviderName)) {
       return c.json({ error: `Unknown or disabled sandbox provider: ${provider}` }, 400);

--- a/apps/api/src/projects/routes/r7.ts
+++ b/apps/api/src/projects/routes/r7.ts
@@ -174,9 +174,11 @@ projectsApp.openapi(
   // threaded and the agent-grant fold fires: an agent-session token must also
   // hold project.members.manage to mutate group grants, not just its user.
   await assertProjectCapability(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_MEMBERS_MANAGE);
-  // Group→project grants are part of the Enterprise RBAC surface (groups are
-  // gated in accounts/iam/groups.ts); gate the mutation here too so grants
-  // can't be minted through the project-scoped path.
+  // Entitlement mirror of accounts/iam/groups.ts so grants can't be minted
+  // through the project-scoped path when the account-scoped one is gated.
+  // Dormant since 2026-07-08: `rbac` is granted on every tier (groups + roles
+  // are core collaboration, not an upsell) — it only bites again if the
+  // packaging in tiers.ts changes.
   {
     const denied = await requireEntitlement(c, loaded.row.accountId, 'rbac');
     if (denied) return denied;
@@ -261,9 +263,9 @@ projectsApp.openapi(
   // threaded and the agent-grant fold fires: an agent-session token must also
   // hold project.members.manage to mutate group grants, not just its user.
   await assertProjectCapability(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_MEMBERS_MANAGE);
-  // Enterprise RBAC gate — same reasoning as the POST above. DELETE below is
-  // deliberately ungated: revoking access is never paywalled, so a downgraded
-  // account can always detach grants it can no longer manage.
+  // Same dormant entitlement mirror as the POST above (rbac is on every
+  // tier). DELETE below carries no gate at all: revoking access is never
+  // paywalled, so an account can always detach grants it can't manage.
   {
     const denied = await requireEntitlement(c, loaded.row.accountId, 'rbac');
     if (denied) return denied;

--- a/apps/api/src/projects/routes/r7.ts
+++ b/apps/api/src/projects/routes/r7.ts
@@ -168,7 +168,7 @@ projectsApp.openapi(
   }),
   async (c: any) => {
   const projectId = c.req.param('projectId');
-  const loaded = await loadProjectForUser(c, projectId, 'manage');
+  const loaded = await loadProjectForUser(c, projectId, 'read');
   if (!loaded) return c.json({ error: 'Not found' }, 404);
   // assertProjectCapability (not bare assertAuthorized) so the acting token is
   // threaded and the agent-grant fold fires: an agent-session token must also
@@ -255,7 +255,7 @@ projectsApp.openapi(
   async (c: any) => {
   const projectId = c.req.param('projectId');
   const groupId = c.req.param('groupId');
-  const loaded = await loadProjectForUser(c, projectId, 'manage');
+  const loaded = await loadProjectForUser(c, projectId, 'read');
   if (!loaded) return c.json({ error: 'Not found' }, 404);
   // assertProjectCapability (not bare assertAuthorized) so the acting token is
   // threaded and the agent-grant fold fires: an agent-session token must also
@@ -320,7 +320,7 @@ projectsApp.openapi(
   async (c: any) => {
   const projectId = c.req.param('projectId');
   const groupId = c.req.param('groupId');
-  const loaded = await loadProjectForUser(c, projectId, 'manage');
+  const loaded = await loadProjectForUser(c, projectId, 'read');
   if (!loaded) return c.json({ error: 'Not found' }, 404);
   // assertProjectCapability (not bare assertAuthorized) so the acting token is
   // threaded and the agent-grant fold fires: an agent-session token must also
@@ -768,7 +768,7 @@ projectsApp.openapi(
   }),
   async (c: any) => {
     const projectId = c.req.param('projectId');
-    const loaded = await loadProjectForUser(c, projectId, 'manage');
+    const loaded = await loadProjectForUser(c, projectId, 'read');
     if (!loaded) return c.json({ error: 'Not found' }, 404);
     await assertProjectCapability(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_MEMBERS_MANAGE);
 
@@ -1365,7 +1365,7 @@ projectsApp.openapi(
   }),
   async (c: any) => {
     const projectId = c.req.param('projectId');
-    const loaded = await loadProjectForUser(c, projectId, 'manage');
+    const loaded = await loadProjectForUser(c, projectId, 'read');
     if (!loaded) return c.json({ error: 'Not found' }, 404);
     // Manager-only: this is the grant PICKER — it returns the FULL agent/skill
     // catalogue + granted-member emails, so it must NOT be readable by a scoped
@@ -1479,7 +1479,7 @@ projectsApp.openapi(
   }),
   async (c: any) => {
     const projectId = c.req.param('projectId');
-    const loaded = await loadProjectForUser(c, projectId, 'manage');
+    const loaded = await loadProjectForUser(c, projectId, 'read');
     if (!loaded) return c.json({ error: 'Not found' }, 404);
     await assertProjectCapability(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_MEMBERS_MANAGE);
 
@@ -1571,7 +1571,7 @@ projectsApp.openapi(
     // grant_id is a uuid column — a malformed id is a clean 404 (same as missing),
     // not a 22P02 500.
     if (!isUuid(grantId)) return c.json({ error: 'grant not found' }, 404);
-    const loaded = await loadProjectForUser(c, projectId, 'manage');
+    const loaded = await loadProjectForUser(c, projectId, 'read');
     if (!loaded) return c.json({ error: 'Not found' }, 404);
     await assertProjectCapability(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_MEMBERS_MANAGE);
 

--- a/apps/api/src/projects/routes/r8.ts
+++ b/apps/api/src/projects/routes/r8.ts
@@ -57,7 +57,10 @@ projectsApp.openapi(
     if (!UUID_V4_REGEX.test(sessionId))
       return c.json({ error: 'Invalid session id' }, 400);
 
-    const loaded = await loadProjectForUser(c, projectId, 'read');
+    // Floor 'session' (= project.session.start) so the human gate matches
+    // restart/stop and a custom role that withholds session.start is denied here
+    // (was 'read', which let any project-reader start sessions).
+    const loaded = await loadProjectForUser(c, projectId, 'session');
     if (!loaded) return c.json({ error: 'Not found' }, 404);
     // Per-agent gate: resuming a session provisions compute. A scoped agent
     // token must hold project.session.start (no-op for human/PAT tokens).
@@ -174,6 +177,10 @@ projectsApp.openapi(
     // Per-agent gate: same capability as start/restart — stopping is part of
     // the agent's session-lifecycle surface.
     assertAgentScope(c, PROJECT_ACTIONS.PROJECT_SESSION_START);
+    // Human gate: stopping has its own leaf (project.session.stop), distinct from
+    // start, so a custom role can allow one and withhold the other. Every
+    // built-in role holds it, so member/editor/manager are unaffected.
+    await assertProjectCapability(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_SESSION_STOP);
 
     // Stop is reserved for the session owner or an account owner/admin, same policy
     // as restart.
@@ -650,12 +657,16 @@ projectsApp.openapi(
     const body = await readBody(c);
     const loaded = await loadProjectForUser(c, projectId, 'write');
     if (!loaded) return c.json({ error: 'Not found' }, 404);
+    // request-changes is a human review decision on a CR, not a code push —
+    // gate it on project.review.act (the same leaf as /review/items/{id}/act),
+    // not gitops.push. Editor/manager hold both; a custom reviewer role with
+    // review.act but no gitops.push can now request changes.
     await assertProjectCapability(
       c,
       loaded.userId,
       loaded.row.accountId,
       projectId,
-      PROJECT_ACTIONS.PROJECT_GITOPS_PUSH,
+      PROJECT_ACTIONS.PROJECT_REVIEW_ACT,
     );
 
     const feedback = normalizeString(body.feedback ?? body.text);

--- a/apps/api/src/projects/routes/setup-links.ts
+++ b/apps/api/src/projects/routes/setup-links.ts
@@ -18,8 +18,9 @@ import { loadPipedreamConnector } from '../../executor/db-deps';
 import { pipedreamConfigured } from '../../executor/pipedream';
 import { mintSetupLink, type SecretFieldSpec } from '../../setup-links/token';
 import { isValidSecretName } from '../secrets';
-import { loadProjectForUser } from '../lib/access';
+import { assertProjectCapability, loadProjectForUser } from '../lib/access';
 import { AnyObject, projectsApp } from '../lib/app';
+import { PROJECT_ACTIONS } from '../../iam';
 import { CODEX_AUTH_JSON_SECRET_NAME, normalizeString, readBody } from '../lib/serializers';
 
 function frontendBase(): string {
@@ -49,8 +50,12 @@ projectsApp.openapi(
   async (c: any) => {
     const projectId = c.req.param('projectId');
     const body = await readBody(c);
-    const loaded = await loadProjectForUser(c, projectId, 'manage');
+    // Floor 'read'; project.secret.write is the real gate — the same leaf as
+    // POST /secrets. Was 'manage' → project.write, so unchecking secret.write
+    // did nothing here.
+    const loaded = await loadProjectForUser(c, projectId, 'read');
     if (!loaded) return c.json({ error: 'Not found' }, 404);
+    await assertProjectCapability(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_SECRET_WRITE);
 
     // Accept `names: [...]` or a single `name`.
     const rawNames: unknown[] = Array.isArray(body.names)
@@ -128,8 +133,11 @@ projectsApp.openapi(
   async (c: any) => {
     const projectId = c.req.param('projectId');
     const body = await readBody(c);
-    const loaded = await loadProjectForUser(c, projectId, 'manage');
+    // Floor 'read'; project.connector.write is the real gate (minting a Pipedream
+    // Quick Connect link is a connector operation). Was 'manage' → project.write.
+    const loaded = await loadProjectForUser(c, projectId, 'read');
     if (!loaded) return c.json({ error: 'Not found' }, 404);
+    await assertProjectCapability(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_CONNECTOR_WRITE);
 
     if (!pipedreamConfigured()) return c.json({ error: 'Pipedream is not configured on this deployment' }, 501);
 

--- a/apps/api/src/projects/triggers.ts
+++ b/apps/api/src/projects/triggers.ts
@@ -258,7 +258,10 @@ export function extractTriggers(manifest: ParsedManifest): LoadedTriggers {
         {
           slug: '(top-level)',
           path: filename,
-          error: '`triggers` must be an array of tables — use [[triggers]], not [triggers]',
+          error:
+            manifest.format === 'yaml'
+              ? '`triggers` must be a list — write it as a YAML `triggers:` list, not a map or scalar.'
+              : '`triggers` must be an array of tables — use [[triggers]], not [triggers]',
         },
       ],
     };

--- a/apps/api/src/snapshots/builder.ts
+++ b/apps/api/src/snapshots/builder.ts
@@ -20,7 +20,7 @@ import { resolveCommitSha, type GitBackedProject } from '../projects/git';
 import { getSandboxProvider, type ProviderState, type SandboxProviderAdapter } from './providers';
 import { config, type SandboxProviderName } from '../config';
 import { warmPrebakeProviders } from '../projects/lib/provider-precedence';
-import { perProjectWarmImageName, ppwarmReapTargets } from './ppwarm-names';
+import { perProjectWarmImageName, ppwarmReapTargets, warmBuildSlug } from './ppwarm-names';
 import {
   computeTemplateIdentity,
   listTemplatesForProject,
@@ -28,6 +28,7 @@ import {
   recordTemplateFailed,
   refreshTemplateState,
   resolveTemplateBySlug,
+  resolveTemplateForBuildSlug,
   type ResolvedTemplate,
 } from './templates';
 import { DEFAULT_SANDBOX_SLUG } from './dockerfile-layer';
@@ -388,12 +389,17 @@ const inflightBuilds = new Map<string, Promise<EnsureSandboxImageResult>>();
 /**
  * Force the next session to rebuild by deleting the provider-side snapshot
  * for a given slug. No-op if nothing is there.
+ *
+ * Accepts a BUILD slug (`default-warm`) as well as a template slug: the retry
+ * surfaces hand us whatever `latest_failure.slug` held, and the warm bake's build
+ * row is never a template. Deleting the base template's snapshot is the correct
+ * response either way — the warm image is re-baked from it.
  */
 export async function deleteSandboxImage(
   project: GitBackedProject,
   opts: { slug?: string } = {},
 ): Promise<{ deleted: boolean; snapshotName: string; slug: string }> {
-  const template = await resolveTemplateBySlug(project, opts.slug);
+  const template = await resolveTemplateForBuildSlug(project, opts.slug);
   const provider = getSandboxProvider(template.provider);
   const identity = await computeTemplateIdentity(project, template);
   const before = await provider.getSnapshotState(identity.snapshotName);
@@ -979,7 +985,7 @@ export async function ensurePerProjectWarmImage(
     ? await openBuildLog({
         accountId: opts.accountId,
         projectId: project.projectId,
-        slug: `${DEFAULT_SANDBOX_SLUG}-warm`,
+        slug: warmBuildSlug(DEFAULT_SANDBOX_SLUG),
         snapshotName,
         contentHash: baseIdentity.contentHash,
         commitSha: tip,
@@ -1001,7 +1007,7 @@ export async function ensurePerProjectWarmImage(
       userDockerfile: baseIdentity.userDockerfile,
       entrypoint: template.entrypoint ? [template.entrypoint] : undefined,
       spec: { cpu: template.cpu, memoryGb: template.memoryGb, diskGb: template.diskGb },
-      slug: `${template.slug}-warm`,
+      slug: warmBuildSlug(template.slug),
       isShared: false,
       warmRepo,
     });

--- a/apps/api/src/snapshots/ppwarm-names.ts
+++ b/apps/api/src/snapshots/ppwarm-names.ts
@@ -10,6 +10,37 @@ import { createHash } from 'node:crypto';
 export const PPWARM_PREFIX = 'kortix-ppwarm-';
 
 /**
+ * Suffix that distinguishes the warm bake's BUILD-LOG row from the template it
+ * layers on top of. `project_snapshot_builds.metadata.slug` records
+ * `<template>-warm` for a warm bake, but no such template exists in
+ * `sandbox_templates` — the warm image is derived, never declared. Anything that
+ * feeds a build slug back into template resolution (rebuild, fix-with-agent)
+ * MUST map it back first via `templateSlugFromBuildSlug`, or it resolves nothing.
+ */
+export const WARM_BUILD_SLUG_SUFFIX = '-warm';
+
+/** The build-log slug recorded for `templateSlug`'s warm bake. */
+export function warmBuildSlug(templateSlug: string): string {
+  return `${templateSlug}${WARM_BUILD_SLUG_SUFFIX}`;
+}
+
+export function isWarmBuildSlug(slug: string): boolean {
+  return slug.endsWith(WARM_BUILD_SLUG_SUFFIX);
+}
+
+/**
+ * Map a build-log slug back to the template slug it was baked from. Note this is
+ * ambiguous by construction: a project MAY declare a real template literally named
+ * `foo-warm`. Callers must therefore try the slug verbatim FIRST and only fall
+ * back to this — see `resolveTemplateForBuildSlug`.
+ */
+export function templateSlugFromBuildSlug(buildSlug: string): string {
+  return isWarmBuildSlug(buildSlug)
+    ? buildSlug.slice(0, -WARM_BUILD_SLUG_SUFFIX.length)
+    : buildSlug;
+}
+
+/**
  * First 8 hex chars of the projectId with dashes stripped — the per-project scope
  * key in a ppwarm name. Matches warm-project.ts's `proj8` so the prefixes line up.
  */

--- a/apps/api/src/snapshots/quota-gc-select.ts
+++ b/apps/api/src/snapshots/quota-gc-select.ts
@@ -32,6 +32,23 @@
  * mean the project is gone — it may be another environment's. `lastUsedAt` is the
  * only cross-env liveness signal we have, and it is the sole basis on which a
  * ppwarm tip belonging to nobody-we-know is reclaimed.
+ *
+ * ── Why ppwarm needs an LRU budget, not just a liveness rule ────────────────
+ * `kortix-ppwarm-<proj8>-<hash>` is minted unconditionally on session-start of the
+ * shared default (builder.ts), one live tip per project. So the cache's floor is the
+ * number of projects that have ever started a session. Measured 2026-07-08: 69 tips
+ * for 69 distinct, non-archived projects — 69 of the org's 100 slots, before a single
+ * default or user template. Liveness rules reclaim NOTHING there (every tip is a live
+ * project's only tip), so a purely liveness-based GC sits at 100% pressure doing
+ * nothing, which is exactly the outage we hit.
+ *
+ * ppwarm is a pure CACHE — evicting a tip costs one cold boot plus a re-bake, never
+ * data — so it is the namespace that absorbs budget pressure. Evict LRU until the org
+ * is back at target, skipping recently-used tips (they'd re-bake at once: churn, not
+ * reclamation). When even that can't reach target, `budgetUnresolved` is set so the
+ * caller can alarm — a GC that silently can't keep up is how this failed the first
+ * time. The real remedy at that point is capacity (raise the org snapshot quota) or
+ * gating the warm bake; GC can only buy time.
  */
 
 /** The Daytona org-wide snapshot cap. Counts every snapshot, ours or not. */
@@ -39,6 +56,9 @@ export const DAYTONA_ORG_SNAPSHOT_LIMIT = 100;
 
 /** Start reclaiming once the ORG total reaches this. Leaves room to act before builds fail. */
 export const QUOTA_GC_ORG_HIGH_WATER = 80;
+
+/** Once reclaiming, free down to here — a buffer, not just back under the high-water mark. */
+export const QUOTA_GC_ORG_TARGET = 85;
 
 /** Live env defaults are booted constantly, so they're always in the freshest set. */
 export const QUOTA_GC_KEEP_FRESHEST_DEFAULTS = 12;
@@ -51,6 +71,13 @@ export const QUOTA_GC_MIN_IDLE_MS = 7 * 24 * 60 * 60 * 1000;
  * it is. Cross-env safe: any environment still booting from it keeps lastUsedAt fresh.
  */
 export const QUOTA_GC_PPWARM_MAX_IDLE_MS = 14 * 24 * 60 * 60 * 1000;
+
+/**
+ * Under budget pressure, ppwarm tips are evicted LRU — but never one used this
+ * recently. An actively-used project would simply re-bake on its next session, so
+ * evicting it is churn (a slot freed and immediately reclaimed), not reclamation.
+ */
+export const QUOTA_GC_PPWARM_EVICT_PROTECT_MS = 6 * 60 * 60 * 1000;
 
 /** Max deletions per sweep pass — keeps each pass cheap and observable. */
 export const QUOTA_GC_MAX_PER_PASS = 15;
@@ -102,6 +129,13 @@ export interface SelectResult {
   doomed: ReapCandidate[];
   /** Reapable but dropped by the per-pass cap — logged so truncation is never silent. */
   deferred: number;
+  /**
+   * True when, even after evicting every eligible ppwarm tip, the org still can't
+   * reach QUOTA_GC_ORG_TARGET. The cache floor (one tip per active project) has
+   * outgrown the quota: GC cannot fix this, only capacity or a warm-bake gate can.
+   * Callers MUST surface this rather than log a quiet no-op.
+   */
+  budgetUnresolved: boolean;
 }
 
 export function isManaged(name: string): boolean {
@@ -149,6 +183,7 @@ export function selectSnapshotsToReap(input: SelectInput): SelectResult {
     underPressure,
     doomed: [],
     deferred: 0,
+    budgetUnresolved: false,
   };
   if (!underPressure) return result;
 
@@ -217,6 +252,32 @@ export function selectSnapshotsToReap(input: SelectInput): SelectResult {
     if (now - t > QUOTA_GC_MIN_IDLE_MS) {
       claim(s, `unreferenced + idle ${Math.floor((now - t) / 86_400_000)}d`);
     }
+  }
+
+  // 6. BUDGET. Everything above is "provably unneeded". If the org is still over
+  //    target after all of it, the shortfall is live cache: one ppwarm tip per active
+  //    project, which no liveness rule can touch (see the header). ppwarm is a pure
+  //    cache, so it is what gives. Evict LRU until we reach target, skipping tips used
+  //    recently enough that they'd just re-bake.
+  const stillOver = () => orgTotal - candidates.length - QUOTA_GC_ORG_TARGET;
+  if (stillOver() > 0) {
+    const evictable = pool
+      .filter((s) => ppwarmProj8(s.name) && !claimed.has(s.id))
+      .filter((s) => {
+        const t = lastTouch(s);
+        return Number.isFinite(t) && now - t > QUOTA_GC_PPWARM_EVICT_PROTECT_MS;
+      })
+      .sort((a, b) => lastTouch(a) - lastTouch(b)); // least-recently-used first
+
+    for (const s of evictable) {
+      if (stillOver() <= 0) break;
+      claim(
+        s,
+        `ppwarm LRU eviction (idle ${Math.floor((now - lastTouch(s)) / 3_600_000)}h, over budget)`,
+      );
+    }
+    // Exhausted every evictable tip and still over: the cache floor beats the quota.
+    result.budgetUnresolved = stillOver() > 0;
   }
 
   result.deferred = Math.max(0, candidates.length - QUOTA_GC_MAX_PER_PASS);

--- a/apps/api/src/snapshots/quota-gc-select.ts
+++ b/apps/api/src/snapshots/quota-gc-select.ts
@@ -1,0 +1,225 @@
+/**
+ * Pure selection logic for the snapshot quota GC.
+ *
+ * Split out from quota-gc.ts (which owns the DB + provider IO) so the rules that
+ * decide what gets DELETED are unit-testable without a database, a Daytona org, or
+ * a clock. Nothing here imports config, db, or a provider.
+ *
+ * ── Why the old pressure gate could never fire ──────────────────────────────
+ * The Daytona quota (100) counts EVERY snapshot in the org: our templates, our
+ * per-project warm images, and Daytona's own stock/bench images. The old gate
+ * counted only `kortix-default-` / `kortix-tpl-` / `kortix-wproj-`. Measured live
+ * (2026-07-08): 120 snapshots tripped the cap while that namespace held 98 — and
+ * after a manual reclaim, 68 total against a GC-visible 15. With ~46 ppwarm + 22
+ * stock images uncounted, the namespace would have to reach 60 before GC woke up,
+ * i.e. an org total of ~128 — nearly 30 snapshots past the ceiling it defends.
+ * The gate is therefore on the ORG TOTAL, which is what the quota actually meters.
+ *
+ * ── Why defaults can't use an idle gate ─────────────────────────────────────
+ * The platform default is resolved dynamically from the runtime fingerprint; it is
+ * NOT stored in `sandbox_templates.provider_snapshot_name` (only custom `kortix-tpl-`
+ * rows and dev's default are). So "referenced" never protects it, and a *superseded*
+ * default keeps a fresh `lastUsedAt` — it was the live default until minutes ago.
+ * A 7-day idle rule makes zero defaults eligible while ~4.5/day accrue. Freshness
+ * rank, not idle time, is the only signal that separates live from superseded:
+ * every live environment boots its default constantly, so the live ones are always
+ * in the freshest few. Reaping a still-live default is self-healing — the next boot
+ * hits the snapshot-missing auto-heal and rebuilds (one slow boot, no data loss).
+ *
+ * ── Cross-environment safety ────────────────────────────────────────────────
+ * dev / staging / prod / laptops share ONE Daytona org but have SEPARATE databases.
+ * This process can only see its own DB. So "no project row for this proj8" does NOT
+ * mean the project is gone — it may be another environment's. `lastUsedAt` is the
+ * only cross-env liveness signal we have, and it is the sole basis on which a
+ * ppwarm tip belonging to nobody-we-know is reclaimed.
+ */
+
+/** The Daytona org-wide snapshot cap. Counts every snapshot, ours or not. */
+export const DAYTONA_ORG_SNAPSHOT_LIMIT = 100;
+
+/** Start reclaiming once the ORG total reaches this. Leaves room to act before builds fail. */
+export const QUOTA_GC_ORG_HIGH_WATER = 80;
+
+/** Live env defaults are booted constantly, so they're always in the freshest set. */
+export const QUOTA_GC_KEEP_FRESHEST_DEFAULTS = 12;
+
+/** Unreferenced user templates / legacy warm bases must be idle this long. */
+export const QUOTA_GC_MIN_IDLE_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * A ppwarm tip unused this long is reclaimed even though we can't see whose project
+ * it is. Cross-env safe: any environment still booting from it keeps lastUsedAt fresh.
+ */
+export const QUOTA_GC_PPWARM_MAX_IDLE_MS = 14 * 24 * 60 * 60 * 1000;
+
+/** Max deletions per sweep pass — keeps each pass cheap and observable. */
+export const QUOTA_GC_MAX_PER_PASS = 15;
+
+export const DEFAULT_PREFIX = 'kortix-default-';
+export const PPWARM_PREFIX = 'kortix-ppwarm-';
+/** Namespaces we own and may reap. Anything else (stock/bench images) is untouched. */
+export const MANAGED_PREFIXES = [
+  DEFAULT_PREFIX,
+  'kortix-tpl-',
+  'kortix-wproj-',
+  PPWARM_PREFIX,
+] as const;
+
+/** States that mean a build is IN FLIGHT — deleting these would break a live boot. */
+const IN_FLIGHT_STATES = new Set(['building', 'pulling']);
+/** States that mean the snapshot is pure waste. */
+const BROKEN_STATES = new Set(['error', 'build_failed']);
+
+export interface SnapshotLike {
+  id: string;
+  name: string;
+  state: string;
+  createdAt: string | null;
+  lastUsedAt: string | null;
+}
+
+export interface ReapCandidate {
+  snapshot: SnapshotLike;
+  reason: string;
+}
+
+export interface SelectInput {
+  /** EVERY snapshot in the org, including stock images. A partial list must never be passed. */
+  all: SnapshotLike[];
+  /** Names any local `sandbox_templates` row still points at. Never reaped. */
+  referenced: ReadonlySet<string>;
+  now: number;
+}
+
+export interface SelectResult {
+  /** Org-wide total — the number the Daytona quota actually meters. */
+  orgTotal: number;
+  /** Snapshots in namespaces we own. */
+  managedCount: number;
+  /** True when orgTotal has reached the high-water mark and reclaiming is warranted. */
+  underPressure: boolean;
+  /** Everything reapable, most-reclaimable first, already capped at MAX_PER_PASS. */
+  doomed: ReapCandidate[];
+  /** Reapable but dropped by the per-pass cap — logged so truncation is never silent. */
+  deferred: number;
+}
+
+export function isManaged(name: string): boolean {
+  return MANAGED_PREFIXES.some((p) => name.startsWith(p));
+}
+
+/** proj8 scope key of a ppwarm name: `kortix-ppwarm-<proj8>-<hash12>`. */
+export function ppwarmProj8(name: string): string | null {
+  if (!name.startsWith(PPWARM_PREFIX)) return null;
+  const rest = name.slice(PPWARM_PREFIX.length);
+  const proj8 = rest.split('-')[0];
+  return proj8 || null;
+}
+
+function lastTouch(s: SnapshotLike): number {
+  const t = s.lastUsedAt || s.createdAt;
+  return t ? new Date(t).getTime() : Number.NaN;
+}
+
+/** Freshest first; anything without a usable timestamp sorts last (and is kept). */
+function byFreshestFirst(a: SnapshotLike, b: SnapshotLike): number {
+  const ta = lastTouch(a);
+  const tb = lastTouch(b);
+  if (!Number.isFinite(ta) && !Number.isFinite(tb)) return 0;
+  if (!Number.isFinite(ta)) return 1;
+  if (!Number.isFinite(tb)) return -1;
+  return tb - ta;
+}
+
+/**
+ * Decide what to reap. Ordering of the returned list is deliberate: the cheapest,
+ * least-recoverable-value deletions come first, so the per-pass cap always spends
+ * itself on the safest wins before touching anything judgement-based.
+ */
+export function selectSnapshotsToReap(input: SelectInput): SelectResult {
+  const { all, referenced, now } = input;
+
+  const orgTotal = all.length;
+  const managed = all.filter((s) => isManaged(s.name));
+  const underPressure = orgTotal >= QUOTA_GC_ORG_HIGH_WATER;
+
+  const result: SelectResult = {
+    orgTotal,
+    managedCount: managed.length,
+    underPressure,
+    doomed: [],
+    deferred: 0,
+  };
+  if (!underPressure) return result;
+
+  // Reapable universe: ours, not referenced by a local template row, not mid-build.
+  const pool = managed.filter((s) => !referenced.has(s.name) && !IN_FLIGHT_STATES.has(s.state));
+
+  const candidates: ReapCandidate[] = [];
+  const claimed = new Set<string>();
+  const claim = (s: SnapshotLike, reason: string) => {
+    if (claimed.has(s.id)) return;
+    claimed.add(s.id);
+    candidates.push({ snapshot: s, reason });
+  };
+
+  // 1. Broken builds — pure waste, zero risk.
+  for (const s of pool
+    .filter((s) => BROKEN_STATES.has(s.state))
+    .sort(byFreshestFirst)
+    .reverse()) {
+    claim(s, `state=${s.state}`);
+  }
+
+  // 2. Superseded ppwarm tips: exactly one tip per project is live. The on-bake
+  //    reaper already does this, but it misses stragglers when a bake fails midway.
+  const byProj = new Map<string, SnapshotLike[]>();
+  for (const s of pool) {
+    if (s.name.includes('__deleted')) continue; // soft-delete tombstone; not quota-counting
+    const proj8 = ppwarmProj8(s.name);
+    if (!proj8) continue;
+    const group = byProj.get(proj8);
+    if (group) group.push(s);
+    else byProj.set(proj8, [s]);
+  }
+  for (const [proj8, group] of byProj) {
+    if (group.length < 2) continue;
+    const [, ...superseded] = [...group].sort(byFreshestFirst);
+    for (const s of superseded) claim(s, `superseded ppwarm tip for project ${proj8}`);
+  }
+
+  // 3. ppwarm tips nobody has booted in a long time. We cannot see other envs' DBs,
+  //    so idle time is the only safe liveness proof. Purely a cache — a wrongly
+  //    reaped tip re-bakes on the project's next background sync.
+  for (const s of pool) {
+    const t = lastTouch(s);
+    if (!ppwarmProj8(s.name)) continue;
+    if (!Number.isFinite(t)) continue; // can't prove idle → keep
+    if (now - t > QUOTA_GC_PPWARM_MAX_IDLE_MS) {
+      claim(s, `ppwarm idle ${Math.floor((now - t) / 86_400_000)}d`);
+    }
+  }
+
+  // 4. Superseded platform defaults — keep only the freshest N. Not idle-gated
+  //    (see the header): a superseded default's lastUsedAt is fresh by construction.
+  const defaults = pool.filter((s) => s.name.startsWith(DEFAULT_PREFIX)).sort(byFreshestFirst);
+  for (const s of defaults.slice(QUOTA_GC_KEEP_FRESHEST_DEFAULTS)) {
+    claim(s, 'superseded default (beyond freshest N)');
+  }
+
+  // 5. Everything else we own (user templates `kortix-tpl-`, legacy `kortix-wproj-`):
+  //    conservative idle gate. These can encode real user intent, so they get the
+  //    benefit of the doubt that a content-addressed default does not.
+  for (const s of pool) {
+    if (s.name.startsWith(DEFAULT_PREFIX) || ppwarmProj8(s.name)) continue;
+    const t = lastTouch(s);
+    if (!Number.isFinite(t)) continue;
+    if (now - t > QUOTA_GC_MIN_IDLE_MS) {
+      claim(s, `unreferenced + idle ${Math.floor((now - t) / 86_400_000)}d`);
+    }
+  }
+
+  result.deferred = Math.max(0, candidates.length - QUOTA_GC_MAX_PER_PASS);
+  result.doomed = candidates.slice(0, QUOTA_GC_MAX_PER_PASS);
+  return result;
+}

--- a/apps/api/src/snapshots/quota-gc.ts
+++ b/apps/api/src/snapshots/quota-gc.ts
@@ -19,18 +19,20 @@
  * Never acts on a partial view: if the org listing fails, the pass does nothing.
  */
 
-import { isNotNull, sql } from 'drizzle-orm';
 import { sandboxTemplates } from '@kortix/db';
-import { db } from '../shared/db';
+import { isNotNull, sql } from 'drizzle-orm';
 import {
   deleteDaytonaSnapshotById,
   isDaytonaConfigured,
   listDaytonaSnapshots,
 } from '../shared/daytona';
+import { db } from '../shared/db';
 import {
+  DAYTONA_ORG_SNAPSHOT_LIMIT,
   QUOTA_GC_MAX_PER_PASS,
-  selectSnapshotsToReap,
+  QUOTA_GC_ORG_TARGET,
   type SnapshotLike,
+  selectSnapshotsToReap,
 } from './quota-gc-select';
 
 /** A project counts as ACTIVE (its legacy warm pointer is protected) when it has a
@@ -46,6 +48,8 @@ export interface QuotaGcResult {
   deleted: number;
   /** Reapable but dropped by the per-pass cap. Never silently truncate. */
   deferred: number;
+  /** GC cannot get the org back to target — capacity problem, needs a human. */
+  budgetUnresolved: boolean;
   dryRun: boolean;
 }
 
@@ -63,6 +67,7 @@ export async function reconcileSnapshotQuota(
     eligible: 0,
     deleted: 0,
     deferred: 0,
+    budgetUnresolved: false,
     dryRun,
   };
   if (!isDaytonaConfigured()) return result;
@@ -71,7 +76,10 @@ export async function reconcileSnapshotQuota(
   try {
     all = await listDaytonaSnapshots();
   } catch (err) {
-    console.warn('[snapshot-gc] org listing failed — pass skipped:', err instanceof Error ? err.message : err);
+    console.warn(
+      '[snapshot-gc] org listing failed — pass skipped:',
+      err instanceof Error ? err.message : err,
+    );
     return result;
   }
 
@@ -105,8 +113,10 @@ export async function reconcileSnapshotQuota(
     FROM kortix.projects p
     WHERE p.metadata -> 'warm_snapshot' ->> 'name' IS NOT NULL
   `);
-  const pointerList = ((pointerRows as unknown as { rows?: any[] }).rows ?? (pointerRows as unknown as any[])) as Array<{
-    name: string; active: boolean;
+  const pointerList = ((pointerRows as unknown as { rows?: any[] }).rows ??
+    (pointerRows as unknown as any[])) as Array<{
+    name: string;
+    active: boolean;
   }>;
   for (const r of pointerList) {
     if (r.name && r.active) referenced.add(r.name);
@@ -117,8 +127,22 @@ export async function reconcileSnapshotQuota(
   result.managedCount = plan.managedCount;
   result.eligible = plan.doomed.length + plan.deferred;
   result.deferred = plan.deferred;
+  result.budgetUnresolved = plan.budgetUnresolved;
 
   if (!plan.underPressure) return result;
+
+  // GC has run out of road: one warm tip per active project already exceeds the
+  // budget, so no amount of sweeping will keep builds from failing. Only capacity
+  // (a bigger org snapshot quota) or gating the warm bake fixes this. Say so —
+  // the first outage happened because a GC that couldn't cope logged nothing.
+  if (plan.budgetUnresolved) {
+    console.error(
+      `[snapshot-gc] BUDGET UNRESOLVED: org=${plan.orgTotal} target=${QUOTA_GC_ORG_TARGET} ` +
+        `limit=${DAYTONA_ORG_SNAPSHOT_LIMIT} — evicted everything eligible and still over. ` +
+        `The per-project warm cache floor exceeds the org snapshot quota; raise the quota ` +
+        `or gate the warm bake. Builds will start failing with 'Snapshot quota exceeded'.`,
+    );
+  }
 
   for (const { snapshot, reason } of plan.doomed) {
     if (dryRun) {
@@ -134,7 +158,9 @@ export async function reconcileSnapshotQuota(
   console.log(
     `[snapshot-gc] org=${result.orgTotal} managed=${result.managedCount} ` +
       `eligible=${result.eligible} ${dryRun ? 'would-delete' : 'deleted'}=${result.deleted}` +
-      (result.deferred > 0 ? ` deferred=${result.deferred} (cap ${QUOTA_GC_MAX_PER_PASS}/pass)` : ''),
+      (result.deferred > 0
+        ? ` deferred=${result.deferred} (cap ${QUOTA_GC_MAX_PER_PASS}/pass)`
+        : ''),
   );
   return result;
 }

--- a/apps/api/src/snapshots/quota-gc.ts
+++ b/apps/api/src/snapshots/quota-gc.ts
@@ -1,31 +1,22 @@
 /**
- * Snapshot quota GC — reclaim superseded template snapshots.
+ * Snapshot quota GC — reclaim superseded snapshots before the org-wide cap bites.
  *
  * Template snapshots are content-addressed (`kortix-default-<hash>` /
  * `kortix-tpl-<hash>`), so every identity drift (each release bumps the runtime
  * fingerprint; every Dockerfile/spec edit) mints a NEW name and silently
  * orphans the old one. Nothing else deletes them: the only same-name deletes
  * run while that exact identity is being rebuilt. Measured live (2026-06-12):
- * ~4.5 new snapshots/day against the 100/org Daytona quota — exhaustion in
- * days, at which point every build org-wide starts failing.
+ * ~4.5 new snapshots/day against the 100/org Daytona quota — exhaustion in days,
+ * at which point every build org-wide starts failing.
  *
- * Deletion criteria (ALL must hold):
- *   1. Name is in our managed namespaces (`kortix-default-` / `kortix-tpl-` / `kortix-wproj-`).
- *      Warm bases have their own age-gated reaper; stock images are untouched.
- *   2. Not referenced by any local `sandbox_templates.provider_snapshot_name`
- *      (the row a session would boot from on the trust-the-row / graceful
- *      path — covers the platform default too, it has a shared row).
- *   3. Not USED for `QUOTA_GC_MIN_IDLE_MS` (lastUsedAt, falling back to
- *      createdAt). Several environments (laptops/dev/prod) share the org but
- *      have separate DBs — `lastUsedAt` is the cross-environment guard: any
- *      env still booting from a snapshot keeps it fresh. A cold-but-needed
- *      snapshot that does get deleted is self-healing: the next session hits
- *      the snapshot-missing auto-heal and rebuilds (one slow boot, no loss).
+ * This file owns the IO (DB reads, provider deletes). The RULES live in
+ * quota-gc-select.ts as a pure function — including the two hard-won invariants:
+ * the pressure gate must measure the ORG TOTAL (not just our namespace), and
+ * platform defaults must be ranked by freshness (not idle time). See that file's
+ * header for why each of those was wrong before, and for the cross-environment
+ * safety argument (one Daytona org, many databases).
  *
- * Pressure-gated: nothing is deleted while the org namespace is comfortably
- * under quota, so quiet orgs never see churn. Bounded per pass, oldest-first,
- * and skipped entirely when the org listing fails (never act on a partial
- * view).
+ * Never acts on a partial view: if the org listing fails, the pass does nothing.
  */
 
 import { isNotNull, sql } from 'drizzle-orm';
@@ -36,28 +27,26 @@ import {
   isDaytonaConfigured,
   listDaytonaSnapshots,
 } from '../shared/daytona';
+import {
+  QUOTA_GC_MAX_PER_PASS,
+  selectSnapshotsToReap,
+  type SnapshotLike,
+} from './quota-gc-select';
 
-const TEMPLATE_PREFIXES = ['kortix-default-', 'kortix-tpl-', 'kortix-wproj-'] as const;
-/** Start deleting only when our namespace holds this many snapshots. */
-const QUOTA_GC_PRESSURE_THRESHOLD = 60;
-/** A snapshot must be unused this long before it is eligible. */
-const QUOTA_GC_MIN_IDLE_MS = 7 * 24 * 60 * 60 * 1000;
-/** Max deletions per sweep pass — keeps each pass cheap and observable. */
-const QUOTA_GC_MAX_PER_PASS = 15;
-/** A project counts as ACTIVE (its warm snapshot is protected) when it has a
- * session or portal presence within this window. */
+/** A project counts as ACTIVE (its legacy warm pointer is protected) when it has a
+ * session within this window. */
 const QUOTA_GC_PROJECT_ACTIVE_MS = 14 * 24 * 60 * 60 * 1000;
 
 export interface QuotaGcResult {
-  /** Snapshots in our template namespaces (the pressure number). */
-  namespaceCount: number;
+  /** Org-wide snapshot count — the number the Daytona quota actually meters. */
+  orgTotal: number;
+  /** Snapshots in namespaces we own. */
+  managedCount: number;
   eligible: number;
   deleted: number;
+  /** Reapable but dropped by the per-pass cap. Never silently truncate. */
+  deferred: number;
   dryRun: boolean;
-}
-
-function isTemplateSnapshot(name: string): boolean {
-  return TEMPLATE_PREFIXES.some((p) => name.startsWith(p));
 }
 
 /**
@@ -68,20 +57,23 @@ export async function reconcileSnapshotQuota(
   opts: { dryRun?: boolean; now?: number } = {},
 ): Promise<QuotaGcResult> {
   const dryRun = opts.dryRun ?? false;
-  const result: QuotaGcResult = { namespaceCount: 0, eligible: 0, deleted: 0, dryRun };
+  const result: QuotaGcResult = {
+    orgTotal: 0,
+    managedCount: 0,
+    eligible: 0,
+    deleted: 0,
+    deferred: 0,
+    dryRun,
+  };
   if (!isDaytonaConfigured()) return result;
 
-  let all;
+  let all: SnapshotLike[];
   try {
     all = await listDaytonaSnapshots();
   } catch (err) {
     console.warn('[snapshot-gc] org listing failed — pass skipped:', err instanceof Error ? err.message : err);
     return result;
   }
-
-  const namespace = all.filter((s) => isTemplateSnapshot(s.name));
-  result.namespaceCount = namespace.length;
-  if (namespace.length < QUOTA_GC_PRESSURE_THRESHOLD) return result;
 
   const now = opts.now ?? Date.now();
 
@@ -120,33 +112,29 @@ export async function reconcileSnapshotQuota(
     if (r.name && r.active) referenced.add(r.name);
   }
 
-  const lastTouch = (s: { lastUsedAt?: string | null; createdAt: string | null }) => {
-    const t = s.lastUsedAt || s.createdAt;
-    return t ? new Date(t).getTime() : Number.NaN;
-  };
-  const eligible = namespace
-    .filter((s) => !referenced.has(s.name))
-    // No usable timestamp → can't prove it's idle → keep.
-    .filter((s) => Number.isFinite(lastTouch(s)) && now - lastTouch(s) > QUOTA_GC_MIN_IDLE_MS)
-    .sort((a, b) => lastTouch(a) - lastTouch(b));
-  result.eligible = eligible.length;
+  const plan = selectSnapshotsToReap({ all, referenced, now });
+  result.orgTotal = plan.orgTotal;
+  result.managedCount = plan.managedCount;
+  result.eligible = plan.doomed.length + plan.deferred;
+  result.deferred = plan.deferred;
 
-  for (const snap of eligible.slice(0, QUOTA_GC_MAX_PER_PASS)) {
+  if (!plan.underPressure) return result;
+
+  for (const { snapshot, reason } of plan.doomed) {
     if (dryRun) {
-      console.log(`[snapshot-gc] DRY RUN would delete ${snap.name} (last used ${snap.lastUsedAt ?? snap.createdAt})`);
+      console.log(`[snapshot-gc] DRY RUN would delete ${snapshot.name} (${reason})`);
       result.deleted++;
       continue;
     }
-    const ok = await deleteDaytonaSnapshotById(snap.id);
-    console.log(`[snapshot-gc] delete ${snap.name} (last used ${snap.lastUsedAt ?? snap.createdAt}): ${ok ? 'ok' : 'failed'}`);
-    if (ok) {
-      result.deleted++;
-    }
+    const ok = await deleteDaytonaSnapshotById(snapshot.id);
+    console.log(`[snapshot-gc] delete ${snapshot.name} (${reason}): ${ok ? 'ok' : 'failed'}`);
+    if (ok) result.deleted++;
   }
-  if (result.namespaceCount >= QUOTA_GC_PRESSURE_THRESHOLD) {
-    console.log(
-      `[snapshot-gc] namespace=${result.namespaceCount} eligible=${result.eligible} ${dryRun ? 'would-delete' : 'deleted'}=${result.deleted}`,
-    );
-  }
+
+  console.log(
+    `[snapshot-gc] org=${result.orgTotal} managed=${result.managedCount} ` +
+      `eligible=${result.eligible} ${dryRun ? 'would-delete' : 'deleted'}=${result.deleted}` +
+      (result.deferred > 0 ? ` deferred=${result.deferred} (cap ${QUOTA_GC_MAX_PER_PASS}/pass)` : ''),
+  );
   return result;
 }

--- a/apps/api/src/snapshots/templates.ts
+++ b/apps/api/src/snapshots/templates.ts
@@ -16,6 +16,7 @@ import { sandboxTemplates, projects } from '@kortix/db';
 import { AGENT_BROWSER_VERSION, OPENCODE_VERSION } from '@kortix/shared';
 type DbSandboxTemplate = typeof sandboxTemplates.$inferSelect;
 import { db } from '../shared/db';
+import { isWarmBuildSlug, templateSlugFromBuildSlug } from './ppwarm-names';
 import { readManifest } from '../projects/triggers';
 import { resolveCommitSha, readRepoFile, type GitBackedProject } from '../projects/git';
 import { SANDBOX_VERSION, config } from '../config';
@@ -231,7 +232,18 @@ export async function listTemplatesForProject(
   return value;
 }
 
-/** Resolve a slug → ResolvedTemplate. Throws if slug missing. */
+/**
+ * A slug that resolves to no template. Typed so callers can answer 404 instead of
+ * folding a client mistake into a generic 502 alongside real provider failures.
+ */
+export class TemplateNotFoundError extends Error {
+  constructor(readonly slug: string) {
+    super(`No sandbox template with slug "${slug}" in this project.`);
+    this.name = 'TemplateNotFoundError';
+  }
+}
+
+/** Resolve a slug → ResolvedTemplate. Throws TemplateNotFoundError if slug missing. */
 export async function resolveTemplateBySlug(
   project: GitBackedProject,
   slug: string | undefined,
@@ -254,7 +266,31 @@ export async function resolveTemplateBySlug(
   const items = await listTemplatesForProject(project);
   const match = items.find((t) => t.slug === target);
   if (match) return match;
-  throw new Error(`No sandbox template with slug "${target}" in this project.`);
+  throw new TemplateNotFoundError(target);
+}
+
+/**
+ * Resolve a slug that may have come from a BUILD LOG rather than a template.
+ *
+ * The warm bake records its build under `<template>-warm`, which is not a template
+ * (see WARM_BUILD_SLUG_SUFFIX). Every surface that hands a `latest_failure.slug` /
+ * `latest_build.slug` back to the API — Retry build, Fix with agent — lands here.
+ * Resolving the slug verbatim FIRST keeps a project that legitimately declares a
+ * template named `foo-warm` working; only when that misses do we treat the `-warm`
+ * as the derived-bake marker it usually is.
+ */
+export async function resolveTemplateForBuildSlug(
+  project: GitBackedProject,
+  slug: string | undefined,
+): Promise<ResolvedTemplate> {
+  try {
+    return await resolveTemplateBySlug(project, slug);
+  } catch (err) {
+    if (err instanceof TemplateNotFoundError && slug && isWarmBuildSlug(slug)) {
+      return resolveTemplateBySlug(project, templateSlugFromBuildSlug(slug));
+    }
+    throw err;
+  }
 }
 
 /**

--- a/apps/web/src/app/(app)/projects/page.tsx
+++ b/apps/web/src/app/(app)/projects/page.tsx
@@ -6,9 +6,10 @@ import Link from 'next/link';
 
 import { PersonalOnboardingWelcome } from '@/components/projects/personal-onboarding-welcome';
 import { Button } from '@/components/ui/button';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { EntityAvatar } from '@/components/ui/entity-avatar';
+import { InfoBanner } from '@/components/ui/info-banner';
 import { Input } from '@/components/ui/input';
-import { SectionCard } from '@/components/ui/section-card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { errorToast, successToast } from '@/components/ui/toast';
@@ -17,6 +18,7 @@ import { UpgradeButton } from '@/features/billing/upgrade-button';
 import { Icon } from '@/features/icon/icon';
 import { AppHeader } from '@/features/layout/app-header';
 import { EmptyState } from '@/features/layout/section/empty-state';
+import { ErrorState } from '@/features/layout/section/error-state';
 import { ProjectCreateModal } from '@/features/projects/modal/project-create-modal';
 import { RenameProjectDialog } from '@/features/projects/modal/rename-project-modal';
 import NewProjectControl from '@/features/projects/new-project-control';
@@ -41,7 +43,7 @@ import {
 } from '@kortix/sdk/projects-client';
 import { Search } from '@mynaui/icons-react';
 import { useMutation, useQueries, useQuery, useQueryClient } from '@tanstack/react-query';
-import { AlertCircle, FolderPlus } from 'lucide-react';
+import { FolderPlus } from 'lucide-react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
@@ -89,6 +91,7 @@ export default function ProjectsPage() {
   const [query, setQuery] = useState('');
   const [archivingId, setArchivingId] = useState<string | null>(null);
   const [renameTarget, setRenameTarget] = useState<KortixProject | null>(null);
+  const [archiveTarget, setArchiveTarget] = useState<KortixProject | null>(null);
   const [modalOpen, setModalOpen] = useState(false);
   const [createAccountId, setCreateAccountId] = useState<string | null>(null);
   const searchParams = useSearchParams();
@@ -291,14 +294,21 @@ export default function ProjectsPage() {
     mutationFn: archiveProject,
     onMutate: (projectId) => setArchivingId(projectId),
     onSettled: () => setArchivingId(null),
-    onSuccess: () => {
+    onSuccess: (_data, projectId) => {
       queryClient.invalidateQueries({ queryKey: ['projects'] });
-      successToast('Project archived');
+      const name = projectId === archiveTarget?.project_id ? archiveTarget?.name : undefined;
+      successToast(name ? `"${name}" archived` : 'Project archived');
+      setArchiveTarget(null);
     },
     onError: (error: Error) => {
       errorToast(error.message || 'Failed to archive project');
     },
   });
+
+  const confirmArchive = () => {
+    if (!archiveTarget || archiveMutation.isPending) return;
+    archiveMutation.mutate(archiveTarget.project_id);
+  };
 
   const filtered = useMemo(
     () => filterProjects(projectsQuery.data ?? []),
@@ -336,8 +346,11 @@ export default function ProjectsPage() {
   const allFilteredTotal = accountGroups.reduce((n, g) => n + g.projects.length, 0);
   const showAllLoading =
     viewAll && (accountsQuery.isLoading || allAccountQueries.some((q) => q.isLoading));
-  const showAllEmpty = viewAll && !showAllLoading && allRawTotal === 0;
-  const showAllNoResults = viewAll && !showAllLoading && allRawTotal > 0 && allFilteredTotal === 0;
+  const failedAllAccountQueries = viewAll ? allAccountQueries.filter((q) => q.isError) : [];
+  const showAllError = viewAll && !showAllLoading && failedAllAccountQueries.length > 0;
+  const showAllEmpty = viewAll && !showAllLoading && !showAllError && allRawTotal === 0;
+  const showAllNoResults =
+    viewAll && !showAllLoading && !showAllError && allRawTotal > 0 && allFilteredTotal === 0;
 
   const openCreateModal = (accountId: string | null) => {
     setCreateAccountId(accountId);
@@ -423,58 +436,51 @@ export default function ProjectsPage() {
               )}
 
               {projectsQuery.isError && (
-                <SectionCard flush>
-                  <EmptyState
-                    icon={AlertCircle}
-                    title={tHardcodedUi.raw(
-                      'appProjectsPage.line252JsxAttrTitleFailedToLoadProjects',
-                    )}
-                    description={(projectsQuery.error as Error).message}
-                    action={
-                      <Button variant="outline" size="sm" onClick={() => projectsQuery.refetch()}>
-                        Retry
-                      </Button>
-                    }
-                  />
-                </SectionCard>
+                <ErrorState
+                  title={tHardcodedUi.raw(
+                    'appProjectsPage.line252JsxAttrTitleFailedToLoadProjects',
+                  )}
+                  description={(projectsQuery.error as Error).message}
+                  action={
+                    <Button variant="outline" size="sm" onClick={() => projectsQuery.refetch()}>
+                      Retry
+                    </Button>
+                  }
+                />
               )}
 
               {showEmptyState && (
-                <SectionCard flush>
-                  <EmptyState
-                    icon={FolderPlus}
-                    title={tI18nHardcoded.raw(
-                      'autoAppAppProjectsPageJsxAttrTitleNoProjectsYet85527dd3',
-                    )}
-                    description={tI18nHardcoded.raw(
-                      'autoAppAppProjectsPageJsxAttrDescriptionAProjectIsa4dc84d2',
-                    )}
-                    action={
-                      <Button
-                        onClick={() => openCreateModal(activeAccountId)}
-                        disabled={!canCreateProjects}
-                      >
-                        <Icon.Plus />
-                        {tI18nHardcoded.raw(
-                          'autoAppAppProjectsPageJsxTextCreateYourFirstProject061cafdb',
-                        )}
-                      </Button>
-                    }
-                  />
-                </SectionCard>
+                <EmptyState
+                  icon={FolderPlus}
+                  title={tI18nHardcoded.raw(
+                    'autoAppAppProjectsPageJsxAttrTitleNoProjectsYet85527dd3',
+                  )}
+                  description={tI18nHardcoded.raw(
+                    'autoAppAppProjectsPageJsxAttrDescriptionAProjectIsa4dc84d2',
+                  )}
+                  action={
+                    <Button
+                      onClick={() => openCreateModal(activeAccountId)}
+                      disabled={!canCreateProjects}
+                    >
+                      <Icon.Plus />
+                      {tI18nHardcoded.raw(
+                        'autoAppAppProjectsPageJsxTextCreateYourFirstProject061cafdb',
+                      )}
+                    </Button>
+                  }
+                />
               )}
 
               {showNoResults && (
-                <SectionCard flush>
-                  <EmptyState
-                    icon={Search}
-                    size="sm"
-                    title={`No matches for "${query}"`}
-                    description={tHardcodedUi.raw(
-                      'appProjectsPage.line288JsxAttrDescriptionTryADifferentSearchTerm',
-                    )}
-                  />
-                </SectionCard>
+                <EmptyState
+                  icon={Search}
+                  size="sm"
+                  title={`No matches for "${query}"`}
+                  description={tHardcodedUi.raw(
+                    'appProjectsPage.line288JsxAttrDescriptionTryADifferentSearchTerm',
+                  )}
+                />
               )}
 
               {filtered.length > 0 && (
@@ -485,7 +491,7 @@ export default function ProjectsPage() {
                       project={project}
                       onOpen={() => router.push(`/projects/${project.project_id}`)}
                       onRename={() => setRenameTarget(project)}
-                      onArchive={() => archiveMutation.mutate(project.project_id)}
+                      onArchive={() => setArchiveTarget(project)}
                       archiving={archivingId === project.project_id}
                     />
                   ))}
@@ -504,43 +510,59 @@ export default function ProjectsPage() {
                 </div>
               )}
 
+              {showAllError && (
+                <InfoBanner
+                  tone="destructive"
+                  title={`Failed to load projects for ${failedAllAccountQueries.length} account${failedAllAccountQueries.length === 1 ? '' : 's'}`}
+                  action={
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => {
+                        for (const q of allAccountQueries) {
+                          if (q.isError) void q.refetch();
+                        }
+                      }}
+                    >
+                      Retry
+                    </Button>
+                  }
+                />
+              )}
+
               {showAllEmpty && (
-                <SectionCard flush>
-                  <EmptyState
-                    icon={FolderPlus}
-                    title={tI18nHardcoded.raw(
-                      'autoAppAppProjectsPageJsxAttrTitleNoProjectsYet85527dd3',
-                    )}
-                    description={tI18nHardcoded.raw(
-                      'autoAppAppProjectsPageJsxAttrDescriptionAProjectIsa4dc84d2',
-                    )}
-                    action={
-                      <NewProjectControl
-                        viewAll
-                        creatableAccounts={creatableAccounts}
-                        activeAccountId={activeAccountId}
-                        canCreateActive={canCreateProjects}
-                        onPick={openCreateModal}
-                        label={tI18nHardcoded.raw(
-                          'autoAppAppProjectsPageJsxAttrLabelCreateYourFirst301a83a6',
-                        )}
-                      />
-                    }
-                  />
-                </SectionCard>
+                <EmptyState
+                  icon={FolderPlus}
+                  title={tI18nHardcoded.raw(
+                    'autoAppAppProjectsPageJsxAttrTitleNoProjectsYet85527dd3',
+                  )}
+                  description={tI18nHardcoded.raw(
+                    'autoAppAppProjectsPageJsxAttrDescriptionAProjectIsa4dc84d2',
+                  )}
+                  action={
+                    <NewProjectControl
+                      viewAll
+                      creatableAccounts={creatableAccounts}
+                      activeAccountId={activeAccountId}
+                      canCreateActive={canCreateProjects}
+                      onPick={openCreateModal}
+                      label={tI18nHardcoded.raw(
+                        'autoAppAppProjectsPageJsxAttrLabelCreateYourFirst301a83a6',
+                      )}
+                    />
+                  }
+                />
               )}
 
               {showAllNoResults && (
-                <SectionCard flush>
-                  <EmptyState
-                    icon={Search}
-                    size="sm"
-                    title={`No matches for "${query}"`}
-                    description={tHardcodedUi.raw(
-                      'appProjectsPage.line288JsxAttrDescriptionTryADifferentSearchTerm',
-                    )}
-                  />
-                </SectionCard>
+                <EmptyState
+                  icon={Search}
+                  size="sm"
+                  title={`No matches for "${query}"`}
+                  description={tHardcodedUi.raw(
+                    'appProjectsPage.line288JsxAttrDescriptionTryADifferentSearchTerm',
+                  )}
+                />
               )}
 
               {!showAllLoading &&
@@ -563,7 +585,7 @@ export default function ProjectsPage() {
                             router.push(`/projects/${project.project_id}`);
                           }}
                           onRename={() => setRenameTarget(project)}
-                          onArchive={() => archiveMutation.mutate(project.project_id)}
+                          onArchive={() => setArchiveTarget(project)}
                           archiving={archivingId === project.project_id}
                         />
                       ))}
@@ -601,6 +623,24 @@ export default function ProjectsPage() {
         onOpenChange={(o) => {
           if (!o) setRenameTarget(null);
         }}
+      />
+
+      <ConfirmDialog
+        open={!!archiveTarget}
+        onOpenChange={(o) => {
+          if (!o && !archiveMutation.isPending) setArchiveTarget(null);
+        }}
+        title="Archive project"
+        description={
+          <>
+            <span className="text-foreground font-medium">{archiveTarget?.name}</span> will be
+            archived and removed from your projects list.
+          </>
+        }
+        confirmLabel="Archive"
+        confirmVariant="destructive"
+        isPending={archiveMutation.isPending}
+        onConfirm={confirmArchive}
       />
 
       <PersonalOnboardingWelcome />

--- a/apps/web/src/components/projects/schedule-view.tsx
+++ b/apps/web/src/components/projects/schedule-view.tsx
@@ -66,6 +66,8 @@ import CustomizeSectionWrapper from '@/features/workspace/customize/sections/com
 import { type ModelKey, modelKeyToWire, wireToModelKey } from '@/hooks/opencode/use-model-store';
 import { useOpenCodeProviders, useVisibleAgents } from '@/hooks/opencode/use-opencode-sessions';
 import { getEnv } from '@/lib/env-config';
+import { PROJECT_ACTIONS } from '@/lib/project-actions';
+import { useProjectCan } from '@/lib/use-project-can';
 import { cn } from '@/lib/utils';
 import {
   type ProjectTrigger,
@@ -271,6 +273,8 @@ export function ScheduleView({ projectId, type }: { projectId: string; type: Tri
 
   const tHardcodedUi = useTranslations('hardcodedUi');
   const queryClient = useQueryClient();
+  const canWrite =
+    useProjectCan(projectId, PROJECT_ACTIONS.PROJECT_TRIGGER_CREATE).allowed === true;
   const queryKey = useMemo(() => ['project-triggers', projectId], [projectId]);
 
   const triggersQuery = useQuery({
@@ -331,7 +335,7 @@ export function ScheduleView({ projectId, type }: { projectId: string; type: Tri
               )
         }
         action={
-          showContent ? (
+          showContent && canWrite ? (
             <Button
               size="sm"
               variant="secondary"
@@ -402,15 +406,17 @@ export function ScheduleView({ projectId, type }: { projectId: string; type: Tri
               size="sm"
               title={meta.empty.title}
               action={
-                <Button
-                  variant="secondary"
-                  size="sm"
-                  onClick={() => setCreateOpen(true)}
-                  className="gap-1.5"
-                >
-                  <Icon.Plus className="size-3.5 shrink-0" />
-                  {meta.createButtonLabel}
-                </Button>
+                canWrite ? (
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    onClick={() => setCreateOpen(true)}
+                    className="gap-1.5"
+                  >
+                    <Icon.Plus className="size-3.5 shrink-0" />
+                    {meta.createButtonLabel}
+                  </Button>
+                ) : null
               }
             />
           ) : filtered.length === 0 ? (
@@ -513,6 +519,7 @@ export function ScheduleView({ projectId, type }: { projectId: string; type: Tri
       <TriggerDetailSheet
         projectId={projectId}
         trigger={selectedTrigger}
+        canWrite={canWrite}
         open={!!selectedTrigger}
         onOpenChange={(open) => {
           if (!open) setSelectedId(null);
@@ -538,6 +545,7 @@ export function ScheduleView({ projectId, type }: { projectId: string; type: Tri
 function TriggerDetailSheet({
   projectId,
   trigger,
+  canWrite,
   open,
   onOpenChange,
   onDelete,
@@ -545,6 +553,7 @@ function TriggerDetailSheet({
 }: {
   projectId: string;
   trigger: ProjectTrigger | null;
+  canWrite: boolean;
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onDelete: () => void;
@@ -592,21 +601,33 @@ function TriggerDetailSheet({
             <h1 className="text-foreground text-xl font-semibold tracking-tight text-balance">
               {getTriggerName(trigger)}
             </h1>
-            <TriggerDetailToolbar
-              enabled={trigger.enabled}
-              firePending={fire.isPending}
-              togglePending={toggle.isPending}
-              fireLabel={tHardcodedUi.raw('componentsProjectsTriggersView.line623JsxTextFireNow')}
-              onFire={() => fire.mutate()}
-              onToggle={() => toggle.mutate(!trigger.enabled)}
-              onDelete={onDelete}
-            />
+            {canWrite ? (
+              <TriggerDetailToolbar
+                enabled={trigger.enabled}
+                firePending={fire.isPending}
+                togglePending={toggle.isPending}
+                fireLabel={tHardcodedUi.raw('componentsProjectsTriggersView.line623JsxTextFireNow')}
+                onFire={() => fire.mutate()}
+                onToggle={() => toggle.mutate(!trigger.enabled)}
+                onDelete={onDelete}
+              />
+            ) : null}
           </header>
 
           <div className="space-y-8">
             {isCron ? <CronSection trigger={trigger} /> : <WebhookSection trigger={trigger} />}
-            <PromptTemplateSection projectId={projectId} trigger={trigger} onMutated={onMutated} />
-            <AgentModelSection projectId={projectId} trigger={trigger} onMutated={onMutated} />
+            <PromptTemplateSection
+              projectId={projectId}
+              trigger={trigger}
+              canWrite={canWrite}
+              onMutated={onMutated}
+            />
+            <AgentModelSection
+              projectId={projectId}
+              trigger={trigger}
+              canWrite={canWrite}
+              onMutated={onMutated}
+            />
             <MetaSection trigger={trigger} />
           </div>
         </SheetBody>
@@ -673,10 +694,12 @@ function TriggerDetailToolbar({
 function AgentModelSection({
   projectId,
   trigger,
+  canWrite,
   onMutated,
 }: {
   projectId: string;
   trigger: ProjectTrigger;
+  canWrite: boolean;
   onMutated: () => void;
 }) {
   const agents = useVisibleAgents({ projectId });
@@ -703,6 +726,28 @@ function AgentModelSection({
     },
     onError: (e: Error) => errorToast(e.message || 'Failed to update model'),
   });
+
+  if (!canWrite) {
+    return (
+      <section className="space-y-2">
+        <Label>Agent &amp; model</Label>
+        <PropertyTable
+          rows={[
+            {
+              label: 'Agent',
+              value: <span className="text-xs tracking-wide uppercase">{trigger.agent}</span>,
+            },
+            {
+              label: 'Model',
+              value: (
+                <span className="font-mono text-xs">{trigger.model ?? 'Agent default'}</span>
+              ),
+            },
+          ]}
+        />
+      </section>
+    );
+  }
 
   return (
     <section className="space-y-4">
@@ -887,10 +932,12 @@ function WebhookSection({ trigger }: { trigger: ProjectTrigger }) {
 function PromptTemplateSection({
   projectId,
   trigger,
+  canWrite,
   onMutated,
 }: {
   projectId: string;
   trigger: ProjectTrigger;
+  canWrite: boolean;
   onMutated: () => void;
 }) {
   const tHardcodedUi = useTranslations('hardcodedUi');
@@ -917,7 +964,7 @@ function PromptTemplateSection({
         <Label>
           {tHardcodedUi.raw('componentsProjectsTriggersView.line817JsxAttrTitlePromptTemplate')}
         </Label>
-        {editing ? (
+        {!canWrite ? null : editing ? (
           <ButtonGroup>
             <Button
               variant="outline"
@@ -946,7 +993,7 @@ function PromptTemplateSection({
         )}
       </div>
 
-      {editing ? (
+      {canWrite && editing ? (
         <Textarea
           value={draft}
           onChange={(e) => setDraft(e.target.value)}

--- a/apps/web/src/features/marketplace/add-to-project-modal.tsx
+++ b/apps/web/src/features/marketplace/add-to-project-modal.tsx
@@ -3,8 +3,10 @@
 import { useQuery } from '@tanstack/react-query';
 import { KeyRound, Plug, Wrench } from 'lucide-react';
 import { useTranslations } from 'next-intl';
-import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { type FormEvent, useEffect, useState } from 'react';
 
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
   Field,
@@ -14,6 +16,7 @@ import {
   FieldLabel,
   FieldTitle,
 } from '@/components/ui/field';
+import Loading from '@/components/ui/loading';
 import {
   Modal,
   ModalBody,
@@ -32,9 +35,16 @@ import {
 } from '@/components/ui/select';
 import { errorToast, successToast } from '@/components/ui/toast';
 import { useAuth } from '@/features/providers/auth-provider';
-import { useInstallMarketplaceItem } from '@/hooks/marketplace';
+import { useInstallMarketplaceItem, useInstalledItems } from '@/hooks/marketplace';
 import type { MarketplaceItem } from '@/lib/marketplace-client';
 import { listProjectsForAccount } from '@kortix/sdk/projects-client';
+import {
+  buildInstallSuccessSummary,
+  capabilityCount,
+  hasCapabilities,
+  isInstallDisabled,
+  projectMarketplaceHref,
+} from './marketplace-install';
 import { typeMeta } from './marketplace-meta';
 
 export function AddToProjectModal({
@@ -52,6 +62,7 @@ export function AddToProjectModal({
   fixedProjectName?: string;
 }) {
   const tI18nHardcoded = useTranslations('hardcodedUi');
+  const router = useRouter();
   const { user } = useAuth();
   const usePicker = !fixedProjectId;
   const [pickedProjectId, setPickedProjectId] = useState('');
@@ -73,14 +84,39 @@ export function AddToProjectModal({
 
   const targetProjectId = fixedProjectId ?? pickedProjectId;
   const caps = item?.capabilities;
-  const hasCaps = !!caps && caps.secrets.length + caps.connectors.length + caps.tools.length > 0;
+  const showCaps = hasCapabilities(caps);
+  const capCount = capabilityCount(caps);
+
+  const installedQuery = useInstalledItems(targetProjectId || null);
+  const alreadyInstalled = !!(
+    item && installedQuery.data?.some((installed) => installed.name === item.name)
+  );
+
+  const disabled = isInstallDisabled({
+    hasItem: !!item,
+    targetProjectId,
+    pending: install.isPending,
+  });
+
+  const guardedOpenChange = (next: boolean) => {
+    // Block the modal from closing mid-flight — losing the pending/error
+    // feedback would leave the user unsure whether the install landed.
+    if (install.isPending) return;
+    onOpenChange(next);
+  };
 
   const onInstall = async () => {
-    if (!item || !targetProjectId) return;
+    if (!item || disabled) return;
     try {
       const res = await install.mutateAsync({ projectId: targetProjectId, id: item.id });
-      successToast(`Added ${item.title}`, {
-        description: `Committed ${res.file_count} file${res.file_count === 1 ? '' : 's'} — live in the next session.`,
+      const summary = buildInstallSuccessSummary(item.title, res);
+      successToast(summary.title, {
+        description: summary.description,
+        button: (
+          <Button size="sm" onClick={() => router.push(projectMarketplaceHref(targetProjectId))}>
+            View in project
+          </Button>
+        ),
       });
       onOpenChange(false);
     } catch (e) {
@@ -88,9 +124,14 @@ export function AddToProjectModal({
     }
   };
 
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    onInstall();
+  };
+
   return (
-    <Modal open={open} onOpenChange={onOpenChange}>
-      <ModalContent className="lg:max-w-md">
+    <Modal open={open} onOpenChange={guardedOpenChange}>
+      <ModalContent className="lg:max-w-md" closeOnOutsideClick={!install.isPending}>
         <ModalHeader>
           <ModalTitle>
             Add {item?.title}
@@ -105,92 +146,138 @@ export function AddToProjectModal({
           </ModalDescription>
         </ModalHeader>
 
-        <ModalBody>
-          <FieldGroup className="gap-4">
-            {usePicker && (
-              <Field className="gap-1.5">
-                <FieldLabel htmlFor="mp-project">Project</FieldLabel>
-                <Select value={pickedProjectId} onValueChange={setPickedProjectId}>
-                  <SelectTrigger id="mp-project">
-                    <SelectValue
-                      placeholder={projectsQuery.isLoading ? 'Loading…' : 'Choose a project'}
-                    />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {projects.map((p) => (
-                      <SelectItem key={p.project_id} value={p.project_id}>
-                        {p.name}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-                {!projectsQuery.isLoading && projects.length === 0 && (
-                  <FieldDescription>
-                    {tI18nHardcoded.raw(
-                      'autoComponentsMarketplaceAddToProjectModalJsxTextYouHavec6bfb213',
-                    )}
-                  </FieldDescription>
-                )}
-              </Field>
-            )}
+        <form onSubmit={handleSubmit}>
+          <ModalBody>
+            <FieldGroup className="gap-4">
+              {usePicker && (
+                <Field className="gap-1.5">
+                  <FieldLabel htmlFor="mp-project">Project</FieldLabel>
+                  <Select value={pickedProjectId} onValueChange={setPickedProjectId}>
+                    <SelectTrigger id="mp-project">
+                      <SelectValue
+                        placeholder={projectsQuery.isLoading ? 'Loading…' : 'Choose a project'}
+                      />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {projects.map((p) => (
+                        <SelectItem key={p.project_id} value={p.project_id}>
+                          {p.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  {!projectsQuery.isLoading && projects.length === 0 && (
+                    <FieldDescription>
+                      {tI18nHardcoded.raw(
+                        'autoComponentsMarketplaceAddToProjectModalJsxTextYouHavec6bfb213',
+                      )}
+                    </FieldDescription>
+                  )}
+                </Field>
+              )}
 
-            {item && item.dependencies.length > 0 && (
-              <FieldDescription>
-                {tI18nHardcoded.raw(
-                  'autoComponentsMarketplaceAddToProjectModalJsxTextAlsoInstallsac6dcc9a',
-                )}
-                <span className="text-foreground">{item.dependencies.join(', ')}</span>
-              </FieldDescription>
-            )}
+              {alreadyInstalled && (
+                <div className="bg-popover flex items-center gap-2 rounded-md border px-4 py-2.5">
+                  <Badge variant="success" size="sm">
+                    Already installed
+                  </Badge>
+                  <span className="text-muted-foreground text-xs">
+                    Adding again reinstalls it from source.
+                  </span>
+                </div>
+              )}
 
-            {hasCaps ? (
-              <Field variant="outline">
-                <FieldContent>
-                  <FieldTitle>
-                    {tI18nHardcoded.raw(
-                      'autoComponentsMarketplaceAddToProjectModalJsxTextThisItem2bb697bd',
-                    )}
-                  </FieldTitle>
-                  <ul className="text-muted-foreground mt-2 space-y-1.5 text-sm">
-                    {caps!.secrets.map((s) => (
-                      <li key={s} className="flex items-center gap-2">
-                        <KeyRound className="size-3.5 shrink-0" />
-                        <span className="font-mono text-xs">{s}</span>
-                      </li>
-                    ))}
-                    {caps!.connectors.map((c) => (
-                      <li key={c} className="flex items-center gap-2">
-                        <Plug className="size-3.5 shrink-0" />
-                        {c}
-                      </li>
-                    ))}
-                    {caps!.tools.map((t) => (
-                      <li key={t} className="flex items-center gap-2">
-                        <Wrench className="size-3.5 shrink-0" />
-                        {t}
-                      </li>
-                    ))}
-                  </ul>
-                </FieldContent>
-              </Field>
-            ) : (
-              <FieldDescription>
-                {tI18nHardcoded.raw(
-                  'autoComponentsMarketplaceAddToProjectModalJsxTextNoSpecial521751ba',
-                )}
-              </FieldDescription>
-            )}
-          </FieldGroup>
-        </ModalBody>
+              {item && item.dependencies.length > 0 && (
+                <FieldDescription>
+                  {tI18nHardcoded.raw(
+                    'autoComponentsMarketplaceAddToProjectModalJsxTextAlsoInstallsac6dcc9a',
+                  )}
+                  <span className="text-foreground">{item.dependencies.join(', ')}</span>
+                </FieldDescription>
+              )}
 
-        <ModalFooter className="sm:justify-between">
-          <Button variant="outline-ghost" size="sm" onClick={() => onOpenChange(false)}>
-            Cancel
-          </Button>
-          <Button size="sm" onClick={onInstall} disabled={!targetProjectId || install.isPending}>
-            {install.isPending ? 'Adding…' : 'Add'}
-          </Button>
-        </ModalFooter>
+              {showCaps ? (
+                <Field variant="outline">
+                  <FieldContent>
+                    <div className="flex items-center gap-2">
+                      <FieldTitle>
+                        {tI18nHardcoded.raw(
+                          'autoComponentsMarketplaceAddToProjectModalJsxTextThisItem2bb697bd',
+                        )}
+                      </FieldTitle>
+                      <Badge variant="outline" size="sm">
+                        {capCount}
+                      </Badge>
+                    </div>
+                    <ul className="mt-2 space-y-1.5">
+                      {caps?.secrets.map((s) => (
+                        <li key={s} className="flex items-center gap-2.5">
+                          <span className="bg-kortix-yellow/15 text-kortix-yellow flex size-6 shrink-0 items-center justify-center rounded-sm">
+                            <KeyRound className="size-3.5" />
+                          </span>
+                          <span className="text-foreground min-w-0 flex-1 truncate font-mono text-xs">
+                            {s}
+                          </span>
+                          <Badge variant="outline" size="sm">
+                            Secret
+                          </Badge>
+                        </li>
+                      ))}
+                      {caps?.connectors.map((c) => (
+                        <li key={c} className="flex items-center gap-2.5">
+                          <span className="bg-kortix-blue/15 text-kortix-blue flex size-6 shrink-0 items-center justify-center rounded-sm">
+                            <Plug className="size-3.5" />
+                          </span>
+                          <span className="text-foreground min-w-0 flex-1 truncate text-sm">
+                            {c}
+                          </span>
+                          <Badge variant="outline" size="sm">
+                            Connector
+                          </Badge>
+                        </li>
+                      ))}
+                      {caps?.tools.map((t) => (
+                        <li key={t} className="flex items-center gap-2.5">
+                          <span className="bg-kortix-orange/15 text-kortix-orange flex size-6 shrink-0 items-center justify-center rounded-sm">
+                            <Wrench className="size-3.5" />
+                          </span>
+                          <span className="text-foreground min-w-0 flex-1 truncate text-sm">
+                            {t}
+                          </span>
+                          <Badge variant="outline" size="sm">
+                            Tool
+                          </Badge>
+                        </li>
+                      ))}
+                    </ul>
+                  </FieldContent>
+                </Field>
+              ) : (
+                <FieldDescription>
+                  {tI18nHardcoded.raw(
+                    'autoComponentsMarketplaceAddToProjectModalJsxTextNoSpecial521751ba',
+                  )}
+                </FieldDescription>
+              )}
+            </FieldGroup>
+          </ModalBody>
+
+          <ModalFooter className="sm:justify-between">
+            <Button
+              type="button"
+              variant="outline-ghost"
+              size="sm"
+              disabled={install.isPending}
+              onClick={() => onOpenChange(false)}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" size="sm" disabled={disabled}>
+              {install.isPending ? <Loading className="size-3.5 shrink-0" /> : null}
+              {install.isPending ? 'Adding…' : alreadyInstalled ? 'Reinstall' : 'Add'}
+            </Button>
+          </ModalFooter>
+        </form>
       </ModalContent>
     </Modal>
   );

--- a/apps/web/src/features/marketplace/add-to-project-modal.tsx
+++ b/apps/web/src/features/marketplace/add-to-project-modal.tsx
@@ -3,8 +3,10 @@
 import { useQuery } from '@tanstack/react-query';
 import { KeyRound, Plug, Wrench } from 'lucide-react';
 import { useTranslations } from 'next-intl';
-import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { type FormEvent, useEffect, useState } from 'react';
 
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
   Field,
@@ -14,6 +16,7 @@ import {
   FieldLabel,
   FieldTitle,
 } from '@/components/ui/field';
+import Loading from '@/components/ui/loading';
 import {
   Modal,
   ModalBody,
@@ -32,9 +35,16 @@ import {
 } from '@/components/ui/select';
 import { errorToast, successToast } from '@/components/ui/toast';
 import { useAuth } from '@/features/providers/auth-provider';
-import { useInstallMarketplaceItem } from '@/hooks/marketplace';
+import { useInstallMarketplaceItem, useInstalledItems } from '@/hooks/marketplace';
 import type { MarketplaceItem } from '@/lib/marketplace-client';
 import { listProjectsForAccount } from '@kortix/sdk/projects-client';
+import {
+  buildInstallSuccessSummary,
+  capabilityCount,
+  hasCapabilities,
+  isInstallDisabled,
+  projectMarketplaceHref,
+} from './marketplace-install';
 import { typeMeta } from './marketplace-meta';
 
 export function AddToProjectModal({
@@ -52,6 +62,7 @@ export function AddToProjectModal({
   fixedProjectName?: string;
 }) {
   const tI18nHardcoded = useTranslations('hardcodedUi');
+  const router = useRouter();
   const { user } = useAuth();
   const usePicker = !fixedProjectId;
   const [pickedProjectId, setPickedProjectId] = useState('');
@@ -71,16 +82,47 @@ export function AddToProjectModal({
     }
   }, [open, usePicker, projects, pickedProjectId]);
 
+  // Reset any stale pending/close-guard state when a fresh item is opened.
+  useEffect(() => {
+    if (!open) return;
+    install.reset();
+  }, [open, item?.id]);
+
   const targetProjectId = fixedProjectId ?? pickedProjectId;
   const caps = item?.capabilities;
-  const hasCaps = !!caps && caps.secrets.length + caps.connectors.length + caps.tools.length > 0;
+  const showCaps = hasCapabilities(caps);
+  const capCount = capabilityCount(caps);
+
+  const installedQuery = useInstalledItems(targetProjectId || null);
+  const alreadyInstalled = !!(
+    item && installedQuery.data?.some((installed) => installed.name === item.name)
+  );
+
+  const disabled = isInstallDisabled({
+    hasItem: !!item,
+    targetProjectId,
+    pending: install.isPending,
+  });
+
+  const guardedOpenChange = (next: boolean) => {
+    // Block the modal from closing mid-flight — losing the pending/error
+    // feedback would leave the user unsure whether the install landed.
+    if (install.isPending) return;
+    onOpenChange(next);
+  };
 
   const onInstall = async () => {
-    if (!item || !targetProjectId) return;
+    if (!item || disabled) return;
     try {
       const res = await install.mutateAsync({ projectId: targetProjectId, id: item.id });
-      successToast(`Added ${item.title}`, {
-        description: `Committed ${res.file_count} file${res.file_count === 1 ? '' : 's'} — live in the next session.`,
+      const summary = buildInstallSuccessSummary(item.title, res);
+      successToast(summary.title, {
+        description: summary.description,
+        button: (
+          <Button size="sm" onClick={() => router.push(projectMarketplaceHref(targetProjectId))}>
+            View in project
+          </Button>
+        ),
       });
       onOpenChange(false);
     } catch (e) {
@@ -88,9 +130,14 @@ export function AddToProjectModal({
     }
   };
 
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    onInstall();
+  };
+
   return (
-    <Modal open={open} onOpenChange={onOpenChange}>
-      <ModalContent className="lg:max-w-md">
+    <Modal open={open} onOpenChange={guardedOpenChange}>
+      <ModalContent className="lg:max-w-md" closeOnOutsideClick={!install.isPending}>
         <ModalHeader>
           <ModalTitle>
             Add {item?.title}
@@ -105,92 +152,138 @@ export function AddToProjectModal({
           </ModalDescription>
         </ModalHeader>
 
-        <ModalBody>
-          <FieldGroup className="gap-4">
-            {usePicker && (
-              <Field className="gap-1.5">
-                <FieldLabel htmlFor="mp-project">Project</FieldLabel>
-                <Select value={pickedProjectId} onValueChange={setPickedProjectId}>
-                  <SelectTrigger id="mp-project">
-                    <SelectValue
-                      placeholder={projectsQuery.isLoading ? 'Loading…' : 'Choose a project'}
-                    />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {projects.map((p) => (
-                      <SelectItem key={p.project_id} value={p.project_id}>
-                        {p.name}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-                {!projectsQuery.isLoading && projects.length === 0 && (
-                  <FieldDescription>
-                    {tI18nHardcoded.raw(
-                      'autoComponentsMarketplaceAddToProjectModalJsxTextYouHavec6bfb213',
-                    )}
-                  </FieldDescription>
-                )}
-              </Field>
-            )}
+        <form onSubmit={handleSubmit}>
+          <ModalBody>
+            <FieldGroup className="gap-4">
+              {usePicker && (
+                <Field className="gap-1.5">
+                  <FieldLabel htmlFor="mp-project">Project</FieldLabel>
+                  <Select value={pickedProjectId} onValueChange={setPickedProjectId}>
+                    <SelectTrigger id="mp-project">
+                      <SelectValue
+                        placeholder={projectsQuery.isLoading ? 'Loading…' : 'Choose a project'}
+                      />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {projects.map((p) => (
+                        <SelectItem key={p.project_id} value={p.project_id}>
+                          {p.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  {!projectsQuery.isLoading && projects.length === 0 && (
+                    <FieldDescription>
+                      {tI18nHardcoded.raw(
+                        'autoComponentsMarketplaceAddToProjectModalJsxTextYouHavec6bfb213',
+                      )}
+                    </FieldDescription>
+                  )}
+                </Field>
+              )}
 
-            {item && item.dependencies.length > 0 && (
-              <FieldDescription>
-                {tI18nHardcoded.raw(
-                  'autoComponentsMarketplaceAddToProjectModalJsxTextAlsoInstallsac6dcc9a',
-                )}
-                <span className="text-foreground">{item.dependencies.join(', ')}</span>
-              </FieldDescription>
-            )}
+              {alreadyInstalled && (
+                <div className="bg-popover flex items-center gap-2 rounded-md border px-4 py-2.5">
+                  <Badge variant="success" size="sm">
+                    Already installed
+                  </Badge>
+                  <span className="text-muted-foreground text-xs">
+                    Adding again reinstalls it from source.
+                  </span>
+                </div>
+              )}
 
-            {hasCaps ? (
-              <Field variant="outline">
-                <FieldContent>
-                  <FieldTitle>
-                    {tI18nHardcoded.raw(
-                      'autoComponentsMarketplaceAddToProjectModalJsxTextThisItem2bb697bd',
-                    )}
-                  </FieldTitle>
-                  <ul className="text-muted-foreground mt-2 space-y-1.5 text-sm">
-                    {caps!.secrets.map((s) => (
-                      <li key={s} className="flex items-center gap-2">
-                        <KeyRound className="size-3.5 shrink-0" />
-                        <span className="font-mono text-xs">{s}</span>
-                      </li>
-                    ))}
-                    {caps!.connectors.map((c) => (
-                      <li key={c} className="flex items-center gap-2">
-                        <Plug className="size-3.5 shrink-0" />
-                        {c}
-                      </li>
-                    ))}
-                    {caps!.tools.map((t) => (
-                      <li key={t} className="flex items-center gap-2">
-                        <Wrench className="size-3.5 shrink-0" />
-                        {t}
-                      </li>
-                    ))}
-                  </ul>
-                </FieldContent>
-              </Field>
-            ) : (
-              <FieldDescription>
-                {tI18nHardcoded.raw(
-                  'autoComponentsMarketplaceAddToProjectModalJsxTextNoSpecial521751ba',
-                )}
-              </FieldDescription>
-            )}
-          </FieldGroup>
-        </ModalBody>
+              {item && item.dependencies.length > 0 && (
+                <FieldDescription>
+                  {tI18nHardcoded.raw(
+                    'autoComponentsMarketplaceAddToProjectModalJsxTextAlsoInstallsac6dcc9a',
+                  )}
+                  <span className="text-foreground">{item.dependencies.join(', ')}</span>
+                </FieldDescription>
+              )}
 
-        <ModalFooter className="sm:justify-between">
-          <Button variant="outline-ghost" size="sm" onClick={() => onOpenChange(false)}>
-            Cancel
-          </Button>
-          <Button size="sm" onClick={onInstall} disabled={!targetProjectId || install.isPending}>
-            {install.isPending ? 'Adding…' : 'Add'}
-          </Button>
-        </ModalFooter>
+              {showCaps ? (
+                <Field variant="outline">
+                  <FieldContent>
+                    <div className="flex items-center gap-2">
+                      <FieldTitle>
+                        {tI18nHardcoded.raw(
+                          'autoComponentsMarketplaceAddToProjectModalJsxTextThisItem2bb697bd',
+                        )}
+                      </FieldTitle>
+                      <Badge variant="outline" size="sm">
+                        {capCount}
+                      </Badge>
+                    </div>
+                    <ul className="mt-2 space-y-1.5">
+                      {caps!.secrets.map((s) => (
+                        <li key={s} className="flex items-center gap-2.5">
+                          <span className="bg-kortix-yellow/15 text-kortix-yellow flex size-6 shrink-0 items-center justify-center rounded-sm">
+                            <KeyRound className="size-3.5" />
+                          </span>
+                          <span className="text-foreground min-w-0 flex-1 truncate font-mono text-xs">
+                            {s}
+                          </span>
+                          <Badge variant="outline" size="sm">
+                            Secret
+                          </Badge>
+                        </li>
+                      ))}
+                      {caps!.connectors.map((c) => (
+                        <li key={c} className="flex items-center gap-2.5">
+                          <span className="bg-kortix-blue/15 text-kortix-blue flex size-6 shrink-0 items-center justify-center rounded-sm">
+                            <Plug className="size-3.5" />
+                          </span>
+                          <span className="text-foreground min-w-0 flex-1 truncate text-sm">
+                            {c}
+                          </span>
+                          <Badge variant="outline" size="sm">
+                            Connector
+                          </Badge>
+                        </li>
+                      ))}
+                      {caps!.tools.map((t) => (
+                        <li key={t} className="flex items-center gap-2.5">
+                          <span className="bg-kortix-orange/15 text-kortix-orange flex size-6 shrink-0 items-center justify-center rounded-sm">
+                            <Wrench className="size-3.5" />
+                          </span>
+                          <span className="text-foreground min-w-0 flex-1 truncate text-sm">
+                            {t}
+                          </span>
+                          <Badge variant="outline" size="sm">
+                            Tool
+                          </Badge>
+                        </li>
+                      ))}
+                    </ul>
+                  </FieldContent>
+                </Field>
+              ) : (
+                <FieldDescription>
+                  {tI18nHardcoded.raw(
+                    'autoComponentsMarketplaceAddToProjectModalJsxTextNoSpecial521751ba',
+                  )}
+                </FieldDescription>
+              )}
+            </FieldGroup>
+          </ModalBody>
+
+          <ModalFooter className="sm:justify-between">
+            <Button
+              type="button"
+              variant="outline-ghost"
+              size="sm"
+              disabled={install.isPending}
+              onClick={() => onOpenChange(false)}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" size="sm" disabled={disabled}>
+              {install.isPending ? <Loading className="size-3.5 shrink-0" /> : null}
+              {install.isPending ? 'Adding…' : alreadyInstalled ? 'Reinstall' : 'Add'}
+            </Button>
+          </ModalFooter>
+        </form>
       </ModalContent>
     </Modal>
   );

--- a/apps/web/src/features/marketplace/add-to-project-modal.tsx
+++ b/apps/web/src/features/marketplace/add-to-project-modal.tsx
@@ -82,12 +82,6 @@ export function AddToProjectModal({
     }
   }, [open, usePicker, projects, pickedProjectId]);
 
-  // Reset any stale pending/close-guard state when a fresh item is opened.
-  useEffect(() => {
-    if (!open) return;
-    install.reset();
-  }, [open, item?.id]);
-
   const targetProjectId = fixedProjectId ?? pickedProjectId;
   const caps = item?.capabilities;
   const showCaps = hasCapabilities(caps);
@@ -216,7 +210,7 @@ export function AddToProjectModal({
                       </Badge>
                     </div>
                     <ul className="mt-2 space-y-1.5">
-                      {caps!.secrets.map((s) => (
+                      {caps?.secrets.map((s) => (
                         <li key={s} className="flex items-center gap-2.5">
                           <span className="bg-kortix-yellow/15 text-kortix-yellow flex size-6 shrink-0 items-center justify-center rounded-sm">
                             <KeyRound className="size-3.5" />
@@ -229,7 +223,7 @@ export function AddToProjectModal({
                           </Badge>
                         </li>
                       ))}
-                      {caps!.connectors.map((c) => (
+                      {caps?.connectors.map((c) => (
                         <li key={c} className="flex items-center gap-2.5">
                           <span className="bg-kortix-blue/15 text-kortix-blue flex size-6 shrink-0 items-center justify-center rounded-sm">
                             <Plug className="size-3.5" />
@@ -242,7 +236,7 @@ export function AddToProjectModal({
                           </Badge>
                         </li>
                       ))}
-                      {caps!.tools.map((t) => (
+                      {caps?.tools.map((t) => (
                         <li key={t} className="flex items-center gap-2.5">
                           <span className="bg-kortix-orange/15 text-kortix-orange flex size-6 shrink-0 items-center justify-center rounded-sm">
                             <Wrench className="size-3.5" />

--- a/apps/web/src/features/marketplace/installed-client.test.ts
+++ b/apps/web/src/features/marketplace/installed-client.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, test } from 'bun:test';
+
+import type { InstalledItem, MarketplaceItem, RegistryItemStatus } from '@/lib/marketplace-client';
+import {
+  buildCatalogByName,
+  deriveInstalledItemStatus,
+  describeRemoveConsequence,
+  filterInstalledItems,
+  matchesInstalledItemQuery,
+  updatableInstalledItemNames,
+} from './installed-client';
+
+function makeItem(overrides: Partial<InstalledItem> = {}): InstalledItem {
+  return {
+    name: 'pdf-toolkit',
+    type: 'registry:skill',
+    source: 'kortix/marketplace',
+    installed_at: '2026-07-01T00:00:00.000Z',
+    file_count: 3,
+    ...overrides,
+  };
+}
+
+describe('deriveInstalledItemStatus', () => {
+  test('reports the status from the updates map when present', () => {
+    const map = new Map<string, RegistryItemStatus>([['pdf-toolkit', 'update-available']]);
+
+    expect(deriveInstalledItemStatus('pdf-toolkit', map)).toBe('update-available');
+  });
+
+  test('reports orphaned when the map says orphaned', () => {
+    const map = new Map<string, RegistryItemStatus>([['pdf-toolkit', 'orphaned']]);
+
+    expect(deriveInstalledItemStatus('pdf-toolkit', map)).toBe('orphaned');
+  });
+
+  test('falls back to up-to-date when absent from the map (server only lists attention items)', () => {
+    const map = new Map<string, RegistryItemStatus>();
+
+    expect(deriveInstalledItemStatus('pdf-toolkit', map)).toBe('up-to-date');
+  });
+});
+
+describe('matchesInstalledItemQuery', () => {
+  test('an empty query matches everything', () => {
+    expect(matchesInstalledItemQuery(makeItem(), '')).toBe(true);
+    expect(matchesInstalledItemQuery(makeItem(), '   ')).toBe(true);
+  });
+
+  test('matches on the raw registry name, case-insensitively', () => {
+    expect(matchesInstalledItemQuery(makeItem({ name: 'PDF-Toolkit' }), 'pdf')).toBe(true);
+  });
+
+  test('matches on the resolved catalog title even when the name differs', () => {
+    const item = makeItem({ name: 'internal-slug-42' });
+
+    expect(matchesInstalledItemQuery(item, 'notion', { catalogTitle: 'Notion Sync' })).toBe(true);
+  });
+
+  test('matches on the source', () => {
+    expect(matchesInstalledItemQuery(makeItem({ source: 'acme/tools' }), 'acme')).toBe(true);
+  });
+
+  test('matches on the type label', () => {
+    expect(matchesInstalledItemQuery(makeItem(), 'skill', { typeLabel: 'Skill' })).toBe(true);
+  });
+
+  test('does not match unrelated text', () => {
+    expect(matchesInstalledItemQuery(makeItem(), 'zzz-nope')).toBe(false);
+  });
+});
+
+describe('filterInstalledItems', () => {
+  const items = [
+    makeItem({ name: 'pdf-toolkit' }),
+    makeItem({ name: 'notion-sync', source: 'acme/tools' }),
+  ];
+  const resolve = () => ({});
+
+  test('an empty query returns every item unfiltered', () => {
+    expect(filterInstalledItems(items, '', resolve)).toEqual(items);
+  });
+
+  test('filters down to items matching the query', () => {
+    const result = filterInstalledItems(items, 'notion', resolve);
+
+    expect(result.map((i) => i.name)).toEqual(['notion-sync']);
+  });
+
+  test('resolves catalog title per item so titles (not just names) are searchable', () => {
+    const resolveByName = (item: InstalledItem) =>
+      item.name === 'pdf-toolkit' ? { catalogTitle: 'PDF Toolkit Pro' } : {};
+
+    const result = filterInstalledItems(items, 'toolkit pro', resolveByName);
+
+    expect(result.map((i) => i.name)).toEqual(['pdf-toolkit']);
+  });
+
+  test('no matches returns an empty list', () => {
+    expect(filterInstalledItems(items, 'nothing-matches-this', resolve)).toEqual([]);
+  });
+});
+
+describe('describeRemoveConsequence', () => {
+  test('names the file count and that it commits the removal', () => {
+    const sentence = describeRemoveConsequence(makeItem({ file_count: 3, name: 'pdf-toolkit' }));
+
+    expect(sentence).toContain('3 files');
+    expect(sentence).toContain('"pdf-toolkit"');
+    expect(sentence).toContain('commits the removal');
+  });
+
+  test('uses singular "file" for a single-file item', () => {
+    const sentence = describeRemoveConsequence(makeItem({ file_count: 1 }));
+
+    expect(sentence).toContain('1 file');
+    expect(sentence).not.toContain('1 files');
+  });
+
+  test('prefers the catalog title over the raw name when available', () => {
+    const sentence = describeRemoveConsequence(
+      makeItem({ name: 'internal-slug-42' }),
+      'Notion Sync',
+    );
+
+    expect(sentence).toContain('"Notion Sync"');
+    expect(sentence).not.toContain('internal-slug-42');
+  });
+});
+
+describe('updatableInstalledItemNames', () => {
+  test('keeps only update-available entries', () => {
+    const updates: { name: string; status: RegistryItemStatus }[] = [
+      { name: 'a', status: 'update-available' },
+      { name: 'b', status: 'up-to-date' },
+      { name: 'c', status: 'orphaned' },
+      { name: 'd', status: 'update-available' },
+    ];
+
+    expect(updatableInstalledItemNames(updates)).toEqual(['a', 'd']);
+  });
+
+  test('an empty updates list yields no updatable names', () => {
+    expect(updatableInstalledItemNames([])).toEqual([]);
+  });
+});
+
+describe('buildCatalogByName', () => {
+  test('indexes catalog items by name', () => {
+    const items = [{ name: 'pdf-toolkit' }, { name: 'notion-sync' }] as MarketplaceItem[];
+
+    const map = buildCatalogByName(items);
+
+    expect(map.get('pdf-toolkit')).toBe(items[0]);
+    expect(map.get('notion-sync')).toBe(items[1]);
+    expect(map.get('missing')).toBeUndefined();
+  });
+
+  test('an empty catalog produces an empty map', () => {
+    expect(buildCatalogByName([]).size).toBe(0);
+  });
+});

--- a/apps/web/src/features/marketplace/installed-client.ts
+++ b/apps/web/src/features/marketplace/installed-client.ts
@@ -1,0 +1,72 @@
+import type { InstalledItem, MarketplaceItem, RegistryItemStatus } from '@/lib/marketplace-client';
+
+/** Display-facing status for an installed item, derived from the registry
+ *  updates check. Absent from the updates map (or the check hasn't loaded
+ *  yet) reads as `'up-to-date'` — the server only lists items that need
+ *  attention (`update-available` / `orphaned`), so silence means "fine". */
+export type InstalledItemStatus = RegistryItemStatus;
+
+/** Resolves an installed item's status badge state from the (possibly still
+ *  loading) `/registry/updates` map. Extracted so the up-to-date/update/
+ *  orphaned decision is unit-testable without mounting the panel. */
+export function deriveInstalledItemStatus(
+  name: string,
+  statusByName: Map<string, RegistryItemStatus>,
+): InstalledItemStatus {
+  return statusByName.get(name) ?? 'up-to-date';
+}
+
+/** Case-insensitive match over the fields a user would recognize an installed
+ *  item by: its catalog title (when resolved), its raw registry name, its
+ *  type label, and its source. Extracted so the search box's predicate is
+ *  testable without react state. */
+export function matchesInstalledItemQuery(
+  item: InstalledItem,
+  query: string,
+  extra?: { catalogTitle?: string; typeLabel?: string },
+): boolean {
+  const q = query.trim().toLowerCase();
+  if (!q) return true;
+  const haystack = [item.name, item.source, extra?.catalogTitle, extra?.typeLabel]
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase();
+  return haystack.includes(q);
+}
+
+/** Filters an installed list against a search query, resolving each item's
+ *  catalog title/type label via the supplied lookup so matches work on the
+ *  friendly title, not just the raw registry name. */
+export function filterInstalledItems(
+  items: InstalledItem[],
+  query: string,
+  resolve: (item: InstalledItem) => { catalogTitle?: string; typeLabel?: string },
+): InstalledItem[] {
+  const q = query.trim();
+  if (!q) return items;
+  return items.filter((item) => matchesInstalledItemQuery(item, q, resolve(item)));
+}
+
+/** Precise consequence sentence for the remove confirm dialog — names the
+ *  exact file count and that removal lands as a new commit, so the user
+ *  knows what "Remove" actually does before confirming. */
+export function describeRemoveConsequence(item: InstalledItem, catalogTitle?: string): string {
+  const label = catalogTitle ?? item.name;
+  const fileWord = item.file_count === 1 ? 'file' : 'files';
+  return `This deletes ${item.file_count} ${fileWord} installed by "${label}" from the repo and commits the removal. This can't be undone from here.`;
+}
+
+/** Names of installed items eligible for a batch "Update all" — anything the
+ *  updates check actually reports as `update-available`. Orphaned items are
+ *  excluded (there's nothing to update them against). */
+export function updatableInstalledItemNames(
+  updates: { name: string; status: RegistryItemStatus }[],
+): string[] {
+  return updates.filter((u) => u.status === 'update-available').map((u) => u.name);
+}
+
+/** Builds the `Map<name, MarketplaceItem>` used to resolve an installed
+ *  item's catalog title/description/capabilities, from a catalog page. */
+export function buildCatalogByName(items: MarketplaceItem[]): Map<string, MarketplaceItem> {
+  return new Map(items.map((item) => [item.name, item]));
+}

--- a/apps/web/src/features/marketplace/marketplace-grid.test.ts
+++ b/apps/web/src/features/marketplace/marketplace-grid.test.ts
@@ -46,6 +46,23 @@ describe('buildMarketplaceGridRows', () => {
     ]);
   });
 
+  test('groups skills, agents, commands, and bundles into their own sections in taxonomy order', () => {
+    // Interleaved + out of section order on input; grouping must sort into the
+    // TYPE_SECTIONS order regardless.
+    const rows = buildMarketplaceGridRows({
+      items: [
+        ...makeItems('registry:command', ['c1']),
+        ...makeItems('registry:bundle', ['b1']),
+        ...makeItems('registry:skill', ['s1', 's2']),
+        ...makeItems('registry:agent', ['a1']),
+      ],
+      grouped: true,
+    });
+
+    const headers = rows.flatMap((r) => (r.kind === 'header' ? [r.label] : []));
+    expect(headers).toEqual(['Skills', 'Agents', 'Commands', 'Bundles']);
+  });
+
   test('for a large dataset, row count is far smaller than item count', () => {
     const items = makeItems(
       'registry:skill',

--- a/apps/web/src/features/marketplace/marketplace-install.test.ts
+++ b/apps/web/src/features/marketplace/marketplace-install.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  buildInstallSuccessSummary,
+  capabilityCount,
+  hasCapabilities,
+  isInstallDisabled,
+  projectMarketplaceHref,
+} from './marketplace-install';
+
+describe('buildInstallSuccessSummary', () => {
+  test('singularizes "file" for a single-file install', () => {
+    const summary = buildInstallSuccessSummary('Code Review', { file_count: 1 });
+
+    expect(summary.title).toBe('Added Code Review');
+    expect(summary.description).toBe('Committed 1 file — live in the next session.');
+  });
+
+  test('pluralizes "files" for multi-file installs', () => {
+    const summary = buildInstallSuccessSummary('Bundle', { file_count: 4 });
+
+    expect(summary.description).toBe('Committed 4 files — live in the next session.');
+  });
+
+  test('pluralizes for a zero-file install', () => {
+    const summary = buildInstallSuccessSummary('Empty', { file_count: 0 });
+
+    expect(summary.description).toBe('Committed 0 files — live in the next session.');
+  });
+});
+
+describe('projectMarketplaceHref', () => {
+  test('builds the customize marketplace deep link for a project', () => {
+    expect(projectMarketplaceHref('proj_123')).toBe('/projects/proj_123/customize/marketplace');
+  });
+
+  test('URL-encodes project ids with special characters', () => {
+    expect(projectMarketplaceHref('proj/weird id')).toBe(
+      '/projects/proj%2Fweird%20id/customize/marketplace',
+    );
+  });
+});
+
+describe('hasCapabilities', () => {
+  test('false for null/undefined', () => {
+    expect(hasCapabilities(null)).toBe(false);
+    expect(hasCapabilities(undefined)).toBe(false);
+  });
+
+  test('false when every list is empty', () => {
+    expect(hasCapabilities({ secrets: [], connectors: [], tools: [], network: [] })).toBe(false);
+  });
+
+  test('true when any list is non-empty', () => {
+    expect(hasCapabilities({ secrets: ['API_KEY'], connectors: [], tools: [], network: [] })).toBe(
+      true,
+    );
+    expect(hasCapabilities({ secrets: [], connectors: ['slack'], tools: [], network: [] })).toBe(
+      true,
+    );
+    expect(hasCapabilities({ secrets: [], connectors: [], tools: ['browser'], network: [] })).toBe(
+      true,
+    );
+  });
+});
+
+describe('capabilityCount', () => {
+  test('0 for null/undefined', () => {
+    expect(capabilityCount(null)).toBe(0);
+    expect(capabilityCount(undefined)).toBe(0);
+  });
+
+  test('sums across all three kinds', () => {
+    expect(
+      capabilityCount({
+        secrets: ['A', 'B'],
+        connectors: ['c'],
+        tools: ['t1', 't2', 't3'],
+        network: [],
+      }),
+    ).toBe(6);
+  });
+});
+
+describe('isInstallDisabled', () => {
+  test('disabled when no item is resolved', () => {
+    expect(isInstallDisabled({ hasItem: false, targetProjectId: 'p1', pending: false })).toBe(true);
+  });
+
+  test('disabled when no target project is chosen', () => {
+    expect(isInstallDisabled({ hasItem: true, targetProjectId: '', pending: false })).toBe(true);
+  });
+
+  test('disabled while a request is pending', () => {
+    expect(isInstallDisabled({ hasItem: true, targetProjectId: 'p1', pending: true })).toBe(true);
+  });
+
+  test('enabled once an item, project, and idle state all line up', () => {
+    expect(isInstallDisabled({ hasItem: true, targetProjectId: 'p1', pending: false })).toBe(false);
+  });
+});

--- a/apps/web/src/features/marketplace/marketplace-install.test.ts
+++ b/apps/web/src/features/marketplace/marketplace-install.test.ts
@@ -72,7 +72,12 @@ describe('capabilityCount', () => {
 
   test('sums across all three kinds', () => {
     expect(
-      capabilityCount({ secrets: ['A', 'B'], connectors: ['c'], tools: ['t1', 't2', 't3'], network: [] }),
+      capabilityCount({
+        secrets: ['A', 'B'],
+        connectors: ['c'],
+        tools: ['t1', 't2', 't3'],
+        network: [],
+      }),
     ).toBe(6);
   });
 });

--- a/apps/web/src/features/marketplace/marketplace-install.test.ts
+++ b/apps/web/src/features/marketplace/marketplace-install.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  buildInstallSuccessSummary,
+  capabilityCount,
+  hasCapabilities,
+  isInstallDisabled,
+  projectMarketplaceHref,
+} from './marketplace-install';
+
+describe('buildInstallSuccessSummary', () => {
+  test('singularizes "file" for a single-file install', () => {
+    const summary = buildInstallSuccessSummary('Code Review', { file_count: 1 });
+
+    expect(summary.title).toBe('Added Code Review');
+    expect(summary.description).toBe('Committed 1 file — live in the next session.');
+  });
+
+  test('pluralizes "files" for multi-file installs', () => {
+    const summary = buildInstallSuccessSummary('Bundle', { file_count: 4 });
+
+    expect(summary.description).toBe('Committed 4 files — live in the next session.');
+  });
+
+  test('pluralizes for a zero-file install', () => {
+    const summary = buildInstallSuccessSummary('Empty', { file_count: 0 });
+
+    expect(summary.description).toBe('Committed 0 files — live in the next session.');
+  });
+});
+
+describe('projectMarketplaceHref', () => {
+  test('builds the customize marketplace deep link for a project', () => {
+    expect(projectMarketplaceHref('proj_123')).toBe('/projects/proj_123/customize/marketplace');
+  });
+
+  test('URL-encodes project ids with special characters', () => {
+    expect(projectMarketplaceHref('proj/weird id')).toBe(
+      '/projects/proj%2Fweird%20id/customize/marketplace',
+    );
+  });
+});
+
+describe('hasCapabilities', () => {
+  test('false for null/undefined', () => {
+    expect(hasCapabilities(null)).toBe(false);
+    expect(hasCapabilities(undefined)).toBe(false);
+  });
+
+  test('false when every list is empty', () => {
+    expect(hasCapabilities({ secrets: [], connectors: [], tools: [], network: [] })).toBe(false);
+  });
+
+  test('true when any list is non-empty', () => {
+    expect(hasCapabilities({ secrets: ['API_KEY'], connectors: [], tools: [], network: [] })).toBe(
+      true,
+    );
+    expect(hasCapabilities({ secrets: [], connectors: ['slack'], tools: [], network: [] })).toBe(
+      true,
+    );
+    expect(hasCapabilities({ secrets: [], connectors: [], tools: ['browser'], network: [] })).toBe(
+      true,
+    );
+  });
+});
+
+describe('capabilityCount', () => {
+  test('0 for null/undefined', () => {
+    expect(capabilityCount(null)).toBe(0);
+    expect(capabilityCount(undefined)).toBe(0);
+  });
+
+  test('sums across all three kinds', () => {
+    expect(
+      capabilityCount({ secrets: ['A', 'B'], connectors: ['c'], tools: ['t1', 't2', 't3'], network: [] }),
+    ).toBe(6);
+  });
+});
+
+describe('isInstallDisabled', () => {
+  test('disabled when no item is resolved', () => {
+    expect(isInstallDisabled({ hasItem: false, targetProjectId: 'p1', pending: false })).toBe(true);
+  });
+
+  test('disabled when no target project is chosen', () => {
+    expect(isInstallDisabled({ hasItem: true, targetProjectId: '', pending: false })).toBe(true);
+  });
+
+  test('disabled while a request is pending', () => {
+    expect(isInstallDisabled({ hasItem: true, targetProjectId: 'p1', pending: true })).toBe(true);
+  });
+
+  test('enabled once an item, project, and idle state all line up', () => {
+    expect(isInstallDisabled({ hasItem: true, targetProjectId: 'p1', pending: false })).toBe(false);
+  });
+});

--- a/apps/web/src/features/marketplace/marketplace-install.ts
+++ b/apps/web/src/features/marketplace/marketplace-install.ts
@@ -1,0 +1,55 @@
+import type { InstallResult, ItemCapabilities } from '@/lib/marketplace-client';
+
+/** Everything the install success toast needs, decoupled from the mutation's
+ *  raw response shape so it's independently testable. */
+export interface InstallSuccessSummary {
+  title: string;
+  description: string;
+}
+
+/** Builds the "what landed" toast copy from the install response — the item
+ *  title plus a plain-English file count, singular/plural handled inline. */
+export function buildInstallSuccessSummary(
+  itemTitle: string,
+  result: Pick<InstallResult, 'file_count'>,
+): InstallSuccessSummary {
+  const { file_count } = result;
+  return {
+    title: `Added ${itemTitle}`,
+    description: `Committed ${file_count} file${file_count === 1 ? '' : 's'} — live in the next session.`,
+  };
+}
+
+/** Deep-link destination for "View in project" — the customize overlay's
+ *  Marketplace section (installed tab lives there), scoped to the project the
+ *  item just landed in. Kept as a plain path builder (no router dependency)
+ *  so it's testable and reusable from both in-app navigation and a toast
+ *  action that has to work from any page, including the public marketplace. */
+export function projectMarketplaceHref(projectId: string): string {
+  return `/projects/${encodeURIComponent(projectId)}/customize/marketplace`;
+}
+
+/** True when an item exposes any secrets/connectors/tools it needs — used to
+ *  decide whether the modal renders the capabilities panel at all. */
+export function hasCapabilities(caps: ItemCapabilities | null | undefined): boolean {
+  return !!caps && caps.secrets.length + caps.connectors.length + caps.tools.length > 0;
+}
+
+/** Total capability count across all three kinds, for the section's count
+ *  badge. */
+export function capabilityCount(caps: ItemCapabilities | null | undefined): number {
+  if (!caps) return 0;
+  return caps.secrets.length + caps.connectors.length + caps.tools.length;
+}
+
+/** Whether the install control should be disabled: no item resolved yet, no
+ *  destination project chosen (picker mode), or a request already in flight —
+ *  the single source of truth so the button and the Enter-to-submit handler
+ *  can't disagree about when a submit is valid. */
+export function isInstallDisabled(params: {
+  hasItem: boolean;
+  targetProjectId: string;
+  pending: boolean;
+}): boolean {
+  return !params.hasItem || !params.targetProjectId || params.pending;
+}

--- a/apps/web/src/features/marketplace/marketplace-installed-panel.tsx
+++ b/apps/web/src/features/marketplace/marketplace-installed-panel.tsx
@@ -215,7 +215,12 @@ export function MarketplaceInstalledPanel({
               <InstalledItemCard
                 item={it}
                 catalogItem={catalogByName.get(it.name)}
-                status={deriveInstalledItemStatus(it.name, statusByName)}
+                // Only assert a status once the updates check has resolved —
+                // before that (loading/failed) the map is empty and every item
+                // would false-claim "Up to date".
+                status={
+                  updates.isSuccess ? deriveInstalledItemStatus(it.name, statusByName) : undefined
+                }
                 busy={busy}
                 onUpdate={() => onUpdate(it)}
                 onRemove={() => onRemove(it)}
@@ -238,7 +243,9 @@ function InstalledItemCard({
 }: {
   item: InstalledItem;
   catalogItem?: MarketplaceItem;
-  status: RegistryItemStatus;
+  /** Absent while the registry-updates check is loading or failed — render no
+   *  freshness claim rather than a false "Up to date". */
+  status: RegistryItemStatus | undefined;
   busy: boolean;
   onUpdate: () => void;
   onRemove: () => void;

--- a/apps/web/src/features/marketplace/marketplace-installed-panel.tsx
+++ b/apps/web/src/features/marketplace/marketplace-installed-panel.tsx
@@ -2,28 +2,47 @@
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { Disclosure, DisclosureContent, DisclosureTrigger } from '@/components/ui/disclosure';
 import { InlineMeta } from '@/components/ui/inline-meta';
+import {
+  InputGroupSearch,
+  InputGroupSearchClear,
+  InputGroupSearchIcon,
+  InputGroupSearchInput,
+} from '@/components/ui/input-group';
+import Loading from '@/components/ui/loading';
 import { Skeleton } from '@/components/ui/skeleton';
 import { errorToast, successToast } from '@/components/ui/toast';
 import { EmptyState } from '@/features/layout/section/empty-state';
+import { ErrorState } from '@/features/layout/section/error-state';
+import {
+  buildCatalogByName,
+  deriveInstalledItemStatus,
+  describeRemoveConsequence,
+  filterInstalledItems,
+} from '@/features/marketplace/installed-client';
 import {
   useInstalledItems,
   useMarketplaceItems,
   useRegistryUpdates,
   useUninstallMarketplaceItem,
+  useUpdateAllMarketplaceItems,
   useUpdateMarketplaceItem,
 } from '@/hooks/marketplace';
-import type { InstalledItem, MarketplaceItem } from '@/lib/marketplace-client';
+import type { InstalledItem, MarketplaceItem, RegistryItemStatus } from '@/lib/marketplace-client';
 import { cn } from '@/lib/utils';
 import { formatRelative } from '@kortix/shared';
-import { TrashSolid } from '@mynaui/icons-react';
+import { Search, TrashSolid } from '@mynaui/icons-react';
 import { ExternalLink, KeyRound, PackageOpen, Plug, RefreshCw, Wrench } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { useState } from 'react';
 import { MarketplaceAvatar } from './marketplace-avatar';
 import { MarketplaceItemAvatar } from './marketplace-item-avatar';
 import { TypeTile, typeMeta } from './marketplace-meta';
+
+// Stable keys for the initial-load skeleton rows (fixed count, never reordered).
+const SKELETON_ROW_IDS = ['s1', 's2', 's3', 's4', 's5', 's6'];
 
 export function MarketplaceInstalledPanel({
   projectId,
@@ -33,17 +52,26 @@ export function MarketplaceInstalledPanel({
   onBrowse: () => void;
 }) {
   const tI18nHardcoded = useTranslations('hardcodedUi');
+  const [query, setQuery] = useState('');
   const installed = useInstalledItems(projectId);
   const updates = useRegistryUpdates(projectId);
   const catalog = useMarketplaceItems({});
   const updateMut = useUpdateMarketplaceItem();
+  const updateAllMut = useUpdateAllMarketplaceItems();
   const uninstallMut = useUninstallMarketplaceItem();
 
   const items = installed.data ?? [];
-  const statusByName = new Map((updates.data?.updates ?? []).map((u) => [u.name, u.status]));
-  const catalogByName = new Map((catalog.data?.items ?? []).map((i) => [i.name, i]));
+  const statusByName = new Map<string, RegistryItemStatus>(
+    (updates.data?.updates ?? []).map((u) => [u.name, u.status]),
+  );
+  const catalogByName = buildCatalogByName(catalog.data?.items ?? []);
   const updateCount = updates.data?.update_available.length ?? 0;
-  const busy = updateMut.isPending || uninstallMut.isPending;
+  const busy = updateMut.isPending || updateAllMut.isPending || uninstallMut.isPending;
+
+  const filteredItems = filterInstalledItems(items, query, (it) => ({
+    catalogTitle: catalogByName.get(it.name)?.title,
+    typeLabel: typeMeta(it.type).label,
+  }));
 
   const onUpdate = async (it: InstalledItem) => {
     try {
@@ -53,6 +81,21 @@ export function MarketplaceInstalledPanel({
       });
     } catch (e) {
       errorToast('Update failed', { description: (e as Error).message });
+    }
+  };
+
+  const onUpdateAll = async () => {
+    try {
+      const res = await updateAllMut.mutateAsync({ projectId });
+      const count = res.updated.length;
+      successToast(count === 1 ? `Updated ${res.updated[0]}` : `Updated ${count} items`, {
+        description:
+          count > 0
+            ? `Re-committed ${res.file_count} file${res.file_count === 1 ? '' : 's'} — live next session.`
+            : 'Nothing needed an update.',
+      });
+    } catch (e) {
+      errorToast('Update all failed', { description: (e as Error).message });
     }
   };
 
@@ -70,10 +113,25 @@ export function MarketplaceInstalledPanel({
   if (installed.isLoading) {
     return (
       <div className="columns-1 gap-2 md:columns-2">
-        {Array.from({ length: 6 }).map((_, i) => (
-          <Skeleton key={i} className="mb-2 h-14 break-inside-avoid rounded-md" />
+        {SKELETON_ROW_IDS.map((id) => (
+          <Skeleton key={id} className="mb-2 h-14 break-inside-avoid rounded-md" />
         ))}
       </div>
+    );
+  }
+
+  if (installed.isError) {
+    return (
+      <ErrorState
+        size="sm"
+        title="Failed to load installed items"
+        description={(installed.error as Error)?.message}
+        action={
+          <Button variant="outline" size="sm" onClick={() => installed.refetch()}>
+            Retry
+          </Button>
+        }
+      />
     );
   }
 
@@ -99,34 +157,73 @@ export function MarketplaceInstalledPanel({
   }
 
   return (
-    <div className="space-y-5">
-      <InlineMeta className="text-sm">
-        <span className="tabular-nums">{items.length} installed</span>
-        {updateCount > 0 && (
-          <span className="text-foreground font-medium tabular-nums">
-            {updateCount} update{updateCount === 1 ? '' : 's'} available
-          </span>
-        )}
-        {updates.isLoading &&
-          tI18nHardcoded.raw(
-            'autoComponentsMarketplaceMarketplaceInstalledPanelJsxTextCheckingForUpdatese5306763',
+    <div className="space-y-4">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <InlineMeta className="text-sm">
+          <span className="tabular-nums">{items.length} installed</span>
+          {updateCount > 0 && (
+            <span className="text-foreground font-medium tabular-nums">
+              {updateCount} update{updateCount === 1 ? '' : 's'} available
+            </span>
           )}
-      </InlineMeta>
-
-      <div className="columns-1 gap-2 md:columns-2">
-        {items.map((it) => (
-          <div key={it.name} className="mb-2 break-inside-avoid">
-            <InstalledItemCard
-              item={it}
-              catalogItem={catalogByName.get(it.name)}
-              status={statusByName.get(it.name)}
-              busy={busy}
-              onUpdate={() => onUpdate(it)}
-              onRemove={() => onRemove(it)}
-            />
-          </div>
-        ))}
+          {updates.isLoading &&
+            tI18nHardcoded.raw(
+              'autoComponentsMarketplaceMarketplaceInstalledPanelJsxTextCheckingForUpdatese5306763',
+            )}
+        </InlineMeta>
+        {updateCount > 1 && (
+          <Button
+            size="sm"
+            variant="secondary"
+            disabled={busy}
+            className="shrink-0 gap-1.5 transition-transform active:scale-[0.96]"
+            onClick={onUpdateAll}
+          >
+            {updateAllMut.isPending ? (
+              <Loading className="size-3.5 shrink-0" />
+            ) : (
+              <RefreshCw className="size-3.5 shrink-0" />
+            )}
+            Update all
+          </Button>
+        )}
       </div>
+
+      {items.length > 5 && (
+        <InputGroupSearch>
+          <InputGroupSearchIcon>
+            <Search />
+          </InputGroupSearchIcon>
+          <InputGroupSearchInput
+            placeholder="Search installed"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            variant="popover"
+          />
+          <InputGroupSearchClear onClick={() => setQuery('')} />
+        </InputGroupSearch>
+      )}
+
+      {filteredItems.length === 0 ? (
+        <p className="text-muted-foreground px-1 py-6 text-center text-xs">
+          No installed items match &ldquo;{query}&rdquo;.
+        </p>
+      ) : (
+        <div className="columns-1 gap-2 md:columns-2">
+          {filteredItems.map((it) => (
+            <div key={it.name} className="mb-2 break-inside-avoid">
+              <InstalledItemCard
+                item={it}
+                catalogItem={catalogByName.get(it.name)}
+                status={deriveInstalledItemStatus(it.name, statusByName)}
+                busy={busy}
+                onUpdate={() => onUpdate(it)}
+                onRemove={() => onRemove(it)}
+              />
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   );
 }
@@ -141,212 +238,234 @@ function InstalledItemCard({
 }: {
   item: InstalledItem;
   catalogItem?: MarketplaceItem;
-  status?: string;
+  status: RegistryItemStatus;
   busy: boolean;
   onUpdate: () => void;
   onRemove: () => void;
 }) {
   const tI18nHardcoded = useTranslations('hardcodedUi');
   const [open, setOpen] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
   const meta = typeMeta(item.type);
   const TypeIcon = meta.Icon;
 
   return (
-    <Disclosure
-      variant="outline"
-      open={open}
-      onOpenChange={setOpen}
-      className="group/card overflow-hidden"
-      transition={{ duration: 0.18, ease: [0.23, 1, 0.32, 1] }}
-    >
-      <DisclosureTrigger variant="outline">
-        <div
-          className={cn(
-            'hover:bg-muted/40 flex w-full cursor-pointer items-center gap-3 px-4 py-3 text-left transition-colors',
-            'focus-visible:bg-muted/40 focus-visible:outline-none',
-          )}
-        >
-          <div className="shrink-0">
-            {catalogItem ? (
-              <MarketplaceItemAvatar item={catalogItem} size="sm" showSource={false} />
-            ) : (
-              <TypeTile type={item.type} size="sm" />
+    <>
+      <Disclosure
+        variant="outline"
+        open={open}
+        onOpenChange={setOpen}
+        className="group/card overflow-hidden"
+        transition={{ duration: 0.18, ease: [0.23, 1, 0.32, 1] }}
+      >
+        <DisclosureTrigger variant="outline">
+          <div
+            className={cn(
+              'hover:bg-muted/40 flex w-full cursor-pointer items-center gap-3 px-4 py-3 text-left transition-colors',
+              'focus-visible:bg-muted/40 focus-visible:outline-none',
             )}
-          </div>
-          <div className="min-w-0 flex-1">
-            <div className="flex items-center gap-2">
-              <span className="text-foreground truncate text-sm font-medium">
-                {catalogItem?.title ?? item.name}
-              </span>
-              {status === 'update-available' && (
-                <Badge variant="update" size="sm">
-                  {tI18nHardcoded.raw(
-                    'autoComponentsMarketplaceMarketplaceInstalledPanelJsxTextUpdateAvailable9830d327',
-                  )}
-                </Badge>
-              )}
-              {status === 'orphaned' && (
-                <Badge variant="muted" size="sm">
-                  {tI18nHardcoded.raw(
-                    'autoComponentsMarketplaceMarketplaceInstalledPanelJsxTextSourceRemoved1896940e',
-                  )}
-                </Badge>
+          >
+            <div className="shrink-0">
+              {catalogItem ? (
+                <MarketplaceItemAvatar item={catalogItem} size="sm" showSource={false} />
+              ) : (
+                <TypeTile type={item.type} size="sm" />
               )}
             </div>
-            <div className="mt-0.5">
-              <InlineMeta>
-                {meta.label}
-                {catalogItem?.marketplaceLabel ?? item.source}
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-2">
+                <span className="text-foreground truncate text-sm font-medium">
+                  {catalogItem?.title ?? item.name}
+                </span>
+                {status === 'update-available' && (
+                  <Badge variant="update" size="sm">
+                    {tI18nHardcoded.raw(
+                      'autoComponentsMarketplaceMarketplaceInstalledPanelJsxTextUpdateAvailable9830d327',
+                    )}
+                  </Badge>
+                )}
+                {status === 'orphaned' && (
+                  <Badge variant="muted" size="sm">
+                    {tI18nHardcoded.raw(
+                      'autoComponentsMarketplaceMarketplaceInstalledPanelJsxTextSourceRemoved1896940e',
+                    )}
+                  </Badge>
+                )}
+                {status === 'up-to-date' && (
+                  <Badge variant="success" size="sm">
+                    Up to date
+                  </Badge>
+                )}
+              </div>
+              <div className="mt-0.5">
+                <InlineMeta>
+                  {meta.label}
+                  {catalogItem?.marketplaceLabel ?? item.source}
+                  <span className="tabular-nums">
+                    {item.file_count} file{item.file_count === 1 ? '' : 's'}
+                  </span>
+                </InlineMeta>
+              </div>
+            </div>
+            <div className="flex shrink-0 items-center gap-1">
+              {status === 'update-available' && (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  disabled={busy}
+                  className="transition-transform active:scale-[0.96]"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onUpdate();
+                  }}
+                >
+                  <RefreshCw className="size-3.5" />
+                  Update
+                </Button>
+              )}
+              <Button
+                size="icon-sm"
+                variant="ghost"
+                disabled={busy}
+                aria-label={`Remove ${item.name}`}
+                className={cn(
+                  'text-muted-foreground/40 hover:text-foreground transition-opacity transition-transform active:scale-[0.96]',
+                  'opacity-0 group-hover/card:opacity-100 focus-visible:opacity-100',
+                )}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setConfirmOpen(true);
+                }}
+              >
+                <TrashSolid className="size-3.5" />
+              </Button>
+            </div>
+          </div>
+        </DisclosureTrigger>
+        <DisclosureContent variant="outline" contentClassName="border-border border-t">
+          <div className="space-y-4 px-4 py-4">
+            {catalogItem?.description ? (
+              <p className="text-muted-foreground text-sm leading-relaxed text-pretty">
+                {catalogItem.description}
+              </p>
+            ) : null}
+
+            <div className="space-y-2">
+              <p className="text-muted-foreground text-xs font-medium">Install</p>
+              <InlineMeta className="text-xs">
+                <span className="inline-flex items-center gap-1">
+                  <TypeIcon className="size-3 shrink-0" />
+                  {meta.label}
+                </span>
+                {item.installed_at ? `added ${formatRelative(item.installed_at) ?? ''}` : null}
+                <span className="font-mono tabular-nums">{item.name}</span>
                 <span className="tabular-nums">
-                  {item.file_count} file{item.file_count === 1 ? '' : 's'}
+                  {item.file_count} file{item.file_count === 1 ? '' : 's'} in repo
                 </span>
               </InlineMeta>
             </div>
-          </div>
-          <div className="flex shrink-0 items-center gap-1">
-            {status === 'update-available' && (
-              <Button
-                size="sm"
-                variant="outline"
-                disabled={busy}
-                className="transition-transform active:scale-[0.96]"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onUpdate();
-                }}
-              >
-                <RefreshCw className="size-3.5" />
-                Update
-              </Button>
+
+            {catalogItem ? (
+              <div className="space-y-2">
+                <p className="text-muted-foreground text-xs font-medium">Source</p>
+                <div className="flex min-w-0 items-center gap-2">
+                  <MarketplaceAvatar
+                    id={catalogItem.marketplaceId}
+                    owner={catalogItem.owner}
+                    sourceUrl={catalogItem.sourceUrl}
+                    label={catalogItem.marketplaceLabel}
+                    size="xs"
+                  />
+                  {catalogItem.sourceUrl ? (
+                    <a
+                      href={catalogItem.sourceUrl}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="text-foreground hover:text-foreground/80 inline-flex min-w-0 items-center gap-1 text-sm transition-colors"
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      <span className="truncate">{catalogItem.marketplaceLabel}</span>
+                      <ExternalLink className="size-3 shrink-0" />
+                    </a>
+                  ) : (
+                    <span className="text-foreground truncate text-sm">
+                      {catalogItem.marketplaceLabel}
+                    </span>
+                  )}
+                </div>
+              </div>
+            ) : (
+              <div className="space-y-2">
+                <p className="text-muted-foreground text-xs font-medium">Source</p>
+                <p className="text-foreground truncate font-mono text-sm">{item.source}</p>
+              </div>
             )}
-            <Button
-              size="icon-sm"
-              variant="ghost"
-              disabled={busy}
-              aria-label={`Remove ${item.name}`}
-              className={cn(
-                'text-muted-foreground/40 hover:text-foreground transition-opacity transition-transform active:scale-[0.96]',
-                'opacity-0 group-hover/card:opacity-100 focus-visible:opacity-100',
-              )}
-              onClick={(e) => {
-                e.stopPropagation();
-                onRemove();
-              }}
-            >
-              <TrashSolid className="size-3.5" />
-            </Button>
+
+            {catalogItem && catalogItem.categories.length > 0 ? (
+              <div className="space-y-2">
+                <p className="text-muted-foreground text-xs font-medium">Categories</p>
+                <div className="flex flex-wrap gap-1">
+                  {catalogItem.categories.map((cat) => (
+                    <Badge key={cat} variant="muted" size="sm">
+                      {cat}
+                    </Badge>
+                  ))}
+                </div>
+              </div>
+            ) : null}
+
+            {catalogItem && hasCapabilities(catalogItem) ? (
+              <div className="space-y-2">
+                <p className="text-muted-foreground text-xs font-medium">Permissions</p>
+                <div className="flex flex-wrap gap-1">
+                  {catalogItem.capabilities.secrets.map((s) => (
+                    <Badge key={s} variant="muted" size="xs" className="font-mono">
+                      <KeyRound />
+                      {s}
+                    </Badge>
+                  ))}
+                  {catalogItem.capabilities.tools.map((tool) => (
+                    <Badge key={tool} variant="muted" size="xs">
+                      <Wrench />
+                      {tool}
+                    </Badge>
+                  ))}
+                  {catalogItem.capabilities.connectors.map((cn) => (
+                    <Badge key={cn} variant="muted" size="xs">
+                      <Plug />
+                      {cn}
+                    </Badge>
+                  ))}
+                </div>
+              </div>
+            ) : null}
+
+            {catalogItem && catalogItem.dependencies.length > 0 ? (
+              <InlineMeta className="text-xs">
+                <span className="tabular-nums">
+                  {catalogItem.dependencies.length} dependenc
+                  {catalogItem.dependencies.length === 1 ? 'y' : 'ies'}
+                </span>
+              </InlineMeta>
+            ) : null}
           </div>
-        </div>
-      </DisclosureTrigger>
-      <DisclosureContent variant="outline" contentClassName="border-border border-t">
-        <div className="space-y-4 px-4 py-4">
-          {catalogItem?.description ? (
-            <p className="text-muted-foreground text-sm leading-relaxed text-pretty">
-              {catalogItem.description}
-            </p>
-          ) : null}
+        </DisclosureContent>
+      </Disclosure>
 
-          <div className="space-y-2">
-            <p className="text-muted-foreground text-xs font-medium">Install</p>
-            <InlineMeta className="text-xs">
-              <span className="inline-flex items-center gap-1">
-                <TypeIcon className="size-3 shrink-0" />
-                {meta.label}
-              </span>
-              {item.installed_at ? `added ${formatRelative(item.installed_at) ?? ''}` : null}
-              <span className="font-mono tabular-nums">{item.name}</span>
-              <span className="tabular-nums">
-                {item.file_count} file{item.file_count === 1 ? '' : 's'} in repo
-              </span>
-            </InlineMeta>
-          </div>
-
-          {catalogItem ? (
-            <div className="space-y-2">
-              <p className="text-muted-foreground text-xs font-medium">Source</p>
-              <div className="flex min-w-0 items-center gap-2">
-                <MarketplaceAvatar
-                  id={catalogItem.marketplaceId}
-                  owner={catalogItem.owner}
-                  sourceUrl={catalogItem.sourceUrl}
-                  label={catalogItem.marketplaceLabel}
-                  size="xs"
-                />
-                {catalogItem.sourceUrl ? (
-                  <a
-                    href={catalogItem.sourceUrl}
-                    target="_blank"
-                    rel="noreferrer"
-                    className="text-foreground hover:text-foreground/80 inline-flex min-w-0 items-center gap-1 text-sm transition-colors"
-                    onClick={(e) => e.stopPropagation()}
-                  >
-                    <span className="truncate">{catalogItem.marketplaceLabel}</span>
-                    <ExternalLink className="size-3 shrink-0" />
-                  </a>
-                ) : (
-                  <span className="text-foreground truncate text-sm">
-                    {catalogItem.marketplaceLabel}
-                  </span>
-                )}
-              </div>
-            </div>
-          ) : (
-            <div className="space-y-2">
-              <p className="text-muted-foreground text-xs font-medium">Source</p>
-              <p className="text-foreground truncate font-mono text-sm">{item.source}</p>
-            </div>
-          )}
-
-          {catalogItem && catalogItem.categories.length > 0 ? (
-            <div className="space-y-2">
-              <p className="text-muted-foreground text-xs font-medium">Categories</p>
-              <div className="flex flex-wrap gap-1">
-                {catalogItem.categories.map((cat) => (
-                  <Badge key={cat} variant="muted" size="sm">
-                    {cat}
-                  </Badge>
-                ))}
-              </div>
-            </div>
-          ) : null}
-
-          {catalogItem && hasCapabilities(catalogItem) ? (
-            <div className="space-y-2">
-              <p className="text-muted-foreground text-xs font-medium">Permissions</p>
-              <div className="flex flex-wrap gap-1">
-                {catalogItem.capabilities.secrets.map((s) => (
-                  <Badge key={s} variant="muted" size="xs" className="font-mono">
-                    <KeyRound />
-                    {s}
-                  </Badge>
-                ))}
-                {catalogItem.capabilities.tools.map((tool) => (
-                  <Badge key={tool} variant="muted" size="xs">
-                    <Wrench />
-                    {tool}
-                  </Badge>
-                ))}
-                {catalogItem.capabilities.connectors.map((cn) => (
-                  <Badge key={cn} variant="muted" size="xs">
-                    <Plug />
-                    {cn}
-                  </Badge>
-                ))}
-              </div>
-            </div>
-          ) : null}
-
-          {catalogItem && catalogItem.dependencies.length > 0 ? (
-            <InlineMeta className="text-xs">
-              <span className="tabular-nums">
-                {catalogItem.dependencies.length} dependenc
-                {catalogItem.dependencies.length === 1 ? 'y' : 'ies'}
-              </span>
-            </InlineMeta>
-          ) : null}
-        </div>
-      </DisclosureContent>
-    </Disclosure>
+      <ConfirmDialog
+        open={confirmOpen}
+        onOpenChange={setConfirmOpen}
+        title={`Remove ${catalogItem?.title ?? item.name}?`}
+        description={describeRemoveConsequence(item, catalogItem?.title)}
+        confirmLabel="Remove"
+        confirmVariant="destructive"
+        isPending={busy}
+        onConfirm={() => {
+          onRemove();
+          setConfirmOpen(false);
+        }}
+      />
+    </>
   );
 }
 

--- a/apps/web/src/features/marketplace/marketplace-installed-panel.tsx
+++ b/apps/web/src/features/marketplace/marketplace-installed-panel.tsx
@@ -2,28 +2,47 @@
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { Disclosure, DisclosureContent, DisclosureTrigger } from '@/components/ui/disclosure';
 import { InlineMeta } from '@/components/ui/inline-meta';
+import {
+  InputGroupSearch,
+  InputGroupSearchClear,
+  InputGroupSearchIcon,
+  InputGroupSearchInput,
+} from '@/components/ui/input-group';
+import Loading from '@/components/ui/loading';
 import { Skeleton } from '@/components/ui/skeleton';
 import { errorToast, successToast } from '@/components/ui/toast';
 import { EmptyState } from '@/features/layout/section/empty-state';
+import { ErrorState } from '@/features/layout/section/error-state';
+import {
+  buildCatalogByName,
+  deriveInstalledItemStatus,
+  describeRemoveConsequence,
+  filterInstalledItems,
+} from '@/features/marketplace/installed-client';
 import {
   useInstalledItems,
   useMarketplaceItems,
   useRegistryUpdates,
   useUninstallMarketplaceItem,
+  useUpdateAllMarketplaceItems,
   useUpdateMarketplaceItem,
 } from '@/hooks/marketplace';
-import type { InstalledItem, MarketplaceItem } from '@/lib/marketplace-client';
+import type { InstalledItem, MarketplaceItem, RegistryItemStatus } from '@/lib/marketplace-client';
 import { cn } from '@/lib/utils';
 import { formatRelative } from '@kortix/shared';
-import { TrashSolid } from '@mynaui/icons-react';
+import { Search, TrashSolid } from '@mynaui/icons-react';
 import { ExternalLink, KeyRound, PackageOpen, Plug, RefreshCw, Wrench } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { useState } from 'react';
 import { MarketplaceAvatar } from './marketplace-avatar';
 import { MarketplaceItemAvatar } from './marketplace-item-avatar';
 import { TypeTile, typeMeta } from './marketplace-meta';
+
+// Stable keys for the initial-load skeleton rows (fixed count, never reordered).
+const SKELETON_ROW_IDS = ['s1', 's2', 's3', 's4', 's5', 's6'];
 
 export function MarketplaceInstalledPanel({
   projectId,
@@ -33,17 +52,26 @@ export function MarketplaceInstalledPanel({
   onBrowse: () => void;
 }) {
   const tI18nHardcoded = useTranslations('hardcodedUi');
+  const [query, setQuery] = useState('');
   const installed = useInstalledItems(projectId);
   const updates = useRegistryUpdates(projectId);
   const catalog = useMarketplaceItems({});
   const updateMut = useUpdateMarketplaceItem();
+  const updateAllMut = useUpdateAllMarketplaceItems();
   const uninstallMut = useUninstallMarketplaceItem();
 
   const items = installed.data ?? [];
-  const statusByName = new Map((updates.data?.updates ?? []).map((u) => [u.name, u.status]));
-  const catalogByName = new Map((catalog.data?.items ?? []).map((i) => [i.name, i]));
+  const statusByName = new Map<string, RegistryItemStatus>(
+    (updates.data?.updates ?? []).map((u) => [u.name, u.status]),
+  );
+  const catalogByName = buildCatalogByName(catalog.data?.items ?? []);
   const updateCount = updates.data?.update_available.length ?? 0;
-  const busy = updateMut.isPending || uninstallMut.isPending;
+  const busy = updateMut.isPending || updateAllMut.isPending || uninstallMut.isPending;
+
+  const filteredItems = filterInstalledItems(items, query, (it) => ({
+    catalogTitle: catalogByName.get(it.name)?.title,
+    typeLabel: typeMeta(it.type).label,
+  }));
 
   const onUpdate = async (it: InstalledItem) => {
     try {
@@ -53,6 +81,21 @@ export function MarketplaceInstalledPanel({
       });
     } catch (e) {
       errorToast('Update failed', { description: (e as Error).message });
+    }
+  };
+
+  const onUpdateAll = async () => {
+    try {
+      const res = await updateAllMut.mutateAsync({ projectId });
+      const count = res.updated.length;
+      successToast(count === 1 ? `Updated ${res.updated[0]}` : `Updated ${count} items`, {
+        description:
+          count > 0
+            ? `Re-committed ${res.file_count} file${res.file_count === 1 ? '' : 's'} — live next session.`
+            : 'Nothing needed an update.',
+      });
+    } catch (e) {
+      errorToast('Update all failed', { description: (e as Error).message });
     }
   };
 
@@ -70,10 +113,25 @@ export function MarketplaceInstalledPanel({
   if (installed.isLoading) {
     return (
       <div className="columns-1 gap-2 md:columns-2">
-        {Array.from({ length: 6 }).map((_, i) => (
-          <Skeleton key={i} className="mb-2 h-14 break-inside-avoid rounded-md" />
+        {SKELETON_ROW_IDS.map((id) => (
+          <Skeleton key={id} className="mb-2 h-14 break-inside-avoid rounded-md" />
         ))}
       </div>
+    );
+  }
+
+  if (installed.isError) {
+    return (
+      <ErrorState
+        size="sm"
+        title="Failed to load installed items"
+        description={(installed.error as Error)?.message}
+        action={
+          <Button variant="outline" size="sm" onClick={() => installed.refetch()}>
+            Retry
+          </Button>
+        }
+      />
     );
   }
 
@@ -99,34 +157,78 @@ export function MarketplaceInstalledPanel({
   }
 
   return (
-    <div className="space-y-5">
-      <InlineMeta className="text-sm">
-        <span className="tabular-nums">{items.length} installed</span>
-        {updateCount > 0 && (
-          <span className="text-foreground font-medium tabular-nums">
-            {updateCount} update{updateCount === 1 ? '' : 's'} available
-          </span>
-        )}
-        {updates.isLoading &&
-          tI18nHardcoded.raw(
-            'autoComponentsMarketplaceMarketplaceInstalledPanelJsxTextCheckingForUpdatese5306763',
+    <div className="space-y-4">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <InlineMeta className="text-sm">
+          <span className="tabular-nums">{items.length} installed</span>
+          {updateCount > 0 && (
+            <span className="text-foreground font-medium tabular-nums">
+              {updateCount} update{updateCount === 1 ? '' : 's'} available
+            </span>
           )}
-      </InlineMeta>
-
-      <div className="columns-1 gap-2 md:columns-2">
-        {items.map((it) => (
-          <div key={it.name} className="mb-2 break-inside-avoid">
-            <InstalledItemCard
-              item={it}
-              catalogItem={catalogByName.get(it.name)}
-              status={statusByName.get(it.name)}
-              busy={busy}
-              onUpdate={() => onUpdate(it)}
-              onRemove={() => onRemove(it)}
-            />
-          </div>
-        ))}
+          {updates.isLoading &&
+            tI18nHardcoded.raw(
+              'autoComponentsMarketplaceMarketplaceInstalledPanelJsxTextCheckingForUpdatese5306763',
+            )}
+        </InlineMeta>
+        {updateCount > 1 && (
+          <Button
+            size="sm"
+            variant="secondary"
+            disabled={busy}
+            className="shrink-0 gap-1.5 transition-transform active:scale-[0.96]"
+            onClick={onUpdateAll}
+          >
+            {updateAllMut.isPending ? (
+              <Loading className="size-3.5 shrink-0" />
+            ) : (
+              <RefreshCw className="size-3.5 shrink-0" />
+            )}
+            Update all
+          </Button>
+        )}
       </div>
+
+      {items.length > 5 && (
+        <InputGroupSearch>
+          <InputGroupSearchIcon>
+            <Search />
+          </InputGroupSearchIcon>
+          <InputGroupSearchInput
+            placeholder="Search installed"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            variant="popover"
+          />
+          <InputGroupSearchClear onClick={() => setQuery('')} />
+        </InputGroupSearch>
+      )}
+
+      {filteredItems.length === 0 ? (
+        <p className="text-muted-foreground px-1 py-6 text-center text-xs">
+          No installed items match &ldquo;{query}&rdquo;.
+        </p>
+      ) : (
+        <div className="columns-1 gap-2 md:columns-2">
+          {filteredItems.map((it) => (
+            <div key={it.name} className="mb-2 break-inside-avoid">
+              <InstalledItemCard
+                item={it}
+                catalogItem={catalogByName.get(it.name)}
+                // Only assert a status once the updates check has resolved —
+                // before that (loading/failed) the map is empty and every item
+                // would false-claim "Up to date".
+                status={
+                  updates.isSuccess ? deriveInstalledItemStatus(it.name, statusByName) : undefined
+                }
+                busy={busy}
+                onUpdate={() => onUpdate(it)}
+                onRemove={() => onRemove(it)}
+              />
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   );
 }
@@ -141,212 +243,236 @@ function InstalledItemCard({
 }: {
   item: InstalledItem;
   catalogItem?: MarketplaceItem;
-  status?: string;
+  /** Absent while the registry-updates check is loading or failed — render no
+   *  freshness claim rather than a false "Up to date". */
+  status: RegistryItemStatus | undefined;
   busy: boolean;
   onUpdate: () => void;
   onRemove: () => void;
 }) {
   const tI18nHardcoded = useTranslations('hardcodedUi');
   const [open, setOpen] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
   const meta = typeMeta(item.type);
   const TypeIcon = meta.Icon;
 
   return (
-    <Disclosure
-      variant="outline"
-      open={open}
-      onOpenChange={setOpen}
-      className="group/card overflow-hidden"
-      transition={{ duration: 0.18, ease: [0.23, 1, 0.32, 1] }}
-    >
-      <DisclosureTrigger variant="outline">
-        <div
-          className={cn(
-            'hover:bg-muted/40 flex w-full cursor-pointer items-center gap-3 px-4 py-3 text-left transition-colors',
-            'focus-visible:bg-muted/40 focus-visible:outline-none',
-          )}
-        >
-          <div className="shrink-0">
-            {catalogItem ? (
-              <MarketplaceItemAvatar item={catalogItem} size="sm" showSource={false} />
-            ) : (
-              <TypeTile type={item.type} size="sm" />
+    <>
+      <Disclosure
+        variant="outline"
+        open={open}
+        onOpenChange={setOpen}
+        className="group/card overflow-hidden"
+        transition={{ duration: 0.18, ease: [0.23, 1, 0.32, 1] }}
+      >
+        <DisclosureTrigger variant="outline">
+          <div
+            className={cn(
+              'hover:bg-muted/40 flex w-full cursor-pointer items-center gap-3 px-4 py-3 text-left transition-colors',
+              'focus-visible:bg-muted/40 focus-visible:outline-none',
             )}
-          </div>
-          <div className="min-w-0 flex-1">
-            <div className="flex items-center gap-2">
-              <span className="text-foreground truncate text-sm font-medium">
-                {catalogItem?.title ?? item.name}
-              </span>
-              {status === 'update-available' && (
-                <Badge variant="update" size="sm">
-                  {tI18nHardcoded.raw(
-                    'autoComponentsMarketplaceMarketplaceInstalledPanelJsxTextUpdateAvailable9830d327',
-                  )}
-                </Badge>
-              )}
-              {status === 'orphaned' && (
-                <Badge variant="muted" size="sm">
-                  {tI18nHardcoded.raw(
-                    'autoComponentsMarketplaceMarketplaceInstalledPanelJsxTextSourceRemoved1896940e',
-                  )}
-                </Badge>
+          >
+            <div className="shrink-0">
+              {catalogItem ? (
+                <MarketplaceItemAvatar item={catalogItem} size="sm" showSource={false} />
+              ) : (
+                <TypeTile type={item.type} size="sm" />
               )}
             </div>
-            <div className="mt-0.5">
-              <InlineMeta>
-                {meta.label}
-                {catalogItem?.marketplaceLabel ?? item.source}
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-2">
+                <span className="text-foreground truncate text-sm font-medium">
+                  {catalogItem?.title ?? item.name}
+                </span>
+                {status === 'update-available' && (
+                  <Badge variant="update" size="sm">
+                    {tI18nHardcoded.raw(
+                      'autoComponentsMarketplaceMarketplaceInstalledPanelJsxTextUpdateAvailable9830d327',
+                    )}
+                  </Badge>
+                )}
+                {status === 'orphaned' && (
+                  <Badge variant="muted" size="sm">
+                    {tI18nHardcoded.raw(
+                      'autoComponentsMarketplaceMarketplaceInstalledPanelJsxTextSourceRemoved1896940e',
+                    )}
+                  </Badge>
+                )}
+                {status === 'up-to-date' && (
+                  <Badge variant="success" size="sm">
+                    Up to date
+                  </Badge>
+                )}
+              </div>
+              <div className="mt-0.5">
+                <InlineMeta>
+                  {meta.label}
+                  {catalogItem?.marketplaceLabel ?? item.source}
+                  <span className="tabular-nums">
+                    {item.file_count} file{item.file_count === 1 ? '' : 's'}
+                  </span>
+                </InlineMeta>
+              </div>
+            </div>
+            <div className="flex shrink-0 items-center gap-1">
+              {status === 'update-available' && (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  disabled={busy}
+                  className="transition-transform active:scale-[0.96]"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onUpdate();
+                  }}
+                >
+                  <RefreshCw className="size-3.5" />
+                  Update
+                </Button>
+              )}
+              <Button
+                size="icon-sm"
+                variant="ghost"
+                disabled={busy}
+                aria-label={`Remove ${item.name}`}
+                className={cn(
+                  'text-muted-foreground/40 hover:text-foreground transition-opacity transition-transform active:scale-[0.96]',
+                  'opacity-0 group-hover/card:opacity-100 focus-visible:opacity-100',
+                )}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setConfirmOpen(true);
+                }}
+              >
+                <TrashSolid className="size-3.5" />
+              </Button>
+            </div>
+          </div>
+        </DisclosureTrigger>
+        <DisclosureContent variant="outline" contentClassName="border-border border-t">
+          <div className="space-y-4 px-4 py-4">
+            {catalogItem?.description ? (
+              <p className="text-muted-foreground text-sm leading-relaxed text-pretty">
+                {catalogItem.description}
+              </p>
+            ) : null}
+
+            <div className="space-y-2">
+              <p className="text-muted-foreground text-xs font-medium">Install</p>
+              <InlineMeta className="text-xs">
+                <span className="inline-flex items-center gap-1">
+                  <TypeIcon className="size-3 shrink-0" />
+                  {meta.label}
+                </span>
+                {item.installed_at ? `added ${formatRelative(item.installed_at) ?? ''}` : null}
+                <span className="font-mono tabular-nums">{item.name}</span>
                 <span className="tabular-nums">
-                  {item.file_count} file{item.file_count === 1 ? '' : 's'}
+                  {item.file_count} file{item.file_count === 1 ? '' : 's'} in repo
                 </span>
               </InlineMeta>
             </div>
-          </div>
-          <div className="flex shrink-0 items-center gap-1">
-            {status === 'update-available' && (
-              <Button
-                size="sm"
-                variant="outline"
-                disabled={busy}
-                className="transition-transform active:scale-[0.96]"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onUpdate();
-                }}
-              >
-                <RefreshCw className="size-3.5" />
-                Update
-              </Button>
+
+            {catalogItem ? (
+              <div className="space-y-2">
+                <p className="text-muted-foreground text-xs font-medium">Source</p>
+                <div className="flex min-w-0 items-center gap-2">
+                  <MarketplaceAvatar
+                    id={catalogItem.marketplaceId}
+                    owner={catalogItem.owner}
+                    sourceUrl={catalogItem.sourceUrl}
+                    label={catalogItem.marketplaceLabel}
+                    size="xs"
+                  />
+                  {catalogItem.sourceUrl ? (
+                    <a
+                      href={catalogItem.sourceUrl}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="text-foreground hover:text-foreground/80 inline-flex min-w-0 items-center gap-1 text-sm transition-colors"
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      <span className="truncate">{catalogItem.marketplaceLabel}</span>
+                      <ExternalLink className="size-3 shrink-0" />
+                    </a>
+                  ) : (
+                    <span className="text-foreground truncate text-sm">
+                      {catalogItem.marketplaceLabel}
+                    </span>
+                  )}
+                </div>
+              </div>
+            ) : (
+              <div className="space-y-2">
+                <p className="text-muted-foreground text-xs font-medium">Source</p>
+                <p className="text-foreground truncate font-mono text-sm">{item.source}</p>
+              </div>
             )}
-            <Button
-              size="icon-sm"
-              variant="ghost"
-              disabled={busy}
-              aria-label={`Remove ${item.name}`}
-              className={cn(
-                'text-muted-foreground/40 hover:text-foreground transition-opacity transition-transform active:scale-[0.96]',
-                'opacity-0 group-hover/card:opacity-100 focus-visible:opacity-100',
-              )}
-              onClick={(e) => {
-                e.stopPropagation();
-                onRemove();
-              }}
-            >
-              <TrashSolid className="size-3.5" />
-            </Button>
+
+            {catalogItem && catalogItem.categories.length > 0 ? (
+              <div className="space-y-2">
+                <p className="text-muted-foreground text-xs font-medium">Categories</p>
+                <div className="flex flex-wrap gap-1">
+                  {catalogItem.categories.map((cat) => (
+                    <Badge key={cat} variant="muted" size="sm">
+                      {cat}
+                    </Badge>
+                  ))}
+                </div>
+              </div>
+            ) : null}
+
+            {catalogItem && hasCapabilities(catalogItem) ? (
+              <div className="space-y-2">
+                <p className="text-muted-foreground text-xs font-medium">Permissions</p>
+                <div className="flex flex-wrap gap-1">
+                  {catalogItem.capabilities.secrets.map((s) => (
+                    <Badge key={s} variant="muted" size="xs" className="font-mono">
+                      <KeyRound />
+                      {s}
+                    </Badge>
+                  ))}
+                  {catalogItem.capabilities.tools.map((tool) => (
+                    <Badge key={tool} variant="muted" size="xs">
+                      <Wrench />
+                      {tool}
+                    </Badge>
+                  ))}
+                  {catalogItem.capabilities.connectors.map((cn) => (
+                    <Badge key={cn} variant="muted" size="xs">
+                      <Plug />
+                      {cn}
+                    </Badge>
+                  ))}
+                </div>
+              </div>
+            ) : null}
+
+            {catalogItem && catalogItem.dependencies.length > 0 ? (
+              <InlineMeta className="text-xs">
+                <span className="tabular-nums">
+                  {catalogItem.dependencies.length} dependenc
+                  {catalogItem.dependencies.length === 1 ? 'y' : 'ies'}
+                </span>
+              </InlineMeta>
+            ) : null}
           </div>
-        </div>
-      </DisclosureTrigger>
-      <DisclosureContent variant="outline" contentClassName="border-border border-t">
-        <div className="space-y-4 px-4 py-4">
-          {catalogItem?.description ? (
-            <p className="text-muted-foreground text-sm leading-relaxed text-pretty">
-              {catalogItem.description}
-            </p>
-          ) : null}
+        </DisclosureContent>
+      </Disclosure>
 
-          <div className="space-y-2">
-            <p className="text-muted-foreground text-xs font-medium">Install</p>
-            <InlineMeta className="text-xs">
-              <span className="inline-flex items-center gap-1">
-                <TypeIcon className="size-3 shrink-0" />
-                {meta.label}
-              </span>
-              {item.installed_at ? `added ${formatRelative(item.installed_at) ?? ''}` : null}
-              <span className="font-mono tabular-nums">{item.name}</span>
-              <span className="tabular-nums">
-                {item.file_count} file{item.file_count === 1 ? '' : 's'} in repo
-              </span>
-            </InlineMeta>
-          </div>
-
-          {catalogItem ? (
-            <div className="space-y-2">
-              <p className="text-muted-foreground text-xs font-medium">Source</p>
-              <div className="flex min-w-0 items-center gap-2">
-                <MarketplaceAvatar
-                  id={catalogItem.marketplaceId}
-                  owner={catalogItem.owner}
-                  sourceUrl={catalogItem.sourceUrl}
-                  label={catalogItem.marketplaceLabel}
-                  size="xs"
-                />
-                {catalogItem.sourceUrl ? (
-                  <a
-                    href={catalogItem.sourceUrl}
-                    target="_blank"
-                    rel="noreferrer"
-                    className="text-foreground hover:text-foreground/80 inline-flex min-w-0 items-center gap-1 text-sm transition-colors"
-                    onClick={(e) => e.stopPropagation()}
-                  >
-                    <span className="truncate">{catalogItem.marketplaceLabel}</span>
-                    <ExternalLink className="size-3 shrink-0" />
-                  </a>
-                ) : (
-                  <span className="text-foreground truncate text-sm">
-                    {catalogItem.marketplaceLabel}
-                  </span>
-                )}
-              </div>
-            </div>
-          ) : (
-            <div className="space-y-2">
-              <p className="text-muted-foreground text-xs font-medium">Source</p>
-              <p className="text-foreground truncate font-mono text-sm">{item.source}</p>
-            </div>
-          )}
-
-          {catalogItem && catalogItem.categories.length > 0 ? (
-            <div className="space-y-2">
-              <p className="text-muted-foreground text-xs font-medium">Categories</p>
-              <div className="flex flex-wrap gap-1">
-                {catalogItem.categories.map((cat) => (
-                  <Badge key={cat} variant="muted" size="sm">
-                    {cat}
-                  </Badge>
-                ))}
-              </div>
-            </div>
-          ) : null}
-
-          {catalogItem && hasCapabilities(catalogItem) ? (
-            <div className="space-y-2">
-              <p className="text-muted-foreground text-xs font-medium">Permissions</p>
-              <div className="flex flex-wrap gap-1">
-                {catalogItem.capabilities.secrets.map((s) => (
-                  <Badge key={s} variant="muted" size="xs" className="font-mono">
-                    <KeyRound />
-                    {s}
-                  </Badge>
-                ))}
-                {catalogItem.capabilities.tools.map((tool) => (
-                  <Badge key={tool} variant="muted" size="xs">
-                    <Wrench />
-                    {tool}
-                  </Badge>
-                ))}
-                {catalogItem.capabilities.connectors.map((cn) => (
-                  <Badge key={cn} variant="muted" size="xs">
-                    <Plug />
-                    {cn}
-                  </Badge>
-                ))}
-              </div>
-            </div>
-          ) : null}
-
-          {catalogItem && catalogItem.dependencies.length > 0 ? (
-            <InlineMeta className="text-xs">
-              <span className="tabular-nums">
-                {catalogItem.dependencies.length} dependenc
-                {catalogItem.dependencies.length === 1 ? 'y' : 'ies'}
-              </span>
-            </InlineMeta>
-          ) : null}
-        </div>
-      </DisclosureContent>
-    </Disclosure>
+      <ConfirmDialog
+        open={confirmOpen}
+        onOpenChange={setConfirmOpen}
+        title={`Remove ${catalogItem?.title ?? item.name}?`}
+        description={describeRemoveConsequence(item, catalogItem?.title)}
+        confirmLabel="Remove"
+        confirmVariant="destructive"
+        isPending={busy}
+        onConfirm={() => {
+          onRemove();
+          setConfirmOpen(false);
+        }}
+      />
+    </>
   );
 }
 

--- a/apps/web/src/features/marketplace/marketplace-item-avatar.tsx
+++ b/apps/web/src/features/marketplace/marketplace-item-avatar.tsx
@@ -72,7 +72,8 @@ export type MarketplaceItemAvatarItem = Pick<
 >;
 
 /**
- * Identity tile for a single marketplace ITEM (a skill). Picks a deterministic
+ * Identity tile for a single marketplace ITEM (skill, agent, command, or
+ * bundle). Picks a deterministic
  * icon from the item's name and pins the source avatar as a corner badge for
  * provenance. All deterministic — no flash, no layout shift.
  */

--- a/apps/web/src/features/marketplace/marketplace-item-card.tsx
+++ b/apps/web/src/features/marketplace/marketplace-item-card.tsx
@@ -61,13 +61,13 @@ export function MarketplaceItemCard({
         <div className="text-muted-foreground/70 mt-1.5 flex items-center gap-1.5 text-xs">
           <span>{label}</span>
           <span aria-hidden>·</span>
-          <span>
+          <span className="tabular-nums">
             {count} {unit}
           </span>
           {secretCount > 0 && (
             <>
               <span aria-hidden>·</span>
-              <span className="inline-flex items-center gap-0.5">
+              <span className="inline-flex items-center gap-0.5 tabular-nums">
                 <KeyRound className="size-3" />
                 {secretCount}
               </span>

--- a/apps/web/src/features/marketplace/marketplace-item-card.tsx
+++ b/apps/web/src/features/marketplace/marketplace-item-card.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import type { MarketplaceItem } from '@/lib/marketplace-client';
 import { MarketplaceItemAvatar } from './marketplace-item-avatar';
+import { emptyDescriptionCopy, itemCountLabel } from './marketplace-item-view';
 import { typeMeta } from './marketplace-meta';
 
 export function MarketplaceItemCard({
@@ -24,8 +25,7 @@ export function MarketplaceItemCard({
 }) {
   const { label } = typeMeta(item.type);
   const secretCount = item.capabilities?.secrets?.length ?? 0;
-  const count = item.type === 'registry:bundle' ? item.dependencies.length : item.fileCount;
-  const countLabel = item.type === 'registry:bundle' ? 'items' : 'files';
+  const { count, unit } = itemCountLabel(item);
 
   return (
     <div
@@ -45,7 +45,9 @@ export function MarketplaceItemCard({
       <MarketplaceItemAvatar item={item} size="md" showSource={showSource} />
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-2">
-          <span className="text-foreground truncate text-sm font-medium">{item.title}</span>
+          <span className="text-foreground truncate text-sm font-medium" title={item.title}>
+            {item.title}
+          </span>
           {installed && (
             <Badge variant="new" size="sm" className="shrink-0 gap-0.5">
               <Check className="size-3" />
@@ -53,19 +55,19 @@ export function MarketplaceItemCard({
             </Badge>
           )}
         </div>
-        {item.description && (
-          <p className="text-muted-foreground mt-0.5 line-clamp-2 text-xs leading-relaxed">{item.description}</p>
-        )}
+        <p className="text-muted-foreground mt-0.5 line-clamp-2 text-xs leading-relaxed text-pretty">
+          {item.description || emptyDescriptionCopy(item.type)}
+        </p>
         <div className="text-muted-foreground/70 mt-1.5 flex items-center gap-1.5 text-xs">
           <span>{label}</span>
           <span aria-hidden>·</span>
-          <span>
-            {count} {countLabel}
+          <span className="tabular-nums">
+            {count} {unit}
           </span>
           {secretCount > 0 && (
             <>
               <span aria-hidden>·</span>
-              <span className="inline-flex items-center gap-0.5">
+              <span className="inline-flex items-center gap-0.5 tabular-nums">
                 <KeyRound className="size-3" />
                 {secretCount}
               </span>
@@ -88,7 +90,7 @@ export function MarketplaceItemCard({
             e.stopPropagation();
             onAdd(item);
           }}
-          aria-label="Add"
+          aria-label={`Add ${item.title}`}
         >
           <Plus className="size-4" />
         </Button>

--- a/apps/web/src/features/marketplace/marketplace-item-card.tsx
+++ b/apps/web/src/features/marketplace/marketplace-item-card.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import type { MarketplaceItem } from '@/lib/marketplace-client';
 import { MarketplaceItemAvatar } from './marketplace-item-avatar';
+import { emptyDescriptionCopy, itemCountLabel } from './marketplace-item-view';
 import { typeMeta } from './marketplace-meta';
 
 export function MarketplaceItemCard({
@@ -24,8 +25,7 @@ export function MarketplaceItemCard({
 }) {
   const { label } = typeMeta(item.type);
   const secretCount = item.capabilities?.secrets?.length ?? 0;
-  const count = item.type === 'registry:bundle' ? item.dependencies.length : item.fileCount;
-  const countLabel = item.type === 'registry:bundle' ? 'items' : 'files';
+  const { count, unit } = itemCountLabel(item);
 
   return (
     <div
@@ -45,7 +45,9 @@ export function MarketplaceItemCard({
       <MarketplaceItemAvatar item={item} size="md" showSource={showSource} />
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-2">
-          <span className="text-foreground truncate text-sm font-medium">{item.title}</span>
+          <span className="text-foreground truncate text-sm font-medium" title={item.title}>
+            {item.title}
+          </span>
           {installed && (
             <Badge variant="new" size="sm" className="shrink-0 gap-0.5">
               <Check className="size-3" />
@@ -53,14 +55,14 @@ export function MarketplaceItemCard({
             </Badge>
           )}
         </div>
-        {item.description && (
-          <p className="text-muted-foreground mt-0.5 line-clamp-2 text-xs leading-relaxed">{item.description}</p>
-        )}
+        <p className="text-muted-foreground mt-0.5 line-clamp-2 text-xs leading-relaxed text-pretty">
+          {item.description || emptyDescriptionCopy(item.type)}
+        </p>
         <div className="text-muted-foreground/70 mt-1.5 flex items-center gap-1.5 text-xs">
           <span>{label}</span>
           <span aria-hidden>·</span>
           <span>
-            {count} {countLabel}
+            {count} {unit}
           </span>
           {secretCount > 0 && (
             <>
@@ -88,7 +90,7 @@ export function MarketplaceItemCard({
             e.stopPropagation();
             onAdd(item);
           }}
-          aria-label="Add"
+          aria-label={`Add ${item.title}`}
         >
           <Plus className="size-4" />
         </Button>

--- a/apps/web/src/features/marketplace/marketplace-item-detail.tsx
+++ b/apps/web/src/features/marketplace/marketplace-item-detail.tsx
@@ -181,7 +181,9 @@ export function MarketplaceItemDetail({
 
               {isBundle && bundleMembers.length > 0 && (
                 <section>
-                  <SectionLabel>What&rsquo;s inside {bundleMembers.length}</SectionLabel>
+                  <SectionLabel>
+                    What&rsquo;s inside <span className="tabular-nums">{bundleMembers.length}</span>
+                  </SectionLabel>
                   <ul className="space-y-2">
                     {bundleMembers.map((member) => (
                       <li key={member.key}>
@@ -217,7 +219,9 @@ export function MarketplaceItemDetail({
 
               {capCount > 0 && (
                 <section>
-                  <SectionLabel>Requires {capCount}</SectionLabel>
+                  <SectionLabel>
+                    Requires <span className="tabular-nums">{capCount}</span>
+                  </SectionLabel>
                   <div className="space-y-3">
                     {capGroups.map((group) => (
                       <div key={group.kind}>
@@ -242,7 +246,9 @@ export function MarketplaceItemDetail({
 
               {data.files.length > 0 && (
                 <section>
-                  <SectionLabel>Files {data.files.length}</SectionLabel>
+                  <SectionLabel>
+                    Files <span className="tabular-nums">{data.files.length}</span>
+                  </SectionLabel>
                   <div className="bg-popover max-h-72 overflow-y-auto rounded-md border">
                     <ul className="divide-border divide-y">
                       {data.files.map((file) => (

--- a/apps/web/src/features/marketplace/marketplace-item-detail.tsx
+++ b/apps/web/src/features/marketplace/marketplace-item-detail.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { ExternalLink, FileText, KeyRound, Plug, Wrench } from 'lucide-react';
-import { useTranslations } from 'next-intl';
+import { ExternalLink, FileText } from 'lucide-react';
 
 import { UnifiedMarkdown } from '@/components/markdown';
+import { Badge } from '@/components/ui/badge';
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -23,7 +23,14 @@ import { TrashSolid } from '@mynaui/icons-react';
 import { Icon } from '../icon/icon';
 import { MarketplaceAvatar } from './marketplace-avatar';
 import { MarketplaceItemAvatar } from './marketplace-item-avatar';
-import { typeMeta } from './marketplace-meta';
+import { TypeTile, typeMeta } from './marketplace-meta';
+import {
+  emptyDescriptionCopy,
+  emptyReadmeCopy,
+  groupCapabilities,
+  resolveBundleMembers,
+  totalCapabilityCount,
+} from './marketplace-item-view';
 
 function SectionLabel({ children }: { children: React.ReactNode }) {
   return <div className="text-muted-foreground/60 mb-3 text-xs font-medium">{children}</div>;
@@ -40,26 +47,6 @@ function stripFrontmatter(md: string): string {
   return md;
 }
 
-function CapabilityCard({
-  icon: IconComponent,
-  title,
-  subtitle,
-}: {
-  icon: React.ComponentType<{ className?: string }>;
-  title: string;
-  subtitle: string;
-}) {
-  return (
-    <div className="bg-muted/40 flex items-start gap-3 rounded-lg px-4 py-3">
-      <IconComponent className="text-muted-foreground mt-0.5 size-4 shrink-0" />
-      <div className="min-w-0">
-        <div className="text-foreground truncate text-sm font-medium">{title}</div>
-        <div className="text-muted-foreground text-xs">{subtitle}</div>
-      </div>
-    </div>
-  );
-}
-
 export function MarketplaceItemDetail({
   onBack,
   onAdd,
@@ -73,20 +60,23 @@ export function MarketplaceItemDetail({
   addLabel?: string;
   installedNames?: Set<string>;
 }) {
-  const tI18nHardcoded = useTranslations('hardcodedUi');
   const openId = useMarketplaceDetailStore((s) => s.openId);
+  const openItem = useMarketplaceDetailStore((s) => s.openItem);
   const { data, isLoading } = useMarketplaceItem(openId);
   const tm = data ? typeMeta(data.type) : null;
-  const caps = data?.capabilities;
-  const capItems = caps
-    ? [
-        ...caps.secrets.map((s) => ({ kind: 'secret' as const, id: s })),
-        ...caps.connectors.map((c) => ({ kind: 'connector' as const, id: c })),
-        ...caps.tools.map((t) => ({ kind: 'tool' as const, id: t })),
-      ]
-    : [];
+  const capGroups = groupCapabilities(data?.capabilities);
+  const capCount = totalCapabilityCount(data?.capabilities);
   const readme = data?.readme ? stripFrontmatter(data.readme) : '';
   const isInstalled = !!(data && installedNames?.has(data.name));
+  const isBundle = data?.type === 'registry:bundle';
+  const bundleMembers =
+    data && isBundle
+      ? resolveBundleMembers({
+          dependencies: data.dependencies,
+          dependencyItems: data.dependencyItems,
+          hrefForId: (id) => id,
+        })
+      : [];
 
   const actions = !data ? null : isInstalled ? (
     <ButtonGroup>
@@ -155,11 +145,9 @@ export function MarketplaceItemDetail({
                   {actions}
                 </div>
 
-                {data.description && (
-                  <p className="text-muted-foreground max-w-prose text-sm leading-relaxed">
-                    {data.description}
-                  </p>
-                )}
+                <p className="text-muted-foreground max-w-prose text-sm leading-relaxed text-pretty">
+                  {data.description || emptyDescriptionCopy(data.type)}
+                </p>
 
                 <div className="text-muted-foreground flex flex-wrap items-center gap-x-4 gap-y-2 text-xs">
                   <span className="inline-flex min-w-0 items-center gap-1.5">
@@ -191,40 +179,88 @@ export function MarketplaceItemDetail({
                 </div>
               </header>
 
-              {capItems.length > 0 && (
+              {isBundle && bundleMembers.length > 0 && (
                 <section>
-                  <SectionLabel>Permissions {capItems.length}</SectionLabel>
-                  <div className="space-y-2">
-                    {capItems.map((item) => {
-                      if (item.kind === 'secret') {
-                        return (
-                          <CapabilityCard
-                            key={`secret:${item.id}`}
-                            icon={KeyRound}
-                            title={item.id}
-                            subtitle="Secret"
-                          />
-                        );
-                      }
-                      if (item.kind === 'connector') {
-                        return (
-                          <CapabilityCard
-                            key={`connector:${item.id}`}
-                            icon={Plug}
-                            title={item.id}
-                            subtitle="Connector"
-                          />
-                        );
-                      }
-                      return (
-                        <CapabilityCard
-                          key={`tool:${item.id}`}
-                          icon={Wrench}
-                          title={item.id}
-                          subtitle="Tool"
-                        />
-                      );
-                    })}
+                  <SectionLabel>
+                    What&rsquo;s inside <span className="tabular-nums">{bundleMembers.length}</span>
+                  </SectionLabel>
+                  <ul className="space-y-2">
+                    {bundleMembers.map((member) => (
+                      <li key={member.key}>
+                        <button
+                          type="button"
+                          disabled={!member.href}
+                          onClick={() => member.href && openItem(member.href)}
+                          className="group bg-popover hover:bg-muted/70 disabled:hover:bg-popover flex w-full items-center gap-3 rounded-md border px-3 py-2 text-left transition-colors disabled:cursor-default"
+                        >
+                          {member.type ? (
+                            <TypeTile type={member.type} size="sm" />
+                          ) : (
+                            <span className="bg-foreground/5 text-muted-foreground flex size-8 shrink-0 items-center justify-center rounded-lg">
+                              <FileText className="size-4" />
+                            </span>
+                          )}
+                          <span className="min-w-0 flex-1">
+                            <span className="text-foreground block truncate text-sm font-medium">
+                              {member.title}
+                            </span>
+                            {member.type && (
+                              <span className="text-muted-foreground block text-xs">
+                                {typeMeta(member.type).label}
+                              </span>
+                            )}
+                          </span>
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                </section>
+              )}
+
+              {capCount > 0 && (
+                <section>
+                  <SectionLabel>
+                    Requires <span className="tabular-nums">{capCount}</span>
+                  </SectionLabel>
+                  <div className="space-y-3">
+                    {capGroups.map((group) => (
+                      <div key={group.kind}>
+                        <div className="text-muted-foreground mb-1.5 text-xs">{group.label}</div>
+                        <div className="flex flex-wrap gap-1.5">
+                          {group.items.map((value) => (
+                            <Badge
+                              key={`${group.kind}:${value}`}
+                              variant="outline"
+                              size="sm"
+                              className="font-mono"
+                            >
+                              {value}
+                            </Badge>
+                          ))}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </section>
+              )}
+
+              {data.files.length > 0 && (
+                <section>
+                  <SectionLabel>
+                    Files <span className="tabular-nums">{data.files.length}</span>
+                  </SectionLabel>
+                  <div className="bg-popover max-h-72 overflow-y-auto rounded-md border">
+                    <ul className="divide-border divide-y">
+                      {data.files.map((file) => (
+                        <li
+                          key={file.target}
+                          className="text-foreground/90 truncate px-4 py-2 font-mono text-xs"
+                          title={file.target}
+                        >
+                          {file.target}
+                        </li>
+                      ))}
+                    </ul>
                   </div>
                 </section>
               )}
@@ -237,12 +273,8 @@ export function MarketplaceItemDetail({
                 ) : (
                   <EmptyState
                     icon={FileText}
-                    title={tI18nHardcoded.raw(
-                      'autoComponentsMarketplaceMarketplaceItemDetailJsxAttrTitleNoREADME4966916b',
-                    )}
-                    description={tI18nHardcoded.raw(
-                      'autoComponentsMarketplaceMarketplaceItemDetailJsxAttrDescriptionThisSkill2316ce31',
-                    )}
+                    title="No README"
+                    description={emptyReadmeCopy(data.type)}
                   />
                 )}
               </section>

--- a/apps/web/src/features/marketplace/marketplace-item-detail.tsx
+++ b/apps/web/src/features/marketplace/marketplace-item-detail.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { ExternalLink, FileText, KeyRound, Plug, Wrench } from 'lucide-react';
-import { useTranslations } from 'next-intl';
+import { ExternalLink, FileText } from 'lucide-react';
 
 import { UnifiedMarkdown } from '@/components/markdown';
+import { Badge } from '@/components/ui/badge';
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -23,7 +23,14 @@ import { TrashSolid } from '@mynaui/icons-react';
 import { Icon } from '../icon/icon';
 import { MarketplaceAvatar } from './marketplace-avatar';
 import { MarketplaceItemAvatar } from './marketplace-item-avatar';
-import { typeMeta } from './marketplace-meta';
+import { TypeTile, typeMeta } from './marketplace-meta';
+import {
+  emptyDescriptionCopy,
+  emptyReadmeCopy,
+  groupCapabilities,
+  resolveBundleMembers,
+  totalCapabilityCount,
+} from './marketplace-item-view';
 
 function SectionLabel({ children }: { children: React.ReactNode }) {
   return <div className="text-muted-foreground/60 mb-3 text-xs font-medium">{children}</div>;
@@ -40,26 +47,6 @@ function stripFrontmatter(md: string): string {
   return md;
 }
 
-function CapabilityCard({
-  icon: IconComponent,
-  title,
-  subtitle,
-}: {
-  icon: React.ComponentType<{ className?: string }>;
-  title: string;
-  subtitle: string;
-}) {
-  return (
-    <div className="bg-muted/40 flex items-start gap-3 rounded-lg px-4 py-3">
-      <IconComponent className="text-muted-foreground mt-0.5 size-4 shrink-0" />
-      <div className="min-w-0">
-        <div className="text-foreground truncate text-sm font-medium">{title}</div>
-        <div className="text-muted-foreground text-xs">{subtitle}</div>
-      </div>
-    </div>
-  );
-}
-
 export function MarketplaceItemDetail({
   onBack,
   onAdd,
@@ -73,20 +60,23 @@ export function MarketplaceItemDetail({
   addLabel?: string;
   installedNames?: Set<string>;
 }) {
-  const tI18nHardcoded = useTranslations('hardcodedUi');
   const openId = useMarketplaceDetailStore((s) => s.openId);
+  const openItem = useMarketplaceDetailStore((s) => s.openItem);
   const { data, isLoading } = useMarketplaceItem(openId);
   const tm = data ? typeMeta(data.type) : null;
-  const caps = data?.capabilities;
-  const capItems = caps
-    ? [
-        ...caps.secrets.map((s) => ({ kind: 'secret' as const, id: s })),
-        ...caps.connectors.map((c) => ({ kind: 'connector' as const, id: c })),
-        ...caps.tools.map((t) => ({ kind: 'tool' as const, id: t })),
-      ]
-    : [];
+  const capGroups = groupCapabilities(data?.capabilities);
+  const capCount = totalCapabilityCount(data?.capabilities);
   const readme = data?.readme ? stripFrontmatter(data.readme) : '';
   const isInstalled = !!(data && installedNames?.has(data.name));
+  const isBundle = data?.type === 'registry:bundle';
+  const bundleMembers =
+    data && isBundle
+      ? resolveBundleMembers({
+          dependencies: data.dependencies,
+          dependencyItems: data.dependencyItems,
+          hrefForId: (id) => id,
+        })
+      : [];
 
   const actions = !data ? null : isInstalled ? (
     <ButtonGroup>
@@ -155,11 +145,9 @@ export function MarketplaceItemDetail({
                   {actions}
                 </div>
 
-                {data.description && (
-                  <p className="text-muted-foreground max-w-prose text-sm leading-relaxed">
-                    {data.description}
-                  </p>
-                )}
+                <p className="text-muted-foreground max-w-prose text-sm leading-relaxed text-pretty">
+                  {data.description || emptyDescriptionCopy(data.type)}
+                </p>
 
                 <div className="text-muted-foreground flex flex-wrap items-center gap-x-4 gap-y-2 text-xs">
                   <span className="inline-flex min-w-0 items-center gap-1.5">
@@ -191,40 +179,82 @@ export function MarketplaceItemDetail({
                 </div>
               </header>
 
-              {capItems.length > 0 && (
+              {isBundle && bundleMembers.length > 0 && (
                 <section>
-                  <SectionLabel>Permissions {capItems.length}</SectionLabel>
-                  <div className="space-y-2">
-                    {capItems.map((item) => {
-                      if (item.kind === 'secret') {
-                        return (
-                          <CapabilityCard
-                            key={`secret:${item.id}`}
-                            icon={KeyRound}
-                            title={item.id}
-                            subtitle="Secret"
-                          />
-                        );
-                      }
-                      if (item.kind === 'connector') {
-                        return (
-                          <CapabilityCard
-                            key={`connector:${item.id}`}
-                            icon={Plug}
-                            title={item.id}
-                            subtitle="Connector"
-                          />
-                        );
-                      }
-                      return (
-                        <CapabilityCard
-                          key={`tool:${item.id}`}
-                          icon={Wrench}
-                          title={item.id}
-                          subtitle="Tool"
-                        />
-                      );
-                    })}
+                  <SectionLabel>What&rsquo;s inside {bundleMembers.length}</SectionLabel>
+                  <ul className="space-y-2">
+                    {bundleMembers.map((member) => (
+                      <li key={member.key}>
+                        <button
+                          type="button"
+                          disabled={!member.href}
+                          onClick={() => member.href && openItem(member.href)}
+                          className="group bg-popover hover:bg-muted/70 disabled:hover:bg-popover flex w-full items-center gap-3 rounded-md border px-3 py-2 text-left transition-colors disabled:cursor-default"
+                        >
+                          {member.type ? (
+                            <TypeTile type={member.type} size="sm" />
+                          ) : (
+                            <span className="bg-foreground/5 text-muted-foreground flex size-8 shrink-0 items-center justify-center rounded-lg">
+                              <FileText className="size-4" />
+                            </span>
+                          )}
+                          <span className="min-w-0 flex-1">
+                            <span className="text-foreground block truncate text-sm font-medium">
+                              {member.title}
+                            </span>
+                            {member.type && (
+                              <span className="text-muted-foreground block text-xs">
+                                {typeMeta(member.type).label}
+                              </span>
+                            )}
+                          </span>
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                </section>
+              )}
+
+              {capCount > 0 && (
+                <section>
+                  <SectionLabel>Requires {capCount}</SectionLabel>
+                  <div className="space-y-3">
+                    {capGroups.map((group) => (
+                      <div key={group.kind}>
+                        <div className="text-muted-foreground mb-1.5 text-xs">{group.label}</div>
+                        <div className="flex flex-wrap gap-1.5">
+                          {group.items.map((value) => (
+                            <Badge
+                              key={`${group.kind}:${value}`}
+                              variant="outline"
+                              size="sm"
+                              className="font-mono"
+                            >
+                              {value}
+                            </Badge>
+                          ))}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </section>
+              )}
+
+              {data.files.length > 0 && (
+                <section>
+                  <SectionLabel>Files {data.files.length}</SectionLabel>
+                  <div className="bg-popover max-h-72 overflow-y-auto rounded-md border">
+                    <ul className="divide-border divide-y">
+                      {data.files.map((file) => (
+                        <li
+                          key={file.target}
+                          className="text-foreground/90 truncate px-4 py-2 font-mono text-xs"
+                          title={file.target}
+                        >
+                          {file.target}
+                        </li>
+                      ))}
+                    </ul>
                   </div>
                 </section>
               )}
@@ -237,12 +267,8 @@ export function MarketplaceItemDetail({
                 ) : (
                   <EmptyState
                     icon={FileText}
-                    title={tI18nHardcoded.raw(
-                      'autoComponentsMarketplaceMarketplaceItemDetailJsxAttrTitleNoREADME4966916b',
-                    )}
-                    description={tI18nHardcoded.raw(
-                      'autoComponentsMarketplaceMarketplaceItemDetailJsxAttrDescriptionThisSkill2316ce31',
-                    )}
+                    title="No README"
+                    description={emptyReadmeCopy(data.type)}
                   />
                 )}
               </section>

--- a/apps/web/src/features/marketplace/marketplace-item-view.test.ts
+++ b/apps/web/src/features/marketplace/marketplace-item-view.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, test } from 'bun:test';
+
+import type { DependencyItem, ItemCapabilities } from '@/lib/marketplace-client';
+import {
+  emptyDescriptionCopy,
+  emptyReadmeCopy,
+  groupCapabilities,
+  itemCountLabel,
+  resolveBundleMembers,
+  totalCapabilityCount,
+} from './marketplace-item-view';
+
+describe('emptyDescriptionCopy', () => {
+  test('derives type-aware wording for a skill', () => {
+    expect(emptyDescriptionCopy('registry:skill')).toBe(
+      "This skill doesn't have a description yet.",
+    );
+  });
+
+  test('derives type-aware wording for an agent', () => {
+    expect(emptyDescriptionCopy('registry:agent')).toBe(
+      "This agent doesn't have a description yet.",
+    );
+  });
+
+  test('derives type-aware wording for a bundle', () => {
+    expect(emptyDescriptionCopy('registry:bundle')).toBe(
+      "This bundle doesn't have a description yet.",
+    );
+  });
+
+  test('falls back to the raw type label for an unknown type', () => {
+    expect(emptyDescriptionCopy('registry:widget')).toBe(
+      "This widget doesn't have a description yet.",
+    );
+  });
+});
+
+describe('emptyReadmeCopy', () => {
+  test('derives type-aware wording for a command', () => {
+    expect(emptyReadmeCopy('registry:command')).toBe("This command doesn't ship a README yet.");
+  });
+
+  test('derives type-aware wording for a skill', () => {
+    expect(emptyReadmeCopy('registry:skill')).toBe("This skill doesn't ship a README yet.");
+  });
+});
+
+describe('itemCountLabel', () => {
+  test('a bundle counts its member dependencies as items', () => {
+    const result = itemCountLabel({
+      type: 'registry:bundle',
+      dependencies: ['a', 'b', 'c'],
+      fileCount: 0,
+    });
+
+    expect(result).toEqual({ count: 3, unit: 'items' });
+  });
+
+  test('a bundle with exactly one member uses the singular unit', () => {
+    const result = itemCountLabel({ type: 'registry:bundle', dependencies: ['a'], fileCount: 0 });
+
+    expect(result).toEqual({ count: 1, unit: 'item' });
+  });
+
+  test('a non-bundle type counts files, ignoring dependencies', () => {
+    const result = itemCountLabel({ type: 'registry:skill', dependencies: ['a', 'b'], fileCount: 5 });
+
+    expect(result).toEqual({ count: 5, unit: 'files' });
+  });
+
+  test('a single file uses the singular unit', () => {
+    const result = itemCountLabel({ type: 'registry:agent', dependencies: [], fileCount: 1 });
+
+    expect(result).toEqual({ count: 1, unit: 'file' });
+  });
+});
+
+describe('resolveBundleMembers', () => {
+  const hrefForId = (id: string) => `/marketplace/${id}`;
+
+  test('joins each dependency name against its resolved metadata', () => {
+    const dependencyItems: DependencyItem[] = [
+      { id: 'kortix:review', name: 'review', type: 'registry:skill', title: 'Review', description: null },
+    ];
+
+    const members = resolveBundleMembers({
+      dependencies: ['review'],
+      dependencyItems,
+      hrefForId,
+    });
+
+    expect(members).toEqual([
+      { key: 'kortix:review', title: 'Review', type: 'registry:skill', href: '/marketplace/kortix:review' },
+    ]);
+  });
+
+  test('preserves dependency order even when resolved metadata arrives in a different order', () => {
+    const dependencyItems: DependencyItem[] = [
+      { id: 'kortix:b', name: 'b', type: 'registry:skill', title: 'B', description: null },
+      { id: 'kortix:a', name: 'a', type: 'registry:skill', title: 'A', description: null },
+    ];
+
+    const members = resolveBundleMembers({
+      dependencies: ['a', 'b'],
+      dependencyItems,
+      hrefForId,
+    });
+
+    expect(members.map((m) => m.key)).toEqual(['kortix:a', 'kortix:b']);
+  });
+
+  test('falls back to the bare name when a dependency has no resolved metadata', () => {
+    const members = resolveBundleMembers({
+      dependencies: ['unresolved-item'],
+      dependencyItems: [],
+      hrefForId,
+    });
+
+    expect(members).toEqual([{ key: 'unresolved-item', title: 'unresolved-item', type: null, href: null }]);
+  });
+
+  test('an empty dependency list produces no members', () => {
+    expect(resolveBundleMembers({ dependencies: [], dependencyItems: [], hrefForId })).toEqual([]);
+  });
+});
+
+describe('groupCapabilities', () => {
+  function caps(overrides: Partial<ItemCapabilities>): ItemCapabilities {
+    return { secrets: [], connectors: [], tools: [], network: [], ...overrides };
+  }
+
+  test('includes network alongside secrets, connectors, and tools', () => {
+    const groups = groupCapabilities(
+      caps({ secrets: ['API_KEY'], connectors: ['slack'], tools: ['search'], network: ['api.example.com'] }),
+    );
+
+    expect(groups).toEqual([
+      { kind: 'secret', label: 'Secrets', items: ['API_KEY'] },
+      { kind: 'connector', label: 'Connectors', items: ['slack'] },
+      { kind: 'tool', label: 'Tools', items: ['search'] },
+      { kind: 'network', label: 'Network', items: ['api.example.com'] },
+    ]);
+  });
+
+  test('drops groups with no items', () => {
+    const groups = groupCapabilities(caps({ secrets: ['API_KEY'] }));
+
+    expect(groups).toEqual([{ kind: 'secret', label: 'Secrets', items: ['API_KEY'] }]);
+  });
+
+  test('an item with no capabilities produces no groups', () => {
+    expect(groupCapabilities(caps({}))).toEqual([]);
+  });
+
+  test('null/undefined capabilities produce no groups', () => {
+    expect(groupCapabilities(null)).toEqual([]);
+    expect(groupCapabilities(undefined)).toEqual([]);
+  });
+});
+
+describe('totalCapabilityCount', () => {
+  test('sums every capability kind, including network', () => {
+    const count = totalCapabilityCount({
+      secrets: ['A', 'B'],
+      connectors: ['c'],
+      tools: [],
+      network: ['n1', 'n2', 'n3'],
+    });
+
+    expect(count).toBe(6);
+  });
+
+  test('null/undefined capabilities count as zero', () => {
+    expect(totalCapabilityCount(null)).toBe(0);
+    expect(totalCapabilityCount(undefined)).toBe(0);
+  });
+});

--- a/apps/web/src/features/marketplace/marketplace-item-view.ts
+++ b/apps/web/src/features/marketplace/marketplace-item-view.ts
@@ -1,0 +1,92 @@
+import type { DependencyItem, ItemCapabilities, MarketplaceItem } from '@/lib/marketplace-client';
+import { typeMeta } from './marketplace-meta';
+
+/** Type-aware copy for the "no description" state. Every item type reads as
+ *  itself instead of silently assuming "skill". */
+export function emptyDescriptionCopy(type: string): string {
+  return `This ${typeMeta(type).label.toLowerCase()} doesn't have a description yet.`;
+}
+
+/** Type-aware copy for the "no README" empty state. */
+export function emptyReadmeCopy(type: string): string {
+  return `This ${typeMeta(type).label.toLowerCase()} doesn't ship a README yet.`;
+}
+
+/** Type-aware meta-line count label for a card/detail (e.g. "3 items" for a
+ *  bundle's member count, "12 files" for everything else). */
+export function itemCountLabel(item: Pick<MarketplaceItem, 'type' | 'dependencies' | 'fileCount'>): {
+  count: number;
+  unit: string;
+} {
+  if (item.type === 'registry:bundle') {
+    const count = item.dependencies.length;
+    return { count, unit: count === 1 ? 'item' : 'items' };
+  }
+  const count = item.fileCount;
+  return { count, unit: count === 1 ? 'file' : 'files' };
+}
+
+/** A single "what's inside" row for a bundle's member items. Prefers the
+ *  resolved `DependencyItem` (title/type known) and falls back to the bare
+ *  dependency name when the server hasn't resolved it (e.g. an external ref
+ *  the catalog couldn't join). */
+export interface BundleMember {
+  key: string;
+  title: string;
+  type: string | null;
+  href: string | null;
+}
+
+/** Derives the ordered member list for a bundle's "What's inside" section,
+ *  joining `dependencies` (names, always present) against `dependencyItems`
+ *  (resolved metadata, best-effort) by name. Extracted so the join/fallback
+ *  logic is unit-testable without mounting the detail view. */
+export function resolveBundleMembers(params: {
+  dependencies: string[];
+  dependencyItems: DependencyItem[];
+  hrefForId: (id: string) => string;
+}): BundleMember[] {
+  const byName = new Map(params.dependencyItems.map((d) => [d.name, d]));
+  return params.dependencies.map((name) => {
+    const resolved = byName.get(name);
+    if (resolved) {
+      return {
+        key: resolved.id,
+        title: resolved.title,
+        type: resolved.type,
+        href: params.hrefForId(resolved.id),
+      };
+    }
+    return { key: name, title: name, type: null, href: null };
+  });
+}
+
+/** One row in the grouped capability-badge display. */
+export type CapabilityKind = 'secret' | 'connector' | 'tool' | 'network';
+
+export interface CapabilityGroup {
+  kind: CapabilityKind;
+  label: string;
+  items: string[];
+}
+
+/** Groups an item's `capabilities` into labeled sections for the detail
+ *  view's scannable badge rows, dropping empty groups. Includes `network`,
+ *  which existing detail views silently omitted. */
+export function groupCapabilities(caps: ItemCapabilities | undefined | null): CapabilityGroup[] {
+  if (!caps) return [];
+  const groups: CapabilityGroup[] = [
+    { kind: 'secret', label: 'Secrets', items: caps.secrets },
+    { kind: 'connector', label: 'Connectors', items: caps.connectors },
+    { kind: 'tool', label: 'Tools', items: caps.tools },
+    { kind: 'network', label: 'Network', items: caps.network },
+  ];
+  return groups.filter((g) => g.items.length > 0);
+}
+
+/** Total capability count across all groups — used for section-header counts
+ *  and to decide whether the capabilities section renders at all. */
+export function totalCapabilityCount(caps: ItemCapabilities | undefined | null): number {
+  if (!caps) return 0;
+  return caps.secrets.length + caps.connectors.length + caps.tools.length + caps.network.length;
+}

--- a/apps/web/src/features/marketplace/marketplace-meta.tsx
+++ b/apps/web/src/features/marketplace/marketplace-meta.tsx
@@ -59,14 +59,22 @@ export function TypeTile({
   );
 }
 
-// Launch scope: marketplace browsing is the skill library. Keep the visual type
-// taxonomy above for detail/legacy data, but only expose skill filters here.
+// The one-click importables users browse + install. Filters and grouped
+// sections auto-hide any type with no items (marketplace-browser derives
+// `typeOptions` from live typeCounts; marketplace-grid only emits a section for
+// present items), so listing a type here is safe even before content exists.
 export const TYPE_FILTERS: Array<{ value: string; label: string }> = [
   { value: 'all', label: 'All' },
   { value: 'skill', label: 'Skills' },
+  { value: 'agent', label: 'Agents' },
+  { value: 'command', label: 'Commands' },
+  { value: 'bundle', label: 'Bundles' },
 ];
 
 /** Section order + labels for the grouped (filter=All) gallery view. */
 export const TYPE_SECTIONS: Array<{ type: string; label: string }> = [
   { type: 'registry:skill', label: 'Skills' },
+  { type: 'registry:agent', label: 'Agents' },
+  { type: 'registry:command', label: 'Commands' },
+  { type: 'registry:bundle', label: 'Bundles' },
 ];

--- a/apps/web/src/features/marketplace/marketplace-public-detail.tsx
+++ b/apps/web/src/features/marketplace/marketplace-public-detail.tsx
@@ -1,12 +1,14 @@
 'use client';
 
-import { FileText, KeyRound, Layers, Plug, Wrench } from 'lucide-react';
+import { FileText } from 'lucide-react';
 import Link from 'next/link';
+import { usePathname } from 'next/navigation';
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 
 import { cn } from '@/lib/utils';
 
 import { UnifiedMarkdown } from '@/components/markdown';
+import { Badge } from '@/components/ui/badge';
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -18,13 +20,21 @@ import {
 import { Button } from '@/components/ui/button';
 import { FadedScrollArea } from '@/components/ui/faded-scroll-area';
 import { EmptyState } from '@/features/layout/section/empty-state';
+import { useAuth } from '@/features/providers/auth-provider';
 import type { MarketplaceItemDetail, MarketplaceSummary } from '@/lib/marketplace-client';
 import { marketplaceCompanyHref, marketplaceItemHref } from '@/lib/marketplace-slug';
 import { MarketplaceAddButton } from './marketplace-add-button';
 import { MarketplaceAvatar } from './marketplace-avatar';
 import { displayCompanyLabel } from './marketplace-company-filter';
 import { MarketplaceItemAvatar } from './marketplace-item-avatar';
-import { typeMeta } from './marketplace-meta';
+import {
+  emptyDescriptionCopy,
+  emptyReadmeCopy,
+  groupCapabilities,
+  resolveBundleMembers,
+  totalCapabilityCount,
+} from './marketplace-item-view';
+import { TypeTile, typeMeta } from './marketplace-meta';
 
 function stripFrontmatter(md: string): string {
   if (md.startsWith('---')) {
@@ -106,24 +116,30 @@ function CompanyAside({
   );
 }
 
-function MetaRow({
-  icon: IconComponent,
+function BundleMemberRow({
   title,
-  subtitle,
+  type,
   href,
 }: {
-  icon: React.ComponentType<{ className?: string }>;
   title: string;
-  subtitle?: string;
-  href?: string;
+  type: string | null;
+  href: string | null;
 }) {
   const body = (
     <>
-      <IconComponent className="text-muted-foreground size-4 shrink-0" />
-      <span className="text-foreground min-w-0 flex-1 truncate text-sm">{title}</span>
-      {subtitle ? (
-        <span className="text-muted-foreground/70 shrink-0 text-xs">{subtitle}</span>
-      ) : null}
+      {type ? (
+        <TypeTile type={type} size="sm" />
+      ) : (
+        <span className="bg-foreground/5 text-muted-foreground flex size-8 shrink-0 items-center justify-center rounded-lg">
+          <FileText className="size-4" />
+        </span>
+      )}
+      <span className="min-w-0 flex-1">
+        <span className="text-foreground block truncate text-sm">{title}</span>
+        {type ? (
+          <span className="text-muted-foreground/70 block text-xs">{typeMeta(type).label}</span>
+        ) : null}
+      </span>
     </>
   );
   if (href) {
@@ -207,12 +223,18 @@ export function MarketplacePublicDetail({
   company?: MarketplaceSummary;
 }) {
   const tm = typeMeta(data.type);
-  const caps = data.capabilities;
-  const capItems = [
-    ...caps.secrets.map((s) => ({ kind: 'secret' as const, id: s })),
-    ...caps.connectors.map((c) => ({ kind: 'connector' as const, id: c })),
-    ...caps.tools.map((t) => ({ kind: 'tool' as const, id: t })),
-  ];
+  const { user, isLoading: authLoading } = useAuth();
+  const pathname = usePathname();
+  const capGroups = groupCapabilities(data.capabilities);
+  const capCount = totalCapabilityCount(data.capabilities);
+  const isBundle = data.type === 'registry:bundle';
+  const bundleMembers = isBundle
+    ? resolveBundleMembers({
+        dependencies: data.dependencies,
+        dependencyItems: data.dependencyItems,
+        hrefForId: marketplaceItemHref,
+      })
+    : [];
   const readme = data.readme ? stripFrontmatter(data.readme) : '';
   const itemTitle = data.title.replaceAll('-', ' ');
   const companyLabel = displayCompanyLabel(data.marketplaceId, data.marketplaceLabel);
@@ -259,65 +281,90 @@ export function MarketplacePublicDetail({
             <div className="flex items-start justify-between gap-4">
               <div className="flex min-w-0 items-center gap-4">
                 <MarketplaceItemAvatar item={data} size="md" showSource={false} />
-                <h1 className="text-foreground text-2xl font-semibold tracking-tight text-balance capitalize sm:text-3xl">
-                  {itemTitle}
-                </h1>
+                <div className="min-w-0 space-y-1">
+                  <h1 className="text-foreground text-2xl font-semibold tracking-tight text-balance capitalize sm:text-3xl">
+                    {itemTitle}
+                  </h1>
+                  <span className="text-muted-foreground inline-flex items-center gap-1.5 text-xs">
+                    <tm.Icon className="size-3.5 shrink-0" />
+                    {tm.label}
+                  </span>
+                </div>
               </div>
-              <MarketplaceAddButton item={data} />
+              <div className="flex shrink-0 flex-col items-end gap-2">
+                <MarketplaceAddButton item={data} />
+                {!authLoading && !user ? (
+                  <Link
+                    href={`/auth?redirect=${encodeURIComponent(pathname)}`}
+                    className="text-muted-foreground hover:text-foreground text-xs transition-colors"
+                  >
+                    Sign in to add to a project
+                  </Link>
+                ) : null}
+              </div>
             </div>
-            {data.description ? (
-              <p className="text-foreground text-base leading-relaxed text-pretty">
-                {data.description}
-              </p>
-            ) : null}
+            <p className="text-foreground text-base leading-relaxed text-pretty">
+              {data.description || emptyDescriptionCopy(data.type)}
+            </p>
           </header>
 
-          {capItems.length > 0 ? (
+          {isBundle && bundleMembers.length > 0 ? (
             <section>
-              <SectionLabel count={capItems.length}>Permissions</SectionLabel>
+              <SectionLabel count={bundleMembers.length}>What&rsquo;s inside</SectionLabel>
               <RowPanel>
-                {capItems.map((item) =>
-                  item.kind === 'secret' ? (
-                    <MetaRow
-                      key={`secret:${item.id}`}
-                      icon={KeyRound}
-                      title={item.id}
-                      subtitle="Secret"
-                    />
-                  ) : item.kind === 'connector' ? (
-                    <MetaRow
-                      key={`connector:${item.id}`}
-                      icon={Plug}
-                      title={item.id}
-                      subtitle="Connector"
-                    />
-                  ) : (
-                    <MetaRow
-                      key={`tool:${item.id}`}
-                      icon={Wrench}
-                      title={item.id}
-                      subtitle="Tool"
-                    />
-                  ),
-                )}
+                {bundleMembers.map((member) => (
+                  <BundleMemberRow
+                    key={member.key}
+                    title={member.title}
+                    type={member.type}
+                    href={member.href}
+                  />
+                ))}
               </RowPanel>
             </section>
           ) : null}
 
-          {data.dependencyItems.length > 0 ? (
+          {capCount > 0 ? (
             <section>
-              <SectionLabel count={data.dependencyItems.length}>Includes</SectionLabel>
-              <RowPanel>
-                {data.dependencyItems.map((dep) => (
-                  <MetaRow
-                    key={dep.id}
-                    icon={Layers}
-                    title={dep.title}
-                    subtitle={typeMeta(dep.type).label}
-                    href={marketplaceItemHref(dep.id)}
-                  />
+              <SectionLabel count={capCount}>Requires</SectionLabel>
+              <div className="bg-popover space-y-3 rounded-md border px-4 py-4">
+                {capGroups.map((group) => (
+                  <div key={group.kind}>
+                    <div className="text-muted-foreground mb-1.5 text-xs">{group.label}</div>
+                    <div className="flex flex-wrap gap-1.5">
+                      {group.items.map((value) => (
+                        <Badge
+                          key={`${group.kind}:${value}`}
+                          variant="outline"
+                          size="sm"
+                          className="font-mono"
+                        >
+                          {value}
+                        </Badge>
+                      ))}
+                    </div>
+                  </div>
                 ))}
-              </RowPanel>
+              </div>
+            </section>
+          ) : null}
+
+          {data.files.length > 0 ? (
+            <section>
+              <SectionLabel count={data.files.length}>Files</SectionLabel>
+              <div className="bg-popover max-h-72 overflow-y-auto rounded-md border">
+                <ul className="divide-border divide-y">
+                  {data.files.map((file) => (
+                    <li
+                      key={file.target}
+                      className="text-foreground/90 truncate px-4 py-2 font-mono text-xs"
+                      title={file.target}
+                    >
+                      {file.target}
+                    </li>
+                  ))}
+                </ul>
+              </div>
             </section>
           ) : null}
 
@@ -329,7 +376,7 @@ export function MarketplacePublicDetail({
                 icon={FileText}
                 size="sm"
                 title="No README"
-                description="This item doesn't ship a README yet."
+                description={emptyReadmeCopy(data.type)}
               />
             )}
           </section>

--- a/apps/web/src/features/projects/modal/rename-project-modal.tsx
+++ b/apps/web/src/features/projects/modal/rename-project-modal.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState } from 'react';
 
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import Loading from '@/components/ui/loading';
 import {
   Modal,
   ModalBody,
@@ -53,7 +54,7 @@ export const RenameProjectDialog = ({
         queryClient.setQueryData(['project', projectId], updated);
       }
       queryClient.invalidateQueries({ queryKey: ['projects'] });
-      successToast('Project renamed');
+      successToast(updated?.name ? `Renamed to "${updated.name}"` : 'Project renamed');
       onSaved?.();
       onOpenChange(false);
     },
@@ -72,7 +73,12 @@ export const RenameProjectDialog = ({
   };
 
   return (
-    <Modal open={open} onOpenChange={onOpenChange}>
+    <Modal
+      open={open}
+      onOpenChange={(o) => {
+        if (!renameMutation.isPending) onOpenChange(o);
+      }}
+    >
       <ModalContent className="lg:max-w-md">
         <ModalHeader>
           <ModalTitle>
@@ -104,11 +110,16 @@ export const RenameProjectDialog = ({
           />
         </ModalBody>
         <ModalFooter className="sm:justify-between">
-          <Button variant="outline-ghost" onClick={() => onOpenChange(false)}>
+          <Button
+            variant="outline-ghost"
+            onClick={() => onOpenChange(false)}
+            disabled={renameMutation.isPending}
+          >
             Cancel
           </Button>
           <Button onClick={submit} disabled={renameMutation.isPending || isUnchanged || isEmpty}>
-            {renameMutation.isPending ? 'Saving…' : 'Save'}
+            {renameMutation.isPending ? <Loading className="size-4 shrink-0" /> : null}
+            Save
           </Button>
         </ModalFooter>
       </ModalContent>

--- a/apps/web/src/features/projects/project-card.tsx
+++ b/apps/web/src/features/projects/project-card.tsx
@@ -46,10 +46,15 @@ const ProjectCard = ({
         <div className="flex w-full items-center gap-3">
           <EntityAvatar label={project.name} size="lg" className="bg-background" />
           <div className="min-w-0 flex-1 space-y-1">
-            <h3 className="text-foreground truncate text-sm leading-tight font-semibold">
+            <h3
+              title={project.name}
+              className="text-foreground truncate text-sm leading-tight font-semibold"
+            >
               {project.name}
             </h3>
-            <p className="text-muted-foreground truncate text-xs">Updated {updatedLabel}</p>
+            <p className="text-muted-foreground truncate text-xs tabular-nums">
+              Updated {updatedLabel}
+            </p>
           </div>
         </div>
       </button>
@@ -81,7 +86,7 @@ const ProjectCard = ({
               onSelect={onArchive}
               disabled={archiving || !canManageProject}
             >
-              {archiving ? <Loading /> : <TrashSolid className="size-4" />}
+              {archiving ? <Loading className="size-4 shrink-0" /> : <TrashSolid className="size-4" />}
               Archive
             </DropdownMenuItem>
           </DropdownMenuContent>

--- a/apps/web/src/features/review-center/hooks/use-review-items.ts
+++ b/apps/web/src/features/review-center/hooks/use-review-items.ts
@@ -7,6 +7,7 @@ import {
   actReviewItem,
   bulkActReviewItems,
   listReviewItems,
+  resolveApproval,
   submitReviewItem,
 } from '@kortix/sdk/projects-client';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
@@ -69,6 +70,30 @@ export function useSubmitReviewItem() {
   const invalidate = useInvalidate(projectId);
   return useMutation<ApiReviewItem, Error, Parameters<typeof submitReviewItem>[1]>({
     mutationFn: (input) => submitReviewItem(projectId, input),
+    onSuccess: invalidate,
+  });
+}
+
+/**
+ * Resolve an executor approval (`exec:` adapted review item) directly from the
+ * inbox — the SAME call + payload the in-session approval prompt uses
+ * (`resolveApproval`, via `SessionApprovalPrompt` → `useResolveApproval` in
+ * session-audit-shared.tsx). Scope is always `'once'` here: the inbox acts on
+ * one specific pending call, not "for the rest of this session" — that
+ * broader scope stays a session-view-only affordance since it needs the
+ * session's other pending rows in view to make sense.
+ */
+export function useResolveReviewApproval() {
+  const ctx = useProjectContext();
+  const projectId = ctx?.projectId ?? '';
+  const invalidate = useInvalidate(projectId);
+  return useMutation<
+    { ok: boolean; scope?: 'once' | 'session' | 'session_all' },
+    Error,
+    { executionId: string; decision: 'approve' | 'deny' }
+  >({
+    mutationFn: ({ executionId, decision }) =>
+      resolveApproval(projectId, executionId, decision, 'once'),
     onSuccess: invalidate,
   });
 }

--- a/apps/web/src/features/review-center/map.ts
+++ b/apps/web/src/features/review-center/map.ts
@@ -6,6 +6,7 @@
  */
 
 import type { ApiReviewItem, ReviewVerdict } from '@kortix/sdk/projects-client';
+import { looksLikeMarkdown } from './review-markdown';
 import type {
   ApprovalAction,
   ApprovalActionIcon,
@@ -92,12 +93,22 @@ const lines = (s: string): string[] =>
 
 function changeDetail(d: AnyRec, row: ApiReviewItem): ChangeDetail {
   const adv = rec(d.advanced);
+  // A free-form description that's real markdown (agent-written CR bodies
+  // often are) is carried whole and rendered as markdown in the modal —
+  // line-splitting it into checkmark rows would show raw `##`/`**` noise.
+  // Plain text keeps the designed per-line treatment; a native structured
+  // `whatChanged` array always wins.
+  const description = str(d.description);
+  const native = arrOf<string>(d.whatChanged);
+  const descriptionMarkdown =
+    !native && description && looksLikeMarkdown(description) ? description : undefined;
   const whatChanged =
-    arrOf<string>(d.whatChanged) ??
-    (str(d.description) ? lines(str(d.description) as string) : row.summary ? [row.summary] : []);
+    native ??
+    (descriptionMarkdown ? [] : description ? lines(description) : row.summary ? [row.summary] : []);
   return {
     crId: str(d.cr_id),
     whatChanged,
+    descriptionMarkdown,
     impact: str(d.impact) ?? '',
     verification: arrOf<ChangeDetail['verification'][number]>(d.verification) ?? [],
     previewUrl: str(d.previewUrl) ?? str(d.preview_url),

--- a/apps/web/src/features/review-center/review-actions.test.ts
+++ b/apps/web/src/features/review-center/review-actions.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import {
+  bulkSkipMessage,
   crChangeRequestId,
   execExecutionId,
   formatItemAge,
@@ -7,7 +8,9 @@ import {
   isQuickDecidableApproval,
   itemDeepLink,
   planBulkAction,
+  resolveBulkOutcome,
 } from './review-actions';
+import type { ReviewRisk } from './types';
 
 describe('execExecutionId', () => {
   test('strips the exec: prefix', () => {
@@ -111,5 +114,66 @@ describe('formatItemAgeLong', () => {
     expect(formatItemAgeLong(new Date(base - 7 * 60_000).toISOString(), base)).toBe('7m ago');
     expect(formatItemAgeLong(new Date(base - 3 * 3_600_000).toISOString(), base)).toBe('3h ago');
     expect(formatItemAgeLong(new Date(base - 50 * 3_600_000).toISOString(), base)).toBe('2d ago');
+  });
+});
+
+describe('resolveBulkOutcome', () => {
+  const risk =
+    (m: Record<string, ReviewRisk>) =>
+    (id: string): ReviewRisk | undefined =>
+      m[id];
+
+  test('dismiss NEVER answers an executor approval — exec ids are kept, not denied', () => {
+    const out = resolveBulkOutcome(['exec:e1', 'rv-1'], 'dismiss', risk({ 'exec:e1': 'none' }));
+    expect(out.act).toEqual(['rv-1']);
+    expect(out.skippedApprovals).toEqual(['exec:e1']);
+    expect(out.skippedRisky).toEqual([]);
+  });
+
+  test('approve sweeps only safe exec approvals; risky ones are skipped', () => {
+    const out = resolveBulkOutcome(
+      ['exec:safe', 'exec:risky', 'rv-1'],
+      'approve',
+      risk({ 'exec:safe': 'low', 'exec:risky': 'high' }),
+    );
+    expect(out.act).toEqual(['exec:safe', 'rv-1']);
+    expect(out.skippedRisky).toEqual(['exec:risky']);
+    expect(out.skippedApprovals).toEqual([]);
+  });
+
+  test('an exec approval with unknown risk is treated as risky on approve', () => {
+    const out = resolveBulkOutcome(['exec:mystery'], 'approve', risk({}));
+    expect(out.act).toEqual([]);
+    expect(out.skippedRisky).toEqual(['exec:mystery']);
+  });
+
+  test('Change Requests are skipped under any verdict', () => {
+    expect(resolveBulkOutcome(['cr:1'], 'approve', risk({})).skippedChanges).toEqual(['cr:1']);
+    expect(resolveBulkOutcome(['cr:1'], 'dismiss', risk({})).skippedChanges).toEqual(['cr:1']);
+  });
+
+  test('native ids act under both verdicts', () => {
+    expect(resolveBulkOutcome(['rv-1', 'rv-2'], 'dismiss', risk({})).act).toEqual(['rv-1', 'rv-2']);
+    expect(resolveBulkOutcome(['rv-1'], 'approve', risk({})).act).toEqual(['rv-1']);
+  });
+});
+
+describe('bulkSkipMessage', () => {
+  test('empty when nothing was skipped', () => {
+    expect(
+      bulkSkipMessage({ act: ['a'], skippedRisky: [], skippedApprovals: [], skippedChanges: [] }),
+    ).toBe('');
+  });
+
+  test('names every skip bucket with counts', () => {
+    const msg = bulkSkipMessage({
+      act: [],
+      skippedRisky: ['exec:r'],
+      skippedApprovals: ['exec:a', 'exec:b'],
+      skippedChanges: ['cr:1'],
+    });
+    expect(msg).toContain('2 approvals kept');
+    expect(msg).toContain('1 risky approval skipped');
+    expect(msg).toContain('1 change skipped');
   });
 });

--- a/apps/web/src/features/review-center/review-actions.test.ts
+++ b/apps/web/src/features/review-center/review-actions.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  crChangeRequestId,
+  execExecutionId,
+  formatItemAge,
+  formatItemAgeLong,
+  isQuickDecidableApproval,
+  itemDeepLink,
+  planBulkAction,
+} from './review-actions';
+
+describe('execExecutionId', () => {
+  test('strips the exec: prefix', () => {
+    expect(execExecutionId('exec:abc-123')).toBe('abc-123');
+  });
+  test('returns null for a non-exec id', () => {
+    expect(execExecutionId('cr:abc-123')).toBeNull();
+    expect(execExecutionId('rv-native-1')).toBeNull();
+    expect(execExecutionId('')).toBeNull();
+  });
+});
+
+describe('crChangeRequestId', () => {
+  test('strips the cr: prefix', () => {
+    expect(crChangeRequestId('cr:xyz-9')).toBe('xyz-9');
+  });
+  test('returns null for a non-cr id', () => {
+    expect(crChangeRequestId('exec:xyz-9')).toBeNull();
+    expect(crChangeRequestId('rv-native-1')).toBeNull();
+  });
+});
+
+describe('itemDeepLink', () => {
+  test('builds the session route when both ids are present', () => {
+    expect(itemDeepLink('proj-1', 'sess-1')).toBe('/projects/proj-1/sessions/sess-1');
+  });
+  test('is null without a session id (nothing to deep-link into)', () => {
+    expect(itemDeepLink('proj-1', undefined)).toBeNull();
+    expect(itemDeepLink('proj-1', null)).toBeNull();
+    expect(itemDeepLink('proj-1', '')).toBeNull();
+  });
+  test('is null without a project id', () => {
+    expect(itemDeepLink('', 'sess-1')).toBeNull();
+  });
+});
+
+describe('planBulkAction', () => {
+  test('buckets ids by how the inbox can act on them', () => {
+    const plan = planBulkAction(['rv-1', 'exec:e1', 'cr:c1', 'rv-2', 'exec:e2']);
+    expect(plan.native).toEqual(['rv-1', 'rv-2']);
+    expect(plan.resolvable).toEqual(['exec:e1', 'exec:e2']);
+    expect(plan.unsupported).toEqual(['cr:c1']);
+  });
+  test('accepts a Set and handles an all-native selection', () => {
+    const plan = planBulkAction(new Set(['rv-1', 'rv-2']));
+    expect(plan).toEqual({ native: ['rv-1', 'rv-2'], resolvable: [], unsupported: [] });
+  });
+  test('empty selection yields empty buckets', () => {
+    expect(planBulkAction([])).toEqual({ native: [], resolvable: [], unsupported: [] });
+  });
+});
+
+describe('formatItemAge', () => {
+  const base = new Date('2026-07-08T12:00:00.000Z').getTime();
+  test('minutes under an hour', () => {
+    expect(formatItemAge(new Date(base - 7 * 60_000).toISOString(), base)).toBe('7m');
+  });
+  test('floors at 1 minute for sub-minute / future timestamps', () => {
+    expect(formatItemAge(new Date(base).toISOString(), base)).toBe('1m');
+    expect(formatItemAge(new Date(base + 60_000).toISOString(), base)).toBe('1m');
+  });
+  test('hours under a day', () => {
+    expect(formatItemAge(new Date(base - 3 * 3_600_000).toISOString(), base)).toBe('3h');
+  });
+  test('days at or beyond 24 hours', () => {
+    expect(formatItemAge(new Date(base - 50 * 3_600_000).toISOString(), base)).toBe('2d');
+  });
+});
+
+describe('isQuickDecidableApproval', () => {
+  test('a single-action executor approval is quick-decidable', () => {
+    expect(
+      isQuickDecidableApproval({ kind: 'approval', id: 'exec:e1', detail: { actions: [{}] } }),
+    ).toBe(true);
+  });
+  test('an approval with no detail (defensive) is quick-decidable', () => {
+    expect(isQuickDecidableApproval({ kind: 'approval', id: 'exec:e1' })).toBe(true);
+  });
+  test('a multi-action approval needs the modal', () => {
+    expect(
+      isQuickDecidableApproval({
+        kind: 'approval',
+        id: 'exec:e1',
+        detail: { actions: [{}, {}] },
+      }),
+    ).toBe(false);
+  });
+  test('a Change Request approval-kind lookalike is not quick-decidable (not an exec id)', () => {
+    expect(
+      isQuickDecidableApproval({ kind: 'approval', id: 'rv-native-1', detail: { actions: [{}] } }),
+    ).toBe(false);
+  });
+  test('non-approval kinds are never quick-decidable', () => {
+    expect(isQuickDecidableApproval({ kind: 'change', id: 'exec:e1' })).toBe(false);
+  });
+});
+
+describe('formatItemAgeLong', () => {
+  const base = new Date('2026-07-08T12:00:00.000Z').getTime();
+  test('appends "ago" at every scale', () => {
+    expect(formatItemAgeLong(new Date(base - 7 * 60_000).toISOString(), base)).toBe('7m ago');
+    expect(formatItemAgeLong(new Date(base - 3 * 3_600_000).toISOString(), base)).toBe('3h ago');
+    expect(formatItemAgeLong(new Date(base - 50 * 3_600_000).toISOString(), base)).toBe('2d ago');
+  });
+});

--- a/apps/web/src/features/review-center/review-actions.test.ts
+++ b/apps/web/src/features/review-center/review-actions.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  bulkSkipMessage,
+  crChangeRequestId,
+  execExecutionId,
+  formatItemAge,
+  formatItemAgeLong,
+  isQuickDecidableApproval,
+  itemDeepLink,
+  planBulkAction,
+  resolveBulkOutcome,
+} from './review-actions';
+import type { ReviewRisk } from './types';
+
+describe('execExecutionId', () => {
+  test('strips the exec: prefix', () => {
+    expect(execExecutionId('exec:abc-123')).toBe('abc-123');
+  });
+  test('returns null for a non-exec id', () => {
+    expect(execExecutionId('cr:abc-123')).toBeNull();
+    expect(execExecutionId('rv-native-1')).toBeNull();
+    expect(execExecutionId('')).toBeNull();
+  });
+});
+
+describe('crChangeRequestId', () => {
+  test('strips the cr: prefix', () => {
+    expect(crChangeRequestId('cr:xyz-9')).toBe('xyz-9');
+  });
+  test('returns null for a non-cr id', () => {
+    expect(crChangeRequestId('exec:xyz-9')).toBeNull();
+    expect(crChangeRequestId('rv-native-1')).toBeNull();
+  });
+});
+
+describe('itemDeepLink', () => {
+  test('builds the session route when both ids are present', () => {
+    expect(itemDeepLink('proj-1', 'sess-1')).toBe('/projects/proj-1/sessions/sess-1');
+  });
+  test('is null without a session id (nothing to deep-link into)', () => {
+    expect(itemDeepLink('proj-1', undefined)).toBeNull();
+    expect(itemDeepLink('proj-1', null)).toBeNull();
+    expect(itemDeepLink('proj-1', '')).toBeNull();
+  });
+  test('is null without a project id', () => {
+    expect(itemDeepLink('', 'sess-1')).toBeNull();
+  });
+});
+
+describe('planBulkAction', () => {
+  test('buckets ids by how the inbox can act on them', () => {
+    const plan = planBulkAction(['rv-1', 'exec:e1', 'cr:c1', 'rv-2', 'exec:e2']);
+    expect(plan.native).toEqual(['rv-1', 'rv-2']);
+    expect(plan.resolvable).toEqual(['exec:e1', 'exec:e2']);
+    expect(plan.unsupported).toEqual(['cr:c1']);
+  });
+  test('accepts a Set and handles an all-native selection', () => {
+    const plan = planBulkAction(new Set(['rv-1', 'rv-2']));
+    expect(plan).toEqual({ native: ['rv-1', 'rv-2'], resolvable: [], unsupported: [] });
+  });
+  test('empty selection yields empty buckets', () => {
+    expect(planBulkAction([])).toEqual({ native: [], resolvable: [], unsupported: [] });
+  });
+});
+
+describe('formatItemAge', () => {
+  const base = new Date('2026-07-08T12:00:00.000Z').getTime();
+  test('minutes under an hour', () => {
+    expect(formatItemAge(new Date(base - 7 * 60_000).toISOString(), base)).toBe('7m');
+  });
+  test('floors at 1 minute for sub-minute / future timestamps', () => {
+    expect(formatItemAge(new Date(base).toISOString(), base)).toBe('1m');
+    expect(formatItemAge(new Date(base + 60_000).toISOString(), base)).toBe('1m');
+  });
+  test('hours under a day', () => {
+    expect(formatItemAge(new Date(base - 3 * 3_600_000).toISOString(), base)).toBe('3h');
+  });
+  test('days at or beyond 24 hours', () => {
+    expect(formatItemAge(new Date(base - 50 * 3_600_000).toISOString(), base)).toBe('2d');
+  });
+});
+
+describe('isQuickDecidableApproval', () => {
+  test('a single-action executor approval is quick-decidable', () => {
+    expect(
+      isQuickDecidableApproval({ kind: 'approval', id: 'exec:e1', detail: { actions: [{}] } }),
+    ).toBe(true);
+  });
+  test('an approval with no detail (defensive) is quick-decidable', () => {
+    expect(isQuickDecidableApproval({ kind: 'approval', id: 'exec:e1' })).toBe(true);
+  });
+  test('a multi-action approval needs the modal', () => {
+    expect(
+      isQuickDecidableApproval({
+        kind: 'approval',
+        id: 'exec:e1',
+        detail: { actions: [{}, {}] },
+      }),
+    ).toBe(false);
+  });
+  test('a Change Request approval-kind lookalike is not quick-decidable (not an exec id)', () => {
+    expect(
+      isQuickDecidableApproval({ kind: 'approval', id: 'rv-native-1', detail: { actions: [{}] } }),
+    ).toBe(false);
+  });
+  test('non-approval kinds are never quick-decidable', () => {
+    expect(isQuickDecidableApproval({ kind: 'change', id: 'exec:e1' })).toBe(false);
+  });
+});
+
+describe('formatItemAgeLong', () => {
+  const base = new Date('2026-07-08T12:00:00.000Z').getTime();
+  test('appends "ago" at every scale', () => {
+    expect(formatItemAgeLong(new Date(base - 7 * 60_000).toISOString(), base)).toBe('7m ago');
+    expect(formatItemAgeLong(new Date(base - 3 * 3_600_000).toISOString(), base)).toBe('3h ago');
+    expect(formatItemAgeLong(new Date(base - 50 * 3_600_000).toISOString(), base)).toBe('2d ago');
+  });
+});
+
+describe('resolveBulkOutcome', () => {
+  const risk =
+    (m: Record<string, ReviewRisk>) =>
+    (id: string): ReviewRisk | undefined =>
+      m[id];
+
+  test('dismiss NEVER answers an executor approval — exec ids are kept, not denied', () => {
+    const out = resolveBulkOutcome(['exec:e1', 'rv-1'], 'dismiss', risk({ 'exec:e1': 'none' }));
+    expect(out.act).toEqual(['rv-1']);
+    expect(out.skippedApprovals).toEqual(['exec:e1']);
+    expect(out.skippedRisky).toEqual([]);
+  });
+
+  test('approve sweeps only safe exec approvals; risky ones are skipped', () => {
+    const out = resolveBulkOutcome(
+      ['exec:safe', 'exec:risky', 'rv-1'],
+      'approve',
+      risk({ 'exec:safe': 'low', 'exec:risky': 'high' }),
+    );
+    expect(out.act).toEqual(['exec:safe', 'rv-1']);
+    expect(out.skippedRisky).toEqual(['exec:risky']);
+    expect(out.skippedApprovals).toEqual([]);
+  });
+
+  test('an exec approval with unknown risk is treated as risky on approve', () => {
+    const out = resolveBulkOutcome(['exec:mystery'], 'approve', risk({}));
+    expect(out.act).toEqual([]);
+    expect(out.skippedRisky).toEqual(['exec:mystery']);
+  });
+
+  test('Change Requests are skipped under any verdict', () => {
+    expect(resolveBulkOutcome(['cr:1'], 'approve', risk({})).skippedChanges).toEqual(['cr:1']);
+    expect(resolveBulkOutcome(['cr:1'], 'dismiss', risk({})).skippedChanges).toEqual(['cr:1']);
+  });
+
+  test('native ids act under both verdicts', () => {
+    expect(resolveBulkOutcome(['rv-1', 'rv-2'], 'dismiss', risk({})).act).toEqual(['rv-1', 'rv-2']);
+    expect(resolveBulkOutcome(['rv-1'], 'approve', risk({})).act).toEqual(['rv-1']);
+  });
+});
+
+describe('bulkSkipMessage', () => {
+  test('empty when nothing was skipped', () => {
+    expect(
+      bulkSkipMessage({ act: ['a'], skippedRisky: [], skippedApprovals: [], skippedChanges: [] }),
+    ).toBe('');
+  });
+
+  test('names every skip bucket with counts', () => {
+    const msg = bulkSkipMessage({
+      act: [],
+      skippedRisky: ['exec:r'],
+      skippedApprovals: ['exec:a', 'exec:b'],
+      skippedChanges: ['cr:1'],
+    });
+    expect(msg).toContain('2 approvals kept');
+    expect(msg).toContain('1 risky approval skipped');
+    expect(msg).toContain('1 change skipped');
+  });
+});

--- a/apps/web/src/features/review-center/review-actions.ts
+++ b/apps/web/src/features/review-center/review-actions.ts
@@ -8,7 +8,7 @@
  * endpoint, which 409s on them by design (see review-center-connected.tsx).
  */
 
-import type { ReviewItem } from './types';
+import { type ReviewItem, type ReviewRisk, isSafeRisk } from './types';
 
 export const CR_ID_PREFIX = 'cr:';
 export const EXEC_ID_PREFIX = 'exec:';
@@ -34,11 +34,15 @@ export function crChangeRequestId(id: string): string | null {
  * several independent decisions.
  */
 export function isQuickDecidableApproval(
-  item: Pick<ReviewItem, 'kind' | 'id'> & { detail?: { actions?: unknown[] } },
+  // `detail` is `unknown` (not `{ actions?: ... }`) so every ReviewItem union
+  // member is assignable — ChangeDetail/OutputDetail have no `actions` and a
+  // weak object type would reject them at the call sites.
+  item: Pick<ReviewItem, 'kind' | 'id'> & { detail?: unknown },
 ): boolean {
   if (item.kind !== 'approval') return false;
   if (execExecutionId(item.id) === null) return false;
-  const count = item.detail?.actions?.length ?? 0;
+  const detail = item.detail as { actions?: readonly unknown[] } | undefined;
+  const count = detail?.actions?.length ?? 0;
   return count <= 1;
 }
 
@@ -77,6 +81,69 @@ export function planBulkAction(ids: Iterable<string>): BulkActionPlan {
     else native.push(id);
   }
   return { native, resolvable, unsupported };
+}
+
+/**
+ * What a bulk verdict on a connected selection will REALLY do, decided before
+ * any optimistic UI update so the toast/removal can never claim more than the
+ * server was asked. The rules the buckets encode:
+ *  - Executor approvals are a live question to the agent: "dismiss" doesn't
+ *    answer it, so they're KEPT (never mapped to a deny) under any non-approve
+ *    verdict, and an approve sweep still respects the safe-risk floor.
+ *  - Change Requests have no bulk path at all (merging needs the diff in view).
+ */
+export interface BulkOutcome {
+  /** Ids the verdict genuinely acts on — safe to optimistically update. */
+  act: string[];
+  /** Exec approvals blocked by the approve safe-risk floor. */
+  skippedRisky: string[];
+  /** Exec approvals kept under a non-approve verdict (dismiss ≠ deny). */
+  skippedApprovals: string[];
+  /** Change Requests — each needs its own review. */
+  skippedChanges: string[];
+}
+
+export function resolveBulkOutcome(
+  ids: Iterable<string>,
+  verdict: 'approve' | 'dismiss',
+  riskOf: (id: string) => ReviewRisk | undefined,
+): BulkOutcome {
+  const act: string[] = [];
+  const skippedRisky: string[] = [];
+  const skippedApprovals: string[] = [];
+  const skippedChanges: string[] = [];
+  for (const id of ids) {
+    if (crChangeRequestId(id) !== null) {
+      skippedChanges.push(id);
+    } else if (execExecutionId(id) !== null) {
+      if (verdict !== 'approve') skippedApprovals.push(id);
+      else if (!isSafeRisk(riskOf(id) ?? 'high')) skippedRisky.push(id);
+      else act.push(id);
+    } else {
+      act.push(id);
+    }
+  }
+  return { act, skippedRisky, skippedApprovals, skippedChanges };
+}
+
+/** One compact sentence describing what a bulk verdict skipped (empty string
+ *  when nothing was). Kept pure so the copy is unit-testable. */
+export function bulkSkipMessage(outcome: BulkOutcome): string {
+  const parts: string[] = [];
+  const plural = (n: number, s: string, p: string) => (n === 1 ? s : p);
+  if (outcome.skippedApprovals.length > 0)
+    parts.push(
+      `${outcome.skippedApprovals.length} ${plural(outcome.skippedApprovals.length, 'approval', 'approvals')} kept — dismissing doesn't answer the agent; approve or deny ${plural(outcome.skippedApprovals.length, 'it', 'them')}`,
+    );
+  if (outcome.skippedRisky.length > 0)
+    parts.push(
+      `${outcome.skippedRisky.length} risky ${plural(outcome.skippedRisky.length, 'approval', 'approvals')} skipped — review ${plural(outcome.skippedRisky.length, 'it', 'them')} individually`,
+    );
+  if (outcome.skippedChanges.length > 0)
+    parts.push(
+      `${outcome.skippedChanges.length} ${plural(outcome.skippedChanges.length, 'change', 'changes')} skipped — open ${plural(outcome.skippedChanges.length, 'it', 'each')} to review`,
+    );
+  return parts.join('. ');
 }
 
 /** Relative age like "7m", "3h", "2d" — the compact inbox-row idiom (see

--- a/apps/web/src/features/review-center/review-actions.ts
+++ b/apps/web/src/features/review-center/review-actions.ts
@@ -1,0 +1,168 @@
+/**
+ * Pure helpers for acting on adapted review items (Change Requests + executor
+ * approvals) from the inbox. Kept free of React/query so the id-parsing and
+ * URL-building logic — the part worth getting right — is unit-testable.
+ *
+ * Adapted items carry a namespaced id (`cr:<id>` / `exec:<id>`) so the inbox
+ * can route a verdict to the right source instead of the native `/act`
+ * endpoint, which 409s on them by design (see review-center-connected.tsx).
+ */
+
+import { type ReviewItem, type ReviewRisk, isSafeRisk } from './types';
+
+export const CR_ID_PREFIX = 'cr:';
+export const EXEC_ID_PREFIX = 'exec:';
+
+/** Strip the `exec:` namespace prefix, returning the underlying
+ *  `executorExecutions.executionId` that `resolveApproval` expects — or
+ *  `null` if `id` isn't an adapted executor-approval id. */
+export function execExecutionId(id: string): string | null {
+  return id.startsWith(EXEC_ID_PREFIX) ? id.slice(EXEC_ID_PREFIX.length) : null;
+}
+
+/** Strip the `cr:` namespace prefix, returning the underlying Change Request
+ *  id — or `null` if `id` isn't an adapted CR id. */
+export function crChangeRequestId(id: string): string | null {
+  return id.startsWith(CR_ID_PREFIX) ? id.slice(CR_ID_PREFIX.length) : null;
+}
+
+/**
+ * True when the row can show Approve/Deny buttons directly — no modal hop —
+ * because the item resolves to exactly one clear decision: a single-action
+ * executor approval. Multi-action approvals (the prototype's bulk-approval
+ * shape) still need the detail modal, since one button pair can't represent
+ * several independent decisions.
+ */
+export function isQuickDecidableApproval(
+  // `detail` is `unknown` (not `{ actions?: ... }`) so every ReviewItem union
+  // member is assignable — ChangeDetail/OutputDetail have no `actions` and a
+  // weak object type would reject them at the call sites.
+  item: Pick<ReviewItem, 'kind' | 'id'> & { detail?: unknown },
+): boolean {
+  if (item.kind !== 'approval') return false;
+  if (execExecutionId(item.id) === null) return false;
+  const detail = item.detail as { actions?: readonly unknown[] } | undefined;
+  const count = detail?.actions?.length ?? 0;
+  return count <= 1;
+}
+
+/** Build the deep link that lands the user exactly where they can act on an
+ *  item whose source view isn't reachable inline from the inbox — the
+ *  item's originating session. Returns `null` when the item has no
+ *  originating session to link to (nothing to deep-link into). */
+export function itemDeepLink(
+  projectId: string,
+  sessionId: string | undefined | null,
+): string | null {
+  if (!projectId || !sessionId) return null;
+  return `/projects/${projectId}/sessions/${sessionId}`;
+}
+
+/**
+ * Split a set of selected ids into the ones a bulk verdict can cover
+ * natively (`/review/bulk`) vs. ones that need their own per-item resolve
+ * call (executor approvals) vs. ones with no bulk path at all (Change
+ * Requests — merging in bulk needs full diff context per item, so they're
+ * excluded rather than silently no-op'd).
+ */
+export interface BulkActionPlan {
+  native: string[];
+  resolvable: string[];
+  unsupported: string[];
+}
+
+export function planBulkAction(ids: Iterable<string>): BulkActionPlan {
+  const native: string[] = [];
+  const resolvable: string[] = [];
+  const unsupported: string[] = [];
+  for (const id of ids) {
+    if (execExecutionId(id) !== null) resolvable.push(id);
+    else if (crChangeRequestId(id) !== null) unsupported.push(id);
+    else native.push(id);
+  }
+  return { native, resolvable, unsupported };
+}
+
+/**
+ * What a bulk verdict on a connected selection will REALLY do, decided before
+ * any optimistic UI update so the toast/removal can never claim more than the
+ * server was asked. The rules the buckets encode:
+ *  - Executor approvals are a live question to the agent: "dismiss" doesn't
+ *    answer it, so they're KEPT (never mapped to a deny) under any non-approve
+ *    verdict, and an approve sweep still respects the safe-risk floor.
+ *  - Change Requests have no bulk path at all (merging needs the diff in view).
+ */
+export interface BulkOutcome {
+  /** Ids the verdict genuinely acts on — safe to optimistically update. */
+  act: string[];
+  /** Exec approvals blocked by the approve safe-risk floor. */
+  skippedRisky: string[];
+  /** Exec approvals kept under a non-approve verdict (dismiss ≠ deny). */
+  skippedApprovals: string[];
+  /** Change Requests — each needs its own review. */
+  skippedChanges: string[];
+}
+
+export function resolveBulkOutcome(
+  ids: Iterable<string>,
+  verdict: 'approve' | 'dismiss',
+  riskOf: (id: string) => ReviewRisk | undefined,
+): BulkOutcome {
+  const act: string[] = [];
+  const skippedRisky: string[] = [];
+  const skippedApprovals: string[] = [];
+  const skippedChanges: string[] = [];
+  for (const id of ids) {
+    if (crChangeRequestId(id) !== null) {
+      skippedChanges.push(id);
+    } else if (execExecutionId(id) !== null) {
+      if (verdict !== 'approve') skippedApprovals.push(id);
+      else if (!isSafeRisk(riskOf(id) ?? 'high')) skippedRisky.push(id);
+      else act.push(id);
+    } else {
+      act.push(id);
+    }
+  }
+  return { act, skippedRisky, skippedApprovals, skippedChanges };
+}
+
+/** One compact sentence describing what a bulk verdict skipped (empty string
+ *  when nothing was). Kept pure so the copy is unit-testable. */
+export function bulkSkipMessage(outcome: BulkOutcome): string {
+  const parts: string[] = [];
+  const plural = (n: number, s: string, p: string) => (n === 1 ? s : p);
+  if (outcome.skippedApprovals.length > 0)
+    parts.push(
+      `${outcome.skippedApprovals.length} ${plural(outcome.skippedApprovals.length, 'approval', 'approvals')} kept — dismissing doesn't answer the agent; approve or deny ${plural(outcome.skippedApprovals.length, 'it', 'them')}`,
+    );
+  if (outcome.skippedRisky.length > 0)
+    parts.push(
+      `${outcome.skippedRisky.length} risky ${plural(outcome.skippedRisky.length, 'approval', 'approvals')} skipped — review ${plural(outcome.skippedRisky.length, 'it', 'them')} individually`,
+    );
+  if (outcome.skippedChanges.length > 0)
+    parts.push(
+      `${outcome.skippedChanges.length} ${plural(outcome.skippedChanges.length, 'change', 'changes')} skipped — open ${plural(outcome.skippedChanges.length, 'it', 'each')} to review`,
+    );
+  return parts.join('. ');
+}
+
+/** Relative age like "7m", "3h", "2d" — the compact inbox-row idiom (see
+ *  `TimeAgo` in review-center.tsx, which renders this client-only to avoid
+ *  an SSR/hydration mismatch on `Date.now()`). */
+export function formatItemAge(iso: string, now = Date.now()): string {
+  const mins = Math.max(1, Math.round((now - new Date(iso).getTime()) / 60_000));
+  if (mins < 60) return `${mins}m`;
+  const hrs = Math.round(mins / 60);
+  if (hrs < 24) return `${hrs}h`;
+  return `${Math.round(hrs / 24)}d`;
+}
+
+/** Longer relative age with a trailing "ago" — the detail-modal idiom (see
+ *  `rel` in review-detail-modal.tsx). */
+export function formatItemAgeLong(iso: string, now = Date.now()): string {
+  const mins = Math.max(1, Math.round((now - new Date(iso).getTime()) / 60_000));
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.round(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  return `${Math.round(hrs / 24)}d ago`;
+}

--- a/apps/web/src/features/review-center/review-actions.ts
+++ b/apps/web/src/features/review-center/review-actions.ts
@@ -1,0 +1,101 @@
+/**
+ * Pure helpers for acting on adapted review items (Change Requests + executor
+ * approvals) from the inbox. Kept free of React/query so the id-parsing and
+ * URL-building logic — the part worth getting right — is unit-testable.
+ *
+ * Adapted items carry a namespaced id (`cr:<id>` / `exec:<id>`) so the inbox
+ * can route a verdict to the right source instead of the native `/act`
+ * endpoint, which 409s on them by design (see review-center-connected.tsx).
+ */
+
+import type { ReviewItem } from './types';
+
+export const CR_ID_PREFIX = 'cr:';
+export const EXEC_ID_PREFIX = 'exec:';
+
+/** Strip the `exec:` namespace prefix, returning the underlying
+ *  `executorExecutions.executionId` that `resolveApproval` expects — or
+ *  `null` if `id` isn't an adapted executor-approval id. */
+export function execExecutionId(id: string): string | null {
+  return id.startsWith(EXEC_ID_PREFIX) ? id.slice(EXEC_ID_PREFIX.length) : null;
+}
+
+/** Strip the `cr:` namespace prefix, returning the underlying Change Request
+ *  id — or `null` if `id` isn't an adapted CR id. */
+export function crChangeRequestId(id: string): string | null {
+  return id.startsWith(CR_ID_PREFIX) ? id.slice(CR_ID_PREFIX.length) : null;
+}
+
+/**
+ * True when the row can show Approve/Deny buttons directly — no modal hop —
+ * because the item resolves to exactly one clear decision: a single-action
+ * executor approval. Multi-action approvals (the prototype's bulk-approval
+ * shape) still need the detail modal, since one button pair can't represent
+ * several independent decisions.
+ */
+export function isQuickDecidableApproval(
+  item: Pick<ReviewItem, 'kind' | 'id'> & { detail?: { actions?: unknown[] } },
+): boolean {
+  if (item.kind !== 'approval') return false;
+  if (execExecutionId(item.id) === null) return false;
+  const count = item.detail?.actions?.length ?? 0;
+  return count <= 1;
+}
+
+/** Build the deep link that lands the user exactly where they can act on an
+ *  item whose source view isn't reachable inline from the inbox — the
+ *  item's originating session. Returns `null` when the item has no
+ *  originating session to link to (nothing to deep-link into). */
+export function itemDeepLink(
+  projectId: string,
+  sessionId: string | undefined | null,
+): string | null {
+  if (!projectId || !sessionId) return null;
+  return `/projects/${projectId}/sessions/${sessionId}`;
+}
+
+/**
+ * Split a set of selected ids into the ones a bulk verdict can cover
+ * natively (`/review/bulk`) vs. ones that need their own per-item resolve
+ * call (executor approvals) vs. ones with no bulk path at all (Change
+ * Requests — merging in bulk needs full diff context per item, so they're
+ * excluded rather than silently no-op'd).
+ */
+export interface BulkActionPlan {
+  native: string[];
+  resolvable: string[];
+  unsupported: string[];
+}
+
+export function planBulkAction(ids: Iterable<string>): BulkActionPlan {
+  const native: string[] = [];
+  const resolvable: string[] = [];
+  const unsupported: string[] = [];
+  for (const id of ids) {
+    if (execExecutionId(id) !== null) resolvable.push(id);
+    else if (crChangeRequestId(id) !== null) unsupported.push(id);
+    else native.push(id);
+  }
+  return { native, resolvable, unsupported };
+}
+
+/** Relative age like "7m", "3h", "2d" — the compact inbox-row idiom (see
+ *  `TimeAgo` in review-center.tsx, which renders this client-only to avoid
+ *  an SSR/hydration mismatch on `Date.now()`). */
+export function formatItemAge(iso: string, now = Date.now()): string {
+  const mins = Math.max(1, Math.round((now - new Date(iso).getTime()) / 60_000));
+  if (mins < 60) return `${mins}m`;
+  const hrs = Math.round(mins / 60);
+  if (hrs < 24) return `${hrs}h`;
+  return `${Math.round(hrs / 24)}d`;
+}
+
+/** Longer relative age with a trailing "ago" — the detail-modal idiom (see
+ *  `rel` in review-detail-modal.tsx). */
+export function formatItemAgeLong(iso: string, now = Date.now()): string {
+  const mins = Math.max(1, Math.round((now - new Date(iso).getTime()) / 60_000));
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.round(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  return `${Math.round(hrs / 24)}d ago`;
+}

--- a/apps/web/src/features/review-center/review-center-connected.tsx
+++ b/apps/web/src/features/review-center/review-center-connected.tsx
@@ -7,7 +7,10 @@
  * items act through THEIR OWN source flow — a Change Request ships via merge,
  * is dismissed via close, and "request changes" persists the feedback + delivers
  * it to the change's agent (the review `/act` endpoint 409s on adapted ids by
- * design). The presentational inbox (review-center.tsx) is shared with the mock
+ * design). Executor approvals (`exec:`) resolve directly via `resolveApproval` —
+ * the same client call the in-session approval prompt uses
+ * (session-approval-prompt.tsx) — so Approve/Deny work inline in the inbox too.
+ * The presentational inbox (review-center.tsx) is shared with the mock
  * prototype. See docs/REVIEW_CENTER_DESIGN.md.
  */
 
@@ -24,12 +27,16 @@ import { clearStartStash } from '@kortix/sdk/react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import { useMemo } from 'react';
-import { useActReviewItem, useBulkActReviewItems, useReviewItems } from './hooks/use-review-items';
+import {
+  useActReviewItem,
+  useBulkActReviewItems,
+  useResolveReviewApproval,
+  useReviewItems,
+} from './hooks/use-review-items';
 import { mapApiReviewItem } from './map';
+import { crChangeRequestId, execExecutionId, itemDeepLink, planBulkAction } from './review-actions';
 import { ReviewCenter } from './review-center';
-
-const CR_PREFIX = 'cr:';
-const EXEC_PREFIX = 'exec:';
+import { isSafeRisk } from './types';
 
 export function ReviewCenterConnected({
   projectName,
@@ -46,9 +53,10 @@ export function ReviewCenterConnected({
   const qc = useQueryClient();
   const router = useRouter();
   const closeCustomize = useCustomizeStore((s) => s.close);
-  const { data, isLoading, isFetching } = useReviewItems();
+  const { data, isLoading, isFetching, isError, refetch } = useReviewItems();
   const act = useActReviewItem();
   const bulk = useBulkActReviewItems();
+  const resolve = useResolveReviewApproval();
   const merge = useMergeChangeRequest();
   const close = useCloseChangeRequest();
   const requestChanges = useRequestChangesOnChangeRequest();
@@ -78,10 +86,28 @@ export function ReviewCenterConnected({
   const refreshInbox = () => qc.invalidateQueries({ queryKey: ['review-center', projectId] });
 
   function handleAct(id: string, verdict: ReviewVerdict, feedback?: string) {
+    // Executor approvals resolve directly — the same call + payload the
+    // in-session approval prompt uses (resolveApproval, 'once' scope: this
+    // acts on the one call the row represents, not "for the rest of the
+    // session" — that broader grant stays a session-view affordance).
+    const executionId = execExecutionId(id);
+    if (executionId) {
+      resolve.mutate(
+        { executionId, decision: verdict === 'approve' ? 'approve' : 'deny' },
+        {
+          onSuccess: () =>
+            verdict === 'approve'
+              ? successToast('Approved — the agent will continue')
+              : infoToast('Denied'),
+          onError: (e) => errorToast(e.message),
+        },
+      );
+      return;
+    }
     // Change Requests ship/close through their own flow — the review `/act`
     // endpoint 409s on `cr:` ids ("act on this item from its source view").
-    if (id.startsWith(CR_PREFIX)) {
-      const crId = id.slice(CR_PREFIX.length);
+    const crId = crChangeRequestId(id);
+    if (crId) {
       if (verdict === 'approve') {
         merge.mutate(crId, {
           onSuccess: () => {
@@ -124,13 +150,41 @@ export function ReviewCenterConnected({
       }
       return;
     }
-    // Executor approvals resume through the connector flow (KORTIX-207); not yet
-    // actionable from the inbox, so guide rather than throw a 409.
-    if (id.startsWith(EXEC_PREFIX)) {
-      infoToast('Approve tool actions from the connector’s policy view for now.');
-      return;
-    }
     act.mutate({ id, verdict, feedback }, { onError: (e) => errorToast(e.message) });
+  }
+
+  // Bulk (multi-select) verdicts: the presentational layer pre-filters the
+  // selection through `resolveBulkOutcome` (same pure helper), so what
+  // arrives here is already actionable — native ids for any verdict, exec
+  // approvals only under an APPROVE that passed the safe-risk floor. The
+  // guards below are defense in depth, not the primary filter:
+  //  - an executor approval is a live question to the agent; a bulk
+  //    "dismiss" must NEVER answer it with a deny, so exec ids resolve only
+  //    on an explicit approve (single-item Deny goes through handleAct).
+  //  - the safe-risk floor is re-checked before each resolve.
+  //  - Change Requests have no bulk path (merging needs the diff in view).
+  function handleBulkAct(ids: string[], verdict: ReviewVerdict) {
+    const { native, resolvable, unsupported } = planBulkAction(ids);
+    if (native.length > 0) {
+      bulk.mutate({ ids: native, verdict }, { onError: (e) => errorToast(e.message) });
+    }
+    if (resolvable.length > 0 && verdict === 'approve') {
+      const riskById = new Map(items.map((i) => [i.id, i.risk]));
+      for (const id of resolvable) {
+        if (!isSafeRisk(riskById.get(id) ?? 'high')) continue;
+        const executionId = execExecutionId(id);
+        if (executionId)
+          resolve.mutate(
+            { executionId, decision: 'approve' },
+            { onError: (e) => errorToast(e.message) },
+          );
+      }
+    }
+    if (unsupported.length > 0) {
+      infoToast(
+        `${unsupported.length} ${unsupported.length === 1 ? 'change needs' : 'changes need'} its own review — open ${unsupported.length === 1 ? 'it' : 'them'} to ship.`,
+      );
+    }
   }
 
   return (
@@ -138,21 +192,20 @@ export function ReviewCenterConnected({
       initialItems={items}
       isLoading={isLoading}
       isFetching={isFetching}
+      isError={isError}
       sessionLabels={sessionLabels}
       onAct={canAct ? handleAct : undefined}
-      onBulkAct={
-        canAct
-          ? (ids, verdict) =>
-              bulk.mutate({ ids, verdict }, { onError: (e) => errorToast(e.message) })
-          : undefined
-      }
+      onBulkAct={canAct ? handleBulkAct : undefined}
+      onRefresh={() => void refetch()}
       onOpenSession={(sessionId) => {
         // "See progress" only VIEWS the session — feedback delivery goes through
         // the backend now. Clear any stale queued prompt so navigating can't
         // auto-send a leftover message (e.g. from an earlier client-side attempt).
+        const href = itemDeepLink(projectId, sessionId);
+        if (!href) return;
         clearStartStash(sessionId);
         closeCustomize();
-        router.push(`/projects/${projectId}/sessions/${sessionId}`);
+        router.push(href);
       }}
     />
   );

--- a/apps/web/src/features/review-center/review-center-connected.tsx
+++ b/apps/web/src/features/review-center/review-center-connected.tsx
@@ -38,7 +38,16 @@ import { crChangeRequestId, execExecutionId, itemDeepLink, planBulkAction } from
 import { ReviewCenter } from './review-center';
 import { isSafeRisk } from './types';
 
-export function ReviewCenterConnected({ projectName }: { projectName: string }) {
+export function ReviewCenterConnected({
+  projectName,
+  canAct = true,
+}: {
+  projectName: string;
+  // When false (a review.read-only role), withhold the act handlers so the
+  // ReviewCenter renders its inbox read-only — no mutation UI that would 403.
+  // Defaults to true to preserve behavior for callers that don't gate.
+  canAct?: boolean;
+}) {
   const ctx = useProjectContext();
   const projectId = ctx?.projectId ?? '';
   const qc = useQueryClient();
@@ -185,8 +194,8 @@ export function ReviewCenterConnected({ projectName }: { projectName: string }) 
       isFetching={isFetching}
       isError={isError}
       sessionLabels={sessionLabels}
-      onAct={handleAct}
-      onBulkAct={handleBulkAct}
+      onAct={canAct ? handleAct : undefined}
+      onBulkAct={canAct ? handleBulkAct : undefined}
       onRefresh={() => void refetch()}
       onOpenSession={(sessionId) => {
         // "See progress" only VIEWS the session — feedback delivery goes through

--- a/apps/web/src/features/review-center/review-center-connected.tsx
+++ b/apps/web/src/features/review-center/review-center-connected.tsx
@@ -7,7 +7,10 @@
  * items act through THEIR OWN source flow — a Change Request ships via merge,
  * is dismissed via close, and "request changes" persists the feedback + delivers
  * it to the change's agent (the review `/act` endpoint 409s on adapted ids by
- * design). The presentational inbox (review-center.tsx) is shared with the mock
+ * design). Executor approvals (`exec:`) resolve directly via `resolveApproval` —
+ * the same client call the in-session approval prompt uses
+ * (session-approval-prompt.tsx) — so Approve/Deny work inline in the inbox too.
+ * The presentational inbox (review-center.tsx) is shared with the mock
  * prototype. See docs/REVIEW_CENTER_DESIGN.md.
  */
 
@@ -24,12 +27,16 @@ import { clearStartStash } from '@kortix/sdk/react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import { useMemo } from 'react';
-import { useActReviewItem, useBulkActReviewItems, useReviewItems } from './hooks/use-review-items';
+import {
+  useActReviewItem,
+  useBulkActReviewItems,
+  useResolveReviewApproval,
+  useReviewItems,
+} from './hooks/use-review-items';
 import { mapApiReviewItem } from './map';
+import { crChangeRequestId, execExecutionId, itemDeepLink, planBulkAction } from './review-actions';
 import { ReviewCenter } from './review-center';
-
-const CR_PREFIX = 'cr:';
-const EXEC_PREFIX = 'exec:';
+import { isSafeRisk } from './types';
 
 export function ReviewCenterConnected({ projectName }: { projectName: string }) {
   const ctx = useProjectContext();
@@ -37,9 +44,10 @@ export function ReviewCenterConnected({ projectName }: { projectName: string }) 
   const qc = useQueryClient();
   const router = useRouter();
   const closeCustomize = useCustomizeStore((s) => s.close);
-  const { data, isLoading, isFetching } = useReviewItems();
+  const { data, isLoading, isFetching, isError, refetch } = useReviewItems();
   const act = useActReviewItem();
   const bulk = useBulkActReviewItems();
+  const resolve = useResolveReviewApproval();
   const merge = useMergeChangeRequest();
   const close = useCloseChangeRequest();
   const requestChanges = useRequestChangesOnChangeRequest();
@@ -69,10 +77,28 @@ export function ReviewCenterConnected({ projectName }: { projectName: string }) 
   const refreshInbox = () => qc.invalidateQueries({ queryKey: ['review-center', projectId] });
 
   function handleAct(id: string, verdict: ReviewVerdict, feedback?: string) {
+    // Executor approvals resolve directly — the same call + payload the
+    // in-session approval prompt uses (resolveApproval, 'once' scope: this
+    // acts on the one call the row represents, not "for the rest of the
+    // session" — that broader grant stays a session-view affordance).
+    const executionId = execExecutionId(id);
+    if (executionId) {
+      resolve.mutate(
+        { executionId, decision: verdict === 'approve' ? 'approve' : 'deny' },
+        {
+          onSuccess: () =>
+            verdict === 'approve'
+              ? successToast('Approved — the agent will continue')
+              : infoToast('Denied'),
+          onError: (e) => errorToast(e.message),
+        },
+      );
+      return;
+    }
     // Change Requests ship/close through their own flow — the review `/act`
     // endpoint 409s on `cr:` ids ("act on this item from its source view").
-    if (id.startsWith(CR_PREFIX)) {
-      const crId = id.slice(CR_PREFIX.length);
+    const crId = crChangeRequestId(id);
+    if (crId) {
       if (verdict === 'approve') {
         merge.mutate(crId, {
           onSuccess: () => {
@@ -115,13 +141,38 @@ export function ReviewCenterConnected({ projectName }: { projectName: string }) 
       }
       return;
     }
-    // Executor approvals resume through the connector flow (KORTIX-207); not yet
-    // actionable from the inbox, so guide rather than throw a 409.
-    if (id.startsWith(EXEC_PREFIX)) {
-      infoToast('Approve tool actions from the connector’s policy view for now.');
-      return;
-    }
     act.mutate({ id, verdict, feedback }, { onError: (e) => errorToast(e.message) });
+  }
+
+  // Bulk (multi-select) verdicts: split the selection by how each id can
+  // actually be acted on. Native ids go through the batch endpoint; executor
+  // approvals resolve one call each (no bulk endpoint for them, but each is
+  // a real approve/deny — not a no-op); Change Requests have no bulk path
+  // (merging needs full diff context per item) so they're skipped with a
+  // toast rather than silently ignored. Bulk APPROVE of executor approvals
+  // additionally respects "approve all safe" — the same none/low-risk-only
+  // rule the single-item bulk bar already applies (never silently sweep a
+  // risky action through a multi-select); bulk DENY has no such risk floor.
+  function handleBulkAct(ids: string[], verdict: ReviewVerdict) {
+    const { native, resolvable, unsupported } = planBulkAction(ids);
+    if (native.length > 0) {
+      bulk.mutate({ ids: native, verdict }, { onError: (e) => errorToast(e.message) });
+    }
+    if (resolvable.length > 0) {
+      const decision = verdict === 'approve' ? 'approve' : 'deny';
+      const riskById = new Map(items.map((i) => [i.id, i.risk]));
+      for (const id of resolvable) {
+        if (decision === 'approve' && !isSafeRisk(riskById.get(id) ?? 'high')) continue;
+        const executionId = execExecutionId(id);
+        if (executionId)
+          resolve.mutate({ executionId, decision }, { onError: (e) => errorToast(e.message) });
+      }
+    }
+    if (unsupported.length > 0) {
+      infoToast(
+        `${unsupported.length} ${unsupported.length === 1 ? 'change needs' : 'changes need'} its own review — open ${unsupported.length === 1 ? 'it' : 'them'} to ship.`,
+      );
+    }
   }
 
   return (
@@ -129,18 +180,20 @@ export function ReviewCenterConnected({ projectName }: { projectName: string }) 
       initialItems={items}
       isLoading={isLoading}
       isFetching={isFetching}
+      isError={isError}
       sessionLabels={sessionLabels}
       onAct={handleAct}
-      onBulkAct={(ids, verdict) =>
-        bulk.mutate({ ids, verdict }, { onError: (e) => errorToast(e.message) })
-      }
+      onBulkAct={handleBulkAct}
+      onRefresh={() => void refetch()}
       onOpenSession={(sessionId) => {
         // "See progress" only VIEWS the session — feedback delivery goes through
         // the backend now. Clear any stale queued prompt so navigating can't
         // auto-send a leftover message (e.g. from an earlier client-side attempt).
+        const href = itemDeepLink(projectId, sessionId);
+        if (!href) return;
         clearStartStash(sessionId);
         closeCustomize();
-        router.push(`/projects/${projectId}/sessions/${sessionId}`);
+        router.push(href);
       }}
     />
   );

--- a/apps/web/src/features/review-center/review-center-connected.tsx
+++ b/apps/web/src/features/review-center/review-center-connected.tsx
@@ -31,7 +31,16 @@ import { ReviewCenter } from './review-center';
 const CR_PREFIX = 'cr:';
 const EXEC_PREFIX = 'exec:';
 
-export function ReviewCenterConnected({ projectName }: { projectName: string }) {
+export function ReviewCenterConnected({
+  projectName,
+  canAct = true,
+}: {
+  projectName: string;
+  // When false (a review.read-only role), withhold the act handlers so the
+  // ReviewCenter renders its inbox read-only — no mutation UI that would 403.
+  // Defaults to true to preserve behavior for callers that don't gate.
+  canAct?: boolean;
+}) {
   const ctx = useProjectContext();
   const projectId = ctx?.projectId ?? '';
   const qc = useQueryClient();
@@ -130,9 +139,12 @@ export function ReviewCenterConnected({ projectName }: { projectName: string }) 
       isLoading={isLoading}
       isFetching={isFetching}
       sessionLabels={sessionLabels}
-      onAct={handleAct}
-      onBulkAct={(ids, verdict) =>
-        bulk.mutate({ ids, verdict }, { onError: (e) => errorToast(e.message) })
+      onAct={canAct ? handleAct : undefined}
+      onBulkAct={
+        canAct
+          ? (ids, verdict) =>
+              bulk.mutate({ ids, verdict }, { onError: (e) => errorToast(e.message) })
+          : undefined
       }
       onOpenSession={(sessionId) => {
         // "See progress" only VIEWS the session — feedback delivery goes through

--- a/apps/web/src/features/review-center/review-center-connected.tsx
+++ b/apps/web/src/features/review-center/review-center-connected.tsx
@@ -144,28 +144,31 @@ export function ReviewCenterConnected({ projectName }: { projectName: string }) 
     act.mutate({ id, verdict, feedback }, { onError: (e) => errorToast(e.message) });
   }
 
-  // Bulk (multi-select) verdicts: split the selection by how each id can
-  // actually be acted on. Native ids go through the batch endpoint; executor
-  // approvals resolve one call each (no bulk endpoint for them, but each is
-  // a real approve/deny — not a no-op); Change Requests have no bulk path
-  // (merging needs full diff context per item) so they're skipped with a
-  // toast rather than silently ignored. Bulk APPROVE of executor approvals
-  // additionally respects "approve all safe" — the same none/low-risk-only
-  // rule the single-item bulk bar already applies (never silently sweep a
-  // risky action through a multi-select); bulk DENY has no such risk floor.
+  // Bulk (multi-select) verdicts: the presentational layer pre-filters the
+  // selection through `resolveBulkOutcome` (same pure helper), so what
+  // arrives here is already actionable — native ids for any verdict, exec
+  // approvals only under an APPROVE that passed the safe-risk floor. The
+  // guards below are defense in depth, not the primary filter:
+  //  - an executor approval is a live question to the agent; a bulk
+  //    "dismiss" must NEVER answer it with a deny, so exec ids resolve only
+  //    on an explicit approve (single-item Deny goes through handleAct).
+  //  - the safe-risk floor is re-checked before each resolve.
+  //  - Change Requests have no bulk path (merging needs the diff in view).
   function handleBulkAct(ids: string[], verdict: ReviewVerdict) {
     const { native, resolvable, unsupported } = planBulkAction(ids);
     if (native.length > 0) {
       bulk.mutate({ ids: native, verdict }, { onError: (e) => errorToast(e.message) });
     }
-    if (resolvable.length > 0) {
-      const decision = verdict === 'approve' ? 'approve' : 'deny';
+    if (resolvable.length > 0 && verdict === 'approve') {
       const riskById = new Map(items.map((i) => [i.id, i.risk]));
       for (const id of resolvable) {
-        if (decision === 'approve' && !isSafeRisk(riskById.get(id) ?? 'high')) continue;
+        if (!isSafeRisk(riskById.get(id) ?? 'high')) continue;
         const executionId = execExecutionId(id);
         if (executionId)
-          resolve.mutate({ executionId, decision }, { onError: (e) => errorToast(e.message) });
+          resolve.mutate(
+            { executionId, decision: 'approve' },
+            { onError: (e) => errorToast(e.message) },
+          );
       }
     }
     if (unsupported.length > 0) {

--- a/apps/web/src/features/review-center/review-center-connected.tsx
+++ b/apps/web/src/features/review-center/review-center-connected.tsx
@@ -7,7 +7,10 @@
  * items act through THEIR OWN source flow — a Change Request ships via merge,
  * is dismissed via close, and "request changes" persists the feedback + delivers
  * it to the change's agent (the review `/act` endpoint 409s on adapted ids by
- * design). The presentational inbox (review-center.tsx) is shared with the mock
+ * design). Executor approvals (`exec:`) resolve directly via `resolveApproval` —
+ * the same client call the in-session approval prompt uses
+ * (session-approval-prompt.tsx) — so Approve/Deny work inline in the inbox too.
+ * The presentational inbox (review-center.tsx) is shared with the mock
  * prototype. See docs/REVIEW_CENTER_DESIGN.md.
  */
 
@@ -24,12 +27,16 @@ import { clearStartStash } from '@kortix/sdk/react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import { useMemo } from 'react';
-import { useActReviewItem, useBulkActReviewItems, useReviewItems } from './hooks/use-review-items';
+import {
+  useActReviewItem,
+  useBulkActReviewItems,
+  useResolveReviewApproval,
+  useReviewItems,
+} from './hooks/use-review-items';
 import { mapApiReviewItem } from './map';
+import { crChangeRequestId, execExecutionId, itemDeepLink, planBulkAction } from './review-actions';
 import { ReviewCenter } from './review-center';
-
-const CR_PREFIX = 'cr:';
-const EXEC_PREFIX = 'exec:';
+import { isSafeRisk } from './types';
 
 export function ReviewCenterConnected({ projectName }: { projectName: string }) {
   const ctx = useProjectContext();
@@ -37,9 +44,10 @@ export function ReviewCenterConnected({ projectName }: { projectName: string }) 
   const qc = useQueryClient();
   const router = useRouter();
   const closeCustomize = useCustomizeStore((s) => s.close);
-  const { data, isLoading, isFetching } = useReviewItems();
+  const { data, isLoading, isFetching, isError, refetch } = useReviewItems();
   const act = useActReviewItem();
   const bulk = useBulkActReviewItems();
+  const resolve = useResolveReviewApproval();
   const merge = useMergeChangeRequest();
   const close = useCloseChangeRequest();
   const requestChanges = useRequestChangesOnChangeRequest();
@@ -69,10 +77,28 @@ export function ReviewCenterConnected({ projectName }: { projectName: string }) 
   const refreshInbox = () => qc.invalidateQueries({ queryKey: ['review-center', projectId] });
 
   function handleAct(id: string, verdict: ReviewVerdict, feedback?: string) {
+    // Executor approvals resolve directly — the same call + payload the
+    // in-session approval prompt uses (resolveApproval, 'once' scope: this
+    // acts on the one call the row represents, not "for the rest of the
+    // session" — that broader grant stays a session-view affordance).
+    const executionId = execExecutionId(id);
+    if (executionId) {
+      resolve.mutate(
+        { executionId, decision: verdict === 'approve' ? 'approve' : 'deny' },
+        {
+          onSuccess: () =>
+            verdict === 'approve'
+              ? successToast('Approved — the agent will continue')
+              : infoToast('Denied'),
+          onError: (e) => errorToast(e.message),
+        },
+      );
+      return;
+    }
     // Change Requests ship/close through their own flow — the review `/act`
     // endpoint 409s on `cr:` ids ("act on this item from its source view").
-    if (id.startsWith(CR_PREFIX)) {
-      const crId = id.slice(CR_PREFIX.length);
+    const crId = crChangeRequestId(id);
+    if (crId) {
       if (verdict === 'approve') {
         merge.mutate(crId, {
           onSuccess: () => {
@@ -115,13 +141,41 @@ export function ReviewCenterConnected({ projectName }: { projectName: string }) 
       }
       return;
     }
-    // Executor approvals resume through the connector flow (KORTIX-207); not yet
-    // actionable from the inbox, so guide rather than throw a 409.
-    if (id.startsWith(EXEC_PREFIX)) {
-      infoToast('Approve tool actions from the connector’s policy view for now.');
-      return;
-    }
     act.mutate({ id, verdict, feedback }, { onError: (e) => errorToast(e.message) });
+  }
+
+  // Bulk (multi-select) verdicts: the presentational layer pre-filters the
+  // selection through `resolveBulkOutcome` (same pure helper), so what
+  // arrives here is already actionable — native ids for any verdict, exec
+  // approvals only under an APPROVE that passed the safe-risk floor. The
+  // guards below are defense in depth, not the primary filter:
+  //  - an executor approval is a live question to the agent; a bulk
+  //    "dismiss" must NEVER answer it with a deny, so exec ids resolve only
+  //    on an explicit approve (single-item Deny goes through handleAct).
+  //  - the safe-risk floor is re-checked before each resolve.
+  //  - Change Requests have no bulk path (merging needs the diff in view).
+  function handleBulkAct(ids: string[], verdict: ReviewVerdict) {
+    const { native, resolvable, unsupported } = planBulkAction(ids);
+    if (native.length > 0) {
+      bulk.mutate({ ids: native, verdict }, { onError: (e) => errorToast(e.message) });
+    }
+    if (resolvable.length > 0 && verdict === 'approve') {
+      const riskById = new Map(items.map((i) => [i.id, i.risk]));
+      for (const id of resolvable) {
+        if (!isSafeRisk(riskById.get(id) ?? 'high')) continue;
+        const executionId = execExecutionId(id);
+        if (executionId)
+          resolve.mutate(
+            { executionId, decision: 'approve' },
+            { onError: (e) => errorToast(e.message) },
+          );
+      }
+    }
+    if (unsupported.length > 0) {
+      infoToast(
+        `${unsupported.length} ${unsupported.length === 1 ? 'change needs' : 'changes need'} its own review — open ${unsupported.length === 1 ? 'it' : 'them'} to ship.`,
+      );
+    }
   }
 
   return (
@@ -129,18 +183,20 @@ export function ReviewCenterConnected({ projectName }: { projectName: string }) 
       initialItems={items}
       isLoading={isLoading}
       isFetching={isFetching}
+      isError={isError}
       sessionLabels={sessionLabels}
       onAct={handleAct}
-      onBulkAct={(ids, verdict) =>
-        bulk.mutate({ ids, verdict }, { onError: (e) => errorToast(e.message) })
-      }
+      onBulkAct={handleBulkAct}
+      onRefresh={() => void refetch()}
       onOpenSession={(sessionId) => {
         // "See progress" only VIEWS the session — feedback delivery goes through
         // the backend now. Clear any stale queued prompt so navigating can't
         // auto-send a leftover message (e.g. from an earlier client-side attempt).
+        const href = itemDeepLink(projectId, sessionId);
+        if (!href) return;
         clearStartStash(sessionId);
         closeCustomize();
-        router.push(`/projects/${projectId}/sessions/${sessionId}`);
+        router.push(href);
       }}
     />
   );

--- a/apps/web/src/features/review-center/review-center.tsx
+++ b/apps/web/src/features/review-center/review-center.tsx
@@ -19,8 +19,10 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import Hint from '@/components/ui/hint';
 import { Input } from '@/components/ui/input';
 import { Kbd } from '@/components/ui/kbd';
+import Loading from '@/components/ui/loading';
 import { Modal, ModalBody, ModalContent, ModalHeader, ModalTitle } from '@/components/ui/modal';
 import { Skeleton } from '@/components/ui/skeleton';
 import { StatusBadge } from '@/components/ui/status';
@@ -33,6 +35,7 @@ import {
 } from '@/components/ui/tabs';
 import { infoToast, successToast } from '@/components/ui/toast';
 import { EmptyState } from '@/features/layout/section/empty-state';
+import { ErrorState } from '@/features/layout/section/error-state';
 import { cn } from '@/lib/utils';
 import type { ReviewVerdict } from '@kortix/sdk/projects-client';
 import { CheckCircleSolid, InboxSolid, ShieldCheckSolid, X } from '@mynaui/icons-react';
@@ -41,6 +44,7 @@ import { AnimatePresence, motion, useReducedMotion } from 'motion/react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { statusToVerdict } from './map';
 import { MOCK_ITEMS } from './mock-data';
+import { formatItemAge, isQuickDecidableApproval } from './review-actions';
 import { type ReviewActions, ReviewDetailModal } from './review-detail-modal';
 import { KIND_META, RISK_BAR, RISK_META, SOURCE_META, STATUS_META } from './review-meta';
 import {
@@ -59,14 +63,6 @@ import { type ReviewItem, type ReviewKind, type ReviewSegment, segmentForStatus 
 /** Calm, premium easing for the inbox's enter/exit/layout motion. */
 const EASE = [0.2, 0, 0, 1] as const;
 
-function rel(iso: string): string {
-  const mins = Math.max(1, Math.round((Date.now() - new Date(iso).getTime()) / 60_000));
-  if (mins < 60) return `${mins}m`;
-  const hrs = Math.round(mins / 60);
-  if (hrs < 24) return `${hrs}h`;
-  return `${Math.round(hrs / 24)}d`;
-}
-
 /**
  * Relative time is client-only: it depends on `Date.now()`, which differs between
  * the server render and hydration. Render nothing until mounted so SSR and the
@@ -75,7 +71,7 @@ function rel(iso: string): string {
 function TimeAgo({ iso }: { iso: string }) {
   const [mounted, setMounted] = useState(false);
   useEffect(() => setMounted(true), []);
-  return <span className="tabular-nums">{mounted ? rel(iso) : ''}</span>;
+  return <span className="tabular-nums">{mounted ? formatItemAge(iso) : ''}</span>;
 }
 
 /** A count that rolls when it changes — the satisfying tick as you clear the inbox. */
@@ -134,8 +130,13 @@ function ItemRow({
   showCheck,
   fresh,
   reduce,
+  quickDecidable,
+  pendingDecision,
+  sessionLabel,
   onOpen,
   onToggleSelect,
+  onQuickApprove,
+  onQuickDeny,
 }: {
   item: ReviewItem;
   idx: number;
@@ -146,13 +147,25 @@ function ItemRow({
   fresh: boolean;
   /** prefers-reduced-motion: collapse enter/stagger to instant. */
   reduce: boolean;
+  /** A single-action approval with a real client-side resolve path (an
+   *  executor approval) — show Approve/Deny right on the row, no modal hop. */
+  quickDecidable: boolean;
+  /** 'approve' | 'deny' while this row's own resolve mutation is in flight. */
+  pendingDecision?: 'approve' | 'deny' | null;
+  /** The item's originating session name, when known — shown inline so a
+   *  Change Request or approval's origin is legible without opening it.
+   *  Omitted in the grouped view (the session already names the group). */
+  sessionLabel?: string;
   onOpen: () => void;
   onToggleSelect: () => void;
+  onQuickApprove?: () => void;
+  onQuickDeny?: () => void;
 }) {
   const kind = KIND_META[item.kind];
   const Source = SOURCE_META[item.source];
   const segment = segmentForStatus(item.status);
   const risk = RISK_META[item.risk];
+  const busy = !!pendingDecision;
   // Left accent bar: kind tone by default; in Needs-you it escalates to the
   // risk tone for medium/high so risky work glows at the row's edge.
   const barClass =
@@ -228,14 +241,32 @@ function ItemRow({
           <span className="text-muted-foreground/70 font-medium">{kind.label}</span>
           {item.summary ? <span className="text-muted-foreground/40"> · </span> : null}
           {item.summary}
+          {sessionLabel ? <span className="text-muted-foreground/40"> · </span> : null}
+          {sessionLabel}
         </div>
       </button>
 
-      <div className="flex shrink-0 items-center gap-2">
+      <div className="flex shrink-0 items-center gap-1.5">
         {segment === 'needs_you' ? (
-          <Button size="sm" variant="secondary" onClick={onOpen}>
-            {item.primaryAction}
-          </Button>
+          quickDecidable ? (
+            <>
+              <Button size="sm" variant="ghost" disabled={busy} onClick={onQuickDeny}>
+                {pendingDecision === 'deny' ? <Loading className="size-3.5 shrink-0" /> : null}
+                Deny
+              </Button>
+              <Button size="sm" variant="secondary" disabled={busy} onClick={onQuickApprove}>
+                {pendingDecision === 'approve' ? <Loading className="size-3.5 shrink-0" /> : null}
+                Approve
+              </Button>
+            </>
+          ) : (
+            <Button size="sm" variant="secondary" onClick={onOpen}>
+              {/* "Ship it" reads as instant-merge, but this only opens the
+                  detail (the modal's own button ships) — label the row
+                  action for what it does: open the full diff to decide. */}
+              {item.kind === 'change' ? 'Review' : item.primaryAction}
+            </Button>
+          )
         ) : (
           <Badge variant={STATUS_META[item.status].badge} size="sm">
             {STATUS_META[item.status].label}
@@ -277,8 +308,10 @@ export function ReviewCenter({
   onAct,
   onBulkAct,
   onOpenSession,
+  onRefresh,
   isLoading,
   isFetching,
+  isError,
   sessionLabels,
 }: {
   /** When provided, the inbox renders real data instead of the mock fixtures. */
@@ -289,9 +322,15 @@ export function ReviewCenter({
   onBulkAct?: (ids: string[], verdict: ReviewVerdict) => void;
   /** Connected mode: open a session (e.g. to watch the agent revise a change). */
   onOpenSession?: (sessionId: string) => void;
+  /** Connected mode: force an immediate poll instead of waiting for the
+   *  interval — the "Live" indicator doubles as this refresh affordance. */
+  onRefresh?: () => void;
   isLoading?: boolean;
   /** A background poll is in flight — drives the "Live" refreshing affordance. */
   isFetching?: boolean;
+  /** The initial/only load failed — show a retry state instead of an empty
+   *  inbox (an empty list and a failed fetch must never look the same). */
+  isError?: boolean;
   /** sessionId → human name, for the per-session filter + group headers. */
   sessionLabels?: Record<string, string>;
 } = {}) {
@@ -317,6 +356,12 @@ export function ReviewCenter({
   const knownIdsRef = useRef<Set<string> | null>(null);
   const [freshIds, setFreshIds] = useState<Set<string>>(new Set());
   const markSeen = () => setFreshIds((prev) => (prev.size ? new Set() : prev));
+  // The single item id currently mid-mutation (row quick-decide or the detail
+  // modal's approve/deny) + which verdict, so the row/modal button that fired
+  // it — and only that one — shows `Loading` while connected. Cleared on the
+  // next `initialItems` reconciliation (the refetch that follows a mutation).
+  const [pendingId, setPendingId] = useState<string | null>(null);
+  const [pendingDecision, setPendingDecision] = useState<'approve' | 'deny' | null>(null);
 
   const undoRef = useRef<ReviewItem[] | null>(null);
   // Query root for scroll-into-view — a container of the [data-idx] rows. It wraps
@@ -377,9 +422,15 @@ export function ReviewCenter({
       ?.scrollIntoView({ block: 'nearest' });
   }, [focusedIdx]);
 
-  // Connected mode: reconcile with the server list as it (re)loads.
+  // Connected mode: reconcile with the server list as it (re)loads. Each
+  // reconciliation is also the "settled" signal for a row/modal quick-decide
+  // mutation (there's no per-call settle callback threaded through `apply`),
+  // so clear the pending marker here rather than leave a button spinning
+  // forever if the item already left the list (e.g. a stale poll raced it).
   useEffect(() => {
     if (initialItems) setItems(initialItems);
+    setPendingId(null);
+    setPendingDecision(null);
   }, [initialItems]);
 
   // Detect items that arrived since the user last looked → flag them "fresh".
@@ -450,6 +501,10 @@ export function ReviewCenter({
   const actions: ReviewActions = {
     resolve: (id, status, message, feedback) => {
       const verdict = statusToVerdict(status);
+      if (connected && (status === 'approved' || status === 'rejected')) {
+        setPendingId(id);
+        setPendingDecision(status === 'approved' ? 'approve' : 'deny');
+      }
       apply(
         setStatus(items, id, status),
         message ?? 'Updated',
@@ -462,11 +517,30 @@ export function ReviewCenter({
     approveAllSafe: (itemId) => setItems(approveAllSafe(items, itemId)),
     openSession: onOpenSession,
     connected,
+    pendingId,
+    pendingDecision,
+  };
+
+  /** Row-level Approve/Deny for a single-action executor approval — resolves
+   *  it directly via `actions.resolve`, no modal hop. */
+  const quickDecide = (item: ReviewItem, decision: 'approve' | 'deny') => {
+    actions.resolve(
+      item.id,
+      decision === 'approve' ? 'approved' : 'rejected',
+      decision === 'approve' ? 'Approved — the agent will continue' : 'Denied',
+    );
   };
 
   const quickPrimary = (item: ReviewItem) => {
-    if (item.kind === 'approval' || item.kind === 'decision') {
-      setSelectedId(item.id); // needs a choice — open the detail
+    if (connected && isQuickDecidableApproval(item)) {
+      quickDecide(item, 'approve');
+      return;
+    }
+    // Change Requests never one-click-ship from the inbox, even via the `a`
+    // shortcut — merging needs the full diff in view, so this always opens
+    // the detail (its "Ship it" button is the real merge action).
+    if (item.kind === 'approval' || item.kind === 'decision' || item.kind === 'change') {
+      setSelectedId(item.id); // needs a choice / full context — open the detail
       return;
     }
     apply(
@@ -478,6 +552,10 @@ export function ReviewCenter({
   };
 
   const quickAskChanges = (item: ReviewItem) => {
+    if (connected && isQuickDecidableApproval(item)) {
+      quickDecide(item, 'deny');
+      return;
+    }
     if (item.kind === 'change' || item.kind === 'output') {
       apply(
         setStatus(items, item.id, 'changes_requested'),
@@ -674,18 +752,22 @@ export function ReviewCenter({
                 </TabsList>
               </Tabs>
               {connected && (
-                <span
-                  className="text-muted-foreground/70 hidden shrink-0 items-center gap-1.5 text-xs sm:flex"
-                  title={isFetching ? 'Refreshing…' : 'Live — auto-updating as agents work'}
-                >
-                  <span
-                    className={cn(
-                      'bg-kortix-green size-1.5 rounded-full',
-                      isFetching && !reduce && 'animate-pulse',
-                    )}
-                  />
-                  Live
-                </span>
+                <Hint label={isFetching ? 'Refreshing…' : 'Auto-updating — click to refresh now'}>
+                  <button
+                    type="button"
+                    onClick={onRefresh}
+                    disabled={!onRefresh || isFetching}
+                    className="text-muted-foreground/70 hover:text-foreground disabled:hover:text-muted-foreground/70 hidden shrink-0 items-center gap-1.5 text-xs transition-colors sm:flex"
+                  >
+                    <span
+                      className={cn(
+                        'bg-kortix-green size-1.5 rounded-full',
+                        isFetching && !reduce && 'animate-pulse',
+                      )}
+                    />
+                    Live
+                  </button>
+                </Hint>
               )}
             </div>
 
@@ -781,9 +863,10 @@ export function ReviewCenter({
             )}
 
             {/* Bulk bar (safe approvals across the current view). Prototype-only:
-                connected-mode approvals are executor-adapted (exec:) and resume
-                via the session's connector prompt, so there's no inbox bulk path
-                to approve them yet (KORTIX-207) — hide rather than fake it. */}
+                connected mode already surfaces "approve all safe" per-item via
+                each approval's own inline Approve/Deny + the floating
+                multi-select bar below, so this global banner would be a
+                second, redundant safe-approve entry point there. */}
             <AnimatePresence initial={false}>
               {!connected &&
                 segment === 'needs_you' &&
@@ -812,7 +895,21 @@ export function ReviewCenter({
           </div>
 
           {/* List */}
-          {isLoading && items.length === 0 ? (
+          {isError && items.length === 0 ? (
+            <div className="pt-6">
+              <ErrorState
+                size="sm"
+                title="Couldn't load the review inbox"
+                description="Check your connection and try again."
+                action={
+                  <Button variant="outline" size="sm" onClick={onRefresh} disabled={isFetching}>
+                    {isFetching ? <Loading className="size-3.5 shrink-0" /> : null}
+                    Retry
+                  </Button>
+                }
+              />
+            </div>
+          ) : isLoading && items.length === 0 ? (
             <ul className="space-y-2">
               {['a', 'b', 'c', 'd'].map((k) => (
                 <li key={k}>
@@ -892,8 +989,12 @@ export function ReviewCenter({
                           showCheck={selectionCount > 0}
                           fresh={freshIds.has(item.id)}
                           reduce={reduce}
+                          quickDecidable={connected && isQuickDecidableApproval(item)}
+                          pendingDecision={pendingId === item.id ? pendingDecision : null}
                           onOpen={() => setSelectedId(item.id)}
                           onToggleSelect={() => toggleSelect(item.id)}
+                          onQuickApprove={() => quickDecide(item, 'approve')}
+                          onQuickDeny={() => quickDecide(item, 'deny')}
                         />
                       );
                     })}
@@ -922,8 +1023,13 @@ export function ReviewCenter({
                   showCheck={selectionCount > 0}
                   fresh={freshIds.has(item.id)}
                   reduce={reduce}
+                  quickDecidable={connected && isQuickDecidableApproval(item)}
+                  pendingDecision={pendingId === item.id ? pendingDecision : null}
+                  sessionLabel={item.sessionId ? labelFor(item.sessionId) : undefined}
                   onOpen={() => setSelectedId(item.id)}
                   onToggleSelect={() => toggleSelect(item.id)}
+                  onQuickApprove={() => quickDecide(item, 'approve')}
+                  onQuickDeny={() => quickDecide(item, 'deny')}
                 />
               ))}
             </ul>

--- a/apps/web/src/features/review-center/review-center.tsx
+++ b/apps/web/src/features/review-center/review-center.tsx
@@ -44,7 +44,12 @@ import { AnimatePresence, motion, useReducedMotion } from 'motion/react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { statusToVerdict } from './map';
 import { MOCK_ITEMS } from './mock-data';
-import { formatItemAge, isQuickDecidableApproval } from './review-actions';
+import {
+  bulkSkipMessage,
+  formatItemAge,
+  isQuickDecidableApproval,
+  resolveBulkOutcome,
+} from './review-actions';
 import { type ReviewActions, ReviewDetailModal } from './review-detail-modal';
 import { KIND_META, RISK_BAR, RISK_META, SOURCE_META, STATUS_META } from './review-meta';
 import {
@@ -568,8 +573,32 @@ export function ReviewCenter({
     }
   };
 
+  /** Connected mode: decide up-front what the verdict will really act on so
+   *  the optimistic removal + toast never claim more than the server was
+   *  asked (exec approvals are never denied by a dismiss; risky approvals
+   *  survive an approve sweep; CRs each need their own review). */
+  const connectedBulkOutcome = (ids: string[], verdict: 'approve' | 'dismiss') => {
+    const riskById = new Map(items.map((i) => [i.id, i.risk]));
+    return resolveBulkOutcome(ids, verdict, (id) => riskById.get(id));
+  };
+
   const dismissIds = (ids: string[]) => {
     if (ids.length === 0) return;
+    if (connected && onBulkAct) {
+      const outcome = connectedBulkOutcome(ids, 'dismiss');
+      const skipped = bulkSkipMessage(outcome);
+      if (skipped) infoToast(skipped);
+      if (outcome.act.length > 0) {
+        apply(
+          bulkSetStatus(items, outcome.act, 'dismissed'),
+          `Dismissed ${outcome.act.length}`,
+          'info',
+          () => onBulkAct(outcome.act, 'dismiss'),
+        );
+      }
+      setSelectedIds(new Set());
+      return;
+    }
     apply(
       bulkSetStatus(items, ids, 'dismissed'),
       `Dismissed ${ids.length}`,
@@ -581,6 +610,21 @@ export function ReviewCenter({
 
   const approveIds = (ids: string[]) => {
     if (ids.length === 0) return;
+    if (connected && onBulkAct) {
+      const outcome = connectedBulkOutcome(ids, 'approve');
+      const skipped = bulkSkipMessage(outcome);
+      if (skipped) infoToast(skipped);
+      if (outcome.act.length > 0) {
+        apply(
+          bulkSetStatus(items, outcome.act, 'approved'),
+          `Approved ${outcome.act.length}`,
+          'success',
+          () => onBulkAct(outcome.act, 'approve'),
+        );
+      }
+      setSelectedIds(new Set());
+      return;
+    }
     let next = items;
     for (const id of ids) {
       const it = items.find((x) => x.id === id);

--- a/apps/web/src/features/review-center/review-center.tsx
+++ b/apps/web/src/features/review-center/review-center.tsx
@@ -19,8 +19,10 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import Hint from '@/components/ui/hint';
 import { Input } from '@/components/ui/input';
 import { Kbd } from '@/components/ui/kbd';
+import Loading from '@/components/ui/loading';
 import { Modal, ModalBody, ModalContent, ModalHeader, ModalTitle } from '@/components/ui/modal';
 import { Skeleton } from '@/components/ui/skeleton';
 import { StatusBadge } from '@/components/ui/status';
@@ -33,6 +35,7 @@ import {
 } from '@/components/ui/tabs';
 import { infoToast, successToast } from '@/components/ui/toast';
 import { EmptyState } from '@/features/layout/section/empty-state';
+import { ErrorState } from '@/features/layout/section/error-state';
 import { cn } from '@/lib/utils';
 import type { ReviewVerdict } from '@kortix/sdk/projects-client';
 import { CheckCircleSolid, InboxSolid, ShieldCheckSolid, X } from '@mynaui/icons-react';
@@ -41,6 +44,12 @@ import { AnimatePresence, motion, useReducedMotion } from 'motion/react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { statusToVerdict } from './map';
 import { MOCK_ITEMS } from './mock-data';
+import {
+  bulkSkipMessage,
+  formatItemAge,
+  isQuickDecidableApproval,
+  resolveBulkOutcome,
+} from './review-actions';
 import { type ReviewActions, ReviewDetailModal } from './review-detail-modal';
 import { KIND_META, RISK_BAR, RISK_META, SOURCE_META, STATUS_META } from './review-meta';
 import {
@@ -59,14 +68,6 @@ import { type ReviewItem, type ReviewKind, type ReviewSegment, segmentForStatus 
 /** Calm, premium easing for the inbox's enter/exit/layout motion. */
 const EASE = [0.2, 0, 0, 1] as const;
 
-function rel(iso: string): string {
-  const mins = Math.max(1, Math.round((Date.now() - new Date(iso).getTime()) / 60_000));
-  if (mins < 60) return `${mins}m`;
-  const hrs = Math.round(mins / 60);
-  if (hrs < 24) return `${hrs}h`;
-  return `${Math.round(hrs / 24)}d`;
-}
-
 /**
  * Relative time is client-only: it depends on `Date.now()`, which differs between
  * the server render and hydration. Render nothing until mounted so SSR and the
@@ -75,7 +76,7 @@ function rel(iso: string): string {
 function TimeAgo({ iso }: { iso: string }) {
   const [mounted, setMounted] = useState(false);
   useEffect(() => setMounted(true), []);
-  return <span className="tabular-nums">{mounted ? rel(iso) : ''}</span>;
+  return <span className="tabular-nums">{mounted ? formatItemAge(iso) : ''}</span>;
 }
 
 /** A count that rolls when it changes — the satisfying tick as you clear the inbox. */
@@ -134,8 +135,13 @@ function ItemRow({
   showCheck,
   fresh,
   reduce,
+  quickDecidable,
+  pendingDecision,
+  sessionLabel,
   onOpen,
   onToggleSelect,
+  onQuickApprove,
+  onQuickDeny,
 }: {
   item: ReviewItem;
   idx: number;
@@ -146,13 +152,25 @@ function ItemRow({
   fresh: boolean;
   /** prefers-reduced-motion: collapse enter/stagger to instant. */
   reduce: boolean;
+  /** A single-action approval with a real client-side resolve path (an
+   *  executor approval) — show Approve/Deny right on the row, no modal hop. */
+  quickDecidable: boolean;
+  /** 'approve' | 'deny' while this row's own resolve mutation is in flight. */
+  pendingDecision?: 'approve' | 'deny' | null;
+  /** The item's originating session name, when known — shown inline so a
+   *  Change Request or approval's origin is legible without opening it.
+   *  Omitted in the grouped view (the session already names the group). */
+  sessionLabel?: string;
   onOpen: () => void;
   onToggleSelect: () => void;
+  onQuickApprove?: () => void;
+  onQuickDeny?: () => void;
 }) {
   const kind = KIND_META[item.kind];
   const Source = SOURCE_META[item.source];
   const segment = segmentForStatus(item.status);
   const risk = RISK_META[item.risk];
+  const busy = !!pendingDecision;
   // Left accent bar: kind tone by default; in Needs-you it escalates to the
   // risk tone for medium/high so risky work glows at the row's edge.
   const barClass =
@@ -228,14 +246,32 @@ function ItemRow({
           <span className="text-muted-foreground/70 font-medium">{kind.label}</span>
           {item.summary ? <span className="text-muted-foreground/40"> · </span> : null}
           {item.summary}
+          {sessionLabel ? <span className="text-muted-foreground/40"> · </span> : null}
+          {sessionLabel}
         </div>
       </button>
 
-      <div className="flex shrink-0 items-center gap-2">
+      <div className="flex shrink-0 items-center gap-1.5">
         {segment === 'needs_you' ? (
-          <Button size="sm" variant="secondary" onClick={onOpen}>
-            {item.primaryAction}
-          </Button>
+          quickDecidable ? (
+            <>
+              <Button size="sm" variant="ghost" disabled={busy} onClick={onQuickDeny}>
+                {pendingDecision === 'deny' ? <Loading className="size-3.5 shrink-0" /> : null}
+                Deny
+              </Button>
+              <Button size="sm" variant="secondary" disabled={busy} onClick={onQuickApprove}>
+                {pendingDecision === 'approve' ? <Loading className="size-3.5 shrink-0" /> : null}
+                Approve
+              </Button>
+            </>
+          ) : (
+            <Button size="sm" variant="secondary" onClick={onOpen}>
+              {/* "Ship it" reads as instant-merge, but this only opens the
+                  detail (the modal's own button ships) — label the row
+                  action for what it does: open the full diff to decide. */}
+              {item.kind === 'change' ? 'Review' : item.primaryAction}
+            </Button>
+          )
         ) : (
           <Badge variant={STATUS_META[item.status].badge} size="sm">
             {STATUS_META[item.status].label}
@@ -277,8 +313,10 @@ export function ReviewCenter({
   onAct,
   onBulkAct,
   onOpenSession,
+  onRefresh,
   isLoading,
   isFetching,
+  isError,
   sessionLabels,
 }: {
   /** When provided, the inbox renders real data instead of the mock fixtures. */
@@ -289,9 +327,15 @@ export function ReviewCenter({
   onBulkAct?: (ids: string[], verdict: ReviewVerdict) => void;
   /** Connected mode: open a session (e.g. to watch the agent revise a change). */
   onOpenSession?: (sessionId: string) => void;
+  /** Connected mode: force an immediate poll instead of waiting for the
+   *  interval — the "Live" indicator doubles as this refresh affordance. */
+  onRefresh?: () => void;
   isLoading?: boolean;
   /** A background poll is in flight — drives the "Live" refreshing affordance. */
   isFetching?: boolean;
+  /** The initial/only load failed — show a retry state instead of an empty
+   *  inbox (an empty list and a failed fetch must never look the same). */
+  isError?: boolean;
   /** sessionId → human name, for the per-session filter + group headers. */
   sessionLabels?: Record<string, string>;
 } = {}) {
@@ -317,6 +361,12 @@ export function ReviewCenter({
   const knownIdsRef = useRef<Set<string> | null>(null);
   const [freshIds, setFreshIds] = useState<Set<string>>(new Set());
   const markSeen = () => setFreshIds((prev) => (prev.size ? new Set() : prev));
+  // The single item id currently mid-mutation (row quick-decide or the detail
+  // modal's approve/deny) + which verdict, so the row/modal button that fired
+  // it — and only that one — shows `Loading` while connected. Cleared on the
+  // next `initialItems` reconciliation (the refetch that follows a mutation).
+  const [pendingId, setPendingId] = useState<string | null>(null);
+  const [pendingDecision, setPendingDecision] = useState<'approve' | 'deny' | null>(null);
 
   const undoRef = useRef<ReviewItem[] | null>(null);
   // Query root for scroll-into-view — a container of the [data-idx] rows. It wraps
@@ -377,9 +427,15 @@ export function ReviewCenter({
       ?.scrollIntoView({ block: 'nearest' });
   }, [focusedIdx]);
 
-  // Connected mode: reconcile with the server list as it (re)loads.
+  // Connected mode: reconcile with the server list as it (re)loads. Each
+  // reconciliation is also the "settled" signal for a row/modal quick-decide
+  // mutation (there's no per-call settle callback threaded through `apply`),
+  // so clear the pending marker here rather than leave a button spinning
+  // forever if the item already left the list (e.g. a stale poll raced it).
   useEffect(() => {
     if (initialItems) setItems(initialItems);
+    setPendingId(null);
+    setPendingDecision(null);
   }, [initialItems]);
 
   // Detect items that arrived since the user last looked → flag them "fresh".
@@ -450,6 +506,10 @@ export function ReviewCenter({
   const actions: ReviewActions = {
     resolve: (id, status, message, feedback) => {
       const verdict = statusToVerdict(status);
+      if (connected && (status === 'approved' || status === 'rejected')) {
+        setPendingId(id);
+        setPendingDecision(status === 'approved' ? 'approve' : 'deny');
+      }
       apply(
         setStatus(items, id, status),
         message ?? 'Updated',
@@ -462,11 +522,30 @@ export function ReviewCenter({
     approveAllSafe: (itemId) => setItems(approveAllSafe(items, itemId)),
     openSession: onOpenSession,
     connected,
+    pendingId,
+    pendingDecision,
+  };
+
+  /** Row-level Approve/Deny for a single-action executor approval — resolves
+   *  it directly via `actions.resolve`, no modal hop. */
+  const quickDecide = (item: ReviewItem, decision: 'approve' | 'deny') => {
+    actions.resolve(
+      item.id,
+      decision === 'approve' ? 'approved' : 'rejected',
+      decision === 'approve' ? 'Approved — the agent will continue' : 'Denied',
+    );
   };
 
   const quickPrimary = (item: ReviewItem) => {
-    if (item.kind === 'approval' || item.kind === 'decision') {
-      setSelectedId(item.id); // needs a choice — open the detail
+    if (connected && isQuickDecidableApproval(item)) {
+      quickDecide(item, 'approve');
+      return;
+    }
+    // Change Requests never one-click-ship from the inbox, even via the `a`
+    // shortcut — merging needs the full diff in view, so this always opens
+    // the detail (its "Ship it" button is the real merge action).
+    if (item.kind === 'approval' || item.kind === 'decision' || item.kind === 'change') {
+      setSelectedId(item.id); // needs a choice / full context — open the detail
       return;
     }
     apply(
@@ -478,6 +557,10 @@ export function ReviewCenter({
   };
 
   const quickAskChanges = (item: ReviewItem) => {
+    if (connected && isQuickDecidableApproval(item)) {
+      quickDecide(item, 'deny');
+      return;
+    }
     if (item.kind === 'change' || item.kind === 'output') {
       apply(
         setStatus(items, item.id, 'changes_requested'),
@@ -490,8 +573,32 @@ export function ReviewCenter({
     }
   };
 
+  /** Connected mode: decide up-front what the verdict will really act on so
+   *  the optimistic removal + toast never claim more than the server was
+   *  asked (exec approvals are never denied by a dismiss; risky approvals
+   *  survive an approve sweep; CRs each need their own review). */
+  const connectedBulkOutcome = (ids: string[], verdict: 'approve' | 'dismiss') => {
+    const riskById = new Map(items.map((i) => [i.id, i.risk]));
+    return resolveBulkOutcome(ids, verdict, (id) => riskById.get(id));
+  };
+
   const dismissIds = (ids: string[]) => {
     if (ids.length === 0) return;
+    if (connected && onBulkAct) {
+      const outcome = connectedBulkOutcome(ids, 'dismiss');
+      const skipped = bulkSkipMessage(outcome);
+      if (skipped) infoToast(skipped);
+      if (outcome.act.length > 0) {
+        apply(
+          bulkSetStatus(items, outcome.act, 'dismissed'),
+          `Dismissed ${outcome.act.length}`,
+          'info',
+          () => onBulkAct(outcome.act, 'dismiss'),
+        );
+      }
+      setSelectedIds(new Set());
+      return;
+    }
     apply(
       bulkSetStatus(items, ids, 'dismissed'),
       `Dismissed ${ids.length}`,
@@ -503,6 +610,21 @@ export function ReviewCenter({
 
   const approveIds = (ids: string[]) => {
     if (ids.length === 0) return;
+    if (connected && onBulkAct) {
+      const outcome = connectedBulkOutcome(ids, 'approve');
+      const skipped = bulkSkipMessage(outcome);
+      if (skipped) infoToast(skipped);
+      if (outcome.act.length > 0) {
+        apply(
+          bulkSetStatus(items, outcome.act, 'approved'),
+          `Approved ${outcome.act.length}`,
+          'success',
+          () => onBulkAct(outcome.act, 'approve'),
+        );
+      }
+      setSelectedIds(new Set());
+      return;
+    }
     let next = items;
     for (const id of ids) {
       const it = items.find((x) => x.id === id);
@@ -674,18 +796,22 @@ export function ReviewCenter({
                 </TabsList>
               </Tabs>
               {connected && (
-                <span
-                  className="text-muted-foreground/70 hidden shrink-0 items-center gap-1.5 text-xs sm:flex"
-                  title={isFetching ? 'Refreshing…' : 'Live — auto-updating as agents work'}
-                >
-                  <span
-                    className={cn(
-                      'bg-kortix-green size-1.5 rounded-full',
-                      isFetching && !reduce && 'animate-pulse',
-                    )}
-                  />
-                  Live
-                </span>
+                <Hint label={isFetching ? 'Refreshing…' : 'Auto-updating — click to refresh now'}>
+                  <button
+                    type="button"
+                    onClick={onRefresh}
+                    disabled={!onRefresh || isFetching}
+                    className="text-muted-foreground/70 hover:text-foreground disabled:hover:text-muted-foreground/70 hidden shrink-0 items-center gap-1.5 text-xs transition-colors sm:flex"
+                  >
+                    <span
+                      className={cn(
+                        'bg-kortix-green size-1.5 rounded-full',
+                        isFetching && !reduce && 'animate-pulse',
+                      )}
+                    />
+                    Live
+                  </button>
+                </Hint>
               )}
             </div>
 
@@ -781,9 +907,10 @@ export function ReviewCenter({
             )}
 
             {/* Bulk bar (safe approvals across the current view). Prototype-only:
-                connected-mode approvals are executor-adapted (exec:) and resume
-                via the session's connector prompt, so there's no inbox bulk path
-                to approve them yet (KORTIX-207) — hide rather than fake it. */}
+                connected mode already surfaces "approve all safe" per-item via
+                each approval's own inline Approve/Deny + the floating
+                multi-select bar below, so this global banner would be a
+                second, redundant safe-approve entry point there. */}
             <AnimatePresence initial={false}>
               {!connected &&
                 segment === 'needs_you' &&
@@ -812,7 +939,21 @@ export function ReviewCenter({
           </div>
 
           {/* List */}
-          {isLoading && items.length === 0 ? (
+          {isError && items.length === 0 ? (
+            <div className="pt-6">
+              <ErrorState
+                size="sm"
+                title="Couldn't load the review inbox"
+                description="Check your connection and try again."
+                action={
+                  <Button variant="outline" size="sm" onClick={onRefresh} disabled={isFetching}>
+                    {isFetching ? <Loading className="size-3.5 shrink-0" /> : null}
+                    Retry
+                  </Button>
+                }
+              />
+            </div>
+          ) : isLoading && items.length === 0 ? (
             <ul className="space-y-2">
               {['a', 'b', 'c', 'd'].map((k) => (
                 <li key={k}>
@@ -892,8 +1033,12 @@ export function ReviewCenter({
                           showCheck={selectionCount > 0}
                           fresh={freshIds.has(item.id)}
                           reduce={reduce}
+                          quickDecidable={connected && isQuickDecidableApproval(item)}
+                          pendingDecision={pendingId === item.id ? pendingDecision : null}
                           onOpen={() => setSelectedId(item.id)}
                           onToggleSelect={() => toggleSelect(item.id)}
+                          onQuickApprove={() => quickDecide(item, 'approve')}
+                          onQuickDeny={() => quickDecide(item, 'deny')}
                         />
                       );
                     })}
@@ -922,8 +1067,13 @@ export function ReviewCenter({
                   showCheck={selectionCount > 0}
                   fresh={freshIds.has(item.id)}
                   reduce={reduce}
+                  quickDecidable={connected && isQuickDecidableApproval(item)}
+                  pendingDecision={pendingId === item.id ? pendingDecision : null}
+                  sessionLabel={item.sessionId ? labelFor(item.sessionId) : undefined}
                   onOpen={() => setSelectedId(item.id)}
                   onToggleSelect={() => toggleSelect(item.id)}
+                  onQuickApprove={() => quickDecide(item, 'approve')}
+                  onQuickDeny={() => quickDecide(item, 'deny')}
                 />
               ))}
             </ul>

--- a/apps/web/src/features/review-center/review-detail-modal.tsx
+++ b/apps/web/src/features/review-center/review-detail-modal.tsx
@@ -13,6 +13,7 @@ import { Button } from '@/components/ui/button';
 import { Disclosure, DisclosureContent, DisclosureTrigger } from '@/components/ui/disclosure';
 import { InfoBanner } from '@/components/ui/info-banner';
 import { Kbd } from '@/components/ui/kbd';
+import Loading from '@/components/ui/loading';
 import {
   Modal,
   ModalBody,
@@ -34,6 +35,7 @@ import {
 } from '@mynaui/icons-react';
 import { useEffect, useRef, useState } from 'react';
 import { ChangeFilesModal } from './change-files';
+import { formatItemAgeLong } from './review-actions';
 import {
   APPROVAL_ACTION_ICON,
   KIND_META,
@@ -49,17 +51,16 @@ export interface ReviewActions {
   approveAllSafe: (itemId: string) => void;
   /** Open the item's originating session (e.g. to watch the agent revise). */
   openSession?: (sessionId: string) => void;
-  /** Live-data mode. Executor approvals are resolved in-session (KORTIX-207), so
-   *  the inbox guides to the session rather than faking an inline decision. */
+  /** Live-data mode: executor approvals resolve inline via `resolve()` too
+   *  (the same `resolveApproval` call the in-session prompt uses), not just
+   *  native/CR items. */
   connected?: boolean;
-}
-
-function rel(iso: string): string {
-  const mins = Math.max(1, Math.round((Date.now() - new Date(iso).getTime()) / 60_000));
-  if (mins < 60) return `${mins}m ago`;
-  const hrs = Math.round(mins / 60);
-  if (hrs < 24) return `${hrs}h ago`;
-  return `${Math.round(hrs / 24)}d ago`;
+  /** The review item id currently mid-mutation, if any — drives the
+   *  per-item `Loading` state on Approve/Deny while connected. */
+  pendingId?: string | null;
+  /** Which verdict `pendingId`'s in-flight mutation is — so Approve and Deny
+   *  don't both show `Loading` at once. */
+  pendingDecision?: 'approve' | 'deny' | null;
 }
 
 /** A muted bordered panel — the friendly content surface. */
@@ -241,14 +242,16 @@ function ChangeBody({
 function ApprovalActionRow({
   action,
   connected,
+  pending,
   onApprove,
   onDeny,
   onAlwaysAllow,
   onOpenSession,
 }: {
   action: ApprovalAction;
-  /** Live mode: resolve in-session (KORTIX-207), so hide the fake inline verdict. */
   connected?: boolean;
+  /** 'approve' | 'deny' while this row's own mutation is in flight. */
+  pending?: 'approve' | 'deny' | null;
   onApprove: () => void;
   onDeny: () => void;
   onAlwaysAllow: () => void;
@@ -257,6 +260,7 @@ function ApprovalActionRow({
   const Icon = APPROVAL_ACTION_ICON[action.icon];
   const safe = isSafeRisk(action.risk);
   const args = action.argsPreview ?? [];
+  const busy = !!pending;
   return (
     <div className="bg-popover rounded-md border px-4 py-3">
       <div className="flex items-start gap-3">
@@ -305,30 +309,40 @@ function ApprovalActionRow({
             <Badge variant={action.decided === 'approved' ? 'success' : 'destructive'} size="sm">
               {action.decided === 'approved' ? 'Approved' : 'Denied'}
             </Badge>
-          ) : connected ? (
-            // Executor approvals resume in the session's own approval prompt.
-            <Button variant="secondary" size="sm" onClick={onOpenSession} disabled={!onOpenSession}>
-              Approve in session
-              <ArrowUpRight className="size-3.5" />
-            </Button>
           ) : (
             <div className="flex flex-col items-end gap-1.5">
               <div className="flex items-center gap-1.5">
-                <Button variant="ghost" size="sm" onClick={onDeny}>
+                <Button variant="ghost" size="sm" disabled={busy} onClick={onDeny}>
+                  {pending === 'deny' ? <Loading className="size-3.5 shrink-0" /> : null}
                   Deny
                 </Button>
-                <Button size="sm" onClick={onApprove}>
-                  <Check className="size-3.5" />
+                <Button size="sm" disabled={busy} onClick={onApprove}>
+                  {pending === 'approve' ? (
+                    <Loading className="size-3.5 shrink-0" />
+                  ) : (
+                    <Check className="size-3.5" />
+                  )}
                   Approve
                 </Button>
               </div>
-              <button
-                type="button"
-                onClick={onAlwaysAllow}
-                className="text-muted-foreground hover:text-foreground text-xs underline-offset-2 hover:underline"
-              >
-                Always allow this
-              </button>
+              {connected && onOpenSession ? (
+                <button
+                  type="button"
+                  onClick={onOpenSession}
+                  className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1 text-xs underline-offset-2 hover:underline"
+                >
+                  See it in the session
+                  <ArrowUpRight className="size-3" />
+                </button>
+              ) : !connected ? (
+                <button
+                  type="button"
+                  onClick={onAlwaysAllow}
+                  className="text-muted-foreground hover:text-foreground text-xs underline-offset-2 hover:underline"
+                >
+                  Always allow this
+                </button>
+              ) : null}
             </div>
           )}
         </div>
@@ -350,68 +364,65 @@ function ApprovalBody({
     actions.openSession && item.sessionId
       ? () => actions.openSession?.(item.sessionId as string)
       : undefined;
+  // Connected mode resolves each action for real via `resolve()` (routes to
+  // `resolveApproval` — the same call the in-session prompt uses), so the row
+  // pending state is keyed off the shared `pendingId` rather than local proto
+  // state. Prototype mode keeps the instant local `decideAction` + "Always
+  // allow this" full-allow affordance.
   return (
     <>
-      {actions.connected ? (
-        // Live mode: executor approvals are resolved in the session's connector
-        // prompt, not the inbox (KORTIX-207) — guide there rather than fake it.
+      {!actions.connected && safePending.length > 0 && (
         <InfoBanner
-          tone="info"
-          title="Approve these from the session"
+          tone="success"
+          title={`${safePending.length} ${safePending.length === 1 ? 'action is' : 'actions are'} safe to approve together`}
           action={
-            openSession && (
-              <Button size="sm" variant="secondary" onClick={openSession}>
-                Open session
-                <ArrowUpRight className="size-3.5" />
-              </Button>
-            )
+            <Button
+              size="sm"
+              onClick={() => {
+                actions.approveAllSafe(item.id);
+                successToast(`Approved ${safePending.length} safe actions`);
+              }}
+            >
+              Approve all safe
+            </Button>
           }
         >
-          Tool approvals resume in the agent&apos;s own conversation, where you can approve or deny
-          with full context. This is the read-only preview.
+          Reads and low-risk writes. Risky actions stay below for you to decide one by one.
         </InfoBanner>
-      ) : (
-        safePending.length > 0 && (
-          <InfoBanner
-            tone="success"
-            title={`${safePending.length} ${safePending.length === 1 ? 'action is' : 'actions are'} safe to approve together`}
-            action={
-              <Button
-                size="sm"
-                onClick={() => {
-                  actions.approveAllSafe(item.id);
-                  successToast(`Approved ${safePending.length} safe actions`);
-                }}
-              >
-                Approve all safe
-              </Button>
-            }
-          >
-            Reads and low-risk writes. Risky actions stay below for you to decide one by one.
-          </InfoBanner>
-        )
       )}
       <div className="space-y-2">
-        {list.map((a) => (
-          <ApprovalActionRow
-            key={a.id}
-            action={a}
-            connected={actions.connected}
-            onOpenSession={openSession}
-            onApprove={() => {
-              actions.decideAction(item.id, a.id, 'approved');
-              successToast(`Approved · ${a.title}`);
-            }}
-            onDeny={() => {
-              actions.decideAction(item.id, a.id, 'denied');
-              infoToast(`Denied · ${a.title}`);
-            }}
-            onAlwaysAllow={() => {
-              actions.decideAction(item.id, a.id, 'approved');
-              infoToast(`Saved — ${a.connector} ${a.action} won’t ask again`);
-            }}
-          />
-        ))}
+        {list.map((a) => {
+          const busy = actions.connected && actions.pendingId === item.id;
+          return (
+            <ApprovalActionRow
+              key={a.id}
+              action={a}
+              connected={actions.connected}
+              pending={busy ? (actions.pendingDecision ?? 'approve') : null}
+              onOpenSession={openSession}
+              onApprove={() => {
+                if (actions.connected) {
+                  actions.resolve(item.id, 'approved', `Approved · ${a.title}`);
+                  return;
+                }
+                actions.decideAction(item.id, a.id, 'approved');
+                successToast(`Approved · ${a.title}`);
+              }}
+              onDeny={() => {
+                if (actions.connected) {
+                  actions.resolve(item.id, 'rejected', `Denied · ${a.title}`);
+                  return;
+                }
+                actions.decideAction(item.id, a.id, 'denied');
+                infoToast(`Denied · ${a.title}`);
+              }}
+              onAlwaysAllow={() => {
+                actions.decideAction(item.id, a.id, 'approved');
+                infoToast(`Saved — ${a.connector} ${a.action} won’t ask again`);
+              }}
+            />
+          );
+        })}
       </div>
     </>
   );
@@ -617,7 +628,7 @@ function Footer({
     return (
       <ModalFooter className="border-border/60 border-t pt-4">
         <span className="text-muted-foreground mr-auto text-xs">
-          {STATUS_META[item.status].label} · {rel(item.createdAt)}
+          {STATUS_META[item.status].label} · {formatItemAgeLong(item.createdAt)}
         </span>
         <Button variant="outline-ghost" onClick={onClose}>
           Close
@@ -754,7 +765,7 @@ export function ReviewDetailModal({
 
         <ModalBody className="space-y-3">
           <div className="text-muted-foreground text-xs">
-            {item.agent} · {rel(item.createdAt)}
+            {item.agent} · {formatItemAgeLong(item.createdAt)}
           </div>
 
           {item.kind === 'change' && <ChangeBody item={item} actions={actions} onClose={onClose} />}

--- a/apps/web/src/features/review-center/review-detail-modal.tsx
+++ b/apps/web/src/features/review-center/review-detail-modal.tsx
@@ -34,6 +34,8 @@ import {
   SparklesSolid,
 } from '@mynaui/icons-react';
 import { useEffect, useRef, useState } from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
 import { ChangeFilesModal } from './change-files';
 import { formatItemAgeLong } from './review-actions';
 import {
@@ -98,6 +100,72 @@ function SectionLabel({ children }: { children: React.ReactNode }) {
   );
 }
 
+/**
+ * Compact markdown for agent-written descriptions (no Shiki/KaTeX/Mermaid —
+ * same lightweight approach as the session QuestionMarkdown). Styled to the
+ * modal's scale: sm body, small semibold headings, muted code chips.
+ */
+function ReviewMarkdown({ content }: { content: string }) {
+  return (
+    <div className="min-w-0 text-sm">
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        components={{
+          h1: ({ children }) => (
+            <h4 className="text-foreground mt-4 mb-1.5 text-sm font-semibold first:mt-0">
+              {children}
+            </h4>
+          ),
+          h2: ({ children }) => (
+            <h4 className="text-foreground mt-4 mb-1.5 text-sm font-semibold first:mt-0">
+              {children}
+            </h4>
+          ),
+          h3: ({ children }) => (
+            <h5 className="text-foreground mt-3 mb-1 text-sm font-medium first:mt-0">{children}</h5>
+          ),
+          p: ({ children }) => (
+            <p className="text-foreground/90 my-1.5 leading-relaxed text-pretty">{children}</p>
+          ),
+          strong: ({ children }) => (
+            <strong className="text-foreground font-semibold">{children}</strong>
+          ),
+          em: ({ children }) => <em>{children}</em>,
+          ul: ({ children }) => <ul className="my-1.5 list-disc space-y-1 pl-5">{children}</ul>,
+          ol: ({ children }) => <ol className="my-1.5 list-decimal space-y-1 pl-5">{children}</ol>,
+          li: ({ children }) => <li className="text-foreground/90 text-pretty">{children}</li>,
+          code: ({ children }) => (
+            <code className="bg-muted rounded px-1 py-0.5 font-mono text-xs">{children}</code>
+          ),
+          pre: ({ children }) => (
+            <pre className="bg-muted my-2 overflow-x-auto rounded-md p-3 font-mono text-xs">
+              {children}
+            </pre>
+          ),
+          a: ({ children, href }) => (
+            <a
+              href={href}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-foreground underline underline-offset-2"
+            >
+              {children}
+            </a>
+          ),
+          blockquote: ({ children }) => (
+            <blockquote className="border-border text-muted-foreground my-2 border-l-2 pl-3">
+              {children}
+            </blockquote>
+          ),
+          hr: () => <hr className="border-border my-3" />,
+        }}
+      >
+        {content}
+      </ReactMarkdown>
+    </div>
+  );
+}
+
 // ── change ────────────────────────────────────────────────────────────────
 function ChangeBody({
   item,
@@ -148,18 +216,24 @@ function ChangeBody({
         </div>
       )}
 
-      {(whatChanged.length > 0 || d.impact) && (
+      {(whatChanged.length > 0 || d.descriptionMarkdown || d.impact) && (
         <div>
           <SectionLabel>What changed</SectionLabel>
-          {whatChanged.length > 0 && (
-            <ul className="space-y-1.5">
-              {whatChanged.map((line) => (
-                <li key={line} className="text-foreground flex items-start gap-2 text-sm">
-                  <Check className="text-kortix-green mt-0.5 size-4 shrink-0" />
-                  <span className="text-pretty">{line}</span>
-                </li>
-              ))}
-            </ul>
+          {/* An agent-written markdown description renders as real markdown;
+              structured/plain-line payloads keep the checkmark treatment. */}
+          {d.descriptionMarkdown ? (
+            <ReviewMarkdown content={d.descriptionMarkdown} />
+          ) : (
+            whatChanged.length > 0 && (
+              <ul className="space-y-1.5">
+                {whatChanged.map((line) => (
+                  <li key={line} className="text-foreground flex items-start gap-2 text-sm">
+                    <Check className="text-kortix-green mt-0.5 size-4 shrink-0" />
+                    <span className="text-pretty">{line}</span>
+                  </li>
+                ))}
+              </ul>
+            )
           )}
           {d.impact && (
             <div className="text-muted-foreground mt-2 text-sm text-pretty">{d.impact}</div>

--- a/apps/web/src/features/review-center/review-detail-modal.tsx
+++ b/apps/web/src/features/review-center/review-detail-modal.tsx
@@ -13,6 +13,7 @@ import { Button } from '@/components/ui/button';
 import { Disclosure, DisclosureContent, DisclosureTrigger } from '@/components/ui/disclosure';
 import { InfoBanner } from '@/components/ui/info-banner';
 import { Kbd } from '@/components/ui/kbd';
+import Loading from '@/components/ui/loading';
 import {
   Modal,
   ModalBody,
@@ -34,6 +35,7 @@ import {
 } from '@mynaui/icons-react';
 import { useEffect, useRef, useState } from 'react';
 import { ChangeFilesModal } from './change-files';
+import { formatItemAgeLong } from './review-actions';
 import {
   APPROVAL_ACTION_ICON,
   KIND_META,
@@ -49,17 +51,16 @@ export interface ReviewActions {
   approveAllSafe: (itemId: string) => void;
   /** Open the item's originating session (e.g. to watch the agent revise). */
   openSession?: (sessionId: string) => void;
-  /** Live-data mode. Executor approvals are resolved in-session (KORTIX-207), so
-   *  the inbox guides to the session rather than faking an inline decision. */
+  /** Live-data mode: executor approvals resolve inline via `resolve()` too
+   *  (the same `resolveApproval` call the in-session prompt uses), not just
+   *  native/CR items. */
   connected?: boolean;
-}
-
-function rel(iso: string): string {
-  const mins = Math.max(1, Math.round((Date.now() - new Date(iso).getTime()) / 60_000));
-  if (mins < 60) return `${mins}m ago`;
-  const hrs = Math.round(mins / 60);
-  if (hrs < 24) return `${hrs}h ago`;
-  return `${Math.round(hrs / 24)}d ago`;
+  /** The review item id currently mid-mutation, if any — drives the
+   *  per-item `Loading` state on Approve/Deny while connected. */
+  pendingId?: string | null;
+  /** Which verdict `pendingId`'s in-flight mutation is — so Approve and Deny
+   *  don't both show `Loading` at once. */
+  pendingDecision?: 'approve' | 'deny' | null;
 }
 
 /** A muted bordered panel — the friendly content surface. */
@@ -241,14 +242,20 @@ function ChangeBody({
 function ApprovalActionRow({
   action,
   connected,
+  pending,
+  readOnly,
   onApprove,
   onDeny,
   onAlwaysAllow,
   onOpenSession,
 }: {
   action: ApprovalAction;
-  /** Live mode: resolve in-session (KORTIX-207), so hide the fake inline verdict. */
   connected?: boolean;
+  /** 'approve' | 'deny' while this row's own mutation is in flight. */
+  pending?: 'approve' | 'deny' | null;
+  /** Display-only row — the decision lives elsewhere (the whole-item bar for
+   *  connected multi-action approvals, where one verdict covers every row). */
+  readOnly?: boolean;
   onApprove: () => void;
   onDeny: () => void;
   onAlwaysAllow: () => void;
@@ -257,6 +264,7 @@ function ApprovalActionRow({
   const Icon = APPROVAL_ACTION_ICON[action.icon];
   const safe = isSafeRisk(action.risk);
   const args = action.argsPreview ?? [];
+  const busy = !!pending;
   return (
     <div className="bg-popover rounded-md border px-4 py-3">
       <div className="flex items-start gap-3">
@@ -305,30 +313,40 @@ function ApprovalActionRow({
             <Badge variant={action.decided === 'approved' ? 'success' : 'destructive'} size="sm">
               {action.decided === 'approved' ? 'Approved' : 'Denied'}
             </Badge>
-          ) : connected ? (
-            // Executor approvals resume in the session's own approval prompt.
-            <Button variant="secondary" size="sm" onClick={onOpenSession} disabled={!onOpenSession}>
-              Approve in session
-              <ArrowUpRight className="size-3.5" />
-            </Button>
-          ) : (
+          ) : readOnly ? null : (
             <div className="flex flex-col items-end gap-1.5">
               <div className="flex items-center gap-1.5">
-                <Button variant="ghost" size="sm" onClick={onDeny}>
+                <Button variant="ghost" size="sm" disabled={busy} onClick={onDeny}>
+                  {pending === 'deny' ? <Loading className="size-3.5 shrink-0" /> : null}
                   Deny
                 </Button>
-                <Button size="sm" onClick={onApprove}>
-                  <Check className="size-3.5" />
+                <Button size="sm" disabled={busy} onClick={onApprove}>
+                  {pending === 'approve' ? (
+                    <Loading className="size-3.5 shrink-0" />
+                  ) : (
+                    <Check className="size-3.5" />
+                  )}
                   Approve
                 </Button>
               </div>
-              <button
-                type="button"
-                onClick={onAlwaysAllow}
-                className="text-muted-foreground hover:text-foreground text-xs underline-offset-2 hover:underline"
-              >
-                Always allow this
-              </button>
+              {connected && onOpenSession ? (
+                <button
+                  type="button"
+                  onClick={onOpenSession}
+                  className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1 text-xs underline-offset-2 hover:underline"
+                >
+                  See it in the session
+                  <ArrowUpRight className="size-3" />
+                </button>
+              ) : !connected ? (
+                <button
+                  type="button"
+                  onClick={onAlwaysAllow}
+                  className="text-muted-foreground hover:text-foreground text-xs underline-offset-2 hover:underline"
+                >
+                  Always allow this
+                </button>
+              ) : null}
             </div>
           )}
         </div>
@@ -350,69 +368,113 @@ function ApprovalBody({
     actions.openSession && item.sessionId
       ? () => actions.openSession?.(item.sessionId as string)
       : undefined;
+  // Connected mode resolves each action for real via `resolve()` (routes to
+  // `resolveApproval` — the same call the in-session prompt uses), so the row
+  // pending state is keyed off the shared `pendingId` rather than local proto
+  // state. Prototype mode keeps the instant local `decideAction` + "Always
+  // allow this" full-allow affordance.
   return (
     <>
-      {actions.connected ? (
-        // Live mode: executor approvals are resolved in the session's connector
-        // prompt, not the inbox (KORTIX-207) — guide there rather than fake it.
+      {!actions.connected && safePending.length > 0 && (
         <InfoBanner
-          tone="info"
-          title="Approve these from the session"
+          tone="success"
+          title={`${safePending.length} ${safePending.length === 1 ? 'action is' : 'actions are'} safe to approve together`}
           action={
-            openSession && (
-              <Button size="sm" variant="secondary" onClick={openSession}>
-                Open session
-                <ArrowUpRight className="size-3.5" />
-              </Button>
-            )
+            <Button
+              size="sm"
+              onClick={() => {
+                actions.approveAllSafe(item.id);
+                successToast(`Approved ${safePending.length} safe actions`);
+              }}
+            >
+              Approve all safe
+            </Button>
           }
         >
-          Tool approvals resume in the agent&apos;s own conversation, where you can approve or deny
-          with full context. This is the read-only preview.
+          Reads and low-risk writes. Risky actions stay below for you to decide one by one.
         </InfoBanner>
-      ) : (
-        safePending.length > 0 && (
-          <InfoBanner
-            tone="success"
-            title={`${safePending.length} ${safePending.length === 1 ? 'action is' : 'actions are'} safe to approve together`}
-            action={
-              <Button
-                size="sm"
-                onClick={() => {
-                  actions.approveAllSafe(item.id);
-                  successToast(`Approved ${safePending.length} safe actions`);
-                }}
-              >
-                Approve all safe
-              </Button>
-            }
-          >
-            Reads and low-risk writes. Risky actions stay below for you to decide one by one.
-          </InfoBanner>
-        )
       )}
-      <div className="space-y-2">
-        {list.map((a) => (
-          <ApprovalActionRow
-            key={a.id}
-            action={a}
-            connected={actions.connected}
-            onOpenSession={openSession}
-            onApprove={() => {
-              actions.decideAction(item.id, a.id, 'approved');
-              successToast(`Approved · ${a.title}`);
-            }}
-            onDeny={() => {
-              actions.decideAction(item.id, a.id, 'denied');
-              infoToast(`Denied · ${a.title}`);
-            }}
-            onAlwaysAllow={() => {
-              actions.decideAction(item.id, a.id, 'approved');
-              infoToast(`Saved — ${a.connector} ${a.action} won’t ask again`);
-            }}
-          />
-        ))}
-      </div>
+      {/* A connected item resolves as ONE unit (`/act` and `resolveApproval`
+          take a single verdict for the whole item), so with several pending
+          actions the per-row button pairs would misrepresent their granularity
+          — clicking Approve on one row would green-light all of them. Rows go
+          display-only and one clearly-labeled decision bar carries the verdict. */}
+      {(() => {
+        const wholeItem = !!actions.connected && list.filter((a) => !a.decided).length > 1;
+        const busy = actions.connected && actions.pendingId === item.id;
+        return (
+          <>
+            <div className="space-y-2">
+              {list.map((a) => (
+                <ApprovalActionRow
+                  key={a.id}
+                  action={a}
+                  connected={actions.connected}
+                  readOnly={wholeItem}
+                  pending={busy && !wholeItem ? (actions.pendingDecision ?? 'approve') : null}
+                  onOpenSession={openSession}
+                  onApprove={() => {
+                    if (actions.connected) {
+                      actions.resolve(item.id, 'approved', `Approved · ${a.title}`);
+                      return;
+                    }
+                    actions.decideAction(item.id, a.id, 'approved');
+                    successToast(`Approved · ${a.title}`);
+                  }}
+                  onDeny={() => {
+                    if (actions.connected) {
+                      actions.resolve(item.id, 'rejected', `Denied · ${a.title}`);
+                      return;
+                    }
+                    actions.decideAction(item.id, a.id, 'denied');
+                    infoToast(`Denied · ${a.title}`);
+                  }}
+                  onAlwaysAllow={() => {
+                    actions.decideAction(item.id, a.id, 'approved');
+                    infoToast(`Saved — ${a.connector} ${a.action} won’t ask again`);
+                  }}
+                />
+              ))}
+            </div>
+            {wholeItem && (
+              <div className="bg-popover flex items-center justify-between gap-3 rounded-md border px-4 py-3">
+                <p className="text-muted-foreground min-w-0 text-sm text-pretty">
+                  These {list.length} actions resolve together — one decision covers all of them.
+                </p>
+                <div className="flex shrink-0 items-center gap-1.5">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    disabled={busy}
+                    onClick={() =>
+                      actions.resolve(item.id, 'rejected', `Denied all ${list.length} actions`)
+                    }
+                  >
+                    {busy && actions.pendingDecision === 'deny' ? (
+                      <Loading className="size-3.5 shrink-0" />
+                    ) : null}
+                    Deny all
+                  </Button>
+                  <Button
+                    size="sm"
+                    disabled={busy}
+                    onClick={() =>
+                      actions.resolve(item.id, 'approved', `Approved all ${list.length} actions`)
+                    }
+                  >
+                    {busy && actions.pendingDecision === 'approve' ? (
+                      <Loading className="size-3.5 shrink-0" />
+                    ) : (
+                      <Check className="size-3.5" />
+                    )}
+                    Approve all
+                  </Button>
+                </div>
+              </div>
+            )}
+          </>
+        );
+      })()}
     </>
   );
 }
@@ -617,7 +679,7 @@ function Footer({
     return (
       <ModalFooter className="border-border/60 border-t pt-4">
         <span className="text-muted-foreground mr-auto text-xs">
-          {STATUS_META[item.status].label} · {rel(item.createdAt)}
+          {STATUS_META[item.status].label} · {formatItemAgeLong(item.createdAt)}
         </span>
         <Button variant="outline-ghost" onClick={onClose}>
           Close
@@ -754,7 +816,7 @@ export function ReviewDetailModal({
 
         <ModalBody className="space-y-3">
           <div className="text-muted-foreground text-xs">
-            {item.agent} · {rel(item.createdAt)}
+            {item.agent} · {formatItemAgeLong(item.createdAt)}
           </div>
 
           {item.kind === 'change' && <ChangeBody item={item} actions={actions} onClose={onClose} />}

--- a/apps/web/src/features/review-center/review-detail-modal.tsx
+++ b/apps/web/src/features/review-center/review-detail-modal.tsx
@@ -243,6 +243,7 @@ function ApprovalActionRow({
   action,
   connected,
   pending,
+  readOnly,
   onApprove,
   onDeny,
   onAlwaysAllow,
@@ -252,6 +253,9 @@ function ApprovalActionRow({
   connected?: boolean;
   /** 'approve' | 'deny' while this row's own mutation is in flight. */
   pending?: 'approve' | 'deny' | null;
+  /** Display-only row — the decision lives elsewhere (the whole-item bar for
+   *  connected multi-action approvals, where one verdict covers every row). */
+  readOnly?: boolean;
   onApprove: () => void;
   onDeny: () => void;
   onAlwaysAllow: () => void;
@@ -309,7 +313,7 @@ function ApprovalActionRow({
             <Badge variant={action.decided === 'approved' ? 'success' : 'destructive'} size="sm">
               {action.decided === 'approved' ? 'Approved' : 'Denied'}
             </Badge>
-          ) : (
+          ) : readOnly ? null : (
             <div className="flex flex-col items-end gap-1.5">
               <div className="flex items-center gap-1.5">
                 <Button variant="ghost" size="sm" disabled={busy} onClick={onDeny}>
@@ -390,40 +394,87 @@ function ApprovalBody({
           Reads and low-risk writes. Risky actions stay below for you to decide one by one.
         </InfoBanner>
       )}
-      <div className="space-y-2">
-        {list.map((a) => {
-          const busy = actions.connected && actions.pendingId === item.id;
-          return (
-            <ApprovalActionRow
-              key={a.id}
-              action={a}
-              connected={actions.connected}
-              pending={busy ? (actions.pendingDecision ?? 'approve') : null}
-              onOpenSession={openSession}
-              onApprove={() => {
-                if (actions.connected) {
-                  actions.resolve(item.id, 'approved', `Approved · ${a.title}`);
-                  return;
-                }
-                actions.decideAction(item.id, a.id, 'approved');
-                successToast(`Approved · ${a.title}`);
-              }}
-              onDeny={() => {
-                if (actions.connected) {
-                  actions.resolve(item.id, 'rejected', `Denied · ${a.title}`);
-                  return;
-                }
-                actions.decideAction(item.id, a.id, 'denied');
-                infoToast(`Denied · ${a.title}`);
-              }}
-              onAlwaysAllow={() => {
-                actions.decideAction(item.id, a.id, 'approved');
-                infoToast(`Saved — ${a.connector} ${a.action} won’t ask again`);
-              }}
-            />
-          );
-        })}
-      </div>
+      {/* A connected item resolves as ONE unit (`/act` and `resolveApproval`
+          take a single verdict for the whole item), so with several pending
+          actions the per-row button pairs would misrepresent their granularity
+          — clicking Approve on one row would green-light all of them. Rows go
+          display-only and one clearly-labeled decision bar carries the verdict. */}
+      {(() => {
+        const wholeItem = !!actions.connected && list.filter((a) => !a.decided).length > 1;
+        const busy = actions.connected && actions.pendingId === item.id;
+        return (
+          <>
+            <div className="space-y-2">
+              {list.map((a) => (
+                <ApprovalActionRow
+                  key={a.id}
+                  action={a}
+                  connected={actions.connected}
+                  readOnly={wholeItem}
+                  pending={busy && !wholeItem ? (actions.pendingDecision ?? 'approve') : null}
+                  onOpenSession={openSession}
+                  onApprove={() => {
+                    if (actions.connected) {
+                      actions.resolve(item.id, 'approved', `Approved · ${a.title}`);
+                      return;
+                    }
+                    actions.decideAction(item.id, a.id, 'approved');
+                    successToast(`Approved · ${a.title}`);
+                  }}
+                  onDeny={() => {
+                    if (actions.connected) {
+                      actions.resolve(item.id, 'rejected', `Denied · ${a.title}`);
+                      return;
+                    }
+                    actions.decideAction(item.id, a.id, 'denied');
+                    infoToast(`Denied · ${a.title}`);
+                  }}
+                  onAlwaysAllow={() => {
+                    actions.decideAction(item.id, a.id, 'approved');
+                    infoToast(`Saved — ${a.connector} ${a.action} won’t ask again`);
+                  }}
+                />
+              ))}
+            </div>
+            {wholeItem && (
+              <div className="bg-popover flex items-center justify-between gap-3 rounded-md border px-4 py-3">
+                <p className="text-muted-foreground min-w-0 text-sm text-pretty">
+                  These {list.length} actions resolve together — one decision covers all of them.
+                </p>
+                <div className="flex shrink-0 items-center gap-1.5">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    disabled={busy}
+                    onClick={() =>
+                      actions.resolve(item.id, 'rejected', `Denied all ${list.length} actions`)
+                    }
+                  >
+                    {busy && actions.pendingDecision === 'deny' ? (
+                      <Loading className="size-3.5 shrink-0" />
+                    ) : null}
+                    Deny all
+                  </Button>
+                  <Button
+                    size="sm"
+                    disabled={busy}
+                    onClick={() =>
+                      actions.resolve(item.id, 'approved', `Approved all ${list.length} actions`)
+                    }
+                  >
+                    {busy && actions.pendingDecision === 'approve' ? (
+                      <Loading className="size-3.5 shrink-0" />
+                    ) : (
+                      <Check className="size-3.5" />
+                    )}
+                    Approve all
+                  </Button>
+                </div>
+              </div>
+            )}
+          </>
+        );
+      })()}
     </>
   );
 }

--- a/apps/web/src/features/review-center/review-markdown.test.ts
+++ b/apps/web/src/features/review-center/review-markdown.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from 'bun:test';
+import type { ApiReviewItem } from '@kortix/sdk/projects-client';
+
+import { mapApiReviewItem } from './map';
+import { looksLikeMarkdown } from './review-markdown';
+import type { ChangeDetail } from './types';
+
+describe('looksLikeMarkdown', () => {
+  test('detects the clear markdown signals', () => {
+    expect(looksLikeMarkdown('## What this changes\nMigrates the manifest.')).toBe(true);
+    expect(looksLikeMarkdown('This has **bold emphasis** in it.')).toBe(true);
+    expect(looksLikeMarkdown('Run `kortix validate` before landing.')).toBe(true);
+    expect(looksLikeMarkdown('```yaml\nagents: {}\n```')).toBe(true);
+    expect(looksLikeMarkdown('See [the docs](https://kortix.com/docs).')).toBe(true);
+    expect(looksLikeMarkdown('1. fetch\n2. rebase\n3. push')).toBe(true);
+  });
+
+  test('plain prose stays plain — the designed checkmark treatment must survive', () => {
+    expect(looksLikeMarkdown('Fixed the header alignment on mobile.')).toBe(false);
+    expect(looksLikeMarkdown('Updated dependencies.\nFixed two flaky tests.')).toBe(false);
+    // Simple dash bullets are common in plain agent output — not enough signal
+    // on their own to switch away from the per-line checkmarks.
+    expect(looksLikeMarkdown('- updated the schema\n- fixed the tests')).toBe(false);
+  });
+
+  test('is not fooled by lookalikes', () => {
+    expect(looksLikeMarkdown('The #4135 PR shipped yesterday.')).toBe(false); // not an ATX heading
+    expect(looksLikeMarkdown('rated 5* by users')).toBe(false);
+    expect(looksLikeMarkdown('')).toBe(false);
+  });
+});
+
+describe('mapApiReviewItem — markdown change descriptions', () => {
+  const changeRow = (description: string): ApiReviewItem =>
+    ({
+      review_item_id: 'rv-1',
+      kind: 'change',
+      title: 'Migrate manifest to v2',
+      summary: 'CR #12',
+      status: 'pending',
+      risk: 'medium',
+      agent: 'Agent',
+      created_at: '2026-07-08T10:00:00.000Z',
+      detail: { cr_id: 'cr-12', base_ref: 'main', head_ref: 'session/x', description },
+    }) as unknown as ApiReviewItem;
+
+  test('a markdown description is carried whole, not line-split into checkmark rows', () => {
+    const md = '## What this changes\nMigrates `kortix.toml` to **kortix.yaml**.';
+    const item = mapApiReviewItem(changeRow(md), 'proj');
+    const d = item.detail as ChangeDetail;
+    expect(d.descriptionMarkdown).toBe(md);
+    expect(d.whatChanged).toEqual([]);
+  });
+
+  test('a plain description keeps the per-line treatment', () => {
+    const item = mapApiReviewItem(changeRow('Updated the schema.\nFixed the tests.'), 'proj');
+    const d = item.detail as ChangeDetail;
+    expect(d.descriptionMarkdown).toBeUndefined();
+    expect(d.whatChanged).toEqual(['Updated the schema.', 'Fixed the tests.']);
+  });
+
+  test('a native structured whatChanged array always wins over markdown detection', () => {
+    const row = changeRow('## ignored');
+    (row.detail as Record<string, unknown>).whatChanged = ['Did the thing'];
+    const d = mapApiReviewItem(row, 'proj').detail as ChangeDetail;
+    expect(d.descriptionMarkdown).toBeUndefined();
+    expect(d.whatChanged).toEqual(['Did the thing']);
+  });
+});

--- a/apps/web/src/features/review-center/review-markdown.ts
+++ b/apps/web/src/features/review-center/review-markdown.ts
@@ -1,0 +1,21 @@
+/**
+ * Markdown detection for free-form review-item descriptions (the thin
+ * Change-Request adapter payload carries whatever prose the agent wrote).
+ * Pure + conservative: plain multi-line text — including simple `-` bullet
+ * lists — must NOT match, so those keep the designed per-line checkmark
+ * treatment; only clear markdown syntax switches the modal to a real
+ * markdown render.
+ */
+
+const MD_SIGNALS: RegExp[] = [
+  /^#{1,6}\s+\S/m, // ATX heading: "## What this changes"
+  /```/, // fenced code block
+  /\*\*[^*\n]+\*\*/, // bold
+  /(^|[^`])`[^`\n]+`([^`]|$)/, // inline code span (not a fence)
+  /\[[^\]\n]+\]\([^)\n]+\)/, // [link](url)
+  /^\s*\d+\.\s+\S/m, // ordered list: "1. step"
+];
+
+export function looksLikeMarkdown(text: string): boolean {
+  return MD_SIGNALS.some((re) => re.test(text));
+}

--- a/apps/web/src/features/review-center/types.ts
+++ b/apps/web/src/features/review-center/types.ts
@@ -59,6 +59,9 @@ export interface RequestedChange {
 export interface ChangeDetail {
   crId?: string; // the underlying Change Request id (connected mode) — enables the live diff
   whatChanged: string[];
+  /** The agent's free-form description when it's real markdown — rendered as
+   *  such in the modal instead of being line-split into `whatChanged` rows. */
+  descriptionMarkdown?: string;
   impact: string;
   verification: { label: string; tone: 'success' | 'warning' | 'neutral' | 'info' }[];
   previewUrl?: string;

--- a/apps/web/src/features/session/model-selector.tsx
+++ b/apps/web/src/features/session/model-selector.tsx
@@ -40,6 +40,8 @@ import { useModelStore } from '@/hooks/opencode/use-model-store';
 import type { ProviderListResponse } from '@/hooks/opencode/use-opencode-sessions';
 import { featureFlags } from '@kortix/sdk/feature-flags';
 import { isLlmGatewayEnabled } from '@/lib/llm-gateway';
+import { PROJECT_ACTIONS } from '@/lib/project-actions';
+import { useProjectCan } from '@/lib/use-project-can';
 import { getProjectDetail, listProjectSecrets } from '@kortix/sdk/projects-client';
 import { useCustomizeStore } from '@/stores/customize-store';
 import type { ProviderModalTab } from '@/stores/provider-modal-store';
@@ -158,6 +160,13 @@ export function ModelSelector({
     staleTime: 30_000,
   });
   const llmGatewayEnabled = isLlmGatewayEnabled(projectDetailQuery.data?.project);
+  // The legacy (non-gateway) provider modal lets you connect/disconnect
+  // providers — all writes. Gate them so a read-only member sees the catalog
+  // but no mutating controls (fails safe to read-only until the probe resolves).
+  const canWriteProviders =
+    useProjectCan(projectId ?? undefined, PROJECT_ACTIONS.PROJECT_WRITE, {
+      accountId: projectDetailQuery.data?.project.account_id,
+    }).allowed === true;
   const baseModels = useMemo(() => {
     return llmGatewayEnabled ? models : models.filter((m) => m.providerID !== 'kortix');
   }, [models, llmGatewayEnabled]);
@@ -344,6 +353,7 @@ export function ModelSelector({
           open={projectModalOpen}
           onOpenChange={setProjectModalOpen}
           defaultTab={projectModalTab}
+          canWrite={canWriteProviders}
         />
       )}
       <CommandPopover open={open} onOpenChange={setOpen}>

--- a/apps/web/src/features/tunnel/tunnel-overview.tsx
+++ b/apps/web/src/features/tunnel/tunnel-overview.tsx
@@ -115,7 +115,7 @@ function LoadingSkeleton() {
   );
 }
 
-export function TunnelOverview() {
+export function TunnelOverview({ canWrite = false }: { canWrite?: boolean }) {
   const tHardcodedUi = useTranslations('hardcodedUi');
   const { data: connections = [], isLoading } = useTunnelConnections();
   const deleteMutation = useDeleteTunnelConnection();
@@ -163,7 +163,7 @@ export function TunnelOverview() {
         title="Computers"
         description="Connect local machines and grant agents permissioned access over a reverse tunnel."
       >
-        {hasConnections && (
+        {hasConnections && canWrite && (
           <div className="flex items-center justify-between gap-3">
             <ConnectCommandPanel />
           </div>
@@ -206,9 +206,11 @@ export function TunnelOverview() {
                   )}
                 </EmptyDescription>
               </EmptyHeader>
-              <EmptyContent className="max-w-md">
-                <ConnectCommandPanel />
-              </EmptyContent>
+              {canWrite && (
+                <EmptyContent className="max-w-md">
+                  <ConnectCommandPanel />
+                </EmptyContent>
+              )}
             </Empty>
           ) : filtered.length === 0 && searchQuery ? (
             <p className="text-muted-foreground px-3 py-6 text-center text-xs">
@@ -293,7 +295,8 @@ export function TunnelOverview() {
           setSettingsOpen(open);
           if (!open) setSelectedTunnel(null);
         }}
-        onDelete={() => selectedTunnel && setDeleteTarget(selectedTunnel)}
+        canWrite={canWrite}
+        onDelete={canWrite ? () => selectedTunnel && setDeleteTarget(selectedTunnel) : undefined}
       />
 
       <DeleteConnectionDialog

--- a/apps/web/src/features/tunnel/tunnel-scope-toggles.tsx
+++ b/apps/web/src/features/tunnel/tunnel-scope-toggles.tsx
@@ -25,6 +25,9 @@ import type { TunnelPermission } from '@/hooks/tunnel/use-tunnel';
 
 interface TunnelScopeTogglesProps {
   tunnelId: string;
+  /** When false, the toggles and expiry select are shown but disabled — the
+   *  active scopes remain visible as read-only data. */
+  canWrite?: boolean;
 }
 
 function groupBy<T>(arr: T[], fn: (item: T) => string): Record<string, T[]> {
@@ -57,7 +60,7 @@ export function buildActiveScopeMap(permissions: TunnelPermission[] | undefined)
   return map;
 }
 
-export function TunnelScopeToggles({ tunnelId }: TunnelScopeTogglesProps) {
+export function TunnelScopeToggles({ tunnelId, canWrite = false }: TunnelScopeTogglesProps) {
   const tHardcodedUi = useTranslations('hardcodedUi');
   const { data: permissions, isLoading } = useTunnelPermissions(tunnelId);
   const grantMutation = useGrantTunnelPermission();
@@ -104,7 +107,7 @@ export function TunnelScopeToggles({ tunnelId }: TunnelScopeTogglesProps) {
         <span className="text-muted-foreground">
           {tHardcodedUi.raw('componentsTunnelTunnelScopeToggles.line79JsxTextNewGrantsExpireIn')}
         </span>
-        <Select value={expiryValue} onValueChange={setExpiryValue}>
+        <Select value={expiryValue} onValueChange={setExpiryValue} disabled={!canWrite}>
           <SelectTrigger variant="popover">
             <SelectValue />
           </SelectTrigger>
@@ -135,7 +138,7 @@ export function TunnelScopeToggles({ tunnelId }: TunnelScopeTogglesProps) {
                     key={scope.key}
                     scope={scope}
                     isActive={isActive}
-                    isPending={grantMutation.isPending || revokeMutation.isPending}
+                    disabled={!canWrite || grantMutation.isPending || revokeMutation.isPending}
                     onToggle={() => handleToggle(scope, isActive)}
                   />
                 );
@@ -151,17 +154,20 @@ export function TunnelScopeToggles({ tunnelId }: TunnelScopeTogglesProps) {
 function ScopeToggleRow({
   scope,
   isActive,
-  isPending,
+  disabled,
   onToggle,
 }: {
   scope: ScopeInfo;
   isActive: boolean;
-  isPending: boolean;
+  disabled: boolean;
   onToggle: () => void;
 }) {
   return (
     <label
-      className={cn('flex cursor-pointer items-center gap-3 rounded-md py-2 transition-colors')}
+      className={cn(
+        'flex items-center gap-3 rounded-md py-2 transition-colors',
+        disabled ? 'cursor-default' : 'cursor-pointer',
+      )}
     >
       <div className="flex min-w-0 flex-1 items-center gap-2">
         <code className="text-foreground font-mono text-xs">{scope.key}</code>
@@ -170,7 +176,7 @@ function ScopeToggleRow({
       <Switch
         checked={isActive}
         onCheckedChange={onToggle}
-        disabled={isPending}
+        disabled={disabled}
         className="shrink-0"
       />
     </label>

--- a/apps/web/src/features/tunnel/tunnel-settings-dialog.tsx
+++ b/apps/web/src/features/tunnel/tunnel-settings-dialog.tsx
@@ -26,6 +26,9 @@ interface TunnelSettingsDialogProps {
   tunnel: TunnelConnection | null;
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  /** When false, the permissions toggles and delete action are hidden — the
+   *  dialog stays open as a read-only view of the connection's data. */
+  canWrite?: boolean;
   onDelete?: () => void;
 }
 
@@ -35,6 +38,7 @@ export function TunnelSettingsDialog({
   tunnel,
   open,
   onOpenChange,
+  canWrite = false,
   onDelete,
 }: TunnelSettingsDialogProps) {
   const tHardcodedUi = useTranslations('hardcodedUi');
@@ -120,7 +124,7 @@ export function TunnelSettingsDialog({
             <div className="min-h-0 flex-1 overflow-y-auto">
               <TabsContent value="permissions">
                 {activeTab === 'permissions' && tunnelId ? (
-                  <TunnelScopeToggles tunnelId={tunnelId || ''} />
+                  <TunnelScopeToggles tunnelId={tunnelId || ''} canWrite={canWrite} />
                 ) : null}
               </TabsContent>
 

--- a/apps/web/src/features/workspace/customize/customize-panel.tsx
+++ b/apps/web/src/features/workspace/customize/customize-panel.tsx
@@ -177,10 +177,12 @@ export function CustomizPanel({ projectId }: { projectId: string }) {
       ),
     [caps],
   );
-  // A section is permitted when its GATE leaf resolved to allowed:true. Every
-  // customize section gates on WRITE (editor+) — a plain `member` sees none of
-  // them (Files lives on its own /projects/[id]/files page, not in here). Until
-  // the probe resolves (or if it errored) we permit everything (optimistic).
+  // A section is permitted when its READ leaf resolved to allowed:true — a role
+  // that can read a section SEES it (read-only unless it also holds the write
+  // leaf; edit controls inside each view gate on can_manage separately). A role
+  // that omits a read leaf hides just that section. (Files lives on its own
+  // /projects/[id]/files page, not in here.) Until the probe resolves (or if it
+  // errored) we permit everything (optimistic) — visibility, not security.
   const isSectionAllowed = useCallback(
     (s: CustomizeSection) => {
       if (!capsResolved) return true;

--- a/apps/web/src/features/workspace/customize/migrate-to-v2/upgrade-view.test.tsx
+++ b/apps/web/src/features/workspace/customize/migrate-to-v2/upgrade-view.test.tsx
@@ -6,7 +6,7 @@ import { UpgradesViewContent } from './upgrade-view';
 describe('UpgradesViewContent — per-state rendering', () => {
   test('v1 lists the manifest migration with a Run action, plus the one-off runner', () => {
     const html = renderToStaticMarkup(
-      <UpgradesViewContent version={1} onRun={() => {}} pending={false} />,
+      <UpgradesViewContent version={1} onRun={() => {}} pending={false} canWrite />,
     );
     expect(html).toContain('Upgrades');
     expect(html).toContain('Migrate manifest to v2');
@@ -17,7 +17,7 @@ describe('UpgradesViewContent — per-state rendering', () => {
 
   test('v2 shows the up-to-date empty state but keeps the one-off runner available', () => {
     const html = renderToStaticMarkup(
-      <UpgradesViewContent version={2} onRun={() => {}} pending={false} />,
+      <UpgradesViewContent version={2} onRun={() => {}} pending={false} canWrite />,
     );
     expect(html).toContain('up to date');
     expect(html).not.toContain('Migrate manifest to v2');
@@ -26,14 +26,28 @@ describe('UpgradesViewContent — per-state rendering', () => {
 
   test('unresolved manifest read renders placeholders — no upgrade rows, no premature up-to-date claim', () => {
     const html = renderToStaticMarkup(
-      <UpgradesViewContent version={null} onRun={() => {}} pending={false} />,
+      <UpgradesViewContent version={null} onRun={() => {}} pending={false} canWrite />,
     );
     expect(html).not.toContain('Migrate manifest to v2');
     expect(html).not.toContain('up to date');
   });
 
   test('run buttons disable while a session is being created', () => {
-    const html = renderToStaticMarkup(<UpgradesViewContent version={1} onRun={() => {}} pending />);
+    const html = renderToStaticMarkup(
+      <UpgradesViewContent version={1} onRun={() => {}} pending canWrite />,
+    );
     expect(html).toContain('disabled');
+  });
+
+  test('read-only (no write) hides the Run action and the one-off runner but keeps the explanation', () => {
+    const html = renderToStaticMarkup(
+      <UpgradesViewContent version={1} onRun={() => {}} pending={false} canWrite={false} />,
+    );
+    // Section + upgrade row still render (data stays visible)…
+    expect(html).toContain('Upgrades');
+    expect(html).toContain('Migrate manifest to v2');
+    expect(html).toContain('One-off upgrade');
+    // …but the mutating "Run upgrade" control is gone.
+    expect(html).not.toContain('Run upgrade');
   });
 });

--- a/apps/web/src/features/workspace/customize/migrate-to-v2/upgrade-view.test.tsx
+++ b/apps/web/src/features/workspace/customize/migrate-to-v2/upgrade-view.test.tsx
@@ -6,7 +6,7 @@ import { UpgradesViewContent } from './upgrade-view';
 describe('UpgradesViewContent — per-state rendering', () => {
   test('v1 lists the manifest migration with a Run action, plus the one-off runner', () => {
     const html = renderToStaticMarkup(
-      <UpgradesViewContent version={1} onRun={() => {}} pending={false} />,
+      <UpgradesViewContent version={1} onRun={() => {}} pending={false} canWrite />,
     );
     expect(html).toContain('Upgrades');
     expect(html).toContain('Migrate manifest to v2');
@@ -19,7 +19,7 @@ describe('UpgradesViewContent — per-state rendering', () => {
 
   test('v2 shows the up-to-date empty state but keeps the one-off runner available', () => {
     const html = renderToStaticMarkup(
-      <UpgradesViewContent version={2} onRun={() => {}} pending={false} />,
+      <UpgradesViewContent version={2} onRun={() => {}} pending={false} canWrite />,
     );
     expect(html).toContain('up to date');
     expect(html).not.toContain('Migrate manifest to v2');
@@ -30,14 +30,28 @@ describe('UpgradesViewContent — per-state rendering', () => {
 
   test('unresolved manifest read renders placeholders — no upgrade rows, no premature up-to-date claim', () => {
     const html = renderToStaticMarkup(
-      <UpgradesViewContent version={null} onRun={() => {}} pending={false} />,
+      <UpgradesViewContent version={null} onRun={() => {}} pending={false} canWrite />,
     );
     expect(html).not.toContain('Migrate manifest to v2');
     expect(html).not.toContain('up to date');
   });
 
   test('run buttons disable while a session is being created', () => {
-    const html = renderToStaticMarkup(<UpgradesViewContent version={1} onRun={() => {}} pending />);
+    const html = renderToStaticMarkup(
+      <UpgradesViewContent version={1} onRun={() => {}} pending canWrite />,
+    );
     expect(html).toContain('disabled');
+  });
+
+  test('read-only (no write) hides the Run action and the one-off runner but keeps the explanation', () => {
+    const html = renderToStaticMarkup(
+      <UpgradesViewContent version={1} onRun={() => {}} pending={false} canWrite={false} />,
+    );
+    // Section + upgrade row still render (data stays visible)…
+    expect(html).toContain('Upgrades');
+    expect(html).toContain('Migrate manifest to v2');
+    expect(html).toContain('One-off upgrade');
+    // …but the mutating "Run upgrade" control is gone.
+    expect(html).not.toContain('Run upgrade');
   });
 });

--- a/apps/web/src/features/workspace/customize/migrate-to-v2/upgrade-view.test.tsx
+++ b/apps/web/src/features/workspace/customize/migrate-to-v2/upgrade-view.test.tsx
@@ -11,6 +11,8 @@ describe('UpgradesViewContent — per-state rendering', () => {
     expect(html).toContain('Upgrades');
     expect(html).toContain('Migrate manifest to v2');
     expect(html).toContain('Run');
+    // Applicable upgrades are surfaced as a highlighted, recommended action.
+    expect(html).toContain('Recommended');
     expect(html).toContain('One-off upgrade');
     expect(html).not.toContain('up to date');
   });
@@ -21,6 +23,8 @@ describe('UpgradesViewContent — per-state rendering', () => {
     );
     expect(html).toContain('up to date');
     expect(html).not.toContain('Migrate manifest to v2');
+    // No applicable upgrade ⇒ no recommended-action highlight.
+    expect(html).not.toContain('Recommended');
     expect(html).toContain('One-off upgrade');
   });
 

--- a/apps/web/src/features/workspace/customize/migrate-to-v2/upgrade-view.tsx
+++ b/apps/web/src/features/workspace/customize/migrate-to-v2/upgrade-view.tsx
@@ -23,6 +23,8 @@ import Loading from '@/components/ui/loading';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Textarea } from '@/components/ui/textarea';
 import { EmptyState } from '@/features/layout/section/empty-state';
+import { PROJECT_ACTIONS } from '@/lib/project-actions';
+import { useProjectCan } from '@/lib/use-project-can';
 import { ArrowUpCircle, CircleCheckBig } from 'lucide-react';
 import { useState } from 'react';
 
@@ -39,11 +41,15 @@ export function UpgradesViewContent({
   version,
   onRun,
   pending,
+  canWrite = false,
 }: {
   /** `null` = the manifest read hasn't resolved yet. */
   version: ManifestVersion | null;
   onRun: (prompt: string) => void;
   pending: boolean;
+  /** When false, the Run action buttons are hidden — the upgrade explanation
+   *  and one-off description stay visible as a read-only view. */
+  canWrite?: boolean;
 }) {
   const [oneOff, setOneOff] = useState('');
   const upgrades = version === null ? null : applicableUpgrades({ manifestVersion: version });
@@ -91,15 +97,17 @@ export function UpgradesViewContent({
                     {upgrade.description}
                   </p>
                 </div>
-                <Button
-                  size="sm"
-                  className="shrink-0"
-                  disabled={pending}
-                  onClick={() => onRun(upgrade.prompt)}
-                >
-                  {pending ? <Loading className="size-3.5 shrink-0" /> : null}
-                  Run
-                </Button>
+                {canWrite ? (
+                  <Button
+                    size="sm"
+                    className="shrink-0"
+                    disabled={pending}
+                    onClick={() => onRun(upgrade.prompt)}
+                  >
+                    {pending ? <Loading className="size-3.5 shrink-0" /> : null}
+                    Run
+                  </Button>
+                ) : null}
               </li>
             ))}
           </ul>
@@ -113,23 +121,27 @@ export function UpgradesViewContent({
             Describe a single change to this project. An agent session makes it, validates, and
             opens a change request — it never merges on its own.
           </p>
-          <Textarea
-            value={oneOff}
-            onChange={(event) => setOneOff(event.target.value)}
-            placeholder="e.g. Rename the release-bot agent to deploy-bot everywhere it's referenced"
-            minHeight={72}
-          />
-          <div className="flex justify-end">
-            <Button
-              size="sm"
-              variant="secondary"
-              disabled={pending || !oneOff.trim()}
-              onClick={() => onRun(buildOneOffUpgradePrompt(oneOff))}
-            >
-              {pending ? <Loading className="size-3.5 shrink-0" /> : null}
-              Run upgrade
-            </Button>
-          </div>
+          {canWrite ? (
+            <>
+              <Textarea
+                value={oneOff}
+                onChange={(event) => setOneOff(event.target.value)}
+                placeholder="e.g. Rename the release-bot agent to deploy-bot everywhere it's referenced"
+                minHeight={72}
+              />
+              <div className="flex justify-end">
+                <Button
+                  size="sm"
+                  variant="secondary"
+                  disabled={pending || !oneOff.trim()}
+                  onClick={() => onRun(buildOneOffUpgradePrompt(oneOff))}
+                >
+                  {pending ? <Loading className="size-3.5 shrink-0" /> : null}
+                  Run upgrade
+                </Button>
+              </div>
+            </>
+          ) : null}
         </div>
       </section>
     </CustomizeSectionWrapper>
@@ -139,5 +151,13 @@ export function UpgradesViewContent({
 export function UpgradesView({ projectId }: { projectId: string }) {
   const { version } = useProjectManifestVersion(projectId);
   const run = useRunUpgrade(projectId);
-  return <UpgradesViewContent version={version} onRun={run.start} pending={run.pending} />;
+  const canWrite = useProjectCan(projectId, PROJECT_ACTIONS.PROJECT_WRITE).allowed === true;
+  return (
+    <UpgradesViewContent
+      version={version}
+      onRun={run.start}
+      pending={run.pending}
+      canWrite={canWrite}
+    />
+  );
 }

--- a/apps/web/src/features/workspace/customize/migrate-to-v2/upgrade-view.tsx
+++ b/apps/web/src/features/workspace/customize/migrate-to-v2/upgrade-view.tsx
@@ -22,6 +22,8 @@ import Loading from '@/components/ui/loading';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Textarea } from '@/components/ui/textarea';
 import { EmptyState } from '@/features/layout/section/empty-state';
+import { PROJECT_ACTIONS } from '@/lib/project-actions';
+import { useProjectCan } from '@/lib/use-project-can';
 import { ArrowUpCircle, CircleCheckBig } from 'lucide-react';
 import { useState } from 'react';
 
@@ -38,11 +40,15 @@ export function UpgradesViewContent({
   version,
   onRun,
   pending,
+  canWrite = false,
 }: {
   /** `null` = the manifest read hasn't resolved yet. */
   version: ManifestVersion | null;
   onRun: (prompt: string) => void;
   pending: boolean;
+  /** When false, the Run action buttons are hidden — the upgrade explanation
+   *  and one-off description stay visible as a read-only view. */
+  canWrite?: boolean;
 }) {
   const [oneOff, setOneOff] = useState('');
   const upgrades = version === null ? null : applicableUpgrades({ manifestVersion: version });
@@ -83,15 +89,17 @@ export function UpgradesViewContent({
                     {upgrade.description}
                   </p>
                 </div>
-                <Button
-                  size="sm"
-                  className="shrink-0"
-                  disabled={pending}
-                  onClick={() => onRun(upgrade.prompt)}
-                >
-                  {pending ? <Loading className="size-3.5 shrink-0" /> : null}
-                  Run
-                </Button>
+                {canWrite ? (
+                  <Button
+                    size="sm"
+                    className="shrink-0"
+                    disabled={pending}
+                    onClick={() => onRun(upgrade.prompt)}
+                  >
+                    {pending ? <Loading className="size-3.5 shrink-0" /> : null}
+                    Run
+                  </Button>
+                ) : null}
               </li>
             ))}
           </ul>
@@ -105,23 +113,27 @@ export function UpgradesViewContent({
             Describe a single change to this project. An agent session makes it, validates, and
             opens a change request — it never merges on its own.
           </p>
-          <Textarea
-            value={oneOff}
-            onChange={(event) => setOneOff(event.target.value)}
-            placeholder="e.g. Rename the release-bot agent to deploy-bot everywhere it's referenced"
-            minHeight={72}
-          />
-          <div className="flex justify-end">
-            <Button
-              size="sm"
-              variant="secondary"
-              disabled={pending || !oneOff.trim()}
-              onClick={() => onRun(buildOneOffUpgradePrompt(oneOff))}
-            >
-              {pending ? <Loading className="size-3.5 shrink-0" /> : null}
-              Run upgrade
-            </Button>
-          </div>
+          {canWrite ? (
+            <>
+              <Textarea
+                value={oneOff}
+                onChange={(event) => setOneOff(event.target.value)}
+                placeholder="e.g. Rename the release-bot agent to deploy-bot everywhere it's referenced"
+                minHeight={72}
+              />
+              <div className="flex justify-end">
+                <Button
+                  size="sm"
+                  variant="secondary"
+                  disabled={pending || !oneOff.trim()}
+                  onClick={() => onRun(buildOneOffUpgradePrompt(oneOff))}
+                >
+                  {pending ? <Loading className="size-3.5 shrink-0" /> : null}
+                  Run upgrade
+                </Button>
+              </div>
+            </>
+          ) : null}
         </div>
       </section>
     </CustomizeSectionWrapper>
@@ -131,5 +143,13 @@ export function UpgradesViewContent({
 export function UpgradesView({ projectId }: { projectId: string }) {
   const { version } = useProjectManifestVersion(projectId);
   const run = useRunUpgrade(projectId);
-  return <UpgradesViewContent version={version} onRun={run.start} pending={run.pending} />;
+  const canWrite = useProjectCan(projectId, PROJECT_ACTIONS.PROJECT_WRITE).allowed === true;
+  return (
+    <UpgradesViewContent
+      version={version}
+      onRun={run.start}
+      pending={run.pending}
+      canWrite={canWrite}
+    />
+  );
 }

--- a/apps/web/src/features/workspace/customize/migrate-to-v2/upgrade-view.tsx
+++ b/apps/web/src/features/workspace/customize/migrate-to-v2/upgrade-view.tsx
@@ -16,6 +16,7 @@
  * Nothing here merges anything.
  */
 
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import Loading from '@/components/ui/loading';
@@ -78,13 +79,20 @@ export function UpgradesViewContent({
             {upgrades.map((upgrade: ProjectUpgrade) => (
               <li
                 key={upgrade.id}
-                className="bg-popover flex items-center gap-3 rounded-md border px-4 py-3"
+                className="border-kortix-base/30 bg-kortix-base/[0.06] shadow-kortix-base/20 flex items-center gap-3 rounded-md border px-4 py-3 shadow-md transition-colors hover:border-kortix-base/45 hover:bg-kortix-base/[0.09]"
               >
-                <span className="bg-kortix-base/15 flex size-9 shrink-0 items-center justify-center rounded-sm">
+                <span className="bg-kortix-base/15 ring-kortix-base/25 flex size-9 shrink-0 items-center justify-center rounded-sm ring-1 ring-inset">
                   <ArrowUpCircle className="text-kortix-base size-5" />
                 </span>
                 <div className="min-w-0 flex-1">
-                  <p className="text-foreground text-sm font-medium">{upgrade.title}</p>
+                  <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+                    <p className="text-foreground text-sm font-medium text-balance">
+                      {upgrade.title}
+                    </p>
+                    <Badge variant="kortix" size="xs" className="shrink-0">
+                      Recommended
+                    </Badge>
+                  </div>
                   <p className="text-muted-foreground mt-0.5 text-xs text-pretty">
                     {upgrade.description}
                   </p>

--- a/apps/web/src/features/workspace/customize/migrate-to-v2/upgrade-view.tsx
+++ b/apps/web/src/features/workspace/customize/migrate-to-v2/upgrade-view.tsx
@@ -16,6 +16,7 @@
  * Nothing here merges anything.
  */
 
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import Loading from '@/components/ui/loading';
@@ -72,13 +73,20 @@ export function UpgradesViewContent({
             {upgrades.map((upgrade: ProjectUpgrade) => (
               <li
                 key={upgrade.id}
-                className="bg-popover flex items-center gap-3 rounded-md border px-4 py-3"
+                className="border-kortix-base/30 bg-kortix-base/[0.06] shadow-kortix-base/20 flex items-center gap-3 rounded-md border px-4 py-3 shadow-md transition-colors hover:border-kortix-base/45 hover:bg-kortix-base/[0.09]"
               >
-                <span className="bg-kortix-base/15 flex size-9 shrink-0 items-center justify-center rounded-sm">
+                <span className="bg-kortix-base/15 ring-kortix-base/25 flex size-9 shrink-0 items-center justify-center rounded-sm ring-1 ring-inset">
                   <ArrowUpCircle className="text-kortix-base size-5" />
                 </span>
                 <div className="min-w-0 flex-1">
-                  <p className="text-foreground text-sm font-medium">{upgrade.title}</p>
+                  <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+                    <p className="text-foreground text-sm font-medium text-balance">
+                      {upgrade.title}
+                    </p>
+                    <Badge variant="kortix" size="xs" className="shrink-0">
+                      Recommended
+                    </Badge>
+                  </div>
                   <p className="text-muted-foreground mt-0.5 text-xs text-pretty">
                     {upgrade.description}
                   </p>

--- a/apps/web/src/features/workspace/customize/sections/channels-view.test.ts
+++ b/apps/web/src/features/workspace/customize/sections/channels-view.test.ts
@@ -41,7 +41,9 @@ describe('Channels view — connect in place', () => {
 describe('Channels view — per-channel binding management (spec §2.5)', () => {
   test('renders the channel-bindings table only once a channel is connected', () => {
     expect(channelsSource).toContain('function ChannelBindingsSection');
-    expect(channelsSource).toContain('install ? <ChannelBindingsSection projectId={projectId} /> : null');
+    // The bindings table renders only when a channel is connected (`install`).
+    // Robust to formatting + extra props (e.g. read-only `canWrite` gating).
+    expect(channelsSource).toMatch(/install \? \(?\s*<ChannelBindingsSection\b/);
   });
 
   test('reads/writes bindings through the shared channel-bindings hook (no ad-hoc fetches)', () => {

--- a/apps/web/src/features/workspace/customize/sections/component/config-entity-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/component/config-entity-view.tsx
@@ -49,6 +49,14 @@ export interface ConfigEntityViewProps<T extends ConfigEntity> {
   /** Lowercase singular used in inline copy ("No matches", "{noun} body is empty"). */
   noun: string;
 
+  /**
+   * Whether the viewer may create/edit entities. Defaults to `true` so any
+   * caller that doesn't gate stays unchanged. When `false` the section renders
+   * READ-ONLY — the "New" and "Edit" mutating controls are hidden — so a role
+   * holding only the READ leaf sees the list + detail without buttons that 403.
+   */
+  canWrite?: boolean;
+
   className?: string;
   // Section shell
   title: string;
@@ -118,6 +126,7 @@ export function ConfigEntityView<T extends ConfigEntity>(props: ConfigEntityView
     emptyBodyLabel,
     renderContext,
     layout = 'accordion',
+    canWrite = true,
     className,
   } = props;
 
@@ -193,20 +202,22 @@ export function ConfigEntityView<T extends ConfigEntity>(props: ConfigEntityView
       title={emptyTitle}
       action={
         <div className="flex flex-col items-center gap-2">
-          <Button
-            variant="outline"
-            size="sm"
-            className="gap-1.5"
-            onClick={() => configure.start(newConfigPrompt(kind))}
-            disabled={configure.pending}
-          >
-            {configure.pending ? (
-              <Loading className="size-3.5 shrink-0" />
-            ) : (
-              <Plus className="size-3.5 shrink-0" />
-            )}
-            Create {noun}
-          </Button>
+          {canWrite ? (
+            <Button
+              variant="outline"
+              size="sm"
+              className="gap-1.5"
+              onClick={() => configure.start(newConfigPrompt(kind))}
+              disabled={configure.pending}
+            >
+              {configure.pending ? (
+                <Loading className="size-3.5 shrink-0" />
+              ) : (
+                <Plus className="size-3.5 shrink-0" />
+              )}
+              Create {noun}
+            </Button>
+          ) : null}
           {emptyDocsHref ? (
             <Button asChild variant="ghost" size="sm" className="gap-1.5">
               <a href={emptyDocsHref} target="_blank" rel="noopener noreferrer">
@@ -248,6 +259,7 @@ export function ConfigEntityView<T extends ConfigEntity>(props: ConfigEntityView
                   renderDetailMeta={renderDetailMeta}
                   renderDetailExtra={renderDetailExtra}
                   emptyBodyLabel={emptyBodyLabel}
+                  canWrite={canWrite}
                 />
               </li>
             ))}
@@ -339,6 +351,7 @@ export function ConfigEntityView<T extends ConfigEntity>(props: ConfigEntityView
                 renderDetailTitle={renderDetailTitle}
                 renderDetailMeta={renderDetailMeta}
                 emptyBodyLabel={emptyBodyLabel}
+                canWrite={canWrite}
                 split
               />
             </div>
@@ -377,19 +390,21 @@ export function ConfigEntityView<T extends ConfigEntity>(props: ConfigEntityView
       action={
         <div className="flex items-center gap-1.5">
           <MarketplaceSectionButton projectId={projectId} />
-          <Button
-            size="sm"
-            variant="secondary"
-            onClick={() => configure.start(newConfigPrompt(kind))}
-            disabled={configure.pending}
-          >
-            {configure.pending ? (
-              <Loading className="size-4 shrink-0" />
-            ) : (
-              <Plus className="size-4" />
-            )}
-            New
-          </Button>
+          {canWrite ? (
+            <Button
+              size="sm"
+              variant="secondary"
+              onClick={() => configure.start(newConfigPrompt(kind))}
+              disabled={configure.pending}
+            >
+              {configure.pending ? (
+                <Loading className="size-4 shrink-0" />
+              ) : (
+                <Plus className="size-4" />
+              )}
+              New
+            </Button>
+          ) : null}
         </div>
       }
     >
@@ -417,6 +432,7 @@ interface EntityDisclosureProps<T extends ConfigEntity> {
   renderDetailMeta?: (entity: T, config: ProjectConfigSummary) => ReactNode;
   renderDetailExtra?: (entity: T, config: ProjectConfigSummary) => ReactNode;
   emptyBodyLabel: string;
+  canWrite: boolean;
 }
 
 function EntityDisclosure<T extends ConfigEntity>({
@@ -431,6 +447,7 @@ function EntityDisclosure<T extends ConfigEntity>({
   renderDetailMeta,
   renderDetailExtra,
   emptyBodyLabel,
+  canWrite,
 }: EntityDisclosureProps<T>) {
   const [open, setOpen] = useState(false);
   const trailing = renderRowTrailing?.(entity, config);
@@ -456,6 +473,7 @@ function EntityDisclosure<T extends ConfigEntity>({
           renderDetailMeta={renderDetailMeta}
           renderDetailExtra={renderDetailExtra}
           emptyBodyLabel={emptyBodyLabel}
+          canWrite={canWrite}
         />
       </DisclosureContent>
     </Disclosure>
@@ -471,6 +489,8 @@ interface EntityDetailProps<T extends ConfigEntity> {
   renderDetailMeta?: (entity: T, config: ProjectConfigSummary) => ReactNode;
   renderDetailExtra?: (entity: T, config: ProjectConfigSummary) => ReactNode;
   emptyBodyLabel: string;
+  /** Read-only viewers (READ leaf, no WRITE) hide the "Edit" control. */
+  canWrite: boolean;
   /** Master-detail mode: render the source in the middle and `renderDetailExtra`
    *  as a right-hand aside, instead of stacking the extra above the source. */
   split?: boolean;
@@ -485,6 +505,7 @@ function EntityDetail<T extends ConfigEntity>({
   renderDetailMeta,
   renderDetailExtra,
   emptyBodyLabel,
+  canWrite,
   split,
 }: EntityDetailProps<T>) {
   const configure = useConfigureThread(projectId);
@@ -558,6 +579,7 @@ function EntityDetail<T extends ConfigEntity>({
         onEdit={() => configure.start(editConfigPrompt(kind, entity.name, entity.path))}
         editing={configure.pending}
         copyDisabled={!fileQuery.data?.content}
+        canWrite={canWrite}
       />
     </div>
   );
@@ -588,24 +610,28 @@ function DetailToolbarActions({
   onEdit,
   editing,
   copyDisabled,
+  canWrite,
 }: {
   onCopy: () => void;
   onEdit: () => void;
   editing: boolean;
   copyDisabled: boolean;
+  canWrite: boolean;
 }) {
   return (
     <ButtonGroup className="shrink-0">
-      <Hint label="Edit">
-        <Button variant="outline" size="sm" onClick={onEdit} disabled={editing}>
-          {editing ? (
-            <Loading className="size-3.5 shrink-0" />
-          ) : (
-            <Pencil className="size-3.5 shrink-0" />
-          )}
-          Edit
-        </Button>
-      </Hint>
+      {canWrite ? (
+        <Hint label="Edit">
+          <Button variant="outline" size="sm" onClick={onEdit} disabled={editing}>
+            {editing ? (
+              <Loading className="size-3.5 shrink-0" />
+            ) : (
+              <Pencil className="size-3.5 shrink-0" />
+            )}
+            Edit
+          </Button>
+        </Hint>
+      ) : null}
       <Hint label="Copy source">
         <Button variant="outline" size="icon" onClick={onCopy} disabled={copyDisabled}>
           <Copy className="size-3.5 shrink-0" />

--- a/apps/web/src/features/workspace/customize/sections/connectors-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/connectors-view.tsx
@@ -98,6 +98,8 @@ import {
   useSlackMode,
   useUpdateEmailPolicy,
 } from '@/hooks/channels/use-channels-installations';
+import { PROJECT_ACTIONS } from '@/lib/project-actions';
+import { useProjectCan } from '@/lib/use-project-can';
 import { cn } from '@/lib/utils';
 import {
   type AdminConnector,
@@ -254,6 +256,11 @@ function ConnectorsMasterDetail({ projectId }: { projectId: string }) {
     staleTime: 10_000,
   });
   const connectors = useMemo(() => query.data?.connectors ?? [], [query.data]);
+  // Section shows to any role holding the connector READ leaf; the mutating
+  // controls below gate on WRITE. Defaults false until the probe resolves →
+  // fails safe (read-only) rather than flashing editable controls that 403.
+  const canWrite =
+    useProjectCan(projectId, PROJECT_ACTIONS.PROJECT_CONNECTOR_WRITE).allowed === true;
   const emailChannelEnabled = projectQuery.data?.experimental?.agentmail_email === true;
   const isForbidden = query.isError && /403|forbidden/i.test((query.error as Error)?.message ?? '');
 
@@ -360,6 +367,7 @@ function ConnectorsMasterDetail({ projectId }: { projectId: string }) {
             key={active.slug}
             projectId={projectId}
             connector={active}
+            canWrite={canWrite}
             onChanged={invalidate}
             onRemoved={() => {
               invalidate();
@@ -737,11 +745,13 @@ function RailItem({
 function ConnectorDetail({
   projectId,
   connector,
+  canWrite,
   onChanged,
   onRemoved,
 }: {
   projectId: string;
   connector: AdminConnector;
+  canWrite: boolean;
   onChanged: () => void;
   onRemoved: () => void;
 }) {
@@ -793,7 +803,9 @@ function ConnectorDetail({
       <div className="flex items-start gap-3.5">
         <ConnectorAppIcon projectId={projectId} connector={connector} size="lg" />
         <div className="min-w-0 flex-1">
-          {editingName ? (
+          {!canWrite ? (
+            <h2 className="text-foreground truncate text-lg font-semibold">{displayName}</h2>
+          ) : editingName ? (
             <form
               className="flex items-center gap-1.5"
               onSubmit={(e) => {
@@ -870,7 +882,8 @@ function ConnectorDetail({
             When NOT connected, the connect action is a big CTA below — not a
             small header button buried next to the title. (Channel connectors
             are managed from the Channels tab, so neither shows.) */}
-        {connector.authSecret &&
+        {canWrite &&
+          connector.authSecret &&
           connected &&
           !isChannel &&
           (isPipedream ? (
@@ -927,7 +940,7 @@ function ConnectorDetail({
           </InfoBanner>
         )}
         {/* Prominent connect CTA — the first thing you see on an unconnected connector. */}
-        {connector.authSecret && !connected && !isChannel && (
+        {canWrite && connector.authSecret && !connected && !isChannel && (
           <InfoBanner
             tone="info"
             icon={KeyRound}
@@ -952,7 +965,10 @@ function ConnectorDetail({
         {/* The sensitive toggle lives under Permissions (it IS a permission
             default), so Profile only exists when there's a connection to
             manage — for Pipedream/managed connectors it would be empty. */}
-        <Tabs defaultValue={!isPipedream && !isManaged ? 'profile' : 'permissions'} className="gap-3">
+        <Tabs
+          defaultValue={!isPipedream && !isManaged ? 'profile' : 'permissions'}
+          className="gap-3"
+        >
           <TabsList>
             {!isPipedream && !isManaged && <TabsTrigger value="profile">Profile</TabsTrigger>}
             <TabsTrigger value="permissions">Permissions</TabsTrigger>
@@ -963,6 +979,7 @@ function ConnectorDetail({
                 <ChannelConnectionSection
                   projectId={projectId}
                   connector={connector}
+                  canWrite={canWrite}
                   onChanged={onChanged}
                   onRemoved={onRemoved}
                 />
@@ -970,6 +987,7 @@ function ConnectorDetail({
                 <ConnectionSection
                   projectId={projectId}
                   connector={connector}
+                  canWrite={canWrite}
                   onChanged={onChanged}
                 />
               )}
@@ -979,12 +997,13 @@ function ConnectorDetail({
             <PermissionsSection
               projectId={projectId}
               connector={connector}
+              canWrite={canWrite}
               onChanged={onChanged}
             />
           </TabsContent>
         </Tabs>
 
-        {!isManaged && !isChannel && (
+        {canWrite && !isManaged && !isChannel && (
           <SectionCard
             tone="destructive"
             title={tI18nHardcoded.raw(
@@ -1057,11 +1076,13 @@ function connectorPlatform(connector: AdminConnector): ChannelPlatform | null {
 function ChannelConnectionSection({
   projectId,
   connector,
+  canWrite,
   onChanged,
   onRemoved,
 }: {
   projectId: string;
   connector: AdminConnector;
+  canWrite: boolean;
   onChanged: () => void;
   onRemoved: () => void;
 }) {
@@ -1071,6 +1092,7 @@ function ChannelConnectionSection({
       <EmailChannelProfile
         projectId={projectId}
         connector={connector}
+        canWrite={canWrite}
         onChanged={onChanged}
         onRemoved={onRemoved}
       />
@@ -1078,7 +1100,12 @@ function ChannelConnectionSection({
   }
   if (platform === 'slack') {
     return (
-      <SlackChannelProfile projectId={projectId} onChanged={onChanged} onRemoved={onRemoved} />
+      <SlackChannelProfile
+        projectId={projectId}
+        canWrite={canWrite}
+        onChanged={onChanged}
+        onRemoved={onRemoved}
+      />
     );
   }
   return (
@@ -1091,11 +1118,13 @@ function ChannelConnectionSection({
 function EmailChannelProfile({
   projectId,
   connector,
+  canWrite,
   onChanged,
   onRemoved,
 }: {
   projectId: string;
   connector: AdminConnector;
+  canWrite: boolean;
   onChanged: () => void;
   onRemoved: () => void;
 }) {
@@ -1113,14 +1142,19 @@ function EmailChannelProfile({
           projectId={projectId}
           connectorSlug={connector.slug}
           installation={install.data}
+          canWrite={canWrite}
           onRemoved={onRemoved}
         />
-      ) : (
+      ) : canWrite ? (
         <EmailConnectForm
           projectId={projectId}
           connectorSlug={connector.slug}
           onConnected={onChanged}
         />
+      ) : (
+        <InfoBanner tone="neutral" icon={Mail} title="No email inbox connected">
+          You have read-only access to connectors. Ask a workspace admin to connect an inbox.
+        </InfoBanner>
       )}
     </SectionCard>
   );
@@ -1130,11 +1164,13 @@ function ConnectedEmailProfile({
   projectId,
   connectorSlug,
   installation,
+  canWrite,
   onRemoved,
 }: {
   projectId: string;
   connectorSlug: string;
   installation: EmailInstallation;
+  canWrite: boolean;
   onRemoved: () => void;
 }) {
   const disconnect = useDisconnectEmail();
@@ -1155,42 +1191,47 @@ function ConnectedEmailProfile({
         projectId={projectId}
         connectorSlug={connectorSlug}
         policy={installation.senderPolicy}
+        canWrite={canWrite}
       />
-      <div className="flex items-center justify-end gap-2">
-        {confirming ? (
-          <>
-            <span className="text-muted-foreground mr-auto text-xs">
-              Removes the Email channel profile from this project.
-            </span>
-            <Button variant="ghost" size="sm" onClick={() => setConfirming(false)}>
-              Cancel
-            </Button>
-            <Button
-              variant="destructive"
-              size="sm"
-              disabled={disconnect.isPending}
-              onClick={() =>
-                disconnect.mutate(
-                  { projectId, connectorSlug },
-                  {
-                    onSuccess: () => {
-                      setConfirming(false);
-                      onRemoved();
+      {canWrite && (
+        <div className="flex items-center justify-end gap-2">
+          {confirming ? (
+            <>
+              <span className="text-muted-foreground mr-auto text-xs">
+                Removes the Email channel profile from this project.
+              </span>
+              <Button variant="ghost" size="sm" onClick={() => setConfirming(false)}>
+                Cancel
+              </Button>
+              <Button
+                variant="destructive"
+                size="sm"
+                disabled={disconnect.isPending}
+                onClick={() =>
+                  disconnect.mutate(
+                    { projectId, connectorSlug },
+                    {
+                      onSuccess: () => {
+                        setConfirming(false);
+                        onRemoved();
+                      },
                     },
-                  },
-                )
-              }
-            >
-              {disconnect.isPending ? <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" /> : null}
+                  )
+                }
+              >
+                {disconnect.isPending ? (
+                  <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" />
+                ) : null}
+                Disconnect
+              </Button>
+            </>
+          ) : (
+            <Button variant="outline" size="sm" onClick={() => setConfirming(true)}>
               Disconnect
             </Button>
-          </>
-        ) : (
-          <Button variant="outline" size="sm" onClick={() => setConfirming(true)}>
-            Disconnect
-          </Button>
-        )}
-      </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }
@@ -1221,10 +1262,12 @@ function EmailSenderPolicyEditor({
   projectId,
   connectorSlug,
   policy,
+  canWrite,
 }: {
   projectId: string;
   connectorSlug: string;
   policy: EmailSenderPolicy | null | undefined;
+  canWrite: boolean;
 }) {
   const update = useUpdateEmailPolicy();
   const initial = normalizeEmailSenderPolicy(policy);
@@ -1280,6 +1323,7 @@ function EmailSenderPolicyEditor({
           id="email-sender-restricted"
           checked={restricted}
           onCheckedChange={(checked) => setRestricted(Boolean(checked))}
+          disabled={!canWrite}
           className="mt-0.5"
         />
         <div className="min-w-0 flex-1 space-y-3">
@@ -1297,6 +1341,7 @@ function EmailSenderPolicyEditor({
                   value={emails}
                   onChange={(e) => setEmails(e.target.value)}
                   placeholder="person@example.com"
+                  disabled={!canWrite}
                 />
               </Field>
               <Field>
@@ -1304,6 +1349,7 @@ function EmailSenderPolicyEditor({
                   value={domains}
                   onChange={(e) => setDomains(e.target.value)}
                   placeholder="example.com"
+                  disabled={!canWrite}
                 />
               </Field>
               <div className="sm:col-span-2">
@@ -1313,24 +1359,27 @@ function EmailSenderPolicyEditor({
                     onChange={(e) => setRegex(e.target.value)}
                     placeholder=".*@customer-[0-9]+\\.com$"
                     spellCheck={false}
+                    disabled={!canWrite}
                   />
                 </Field>
               </div>
             </div>
           ) : null}
           {error ? <InfoBanner tone="destructive">{error}</InfoBanner> : null}
-          <SaveBar
-            dirty={dirty}
-            saving={update.isPending}
-            onSave={save}
-            onReset={() => {
-              setRestricted(initial.mode === 'restricted');
-              setEmails(initial.allowedEmails.join('\n'));
-              setDomains(initial.allowedDomains.join('\n'));
-              setRegex(initial.allowedRegex ?? '');
-            }}
-            label="Save policy"
-          />
+          {canWrite && (
+            <SaveBar
+              dirty={dirty}
+              saving={update.isPending}
+              onSave={save}
+              onReset={() => {
+                setRestricted(initial.mode === 'restricted');
+                setEmails(initial.allowedEmails.join('\n'));
+                setDomains(initial.allowedDomains.join('\n'));
+                setRegex(initial.allowedRegex ?? '');
+              }}
+              label="Save policy"
+            />
+          )}
         </div>
       </div>
     </div>
@@ -1601,10 +1650,12 @@ export function EmailConnectForm({
 
 function SlackChannelProfile({
   projectId,
+  canWrite,
   onChanged,
   onRemoved,
 }: {
   projectId: string;
+  canWrite: boolean;
   onChanged: () => void;
   onRemoved: () => void;
 }) {
@@ -1620,10 +1671,15 @@ function SlackChannelProfile({
         <ConnectedSlackProfile
           projectId={projectId}
           installation={install.data}
+          canWrite={canWrite}
           onRemoved={onRemoved}
         />
-      ) : (
+      ) : canWrite ? (
         <SlackConnectForm projectId={projectId} onConnected={onChanged} />
+      ) : (
+        <InfoBanner tone="neutral" icon={<SlackLogo />} title="No Slack workspace connected">
+          You have read-only access to connectors. Ask a workspace admin to connect Slack.
+        </InfoBanner>
       )}
     </SectionCard>
   );
@@ -1632,10 +1688,12 @@ function SlackChannelProfile({
 function ConnectedSlackProfile({
   projectId,
   installation,
+  canWrite,
   onRemoved,
 }: {
   projectId: string;
   installation: SlackInstallation;
+  canWrite: boolean;
   onRemoved: () => void;
 }) {
   const disconnect = useDisconnectSlack();
@@ -1646,38 +1704,42 @@ function ConnectedSlackProfile({
         Workspace{' '}
         <code className="font-mono">{installation.workspaceName || installation.workspaceId}</code>
       </InfoBanner>
-      <div className="flex items-center justify-end gap-2">
-        {confirming ? (
-          <>
-            <span className="text-muted-foreground mr-auto text-xs">
-              Removes the Slack channel profile from this project.
-            </span>
-            <Button variant="ghost" size="sm" onClick={() => setConfirming(false)}>
-              Cancel
-            </Button>
-            <Button
-              variant="destructive"
-              size="sm"
-              disabled={disconnect.isPending}
-              onClick={() =>
-                disconnect.mutate(projectId, {
-                  onSuccess: () => {
-                    setConfirming(false);
-                    onRemoved();
-                  },
-                })
-              }
-            >
-              {disconnect.isPending ? <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" /> : null}
+      {canWrite && (
+        <div className="flex items-center justify-end gap-2">
+          {confirming ? (
+            <>
+              <span className="text-muted-foreground mr-auto text-xs">
+                Removes the Slack channel profile from this project.
+              </span>
+              <Button variant="ghost" size="sm" onClick={() => setConfirming(false)}>
+                Cancel
+              </Button>
+              <Button
+                variant="destructive"
+                size="sm"
+                disabled={disconnect.isPending}
+                onClick={() =>
+                  disconnect.mutate(projectId, {
+                    onSuccess: () => {
+                      setConfirming(false);
+                      onRemoved();
+                    },
+                  })
+                }
+              >
+                {disconnect.isPending ? (
+                  <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" />
+                ) : null}
+                Disconnect
+              </Button>
+            </>
+          ) : (
+            <Button variant="outline" size="sm" onClick={() => setConfirming(true)}>
               Disconnect
             </Button>
-          </>
-        ) : (
-          <Button variant="outline" size="sm" onClick={() => setConfirming(true)}>
-            Disconnect
-          </Button>
-        )}
-      </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }
@@ -1931,10 +1993,12 @@ function connectionSig(d: ConnectorDraftInput): string {
 function ConnectionSection({
   projectId,
   connector,
+  canWrite,
   onChanged,
 }: {
   projectId: string;
   connector: AdminConnector;
+  canWrite: boolean;
   onChanged: () => void;
 }) {
   const tI18nHardcoded = useTranslations('hardcodedUi');
@@ -2003,17 +2067,19 @@ function ConnectionSection({
         </div>
       ) : (
         <div className="space-y-4">
-          <ConnectorConfigFields draft={draft} onChange={setDraft} />
-          <SaveBar
-            dirty={dirty}
-            saving={save.isPending}
-            disabled={!connectionValid(draft)}
-            onSave={() => save.mutate()}
-            onReset={reset}
-            label={tI18nHardcoded.raw(
-              'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrLabelSave8c6f945f',
-            )}
-          />
+          <ConnectorConfigFields draft={draft} onChange={setDraft} readOnly={!canWrite} />
+          {canWrite && (
+            <SaveBar
+              dirty={dirty}
+              saving={save.isPending}
+              disabled={!connectionValid(draft)}
+              onSave={() => save.mutate()}
+              onReset={reset}
+              label={tI18nHardcoded.raw(
+                'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrLabelSave8c6f945f',
+              )}
+            />
+          )}
         </div>
       )}
     </SectionCard>
@@ -2128,10 +2194,12 @@ function tsSignature(slug: string, action: ConnectorAction): string {
 function PermissionsSection({
   projectId,
   connector,
+  canWrite,
   onChanged,
 }: {
   projectId: string;
   connector: AdminConnector;
+  canWrite: boolean;
   onChanged: () => void;
 }) {
   const tI18nHardcoded = useTranslations('hardcodedUi');
@@ -2298,7 +2366,7 @@ function PermissionsSection({
               description="Reads run automatically; writes and destructive actions still ask, per the rules below."
               size="lg"
               variant="outline"
-              disabled={sensitiveMut.isPending}
+              disabled={!canWrite || sensitiveMut.isPending}
             />
             <RadioGroupItem
               value="ask_first"
@@ -2315,7 +2383,7 @@ function PermissionsSection({
               }
               size="lg"
               variant="outline"
-              disabled={sensitiveMut.isPending}
+              disabled={!canWrite || sensitiveMut.isPending}
             />
           </RadioGroup>
         </div>
@@ -2335,17 +2403,19 @@ function PermissionsSection({
           <div className="border-border/60 overflow-hidden rounded-2xl border">
             {/* Select-all + bulk apply */}
             <div className="border-border/60 bg-muted/30 flex h-9 items-center gap-2 border-b px-3">
-              <Checkbox
-                checked={
-                  allFilteredSelected ? true : someFilteredSelected ? 'indeterminate' : false
-                }
-                onCheckedChange={toggleAllFiltered}
-                aria-label={tI18nHardcoded.raw(
-                  'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrAriaLabel924a321f',
-                )}
-                className="size-3.5"
-              />
-              {selected.size > 0 ? (
+              {canWrite && (
+                <Checkbox
+                  checked={
+                    allFilteredSelected ? true : someFilteredSelected ? 'indeterminate' : false
+                  }
+                  onCheckedChange={toggleAllFiltered}
+                  aria-label={tI18nHardcoded.raw(
+                    'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrAriaLabel924a321f',
+                  )}
+                  className="size-3.5"
+                />
+              )}
+              {canWrite && selected.size > 0 ? (
                 <>
                   <span className="text-foreground text-xs font-medium">
                     {selected.size} selected
@@ -2402,17 +2472,19 @@ function PermissionsSection({
                         isSel ? 'bg-primary/[0.05]' : 'hover:bg-muted/30',
                       )}
                     >
-                      <Checkbox
-                        checked={isSel}
-                        onCheckedChange={() => toggleSel(t.path)}
-                        aria-label={`Select ${t.path}`}
-                        className={cn(
-                          'size-3.5 shrink-0 transition-opacity',
-                          isSel
-                            ? ''
-                            : 'opacity-0 group-hover:opacity-100 focus-visible:opacity-100',
-                        )}
-                      />
+                      {canWrite && (
+                        <Checkbox
+                          checked={isSel}
+                          onCheckedChange={() => toggleSel(t.path)}
+                          aria-label={`Select ${t.path}`}
+                          className={cn(
+                            'size-3.5 shrink-0 transition-opacity',
+                            isSel
+                              ? ''
+                              : 'opacity-0 group-hover:opacity-100 focus-visible:opacity-100',
+                          )}
+                        />
+                      )}
                       <button
                         type="button"
                         onClick={() => setExpanded(isOpen ? null : t.path)}
@@ -2447,10 +2519,21 @@ function PermissionsSection({
                             : 'text-muted-foreground/40 opacity-0 group-hover:opacity-100',
                         )}
                       />
-                      <PermissionPicker
-                        value={explicit ?? 'default'}
-                        onChange={(c) => setChoice(t.path, c)}
-                      />
+                      {canWrite ? (
+                        <PermissionPicker
+                          value={explicit ?? 'default'}
+                          onChange={(c) => setChoice(t.path, c)}
+                        />
+                      ) : (
+                        <span
+                          className={cn(
+                            'shrink-0 px-2 py-0.5 text-xs font-medium',
+                            explicit ? POLICY_LABEL[explicit].tint : 'text-muted-foreground',
+                          )}
+                        >
+                          {explicit ? POLICY_LABEL[explicit].label : 'Default'}
+                        </span>
+                      )}
                     </div>
                     {isOpen && (
                       <div className="bg-muted/20 space-y-3 px-4 pt-1 pb-3">
@@ -2553,9 +2636,11 @@ function PermissionsSection({
                         'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrPlaceholderSend3b0a4ee1',
                       )}
                       className="h-8 flex-1 font-mono text-xs"
+                      disabled={!canWrite}
                     />
                     <Select
                       value={r.action}
+                      disabled={!canWrite}
                       onValueChange={(v) =>
                         setRules((rs) =>
                           rs.map((x) =>
@@ -2577,50 +2662,58 @@ function PermissionsSection({
                         ))}
                       </SelectContent>
                     </Select>
-                    <Button
-                      size="icon"
-                      variant="ghost"
-                      className="hover:text-destructive h-8 w-8 shrink-0"
-                      onClick={() => setRules((rs) => rs.filter((x) => x.id !== r.id))}
-                      aria-label={tI18nHardcoded.raw(
-                        'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrAriaLabeld2296c34',
-                      )}
-                    >
-                      <Trash2 className="h-3.5 w-3.5" />
-                    </Button>
+                    {canWrite && (
+                      <Button
+                        size="icon"
+                        variant="ghost"
+                        className="hover:text-destructive h-8 w-8 shrink-0"
+                        onClick={() => setRules((rs) => rs.filter((x) => x.id !== r.id))}
+                        aria-label={tI18nHardcoded.raw(
+                          'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrAriaLabeld2296c34',
+                        )}
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
+                      </Button>
+                    )}
                   </div>
                 ))}
-                <Button
-                  size="sm"
-                  variant="outline"
-                  className="h-8 gap-1.5 text-xs"
-                  onClick={() =>
-                    setRules((rs) => [
-                      ...rs,
-                      { id: ruleId(), match: '', action: 'require_approval' },
-                    ])
-                  }
-                >
-                  <Plus className="h-3.5 w-3.5" />
-                  {tI18nHardcoded.raw(
-                    'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxTextAddRule873a093f',
-                  )}
-                </Button>
+                {canWrite ? (
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="h-8 gap-1.5 text-xs"
+                    onClick={() =>
+                      setRules((rs) => [
+                        ...rs,
+                        { id: ruleId(), match: '', action: 'require_approval' },
+                      ])
+                    }
+                  >
+                    <Plus className="h-3.5 w-3.5" />
+                    {tI18nHardcoded.raw(
+                      'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxTextAddRule873a093f',
+                    )}
+                  </Button>
+                ) : rules.length === 0 ? (
+                  <p className="text-muted-foreground text-xs">No pattern rules.</p>
+                ) : null}
               </div>
             )}
           </div>
         )}
       </div>
 
-      <SaveBar
-        dirty={dirty}
-        saving={save.isPending}
-        onSave={() => save.mutate()}
-        onReset={reset}
-        label={tI18nHardcoded.raw(
-          'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrLabelSave783950c7',
-        )}
-      />
+      {canWrite && (
+        <SaveBar
+          dirty={dirty}
+          saving={save.isPending}
+          onSave={() => save.mutate()}
+          onReset={reset}
+          label={tI18nHardcoded.raw(
+            'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrLabelSave783950c7',
+          )}
+        />
+      )}
     </SectionCard>
   );
 }
@@ -2648,7 +2741,6 @@ function GlobalRulesPanel({ projectId }: { projectId: string }) {
     </div>
   );
 }
-
 
 function AddAppPanel({
   projectId,
@@ -3069,11 +3161,13 @@ function ConnectorConfigFields({
   draft,
   onChange,
   slugEditable,
+  readOnly = false,
   emailChannelEnabled = true,
 }: {
   draft: ConnectorDraftInput;
   onChange: (d: ConnectorDraftInput) => void;
   slugEditable?: boolean;
+  readOnly?: boolean;
   emailChannelEnabled?: boolean;
 }) {
   const tI18nHardcoded = useTranslations('hardcodedUi');
@@ -3097,7 +3191,7 @@ function ConnectorConfigFields({
             placeholder="my-api"
             className="font-mono text-xs"
             variant="popover"
-            disabled={!slugEditable}
+            disabled={!slugEditable || readOnly}
             required
           />
         </Field>
@@ -3105,6 +3199,7 @@ function ConnectorConfigFields({
           <FieldLabel htmlFor="connector-provider">Provider</FieldLabel>
           <Select
             value={p}
+            disabled={readOnly}
             onValueChange={(v) => {
               const provider = v as ConnectorDraftInput['provider'];
               set({
@@ -3141,6 +3236,7 @@ function ConnectorConfigFields({
                 ? 'slack'
                 : (draft.platform ?? (emailChannelEnabled ? 'email' : 'slack'))
             }
+            disabled={readOnly}
             onValueChange={(v) => set({ platform: v as ChannelPlatform, auth: { type: 'none' } })}
           >
             <SelectTrigger>
@@ -3166,6 +3262,7 @@ function ConnectorConfigFields({
             onChange={(e) => set({ spec: e.target.value })}
             placeholder="https://…/openapi.json"
             variant="popover"
+            disabled={readOnly}
             required
           />
         </Field>
@@ -3180,6 +3277,7 @@ function ConnectorConfigFields({
               onChange={(e) => set({ endpoint: e.target.value })}
               placeholder="https://api/graphql"
               variant="popover"
+              disabled={readOnly}
               required
             />
           </Field>
@@ -3195,6 +3293,7 @@ function ConnectorConfigFields({
               onChange={(e) => set({ spec: e.target.value })}
               placeholder=".kortix/executor/schema.graphql"
               variant="popover"
+              disabled={readOnly}
             />
           </Field>
         </>
@@ -3209,6 +3308,7 @@ function ConnectorConfigFields({
               onChange={(e) => set({ url: e.target.value })}
               placeholder="https://mcp…/mcp"
               variant="popover"
+              disabled={readOnly}
               required
             />
           </Field>
@@ -3216,6 +3316,7 @@ function ConnectorConfigFields({
             <FieldLabel htmlFor="connector-transport">Transport</FieldLabel>
             <Select
               value={draft.transport ?? 'http'}
+              disabled={readOnly}
               onValueChange={(v) => set({ transport: v as 'http' | 'sse' })}
             >
               <SelectTrigger id="connector-transport" className="w-full" variant="popover">
@@ -3243,6 +3344,7 @@ function ConnectorConfigFields({
               onChange={(e) => set({ baseUrl: e.target.value })}
               placeholder="https://api.internal"
               variant="popover"
+              disabled={readOnly}
               required
             />
           </Field>
@@ -3258,6 +3360,7 @@ function ConnectorConfigFields({
               onChange={(e) => set({ spec: e.target.value })}
               placeholder=".kortix/executor/routes.toml"
               variant="popover"
+              disabled={readOnly}
             />
           </Field>
         </>
@@ -3268,6 +3371,7 @@ function ConnectorConfigFields({
             <FieldLabel htmlFor="connector-auth">Auth</FieldLabel>
             <Select
               value={draft.auth?.type ?? 'none'}
+              disabled={readOnly}
               onValueChange={(v) => setAuth({ type: v as 'none' | 'bearer' | 'basic' | 'custom' })}
             >
               <SelectTrigger id="connector-auth" className="w-full" variant="popover">
@@ -3298,6 +3402,7 @@ function ConnectorConfigFields({
                 onChange={(e) => setAuth({ name: e.target.value })}
                 placeholder="X-API-Key"
                 variant="popover"
+                disabled={readOnly}
                 required
               />
             </Field>
@@ -3377,7 +3482,9 @@ export function CustomConnectorForm({
             <Button
               type="submit"
               size="sm"
-              disabled={!draft.slug || save.isPending || !connectionValid(draft, emailChannelEnabled)}
+              disabled={
+                !draft.slug || save.isPending || !connectionValid(draft, emailChannelEnabled)
+              }
               className="gap-1.5"
             >
               {save.isPending && <Loader2 className="h-4 w-4 animate-spin" />}

--- a/apps/web/src/features/workspace/customize/sections/connectors-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/connectors-view.tsx
@@ -12,7 +12,6 @@ import {
   ExternalLink,
   Globe,
   KeyRound,
-  Loader2,
   type LucideIcon,
   Mail,
   MessageSquare,
@@ -33,19 +32,13 @@ import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { type ReactNode, useEffect, useMemo, useState } from 'react';
 
 import { PoliciesPanel } from '@/components/projects/policies-panel';
+import { PROJECT_ACTIONS } from '@/lib/project-actions';
+import { useProjectCan } from '@/lib/use-project-can';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { CodeBlockCode } from '@/components/ui/code-block';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -70,7 +63,6 @@ import {
   ModalTitle,
 } from '@/components/ui/modal';
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
-import { SectionCard } from '@/components/ui/section-card';
 import {
   Select,
   SelectContent,
@@ -81,7 +73,6 @@ import {
 import { Skeleton } from '@/components/ui/skeleton';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { errorToast, successToast, warningToast } from '@/components/ui/toast';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { EmptyState } from '@/features/layout/section/empty-state';
 import {
   type EmailInstallation,
@@ -98,8 +89,6 @@ import {
   useSlackMode,
   useUpdateEmailPolicy,
 } from '@/hooks/channels/use-channels-installations';
-import { PROJECT_ACTIONS } from '@/lib/project-actions';
-import { useProjectCan } from '@/lib/use-project-can';
 import { cn } from '@/lib/utils';
 import {
   type AdminConnector,
@@ -256,13 +245,13 @@ function ConnectorsMasterDetail({ projectId }: { projectId: string }) {
     staleTime: 10_000,
   });
   const connectors = useMemo(() => query.data?.connectors ?? [], [query.data]);
-  // Section shows to any role holding the connector READ leaf; the mutating
-  // controls below gate on WRITE. Defaults false until the probe resolves →
-  // fails safe (read-only) rather than flashing editable controls that 403.
-  const canWrite =
-    useProjectCan(projectId, PROJECT_ACTIONS.PROJECT_CONNECTOR_WRITE).allowed === true;
   const emailChannelEnabled = projectQuery.data?.experimental?.agentmail_email === true;
   const isForbidden = query.isError && /403|forbidden/i.test((query.error as Error)?.message ?? '');
+  // READ vs WRITE: the section is visible to project.connector.read, but every
+  // mutating control (rename/remove/reconnect/credentials/permissions/channels/
+  // config) is gated on project.connector.write. Fails closed until the probe
+  // resolves, matching the backend's assertProjectCapability on those routes.
+  const canWrite = useProjectCan(projectId, PROJECT_ACTIONS.PROJECT_CONNECTOR_WRITE).allowed === true;
 
   // Selection persists in ?c= (slug | "global" | "add") for deep links.
   const search = useSearchParams();
@@ -348,6 +337,7 @@ function ConnectorsMasterDetail({ projectId }: { projectId: string }) {
           onSelect={select}
           onSync={() => sync.mutate()}
           syncing={sync.isPending}
+          canWrite={canWrite}
         />
       )}
       <div className="min-h-0 min-w-0 flex-1 overflow-y-auto">
@@ -355,6 +345,7 @@ function ConnectorsMasterDetail({ projectId }: { projectId: string }) {
           <AddAppPanel
             projectId={projectId}
             emailChannelEnabled={emailChannelEnabled}
+            canWrite={canWrite}
             onAdded={(slug) => {
               invalidate();
               if (slug) select({ kind: 'connector', slug });
@@ -460,7 +451,7 @@ function SaveBar({
         </Button>
       )}
       <Button size="sm" onClick={onSave} disabled={saving || disabled} className="gap-1.5">
-        {saving && <Loader2 className="h-4 w-4 animate-spin" />}
+        {saving && <Loading className="size-4 shrink-0" />}
         {label}
       </Button>
     </div>
@@ -474,6 +465,7 @@ function ConnectorRail({
   onSelect,
   onSync,
   syncing,
+  canWrite = false,
 }: {
   projectId: string;
   connectors: AdminConnector[];
@@ -481,6 +473,7 @@ function ConnectorRail({
   onSelect: (s: Selection) => void;
   onSync: () => void;
   syncing: boolean;
+  canWrite?: boolean;
 }) {
   const tI18nHardcoded = useTranslations('hardcodedUi');
   const [q, setQ] = useState('');
@@ -497,17 +490,19 @@ function ConnectorRail({
       className="border-border/60 bg-muted/20 flex w-72 shrink-0 flex-col border-r"
     >
       <div className="border-border/60 space-y-2 border-b p-3">
-        <Button
-          size="sm"
-          className="w-full justify-start gap-2"
-          variant={selection.kind === 'add' ? 'secondary' : 'default'}
-          onClick={() => onSelect({ kind: 'add' })}
-        >
-          <Plus className="h-4 w-4" />
-          {tI18nHardcoded.raw(
-            'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxTextAddAppb53818fa',
-          )}
-        </Button>
+        {canWrite && (
+          <Button
+            size="sm"
+            className="w-full justify-start gap-2"
+            variant={selection.kind === 'add' ? 'secondary' : 'default'}
+            onClick={() => onSelect({ kind: 'add' })}
+          >
+            <Plus className="h-4 w-4" />
+            {tI18nHardcoded.raw(
+              'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxTextAddAppb53818fa',
+            )}
+          </Button>
+        )}
         <div className="relative">
           <Search className="text-muted-foreground pointer-events-none absolute top-1/2 left-2.5 h-3.5 w-3.5 -translate-y-1/2" />
           <Input
@@ -586,24 +581,26 @@ function ConnectorRail({
         )}
       </div>
 
-      <div className="border-border/60 border-t p-2">
-        <Button
-          variant="ghost"
-          size="sm"
-          className="text-muted-foreground w-full justify-start gap-2"
-          onClick={onSync}
-          disabled={syncing}
-        >
-          {syncing ? (
-            <Loader2 className="h-3.5 w-3.5 animate-spin" />
-          ) : (
-            <RefreshCw className="h-3.5 w-3.5" />
-          )}
-          {tI18nHardcoded.raw(
-            'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxTextSyncFromb820661f',
-          )}
-        </Button>
-      </div>
+      {canWrite && (
+        <div className="border-border/60 border-t p-2">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="text-muted-foreground w-full justify-start gap-2"
+            onClick={onSync}
+            disabled={syncing}
+          >
+            {syncing ? (
+              <Loading className="size-3.5 shrink-0" />
+            ) : (
+              <RefreshCw className="h-3.5 w-3.5" />
+            )}
+            {tI18nHardcoded.raw(
+              'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxTextSyncFromb820661f',
+            )}
+          </Button>
+        </div>
+      )}
     </nav>
   );
 }
@@ -745,15 +742,15 @@ function RailItem({
 function ConnectorDetail({
   projectId,
   connector,
-  canWrite,
   onChanged,
   onRemoved,
+  canWrite = false,
 }: {
   projectId: string;
   connector: AdminConnector;
-  canWrite: boolean;
   onChanged: () => void;
   onRemoved: () => void;
+  canWrite?: boolean;
 }) {
   const tI18nHardcoded = useTranslations('hardcodedUi');
   const isPipedream = connector.provider === 'pipedream';
@@ -803,9 +800,7 @@ function ConnectorDetail({
       <div className="flex items-start gap-3.5">
         <ConnectorAppIcon projectId={projectId} connector={connector} size="lg" />
         <div className="min-w-0 flex-1">
-          {!canWrite ? (
-            <h2 className="text-foreground truncate text-lg font-semibold">{displayName}</h2>
-          ) : editingName ? (
+          {editingName && canWrite ? (
             <form
               className="flex items-center gap-1.5"
               onSubmit={(e) => {
@@ -831,7 +826,7 @@ function ConnectorDetail({
                 )}
               >
                 {rename.isPending ? (
-                  <Loader2 className="h-4 w-4 animate-spin" />
+                  <Loading className="size-4 shrink-0" />
                 ) : (
                   <Check className="h-4 w-4" />
                 )}
@@ -852,8 +847,8 @@ function ConnectorDetail({
           ) : (
             <div className="group flex items-center gap-2">
               <h2 className="text-foreground truncate text-lg font-semibold">{displayName}</h2>
-              <Tooltip>
-                <TooltipTrigger asChild>
+              {canWrite && (
+                <Hint label="Rename">
                   <button
                     type="button"
                     onClick={() => setEditingName(true)}
@@ -862,9 +857,8 @@ function ConnectorDetail({
                   >
                     <Pencil className="h-3.5 w-3.5" />
                   </button>
-                </TooltipTrigger>
-                <TooltipContent>Rename</TooltipContent>
-              </Tooltip>
+                </Hint>
+              )}
             </div>
           )}
           <div className="mt-1.5 flex items-center gap-2">
@@ -895,7 +889,7 @@ function ConnectorDetail({
               disabled={reconnect.isPending}
             >
               {reconnect.isPending ? (
-                <Loader2 className="h-4 w-4 animate-spin" />
+                <Loading className="size-4 shrink-0" />
               ) : (
                 <KeyRound className="h-4 w-4" />
               )}
@@ -940,21 +934,23 @@ function ConnectorDetail({
           </InfoBanner>
         )}
         {/* Prominent connect CTA — the first thing you see on an unconnected connector. */}
-        {canWrite && connector.authSecret && !connected && !isChannel && (
+        {connector.authSecret && !connected && !isChannel && (
           <InfoBanner
             tone="info"
             icon={KeyRound}
             title={`Connect ${displayName}`}
             action={
-              <Button
-                size="lg"
-                className="h-11 shrink-0 gap-2 px-5 font-semibold"
-                onClick={() => (isPipedream ? reconnect.mutate() : setCredOpen(true))}
-                disabled={isPipedream && reconnect.isPending}
-              >
-                {isPipedream && reconnect.isPending && <Loader2 className="h-4 w-4 animate-spin" />}
-                {isPipedream ? `Connect ${displayName}` : 'Set credential'}
-              </Button>
+              canWrite ? (
+                <Button
+                  size="lg"
+                  className="h-11 shrink-0 gap-2 px-5 font-semibold"
+                  onClick={() => (isPipedream ? reconnect.mutate() : setCredOpen(true))}
+                  disabled={isPipedream && reconnect.isPending}
+                >
+                  {isPipedream && reconnect.isPending && <Loading className="size-4 shrink-0" />}
+                  {isPipedream ? `Connect ${displayName}` : 'Set credential'}
+                </Button>
+              ) : undefined
             }
           >
             {isPipedream
@@ -965,10 +961,7 @@ function ConnectorDetail({
         {/* The sensitive toggle lives under Permissions (it IS a permission
             default), so Profile only exists when there's a connection to
             manage — for Pipedream/managed connectors it would be empty. */}
-        <Tabs
-          defaultValue={!isPipedream && !isManaged ? 'profile' : 'permissions'}
-          className="gap-3"
-        >
+        <Tabs defaultValue={!isPipedream && !isManaged ? 'profile' : 'permissions'} className="gap-3">
           <TabsList>
             {!isPipedream && !isManaged && <TabsTrigger value="profile">Profile</TabsTrigger>}
             <TabsTrigger value="permissions">Permissions</TabsTrigger>
@@ -979,16 +972,16 @@ function ConnectorDetail({
                 <ChannelConnectionSection
                   projectId={projectId}
                   connector={connector}
-                  canWrite={canWrite}
                   onChanged={onChanged}
                   onRemoved={onRemoved}
+                  canWrite={canWrite}
                 />
               ) : (
                 <ConnectionSection
                   projectId={projectId}
                   connector={connector}
-                  canWrite={canWrite}
                   onChanged={onChanged}
+                  canWrite={canWrite}
                 />
               )}
             </TabsContent>
@@ -997,33 +990,38 @@ function ConnectorDetail({
             <PermissionsSection
               projectId={projectId}
               connector={connector}
-              canWrite={canWrite}
               onChanged={onChanged}
+              canWrite={canWrite}
             />
           </TabsContent>
         </Tabs>
 
         {canWrite && !isManaged && !isChannel && (
-          <SectionCard
-            tone="destructive"
-            title={tI18nHardcoded.raw(
-              'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrTitleRemove74be1411',
-            )}
-            description={tI18nHardcoded.raw(
-              'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrDescriptionDeletes0a130396',
-            )}
-            action={
+          <div className="bg-popover rounded-md border px-4 py-3">
+            <div className="flex items-center justify-between gap-4">
+              <div className="min-w-0">
+                <p className="text-foreground text-sm font-medium">
+                  {tI18nHardcoded.raw(
+                    'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrTitleRemove74be1411',
+                  )}
+                </p>
+                <p className="text-muted-foreground mt-0.5 text-xs text-pretty">
+                  {tI18nHardcoded.raw(
+                    'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrDescriptionDeletes0a130396',
+                  )}
+                </p>
+              </div>
               <Button
                 size="sm"
                 variant="outline"
-                className="gap-1.5"
+                className="shrink-0 gap-1.5"
                 onClick={() => setConfirmDelete(true)}
               >
                 <Trash2 className="h-3.5 w-3.5" />
                 Remove
               </Button>
-            }
-          />
+            </div>
+          </div>
         )}
       </div>
 
@@ -1076,15 +1074,15 @@ function connectorPlatform(connector: AdminConnector): ChannelPlatform | null {
 function ChannelConnectionSection({
   projectId,
   connector,
-  canWrite,
   onChanged,
   onRemoved,
+  canWrite = false,
 }: {
   projectId: string;
   connector: AdminConnector;
-  canWrite: boolean;
   onChanged: () => void;
   onRemoved: () => void;
+  canWrite?: boolean;
 }) {
   const platform = connectorPlatform(connector);
   if (platform === 'email') {
@@ -1092,9 +1090,9 @@ function ChannelConnectionSection({
       <EmailChannelProfile
         projectId={projectId}
         connector={connector}
-        canWrite={canWrite}
         onChanged={onChanged}
         onRemoved={onRemoved}
+        canWrite={canWrite}
       />
     );
   }
@@ -1102,61 +1100,67 @@ function ChannelConnectionSection({
     return (
       <SlackChannelProfile
         projectId={projectId}
-        canWrite={canWrite}
         onChanged={onChanged}
         onRemoved={onRemoved}
+        canWrite={canWrite}
       />
     );
   }
   return (
-    <SectionCard title="Connection">
-      <InfoBanner tone="warning">This channel profile is missing its platform setting.</InfoBanner>
-    </SectionCard>
+    <section className="space-y-4">
+      <Label>Connection</Label>
+      <div className="bg-popover rounded-md border px-4 py-5">
+        <InfoBanner tone="warning">This channel profile is missing its platform setting.</InfoBanner>
+      </div>
+    </section>
   );
 }
 
 function EmailChannelProfile({
   projectId,
   connector,
-  canWrite,
   onChanged,
   onRemoved,
+  canWrite = false,
 }: {
   projectId: string;
   connector: AdminConnector;
-  canWrite: boolean;
   onChanged: () => void;
   onRemoved: () => void;
+  canWrite?: boolean;
 }) {
   const install = useEmailInstall(projectId, connector.slug);
 
   return (
-    <SectionCard
-      title="Email connection"
-      description="AgentMail inbox assigned to this connector profile."
-    >
-      {install.isLoading ? (
-        <Skeleton className="h-24 w-full rounded-2xl" />
-      ) : install.data ? (
-        <ConnectedEmailProfile
-          projectId={projectId}
-          connectorSlug={connector.slug}
-          installation={install.data}
-          canWrite={canWrite}
-          onRemoved={onRemoved}
-        />
-      ) : canWrite ? (
-        <EmailConnectForm
-          projectId={projectId}
-          connectorSlug={connector.slug}
-          onConnected={onChanged}
-        />
-      ) : (
-        <InfoBanner tone="neutral" icon={Mail} title="No email inbox connected">
-          You have read-only access to connectors. Ask a workspace admin to connect an inbox.
-        </InfoBanner>
-      )}
-    </SectionCard>
+    <section className="space-y-4">
+      <Label>Email connection</Label>
+      <p className="text-muted-foreground -mt-2 text-xs">
+        AgentMail inbox assigned to this connector profile.
+      </p>
+      <div className="bg-popover rounded-md border px-4 py-5">
+        {install.isLoading ? (
+          <Skeleton className="h-24 w-full rounded-2xl" />
+        ) : install.data ? (
+          <ConnectedEmailProfile
+            projectId={projectId}
+            connectorSlug={connector.slug}
+            installation={install.data}
+            onRemoved={onRemoved}
+            canWrite={canWrite}
+          />
+        ) : canWrite ? (
+          <EmailConnectForm
+            projectId={projectId}
+            connectorSlug={connector.slug}
+            onConnected={onChanged}
+          />
+        ) : (
+          <InfoBanner tone="neutral" icon={Mail} title="Email not connected">
+            This channel profile has no AgentMail inbox yet.
+          </InfoBanner>
+        )}
+      </div>
+    </section>
   );
 }
 
@@ -1164,14 +1168,14 @@ function ConnectedEmailProfile({
   projectId,
   connectorSlug,
   installation,
-  canWrite,
   onRemoved,
+  canWrite = false,
 }: {
   projectId: string;
   connectorSlug: string;
   installation: EmailInstallation;
-  canWrite: boolean;
   onRemoved: () => void;
+  canWrite?: boolean;
 }) {
   const disconnect = useDisconnectEmail();
   const [confirming, setConfirming] = useState(false);
@@ -1194,43 +1198,41 @@ function ConnectedEmailProfile({
         canWrite={canWrite}
       />
       {canWrite && (
-        <div className="flex items-center justify-end gap-2">
-          {confirming ? (
-            <>
-              <span className="text-muted-foreground mr-auto text-xs">
-                Removes the Email channel profile from this project.
-              </span>
-              <Button variant="ghost" size="sm" onClick={() => setConfirming(false)}>
-                Cancel
-              </Button>
-              <Button
-                variant="destructive"
-                size="sm"
-                disabled={disconnect.isPending}
-                onClick={() =>
-                  disconnect.mutate(
-                    { projectId, connectorSlug },
-                    {
-                      onSuccess: () => {
-                        setConfirming(false);
-                        onRemoved();
-                      },
+      <div className="flex items-center justify-end gap-2">
+        {confirming ? (
+          <>
+            <span className="text-muted-foreground mr-auto text-xs">
+              Removes the Email channel profile from this project.
+            </span>
+            <Button variant="ghost" size="sm" onClick={() => setConfirming(false)}>
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              size="sm"
+              disabled={disconnect.isPending}
+              onClick={() =>
+                disconnect.mutate(
+                  { projectId, connectorSlug },
+                  {
+                    onSuccess: () => {
+                      setConfirming(false);
+                      onRemoved();
                     },
-                  )
-                }
-              >
-                {disconnect.isPending ? (
-                  <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" />
-                ) : null}
-                Disconnect
-              </Button>
-            </>
-          ) : (
-            <Button variant="outline" size="sm" onClick={() => setConfirming(true)}>
+                  },
+                )
+              }
+            >
+              {disconnect.isPending ? <Loading className="mr-2 size-3.5 shrink-0" /> : null}
               Disconnect
             </Button>
-          )}
-        </div>
+          </>
+        ) : (
+          <Button variant="outline" size="sm" onClick={() => setConfirming(true)}>
+            Disconnect
+          </Button>
+        )}
+      </div>
       )}
     </div>
   );
@@ -1262,12 +1264,12 @@ function EmailSenderPolicyEditor({
   projectId,
   connectorSlug,
   policy,
-  canWrite,
+  canWrite = false,
 }: {
   projectId: string;
   connectorSlug: string;
   policy: EmailSenderPolicy | null | undefined;
-  canWrite: boolean;
+  canWrite?: boolean;
 }) {
   const update = useUpdateEmailPolicy();
   const initial = normalizeEmailSenderPolicy(policy);
@@ -1323,8 +1325,8 @@ function EmailSenderPolicyEditor({
           id="email-sender-restricted"
           checked={restricted}
           onCheckedChange={(checked) => setRestricted(Boolean(checked))}
-          disabled={!canWrite}
           className="mt-0.5"
+          disabled={!canWrite}
         />
         <div className="min-w-0 flex-1 space-y-3">
           <div>
@@ -1640,7 +1642,7 @@ export function EmailConnectForm({
       {error ? <InfoBanner tone="destructive">{error}</InfoBanner> : null}
       <div className="flex justify-end">
         <Button size="sm" onClick={submit} disabled={connect.isPending || mode.isLoading}>
-          {connect.isPending ? <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" /> : null}
+          {connect.isPending ? <Loading className="mr-2 size-3.5 shrink-0" /> : null}
           Create inbox
         </Button>
       </div>
@@ -1650,51 +1652,54 @@ export function EmailConnectForm({
 
 function SlackChannelProfile({
   projectId,
-  canWrite,
   onChanged,
   onRemoved,
+  canWrite = false,
 }: {
   projectId: string;
-  canWrite: boolean;
   onChanged: () => void;
   onRemoved: () => void;
+  canWrite?: boolean;
 }) {
   const install = useSlackInstall(projectId);
   return (
-    <SectionCard
-      title="Slack connection"
-      description="Slack workspace assigned to this connector profile."
-    >
-      {install.isLoading ? (
-        <Skeleton className="h-24 w-full rounded-2xl" />
-      ) : install.data ? (
-        <ConnectedSlackProfile
-          projectId={projectId}
-          installation={install.data}
-          canWrite={canWrite}
-          onRemoved={onRemoved}
-        />
-      ) : canWrite ? (
-        <SlackConnectForm projectId={projectId} onConnected={onChanged} />
-      ) : (
-        <InfoBanner tone="neutral" icon={<SlackLogo />} title="No Slack workspace connected">
-          You have read-only access to connectors. Ask a workspace admin to connect Slack.
-        </InfoBanner>
-      )}
-    </SectionCard>
+    <section className="space-y-4">
+      <Label>Slack connection</Label>
+      <p className="text-muted-foreground -mt-2 text-xs">
+        Slack workspace assigned to this connector profile.
+      </p>
+      <div className="bg-popover rounded-md border px-4 py-5">
+        {install.isLoading ? (
+          <Skeleton className="h-24 w-full rounded-2xl" />
+        ) : install.data ? (
+          <ConnectedSlackProfile
+            projectId={projectId}
+            installation={install.data}
+            onRemoved={onRemoved}
+            canWrite={canWrite}
+          />
+        ) : canWrite ? (
+          <SlackConnectForm projectId={projectId} onConnected={onChanged} />
+        ) : (
+          <InfoBanner tone="neutral" icon={<SlackLogo />} title="Slack not connected">
+            This channel profile has no Slack workspace yet.
+          </InfoBanner>
+        )}
+      </div>
+    </section>
   );
 }
 
 function ConnectedSlackProfile({
   projectId,
   installation,
-  canWrite,
   onRemoved,
+  canWrite = false,
 }: {
   projectId: string;
   installation: SlackInstallation;
-  canWrite: boolean;
   onRemoved: () => void;
+  canWrite?: boolean;
 }) {
   const disconnect = useDisconnectSlack();
   const [confirming, setConfirming] = useState(false);
@@ -1705,40 +1710,38 @@ function ConnectedSlackProfile({
         <code className="font-mono">{installation.workspaceName || installation.workspaceId}</code>
       </InfoBanner>
       {canWrite && (
-        <div className="flex items-center justify-end gap-2">
-          {confirming ? (
-            <>
-              <span className="text-muted-foreground mr-auto text-xs">
-                Removes the Slack channel profile from this project.
-              </span>
-              <Button variant="ghost" size="sm" onClick={() => setConfirming(false)}>
-                Cancel
-              </Button>
-              <Button
-                variant="destructive"
-                size="sm"
-                disabled={disconnect.isPending}
-                onClick={() =>
-                  disconnect.mutate(projectId, {
-                    onSuccess: () => {
-                      setConfirming(false);
-                      onRemoved();
-                    },
-                  })
-                }
-              >
-                {disconnect.isPending ? (
-                  <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" />
-                ) : null}
-                Disconnect
-              </Button>
-            </>
-          ) : (
-            <Button variant="outline" size="sm" onClick={() => setConfirming(true)}>
+      <div className="flex items-center justify-end gap-2">
+        {confirming ? (
+          <>
+            <span className="text-muted-foreground mr-auto text-xs">
+              Removes the Slack channel profile from this project.
+            </span>
+            <Button variant="ghost" size="sm" onClick={() => setConfirming(false)}>
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              size="sm"
+              disabled={disconnect.isPending}
+              onClick={() =>
+                disconnect.mutate(projectId, {
+                  onSuccess: () => {
+                    setConfirming(false);
+                    onRemoved();
+                  },
+                })
+              }
+            >
+              {disconnect.isPending ? <Loading className="mr-2 size-3.5 shrink-0" /> : null}
               Disconnect
             </Button>
-          )}
-        </div>
+          </>
+        ) : (
+          <Button variant="outline" size="sm" onClick={() => setConfirming(true)}>
+            Disconnect
+          </Button>
+        )}
+      </div>
       )}
     </div>
   );
@@ -1941,7 +1944,7 @@ export function SlackConnectForm({
                   onClick={submit}
                   disabled={connect.isPending || !botToken.trim() || !signingSecret.trim()}
                 >
-                  {connect.isPending ? <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" /> : null}
+                  {connect.isPending ? <Loading className="mr-2 size-3.5 shrink-0" /> : null}
                   Connect custom Slack app
                 </Button>
               </div>
@@ -1993,13 +1996,13 @@ function connectionSig(d: ConnectorDraftInput): string {
 function ConnectionSection({
   projectId,
   connector,
-  canWrite,
   onChanged,
+  canWrite = false,
 }: {
   projectId: string;
   connector: AdminConnector;
-  canWrite: boolean;
   onChanged: () => void;
+  canWrite?: boolean;
 }) {
   const tI18nHardcoded = useTranslations('hardcodedUi');
   const queryClient = useQueryClient();
@@ -2039,50 +2042,53 @@ function ConnectionSection({
   });
 
   return (
-    <SectionCard
-      title="Connection"
-      description={tI18nHardcoded.raw(
-        'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrDescriptionHowa31daf50',
-      )}
-    >
-      {configQuery.isError ? (
-        <InfoBanner
-          tone="destructive"
-          title={tI18nHardcoded.raw(
-            'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrTitleCouldn277b73a0',
-          )}
-          action={
-            <Button size="sm" variant="outline" onClick={() => configQuery.refetch()}>
-              Retry
-            </Button>
-          }
-        >
-          {(configQuery.error as Error)?.message ?? 'Unknown error'}
-        </InfoBanner>
-      ) : configQuery.isLoading || !draft ? (
-        <div className="space-y-3">
-          <Skeleton className="h-9 w-full rounded-2xl" />
-          <Skeleton className="h-9 w-2/3 rounded-2xl" />
-          <Skeleton className="h-9 w-full rounded-2xl" />
-        </div>
-      ) : (
-        <div className="space-y-4">
-          <ConnectorConfigFields draft={draft} onChange={setDraft} readOnly={!canWrite} />
-          {canWrite && (
-            <SaveBar
-              dirty={dirty}
-              saving={save.isPending}
-              disabled={!connectionValid(draft)}
-              onSave={() => save.mutate()}
-              onReset={reset}
-              label={tI18nHardcoded.raw(
-                'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrLabelSave8c6f945f',
-              )}
-            />
-          )}
-        </div>
-      )}
-    </SectionCard>
+    <section className="space-y-4">
+      <Label>Connection</Label>
+      <p className="text-muted-foreground -mt-2 text-xs">
+        {tI18nHardcoded.raw(
+          'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrDescriptionHowa31daf50',
+        )}
+      </p>
+      <div className="bg-popover rounded-md border px-4 py-5">
+        {configQuery.isError ? (
+          <InfoBanner
+            tone="destructive"
+            title={tI18nHardcoded.raw(
+              'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrTitleCouldn277b73a0',
+            )}
+            action={
+              <Button size="sm" variant="outline" onClick={() => configQuery.refetch()}>
+                Retry
+              </Button>
+            }
+          >
+            {(configQuery.error as Error)?.message ?? 'Unknown error'}
+          </InfoBanner>
+        ) : configQuery.isLoading || !draft ? (
+          <div className="space-y-3">
+            <Skeleton className="h-9 w-full rounded-2xl" />
+            <Skeleton className="h-9 w-2/3 rounded-2xl" />
+            <Skeleton className="h-9 w-full rounded-2xl" />
+          </div>
+        ) : (
+          <div className="space-y-4">
+            <ConnectorConfigFields draft={draft} onChange={setDraft} readOnly={!canWrite} />
+            {canWrite && (
+              <SaveBar
+                dirty={dirty}
+                saving={save.isPending}
+                disabled={!connectionValid(draft)}
+                onSave={() => save.mutate()}
+                onReset={reset}
+                label={tI18nHardcoded.raw(
+                  'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrLabelSave8c6f945f',
+                )}
+              />
+            )}
+          </div>
+        )}
+      </div>
+    </section>
   );
 }
 
@@ -2104,14 +2110,28 @@ const POLICY_LABEL: Record<ConnectorPolicyAction, { label: string; tint: string 
 function PermissionPicker({
   value,
   onChange,
+  readOnly = false,
 }: {
   value: PolicyChoice;
   onChange: (c: PolicyChoice) => void;
+  readOnly?: boolean;
 }) {
   const meta =
     value === 'default'
       ? { label: 'Default', tint: 'text-muted-foreground' }
       : { label: POLICY_LABEL[value].label, tint: POLICY_LABEL[value].tint };
+  if (readOnly) {
+    return (
+      <span
+        className={cn(
+          'inline-flex shrink-0 items-center rounded-full px-2 py-0.5 text-xs font-medium',
+          meta.tint,
+        )}
+      >
+        {meta.label}
+      </span>
+    );
+  }
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -2194,13 +2214,13 @@ function tsSignature(slug: string, action: ConnectorAction): string {
 function PermissionsSection({
   projectId,
   connector,
-  canWrite,
   onChanged,
+  canWrite = false,
 }: {
   projectId: string;
   connector: AdminConnector;
-  canWrite: boolean;
   onChanged: () => void;
+  canWrite?: boolean;
 }) {
   const tI18nHardcoded = useTranslations('hardcodedUi');
   const queryClient = useQueryClient();
@@ -2330,14 +2350,18 @@ function PermissionsSection({
   };
 
   return (
-    <SectionCard
-      title="Permissions"
-      description={tI18nHardcoded.raw(
-        'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrDescriptionWhat4e375237',
-      )}
-      action={
-        tools.length > 6 ? (
-          <div className="relative w-48">
+    <section className="space-y-4">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h3 className="text-sm font-medium">Permissions</h3>
+          <p className="text-muted-foreground mt-1 text-xs">
+            {tI18nHardcoded.raw(
+              'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrDescriptionWhat4e375237',
+            )}
+          </p>
+        </div>
+        {tools.length > 6 ? (
+          <div className="relative w-48 shrink-0">
             <Search className="text-muted-foreground pointer-events-none absolute top-1/2 left-2.5 h-3.5 w-3.5 -translate-y-1/2" />
             <Input
               value={search}
@@ -2348,15 +2372,15 @@ function PermissionsSection({
               className="h-8 pl-8 text-sm"
             />
           </div>
-        ) : undefined
-      }
-    >
-      <div className="space-y-4">
+        ) : null}
+      </div>
+      <div className="bg-popover rounded-md border px-4 py-5">
+        <div className="space-y-4">
         <div className="space-y-2">
           <Label>Default</Label>
           <RadioGroup
             value={connector.sensitive ? 'ask_first' : 'follow_rules'}
-            onValueChange={(v) => sensitiveMut.mutate(v === 'ask_first')}
+            onValueChange={(v) => canWrite && sensitiveMut.mutate(v === 'ask_first')}
             className="space-y-2"
           >
             <RadioGroupItem
@@ -2366,7 +2390,7 @@ function PermissionsSection({
               description="Reads run automatically; writes and destructive actions still ask, per the rules below."
               size="lg"
               variant="outline"
-              disabled={!canWrite || sensitiveMut.isPending}
+              disabled={sensitiveMut.isPending || !canWrite}
             />
             <RadioGroupItem
               value="ask_first"
@@ -2383,7 +2407,7 @@ function PermissionsSection({
               }
               size="lg"
               variant="outline"
-              disabled={!canWrite || sensitiveMut.isPending}
+              disabled={sensitiveMut.isPending || !canWrite}
             />
           </RadioGroup>
         </div>
@@ -2519,21 +2543,11 @@ function PermissionsSection({
                             : 'text-muted-foreground/40 opacity-0 group-hover:opacity-100',
                         )}
                       />
-                      {canWrite ? (
-                        <PermissionPicker
-                          value={explicit ?? 'default'}
-                          onChange={(c) => setChoice(t.path, c)}
-                        />
-                      ) : (
-                        <span
-                          className={cn(
-                            'shrink-0 px-2 py-0.5 text-xs font-medium',
-                            explicit ? POLICY_LABEL[explicit].tint : 'text-muted-foreground',
-                          )}
-                        >
-                          {explicit ? POLICY_LABEL[explicit].label : 'Default'}
-                        </span>
-                      )}
+                      <PermissionPicker
+                        value={explicit ?? 'default'}
+                        onChange={(c) => setChoice(t.path, c)}
+                        readOnly={!canWrite}
+                      />
                     </div>
                     {isOpen && (
                       <div className="bg-muted/20 space-y-3 px-4 pt-1 pb-3">
@@ -2677,44 +2691,43 @@ function PermissionsSection({
                     )}
                   </div>
                 ))}
-                {canWrite ? (
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    className="h-8 gap-1.5 text-xs"
-                    onClick={() =>
-                      setRules((rs) => [
-                        ...rs,
-                        { id: ruleId(), match: '', action: 'require_approval' },
-                      ])
-                    }
-                  >
-                    <Plus className="h-3.5 w-3.5" />
-                    {tI18nHardcoded.raw(
-                      'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxTextAddRule873a093f',
-                    )}
-                  </Button>
-                ) : rules.length === 0 ? (
-                  <p className="text-muted-foreground text-xs">No pattern rules.</p>
-                ) : null}
+                {canWrite && (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  className="h-8 gap-1.5 text-xs"
+                  onClick={() =>
+                    setRules((rs) => [
+                      ...rs,
+                      { id: ruleId(), match: '', action: 'require_approval' },
+                    ])
+                  }
+                >
+                  <Plus className="h-3.5 w-3.5" />
+                  {tI18nHardcoded.raw(
+                    'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxTextAddRule873a093f',
+                  )}
+                </Button>
+                )}
               </div>
             )}
           </div>
         )}
-      </div>
+        </div>
 
-      {canWrite && (
-        <SaveBar
-          dirty={dirty}
-          saving={save.isPending}
-          onSave={() => save.mutate()}
-          onReset={reset}
-          label={tI18nHardcoded.raw(
-            'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrLabelSave783950c7',
-          )}
-        />
-      )}
-    </SectionCard>
+        {canWrite && (
+          <SaveBar
+            dirty={dirty}
+            saving={save.isPending}
+            onSave={() => save.mutate()}
+            onReset={reset}
+            label={tI18nHardcoded.raw(
+              'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrLabelSave783950c7',
+            )}
+          />
+        )}
+      </div>
+    </section>
   );
 }
 
@@ -2742,14 +2755,17 @@ function GlobalRulesPanel({ projectId }: { projectId: string }) {
   );
 }
 
+
 function AddAppPanel({
   projectId,
   emailChannelEnabled,
   onAdded,
+  canWrite = false,
 }: {
   projectId: string;
   emailChannelEnabled: boolean;
   onAdded: (slug?: string) => void;
+  canWrite?: boolean;
 }) {
   const tI18nHardcoded = useTranslations('hardcodedUi');
   const connectStatus = useQuery({
@@ -2757,6 +2773,17 @@ function AddAppPanel({
     queryFn: getConnectStatus,
     staleTime: 5 * 60_000,
   });
+  if (!canWrite) {
+    return (
+      <div className="mx-auto w-full max-w-2xl px-6 py-10">
+        <EmptyState
+          icon={Plug}
+          title="No connectors yet"
+          description="You have read-only access to this project's connectors. Ask a project manager to add one."
+        />
+      </div>
+    );
+  }
   const easyConnectDisabled = connectStatus.data?.configured === false;
   const easyConnectLabel = tI18nHardcoded.raw(
     'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxTextEasyConnect19ca1c01',
@@ -2913,16 +2940,16 @@ function AddEmailProfileCard({
           agent should run.
         </p>
       </button>
-      <Dialog open={open} onOpenChange={(next) => !add.isPending && setOpen(next)}>
-        <DialogContent className="gap-0 overflow-hidden p-0 sm:max-w-md">
-          <DialogHeader className="border-border/60 border-b px-6 pt-6 pb-4">
-            <DialogTitle>Add Email inbox</DialogTitle>
-            <DialogDescription>
+      <Modal open={open} onOpenChange={(next) => !add.isPending && setOpen(next)}>
+        <ModalContent className="lg:max-w-md">
+          <ModalHeader>
+            <ModalTitle>Add Email inbox</ModalTitle>
+            <ModalDescription>
               Create a separate connector profile. You choose the AgentMail address when connecting
               it.
-            </DialogDescription>
-          </DialogHeader>
-          <div className="space-y-4 px-6 py-5">
+            </ModalDescription>
+          </ModalHeader>
+          <ModalBody className="max-h-[60vh] space-y-4 overflow-y-auto">
             <Field>
               <Input
                 id="email-profile-name"
@@ -2948,18 +2975,18 @@ function AddEmailProfileCard({
                 Used as the first choice for the AgentMail address, for example support@agentmail.
               </p>
             </Field>
-          </div>
-          <DialogFooter className="border-border/60 bg-muted/30 flex items-center justify-end gap-2 border-t px-6 py-3">
-            <Button variant="ghost" onClick={() => setOpen(false)} disabled={add.isPending}>
+          </ModalBody>
+          <ModalFooter className="sm:justify-between">
+            <Button variant="outline-ghost" onClick={() => setOpen(false)} disabled={add.isPending}>
               Cancel
             </Button>
             <Button onClick={() => add.mutate()} disabled={add.isPending} className="gap-1.5">
-              {add.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+              {add.isPending ? <Loading className="size-4 shrink-0" /> : null}
               Add inbox
             </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
     </>
   );
 }
@@ -2992,20 +3019,20 @@ function AddSlackProfileCard({
           Add Kortix to Slack so mentions and threaded replies route into Kortix agent sessions.
         </p>
       </button>
-      <Dialog open={open} onOpenChange={setOpen}>
-        <DialogContent className="gap-0 overflow-hidden p-0 sm:max-w-2xl">
-          <DialogHeader className="border-border/60 border-b px-6 pt-6 pb-4">
-            <DialogTitle>Add Kortix to Slack</DialogTitle>
-            <DialogDescription>
+      <Modal open={open} onOpenChange={setOpen}>
+        <ModalContent className="lg:max-w-2xl">
+          <ModalHeader>
+            <ModalTitle>Add Kortix to Slack</ModalTitle>
+            <ModalDescription>
               Connect the built-in Slack channel. The connector profile appears automatically after
               installation.
-            </DialogDescription>
-          </DialogHeader>
-          <div className="max-h-[75vh] overflow-y-auto px-6 py-5">
+            </ModalDescription>
+          </ModalHeader>
+          <ModalBody className="max-h-[60vh] overflow-y-auto">
             <SlackConnectForm projectId={projectId} onConnected={handleConnected} />
-          </div>
-        </DialogContent>
-      </Dialog>
+          </ModalBody>
+        </ModalContent>
+      </Modal>
     </>
   );
 }
@@ -3139,7 +3166,7 @@ function AppCatalogue({
                 >
                   {appsQuery.isFetchingNextPage ? (
                     <>
-                      <Loading className="size-4 animate-spin" />
+                      <Loading className="size-4 shrink-0" />
                       {tI18nHardcoded.raw(
                         'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxTextLoading7131cc18',
                       )}
@@ -3161,14 +3188,14 @@ function ConnectorConfigFields({
   draft,
   onChange,
   slugEditable,
-  readOnly = false,
   emailChannelEnabled = true,
+  readOnly = false,
 }: {
   draft: ConnectorDraftInput;
   onChange: (d: ConnectorDraftInput) => void;
   slugEditable?: boolean;
-  readOnly?: boolean;
   emailChannelEnabled?: boolean;
+  readOnly?: boolean;
 }) {
   const tI18nHardcoded = useTranslations('hardcodedUi');
   const set = (patch: Partial<ConnectorDraftInput>) => onChange({ ...draft, ...patch });
@@ -3482,12 +3509,10 @@ export function CustomConnectorForm({
             <Button
               type="submit"
               size="sm"
-              disabled={
-                !draft.slug || save.isPending || !connectionValid(draft, emailChannelEnabled)
-              }
+              disabled={!draft.slug || save.isPending || !connectionValid(draft, emailChannelEnabled)}
               className="gap-1.5"
             >
-              {save.isPending && <Loader2 className="h-4 w-4 animate-spin" />}
+              {save.isPending && <Loading className="size-4 shrink-0" />}
               {tI18nHardcoded.raw(
                 'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxTextAddConnectore01e22fc',
               )}
@@ -3579,7 +3604,7 @@ function SetCredentialModal({
               Cancel
             </Button>
             <Button type="submit" size="sm" disabled={!value || save.isPending} className="gap-1.5">
-              {save.isPending && <Loader2 className="h-4 w-4 animate-spin" />}Save
+              {save.isPending && <Loading className="size-4 shrink-0" />}Save
             </Button>
           </ModalFooter>
         </form>

--- a/apps/web/src/features/workspace/customize/sections/connectors-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/connectors-view.tsx
@@ -32,6 +32,8 @@ import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { type ReactNode, useEffect, useMemo, useState } from 'react';
 
 import { PoliciesPanel } from '@/components/projects/policies-panel';
+import { PROJECT_ACTIONS } from '@/lib/project-actions';
+import { useProjectCan } from '@/lib/use-project-can';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
@@ -245,6 +247,11 @@ function ConnectorsMasterDetail({ projectId }: { projectId: string }) {
   const connectors = useMemo(() => query.data?.connectors ?? [], [query.data]);
   const emailChannelEnabled = projectQuery.data?.experimental?.agentmail_email === true;
   const isForbidden = query.isError && /403|forbidden/i.test((query.error as Error)?.message ?? '');
+  // READ vs WRITE: the section is visible to project.connector.read, but every
+  // mutating control (rename/remove/reconnect/credentials/permissions/channels/
+  // config) is gated on project.connector.write. Fails closed until the probe
+  // resolves, matching the backend's assertProjectCapability on those routes.
+  const canWrite = useProjectCan(projectId, PROJECT_ACTIONS.PROJECT_CONNECTOR_WRITE).allowed === true;
 
   // Selection persists in ?c= (slug | "global" | "add") for deep links.
   const search = useSearchParams();
@@ -330,6 +337,7 @@ function ConnectorsMasterDetail({ projectId }: { projectId: string }) {
           onSelect={select}
           onSync={() => sync.mutate()}
           syncing={sync.isPending}
+          canWrite={canWrite}
         />
       )}
       <div className="min-h-0 min-w-0 flex-1 overflow-y-auto">
@@ -337,6 +345,7 @@ function ConnectorsMasterDetail({ projectId }: { projectId: string }) {
           <AddAppPanel
             projectId={projectId}
             emailChannelEnabled={emailChannelEnabled}
+            canWrite={canWrite}
             onAdded={(slug) => {
               invalidate();
               if (slug) select({ kind: 'connector', slug });
@@ -349,6 +358,7 @@ function ConnectorsMasterDetail({ projectId }: { projectId: string }) {
             key={active.slug}
             projectId={projectId}
             connector={active}
+            canWrite={canWrite}
             onChanged={invalidate}
             onRemoved={() => {
               invalidate();
@@ -455,6 +465,7 @@ function ConnectorRail({
   onSelect,
   onSync,
   syncing,
+  canWrite = false,
 }: {
   projectId: string;
   connectors: AdminConnector[];
@@ -462,6 +473,7 @@ function ConnectorRail({
   onSelect: (s: Selection) => void;
   onSync: () => void;
   syncing: boolean;
+  canWrite?: boolean;
 }) {
   const tI18nHardcoded = useTranslations('hardcodedUi');
   const [q, setQ] = useState('');
@@ -478,17 +490,19 @@ function ConnectorRail({
       className="border-border/60 bg-muted/20 flex w-72 shrink-0 flex-col border-r"
     >
       <div className="border-border/60 space-y-2 border-b p-3">
-        <Button
-          size="sm"
-          className="w-full justify-start gap-2"
-          variant={selection.kind === 'add' ? 'secondary' : 'default'}
-          onClick={() => onSelect({ kind: 'add' })}
-        >
-          <Plus className="h-4 w-4" />
-          {tI18nHardcoded.raw(
-            'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxTextAddAppb53818fa',
-          )}
-        </Button>
+        {canWrite && (
+          <Button
+            size="sm"
+            className="w-full justify-start gap-2"
+            variant={selection.kind === 'add' ? 'secondary' : 'default'}
+            onClick={() => onSelect({ kind: 'add' })}
+          >
+            <Plus className="h-4 w-4" />
+            {tI18nHardcoded.raw(
+              'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxTextAddAppb53818fa',
+            )}
+          </Button>
+        )}
         <div className="relative">
           <Search className="text-muted-foreground pointer-events-none absolute top-1/2 left-2.5 h-3.5 w-3.5 -translate-y-1/2" />
           <Input
@@ -567,24 +581,26 @@ function ConnectorRail({
         )}
       </div>
 
-      <div className="border-border/60 border-t p-2">
-        <Button
-          variant="ghost"
-          size="sm"
-          className="text-muted-foreground w-full justify-start gap-2"
-          onClick={onSync}
-          disabled={syncing}
-        >
-          {syncing ? (
-            <Loading className="size-3.5 shrink-0" />
-          ) : (
-            <RefreshCw className="h-3.5 w-3.5" />
-          )}
-          {tI18nHardcoded.raw(
-            'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxTextSyncFromb820661f',
-          )}
-        </Button>
-      </div>
+      {canWrite && (
+        <div className="border-border/60 border-t p-2">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="text-muted-foreground w-full justify-start gap-2"
+            onClick={onSync}
+            disabled={syncing}
+          >
+            {syncing ? (
+              <Loading className="size-3.5 shrink-0" />
+            ) : (
+              <RefreshCw className="h-3.5 w-3.5" />
+            )}
+            {tI18nHardcoded.raw(
+              'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxTextSyncFromb820661f',
+            )}
+          </Button>
+        </div>
+      )}
     </nav>
   );
 }
@@ -728,11 +744,13 @@ function ConnectorDetail({
   connector,
   onChanged,
   onRemoved,
+  canWrite = false,
 }: {
   projectId: string;
   connector: AdminConnector;
   onChanged: () => void;
   onRemoved: () => void;
+  canWrite?: boolean;
 }) {
   const tI18nHardcoded = useTranslations('hardcodedUi');
   const isPipedream = connector.provider === 'pipedream';
@@ -782,7 +800,7 @@ function ConnectorDetail({
       <div className="flex items-start gap-3.5">
         <ConnectorAppIcon projectId={projectId} connector={connector} size="lg" />
         <div className="min-w-0 flex-1">
-          {editingName ? (
+          {editingName && canWrite ? (
             <form
               className="flex items-center gap-1.5"
               onSubmit={(e) => {
@@ -829,16 +847,18 @@ function ConnectorDetail({
           ) : (
             <div className="group flex items-center gap-2">
               <h2 className="text-foreground truncate text-lg font-semibold">{displayName}</h2>
-              <Hint label="Rename">
-                <button
-                  type="button"
-                  onClick={() => setEditingName(true)}
-                  aria-label="Rename"
-                  className="text-muted-foreground hover:text-foreground opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100"
-                >
-                  <Pencil className="h-3.5 w-3.5" />
-                </button>
-              </Hint>
+              {canWrite && (
+                <Hint label="Rename">
+                  <button
+                    type="button"
+                    onClick={() => setEditingName(true)}
+                    aria-label="Rename"
+                    className="text-muted-foreground hover:text-foreground opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100"
+                  >
+                    <Pencil className="h-3.5 w-3.5" />
+                  </button>
+                </Hint>
+              )}
             </div>
           )}
           <div className="mt-1.5 flex items-center gap-2">
@@ -856,7 +876,8 @@ function ConnectorDetail({
             When NOT connected, the connect action is a big CTA below — not a
             small header button buried next to the title. (Channel connectors
             are managed from the Channels tab, so neither shows.) */}
-        {connector.authSecret &&
+        {canWrite &&
+          connector.authSecret &&
           connected &&
           !isChannel &&
           (isPipedream ? (
@@ -919,15 +940,17 @@ function ConnectorDetail({
             icon={KeyRound}
             title={`Connect ${displayName}`}
             action={
-              <Button
-                size="lg"
-                className="h-11 shrink-0 gap-2 px-5 font-semibold"
-                onClick={() => (isPipedream ? reconnect.mutate() : setCredOpen(true))}
-                disabled={isPipedream && reconnect.isPending}
-              >
-                {isPipedream && reconnect.isPending && <Loading className="size-4 shrink-0" />}
-                {isPipedream ? `Connect ${displayName}` : 'Set credential'}
-              </Button>
+              canWrite ? (
+                <Button
+                  size="lg"
+                  className="h-11 shrink-0 gap-2 px-5 font-semibold"
+                  onClick={() => (isPipedream ? reconnect.mutate() : setCredOpen(true))}
+                  disabled={isPipedream && reconnect.isPending}
+                >
+                  {isPipedream && reconnect.isPending && <Loading className="size-4 shrink-0" />}
+                  {isPipedream ? `Connect ${displayName}` : 'Set credential'}
+                </Button>
+              ) : undefined
             }
           >
             {isPipedream
@@ -951,12 +974,14 @@ function ConnectorDetail({
                   connector={connector}
                   onChanged={onChanged}
                   onRemoved={onRemoved}
+                  canWrite={canWrite}
                 />
               ) : (
                 <ConnectionSection
                   projectId={projectId}
                   connector={connector}
                   onChanged={onChanged}
+                  canWrite={canWrite}
                 />
               )}
             </TabsContent>
@@ -966,11 +991,12 @@ function ConnectorDetail({
               projectId={projectId}
               connector={connector}
               onChanged={onChanged}
+              canWrite={canWrite}
             />
           </TabsContent>
         </Tabs>
 
-        {!isManaged && !isChannel && (
+        {canWrite && !isManaged && !isChannel && (
           <div className="bg-popover rounded-md border px-4 py-3">
             <div className="flex items-center justify-between gap-4">
               <div className="min-w-0">
@@ -1050,11 +1076,13 @@ function ChannelConnectionSection({
   connector,
   onChanged,
   onRemoved,
+  canWrite = false,
 }: {
   projectId: string;
   connector: AdminConnector;
   onChanged: () => void;
   onRemoved: () => void;
+  canWrite?: boolean;
 }) {
   const platform = connectorPlatform(connector);
   if (platform === 'email') {
@@ -1064,12 +1092,18 @@ function ChannelConnectionSection({
         connector={connector}
         onChanged={onChanged}
         onRemoved={onRemoved}
+        canWrite={canWrite}
       />
     );
   }
   if (platform === 'slack') {
     return (
-      <SlackChannelProfile projectId={projectId} onChanged={onChanged} onRemoved={onRemoved} />
+      <SlackChannelProfile
+        projectId={projectId}
+        onChanged={onChanged}
+        onRemoved={onRemoved}
+        canWrite={canWrite}
+      />
     );
   }
   return (
@@ -1087,11 +1121,13 @@ function EmailChannelProfile({
   connector,
   onChanged,
   onRemoved,
+  canWrite = false,
 }: {
   projectId: string;
   connector: AdminConnector;
   onChanged: () => void;
   onRemoved: () => void;
+  canWrite?: boolean;
 }) {
   const install = useEmailInstall(projectId, connector.slug);
 
@@ -1110,13 +1146,18 @@ function EmailChannelProfile({
             connectorSlug={connector.slug}
             installation={install.data}
             onRemoved={onRemoved}
+            canWrite={canWrite}
           />
-        ) : (
+        ) : canWrite ? (
           <EmailConnectForm
             projectId={projectId}
             connectorSlug={connector.slug}
             onConnected={onChanged}
           />
+        ) : (
+          <InfoBanner tone="neutral" icon={Mail} title="Email not connected">
+            This channel profile has no AgentMail inbox yet.
+          </InfoBanner>
         )}
       </div>
     </section>
@@ -1128,11 +1169,13 @@ function ConnectedEmailProfile({
   connectorSlug,
   installation,
   onRemoved,
+  canWrite = false,
 }: {
   projectId: string;
   connectorSlug: string;
   installation: EmailInstallation;
   onRemoved: () => void;
+  canWrite?: boolean;
 }) {
   const disconnect = useDisconnectEmail();
   const [confirming, setConfirming] = useState(false);
@@ -1152,7 +1195,9 @@ function ConnectedEmailProfile({
         projectId={projectId}
         connectorSlug={connectorSlug}
         policy={installation.senderPolicy}
+        canWrite={canWrite}
       />
+      {canWrite && (
       <div className="flex items-center justify-end gap-2">
         {confirming ? (
           <>
@@ -1188,6 +1233,7 @@ function ConnectedEmailProfile({
           </Button>
         )}
       </div>
+      )}
     </div>
   );
 }
@@ -1218,10 +1264,12 @@ function EmailSenderPolicyEditor({
   projectId,
   connectorSlug,
   policy,
+  canWrite = false,
 }: {
   projectId: string;
   connectorSlug: string;
   policy: EmailSenderPolicy | null | undefined;
+  canWrite?: boolean;
 }) {
   const update = useUpdateEmailPolicy();
   const initial = normalizeEmailSenderPolicy(policy);
@@ -1278,6 +1326,7 @@ function EmailSenderPolicyEditor({
           checked={restricted}
           onCheckedChange={(checked) => setRestricted(Boolean(checked))}
           className="mt-0.5"
+          disabled={!canWrite}
         />
         <div className="min-w-0 flex-1 space-y-3">
           <div>
@@ -1294,6 +1343,7 @@ function EmailSenderPolicyEditor({
                   value={emails}
                   onChange={(e) => setEmails(e.target.value)}
                   placeholder="person@example.com"
+                  disabled={!canWrite}
                 />
               </Field>
               <Field>
@@ -1301,6 +1351,7 @@ function EmailSenderPolicyEditor({
                   value={domains}
                   onChange={(e) => setDomains(e.target.value)}
                   placeholder="example.com"
+                  disabled={!canWrite}
                 />
               </Field>
               <div className="sm:col-span-2">
@@ -1310,24 +1361,27 @@ function EmailSenderPolicyEditor({
                     onChange={(e) => setRegex(e.target.value)}
                     placeholder=".*@customer-[0-9]+\\.com$"
                     spellCheck={false}
+                    disabled={!canWrite}
                   />
                 </Field>
               </div>
             </div>
           ) : null}
           {error ? <InfoBanner tone="destructive">{error}</InfoBanner> : null}
-          <SaveBar
-            dirty={dirty}
-            saving={update.isPending}
-            onSave={save}
-            onReset={() => {
-              setRestricted(initial.mode === 'restricted');
-              setEmails(initial.allowedEmails.join('\n'));
-              setDomains(initial.allowedDomains.join('\n'));
-              setRegex(initial.allowedRegex ?? '');
-            }}
-            label="Save policy"
-          />
+          {canWrite && (
+            <SaveBar
+              dirty={dirty}
+              saving={update.isPending}
+              onSave={save}
+              onReset={() => {
+                setRestricted(initial.mode === 'restricted');
+                setEmails(initial.allowedEmails.join('\n'));
+                setDomains(initial.allowedDomains.join('\n'));
+                setRegex(initial.allowedRegex ?? '');
+              }}
+              label="Save policy"
+            />
+          )}
         </div>
       </div>
     </div>
@@ -1600,10 +1654,12 @@ function SlackChannelProfile({
   projectId,
   onChanged,
   onRemoved,
+  canWrite = false,
 }: {
   projectId: string;
   onChanged: () => void;
   onRemoved: () => void;
+  canWrite?: boolean;
 }) {
   const install = useSlackInstall(projectId);
   return (
@@ -1620,9 +1676,14 @@ function SlackChannelProfile({
             projectId={projectId}
             installation={install.data}
             onRemoved={onRemoved}
+            canWrite={canWrite}
           />
-        ) : (
+        ) : canWrite ? (
           <SlackConnectForm projectId={projectId} onConnected={onChanged} />
+        ) : (
+          <InfoBanner tone="neutral" icon={<SlackLogo />} title="Slack not connected">
+            This channel profile has no Slack workspace yet.
+          </InfoBanner>
         )}
       </div>
     </section>
@@ -1633,10 +1694,12 @@ function ConnectedSlackProfile({
   projectId,
   installation,
   onRemoved,
+  canWrite = false,
 }: {
   projectId: string;
   installation: SlackInstallation;
   onRemoved: () => void;
+  canWrite?: boolean;
 }) {
   const disconnect = useDisconnectSlack();
   const [confirming, setConfirming] = useState(false);
@@ -1646,6 +1709,7 @@ function ConnectedSlackProfile({
         Workspace{' '}
         <code className="font-mono">{installation.workspaceName || installation.workspaceId}</code>
       </InfoBanner>
+      {canWrite && (
       <div className="flex items-center justify-end gap-2">
         {confirming ? (
           <>
@@ -1678,6 +1742,7 @@ function ConnectedSlackProfile({
           </Button>
         )}
       </div>
+      )}
     </div>
   );
 }
@@ -1932,10 +1997,12 @@ function ConnectionSection({
   projectId,
   connector,
   onChanged,
+  canWrite = false,
 }: {
   projectId: string;
   connector: AdminConnector;
   onChanged: () => void;
+  canWrite?: boolean;
 }) {
   const tI18nHardcoded = useTranslations('hardcodedUi');
   const queryClient = useQueryClient();
@@ -2005,17 +2072,19 @@ function ConnectionSection({
           </div>
         ) : (
           <div className="space-y-4">
-            <ConnectorConfigFields draft={draft} onChange={setDraft} />
-            <SaveBar
-              dirty={dirty}
-              saving={save.isPending}
-              disabled={!connectionValid(draft)}
-              onSave={() => save.mutate()}
-              onReset={reset}
-              label={tI18nHardcoded.raw(
-                'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrLabelSave8c6f945f',
-              )}
-            />
+            <ConnectorConfigFields draft={draft} onChange={setDraft} readOnly={!canWrite} />
+            {canWrite && (
+              <SaveBar
+                dirty={dirty}
+                saving={save.isPending}
+                disabled={!connectionValid(draft)}
+                onSave={() => save.mutate()}
+                onReset={reset}
+                label={tI18nHardcoded.raw(
+                  'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrLabelSave8c6f945f',
+                )}
+              />
+            )}
           </div>
         )}
       </div>
@@ -2041,14 +2110,28 @@ const POLICY_LABEL: Record<ConnectorPolicyAction, { label: string; tint: string 
 function PermissionPicker({
   value,
   onChange,
+  readOnly = false,
 }: {
   value: PolicyChoice;
   onChange: (c: PolicyChoice) => void;
+  readOnly?: boolean;
 }) {
   const meta =
     value === 'default'
       ? { label: 'Default', tint: 'text-muted-foreground' }
       : { label: POLICY_LABEL[value].label, tint: POLICY_LABEL[value].tint };
+  if (readOnly) {
+    return (
+      <span
+        className={cn(
+          'inline-flex shrink-0 items-center rounded-full px-2 py-0.5 text-xs font-medium',
+          meta.tint,
+        )}
+      >
+        {meta.label}
+      </span>
+    );
+  }
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -2132,10 +2215,12 @@ function PermissionsSection({
   projectId,
   connector,
   onChanged,
+  canWrite = false,
 }: {
   projectId: string;
   connector: AdminConnector;
   onChanged: () => void;
+  canWrite?: boolean;
 }) {
   const tI18nHardcoded = useTranslations('hardcodedUi');
   const queryClient = useQueryClient();
@@ -2295,7 +2380,7 @@ function PermissionsSection({
           <Label>Default</Label>
           <RadioGroup
             value={connector.sensitive ? 'ask_first' : 'follow_rules'}
-            onValueChange={(v) => sensitiveMut.mutate(v === 'ask_first')}
+            onValueChange={(v) => canWrite && sensitiveMut.mutate(v === 'ask_first')}
             className="space-y-2"
           >
             <RadioGroupItem
@@ -2305,7 +2390,7 @@ function PermissionsSection({
               description="Reads run automatically; writes and destructive actions still ask, per the rules below."
               size="lg"
               variant="outline"
-              disabled={sensitiveMut.isPending}
+              disabled={sensitiveMut.isPending || !canWrite}
             />
             <RadioGroupItem
               value="ask_first"
@@ -2322,7 +2407,7 @@ function PermissionsSection({
               }
               size="lg"
               variant="outline"
-              disabled={sensitiveMut.isPending}
+              disabled={sensitiveMut.isPending || !canWrite}
             />
           </RadioGroup>
         </div>
@@ -2342,17 +2427,19 @@ function PermissionsSection({
           <div className="border-border/60 overflow-hidden rounded-2xl border">
             {/* Select-all + bulk apply */}
             <div className="border-border/60 bg-muted/30 flex h-9 items-center gap-2 border-b px-3">
-              <Checkbox
-                checked={
-                  allFilteredSelected ? true : someFilteredSelected ? 'indeterminate' : false
-                }
-                onCheckedChange={toggleAllFiltered}
-                aria-label={tI18nHardcoded.raw(
-                  'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrAriaLabel924a321f',
-                )}
-                className="size-3.5"
-              />
-              {selected.size > 0 ? (
+              {canWrite && (
+                <Checkbox
+                  checked={
+                    allFilteredSelected ? true : someFilteredSelected ? 'indeterminate' : false
+                  }
+                  onCheckedChange={toggleAllFiltered}
+                  aria-label={tI18nHardcoded.raw(
+                    'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrAriaLabel924a321f',
+                  )}
+                  className="size-3.5"
+                />
+              )}
+              {canWrite && selected.size > 0 ? (
                 <>
                   <span className="text-foreground text-xs font-medium">
                     {selected.size} selected
@@ -2409,17 +2496,19 @@ function PermissionsSection({
                         isSel ? 'bg-primary/[0.05]' : 'hover:bg-muted/30',
                       )}
                     >
-                      <Checkbox
-                        checked={isSel}
-                        onCheckedChange={() => toggleSel(t.path)}
-                        aria-label={`Select ${t.path}`}
-                        className={cn(
-                          'size-3.5 shrink-0 transition-opacity',
-                          isSel
-                            ? ''
-                            : 'opacity-0 group-hover:opacity-100 focus-visible:opacity-100',
-                        )}
-                      />
+                      {canWrite && (
+                        <Checkbox
+                          checked={isSel}
+                          onCheckedChange={() => toggleSel(t.path)}
+                          aria-label={`Select ${t.path}`}
+                          className={cn(
+                            'size-3.5 shrink-0 transition-opacity',
+                            isSel
+                              ? ''
+                              : 'opacity-0 group-hover:opacity-100 focus-visible:opacity-100',
+                          )}
+                        />
+                      )}
                       <button
                         type="button"
                         onClick={() => setExpanded(isOpen ? null : t.path)}
@@ -2457,6 +2546,7 @@ function PermissionsSection({
                       <PermissionPicker
                         value={explicit ?? 'default'}
                         onChange={(c) => setChoice(t.path, c)}
+                        readOnly={!canWrite}
                       />
                     </div>
                     {isOpen && (
@@ -2560,9 +2650,11 @@ function PermissionsSection({
                         'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrPlaceholderSend3b0a4ee1',
                       )}
                       className="h-8 flex-1 font-mono text-xs"
+                      disabled={!canWrite}
                     />
                     <Select
                       value={r.action}
+                      disabled={!canWrite}
                       onValueChange={(v) =>
                         setRules((rs) =>
                           rs.map((x) =>
@@ -2584,19 +2676,22 @@ function PermissionsSection({
                         ))}
                       </SelectContent>
                     </Select>
-                    <Button
-                      size="icon"
-                      variant="ghost"
-                      className="hover:text-destructive h-8 w-8 shrink-0"
-                      onClick={() => setRules((rs) => rs.filter((x) => x.id !== r.id))}
-                      aria-label={tI18nHardcoded.raw(
-                        'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrAriaLabeld2296c34',
-                      )}
-                    >
-                      <Trash2 className="h-3.5 w-3.5" />
-                    </Button>
+                    {canWrite && (
+                      <Button
+                        size="icon"
+                        variant="ghost"
+                        className="hover:text-destructive h-8 w-8 shrink-0"
+                        onClick={() => setRules((rs) => rs.filter((x) => x.id !== r.id))}
+                        aria-label={tI18nHardcoded.raw(
+                          'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrAriaLabeld2296c34',
+                        )}
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
+                      </Button>
+                    )}
                   </div>
                 ))}
+                {canWrite && (
                 <Button
                   size="sm"
                   variant="outline"
@@ -2613,21 +2708,24 @@ function PermissionsSection({
                     'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxTextAddRule873a093f',
                   )}
                 </Button>
+                )}
               </div>
             )}
           </div>
         )}
         </div>
 
-        <SaveBar
-          dirty={dirty}
-          saving={save.isPending}
-          onSave={() => save.mutate()}
-          onReset={reset}
-          label={tI18nHardcoded.raw(
-            'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrLabelSave783950c7',
-          )}
-        />
+        {canWrite && (
+          <SaveBar
+            dirty={dirty}
+            saving={save.isPending}
+            onSave={() => save.mutate()}
+            onReset={reset}
+            label={tI18nHardcoded.raw(
+              'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrLabelSave783950c7',
+            )}
+          />
+        )}
       </div>
     </section>
   );
@@ -2662,10 +2760,12 @@ function AddAppPanel({
   projectId,
   emailChannelEnabled,
   onAdded,
+  canWrite = false,
 }: {
   projectId: string;
   emailChannelEnabled: boolean;
   onAdded: (slug?: string) => void;
+  canWrite?: boolean;
 }) {
   const tI18nHardcoded = useTranslations('hardcodedUi');
   const connectStatus = useQuery({
@@ -2673,6 +2773,17 @@ function AddAppPanel({
     queryFn: getConnectStatus,
     staleTime: 5 * 60_000,
   });
+  if (!canWrite) {
+    return (
+      <div className="mx-auto w-full max-w-2xl px-6 py-10">
+        <EmptyState
+          icon={Plug}
+          title="No connectors yet"
+          description="You have read-only access to this project's connectors. Ask a project manager to add one."
+        />
+      </div>
+    );
+  }
   const easyConnectDisabled = connectStatus.data?.configured === false;
   const easyConnectLabel = tI18nHardcoded.raw(
     'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxTextEasyConnect19ca1c01',
@@ -3078,11 +3189,13 @@ function ConnectorConfigFields({
   onChange,
   slugEditable,
   emailChannelEnabled = true,
+  readOnly = false,
 }: {
   draft: ConnectorDraftInput;
   onChange: (d: ConnectorDraftInput) => void;
   slugEditable?: boolean;
   emailChannelEnabled?: boolean;
+  readOnly?: boolean;
 }) {
   const tI18nHardcoded = useTranslations('hardcodedUi');
   const set = (patch: Partial<ConnectorDraftInput>) => onChange({ ...draft, ...patch });
@@ -3105,7 +3218,7 @@ function ConnectorConfigFields({
             placeholder="my-api"
             className="font-mono text-xs"
             variant="popover"
-            disabled={!slugEditable}
+            disabled={!slugEditable || readOnly}
             required
           />
         </Field>
@@ -3113,6 +3226,7 @@ function ConnectorConfigFields({
           <FieldLabel htmlFor="connector-provider">Provider</FieldLabel>
           <Select
             value={p}
+            disabled={readOnly}
             onValueChange={(v) => {
               const provider = v as ConnectorDraftInput['provider'];
               set({
@@ -3149,6 +3263,7 @@ function ConnectorConfigFields({
                 ? 'slack'
                 : (draft.platform ?? (emailChannelEnabled ? 'email' : 'slack'))
             }
+            disabled={readOnly}
             onValueChange={(v) => set({ platform: v as ChannelPlatform, auth: { type: 'none' } })}
           >
             <SelectTrigger>
@@ -3174,6 +3289,7 @@ function ConnectorConfigFields({
             onChange={(e) => set({ spec: e.target.value })}
             placeholder="https://…/openapi.json"
             variant="popover"
+            disabled={readOnly}
             required
           />
         </Field>
@@ -3188,6 +3304,7 @@ function ConnectorConfigFields({
               onChange={(e) => set({ endpoint: e.target.value })}
               placeholder="https://api/graphql"
               variant="popover"
+              disabled={readOnly}
               required
             />
           </Field>
@@ -3203,6 +3320,7 @@ function ConnectorConfigFields({
               onChange={(e) => set({ spec: e.target.value })}
               placeholder=".kortix/executor/schema.graphql"
               variant="popover"
+              disabled={readOnly}
             />
           </Field>
         </>
@@ -3217,6 +3335,7 @@ function ConnectorConfigFields({
               onChange={(e) => set({ url: e.target.value })}
               placeholder="https://mcp…/mcp"
               variant="popover"
+              disabled={readOnly}
               required
             />
           </Field>
@@ -3224,6 +3343,7 @@ function ConnectorConfigFields({
             <FieldLabel htmlFor="connector-transport">Transport</FieldLabel>
             <Select
               value={draft.transport ?? 'http'}
+              disabled={readOnly}
               onValueChange={(v) => set({ transport: v as 'http' | 'sse' })}
             >
               <SelectTrigger id="connector-transport" className="w-full" variant="popover">
@@ -3251,6 +3371,7 @@ function ConnectorConfigFields({
               onChange={(e) => set({ baseUrl: e.target.value })}
               placeholder="https://api.internal"
               variant="popover"
+              disabled={readOnly}
               required
             />
           </Field>
@@ -3266,6 +3387,7 @@ function ConnectorConfigFields({
               onChange={(e) => set({ spec: e.target.value })}
               placeholder=".kortix/executor/routes.toml"
               variant="popover"
+              disabled={readOnly}
             />
           </Field>
         </>
@@ -3276,6 +3398,7 @@ function ConnectorConfigFields({
             <FieldLabel htmlFor="connector-auth">Auth</FieldLabel>
             <Select
               value={draft.auth?.type ?? 'none'}
+              disabled={readOnly}
               onValueChange={(v) => setAuth({ type: v as 'none' | 'bearer' | 'basic' | 'custom' })}
             >
               <SelectTrigger id="connector-auth" className="w-full" variant="popover">
@@ -3306,6 +3429,7 @@ function ConnectorConfigFields({
                 onChange={(e) => setAuth({ name: e.target.value })}
                 placeholder="X-API-Key"
                 variant="popover"
+                disabled={readOnly}
                 required
               />
             </Field>

--- a/apps/web/src/features/workspace/customize/sections/connectors-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/connectors-view.tsx
@@ -12,7 +12,6 @@ import {
   ExternalLink,
   Globe,
   KeyRound,
-  Loader2,
   type LucideIcon,
   Mail,
   MessageSquare,
@@ -39,14 +38,6 @@ import { Checkbox } from '@/components/ui/checkbox';
 import { CodeBlockCode } from '@/components/ui/code-block';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog';
-import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -70,7 +61,6 @@ import {
   ModalTitle,
 } from '@/components/ui/modal';
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
-import { SectionCard } from '@/components/ui/section-card';
 import {
   Select,
   SelectContent,
@@ -81,7 +71,6 @@ import {
 import { Skeleton } from '@/components/ui/skeleton';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { errorToast, successToast, warningToast } from '@/components/ui/toast';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { EmptyState } from '@/features/layout/section/empty-state';
 import {
   type EmailInstallation,
@@ -452,7 +441,7 @@ function SaveBar({
         </Button>
       )}
       <Button size="sm" onClick={onSave} disabled={saving || disabled} className="gap-1.5">
-        {saving && <Loader2 className="h-4 w-4 animate-spin" />}
+        {saving && <Loading className="size-4 shrink-0" />}
         {label}
       </Button>
     </div>
@@ -587,7 +576,7 @@ function ConnectorRail({
           disabled={syncing}
         >
           {syncing ? (
-            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            <Loading className="size-3.5 shrink-0" />
           ) : (
             <RefreshCw className="h-3.5 w-3.5" />
           )}
@@ -819,7 +808,7 @@ function ConnectorDetail({
                 )}
               >
                 {rename.isPending ? (
-                  <Loader2 className="h-4 w-4 animate-spin" />
+                  <Loading className="size-4 shrink-0" />
                 ) : (
                   <Check className="h-4 w-4" />
                 )}
@@ -840,19 +829,16 @@ function ConnectorDetail({
           ) : (
             <div className="group flex items-center gap-2">
               <h2 className="text-foreground truncate text-lg font-semibold">{displayName}</h2>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <button
-                    type="button"
-                    onClick={() => setEditingName(true)}
-                    aria-label="Rename"
-                    className="text-muted-foreground hover:text-foreground opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100"
-                  >
-                    <Pencil className="h-3.5 w-3.5" />
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent>Rename</TooltipContent>
-              </Tooltip>
+              <Hint label="Rename">
+                <button
+                  type="button"
+                  onClick={() => setEditingName(true)}
+                  aria-label="Rename"
+                  className="text-muted-foreground hover:text-foreground opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100"
+                >
+                  <Pencil className="h-3.5 w-3.5" />
+                </button>
+              </Hint>
             </div>
           )}
           <div className="mt-1.5 flex items-center gap-2">
@@ -882,7 +868,7 @@ function ConnectorDetail({
               disabled={reconnect.isPending}
             >
               {reconnect.isPending ? (
-                <Loader2 className="h-4 w-4 animate-spin" />
+                <Loading className="size-4 shrink-0" />
               ) : (
                 <KeyRound className="h-4 w-4" />
               )}
@@ -939,7 +925,7 @@ function ConnectorDetail({
                 onClick={() => (isPipedream ? reconnect.mutate() : setCredOpen(true))}
                 disabled={isPipedream && reconnect.isPending}
               >
-                {isPipedream && reconnect.isPending && <Loader2 className="h-4 w-4 animate-spin" />}
+                {isPipedream && reconnect.isPending && <Loading className="size-4 shrink-0" />}
                 {isPipedream ? `Connect ${displayName}` : 'Set credential'}
               </Button>
             }
@@ -985,26 +971,31 @@ function ConnectorDetail({
         </Tabs>
 
         {!isManaged && !isChannel && (
-          <SectionCard
-            tone="destructive"
-            title={tI18nHardcoded.raw(
-              'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrTitleRemove74be1411',
-            )}
-            description={tI18nHardcoded.raw(
-              'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrDescriptionDeletes0a130396',
-            )}
-            action={
+          <div className="bg-popover rounded-md border px-4 py-3">
+            <div className="flex items-center justify-between gap-4">
+              <div className="min-w-0">
+                <p className="text-foreground text-sm font-medium">
+                  {tI18nHardcoded.raw(
+                    'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrTitleRemove74be1411',
+                  )}
+                </p>
+                <p className="text-muted-foreground mt-0.5 text-xs text-pretty">
+                  {tI18nHardcoded.raw(
+                    'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrDescriptionDeletes0a130396',
+                  )}
+                </p>
+              </div>
               <Button
                 size="sm"
                 variant="outline"
-                className="gap-1.5"
+                className="shrink-0 gap-1.5"
                 onClick={() => setConfirmDelete(true)}
               >
                 <Trash2 className="h-3.5 w-3.5" />
                 Remove
               </Button>
-            }
-          />
+            </div>
+          </div>
         )}
       </div>
 
@@ -1082,9 +1073,12 @@ function ChannelConnectionSection({
     );
   }
   return (
-    <SectionCard title="Connection">
-      <InfoBanner tone="warning">This channel profile is missing its platform setting.</InfoBanner>
-    </SectionCard>
+    <section className="space-y-4">
+      <Label>Connection</Label>
+      <div className="bg-popover rounded-md border px-4 py-5">
+        <InfoBanner tone="warning">This channel profile is missing its platform setting.</InfoBanner>
+      </div>
+    </section>
   );
 }
 
@@ -1102,27 +1096,30 @@ function EmailChannelProfile({
   const install = useEmailInstall(projectId, connector.slug);
 
   return (
-    <SectionCard
-      title="Email connection"
-      description="AgentMail inbox assigned to this connector profile."
-    >
-      {install.isLoading ? (
-        <Skeleton className="h-24 w-full rounded-2xl" />
-      ) : install.data ? (
-        <ConnectedEmailProfile
-          projectId={projectId}
-          connectorSlug={connector.slug}
-          installation={install.data}
-          onRemoved={onRemoved}
-        />
-      ) : (
-        <EmailConnectForm
-          projectId={projectId}
-          connectorSlug={connector.slug}
-          onConnected={onChanged}
-        />
-      )}
-    </SectionCard>
+    <section className="space-y-4">
+      <Label>Email connection</Label>
+      <p className="text-muted-foreground -mt-2 text-xs">
+        AgentMail inbox assigned to this connector profile.
+      </p>
+      <div className="bg-popover rounded-md border px-4 py-5">
+        {install.isLoading ? (
+          <Skeleton className="h-24 w-full rounded-2xl" />
+        ) : install.data ? (
+          <ConnectedEmailProfile
+            projectId={projectId}
+            connectorSlug={connector.slug}
+            installation={install.data}
+            onRemoved={onRemoved}
+          />
+        ) : (
+          <EmailConnectForm
+            projectId={projectId}
+            connectorSlug={connector.slug}
+            onConnected={onChanged}
+          />
+        )}
+      </div>
+    </section>
   );
 }
 
@@ -1181,7 +1178,7 @@ function ConnectedEmailProfile({
                 )
               }
             >
-              {disconnect.isPending ? <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" /> : null}
+              {disconnect.isPending ? <Loading className="mr-2 size-3.5 shrink-0" /> : null}
               Disconnect
             </Button>
           </>
@@ -1591,7 +1588,7 @@ export function EmailConnectForm({
       {error ? <InfoBanner tone="destructive">{error}</InfoBanner> : null}
       <div className="flex justify-end">
         <Button size="sm" onClick={submit} disabled={connect.isPending || mode.isLoading}>
-          {connect.isPending ? <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" /> : null}
+          {connect.isPending ? <Loading className="mr-2 size-3.5 shrink-0" /> : null}
           Create inbox
         </Button>
       </div>
@@ -1610,22 +1607,25 @@ function SlackChannelProfile({
 }) {
   const install = useSlackInstall(projectId);
   return (
-    <SectionCard
-      title="Slack connection"
-      description="Slack workspace assigned to this connector profile."
-    >
-      {install.isLoading ? (
-        <Skeleton className="h-24 w-full rounded-2xl" />
-      ) : install.data ? (
-        <ConnectedSlackProfile
-          projectId={projectId}
-          installation={install.data}
-          onRemoved={onRemoved}
-        />
-      ) : (
-        <SlackConnectForm projectId={projectId} onConnected={onChanged} />
-      )}
-    </SectionCard>
+    <section className="space-y-4">
+      <Label>Slack connection</Label>
+      <p className="text-muted-foreground -mt-2 text-xs">
+        Slack workspace assigned to this connector profile.
+      </p>
+      <div className="bg-popover rounded-md border px-4 py-5">
+        {install.isLoading ? (
+          <Skeleton className="h-24 w-full rounded-2xl" />
+        ) : install.data ? (
+          <ConnectedSlackProfile
+            projectId={projectId}
+            installation={install.data}
+            onRemoved={onRemoved}
+          />
+        ) : (
+          <SlackConnectForm projectId={projectId} onConnected={onChanged} />
+        )}
+      </div>
+    </section>
   );
 }
 
@@ -1668,7 +1668,7 @@ function ConnectedSlackProfile({
                 })
               }
             >
-              {disconnect.isPending ? <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" /> : null}
+              {disconnect.isPending ? <Loading className="mr-2 size-3.5 shrink-0" /> : null}
               Disconnect
             </Button>
           </>
@@ -1879,7 +1879,7 @@ export function SlackConnectForm({
                   onClick={submit}
                   disabled={connect.isPending || !botToken.trim() || !signingSecret.trim()}
                 >
-                  {connect.isPending ? <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" /> : null}
+                  {connect.isPending ? <Loading className="mr-2 size-3.5 shrink-0" /> : null}
                   Connect custom Slack app
                 </Button>
               </div>
@@ -1975,48 +1975,51 @@ function ConnectionSection({
   });
 
   return (
-    <SectionCard
-      title="Connection"
-      description={tI18nHardcoded.raw(
-        'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrDescriptionHowa31daf50',
-      )}
-    >
-      {configQuery.isError ? (
-        <InfoBanner
-          tone="destructive"
-          title={tI18nHardcoded.raw(
-            'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrTitleCouldn277b73a0',
-          )}
-          action={
-            <Button size="sm" variant="outline" onClick={() => configQuery.refetch()}>
-              Retry
-            </Button>
-          }
-        >
-          {(configQuery.error as Error)?.message ?? 'Unknown error'}
-        </InfoBanner>
-      ) : configQuery.isLoading || !draft ? (
-        <div className="space-y-3">
-          <Skeleton className="h-9 w-full rounded-2xl" />
-          <Skeleton className="h-9 w-2/3 rounded-2xl" />
-          <Skeleton className="h-9 w-full rounded-2xl" />
-        </div>
-      ) : (
-        <div className="space-y-4">
-          <ConnectorConfigFields draft={draft} onChange={setDraft} />
-          <SaveBar
-            dirty={dirty}
-            saving={save.isPending}
-            disabled={!connectionValid(draft)}
-            onSave={() => save.mutate()}
-            onReset={reset}
-            label={tI18nHardcoded.raw(
-              'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrLabelSave8c6f945f',
+    <section className="space-y-4">
+      <Label>Connection</Label>
+      <p className="text-muted-foreground -mt-2 text-xs">
+        {tI18nHardcoded.raw(
+          'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrDescriptionHowa31daf50',
+        )}
+      </p>
+      <div className="bg-popover rounded-md border px-4 py-5">
+        {configQuery.isError ? (
+          <InfoBanner
+            tone="destructive"
+            title={tI18nHardcoded.raw(
+              'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrTitleCouldn277b73a0',
             )}
-          />
-        </div>
-      )}
-    </SectionCard>
+            action={
+              <Button size="sm" variant="outline" onClick={() => configQuery.refetch()}>
+                Retry
+              </Button>
+            }
+          >
+            {(configQuery.error as Error)?.message ?? 'Unknown error'}
+          </InfoBanner>
+        ) : configQuery.isLoading || !draft ? (
+          <div className="space-y-3">
+            <Skeleton className="h-9 w-full rounded-2xl" />
+            <Skeleton className="h-9 w-2/3 rounded-2xl" />
+            <Skeleton className="h-9 w-full rounded-2xl" />
+          </div>
+        ) : (
+          <div className="space-y-4">
+            <ConnectorConfigFields draft={draft} onChange={setDraft} />
+            <SaveBar
+              dirty={dirty}
+              saving={save.isPending}
+              disabled={!connectionValid(draft)}
+              onSave={() => save.mutate()}
+              onReset={reset}
+              label={tI18nHardcoded.raw(
+                'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrLabelSave8c6f945f',
+              )}
+            />
+          </div>
+        )}
+      </div>
+    </section>
   );
 }
 
@@ -2262,14 +2265,18 @@ function PermissionsSection({
   };
 
   return (
-    <SectionCard
-      title="Permissions"
-      description={tI18nHardcoded.raw(
-        'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrDescriptionWhat4e375237',
-      )}
-      action={
-        tools.length > 6 ? (
-          <div className="relative w-48">
+    <section className="space-y-4">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h3 className="text-sm font-medium">Permissions</h3>
+          <p className="text-muted-foreground mt-1 text-xs">
+            {tI18nHardcoded.raw(
+              'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrDescriptionWhat4e375237',
+            )}
+          </p>
+        </div>
+        {tools.length > 6 ? (
+          <div className="relative w-48 shrink-0">
             <Search className="text-muted-foreground pointer-events-none absolute top-1/2 left-2.5 h-3.5 w-3.5 -translate-y-1/2" />
             <Input
               value={search}
@@ -2280,10 +2287,10 @@ function PermissionsSection({
               className="h-8 pl-8 text-sm"
             />
           </div>
-        ) : undefined
-      }
-    >
-      <div className="space-y-4">
+        ) : null}
+      </div>
+      <div className="bg-popover rounded-md border px-4 py-5">
+        <div className="space-y-4">
         <div className="space-y-2">
           <Label>Default</Label>
           <RadioGroup
@@ -2610,18 +2617,19 @@ function PermissionsSection({
             )}
           </div>
         )}
-      </div>
+        </div>
 
-      <SaveBar
-        dirty={dirty}
-        saving={save.isPending}
-        onSave={() => save.mutate()}
-        onReset={reset}
-        label={tI18nHardcoded.raw(
-          'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrLabelSave783950c7',
-        )}
-      />
-    </SectionCard>
+        <SaveBar
+          dirty={dirty}
+          saving={save.isPending}
+          onSave={() => save.mutate()}
+          onReset={reset}
+          label={tI18nHardcoded.raw(
+            'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrLabelSave783950c7',
+          )}
+        />
+      </div>
+    </section>
   );
 }
 
@@ -2821,16 +2829,16 @@ function AddEmailProfileCard({
           agent should run.
         </p>
       </button>
-      <Dialog open={open} onOpenChange={(next) => !add.isPending && setOpen(next)}>
-        <DialogContent className="gap-0 overflow-hidden p-0 sm:max-w-md">
-          <DialogHeader className="border-border/60 border-b px-6 pt-6 pb-4">
-            <DialogTitle>Add Email inbox</DialogTitle>
-            <DialogDescription>
+      <Modal open={open} onOpenChange={(next) => !add.isPending && setOpen(next)}>
+        <ModalContent className="lg:max-w-md">
+          <ModalHeader>
+            <ModalTitle>Add Email inbox</ModalTitle>
+            <ModalDescription>
               Create a separate connector profile. You choose the AgentMail address when connecting
               it.
-            </DialogDescription>
-          </DialogHeader>
-          <div className="space-y-4 px-6 py-5">
+            </ModalDescription>
+          </ModalHeader>
+          <ModalBody className="max-h-[60vh] space-y-4 overflow-y-auto">
             <Field>
               <Input
                 id="email-profile-name"
@@ -2856,18 +2864,18 @@ function AddEmailProfileCard({
                 Used as the first choice for the AgentMail address, for example support@agentmail.
               </p>
             </Field>
-          </div>
-          <DialogFooter className="border-border/60 bg-muted/30 flex items-center justify-end gap-2 border-t px-6 py-3">
-            <Button variant="ghost" onClick={() => setOpen(false)} disabled={add.isPending}>
+          </ModalBody>
+          <ModalFooter className="sm:justify-between">
+            <Button variant="outline-ghost" onClick={() => setOpen(false)} disabled={add.isPending}>
               Cancel
             </Button>
             <Button onClick={() => add.mutate()} disabled={add.isPending} className="gap-1.5">
-              {add.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+              {add.isPending ? <Loading className="size-4 shrink-0" /> : null}
               Add inbox
             </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
     </>
   );
 }
@@ -2900,20 +2908,20 @@ function AddSlackProfileCard({
           Add Kortix to Slack so mentions and threaded replies route into Kortix agent sessions.
         </p>
       </button>
-      <Dialog open={open} onOpenChange={setOpen}>
-        <DialogContent className="gap-0 overflow-hidden p-0 sm:max-w-2xl">
-          <DialogHeader className="border-border/60 border-b px-6 pt-6 pb-4">
-            <DialogTitle>Add Kortix to Slack</DialogTitle>
-            <DialogDescription>
+      <Modal open={open} onOpenChange={setOpen}>
+        <ModalContent className="lg:max-w-2xl">
+          <ModalHeader>
+            <ModalTitle>Add Kortix to Slack</ModalTitle>
+            <ModalDescription>
               Connect the built-in Slack channel. The connector profile appears automatically after
               installation.
-            </DialogDescription>
-          </DialogHeader>
-          <div className="max-h-[75vh] overflow-y-auto px-6 py-5">
+            </ModalDescription>
+          </ModalHeader>
+          <ModalBody className="max-h-[60vh] overflow-y-auto">
             <SlackConnectForm projectId={projectId} onConnected={handleConnected} />
-          </div>
-        </DialogContent>
-      </Dialog>
+          </ModalBody>
+        </ModalContent>
+      </Modal>
     </>
   );
 }
@@ -3047,7 +3055,7 @@ function AppCatalogue({
                 >
                   {appsQuery.isFetchingNextPage ? (
                     <>
-                      <Loading className="size-4 animate-spin" />
+                      <Loading className="size-4 shrink-0" />
                       {tI18nHardcoded.raw(
                         'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxTextLoading7131cc18',
                       )}
@@ -3380,7 +3388,7 @@ export function CustomConnectorForm({
               disabled={!draft.slug || save.isPending || !connectionValid(draft, emailChannelEnabled)}
               className="gap-1.5"
             >
-              {save.isPending && <Loader2 className="h-4 w-4 animate-spin" />}
+              {save.isPending && <Loading className="size-4 shrink-0" />}
               {tI18nHardcoded.raw(
                 'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxTextAddConnectore01e22fc',
               )}
@@ -3472,7 +3480,7 @@ function SetCredentialModal({
               Cancel
             </Button>
             <Button type="submit" size="sm" disabled={!value || save.isPending} className="gap-1.5">
-              {save.isPending && <Loader2 className="h-4 w-4 animate-spin" />}Save
+              {save.isPending && <Loading className="size-4 shrink-0" />}Save
             </Button>
           </ModalFooter>
         </form>

--- a/apps/web/src/features/workspace/customize/sections/gateway-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/gateway-view.tsx
@@ -29,6 +29,8 @@ import { GatewayOverview } from '@/features/workspace/customize/sections/view/ga
 import { useModelDefaults } from '@/hooks/opencode/use-model-defaults';
 import { useOpenCodeProviders } from '@/hooks/opencode/use-opencode-sessions';
 import type { CustomizeSection } from '@/lib/customize-sections';
+import { PROJECT_ACTIONS } from '@/lib/project-actions';
+import { useProjectCan } from '@/lib/use-project-can';
 import { useCustomizeStore } from '@/stores/customize-store';
 
 type LlmTab = 'providers' | 'overview' | 'logs' | 'budgets' | 'keys';
@@ -63,6 +65,11 @@ export function LlmManagementView({ projectId }: { projectId: string }) {
   const models = useMemo(() => flattenModels(providers), [providers]);
   const modelDefaults = useModelDefaults(projectId);
   const effectiveDefault = modelDefaults.accountDefault ?? modelDefaults.platformDefault ?? null;
+  // A role with the LLM section's READ leaf (project.read) but not project.write
+  // sees the gateway read-only: logs/overview/spend stay visible, but the
+  // account-default model picker — the one mutating control in this bar, which
+  // POSTs setAccountDefault — is hidden so a read-only user can't 403.
+  const canWrite = useProjectCan(projectId, PROJECT_ACTIONS.PROJECT_WRITE).allowed === true;
 
   // Follow an external deep-link (e.g. openCustomize('llm-providers')) to its
   // tab. Plain in-view tab clicks stay local and never move the main rail.
@@ -88,14 +95,16 @@ export function LlmManagementView({ projectId }: { projectId: string }) {
             </TabsTrigger>
           ))}
         </TabsList>
-        <ModelSelector
-          models={models}
-          providers={providers}
-          selectedModel={effectiveDefault}
-          onSelect={(m) => {
-            if (m) void modelDefaults.setAccountDefault(m);
-          }}
-        />
+        {canWrite ? (
+          <ModelSelector
+            models={models}
+            providers={providers}
+            selectedModel={effectiveDefault}
+            onSelect={(m) => {
+              if (m) void modelDefaults.setAccountDefault(m);
+            }}
+          />
+        ) : null}
       </div>
 
       {/* min-h-0 lets each panel actually shrink inside the flex column so
@@ -107,6 +116,7 @@ export function LlmManagementView({ projectId }: { projectId: string }) {
           open={open}
           onOpenChange={() => {}}
           defaultTab={llmProvidersTab}
+          canWrite={canWrite}
         />
       </TabsContent>
       <TabsContent value="overview" className="min-h-0 overflow-y-auto">
@@ -116,10 +126,10 @@ export function LlmManagementView({ projectId }: { projectId: string }) {
         <GatewayLogs projectId={projectId} />
       </TabsContent>
       <TabsContent value="budgets" className="min-h-0 overflow-y-auto">
-        <GatewayBudgets projectId={projectId} />
+        <GatewayBudgets projectId={projectId} canWrite={canWrite} />
       </TabsContent>
       <TabsContent value="keys" className="min-h-0 overflow-y-auto">
-        <GatewayKeys projectId={projectId} />
+        <GatewayKeys projectId={projectId} canWrite={canWrite} />
       </TabsContent>
     </Tabs>
   );

--- a/apps/web/src/features/workspace/customize/sections/llm-provider/api-key-connect-form.tsx
+++ b/apps/web/src/features/workspace/customize/sections/llm-provider/api-key-connect-form.tsx
@@ -1,7 +1,9 @@
 'use client';
 
 import { Button } from '@/components/ui/button';
+import { InfoBanner } from '@/components/ui/info-banner';
 import { Input } from '@/components/ui/input';
+import Loading from '@/components/ui/loading';
 import { successToast } from '@/components/ui/toast';
 import { ProviderLogo } from '@/features/providers/provider-branding';
 import { refreshProjectProviderState } from '@/hooks/opencode/provider-refresh';
@@ -9,7 +11,7 @@ import type { LlmProviderEntry } from '@/lib/llm-providers';
 import { cn } from '@/lib/utils';
 import { upsertProjectSecret } from '@kortix/sdk/projects-client';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { AlertCircle, ChevronLeft, ExternalLink, Info, Loader2 } from 'lucide-react';
+import { AlertCircle, ChevronLeft, ExternalLink, Info } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { type FormEvent, useMemo, useState } from 'react';
 
@@ -159,19 +161,16 @@ export function ApiKeyConnectForm({
           </div>
         )}
 
-        <div className="flex items-start gap-2.5 rounded-2xl border border-amber-500/20 bg-amber-500/[0.06] px-3 py-2.5">
-          <Info className="mt-0.5 size-4 shrink-0 text-amber-600 dark:text-amber-500" />
-          <p className="text-foreground/80 text-xs leading-relaxed">
-            {tHardcodedUi.raw(
-              'autoComponentsProjectsProjectProviderModalJsxTextASandboxPicks96cfb428',
-            )}
-          </p>
-        </div>
+        <InfoBanner tone="warning" icon={Info} className="rounded-2xl">
+          {tHardcodedUi.raw(
+            'autoComponentsProjectsProjectProviderModalJsxTextASandboxPicks96cfb428',
+          )}
+        </InfoBanner>
 
         <Button type="submit" size="sm" className="px-4" disabled={upsert.isPending || !allFilled}>
           {upsert.isPending ? (
             <>
-              <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+              <Loading className="mr-1.5 size-3.5 shrink-0" />
               {tHardcodedUi.raw('componentsProjectsProjectProviderModal.line847JsxTextConnecting')}
             </>
           ) : (

--- a/apps/web/src/features/workspace/customize/sections/llm-provider/catalog-tab.tsx
+++ b/apps/web/src/features/workspace/customize/sections/llm-provider/catalog-tab.tsx
@@ -24,12 +24,14 @@ export function CatalogTab({
   search,
   subview,
   setSubview,
+  canWrite = false,
 }: {
   projectId: string;
   connectedIds: Set<string>;
   search: string;
   subview: CatalogSubview;
   setSubview: (next: CatalogSubview) => void;
+  canWrite?: boolean;
 }) {
   const tHardcodedUi = useTranslations('hardcodedUi');
   const filtered = useMemo(() => {
@@ -43,6 +45,13 @@ export function CatalogTab({
     );
   }, [search]);
 
+  // Read-only members can browse the list/detail but can't reach the write
+  // flows; fold connect/custom back to the list so a POST is never attempted.
+  if (!canWrite && (subview.kind === 'connect' || subview.kind === 'custom')) {
+    setSubview({ kind: 'list' });
+    return null;
+  }
+
   if (subview.kind === 'detail') {
     const provider = LLM_PROVIDER_BY_ID.get(subview.providerId);
     if (!provider) {
@@ -53,6 +62,7 @@ export function CatalogTab({
       <ProviderDetail
         provider={provider}
         isConnected={connectedIds.has(provider.id)}
+        canWrite={canWrite}
         onBack={() => setSubview({ kind: 'list' })}
         onConnect={() => setSubview({ kind: 'connect', providerId: provider.id })}
       />
@@ -87,22 +97,24 @@ export function CatalogTab({
 
   return (
     <div className="space-y-3 px-5 pt-3 pb-4">
-      <button type="button" className={`${ROW} border-dashed`} onClick={() => setSubview({ kind: 'custom' })}>
-        <span className="border-border/60 text-muted-foreground/70 flex size-9 shrink-0 items-center justify-center rounded-sm border border-dashed">
-          <Plus className="size-4 shrink-0" />
-        </span>
-        <div className="min-w-0 flex-1">
-          <div className="text-foreground truncate text-sm font-medium">
-            {tHardcodedUi.raw('componentsProjectsProjectProviderModal.line492JsxTextCustomProvider')}
+      {canWrite && (
+        <button type="button" className={`${ROW} border-dashed`} onClick={() => setSubview({ kind: 'custom' })}>
+          <span className="border-border/60 text-muted-foreground/70 flex size-9 shrink-0 items-center justify-center rounded-sm border border-dashed">
+            <Plus className="size-4 shrink-0" />
+          </span>
+          <div className="min-w-0 flex-1">
+            <div className="text-foreground truncate text-sm font-medium">
+              {tHardcodedUi.raw('componentsProjectsProjectProviderModal.line492JsxTextCustomProvider')}
+            </div>
+            <p className="text-muted-foreground mt-0.5 truncate text-xs">
+              {tHardcodedUi.raw(
+                'componentsProjectsProjectProviderModal.line495JsxTextConnectAnyOpenaiCompatibleEndpointWithYourOwn',
+              )}
+            </p>
           </div>
-          <p className="text-muted-foreground mt-0.5 truncate text-xs">
-            {tHardcodedUi.raw(
-              'componentsProjectsProjectProviderModal.line495JsxTextConnectAnyOpenaiCompatibleEndpointWithYourOwn',
-            )}
-          </p>
-        </div>
-        <ChevronRight className="text-muted-foreground/40 size-4 shrink-0 transition-transform group-hover:translate-x-0.5" />
-      </button>
+          <ChevronRight className="text-muted-foreground/40 size-4 shrink-0 transition-transform group-hover:translate-x-0.5" />
+        </button>
+      )}
 
       {filtered.length === 0 ? (
         <EmptyState size="sm" title={search ? `No providers match "${search}"` : 'No providers'} />
@@ -145,11 +157,13 @@ export function CatalogTab({
 function ProviderDetail({
   provider,
   isConnected,
+  canWrite,
   onBack,
   onConnect,
 }: {
   provider: LlmProviderEntry;
   isConnected: boolean;
+  canWrite: boolean;
   onBack: () => void;
   onConnect: () => void;
 }) {
@@ -188,9 +202,11 @@ function ProviderDetail({
             {models.length === 1 ? '' : 's'}
           </p>
         </div>
-        <Button size="sm" className="shrink-0" onClick={onConnect}>
-          {isConnected ? 'Reconnect' : 'Connect'}
-        </Button>
+        {canWrite && (
+          <Button size="sm" className="shrink-0" onClick={onConnect}>
+            {isConnected ? 'Reconnect' : 'Connect'}
+          </Button>
+        )}
       </div>
 
       {helpHostname && provider.helpUrl && (

--- a/apps/web/src/features/workspace/customize/sections/llm-provider/chatgpt-subscription-connect.tsx
+++ b/apps/web/src/features/workspace/customize/sections/llm-provider/chatgpt-subscription-connect.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Button } from '@/components/ui/button';
+import Loading from '@/components/ui/loading';
 import { successToast } from '@/components/ui/toast';
 import { ProviderLogo } from '@/features/providers/provider-branding';
 import { refreshProjectProviderState } from '@/hooks/opencode/provider-refresh';
@@ -9,7 +10,7 @@ import {
   startProjectProviderOAuth,
 } from '@kortix/sdk/projects-client';
 import { useQueryClient } from '@tanstack/react-query';
-import { AlertCircle, ExternalLink, Loader2 } from 'lucide-react';
+import { AlertCircle, ExternalLink } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
@@ -169,14 +170,14 @@ export function ChatGptSubscriptionConnect({
             </div>
           )}
           <div className="text-muted-foreground mt-3 flex items-center gap-2 text-xs">
-            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            <Loading className="size-3.5 shrink-0" />
             {challenge ? 'Waiting for you to finish in the browser…' : 'Connecting to OpenAI…'}
           </div>
         </div>
       )}
 
       {phase === 'done' && (
-        <div className="text-foreground/80 mt-3 flex items-start gap-2 rounded-2xl border border-emerald-500/20 bg-emerald-500/[0.06] px-3 py-2.5 text-xs">
+        <div className="text-foreground/80 border-kortix-green/20 bg-kortix-green/[0.06] mt-3 flex items-start gap-2 rounded-2xl border px-3 py-2.5 text-xs">
           {tHardcodedUi.raw(
             'autoComponentsProjectsProjectProviderModalJsxTextChatGPTSubscriptionConnectedcf12bc87',
           )}

--- a/apps/web/src/features/workspace/customize/sections/llm-provider/connected-tab.tsx
+++ b/apps/web/src/features/workspace/customize/sections/llm-provider/connected-tab.tsx
@@ -23,11 +23,13 @@ export function ConnectedTab({
   connectedProviders,
   search,
   onAddProvider,
+  canWrite = false,
 }: {
   projectId: string;
   connectedProviders: LlmProviderEntry[];
   search: string;
   onAddProvider: () => void;
+  canWrite?: boolean;
 }) {
   const tHardcodedUi = useTranslations('hardcodedUi');
   const queryClient = useQueryClient();
@@ -78,9 +80,13 @@ export function ConnectedTab({
             'componentsProjectsProjectProviderModal.line300JsxTextNoProvidersConnectedYet',
           )}
           action={
-            <Button variant="outline" size="sm" onClick={onAddProvider}>
-              {tHardcodedUi.raw('componentsProjectsProjectProviderModal.line302JsxTextAddProvider')}
-            </Button>
+            canWrite ? (
+              <Button variant="outline" size="sm" onClick={onAddProvider}>
+                {tHardcodedUi.raw(
+                  'componentsProjectsProjectProviderModal.line302JsxTextAddProvider',
+                )}
+              </Button>
+            ) : undefined
           }
         />
       </div>
@@ -130,7 +136,7 @@ export function ConnectedTab({
                     : `${providerCredentialSummary(provider)} · ${provider.models.length} model${provider.models.length === 1 ? '' : 's'}`}
                 </p>
               </div>
-              {!provider.managed && (
+              {canWrite && !provider.managed && (
                 <Hint label="Disconnect">
                   <Button
                     type="button"

--- a/apps/web/src/features/workspace/customize/sections/llm-provider/custom-provider-form.tsx
+++ b/apps/web/src/features/workspace/customize/sections/llm-provider/custom-provider-form.tsx
@@ -2,11 +2,12 @@
 
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import Loading from '@/components/ui/loading';
 import { errorToast, successToast } from '@/components/ui/toast';
 import { refreshProjectProviderState } from '@/hooks/opencode/provider-refresh';
 import { upsertProjectSecret } from '@kortix/sdk/projects-client';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { AlertCircle, ChevronLeft, Copy, Loader2 } from 'lucide-react';
+import { AlertCircle, ChevronLeft, Copy } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { type FormEvent, useState } from 'react';
 
@@ -252,7 +253,7 @@ export function CustomProviderForm({
         <Button type="submit" size="sm" className="px-4" disabled={save.isPending}>
           {save.isPending ? (
             <>
-              <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+              <Loading className="mr-1.5 size-3.5 shrink-0" />
               {tHardcodedUi.raw('componentsProjectsProjectProviderModal.line1094JsxTextGenerating')}
             </>
           ) : (
@@ -289,7 +290,7 @@ function CustomProviderSnippetView({
 
   return (
     <div className="space-y-3 px-5 pt-3 pb-5">
-      <div className="rounded-2xl border border-emerald-500/30 bg-emerald-500/[0.04] px-3.5 py-3">
+      <div className="border-kortix-green/30 bg-kortix-green/[0.04] rounded-2xl border px-3.5 py-3">
         <div className="text-foreground text-sm font-medium">
           {secretName ? 'API key saved' : 'Snippet ready'}
         </div>

--- a/apps/web/src/features/workspace/customize/sections/llm-provider/llm-provider-modal.tsx
+++ b/apps/web/src/features/workspace/customize/sections/llm-provider/llm-provider-modal.tsx
@@ -141,7 +141,7 @@ export function ProjectProviderModal({
       <div className="min-h-0 flex-1 overflow-y-auto">
         {secretsQuery.isLoading && (
           <div className="flex min-h-[200px] items-center justify-center">
-            <Loading className="text-muted-foreground h-4 w-4 animate-spin" />
+            <Loading className="text-muted-foreground size-4 shrink-0" />
           </div>
         )}
 

--- a/apps/web/src/features/workspace/customize/sections/llm-provider/llm-provider-modal.tsx
+++ b/apps/web/src/features/workspace/customize/sections/llm-provider/llm-provider-modal.tsx
@@ -148,7 +148,7 @@ export function ProjectProviderModal({
       <div className="min-h-0 flex-1 overflow-y-auto">
         {secretsQuery.isLoading && (
           <div className="flex min-h-[200px] items-center justify-center">
-            <Loading className="text-muted-foreground h-4 w-4 animate-spin" />
+            <Loading className="text-muted-foreground size-4 shrink-0" />
           </div>
         )}
 

--- a/apps/web/src/features/workspace/customize/sections/llm-provider/llm-provider-modal.tsx
+++ b/apps/web/src/features/workspace/customize/sections/llm-provider/llm-provider-modal.tsx
@@ -36,6 +36,7 @@ export function ProjectProviderModal({
   initialProviderId,
   asPanel = false,
   allowedTabs,
+  canWrite = false,
 }: ProjectProviderModalProps) {
   const tHardcodedUi = useTranslations('hardcodedUi');
   const { secretsQuery, connectedProviders, llmGatewayEnabled } = useConnectedProviders(
@@ -44,9 +45,14 @@ export function ProjectProviderModal({
   );
   const hasConnections = connectedProviders.length > 0;
 
+  // Read-only members never reach the catalog (its detail → connect forms POST
+  // secrets and would 403); fold any attempt to land there back to Connected.
   const clampTab = useCallback(
-    (t: ActiveTab): ActiveTab => (allowedTabs && !allowedTabs.includes(t) ? allowedTabs[0] : t),
-    [allowedTabs],
+    (t: ActiveTab): ActiveTab => {
+      const resolved = allowedTabs && !allowedTabs.includes(t) ? allowedTabs[0] : t;
+      return !canWrite && resolved === 'catalog' ? 'connected' : resolved;
+    },
+    [allowedTabs, canWrite],
   );
 
   const [activeTab, setActiveTab] = useState<ActiveTab>(() =>
@@ -57,7 +63,7 @@ export function ProjectProviderModal({
 
   useEffect(() => {
     if (open) {
-      if (initialProviderId) {
+      if (initialProviderId && canWrite) {
         setActiveTab(clampTab('catalog'));
         setSubview({ kind: 'connect', providerId: initialProviderId });
       } else {
@@ -84,7 +90,8 @@ export function ProjectProviderModal({
         ? 'Search models...'
         : 'Search providers...';
 
-  const showTab = (t: ActiveTab) => !allowedTabs || allowedTabs.includes(t);
+  const showTab = (t: ActiveTab) =>
+    (!allowedTabs || allowedTabs.includes(t)) && (canWrite || t !== 'catalog');
   const showTabBar = !allowedTabs || allowedTabs.length > 1;
 
   const body = (
@@ -152,6 +159,7 @@ export function ProjectProviderModal({
                 projectId={projectId}
                 connectedProviders={connectedProviders}
                 search={search}
+                canWrite={canWrite}
                 onAddProvider={() => switchTab('catalog')}
               />
             </TabsContent>
@@ -163,6 +171,7 @@ export function ProjectProviderModal({
                 search={search}
                 subview={subview}
                 setSubview={setSubview}
+                canWrite={canWrite}
               />
             </TabsContent>
 

--- a/apps/web/src/features/workspace/customize/sections/llm-provider/types.ts
+++ b/apps/web/src/features/workspace/customize/sections/llm-provider/types.ts
@@ -14,6 +14,12 @@ export interface ProjectProviderModalProps {
   initialProviderId?: string;
   asPanel?: boolean;
   allowedTabs?: ActiveTab[];
+  /**
+   * Read-only members see connected providers + catalog but not the
+   * add/connect/remove controls (which POST and would 403). Fails safe: a
+   * missing value is treated as read-only.
+   */
+  canWrite?: boolean;
 }
 
 export interface CustomFormState {

--- a/apps/web/src/features/workspace/customize/sections/view/agents-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/agents-view.tsx
@@ -14,7 +14,9 @@ import {
 import { formatMode } from '@/features/workspace/customize/shared/utils';
 import { useModelDefaults } from '@/hooks/opencode/use-model-defaults';
 import { useOpenCodeProviders } from '@/hooks/opencode/use-opencode-sessions';
+import { PROJECT_ACTIONS } from '@/lib/project-actions';
 import { toast } from '@/lib/toast';
+import { useProjectCan } from '@/lib/use-project-can';
 import { cn } from '@/lib/utils';
 import {
   type AgentGrantSet,
@@ -33,12 +35,14 @@ import { useEffect, useMemo, useState } from 'react';
 type Agent = ProjectConfigSummary['agents'][number];
 
 export function AgentsView({ projectId }: { projectId: string }) {
+  const canWrite = useProjectCan(projectId, PROJECT_ACTIONS.PROJECT_AGENT_WRITE).allowed === true;
   return (
     <ConfigEntityView<Agent>
       projectId={projectId}
       kind="agent"
       noun="agent"
       layout="split"
+      canWrite={canWrite}
       title="Agents"
       searchPlaceholder="Search agents"
       emptyIcon={Bot}

--- a/apps/web/src/features/workspace/customize/sections/view/agents-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/agents-view.tsx
@@ -16,6 +16,8 @@ import {
 import { formatMode } from '@/features/workspace/customize/shared/utils';
 import { useModelDefaults } from '@/hooks/opencode/use-model-defaults';
 import { useOpenCodeProviders } from '@/hooks/opencode/use-opencode-sessions';
+import { PROJECT_ACTIONS } from '@/lib/project-actions';
+import { useProjectCan } from '@/lib/use-project-can';
 import { cn } from '@/lib/utils';
 import {
   type AgentGrantSet,
@@ -34,12 +36,14 @@ import { useEffect, useMemo, useState } from 'react';
 type Agent = ProjectConfigSummary['agents'][number];
 
 export function AgentsView({ projectId }: { projectId: string }) {
+  const canWrite = useProjectCan(projectId, PROJECT_ACTIONS.PROJECT_AGENT_WRITE).allowed === true;
   return (
     <ConfigEntityView<Agent>
       projectId={projectId}
       kind="agent"
       noun="agent"
       layout="split"
+      canWrite={canWrite}
       title="Agents"
       searchPlaceholder="Search agents"
       emptyIcon={Bot}

--- a/apps/web/src/features/workspace/customize/sections/view/agents-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/agents-view.tsx
@@ -2,6 +2,8 @@
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import Loading from '@/components/ui/loading';
+import { errorToast, successToast } from '@/components/ui/toast';
 import { ModelSelector } from '@/features/session/model-selector';
 import { flattenModels } from '@/features/session/session-chat-input';
 import { AgentConfigEditor } from '@/features/workspace/customize/sections/view/agent-editor';
@@ -14,7 +16,6 @@ import {
 import { formatMode } from '@/features/workspace/customize/shared/utils';
 import { useModelDefaults } from '@/hooks/opencode/use-model-defaults';
 import { useOpenCodeProviders } from '@/hooks/opencode/use-opencode-sessions';
-import { toast } from '@/lib/toast';
 import { cn } from '@/lib/utils';
 import {
   type AgentGrantSet,
@@ -27,7 +28,7 @@ import {
 } from '@kortix/sdk/projects-client';
 import { StarSolid } from '@mynaui/icons-react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { Bot, Check, Loader2, ShieldCheck, Sparkles, User, Users } from 'lucide-react';
+import { Bot, Check, ShieldCheck, Sparkles, User, Users } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 
 type Agent = ProjectConfigSummary['agents'][number];
@@ -216,7 +217,7 @@ function AgentModel({ projectId, agentName }: { projectId: string; agentName: st
             onSelect={(m) => {
               if (m) {
                 void defaults.setAgentDefault(agentName, m);
-                toast.success(`${agentName} → ${nameOf(m)}`);
+                successToast(`${agentName} → ${nameOf(m)}`);
               } else {
                 void defaults.clearAgentDefault(agentName);
               }
@@ -229,7 +230,7 @@ function AgentModel({ projectId, agentName }: { projectId: string; agentName: st
               className="h-7 px-2 text-xs"
               onClick={() => {
                 void defaults.clearAgentDefault(agentName);
-                toast.success(`${agentName} follows the default model again`);
+                successToast(`${agentName} follows the default model again`);
               }}
             >
               Reset to default
@@ -350,11 +351,11 @@ function AgentScopeCard({
   const save = useMutation({
     mutationFn: () => setAgentScope(projectId, agentName, { env, connectors }),
     onSuccess: () => {
-      toast.success(`Scope updated for ${agentName}`);
+      successToast(`Scope updated for ${agentName}`);
       // Refetch the project config so the committed scope (this card's source) updates.
       queryClient.invalidateQueries({ queryKey: ['project-detail', projectId] });
     },
-    onError: (e: Error) => toast.error(e.message || 'Failed to update scope'),
+    onError: (e: Error) => errorToast(e.message || 'Failed to update scope'),
   });
 
   // Non-managers get the read-only mirror (the old presentation).
@@ -423,7 +424,7 @@ function AgentScopeCard({
             disabled={!dirty || save.isPending}
             onClick={() => save.mutate()}
           >
-            {save.isPending && <Loader2 className="size-3.5 animate-spin" />}
+            {save.isPending && <Loading className="size-3.5 shrink-0" />}
             Save scope
           </Button>
         </div>
@@ -561,7 +562,7 @@ function ScopeEditor({
                     {isSel && <Check className="size-3" />}
                   </span>
                   <span className="min-w-0 flex-1 truncate font-mono">{o.label}</span>
-                  {isOrphan && <span className="text-amber-600 dark:text-amber-400">missing</span>}
+                  {isOrphan && <span className="text-kortix-orange">missing</span>}
                 </button>
               );
             })}

--- a/apps/web/src/features/workspace/customize/sections/view/agents-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/agents-view.tsx
@@ -2,6 +2,8 @@
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import Loading from '@/components/ui/loading';
+import { errorToast, successToast } from '@/components/ui/toast';
 import { ModelSelector } from '@/features/session/model-selector';
 import { flattenModels } from '@/features/session/session-chat-input';
 import { AgentConfigEditor } from '@/features/workspace/customize/sections/view/agent-editor';
@@ -15,7 +17,6 @@ import { formatMode } from '@/features/workspace/customize/shared/utils';
 import { useModelDefaults } from '@/hooks/opencode/use-model-defaults';
 import { useOpenCodeProviders } from '@/hooks/opencode/use-opencode-sessions';
 import { PROJECT_ACTIONS } from '@/lib/project-actions';
-import { toast } from '@/lib/toast';
 import { useProjectCan } from '@/lib/use-project-can';
 import { cn } from '@/lib/utils';
 import {
@@ -29,7 +30,7 @@ import {
 } from '@kortix/sdk/projects-client';
 import { StarSolid } from '@mynaui/icons-react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { Bot, Check, Loader2, ShieldCheck, Sparkles, User, Users } from 'lucide-react';
+import { Bot, Check, ShieldCheck, Sparkles, User, Users } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 
 type Agent = ProjectConfigSummary['agents'][number];
@@ -220,7 +221,7 @@ function AgentModel({ projectId, agentName }: { projectId: string; agentName: st
             onSelect={(m) => {
               if (m) {
                 void defaults.setAgentDefault(agentName, m);
-                toast.success(`${agentName} → ${nameOf(m)}`);
+                successToast(`${agentName} → ${nameOf(m)}`);
               } else {
                 void defaults.clearAgentDefault(agentName);
               }
@@ -233,7 +234,7 @@ function AgentModel({ projectId, agentName }: { projectId: string; agentName: st
               className="h-7 px-2 text-xs"
               onClick={() => {
                 void defaults.clearAgentDefault(agentName);
-                toast.success(`${agentName} follows the default model again`);
+                successToast(`${agentName} follows the default model again`);
               }}
             >
               Reset to default
@@ -354,11 +355,11 @@ function AgentScopeCard({
   const save = useMutation({
     mutationFn: () => setAgentScope(projectId, agentName, { env, connectors }),
     onSuccess: () => {
-      toast.success(`Scope updated for ${agentName}`);
+      successToast(`Scope updated for ${agentName}`);
       // Refetch the project config so the committed scope (this card's source) updates.
       queryClient.invalidateQueries({ queryKey: ['project-detail', projectId] });
     },
-    onError: (e: Error) => toast.error(e.message || 'Failed to update scope'),
+    onError: (e: Error) => errorToast(e.message || 'Failed to update scope'),
   });
 
   // Non-managers get the read-only mirror (the old presentation).
@@ -427,7 +428,7 @@ function AgentScopeCard({
             disabled={!dirty || save.isPending}
             onClick={() => save.mutate()}
           >
-            {save.isPending && <Loader2 className="size-3.5 animate-spin" />}
+            {save.isPending && <Loading className="size-3.5 shrink-0" />}
             Save scope
           </Button>
         </div>
@@ -565,7 +566,7 @@ function ScopeEditor({
                     {isSel && <Check className="size-3" />}
                   </span>
                   <span className="min-w-0 flex-1 truncate font-mono">{o.label}</span>
-                  {isOrphan && <span className="text-amber-600 dark:text-amber-400">missing</span>}
+                  {isOrphan && <span className="text-kortix-orange">missing</span>}
                 </button>
               );
             })}

--- a/apps/web/src/features/workspace/customize/sections/view/changes-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/changes-view.tsx
@@ -22,6 +22,8 @@ import {
 } from '@/features/project-files/hooks/use-change-requests';
 import { useCommits } from '@/features/project-files/hooks/use-commits';
 import { getProject, type ProjectCommit } from '@kortix/sdk/projects-client';
+import { PROJECT_ACTIONS } from '@/lib/project-actions';
+import { useProjectCan } from '@/lib/use-project-can';
 import { cn } from '@/lib/utils';
 import {
   Check,
@@ -127,7 +129,15 @@ function CheckpointRow({
   );
 }
 
-function ChangeRequestRow({ cr, onOpen }: { cr: ChangeRequest; onOpen: (crId: string) => void }) {
+function ChangeRequestRow({
+  cr,
+  onOpen,
+  canAct,
+}: {
+  cr: ChangeRequest;
+  onOpen: (crId: string) => void;
+  canAct: boolean;
+}) {
   const merge = useMergeChangeRequest();
   const close = useCloseChangeRequest();
   const reopen = useReopenChangeRequest();
@@ -189,7 +199,7 @@ function ChangeRequestRow({ cr, onOpen }: { cr: ChangeRequest; onOpen: (crId: st
         </span>
       </button>
 
-      {cr.status === 'open' && (
+      {canAct && cr.status === 'open' && (
         <div className="flex shrink-0 items-center gap-2">
           <Button variant="ghost" size="sm" onClick={onClose} disabled={busy}>
             Dismiss
@@ -200,7 +210,7 @@ function ChangeRequestRow({ cr, onOpen }: { cr: ChangeRequest; onOpen: (crId: st
           </Button>
         </div>
       )}
-      {cr.status === 'closed' && (
+      {canAct && cr.status === 'closed' && (
         <Button variant="secondary" size="sm" onClick={onReopen} disabled={busy}>
           Reopen
         </Button>
@@ -214,16 +224,18 @@ function TimelineRow({
   index,
   onOpenCheckpoint,
   onOpenCr,
+  canAct,
 }: {
   item: TimelineItem;
   index: number;
   onOpenCheckpoint: (sha: string) => void;
   onOpenCr: (crId: string) => void;
+  canAct: boolean;
 }) {
   if (item.kind === 'checkpoint') {
     return <CheckpointRow commit={item.commit} index={index} onOpen={onOpenCheckpoint} />;
   }
-  return <ChangeRequestRow cr={item.cr} onOpen={onOpenCr} />;
+  return <ChangeRequestRow cr={item.cr} onOpen={onOpenCr} canAct={canAct} />;
 }
 
 function ListSkeleton({ rows = 6 }: { rows?: number }) {
@@ -253,10 +265,18 @@ export function ChangesView({ projectId }: { projectId: string }) {
     staleTime: 60_000,
   });
   const defaultBranch = projectQuery.data?.default_branch ?? '';
+  // Apply/Dismiss/Reopen assert project.gitops.push server-side; a read-only role
+  // (gitops.read but not gitops.push) still SEES the change list + diffs, just no
+  // action buttons that would 403. Fails safe: false until the probe resolves.
+  const canAct = useProjectCan(projectId, PROJECT_ACTIONS.PROJECT_GITOPS_PUSH).allowed === true;
 
   return (
     <ProjectFilesProvider value={{ projectId, ref: defaultBranch, defaultBranch }}>
-      <ChangesTimeline defaultBranch={defaultBranch} projectLoading={projectQuery.isLoading} />
+      <ChangesTimeline
+        defaultBranch={defaultBranch}
+        projectLoading={projectQuery.isLoading}
+        canAct={canAct}
+      />
     </ProjectFilesProvider>
   );
 }
@@ -264,9 +284,11 @@ export function ChangesView({ projectId }: { projectId: string }) {
 function ChangesTimeline({
   defaultBranch,
   projectLoading,
+  canAct,
 }: {
   defaultBranch: string;
   projectLoading: boolean;
+  canAct: boolean;
 }) {
   const [selectedSha, setSelectedSha] = useState<string | null>(null);
   const [detailCrId, setDetailCrId] = useState<string | null>(null);
@@ -381,6 +403,7 @@ function ChangesTimeline({
                     index={i}
                     onOpenCheckpoint={setSelectedSha}
                     onOpenCr={setDetailCrId}
+                    canAct={canAct}
                   />
                 ))}
               </ul>

--- a/apps/web/src/features/workspace/customize/sections/view/channels-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/channels-view.tsx
@@ -65,6 +65,8 @@ import {
   listProjectAccess,
   type ProjectConfigSummary,
 } from '@kortix/sdk/projects-client';
+import { PROJECT_ACTIONS } from '@/lib/project-actions';
+import { useProjectCan } from '@/lib/use-project-can';
 import { cn } from '@/lib/utils';
 import { Check, CheckCircleSolid, ExternalLinkSolid } from '@mynaui/icons-react';
 import { Copy, Mail, MessageSquare, X } from 'lucide-react';
@@ -93,6 +95,8 @@ export function ChannelsView({ projectId }: { projectId: string | null }) {
   const loading =
     loadingInstall || loadingMode || projectQuery.isLoading || (emailChannelEnabled && loadingEmail);
   const oauthInstallUrl = mode?.oauth_available ? mode.install_url : null;
+  const canWrite =
+    useProjectCan(projectId ?? undefined, PROJECT_ACTIONS.PROJECT_CONNECTOR_WRITE).allowed === true;
 
   return (
     <CustomizeSectionWrapper
@@ -101,7 +105,7 @@ export function ChannelsView({ projectId }: { projectId: string | null }) {
         'autoComponentsProjectsCustomizeSectionsChannelsViewJsxTextRunThisb83f74db',
       )}
       action={
-        projectId && !loading && !install && oauthInstallUrl ? (
+        canWrite && projectId && !loading && !install && oauthInstallUrl ? (
           <Button size="sm" variant="secondary" asChild>
             <Link href={oauthInstallUrl} target="_blank" rel="noopener noreferrer">
               {tI18nHardcoded.raw(
@@ -168,11 +172,13 @@ export function ChannelsView({ projectId }: { projectId: string | null }) {
                   projectId={projectId}
                   installation={install ?? null}
                   oauthInstallUrl={oauthInstallUrl}
+                  canWrite={canWrite}
                 />
                 {emailChannelEnabled ? (
                   <EmailChannelRow
                     projectId={projectId}
                     installation={emailInstall ?? null}
+                    canWrite={canWrite}
                   />
                 ) : null}
               </TableBody>
@@ -199,7 +205,9 @@ export function ChannelsView({ projectId }: { projectId: string | null }) {
               <BringYourOwnPanel projectId={projectId} />
             ) : null}
 
-            {install ? <ChannelBindingsSection projectId={projectId} /> : null}
+            {install ? (
+              <ChannelBindingsSection projectId={projectId} canWrite={canWrite} />
+            ) : null}
           </>
         )}
       </div>
@@ -213,7 +221,13 @@ export function ChannelsView({ projectId }: { projectId: string | null }) {
  * the only other way to change these is the in-Slack `/kortix agent|model|policy`
  * commands; this edits the same row through `PATCH …/channels/bindings/:id`.
  */
-function ChannelBindingsSection({ projectId }: { projectId: string }) {
+function ChannelBindingsSection({
+  projectId,
+  canWrite,
+}: {
+  projectId: string;
+  canWrite: boolean;
+}) {
   const bindingsQuery = useChannelBindings(projectId);
   const bindings = bindingsQuery.data?.bindings ?? [];
 
@@ -250,6 +264,7 @@ function ChannelBindingsSection({ projectId }: { projectId: string }) {
               projectId={projectId}
               binding={b}
               projectDefaultAgent={bindingsQuery.data?.projectDefaultAgent ?? null}
+              canWrite={canWrite}
             />
           ))}
         </TableBody>
@@ -271,17 +286,22 @@ function ChannelBindingTableRow({
   projectId,
   binding,
   projectDefaultAgent,
+  canWrite,
 }: {
   projectId: string;
   binding: ChannelBinding;
   projectDefaultAgent: string | null;
+  canWrite: boolean;
 }) {
   const accessQuery = useQuery({
     queryKey: ['project-access', projectId],
     queryFn: () => listProjectAccess(projectId),
     staleTime: 20_000,
   });
-  const canManage = Boolean(accessQuery.data?.can_manage);
+  // `can_manage` is the coarse project-manage flag; AND it with the real
+  // connector write leaf so a READ-only connector role can't edit bindings
+  // (the PATCH route asserts project.connector.write and would 403).
+  const canManage = Boolean(accessQuery.data?.can_manage) && canWrite;
 
   const detailQuery = useQuery({
     queryKey: ['project-detail', projectId],
@@ -415,10 +435,12 @@ function SlackChannelRow({
   projectId,
   installation,
   oauthInstallUrl,
+  canWrite,
 }: {
   projectId: string;
   installation: SlackInstallation | null;
   oauthInstallUrl: string | null;
+  canWrite: boolean;
 }) {
   const tI18nHardcoded = useTranslations('hardcodedUi');
   const disconnect = useDisconnectSlack();
@@ -449,7 +471,7 @@ function SlackChannelRow({
         {connected ? (installation?.workspaceName ?? installation?.workspaceId ?? '—') : '—'}
       </TableCell>
       <TableCell>
-        {connected ? (
+        {!canWrite ? null : connected ? (
           confirming ? (
             <div className="flex items-center justify-end gap-1">
               <Button variant="ghost" size="sm" onClick={() => setConfirming(false)}>
@@ -497,9 +519,11 @@ function SlackChannelRow({
 function EmailChannelRow({
   projectId,
   installation,
+  canWrite,
 }: {
   projectId: string;
   installation: EmailInstallation | null;
+  canWrite: boolean;
 }) {
   const disconnect = useDisconnectEmail();
   const [connectOpen, setConnectOpen] = useState(false);
@@ -535,7 +559,7 @@ function EmailChannelRow({
           )}
         </TableCell>
         <TableCell>
-          {connected ? (
+          {!canWrite ? null : connected ? (
             confirming ? (
               <div className="flex items-center justify-end gap-1">
                 <Button variant="ghost" size="sm" onClick={() => setConfirming(false)}>

--- a/apps/web/src/features/workspace/customize/sections/view/commands-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/commands-view.tsx
@@ -4,17 +4,21 @@ import {
   type ConfigEntity,
   ConfigEntityView,
 } from '@/features/workspace/customize/sections/component/config-entity-view';
+import { PROJECT_ACTIONS } from '@/lib/project-actions';
+import { useProjectCan } from '@/lib/use-project-can';
 import { SquareSlash } from 'lucide-react';
 
 type Command = ConfigEntity;
 
 export function CommandsView({ projectId }: { projectId: string }) {
+  const canWrite = useProjectCan(projectId, PROJECT_ACTIONS.PROJECT_COMMAND_WRITE).allowed === true;
   return (
     <ConfigEntityView<Command>
       projectId={projectId}
       kind="command"
       noun="command"
       layout="split"
+      canWrite={canWrite}
       title="Commands"
       searchPlaceholder="Search commands"
       emptyIcon={SquareSlash}

--- a/apps/web/src/features/workspace/customize/sections/view/computers-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/computers-view.tsx
@@ -1,7 +1,11 @@
 'use client';
 
 import { TunnelOverview } from '@/features/tunnel/tunnel-overview';
+import { PROJECT_ACTIONS } from '@/lib/project-actions';
+import { useProjectCan } from '@/lib/use-project-can';
 
-export function ComputersView({ projectId: _projectId }: { projectId: string }) {
-  return <TunnelOverview />;
+export function ComputersView({ projectId }: { projectId: string }) {
+  const canWrite =
+    useProjectCan(projectId, PROJECT_ACTIONS.PROJECT_CONNECTOR_WRITE).allowed === true;
+  return <TunnelOverview canWrite={canWrite} />;
 }

--- a/apps/web/src/features/workspace/customize/sections/view/dev-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/dev-view.tsx
@@ -24,6 +24,8 @@ import { Icon } from '@/features/icon/icon';
 import { ErrorState } from '@/features/layout/section/error-state';
 import { useCopy } from '@/hooks/use-copy';
 import { getProject, inviteRepoCollaborator, isManagedGithubProject } from '@kortix/sdk/projects-client';
+import { PROJECT_ACTIONS } from '@/lib/project-actions';
+import { useProjectCan } from '@/lib/use-project-can';
 import { cn } from '@/lib/utils';
 import CustomizeSectionWrapper from '../component/section-wrapper';
 
@@ -36,6 +38,11 @@ export function DevView({ projectId }: { projectId: string }) {
   });
 
   const project = projectQuery.data;
+  // The GitHub-invite form calls inviteRepoCollaborator, which asserts
+  // project.write server-side. A read-only role (project.read only) still sees the
+  // whole dev walkthrough — just not the invite control that would 403. Fails safe:
+  // false until the probe resolves.
+  const canWrite = useProjectCan(projectId, PROJECT_ACTIONS.PROJECT_WRITE).allowed === true;
 
   return (
     <CustomizeSectionWrapper
@@ -68,7 +75,7 @@ export function DevView({ projectId }: { projectId: string }) {
         />
       )}
 
-      {project && <DevSteps project={project} />}
+      {project && <DevSteps project={project} canWrite={canWrite} />}
     </CustomizeSectionWrapper>
   );
 }
@@ -79,7 +86,13 @@ type DevStep = {
   content: ReactNode;
 };
 
-function DevSteps({ project }: { project: Awaited<ReturnType<typeof getProject>> }) {
+function DevSteps({
+  project,
+  canWrite,
+}: {
+  project: Awaited<ReturnType<typeof getProject>>;
+  canWrite: boolean;
+}) {
   const tI18nHardcoded = useTranslations('hardcodedUi');
   const cloneUrl = cloneUrlFor(project.repo_url);
   const repoDir = repoDirFor(project.repo_url) || 'my-project';
@@ -88,7 +101,9 @@ function DevSteps({ project }: { project: Awaited<ReturnType<typeof getProject>>
 
   const steps: DevStep[] = [];
 
-  if (managed) {
+  // The invite step is the only WRITE surface in this walkthrough; hide it for
+  // read-only roles so they don't hit a 403 on submit. The rest stays visible.
+  if (managed && canWrite) {
     steps.push({
       title: tI18nHardcoded.raw(
         'autoComponentsProjectsCustomizeSectionsDevViewJsxAttrTitleGetd1e11afa',

--- a/apps/web/src/features/workspace/customize/sections/view/gateway/gateway-budgets.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/gateway/gateway-budgets.tsx
@@ -72,7 +72,13 @@ type EditTarget =
   | { scope: 'project' }
   | { scope: 'member'; subjectUserId: string; email: string | null };
 
-export function GatewayBudgets({ projectId }: { projectId: string }) {
+export function GatewayBudgets({
+  projectId,
+  canWrite = false,
+}: {
+  projectId: string;
+  canWrite?: boolean;
+}) {
   const { data } = useGatewayBudgets(projectId);
   const setBudget = useSetGatewayBudget(projectId);
   const delBudget = useDeleteGatewayBudget(projectId);
@@ -123,9 +129,11 @@ export function GatewayBudgets({ projectId }: { projectId: string }) {
           title="Project budget"
           description="Cap total spend across everyone in this project's gateway"
           action={
-            <Button size="sm" variant="outline" onClick={() => setEditing({ scope: 'project' })}>
-              {projectBudget ? 'Edit' : 'Set budget'}
-            </Button>
+            canWrite ? (
+              <Button size="sm" variant="outline" onClick={() => setEditing({ scope: 'project' })}>
+                {projectBudget ? 'Edit' : 'Set budget'}
+              </Button>
+            ) : undefined
           }
         >
           {projectBudget ? (
@@ -154,15 +162,17 @@ export function GatewayBudgets({ projectId }: { projectId: string }) {
                     </span>
                   </div>
                   <Meter spent={projectSpend} limit={projectBudget.limit_usd} />
-                  <div className="flex justify-end">
-                    <button
-                      type="button"
-                      onClick={() => remove(projectBudget.budget_id)}
-                      className="text-xs text-muted-foreground transition-colors hover:text-foreground"
-                    >
-                      Remove budget
-                    </button>
-                  </div>
+                  {canWrite && (
+                    <div className="flex justify-end">
+                      <button
+                        type="button"
+                        onClick={() => remove(projectBudget.budget_id)}
+                        className="text-xs text-muted-foreground transition-colors hover:text-foreground"
+                      >
+                        Remove budget
+                      </button>
+                    </div>
+                  )}
                 </div>
               );
             })()
@@ -191,6 +201,7 @@ export function GatewayBudgets({ projectId }: { projectId: string }) {
                   member={m}
                   maxCost={Math.max(1e-9, ...members.map((x) => x.cost))}
                   budget={memberBudget(m.user_id)}
+                  canWrite={canWrite}
                   onSetCap={() =>
                     m.user_id &&
                     setEditing({ scope: 'member', subjectUserId: m.user_id, email: m.email })
@@ -238,12 +249,14 @@ function MemberRow({
   member,
   maxCost,
   budget,
+  canWrite,
   onSetCap,
   onRemove,
 }: {
   member: GatewayMemberSpend;
   maxCost: number;
   budget: GatewayBudgetRow | null;
+  canWrite: boolean;
   onSetCap: () => void;
   onRemove: (id: string) => void;
 }) {
@@ -271,19 +284,20 @@ function MemberRow({
           </div>
         )}
       </div>
-      {budget ? (
-        <button
-          type="button"
-          onClick={() => onRemove(budget.budget_id)}
-          className="shrink-0 text-xs text-muted-foreground transition-colors hover:text-foreground"
-        >
-          Remove
-        </button>
-      ) : (
-        <Button size="sm" variant="ghost" className="shrink-0" onClick={onSetCap}>
-          Set cap
-        </Button>
-      )}
+      {canWrite &&
+        (budget ? (
+          <button
+            type="button"
+            onClick={() => onRemove(budget.budget_id)}
+            className="shrink-0 text-xs text-muted-foreground transition-colors hover:text-foreground"
+          >
+            Remove
+          </button>
+        ) : (
+          <Button size="sm" variant="ghost" className="shrink-0" onClick={onSetCap}>
+            Set cap
+          </Button>
+        ))}
     </div>
   );
 }

--- a/apps/web/src/features/workspace/customize/sections/view/gateway/gateway-keys.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/gateway/gateway-keys.tsx
@@ -45,7 +45,13 @@ function fmtDate(s: string | null): string {
   });
 }
 
-export function GatewayKeys({ projectId }: { projectId: string }) {
+export function GatewayKeys({
+  projectId,
+  canWrite = false,
+}: {
+  projectId: string;
+  canWrite?: boolean;
+}) {
   const { data, isError } = useGatewayKeys(projectId);
   const createKey = useCreateGatewayKey(projectId);
   const revokeKey = useRevokeGatewayKey(projectId);
@@ -93,9 +99,11 @@ export function GatewayKeys({ projectId }: { projectId: string }) {
                 logged and billed here.
               </p>
             </div>
-            <Button size="sm" className="shrink-0" onClick={() => setCreating(true)}>
-              Create key
-            </Button>
+            {canWrite && (
+              <Button size="sm" className="shrink-0" onClick={() => setCreating(true)}>
+                Create key
+              </Button>
+            )}
           </div>
 
           {keys.length === 0 ? (
@@ -105,9 +113,11 @@ export function GatewayKeys({ projectId }: { projectId: string }) {
               title="No keys yet"
               description="Create a project-scoped key to call the gateway from outside a Kortix session."
               action={
-                <Button variant="outline" size="sm" onClick={() => setCreating(true)}>
-                  Create key
-                </Button>
+                canWrite ? (
+                  <Button variant="outline" size="sm" onClick={() => setCreating(true)}>
+                    Create key
+                  </Button>
+                ) : undefined
               }
             />
           ) : (
@@ -139,7 +149,7 @@ export function GatewayKeys({ projectId }: { projectId: string }) {
                         <span>last used {fmtDate(k.last_used_at)}</span>
                       </InlineMeta>
                     </div>
-                    {active && (
+                    {active && canWrite && (
                       <DropdownMenu>
                         <DropdownMenuTrigger asChild>
                           <Button

--- a/apps/web/src/features/workspace/customize/sections/view/gateway/gateway-keys.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/gateway/gateway-keys.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import { useState } from 'react';
 import { Check, Copy, KeyRound, MoreHorizontal, Trash2 } from 'lucide-react';
+import { useState } from 'react';
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -58,6 +59,7 @@ export function GatewayKeys({
   const [creating, setCreating] = useState(false);
   const [name, setName] = useState('');
   const [created, setCreated] = useState<CreatedGatewayKey | null>(null);
+  const [revokeTarget, setRevokeTarget] = useState<{ key_id: string; name: string } | null>(null);
 
   const keys = data?.keys ?? [];
 
@@ -94,7 +96,7 @@ export function GatewayKeys({
                 API keys
                 <span className="text-muted-foreground font-normal"> ({keys.length})</span>
               </Label>
-              <p className="text-muted-foreground mt-0.5 text-xs text-pretty">
+              <p className="text-muted-foreground mt-0.5 text-pretty text-xs">
                 Project-scoped keys for calling the gateway from external apps — every request is
                 logged and billed here.
               </p>
@@ -128,7 +130,7 @@ export function GatewayKeys({
                 return (
                   <li
                     key={k.key_id}
-                    className="group bg-popover flex items-center gap-3 rounded-md border px-4 py-2.5 transition-colors"
+                    className="bg-popover group flex items-center gap-3 rounded-md border px-4 py-2.5 transition-colors"
                   >
                     <EntityAvatar icon={KeyRound} size="sm" />
                     <div className="min-w-0 flex-1">
@@ -169,13 +171,7 @@ export function GatewayKeys({
                         <DropdownMenuContent align="end" className="w-44">
                           <DropdownMenuItem
                             variant="destructive"
-                            onClick={() =>
-                              revokeKey.mutate(k.key_id, {
-                                onSuccess: () => successToast('Key revoked'),
-                                onError: (e) =>
-                                  errorToast(e instanceof Error ? e.message : 'Could not revoke'),
-                              })
-                            }
+                            onClick={() => setRevokeTarget({ key_id: k.key_id, name: k.name })}
                           >
                             <Trash2 className="size-3.5 shrink-0" />
                             Revoke key
@@ -230,6 +226,32 @@ export function GatewayKeys({
           onClose={() => setCreated(null)}
         />
       )}
+
+      <ConfirmDialog
+        open={revokeTarget !== null}
+        onOpenChange={(open) => {
+          if (!open) setRevokeTarget(null);
+        }}
+        title="Revoke key"
+        description={
+          revokeTarget
+            ? `Revoke ${revokeTarget.name}? Apps calling the gateway with it stop working immediately.`
+            : ''
+        }
+        confirmLabel="Revoke"
+        confirmVariant="destructive"
+        onConfirm={() => {
+          if (!revokeTarget) return;
+          revokeKey.mutate(revokeTarget.key_id, {
+            onSuccess: () => {
+              setRevokeTarget(null);
+              successToast('Key revoked');
+            },
+            onError: (e) => errorToast(e instanceof Error ? e.message : 'Could not revoke'),
+          });
+        }}
+        isPending={revokeKey.isPending}
+      />
     </div>
   );
 }

--- a/apps/web/src/features/workspace/customize/sections/view/gateway/gateway-logs.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/gateway/gateway-logs.tsx
@@ -16,6 +16,7 @@ import { forwardRef, type ReactNode, useEffect, useRef, useState } from 'react';
 import { EmptyState } from '@/features/layout/section/empty-state';
 import { FilterBar, FilterBarItem } from '@/components/ui/tabs';
 import Hint from '@/components/ui/hint';
+import { Skeleton } from '@/components/ui/skeleton';
 import { useGatewayLog, useGatewayLogs } from '@/hooks/projects/use-project-gateway';
 import type { GatewayLogRow } from '@/lib/projects-gateway-client';
 import { cn } from '@/lib/utils';
@@ -222,8 +223,8 @@ function GatewayLogDetail({
       </div>
       {isLoading || !data ? (
         <div className="space-y-3 p-5">
-          <div className="h-24 animate-pulse rounded-2xl bg-muted" />
-          <div className="h-40 animate-pulse rounded-2xl bg-muted" />
+          <Skeleton className="h-24 rounded-2xl" />
+          <Skeleton className="h-40 rounded-2xl" />
         </div>
       ) : (
         <div className="flex w-full animate-in fade-in-0 flex-col gap-4 p-5">
@@ -422,12 +423,12 @@ export function GatewayLogs({ projectId }: { projectId: string }) {
           <div className="divide-y divide-border/40">
             {Array.from({ length: 8 }).map((_, i) => (
               <div key={i} className="flex items-center gap-3 px-4 py-3">
-                <span className="size-2 animate-pulse rounded-full bg-muted" />
+                <Skeleton className="size-2 shrink-0 rounded-full" />
                 <div className="flex-1 space-y-1.5">
-                  <div className="h-3 w-40 animate-pulse rounded-full bg-muted" />
-                  <div className="h-2.5 w-24 animate-pulse rounded-full bg-muted" />
+                  <Skeleton className="h-3 w-40 rounded-full" />
+                  <Skeleton className="h-2.5 w-24 rounded-full" />
                 </div>
-                <div className="h-4 w-14 animate-pulse rounded-full bg-muted" />
+                <Skeleton className="h-4 w-14 rounded-full" />
               </div>
             ))}
           </div>

--- a/apps/web/src/features/workspace/customize/sections/view/meet-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/meet-view.tsx
@@ -24,11 +24,16 @@ import {
   useSetMeetBotName,
   useSetMeetVoice,
 } from '@/hooks/channels/use-meet-voices';
+import { PROJECT_ACTIONS } from '@/lib/project-actions';
+import { useProjectCan } from '@/lib/use-project-can';
 
 export function MeetView({ projectId }: { projectId: string }) {
   const voicesQuery = useMeetVoices(projectId);
   const setVoice = useSetMeetVoice();
   const setBotName = useSetMeetBotName();
+  // Read-only unless the role can write connectors (meet is connector-backed);
+  // fails closed while the probe resolves.
+  const canWrite = useProjectCan(projectId, PROJECT_ACTIONS.PROJECT_CONNECTOR_WRITE).allowed === true;
   const [previewing, setPreviewing] = useState<string | null>(null);
   const [draftName, setDraftName] = useState<string | null>(null);
 
@@ -102,6 +107,10 @@ export function MeetView({ projectId }: { projectId: string }) {
           <div className="bg-popover rounded-md border px-4 py-5">
             {voicesQuery.isLoading ? (
               <Skeleton className="h-10 w-full rounded-lg" />
+            ) : !canWrite ? (
+              <p className="text-foreground text-sm font-medium">
+                {(data?.bot_name ?? '').trim() || defaultBotName}
+              </p>
             ) : (
               <div className="flex items-center gap-2">
                 <Input
@@ -138,6 +147,17 @@ export function MeetView({ projectId }: { projectId: string }) {
               <Skeleton className="h-11 w-full rounded-lg" />
             ) : voices.length === 0 ? (
               <p className="text-muted-foreground text-sm">No voices available.</p>
+            ) : !canWrite ? (
+              <p className="text-muted-foreground text-sm">
+                {selectedVoice ? (
+                  <>
+                    <span className="text-foreground font-medium">{selectedVoice.name}</span> —{' '}
+                    {selectedVoice.desc}
+                  </>
+                ) : (
+                  'No voice selected.'
+                )}
+              </p>
             ) : (
               <div className="space-y-3">
                 <div className="flex items-center gap-2">

--- a/apps/web/src/features/workspace/customize/sections/view/meet-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/meet-view.tsx
@@ -23,11 +23,15 @@ import {
   useSetMeetBotName,
   useSetMeetVoice,
 } from '@/hooks/channels/use-meet-voices';
+import { PROJECT_ACTIONS } from '@/lib/project-actions';
+import { useProjectCan } from '@/lib/use-project-can';
 
 export function MeetView({ projectId }: { projectId: string }) {
   const voicesQuery = useMeetVoices(projectId);
   const setVoice = useSetMeetVoice();
   const setBotName = useSetMeetBotName();
+  const canWrite =
+    useProjectCan(projectId, PROJECT_ACTIONS.PROJECT_CONNECTOR_WRITE).allowed === true;
   const [previewing, setPreviewing] = useState<string | null>(null);
   const [draftName, setDraftName] = useState<string | null>(null);
 
@@ -98,6 +102,10 @@ export function MeetView({ projectId }: { projectId: string }) {
         >
           {voicesQuery.isLoading ? (
             <Skeleton className="h-10 w-full rounded-lg" />
+          ) : !canWrite ? (
+            <p className="text-foreground text-sm font-medium">
+              {(data?.bot_name ?? '').trim() || defaultBotName}
+            </p>
           ) : (
             <div className="flex items-center gap-2">
               <Input
@@ -131,6 +139,17 @@ export function MeetView({ projectId }: { projectId: string }) {
             <Skeleton className="h-11 w-full rounded-lg" />
           ) : voices.length === 0 ? (
             <p className="text-muted-foreground text-sm">No voices available.</p>
+          ) : !canWrite ? (
+            <p className="text-muted-foreground text-sm">
+              {selectedVoice ? (
+                <>
+                  <span className="text-foreground font-medium">{selectedVoice.name}</span> —{' '}
+                  {selectedVoice.desc}
+                </>
+              ) : (
+                'No voice selected.'
+              )}
+            </p>
           ) : (
             <div className="space-y-3">
               <div className="flex items-center gap-2">

--- a/apps/web/src/features/workspace/customize/sections/view/meet-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/meet-view.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import { Loader2, Play } from 'lucide-react';
+import { Play } from 'lucide-react';
 import { useState } from 'react';
 
 import { Button } from '@/components/ui/button';
 import { InfoBanner } from '@/components/ui/info-banner';
 import { Input } from '@/components/ui/input';
-import { SectionCard } from '@/components/ui/section-card';
+import { Label } from '@/components/ui/label';
+import Loading from '@/components/ui/loading';
 import {
   Select,
   SelectContent,
@@ -30,8 +31,9 @@ export function MeetView({ projectId }: { projectId: string }) {
   const voicesQuery = useMeetVoices(projectId);
   const setVoice = useSetMeetVoice();
   const setBotName = useSetMeetBotName();
-  const canWrite =
-    useProjectCan(projectId, PROJECT_ACTIONS.PROJECT_CONNECTOR_WRITE).allowed === true;
+  // Read-only unless the role can write connectors (meet is connector-backed);
+  // fails closed while the probe resolves.
+  const canWrite = useProjectCan(projectId, PROJECT_ACTIONS.PROJECT_CONNECTOR_WRITE).allowed === true;
   const [previewing, setPreviewing] = useState<string | null>(null);
   const [draftName, setDraftName] = useState<string | null>(null);
 
@@ -96,99 +98,106 @@ export function MeetView({ projectId }: { projectId: string }) {
           </InfoBanner>
         ) : null}
 
-        <SectionCard
-          title="Bot name"
-          description="The display name the notetaker joins under. People wake it in the call by saying its first name."
-        >
-          {voicesQuery.isLoading ? (
-            <Skeleton className="h-10 w-full rounded-lg" />
-          ) : !canWrite ? (
-            <p className="text-foreground text-sm font-medium">
-              {(data?.bot_name ?? '').trim() || defaultBotName}
-            </p>
-          ) : (
-            <div className="flex items-center gap-2">
-              <Input
-                size="lg"
-                value={botName}
-                onChange={(e) => setDraftName(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter') onSaveName();
-                }}
-                placeholder={defaultBotName}
-                maxLength={80}
-                className="flex-1"
-              />
-              <Button
-                size="lg"
-                className="shrink-0"
-                disabled={setBotName.isPending || !nameDirty}
-                onClick={onSaveName}
-              >
-                Save
-              </Button>
-            </div>
-          )}
-        </SectionCard>
-
-        <SectionCard
-          title="Default voice"
-          description="Used for the bot's spoken replies in calls. Preview a voice before you set it."
-        >
-          {voicesQuery.isLoading ? (
-            <Skeleton className="h-11 w-full rounded-lg" />
-          ) : voices.length === 0 ? (
-            <p className="text-muted-foreground text-sm">No voices available.</p>
-          ) : !canWrite ? (
-            <p className="text-muted-foreground text-sm">
-              {selectedVoice ? (
-                <>
-                  <span className="text-foreground font-medium">{selectedVoice.name}</span> —{' '}
-                  {selectedVoice.desc}
-                </>
-              ) : (
-                'No voice selected.'
-              )}
-            </p>
-          ) : (
-            <div className="space-y-3">
+        <section className="space-y-4">
+          <Label>Bot name</Label>
+          <p className="text-muted-foreground -mt-2 text-xs">
+            The display name the notetaker joins under. People wake it in the call by saying its
+            first name.
+          </p>
+          <div className="bg-popover rounded-md border px-4 py-5">
+            {voicesQuery.isLoading ? (
+              <Skeleton className="h-10 w-full rounded-lg" />
+            ) : !canWrite ? (
+              <p className="text-foreground text-sm font-medium">
+                {(data?.bot_name ?? '').trim() || defaultBotName}
+              </p>
+            ) : (
               <div className="flex items-center gap-2">
-                <Select value={selected} onValueChange={onSelect} disabled={setVoice.isPending}>
-                  <SelectTrigger size="lg" className="flex-1">
-                    <SelectValue placeholder="Select a voice" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {voices.map((v) => (
-                      <SelectItem key={v.id} value={v.id}>
-                        <span className="font-medium">{v.name}</span>
-                        <span className="text-muted-foreground ml-2">{v.desc}</span>
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-                <Button
-                  variant="outline"
+                <Input
                   size="lg"
-                  className="shrink-0 gap-1.5"
-                  disabled={!selected || previewing !== null}
-                  onClick={() => selected && onPreview(selected)}
+                  value={botName}
+                  onChange={(e) => setDraftName(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') onSaveName();
+                  }}
+                  placeholder={defaultBotName}
+                  maxLength={80}
+                  className="flex-1"
+                />
+                <Button
+                  size="lg"
+                  className="shrink-0"
+                  disabled={setBotName.isPending || !nameDirty}
+                  onClick={onSaveName}
                 >
-                  {previewing === selected ? (
-                    <Loader2 className="size-4 animate-spin" />
-                  ) : (
-                    <Play className="size-4" />
-                  )}
-                  Preview
+                  Save
                 </Button>
               </div>
-              {selectedVoice ? (
-                <p className="text-muted-foreground text-xs">
-                  Current: {selectedVoice.name} — {selectedVoice.desc}
-                </p>
-              ) : null}
-            </div>
-          )}
-        </SectionCard>
+            )}
+          </div>
+        </section>
+
+        <section className="space-y-4">
+          <Label>Default voice</Label>
+          <p className="text-muted-foreground -mt-2 text-xs">
+            Used for the bot's spoken replies in calls. Preview a voice before you set it.
+          </p>
+          <div className="bg-popover rounded-md border px-4 py-5">
+            {voicesQuery.isLoading ? (
+              <Skeleton className="h-11 w-full rounded-lg" />
+            ) : voices.length === 0 ? (
+              <p className="text-muted-foreground text-sm">No voices available.</p>
+            ) : !canWrite ? (
+              <p className="text-muted-foreground text-sm">
+                {selectedVoice ? (
+                  <>
+                    <span className="text-foreground font-medium">{selectedVoice.name}</span> —{' '}
+                    {selectedVoice.desc}
+                  </>
+                ) : (
+                  'No voice selected.'
+                )}
+              </p>
+            ) : (
+              <div className="space-y-3">
+                <div className="flex items-center gap-2">
+                  <Select value={selected} onValueChange={onSelect} disabled={setVoice.isPending}>
+                    <SelectTrigger size="lg" className="flex-1">
+                      <SelectValue placeholder="Select a voice" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {voices.map((v) => (
+                        <SelectItem key={v.id} value={v.id}>
+                          <span className="font-medium">{v.name}</span>
+                          <span className="text-muted-foreground ml-2">{v.desc}</span>
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <Button
+                    variant="outline"
+                    size="lg"
+                    className="shrink-0 gap-1.5"
+                    disabled={!selected || previewing !== null}
+                    onClick={() => selected && onPreview(selected)}
+                  >
+                    {previewing === selected ? (
+                      <Loading className="size-4 shrink-0" />
+                    ) : (
+                      <Play className="size-4 shrink-0" />
+                    )}
+                    Preview
+                  </Button>
+                </div>
+                {selectedVoice ? (
+                  <p className="text-muted-foreground text-xs">
+                    Current: {selectedVoice.name} — {selectedVoice.desc}
+                  </p>
+                ) : null}
+              </div>
+            )}
+          </div>
+        </section>
       </div>
     </CustomizeSectionWrapper>
   );

--- a/apps/web/src/features/workspace/customize/sections/view/meet-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/meet-view.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import { Loader2, Play } from 'lucide-react';
+import { Play } from 'lucide-react';
 import { useState } from 'react';
 
 import { Button } from '@/components/ui/button';
 import { InfoBanner } from '@/components/ui/info-banner';
 import { Input } from '@/components/ui/input';
-import { SectionCard } from '@/components/ui/section-card';
+import { Label } from '@/components/ui/label';
+import Loading from '@/components/ui/loading';
 import {
   Select,
   SelectContent,
@@ -92,84 +93,91 @@ export function MeetView({ projectId }: { projectId: string }) {
           </InfoBanner>
         ) : null}
 
-        <SectionCard
-          title="Bot name"
-          description="The display name the notetaker joins under. People wake it in the call by saying its first name."
-        >
-          {voicesQuery.isLoading ? (
-            <Skeleton className="h-10 w-full rounded-lg" />
-          ) : (
-            <div className="flex items-center gap-2">
-              <Input
-                size="lg"
-                value={botName}
-                onChange={(e) => setDraftName(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter') onSaveName();
-                }}
-                placeholder={defaultBotName}
-                maxLength={80}
-                className="flex-1"
-              />
-              <Button
-                size="lg"
-                className="shrink-0"
-                disabled={setBotName.isPending || !nameDirty}
-                onClick={onSaveName}
-              >
-                Save
-              </Button>
-            </div>
-          )}
-        </SectionCard>
-
-        <SectionCard
-          title="Default voice"
-          description="Used for the bot's spoken replies in calls. Preview a voice before you set it."
-        >
-          {voicesQuery.isLoading ? (
-            <Skeleton className="h-11 w-full rounded-lg" />
-          ) : voices.length === 0 ? (
-            <p className="text-muted-foreground text-sm">No voices available.</p>
-          ) : (
-            <div className="space-y-3">
+        <section className="space-y-4">
+          <Label>Bot name</Label>
+          <p className="text-muted-foreground -mt-2 text-xs">
+            The display name the notetaker joins under. People wake it in the call by saying its
+            first name.
+          </p>
+          <div className="bg-popover rounded-md border px-4 py-5">
+            {voicesQuery.isLoading ? (
+              <Skeleton className="h-10 w-full rounded-lg" />
+            ) : (
               <div className="flex items-center gap-2">
-                <Select value={selected} onValueChange={onSelect} disabled={setVoice.isPending}>
-                  <SelectTrigger size="lg" className="flex-1">
-                    <SelectValue placeholder="Select a voice" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {voices.map((v) => (
-                      <SelectItem key={v.id} value={v.id}>
-                        <span className="font-medium">{v.name}</span>
-                        <span className="text-muted-foreground ml-2">{v.desc}</span>
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-                <Button
-                  variant="outline"
+                <Input
                   size="lg"
-                  className="shrink-0 gap-1.5"
-                  disabled={!selected || previewing !== null}
-                  onClick={() => selected && onPreview(selected)}
+                  value={botName}
+                  onChange={(e) => setDraftName(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') onSaveName();
+                  }}
+                  placeholder={defaultBotName}
+                  maxLength={80}
+                  className="flex-1"
+                />
+                <Button
+                  size="lg"
+                  className="shrink-0"
+                  disabled={setBotName.isPending || !nameDirty}
+                  onClick={onSaveName}
                 >
-                  {previewing === selected ? (
-                    <Loader2 className="size-4 animate-spin" />
-                  ) : (
-                    <Play className="size-4" />
-                  )}
-                  Preview
+                  Save
                 </Button>
               </div>
-              {selectedVoice ? (
-                <p className="text-muted-foreground text-xs">
-                  Current: {selectedVoice.name} — {selectedVoice.desc}
-                </p>
-              ) : null}
-            </div>
-          )}
-        </SectionCard>
+            )}
+          </div>
+        </section>
+
+        <section className="space-y-4">
+          <Label>Default voice</Label>
+          <p className="text-muted-foreground -mt-2 text-xs">
+            Used for the bot's spoken replies in calls. Preview a voice before you set it.
+          </p>
+          <div className="bg-popover rounded-md border px-4 py-5">
+            {voicesQuery.isLoading ? (
+              <Skeleton className="h-11 w-full rounded-lg" />
+            ) : voices.length === 0 ? (
+              <p className="text-muted-foreground text-sm">No voices available.</p>
+            ) : (
+              <div className="space-y-3">
+                <div className="flex items-center gap-2">
+                  <Select value={selected} onValueChange={onSelect} disabled={setVoice.isPending}>
+                    <SelectTrigger size="lg" className="flex-1">
+                      <SelectValue placeholder="Select a voice" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {voices.map((v) => (
+                        <SelectItem key={v.id} value={v.id}>
+                          <span className="font-medium">{v.name}</span>
+                          <span className="text-muted-foreground ml-2">{v.desc}</span>
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <Button
+                    variant="outline"
+                    size="lg"
+                    className="shrink-0 gap-1.5"
+                    disabled={!selected || previewing !== null}
+                    onClick={() => selected && onPreview(selected)}
+                  >
+                    {previewing === selected ? (
+                      <Loading className="size-4 shrink-0" />
+                    ) : (
+                      <Play className="size-4 shrink-0" />
+                    )}
+                    Preview
+                  </Button>
+                </div>
+                {selectedVoice ? (
+                  <p className="text-muted-foreground text-xs">
+                    Current: {selectedVoice.name} — {selectedVoice.desc}
+                  </p>
+                ) : null}
+              </div>
+            )}
+          </div>
+        </section>
       </div>
     </CustomizeSectionWrapper>
   );

--- a/apps/web/src/features/workspace/customize/sections/view/members-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/members-view.tsx
@@ -173,7 +173,12 @@ export function MembersView({ projectId }: { projectId: string }) {
         />
       )}
 
-      {project?.account_id && (
+      {/* Resource-access grants and custom-role bindings are manager-only
+          DATA (the grants list and the account policies route both deny
+          non-managers), so the cards hide entirely for viewers who can't
+          read them — an inert husk with an error or empty body is worse
+          than absence. Group access above stays: its list is member-readable. */}
+      {project?.account_id && canManage && (
         <ResourceAccessCard
           projectId={projectId}
           accountId={project.account_id}
@@ -182,7 +187,7 @@ export function MembersView({ projectId }: { projectId: string }) {
         />
       )}
 
-      {project?.account_id && (
+      {project?.account_id && canManage && (
         <ProjectRoleAssignmentsCard
           projectId={projectId}
           accountId={project.account_id}
@@ -2138,6 +2143,10 @@ function ProjectRoleAssignmentsCard({
 
   const policiesQuery = useQuery({
     queryKey: policiesKey,
+    // Gated like every sibling below: the account-IAM policies route asserts
+    // policy.read, which a non-manager doesn't hold — firing it anyway just
+    // 403s for data this card can never show them.
+    enabled: canManage,
     queryFn: () => listPolicies(accountId, { scopeId: projectId }),
     staleTime: 20_000,
   });

--- a/apps/web/src/features/workspace/customize/sections/view/members-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/members-view.tsx
@@ -4,7 +4,7 @@ import { useTranslations } from 'next-intl';
 
 import { errorToast, successToast, warningToast } from '@/components/ui/toast';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { Bot, Check, Clock, CornerDownRight, KeyRound, Loader2, Mail, MessageSquare, Plug, Plus, RefreshCw, Shield, Sparkles, User, Users, X } from 'lucide-react';
+import { Bot, Check, Clock, CornerDownRight, KeyRound, Mail, MessageSquare, Plug, Plus, RefreshCw, Shield, Sparkles, User, Users, X } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { FormEvent, useEffect, useMemo, useState } from 'react';
 
@@ -18,16 +18,6 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import {
-  Dialog,
-  DialogClose,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from '@/components/ui/dialog';
-import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -37,9 +27,16 @@ import { EntityAvatar } from '@/components/ui/entity-avatar';
 import { Field, FieldDescription, FieldError, FieldGroup, FieldLabel } from '@/components/ui/field';
 import { InlineMeta } from '@/components/ui/inline-meta';
 import { InputGroup, InputGroupAddon, InputGroupInput } from '@/components/ui/input-group';
-import { List, ListRow } from '@/components/ui/list';
 import Loading from '@/components/ui/loading';
-import { SectionCard } from '@/components/ui/section-card';
+import {
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalDescription,
+  ModalFooter,
+  ModalHeader,
+  ModalTitle,
+} from '@/components/ui/modal';
 import {
   Select,
   SelectContent,
@@ -1914,187 +1911,208 @@ function ResourceAccessCard({
   const canSubmit = !!pickerType && !!pickerResourceId && !!principalValue && !createMutation.isPending;
 
   return (
-    <SectionCard
-      flush
-      title="Resource access"
-      description="Assign agents to a member or group to control who can USE them. An agent with no assignment is open to everyone with project access; assigning one restricts it to the people or groups you choose — they inherit that agent's declared skills, connectors, and secrets to use in its sessions. This only ever grants USE, never edit: changing the agent, a skill, a connector, or a secret still requires the editor role."
-      count={grants.length}
-      action={
-        canManage && hasResources ? (
-          <Dialog open={dialogOpen} onOpenChange={onDialogOpenChange}>
-            <DialogTrigger asChild>
-              <Button size="sm" variant="outline" className="gap-1.5">
-                <Plus className="h-3.5 w-3.5" />
-                Grant access
-              </Button>
-            </DialogTrigger>
-            <DialogContent className="sm:max-w-md">
-              <DialogHeader>
-                <DialogTitle>Assign an agent</DialogTitle>
-                <DialogDescription>
-                  Assign an agent to a member or group — they inherit everything that agent
-                  uses (its secrets, connectors, and skills) to USE, not edit. Resources reach
-                  people through agents, not by a direct grant; agents you don't assign stay open
-                  to everyone with project access. Editing the agent or any resource it uses still
-                  requires the editor role.
-                </DialogDescription>
-              </DialogHeader>
+    <>
+      <section className="space-y-4">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h3 className="text-sm font-medium">
+              Resource access
+              {grants.length > 0 ? (
+                <span className="text-muted-foreground ml-1.5 font-normal">({grants.length})</span>
+              ) : null}
+            </h3>
+            <p className="text-muted-foreground mt-1 text-xs">
+              Assign agents to a member or group to control who can USE them. An agent with no
+              assignment is open to everyone with project access; assigning one restricts it to
+              the people or groups you choose — they inherit that agent's declared skills,
+              connectors, and secrets to use in its sessions. This only ever grants USE, never
+              edit: changing the agent, a skill, a connector, or a secret still requires the
+              editor role.
+            </p>
+          </div>
 
-              <form
-                id="grant-resource-form"
-                className="space-y-4 py-1"
-                onSubmit={(e) => {
-                  e.preventDefault();
-                  if (!canSubmit) return;
-                  createMutation.mutate();
-                }}
-              >
-                <div className="space-y-1.5">
-                  <span className="text-muted-foreground text-xs font-medium">1. Agent</span>
-                  <Select
-                    value={pickerResourceId}
-                    onValueChange={setPickerResourceId}
-                    disabled={createMutation.isPending}
-                  >
-                    <SelectTrigger className="w-full">
-                      <SelectValue placeholder="Select an agent" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {activeItems.map((r) => (
-                        <SelectItem key={r.id} value={r.id}>
-                          {r.name}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-
-                {selectedAgentDeclares && <BlastRadiusPreview declares={selectedAgentDeclares} />}
-
-                <div className="space-y-1.5">
-                  <span className="text-muted-foreground text-xs font-medium">2. Grant to</span>
-                  <Select
-                    value={principalValue}
-                    onValueChange={setPrincipalValue}
-                    disabled={createMutation.isPending}
-                  >
-                    <SelectTrigger className="w-full">
-                      <SelectValue placeholder="Member or group" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {members.map((m) => (
-                        <SelectItem key={`member:${m.user_id}`} value={`member:${m.user_id}`}>
-                          {userLabel(m)}
-                        </SelectItem>
-                      ))}
-                      {groups.map((g) => (
-                        <SelectItem key={`group:${g.group_id}`} value={`group:${g.group_id}`}>
-                          {g.name} · group
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-              </form>
-
-              <DialogFooter>
-                <DialogClose asChild>
-                  <Button type="button" variant="ghost" size="sm">
-                    Cancel
-                  </Button>
-                </DialogClose>
-                <Button type="submit" form="grant-resource-form" size="sm" disabled={!canSubmit}>
-                  {createMutation.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : 'Grant access'}
-                </Button>
-              </DialogFooter>
-            </DialogContent>
-          </Dialog>
-        ) : null
-      }
-    >
-      {grantsQuery.isLoading && (
-        <div className="px-6 py-5">
-          <Skeleton className="h-8 w-full" />
+          {canManage && hasResources ? (
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              className="shrink-0 gap-1.5"
+              onClick={() => onDialogOpenChange(true)}
+            >
+              <Plus className="size-3.5 shrink-0" />
+              Grant access
+            </Button>
+          ) : null}
         </div>
-      )}
 
-      {!grantsQuery.isLoading && grants.length === 0 && (
-        <div className="text-muted-foreground px-6 py-5 text-xs">
-          {hasResources
-            ? 'Nothing is scoped yet — every agent is open to everyone with project access to use. Grant one above to restrict who can use it. Skills, connectors, and secrets aren’t assigned directly here — they’re governed by the editor role (to edit) and inherited through the agents you assign (to use).'
-            : 'This project has no agents to scope yet. Add one first, then come back here to limit who can use it.'}
-        </div>
-      )}
+        {grantsQuery.isLoading && (
+          <div className="space-y-2">
+            <Skeleton className="h-14 w-full rounded-md" />
+          </div>
+        )}
 
-      {!grantsQuery.isLoading && grants.length > 0 && (
-        <>
-          {grantFilterOptions.length > 2 && (
-            <FilterChips value={resourceFilter} onChange={setResourceFilter} options={grantFilterOptions} />
-          )}
-          <List>
-            {visibleGrants.map((g: ProjectResourceGrant) => {
-              const busy = pendingIds.has(g.grant_id);
-              const displayName = resourceName.get(`${g.resource_type}:${g.resource_id}`) ?? g.resource_id;
-            const ResourceIcon = g.resource_type === 'agent' ? Bot : g.resource_type === 'secret' ? KeyRound : Sparkles;
-            return (
-              <ListRow
-                key={g.grant_id}
-                leading={
-                  <span className="bg-muted/60 flex h-8 w-8 items-center justify-center rounded-full">
-                    <ResourceIcon className="text-muted-foreground h-4 w-4" />
-                  </span>
-                }
-                title={
-                  <span className="flex items-center gap-2">
-                    {displayName}
-                    <Badge variant="outline" size="sm" className="capitalize">
-                      {g.resource_type}
-                    </Badge>
-                    {g.orphaned && (
-                      <Badge
-                        variant="outline"
+        {!grantsQuery.isLoading && grants.length === 0 && (
+          <p className="text-muted-foreground text-xs">
+            {hasResources
+              ? 'Nothing is scoped yet — every agent is open to everyone with project access to use. Grant one above to restrict who can use it. Skills, connectors, and secrets aren’t assigned directly here — they’re governed by the editor role (to edit) and inherited through the agents you assign (to use).'
+              : 'This project has no agents to scope yet. Add one first, then come back here to limit who can use it.'}
+          </p>
+        )}
+
+        {!grantsQuery.isLoading && grants.length > 0 && (
+          <div className="space-y-3">
+            {grantFilterOptions.length > 2 && (
+              <FilterChips value={resourceFilter} onChange={setResourceFilter} options={grantFilterOptions} />
+            )}
+            <ul className="space-y-2">
+              {visibleGrants.map((g: ProjectResourceGrant) => {
+                const busy = pendingIds.has(g.grant_id);
+                const displayName = resourceName.get(`${g.resource_type}:${g.resource_id}`) ?? g.resource_id;
+                const ResourceIcon = g.resource_type === 'agent' ? Bot : g.resource_type === 'secret' ? KeyRound : Sparkles;
+                return (
+                  <li key={g.grant_id} className={MEMBER_ROW}>
+                    <span className="bg-muted/60 flex size-8 shrink-0 items-center justify-center rounded-full">
+                      <ResourceIcon className="text-muted-foreground size-4" />
+                    </span>
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2">
+                        <span className="text-foreground truncate text-sm font-medium">
+                          {displayName}
+                        </span>
+                        <Badge variant="outline" size="sm" className="capitalize">
+                          {g.resource_type}
+                        </Badge>
+                        {g.orphaned && (
+                          <Badge
+                            variant="outline"
+                            size="sm"
+                            className="border-kortix-orange/30 text-kortix-orange"
+                            title={`This ${g.resource_type} no longer exists (renamed or deleted). The grant is inert — the restriction has lapsed. Remove it or re-grant the current ${g.resource_type}.`}
+                          >
+                            renamed / removed
+                          </Badge>
+                        )}
+                      </div>
+                      <span className="text-muted-foreground text-xs">
+                        <InlineMeta>
+                          <span>
+                            {g.principal_type === 'group' ? 'Group' : 'Member'}: {g.principal_label}
+                          </span>
+                          <span>Granted {formatDate(g.created_at)}</span>
+                        </InlineMeta>
+                      </span>
+                    </div>
+                    {busy ? (
+                      <Loading className="text-muted-foreground shrink-0" />
+                    ) : canManage ? (
+                      <Button
+                        type="button"
                         size="sm"
-                        className="border-amber-300 text-amber-700 dark:border-amber-500/40 dark:text-amber-400"
-                        title={`This ${g.resource_type} no longer exists (renamed or deleted). The grant is inert — the restriction has lapsed. Remove it or re-grant the current ${g.resource_type}.`}
+                        variant="ghost"
+                        onClick={() => removeMutation.mutate(g.grant_id)}
                       >
-                        renamed / removed
+                        Remove
+                      </Button>
+                    ) : (
+                      <Badge variant="outline" size="sm" className="capitalize">
+                        {g.principal_type}
                       </Badge>
                     )}
-                  </span>
-                }
-                subtitle={
-                  <InlineMeta>
-                    <span>
-                      {g.principal_type === 'group' ? 'Group' : 'Member'}: {g.principal_label}
-                    </span>
-                    <span>Granted {formatDate(g.created_at)}</span>
-                  </InlineMeta>
-                }
-                trailing={
-                  busy ? (
-                    <Loader2 className="text-muted-foreground h-4 w-4 animate-spin" />
-                  ) : canManage ? (
-                    <Button
-                      type="button"
-                      size="sm"
-                      variant="ghost"
-                      onClick={() => removeMutation.mutate(g.grant_id)}
-                    >
-                      Remove
-                    </Button>
-                  ) : (
-                    <Badge variant="outline" size="sm" className="capitalize">
-                      {g.principal_type}
-                    </Badge>
-                  )
-                }
-              />
-            );
-          })}
-          </List>
-        </>
-      )}
-    </SectionCard>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        )}
+      </section>
+
+      <Modal open={dialogOpen} onOpenChange={onDialogOpenChange}>
+        <ModalContent className="sm:max-w-md">
+          <ModalHeader>
+            <ModalTitle>Assign an agent</ModalTitle>
+            <ModalDescription>
+              Assign an agent to a member or group — they inherit everything that agent
+              uses (its secrets, connectors, and skills) to USE, not edit. Resources reach
+              people through agents, not by a direct grant; agents you don't assign stay open
+              to everyone with project access. Editing the agent or any resource it uses still
+              requires the editor role.
+            </ModalDescription>
+          </ModalHeader>
+
+          <form
+            onSubmit={(e) => {
+              e.preventDefault();
+              if (!canSubmit) return;
+              createMutation.mutate();
+            }}
+          >
+            <ModalBody className="space-y-4">
+              <div className="space-y-1.5">
+                <span className="text-muted-foreground text-xs font-medium">1. Agent</span>
+                <Select
+                  value={pickerResourceId}
+                  onValueChange={setPickerResourceId}
+                  disabled={createMutation.isPending}
+                >
+                  <SelectTrigger className="w-full">
+                    <SelectValue placeholder="Select an agent" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {activeItems.map((r) => (
+                      <SelectItem key={r.id} value={r.id}>
+                        {r.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              {selectedAgentDeclares && <BlastRadiusPreview declares={selectedAgentDeclares} />}
+
+              <div className="space-y-1.5">
+                <span className="text-muted-foreground text-xs font-medium">2. Grant to</span>
+                <Select
+                  value={principalValue}
+                  onValueChange={setPrincipalValue}
+                  disabled={createMutation.isPending}
+                >
+                  <SelectTrigger className="w-full">
+                    <SelectValue placeholder="Member or group" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {members.map((m) => (
+                      <SelectItem key={`member:${m.user_id}`} value={`member:${m.user_id}`}>
+                        {userLabel(m)}
+                      </SelectItem>
+                    ))}
+                    {groups.map((g) => (
+                      <SelectItem key={`group:${g.group_id}`} value={`group:${g.group_id}`}>
+                        {g.name} · group
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </ModalBody>
+
+            <ModalFooter className="sm:justify-between">
+              <Button
+                type="button"
+                variant="outline-ghost"
+                size="sm"
+                onClick={() => onDialogOpenChange(false)}
+              >
+                Cancel
+              </Button>
+              <Button type="submit" size="sm" disabled={!canSubmit}>
+                {createMutation.isPending ? <Loading className="size-4 shrink-0" /> : null}
+                Grant access
+              </Button>
+            </ModalFooter>
+          </form>
+        </ModalContent>
+      </Modal>
+    </>
   );
 }
 
@@ -2290,194 +2308,211 @@ function ProjectRoleAssignmentsCard({
   const canSubmit = !!subjectType && !!subjectId && !!roleId && !createMutation.isPending;
 
   return (
-    <SectionCard
-      flush
-      title="Custom roles"
-      description="Grant a custom role to a member, group, or agent on this project. Custom roles are defined on the account Roles page; here you bind them for this project only."
-      count={policies.length}
-      action={
-        canManage && customRoles.length > 0 ? (
-          <Dialog open={dialogOpen} onOpenChange={onDialogOpenChange}>
-            <DialogTrigger asChild>
-              <Button size="sm" variant="outline" className="gap-1.5">
-                <Plus className="h-3.5 w-3.5" />
+    <>
+      <section className="space-y-4">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h3 className="text-sm font-medium">
+              Custom roles
+              {policies.length > 0 ? (
+                <span className="text-muted-foreground ml-1.5 font-normal">({policies.length})</span>
+              ) : null}
+            </h3>
+            <p className="text-muted-foreground mt-1 text-xs">
+              Grant a custom role to a member, group, or agent on this project. Custom roles are
+              defined on the account Roles page; here you bind them for this project only.
+            </p>
+          </div>
+
+          {canManage && customRoles.length > 0 ? (
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              className="shrink-0 gap-1.5"
+              onClick={() => onDialogOpenChange(true)}
+            >
+              <Plus className="size-3.5 shrink-0" />
+              Assign role
+            </Button>
+          ) : null}
+        </div>
+
+        {policiesQuery.isLoading && (
+          <div className="space-y-2">
+            <Skeleton className="h-14 w-full rounded-md" />
+          </div>
+        )}
+
+        {!policiesQuery.isLoading && policies.length === 0 && (
+          <p className="text-muted-foreground text-xs">
+            {customRoles.length === 0 ? (
+              <>
+                No custom roles exist yet. Create one on the{' '}
+                <a href={`/accounts/${accountId}?tab=roles`} className="underline">
+                  account Roles page
+                </a>
+                , then bind it here for this project.
+              </>
+            ) : (
+              'No custom-role assignments on this project yet. Bind one above to grant a member, group, or agent a custom role here.'
+            )}
+          </p>
+        )}
+
+        {!policiesQuery.isLoading && policies.length > 0 && (
+          <div className="space-y-3">
+            {policyFilterOptions.length > 2 && (
+              <FilterChips value={policyFilter} onChange={setPolicyFilter} options={policyFilterOptions} />
+            )}
+            <ul className="space-y-2">
+              {visiblePolicies.map((p) => {
+                const busy = pendingIds.has(p.policy_id);
+                const { kind, label, missing } = principalLabel(p);
+                return (
+                  <li key={p.policy_id} className={MEMBER_ROW}>
+                    <span className="bg-muted/60 flex size-8 shrink-0 items-center justify-center rounded-full">
+                      <Shield className="text-muted-foreground size-4" />
+                    </span>
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2">
+                        <span className="text-foreground truncate text-sm font-medium">
+                          {roleNameById.get(p.role_id) ?? p.role_id}
+                        </span>
+                        <Badge variant="outline" size="sm">
+                          Custom
+                        </Badge>
+                      </div>
+                      <span className="text-muted-foreground text-xs">
+                        <InlineMeta>
+                          <span className="flex items-center gap-1.5">
+                            {kind}: {label}
+                            {missing && (
+                              <Badge
+                                variant="outline"
+                                size="sm"
+                                className="border-kortix-orange/30 text-kortix-orange"
+                                title="This agent no longer exists (deleted or renamed). The binding is stale — remove it or re-assign the current agent."
+                              >
+                                removed
+                              </Badge>
+                            )}
+                          </span>
+                          {p.expires_at ? <span>Expires {formatDate(p.expires_at)}</span> : null}
+                        </InlineMeta>
+                      </span>
+                    </div>
+                    {busy ? (
+                      <Loading className="text-muted-foreground shrink-0" />
+                    ) : canManage ? (
+                      <Button type="button" size="sm" variant="ghost" onClick={() => removeMutation.mutate(p.policy_id)}>
+                        Remove
+                      </Button>
+                    ) : (
+                      <Badge variant="outline" size="sm" className="capitalize">
+                        {kind}
+                      </Badge>
+                    )}
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        )}
+      </section>
+
+      <Modal open={dialogOpen} onOpenChange={onDialogOpenChange}>
+        <ModalContent className="sm:max-w-md">
+          <ModalHeader>
+            <ModalTitle>Assign a custom role</ModalTitle>
+            <ModalDescription>
+              Bind a custom role to a member, group, or agent on this project only.
+            </ModalDescription>
+          </ModalHeader>
+
+          <form
+            onSubmit={(e) => {
+              e.preventDefault();
+              if (!canSubmit) return;
+              createMutation.mutate();
+            }}
+          >
+            <ModalBody className="space-y-4">
+              <div className="space-y-1.5">
+                <span className="text-muted-foreground text-xs font-medium">1. Assign to</span>
+                <div className="flex gap-1.5">
+                  {subjectOptions.map(({ type, label, Icon }) => (
+                    <Button
+                      key={type}
+                      type="button"
+                      size="sm"
+                      variant={subjectType === type ? 'default' : 'outline'}
+                      className="flex-1 gap-1.5"
+                      onClick={() => onSubjectTypeChange(type)}
+                    >
+                      <Icon className="size-3.5 shrink-0" />
+                      {label}
+                    </Button>
+                  ))}
+                </div>
+              </div>
+
+              <div className="space-y-1.5">
+                <span className="text-muted-foreground text-xs font-medium">
+                  2. {subjectType === 'group' ? 'Group' : subjectType === 'token' ? 'Agent' : 'Member'}
+                </span>
+                <Select
+                  value={subjectId}
+                  onValueChange={setSubjectId}
+                  disabled={!subjectType || createMutation.isPending}
+                >
+                  <SelectTrigger className="w-full">
+                    <SelectValue placeholder={subjectType ? 'Select one' : 'Pick a type first'} />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {activeSubjects.map((s) => (
+                      <SelectItem key={s.id} value={s.id}>
+                        {s.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="space-y-1.5">
+                <span className="text-muted-foreground text-xs font-medium">3. Custom role</span>
+                <Select value={roleId} onValueChange={setRoleId} disabled={createMutation.isPending}>
+                  <SelectTrigger className="w-full">
+                    <SelectValue placeholder="Select a role" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {customRoles.map((r) => (
+                      <SelectItem key={r.role_id} value={r.role_id}>
+                        {r.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </ModalBody>
+
+            <ModalFooter className="sm:justify-between">
+              <Button
+                type="button"
+                variant="outline-ghost"
+                size="sm"
+                onClick={() => onDialogOpenChange(false)}
+              >
+                Cancel
+              </Button>
+              <Button type="submit" size="sm" disabled={!canSubmit}>
+                {createMutation.isPending ? <Loading className="size-4 shrink-0" /> : null}
                 Assign role
               </Button>
-            </DialogTrigger>
-            <DialogContent className="sm:max-w-md">
-              <DialogHeader>
-                <DialogTitle>Assign a custom role</DialogTitle>
-                <DialogDescription>
-                  Bind a custom role to a member, group, or agent on this project only.
-                </DialogDescription>
-              </DialogHeader>
-
-              <form
-                id="assign-role-form"
-                className="space-y-4 py-1"
-                onSubmit={(e) => {
-                  e.preventDefault();
-                  if (!canSubmit) return;
-                  createMutation.mutate();
-                }}
-              >
-                <div className="space-y-1.5">
-                  <span className="text-muted-foreground text-xs font-medium">1. Assign to</span>
-                  <div className="flex gap-1.5">
-                    {subjectOptions.map(({ type, label, Icon }) => (
-                      <Button
-                        key={type}
-                        type="button"
-                        size="sm"
-                        variant={subjectType === type ? 'default' : 'outline'}
-                        className="flex-1 gap-1.5"
-                        onClick={() => onSubjectTypeChange(type)}
-                      >
-                        <Icon className="h-3.5 w-3.5" />
-                        {label}
-                      </Button>
-                    ))}
-                  </div>
-                </div>
-
-                <div className="space-y-1.5">
-                  <span className="text-muted-foreground text-xs font-medium">
-                    2. {subjectType === 'group' ? 'Group' : subjectType === 'token' ? 'Agent' : 'Member'}
-                  </span>
-                  <Select
-                    value={subjectId}
-                    onValueChange={setSubjectId}
-                    disabled={!subjectType || createMutation.isPending}
-                  >
-                    <SelectTrigger className="w-full">
-                      <SelectValue placeholder={subjectType ? 'Select one' : 'Pick a type first'} />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {activeSubjects.map((s) => (
-                        <SelectItem key={s.id} value={s.id}>
-                          {s.name}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-
-                <div className="space-y-1.5">
-                  <span className="text-muted-foreground text-xs font-medium">3. Custom role</span>
-                  <Select value={roleId} onValueChange={setRoleId} disabled={createMutation.isPending}>
-                    <SelectTrigger className="w-full">
-                      <SelectValue placeholder="Select a role" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {customRoles.map((r) => (
-                        <SelectItem key={r.role_id} value={r.role_id}>
-                          {r.name}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-              </form>
-
-              <DialogFooter>
-                <DialogClose asChild>
-                  <Button type="button" variant="ghost" size="sm">
-                    Cancel
-                  </Button>
-                </DialogClose>
-                <Button type="submit" form="assign-role-form" size="sm" disabled={!canSubmit}>
-                  {createMutation.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : 'Assign role'}
-                </Button>
-              </DialogFooter>
-            </DialogContent>
-          </Dialog>
-        ) : null
-      }
-    >
-      {policiesQuery.isLoading && (
-        <div className="px-6 py-5">
-          <Skeleton className="h-8 w-full" />
-        </div>
-      )}
-
-      {!policiesQuery.isLoading && policies.length === 0 && (
-        <div className="text-muted-foreground px-6 py-5 text-xs">
-          {customRoles.length === 0 ? (
-            <>
-              No custom roles exist yet. Create one on the{' '}
-              <a href={`/accounts/${accountId}?tab=roles`} className="underline">
-                account Roles page
-              </a>
-              , then bind it here for this project.
-            </>
-          ) : (
-            'No custom-role assignments on this project yet. Bind one above to grant a member, group, or agent a custom role here.'
-          )}
-        </div>
-      )}
-
-      {!policiesQuery.isLoading && policies.length > 0 && (
-        <>
-          {policyFilterOptions.length > 2 && (
-            <FilterChips value={policyFilter} onChange={setPolicyFilter} options={policyFilterOptions} />
-          )}
-          <List>
-            {visiblePolicies.map((p) => {
-            const busy = pendingIds.has(p.policy_id);
-            const { kind, label, missing } = principalLabel(p);
-            return (
-              <ListRow
-                key={p.policy_id}
-                leading={
-                  <span className="bg-muted/60 flex h-8 w-8 items-center justify-center rounded-full">
-                    <Shield className="text-muted-foreground h-4 w-4" />
-                  </span>
-                }
-                title={
-                  <span className="flex items-center gap-2">
-                    {roleNameById.get(p.role_id) ?? p.role_id}
-                    <Badge variant="outline" size="sm">
-                      Custom
-                    </Badge>
-                  </span>
-                }
-                subtitle={
-                  <InlineMeta>
-                    <span className="flex items-center gap-1.5">
-                      {kind}: {label}
-                      {missing && (
-                        <Badge
-                          variant="outline"
-                          size="sm"
-                          className="border-amber-300 text-amber-700 dark:border-amber-500/40 dark:text-amber-400"
-                          title="This agent no longer exists (deleted or renamed). The binding is stale — remove it or re-assign the current agent."
-                        >
-                          removed
-                        </Badge>
-                      )}
-                    </span>
-                    {p.expires_at ? <span>Expires {formatDate(p.expires_at)}</span> : null}
-                  </InlineMeta>
-                }
-                trailing={
-                  busy ? (
-                    <Loader2 className="text-muted-foreground h-4 w-4 animate-spin" />
-                  ) : canManage ? (
-                    <Button type="button" size="sm" variant="ghost" onClick={() => removeMutation.mutate(p.policy_id)}>
-                      Remove
-                    </Button>
-                  ) : (
-                    <Badge variant="outline" size="sm" className="capitalize">
-                      {kind}
-                    </Badge>
-                  )
-                }
-              />
-            );
-          })}
-          </List>
-        </>
-      )}
-    </SectionCard>
+            </ModalFooter>
+          </form>
+        </ModalContent>
+      </Modal>
+    </>
   );
 }

--- a/apps/web/src/features/workspace/customize/sections/view/review-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/review-view.tsx
@@ -2,6 +2,8 @@
 
 import { ProjectFilesProvider } from '@/features/project-files';
 import { ReviewCenterConnected } from '@/features/review-center/review-center-connected';
+import { PROJECT_ACTIONS } from '@/lib/project-actions';
+import { useProjectCan } from '@/lib/use-project-can';
 import { getProject } from '@kortix/sdk/projects-client';
 import { useQuery } from '@tanstack/react-query';
 
@@ -17,11 +19,17 @@ export function ReviewView({ projectId }: { projectId: string }) {
     staleTime: 60_000,
   });
   const projectName = projectQuery.data?.name ?? '';
+  // Acting on a review item (approve/reject/request-changes, and the bulk act)
+  // asserts project.review.act server-side. A read-only role (review.read only)
+  // still SEES the inbox — ReviewCenterConnected withholds the act handlers so the
+  // ReviewCenter's mutation UI disables itself. Fails safe: false until resolved.
+  const canActReview =
+    useProjectCan(projectId, PROJECT_ACTIONS.PROJECT_REVIEW_ACT).allowed === true;
 
   return (
     <div className="bg-background flex h-full min-h-0 flex-col">
       <ProjectFilesProvider value={{ projectId, ref: '', defaultBranch: '' }}>
-        <ReviewCenterConnected projectName={projectName} />
+        <ReviewCenterConnected projectName={projectName} canAct={canActReview} />
       </ProjectFilesProvider>
     </div>
   );

--- a/apps/web/src/features/workspace/customize/sections/view/sandbox-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/sandbox-view.tsx
@@ -3,6 +3,7 @@
 import { SandboxTemplateForm } from '@/components/projects/sandbox-template-form';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import {
   Disclosure,
   DisclosureBody,
@@ -347,6 +348,7 @@ function TemplateRow({
   const tI18nHardcoded = useTranslations('hardcodedUi');
   const queryClient = useQueryClient();
   const { version: manifestVersion } = useProjectManifestVersion(projectId);
+  const [confirmDelete, setConfirmDelete] = useState(false);
   const buildMut = useMutation({
     mutationFn: () => buildSandboxTemplate(projectId, template.template_id!),
     onSuccess: () => {
@@ -361,6 +363,7 @@ function TemplateRow({
       successToast(`Deleted "${template.name}"`);
       queryClient.invalidateQueries({ queryKey: SNAPSHOTS_QUERY_KEY(projectId) });
       queryClient.invalidateQueries({ queryKey: ['project-sandboxes', projectId] });
+      setConfirmDelete(false);
     },
     onError: (err: Error) => errorToast(err.message || 'Failed to delete template'),
   });
@@ -391,97 +394,105 @@ function TemplateRow({
           : AlarmClockSolid;
 
   return (
-    <li className="bg-popover flex flex-wrap items-center gap-4 overflow-hidden px-4 py-3 text-sm">
-      <div
-        className={cn(
-          'inline-flex size-11 shrink-0 items-center justify-center rounded-sm border',
-          DAYTONA_TONE_ICON_TILE[stateInfo.tone],
-        )}
-      >
-        <Icon className="size-6 shrink-0" />
-      </div>
-      <div className="min-w-0 flex-1 space-y-0.5">
-        <div className="flex items-center gap-2">
-          <span className="font-medium">{template.name}</span>
-          <Badge variant="secondary" size="sm">
-            {template.slug}
-          </Badge>
-          <span className="text-muted-foreground/70 text-[10px] tracking-wide uppercase">
-            {sourceTag}
-          </span>
+    <>
+      <li className="bg-popover flex flex-wrap items-center gap-4 overflow-hidden px-4 py-3 text-sm">
+        <div
+          className={cn(
+            'inline-flex size-11 shrink-0 items-center justify-center rounded-sm border',
+            DAYTONA_TONE_ICON_TILE[stateInfo.tone],
+          )}
+        >
+          <Icon className="size-6 shrink-0" />
         </div>
-        <div className="text-muted-foreground gap-1 truncate text-[13px]">
-          {sub} &bull; {template.cpu} &bull;{' '}
-          {tI18nHardcoded.raw('autoComponentsProjectsSandboxSnapshotCardJsxTextVCPU15535b27')}
-          &bull; {template.memory_gb}{' '}
-          {tI18nHardcoded.raw('autoComponentsProjectsSandboxSnapshotCardJsxTextGiB9d1e488f')}
-          &bull; {template.disk_gb}{' '}
-          {tI18nHardcoded.raw('autoComponentsProjectsSandboxSnapshotCardJsxTextGiBDiskd395296d')}
+        <div className="min-w-0 flex-1 space-y-0.5">
+          <div className="flex items-center gap-2">
+            <span className="font-medium">{template.name}</span>
+            <Badge variant="secondary" size="sm">
+              {template.slug}
+            </Badge>
+            <span className="text-muted-foreground/70 text-[10px] tracking-wide uppercase">
+              {sourceTag}
+            </span>
+          </div>
+          <div className="text-muted-foreground gap-1 truncate text-[13px]">
+            {sub} &bull; {template.cpu} &bull;{' '}
+            {tI18nHardcoded.raw('autoComponentsProjectsSandboxSnapshotCardJsxTextVCPU15535b27')}
+            &bull; {template.memory_gb}{' '}
+            {tI18nHardcoded.raw('autoComponentsProjectsSandboxSnapshotCardJsxTextGiB9d1e488f')}
+            &bull; {template.disk_gb}{' '}
+            {tI18nHardcoded.raw('autoComponentsProjectsSandboxSnapshotCardJsxTextGiBDiskd395296d')}
+          </div>
         </div>
-      </div>
-      <Badge
-        variant={stateBadge.variant}
-        color={'color' in stateBadge ? stateBadge.color : undefined}
-      >
-        <StateIcon className="size-4 shrink-0" />
-        {stateInfo.label}
-      </Badge>
-      {canManage && (
-        <div className="flex items-center gap-1">
-          {template.template_id && !template.is_default && (
-            <>
+        <Badge
+          variant={stateBadge.variant}
+          color={'color' in stateBadge ? stateBadge.color : undefined}
+        >
+          <StateIcon className="size-4 shrink-0" />
+          {stateInfo.label}
+        </Badge>
+        {canManage && (
+          <div className="flex items-center gap-1">
+            {template.template_id && !template.is_default && (
+              <>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="size-7 p-0"
+                  onClick={() => onEdit(template)}
+                  aria-label={tI18nHardcoded.raw(
+                    'autoComponentsProjectsSandboxSnapshotCardJsxAttrAriaLabelEditdc9d24c2',
+                  )}
+                >
+                  <Edit3 className="size-3.5" />
+                </Button>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="text-destructive hover:text-destructive size-7 p-0"
+                  disabled={deleteMut.isPending}
+                  onClick={() => setConfirmDelete(true)}
+                  aria-label={tI18nHardcoded.raw(
+                    'autoComponentsProjectsSandboxSnapshotCardJsxAttrAriaLabelDeleteda0507cf',
+                  )}
+                >
+                  {deleteMut.isPending ? (
+                    <Loading className="size-3.5 shrink-0" />
+                  ) : (
+                    <Trash2 className="size-3.5 shrink-0" />
+                  )}
+                </Button>
+              </>
+            )}
+            {template.template_id && (
               <Button
                 size="sm"
-                variant="ghost"
-                className="size-7 p-0"
-                onClick={() => onEdit(template)}
-                aria-label={tI18nHardcoded.raw(
-                  'autoComponentsProjectsSandboxSnapshotCardJsxAttrAriaLabelEditdc9d24c2',
-                )}
+                variant="outline"
+                className="gap-1.5"
+                disabled={buildMut.isPending}
+                onClick={() => buildMut.mutate()}
               >
-                <Edit3 className="size-3.5" />
-              </Button>
-              <Button
-                size="sm"
-                variant="ghost"
-                className="text-destructive hover:text-destructive size-7 p-0"
-                disabled={deleteMut.isPending}
-                onClick={() => {
-                  if (window.confirm(`Delete sandbox template "${template.name}"?`)) {
-                    deleteMut.mutate();
-                  }
-                }}
-                aria-label={tI18nHardcoded.raw(
-                  'autoComponentsProjectsSandboxSnapshotCardJsxAttrAriaLabelDeleteda0507cf',
-                )}
-              >
-                {deleteMut.isPending ? (
+                {buildMut.isPending ? (
                   <Loading className="size-3.5 shrink-0" />
                 ) : (
-                  <Trash2 className="size-3.5 shrink-0" />
+                  <RefreshCw className="size-3.5 shrink-0" />
                 )}
+                Rebuild
               </Button>
-            </>
-          )}
-          {template.template_id && (
-            <Button
-              size="sm"
-              variant="outline"
-              className="gap-1.5"
-              disabled={buildMut.isPending}
-              onClick={() => buildMut.mutate()}
-            >
-              {buildMut.isPending ? (
-                <Loading className="size-3.5 shrink-0" />
-              ) : (
-                <RefreshCw className="size-3.5 shrink-0" />
-              )}
-              Rebuild
-            </Button>
-          )}
-        </div>
-      )}
-    </li>
+            )}
+          </div>
+        )}
+      </li>
+      <ConfirmDialog
+        open={confirmDelete}
+        onOpenChange={setConfirmDelete}
+        title={`Delete sandbox template "${template.name}"?`}
+        description="This removes the template from the project. Sessions already using it are unaffected."
+        confirmLabel="Delete"
+        confirmVariant="destructive"
+        isPending={deleteMut.isPending}
+        onConfirm={() => deleteMut.mutate()}
+      />
+    </>
   );
 }
 

--- a/apps/web/src/features/workspace/customize/sections/view/sandbox-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/sandbox-view.tsx
@@ -56,6 +56,7 @@ import { useState, type ReactNode } from 'react';
 const SNAPSHOTS_QUERY_KEY = (projectId: string) => ['project-snapshots', projectId];
 
 const CATEGORY_LABEL: Record<SnapshotErrorCategory, string> = {
+  quota: 'Snapshot quota reached',
   dockerfile: 'Dockerfile build failed',
   git: 'Repository access failed',
   tunnel: 'Sandbox callback unreachable',

--- a/apps/web/src/features/workspace/customize/sections/view/sandbox-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/sandbox-view.tsx
@@ -14,6 +14,7 @@ import { InlineMeta } from '@/components/ui/inline-meta';
 import { Label } from '@/components/ui/label';
 import Loading from '@/components/ui/loading';
 import { Skeleton } from '@/components/ui/skeleton';
+import { errorToast, successToast } from '@/components/ui/toast';
 import { Icon } from '@/features/icon/icon';
 import { EmptyState } from '@/features/layout/section/empty-state';
 import { ErrorState } from '@/features/layout/section/error-state';
@@ -30,7 +31,6 @@ import {
   type SandboxTemplate,
   type SnapshotErrorCategory,
 } from '@kortix/sdk/projects-client';
-import { toast } from '@/lib/toast';
 import { cn } from '@/lib/utils';
 import {
   AlarmClockSolid,
@@ -44,7 +44,6 @@ import {
   Container,
   Edit3,
   FileCode,
-  Loader2,
   Package,
   Plus,
   RefreshCw,
@@ -83,7 +82,6 @@ const BUILD_STATUS_TILE: Record<
     tileBg: string;
     iconColor: string;
     Icon: typeof CheckCircleSolid;
-    spin?: boolean;
   }
 > = {
   ready: {
@@ -99,7 +97,6 @@ const BUILD_STATUS_TILE: Record<
     tileBg: 'bg-kortix-yellow/15',
     iconColor: 'text-kortix-yellow',
     Icon: Loading,
-    spin: true,
   },
   failed: {
     label: 'failed',
@@ -166,7 +163,7 @@ function BuildRow({ build }: { build: ProjectSnapshotBuild }) {
       <span
         className={cn('flex size-9 shrink-0 items-center justify-center rounded-sm', status.tileBg)}
       >
-        <Icon className={cn('size-5', status.iconColor, status.spin && 'animate-spin')} />
+        <Icon className={cn('size-5 shrink-0', status.iconColor)} />
       </span>
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-1.5">
@@ -298,7 +295,7 @@ function LatestFailureBanner({
                     onClick={onFix}
                   >
                     {isFixPending ? (
-                      <Loading className="size-3.5 shrink-0 animate-spin" />
+                      <Loading className="size-3.5 shrink-0" />
                     ) : (
                       <SparklesSolid className="size-3.5 shrink-0" />
                     )}
@@ -353,19 +350,19 @@ function TemplateRow({
   const buildMut = useMutation({
     mutationFn: () => buildSandboxTemplate(projectId, template.template_id!),
     onSuccess: () => {
-      toast.success(`Rebuild started for "${template.name}"`);
+      successToast(`Rebuild started for "${template.name}"`);
       queryClient.invalidateQueries({ queryKey: SNAPSHOTS_QUERY_KEY(projectId) });
     },
-    onError: (err: Error) => toast.error(err.message || 'Failed to start build'),
+    onError: (err: Error) => errorToast(err.message || 'Failed to start build'),
   });
   const deleteMut = useMutation({
     mutationFn: () => deleteSandboxTemplate(projectId, template.template_id!),
     onSuccess: () => {
-      toast.success(`Deleted "${template.name}"`);
+      successToast(`Deleted "${template.name}"`);
       queryClient.invalidateQueries({ queryKey: SNAPSHOTS_QUERY_KEY(projectId) });
       queryClient.invalidateQueries({ queryKey: ['project-sandboxes', projectId] });
     },
-    onError: (err: Error) => toast.error(err.message || 'Failed to delete template'),
+    onError: (err: Error) => errorToast(err.message || 'Failed to delete template'),
   });
 
   const Icon = template.is_default ? Container : template.has_image ? Package : FileCode;
@@ -426,7 +423,7 @@ function TemplateRow({
         variant={stateBadge.variant}
         color={'color' in stateBadge ? stateBadge.color : undefined}
       >
-        <StateIcon className={cn(stateInfo.tone === 'busy' && 'animate-spin', 'size-4')} />
+        <StateIcon className="size-4 shrink-0" />
         {stateInfo.label}
       </Badge>
       {canManage && (
@@ -459,9 +456,9 @@ function TemplateRow({
                 )}
               >
                 {deleteMut.isPending ? (
-                  <Loader2 className="size-3.5 animate-spin" />
+                  <Loading className="size-3.5 shrink-0" />
                 ) : (
-                  <Trash2 className="size-3.5" />
+                  <Trash2 className="size-3.5 shrink-0" />
                 )}
               </Button>
             </>
@@ -475,9 +472,9 @@ function TemplateRow({
               onClick={() => buildMut.mutate()}
             >
               {buildMut.isPending ? (
-                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                <Loading className="size-3.5 shrink-0" />
               ) : (
-                <RefreshCw className="h-3.5 w-3.5" />
+                <RefreshCw className="size-3.5 shrink-0" />
               )}
               Rebuild
             </Button>

--- a/apps/web/src/features/workspace/customize/sections/view/sandbox-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/sandbox-view.tsx
@@ -3,6 +3,7 @@
 import { SandboxTemplateForm } from '@/components/projects/sandbox-template-form';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import {
   Disclosure,
   DisclosureBody,
@@ -14,6 +15,7 @@ import { InlineMeta } from '@/components/ui/inline-meta';
 import { Label } from '@/components/ui/label';
 import Loading from '@/components/ui/loading';
 import { Skeleton } from '@/components/ui/skeleton';
+import { errorToast, successToast } from '@/components/ui/toast';
 import { Icon } from '@/features/icon/icon';
 import { EmptyState } from '@/features/layout/section/empty-state';
 import { ErrorState } from '@/features/layout/section/error-state';
@@ -30,7 +32,6 @@ import {
   type SandboxTemplate,
   type SnapshotErrorCategory,
 } from '@kortix/sdk/projects-client';
-import { toast } from '@/lib/toast';
 import { cn } from '@/lib/utils';
 import {
   AlarmClockSolid,
@@ -44,7 +45,6 @@ import {
   Container,
   Edit3,
   FileCode,
-  Loader2,
   Package,
   Plus,
   RefreshCw,
@@ -83,7 +83,6 @@ const BUILD_STATUS_TILE: Record<
     tileBg: string;
     iconColor: string;
     Icon: typeof CheckCircleSolid;
-    spin?: boolean;
   }
 > = {
   ready: {
@@ -99,7 +98,6 @@ const BUILD_STATUS_TILE: Record<
     tileBg: 'bg-kortix-yellow/15',
     iconColor: 'text-kortix-yellow',
     Icon: Loading,
-    spin: true,
   },
   failed: {
     label: 'failed',
@@ -166,7 +164,7 @@ function BuildRow({ build }: { build: ProjectSnapshotBuild }) {
       <span
         className={cn('flex size-9 shrink-0 items-center justify-center rounded-sm', status.tileBg)}
       >
-        <Icon className={cn('size-5', status.iconColor, status.spin && 'animate-spin')} />
+        <Icon className={cn('size-5 shrink-0', status.iconColor)} />
       </span>
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-1.5">
@@ -298,7 +296,7 @@ function LatestFailureBanner({
                     onClick={onFix}
                   >
                     {isFixPending ? (
-                      <Loading className="size-3.5 shrink-0 animate-spin" />
+                      <Loading className="size-3.5 shrink-0" />
                     ) : (
                       <SparklesSolid className="size-3.5 shrink-0" />
                     )}
@@ -350,22 +348,24 @@ function TemplateRow({
   const tI18nHardcoded = useTranslations('hardcodedUi');
   const queryClient = useQueryClient();
   const { version: manifestVersion } = useProjectManifestVersion(projectId);
+  const [confirmDelete, setConfirmDelete] = useState(false);
   const buildMut = useMutation({
     mutationFn: () => buildSandboxTemplate(projectId, template.template_id!),
     onSuccess: () => {
-      toast.success(`Rebuild started for "${template.name}"`);
+      successToast(`Rebuild started for "${template.name}"`);
       queryClient.invalidateQueries({ queryKey: SNAPSHOTS_QUERY_KEY(projectId) });
     },
-    onError: (err: Error) => toast.error(err.message || 'Failed to start build'),
+    onError: (err: Error) => errorToast(err.message || 'Failed to start build'),
   });
   const deleteMut = useMutation({
     mutationFn: () => deleteSandboxTemplate(projectId, template.template_id!),
     onSuccess: () => {
-      toast.success(`Deleted "${template.name}"`);
+      successToast(`Deleted "${template.name}"`);
       queryClient.invalidateQueries({ queryKey: SNAPSHOTS_QUERY_KEY(projectId) });
       queryClient.invalidateQueries({ queryKey: ['project-sandboxes', projectId] });
+      setConfirmDelete(false);
     },
-    onError: (err: Error) => toast.error(err.message || 'Failed to delete template'),
+    onError: (err: Error) => errorToast(err.message || 'Failed to delete template'),
   });
 
   const Icon = template.is_default ? Container : template.has_image ? Package : FileCode;
@@ -394,97 +394,105 @@ function TemplateRow({
           : AlarmClockSolid;
 
   return (
-    <li className="bg-popover flex flex-wrap items-center gap-4 overflow-hidden px-4 py-3 text-sm">
-      <div
-        className={cn(
-          'inline-flex size-11 shrink-0 items-center justify-center rounded-sm border',
-          DAYTONA_TONE_ICON_TILE[stateInfo.tone],
-        )}
-      >
-        <Icon className="size-6 shrink-0" />
-      </div>
-      <div className="min-w-0 flex-1 space-y-0.5">
-        <div className="flex items-center gap-2">
-          <span className="font-medium">{template.name}</span>
-          <Badge variant="secondary" size="sm">
-            {template.slug}
-          </Badge>
-          <span className="text-muted-foreground/70 text-[10px] tracking-wide uppercase">
-            {sourceTag}
-          </span>
+    <>
+      <li className="bg-popover flex flex-wrap items-center gap-4 overflow-hidden px-4 py-3 text-sm">
+        <div
+          className={cn(
+            'inline-flex size-11 shrink-0 items-center justify-center rounded-sm border',
+            DAYTONA_TONE_ICON_TILE[stateInfo.tone],
+          )}
+        >
+          <Icon className="size-6 shrink-0" />
         </div>
-        <div className="text-muted-foreground gap-1 truncate text-[13px]">
-          {sub} &bull; {template.cpu} &bull;{' '}
-          {tI18nHardcoded.raw('autoComponentsProjectsSandboxSnapshotCardJsxTextVCPU15535b27')}
-          &bull; {template.memory_gb}{' '}
-          {tI18nHardcoded.raw('autoComponentsProjectsSandboxSnapshotCardJsxTextGiB9d1e488f')}
-          &bull; {template.disk_gb}{' '}
-          {tI18nHardcoded.raw('autoComponentsProjectsSandboxSnapshotCardJsxTextGiBDiskd395296d')}
+        <div className="min-w-0 flex-1 space-y-0.5">
+          <div className="flex items-center gap-2">
+            <span className="font-medium">{template.name}</span>
+            <Badge variant="secondary" size="sm">
+              {template.slug}
+            </Badge>
+            <span className="text-muted-foreground/70 text-[10px] tracking-wide uppercase">
+              {sourceTag}
+            </span>
+          </div>
+          <div className="text-muted-foreground gap-1 truncate text-[13px]">
+            {sub} &bull; {template.cpu} &bull;{' '}
+            {tI18nHardcoded.raw('autoComponentsProjectsSandboxSnapshotCardJsxTextVCPU15535b27')}
+            &bull; {template.memory_gb}{' '}
+            {tI18nHardcoded.raw('autoComponentsProjectsSandboxSnapshotCardJsxTextGiB9d1e488f')}
+            &bull; {template.disk_gb}{' '}
+            {tI18nHardcoded.raw('autoComponentsProjectsSandboxSnapshotCardJsxTextGiBDiskd395296d')}
+          </div>
         </div>
-      </div>
-      <Badge
-        variant={stateBadge.variant}
-        color={'color' in stateBadge ? stateBadge.color : undefined}
-      >
-        <StateIcon className={cn(stateInfo.tone === 'busy' && 'animate-spin', 'size-4')} />
-        {stateInfo.label}
-      </Badge>
-      {canManage && (
-        <div className="flex items-center gap-1">
-          {template.template_id && !template.is_default && (
-            <>
+        <Badge
+          variant={stateBadge.variant}
+          color={'color' in stateBadge ? stateBadge.color : undefined}
+        >
+          <StateIcon className="size-4 shrink-0" />
+          {stateInfo.label}
+        </Badge>
+        {canManage && (
+          <div className="flex items-center gap-1">
+            {template.template_id && !template.is_default && (
+              <>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="size-7 p-0"
+                  onClick={() => onEdit(template)}
+                  aria-label={tI18nHardcoded.raw(
+                    'autoComponentsProjectsSandboxSnapshotCardJsxAttrAriaLabelEditdc9d24c2',
+                  )}
+                >
+                  <Edit3 className="size-3.5" />
+                </Button>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="text-destructive hover:text-destructive size-7 p-0"
+                  disabled={deleteMut.isPending}
+                  onClick={() => setConfirmDelete(true)}
+                  aria-label={tI18nHardcoded.raw(
+                    'autoComponentsProjectsSandboxSnapshotCardJsxAttrAriaLabelDeleteda0507cf',
+                  )}
+                >
+                  {deleteMut.isPending ? (
+                    <Loading className="size-3.5 shrink-0" />
+                  ) : (
+                    <Trash2 className="size-3.5 shrink-0" />
+                  )}
+                </Button>
+              </>
+            )}
+            {template.template_id && (
               <Button
                 size="sm"
-                variant="ghost"
-                className="size-7 p-0"
-                onClick={() => onEdit(template)}
-                aria-label={tI18nHardcoded.raw(
-                  'autoComponentsProjectsSandboxSnapshotCardJsxAttrAriaLabelEditdc9d24c2',
-                )}
+                variant="outline"
+                className="gap-1.5"
+                disabled={buildMut.isPending}
+                onClick={() => buildMut.mutate()}
               >
-                <Edit3 className="size-3.5" />
-              </Button>
-              <Button
-                size="sm"
-                variant="ghost"
-                className="text-destructive hover:text-destructive size-7 p-0"
-                disabled={deleteMut.isPending}
-                onClick={() => {
-                  if (window.confirm(`Delete sandbox template "${template.name}"?`)) {
-                    deleteMut.mutate();
-                  }
-                }}
-                aria-label={tI18nHardcoded.raw(
-                  'autoComponentsProjectsSandboxSnapshotCardJsxAttrAriaLabelDeleteda0507cf',
-                )}
-              >
-                {deleteMut.isPending ? (
-                  <Loader2 className="size-3.5 animate-spin" />
+                {buildMut.isPending ? (
+                  <Loading className="size-3.5 shrink-0" />
                 ) : (
-                  <Trash2 className="size-3.5" />
+                  <RefreshCw className="size-3.5 shrink-0" />
                 )}
+                Rebuild
               </Button>
-            </>
-          )}
-          {template.template_id && (
-            <Button
-              size="sm"
-              variant="outline"
-              className="gap-1.5"
-              disabled={buildMut.isPending}
-              onClick={() => buildMut.mutate()}
-            >
-              {buildMut.isPending ? (
-                <Loader2 className="h-3.5 w-3.5 animate-spin" />
-              ) : (
-                <RefreshCw className="h-3.5 w-3.5" />
-              )}
-              Rebuild
-            </Button>
-          )}
-        </div>
-      )}
-    </li>
+            )}
+          </div>
+        )}
+      </li>
+      <ConfirmDialog
+        open={confirmDelete}
+        onOpenChange={setConfirmDelete}
+        title={`Delete sandbox template "${template.name}"?`}
+        description="This removes the template from the project. Sessions already using it are unaffected."
+        confirmLabel="Delete"
+        confirmVariant="destructive"
+        isPending={deleteMut.isPending}
+        onConfirm={() => deleteMut.mutate()}
+      />
+    </>
   );
 }
 

--- a/apps/web/src/features/workspace/customize/sections/view/secrets-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/secrets-view.tsx
@@ -8,6 +8,7 @@ import { type FormEvent, useCallback, useEffect, useMemo, useState } from 'react
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -113,6 +114,7 @@ export function SecretsView({ projectId }: { projectId: string }) {
   const [providerModalOpen, setProviderModalOpen] = useState(false);
   const [dialogOpen, setDialogOpen] = useState(false);
   const [dialogRow, setDialogRow] = useState<SecretRow | null>(null);
+  const [deleteRow, setDeleteRow] = useState<SecretRow | null>(null);
 
   const refreshSecretsAndProviders = useCallback(() => {
     queryClient.invalidateQueries({ queryKey });
@@ -262,7 +264,7 @@ export function SecretsView({ projectId }: { projectId: string }) {
                         canManage={canManage}
                         busy={removeShared.isPending && removeShared.variables === row.identifier}
                         onEdit={() => openEdit(row)}
-                        onDelete={() => removeShared.mutate(row.identifier)}
+                        onDelete={() => setDeleteRow(row)}
                       />
                     ))}
                   </TableBody>
@@ -285,6 +287,29 @@ export function SecretsView({ projectId }: { projectId: string }) {
         open={providerModalOpen}
         onOpenChange={setProviderModalOpen}
         canWrite={canManage}
+      />
+      <ConfirmDialog
+        open={deleteRow !== null}
+        onOpenChange={(open) => {
+          if (!open) setDeleteRow(null);
+        }}
+        title="Delete secret"
+        description={
+          deleteRow ? `Delete ${deleteRow.identifier}? The stored value can't be recovered.` : ''
+        }
+        confirmLabel="Delete"
+        confirmVariant="destructive"
+        onConfirm={() => {
+          if (!deleteRow) return;
+          removeShared.mutate(deleteRow.identifier, {
+            onSuccess: () => {
+              setDeleteRow(null);
+              successToast('Secret deleted');
+            },
+            onError: (e) => errorToast(e instanceof Error ? e.message : 'Could not delete secret'),
+          });
+        }}
+        isPending={removeShared.isPending}
       />
     </>
   );
@@ -356,8 +381,12 @@ function buildRows(raw: ProjectSecretsResponse | ProjectSecret[] | null | undefi
     });
   }
 
-  const rank = (r: SecretRow) => (r.requirement === 'required' ? 0 : r.requirement === 'optional' ? 1 : 2);
-  rows.sort((a, b) => rank(a) - rank(b) || a.key.localeCompare(b.key) || a.identifier.localeCompare(b.identifier));
+  const rank = (r: SecretRow) =>
+    r.requirement === 'required' ? 0 : r.requirement === 'optional' ? 1 : 2;
+  rows.sort(
+    (a, b) =>
+      rank(a) - rank(b) || a.key.localeCompare(b.key) || a.identifier.localeCompare(b.identifier),
+  );
   return rows;
 }
 
@@ -412,7 +441,7 @@ function SecretTableRow({
           </div>
         </div>
       </TableCell>
-      <TableCell className="text-muted-foreground max-w-[200px] text-xs font-medium whitespace-normal">
+      <TableCell className="text-muted-foreground max-w-[200px] whitespace-normal text-xs font-medium">
         {statusLabel(row)}
       </TableCell>
       <TableCell>
@@ -504,7 +533,9 @@ function SecretDialog({
       });
     },
     onSuccess: () => {
-      successToast(`Saved ${(row?.identifier ?? identifier).trim() || (row?.key ?? key).trim().toUpperCase()}`);
+      successToast(
+        `Saved ${(row?.identifier ?? identifier).trim() || (row?.key ?? key).trim().toUpperCase()}`,
+      );
       onSaved();
       onOpenChange(false);
     },
@@ -518,7 +549,11 @@ function SecretDialog({
     save.mutate();
   }
 
-  const title = !row ? 'Add secret' : row.configured ? `Edit ${row.identifier}` : `Set ${row.identifier}`;
+  const title = !row
+    ? 'Add secret'
+    : row.configured
+      ? `Edit ${row.identifier}`
+      : `Set ${row.identifier}`;
 
   return (
     <Modal
@@ -541,7 +576,10 @@ function SecretDialog({
           <ModalBody className="max-h-[60vh] space-y-4 overflow-y-auto">
             <div className="border-border bg-sidebar flex flex-col overflow-hidden rounded-md border">
               <div className="flex flex-col gap-1 border-b px-3 py-2">
-                <label className="text-muted-foreground text-xs font-medium" htmlFor="secret-dialog-identifier">
+                <label
+                  className="text-muted-foreground text-xs font-medium"
+                  htmlFor="secret-dialog-identifier"
+                >
                   Identifier
                 </label>
                 <Input
@@ -592,8 +630,8 @@ function SecretDialog({
 
             {!isEdit && (
               <p className="text-muted-foreground text-xs">
-                Leave the identifier blank to use the key as its own identifier — the common case. Set
-                it explicitly to keep a second value under the same key (e.g. a backup key).
+                Leave the identifier blank to use the key as its own identifier — the common case.
+                Set it explicitly to keep a second value under the same key (e.g. a backup key).
               </p>
             )}
             {row?.configured && (
@@ -618,7 +656,9 @@ function SecretDialog({
               type="submit"
               size="sm"
               className="w-full sm:w-auto"
-              disabled={(!isEdit && !key.trim()) || (requiresValue && !value.trim()) || save.isPending}
+              disabled={
+                (!isEdit && !key.trim()) || (requiresValue && !value.trim()) || save.isPending
+              }
             >
               {save.isPending && <Loading className="size-4 shrink-0 animate-spin" />}
               Save

--- a/apps/web/src/features/workspace/customize/sections/view/secrets-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/secrets-view.tsx
@@ -284,6 +284,7 @@ export function SecretsView({ projectId }: { projectId: string }) {
         projectId={projectId}
         open={providerModalOpen}
         onOpenChange={setProviderModalOpen}
+        canWrite={canManage}
       />
     </>
   );

--- a/apps/web/src/features/workspace/customize/sections/view/settings-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/settings-view.tsx
@@ -50,6 +50,8 @@ import {
   type ProjectDetail,
 } from '@kortix/sdk/projects-client';
 import { refreshProjectProviderState } from '@/hooks/opencode/provider-refresh';
+import { PROJECT_ACTIONS } from '@/lib/project-actions';
+import { useProjectCan } from '@/lib/use-project-can';
 import { TrashSolid } from '@mynaui/icons-react';
 import CustomizeSectionWrapper from '../component/section-wrapper';
 
@@ -66,6 +68,12 @@ export function SettingsView({ projectId }: { projectId: string }) {
 
   const project = projectQuery.data;
   const canManage = project?.effective_project_role === 'manager';
+  // Real per-leaf write cap: a custom role granted project.write edits the
+  // general controls (name/repo/experimental) without being a full manager.
+  // The mutating routes assert project.write, so a READ-only role sees the
+  // section read-only. Archive/danger-zone stays manager-only below.
+  const canWrite = useProjectCan(projectId, PROJECT_ACTIONS.PROJECT_WRITE).allowed === true;
+  const canEdit = canManage || canWrite;
 
   const archiveMutation = useMutation({
     mutationFn: () => archiveProject(projectId),
@@ -103,15 +111,15 @@ export function SettingsView({ projectId }: { projectId: string }) {
 
       {project && (
         <div className="space-y-8">
-          <GeneralProjectCard project={project} canManage={!!canManage} />
-          <RepositoryCard project={project} canManage={!!canManage} />
+          <GeneralProjectCard project={project} canManage={canEdit} />
+          <RepositoryCard project={project} canManage={canEdit} />
           {canManage && (
             <section className="space-y-4">
               <Label>Automation</Label>
-              <TriggersActivationCard projectId={projectId} canManage={!!canManage} />
+              <TriggersActivationCard projectId={projectId} canManage={canEdit} />
             </section>
           )}
-          <ExperimentalCard project={project} canManage={!!canManage} />
+          <ExperimentalCard project={project} canManage={canEdit} />
           {canManage && (
             <section className="space-y-4">
               <Label>
@@ -269,7 +277,7 @@ function RepositoryCard({ project, canManage }: { project: KortixProject; canMan
 
         {managed ? (
           <div className="border-border/60 border-t pt-5">
-            <RepoCollaboratorInvite projectId={project.project_id} />
+            <RepoCollaboratorInvite projectId={project.project_id} canManage={canManage} />
           </div>
         ) : null}
       </div>
@@ -492,7 +500,13 @@ function TriggersActivationCard({
   );
 }
 
-function RepoCollaboratorInvite({ projectId }: { projectId: string }) {
+function RepoCollaboratorInvite({
+  projectId,
+  canManage,
+}: {
+  projectId: string;
+  canManage: boolean;
+}) {
   const tI18nHardcoded = useTranslations('hardcodedUi');
   const [username, setUsername] = useState('');
   const [permission, setPermission] = useState<'read' | 'write'>('write');
@@ -512,6 +526,7 @@ function RepoCollaboratorInvite({ projectId }: { projectId: string }) {
 
   const submit = (e: FormEvent) => {
     e.preventDefault();
+    if (!canManage) return;
     if (username.trim() && !inviteMutation.isPending) inviteMutation.mutate();
   };
 
@@ -528,6 +543,7 @@ function RepoCollaboratorInvite({ projectId }: { projectId: string }) {
         </p>
       </div>
 
+      {canManage ? (
       <form onSubmit={submit}>
         <FieldGroup className="gap-3">
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-[minmax(0,1fr)_8.5rem_auto] sm:items-end sm:gap-x-3">
@@ -590,6 +606,7 @@ function RepoCollaboratorInvite({ projectId }: { projectId: string }) {
           </div>
         </FieldGroup>
       </form>
+      ) : null}
     </div>
   );
 }

--- a/apps/web/src/features/workspace/customize/sections/view/settings-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/settings-view.tsx
@@ -50,6 +50,8 @@ import {
   type ProjectDetail,
 } from '@kortix/sdk/projects-client';
 import { refreshProjectProviderState } from '@/hooks/opencode/provider-refresh';
+import { PROJECT_ACTIONS } from '@/lib/project-actions';
+import { useProjectCan } from '@/lib/use-project-can';
 import { TrashSolid } from '@mynaui/icons-react';
 import CustomizeSectionWrapper from '../component/section-wrapper';
 
@@ -66,6 +68,12 @@ export function SettingsView({ projectId }: { projectId: string }) {
 
   const project = projectQuery.data;
   const canManage = project?.effective_project_role === 'manager';
+  // Real per-leaf write cap: a custom role granted project.write edits the
+  // general controls (name/repo/experimental) without being a full manager.
+  // The mutating routes assert project.write, so a READ-only role sees the
+  // section read-only. Archive/danger-zone stays manager-only below.
+  const canWrite = useProjectCan(projectId, PROJECT_ACTIONS.PROJECT_WRITE).allowed === true;
+  const canEdit = canManage || canWrite;
 
   const archiveMutation = useMutation({
     mutationFn: () => archiveProject(projectId),
@@ -103,15 +111,15 @@ export function SettingsView({ projectId }: { projectId: string }) {
 
       {project && (
         <div className="space-y-8">
-          <GeneralProjectCard project={project} canManage={!!canManage} />
-          <RepositoryCard project={project} canManage={!!canManage} />
+          <GeneralProjectCard project={project} canManage={canEdit} />
+          <RepositoryCard project={project} canManage={canEdit} />
           {canManage && (
             <section className="space-y-4">
               <Label>Automation</Label>
-              <TriggersActivationCard projectId={projectId} canManage={!!canManage} />
+              <TriggersActivationCard projectId={projectId} canManage={canEdit} />
             </section>
           )}
-          <ExperimentalCard project={project} canManage={!!canManage} />
+          <ExperimentalCard project={project} canManage={canEdit} />
           {canManage && (
             <section className="space-y-4">
               <Label>
@@ -269,7 +277,7 @@ function RepositoryCard({ project, canManage }: { project: KortixProject; canMan
 
         {managed ? (
           <div className="border-border/60 border-t pt-5">
-            <RepoCollaboratorInvite projectId={project.project_id} />
+            <RepoCollaboratorInvite projectId={project.project_id} canManage={canManage} />
           </div>
         ) : null}
       </div>
@@ -492,7 +500,13 @@ function TriggersActivationCard({
   );
 }
 
-function RepoCollaboratorInvite({ projectId }: { projectId: string }) {
+function RepoCollaboratorInvite({
+  projectId,
+  canManage,
+}: {
+  projectId: string;
+  canManage: boolean;
+}) {
   const tI18nHardcoded = useTranslations('hardcodedUi');
   const [username, setUsername] = useState('');
   const [permission, setPermission] = useState<'read' | 'write'>('write');
@@ -512,6 +526,7 @@ function RepoCollaboratorInvite({ projectId }: { projectId: string }) {
 
   const submit = (e: FormEvent) => {
     e.preventDefault();
+    if (!canManage) return;
     if (username.trim() && !inviteMutation.isPending) inviteMutation.mutate();
   };
 
@@ -528,6 +543,7 @@ function RepoCollaboratorInvite({ projectId }: { projectId: string }) {
         </p>
       </div>
 
+      {canManage ? (
       <form onSubmit={submit}>
         <FieldGroup className="gap-3">
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-[minmax(0,1fr)_8.5rem_auto] sm:items-end sm:gap-x-3">
@@ -581,7 +597,7 @@ function RepoCollaboratorInvite({ projectId }: { projectId: string }) {
               <Button
                 type="submit"
                 className="w-full shrink-0 sm:w-auto"
-                disabled={!username.trim() || inviteMutation.isPending}
+                disabled={!canManage || !username.trim() || inviteMutation.isPending}
               >
                 {inviteMutation.isPending ? <Loading className="size-3.5 animate-spin" /> : null}
                 Add
@@ -590,6 +606,7 @@ function RepoCollaboratorInvite({ projectId }: { projectId: string }) {
           </div>
         </FieldGroup>
       </form>
+      ) : null}
     </div>
   );
 }

--- a/apps/web/src/features/workspace/customize/sections/view/settings-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/settings-view.tsx
@@ -597,7 +597,7 @@ function RepoCollaboratorInvite({
               <Button
                 type="submit"
                 className="w-full shrink-0 sm:w-auto"
-                disabled={!canManage || !username.trim() || inviteMutation.isPending}
+                disabled={!username.trim() || inviteMutation.isPending}
               >
                 {inviteMutation.isPending ? <Loading className="size-3.5 animate-spin" /> : null}
                 Add

--- a/apps/web/src/features/workspace/customize/sections/view/skills-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/skills-view.tsx
@@ -4,17 +4,21 @@ import {
   type ConfigEntity,
   ConfigEntityView,
 } from '@/features/workspace/customize/sections/component/config-entity-view';
+import { PROJECT_ACTIONS } from '@/lib/project-actions';
+import { useProjectCan } from '@/lib/use-project-can';
 import { Sparkles } from 'lucide-react';
 
 type Skill = ConfigEntity;
 
 export function SkillsView({ projectId }: { projectId: string }) {
+  const canWrite = useProjectCan(projectId, PROJECT_ACTIONS.PROJECT_SKILL_WRITE).allowed === true;
   return (
     <ConfigEntityView<Skill>
       projectId={projectId}
       kind="skill"
       noun="skill"
       layout="split"
+      canWrite={canWrite}
       title="Skills"
       searchPlaceholder="Search skills"
       emptyIcon={Sparkles}

--- a/apps/web/src/features/workspace/project-sidebar/footer/project-sandbox-alert.tsx
+++ b/apps/web/src/features/workspace/project-sidebar/footer/project-sandbox-alert.tsx
@@ -54,6 +54,7 @@ const SEVERITY_LABEL: Record<Severity, string> = {
 };
 
 const CATEGORY_LABEL: Record<string, string> = {
+  quota: 'Snapshot quota reached',
   dockerfile: 'Dockerfile build failed',
   git: 'Repository access failed',
   tunnel: 'Sandbox callback unreachable',
@@ -122,8 +123,16 @@ function SandboxAlertContent({
   const openCustomize = useCustomizeStore((s) => s.openCustomize);
   const { retry, fixWithAgent } = useSandboxRecovery(projectId);
   const failure = health.latest_failure;
+  // Only offer the agent for failures it can actually act on. Infra categories
+  // (quota, provider, timeout, runtime, tunnel) aren't repo-editable, and the fix
+  // session itself needs a bootable sandbox — the very thing the failure denied —
+  // so the button would fail to start the session meant to diagnose the failure.
+  // `fixable_by_agent` is server-derived; the API rejects the rest with 409.
   const canFixWithAgent =
-    !!failure && !!health.latest_build && health.latest_build.status === 'ready';
+    !!failure &&
+    failure.fixable_by_agent &&
+    !!health.latest_build &&
+    health.latest_build.status === 'ready';
 
   return (
     <div className="w-full overflow-hidden">
@@ -191,7 +200,7 @@ function SandboxAlertContent({
           variant="secondary"
           className="w-full border"
           disabled={retry.isPending}
-          onClick={() => retry.mutate(failure?.slug)}
+          onClick={() => retry.mutate(failure?.template_slug)}
         >
           {retry.isPending ? (
             <Loading className="text-foreground! size-3.5" />

--- a/apps/web/src/features/workspace/project-sidebar/modal/rename-session-modal.tsx
+++ b/apps/web/src/features/workspace/project-sidebar/modal/rename-session-modal.tsx
@@ -2,6 +2,7 @@
 
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import Loading from '@/components/ui/loading';
 import {
   Modal,
   ModalBody,
@@ -49,9 +50,9 @@ export function RenameSessionModal({
       if (!sessionId) throw new Error('No session selected');
       return updateProjectSession(projectId, sessionId, { name });
     },
-    onSuccess: () => {
+    onSuccess: (_updated, name) => {
       queryClient.invalidateQueries({ queryKey: ['project-sessions', projectId] });
-      successToast('Session renamed');
+      successToast(name ? `Renamed to "${name}"` : 'Session renamed');
       onSaved?.();
       onOpenChange(false);
     },
@@ -69,7 +70,12 @@ export function RenameSessionModal({
   };
 
   return (
-    <Modal open={open} onOpenChange={onOpenChange}>
+    <Modal
+      open={open}
+      onOpenChange={(o) => {
+        if (!renameMutation.isPending) onOpenChange(o);
+      }}
+    >
       <ModalContent className="lg:max-w-md">
         <ModalHeader>
           <ModalTitle>
@@ -106,6 +112,7 @@ export function RenameSessionModal({
             size="sm"
             className="w-full sm:w-auto"
             onClick={() => onOpenChange(false)}
+            disabled={renameMutation.isPending}
           >
             Cancel
           </Button>
@@ -115,7 +122,8 @@ export function RenameSessionModal({
             onClick={submit}
             disabled={renameMutation.isPending || isUnchanged}
           >
-            {renameMutation.isPending ? 'Saving…' : 'Save'}
+            {renameMutation.isPending ? <Loading className="size-4 shrink-0" /> : null}
+            Save
           </Button>
         </ModalFooter>
       </ModalContent>

--- a/apps/web/src/features/workspace/project-sidebar/modal/session-delete-modal.tsx
+++ b/apps/web/src/features/workspace/project-sidebar/modal/session-delete-modal.tsx
@@ -1,15 +1,6 @@
 'use client';
 
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from '@/components/ui/alert-dialog';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { errorToast, successToast } from '@/components/ui/toast';
 import { deleteProjectSession } from '@kortix/sdk/projects-client';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
@@ -38,7 +29,7 @@ export function SessionDeleteModal({
   const deleteMutation = useMutation({
     mutationFn: (id: string) => deleteProjectSession(projectId, id),
     onSuccess: () => {
-      successToast('Session deleted');
+      successToast(sessionLabel ? `"${sessionLabel}" deleted` : 'Session deleted');
       queryClient.invalidateQueries({ queryKey: ['project-sessions', projectId] });
       onDeleted?.();
       onOpenChange(false);
@@ -54,33 +45,27 @@ export function SessionDeleteModal({
   };
 
   return (
-    <AlertDialog open={open} onOpenChange={onOpenChange}>
-      <AlertDialogContent>
-        <AlertDialogHeader>
-          <AlertDialogTitle>
-            {tHardcodedUi.raw('componentsProjectsProjectSessionList.line189JsxTextDeleteSession')}
-          </AlertDialogTitle>
-          <AlertDialogDescription>
-            {tHardcodedUi.raw(
-              'componentsProjectsProjectSessionList.line191JsxTextThisWillPermanentlyDestroyTheBranchAndSandbox',
-            )}{' '}
-            <span className="text-foreground font-medium">{sessionLabel}</span>
-            {tHardcodedUi.raw(
-              'componentsProjectsProjectSessionList.line193JsxTextThisActionCannotBeUndone',
-            )}
-          </AlertDialogDescription>
-        </AlertDialogHeader>
-        <AlertDialogFooter>
-          <AlertDialogCancel>Cancel</AlertDialogCancel>
-          <AlertDialogAction
-            variant="destructive"
-            onClick={confirmDelete}
-            disabled={deleteMutation.isPending}
-          >
-            Delete
-          </AlertDialogAction>
-        </AlertDialogFooter>
-      </AlertDialogContent>
-    </AlertDialog>
+    <ConfirmDialog
+      open={open}
+      onOpenChange={(o) => {
+        if (!deleteMutation.isPending) onOpenChange(o);
+      }}
+      title={tHardcodedUi.raw('componentsProjectsProjectSessionList.line189JsxTextDeleteSession')}
+      description={
+        <>
+          {tHardcodedUi.raw(
+            'componentsProjectsProjectSessionList.line191JsxTextThisWillPermanentlyDestroyTheBranchAndSandbox',
+          )}{' '}
+          <span className="text-foreground font-medium">{sessionLabel}</span>
+          {tHardcodedUi.raw(
+            'componentsProjectsProjectSessionList.line193JsxTextThisActionCannotBeUndone',
+          )}
+        </>
+      }
+      confirmLabel="Delete"
+      confirmVariant="destructive"
+      isPending={deleteMutation.isPending}
+      onConfirm={confirmDelete}
+    />
   );
 }

--- a/apps/web/src/features/workspace/project-sidebar/project-session-list-helpers.test.ts
+++ b/apps/web/src/features/workspace/project-sidebar/project-session-list-helpers.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  getSessionDisplayTitle,
+  resolveSessionListViewState,
+  shortRelative,
+  shouldPollProjectSessions,
+  sortSessionsByCreatedAt,
+} from './project-session-list-helpers';
+import type { ProjectSession } from '@kortix/sdk/projects-client';
+
+function makeSession(overrides: Partial<ProjectSession> = {}): ProjectSession {
+  return {
+    session_id: 's1',
+    project_id: 'p1',
+    status: 'running',
+    created_at: '2026-01-01T00:00:00.000Z',
+    custom_name: null,
+    name: null,
+    branch_name: null,
+    metadata: null,
+    ...overrides,
+  } as unknown as ProjectSession;
+}
+
+describe('shouldPollProjectSessions', () => {
+  test('polls when a session is queued', () => {
+    expect(shouldPollProjectSessions([makeSession({ status: 'queued' })])).toBe(true);
+  });
+
+  test('polls when a session is branching', () => {
+    expect(shouldPollProjectSessions([makeSession({ status: 'branching' })])).toBe(true);
+  });
+
+  test('polls when a session is provisioning', () => {
+    expect(shouldPollProjectSessions([makeSession({ status: 'provisioning' })])).toBe(true);
+  });
+
+  test('does not poll when every session has settled', () => {
+    const sessions = [
+      makeSession({ status: 'running' }),
+      makeSession({ status: 'stopped' }),
+      makeSession({ status: 'completed' }),
+    ];
+    expect(shouldPollProjectSessions(sessions)).toBe(false);
+  });
+
+  test('does not poll an empty or undefined list', () => {
+    expect(shouldPollProjectSessions([])).toBe(false);
+    expect(shouldPollProjectSessions(undefined)).toBe(false);
+  });
+});
+
+describe('sortSessionsByCreatedAt', () => {
+  test('orders sessions newest-first', () => {
+    const oldest = makeSession({ session_id: 'a', created_at: '2026-01-01T00:00:00.000Z' });
+    const middle = makeSession({ session_id: 'b', created_at: '2026-01-02T00:00:00.000Z' });
+    const newest = makeSession({ session_id: 'c', created_at: '2026-01-03T00:00:00.000Z' });
+
+    const result = sortSessionsByCreatedAt([oldest, newest, middle]);
+
+    expect(result.map((s) => s.session_id)).toEqual(['c', 'b', 'a']);
+  });
+
+  test('does not mutate the input array', () => {
+    const input = [
+      makeSession({ session_id: 'a', created_at: '2026-01-01T00:00:00.000Z' }),
+      makeSession({ session_id: 'b', created_at: '2026-01-02T00:00:00.000Z' }),
+    ];
+    const inputCopy = [...input];
+
+    sortSessionsByCreatedAt(input);
+
+    expect(input).toEqual(inputCopy);
+  });
+
+  test('an empty list sorts to an empty list', () => {
+    expect(sortSessionsByCreatedAt([])).toEqual([]);
+  });
+});
+
+describe('getSessionDisplayTitle', () => {
+  test('a user rename (custom_name) wins over everything else', () => {
+    const session = makeSession({
+      custom_name: 'My renamed session',
+      name: 'server-name',
+      branch_name: 'feature/branch-name',
+    });
+    expect(getSessionDisplayTitle(session)).toBe('My renamed session');
+  });
+
+  test('falls back to the server name when there is no custom name', () => {
+    const session = makeSession({ name: 'server-name', branch_name: 'feature/branch-name' });
+    expect(getSessionDisplayTitle(session)).toBe('server-name');
+  });
+
+  test('falls back to legacy metadata.session_name next', () => {
+    const session = makeSession({
+      metadata: { session_name: 'legacy-name' },
+      branch_name: 'feature/branch-name',
+    });
+    expect(getSessionDisplayTitle(session)).toBe('legacy-name');
+  });
+
+  test('falls back to a 14-char slice of the branch name', () => {
+    const session = makeSession({ branch_name: 'feature/a-very-long-branch-name' });
+    expect(getSessionDisplayTitle(session)).toBe('feature/a-very');
+  });
+
+  test('falls back to the literal "session" when nothing is available', () => {
+    expect(getSessionDisplayTitle(makeSession())).toBe('session');
+  });
+
+  test('blank/whitespace-only names are treated as absent', () => {
+    const session = makeSession({ custom_name: '   ', name: 'server-name' });
+    expect(getSessionDisplayTitle(session)).toBe('server-name');
+  });
+});
+
+describe('shortRelative', () => {
+  test('collapses "less than a minute" to "now"', () => {
+    expect(shortRelative('less than a minute')).toBe('now');
+  });
+
+  test('collapses "0 seconds" to "now"', () => {
+    expect(shortRelative('0 seconds')).toBe('now');
+  });
+
+  test('compresses each unit to its single-letter suffix', () => {
+    expect(shortRelative('5 seconds')).toBe('5s');
+    expect(shortRelative('5 minutes')).toBe('5m');
+    expect(shortRelative('5 hours')).toBe('5h');
+    expect(shortRelative('5 days')).toBe('5d');
+    expect(shortRelative('5 months')).toBe('5mo');
+    expect(shortRelative('5 years')).toBe('5y');
+  });
+
+  test('handles the singular form (no trailing "s")', () => {
+    expect(shortRelative('1 minute')).toBe('1m');
+  });
+
+  test('passes unrecognized input through unchanged', () => {
+    expect(shortRelative('a while ago')).toBe('a while ago');
+  });
+});
+
+describe('resolveSessionListViewState', () => {
+  test('loading wins regardless of error or counts', () => {
+    const state = resolveSessionListViewState({
+      isLoading: true,
+      isError: true,
+      totalCount: 5,
+      visibleCount: 5,
+    });
+    expect(state).toBe('loading');
+  });
+
+  test('error wins over empty/no-matches once loading has settled', () => {
+    const state = resolveSessionListViewState({
+      isLoading: false,
+      isError: true,
+      totalCount: 0,
+      visibleCount: 0,
+    });
+    expect(state).toBe('error');
+  });
+
+  test('no sessions at all is "empty"', () => {
+    const state = resolveSessionListViewState({
+      isLoading: false,
+      isError: false,
+      totalCount: 0,
+      visibleCount: 0,
+    });
+    expect(state).toBe('empty');
+  });
+
+  test('sessions exist but the active filter matches none: "no-matches"', () => {
+    const state = resolveSessionListViewState({
+      isLoading: false,
+      isError: false,
+      totalCount: 3,
+      visibleCount: 0,
+    });
+    expect(state).toBe('no-matches');
+  });
+
+  test('sessions exist and the filter matches some: "content"', () => {
+    const state = resolveSessionListViewState({
+      isLoading: false,
+      isError: false,
+      totalCount: 3,
+      visibleCount: 2,
+    });
+    expect(state).toBe('content');
+  });
+});

--- a/apps/web/src/features/workspace/project-sidebar/project-session-list-helpers.ts
+++ b/apps/web/src/features/workspace/project-sidebar/project-session-list-helpers.ts
@@ -1,0 +1,90 @@
+import type { ProjectSession, ProjectSessionStatus } from '@kortix/sdk/projects-client';
+
+/**
+ * Pure helpers extracted from `project-session-list.tsx` so the sidebar's
+ * sort/poll/label/time-formatting decisions and its loading/error/empty/
+ * content state selection are unit-testable without mounting react-query or
+ * the row components.
+ */
+
+export const LIVE_SESSION_STATUSES: ProjectSessionStatus[] = [
+  'queued',
+  'branching',
+  'provisioning',
+];
+
+/** Whether the session list should keep polling — true while any session is
+ *  still mid-provisioning (queued/branching/provisioning). */
+export function shouldPollProjectSessions(sessions: ProjectSession[] | undefined): boolean {
+  return (sessions ?? []).some((session) => LIVE_SESSION_STATUSES.includes(session.status));
+}
+
+/** Newest-first sort by `created_at`. Extracted so the ordering rule (and its
+ *  stability for equal timestamps) is independently testable. */
+export function sortSessionsByCreatedAt(sessions: ProjectSession[]): ProjectSession[] {
+  return sessions
+    .slice()
+    .sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime());
+}
+
+/**
+ * Display title for a session row. Precedence: user rename (custom_name) →
+ * server name → legacy metadata.session_name → a slice of the branch name →
+ * the literal "session" fallback when nothing else is available.
+ */
+export function getSessionDisplayTitle(session: ProjectSession): string {
+  const legacyMetadataName =
+    typeof session.metadata?.session_name === 'string'
+      ? (session.metadata.session_name as string)
+      : null;
+  const titleCandidate =
+    session.custom_name?.trim() || session.name?.trim() || legacyMetadataName?.trim();
+
+  if (titleCandidate) return titleCandidate;
+  return session.branch_name ? session.branch_name.slice(0, 14) : 'session';
+}
+
+/** Compresses date-fns' `formatDistanceToNowStrict` output ("5 minutes") down
+ *  to the sidebar's fixed-width form ("5m") so the relative-time column never
+ *  reflows the row. "0 seconds" and "less than a minute" both collapse to
+ *  "now". Unrecognized input (a future date-fns phrasing change, or a locale
+ *  string) is passed through unchanged rather than dropped. */
+export function shortRelative(input: string): string {
+  if (input === 'less than a minute') return 'now';
+  const match = input.match(/^(\d+)\s+(second|minute|hour|day|month|year)s?$/);
+  if (!match) return input;
+  if (match[1] === '0' && match[2] === 'second') return 'now';
+  const [, n, unit] = match;
+  const suffix =
+    unit === 'second'
+      ? 's'
+      : unit === 'minute'
+        ? 'm'
+        : unit === 'hour'
+          ? 'h'
+          : unit === 'day'
+            ? 'd'
+            : unit === 'month'
+              ? 'mo'
+              : 'y';
+  return `${n}${suffix}`;
+}
+
+/** Which of the sidebar's mutually-exclusive render states applies. Mirrors
+ *  the early-return ladder in `ProjectSessionList`: loading and error both
+ *  win outright (independent of data), then "no sessions at all" wins over
+ *  "sessions exist but none match the active filter". */
+export type SessionListViewState = 'loading' | 'error' | 'empty' | 'no-matches' | 'content';
+
+export function resolveSessionListViewState(params: {
+  isLoading: boolean;
+  isError: boolean;
+  totalCount: number;
+  visibleCount: number;
+}): SessionListViewState {
+  if (params.isLoading) return 'loading';
+  if (params.isError) return 'error';
+  if (params.totalCount === 0) return 'empty';
+  if (params.visibleCount === 0) return 'no-matches';
+  return 'content';
+}

--- a/apps/web/src/features/workspace/project-sidebar/project-session-list.tsx
+++ b/apps/web/src/features/workspace/project-sidebar/project-session-list.tsx
@@ -24,6 +24,13 @@ import { errorToast, successToast } from '@/components/ui/toast';
 import { RenameSessionModal } from '@/features/workspace/project-sidebar/modal/rename-session-modal';
 import { SessionDeleteModal } from '@/features/workspace/project-sidebar/modal/session-delete-modal';
 import { ShareSessionModal } from '@/features/workspace/project-sidebar/modal/share-session-modal';
+import {
+  getSessionDisplayTitle,
+  resolveSessionListViewState,
+  shortRelative,
+  shouldPollProjectSessions,
+  sortSessionsByCreatedAt,
+} from '@/features/workspace/project-sidebar/project-session-list-helpers';
 import { Icon } from '@/features/icon/icon';
 import {
   listProjectSessions,
@@ -55,8 +62,6 @@ interface ProjectSessionListProps {
   filter?: SessionFilterValue;
 }
 
-const LIVE_SESSION_STATUSES: ProjectSessionStatus[] = ['queued', 'branching', 'provisioning'];
-
 const SESSION_RELATIVE_TIME_CLASS =
   'text-muted-foreground/60 block w-10 min-w-10 max-w-10 shrink-0 truncate text-right text-xs tabular-nums';
 
@@ -70,10 +75,6 @@ const SOURCE_ICONS: Record<
   schedule: CalendarClock,
   webhook: Webhook,
 };
-
-function shouldPollProjectSessions(sessions: ProjectSession[] | undefined): boolean {
-  return (sessions ?? []).some((session) => LIVE_SESSION_STATUSES.includes(session.status));
-}
 
 // Staggered (unique) widths so the loading state reads as a list of rows, not a
 // block; the width doubles as a stable key.
@@ -107,7 +108,7 @@ export function ProjectSessionList({ projectId, filter = 'all' }: ProjectSession
   const [sessionToShare, setSessionToShare] = useState<ProjectSession | null>(null);
   const [sessionToRename, setSessionToRename] = useState<{ id: string; name: string } | null>(null);
 
-  const { data, isLoading, error } = useQuery({
+  const { data, isLoading, isError, error, refetch } = useQuery({
     queryKey: ['project-sessions', projectId],
     queryFn: () => listProjectSessions(projectId),
     staleTime: 10_000,
@@ -117,9 +118,10 @@ export function ProjectSessionList({ projectId, filter = 'all' }: ProjectSession
   });
 
   const restartMutation = useMutation({
-    mutationFn: (sessionId: string) => restartProjectSession(projectId, sessionId),
-    onSuccess: () => {
-      successToast('Restarting session…');
+    mutationFn: ({ sessionId }: { sessionId: string; label: string }) =>
+      restartProjectSession(projectId, sessionId),
+    onSuccess: (_data, { label }) => {
+      successToast(`Restarting "${label}"…`);
       queryClient.invalidateQueries({ queryKey: ['project-sessions', projectId] });
     },
     onError: (err) => {
@@ -128,9 +130,10 @@ export function ProjectSessionList({ projectId, filter = 'all' }: ProjectSession
   });
 
   const stopMutation = useMutation({
-    mutationFn: (sessionId: string) => stopProjectSession(projectId, sessionId),
-    onSuccess: () => {
-      successToast('Session stopped');
+    mutationFn: ({ sessionId }: { sessionId: string; label: string }) =>
+      stopProjectSession(projectId, sessionId),
+    onSuccess: (_data, { label }) => {
+      successToast(`"${label}" stopped`);
       queryClient.invalidateQueries({ queryKey: ['project-sessions', projectId] });
     },
     onError: (err) => {
@@ -138,25 +141,44 @@ export function ProjectSessionList({ projectId, filter = 'all' }: ProjectSession
     },
   });
 
-  if (isLoading) {
+  const sessions = sortSessionsByCreatedAt(data ?? []);
+  // Filtering itself lives in the SESSIONS header dropdown (project-sidebar);
+  // this list only applies the chosen filter.
+  const visibleSessions = sessions.filter((session) => matchesSessionFilter(session, filter));
+
+  const viewState = resolveSessionListViewState({
+    isLoading,
+    isError,
+    totalCount: sessions.length,
+    visibleCount: visibleSessions.length,
+  });
+
+  if (viewState === 'loading') {
     return <ProjectSessionListSkeleton />;
   }
 
-  if (error) {
+  if (viewState === 'error') {
+    const message = error instanceof Error ? error.message : undefined;
     return (
-      <div className="text-destructive/80 px-2 py-2 text-xs">
-        {tHardcodedUi.raw(
-          'componentsProjectsProjectSessionList.line120JsxTextFailedToLoadSessions',
+      <div className="space-y-1.5 px-2 py-2">
+        <p className="text-destructive/80 text-xs">
+          {tHardcodedUi.raw(
+            'componentsProjectsProjectSessionList.line120JsxTextFailedToLoadSessions',
+          )}
+        </p>
+        {message && (
+          <p className="text-muted-foreground/70 truncate text-xs" title={message}>
+            {message}
+          </p>
         )}
+        <Button variant="outline" size="sm" className="h-6 px-2 text-xs" onClick={() => refetch()}>
+          Retry
+        </Button>
       </div>
     );
   }
 
-  const sessions = (data ?? [])
-    .slice()
-    .sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime());
-
-  if (sessions.length === 0) {
+  if (viewState === 'empty') {
     return (
       <div className="text-muted-foreground/60 px-2 pt-1 pb-2 text-xs">
         {tHardcodedUi.raw('componentsProjectsProjectSessionList.line132JsxTextNoSessionsYet')}
@@ -164,11 +186,7 @@ export function ProjectSessionList({ projectId, filter = 'all' }: ProjectSession
     );
   }
 
-  // Filtering itself lives in the SESSIONS header dropdown (project-sidebar);
-  // this list only applies the chosen filter.
-  const visibleSessions = sessions.filter((session) => matchesSessionFilter(session, filter));
-
-  if (visibleSessions.length === 0) {
+  if (viewState === 'no-matches') {
     return (
       <div className="text-muted-foreground/60 px-2 pt-1 pb-2 text-xs">
         {tI18nHardcoded.raw('autoFeaturesCoWorkerProjectSidebarProjectSessionListJsxText1fba7ca0')}
@@ -194,13 +212,14 @@ export function ProjectSessionList({ projectId, filter = 'all' }: ProjectSession
                 onDelete={(id, label) => setSessionToDelete({ id, label })}
                 onShare={(s) => setSessionToShare(s)}
                 onRename={(id, name) => setSessionToRename({ id, name })}
-                onRestart={(id) => restartMutation.mutate(id)}
+                onRestart={(id, label) => restartMutation.mutate({ sessionId: id, label })}
                 isRestarting={
-                  restartMutation.isPending && restartMutation.variables === session.session_id
+                  restartMutation.isPending &&
+                  restartMutation.variables?.sessionId === session.session_id
                 }
-                onStop={(id) => stopMutation.mutate(id)}
+                onStop={(id, label) => stopMutation.mutate({ sessionId: id, label })}
                 isStopping={
-                  stopMutation.isPending && stopMutation.variables === session.session_id
+                  stopMutation.isPending && stopMutation.variables?.sessionId === session.session_id
                 }
               />
               {children.length > 0 && isActive && (
@@ -260,9 +279,9 @@ interface ProjectSessionRowProps {
   onDelete: (sessionId: string, label: string) => void;
   onShare: (session: ProjectSession) => void;
   onRename: (sessionId: string, currentName: string) => void;
-  onRestart: (sessionId: string) => void;
+  onRestart: (sessionId: string, label: string) => void;
   isRestarting: boolean;
-  onStop: (sessionId: string) => void;
+  onStop: (sessionId: string, label: string) => void;
   isStopping: boolean;
   childCount?: number;
 }
@@ -313,7 +332,10 @@ function ProjectSessionRow({
         <Link href={href} className="flex min-w-0 flex-1 items-center gap-2 self-stretch">
           <SessionStatusDot status={session.status} />
 
-          <span className={cn('min-w-0 flex-1 truncate text-sm', isActive && 'font-medium')}>
+          <span
+            title={displayTitle}
+            className={cn('min-w-0 flex-1 truncate text-sm', isActive && 'font-medium')}
+          >
             {displayTitle}
           </span>
 
@@ -400,18 +422,18 @@ function ProjectSessionRow({
                 <DropdownMenuItem
                   className="cursor-pointer"
                   disabled={isRestarting}
-                  onSelect={() => deferAfterClose(() => onRestart(session.session_id))}
+                  onSelect={() => deferAfterClose(() => onRestart(session.session_id, displayTitle))}
                 >
-                  {isRestarting ? <Loading /> : <RotateCcw />}
+                  {isRestarting ? <Loading className="size-4 shrink-0" /> : <RotateCcw />}
                   Restart
                 </DropdownMenuItem>
                 {session.status === 'running' && session.can_manage_sharing !== false && (
                   <DropdownMenuItem
                     className="cursor-pointer"
                     disabled={isStopping}
-                    onSelect={() => deferAfterClose(() => onStop(session.session_id))}
+                    onSelect={() => deferAfterClose(() => onStop(session.session_id, displayTitle))}
                   >
-                    {isStopping ? <Loading /> : <Square />}
+                    {isStopping ? <Loading className="size-4 shrink-0" /> : <Square />}
                     Stop
                   </DropdownMenuItem>
                 )}
@@ -456,7 +478,9 @@ function ProjectSubsessionRow({
         )}
       >
         <span className="bg-muted-foreground/40 h-1 w-1 shrink-0 rounded-full" />
-        <span className={cn('flex-1 truncate', isActive && 'font-medium')}>{title}</span>
+        <span title={title} className={cn('flex-1 truncate', isActive && 'font-medium')}>
+          {title}
+        </span>
         {relative && <span className={SESSION_RELATIVE_TIME_CLASS}>{relative}</span>}
       </div>
     </Link>
@@ -506,37 +530,4 @@ function SessionStatusDot({ status }: { status: ProjectSessionStatus }) {
       </div>
     </Hint>
   );
-}
-
-function getSessionDisplayTitle(session: ProjectSession): string {
-  const legacyMetadataName =
-    typeof session.metadata?.session_name === 'string'
-      ? (session.metadata.session_name as string)
-      : null;
-  const titleCandidate =
-    session.custom_name?.trim() || session.name?.trim() || legacyMetadataName?.trim();
-
-  if (titleCandidate) return titleCandidate;
-  return session.branch_name ? session.branch_name.slice(0, 14) : 'session';
-}
-
-function shortRelative(input: string): string {
-  if (input === 'less than a minute') return 'now';
-  const match = input.match(/^(\d+)\s+(second|minute|hour|day|month|year)s?$/);
-  if (!match) return input;
-  if (match[1] === '0' && match[2] === 'second') return 'now';
-  const [, n, unit] = match;
-  const suffix =
-    unit === 'second'
-      ? 's'
-      : unit === 'minute'
-        ? 'm'
-        : unit === 'hour'
-          ? 'h'
-          : unit === 'day'
-            ? 'd'
-            : unit === 'month'
-              ? 'mo'
-              : 'y';
-  return `${n}${suffix}`;
 }

--- a/apps/web/src/lib/iam-client.test.ts
+++ b/apps/web/src/lib/iam-client.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+/**
+ * Pins the IAM client's error-surfacing contract: READS pass
+ * `showErrors: false` (a capability-denied background query must never raise
+ * the global "contact support" toast — the UI gates/hides instead), while
+ * MUTATIONS keep default error surfacing (user-initiated; their call sites
+ * toast specific messages).
+ */
+
+const calls: { method: string; path: string; options?: Record<string, unknown> }[] = [];
+
+const ok = (data: unknown) => Promise.resolve({ success: true, data });
+
+mock.module('@/lib/api-client', () => ({
+  backendApi: {
+    get: (path: string, options?: Record<string, unknown>) => {
+      calls.push({ method: 'get', path, options });
+      return ok({ groups: [], policies: [], roles: [], agents: [] });
+    },
+    post: (path: string, _body?: unknown, options?: Record<string, unknown>) => {
+      calls.push({ method: 'post', path, options });
+      return ok({ group: { group_id: 'g1', name: 'x' } });
+    },
+    put: (path: string, _body?: unknown, options?: Record<string, unknown>) => {
+      calls.push({ method: 'put', path, options });
+      return ok({ ok: true });
+    },
+    delete: (path: string, options?: Record<string, unknown>) => {
+      calls.push({ method: 'delete', path, options });
+      return ok({ ok: true });
+    },
+  },
+}));
+
+const { listGroups, listPolicies, listRoles, listAgentIdentities } = await import('./iam-client');
+
+describe('iam-client error-surfacing contract', () => {
+  beforeEach(() => {
+    calls.length = 0;
+  });
+
+  test('reads are silent: list calls pass showErrors:false so a capability 403 never global-toasts', async () => {
+    await listGroups('acc-1');
+    await listPolicies('acc-1', { scopeId: 'proj-1' });
+    await listRoles('acc-1');
+    await listAgentIdentities('acc-1');
+
+    const gets = calls.filter((c) => c.method === 'get');
+    expect(gets.length).toBe(4);
+    for (const c of gets) {
+      expect(c.options?.showErrors).toBe(false);
+    }
+  });
+});

--- a/apps/web/src/lib/iam-client.ts
+++ b/apps/web/src/lib/iam-client.ts
@@ -93,16 +93,30 @@ function unwrap<T>(response: { data?: T; success: boolean; error?: Error }) {
   return response.data;
 }
 
+/**
+ * All IAM READS go through this instead of `backendApi.get` directly:
+ * `showErrors: false` keeps a capability-denied read (403 "You don't have
+ * permission to perform this action (policy.read)") out of the GLOBAL error
+ * toast. Reads are background queries — when the viewer can't read something,
+ * the UI's job is to gate or hide that surface (react-query still exposes
+ * `isError` to any component that wants an explicit error state), not to
+ * raise a "contact support" toast. Mutations keep full error surfacing —
+ * they're user-initiated and their call sites toast specific messages.
+ */
+function iamGet<T>(path: string) {
+  return backendApi.get<T>(path, { showErrors: false });
+}
+
 // ─── Groups ────────────────────────────────────────────────────────────────
 
 export async function listGroups(accountId: string) {
   return unwrap(
-    await backendApi.get<{ groups: AccountGroup[] }>(`/accounts/${accountId}/iam/groups`),
+    await iamGet<{ groups: AccountGroup[] }>(`/accounts/${accountId}/iam/groups`),
   ).groups;
 }
 
 export async function getGroup(accountId: string, groupId: string) {
-  return unwrap(await backendApi.get<AccountGroup>(`/accounts/${accountId}/iam/groups/${groupId}`));
+  return unwrap(await iamGet<AccountGroup>(`/accounts/${accountId}/iam/groups/${groupId}`));
 }
 
 export async function createGroup(
@@ -134,7 +148,7 @@ export async function deleteGroup(accountId: string, groupId: string) {
 
 export async function listGroupMembers(accountId: string, groupId: string) {
   return unwrap(
-    await backendApi.get<{ members: GroupMember[] }>(
+    await iamGet<{ members: GroupMember[] }>(
       `/accounts/${accountId}/iam/groups/${groupId}/members`,
     ),
   ).members;
@@ -166,7 +180,7 @@ export interface GroupProjectGrant {
 
 export async function listGroupProjectGrants(accountId: string, groupId: string) {
   return unwrap(
-    await backendApi.get<{ grants: GroupProjectGrant[] }>(
+    await iamGet<{ grants: GroupProjectGrant[] }>(
       `/accounts/${accountId}/iam/groups/${groupId}/project-grants`,
     ),
   ).grants;
@@ -190,7 +204,7 @@ export interface MemberGroupSummary {
  *  listGroupMembers — backs the "via groups" panel on member detail. */
 export async function listMemberGroups(accountId: string, userId: string) {
   return unwrap(
-    await backendApi.get<{ groups: MemberGroupSummary[] }>(
+    await iamGet<{ groups: MemberGroupSummary[] }>(
       `/accounts/${accountId}/iam/members/${userId}/groups`,
     ),
   ).groups;
@@ -210,7 +224,7 @@ export interface MemberProjectAccess {
 
 export async function listMemberProjectAccess(accountId: string, userId: string) {
   return unwrap(
-    await backendApi.get<{ projects: MemberProjectAccess[] }>(
+    await iamGet<{ projects: MemberProjectAccess[] }>(
       `/accounts/${accountId}/iam/members/${userId}/project-access`,
     ),
   ).projects;
@@ -235,7 +249,7 @@ export async function listPolicies(accountId: string, filter: ListPoliciesFilter
   }
   const qs = params.toString();
   return unwrap(
-    await backendApi.get<{ policies: IamPolicy[] }>(
+    await iamGet<{ policies: IamPolicy[] }>(
       `/accounts/${accountId}/iam/policies${qs ? `?${qs}` : ''}`,
     ),
   ).policies;
@@ -339,7 +353,7 @@ export async function bulkImportPolicies(accountId: string, policies: BulkImport
 // ─── Roles ─────────────────────────────────────────────────────────────────
 
 export async function listRoles(accountId: string) {
-  return unwrap(await backendApi.get<{ roles: IamRole[] }>(`/accounts/${accountId}/iam/roles`))
+  return unwrap(await iamGet<{ roles: IamRole[] }>(`/accounts/${accountId}/iam/roles`))
     .roles;
 }
 
@@ -354,7 +368,7 @@ export interface AgentIdentity {
 
 export async function listAgentIdentities(accountId: string) {
   return unwrap(
-    await backendApi.get<{ agents: AgentIdentity[] }>(
+    await iamGet<{ agents: AgentIdentity[] }>(
       `/accounts/${accountId}/iam/agent-identities`,
     ),
   ).agents;
@@ -362,7 +376,7 @@ export async function listAgentIdentities(accountId: string) {
 
 export async function getRolePermissions(accountId: string, roleId: string) {
   return unwrap(
-    await backendApi.get<{ role_id: string; key: string; actions: string[] }>(
+    await iamGet<{ role_id: string; key: string; actions: string[] }>(
       `/accounts/${accountId}/iam/roles/${roleId}/permissions`,
     ),
   );
@@ -376,13 +390,13 @@ export interface ActionCatalogEntry {
 
 export async function listActions(accountId: string) {
   return unwrap(
-    await backendApi.get<{ actions: ActionCatalogEntry[] }>(`/accounts/${accountId}/iam/actions`),
+    await iamGet<{ actions: ActionCatalogEntry[] }>(`/accounts/${accountId}/iam/actions`),
   ).actions;
 }
 
 export async function getRoleUsage(accountId: string, roleId: string) {
   return unwrap(
-    await backendApi.get<{ role_id: string; policy_count: number }>(
+    await iamGet<{ role_id: string; policy_count: number }>(
       `/accounts/${accountId}/iam/roles/${roleId}/usage`,
     ),
   );
@@ -473,7 +487,7 @@ export interface CreatedScimToken
 
 export async function listScimTokens(accountId: string) {
   return unwrap(
-    await backendApi.get<{ tokens: ScimToken[] }>(`/accounts/${accountId}/iam/scim/tokens`),
+    await iamGet<{ tokens: ScimToken[] }>(`/accounts/${accountId}/iam/scim/tokens`),
   ).tokens;
 }
 
@@ -519,12 +533,12 @@ export interface MfaRequiredPreview {
 }
 
 export async function getMfaRequired(accountId: string) {
-  return unwrap(await backendApi.get<MfaRequiredStatus>(`/accounts/${accountId}/iam/mfa-required`));
+  return unwrap(await iamGet<MfaRequiredStatus>(`/accounts/${accountId}/iam/mfa-required`));
 }
 
 export async function previewMfaRequired(accountId: string) {
   return unwrap(
-    await backendApi.get<MfaRequiredPreview>(`/accounts/${accountId}/iam/mfa-required/preview`),
+    await iamGet<MfaRequiredPreview>(`/accounts/${accountId}/iam/mfa-required/preview`),
   );
 }
 
@@ -562,7 +576,7 @@ export interface SsoGroupMapping {
 
 export async function getSsoProvider(accountId: string) {
   return unwrap(
-    await backendApi.get<{ provider: SsoProvider | null }>(
+    await iamGet<{ provider: SsoProvider | null }>(
       `/accounts/${accountId}/iam/sso/provider`,
     ),
   ).provider;
@@ -624,7 +638,7 @@ export async function deleteSsoProvider(accountId: string) {
 
 export async function listSsoGroupMappings(accountId: string) {
   return unwrap(
-    await backendApi.get<{ mappings: SsoGroupMapping[] }>(
+    await iamGet<{ mappings: SsoGroupMapping[] }>(
       `/accounts/${accountId}/iam/sso/mappings`,
     ),
   ).mappings;
@@ -670,7 +684,7 @@ export interface ActiveSession {
 }
 
 export async function getSessionPolicy(accountId: string) {
-  return unwrap(await backendApi.get<SessionPolicy>(`/accounts/${accountId}/iam/session-policy`));
+  return unwrap(await iamGet<SessionPolicy>(`/accounts/${accountId}/iam/session-policy`));
 }
 
 export async function updateSessionPolicy(accountId: string, patch: Partial<SessionPolicy>) {
@@ -683,7 +697,7 @@ export async function updateSessionPolicy(accountId: string, patch: Partial<Sess
 
 export async function listAccountSessions(accountId: string) {
   return unwrap(
-    await backendApi.get<{ sessions: ActiveSession[] }>(`/accounts/${accountId}/iam/sessions`),
+    await iamGet<{ sessions: ActiveSession[] }>(`/accounts/${accountId}/iam/sessions`),
   ).sessions;
 }
 
@@ -709,7 +723,7 @@ export interface PatPolicy {
 }
 
 export async function getPatPolicy(accountId: string) {
-  return unwrap(await backendApi.get<PatPolicy>(`/accounts/${accountId}/iam/pat-policy`));
+  return unwrap(await iamGet<PatPolicy>(`/accounts/${accountId}/iam/pat-policy`));
 }
 
 export async function updatePatPolicy(accountId: string, patch: Partial<PatPolicy>) {
@@ -741,7 +755,7 @@ export interface CreatedServiceAccount extends ServiceAccount {
 
 export async function listServiceAccountsApi(accountId: string) {
   return unwrap(
-    await backendApi.get<{ service_accounts: ServiceAccount[] }>(
+    await iamGet<{ service_accounts: ServiceAccount[] }>(
       `/accounts/${accountId}/iam/service-accounts`,
     ),
   ).service_accounts;
@@ -804,7 +818,7 @@ export interface CreatedAuditWebhook extends AuditWebhook {
 
 export async function listAuditWebhooks(accountId: string) {
   return unwrap(
-    await backendApi.get<{ webhooks: AuditWebhook[] }>(`/accounts/${accountId}/audit/webhooks`),
+    await iamGet<{ webhooks: AuditWebhook[] }>(`/accounts/${accountId}/audit/webhooks`),
   ).webhooks;
 }
 
@@ -876,7 +890,7 @@ export async function listAuditEvents(accountId: string, filter: ListAuditFilter
   if (filter.limit) params.set('limit', String(filter.limit));
   const qs = params.toString();
   return unwrap(
-    await backendApi.get<{ events: AuditEvent[]; next_cursor: string | null }>(
+    await iamGet<{ events: AuditEvent[]; next_cursor: string | null }>(
       `/accounts/${accountId}/audit${qs ? `?${qs}` : ''}`,
     ),
   );
@@ -894,7 +908,7 @@ export async function probeEffectivePermission(
   if (args.resourceType) params.set('resourceType', args.resourceType);
   if (args.resourceId) params.set('resourceId', args.resourceId);
   return unwrap(
-    await backendApi.get<EffectivePermissionProbe>(
+    await iamGet<EffectivePermissionProbe>(
       `/accounts/${accountId}/iam/members/${userId}/effective?${params.toString()}`,
     ),
   );
@@ -941,7 +955,7 @@ export async function probeEffectivePermissions(
 
 export async function getEnterpriseDemo(accountId: string): Promise<boolean> {
   return unwrap(
-    await backendApi.get<{ enabled: boolean }>(`/accounts/${accountId}/iam/enterprise-demo`),
+    await iamGet<{ enabled: boolean }>(`/accounts/${accountId}/iam/enterprise-demo`),
   ).enabled;
 }
 

--- a/apps/web/src/lib/project-actions.test.ts
+++ b/apps/web/src/lib/project-actions.test.ts
@@ -8,9 +8,8 @@ import {
 // A `can(action)` that returns true for the given allow-list.
 const canFrom = (allowed: string[]) => (action: string) => allowed.includes(action);
 
-// The read leaves a plain `member` (read-only floor) holds — everything READ,
-// nothing WRITE. (Mirrors PROJECT_ROLE_PERMS.member in the backend.)
-const MEMBER_READS = [
+// A generic set of section READ leaves (agents/skills/commands/connectors/etc.).
+const READS = [
   PROJECT_ACTIONS.PROJECT_READ,
   PROJECT_ACTIONS.PROJECT_AGENT_READ,
   PROJECT_ACTIONS.PROJECT_SKILL_READ,
@@ -19,44 +18,48 @@ const MEMBER_READS = [
   PROJECT_ACTIONS.PROJECT_SECRET_READ,
   PROJECT_ACTIONS.PROJECT_TRIGGER_READ,
   PROJECT_ACTIONS.PROJECT_GITOPS_READ,
-  PROJECT_ACTIONS.PROJECT_FILE_READ,
   PROJECT_ACTIONS.PROJECT_MEMBERS_READ,
 ];
 
-describe('isCustomizeSectionVisible — member vs editor+', () => {
-  test('a member (reads only, no customize.write) sees no customize sections', () => {
-    const can = canFrom(MEMBER_READS);
-    expect(isCustomizeSectionVisible('agents', can)).toBe(false);
-    expect(isCustomizeSectionVisible('connectors', can)).toBe(false);
-    expect(isCustomizeSectionVisible('secrets', can)).toBe(false);
-    expect(isCustomizeSectionVisible('schedules', can)).toBe(false);
-    expect(isCustomizeSectionVisible('members', can)).toBe(false);
-    expect(isCustomizeSectionVisible('settings', can)).toBe(false);
-  });
-
-  test('an editor (has customize.write + the read leaves) sees the customization sections', () => {
-    const can = canFrom([...MEMBER_READS, PROJECT_ACTIONS.PROJECT_CUSTOMIZE_WRITE]);
+describe('isCustomizeSectionVisible — gates on the READ leaf, not write', () => {
+  test('a read-only role (read leaves, NO customize.write) STILL SEES the sections (the bug fix)', () => {
+    // The old rule required project.customize.write for every section → a
+    // read-only / granular role saw a blank panel. Now the read leaf is enough.
+    const can = canFrom(READS); // deliberately no customize.write
     expect(isCustomizeSectionVisible('agents', can)).toBe(true);
     expect(isCustomizeSectionVisible('connectors', can)).toBe(true);
     expect(isCustomizeSectionVisible('secrets', can)).toBe(true);
     expect(isCustomizeSectionVisible('schedules', can)).toBe(true);
-    expect(isCustomizeSectionVisible('webhooks', can)).toBe(true);
     expect(isCustomizeSectionVisible('members', can)).toBe(true);
     expect(isCustomizeSectionVisible('settings', can)).toBe(true);
   });
 
-  test('a custom role omitting a specific read leaf still hides just that section (editor+)', () => {
-    const can = canFrom(
-      [...MEMBER_READS, PROJECT_ACTIONS.PROJECT_CUSTOMIZE_WRITE].filter(
-        (a) => a !== PROJECT_ACTIONS.PROJECT_SECRET_READ,
-      ),
-    );
+  test("the reported role (customize.read + secret.read) sees the sections it can read", () => {
+    const can = canFrom([
+      PROJECT_ACTIONS.PROJECT_READ,
+      PROJECT_ACTIONS.PROJECT_CUSTOMIZE_READ,
+      PROJECT_ACTIONS.PROJECT_SECRET_READ,
+    ]);
+    expect(isCustomizeSectionVisible('secrets', can)).toBe(true); // has secret.read
+    expect(isCustomizeSectionVisible('settings', can)).toBe(true); // gates on project.read
+    expect(isCustomizeSectionVisible('agents', can)).toBe(false); // lacks agent.read
+  });
+
+  test('a role omitting a specific read leaf hides just that section', () => {
+    const can = canFrom(READS.filter((a) => a !== PROJECT_ACTIONS.PROJECT_SECRET_READ));
     expect(isCustomizeSectionVisible('agents', can)).toBe(true);
     expect(isCustomizeSectionVisible('secrets', can)).toBe(false); // read leaf omitted
   });
 
-  test('the probe list includes customize.write + is deduped', () => {
-    expect(CUSTOMIZE_SECTION_GATE_ACTIONS).toContain(PROJECT_ACTIONS.PROJECT_CUSTOMIZE_WRITE);
+  test('a role with NO read leaves sees nothing (empty panel, correctly)', () => {
+    const can = canFrom([]);
+    expect(isCustomizeSectionVisible('agents', can)).toBe(false);
+    expect(isCustomizeSectionVisible('secrets', can)).toBe(false);
+    expect(isCustomizeSectionVisible('settings', can)).toBe(false);
+  });
+
+  test('the probe list is READ leaves only (no customize.write) + deduped', () => {
+    expect(CUSTOMIZE_SECTION_GATE_ACTIONS).not.toContain(PROJECT_ACTIONS.PROJECT_CUSTOMIZE_WRITE);
     expect(new Set(CUSTOMIZE_SECTION_GATE_ACTIONS).size).toBe(CUSTOMIZE_SECTION_GATE_ACTIONS.length);
   });
 });

--- a/apps/web/src/lib/project-actions.ts
+++ b/apps/web/src/lib/project-actions.ts
@@ -150,27 +150,28 @@ export const CUSTOMIZE_SECTION_READ_ACTIONS: readonly ProjectAction[] = Array.fr
 
 /**
  * Whether a section is visible in the rail, given the current user's resolved
- * capabilities (`caps[action].allowed`). Customization is an editor+
- * capability, so a section shows only when the user can customize
- * (`project.customize.write`, i.e. editor or manager) AND still holds that
- * section's own read leaf (so a custom role that omits a read leaf keeps
- * hiding just that section). A plain `member` (read-only floor) lacks
- * customize.write → sees none of them. Files is NOT here — it's the
- * standalone /projects/[id]/files page, reachable by any member.
+ * capabilities (`caps[action].allowed`). Visibility gates on the section's own
+ * READ leaf: a role that can READ a section SEES it — read-only if it lacks the
+ * section's WRITE leaf (the mutating controls inside each view gate on
+ * write / can_manage SEPARATELY). This mirrors the read/write split declared in
+ * CUSTOMIZE_SECTION_ACCESS above and the backend's granular capability model —
+ * so a custom role granted e.g. `secret.read` sees the Secrets section
+ * read-only, and a role that omits a read leaf hides just that one section.
+ * (Previously this ALSO required `project.customize.write`, which blanked the
+ * whole panel for every read-only / granular role — the bug this fixes.) This
+ * is a VISIBILITY layer only; the API re-checks every mutation. Files is NOT
+ * here — it's the standalone /projects/[id]/files page, gated on project.file.read.
  */
 export function isCustomizeSectionVisible(
   s: CustomizeSection,
   can: (action: ProjectAction) => boolean,
 ): boolean {
-  const a = CUSTOMIZE_SECTION_ACCESS[s];
-  return can(PROJECT_ACTIONS.PROJECT_CUSTOMIZE_WRITE) && can(a.read);
+  return can(CUSTOMIZE_SECTION_ACCESS[s].read);
 }
 
-/** Distinct actions to probe for section visibility — every read leaf plus the
- *  editor+ `customize.write` gate — in one batched capability call. */
+/** Distinct READ leaves to probe for section visibility — one batched capability
+ *  call over every section the rail might show. (Edit controls inside each
+ *  section gate separately on can_manage / the section's own write leaf.) */
 export const CUSTOMIZE_SECTION_GATE_ACTIONS: readonly ProjectAction[] = Array.from(
-  new Set<ProjectAction>([
-    ...Object.values(CUSTOMIZE_SECTION_ACCESS).map((a) => a.read),
-    PROJECT_ACTIONS.PROJECT_CUSTOMIZE_WRITE,
-  ]),
+  new Set<ProjectAction>(Object.values(CUSTOMIZE_SECTION_ACCESS).map((a) => a.read)),
 );

--- a/infra/k8s/envs/dev/values.yaml
+++ b/infra/k8s/envs/dev/values.yaml
@@ -6,7 +6,7 @@
 # Immutable dev tag (CI bumps to dev-<sha8> on each main push). Bootstrap value
 # is :dev-latest until the first deploy-dev-eks run pins an immutable sha.
 image:
-  tag: "dev-cb059309"
+  tag: "dev-3468e086"
 kortixVersion: ""
 env:
   internalKortixEnv: dev

--- a/infra/k8s/envs/dev/values.yaml
+++ b/infra/k8s/envs/dev/values.yaml
@@ -6,7 +6,7 @@
 # Immutable dev tag (CI bumps to dev-<sha8> on each main push). Bootstrap value
 # is :dev-latest until the first deploy-dev-eks run pins an immutable sha.
 image:
-  tag: "dev-c5237bfc"
+  tag: "dev-60572652"
 kortixVersion: ""
 env:
   internalKortixEnv: dev

--- a/infra/k8s/envs/dev/values.yaml
+++ b/infra/k8s/envs/dev/values.yaml
@@ -6,7 +6,7 @@
 # Immutable dev tag (CI bumps to dev-<sha8> on each main push). Bootstrap value
 # is :dev-latest until the first deploy-dev-eks run pins an immutable sha.
 image:
-  tag: "dev-aa10200f"
+  tag: "dev-615075e8"
 kortixVersion: ""
 env:
   internalKortixEnv: dev

--- a/infra/k8s/envs/dev/values.yaml
+++ b/infra/k8s/envs/dev/values.yaml
@@ -6,7 +6,7 @@
 # Immutable dev tag (CI bumps to dev-<sha8> on each main push). Bootstrap value
 # is :dev-latest until the first deploy-dev-eks run pins an immutable sha.
 image:
-  tag: "dev-60572652"
+  tag: "dev-cb059309"
 kortixVersion: ""
 env:
   internalKortixEnv: dev

--- a/infra/k8s/envs/dev/values.yaml
+++ b/infra/k8s/envs/dev/values.yaml
@@ -6,7 +6,7 @@
 # Immutable dev tag (CI bumps to dev-<sha8> on each main push). Bootstrap value
 # is :dev-latest until the first deploy-dev-eks run pins an immutable sha.
 image:
-  tag: "dev-615075e8"
+  tag: "dev-c5237bfc"
 kortixVersion: ""
 env:
   internalKortixEnv: dev

--- a/infra/k8s/envs/dev/values.yaml
+++ b/infra/k8s/envs/dev/values.yaml
@@ -6,7 +6,7 @@
 # Immutable dev tag (CI bumps to dev-<sha8> on each main push). Bootstrap value
 # is :dev-latest until the first deploy-dev-eks run pins an immutable sha.
 image:
-  tag: "dev-3468e086"
+  tag: "dev-1a0b95ad"
 kortixVersion: ""
 env:
   internalKortixEnv: dev

--- a/packages/manifest-schema/src/__tests__/format_error_message_bug.test.ts
+++ b/packages/manifest-schema/src/__tests__/format_error_message_bug.test.ts
@@ -1,0 +1,55 @@
+import { describe, test, expect } from 'bun:test';
+import { validateManifest } from '../index';
+
+// Regression: a manifest section-SHAPE error must reference the syntax that fits
+// the FILE'S format. A YAML author who writes `triggers:` as a map/scalar must
+// be told to use a YAML list — never "use `[[triggers]]`" (TOML table-array),
+// and vice-versa. Each `*Bad` input below malforms exactly one section (a
+// single table/map where a list is required) so the list-shape validator fires.
+describe('manifest error messages are format-aware (YAML vs TOML)', () => {
+  const cases = [
+    {
+      name: 'agents',
+      toml: '[[agents]]',
+      yamlBad: `kortix_version: 1\nagents:\n  name: test`,
+      tomlBad: `kortix_version = 1\n[agents]\nname = "test"`,
+    },
+    {
+      name: 'connectors',
+      toml: '[[connectors]]',
+      yamlBad: `kortix_version: 1\nconnectors:\n  name: test`,
+      tomlBad: `kortix_version = 1\n[connectors]\nname = "test"`,
+    },
+    {
+      name: 'triggers',
+      toml: '[[triggers]]',
+      yamlBad: `kortix_version: 1\ntriggers:\n  slug: test`,
+      tomlBad: `kortix_version = 1\n[triggers]\nslug = "test"`,
+    },
+    {
+      name: 'sandbox.templates',
+      toml: '[[sandbox.templates]]',
+      yamlBad: `kortix_version: 1\nsandbox:\n  templates:\n    slug: test`,
+      tomlBad: `kortix_version = 1\n[sandbox.templates]\nslug = "test"`,
+    },
+  ];
+
+  const errText = (input: string, fmt: 'yaml' | 'toml') =>
+    validateManifest(input, fmt)
+      .issues.filter((i) => i.severity === 'error')
+      .map((i) => i.message)
+      .join(' | ');
+
+  for (const c of cases) {
+    test(`${c.name} — YAML shape error says "list", never the TOML ${c.toml}`, () => {
+      const e = errText(c.yamlBad, 'yaml');
+      expect(e).toContain('must be a list');
+      expect(e).not.toContain(c.toml);
+    });
+
+    test(`${c.name} — TOML shape error references ${c.toml}`, () => {
+      const e = errText(c.tomlBad, 'toml');
+      expect(e).toContain(c.toml);
+    });
+  }
+});

--- a/packages/manifest-schema/src/index.ts
+++ b/packages/manifest-schema/src/index.ts
@@ -202,9 +202,9 @@ export function validateManifest(
   const version = validateRoot(parsed, format, issues);
 
   if (version === 2) {
-    validateManifestBodyV2(parsed, issues);
+    validateManifestBodyV2(parsed, format, issues);
   } else {
-    validateManifestBodyV1(parsed, issues);
+    validateManifestBodyV1(parsed, format, issues);
   }
 
   return {
@@ -219,17 +219,21 @@ export function validateManifest(
  * Byte-for-byte the same calls as always; v1 manifests must keep validating
  * identically no matter what v2 support is added alongside it.
  */
-function validateManifestBodyV1(parsed: Record<string, unknown>, issues: ManifestIssue[]): void {
+function validateManifestBodyV1(
+  parsed: Record<string, unknown>,
+  format: ManifestFormat,
+  issues: ManifestIssue[],
+): void {
   validateProject(parsed.project, 'project', issues);
   validateEnv(parsed.env, 'env', issues);
   validateOpenCode(parsed.opencode, 'opencode', issues);
-  validateSandbox(parsed.sandbox, 'sandbox', issues);
+  validateSandbox(parsed.sandbox, 'sandbox', issues, format);
   rejectLegacySandboxes(parsed.sandboxes, 'sandboxes', issues);
-  validateTriggers(parsed.triggers, 'triggers', issues);
-  validateConnectors(parsed.connectors, 'connectors', issues, 1);
-  validateAgents(parsed.agents, 'agents', issues);
-  validateChannels(parsed.channels, 'channels', issues);
-  validateApps(parsed.apps, 'apps', issues);
+  validateTriggers(parsed.triggers, 'triggers', issues, format);
+  validateConnectors(parsed.connectors, 'connectors', issues, 1, format);
+  validateAgents(parsed.agents, 'agents', issues, format);
+  validateChannels(parsed.channels, 'channels', issues, format);
+  validateApps(parsed.apps, 'apps', issues, format);
 }
 
 /**
@@ -239,15 +243,19 @@ function validateManifestBodyV1(parsed: Record<string, unknown>, issues: Manifes
  * is removed (§2.5), and `default_agent` + `runtime` are new top-level keys
  * (§2.1/§2.3).
  */
-function validateManifestBodyV2(parsed: Record<string, unknown>, issues: ManifestIssue[]): void {
+function validateManifestBodyV2(
+  parsed: Record<string, unknown>,
+  format: ManifestFormat,
+  issues: ManifestIssue[],
+): void {
   validateProject(parsed.project, 'project', issues);
   validateEnv(parsed.env, 'env', issues);
   validateOpenCode(parsed.opencode, 'opencode', issues);
-  validateSandbox(parsed.sandbox, 'sandbox', issues);
+  validateSandbox(parsed.sandbox, 'sandbox', issues, format);
   rejectLegacySandboxes(parsed.sandboxes, 'sandboxes', issues);
-  validateTriggers(parsed.triggers, 'triggers', issues);
-  validateConnectors(parsed.connectors, 'connectors', issues, 2);
-  validateApps(parsed.apps, 'apps', issues);
+  validateTriggers(parsed.triggers, 'triggers', issues, format);
+  validateConnectors(parsed.connectors, 'connectors', issues, 2, format);
+  validateApps(parsed.apps, 'apps', issues, format);
   rejectChannelsV2(parsed.channels, 'channels', issues);
   validateRuntimeV2(parsed.runtime, 'runtime', issues);
   const { names: agentNames, disabledNames } = validateAgentsV2(parsed.agents, 'agents', issues);
@@ -268,6 +276,19 @@ export function formatIssues(issues: ManifestIssue[], opts: { color?: boolean } 
       return `  ${tag} ${dim(i.path)}: ${i.message}${where}`;
     })
     .join('\n');
+}
+
+/**
+ * A format-appropriate "this section must be a list" hint. Legacy TOML uses
+ * `[[key]]` table-arrays; YAML (every v2 manifest, and any v1 YAML) uses a
+ * plain `key:` list — so a YAML author who malforms a section should never be
+ * told to "use `[[triggers]]`". Defaults to TOML so v1 TOML messages stay
+ * byte-for-byte identical.
+ */
+function listSectionHint(key: string, format: ManifestFormat = 'toml'): string {
+  return format === 'yaml'
+    ? `\`${key}\` must be a list of entries — write it as a YAML \`${key}:\` list, not a map or scalar.`
+    : `\`${key}\` must be an array of tables — use \`[[${key}]]\`.`;
 }
 
 // ─── Section validators ───────────────────────────────────────────────────
@@ -348,12 +369,12 @@ export function validateGrantList(
 }
 
 /** `[[agents]]` — the per-agent scoping overlay (name + connectors + kortix_cli). */
-function validateAgents(node: unknown, path: string, issues: ManifestIssue[]): void {
+function validateAgents(node: unknown, path: string, issues: ManifestIssue[], format: ManifestFormat = 'toml'): void {
   if (node == null) return;
   if (!Array.isArray(node)) {
     issues.push({
       path,
-      message: '`agents` must be an array of tables — use `[[agents]]`.',
+      message: listSectionHint('agents', format),
       severity: 'error',
     });
     return;
@@ -516,7 +537,7 @@ function validateOpenCode(node: unknown, path: string, issues: ManifestIssue[]):
  * carries no direct image keys — those belonged to the removed singular
  * `[sandbox]` table, so any that linger are flagged as legacy.
  */
-function validateSandbox(node: unknown, path: string, issues: ManifestIssue[]): void {
+function validateSandbox(node: unknown, path: string, issues: ManifestIssue[], format: ManifestFormat = 'toml'): void {
   if (node == null) return;
   if (!isTable(node)) {
     issues.push({
@@ -538,7 +559,7 @@ function validateSandbox(node: unknown, path: string, issues: ManifestIssue[]): 
       severity: 'error',
     });
   }
-  validateSandboxTemplates(node.templates, `${path}.templates`, issues);
+  validateSandboxTemplates(node.templates, `${path}.templates`, issues, format);
 
   // `default` selects which template EVERY session in the project boots
   // (UI, triggers, channels) without passing `sandbox_slug`. It must name a
@@ -573,13 +594,13 @@ function validateSandbox(node: unknown, path: string, issues: ManifestIssue[]): 
   }
 }
 
-function validateSandboxTemplates(node: unknown, path: string, issues: ManifestIssue[]): void {
+function validateSandboxTemplates(node: unknown, path: string, issues: ManifestIssue[], format: ManifestFormat = 'toml'): void {
   if (node == null) return;
   if (!Array.isArray(node)) {
     issues.push({
       path,
       message:
-        '`sandbox.templates` must be an array of tables — use `[[sandbox.templates]]`, not `[sandbox.templates]`.',
+        listSectionHint('sandbox.templates', format),
       severity: 'error',
     });
     return;
@@ -685,12 +706,12 @@ function rejectLegacySandboxes(node: unknown, path: string, issues: ManifestIssu
   });
 }
 
-function validateTriggers(node: unknown, path: string, issues: ManifestIssue[]): void {
+function validateTriggers(node: unknown, path: string, issues: ManifestIssue[], format: ManifestFormat = 'toml'): void {
   if (node == null) return;
   if (!Array.isArray(node)) {
     issues.push({
       path,
-      message: '`triggers` must be an array of tables — use `[[triggers]]`.',
+      message: listSectionHint('triggers', format),
       severity: 'error',
     });
     return;
@@ -841,12 +862,12 @@ function validateTriggers(node: unknown, path: string, issues: ManifestIssue[]):
   });
 }
 
-function validateConnectors(node: unknown, path: string, issues: ManifestIssue[], version: 1 | 2 = 1): void {
+function validateConnectors(node: unknown, path: string, issues: ManifestIssue[], version: 1 | 2 = 1, format: ManifestFormat = 'toml'): void {
   if (node == null) return;
   if (!Array.isArray(node)) {
     issues.push({
       path,
-      message: '`connectors` must be an array of tables — use `[[connectors]]`.',
+      message: listSectionHint('connectors', format),
       severity: 'error',
     });
     return;
@@ -1107,12 +1128,12 @@ function validateConnectors(node: unknown, path: string, issues: ManifestIssue[]
   });
 }
 
-function validateChannels(node: unknown, path: string, issues: ManifestIssue[]): void {
+function validateChannels(node: unknown, path: string, issues: ManifestIssue[], format: ManifestFormat = 'toml'): void {
   if (node == null) return;
   if (!Array.isArray(node)) {
     issues.push({
       path,
-      message: '`channels` must be an array of tables — use `[[channels]]`.',
+      message: listSectionHint('channels', format),
       severity: 'error',
     });
     return;
@@ -1169,12 +1190,12 @@ function validateChannels(node: unknown, path: string, issues: ManifestIssue[]):
   });
 }
 
-function validateApps(node: unknown, path: string, issues: ManifestIssue[]): void {
+function validateApps(node: unknown, path: string, issues: ManifestIssue[], format: ManifestFormat = 'toml'): void {
   if (node == null) return;
   if (!Array.isArray(node)) {
     issues.push({
       path,
-      message: '`apps` must be an array of tables — use `[[apps]]`.',
+      message: listSectionHint('apps', format),
       severity: 'error',
     });
     return;

--- a/packages/sdk/src/platform/projects-client/sandbox.ts
+++ b/packages/sdk/src/platform/projects-client/sandbox.ts
@@ -9,7 +9,10 @@ import { unwrap } from './shared';
 export type ProjectSnapshotStatus = 'building' | 'ready' | 'failed';
 
 /** Classified reason a snapshot build failed. */
+/** Mirrors apps/api/src/snapshots/error-classify.ts — keep in sync. */
 export type SnapshotErrorCategory =
+  /** Daytona org snapshot quota exhausted — infra, not repo-fixable. */
+  | 'quota'
   | 'dockerfile'
   | 'tunnel'
   | 'provider'
@@ -17,6 +20,7 @@ export type SnapshotErrorCategory =
   | 'runtime'
   | 'git'
   | 'unknown';
+
 
 /** A sandbox template: platform default + each `[[sandbox.templates]]` / UI-created entry. */
 export interface SandboxTemplate {
@@ -61,12 +65,21 @@ export interface SandboxTemplatesResponse {
 
 export interface ProjectSnapshotBuild {
   build_id: string;
+  /**
+   * The build-log slug. For a warm bake this is `<template>-warm`, which names NO
+   * template. Never feed this back to an API that expects a template slug — use
+   * `template_slug`.
+   */
   slug: string;
+  /** The template this build was for. Safe to pass to rebuild / session create. */
+  template_slug: string;
   snapshot_name: string;
   content_hash: string;
   status: ProjectSnapshotStatus;
   error: string | null;
   error_category: SnapshotErrorCategory | null;
+  /** Server-derived: can an in-sandbox agent plausibly fix this by editing the repo? */
+  fixable_by_agent: boolean;
   source: 'session-start' | 'project-create' | 'cr-merge' | 'manual' | 'background' | 'startup' | null;
   started_at: string;
   finished_at: string | null;


### PR DESCRIPTION
Promote `main` → `staging` (8 commits).

## Why now
Staging hit `Snapshot quota exceeded. Maximum allowed: 100`. I reclaimed the Daytona org quota by hand (120 → 68 snapshots) and rebuilt staging's platform default (`kortix-default-ccb374fbbeb3`, now `active`), so staging is **already healthy**. This promote ships the *code* fixes so the recovery paths work the next time.

## What's in it

**#4320 — snapshot fixes** (the reason for this promote)
- `Retry build` → 502 on every base-build failure. `default-warm` is a build-log pseudo-slug that names no template; it was fed straight back into template resolution. Fixed, and an unknown slug is now `404` instead of `502`.
- `Fix with agent` → 400. Same root cause (`sandbox_slug: 'default-warm'`), plus it was offered for `quota` failures — infra the agent can't fix, and the fix session needs the very snapshot the quota denied. Now `409 NOT_AGENT_FIXABLE`, hidden in the UI via a server-derived `fixable_by_agent`.
- `quota-gc` could never fire in time: its pressure gate counted only `default-`/`tpl-`/`wproj-` (15 of 68 snapshots) while the Daytona quota counts all of them. Now gated on the org total, with defaults ranked by freshness rather than an idle rule that made zero of them eligible.

**#4275, #4279, #4282 — IAM capability gating** (already on dev, riding along)
- gate ungated project endpoints on their capability leaves
- `members.manage` routes gate on the leaf, not a `project.write` floor
- trigger fire floors `read` so the floor member role can fire
- `GET /detail` filters sections by read capability instead of leaking them

## Verification so far
- CI on #4320: 17/17 pass. `bun test` 29/29. `tsc --noEmit` clean on api / sdk / web.
- Prod (same shared Daytona org): 25 quota-failed builds in the preceding 24h → 0 failures and 4 `ready` builds since the reclaim.
- Staging default snapshot rebuilt and `active`; `ready` derives from live provider state, so the sidebar alert clears.

After deploy I'll verify on staging that `Retry build` returns `202` and that `Fix with agent` is suppressed for a quota failure.