### PR TITLE
feat(docs): fumadocs UI overhaul + unified-markdown content styling

### DIFF
--- a/apps/web/content/docs/concepts/accounts.mdx
+++ b/apps/web/content/docs/concepts/accounts.mdx
@@ -3,8 +3,6 @@ title: Accounts and teams
 description: Your account holds your projects and the people you work with.
 ---
 
-import { Callout } from 'fumadocs-ui/components/callout';
-
 An **account** holds your [projects](/docs/concepts/projects) and teammates. Signing up gives you a personal account; you can also create shared accounts for a company or team.
 
 ## People and roles

--- a/apps/web/content/docs/concepts/agents.mdx
+++ b/apps/web/content/docs/concepts/agents.mdx
@@ -3,8 +3,6 @@ title: Agents
 description: The agent runtime is OpenCode; the manifest's agents map is governance-only, agent behavior lives in .kortix/opencode.
 ---
 
-import { Callout } from 'fumadocs-ui/components/callout';
-
 The agent in every [session](/docs/concepts/sessions) is
 **[OpenCode](https://opencode.ai/docs/)**. The `kortix-agent` daemon runs it as
 `opencode serve` with its config dir pointed at the project's `.kortix/opencode/`.

--- a/apps/web/content/docs/concepts/apps.mdx
+++ b/apps/web/content/docs/concepts/apps.mdx
@@ -3,8 +3,6 @@ title: Apps
 description: Ship a website from your project — the manifest declares it, Kortix deploys it. Experimental.
 ---
 
-import { Callout } from 'fumadocs-ui/components/callout';
-
 <Callout type="warn" title="Experimental">
 Apps is an experimental feature with a two-layer gate. Any project can turn it
 on for itself in Customize → Settings → Experimental, regardless of the

--- a/apps/web/content/docs/concepts/channels.mdx
+++ b/apps/web/content/docs/concepts/channels.mdx
@@ -3,8 +3,6 @@ title: Channels
 description: Drive a project from Slack — messages spawn sessions and the agent replies in-thread.
 ---
 
-import { Callout } from 'fumadocs-ui/components/callout';
-
 A **channel** connects a chat workspace to a project so you can run the agent
 from chat. Connect Slack to a project, and a message or mention spawns a
 [session](/docs/concepts/sessions); the agent replies in the thread. Follow-up

--- a/apps/web/content/docs/concepts/computers.mdx
+++ b/apps/web/content/docs/concepts/computers.mdx
@@ -3,8 +3,6 @@ title: Computers
 description: Let the agent reach your own machine — files, shell, and desktop — over a permissioned tunnel, through the Executor.
 ---
 
-import { Callout } from 'fumadocs-ui/components/callout';
-
 A **computer** is one of your own machines (laptop, desktop, server) connected to
 Kortix over the **Agent Computer Tunnel** — a permissioned reverse tunnel. Once
 connected, the agent can read/write files, run shell commands, and drive the

--- a/apps/web/content/docs/concepts/connections.mdx
+++ b/apps/web/content/docs/concepts/connections.mdx
@@ -3,8 +3,6 @@ title: Connections
 description: Let the agent call your external tools, brokered server-side per project.
 ---
 
-import { Callout } from 'fumadocs-ui/components/callout';
-
 A **connection** (connector) lets a project's agent call an external tool or
 service — Slack, Gmail, a database, any HTTP/GraphQL API. Connections are
 per-project, and the agent can only use what you connect.

--- a/apps/web/content/docs/concepts/index.mdx
+++ b/apps/web/content/docs/concepts/index.mdx
@@ -3,8 +3,6 @@ title: How Kortix works
 description: The architecture — repo-as-project, the control plane, ephemeral sandboxes on branches, and change requests.
 ---
 
-import { Callout } from 'fumadocs-ui/components/callout';
-
 A **project** is one git repository with a [manifest](/docs/reference/manifest) —
 `kortix.yaml` by default, or legacy `kortix.toml` — at its root. A **session** runs
 the agent in an isolated sandbox VM with the repo cloned onto a branch named after

--- a/apps/web/content/docs/concepts/projects.mdx
+++ b/apps/web/content/docs/concepts/projects.mdx
@@ -3,8 +3,6 @@ title: Projects
 description: A project is one git repository plus a kortix.yaml manifest.
 ---
 
-import { Callout } from 'fumadocs-ui/components/callout';
-
 A **project is one git repository** with a [manifest](/docs/reference/manifest)
 at its root — `kortix.yaml` by default. The repo is the project — files, history,
 agent config, and settings all live in git. No separate database to keep in sync.

--- a/apps/web/content/docs/concepts/secrets.mdx
+++ b/apps/web/content/docs/concepts/secrets.mdx
@@ -3,8 +3,6 @@ title: Secrets
 description: Per-project encrypted values, given to each session as environment variables.
 ---
 
-import { Callout } from 'fumadocs-ui/components/callout';
-
 A **secret** is a per-project value (an API key, token, or connection string)
 that the agent needs but that must not live in the repo. Secrets are encrypted at
 rest and provided to each [session](/docs/concepts/sessions) as environment

--- a/apps/web/content/docs/concepts/sessions.mdx
+++ b/apps/web/content/docs/concepts/sessions.mdx
@@ -3,8 +3,6 @@ title: Sessions
 description: An isolated, disposable sandbox VM on a branch named after the session.
 ---
 
-import { Callout } from 'fumadocs-ui/components/callout';
-
 A **session** runs the agent in its own isolated sandbox. The platform cuts a
 branch named after the session id, provisions a sandbox VM with the repo cloned
 onto it, and runs [OpenCode](/docs/concepts/agents) inside.

--- a/apps/web/content/docs/development.mdx
+++ b/apps/web/content/docs/development.mdx
@@ -4,7 +4,6 @@ description: Run the Kortix stack on your machine and work with the encrypted AP
 ---
 
 import { Steps, Step } from 'fumadocs-ui/components/steps';
-import { Callout } from 'fumadocs-ui/components/callout';
 
 For contributors running this repository locally. Requires Docker, Node 22, and pnpm 8.
 

--- a/apps/web/content/docs/guides/automating-work.mdx
+++ b/apps/web/content/docs/guides/automating-work.mdx
@@ -3,8 +3,6 @@ title: Automating work
 description: How to run a session on a schedule or from an event using triggers.
 ---
 
-import { Callout } from 'fumadocs-ui/components/callout';
-
 [Triggers](/docs/concepts/triggers) start a [session](/docs/concepts/sessions) on its own, with no one watching. A triggered session works like any other: the agent does the work, proposes a [change request](/docs/concepts/change-requests), and waits for review.
 
 ## Two ways to trigger a session

--- a/apps/web/content/docs/guides/connecting-tools.mdx
+++ b/apps/web/content/docs/guides/connecting-tools.mdx
@@ -4,7 +4,6 @@ description: How to let your agent act in the external tools and services you al
 ---
 
 import { Steps, Step } from 'fumadocs-ui/components/steps';
-import { Callout } from 'fumadocs-ui/components/callout';
 
 **Connections** (also called connectors) let an agent act in external tools and services on your behalf — Slack, Gmail, a database, any HTTP/GraphQL API. Setup depends on the tool, and you stay in control of what's connected. For the full model, see [Connections](/docs/concepts/connections).
 

--- a/apps/web/content/docs/guides/managing-secrets.mdx
+++ b/apps/web/content/docs/guides/managing-secrets.mdx
@@ -4,7 +4,6 @@ description: How to give your agent the API keys and tokens it needs, stored saf
 ---
 
 import { Steps, Step } from 'fumadocs-ui/components/steps';
-import { Callout } from 'fumadocs-ui/components/callout';
 
 **Secrets** are private values — API keys, tokens, connection strings — that belong to a [project](/docs/concepts/projects) and are made available to your agent during a session. They're stored encrypted, never written into your project's files, and provided to each session as it starts.
 

--- a/apps/web/content/docs/guides/using-the-cli.mdx
+++ b/apps/web/content/docs/guides/using-the-cli.mdx
@@ -4,7 +4,6 @@ description: How to drive Kortix from a terminal with the kortix CLI.
 ---
 
 import { Steps, Step } from 'fumadocs-ui/components/steps';
-import { Callout } from 'fumadocs-ui/components/callout';
 
 The `kortix` CLI does everything the dashboard does, from a terminal. It's optional — if you're not technical, use the dashboard instead.
 

--- a/apps/web/content/docs/reference/config-boundary.mdx
+++ b/apps/web/content/docs/reference/config-boundary.mdx
@@ -3,8 +3,6 @@ title: Kortix vs OpenCode config
 description: The strict ownership boundary between the manifest and the .kortix/opencode/ config directory.
 ---
 
-import { Callout } from 'fumadocs-ui/components/callout';
-
 A Kortix project's config has two owners, and the boundary is strict.
 
 - **Kortix owns** the manifest (`kortix.yaml`) and `.kortix/Dockerfile` — what a project is, its sandbox, secrets, triggers, apps, and which agents the platform may launch/authorize.

--- a/apps/web/content/docs/reference/manifest.mdx
+++ b/apps/web/content/docs/reference/manifest.mdx
@@ -3,8 +3,6 @@ title: Manifest reference
 description: The project manifest — every table, field, default, and validation rule, for both kortix.yaml (v2) and kortix.toml (v1, legacy).
 ---
 
-import { Callout } from 'fumadocs-ui/components/callout';
-
 The one file the platform treats as authoritative for a project. For the plain-language version, see [Projects](/docs/concepts/projects).
 
 The manifest lives at the repo root — `kortix.yaml` (v2, the current default for new projects), its `kortix.yml` short-extension sibling, or `kortix.toml` (v1, legacy, still fully supported for existing projects). Any repo with a valid manifest at the root is a Kortix project. When more than one candidate file is present, the platform resolves them in priority order — `.yaml` first, then `.yml`, then `.toml` — and reads the first one it finds. The parser is permissive — it never throws on a bad entry: bad triggers and apps go into an `errors` list alongside the good ones, and unknown top-level keys are ignored (park your own metadata freely).

--- a/apps/web/content/docs/reference/secrets.mdx
+++ b/apps/web/content/docs/reference/secrets.mdx
@@ -3,8 +3,6 @@ title: Secrets
 description: How project_secrets flow from the manifest to your sandbox.
 ---
 
-import { Callout } from 'fumadocs-ui/components/callout';
-
 The technical contract for secrets. For a walkthrough, see [Managing secrets](/docs/guides/managing-secrets).
 
 Secrets are per-project, encrypted at rest, and injected into every session as plain environment variables. They live in the platform's database (`project_secrets` table), never inline in your repo.

--- a/apps/web/content/docs/sdk/auth.mdx
+++ b/apps/web/content/docs/sdk/auth.mdx
@@ -3,8 +3,6 @@ title: Authentication
 description: Two concepts only — an API key (account-wide or project-scoped) for anything programmatic, or a Supabase JWT for web apps.
 ---
 
-import { Callout } from 'fumadocs-ui/components/callout';
-
 Kortix has exactly two ways to authenticate: a **session** (you logged in) and an
 **API key** (everything programmatic — the SDK, the CLI, your backend, CI). The SDK
 takes one via `getToken`, which it sends as `Authorization: Bearer <token>`.

--- a/apps/web/content/docs/sdk/error-handling.mdx
+++ b/apps/web/content/docs/sdk/error-handling.mdx
@@ -3,8 +3,6 @@ title: Error handling
 description: The typed error hierarchy — ApiError, AuthError, BillingError, RequestTooLargeError — and how to catch, branch on, and format them for the UI.
 ---
 
-import { Callout } from 'fumadocs-ui/components/callout';
-
 Every REST call made through `createKortix(...)` or `backendApi` rejects with a
 real `Error` subclass — never a plain object. `catch` it, `instanceof` it, and
 branch on `.status`/`.code`. These are the **same classes** on every host: a

--- a/apps/web/content/docs/sdk/getting-started.mdx
+++ b/apps/web/content/docs/sdk/getting-started.mdx
@@ -3,8 +3,6 @@ title: Getting started
 description: Install @kortix/sdk, create a client, authenticate, and make your first calls.
 ---
 
-import { Callout } from 'fumadocs-ui/components/callout';
-
 ## Install
 
 ```sh

--- a/apps/web/content/docs/sdk/index.mdx
+++ b/apps/web/content/docs/sdk/index.mdx
@@ -4,7 +4,6 @@ description: "@kortix/sdk — one typed client for the Kortix platform: projects
 ---
 
 import { Card, Cards } from 'fumadocs-ui/components/card';
-import { Callout } from 'fumadocs-ui/components/callout';
 
 `@kortix/sdk` is the single, opinionated data layer for the Kortix platform. One
 typed client wraps both the **Kortix REST API** and the **OpenCode runtime**, so a

--- a/apps/web/content/docs/sdk/modules.mdx
+++ b/apps/web/content/docs/sdk/modules.mdx
@@ -3,8 +3,6 @@ title: Modules
 description: The @kortix/sdk subpath imports — files, session runtime, the opencode client, auth, REST, and the live stores.
 ---
 
-import { Callout } from 'fumadocs-ui/components/callout';
-
 Most app code should use the [`createKortix`](/docs/sdk/the-client) facade and the
 [React hooks](/docs/sdk/react) — they cover the whole surface and keep auth,
 caching, and runtime resolution wired for you. The subpath modules below are the

--- a/apps/web/content/docs/sdk/react.mdx
+++ b/apps/web/content/docs/sdk/react.mdx
@@ -3,8 +3,6 @@ title: React hooks
 description: "@kortix/sdk/react — one hook to run a session (useSession), plus reactive hooks for models, config, PTY, and the session list."
 ---
 
-import { Callout } from 'fumadocs-ui/components/callout';
-
 `@kortix/sdk/react` is the **reactive** half of the SDK. Where `createKortix(...)`
 is imperative — you call a method, you get a promise — these hooks subscribe to
 **live** data and re-render as it changes. They're built on

--- a/apps/web/content/docs/sdk/sessions.mdx
+++ b/apps/web/content/docs/sdk/sessions.mdx
@@ -3,8 +3,6 @@ title: Sessions
 description: The session handle — lifecycle, the session-owned runtime (health & previews), and the typed opencode runtime.
 ---
 
-import { Callout } from 'fumadocs-ui/components/callout';
-
 A **session** is one agent run, in its own disposable sandbox, on its own git
 branch. `kortix.session(projectId, sessionId)` binds both ids and is the single
 handle for everything a session does.

--- a/apps/web/content/docs/sdk/the-client.mdx
+++ b/apps/web/content/docs/sdk/the-client.mdx
@@ -3,8 +3,6 @@ title: The client
 description: The createKortix facade — the complete method reference for accounts, projects, and the id-bound project handle.
 ---
 
-import { Callout } from 'fumadocs-ui/components/callout';
-
 `createKortix(config)` returns one client. Every REST method is a direct, fully
 typed reference to the platform client; the `project()` and `session()` handles
 bind ids so you never repeat them. This page is the **complete** surface — every

--- a/apps/web/content/docs/sdk/turns.mdx
+++ b/apps/web/content/docs/sdk/turns.mdx
@@ -3,8 +3,6 @@ title: Turns
 description: Framework-free turn grouping, part classification, and view-model helpers for building a chat UI on raw session messages.
 ---
 
-import { Callout } from 'fumadocs-ui/components/callout';
-
 `@kortix/sdk/turns` is the pure, framework-free engine behind the web and
 mobile chat renderers: grouping raw session messages into **turns**,
 classifying every message **part** into a typed shape, mapping tool parts to

--- a/apps/web/source.config.ts
+++ b/apps/web/source.config.ts
@@ -1,3 +1,4 @@
+import { rehypeCodeDefaultOptions } from 'fumadocs-core/mdx-plugins';
 import { defineConfig, defineDocs } from 'fumadocs-mdx/config';
 
 // Docs use fumadocs/MDX. The blog does NOT — it is React-rendered from a typed
@@ -6,4 +7,15 @@ export const docs = defineDocs({
   dir: 'content/docs',
 });
 
-export default defineConfig();
+export default defineConfig({
+  mdxOptions: {
+    rehypeCodeOptions: {
+      // Keep fumadocs' defaults (defaultColor: false dual-theme CSS vars, lazy
+      // grammars, notation transformers); only swap the palette.
+      ...rehypeCodeDefaultOptions,
+      // Intentionally mirrors SHIKI_THEME_LIGHT / SHIKI_THEME_DARK in
+      // doc-markdown.tsx so docs code matches the app's markdown renderer.
+      themes: { light: 'slack-ochin', dark: 'plastic' },
+    },
+  },
+});

--- a/apps/web/src/app/api/search/route.ts
+++ b/apps/web/src/app/api/search/route.ts
@@ -1,0 +1,6 @@
+import { source } from '@/lib/source';
+import { createFromSource } from 'fumadocs-core/search/server';
+
+// Powers the fumadocs search dialog (RootProvider defaults to fetching
+// `/api/search`). Orama index is built from the docs source at request time.
+export const { GET } = createFromSource(source);

--- a/apps/web/src/app/docs/[[...slug]]/page.tsx
+++ b/apps/web/src/app/docs/[[...slug]]/page.tsx
@@ -1,8 +1,21 @@
+import { docsMdxComponents } from '@/components/markdown/docs-mdx-components';
+import { Button } from '@/components/ui/button';
+import { Icon } from '@/features/icon/icon';
 import { source } from '@/lib/source';
+import { cn } from '@/lib/utils';
+import { getBreadcrumbItems } from 'fumadocs-core/breadcrumb';
+import { findNeighbour } from 'fumadocs-core/server';
+import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
+import { Card, Cards } from 'fumadocs-ui/components/card';
+import { Step, Steps } from 'fumadocs-ui/components/steps';
+import { Tab, Tabs } from 'fumadocs-ui/components/tabs';
 import defaultMdxComponents from 'fumadocs-ui/mdx';
 import { DocsBody, DocsDescription, DocsPage, DocsTitle } from 'fumadocs-ui/page';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
 import type { Metadata } from 'next';
+import Link from 'next/link';
 import { notFound } from 'next/navigation';
+import { Fragment } from 'react';
 
 export default async function Page(props: { params: Promise<{ slug?: string[] }> }) {
   const params = await props.params;
@@ -10,14 +23,107 @@ export default async function Page(props: { params: Promise<{ slug?: string[] }>
   if (!page) notFound();
 
   const MDX = (page.data as any).body;
+  const tree = source.getPageTree();
+  const { previous, next } = findNeighbour(tree, page.url);
+  const breadcrumbs = getBreadcrumbItems(page.url, tree);
+  // `page.path` is the loader's virtualized path relative to the content
+  // directory (e.g. `sdk/getting-started.mdx`).
+  const editUrl = `https://github.com/kortix-ai/suna/blob/main/apps/web/content/docs/${page.path}`;
 
   return (
-    <DocsPage toc={(page.data as any).toc} full={(page.data as any).full}>
+    <DocsPage
+      toc={(page.data as any).toc}
+      full={(page.data as any).full}
+      tableOfContent={{ style: 'clerk' }}
+      footer={{ enabled: false }}
+      breadcrumb={{
+        // Replaces the built-in breadcrumb so the same row can carry the
+        // edit link: section trail on the left, "Edit on GitHub" on the right.
+        component: (
+          <div className="flex flex-row items-center justify-between gap-4">
+            <span className="text-fd-muted-foreground flex min-w-0 items-center gap-1.5 text-sm">
+              {breadcrumbs.map((item, i) => {
+                const itemClassName = cn(
+                  'truncate',
+                  i === breadcrumbs.length - 1 && 'text-fd-primary font-medium',
+                );
+                return (
+                  <Fragment key={i}>
+                    {i !== 0 && <ChevronRight className="size-3.5 shrink-0" />}
+                    {item.url ? (
+                      <Link
+                        href={item.url}
+                        className={cn(itemClassName, 'transition-opacity hover:opacity-80')}
+                      >
+                        {item.name}
+                      </Link>
+                    ) : (
+                      <span className={itemClassName}>{item.name}</span>
+                    )}
+                  </Fragment>
+                );
+              })}
+            </span>
+            <Button asChild variant="outline" size="xs" className="shrink-0 gap-1.5">
+              <a href={editUrl} target="_blank" rel="noreferrer noopener">
+                <Icon.Github className="size-3.5" />
+                Edit on GitHub
+              </a>
+            </Button>
+          </div>
+        ),
+      }}
+    >
       <DocsTitle>{page.data.title}</DocsTitle>
       {page.data.description && <DocsDescription>{page.data.description}</DocsDescription>}
-      <DocsBody>
-        <MDX components={{ ...defaultMdxComponents }} />
+      <DocsBody className="text-[15px]">
+        <MDX
+          components={{
+            ...defaultMdxComponents,
+            // App-parity styling (unified-markdown look) — overrides the
+            // default pre/img/headings/a while keeping fumadocs' named blocks.
+            ...docsMdxComponents,
+            // Rich MDX building blocks available to all docs content.
+            // (Callout comes from docsMdxComponents — restyled shadowless there.)
+            Accordion,
+            Accordions,
+            Card,
+            Cards,
+            Step,
+            Steps,
+            Tab,
+            Tabs,
+          }}
+        />
       </DocsBody>
+      {(previous || next) && (
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          {previous && (
+            <Link
+              href={previous.url}
+              className="flex flex-col gap-1 rounded-lg border p-4 transition-colors hover:bg-fd-accent"
+            >
+              <span className="inline-flex items-center gap-1 text-xs text-fd-muted-foreground">
+                <ChevronLeft className="size-3.5" />
+                Previous
+              </span>
+              <span className="text-sm font-medium">{previous.name}</span>
+            </Link>
+          )}
+          {next && (
+            <Link
+              href={next.url}
+              className="flex flex-col items-end gap-1 rounded-lg border p-4 text-right transition-colors hover:bg-fd-accent sm:col-start-2"
+            >
+              <span className="inline-flex items-center gap-1 text-xs text-fd-muted-foreground">
+                Next
+                <ChevronRight className="size-3.5" />
+              </span>
+              <span className="text-sm font-medium">{next.name}</span>
+            </Link>
+          )}
+        </div>
+      )}
     </DocsPage>
   );
 }

