### PR TITLE
feat(cli): kortix skills new — scaffold a spec-valid SKILL.md (self-authoring loop, slice 1)

### DIFF
--- a/apps/cli/src/__tests__/cli-blackbox.test.ts
+++ b/apps/cli/src/__tests__/cli-blackbox.test.ts
@@ -1,7 +1,15 @@
-import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync, existsSync } from 'node:fs';
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
-import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 
 const CLI_ROOT = resolve(import.meta.dir, '..', '..');
 const CLI_ENTRY = join(CLI_ROOT, 'src', 'index.ts');
@@ -18,7 +26,12 @@ const SANDBOX_ENV_OVERRIDES = [
 
 let tmp: string;
 let server: ReturnType<typeof Bun.serve> | null = null;
-let requests: Array<{ method: string; path: string; authorization: string | null; body?: unknown }> = [];
+let requests: Array<{
+  method: string;
+  path: string;
+  authorization: string | null;
+  body?: unknown;
+}> = [];
 
 function writeConfig(apiBase: string): string {
   const path = join(tmp, 'config.json');
@@ -85,21 +98,23 @@ function startMarketplaceServer() {
       });
       if (url.pathname === '/v1/marketplace/items') {
         return Response.json({
-          items: [{
-            id: 'kortix-starter:pdf',
-            registry: 'kortix-starter',
-            name: 'pdf',
-            type: 'registry:skill',
-            title: 'PDF',
-            description: 'Read and write PDFs.',
-            categories: ['general-knowledge-worker'],
-            capabilities: { secrets: [], connectors: [], tools: [], network: [] },
-            dependencies: [],
-            fileCount: 1,
-            external: false,
-            marketplaceId: 'kortix',
-            marketplaceLabel: 'Kortix',
-          }],
+          items: [
+            {
+              id: 'kortix-starter:pdf',
+              registry: 'kortix-starter',
+              name: 'pdf',
+              type: 'registry:skill',
+              title: 'PDF',
+              description: 'Read and write PDFs.',
+              categories: ['general-knowledge-worker'],
+              capabilities: { secrets: [], connectors: [], tools: [], network: [] },
+              dependencies: [],
+              fileCount: 1,
+              external: false,
+              marketplaceId: 'kortix',
+              marketplaceLabel: 'Kortix',
+            },
+          ],
         });
       }
       return Response.json({ error: 'not found' }, { status: 404 });
@@ -146,7 +161,10 @@ function catalogItem(name: string) {
 }
 
 function startCliE2eServer() {
-  const installed = new Map<string, { name: string; type: string; source: string; installed_at: string | null; file_count: number }>();
+  const installed = new Map<
+    string,
+    { name: string; type: string; source: string; installed_at: string | null; file_count: number }
+  >();
   let updateAvailable = true;
   let removed = false;
   let archived = false;
@@ -155,11 +173,12 @@ function startCliE2eServer() {
     port: 0,
     fetch: async (req) => {
       const url = new URL(req.url);
-      const entry: { method: string; path: string; authorization: string | null; body?: unknown } = {
-        method: req.method,
-        path: `${url.pathname}${url.search}`,
-        authorization: req.headers.get('authorization'),
-      };
+      const entry: { method: string; path: string; authorization: string | null; body?: unknown } =
+        {
+          method: req.method,
+          path: `${url.pathname}${url.search}`,
+          authorization: req.headers.get('authorization'),
+        };
       if (!['GET', 'HEAD'].includes(req.method)) {
         const text = await req.text();
         if (text) {
@@ -184,7 +203,11 @@ function startCliE2eServer() {
       }
       if (url.pathname === '/v1/projects/proj_e2e' && req.method === 'DELETE') {
         archived = true;
-        return Response.json({ ok: true, archived: true, repo_deleted: url.searchParams.get('purge') === 'true' });
+        return Response.json({
+          ok: true,
+          archived: true,
+          repo_deleted: url.searchParams.get('purge') === 'true',
+        });
       }
       if (url.pathname === '/v1/projects/proj_e2e/sessions/sess_connect' && req.method === 'GET') {
         return Response.json({
@@ -241,14 +264,17 @@ function startCliE2eServer() {
         });
         removed = false;
         updateAvailable = true;
-        return Response.json({
-          ok: true,
-          commit_sha: `commit_install_${name}`,
-          branch: 'main',
-          file_count: installed.get(name)!.file_count + 1,
-          installed: [{ name, type: installed.get(name)!.type }],
-          capabilities: catalogItem(name).capabilities,
-        }, { status: 201 });
+        return Response.json(
+          {
+            ok: true,
+            commit_sha: `commit_install_${name}`,
+            branch: 'main',
+            file_count: installed.get(name)!.file_count + 1,
+            installed: [{ name, type: installed.get(name)!.type }],
+            capabilities: catalogItem(name).capabilities,
+          },
+          { status: 201 },
+        );
       }
       if (url.pathname === '/v1/projects/proj_e2e/marketplace' && req.method === 'GET') {
         return Response.json({ installed: [...installed.values()] });
@@ -262,12 +288,15 @@ function startCliE2eServer() {
         }));
         return Response.json({
           updates,
-          update_available: updates.filter((item) => item.status === 'update-available').map((item) => item.name),
+          update_available: updates
+            .filter((item) => item.status === 'update-available')
+            .map((item) => item.name),
         });
       }
       if (url.pathname === '/v1/projects/proj_e2e/marketplace/update' && req.method === 'POST') {
         const body = entry.body as { name?: string } | undefined;
-        if (!body?.name || !installed.has(body.name)) return Response.json({ error: 'not installed' }, { status: 404 });
+        if (!body?.name || !installed.has(body.name))
+          return Response.json({ error: 'not installed' }, { status: 404 });
         updateAvailable = false;
         return Response.json({
           ok: true,
@@ -280,7 +309,8 @@ function startCliE2eServer() {
       const remove = url.pathname.match(/^\/v1\/projects\/proj_e2e\/marketplace\/(.+)$/);
       if (remove && req.method === 'DELETE') {
         const name = decodeURIComponent(remove[1]!);
-        if (!installed.has(name)) return Response.json({ error: `"${name}" is not installed` }, { status: 404 });
+        if (!installed.has(name))
+          return Response.json({ error: `"${name}" is not installed` }, { status: 404 });
         const fileCount = installed.get(name)!.file_count;
         installed.delete(name);
         removed = true;
@@ -331,11 +361,13 @@ describe('kortix CLI black-box behavior', () => {
       marketplaceLabel: 'Kortix',
     });
     expect(result.stderr).toContain('host test');
-    expect(requests).toEqual([{
-      method: 'GET',
-      path: '/v1/marketplace/items?query=pdf&source=kortix',
-      authorization: 'Bearer tok_blackbox',
-    }]);
+    expect(requests).toEqual([
+      {
+        method: 'GET',
+        path: '/v1/marketplace/items?query=pdf&source=kortix',
+        authorization: 'Bearer tok_blackbox',
+      },
+    ]);
   }, 15_000);
 
   test('marketplace install dry-run resolves through the API before reporting output', async () => {
@@ -352,11 +384,13 @@ describe('kortix CLI black-box behavior', () => {
     expect(result.stdout).toContain('PDF');
     expect(result.stdout).toContain('Dry run');
     expect(result.stdout).toContain('proj_1');
-    expect(requests).toEqual([{
-      method: 'GET',
-      path: '/v1/marketplace/items?query=pdf',
-      authorization: 'Bearer tok_blackbox',
-    }]);
+    expect(requests).toEqual([
+      {
+        method: 'GET',
+        path: '/v1/marketplace/items?query=pdf',
+        authorization: 'Bearer tok_blackbox',
+      },
+    ]);
   }, 15_000);
 
   test('top-level help exposes marketplace but hides add and registry commands', async () => {
@@ -603,6 +637,33 @@ console.log(JSON.stringify({ cmd, args, body }));
     expect(result.stdout).toContain('not logged in');
   }, 15_000);
 
+  test('skills --help is dispatched (not unknown command)', async () => {
+    const result = await runCli(['skills', '--help']);
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain('Usage: kortix skills');
+    expect(result.stderr).not.toContain('unknown command');
+  }, 15_000);
+
+  test('skills new scaffolds a spec-valid SKILL.md in a kortix project', async () => {
+    mkdirSync(join(tmp, '.kortix'), { recursive: true });
+    const result = await runCli(
+      ['skills', 'new', 'release-notes', '--description', 'Draft release notes from the git log'],
+      tmp,
+    );
+    expect(result.code).toBe(0);
+    const md = readFileSync(join(tmp, '.kortix/opencode/skills/release-notes/SKILL.md'), 'utf8');
+    expect(md.startsWith('---\n')).toBe(true);
+    expect(md).toContain('name: release-notes');
+    expect(md).toContain('Draft release notes from the git log');
+  }, 15_000);
+
+  test('skills new errors (no scaffold) outside a kortix project', async () => {
+    const result = await runCli(['skills', 'new', 'x', '--description', 'y'], tmp);
+    expect(result.code).toBe(2);
+    expect(result.stderr).toContain('not a Kortix project');
+    expect(existsSync(join(tmp, '.kortix'))).toBe(false);
+  }, 15_000);
+
   test('schema --version 2 prints the v2 JSON Schema, not the CLI version banner', async () => {
     // Regression guard: `main()` used to scan the ENTIRE argv for a bare
     // `--version`/`-v` and print the CLI's own version banner before any
@@ -626,11 +687,9 @@ console.log(JSON.stringify({ cmd, args, body }));
     const apiBase = startMarketplaceServer();
     const configFile = writeConfig(apiBase);
 
-    const result = await runCli(
-      ['add', 'pdf', '--project', 'proj_1', '--dry-run'],
-      tmp,
-      { KORTIX_CONFIG_FILE: configFile },
-    );
+    const result = await runCli(['add', 'pdf', '--project', 'proj_1', '--dry-run'], tmp, {
+      KORTIX_CONFIG_FILE: configFile,
+    });
 
     expect(result.code).toBe(2);
     expect(result.stderr).toContain('unknown command `add`');
@@ -642,9 +701,15 @@ console.log(JSON.stringify({ cmd, args, body }));
 
     expect(result.code).toBe(0);
     const root = join(tmp, 'minimal-project');
-    expect(existsSync(join(root, '.kortix', 'opencode', 'skills', 'kortix-system', 'SKILL.md'))).toBe(true);
-    expect(existsSync(join(root, '.kortix', 'opencode', 'skills', 'kortix-computer', 'SKILL.md'))).toBe(false);
-    expect(existsSync(join(root, '.kortix', 'opencode', 'skills', 'agent-browser', 'SKILL.md'))).toBe(false);
+    expect(
+      existsSync(join(root, '.kortix', 'opencode', 'skills', 'kortix-system', 'SKILL.md')),
+    ).toBe(true);
+    expect(
+      existsSync(join(root, '.kortix', 'opencode', 'skills', 'kortix-computer', 'SKILL.md')),
+    ).toBe(false);
+    expect(
+      existsSync(join(root, '.kortix', 'opencode', 'skills', 'agent-browser', 'SKILL.md')),
+    ).toBe(false);
     expect(existsSync(join(root, '.kortix', 'opencode', 'plugins', 'pty.ts'))).toBe(true);
     expect(existsSync(join(root, '.kortix', 'opencode', 'tools', 'memory.ts'))).toBe(true);
     expect(existsSync(join(root, '.kortix', 'opencode', 'tools', 'web_search.ts'))).toBe(true);
@@ -665,7 +730,9 @@ console.log(JSON.stringify({ cmd, args, body }));
 
     expect(result.code).toBe(0);
     const root = join(tmp, 'gkw-project');
-    expect(existsSync(join(root, '.kortix', 'opencode', 'skills', 'kortix-system', 'SKILL.md'))).toBe(true);
+    expect(
+      existsSync(join(root, '.kortix', 'opencode', 'skills', 'kortix-system', 'SKILL.md')),
+    ).toBe(true);
     expect(existsSync(join(root, '.kortix', 'opencode', 'skills', 'pdf', 'SKILL.md'))).toBe(true);
   });
 
@@ -683,10 +750,25 @@ console.log(JSON.stringify({ cmd, args, body }));
     const root = join(tmp, 'marketplace-project');
     expect(existsSync(join(root, '.kortix', 'opencode', 'tools', 'show.ts'))).toBe(true);
     expect(existsSync(join(root, '.kortix', 'opencode', 'plugins', 'pty.ts'))).toBe(true);
-    expect(existsSync(join(root, '.kortix', 'opencode', 'plugins', 'opencode-pty', 'src', 'plugin', 'constants.ts'))).toBe(true);
+    expect(
+      existsSync(
+        join(
+          root,
+          '.kortix',
+          'opencode',
+          'plugins',
+          'opencode-pty',
+          'src',
+          'plugin',
+          'constants.ts',
+        ),
+      ),
+    ).toBe(true);
     expect(existsSync(join(root, '.kortix', 'opencode', 'tools', 'web_search.ts'))).toBe(true);
     expect(existsSync(join(root, '.kortix', 'opencode', 'tools', 'lib', 'get-env.ts'))).toBe(true);
-    expect(existsSync(join(root, '.kortix', 'opencode', 'skills', 'agent-browser', 'SKILL.md'))).toBe(true);
+    expect(
+      existsSync(join(root, '.kortix', 'opencode', 'skills', 'agent-browser', 'SKILL.md')),
+    ).toBe(true);
 
     const lock = JSON.parse(readFileSync(join(root, 'registry-lock.json'), 'utf8'));
     expect(lock.version).toBe(2);
@@ -702,26 +784,50 @@ console.log(JSON.stringify({ cmd, args, body }));
     const root = join(tmp, 'full-e2e');
     expect(existsSync(join(root, 'kortix.yaml'))).toBe(true);
     expect(existsSync(join(root, '.kortix', 'opencode', 'tools', 'show.ts'))).toBe(true);
-    expect(existsSync(join(root, '.kortix', 'opencode', 'skills', 'kortix-system', 'SKILL.md'))).toBe(true);
-    expect(existsSync(join(root, '.kortix', 'opencode', 'skills', 'agent-browser', 'SKILL.md'))).toBe(false);
+    expect(
+      existsSync(join(root, '.kortix', 'opencode', 'skills', 'kortix-system', 'SKILL.md')),
+    ).toBe(true);
+    expect(
+      existsSync(join(root, '.kortix', 'opencode', 'skills', 'agent-browser', 'SKILL.md')),
+    ).toBe(false);
     expect(existsSync(join(root, '.kortix', 'opencode', 'plugins', 'pty.ts'))).toBe(true);
     expect(existsSync(join(root, '.kortix', 'opencode', 'tools', 'web_search.ts'))).toBe(true);
 
-    const listBeforeLink = await runCli(['projects', 'ls', '--json'], root, { KORTIX_CONFIG_FILE: configFile });
+    const listBeforeLink = await runCli(['projects', 'ls', '--json'], root, {
+      KORTIX_CONFIG_FILE: configFile,
+    });
     expect(listBeforeLink.code).toBe(0);
-    expect(JSON.parse(listBeforeLink.stdout)).toEqual([expect.objectContaining({ project_id: 'proj_e2e', name: 'E2E Project' })]);
+    expect(JSON.parse(listBeforeLink.stdout)).toEqual([
+      expect.objectContaining({ project_id: 'proj_e2e', name: 'E2E Project' }),
+    ]);
 
-    const link = await runCli(['projects', 'link', 'proj_e2e'], root, { KORTIX_CONFIG_FILE: configFile });
+    const link = await runCli(['projects', 'link', 'proj_e2e'], root, {
+      KORTIX_CONFIG_FILE: configFile,
+    });
     expect(link.code).toBe(0);
     expect(link.stdout).toContain('Linked');
     const linked = JSON.parse(readFileSync(join(root, '.kortix', 'link.json'), 'utf8'));
-    expect(linked).toMatchObject({ project_id: 'proj_e2e', account_id: 'account_1', host: 'test', host_url: apiBase });
+    expect(linked).toMatchObject({
+      project_id: 'proj_e2e',
+      account_id: 'account_1',
+      host: 'test',
+      host_url: apiBase,
+    });
 
-    const info = await runCli(['projects', 'info', '--json'], root, { KORTIX_CONFIG_FILE: configFile });
+    const info = await runCli(['projects', 'info', '--json'], root, {
+      KORTIX_CONFIG_FILE: configFile,
+    });
     expect(info.code).toBe(0);
-    expect(JSON.parse(info.stdout)).toMatchObject({ project_id: 'proj_e2e', default_branch: 'main' });
+    expect(JSON.parse(info.stdout)).toMatchObject({
+      project_id: 'proj_e2e',
+      default_branch: 'main',
+    });
 
-    const search = await runCli(['marketplace', 'search', 'agent-browser', '--source', 'kortix', '--json'], root, { KORTIX_CONFIG_FILE: configFile });
+    const search = await runCli(
+      ['marketplace', 'search', 'agent-browser', '--source', 'kortix', '--json'],
+      root,
+      { KORTIX_CONFIG_FILE: configFile },
+    );
     expect(search.code).toBe(0);
     expect(JSON.parse(search.stdout).items).toEqual([
       expect.objectContaining({
@@ -732,16 +838,28 @@ console.log(JSON.stringify({ cmd, args, body }));
       }),
     ]);
 
-    const show = await runCli(['marketplace', 'show', 'agent-browser', '--json'], root, { KORTIX_CONFIG_FILE: configFile });
+    const show = await runCli(['marketplace', 'show', 'agent-browser', '--json'], root, {
+      KORTIX_CONFIG_FILE: configFile,
+    });
     expect(show.code).toBe(0);
-    expect(JSON.parse(show.stdout)).toMatchObject({ id: 'kortix-starter:agent-browser', name: 'agent-browser', type: 'registry:skill' });
+    expect(JSON.parse(show.stdout)).toMatchObject({
+      id: 'kortix-starter:agent-browser',
+      name: 'agent-browser',
+      type: 'registry:skill',
+    });
 
-    const dryInstall = await runCli(['marketplace', 'install', 'agent-browser', '--dry-run'], root, { KORTIX_CONFIG_FILE: configFile });
+    const dryInstall = await runCli(
+      ['marketplace', 'install', 'agent-browser', '--dry-run'],
+      root,
+      { KORTIX_CONFIG_FILE: configFile },
+    );
     expect(dryInstall.code).toBe(0);
     expect(dryInstall.stdout).toContain('Dry run');
     expect(dryInstall.stdout).toContain('proj_e2e');
 
-    const install = await runCli(['marketplace', 'install', 'agent-browser', '--json'], root, { KORTIX_CONFIG_FILE: configFile });
+    const install = await runCli(['marketplace', 'install', 'agent-browser', '--json'], root, {
+      KORTIX_CONFIG_FILE: configFile,
+    });
     expect(install.code).toBe(0);
     expect(JSON.parse(install.stdout)).toMatchObject({
       ok: true,
@@ -750,29 +868,54 @@ console.log(JSON.stringify({ cmd, args, body }));
       installed: [{ name: 'agent-browser', type: 'registry:skill' }],
     });
 
-    const status = await runCli(['marketplace', 'status', '--json'], root, { KORTIX_CONFIG_FILE: configFile });
+    const status = await runCli(['marketplace', 'status', '--json'], root, {
+      KORTIX_CONFIG_FILE: configFile,
+    });
     expect(status.code).toBe(0);
     expect(JSON.parse(status.stdout).installed).toEqual([
-      expect.objectContaining({ name: 'agent-browser', type: 'registry:skill', source: 'kortix-starter:agent-browser', file_count: 1 }),
+      expect.objectContaining({
+        name: 'agent-browser',
+        type: 'registry:skill',
+        source: 'kortix-starter:agent-browser',
+        file_count: 1,
+      }),
     ]);
 
-    const updates = await runCli(['marketplace', 'updates', '--json'], root, { KORTIX_CONFIG_FILE: configFile });
+    const updates = await runCli(['marketplace', 'updates', '--json'], root, {
+      KORTIX_CONFIG_FILE: configFile,
+    });
     expect(updates.code).toBe(0);
     expect(JSON.parse(updates.stdout)).toMatchObject({ update_available: ['agent-browser'] });
 
-    const update = await runCli(['marketplace', 'update', 'agent-browser', '--json'], root, { KORTIX_CONFIG_FILE: configFile });
+    const update = await runCli(['marketplace', 'update', 'agent-browser', '--json'], root, {
+      KORTIX_CONFIG_FILE: configFile,
+    });
     expect(update.code).toBe(0);
-    expect(JSON.parse(update.stdout)).toMatchObject({ ok: true, updated: 'agent-browser', commit_sha: 'commit_update_agent-browser' });
+    expect(JSON.parse(update.stdout)).toMatchObject({
+      ok: true,
+      updated: 'agent-browser',
+      commit_sha: 'commit_update_agent-browser',
+    });
 
-    const updatesAfter = await runCli(['marketplace', 'updates', '--json'], root, { KORTIX_CONFIG_FILE: configFile });
+    const updatesAfter = await runCli(['marketplace', 'updates', '--json'], root, {
+      KORTIX_CONFIG_FILE: configFile,
+    });
     expect(updatesAfter.code).toBe(0);
     expect(JSON.parse(updatesAfter.stdout)).toMatchObject({ update_available: [] });
 
-    const remove = await runCli(['marketplace', 'remove', 'agent-browser', '--json'], root, { KORTIX_CONFIG_FILE: configFile });
+    const remove = await runCli(['marketplace', 'remove', 'agent-browser', '--json'], root, {
+      KORTIX_CONFIG_FILE: configFile,
+    });
     expect(remove.code).toBe(0);
-    expect(JSON.parse(remove.stdout)).toMatchObject({ ok: true, removed: 'agent-browser', commit_sha: 'commit_remove_agent-browser' });
+    expect(JSON.parse(remove.stdout)).toMatchObject({
+      ok: true,
+      removed: 'agent-browser',
+      commit_sha: 'commit_remove_agent-browser',
+    });
 
-    const statusAfterRemove = await runCli(['marketplace', 'status', '--json'], root, { KORTIX_CONFIG_FILE: configFile });
+    const statusAfterRemove = await runCli(['marketplace', 'status', '--json'], root, {
+      KORTIX_CONFIG_FILE: configFile,
+    });
     expect(statusAfterRemove.code).toBe(0);
     expect(JSON.parse(statusAfterRemove.stdout).installed).toEqual([]);
 
@@ -780,11 +923,15 @@ console.log(JSON.stringify({ cmd, args, body }));
     expect(unlink.code).toBe(0);
     expect(existsSync(join(root, '.kortix', 'link.json'))).toBe(false);
 
-    const relink = await runCli(['projects', 'link', 'proj_e2e'], root, { KORTIX_CONFIG_FILE: configFile });
+    const relink = await runCli(['projects', 'link', 'proj_e2e'], root, {
+      KORTIX_CONFIG_FILE: configFile,
+    });
     expect(relink.code).toBe(0);
     expect(existsSync(join(root, '.kortix', 'link.json'))).toBe(true);
 
-    const removeProject = await runCli(['projects', 'rm', 'proj_e2e', '--purge', '--yes'], root, { KORTIX_CONFIG_FILE: configFile });
+    const removeProject = await runCli(['projects', 'rm', 'proj_e2e', '--purge', '--yes'], root, {
+      KORTIX_CONFIG_FILE: configFile,
+    });
     expect(removeProject.code).toBe(0);
     expect(removeProject.stdout).toContain('Archived');
     expect(existsSync(join(root, '.kortix', 'link.json'))).toBe(false);
@@ -816,14 +963,18 @@ console.log(JSON.stringify({ cmd, args, body }));
     const apiBase = startCliE2eServer();
     const configFile = writeConfig(apiBase);
 
-    const noAuth = await runCli(['marketplace', 'search', 'pty', '--json'], tmp, { KORTIX_CONFIG_FILE: join(tmp, 'missing-config.json') });
+    const noAuth = await runCli(['marketplace', 'search', 'pty', '--json'], tmp, {
+      KORTIX_CONFIG_FILE: join(tmp, 'missing-config.json'),
+    });
     expect(noAuth.code).toBe(1);
     expect(noAuth.stderr).toContain('Not logged in');
 
     // No project bound + logged in + exactly one project in the account →
     // the always-bound invariant auto-binds it and the command proceeds
     // instead of dead-ending with "No project linked".
-    const noLink = await runCli(['marketplace', 'status', '--json'], tmp, { KORTIX_CONFIG_FILE: configFile });
+    const noLink = await runCli(['marketplace', 'status', '--json'], tmp, {
+      KORTIX_CONFIG_FILE: configFile,
+    });
     expect(noLink.code).toBe(0);
     expect(noLink.stderr).toContain('Default project:');
     const boundConfig = JSON.parse(readFileSync(configFile, 'utf8'));
@@ -835,23 +986,37 @@ console.log(JSON.stringify({ cmd, args, body }));
     expect(init.code).toBe(0);
     const root = join(tmp, 'edge-e2e');
 
-    const missingProject = await runCli(['projects', 'link', 'missing'], root, { KORTIX_CONFIG_FILE: configFile });
+    const missingProject = await runCli(['projects', 'link', 'missing'], root, {
+      KORTIX_CONFIG_FILE: configFile,
+    });
     expect(missingProject.code).toBe(1);
     expect(missingProject.stderr).toContain('Not found');
 
-    const unknownShow = await runCli(['marketplace', 'show', 'does-not-exist'], root, { KORTIX_CONFIG_FILE: configFile });
+    const unknownShow = await runCli(['marketplace', 'show', 'does-not-exist'], root, {
+      KORTIX_CONFIG_FILE: configFile,
+    });
     expect(unknownShow.code).toBe(1);
     expect(unknownShow.stderr).toContain('No marketplace item matches');
 
-    const unknownInstall = await runCli(['marketplace', 'install', 'does-not-exist', '--project', 'proj_e2e'], root, { KORTIX_CONFIG_FILE: configFile });
+    const unknownInstall = await runCli(
+      ['marketplace', 'install', 'does-not-exist', '--project', 'proj_e2e'],
+      root,
+      { KORTIX_CONFIG_FILE: configFile },
+    );
     expect(unknownInstall.code).toBe(1);
     expect(unknownInstall.stderr).toContain('No marketplace item matches');
 
-    const removeMissing = await runCli(['marketplace', 'remove', 'pty', '--project', 'proj_e2e', '--json'], root, { KORTIX_CONFIG_FILE: configFile });
+    const removeMissing = await runCli(
+      ['marketplace', 'remove', 'pty', '--project', 'proj_e2e', '--json'],
+      root,
+      { KORTIX_CONFIG_FILE: configFile },
+    );
     expect(removeMissing.code).toBe(1);
     expect(removeMissing.stderr).toContain('not installed');
 
-    const add = await runCli(['add', 'pty', '--project', 'proj_e2e'], root, { KORTIX_CONFIG_FILE: configFile });
+    const add = await runCli(['add', 'pty', '--project', 'proj_e2e'], root, {
+      KORTIX_CONFIG_FILE: configFile,
+    });
     expect(add.code).toBe(2);
     expect(add.stderr).toContain('unknown command `add`');
 

--- a/apps/cli/src/__tests__/skill-scaffold.test.ts
+++ b/apps/cli/src/__tests__/skill-scaffold.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { applySkillScaffold, renderSkillMd, validateSkillName } from '../skill-scaffold';
+
+let dir: string;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'kortix-skill-'));
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe('validateSkillName', () => {
+  test('accepts agentskills.io-valid names', () => {
+    expect(validateSkillName('release-notes')).toBeUndefined();
+    expect(validateSkillName('pdf')).toBeUndefined();
+    expect(validateSkillName('invoice-parse-2')).toBeUndefined();
+  });
+  test('rejects invalid names', () => {
+    expect(validateSkillName('My_Skill')).toBeDefined();
+    expect(validateSkillName('-draft')).toBeDefined();
+    expect(validateSkillName('pdf--merge')).toBeDefined();
+    expect(validateSkillName('trailing-')).toBeDefined();
+    expect(validateSkillName('UPPER')).toBeDefined();
+  });
+});
+
+describe('renderSkillMd', () => {
+  test('starts with frontmatter at byte 1 and includes name + description', () => {
+    const md = renderSkillMd('invoice-parse', 'Parse invoices into JSON');
+    expect(md.startsWith('---\n')).toBe(true);
+    expect(md).toContain('name: invoice-parse');
+    expect(md).toContain('description: "Parse invoices into JSON"');
+    expect(md).not.toContain('license:');
+  });
+  test('adds a license line when provided', () => {
+    expect(renderSkillMd('x', 'y', 'MIT')).toContain('license: "MIT"');
+  });
+});
+
+describe('applySkillScaffold', () => {
+  test('writes a spec-valid SKILL.md at the canonical path', () => {
+    const r = applySkillScaffold({
+      repoRoot: dir,
+      name: 'invoice-parse',
+      description: 'Parse invoices',
+    });
+    expect(r.path).toBe('.kortix/opencode/skills/invoice-parse/SKILL.md');
+    const content = readFileSync(join(dir, r.path), 'utf8');
+    expect(content.startsWith('---\n')).toBe(true);
+    expect(content).toContain('name: invoice-parse');
+  });
+
+  test('throws on an invalid name', () => {
+    expect(() =>
+      applySkillScaffold({ repoRoot: dir, name: 'Bad Name', description: 'd' }),
+    ).toThrow();
+  });
+
+  test('refuses to overwrite unless force is set', () => {
+    applySkillScaffold({ repoRoot: dir, name: 'x', description: 'd' });
+    expect(() => applySkillScaffold({ repoRoot: dir, name: 'x', description: 'd2' })).toThrow();
+    const r = applySkillScaffold({ repoRoot: dir, name: 'x', description: 'd2', force: true });
+    expect(readFileSync(join(dir, r.path), 'utf8')).toContain('description: "d2"');
+  });
+});

--- a/apps/cli/src/commands/skills.ts
+++ b/apps/cli/src/commands/skills.ts
@@ -1,0 +1,89 @@
+import { takeFlagBool, takeFlagValue } from '../command-helpers.ts';
+import { isKortixProject } from '../project-link.ts';
+import { applySkillScaffold, validateSkillName } from '../skill-scaffold.ts';
+import { C, help, status } from '../style.ts';
+
+const HELP = help`Usage: kortix skills <subcommand> [options]
+
+Author and manage the skills in this project's .kortix/opencode/skills/.
+
+Subcommands:
+  new <name>   Scaffold a new, spec-valid SKILL.md skeleton.
+
+Options (new):
+  -d, --description <text>   What the skill does + when to load it (required —
+                             this is the trigger the agent matches on).
+  --license <spdx>           Optional SPDX license id for the frontmatter.
+  --force                    Overwrite an existing skill of the same name.
+  -h, --help                 Show this help.
+
+After scaffolding, fill in the body and open a change request:
+  git add .kortix/opencode/skills/<name> && git commit -m "add <name> skill"
+  git push origin HEAD && kortix cr open --title "Add <name> skill"
+`;
+
+export async function runSkills(argv: string[]): Promise<number> {
+  if (argv.length === 0 || argv[0] === '-h' || argv[0] === '--help') {
+    process.stdout.write(HELP);
+    return 0;
+  }
+  const sub = argv[0];
+  if (sub === 'new') {
+    return runSkillsNew(argv.slice(1));
+  }
+  process.stderr.write(`${status.err(`unknown skills subcommand "${sub}"`)}\n\n${HELP}`);
+  return 2;
+}
+
+function runSkillsNew(argv: string[]): number {
+  const rest = [...argv];
+  if (takeFlagBool(rest, ['-h', '--help'])) {
+    process.stdout.write(HELP);
+    return 0;
+  }
+  const force = takeFlagBool(rest, ['--force']);
+  const description = takeFlagValue(rest, ['-d', '--description']);
+  const license = takeFlagValue(rest, ['--license']);
+  const name = rest.shift();
+
+  if (rest.length > 0) {
+    process.stderr.write(`${status.err(`unexpected argument "${rest[0]}"`)}\n\n${HELP}`);
+    return 2;
+  }
+  if (!name) {
+    process.stderr.write(`${status.err('skills new requires a <name>.')}\n\n${HELP}`);
+    return 2;
+  }
+  const nameErr = validateSkillName(name);
+  if (nameErr) {
+    process.stderr.write(`${status.err(nameErr)}\n`);
+    return 2;
+  }
+  if (!description) {
+    process.stderr.write(
+      `${status.err('skills new requires --description "<text>" — it is the trigger the agent uses to decide when to load the skill.')}\n`,
+    );
+    return 2;
+  }
+  if (!isKortixProject()) {
+    process.stderr.write(
+      `${status.err('not a Kortix project here (no .kortix/ or kortix.yaml). Run from a project root, or `kortix init` first.')}\n`,
+    );
+    return 2;
+  }
+
+  let result: { path: string };
+  try {
+    result = applySkillScaffold({ repoRoot: process.cwd(), name, description, license, force });
+  } catch (err) {
+    process.stderr.write(`${status.err((err as Error).message)}\n`);
+    return 1;
+  }
+
+  process.stdout.write(`\n${status.ok(`Wrote ${result.path}`)}\n`);
+  process.stdout.write(
+    `  ${C.dim}Fill in the body, then commit + open a change request:${C.reset}\n`,
+  );
+  process.stdout.write(`  ${C.cyan}kortix cr open --title "Add ${name} skill"${C.reset}\n\n`);
+  return 0;
+}

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -30,6 +30,7 @@ import { runSelfHost } from './commands/self-host.ts';
 import { runSessionsChat } from './commands/sessions-chat.ts';
 import { runSessions } from './commands/sessions.ts';
 import { runShip } from './commands/ship.ts';
+import { runSkills } from './commands/skills.ts';
 import { runTriggers } from './commands/triggers.ts';
 import { runUninstall } from './commands/uninstall.ts';
 import { runUpdate } from './commands/update.ts';
@@ -127,6 +128,11 @@ const TIERS: readonly CommandTier[] = [
             args: '[--version 1|2]',
             blurb: 'Print the canonical kortix.yaml/kortix.toml JSON Schema',
           },
+          {
+            name: 'skills',
+            args: '<subcommand>',
+            blurb: 'Author project skills (`skills new` scaffolds a SKILL.md)',
+          },
         ],
       },
       {
@@ -138,8 +144,16 @@ const TIERS: readonly CommandTier[] = [
             args: '<subcommand>',
             blurb: 'Manage integrations agents call as tools (Pipedream/MCP/HTTP)',
           },
-          { name: 'secrets', args: '<subcommand>', blurb: 'Manage project secrets (project-scoped)' },
-          { name: 'env', args: '<subcommand>', blurb: 'Pull/push project secrets as a dotenv file' },
+          {
+            name: 'secrets',
+            args: '<subcommand>',
+            blurb: 'Manage project secrets (project-scoped)',
+          },
+          {
+            name: 'env',
+            args: '<subcommand>',
+            blurb: 'Pull/push project secrets as a dotenv file',
+          },
           {
             name: 'providers',
             args: '<subcommand>',
@@ -166,14 +180,24 @@ const TIERS: readonly CommandTier[] = [
             blurb: 'Call connectors as tools (discover/describe/call) + run the MCP server',
           },
           ...(appsExperimentalEnabled()
-            ? [{ name: 'apps', args: '<subcommand>', blurb: 'Manage deployable apps (experimental)' }]
+            ? [
+                {
+                  name: 'apps',
+                  args: '<subcommand>',
+                  blurb: 'Manage deployable apps (experimental)',
+                },
+              ]
             : []),
         ],
       },
       {
         title: 'Sessions & work',
         commands: [
-          { name: 'sessions', args: '<subcommand>', blurb: 'List, create, restart project sessions' },
+          {
+            name: 'sessions',
+            args: '<subcommand>',
+            blurb: 'List, create, restart project sessions',
+          },
           {
             name: 'chat',
             args: '[session-id]',
@@ -184,7 +208,11 @@ const TIERS: readonly CommandTier[] = [
             args: '<subcommand>',
             blurb: 'Share a port inside a session sandbox via a public URL',
           },
-          { name: 'files', args: '<subcommand>', blurb: 'Browse repo files, commits, branches, diffs' },
+          {
+            name: 'files',
+            args: '<subcommand>',
+            blurb: 'Browse repo files, commits, branches, diffs',
+          },
           { name: 'cr', args: '<subcommand>', blurb: 'Open, review, merge change requests' },
           { name: 'triggers', args: '<subcommand>', blurb: 'List, fire, enable/disable triggers' },
         ],
@@ -205,7 +233,8 @@ const TIERS: readonly CommandTier[] = [
           {
             name: 'grants',
             args: '<subcommand>',
-            blurb: "Assign agents to members or groups (they inherit the agent's skills/connectors/secrets)",
+            blurb:
+              "Assign agents to members or groups (they inherit the agent's skills/connectors/secrets)",
           },
         ],
       },
@@ -326,6 +355,9 @@ async function main(argv: string[]): Promise<number> {
   if (argv[0] === 'schema') {
     return runSchema(argv.slice(1));
   }
+  if (argv[0] === 'skills') {
+    return runSkills(argv.slice(1));
+  }
   if (argv[0] === 'login') {
     return runLogin(argv.slice(1));
   }
@@ -445,6 +477,7 @@ const KNOWN_COMMANDS = [
   'deploy',
   'validate',
   'schema',
+  'skills',
   'self-host',
   'login',
   'logout',
@@ -506,7 +539,11 @@ function closestCommand(input: string): string | undefined {
     const distance = editDistance(needle, name);
     // The distance cap alone lets tiny inputs match anything short ("us" →
     // "cr"), so also require most of the input to survive the edit.
-    if (distance <= 2 && distance < needle.length && (best === undefined || distance < best.distance)) {
+    if (
+      distance <= 2 &&
+      distance < needle.length &&
+      (best === undefined || distance < best.distance)
+    ) {
       best = { name, distance };
     }
   }

--- a/apps/cli/src/skill-scaffold.ts
+++ b/apps/cli/src/skill-scaffold.ts
@@ -1,0 +1,82 @@
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+// The agentskills.io skill-name rule (see the create-skill skill): lowercase
+// letters/digits in single-hyphen-separated groups, no leading/trailing/double
+// hyphen. The skill's directory name MUST equal this frontmatter `name`.
+const NAME_RE = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+
+export interface SkillScaffoldInput {
+  /** Project root — the dir containing `.kortix/`. */
+  repoRoot: string;
+  name: string;
+  description: string;
+  license?: string;
+  /** Overwrite an existing SKILL.md instead of refusing. */
+  force?: boolean;
+}
+
+export interface SkillScaffoldResult {
+  /** Repo-relative path to the written SKILL.md. */
+  path: string;
+  written: boolean;
+}
+
+export function validateSkillName(name: string): string | undefined {
+  if (!NAME_RE.test(name)) {
+    return `"${name}" is not a valid skill name — use lowercase letters, digits, and single hyphens (e.g. invoice-parse), no leading, trailing, or doubled hyphens.`;
+  }
+  return undefined;
+}
+
+function titleCase(name: string): string {
+  return name
+    .split('-')
+    .map((w) => (w ? w[0].toUpperCase() + w.slice(1) : w))
+    .join(' ');
+}
+
+/** Render a spec-valid SKILL.md skeleton. The file MUST start with `---` at
+ *  byte 1 (no leading blank line or comment) or the skill loader rejects it. */
+export function renderSkillMd(name: string, description: string, license?: string): string {
+  const licenseLine = license ? `\nlicense: ${JSON.stringify(license)}` : '';
+  return `---
+name: ${name}
+description: ${JSON.stringify(description)}${licenseLine}
+---
+
+# ${titleCase(name)}
+
+## When to use this skill
+Describe, concretely, the situations where an agent should load this skill —
+the phrases a user would actually type, and the signals that this is the right
+tool. A vague description here means the skill never gets triggered.
+
+## Instructions
+1. <the first concrete step>
+
+## Examples
+Input: <a representative request>
+Output: <what a good result looks like>
+`;
+}
+
+export function applySkillScaffold(input: SkillScaffoldInput): SkillScaffoldResult {
+  const nameErr = validateSkillName(input.name);
+  if (nameErr) throw new Error(nameErr);
+
+  const relDir = `.kortix/opencode/skills/${input.name}`;
+  const relPath = `${relDir}/SKILL.md`;
+  const absDir = join(input.repoRoot, relDir);
+  const absPath = join(absDir, 'SKILL.md');
+
+  if (existsSync(absPath) && !input.force) {
+    throw new Error(
+      `${relPath} already exists — pass --force to overwrite, or pick a different name.`,
+    );
+  }
+
+  mkdirSync(absDir, { recursive: true });
+  writeFileSync(absPath, renderSkillMd(input.name, input.description, input.license), 'utf8');
+  return { path: relPath, written: true };
+}


### PR DESCRIPTION
> **Stacked on #4380** (base branch `cli-surface`). Review/merge #4380 first; this retargets to `main` once that lands.

## Summary

Adds `kortix skills new <name> --description "<text>"` — it scaffolds a spec-correct `SKILL.md` skeleton into `.kortix/opencode/skills/<name>/`. This is the first, offline slice of the self-improving loop: authoring a skill locally, then landing it through a change request.

## Behavior

```
kortix skills new release-notes --description "Draft release notes from the git log"
  ✓  Wrote .kortix/opencode/skills/release-notes/SKILL.md
     Fill in the body, then commit + open a change request:
     kortix cr open --title "Add release-notes skill"
```

- Validates the name against the agentskills.io rule (`^[a-z0-9]+(-[a-z0-9]+)*$`; the directory name must equal the frontmatter `name`).
- Writes a spec-valid skeleton: frontmatter at byte 1, `name` + quoted `description`, optional `--license`, and `When to use / Instructions / Examples` sections.
- Refuses to overwrite an existing skill unless `--force`.
- Errors clearly outside a Kortix project (no `.kortix/`), and never scaffolds there.

## Design

- `apps/cli/src/skill-scaffold.ts` — pure `validateSkillName` / `renderSkillMd` / `applySkillScaffold` (no CLI/process coupling, so it unit-tests directly).
- `apps/cli/src/commands/skills.ts` — the `skills` command (`new` subcommand today; room for `ls`/`validate` later).
- Registered in the dispatcher, help ("Author & ship" tier), and known-commands.

## Tests

- `apps/cli/src/__tests__/skill-scaffold.test.ts` — pure unit tests (valid/invalid names, frontmatter-at-byte-1, license line, no-overwrite-without-force).
- `apps/cli/src/__tests__/cli-blackbox.test.ts` — command dispatch + help, a happy-path scaffold in a temp project, and the "not a Kortix project" error path.
- Full CLI suite: 209 pass / 0 fail. Typecheck passes; new files are biome-clean.

## Follow-ups (next PRs in the loop)

- An **agent-facing tool** (same shape as the ported `memory` tool) so an agent can author a skill mid-session and auto-open a `skill:` change request — the full self-improving loop (needs the sandbox runtime, so it comes after this offline slice).
- A **curator** to prune/consolidate agent-authored skills, with snapshot + rollback.
