### PR TITLE
fix: no red error-toast storm when joining a project as a member

### DIFF
--- a/apps/api/src/__tests__/e2e-executor.test.ts
+++ b/apps/api/src/__tests__/e2e-executor.test.ts
@@ -146,6 +146,12 @@ const deps: ExecutorRouterDeps = {
     const u = c.req.header('x-test-admin');
     return u ? { accountId: ACCOUNT, userId: u } : null;
   },
+  // Read-tier (project.connector.read): a plain member can LIST connectors but
+  // not administer them. Admin implies reader, mirroring the real role chain.
+  resolveReader: async (c) => {
+    const u = c.req.header('x-test-reader') ?? c.req.header('x-test-admin');
+    return u ? { accountId: ACCOUNT, userId: u } : null;
+  },
   listConnectors: async (_projectId, viewerUserId): Promise<AdminConnectorView[]> =>
     [...world.connectors.values()].map((conn) => ({
       slug: conn.slug,
@@ -244,6 +250,21 @@ describe('admin routes', () => {
 
   test('sync returns count', async () => {
     expect((await (await req(`/projects/${PROJECT}/connectors/sync`, { method: 'POST', headers: { 'x-test-admin': ALICE } })).json()).synced).toBe(1);
+  });
+
+  test('a read-tier member can LIST connectors (project.connector.read is member-baseline)', async () => {
+    const res = await req(`/projects/${PROJECT}/connectors`, { headers: { 'x-test-reader': ALICE } });
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.connectors[0]).toMatchObject({ slug: 'stripe', secretSet: true });
+  });
+
+  test('a read-tier member still cannot administer connectors (sync stays write-gated)', async () => {
+    const res = await req(`/projects/${PROJECT}/connectors/sync`, {
+      method: 'POST',
+      headers: { 'x-test-reader': ALICE },
+    });
+    expect(res.status).toBe(403);
   });
 
   test('the old connector sharing route is gone (404)', async () => {

--- a/apps/api/src/executor/db-deps.ts
+++ b/apps/api/src/executor/db-deps.ts
@@ -596,27 +596,44 @@ async function listCatalog(p: ExecutorPrincipal): Promise<CatalogConnector[]> {
   return out;
 }
 
-async function resolveAdmin(c: Context, projectId: string): Promise<{ accountId: string; userId: string } | null> {
+async function resolveProjectUserWith(
+  c: Context,
+  projectId: string,
+  action: 'project.connector.read' | 'project.connector.write',
+): Promise<{ accountId: string; userId: string } | null> {
   if (!isUuid(projectId)) return null;
   const userId = c.get('userId') as string | undefined;
   if (!userId) return null;
   const [proj] = await db.select({ accountId: projects.accountId }).from(projects).where(eq(projects.projectId, projectId)).limit(1);
   if (!proj) return null;
-  // Connector administration (create/delete connectors, write shared credentials,
-  // grants/policies) is project.connector.write — NOT the coarse, fold-exempt
-  // project.write. Thread the acting token (iamTokenId) so the agent-grant fold
-  // fires: a scoped agent-session token must actually hold connector.write to
-  // manage connectors, and a custom role can withhold it from humans too.
+  // Thread the acting token (iamTokenId) so the agent-grant fold fires: a
+  // scoped agent-session token must actually hold the leaf, and a custom role
+  // can withhold it from humans too.
   const actingTokenId = (c.get('iamTokenId') as string | undefined) ?? undefined;
   const decision = await authorize(
     userId,
     proj.accountId,
-    'project.connector.write',
+    action,
     { type: 'project', id: projectId },
     actingTokenId,
   );
   if (!decision.allowed) return null;
   return { accountId: proj.accountId, userId };
+}
+
+// Connector administration (create/delete connectors, write shared credentials,
+// grants/policies) is project.connector.write — NOT the coarse, fold-exempt
+// project.write.
+async function resolveAdmin(c: Context, projectId: string): Promise<{ accountId: string; userId: string } | null> {
+  return resolveProjectUserWith(c, projectId, 'project.connector.write');
+}
+
+// The connectors LIST is read-tier: project.connector.read is in the member
+// baseline (the Connectors/Channels rail sections gate visibility on it), so a
+// plain member can see which connectors exist and their status. The list never
+// carries credential values — only whether one is set.
+async function resolveReader(c: Context, projectId: string): Promise<{ accountId: string; userId: string } | null> {
+  return resolveProjectUserWith(c, projectId, 'project.connector.read');
 }
 
 /** Admin list — sharing + credential mode + whether the shared credential is set.
@@ -729,6 +746,7 @@ export const dbExecutorRouterDeps: ExecutorRouterDeps = {
   makeGatewayDeps: () => makeDbGatewayDeps(),
   listCatalog,
   resolveAdmin,
+  resolveReader,
   listConnectors,
   // The manual "Sync" button re-pulls catalogs unconditionally (force) — the
   // user is explicitly asking to refresh, e.g. an MCP server gained new tools.

--- a/apps/api/src/executor/router.ts
+++ b/apps/api/src/executor/router.ts
@@ -161,6 +161,14 @@ export interface ExecutorRouterDeps {
     c: Context,
     projectId: string,
   ): Promise<{ accountId: string; userId: string } | null>;
+  /** Read-tier auth for the connectors LIST: `project.connector.read` is in the
+   *  member baseline (the Connectors/Channels rail sections gate on it), so the
+   *  list must not require connector.write like the mutations do. Falls back to
+   *  resolveAdmin when a deps implementation doesn't provide it. */
+  resolveReader?(
+    c: Context,
+    projectId: string,
+  ): Promise<{ accountId: string; userId: string } | null>;
   listConnectors(projectId: string, viewerUserId: string): Promise<AdminConnectorView[]>;
   syncConnectors(projectId: string, accountId: string): Promise<SyncResult>;
   /** Create/update a connector in kortix.yaml + materialize. */
@@ -502,9 +510,14 @@ export function createExecutorRouter(deps: ExecutorRouterDeps): OpenAPIHono {
     }),
     async (c: any) => {
       const projectId = c.req.param('projectId');
-      const admin = await deps.resolveAdmin(c, projectId);
-      if (!admin) return c.json({ error: 'forbidden' }, 403);
-      return c.json({ connectors: await deps.listConnectors(projectId, admin.userId) });
+      // Read-tier: plain members hold project.connector.read and the dashboard
+      // sections that render this list are visible to them. The response carries
+      // no credential values (only whether one is set).
+      const reader = deps.resolveReader
+        ? await deps.resolveReader(c, projectId)
+        : await deps.resolveAdmin(c, projectId);
+      if (!reader) return c.json({ error: 'forbidden' }, 403);
+      return c.json({ connectors: await deps.listConnectors(projectId, reader.userId) });
     },
   );
 

--- a/apps/web/src/app/(app)/projects/[id]/files/page.tsx
+++ b/apps/web/src/app/(app)/projects/[id]/files/page.tsx
@@ -8,7 +8,9 @@ import { ProjectShell } from '@/features/workspace/project-layout/project-shell'
 /**
  * /projects/[id]/files — the standalone Files page (Google-Drive-style browser
  * over the project repo). A regular routed page inside the project shell, NOT
- * a Customize section: any member can browse files, no editor access needed.
+ * a Customize section. Requires `project.file.read` (editor-tier): the sidebar
+ * entry hides for floor members and the API 403s their reads (silently — the
+ * view shows its own empty/error state, never a global toast).
  */
 export default function ProjectFilesPage() {
   const { id: projectId } = useParams<{ id: string }>();

--- a/apps/web/src/features/workspace/project-sidebar/footer/project-customize-nav.tsx
+++ b/apps/web/src/features/workspace/project-sidebar/footer/project-customize-nav.tsx
@@ -7,6 +7,8 @@ import { useCallback, useEffect } from 'react';
 
 import Hint from '@/components/ui/hint';
 import { SidebarMenuButton, SidebarMenuItem, useSidebar } from '@/components/ui/sidebar';
+import { PROJECT_ACTIONS } from '@/lib/project-actions';
+import { useProjectCan } from '@/lib/use-project-can';
 import { useIsMobile } from '@/hooks/utils';
 import { useCustomizeStore } from '@/stores/customize-store';
 import { Kbd, KbdGroup } from '@/components/ui/kbd';
@@ -99,12 +101,20 @@ export function ProjectCustomizeRailItem() {
   );
 }
 
-/** Top-level Files entry — sits ABOVE Customize and is shown to every member
- *  (files aren't part of customization). Navigates to the standalone page. */
+/** Top-level Files entry — sits ABOVE Customize (files aren't part of
+ *  customization). Hidden when the caller lacks `project.file.read`: that leaf
+ *  is editor-tier (IAM v1 moved the sensitive file/secret reads off the floor
+ *  `member` role), so showing it to a plain member would just land them on a
+ *  page whose every read 403s. Optimistic while the probe loads — the entry
+ *  only disappears on an explicit deny. */
 export function ProjectFilesNavItem() {
   const onClick = useFilesActivate();
   const pathname = usePathname();
+  const params = useParams<{ id: string }>();
+  const canReadFiles = useProjectCan(params?.id, PROJECT_ACTIONS.PROJECT_FILE_READ);
   const isActive = !!pathname && /^\/projects\/[^/]+\/files(\/|$)/.test(pathname);
+
+  if (!canReadFiles.allowed && !canReadFiles.isLoading) return null;
 
   return (
     <SidebarMenuItem>

--- a/apps/web/src/hooks/legacy/use-legacy-machine-migration.ts
+++ b/apps/web/src/hooks/legacy/use-legacy-machine-migration.ts
@@ -59,7 +59,12 @@ export function useLegacyMachines(opts?: { enabled?: boolean; accountId?: string
     queryFn: async () => {
       const qs = accountId ? `?account_id=${encodeURIComponent(accountId)}` : '';
       return unwrap(
-        await backendApi.get<LegacyEligibility>(`/projects/legacy-migration/eligibility${qs}`),
+        // Background eligibility probe on the projects grid — a user who just
+        // joined (or left) an account can race the account switch and 403;
+        // the Migrate card simply doesn't render, never a global toast.
+        await backendApi.get<LegacyEligibility>(`/projects/legacy-migration/eligibility${qs}`, {
+          showErrors: false,
+        }),
       );
     },
     enabled: opts?.enabled ?? true,

--- a/apps/web/src/lib/project-actions.ts
+++ b/apps/web/src/lib/project-actions.ts
@@ -11,10 +11,11 @@
  * Gating rule (IAM v1): a capability is DEACTIVATED for a group by giving
  * its custom role a permission set that OMITS the capability's leaf. The UI
  * reflects that by hiding/disabling the section whose `read`/`write` leaf the
- * role no longer grants. Therefore every `read` leaf used below MUST be one the
- * built-in Member role is seeded with (role-perms.ts `PROJECT_MEMBER_BASELINE`)
- * and every `write` leaf one Editor is seeded with — otherwise a normal
- * member/editor would be stranded out of a section they should still see.
+ * role no longer grants. Sections whose read leaf is in the Member baseline
+ * (role-perms.ts `PROJECT_MEMBER_BASELINE`) are visible to every project role;
+ * `secrets` gates on project.secret.read, which is DELIBERATELY editor-tier
+ * (the sensitive file/secret reads moved off the floor `member` role), so that
+ * section — like the standalone Files page — hides for plain members by design.
  */
 
 import type { CustomizeSection } from '@/lib/customize-sections';

--- a/packages/sdk/src/platform/projects-client/connectors.test.ts
+++ b/packages/sdk/src/platform/projects-client/connectors.test.ts
@@ -53,6 +53,20 @@ test('listConnectors throws on a failed response', async () => {
   await expect(listConnectors('P1')).rejects.toBeTruthy();
 });
 
+test('listConnectors is a silent background read — a 403 never hits the global error sink', async () => {
+  // Fired at workspace mount (project-home tiles, sidebar setup checklist);
+  // callers render their own state, never a global toast.
+  const onError = mock(() => {});
+  configureKortix({ backendUrl: 'http://test.local', getToken: async () => 'tok', onError });
+  try {
+    nextResponse = { status: 403, body: { error: 'forbidden' } };
+    await expect(listConnectors('P1')).rejects.toBeTruthy();
+    expect(onError).not.toHaveBeenCalled();
+  } finally {
+    configureKortix({ backendUrl: 'http://test.local', getToken: async () => 'tok' });
+  }
+});
+
 test('syncConnectors POSTs an empty body to the sync endpoint', async () => {
   nextResponse = { status: 200, body: { synced: 2, errors: [] } };
   const result = await syncConnectors('P1');

--- a/packages/sdk/src/platform/projects-client/connectors.ts
+++ b/packages/sdk/src/platform/projects-client/connectors.ts
@@ -44,7 +44,11 @@ export interface ConnectorSyncResult {
 
 export async function listConnectors(projectId: string) {
   return unwrap(
-    await backendApi.get<ConnectorsResponse>(`/executor/projects/${projectId}/connectors`),
+    // Background read fired at workspace mount (project-home tiles, sidebar
+    // setup checklist) — never global-toast; callers render their own state.
+    await backendApi.get<ConnectorsResponse>(`/executor/projects/${projectId}/connectors`, {
+      showErrors: false,
+    }),
   );
 }
 

--- a/packages/sdk/src/platform/projects-client/files.test.ts
+++ b/packages/sdk/src/platform/projects-client/files.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, expect, mock, test } from 'bun:test';
+import { configureKortix } from '../config';
+import { listProjectFiles } from './files';
+
+let calls: { url: string; method: string; body: unknown }[] = [];
+let nextResponse: { status: number; body: unknown } = { status: 200, body: {} };
+
+beforeEach(() => {
+  calls = [];
+  nextResponse = { status: 200, body: {} };
+  globalThis.fetch = mock(async (url: unknown, opts: { method?: string; body?: string } = {}) => {
+    calls.push({
+      url: String(url),
+      method: opts.method ?? 'GET',
+      body: opts.body ? JSON.parse(opts.body) : undefined,
+    });
+    return new Response(JSON.stringify(nextResponse.body), {
+      status: nextResponse.status,
+      headers: { 'content-type': 'application/json' },
+    });
+  }) as unknown as typeof fetch;
+});
+
+configureKortix({ backendUrl: 'http://test.local', getToken: async () => 'tok' });
+const last = () => calls[calls.length - 1];
+
+test('listProjectFiles GETs /projects/:id/files with ref/path query', async () => {
+  nextResponse = { status: 200, body: [] };
+  const result = await listProjectFiles('P1', { ref: 'main', path: 'src' });
+  expect(last().url).toContain('/projects/P1/files?ref=main&path=src');
+  expect(last().method).toBe('GET');
+  expect(result).toEqual([]);
+});
+
+test('listProjectFiles is a silent background read — a 403 never hits the global error sink', async () => {
+  // project.file.read is editor-tier: a member deep-linking to the files page
+  // legitimately 403s. The files view renders its own error state, no toast.
+  const onError = mock(() => {});
+  configureKortix({ backendUrl: 'http://test.local', getToken: async () => 'tok', onError });
+  try {
+    nextResponse = { status: 403, body: { message: 'forbidden' } };
+    await expect(listProjectFiles('P1')).rejects.toBeTruthy();
+    expect(onError).not.toHaveBeenCalled();
+  } finally {
+    configureKortix({ backendUrl: 'http://test.local', getToken: async () => 'tok' });
+  }
+});

--- a/packages/sdk/src/platform/projects-client/files.ts
+++ b/packages/sdk/src/platform/projects-client/files.ts
@@ -16,6 +16,9 @@ export async function listProjectFiles(
   return unwrap(
     await backendApi.get<ProjectFileEntry[]>(
       `/projects/${projectId}/files${query}`,
+      // project.file.read is editor-tier — a member deep-linking to the files
+      // page legitimately 403s. The files view renders its own error state.
+      { showErrors: false },
     ),
   );
 }

--- a/packages/sdk/src/platform/projects-client/secrets.test.ts
+++ b/packages/sdk/src/platform/projects-client/secrets.test.ts
@@ -46,6 +46,20 @@ test('listProjectSecrets throws when the response is unsuccessful', async () => 
   await expect(listProjectSecrets('P1')).rejects.toBeTruthy();
 });
 
+test('listProjectSecrets is a silent background read — a 403 never hits the global error sink', async () => {
+  // project.secret.read is editor-tier: plain members legitimately 403 from
+  // member-visible surfaces (model picker, LLM providers). No global toast.
+  const onError = mock(() => {});
+  configureKortix({ backendUrl: 'http://test.local', getToken: async () => 'tok', onError });
+  try {
+    nextResponse = { status: 403, body: { message: 'forbidden' } };
+    await expect(listProjectSecrets('P1')).rejects.toBeTruthy();
+    expect(onError).not.toHaveBeenCalled();
+  } finally {
+    configureKortix({ backendUrl: 'http://test.local', getToken: async () => 'tok' });
+  }
+});
+
 test('upsertProjectSecret POSTs name/value as the raw body', async () => {
   nextResponse = { status: 200, body: { name: 'FOO' } };
   await upsertProjectSecret('P1', { name: 'FOO', value: 'bar' });

--- a/packages/sdk/src/platform/projects-client/secrets.ts
+++ b/packages/sdk/src/platform/projects-client/secrets.ts
@@ -63,6 +63,10 @@ export async function listProjectSecrets(projectId: string) {
   return unwrap(
     await backendApi.get<ProjectSecretsResponse>(
       `/projects/${projectId}/secrets`,
+      // Background read fired from member-visible surfaces (model picker, LLM
+      // providers, agent editor) — project.secret.read is editor-tier, so a
+      // plain member legitimately 403s here. Callers render their own state.
+      { showErrors: false },
     ),
   );
 }


### PR DESCRIPTION
## What we hit

Get invited to a project as a **member** → accept → the workspace throws a pile of red \"Access denied / Contact support\" toasts. Reproduced end-to-end against a live stack by minting a fresh owner + member and replaying every GET the web app fires on the member journey: **9 distinct endpoints 403 for a plain member**, and several of them were fired unguarded at workspace mount, each turning into a global red toast.

## Root causes (two classes)

**1. Server inconsistency — reads gated on write.** `GET /v1/executor/projects/:id/connectors` required `project.connector.write` (`resolveAdmin`), but `project.connector.read` is deliberately in the member baseline and the Connectors/Channels/Meet sections are visible to members because of it. The list fires at workspace mount from project-home's setup tiles and the sidebar setup checklist → guaranteed 403 toast for every member, on every project open.

**2. Client fires editor/manager-tier reads for everyone, with global error toasts on.** IAM v1 moved `project.secret.read` / `project.file.read` to editor-tier (deliberate), but:
- the **model selector** fetches the project secrets list on every session surface (to light up connected providers) with default `showErrors` → red toast for every member
- the **Files** sidebar entry was shown to everyone (\"files aren't gated behind customize access\") → members land on a page whose every read 403s
- the **legacy-migration eligibility** probe on the projects grid toasts on account-switch races

## The fix

- **api**: connectors LIST now resolves via `project.connector.read` (new `resolveReader` dep; falls back to `resolveAdmin` for deps impls that don't provide it). Administration (create/delete/credentials/sync/policies) stays behind `connector.write` — pinned by a new test.
- **sdk**: `listProjectSecrets`, `listConnectors`, `listProjectFiles` are background reads — `showErrors: false`; callers already render their own degraded states (model picker falls back to the baked catalog, tiles show counts, files view shows its own error). Contract tests pin that a 403 never reaches the global error sink.
- **web**: Files sidebar entry hides when the IAM probe denies `project.file.read` (same `useProjectCan` machinery as the #4330 rail gating); legacy eligibility probe silenced; stale \"any member can browse files\" comments corrected.

## Verified

Live probe (owner + invited member + fresh-signup member, ~50 endpoints each): after the fix the connectors list 200s for members and **every remaining 403 is on an endpoint the web either never fires at mount or already fires silently/manage-gated**. `tsc` clean on api/sdk/web; 182 sdk + 32 executor + 5 web tests pass; biome adds no new findings on touched files.

## How to test

1. From account A (owner), open a project → Members → invite a fresh email as **member**.
2. Open the invite link in an incognito window, sign up, accept.
3. You land on /projects → open the shared project → open a session, click around (home, review, members).
4. Expect: **zero red toasts**. Member sees no Files entry, no Secrets section, model picker shows the default catalog, manager cards on Members stay hidden.
5. As an editor/manager everything looks unchanged (Files entry present, connectors list + counts still load).