### PR TITLE
content(use-cases): refine dependency-upgrades use case

### DIFF
--- a/apps/web/content/use-cases/dependency-upgrades.mdx
+++ b/apps/web/content/use-cases/dependency-upgrades.mdx
@@ -1,146 +1,255 @@
 ---
 title: "How we keep dependencies up to date"
-description: The upgrade agent we run on Kortix — a weekly cron that opens dependency PRs, runs the full suite in a sandbox, and only opens the PR when it's green.
+description: A weekly upgrade agent that applies dependency bumps on an isolated branch, runs the full suite — including breaking-change migrations — and opens a PR only when everything is green.
 date: "2026-02-11"
 author: team
 tags:
   - Engineering
-  - Case Study
   - DevTools
+  - Case Study
 template: dependency-upgrades
 ---
 
-Dependencies drift. Left alone, a project falls months behind, security patches
-pile up, and the eventual upgrade turns into a large, risky change nobody wants
-to own. The usual bots open a PR for every bump and leave a human to work out
-whether each one is safe, which mostly means the PRs sit unreviewed.
+Dependencies drift quietly. A project that was current six months ago is now
+dozens of patch versions behind, a handful of minor releases past where it
+started, and sitting on at least one package with a known CVE. Nobody planned for
+it to happen — it happened because the work of staying current is unglamorous,
+interruptible, and always lower priority than whatever is shipping this week.
 
-We run an upgrade agent on Kortix that does the checking before it asks for a
-review. A weekly cron proposes upgrades, applies them in an isolated sandbox,
-runs the full suite, and only opens a PR when the change is green. This write-up
-covers how the setup works: the trigger, the session model, and the guardrails.
+The standard fix is a version-bump bot. It opens a PR per package, sets the CI
+badge to green, and calls it done. But "green CI" and "safe to merge" are
+different things. The tests that ran were written before the upgrade. A new
+version that changes a default, deprecates a method, or silently alters behavior
+can pass every existing test and still break the application in ways reviewers
+won't catch without checking it out and running it by hand. So the PRs pile up.
+
+We built an upgrade agent to close that gap. The agent does the checking the
+bump bot skips: it applies the upgrade, installs clean, migrates any breaking
+changes it can handle automatically, and runs the full suite — unit, integration,
+and end-to-end — inside an isolated sandbox before it opens a PR. A PR from this
+agent means the suite was green on the upgraded code. The team reviews a proven
+change, not a candidate one.
 
 <KeyFacts>
-  <Fact label="Team">Kortix</Fact>
   <Fact label="Runs on">A weekly cron</Fact>
-  <Fact label="Connected systems">GitHub · CI</Fact>
-  <Fact label="Mode">Cron-driven · PR opened only when green</Fact>
+  <Fact label="Connected systems">GitHub · CI · Package registry</Fact>
+  <Fact label="Mode">Cron-driven · sandbox-verified · PR opened only when green</Fact>
+  <Fact label="Human role">Review and merge — the agent never merges itself</Fact>
 </KeyFacts>
 
 ## The problem
 
-Keeping dependencies current is work no one schedules. A version-bump bot opens a
-PR per package, but it can't tell whether the bump breaks anything — that check
-still falls to a person, so the PRs queue up and the project drifts anyway.
+Dependency maintenance fails in a predictable pattern. A project ships fast for a
+few months, nobody books time for upgrades, and the gap between current versions
+and installed versions grows. When something finally forces the issue — a security
+advisory, a compatibility break with a new tool, a colleague asking why the project
+is still on a three-year-old major — the upgrade is no longer a small job. It's a
+migration.
 
-The common fixes are incomplete. Ignoring upgrades until something forces the
-issue turns a routine bump into a migration. Merging bot PRs on green CI trusts
-whatever tests already exist, not that the upgrade is actually safe. Doing it by
-hand is reliable but slow, and it's the first thing dropped when the team is busy.
+<PullQuote>
+  The usual bots open a PR for every bump and leave a human to work out whether
+  each one is safe. Which mostly means the PRs sit unreviewed.
+</PullQuote>
+
+Bump bots make the problem visible without solving it. Each bot PR that lands
+unanswered is a small accusation: something is behind, and nobody has time to
+check it. The PRs that do get merged often get merged on faith — the CI was green,
+the package name sounds fine, and the reviewer had three other things to look at.
+That's how silent regressions sneak in.
+
+The real work is not opening the PR. It's running the upgraded code, seeing
+whether it breaks, and producing a result a reviewer can trust. That's the work
+this agent does.
 
 ## What we built
 
