### PR TITLE
fix(sandbox): ignore stale failed builds

### DIFF
--- a/apps/api/src/__tests__/unit-snapshot-build-state.test.ts
+++ b/apps/api/src/__tests__/unit-snapshot-build-state.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from 'bun:test';
+
+import { currentFailedSnapshotBuild } from '../snapshots/build-state';
+
+describe('currentFailedSnapshotBuild', () => {
+  test('returns the newest build when it failed', () => {
+    const failed = { id: 'failed-latest', status: 'failed' as const };
+
+    expect(
+      currentFailedSnapshotBuild([failed, { id: 'ready-older', status: 'ready' as const }]),
+    ).toBe(failed);
+  });
+
+  test('ignores older failed rows once a newer build is ready', () => {
+    expect(
+      currentFailedSnapshotBuild([
+        { id: 'ready-latest', status: 'ready' as const },
+        { id: 'failed-older', status: 'failed' as const },
+      ]),
+    ).toBeNull();
+  });
+
+  test('ignores older failed rows while a newer build is still running', () => {
+    expect(
+      currentFailedSnapshotBuild([
+        { id: 'building-latest', status: 'building' as const },
+        { id: 'failed-older', status: 'failed' as const },
+      ]),
+    ).toBeNull();
+  });
+});

--- a/apps/api/src/projects/routes/r2.ts
+++ b/apps/api/src/projects/routes/r2.ts
@@ -1,6 +1,7 @@
 import { ACCOUNT_ACTIONS, PROJECT_ACTIONS, assertAuthorized } from '../../iam';
 import { auth, errors, json } from '../../openapi';
 import { DEFAULT_SANDBOX_SLUG, deleteSandboxImage, kickPreBuild, kickProjectTemplatePrebuilds, listSandboxTemplates, listSnapshotBuilds, reconcileStaleBuilds } from '../../snapshots/builder';
+import { currentFailedSnapshotBuild } from '../../snapshots/build-state';
 import { classifySnapshotError, describeSnapshotError } from '../../snapshots/error-classify';
 import { getSandboxProvider } from '../../snapshots/providers';
 import { withTimeout } from '../../shared/with-timeout';