--- a/apps/web/src/app/docs/docs-controls.tsx
+++ b/apps/web/src/app/docs/docs-controls.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { ButtonGroup } from '@/components/ui/button-group';
+import { Kbd, KbdGroup } from '@/components/ui/kbd';
+import { cn } from '@/lib/utils';
+import type { PageTree } from 'fumadocs-core/server';
+import { SidebarSeparator } from 'fumadocs-ui/components/layout/sidebar';
+import { useSearchContext, useSidebar } from 'fumadocs-ui/provider';
+import { PanelLeftIcon, Search } from 'lucide-react';
+
+// App-Button replacements for fumadocs' built-in sidebar chrome (search
+// toggles, collapse trigger, collapsed floating control) so the docs share
+// the app's control language instead of fumadocs' default styling.
+
+// Section labels ("Learn", "Reference", …) — the stock separator inherits the
+// sidebar's 12px, too faint next to 14px items; render at text-sm instead.
+// mt-6/first:mt-0 reproduces the default's spacing (mt-6 on all but the first).
+export function DocsSidebarSeparator({ item }: { item: PageTree.Separator }) {
+  return (
+    <SidebarSeparator className="mt-6 text-sm first:mt-0">
+      {item.icon}
+      {item.name}
+    </SidebarSeparator>
+  );
+}
+
+// Sidebar search row — same shape as the app sidebar's Search entry.
+export function DocsSearchButton() {
+  const { enabled, hotKey, setOpenSearch } = useSearchContext();
+  if (!enabled) return null;
+
+  return (
+    <Button variant="secondary" onClick={() => setOpenSearch(true)} className="group/row w-full">
+      <Search className="text-sidebar-foreground shrink-0" />
+      <span className="flex-1 text-left">Search</span>
+      <KbdGroup className="ml-auto opacity-0 transition-opacity duration-150 group-hover/row:opacity-100">
+        {hotKey.map((k, i) => (
+          <Kbd key={i}>{k.display}</Kbd>
+        ))}
+      </KbdGroup>
+    </Button>
+  );
+}
+
+// Mobile navbar search — icon-only.
+export function DocsSearchIconButton() {
+  const { enabled, setOpenSearch } = useSearchContext();
+  if (!enabled) return null;
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon-sm"
+      aria-label="Open search"
+      onClick={() => setOpenSearch(true)}
+    >
+      <Search />
+    </Button>
+  );
+}
+
+// Sidebar-header collapse trigger (desktop only) — replaces the stock
+// SidebarCollapseTrigger that `sidebar.collapsible: false` removes.
+export function DocsSidebarCollapseButton() {
+  const { collapsed, setCollapsed } = useSidebar();
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon-sm"
+      aria-label="Collapse sidebar"
+      className="text-muted-foreground mb-auto max-md:hidden"
+      onClick={() => setCollapsed(!collapsed)}
+    >
+      <PanelLeftIcon />
+    </Button>
+  );
+}
+
+// Floating expand/search pair shown while the sidebar is collapsed. Replaces
+// fumadocs' CollapsibleControl (a shadowed pill that jumps to the right edge
+// below xl); this one is a flat bordered ButtonGroup pinned to the far left.
+export function DocsCollapsedControls() {
+  const { collapsed, setCollapsed } = useSidebar();
+  const { enabled, setOpenSearch } = useSearchContext();
+
+  return (
+    <div
+      className={cn(
+        'fixed start-4 z-10 transition-opacity max-md:hidden',
+        !collapsed && 'pointer-events-none opacity-0',
+      )}
+      style={{
+        top: 'calc(var(--fd-banner-height) + var(--fd-tocnav-height) + var(--spacing) * 4)',
+      }}
+    >
+      <ButtonGroup className="bg-secondary rounded-md">
+        <Button
+          variant="outline"
+          size="icon"
+          aria-label="Open sidebar"
+          onClick={() => setCollapsed(false)}
+        >
+          <PanelLeftIcon />
+        </Button>
+        {enabled && (
+          <Button
+            variant="outline"
+            size="icon"
+            aria-label="Open search"
+            onClick={() => setOpenSearch(true)}
+          >
+            <Search />
+          </Button>
+        )}
+      </ButtonGroup>
+    </div>
+  );
+}

