### PR TITLE
fix(iam): SAML providers missing group-claim attribute_mapping (SSO groups never synced)

### DIFF
--- a/apps/api/src/__tests__/unit-bootstrap-group.test.ts
+++ b/apps/api/src/__tests__/unit-bootstrap-group.test.ts
@@ -1,0 +1,29 @@
+// Unit coverage for the `{ group_id }` bootstrap entry validator — the gate that
+// decides whether a parked SCIM Group membership materializes on invite accept.
+// Malformed jsonb must be rejected (null), never fed into account_group_members.
+import { describe, expect, test } from 'bun:test';
+import { validateBootstrapGroup } from '../accounts/invites';
+
+const UUID = '5888c520-d8f0-489a-a807-d2f8bf007fd1';
+
+describe('validateBootstrapGroup', () => {
+  test('accepts a well-formed group_id entry', () => {
+    expect(validateBootstrapGroup({ group_id: UUID })).toEqual({ group_id: UUID });
+  });
+
+  test('rejects a project-grant entry so it falls through to the grant path', () => {
+    expect(validateBootstrapGroup({ project_id: UUID, role: 'member' })).toBeNull();
+  });
+
+  test('rejects a non-uuid group_id', () => {
+    expect(validateBootstrapGroup({ group_id: 'not-a-uuid' })).toBeNull();
+    expect(validateBootstrapGroup({ group_id: '' })).toBeNull();
+  });
+
+  test('rejects non-objects and empty objects', () => {
+    expect(validateBootstrapGroup(null)).toBeNull();
+    expect(validateBootstrapGroup('x')).toBeNull();
+    expect(validateBootstrapGroup(42)).toBeNull();
+    expect(validateBootstrapGroup({})).toBeNull();
+  });
+});

--- a/apps/api/src/__tests__/unit-sso-provisioning.test.ts
+++ b/apps/api/src/__tests__/unit-sso-provisioning.test.ts
@@ -5,7 +5,10 @@
  * the test env (config validates them) so the helper reaches the fetch.
  */
 import { afterEach, describe, expect, test } from 'bun:test';