-On Kortix, a weekly cron triggers an upgrade agent. Each run spawns an isolated
-session (a cloud sandbox) with scoped access to the repository and CI. The agent
-checks which dependencies are behind, applies the upgrades on a branch, installs
-clean, and runs the full suite inside the sandbox. It opens a PR only when the
-change is green; a human merges.
+A weekly cron triggers an upgrade agent. Each run spawns a fresh session in its
+own isolated sandbox, checks out the default branch, resolves which packages are
+behind, and works through the upgrades in three tiers.
+
+**Patch and minor bumps** are applied together in one batch — update the manifests,
+regenerate the lockfile, install clean. If the suite passes, they become one PR
+with the full changelog attached.
+
+**Major version upgrades** are handled one at a time. Before applying each one,
+the agent reads the package's changelog and migration guide, audits the codebase
+for usage of removed or renamed APIs, and applies the mechanical migration steps
+it can automate — import renames, method signature changes, configuration
+reshaping. Only then does it bump the version and run the suite.
+
+**Breaking changes it can't complete automatically** get a tracked issue instead
+of a PR. The issue documents what the migration requires, what the agent tried,
+and why it stopped short. Nothing gets pushed half-migrated; the team decides when
+to take the manual work on.
 
 <Figure
-  caption="The upgrade agent opening a green dependency PR"
+  caption="A green upgrade PR — suite results, changelog, and migration notes in the body"
   aspect="16/9"
 />
 
 ## How it works
 
 <Steps>
-<Step title="Connect a weekly cron as the trigger">
+<Step title="Trigger on a weekly cron">
 
-A scheduled **trigger** fires the project once a week. Each firing spawns a fresh
-**session** in its own sandbox, seeded with a clean checkout of the default
-branch. One run, one disposable machine, so nothing carries over between weeks and
-independent upgrade sets can run in parallel.
+A scheduled **trigger** fires once a week. Each firing spawns a fresh **session**
+in its own microVM sandbox, seeded with a clean checkout of the default branch and
+a fresh install of the current lockfile.
 
-</Step>
-<Step title="Give the agent the upgrade playbook">
-
-How we handle upgrades lives as **skills** and **memory** that travel with the
-agent: which packages are pinned on purpose, how to run the suite, the order to
-apply major versions in, and migrations that have bitten us before. When an
-upgrade needs a manual step, we write it down and the agent applies it on the next
-run.
+The session is disposable. Nothing carries over from the prior week's run — no
+stale environment, no leftover state from a partial upgrade. If this week's
+upgrades need to be done in parallel batches, each batch gets its own session on
+its own branch, running at the same time.
 
 </Step>
-<Step title="Connect the systems the upgrade needs">
+<Step title="Resolve what is behind">
+
+The agent runs the package manager's resolution tools against the current
+manifests: what is installed, what is available, and by how much each package
+has drifted. Packages are separated into tiers — patch, minor, major — and
+checked against a **pinned-packages ledger** in the project's memory. Anything
+intentionally pinned is skipped with a note; the agent never tries to upgrade
+a package that has a documented reason to stay where it is.
+
+</Step>
+<Step title="Encode the upgrade playbook as skills and memory">
+
+How upgrades are handled lives as **skills** and **memory** that travel with the
+agent across every run:
+
+- Which packages are pinned and why
+- The order to apply major versions — some majors depend on other majors landing first
+- Migration patterns the team has worked through before, so the agent applies them
+  automatically on the next bump
+- Known flaky tests to distinguish from genuine regressions
+
+When an upgrade bites the team in an unexpected way, the fix and the lesson go
+into memory. The next time that package bumps, the agent already knows what to
+check.
+
+</Step>
+<Step title="Connect the repository and CI">
 
 Through scoped **connectors**, brokered server-side so no raw token reaches the
 model, the agent can:
 
-- **Read the manifests** — resolve which dependencies are behind and how far,
-  separating patch and minor bumps from majors.
-- **Apply and install in the sandbox** — update the lockfile and install clean on
-  a branch, with the resolution output captured in full.
-- **Run the full suite** — unit, integration, and e2e inside the sandbox, so a
-  bump that breaks a path fails here rather than in review.
-- **Open a PR on GitHub** — the branch, the changelog for each bump, and the green
-  result post as a pull request.
+- **Read and write the manifests** — resolve versions, update package files, and
+  regenerate the lockfile in the sandbox
+- **Run the full suite** — unit, integration, and end-to-end tests inside the
+  sandbox, with the full output captured and indexed against the diff
+- **Read the changelog and release notes** — fetch them from the package registry
+  or GitHub releases to understand what changed before applying the bump
+- **Open a PR on GitHub** — push the branch and create the pull request only after
+  the suite passes, with the verification results embedded in the PR body
+- **File a tracked issue** — when a major upgrade requires manual migration work
+  beyond what the agent can automate, it files a precise issue with the steps and
+  the evidence, then continues with the rest of the upgrades
 
 </Step>
