### PR TITLE
feat(slack): slack bind-thread — bind current session to a Slack thread

### DIFF
--- a/apps/api/src/channels/slack/binding.ts
+++ b/apps/api/src/channels/slack/binding.ts
@@ -1,0 +1,55 @@
+import { and, eq } from 'drizzle-orm';
+import { chatChannelBindings, chatThreads } from '@kortix/db';
+import { db } from '../../shared/db';
+
+/**
+ * Bind a Slack thread to a session so later replies in that thread route back into
+ * the session (the platform's `follow_up` path keys off a `chat_threads` row via
+ * `threadIsOwned`). This is the exact write the inbound `bind_chat_thread`
+ * post-create action performs — factored out here so a run that created a thread
+ * out of band (e.g. a webhook/cron trigger posting an approval request) can register
+ * its own thread on demand via `slack bind-thread`.
+ */
+export async function bindChatThread(input: {
+  projectId: string;
+  workspaceId: string;
+  threadId: string;
+  sessionId: string;
+  platform?: string;
+}): Promise<void> {
+  await db
+    .insert(chatThreads)
+    .values({
+      projectId: input.projectId,
+      platform: input.platform ?? 'slack',
+      workspaceId: input.workspaceId,
+      threadId: input.threadId,
+      sessionId: input.sessionId,
+    })
+    .onConflictDoNothing({
+      target: [chatThreads.platform, chatThreads.workspaceId, chatThreads.threadId],
+    });
+}
+
+/**
+ * Resolve the Slack workspace/team id for a channel from its project binding
+ * (`chat_channel_bindings`). Returns null when the channel isn't bound to the
+ * project yet.
+ */
+export async function resolveWorkspaceIdForChannel(
+  projectId: string,
+  channelId: string,
+): Promise<string | null> {
+  const [row] = await db
+    .select({ workspaceId: chatChannelBindings.workspaceId })
+    .from(chatChannelBindings)
+    .where(
+      and(
+        eq(chatChannelBindings.platform, 'slack'),
+        eq(chatChannelBindings.projectId, projectId),
+        eq(chatChannelBindings.channelId, channelId),
+      ),
+    )
+    .limit(1);
+  return row?.workspaceId ?? null;
+}

--- a/apps/api/src/projects/routes/r4.ts
+++ b/apps/api/src/projects/routes/r4.ts
@@ -75,6 +75,10 @@ import {
 } from "@kortix/db";
 import { and, eq, inArray } from "drizzle-orm";
 import { loadProjectForUser, assertProjectCapability } from "../lib/access";