--- a/apps/web/src/app/docs/layout.tsx
+++ b/apps/web/src/app/docs/layout.tsx
@@ -1,21 +1,28 @@
+import { ThemeToggle } from '@/components/home/theme-toggle';
 import { KortixLogo } from '@/components/sidebar/kortix-logo';
+import { Icon } from '@/features/icon/icon';
 import { source } from '@/lib/source';
 import { DocsLayout } from 'fumadocs-ui/layouts/docs';
 import { RootProvider } from 'fumadocs-ui/provider';
-import { Github } from 'lucide-react';
 import type { ReactNode } from 'react';
+
+import {
+  DocsCollapsedControls,
+  DocsSearchButton,
+  DocsSearchIconButton,
+  DocsSidebarCollapseButton,
+  DocsSidebarSeparator,
+} from './docs-controls';
 
 // Fumadocs wraps `nav.title` in a link to `nav.url` ("/docs"), so this must NOT
 // contain its own anchor — a nested <a> breaks hydration.
 function DocsLogo() {
   return (
-    <span className="flex items-center gap-2.5 no-underline">
+    <span className="flex items-center gap-2.5 no-underline ml-1">
       {/* The canonical full Kortix logo (symbol + wordmark), via the shared
           KortixLogo component so the docs stay in lockstep with the rest of
           the app's brand treatment. */}
       <KortixLogo variant="logomark" size={18} />
-      <span aria-hidden className="bg-fd-border h-3.5 w-px shrink-0" />
-      <span className="text-fd-muted-foreground text-[13px] font-medium tracking-tight">Docs</span>
     </span>
   );
 }