-<Step title="Set the guardrails">
+<Step title="Handle breaking changes before pushing">
 
-The agent opens a PR only when the suite passes; a failing upgrade is dropped or
-split, not pushed for a human to debug. It never merges — the merge is a **human
-approval gate**. Credentials are encrypted in the secrets manager and injected at
-runtime, never shown to the model or written to logs.
+Major version upgrades go through a structured sequence before the suite runs:
+
+1. Fetch the changelog and migration guide for the new version
+2. Grep the codebase for usage of removed or renamed APIs
+3. Apply mechanical migration changes — import path renames, method renames,
+   configuration key changes — using codemods where available
+4. Run the typechecker to catch anything the codemod missed
+5. Fix remaining type errors if they are contained to the touched surfaces
+
+If the migration requires semantic judgment — a removed API with no direct
+equivalent, a behavior change the tests don't cover, a dependency on internal
+package structure — the agent reverts the bump and files a tracked issue instead.
+It does not push a partially migrated upgrade for someone else to diagnose.
 
 </Step>
-<Step title="Let the weekly run happen">
+<Step title="Run the full verification suite">
 
-With that in place, each week the agent finds what's behind, applies the upgrades,
-runs the suite in the sandbox, and opens a PR that's already been proven green —
-with the bumps grouped and the changelog attached. A bump that breaks a test never
-becomes a PR; it comes back flagged with the failure instead.
+This is the gate. The PR is not opened until every check passes:
+
+- `install` — clean install from the updated lockfile, with the full resolution
+  output captured
+- `typecheck` — catches broken API surfaces and type regressions introduced by the
+  new version
+- `lint` — catches deprecation warnings and new lint rules that ship with the
+  upgraded toolchain
+- `build` — catches tree-shaking and import-resolution regressions
+- `test` — unit and integration tests against the upgraded code
+- `audit` — confirms the vulnerable versions are gone and no new advisories were
+  introduced by the bump
+
+A failing upgrade is dropped from this week's PR, logged with the failure output,
+and either retried next run or queued as a tracked issue. It is never pushed.
+
+</Step>
+<Step title="Open the PR only when green">
+
+After the suite passes, the agent pushes the branch and opens a pull request. The
+PR body includes the full list of bumped packages with version ranges, a
+verification table showing every check and its result, notes on any breaking
+changes that were migrated, and the list of upgrades that were dropped this week
+with the reason for each.
+
+The agent opens the PR and stops. It does not merge, does not request a review
+from a specific person, and does not push to the default branch. A human reviews
+the diff, reads the verification table, and decides whether to merge.
 
 </Step>
 </Steps>
 
 <Callout title="The pattern" tone="accent">
-  A weekly **trigger** spawns a session with scoped **connectors** into the repo
-  and CI. The upgrade playbook is encoded as **skills** and **memory**. The agent
-  proves the change green in its sandbox and a human owns the merge.
+  A weekly **trigger** spawns a session with scoped **connectors** into the
+  repository and CI. The upgrade playbook — pinned packages, migration patterns,
+  known regressions — lives as **skills** and **memory**. The agent proves the
+  change green in its sandbox, including any breaking-change migrations, and a
+  human owns the merge.
 </Callout>
 
 ## Guardrails
 
-The agent changes dependencies and runs code, so the access is scoped and
-contained:
+The agent changes dependency manifests, runs a lockfile resolver, and executes
+the full test suite against code it modified. The access is scoped to match the
+actual need:
 
 - **Isolation.** Every run happens in its own microVM sandbox on its own branch.
