### PR TITLE
feat(cli+marketplace): complete the CLI command surface + role-pack skill bundles

### DIFF
--- a/apps/api/src/__tests__/unit-marketplace.test.ts
+++ b/apps/api/src/__tests__/unit-marketplace.test.ts
@@ -40,6 +40,43 @@ describe('marketplace catalog', () => {
     expect(all.find((i) => i.name === 'pdf')).toBeTruthy();
   });
 
+  test('every curated bundle references only skills that exist in the catalog', async () => {
+    const all = await listCatalogItems({ source: 'kortix' });
+    const names = new Set(all.map((i) => i.name));
+    const bundles = all.filter((i) => i.type === 'registry:bundle');
+
+    // Guards against silently losing a pack in a future edit.
+    expect(bundles.length).toBeGreaterThanOrEqual(10);
+    for (const bundle of bundles) {
+      expect(bundle.dependencies.length).toBeGreaterThan(0);
+      for (const dep of bundle.dependencies) {
+        // A typo'd dependency renders as a ghost item in the UI instead of
+        // failing anywhere — this turns that into a hard failure.
+        expect(names.has(dep)).toBe(true);
+      }
+    }
+  });
+
+  test('curated bundle ids are the full role-pack set', async () => {
+    const all = await listCatalogItems({ source: 'kortix' });
+    const ids = all
+      .filter((i) => i.type === 'registry:bundle')
+      .map((i) => i.id)
+      .sort();
+    expect(ids).toEqual([
+      'kortix:customer-support-pack',
+      'kortix:documents-pack',
+      'kortix:finance-close-pack',
+      'kortix:health-pack',
+      'kortix:legal-pack',
+      'kortix:marketing-pack',
+      'kortix:product-management-pack',
+      'kortix:recruiting-pack',
+      'kortix:research-pack',
+      'kortix:sales-pack',
+    ]);
+  });
+
   test('lists only optional Kortix skills through the marketplace', async () => {
     const all = await listCatalogItems({ source: 'kortix' });
     const agentBrowser = all.find((i) => i.name === 'agent-browser');

--- a/apps/api/src/marketplace/catalog.ts
+++ b/apps/api/src/marketplace/catalog.ts
@@ -318,6 +318,113 @@ const CURATED_BUNDLES: RegistryItem[] = [
     registryDependencies: ["pdf", "docx", "xlsx", "presentations"],
     meta: { source: "kortix" },
   },
+  {
+    name: "legal-pack",
+    type: "registry:bundle",
+    title: "Legal Pack",
+    description:
+      "In-house legal team essentials: contract review, NDA triage, compliance, risk assessment, and legal drafting.",
+    categories: ["bundle", "legal"],
+    registryDependencies: [
+      "contract-review",
+      "nda-triage",
+      "compliance",
+      "risk-assessment",
+      "legal-writer",
+    ],
+    meta: { source: "kortix" },
+  },
+  {
+    name: "finance-close-pack",
+    type: "registry:bundle",
+    title: "Finance Close Pack",
+    description:
+      "Month-end close, end to end: reconciliations, journal entries, variance analysis, financial statements, and close-checklist management.",
+    categories: ["bundle", "finance"],
+    registryDependencies: [
+      "reconciliation",
+      "journal-entry-prep",
+      "variance-analysis",
+      "financial-statements",
+      "close-management",
+    ],
+    meta: { source: "kortix" },
+  },
+  {
+    name: "product-management-pack",
+    type: "registry:bundle",
+    title: "Product Management Pack",
+    description:
+      "Ship better product decisions: PRDs, roadmap planning, user research synthesis, metrics tracking, and stakeholder communication.",
+    categories: ["bundle", "product"],
+    registryDependencies: [
+      "feature-spec",
+      "roadmap-management",
+      "user-research-synthesis",
+      "metrics-tracking",
+      "stakeholder-comms",
+    ],
+    meta: { source: "kortix" },
+  },
+  {
+    name: "customer-support-pack",
+    type: "registry:bundle",
+    title: "Customer Support Pack",
+    description:
+      "Triage, resolve, and document support tickets: prioritized triage, empathetic response drafting, escalation briefs, and knowledge-base articles.",
+    categories: ["bundle", "support"],
+    registryDependencies: [
+      "ticket-triage",
+      "response-drafting",
+      "escalation",
+      "knowledge-management",
+    ],
+    meta: { source: "kortix" },
+  },
+  {
+    name: "health-pack",
+    type: "registry:bundle",
+    title: "Health Pack",
+    description:
+      "Your personal health data in one place: wearable metrics, electronic health records, and a unified health summary.",
+    categories: ["bundle", "health"],
+    registryDependencies: [
+      "personal-health",
+      "wearables-data",
+      "electronic-health-records",
+    ],
+    meta: { source: "kortix" },
+  },
+  {
+    name: "marketing-pack",
+    type: "registry:bundle",
+    title: "Marketing Pack",
+    description:
+      "Plan and produce on-brand campaigns: campaign planning, content creation, brand voice, and performance analytics.",
+    categories: ["bundle", "marketing"],
+    registryDependencies: [
+      "campaign-planning",
+      "content-creation",
+      "brand-voice",
+      "performance-analytics",
+    ],
+    meta: { source: "kortix" },
+  },
+  {
+    name: "recruiting-pack",
+    type: "registry:bundle",
+    title: "Recruiting Pack",
+    description:
+      "Run a recruiting pipeline: automated sourcing, resume ranking against a role, readiness-to-move scoring, and a shareable talent-pool leaderboard.",
+    categories: ["bundle", "recruiting"],
+    registryDependencies: [
+      "automated-sourcing",
+      "ats-ranker",
+      "rtm-ranker",
+      "talent-pool-rendering",
+    ],
+    meta: { source: "kortix" },
+  },
 ];
 
 let BASE: Catalog | null = null;

--- a/apps/cli/src/__tests__/cli-blackbox.test.ts
+++ b/apps/cli/src/__tests__/cli-blackbox.test.ts
@@ -535,6 +535,74 @@ console.log(JSON.stringify({ cmd, args, body }));
     expect(help.stdout).toContain('init');
   });
 