@@ -32,6 +39,15 @@ export default function Layout({ children }: { children: ReactNode }) {
         nav={{
           title: <DocsLogo />,
           url: '/docs',
+          // Our own collapse trigger — `sidebar.collapsible: false` below
+          // removes fumadocs' stock trigger + floating CollapsibleControl.
+          children: <DocsSidebarCollapseButton />,
+        }}
+        searchToggle={{
+          components: {
+            lg: <DocsSearchButton />,
+            sm: <DocsSearchIconButton />,
+          },
         }}
         links={[
           {
@@ -46,16 +62,32 @@ export default function Layout({ children }: { children: ReactNode }) {
             type: 'icon',
             text: 'GitHub',
             label: 'GitHub',
-            icon: <Github />,
+            icon: <Icon.Github />,
             url: 'https://github.com/kortix-ai/suna',
             external: true,
           },
         ]}
         sidebar={{
           defaultOpenLevel: 1,
-          collapsible: true,
+          // Collapse is still driven through useSidebar() by our own buttons
+          // (docs-controls.tsx); false only strips fumadocs' built-in chrome.
+          collapsible: false,
+          components: {
+            Separator: DocsSidebarSeparator,
+          },
+        }}
+        themeSwitch={{
+          // The app's own theme control (same one as the user menu) instead of
+          // the fumadocs switch. The app-level next-themes provider still owns
+          // persistence; RootProvider theme is disabled above.
+          component: (
+            <div className="ms-auto">
+              <ThemeToggle variant="compact" />
+            </div>
+          ),
         }}
       >
+        <DocsCollapsedControls />
         {children}
       </DocsLayout>
     </RootProvider>

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -9,23 +9,52 @@
 @source "../node_modules/fumadocs-ui/dist/**/*.js";
 
 /* ─── Fumadocs → Kortix brand overrides ─── */
+/* fd-* tokens inherit the app's semantic tokens so light/dark stay in parity
+   automatically and color has a single source of truth. `--color-fd-card`
+   deliberately maps to --popover: fumadocs cards and code-block chrome sit on
+   the flat elevated surface, not the washed-gray --card token. The `.dark`
+   selector is required so these win over the `.dark` block that ships in
+   fumadocs-ui/css/neutral.css. */
+:root,
+.dark {
+  --color-fd-background: var(--background);
+  --color-fd-foreground: var(--foreground);
+  --color-fd-muted: var(--muted);
+  --color-fd-muted-foreground: var(--muted-foreground);
+  --color-fd-popover: var(--popover);
+  --color-fd-popover-foreground: var(--popover-foreground);
+  --color-fd-card: var(--popover);
+  --color-fd-card-foreground: var(--popover-foreground);
+  --color-fd-border: var(--border);
+  --color-fd-primary: var(--primary);
+  --color-fd-primary-foreground: var(--primary-foreground);
+  --color-fd-secondary: var(--secondary);
+  --color-fd-secondary-foreground: var(--secondary-foreground);
+  --color-fd-accent: var(--accent);
+  --color-fd-accent-foreground: var(--accent-foreground);
+  --color-fd-ring: var(--ring);
+}
+
+/* Docs borders run a step darker than the app's hairline --border — the
+   default reads too faint on docs surfaces (callouts, tables, code chrome).
+   Scoped to the fumadocs layout root so the rest of the app keeps the lighter
+   token. --color-fd-border must be re-declared here: the :root mapping above
+   already resolved var(--border) at the root, so it would not pick up this
+   scoped override on its own. */
+#nd-docs-layout {
+  --border: oklch(0.86 0 0);
+  --color-fd-border: var(--border);
+}
+.dark #nd-docs-layout {
+  /* In dark theme a literally darker border would vanish into the background —
+     step lighter instead for the same contrast boost. */
+  --border: oklch(0.34 0.006 286.033);
+}
+
+/* Legacy --sidebar-* values used by the app's own sidebar components. The
+   canonical app token blocks further down redeclare these; kept here verbatim
+   from the original override block. */
 :root {
-  --color-fd-background: oklch(0.985 0 0);
-  --color-fd-foreground: oklch(0.145 0 0);
-  --color-fd-muted: oklch(0.955 0 0);
-  --color-fd-muted-foreground: oklch(0.45 0 0);
-  --color-fd-popover: oklch(1 0 0);
-  --color-fd-popover-foreground: oklch(0.145 0 0);
-  --color-fd-card: oklch(0.97 0 0);
-  --color-fd-card-foreground: oklch(0.145 0 0);
-  --color-fd-border: oklch(0.885 0 0 / 0.6);
-  --color-fd-primary: oklch(0.205 0 0);
-  --color-fd-primary-foreground: oklch(0.985 0 0);
-  --color-fd-secondary: oklch(0.955 0 0);
-  --color-fd-secondary-foreground: oklch(0.205 0 0);
-  --color-fd-accent: oklch(0.92 0 0 / 0.5);
-  --color-fd-accent-foreground: oklch(0.205 0 0);
-  --color-fd-ring: oklch(0.708 0 0);
   --sidebar: hsl(0 0% 98%);
   --sidebar-foreground: hsl(240 5.3% 26.1%);
   --sidebar-primary: hsl(240 5.9% 10%);
@@ -36,22 +65,6 @@
   --sidebar-ring: hsl(217.2 91.2% 59.8%);
 }
 .dark {
-  --color-fd-background: oklch(0.18 0 0);
-  --color-fd-foreground: oklch(0.94 0 0);
-  --color-fd-muted: oklch(0.27 0 0);
-  --color-fd-muted-foreground: oklch(0.6 0 0);
-  --color-fd-popover: oklch(0.24 0 0);
-  --color-fd-popover-foreground: oklch(0.94 0 0);
-  --color-fd-card: oklch(0.21 0 0);
-  --color-fd-card-foreground: oklch(0.94 0 0);
-  --color-fd-border: oklch(0.3 0 0 / 0.5);
-  --color-fd-primary: oklch(0.94 0 0);
-  --color-fd-primary-foreground: oklch(0.18 0 0);
-  --color-fd-secondary: oklch(0.27 0 0);
-  --color-fd-secondary-foreground: oklch(0.94 0 0);
-  --color-fd-accent: oklch(0.35 0 0 / 0.5);
-  --color-fd-accent-foreground: oklch(0.94 0 0);
-  --color-fd-ring: oklch(0.5 0 0);
   --sidebar: hsl(240 5.9% 10%);
   --sidebar-foreground: hsl(240 4.8% 95.9%);
   --sidebar-primary: hsl(224.3 76.3% 48%);
@@ -61,34 +74,101 @@
   --sidebar-border: hsl(240 3.7% 15.9%);
   --sidebar-ring: hsl(217.2 91.2% 59.8%);
 }
