### PR TITLE
fix(iam-web): hide Supabase internals from the SSO card

### DIFF
--- a/apps/web/src/components/iam/sso-card.test.ts
+++ b/apps/web/src/components/iam/sso-card.test.ts
@@ -1,0 +1,35 @@
+// The SSO card is customer-facing (enterprise admins): the Supabase delegation
+// is an internal implementation detail and must never surface in the UI — no
+// provider-UUID field, no "register it in Supabase Studio" copy. The id still
+// exists on the wire; the card threads it silently on edit.
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const source = readFileSync(join(import.meta.dir, 'sso-card.tsx'), 'utf8');
+
+describe('SSO card — no internal provider plumbing in the UI', () => {
+  test('the provider summary does not render the internal provider id', () => {
+    expect(source).not.toContain('SupabaseProviderId');
+  });
+
+  test('no UUID input or advanced registration mode is offered', () => {
+    expect(source).not.toContain('SupabaseProviderUUID');
+    expect(source).not.toContain('Advanced: Supabase UUID');
+    expect(source).not.toContain('setSupabaseId');
+  });
+
+  test('no dialog copy points admins at Supabase Studio', () => {
+    expect(source).not.toContain('SupabaseStudio');
+    expect(source).not.toContain('Supabase Studio');
+  });
+
+  test('edits thread the stored provider id under the hood', () => {
+    expect(source).toContain('existing!.supabase_sso_provider_id');
+  });
+
+  test('new providers register via metadata import only', () => {
+    expect(source).toContain('const importing = !existing');
+    expect(source).toContain('importSsoProviderFromMetadata');
+  });
+});

--- a/apps/web/src/components/iam/sso-card.tsx
+++ b/apps/web/src/components/iam/sso-card.tsx
@@ -180,7 +180,7 @@ export function SsoCard({ accountId, canManage }: SsoCardProps) {
                   )}
                 </dd>
               </div>
