### PR TITLE
fix(slack): recover from a deleted channel agent + honest session-start errors

### DIFF
--- a/apps/api/src/__tests__/unit-slack-error-classify.test.ts
+++ b/apps/api/src/__tests__/unit-slack-error-classify.test.ts
@@ -118,6 +118,25 @@ describe('classifyTurnError', () => {
     expect(r.text.toLowerCase()).toContain('model');
   });
 
+  test('agent-not-found → "Agent unavailable" routing to /kortix agents', () => {
+    const r = classifyTurnError({ name: 'UnknownError', message: 'agent "shipper" not found' });
+    expect(r.title).toBe('Agent unavailable');
+    expect(r.text).toContain('/kortix agents');
+    expect(r.aborted).toBe(false);
+  });
+
+  test('agent-not-declared (legacy runtime failure) → "Agent unavailable"', () => {
+    const r = classifyTurnError({ message: 'Agent "old-bot" is not a declared agent in this project' });
+    expect(r.title).toBe('Agent unavailable');
+  });
+
+  // The agent bucket requires the word "agent" so it can never shadow the
+  // broader model-not-found "does not exist" match.
+  test('a model "does not exist" error without the word "agent" stays "Model unavailable"', () => {
+    const r = classifyTurnError({ name: 'APIError', statusCode: 404, message: 'The model `gpt-foo` does not exist' });
+    expect(r.title).toBe('Model unavailable');
+  });
+
   test('401 → provider config copy (consolidated with ProviderAuthError)', () => {
     const r = classifyTurnError({ name: 'APIError', statusCode: 401, message: 'Unauthorized' });
     expect(r.title).toBe('Provider rejected the request');

--- a/apps/api/src/__tests__/unit-slack-start-error.test.ts
+++ b/apps/api/src/__tests__/unit-slack-start-error.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from 'bun:test';
+
+import { startErrorMessage } from '../channels/slack/start-error';
+
+// Honest, actionable copy for EVERY create-path failure a Slack turn can hit.
+// Before this, only 402/429/404 were mapped; every other status (and the
+// deleted-agent case) collapsed into the same "give it a moment and try again"
+// line — which is actively wrong when retrying can never succeed.
+describe('startErrorMessage', () => {
+  test('402 → out of credits, points to top-up', () => {
+    const m = startErrorMessage(402, { error: 'insufficient credits' });
+    expect(m.toLowerCase()).toContain('out of credits');
+    expect(m).toContain('Top up');
+  });
+
+  test('429 → concurrent-session limit', () => {
+    const m = startErrorMessage(429, {});
+    expect(m.toLowerCase()).toContain('concurrent-session limit');
+  });
+
+  test('404 → project moved/deleted, points to /kortix switch', () => {
+    const m = startErrorMessage(404, {});
+    expect(m).toContain('/kortix switch');
+  });
+
+  test('409 → no owning account, points to /kortix login', () => {
+    const m = startErrorMessage(409, {});
+    expect(m).toContain('/kortix login');
+  });
+
+  test('403 → permission, ask an admin', () => {
+    const m = startErrorMessage(403, {});
+    expect(m.toLowerCase()).toContain('permission');
+    expect(m.toLowerCase()).toContain('admin');
+  });
+
+  test('UNKNOWN_SANDBOX_TEMPLATE code → template-specific copy (beats the 400 status)', () => {
+    const m = startErrorMessage(400, { code: 'UNKNOWN_SANDBOX_TEMPLATE', error: 'no such template' });
+    expect(m.toLowerCase()).toContain('sandbox template');
+  });
+
+  test('KORTIX_URL_UNREACHABLE code → runtime-unreachable copy', () => {
+    const m = startErrorMessage(503, { code: 'KORTIX_URL_UNREACHABLE', error: 'unreachable' });
+    expect(m.toLowerCase()).toContain('sandbox runtime');
+  });
+
+  test('400 with a short human detail surfaces it verbatim', () => {
+    const m = startErrorMessage(400, { error: 'Unknown or disabled sandbox provider: platinum' });
+    expect(m).toContain('platinum');
+    expect(m).toContain('/kortix');
+  });
+
+  test('400 with a long/internal detail drops the noise', () => {
+    const long = 'x'.repeat(400);
+    const m = startErrorMessage(400, { error: long });
+    expect(m).not.toContain(long);
+  });
+
+  test('5xx → temporary error, retry guidance', () => {
+    for (const s of [500, 502, 503, 504]) {
+      const m = startErrorMessage(s, {});
+      expect(m.toLowerCase()).toContain('temporary error');
+    }
+  });
+
+  test('unknown status still yields a sensible next-step line (never blank)', () => {
+    const m = startErrorMessage(418, {});
+    expect(m.length).toBeGreaterThan(0);
+    expect(m.toLowerCase()).toContain('send your message again');
+  });
+
+  test('undefined body never throws', () => {
+    expect(() => startErrorMessage(undefined, undefined)).not.toThrow();
+  });
+});

--- a/apps/api/src/channels/slack/__tests__/agent-picker.test.ts
+++ b/apps/api/src/channels/slack/__tests__/agent-picker.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from 'bun:test';
+
+// Keep config validation happy when commands.ts's import graph loads.
+process.env.SLACK_REQUIRE_USER_IDENTITY = 'false';
+
+import { buildAgentUnavailablePickerBlocks } from '../commands';
+
+// The deleted-agent recovery picker: names the dead agent and renders one
+// clickable row per current agent, each wired to the existing `set_agent_*`
+// interactivity handler (interactivity.ts → handleSetSelection), so a click
+// re-points the channel binding and the user just re-sends.
+describe('buildAgentUnavailablePickerBlocks', () => {
+  const agents = [
+    { name: 'shipper', description: 'Ships things.' },
+    { name: 'reviewer', description: null },
+  ];
+
+  test('names the dead channel-override agent in the lead', () => {
+    const blocks = buildAgentUnavailablePickerBlocks({ channelId: 'C1', badAgent: 'ghost', agents });
+    const lead = JSON.stringify(blocks[0]);
+    expect(lead).toContain('ghost');
+    expect(lead.toLowerCase()).toContain('no longer exists');
+  });
+
+  test('renders a set_agent_* button per agent, plus the always-present default', () => {
+    const blocks = buildAgentUnavailablePickerBlocks({ channelId: 'C1', badAgent: 'ghost', agents });
+    const json = JSON.stringify(blocks);
+    expect(json).toContain('set_agent_default');
+    expect(json).toContain('set_agent_shipper');
+    expect(json).toContain('set_agent_reviewer');
+    // Every button's value carries the channel (so the existing set_agent_*
+    // handler updates THIS channel's binding) and its target agent name.
+    const buttons = blocks
+      .map((b) => (b as any).accessory)
+      .filter((a) => a && a.action_id?.startsWith('set_agent_'))
+      .map((a) => JSON.parse(a.value as string) as { c?: string; a?: string });
+    expect(buttons.length).toBe(3);
+    expect(buttons.every((v) => v.c === 'C1')).toBe(true);
+    // `default` clears the override (empty a); the two real agents name themselves.
+    expect(buttons.map((v) => v.a).sort()).toEqual(['', 'reviewer', 'shipper']);
+  });
+
+  test('null badAgent (broken default sentinel) still renders the picker', () => {
+    const blocks = buildAgentUnavailablePickerBlocks({ channelId: 'C1', badAgent: null, agents });
+    expect(JSON.stringify(blocks[0]).toLowerCase()).toContain("channel's default agent");
+    expect(JSON.stringify(blocks)).toContain('set_agent_shipper');
+  });
+
+  test('the dead agent is not marked as the current selection (no false ✓)', () => {
+    const blocks = buildAgentUnavailablePickerBlocks({ channelId: 'C1', badAgent: 'ghost', agents });
+    // 'ghost' isn't in the list, so no row should carry the ✓ current marker.
+    expect(JSON.stringify(blocks)).not.toContain('✓ Current');
+  });
+});

--- a/apps/api/src/channels/slack/commands.ts
+++ b/apps/api/src/channels/slack/commands.ts
@@ -816,37 +816,12 @@ async function slashAgents(ctx: SlashCtx, arg: string): Promise<SlashResponse> {
   // immediately and post the real picker out-of-band: to the response_url for a
   // real slash command, or straight into the DM for the message-fallback path.
   void (async () => {
-    let agents: Awaited<ReturnType<typeof listProjectAgents>> = [];
-    try {
-      agents = await listProjectAgents(selection.projectId);
-    } catch (err) {
-      console.warn('[slack-webhook] listProjectAgents failed', err);
-    }
-    // Per-resource scoping: a linked member sees only agents they're scoped to;
-    // an unlinked caller sees only project-wide (unscoped) agents — never leak a
-    // scoped agent's name cross-department. No-op when nothing is scoped.
-    try {
-      const names = agents.map((a) => a.name);
-      const identity = ctx.slackUserId ? await lookupSlackIdentity(ctx.teamId, ctx.slackUserId) : null;
-      let allowedNames: string[];
-      if (identity) {
-        const [proj] = await db
-          .select({ accountId: projects.accountId })
-          .from(projects)
-          .where(eq(projects.projectId, selection.projectId))
-          .limit(1);
-        allowedNames = proj
-          ? await filterAccessibleProjectResources(identity.userId, proj.accountId, selection.projectId, 'agent', names)
-          : await unscopedResourceIds(selection.projectId, 'agent', names);
-      } else {
-        allowedNames = await unscopedResourceIds(selection.projectId, 'agent', names);
-      }
-      const allow = new Set(allowedNames);
-      agents = agents.filter((a) => allow.has(a.name));
-    } catch (err) {
-      console.warn('[slack-webhook] agent scoping filter failed', err);
-    }
-    const blocks = buildAgentPickerBlocks(ctx, selection.agentName, agents);
+    const agents = await loadScopedChannelAgents({
+      teamId: ctx.teamId,
+      projectId: selection.projectId,
+      slackUserId: ctx.slackUserId,
+    });
+    const blocks = buildAgentPickerBlocks(ctx.channelId, selection.agentName, agents);
     if (ctx.deferredDeliver) {
       await ctx.deferredDeliver({ response_type: 'ephemeral', blocks });
     } else {
@@ -856,10 +831,57 @@ async function slashAgents(ctx: SlashCtx, arg: string): Promise<SlashResponse> {
   return { response_type: 'ephemeral', text: 'Loading agents…' };
 }
 
-function buildAgentPickerBlocks(
-  ctx: SlashCtx,
+/**
+ * The project's launchable agents (git-backed catalog), filtered to what THIS
+ * caller may see: a linked member sees only agents they're scoped to; an
+ * unlinked caller sees only project-wide (unscoped) agents — never leak a scoped
+ * agent's name cross-department. No-op when nothing is scoped. Touches git, so
+ * callers must be off the synchronous 3s slash window. Shared by the `/kortix
+ * agents` picker and the session-start "agent no longer exists" recovery picker
+ * (session.ts) so both list the same scoped catalog.
+ */
+export async function loadScopedChannelAgents(input: {
+  teamId: string;
+  projectId: string;
+  slackUserId?: string;
+}): Promise<Array<{ name: string; description: string | null }>> {
+  let agents: Awaited<ReturnType<typeof listProjectAgents>> = [];
+  try {
+    agents = await listProjectAgents(input.projectId);
+  } catch (err) {
+    console.warn('[slack-webhook] listProjectAgents failed', err);
+  }
+  try {
+    const names = agents.map((a) => a.name);
+    const identity = input.slackUserId ? await lookupSlackIdentity(input.teamId, input.slackUserId) : null;
+    let allowedNames: string[];
+    if (identity) {
+      const [proj] = await db
+        .select({ accountId: projects.accountId })
+        .from(projects)
+        .where(eq(projects.projectId, input.projectId))
+        .limit(1);
+      allowedNames = proj
+        ? await filterAccessibleProjectResources(identity.userId, proj.accountId, input.projectId, 'agent', names)
+        : await unscopedResourceIds(input.projectId, 'agent', names);
+    } else {
+      allowedNames = await unscopedResourceIds(input.projectId, 'agent', names);
+    }
+    const allow = new Set(allowedNames);
+    agents = agents.filter((a) => allow.has(a.name));
+  } catch (err) {
+    console.warn('[slack-webhook] agent scoping filter failed', err);
+  }
+  return agents;
+}
+
+export function buildAgentPickerBlocks(
+  channelId: string,
   currentAgent: string | null,
   agents: Array<{ name: string; description: string | null }>,
+  // Override the default "Agents" header + "Pick which agent…" caption — e.g. the
+  // session-start recovery picker leads with the failure it's recovering from.
+  lead?: Array<Record<string, unknown>>,
 ): Array<Record<string, unknown>> {
   // `default` is the always-available implicit agent. Listed first.
   const rows: Array<{ name: string; description: string | null }> = [
@@ -867,13 +889,15 @@ function buildAgentPickerBlocks(
     ...agents.filter((a) => a.name !== 'default'),
   ];
   const current = currentAgent ?? 'default';
-  const blocks: Array<Record<string, unknown>> = [
-    { type: 'header', text: { type: 'plain_text', text: 'Agents', emoji: true } },
-    { type: 'context', elements: [{ type: 'mrkdwn', text: `Pick which agent answers in this channel. Current: *${escapeMrkdwn(current)}*` }] },
-  ];
+  const blocks: Array<Record<string, unknown>> = lead
+    ? [...lead]
+    : [
+        { type: 'header', text: { type: 'plain_text', text: 'Agents', emoji: true } },
+        { type: 'context', elements: [{ type: 'mrkdwn', text: `Pick which agent answers in this channel. Current: *${escapeMrkdwn(current)}*` }] },
+      ];
   for (const a of rows) {
     const isCurrent = a.name === current;
-    const value = JSON.stringify({ c: ctx.channelId, a: a.name === 'default' ? '' : a.name });
+    const value = JSON.stringify({ c: channelId, a: a.name === 'default' ? '' : a.name });
     blocks.push({
       type: 'section',
       text: { type: 'mrkdwn', text: `${isCurrent ? '✓ ' : ''}*${escapeMrkdwn(a.name)}*${a.description ? `\n_${escapeMrkdwn(a.description.slice(0, 140))}_` : ''}` },
@@ -887,6 +911,33 @@ function buildAgentPickerBlocks(
     });
   }
   return blocks;
+}
+
+/**
+ * In-thread recovery blocks for when a Slack turn can't start because the agent
+ * configured for the channel (a channel override, or the project default the
+ * `default` sentinel resolves to) no longer exists — deleted, renamed, or
+ * disabled. Names the dead agent, then offers an inline picker of the project's
+ * CURRENT agents; the `set_agent_*` buttons run the SAME handler as `/kortix
+ * agents` (interactivity.ts → handleSetSelection), so one click re-points the
+ * channel binding and the user just re-sends. `badAgent` null = the `default`
+ * sentinel couldn't resolve (no channel override was set).
+ */
+export function buildAgentUnavailablePickerBlocks(input: {
+  channelId: string;
+  badAgent: string | null;
+  agents: Array<{ name: string; description: string | null }>;
+}): Array<Record<string, unknown>> {
+  const bad = input.badAgent && input.badAgent.trim() ? input.badAgent.trim() : null;
+  const lead = bad
+    ? `:warning:  *I couldn't start a session — the agent set for this channel (\`${escapeMrkdwn(bad)}\`) no longer exists.*\nIt was deleted, renamed, or disabled. Pick one of this project's current agents below, then send your message again.`
+    : `:warning:  *I couldn't start a session — this channel's default agent no longer exists.*\nIt was deleted, renamed, or disabled. Pick one of this project's current agents below, then send your message again.`;
+  // Mark nothing as "current": the previously-selected agent is the dead one, so
+  // implying an existing selection would be misleading. Pass the bad name as
+  // `currentAgent` — it isn't in the list, so no row gets a ✓.
+  return buildAgentPickerBlocks(input.channelId, bad, input.agents, [
+    { type: 'section', text: { type: 'mrkdwn', text: lead } },
+  ]);
 }
 
 async function slashSetAgent(ctx: SlashCtx, arg: string): Promise<SlashResponse> {

--- a/apps/api/src/channels/slack/errors.ts
+++ b/apps/api/src/channels/slack/errors.ts
@@ -132,6 +132,29 @@ function isProviderConfig(name: string, status: number | undefined): boolean {
   return name === 'ProviderAuthError' || status === 401 || status === 403;
 }
 
+// The configured agent doesn't exist — deleted/renamed/disabled since the
+// channel (or project default) was pointed at it. On a governed project this is
+// caught at session-create (400 AGENT_NOT_DECLARED → inline picker); on a legacy
+// project the session boots and opencode fails here when the agent markdown is
+// missing. Requires 'agent' in the text so it can't shadow the model-not-found
+// bucket below (which matches the broad "does not exist").
+function isAgentUnavailable(lower: string): boolean {
+  // Must mention an agent, so it can't shadow the broad model-not-found match.
+  if (!lower.includes('agent')) return false;
+  // …then any "this thing is gone" phrasing. `not found` / `does not exist`
+  // catch the natural `agent "X" not found` shapes (the name sits mid-phrase, so
+  // we can't require the words to be adjacent).
+  return (
+    lower.includes('not found') ||
+    lower.includes('does not exist') ||
+    lower.includes('no such') ||
+    lower.includes('not declared') ||
+    lower.includes('declared agent') ||
+    lower.includes('not a valid agent') ||
+    lower.includes('unknown agent')
+  );
+}
+
 // The selected model doesn't exist / isn't enabled for this key — a config fix,
 // not an outage. Usually a 404, sometimes phrased in the message.
 function isModelNotFound(status: number | undefined, lower: string): boolean {
@@ -251,7 +274,19 @@ export function classifyTurnError(info?: TurnErrorInfo): ClassifiedTurnError {
     };
   }
 
-  // 6. Model doesn't exist / isn't enabled — a config fix.
+  // 6. The configured agent is gone — deleted/renamed since the channel was
+  //    pointed at it. Route the user straight to the picker to fix it.
+  if (isAgentUnavailable(lower)) {
+    return {
+      title: 'Agent unavailable',
+      text:
+        `:warning: *The agent configured for this channel isn't available* — it may have been deleted, renamed, or disabled.` +
+        ` Run \`/kortix agents\` to pick one of this project's current agents, then mention me again.`,
+      aborted: false,
+    };
+  }
+
+  // 7. Model doesn't exist / isn't enabled — a config fix.
   if (isModelNotFound(status, lower)) {
     return {
       title: 'Model unavailable',
@@ -262,7 +297,7 @@ export function classifyTurnError(info?: TurnErrorInfo): ClassifiedTurnError {
     };
   }
 
-  // 7. Provider auth / config — bad or expired key, billing not set up.
+  // 8. Provider auth / config — bad or expired key, billing not set up.
   if (isProviderConfig(name, status)) {
     const who = providerID ? `the ${providerID} provider` : 'the model provider';
     return {
@@ -274,7 +309,7 @@ export function classifyTurnError(info?: TurnErrorInfo): ClassifiedTurnError {
     };
   }
 
-  // 8. Transient provider/network trouble — temporary, retry guidance, no raw body.
+  // 9. Transient provider/network trouble — temporary, retry guidance, no raw body.
   //    Checked BEFORE content-filter so a retryable 5xx whose body mentions a
   //    "safety system" isn't mislabeled a permanent policy refusal.
   if (isTransient(status, isRetryable, lower)) {
@@ -287,7 +322,7 @@ export function classifyTurnError(info?: TurnErrorInfo): ClassifiedTurnError {
     };
   }
 
-  // 9. Content-policy refusal — neutral copy, never echo the raw safety text.
+  // 10. Content-policy refusal — neutral copy, never echo the raw safety text.
   if (isContentFilter(status, isRetryable, lower)) {
     return {
       title: 'Request blocked',
@@ -298,7 +333,7 @@ export function classifyTurnError(info?: TurnErrorInfo): ClassifiedTurnError {
     };
   }
 
-  // 10. Anything else — never hide it. Show the real error when we have one;
+  // 11. Anything else — never hide it. Show the real error when we have one;
   //     otherwise an honest "unexpected error" (the session footer carries the
   //     link to dig in). Name-tag a detail-less error for debuggability.
   if (message) {

--- a/apps/api/src/channels/slack/session.ts
+++ b/apps/api/src/channels/slack/session.ts
@@ -8,7 +8,9 @@ import {
   resolveProjectAutomationActor as resolveLifecycleAutomationActor,
 } from '../../projects/session-lifecycle';
 import { EVENT_DEDUPE_TTL_MS } from './app';
+import { buildAgentUnavailablePickerBlocks, loadScopedChannelAgents } from './commands';
 import { currentChannelSelection } from './selection';
+import { startErrorMessage } from './start-error';
 import {
   normalizeConversationPolicy,
   rememberSlackThreadOwner,
@@ -180,7 +182,28 @@ export async function createOrJoinThreadSession(input: {
   if (result.error) {
     console.error('[slack-webhook] createProjectSession failed', { status: result.error.status, body: result.error.body });
     if (handle) {
-      await finalizeTurn(handle, { error: startErrorMessage(result.error.status, result.error.body?.error) });
+      // A deleted/renamed/disabled agent — the channel's own agent override, or
+      // the project default the `default` sentinel resolves to — is rejected up
+      // front as 400 AGENT_NOT_DECLARED. The generic "give it a moment and try
+      // again" copy is actively wrong here: retrying hits the same dead agent
+      // forever. Name the problem and drop an inline agent picker so the user
+      // re-points the channel to a live agent in one click, then re-sends.
+      if (result.error.body?.code === 'AGENT_NOT_DECLARED' && event.channel) {
+        const agents = await loadScopedChannelAgents({ teamId, projectId, slackUserId: event.user ?? undefined });
+        await finalizeTurn(handle, {
+          title: "Couldn't start — pick an agent",
+          // Fallback/notification text only (the picker blocks render in-thread);
+          // `error` keeps this off the ✅ path without inventing a second section.
+          error: "I couldn't start a session — the agent set for this channel no longer exists. Pick a current agent, then send your message again.",
+          blocks: buildAgentUnavailablePickerBlocks({
+            channelId: event.channel,
+            badAgent: selection?.agentName ?? null,
+            agents,
+          }),
+        });
+      } else {
+        await finalizeTurn(handle, { error: startErrorMessage(result.error.status, result.error.body) });
+      }
     }
     return;
   }
@@ -205,24 +228,6 @@ export async function createOrJoinThreadSession(input: {
       userId,
     });
   }
-}
-
-// Honest, actionable copy for the two non-success outcomes of starting a Slack
-// session — surfaced in-thread instead of a generic "try again" so a real
-// blocker (out of credits, at the session cap) tells the user what to do.
-function startErrorMessage(status: number | undefined, detail: unknown): string {
-  if (status === 402) {
-    return "This workspace is out of credits, so I can't start a session. Top up in the Kortix dashboard and send your message again.";
-  }
-  if (status === 429) {
-    return "This workspace is at its concurrent-session limit right now. Close or finish a running session, then send your message again.";
-  }
-  if (status === 404) {
-    return "I couldn't find this project to start a session — it may have been moved or deleted. Reconnect Kortix to this channel and try again.";
-  }
-  const text = typeof detail === 'string' ? detail.trim() : '';
-  const tail = text && text.length <= 140 ? ` (${text})` : '';
-  return `I couldn't start a session just now${tail}. Give it a moment and send your message again — I'll reply right here.`;
 }
 
 function queuedMessage(reason?: string): string {

--- a/apps/api/src/channels/slack/start-error.ts
+++ b/apps/api/src/channels/slack/start-error.ts
@@ -1,0 +1,55 @@
+/**
+ * Honest, actionable copy for EVERY non-success outcome of starting a Slack
+ * session — surfaced in-thread instead of a generic "try again" so a real
+ * blocker tells the user exactly what to do. Every error shape the create path
+ * (createProjectSession + the session lifecycle) can return is mapped here:
+ * most-specific by `code`, then by HTTP status, then a safe generic fallback.
+ *
+ * The AGENT_NOT_DECLARED case is handled by its own inline-picker branch at the
+ * call site (session.ts) — it needs interactive blocks, not a text line — so it
+ * never reaches here.
+ *
+ * Pure + dependency-free (mirrors errors.ts) so it's unit-tested in isolation,
+ * with no config/DB import to boot. Keep it exhaustive: an unmapped status must
+ * still read sensibly and always leave the user a next step.
+ */
+export function startErrorMessage(status: number | undefined, body: unknown): string {
+  const b = (body && typeof body === 'object' ? body : {}) as Record<string, unknown>;
+  const code = typeof b.code === 'string' ? b.code : undefined;
+  const detail = typeof b.error === 'string' ? b.error.trim() : '';
+  // A short, human 400 detail is worth surfacing verbatim; a long internal one
+  // (stack-ish message, SQL error) is noise — drop it and keep the copy clean.
+  const shortDetail = detail && detail.length <= 160 ? detail : '';
+
+  // Most specific: known error CODES from the create path.
+  switch (code) {
+    case 'UNKNOWN_SANDBOX_TEMPLATE':
+      return "I couldn't start a session — the sandbox template configured for this project no longer exists. Update it in the project's Kortix settings, then send your message again.";
+    case 'KORTIX_URL_UNREACHABLE':
+      return "I couldn't start a session — Kortix couldn't reach the sandbox runtime just now. This is usually a brief infrastructure hiccup; give it a moment and send your message again.";
+  }
+
+  // Then HTTP status.
+  switch (status) {
+    case 400:
+      return `I couldn't start a session — the request was rejected${shortDetail ? ` (${shortDetail})` : ''}. Check this channel's Kortix settings with \`/kortix\`, then send your message again.`;
+    case 402:
+      return "This workspace is out of credits, so I can't start a session. Top up in the Kortix dashboard and send your message again.";
+    case 403:
+      return "I couldn't start a session — this workspace doesn't have permission to run one here. Ask a Kortix workspace admin to grant access, then send your message again.";
+    case 404:
+      return "I couldn't find this project to start a session — it may have been moved or deleted. Reconnect Kortix to this channel with `/kortix switch`, then try again.";
+    case 409:
+      return "I couldn't find a Kortix account to run this session as. Connect your account with `/kortix login`, then send your message again.";
+    case 429:
+      return "This workspace is at its concurrent-session limit right now. Close or finish a running session, then send your message again.";
+    case 500:
+    case 502:
+    case 503:
+    case 504:
+      return "I couldn't start a session — Kortix hit a temporary error. Give it a moment and send your message again — I'll reply right here.";
+  }
+
+  // Unknown status/code — never leave the user without a next step.
+  return `I couldn't start a session just now${shortDetail ? ` (${shortDetail})` : ''}. Give it a moment and send your message again — I'll reply right here.`;
+}


### PR DESCRIPTION
## Why

A Slack `@`-mention failed to start a session and replied:

> I couldn't start a session just now. Give it a moment and send your message again — I'll reply right here.

The root cause was a **deleted agent**: the channel was still configured with an agent (the channel's default) that had since been deleted. On a governed project that's rejected up front as `400 AGENT_NOT_DECLARED`, but the error `code` was never threaded through `startErrorMessage`, so it collapsed into the generic "try again" copy — advice that can **never** succeed, since every retry hits the same dead agent. A normal user has no way to know what's wrong or how to fix it.

## What changed

**1. Deleted-agent recovery (the reported bug).** When session-create returns `AGENT_NOT_DECLARED`, instead of the dead-end message we now post an **inline agent picker** in-thread listing the project's *current* agents (scoped to the caller, same as `/kortix agents`). The buttons reuse the existing `set_agent_*` interactivity handler, so **one click re-points the channel binding** and the user just re-sends. Names the dead agent so it's obvious what happened.

**2. Every start error is now honest & actionable.** Rewrote `startErrorMessage` to map *every* create-path outcome to specific copy with a real next step — never a bare "try again" when a retry can't help:

| Outcome | Copy |
| --- | --- |
| `UNKNOWN_SANDBOX_TEMPLATE` | sandbox template gone → update project settings |
| `KORTIX_URL_UNREACHABLE` | runtime unreachable → transient, retry |
| 400 | rejected (+ short detail) → check `/kortix` settings |
| 402 | out of credits → top up |
| 403 | no permission → ask an admin |
| 404 | project moved/deleted → `/kortix switch` |
| 409 | no owning account → `/kortix login` |
| 429 | at session cap → free a slot |
| 5xx | temporary → retry |

Extracted to a pure, dependency-free module (`start-error.ts`) and unit-tested in isolation (mirrors `errors.ts`).

**3. Legacy runtime path too.** On an ungoverned project a missing agent doesn't fail at create — it boots and fails at runtime. Added an **"Agent unavailable"** bucket to `classifyTurnError` so that case also routes the user to `/kortix agents` instead of a raw "Run failed".

**4. Refactor.** Extracted `loadScopedChannelAgents` and generalized `buildAgentPickerBlocks` so the `/kortix agents` picker and the recovery picker share one scoped-catalog loader.

## Tests
- `unit-slack-start-error.test.ts` — every status/code branch of `startErrorMessage`.
- `agent-picker.test.ts` — the recovery picker names the dead agent, renders one `set_agent_*` button per current agent, and never false-marks the dead one as current.
- `unit-slack-error-classify.test.ts` — new "Agent unavailable" cases + a regression guard that a model "does not exist" error (no "agent" word) still classifies as *Model unavailable*.

`tsc --noEmit` clean. (Local full-suite has the known `KORTIX_URL` false-failures in `identity.test.ts` — unrelated; verified via isolated runs per the documented workflow.)

## Notes
- I deliberately did **not** add an upfront agent-existence check on the happy path — `listProjectAgents` refreshes the git mirror, so validating every override-channel turn would be a real latency regression. The catalog read happens only on the failure path (to build the picker).