-.dark #nd-sidebar {
-  --color-fd-muted: oklch(0.22 0 0);
-  --color-fd-secondary: oklch(0.25 0 0);
-  --color-fd-muted-foreground: oklch(0.6 0 0);
+
+/* ─── Docs polish layer ─── */
+/* Everything below is scoped to the fumadocs layout ids (#nd-*) so the rest
+   of the app is untouched. Quiet, flat, better-auth-grade surfaces. */
+
+/* Sidebar: one flat surface with the page, split by a hairline. */
+#nd-sidebar {
+  background-color: var(--background);
+  border-color: var(--border);
 }
 
-/* Fumadocs docs layout — fumadocs-ui builds these via cn() in layouts/docs,
-   so Tailwind's scanner never emits the md/lg arbitrary property utilities. */
-#nd-docs-layout {
-  --fd-sidebar-width: 0px;
+/* Nav rows: compact (~30px), quiet, rounded-md. Covers page links and folder
+   triggers — both carry the shared ps-(--sidebar-item-offset) item class.
+   padding-inline-start is left alone: it drives nested indentation. */
+#nd-sidebar a[data-active],
+#nd-sidebar button[class*='ps-(--sidebar-item-offset)'] {
+  border-radius: 6px;
+  padding-block: 5px;
+  color: var(--muted-foreground);
+}
+#nd-sidebar a[data-active]:hover,
+#nd-sidebar button[class*='ps-(--sidebar-item-offset)']:hover {
+  background-color: var(--accent);
+  color: var(--foreground);
+}
+/* Active page: foreground + primary tint (Kortix law: active = primary 5-8%). */
+#nd-sidebar a[data-active='true'] {
+  background-color: color-mix(in oklab, var(--primary) 6%, transparent);
+  color: var(--foreground);
+  font-weight: 500;
+}
+#nd-sidebar a[data-active='true']:hover {
+  background-color: color-mix(in oklab, var(--primary) 8%, transparent);
 }
 