@@ -427,7 +428,7 @@ projectsApp.openapi(
 
 // GET /v1/projects/:projectId/sandbox-health
 // Cheap polling endpoint for the sidebar alert. Surfaces the platform default
-// template's live state + the most recent failed build (across any template).
+// template's live state + the current failed build, if the newest attempt failed.
 //
 // Whole-handler wall-clock budget, kept comfortably under the frontend's 30s
 // request timeout (apps/web/src/lib/api-client.ts → "Request timed out after
@@ -478,7 +479,7 @@ async function buildSandboxHealth(
   const primary = templates[0] ?? null;
   const builds = await listSnapshotBuilds(projectId, { limit: 10 }).catch(() => []);
   const latest = builds[0] ?? null;
-  const latestFailure = builds.find((b) => b.status === 'failed') ?? null;
+  const latestFailure = currentFailedSnapshotBuild(builds);
   const isBuilding =
     (latest && latest.status === 'building') ||
     (primary ? ['pulling', 'building'].includes(primary.daytonaState.toLowerCase()) : false);
@@ -636,9 +637,9 @@ projectsApp.openapi(
   const userId = c.get('userId') as string;
 
   const builds = await listSnapshotBuilds(projectId, { limit: 50 }).catch(() => []);
-  const failed = builds.find((b) => b.status === 'failed');
+  const failed = currentFailedSnapshotBuild(builds);
   if (!failed) {
-    return c.json({ error: 'No failed snapshot build to fix.' }, 409);
+    return c.json({ error: 'No current failed snapshot build to fix.' }, 409);
   }
 
   const errorText = failed.error ?? 'Snapshot build failed';

--- a/apps/api/src/snapshots/build-state.ts
+++ b/apps/api/src/snapshots/build-state.ts
@@ -1,0 +1,18 @@
+/** Pure helpers for interpreting the append-only snapshot build log. */
+
+export type SnapshotBuildStateLike = {
+  status: 'building' | 'ready' | 'failed';
+};
+
+/**
+ * `listSnapshotBuilds` returns newest build attempt first. A sandbox is only in a
+ * "failed build" state when that newest attempt failed. Older failed rows are
+ * history and must not keep the sidebar/customize alert red after a newer ready
+ * or building attempt exists.
+ */
+export function currentFailedSnapshotBuild<T extends SnapshotBuildStateLike>(
+  builds: readonly T[],
+): T | null {
+  const latest = builds[0] ?? null;
+  return latest?.status === 'failed' ? latest : null;
+}

--- a/apps/web/src/features/workspace/customize/sections/view/sandbox-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/sandbox-view.tsx
@@ -19,20 +19,21 @@ import { errorToast, successToast } from '@/components/ui/toast';
 import { Icon } from '@/features/icon/icon';
 import { EmptyState } from '@/features/layout/section/empty-state';
 import { ErrorState } from '@/features/layout/section/error-state';
-import CustomizeSectionWrapper from '@/features/workspace/customize/sections/component/section-wrapper';
 import { useProjectManifestVersion } from '@/features/workspace/customize/migrate-to-v2/manifest-version';
+import CustomizeSectionWrapper from '@/features/workspace/customize/sections/component/section-wrapper';
 import { useSandboxRecovery } from '@/features/workspace/project-sidebar/footer/project-sandbox-alert';
+import { currentFailedBuild } from '@/features/workspace/project-sidebar/footer/sandbox-alert-state';
+import { cn } from '@/lib/utils';
 import {
-  buildSandboxTemplate,
-  deleteSandboxTemplate,
-  getProject,
-  listProjectSnapshots,
   type ProjectSnapshotBuild,
   type ProjectSnapshotStatus,
   type SandboxTemplate,
   type SnapshotErrorCategory,
+  buildSandboxTemplate,
+  deleteSandboxTemplate,
+  getProject,
+  listProjectSnapshots,
 } from '@kortix/sdk/projects-client';
-import { cn } from '@/lib/utils';
 import {
   AlarmClockSolid,
   CheckCircleSolid,
@@ -51,7 +52,7 @@ import {
   Trash2,
 } from 'lucide-react';
 import { useTranslations } from 'next-intl';
-import { useState, type ReactNode } from 'react';
+import { type ReactNode, useState } from 'react';
 
 const SNAPSHOTS_QUERY_KEY = (projectId: string) => ['project-snapshots', projectId];
 
@@ -543,9 +544,9 @@ export function SandboxView({ projectId }: { projectId: string }) {
   const data = snapshotsQuery.data;
   const builds = Array.isArray(data?.builds) ? data.builds : [];
   const templates = Array.isArray(data?.templates) ? data.templates : [];
-  const latestFailure = builds.find((b) => b.status === 'failed') ?? null;
+  const latestFailure = currentFailedBuild(builds);
   const latestReady = builds.find((b) => b.status === 'ready') ?? null;
-  const canFixWithAgent = !!latestFailure && !!latestReady;
+  const canFixWithAgent = !!latestFailure && latestFailure.fixable_by_agent && !!latestReady;
   const isFullyEmpty = templates.length === 0 && builds.length === 0;
 
   // Build-log rows carry no provider column of their own, so resolve it from the

--- a/apps/web/src/features/workspace/project-sidebar/footer/project-sandbox-alert.tsx
+++ b/apps/web/src/features/workspace/project-sidebar/footer/project-sandbox-alert.tsx
@@ -15,27 +15,23 @@ import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover
 import { SidebarMenuButton, SidebarMenuItem } from '@/components/ui/sidebar';
 import { errorToast, successToast } from '@/components/ui/toast';
 import {
+  type SandboxAlertSeverity,
+  resolveSandboxAlertSeverity,
+  selectCurrentSandboxFailure,
+} from '@/features/workspace/project-sidebar/footer/sandbox-alert-state';
+import { cn } from '@/lib/utils';
+import { useCustomizeStore } from '@/stores/customize-store';
+import {
+  type ProjectSandboxHealth,
   fixSandboxWithAgent,
   getProjectSandboxHealth,
   rebuildProjectSnapshot,
-  type ProjectSandboxHealth,
 } from '@kortix/sdk/projects-client';
-import { cn } from '@/lib/utils';
-import { useCustomizeStore } from '@/stores/customize-store';
 import { DangerTriangleSolid, SparklesSolid } from '@mynaui/icons-react';
 
 export const SANDBOX_HEALTH_QUERY_KEY = (projectId: string) => ['sandbox-health', projectId];
 
-type Severity = 'critical' | 'building';
-
-function severityOf(health: ProjectSandboxHealth | null | undefined): Severity | null {
-  if (!health) return null;
-  if (health.latest_failure && !health.ready) return 'critical';
-  if (health.building && !health.ready) return 'building';
-  return null;
-}
-
-const SEVERITY_TONE: Record<Severity, { text: string; icon: string; dot: string }> = {
+const SEVERITY_TONE: Record<SandboxAlertSeverity, { text: string; icon: string; dot: string }> = {
   critical: {
     text: 'text-destructive',
     icon: 'text-destructive',
@@ -44,11 +40,11 @@ const SEVERITY_TONE: Record<Severity, { text: string; icon: string; dot: string 
   building: {
     text: 'text-muted-foreground',
     icon: 'text-muted-foreground',
-    dot: 'bg-blue-500',
+    dot: 'bg-kortix-yellow',
   },
 };
 
-const SEVERITY_LABEL: Record<Severity, string> = {
+const SEVERITY_LABEL: Record<SandboxAlertSeverity, string> = {
   critical: 'Fix sandbox build',
   building: 'Sandbox build running…',
 };
@@ -72,7 +68,7 @@ export function useSandboxHealth(projectId: string) {
     refetchInterval: (query) => {
       const data = query.state.data;
       if (!data) return 15_000;
-      if (data.building || data.latest_failure) return 8_000;
+      if (data.building || selectCurrentSandboxFailure(data)) return 8_000;
       return 30_000;
     },
     refetchOnWindowFocus: true,
@@ -117,12 +113,12 @@ function SandboxAlertContent({
 }: {
   projectId: string;
   health: ProjectSandboxHealth;
-  severity: Severity;
+  severity: SandboxAlertSeverity;
 }) {
   const tI18nHardcoded = useTranslations('hardcodedUi');
   const openCustomize = useCustomizeStore((s) => s.openCustomize);
   const { retry, fixWithAgent } = useSandboxRecovery(projectId);
-  const failure = health.latest_failure;
+  const failure = selectCurrentSandboxFailure(health);
   // Only offer the agent for failures it can actually act on. Infra categories
   // (quota, provider, timeout, runtime, tunnel) aren't repo-editable, and the fix
   // session itself needs a bootable sandbox — the very thing the failure denied —
@@ -219,7 +215,7 @@ function SandboxAlertContent({
 export function ProjectSandboxAlert({ projectId }: { projectId: string }) {
   const [isOpen, setIsOpen] = useState(false);
   const { data } = useSandboxHealth(projectId);
-  const severity = severityOf(data);
+  const severity = resolveSandboxAlertSeverity(data);
   if (!severity || !data) return null;
   const tone = SEVERITY_TONE[severity];
 
@@ -256,7 +252,7 @@ export function ProjectSandboxAlert({ projectId }: { projectId: string }) {
 
 export function ProjectSandboxAlertRailItem({ projectId }: { projectId: string }) {
   const { data } = useSandboxHealth(projectId);
-  const severity = severityOf(data);
+  const severity = resolveSandboxAlertSeverity(data);
   if (!severity || !data) return null;
   const tone = SEVERITY_TONE[severity];
 
@@ -266,7 +262,7 @@ export function ProjectSandboxAlertRailItem({ projectId }: { projectId: string }
         <PopoverTrigger asChild>
           <SidebarMenuButton type="button" aria-label={SEVERITY_LABEL[severity]}>
             {severity === 'building' ? (
-              <Loading className={cn('size-4 animate-spin', tone.icon)} />
+              <Loading className={cn('size-4', tone.icon)} />
             ) : (
               <DangerTriangleSolid className={cn('size-4', tone.icon)} />
             )}

--- a/apps/web/src/features/workspace/project-sidebar/footer/sandbox-alert-state.test.ts
+++ b/apps/web/src/features/workspace/project-sidebar/footer/sandbox-alert-state.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from 'bun:test';
+
+import type { ProjectSandboxHealth, ProjectSnapshotBuild } from '@kortix/sdk/projects-client';
+import {
+  currentFailedBuild,
+  resolveSandboxAlertSeverity,
+  selectCurrentSandboxFailure,
+} from './sandbox-alert-state';
+
+function build(overrides: Partial<ProjectSnapshotBuild>): ProjectSnapshotBuild {
+  return {
+    build_id: 'build-1',
+    slug: 'default',
+    template_slug: 'default',
+    snapshot_name: 'kortix-default-123',
+    content_hash: 'hash',
+    status: 'ready',
+    error: null,
+    error_category: null,
+    fixable_by_agent: false,
+    source: 'manual',
+    started_at: '2026-07-11T00:00:00.000Z',
+    finished_at: '2026-07-11T00:01:00.000Z',
+    ...overrides,
+  };
+}
+
+function health(overrides: Partial<ProjectSandboxHealth>): ProjectSandboxHealth {
+  return {
+    primary_slug: 'default',
+    primary_template: null,
+    ready: false,
+    building: false,
+    latest_build: null,
+    latest_failure: null,
+    ...overrides,
+  };
+}
+
+describe('selectCurrentSandboxFailure', () => {
+  test('keeps a failed latest build actionable', () => {
+    const failed = build({ build_id: 'failed-latest', status: 'failed' });
+
+    expect(
+      selectCurrentSandboxFailure(health({ latest_build: failed, latest_failure: failed })),
+    ).toBe(failed);
+  });
+
+  test('drops an older failed build when a newer build is ready', () => {
+    const latestReady = build({ build_id: 'ready-latest', status: 'ready' });
+    const oldFailure = build({ build_id: 'failed-older', status: 'failed' });
+
+    expect(
+      selectCurrentSandboxFailure(
+        health({ latest_build: latestReady, latest_failure: oldFailure, ready: false }),
+      ),
+    ).toBeNull();
+  });
+});
+
+describe('resolveSandboxAlertSeverity', () => {
+  test('does not show the red fix alert for stale failed history', () => {
+    const latestReady = build({ build_id: 'ready-latest', status: 'ready' });
+    const oldFailure = build({ build_id: 'failed-older', status: 'failed' });
+
+    expect(
+      resolveSandboxAlertSeverity(
+        health({ latest_build: latestReady, latest_failure: oldFailure, ready: false }),
+      ),
+    ).toBeNull();
+  });
+
+  test('shows building when a newer build is running after an older failure', () => {
+    const latestBuilding = build({ build_id: 'building-latest', status: 'building' });
+    const oldFailure = build({ build_id: 'failed-older', status: 'failed' });
+
+    expect(
+      resolveSandboxAlertSeverity(
+        health({ latest_build: latestBuilding, latest_failure: oldFailure, building: true }),
+      ),
+    ).toBe('building');
+  });
+});
+
+describe('currentFailedBuild', () => {
+  test('returns the failed build only when it is the newest row', () => {
+    const failed = build({ build_id: 'failed-latest', status: 'failed' });
+    expect(currentFailedBuild([failed, build({ build_id: 'ready-older' })])).toBe(failed);
+  });
+
+  test('ignores older failed rows after a newer ready build', () => {
+    expect(
+      currentFailedBuild([
+        build({ build_id: 'ready-latest', status: 'ready' }),
+        build({ build_id: 'failed-older', status: 'failed' }),
+      ]),
+    ).toBeNull();
+  });
+});

--- a/apps/web/src/features/workspace/project-sidebar/footer/sandbox-alert-state.ts
+++ b/apps/web/src/features/workspace/project-sidebar/footer/sandbox-alert-state.ts
@@ -1,0 +1,31 @@
+import type { ProjectSandboxHealth, ProjectSnapshotBuild } from '@kortix/sdk/projects-client';
+
+export type SandboxAlertSeverity = 'critical' | 'building';
+
+export function selectCurrentSandboxFailure(
+  health: ProjectSandboxHealth | null | undefined,
+): ProjectSnapshotBuild | null {
+  const failure = health?.latest_failure ?? null;
+  if (!failure) return null;
+
+  const latest = health?.latest_build ?? null;
+  if (latest && latest.build_id !== failure.build_id) return null;
+
+  return failure;
+}
+
+export function resolveSandboxAlertSeverity(
+  health: ProjectSandboxHealth | null | undefined,
+): SandboxAlertSeverity | null {
+  if (!health) return null;
+  if (selectCurrentSandboxFailure(health) && !health.ready) return 'critical';
+  if (health.building && !health.ready) return 'building';
+  return null;
+}
+
+export function currentFailedBuild<T extends { status: ProjectSnapshotBuild['status'] }>(
+  builds: readonly T[],
+): T | null {
+  const latest = builds[0] ?? null;
+  return latest?.status === 'failed' ? latest : null;
+}


### PR DESCRIPTION
## Summary
- Treat only the newest snapshot build row as the current sandbox failure, so older failed builds no longer keep the sidebar stuck on `Fix sandbox build` after a newer ready/building build exists.
- Reuse the same current-failure selector in the sandbox customize view and hide `Fix with agent` for non-agent-fixable failures.
- Add API/web regression coverage for stale failed build rows.

## Verification
- `bun test apps/api/src/__tests__/unit-snapshot-build-state.test.ts apps/web/src/features/workspace/project-sidebar/footer/sandbox-alert-state.test.ts`
- `pnpm --filter Kortix-Computer-Frontend exec eslint src/features/workspace/project-sidebar/footer/project-sandbox-alert.tsx src/features/workspace/project-sidebar/footer/sandbox-alert-state.ts src/features/workspace/project-sidebar/footer/sandbox-alert-state.test.ts src/features/workspace/customize/sections/view/sandbox-view.tsx`
- `pnpm --filter kortix-api typecheck`
- `pnpm --filter Kortix-Computer-Frontend exec fumadocs-mdx`
- `pnpm --filter Kortix-Computer-Frontend exec tsc --noEmit`
