### PR TITLE
fix(iam-web): audit export 404 + make the guide's affordances real

### DIFF
--- a/apps/web/src/components/iam/audit-tab.tsx
+++ b/apps/web/src/components/iam/audit-tab.tsx
@@ -82,8 +82,10 @@ export function AuditTab({ accountId }: AuditTabProps) {
         toast.error('Not signed in');
         return;
       }
-      const base = getEnv().BACKEND_URL ?? '';
-      const url = `${base}/v1/accounts/${accountId}/audit/export?${params.toString()}`;
+      // BACKEND_URL already includes the `/v1` prefix (e.g. https://api.kortix.com/v1),
+      // so paths are appended WITHOUT another `/v1` — adding one 404'd the export.
+      const base = (getEnv().BACKEND_URL ?? '').replace(/\/+$/, '');
+      const url = `${base}/accounts/${accountId}/audit/export?${params.toString()}`;
       const res = await fetch(url, {
         headers: { Authorization: `Bearer ${token}` },
       });

--- a/apps/web/src/components/iam/roles-tab.tsx
+++ b/apps/web/src/components/iam/roles-tab.tsx
@@ -369,15 +369,21 @@ function RoleRow({
               </>
             ) : (
               <Hint
-                label={rbacEnabled ? `Duplicate ${role.name} into a new custom role` : RBAC_UPSELL_MESSAGE}
+                label={
+                  rbacEnabled
+                    ? `Start a custom role from ${role.name}'s capability set`
+                    : RBAC_UPSELL_MESSAGE
+                }
                 side="top"
                 className={rbacEnabled ? undefined : 'max-w-xs'}
               >
                 <span className="inline-flex">
+                  {/* Labeled (not icon-only): "Duplicate" is the documented path to
+                      "editor minus X" — it must be findable at a glance. */}
                   <Button
-                    size="icon"
-                    variant="ghost"
-                    className="h-8 w-8 text-muted-foreground hover:text-foreground"
+                    size="sm"
+                    variant="outline"
+                    className="h-7 gap-1.5 px-2.5 text-xs"
                     onClick={handleDuplicate}
                     disabled={duplicating || !rbacEnabled}
                     aria-label={`Duplicate role ${role.name}`}
@@ -387,6 +393,7 @@ function RoleRow({
                     ) : (
                       <Copy className="h-3.5 w-3.5" />
                     )}
+                    Duplicate
                   </Button>
                 </span>
               </Hint>

--- a/apps/web/src/features/workspace/customize/sections/view/members-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/members-view.tsx
@@ -26,6 +26,7 @@ import {
 import { EntityAvatar } from '@/components/ui/entity-avatar';
 import { Field, FieldDescription, FieldError, FieldGroup, FieldLabel } from '@/components/ui/field';
 import { InlineMeta } from '@/components/ui/inline-meta';
+import { Input } from '@/components/ui/input';
 import { InputGroup, InputGroupAddon, InputGroupInput } from '@/components/ui/input-group';
 import Loading from '@/components/ui/loading';
 import {
@@ -260,6 +261,10 @@ function InviteMemberCard({ projectId }: { projectId: string }) {
   const [emails, setEmails] = useState<string[]>([]);
   const [inputValue, setInputValue] = useState('');
   const [role, setRole] = useState<ProjectRole>('member');
+  // Optional ISO time-bound: the granted role auto-revokes at this instant once
+  // the invitee joins. Empty = permanent. `datetime-local` yields a local
+  // wall-clock string; converted to ISO at submit.
+  const [expiresAt, setExpiresAt] = useState('');
   const [inlineError, setInlineError] = useState<string | null>(null);
 
   const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
@@ -269,7 +274,12 @@ function InviteMemberCard({ projectId }: { projectId: string }) {
       Promise.all(
         list.map(async (addr) => {
           try {
-            const res = await inviteProjectMember(projectId, addr, role);
+            const res = await inviteProjectMember(
+              projectId,
+              addr,
+              role,
+              expiresAt ? new Date(expiresAt).toISOString() : null,
+            );
             return { email: addr, ok: true as const, res };
           } catch (err) {
             return {
@@ -436,7 +446,7 @@ function InviteMemberCard({ projectId }: { projectId: string }) {
 
       <form onSubmit={handleSubmit}>
         <FieldGroup className="gap-3">
-          <div className="grid grid-cols-1 gap-3 sm:grid-cols-[minmax(0,1fr)_10rem_auto] sm:items-end sm:gap-x-3">
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-[minmax(0,1fr)_9rem_12rem_auto] sm:items-end sm:gap-x-3">
             <Field className="gap-1.5 p-0">
               <FieldLabel htmlFor="invite-email">Emails</FieldLabel>
               <InputGroup
@@ -510,6 +520,18 @@ function InviteMemberCard({ projectId }: { projectId: string }) {
                   <ProjectRoleSelectItem role="manager" />
                 </SelectContent>
               </Select>
+            </Field>
+
+            <Field className="gap-1.5">
+              <FieldLabel htmlFor="invite-expiry">Expires (optional)</FieldLabel>
+              <Input
+                id="invite-expiry"
+                type="datetime-local"
+                value={expiresAt}
+                min={new Date(Date.now() + 60_000).toISOString().slice(0, 16)}
+                onChange={(e) => setExpiresAt(e.target.value)}
+                disabled={inviteMutation.isPending}
+              />
             </Field>
 
             <Field className="gap-1.5">
@@ -744,6 +766,11 @@ function ProjectAccessCard({
                                 ? `Granted ${formatDate(member.granted_at)}`
                                 : 'No project access'}
                         </span>
+                        {member.expires_at ? (
+                          <span className="text-kortix-yellow">
+                            Expires {formatDate(member.expires_at)}
+                          </span>
+                        ) : null}
                       </InlineMeta>
                     </span>
                   </div>

--- a/packages/sdk/src/kortix.test.ts
+++ b/packages/sdk/src/kortix.test.ts
@@ -5,11 +5,15 @@ import { listFiles as globalListFiles } from './files/client';
 import { ApiError } from './platform/api/errors';
 
 // Capture every outbound request the facade makes.
-let calls: { url: string; method: string }[] = [];
+let calls: { url: string; method: string; body?: unknown }[] = [];
 beforeEach(() => {
   calls = [];
-  globalThis.fetch = mock(async (url: unknown, opts: { method?: string } = {}) => {
-    calls.push({ url: String(url), method: opts.method ?? 'GET' });
+  globalThis.fetch = mock(async (url: unknown, opts: { method?: string; body?: unknown } = {}) => {
+    calls.push({
+      url: String(url),
+      method: opts.method ?? 'GET',
+      body: typeof opts.body === 'string' ? JSON.parse(opts.body) : opts.body,
+    });
     return new Response(JSON.stringify({ ok: true, secrets: [], candidates: [], sessions: [] }), {
       status: 200,
       headers: { 'content-type': 'application/json' },
@@ -56,6 +60,28 @@ test('top-level projects.list hits /projects', async () => {
 test('session(...).audit hits the audit endpoint with the given limit', async () => {
   await kortix.session('PID123', 'SID456').audit(10);
   expect(last().url).toContain('/projects/PID123/sessions/SID456/audit?limit=10');
+});
+
+test('project(id).access.invite forwards a time-bound expiry to the backend', async () => {
+  const expiry = '2027-01-01T00:00:00.000Z';
+  await kortix.project('PID123').access.invite('teammate@essentia.com', 'member', expiry);
+  expect(last().url).toContain('/projects/PID123/access/invite');
+  expect(last().method).toBe('POST');
+  expect(last().body).toMatchObject({
+    email: 'teammate@essentia.com',
+    role: 'member',
+    expires_at: expiry,
+  });
+});
+
+test('project(id).access.invite omits expires_at for a permanent grant', async () => {
+  await kortix.project('PID123').access.invite('teammate@essentia.com', 'member');
+  expect(last().body).not.toHaveProperty('expires_at');
+});
+
+test('project(id).access.invite sends expires_at:null to clear a bound', async () => {
+  await kortix.project('PID123').access.invite('teammate@essentia.com', 'member', null);
+  expect(last().body).toMatchObject({ expires_at: null });
 });
 
 // ── review / approvals / gateway / channels / apps / model-defaults / sandbox

--- a/packages/sdk/src/platform/projects-client/access.ts
+++ b/packages/sdk/src/platform/projects-client/access.ts
@@ -160,11 +160,14 @@ export async function inviteProjectMember(
   projectId: string,
   email: string,
   role: ProjectRole,
+  /** Optional ISO-8601 time-bound: the granted role auto-revokes at this instant
+   *  once the invitee joins. Omit / null for a permanent grant. */
+  expiresAt?: string | null,
 ) {
   return unwrap(
     await backendApi.post<InviteProjectMemberResult>(
       `/projects/${projectId}/access/invite`,
-      { email, role },
+      { email, role, ...(expiresAt !== undefined ? { expires_at: expiresAt } : {}) },
     ),
   );
 }


### PR DESCRIPTION
Fixes a live bug the founder hit, plus the two real gaps a UI-audit of `IAM_ADMIN_GUIDE.md` found (the guide is now the spec — anything it claims must exist and be findable).

## 🐞 Audit export 404 (CSV + JSONL)
`audit-tab.tsx` built the export URL as `${BACKEND_URL}/v1/accounts/…`, but `BACKEND_URL` **already includes `/v1`** (every other call site uses paths *without* it; `buildScimBaseUrl` strips it to origin for the same reason). Result: `…/v1/v1/accounts/…/audit/export` → **404**, both formats (one code path). Fixed to `${base}/accounts/…` + trailing-slash trim, matching the `backendApi` convention. Works for both absolute (`https://api…/v1`) and relative (`/v1` proxy) `BACKEND_URL`.

## 📋 Guide-parity gaps (from a 4-agent existence audit — 20/25 already fine)
- **Duplicate role** — the guide's "Duplicate a built-in preset (fastest path to *editor minus X*)" existed but as an **unlabeled icon button**, so it read as missing. Now a labeled **Duplicate** button.
- **Invite expiry** — the guide says invites can "optionally set an expiry"; the form had no field although the API accepts `expires_at`. Added an optional **Expires** datetime-local to the invite card, threaded through `inviteProjectMember(…, expiresAt)` (new optional SDK arg).
- **Member-row expiry** — the guide says time-boxed access is visible; `expires_at` was in the data but never rendered. Now shown (amber "Expires …") on member rows, matching the policy/group-grant rows.

Non-issues the audit cleared (guide already accurate): non-delegable actions genuinely aren't offered in the matrix; the effective-access probe is correctly documented as API-only; the Roles tab shows for an owner/admin.

## Verify
`tsc --noEmit` clean on both `apps/web` and `packages/sdk`; SDK tests 58/58. Please spot-check on dev: **Audit → Export CSV/JSONL downloads**; Roles tab shows a **Duplicate** button on built-ins; invite has an **Expires** field and time-boxed members show an expiry.