+import {
+  bindChatThread,
+  resolveWorkspaceIdForChannel,
+} from "../../channels/slack/binding";
 import { AnyObject, AppSchema, TriggerSchema, projectsApp } from "../lib/app";
 import {
   APPS_DISABLED_BODY,
@@ -1236,6 +1240,116 @@ projectsApp.openapi(
     if (!result.ok)
       return c.json({ error: result.error }, result.status as 400 | 404);
     return c.json({ ok: true, files: result.files });
+  },
+);
+
+// POST /v1/projects/:projectId/channels/slack/bind-thread
+// Bind a Slack thread the agent created (e.g. from a webhook/cron run) to its
+// session, so a later human reply in that thread routes back into this session
+// (approval loops, follow-up Q&A). This writes the same `chat_threads` row the
+// inbound `bind_chat_thread` post-create action does; without it, replies to a
+// non-Slack-originated thread are classified `ignore` and dropped.
+projectsApp.openapi(
+  createRoute({
+    method: "post",
+    path: "/{projectId}/channels/slack/bind-thread",
+    tags: ["channels"],
+    summary: "POST /:projectId/channels/slack/bind-thread",
+    ...auth,
+    request: {
+      params: z.object({ projectId: z.string() }),
+      body: { content: { "application/json": { schema: AnyObject } } },
+    },
+    responses: {
+      200: json(
+        z.object({ ok: z.boolean(), bound: z.boolean() }).passthrough(),
+        "Bound",
+      ),
+      ...errors(400, 403, 404),
+    },
+  }),
+  async (c: any) => {
+    const projectId = c.req.param("projectId");
+    // Same dual auth as turn-stream: the in-sandbox agent's sandbox token (scoped
+    // back to this project) or a project/session-scoped user PAT.
+    const authType = (c as any).get("authType") as string | undefined;
+    if (authType === "apiKey" && (c as any).get("apiKeyType") === "sandbox") {
+      const accountId = (c as any).get("accountId") as string | undefined;
+      const sandboxId = (c as any).get("sandboxId") as string | undefined;
+      if (!accountId || !sandboxId) {
+        return c.json({ error: "bind-thread requires a sandbox token" }, 403);
+      }
+      const [sandbox] = await db
+        .select({ sandboxId: sessionSandboxes.sandboxId })
+        .from(sessionSandboxes)
+        .where(
+          and(
+            eq(sessionSandboxes.sandboxId, sandboxId),
+            eq(sessionSandboxes.projectId, projectId),
+            eq(sessionSandboxes.accountId, accountId),
+            inArray(sessionSandboxes.status, ["provisioning", "active"]),
+          ),
+        )
+        .limit(1);
+      if (!sandbox) {
+        return c.json(
+          { error: "sandbox token is not scoped to this project" },
+          403,
+        );
+      }
+    } else {
+      const loaded = await loadProjectForUser(c, projectId, "read");
+      if (!loaded) return c.json({ error: "Not found" }, 404);
+    }
+
+    let body: {
+      session_id?: string;
+      channel?: string;
+      thread_ts?: string;
+      workspace_id?: string;
+    };
+    try {
+      body = (await c.req.json()) as typeof body;
+    } catch {
+      return c.json({ error: "Invalid JSON body" }, 400);
+    }
+    const sessionId = body.session_id?.trim();
+    const channel = body.channel?.trim();
+    const threadTs = body.thread_ts?.trim();
+    if (!sessionId || !channel || !threadTs) {
+      return c.json(
+        { error: "session_id, channel, and thread_ts are required" },
+        400,
+      );
+    }
+    // the session must belong to this project
+    const [sess] = await db
+      .select({ sessionId: projectSessions.sessionId })
+      .from(projectSessions)
+      .where(
+        and(
+          eq(projectSessions.sessionId, sessionId),
+          eq(projectSessions.projectId, projectId),
+        ),
+      )
+      .limit(1);
+    if (!sess) {
+      return c.json({ error: "session not found in project" }, 404);
+    }
+    const workspaceId =
+      body.workspace_id?.trim() ||
+      (await resolveWorkspaceIdForChannel(projectId, channel));
+    if (!workspaceId) {
+      return c.json(
+        {
+          error:
+            "could not resolve Slack workspace for channel (is the channel bound to this project?)",
+        },
+        400,
+      );
+    }
+    await bindChatThread({ projectId, workspaceId, threadId: threadTs, sessionId });
+    return c.json({ ok: true, bound: true, channel, thread_ts: threadTs });
   },
 );
 

--- a/apps/api/src/projects/session-lifecycle/engine.ts
+++ b/apps/api/src/projects/session-lifecycle/engine.ts
@@ -1,5 +1,6 @@
 import { eq } from 'drizzle-orm';
-import { chatThreads, executorExecutions, projects, projectSessions } from '@kortix/db';
+import { executorExecutions, projects, projectSessions } from '@kortix/db';
+import { bindChatThread } from '../../channels/slack/binding';
 import { config } from '../../config';
 import { forwardToSandbox } from '../../sandbox-proxy/routes/preview';
 import { db } from '../../shared/db';
