### PR TITLE
fix(llm-gateway): surface real upstream stream errors instead of generic empty_completion

### DIFF
--- a/apps/llm-gateway/src/config.ts
+++ b/apps/llm-gateway/src/config.ts
@@ -34,6 +34,9 @@ export const config = {
   },
   captureBodies: flag('GATEWAY_CAPTURE_BODIES', true),
   maxCapturedBodyBytes: optionalInt('GATEWAY_MAX_CAPTURED_BODY_BYTES', 256 * 1024),
+  // 0 = disabled. Set to a byte ceiling (e.g. 1048576 for 1 MiB) to reject
+  // oversized requests with a 413 before they reach an upstream.
+  maxRequestBytes: optionalInt('GATEWAY_MAX_REQUEST_BYTES', 0),
   retry: {
     maxAttempts: optionalInt('GATEWAY_RETRY_MAX_ATTEMPTS', 3),
     baseDelayMs: optionalInt('GATEWAY_RETRY_BASE_MS', 300),

--- a/apps/llm-gateway/src/server.ts
+++ b/apps/llm-gateway/src/server.ts
@@ -62,6 +62,7 @@ export function buildServer(): GatewayServer {
       breaker: config.breaker,
       captureBodies: config.captureBodies,
       maxCapturedBodyBytes: config.maxCapturedBodyBytes,
+      maxRequestBytes: config.maxRequestBytes || undefined,
       // Resolve `auto` against the principal's account/agent default (resolved
       // API-side in withResolvedTier and carried across the authorize RPC).
       autoRouter: (model, body, principal) =>

--- a/packages/llm-gateway/src/domain/config.ts
+++ b/packages/llm-gateway/src/domain/config.ts
@@ -6,6 +6,10 @@ export interface GatewayConfig {
   breaker?: CircuitBreakerOptions;
   captureBodies?: boolean;
   maxCapturedBodyBytes?: number;
+  // Hard ceiling on the raw request body size (bytes). Unset/0 disables the check
+  // (the default). When set, over-limit requests are rejected up front with a 413
+  // instead of being dispatched to an upstream that may silently drop them.
+  maxRequestBytes?: number;
   // Optional host-supplied router for synthetic models (e.g. "auto"): given the
   // requested model + parsed body + the authenticated principal, return a
   // concrete model id to route to, or null to use the requested model unchanged.

--- a/packages/llm-gateway/src/pipeline/handler.test.ts
+++ b/packages/llm-gateway/src/pipeline/handler.test.ts
@@ -751,4 +751,98 @@ describe("gateway.chatCompletions — empty-completion failover", () => {
     expect(traces[0].ok).toBe(false);
     expect(traces[0].errorCode).toBe("empty_completion");
   });
+
+  // An otherwise-200 stream that carries a structured `{error:{...}}` frame and no
+  // content is a real upstream failure (overloaded, request too large, ...). It
+  // must surface the real error — not be retried in place and buried under a
+  // generic empty_completion.
+  const errorSse =
+    'data: {"error":{"message":"Overloaded","type":"overloaded_error","code":"overloaded_error"}}\n\n' +
+    "data: [DONE]\n\n";
+
+  test("streaming: an upstream error frame surfaces as 502 upstream_error with the real message — no same-candidate retry storm", async () => {
+    const { hooks, traces, usage } = makeHooks({ resolveUpstream: async () => [managed] });
+    let calls = 0;
+    const fetchImpl: FetchImpl = async () => {
+      calls += 1;
+      return sseResponse(errorSse);
+    };
+
+    const res = await createGateway(hooks, { retry: fastRetry }, { fetchImpl }).chatCompletions({
+      authorization: "Bearer good",
+      rawBody: '{"model":"x","stream":true}',
+    });
+
+    expect(res.status).toBe(502);
+    const body = await res.json();
+    expect(body.code).toBe("upstream_error");
+    expect(body.error).toBe("Overloaded");
+    expect(body.upstream_code).toBe("overloaded_error");
+    expect(calls).toBe(1); // the error candidate is excluded at once, not retried 3×
+    await flush();
+    expect(usage).toHaveLength(0);
+    expect(traces[0].ok).toBe(false);
+    expect(traces[0].errorCode).toBe("upstream_error");
+    expect(traces[0].candidatesTried).toEqual(["openrouter"]);
+  });
+
+  test("streaming: an error frame from candidate A still fails over to a healthy candidate B", async () => {
+    const a: UpstreamDescriptor = { ...managed, provider: "a", baseUrl: "https://a.test/v1" };
+    const b: UpstreamDescriptor = { ...managed, provider: "b", baseUrl: "https://b.test/v1" };
+    const { hooks, traces } = makeHooks({ resolveUpstream: async () => [a, b] });
+    const fetchImpl: FetchImpl = async (url) =>
+      sseResponse(new URL(url).hostname === "a.test" ? errorSse : goodSse);
+
+    const res = await createGateway(hooks, { retry: fastRetry }, { fetchImpl }).chatCompletions({
+      authorization: "Bearer good",
+      rawBody: '{"model":"x","stream":true}',
+    });
+
+    expect(res.status).toBe(200);
+    expect(await new Response(res.body).text()).toBe(goodSse);
+    await flush();
+    expect(traces.find((t) => t.ok)?.provider).toBe("b");
+  });
+});
+
+describe("gateway.chatCompletions — request size guard", () => {
+  test("a body over maxRequestBytes is rejected with 413 before any upstream dispatch", async () => {
+    const { hooks, traces } = makeHooks({ resolveUpstream: async () => [managed] });
+    let dispatched = false;
+    const fetchImpl: FetchImpl = async () => {
+      dispatched = true;
+      return new Response(JSON.stringify({ choices: [{ message: { content: "x" } }] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    };
+
+    const rawBody = `{"model":"x","pad":"${"z".repeat(500)}"}`;
+    const res = await createGateway(
+      hooks,
+      { maxRequestBytes: 100 },
+      { fetchImpl },
+    ).chatCompletions({ authorization: "Bearer good", rawBody });
+
+    expect(res.status).toBe(413);
+    expect((await res.json()).code).toBe("request_too_large");
+    expect(dispatched).toBe(false); // rejected up front — no upstream call
+    await flush();
+    expect(traces[0].ok).toBe(false);
+    expect(traces[0].errorCode).toBe("request_too_large");
+  });
+
+  test("the guard is off by default — a large body dispatches normally", async () => {
+    const { hooks } = makeHooks({ resolveUpstream: async () => [managed] });
+    const res = await createGateway(
+      hooks,
+      {},
+      { fetchImpl: okFetch({ choices: [{ message: { content: "ok" } }] }) },
+    ).chatCompletions({
+      authorization: "Bearer good",
+      rawBody: `{"model":"x","pad":"${"z".repeat(5000)}"}`,
+    });
+
+    expect(res.status).toBe(200);
+  });
 });

--- a/packages/llm-gateway/src/pipeline/handler.ts
+++ b/packages/llm-gateway/src/pipeline/handler.ts
@@ -204,6 +204,28 @@ export async function handleChatCompletions(
 
   const id = idOf(principal);
 
+  // Reject oversized bodies before the JSON parse and upstream dispatch. Off by
+  // default (`maxRequestBytes` unset/0); when configured it turns an upstream
+  // that silently drops an over-limit request into an immediate, actionable 413
+  // instead of a multi-second retry storm that ends in a generic 502.
+  if (config.maxRequestBytes && req.rawBody.length > config.maxRequestBytes) {
+    step('request_too_large', { bytes: req.rawBody.length, limit: config.maxRequestBytes });
+    emit({
+      ...id,
+      status: 413,
+      ok: false,
+      errorCode: 'request_too_large',
+      errorMessage: `Request body ${req.rawBody.length} bytes exceeds limit ${config.maxRequestBytes}`,
+    });
+    return json(
+      {
+        error: `Request body of ${req.rawBody.length} bytes exceeds the ${config.maxRequestBytes}-byte limit`,
+        code: 'request_too_large',
+      },
+      413,
+    );
+  }
+
   let body: Record<string, unknown>;
   try {
     body = JSON.parse(req.rawBody) as Record<string, unknown>;
@@ -321,11 +343,22 @@ export async function handleChatCompletions(
   let attempts = 0;
   let nonStreamBody: unknown;
   let streamProbe: StreamProbeResult | null = null;
+  // The real upstream error behind an empty stream, if a candidate returned one
+  // (see the error-frame branch below). Surfaced in place of the generic
+  // empty-completion 502 when every candidate ends up producing nothing usable.
+  let lastErrorFrame: SseErrorFrame | null = null;
 
   for (;;) {
     const remaining = candidates.filter((c) => !emptyProviders.has(c.provider));
     if (remaining.length === 0) {
-      step('all_candidates_empty', { ms: lap(), tried });
+      step('all_candidates_empty', { ms: lap(), tried, hadErrorFrame: Boolean(lastErrorFrame) });
+      // Prefer the real upstream cause (overloaded, request too large, content
+      // filter) that a candidate reported over the generic "empty" message that
+      // would otherwise bury it.
+      const errorCode = lastErrorFrame ? 'upstream_error' : 'empty_completion';
+      const message = lastErrorFrame
+        ? lastErrorFrame.message
+        : 'All upstream candidates returned an empty completion';
       emit({
         ...id,
         requestedModel,
@@ -333,13 +366,18 @@ export async function handleChatCompletions(
         streaming,
         status: 502,
         ok: false,
-        errorCode: 'empty_completion',
+        errorCode,
+        errorMessage: message,
         candidatesTried: tried,
         request: capture(payload),
         metadata,
       });
       return json(
-        { error: 'All upstream candidates returned an empty completion', code: 'empty_completion' },
+        {
+          error: message,
+          code: errorCode,
+          ...(lastErrorFrame?.code !== undefined ? { upstream_code: lastErrorFrame.code } : {}),
+        },
         502,
       );
     }
@@ -395,6 +433,23 @@ export async function handleChatCompletions(
       descriptor = chosen;
       streamProbe = probe;
       break;
+    }
+    // A structured error frame is a definitive failure for THIS candidate, not the
+    // transient empty-stop hiccup the same-candidate retry targets — so exclude the
+    // candidate at once (no in-place retry) and remember the real error to surface
+    // if nothing usable ever arrives. Other candidates, if any, still get a turn.
+    if (probe.errorFrame) {
+      lastErrorFrame = probe.errorFrame;
+      logger.warn(
+        `[llm-gateway] upstream error frame from ${chosen.provider} ${requestId}: "${probe.errorFrame.message}"${probe.errorFrame.code !== undefined ? ` (code ${probe.errorFrame.code})` : ''}`,
+      );
+      step('upstream_error_frame', {
+        provider: chosen.provider,
+        message: probe.errorFrame.message,
+        code: probe.errorFrame.code,
+      });
+      emptyProviders.add(chosen.provider);
+      continue;
     }
     await registerEmptyCompletion(chosen.provider, { streaming: true });
   }

--- a/packages/llm-gateway/src/pipeline/streaming.ts
+++ b/packages/llm-gateway/src/pipeline/streaming.ts
@@ -42,15 +42,22 @@ const PROBE_MAX_BYTES = 64 * 1024;
 
 export interface StreamProbeResult {
   hasContent: boolean;
+  // First structured upstream error frame seen during the probe, if any. An
+  // otherwise-200 stream that carries `data: {"error":{...}}` and no content is a
+  // definitive upstream failure (Anthropic `overloaded_error`, an OpenAI
+  // `response.failed`, a request-too-large rejection) — not the transient
+  // "empty stop" hiccup that same-candidate retries target. The caller surfaces
+  // this real error instead of retrying into a generic empty-completion.
+  errorFrame?: SseErrorFrame | null;
   reader: ReadableStreamDefaultReader<Uint8Array>;
   chunks: Uint8Array[];
 }
 
-// Reads from the upstream body until either real content/tool-call/reasoning
-// output is seen, the stream ends, or the probe budget is exhausted — whichever
-// comes first. Every chunk consumed is captured in `chunks` so the caller can
-// replay them verbatim (via `primed`) without losing a single byte, regardless
-// of which outcome is reached.
+// Reads from the upstream body until real content/tool-call/reasoning output is
+// seen, a structured upstream error frame is seen, the stream ends, or the probe
+// budget is exhausted — whichever comes first. Every chunk consumed is captured
+// in `chunks` so the caller can replay them verbatim (via `primed`) without
+// losing a single byte, regardless of which outcome is reached.
 export async function probeStream(body: ReadableStream<Uint8Array>): Promise<StreamProbeResult> {
   const reader = body.getReader();
   const chunks: Uint8Array[] = [];
@@ -68,15 +75,30 @@ export async function probeStream(body: ReadableStream<Uint8Array>): Promise<Str
       ({ done, value } = await reader.read());
     } catch {
       // A read error mid-probe is not this function's concern to report — whatever
-      // content (if any) arrived before the error is all there is to judge on.
-      return { hasContent: sseHasContent(buffer), reader, chunks };
+      // content/error (if any) arrived before it is all there is to judge on.
+      return {
+        hasContent: sseHasContent(buffer),
+        errorFrame: sseErrorFrame(buffer),
+        reader,
+        chunks,
+      };
     }
-    if (done) return { hasContent: sseHasContent(buffer), reader, chunks };
+    if (done)
+      return {
+        hasContent: sseHasContent(buffer),
+        errorFrame: sseErrorFrame(buffer),
+        reader,
+        chunks,
+      };
     if (!value) continue;
     chunks.push(value);
     bytes += value.byteLength;
     buffer += decoder.decode(value, { stream: true });
+    // Content wins over an error frame in the same buffer: real output already
+    // streamed, so relay it and let the relay path record any trailing error.
     if (sseHasContent(buffer)) return { hasContent: true, reader, chunks };
+    const errorFrame = sseErrorFrame(buffer);
+    if (errorFrame) return { hasContent: false, errorFrame, reader, chunks };
   }
 }
 

--- a/packages/llm-gateway/src/transports/anthropic/anthropic.test.ts
+++ b/packages/llm-gateway/src/transports/anthropic/anthropic.test.ts
@@ -160,3 +160,39 @@ describe('translateAnthropicResponse (non-streaming)', () => {
     });
   });
 });
+
+describe('translateAnthropicResponse (streaming)', () => {
+  function anthropicSse(...frames: string[]): Response {
+    return new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode(frames.join('')));
+          controller.close();
+        },
+      }),
+      { status: 200, headers: { 'content-type': 'text/event-stream' } },
+    );
+  }
+
+  test('translates a mid-stream `error` event into an OpenAI-shaped error frame', async () => {
+    const upstream = anthropicSse(
+      'event: message_start\ndata: {"type":"message_start","message":{"id":"msg_1","model":"claude-sonnet-4-6","usage":{"input_tokens":10}}}\n\n',
+      'event: error\ndata: {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}\n\n',
+    );
+    const out = await translateAnthropicResponse(upstream, { streaming: true });
+    const text = await new Response(out.body).text();
+
+    // The error surfaces as a canonical `{error:{...}}` SSE frame that the probe /
+    // sseErrorFrame recognize — not swallowed into a silent empty stop.
+    expect(text).toContain('"error"');
+    const frame = text
+      .split('\n')
+      .find((l) => l.startsWith('data:') && l.includes('"error"'))!
+      .slice(5)
+      .trim();
+    const parsed = JSON.parse(frame) as { error: { message: string; type: string; code: string } };
+    expect(parsed.error.message).toBe('Overloaded');
+    expect(parsed.error.type).toBe('overloaded_error');
+    expect(parsed.error.code).toBe('overloaded_error');
+  });
+});