-@media (min-width: 768px) {
-  /* Desktop: navbar is md:hidden, so zero the nav-height offset that drives
-     pt-(--fd-nav-height) on #nd-docs-layout and --fd-sidebar-top on #nd-sidebar. */
-  :root:has(#nd-docs-layout) {
-    --fd-nav-height: 0px;
-  }
-
-  #nd-docs-layout {
-    --fd-sidebar-width: 268px;
-  }
+/* Section separator labels (Learn / Reference / SDK / Contribute): quiet.
+   Size is owned by DocsSidebarSeparator (docs-controls.tsx) — its text-sm
+   reaches both this desktop aside and the mobile drawer, so no font-size
+   here or the id specificity would override it on desktop only. */
+#nd-sidebar p[class*='ps-(--sidebar-item-offset)'] {
+  margin-top: 1.5rem;
+  font-weight: 500;
+  color: var(--muted-foreground);
 }
 
-@media (min-width: 1024px) {
-  #nd-docs-layout {
-    --fd-sidebar-width: 286px;
-  }
+/* Prose rhythm: tighten the page title only; body sizes stay stock. */
+#nd-page h1 {
+  letter-spacing: -0.02em;
+}
+
+/* TOC-less pages (e.g. /docs): the article otherwise stretches past 1100px.
+   Cap it at a readable column; `md:mx-auto` on the article keeps it centered.
+   Pages with a TOC already sit under ~868px, so this is a no-op there.
+   padding-bottom: the stock article has none (pt-8 only) and our custom
+   prev/next footer replaces the built-in one that used to provide end space,
+   so without this the cards sit flush against the viewport bottom. */
+#nd-page article {
+  max-width: 56rem;
+  padding-bottom: 2rem;
+}
+
+/* Sidebar search shortcut: collapse the two bordered ⌘ / K chips into one
+   quiet "⌘K" hint. Scoped to the sidebar search toggle (data-search-full)
+   so prose <kbd> styling is untouched. */
+#nd-sidebar button[data-search-full] div:has(> kbd) {
+  gap: 0;
+}
+#nd-sidebar button[data-search-full] kbd {
+  background: transparent;
+  border: none;
+  box-shadow: none;
+  padding: 0;
+  font-size: 0.75rem;
+  color: var(--muted-foreground);
+}
+
+/* TOC rail ("On this page"): keep fumadocs' stock code chips but slim them —
+   the prose default pads 3px on every side, which makes each chip tall and
+   opens the rows up. Only the vertical padding drops; horizontal padding,
+   border, background and mono size stay stock. Covers the desktop rail
+   (#nd-toc) and the mobile popover (#nd-tocnav). */
+#nd-toc a code,
+#nd-tocnav a code {
+  padding-block: 1px;
+}
+
+/* Fumadocs cards + tab/code containers: rounded-md family, never rounded-xl. */
+#nd-page a[class*='bg-fd-card'],
+#nd-page div[class*='bg-fd-card'] {
+  border-radius: 8px;
+  border-color: var(--border);
+}
+/* Linked cards: colors-only hover onto the flat accent surface. */
+#nd-page a[class*='bg-fd-card']:hover {
+  background-color: var(--accent);
 }
 
 @custom-variant dark (&:where(.dark, .dark *));