-              <div className="border-border/40 flex items-center justify-between gap-4 border-b py-2">
+              <div className="flex items-center justify-between gap-4 py-2">
                 <dt className="text-muted-foreground shrink-0">Auto-provision groups</dt>
                 <dd className="text-right">
                   {provider.auto_provision_groups ? (
@@ -191,14 +191,6 @@ export function SsoCard({ accountId, canManage }: SsoCardProps) {
                   ) : (
                     <span className="text-muted-foreground">No</span>
                   )}
-                </dd>
-              </div>
-              <div className="flex items-center justify-between gap-4 py-2">
-                <dt className="text-muted-foreground shrink-0">
-                  {tHardcodedUi.raw('componentsIamSsoCard.line143JsxTextSupabaseProviderId')}
-                </dt>
-                <dd className="text-muted-foreground min-w-0 truncate text-right font-mono text-[11px]">
-                  {provider.supabase_sso_provider_id}
                 </dd>
               </div>
             </dl>
@@ -366,15 +358,13 @@ function EditProviderDialog({
 }) {
   const tHardcodedUi = useTranslations('hardcodedUi');
   const [name, setName] = useState(existing?.name ?? '');
-  const [supabaseId, setSupabaseId] = useState(existing?.supabase_sso_provider_id ?? '');
   const [domain, setDomain] = useState(existing?.primary_domain ?? '');
   const [claim, setClaim] = useState(existing?.group_claim_name ?? 'groups');
   const [autoCreate, setAutoCreate] = useState(existing?.auto_create_members ?? true);
   const [autoProvision, setAutoProvision] = useState(existing?.auto_provision_groups ?? false);
-  // Import path (new providers only): paste the IdP metadata XML or its URL and
-  // we register it with Supabase server-side. Editing an existing provider keeps
-  // the advanced UUID form (the Supabase provider already exists).
-  const [mode, setMode] = useState<'metadata' | 'uuid'>(existing ? 'uuid' : 'metadata');
+  // New providers register by importing the IdP metadata (XML or URL) — the
+  // backend handles the identity-provider registration; no internals surface in
+  // the UI. Edits reuse the stored provider id under the hood.
   const [metaKind, setMetaKind] = useState<'xml' | 'url'>('xml');
   const [metaXml, setMetaXml] = useState('');
   const [metaUrl, setMetaUrl] = useState('');
@@ -383,19 +373,17 @@ function EditProviderDialog({
   useMemo(() => {
     if (open) {
       setName(existing?.name ?? '');
-      setSupabaseId(existing?.supabase_sso_provider_id ?? '');
       setDomain(existing?.primary_domain ?? '');
       setClaim(existing?.group_claim_name ?? 'groups');
       setAutoCreate(existing?.auto_create_members ?? true);
       setAutoProvision(existing?.auto_provision_groups ?? false);
-      setMode(existing ? 'uuid' : 'metadata');
       setMetaKind('xml');
       setMetaXml('');
       setMetaUrl('');
     }
   }, [open, existing]);
 
-  const importing = mode === 'metadata' && !existing;
+  const importing = !existing;
   const mutation = useMutation({
     mutationFn: () =>
       importing
@@ -410,7 +398,9 @@ function EditProviderDialog({
               : { metadata_url: metaUrl.trim() }),
           })
         : upsertSsoProvider(accountId, {
-            supabase_sso_provider_id: supabaseId.trim(),
+            // Threaded from the loaded provider — an internal id, never shown
+            // or editable in the UI.
+            supabase_sso_provider_id: existing!.supabase_sso_provider_id,
             name: name.trim(),
             primary_domain: domain.trim().toLowerCase(),
             group_claim_name: claim.trim() || 'groups',
@@ -430,7 +420,7 @@ function EditProviderDialog({
   const ready =
     name.trim().length > 0 &&
     /^[a-z0-9.-]+\.[a-z]{2,}$/i.test(domain.trim()) &&
-    (importing ? metadataReady : /^[0-9a-f-]{36}$/i.test(supabaseId.trim()));
+    (importing ? metadataReady : true);
 
   return (
     <Dialog open={open} onOpenChange={(o) => !mutation.isPending && onOpenChange(o)}>
@@ -439,41 +429,12 @@ function EditProviderDialog({
           <DialogTitle>{existing ? 'Edit SAML provider' : 'Configure SAML SSO'}</DialogTitle>
           <DialogDescription>
             {existing
-              ? tHardcodedUi.raw(
-                  'componentsIamSsoCard.line343JsxTextCreateTheProviderInSupabaseStudioAuthenticationSSO',
-                )
-              : 'Paste your IdP’s SAML metadata (Entra → “App Federation Metadata XML”) and we register it for you — no Supabase step.'}
+              ? 'Update the display name, sign-in domain, and group-claim settings for your identity provider.'
+              : 'Paste your IdP’s SAML metadata (Entra → “App Federation Metadata XML”) and we register it for you.'}
           </DialogDescription>
         </DialogHeader>
 
         <div className="space-y-4">
-          {/* New providers choose how to register: import metadata (self-serve)
-              or the advanced pre-registered Supabase UUID path. */}
-          {!existing && (
-            <div className="border-border/70 inline-flex overflow-hidden rounded-md border">
-              {(
-                [
-                  ['metadata', 'Import IdP metadata'],
-                  ['uuid', 'Advanced: Supabase UUID'],
-                ] as const
-              ).map(([m, label]) => (
-                <button
-                  key={m}
-                  type="button"
-                  onClick={() => setMode(m)}
-                  disabled={mutation.isPending}
-                  className={
-                    mode === m
-                      ? 'bg-secondary text-foreground px-3 py-1.5 text-xs font-medium'
-                      : 'text-muted-foreground hover:bg-muted/50 px-3 py-1.5 text-xs'
-                  }
-                >
-                  {label}
-                </button>
-              ))}
-            </div>
-          )}
-
           <div className="space-y-1.5">
             <Label>{tHardcodedUi.raw('componentsIamSsoCard.line350JsxTextDisplayName')}</Label>
             <Input
@@ -484,7 +445,7 @@ function EditProviderDialog({
             />
           </div>
 
-          {importing ? (
+          {importing && (
             <div className="space-y-1.5">
               <div className="flex items-center justify-between">
                 <Label>IdP SAML metadata</Label>
@@ -532,19 +493,6 @@ function EditProviderDialog({
               <p className="text-muted-foreground text-[11px]">
                 From Entra: Enterprise App → Single sign-on → SAML → “App Federation Metadata XML”.
               </p>
-            </div>
-          ) : (
-            <div className="space-y-1.5">
-              <Label>
-                {tHardcodedUi.raw('componentsIamSsoCard.line360JsxTextSupabaseProviderUUID')}
-              </Label>
-              <Input
-                value={supabaseId}
-                onChange={(e) => setSupabaseId(e.target.value)}
-                placeholder="00000000-0000-0000-0000-000000000000"
-                className="font-mono text-xs"
-                disabled={mutation.isPending}
-              />
             </div>
           )}
 
@@ -642,7 +590,7 @@ function EditProviderDialog({
             className="gap-1.5"
           >
             {mutation.isPending && <Loader2 className="h-4 w-4 animate-spin" />}
-            {existing ? 'Save changes' : importing ? 'Import & configure' : 'Configure SSO'}
+            {existing ? 'Save changes' : 'Import & configure'}
           </Button>
         </DialogFooter>
       </DialogContent>


### PR DESCRIPTION
The SSO card leaked implementation internals to customer-facing enterprise admins:

- a **Supabase provider id** row in the provider summary
- an **"Advanced: Supabase UUID"** registration mode with a paste-a-UUID input
- edit-dialog copy telling admins to *"Create the provider in Supabase Studio (Authentication → SSO) first"*

None of that should exist for a customer (e.g. an enterprise pilot customer's IT admin) — Supabase is our SP delegation detail, not part of the product surface.

## Changes (`sso-card.tsx`, UI-only — no API change)
- Provider summary: internal id row removed.
- Edit dialog: neutral copy; name/domain/claim/toggles only. The stored `supabase_sso_provider_id` is threaded into the PUT under the hood (`existing!.supabase_sso_provider_id`) — never shown, never editable.
- New providers: metadata import is the only path (mode toggle + UUID input removed). The operator/pre-registered-UUID path still exists at the API level (`PUT …/iam/sso/provider`) for ops use.
- Removed the now-dead third submit-label branch (`importing = !existing`).

## Tests
`sso-card.test.ts` (structural, same pattern as `channels-view.test.ts`): asserts no UUID field / advanced mode / Supabase Studio copy, and that edits thread the stored id. 5/5 pass; web tsc clean (0 errors).