--- a/packages/llm-gateway/src/transports/anthropic/response.ts
+++ b/packages/llm-gateway/src/transports/anthropic/response.ts
@@ -150,6 +150,21 @@ function translateStreaming(response: Response): Response {
             } else if (t === 'message_delta') {
               if (evt.delta?.stop_reason) finishReason = FINISH_REASON[evt.delta.stop_reason] ?? 'stop';
               if (evt.usage?.output_tokens != null) usage.completion_tokens = evt.usage.output_tokens;
+            } else if (t === 'error') {
+              // Anthropic reports a mid-flight failure (overloaded, request too
+              // large, etc.) as an `error` event on an otherwise-200 stream. Emit
+              // it as an OpenAI-shaped error frame — matching the openai-responses
+              // transport — so the probe/relay surface the real cause instead of
+              // laundering it into a generic empty "stop".
+              const err = evt.error ?? {};
+              const errChunk = {
+                error: {
+                  message: typeof err.message === 'string' ? err.message : 'anthropic upstream error',
+                  type: typeof err.type === 'string' ? err.type : 'upstream_error',
+                  code: typeof err.type === 'string' ? err.type : 'upstream_error',
+                },
+              };
+              controller.enqueue(encoder.encode(`data: ${JSON.stringify(errChunk)}\n\n`));
             } else if (t === 'message_stop') {
               const finalChunk = {
                 id,


### PR DESCRIPTION
## What & why

Triaging the prod gateway (`gateway.kortix.com`) I found **~9% of requests failing as `502 empty_completion`** over a 2h window — **all 82 failures from just two accounts** (runaway agent loops sending large streaming requests). The other 802 requests were fine; this was never a gateway outage.

**Root cause (confirmed in code, not guessed):** when an upstream fails *mid-stream* on an otherwise-200 SSE — Anthropic `overloaded_error`, OpenAI `response.failed`, or a request-too-large rejection — it produces a **content-less** stream. `probeStream` only checked for *content*, so it treated these as the transient "empty stop" hiccup the same-candidate retry was built for: it retried the single candidate 3× (~12–36s wasted) and then returned `empty_completion`, **burying the real upstream error**. The `openai-responses` transport already emits a proper `{error:{...}}` frame for these — but the probe threw it away, and the `anthropic` transport didn't emit one at all.

## Changes
- **`probeStream`** now also detects a structured error frame (via the existing `sseErrorFrame`) and returns it. Content still wins over an error frame in the same buffer.
- **`handler`** surfaces the real error as **`502 upstream_error`** (upstream message + `upstream_code`) instead of the generic `empty_completion`, and **excludes an errored candidate immediately** (no same-candidate retry storm) while still failing over to any *other* candidate.
- **`anthropic` streaming transport** emits an OpenAI-shaped error frame on `error` events, matching the `openai-responses` transport (which previously silently dropped them).
- **Off-by-default request-size guard** (`GATEWAY_MAX_REQUEST_BYTES`, `0` = disabled): returns `413 request_too_large` up front instead of dispatching an over-limit body the upstream will silently drop.

## Tests
New coverage: error-frame → `upstream_error` with no retry storm; error-frame on candidate A still fails over to healthy B; size guard rejects with 413 before dispatch / is a no-op when unset; anthropic `error` event → canonical error frame. **Full `@kortix/llm-gateway` suite (132) + `tsc` green.**

## Deploy notes
- Merging to `main` reconciles to **dev** via Argo (prod is promoted separately).
- The size guard ships **disabled**. Empirically the codex failures clustered just over **1 MiB** (largest *successful* request was 1,048,029 bytes) — set `GATEWAY_MAX_REQUEST_BYTES=1048576` to turn 502-after-retries into an instant 413. I left it off by default because the safe margin against legitimate large-context traffic is thin and provider-specific.

## Honest scope limits
- The **anthropic** failures (account `af802d0f`) were ~267 KB — *smaller* than that account's ~344 KB successes — so size is **not** their cause. This PR makes those failures surface their **real** upstream error (whatever it is) instead of `empty_completion`; the actual cause (likely the concurrent Anthropic incident that afternoon, or that account's request shape) needs the Langfuse upstream bodies to confirm.
- Did **not** touch the ~1.8k/2h `Data is not base64 encoded` log lines — they originate in a dependency (stack frames don't match our source) and occur on *succeeding* requests. Separate, cosmetic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)