--- a/apps/web/src/components/markdown/copy-button.tsx
+++ b/apps/web/src/components/markdown/copy-button.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { cn } from '@/lib/utils';
+import { Check, Copy } from 'lucide-react';
+import { AnimatePresence, motion } from 'motion/react';
+import { useCallback, useState } from 'react';
+
+export function CopyButton({ code }: { code: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(code);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (err) {
+      console.error('Failed to copy:', err);
+    }
+  }, [code]);
+
+  return (
+    <button
+      onClick={handleCopy}
+      aria-label={copied ? 'Copied' : 'Copy code'}
+      className={cn(
+        'inline-flex size-7 items-center justify-center rounded-md',
+        'text-muted-foreground hover:text-foreground hover:bg-muted-foreground/10',
+        'cursor-pointer transition-colors active:scale-[0.97]',
+        'outline-none focus-visible:outline-none',
+      )}
+    >
+      <span className="relative inline-flex size-3.5 items-center justify-center">
+        <AnimatePresence initial={false} mode="popLayout">
+          <motion.span
+            key={copied ? 'check' : 'copy'}
+            initial={{ scale: 0.25, opacity: 0, filter: 'blur(4px)' }}
+            animate={{ scale: 1, opacity: 1, filter: 'blur(0px)' }}
+            exit={{ scale: 0.25, opacity: 0, filter: 'blur(4px)' }}
+            transition={{ type: 'spring', duration: 0.3, bounce: 0 }}
+            className="absolute inset-0 inline-flex items-center justify-center"
+          >
+            {copied ? (
+              <Check className="text-kortix-green size-3.5" />
+            ) : (
+              <Copy className="size-3.5" />
+            )}
+          </motion.span>
+        </AnimatePresence>
+      </span>
+    </button>
+  );
+}

--- a/apps/web/src/components/markdown/doc-markdown.tsx
+++ b/apps/web/src/components/markdown/doc-markdown.tsx
@@ -402,7 +402,7 @@ export function CodeHighlight({
   );
 }
 