+  test('doctor, providers, and proxy are wired (not unknown commands)', async () => {
+    const doctor = await runCli(['doctor', '--help']);
+    expect(doctor.code).toBe(0);
+    expect(doctor.stdout).toContain('Usage: kortix doctor');
+    expect(doctor.stderr).not.toContain('unknown command');
+
+    const providers = await runCli(['providers', '--help']);
+    expect(providers.code).toBe(0);
+    expect(providers.stdout).toContain('Usage: kortix providers');
+    expect(providers.stderr).not.toContain('unknown command');
+
+    const proxy = await runCli(['proxy', '--help']);
+    expect(proxy.code).toBe(0);
+    expect(proxy.stdout).toContain('Usage: kortix proxy');
+    expect(proxy.stderr).not.toContain('unknown command');
+  }, 20_000);
+
+  test('top-level help lists the newly wired commands', async () => {
+    const help = await runCli(['--help']);
+    expect(help.code).toBe(0);
+    expect(help.stdout).toContain('doctor');
+    expect(help.stdout).toContain('dump');
+    expect(help.stdout).toContain('providers');
+    expect(help.stdout).toContain('proxy');
+  }, 15_000);
+
+  test('dump --offline --json emits a redacted, machine-readable report', async () => {
+    const configFile = writeConfig('https://api.example.test');
+    const result = await runCli(['dump', '--offline', '--json'], tmp, {
+      KORTIX_CONFIG_FILE: configFile,
+    });
+    expect(result.code).toBe(0);
+    const report = JSON.parse(result.stdout);
+    expect(report.cli_version).toBeDefined();
+    expect(report.platform).toContain('/');
+    expect(report.config_file).toContain('config.json');
+    expect(report.auth.logged_in).toBe(true);
+    expect(report.auth.user_email).toBe('user@example.test');
+    // --offline must skip the network probe entirely.
+    expect(report.identity_probe).toBeNull();
+    // The token value must never appear anywhere in the output.
+    expect(result.stdout).not.toContain('tok_blackbox');
+  }, 15_000);
+
+  test('dump reports not-logged-in without a token and never leaks it', async () => {
+    const path = join(tmp, 'empty-config.json');
+    writeFileSync(
+      path,
+      JSON.stringify({
+        active: 'test',
+        hosts: {
+          test: {
+            url: 'https://api.example.test',
+            token: '',
+            user_id: '',
+            user_email: '',
+            account_id: '',
+            logged_in_at: '',
+          },
+        },
+      }),
+      'utf8',
+    );
+    const result = await runCli(['dump', '--offline'], tmp, { KORTIX_CONFIG_FILE: path });
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain('not logged in');
+  }, 15_000);
+
   test('schema --version 2 prints the v2 JSON Schema, not the CLI version banner', async () => {
     // Regression guard: `main()` used to scan the ENTIRE argv for a bare
     // `--version`/`-v` and print the CLI's own version banner before any

--- a/apps/cli/src/commands/dump.ts
+++ b/apps/cli/src/commands/dump.ts
@@ -1,0 +1,167 @@
+import { loadAuth, loadAuthForHost } from '../api/auth.ts';
+import { ApiError, clientFromAuth } from '../api/client.ts';
+import {
+  activeAccount,
+  activeHostName,
+  configFilePath,
+  defaultProject,
+  hasEnvTokenHost,
+  listHosts,
+} from '../api/config.ts';
+import type { MeResponse } from '../api/types.ts';
+import { emitJson, takeFlagBool, takeFlagValue } from '../command-helpers.ts';
+import { isKortixProject, linkFilePath, loadLink } from '../project-link.ts';
+import { C, help, status } from '../style.ts';
+
+// Mirrors the fallback in index.ts — the compiled binary injects the real
+// version via KORTIX_CLI_VERSION; importing it back from index.ts is circular.
+const VERSION = process.env.KORTIX_CLI_VERSION ?? 'dev';
+
+const HELP = help`Usage: kortix dump [options]
+
+Print a redacted, copy-pasteable debug summary — CLI version, runtime,
+active host/account/project, auth presence, and config file locations.
+Safe to paste into a support thread: no secret values are ever printed.
+
+Options:
+  --host <name>   Probe a specific host instead of the active one.
+  --offline       Skip the network identity probe (pure local info).
+  --json          Machine-readable JSON output.
+  -h, --help      Show this help.
+`;
+
+interface DumpFlags {
+  host?: string;
+  offline: boolean;
+  json: boolean;
+  help: boolean;
+}
+
+function parseFlags(argv: string[]): DumpFlags {
+  const rest = [...argv];
+  const help = takeFlagBool(rest, ['-h', '--help']);
+  const offline = takeFlagBool(rest, ['--offline']);
+  const json = takeFlagBool(rest, ['--json']);
+  const host = takeFlagValue(rest, ['--host']);
+  if (rest.length > 0) throw new Error(`unknown option "${rest[0]}"`);
+  return { host, offline, json, help };
+}
+
+function runtimeLabel(): string {
+  const bun = (process.versions as Record<string, string | undefined>).bun;
+  return bun ? `bun ${bun}` : `node ${process.version}`;
+}
+
+export async function runDump(argv: string[]): Promise<number> {
+  let flags: DumpFlags;
+  try {
+    flags = parseFlags(argv);
+  } catch (err) {
+    process.stderr.write(`${(err as Error).message}\n\n${HELP}`);
+    return 2;
+  }
+  if (flags.help) {
+    process.stdout.write(HELP);
+    return 0;
+  }
+
+  // Local facts first — a debug dump must work with no login and no project.
+  const auth = flags.host ? loadAuthForHost(flags.host) : loadAuth();
+  const hostName = flags.host ?? activeHostName();
+  const account = flags.host ? null : activeAccount();
+  const def = flags.host ? null : defaultProject();
+  const link = isKortixProject() ? loadLink() : null;
+  const loggedIn = Boolean(auth?.token);
+
+  const project = link
+    ? { project_id: link.project_id, source: 'linked' as const, host: link.host ?? null }
+    : def
+      ? { project_id: def.project_id, source: 'default' as const, name: def.name ?? null }
+      : null;
+
+  let probe:
+    | { ok: true; latency_ms: number; verified_email: string | null }
+    | { ok: false; latency_ms: number; error: string }
+    | null = null;
+
+  // Best-effort reachability check — never fatal, never blocks the report.
+  if (!flags.offline && auth?.token) {
+    const started = Date.now();
+    try {
+      const me = await clientFromAuth(auth).get<MeResponse>('/accounts/me');
+      probe = { ok: true, latency_ms: Date.now() - started, verified_email: me.email || null };
+    } catch (err) {
+      const error =
+        err instanceof ApiError ? `HTTP ${err.status}: ${err.message}` : (err as Error).message;
+      probe = { ok: false, latency_ms: Date.now() - started, error };
+    }
+  }
+
+  const report = {
+    cli_version: VERSION,
+    runtime: runtimeLabel(),
+    platform: `${process.platform}/${process.arch}`,
+    config_file: configFilePath(),
+    link_file: link ? linkFilePath() : null,
+    host: {
+      name: hostName,
+      url: auth?.api_base ?? null,
+      total_configured: listHosts().length,
+      via_sandbox_env_token: hasEnvTokenHost(),
+    },
+    auth: {
+      logged_in: loggedIn,
+      user_id: auth?.user_id || null,
+      user_email: auth?.user_email || null,
+    },
+    account: account ? { id: account.id, slug: account.slug, name: account.name || null } : null,
+    project,
+    identity_probe: probe,
+  };
+
+  if (flags.json) {
+    emitJson(report);
+    return 0;
+  }
+
+  const out: string[] = [
+    '',
+    `  ${C.white}${C.bold}kortix dump${C.reset}  ${C.faded}v${VERSION}${C.reset}`,
+    '',
+  ];
+  out.push(
+    `  ${C.dim}platform  ${C.reset}${report.platform} ${C.faded}(${report.runtime})${C.reset}`,
+  );
+  out.push(`  ${C.dim}config    ${C.reset}${report.config_file}`);
+  if (report.link_file) out.push(`  ${C.dim}link file ${C.reset}${report.link_file}`);
+  out.push('');
+  out.push(
+    `  ${C.dim}host      ${C.reset}${hostName ?? '—'} ${C.faded}(${report.host.url ?? 'no url'})${C.reset}`,
+  );
+  out.push(
+    loggedIn
+      ? status.ok(`logged in${auth?.user_email ? ` as ${auth.user_email}` : ''}`)
+      : status.warn('not logged in'),
+  );
+  if (account) {
+    out.push(`  ${C.dim}account   ${C.reset}${account.name || account.slug}`);
+  }
+  out.push(
+    project
+      ? `  ${C.dim}project   ${C.reset}${project.project_id} ${C.faded}(${project.source})${C.reset}`
+      : `  ${C.dim}project   ${C.reset}${C.faded}none${C.reset}`,
+  );
+  if (probe) {
+    out.push(
+      probe.ok
+        ? status.ok(`API reachable (${probe.latency_ms}ms)`)
+        : status.err(`API probe failed (${probe.latency_ms}ms): ${probe.error}`),
+    );
+  }
+  if (report.host.total_configured > 1) {
+    out.push(`  ${C.dim}hosts     ${C.reset}${report.host.total_configured} configured`);
+  }
+  out.push('');
+  process.stdout.write(`${out.join('\n')}\n`);
+  return 0;
+}

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -7,6 +7,8 @@ import { appsExperimentalEnabled, runApps } from './commands/apps.ts';
 import { runChannels } from './commands/channels.ts';
 import { runConnectors } from './commands/connectors.ts';
 import { runCr } from './commands/cr.ts';
+import { runDoctor } from './commands/doctor.ts';
+import { runDump } from './commands/dump.ts';
 import { runEnv } from './commands/env.ts';
 import { runExecutor } from './commands/executor.ts';
 import { runFiles } from './commands/files.ts';
@@ -17,6 +19,8 @@ import { runLogin } from './commands/login.ts';
 import { runLogout } from './commands/logout.ts';
 import { runMarketplace } from './commands/marketplace.ts';
 import { runProjects } from './commands/projects.ts';
+import { runProviders } from './commands/providers.ts';
+import { runProxy } from './commands/proxy.ts';
 import { runRegistry } from './commands/registry.ts';
 import { runRoles } from './commands/roles.ts';
 import { runSandboxes } from './commands/sandboxes.ts';
@@ -137,6 +141,11 @@ const TIERS: readonly CommandTier[] = [
           { name: 'secrets', args: '<subcommand>', blurb: 'Manage project secrets (project-scoped)' },
           { name: 'env', args: '<subcommand>', blurb: 'Pull/push project secrets as a dotenv file' },
           {
+            name: 'providers',
+            args: '<subcommand>',
+            blurb: 'Configure LLM providers for this project (OAuth or API key)',
+          },
+          {
             name: 'channels',
             args: '<subcommand>',
             blurb: 'Connect Slack to this project — `connect` prints a one-click install link',
@@ -169,6 +178,11 @@ const TIERS: readonly CommandTier[] = [
             name: 'chat',
             args: '[session-id]',
             blurb: "Talk to a session's agent (REPL or --prompt)",
+          },
+          {
+            name: 'proxy',
+            args: '<subcommand>',
+            blurb: 'Share a port inside a session sandbox via a public URL',
           },
           { name: 'files', args: '<subcommand>', blurb: 'Browse repo files, commits, branches, diffs' },
           { name: 'cr', args: '<subcommand>', blurb: 'Open, review, merge change requests' },
@@ -203,6 +217,11 @@ const TIERS: readonly CommandTier[] = [
       {
         title: '',
         commands: [
+          {
+            name: 'doctor',
+            blurb: 'End-to-end smoke test: auth → project → session → agent reply',
+          },
+          { name: 'dump', blurb: 'Print a redacted debug summary for support' },
           { name: 'update', blurb: 'Pull the latest CLI from kortix.com/install' },
           { name: 'uninstall', blurb: 'Remove the Kortix CLI from this machine' },
           { name: 'help', blurb: 'Show this help' },
@@ -340,11 +359,17 @@ async function main(argv: string[]): Promise<number> {
   if (argv[0] === 'env') {
     return runEnv(argv.slice(1));
   }
+  if (argv[0] === 'providers') {
+    return runProviders(argv.slice(1));
+  }
   if (argv[0] === 'sessions') {
     return runSessions(argv.slice(1));
   }
   if (argv[0] === 'chat') {
     return runSessionsChat(argv.slice(1));
+  }
+  if (argv[0] === 'proxy') {
+    return runProxy(argv.slice(1));
   }
   if (argv[0] === 'files') {
     return runFiles(argv.slice(1));
@@ -388,6 +413,12 @@ async function main(argv: string[]): Promise<number> {
   if (argv[0] === 'grants') {
     return runGrants(argv.slice(1));
   }
+  if (argv[0] === 'doctor') {
+    return runDoctor(argv.slice(1));
+  }
+  if (argv[0] === 'dump') {
+    return runDump(argv.slice(1));
+  }
   if (argv[0] === 'update') {
     return runUpdate(argv.slice(1));
   }
@@ -424,12 +455,14 @@ const KNOWN_COMMANDS = [
   'projects',
   'sessions',
   'chat',
+  'proxy',
   'files',
   'cr',
   'triggers',
   'connectors',
   'secrets',
   'env',
+  'providers',
   'channels',
   'sandboxes',
   'marketplace',
@@ -440,6 +473,8 @@ const KNOWN_COMMANDS = [
   'access',
   'roles',
   'grants',
+  'doctor',
+  'dump',
   'update',
   'uninstall',
   'help',


### PR DESCRIPTION
## Summary

Three additive, low-risk changes that move the CLI and skill-packaging surface toward completeness:

1. **Wire three dead CLI commands** — `doctor`, `providers`, and `proxy` were fully implemented but never registered in the dispatcher, help tiers, or known-commands list, so they errored as unknown commands. Now live.
2. **New `kortix dump`** — a redacted, copy-pasteable support summary (CLI version, runtime, host, account, project, auth presence, config path). Never prints secret values; supports `--offline` and `--json`.
3. **Role-pack skill bundles** — grow the curated one-click bundles from 3 to 10 (legal, finance-close, product-management, customer-support, health, marketing, recruiting), composed entirely from skills that already ship.

## Why

- `doctor` is an end-to-end smoke test (auth → project → session → agent reply) — especially valuable for agents self-verifying before they orchestrate real work. It was sitting dead in the tree.
- `dump` gives users and support a safe one-shot diagnostic to paste into a thread, with the token never included.
- The skill library clusters obviously by role; bundles turn that into a one-click "install my role's toolkit" moment. Only the curated groupings are new — every referenced skill already exists.

## Tests

- **CLI** (`cli-blackbox.test.ts`): dispatch of the three wired commands, top-level help listing, and `dump` redaction + JSON output — full suite 25/25 pass.
- **Marketplace** (`unit-marketplace.test.ts`): every curated bundle dependency resolves to a real catalog skill, and the full pack set is pinned.
- `pnpm --filter @kortix/cli typecheck` passes · `pnpm --filter kortix-api typecheck` passes · new `dump.ts` is biome-clean.

## Notes

- `prompt-size` was intentionally left out: the fully-assembled system prompt is not reachable from the CLI without new sandbox/runtime support, so a CLI-only version would report a misleading (too-small) number. Deferred until a runtime-side endpoint exists.
- The doc line `tests/spec/end-to-end.md:500` (claiming `providers`/`doctor`/`proxy` scaffold a project) is now stale — that scaffold path was already removed — and is worth a follow-up cleanup.

## Follow-on waves (not in this PR)

Tracked for subsequent PRs, roughly in priority order:

- Make the full skill library the default new-project experience (today the default is the 4-skill minimal template).
- Self-authored skills via change request (a `learn` flow) plus a curator to garbage-collect agent-authored skills.
- One-click import of an existing local agent setup, staged as a change request.
- Channel adapter interface + WhatsApp Cloud + scriptable outbound send + generalized DM pairing.
- Model plurality: credential pools, fallback chains, mixture-of-agents.
- A CLI parity gate (route-manifest annotation) so the command surface stops regressing silently.
