### PR TITLE
feat(cli): surface env grant in token context + switch hint on bare landing

### DIFF
--- a/apps/api/src/accounts/core/app.ts
+++ b/apps/api/src/accounts/core/app.ts
@@ -112,6 +112,7 @@ export const MeSchema = z
       agent: z.string().nullable(),
       connectors: z.union([z.literal('all'), z.array(z.string())]).nullable(),
       kortix_cli: z.union([z.literal('all'), z.array(z.string())]).nullable(),
+      env: z.union([z.literal('all'), z.array(z.string())]).nullable(),
     }).optional(),
     accounts: z.array(
       z.object({

--- a/apps/api/src/accounts/core/tokens.ts
+++ b/apps/api/src/accounts/core/tokens.ts
@@ -97,6 +97,7 @@ accountsRouter.openapi(
       agent: (c.get('agentGrant') as { agent?: string } | null | undefined)?.agent ?? null,
       connectors: (c.get('agentGrant') as { connectors?: string[] | 'all' } | null | undefined)?.connectors ?? null,
       kortix_cli: (c.get('agentGrant') as { kortixCli?: string[] | 'all' } | null | undefined)?.kortixCli ?? null,
+      env: (c.get('agentGrant') as { env?: string[] | 'all' } | null | undefined)?.env ?? null,
     },
     accounts: memberships.map((m) => ({
       account_id: m.accountId,

--- a/apps/cli/src/__tests__/account-project-config.test.ts
+++ b/apps/cli/src/__tests__/account-project-config.test.ts
@@ -178,6 +178,27 @@ describe('renderContext + host notice', () => {
     expect(out).toContain('project');
     expect(out).toContain('Alpha');
     expect(out).toContain('(default)');
+    // A bound default project points at the switch verb.
+    expect(out).toContain('switch with `kortix projects use`');
+  });
+
+  test('a directory-linked project does not show the default-project switch hint', () => {
+    writeConfig({
+      test: loggedInHost({
+        account_slug: 'kortix',
+        account_name: 'Kortix',
+        default_project: { project_id: 'proj_a', account_id: 'account_1', name: 'Alpha' },
+      }),
+    });
+    mkdirSync(join(tmp, '.kortix'), { recursive: true });
+    saveLink(
+      { project_id: 'proj_linked', account_id: 'account_1', linked_at: '2026-01-01T00:00:00.000Z' },
+      tmp,
+    );
+    process.chdir(tmp);
+    const out = stripAnsi(renderContext());
+    expect(out).toContain('(linked)');
+    expect(out).not.toContain('switch with');
   });
 
   test('context block nudges when account / default project are unset', () => {

--- a/apps/cli/src/api/types.ts
+++ b/apps/cli/src/api/types.ts
@@ -18,6 +18,7 @@ export interface MeResponse {
     agent: string | null;
     connectors: string[] | 'all' | null;
     kortix_cli: string[] | 'all' | null;
+    env?: string[] | 'all' | null;
   };
   accounts: AccountMembership[];
 }

--- a/apps/cli/src/commands/whoami.ts
+++ b/apps/cli/src/commands/whoami.ts
@@ -122,6 +122,9 @@ export async function runWhoami(argv: string[]): Promise<number> {
     if (ctx?.kortix_cli != null) {
       process.stdout.write(`  ${C.dim}kortix_cli ${C.reset}${formatGrant(ctx.kortix_cli)}\n`);
     }
+    if (ctx?.env != null) {
+      process.stdout.write(`  ${C.dim}env       ${C.reset}${formatGrant(ctx.env)}\n`);
+    }
     process.stdout.write('\n');
     return 0;
   }

--- a/apps/cli/src/host-notice.ts
+++ b/apps/cli/src/host-notice.ts
@@ -124,5 +124,12 @@ export function renderContext(): string {
         : `${C.faded}— none (run \`kortix projects use\`)${C.reset}`
     }`,
   );
+  // When a default project is bound, point at the switch verb (a linked cwd
+  // wins and can't be swapped with `projects use`, so only hint for defaults).
+  if (proj?.source === 'default') {
+    rows.push(
+      `  ${C.dim}${pad('', labelW)}${C.reset}  ${C.faded}switch with \`kortix projects use\`${C.reset}`,
+    );
+  }
   return rows.join('\n') + '\n';
 }


### PR DESCRIPTION
Track A A0 (`token_context` parity) + Track B B0 polish from the one-token/CLI-centric plan (#4295).

Two small, decision-free identity-surface completions:

1. **`env` grant in token_context.** An agent grant has three dimensions — connectors, kortix_cli, **env** (project-secret identifier allowlist) — but `/accounts/me` `token_context` and `kortix token` only surfaced the first two. Adds `env` to `MeSchema` + the handler + `kortix token` output, so an agent-session token fully describes what it may touch.
2. **Switch hint on the bare landing.** When a default project is bound, the `kortix` context block now points at `kortix projects use` to switch. A directory-linked cwd wins over the default and can't be swapped with that verb, so the hint is shown only for `(default)`, not `(linked)`.

## Tests
- New `renderContext` assertions: default-bound shows the switch hint; linked cwd does not.
- CLI suite 177/177, API + CLI typecheck clean. (Pre-existing biome findings in the touched files unchanged; added lines match surrounding style.)