### PR TITLE
fix(api): hash OAuth tokens with peppered scrypt, not bare sha256

### DIFF
--- a/apps/api/src/oauth/index.ts
+++ b/apps/api/src/oauth/index.ts
@@ -5,6 +5,7 @@ import { createHash, randomBytes, timingSafeEqual } from 'crypto';
 import { eq, and, inArray, isNull } from 'drizzle-orm';
 import { db } from '../shared/db';
 import { randomAlphanumeric, verifySecretKey } from '../shared/crypto';
+import { hashOauthToken, oauthTokenHashCandidates } from './token-hash';
 import { supabaseAuth } from '../middleware/auth';
 import { config } from '../config';
 import {
@@ -17,11 +18,8 @@ import {
 } from '@kortix/db';
 import { makeOpenApiApp, json, errors, auth } from '../openapi';
 
-// ─── Token Hashing ──────────────────────────────────────────────────────────
-
-function hashToken(token: string): string {
-  return createHash('sha256').update(token).digest('hex');
-}
+// Token hashing lives in ./token-hash (hashOauthToken for minting,
+// oauthTokenHashCandidates for dual-read lookup during the legacy window).
 
 // ─── Rate Limiter (in-memory, per client_id) ────────────────────────────────
 
@@ -68,7 +66,6 @@ async function oauthTokenAuth(c: Context, next: Next) {
     throw new HTTPException(401, { message: 'Missing token' });
   }
 
-  const tokenHash = hashToken(token);
   const now = new Date();
 
   const [row] = await db
@@ -76,7 +73,7 @@ async function oauthTokenAuth(c: Context, next: Next) {
     .from(oauthAccessTokens)
     .where(
       and(
-        eq(oauthAccessTokens.tokenHash, tokenHash),
+        inArray(oauthAccessTokens.tokenHash, oauthTokenHashCandidates(token)),
         isNull(oauthAccessTokens.revokedAt),
       ),
     )
@@ -209,8 +206,8 @@ async function issueTokenPair(params: {
 }) {
   const accessToken = generateAccessToken();
   const refreshToken = generateRefreshToken();
-  const accessTokenHash = hashToken(accessToken);
-  const refreshTokenHash = hashToken(refreshToken);
+  const accessTokenHash = hashOauthToken(accessToken);
+  const refreshTokenHash = hashOauthToken(refreshToken);
 
   const now = new Date();
   const accessExpiresAt = new Date(now.getTime() + 3600 * 1000);
@@ -627,14 +624,12 @@ async function handleRefreshTokenGrant(c: Context, body: Record<string, any>, cl
     return c.json({ error: 'invalid_request', error_description: 'Missing refresh_token' }, 400);
   }
 
-  const refreshTokenHash = hashToken(refreshTokenRaw);
-
   const [refreshRow] = await db
     .select()
     .from(oauthRefreshTokens)
     .where(
       and(
-        eq(oauthRefreshTokens.tokenHash, refreshTokenHash),
+        inArray(oauthRefreshTokens.tokenHash, oauthTokenHashCandidates(refreshTokenRaw)),
         eq(oauthRefreshTokens.clientId, client.clientId),
         isNull(oauthRefreshTokens.revokedAt),
       ),

--- a/apps/api/src/oauth/token-hash.test.ts
+++ b/apps/api/src/oauth/token-hash.test.ts
@@ -1,0 +1,42 @@
+import { createHash } from 'crypto';
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+mock.module('../config', () => ({ config: { API_KEY_SECRET: 'test-pepper' } }));
+
+const { hashOauthToken, legacyHashOauthToken, oauthTokenHashCandidates } = await import(
+  './token-hash'
+);
+
+describe('oauth token hashing', () => {
+  // Obviously-fake literal; the trailing marker exempts it from secret scanning.
+  const token = 'kortix_oat_FAKE_TEST_TOKEN'; // gitleaks:allow
+
+  test('new tokens hash under the peppered-scrypt scheme, not bare sha256', () => {
+    const hash = hashOauthToken(token);
+    expect(hash.startsWith('scrypt:v1:')).toBe(true);
+    expect(hash).not.toBe(createHash('sha256').update(token).digest('hex'));
+  });
+
+  test('hashing is deterministic so hash-equality lookup still works', () => {
+    expect(hashOauthToken(token)).toBe(hashOauthToken(token));
+  });
+
+  test('legacy hash matches the pre-change bare sha256', () => {
+    expect(legacyHashOauthToken(token)).toBe(
+      createHash('sha256').update(token).digest('hex'),
+    );
+  });
+
+  test('candidates cover both schemes, scrypt first — a token stored either way validates', () => {
+    const candidates = oauthTokenHashCandidates(token);
+    expect(candidates).toEqual([hashOauthToken(token), legacyHashOauthToken(token)]);
+    // A token minted before this change (legacy hash on the row) is still found.
+    expect(candidates).toContain(createHash('sha256').update(token).digest('hex'));
+    // A token minted after (scrypt hash on the row) is found too.
+    expect(candidates).toContain(hashOauthToken(token));
+  });
+
+  test('distinct tokens produce distinct hashes', () => {
+    expect(hashOauthToken('kortix_oat_one')).not.toBe(hashOauthToken('kortix_oat_two'));
+  });
+});

--- a/apps/api/src/oauth/token-hash.ts
+++ b/apps/api/src/oauth/token-hash.ts
@@ -1,0 +1,27 @@
+import { createHash } from 'crypto';
+import { hashSecretKey } from '../shared/crypto';
+
+// OAuth access/refresh tokens (kortix_oat_ / kortix_ort_) are stored under the
+// same peppered-scrypt scheme as the rest of the credential system
+// (crypto.hashSecretKey), rather than the bare unpeppered sha256 they used to
+// use. Both schemes are deterministic — scrypt here is peppered with
+// API_KEY_SECRET, not per-token salted — so hash-equality lookup still works;
+// we just look up over BOTH candidate hashes so tokens minted before this
+// change keep validating until they expire (access 1h, refresh 30d). The
+// legacy branch can be deleted after that window.
+
+/** How new oauth tokens are hashed for storage. */
+export function hashOauthToken(token: string): string {
+  return hashSecretKey(token);
+}
+
+/** The pre-change scheme (bare sha256), kept only for dual-read validation. */
+export function legacyHashOauthToken(token: string): string {
+  return createHash('sha256').update(token).digest('hex');
+}
+
+/** Both hashes a presented token could be stored under, newest first. Use in
+ *  an `inArray(tokenHash, …)` lookup so old and new tokens both validate. */
+export function oauthTokenHashCandidates(token: string): string[] {
+  return [hashOauthToken(token), legacyHashOauthToken(token)];
+}


### PR DESCRIPTION
Track A A0 (defect 2 from the 2026-07-08 credential audit, spec #4295).

## Bug

Kortix-as-OAuth-server tokens (`kortix_oat_` access, `kortix_ort_` refresh) were stored as bare unpeppered `sha256(token)`, while every other credential in the system uses peppered scrypt (`crypto.hashSecretKey`). Bare SHA-256 of a high-entropy token isn't a practical break, but it's an inconsistent, weaker-by-design path in the credential system — worth removing.

## Fix

Store new tokens under `hashSecretKey` (peppered scrypt). The key enabler: that scrypt is **deterministic** — peppered with `API_KEY_SECRET`, not per-token salted — so the existing hash-equality lookup keeps working with no schema change (scrypt output is 74 chars, fits `varchar(128)`).

Lookups become a **dual-read**: `inArray(tokenHash, [scrypt(token), sha256(token)])`, mirroring `candidateSecretKeyHashes` in `crypto.ts`, so tokens minted before this change keep validating until they naturally expire (access 1h, refresh 30d). The legacy branch can be deleted after that window.

Hashing is extracted from the 700-line route file into `oauth/token-hash.ts` (`hashOauthToken`, `legacyHashOauthToken`, `oauthTokenHashCandidates`).

## Tests

New `token-hash.test.ts` (5 tests): new tokens use scrypt not sha256, deterministic, legacy matches old sha256, candidates cover both schemes scrypt-first (mint-then-validate and legacy-stored-still-validates), distinct tokens distinct hashes. API typecheck clean; `token-hash` + lint clean. (`unit-oauth-consent.test.ts` fails identically at HEAD — pre-existing local-env issue, not this change; the OAU-3/OAU-4 ke2e flow is the live mint→validate→refresh guard.)