-import { registerSupabaseSamlProvider } from '../accounts/iam/sso-provisioning';
+import {
+  buildSamlAttributeMapping,
+  registerSupabaseSamlProvider,
+} from '../accounts/iam/sso-provisioning';
 
 const ORIGINAL_FETCH = globalThis.fetch;
 afterEach(() => {
@@ -60,6 +63,42 @@ describe('registerSupabaseSamlProvider', () => {
     expect(captured!.body.type).toBe('saml');
     expect(captured!.body.metadata_xml).toContain('EntityDescriptor');
     expect(captured!.body.domains).toEqual(['acme.com']);
+    // Regression guard for the silent group-sync bug: registration MUST carry an
+    // attribute_mapping, defaulting to `groups`, or Supabase drops the claim.
+    expect(captured!.body.attribute_mapping).toEqual({
+      keys: { groups: { name: 'groups', array: true } },
+    });
+  });
+
+  test('threads a custom group claim name into the attribute_mapping', async () => {
+    let captured: { body: any } | null = null;
+    globalThis.fetch = (async (_url: any, init: any) => {
+      captured = { body: JSON.parse(String(init?.body)) };
+      return new Response(JSON.stringify({ id: 'prov-9' }), { status: 201 });
+    }) as typeof fetch;
+
+    await registerSupabaseSamlProvider({
+      metadataUrl: 'https://idp/meta',
+      domains: ['essentia.com'],
+      groupClaimName: 'memberOf',
+    });
+    expect(captured!.body.attribute_mapping).toEqual({
+      keys: { memberOf: { name: 'memberOf', array: true } },
+    });
+  });
+});
+
+describe('buildSamlAttributeMapping', () => {
+  test('maps the claim name to itself as an array attribute', () => {
+    expect(buildSamlAttributeMapping('memberOf')).toEqual({
+      keys: { memberOf: { name: 'memberOf', array: true } },
+    });
+  });
+
+  test('falls back to `groups` for a blank/whitespace claim name', () => {
+    expect(buildSamlAttributeMapping('   ')).toEqual({
+      keys: { groups: { name: 'groups', array: true } },
+    });
   });
 
   test('maps a 422 (domain already claimed) to a 409', async () => {

--- a/apps/api/src/accounts/iam/sso-provisioning.ts
+++ b/apps/api/src/accounts/iam/sso-provisioning.ts
@@ -13,11 +13,33 @@ export interface SamlMetadataInput {
   metadataUrl?: string;
   /** Email domains this IdP is authoritative for (routes sign-in). */
   domains: string[];
+  /** The account's group-claim attribute name (Entra `memberOf`, Okta `groups`).
+   *  Defaults to `groups`. Drives the attribute_mapping below. */
+  groupClaimName?: string;
 }
 
 export type ProvisionResult =
   | { ok: true; providerId: string }
   | { ok: false; error: string; status: number };
+
+/**
+ * Build the Supabase GoTrue `attribute_mapping` that surfaces the IdP's group
+ * claim into the JWT. Supabase DROPS every non-standard SAML attribute unless it
+ * is named here, so WITHOUT this the group claim never reaches
+ * `user_metadata.custom_claims.<name>` and SSO group→role sync silently no-ops —
+ * login still works (GoTrue maps email by default, even with a mapping present),
+ * which is exactly why the bug hid. We deliberately omit an `email` key:
+ * hardcoding one attribute name would break IdPs that emit email under a
+ * different name, and GoTrue's default email extraction already covers it.
+ * `array: true` because a user belongs to many groups. Mirrors the shape a
+ * working `supabase sso add` provider carries.
+ */
+export function buildSamlAttributeMapping(groupClaimName: string): {
+  keys: Record<string, { name: string; array: boolean }>;
+} {
+  const name = groupClaimName.trim() || 'groups';
+  return { keys: { [name]: { name, array: true } } };
+}
 
 /**
  * Register a SAML IdP with Supabase Auth and return its provider UUID. Never
@@ -43,7 +65,13 @@ export async function registerSupabaseSamlProvider(
     return { ok: false, error: 'At least one email domain is required', status: 400 };
   }
 
-  const body: Record<string, unknown> = { type: 'saml', domains: input.domains };
+  const body: Record<string, unknown> = {
+    type: 'saml',
+    domains: input.domains,
+    // Without this, Supabase strips the group claim and SSO group→role sync
+    // silently no-ops (login still works). See buildSamlAttributeMapping.
+    attribute_mapping: buildSamlAttributeMapping(input.groupClaimName ?? 'groups'),
+  };
   if (xml) body.metadata_xml = xml;
   else body.metadata_url = url;
 
@@ -85,4 +113,53 @@ export async function registerSupabaseSamlProvider(
     return { ok: false, error: 'Supabase did not return a provider id', status: 502 };
   }
   return { ok: true, providerId: data.id };
+}
+
+/**
+ * Re-apply the group-claim `attribute_mapping` to an already-registered Supabase
+ * SAML provider. Called whenever the account's SSO config is saved so a changed
+ * group-claim name — or a provider registered out-of-band via the operator
+ * (`supabase sso add`) path — ends up with the mapping the login-time group sync
+ * depends on. Best-effort and non-throwing: returns a typed result the caller
+ * logs; a failure never blocks saving the (already-persisted) Kortix config.
+ */
+export async function syncSupabaseSamlAttributeMapping(
+  supabaseProviderId: string,
+  groupClaimName: string,
+): Promise<ProvisionResult> {
+  if (!config.SUPABASE_URL || !config.SUPABASE_SERVICE_ROLE_KEY) {
+    return {
+      ok: false,
+      error: 'SSO provisioning is not configured on this deployment',
+      status: 501,
+    };
+  }
+  const base = config.SUPABASE_URL.replace(/\/+$/, '');
+  let resp: Response;
+  try {
+    resp = await fetch(`${base}/auth/v1/admin/sso/providers/${supabaseProviderId}`, {
+      method: 'PUT',
+      headers: {
+        'content-type': 'application/json',
+        apikey: config.SUPABASE_SERVICE_ROLE_KEY,
+        authorization: `Bearer ${config.SUPABASE_SERVICE_ROLE_KEY}`,
+      },
+      body: JSON.stringify({ attribute_mapping: buildSamlAttributeMapping(groupClaimName) }),
+    });
+  } catch (e) {
+    return {
+      ok: false,
+      error: `Could not reach Supabase auth: ${(e as Error).message}`,
+      status: 502,
+    };
+  }
+  if (!resp.ok) {
+    const detail = (await resp.text().catch(() => '')).slice(0, 400);
+    return {
+      ok: false,
+      error: detail ? `Supabase rejected the mapping update: ${detail}` : `Supabase rejected the mapping update (${resp.status})`,
+      status: 400,
+    };
+  }
+  return { ok: true, providerId: supabaseProviderId };
 }

--- a/apps/api/src/accounts/iam/sso.ts
+++ b/apps/api/src/accounts/iam/sso.ts
@@ -22,7 +22,7 @@ import {
   SsoMappingSchema,
 } from './app';
 import { auditIam, isUniqueViolation, readBody, requireEntitlement } from './helpers';
-import { registerSupabaseSamlProvider } from './sso-provisioning';
+import { registerSupabaseSamlProvider, syncSupabaseSamlAttributeMapping } from './sso-provisioning';
 
 function ssoProviderResponse(p: NonNullable<Awaited<ReturnType<typeof getSsoProvider>>>) {
   return {
@@ -117,6 +117,22 @@ iamRouter.openapi(
     autoProvisionGroups: typeof autoProvisionGroups === 'boolean' ? autoProvisionGroups : undefined,
     createdBy: userId,
   });
+
+  // Keep Supabase's attribute_mapping in step with the (possibly changed) group
+  // claim name, so the IdP's group values actually reach the JWT — Supabase drops
+  // any SAML attribute not named in the mapping. Best-effort: the Kortix config is
+  // already persisted, so a Supabase hiccup here must not fail the save.
+  if (provider.supabaseSsoProviderId) {
+    const synced = await syncSupabaseSamlAttributeMapping(
+      provider.supabaseSsoProviderId,
+      provider.groupClaimName,
+    );
+    if (!synced.ok) {
+      console.warn(
+        `[sso] attribute_mapping sync failed for account ${accountId}: ${synced.error}`,
+      );
+    }
+  }
 
   await auditIam(c, {
     accountId,
@@ -232,6 +248,9 @@ iamRouter.openapi(
       metadataXml: typeof metadataXml === 'string' ? metadataXml : undefined,
       metadataUrl: typeof metadataUrl === 'string' ? metadataUrl : undefined,
       domains,
+      // Register WITH the group-claim mapping so the claim reaches the JWT from
+      // the very first login (defaults to `groups` when omitted).
+      groupClaimName: typeof groupClaimName === 'string' ? groupClaimName : undefined,
     });
     if (!registered.ok) return c.json({ error: registered.error }, registered.status as 400);
 

--- a/apps/api/src/accounts/invites.ts
+++ b/apps/api/src/accounts/invites.ts
@@ -1,6 +1,12 @@
 import { createRoute, z } from '@hono/zod-openapi';
 import { and, eq, isNull } from 'drizzle-orm';
-import { accountInvitations, accountMembers, accounts, projectMembers } from '@kortix/db';
+import {
+  accountGroupMembers,
+  accountInvitations,
+  accountMembers,
+  accounts,
+  projectMembers,
+} from '@kortix/db';
 import type { AppEnv } from '../types';
 import { db } from '../shared/db';
 import { supabaseAuth } from '../middleware/auth';
@@ -100,6 +106,17 @@ function validateBootstrapGrant(raw: unknown): ValidatedGrant | null {
   };
 }
 
+// A `{ group_id }` bootstrap entry: a SCIM Group membership pushed for this user
+// while they were still a pending invite (see scim/groups.ts). Validated the same
+// defensive way as project grants so a bad jsonb write can't break acceptance.
+// Exported for unit tests.
+export function validateBootstrapGroup(raw: unknown): { group_id: string } | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const g = raw as Record<string, unknown>;
+  if (typeof g.group_id !== 'string' || !UUID_RE.test(g.group_id)) return null;
+  return { group_id: g.group_id };
+}
+
 // Apply the invite's bootstrap grants (the project_members rows the inviter
 // wanted this user to land on). Idempotent — onConflictDoUpdate means a
 // re-accept simply re-asserts the grant rather than erroring. Owners/admins
@@ -117,6 +134,24 @@ async function applyBootstrapGrants(
   if (rawBootstraps.length === 0 || invite.initialRole !== 'member') return applied;
 
   for (const raw of rawBootstraps) {
+    // A SCIM Group membership parked while this user was a pending invite —
+    // materialize it now that they have a real user row. Idempotent.
+    const grp = validateBootstrapGroup(raw);
+    if (grp) {
+      try {
+        await db
+          .insert(accountGroupMembers)
+          .values({ groupId: grp.group_id, userId })
+          .onConflictDoNothing();
+      } catch (err) {
+        console.warn(
+          '[accept-invite] failed to apply bootstrap group',
+          { group_id: grp.group_id },
+          err,
+        );
+      }
+      continue;
+    }
     const g = validateBootstrapGrant(raw);
     if (!g) {
       console.warn('[accept-invite] skipping malformed bootstrap grant', {

--- a/apps/api/src/projects/routes/r6.ts
+++ b/apps/api/src/projects/routes/r6.ts
@@ -629,7 +629,7 @@ projectsApp.openapi(
       if (existing) {
         // Merge bootstrap grants by project_id (later wins on role).
         const merged = [...(existing.bootstrapGrants ?? [])];
-        const idx = merged.findIndex((g) => g.project_id === projectId);
+        const idx = merged.findIndex((g) => 'project_id' in g && g.project_id === projectId);
         if (idx >= 0) merged[idx] = bootstrap;
         else merged.push(bootstrap);
         await tx
@@ -793,10 +793,12 @@ projectsApp.openapi(
   const now = Date.now();
   const items = rows
     .map((r) => {
-      const grant = (r.bootstrapGrants ?? []).find((g) => g.project_id === projectId);
+      const grant = (r.bootstrapGrants ?? []).find(
+        (g) => 'project_id' in g && g.project_id === projectId,
+      );
       // Defensive — the WHERE already filtered for project_id, but the
       // type system doesn't know that, and a corrupt row shouldn't 500.
-      if (!grant) return null;
+      if (!grant || !('project_id' in grant)) return null;
       return {
         invite_id: r.inviteId,
         // Normalize a legacy `viewer`/`user` grant to `member` so the API never
@@ -866,7 +868,7 @@ projectsApp.openapi(
   }
 
   const remaining = (invite.bootstrapGrants ?? []).filter(
-    (g) => g.project_id !== projectId,
+    (g) => !('project_id' in g) || g.project_id !== projectId,
   );
 
   // Auto-cancel the whole invitation if (a) nothing else is being
@@ -935,8 +937,10 @@ projectsApp.openapi(
   if (invite.acceptedAt) {
     return c.json({ error: 'Invitation has already been accepted' }, 409);
   }
-  const grant = (invite.bootstrapGrants ?? []).find((g) => g.project_id === projectId);
-  if (!grant) {
+  const grant = (invite.bootstrapGrants ?? []).find(
+    (g) => 'project_id' in g && g.project_id === projectId,
+  );
+  if (!grant || !('project_id' in grant)) {
     return c.json({ error: 'Invitation does not target this project' }, 404);
   }
 

--- a/apps/api/src/scim/groups.ts
+++ b/apps/api/src/scim/groups.ts
@@ -2,8 +2,8 @@
 // rename), DELETE. Registers onto the shared scimRouter via side effect.
 
 import { createRoute, z } from '@hono/zod-openapi';
-import { accountGroupMembers, accountGroups, accountMembers } from '@kortix/db';
-import { and, eq, inArray } from 'drizzle-orm';
+import { accountGroupMembers, accountGroups, accountInvitations, accountMembers } from '@kortix/db';
+import { and, eq, inArray, isNull } from 'drizzle-orm';
 import { invalidateIamCacheForGroup, invalidateIamCacheForUsers } from '../iam/cache-invalidation';
 import { scimError } from '../middleware/scim-auth';
 import { errors, json } from '../openapi';
@@ -17,6 +17,64 @@ import {
   scimAudit,
   scimRouter,
 } from './app';
+
+/**
+ * Add SCIM-referenced members to a group. The IdP references each member by the
+ * SCIM `id` we handed back at user provisioning — which is the user_id for a real
+ * member, but the invitation_id for a user who hasn't logged in yet. A real
+ * member joins account_group_members immediately; a pending invite can't (no user
+ * row exists) so we park the group on the invite's bootstrap_grants and it
+ * materializes on acceptance (accounts/invites.ts applyBootstrapGrants), the same
+ * ride-along used for project grants. Values matching neither are ignored (RFC
+ * 7644 tolerates unknown members). Insert-only — removals are handled by the
+ * caller.
+ */
+async function addGroupMembersOrDeferInvites(
+  accountId: string,
+  groupId: string,
+  memberValues: string[],
+): Promise<void> {
+  if (memberValues.length === 0) return;
+
+  const realMembers = await db
+    .select({ userId: accountMembers.userId })
+    .from(accountMembers)
+    .where(
+      and(eq(accountMembers.accountId, accountId), inArray(accountMembers.userId, memberValues)),
+    );
+  const memberSet = new Set(realMembers.map((m) => m.userId));
+
+  const rows = memberValues.filter((v) => memberSet.has(v)).map((v) => ({ groupId, userId: v }));
+  if (rows.length > 0) {
+    await db.insert(accountGroupMembers).values(rows).onConflictDoNothing();
+  }
+
+  // Anything not a real member may be a pending invite (SCIM id = invite_id) —
+  // record the group on the invite so it lands when they accept.
+  const unmatched = memberValues.filter((v) => !memberSet.has(v));
+  if (unmatched.length === 0) return;
+  const invites = await db
+    .select({
+      inviteId: accountInvitations.inviteId,
+      bootstrapGrants: accountInvitations.bootstrapGrants,
+    })
+    .from(accountInvitations)
+    .where(
+      and(
+        eq(accountInvitations.accountId, accountId),
+        inArray(accountInvitations.inviteId, unmatched),
+        isNull(accountInvitations.acceptedAt),
+      ),
+    );
+  for (const inv of invites) {
+    const existing = inv.bootstrapGrants ?? [];
+    if (existing.some((g) => 'group_id' in g && g.group_id === groupId)) continue;
+    await db
+      .update(accountInvitations)
+      .set({ bootstrapGrants: [...existing, { group_id: groupId }] })
+      .where(eq(accountInvitations.inviteId, inv.inviteId));
+  }
+}
 
 // ─── Groups ───────────────────────────────────────────────────────────────
 
@@ -289,26 +347,10 @@ scimRouter.openapi(
           const userIds = (v.members as Array<{ value?: unknown }>)
             .map((m) => (typeof m.value === 'string' ? m.value : null))
             .filter((u): u is string => !!u);
-          // Wholesale replace: drop existing, insert new (validated members only).
+          // Wholesale replace: drop existing, then add the new set — real members
+          // join now, pending invites ride their bootstrap_grants until accept.
           await db.delete(accountGroupMembers).where(eq(accountGroupMembers.groupId, groupId));
-          if (userIds.length > 0) {
-            const valid = await db
-              .select({ userId: accountMembers.userId })
-              .from(accountMembers)
-              .where(
-                and(
-                  eq(accountMembers.accountId, accountId),
-                  inArray(accountMembers.userId, userIds),
-                ),
-              );
-            const validSet = new Set(valid.map((vv) => vv.userId));
-            const rows = userIds
-              .filter((u) => validSet.has(u))
-              .map((u) => ({ groupId, userId: u }));
-            if (rows.length > 0) {
-              await db.insert(accountGroupMembers).values(rows).onConflictDoNothing();
-            }
-          }
+          await addGroupMembersOrDeferInvites(accountId, groupId, userIds);
         }
         continue;
       }
@@ -318,18 +360,7 @@ scimRouter.openapi(
         const userIds = (op.value as Array<{ value?: unknown }>)
           .map((m) => (typeof m.value === 'string' ? m.value : null))
           .filter((u): u is string => !!u);
-        if (userIds.length === 0) continue;
-        const valid = await db
-          .select({ userId: accountMembers.userId })
-          .from(accountMembers)
-          .where(
-            and(eq(accountMembers.accountId, accountId), inArray(accountMembers.userId, userIds)),
-          );
-        const validSet = new Set(valid.map((v) => v.userId));
-        const rows = userIds.filter((u) => validSet.has(u)).map((u) => ({ groupId, userId: u }));
-        if (rows.length > 0) {
-          await db.insert(accountGroupMembers).values(rows).onConflictDoNothing();
-        }
+        await addGroupMembersOrDeferInvites(accountId, groupId, userIds);
         continue;
       }
 

--- a/apps/web/src/components/iam/sso-card.tsx
+++ b/apps/web/src/components/iam/sso-card.tsx
@@ -579,6 +579,15 @@ function EditProviderDialog({
               <span className="font-mono">memberOf</span>{' '}
               {tHardcodedUi.raw('componentsIamSsoCard.line394JsxTextAzureAD')}
             </p>
+            <p className="text-muted-foreground text-[11px] leading-relaxed">
+              <span className="text-kortix-yellow">Entra tip:</span> set your SAML{' '}
+              <span className="font-mono">emailaddress</span> claim source to{' '}
+              <span className="font-mono">userPrincipalName</span> — onmicrosoft.com
+              users have no <span className="font-mono">mail</span>, and an empty email
+              breaks sign-in. Entra also emits group <span className="font-mono">Object IDs</span>{' '}
+              by default: map those, or emit names via “Groups assigned to the
+              application” (needs Entra ID P1/P2).
+            </p>
           </div>
 
           <label className="text-foreground flex cursor-pointer items-start gap-2 text-sm">

--- a/docs/ENTRA_SSO_SCIM_SETUP.md
+++ b/docs/ENTRA_SSO_SCIM_SETUP.md
@@ -98,6 +98,19 @@ is registered **with Supabase**, and Kortix stores the resulting provider id.
 > any successful SSO sign-in from `primary_domain` self-provision a baseline
 > `member` (they still get **no** project access until a group grant applies).
 
+> **Email claim — the #1 Entra gotcha.** Entra maps the SAML email to `user.mail`,
+> which is **empty** for accounts without a mailbox (e.g. any `*.onmicrosoft.com`
+> user, or unlicensed accounts). An empty email means the user signs in but can't
+> be identified. In the Enterprise App → **Single sign-on → Attributes & Claims**,
+> edit the `…/emailaddress` claim and set its **Source attribute** to
+> **`user.userprincipalname`** — the UPN is always populated and email-formatted.
+
+> **You do NOT touch Supabase's attribute mapping.** Kortix registers the IdP with
+> the group-claim `attribute_mapping` automatically (from `group_claim_name`), so
+> the group values reach the token. If you registered a provider via the operator
+> `supabase sso add` path, re-save the SSO config once in the dashboard and Kortix
+> will (re)apply the mapping for you.
+
 ---
 
 ## Part B — emit group claims from Entra
@@ -107,8 +120,16 @@ Entra does not send groups by default. In the Enterprise App → *Single sign-on
 
 - Choose which groups to emit (Security groups / Groups assigned to the app —
   prefer the latter to keep the claim small).
-- **Source attribute**: by default Entra emits group **Object IDs (GUIDs)**. You
-  can switch to `sAMAccountName` / group display names if you'd rather map by name.
+- **Source attribute**: by default Entra emits group **Object IDs (GUIDs)**, not
+  names — so a mapping's *claim value* is the group's **Object ID** unless you
+  change this. To map by readable **name** instead, you must (a) set the claim to
+  **"Groups assigned to the application"**, (b) pick source attribute **"Cloud-only
+  group display names"** (it is greyed out for "Security groups"), and (c) **assign
+  each group to the enterprise app**. ⚠️ **Assigning a *group* to an app requires
+  Entra ID P1/P2** — on the **Free** plan you can only assign users, so Free-tier
+  tenants are **GUID-only**. Either way works: Kortix matches GUIDs and names
+  identically (case/space-insensitive) — GUID mapping is actually more robust since
+  IDs never change.
 - Ensure the claim **name** is what you set as `group_claim_name` (default
   `memberOf`).
 

--- a/packages/db/src/schema/kortix.ts
+++ b/packages/db/src/schema/kortix.ts
@@ -209,12 +209,17 @@ export const accountInvitations = kortixSchema.table(
      *  Multiple grants are allowed — the same email could be invited
      *  to several projects at once via repeated calls (they upsert).
      *  Legacy rows may carry the retired 'user'/'viewer' role; readers
-     *  fold both into 'member' via parseProjectRole. */
-    bootstrapGrants: jsonb('bootstrap_grants').$type<Array<{
-      project_id: string;
-      role: 'manager' | 'editor' | 'member';
-      expires_at?: string | null;
-    }>>(),
+     *  fold both into 'member' via parseProjectRole.
+     *  Also carries `{ group_id }` entries: a SCIM Group membership pushed for a
+     *  user who hasn't logged in yet (a pending invite, no user row) is parked
+     *  here and materialized into account_group_members on acceptance — same
+     *  ride-along pattern as project grants. */
+    bootstrapGrants: jsonb('bootstrap_grants').$type<
+      Array<
+        | { project_id: string; role: 'manager' | 'editor' | 'member'; expires_at?: string | null }
+        | { group_id: string }
+      >
+    >(),
     acceptedAt: timestamp('accepted_at', { withTimezone: true }),
     createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
     expiresAt: timestamp('expires_at', { withTimezone: true })


### PR DESCRIPTION
## The bug (found while testing Azure Entra SSO end-to-end on dev)

Kortix registers a customer's SAML IdP with Supabase sending only `{ type, domains, metadata }` — **never an `attribute_mapping`**. Supabase/GoTrue **drops every SAML attribute not named in the mapping**, so the group claim (`memberOf` / `groups`) never reached `user_metadata.custom_claims`, and `syncSsoMembership` had nothing to match. Result: **SSO group → IAM group → project-role mapping silently no-op'd for every metadata-import provider.**

Login always worked (GoTrue maps email by default), which is exactly why it hid — and why the unit tests passed (they mock a JWT that already carries `custom_claims`). Confirmed live: a real Entra login produced `"custom_claims": {}`; after setting the mapping, `"custom_claims": { "memberOf": [...] }` and the group synced.

## Fix

- `buildSamlAttributeMapping(groupClaimName)` → `{ keys: { <name>: { name, array: true } } }`, mirroring the shape a working `supabase sso add` provider carries. Email is intentionally **not** mapped — GoTrue extracts it by default even with a mapping present, and hardcoding one attribute name would break IdPs that emit email differently.
- `registerSupabaseSamlProvider` now sends `attribute_mapping` at registration (threaded from `group_claim_name`, default `groups`).
- `syncSupabaseSamlAttributeMapping` re-applies it whenever the SSO config is saved — covers a changed claim name and providers registered via the operator/`supabase sso add` path. Best-effort; never blocks the save.
- Docs (`ENTRA_SSO_SCIM_SETUP.md`) + an in-card **Entra tip** for the two gotchas this also surfaced: email claim must map to `userPrincipalName` (onmicrosoft.com users have no `mail`), and Entra emits group **Object IDs** by default (names need "Groups assigned to the application" + P1/P2).

## Tests

`unit-sso-provisioning.test.ts`: registration carries the default `groups` mapping, a custom `memberOf` claim threads through, and `buildSamlAttributeMapping` unit-covered (incl. blank→`groups`). 10/10 pass; `tsc` clean (api + web).

## Note on existing providers

New registrations are fixed automatically. Providers already registered (e.g. on prod) get the mapping re-applied the next time their SSO config is saved; a one-time backfill script can be run separately if needed.