### PR TITLE
fix(web): keep project shell during session loading

### DIFF
--- a/apps/web/src/app/(app)/projects/[id]/layout.tsx
+++ b/apps/web/src/app/(app)/projects/[id]/layout.tsx
@@ -3,7 +3,6 @@ import { redirect } from 'next/navigation';
 
 import { ProjectAccessBoundary } from '@/components/projects/project-access-boundary';
 import { SessionStreamKeeper } from '@/components/projects/session-stream-keeper';
-import { SandboxLoadingBoundary } from '@/features/session/sandbox-loading-boundary';
 import { createClient } from '@/lib/supabase/server';
 
 interface ProjectLayoutProps {
@@ -24,13 +23,8 @@ export default async function ProjectLayout({ children, params }: ProjectLayoutP
 
   return (
     <ProjectAccessBoundary projectId={projectId}>
-      {/* Contain the "sandbox is still loading" boot race here (web-side, so it
-          hot-reloads reliably) — a stray getClient() during a session switch
-          shows the loader + auto-retries instead of the full-page error route. */}
-      <SandboxLoadingBoundary>
-        <SessionStreamKeeper projectId={projectId} />
-        {children}
-      </SandboxLoadingBoundary>
+      <SessionStreamKeeper projectId={projectId} />
+      {children}
     </ProjectAccessBoundary>
   );
 }

--- a/apps/web/src/features/session/sandbox-loading-boundary.test.ts
+++ b/apps/web/src/features/session/sandbox-loading-boundary.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const boundarySource = readFileSync(join(import.meta.dir, 'sandbox-loading-boundary.tsx'), 'utf8');
+const projectLayoutSource = readFileSync(
+  join(import.meta.dir, '../../app/(app)/projects/[id]/layout.tsx'),
+  'utf8',
+);
+const projectAccessSource = readFileSync(
+  join(import.meta.dir, '../../components/projects/project-access-boundary.tsx'),
+  'utf8',
+);
+
+describe('session navigation loading boundaries', () => {
+  test('runtime-not-ready retries never render the full-page ASCII logo', () => {
+    expect(boundarySource).toContain('return null;');
+    expect(boundarySource).not.toContain('KortixHyperLogo');
+    expect(boundarySource).not.toContain('min-h-[50vh]');
+  });
+
+  test('the project shell cannot be replaced by a route-wide sandbox fallback', () => {
+    expect(projectLayoutSource).not.toContain('SandboxLoadingBoundary');
+    expect(projectLayoutSource).toContain('<ProjectAccessBoundary projectId={projectId}>');
+    expect(projectLayoutSource).toContain('<SessionStreamKeeper projectId={projectId} />');
+  });
+
+  test('first project access still keeps its intentional full-page loader', () => {
+    expect(projectAccessSource).toContain('function ProjectAccessLoading()');
+    expect(projectAccessSource).toContain('<KortixHyperLogo');
+    expect(projectAccessSource).toContain('min-h-screen');
+  });
+});

--- a/apps/web/src/features/session/sandbox-loading-boundary.tsx
+++ b/apps/web/src/features/session/sandbox-loading-boundary.tsx
@@ -7,9 +7,11 @@
  * escalates to the Next route boundary (app/error.tsx) and the user sees a hard
  * "Something went wrong" instead of a loading state.
  *
- * This boundary catches ONLY those transient runtime-not-ready errors and shows
- * the normal provisioning loader, auto-retrying until the runtime is ready. Every
- * other error is rethrown so it bubbles to the outer boundary exactly as before.
+ * This boundary catches ONLY those transient runtime-not-ready errors and
+ * auto-retries silently until the runtime is ready. It intentionally renders no
+ * fallback: the project shell is already mounted during session navigation and
+ * must never be replaced by a full-page loading logo. Every other error is
+ * rethrown so it bubbles to the outer boundary exactly as before.
  *
  * The gate fix in `use-opencode-sessions/keys.ts` + the guard in `session-chat`
  * should prevent these throws in the first place; this is belt-and-suspenders so
@@ -17,7 +19,6 @@
  */
 
 import { ClientErrorBoundary } from '@/components/common/error-boundary';
-import { KortixHyperLogo } from '@/components/ui/marketing/kortix-hyper-logo';
 import { useEffect } from 'react';
 
 /** Transient errors thrown while the sandbox/opencode runtime is still booting. */
@@ -29,18 +30,15 @@ function isRuntimeNotReadyError(error: Error): boolean {
 function RuntimeLoadingFallback({ reset }: { reset: () => void }) {
   // The runtime URL lands within a second or two of provisioning. Soft-reset the
   // boundary on a short interval so the subtree re-renders and picks it up the
-  // moment it's ready — no hard reload, no manual "Try again". Render the one
-  // canonical Kortix loader (same as ProjectAccessLoading) so the whole project
-  // route shows a single, consistent loader rather than a stray spinner.
+  // moment it's ready — no hard reload, no manual "Try again". This must stay
+  // visually empty: initial project access has its own legitimate loader, but a
+  // transient runtime race while switching sessions must not cover the loaded
+  // project with the ASCII logo.
   useEffect(() => {
     const t = setInterval(reset, 800);
     return () => clearInterval(t);
   }, [reset]);
-  return (
-    <div className="flex h-full min-h-[50vh] w-full flex-1 items-center justify-center">
-      <KortixHyperLogo size={34} startOnView={false} animateOnHover={false} />
-    </div>
-  );
+  return null;
 }
 
 // Rethrow non-runtime errors so they propagate to the nearest OUTER boundary


### PR DESCRIPTION
## Summary
- remove the ASCII Kortix logo from transient runtime-not-ready retries
- keep the project shell mounted by scoping the sandbox boundary to session content
- preserve the existing full-page loader for genuine first project access
- add regression coverage for all three behaviors

## Verification
- pnpm --filter Kortix-Computer-Frontend test src/features/session (71 pass)
- targeted ESLint with --max-warnings=0 (pass)
- targeted Prettier check (pass)
- git diff --check (pass)
- live worktree API health at localhost:18308/v1/health (status ok)
- affected Next route compiled and returned the expected auth redirect

## Verification gap
- in-app Chromium was unavailable in this Codex session, so interactive DOM/network session switching was not run locally