@@ -523,18 +524,13 @@ async function applyPostCreateActions(input: {
   try {
     for (const action of input.actions) {
       if (action.type === 'bind_chat_thread') {
-        await db
-          .insert(chatThreads)
-          .values({
-            projectId: input.projectId,
-            platform: action.platform,
-            workspaceId: action.workspaceId,
-            threadId: action.threadId,
-            sessionId: input.sessionId,
-          })
-          .onConflictDoNothing({
-            target: [chatThreads.platform, chatThreads.workspaceId, chatThreads.threadId],
-          });
+        await bindChatThread({
+          projectId: input.projectId,
+          platform: action.platform,
+          workspaceId: action.workspaceId,
+          threadId: action.threadId,
+          sessionId: input.sessionId,
+        });
       } else if (action.type === 'deliver_prompt') {
         const outcome = await continueSession({
           source: action.source,

--- a/apps/sandbox/slack-cli/channels/slack.ts
+++ b/apps/sandbox/slack-cli/channels/slack.ts
@@ -525,6 +525,30 @@ async function main(): Promise<void> {
         await thread({ ...requiredFlags(flags, 'channel', 'ts'), limit: optionalInt(flags.limit) }),
       );
       break;
+    case 'bind-thread': {
+      // Bind THIS session to a Slack thread so later replies route back to it —
+      // e.g. after a webhook run posts an approval request, a human's "APPROVE"
+      // reply resumes this session. Defaults to the Slack-turn env when present.
+      const channel = flags.channel ?? getEnv('SLACK_CHANNEL_ID');
+      const threadTs = flags.thread ?? getEnv('SLACK_THREAD_TS');
+      const sessionId = kortixSessionId();
+      const projectId = kortixProjectId();
+      if (!channel || !threadTs) {
+        throw new CliError(
+          'bind-thread needs --channel and --thread (defaults to $SLACK_CHANNEL_ID/$SLACK_THREAD_TS on Slack turns)',
+        );
+      }
+      if (!sessionId) throw new CliError('KORTIX_SESSION_ID not set — cannot bind this session.');
+      if (!projectId) throw new CliError('KORTIX_PROJECT_ID not set — cannot bind.');
+      out(
+        await kortixPost(`/projects/${projectId}/channels/slack/bind-thread`, {
+          session_id: sessionId,
+          channel,
+          thread_ts: threadTs,
+        }),
+      );
+      break;
+    }
     case 'channels':
       out(await listChannels({ limit: optionalInt(flags.limit) }));
       break;
@@ -583,6 +607,7 @@ Commands:
   typing       (--channel)               # no-op on Slack Web API
   history      (--channel, [--limit])
   thread       (--channel, --ts, [--limit])
+  bind-thread  (--channel, --thread)     # route later replies in this thread back to this session
   channels     ([--limit])
   channel-info (--channel)
   join         (--channel)


### PR DESCRIPTION
## What

Adds a general `slack bind-thread` capability: an agent can bind its **current session** to a Slack thread so later human replies in that thread route back into the session.

## Why

The inbound `follow_up` path already routes a thread reply into its session **iff** a `chat_threads` row exists (`threadIsOwned`). That row is only written when an inbound Slack event spawns a session. So threads created **out of band** — e.g. a webhook/cron run that posts an approval request via `slack send` — are **not** bound, and replies ("APPROVE") are classified `ignore` and dropped.

## How

- `apps/api/src/channels/slack/binding.ts` (new): `bindChatThread()` (factored out of the `bind_chat_thread` post-create action) + `resolveWorkspaceIdForChannel()`.
- `engine.ts`: the `bind_chat_thread` post-create action now calls the shared helper (behavior-preserving).
- New route `POST /projects/:id/channels/slack/bind-thread` — same dual auth as `turn-stream` (in-sandbox token scoped to project, or user PAT); verifies the session belongs to the project; resolves the workspace from the channel binding; writes `chat_threads`.
- New sandbox CLI subcommand `slack bind-thread --channel --thread` (defaults to `$SLACK_CHANNEL_ID`/`$SLACK_THREAD_TS`).

No new table; reuses `chat_threads` + the existing follow-up delivery. Additive/backward-compatible.

## Test

`tsc --noEmit` clean in `apps/api` and `apps/sandbox` (0 errors).