### PR TITLE
fix(snapshots): bound the ppwarm cache, and alarm when GC can't keep up

### DIFF
--- a/apps/api/src/__tests__/unit-quota-gc-select.test.ts
+++ b/apps/api/src/__tests__/unit-quota-gc-select.test.ts
@@ -4,6 +4,7 @@ import {
   QUOTA_GC_KEEP_FRESHEST_DEFAULTS,
   QUOTA_GC_MAX_PER_PASS,
   QUOTA_GC_ORG_HIGH_WATER,
+  QUOTA_GC_ORG_TARGET,
   type SnapshotLike,
   selectSnapshotsToReap,
 } from '../snapshots/quota-gc-select';
@@ -130,6 +131,11 @@ describe('selectSnapshotsToReap — safety invariants', () => {
     expect(names(run(all))).toContain('kortix-default-bad');
   });
 
+  // These two isolate the LIVENESS rules, so the org sits under QUOTA_GC_ORG_TARGET
+  // (still over the high-water mark). Above target the budget stage legitimately
+  // evicts idle ppwarm tips these cases expect to survive — covered separately below.
+  const UNDER_TARGET = QUOTA_GC_ORG_TARGET - 1;
+
   it('keeps the freshest ppwarm tip per project and reaps its stragglers', () => {
     const all = padToOrgSize(
       [
@@ -138,7 +144,7 @@ describe('selectSnapshotsToReap — safety invariants', () => {
         snap('kortix-ppwarm-0945686d-older', { lastUsedAt: ago(3) }),
         snap('kortix-ppwarm-ffffffff-solo', { lastUsedAt: ago(5) }),
       ],
-      90,
+      UNDER_TARGET,
     );
     const reaped = names(run(all));
     expect(reaped).not.toContain('kortix-ppwarm-0945686d-new');
@@ -156,7 +162,7 @@ describe('selectSnapshotsToReap — safety invariants', () => {
         snap('kortix-ppwarm-aaaaaaaa-stale', { lastUsedAt: ago(20) }),
         snap('kortix-ppwarm-bbbbbbbb-fresh', { lastUsedAt: ago(2) }),
       ],
-      90,
+      UNDER_TARGET,
     );
     const reaped = names(run(all));
     expect(reaped).toContain('kortix-ppwarm-aaaaaaaa-stale');
@@ -179,5 +185,76 @@ describe('selectSnapshotsToReap — safety invariants', () => {
     expect(res.doomed.length).toBe(QUOTA_GC_MAX_PER_PASS);
     // 60 defaults, freshest 12 kept → 48 reapable, 15 this pass, 33 deferred.
     expect(res.deferred).toBe(48 - QUOTA_GC_MAX_PER_PASS);
+  });
+});
+
+/**
+ * The live shape on 2026-07-08: 69 ppwarm tips for 69 distinct, non-archived
+ * projects + 22 stock images + 13 defaults + 3 templates = 107, over the 100 cap.
+ * Every liveness rule reclaims nothing (each tip is a live project's only tip), so
+ * a purely liveness-based GC sat at 100% pressure doing nothing. ppwarm is a pure
+ * cache, so it must absorb budget pressure — or say it cannot.
+ */
+describe('selectSnapshotsToReap — ppwarm LRU budget', () => {
+  const liveOrg = (ppwarmCount: number, idleHours: number) =>
+    padToOrgSize(
+      [
+        ...Array.from({ length: ppwarmCount }, (_, i) =>
+          // distinct proj8 per tip → no "superseded tip" rule can fire
+          snap(`kortix-ppwarm-${i.toString(16).padStart(8, '0')}-tip`, {
+            lastUsedAt: new Date(NOW - idleHours * 3_600_000).toISOString(),
+          }),
+        ),
+        ...Array.from({ length: 12 }, (_, i) =>
+          snap(`kortix-default-${i}`, { lastUsedAt: ago(0) }),
+        ),
+      ],
+      107,
+    );
+
+  it('evicts LRU ppwarm to reach target when no liveness rule can free anything', () => {
+    const res = run(liveOrg(69, 30));
+    expect(res.orgTotal).toBe(107);
+    expect(res.underPressure).toBe(true);
+    expect(res.doomed.length).toBeGreaterThan(0);
+    expect(res.doomed.every((d) => d.snapshot.name.startsWith('kortix-ppwarm-'))).toBe(true);
+    expect(res.doomed.some((d) => d.reason.includes('LRU eviction'))).toBe(true);
+    expect(res.budgetUnresolved).toBe(false);
+  });
+
+  it('evicts oldest-first', () => {
+    const all = padToOrgSize(
+      [
+        snap('kortix-ppwarm-aaaaaaaa-tip', {
+          lastUsedAt: new Date(NOW - 50 * 3_600_000).toISOString(),
+        }),
+        snap('kortix-ppwarm-bbbbbbbb-tip', {
+          lastUsedAt: new Date(NOW - 10 * 3_600_000).toISOString(),
+        }),
+      ],
+      QUOTA_GC_ORG_TARGET + 1,
+    );
+    const reaped = names(run(all));
+    expect(reaped).toContain('kortix-ppwarm-aaaaaaaa-tip');
+    expect(reaped).not.toContain('kortix-ppwarm-bbbbbbbb-tip');
+  });
+
+  // Evicting a hot project's tip frees a slot it reclaims on its next session:
+  // churn, not reclamation.
+  it('never evicts a recently-used ppwarm tip, even under pressure', () => {
+    const res = run(liveOrg(69, 1)); // every tip used an hour ago
+    expect(res.underPressure).toBe(true);
+    expect(res.doomed.every((d) => !d.reason.includes('LRU eviction'))).toBe(true);
+  });
+
+  // The alarm that would have caught the original outage: GC out of road.
+  it('flags budgetUnresolved when the cache floor exceeds the quota', () => {
+    const res = run(liveOrg(69, 1)); // nothing evictable, still 107 > target
+    expect(res.budgetUnresolved).toBe(true);
+  });
+
+  it('does not flag budgetUnresolved once target is reachable', () => {
+    const res = run(liveOrg(69, 30));
+    expect(res.budgetUnresolved).toBe(false);
   });
 });

--- a/apps/api/src/projects/maintenance.test.ts
+++ b/apps/api/src/projects/maintenance.test.ts
@@ -25,23 +25,50 @@ mock.module('../shared/db', () => ({
   },
 }));
 mock.module('./git', () => ({ deleteRemoteSessionBranch: async () => false }));
-mock.module('../billing/services/compute-metering', () => ({ tickRunningComputeCharges: async () => ({ settled: 0 }) }));
-mock.module('../snapshots/builder', () => ({ reconcileStaleBuilds: async () => ({ checked: 0, closedReady: 0, closedFailed: 0 }) }));
-mock.module('../snapshots/quota-gc', () => ({ reconcileSnapshotQuota: async () => ({ orgTotal: 0, managedCount: 0, eligible: 0, deleted: 0, deferred: 0, dryRun: false }) }));
+mock.module('../billing/services/compute-metering', () => ({
+  tickRunningComputeCharges: async () => ({ settled: 0 }),
+}));
+mock.module('../snapshots/builder', () => ({
+  reconcileStaleBuilds: async () => ({ checked: 0, closedReady: 0, closedFailed: 0 }),
+}));
+mock.module('../snapshots/quota-gc', () => ({
+  reconcileSnapshotQuota: async () => ({
+    orgTotal: 0,
+    managedCount: 0,
+    eligible: 0,
+    deleted: 0,
+    deferred: 0,
+    budgetUnresolved: false,
+    dryRun: false,
+  }),
+}));
 // Controllable per-test: the first call can be made to hang forever (to
 // simulate the exact 2026-07-02 failure mode — an unbounded provider call
 // stuck inside reapAndReconcileSandboxes), later calls resolve normally.
-let reapAndReconcileSandboxesImpl = async () => ({ candidates: 0, stopped: 0, reconciled: 0, billingClosed: 0, skipped: 0, errors: 0 });
+let reapAndReconcileSandboxesImpl = async () => ({
+  candidates: 0,
+  stopped: 0,
+  reconciled: 0,
+  billingClosed: 0,
+  skipped: 0,
+  errors: 0,
+});
 
 mock.module('./sandbox-reaper', () => ({
   reapAndReconcileSandboxes: () => reapAndReconcileSandboxesImpl(),
   reconcileOrphanComputeSessions: async () => ({ checked: 0, closed: 0, errors: 0 }),
-  reconcileStuckActiveSessions: async () => ({ candidates: 0, reconciled: 0, billingClosed: 0, errors: 0 }),
+  reconcileStuckActiveSessions: async () => ({
+    candidates: 0,
+    reconciled: 0,
+    billingClosed: 0,
+    errors: 0,
+  }),
   reapOrphanProviderBoxes: async () => ({ listed: 0, orphans: 0, stopped: 0, errors: 0 }),
   countBillingInvariantViolations: async () => 0,
 }));
 
-const { shouldForceResetStaleLock, runProjectMaintenance, __isMaintenanceRunningForTest } = await import('./maintenance');
+const { shouldForceResetStaleLock, runProjectMaintenance, __isMaintenanceRunningForTest } =
+  await import('./maintenance');
 
 // Regression coverage for the 2026-07-02 incident: an unbounded Daytona SDK
 // call inside a maintenance cycle left `maintenanceRunning` stuck `true`
@@ -85,7 +112,7 @@ describe('shouldForceResetStaleLock', () => {
 // THIRD cycle start concurrently. The fix gates the `finally` release on a
 // generation counter so only the run that's still current can release it.
 describe('runProjectMaintenance stale-lock generation guard', () => {
-  test('an abandoned run settling late does not release a newer run\'s lock', async () => {
+  test("an abandoned run settling late does not release a newer run's lock", async () => {
     process.env.KORTIX_PROJECT_MAINTENANCE_STALL_MS = '20';
 
     let releaseHungRun: () => void = () => {};
@@ -95,7 +122,14 @@ describe('runProjectMaintenance stale-lock generation guard', () => {
 
     // Run A: hangs until we explicitly release it.
     reapAndReconcileSandboxesImpl = () =>
-      hungRunSettled.then(() => ({ candidates: 0, stopped: 0, reconciled: 0, billingClosed: 0, skipped: 0, errors: 0 }));
+      hungRunSettled.then(() => ({
+        candidates: 0,
+        stopped: 0,
+        reconciled: 0,
+        billingClosed: 0,
+        skipped: 0,
+        errors: 0,
+      }));
     const runA = runProjectMaintenance();
 
     // Let run A acquire the lock before we try to stall past the threshold.
@@ -105,7 +139,14 @@ describe('runProjectMaintenance stale-lock generation guard', () => {
     // Wait past the (tiny, test-only) stall threshold, then start run B —
     // this is the watchdog force-reset path.
     await new Promise((r) => setTimeout(r, 30));
-    reapAndReconcileSandboxesImpl = async () => ({ candidates: 0, stopped: 0, reconciled: 0, billingClosed: 0, skipped: 0, errors: 0 });
+    reapAndReconcileSandboxesImpl = async () => ({
+      candidates: 0,
+      stopped: 0,
+      reconciled: 0,
+      billingClosed: 0,
+      skipped: 0,
+      errors: 0,
+    });
     const errorSpy = mock((..._args: unknown[]) => {});
     const originalError = console.error;
     console.error = errorSpy;

--- a/apps/api/src/projects/maintenance.ts
+++ b/apps/api/src/projects/maintenance.ts
@@ -1,16 +1,16 @@
-import { and, eq, inArray, lt, ne } from 'drizzle-orm';
 import { projectSessions, projects } from '@kortix/db';
-import { db } from '../shared/db';
-import { deleteRemoteSessionBranch, type GitBackedProject } from './git';
+import { and, eq, inArray, lt, ne } from 'drizzle-orm';
 import { tickRunningComputeCharges } from '../billing/services/compute-metering';
+import { db } from '../shared/db';
 import { reconcileStaleBuilds } from '../snapshots/builder';
 import { reconcileSnapshotQuota } from '../snapshots/quota-gc';
+import { type GitBackedProject, deleteRemoteSessionBranch } from './git';
 import {
+  countBillingInvariantViolations,
   reapAndReconcileSandboxes,
+  reapOrphanProviderBoxes,
   reconcileOrphanComputeSessions,
   reconcileStuckActiveSessions,
-  reapOrphanProviderBoxes,
-  countBillingInvariantViolations,
 } from './sandbox-reaper';
 
 const DEFAULT_BRANCH_RETENTION_DAYS = 90;
@@ -50,7 +50,10 @@ function branchRetentionDays(): number {
 }
 
 function maintenanceIntervalMs(): number {
-  return positiveInt(process.env.KORTIX_PROJECT_MAINTENANCE_INTERVAL_MS, DEFAULT_MAINTENANCE_INTERVAL_MS);
+  return positiveInt(
+    process.env.KORTIX_PROJECT_MAINTENANCE_INTERVAL_MS,
+    DEFAULT_MAINTENANCE_INTERVAL_MS,
+  );
 }
 
 // STALL WATCHDOG — the second, independent line of defense against this exact
@@ -74,7 +77,9 @@ export function shouldForceResetStaleLock(heldForMs: number, thresholdMs: number
   return heldForMs >= thresholdMs;
 }
 
-export function hasOpenPullRequestMarker(metadata: Record<string, unknown> | null | undefined): boolean {
+export function hasOpenPullRequestMarker(
+  metadata: Record<string, unknown> | null | undefined,
+): boolean {
   if (!metadata) return false;
   if (metadata.open_pr === true || metadata.has_open_pr === true) return true;
   for (const key of ['pull_request', 'github_pull_request', 'pr']) {
@@ -117,11 +122,13 @@ export async function sweepExpiredSessionBranches(now = new Date()): Promise<{
     })
     .from(projectSessions)
     .innerJoin(projects, eq(projectSessions.projectId, projects.projectId))
-    .where(and(
-      inArray(projectSessions.status, [...TERMINAL_SESSION_STATUSES]),
-      lt(projectSessions.updatedAt, cutoff),
-      ne(projectSessions.branchName, projects.defaultBranch),
-    ))
+    .where(
+      and(
+        inArray(projectSessions.status, [...TERMINAL_SESSION_STATUSES]),
+        lt(projectSessions.updatedAt, cutoff),
+        ne(projectSessions.branchName, projects.defaultBranch),
+      ),
+    )
     .limit(GC_BATCH_SIZE);
 
   let deleted = 0;
@@ -190,24 +197,46 @@ export async function runProjectMaintenance(): Promise<void> {
     // below so it can no longer clobber this (or a later) run's lock.
     console.error(
       `[project-maintenance] STALLED — lock held for ${heldForMs}ms (threshold ${stallThresholdMs()}ms), forcing reset. ` +
-      'This means a prior cycle hung on an unbounded call — file a bug, this should not happen with all provider calls timeout-bounded.',
+        'This means a prior cycle hung on an unbounded call — file a bug, this should not happen with all provider calls timeout-bounded.',
     );
   }
   const myGeneration = ++maintenanceGeneration;
   maintenanceRunning = true;
   maintenanceStartedAt = Date.now();
   try {
-    const [idle, orphanCompute, stuckSessions, orphanBoxes, branches, computeTick, staleBuilds, snapshotGc] = await Promise.all([
+    const [
+      idle,
+      orphanCompute,
+      stuckSessions,
+      orphanBoxes,
+      branches,
+      computeTick,
+      staleBuilds,
+      snapshotGc,
+    ] = await Promise.all([
       // Provider-authoritative idle reaper + state/billing reconcile (the fix for
       // boxes that never auto-stopped and kept billing). Backstops the webhooks.
       reapAndReconcileSandboxes().catch((err) => {
-        console.warn('[project-maintenance] reaper failed:', err instanceof Error ? err.message : err);
-        return { candidates: 0, stopped: 0, reconciled: 0, billingClosed: 0, skipped: 0, errors: 0 };
+        console.warn(
+          '[project-maintenance] reaper failed:',
+          err instanceof Error ? err.message : err,
+        );
+        return {
+          candidates: 0,
+          stopped: 0,
+          reconciled: 0,
+          billingClosed: 0,
+          skipped: 0,
+          errors: 0,
+        };
       }),
       // Billing safety net: close metering for any active compute row whose box
       // is not actually running (catches orphans / missed webhooks).
       reconcileOrphanComputeSessions().catch((err) => {
-        console.warn('[project-maintenance] orphan-compute reconcile failed:', err instanceof Error ? err.message : err);
+        console.warn(
+          '[project-maintenance] orphan-compute reconcile failed:',
+          err instanceof Error ? err.message : err,
+        );
         return { checked: 0, closed: 0, errors: 0 };
       }),
       // Session-side leak fix: reconcile project_sessions stuck in an ACTIVE
@@ -216,47 +245,88 @@ export async function runProjectMaintenance(): Promise<void> {
       // account's concurrent-session cap fills up and wedges Slack. DB-only, so
       // it drains the cap even while Daytona is throttling the box reaper.
       reconcileStuckActiveSessions().catch((err) => {
-        console.warn('[project-maintenance] stuck-session reconcile failed:', err instanceof Error ? err.message : err);
+        console.warn(
+          '[project-maintenance] stuck-session reconcile failed:',
+          err instanceof Error ? err.message : err,
+        );
         return { candidates: 0, reconciled: 0, billingClosed: 0, errors: 0 };
       }),
       // Provider-authoritative orphan-BOX reaper: stops boxes still running on
       // the provider (this env) with no live DB row — the leak the DB-driven
       // reaper above structurally can't see. STOP-only, label-scoped, age-gated.
       reapOrphanProviderBoxes().catch((err) => {
-        console.warn('[project-maintenance] orphan-box reaper failed:', err instanceof Error ? err.message : err);
+        console.warn(
+          '[project-maintenance] orphan-box reaper failed:',
+          err instanceof Error ? err.message : err,
+        );
         return { listed: 0, orphans: 0, stopped: 0, errors: 0 };
       }),
       sweepExpiredSessionBranches(),
       // Billing v2 — partial-bill any active compute sessions that haven't
       // settled in > 1h, so a missed stop hook can't accrue uncharged compute.
       tickRunningComputeCharges().catch((err) => {
-        console.warn('[project-maintenance] compute tick failed:', err instanceof Error ? err.message : err);
+        console.warn(
+          '[project-maintenance] compute tick failed:',
+          err instanceof Error ? err.message : err,
+        );
         return { settled: 0 };
       }),
       // Heal snapshot build-log rows orphaned at "building" by a process
       // restart/crash, globally across all projects.
       reconcileStaleBuilds().catch((err) => {
-        console.warn('[project-maintenance] stale-build reconcile failed:', err instanceof Error ? err.message : err);
+        console.warn(
+          '[project-maintenance] stale-build reconcile failed:',
+          err instanceof Error ? err.message : err,
+        );
         return { checked: 0, closedReady: 0, closedFailed: 0 };
       }),
       // GC superseded template snapshots (content-addressed names orphaned by
       // every identity drift) before the 100/org Daytona quota fills up.
       // Pressure-gated + bounded; no-op while the ORG total is small.
       reconcileSnapshotQuota().catch((err) => {
-        console.warn('[project-maintenance] snapshot quota GC failed:', err instanceof Error ? err.message : err);
-        return { orgTotal: 0, managedCount: 0, eligible: 0, deleted: 0, deferred: 0, dryRun: false };
+        console.warn(
+          '[project-maintenance] snapshot quota GC failed:',
+          err instanceof Error ? err.message : err,
+        );
+        return {
+          orgTotal: 0,
+          managedCount: 0,
+          eligible: 0,
+          deleted: 0,
+          deferred: 0,
+          budgetUnresolved: false,
+          dryRun: false,
+        };
       }),
     ]);
     const hadAction = Boolean(
-      idle.stopped || idle.reconciled || idle.errors || orphanCompute.closed || orphanCompute.errors ||
-      stuckSessions.reconciled || stuckSessions.errors ||
-      orphanBoxes.stopped || orphanBoxes.errors ||
-      branches.deleted || branches.errors ||
-      computeTick.settled || staleBuilds.closedReady || staleBuilds.closedFailed ||
-      snapshotGc.deleted,
+      idle.stopped ||
+        idle.reconciled ||
+        idle.errors ||
+        orphanCompute.closed ||
+        orphanCompute.errors ||
+        stuckSessions.reconciled ||
+        stuckSessions.errors ||
+        orphanBoxes.stopped ||
+        orphanBoxes.errors ||
+        branches.deleted ||
+        branches.errors ||
+        computeTick.settled ||
+        staleBuilds.closedReady ||
+        staleBuilds.closedFailed ||
+        snapshotGc.deleted,
     );
     if (hadAction) {
-      console.log('[project-maintenance] completed', { idle, orphanCompute, stuckSessions, orphanBoxes, branches, computeTick, staleBuilds, snapshotGc });
+      console.log('[project-maintenance] completed', {
+        idle,
+        orphanCompute,
+        stuckSessions,
+        orphanBoxes,
+        branches,
+        computeTick,
+        staleBuilds,
+        snapshotGc,
+      });
     }
     // Unconditional heartbeat — proof-of-life independent of whether any
     // action happened. A stuck lock (see the watchdog above) produces total
@@ -266,7 +336,9 @@ export async function runProjectMaintenance(): Promise<void> {
     // the 2026-07-02 incident went undetected for hours. This line is cheap
     // (one per cycle, ~every 5min) and makes "the loop is alive" observable —
     // wire an alert on its absence for N cycles instead of trusting silence.
-    console.log(`[project-maintenance] heartbeat idle_candidates=${idle.candidates} action=${hadAction}`);
+    console.log(
+      `[project-maintenance] heartbeat idle_candidates=${idle.candidates} action=${hadAction}`,
+    );
 
     // Invariant monitor: in steady state, every `active` compute session has a
     // running box. A non-zero count means billing is leaking — make it loud so a
@@ -274,10 +346,15 @@ export async function runProjectMaintenance(): Promise<void> {
     try {
       const billingLeak = await countBillingInvariantViolations();
       if (billingLeak > 0) {
-        console.warn(`[project-maintenance] BILLING INVARIANT VIOLATED: ${billingLeak} active compute session(s) with a non-running box`);
+        console.warn(
+          `[project-maintenance] BILLING INVARIANT VIOLATED: ${billingLeak} active compute session(s) with a non-running box`,
+        );
       }
     } catch (err) {
-      console.warn('[project-maintenance] billing invariant check failed:', err instanceof Error ? err.message : err);
+      console.warn(
+        '[project-maintenance] billing invariant check failed:',
+        err instanceof Error ? err.message : err,
+      );
     }
   } finally {
     // Only the run that's still current may release the lock — see

--- a/apps/api/src/snapshots/quota-gc-select.ts
+++ b/apps/api/src/snapshots/quota-gc-select.ts
@@ -32,6 +32,23 @@
  * mean the project is gone — it may be another environment's. `lastUsedAt` is the
  * only cross-env liveness signal we have, and it is the sole basis on which a
  * ppwarm tip belonging to nobody-we-know is reclaimed.
+ *
+ * ── Why ppwarm needs an LRU budget, not just a liveness rule ────────────────
+ * `kortix-ppwarm-<proj8>-<hash>` is minted unconditionally on session-start of the
+ * shared default (builder.ts), one live tip per project. So the cache's floor is the
+ * number of projects that have ever started a session. Measured 2026-07-08: 69 tips
+ * for 69 distinct, non-archived projects — 69 of the org's 100 slots, before a single
+ * default or user template. Liveness rules reclaim NOTHING there (every tip is a live
+ * project's only tip), so a purely liveness-based GC sits at 100% pressure doing
+ * nothing, which is exactly the outage we hit.
+ *
+ * ppwarm is a pure CACHE — evicting a tip costs one cold boot plus a re-bake, never
+ * data — so it is the namespace that absorbs budget pressure. Evict LRU until the org
+ * is back at target, skipping recently-used tips (they'd re-bake at once: churn, not
+ * reclamation). When even that can't reach target, `budgetUnresolved` is set so the
+ * caller can alarm — a GC that silently can't keep up is how this failed the first
+ * time. The real remedy at that point is capacity (raise the org snapshot quota) or
+ * gating the warm bake; GC can only buy time.
  */
 
 /** The Daytona org-wide snapshot cap. Counts every snapshot, ours or not. */
@@ -39,6 +56,9 @@ export const DAYTONA_ORG_SNAPSHOT_LIMIT = 100;
 
 /** Start reclaiming once the ORG total reaches this. Leaves room to act before builds fail. */
 export const QUOTA_GC_ORG_HIGH_WATER = 80;
+
+/** Once reclaiming, free down to here — a buffer, not just back under the high-water mark. */
+export const QUOTA_GC_ORG_TARGET = 85;
 
 /** Live env defaults are booted constantly, so they're always in the freshest set. */
 export const QUOTA_GC_KEEP_FRESHEST_DEFAULTS = 12;
@@ -51,6 +71,13 @@ export const QUOTA_GC_MIN_IDLE_MS = 7 * 24 * 60 * 60 * 1000;
  * it is. Cross-env safe: any environment still booting from it keeps lastUsedAt fresh.
  */
 export const QUOTA_GC_PPWARM_MAX_IDLE_MS = 14 * 24 * 60 * 60 * 1000;
+
+/**
+ * Under budget pressure, ppwarm tips are evicted LRU — but never one used this
+ * recently. An actively-used project would simply re-bake on its next session, so
+ * evicting it is churn (a slot freed and immediately reclaimed), not reclamation.
+ */
+export const QUOTA_GC_PPWARM_EVICT_PROTECT_MS = 6 * 60 * 60 * 1000;
 
 /** Max deletions per sweep pass — keeps each pass cheap and observable. */
 export const QUOTA_GC_MAX_PER_PASS = 15;
@@ -102,6 +129,13 @@ export interface SelectResult {
   doomed: ReapCandidate[];
   /** Reapable but dropped by the per-pass cap — logged so truncation is never silent. */
   deferred: number;
+  /**
+   * True when, even after evicting every eligible ppwarm tip, the org still can't
+   * reach QUOTA_GC_ORG_TARGET. The cache floor (one tip per active project) has
+   * outgrown the quota: GC cannot fix this, only capacity or a warm-bake gate can.
+   * Callers MUST surface this rather than log a quiet no-op.
+   */
+  budgetUnresolved: boolean;
 }
 
 export function isManaged(name: string): boolean {
@@ -149,6 +183,7 @@ export function selectSnapshotsToReap(input: SelectInput): SelectResult {
     underPressure,
     doomed: [],
     deferred: 0,
+    budgetUnresolved: false,
   };
   if (!underPressure) return result;
 
@@ -217,6 +252,32 @@ export function selectSnapshotsToReap(input: SelectInput): SelectResult {
     if (now - t > QUOTA_GC_MIN_IDLE_MS) {
       claim(s, `unreferenced + idle ${Math.floor((now - t) / 86_400_000)}d`);
     }
+  }
+
+  // 6. BUDGET. Everything above is "provably unneeded". If the org is still over
+  //    target after all of it, the shortfall is live cache: one ppwarm tip per active
+  //    project, which no liveness rule can touch (see the header). ppwarm is a pure
+  //    cache, so it is what gives. Evict LRU until we reach target, skipping tips used
+  //    recently enough that they'd just re-bake.
+  const stillOver = () => orgTotal - candidates.length - QUOTA_GC_ORG_TARGET;
+  if (stillOver() > 0) {
+    const evictable = pool
+      .filter((s) => ppwarmProj8(s.name) && !claimed.has(s.id))
+      .filter((s) => {
+        const t = lastTouch(s);
+        return Number.isFinite(t) && now - t > QUOTA_GC_PPWARM_EVICT_PROTECT_MS;
+      })
+      .sort((a, b) => lastTouch(a) - lastTouch(b)); // least-recently-used first
+
+    for (const s of evictable) {
+      if (stillOver() <= 0) break;
+      claim(
+        s,
+        `ppwarm LRU eviction (idle ${Math.floor((now - lastTouch(s)) / 3_600_000)}h, over budget)`,
+      );
+    }
+    // Exhausted every evictable tip and still over: the cache floor beats the quota.
+    result.budgetUnresolved = stillOver() > 0;
   }
 
   result.deferred = Math.max(0, candidates.length - QUOTA_GC_MAX_PER_PASS);

--- a/apps/api/src/snapshots/quota-gc.ts
+++ b/apps/api/src/snapshots/quota-gc.ts
@@ -19,18 +19,20 @@
  * Never acts on a partial view: if the org listing fails, the pass does nothing.
  */
 
-import { isNotNull, sql } from 'drizzle-orm';
 import { sandboxTemplates } from '@kortix/db';
-import { db } from '../shared/db';
+import { isNotNull, sql } from 'drizzle-orm';
 import {
   deleteDaytonaSnapshotById,
   isDaytonaConfigured,
   listDaytonaSnapshots,
 } from '../shared/daytona';
+import { db } from '../shared/db';
 import {
+  DAYTONA_ORG_SNAPSHOT_LIMIT,
   QUOTA_GC_MAX_PER_PASS,
-  selectSnapshotsToReap,
+  QUOTA_GC_ORG_TARGET,
   type SnapshotLike,
+  selectSnapshotsToReap,
 } from './quota-gc-select';
 
 /** A project counts as ACTIVE (its legacy warm pointer is protected) when it has a
@@ -46,6 +48,8 @@ export interface QuotaGcResult {
   deleted: number;
   /** Reapable but dropped by the per-pass cap. Never silently truncate. */
   deferred: number;
+  /** GC cannot get the org back to target — capacity problem, needs a human. */
+  budgetUnresolved: boolean;
   dryRun: boolean;
 }
 
@@ -63,6 +67,7 @@ export async function reconcileSnapshotQuota(
     eligible: 0,
     deleted: 0,
     deferred: 0,
+    budgetUnresolved: false,
     dryRun,
   };
   if (!isDaytonaConfigured()) return result;
@@ -71,7 +76,10 @@ export async function reconcileSnapshotQuota(
   try {
     all = await listDaytonaSnapshots();
   } catch (err) {
-    console.warn('[snapshot-gc] org listing failed — pass skipped:', err instanceof Error ? err.message : err);
+    console.warn(
+      '[snapshot-gc] org listing failed — pass skipped:',
+      err instanceof Error ? err.message : err,
+    );
     return result;
   }
 
@@ -105,8 +113,10 @@ export async function reconcileSnapshotQuota(
     FROM kortix.projects p
     WHERE p.metadata -> 'warm_snapshot' ->> 'name' IS NOT NULL
   `);
-  const pointerList = ((pointerRows as unknown as { rows?: any[] }).rows ?? (pointerRows as unknown as any[])) as Array<{
-    name: string; active: boolean;
+  const pointerList = ((pointerRows as unknown as { rows?: any[] }).rows ??
+    (pointerRows as unknown as any[])) as Array<{
+    name: string;
+    active: boolean;
   }>;
   for (const r of pointerList) {
     if (r.name && r.active) referenced.add(r.name);
@@ -117,8 +127,22 @@ export async function reconcileSnapshotQuota(
   result.managedCount = plan.managedCount;
   result.eligible = plan.doomed.length + plan.deferred;
   result.deferred = plan.deferred;
+  result.budgetUnresolved = plan.budgetUnresolved;
 
   if (!plan.underPressure) return result;
+
+  // GC has run out of road: one warm tip per active project already exceeds the
+  // budget, so no amount of sweeping will keep builds from failing. Only capacity
+  // (a bigger org snapshot quota) or gating the warm bake fixes this. Say so —
+  // the first outage happened because a GC that couldn't cope logged nothing.
+  if (plan.budgetUnresolved) {
+    console.error(
+      `[snapshot-gc] BUDGET UNRESOLVED: org=${plan.orgTotal} target=${QUOTA_GC_ORG_TARGET} ` +
+        `limit=${DAYTONA_ORG_SNAPSHOT_LIMIT} — evicted everything eligible and still over. ` +
+        `The per-project warm cache floor exceeds the org snapshot quota; raise the quota ` +
+        `or gate the warm bake. Builds will start failing with 'Snapshot quota exceeded'.`,
+    );
+  }
 
   for (const { snapshot, reason } of plan.doomed) {
     if (dryRun) {
@@ -134,7 +158,9 @@ export async function reconcileSnapshotQuota(
   console.log(
     `[snapshot-gc] org=${result.orgTotal} managed=${result.managedCount} ` +
       `eligible=${result.eligible} ${dryRun ? 'would-delete' : 'deleted'}=${result.deleted}` +
-      (result.deferred > 0 ? ` deferred=${result.deferred} (cap ${QUOTA_GC_MAX_PER_PASS}/pass)` : ''),
+      (result.deferred > 0
+        ? ` deferred=${result.deferred} (cap ${QUOTA_GC_MAX_PER_PASS}/pass)`
+        : ''),
   );
   return result;
 }


### PR DESCRIPTION
Follow-up to #4320, found by running that GC against the **live** org instead of trusting the unit tests.

## The GC was correct but toothless

```
orgTotal=107 managed=85 underPressure=true doomed=0
```

107 snapshots against a 100 cap, GC awake, reclaiming **nothing**.

`kortix-ppwarm-<proj8>-<hash>` is minted unconditionally on session-start of the shared default (`builder.ts:101` — no feature gate), one live tip per project. Its floor is the number of projects that have ever started a session. Measured today:

| | count |
|---|---|
| `kortix-ppwarm-` | **69** (69 distinct, non-archived projects) |
| non-kortix stock | 22 |
| `kortix-default-` | 13 |
| `kortix-tpl-` | 3 |
| **total** | **107** |

Every liveness rule — superseded tip, dead project, long-idle — reclaims zero against that shape, because each tip is a live project's *only* tip. I confirmed this by classifying all 69 `proj8` keys against prod + dev + staging: `orphaned=0 archived=0 live=69`.

So a purely liveness-based GC sits at 100% pressure doing nothing. **That is the outage.**

## Fix: ppwarm absorbs budget pressure

ppwarm is a pure cache — evicting a tip costs one cold boot plus a re-bake, never data. So it's the namespace that gives:

> **6. BUDGET** — if the org is still over `QUOTA_GC_ORG_TARGET` after every provably-unneeded snapshot is claimed, evict ppwarm LRU until it isn't. Tips used within `QUOTA_GC_PPWARM_EVICT_PROTECT_MS` (6h) are spared: a hot project re-bakes immediately, so evicting it is churn, not reclamation.

## And when GC runs out of road, it says so

If even full eviction can't reach target, `budgetUnresolved` is set and the caller emits `console.error`. GC can only buy time; the real remedy is **capacity** (raise the org snapshot quota) or gating the warm bake. A GC that quietly cannot keep up is exactly how this failed the first time.

## Verification against the live org (read-only)

```
orgTotal=92 managed=70 underPressure=true doomed=7 budgetUnresolved=false
  kortix-ppwarm-58654014-…  ppwarm LRU eviction (idle 19h, over budget)
  … 7 total, oldest-first
tpl protected:      3/3
stock touched:      0 (must be 0)
in-flight touched:  0 (must be 0)
```

## Tests
- LRU eviction reaches target when no liveness rule can free anything (the 69-tip shape, verbatim)
- evicts oldest-first
- never evicts a recently-used tip, even under pressure
- flags `budgetUnresolved` exactly when the cache floor exceeds the quota, and not otherwise

The two pre-existing ppwarm liveness tests are pinned below target so they keep testing the liveness rule rather than the new budget stage.

`bun test` 34/34. `tsc --noEmit` clean on `apps/api`.

## Note for a human

This buys headroom; it does not make the arithmetic work long-term. At ~69 active projects the warm cache alone is 69% of the org quota, and it grows with project count. **The durable fix is raising the Daytona org snapshot quota** (or gating the warm bake). Until then GC will keep evicting the coldest tips, which means the least-active projects pay a cold boot. `budgetUnresolved` is the tripwire for when that stops being enough.