-export interface UnifiedMarkdownProps {
+export interface DocMarkdownProps {
   content: string;
   className?: string;
   isStreaming?: boolean;
@@ -413,9 +413,10 @@ export interface UnifiedMarkdownProps {
   allowHtml?: boolean;
 }
 
-// Single source of truth for markdown rendering across the app — clean, minimal,
-// readable in both themes.
-export const UnifiedMarkdown = React.memo<UnifiedMarkdownProps>(
+// Docs-owned markdown renderer — a copy of unified-markdown.tsx so the docs
+// evolve independently of the app renderer (which changes only in the
+// `markdown` worktree). Same code, docs name.
+export const DocMarkdown = React.memo<DocMarkdownProps>(
   ({ content, className, isStreaming = false, allowHtml = true }) => {
     const tHardcodedUi = useTranslations('hardcodedUi');
     const { proxyUrl } = useSandboxProxy();
@@ -713,4 +714,4 @@ export const UnifiedMarkdown = React.memo<UnifiedMarkdownProps>(
   },
 );
 
-UnifiedMarkdown.displayName = 'UnifiedMarkdown';
+DocMarkdown.displayName = 'DocMarkdown';

--- a/apps/web/src/components/markdown/docs-mdx-components.tsx
+++ b/apps/web/src/components/markdown/docs-mdx-components.tsx
@@ -1,0 +1,198 @@
+import { isInternalUrl } from '@/components/markdown/unified-markdown-utils';
+import { cn } from '@/lib/utils';
+import { Callout as FumadocsCallout } from 'fumadocs-ui/components/callout';
+import { CodeBlock, Pre } from 'fumadocs-ui/components/codeblock';
+import Link from 'next/link';
+import type { ComponentProps } from 'react';
+
+// Visual parity with doc-markdown.tsx (the docs-owned copy of the app
+// renderer) — when that file's styles change, mirror them here. This map
+// restyles fumadocs MDX output (server-rendered, no 'use client') to the
+// app's markdown look: same heading scale, paragraph voice, list markers,
+// kortix-blue links, inline-code chips, tables, images, blockquote, hr and
+// strong/em/del — minus app-only interactivity (sandbox proxy, file-preview
+// clicks, setup links, KaTeX, Mermaid, streaming). Code blocks stay on
+// fumadocs' native CodeBlock (copy button, title bar) — the `pre` override
+// below only flattens its chrome to the app surface (rounded-md, no shadow).
+
+const linkClass = cn(
+  'font-medium text-kortix-blue',
+  'underline decoration-kortix-blue/40 decoration-[1px] underline-offset-[3px]',
+  'transition-colors hover:decoration-kortix-blue',
+  '[overflow-wrap:anywhere]',
+);
+
+// Inline-code chip — unified-markdown's INLINE_CODE at its non-clickable size.
+const inlineCodeClass =
+  'rounded-sm border border-border/40 bg-muted px-1.5 py-[0.1rem] font-mono text-[0.8rem] text-foreground/95 dark:bg-card';
+
+export const docsMdxComponents = {
+  // Fumadocs' Callout ships with shadow-md baked in — the docs surface is flat.
+  Callout: ({ className, ...props }: ComponentProps<typeof FumadocsCallout>) => (
+    <FumadocsCallout {...props} className={cn('shadow-none', className)} />
+  ),
+
+  // Headings — unified's graduated hierarchy plus `scroll-mt-24` (anchor
+  // targets under the sticky nav). Props are spread so rehype heading ids
+  // survive — the TOC and #anchors depend on them.
+  h1: ({ children, ...props }: ComponentProps<'h1'>) => (
+    <h1
+      className="text-foreground mt-10 mb-4 scroll-mt-24 text-xl font-semibold first:mt-0"
+      {...props}
+    >
+      {children}
+    </h1>
+  ),
+  h2: ({ children, ...props }: ComponentProps<'h2'>) => (
+    <h2
+      className="text-foreground mt-8 mb-3 scroll-mt-24 text-xl font-semibold first:mt-0"
+      {...props}
+    >
+      {children}
+    </h2>
+  ),
+  h3: ({ children, ...props }: ComponentProps<'h3'>) => (
+    <h3
+      className="text-foreground mt-6 mb-2 scroll-mt-24 text-lg font-semibold first:mt-0"
+      {...props}
+    >
+      {children}
+    </h3>
+  ),
+  h4: ({ children, ...props }: ComponentProps<'h4'>) => (
+    <h4
+      className="text-foreground mt-6 mb-2 scroll-mt-24 text-lg font-semibold first:mt-0"
+      {...props}
+    >
+      {children}
+    </h4>
+  ),
+  h5: ({ children, ...props }: ComponentProps<'h5'>) => (
+    <h5
+      className="text-foreground mt-4 mb-1 scroll-mt-24 text-base font-semibold first:mt-0"
+      {...props}
+    >
+      {children}
+    </h5>
+  ),
+  h6: ({ children, ...props }: ComponentProps<'h6'>) => (
+    <h6
+      className="text-foreground mt-4 mb-1 scroll-mt-24 text-base font-semibold tracking-wide first:mt-0"
+      {...props}
+    >
+      {children}
+    </h6>
+  ),
+
+  p: ({ children }: ComponentProps<'p'>) => (
+    <p className="text-foreground/95 my-4 leading-relaxed font-medium first:mt-0 last:mb-0 [&:has(img)]:my-0">
+      {children}
+    </p>
+  ),
+
+  ul: ({ children }: ComponentProps<'ul'>) => (
+    <ul className="marker:text-muted-foreground/60 my-4 list-outside list-disc space-y-1 pl-6 first:mt-0 last:mb-0 [&_p]:mb-2 [&_p]:last:mb-0">
+      {children}
+    </ul>
+  ),
+  ol: ({ children }: ComponentProps<'ol'>) => (
+    <ol className="marker:text-muted-foreground/80 my-4 list-outside list-decimal space-y-1 pl-6 marker:font-medium first:mt-0 last:mb-0 [&_p]:mb-2 [&_p]:last:mb-0">
+      {children}
+    </ol>
+  ),
+  li: ({ children }: ComponentProps<'li'>) => (
+    <li className="text-foreground/95 leading-relaxed font-medium">{children}</li>
+  ),
+
+  a: ({ href, children }: ComponentProps<'a'>) => {
+    const resolvedHref = href ?? '#';
+    const isHash = resolvedHref.startsWith('#');
+    const isExternal = !isInternalUrl(resolvedHref);
+    return (
+      <Link
+        href={resolvedHref}
+        className={linkClass}
+        {...(isExternal && !isHash ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
+      >
+        {children}
+      </Link>
+    );
+  },
+
+  // Inline code becomes the bordered chip; multiline/block code is the shiki
+  // <code> inside <pre> — pass it through untouched for fumadocs' CodeBlock.
+  code: ({ children, ...props }: ComponentProps<'code'>) => {
+    if (typeof children === 'string' && !children.includes('\n')) {
+      return <code className={inlineCodeClass}>{children}</code>;
+    }
+    return <code {...props}>{children}</code>;
+  },
+
+  // Fumadocs' native CodeBlock (copy button, fence titles), flattened to the
+  // app surface: its stock chrome is rounded-xl + shadow-sm.
+  pre: ({ className, children, ...props }: ComponentProps<'pre'>) => (
+    <CodeBlock {...props} className={cn(className, 'rounded-md shadow-none')}>
+      <Pre>{children}</Pre>
+    </CodeBlock>
+  ),
+
+  blockquote: ({ children }: ComponentProps<'blockquote'>) => (
+    <blockquote className="border-border text-muted-foreground my-5 border-l-2 pl-6 italic [&>p]:my-2">
+      {children}
+    </blockquote>
+  ),
+
+  hr: () => <hr className="border-border/60 my-6 h-px border-0 border-t" />,
+
+  // `not-prose` opts the whole table out of fumadocs' prose styles, which
+  // give the <table> its own border + radius — doubled against this wrapper.
+  // border-collapse is required once prose is off (UA default border-spacing
+  // would open gaps between the divide-y row lines).
+  // Table lines run at 70% of the docs border token — full strength reads
+  // heavy against the dense cell grid.
+  table: ({ children }: ComponentProps<'table'>) => (
+    <div className="border-border/70 not-prose my-5 overflow-x-auto rounded-md border">
+      <table className="w-full border-collapse text-sm">{children}</table>
+    </div>
+  ),
+  thead: ({ children }: ComponentProps<'thead'>) => (
+    <thead className="border-border/70 bg-muted border-b">{children}</thead>
+  ),
+  tbody: ({ children }: ComponentProps<'tbody'>) => (
+    <tbody className="divide-border/70 divide-y">{children}</tbody>
+  ),
+  tr: ({ children }: ComponentProps<'tr'>) => <tr>{children}</tr>,
+  th: ({ children }: ComponentProps<'th'>) => (
+    <th className="text-foreground px-4 py-2 text-left font-semibold">{children}</th>
+  ),
+  td: ({ children }: ComponentProps<'td'>) => (
+    <td className="text-foreground px-4 py-2 text-left font-normal">{children}</td>
+  ),
+
+  img: ({ src, alt }: ComponentProps<'img'>) => {
+    if (!src || typeof src !== 'string') return null;
+    return (
+      <span className="my-5 block">
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={src}
+          alt={alt || ''}
+          loading="lazy"
+          className="h-auto max-w-full rounded-lg outline outline-1 -outline-offset-1 outline-black/10 dark:outline-white/10"
+        />
+      </span>
+    );
+  },
+
+  strong: ({ children }: ComponentProps<'strong'>) => (
+    <strong className="text-foreground font-semibold">{children}</strong>
+  ),
+  em: ({ children }: ComponentProps<'em'>) => (
+    <em className="text-foreground/90 italic">{children}</em>
+  ),
+  del: ({ children }: ComponentProps<'del'>) => (
+    <del className="text-muted-foreground decoration-muted-foreground/50 line-through">
+      {children}
+    </del>
+  ),
+};

--- a/apps/web/src/components/markdown/unified-markdown-utils.test.ts
+++ b/apps/web/src/components/markdown/unified-markdown-utils.test.ts
@@ -49,6 +49,10 @@ describe('languageLabel', () => {
     expect(languageLabel('')).toBe('text');
   });
 
+  test('shiki defaultLanguage "plaintext" collapses to text', () => {
+    expect(languageLabel('plaintext')).toBe('text');
+  });
+
   test('expands short aliases and lowercases the rest', () => {
     expect(languageLabel('js')).toBe('javascript');
     expect(languageLabel('TS')).toBe('typescript');

--- a/apps/web/src/components/markdown/unified-markdown-utils.ts
+++ b/apps/web/src/components/markdown/unified-markdown-utils.ts
@@ -35,6 +35,7 @@ export function languageLabel(language: string): string {
   if (!language) return 'text';
   const lower = language.toLowerCase();
   const display: Record<string, string> = {
+    plaintext: 'text',
     js: 'javascript',
     ts: 'typescript',
     py: 'python',


### PR DESCRIPTION
## Summary

- Rebuilds `/docs` into a clean, better-auth-grade fumadocs UI: the `--color-fd-*` tokens now inherit the app's semantic tokens (single source of truth, automatic light/dark parity), clerk-style TOC, breadcrumb row with an Edit-on-GitHub button, custom prev/next footer cards, sidebar + search polish, and a working search dialog backed by a new `/api/search` route (it previously 404'd).
- Docs MDX content now renders in the app's unified-markdown style: same heading scale and 15px body voice, kortix-blue links, bordered inline-code chips, flat code cards with a language header + copy button, and the same `slack-ochin`/`plastic` Shiki palettes — highlighted server-side by the fumadocs pipeline, so no client-side highlighter enters the docs bundle.
- Fumadocs building blocks (Callout, Tabs, Steps, Cards, Accordions) are registered globally for all MDX; per-file `Callout` imports were removed from content.
- `CopyButton` is extracted from `unified-markdown.tsx` into a shared module (no behavior change).

## Test plan

- `pnpm exec tsc --noEmit` clean; markdown util unit tests pass (12/12, including a new `plaintext` → `text` label case).
- Verified `/docs`, `/docs/quickstart`, `/docs/sdk/getting-started` at 1440/834/390 in light + dark via Playwright screenshots: sidebar, TOC, breadcrumbs, prev/next cards, code cards, tables, and the ⌘K search dialog returning results.
- `curl "/api/search?query=session"` → 200 with JSON results.