-  The session can install, resolve, and run the suite to prove an upgrade; only
-  the branch and result leave the sandbox.
-- **Scoped secrets.** The GitHub and CI credentials are encrypted in the secrets
-  manager and injected into the sandbox at runtime, never exposed to the model or
-  the logs.
-- **PR-gated.** The agent opens a pull request and stops. It never merges and
-  never pushes to the default branch; a human owns the merge.
-- **Everything is code.** The agent's configuration, skills, and permissions are
-  files in the repo, versioned and changed through a reviewed **change request**
-  rather than a dashboard setting.
+  The session installs, migrates, and tests inside that box; only the verified
+  branch and PR leave the sandbox. Nothing touches the default branch directly.
+- **Scoped secrets.** The GitHub token and any CI credentials are encrypted in
+  the secrets manager and injected into the sandbox at runtime. They are never
+  exposed to the model, written to disk outside the sandbox, or included in logs.
+- **PR-gated.** The agent opens a pull request and stops. Merging is a human
+  decision. The agent will not merge its own upgrade PRs under any condition.
+- **No half-migrations.** If a major upgrade requires changes the agent cannot
+  complete automatically, the bump is reverted and a tracked issue is filed. The
+  PR contains only changes the agent has verified end to end.
+- **Everything is code.** The upgrade playbook, pinned-package list, migration
+  patterns, and agent permissions are all files in the repository. Changing how
+  the agent handles a specific package means editing a file and merging a
+  **change request** — not adjusting a setting in a dashboard.
 
 <Figure
-  caption="A merged upgrade PR with the suite green and the changelog attached"
+  caption="A breaking-change migration applied inline — the PR shows both the manifest bump and the source changes"
   aspect="16/9"
 />
 
 ## The outcome
 
 <StatGrid>
-  <Stat value="Weekly" label="Upgrades proposed on a schedule, not when something breaks" />
-  <Stat value="Green-only" label="PRs opened only after the full suite passes" />
-  <Stat value="Human merge" label="The agent proves the change; the team decides" />
+  <Stat value="Weekly" label="Upgrades run on a schedule, not when something breaks" />
+  <Stat value="Green-only" label="PRs opened only after the full suite passes in the sandbox" />
+  <Stat value="Human merge" label="The agent proves the change; the team decides whether to ship it" />
 </StatGrid>
 
-Dependencies stay current without anyone scheduling the work, and the upgrade PRs
-that land in review have already been run against the full suite. Reviewers see a
-green change with the changelog attached instead of a bump they have to check out
-and test by hand.
+The upgrade PRs that land in review have already been run against the full suite
+on the upgraded code. Reviewers see a verification table, a changelog, and a list
+of any breaking changes that were handled automatically — not a candidate change
+that still needs testing by hand.
+
+Packages that drift because their major migration was too large to automate get a
+tracked issue with the exact steps, so the work is visible and can be picked up
+deliberately rather than discovered later when the gap has grown larger.
+
+The work that used to require someone to block off an afternoon, check out a
+branch, run the tests, read the failures, and decide whether each bump was safe
+now happens in the background every week. The team's role is reviewing a proven
+result and deciding whether to ship it.

--- a/apps/web/src/components/use-cases/covers.tsx
+++ b/apps/web/src/components/use-cases/covers.tsx
@@ -270,9 +270,15 @@ export const USE_CASE_COVERS: Record<string, ComponentType<UseCaseCoverProps>> =
     />
   ),
   'dependency-upgrades': () => (
-    <HeroCover>
-      <img src="/usecases/logos/github.svg" alt="GitHub" className="size-9 object-contain sm:size-11" />
-    </HeroCover>
+    <RowCover>
+      <GitHub />
+      <div className={cn(TILE, 'bg-emerald-500 text-white')}>
+        <CheckCircle2 className={ic} />
+      </div>
+      <IconTile>
+        <GitPullRequest className={cn(ic, 'text-foreground/70')} />
+      </IconTile>
+    </RowCover>
   ),
   'inbox-triage': () => (
     <DuoCover


### PR DESCRIPTION
Rewrites the dependency-upgrades use case MDX end to end.

## What changed

**`dependency-upgrades.mdx`:**
- Generic team voice — no product-specific references, reads as a pattern any team can follow on the platform
- Covers **breaking-change handling** explicitly: a 5-step migration sequence (read changelog → grep for removed APIs → apply codemods → typecheck → fix residuals), tracked issues for work that cannot be automated, no half-migrations pushed
- Steps expanded from 5 → 7 with fuller explanations
- `PullQuote` block added
- `KeyFacts` expanded to 4 fields (adds Human role)
- Second `Figure` placeholder for the breaking-change migration screenshot
- `Callout` tightened to the canonical trigger/connector/skills/memory pattern
- `StatGrid` outcome labels refined

**`covers.tsx`:**
- Replaces the GitHub-only `HeroCover` with a `RowCover` showing the full upgrade loop: `GitHub → green CheckCircle2 → GitPullRequest`

Content-only change. No code, no logic, no schema changes.