### PR TITLE
fix(templates): surface registry:template items in the templates list

### DIFF
--- a/apps/api/src/marketplace/catalog.test.ts
+++ b/apps/api/src/marketplace/catalog.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from 'bun:test';
-import { clampMarketplaceItemsLimit, pageCatalogItems, type CatalogItem } from './catalog';
+import {
+  clampMarketplaceItemsLimit,
+  pageCatalogItems,
+  selectTemplateItems,
+  type CatalogItem,
+} from './catalog';
 
 function item(overrides: Partial<CatalogItem> = {}): CatalogItem {
   return {
@@ -25,6 +30,22 @@ function synthetic(count: number, overrides: (i: number) => Partial<CatalogItem>
     item({ id: `kortix:item-${i}`, name: `item-${i}`, ...overrides(i) }),
   );
 }
+
+describe('selectTemplateItems', () => {
+  test('keeps registry:template items only, and drops hidden ones', () => {
+    const items = [
+      item({ id: 'kortix:ar-chaser', name: 'ar-chaser', type: 'registry:template' }),
+      item({ id: 'kortix:a-skill', name: 'a-skill', type: 'registry:skill' }),
+      item({ id: 'kortix:a-bundle', name: 'a-bundle', type: 'registry:bundle' }),
+      item({ id: 'kortix:hidden', name: 'hidden', type: 'registry:template', hidden: true }),
+    ];
+    expect(selectTemplateItems(items).map((i) => i.name)).toEqual(['ar-chaser']);
+  });
+
+  test('returns an empty list when there are no templates', () => {
+    expect(selectTemplateItems([item({ type: 'registry:skill' })])).toEqual([]);
+  });
+});
 
 describe('pageCatalogItems', () => {
   test('slices correctly for a given limit and offset', () => {

--- a/apps/api/src/marketplace/catalog.ts
+++ b/apps/api/src/marketplace/catalog.ts
@@ -1526,6 +1526,20 @@ export async function listCatalogItemsLive(
   return filterCatalogItems((await mergedCatalog()).items, opts);
 }
 
+/** Installable use-case templates. Kept OUT of the marketplace browse list
+ *  (`MARKETPLACE_VISIBLE_TYPES`) on purpose — a template installs through the
+ *  guided wizard (`POST /v1/templates/:id/install`, which renders inputs and
+ *  merges the manifest), not the raw marketplace commit path. So the /v1/templates
+ *  API lists them here, bypassing the browse filter. */
+/** Pure: the installable templates within a catalog item list. */
+export function selectTemplateItems(items: CatalogItem[]): CatalogItem[] {
+  return items.filter((it) => it.type === "registry:template" && !it.hidden);
+}
+
+export async function listTemplateCatalogItems(): Promise<CatalogItem[]> {
+  return selectTemplateItems((await mergedCatalog()).items);
+}
+
 /** Progressive catalog, paginated. Opt-in: pass `limit` to slice; omit it (or
  *  pass an invalid value) to get the full filtered list, matching
  *  `listCatalogItemsLive`'s existing full-list contract. `total` is always the

--- a/apps/api/src/projects/templates/routes.ts
+++ b/apps/api/src/projects/templates/routes.ts
@@ -16,7 +16,7 @@ import { eq } from 'drizzle-orm';
 
 import { db } from '../../shared/db';
 
-import { findCatalogEntryByName, listCatalogItemsLive } from '../../marketplace/catalog';
+import { findCatalogEntryByName, listTemplateCatalogItems } from '../../marketplace/catalog';
 import { buildInstall } from '../../marketplace/install-service';
 import { config } from '../../config';
 import { supabaseAuth } from '../../middleware/auth';
@@ -108,7 +108,7 @@ templatesApp.openapi(
     responses: { 200: json(z.any(), 'Installable templates') },
   }),
   async (c: any) => {
-    const items = await listCatalogItemsLive({ type: 'registry:template' });
+    const items = await listTemplateCatalogItems();
     return c.json({ templates: items });
   },
 );


### PR DESCRIPTION
Bug fix on the templates feature shipped in #4397.

## Problem
`GET /v1/templates` always returned an empty list. The catalog's browse filter (`MARKETPLACE_VISIBLE_TYPES`) only allows `registry:skill / agent / command / bundle`, so `registry:template` items were filtered out of every listing. `findCatalogEntryByName` bypasses that filter, which is why **install and preview worked** but the list (and therefore the "Use this template" gallery/button data) was empty. No deploy would have fixed it.

## Fix
Add a dedicated **`listTemplateCatalogItems()`** (+ a pure `selectTemplateItems`) that lists `registry:template` items **bypassing the browse filter**, and point `GET /v1/templates` at it.

Templates are deliberately **not** added to `MARKETPLACE_VISIBLE_TYPES` — a template installs through the guided wizard (`POST /v1/templates/:id/install`, which renders inputs and merges the manifest), so surfacing it in the raw marketplace browse/install path would produce a broken, wizard-less setup.

## Verify
```
listTemplateCatalogItems() → 4  [ar-chaser, customer-support, dependency-upgrades, standup-summary]
```
Co-located unit test added for `selectTemplateItems` (keeps templates, drops other types + hidden). Catalog tests green, api typecheck clean. Behind the same `KORTIX_TEMPLATES_ENABLED` flag.
